### PR TITLE
[codex] Core hooks for station discovery, observer WS, and USB audio selection

### DIFF
--- a/docs/api/web.md
+++ b/docs/api/web.md
@@ -867,15 +867,19 @@ UDP discovery responses use the same `rigplane.station.discovery.v1` schema.
 Single-station responses keep the same top-level `kind: "station_server"`,
 `url`, `urls`, `station`, and `radio` fields. Fleet-aware supervisors can add
 an additive `radios` array and set `kind: "station_fleet"` while preserving the
-legacy top-level single-radio fields for older clients:
+legacy top-level single-radio fields for older clients. When a supervisor has a
+reachable Fleet API base or stable box identity, it can also add `urls.fleet`
+and top-level `box_id`:
 
 ```json
 {
   "schema": "rigplane.station.discovery.v1",
   "kind": "station_fleet",
+  "box_id": "RP-354E-3168-2C7B",
   "url": "http://192.168.1.50:58421",
   "urls": {
     "base": "http://192.168.1.50:58421",
+    "fleet": "http://192.168.1.50:8090",
     "station": "http://192.168.1.50:58421/api/v1/station"
   },
   "station": {

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -143,6 +143,8 @@ If `--serial-baud` and `ICOM_SERIAL_BAUDRATE` are both unset:
 ### Audio device selection (serial backend)
 
 The serial backend uses USB audio devices exported by the radio. By default, devices are auto-detected.
+When display names are duplicated, pass a PortAudio device index or a unique
+hardware identifier such as `hw:3,0` instead of the shared display name.
 
 ```bash
 # List all available audio devices
@@ -153,6 +155,12 @@ rigplane --list-audio-devices --json
 rigplane --backend serial --serial-port /dev/tty.usbmodem-IC7610 \
     --rx-device "IC-7610 USB Audio" \
     --tx-device "IC-7610 USB Audio" \
+    audio rx --out rx.wav --seconds 10
+
+# Specify an ALSA hardware id from --list-audio-devices --json
+rigplane --backend serial --serial-port /dev/ttyACM0 \
+    --rx-device "hw:3,0" \
+    --tx-device "hw:3,0" \
     audio rx --out rx.wav --seconds 10
 ```
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -31,8 +31,8 @@ rigplane supports two backends selected via `--backend`:
 | Device | `device` | `--serial-port` | `ICOM_SERIAL_DEVICE` | — | Serial device path (required) |
 | Baud rate | `baudrate` | `--serial-baud` | `ICOM_SERIAL_BAUDRATE` | `115200` | CI-V baud rate |
 | PTT mode | `ptt_mode` | `--serial-ptt-mode` | `ICOM_SERIAL_PTT_MODE` | `civ` | Serial PTT control mode (`civ` supported) |
-| RX device | `rx_device` | `--rx-device` | `ICOM_USB_RX_DEVICE` | auto | USB audio RX device name |
-| TX device | `tx_device` | `--tx-device` | `ICOM_USB_TX_DEVICE` | auto | USB audio TX device name |
+| RX device | `rx_device` | `--rx-device` | `ICOM_USB_RX_DEVICE` | auto | USB audio RX device selector (name, index, or hardware id) |
+| TX device | `tx_device` | `--tx-device` | `ICOM_USB_TX_DEVICE` | auto | USB audio TX device selector (name, index, or hardware id) |
 | CI-V Address | `radio_addr` | — | — | `0x98` (IC-7610) | Radio's CI-V address |
 | Timeout | `timeout` | `--timeout` | — | `5.0` | Operation timeout (seconds) |
 

--- a/docs/internals/legacy-state-writer-inventory.md
+++ b/docs/internals/legacy-state-writer-inventory.md
@@ -1,0 +1,122 @@
+# Legacy State Writer Inventory
+
+Status: MOR-335 baseline audit
+Date: 2026-06-02
+Spec: `docs/superpowers/specs/2026-06-02-radio-state-pipeline-design.md`
+
+This inventory records the current pre-migration state/revision/cache paths.
+It is intentionally descriptive: MOR-335 adds diagnostics only and does not
+change delivery semantics.
+
+Migration classes:
+
+- `observation_adapter`: decoded or polled values should become observations.
+- `pending_overlay`: local intent/read-after-write state only.
+- `executor_cache`: private timeout, pacing, or dedupe cache.
+- `protocol_local_keep`: protocol/session state that is not radio state.
+- `compatibility_shim`: retained temporarily for API/wire stability.
+- `delete`: replace with the shared state model when the field family migrates.
+
+## Icom Runtime and CI-V
+
+| Path | Current behavior | Class | Migration note |
+|---|---|---|---|
+| `runtime/_civ_rx.py::_update_state_cache_from_frame` | Parses solicited and unsolicited CI-V frames, updates `_state_cache`, `_last_freq_hz`, `_last_mode`, `_last_vfo`, and selected `RadioState` fields, then calls `_update_radio_state_from_frame`. | `observation_adapter` plus `executor_cache` | Convert decoded frame values to observations. Keep private request/cache hints only for executor fallback. |
+| `runtime/_civ_rx.py::_RADIO_STATE_HANDLERS` | Directly writes `RadioState` for frequency, mode, VFO/dual-watch, scan/split/tuning, levels, meters, function flags, scope controls, PTT, RIT, and dual-RX cmd25/cmd26. | `observation_adapter` now, then `delete` | These are the highest-risk legacy confirmed-state writers. Diagnostics now record `direct_state_write` for handler dispatches. |
+| `runtime/_civ_rx.py::_notify_change` | Only selected decoded fields notify Web, which indirectly bumps Web poller revision and broadcasts. Meter, frequency, mode, and many slow-state writes can be silent. | `compatibility_shim` then `delete` | Replace with `StateStore.apply(...) -> ChangeSet`; diagnostics record `revision_producing_event`. |
+| `runtime/_civ_rx.py::_publish_scope_frame` and `_scope_frame_queue` | Scope samples use their own delivery queue/callback. | `protocol_local_keep` | Scope sample streaming is not canonical radio state; scope control values still need observations. |
+| `runtime/_dual_rx_runtime.py` main getters/setters | Uses `_state_cache`, `_last_freq_hz`, `_last_mode`, `_filter_width`, and direct `RadioState` writes for fallback VFO routing and selected slot APIs. | `executor_cache` plus `pending_overlay` | Convert confirmed getter results to observations. Keep VFO-switch sequencing private to the executor. |
+| `runtime/radio_initial_state.py` | Sends initial query sweep to populate `RadioState` through existing backend/RX paths. | `observation_adapter` | Initial acquisition should emit observations, not own delivery. |
+| `runtime/radio_state_snapshot.py` | Best-effort snapshot/restore uses `_last_*` caches when reads fail. | `executor_cache` | Keep only as private restore fallback; do not expose as fresher consumer state. |
+| `core/_state_cache.py` and re-export `_state_cache.py` | Shared mutable cache with per-field timestamps for freq/mode/PTT/meters/levels. | `executor_cache` and `compatibility_shim` | Retain only for executor timeout fallback until freshness metadata moves into the state model. |
+| `backends/icom7610/drivers/serial_stub.py` | Fake serial backend mirrors private receiver state into `RadioState` and `StateCache`. | `compatibility_shim` | Test backend should migrate behind the same observation/state-store test harness. |
+
+## Web Runtime, Revisions, and Frontend Store
+
+| Path | Current behavior | Class | Migration note |
+|---|---|---|---|
+| `web/radio_poller.py::_revision` / `bump_revision` | Web-owned public revision counter, bumped by optimistic command updates and selected state-change callbacks. | `compatibility_shim` then `delete` | Canonical revision must move to the state model. Diagnostics record `revision_producing_event`. |
+| `web/radio_poller.py::_execute` | Many command handlers optimistically write `RadioState` and call `bump_revision`; frequency/mode/filter/DSP/scope/power/antenna paths are included. | `pending_overlay` | Preserve read-after-write UX as pending intent, not confirmed state. |
+| `web/radio_poller.py::_last_polled` and `_send_query` | Poll freshness and meter/state query cadence are poller-local. | `executor_cache` | Diagnostics now record `meter_cadence` and `backend_read`; later acquisition policy should own scheduling. |
+| `web/radio_poller.py::_poll_unselected_slot` / host `_vfo_slot_override` | Temporarily swaps VFO slot, routes late 0x03/0x04 responses into inactive slot, then restores. | `observation_adapter` plus `protocol_local_keep` | Keep the swap/restore protocol mechanics local; convert returned values into slot-scoped observations. |
+| `web/server.py::_radio_state` and `build_public_state` | Web projects the mutable `RadioState` plus Web poller revision into HTTP/WS payloads. | `compatibility_shim` | Snapshot builder should consume canonical state model snapshots. |
+| `web/server.py::_health_revision` | Separate health revision for readiness transitions. | `compatibility_shim` | Confirms spec assumption that freshness/health revision must be separate from value revision. |
+| `web/server.py::_broadcast_state_update` | Throttled WebSocket delivery trigger; delta encoder revision is separate from public state revision. | `compatibility_shim` | Diagnostics now record `web_delivery_trigger`. Delta delivery remains representation-only. |
+| `web/server.py::_serve_state` | HTTP snapshot uses `revision-healthRevision` ETag from Web payload. | `compatibility_shim` | HTTP should use canonical state/freshness revisions from the state model. |
+| `web/_delta_encoder.py` | Maintains transport-local `revision` and emits full/delta envelopes. | `compatibility_shim` then `delete` as state revision source | Keep transport sequence only if renamed/split from canonical state revision. |
+| `web/handlers/control.py` initial state | Sends a full state envelope whose revision is the delta encoder revision, while payload also has public revision. | `compatibility_shim` | Confirms spec assumption that wire `transportSeq` and state revision are currently conflated. |
+| `web/web_startup.py` `StatePollable` branch | Yaesu/external pollers replace `server._radio_state` and trigger broadcast on callback. | `observation_adapter` | Callback should apply observations/change sets; diagnostics record a backend read callback. |
+| `frontend/src/lib/transport/http-client.ts` | HTTP callback only fires when `revision` or `healthRevision` advances. | `compatibility_shim` | Confirms meter jitter symptom: silent meter writes remain invisible until a revision/health change. |
+| `frontend/src/lib/transport/ws-client.ts` | Applies delta encoder envelope and copies envelope `revision` to full state. | `compatibility_shim` | Split transport sequence from canonical `stateRevision`. |
+| `frontend/src/lib/stores/radio.svelte.ts` | Store accepts state only when revision/health advances; optimistic maps overlay receiver/top-level fields. | `compatibility_shim` plus `pending_overlay` | Optimistic maps are pending overlays. Revision gate should use canonical value/freshness revisions. |
+
+## rigctld Server and Hamlib Compatibility
+
+| Path | Current behavior | Class | Migration note |
+|---|---|---|---|
+| `rigctld/handler.py::_PendingRigState` | Local optimistic read-after-write state for MAIN freq/mode/filter/data_mode. | `pending_overlay` | Keep as scoped pending intent until shared pending overlays exist. |
+| `rigctld/handler.py::_FallbackRigState` | Handler-local fallback cache for freq/mode/data/PTT/S-meter/RF power/SWR. | `compatibility_shim` and `executor_cache` | Replace consumer-visible fallback with shared state/freshness; keep only private executor fallback if needed. |
+| `rigctld/handler.py::_split_tx_vfo` | Tracks Hamlib protocol TX VFO label across split commands. | `protocol_local_keep` | This is session/protocol state, not confirmed radio state. |
+| `rigctld/handler.py` GET paths | Prefer `RadioState`, then pending/cache, then backend reads for some fields. | `compatibility_shim` | GET should consume shared state projections. Diagnostics now record `rigctld_delivery_trigger`. |
+| `rigctld/routing.py` level/func routing | Reads backend meters/levels/functions and updates `_FallbackRigState`. | `observation_adapter` plus `compatibility_shim` | Backend reads should become observations; Hamlib response formatting remains compatibility. |
+| `rigctld/poller.py` | Background poller updates `StateCache` for freq/mode/data_mode. | `executor_cache` then `delete` as consumer source | Later rigctld should consume shared state model instead of this cache. |
+| `rigctld/server.py` session `vfo_mode` | Per-client Hamlib `chk_vfo` state. | `protocol_local_keep` | Keep local; do not migrate into radio state. |
+| `rigctld/contract.py` and dump-state constants | Hamlib wire compatibility, positional dump-state assumptions. | `compatibility_shim` | Preserve wire behavior; state migration must not alter protocol text output. |
+
+## Yaesu and External rigctld Client Backends
+
+| Path | Current behavior | Class | Migration note |
+|---|---|---|---|
+| `backends/yaesu_cat/radio.py::_state` | Request/response getters and setters directly mutate `RadioState`; IF bulk query seeds several fields. | `observation_adapter` plus `pending_overlay` | Getter/IF responses should emit observations. Setter echoes become pending overlays until confirmed. |
+| `backends/yaesu_cat/poller.py` | Fast/medium/slow loops call getters, smooth S-meter, mutate backend `RadioState`, then invoke callback. | `observation_adapter` | Poller is an acquisition scheduler precursor; callback should carry observations/change sets. |
+| `backends/yaesu_cat/poller.py` EMA S-meter state | Local smoothing memory for meter samples. | `executor_cache` | Keep as acquisition/presentation policy only if explicitly needed; do not treat as confirmed state. |
+| `backends/rigctld_client/radio.py::_state` | External Hamlib responses and local SET commands directly mutate `RadioState`; VFO support probe caches capability. | `observation_adapter` plus `pending_overlay` | Translate rigctld responses to observations. SET writes should be pending until readback/confirmation. |
+| `backends/rigctld_client/radio.py::_vfo_supported` | Capability probe result for external rigctld VFO command availability. | `executor_cache` | Keep as backend capability/cache, not radio state. |
+| `core.radio_protocol.StateCacheCapable` | Protocol advertises `state_cache` and `radio_state` to consumers. | `compatibility_shim` | Shared state service should replace consumer reliance on these mutable objects. |
+
+## Profile and Schema Gaps
+
+| Gap | Current behavior | Class | Migration note |
+|---|---|---|---|
+| Meter push/support metadata | Profiles expose meter calibration/redlines, but not complete unsolicited-vs-polled meter freshness policy. | `compatibility_shim` | Add profile capability metadata for acquisition policy and freshness windows. |
+| VFO path precision | Profiles know VFO schemes/codes, but current state paths still mix receiver active state, VFO slots, and Hamlib VFO labels. | `protocol_local_keep` and `compatibility_shim` | Target `FieldPath` must include receiver and slot. |
+| Hamlib wire assumptions | dump-state constants, `chk_vfo`, and split VFO labels are protocol compatibility, not state correctness. | `compatibility_shim` and `protocol_local_keep` | Preserve wire output while moving GET values to shared state projections. |
+
+## Baseline Diagnostics Added in MOR-335
+
+`rigplane.core.state_diagnostics.StateDiagnosticsRecorder` is disabled by
+default and records nothing unless explicitly enabled. When enabled through
+`WebConfig(state_diagnostics=True)` or tests, instrumentation records:
+
+- `direct_state_write`: CI-V `RadioState` handler dispatches.
+- `revision_producing_event`: CI-V notify events and Web poller revision bumps.
+- `meter_cadence`: Web poller meter query cadence.
+- `backend_read`: Web poller state/meter queries and `StatePollable` callbacks.
+- `web_delivery_trigger`: HTTP state and WebSocket state delivery.
+- `rigctld_delivery_trigger`: rigctld handler responses.
+
+Focused tests cover the recorder's inert behavior, CI-V S-meter direct writes
+without notify/revision, and the current Web-visible symptom where a silent
+meter write is only delivered after an unrelated state-change trigger.
+
+## Spec Assumptions Confirmed
+
+- A mutable `RadioState` is currently consumer-visible and has multiple writers.
+- Meter fields can change without a public Web revision-producing event.
+- HTTP and WebSocket both gate frontend updates through legacy revision fields.
+- Web delta revision and public state revision are separate counters today but
+  are exposed with the same `revision` name in different envelope positions.
+- rigctld has protocol-local state that must not become canonical radio state.
+- Hamlib external rigctld remains the correct Core boundary; no direct Hamlib
+  binding is needed for this migration.
+
+## Deferred Follow-Ups
+
+- Add typed `Observation`, `FieldPath`, and `ChangeSet` contracts in the next
+  implementation milestone.
+- Replace the CI-V direct writer handlers with observation adapters one field
+  family at a time.
+- Add frontend tests for `stateRevision`/`transportSeq` split when the wire
+  schema changes.
+- Add rigctld fake-radio tests that compare GET responses against shared state
+  projections once the state model exists.

--- a/docs/internals/radio-acquisition-policy.md
+++ b/docs/internals/radio-acquisition-policy.md
@@ -1,0 +1,71 @@
+# Radio Capability And Acquisition Policy
+
+MOR-344 adds schema only. It does not implement `StateStore`,
+`FreshnessClock`, `AcquisitionScheduler`, Web migration, rigctld migration, or
+backend behavior changes.
+
+## Purpose
+
+Radio/provider state behavior is represented as profile metadata:
+
+- `FieldCapability` says whether a canonical field is supported, unsupported,
+  or unknown, and whether it can be acquired by unsolicited push, polling,
+  stream-like meter updates, or observable command responses.
+- `AcquisitionPolicy` says how future scheduler/adapters should poll and
+  reconcile fields: cadence, freshness TTL, reconciliation priority, adaptive
+  decay, external-CAT pause behavior, and meter coalescing.
+- Missing metadata is explicit. `RadioAcquisitionProfile.capability_for(path)`
+  returns an `unknown` capability with a diagnostic instead of implying that a
+  scheduler should poll forever.
+
+The schema lives under `rigplane.core` and is loaded by `rigplane.profiles`.
+Web and rigctld delivery code must not consume this metadata directly; later
+scheduler/adapters should consume it.
+
+## Provider Examples
+
+### Icom CI-V
+
+`rigs/ic7610.toml` declares `provider = "icom_civ"`. It uses
+`default_reconciliation_priority = "unsolicited"` because representative Icom
+CI-V state can arrive as unsolicited updates while still remaining pollable.
+Meters are marked `stream_like_meters` and get a short coalescing window.
+
+### Yaesu CAT
+
+`rigs/ftx1.toml` declares `provider = "yaesu_cat"`. It is polling-first:
+frequency, mode, and meter fields are read by explicit CAT requests. Power-on
+state is explicitly marked unsupported so future schedulers can report it
+unavailable instead of retrying indefinitely.
+
+### X6200-Like CI-V
+
+`rigs/x6200.toml` declares `provider = "xiegu_civ"`. Frequency and mode are
+polling-capable and command-response observable. The active mode field has a
+per-field policy with `reconciliation_priority = "command_response"` to
+represent X6200-like tuning behavior as data, not as Web or rigctld delivery
+branches. SWR and ALC are marked unknown until hardware evidence proves support.
+
+### External rigctld / Hamlib
+
+External rigctld/Hamlib should use `provider = "external_rigctld"` when a
+profile or adapter layer supplies acquisition metadata. Hamlib model output can
+map known levels/functions to `supported` fields, omitted capabilities to
+`unknown`, and model-proven gaps to `unsupported`. Core owns the schema and
+read-only probing/ranking contract; managed setup UX, support evidence, and
+private validation matrices stay outside this repository.
+
+## Conservative Defaults
+
+The schema defaults are intentionally cautious:
+
+- cadence: `5.0` seconds
+- freshness TTL: `15.0` seconds
+- reconciliation priority: `poll`
+- adaptive decay: disabled
+- external CAT behavior: `pause_polling`
+
+Unsupported and unknown fields cannot be marked pollable, stream-like,
+unsolicited, command-response observable, or controllable. Stream-like fields
+must be meter-family paths. Per-field meter coalescing is only valid for meter
+paths.

--- a/docs/internals/radio-acquisition-scheduler.md
+++ b/docs/internals/radio-acquisition-scheduler.md
@@ -1,0 +1,52 @@
+# Radio AcquisitionScheduler Semantics
+
+MOR-339 adds the minimal backend-neutral acquisition scheduler in
+`rigplane.core.acquisition_scheduler`. It is a freshness and reconciliation
+request queue only; it does not call radio backends, mutate confirmed state, or
+deliver Web/rigctld updates.
+
+## Model Service API
+
+`RadioStateModelService.ensure_fresh(paths, max_age, priority, reason)` first
+checks the shared `StateStore` snapshot. If every requested field is fresh and
+newer than `max_age`, the service returns the current `FieldSnapshot` values.
+Otherwise it delegates to `AcquisitionScheduler.ensure_fresh(...)`.
+
+This keeps consumers behind the model service. Web, rigctld, CLI, and public
+API callers should request freshness through this service instead of calling
+backend getters directly.
+
+## Scheduler Output
+
+The scheduler emits `AcquisitionRequest` objects. A request includes:
+
+- typed `FieldPath` targets;
+- priority and reason metadata;
+- requested time, freshness deadline, timeout, and max age;
+- provider and capability ids from `RadioAcquisitionProfile`;
+- selected acquisition method (`poll`, `command_response`, or
+  `wait_for_unsolicited`);
+- the relevant `AcquisitionPolicy`, including meter coalescing and external
+  CAT behavior.
+
+Backend executors may consume these requests and later apply real
+`Observation` values through `StateStore.apply(...)`. The scheduler must not
+invent synthetic confirmed state.
+
+## Dedupe And Priority
+
+Requests dedupe by the sorted tuple of target paths. Repeated requests for the
+same target keep one acquisition id, preserve accumulated reasons, and upgrade
+to the highest priority and most urgent deadline/max age. Pending requests are
+returned in execution order so user-facing freshness and command confirmation
+can preempt background telemetry.
+
+## External CAT Ownership
+
+`pause_external_cat(...)` defers requests whose policy requires polling pause.
+`resume_external_cat()` queues the deferred requests in priority order. Fields
+with `external_cat_pause = "continue"` can still queue while ownership is
+active, and the emitted request records that external CAT was paused.
+
+Unsupported or unknown capabilities return `UNAVAILABLE` instead of retrying
+forever or bypassing the backend-neutral queue.

--- a/docs/internals/radio-acquisition-scheduler.md
+++ b/docs/internals/radio-acquisition-scheduler.md
@@ -35,9 +35,10 @@ invent synthetic confirmed state.
 
 ## Dedupe And Priority
 
-Requests dedupe by the sorted tuple of target paths. Repeated requests for the
-same target keep one acquisition id, preserve accumulated reasons, and upgrade
-to the highest priority and most urgent deadline/max age. Pending requests are
+Requests dedupe by compatible field family, receiver/slot scope, acquisition
+method, and acquisition policy. Repeated compatible requests keep one
+acquisition id, preserve accumulated reasons, merge target paths, and upgrade to
+the highest priority and most urgent deadline/max age. Pending requests are
 returned in execution order so user-facing freshness and command confirmation
 can preempt background telemetry.
 

--- a/docs/internals/radio-state-pipeline-contracts.md
+++ b/docs/internals/radio-state-pipeline-contracts.md
@@ -1,0 +1,119 @@
+# Radio State Pipeline Contracts
+
+Status: MOR-337 contract baseline
+Date: 2026-06-02
+Canonical import path: `rigplane.core.state_pipeline_contracts`
+
+This document records the first backend-neutral state pipeline contracts. The
+contracts are additive and do not change the current public API, Web payloads,
+rigctld wire behavior, backend delivery semantics, or `RadioState` mutation
+paths. Later migration lanes can consume these contracts without adding
+radio-model-specific branches.
+
+## FieldPath Grammar
+
+`FieldPath` is the canonical state-field address. String paths are stable for
+tests, Web projections, rigctld projections, diagnostics, and provider
+capability metadata.
+
+Canonical forms:
+
+- `receiver.<receiver>.slot.<A|B>.freq_mode.<field>`
+- `receiver.<receiver>.active.freq_mode.<field>`
+- `receiver.<receiver>.<family>.<field>`
+- `receiver.<receiver>.vfo.active_slot`
+- `global.<family>.<field>`
+- `scope_controls.receiver.<receiver>.display.<field>`
+- `scope_controls.global.display.<field>`
+
+Validation rules:
+
+- Receiver ids, families, and field names use lowercase snake-case tokens.
+- VFO slot paths only accept `A`, `B`, or `active`.
+- Fixed slot and active slot paths are only valid for `freq_mode` fields.
+- Global, connection, and health paths cannot include receiver or slot
+  dimensions.
+- Scope-control paths can include a receiver dimension, but not a VFO slot.
+- Registry construction rejects duplicate serialized paths and ambiguous paths
+  that reuse the same target/name with different families.
+
+## Examples
+
+| State | Canonical path | Notes |
+|---|---|---|
+| Active MAIN frequency | `receiver.main.active.freq_mode.freq_hz` | Active VFO view for commands and consumer projections. |
+| MAIN VFO A frequency | `receiver.main.slot.A.freq_mode.freq_hz` | Fixed slot view for unselected-slot freshness and pending confirmation. |
+| Active SUB mode | `receiver.sub.active.freq_mode.mode` | Backend-neutral mode string value. |
+| MAIN active slot | `receiver.main.vfo.active_slot` | Selected VFO slot state, separate from frequency/mode values. |
+| MAIN S-meter | `receiver.main.meters.s_meter` | Receiver-scoped meter sample. |
+| ALC meter | `global.meters.alc` | TX meter sample not tied to one receive VFO. |
+| Power meter | `global.meters.power` | TX output meter sample. |
+| Noise reduction | `receiver.main.operator_toggles.nr` | Operator toggle, writable when backend capabilities allow it. |
+| Noise blanker | `receiver.main.operator_toggles.nb` | Operator toggle, writable when backend capabilities allow it. |
+| Volume / AF level | `receiver.main.operator_controls.af_level` | Normalized receiver level. |
+| RF gain | `receiver.main.operator_controls.rf_gain` | Normalized receiver level. |
+| PBT inner | `receiver.main.operator_controls.pbt_inner` | Passband tuning control. |
+| PBT outer | `receiver.main.operator_controls.pbt_outer` | Passband tuning control. |
+| PTT | `global.tx_state.ptt` | Global TX state. |
+| Power on/off | `global.tx_state.power_on` | Global power state. |
+| Scope span | `scope_controls.receiver.main.display.span` | Scope display control scoped to a receiver. |
+
+The default registry includes representative MAIN and SUB receiver paths for
+frequency, mode, active slot, S-meter, NR/NB, AF level, RF gain, and PBT, plus
+global TX and meter paths. It is intentionally not a complete `RadioState`
+field map yet; later lanes should extend it as field families migrate.
+
+## Observation
+
+`Observation` represents one decoded state-bearing sample from CI-V, CAT,
+external rigctld, polling, command response, or local reconciliation. It is not
+a command acknowledgement and does not imply a state change.
+
+Serializable fields:
+
+- `path`: canonical `FieldPath` string.
+- `value`: JSON-compatible normalized value.
+- `source`: `SourceMetadata`, including source type, provider, transport,
+  native protocol id, and optional capability id.
+- `timestampMonotonic`: local monotonic timestamp.
+- `quality`: flags such as `confirmed`, `partial`, or `synthetic`.
+- `correlationId`: optional command or acquisition id.
+- `maxAge`: optional freshness policy window.
+
+## ChangeSet
+
+`ChangeSet` represents the result of applying observations to a future
+production state model. It carries the canonical state revision and
+freshness revision separately. It does not own WebSocket transport sequencing
+and does not replace the current delivery behavior in MOR-337.
+
+Serializable fields:
+
+- `revision`: canonical state-value revision after the change.
+- `freshnessRevision`: freshness or health revision after the change.
+- `observationSeq`: observation sequence after the applied sample or batch.
+- `changes`: typed `FieldChange` entries with previous and current values.
+- `timestampMonotonic`: local monotonic timestamp.
+- `sources`: source metadata represented in the change set.
+- `coalesced`: whether multiple observations were batched.
+
+## Command Contracts
+
+`CommandIntent` represents an attempt to query or change radio state from
+WebSocket, HTTP, rigctld, public API, diagnostics, or internal policy code.
+`CommandLifecycleEvent` records accepted, queued, sent, acknowledged, failed,
+timed out, confirmed, and superseded states. These lifecycle events are
+separate from confirmed state changes.
+
+Command contracts can name a target `FieldPath`, a pending-overlay policy, and
+expected observation paths. They do not implement command execution or mutate
+confirmed state.
+
+## Compatibility
+
+MOR-337 only adds a new core module and documentation. Existing import paths,
+public `RadioState` serialization, Web state payloads, rigctld text protocol,
+Icom/Yaesu/Hamlib adapter behavior, and state delivery semantics remain
+unchanged. New code should import contracts from
+`rigplane.core.state_pipeline_contracts`; they are not added to the top-level
+`rigplane` Tier 1 API in this milestone.

--- a/docs/internals/radio-state-pipeline-regression-matrix.md
+++ b/docs/internals/radio-state-pipeline-regression-matrix.md
@@ -1,0 +1,67 @@
+# Radio State Pipeline Regression Matrix
+
+Status: MOR-336 shared test foundation
+Date: 2026-06-02
+
+This matrix maps the original state-pipeline symptoms from
+`docs/superpowers/specs/2026-06-02-radio-state-pipeline-design.md` to reusable
+future tests. CI cases must run without physical radios and should use
+`tests/support/state_pipeline.py`. Hardware validation cases are listed
+separately and require explicit opt-in.
+
+## Harness Coverage
+
+The shared harness provides:
+
+- `FakeClock` for deterministic monotonic time, freshness deadlines, pending
+  overlay expiry, and acquisition scheduling.
+- `FieldPath`, `Observation`, `ChangeSet`, and `FreshnessTransition` test
+  contracts for model-facing state pipeline assertions.
+- `FakeStatePipeline` with `state_revision`, `freshness_revision`, and
+  `observation_seq` counters.
+- Fake backends for CI-V push, command responses, dropped unsolicited events,
+  polling-only backends, Yaesu-like polling, and external rigctld-client
+  responses.
+- `FakeAcquisitionScheduler` for ensure-fresh scheduling assertions.
+- `FakePendingOverlayStore` for scoped read-after-write overlay tests.
+- Assertion helpers for revision counters and consumer-visible deltas.
+
+## CI Regression Matrix
+
+| Area | Original symptom or risk | Future CI tests | Harness primitives |
+|---|---|---|---|
+| Meters | S-meter/meter samples mutate state but wait for unrelated revision bumps before Web sees them. | Meter observations advance `observation_seq`; delivered meter deltas include latest sample and do not require unrelated frequency/mode changes. Add coalescing tests once production store exists. | `FakeCivPushBackend`, `FakeStatePipeline`, `assert_consumer_delta`, `assert_revision_counters` |
+| Frequency latency | Slow serial or request/response radios can show delayed panel tuning updates. | CI-V unsolicited frequency, command-response frequency, and polling-only frequency observations all enter the same apply path; pulse polling can be scheduled after local/external tuning. | `FakeCivPushBackend`, `FakeCommandResponseBackend`, `FakePollingOnlyBackend`, `FakeYaesuLikeBackend`, `FakeAcquisitionScheduler`, `FakeClock` |
+| Stale fields | A missed or malformed unsolicited frame leaves consumers believing old state is authoritative. | Freshness deadline marks the field stale without changing `stateRevision`; reconciliation poll publishes the corrected value and advances `freshnessRevision` separately. | `FakeDroppedUnsolicitedBackend`, `FakeClock`, `FakeStatePipeline` |
+| Snapshots | HTTP snapshots and initial WebSocket state can disagree when they are built from different revision sources. | Snapshot projection uses the same `stateRevision` and `freshnessRevision` as WebSocket initial state; legacy `revision` aliases only `stateRevision`. | `FakeStatePipeline.snapshot()`, revision assertions |
+| WebSocket reconnect | Reconnect/reset logic can confuse canonical state revision with transport sequence. | Reconnected WebSocket full state preserves canonical `stateRevision`/`freshnessRevision`; `transportSeq` reset does not look like a state rollback. | `FakeStatePipeline`, consumer delta assertions |
+| rigctld GET | rigctld GET can read stale local cache instead of shared confirmed state. | GET frequency/mode reads fresh shared state; stale critical fields request acquisition or report unavailable instead of trusting expired values. | `FakeStatePipeline`, `FakeAcquisitionScheduler`, `FakeExternalRigctldClientBackend` |
+| rigctld SET | SET read-after-write behavior currently depends on local pending/cache state. | SET creates a scoped pending overlay, confirms only on matching observation, and expires without mutating confirmed state. | `FakePendingOverlayStore`, `FakeCommandResponseBackend`, `FakeExternalRigctldClientBackend`, `FakeClock` |
+| Pending overlays | Optimistic values can leak between Web, HTTP, rigctld sessions, or command IDs. | Pending overlays are scoped by source, session, command id, field path, and expiry; confirmation clears matching overlays only. | `FakePendingOverlayStore` |
+| Dropped unsolicited events | Push-capable backends can still lose an event, so revision alone is not proof of physical state. | Dropped push sample does not mutate state or increment `observation_seq`; stale transition plus poll response reconciles the value. | `FakeDroppedUnsolicitedBackend`, `FakeStatePipeline`, `FakeClock` |
+| Adaptive acquisition | Background polling can delay user commands or flood slow links. | ensure-fresh requests are deduped by path family, scheduled with fake time, and prioritized separately from background telemetry. | `FakeAcquisitionScheduler`, `FakeClock`, backend capability flags |
+| Command responses | Command acknowledgements can be mistaken for confirmed radio state, or confirmed responses can bypass state revisions. | Command lifecycle remains separate; only response observations mutate confirmed state and produce deltas. | `FakeCommandResponseBackend`, `correlation_id`, revision assertions |
+| External rigctld client | Hamlib-backed responses need to behave like observations, not a separate cache. | External rigctld-client poll responses publish `hamlib_response` observations into the same pipeline and preserve Hamlib error/read-only tests elsewhere. | `FakeExternalRigctldClientBackend`, `FakeStatePipeline` |
+
+## Hardware Validation Matrix
+
+Hardware validation must remain separate from CI and use explicit opt-in
+markers such as `integration`, `hardware`, or `validation_hardware`.
+
+| Hardware case | Purpose | Expected marker |
+|---|---|---|
+| IC-7610 LAN CI-V unsolicited meter/frequency burst | Compare real CI-V ingress rate with state revision and Web delivery rate. | `hardware` or `validation_hardware` |
+| IC-7610 LAN missed-event recovery | Drop or ignore one captured unsolicited frame and verify reconciliation read corrects shared state. | `validation_hardware` |
+| X6200 serial panel tuning latency | Measure bounded frequency update latency after external VFO tuning with and without unsolicited frames. | `integration` plus hardware opt-in |
+| Yaesu CAT polling profile | Verify request/response polling updates shared state without model-specific state delivery branches. | `integration` plus hardware opt-in |
+| External Hamlib rigctld client | Verify real `rigctld` GET/SET responses publish observations and preserve read-after-write behavior. | `integration` or `validation_hardware` |
+| WebSocket reconnect against live radio | Verify reconnect full-state envelope preserves canonical state/freshness revisions while transport sequence resets. | `integration` plus hardware opt-in |
+
+## Current MOR-336 Sample Tests
+
+- `test_meter_updates_do_not_wait_for_unrelated_state_revisions` demonstrates a
+  meter delta independent from unrelated state revisions.
+- `test_stale_field_reconciles_after_missed_unsolicited_event` demonstrates
+  stale-field reconciliation after a missed unsolicited event.
+- `test_backend_variants_and_pending_overlays_are_scoped` demonstrates backend
+  source variants and scoped pending overlays.

--- a/docs/internals/radio-state-store.md
+++ b/docs/internals/radio-state-store.md
@@ -1,0 +1,50 @@
+# Radio StateStore Semantics
+
+MOR-338 adds the runtime-level `StateStore` in `rigplane.core.state_store`.
+It is the future single source of truth for decoded radio state, while legacy
+mutable `RadioState` remains a compatibility surface until later migrations.
+
+## Ownership
+
+`StateStore` owns the mutable backing dictionaries for semantic field values
+and freshness metadata. New consumers should read through snapshot APIs only:
+
+- `StateStore.snapshot()` returns a full `StateSnapshot`.
+- `StateStore.delta_since(snapshot)` returns semantic and freshness deltas
+  since a prior snapshot.
+- `StateStore.apply(observation)` is the only semantic write path.
+- `StateStore.mark_stale_due()` is the only freshness-expiration write path.
+
+Values are copied on ingress and egress so mutating an input observation payload
+or exported snapshot dictionary cannot mutate store-owned state.
+
+## Revisions
+
+The store maintains three independent counters:
+
+- `stateRevision`: increments only when a field value changes semantically.
+- `freshnessRevision`: increments when a field moves between `unknown`,
+  `fresh`, and `stale`, even when the semantic value is unchanged.
+- `observationSeq`: increments for every applied observation, including no-op
+  observations that only confirm an existing value.
+
+Transport sequence is not owned by `StateStore`. Backend transports may keep
+their own packet/frame ordering metadata, but that sequence is not interpreted
+as a state revision and is not exposed by the store API.
+
+## Freshness
+
+Each observation may carry `max_age`. When `mark_stale_due()` observes that a
+fresh field has exceeded that age, the field becomes stale without changing its
+semantic value. The returned delta includes a `ReconciliationRequest` hint for
+future acquisition scheduling. MOR-339 owns the actual scheduler and
+`ensure_fresh` policy.
+
+An observation for a stale field marks it fresh again. If the value is
+unchanged, only `freshnessRevision` advances; `stateRevision` remains stable.
+
+## Compatibility Boundary
+
+This module does not import Web, rigctld, runtime, transport, or legacy
+`RadioState` types. One-way compatibility adapters may be added later, but
+direct mutation of the store's backing state is not a supported public API.

--- a/docs/superpowers/specs/2026-06-02-radio-state-pipeline-design.md
+++ b/docs/superpowers/specs/2026-06-02-radio-state-pipeline-design.md
@@ -1,0 +1,677 @@
+# Radio State Pipeline Design
+
+Status: draft for review
+Date: 2026-06-02
+Scope: public open-core runtime, web, rigctld, and backend-neutral state flow
+
+## Summary
+
+RigPlane needs one canonical radio state model. WebSocket, HTTP snapshots,
+rigctld reads, diagnostics, and future processing hooks should all consume the
+same state source, with one revision sequence. Polling, push frames, command
+responses, and adaptive acquisition are ways to discover values; they must not
+be delivery pipelines.
+
+The target architecture separates command ingress from data ingress:
+
+```text
+Command ingress:
+  WebSocket / HTTP / rigctld / public API
+    -> CommandIntent
+    -> backend-neutral CommandService
+    -> backend executor / existing command queue / IcomCommander
+
+Data ingress:
+  CI-V push / command response / poll response / Yaesu poller / Hamlib rigctld client
+    -> Observation
+    -> StateStore.apply(...)
+    -> ChangeSet + revision
+
+Consumers:
+  WebSocket / HTTP state / rigctld GET / diagnostics / future hooks
+```
+
+The first delivery milestone should introduce the neutral contracts and migrate
+the highest-impact Icom/Web path. Later milestones should bring Yaesu,
+Hamlib/external-rigctld, rigctld SET/GET, and adaptive policy hooks onto the
+same model.
+
+## Problem Statement
+
+The current command execution system is reliable and should remain intact. The
+fragile area is the pipeline from "a value was received from the radio" to "all
+consumers observe the same state".
+
+Current symptoms:
+
+- S-meter and other meters can update in `RadioState` without consistently
+  advancing the public web revision. The UI then sees meters in bursts when an
+  unrelated event advances the revision.
+- X6200 can show multi-second lag after tuning from the radio panel. IC-7610
+  LAN often masks the same architectural weakness with faster transport and
+  richer unsolicited state.
+- WebSocket and HTTP both update the frontend store, but they do not currently
+  share a canonical state revision owned by the state model.
+- rigctld maintains local pending/cache state for some operations instead of
+  consuming the same radio state source as Web.
+- Radio-specific workarounds are tempting because acquisition policy and state
+  delivery are not cleanly separated.
+
+## Goals
+
+- Make the radio state model the single source of truth for confirmed radio
+  state and canonical state revision.
+- Ensure every meaningful state mutation is represented as a typed `ChangeSet`.
+- Treat WebSocket and HTTP as two representations of the same state source.
+- Treat rigctld GET as a consumer of the same state source.
+- Preserve the existing command queue, IcomCommander, transport pacing, raw
+  CI-V transaction ownership, and backend safety behavior.
+- Represent writes as `CommandIntent` lifecycle events, not as direct state
+  delivery.
+- Support optional pending state for local writes without confusing it with
+  confirmed observations from the radio.
+- Make radio-specific behavior capability/policy-driven rather than
+  backend-name branches.
+- Provide explicit hooks for diagnostics, pulse/adaptive polling, meter
+  coalescing, and future public processing.
+
+## Non-Goals
+
+- Do not replace the existing serialized command executors in the first
+  milestone.
+- Do not introduce direct `libhamlib` bindings. Core's Hamlib boundary remains
+  external `rigctld`.
+- Do not change rigctld wire protocol behavior.
+- Do not redesign the frontend UI.
+- Do not add proprietary, hosted-account, customer-specific, or Pro-only
+  workflow logic to Core.
+
+## Current Model
+
+### Web State Delivery
+
+The frontend currently starts HTTP polling for `/api/v1/state`, then opens the
+control WebSocket. Both channels write into the same frontend store.
+
+HTTP polling only calls the store callback when `revision` or
+`healthRevision` advances. The control WebSocket receives `state_update`
+messages and also writes to the store. This is operationally useful, but the
+backend revision is not owned by the radio state model.
+
+### Icom CI-V State Updates
+
+The CI-V RX path decodes solicited and unsolicited frames and mutates state.
+Only selected fields call a state-change callback. Some high-value fields such
+as meters and frequency/mode are updated silently or through separate paths.
+
+That creates this failure mode:
+
+```text
+meter frame arrives
+  -> RadioState meter field changes
+  -> no state revision bump
+  -> no Web state broadcast
+  -> later unrelated event bumps revision
+  -> UI receives several meter changes as one jump
+```
+
+### SET Commands
+
+WebSocket commands and HTTP commands mostly enter the Web `CommandQueue`, then
+the poller executes them through the backend API. Some commands also apply
+manual optimistic updates to `RadioState` and bump a poller-owned revision.
+
+rigctld SET commands currently call backend methods directly and maintain local
+pending/cache values for some fields. This is a separate command ingress path
+and a separate read cache.
+
+## Target Architecture
+
+```mermaid
+flowchart LR
+    subgraph "Command Ingress"
+        WS_CMD["WebSocket command"]
+        HTTP_CMD["HTTP command"]
+        RIGCTL_SET["rigctld SET"]
+        API_CMD["Public API call"]
+    end
+
+    subgraph "Command Layer"
+        INTENT["CommandIntent"]
+        SERVICE["CommandService"]
+        EXEC["Backend executor\nCommandQueue / IcomCommander / backend API"]
+        LIFE["CommandLifecycleEvent"]
+    end
+
+    subgraph "Data Ingress"
+        CIV_PUSH["CI-V unsolicited frame"]
+        CIV_RESP["CI-V command/poll response"]
+        STATE_POLL["StatePollable poll result"]
+        HAMLIB_RESP["External rigctld client response"]
+    end
+
+    subgraph "State Pipeline"
+        OBS["Observation"]
+        STORE["RadioStateModel / StateStore"]
+        CHANGE["ChangeSet + state revision"]
+    end
+
+    subgraph "Consumers"
+        WS_STATE["WebSocket state_update"]
+        HTTP_STATE["HTTP /api/v1/state + ETag"]
+        RIGCTL_GET["rigctld GET"]
+        DIAG["Diagnostics"]
+        HOOKS["Policy/hooks"]
+    end
+
+    WS_CMD --> INTENT
+    HTTP_CMD --> INTENT
+    RIGCTL_SET --> INTENT
+    API_CMD --> INTENT
+    INTENT --> SERVICE --> EXEC
+    SERVICE --> LIFE
+
+    CIV_PUSH --> OBS
+    CIV_RESP --> OBS
+    STATE_POLL --> OBS
+    HAMLIB_RESP --> OBS
+    EXEC -. "may produce response/echo" .-> OBS
+
+    OBS --> STORE --> CHANGE
+    CHANGE --> WS_STATE
+    CHANGE --> HTTP_STATE
+    CHANGE --> RIGCTL_GET
+    CHANGE --> DIAG
+    CHANGE --> HOOKS
+    LIFE --> DIAG
+    LIFE --> HOOKS
+```
+
+### Core Concepts
+
+#### RadioStateModel / StateStore
+
+The state model owns the canonical `RadioState` instance and the canonical
+state revision. It is the only layer that applies observations to confirmed
+state.
+
+Responsibilities:
+
+- Validate and normalize field updates.
+- Compare previous and next values.
+- Emit `ChangeSet` only when confirmed state changes.
+- Keep one monotonic state revision per process lifetime.
+- Provide full snapshots for HTTP and initial WebSocket state.
+- Provide optional projections for rigctld and diagnostics.
+- Maintain health/staleness metadata separately from data values.
+
+The implementation should avoid web or rigctld imports. Contracts should live
+in a neutral layer; the concrete runtime object can be wired into Web and
+rigctld at startup.
+
+#### Observation
+
+An `Observation` is a decoded value from an acquisition source. It is not a
+command acknowledgement and not a Web event.
+
+Suggested fields:
+
+- `path`: typed state path, such as `main.freq`, `main.s_meter`,
+  `power_meter`, `ptt`.
+- `value`: normalized Python value.
+- `source`: `civ_unsolicited`, `poll_response`, `command_response`,
+  `state_poller`, `hamlib_response`, `local_reconcile`.
+- `receiver`: optional receiver identity.
+- `timestamp_monotonic`.
+- `quality`: optional flags such as `confirmed`, `stale`, `partial`,
+  `synthetic`.
+- `correlation_id`: optional command intent or poll request id.
+
+Observation hooks should fire for every decoded sample, even if the value did
+not change. This supports diagnostics and policy decisions such as "radio is
+alive" and "meter sample rate".
+
+#### ChangeSet
+
+A `ChangeSet` is the result of applying one or more observations to the state
+model.
+
+Suggested fields:
+
+- `revision`: canonical state revision after the change.
+- `changes`: typed field changes with previous and next values.
+- `timestamp_monotonic`.
+- `sources`: acquisition sources represented in this change set.
+- `coalesced`: whether multiple observations were batched.
+
+Change hooks fire only when confirmed state changes. WebSocket deltas, HTTP
+ETags, rigctld GET cache invalidation, and diagnostics should derive from this
+event.
+
+#### CommandIntent
+
+A `CommandIntent` represents an attempt to change or query radio state from a
+consumer.
+
+Suggested fields:
+
+- `id`: stable command id.
+- `name`: backend-neutral operation name, such as `set_freq`.
+- `params`: normalized command parameters.
+- `source`: `websocket`, `http`, `rigctld`, `public_api`, `internal_policy`.
+- `target`: receiver/VFO/global target.
+- `priority`: user, normal, background.
+- `timeout`.
+- `pending_policy`: whether the command should create a pending local overlay.
+- `expected_observations`: optional fields likely to confirm the command.
+
+Command lifecycle events are separate from state changes:
+
+- `accepted`
+- `queued`
+- `sent`
+- `acknowledged`
+- `failed`
+- `timed_out`
+- `confirmed`
+- `superseded`
+
+#### Pending State
+
+For user experience and rigctld compatibility, some writes need immediate
+read-after-write behavior. This should be represented as pending intent, not as
+confirmed radio state.
+
+Example:
+
+```text
+CommandIntent(set_freq=14074000, source=rigctld)
+  -> pending overlay: main.freq=14074000, confirmed=false
+  -> CI-V observation: main.freq=14074000
+  -> confirmed state change, pending cleared
+```
+
+The public state schema can remain backward compatible by continuing to expose
+plain values. Additive metadata can expose pending/confirmed status later if
+needed. Internally, consumers must be able to distinguish confirmed state from
+local intent.
+
+### Acquisition Policy
+
+Acquisition policies decide how values are obtained. They do not own state
+delivery.
+
+Examples:
+
+- Prefer CI-V unsolicited frames when a backend/profile supports them.
+- Poll frequency/mode on a short pulse after local writes or detected external
+  activity when unsolicited updates are unavailable.
+- Poll S-meter at a profile-safe target rate.
+- Poll TX meters more aggressively while transmitting.
+- Slow down background state queries when the link is idle or congested.
+- Reduce background telemetry before delaying user commands.
+
+Policy decisions should be capability-driven:
+
+- transport type and safe minimum gap
+- profile meter support
+- unsolicited frequency/mode support
+- unsolicited meter support
+- command response semantics
+- serial backpressure/error rate
+- external CAT session ownership
+
+No policy should branch directly on a model name such as X6200 unless the model
+profile exposes that capability or constraint.
+
+### Hooks
+
+The architecture should expose these hook categories:
+
+- `on_command(event)`: command lifecycle, audit, latency, failure analysis.
+- `on_observation(observation)`: raw sample accounting and acquisition policy.
+- `on_change(changeset)`: canonical state revision, delivery, history.
+- `on_policy_signal(signal)`: pulse/adaptive scheduling, backpressure, mode
+  changes such as RX/TX.
+
+Hooks must not mutate `RadioState` directly. They may enqueue acquisition work,
+emit diagnostics, update metrics, or request command execution through the
+command service.
+
+## HTTP and WebSocket Representation
+
+HTTP and WebSocket must become projections of the same `RadioStateModel`.
+
+```mermaid
+flowchart TB
+    STORE["RadioStateModel / StateStore"]
+    SNAP["Full public snapshot"]
+    DIFF["ChangeSet projection"]
+    HTTP["GET /api/v1/state\nETag = state revision + health revision"]
+    WS_INIT["Initial WebSocket full state"]
+    WS_DELTA["WebSocket state_update delta"]
+
+    STORE --> SNAP
+    STORE --> DIFF
+    SNAP --> HTTP
+    SNAP --> WS_INIT
+    DIFF --> WS_DELTA
+```
+
+Rules:
+
+- Initial WebSocket state and HTTP snapshot come from the same snapshot builder.
+- HTTP ETag uses the canonical state revision plus health revision.
+- WebSocket `state_update.revision` uses the canonical state revision.
+- Any transport-local sequence, if needed, should be a separate field and not
+  the state revision.
+- Delta encoding is a representation concern. It must not own canonical state
+  revision.
+- HTTP polling can remain as a startup/fallback edge case, but it is not a
+  second source of truth.
+
+## Command Flow
+
+```mermaid
+sequenceDiagram
+    participant Client as Web/HTTP/rigctld/API
+    participant CommandService
+    participant Executor as Existing executor
+    participant Radio
+    participant Acquisition as RX/poll response
+    participant StateStore
+    participant Consumers as WS/HTTP/rigctld/diagnostics
+
+    Client->>CommandService: CommandIntent(set_freq)
+    CommandService-->>Client: accepted / queued
+    CommandService->>Executor: execute intent
+    Executor->>Radio: backend-specific command
+    Executor-->>CommandService: sent/ack/failed
+    Radio-->>Acquisition: response or unsolicited echo
+    Acquisition->>StateStore: Observation(freq)
+    StateStore->>StateStore: apply + compare
+    StateStore-->>Consumers: ChangeSet(revision++)
+    StateStore-->>CommandService: confirmation correlation
+    CommandService-->>Client: confirmed or timed out
+```
+
+Important separation:
+
+- Command acceptance does not imply confirmed state.
+- Fire-and-forget command execution may still create pending local intent.
+- Confirmed state changes only through observations or explicit local
+  reconciliation events.
+- Failed commands clear or expire pending overlays without creating confirmed
+  state.
+
+## Backend Coverage
+
+### Icom CI-V
+
+Icom is the first high-impact migration path because it already has an RX pump
+that can decode unsolicited frames and poll responses.
+
+Required changes in the Icom path:
+
+- Convert decoded CI-V frames into observations for all state-bearing frames,
+  including frequency, mode, meters, PTT, power, DSP flags, and levels.
+- Preserve raw CI-V transaction ownership and request tracking.
+- Keep IcomCommander and serial/LAN pacing.
+- Mark poller-originated queries as acquisition work, not state delivery work.
+- Use background priority and dedupe for background acquisition where possible.
+
+### StatePollable Backends
+
+Backends that expose request-response polling should publish observations from
+their polling results. The existing poller can remain as the acquisition
+mechanism.
+
+### Hamlib External rigctld Provider
+
+Core's Hamlib boundary remains an external `rigctld` process. The Hamlib client
+backend should translate rigctld responses into observations and expose
+capabilities that describe whether useful push/notification behavior is
+available.
+
+### rigctld Server
+
+rigctld GET should read from the shared state model. rigctld SET should become
+command ingress into `CommandService`, or at minimum publish command intents and
+pending overlays while still using the existing backend method path during
+migration.
+
+## Milestones
+
+### Milestone 0: Evidence and Diagnostics
+
+Deliverables:
+
+- Counters for observations by source and field family.
+- Counters for `ChangeSet` emission by field family.
+- Broadcast counters for WebSocket and HTTP ETag revision changes.
+- Command queue latency and executor latency metrics.
+- Serial partial-frame, timeout, and backpressure metrics.
+
+Acceptance:
+
+- It is possible to compare meter frame ingress rate with Web/UI state delivery
+  rate.
+- It is possible to determine whether X6200 emits unsolicited frequency frames
+  during VFO tuning.
+- No behavior changes are required in this milestone.
+
+### Milestone 1: Core Contracts and StateStore
+
+Deliverables:
+
+- Backend-neutral `Observation`, `ChangeSet`, `CommandIntent`, and
+  `CommandLifecycleEvent` contracts.
+- `RadioStateModel` / `StateStore` implementation with canonical revision.
+- Snapshot projection for the existing public state schema.
+- Hook registration for observation/change/command/policy events.
+- Unit tests for revision behavior, no-op applies, receiver paths, and
+  coalesced changes.
+
+Acceptance:
+
+- Applying a changed observation increments state revision exactly once.
+- Applying an unchanged observation does not increment state revision.
+- Full snapshots match the existing public state contract.
+- No Web or rigctld imports are introduced into core/runtime state modules.
+
+### Milestone 2: Icom RX and Web State Migration
+
+Deliverables:
+
+- Icom CI-V RX path emits observations for frequency, mode, meters, and existing
+  notify-backed fields.
+- Icom poll responses feed the same observation path.
+- Web HTTP snapshot and initial WebSocket full state are built from
+  `StateStore`.
+- WebSocket deltas use canonical state revision.
+- Meter changes are coalesced for Web delivery at a bounded rate.
+
+Acceptance:
+
+- S-meter changes advance state revision or are included in bounded coalesced
+  revisions.
+- Frequency changes from unsolicited CI-V frames reach Web without waiting for
+  unrelated events.
+- HTTP `/api/v1/state` and WebSocket initial state agree on revision and data.
+- Existing command execution behavior remains compatible.
+
+### Milestone 3: Backend-Neutral Acquisition Adapters
+
+Deliverables:
+
+- `StatePollable` adapters publish observations instead of direct Web
+  callbacks.
+- Yaesu request-response polling updates the shared state model.
+- External Hamlib/rigctld client backend responses update the shared state
+  model.
+- Capability/policy metadata describes push support, safe poll rates, meter
+  support, and transport constraints.
+
+Acceptance:
+
+- Web and HTTP do not need backend-specific state delivery code.
+- Backend differences are represented through capabilities and acquisition
+  policies.
+- No model-specific X6200 branch is required for the general state pipeline.
+
+### Milestone 4: rigctld Consumer Migration
+
+Deliverables:
+
+- rigctld GET reads from shared state snapshots/projections where freshness is
+  acceptable.
+- rigctld fallback reads still produce observations when they hit the radio.
+- rigctld SET publishes command intents and pending overlays.
+- Existing rigctld wire responses remain compatible with Hamlib clients.
+
+Acceptance:
+
+- Web and rigctld see consistent frequency/mode/meter state after the same radio
+  observation.
+- rigctld read-after-write behavior is preserved through pending intent or
+  confirmed state.
+- Local rigctld caches are either removed or reduced to compatibility shims.
+
+### Milestone 5: Unified CommandService
+
+Deliverables:
+
+- WebSocket, HTTP, rigctld, and public API write paths enter a backend-neutral
+  `CommandService`.
+- Existing command queues/executors remain as backend execution adapters.
+- Command lifecycle events are observable.
+- Pending overlays are correlated with observations and cleared on
+  confirmation, supersession, timeout, or failure.
+
+Acceptance:
+
+- Command ingress is consistent across Web, HTTP, rigctld, and public API.
+- Command success/failure is not confused with confirmed state mutation.
+- User-facing commands can preempt background acquisition on slow transports.
+
+### Milestone 6: Adaptive Acquisition Policies
+
+Deliverables:
+
+- Frequency/mode pulse policy for radios without reliable unsolicited updates.
+- Meter telemetry policy separated from slow state polling.
+- TX-aware meter policy for POWER/ALC/SWR/COMP.
+- Idle decay policy for background state queries.
+- Backpressure policy that reduces background telemetry before delaying user
+  commands.
+
+Acceptance:
+
+- X6200-like serial radios can use short freq/mode pulse polling without
+  increasing all background traffic.
+- Meters have stable, bounded delivery cadence appropriate to transport
+  capability.
+- Policy behavior is configured through capabilities/profile metadata, not
+  hard-coded model branches.
+
+### Milestone 7: Cleanup and Compatibility Hardening
+
+Deliverables:
+
+- Remove or deprecate poller-owned public state revision.
+- Remove duplicate state caches where replaced by the shared state model.
+- Update docs for Web, rigctld, state pipeline, and backend capabilities.
+- Add regression tests for known meter and X6200 frequency-lag scenarios.
+
+Acceptance:
+
+- One canonical state revision remains for Web/HTTP state.
+- No stale silent mutation path exists for supported state fields.
+- Public API, Web state schema, and rigctld wire behavior remain compatible or
+  any additive changes are documented.
+
+## Coalescing and Rate Limits
+
+The state model should emit canonical changes. Transports may coalesce delivery
+for high-rate fields.
+
+Guidelines:
+
+- Frequency/mode changes should be delivered with minimal coalescing.
+- Meter delivery to Web should be bounded, for example 20-30 Hz on capable
+  links and lower on slow serial links.
+- Observation hooks may see every sample even when Web delivery is coalesced.
+- Coalescing must not hide the last value in a burst.
+- Backpressure must drop or merge background telemetry before user-visible
+  command lifecycle events.
+
+## Error Handling
+
+- Failed commands emit lifecycle failure events and clear relevant pending
+  overlays.
+- Timed-out pending overlays expire and may trigger reconciliation polling.
+- Reconnect marks stale fields and may reset transport-local policy state.
+- External CAT/raw CI-V ownership remains exclusive; acquisition policies pause
+  when required by the existing ownership mechanism.
+- Malformed or partial frames become diagnostics observations or counters, not
+  state mutations.
+- Health revision remains separate from state revision, but HTTP ETags include
+  both.
+
+## Testing Strategy
+
+Unit tests:
+
+- `StateStore.apply` increments revision only on real changes.
+- No-op observations do not emit `ChangeSet`.
+- Meter observations can be coalesced without losing latest values.
+- Pending overlays confirm, expire, and supersede correctly.
+- Snapshot projection matches the existing public state schema.
+
+Icom tests:
+
+- CI-V `0x15` meter frames produce observations and state changes.
+- CI-V `0x00`/`0x03` frequency frames produce observations and state changes.
+- Poll responses and unsolicited frames use the same apply path.
+- Background acquisition uses priority/dedupe where supported.
+
+Web tests:
+
+- Initial WebSocket full state and HTTP `/api/v1/state` are generated from the
+  same state revision.
+- WebSocket deltas use canonical state revision.
+- HTTP ETag advances when state revision advances.
+
+rigctld tests:
+
+- GET frequency/mode reads shared state when fresh.
+- SET frequency creates command intent and preserves read-after-write behavior.
+- Fallback radio reads publish observations.
+
+Integration/fake-backend tests:
+
+- X6200-like serial profile shows bounded frequency update latency after VFO
+  tuning when unsolicited frames are present.
+- X6200-like no-push profile uses pulse polling without flooding background
+  state queries.
+- Meter delivery cadence is stable and bounded.
+
+## Open Decisions
+
+- Exact module placement for contracts and implementation must satisfy the
+  import-linter layer matrix. The preferred split is neutral contracts in core
+  and runtime orchestration in runtime.
+- Public exposure of pending metadata should be additive and may be deferred.
+- The exact Web meter delivery rate should be profile/policy driven after
+  diagnostics establish realistic serial and LAN rates.
+- The command confirmation timeout policy should differ by command family and
+  transport.
+
+## Review Checklist
+
+- The radio state model is the only canonical source of state revision.
+- WebSocket and HTTP are representations of the same state source.
+- Pollers acquire observations; they do not own state delivery.
+- rigctld is both command ingress and state consumer.
+- Radio-specific behavior is modeled as capabilities/policy.
+- Existing command serialization and raw CI-V ownership are preserved.

--- a/docs/superpowers/specs/2026-06-02-radio-state-pipeline-design.md
+++ b/docs/superpowers/specs/2026-06-02-radio-state-pipeline-design.md
@@ -198,6 +198,11 @@ flowchart LR
 
 The target model is single-writer for confirmed state: `StateStore.apply(...)`
 is the only place that changes the consumer-visible confirmed state model.
+To make that enforceable, the state service must own a private state instance
+or immutable snapshot source. Exposing a mutable `RadioState` object as the
+consumer-visible state source is a migration hazard and should be treated as a
+legacy compatibility surface until each field family moves behind the state
+service.
 
 During migration, every legacy writer must be classified before it is touched:
 
@@ -238,6 +243,15 @@ Responsibilities:
 The implementation should avoid web or rigctld imports. Contracts should live
 in a neutral layer; the concrete runtime object can be wired into Web and
 rigctld at startup.
+
+Layer placement rule:
+
+- `core`: neutral contracts only, such as `Observation`, `FieldPath`, and
+  `ChangeSet`. Core must not contain Web or rigctld projection schemas.
+- `runtime`: state service implementation and backend orchestration.
+- `web` and `rigctld`: projections, wire schemas, and compatibility adapters.
+- `profiles`: static capability and acquisition-policy metadata, with loader
+  validation.
 
 #### Observation
 
@@ -610,22 +624,25 @@ migration.
 
 Deliverables:
 
-- Counters for observations by source and field family.
-- Counters for `ChangeSet` emission by field family.
-- Counters for stale/fresh transitions by field family.
-- Counters for reconciliation reads and `ensure_fresh` calls.
-- Broadcast counters for WebSocket and HTTP ETag revision changes.
+- Legacy baseline counters for current CI-V frame ingress by command/subcommand
+  family, including meters and frequency/mode frames.
+- Legacy baseline counters for current `_notify_change(...)` calls and event
+  names.
+- Legacy baseline counters for current poller revision bumps, WebSocket
+  broadcasts, HTTP ETag changes, and frontend accepted/rejected state updates.
 - Command queue latency and executor latency metrics.
-- Serial partial-frame, timeout, and backpressure metrics.
+- Serial partial-frame, timeout, external-CAT pause, and backpressure metrics.
+- Baseline traces that can answer whether X6200 emits unsolicited frequency
+  frames during VFO tuning and how long Web/rigctld take to observe the change.
 
 Acceptance:
 
-- It is possible to compare meter frame ingress rate with Web/UI state delivery
-  rate.
+- It is possible to compare current meter frame ingress rate with current Web/UI
+  state delivery rate.
 - It is possible to determine whether X6200 emits unsolicited frequency frames
   during VFO tuning.
-- It is possible to determine whether reconciliation corrected a missed or
-  stale field.
+- It is possible to identify which legacy mechanism advanced the public state
+  revision for a given Web update.
 - No behavior changes are required in this milestone.
 
 ### Milestone 1: Core Contracts and StateStore
@@ -640,8 +657,13 @@ Deliverables:
 - State ownership inventory that classifies legacy writers as
   `observation_adapter`, `pending_overlay`, `executor_cache`,
   `protocol_local_keep`, `compatibility_shim`, or `delete`.
+- FieldPath registry/table for existing public schema fields, including
+  MAIN/SUB, VFO A/B/active, global fields, scope controls, Yaesu extensions,
+  meter families, and legacy aliases.
 - Per-field freshness metadata and separate freshness/health revision semantics.
 - Active `FreshnessClock`/ticker for freshness deadlines and stale events.
+- New counters for observations, `ChangeSet` emission, freshness transitions,
+  and state/freshness revision movement.
 - Snapshot projection for the existing public state schema.
 - Hook registration for observation/change/command/policy events.
 - Unit tests for revision behavior, no-op applies, receiver paths, and
@@ -657,6 +679,31 @@ Acceptance:
   state revision churn.
 - Full snapshots match the existing public state contract.
 - No Web or rigctld imports are introduced into core/runtime state modules.
+
+### Milestone 1.5: Minimal AcquisitionScheduler
+
+Deliverables:
+
+- Minimal `AcquisitionScheduler` contract and implementation for freshness and
+  reconciliation reads.
+- Dedupe keys and waiter semantics for concurrent requests for the same
+  `FieldPath` family.
+- Priority classes for user freshness, command confirmation, reconciliation,
+  and background telemetry.
+- External-CAT/raw CI-V ownership checks.
+- Icom-safe acquisition path that queues queries and waits for RX-pump
+  observations instead of bypassing fire-and-forget semantics.
+
+Acceptance:
+
+- `ensure_fresh` can request an acquisition read without Web or rigctld calling
+  direct backend getters.
+- Concurrent freshness requests for the same field family share one acquisition
+  request.
+- External-CAT ownership causes freshness requests to pause, fail, or report
+  unavailable state without polluting the owned stream.
+- User-facing commands can still preempt background reconciliation on slow
+  transports.
 
 ### Milestone 2: Icom RX and Web State Migration
 
@@ -695,6 +742,11 @@ Deliverables:
 - Yaesu request-response polling updates the shared state model.
 - External Hamlib/rigctld client backend responses update the shared state
   model.
+- RadioProfile schema additions for acquisition policy metadata: push support,
+  safe poll rates, freshness windows, reconciliation intervals, transport
+  constraints, and meter family support.
+- Profile loader validation for acquisition policy metadata, with conservative
+  defaults for existing profiles.
 - Capability/policy metadata describes push support, safe poll rates, meter
   support, freshness windows, reconciliation intervals, and transport
   constraints.
@@ -705,6 +757,8 @@ Acceptance:
 - Backend differences are represented through capabilities and acquisition
   policies.
 - No model-specific X6200 branch is required for the general state pipeline.
+- The "no model-specific branch" acceptance is backed by profile metadata and
+  loader validation, not implicit backend-name checks.
 
 ### Milestone 4: rigctld Consumer Migration
 
@@ -810,6 +864,22 @@ removing code, create an inventory document and classify every legacy state path
 as `keep`, `migrate`, or `delete`. Each `delete` item needs a replacement path
 and regression coverage.
 
+Before the first implementation code change, complete an audit gate covering:
+
+- all Icom `_RADIO_STATE_HANDLERS`, `_notify_change(...)` sites, and direct
+  `RadioState` writes;
+- Web `RadioPoller` revision, mutation, `mark_polled`, and `bump_revision`
+  sites;
+- Web server public-state building, ETag, broadcast, delta, radio connect, and
+  power paths;
+- frontend HTTP/WS/store revision logic, optimistic overlays, restart handling,
+  and stale rejection;
+- rigctld pending/cache/VFO/protocol-local paths and Hamlib error mapping;
+- `StateCacheCapable`, core `_state_cache`, and any runtime cache exposed to
+  consumers;
+- Yaesu and external rigctld-client direct `RadioState` mutations;
+- profile schema gaps for acquisition policy metadata.
+
 Initial inventory candidates:
 
 - Web `RadioPoller` revision: `_revision`, `revision`, `bump_revision`, and all
@@ -861,6 +931,10 @@ Required Web audit surfaces:
   the owner of canonical state revision.
 - `web/runtime_helpers`: public state schema projection and backward-compatible
   field names.
+- Web revision migration tests must be written before changing wire behavior:
+  HTTP-vs-WebSocket race, full/delta handling, restart/reset, optimistic patch
+  confirmation/expiry, and no overwrite of canonical revision by transport
+  sequence.
 - Frontend transport/store: HTTP polling, WebSocket delta application,
   revision/healthRevision stale rejection, restart detection, and optimistic
   patches.
@@ -887,6 +961,8 @@ Required rigctl/rigctld audit surfaces:
 - Integration tests: WSJT-X/fldigi-like command sequences, rigctl `F/M/f/m`
   read-after-write, VFO-prefixed commands, stale/fresh reads, and Hamlib error
   codes.
+- rigctld caches must not be removed until pending-overlay parity tests prove
+  read-after-write behavior and protocol-local state remains compatible.
 
 Cleanup rules:
 

--- a/docs/superpowers/specs/2026-06-02-radio-state-pipeline-design.md
+++ b/docs/superpowers/specs/2026-06-02-radio-state-pipeline-design.md
@@ -632,6 +632,8 @@ Deliverables:
 - Produce a cleanup inventory that lists every legacy state/revision/cache owner,
   its replacement, migration status, tests that protect it, and whether it must
   be kept, migrated, or deleted.
+- Produce explicit Web implementation and rigctl/rigctld implementation audits
+  before deleting compatibility paths.
 - Remove or deprecate poller-owned public state revision.
 - Remove duplicate state caches where replaced by the shared state model.
 - Remove manual state-change callback paths once observations cover the same
@@ -645,6 +647,10 @@ Acceptance:
 
 - The cleanup inventory is complete enough that each legacy tail has an owner
   and an explicit keep/migrate/delete decision.
+- The Web audit covers backend server state delivery, frontend state ingestion,
+  and HTTP/WebSocket compatibility.
+- The rigctl/rigctld audit covers command parsing, SET execution, GET state
+  reads, pending/cache behavior, and Hamlib wire compatibility.
 - One canonical state revision remains for Web/HTTP state.
 - No stale silent mutation path exists for supported state fields.
 - No legacy cache can serve fresher-looking data than the shared state model.
@@ -687,6 +693,46 @@ Initial inventory candidates:
   additive freshness metadata.
 - Documentation tails: update Web, rigctld, layer docs, and any outdated poller
   cadence or "poller broadcasts state" descriptions.
+
+Required Web audit surfaces:
+
+- `web_startup`: backend startup wiring for `StatePollable`,
+  `StateNotifyCapable`, `RadioPoller`, and state callbacks.
+- `web/server`: public state building, ETag construction, health/freshness
+  revision handling, `_broadcast_state_update`, and radio connect/power paths
+  that currently perform optimistic state mutation.
+- `web/handlers/control`: initial WebSocket state, command ACK behavior,
+  subscription behavior, and any direct fallback state payload generation.
+- `web/radio_poller`: command execution, acquisition queries, optimistic
+  mutations, `mark_polled`, and all revision bump sites.
+- `web/_delta_encoder`: delta encoding must remain a transport projection, not
+  the owner of canonical state revision.
+- `web/runtime_helpers`: public state schema projection and backward-compatible
+  field names.
+- Frontend transport/store: HTTP polling, WebSocket delta application,
+  revision/healthRevision stale rejection, restart detection, and optimistic
+  patches.
+- Web tests: state endpoint ETags, WebSocket initial/delta messages, frontend
+  stale-state rejection, and meter/frequency regression coverage.
+
+Required rigctl/rigctld audit surfaces:
+
+- `rigctld/contract` and `rigctld/protocol`: command definitions, VFO argument
+  handling, parser behavior, and stable Hamlib-compatible wire responses.
+- `rigctld/handler`: GET/SET dispatch, direct backend calls, `_FallbackRigState`,
+  `_PendingRigState`, read-after-write behavior, mode/data-mode compatibility,
+  and error mapping.
+- `rigctld/server`: per-client lifecycle, rate limiting, circuit breaker
+  interactions, poller startup/shutdown, and command timeout behavior.
+- `rigctld/poller`: state refresh cadence, cache updates, circuit breaker
+  behavior, and whether it should become an acquisition adapter.
+- `rigctld/routing`: level/function routing that currently depends on local
+  cache projections.
+- `rigctld/state_cache` and core `_state_cache` shims: decide whether each use
+  is an executor timeout cache, compatibility shim, or obsolete duplicate.
+- Integration tests: WSJT-X/fldigi-like command sequences, rigctl `F/M/f/m`
+  read-after-write, VFO-prefixed commands, stale/fresh reads, and Hamlib error
+  codes.
 
 Cleanup rules:
 

--- a/docs/superpowers/specs/2026-06-02-radio-state-pipeline-design.md
+++ b/docs/superpowers/specs/2026-06-02-radio-state-pipeline-design.md
@@ -8,9 +8,9 @@ Scope: public open-core runtime, web, rigctld, and backend-neutral state flow
 
 RigPlane needs one canonical radio state model. WebSocket, HTTP snapshots,
 rigctld reads, diagnostics, and future processing hooks should all consume the
-same state source, with one revision sequence. Polling, push frames, command
-responses, and adaptive acquisition are ways to discover values; they must not
-be delivery pipelines.
+same state source, with one state revision sequence and separate freshness
+versioning. Polling, push frames, command responses, and adaptive acquisition
+are ways to discover values; they must not be delivery pipelines.
 
 The target architecture separates command ingress from data ingress:
 
@@ -200,10 +200,15 @@ Responsibilities:
 - Validate and normalize field updates.
 - Compare previous and next values.
 - Emit `ChangeSet` only when confirmed state changes.
-- Keep one monotonic state revision per process lifetime.
+- Keep one monotonic state revision for applied model snapshots. This revision
+  is a local version/cache-invalidation sequence, not proof that the physical
+  radio has not changed.
 - Provide full snapshots for HTTP and initial WebSocket state.
 - Provide optional projections for rigctld and diagnostics.
-- Maintain health/staleness metadata separately from data values.
+- Track per-field freshness metadata: last observation time, source,
+  confidence, max age, and stale/unknown status.
+- Maintain health/freshness revision separately from value revision for
+  validity changes that do not alter a data value.
 
 The implementation should avoid web or rigctld imports. Contracts should live
 in a neutral layer; the concrete runtime object can be wired into Web and
@@ -247,6 +252,31 @@ Suggested fields:
 Change hooks fire only when confirmed state changes. WebSocket deltas, HTTP
 ETags, rigctld GET cache invalidation, and diagnostics should derive from this
 event.
+
+#### Revision, Freshness, and Missed Events
+
+State revision answers only this question: "has the model applied a newer known
+state value?" It must not be interpreted as "the radio definitely did not
+change."
+
+If an unsolicited radio frame is lost, malformed, or never emitted by the radio,
+the model cannot infer the missing value change from revision alone. The system
+therefore also needs field freshness and reconciliation:
+
+- Each state field or field family tracks `last_observed_monotonic`, source,
+  confidence, and a policy-defined freshness window.
+- Freshness transitions, such as `fresh -> stale` or `unknown -> fresh`, emit a
+  health/freshness event and may advance a separate freshness revision.
+- Consumers that need authoritative state can call an `ensure_fresh(paths,
+  max_age)` style API. That API may return the current fresh value, trigger an
+  acquisition read, or report stale/unavailable state.
+- Critical fields such as frequency, mode, PTT, power state, and selected
+  receiver need reconciliation polling even when push is supported.
+- Meter fields can have shorter freshness windows and coalesced delivery, but
+  the latest sample must still be tracked independently from Web delivery rate.
+
+This keeps revision useful for transport deltas while preventing it from
+becoming a false correctness signal.
 
 #### CommandIntent
 
@@ -304,8 +334,12 @@ delivery.
 Examples:
 
 - Prefer CI-V unsolicited frames when a backend/profile supports them.
+- Run low-rate reconciliation reads for critical state even when push is
+  supported, because unsolicited frames can be missed.
 - Poll frequency/mode on a short pulse after local writes or detected external
   activity when unsolicited updates are unavailable.
+- Trigger `ensure_fresh` reads when a consumer requires data newer than the
+  field's freshness window.
 - Poll S-meter at a profile-safe target rate.
 - Poll TX meters more aggressively while transmitting.
 - Slow down background state queries when the link is idle or congested.
@@ -347,7 +381,7 @@ flowchart TB
     STORE["RadioStateModel / StateStore"]
     SNAP["Full public snapshot"]
     DIFF["ChangeSet projection"]
-    HTTP["GET /api/v1/state\nETag = state revision + health revision"]
+    HTTP["GET /api/v1/state\nETag = state revision + health/freshness revision"]
     WS_INIT["Initial WebSocket full state"]
     WS_DELTA["WebSocket state_update delta"]
 
@@ -361,12 +395,16 @@ flowchart TB
 Rules:
 
 - Initial WebSocket state and HTTP snapshot come from the same snapshot builder.
-- HTTP ETag uses the canonical state revision plus health revision.
+- HTTP ETag uses the canonical state revision plus health/freshness revision.
 - WebSocket `state_update.revision` uses the canonical state revision.
+- No state revision advance means "the model has no newer applied value"; it
+  does not prove the physical radio did not change.
 - Any transport-local sequence, if needed, should be a separate field and not
   the state revision.
 - Delta encoding is a representation concern. It must not own canonical state
   revision.
+- HTTP ETags include state revision plus health/freshness revision so stale
+  transitions can be observed even when values do not change.
 - HTTP polling can remain as a startup/fallback edge case, but it is not a
   second source of truth.
 
@@ -448,6 +486,8 @@ Deliverables:
 
 - Counters for observations by source and field family.
 - Counters for `ChangeSet` emission by field family.
+- Counters for stale/fresh transitions by field family.
+- Counters for reconciliation reads and `ensure_fresh` calls.
 - Broadcast counters for WebSocket and HTTP ETag revision changes.
 - Command queue latency and executor latency metrics.
 - Serial partial-frame, timeout, and backpressure metrics.
@@ -458,6 +498,8 @@ Acceptance:
   rate.
 - It is possible to determine whether X6200 emits unsolicited frequency frames
   during VFO tuning.
+- It is possible to determine whether reconciliation corrected a missed or
+  stale field.
 - No behavior changes are required in this milestone.
 
 ### Milestone 1: Core Contracts and StateStore
@@ -467,6 +509,7 @@ Deliverables:
 - Backend-neutral `Observation`, `ChangeSet`, `CommandIntent`, and
   `CommandLifecycleEvent` contracts.
 - `RadioStateModel` / `StateStore` implementation with canonical revision.
+- Per-field freshness metadata and separate freshness/health revision semantics.
 - Snapshot projection for the existing public state schema.
 - Hook registration for observation/change/command/policy events.
 - Unit tests for revision behavior, no-op applies, receiver paths, and
@@ -476,6 +519,8 @@ Acceptance:
 
 - Applying a changed observation increments state revision exactly once.
 - Applying an unchanged observation does not increment state revision.
+- Freshness-only transitions do not fake data changes, but they are visible to
+  consumers through freshness/health revision.
 - Full snapshots match the existing public state contract.
 - No Web or rigctld imports are introduced into core/runtime state modules.
 
@@ -497,6 +542,8 @@ Acceptance:
   revisions.
 - Frequency changes from unsolicited CI-V frames reach Web without waiting for
   unrelated events.
+- If an unsolicited frequency/mode event is missed, a reconciliation read can
+  eventually correct the shared state.
 - HTTP `/api/v1/state` and WebSocket initial state agree on revision and data.
 - Existing command execution behavior remains compatible.
 
@@ -510,7 +557,8 @@ Deliverables:
 - External Hamlib/rigctld client backend responses update the shared state
   model.
 - Capability/policy metadata describes push support, safe poll rates, meter
-  support, and transport constraints.
+  support, freshness windows, reconciliation intervals, and transport
+  constraints.
 
 Acceptance:
 
@@ -559,6 +607,7 @@ Acceptance:
 Deliverables:
 
 - Frequency/mode pulse policy for radios without reliable unsolicited updates.
+- Low-rate reconciliation policy for critical state even when push is available.
 - Meter telemetry policy separated from slow state polling.
 - TX-aware meter policy for POWER/ALC/SWR/COMP.
 - Idle decay policy for background state queries.
@@ -569,6 +618,8 @@ Acceptance:
 
 - X6200-like serial radios can use short freq/mode pulse polling without
   increasing all background traffic.
+- Push-capable radios still recover from missed critical-state events through
+  bounded reconciliation.
 - Meters have stable, bounded delivery cadence appropriate to transport
   capability.
 - Policy behavior is configured through capabilities/profile metadata, not
@@ -611,12 +662,14 @@ Guidelines:
   overlays.
 - Timed-out pending overlays expire and may trigger reconciliation polling.
 - Reconnect marks stale fields and may reset transport-local policy state.
+- Missing expected observations do not silently confirm intent. They expire the
+  pending overlay and may trigger targeted reconciliation.
 - External CAT/raw CI-V ownership remains exclusive; acquisition policies pause
   when required by the existing ownership mechanism.
 - Malformed or partial frames become diagnostics observations or counters, not
   state mutations.
 - Health revision remains separate from state revision, but HTTP ETags include
-  both.
+  state, health, and freshness revision inputs.
 
 ## Testing Strategy
 
@@ -626,6 +679,9 @@ Unit tests:
 - No-op observations do not emit `ChangeSet`.
 - Meter observations can be coalesced without losing latest values.
 - Pending overlays confirm, expire, and supersede correctly.
+- Freshness transitions are observable without changing confirmed values.
+- `ensure_fresh` returns fresh cached values, triggers acquisition for stale
+  values, and reports unavailable state when acquisition fails.
 - Snapshot projection matches the existing public state schema.
 
 Icom tests:
@@ -633,6 +689,7 @@ Icom tests:
 - CI-V `0x15` meter frames produce observations and state changes.
 - CI-V `0x00`/`0x03` frequency frames produce observations and state changes.
 - Poll responses and unsolicited frames use the same apply path.
+- Reconciliation reads correct stale or missed frequency/mode observations.
 - Background acquisition uses priority/dedupe where supported.
 
 Web tests:
@@ -641,12 +698,16 @@ Web tests:
   same state revision.
 - WebSocket deltas use canonical state revision.
 - HTTP ETag advances when state revision advances.
+- HTTP ETag or equivalent freshness token advances when critical fields become
+  stale even if values do not change.
 
 rigctld tests:
 
 - GET frequency/mode reads shared state when fresh.
 - SET frequency creates command intent and preserves read-after-write behavior.
 - Fallback radio reads publish observations.
+- GET paths can request fresh-enough values instead of trusting indefinitely
+  stale state.
 
 Integration/fake-backend tests:
 

--- a/docs/superpowers/specs/2026-06-02-radio-state-pipeline-design.md
+++ b/docs/superpowers/specs/2026-06-02-radio-state-pipeline-design.md
@@ -629,17 +629,77 @@ Acceptance:
 
 Deliverables:
 
+- Produce a cleanup inventory that lists every legacy state/revision/cache owner,
+  its replacement, migration status, tests that protect it, and whether it must
+  be kept, migrated, or deleted.
 - Remove or deprecate poller-owned public state revision.
 - Remove duplicate state caches where replaced by the shared state model.
+- Remove manual state-change callback paths once observations cover the same
+  fields.
+- Rename or split any transport-local sequence counters that are currently
+  exposed as state revision.
 - Update docs for Web, rigctld, state pipeline, and backend capabilities.
 - Add regression tests for known meter and X6200 frequency-lag scenarios.
 
 Acceptance:
 
+- The cleanup inventory is complete enough that each legacy tail has an owner
+  and an explicit keep/migrate/delete decision.
 - One canonical state revision remains for Web/HTTP state.
 - No stale silent mutation path exists for supported state fields.
+- No legacy cache can serve fresher-looking data than the shared state model.
 - Public API, Web state schema, and rigctld wire behavior remain compatible or
   any additive changes are documented.
+
+## Legacy Cleanup Inventory
+
+Cleanup must be an explicit workstream, not an incidental final sweep. Before
+removing code, create an inventory document and classify every legacy state path
+as `keep`, `migrate`, or `delete`. Each `delete` item needs a replacement path
+and regression coverage.
+
+Initial inventory candidates:
+
+- Web `RadioPoller` revision: `_revision`, `revision`, `bump_revision`, and all
+  command branches that mutate `RadioState` and manually advance the revision.
+- Web public state builder: any code that reads state revision from the poller
+  instead of the state model.
+- Web broadcast path: `_broadcast_state_update`, `_on_radio_state_change`, and
+  `_on_poller_state_event` should consume `ChangeSet`/freshness events rather
+  than acting as state mutation triggers.
+- Web `DeltaEncoder`: keep delta encoding as a representation concern, but stop
+  treating its counter as canonical state revision. Rename or expose a separate
+  transport sequence only if needed.
+- CI-V RX manual notifications: `_notify_change(...)` calls should be replaced
+  by observation emission for all supported state-bearing frames.
+- StatePollable startup callback: direct Web callbacks should migrate to
+  observation application through the shared state model.
+- rigctld local state: `_FallbackRigState`, `_PendingRigState`, and routing
+  caches should either become projections/pending overlays from the state model
+  or be retained only as documented compatibility shims.
+- runtime `_state_cache`: decide field by field whether it remains an executor
+  optimization, migrates into the state model freshness index, or is removed.
+  It must not become a second source of truth for consumers.
+- Web HTTP ETag handling: move from poller revision plus health revision to
+  state revision plus health/freshness revision.
+- Frontend revision assumptions: HTTP polling, WebSocket delta application, and
+  store stale-state rejection should align with canonical state revision and
+  additive freshness metadata.
+- Documentation tails: update Web, rigctld, layer docs, and any outdated poller
+  cadence or "poller broadcasts state" descriptions.
+
+Cleanup rules:
+
+- Do not remove a legacy cache before the corresponding consumer reads from the
+  state model or an explicit compatibility shim.
+- Do not remove optimistic/pending behavior before `CommandIntent` pending
+  overlays preserve read-after-write semantics.
+- Do not remove Web HTTP polling; reduce it to startup/fallback representation
+  of the same state model.
+- Do not remove backend executor caches that are still required for timeout
+  fallback until `ensure_fresh` semantics cover the same behavior.
+- Every deleted path needs a regression test or an explicit reason why the path
+  is unreachable after migration.
 
 ## Coalescing and Rate Limits
 

--- a/docs/superpowers/specs/2026-06-02-radio-state-pipeline-design.md
+++ b/docs/superpowers/specs/2026-06-02-radio-state-pipeline-design.md
@@ -127,6 +127,11 @@ and a separate read cache.
 
 ## Target Architecture
 
+The shared state service is a runtime-level service, not Web-only wiring. Web,
+rigctld, CLI/public API paths, and backend runtimes should receive the same
+service instance through startup composition. This is required for rigctld and
+public SDK calls to observe the same source of truth as Web.
+
 ```mermaid
 flowchart LR
     subgraph "Command Ingress"
@@ -189,6 +194,26 @@ flowchart LR
 
 ### Core Concepts
 
+#### State Ownership and Migration Invariants
+
+The target model is single-writer for confirmed state: `StateStore.apply(...)`
+is the only place that changes the consumer-visible confirmed state model.
+
+During migration, every legacy writer must be classified before it is touched:
+
+- `observation_adapter`: decodes or polls values and emits observations only.
+- `pending_overlay`: records local intent but does not change confirmed state.
+- `executor_cache`: private timeout/pacing cache used by a command executor,
+  never exposed as fresher consumer state.
+- `protocol_local_keep`: protocol/session state that is not radio state, such
+  as rigctld session VFO handling.
+- `compatibility_shim`: temporary projection retained for API/wire stability.
+- `delete`: replaced by the shared state model and protected by tests.
+
+No legacy writer may remain a consumer-visible source of truth once its field
+family has migrated. If a temporary compatibility shim remains, the spec or
+inventory must name its owner, replacement, and removal condition.
+
 #### RadioStateModel / StateStore
 
 The state model owns the canonical `RadioState` instance and the canonical
@@ -221,8 +246,10 @@ command acknowledgement and not a Web event.
 
 Suggested fields:
 
-- `path`: typed state path, such as `main.freq`, `main.s_meter`,
-  `power_meter`, `ptt`.
+- `path`: typed `FieldPath`, not an ad-hoc string. It must distinguish receiver,
+  VFO slot, active slot, global fields, scope controls, and meter families.
+  Examples: `receiver.main.slot.A.freq_hz`, `receiver.sub.active_slot`,
+  `receiver.main.s_meter`, `global.ptt`.
 - `value`: normalized Python value.
 - `source`: `civ_unsolicited`, `poll_response`, `command_response`,
   `state_poller`, `hamlib_response`, `local_reconcile`.
@@ -278,6 +305,25 @@ therefore also needs field freshness and reconciliation:
 This keeps revision useful for transport deltas while preventing it from
 becoming a false correctness signal.
 
+#### FieldPath
+
+`FieldPath` should be a typed schema or enum-like value so pending overlays,
+freshness, and observations cannot accidentally target the wrong receiver or
+VFO slot.
+
+Required path dimensions:
+
+- scope: `global`, `receiver`, `scope_controls`, `connection`, `health`.
+- receiver: `main`, `sub`, or profile-specific receiver id.
+- slot: `active`, `A`, `B`, or `none`.
+- field family: `freq_mode`, `operator_toggles`, `operator_controls`,
+  `meters`, `tx_state`, `slow_state`.
+- field name: normalized `RadioState` field name.
+
+The VFO slot dimension is required because RigPlane supports selected and
+unselected frequency/mode reads. A path such as `main.freq` is not precise
+enough once pending confirmation and freshness windows are field-specific.
+
 #### CommandIntent
 
 A `CommandIntent` represents an attempt to change or query radio state from a
@@ -326,6 +372,20 @@ plain values. Additive metadata can expose pending/confirmed status later if
 needed. Internally, consumers must be able to distinguish confirmed state from
 local intent.
 
+Pending overlays must be scoped. A pending value is keyed by at least:
+
+- source: WebSocket, HTTP, rigctld, public API, internal policy.
+- session/client id when the protocol has session-local behavior.
+- command id.
+- `FieldPath`.
+- target receiver/VFO slot.
+- expiration/confirmation deadline.
+
+Global pending overlays may be used only when read-after-write behavior should
+be visible to every consumer. rigctld protocol-local state, such as split TX VFO
+selection or parser VFO mode, is not radio state and should remain
+`protocol_local_keep` unless a separate state projection is explicitly designed.
+
 ### Acquisition Policy
 
 Acquisition policies decide how values are obtained. They do not own state
@@ -357,6 +417,44 @@ Policy decisions should be capability-driven:
 
 No policy should branch directly on a model name such as X6200 unless the model
 profile exposes that capability or constraint.
+
+#### AcquisitionScheduler and `ensure_fresh`
+
+`ensure_fresh(paths, max_age, timeout, reason)` must not perform arbitrary
+direct backend reads from Web or rigctld. It asks an `AcquisitionScheduler` for
+fresh observations and waits for the state model to observe or reject them.
+
+Scheduler requirements:
+
+- Accept typed `FieldPath` requests and map them to backend/profile-safe
+  acquisition commands.
+- Use priorities: user-facing freshness, command confirmation, reconciliation,
+  background telemetry.
+- Use dedupe keys so concurrent `ensure_fresh` calls for the same field family
+  share one acquisition request.
+- Respect external CAT/raw CI-V ownership and pause or fail freshness requests
+  instead of polluting an owned byte stream.
+- Preserve Icom fire-and-forget polling semantics: queued acquisition requests
+  should emit CI-V queries and wait for RX-pump observations, not bypass the
+  queue with direct request-response reads in the Web poller path.
+- Prefer command preemption over background reconciliation on slow serial links.
+- Surface timeout/unavailable results without inventing synthetic confirmed
+  state.
+
+For Icom, an `ensure_fresh` confirmation should normally be:
+
+```text
+ensure_fresh(path)
+  -> AcquisitionScheduler queues deduped query
+  -> CI-V RX pump receives response
+  -> Observation(path)
+  -> StateStore.apply(...)
+  -> waiter resolves against ChangeSet or fresh unchanged observation
+```
+
+Direct getter-style reads may still exist inside backend executors for public
+API compatibility, but their results must be converted into observations before
+they become consumer-visible state.
 
 ### Hooks
 
@@ -396,7 +494,8 @@ Rules:
 
 - Initial WebSocket state and HTTP snapshot come from the same snapshot builder.
 - HTTP ETag uses the canonical state revision plus health/freshness revision.
-- WebSocket `state_update.revision` uses the canonical state revision.
+- WebSocket state payloads expose canonical state revision as `stateRevision`;
+  legacy `revision`, while present, is only an alias for that canonical value.
 - No state revision advance means "the model has no newer applied value"; it
   does not prove the physical radio did not change.
 - Any transport-local sequence, if needed, should be a separate field and not
@@ -407,6 +506,33 @@ Rules:
   transitions can be observed even when values do not change.
 - HTTP polling can remain as a startup/fallback edge case, but it is not a
   second source of truth.
+
+### WebSocket Wire Revision Semantics
+
+Current WebSocket deltas use an envelope revision that can overwrite the public
+state revision in the frontend. The migration must split these concepts.
+
+Target wire fields:
+
+- `stateRevision`: canonical value revision from `StateStore`.
+- `freshnessRevision`: freshness/health validity revision.
+- `transportSeq`: optional per-WebSocket delta/full-message sequence for
+  ordering and drift detection.
+- legacy `revision`: backward-compatible alias for `stateRevision` only while
+  old clients require it.
+
+Frontend rules:
+
+- A full-state envelope must not overwrite canonical state revision with
+  `transportSeq`.
+- A delta envelope applies only when it has a compatible base or carries enough
+  data to recover.
+- HTTP and WebSocket races are resolved by canonical `stateRevision` plus
+  `freshnessRevision`, not by transport-local sequence.
+- Restart/reset detection must use canonical state revision and server identity
+  if available, not delta encoder sequence.
+- Optimistic patches remain local overlays until confirmed, expired, or
+  superseded by canonical state/freshness changes.
 
 ## Command Flow
 
@@ -509,7 +635,13 @@ Deliverables:
 - Backend-neutral `Observation`, `ChangeSet`, `CommandIntent`, and
   `CommandLifecycleEvent` contracts.
 - `RadioStateModel` / `StateStore` implementation with canonical revision.
+- Typed `FieldPath` schema covering receiver, VFO slot, global, scope control,
+  and meter paths.
+- State ownership inventory that classifies legacy writers as
+  `observation_adapter`, `pending_overlay`, `executor_cache`,
+  `protocol_local_keep`, `compatibility_shim`, or `delete`.
 - Per-field freshness metadata and separate freshness/health revision semantics.
+- Active `FreshnessClock`/ticker for freshness deadlines and stale events.
 - Snapshot projection for the existing public state schema.
 - Hook registration for observation/change/command/policy events.
 - Unit tests for revision behavior, no-op applies, receiver paths, and
@@ -521,6 +653,8 @@ Acceptance:
 - Applying an unchanged observation does not increment state revision.
 - Freshness-only transitions do not fake data changes, but they are visible to
   consumers through freshness/health revision.
+- High-rate observations can advance `observationSeq` without forcing HTTP
+  state revision churn.
 - Full snapshots match the existing public state contract.
 - No Web or rigctld imports are introduced into core/runtime state modules.
 
@@ -531,6 +665,8 @@ Deliverables:
 - Icom CI-V RX path emits observations for frequency, mode, meters, and existing
   notify-backed fields.
 - Icom poll responses feed the same observation path.
+- Icom freshness reads go through `AcquisitionScheduler` and RX-pump
+  observations, respecting fire-and-forget and external-CAT ownership.
 - Web HTTP snapshot and initial WebSocket full state are built from
   `StateStore`.
 - WebSocket deltas use canonical state revision.
@@ -544,6 +680,9 @@ Acceptance:
   unrelated events.
 - If an unsolicited frequency/mode event is missed, a reconciliation read can
   eventually correct the shared state.
+- WebSocket envelope migration separates `stateRevision`, `freshnessRevision`,
+  and `transportSeq`; frontend code does not overwrite canonical state revision
+  with a transport-local sequence.
 - HTTP `/api/v1/state` and WebSocket initial state agree on revision and data.
 - Existing command execution behavior remains compatible.
 
@@ -595,12 +734,16 @@ Deliverables:
 - Command lifecycle events are observable.
 - Pending overlays are correlated with observations and cleared on
   confirmation, supersession, timeout, or failure.
+- Pending overlays are scoped by source/session/command id/`FieldPath` and do
+  not replace protocol-local state such as rigctld session VFO handling.
 
 Acceptance:
 
 - Command ingress is consistent across Web, HTTP, rigctld, and public API.
 - Command success/failure is not confused with confirmed state mutation.
 - User-facing commands can preempt background acquisition on slow transports.
+- rigctld protocol-local state is either preserved as `protocol_local_keep` or
+  explicitly migrated with wire-compatibility tests.
 
 ### Milestone 6: Adaptive Acquisition Policies
 
@@ -647,6 +790,9 @@ Acceptance:
 
 - The cleanup inventory is complete enough that each legacy tail has an owner
   and an explicit keep/migrate/delete decision.
+- Legacy confirmed-state writers are either migrated to observation adapters or
+  retained only as named compatibility shims that cannot be fresher than the
+  state model.
 - The Web audit covers backend server state delivery, frontend state ingestion,
   and HTTP/WebSocket compatibility.
 - The rigctl/rigctld audit covers command parsing, SET execution, GET state
@@ -683,9 +829,15 @@ Initial inventory candidates:
 - rigctld local state: `_FallbackRigState`, `_PendingRigState`, and routing
   caches should either become projections/pending overlays from the state model
   or be retained only as documented compatibility shims.
+- rigctld protocol-local state: `_split_tx_vfo`, client VFO mode, `chk_vfo`
+  parsing state, and similar Hamlib session semantics should be classified
+  separately from radio state and usually kept as protocol-local state.
 - runtime `_state_cache`: decide field by field whether it remains an executor
   optimization, migrates into the state model freshness index, or is removed.
   It must not become a second source of truth for consumers.
+- Public `StateCacheCapable`/`state_cache`: decide and document whether the
+  protocol remains as an executor timeout cache, becomes a projection of
+  `StateStore`, or is deprecated with compatibility guarantees.
 - Web HTTP ETag handling: move from poller revision plus health revision to
   state revision plus health/freshness revision.
 - Frontend revision assumptions: HTTP polling, WebSocket delta application, and
@@ -722,6 +874,8 @@ Required rigctl/rigctld audit surfaces:
 - `rigctld/handler`: GET/SET dispatch, direct backend calls, `_FallbackRigState`,
   `_PendingRigState`, read-after-write behavior, mode/data-mode compatibility,
   and error mapping.
+- rigctld protocol-local behavior: `_split_tx_vfo`, client/session VFO mode,
+  `chk_vfo`, read-only gates, and Hamlib error code mapping.
 - `rigctld/server`: per-client lifecycle, rate limiting, circuit breaker
   interactions, poller startup/shutdown, and command timeout behavior.
 - `rigctld/poller`: state refresh cadence, cache updates, circuit breaker
@@ -749,8 +903,25 @@ Cleanup rules:
 
 ## Coalescing and Rate Limits
 
-The state model should emit canonical changes. Transports may coalesce delivery
-for high-rate fields.
+The state model should emit canonical changes for discrete state. High-rate
+telemetry, especially meters, needs separate sample and delivery semantics so
+HTTP ETags do not churn at meter sample rate while diagnostics still see every
+sample.
+
+Revision semantics:
+
+- `observationSeq`: advances for every decoded observation sample, including
+  meter samples that do not become public state updates.
+- `stateRevision`: advances when the consumer-visible state snapshot changes.
+- `freshnessRevision`: advances when validity/freshness changes without a value
+  change.
+- `transportSeq`: optional WebSocket delivery sequence.
+
+For high-rate meter fields, `StateStore` may retain the latest raw sample and
+emit observation hooks for every sample, while publishing a coalesced `ChangeSet`
+at the configured meter delivery cadence. The published `ChangeSet` must include
+the latest sample in the batch and enough metadata for diagnostics to know how
+many samples were coalesced.
 
 Guidelines:
 
@@ -761,6 +932,25 @@ Guidelines:
 - Coalescing must not hide the last value in a burst.
 - Backpressure must drop or merge background telemetry before user-visible
   command lifecycle events.
+
+## Freshness Clock
+
+Freshness cannot be only a passive timestamp checked during reads. The state
+service needs an active clock/ticker that manages freshness deadlines.
+
+Responsibilities:
+
+- Maintain nearest stale deadlines by field family.
+- Emit freshness events when a field transitions `fresh -> stale`,
+  `unknown -> fresh`, or `stale -> fresh`.
+- Advance `freshnessRevision` when these transitions affect public snapshots or
+  consumers.
+- Trigger reconciliation requests for critical stale fields according to policy.
+- Avoid one timer per leaf field by grouping compatible paths into field
+  families.
+
+This replaces the current pattern where caches become stale only when some
+caller asks them.
 
 ## Error Handling
 
@@ -782,12 +972,20 @@ Guidelines:
 Unit tests:
 
 - `StateStore.apply` increments revision only on real changes.
+- `FieldPath` routing distinguishes MAIN/SUB, VFO A/B, active slot, global, and
+  meter paths.
 - No-op observations do not emit `ChangeSet`.
 - Meter observations can be coalesced without losing latest values.
+- Meter sample accounting advances observation metadata without forcing every
+  sample into HTTP-visible `stateRevision`.
 - Pending overlays confirm, expire, and supersede correctly.
+- Pending overlays are scoped by source/session/command id/path and do not leak
+  across unrelated consumers.
 - Freshness transitions are observable without changing confirmed values.
 - `ensure_fresh` returns fresh cached values, triggers acquisition for stale
   values, and reports unavailable state when acquisition fails.
+- `FreshnessClock` emits stale transitions without requiring another radio frame
+  or consumer read.
 - Snapshot projection matches the existing public state schema.
 
 Icom tests:
@@ -796,16 +994,21 @@ Icom tests:
 - CI-V `0x00`/`0x03` frequency frames produce observations and state changes.
 - Poll responses and unsolicited frames use the same apply path.
 - Reconciliation reads correct stale or missed frequency/mode observations.
+- `ensure_fresh` requests respect external CAT ownership and do not bypass the
+  Icom fire-and-forget RX-pump observation path.
 - Background acquisition uses priority/dedupe where supported.
 
 Web tests:
 
 - Initial WebSocket full state and HTTP `/api/v1/state` are generated from the
   same state revision.
-- WebSocket deltas use canonical state revision.
+- WebSocket deltas use canonical `stateRevision` and optional `transportSeq`
+  without overwriting public snapshot revision.
 - HTTP ETag advances when state revision advances.
 - HTTP ETag or equivalent freshness token advances when critical fields become
   stale even if values do not change.
+- HTTP-vs-WebSocket races, restart/reset detection, optimistic patch
+  confirmation/expiry, and stale rejection are covered by frontend tests.
 
 rigctld tests:
 
@@ -814,6 +1017,9 @@ rigctld tests:
 - Fallback radio reads publish observations.
 - GET paths can request fresh-enough values instead of trusting indefinitely
   stale state.
+- Protocol-local state, including session VFO handling and split TX VFO state,
+  remains wire-compatible and does not masquerade as confirmed radio state.
+- Hamlib error mapping and read-only gates remain compatible.
 
 Integration/fake-backend tests:
 
@@ -833,6 +1039,8 @@ Integration/fake-backend tests:
   diagnostics establish realistic serial and LAN rates.
 - The command confirmation timeout policy should differ by command family and
   transport.
+- The public `StateCacheCapable` compatibility plan should be decided before
+  runtime cache cleanup begins.
 
 ## Review Checklist
 

--- a/frontend/src/components-v2/panels/RxAudioPanel.svelte
+++ b/frontend/src/components-v2/panels/RxAudioPanel.svelte
@@ -20,7 +20,7 @@
   );
 </script>
 
-{#if props.hasLiveAudio}
+{#if props.hasAfLevel || props.hasLiveAudio}
     <div class="panel-body">
       <div class="button-group">
         {#each options as option}

--- a/frontend/src/components-v2/panels/__tests__/DspPanel.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/DspPanel.test.ts
@@ -219,6 +219,22 @@ describe('modal initial state', () => {
     expect(t.querySelector('[aria-label="Notch filter settings"]')).toBeNull();
   });
 
+  it('opens NR settings on long press', () => {
+    vi.useFakeTimers();
+    try {
+      const t = mountPanel();
+      const nrBtn = getFillButtons(t).find((b) => b.textContent?.trim().startsWith('NR'));
+
+      nrBtn?.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+      vi.advanceTimersByTime(600);
+      flushSync();
+
+      expect(t.querySelector('[aria-label="Noise reduction settings"]')).not.toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('renders the A-NOTCH button', () => {
     const t = mountPanel();
     const buttons = getFillButtons(t);

--- a/frontend/src/components-v2/panels/__tests__/RxAudioPanel.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/RxAudioPanel.test.ts
@@ -10,6 +10,7 @@ import RxAudioPanel from '../RxAudioPanel.svelte';
 const mockProps = {
   monitorMode: 'local' as 'local' | 'live' | 'mute',
   afLevel: 128,
+  hasAfLevel: true,
   hasLiveAudio: false,
   isAudioConnected: true,
   hasDualReceiver: false,
@@ -125,6 +126,7 @@ beforeEach(() => {
   components = [];
   mockProps.monitorMode = 'local';
   mockProps.afLevel = 128;
+  mockProps.hasAfLevel = true;
   mockProps.hasLiveAudio = false;
   mockProps.isAudioConnected = true;
   mockProps.hasDualReceiver = false;
@@ -138,20 +140,25 @@ afterEach(() => {
 });
 
 describe('panel visibility', () => {
-  it('renders the panel when hasLiveAudio is true', () => {
-    const t = mountPanel({ hasLiveAudio: true });
+  it('renders the panel when only radio AF level is available', () => {
+    const t = mountPanel({ hasAfLevel: true, hasLiveAudio: false });
     expect(t.querySelector('.panel-body')).not.toBeNull();
   });
 
-  it('does not render the panel when hasLiveAudio is false', () => {
-    const t = mountPanel({ hasLiveAudio: false });
+  it('renders the panel when hasLiveAudio is true', () => {
+    const t = mountPanel({ hasAfLevel: true, hasLiveAudio: true });
+    expect(t.querySelector('.panel-body')).not.toBeNull();
+  });
+
+  it('does not render the panel when neither AF level nor live audio is available', () => {
+    const t = mountPanel({ hasAfLevel: false, hasLiveAudio: false });
     expect(t.querySelector('.panel-body')).toBeNull();
   });
 });
 
 describe('panel structure', () => {
   it('renders the AF Level slider', () => {
-    const t = mountPanel({ hasLiveAudio: true });
+    const t = mountPanel({ hasAfLevel: true, hasLiveAudio: false });
     const labels = Array.from(t.querySelectorAll('.vc-label'));
     expect(labels.some((el) => el.textContent === 'AF Level')).toBe(true);
   });

--- a/frontend/src/components-v2/wiring/state-adapter.ts
+++ b/frontend/src/components-v2/wiring/state-adapter.ts
@@ -464,6 +464,7 @@ export function toMeterProps(state: ServerState | null): MeterProps {
 export interface RxAudioProps {
   monitorMode: 'local' | 'live' | 'mute';
   afLevel: number;
+  hasAfLevel: boolean;
   hasLiveAudio: boolean;
 }
 
@@ -480,6 +481,7 @@ export function toRxAudioProps(
 ): RxAudioProps {
   const rx = state ? activeRx(state) : null;
   const hasLiveAudio = hasCap(caps, 'audio');
+  const hasAfLevel = hasCap(caps, 'af_level') || hasLiveAudio;
   const monitorMode = audioState.muted
     ? 'mute'
     : audioState.rxEnabled && hasLiveAudio
@@ -492,6 +494,7 @@ export function toRxAudioProps(
   return {
     monitorMode,
     afLevel,
+    hasAfLevel,
     hasLiveAudio,
   };
 }

--- a/frontend/src/lib/Button/ControlButton.svelte
+++ b/frontend/src/lib/Button/ControlButton.svelte
@@ -13,6 +13,10 @@
     title?: string | null;
     shortcutHint?: string | null;
     onclick?: (event: MouseEvent) => void;
+    onpointerdown?: (event: PointerEvent) => void;
+    onpointerup?: (event: PointerEvent) => void;
+    onpointercancel?: (event: PointerEvent) => void;
+    onpointerleave?: (event: PointerEvent) => void;
     children?: any;
   }
 
@@ -27,6 +31,10 @@
     title = null,
     shortcutHint = null,
     onclick,
+    onpointerdown,
+    onpointerup,
+    onpointercancel,
+    onpointerleave,
     children
   }: Props = $props();
 
@@ -40,6 +48,26 @@
   function handleClick(event: MouseEvent) {
     if (disabled) return;
     onclick?.(event);
+  }
+
+  function handlePointerDown(event: PointerEvent) {
+    if (disabled) return;
+    onpointerdown?.(event);
+  }
+
+  function handlePointerUp(event: PointerEvent) {
+    if (disabled) return;
+    onpointerup?.(event);
+  }
+
+  function handlePointerCancel(event: PointerEvent) {
+    if (disabled) return;
+    onpointercancel?.(event);
+  }
+
+  function handlePointerLeave(event: PointerEvent) {
+    if (disabled) return;
+    onpointerleave?.(event);
   }
 
   // Compute glow attribute (only 'white' or 'warm', 'color' = omit)
@@ -59,6 +87,10 @@
   data-shortcut-hint={shortcutHint ?? undefined}
   {disabled}
   onclick={handleClick}
+  onpointerdown={handlePointerDown}
+  onpointerup={handlePointerUp}
+  onpointercancel={handlePointerCancel}
+  onpointerleave={handlePointerLeave}
 >
   {@render children?.()}
 </button>

--- a/frontend/src/lib/Button/DotButton.svelte
+++ b/frontend/src/lib/Button/DotButton.svelte
@@ -12,7 +12,13 @@
     compact = false,
     color = 'cyan',
     glow = 'color',
+    title = null,
+    shortcutHint = null,
     onclick,
+    onpointerdown,
+    onpointerup,
+    onpointercancel,
+    onpointerleave,
     children
   }: Props = $props();
 </script>
@@ -24,7 +30,13 @@
   indicatorStyle="dot"
   indicatorColor={color}
   {glow}
+  {title}
+  {shortcutHint}
   {onclick}
+  {onpointerdown}
+  {onpointerup}
+  {onpointercancel}
+  {onpointerleave}
 >
   {@render children?.()}
 </ControlButton>

--- a/frontend/src/lib/Button/FillButton.svelte
+++ b/frontend/src/lib/Button/FillButton.svelte
@@ -14,6 +14,10 @@
     title = null,
     shortcutHint = null,
     onclick,
+    onpointerdown,
+    onpointerup,
+    onpointercancel,
+    onpointerleave,
     children
   }: Props = $props();
 </script>
@@ -27,6 +31,10 @@
   {title}
   {shortcutHint}
   {onclick}
+  {onpointerdown}
+  {onpointerup}
+  {onpointercancel}
+  {onpointerleave}
 >
   {@render children?.()}
 </ControlButton>

--- a/frontend/src/lib/Button/HardwareButton.svelte
+++ b/frontend/src/lib/Button/HardwareButton.svelte
@@ -12,7 +12,13 @@
     compact = false,
     indicator = 'dot',
     color = 'cyan',
+    title = null,
+    shortcutHint = null,
     onclick,
+    onpointerdown,
+    onpointerup,
+    onpointercancel,
+    onpointerleave,
     children
   }: Props = $props();
 </script>
@@ -24,7 +30,13 @@
   surface="hardware"
   indicatorStyle={indicator}
   indicatorColor={color}
+  {title}
+  {shortcutHint}
   {onclick}
+  {onpointerdown}
+  {onpointerup}
+  {onpointercancel}
+  {onpointerleave}
 >
   {@render children?.()}
 </ControlButton>

--- a/frontend/src/lib/Button/HardwarePlainButton.svelte
+++ b/frontend/src/lib/Button/HardwarePlainButton.svelte
@@ -14,6 +14,10 @@
     title = null,
     shortcutHint = null,
     onclick,
+    onpointerdown,
+    onpointerup,
+    onpointercancel,
+    onpointerleave,
     children
   }: Props = $props();
 </script>
@@ -27,6 +31,10 @@
   {title}
   {shortcutHint}
   {onclick}
+  {onpointerdown}
+  {onpointerup}
+  {onpointercancel}
+  {onpointerleave}
 >
   {@render children?.()}
 </ControlButton>

--- a/frontend/src/lib/runtime/props/panel-props.ts
+++ b/frontend/src/lib/runtime/props/panel-props.ts
@@ -531,6 +531,8 @@ export function toMeterProps(
 export interface RxAudioProps {
   monitorMode: 'local' | 'live' | 'mute';
   afLevel: number;
+  /** Radio AF-level control capability; independent from browser live audio. */
+  hasAfLevel: boolean;
   hasLiveAudio: boolean;
   /** Audio-WS connection health — used to render a "link lost" indicator. */
   isAudioConnected: boolean;
@@ -552,6 +554,7 @@ export function toRxAudioProps(
 ): RxAudioProps {
   const rx = state ? activeRx(state) : null;
   const hasLiveAudio = hasCap(caps, 'audio');
+  const hasAfLevel = hasCap(caps, 'af_level') || hasLiveAudio;
   const monitorMode = audioState.muted
     ? 'mute'
     : audioState.rxEnabled && hasLiveAudio
@@ -565,6 +568,7 @@ export function toRxAudioProps(
   return {
     monitorMode,
     afLevel,
+    hasAfLevel,
     hasLiveAudio,
     isAudioConnected: audioConnected,
     hasDualReceiver,

--- a/frontend/src/lib/stores/__tests__/radio.test.ts
+++ b/frontend/src/lib/stores/__tests__/radio.test.ts
@@ -211,6 +211,41 @@ describe('radio store', () => {
     expect(store.getRadioState()?.main.sMeter).toBe(77);
   });
 
+  it('ignores stale semantic state even when freshnessRevision advances', () => {
+    store.setRadioState(makeState({ revision: 6, stateRevision: 6, freshnessRevision: 1, ptt: true }));
+    store.setRadioState(makeState({
+      revision: 5,
+      stateRevision: 5,
+      freshnessRevision: 2,
+      ptt: false,
+      main: {
+        ...makeState().main,
+        freqHz: 7100000,
+      },
+    }));
+
+    expect(store.getRadioState()?.stateRevision).toBe(6);
+    expect(store.getRadioState()?.freshnessRevision).toBe(1);
+    expect(store.getRadioState()?.ptt).toBe(true);
+    expect(store.getRadioState()?.main.freqHz).toBe(14074000);
+  });
+
+  it('ignores stale semantic state even when healthRevision advances', () => {
+    store.setRadioState(makeState({ revision: 6, stateRevision: 6, healthRevision: 1, ptt: true }));
+    store.setRadioState(makeState({
+      revision: 5,
+      stateRevision: 5,
+      healthRevision: 2,
+      ptt: false,
+      connection: { rigConnected: true, radioReady: false, controlConnected: true },
+    }));
+
+    expect(store.getRadioState()?.stateRevision).toBe(6);
+    expect(store.getRadioState()?.healthRevision).toBe(1);
+    expect(store.getRadioState()?.ptt).toBe(true);
+    expect(store.getRadioState()?.connection.radioReady).toBe(true);
+  });
+
   it('getFrequency returns active receiver frequency (MAIN)', () => {
     store.setRadioState(makeState({ active: 'MAIN' }));
     expect(store.getFrequency()).toBe(14074000);

--- a/frontend/src/lib/stores/__tests__/radio.test.ts
+++ b/frontend/src/lib/stores/__tests__/radio.test.ts
@@ -2,8 +2,12 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import type { ServerState } from '../../types/state';
 
 function makeState(overrides: Partial<ServerState> = {}): ServerState {
+  const revision = overrides.stateRevision ?? overrides.revision ?? 1;
+  const freshnessRevision = overrides.freshnessRevision ?? 1;
   return {
-    revision: 1,
+    revision,
+    stateRevision: revision,
+    freshnessRevision,
     updatedAt: '2026-03-07T00:00:00Z',
     active: 'MAIN',
     ptt: false,
@@ -189,6 +193,22 @@ describe('radio store', () => {
     expect(store.getRadioState()?.radioHealth?.likelyCause).toBe('radio_not_responding');
     expect(connection.getRadioReady()).toBe(false);
     expect(connection.getRadioHealth()?.readiness).toBe('delayed');
+  });
+
+  it('accepts freshness-only updates when freshnessRevision advances', () => {
+    store.setRadioState(makeState({ revision: 5, stateRevision: 5, freshnessRevision: 1 }));
+    store.setRadioState(makeState({
+      revision: 5,
+      stateRevision: 5,
+      freshnessRevision: 2,
+      main: {
+        ...makeState().main,
+        sMeter: 77,
+      },
+    }));
+
+    expect(store.getRadioState()?.freshnessRevision).toBe(2);
+    expect(store.getRadioState()?.main.sMeter).toBe(77);
   });
 
   it('getFrequency returns active receiver frequency (MAIN)', () => {

--- a/frontend/src/lib/stores/radio.svelte.test.ts
+++ b/frontend/src/lib/stores/radio.svelte.test.ts
@@ -5,6 +5,8 @@ import type { ServerState } from '../types/state';
 function makeState(revision: number): ServerState {
   return {
     revision,
+    stateRevision: revision,
+    freshnessRevision: 1,
     active: 'MAIN',
     powerOn: true,
     ptt: false,

--- a/frontend/src/lib/stores/radio.svelte.ts
+++ b/frontend/src/lib/stores/radio.svelte.ts
@@ -13,8 +13,17 @@ class RadioStore {
 export const radio = new RadioStore();
 
 let lastRevision = -1;
+let lastFreshnessRevision = -1;
 let lastHealthRevision = -1;
 const stateSubscribers = new Set<(state: ServerState | null) => void>();
+
+function stateRevision(state: ServerState): number {
+  return state.stateRevision ?? state.revision;
+}
+
+function freshnessRevision(state: ServerState): number {
+  return state.freshnessRevision ?? 0;
+}
 
 function notifyRadioStateSubscribers(): void {
   for (const handler of stateSubscribers) {
@@ -126,6 +135,7 @@ function applyOptimistic(state: ServerState): ServerState {
 export function resetRadioState(): void {
   radio.current = null;
   lastRevision = -1;
+  lastFreshnessRevision = -1;
   lastHealthRevision = -1;
   optimisticMain.clear();
   optimisticSub.clear();
@@ -135,17 +145,27 @@ export function resetRadioState(): void {
 }
 
 export function setRadioState(state: ServerState): void {
-  const isReset = lastRevision > 10 && state.revision < lastRevision / 2;
+  const nextStateRevision = stateRevision(state);
+  const nextFreshnessRevision = freshnessRevision(state);
+  const isReset = lastRevision > 10 && nextStateRevision < lastRevision / 2;
   const isInitial = radio.current === null;
   const nextHealthRevision = state.healthRevision ?? 0;
   const healthAdvanced = nextHealthRevision > lastHealthRevision;
+  const freshnessAdvanced = nextFreshnessRevision > lastFreshnessRevision;
   if (isReset) {
     console.warn(
-      `Detected server restart: revision reset from ${lastRevision} to ${state.revision}`,
+      `Detected server restart: revision reset from ${lastRevision} to ${nextStateRevision}`,
     );
   }
-  if (isInitial || state.revision > lastRevision || healthAdvanced || isReset) {
-    lastRevision = state.revision;
+  if (
+    isInitial
+    || nextStateRevision > lastRevision
+    || freshnessAdvanced
+    || healthAdvanced
+    || isReset
+  ) {
+    lastRevision = nextStateRevision;
+    lastFreshnessRevision = nextFreshnessRevision;
     lastHealthRevision = nextHealthRevision;
     radio.current = applyOptimistic(state);
     notifyRadioStateSubscribers();

--- a/frontend/src/lib/stores/radio.svelte.ts
+++ b/frontend/src/lib/stores/radio.svelte.ts
@@ -152,6 +152,9 @@ export function setRadioState(state: ServerState): void {
   const nextHealthRevision = state.healthRevision ?? 0;
   const healthAdvanced = nextHealthRevision > lastHealthRevision;
   const freshnessAdvanced = nextFreshnessRevision > lastFreshnessRevision;
+  const semanticAdvanced = nextStateRevision > lastRevision;
+  const semanticCurrent = nextStateRevision === lastRevision;
+  const metadataAdvanced = semanticCurrent && (freshnessAdvanced || healthAdvanced);
   if (isReset) {
     console.warn(
       `Detected server restart: revision reset from ${lastRevision} to ${nextStateRevision}`,
@@ -159,9 +162,8 @@ export function setRadioState(state: ServerState): void {
   }
   if (
     isInitial
-    || nextStateRevision > lastRevision
-    || freshnessAdvanced
-    || healthAdvanced
+    || semanticAdvanced
+    || metadataAdvanced
     || isReset
   ) {
     lastRevision = nextStateRevision;

--- a/frontend/src/lib/transport/__tests__/http-client.test.ts
+++ b/frontend/src/lib/transport/__tests__/http-client.test.ts
@@ -260,6 +260,74 @@ describe('startPolling', () => {
     stop();
   });
 
+  it('skips stale semantic state even when freshnessRevision advances', async () => {
+    const first = makeState(42);
+    first.freshnessRevision = 1;
+    first.ptt = true;
+    const second = makeState(41);
+    second.freshnessRevision = 2;
+    second.ptt = false;
+    second.main.freqHz = 7100000;
+    let index = 0;
+    globalThis.fetch = vi.fn().mockImplementation(() => {
+      const state = index++ === 0 ? first : second;
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        headers: { get: () => `"${state.stateRevision}-${state.freshnessRevision}"` },
+        json: () => Promise.resolve(state),
+      });
+    });
+
+    const { startPolling } = await import('../http-client');
+    const received: ServerState[] = [];
+    const stop = startPolling((s) => received.push(s), 200);
+
+    await flushMicrotasks();
+    vi.advanceTimersByTime(200);
+    await flushMicrotasks();
+
+    expect(received).toHaveLength(1);
+    expect(received[0].stateRevision).toBe(42);
+    expect(received[0].ptt).toBe(true);
+    expect(received[0].main.freqHz).toBe(14074000);
+    stop();
+  });
+
+  it('skips stale semantic state even when healthRevision advances', async () => {
+    const first = makeState(42);
+    first.healthRevision = 1;
+    first.ptt = true;
+    const second = makeState(41);
+    second.healthRevision = 2;
+    second.ptt = false;
+    second.connection = { rigConnected: true, radioReady: false, controlConnected: true };
+    let index = 0;
+    globalThis.fetch = vi.fn().mockImplementation(() => {
+      const state = index++ === 0 ? first : second;
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        headers: { get: () => `"${state.stateRevision}-h${state.healthRevision}"` },
+        json: () => Promise.resolve(state),
+      });
+    });
+
+    const { startPolling } = await import('../http-client');
+    const received: ServerState[] = [];
+    const stop = startPolling((s) => received.push(s), 200);
+
+    await flushMicrotasks();
+    vi.advanceTimersByTime(200);
+    await flushMicrotasks();
+
+    expect(received).toHaveLength(1);
+    expect(received[0].stateRevision).toBe(42);
+    expect(received[0].ptt).toBe(true);
+    expect(received[0].connection.radioReady).toBe(true);
+    stop();
+  });
+
   it('does not crash on fetch error', async () => {
     globalThis.fetch = vi.fn().mockRejectedValue(new Error('network gone'));
 

--- a/frontend/src/lib/transport/__tests__/http-client.test.ts
+++ b/frontend/src/lib/transport/__tests__/http-client.test.ts
@@ -6,6 +6,8 @@ import type { ServerState } from '../../types/state';
 function makeState(revision: number): ServerState {
   return {
     revision,
+    stateRevision: revision,
+    freshnessRevision: 1,
     updatedAt: new Date().toISOString(),
     active: 'MAIN',
     ptt: false,
@@ -223,6 +225,38 @@ describe('startPolling', () => {
     expect(received).toHaveLength(2);
     expect(received[1].revision).toBe(42);
     expect(received[1].healthRevision).toBe(2);
+    stop();
+  });
+
+  it('calls callback when only freshnessRevision advances', async () => {
+    const first = makeState(42);
+    first.freshnessRevision = 1;
+    const second = makeState(42);
+    second.freshnessRevision = 2;
+    second.main.sMeter = 64;
+    let index = 0;
+    globalThis.fetch = vi.fn().mockImplementation(() => {
+      const state = index++ === 0 ? first : second;
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        headers: { get: () => `"42-${state.freshnessRevision}-0"` },
+        json: () => Promise.resolve(state),
+      });
+    });
+
+    const { startPolling } = await import('../http-client');
+    const received: ServerState[] = [];
+    const stop = startPolling((s) => received.push(s), 200);
+
+    await flushMicrotasks();
+    vi.advanceTimersByTime(200);
+    await flushMicrotasks();
+
+    expect(received).toHaveLength(2);
+    expect(received[1].stateRevision).toBe(42);
+    expect(received[1].freshnessRevision).toBe(2);
+    expect(received[1].main.sMeter).toBe(64);
     stop();
   });
 

--- a/frontend/src/lib/transport/http-client.ts
+++ b/frontend/src/lib/transport/http-client.ts
@@ -13,6 +13,14 @@ export function setPollingMultiplier(m: number): void {
 
 let lastStateEtag: string | null = null;
 
+function getStateRevision(state: ServerState): number {
+  return state.stateRevision ?? state.revision;
+}
+
+function getFreshnessRevision(state: ServerState): number {
+  return state.freshnessRevision ?? 0;
+}
+
 function getStoredToken(): string | null {
   const storage = globalThis.localStorage;
   if (!storage || typeof storage.getItem !== 'function') {
@@ -92,7 +100,8 @@ export function startPolling(
   let timer: ReturnType<typeof setTimeout> | null = null;
   let running = true;
   let inflight = false;
-  let lastRevision = -1;
+  let lastStateRevision = -1;
+  let lastFreshnessRevision = -1;
   let lastHealthRevision = -1;
   let consecutiveErrors = 0;
 
@@ -112,11 +121,18 @@ export function startPolling(
           setRadioStatus(state.radioDetail.status);
         }
         const healthRevision = state?.healthRevision ?? 0;
+        const stateRevision = state ? getStateRevision(state) : -1;
+        const freshnessRevision = state ? getFreshnessRevision(state) : -1;
         if (
           state
-          && (state.revision > lastRevision || healthRevision > lastHealthRevision)
+          && (
+            stateRevision > lastStateRevision
+            || freshnessRevision > lastFreshnessRevision
+            || healthRevision > lastHealthRevision
+          )
         ) {
-          lastRevision = state.revision;
+          lastStateRevision = stateRevision;
+          lastFreshnessRevision = freshnessRevision;
           lastHealthRevision = healthRevision;
           callback(state);
         }

--- a/frontend/src/lib/transport/http-client.ts
+++ b/frontend/src/lib/transport/http-client.ts
@@ -123,13 +123,15 @@ export function startPolling(
         const healthRevision = state?.healthRevision ?? 0;
         const stateRevision = state ? getStateRevision(state) : -1;
         const freshnessRevision = state ? getFreshnessRevision(state) : -1;
+        const semanticAdvanced = stateRevision > lastStateRevision;
+        const semanticCurrent = stateRevision === lastStateRevision;
+        const metadataAdvanced = semanticCurrent && (
+          freshnessRevision > lastFreshnessRevision
+          || healthRevision > lastHealthRevision
+        );
         if (
           state
-          && (
-            stateRevision > lastStateRevision
-            || freshnessRevision > lastFreshnessRevision
-            || healthRevision > lastHealthRevision
-          )
+          && (semanticAdvanced || metadataAdvanced)
         ) {
           lastStateRevision = stateRevision;
           lastFreshnessRevision = freshnessRevision;

--- a/frontend/src/lib/transport/ws-client.ts
+++ b/frontend/src/lib/transport/ws-client.ts
@@ -247,14 +247,31 @@ _ctrl.onStateChange((s) => {
 let _fullState: Record<string, unknown> = {};
 let _hasReceivedFullState = false;
 
+function syncEnvelopeRevisions(
+  state: Record<string, unknown>,
+  envelope: Record<string, unknown>,
+): Record<string, unknown> {
+  if (typeof envelope.revision === 'number') {
+    state.revision = envelope.revision;
+  }
+  if (typeof envelope.stateRevision === 'number') {
+    state.stateRevision = envelope.stateRevision;
+  }
+  if (typeof envelope.freshnessRevision === 'number') {
+    state.freshnessRevision = envelope.freshnessRevision;
+  }
+  return state;
+}
+
 function applyDeltaEnvelope(envelope: Record<string, unknown>): Record<string, unknown> | null {
   const deltaType = envelope.type as string;
 
   if (deltaType === 'full') {
     // Full state refresh — replace everything
-    _fullState = { ...(envelope.data as Record<string, unknown>) };
-    // Carry revision at top level for setRadioState
-    _fullState.revision = envelope.revision as number;
+    _fullState = syncEnvelopeRevisions(
+      { ...(envelope.data as Record<string, unknown>) },
+      envelope,
+    );
     _hasReceivedFullState = true;
     return _fullState;
   }
@@ -270,9 +287,7 @@ function applyDeltaEnvelope(envelope: Record<string, unknown>): Record<string, u
     for (const key of removed) {
       delete _fullState[key];
     }
-    // Update revision
-    _fullState.revision = envelope.revision as number;
-    return _fullState;
+    return syncEnvelopeRevisions(_fullState, envelope);
   }
 
   // Legacy format (no delta envelope) — plain state object

--- a/frontend/src/lib/types/state.ts
+++ b/frontend/src/lib/types/state.ts
@@ -60,6 +60,8 @@ export interface ScopeControls {
 
 export interface ServerState {
   revision: number;
+  stateRevision?: number;
+  freshnessRevision?: number;
   healthRevision?: number;
   updatedAt: string;
 

--- a/frontend/tests/e2e/v2-ui-interactive.impl.ts
+++ b/frontend/tests/e2e/v2-ui-interactive.impl.ts
@@ -226,21 +226,8 @@ function verifyAllCommands(
   };
 }
 
-function clampToBipolarRange(value: number): number {
-  return Math.max(-1200, Math.min(1200, Math.round(value)));
-}
-
-function deriveIfShift(pbtInner: number, pbtOuter: number): number {
-  return clampToBipolarRange((pbtInner + pbtOuter) / 2);
-}
-
-function mapIfShiftToPbt(targetIfShift: number, currentPbtInner: number, currentPbtOuter: number) {
-  const currentIfShift = deriveIfShift(currentPbtInner, currentPbtOuter);
-  const delta = clampToBipolarRange(targetIfShift) - currentIfShift;
-  return {
-    pbtInner: clampToBipolarRange(currentPbtInner + delta),
-    pbtOuter: clampToBipolarRange(currentPbtOuter + delta),
-  };
+function pbtHzToRaw(hz: number): number {
+  return Math.max(0, Math.min(255, Math.round(hz * (128 / 1200) + 128)));
 }
 
 async function installWebSocketInterceptor(page: Page): Promise<void> {
@@ -453,24 +440,83 @@ async function restoreOriginalActiveReceiver(ctx: CaseContext): Promise<void> {
 }
 
 async function ensureCompSliderVisible(ctx: CaseContext): Promise<void> {
+  await ensureTxSettingsOpen(ctx);
   const slider = ctx.page.getByRole('slider', { name: 'Comp Level' });
   if (await slider.isVisible().catch(() => false)) {
     return;
   }
 
-  await panelByHeader(ctx.page, 'TX').getByRole('button', { name: 'COMP', exact: true }).click();
+  await closeOpenModal(ctx.page);
+  await panelByHeader(ctx.page, 'TX').getByRole('button', { name: /^COMP(?:\s+\d+%)?$/ }).click();
+  await wait(CONTROL_DELAY_MS);
+  await clearCommands(ctx.page);
+  await ensureTxSettingsOpen(ctx);
   await slider.waitFor({ state: 'visible', timeout: 5_000 });
   await clearCommands(ctx.page);
 }
 
 async function ensureMonSliderVisible(ctx: CaseContext): Promise<void> {
+  await ensureTxSettingsOpen(ctx);
   const slider = ctx.page.getByRole('slider', { name: 'Mon Level' });
   if (await slider.isVisible().catch(() => false)) {
     return;
   }
 
-  await panelByHeader(ctx.page, 'TX').getByRole('button', { name: 'MON', exact: true }).click();
+  await closeOpenModal(ctx.page);
+  await panelByHeader(ctx.page, 'TX').getByRole('button', { name: /^MON(?:\s+\d+%)?$/ }).click();
+  await wait(CONTROL_DELAY_MS);
+  await clearCommands(ctx.page);
+  await ensureTxSettingsOpen(ctx);
   await slider.waitFor({ state: 'visible', timeout: 5_000 });
+  await clearCommands(ctx.page);
+}
+
+async function ensureFilterSettingsOpen(ctx: CaseContext): Promise<void> {
+  const dialog = ctx.page.getByRole('dialog', { name: /Filter settings/ });
+  if (await dialog.isVisible().catch(() => false)) {
+    return;
+  }
+
+  await closeOpenModal(ctx.page);
+  await panelByHeader(ctx.page, 'FILTER').getByRole('button', { name: 'Open filter settings' }).click();
+  await dialog.waitFor({ state: 'visible', timeout: 5_000 });
+  await clearCommands(ctx.page);
+}
+
+async function ensureDspSettingsOpen(
+  ctx: CaseContext,
+  buttonName: string | RegExp,
+  dialogName: string | RegExp,
+): Promise<void> {
+  const dialog = ctx.page.getByRole('dialog', { name: dialogName });
+  if (await dialog.isVisible().catch(() => false)) {
+    return;
+  }
+
+  await closeOpenModal(ctx.page);
+  const button = panelByHeader(ctx.page, 'DSP').getByRole('button', { name: buttonName });
+  await button.scrollIntoViewIfNeeded();
+  const box = await button.boundingBox();
+  if (!box) {
+    throw new Error('DSP settings button has no bounding box');
+  }
+  await ctx.page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await ctx.page.mouse.down();
+  await wait(650);
+  await ctx.page.mouse.up();
+  await dialog.waitFor({ state: 'visible', timeout: 5_000 });
+  await clearCommands(ctx.page);
+}
+
+async function ensureTxSettingsOpen(ctx: CaseContext): Promise<void> {
+  const dialog = ctx.page.getByRole('dialog', { name: 'TX level settings' });
+  if (await dialog.isVisible().catch(() => false)) {
+    return;
+  }
+
+  await closeOpenModal(ctx.page);
+  await panelByHeader(ctx.page, 'TX').getByRole('button', { name: /LEVELS/ }).click();
+  await dialog.waitFor({ state: 'visible', timeout: 5_000 });
   await clearCommands(ctx.page);
 }
 
@@ -521,15 +567,52 @@ async function restoreSubReceiverFromOriginal(ctx: CaseContext): Promise<void> {
   await sendRestoreCommands(ctx.page, ctx.request, commands);
 }
 
-async function setRangeValue(locator: Locator, value: number): Promise<void> {
+async function closeOpenModal(page: Page): Promise<void> {
+  for (let i = 0; i < 3; i += 1) {
+    const filterClose = page.getByRole('dialog', { name: /Filter settings/ }).getByRole('button', { name: 'Close' });
+    if (await filterClose.isVisible().catch(() => false)) {
+      await filterClose.click();
+      await wait(100);
+      continue;
+    }
+
+    const backdrop = page.locator('.menu-backdrop:visible, .modal-backdrop:visible').first();
+    if ((await backdrop.count()) === 0) {
+      return;
+    }
+    await page.mouse.click(6, 6);
+    await wait(100);
+  }
+}
+
+async function setRangeValue(page: Page, locator: Locator, value: number): Promise<void> {
   await locator.scrollIntoViewIfNeeded();
-  await locator.evaluate((element, targetValue) => {
-    const input = element as HTMLInputElement;
-    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
-    setter?.call(input, String(targetValue));
-    input.dispatchEvent(new Event('input', { bubbles: true }));
-    input.dispatchEvent(new Event('change', { bubbles: true }));
-  }, value);
+  const range = await locator.evaluate((element) => {
+    const min = Number(element.getAttribute('aria-valuemin') ?? 0);
+    const max = Number(element.getAttribute('aria-valuemax') ?? 100);
+    return { min, max };
+  });
+  const box = await locator.boundingBox();
+  if (!box) {
+    throw new Error('Slider has no bounding box');
+  }
+
+  const ratio = range.max === range.min ? 0 : (value - range.min) / (range.max - range.min);
+  const x = box.x + Math.max(1, Math.min(box.width - 1, box.width * Math.max(0, Math.min(1, ratio))));
+  await page.mouse.click(x, box.y + box.height / 2);
+}
+
+async function setDualRfGain(page: Page, locator: Locator, value: number): Promise<void> {
+  await locator.scrollIntoViewIfNeeded();
+  const box = await locator.boundingBox();
+  if (!box) {
+    throw new Error('RF/SQL slider has no bounding box');
+  }
+
+  const leftEdge = 0.5 - 0.04;
+  const ratio = leftEdge * (Math.max(0, Math.min(255, value)) / 255);
+  const x = box.x + Math.max(1, Math.min(box.width - 1, box.width * ratio));
+  await page.mouse.click(x, box.y + box.height / 2);
 }
 
 async function takeFailureScreenshot(page: Page, panel: string, control: string): Promise<string> {
@@ -541,19 +624,9 @@ async function takeFailureScreenshot(page: Page, panel: string, control: string)
 
 function panelByHeader(page: Page, header: string): Locator {
   return page
-    .locator('.panel, .filter-panel')
+    .locator('.collapsible-panel')
     .filter({ has: page.locator('.panel-header', { hasText: header }) })
     .first();
-}
-
-function rfControlRow(page: Page, label: string): Locator {
-  const panel = panelByHeader(page, 'RF FRONT END');
-  return panel.locator('.control-row').filter({ has: panel.locator('.control-label', { hasText: label }) }).first();
-}
-
-function dspSection(page: Page, label: string): Locator {
-  const panel = panelByHeader(page, 'DSP');
-  return panel.locator('.section').filter({ has: panel.locator('.section-label', { hasText: label }) }).first();
 }
 
 function bandCode(capabilities: Capabilities, bandName: string): number | undefined {
@@ -575,12 +648,12 @@ async function buildAuditCases(capabilities: Capabilities): Promise<AuditCase[]>
       control: 'RF Gain',
       action: 'set 200',
       expected: 'set_rf_gain { level: 200, receiver: 0 }',
-      locate: (page) => panelByHeader(page, 'RF FRONT END').getByRole('slider', { name: 'RF Gain' }),
-      act: async (_page, locator) => setRangeValue(locator, 200),
+      locate: (page) => panelByHeader(page, 'RF FRONT END').getByRole('slider', { name: /RF gain and squelch/ }),
+      act: async (page, locator) => setDualRfGain(page, locator, 200),
       verify: (_ctx, commands) =>
         verifySingleCommand(commands, {
           name: 'set_rf_gain',
-          approx: { level: { expected: 200 } },
+          approx: { level: { expected: 200, tolerance: 1 } },
           params: { receiver: 0 },
         }),
       cleanup: async (ctx) => {
@@ -594,7 +667,7 @@ async function buildAuditCases(capabilities: Capabilities): Promise<AuditCase[]>
       control: 'ATT',
       action: 'click 6dB',
       expected: 'set_attenuator { db: 6, receiver: 0 }',
-      locate: (page) => page.getByRole('radio', { name: '6dB', exact: true }),
+      locate: (page) => panelByHeader(page, 'RF FRONT END').getByRole('button', { name: '6dB', exact: true }),
       act: async (_page, locator) => locator.click(),
       verify: (_ctx, commands) =>
         verifySingleCommand(commands, {
@@ -612,7 +685,7 @@ async function buildAuditCases(capabilities: Capabilities): Promise<AuditCase[]>
       control: 'PRE',
       action: 'click P1',
       expected: 'set_preamp { level: 1, receiver: 0 }',
-      locate: (page) => page.getByRole('radio', { name: 'P1', exact: true }),
+      locate: (page) => panelByHeader(page, 'RF FRONT END').getByRole('button', { name: 'P1', exact: true }),
       act: async (_page, locator) => locator.click(),
       verify: (_ctx, commands) =>
         verifySingleCommand(commands, {
@@ -630,8 +703,9 @@ async function buildAuditCases(capabilities: Capabilities): Promise<AuditCase[]>
       control: 'Width',
       action: 'set 1500',
       expected: 'set_filter_width { width: 1500, receiver: 0 }',
-      locate: (page) => page.getByRole('slider', { name: 'Width' }),
-      act: async (_page, locator) => setRangeValue(locator, 1500),
+      prepare: ensureFilterSettingsOpen,
+      locate: (page) => page.getByRole('dialog', { name: /Filter settings/ }).getByRole('slider').first(),
+      act: async (page, locator) => setRangeValue(page, locator, 1500),
       verify: (_ctx, commands) =>
         verifySingleCommand(commands, {
           name: 'set_filter_width',
@@ -651,20 +725,23 @@ async function buildAuditCases(capabilities: Capabilities): Promise<AuditCase[]>
       control: 'IF Shift',
       action: 'set 300',
       expected: 'set_pbt_inner + set_pbt_outer',
-      locate: (page) => page.getByRole('slider', { name: 'IF Shift' }),
-      act: async (_page, locator) => setRangeValue(locator, 300),
-      verify: (ctx, commands) => {
-        const expected = mapIfShiftToPbt(300, ctx.originalState.main.pbtInner, ctx.originalState.main.pbtOuter);
+      locate: (page) => panelByHeader(page, 'FILTER').getByRole('slider', { name: 'PBT Inner' }),
+      act: async (page) => {
+        await setRangeValue(page, panelByHeader(page, 'FILTER').getByRole('slider', { name: 'PBT Inner' }), 300);
+        await setRangeValue(page, panelByHeader(page, 'FILTER').getByRole('slider', { name: 'PBT Outer' }), 300);
+      },
+      verify: (_ctx, commands) => {
+        const expectedRaw = pbtHzToRaw(300);
         return verifyAllCommands(commands, [
           {
             name: 'set_pbt_inner',
             params: { receiver: 0 },
-            approx: { value: { expected: expected.pbtInner } },
+            approx: { value: { expected: expectedRaw, tolerance: 1 } },
           },
           {
             name: 'set_pbt_outer',
             params: { receiver: 0 },
-            approx: { value: { expected: expected.pbtOuter } },
+            approx: { value: { expected: expectedRaw, tolerance: 1 } },
           },
         ]);
       },
@@ -680,7 +757,7 @@ async function buildAuditCases(capabilities: Capabilities): Promise<AuditCase[]>
       control: 'Mode',
       action: 'click FAST',
       expected: 'set_agc { mode: 1, receiver: 0 }',
-      locate: (page) => panelByHeader(page, 'AGC').getByRole('radio', { name: 'FAST' }),
+      locate: (page) => panelByHeader(page, 'AGC').getByRole('button', { name: 'FAST' }),
       act: async (_page, locator) => locator.click(),
       verify: (_ctx, commands) =>
         verifySingleCommand(commands, {
@@ -696,15 +773,16 @@ async function buildAuditCases(capabilities: Capabilities): Promise<AuditCase[]>
     {
       panel: 'AGC',
       control: 'Decay',
-      action: 'set 100',
-      expected: 'set_agc_time_constant { value: 100, receiver: 0 }',
-      locate: (page) => panelByHeader(page, 'AGC').getByRole('slider', { name: 'Decay' }),
-      act: async (_page, locator) => setRangeValue(locator, 100),
+      action: 'set 5',
+      expected: 'set_agc_time_constant { value: 5, receiver: 0 }',
+      prepare: (ctx) => ensureDspSettingsOpen(ctx, /^AGC-T/, 'AGC time settings'),
+      locate: (page) => page.getByRole('dialog', { name: 'AGC time settings' }).getByRole('slider', { name: 'AGC Time' }),
+      act: async (page, locator) => setRangeValue(page, locator, 5),
       verify: (_ctx, commands) =>
         verifySingleCommand(commands, {
           name: 'set_agc_time_constant',
           params: { receiver: 0 },
-          approx: { value: { expected: 100 } },
+          approx: { value: { expected: 5 } },
         }),
       cleanup: async (ctx) => {
         await sendRestoreCommands(ctx.page, ctx.request, [
@@ -717,7 +795,7 @@ async function buildAuditCases(capabilities: Capabilities): Promise<AuditCase[]>
       control: 'RIT',
       action: 'toggle',
       expected: `set_rit_status { on: ${String(true)} }`,
-      locate: (page) => panelByHeader(page, 'RIT / XIT').getByRole('button', { name: 'RIT' }),
+      locate: (page) => panelByHeader(page, 'RIT / XIT').getByRole('button', { name: 'RIT', exact: true }),
       act: async (_page, locator) => locator.click(),
       verify: (ctx, commands) =>
         verifySingleCommand(commands, {
@@ -735,7 +813,7 @@ async function buildAuditCases(capabilities: Capabilities): Promise<AuditCase[]>
       control: 'XIT',
       action: 'toggle',
       expected: `set_rit_tx_status { on: ${String(true)} }`,
-      locate: (page) => panelByHeader(page, 'RIT / XIT').getByRole('button', { name: 'XIT' }),
+      locate: (page) => panelByHeader(page, 'RIT / XIT').getByRole('button', { name: 'XIT', exact: true }),
       act: async (_page, locator) => locator.click(),
       verify: (ctx, commands) =>
         verifySingleCommand(commands, {
@@ -810,7 +888,7 @@ async function buildAuditCases(capabilities: Capabilities): Promise<AuditCase[]>
       expected: expected20mCode !== undefined
         ? `set_band { band: ${expected20mCode} }`
         : 'set_band { band: <number> }',
-      locate: (page) => page.locator('[data-band="20m"]').first(),
+      locate: (page) => panelByHeader(page, 'BAND').getByRole('button', { name: '20m', exact: true }),
       act: async (_page, locator) => locator.click(),
       verify: (_ctx, commands) =>
         verifySingleCommand(
@@ -835,7 +913,7 @@ async function buildAuditCases(capabilities: Capabilities): Promise<AuditCase[]>
       action: 'set 150',
       expected: 'set_af_level { level: 150, receiver: 0 }',
       locate: (page) => panelByHeader(page, 'RX AUDIO').getByRole('slider', { name: 'AF Level' }),
-      act: async (_page, locator) => setRangeValue(locator, 150),
+      act: async (page, locator) => setRangeValue(page, locator, 150),
       verify: (_ctx, commands) =>
         verifySingleCommand(commands, {
           name: 'set_af_level',
@@ -851,14 +929,14 @@ async function buildAuditCases(capabilities: Capabilities): Promise<AuditCase[]>
     {
       panel: 'DSP',
       control: 'NR',
-      action: 'click NR1',
+      action: 'toggle',
       expected: 'set_nr { on: true, receiver: 0 }',
-      locate: (page) => page.getByRole('radio', { name: 'NR1', exact: true }),
+      locate: (page) => panelByHeader(page, 'DSP').getByRole('button', { name: /^NR(?:\s+\d+)?$/ }),
       act: async (_page, locator) => locator.click(),
-      verify: (_ctx, commands) =>
+      verify: (ctx, commands) =>
         verifySingleCommand(commands, {
           name: 'set_nr',
-          params: { on: true, receiver: 0 },
+          params: { on: !ctx.originalState.main.nr, receiver: 0 },
         }),
       cleanup: async (ctx) => {
         await sendRestoreCommands(ctx.page, ctx.request, [
@@ -871,8 +949,9 @@ async function buildAuditCases(capabilities: Capabilities): Promise<AuditCase[]>
       control: 'NR Level',
       action: 'set 5',
       expected: 'set_nr_level { level: 5, receiver: 0 }',
-      locate: (page) => panelByHeader(page, 'DSP').getByRole('slider', { name: 'NR Level' }),
-      act: async (_page, locator) => setRangeValue(locator, 5),
+      prepare: (ctx) => ensureDspSettingsOpen(ctx, /^NR(?:\s+\d+)?$/, 'Noise reduction settings'),
+      locate: (page) => page.getByRole('dialog', { name: 'Noise reduction settings' }).getByRole('slider', { name: 'NR Level' }),
+      act: async (page, locator) => setRangeValue(page, locator, 5),
       verify: (_ctx, commands) =>
         verifySingleCommand(commands, {
           name: 'set_nr_level',
@@ -890,7 +969,7 @@ async function buildAuditCases(capabilities: Capabilities): Promise<AuditCase[]>
       control: 'NB',
       action: 'toggle',
       expected: `set_nb { on: ${String(true)}, receiver: 0 }`,
-      locate: (page) => page.getByRole('button', { name: /^(ON|OFF)$/ }).first(),
+      locate: (page) => panelByHeader(page, 'DSP').getByRole('button', { name: /^NB(?:\s+\d+)?$/ }),
       act: async (_page, locator) => locator.click(),
       verify: (ctx, commands) =>
         verifySingleCommand(commands, {
@@ -908,8 +987,9 @@ async function buildAuditCases(capabilities: Capabilities): Promise<AuditCase[]>
       control: 'NB Level',
       action: 'set 5',
       expected: 'set_nb_level { level: 5, receiver: 0 }',
-      locate: (page) => panelByHeader(page, 'DSP').getByRole('slider', { name: 'NB Level' }),
-      act: async (_page, locator) => setRangeValue(locator, 5),
+      prepare: (ctx) => ensureDspSettingsOpen(ctx, /^NB(?:\s+\d+)?$/, 'Noise blanker settings'),
+      locate: (page) => page.getByRole('dialog', { name: 'Noise blanker settings' }).getByRole('slider', { name: 'NB Level' }),
+      act: async (page, locator) => setRangeValue(page, locator, 5),
       verify: (_ctx, commands) =>
         verifySingleCommand(commands, {
           name: 'set_nb_level',
@@ -925,9 +1005,9 @@ async function buildAuditCases(capabilities: Capabilities): Promise<AuditCase[]>
     {
       panel: 'DSP',
       control: 'Notch',
-      action: 'click AUTO',
+      action: 'click A-NOTCH',
       expected: 'set_auto_notch { on: true, receiver: 0 }',
-      locate: (page) => page.getByRole('radio', { name: 'AUTO', exact: true }),
+      locate: (page) => panelByHeader(page, 'DSP').getByRole('button', { name: 'A-NOTCH' }),
       act: async (_page, locator) => locator.click(),
       verify: (_ctx, commands) =>
         verifySingleCommand(commands, {
@@ -961,7 +1041,7 @@ async function buildAuditCases(capabilities: Capabilities): Promise<AuditCase[]>
         actual: 'control missing from DOM',
         details: 'CW Pitch did not render after switching MAIN to CW mode with a direct set_mode command.',
       }),
-      act: async (_page, locator) => setRangeValue(locator, 700),
+      act: async (page, locator) => setRangeValue(page, locator, 700),
       verify: (_ctx, commands) =>
         verifySingleCommand(commands, {
           name: 'set_cw_pitch',
@@ -979,8 +1059,9 @@ async function buildAuditCases(capabilities: Capabilities): Promise<AuditCase[]>
       control: 'Mic Gain',
       action: 'set 100',
       expected: 'set_mic_gain { level: 100 }',
-      locate: (page) => panelByHeader(page, 'TX').getByRole('slider', { name: 'Mic Gain' }),
-      act: async (_page, locator) => setRangeValue(locator, 100),
+      prepare: ensureTxSettingsOpen,
+      locate: (page) => page.getByRole('dialog', { name: 'TX level settings' }).getByRole('slider', { name: 'Mic Gain' }),
+      act: async (page, locator) => setRangeValue(page, locator, 100),
       verify: (_ctx, commands) =>
         verifySingleCommand(commands, {
           name: 'set_mic_gain',
@@ -1015,7 +1096,7 @@ async function buildAuditCases(capabilities: Capabilities): Promise<AuditCase[]>
       control: 'COMP',
       action: 'toggle',
       expected: 'set_compressor { on: true/false }',
-      locate: (page) => panelByHeader(page, 'TX').getByRole('button', { name: 'COMP' }),
+      locate: (page) => panelByHeader(page, 'TX').getByRole('button', { name: /^COMP(?:\s+\d+%)?$/ }),
       act: async (_page, locator) => locator.click(),
       verify: (ctx, commands) =>
         verifySingleCommand(commands, {
@@ -1040,7 +1121,7 @@ async function buildAuditCases(capabilities: Capabilities): Promise<AuditCase[]>
         actual: 'control missing from DOM',
         details: 'Comp Level slider did not render after enabling COMP.',
       }),
-      act: async (_page, locator) => setRangeValue(locator, 5),
+      act: async (page, locator) => setRangeValue(page, locator, 5),
       verify: (_ctx, commands) =>
         verifySingleCommand(commands, {
           name: 'set_compressor_level',
@@ -1058,7 +1139,7 @@ async function buildAuditCases(capabilities: Capabilities): Promise<AuditCase[]>
       control: 'MON',
       action: 'toggle',
       expected: 'set_monitor { on: true/false }',
-      locate: (page) => panelByHeader(page, 'TX').getByRole('button', { name: 'MON' }),
+      locate: (page) => panelByHeader(page, 'TX').getByRole('button', { name: /^MON(?:\s+\d+%)?$/ }),
       act: async (_page, locator) => locator.click(),
       verify: (ctx, commands) =>
         verifySingleCommand(commands, {
@@ -1083,7 +1164,7 @@ async function buildAuditCases(capabilities: Capabilities): Promise<AuditCase[]>
         actual: 'control missing from DOM',
         details: 'Mon Level slider did not render after enabling MON.',
       }),
-      act: async (_page, locator) => setRangeValue(locator, 100),
+      act: async (page, locator) => setRangeValue(page, locator, 100),
       verify: (_ctx, commands) =>
         verifySingleCommand(commands, {
           name: 'set_monitor_gain',
@@ -1331,6 +1412,7 @@ test('v2 interactive audit against the live backend', async ({ page, request }) 
             await auditCase.cleanup(ctx);
           }
         } finally {
+          await closeOpenModal(page);
           if (auditCase.ensureMain !== false) {
             await restoreOriginalActiveReceiver(ctx);
           }

--- a/rigs/_schema.md
+++ b/rigs/_schema.md
@@ -105,6 +105,71 @@ Known capability strings (grouped by area):
 
 **System:** `power_control`, `dial_lock`, `scan`, `bsr`, `main_sub_tracking`, `lcd_backlight`
 
+## `[state_acquisition]` — State Capability And Policy Metadata
+
+Optional section. Defines provider-specific state acquisition behavior as data
+for future scheduler/adapters. Web and rigctld delivery code must not branch on
+these fields directly.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `provider` | string | no | Lowercase provider identifier such as `"icom_civ"`, `"yaesu_cat"`, `"xiegu_civ"`, or `"external_rigctld"`. Defaults to `"profile"`. |
+| `default_cadence_seconds` | float | no | Conservative default polling cadence for supported fields. Defaults to `5.0`. |
+| `default_freshness_ttl_seconds` | float | no | TTL before a value should be considered stale. Must be greater than or equal to cadence. Defaults to `15.0`. |
+| `default_reconciliation_priority` | string | no | `"unsolicited"`, `"command_response"`, `"poll"`, or `"last_observation"`. Defaults to `"poll"`. |
+| `adaptive_decay` | bool | no | Whether a scheduler may widen cadence while idle. Defaults to `false`. |
+| `adaptive_decay_idle_multiplier` | float | no | Multiplier for idle cadence when adaptive decay is enabled. Must be greater than `1.0` when enabled. |
+| `adaptive_decay_max_cadence_seconds` | float | no | Maximum widened cadence. |
+| `external_cat_pause` | string | no | `"pause_polling"`, `"coalesce_meters_only"`, or `"continue"`. Defaults to `"pause_polling"`. |
+| `meter_coalescing_window_seconds` | float | no | Default short coalescing window for stream-like meter observations. |
+
+### `[state_acquisition.capabilities]`
+
+Each field path uses the canonical `FieldPath` strings from
+`rigplane.core.state_pipeline_contracts`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `unsolicited_push` | string[] | Fields the provider may push without an explicit poll. |
+| `polling_only` | string[] | Fields acquired by explicit polling. |
+| `stream_like_meters` | string[] | Meter fields whose observations may arrive frequently and be coalesced. Each path must use the `meters` family. |
+| `command_response_observable` | string[] | Fields where command responses can confirm state after a write. |
+| `supported_controls` | string[] | Writable/control fields supported by the provider profile. |
+| `unsupported` | string[] | Known-unavailable fields. These must not also appear in acquisition lists. |
+| `unknown` | string[] | Fields without enough evidence. Schedulers should diagnose them as unknown instead of polling forever. |
+
+### `[state_acquisition.field_policies."<field-path>"]`
+
+Optional per-field policy overrides. Supported keys are `cadence_seconds`,
+`freshness_ttl_seconds`, `reconciliation_priority`, `external_cat_pause`,
+`adaptive_decay`, `adaptive_decay_idle_multiplier`,
+`adaptive_decay_max_cadence_seconds`, and `meter_coalescing_window_seconds`.
+Field-specific `meter_coalescing_window_seconds` is valid only for meter paths.
+
+Example:
+
+```toml
+[state_acquisition]
+provider = "xiegu_civ"
+default_cadence_seconds = 2.0
+default_freshness_ttl_seconds = 8.0
+default_reconciliation_priority = "poll"
+external_cat_pause = "pause_polling"
+
+[state_acquisition.capabilities]
+polling_only = [
+    "receiver.main.active.freq_mode.freq_hz",
+    "receiver.main.active.freq_mode.mode",
+]
+command_response_observable = ["receiver.main.active.freq_mode.mode"]
+unsupported = ["global.tx_state.power_on"]
+
+[state_acquisition.field_policies."receiver.main.active.freq_mode.mode"]
+cadence_seconds = 1.0
+freshness_ttl_seconds = 4.0
+reconciliation_priority = "command_response"
+```
+
 ## `[attenuator]` — Attenuator Steps
 
 Optional section. Defines available attenuator values for the radio.

--- a/rigs/ftx1.toml
+++ b/rigs/ftx1.toml
@@ -62,6 +62,13 @@ polling_only = [
     "receiver.main.active.freq_mode.mode",
     "receiver.sub.active.freq_mode.freq_hz",
     "receiver.sub.active.freq_mode.mode",
+    "global.tx_state.ptt",
+    "receiver.main.operator_controls.af_level",
+    "receiver.main.operator_controls.rf_gain",
+    "receiver.main.operator_controls.squelch",
+    "receiver.sub.operator_controls.af_level",
+    "receiver.sub.operator_controls.rf_gain",
+    "receiver.sub.operator_controls.squelch",
 ]
 stream_like_meters = [
     "receiver.main.meters.s_meter",
@@ -80,8 +87,33 @@ supported_controls = [
     "receiver.main.active.freq_mode.mode",
     "receiver.sub.active.freq_mode.freq_hz",
     "receiver.sub.active.freq_mode.mode",
+    "global.tx_state.ptt",
 ]
 unsupported = ["global.tx_state.power_on"]
+
+[state_acquisition.field_policies."receiver.main.operator_controls.af_level"]
+cadence_seconds = 30.0
+freshness_ttl_seconds = 120.0
+
+[state_acquisition.field_policies."receiver.main.operator_controls.rf_gain"]
+cadence_seconds = 30.0
+freshness_ttl_seconds = 120.0
+
+[state_acquisition.field_policies."receiver.main.operator_controls.squelch"]
+cadence_seconds = 30.0
+freshness_ttl_seconds = 120.0
+
+[state_acquisition.field_policies."receiver.sub.operator_controls.af_level"]
+cadence_seconds = 30.0
+freshness_ttl_seconds = 120.0
+
+[state_acquisition.field_policies."receiver.sub.operator_controls.rf_gain"]
+cadence_seconds = 30.0
+freshness_ttl_seconds = 120.0
+
+[state_acquisition.field_policies."receiver.sub.operator_controls.squelch"]
+cadence_seconds = 30.0
+freshness_ttl_seconds = 120.0
 
 [modes]
 list = [

--- a/rigs/ftx1.toml
+++ b/rigs/ftx1.toml
@@ -91,6 +91,30 @@ supported_controls = [
 ]
 unsupported = ["global.tx_state.power_on"]
 
+[state_acquisition.field_policies."receiver.main.meters.s_meter"]
+cadence_seconds = 0.2
+freshness_ttl_seconds = 0.8
+adaptive_decay = false
+meter_coalescing_window_seconds = 0.2
+
+[state_acquisition.field_policies."receiver.sub.meters.s_meter"]
+cadence_seconds = 0.2
+freshness_ttl_seconds = 0.8
+adaptive_decay = false
+meter_coalescing_window_seconds = 0.2
+
+[state_acquisition.field_policies."global.meters.power"]
+cadence_seconds = 0.2
+freshness_ttl_seconds = 0.8
+adaptive_decay = false
+meter_coalescing_window_seconds = 0.2
+
+[state_acquisition.field_policies."global.meters.swr"]
+cadence_seconds = 0.2
+freshness_ttl_seconds = 0.8
+adaptive_decay = false
+meter_coalescing_window_seconds = 0.2
+
 [state_acquisition.field_policies."receiver.main.operator_controls.af_level"]
 cadence_seconds = 30.0
 freshness_ttl_seconds = 120.0

--- a/rigs/ftx1.toml
+++ b/rigs/ftx1.toml
@@ -45,6 +45,44 @@ features = [
     "dial_lock",
 ]
 
+[state_acquisition]
+provider = "yaesu_cat"
+default_cadence_seconds = 2.0
+default_freshness_ttl_seconds = 8.0
+default_reconciliation_priority = "poll"
+adaptive_decay = true
+adaptive_decay_idle_multiplier = 3.0
+adaptive_decay_max_cadence_seconds = 20.0
+external_cat_pause = "pause_polling"
+meter_coalescing_window_seconds = 0.2
+
+[state_acquisition.capabilities]
+polling_only = [
+    "receiver.main.active.freq_mode.freq_hz",
+    "receiver.main.active.freq_mode.mode",
+    "receiver.sub.active.freq_mode.freq_hz",
+    "receiver.sub.active.freq_mode.mode",
+]
+stream_like_meters = [
+    "receiver.main.meters.s_meter",
+    "receiver.sub.meters.s_meter",
+    "global.meters.power",
+    "global.meters.swr",
+]
+command_response_observable = [
+    "receiver.main.active.freq_mode.freq_hz",
+    "receiver.main.active.freq_mode.mode",
+    "receiver.sub.active.freq_mode.freq_hz",
+    "receiver.sub.active.freq_mode.mode",
+]
+supported_controls = [
+    "receiver.main.active.freq_mode.freq_hz",
+    "receiver.main.active.freq_mode.mode",
+    "receiver.sub.active.freq_mode.freq_hz",
+    "receiver.sub.active.freq_mode.mode",
+]
+unsupported = ["global.tx_state.power_on"]
+
 [modes]
 list = [
     "LSB", "USB", "CW-U", "FM", "AM",

--- a/rigs/ic7610.toml
+++ b/rigs/ic7610.toml
@@ -154,6 +154,30 @@ supported_controls = [
     "global.tx_state.ptt",
 ]
 
+[state_acquisition.field_policies."receiver.main.meters.s_meter"]
+cadence_seconds = 0.2
+freshness_ttl_seconds = 0.8
+adaptive_decay = false
+meter_coalescing_window_seconds = 0.2
+
+[state_acquisition.field_policies."global.meters.power"]
+cadence_seconds = 0.2
+freshness_ttl_seconds = 0.8
+adaptive_decay = false
+meter_coalescing_window_seconds = 0.2
+
+[state_acquisition.field_policies."global.meters.swr"]
+cadence_seconds = 0.2
+freshness_ttl_seconds = 0.8
+adaptive_decay = false
+meter_coalescing_window_seconds = 0.2
+
+[state_acquisition.field_policies."global.meters.alc"]
+cadence_seconds = 0.2
+freshness_ttl_seconds = 0.8
+adaptive_decay = false
+meter_coalescing_window_seconds = 0.2
+
 # ── Parameterized Capabilities ───────────────────────────────────
 
 [attenuator]

--- a/rigs/ic7610.toml
+++ b/rigs/ic7610.toml
@@ -116,6 +116,44 @@ features = [
     "system_settings",
 ]
 
+[state_acquisition]
+provider = "icom_civ"
+default_cadence_seconds = 2.0
+default_freshness_ttl_seconds = 8.0
+default_reconciliation_priority = "unsolicited"
+adaptive_decay = true
+adaptive_decay_idle_multiplier = 4.0
+adaptive_decay_max_cadence_seconds = 30.0
+external_cat_pause = "pause_polling"
+meter_coalescing_window_seconds = 0.2
+
+[state_acquisition.capabilities]
+unsolicited_push = [
+    "receiver.main.active.freq_mode.freq_hz",
+    "receiver.main.active.freq_mode.mode",
+    "global.tx_state.ptt",
+]
+polling_only = [
+    "receiver.main.operator_controls.af_level",
+    "receiver.main.operator_controls.rf_gain",
+]
+stream_like_meters = [
+    "receiver.main.meters.s_meter",
+    "global.meters.power",
+    "global.meters.swr",
+    "global.meters.alc",
+]
+command_response_observable = [
+    "receiver.main.active.freq_mode.freq_hz",
+    "receiver.main.active.freq_mode.mode",
+    "global.tx_state.ptt",
+]
+supported_controls = [
+    "receiver.main.active.freq_mode.freq_hz",
+    "receiver.main.active.freq_mode.mode",
+    "global.tx_state.ptt",
+]
+
 # ── Parameterized Capabilities ───────────────────────────────────
 
 [attenuator]

--- a/rigs/x6200.toml
+++ b/rigs/x6200.toml
@@ -89,6 +89,43 @@ features = [
     "agc",
 ]
 
+[state_acquisition]
+provider = "xiegu_civ"
+default_cadence_seconds = 2.0
+default_freshness_ttl_seconds = 8.0
+default_reconciliation_priority = "poll"
+adaptive_decay = true
+adaptive_decay_idle_multiplier = 4.0
+adaptive_decay_max_cadence_seconds = 30.0
+external_cat_pause = "pause_polling"
+meter_coalescing_window_seconds = 0.25
+
+[state_acquisition.capabilities]
+polling_only = [
+    "receiver.main.active.freq_mode.freq_hz",
+    "receiver.main.active.freq_mode.mode",
+]
+stream_like_meters = [
+    "receiver.main.meters.s_meter",
+    "global.meters.power",
+]
+command_response_observable = [
+    "receiver.main.active.freq_mode.freq_hz",
+    "receiver.main.active.freq_mode.mode",
+]
+supported_controls = [
+    "receiver.main.active.freq_mode.freq_hz",
+    "receiver.main.active.freq_mode.mode",
+]
+unsupported = ["global.tx_state.power_on"]
+unknown = ["global.meters.swr", "global.meters.alc"]
+
+[state_acquisition.field_policies."receiver.main.active.freq_mode.mode"]
+cadence_seconds = 1.0
+freshness_ttl_seconds = 4.0
+reconciliation_priority = "command_response"
+external_cat_pause = "pause_polling"
+
 # PDF page 10 (Table 3 — Mode, Data & filter bandwidth) documents:
 # LSB, LSB-D, USB, USB-D, AM, CW, NFM, CWR. The ``-D`` variants are the
 # data-mode flavours selected via byte 2 of mode commands 0x26 0x00/0x01.

--- a/rigs/x6200.toml
+++ b/rigs/x6200.toml
@@ -126,6 +126,18 @@ freshness_ttl_seconds = 4.0
 reconciliation_priority = "command_response"
 external_cat_pause = "pause_polling"
 
+[state_acquisition.field_policies."receiver.main.meters.s_meter"]
+cadence_seconds = 0.25
+freshness_ttl_seconds = 1.0
+adaptive_decay = false
+meter_coalescing_window_seconds = 0.25
+
+[state_acquisition.field_policies."global.meters.power"]
+cadence_seconds = 0.25
+freshness_ttl_seconds = 1.0
+adaptive_decay = false
+meter_coalescing_window_seconds = 0.25
+
 # PDF page 10 (Table 3 — Mode, Data & filter bandwidth) documents:
 # LSB, LSB-D, USB, USB-D, AM, CW, NFM, CWR. The ``-D`` variants are the
 # data-mode flavours selected via byte 2 of mode commands 0x26 0x00/0x01.

--- a/src/rigplane/audio/backend.py
+++ b/src/rigplane/audio/backend.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import logging
 import math
+import re
 import threading
 import time
 from collections import deque
@@ -29,6 +30,15 @@ _TX_BUFFER_MS = 1_000
 AudioDeviceId = NewType("AudioDeviceId", int)
 """Opaque device identifier (maps to a host-API device index)."""
 
+_ALSA_HW_RE = re.compile(r"(?:plug)?(hw:\d+,\d+)")
+
+
+def _platform_uid_from_device_name(name: str) -> str:
+    match = _ALSA_HW_RE.search(name)
+    if match is None:
+        return ""
+    return match.group(1)
+
 
 @dataclass(frozen=True, slots=True)
 class AudioDeviceInfo:
@@ -41,6 +51,7 @@ class AudioDeviceInfo:
     default_samplerate: int = 48_000
     is_default_input: bool = False
     is_default_output: bool = False
+    platform_uid: str = ""
 
     @property
     def supports_rx(self) -> bool:
@@ -822,6 +833,9 @@ class PortAudioBackend:
                     is_default_input=(default_in is not None and dev_idx == default_in),
                     is_default_output=(
                         default_out is not None and dev_idx == default_out
+                    ),
+                    platform_uid=_platform_uid_from_device_name(
+                        str(raw.get("name", f"device-{dev_idx}"))
                     ),
                 )
             )

--- a/src/rigplane/audio/usb_driver.py
+++ b/src/rigplane/audio/usb_driver.py
@@ -24,6 +24,7 @@ from .backend import (
     PortAudioBackend,
     RxStream,
     TxStream,
+    _platform_uid_from_device_name,
 )
 
 logger = logging.getLogger(__name__)
@@ -160,28 +161,103 @@ def _name_score(name: str) -> int:
     return 99
 
 
+def _format_device_choices(devices: list[UsbAudioDevice]) -> str:
+    choices: list[str] = []
+    for dev in sorted(devices, key=lambda item: (item.index, item.name.lower())):
+        label = f"[{dev.index}] {dev.name}"
+        if dev.platform_uid:
+            label = f"{label} ({dev.platform_uid})"
+        choices.append(label)
+    return ", ".join(choices) or "<none>"
+
+
+def _unique_override_match(
+    matches: list[UsbAudioDevice],
+    *,
+    override: str,
+    direction: str,
+) -> UsbAudioDevice | None:
+    if len(matches) == 1:
+        return matches[0]
+    if len(matches) > 1:
+        available = _format_device_choices(matches)
+        raise AudioDeviceSelectionError(
+            f"Ambiguous {direction.upper()} device override {override!r}. "
+            f"Matching {direction.upper()} devices: {available}"
+        )
+    return None
+
+
 def _find_by_override(
     devices: list[UsbAudioDevice],
     *,
     override: str,
     direction: str,
 ) -> UsbAudioDevice:
-    if not override.strip():
+    selector = override.strip()
+    if not selector:
         raise AudioDeviceSelectionError(
             f"{direction.upper()} device override must be a non-empty string."
         )
-    exact = [dev for dev in devices if dev.name == override]
-    if len(exact) == 1:
-        return exact[0]
-    exact_ci = [dev for dev in devices if dev.name.lower() == override.lower()]
-    if len(exact_ci) == 1:
-        return exact_ci[0]
-    partial = [dev for dev in devices if override.lower() in dev.name.lower()]
-    if len(partial) == 1:
-        return partial[0]
-    available = ", ".join(sorted(dev.name for dev in devices)) or "<none>"
+
+    index_matches = [
+        dev
+        for dev in devices
+        if selector in {str(dev.index), f"[{dev.index}]", f"index:{dev.index}"}
+    ]
+    match = _unique_override_match(
+        index_matches,
+        override=selector,
+        direction=direction,
+    )
+    if match is not None:
+        return match
+
+    exact = [
+        dev
+        for dev in devices
+        if dev.name == selector or (dev.platform_uid and dev.platform_uid == selector)
+    ]
+    match = _unique_override_match(
+        exact,
+        override=selector,
+        direction=direction,
+    )
+    if match is not None:
+        return match
+
+    selector_ci = selector.lower()
+    exact_ci = [
+        dev
+        for dev in devices
+        if dev.name.lower() == selector_ci
+        or (dev.platform_uid and dev.platform_uid.lower() == selector_ci)
+    ]
+    match = _unique_override_match(
+        exact_ci,
+        override=selector,
+        direction=direction,
+    )
+    if match is not None:
+        return match
+
+    partial = [
+        dev
+        for dev in devices
+        if selector_ci in dev.name.lower()
+        or (dev.platform_uid and selector_ci in dev.platform_uid.lower())
+    ]
+    match = _unique_override_match(
+        partial,
+        override=selector,
+        direction=direction,
+    )
+    if match is not None:
+        return match
+
+    available = _format_device_choices(devices)
     raise AudioDeviceSelectionError(
-        f"Unknown {direction.upper()} device override {override!r}. "
+        f"Unknown {direction.upper()} device override {selector!r}. "
         f"Available {direction.upper()} devices: {available}"
     )
 
@@ -288,7 +364,11 @@ def _device_info_to_usb(
         default_samplerate=info.default_samplerate,
         is_default_input=info.is_default_input,
         is_default_output=info.is_default_output,
-        platform_uid=uid_map.get(info.name, ""),
+        platform_uid=(
+            info.platform_uid
+            or uid_map.get(info.name, "")
+            or _platform_uid_from_device_name(info.name)
+        ),
     )
 
 
@@ -334,7 +414,8 @@ def list_usb_audio_devices(sounddevice_module: Any) -> list[UsbAudioDevice]:
                 is_default_output=(
                     default_output_idx is not None and index == default_output_idx
                 ),
-                platform_uid=uid_map.get(name, ""),
+                platform_uid=uid_map.get(name, "")
+                or _platform_uid_from_device_name(name),
             )
         )
     return normalized

--- a/src/rigplane/backends/rigctld_client/observations.py
+++ b/src/rigplane/backends/rigctld_client/observations.py
@@ -210,7 +210,7 @@ class RigctldClientObservationAdapter:
 
     async def read_ptt(self) -> Observation:
         radio = self._require_radio()
-        return self._adapter().observation(
+        return self._observation(
             _PTT,
             await radio.get_ptt(),
             native_id="t",
@@ -218,7 +218,7 @@ class RigctldClientObservationAdapter:
 
     async def read_freq(self) -> Observation:
         radio = self._require_radio()
-        return self._adapter().observation(
+        return self._observation(
             _FREQ,
             await radio.get_freq(),
             native_id="f",
@@ -235,7 +235,7 @@ class RigctldClientObservationAdapter:
 
     async def read_rf_gain(self) -> Observation:
         radio = self._require_radio()
-        return self._adapter().observation(
+        return self._observation(
             _RF_GAIN,
             await radio.get_rf_gain(),
             native_id="l RF",
@@ -243,7 +243,7 @@ class RigctldClientObservationAdapter:
 
     async def read_af_level(self) -> Observation:
         radio = self._require_radio()
-        return self._adapter().observation(
+        return self._observation(
             _AF_LEVEL,
             await radio.get_af_level(),
             native_id="l AF",
@@ -251,7 +251,7 @@ class RigctldClientObservationAdapter:
 
     async def read_preamp(self) -> Observation:
         radio = self._require_radio()
-        return self._adapter().observation(
+        return self._observation(
             _PREAMP,
             await radio.get_preamp(),
             native_id="l PREAMP",
@@ -259,7 +259,7 @@ class RigctldClientObservationAdapter:
 
     async def read_attenuator(self) -> Observation:
         radio = self._require_radio()
-        return self._adapter().observation(
+        return self._observation(
             _ATT,
             await radio.get_attenuator_level(),
             native_id="l ATT",
@@ -267,7 +267,7 @@ class RigctldClientObservationAdapter:
 
     async def read_nb(self) -> Observation:
         radio = self._require_radio()
-        return self._adapter().observation(
+        return self._observation(
             _NB,
             await radio.get_nb(),
             native_id="u NB",
@@ -275,7 +275,7 @@ class RigctldClientObservationAdapter:
 
     async def read_nr(self) -> Observation:
         radio = self._require_radio()
-        return self._adapter().observation(
+        return self._observation(
             _NR,
             await radio.get_nr(),
             native_id="u NR",
@@ -295,7 +295,7 @@ class RigctldClientObservationAdapter:
         if not self.profile.capability_for(_ACTIVE_VFO).can_poll:
             return None
         radio = self._require_radio()
-        return self._adapter().observation(
+        return self._observation(
             _ACTIVE_VFO,
             await radio.get_vfo_slot(),
             native_id="v",
@@ -307,7 +307,7 @@ class RigctldClientObservationAdapter:
         *,
         value: object = None,
     ) -> Observation:
-        observation = self._adapter().command_response(intent, value=value)
+        observation = self._command_response_observation(intent, value=value)
         normalized_path = _normalize_command_path(observation.path)
         if normalized_path == observation.path:
             return observation
@@ -328,6 +328,31 @@ class RigctldClientObservationAdapter:
             transport="rigctld",
             clock=self.clock,
         )
+
+    def _observation(
+        self,
+        path: FieldPath,
+        value: object,
+        *,
+        native_id: str | None = None,
+    ) -> Observation:
+        adapter = self._adapter()
+        observation: Observation = adapter.observation(
+            path,
+            value,
+            native_id=native_id,
+        )
+        return observation
+
+    def _command_response_observation(
+        self,
+        intent: CommandIntent,
+        *,
+        value: object = None,
+    ) -> Observation:
+        adapter = self._adapter()
+        observation: Observation = adapter.command_response(intent, value=value)
+        return observation
 
     def _require_radio(self) -> RigctldObservationRadio:
         if self.radio is None:

--- a/src/rigplane/backends/rigctld_client/observations.py
+++ b/src/rigplane/backends/rigctld_client/observations.py
@@ -53,9 +53,19 @@ class RigctldObservationRadio(Protocol):
 
     async def get_mode(self, receiver: int = 0) -> tuple[str, int | None]: ...
 
+    async def get_ptt(self) -> bool: ...
+
     async def get_rf_gain(self, receiver: int = 0) -> int: ...
 
     async def get_af_level(self, receiver: int = 0) -> int: ...
+
+    async def get_preamp(self, receiver: int = 0) -> int: ...
+
+    async def get_attenuator_level(self, receiver: int = 0) -> int: ...
+
+    async def get_nb(self) -> bool: ...
+
+    async def get_nr(self) -> bool: ...
 
     async def get_vfo_slot(self, receiver: int = 0) -> str: ...
 
@@ -80,8 +90,12 @@ def build_external_rigctld_acquisition_profile(
         FieldCapability(
             path=_FILTER,
             polling=True,
-            command_response_observable=True,
+            command_response_observable=False,
             supported_controls=("set_mode",),
+            diagnostic=(
+                "External rigctld confirms filter width through get_mode polling "
+                "readback, not a direct command response"
+            ),
         ),
         FieldCapability(
             path=_PTT,
@@ -194,6 +208,14 @@ class RigctldClientObservationAdapter:
             await self.read_af_level(),
         )
 
+    async def read_ptt(self) -> Observation:
+        radio = self._require_radio()
+        return self._adapter().observation(
+            _PTT,
+            await radio.get_ptt(),
+            native_id="t",
+        )
+
     async def read_freq(self) -> Observation:
         radio = self._require_radio()
         return self._adapter().observation(
@@ -225,6 +247,48 @@ class RigctldClientObservationAdapter:
             _AF_LEVEL,
             await radio.get_af_level(),
             native_id="l AF",
+        )
+
+    async def read_preamp(self) -> Observation:
+        radio = self._require_radio()
+        return self._adapter().observation(
+            _PREAMP,
+            await radio.get_preamp(),
+            native_id="l PREAMP",
+        )
+
+    async def read_attenuator(self) -> Observation:
+        radio = self._require_radio()
+        return self._adapter().observation(
+            _ATT,
+            await radio.get_attenuator_level(),
+            native_id="l ATT",
+        )
+
+    async def read_nb(self) -> Observation:
+        radio = self._require_radio()
+        return self._adapter().observation(
+            _NB,
+            await radio.get_nb(),
+            native_id="u NB",
+        )
+
+    async def read_nr(self) -> Observation:
+        radio = self._require_radio()
+        return self._adapter().observation(
+            _NR,
+            await radio.get_nr(),
+            native_id="u NR",
+        )
+
+    async def read_slow_controls(self) -> tuple[Observation, ...]:
+        return (
+            await self.read_rf_gain(),
+            await self.read_af_level(),
+            await self.read_preamp(),
+            await self.read_attenuator(),
+            await self.read_nb(),
+            await self.read_nr(),
         )
 
     async def read_active_vfo(self) -> Observation | None:

--- a/src/rigplane/backends/rigctld_client/observations.py
+++ b/src/rigplane/backends/rigctld_client/observations.py
@@ -1,0 +1,279 @@
+"""Observation adapters for the external rigctld client backend."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Protocol
+
+from rigplane.core.observation_adapter import ProviderObservationAdapter
+from rigplane.core.state_acquisition_policy import (
+    AcquisitionPolicy,
+    FieldAvailability,
+    FieldCapability,
+    RadioAcquisitionProfile,
+)
+from rigplane.core.state_pipeline_contracts import (
+    CommandIntent,
+    FieldPath,
+    FieldScope,
+    Observation,
+)
+
+Clock = Callable[[], float]
+
+__all__ = [
+    "RigctldClientObservationAdapter",
+    "build_external_rigctld_acquisition_profile",
+]
+
+_FREQ = FieldPath.active("main", "freq_mode", "freq_hz")
+_MODE = FieldPath.active("main", "freq_mode", "mode")
+_FILTER = FieldPath.active("main", "freq_mode", "filter_width")
+_PTT = FieldPath.global_("tx_state", "ptt")
+_ACTIVE_VFO = FieldPath.active_slot("main")
+_RF_GAIN = FieldPath.receiver("main", "operator_controls", "rf_gain")
+_AF_LEVEL = FieldPath.receiver("main", "operator_controls", "af_level")
+_PREAMP = FieldPath.receiver("main", "operator_controls", "preamp")
+_ATT = FieldPath.receiver("main", "operator_controls", "att")
+_NB = FieldPath.receiver("main", "operator_toggles", "nb")
+_NR = FieldPath.receiver("main", "operator_toggles", "nr")
+_POWER = FieldPath.global_("tx_state", "power_on")
+_SLOW_CONTROL_POLICY = AcquisitionPolicy(
+    cadence_seconds=30.0,
+    freshness_ttl_seconds=120.0,
+)
+
+
+class RigctldObservationRadio(Protocol):
+    _vfo_supported: bool
+
+    async def get_freq(self, receiver: int = 0) -> int: ...
+
+    async def get_mode(self, receiver: int = 0) -> tuple[str, int | None]: ...
+
+    async def get_rf_gain(self, receiver: int = 0) -> int: ...
+
+    async def get_af_level(self, receiver: int = 0) -> int: ...
+
+    async def get_vfo_slot(self, receiver: int = 0) -> str: ...
+
+
+def build_external_rigctld_acquisition_profile(
+    *,
+    vfo_supported: bool,
+) -> RadioAcquisitionProfile:
+    capabilities = [
+        FieldCapability(
+            path=_FREQ,
+            polling=True,
+            command_response_observable=True,
+            supported_controls=("set_freq",),
+        ),
+        FieldCapability(
+            path=_MODE,
+            polling=True,
+            command_response_observable=True,
+            supported_controls=("set_mode",),
+        ),
+        FieldCapability(
+            path=_FILTER,
+            polling=True,
+            command_response_observable=True,
+            supported_controls=("set_mode",),
+        ),
+        FieldCapability(
+            path=_PTT,
+            polling=True,
+            command_response_observable=True,
+            supported_controls=("set_ptt",),
+        ),
+        FieldCapability(
+            path=_RF_GAIN,
+            polling=True,
+            command_response_observable=True,
+            supported_controls=("set_rf_gain",),
+        ),
+        FieldCapability(
+            path=_AF_LEVEL,
+            polling=True,
+            command_response_observable=True,
+            supported_controls=("set_af_level",),
+        ),
+        FieldCapability(
+            path=_PREAMP,
+            polling=True,
+            command_response_observable=True,
+            supported_controls=("set_preamp",),
+        ),
+        FieldCapability(
+            path=_ATT,
+            polling=True,
+            command_response_observable=True,
+            supported_controls=("set_attenuator", "set_attenuator_level"),
+        ),
+        FieldCapability(
+            path=_NB,
+            polling=True,
+            command_response_observable=True,
+            supported_controls=("set_nb",),
+        ),
+        FieldCapability(
+            path=_NR,
+            polling=True,
+            command_response_observable=True,
+            supported_controls=("set_nr",),
+        ),
+        FieldCapability(
+            path=_ACTIVE_VFO,
+            availability=(
+                FieldAvailability.SUPPORTED
+                if vfo_supported
+                else FieldAvailability.UNSUPPORTED
+            ),
+            polling=vfo_supported,
+            command_response_observable=vfo_supported,
+            supported_controls=("set_vfo_slot",) if vfo_supported else (),
+            diagnostic=(
+                ""
+                if vfo_supported
+                else "External rigctld does not expose VFO slot commands"
+            ),
+        ),
+        FieldCapability(
+            path=_POWER,
+            availability=FieldAvailability.UNSUPPORTED,
+            diagnostic="External rigctld does not expose power state",
+        ),
+    ]
+    return RadioAcquisitionProfile(
+        provider="external_rigctld",
+        capabilities=tuple(capabilities),
+        default_policy=AcquisitionPolicy(
+            cadence_seconds=2.0,
+            freshness_ttl_seconds=8.0,
+        ),
+        field_policies={
+            _RF_GAIN: _SLOW_CONTROL_POLICY,
+            _AF_LEVEL: _SLOW_CONTROL_POLICY,
+            _PREAMP: _SLOW_CONTROL_POLICY,
+            _ATT: _SLOW_CONTROL_POLICY,
+            _NB: _SLOW_CONTROL_POLICY,
+            _NR: _SLOW_CONTROL_POLICY,
+        },
+    )
+
+
+@dataclass(slots=True)
+class RigctldClientObservationAdapter:
+    """Collect backend-neutral observations from external rigctld reads."""
+
+    radio: RigctldObservationRadio | None
+    profile: RadioAcquisitionProfile
+    clock: Clock = time.monotonic
+
+    def __init__(
+        self,
+        radio: RigctldObservationRadio | None,
+        *,
+        profile: RadioAcquisitionProfile | None = None,
+        clock: Clock = time.monotonic,
+    ) -> None:
+        self.radio = radio
+        self.profile = profile or build_external_rigctld_acquisition_profile(
+            vfo_supported=bool(getattr(radio, "_vfo_supported", True))
+        )
+        self.clock = clock
+
+    async def read_freq_mode_controls(self) -> tuple[Observation, ...]:
+        return (
+            await self.read_freq(),
+            *(await self.read_mode()),
+            await self.read_rf_gain(),
+            await self.read_af_level(),
+        )
+
+    async def read_freq(self) -> Observation:
+        radio = self._require_radio()
+        return self._adapter().observation(
+            _FREQ,
+            await radio.get_freq(),
+            native_id="f",
+        )
+
+    async def read_mode(self) -> tuple[Observation, Observation]:
+        radio = self._require_radio()
+        mode, filter_width = await radio.get_mode()
+        adapter = self._adapter()
+        return (
+            adapter.observation(_MODE, mode, native_id="m"),
+            adapter.observation(_FILTER, filter_width, native_id="m"),
+        )
+
+    async def read_rf_gain(self) -> Observation:
+        radio = self._require_radio()
+        return self._adapter().observation(
+            _RF_GAIN,
+            await radio.get_rf_gain(),
+            native_id="l RF",
+        )
+
+    async def read_af_level(self) -> Observation:
+        radio = self._require_radio()
+        return self._adapter().observation(
+            _AF_LEVEL,
+            await radio.get_af_level(),
+            native_id="l AF",
+        )
+
+    async def read_active_vfo(self) -> Observation | None:
+        if not self.profile.capability_for(_ACTIVE_VFO).can_poll:
+            return None
+        radio = self._require_radio()
+        return self._adapter().observation(
+            _ACTIVE_VFO,
+            await radio.get_vfo_slot(),
+            native_id="v",
+        )
+
+    def command_response(
+        self,
+        intent: CommandIntent,
+        *,
+        value: object = None,
+    ) -> Observation:
+        observation = self._adapter().command_response(intent, value=value)
+        normalized_path = _normalize_command_path(observation.path)
+        if normalized_path == observation.path:
+            return observation
+        return Observation(
+            path=normalized_path,
+            value=observation.value,
+            source=observation.source,
+            timestamp_monotonic=observation.timestamp_monotonic,
+            quality=observation.quality,
+            correlation_id=observation.correlation_id,
+            max_age=self.profile.policy_for(normalized_path).freshness_ttl_seconds,
+        )
+
+    def _adapter(self) -> ProviderObservationAdapter:
+        return ProviderObservationAdapter(
+            profile=self.profile,
+            source="hamlib_response",
+            transport="rigctld",
+            clock=self.clock,
+        )
+
+    def _require_radio(self) -> RigctldObservationRadio:
+        if self.radio is None:
+            raise ValueError("radio is required for backend read observations")
+        return self.radio
+
+
+def _normalize_command_path(path: FieldPath) -> FieldPath:
+    if path.scope is not FieldScope.RECEIVER or path.receiver_id != "0":
+        return path
+    if path.family.value == "freq_mode" and path.slot is None:
+        return FieldPath.active("main", path.family.value, path.name)
+    return FieldPath.receiver("main", path.family.value, path.name)

--- a/src/rigplane/backends/yaesu_cat/observations.py
+++ b/src/rigplane/backends/yaesu_cat/observations.py
@@ -138,7 +138,11 @@ class YaesuObservationAdapter:
                     native_id="get_squelch",
                 )
             )
-        if self._has_runtime_capability("dual_rx") and self._can_poll(_SUB_AF):
+        if (
+            self._has_runtime_capability("dual_rx")
+            and self._has_runtime_capability("af_level")
+            and self._can_poll(_SUB_AF)
+        ):
             observations.append(
                 adapter.observation(
                     _SUB_AF,
@@ -146,7 +150,11 @@ class YaesuObservationAdapter:
                     native_id="get_af_level",
                 )
             )
-        if self._has_runtime_capability("dual_rx") and self._can_poll(_SUB_RF):
+        if (
+            self._has_runtime_capability("dual_rx")
+            and self._has_runtime_capability("rf_gain")
+            and self._can_poll(_SUB_RF)
+        ):
             observations.append(
                 adapter.observation(
                     _SUB_RF,
@@ -154,7 +162,11 @@ class YaesuObservationAdapter:
                     native_id="get_rf_gain",
                 )
             )
-        if self._has_runtime_capability("dual_rx") and self._can_poll(_SUB_SQL):
+        if (
+            self._has_runtime_capability("dual_rx")
+            and self._has_runtime_capability("squelch")
+            and self._can_poll(_SUB_SQL)
+        ):
             observations.append(
                 adapter.observation(
                     _SUB_SQL,

--- a/src/rigplane/backends/yaesu_cat/observations.py
+++ b/src/rigplane/backends/yaesu_cat/observations.py
@@ -61,7 +61,9 @@ class YaesuObservationAdapter:
     ) -> YaesuObservationAdapter:
         profile = getattr(radio, "profile").state_acquisition
         if profile is None:
-            raise ValueError("radio profile does not declare state_acquisition metadata")
+            raise ValueError(
+                "radio profile does not declare state_acquisition metadata"
+            )
         return cls(radio, profile=profile, clock=clock)
 
     async def poll_medium(self) -> tuple[Observation, ...]:

--- a/src/rigplane/backends/yaesu_cat/observations.py
+++ b/src/rigplane/backends/yaesu_cat/observations.py
@@ -1,0 +1,181 @@
+"""Observation adapters for Yaesu CAT polling reads."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Protocol
+
+from rigplane.core.observation_adapter import ProviderObservationAdapter
+from rigplane.core.state_acquisition_policy import RadioAcquisitionProfile
+from rigplane.core.state_pipeline_contracts import FieldPath, Observation
+
+Clock = Callable[[], float]
+
+__all__ = ["YaesuObservationAdapter"]
+
+_MAIN_FREQ = FieldPath.active("main", "freq_mode", "freq_hz")
+_MAIN_MODE = FieldPath.active("main", "freq_mode", "mode")
+_SUB_FREQ = FieldPath.active("sub", "freq_mode", "freq_hz")
+_SUB_MODE = FieldPath.active("sub", "freq_mode", "mode")
+_PTT = FieldPath.global_("tx_state", "ptt")
+_MAIN_AF = FieldPath.receiver("main", "operator_controls", "af_level")
+_MAIN_RF = FieldPath.receiver("main", "operator_controls", "rf_gain")
+_MAIN_SQL = FieldPath.receiver("main", "operator_controls", "squelch")
+_SUB_AF = FieldPath.receiver("sub", "operator_controls", "af_level")
+_SUB_RF = FieldPath.receiver("sub", "operator_controls", "rf_gain")
+_SUB_SQL = FieldPath.receiver("sub", "operator_controls", "squelch")
+
+
+class YaesuObservationRadio(Protocol):
+    capabilities: set[str]
+
+    async def get_freq(self, receiver: int = 0) -> int: ...
+
+    async def get_mode(self, receiver: int = 0) -> tuple[str, int | None]: ...
+
+    async def get_ptt(self) -> bool: ...
+
+    async def get_af_level(self, receiver: int = 0) -> int: ...
+
+    async def get_rf_gain(self, receiver: int = 0) -> int: ...
+
+    async def get_squelch(self, receiver: int = 0) -> int: ...
+
+
+@dataclass(slots=True)
+class YaesuObservationAdapter:
+    """Collect backend-neutral observations from Yaesu polling reads."""
+
+    radio: YaesuObservationRadio
+    profile: RadioAcquisitionProfile
+    clock: Clock = time.monotonic
+
+    @classmethod
+    def from_radio(
+        cls,
+        radio: YaesuObservationRadio,
+        *,
+        clock: Clock = time.monotonic,
+    ) -> YaesuObservationAdapter:
+        profile = getattr(radio, "profile").state_acquisition
+        if profile is None:
+            raise ValueError("radio profile does not declare state_acquisition metadata")
+        return cls(radio, profile=profile, clock=clock)
+
+    async def poll_medium(self) -> tuple[Observation, ...]:
+        adapter = self._adapter()
+        observations: list[Observation] = []
+        if self._can_poll(_MAIN_FREQ):
+            observations.append(
+                adapter.observation(
+                    _MAIN_FREQ,
+                    await self.radio.get_freq(0),
+                    native_id="get_freq",
+                )
+            )
+        if self._can_poll(_MAIN_MODE):
+            mode, _ = await self.radio.get_mode(0)
+            observations.append(
+                adapter.observation(
+                    _MAIN_MODE,
+                    mode,
+                    native_id="get_mode",
+                )
+            )
+        if self._has_runtime_capability("dual_rx") and self._can_poll(_SUB_FREQ):
+            observations.append(
+                adapter.observation(
+                    _SUB_FREQ,
+                    await self.radio.get_freq(1),
+                    native_id="get_freq",
+                )
+            )
+        if self._has_runtime_capability("dual_rx") and self._can_poll(_SUB_MODE):
+            mode, _ = await self.radio.get_mode(1)
+            observations.append(
+                adapter.observation(
+                    _SUB_MODE,
+                    mode,
+                    native_id="get_mode",
+                )
+            )
+        if self._can_poll(_PTT):
+            observations.append(
+                adapter.observation(
+                    _PTT,
+                    await self.radio.get_ptt(),
+                    native_id="get_ptt",
+                )
+            )
+        return tuple(observations)
+
+    async def poll_slow_controls(self) -> tuple[Observation, ...]:
+        adapter = self._adapter()
+        observations: list[Observation] = []
+        if self._has_runtime_capability("af_level") and self._can_poll(_MAIN_AF):
+            observations.append(
+                adapter.observation(
+                    _MAIN_AF,
+                    await self.radio.get_af_level(0),
+                    native_id="get_af_level",
+                )
+            )
+        if self._has_runtime_capability("rf_gain") and self._can_poll(_MAIN_RF):
+            observations.append(
+                adapter.observation(
+                    _MAIN_RF,
+                    await self.radio.get_rf_gain(0),
+                    native_id="get_rf_gain",
+                )
+            )
+        if self._has_runtime_capability("squelch") and self._can_poll(_MAIN_SQL):
+            observations.append(
+                adapter.observation(
+                    _MAIN_SQL,
+                    await self.radio.get_squelch(0),
+                    native_id="get_squelch",
+                )
+            )
+        if self._has_runtime_capability("dual_rx") and self._can_poll(_SUB_AF):
+            observations.append(
+                adapter.observation(
+                    _SUB_AF,
+                    await self.radio.get_af_level(1),
+                    native_id="get_af_level",
+                )
+            )
+        if self._has_runtime_capability("dual_rx") and self._can_poll(_SUB_RF):
+            observations.append(
+                adapter.observation(
+                    _SUB_RF,
+                    await self.radio.get_rf_gain(1),
+                    native_id="get_rf_gain",
+                )
+            )
+        if self._has_runtime_capability("dual_rx") and self._can_poll(_SUB_SQL):
+            observations.append(
+                adapter.observation(
+                    _SUB_SQL,
+                    await self.radio.get_squelch(1),
+                    native_id="get_squelch",
+                )
+            )
+        return tuple(observations)
+
+    def _adapter(self) -> ProviderObservationAdapter:
+        return ProviderObservationAdapter(
+            profile=self.profile,
+            source="yaesu_poll_response",
+            transport="serial",
+            clock=self.clock,
+        )
+
+    def _can_poll(self, path: FieldPath) -> bool:
+        capability = self.profile.capability_for(path)
+        return bool(capability.can_poll)
+
+    def _has_runtime_capability(self, capability: str) -> bool:
+        raw: object = getattr(self.radio, "capabilities", set())
+        return capability in raw if isinstance(raw, set) else False

--- a/src/rigplane/cli/__init__.py
+++ b/src/rigplane/cli/__init__.py
@@ -1751,6 +1751,7 @@ async def _cmd_list_audio_devices(args: argparse.Namespace) -> int:
                         "default_samplerate": d.default_samplerate,
                         "is_default_input": d.is_default_input,
                         "is_default_output": d.is_default_output,
+                        "platform_uid": d.platform_uid,
                     }
                     for d in devices
                 ]

--- a/src/rigplane/core/acquisition_scheduler.py
+++ b/src/rigplane/core/acquisition_scheduler.py
@@ -878,22 +878,31 @@ class MeterObservationCoalescer:
         return self._flush_samples(store, samples=samples)
 
     def flush_due(self, store: StateStore, *, now: float) -> ChangeSet | None:
-        """Flush pending samples whose individual coalescing windows elapsed."""
+        """Flush paths whose latest pending sample has aged past its window."""
 
-        due: list[_PendingMeterSample] = []
-        pending: list[_PendingMeterSample] = []
+        latest_by_path: dict[FieldPath, _PendingMeterSample] = {}
         for sample in self._pending:
+            latest_by_path[sample.observation.path] = sample
+
+        due_paths: set[FieldPath] = set()
+        for path, sample in latest_by_path.items():
             flush_at = (
                 sample.observation.timestamp_monotonic
                 + sample.policy.window_seconds
             )
             if flush_at <= now:
+                due_paths.add(path)
+
+        if not due_paths:
+            return None
+
+        due: list[_PendingMeterSample] = []
+        pending: list[_PendingMeterSample] = []
+        for sample in self._pending:
+            if sample.observation.path in due_paths:
                 due.append(sample)
             else:
                 pending.append(sample)
-
-        if not due:
-            return None
 
         self._pending = pending
         return self._flush_samples(store, samples=due)
@@ -939,10 +948,13 @@ class MeterObservationCoalescer:
 
         if not self._pending:
             return None
+        latest_by_path: dict[FieldPath, _PendingMeterSample] = {}
+        for sample in self._pending:
+            latest_by_path[sample.observation.path] = sample
         return float(
             min(
                 sample.observation.timestamp_monotonic + sample.policy.window_seconds
-                for sample in self._pending
+                for sample in latest_by_path.values()
             )
         )
 

--- a/src/rigplane/core/acquisition_scheduler.py
+++ b/src/rigplane/core/acquisition_scheduler.py
@@ -46,6 +46,7 @@ __all__ = [
     "MeterObservationCoalescer",
     "RadioStateModelService",
     "StateFreshnessService",
+    "civ_acquisition_executor_for_provider",
 ]
 
 
@@ -221,10 +222,11 @@ _GLOBAL_METER_QUERY_SUBS: dict[str, int] = {
     "swr": 0x12,
     "alc": 0x13,
 }
+_CIV_ACQUISITION_PROVIDERS = frozenset(("icom_civ", "xiegu_civ"))
 
 
 class IcomCivAcquisitionExecutor:
-    """CI-V path-to-query executor for Icom acquisition profiles."""
+    """CI-V path-to-query executor for compatible CI-V acquisition profiles."""
 
     __slots__ = ("_send_query",)
 
@@ -293,6 +295,17 @@ class IcomCivAcquisitionExecutor:
         return None
 
 
+def civ_acquisition_executor_for_provider(
+    provider: str,
+    send_query: AcquisitionQuerySender,
+) -> AcquisitionExecutor | None:
+    """Return the shared CI-V executor for providers using this query envelope."""
+
+    if provider not in _CIV_ACQUISITION_PROVIDERS:
+        return None
+    return IcomCivAcquisitionExecutor(send_query)
+
+
 _PRIORITY_RANK: dict[AcquisitionPriority, int] = {
     AcquisitionPriority.BACKGROUND: 0,
     AcquisitionPriority.RECONCILIATION: 1,
@@ -347,7 +360,8 @@ class AcquisitionScheduler:
     def provider(self) -> str:
         """Return the backend/provider id declared by the acquisition profile."""
 
-        return self._profile.provider
+        provider: str = self._profile.provider
+        return provider
 
     def ensure_fresh(
         self,

--- a/src/rigplane/core/acquisition_scheduler.py
+++ b/src/rigplane/core/acquisition_scheduler.py
@@ -120,6 +120,16 @@ class _PendingEnsureFresh:
     external_cat_owner: str | None
 
 
+@dataclass(frozen=True, slots=True)
+class _AcquisitionRequestKey:
+    scope: str
+    family: str
+    receiver_id: str | None
+    slot: str | None
+    acquisition_method: AcquisitionMethod
+    policy: AcquisitionPolicy
+
+
 _PRIORITY_RANK: dict[AcquisitionPriority, int] = {
     AcquisitionPriority.BACKGROUND: 0,
     AcquisitionPriority.RECONCILIATION: 1,
@@ -151,7 +161,7 @@ class AcquisitionScheduler:
     ) -> None:
         self._profile = profile
         self._clock = clock or FreshnessClock()
-        self._requests_by_key: dict[tuple[FieldPath, ...], AcquisitionRequest] = {}
+        self._requests_by_key: dict[_AcquisitionRequestKey, AcquisitionRequest] = {}
         self._deferred: dict[tuple[FieldPath, ...], _PendingEnsureFresh] = {}
         self._next_id = 1
         self._external_cat_paused = False
@@ -281,31 +291,56 @@ class AcquisitionScheduler:
         requested_at: float,
         external_cat_owner: str | None,
     ) -> AcquisitionRequest:
-        key = paths
-        existing = self._requests_by_key.get(key)
-        if existing is not None:
-            request = self._coalesce(
-                existing,
+        queued: list[AcquisitionRequest] = []
+        for key, grouped_paths in self._request_groups(paths):
+            existing = self._requests_by_key.get(key)
+            if existing is not None:
+                request = self._coalesce(
+                    existing,
+                    paths=grouped_paths,
+                    max_age=max_age,
+                    priority=priority,
+                    reason=reason,
+                    timeout=timeout,
+                    requested_at=requested_at,
+                )
+                self._requests_by_key[key] = request
+                queued.append(request)
+                continue
+
+            request = self._new_request(
+                paths=grouped_paths,
                 max_age=max_age,
                 priority=priority,
                 reason=reason,
                 timeout=timeout,
                 requested_at=requested_at,
+                external_cat_owner=external_cat_owner,
+                acquisition_method=key.acquisition_method,
+                policy=key.policy,
             )
             self._requests_by_key[key] = request
-            return request
+            queued.append(request)
+        return queued[0]
 
-        request = self._new_request(
-            paths=paths,
-            max_age=max_age,
-            priority=priority,
-            reason=reason,
-            timeout=timeout,
-            requested_at=requested_at,
-            external_cat_owner=external_cat_owner,
+    def _request_groups(
+        self,
+        paths: tuple[FieldPath, ...],
+    ) -> tuple[tuple[_AcquisitionRequestKey, tuple[FieldPath, ...]], ...]:
+        grouped: dict[_AcquisitionRequestKey, list[FieldPath]] = {}
+        for path in paths:
+            capability = self._profile.capability_for(path)
+            policy = self._profile.policy_for(path)
+            key = _request_key(
+                path,
+                acquisition_method=_capability_method(capability),
+                policy=policy,
+            )
+            grouped.setdefault(key, []).append(path)
+        return tuple(
+            (key, tuple(sorted(group_paths, key=str)))
+            for key, group_paths in grouped.items()
         )
-        self._requests_by_key[key] = request
-        return request
 
     def _new_request(
         self,
@@ -317,11 +352,11 @@ class AcquisitionScheduler:
         timeout: float | None,
         requested_at: float,
         external_cat_owner: str | None,
+        acquisition_method: AcquisitionMethod,
+        policy: AcquisitionPolicy,
     ) -> AcquisitionRequest:
-        capabilities = tuple(self._profile.capability_for(path) for path in paths)
         request_id = f"acq-{self._next_id}"
         self._next_id += 1
-        method = _select_method(capabilities)
         return AcquisitionRequest(
             id=request_id,
             paths=paths,
@@ -333,8 +368,8 @@ class AcquisitionScheduler:
             max_age=max_age,
             timeout=timeout,
             provider=self._profile.provider,
-            acquisition_method=method,
-            policy=self._merged_policy(paths),
+            acquisition_method=acquisition_method,
+            policy=policy,
             capability_ids=tuple(str(path) for path in paths),
             external_cat_paused=self._external_cat_paused,
             external_cat_owner=external_cat_owner,
@@ -348,6 +383,7 @@ class AcquisitionScheduler:
         self,
         existing: AcquisitionRequest,
         *,
+        paths: tuple[FieldPath, ...],
         max_age: float,
         priority: AcquisitionPriority,
         reason: str,
@@ -363,13 +399,20 @@ class AcquisitionScheduler:
         if reason not in reasons:
             reasons = (*reasons, reason)
         deadline = min(existing.deadline_monotonic, requested_at + max_age)
+        merged_paths = _merge_paths(existing.paths, paths)
         return replace(
             existing,
+            paths=merged_paths,
             priority=priority_to_keep,
             max_age=min(existing.max_age, max_age),
             timeout=_min_optional_timeout(existing.timeout, timeout),
             deadline_monotonic=deadline,
             reasons=reasons,
+            capability_ids=tuple(str(path) for path in merged_paths),
+            source_metadata={
+                "provider": self._profile.provider,
+                "capabilityId": ",".join(str(path) for path in merged_paths),
+            },
         )
 
     def _defer(self, item: _PendingEnsureFresh) -> None:
@@ -431,10 +474,6 @@ class AcquisitionScheduler:
             return True
         return False
 
-    def _merged_policy(self, paths: Sequence[FieldPath]) -> AcquisitionPolicy:
-        return self._profile.policy_for(paths[0])
-
-
 class RadioStateModelService:
     """Small service API joining StateStore freshness and scheduler requests."""
 
@@ -473,6 +512,10 @@ class RadioStateModelService:
             except KeyError:
                 break
             if field.freshness is not FreshnessState.FRESH:
+                break
+            if field.max_age is not None and now - field.last_observed_monotonic > (
+                field.max_age
+            ):
                 break
             if now - field.last_observed_monotonic > max_age:
                 break
@@ -521,12 +564,37 @@ def _has_acquisition_hook(capability: FieldCapability) -> bool:
     )
 
 
-def _select_method(capabilities: Sequence[FieldCapability]) -> AcquisitionMethod:
-    if any(capability.can_poll for capability in capabilities):
+def _request_key(
+    path: FieldPath,
+    *,
+    acquisition_method: AcquisitionMethod,
+    policy: AcquisitionPolicy,
+) -> _AcquisitionRequestKey:
+    return _AcquisitionRequestKey(
+        scope=path.scope.value,
+        family=path.family.value,
+        receiver_id=path.receiver_id,
+        slot=None if path.slot is None else path.slot.value,
+        acquisition_method=acquisition_method,
+        policy=policy,
+    )
+
+
+def _capability_method(capability: FieldCapability) -> AcquisitionMethod:
+    if capability.can_poll:
         return "poll"
-    if any(capability.command_response_observable for capability in capabilities):
+    if capability.command_response_observable:
         return "command_response"
-    return "wait_for_unsolicited"
+    if capability.unsolicited_push:
+        return "wait_for_unsolicited"
+    raise ValueError(f"{capability.path}: no acquisition hook is declared")
+
+
+def _merge_paths(
+    left: tuple[FieldPath, ...],
+    right: tuple[FieldPath, ...],
+) -> tuple[FieldPath, ...]:
+    return tuple(sorted({*left, *right}, key=str))
 
 
 def _min_optional_timeout(left: float | None, right: float | None) -> float | None:

--- a/src/rigplane/core/acquisition_scheduler.py
+++ b/src/rigplane/core/acquisition_scheduler.py
@@ -273,10 +273,7 @@ class IcomCivAcquisitionExecutor:
             if path.name == "s_meter":
                 return (0x15, 0x02, receiver)
             return None
-        if (
-            path.scope.value == "receiver"
-            and path.family.value == "operator_controls"
-        ):
+        if path.scope.value == "receiver" and path.family.value == "operator_controls":
             sub = _RECEIVER_LEVEL_QUERY_SUBS.get(path.name)
             return None if sub is None else (0x14, sub, receiver)
         if path.scope.value == "global" and path.family.value == "meters":
@@ -286,10 +283,7 @@ class IcomCivAcquisitionExecutor:
             if path.name == "ptt":
                 return (0x1C, 0x00, None)
             return None
-        if (
-            path.scope.value == "global"
-            and path.family.value == "operator_controls"
-        ):
+        if path.scope.value == "global" and path.family.value == "operator_controls":
             sub = _GLOBAL_LEVEL_QUERY_SUBS.get(path.name)
             return None if sub is None else (0x14, sub, None)
         return None
@@ -461,7 +455,9 @@ class AcquisitionScheduler:
             )
         )
 
-    def due_requests(self, *, now: float | None = None) -> tuple[AcquisitionRequest, ...]:
+    def due_requests(
+        self, *, now: float | None = None
+    ) -> tuple[AcquisitionRequest, ...]:
         """Queue and return policy-cadence poll requests that are due."""
 
         timestamp = self._clock.now() if now is None else now
@@ -551,9 +547,7 @@ class AcquisitionScheduler:
         pending_cadence = self._pending_cadence_by_key.get(key)
         if matched_pending_request and remaining_paths:
             if pending_cadence is not None and pending_cadence.request_id == request.id:
-                semantic_changed = (
-                    semantic_changed or pending_cadence.semantic_changed
-                )
+                semantic_changed = semantic_changed or pending_cadence.semantic_changed
             self._pending_cadence_by_key[key] = _PendingCadenceUpdate(
                 request_id=request.id,
                 semantic_changed=semantic_changed,
@@ -613,7 +607,9 @@ class AcquisitionScheduler:
         )
         existing = self._requests_by_key.get(key)
         if existing is not None and existing.id == request.id:
-            remaining_paths = tuple(path for path in existing.paths if path not in failed)
+            remaining_paths = tuple(
+                path for path in existing.paths if path not in failed
+            )
             if remaining_paths:
                 self._requests_by_key[key] = self._replace_request_paths(
                     existing,
@@ -751,9 +747,7 @@ class AcquisitionScheduler:
     ) -> tuple[AcquisitionRequest, ...]:
         request_reasons = (reason,) if reasons is None else reasons
         request_deadline = (
-            requested_at + max_age
-            if deadline_monotonic is None
-            else deadline_monotonic
+            requested_at + max_age if deadline_monotonic is None else deadline_monotonic
         )
         return self._queue_grouped(
             groups=self._request_groups(paths),
@@ -782,9 +776,7 @@ class AcquisitionScheduler:
     ) -> tuple[AcquisitionRequest, ...]:
         request_reasons = (reason,) if reasons is None else reasons
         request_deadline = (
-            requested_at + max_age
-            if deadline_monotonic is None
-            else deadline_monotonic
+            requested_at + max_age if deadline_monotonic is None else deadline_monotonic
         )
         queued: list[AcquisitionRequest] = []
         for key, grouped_paths in groups:
@@ -860,10 +852,7 @@ class AcquisitionScheduler:
                 policy=policy,
             )
             grouped.setdefault(key, []).append(capability.path)
-        return {
-            key: tuple(sorted(paths, key=str))
-            for key, paths in grouped.items()
-        }
+        return {key: tuple(sorted(paths, key=str)) for key, paths in grouped.items()}
 
     def _cadence_state_for(
         self,
@@ -1105,7 +1094,9 @@ class MeterObservationCoalescer:
         if observation.path.family.value != "meters":
             raise ValueError(f"{observation.path}: meter coalescing requires meters")
 
-        self._pending.append(_PendingMeterSample(observation=observation, policy=policy))
+        self._pending.append(
+            _PendingMeterSample(observation=observation, policy=policy)
+        )
         if policy.max_samples is None:
             return
         overflow = len(self._pending) - policy.max_samples
@@ -1134,8 +1125,7 @@ class MeterObservationCoalescer:
         due_paths: set[FieldPath] = set()
         for path, sample in latest_by_path.items():
             flush_at = (
-                sample.observation.timestamp_monotonic
-                + sample.policy.window_seconds
+                sample.observation.timestamp_monotonic + sample.policy.window_seconds
             )
             if flush_at <= now:
                 due_paths.add(path)
@@ -1216,9 +1206,7 @@ class MeterObservationCoalescer:
 
         return {
             "pendingSampleCount": len(self._pending),
-            "pendingPaths": [
-                str(sample.observation.path) for sample in self._pending
-            ],
+            "pendingPaths": [str(sample.observation.path) for sample in self._pending],
             "droppedSampleCount": self._dropped_sample_count,
             "coalescedSampleCount": self._coalesced_sample_count,
             "nextFlushMonotonic": self.next_flush_monotonic(),
@@ -1427,10 +1415,7 @@ def _capability_method(
     for method in methods:
         if method == "poll" and capability.can_poll:
             return "poll"
-        if (
-            method == "command_response"
-            and capability.command_response_observable
-        ):
+        if method == "command_response" and capability.command_response_observable:
             return "command_response"
         if method == "wait_for_unsolicited" and capability.unsolicited_push:
             return "wait_for_unsolicited"

--- a/src/rigplane/core/acquisition_scheduler.py
+++ b/src/rigplane/core/acquisition_scheduler.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, replace
 from enum import StrEnum
-from typing import Any, Literal
+from typing import Any, Callable, Literal
 
 from rigplane.core.state_acquisition_policy import (
     AcquisitionPolicy,
@@ -27,6 +28,8 @@ from rigplane.core.state_store import (
     FieldSnapshot,
     FreshnessClock,
     FreshnessState,
+    ReconciliationRequest,
+    SnapshotDelta,
     StateStore,
 )
 
@@ -39,6 +42,7 @@ __all__ = [
     "EnsureFreshResult",
     "MeterObservationCoalescer",
     "RadioStateModelService",
+    "StateFreshnessService",
 ]
 
 
@@ -166,6 +170,7 @@ _PRIORITY_RANK: dict[AcquisitionPriority, int] = {
     AcquisitionPriority.COMMAND: 3,
     AcquisitionPriority.USER: 4,
 }
+_MIN_RECONCILIATION_MAX_AGE = 1e-9
 
 
 class AcquisitionScheduler:
@@ -1014,6 +1019,60 @@ class MeterObservationCoalescer:
             "coalescedSampleCount": self._coalesced_sample_count,
             "nextFlushMonotonic": self.next_flush_monotonic(),
         }
+
+
+class StateFreshnessService:
+    """Advance StateStore freshness and enqueue reconciliation requests."""
+
+    __slots__ = ("_interval_seconds", "_on_delta", "_scheduler", "_store")
+
+    def __init__(
+        self,
+        *,
+        store: StateStore,
+        scheduler: AcquisitionScheduler | None = None,
+        interval_seconds: float = 0.05,
+        on_delta: Callable[[SnapshotDelta], None] | None = None,
+    ) -> None:
+        _validate_positive(interval_seconds, label="interval_seconds")
+        self._store = store
+        self._scheduler = scheduler
+        self._interval_seconds = interval_seconds
+        self._on_delta = on_delta
+
+    def tick(self, *, now: float | None = None) -> SnapshotDelta:
+        """Advance stale fields once and queue reconciliation through scheduler."""
+
+        delta = self._store.mark_stale_due(now=now)
+        for request in delta.reconciliation_requests:
+            self._queue_reconciliation(request)
+        if (delta.freshness or delta.reconciliation_requests) and self._on_delta:
+            self._on_delta(delta)
+        return delta
+
+    async def run(self) -> None:
+        """Run the periodic freshness loop until cancelled by the host."""
+
+        try:
+            while True:
+                await asyncio.sleep(self._interval_seconds)
+                self.tick()
+        except asyncio.CancelledError:
+            pass
+
+    def _queue_reconciliation(self, request: ReconciliationRequest) -> None:
+        scheduler = self._scheduler
+        if scheduler is None:
+            return
+        max_age = request.max_age
+        if max_age is None or max_age <= 0:
+            max_age = _MIN_RECONCILIATION_MAX_AGE
+        scheduler.ensure_fresh(
+            (request.path,),
+            max_age=max_age,
+            priority=AcquisitionPriority.RECONCILIATION,
+            reason=request.reason,
+        )
 
 
 class RadioStateModelService:

--- a/src/rigplane/core/acquisition_scheduler.py
+++ b/src/rigplane/core/acquisition_scheduler.py
@@ -142,6 +142,12 @@ class _CadenceState:
 
 
 @dataclass(frozen=True, slots=True)
+class _PendingCadenceUpdate:
+    request_id: str
+    semantic_changed: bool
+
+
+@dataclass(frozen=True, slots=True)
 class _PendingMeterSample:
     observation: Observation
     policy: MeterCoalescingPolicy
@@ -167,6 +173,7 @@ class AcquisitionScheduler:
         "_external_cat_paused",
         "_external_cat_reason",
         "_next_id",
+        "_pending_cadence_by_key",
         "_profile",
         "_requests_by_key",
     )
@@ -182,6 +189,10 @@ class AcquisitionScheduler:
         self._requests_by_key: dict[_AcquisitionRequestKey, AcquisitionRequest] = {}
         self._deferred: dict[_AcquisitionRequestKey, _PendingEnsureFresh] = {}
         self._cadence_by_key: dict[_AcquisitionRequestKey, _CadenceState] = {}
+        self._pending_cadence_by_key: dict[
+            _AcquisitionRequestKey,
+            _PendingCadenceUpdate,
+        ] = {}
         self._next_id = 1
         self._external_cat_paused = False
         self._external_cat_owner: str | None = None
@@ -345,7 +356,10 @@ class AcquisitionScheduler:
             policy=request.policy,
         )
         existing = self._requests_by_key.get(key)
+        matched_pending_request = False
+        remaining_paths: tuple[FieldPath, ...] = ()
         if existing is not None and existing.id == request.id:
+            matched_pending_request = True
             completed_paths = frozenset(request.paths)
             remaining_paths = tuple(
                 path for path in existing.paths if path not in completed_paths
@@ -361,16 +375,34 @@ class AcquisitionScheduler:
 
         base_cadence = request.policy.cadence_seconds
         if base_cadence is None:
+            if matched_pending_request and not remaining_paths:
+                self._pending_cadence_by_key.pop(key, None)
             return
+
+        requested_paths = frozenset(request.paths)
+        semantic_changed = any(
+            change.path in requested_paths for change in change_set.changes
+        )
+        pending_cadence = self._pending_cadence_by_key.get(key)
+        if matched_pending_request and remaining_paths:
+            if pending_cadence is not None and pending_cadence.request_id == request.id:
+                semantic_changed = (
+                    semantic_changed or pending_cadence.semantic_changed
+                )
+            self._pending_cadence_by_key[key] = _PendingCadenceUpdate(
+                request_id=request.id,
+                semantic_changed=semantic_changed,
+            )
+            return
+
+        if pending_cadence is not None and pending_cadence.request_id == request.id:
+            semantic_changed = semantic_changed or pending_cadence.semantic_changed
+            del self._pending_cadence_by_key[key]
 
         previous = self._cadence_state_for(
             key,
             request.policy,
             now=change_set.timestamp_monotonic,
-        )
-        requested_paths = frozenset(request.paths)
-        semantic_changed = any(
-            change.path in requested_paths for change in change_set.changes
         )
         if semantic_changed or not request.policy.adaptive_decay.enabled:
             current_cadence = base_cadence

--- a/src/rigplane/core/acquisition_scheduler.py
+++ b/src/rigplane/core/acquisition_scheduler.py
@@ -13,6 +13,7 @@ from rigplane.core.state_acquisition_policy import (
     FieldAvailability,
     FieldCapability,
     RadioAcquisitionProfile,
+    ReconciliationPriority,
 )
 from rigplane.core.state_pipeline_contracts import FieldPath
 from rigplane.core.state_store import (
@@ -115,8 +116,10 @@ class _PendingEnsureFresh:
     max_age: float
     priority: AcquisitionPriority
     reason: str
+    reasons: tuple[str, ...]
     timeout: float | None
     requested_at_monotonic: float
+    deadline_monotonic: float
     external_cat_owner: str | None
 
 
@@ -162,7 +165,7 @@ class AcquisitionScheduler:
         self._profile = profile
         self._clock = clock or FreshnessClock()
         self._requests_by_key: dict[_AcquisitionRequestKey, AcquisitionRequest] = {}
-        self._deferred: dict[tuple[FieldPath, ...], _PendingEnsureFresh] = {}
+        self._deferred: dict[_AcquisitionRequestKey, _PendingEnsureFresh] = {}
         self._next_id = 1
         self._external_cat_paused = False
         self._external_cat_owner: str | None = None
@@ -188,37 +191,68 @@ class AcquisitionScheduler:
         if availability is not None:
             return availability
 
-        if self._external_cat_paused and self._must_defer_for_external_cat(
-            normalized_paths
-        ):
-            self._defer(
-                _PendingEnsureFresh(
-                    paths=normalized_paths,
-                    max_age=max_age,
-                    priority=normalized_priority,
-                    reason=reason,
-                    timeout=timeout,
-                    requested_at_monotonic=now,
-                    external_cat_owner=self._external_cat_owner,
+        if self._external_cat_paused:
+            queued: list[AcquisitionRequest] = []
+            deferred = False
+            for key, grouped_paths in self._request_groups(normalized_paths):
+                if self._must_defer_for_external_cat(grouped_paths):
+                    deferred = True
+                    self._defer(
+                        key,
+                        _PendingEnsureFresh(
+                            paths=grouped_paths,
+                            max_age=max_age,
+                            priority=normalized_priority,
+                            reason=reason,
+                            reasons=(reason,),
+                            timeout=timeout,
+                            requested_at_monotonic=now,
+                            deadline_monotonic=now + max_age,
+                            external_cat_owner=self._external_cat_owner,
+                        ),
+                    )
+                    continue
+                queued.extend(
+                    self._queue(
+                        paths=grouped_paths,
+                        max_age=max_age,
+                        priority=normalized_priority,
+                        reason=reason,
+                        timeout=timeout,
+                        requested_at=now,
+                        external_cat_owner=self._external_cat_owner,
+                    )
                 )
-            )
-            return EnsureFreshResult(
-                status=AcquisitionStatus.DEFERRED,
-                message=self._external_cat_reason or "external CAT ownership active",
-            )
+            if queued:
+                return EnsureFreshResult(
+                    status=AcquisitionStatus.QUEUED,
+                    request=queued[0],
+                )
+            if deferred:
+                return EnsureFreshResult(
+                    status=AcquisitionStatus.DEFERRED,
+                    message=self._external_cat_reason
+                    or "external CAT ownership active",
+                )
 
-        request = self._queue(
+        queued_requests = self._queue(
             paths=normalized_paths,
             max_age=max_age,
             priority=normalized_priority,
             reason=reason,
             timeout=timeout,
             requested_at=now,
-            external_cat_owner=self._external_cat_owner
-            if self._external_cat_paused
-            else None,
+            external_cat_owner=None,
         )
-        return EnsureFreshResult(status=AcquisitionStatus.QUEUED, request=request)
+        if not queued_requests:
+            return EnsureFreshResult(
+                status=AcquisitionStatus.DEFERRED,
+                message=self._external_cat_reason or "external CAT ownership active",
+            )
+        return EnsureFreshResult(
+            status=AcquisitionStatus.QUEUED,
+            request=queued_requests[0],
+        )
 
     def pending_requests(self) -> tuple[AcquisitionRequest, ...]:
         """Return queued backend acquisition requests in execution order."""
@@ -267,15 +301,17 @@ class AcquisitionScheduler:
         self._deferred.clear()
         queued: list[AcquisitionRequest] = []
         for item in deferred:
-            queued.append(
+            queued.extend(
                 self._queue(
                     paths=item.paths,
                     max_age=item.max_age,
                     priority=item.priority,
                     reason=item.reason,
+                    reasons=item.reasons,
                     timeout=item.timeout,
-                    requested_at=self._clock.now(),
+                    requested_at=item.requested_at_monotonic,
                     external_cat_owner=item.external_cat_owner or owner,
+                    deadline_monotonic=item.deadline_monotonic,
                 )
             )
         return tuple(queued)
@@ -290,7 +326,15 @@ class AcquisitionScheduler:
         timeout: float | None,
         requested_at: float,
         external_cat_owner: str | None,
-    ) -> AcquisitionRequest:
+        reasons: tuple[str, ...] | None = None,
+        deadline_monotonic: float | None = None,
+    ) -> tuple[AcquisitionRequest, ...]:
+        request_reasons = (reason,) if reasons is None else reasons
+        request_deadline = (
+            requested_at + max_age
+            if deadline_monotonic is None
+            else deadline_monotonic
+        )
         queued: list[AcquisitionRequest] = []
         for key, grouped_paths in self._request_groups(paths):
             existing = self._requests_by_key.get(key)
@@ -301,8 +345,10 @@ class AcquisitionScheduler:
                     max_age=max_age,
                     priority=priority,
                     reason=reason,
+                    reasons=request_reasons,
                     timeout=timeout,
                     requested_at=requested_at,
+                    deadline_monotonic=request_deadline,
                 )
                 self._requests_by_key[key] = request
                 queued.append(request)
@@ -318,10 +364,12 @@ class AcquisitionScheduler:
                 external_cat_owner=external_cat_owner,
                 acquisition_method=key.acquisition_method,
                 policy=key.policy,
+                reasons=request_reasons,
+                deadline_monotonic=request_deadline,
             )
             self._requests_by_key[key] = request
             queued.append(request)
-        return queued[0]
+        return tuple(queued)
 
     def _request_groups(
         self,
@@ -333,7 +381,7 @@ class AcquisitionScheduler:
             policy = self._profile.policy_for(path)
             key = _request_key(
                 path,
-                acquisition_method=_capability_method(capability),
+                acquisition_method=_capability_method(capability, policy),
                 policy=policy,
             )
             grouped.setdefault(key, []).append(path)
@@ -354,6 +402,8 @@ class AcquisitionScheduler:
         external_cat_owner: str | None,
         acquisition_method: AcquisitionMethod,
         policy: AcquisitionPolicy,
+        reasons: tuple[str, ...],
+        deadline_monotonic: float,
     ) -> AcquisitionRequest:
         request_id = f"acq-{self._next_id}"
         self._next_id += 1
@@ -362,9 +412,9 @@ class AcquisitionScheduler:
             paths=paths,
             priority=priority,
             reason=reason,
-            reasons=(reason,),
+            reasons=reasons,
             requested_at_monotonic=requested_at,
-            deadline_monotonic=requested_at + max_age,
+            deadline_monotonic=deadline_monotonic,
             max_age=max_age,
             timeout=timeout,
             provider=self._profile.provider,
@@ -387,18 +437,21 @@ class AcquisitionScheduler:
         max_age: float,
         priority: AcquisitionPriority,
         reason: str,
+        reasons: tuple[str, ...],
         timeout: float | None,
         requested_at: float,
+        deadline_monotonic: float,
     ) -> AcquisitionRequest:
         priority_to_keep = (
             priority
             if _PRIORITY_RANK[priority] > _PRIORITY_RANK[existing.priority]
             else existing.priority
         )
-        reasons = existing.reasons
-        if reason not in reasons:
-            reasons = (*reasons, reason)
-        deadline = min(existing.deadline_monotonic, requested_at + max_age)
+        merged_reasons = existing.reasons
+        for candidate in reasons:
+            if candidate not in merged_reasons:
+                merged_reasons = (*merged_reasons, candidate)
+        deadline = min(existing.deadline_monotonic, deadline_monotonic)
         merged_paths = _merge_paths(existing.paths, paths)
         return replace(
             existing,
@@ -407,7 +460,7 @@ class AcquisitionScheduler:
             max_age=min(existing.max_age, max_age),
             timeout=_min_optional_timeout(existing.timeout, timeout),
             deadline_monotonic=deadline,
-            reasons=reasons,
+            reasons=merged_reasons,
             capability_ids=tuple(str(path) for path in merged_paths),
             source_metadata={
                 "provider": self._profile.provider,
@@ -415,10 +468,14 @@ class AcquisitionScheduler:
             },
         )
 
-    def _defer(self, item: _PendingEnsureFresh) -> None:
-        existing = self._deferred.get(item.paths)
+    def _defer(
+        self,
+        key: _AcquisitionRequestKey,
+        item: _PendingEnsureFresh,
+    ) -> None:
+        existing = self._deferred.get(key)
         if existing is None:
-            self._deferred[item.paths] = item
+            self._deferred[key] = item
             return
         priority = (
             item.priority
@@ -428,15 +485,24 @@ class AcquisitionScheduler:
         max_age = min(existing.max_age, item.max_age)
         timeout = _min_optional_timeout(existing.timeout, item.timeout)
         reason = existing.reason if existing.reason == item.reason else item.reason
-        self._deferred[item.paths] = _PendingEnsureFresh(
-            paths=item.paths,
+        reasons = existing.reasons
+        for candidate in item.reasons:
+            if candidate not in reasons:
+                reasons = (*reasons, candidate)
+        self._deferred[key] = _PendingEnsureFresh(
+            paths=_merge_paths(existing.paths, item.paths),
             max_age=max_age,
             priority=priority,
             reason=reason,
+            reasons=reasons,
             timeout=timeout,
             requested_at_monotonic=min(
                 existing.requested_at_monotonic,
                 item.requested_at_monotonic,
+            ),
+            deadline_monotonic=min(
+                existing.deadline_monotonic,
+                item.deadline_monotonic,
             ),
             external_cat_owner=item.external_cat_owner or existing.external_cat_owner,
         )
@@ -473,6 +539,7 @@ class AcquisitionScheduler:
                     continue
             return True
         return False
+
 
 class RadioStateModelService:
     """Small service API joining StateStore freshness and scheduler requests."""
@@ -580,13 +647,33 @@ def _request_key(
     )
 
 
-def _capability_method(capability: FieldCapability) -> AcquisitionMethod:
-    if capability.can_poll:
-        return "poll"
-    if capability.command_response_observable:
-        return "command_response"
-    if capability.unsolicited_push:
-        return "wait_for_unsolicited"
+def _capability_method(
+    capability: FieldCapability,
+    policy: AcquisitionPolicy,
+) -> AcquisitionMethod:
+    preferred = ReconciliationPriority(str(policy.reconciliation_priority))
+    methods_by_priority: dict[ReconciliationPriority, tuple[AcquisitionMethod, ...]] = {
+        ReconciliationPriority.POLL: ("poll",),
+        ReconciliationPriority.COMMAND_RESPONSE: ("command_response",),
+        ReconciliationPriority.UNSOLICITED: ("wait_for_unsolicited",),
+        ReconciliationPriority.LAST_OBSERVATION: (),
+    }
+    fallback_methods: tuple[AcquisitionMethod, ...] = (
+        "poll",
+        "command_response",
+        "wait_for_unsolicited",
+    )
+    methods = (*methods_by_priority[preferred], *fallback_methods)
+    for method in methods:
+        if method == "poll" and capability.can_poll:
+            return "poll"
+        if (
+            method == "command_response"
+            and capability.command_response_observable
+        ):
+            return "command_response"
+        if method == "wait_for_unsolicited" and capability.unsolicited_push:
+            return "wait_for_unsolicited"
     raise ValueError(f"{capability.path}: no acquisition hook is declared")
 
 

--- a/src/rigplane/core/acquisition_scheduler.py
+++ b/src/rigplane/core/acquisition_scheduler.py
@@ -5,17 +5,18 @@ from __future__ import annotations
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, replace
 from enum import StrEnum
-from typing import Literal
+from typing import Any, Literal
 
 from rigplane.core.state_acquisition_policy import (
     AcquisitionPolicy,
     ExternalCatPauseBehavior,
     FieldAvailability,
     FieldCapability,
+    MeterCoalescingPolicy,
     RadioAcquisitionProfile,
     ReconciliationPriority,
 )
-from rigplane.core.state_pipeline_contracts import FieldPath
+from rigplane.core.state_pipeline_contracts import ChangeSet, FieldPath, Observation
 from rigplane.core.state_store import (
     FieldSnapshot,
     FreshnessClock,
@@ -30,6 +31,7 @@ __all__ = [
     "AcquisitionScheduler",
     "AcquisitionStatus",
     "EnsureFreshResult",
+    "MeterObservationCoalescer",
     "RadioStateModelService",
 ]
 
@@ -133,6 +135,18 @@ class _AcquisitionRequestKey:
     policy: AcquisitionPolicy
 
 
+@dataclass(frozen=True, slots=True)
+class _CadenceState:
+    current_cadence_seconds: float
+    next_due_monotonic: float
+
+
+@dataclass(frozen=True, slots=True)
+class _PendingMeterSample:
+    observation: Observation
+    policy: MeterCoalescingPolicy
+
+
 _PRIORITY_RANK: dict[AcquisitionPriority, int] = {
     AcquisitionPriority.BACKGROUND: 0,
     AcquisitionPriority.RECONCILIATION: 1,
@@ -147,6 +161,7 @@ class AcquisitionScheduler:
 
     __slots__ = (
         "_clock",
+        "_cadence_by_key",
         "_deferred",
         "_external_cat_owner",
         "_external_cat_paused",
@@ -166,6 +181,7 @@ class AcquisitionScheduler:
         self._clock = clock or FreshnessClock()
         self._requests_by_key: dict[_AcquisitionRequestKey, AcquisitionRequest] = {}
         self._deferred: dict[_AcquisitionRequestKey, _PendingEnsureFresh] = {}
+        self._cadence_by_key: dict[_AcquisitionRequestKey, _CadenceState] = {}
         self._next_id = 1
         self._external_cat_paused = False
         self._external_cat_owner: str | None = None
@@ -269,6 +285,134 @@ class AcquisitionScheduler:
             )
         )
 
+    def due_requests(self, *, now: float | None = None) -> tuple[AcquisitionRequest, ...]:
+        """Queue and return policy-cadence poll requests that are due."""
+
+        timestamp = self._clock.now() if now is None else now
+        groups = self._due_poll_groups(timestamp)
+        queued: list[AcquisitionRequest] = []
+        for key, grouped_paths in groups:
+            policy = key.policy
+            assert policy.cadence_seconds is not None
+            max_age = (
+                policy.freshness_ttl_seconds
+                if policy.freshness_ttl_seconds is not None
+                else policy.cadence_seconds
+            )
+            if self._external_cat_paused and self._must_defer_for_external_cat(
+                grouped_paths
+            ):
+                self._defer(
+                    key,
+                    _PendingEnsureFresh(
+                        paths=grouped_paths,
+                        max_age=max_age,
+                        priority=AcquisitionPriority.BACKGROUND,
+                        reason="policy-cadence",
+                        reasons=("policy-cadence",),
+                        timeout=None,
+                        requested_at_monotonic=timestamp,
+                        deadline_monotonic=timestamp + max_age,
+                        external_cat_owner=self._external_cat_owner,
+                    ),
+                )
+                continue
+            queued.extend(
+                self._queue_grouped(
+                    groups=((key, grouped_paths),),
+                    max_age=max_age,
+                    priority=AcquisitionPriority.BACKGROUND,
+                    reason="policy-cadence",
+                    timeout=None,
+                    requested_at=timestamp,
+                    external_cat_owner=self._external_cat_owner,
+                )
+            )
+        return tuple(queued)
+
+    poll_due_requests = due_requests
+
+    def record_acquisition_result(
+        self,
+        request: AcquisitionRequest,
+        change_set: ChangeSet,
+    ) -> None:
+        """Update adaptive cadence state after a backend acquisition completes."""
+
+        key = _request_key(
+            request.paths[0],
+            acquisition_method=request.acquisition_method,
+            policy=request.policy,
+        )
+        existing = self._requests_by_key.get(key)
+        if existing is not None and existing.id == request.id:
+            del self._requests_by_key[key]
+
+        base_cadence = request.policy.cadence_seconds
+        if base_cadence is None:
+            return
+
+        previous = self._cadence_state_for(
+            key,
+            request.policy,
+            now=change_set.timestamp_monotonic,
+        )
+        requested_paths = frozenset(request.paths)
+        semantic_changed = any(
+            change.path in requested_paths for change in change_set.changes
+        )
+        if semantic_changed or not request.policy.adaptive_decay.enabled:
+            current_cadence = base_cadence
+        else:
+            current_cadence = (
+                previous.current_cadence_seconds
+                * request.policy.adaptive_decay.idle_multiplier
+            )
+            max_cadence = request.policy.adaptive_decay.max_cadence_seconds
+            if max_cadence is not None:
+                current_cadence = min(current_cadence, max_cadence)
+        self._cadence_by_key[key] = _CadenceState(
+            current_cadence_seconds=current_cadence,
+            next_due_monotonic=change_set.timestamp_monotonic + current_cadence,
+        )
+
+    def diagnostics(self) -> dict[str, Any]:
+        """Return a JSON-safe scheduler projection for diagnostics surfaces."""
+
+        now = self._clock.now()
+        cadence_by_path: dict[str, dict[str, Any]] = {}
+        cadence_by_group: dict[str, dict[str, Any]] = {}
+        for key, paths in self._poll_cadence_groups().items():
+            policy = key.policy
+            if policy.cadence_seconds is None:
+                continue
+            state = self._cadence_state_for(key, policy, now=now)
+            group_key = _diagnostic_group_key(key)
+            payload = {
+                "paths": [str(path) for path in paths],
+                "baseCadenceSeconds": policy.cadence_seconds,
+                "currentCadenceSeconds": state.current_cadence_seconds,
+                "nextDueMonotonic": state.next_due_monotonic,
+            }
+            cadence_by_group[group_key] = payload
+            for path in paths:
+                cadence_by_path[str(path)] = {
+                    "group": group_key,
+                    "baseCadenceSeconds": policy.cadence_seconds,
+                    "currentCadenceSeconds": state.current_cadence_seconds,
+                    "nextDueMonotonic": state.next_due_monotonic,
+                }
+
+        return {
+            "queuedRequestCount": len(self._requests_by_key),
+            "deferredRequestCount": len(self._deferred),
+            "cadenceByPath": cadence_by_path,
+            "cadenceByGroup": cadence_by_group,
+            "requestPressureByPriorityFamily": self._request_pressure(),
+        }
+
+    to_diagnostics = diagnostics
+
     def pause_external_cat(
         self,
         *,
@@ -353,8 +497,39 @@ class AcquisitionScheduler:
             if deadline_monotonic is None
             else deadline_monotonic
         )
+        return self._queue_grouped(
+            groups=self._request_groups(paths),
+            max_age=max_age,
+            priority=priority,
+            reason=reason,
+            timeout=timeout,
+            requested_at=requested_at,
+            external_cat_owner=external_cat_owner,
+            reasons=request_reasons,
+            deadline_monotonic=request_deadline,
+        )
+
+    def _queue_grouped(
+        self,
+        *,
+        groups: tuple[tuple[_AcquisitionRequestKey, tuple[FieldPath, ...]], ...],
+        max_age: float,
+        priority: AcquisitionPriority,
+        reason: str,
+        timeout: float | None,
+        requested_at: float,
+        external_cat_owner: str | None,
+        reasons: tuple[str, ...] | None = None,
+        deadline_monotonic: float | None = None,
+    ) -> tuple[AcquisitionRequest, ...]:
+        request_reasons = (reason,) if reasons is None else reasons
+        request_deadline = (
+            requested_at + max_age
+            if deadline_monotonic is None
+            else deadline_monotonic
+        )
         queued: list[AcquisitionRequest] = []
-        for key, grouped_paths in self._request_groups(paths):
+        for key, grouped_paths in groups:
             existing = self._requests_by_key.get(key)
             if existing is not None:
                 request = self._coalesce(
@@ -388,6 +563,81 @@ class AcquisitionScheduler:
             self._requests_by_key[key] = request
             queued.append(request)
         return tuple(queued)
+
+    def _due_poll_groups(
+        self,
+        now: float,
+    ) -> tuple[tuple[_AcquisitionRequestKey, tuple[FieldPath, ...]], ...]:
+        due: list[tuple[_AcquisitionRequestKey, FieldPath]] = []
+        for key, paths in self._poll_cadence_groups().items():
+            policy = key.policy
+            if policy.cadence_seconds is None:
+                continue
+            state = self._cadence_state_for(key, policy, now=now)
+            if state.next_due_monotonic <= now:
+                due.extend((key, path) for path in paths)
+
+        grouped: dict[_AcquisitionRequestKey, list[FieldPath]] = {}
+        for key, path in due:
+            grouped.setdefault(key, []).append(path)
+        return tuple(
+            (key, tuple(sorted(paths, key=str))) for key, paths in grouped.items()
+        )
+
+    def _poll_cadence_groups(
+        self,
+    ) -> dict[_AcquisitionRequestKey, tuple[FieldPath, ...]]:
+        grouped: dict[_AcquisitionRequestKey, list[FieldPath]] = {}
+        for capability in self._profile.capabilities:
+            if not capability.can_poll:
+                continue
+            policy = self._profile.policy_for(capability.path)
+            if policy.cadence_seconds is None:
+                continue
+            key = _request_key(
+                capability.path,
+                acquisition_method="poll",
+                policy=policy,
+            )
+            grouped.setdefault(key, []).append(capability.path)
+        return {
+            key: tuple(sorted(paths, key=str))
+            for key, paths in grouped.items()
+        }
+
+    def _cadence_state_for(
+        self,
+        key: _AcquisitionRequestKey,
+        policy: AcquisitionPolicy,
+        *,
+        now: float,
+    ) -> _CadenceState:
+        existing = self._cadence_by_key.get(key)
+        if existing is not None:
+            return existing
+        assert policy.cadence_seconds is not None
+        state = _CadenceState(
+            current_cadence_seconds=policy.cadence_seconds,
+            next_due_monotonic=now,
+        )
+        self._cadence_by_key[key] = state
+        return state
+
+    def _request_pressure(self) -> dict[str, int]:
+        pressure: dict[str, int] = {}
+        for request in self._requests_by_key.values():
+            _add_pressure(
+                pressure,
+                priority=request.priority,
+                family=request.paths[0].family.value,
+            )
+        for item in self._deferred.values():
+            _add_pressure(
+                pressure,
+                priority=item.priority,
+                family=item.paths[0].family.value,
+            )
+        return pressure
 
     def _request_groups(
         self,
@@ -559,6 +809,100 @@ class AcquisitionScheduler:
         return False
 
 
+class MeterObservationCoalescer:
+    """Coalesce short-window meter observations before StateStore apply."""
+
+    __slots__ = ("_coalesced_sample_count", "_dropped_sample_count", "_pending")
+
+    def __init__(self) -> None:
+        self._pending: list[_PendingMeterSample] = []
+        self._dropped_sample_count = 0
+        self._coalesced_sample_count = 0
+
+    def record(
+        self,
+        observation: Observation,
+        policy: MeterCoalescingPolicy,
+    ) -> None:
+        """Record one meter observation under its coalescing policy."""
+
+        if observation.path.family.value != "meters":
+            raise ValueError(f"{observation.path}: meter coalescing requires meters")
+
+        self._pending.append(_PendingMeterSample(observation=observation, policy=policy))
+        if policy.max_samples is None:
+            return
+        overflow = len(self._pending) - policy.max_samples
+        if overflow <= 0:
+            return
+        del self._pending[:overflow]
+        self._dropped_sample_count += overflow
+
+    def flush(self, store: StateStore) -> ChangeSet | None:
+        """Apply latest pending sample per path and return one coalesced ChangeSet."""
+
+        if not self._pending:
+            return None
+
+        latest_by_path: dict[FieldPath, Observation] = {}
+        for sample in self._pending:
+            latest_by_path[sample.observation.path] = sample.observation
+        self._coalesced_sample_count += len(self._pending) - len(latest_by_path)
+
+        changes = []
+        sources = []
+        result: ChangeSet | None = None
+        for observation in sorted(latest_by_path.values(), key=lambda item: str(item.path)):
+            result = store.apply(observation)
+            changes.extend(result.changes)
+            sources.extend(result.sources)
+
+        self._pending.clear()
+        assert result is not None
+        return ChangeSet(
+            revision=result.revision,
+            freshness_revision=result.freshness_revision,
+            observation_seq=result.observation_seq,
+            changes=tuple(changes),
+            timestamp_monotonic=result.timestamp_monotonic,
+            sources=tuple(sources),
+            coalesced=True,
+        )
+
+    def flush_due(self, store: StateStore, *, now: float) -> ChangeSet | None:
+        """Flush only when the oldest pending coalescing window has elapsed."""
+
+        next_flush = self.next_flush_monotonic()
+        if next_flush is None or now < next_flush:
+            return None
+        return self.flush(store)
+
+    def next_flush_monotonic(self) -> float | None:
+        """Return the earliest monotonic time at which pending samples should flush."""
+
+        if not self._pending:
+            return None
+        return float(
+            min(
+                sample.observation.timestamp_monotonic + sample.policy.window_seconds
+                for sample in self._pending
+            )
+        )
+
+    def diagnostics(self) -> dict[str, Any]:
+        """Return JSON-safe coalescing counters."""
+
+        return {
+            "pendingSampleCount": len(self._pending),
+            "pendingPaths": [
+                str(sample.observation.path) for sample in self._pending
+            ],
+            "droppedSampleCount": self._dropped_sample_count,
+            "coalescedSampleCount": self._coalesced_sample_count,
+            "nextFlushMonotonic": self.next_flush_monotonic(),
+        }
+
+
 class RadioStateModelService:
     """Small service API joining StateStore freshness and scheduler requests."""
 
@@ -663,6 +1007,27 @@ def _request_key(
         acquisition_method=acquisition_method,
         policy=policy,
     )
+
+
+def _diagnostic_group_key(key: _AcquisitionRequestKey) -> str:
+    parts = [
+        key.scope,
+        key.family,
+        "" if key.receiver_id is None else key.receiver_id,
+        "" if key.slot is None else key.slot,
+        key.acquisition_method,
+    ]
+    return ":".join(parts)
+
+
+def _add_pressure(
+    pressure: dict[str, int],
+    *,
+    priority: AcquisitionPriority,
+    family: str,
+) -> None:
+    key = f"{priority.value}:{family}"
+    pressure[key] = pressure.get(key, 0) + 1
 
 
 def _capability_method(

--- a/src/rigplane/core/acquisition_scheduler.py
+++ b/src/rigplane/core/acquisition_scheduler.py
@@ -346,7 +346,18 @@ class AcquisitionScheduler:
         )
         existing = self._requests_by_key.get(key)
         if existing is not None and existing.id == request.id:
-            del self._requests_by_key[key]
+            completed_paths = frozenset(request.paths)
+            remaining_paths = tuple(
+                path for path in existing.paths if path not in completed_paths
+            )
+            if remaining_paths:
+                if remaining_paths != existing.paths:
+                    self._requests_by_key[key] = self._replace_request_paths(
+                        existing,
+                        paths=remaining_paths,
+                    )
+            else:
+                del self._requests_by_key[key]
 
         base_cadence = request.policy.cadence_seconds
         if base_cadence is None:
@@ -570,6 +581,8 @@ class AcquisitionScheduler:
     ) -> tuple[tuple[_AcquisitionRequestKey, tuple[FieldPath, ...]], ...]:
         due: list[tuple[_AcquisitionRequestKey, FieldPath]] = []
         for key, paths in self._poll_cadence_groups().items():
+            if key in self._requests_by_key or key in self._deferred:
+                continue
             policy = key.policy
             if policy.cadence_seconds is None:
                 continue
@@ -736,6 +749,22 @@ class AcquisitionScheduler:
             },
         )
 
+    def _replace_request_paths(
+        self,
+        request: AcquisitionRequest,
+        *,
+        paths: tuple[FieldPath, ...],
+    ) -> AcquisitionRequest:
+        return replace(
+            request,
+            paths=paths,
+            capability_ids=tuple(str(path) for path in paths),
+            source_metadata={
+                "provider": self._profile.provider,
+                "capabilityId": ",".join(str(path) for path in paths),
+            },
+        )
+
     def _defer(
         self,
         key: _AcquisitionRequestKey,
@@ -844,38 +873,66 @@ class MeterObservationCoalescer:
         if not self._pending:
             return None
 
-        latest_by_path: dict[FieldPath, Observation] = {}
+        samples = self._pending
+        self._pending = []
+        return self._flush_samples(store, samples=samples)
+
+    def flush_due(self, store: StateStore, *, now: float) -> ChangeSet | None:
+        """Flush pending samples whose individual coalescing windows elapsed."""
+
+        due: list[_PendingMeterSample] = []
+        pending: list[_PendingMeterSample] = []
         for sample in self._pending:
+            flush_at = (
+                sample.observation.timestamp_monotonic
+                + sample.policy.window_seconds
+            )
+            if flush_at <= now:
+                due.append(sample)
+            else:
+                pending.append(sample)
+
+        if not due:
+            return None
+
+        self._pending = pending
+        return self._flush_samples(store, samples=due)
+
+    def _flush_samples(
+        self,
+        store: StateStore,
+        *,
+        samples: Sequence[_PendingMeterSample],
+    ) -> ChangeSet:
+        latest_by_path: dict[FieldPath, Observation] = {}
+        for sample in samples:
             latest_by_path[sample.observation.path] = sample.observation
-        self._coalesced_sample_count += len(self._pending) - len(latest_by_path)
+        self._coalesced_sample_count += len(samples) - len(latest_by_path)
 
         changes = []
         sources = []
         result: ChangeSet | None = None
-        for observation in sorted(latest_by_path.values(), key=lambda item: str(item.path)):
+        timestamp_monotonic = max(
+            observation.timestamp_monotonic for observation in latest_by_path.values()
+        )
+        for observation in sorted(
+            latest_by_path.values(),
+            key=lambda item: str(item.path),
+        ):
             result = store.apply(observation)
             changes.extend(result.changes)
             sources.extend(result.sources)
 
-        self._pending.clear()
         assert result is not None
         return ChangeSet(
             revision=result.revision,
             freshness_revision=result.freshness_revision,
             observation_seq=result.observation_seq,
             changes=tuple(changes),
-            timestamp_monotonic=result.timestamp_monotonic,
+            timestamp_monotonic=timestamp_monotonic,
             sources=tuple(sources),
             coalesced=True,
         )
-
-    def flush_due(self, store: StateStore, *, now: float) -> ChangeSet | None:
-        """Flush only when the oldest pending coalescing window has elapsed."""
-
-        next_flush = self.next_flush_monotonic()
-        if next_flush is None or now < next_flush:
-            return None
-        return self.flush(store)
 
     def next_flush_monotonic(self) -> float | None:
         """Return the earliest monotonic time at which pending samples should flush."""

--- a/src/rigplane/core/acquisition_scheduler.py
+++ b/src/rigplane/core/acquisition_scheduler.py
@@ -280,6 +280,24 @@ class AcquisitionScheduler:
         self._external_cat_paused = True
         self._external_cat_owner = owner
         self._external_cat_reason = reason
+        for key, request in tuple(self._requests_by_key.items()):
+            if not self._must_defer_for_external_cat(request.paths):
+                continue
+            del self._requests_by_key[key]
+            self._defer(
+                key,
+                _PendingEnsureFresh(
+                    paths=request.paths,
+                    max_age=request.max_age,
+                    priority=request.priority,
+                    reason=request.reason,
+                    reasons=request.reasons,
+                    timeout=request.timeout,
+                    requested_at_monotonic=request.requested_at_monotonic,
+                    deadline_monotonic=request.deadline_monotonic,
+                    external_cat_owner=owner,
+                ),
+            )
 
     def resume_external_cat(self) -> tuple[AcquisitionRequest, ...]:
         """Resume acquisition and queue any deferred freshness requests."""

--- a/src/rigplane/core/acquisition_scheduler.py
+++ b/src/rigplane/core/acquisition_scheduler.py
@@ -1,0 +1,537 @@
+"""Backend-neutral acquisition scheduling for state freshness repair."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass, replace
+from enum import StrEnum
+from typing import Literal
+
+from rigplane.core.state_acquisition_policy import (
+    AcquisitionPolicy,
+    ExternalCatPauseBehavior,
+    FieldAvailability,
+    FieldCapability,
+    RadioAcquisitionProfile,
+)
+from rigplane.core.state_pipeline_contracts import FieldPath
+from rigplane.core.state_store import (
+    FieldSnapshot,
+    FreshnessClock,
+    FreshnessState,
+    StateStore,
+)
+
+__all__ = [
+    "AcquisitionMethod",
+    "AcquisitionPriority",
+    "AcquisitionRequest",
+    "AcquisitionScheduler",
+    "AcquisitionStatus",
+    "EnsureFreshResult",
+    "RadioStateModelService",
+]
+
+
+AcquisitionMethod = Literal["poll", "command_response", "wait_for_unsolicited"]
+
+
+class AcquisitionPriority(StrEnum):
+    """Scheduler priority classes for backend acquisition requests."""
+
+    BACKGROUND = "background"
+    RECONCILIATION = "reconciliation"
+    NORMAL = "normal"
+    COMMAND = "command"
+    USER = "user"
+
+
+class AcquisitionStatus(StrEnum):
+    """Result of an ensure-fresh request."""
+
+    FRESH = "fresh"
+    QUEUED = "queued"
+    DEFERRED = "deferred"
+    UNAVAILABLE = "unavailable"
+
+
+@dataclass(frozen=True, slots=True)
+class AcquisitionRequest:
+    """One backend-neutral acquisition request emitted by the scheduler."""
+
+    id: str
+    paths: tuple[FieldPath, ...]
+    priority: AcquisitionPriority
+    reason: str
+    reasons: tuple[str, ...]
+    requested_at_monotonic: float
+    deadline_monotonic: float
+    max_age: float
+    timeout: float | None
+    provider: str
+    acquisition_method: AcquisitionMethod
+    policy: AcquisitionPolicy
+    capability_ids: tuple[str, ...]
+    external_cat_paused: bool = False
+    external_cat_owner: str | None = None
+    source_metadata: dict[str, str | None] | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a stable serializable projection for diagnostics/executors."""
+
+        return {
+            "id": self.id,
+            "paths": [str(path) for path in self.paths],
+            "priority": self.priority.value,
+            "reason": self.reason,
+            "reasons": list(self.reasons),
+            "requestedAtMonotonic": self.requested_at_monotonic,
+            "deadlineMonotonic": self.deadline_monotonic,
+            "maxAge": self.max_age,
+            "timeout": self.timeout,
+            "provider": self.provider,
+            "acquisitionMethod": self.acquisition_method,
+            "policy": self.policy.to_dict(),
+            "capabilityIds": list(self.capability_ids),
+            "externalCatPaused": self.external_cat_paused,
+            "externalCatOwner": self.external_cat_owner,
+            "sourceMetadata": self.source_metadata,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class EnsureFreshResult:
+    """Model-service result for a freshness request."""
+
+    status: AcquisitionStatus
+    fields: tuple[FieldSnapshot, ...] = ()
+    request: AcquisitionRequest | None = None
+    message: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class _PendingEnsureFresh:
+    paths: tuple[FieldPath, ...]
+    max_age: float
+    priority: AcquisitionPriority
+    reason: str
+    timeout: float | None
+    requested_at_monotonic: float
+    external_cat_owner: str | None
+
+
+_PRIORITY_RANK: dict[AcquisitionPriority, int] = {
+    AcquisitionPriority.BACKGROUND: 0,
+    AcquisitionPriority.RECONCILIATION: 1,
+    AcquisitionPriority.NORMAL: 2,
+    AcquisitionPriority.COMMAND: 3,
+    AcquisitionPriority.USER: 4,
+}
+
+
+class AcquisitionScheduler:
+    """Minimal priority/dedupe queue for backend-neutral acquisition reads."""
+
+    __slots__ = (
+        "_clock",
+        "_deferred",
+        "_external_cat_owner",
+        "_external_cat_paused",
+        "_external_cat_reason",
+        "_next_id",
+        "_profile",
+        "_requests_by_key",
+    )
+
+    def __init__(
+        self,
+        *,
+        profile: RadioAcquisitionProfile,
+        clock: FreshnessClock | None = None,
+    ) -> None:
+        self._profile = profile
+        self._clock = clock or FreshnessClock()
+        self._requests_by_key: dict[tuple[FieldPath, ...], AcquisitionRequest] = {}
+        self._deferred: dict[tuple[FieldPath, ...], _PendingEnsureFresh] = {}
+        self._next_id = 1
+        self._external_cat_paused = False
+        self._external_cat_owner: str | None = None
+        self._external_cat_reason = ""
+
+    def ensure_fresh(
+        self,
+        paths: FieldPath | str | Iterable[FieldPath | str],
+        *,
+        max_age: float,
+        priority: AcquisitionPriority | str,
+        reason: str,
+        timeout: float | None = None,
+    ) -> EnsureFreshResult:
+        """Queue acquisition for one or more field paths if policy allows it."""
+
+        normalized_paths = _normalize_paths(paths)
+        _validate_positive(max_age, label="max_age")
+        normalized_priority = AcquisitionPriority(str(priority))
+        now = self._clock.now()
+
+        availability = self._availability_for(normalized_paths)
+        if availability is not None:
+            return availability
+
+        if self._external_cat_paused and self._must_defer_for_external_cat(
+            normalized_paths
+        ):
+            self._defer(
+                _PendingEnsureFresh(
+                    paths=normalized_paths,
+                    max_age=max_age,
+                    priority=normalized_priority,
+                    reason=reason,
+                    timeout=timeout,
+                    requested_at_monotonic=now,
+                    external_cat_owner=self._external_cat_owner,
+                )
+            )
+            return EnsureFreshResult(
+                status=AcquisitionStatus.DEFERRED,
+                message=self._external_cat_reason or "external CAT ownership active",
+            )
+
+        request = self._queue(
+            paths=normalized_paths,
+            max_age=max_age,
+            priority=normalized_priority,
+            reason=reason,
+            timeout=timeout,
+            requested_at=now,
+            external_cat_owner=self._external_cat_owner
+            if self._external_cat_paused
+            else None,
+        )
+        return EnsureFreshResult(status=AcquisitionStatus.QUEUED, request=request)
+
+    def pending_requests(self) -> tuple[AcquisitionRequest, ...]:
+        """Return queued backend acquisition requests in execution order."""
+
+        return tuple(
+            sorted(
+                self._requests_by_key.values(),
+                key=lambda request: (
+                    -_PRIORITY_RANK[request.priority],
+                    request.deadline_monotonic,
+                    request.requested_at_monotonic,
+                    request.id,
+                ),
+            )
+        )
+
+    def pause_external_cat(
+        self,
+        *,
+        owner: str | None = None,
+        reason: str = "",
+    ) -> None:
+        """Pause conflicting polling while an external CAT owner has control."""
+
+        self._external_cat_paused = True
+        self._external_cat_owner = owner
+        self._external_cat_reason = reason
+
+    def resume_external_cat(self) -> tuple[AcquisitionRequest, ...]:
+        """Resume acquisition and queue any deferred freshness requests."""
+
+        owner = self._external_cat_owner
+        self._external_cat_paused = False
+        self._external_cat_owner = None
+        self._external_cat_reason = ""
+        deferred = tuple(
+            sorted(
+                self._deferred.values(),
+                key=lambda item: (
+                    -_PRIORITY_RANK[item.priority],
+                    item.requested_at_monotonic,
+                    ",".join(str(path) for path in item.paths),
+                ),
+            )
+        )
+        self._deferred.clear()
+        queued: list[AcquisitionRequest] = []
+        for item in deferred:
+            queued.append(
+                self._queue(
+                    paths=item.paths,
+                    max_age=item.max_age,
+                    priority=item.priority,
+                    reason=item.reason,
+                    timeout=item.timeout,
+                    requested_at=self._clock.now(),
+                    external_cat_owner=item.external_cat_owner or owner,
+                )
+            )
+        return tuple(queued)
+
+    def _queue(
+        self,
+        *,
+        paths: tuple[FieldPath, ...],
+        max_age: float,
+        priority: AcquisitionPriority,
+        reason: str,
+        timeout: float | None,
+        requested_at: float,
+        external_cat_owner: str | None,
+    ) -> AcquisitionRequest:
+        key = paths
+        existing = self._requests_by_key.get(key)
+        if existing is not None:
+            request = self._coalesce(
+                existing,
+                max_age=max_age,
+                priority=priority,
+                reason=reason,
+                timeout=timeout,
+                requested_at=requested_at,
+            )
+            self._requests_by_key[key] = request
+            return request
+
+        request = self._new_request(
+            paths=paths,
+            max_age=max_age,
+            priority=priority,
+            reason=reason,
+            timeout=timeout,
+            requested_at=requested_at,
+            external_cat_owner=external_cat_owner,
+        )
+        self._requests_by_key[key] = request
+        return request
+
+    def _new_request(
+        self,
+        *,
+        paths: tuple[FieldPath, ...],
+        max_age: float,
+        priority: AcquisitionPriority,
+        reason: str,
+        timeout: float | None,
+        requested_at: float,
+        external_cat_owner: str | None,
+    ) -> AcquisitionRequest:
+        capabilities = tuple(self._profile.capability_for(path) for path in paths)
+        request_id = f"acq-{self._next_id}"
+        self._next_id += 1
+        method = _select_method(capabilities)
+        return AcquisitionRequest(
+            id=request_id,
+            paths=paths,
+            priority=priority,
+            reason=reason,
+            reasons=(reason,),
+            requested_at_monotonic=requested_at,
+            deadline_monotonic=requested_at + max_age,
+            max_age=max_age,
+            timeout=timeout,
+            provider=self._profile.provider,
+            acquisition_method=method,
+            policy=self._merged_policy(paths),
+            capability_ids=tuple(str(path) for path in paths),
+            external_cat_paused=self._external_cat_paused,
+            external_cat_owner=external_cat_owner,
+            source_metadata={
+                "provider": self._profile.provider,
+                "capabilityId": ",".join(str(path) for path in paths),
+            },
+        )
+
+    def _coalesce(
+        self,
+        existing: AcquisitionRequest,
+        *,
+        max_age: float,
+        priority: AcquisitionPriority,
+        reason: str,
+        timeout: float | None,
+        requested_at: float,
+    ) -> AcquisitionRequest:
+        priority_to_keep = (
+            priority
+            if _PRIORITY_RANK[priority] > _PRIORITY_RANK[existing.priority]
+            else existing.priority
+        )
+        reasons = existing.reasons
+        if reason not in reasons:
+            reasons = (*reasons, reason)
+        deadline = min(existing.deadline_monotonic, requested_at + max_age)
+        return replace(
+            existing,
+            priority=priority_to_keep,
+            max_age=min(existing.max_age, max_age),
+            timeout=_min_optional_timeout(existing.timeout, timeout),
+            deadline_monotonic=deadline,
+            reasons=reasons,
+        )
+
+    def _defer(self, item: _PendingEnsureFresh) -> None:
+        existing = self._deferred.get(item.paths)
+        if existing is None:
+            self._deferred[item.paths] = item
+            return
+        priority = (
+            item.priority
+            if _PRIORITY_RANK[item.priority] > _PRIORITY_RANK[existing.priority]
+            else existing.priority
+        )
+        max_age = min(existing.max_age, item.max_age)
+        timeout = _min_optional_timeout(existing.timeout, item.timeout)
+        reason = existing.reason if existing.reason == item.reason else item.reason
+        self._deferred[item.paths] = _PendingEnsureFresh(
+            paths=item.paths,
+            max_age=max_age,
+            priority=priority,
+            reason=reason,
+            timeout=timeout,
+            requested_at_monotonic=min(
+                existing.requested_at_monotonic,
+                item.requested_at_monotonic,
+            ),
+            external_cat_owner=item.external_cat_owner or existing.external_cat_owner,
+        )
+
+    def _availability_for(
+        self,
+        paths: Sequence[FieldPath],
+    ) -> EnsureFreshResult | None:
+        for path in paths:
+            capability = self._profile.capability_for(path)
+            if capability.availability in (
+                FieldAvailability.UNSUPPORTED,
+                FieldAvailability.UNKNOWN,
+            ):
+                return EnsureFreshResult(
+                    status=AcquisitionStatus.UNAVAILABLE,
+                    message=capability.diagnostic
+                    or f"{path}: acquisition capability unavailable",
+                )
+            if not _has_acquisition_hook(capability):
+                return EnsureFreshResult(
+                    status=AcquisitionStatus.UNAVAILABLE,
+                    message=f"{path}: no acquisition hook is declared",
+                )
+        return None
+
+    def _must_defer_for_external_cat(self, paths: Sequence[FieldPath]) -> bool:
+        for path in paths:
+            behavior = self._profile.policy_for(path).external_cat_pause
+            if behavior is ExternalCatPauseBehavior.CONTINUE:
+                continue
+            if behavior is ExternalCatPauseBehavior.COALESCE_METERS_ONLY:
+                if all(candidate.family.value == "meters" for candidate in paths):
+                    continue
+            return True
+        return False
+
+    def _merged_policy(self, paths: Sequence[FieldPath]) -> AcquisitionPolicy:
+        return self._profile.policy_for(paths[0])
+
+
+class RadioStateModelService:
+    """Small service API joining StateStore freshness and scheduler requests."""
+
+    __slots__ = ("_clock", "_scheduler", "_store")
+
+    def __init__(
+        self,
+        *,
+        store: StateStore,
+        scheduler: AcquisitionScheduler,
+        clock: FreshnessClock | None = None,
+    ) -> None:
+        self._store = store
+        self._scheduler = scheduler
+        self._clock = clock or FreshnessClock()
+
+    def ensure_fresh(
+        self,
+        paths: FieldPath | str | Iterable[FieldPath | str],
+        *,
+        max_age: float,
+        priority: AcquisitionPriority | str,
+        reason: str,
+        timeout: float | None = None,
+    ) -> EnsureFreshResult:
+        """Return fresh snapshots or queue acquisition through the scheduler."""
+
+        normalized_paths = _normalize_paths(paths)
+        _validate_positive(max_age, label="max_age")
+        snapshot = self._store.snapshot()
+        fields: list[FieldSnapshot] = []
+        now = self._clock.now()
+        for path in normalized_paths:
+            try:
+                field = snapshot.field(path)
+            except KeyError:
+                break
+            if field.freshness is not FreshnessState.FRESH:
+                break
+            if now - field.last_observed_monotonic > max_age:
+                break
+            fields.append(field)
+        else:
+            return EnsureFreshResult(
+                status=AcquisitionStatus.FRESH,
+                fields=tuple(fields),
+            )
+
+        return self._scheduler.ensure_fresh(
+            normalized_paths,
+            max_age=max_age,
+            priority=priority,
+            reason=reason,
+            timeout=timeout,
+        )
+
+
+def _normalize_paths(
+    paths: FieldPath | str | Iterable[FieldPath | str],
+) -> tuple[FieldPath, ...]:
+    if isinstance(paths, FieldPath):
+        normalized = (paths,)
+    elif isinstance(paths, str):
+        normalized = (FieldPath.parse(paths),)
+    else:
+        normalized = tuple(
+            FieldPath.parse(path) if isinstance(path, str) else path for path in paths
+        )
+    if not normalized:
+        raise ValueError("ensure_fresh requires at least one field path")
+    return tuple(sorted(normalized, key=str))
+
+
+def _validate_positive(value: float, *, label: str) -> None:
+    if value <= 0:
+        raise ValueError(f"{label} must be positive")
+
+
+def _has_acquisition_hook(capability: FieldCapability) -> bool:
+    return bool(
+        capability.can_poll
+        or capability.command_response_observable
+        or capability.unsolicited_push
+    )
+
+
+def _select_method(capabilities: Sequence[FieldCapability]) -> AcquisitionMethod:
+    if any(capability.can_poll for capability in capabilities):
+        return "poll"
+    if any(capability.command_response_observable for capability in capabilities):
+        return "command_response"
+    return "wait_for_unsolicited"
+
+
+def _min_optional_timeout(left: float | None, right: float | None) -> float | None:
+    if left is None:
+        return right
+    if right is None:
+        return left
+    return min(left, right)

--- a/src/rigplane/core/acquisition_scheduler.py
+++ b/src/rigplane/core/acquisition_scheduler.py
@@ -16,7 +16,13 @@ from rigplane.core.state_acquisition_policy import (
     RadioAcquisitionProfile,
     ReconciliationPriority,
 )
-from rigplane.core.state_pipeline_contracts import ChangeSet, FieldPath, Observation
+from rigplane.core.state_pipeline_contracts import (
+    ChangeSet,
+    FieldChange,
+    FieldPath,
+    Observation,
+    SourceMetadata,
+)
 from rigplane.core.state_store import (
     FieldSnapshot,
     FreshnessClock,
@@ -950,8 +956,8 @@ class MeterObservationCoalescer:
             latest_by_path[sample.observation.path] = sample.observation
         self._coalesced_sample_count += len(samples) - len(latest_by_path)
 
-        changes = []
-        sources = []
+        changes: list[FieldChange] = []
+        sources: list[SourceMetadata] = []
         observed_paths: list[FieldPath] = []
         freshness_paths: list[FieldPath] = []
         result: ChangeSet | None = None
@@ -1074,6 +1080,7 @@ class RadioStateModelService:
 def _normalize_paths(
     paths: FieldPath | str | Iterable[FieldPath | str],
 ) -> tuple[FieldPath, ...]:
+    normalized: tuple[FieldPath, ...]
     if isinstance(paths, FieldPath):
         normalized = (paths,)
     elif isinstance(paths, str):

--- a/src/rigplane/core/acquisition_scheduler.py
+++ b/src/rigplane/core/acquisition_scheduler.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Sequence
+from collections.abc import Awaitable, Callable, Iterable, Sequence
 from dataclasses import dataclass, replace
 from enum import StrEnum
-from typing import Any, Literal
+from typing import Any, Literal, Protocol
 
 from rigplane.core.state_acquisition_policy import (
     AcquisitionPolicy,
@@ -32,17 +32,21 @@ from rigplane.core.state_store import (
 
 __all__ = [
     "AcquisitionMethod",
+    "AcquisitionExecutionResult",
+    "AcquisitionExecutor",
     "AcquisitionPriority",
     "AcquisitionRequest",
     "AcquisitionScheduler",
     "AcquisitionStatus",
     "EnsureFreshResult",
+    "IcomCivAcquisitionExecutor",
     "MeterObservationCoalescer",
     "RadioStateModelService",
 ]
 
 
 AcquisitionMethod = Literal["poll", "command_response", "wait_for_unsolicited"]
+AcquisitionQuerySender = Callable[[int, int | None, int | None], Awaitable[None]]
 
 
 class AcquisitionPriority(StrEnum):
@@ -62,6 +66,27 @@ class AcquisitionStatus(StrEnum):
     QUEUED = "queued"
     DEFERRED = "deferred"
     UNAVAILABLE = "unavailable"
+
+
+@dataclass(frozen=True, slots=True)
+class AcquisitionExecutionResult:
+    """Backend executor result for one scheduler request attempt."""
+
+    sent_paths: tuple[FieldPath, ...] = ()
+    failed_paths: tuple[FieldPath, ...] = ()
+    failure_reason: str = ""
+
+
+class AcquisitionExecutor(Protocol):
+    """Backend-owned executor for scheduler acquisition requests."""
+
+    async def execute(
+        self,
+        request: AcquisitionRequest,
+        *,
+        already_sent_paths: frozenset[FieldPath],
+    ) -> AcquisitionExecutionResult:
+        """Send backend reads for paths not already in flight."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -159,6 +184,111 @@ class _PendingMeterSample:
     policy: MeterCoalescingPolicy
 
 
+_RECEIVER_IDS: dict[str, int] = {
+    "0": 0,
+    "main": 0,
+    "1": 1,
+    "sub": 1,
+}
+_RECEIVER_LEVEL_QUERY_SUBS: dict[str, int] = {
+    "af_level": 0x01,
+    "rf_gain": 0x02,
+    "squelch": 0x03,
+    "apf_type_level": 0x05,
+    "nr_level": 0x06,
+    "pbt_inner": 0x07,
+    "pbt_outer": 0x08,
+    "nb_level": 0x12,
+    "digisel_shift": 0x13,
+}
+_GLOBAL_LEVEL_QUERY_SUBS: dict[str, int] = {
+    "power_level": 0x0A,
+    "mic_gain": 0x0B,
+    "notch_filter": 0x0D,
+    "compressor_level": 0x0E,
+    "break_in_delay": 0x0F,
+    "drive_gain": 0x14,
+    "monitor_gain": 0x15,
+    "vox_gain": 0x16,
+    "anti_vox_gain": 0x17,
+}
+_GLOBAL_METER_QUERY_SUBS: dict[str, int] = {
+    "power": 0x11,
+    "swr": 0x12,
+    "alc": 0x13,
+}
+
+
+class IcomCivAcquisitionExecutor:
+    """CI-V path-to-query executor for Icom acquisition profiles."""
+
+    __slots__ = ("_send_query",)
+
+    def __init__(self, send_query: AcquisitionQuerySender) -> None:
+        self._send_query = send_query
+
+    async def execute(
+        self,
+        request: AcquisitionRequest,
+        *,
+        already_sent_paths: frozenset[FieldPath],
+    ) -> AcquisitionExecutionResult:
+        sent: list[FieldPath] = []
+        failed: list[FieldPath] = []
+        for path in request.paths:
+            if path in already_sent_paths:
+                continue
+            query = self.query_for_path(path)
+            if query is None:
+                failed.append(path)
+                continue
+            await self._send_query(*query)
+            sent.append(path)
+        return AcquisitionExecutionResult(
+            sent_paths=tuple(sent),
+            failed_paths=tuple(failed),
+            failure_reason="no_civ_query_mapping" if failed else "",
+        )
+
+    def query_for_path(
+        self,
+        path: FieldPath,
+    ) -> tuple[int, int | None, int | None] | None:
+        receiver = _RECEIVER_IDS.get(path.receiver_id or "")
+        if path.scope.value == "receiver" and receiver is None:
+            return None
+        if path.scope.value == "receiver" and path.family.value == "freq_mode":
+            if path.name == "freq_hz":
+                return (0x25, None, receiver)
+            if path.name == "mode":
+                return (0x26, None, receiver)
+            return None
+        if path.scope.value == "receiver" and path.family.value == "meters":
+            if path.name == "s_meter":
+                return (0x15, 0x02, receiver)
+            return None
+        if (
+            path.scope.value == "receiver"
+            and path.family.value == "operator_controls"
+        ):
+            sub = _RECEIVER_LEVEL_QUERY_SUBS.get(path.name)
+            return None if sub is None else (0x14, sub, receiver)
+        if path.scope.value == "global" and path.family.value == "meters":
+            sub = _GLOBAL_METER_QUERY_SUBS.get(path.name)
+            return None if sub is None else (0x15, sub, None)
+        if path.scope.value == "global" and path.family.value == "tx_state":
+            if path.name == "ptt":
+                return (0x1C, 0x00, None)
+            return None
+        if (
+            path.scope.value == "global"
+            and path.family.value == "operator_controls"
+        ):
+            sub = _GLOBAL_LEVEL_QUERY_SUBS.get(path.name)
+            return None if sub is None else (0x14, sub, None)
+        return None
+
+
 _PRIORITY_RANK: dict[AcquisitionPriority, int] = {
     AcquisitionPriority.BACKGROUND: 0,
     AcquisitionPriority.RECONCILIATION: 1,
@@ -178,6 +308,8 @@ class AcquisitionScheduler:
         "_external_cat_owner",
         "_external_cat_paused",
         "_external_cat_reason",
+        "_failed_request_count",
+        "_failure_count_by_reason",
         "_next_id",
         "_pending_cadence_by_key",
         "_profile",
@@ -199,10 +331,18 @@ class AcquisitionScheduler:
             _AcquisitionRequestKey,
             _PendingCadenceUpdate,
         ] = {}
+        self._failed_request_count = 0
+        self._failure_count_by_reason: dict[str, int] = {}
         self._next_id = 1
         self._external_cat_paused = False
         self._external_cat_owner: str | None = None
         self._external_cat_reason = ""
+
+    @property
+    def provider(self) -> str:
+        """Return the backend/provider id declared by the acquisition profile."""
+
+        return self._profile.provider
 
     def ensure_fresh(
         self,
@@ -425,6 +565,54 @@ class AcquisitionScheduler:
             next_due_monotonic=change_set.timestamp_monotonic + current_cadence,
         )
 
+    def record_acquisition_failure(
+        self,
+        request: AcquisitionRequest,
+        *,
+        reason: str,
+        failed_paths: Iterable[FieldPath] | None = None,
+        now: float | None = None,
+    ) -> None:
+        """Complete failed paths and advance cadence to avoid immediate resend."""
+
+        failure_reason = reason or "acquisition_failed"
+        requested_paths = frozenset(request.paths)
+        failed = requested_paths if failed_paths is None else frozenset(failed_paths)
+        failed = failed.intersection(requested_paths)
+        if not failed:
+            return
+
+        self._failed_request_count += 1
+        self._failure_count_by_reason[failure_reason] = (
+            self._failure_count_by_reason.get(failure_reason, 0) + 1
+        )
+
+        key = _request_key(
+            request.paths[0],
+            acquisition_method=request.acquisition_method,
+            policy=request.policy,
+        )
+        existing = self._requests_by_key.get(key)
+        if existing is not None and existing.id == request.id:
+            remaining_paths = tuple(path for path in existing.paths if path not in failed)
+            if remaining_paths:
+                self._requests_by_key[key] = self._replace_request_paths(
+                    existing,
+                    paths=remaining_paths,
+                )
+            else:
+                del self._requests_by_key[key]
+                self._pending_cadence_by_key.pop(key, None)
+
+        if request.policy.cadence_seconds is None:
+            return
+        timestamp = self._clock.now() if now is None else now
+        previous = self._cadence_state_for(key, request.policy, now=timestamp)
+        self._cadence_by_key[key] = _CadenceState(
+            current_cadence_seconds=previous.current_cadence_seconds,
+            next_due_monotonic=timestamp + previous.current_cadence_seconds,
+        )
+
     def diagnostics(self) -> dict[str, Any]:
         """Return a JSON-safe scheduler projection for diagnostics surfaces."""
 
@@ -455,6 +643,8 @@ class AcquisitionScheduler:
         return {
             "queuedRequestCount": len(self._requests_by_key),
             "deferredRequestCount": len(self._deferred),
+            "failedRequestCount": self._failed_request_count,
+            "failureCountByReason": dict(self._failure_count_by_reason),
             "cadenceByPath": cadence_by_path,
             "cadenceByGroup": cadence_by_group,
             "requestPressureByPriorityFamily": self._request_pressure(),

--- a/src/rigplane/core/acquisition_scheduler.py
+++ b/src/rigplane/core/acquisition_scheduler.py
@@ -920,6 +920,8 @@ class MeterObservationCoalescer:
 
         changes = []
         sources = []
+        observed_paths: list[FieldPath] = []
+        freshness_paths: list[FieldPath] = []
         result: ChangeSet | None = None
         timestamp_monotonic = max(
             observation.timestamp_monotonic for observation in latest_by_path.values()
@@ -931,6 +933,8 @@ class MeterObservationCoalescer:
             result = store.apply(observation)
             changes.extend(result.changes)
             sources.extend(result.sources)
+            observed_paths.extend(result.observed_paths)
+            freshness_paths.extend(result.freshness_paths)
 
         assert result is not None
         return ChangeSet(
@@ -941,6 +945,8 @@ class MeterObservationCoalescer:
             timestamp_monotonic=timestamp_monotonic,
             sources=tuple(sources),
             coalesced=True,
+            observed_paths=tuple(observed_paths),
+            freshness_paths=tuple(freshness_paths),
         )
 
     def next_flush_monotonic(self) -> float | None:

--- a/src/rigplane/core/command_service.py
+++ b/src/rigplane/core/command_service.py
@@ -1,0 +1,336 @@
+"""Backend-neutral command execution service.
+
+The service normalizes command ingress into :class:`CommandIntent`, delegates
+actual radio work to an injected executor, and applies any resulting readbacks
+as confirmed :class:`Observation` values through :class:`StateStore`.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from rigplane.core.state_pipeline_contracts import (
+    ChangeSet,
+    CommandIntent,
+    CommandLifecycleEvent,
+    CommandLifecycleState,
+    CommandSource,
+    FieldPath,
+    Observation,
+)
+from rigplane.core.state_store import StateStore
+
+__all__ = [
+    "CommandExecutionResult",
+    "CommandExecutor",
+    "CommandService",
+    "CommandServiceResult",
+    "PendingOverlay",
+]
+
+
+Clock = Callable[[], float]
+LifecycleSubscriber = Callable[[CommandLifecycleEvent], None]
+
+
+@dataclass(frozen=True, slots=True)
+class CommandExecutionResult:
+    """Backend executor result returned after command queue/backend execution."""
+
+    observations: tuple[Observation, ...] = ()
+    details: Mapping[str, Any] | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "observations", tuple(self.observations))
+        object.__setattr__(
+            self,
+            "details",
+            {} if self.details is None else dict(self.details),
+        )
+
+
+class CommandExecutor(Protocol):
+    """Backend-neutral command executor seam.
+
+    Runtime, Web, rigctld, and public API adapters can implement this protocol
+    by delegating to the existing command queue, IcomCommander, or backend API.
+    """
+
+    async def execute(self, intent: CommandIntent) -> CommandExecutionResult:
+        """Execute one command intent without directly mutating semantic state."""
+
+
+@dataclass(frozen=True, slots=True)
+class PendingOverlay:
+    """Read-your-writes projection scoped to one command ingress context."""
+
+    source: CommandSource
+    session_id: str | None
+    command_id: str
+    path: FieldPath
+    value: Any
+    expires_at_monotonic: float
+
+    def is_expired(self, now: float) -> bool:
+        return now >= self.expires_at_monotonic
+
+
+@dataclass(frozen=True, slots=True)
+class CommandServiceResult:
+    """Observable result of one command service execution."""
+
+    lifecycle_events: tuple[CommandLifecycleEvent, ...]
+    observation_changes: tuple[ChangeSet, ...]
+    executor_result: CommandExecutionResult
+
+
+class CommandService:
+    """Coordinate backend-neutral command execution and pending overlays."""
+
+    __slots__ = (
+        "_clock",
+        "_default_pending_ttl",
+        "_events",
+        "_executor",
+        "_overlays",
+        "_state_store",
+        "_subscribers",
+    )
+
+    def __init__(
+        self,
+        *,
+        executor: CommandExecutor,
+        state_store: StateStore,
+        clock: Clock | None = None,
+        default_pending_ttl: float = 2.0,
+    ) -> None:
+        if default_pending_ttl < 0:
+            raise ValueError("default_pending_ttl must be non-negative")
+        self._executor = executor
+        self._state_store = state_store
+        self._clock = clock or time.monotonic
+        self._default_pending_ttl = default_pending_ttl
+        self._events: list[CommandLifecycleEvent] = []
+        self._subscribers: list[LifecycleSubscriber] = []
+        self._overlays: list[PendingOverlay] = []
+
+    async def execute(self, intent: CommandIntent) -> CommandServiceResult:
+        """Execute an intent through the injected backend executor."""
+
+        start = len(self._events)
+        self.emit_lifecycle(intent, "accepted")
+        self._record_intent_overlay(intent)
+        self.emit_lifecycle(intent, "queued")
+        self.emit_lifecycle(intent, "sent")
+
+        try:
+            executor_result = await self._executor.execute(intent)
+        except TimeoutError as exc:
+            self.expire_command(intent.id)
+            self.emit_lifecycle(intent, "timed_out", message=str(exc) or None)
+            raise
+        except Exception as exc:
+            self.expire_command(intent.id)
+            self.emit_lifecycle(intent, "failed", message=str(exc) or None)
+            raise
+
+        self.emit_lifecycle(intent, "acknowledged", details=executor_result.details)
+        changes: list[ChangeSet] = []
+        for observation in executor_result.observations:
+            changes.append(self.apply_observation(observation))
+
+        return CommandServiceResult(
+            lifecycle_events=tuple(self._events[start:]),
+            observation_changes=tuple(changes),
+            executor_result=executor_result,
+        )
+
+    def apply_observation(self, observation: Observation) -> ChangeSet:
+        """Apply a confirmed observation and reconcile matching overlays."""
+
+        changeset = self._state_store.apply(observation)
+        self._reconcile_observation(observation, changeset)
+        return changeset
+
+    def emit_lifecycle(
+        self,
+        intent: CommandIntent,
+        state: CommandLifecycleState,
+        *,
+        message: str | None = None,
+        details: Mapping[str, Any] | None = None,
+    ) -> CommandLifecycleEvent:
+        """Record and publish a lifecycle event for an intent."""
+
+        event = CommandLifecycleEvent(
+            command_id=intent.id,
+            state=state,
+            timestamp_monotonic=self._clock(),
+            source=intent.source,
+            target=intent.target,
+            message=message,
+            details=details,
+        )
+        self._events.append(event)
+        for subscriber in tuple(self._subscribers):
+            subscriber(event)
+        return event
+
+    def lifecycle_events(self) -> tuple[CommandLifecycleEvent, ...]:
+        """Return recorded lifecycle events in emission order."""
+
+        return tuple(self._events)
+
+    def subscribe_lifecycle(
+        self,
+        subscriber: LifecycleSubscriber,
+    ) -> Callable[[], None]:
+        """Subscribe to lifecycle events and return an unsubscribe callback."""
+
+        self._subscribers.append(subscriber)
+
+        def unsubscribe() -> None:
+            try:
+                self._subscribers.remove(subscriber)
+            except ValueError:
+                pass
+
+        return unsubscribe
+
+    def record_pending_overlay(self, overlay: PendingOverlay) -> None:
+        """Record or replace one scoped pending overlay."""
+
+        self._purge_expired()
+        self._overlays = [
+            item
+            for item in self._overlays
+            if not (
+                item.source == overlay.source
+                and item.session_id == overlay.session_id
+                and item.command_id == overlay.command_id
+                and item.path == overlay.path
+            )
+        ]
+        if not overlay.is_expired(self._clock()):
+            self._overlays.append(overlay)
+
+    def pending_overlays(
+        self,
+        *,
+        source: CommandSource,
+        session_id: str | None,
+        command_id: str | None = None,
+        path: FieldPath | None = None,
+    ) -> tuple[PendingOverlay, ...]:
+        """Return non-expired overlays matching an ingress scope."""
+
+        self._purge_expired()
+        return tuple(
+            item
+            for item in self._overlays
+            if item.source == source
+            and item.session_id == session_id
+            and (command_id is None or item.command_id == command_id)
+            and (path is None or item.path == path)
+        )
+
+    def project_pending_values(
+        self,
+        *,
+        source: CommandSource,
+        session_id: str | None,
+        paths: Sequence[FieldPath],
+    ) -> dict[FieldPath, Any]:
+        """Project pending values for one source/session without leakage."""
+
+        wanted = set(paths)
+        projected: dict[FieldPath, Any] = {}
+        for overlay in self.pending_overlays(source=source, session_id=session_id):
+            if overlay.path in wanted:
+                projected[overlay.path] = overlay.value
+        return projected
+
+    def expire_command(self, command_id: str) -> None:
+        """Remove all pending overlays created by one command."""
+
+        self._overlays = [
+            item for item in self._overlays if item.command_id != command_id
+        ]
+
+    def _record_intent_overlay(self, intent: CommandIntent) -> None:
+        if intent.pending_policy != "scoped" or intent.target is None:
+            return
+        try:
+            value = _pending_value_for_intent(intent)
+        except KeyError:
+            return
+        timeout = (
+            self._default_pending_ttl if intent.timeout is None else intent.timeout
+        )
+        self.record_pending_overlay(
+            PendingOverlay(
+                source=intent.source,
+                session_id=_session_id(intent),
+                command_id=intent.id,
+                path=intent.target,
+                value=value,
+                expires_at_monotonic=self._clock() + timeout,
+            )
+        )
+
+    def _reconcile_observation(
+        self,
+        observation: Observation,
+        changeset: ChangeSet,
+    ) -> None:
+        self._purge_expired()
+        reconciled: list[PendingOverlay] = []
+        remaining: list[PendingOverlay] = []
+        for overlay in self._overlays:
+            if overlay.path == observation.path and overlay.value == observation.value:
+                reconciled.append(overlay)
+            else:
+                remaining.append(overlay)
+        self._overlays = remaining
+
+        for overlay in reconciled:
+            self.emit_lifecycle(
+                CommandIntent(
+                    id=overlay.command_id,
+                    name="reconcile",
+                    params={},
+                    source=overlay.source,
+                    target=overlay.path,
+                ),
+                "reconciled",
+                message="confirmed by matching observation",
+                details={
+                    "revision": changeset.revision,
+                    "observationSeq": changeset.observation_seq,
+                },
+            )
+
+    def _purge_expired(self) -> None:
+        now = self._clock()
+        self._overlays = [
+            overlay for overlay in self._overlays if not overlay.is_expired(now)
+        ]
+
+
+def _pending_value_for_intent(intent: CommandIntent) -> Any:
+    assert intent.target is not None
+    params = intent.params
+    if intent.target.name in params:
+        return params[intent.target.name]
+    if "value" in params:
+        return params["value"]
+    raise KeyError(intent.target.name)
+
+
+def _session_id(intent: CommandIntent) -> str | None:
+    value = intent.params.get("session_id")
+    return None if value is None else str(value)

--- a/src/rigplane/core/command_service.py
+++ b/src/rigplane/core/command_service.py
@@ -159,6 +159,42 @@ class CommandService:
         self._reconcile_observation(observation, changeset)
         return changeset
 
+    def fail_command(
+        self,
+        command_id: str,
+        *,
+        message: str | None = None,
+        timed_out: bool = False,
+    ) -> bool:
+        """Mark a previously acknowledged command as failed and expire overlays."""
+
+        template = self._last_event(command_id)
+        if template is None or template.state in {
+            "failed",
+            "timed_out",
+            "reconciled",
+            "confirmed",
+            "superseded",
+        }:
+            return False
+        self.expire_command(command_id)
+        self.emit_lifecycle(
+            CommandIntent(
+                id=command_id,
+                name="queued_completion",
+                params={},
+                source=template.source,
+                target=template.target,
+                priority="user",
+                timeout=None,
+                pending_policy="none",
+                expected_observations=(),
+            ),
+            "timed_out" if timed_out else "failed",
+            message=message,
+        )
+        return True
+
     def emit_lifecycle(
         self,
         intent: CommandIntent,
@@ -323,6 +359,12 @@ class CommandService:
             overlay for overlay in self._overlays if not overlay.is_expired(now)
         ]
 
+    def _last_event(self, command_id: str) -> CommandLifecycleEvent | None:
+        for event in reversed(self._events):
+            if event.command_id == command_id:
+                return event
+        return None
+
 
 def _pending_value_for_intent(intent: CommandIntent) -> Any:
     assert intent.target is not None
@@ -343,6 +385,12 @@ def _observation_reconciles_overlay(
     observation: Observation,
     overlay: PendingOverlay,
 ) -> bool:
+    observed_source = observation.source.command_source
+    if observed_source is not None and observed_source != overlay.source:
+        return False
+    observed_session = observation.source.session_id
+    if observed_session is not None and observed_session != overlay.session_id:
+        return False
     return (
         observation.correlation_id is not None
         and observation.correlation_id == overlay.command_id
@@ -466,6 +514,8 @@ def command_response_observation(
             source="command_response",
             provider=provider,
             transport=transport,
+            command_source=intent.source,
+            session_id=_session_id(intent),
         ),
         timestamp_monotonic=timestamp_monotonic,
         correlation_id=intent.id,

--- a/src/rigplane/core/command_service.py
+++ b/src/rigplane/core/command_service.py
@@ -34,6 +34,8 @@ __all__ = [
     "command_response_observation",
 ]
 
+_UNSET = object()
+
 
 Clock = Callable[[], float]
 LifecycleSubscriber = Callable[[CommandLifecycleEvent], None]
@@ -133,11 +135,19 @@ class CommandService:
         try:
             executor_result = await self._executor.execute(intent)
         except TimeoutError as exc:
-            self.expire_command(intent.id)
+            self.expire_command(
+                intent.id,
+                source=intent.source,
+                session_id=_session_id(intent),
+            )
             self.emit_lifecycle(intent, "timed_out", message=str(exc) or None)
             raise
         except Exception as exc:
-            self.expire_command(intent.id)
+            self.expire_command(
+                intent.id,
+                source=intent.source,
+                session_id=_session_id(intent),
+            )
             self.emit_lifecycle(intent, "failed", message=str(exc) or None)
             raise
 
@@ -165,10 +175,16 @@ class CommandService:
         *,
         message: str | None = None,
         timed_out: bool = False,
+        source: CommandSource | None = None,
+        session_id: str | None | object = _UNSET,
     ) -> bool:
         """Mark a previously acknowledged command as failed and expire overlays."""
 
-        template = self._last_event(command_id)
+        template = self._last_event(
+            command_id,
+            source=source,
+            session_id=session_id,
+        )
         if template is None or template.state in {
             "failed",
             "timed_out",
@@ -177,13 +193,24 @@ class CommandService:
             "superseded",
         }:
             return False
-        self.expire_command(command_id)
+        scoped_source = template.source if source is None else source
+        scoped_session = (
+            _event_session_id(template) if session_id is _UNSET else session_id
+        )
+        self.expire_command(
+            command_id,
+            source=scoped_source,
+            session_id=scoped_session,
+        )
+        params = {}
+        if scoped_session is not _UNSET:
+            params["session_id"] = scoped_session
         self.emit_lifecycle(
             CommandIntent(
                 id=command_id,
                 name="queued_completion",
-                params={},
-                source=template.source,
+                params=params,
+                source=scoped_source,
                 target=template.target,
                 priority="user",
                 timeout=None,
@@ -205,6 +232,9 @@ class CommandService:
     ) -> CommandLifecycleEvent:
         """Record and publish a lifecycle event for an intent."""
 
+        payload_details = dict(details or {})
+        if "session_id" in intent.params:
+            payload_details.setdefault("session_id", intent.params["session_id"])
         event = CommandLifecycleEvent(
             command_id=intent.id,
             state=state,
@@ -212,7 +242,7 @@ class CommandService:
             source=intent.source,
             target=intent.target,
             message=message,
-            details=details,
+            details=payload_details,
         )
         self._events.append(event)
         for subscriber in tuple(self._subscribers):
@@ -293,11 +323,24 @@ class CommandService:
                 projected[overlay.path] = overlay.value
         return projected
 
-    def expire_command(self, command_id: str) -> None:
+    def expire_command(
+        self,
+        command_id: str,
+        *,
+        source: CommandSource | None = None,
+        session_id: str | None | object = _UNSET,
+    ) -> None:
         """Remove all pending overlays created by one command."""
 
         self._overlays = [
-            item for item in self._overlays if item.command_id != command_id
+            item
+            for item in self._overlays
+            if not _overlay_matches(
+                item,
+                command_id=command_id,
+                source=source,
+                session_id=session_id,
+            )
         ]
 
     def _record_intent_overlay(self, intent: CommandIntent) -> None:
@@ -359,9 +402,22 @@ class CommandService:
             overlay for overlay in self._overlays if not overlay.is_expired(now)
         ]
 
-    def _last_event(self, command_id: str) -> CommandLifecycleEvent | None:
+    def _last_event(
+        self,
+        command_id: str,
+        *,
+        source: CommandSource | None = None,
+        session_id: str | None | object = _UNSET,
+    ) -> CommandLifecycleEvent | None:
         for event in reversed(self._events):
-            if event.command_id == command_id:
+            if (
+                event.command_id == command_id
+                and (source is None or event.source == source)
+                and (
+                    session_id is _UNSET
+                    or _event_session_id(event) == session_id
+                )
+            ):
                 return event
         return None
 
@@ -379,6 +435,25 @@ def _pending_value_for_intent(intent: CommandIntent) -> Any:
 def _session_id(intent: CommandIntent) -> str | None:
     value = intent.params.get("session_id")
     return None if value is None else str(value)
+
+
+def _event_session_id(event: CommandLifecycleEvent) -> str | None:
+    value = (event.details or {}).get("session_id")
+    return None if value is None else str(value)
+
+
+def _overlay_matches(
+    overlay: PendingOverlay,
+    *,
+    command_id: str,
+    source: CommandSource | None,
+    session_id: str | None | object,
+) -> bool:
+    return (
+        overlay.command_id == command_id
+        and (source is None or overlay.source == source)
+        and (session_id is _UNSET or overlay.session_id == session_id)
+    )
 
 
 def _observation_reconciles_overlay(
@@ -447,6 +522,12 @@ def command_intent_from_request(
         normalized["af_level"] = int(normalized["level"])
     elif command_name in ("set_sql", "set_squelch"):
         normalized["squelch"] = int(normalized["level"])
+    elif command_name == "set_attenuator_level":
+        raw_value = normalized["db"] if "db" in normalized else normalized["value"]
+        normalized["att"] = int(raw_value)
+    elif command_name == "set_preamp":
+        raw_value = normalized["level"] if "level" in normalized else normalized["value"]
+        normalized["preamp"] = int(raw_value)
     elif command_name == "set_nb":
         normalized["nb"] = bool(normalized["on"])
     elif command_name == "set_nr":
@@ -540,6 +621,10 @@ def _command_target(name: str, params: Mapping[str, Any]) -> FieldPath | None:
         return FieldPath.receiver(receiver, "operator_controls", "af_level")
     if name in ("set_sql", "set_squelch"):
         return FieldPath.receiver(receiver, "operator_controls", "squelch")
+    if name == "set_attenuator_level":
+        return FieldPath.receiver(receiver, "operator_controls", "att")
+    if name == "set_preamp":
+        return FieldPath.receiver(receiver, "operator_controls", "preamp")
     if name == "set_nb":
         return FieldPath.receiver(receiver, "operator_toggles", "nb")
     if name == "set_nr":

--- a/src/rigplane/core/command_service.py
+++ b/src/rigplane/core/command_service.py
@@ -414,10 +414,7 @@ class CommandService:
             if (
                 event.command_id == command_id
                 and (source is None or event.source == source)
-                and (
-                    session_id is _UNSET
-                    or _event_session_id(event) == session_id
-                )
+                and (session_id is _UNSET or _event_session_id(event) == session_id)
             ):
                 return event
         return None
@@ -533,22 +530,30 @@ def command_intent_from_request(
         )
         normalized["att"] = int(raw_value)
     elif command_name == "set_preamp":
-        raw_value = normalized["level"] if "level" in normalized else normalized["value"]
+        raw_value = (
+            normalized["level"] if "level" in normalized else normalized["value"]
+        )
         normalized["preamp"] = int(raw_value)
     elif command_name == "set_nb":
         normalized["nb"] = bool(normalized["on"])
     elif command_name == "set_nr":
         normalized["nr"] = bool(normalized["on"])
     elif command_name == "set_pbt_inner":
-        raw_level = normalized["value"] if "value" in normalized else normalized["level"]
+        raw_level = (
+            normalized["value"] if "value" in normalized else normalized["level"]
+        )
         normalized["pbt_inner"] = int(raw_level)
     elif command_name == "set_pbt_outer":
-        raw_level = normalized["value"] if "value" in normalized else normalized["level"]
+        raw_level = (
+            normalized["value"] if "value" in normalized else normalized["level"]
+        )
         normalized["pbt_outer"] = int(raw_level)
     elif command_name == "set_powerstat":
         normalized["power_on"] = bool(normalized.get("on", True))
     elif command_name in ("set_rf_power", "set_power"):
-        raw_level = normalized["level"] if "level" in normalized else normalized["value"]
+        raw_level = (
+            normalized["level"] if "level" in normalized else normalized["value"]
+        )
         normalized["power_level"] = int(raw_level)
     elif command_name == "set_split":
         normalized["split"] = bool(normalized.get("on", False))

--- a/src/rigplane/core/command_service.py
+++ b/src/rigplane/core/command_service.py
@@ -291,7 +291,7 @@ class CommandService:
         reconciled: list[PendingOverlay] = []
         remaining: list[PendingOverlay] = []
         for overlay in self._overlays:
-            if overlay.path == observation.path and overlay.value == observation.value:
+            if _observation_reconciles_overlay(observation, overlay):
                 reconciled.append(overlay)
             else:
                 remaining.append(overlay)
@@ -334,3 +334,15 @@ def _pending_value_for_intent(intent: CommandIntent) -> Any:
 def _session_id(intent: CommandIntent) -> str | None:
     value = intent.params.get("session_id")
     return None if value is None else str(value)
+
+
+def _observation_reconciles_overlay(
+    observation: Observation,
+    overlay: PendingOverlay,
+) -> bool:
+    return (
+        observation.correlation_id is not None
+        and observation.correlation_id == overlay.command_id
+        and overlay.path == observation.path
+        and overlay.value == observation.value
+    )

--- a/src/rigplane/core/command_service.py
+++ b/src/rigplane/core/command_service.py
@@ -12,6 +12,7 @@ from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, Protocol
 
+from rigplane.core.exceptions import TimeoutError as RigplaneTimeoutError
 from rigplane.core.state_pipeline_contracts import (
     ChangeSet,
     CommandIntent,
@@ -134,7 +135,7 @@ class CommandService:
 
         try:
             executor_result = await self._executor.execute(intent)
-        except TimeoutError as exc:
+        except (TimeoutError, RigplaneTimeoutError) as exc:
             self.expire_command(
                 intent.id,
                 source=intent.source,
@@ -522,8 +523,14 @@ def command_intent_from_request(
         normalized["af_level"] = int(normalized["level"])
     elif command_name in ("set_sql", "set_squelch"):
         normalized["squelch"] = int(normalized["level"])
-    elif command_name == "set_attenuator_level":
-        raw_value = normalized["db"] if "db" in normalized else normalized["value"]
+    elif command_name in ("set_att", "set_attenuator", "set_attenuator_level"):
+        raw_value = (
+            normalized["db"]
+            if "db" in normalized
+            else normalized["level"]
+            if "level" in normalized
+            else normalized["value"]
+        )
         normalized["att"] = int(raw_value)
     elif command_name == "set_preamp":
         raw_value = normalized["level"] if "level" in normalized else normalized["value"]
@@ -621,7 +628,7 @@ def _command_target(name: str, params: Mapping[str, Any]) -> FieldPath | None:
         return FieldPath.receiver(receiver, "operator_controls", "af_level")
     if name in ("set_sql", "set_squelch"):
         return FieldPath.receiver(receiver, "operator_controls", "squelch")
-    if name == "set_attenuator_level":
+    if name in ("set_att", "set_attenuator", "set_attenuator_level"):
         return FieldPath.receiver(receiver, "operator_controls", "att")
     if name == "set_preamp":
         return FieldPath.receiver(receiver, "operator_controls", "preamp")

--- a/src/rigplane/core/command_service.py
+++ b/src/rigplane/core/command_service.py
@@ -20,6 +20,7 @@ from rigplane.core.state_pipeline_contracts import (
     CommandSource,
     FieldPath,
     Observation,
+    SourceMetadata,
 )
 from rigplane.core.state_store import StateStore
 
@@ -29,6 +30,8 @@ __all__ = [
     "CommandService",
     "CommandServiceResult",
     "PendingOverlay",
+    "command_intent_from_request",
+    "command_response_observation",
 ]
 
 
@@ -346,3 +349,104 @@ def _observation_reconciles_overlay(
         and overlay.path == observation.path
         and overlay.value == observation.value
     )
+
+
+def command_intent_from_request(
+    name: str,
+    params: Mapping[str, Any],
+    *,
+    source: CommandSource,
+    command_id: str | None = None,
+    session_id: str | None = None,
+    timeout: float | None = 2.0,
+) -> CommandIntent:
+    """Normalize a production command request into a backend-neutral intent."""
+
+    normalized = dict(params)
+    if session_id is not None:
+        normalized["session_id"] = session_id
+    command_name = str(name)
+    target = _command_target(command_name, normalized)
+    if command_name == "set_freq":
+        raw_freq = (
+            normalized["freq_hz"] if "freq_hz" in normalized else normalized["freq"]
+        )
+        freq = int(raw_freq)
+        normalized["freq_hz"] = freq
+        normalized.setdefault("freq", freq)
+    elif command_name == "set_mode":
+        normalized["mode"] = str(normalized["mode"])
+    elif command_name == "set_filter":
+        if "filter_num" not in normalized:
+            raw_filter = normalized.get("filter", normalized.get("value", 1))
+            if isinstance(raw_filter, str):
+                normalized["filter_num"] = (
+                    int(raw_filter[-1]) if raw_filter[-1:].isdigit() else 1
+                )
+            else:
+                normalized["filter_num"] = int(raw_filter)
+
+    expected = () if target is None else (target,)
+    return CommandIntent(
+        id=command_id or f"{source}-{time.monotonic_ns()}",
+        name=command_name,
+        params=normalized,
+        source=source,
+        target=target,
+        priority="user",
+        timeout=timeout,
+        pending_policy="scoped" if target is not None else "none",
+        expected_observations=expected,
+    )
+
+
+def command_response_observation(
+    intent: CommandIntent,
+    *,
+    timestamp_monotonic: float,
+    provider: str,
+    transport: str | None = None,
+    value: Any = None,
+) -> Observation:
+    """Create a confirmed command-response observation for an intent target."""
+
+    if intent.target is None:
+        raise ValueError(f"command {intent.name!r} has no observable target")
+    observed_value = _value_for_observable_intent(intent) if value is None else value
+    return Observation(
+        path=intent.target,
+        value=observed_value,
+        source=SourceMetadata(
+            source="command_response",
+            provider=provider,
+            transport=transport,
+        ),
+        timestamp_monotonic=timestamp_monotonic,
+        correlation_id=intent.id,
+    )
+
+
+def _command_target(name: str, params: Mapping[str, Any]) -> FieldPath | None:
+    receiver = str(int(params.get("receiver", 0)))
+    if name == "set_freq":
+        return FieldPath.receiver(receiver, "freq_mode", "freq_hz")
+    if name == "set_mode":
+        return FieldPath.receiver(receiver, "freq_mode", "mode")
+    if name == "set_filter":
+        return FieldPath.receiver(receiver, "freq_mode", "filter_width")
+    return None
+
+
+def _value_for_observable_intent(intent: CommandIntent) -> Any:
+    if intent.target is None:
+        raise ValueError(f"command {intent.name!r} has no observable target")
+    params = intent.params
+    if intent.target.name in params:
+        return params[intent.target.name]
+    if intent.target.name == "freq_hz" and "freq" in params:
+        return params["freq"]
+    if intent.target.name == "filter_width" and "filter_num" in params:
+        return params["filter_num"]
+    if "value" in params:
+        return params["value"]
+    raise KeyError(intent.target.name)

--- a/src/rigplane/core/command_service.py
+++ b/src/rigplane/core/command_service.py
@@ -366,7 +366,6 @@ def command_intent_from_request(
     if session_id is not None:
         normalized["session_id"] = session_id
     command_name = str(name)
-    target = _command_target(command_name, normalized)
     if command_name == "set_freq":
         raw_freq = (
             normalized["freq_hz"] if "freq_hz" in normalized else normalized["freq"]
@@ -385,7 +384,54 @@ def command_intent_from_request(
                 )
             else:
                 normalized["filter_num"] = int(raw_filter)
+        normalized["filter_width"] = int(normalized["filter_num"])
+    elif command_name == "set_filter_width":
+        normalized["filter_width"] = int(normalized["width"])
+    elif command_name in ("set_ptt", "ptt"):
+        normalized["ptt"] = _ptt_value(command_name, normalized)
+    elif command_name == "ptt_on":
+        normalized["ptt"] = True
+    elif command_name == "ptt_off":
+        normalized["ptt"] = False
+    elif command_name == "set_rf_gain":
+        normalized["rf_gain"] = int(normalized["level"])
+    elif command_name == "set_af_level":
+        normalized["af_level"] = int(normalized["level"])
+    elif command_name in ("set_sql", "set_squelch"):
+        normalized["squelch"] = int(normalized["level"])
+    elif command_name == "set_nb":
+        normalized["nb"] = bool(normalized["on"])
+    elif command_name == "set_nr":
+        normalized["nr"] = bool(normalized["on"])
+    elif command_name == "set_pbt_inner":
+        raw_level = normalized["value"] if "value" in normalized else normalized["level"]
+        normalized["pbt_inner"] = int(raw_level)
+    elif command_name == "set_pbt_outer":
+        raw_level = normalized["value"] if "value" in normalized else normalized["level"]
+        normalized["pbt_outer"] = int(raw_level)
+    elif command_name == "set_powerstat":
+        normalized["power_on"] = bool(normalized.get("on", True))
+    elif command_name in ("set_rf_power", "set_power"):
+        raw_level = normalized["level"] if "level" in normalized else normalized["value"]
+        normalized["power_level"] = int(raw_level)
+    elif command_name == "set_split":
+        normalized["split"] = bool(normalized.get("on", False))
+    elif command_name in ("set_vfo", "select_vfo"):
+        active_slot = _active_slot_value(normalized.get("vfo", "A"))
+        if active_slot is not None:
+            normalized["active_slot"] = active_slot
+    elif command_name == "set_level":
+        normalized["level"] = str(normalized["level"]).upper()
+        normalized["value"] = float(normalized["value"])
+        _normalize_level_value(normalized)
+    elif command_name == "set_func":
+        func = str(normalized["func"]).lower()
+        normalized["func"] = func.upper()
+        normalized[func] = bool(normalized["on"])
+    elif command_name == "set_split_vfo":
+        normalized["split"] = bool(normalized["on"])
 
+    target = _command_target(command_name, normalized)
     expected = () if target is None else (target,)
     return CommandIntent(
         id=command_id or f"{source}-{time.monotonic_ns()}",
@@ -434,6 +480,42 @@ def _command_target(name: str, params: Mapping[str, Any]) -> FieldPath | None:
         return FieldPath.receiver(receiver, "freq_mode", "mode")
     if name == "set_filter":
         return FieldPath.receiver(receiver, "freq_mode", "filter_width")
+    if name == "set_filter_width":
+        return FieldPath.receiver(receiver, "freq_mode", "filter_width")
+    if name in ("set_ptt", "ptt", "ptt_on", "ptt_off"):
+        return FieldPath.global_("tx_state", "ptt")
+    if name == "set_rf_gain":
+        return FieldPath.receiver(receiver, "operator_controls", "rf_gain")
+    if name == "set_af_level":
+        return FieldPath.receiver(receiver, "operator_controls", "af_level")
+    if name in ("set_sql", "set_squelch"):
+        return FieldPath.receiver(receiver, "operator_controls", "squelch")
+    if name == "set_nb":
+        return FieldPath.receiver(receiver, "operator_toggles", "nb")
+    if name == "set_nr":
+        return FieldPath.receiver(receiver, "operator_toggles", "nr")
+    if name == "set_pbt_inner":
+        return FieldPath.receiver(receiver, "operator_controls", "pbt_inner")
+    if name == "set_pbt_outer":
+        return FieldPath.receiver(receiver, "operator_controls", "pbt_outer")
+    if name == "set_powerstat":
+        return FieldPath.global_("tx_state", "power_on")
+    if name in ("set_rf_power", "set_power"):
+        return FieldPath.global_("operator_controls", "power_level")
+    if name == "set_split":
+        return FieldPath.global_("tx_state", "split")
+    if name in ("set_vfo", "select_vfo") and "active_slot" in params:
+        return FieldPath.active_slot(receiver)
+    if name == "set_level":
+        return _level_target(params, receiver)
+    if name == "set_func":
+        return FieldPath.receiver(
+            receiver,
+            "operator_toggles",
+            str(params["func"]).lower(),
+        )
+    if name == "set_split_vfo":
+        return FieldPath.global_("tx_state", "split")
     return None
 
 
@@ -450,3 +532,71 @@ def _value_for_observable_intent(intent: CommandIntent) -> Any:
     if "value" in params:
         return params["value"]
     raise KeyError(intent.target.name)
+
+
+def _ptt_value(name: str, params: Mapping[str, Any]) -> bool:
+    if name == "ptt" and "state" in params:
+        return bool(params["state"])
+    if "on" in params:
+        return bool(params["on"])
+    if "value" in params:
+        return bool(params["value"])
+    return False
+
+
+def _active_slot_value(value: Any) -> str | None:
+    text = str(value).strip().upper()
+    if text in ("B", "VFOB", "SUB", "1"):
+        return "B"
+    if text in ("A", "VFOA", "MAIN", "0"):
+        return "A"
+    return None
+
+
+def _normalize_level_value(params: dict[str, Any]) -> None:
+    level = str(params["level"]).upper()
+    value = float(params["value"])
+    receiver_control_names = {
+        "AF": "af_level",
+        "RF": "rf_gain",
+        "SQL": "squelch",
+        "NR": "nr_level",
+        "NB": "nb_level",
+        "COMP": "compressor_level",
+        "MICGAIN": "mic_gain",
+        "MONITOR_GAIN": "monitor_gain",
+        "KEYSPD": "key_speed",
+        "CWPITCH": "cw_pitch",
+        "PREAMP": "preamp",
+        "ATT": "att",
+    }
+    if level == "RFPOWER":
+        params["power_level"] = round(value * 255)
+    elif level in {"AF", "RF", "SQL", "NR", "NB", "COMP", "MICGAIN", "MONITOR_GAIN"}:
+        params[receiver_control_names[level]] = max(0, min(255, round(value * 255)))
+    elif level in receiver_control_names:
+        params[receiver_control_names[level]] = round(value)
+
+
+def _level_target(params: Mapping[str, Any], receiver: str) -> FieldPath | None:
+    level = str(params["level"]).upper()
+    if level == "RFPOWER":
+        return FieldPath.global_("operator_controls", "power_level")
+    names = {
+        "AF": "af_level",
+        "RF": "rf_gain",
+        "SQL": "squelch",
+        "NR": "nr_level",
+        "NB": "nb_level",
+        "COMP": "compressor_level",
+        "MICGAIN": "mic_gain",
+        "MONITOR_GAIN": "monitor_gain",
+        "KEYSPD": "key_speed",
+        "CWPITCH": "cw_pitch",
+        "PREAMP": "preamp",
+        "ATT": "att",
+    }
+    name = names.get(level)
+    if name is None:
+        return None
+    return FieldPath.receiver(receiver, "operator_controls", name)

--- a/src/rigplane/core/observation_adapter.py
+++ b/src/rigplane/core/observation_adapter.py
@@ -1,0 +1,89 @@
+"""Helpers for translating backend reads into state observations."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from rigplane.core.command_service import command_response_observation
+from rigplane.core.state_acquisition_policy import RadioAcquisitionProfile
+from rigplane.core.state_pipeline_contracts import (
+    CommandIntent,
+    FieldPath,
+    Observation,
+    ObservationSource,
+    SourceMetadata,
+)
+
+Clock = Callable[[], float]
+
+__all__ = ["ProviderObservationAdapter"]
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderObservationAdapter:
+    """Build observations using provider capability and policy metadata."""
+
+    profile: RadioAcquisitionProfile
+    source: ObservationSource
+    transport: str | None = None
+    clock: Clock = time.monotonic
+
+    def observation(
+        self,
+        path: FieldPath,
+        value: Any,
+        *,
+        native_id: str | None = None,
+        timestamp_monotonic: float | None = None,
+        max_age: float | None = None,
+    ) -> Observation:
+        return Observation(
+            path=path,
+            value=value,
+            source=SourceMetadata(
+                source=self.source,
+                provider=self.profile.provider,
+                transport=self.transport,
+                native_id=native_id,
+                capability_id=str(path),
+            ),
+            timestamp_monotonic=(
+                self.clock() if timestamp_monotonic is None else timestamp_monotonic
+            ),
+            max_age=(
+                self.profile.policy_for(path).freshness_ttl_seconds
+                if max_age is None
+                else max_age
+            ),
+        )
+
+    def command_response(
+        self,
+        intent: CommandIntent,
+        *,
+        value: Any = None,
+        timestamp_monotonic: float | None = None,
+    ) -> Observation:
+        observation = command_response_observation(
+            intent,
+            timestamp_monotonic=(
+                self.clock() if timestamp_monotonic is None else timestamp_monotonic
+            ),
+            provider=self.profile.provider,
+            transport=self.transport,
+            value=value,
+        )
+        if intent.target is None:
+            return observation
+        return Observation(
+            path=observation.path,
+            value=observation.value,
+            source=observation.source,
+            timestamp_monotonic=observation.timestamp_monotonic,
+            quality=observation.quality,
+            correlation_id=observation.correlation_id,
+            max_age=self.profile.policy_for(intent.target).freshness_ttl_seconds,
+        )

--- a/src/rigplane/core/state_acquisition_policy.py
+++ b/src/rigplane/core/state_acquisition_policy.py
@@ -53,6 +53,17 @@ class ExternalCatPauseBehavior(StrEnum):
 _TOKEN_ALPHABET = frozenset("abcdefghijklmnopqrstuvwxyz0123456789_")
 
 
+def _reject_unknown_keys(
+    value: Mapping[str, Any],
+    *,
+    allowed: frozenset[str],
+    label: str,
+) -> None:
+    unknown = sorted(set(value) - allowed)
+    if unknown:
+        raise ValueError(f"{label} unknown keys: {', '.join(unknown)}")
+
+
 def _validate_token(value: str, *, label: str) -> str:
     if not value:
         raise ValueError(f"{label} must not be empty")
@@ -61,10 +72,28 @@ def _validate_token(value: str, *, label: str) -> str:
     return value
 
 
+def _strict_bool(value: Any, *, label: str) -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{label} must be a bool")
+    return value
+
+
+def _strict_float(value: Any, *, label: str) -> float:
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        raise ValueError(f"{label} must be a number")
+    return float(value)
+
+
+def _strict_int(value: Any, *, label: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValueError(f"{label} must be an integer")
+    return value
+
+
 def _optional_positive_float(value: Any, *, label: str) -> float | None:
     if value is None:
         return None
-    number = float(value)
+    number = _strict_float(value, label=label)
     if number <= 0:
         raise ValueError(f"{label} must be positive")
     return number
@@ -79,14 +108,21 @@ class AdaptiveDecayPolicy:
     max_cadence_seconds: float | None = None
 
     def __post_init__(self) -> None:
-        if self.idle_multiplier < 1.0:
+        enabled = _strict_bool(self.enabled, label="enabled")
+        idle_multiplier = _strict_float(
+            self.idle_multiplier,
+            label="idle_multiplier",
+        )
+        if idle_multiplier < 1.0:
             raise ValueError("idle_multiplier must be >= 1.0")
         max_cadence = _optional_positive_float(
             self.max_cadence_seconds,
             label="max_cadence_seconds",
         )
-        if self.enabled and self.idle_multiplier <= 1.0:
+        if enabled and idle_multiplier <= 1.0:
             raise ValueError("enabled adaptive decay requires idle_multiplier > 1.0")
+        object.__setattr__(self, "enabled", enabled)
+        object.__setattr__(self, "idle_multiplier", idle_multiplier)
         object.__setattr__(self, "max_cadence_seconds", max_cadence)
 
     def to_dict(self) -> dict[str, Any]:
@@ -100,13 +136,24 @@ class AdaptiveDecayPolicy:
     def from_dict(cls, value: Mapping[str, Any] | None) -> AdaptiveDecayPolicy:
         if value is None:
             return cls()
+        _reject_unknown_keys(
+            value,
+            allowed=frozenset(
+                {
+                    "enabled",
+                    "idleMultiplier",
+                    "maxCadenceSeconds",
+                }
+            ),
+            label="adaptiveDecay",
+        )
         return cls(
-            enabled=bool(value.get("enabled", False)),
-            idle_multiplier=float(value.get("idleMultiplier", 1.0)),
+            enabled=value.get("enabled", False),
+            idle_multiplier=value.get("idleMultiplier", 1.0),
             max_cadence_seconds=(
                 None
                 if value.get("maxCadenceSeconds") is None
-                else float(value["maxCadenceSeconds"])
+                else value["maxCadenceSeconds"]
             ),
         )
 
@@ -119,10 +166,21 @@ class MeterCoalescingPolicy:
     max_samples: int | None = None
 
     def __post_init__(self) -> None:
-        if self.window_seconds < 0:
+        window_seconds = _strict_float(
+            self.window_seconds,
+            label="window_seconds",
+        )
+        max_samples = (
+            None
+            if self.max_samples is None
+            else _strict_int(self.max_samples, label="max_samples")
+        )
+        if window_seconds < 0:
             raise ValueError("window_seconds must be non-negative")
-        if self.max_samples is not None and self.max_samples <= 0:
+        if max_samples is not None and max_samples <= 0:
             raise ValueError("max_samples must be positive")
+        object.__setattr__(self, "window_seconds", window_seconds)
+        object.__setattr__(self, "max_samples", max_samples)
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -137,10 +195,15 @@ class MeterCoalescingPolicy:
     ) -> MeterCoalescingPolicy | None:
         if value is None:
             return None
+        _reject_unknown_keys(
+            value,
+            allowed=frozenset({"windowSeconds", "maxSamples"}),
+            label="meterCoalescing",
+        )
         return cls(
-            window_seconds=float(value["windowSeconds"]),
+            window_seconds=value["windowSeconds"],
             max_samples=(
-                None if value.get("maxSamples") is None else int(value["maxSamples"])
+                None if value.get("maxSamples") is None else value["maxSamples"]
             ),
         )
 
@@ -202,17 +265,36 @@ class AcquisitionPolicy:
 
     @classmethod
     def from_dict(cls, value: Mapping[str, Any]) -> AcquisitionPolicy:
+        _reject_unknown_keys(
+            value,
+            allowed=frozenset(
+                {
+                    "cadenceSeconds",
+                    "freshnessTtlSeconds",
+                    "reconciliationPriority",
+                    "adaptiveDecay",
+                    "externalCatPause",
+                    "meterCoalescing",
+                }
+            ),
+            label="acquisition policy",
+        )
+        cadence_seconds = (
+            None
+            if value.get("cadenceSeconds") is None
+            else _strict_float(value["cadenceSeconds"], label="cadenceSeconds")
+        )
+        freshness_ttl_seconds = (
+            None
+            if value.get("freshnessTtlSeconds") is None
+            else _strict_float(
+                value["freshnessTtlSeconds"],
+                label="freshnessTtlSeconds",
+            )
+        )
         return cls(
-            cadence_seconds=(
-                None
-                if value.get("cadenceSeconds") is None
-                else float(value["cadenceSeconds"])
-            ),
-            freshness_ttl_seconds=(
-                None
-                if value.get("freshnessTtlSeconds") is None
-                else float(value["freshnessTtlSeconds"])
-            ),
+            cadence_seconds=cadence_seconds,
+            freshness_ttl_seconds=freshness_ttl_seconds,
             reconciliation_priority=ReconciliationPriority(
                 str(value.get("reconciliationPriority", ReconciliationPriority.POLL))
             ),
@@ -246,22 +328,40 @@ class FieldCapability:
 
     def __post_init__(self) -> None:
         availability = FieldAvailability(str(self.availability))
+        unsolicited_push = _strict_bool(
+            self.unsolicited_push,
+            label="unsolicitedPush",
+        )
+        polling = _strict_bool(self.polling, label="polling")
+        stream_like = _strict_bool(self.stream_like, label="streamLike")
+        command_response_observable = _strict_bool(
+            self.command_response_observable,
+            label="commandResponseObservable",
+        )
         controls = tuple(str(control) for control in self.supported_controls)
         for control in controls:
             _validate_token(control, label="supported control")
         if availability is not FieldAvailability.SUPPORTED and (
-            self.unsolicited_push
-            or self.polling
-            or self.stream_like
-            or self.command_response_observable
+            unsolicited_push
+            or polling
+            or stream_like
+            or command_response_observable
             or controls
         ):
             raise ValueError(
                 f"{self.path}: unavailable fields cannot be acquired or controlled"
             )
-        if self.stream_like and self.path.family is not FieldFamily.METERS:
+        if stream_like and self.path.family is not FieldFamily.METERS:
             raise ValueError(f"{self.path}: stream_like fields must be meters")
         object.__setattr__(self, "availability", availability)
+        object.__setattr__(self, "unsolicited_push", unsolicited_push)
+        object.__setattr__(self, "polling", polling)
+        object.__setattr__(self, "stream_like", stream_like)
+        object.__setattr__(
+            self,
+            "command_response_observable",
+            command_response_observable,
+        )
         object.__setattr__(self, "supported_controls", controls)
 
     @property
@@ -289,16 +389,33 @@ class FieldCapability:
 
     @classmethod
     def from_dict(cls, value: Mapping[str, Any]) -> FieldCapability:
+        _reject_unknown_keys(
+            value,
+            allowed=frozenset(
+                {
+                    "path",
+                    "availability",
+                    "unsolicitedPush",
+                    "polling",
+                    "streamLike",
+                    "commandResponseObservable",
+                    "supportedControls",
+                    "diagnostic",
+                }
+            ),
+            label="field capability",
+        )
         return cls(
             path=FieldPath.parse(str(value["path"])),
             availability=FieldAvailability(
                 str(value.get("availability", FieldAvailability.SUPPORTED))
             ),
-            unsolicited_push=bool(value.get("unsolicitedPush", False)),
-            polling=bool(value.get("polling", False)),
-            stream_like=bool(value.get("streamLike", False)),
-            command_response_observable=bool(
-                value.get("commandResponseObservable", False)
+            unsolicited_push=value.get("unsolicitedPush", False),
+            polling=value.get("polling", False),
+            stream_like=value.get("streamLike", False),
+            command_response_observable=value.get(
+                "commandResponseObservable",
+                False,
             ),
             supported_controls=tuple(
                 str(control) for control in value.get("supportedControls", ())
@@ -374,6 +491,18 @@ class RadioAcquisitionProfile:
 
     @classmethod
     def from_dict(cls, value: Mapping[str, Any]) -> RadioAcquisitionProfile:
+        _reject_unknown_keys(
+            value,
+            allowed=frozenset(
+                {
+                    "provider",
+                    "capabilities",
+                    "defaultPolicy",
+                    "fieldPolicies",
+                }
+            ),
+            label="radio acquisition profile",
+        )
         return cls(
             provider=str(value["provider"]),
             capabilities=tuple(

--- a/src/rigplane/core/state_acquisition_policy.py
+++ b/src/rigplane/core/state_acquisition_policy.py
@@ -1,0 +1,388 @@
+"""Radio state capability and acquisition-policy metadata.
+
+These schema objects describe what a provider can acquire and how future
+schedulers should acquire it. They intentionally do not implement scheduling.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any
+
+from rigplane.core.state_pipeline_contracts import FieldFamily, FieldPath
+
+__all__ = [
+    "AcquisitionPolicy",
+    "AdaptiveDecayPolicy",
+    "ExternalCatPauseBehavior",
+    "FieldAvailability",
+    "FieldCapability",
+    "MeterCoalescingPolicy",
+    "RadioAcquisitionProfile",
+    "ReconciliationPriority",
+]
+
+
+class FieldAvailability(StrEnum):
+    """Whether a state field is available from a provider."""
+
+    SUPPORTED = "supported"
+    UNSUPPORTED = "unsupported"
+    UNKNOWN = "unknown"
+
+
+class ReconciliationPriority(StrEnum):
+    """Preferred source when several observations can update the same field."""
+
+    UNSOLICITED = "unsolicited"
+    COMMAND_RESPONSE = "command_response"
+    POLL = "poll"
+    LAST_OBSERVATION = "last_observation"
+
+
+class ExternalCatPauseBehavior(StrEnum):
+    """How acquisition reacts while an external CAT owner controls the radio."""
+
+    PAUSE_POLLING = "pause_polling"
+    COALESCE_METERS_ONLY = "coalesce_meters_only"
+    CONTINUE = "continue"
+
+
+_TOKEN_ALPHABET = frozenset("abcdefghijklmnopqrstuvwxyz0123456789_")
+
+
+def _validate_token(value: str, *, label: str) -> str:
+    if not value:
+        raise ValueError(f"{label} must not be empty")
+    if any(ch not in _TOKEN_ALPHABET for ch in value):
+        raise ValueError(f"{label} must use lowercase snake-case tokens: {value!r}")
+    return value
+
+
+def _optional_positive_float(value: Any, *, label: str) -> float | None:
+    if value is None:
+        return None
+    number = float(value)
+    if number <= 0:
+        raise ValueError(f"{label} must be positive")
+    return number
+
+
+@dataclass(frozen=True, slots=True)
+class AdaptiveDecayPolicy:
+    """Cadence widening policy for idle or low-value fields."""
+
+    enabled: bool = False
+    idle_multiplier: float = 1.0
+    max_cadence_seconds: float | None = None
+
+    def __post_init__(self) -> None:
+        if self.idle_multiplier < 1.0:
+            raise ValueError("idle_multiplier must be >= 1.0")
+        max_cadence = _optional_positive_float(
+            self.max_cadence_seconds,
+            label="max_cadence_seconds",
+        )
+        if self.enabled and self.idle_multiplier <= 1.0:
+            raise ValueError("enabled adaptive decay requires idle_multiplier > 1.0")
+        object.__setattr__(self, "max_cadence_seconds", max_cadence)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "enabled": self.enabled,
+            "idleMultiplier": self.idle_multiplier,
+            "maxCadenceSeconds": self.max_cadence_seconds,
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any] | None) -> AdaptiveDecayPolicy:
+        if value is None:
+            return cls()
+        return cls(
+            enabled=bool(value.get("enabled", False)),
+            idle_multiplier=float(value.get("idleMultiplier", 1.0)),
+            max_cadence_seconds=(
+                None
+                if value.get("maxCadenceSeconds") is None
+                else float(value["maxCadenceSeconds"])
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class MeterCoalescingPolicy:
+    """Short-window coalescing policy for stream-like meter updates."""
+
+    window_seconds: float
+    max_samples: int | None = None
+
+    def __post_init__(self) -> None:
+        if self.window_seconds < 0:
+            raise ValueError("window_seconds must be non-negative")
+        if self.max_samples is not None and self.max_samples <= 0:
+            raise ValueError("max_samples must be positive")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "windowSeconds": self.window_seconds,
+            "maxSamples": self.max_samples,
+        }
+
+    @classmethod
+    def from_dict(
+        cls,
+        value: Mapping[str, Any] | None,
+    ) -> MeterCoalescingPolicy | None:
+        if value is None:
+            return None
+        return cls(
+            window_seconds=float(value["windowSeconds"]),
+            max_samples=(
+                None if value.get("maxSamples") is None else int(value["maxSamples"])
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class AcquisitionPolicy:
+    """Scheduler-facing policy for acquiring one or more fields."""
+
+    cadence_seconds: float | None = 5.0
+    freshness_ttl_seconds: float | None = 15.0
+    reconciliation_priority: ReconciliationPriority | str = ReconciliationPriority.POLL
+    adaptive_decay: AdaptiveDecayPolicy = field(default_factory=AdaptiveDecayPolicy)
+    external_cat_pause: ExternalCatPauseBehavior | str = (
+        ExternalCatPauseBehavior.PAUSE_POLLING
+    )
+    meter_coalescing: MeterCoalescingPolicy | None = None
+
+    def __post_init__(self) -> None:
+        cadence = _optional_positive_float(
+            self.cadence_seconds,
+            label="cadence_seconds",
+        )
+        ttl = _optional_positive_float(
+            self.freshness_ttl_seconds,
+            label="freshness_ttl_seconds",
+        )
+        if cadence is not None and ttl is not None and ttl < cadence:
+            raise ValueError("freshness_ttl_seconds must be >= cadence_seconds")
+        object.__setattr__(self, "cadence_seconds", cadence)
+        object.__setattr__(self, "freshness_ttl_seconds", ttl)
+        object.__setattr__(
+            self,
+            "reconciliation_priority",
+            ReconciliationPriority(str(self.reconciliation_priority)),
+        )
+        object.__setattr__(
+            self,
+            "external_cat_pause",
+            ExternalCatPauseBehavior(str(self.external_cat_pause)),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "cadenceSeconds": self.cadence_seconds,
+            "freshnessTtlSeconds": self.freshness_ttl_seconds,
+            "reconciliationPriority": ReconciliationPriority(
+                str(self.reconciliation_priority)
+            ).value,
+            "adaptiveDecay": self.adaptive_decay.to_dict(),
+            "externalCatPause": ExternalCatPauseBehavior(
+                str(self.external_cat_pause)
+            ).value,
+            "meterCoalescing": (
+                None
+                if self.meter_coalescing is None
+                else self.meter_coalescing.to_dict()
+            ),
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> AcquisitionPolicy:
+        return cls(
+            cadence_seconds=(
+                None
+                if value.get("cadenceSeconds") is None
+                else float(value["cadenceSeconds"])
+            ),
+            freshness_ttl_seconds=(
+                None
+                if value.get("freshnessTtlSeconds") is None
+                else float(value["freshnessTtlSeconds"])
+            ),
+            reconciliation_priority=ReconciliationPriority(
+                str(value.get("reconciliationPriority", ReconciliationPriority.POLL))
+            ),
+            adaptive_decay=AdaptiveDecayPolicy.from_dict(value.get("adaptiveDecay")),
+            external_cat_pause=ExternalCatPauseBehavior(
+                str(
+                    value.get(
+                        "externalCatPause",
+                        ExternalCatPauseBehavior.PAUSE_POLLING,
+                    )
+                )
+            ),
+            meter_coalescing=MeterCoalescingPolicy.from_dict(
+                value.get("meterCoalescing")
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class FieldCapability:
+    """Provider capability metadata for one field path."""
+
+    path: FieldPath
+    availability: FieldAvailability | str = FieldAvailability.SUPPORTED
+    unsolicited_push: bool = False
+    polling: bool = False
+    stream_like: bool = False
+    command_response_observable: bool = False
+    supported_controls: tuple[str, ...] = ()
+    diagnostic: str = ""
+
+    def __post_init__(self) -> None:
+        availability = FieldAvailability(str(self.availability))
+        controls = tuple(str(control) for control in self.supported_controls)
+        for control in controls:
+            _validate_token(control, label="supported control")
+        if availability is not FieldAvailability.SUPPORTED and (
+            self.unsolicited_push
+            or self.polling
+            or self.stream_like
+            or self.command_response_observable
+            or controls
+        ):
+            raise ValueError(
+                f"{self.path}: unavailable fields cannot be acquired or controlled"
+            )
+        if self.stream_like and self.path.family is not FieldFamily.METERS:
+            raise ValueError(f"{self.path}: stream_like fields must be meters")
+        object.__setattr__(self, "availability", availability)
+        object.__setattr__(self, "supported_controls", controls)
+
+    @property
+    def can_poll(self) -> bool:
+        return self.availability is FieldAvailability.SUPPORTED and self.polling
+
+    @property
+    def is_unavailable(self) -> bool:
+        return self.availability in (
+            FieldAvailability.UNSUPPORTED,
+            FieldAvailability.UNKNOWN,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "path": str(self.path),
+            "availability": FieldAvailability(str(self.availability)).value,
+            "unsolicitedPush": self.unsolicited_push,
+            "polling": self.polling,
+            "streamLike": self.stream_like,
+            "commandResponseObservable": self.command_response_observable,
+            "supportedControls": list(self.supported_controls),
+            "diagnostic": self.diagnostic,
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> FieldCapability:
+        return cls(
+            path=FieldPath.parse(str(value["path"])),
+            availability=FieldAvailability(
+                str(value.get("availability", FieldAvailability.SUPPORTED))
+            ),
+            unsolicited_push=bool(value.get("unsolicitedPush", False)),
+            polling=bool(value.get("polling", False)),
+            stream_like=bool(value.get("streamLike", False)),
+            command_response_observable=bool(
+                value.get("commandResponseObservable", False)
+            ),
+            supported_controls=tuple(
+                str(control) for control in value.get("supportedControls", ())
+            ),
+            diagnostic=str(value.get("diagnostic", "")),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class RadioAcquisitionProfile:
+    """Provider-specific state acquisition metadata for one radio profile."""
+
+    provider: str
+    capabilities: tuple[FieldCapability, ...] = ()
+    default_policy: AcquisitionPolicy = field(default_factory=AcquisitionPolicy)
+    field_policies: Mapping[FieldPath, AcquisitionPolicy] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        _validate_token(self.provider, label="provider")
+        by_path: dict[FieldPath, FieldCapability] = {}
+        for capability in self.capabilities:
+            if capability.path in by_path:
+                raise ValueError(f"duplicate capability path: {capability.path}")
+            by_path[capability.path] = capability
+        policies = dict(self.field_policies)
+        for path, policy in policies.items():
+            if (
+                policy.meter_coalescing is not None
+                and path.family is not FieldFamily.METERS
+            ):
+                raise ValueError(f"{path}: meter_coalescing requires meter fields")
+        object.__setattr__(self, "capabilities", tuple(by_path.values()))
+        object.__setattr__(self, "field_policies", policies)
+
+    def capability_for(self, path: FieldPath) -> FieldCapability:
+        for capability in self.capabilities:
+            if capability.path == path:
+                return capability
+        return FieldCapability(
+            path=path,
+            availability=FieldAvailability.UNKNOWN,
+            diagnostic=f"{path}: missing capability metadata",
+        )
+
+    def policy_for(self, path: FieldPath) -> AcquisitionPolicy:
+        return self.field_policies.get(path, self.default_policy)
+
+    def pollable_paths(self) -> tuple[FieldPath, ...]:
+        return tuple(
+            capability.path for capability in self.capabilities if capability.can_poll
+        )
+
+    def unavailable_paths(self) -> tuple[FieldPath, ...]:
+        return tuple(
+            capability.path
+            for capability in self.capabilities
+            if capability.is_unavailable
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "provider": self.provider,
+            "capabilities": [capability.to_dict() for capability in self.capabilities],
+            "defaultPolicy": self.default_policy.to_dict(),
+            "fieldPolicies": {
+                str(path): policy.to_dict()
+                for path, policy in sorted(
+                    self.field_policies.items(),
+                    key=lambda item: str(item[0]),
+                )
+            },
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> RadioAcquisitionProfile:
+        return cls(
+            provider=str(value["provider"]),
+            capabilities=tuple(
+                FieldCapability.from_dict(item)
+                for item in value.get("capabilities", ())
+            ),
+            default_policy=AcquisitionPolicy.from_dict(value.get("defaultPolicy", {})),
+            field_policies={
+                FieldPath.parse(str(path)): AcquisitionPolicy.from_dict(policy)
+                for path, policy in value.get("fieldPolicies", {}).items()
+            },
+        )

--- a/src/rigplane/core/state_acquisition_policy.py
+++ b/src/rigplane/core/state_acquisition_policy.py
@@ -512,8 +512,11 @@ class RadioAcquisitionProfile:
             ),
             label="radio acquisition profile",
         )
+        provider = value["provider"]
+        if not isinstance(provider, str):
+            raise ValueError("provider must be a string")
         return cls(
-            provider=str(value["provider"]),
+            provider=provider,
             capabilities=tuple(
                 FieldCapability.from_dict(item)
                 for item in value.get("capabilities", ())

--- a/src/rigplane/core/state_acquisition_policy.py
+++ b/src/rigplane/core/state_acquisition_policy.py
@@ -331,7 +331,7 @@ class FieldCapability:
     polling: bool = False
     stream_like: bool = False
     command_response_observable: bool = False
-    supported_controls: tuple[str, ...] = ()
+    supported_controls: Sequence[str] | None = ()
     diagnostic: str = ""
 
     def __post_init__(self) -> None:
@@ -346,7 +346,14 @@ class FieldCapability:
             self.command_response_observable,
             label="commandResponseObservable",
         )
-        controls = tuple(str(control) for control in self.supported_controls)
+        controls = (
+            ()
+            if self.supported_controls is None
+            else _strict_string_sequence(
+                self.supported_controls,
+                label="supported_controls",
+            )
+        )
         for control in controls:
             _validate_token(control, label="supported control")
         if availability is not FieldAvailability.SUPPORTED and (
@@ -391,7 +398,7 @@ class FieldCapability:
             "polling": self.polling,
             "streamLike": self.stream_like,
             "commandResponseObservable": self.command_response_observable,
-            "supportedControls": list(self.supported_controls),
+            "supportedControls": list(self.supported_controls or ()),
             "diagnostic": self.diagnostic,
         }
 

--- a/src/rigplane/core/state_acquisition_policy.py
+++ b/src/rigplane/core/state_acquisition_policy.py
@@ -6,7 +6,7 @@ schedulers should acquire it. They intentionally do not implement scheduling.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Any
@@ -88,6 +88,14 @@ def _strict_int(value: Any, *, label: str) -> int:
     if not isinstance(value, int) or isinstance(value, bool):
         raise ValueError(f"{label} must be an integer")
     return value
+
+
+def _strict_string_sequence(value: Any, *, label: str) -> tuple[str, ...]:
+    if isinstance(value, str) or not isinstance(value, Sequence):
+        raise ValueError(f"{label} must be a sequence of strings")
+    if not all(isinstance(item, str) for item in value):
+        raise ValueError(f"{label} must be a sequence of strings")
+    return tuple(value)
 
 
 def _optional_positive_float(value: Any, *, label: str) -> float | None:
@@ -417,8 +425,9 @@ class FieldCapability:
                 "commandResponseObservable",
                 False,
             ),
-            supported_controls=tuple(
-                str(control) for control in value.get("supportedControls", ())
+            supported_controls=_strict_string_sequence(
+                value.get("supportedControls", ()),
+                label="supportedControls",
             ),
             diagnostic=str(value.get("diagnostic", "")),
         )

--- a/src/rigplane/core/state_diagnostics.py
+++ b/src/rigplane/core/state_diagnostics.py
@@ -1,0 +1,93 @@
+"""Behavior-neutral diagnostics for legacy state pipeline migration."""
+
+from __future__ import annotations
+
+import time
+from collections import Counter, deque
+from dataclasses import dataclass
+from typing import Any, Literal
+
+__all__ = [
+    "StateDiagnosticEvent",
+    "StateDiagnosticKind",
+    "StateDiagnosticsRecorder",
+]
+
+StateDiagnosticKind = Literal[
+    "backend_read",
+    "direct_state_write",
+    "meter_cadence",
+    "revision_producing_event",
+    "rigctld_delivery_trigger",
+    "web_delivery_trigger",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class StateDiagnosticEvent:
+    """One recorded state-pipeline diagnostic event."""
+
+    kind: str
+    source: str
+    monotonic_ts: float
+    details: dict[str, Any]
+
+
+class StateDiagnosticsRecorder:
+    """Small in-memory event recorder, disabled by default.
+
+    The recorder intentionally has no side effects when disabled. Runtime
+    instrumentation may call :meth:`record` from hot paths; normal behavior is
+    unchanged unless tests or debug startup explicitly enable this object.
+    """
+
+    def __init__(self, *, enabled: bool = False, max_events: int = 512) -> None:
+        if max_events <= 0:
+            raise ValueError("max_events must be positive")
+        self.enabled = enabled
+        self._events: deque[StateDiagnosticEvent] = deque(maxlen=max_events)
+        self._counts: Counter[str] = Counter()
+
+    def record(
+        self,
+        kind: StateDiagnosticKind | str,
+        source: str,
+        **details: Any,
+    ) -> StateDiagnosticEvent | None:
+        """Record an event when enabled; otherwise return ``None``."""
+        if not self.enabled:
+            return None
+        event = StateDiagnosticEvent(
+            kind=str(kind),
+            source=source,
+            monotonic_ts=time.monotonic(),
+            details=dict(details),
+        )
+        self._events.append(event)
+        self._counts[event.kind] += 1
+        return event
+
+    def events(self) -> tuple[StateDiagnosticEvent, ...]:
+        """Return recorded events in insertion order."""
+        return tuple(self._events)
+
+    def clear(self) -> None:
+        """Clear recorded events and counters."""
+        self._events.clear()
+        self._counts.clear()
+
+    def snapshot(self) -> dict[str, Any]:
+        """Return a JSON-friendly snapshot of recorded diagnostics."""
+        return {
+            "enabled": self.enabled,
+            "counts": dict(self._counts),
+            "events": [
+                {
+                    "kind": event.kind,
+                    "source": event.source,
+                    "monotonicTs": event.monotonic_ts,
+                    "details": dict(event.details),
+                }
+                for event in self._events
+            ],
+        }

--- a/src/rigplane/core/state_pipeline_contracts.py
+++ b/src/rigplane/core/state_pipeline_contracts.py
@@ -528,10 +528,20 @@ class SourceMetadata:
     transport: str | None = None
     native_id: str | None = None
     capability_id: str | None = None
+    command_source: CommandSource | None = None
+    session_id: str | None = None
 
     def __post_init__(self) -> None:
         _validate_source(self.source, _OBSERVATION_SOURCES, label="observation source")
         _validate_token(self.provider, label="provider")
+        if self.command_source is not None:
+            _validate_source(
+                self.command_source,
+                _COMMAND_SOURCES,
+                label="command source",
+            )
+        if self.session_id is not None and not self.session_id:
+            raise ValueError("session_id must not be empty")
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -540,6 +550,8 @@ class SourceMetadata:
             "transport": self.transport,
             "nativeId": self.native_id,
             "capabilityId": self.capability_id,
+            "commandSource": self.command_source,
+            "sessionId": self.session_id,
         }
 
     @classmethod
@@ -555,6 +567,16 @@ class SourceMetadata:
                 None
                 if value.get("capabilityId") is None
                 else str(value["capabilityId"])
+            ),
+            command_source=(
+                None
+                if value.get("commandSource") is None
+                else _command_source(value["commandSource"])
+            ),
+            session_id=(
+                None
+                if value.get("sessionId") is None
+                else str(value["sessionId"])
             ),
         )
 

--- a/src/rigplane/core/state_pipeline_contracts.py
+++ b/src/rigplane/core/state_pipeline_contracts.py
@@ -701,6 +701,8 @@ class ChangeSet:
     timestamp_monotonic: float
     sources: tuple[SourceMetadata, ...]
     coalesced: bool = False
+    observed_paths: tuple[FieldPath, ...] = ()
+    freshness_paths: tuple[FieldPath, ...] = ()
 
     def __post_init__(self) -> None:
         if self.revision < 0:
@@ -709,6 +711,22 @@ class ChangeSet:
             raise ValueError("freshness_revision must be non-negative")
         if self.observation_seq < 0:
             raise ValueError("observation_seq must be non-negative")
+        object.__setattr__(
+            self,
+            "observed_paths",
+            tuple(
+                FieldPath.from_dict(path) if isinstance(path, str) else path
+                for path in self.observed_paths
+            ),
+        )
+        object.__setattr__(
+            self,
+            "freshness_paths",
+            tuple(
+                FieldPath.from_dict(path) if isinstance(path, str) else path
+                for path in self.freshness_paths
+            ),
+        )
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -719,6 +737,8 @@ class ChangeSet:
             "timestampMonotonic": self.timestamp_monotonic,
             "sources": [source.to_dict() for source in self.sources],
             "coalesced": self.coalesced,
+            "observedPaths": [str(path) for path in self.observed_paths],
+            "freshnessPaths": [str(path) for path in self.freshness_paths],
         }
 
     @classmethod
@@ -731,6 +751,12 @@ class ChangeSet:
             timestamp_monotonic=float(value["timestampMonotonic"]),
             sources=tuple(SourceMetadata.from_dict(item) for item in value["sources"]),
             coalesced=_optional_bool(value, "coalesced", default=False),
+            observed_paths=tuple(
+                FieldPath.from_dict(item) for item in value.get("observedPaths", ())
+            ),
+            freshness_paths=tuple(
+                FieldPath.from_dict(item) for item in value.get("freshnessPaths", ())
+            ),
         )
 
 

--- a/src/rigplane/core/state_pipeline_contracts.py
+++ b/src/rigplane/core/state_pipeline_contracts.py
@@ -62,6 +62,7 @@ CommandLifecycleState = Literal[
     "failed",
     "timed_out",
     "confirmed",
+    "reconciled",
     "superseded",
 ]
 

--- a/src/rigplane/core/state_pipeline_contracts.py
+++ b/src/rigplane/core/state_pipeline_contracts.py
@@ -574,9 +574,7 @@ class SourceMetadata:
                 else _command_source(value["commandSource"])
             ),
             session_id=(
-                None
-                if value.get("sessionId") is None
-                else str(value["sessionId"])
+                None if value.get("sessionId") is None else str(value["sessionId"])
             ),
         )
 

--- a/src/rigplane/core/state_pipeline_contracts.py
+++ b/src/rigplane/core/state_pipeline_contracts.py
@@ -1,0 +1,925 @@
+"""Backend-neutral contracts for the radio state pipeline.
+
+These contracts describe state paths, observations, changes, and command
+events. They intentionally do not implement a production StateStore.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any, Literal, cast, get_args
+
+__all__ = [
+    "CapabilityMetadata",
+    "ChangeSet",
+    "CommandIntent",
+    "CommandLifecycleEvent",
+    "CommandLifecycleState",
+    "CommandPriority",
+    "CommandSource",
+    "FieldChange",
+    "FieldFamily",
+    "FieldPath",
+    "FieldRegistry",
+    "FieldScope",
+    "FieldSpec",
+    "Observation",
+    "ObservationSource",
+    "PendingPolicy",
+    "SourceMetadata",
+    "VfoSlot",
+]
+
+
+ObservationSource = Literal[
+    "civ_unsolicited",
+    "command_response",
+    "poll_response",
+    "state_poller",
+    "hamlib_response",
+    "yaesu_poll_response",
+    "local_reconcile",
+    "test",
+]
+CommandSource = Literal[
+    "websocket",
+    "http",
+    "rigctld",
+    "public_api",
+    "internal_policy",
+    "diagnostics",
+    "test",
+]
+CommandPriority = Literal["user", "normal", "background"]
+PendingPolicy = Literal["none", "scoped", "global"]
+CommandLifecycleState = Literal[
+    "accepted",
+    "queued",
+    "sent",
+    "acknowledged",
+    "failed",
+    "timed_out",
+    "confirmed",
+    "superseded",
+]
+
+_OBSERVATION_SOURCES: frozenset[str] = frozenset(get_args(ObservationSource))
+_COMMAND_SOURCES: frozenset[str] = frozenset(get_args(CommandSource))
+_COMMAND_PRIORITIES: frozenset[str] = frozenset(get_args(CommandPriority))
+_PENDING_POLICIES: frozenset[str] = frozenset(get_args(PendingPolicy))
+_COMMAND_STATES: frozenset[str] = frozenset(get_args(CommandLifecycleState))
+
+
+class FieldScope(StrEnum):
+    """Top-level state path scope."""
+
+    GLOBAL = "global"
+    RECEIVER = "receiver"
+    SCOPE_CONTROLS = "scope_controls"
+    CONNECTION = "connection"
+    HEALTH = "health"
+
+
+class VfoSlot(StrEnum):
+    """VFO slot dimension for receiver-scoped frequency/mode fields."""
+
+    ACTIVE = "active"
+    A = "A"
+    B = "B"
+
+
+class FieldFamily(StrEnum):
+    """Canonical family for a radio state field."""
+
+    FREQ_MODE = "freq_mode"
+    VFO = "vfo"
+    OPERATOR_TOGGLES = "operator_toggles"
+    OPERATOR_CONTROLS = "operator_controls"
+    METERS = "meters"
+    TX_STATE = "tx_state"
+    SLOW_STATE = "slow_state"
+    DISPLAY = "display"
+    CONNECTION = "connection"
+    HEALTH = "health"
+
+
+_TOKEN_ALPHABET = frozenset("abcdefghijklmnopqrstuvwxyz0123456789_")
+
+
+def _validate_token(value: str, *, label: str) -> str:
+    if not value:
+        raise ValueError(f"{label} must not be empty")
+    if any(ch not in _TOKEN_ALPHABET for ch in value):
+        raise ValueError(f"{label} must use lowercase snake-case tokens: {value!r}")
+    return value
+
+
+def _validate_family(value: str) -> FieldFamily:
+    _validate_token(value, label="family")
+    try:
+        return FieldFamily(value)
+    except ValueError as exc:
+        raise ValueError(f"unknown field family: {value!r}") from exc
+
+
+def _validate_source(value: str, allowed: frozenset[str], *, label: str) -> str:
+    if value not in allowed:
+        raise ValueError(f"unknown {label}: {value!r}")
+    return value
+
+
+def _observation_source(value: Any) -> ObservationSource:
+    text = str(value)
+    _validate_source(text, _OBSERVATION_SOURCES, label="observation source")
+    return cast(ObservationSource, text)
+
+
+def _command_source(value: Any) -> CommandSource:
+    text = str(value)
+    _validate_source(text, _COMMAND_SOURCES, label="command source")
+    return cast(CommandSource, text)
+
+
+def _command_priority(value: Any) -> CommandPriority:
+    text = str(value)
+    _validate_source(text, _COMMAND_PRIORITIES, label="command priority")
+    return cast(CommandPriority, text)
+
+
+def _pending_policy(value: Any) -> PendingPolicy:
+    text = str(value)
+    _validate_source(text, _PENDING_POLICIES, label="pending policy")
+    return cast(PendingPolicy, text)
+
+
+def _command_state(value: Any) -> CommandLifecycleState:
+    text = str(value)
+    _validate_source(text, _COMMAND_STATES, label="command lifecycle state")
+    return cast(CommandLifecycleState, text)
+
+
+@dataclass(frozen=True, order=True, slots=True)
+class FieldPath:
+    """Stable, serializable path to one radio state field.
+
+    Canonical string forms are:
+
+    - ``receiver.<rx>.slot.<A|B>.<family>.<name>``
+    - ``receiver.<rx>.active.<family>.<name>``
+    - ``receiver.<rx>.<family>.<name>``
+    - ``receiver.<rx>.vfo.active_slot``
+    - ``global.<family>.<name>``
+    - ``scope_controls.receiver.<rx>.<family>.<name>``
+    - ``scope_controls.global.<family>.<name>``
+    """
+
+    scope: FieldScope
+    family: FieldFamily
+    name: str
+    receiver_id: str | None = None
+    slot: VfoSlot | None = None
+
+    def __post_init__(self) -> None:
+        scope = FieldScope(str(self.scope))
+        family = _validate_family(str(self.family))
+        name = _validate_token(self.name, label="name")
+        receiver_id = (
+            None
+            if self.receiver_id is None
+            else _validate_token(self.receiver_id, label="receiver_id")
+        )
+        slot = None if self.slot is None else VfoSlot(str(self.slot))
+
+        if scope is FieldScope.RECEIVER and receiver_id is None:
+            raise ValueError("receiver field paths require receiver_id")
+        if scope in (FieldScope.GLOBAL, FieldScope.CONNECTION, FieldScope.HEALTH):
+            if receiver_id is not None or slot is not None:
+                raise ValueError(
+                    f"{scope.value} field paths cannot include receiver or slot"
+                )
+        if scope is FieldScope.SCOPE_CONTROLS and slot is not None:
+            raise ValueError("scope_controls field paths cannot include VFO slot")
+        if slot is VfoSlot.ACTIVE and scope is not FieldScope.RECEIVER:
+            raise ValueError("active VFO slot is only valid for receiver fields")
+        if slot is not None and family is not FieldFamily.FREQ_MODE:
+            raise ValueError("VFO slot paths are only valid for freq_mode fields")
+
+        object.__setattr__(self, "scope", scope)
+        object.__setattr__(self, "family", family)
+        object.__setattr__(self, "name", name)
+        object.__setattr__(self, "receiver_id", receiver_id)
+        object.__setattr__(self, "slot", slot)
+
+    @classmethod
+    def parse(cls, value: str) -> FieldPath:
+        parts = value.split(".")
+        if len(parts) < 3:
+            raise ValueError(f"field path is too short: {value!r}")
+
+        scope = parts[0]
+        if scope == FieldScope.RECEIVER.value:
+            return cls._parse_receiver(parts, raw=value)
+        if scope == FieldScope.GLOBAL.value:
+            if len(parts) != 3:
+                raise ValueError(f"global field path must have 3 parts: {value!r}")
+            return cls.global_(parts[1], parts[2])
+        if scope == FieldScope.SCOPE_CONTROLS.value:
+            return cls._parse_scope_controls(parts, raw=value)
+        if scope in (FieldScope.CONNECTION.value, FieldScope.HEALTH.value):
+            if len(parts) != 3:
+                raise ValueError(f"{scope} field path must have 3 parts: {value!r}")
+            return cls(FieldScope(scope), _validate_family(parts[1]), parts[2])
+        raise ValueError(f"unknown field path scope: {scope!r}")
+
+    @classmethod
+    def _parse_receiver(cls, parts: list[str], *, raw: str) -> FieldPath:
+        if len(parts) < 4:
+            raise ValueError(f"receiver field path is too short: {raw!r}")
+        receiver = parts[1]
+        marker = parts[2]
+        if marker == "slot":
+            if len(parts) != 6:
+                raise ValueError(f"receiver slot path must have 6 parts: {raw!r}")
+            return cls.vfo_slot(receiver, parts[3], parts[4], parts[5])
+        if marker == VfoSlot.ACTIVE.value:
+            if len(parts) != 5:
+                raise ValueError(f"receiver active path must have 5 parts: {raw!r}")
+            return cls.active(receiver, parts[3], parts[4])
+        if len(parts) != 4:
+            raise ValueError(f"receiver field path must have 4 parts: {raw!r}")
+        return cls.receiver(receiver, marker, parts[3])
+
+    @classmethod
+    def _parse_scope_controls(cls, parts: list[str], *, raw: str) -> FieldPath:
+        if parts[1] == "receiver":
+            if len(parts) != 5:
+                raise ValueError(
+                    f"receiver scope_controls path must have 5 parts: {raw!r}"
+                )
+            return cls.scope_control(parts[3], parts[4], receiver_id=parts[2])
+        if parts[1] == FieldScope.GLOBAL.value:
+            if len(parts) != 4:
+                raise ValueError(
+                    f"global scope_controls path must have 4 parts: {raw!r}"
+                )
+            return cls.scope_control(parts[2], parts[3])
+        raise ValueError(f"unknown scope_controls target: {parts[1]!r}")
+
+    @classmethod
+    def receiver(cls, receiver_id: str, family: str, name: str) -> FieldPath:
+        return cls(
+            scope=FieldScope.RECEIVER,
+            receiver_id=receiver_id,
+            slot=None,
+            family=_validate_family(family),
+            name=name,
+        )
+
+    @classmethod
+    def vfo_slot(
+        cls,
+        receiver_id: str,
+        slot: str,
+        family: str,
+        name: str,
+    ) -> FieldPath:
+        if slot not in {VfoSlot.A.value, VfoSlot.B.value}:
+            raise ValueError(f"VFO slot must be A or B: {slot!r}")
+        return cls(
+            scope=FieldScope.RECEIVER,
+            receiver_id=receiver_id,
+            slot=VfoSlot(slot),
+            family=_validate_family(family),
+            name=name,
+        )
+
+    @classmethod
+    def active(cls, receiver_id: str, family: str, name: str) -> FieldPath:
+        return cls(
+            scope=FieldScope.RECEIVER,
+            receiver_id=receiver_id,
+            slot=VfoSlot.ACTIVE,
+            family=_validate_family(family),
+            name=name,
+        )
+
+    @classmethod
+    def active_slot(cls, receiver_id: str) -> FieldPath:
+        return cls.receiver(receiver_id, FieldFamily.VFO.value, "active_slot")
+
+    @classmethod
+    def global_(cls, family: str, name: str) -> FieldPath:
+        return cls(
+            scope=FieldScope.GLOBAL,
+            receiver_id=None,
+            slot=None,
+            family=_validate_family(family),
+            name=name,
+        )
+
+    @classmethod
+    def scope_control(
+        cls,
+        family: str,
+        name: str,
+        *,
+        receiver_id: str | None = None,
+    ) -> FieldPath:
+        return cls(
+            scope=FieldScope.SCOPE_CONTROLS,
+            receiver_id=receiver_id,
+            slot=None,
+            family=_validate_family(family),
+            name=name,
+        )
+
+    def __str__(self) -> str:
+        if self.scope is FieldScope.RECEIVER:
+            assert self.receiver_id is not None
+            if self.slot is VfoSlot.ACTIVE:
+                return ".".join(
+                    [
+                        self.scope.value,
+                        self.receiver_id,
+                        self.slot.value,
+                        self.family.value,
+                        self.name,
+                    ]
+                )
+            if self.slot in (VfoSlot.A, VfoSlot.B):
+                return ".".join(
+                    [
+                        self.scope.value,
+                        self.receiver_id,
+                        "slot",
+                        self.slot.value,
+                        self.family.value,
+                        self.name,
+                    ]
+                )
+            return ".".join(
+                [self.scope.value, self.receiver_id, self.family.value, self.name]
+            )
+        if self.scope is FieldScope.SCOPE_CONTROLS:
+            if self.receiver_id is None:
+                return ".".join(
+                    [
+                        self.scope.value,
+                        FieldScope.GLOBAL.value,
+                        self.family.value,
+                        self.name,
+                    ]
+                )
+            return ".".join(
+                [
+                    self.scope.value,
+                    "receiver",
+                    self.receiver_id,
+                    self.family.value,
+                    self.name,
+                ]
+            )
+        return ".".join([self.scope.value, self.family.value, self.name])
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "path": str(self),
+            "scope": self.scope.value,
+            "receiverId": self.receiver_id,
+            "slot": None if self.slot is None else self.slot.value,
+            "family": self.family.value,
+            "name": self.name,
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any] | str) -> FieldPath:
+        if isinstance(value, str):
+            return cls.parse(value)
+        path = value.get("path")
+        if isinstance(path, str):
+            return cls.parse(path)
+        return cls(
+            scope=FieldScope(str(value["scope"])),
+            receiver_id=(
+                None if value.get("receiverId") is None else str(value["receiverId"])
+            ),
+            slot=None if value.get("slot") is None else VfoSlot(str(value["slot"])),
+            family=_validate_family(str(value["family"])),
+            name=str(value["name"]),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class FieldSpec:
+    """Registry metadata for one canonical field path."""
+
+    path: FieldPath
+    family: FieldFamily
+    value_type: str
+    readable: bool = True
+    writable: bool = False
+    unit: str | None = None
+    description: str = ""
+
+    def __post_init__(self) -> None:
+        if self.family is not self.path.family:
+            raise ValueError(
+                f"field spec family {self.family.value!r} does not match "
+                f"path family {self.path.family.value!r}"
+            )
+        _validate_token(self.value_type, label="value_type")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "path": str(self.path),
+            "family": self.family.value,
+            "valueType": self.value_type,
+            "readable": self.readable,
+            "writable": self.writable,
+            "unit": self.unit,
+            "description": self.description,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class FieldRegistry:
+    """Immutable registry for canonical field paths."""
+
+    fields: tuple[FieldSpec, ...]
+
+    def __post_init__(self) -> None:
+        by_path: set[str] = set()
+        ambiguity_keys: dict[
+            tuple[FieldScope, str | None, VfoSlot | None, str], str
+        ] = {}
+        for spec in self.fields:
+            serialized = str(spec.path)
+            if serialized in by_path:
+                raise ValueError(f"duplicate field path: {serialized}")
+            by_path.add(serialized)
+
+            key = (
+                spec.path.scope,
+                spec.path.receiver_id,
+                spec.path.slot,
+                spec.path.name,
+            )
+            previous = ambiguity_keys.get(key)
+            if previous is not None and previous != spec.path.family.value:
+                raise ValueError(
+                    "ambiguous field name for path target: "
+                    f"{spec.path.name!r} in {spec.path.scope.value}"
+                )
+            ambiguity_keys[key] = spec.path.family.value
+
+    @classmethod
+    def from_paths(cls, paths: Iterable[FieldPath]) -> FieldRegistry:
+        return cls(
+            tuple(
+                FieldSpec(
+                    path=path,
+                    family=path.family,
+                    value_type="object",
+                )
+                for path in paths
+            )
+        )
+
+    def require(self, path: FieldPath | str) -> FieldSpec:
+        needle = FieldPath.parse(path) if isinstance(path, str) else path
+        for spec in self.fields:
+            if spec.path == needle:
+                return spec
+        raise KeyError(str(needle))
+
+    def paths(self) -> tuple[FieldPath, ...]:
+        return tuple(spec.path for spec in self.fields)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"fields": [field.to_dict() for field in self.fields]}
+
+
+@dataclass(frozen=True, slots=True)
+class SourceMetadata:
+    """Origin metadata for an observation or command-facing state sample."""
+
+    source: ObservationSource
+    provider: str
+    transport: str | None = None
+    native_id: str | None = None
+    capability_id: str | None = None
+
+    def __post_init__(self) -> None:
+        _validate_source(self.source, _OBSERVATION_SOURCES, label="observation source")
+        _validate_token(self.provider, label="provider")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "source": self.source,
+            "provider": self.provider,
+            "transport": self.transport,
+            "nativeId": self.native_id,
+            "capabilityId": self.capability_id,
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> SourceMetadata:
+        return cls(
+            source=_observation_source(value["source"]),
+            provider=str(value["provider"]),
+            transport=None
+            if value.get("transport") is None
+            else str(value["transport"]),
+            native_id=None if value.get("nativeId") is None else str(value["nativeId"]),
+            capability_id=(
+                None
+                if value.get("capabilityId") is None
+                else str(value["capabilityId"])
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class CapabilityMetadata:
+    """Backend capability metadata for one field path."""
+
+    path: FieldPath
+    sources: tuple[ObservationSource, ...]
+    readable: bool = True
+    writable: bool = False
+    unsolicited: bool = False
+    max_age: float | None = None
+
+    def __post_init__(self) -> None:
+        for source in self.sources:
+            _validate_source(source, _OBSERVATION_SOURCES, label="observation source")
+        if self.max_age is not None and self.max_age < 0:
+            raise ValueError("max_age must be non-negative")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "path": str(self.path),
+            "sources": list(self.sources),
+            "readable": self.readable,
+            "writable": self.writable,
+            "unsolicited": self.unsolicited,
+            "maxAge": self.max_age,
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> CapabilityMetadata:
+        return cls(
+            path=FieldPath.parse(str(value["path"])),
+            sources=tuple(_observation_source(source) for source in value["sources"]),
+            readable=bool(value.get("readable", True)),
+            writable=bool(value.get("writable", False)),
+            unsolicited=bool(value.get("unsolicited", False)),
+            max_age=None if value.get("maxAge") is None else float(value["maxAge"]),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class Observation:
+    """One decoded state-bearing sample from an acquisition source."""
+
+    path: FieldPath
+    value: Any
+    source: SourceMetadata
+    timestamp_monotonic: float
+    quality: tuple[str, ...] = ("confirmed",)
+    correlation_id: str | None = None
+    max_age: float | None = None
+
+    def __post_init__(self) -> None:
+        if self.max_age is not None and self.max_age < 0:
+            raise ValueError("max_age must be non-negative")
+        for item in self.quality:
+            _validate_token(item, label="quality")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "path": str(self.path),
+            "value": self.value,
+            "source": self.source.to_dict(),
+            "timestampMonotonic": self.timestamp_monotonic,
+            "quality": list(self.quality),
+            "correlationId": self.correlation_id,
+            "maxAge": self.max_age,
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> Observation:
+        return cls(
+            path=FieldPath.from_dict(str(value["path"])),
+            value=value.get("value"),
+            source=SourceMetadata.from_dict(value["source"]),
+            timestamp_monotonic=float(value["timestampMonotonic"]),
+            quality=tuple(str(item) for item in value.get("quality", ("confirmed",))),
+            correlation_id=(
+                None
+                if value.get("correlationId") is None
+                else str(value["correlationId"])
+            ),
+            max_age=None if value.get("maxAge") is None else float(value["maxAge"]),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class FieldChange:
+    """One confirmed state value change."""
+
+    path: FieldPath
+    previous: Any
+    current: Any
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "path": str(self.path),
+            "previous": self.previous,
+            "current": self.current,
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> FieldChange:
+        return cls(
+            path=FieldPath.from_dict(str(value["path"])),
+            previous=value.get("previous"),
+            current=value.get("current"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ChangeSet:
+    """Result of applying observations to a future production StateStore."""
+
+    revision: int
+    freshness_revision: int
+    observation_seq: int
+    changes: tuple[FieldChange, ...]
+    timestamp_monotonic: float
+    sources: tuple[SourceMetadata, ...]
+    coalesced: bool = False
+
+    def __post_init__(self) -> None:
+        if self.revision < 0:
+            raise ValueError("revision must be non-negative")
+        if self.freshness_revision < 0:
+            raise ValueError("freshness_revision must be non-negative")
+        if self.observation_seq < 0:
+            raise ValueError("observation_seq must be non-negative")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "revision": self.revision,
+            "freshnessRevision": self.freshness_revision,
+            "observationSeq": self.observation_seq,
+            "changes": [change.to_dict() for change in self.changes],
+            "timestampMonotonic": self.timestamp_monotonic,
+            "sources": [source.to_dict() for source in self.sources],
+            "coalesced": self.coalesced,
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> ChangeSet:
+        return cls(
+            revision=int(value["revision"]),
+            freshness_revision=int(value["freshnessRevision"]),
+            observation_seq=int(value["observationSeq"]),
+            changes=tuple(FieldChange.from_dict(item) for item in value["changes"]),
+            timestamp_monotonic=float(value["timestampMonotonic"]),
+            sources=tuple(SourceMetadata.from_dict(item) for item in value["sources"]),
+            coalesced=bool(value.get("coalesced", False)),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class CommandIntent:
+    """Backend-neutral command or query request from a consumer."""
+
+    id: str
+    name: str
+    params: Mapping[str, Any]
+    source: CommandSource
+    target: FieldPath | None = None
+    priority: CommandPriority = "normal"
+    timeout: float | None = None
+    pending_policy: PendingPolicy = "none"
+    expected_observations: tuple[FieldPath, ...] = ()
+
+    def __post_init__(self) -> None:
+        _validate_token(self.name, label="command name")
+        _validate_source(self.source, _COMMAND_SOURCES, label="command source")
+        _validate_source(self.priority, _COMMAND_PRIORITIES, label="command priority")
+        _validate_source(self.pending_policy, _PENDING_POLICIES, label="pending policy")
+        if self.timeout is not None and self.timeout < 0:
+            raise ValueError("timeout must be non-negative")
+        object.__setattr__(self, "params", dict(self.params))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "params": dict(self.params),
+            "source": self.source,
+            "target": None if self.target is None else str(self.target),
+            "priority": self.priority,
+            "timeout": self.timeout,
+            "pendingPolicy": self.pending_policy,
+            "expectedObservations": [str(path) for path in self.expected_observations],
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> CommandIntent:
+        return cls(
+            id=str(value["id"]),
+            name=str(value["name"]),
+            params=dict(value.get("params", {})),
+            source=_command_source(value["source"]),
+            target=(
+                None
+                if value.get("target") is None
+                else FieldPath.parse(str(value["target"]))
+            ),
+            priority=_command_priority(value.get("priority", "normal")),
+            timeout=None if value.get("timeout") is None else float(value["timeout"]),
+            pending_policy=_pending_policy(value.get("pendingPolicy", "none")),
+            expected_observations=tuple(
+                FieldPath.parse(str(path))
+                for path in value.get("expectedObservations", ())
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class CommandLifecycleEvent:
+    """Lifecycle event for a command intent, separate from state changes."""
+
+    command_id: str
+    state: CommandLifecycleState
+    timestamp_monotonic: float
+    source: CommandSource
+    target: FieldPath | None = None
+    message: str | None = None
+    details: Mapping[str, Any] | None = None
+
+    def __post_init__(self) -> None:
+        _validate_source(self.state, _COMMAND_STATES, label="command lifecycle state")
+        _validate_source(self.source, _COMMAND_SOURCES, label="command source")
+        object.__setattr__(
+            self,
+            "details",
+            {} if self.details is None else dict(self.details),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "commandId": self.command_id,
+            "state": self.state,
+            "timestampMonotonic": self.timestamp_monotonic,
+            "source": self.source,
+            "target": None if self.target is None else str(self.target),
+            "message": self.message,
+            "details": dict(self.details or {}),
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> CommandLifecycleEvent:
+        return cls(
+            command_id=str(value["commandId"]),
+            state=_command_state(value["state"]),
+            timestamp_monotonic=float(value["timestampMonotonic"]),
+            source=_command_source(value["source"]),
+            target=(
+                None
+                if value.get("target") is None
+                else FieldPath.parse(str(value["target"]))
+            ),
+            message=None if value.get("message") is None else str(value["message"]),
+            details=dict(value.get("details", {})),
+        )
+
+
+def _receiver_specs(receiver_id: str) -> tuple[FieldSpec, ...]:
+    def spec(
+        path: FieldPath,
+        value_type: str,
+        *,
+        writable: bool = False,
+        unit: str | None = None,
+    ) -> FieldSpec:
+        return FieldSpec(
+            path=path,
+            family=path.family,
+            value_type=value_type,
+            writable=writable,
+            unit=unit,
+        )
+
+    return (
+        spec(
+            FieldPath.active(receiver_id, "freq_mode", "freq_hz"),
+            "int",
+            writable=True,
+            unit="hz",
+        ),
+        spec(FieldPath.active(receiver_id, "freq_mode", "mode"), "str", writable=True),
+        spec(
+            FieldPath.vfo_slot(receiver_id, "A", "freq_mode", "freq_hz"),
+            "int",
+            writable=True,
+            unit="hz",
+        ),
+        spec(
+            FieldPath.vfo_slot(receiver_id, "A", "freq_mode", "mode"),
+            "str",
+            writable=True,
+        ),
+        spec(
+            FieldPath.vfo_slot(receiver_id, "B", "freq_mode", "freq_hz"),
+            "int",
+            writable=True,
+            unit="hz",
+        ),
+        spec(
+            FieldPath.vfo_slot(receiver_id, "B", "freq_mode", "mode"),
+            "str",
+            writable=True,
+        ),
+        spec(FieldPath.active_slot(receiver_id), "str", writable=True),
+        spec(FieldPath.receiver(receiver_id, "meters", "s_meter"), "int"),
+        spec(
+            FieldPath.receiver(receiver_id, "operator_toggles", "nr"),
+            "bool",
+            writable=True,
+        ),
+        spec(
+            FieldPath.receiver(receiver_id, "operator_toggles", "nb"),
+            "bool",
+            writable=True,
+        ),
+        spec(
+            FieldPath.receiver(receiver_id, "operator_controls", "af_level"),
+            "int",
+            writable=True,
+        ),
+        spec(
+            FieldPath.receiver(receiver_id, "operator_controls", "rf_gain"),
+            "int",
+            writable=True,
+        ),
+        spec(
+            FieldPath.receiver(receiver_id, "operator_controls", "pbt_inner"),
+            "int",
+            writable=True,
+        ),
+        spec(
+            FieldPath.receiver(receiver_id, "operator_controls", "pbt_outer"),
+            "int",
+            writable=True,
+        ),
+    )
+
+
+def _global_specs() -> tuple[FieldSpec, ...]:
+    def spec(
+        path: FieldPath,
+        value_type: str,
+        *,
+        writable: bool = False,
+        unit: str | None = None,
+    ) -> FieldSpec:
+        return FieldSpec(
+            path=path,
+            family=path.family,
+            value_type=value_type,
+            writable=writable,
+            unit=unit,
+        )
+
+    return (
+        spec(FieldPath.global_("tx_state", "ptt"), "bool", writable=True),
+        spec(FieldPath.global_("tx_state", "power_on"), "bool", writable=True),
+        spec(
+            FieldPath.global_("operator_controls", "power_level"), "int", writable=True
+        ),
+        spec(FieldPath.global_("meters", "alc"), "int"),
+        spec(FieldPath.global_("meters", "power"), "int"),
+        spec(FieldPath.global_("meters", "swr"), "int"),
+        spec(
+            FieldPath.scope_control("display", "span", receiver_id="main"),
+            "int",
+            writable=True,
+        ),
+        spec(
+            FieldPath.scope_control("display", "span", receiver_id="sub"),
+            "int",
+            writable=True,
+        ),
+    )
+
+
+DEFAULT_FIELD_REGISTRY = FieldRegistry(
+    _receiver_specs("main") + _receiver_specs("sub") + _global_specs()
+)

--- a/src/rigplane/core/state_pipeline_contracts.py
+++ b/src/rigplane/core/state_pipeline_contracts.py
@@ -130,6 +130,21 @@ def _validate_source(value: str, allowed: frozenset[str], *, label: str) -> str:
     return value
 
 
+def _required(value: Mapping[str, Any], key: str) -> Any:
+    if key not in value:
+        raise KeyError(key)
+    return value[key]
+
+
+def _optional_bool(value: Mapping[str, Any], key: str, *, default: bool) -> bool:
+    if key not in value:
+        return default
+    item = value[key]
+    if not isinstance(item, bool):
+        raise TypeError(f"{key} must be a boolean")
+    return item
+
+
 def _observation_source(value: Any) -> ObservationSource:
     text = str(value)
     _validate_source(text, _OBSERVATION_SOURCES, label="observation source")
@@ -201,6 +216,8 @@ class FieldPath:
                 )
         if scope is FieldScope.SCOPE_CONTROLS and slot is not None:
             raise ValueError("scope_controls field paths cannot include VFO slot")
+        if scope is FieldScope.SCOPE_CONTROLS and family is not FieldFamily.DISPLAY:
+            raise ValueError("scope_controls field paths must use display family")
         if slot is VfoSlot.ACTIVE and scope is not FieldScope.RECEIVER:
             raise ValueError("active VFO slot is only valid for receiver fields")
         if slot is not None and family is not FieldFamily.FREQ_MODE:
@@ -573,9 +590,9 @@ class CapabilityMetadata:
         return cls(
             path=FieldPath.parse(str(value["path"])),
             sources=tuple(_observation_source(source) for source in value["sources"]),
-            readable=bool(value.get("readable", True)),
-            writable=bool(value.get("writable", False)),
-            unsolicited=bool(value.get("unsolicited", False)),
+            readable=_optional_bool(value, "readable", default=True),
+            writable=_optional_bool(value, "writable", default=False),
+            unsolicited=_optional_bool(value, "unsolicited", default=False),
             max_age=None if value.get("maxAge") is None else float(value["maxAge"]),
         )
 
@@ -613,7 +630,7 @@ class Observation:
     def from_dict(cls, value: Mapping[str, Any]) -> Observation:
         return cls(
             path=FieldPath.from_dict(str(value["path"])),
-            value=value.get("value"),
+            value=_required(value, "value"),
             source=SourceMetadata.from_dict(value["source"]),
             timestamp_monotonic=float(value["timestampMonotonic"]),
             quality=tuple(str(item) for item in value.get("quality", ("confirmed",))),
@@ -645,8 +662,8 @@ class FieldChange:
     def from_dict(cls, value: Mapping[str, Any]) -> FieldChange:
         return cls(
             path=FieldPath.from_dict(str(value["path"])),
-            previous=value.get("previous"),
-            current=value.get("current"),
+            previous=_required(value, "previous"),
+            current=_required(value, "current"),
         )
 
 
@@ -690,7 +707,7 @@ class ChangeSet:
             changes=tuple(FieldChange.from_dict(item) for item in value["changes"]),
             timestamp_monotonic=float(value["timestampMonotonic"]),
             sources=tuple(SourceMetadata.from_dict(item) for item in value["sources"]),
-            coalesced=bool(value.get("coalesced", False)),
+            coalesced=_optional_bool(value, "coalesced", default=False),
         )
 
 

--- a/src/rigplane/core/state_store.py
+++ b/src/rigplane/core/state_store.py
@@ -1,0 +1,420 @@
+"""Runtime-owned radio state snapshots and freshness tracking."""
+
+from __future__ import annotations
+
+import copy
+import time
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+from rigplane.core.state_pipeline_contracts import (
+    ChangeSet,
+    FieldChange,
+    FieldPath,
+    Observation,
+    SourceMetadata,
+)
+
+__all__ = [
+    "FieldSnapshot",
+    "FreshnessClock",
+    "FreshnessState",
+    "FreshnessTransition",
+    "ReconciliationRequest",
+    "SnapshotDelta",
+    "StateSnapshot",
+    "StateStore",
+]
+
+
+class FreshnessState(StrEnum):
+    """Freshness state for one observed field."""
+
+    UNKNOWN = "unknown"
+    FRESH = "fresh"
+    STALE = "stale"
+
+
+@dataclass(frozen=True, slots=True)
+class FreshnessTransition:
+    """Freshness-only transition for a field."""
+
+    path: FieldPath
+    previous: FreshnessState
+    current: FreshnessState
+    freshness_revision: int
+    timestamp_monotonic: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "path": str(self.path),
+            "previous": self.previous.value,
+            "current": self.current.value,
+            "freshnessRevision": self.freshness_revision,
+            "timestampMonotonic": self.timestamp_monotonic,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ReconciliationRequest:
+    """A future scheduler hint emitted when a field becomes stale."""
+
+    path: FieldPath
+    reason: str
+    requested_at_monotonic: float
+    state_revision: int
+    freshness_revision: int
+    max_age: float | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "path": str(self.path),
+            "reason": self.reason,
+            "requestedAtMonotonic": self.requested_at_monotonic,
+            "stateRevision": self.state_revision,
+            "freshnessRevision": self.freshness_revision,
+            "maxAge": self.max_age,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class FieldSnapshot:
+    """Consumer-facing snapshot of one field."""
+
+    path: FieldPath
+    value: Any
+    freshness: FreshnessState
+    last_observed_monotonic: float
+    max_age: float | None
+    source: SourceMetadata
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "path": str(self.path),
+            "value": _copy_value(self.value),
+            "freshness": self.freshness.value,
+            "lastObservedMonotonic": self.last_observed_monotonic,
+            "maxAge": self.max_age,
+            "source": self.source.to_dict(),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class StateSnapshot:
+    """Immutable projection of the store-owned state at one point in time."""
+
+    state_revision: int
+    freshness_revision: int
+    observation_seq: int
+    generated_at_monotonic: float
+    fields: tuple[FieldSnapshot, ...]
+
+    @classmethod
+    def empty(cls) -> StateSnapshot:
+        return cls(
+            state_revision=0,
+            freshness_revision=0,
+            observation_seq=0,
+            generated_at_monotonic=0.0,
+            fields=(),
+        )
+
+    def field(self, path: FieldPath | str) -> FieldSnapshot:
+        needle = FieldPath.parse(path) if isinstance(path, str) else path
+        for field in self.fields:
+            if field.path == needle:
+                return field
+        raise KeyError(str(needle))
+
+    def as_dict(self) -> dict[str, dict[str, Any]]:
+        return {str(field.path): field.to_dict() for field in self.fields}
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "stateRevision": self.state_revision,
+            "freshnessRevision": self.freshness_revision,
+            "observationSeq": self.observation_seq,
+            "generatedAtMonotonic": self.generated_at_monotonic,
+            "fields": [field.to_dict() for field in self.fields],
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class SnapshotDelta:
+    """Consumer-facing delta projection since a prior snapshot."""
+
+    state_revision: int
+    freshness_revision: int
+    observation_seq: int
+    changes: tuple[FieldChange, ...]
+    freshness: tuple[FreshnessTransition, ...] = ()
+    reconciliation_requests: tuple[ReconciliationRequest, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "stateRevision": self.state_revision,
+            "freshnessRevision": self.freshness_revision,
+            "observationSeq": self.observation_seq,
+            "changes": [change.to_dict() for change in self.changes],
+            "freshness": [transition.to_dict() for transition in self.freshness],
+            "reconciliationRequests": [
+                request.to_dict() for request in self.reconciliation_requests
+            ],
+        }
+
+
+@dataclass(slots=True)
+class _FieldEntry:
+    value: Any
+    freshness: FreshnessState
+    last_observed_monotonic: float
+    max_age: float | None
+    source: SourceMetadata
+
+
+class FreshnessClock:
+    """Monotonic clock used by freshness expiration."""
+
+    __slots__ = ("_manual_now",)
+
+    def __init__(self, *, start: float | None = None) -> None:
+        self._manual_now = None if start is None else float(start)
+
+    def now(self) -> float:
+        if self._manual_now is None:
+            return time.monotonic()
+        return self._manual_now
+
+    def advance(self, seconds: float) -> float:
+        if seconds < 0:
+            raise ValueError("freshness clock cannot move backwards")
+        if self._manual_now is None:
+            self._manual_now = time.monotonic()
+        self._manual_now += seconds
+        return self._manual_now
+
+
+class StateStore:
+    """Single-writer store for confirmed radio state observations."""
+
+    __slots__ = (
+        "_entries",
+        "_freshness_clock",
+        "_freshness_revision",
+        "_history",
+        "_observation_seq",
+        "_state_revision",
+    )
+
+    def __init__(self, *, freshness_clock: FreshnessClock | None = None) -> None:
+        self._freshness_clock = freshness_clock or FreshnessClock()
+        self._state_revision = 0
+        self._freshness_revision = 0
+        self._observation_seq = 0
+        self._entries: dict[FieldPath, _FieldEntry] = {}
+        self._history: list[SnapshotDelta] = []
+
+    def apply(self, observation: Observation) -> ChangeSet:
+        """Apply one confirmed observation and return its state ChangeSet."""
+
+        self._observation_seq += 1
+        previous_entry = self._entries.get(observation.path)
+        previous_freshness = (
+            FreshnessState.UNKNOWN
+            if previous_entry is None
+            else previous_entry.freshness
+        )
+        freshness_transition = self._mark_fresh(
+            observation.path,
+            previous_freshness=previous_freshness,
+            timestamp_monotonic=observation.timestamp_monotonic,
+        )
+
+        previous_value = None if previous_entry is None else previous_entry.value
+        semantic_changed = previous_entry is None or previous_value != observation.value
+        changes: tuple[FieldChange, ...]
+        if semantic_changed:
+            self._state_revision += 1
+            changes = (
+                FieldChange(
+                    path=observation.path,
+                    previous=_copy_value(previous_value),
+                    current=_copy_value(observation.value),
+                ),
+            )
+        else:
+            changes = ()
+
+        self._entries[observation.path] = _FieldEntry(
+            value=_copy_value(observation.value),
+            freshness=FreshnessState.FRESH,
+            last_observed_monotonic=observation.timestamp_monotonic,
+            max_age=observation.max_age,
+            source=observation.source,
+        )
+        changeset = ChangeSet(
+            revision=self._state_revision,
+            freshness_revision=self._freshness_revision,
+            observation_seq=self._observation_seq,
+            changes=changes,
+            timestamp_monotonic=observation.timestamp_monotonic,
+            sources=(observation.source,),
+            coalesced=False,
+        )
+        self._append_history(
+            changes=changes,
+            freshness=() if freshness_transition is None else (freshness_transition,),
+            reconciliation_requests=(),
+        )
+        return changeset
+
+    def mark_stale_due(self, *, now: float | None = None) -> SnapshotDelta:
+        """Mark overdue fresh fields stale and emit reconciliation hints."""
+
+        timestamp = self._freshness_clock.now() if now is None else now
+        transitions: list[FreshnessTransition] = []
+        requests: list[ReconciliationRequest] = []
+        for path, entry in sorted(self._entries.items(), key=lambda item: str(item[0])):
+            if entry.freshness is not FreshnessState.FRESH or entry.max_age is None:
+                continue
+            if timestamp - entry.last_observed_monotonic <= entry.max_age:
+                continue
+
+            self._freshness_revision += 1
+            entry.freshness = FreshnessState.STALE
+            transition = FreshnessTransition(
+                path=path,
+                previous=FreshnessState.FRESH,
+                current=FreshnessState.STALE,
+                freshness_revision=self._freshness_revision,
+                timestamp_monotonic=timestamp,
+            )
+            request = ReconciliationRequest(
+                path=path,
+                reason="stale",
+                requested_at_monotonic=timestamp,
+                state_revision=self._state_revision,
+                freshness_revision=self._freshness_revision,
+                max_age=entry.max_age,
+            )
+            transitions.append(transition)
+            requests.append(request)
+
+        delta = SnapshotDelta(
+            state_revision=self._state_revision,
+            freshness_revision=self._freshness_revision,
+            observation_seq=self._observation_seq,
+            changes=(),
+            freshness=tuple(transitions),
+            reconciliation_requests=tuple(requests),
+        )
+        if transitions or requests:
+            self._history.append(delta)
+        return delta
+
+    def snapshot(self) -> StateSnapshot:
+        """Return a full immutable projection of the current store state."""
+
+        return StateSnapshot(
+            state_revision=self._state_revision,
+            freshness_revision=self._freshness_revision,
+            observation_seq=self._observation_seq,
+            generated_at_monotonic=self._freshness_clock.now(),
+            fields=tuple(
+                FieldSnapshot(
+                    path=path,
+                    value=_copy_value(entry.value),
+                    freshness=entry.freshness,
+                    last_observed_monotonic=entry.last_observed_monotonic,
+                    max_age=entry.max_age,
+                    source=entry.source,
+                )
+                for path, entry in sorted(
+                    self._entries.items(),
+                    key=lambda item: str(item[0]),
+                )
+            ),
+        )
+
+    def delta_since(self, snapshot: StateSnapshot) -> SnapshotDelta:
+        """Return all semantic and freshness deltas after ``snapshot``."""
+
+        changes: list[FieldChange] = []
+        freshness: list[FreshnessTransition] = []
+        requests: list[ReconciliationRequest] = []
+        for delta in self._history:
+            if delta.state_revision > snapshot.state_revision:
+                changes.extend(delta.changes)
+            freshness.extend(
+                transition
+                for transition in delta.freshness
+                if transition.freshness_revision > snapshot.freshness_revision
+            )
+            requests.extend(
+                request
+                for request in delta.reconciliation_requests
+                if request.freshness_revision > snapshot.freshness_revision
+            )
+
+        return SnapshotDelta(
+            state_revision=self._state_revision,
+            freshness_revision=self._freshness_revision,
+            observation_seq=self._observation_seq,
+            changes=_copy_changes(tuple(changes)),
+            freshness=tuple(freshness),
+            reconciliation_requests=tuple(requests),
+        )
+
+    def _mark_fresh(
+        self,
+        path: FieldPath,
+        *,
+        previous_freshness: FreshnessState,
+        timestamp_monotonic: float,
+    ) -> FreshnessTransition | None:
+        if previous_freshness is FreshnessState.FRESH:
+            return None
+        self._freshness_revision += 1
+        return FreshnessTransition(
+            path=path,
+            previous=previous_freshness,
+            current=FreshnessState.FRESH,
+            freshness_revision=self._freshness_revision,
+            timestamp_monotonic=timestamp_monotonic,
+        )
+
+    def _append_history(
+        self,
+        *,
+        changes: tuple[FieldChange, ...],
+        freshness: tuple[FreshnessTransition, ...],
+        reconciliation_requests: tuple[ReconciliationRequest, ...],
+    ) -> None:
+        if not changes and not freshness and not reconciliation_requests:
+            return
+        self._history.append(
+            SnapshotDelta(
+                state_revision=self._state_revision,
+                freshness_revision=self._freshness_revision,
+                observation_seq=self._observation_seq,
+                changes=_copy_changes(changes),
+                freshness=freshness,
+                reconciliation_requests=reconciliation_requests,
+            )
+        )
+
+
+def _copy_value(value: Any) -> Any:
+    return copy.deepcopy(value)
+
+
+def _copy_changes(changes: tuple[FieldChange, ...]) -> tuple[FieldChange, ...]:
+    return tuple(
+        FieldChange(
+            path=change.path,
+            previous=_copy_value(change.previous),
+            current=_copy_value(change.current),
+        )
+        for change in changes
+    )

--- a/src/rigplane/core/state_store.py
+++ b/src/rigplane/core/state_store.py
@@ -261,6 +261,10 @@ class StateStore:
             timestamp_monotonic=observation.timestamp_monotonic,
             sources=(observation.source,),
             coalesced=False,
+            observed_paths=(observation.path,),
+            freshness_paths=()
+            if freshness_transition is None
+            else (freshness_transition.path,),
         )
         self._append_history(
             changes=changes,

--- a/src/rigplane/profiles/__init__.py
+++ b/src/rigplane/profiles/__init__.py
@@ -12,6 +12,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Required, TypedDict
 
+from rigplane.core.state_acquisition_policy import RadioAcquisitionProfile
+
 __all__ = [
     "ControlSpec",
     "FilterWidthSegment",
@@ -204,6 +206,10 @@ class RadioProfile:
     # driven from ``[validation].write_only_controls`` in the rig TOML (MOR-208).
     # Empty by default: every control uses the standard RMVR path.
     write_only_controls: frozenset[str] = frozenset()
+    # Provider-specific state acquisition metadata (MOR-344). This is profile
+    # data only; future schedulers/adapters consume it instead of Web or
+    # rigctld delivery code branching on radio model.
+    state_acquisition: RadioAcquisitionProfile | None = None
 
     @property
     def vfo_swap_code(self) -> int | None:

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -10,6 +10,17 @@ from pathlib import Path
 from typing import Any
 
 from rigplane.core.capabilities import KNOWN_CAPABILITIES
+from rigplane.core.state_acquisition_policy import (
+    AcquisitionPolicy,
+    AdaptiveDecayPolicy,
+    ExternalCatPauseBehavior,
+    FieldAvailability,
+    FieldCapability,
+    MeterCoalescingPolicy,
+    RadioAcquisitionProfile,
+    ReconciliationPriority,
+)
+from rigplane.core.state_pipeline_contracts import FieldPath
 from rigplane.commands.command_map import CommandMap
 
 __all__ = ["RigConfig", "RigLoadError", "load_rig", "discover_rigs"]
@@ -115,6 +126,7 @@ class RigConfig:
     browser_rx_transport: str | None = None
     browser_rx_transcode_to_opus: bool | None = None
     write_only_controls: tuple[str, ...] = ()
+    state_acquisition: RadioAcquisitionProfile | None = None
 
     def to_profile(self) -> RadioProfile:
         """Build a ``RadioProfile`` from this config."""
@@ -195,6 +207,7 @@ class RigConfig:
             browser_rx_transport=self.browser_rx_transport,
             browser_rx_transcode_to_opus=self.browser_rx_transcode_to_opus,
             write_only_controls=frozenset(self.write_only_controls),
+            state_acquisition=self.state_acquisition,
         )
 
     def to_command_map(self) -> CommandMap:
@@ -491,6 +504,278 @@ def _validate_audio_sample_rate(filename: str, field_name: str, value: Any) -> i
             f"{sorted(VALID_AUDIO_SAMPLE_RATES_HZ)}, got {value!r}"
         )
     return value
+
+
+def _state_path_list(filename: str, section: str, value: Any) -> tuple[FieldPath, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise RigLoadError(f"{filename}: {section} must be a list of field paths")
+    try:
+        return tuple(FieldPath.parse(item) for item in value)
+    except ValueError as exc:
+        raise RigLoadError(
+            f"{filename}: {section} has invalid field path: {exc}"
+        ) from exc
+
+
+def _policy_seconds(
+    raw: dict[str, Any],
+    key: str,
+    *,
+    defaults: AcquisitionPolicy | None,
+    fallback: float,
+) -> float | None:
+    if key in raw:
+        value = raw[key]
+    elif defaults is not None:
+        value = getattr(defaults, key)
+    else:
+        value = fallback
+    return None if value is None else float(value)
+
+
+def _parse_acquisition_policy(
+    filename: str,
+    raw: dict[str, Any],
+    *,
+    prefix: str,
+    defaults: AcquisitionPolicy | None = None,
+) -> AcquisitionPolicy:
+    try:
+        return AcquisitionPolicy(
+            cadence_seconds=_policy_seconds(
+                raw,
+                "cadence_seconds",
+                defaults=defaults,
+                fallback=5.0,
+            ),
+            freshness_ttl_seconds=_policy_seconds(
+                raw,
+                "freshness_ttl_seconds",
+                defaults=defaults,
+                fallback=15.0,
+            ),
+            reconciliation_priority=ReconciliationPriority(
+                str(
+                    raw.get(
+                        "reconciliation_priority",
+                        defaults.reconciliation_priority
+                        if defaults is not None
+                        else ReconciliationPriority.POLL,
+                    )
+                )
+            ),
+            adaptive_decay=AdaptiveDecayPolicy(
+                enabled=bool(
+                    raw.get(
+                        "adaptive_decay",
+                        defaults.adaptive_decay.enabled
+                        if defaults is not None
+                        else False,
+                    )
+                ),
+                idle_multiplier=float(
+                    raw.get(
+                        "adaptive_decay_idle_multiplier",
+                        defaults.adaptive_decay.idle_multiplier
+                        if defaults is not None
+                        else 1.0,
+                    )
+                ),
+                max_cadence_seconds=(
+                    raw.get(
+                        "adaptive_decay_max_cadence_seconds",
+                        defaults.adaptive_decay.max_cadence_seconds
+                        if defaults is not None
+                        else None,
+                    )
+                ),
+            ),
+            external_cat_pause=ExternalCatPauseBehavior(
+                str(
+                    raw.get(
+                        "external_cat_pause",
+                        defaults.external_cat_pause
+                        if defaults is not None
+                        else ExternalCatPauseBehavior.PAUSE_POLLING,
+                    )
+                )
+            ),
+            meter_coalescing=(
+                MeterCoalescingPolicy(
+                    window_seconds=float(raw["meter_coalescing_window_seconds"])
+                )
+                if "meter_coalescing_window_seconds" in raw
+                else None
+            ),
+        )
+    except (TypeError, ValueError) as exc:
+        raise RigLoadError(
+            f"{filename}: {prefix} invalid acquisition policy: {exc}"
+        ) from exc
+
+
+def _parse_state_acquisition(
+    filename: str,
+    raw: Any,
+) -> RadioAcquisitionProfile | None:
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        raise RigLoadError(f"{filename}: [state_acquisition] must be a table")
+
+    caps_raw = raw.get("capabilities", {})
+    if not isinstance(caps_raw, dict):
+        raise RigLoadError(
+            f"{filename}: [state_acquisition.capabilities] must be a table"
+        )
+
+    section = "[state_acquisition.capabilities]"
+    unsolicited = set(
+        _state_path_list(
+            filename, f"{section}.unsolicited_push", caps_raw.get("unsolicited_push")
+        )
+    )
+    polling = set(
+        _state_path_list(
+            filename, f"{section}.polling_only", caps_raw.get("polling_only")
+        )
+    )
+    stream = set(
+        _state_path_list(
+            filename,
+            f"{section}.stream_like_meters",
+            caps_raw.get("stream_like_meters"),
+        )
+    )
+    command_response = set(
+        _state_path_list(
+            filename,
+            f"{section}.command_response_observable",
+            caps_raw.get("command_response_observable"),
+        )
+    )
+    supported_controls = set(
+        _state_path_list(
+            filename,
+            f"{section}.supported_controls",
+            caps_raw.get("supported_controls"),
+        )
+    )
+    unsupported = set(
+        _state_path_list(
+            filename, f"{section}.unsupported", caps_raw.get("unsupported")
+        )
+    )
+    unknown = set(
+        _state_path_list(filename, f"{section}.unknown", caps_raw.get("unknown"))
+    )
+
+    paths = (
+        unsolicited
+        | polling
+        | stream
+        | command_response
+        | supported_controls
+        | unsupported
+        | unknown
+    )
+    capabilities: list[FieldCapability] = []
+    for path in sorted(paths, key=str):
+        availability = FieldAvailability.SUPPORTED
+        diagnostic = ""
+        if path in unsupported:
+            availability = FieldAvailability.UNSUPPORTED
+            diagnostic = "profile marks field unsupported"
+        if path in unknown:
+            availability = FieldAvailability.UNKNOWN
+            diagnostic = "profile marks field unknown"
+        try:
+            capabilities.append(
+                FieldCapability(
+                    path=path,
+                    availability=availability,
+                    unsolicited_push=path in unsolicited,
+                    polling=path in polling or path in stream,
+                    stream_like=path in stream,
+                    command_response_observable=path in command_response,
+                    supported_controls=(
+                        ("profile_control",) if path in supported_controls else ()
+                    ),
+                    diagnostic=diagnostic,
+                )
+            )
+        except ValueError as exc:
+            raise RigLoadError(f"{filename}: {path}: {exc}") from exc
+
+    default_policy = _parse_acquisition_policy(
+        filename,
+        {
+            "cadence_seconds": raw.get("default_cadence_seconds", 5.0),
+            "freshness_ttl_seconds": raw.get("default_freshness_ttl_seconds", 15.0),
+            "reconciliation_priority": raw.get(
+                "default_reconciliation_priority",
+                ReconciliationPriority.POLL,
+            ),
+            "adaptive_decay": raw.get("adaptive_decay", False),
+            "adaptive_decay_idle_multiplier": raw.get(
+                "adaptive_decay_idle_multiplier",
+                1.0,
+            ),
+            "adaptive_decay_max_cadence_seconds": raw.get(
+                "adaptive_decay_max_cadence_seconds"
+            ),
+            "external_cat_pause": raw.get(
+                "external_cat_pause",
+                ExternalCatPauseBehavior.PAUSE_POLLING,
+            ),
+            **(
+                {
+                    "meter_coalescing_window_seconds": raw[
+                        "meter_coalescing_window_seconds"
+                    ]
+                }
+                if "meter_coalescing_window_seconds" in raw
+                else {}
+            ),
+        },
+        prefix="[state_acquisition]",
+    )
+
+    policies_raw = raw.get("field_policies", {})
+    if not isinstance(policies_raw, dict):
+        raise RigLoadError(
+            f"{filename}: [state_acquisition.field_policies] must be a table"
+        )
+    field_policies: dict[FieldPath, AcquisitionPolicy] = {}
+    for path_text, policy_raw in policies_raw.items():
+        if not isinstance(policy_raw, dict):
+            raise RigLoadError(
+                f"{filename}: [state_acquisition.field_policies.{path_text}] must be a table"
+            )
+        try:
+            path = FieldPath.parse(str(path_text))
+        except ValueError as exc:
+            raise RigLoadError(
+                f"{filename}: [state_acquisition.field_policies] invalid path {path_text!r}: {exc}"
+            ) from exc
+        field_policies[path] = _parse_acquisition_policy(
+            filename,
+            policy_raw,
+            prefix=f"[state_acquisition.field_policies.{path_text}]",
+            defaults=default_policy,
+        )
+
+    try:
+        return RadioAcquisitionProfile(
+            provider=str(raw.get("provider", "profile")),
+            capabilities=tuple(capabilities),
+            default_policy=default_policy,
+            field_policies=field_policies,
+        )
+    except ValueError as exc:
+        raise RigLoadError(f"{filename}: [state_acquisition] invalid: {exc}") from exc
 
 
 def load_rig(path: Path) -> RigConfig:
@@ -893,6 +1178,11 @@ def load_rig(path: Path) -> RigConfig:
                 )
             browser_rx_transcode_to_opus = transcode_raw
 
+    state_acquisition = _parse_state_acquisition(
+        filename,
+        data.get("state_acquisition"),
+    )
+
     return RigConfig(
         id=radio["id"],
         model=radio["model"],
@@ -950,6 +1240,7 @@ def load_rig(path: Path) -> RigConfig:
         browser_rx_transport=browser_rx_transport,
         browser_rx_transcode_to_opus=browser_rx_transcode_to_opus,
         write_only_controls=write_only_controls,
+        state_acquisition=state_acquisition,
     )
 
 

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -519,12 +519,51 @@ def _state_path_list(filename: str, section: str, value: Any) -> tuple[FieldPath
         ) from exc
 
 
+def _reject_unknown_keys(
+    filename: str,
+    section: str,
+    raw: dict[str, Any],
+    allowed: frozenset[str],
+) -> None:
+    unknown = sorted(set(raw) - allowed)
+    if unknown:
+        raise RigLoadError(
+            f"{filename}: {section} unknown key {unknown[0]!r}. "
+            f"Valid keys: {sorted(allowed)}"
+        )
+
+
+def _strict_policy_bool(
+    filename: str,
+    prefix: str,
+    key: str,
+    value: Any,
+) -> bool:
+    if not isinstance(value, bool):
+        raise RigLoadError(f"{filename}: {prefix}.{key} must be a bool")
+    return value
+
+
+def _strict_policy_float(
+    filename: str,
+    prefix: str,
+    key: str,
+    value: Any,
+) -> float:
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        raise RigLoadError(f"{filename}: {prefix}.{key} must be a number")
+    return float(value)
+
+
 def _policy_seconds(
+    filename: str,
+    prefix: str,
     raw: dict[str, Any],
     key: str,
     *,
     defaults: AcquisitionPolicy | None,
     fallback: float,
+    label: str | None = None,
 ) -> float | None:
     if key in raw:
         value = raw[key]
@@ -532,7 +571,54 @@ def _policy_seconds(
         value = getattr(defaults, key)
     else:
         value = fallback
-    return None if value is None else float(value)
+    key_label = label if label is not None else key
+    return (
+        None
+        if value is None
+        else _strict_policy_float(filename, prefix, key_label, value)
+    )
+
+
+_ACQUISITION_POLICY_KEYS = frozenset(
+    {
+        "cadence_seconds",
+        "freshness_ttl_seconds",
+        "reconciliation_priority",
+        "adaptive_decay",
+        "adaptive_decay_idle_multiplier",
+        "adaptive_decay_max_cadence_seconds",
+        "external_cat_pause",
+        "meter_coalescing_window_seconds",
+    }
+)
+
+_STATE_ACQUISITION_KEYS = frozenset(
+    {
+        "provider",
+        "default_cadence_seconds",
+        "default_freshness_ttl_seconds",
+        "default_reconciliation_priority",
+        "adaptive_decay",
+        "adaptive_decay_idle_multiplier",
+        "adaptive_decay_max_cadence_seconds",
+        "external_cat_pause",
+        "meter_coalescing_window_seconds",
+        "capabilities",
+        "field_policies",
+    }
+)
+
+_STATE_ACQUISITION_CAPABILITY_KEYS = frozenset(
+    {
+        "unsolicited_push",
+        "polling_only",
+        "stream_like_meters",
+        "command_response_observable",
+        "supported_controls",
+        "unsupported",
+        "unknown",
+    }
+)
 
 
 def _parse_acquisition_policy(
@@ -541,20 +627,29 @@ def _parse_acquisition_policy(
     *,
     prefix: str,
     defaults: AcquisitionPolicy | None = None,
+    key_labels: dict[str, str] | None = None,
 ) -> AcquisitionPolicy:
+    _reject_unknown_keys(filename, prefix, raw, _ACQUISITION_POLICY_KEYS)
+    labels = key_labels or {}
     try:
         return AcquisitionPolicy(
             cadence_seconds=_policy_seconds(
+                filename,
+                prefix,
                 raw,
                 "cadence_seconds",
                 defaults=defaults,
                 fallback=5.0,
+                label=labels.get("cadence_seconds"),
             ),
             freshness_ttl_seconds=_policy_seconds(
+                filename,
+                prefix,
                 raw,
                 "freshness_ttl_seconds",
                 defaults=defaults,
                 fallback=15.0,
+                label=labels.get("freshness_ttl_seconds"),
             ),
             reconciliation_priority=ReconciliationPriority(
                 str(
@@ -567,15 +662,24 @@ def _parse_acquisition_policy(
                 )
             ),
             adaptive_decay=AdaptiveDecayPolicy(
-                enabled=bool(
+                enabled=_strict_policy_bool(
+                    filename,
+                    prefix,
+                    labels.get("adaptive_decay", "adaptive_decay"),
                     raw.get(
                         "adaptive_decay",
                         defaults.adaptive_decay.enabled
                         if defaults is not None
                         else False,
-                    )
+                    ),
                 ),
-                idle_multiplier=float(
+                idle_multiplier=_strict_policy_float(
+                    filename,
+                    prefix,
+                    labels.get(
+                        "adaptive_decay_idle_multiplier",
+                        "adaptive_decay_idle_multiplier",
+                    ),
                     raw.get(
                         "adaptive_decay_idle_multiplier",
                         defaults.adaptive_decay.idle_multiplier
@@ -584,11 +688,27 @@ def _parse_acquisition_policy(
                     )
                 ),
                 max_cadence_seconds=(
-                    raw.get(
+                    None
+                    if raw.get(
                         "adaptive_decay_max_cadence_seconds",
                         defaults.adaptive_decay.max_cadence_seconds
                         if defaults is not None
                         else None,
+                    )
+                    is None
+                    else _strict_policy_float(
+                        filename,
+                        prefix,
+                        labels.get(
+                            "adaptive_decay_max_cadence_seconds",
+                            "adaptive_decay_max_cadence_seconds",
+                        ),
+                        raw.get(
+                            "adaptive_decay_max_cadence_seconds",
+                            defaults.adaptive_decay.max_cadence_seconds
+                            if defaults is not None
+                            else None,
+                        ),
                     )
                 ),
             ),
@@ -604,7 +724,15 @@ def _parse_acquisition_policy(
             ),
             meter_coalescing=(
                 MeterCoalescingPolicy(
-                    window_seconds=float(raw["meter_coalescing_window_seconds"])
+                    window_seconds=_strict_policy_float(
+                        filename,
+                        prefix,
+                        labels.get(
+                            "meter_coalescing_window_seconds",
+                            "meter_coalescing_window_seconds",
+                        ),
+                        raw["meter_coalescing_window_seconds"],
+                    )
                 )
                 if "meter_coalescing_window_seconds" in raw
                 else None
@@ -624,12 +752,24 @@ def _parse_state_acquisition(
         return None
     if not isinstance(raw, dict):
         raise RigLoadError(f"{filename}: [state_acquisition] must be a table")
+    _reject_unknown_keys(
+        filename,
+        "[state_acquisition]",
+        raw,
+        _STATE_ACQUISITION_KEYS,
+    )
 
     caps_raw = raw.get("capabilities", {})
     if not isinstance(caps_raw, dict):
         raise RigLoadError(
             f"{filename}: [state_acquisition.capabilities] must be a table"
         )
+    _reject_unknown_keys(
+        filename,
+        "[state_acquisition.capabilities]",
+        caps_raw,
+        _STATE_ACQUISITION_CAPABILITY_KEYS,
+    )
 
     section = "[state_acquisition.capabilities]"
     unsolicited = set(
@@ -741,6 +881,10 @@ def _parse_state_acquisition(
             ),
         },
         prefix="[state_acquisition]",
+        key_labels={
+            "cadence_seconds": "default_cadence_seconds",
+            "freshness_ttl_seconds": "default_freshness_ttl_seconds",
+        },
     )
 
     policies_raw = raw.get("field_policies", {})

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -911,9 +911,13 @@ def _parse_state_acquisition(
             defaults=default_policy,
         )
 
+    provider = raw.get("provider", "profile")
+    if not isinstance(provider, str):
+        raise RigLoadError(f"{filename}: [state_acquisition].provider must be a string")
+
     try:
         return RadioAcquisitionProfile(
-            provider=str(raw.get("provider", "profile")),
+            provider=provider,
             capabilities=tuple(capabilities),
             default_policy=default_policy,
             field_policies=field_policies,

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -685,7 +685,7 @@ def _parse_acquisition_policy(
                         defaults.adaptive_decay.idle_multiplier
                         if defaults is not None
                         else 1.0,
-                    )
+                    ),
                 ),
                 max_cadence_seconds=(
                     None

--- a/src/rigplane/rigctld/handler.py
+++ b/src/rigplane/rigctld/handler.py
@@ -31,7 +31,7 @@ from ..core.command_service import (
 )
 from ..core.state_diagnostics import StateDiagnosticsRecorder
 from ..core.state_pipeline_contracts import CommandIntent, FieldPath, Observation, SourceMetadata
-from ..core.state_store import StateStore, StateSnapshot
+from ..core.state_store import FreshnessState, StateStore, StateSnapshot
 from ..exceptions import ConnectionError, TimeoutError as RigplaneTimeoutError
 from ..radio_state import RadioState, ReceiverState
 from ..types import Mode
@@ -439,6 +439,8 @@ class _RigctldProjection:
                     field = self.snapshot.field(candidate)
                 except KeyError:
                     continue
+                if field.freshness is not FreshnessState.FRESH:
+                    continue
                 if (
                     newest is None
                     or field.last_observed_monotonic > newest.last_observed_monotonic
@@ -516,7 +518,7 @@ class RigctldHandler:
         # Icoms — set_vfo_split routing is via active receiver). Initial
         # value mirrors the Hamlib default ("VFOA"). Updated by
         # ``_cmd_set_split_vfo`` on every ``S`` request. (Issue #1345.)
-        self._split_tx_vfo: Literal["VFOA", "VFOB"] = "VFOA"
+        self._split_tx_vfo_by_session: dict[str | None, Literal["VFOA", "VFOB"]] = {}
         # Legacy routing cache is retained only for vendor-specific routing
         # strategies that still depend on it (Yaesu today). Core rigctld GET
         # paths project from StateStore plus scoped CommandService overlays.
@@ -580,6 +582,12 @@ class RigctldHandler:
 
     def _receiver_id(self, receiver: int) -> str:
         return "sub" if receiver == 1 else "main"
+
+    def _split_tx_vfo(self) -> Literal["VFOA", "VFOB"]:
+        return self._split_tx_vfo_by_session.get(self._session_id(), "VFOA")
+
+    def _set_split_tx_vfo(self, tx_vfo: Literal["VFOA", "VFOB"]) -> None:
+        self._split_tx_vfo_by_session[self._session_id()] = tx_vfo
 
     def _legacy_receiver_id(self, receiver_id: str) -> str | None:
         if receiver_id == "main":
@@ -1883,7 +1891,7 @@ class RigctldHandler:
         # ``_split_tx_vfo`` is handler-local Hamlib-protocol state, set by
         # the most recent ``S`` command (issue #1345 — fixes #1319 finding
         # #2 where this used to leak the active VFO instead of TX_VFO).
-        return RigctldResponse(values=[str(int(split)), self._split_tx_vfo])
+        return RigctldResponse(values=[str(int(split)), self._split_tx_vfo()])
 
     async def _cmd_set_split_vfo(self, cmd: RigctldCommand) -> RigctldResponse:
         # Validate the (optional) leading VFO label first — VFOB on a
@@ -1958,7 +1966,7 @@ class RigctldHandler:
         # (issue #1345). Validate the label so a malformed request never
         # poisons the cached value.
         if tx_vfo in ("VFOA", "VFOB"):
-            self._split_tx_vfo = cast(Literal["VFOA", "VFOB"], tx_vfo)
+            self._set_split_tx_vfo(cast(Literal["VFOA", "VFOB"], tx_vfo))
         return HamlibError.OK
 
     async def _rollback_split(self, set_split: Any) -> None:

--- a/src/rigplane/rigctld/handler.py
+++ b/src/rigplane/rigctld/handler.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, cast
 
@@ -23,12 +24,13 @@ from ..commands import build_civ_frame
 from ..core.command_service import (
     CommandExecutionResult,
     CommandService,
+    PendingOverlay,
     command_intent_from_request,
     command_response_observation,
 )
 from ..core.state_diagnostics import StateDiagnosticsRecorder
-from ..core.state_pipeline_contracts import CommandIntent
-from ..core.state_store import StateStore
+from ..core.state_pipeline_contracts import CommandIntent, FieldPath, Observation, SourceMetadata
+from ..core.state_store import StateStore, StateSnapshot
 from ..exceptions import ConnectionError, TimeoutError as RigplaneTimeoutError
 from ..radio_state import RadioState, ReceiverState
 from ..types import Mode
@@ -391,7 +393,7 @@ class _RigctldCommandExecutor:
         else:
             raise ValueError(f"unsupported rigctld command intent: {intent.name!r}")
 
-        observations = ()
+        observations: tuple[Observation, ...] = ()
         if intent.target is not None:
             observations = (
                 command_response_observation(
@@ -401,6 +403,35 @@ class _RigctldCommandExecutor:
                 ),
             )
         return CommandExecutionResult(observations=observations)
+
+
+@dataclass(frozen=True, slots=True)
+class _ProjectedField:
+    path: str
+    value: Any
+
+
+@dataclass(slots=True)
+class _RigctldProjection:
+    """Snapshot plus scoped pending overlays for one rigctld session."""
+
+    snapshot: StateSnapshot
+    overlays: dict[str, Any]
+
+    def covers(self, paths: Sequence[str]) -> bool:
+        return all(path in self.overlays for path in paths)
+
+    def value(self, *paths: str) -> _ProjectedField | None:
+        for path in paths:
+            if path in self.overlays:
+                return _ProjectedField(path=path, value=self.overlays[path])
+        for path in paths:
+            try:
+                field = self.snapshot.field(path)
+            except KeyError:
+                continue
+            return _ProjectedField(path=path, value=field.value)
+        return None
 
 
 # ---------------------------------------------------------------------------
@@ -465,15 +496,15 @@ class RigctldHandler:
         self._radio = radio
         self._config = config
         self._state_diagnostics = getattr(radio, "_state_diagnostics", None)
-        self._ptt_state: bool | None = None
         # Hamlib-protocol concept: TX VFO label tracked across S/s commands.
         # Not radio state (CI-V has no per-VFO TX-routing register on most
         # Icoms — set_vfo_split routing is via active receiver). Initial
         # value mirrors the Hamlib default ("VFOA"). Updated by
         # ``_cmd_set_split_vfo`` on every ``S`` request. (Issue #1345.)
         self._split_tx_vfo: Literal["VFOA", "VFOB"] = "VFOA"
-        # Temporary rigctld GET/read-projection shims until MOR-340/MOR-341/
-        # MOR-343 move delivery fully onto the shared StateStore.
+        # Legacy routing cache is retained only for vendor-specific routing
+        # strategies that still depend on it (Yaesu today). Core rigctld GET
+        # paths project from StateStore plus scoped CommandService overlays.
         self._cache = _FallbackRigState()
         self._pending = _PendingRigState()
         self._routing = create_routing(
@@ -486,6 +517,8 @@ class RigctldHandler:
                 setattr(radio, "_state_store", state_store)
             except Exception:
                 logger.debug("rigctld: failed to attach command StateStore")
+        self._state_store = state_store
+        self._state_model_service = getattr(radio, "_state_model_service", None)
         self._command_service = CommandService(
             executor=_RigctldCommandExecutor(self),
             state_store=state_store,
@@ -497,7 +530,7 @@ class RigctldHandler:
             return True
         if value > _profile_data_mode_count(self._radio):
             return True
-        return value
+        return int(value)
 
     async def _apply_packet_data_mode(self, *, receiver: int = 0) -> int | bool:
         data_mode = self._packet_data_mode_value()
@@ -526,6 +559,151 @@ class RigctldHandler:
         if state is None or state.main.freq <= 0:
             return None
         return state.main
+
+    def _receiver_id(self, receiver: int) -> str:
+        return str(receiver)
+
+    def _freq_path(self, receiver: int) -> str:
+        return f"receiver.{self._receiver_id(receiver)}.freq_mode.freq_hz"
+
+    def _mode_path(self, receiver: int) -> str:
+        return f"receiver.{self._receiver_id(receiver)}.freq_mode.mode"
+
+    def _filter_path(self, receiver: int) -> str:
+        return f"receiver.{self._receiver_id(receiver)}.freq_mode.filter_width"
+
+    def _data_mode_path(self, receiver: int) -> str:
+        return f"receiver.{self._receiver_id(receiver)}.freq_mode.data_mode"
+
+    def _active_slot_path(self, receiver: int = 0) -> str:
+        return f"receiver.{self._receiver_id(receiver)}.vfo.active_slot"
+
+    def _level_path(self, level: str, *, receiver: int) -> str | None:
+        if level == "STRENGTH":
+            return f"receiver.{self._receiver_id(receiver)}.meters.s_meter"
+        if level == "RFPOWER":
+            return "global.operator_controls.power_level"
+        if level == "SWR":
+            return "global.meters.swr"
+        if level == "RFPOWER_METER":
+            return "global.meters.power"
+        if level == "COMP_METER":
+            return "global.meters.comp_meter"
+        if level == "ID_METER":
+            return "global.meters.id_meter"
+        if level == "VD_METER":
+            return "global.meters.vd_meter"
+        names = {
+            "AF": "af_level",
+            "RF": "rf_gain",
+            "SQL": "squelch",
+            "NR": "nr_level",
+            "NB": "nb_level",
+            "COMP": "compressor_level",
+            "MICGAIN": "mic_gain",
+            "MONITOR_GAIN": "monitor_gain",
+            "KEYSPD": "key_speed",
+            "CWPITCH": "cw_pitch",
+            "PREAMP": "preamp",
+            "ATT": "att",
+        }
+        name = names.get(level)
+        if name is None:
+            return None
+        return f"receiver.{self._receiver_id(receiver)}.operator_controls.{name}"
+
+    def _func_path(self, func: str, *, receiver: int) -> str:
+        return (
+            f"receiver.{self._receiver_id(receiver)}."
+            f"operator_toggles.{func.lower()}"
+        )
+
+    def _project_fields(self, paths: Sequence[str]) -> _RigctldProjection:
+        snapshot = self._state_store.snapshot()
+        overlays = {
+            str(path): value
+            for path, value in self._command_service.project_pending_values(
+                source="rigctld",
+                session_id=None,
+                paths=tuple(FieldPath.parse(path) for path in paths),
+            ).items()
+        }
+        return _RigctldProjection(snapshot=snapshot, overlays=overlays)
+
+    def _ensure_fresh(self, paths: Sequence[str], *, reason: str) -> None:
+        service = self._state_model_service
+        if service is None or self._config.cache_ttl <= 0:
+            return
+        ensure_fresh = getattr(service, "ensure_fresh", None)
+        if not callable(ensure_fresh) or asyncio.iscoroutinefunction(ensure_fresh):
+            return
+        ensure_fresh(
+            tuple(sorted(paths)),
+            max_age=self._config.cache_ttl,
+            priority="user",
+            reason=reason,
+        )
+
+    def _project_with_freshness(
+        self,
+        paths: Sequence[str],
+        *,
+        reason: str,
+    ) -> _RigctldProjection:
+        projection = self._project_fields(paths)
+        if not projection.covers(paths):
+            self._ensure_fresh(paths, reason=reason)
+            projection = self._project_fields(paths)
+        return projection
+
+    def _record_state_sample(
+        self,
+        path: str,
+        value: Any,
+        *,
+        source: Literal["hamlib_response", "state_poller"],
+        max_age: float | None = None,
+    ) -> None:
+        self._state_store.apply(
+            Observation(
+                path=FieldPath.parse(path),
+                value=value,
+                source=SourceMetadata(
+                    source=source,
+                    provider="rigctld",
+                    command_source="rigctld",
+                ),
+                timestamp_monotonic=time.monotonic(),
+                max_age=max_age,
+            )
+        )
+
+    def _record_pending_overlay(self, path: str, value: Any, *, command_id: str) -> None:
+        self._command_service.record_pending_overlay(
+            PendingOverlay(
+                source="rigctld",
+                session_id=None,
+                command_id=command_id,
+                path=FieldPath.parse(path),
+                value=value,
+                expires_at_monotonic=time.monotonic() + 2.0,
+            )
+        )
+
+    def _confirm_pending_value(self, path: str, value: Any, *, command_id: str) -> None:
+        self._command_service.apply_observation(
+            Observation(
+                path=FieldPath.parse(path),
+                value=value,
+                source=SourceMetadata(
+                    source="command_response",
+                    provider="rigctld",
+                    command_source="rigctld",
+                ),
+                timestamp_monotonic=time.monotonic(),
+                correlation_id=command_id,
+            )
+        )
 
     def _effective_pending_freq(self, main_state: ReceiverState | None) -> int | None:
         pending_freq = self._pending.freq
@@ -631,13 +809,25 @@ class RigctldHandler:
         except ValueError:
             return _err(HamlibError.EVFO)
 
+        receiver = self._receiver_index_for(target)
+        path = self._freq_path(receiver)
+        projection = self._project_with_freshness((path,), reason="rigctld.get_freq")
+        projected = projection.value(path)
+        if projected is not None:
+            return RigctldResponse(values=[str(int(projected.value))])
+
         # Per-VFO routing for VFOB on dual-RX: read SUB receiver state directly.
-        # Skip pending/cache (those track MAIN only — see _PendingRigState).
-        # Gate on _receiver_index_for so single-RX active_slot="B" falls through
-        # to the MAIN path (slot selection is via set_vfo_slot, not receiver=).
-        if self._receiver_index_for(target) == 1:
+        # StateStore projections are canonical when present; RadioState remains
+        # a compatibility fallback until runtime observation delivery owns SUB.
+        if receiver == 1:
             state = self._radio_state()
             if state is not None:
+                self._record_state_sample(
+                    path,
+                    state.sub.freq,
+                    source="state_poller",
+                    max_age=self._config.cache_ttl,
+                )
                 return RigctldResponse(values=[str(state.sub.freq)])
             # State unavailable. For an EXPLICIT VFOB request under chk_vfo=1
             # surface ENIMPL rather than silently returning MAIN data labelled
@@ -648,17 +838,21 @@ class RigctldHandler:
                 return _err(HamlibError.ENIMPL)
 
         main_state = self._main_receiver_state()
-        pending_freq = self._effective_pending_freq(main_state)
-        if pending_freq is not None:
-            self._cache.update_freq(pending_freq)
-            return RigctldResponse(values=[str(pending_freq)])
         if main_state is not None:
-            self._cache.update_freq(main_state.freq)
+            self._record_state_sample(
+                path,
+                main_state.freq,
+                source="state_poller",
+                max_age=self._config.cache_ttl,
+            )
             return RigctldResponse(values=[str(main_state.freq)])
-        if self._cache.is_fresh("freq", self._config.cache_ttl):
-            return RigctldResponse(values=[str(self._cache.freq)])
         freq = await self._radio.get_freq()
-        self._cache.update_freq(freq)
+        self._record_state_sample(
+            path,
+            freq,
+            source="hamlib_response",
+            max_age=self._config.cache_ttl,
+        )
         return RigctldResponse(values=[str(freq)])
 
     async def _cmd_set_freq(self, cmd: RigctldCommand) -> RigctldResponse:
@@ -681,12 +875,6 @@ class RigctldHandler:
             command_id=f"rigctld-set-freq-{time.monotonic_ns()}",
         )
         await self._command_service.execute(intent)
-        # Compatibility shim until MOR-340/MOR-341/MOR-343 move rigctld reads
-        # fully onto StateStore projections: pending/cache track MAIN only, so
-        # subsequent ``f VFOA`` reads coalesce against the just-written value.
-        if receiver == 0:
-            self._pending.freq = freq
-            self._cache.update_freq(freq)
         return _ok()
 
     # ------------------------------------------------------------------
@@ -699,17 +887,64 @@ class RigctldHandler:
         except ValueError:
             return _err(HamlibError.EVFO)
 
+        receiver = self._receiver_index_for(target)
+        mode_path = self._mode_path(receiver)
+        filter_path = self._filter_path(receiver)
+        data_mode_path = self._data_mode_path(receiver)
+        projection = self._project_with_freshness(
+            (mode_path, filter_path, data_mode_path),
+            reason="rigctld.get_mode",
+        )
+        projected_mode = projection.value(mode_path)
+        projected_filter = projection.value(filter_path)
+        projected_data_mode = projection.value(data_mode_path)
+        if (
+            projected_mode is not None
+            and projected_filter is not None
+            and projected_data_mode is not None
+        ):
+            mode_str = str(projected_mode.value).upper()
+            passband = _filter_to_passband(
+                None
+                if projected_filter.value is None
+                else int(projected_filter.value)
+            )
+            data_mode = bool(projected_data_mode.value)
+            if data_mode:
+                if mode_str == "USB":
+                    mode_str = "PKTUSB"
+                elif mode_str == "LSB":
+                    mode_str = "PKTLSB"
+                elif mode_str == "RTTY":
+                    mode_str = "PKTRTTY"
+            return RigctldResponse(values=[mode_str, str(passband)])
+
         # Per-VFO routing for VFOB on dual-RX: read SUB receiver state directly.
-        # Skip pending/cache (those track MAIN only — see _PendingRigState).
-        # Gate on _receiver_index_for so single-RX active_slot="B" falls through
-        # to the MAIN path (slot selection is via set_vfo_slot, not receiver=).
-        if self._receiver_index_for(target) == 1:
+        if receiver == 1:
             state = self._radio_state()
             if state is not None:
                 sub = state.sub
                 mode_str = sub.mode.upper()
                 passband = _filter_to_passband(sub.filter)
                 data_mode = sub.data_mode
+                self._record_state_sample(
+                    mode_path,
+                    mode_str,
+                    source="state_poller",
+                    max_age=self._config.cache_ttl,
+                )
+                self._record_state_sample(
+                    filter_path,
+                    sub.filter,
+                    source="state_poller",
+                    max_age=self._config.cache_ttl,
+                )
+                self._record_state_sample(
+                    data_mode_path,
+                    bool(data_mode),
+                    source="state_poller",
+                    max_age=self._config.cache_ttl,
+                )
                 if data_mode:
                     if mode_str == "USB":
                         mode_str = "PKTUSB"
@@ -727,35 +962,61 @@ class RigctldHandler:
                 return _err(HamlibError.ENIMPL)
 
         main_state = self._main_receiver_state()
-        pending_mode = self._effective_pending_mode(main_state)
-        if pending_mode is not None:
-            mode_str, passband, data_mode = pending_mode
-            self._cache.update_mode(mode_str, self._pending.filter_width)
-            self._cache.update_data_mode(bool(data_mode))
-        elif main_state is not None:
+        if main_state is not None:
             mode_str = main_state.mode.upper()
             passband = _filter_to_passband(main_state.filter)
             data_mode = main_state.data_mode
-            self._cache.update_mode(mode_str, main_state.filter)
-            self._cache.update_data_mode(bool(data_mode))
-        elif self._cache.is_fresh("mode", self._config.cache_ttl):
-            mode_str = self._cache.mode
-            passband = _filter_to_passband(self._cache.filter_width)
-            data_mode = self._cache.data_mode
+            self._record_state_sample(
+                mode_path,
+                mode_str,
+                source="state_poller",
+                max_age=self._config.cache_ttl,
+            )
+            self._record_state_sample(
+                filter_path,
+                main_state.filter,
+                source="state_poller",
+                max_age=self._config.cache_ttl,
+            )
+            self._record_state_sample(
+                data_mode_path,
+                bool(data_mode),
+                source="state_poller",
+                max_age=self._config.cache_ttl,
+            )
         else:
             get_mode = get_mode_reader(self._radio, _mode_to_hamlib_str)
             if get_mode is None:
                 return _err(HamlibError.ENIMPL)
             mode_str, filt = await get_mode()
-            self._cache.update_mode(mode_str, filt)
+            self._record_state_sample(
+                mode_path,
+                mode_str,
+                source="hamlib_response",
+                max_age=self._config.cache_ttl,
+            )
+            self._record_state_sample(
+                filter_path,
+                filt,
+                source="hamlib_response",
+                max_age=self._config.cache_ttl,
+            )
             passband = _filter_to_passband(filt)
             # Fetch data mode alongside mode to keep them in sync.
             try:
                 data_mode = await self._radio.get_data_mode()
-                self._cache.update_data_mode(data_mode)
+                self._record_state_sample(
+                    data_mode_path,
+                    bool(data_mode),
+                    source="hamlib_response",
+                    max_age=self._config.cache_ttl,
+                )
             except Exception:
-                logger.debug("get_data_mode failed, using cache", exc_info=True)
-                data_mode = self._cache.data_mode
+                logger.debug(
+                    "get_data_mode failed, preserving last projected value",
+                    exc_info=True,
+                )
+                data_mode = False
 
         # Map DATA overlays to packet modes where hamlib expects them.
         if data_mode:
@@ -799,19 +1060,29 @@ class RigctldHandler:
         # Gate on _receiver_index_for so single-RX active_slot="B" falls through
         # to the MAIN path (slot selection is via set_vfo_slot, not receiver=).
         if self._receiver_index_for(target) == 1:
-            await self._command_service.execute(
-                command_intent_from_request(
-                    "set_mode",
-                    {
-                        "mode": base_mode_str,
-                        "filter_width": filter_width,
-                        "receiver": 1,
-                        "packet_mode": requested_mode in packet_modes,
-                    },
-                    source="rigctld",
-                    command_id=f"rigctld-set-mode-{time.monotonic_ns()}",
-                )
+            intent = command_intent_from_request(
+                "set_mode",
+                {
+                    "mode": base_mode_str,
+                    "filter_width": filter_width,
+                    "receiver": 1,
+                    "packet_mode": requested_mode in packet_modes,
+                },
+                source="rigctld",
+                command_id=f"rigctld-set-mode-{time.monotonic_ns()}",
             )
+            await self._command_service.execute(intent)
+            self._record_pending_overlay(
+                self._filter_path(1),
+                filter_width,
+                command_id=intent.id,
+            )
+            if requested_mode in packet_modes:
+                self._record_pending_overlay(
+                    self._data_mode_path(1),
+                    True,
+                    command_id=intent.id,
+                )
             return _ok()
 
         intent = command_intent_from_request(
@@ -826,6 +1097,17 @@ class RigctldHandler:
             command_id=f"rigctld-set-mode-{time.monotonic_ns()}",
         )
         await self._command_service.execute(intent)
+        self._record_pending_overlay(
+            self._filter_path(0),
+            filter_width,
+            command_id=intent.id,
+        )
+        if requested_mode in packet_modes:
+            self._record_pending_overlay(
+                self._data_mode_path(0),
+                True,
+                command_id=intent.id,
+            )
 
         # Only set DATA mode explicitly for packet modes.
         # For non-packet modes, avoid hidden side-effects (do not force DATA off).
@@ -842,13 +1124,15 @@ class RigctldHandler:
                         read_mode, _ = await get_mode()
                         read_data = await self._radio.get_data_mode()
                         if read_mode == base_mode_str and read_data:
-                            self._command_service.apply_observation(
-                                command_response_observation(
-                                    intent,
-                                    timestamp_monotonic=time.monotonic(),
-                                    provider="rigctld",
-                                    value=read_mode,
-                                )
+                            self._confirm_pending_value(
+                                self._filter_path(0),
+                                filter_width,
+                                command_id=intent.id,
+                            )
+                            self._confirm_pending_value(
+                                self._data_mode_path(0),
+                                True,
+                                command_id=intent.id,
                             )
                             synced = True
                             break
@@ -856,26 +1140,13 @@ class RigctldHandler:
                         logger.debug("rigctld: sync poll failed", exc_info=True)
                     await asyncio.sleep(0.05)
 
-            # Compatibility shim until rigctld reads are projected from
-            # StateStore: cache optimistic final state even if read-back lagged.
-            self._cache.update_mode(base_mode_str, filter_width)
-            self._cache.update_data_mode(True)
-            self._pending.mode = base_mode_str
-            self._pending.filter_width = filter_width
-            self._pending.data_mode = True
             logger.debug("set_mode(%s): DATA%s selected", requested_mode, data_mode)
             if not synced:
                 logger.debug(
-                    "set_mode(%s): packet read-back not fully synced yet; cached optimistic state",
+                    "set_mode(%s): packet read-back not fully synced yet; "
+                    "scoped pending overlays remain active",
                     requested_mode,
                 )
-        else:
-            # For non-packet mode changes update mode cache, but preserve DATA
-            # state (no forced DATA off side-effect).
-            self._cache.update_mode(base_mode_str, filter_width)
-            self._pending.mode = base_mode_str
-            self._pending.filter_width = filter_width
-            self._pending.data_mode = None
 
         return _ok()
 
@@ -894,16 +1165,24 @@ class RigctldHandler:
         except ValueError:
             return _err(HamlibError.EVFO)
 
+        projection = self._project_with_freshness(
+            ("global.tx_state.ptt",),
+            reason="rigctld.get_ptt",
+        )
+        projected = projection.value("global.tx_state.ptt")
+        if projected is not None:
+            return RigctldResponse(values=[str(int(bool(projected.value)))])
+
         state = self._radio_state()
         if state is not None:
-            self._cache.update_ptt(state.ptt)
-            if self._ptt_state is None:
-                return RigctldResponse(values=[str(int(state.ptt))])
-            if state.ptt == self._ptt_state:
-                self._ptt_state = None
-                return RigctldResponse(values=[str(int(state.ptt))])
-            return RigctldResponse(values=[str(int(self._ptt_state))])
-        return RigctldResponse(values=[str(int(bool(self._ptt_state)))])
+            self._record_state_sample(
+                "global.tx_state.ptt",
+                bool(state.ptt),
+                source="state_poller",
+                max_age=self._config.cache_ttl,
+            )
+            return RigctldResponse(values=[str(int(state.ptt))])
+        return RigctldResponse(values=["0"])
 
     async def _cmd_set_ptt(self, cmd: RigctldCommand) -> RigctldResponse:
         if not cmd.args:
@@ -926,8 +1205,6 @@ class RigctldHandler:
                 command_id=f"rigctld-set-ptt-{time.monotonic_ns()}",
             )
         )
-        self._ptt_state = on
-        self._cache.update_ptt(on)
         return _ok()
 
     # ------------------------------------------------------------------
@@ -957,6 +1234,10 @@ class RigctldHandler:
         1-Rx: maps ``radio_state.main.active_slot`` (``A``/``B``) → VFOA/VFOB.
         Falls back to ``VFOA`` when state is missing or profile is unknown.
         """
+        projection = self._project_fields((self._active_slot_path(),))
+        active_slot = projection.value(self._active_slot_path())
+        if active_slot is not None:
+            return "VFOB" if str(active_slot.value).upper() == "B" else "VFOA"
         info = self._profile_vfo_info()
         state = self._radio_state()
         if info is None or state is None:
@@ -1015,6 +1296,7 @@ class RigctldHandler:
         raise ValueError(f"Unknown VFO arg: {vfo_arg!r}")
 
     async def _cmd_get_vfo(self, cmd: RigctldCommand) -> RigctldResponse:
+        self._ensure_fresh((self._active_slot_path(),), reason="rigctld.get_vfo")
         return RigctldResponse(values=[self._active_vfo_name()])
 
     async def _cmd_set_vfo(self, cmd: RigctldCommand) -> RigctldResponse:
@@ -1095,46 +1377,102 @@ class RigctldHandler:
             return await self._routing.get_level(level, vfo=cmd.vfo_arg)
 
         all_levels = (
-            {"STRENGTH", "RFPOWER", "SWR", "PREAMP", "ATT", "KEYSPD", "CWPITCH"}
+            {
+                "STRENGTH",
+                "RFPOWER",
+                "SWR",
+                "PREAMP",
+                "ATT",
+                "KEYSPD",
+                "CWPITCH",
+                "RFPOWER_METER",
+                "COMP_METER",
+                "ID_METER",
+                "VD_METER",
+            }
             | set(_GET_LEVEL_FLOAT)
             | set(_GET_LEVEL_INT)
         )
         if level not in all_levels:
             return _err(HamlibError.EINVAL)
+        level_path = self._level_path(level, receiver=receiver)
+        if level_path is not None:
+            projection = self._project_with_freshness(
+                (level_path,),
+                reason=f"rigctld.get_level.{level.lower()}",
+            )
+            projected = projection.value(level_path)
+            if projected is not None:
+                if level == "STRENGTH":
+                    raw = int(projected.value)
+                    return RigctldResponse(
+                        values=[str(round((raw / 241.0) * 114.0 - 54.0))]
+                    )
+                if level == "RFPOWER":
+                    return RigctldResponse(
+                        values=[f"{int(projected.value) / 255.0:.6f}"]
+                    )
+                if level == "SWR":
+                    return RigctldResponse(values=[f"{float(projected.value):.6f}"])
+                if level in {"RFPOWER_METER", "COMP_METER", "ID_METER", "VD_METER"}:
+                    return RigctldResponse(
+                        values=[f"{int(projected.value) / 255.0:.6f}"]
+                    )
+                if level in _GET_LEVEL_FLOAT:
+                    return RigctldResponse(
+                        values=[f"{int(projected.value) / 255.0:.6f}"]
+                    )
+                return RigctldResponse(values=[str(projected.value)])
         main_state = self._main_receiver_state()
 
         # STRENGTH — per-receiver on dual-RX. VFOB reads SUB s_meter
-        # directly from RadioState (don't update _cache — it tracks MAIN
-        # only, mirroring the freq routing in #1344).
+        # directly from RadioState until runtime observations own SUB meters.
         if level == "STRENGTH":
             if receiver == 1:
                 state = self._radio_state()
                 if state is not None:
                     raw = state.sub.s_meter
+                    self._record_state_sample(
+                        self._level_path(level, receiver=receiver) or "",
+                        raw,
+                        source="state_poller",
+                        max_age=self._config.cache_ttl,
+                    )
                     return RigctldResponse(
                         values=[str(round((raw / 241.0) * 114.0 - 54.0))]
                     )
                 if CAP_METERS in self._radio.capabilities:
                     raw = await self._radio.get_s_meter(receiver=1)
+                    self._record_state_sample(
+                        self._level_path(level, receiver=receiver) or "",
+                        raw,
+                        source="hamlib_response",
+                        max_age=self._config.cache_ttl,
+                    )
                     return RigctldResponse(
                         values=[str(round((raw / 241.0) * 114.0 - 54.0))]
                     )
                 return _err(HamlibError.ENIMPL)
             if main_state is not None:
                 raw = main_state.s_meter
-                self._cache.update_s_meter(raw)
+                self._record_state_sample(
+                    self._level_path(level, receiver=receiver) or "",
+                    raw,
+                    source="state_poller",
+                    max_age=self._config.cache_ttl,
+                )
                 return RigctldResponse(
                     values=[str(round((raw / 241.0) * 114.0 - 54.0))]
                 )
             if CAP_METERS not in self._radio.capabilities:
-                if self._cache.s_meter is not None:
-                    raw = self._cache.s_meter
-                    return RigctldResponse(
-                        values=[str(round((raw / 241.0) * 114.0 - 54.0))]
-                    )
                 return _err(HamlibError.ENIMPL)
             raw = await self._radio.get_s_meter()
-            self._cache.update_s_meter(raw)
+            self._record_state_sample(
+                self._level_path(level, receiver=receiver) or "",
+                raw,
+                source="hamlib_response",
+                max_age=self._config.cache_ttl,
+            )
             # IC-7610 S-meter: 0→S0(−54 dB), 120→S9(0 dB), 241→S9+60 dB
             return RigctldResponse(values=[str(round((raw / 241.0) * 114.0 - 54.0))])
 
@@ -1143,28 +1481,49 @@ class RigctldHandler:
             state = self._radio_state()
             if state is not None and main_state is not None:
                 raw_power = state.power_level / 255.0
-                self._cache.update_rf_power(raw_power)
+                self._record_state_sample(
+                    self._level_path(level, receiver=receiver) or "",
+                    state.power_level,
+                    source="state_poller",
+                    max_age=self._config.cache_ttl,
+                )
                 return RigctldResponse(values=[f"{raw_power:.6f}"])
             if CAP_METERS not in self._radio.capabilities:
-                if self._cache.rf_power is not None:
-                    return RigctldResponse(values=[f"{self._cache.rf_power:.6f}"])
                 return _err(HamlibError.ENIMPL)
             raw = await self._radio.get_rf_power()
-            normalized = raw / 255.0
-            self._cache.update_rf_power(normalized)
-            return RigctldResponse(values=[f"{normalized:.6f}"])
+            self._record_state_sample(
+                self._level_path(level, receiver=receiver) or "",
+                raw,
+                source="hamlib_response",
+                max_age=self._config.cache_ttl,
+            )
+            return RigctldResponse(values=[f"{raw / 255.0:.6f}"])
 
         # SWR — meter call. ``get_swr`` already returns a calibrated
         # ratio (>= 1.0) per ``MetersCapable``; pass the float through
         # without re-mapping (issue #1173).
         if level == "SWR":
             if CAP_METERS not in self._radio.capabilities:
-                if self._cache.swr is not None:
-                    return RigctldResponse(values=[f"{self._cache.swr:.6f}"])
                 return _err(HamlibError.ENIMPL)
             swr = float(await self._radio.get_swr())
-            self._cache.update_swr(swr)
+            self._record_state_sample(
+                self._level_path(level, receiver=receiver) or "",
+                swr,
+                source="hamlib_response",
+                max_age=self._config.cache_ttl,
+            )
             return RigctldResponse(values=[f"{swr:.6f}"])
+
+        if level in {"RFPOWER_METER", "COMP_METER", "ID_METER", "VD_METER"}:
+            method = getattr(self._radio, _GET_LEVEL_FLOAT[level])
+            raw = await method()
+            self._record_state_sample(
+                self._level_path(level, receiver=receiver) or "",
+                raw,
+                source="hamlib_response",
+                max_age=self._config.cache_ttl,
+            )
+            return RigctldResponse(values=[f"{raw / 255.0:.6f}"])
 
         # Simple 0-255 → 0.0-1.0 float levels
         if level in _GET_LEVEL_FLOAT:
@@ -1175,22 +1534,46 @@ class RigctldHandler:
                 raw = await method(receiver=receiver)
             else:
                 raw = await method()
+            self._record_state_sample(
+                self._level_path(level, receiver=receiver) or "",
+                raw,
+                source="hamlib_response",
+                max_age=self._config.cache_ttl,
+            )
             return RigctldResponse(values=[f"{raw / 255.0:.6f}"])
 
         # Integer levels (WPM, Hz)
         if level in _GET_LEVEL_INT:
             val = await getattr(self._radio, _GET_LEVEL_INT[level])()
+            self._record_state_sample(
+                self._level_path(level, receiver=receiver) or "",
+                val,
+                source="hamlib_response",
+                max_age=self._config.cache_ttl,
+            )
             return RigctldResponse(values=[str(val)])
 
         # PREAMP — returns dB (0, 12, 20)
         if level == "PREAMP":
             idx = await self._radio.get_preamp()
             db = _PREAMP_IDX_TO_DB[idx] if 0 <= idx < len(_PREAMP_IDX_TO_DB) else 0
+            self._record_state_sample(
+                self._level_path(level, receiver=receiver) or "",
+                db,
+                source="hamlib_response",
+                max_age=self._config.cache_ttl,
+            )
             return RigctldResponse(values=[str(db)])
 
         # ATT — returns dB directly (0, 6, 12, 18)
         if level == "ATT":
             db = await self._radio.get_attenuator_level()
+            self._record_state_sample(
+                self._level_path(level, receiver=receiver) or "",
+                db,
+                source="hamlib_response",
+                max_age=self._config.cache_ttl,
+            )
             return RigctldResponse(values=[str(db)])
 
         return _err(HamlibError.EINVAL)
@@ -1303,6 +1686,14 @@ class RigctldHandler:
 
         if func not in _FUNC_GET:
             return _err(HamlibError.EINVAL)
+        func_path = self._func_path(func, receiver=receiver)
+        projection = self._project_with_freshness(
+            (func_path,),
+            reason=f"rigctld.get_func.{func.lower()}",
+        )
+        projected = projection.value(func_path)
+        if projected is not None:
+            return RigctldResponse(values=[str(int(bool(projected.value)))])
         method = getattr(self._radio, _FUNC_GET[func])
         # NB / NR are per-receiver on dual-RX Icoms.  Other funcs are
         # radio-global — VFO arg is validated above but ignored.
@@ -1310,6 +1701,12 @@ class RigctldHandler:
             result = await method(receiver=receiver)
         else:
             result = await method()
+        self._record_state_sample(
+            func_path,
+            bool(result),
+            source="hamlib_response",
+            max_age=self._config.cache_ttl,
+        )
         # APF returns AudioPeakFilter int enum (0=off); others return bool
         return RigctldResponse(values=[str(int(bool(result)))])
 
@@ -1380,8 +1777,23 @@ class RigctldHandler:
             self._resolve_target_vfo(cmd.vfo_arg)
         except ValueError:
             return _err(HamlibError.EVFO)
-        state = self._radio_state()
-        split = state.split if state is not None else False
+        projection = self._project_with_freshness(
+            ("global.tx_state.split",),
+            reason="rigctld.get_split_vfo",
+        )
+        projected = projection.value("global.tx_state.split")
+        if projected is not None:
+            split = bool(projected.value)
+        else:
+            state = self._radio_state()
+            split = state.split if state is not None else False
+            if state is not None:
+                self._record_state_sample(
+                    "global.tx_state.split",
+                    split,
+                    source="state_poller",
+                    max_age=self._config.cache_ttl,
+                )
         # ``_split_tx_vfo`` is handler-local Hamlib-protocol state, set by
         # the most recent ``S`` command (issue #1345 — fixes #1319 finding
         # #2 where this used to leak the active VFO instead of TX_VFO).

--- a/src/rigplane/rigctld/handler.py
+++ b/src/rigplane/rigctld/handler.py
@@ -1188,6 +1188,9 @@ class RigctldHandler:
             session_id=self._session_id(),
         )
         await self._command_service.execute(intent)
+        self._cache.update_mode(base_mode_str, filter_width)
+        if requested_mode in packet_modes:
+            self._cache.update_data_mode(True)
         self._record_pending_overlay(
             self._filter_path(0),
             filter_width,

--- a/src/rigplane/rigctld/handler.py
+++ b/src/rigplane/rigctld/handler.py
@@ -20,7 +20,15 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, cast
 
 from ..commands import build_civ_frame
+from ..core.command_service import (
+    CommandExecutionResult,
+    CommandService,
+    command_intent_from_request,
+    command_response_observation,
+)
 from ..core.state_diagnostics import StateDiagnosticsRecorder
+from ..core.state_pipeline_contracts import CommandIntent
+from ..core.state_store import StateStore
 from ..exceptions import ConnectionError, TimeoutError
 from ..radio_state import RadioState, ReceiverState
 from ..types import Mode
@@ -287,6 +295,51 @@ class _FallbackRigState:
         self.swr_ts = time.monotonic()
 
 
+@dataclass(slots=True)
+class _RigctldCommandExecutor:
+    handler: "RigctldHandler"
+
+    async def execute(self, intent: CommandIntent) -> CommandExecutionResult:
+        params = intent.params
+        if intent.name == "set_freq":
+            await self.handler._radio.set_freq(
+                int(params["freq_hz"]),
+                receiver=int(params.get("receiver", 0)),
+            )
+        elif intent.name == "set_mode":
+            receiver = int(params.get("receiver", 0))
+            mode = str(params["mode"])
+            filter_width = params.get("filter_width")
+            if filter_width is not None:
+                filter_width = int(filter_width)
+            if receiver == 0:
+                await self.handler._radio.set_mode(
+                    mode,
+                    filter_width=filter_width,
+                )
+            else:
+                await self.handler._radio.set_mode(
+                    mode,
+                    filter_width=filter_width,
+                    receiver=receiver,
+                )
+            if bool(params.get("packet_mode", False)):
+                await self.handler._apply_packet_data_mode(receiver=receiver)
+        else:
+            raise ValueError(f"unsupported rigctld command intent: {intent.name!r}")
+
+        observations = ()
+        if intent.target is not None:
+            observations = (
+                command_response_observation(
+                    intent,
+                    timestamp_monotonic=time.monotonic(),
+                    provider="rigctld",
+                ),
+            )
+        return CommandExecutionResult(observations=observations)
+
+
 # ---------------------------------------------------------------------------
 # Raw CI-V helpers
 # ---------------------------------------------------------------------------
@@ -360,6 +413,17 @@ class RigctldHandler:
         self._pending = _PendingRigState()
         self._routing = create_routing(
             radio, self._cache, getattr(config, "max_power_w", 100.0)
+        )
+        state_store = getattr(radio, "_state_store", None)
+        if not isinstance(state_store, StateStore):
+            state_store = StateStore()
+            try:
+                setattr(radio, "_state_store", state_store)
+            except Exception:
+                logger.debug("rigctld: failed to attach command StateStore")
+        self._command_service = CommandService(
+            executor=_RigctldCommandExecutor(self),
+            state_store=state_store,
         )
 
     def _packet_data_mode_value(self) -> int | bool:
@@ -542,8 +606,15 @@ class RigctldHandler:
             return _err(HamlibError.EVFO)
 
         receiver = self._receiver_index_for(target)
-        await self._radio.set_freq(freq, receiver=receiver)
-        # Pending/cache track MAIN only — only update on the MAIN path so
+        intent = command_intent_from_request(
+            "set_freq",
+            {"freq": freq, "receiver": receiver},
+            source="rigctld",
+            command_id=f"rigctld-set-freq-{time.monotonic_ns()}",
+        )
+        await self._command_service.execute(intent)
+        # Compatibility shim until MOR-340/MOR-341/MOR-343 move rigctld reads
+        # fully onto StateStore projections: pending/cache track MAIN only, so
         # subsequent ``f VFOA`` reads coalesce against the just-written value.
         if receiver == 0:
             self._pending.freq = freq
@@ -660,24 +731,42 @@ class RigctldHandler:
         # Gate on _receiver_index_for so single-RX active_slot="B" falls through
         # to the MAIN path (slot selection is via set_vfo_slot, not receiver=).
         if self._receiver_index_for(target) == 1:
-            await self._radio.set_mode(
-                base_mode_str, filter_width=filter_width, receiver=1
+            await self._command_service.execute(
+                command_intent_from_request(
+                    "set_mode",
+                    {
+                        "mode": base_mode_str,
+                        "filter_width": filter_width,
+                        "receiver": 1,
+                        "packet_mode": requested_mode in packet_modes,
+                    },
+                    source="rigctld",
+                    command_id=f"rigctld-set-mode-{time.monotonic_ns()}",
+                )
             )
-            if requested_mode in packet_modes:
-                await self._apply_packet_data_mode(receiver=1)
             return _ok()
 
-        await self._radio.set_mode(base_mode_str, filter_width=filter_width)
+        intent = command_intent_from_request(
+            "set_mode",
+            {
+                "mode": base_mode_str,
+                "filter_width": filter_width,
+                "receiver": 0,
+                "packet_mode": requested_mode in packet_modes,
+            },
+            source="rigctld",
+            command_id=f"rigctld-set-mode-{time.monotonic_ns()}",
+        )
+        await self._command_service.execute(intent)
 
         # Only set DATA mode explicitly for packet modes.
         # For non-packet modes, avoid hidden side-effects (do not force DATA off).
         if requested_mode in packet_modes:
-            data_mode = await self._apply_packet_data_mode()
-
             # Read-back sync: keep next get_mode deterministic for CAT clients.
             # Some radios acknowledge set-data quickly but reflect packet mode
             # with a short delay. We wait briefly to reduce client-side stalls.
             synced = False
+            data_mode = self._packet_data_mode_value()
             get_mode = get_mode_reader(self._radio, _mode_to_hamlib_str)
             if get_mode is not None:
                 for _ in range(5):
@@ -685,13 +774,22 @@ class RigctldHandler:
                         read_mode, _ = await get_mode()
                         read_data = await self._radio.get_data_mode()
                         if read_mode == base_mode_str and read_data:
+                            self._command_service.apply_observation(
+                                command_response_observation(
+                                    intent,
+                                    timestamp_monotonic=time.monotonic(),
+                                    provider="rigctld",
+                                    value=read_mode,
+                                )
+                            )
                             synced = True
                             break
                     except Exception:
                         logger.debug("rigctld: sync poll failed", exc_info=True)
                     await asyncio.sleep(0.05)
 
-            # Cache optimistic final state even if read-back lagged.
+            # Compatibility shim until rigctld reads are projected from
+            # StateStore: cache optimistic final state even if read-back lagged.
             self._cache.update_mode(base_mode_str, filter_width)
             self._cache.update_data_mode(True)
             self._pending.mode = base_mode_str

--- a/src/rigplane/rigctld/handler.py
+++ b/src/rigplane/rigctld/handler.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, cast
 
 from ..commands import build_civ_frame
+from ..core.state_diagnostics import StateDiagnosticsRecorder
 from ..exceptions import ConnectionError, TimeoutError
 from ..radio_state import RadioState, ReceiverState
 from ..types import Mode
@@ -347,6 +348,7 @@ class RigctldHandler:
     ) -> None:
         self._radio = radio
         self._config = config
+        self._state_diagnostics = getattr(radio, "_state_diagnostics", None)
         self._ptt_state: bool | None = None
         # Hamlib-protocol concept: TX VFO label tracked across S/s commands.
         # Not radio state (CI-V has no per-VFO TX-routing register on most
@@ -464,7 +466,16 @@ class RigctldHandler:
             return _err(HamlibError.ENIMPL)
 
         try:
-            return cast(RigctldResponse, await handler_fn(self, cmd))
+            response = cast(RigctldResponse, await handler_fn(self, cmd))
+            if isinstance(self._state_diagnostics, StateDiagnosticsRecorder):
+                self._state_diagnostics.record(
+                    "rigctld_delivery_trigger",
+                    "rigctld.handler",
+                    command=cmd.long_cmd,
+                    is_set=cmd.is_set,
+                    error=int(response.error),
+                )
+            return response
         except ConnectionError:
             logger.warning("I/O error executing %s", cmd.long_cmd)
             return _err(HamlibError.EIO)

--- a/src/rigplane/rigctld/handler.py
+++ b/src/rigplane/rigctld/handler.py
@@ -1324,17 +1324,18 @@ class RigctldHandler:
         1-Rx: maps ``radio_state.main.active_slot`` (``A``/``B``) → VFOA/VFOB.
         Falls back to ``VFOA`` when state is missing or profile is unknown.
         """
+        info = self._profile_vfo_info()
+        state = self._radio_state()
+        if info is not None and info[0] >= 2:
+            if state is None:
+                return "VFOA"
+            return "VFOB" if state.active == "SUB" else "VFOA"
         projection = self._project_fields((self._active_slot_path(),))
         active_slot = projection.value(self._active_slot_path())
         if active_slot is not None:
             return "VFOB" if str(active_slot.value).upper() == "B" else "VFOA"
-        info = self._profile_vfo_info()
-        state = self._radio_state()
         if info is None or state is None:
             return "VFOA"
-        rc, _ = info
-        if rc >= 2:
-            return "VFOB" if state.active == "SUB" else "VFOA"
         return "VFOB" if state.main.active_slot == "B" else "VFOA"
 
     def _receiver_index_for(self, target: Literal["VFOA", "VFOB"]) -> int:

--- a/src/rigplane/rigctld/handler.py
+++ b/src/rigplane/rigctld/handler.py
@@ -30,7 +30,12 @@ from ..core.command_service import (
     command_response_observation,
 )
 from ..core.state_diagnostics import StateDiagnosticsRecorder
-from ..core.state_pipeline_contracts import CommandIntent, FieldPath, Observation, SourceMetadata
+from ..core.state_pipeline_contracts import (
+    CommandIntent,
+    FieldPath,
+    Observation,
+    SourceMetadata,
+)
 from ..core.state_store import FreshnessState, StateStore, StateSnapshot
 from ..exceptions import ConnectionError, TimeoutError as RigplaneTimeoutError
 from ..radio_state import RadioState, ReceiverState
@@ -623,7 +628,9 @@ class RigctldHandler:
         return FieldPath.active(self._receiver_id(receiver), "freq_mode", "mode")
 
     def _filter_path(self, receiver: int) -> FieldPath:
-        return FieldPath.active(self._receiver_id(receiver), "freq_mode", "filter_width")
+        return FieldPath.active(
+            self._receiver_id(receiver), "freq_mode", "filter_width"
+        )
 
     def _data_mode_path(self, receiver: int) -> FieldPath:
         return FieldPath.active(self._receiver_id(receiver), "freq_mode", "data_mode")
@@ -663,7 +670,9 @@ class RigctldHandler:
         name = names.get(level)
         if name is None:
             return None
-        return FieldPath.receiver(self._receiver_id(receiver), "operator_controls", name)
+        return FieldPath.receiver(
+            self._receiver_id(receiver), "operator_controls", name
+        )
 
     def _func_path(self, func: str, *, receiver: int) -> FieldPath:
         return FieldPath.receiver(
@@ -994,9 +1003,7 @@ class RigctldHandler:
         ):
             mode_str = str(projected_mode.value).upper()
             passband = _filter_to_passband(
-                None
-                if projected_filter.value is None
-                else int(projected_filter.value)
+                None if projected_filter.value is None else int(projected_filter.value)
             )
             data_mode = bool(projected_data_mode.value)
             if data_mode:
@@ -1949,7 +1956,11 @@ class RigctldHandler:
                     )
                     await self._rollback_split(set_split)
                     return HamlibError.EIO
-                except (RigplaneTimeoutError, TimeoutError, asyncio.TimeoutError) as exc:
+                except (
+                    RigplaneTimeoutError,
+                    TimeoutError,
+                    asyncio.TimeoutError,
+                ) as exc:
                     logger.warning(
                         "set_split_vfo: set_vfo(%s) timed out (%s); rolling back split",
                         target,

--- a/src/rigplane/rigctld/handler.py
+++ b/src/rigplane/rigctld/handler.py
@@ -29,7 +29,7 @@ from ..core.command_service import (
 from ..core.state_diagnostics import StateDiagnosticsRecorder
 from ..core.state_pipeline_contracts import CommandIntent
 from ..core.state_store import StateStore
-from ..exceptions import ConnectionError, TimeoutError
+from ..exceptions import ConnectionError, TimeoutError as RigplaneTimeoutError
 from ..radio_state import RadioState, ReceiverState
 from ..types import Mode
 from .contract import (  # noqa: TID251
@@ -380,7 +380,7 @@ class _RigctldCommandExecutor:
             frame_bytes = params["frame_bytes"]
             try:
                 resp = await send_fn(frame_bytes)
-            except (TimeoutError, asyncio.TimeoutError):
+            except (RigplaneTimeoutError, TimeoutError, asyncio.TimeoutError):
                 logger.debug("send_raw: timeout — returning empty response")
                 return CommandExecutionResult(details={"values": []})
             if resp is None:
@@ -608,7 +608,7 @@ class RigctldHandler:
         except ConnectionError:
             logger.warning("I/O error executing %s", cmd.long_cmd)
             return _err(HamlibError.EIO)
-        except TimeoutError:
+        except (RigplaneTimeoutError, TimeoutError, asyncio.TimeoutError):
             logger.warning("Timeout executing %s", cmd.long_cmd)
             return _err(HamlibError.ETIMEOUT)
         except _RigctldCommandFailure as exc:
@@ -1438,7 +1438,7 @@ class RigctldHandler:
                     )
                     await self._rollback_split(set_split)
                     return HamlibError.EIO
-                except TimeoutError as exc:
+                except (RigplaneTimeoutError, TimeoutError, asyncio.TimeoutError) as exc:
                     logger.warning(
                         "set_split_vfo: set_vfo(%s) timed out (%s); rolling back split",
                         target,

--- a/src/rigplane/rigctld/handler.py
+++ b/src/rigplane/rigctld/handler.py
@@ -295,6 +295,11 @@ class _FallbackRigState:
         self.swr_ts = time.monotonic()
 
 
+@dataclass(frozen=True, slots=True)
+class _RigctldCommandFailure(Exception):
+    error: HamlibError
+
+
 @dataclass(slots=True)
 class _RigctldCommandExecutor:
     handler: "RigctldHandler"
@@ -325,6 +330,56 @@ class _RigctldCommandExecutor:
                 )
             if bool(params.get("packet_mode", False)):
                 await self.handler._apply_packet_data_mode(receiver=receiver)
+        elif intent.name == "set_ptt":
+            await self.handler._radio.set_ptt(bool(params["ptt"]))
+        elif intent.name == "set_vfo":
+            error = await self.handler._execute_set_vfo(str(params["vfo"]))
+            if error is not HamlibError.OK:
+                raise _RigctldCommandFailure(error)
+        elif intent.name == "set_level":
+            error = await self.handler._execute_set_level(
+                str(params["level"]),
+                float(params["value"]),
+                receiver=int(params.get("receiver", 0)),
+                vfo_arg=None
+                if params.get("vfo_arg") is None
+                else str(params["vfo_arg"]),
+            )
+            if error is not HamlibError.OK:
+                raise _RigctldCommandFailure(error)
+        elif intent.name == "set_func":
+            error = await self.handler._execute_set_func(
+                str(params["func"]),
+                bool(params["on"]),
+                receiver=int(params.get("receiver", 0)),
+                vfo_arg=None
+                if params.get("vfo_arg") is None
+                else str(params["vfo_arg"]),
+            )
+            if error is not HamlibError.OK:
+                raise _RigctldCommandFailure(error)
+        elif intent.name == "set_split_vfo":
+            error = await self.handler._execute_set_split_vfo(
+                bool(params["on"]),
+                str(params["tx_vfo"]),
+            )
+            if error is not HamlibError.OK:
+                raise _RigctldCommandFailure(error)
+        elif intent.name == "send_raw":
+            send_fn = getattr(self.handler._radio, "_send_civ_raw", None)
+            if send_fn is None:
+                raise _RigctldCommandFailure(HamlibError.ENIMPL)
+            frame_bytes = params["frame_bytes"]
+            try:
+                resp = await send_fn(frame_bytes)
+            except (TimeoutError, asyncio.TimeoutError):
+                logger.debug("send_raw: timeout — returning empty response")
+                return CommandExecutionResult(details={"values": []})
+            if resp is None:
+                return CommandExecutionResult(details={"values": []})
+            raw = _civ_frame_to_bytes(resp)
+            hex_str = " ".join(f"{b:02X}" for b in raw)
+            return CommandExecutionResult(details={"values": [hex_str]})
         else:
             raise ValueError(f"unsupported rigctld command intent: {intent.name!r}")
 
@@ -409,6 +464,8 @@ class RigctldHandler:
         # value mirrors the Hamlib default ("VFOA"). Updated by
         # ``_cmd_set_split_vfo`` on every ``S`` request. (Issue #1345.)
         self._split_tx_vfo: Literal["VFOA", "VFOB"] = "VFOA"
+        # Temporary rigctld GET/read-projection shims until MOR-340/MOR-341/
+        # MOR-343 move delivery fully onto the shared StateStore.
         self._cache = _FallbackRigState()
         self._pending = _PendingRigState()
         self._routing = create_routing(
@@ -546,6 +603,9 @@ class RigctldHandler:
         except TimeoutError:
             logger.warning("Timeout executing %s", cmd.long_cmd)
             return _err(HamlibError.ETIMEOUT)
+        except _RigctldCommandFailure as exc:
+            logger.debug("rigctld command %s failed with %s", cmd.long_cmd, exc.error)
+            return _err(exc.error)
         except ValueError:
             logger.warning("Invalid value in %s", cmd.long_cmd)
             return _err(HamlibError.EINVAL)
@@ -850,7 +910,14 @@ class RigctldHandler:
             self._resolve_target_vfo(cmd.vfo_arg)
         except ValueError:
             return _err(HamlibError.EVFO)
-        await self._radio.set_ptt(on)
+        await self._command_service.execute(
+            command_intent_from_request(
+                "set_ptt",
+                {"on": on},
+                source="rigctld",
+                command_id=f"rigctld-set-ptt-{time.monotonic_ns()}",
+            )
+        )
         self._ptt_state = on
         self._cache.update_ptt(on)
         return _ok()
@@ -946,10 +1013,21 @@ class RigctldHandler:
         if not cmd.args:
             return _err(HamlibError.EINVAL)
         vfo = cmd.args[0].upper()
+        await self._command_service.execute(
+            command_intent_from_request(
+                "set_vfo",
+                {"vfo": vfo},
+                source="rigctld",
+                command_id=f"rigctld-set-vfo-{time.monotonic_ns()}",
+            )
+        )
+        return _ok()
+
+    async def _execute_set_vfo(self, vfo: str) -> HamlibError:
         info = self._profile_vfo_info()
         # Backwards-compat: unknown VFO names or profile-less radios → no-op
         if vfo not in ("VFOA", "VFOB") or info is None:
-            return _ok()
+            return HamlibError.OK
         rc, _ = info
         # Issue #1172: route by capability, not by string-overloaded
         # ``set_vfo``.  Dual-RX rigs use ``select_receiver`` (the
@@ -963,14 +1041,14 @@ class RigctldHandler:
             if select_receiver is not None:
                 target = "MAIN" if vfo == "VFOA" else "SUB"
                 await select_receiver(target)
-                return _ok()
+                return HamlibError.OK
             target = "MAIN" if vfo == "VFOA" else "SUB"
         else:
             set_vfo_slot = getattr(self._radio, "set_vfo_slot", None)
             if set_vfo_slot is not None:
                 slot = "A" if vfo == "VFOA" else "B"
                 await set_vfo_slot(slot)
-                return _ok()
+                return HamlibError.OK
             target = "A" if vfo == "VFOA" else "B"
         # Issue #1189: legacy backends (e.g. SerialMockRadio,
         # 3rd-party Radio implementers) predate ``ReceiverBankCapable`` /
@@ -981,9 +1059,9 @@ class RigctldHandler:
         # intentional — it signals migration.
         legacy_set_vfo = getattr(self._radio, "set_vfo", None)
         if legacy_set_vfo is None:
-            return _err(HamlibError.ENAVAIL)
+            return HamlibError.ENAVAIL
         await legacy_set_vfo(target)
-        return _ok()
+        return HamlibError.OK
 
     # ------------------------------------------------------------------
     # Level commands
@@ -1126,13 +1204,35 @@ class RigctldHandler:
         # Single-RX profiles only have receiver=0; per-VFO state is selected
         # via set_vfo_slot, not receiver= (issue #1354).
         receiver = self._receiver_index_for(target)
+        await self._command_service.execute(
+            command_intent_from_request(
+                "set_level",
+                {
+                    "level": level,
+                    "value": value,
+                    "receiver": receiver,
+                    "vfo_arg": cmd.vfo_arg,
+                },
+                source="rigctld",
+                command_id=f"rigctld-set-level-{time.monotonic_ns()}",
+            )
+        )
+        return _ok()
 
+    async def _execute_set_level(
+        self,
+        level: str,
+        value: float,
+        *,
+        receiver: int,
+        vfo_arg: str | None,
+    ) -> HamlibError:
         if self._routing is not None:
-            return await self._routing.set_level(level, value, vfo=cmd.vfo_arg)
+            return (await self._routing.set_level(level, value, vfo=vfo_arg)).error
 
         if level == "RFPOWER":
             await self._radio.set_rf_power(round(value * 255))
-            return _ok()
+            return HamlibError.OK
 
         if level in _SET_LEVEL_FLOAT:
             raw = max(0, min(255, round(value * 255)))
@@ -1142,15 +1242,15 @@ class RigctldHandler:
                 await method(raw, receiver=receiver)
             else:
                 await method(raw)
-            return _ok()
+            return HamlibError.OK
 
         if level == "KEYSPD":
             await self._radio.set_key_speed(round(value))
-            return _ok()
+            return HamlibError.OK
 
         if level == "CWPITCH":
             await self._radio.set_cw_pitch(round(value))
-            return _ok()
+            return HamlibError.OK
 
         if level == "PREAMP":
             db = round(value)
@@ -1160,7 +1260,7 @@ class RigctldHandler:
                 key=lambda i: abs(_PREAMP_IDX_TO_DB[i] - db),
             )
             await self._radio.set_preamp(idx)
-            return _ok()
+            return HamlibError.OK
 
         if level == "ATT":
             # Find nearest supported dB (0, 6, 12, 18)
@@ -1168,9 +1268,9 @@ class RigctldHandler:
             db = round(value)
             nearest = min(_att_steps, key=lambda x: abs(x - db))
             await self._radio.set_attenuator_level(nearest)
-            return _ok()
+            return HamlibError.OK
 
-        return _err(HamlibError.EINVAL)
+        return HamlibError.EINVAL
 
     # ------------------------------------------------------------------
     # Function commands
@@ -1222,12 +1322,34 @@ class RigctldHandler:
         # Single-RX profiles only have receiver=0; per-VFO state is selected
         # via set_vfo_slot, not receiver= (issue #1354).
         receiver = self._receiver_index_for(target)
+        await self._command_service.execute(
+            command_intent_from_request(
+                "set_func",
+                {
+                    "func": func,
+                    "on": on,
+                    "receiver": receiver,
+                    "vfo_arg": cmd.vfo_arg,
+                },
+                source="rigctld",
+                command_id=f"rigctld-set-func-{time.monotonic_ns()}",
+            )
+        )
+        return _ok()
 
+    async def _execute_set_func(
+        self,
+        func: str,
+        on: bool,
+        *,
+        receiver: int,
+        vfo_arg: str | None,
+    ) -> HamlibError:
         if self._routing is not None:
-            return await self._routing.set_func(func, on, vfo=cmd.vfo_arg)
+            return (await self._routing.set_func(func, on, vfo=vfo_arg)).error
 
         if func not in _FUNC_SET:
-            return _err(HamlibError.EINVAL)
+            return HamlibError.EINVAL
         if func == "APF":
             # APF takes an int mode: 0=off, 1=soft
             await self._radio.set_audio_peak_filter(1 if on else 0)
@@ -1236,7 +1358,7 @@ class RigctldHandler:
             await getattr(self._radio, _FUNC_SET[func])(on, receiver=receiver)
         else:
             await getattr(self._radio, _FUNC_SET[func])(on)
-        return _ok()
+        return HamlibError.OK
 
     # ------------------------------------------------------------------
     # Split VFO commands
@@ -1272,6 +1394,17 @@ class RigctldHandler:
         except ValueError:
             return _err(HamlibError.EINVAL)
         tx_vfo = cmd.args[1].upper()
+        await self._command_service.execute(
+            command_intent_from_request(
+                "set_split_vfo",
+                {"on": on, "tx_vfo": tx_vfo},
+                source="rigctld",
+                command_id=f"rigctld-set-split-vfo-{time.monotonic_ns()}",
+            )
+        )
+        return _ok()
+
+    async def _execute_set_split_vfo(self, on: bool, tx_vfo: str) -> HamlibError:
         info = self._profile_vfo_info()
         set_split = getattr(self._radio, "set_split", None)
         if set_split is not None:
@@ -1296,7 +1429,7 @@ class RigctldHandler:
                         exc,
                     )
                     await self._rollback_split(set_split)
-                    return _err(HamlibError.EIO)
+                    return HamlibError.EIO
                 except TimeoutError as exc:
                     logger.warning(
                         "set_split_vfo: set_vfo(%s) timed out (%s); rolling back split",
@@ -1304,7 +1437,7 @@ class RigctldHandler:
                         exc,
                     )
                     await self._rollback_split(set_split)
-                    return _err(HamlibError.ETIMEOUT)
+                    return HamlibError.ETIMEOUT
                 except Exception:
                     logger.exception(
                         "set_split_vfo: set_vfo(%s) failed unexpectedly; "
@@ -1312,14 +1445,14 @@ class RigctldHandler:
                         target,
                     )
                     await self._rollback_split(set_split)
-                    return _err(HamlibError.EINTERNAL)
+                    return HamlibError.EINTERNAL
         # Record the requested TX VFO for the next ``s`` (get_split_vfo)
         # query — Hamlib protocol expects the TX VFO label round-trip
         # (issue #1345). Validate the label so a malformed request never
         # poisons the cached value.
         if tx_vfo in ("VFOA", "VFOB"):
             self._split_tx_vfo = cast(Literal["VFOA", "VFOB"], tx_vfo)
-        return _ok()
+        return HamlibError.OK
 
     async def _rollback_split(self, set_split: Any) -> None:
         """Best-effort rollback: disable split that was just enabled.
@@ -1500,22 +1633,16 @@ class RigctldHandler:
         except (ValueError, IndexError):
             return _err(HamlibError.EINVAL)
 
-        send_fn = getattr(self._radio, "_send_civ_raw", None)
-        if send_fn is None:
-            return _err(HamlibError.ENIMPL)
-
-        try:
-            resp = await send_fn(frame_bytes)
-        except (TimeoutError, asyncio.TimeoutError):
-            logger.debug("send_raw: timeout — returning empty response")
-            return RigctldResponse(values=[])
-
-        if resp is None:
-            return RigctldResponse(values=[])
-
-        raw = _civ_frame_to_bytes(resp)
-        hex_str = " ".join(f"{b:02X}" for b in raw)
-        return RigctldResponse(values=[hex_str])
+        result = await self._command_service.execute(
+            command_intent_from_request(
+                "send_raw",
+                {"frame_bytes": frame_bytes},
+                source="rigctld",
+                command_id=f"rigctld-send-raw-{time.monotonic_ns()}",
+            )
+        )
+        values = result.executor_result.details.get("values", [])
+        return RigctldResponse(values=list(values))
 
     # ------------------------------------------------------------------
     # Dispatch table (populated after method definitions)

--- a/src/rigplane/rigctld/handler.py
+++ b/src/rigplane/rigctld/handler.py
@@ -332,6 +332,14 @@ class _RigctldCommandExecutor:
                 await self.handler._apply_packet_data_mode(receiver=receiver)
         elif intent.name == "set_ptt":
             await self.handler._radio.set_ptt(bool(params["ptt"]))
+        elif intent.name == "set_rit":
+            hz = int(params["hz"])
+            await self.handler._radio.set_rit_frequency(hz)
+            await self.handler._radio.set_rit_status(hz != 0)
+        elif intent.name == "set_xit":
+            hz = int(params["hz"])
+            await self.handler._radio.set_rit_frequency(hz)
+            await self.handler._radio.set_rit_tx_status(hz != 0)
         elif intent.name == "set_vfo":
             error = await self.handler._execute_set_vfo(str(params["vfo"]))
             if error is not HamlibError.OK:
@@ -1500,8 +1508,14 @@ class RigctldHandler:
             return _err(HamlibError.EINVAL)
         if CAP_RIT not in self._radio.capabilities:
             return _err(HamlibError.ENIMPL)
-        await self._radio.set_rit_frequency(hz)
-        await self._radio.set_rit_status(hz != 0)
+        await self._command_service.execute(
+            command_intent_from_request(
+                "set_rit",
+                {"hz": hz},
+                source="rigctld",
+                command_id=f"rigctld-set-rit-{time.monotonic_ns()}",
+            )
+        )
         return _ok()
 
     async def _cmd_get_xit(self, cmd: RigctldCommand) -> RigctldResponse:
@@ -1524,8 +1538,14 @@ class RigctldHandler:
             return _err(HamlibError.EINVAL)
         if CAP_RIT not in self._radio.capabilities:
             return _err(HamlibError.ENIMPL)
-        await self._radio.set_rit_frequency(hz)
-        await self._radio.set_rit_tx_status(hz != 0)
+        await self._command_service.execute(
+            command_intent_from_request(
+                "set_xit",
+                {"hz": hz},
+                source="rigctld",
+                command_id=f"rigctld-set-xit-{time.monotonic_ns()}",
+            )
+        )
         return _ok()
 
     # ------------------------------------------------------------------

--- a/src/rigplane/rigctld/handler.py
+++ b/src/rigplane/rigctld/handler.py
@@ -2172,7 +2172,8 @@ class RigctldHandler:
                 session_id=self._session_id(),
             )
         )
-        values = result.executor_result.details.get("values", [])
+        details = result.executor_result.details or {}
+        values = details.get("values", [])
         return RigctldResponse(values=list(values))
 
     # ------------------------------------------------------------------

--- a/src/rigplane/rigctld/handler.py
+++ b/src/rigplane/rigctld/handler.py
@@ -17,6 +17,7 @@ import asyncio
 import logging
 import time
 from collections.abc import Sequence
+from contextvars import ContextVar
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, cast
 
@@ -53,6 +54,10 @@ from .routing import create_routing  # noqa: TID251
 __all__ = ["RigctldHandler"]
 
 logger = logging.getLogger(__name__)
+_RIGCTLD_SESSION_ID: ContextVar[str | None] = ContextVar(
+    "rigctld_session_id",
+    default=None,
+)
 
 # ---------------------------------------------------------------------------
 # IC-7610 hardcoded dump_state (hamlib protocol v0 positional format)
@@ -417,20 +422,30 @@ class _RigctldProjection:
 
     snapshot: StateSnapshot
     overlays: dict[str, Any]
+    aliases: dict[str, tuple[FieldPath, ...]]
 
-    def covers(self, paths: Sequence[str]) -> bool:
-        return all(path in self.overlays for path in paths)
+    def covers(self, paths: Sequence[FieldPath]) -> bool:
+        return all(self.value(path) is not None for path in paths)
 
-    def value(self, *paths: str) -> _ProjectedField | None:
+    def value(self, *paths: FieldPath) -> _ProjectedField | None:
         for path in paths:
-            if path in self.overlays:
-                return _ProjectedField(path=path, value=self.overlays[path])
+            key = str(path)
+            if key in self.overlays:
+                return _ProjectedField(path=key, value=self.overlays[key])
         for path in paths:
-            try:
-                field = self.snapshot.field(path)
-            except KeyError:
-                continue
-            return _ProjectedField(path=path, value=field.value)
+            newest = None
+            for candidate in self.aliases.get(str(path), (path,)):
+                try:
+                    field = self.snapshot.field(candidate)
+                except KeyError:
+                    continue
+                if (
+                    newest is None
+                    or field.last_observed_monotonic > newest.last_observed_monotonic
+                ):
+                    newest = field
+            if newest is not None:
+                return _ProjectedField(path=str(path), value=newest.value)
         return None
 
 
@@ -560,39 +575,69 @@ class RigctldHandler:
             return None
         return state.main
 
+    def _session_id(self) -> str | None:
+        return _RIGCTLD_SESSION_ID.get()
+
     def _receiver_id(self, receiver: int) -> str:
-        return str(receiver)
+        return "sub" if receiver == 1 else "main"
 
-    def _freq_path(self, receiver: int) -> str:
-        return f"receiver.{self._receiver_id(receiver)}.freq_mode.freq_hz"
+    def _legacy_receiver_id(self, receiver_id: str) -> str | None:
+        if receiver_id == "main":
+            return "0"
+        if receiver_id == "sub":
+            return "1"
+        return None
 
-    def _mode_path(self, receiver: int) -> str:
-        return f"receiver.{self._receiver_id(receiver)}.freq_mode.mode"
+    def _path_aliases(self, path: FieldPath) -> tuple[FieldPath, ...]:
+        aliases = [path]
+        if path.scope.value != "receiver":
+            return (path,)
+        receiver_id = path.receiver_id
+        if receiver_id is None:
+            return (path,)
+        legacy_receiver = self._legacy_receiver_id(receiver_id)
+        if legacy_receiver is None:
+            return (path,)
+        if path.slot is not None and path.slot.value == "active":
+            aliases.append(
+                FieldPath.receiver(legacy_receiver, path.family.value, path.name)
+            )
+        elif path.scope.value == "receiver":
+            aliases.append(
+                FieldPath.receiver(legacy_receiver, path.family.value, path.name)
+            )
+        return tuple(aliases)
 
-    def _filter_path(self, receiver: int) -> str:
-        return f"receiver.{self._receiver_id(receiver)}.freq_mode.filter_width"
+    def _freq_path(self, receiver: int) -> FieldPath:
+        return FieldPath.active(self._receiver_id(receiver), "freq_mode", "freq_hz")
 
-    def _data_mode_path(self, receiver: int) -> str:
-        return f"receiver.{self._receiver_id(receiver)}.freq_mode.data_mode"
+    def _mode_path(self, receiver: int) -> FieldPath:
+        return FieldPath.active(self._receiver_id(receiver), "freq_mode", "mode")
 
-    def _active_slot_path(self, receiver: int = 0) -> str:
-        return f"receiver.{self._receiver_id(receiver)}.vfo.active_slot"
+    def _filter_path(self, receiver: int) -> FieldPath:
+        return FieldPath.active(self._receiver_id(receiver), "freq_mode", "filter_width")
 
-    def _level_path(self, level: str, *, receiver: int) -> str | None:
+    def _data_mode_path(self, receiver: int) -> FieldPath:
+        return FieldPath.active(self._receiver_id(receiver), "freq_mode", "data_mode")
+
+    def _active_slot_path(self, receiver: int = 0) -> FieldPath:
+        return FieldPath.active_slot(self._receiver_id(receiver))
+
+    def _level_path(self, level: str, *, receiver: int) -> FieldPath | None:
         if level == "STRENGTH":
-            return f"receiver.{self._receiver_id(receiver)}.meters.s_meter"
+            return FieldPath.receiver(self._receiver_id(receiver), "meters", "s_meter")
         if level == "RFPOWER":
-            return "global.operator_controls.power_level"
+            return FieldPath.global_("operator_controls", "power_level")
         if level == "SWR":
-            return "global.meters.swr"
+            return FieldPath.global_("meters", "swr")
         if level == "RFPOWER_METER":
-            return "global.meters.power"
+            return FieldPath.global_("meters", "power")
         if level == "COMP_METER":
-            return "global.meters.comp_meter"
+            return FieldPath.global_("meters", "comp_meter")
         if level == "ID_METER":
-            return "global.meters.id_meter"
+            return FieldPath.global_("meters", "id_meter")
         if level == "VD_METER":
-            return "global.meters.vd_meter"
+            return FieldPath.global_("meters", "vd_meter")
         names = {
             "AF": "af_level",
             "RF": "rf_gain",
@@ -610,27 +655,36 @@ class RigctldHandler:
         name = names.get(level)
         if name is None:
             return None
-        return f"receiver.{self._receiver_id(receiver)}.operator_controls.{name}"
+        return FieldPath.receiver(self._receiver_id(receiver), "operator_controls", name)
 
-    def _func_path(self, func: str, *, receiver: int) -> str:
-        return (
-            f"receiver.{self._receiver_id(receiver)}."
-            f"operator_toggles.{func.lower()}"
+    def _func_path(self, func: str, *, receiver: int) -> FieldPath:
+        return FieldPath.receiver(
+            self._receiver_id(receiver),
+            "operator_toggles",
+            func.lower(),
         )
 
-    def _project_fields(self, paths: Sequence[str]) -> _RigctldProjection:
+    def _project_fields(self, paths: Sequence[FieldPath]) -> _RigctldProjection:
         snapshot = self._state_store.snapshot()
-        overlays = {
-            str(path): value
-            for path, value in self._command_service.project_pending_values(
-                source="rigctld",
-                session_id=None,
-                paths=tuple(FieldPath.parse(path) for path in paths),
-            ).items()
-        }
-        return _RigctldProjection(snapshot=snapshot, overlays=overlays)
+        aliases = {str(path): self._path_aliases(path) for path in paths}
+        projected = self._command_service.project_pending_values(
+            source="rigctld",
+            session_id=self._session_id(),
+            paths=tuple(
+                candidate
+                for path_aliases in aliases.values()
+                for candidate in path_aliases
+            ),
+        )
+        overlays: dict[str, Any] = {}
+        for key, candidates in aliases.items():
+            for candidate in candidates:
+                if candidate in projected:
+                    overlays[key] = projected[candidate]
+                    break
+        return _RigctldProjection(snapshot=snapshot, overlays=overlays, aliases=aliases)
 
-    def _ensure_fresh(self, paths: Sequence[str], *, reason: str) -> None:
+    def _ensure_fresh(self, paths: Sequence[FieldPath], *, reason: str) -> None:
         service = self._state_model_service
         if service is None or self._config.cache_ttl <= 0:
             return
@@ -638,7 +692,7 @@ class RigctldHandler:
         if not callable(ensure_fresh) or asyncio.iscoroutinefunction(ensure_fresh):
             return
         ensure_fresh(
-            tuple(sorted(paths)),
+            tuple(sorted(paths, key=str)),
             max_age=self._config.cache_ttl,
             priority="user",
             reason=reason,
@@ -646,19 +700,19 @@ class RigctldHandler:
 
     def _project_with_freshness(
         self,
-        paths: Sequence[str],
+        paths: Sequence[FieldPath],
         *,
         reason: str,
     ) -> _RigctldProjection:
         projection = self._project_fields(paths)
+        self._ensure_fresh(paths, reason=reason)
         if not projection.covers(paths):
-            self._ensure_fresh(paths, reason=reason)
             projection = self._project_fields(paths)
         return projection
 
     def _record_state_sample(
         self,
-        path: str,
+        path: FieldPath | str,
         value: Any,
         *,
         source: Literal["hamlib_response", "state_poller"],
@@ -666,7 +720,7 @@ class RigctldHandler:
     ) -> None:
         self._state_store.apply(
             Observation(
-                path=FieldPath.parse(path),
+                path=FieldPath.parse(path) if isinstance(path, str) else path,
                 value=value,
                 source=SourceMetadata(
                     source=source,
@@ -678,27 +732,40 @@ class RigctldHandler:
             )
         )
 
-    def _record_pending_overlay(self, path: str, value: Any, *, command_id: str) -> None:
+    def _record_pending_overlay(
+        self,
+        path: FieldPath | str,
+        value: Any,
+        *,
+        command_id: str,
+    ) -> None:
         self._command_service.record_pending_overlay(
             PendingOverlay(
                 source="rigctld",
-                session_id=None,
+                session_id=self._session_id(),
                 command_id=command_id,
-                path=FieldPath.parse(path),
+                path=FieldPath.parse(path) if isinstance(path, str) else path,
                 value=value,
                 expires_at_monotonic=time.monotonic() + 2.0,
             )
         )
 
-    def _confirm_pending_value(self, path: str, value: Any, *, command_id: str) -> None:
+    def _confirm_pending_value(
+        self,
+        path: FieldPath | str,
+        value: Any,
+        *,
+        command_id: str,
+    ) -> None:
         self._command_service.apply_observation(
             Observation(
-                path=FieldPath.parse(path),
+                path=FieldPath.parse(path) if isinstance(path, str) else path,
                 value=value,
                 source=SourceMetadata(
                     source="command_response",
                     provider="rigctld",
                     command_source="rigctld",
+                    session_id=self._session_id(),
                 ),
                 timestamp_monotonic=time.monotonic(),
                 correlation_id=command_id,
@@ -753,7 +820,12 @@ class RigctldHandler:
     # Public entry point
     # ------------------------------------------------------------------
 
-    async def execute(self, cmd: RigctldCommand) -> RigctldResponse:
+    async def execute(
+        self,
+        cmd: RigctldCommand,
+        *,
+        session_id: str | None = None,
+    ) -> RigctldResponse:
         """Execute a parsed rigctld command and return the response.
 
         Args:
@@ -762,42 +834,50 @@ class RigctldHandler:
         Returns:
             Response to send back.
         """
+        token = _RIGCTLD_SESSION_ID.set(session_id)
         # Read-only gate
-        if self._config.read_only and cmd.is_set:
-            logger.debug("read-only: rejecting set command %s", cmd.long_cmd)
-            return _err(HamlibError.EACCESS)
-
-        handler_fn = self._DISPATCH.get(cmd.long_cmd)
-        if handler_fn is None:
-            logger.debug("unimplemented command: %s", cmd.long_cmd)
-            return _err(HamlibError.ENIMPL)
-
         try:
-            response = cast(RigctldResponse, await handler_fn(self, cmd))
-            if isinstance(self._state_diagnostics, StateDiagnosticsRecorder):
-                self._state_diagnostics.record(
-                    "rigctld_delivery_trigger",
-                    "rigctld.handler",
-                    command=cmd.long_cmd,
-                    is_set=cmd.is_set,
-                    error=int(response.error),
+            if self._config.read_only and cmd.is_set:
+                logger.debug("read-only: rejecting set command %s", cmd.long_cmd)
+                return _err(HamlibError.EACCESS)
+
+            handler_fn = self._DISPATCH.get(cmd.long_cmd)
+            if handler_fn is None:
+                logger.debug("unimplemented command: %s", cmd.long_cmd)
+                return _err(HamlibError.ENIMPL)
+
+            try:
+                response = cast(RigctldResponse, await handler_fn(self, cmd))
+                if isinstance(self._state_diagnostics, StateDiagnosticsRecorder):
+                    self._state_diagnostics.record(
+                        "rigctld_delivery_trigger",
+                        "rigctld.handler",
+                        command=cmd.long_cmd,
+                        is_set=cmd.is_set,
+                        error=int(response.error),
+                    )
+                return response
+            except ConnectionError:
+                logger.warning("I/O error executing %s", cmd.long_cmd)
+                return _err(HamlibError.EIO)
+            except (RigplaneTimeoutError, TimeoutError, asyncio.TimeoutError):
+                logger.warning("Timeout executing %s", cmd.long_cmd)
+                return _err(HamlibError.ETIMEOUT)
+            except _RigctldCommandFailure as exc:
+                logger.debug(
+                    "rigctld command %s failed with %s",
+                    cmd.long_cmd,
+                    exc.error,
                 )
-            return response
-        except ConnectionError:
-            logger.warning("I/O error executing %s", cmd.long_cmd)
-            return _err(HamlibError.EIO)
-        except (RigplaneTimeoutError, TimeoutError, asyncio.TimeoutError):
-            logger.warning("Timeout executing %s", cmd.long_cmd)
-            return _err(HamlibError.ETIMEOUT)
-        except _RigctldCommandFailure as exc:
-            logger.debug("rigctld command %s failed with %s", cmd.long_cmd, exc.error)
-            return _err(exc.error)
-        except ValueError:
-            logger.warning("Invalid value in %s", cmd.long_cmd)
-            return _err(HamlibError.EINVAL)
-        except Exception:
-            logger.exception("Internal error executing %s", cmd.long_cmd)
-            return _err(HamlibError.EINTERNAL)
+                return _err(exc.error)
+            except ValueError:
+                logger.warning("Invalid value in %s", cmd.long_cmd)
+                return _err(HamlibError.EINVAL)
+            except Exception:
+                logger.exception("Internal error executing %s", cmd.long_cmd)
+                return _err(HamlibError.EINTERNAL)
+        finally:
+            _RIGCTLD_SESSION_ID.reset(token)
 
     # ------------------------------------------------------------------
     # Frequency commands
@@ -873,6 +953,7 @@ class RigctldHandler:
             {"freq": freq, "receiver": receiver},
             source="rigctld",
             command_id=f"rigctld-set-freq-{time.monotonic_ns()}",
+            session_id=self._session_id(),
         )
         await self._command_service.execute(intent)
         return _ok()
@@ -1070,6 +1151,7 @@ class RigctldHandler:
                 },
                 source="rigctld",
                 command_id=f"rigctld-set-mode-{time.monotonic_ns()}",
+                session_id=self._session_id(),
             )
             await self._command_service.execute(intent)
             self._record_pending_overlay(
@@ -1095,6 +1177,7 @@ class RigctldHandler:
             },
             source="rigctld",
             command_id=f"rigctld-set-mode-{time.monotonic_ns()}",
+            session_id=self._session_id(),
         )
         await self._command_service.execute(intent)
         self._record_pending_overlay(
@@ -1165,18 +1248,16 @@ class RigctldHandler:
         except ValueError:
             return _err(HamlibError.EVFO)
 
-        projection = self._project_with_freshness(
-            ("global.tx_state.ptt",),
-            reason="rigctld.get_ptt",
-        )
-        projected = projection.value("global.tx_state.ptt")
+        ptt_path = FieldPath.global_("tx_state", "ptt")
+        projection = self._project_with_freshness((ptt_path,), reason="rigctld.get_ptt")
+        projected = projection.value(ptt_path)
         if projected is not None:
             return RigctldResponse(values=[str(int(bool(projected.value)))])
 
         state = self._radio_state()
         if state is not None:
             self._record_state_sample(
-                "global.tx_state.ptt",
+                ptt_path,
                 bool(state.ptt),
                 source="state_poller",
                 max_age=self._config.cache_ttl,
@@ -1203,6 +1284,7 @@ class RigctldHandler:
                 {"on": on},
                 source="rigctld",
                 command_id=f"rigctld-set-ptt-{time.monotonic_ns()}",
+                session_id=self._session_id(),
             )
         )
         return _ok()
@@ -1309,6 +1391,7 @@ class RigctldHandler:
                 {"vfo": vfo},
                 source="rigctld",
                 command_id=f"rigctld-set-vfo-{time.monotonic_ns()}",
+                session_id=self._session_id(),
             )
         )
         return _ok()
@@ -1606,6 +1689,7 @@ class RigctldHandler:
                 },
                 source="rigctld",
                 command_id=f"rigctld-set-level-{time.monotonic_ns()}",
+                session_id=self._session_id(),
             )
         )
         return _ok()
@@ -1738,6 +1822,7 @@ class RigctldHandler:
                 },
                 source="rigctld",
                 command_id=f"rigctld-set-func-{time.monotonic_ns()}",
+                session_id=self._session_id(),
             )
         )
         return _ok()
@@ -1777,11 +1862,12 @@ class RigctldHandler:
             self._resolve_target_vfo(cmd.vfo_arg)
         except ValueError:
             return _err(HamlibError.EVFO)
+        split_path = FieldPath.global_("tx_state", "split")
         projection = self._project_with_freshness(
-            ("global.tx_state.split",),
+            (split_path,),
             reason="rigctld.get_split_vfo",
         )
-        projected = projection.value("global.tx_state.split")
+        projected = projection.value(split_path)
         if projected is not None:
             split = bool(projected.value)
         else:
@@ -1789,7 +1875,7 @@ class RigctldHandler:
             split = state.split if state is not None else False
             if state is not None:
                 self._record_state_sample(
-                    "global.tx_state.split",
+                    split_path,
                     split,
                     source="state_poller",
                     max_age=self._config.cache_ttl,
@@ -1820,6 +1906,7 @@ class RigctldHandler:
                 {"on": on, "tx_vfo": tx_vfo},
                 source="rigctld",
                 command_id=f"rigctld-set-split-vfo-{time.monotonic_ns()}",
+                session_id=self._session_id(),
             )
         )
         return _ok()
@@ -1926,6 +2013,7 @@ class RigctldHandler:
                 {"hz": hz},
                 source="rigctld",
                 command_id=f"rigctld-set-rit-{time.monotonic_ns()}",
+                session_id=self._session_id(),
             )
         )
         return _ok()
@@ -1956,6 +2044,7 @@ class RigctldHandler:
                 {"hz": hz},
                 source="rigctld",
                 command_id=f"rigctld-set-xit-{time.monotonic_ns()}",
+                session_id=self._session_id(),
             )
         )
         return _ok()
@@ -2071,6 +2160,7 @@ class RigctldHandler:
                 {"frame_bytes": frame_bytes},
                 source="rigctld",
                 command_id=f"rigctld-send-raw-{time.monotonic_ns()}",
+                session_id=self._session_id(),
             )
         )
         values = result.executor_result.details.get("values", [])

--- a/src/rigplane/rigctld/server.py
+++ b/src/rigplane/rigctld/server.py
@@ -141,7 +141,9 @@ class RigctldServer:
         task.add_done_callback(self._bg_tasks.discard)
         return task
 
-    def _handler_execute_call(self, cmd: Any, *, session_id: str) -> Coroutine[Any, Any, Any]:
+    def _handler_execute_call(
+        self, cmd: Any, *, session_id: str
+    ) -> Coroutine[Any, Any, Any]:
         execute = getattr(self._rig_handler, "execute")
         try:
             signature = inspect.signature(execute)
@@ -151,9 +153,13 @@ class RigctldServer:
         if signature is not None:
             for parameter in signature.parameters.values():
                 if parameter.kind is inspect.Parameter.VAR_KEYWORD:
-                    return cast(Coroutine[Any, Any, Any], execute(cmd, session_id=session_id))
+                    return cast(
+                        Coroutine[Any, Any, Any], execute(cmd, session_id=session_id)
+                    )
                 if parameter.name == "session_id":
-                    return cast(Coroutine[Any, Any, Any], execute(cmd, session_id=session_id))
+                    return cast(
+                        Coroutine[Any, Any, Any], execute(cmd, session_id=session_id)
+                    )
         return cast(Coroutine[Any, Any, Any], execute(cmd))
 
     def __del__(self) -> None:

--- a/src/rigplane/rigctld/server.py
+++ b/src/rigplane/rigctld/server.py
@@ -43,7 +43,7 @@ def _profile_data_mode_count(radio: "Radio") -> int:
 
 def _wsjtx_data_mode_value(radio: "Radio", config: RigctldConfig) -> int | bool:
     if config.wsjtx_data_mode is not None:
-        return config.wsjtx_data_mode
+        return int(config.wsjtx_data_mode)
     return True
 
 
@@ -437,7 +437,10 @@ class RigctldServer:
                 t_start = time.monotonic()
                 try:
                     resp = await asyncio.wait_for(
-                        rig_handler.execute(cmd),
+                        rig_handler.execute(
+                            cmd,
+                            session_id=f"rigctld-client-{client_id}",
+                        ),
                         timeout=self._config.command_timeout,
                     )
                 except asyncio.TimeoutError:

--- a/src/rigplane/rigctld/server.py
+++ b/src/rigplane/rigctld/server.py
@@ -16,10 +16,11 @@ from __future__ import annotations
 
 import asyncio
 import datetime
+import inspect
 import logging
 import time
 from collections.abc import Coroutine
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from ..startup_checks import assert_radio_startup_ready
 from . import audit as _audit  # noqa: TID251
@@ -139,6 +140,21 @@ class RigctldServer:
         self._bg_tasks.add(task)
         task.add_done_callback(self._bg_tasks.discard)
         return task
+
+    def _handler_execute_call(self, cmd: Any, *, session_id: str) -> Coroutine[Any, Any, Any]:
+        execute = getattr(self._rig_handler, "execute")
+        try:
+            signature = inspect.signature(execute)
+        except (TypeError, ValueError):
+            signature = None
+
+        if signature is not None:
+            for parameter in signature.parameters.values():
+                if parameter.kind is inspect.Parameter.VAR_KEYWORD:
+                    return cast(Coroutine[Any, Any, Any], execute(cmd, session_id=session_id))
+                if parameter.name == "session_id":
+                    return cast(Coroutine[Any, Any, Any], execute(cmd, session_id=session_id))
+        return cast(Coroutine[Any, Any, Any], execute(cmd))
 
     def __del__(self) -> None:
         """Emit WARN if instance is collected while TCP server/poller is still active."""
@@ -358,7 +374,6 @@ class RigctldServer:
     ) -> None:
         """Manage a single TCP client for its full lifetime."""
         proto = self._protocol
-        rig_handler = self._rig_handler
 
         peer = writer.get_extra_info("peername", ("?", 0))
         self._next_client_id += 1
@@ -437,7 +452,7 @@ class RigctldServer:
                 t_start = time.monotonic()
                 try:
                     resp = await asyncio.wait_for(
-                        rig_handler.execute(
+                        self._handler_execute_call(
                             cmd,
                             session_id=f"rigctld-client-{client_id}",
                         ),

--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -39,7 +39,12 @@ from rigplane.commands import (
     parse_scope_vbw_response,
 )
 from rigplane.core.exceptions import ConnectionError, TimeoutError
-from rigplane.core.state_pipeline_contracts import FieldPath, Observation, SourceMetadata
+from rigplane.core.state_pipeline_contracts import (
+    FieldPath,
+    Observation,
+    ObservationSource,
+    SourceMetadata,
+)
 from rigplane.core.state_diagnostics import StateDiagnosticsRecorder
 from rigplane.scope import ScopeFrame
 from rigplane.core.types import CivFrame, Mode
@@ -870,6 +875,8 @@ class CivRuntime:
 
     def _update_state_cache_from_frame(self, frame: CivFrame) -> None:
         """Best-effort update of state cache from an incoming CI-V frame."""
+        self._apply_state_store_observations(frame)
+
         host = self._host
         _rs = getattr(host, "_radio_state", None)
         _rx = None
@@ -1033,7 +1040,6 @@ class CivRuntime:
             logger.debug("civ-rx: cache update failed: %s", exc)
         except Exception:
             logger.warning("civ-rx: unexpected error in cache update", exc_info=True)
-        self._apply_state_store_observations(frame)
         self._update_radio_state_from_frame(frame)
 
     def _update_radio_state_from_frame(self, frame: CivFrame) -> None:
@@ -1093,7 +1099,26 @@ class CivRuntime:
     def _apply_state_store_observations(self, frame: CivFrame) -> None:
         """Project supported CI-V ingress fields into the runtime StateStore."""
 
-        for observation in self._observations_from_frame(frame):
+        try:
+            observations = self._observations_from_frame(frame)
+        except (ValueError, IndexError, KeyError, AttributeError, TypeError) as exc:
+            logger.debug(
+                "civ-rx: observation decode failed for cmd=0x%02x sub=0x%02x: %s",
+                frame.command,
+                frame.sub or 0,
+                exc,
+            )
+            return
+        except Exception:
+            logger.warning(
+                "civ-rx: unexpected observation decode error for cmd=0x%02x sub=0x%02x",
+                frame.command,
+                frame.sub or 0,
+                exc_info=True,
+            )
+            return
+
+        for observation in observations:
             try:
                 self._host._state_store.apply(observation)
             except Exception:
@@ -1135,15 +1160,6 @@ class CivRuntime:
                     frame=frame,
                 )
             )
-        elif frame.command == 0x07 and len(frame.data) >= 2:
-            if frame.data[0] == 0xD2:
-                observations.append(
-                    self._observation(
-                        FieldPath.active_slot("0"),
-                        "B" if bool(frame.data[1]) else "A",
-                        frame=frame,
-                    )
-                )
         elif frame.command == 0x25 and len(frame.data) >= 6:
             from rigplane.types import bcd_decode
 
@@ -1266,7 +1282,11 @@ class CivRuntime:
         return FieldPath.active(receiver_id, "freq_mode", name)
 
     def _observation(self, path: FieldPath, value: Any, *, frame: CivFrame) -> Observation:
-        source = "civ_unsolicited" if frame.to_addr == 0x00 or frame.command in (0x00, 0x01) else "command_response"
+        source: ObservationSource = (
+            "civ_unsolicited"
+            if frame.to_addr == 0x00 or frame.command in (0x00, 0x01)
+            else "command_response"
+        )
         return Observation(
             path=path,
             value=value,

--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -39,6 +39,7 @@ from rigplane.commands import (
     parse_scope_vbw_response,
 )
 from rigplane.core.exceptions import ConnectionError, TimeoutError
+from rigplane.core.state_diagnostics import StateDiagnosticsRecorder
 from rigplane.scope import ScopeFrame
 from rigplane.core.types import CivFrame
 
@@ -58,6 +59,30 @@ _FREQ_BCD_LEN = 5
 _SCOPE_BACKLOG_SHED_THRESHOLD = 256
 _SCOPE_BACKLOG_KEEP_LATEST = 64
 _RAW_RECEIVED_FRAME_BYTES_LIMIT = 256
+
+_CIV_STATE_FIELD_FAMILIES = {
+    0x00: "freq_mode",
+    0x01: "freq_mode",
+    0x03: "freq_mode",
+    0x04: "freq_mode",
+    0x07: "vfo",
+    0x0E: "slow_state",
+    0x0F: "operator_toggles",
+    0x10: "operator_controls",
+    0x11: "operator_controls",
+    0x12: "operator_controls",
+    0x14: "operator_controls",
+    0x15: "meters",
+    0x16: "operator_toggles",
+    0x1A: "operator_controls",
+    0x1B: "operator_controls",
+    0x1C: "tx_state",
+    0x1E: "slow_state",
+    0x21: "operator_controls",
+    0x25: "freq_mode",
+    0x26: "freq_mode",
+    0x27: "scope_controls",
+}
 
 __all__ = [
     "CivRuntime",
@@ -996,6 +1021,17 @@ class CivRuntime:
 
             handler = self._RADIO_STATE_HANDLERS.get(frame.command)
             if handler is not None:
+                self._record_state_diagnostic(
+                    "direct_state_write",
+                    "civ_rx",
+                    command=f"0x{frame.command:02x}",
+                    sub=None if frame.sub is None else f"0x{frame.sub:02x}",
+                    receiver=rx_name,
+                    field_family=_CIV_STATE_FIELD_FAMILIES.get(
+                        frame.command, "unknown"
+                    ),
+                    slot_override=slot_override,
+                )
                 handler(self, frame, rx, rs, slot_override)
 
         except (ValueError, IndexError, KeyError, AttributeError, TypeError) as exc:
@@ -1525,6 +1561,12 @@ class CivRuntime:
 
     def _notify_change(self, event_name: str, data: dict[str, Any]) -> None:
         """Notify server of state change (best-effort)."""
+        self._record_state_diagnostic(
+            "revision_producing_event",
+            "civ_rx.notify",
+            event=event_name,
+            data=data,
+        )
         cb = getattr(self._host, "_on_state_change", None)
         if cb is not None:
             logger.debug("civ-rx: notify %s %s", event_name, data)
@@ -1534,6 +1576,11 @@ class CivRuntime:
                 logger.warning("civ-rx: notify failed", exc_info=True)
         else:
             logger.debug("civ-rx: no callback for %s", event_name)
+
+    def _record_state_diagnostic(self, kind: str, source: str, **details: Any) -> None:
+        recorder = getattr(self._host, "_state_diagnostics", None)
+        if isinstance(recorder, StateDiagnosticsRecorder):
+            recorder.record(kind, source, **details)
 
     def _publish_scope_frame(self, frame: ScopeFrame) -> None:
         """Publish a complete scope frame to callback and bounded queue."""

--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -6,9 +6,14 @@ import asyncio
 import logging
 import time
 from dataclasses import dataclass
+from dataclasses import replace as _replace_dataclass
 from typing import TYPE_CHECKING, Any, cast
 from typing import Literal
 
+from rigplane.core.acquisition_scheduler import (
+    AcquisitionScheduler,
+    MeterObservationCoalescer,
+)
 from rigplane.core.civ import (
     CivEvent,
     CivEventType,
@@ -40,6 +45,8 @@ from rigplane.commands import (
 )
 from rigplane.core.exceptions import ConnectionError, TimeoutError
 from rigplane.core.state_pipeline_contracts import (
+    ChangeSet,
+    FieldChange,
     FieldPath,
     Observation,
     ObservationSource,
@@ -228,6 +235,65 @@ def _frame_native_id(frame: CivFrame) -> str:
     if frame.sub is None:
         return f"civ:{frame.command:02x}"
     return f"civ:{frame.command:02x}:{frame.sub:02x}"
+
+
+_RECEIVER_ALIASES: dict[str, str] = {
+    "0": "main",
+    "main": "0",
+    "1": "sub",
+    "sub": "1",
+}
+
+
+def _field_paths_match(expected: FieldPath, observed: FieldPath) -> bool:
+    if expected == observed:
+        return True
+    if (
+        expected.scope != observed.scope
+        or expected.family != observed.family
+        or expected.name != observed.name
+        or expected.slot != observed.slot
+    ):
+        return False
+    if expected.receiver_id is None or observed.receiver_id is None:
+        return bool(expected.receiver_id == observed.receiver_id)
+    return bool(_RECEIVER_ALIASES.get(expected.receiver_id) == observed.receiver_id)
+
+
+def _profile_path_for_observation(profile: Any, path: FieldPath) -> FieldPath:
+    if path.receiver_id is None:
+        return path
+    candidates = [path]
+    alias = _RECEIVER_ALIASES.get(path.receiver_id)
+    if alias is not None:
+        candidates.append(_replace_dataclass(path, receiver_id=alias))
+    for candidate in candidates:
+        capability = profile.capability_for(candidate)
+        if capability.availability.value != "unknown":
+            return candidate
+    return path
+
+
+def _changeset_for_request_paths(
+    changeset: ChangeSet,
+    *,
+    observed_path: FieldPath,
+    request_paths: tuple[FieldPath, ...],
+) -> ChangeSet:
+    if not changeset.changes:
+        return changeset
+    remapped: list[FieldChange] = []
+    for change in changeset.changes:
+        replacement = None
+        if _field_paths_match(change.path, observed_path):
+            for request_path in request_paths:
+                if _field_paths_match(request_path, change.path):
+                    replacement = request_path
+                    break
+        remapped.append(
+            change if replacement is None else _replace_dataclass(change, path=replacement)
+        )
+    return _replace_dataclass(changeset, changes=tuple(remapped))
 
 _CMD1A_CTL_MEM_LEVEL_FIELDS = {
     b"\x00\x70": ("ref_adjust", 2),
@@ -1120,13 +1186,125 @@ class CivRuntime:
 
         for observation in observations:
             try:
-                self._host._state_store.apply(observation)
+                self.flush_due_meter_observations(
+                    now=observation.timestamp_monotonic
+                )
+                if self._record_coalesced_meter_observation(observation):
+                    continue
+                changeset = self._host._state_store.apply(observation)
+                self._record_scheduler_result_for_observation(
+                    observation,
+                    changeset,
+                )
+                self._notify_state_store_changed(changeset)
             except Exception:
                 logger.warning(
                     "civ-rx: state-store apply failed for %s",
                     observation.path,
                     exc_info=True,
                 )
+
+    def _record_coalesced_meter_observation(self, observation: Observation) -> bool:
+        if observation.path.family.value != "meters":
+            return False
+        scheduler = getattr(self._host, "_acquisition_scheduler", None)
+        if not isinstance(scheduler, AcquisitionScheduler):
+            return False
+        profile = getattr(scheduler, "_profile", None)
+        if profile is None:
+            return False
+        policy = profile.policy_for(_profile_path_for_observation(profile, observation.path))
+        if policy.meter_coalescing is None:
+            return False
+        coalescer = getattr(self._host, "_meter_observation_coalescer", None)
+        if not isinstance(coalescer, MeterObservationCoalescer):
+            return False
+        coalescer.record(observation, policy.meter_coalescing)
+        self._record_state_diagnostic(
+            "meter_coalescing",
+            "civ_rx.coalescer",
+            **coalescer.diagnostics(),
+        )
+        self.flush_due_meter_observations(now=observation.timestamp_monotonic)
+        return True
+
+    def flush_due_meter_observations(self, *, now: float | None = None) -> ChangeSet | None:
+        coalescer = getattr(self._host, "_meter_observation_coalescer", None)
+        if not isinstance(coalescer, MeterObservationCoalescer):
+            return None
+        timestamp = time.monotonic() if now is None else now
+        changeset = coalescer.flush_due(self._host._state_store, now=timestamp)
+        if changeset is None:
+            return None
+        self._record_scheduler_results_for_changeset(changeset)
+        self._record_state_diagnostic(
+            "meter_coalescing",
+            "civ_rx.coalescer",
+            **coalescer.diagnostics(),
+        )
+        self._notify_state_store_changed(changeset)
+        return changeset
+
+    def _record_scheduler_result_for_observation(
+        self,
+        observation: Observation,
+        changeset: ChangeSet,
+    ) -> None:
+        scheduler = getattr(self._host, "_acquisition_scheduler", None)
+        if not isinstance(scheduler, AcquisitionScheduler):
+            return
+        for request in scheduler.pending_requests():
+            matched_paths = tuple(
+                path for path in request.paths if _field_paths_match(path, observation.path)
+            )
+            if not matched_paths:
+                continue
+            scheduler.record_acquisition_result(
+                _replace_dataclass(request, paths=matched_paths),
+                _changeset_for_request_paths(
+                    changeset,
+                    observed_path=observation.path,
+                    request_paths=matched_paths,
+                ),
+            )
+            self._record_state_diagnostic(
+                "acquisition_result",
+                "civ_rx.scheduler",
+                request_id=request.id,
+                paths=[str(path) for path in matched_paths],
+                changed=bool(changeset.changes),
+            )
+
+    def _record_scheduler_results_for_changeset(self, changeset: ChangeSet) -> None:
+        scheduler = getattr(self._host, "_acquisition_scheduler", None)
+        if not isinstance(scheduler, AcquisitionScheduler):
+            return
+        for change in changeset.changes:
+            observation = Observation(
+                path=change.path,
+                value=change.current,
+                source=changeset.sources[0]
+                if changeset.sources
+                else SourceMetadata(
+                    source="command_response",
+                    provider="icom_civ",
+                    transport="civ",
+                    native_id="coalesced",
+                ),
+                timestamp_monotonic=changeset.timestamp_monotonic,
+            )
+            self._record_scheduler_result_for_observation(observation, changeset)
+
+    def _notify_state_store_changed(self, changeset: ChangeSet) -> None:
+        if not changeset.changes:
+            return
+        self._notify_change(
+            "state_store_changed",
+            {
+                "coalesced": changeset.coalesced,
+                "paths": sorted(str(change.path) for change in changeset.changes),
+            },
+        )
 
     def _observations_from_frame(self, frame: CivFrame) -> tuple[Observation, ...]:
         """Decode one CI-V frame into supported observation contracts."""

--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -39,9 +39,10 @@ from rigplane.commands import (
     parse_scope_vbw_response,
 )
 from rigplane.core.exceptions import ConnectionError, TimeoutError
+from rigplane.core.state_pipeline_contracts import FieldPath, Observation, SourceMetadata
 from rigplane.core.state_diagnostics import StateDiagnosticsRecorder
 from rigplane.scope import ScopeFrame
-from rigplane.core.types import CivFrame
+from rigplane.core.types import CivFrame, Mode
 
 if TYPE_CHECKING:
     from ._runtime_protocols import CivRuntimeHost
@@ -59,6 +60,25 @@ _FREQ_BCD_LEN = 5
 _SCOPE_BACKLOG_SHED_THRESHOLD = 256
 _SCOPE_BACKLOG_KEEP_LATEST = 64
 _RAW_RECEIVED_FRAME_BYTES_LIMIT = 256
+
+_OBSERVATION_MAX_AGE_SECONDS: dict[tuple[str, str, str], float] = {
+    ("receiver", "freq_mode", "freq_hz"): 5.0,
+    ("receiver", "freq_mode", "mode"): 5.0,
+    ("receiver", "vfo", "active_slot"): 5.0,
+    ("receiver", "meters", "s_meter"): 0.6,
+    ("receiver", "operator_toggles", "nb"): 10.0,
+    ("receiver", "operator_toggles", "nr"): 10.0,
+    ("receiver", "operator_controls", "af_level"): 10.0,
+    ("receiver", "operator_controls", "rf_gain"): 10.0,
+    ("receiver", "operator_controls", "pbt_inner"): 10.0,
+    ("receiver", "operator_controls", "pbt_outer"): 10.0,
+    ("global", "tx_state", "ptt"): 1.0,
+    ("global", "tx_state", "power_on"): 30.0,
+    ("global", "operator_controls", "power_level"): 30.0,
+    ("global", "meters", "alc"): 0.6,
+    ("global", "meters", "power"): 0.6,
+    ("global", "meters", "swr"): 0.6,
+}
 
 _CIV_STATE_FIELD_FAMILIES = {
     0x00: "freq_mode",
@@ -177,6 +197,32 @@ _CMD16_NOTIFY_EVENTS = {
     0x58: "ssb_tx_bandwidth_changed",
     0x65: "ipplus_changed",
 }
+
+_OBSERVABLE_CMD14_FIELDS = {
+    0x01: ("receiver", "operator_controls", "af_level"),
+    0x02: ("receiver", "operator_controls", "rf_gain"),
+    0x07: ("receiver", "operator_controls", "pbt_inner"),
+    0x08: ("receiver", "operator_controls", "pbt_outer"),
+    0x0A: ("global", "operator_controls", "power_level"),
+}
+
+_OBSERVABLE_CMD15_FIELDS = {
+    0x02: ("receiver", "meters", "s_meter"),
+    0x11: ("global", "meters", "power"),
+    0x12: ("global", "meters", "swr"),
+    0x13: ("global", "meters", "alc"),
+}
+
+_OBSERVABLE_CMD16_FIELDS = {
+    0x22: ("receiver", "operator_toggles", "nb"),
+    0x40: ("receiver", "operator_toggles", "nr"),
+}
+
+
+def _frame_native_id(frame: CivFrame) -> str:
+    if frame.sub is None:
+        return f"civ:{frame.command:02x}"
+    return f"civ:{frame.command:02x}:{frame.sub:02x}"
 
 _CMD1A_CTL_MEM_LEVEL_FIELDS = {
     b"\x00\x70": ("ref_adjust", 2),
@@ -987,15 +1033,15 @@ class CivRuntime:
             logger.debug("civ-rx: cache update failed: %s", exc)
         except Exception:
             logger.warning("civ-rx: unexpected error in cache update", exc_info=True)
+        self._apply_state_store_observations(frame)
         self._update_radio_state_from_frame(frame)
 
     def _update_radio_state_from_frame(self, frame: CivFrame) -> None:
-        """Update RadioState from a CI-V frame (additive alongside StateCache).
+        """Mirror confirmed observations into legacy RadioState compatibility.
 
-        Top-level dispatch via ``_RADIO_STATE_HANDLERS`` (cmd-keyed). Each
-        handler is a small private method that performs the same mutations
-        as the original if/elif ladder. Behavior is fenced by the golden
-        tests in ``tests/test_civ_rx_dispatch_golden.py``.
+        ``StateStore.apply(...)`` is the canonical semantic write path. These
+        handlers remain only as compatibility shims for MOR-341/MOR-347 until
+        Web and other consumers stop reading mutable ``RadioState`` directly.
         """
         rs: "RadioState | None" = getattr(self._host, "_radio_state", None)
         if rs is None:
@@ -1043,6 +1089,199 @@ class CivRuntime:
             )
         except Exception:
             logger.warning("civ-rx: unexpected error in state update", exc_info=True)
+
+    def _apply_state_store_observations(self, frame: CivFrame) -> None:
+        """Project supported CI-V ingress fields into the runtime StateStore."""
+
+        for observation in self._observations_from_frame(frame):
+            try:
+                self._host._state_store.apply(observation)
+            except Exception:
+                logger.warning(
+                    "civ-rx: state-store apply failed for %s",
+                    observation.path,
+                    exc_info=True,
+                )
+
+    def _observations_from_frame(self, frame: CivFrame) -> tuple[Observation, ...]:
+        """Decode one CI-V frame into supported observation contracts."""
+
+        receiver_id, _, slot_override = self._receiver_context(frame)
+        observations: list[Observation] = []
+
+        if frame.command in (0x00, 0x03):
+            if len(frame.data) == _FREQ_BCD_LEN:
+                observations.append(
+                    self._observation(
+                        self._freq_mode_path(
+                            receiver_id=receiver_id,
+                            slot_override=slot_override,
+                            name="freq_hz",
+                        ),
+                        parse_frequency_response(frame),
+                        frame=frame,
+                    )
+                )
+        elif frame.command in (0x01, 0x04):
+            mode_val, _ = parse_mode_response(frame)
+            observations.append(
+                self._observation(
+                    self._freq_mode_path(
+                        receiver_id=receiver_id,
+                        slot_override=slot_override,
+                        name="mode",
+                    ),
+                    mode_val.name,
+                    frame=frame,
+                )
+            )
+        elif frame.command == 0x07 and len(frame.data) >= 2:
+            if frame.data[0] == 0xD2:
+                observations.append(
+                    self._observation(
+                        FieldPath.active_slot("0"),
+                        "B" if bool(frame.data[1]) else "A",
+                        frame=frame,
+                    )
+                )
+        elif frame.command == 0x25 and len(frame.data) >= 6:
+            from rigplane.types import bcd_decode
+
+            target_receiver = "1" if frame.data[0] else "0"
+            observations.append(
+                self._observation(
+                    FieldPath.active(target_receiver, "freq_mode", "freq_hz"),
+                    bcd_decode(frame.data[1:6]),
+                    frame=frame,
+                )
+            )
+        elif frame.command == 0x26 and len(frame.data) >= 2:
+            target_receiver = "1" if frame.data[0] else "0"
+            observations.append(
+                self._observation(
+                    FieldPath.active(target_receiver, "freq_mode", "mode"),
+                    Mode(frame.data[1]).name,
+                    frame=frame,
+                )
+            )
+        elif frame.command == 0x14 and len(frame.data) >= 2:
+            mapping = _OBSERVABLE_CMD14_FIELDS.get(frame.sub or 0)
+            if mapping is not None:
+                observations.append(
+                    self._observation(
+                        self._field_path(mapping, receiver_id=receiver_id),
+                        self._decode_level(frame.data),
+                        frame=frame,
+                    )
+                )
+        elif frame.command == 0x15 and len(frame.data) >= 2:
+            mapping = _OBSERVABLE_CMD15_FIELDS.get(frame.sub or 0)
+            if mapping is not None:
+                observations.append(
+                    self._observation(
+                        self._field_path(mapping, receiver_id=receiver_id),
+                        self._decode_level(frame.data),
+                        frame=frame,
+                    )
+                )
+        elif frame.command == 0x16:
+            sub = frame.sub or 0
+            data = frame.data
+            if sub == 0 and len(data) >= 2:
+                sub = data[0]
+                data = data[1:]
+            mapping = _OBSERVABLE_CMD16_FIELDS.get(sub)
+            if mapping is not None and data:
+                observations.append(
+                    self._observation(
+                        self._field_path(mapping, receiver_id=receiver_id),
+                        bool(data[0]),
+                        frame=frame,
+                    )
+                )
+        elif frame.command == 0x18 and len(frame.data) == 1:
+            observations.append(
+                self._observation(
+                    FieldPath.global_("tx_state", "power_on"),
+                    bool(frame.data[0]),
+                    frame=frame,
+                )
+            )
+        elif frame.command == 0x1C and frame.sub == 0x00 and frame.data:
+            observations.append(
+                self._observation(
+                    FieldPath.global_("tx_state", "ptt"),
+                    bool(frame.data[0]),
+                    frame=frame,
+                )
+            )
+
+        return tuple(observations)
+
+    def _receiver_context(self, frame: CivFrame) -> tuple[str, str, str | None]:
+        """Return receiver id/name plus any temporary VFO-slot override."""
+
+        rs = getattr(self._host, "_radio_state", None)
+        if frame.receiver is not None:
+            receiver_name = "SUB" if frame.receiver else "MAIN"
+            receiver_id = "1" if frame.receiver else "0"
+        else:
+            receiver_name = "SUB" if getattr(rs, "active", "MAIN") == "SUB" else "MAIN"
+            receiver_id = "1" if receiver_name == "SUB" else "0"
+
+        slot_override: str | None = None
+        override_map = getattr(self._host, "_vfo_slot_override", None)
+        if isinstance(override_map, dict):
+            candidate = override_map.get(receiver_name)
+            if candidate in ("A", "B"):
+                slot_override = candidate
+
+        return receiver_id, receiver_name, slot_override
+
+    @staticmethod
+    def _decode_level(data: bytes) -> int:
+        b0, b1 = data[0], data[1]
+        return (b0 >> 4) * 1000 + (b0 & 0x0F) * 100 + (b1 >> 4) * 10 + (b1 & 0x0F)
+
+    @staticmethod
+    def _field_path(
+        mapping: tuple[str, str, str],
+        *,
+        receiver_id: str,
+    ) -> FieldPath:
+        scope, family, name = mapping
+        if scope == "global":
+            return FieldPath.global_(family, name)
+        return FieldPath.receiver(receiver_id, family, name)
+
+    @staticmethod
+    def _freq_mode_path(
+        *,
+        receiver_id: str,
+        slot_override: str | None,
+        name: str,
+    ) -> FieldPath:
+        if slot_override is not None:
+            return FieldPath.vfo_slot(receiver_id, slot_override, "freq_mode", name)
+        return FieldPath.active(receiver_id, "freq_mode", name)
+
+    def _observation(self, path: FieldPath, value: Any, *, frame: CivFrame) -> Observation:
+        source = "civ_unsolicited" if frame.to_addr == 0x00 or frame.command in (0x00, 0x01) else "command_response"
+        return Observation(
+            path=path,
+            value=value,
+            source=SourceMetadata(
+                source=source,
+                provider="icom_civ",
+                transport="civ",
+                native_id=_frame_native_id(frame),
+                capability_id=str(path),
+            ),
+            timestamp_monotonic=time.monotonic(),
+            max_age=_OBSERVATION_MAX_AGE_SECONDS.get(
+                (path.scope.value, path.family.value, path.name)
+            ),
+        )
 
     # ------------------------------------------------------------------
     # Per-command handlers for _update_radio_state_from_frame.

--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -280,20 +280,60 @@ def _changeset_for_request_paths(
     observed_path: FieldPath,
     request_paths: tuple[FieldPath, ...],
 ) -> ChangeSet:
-    if not changeset.changes:
+    if (
+        not changeset.changes
+        and not changeset.observed_paths
+        and not changeset.freshness_paths
+    ):
         return changeset
+    remapped_observed_paths = tuple(
+        _request_path_for_observed_path(
+            path,
+            observed_path=observed_path,
+            request_paths=request_paths,
+        )
+        or path
+        for path in changeset.observed_paths
+    )
+    remapped_freshness_paths = tuple(
+        _request_path_for_observed_path(
+            path,
+            observed_path=observed_path,
+            request_paths=request_paths,
+        )
+        or path
+        for path in changeset.freshness_paths
+    )
     remapped: list[FieldChange] = []
     for change in changeset.changes:
-        replacement = None
-        if _field_paths_match(change.path, observed_path):
-            for request_path in request_paths:
-                if _field_paths_match(request_path, change.path):
-                    replacement = request_path
-                    break
+        replacement = _request_path_for_observed_path(
+            change.path,
+            observed_path=observed_path,
+            request_paths=request_paths,
+        )
         remapped.append(
             change if replacement is None else _replace_dataclass(change, path=replacement)
         )
-    return _replace_dataclass(changeset, changes=tuple(remapped))
+    return _replace_dataclass(
+        changeset,
+        changes=tuple(remapped),
+        observed_paths=remapped_observed_paths,
+        freshness_paths=remapped_freshness_paths,
+    )
+
+
+def _request_path_for_observed_path(
+    path: FieldPath,
+    *,
+    observed_path: FieldPath,
+    request_paths: tuple[FieldPath, ...],
+) -> FieldPath | None:
+    if not _field_paths_match(path, observed_path):
+        return None
+    for request_path in request_paths:
+        if _field_paths_match(request_path, path):
+            return request_path
+    return None
 
 _CMD1A_CTL_MEM_LEVEL_FIELDS = {
     b"\x00\x70": ("ref_adjust", 2),
@@ -1279,10 +1319,13 @@ class CivRuntime:
         scheduler = getattr(self._host, "_acquisition_scheduler", None)
         if not isinstance(scheduler, AcquisitionScheduler):
             return
-        for change in changeset.changes:
+        change_by_path = {change.path: change for change in changeset.changes}
+        paths = changeset.observed_paths or tuple(change_by_path)
+        for path in paths:
+            change = change_by_path.get(path)
             observation = Observation(
-                path=change.path,
-                value=change.current,
+                path=path,
+                value=None if change is None else change.current,
                 source=changeset.sources[0]
                 if changeset.sources
                 else SourceMetadata(
@@ -1296,13 +1339,15 @@ class CivRuntime:
             self._record_scheduler_result_for_observation(observation, changeset)
 
     def _notify_state_store_changed(self, changeset: ChangeSet) -> None:
-        if not changeset.changes:
+        paths = {change.path for change in changeset.changes}
+        paths.update(changeset.freshness_paths)
+        if not paths:
             return
         self._notify_change(
             "state_store_changed",
             {
                 "coalesced": changeset.coalesced,
-                "paths": sorted(str(change.path) for change in changeset.changes),
+                "paths": sorted(str(path) for path in paths),
             },
         )
 

--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -312,7 +312,9 @@ def _changeset_for_request_paths(
             request_paths=request_paths,
         )
         remapped.append(
-            change if replacement is None else _replace_dataclass(change, path=replacement)
+            change
+            if replacement is None
+            else _replace_dataclass(change, path=replacement)
         )
     return _replace_dataclass(
         changeset,
@@ -334,6 +336,7 @@ def _request_path_for_observed_path(
         if _field_paths_match(request_path, path):
             return request_path
     return None
+
 
 _CMD1A_CTL_MEM_LEVEL_FIELDS = {
     b"\x00\x70": ("ref_adjust", 2),
@@ -1226,9 +1229,7 @@ class CivRuntime:
 
         for observation in observations:
             try:
-                self.flush_due_meter_observations(
-                    now=observation.timestamp_monotonic
-                )
+                self.flush_due_meter_observations(now=observation.timestamp_monotonic)
                 if self._record_coalesced_meter_observation(observation):
                     continue
                 changeset = self._host._state_store.apply(observation)
@@ -1253,7 +1254,9 @@ class CivRuntime:
         profile = getattr(scheduler, "_profile", None)
         if profile is None:
             return False
-        policy = profile.policy_for(_profile_path_for_observation(profile, observation.path))
+        policy = profile.policy_for(
+            _profile_path_for_observation(profile, observation.path)
+        )
         if policy.meter_coalescing is None:
             return False
         coalescer = getattr(self._host, "_meter_observation_coalescer", None)
@@ -1268,7 +1271,9 @@ class CivRuntime:
         self.flush_due_meter_observations(now=observation.timestamp_monotonic)
         return True
 
-    def flush_due_meter_observations(self, *, now: float | None = None) -> ChangeSet | None:
+    def flush_due_meter_observations(
+        self, *, now: float | None = None
+    ) -> ChangeSet | None:
         coalescer = getattr(self._host, "_meter_observation_coalescer", None)
         if not isinstance(coalescer, MeterObservationCoalescer):
             return None
@@ -1295,7 +1300,9 @@ class CivRuntime:
             return
         for request in scheduler.pending_requests():
             matched_paths = tuple(
-                path for path in request.paths if _field_paths_match(path, observation.path)
+                path
+                for path in request.paths
+                if _field_paths_match(path, observation.path)
             )
             if not matched_paths:
                 continue
@@ -1504,7 +1511,9 @@ class CivRuntime:
             return FieldPath.vfo_slot(receiver_id, slot_override, "freq_mode", name)
         return FieldPath.active(receiver_id, "freq_mode", name)
 
-    def _observation(self, path: FieldPath, value: Any, *, frame: CivFrame) -> Observation:
+    def _observation(
+        self, path: FieldPath, value: Any, *, frame: CivFrame
+    ) -> Observation:
         source: ObservationSource = (
             "civ_unsolicited"
             if frame.to_addr == 0x00 or frame.command in (0x00, 0x01)

--- a/src/rigplane/runtime/_poller_types.py
+++ b/src/rigplane/runtime/_poller_types.py
@@ -963,6 +963,7 @@ class CommandQueueEntry:
     future: asyncio.Future[None] | None = None
     command_id: str | None = None
     source: CommandSource | None = None
+    session_id: str | None = None
     command_service: Any | None = None
 
 
@@ -1012,12 +1013,14 @@ class CommandQueue:
         *,
         command_id: str | None = None,
         source: CommandSource | None = None,
+        session_id: str | None = None,
         command_service: Any | None = None,
     ) -> None:
         entry = CommandQueueEntry(
             cmd,
             command_id=command_id,
             source=source,
+            session_id=session_id,
             command_service=command_service,
         )
         segment = self._coalesced_tail()
@@ -1034,6 +1037,7 @@ class CommandQueue:
         future: asyncio.Future[None] | None = None,
         command_id: str | None = None,
         source: CommandSource | None = None,
+        session_id: str | None = None,
         command_service: Any | None = None,
     ) -> None:
         self._segments.append(
@@ -1043,6 +1047,7 @@ class CommandQueue:
                     future=future,
                     command_id=command_id,
                     source=source,
+                    session_id=session_id,
                     command_service=command_service,
                 )
             )

--- a/src/rigplane/runtime/_poller_types.py
+++ b/src/rigplane/runtime/_poller_types.py
@@ -11,6 +11,8 @@ import asyncio
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
+from rigplane.core.state_pipeline_contracts import CommandSource
+
 __all__ = [
     "Command",
     "CommandQueue",
@@ -959,6 +961,9 @@ Command = (
 class CommandQueueEntry:
     command: Command
     future: asyncio.Future[None] | None = None
+    command_id: str | None = None
+    source: CommandSource | None = None
+    command_service: Any | None = None
 
 
 @dataclass(slots=True)
@@ -1001,8 +1006,20 @@ class CommandQueue:
         self._segments.append(segment)
         return segment
 
-    def put(self, cmd: Command) -> None:
-        entry = CommandQueueEntry(cmd)
+    def put(
+        self,
+        cmd: Command,
+        *,
+        command_id: str | None = None,
+        source: CommandSource | None = None,
+        command_service: Any | None = None,
+    ) -> None:
+        entry = CommandQueueEntry(
+            cmd,
+            command_id=command_id,
+            source=source,
+            command_service=command_service,
+        )
         segment = self._coalesced_tail()
         if isinstance(cmd, (PttOn, PttOff)):
             segment.ptt.append(entry)
@@ -1015,9 +1032,20 @@ class CommandQueue:
         cmd: Command,
         *,
         future: asyncio.Future[None] | None = None,
+        command_id: str | None = None,
+        source: CommandSource | None = None,
+        command_service: Any | None = None,
     ) -> None:
         self._segments.append(
-            _CommandQueueSegment.ordered_entry(CommandQueueEntry(cmd, future=future))
+            _CommandQueueSegment.ordered_entry(
+                CommandQueueEntry(
+                    cmd,
+                    future=future,
+                    command_id=command_id,
+                    source=source,
+                    command_service=command_service,
+                )
+            )
         )
         self._notify.set()
 

--- a/src/rigplane/runtime/_runtime_protocols.py
+++ b/src/rigplane/runtime/_runtime_protocols.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
     from rigplane.civ import CivEvent, CivRequestTracker
     from rigplane.commander import IcomCommander
     from rigplane.radio_state import RadioState
+    from rigplane.core.state_store import StateStore
     from rigplane.scope import ScopeAssembler, ScopeFrame
     from rigplane.transport import IcomTransport
     from rigplane.types import Mode
@@ -77,6 +78,7 @@ class CivRuntimeHost(Protocol):
 
     # State cache / last-known values
     _state_cache: "StateCache"
+    _state_store: "StateStore"
     _last_freq_hz: "int | None"
     _last_mode: "Mode | None"
     _filter_width: "int | None"

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -274,6 +274,7 @@ from rigplane.commands import set_tone_freq as _set_tone_freq_cmd
 from rigplane.commands import set_tsql_freq as _set_tsql_freq_cmd
 from rigplane.commands import set_vfo as _select_vfo_cmd
 from rigplane.core.exceptions import CommandError, TimeoutError
+from rigplane.core.state_store import StateStore
 from rigplane.runtime.meter_cal import interpolate_swr
 from rigplane.profiles import RadioProfile, resolve_radio_profile
 from rigplane.core.radio_state import RadioState
@@ -789,6 +790,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             float(os.environ.get("ICOM_CIV_RETRY_SLICE_MS", "150")) / 1000.0
         )
         self._state_cache: StateCache = StateCache()
+        self._state_store: StateStore = StateStore()
         self._state_diagnostics: StateDiagnosticsRecorder | None = None
         self._on_state_change: Callable[[str, dict[str, Any]], None] | None = (
             None  # set by server
@@ -975,6 +977,12 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         non-blocking snapshot of recent state.
         """
         return self._state_cache
+
+    @property
+    def state_store(self) -> StateStore:
+        """Canonical confirmed-observation store for runtime state ingress."""
+
+        return self._state_store
 
     @property
     def radio_state(self) -> RadioState:

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -277,6 +277,7 @@ from rigplane.core.exceptions import CommandError, TimeoutError
 from rigplane.runtime.meter_cal import interpolate_swr
 from rigplane.profiles import RadioProfile, resolve_radio_profile
 from rigplane.core.radio_state import RadioState
+from rigplane.core.state_diagnostics import StateDiagnosticsRecorder
 from rigplane.core._state_cache import StateCache
 from rigplane.scope import ScopeAssembler, ScopeFrame
 from rigplane.core.transport import IcomTransport
@@ -788,6 +789,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             float(os.environ.get("ICOM_CIV_RETRY_SLICE_MS", "150")) / 1000.0
         )
         self._state_cache: StateCache = StateCache()
+        self._state_diagnostics: StateDiagnosticsRecorder | None = None
         self._on_state_change: Callable[[str, dict[str, Any]], None] | None = (
             None  # set by server
         )

--- a/src/rigplane/runtime/sync.py
+++ b/src/rigplane/runtime/sync.py
@@ -59,6 +59,12 @@ class _SyncCommandExecutor:
             )
         elif intent.name == "set_rf_power":
             await radio.set_rf_power(int(params["value"]))
+        elif intent.name == "set_ptt":
+            await radio.set_ptt(bool(params["ptt"]))
+        elif intent.name == "set_split":
+            await radio.set_split(bool(params["split"]))
+        elif intent.name == "set_powerstat":
+            await radio.set_powerstat(bool(params["power_on"]))
         else:
             raise ValueError(f"unsupported public API command intent: {intent.name!r}")
 
@@ -320,7 +326,15 @@ class IcomRadio:
 
     def set_ptt(self, on: bool) -> None:
         """Enable or disable PTT."""
-        self._run(self._radio.set_ptt(on))
+        self._run(
+            self._command_service.execute(
+                command_intent_from_request(
+                    "set_ptt",
+                    {"on": on},
+                    source="public_api",
+                )
+            )
+        )
 
     # ------------------------------------------------------------------
     # VFO / Split
@@ -349,7 +363,15 @@ class IcomRadio:
 
     def set_split(self, on: bool) -> None:
         """Enable or disable split mode."""
-        self._run(self._radio.set_split(on))
+        self._run(
+            self._command_service.execute(
+                command_intent_from_request(
+                    "set_split",
+                    {"on": on},
+                    source="public_api",
+                )
+            )
+        )
 
     def get_split(self) -> bool:
         """Read split mode state."""
@@ -492,7 +514,15 @@ class IcomRadio:
             raise AttributeError(
                 "power_control requires a radio that implements PowerControlCapable"
             )
-        self._run(self._radio.set_powerstat(on))
+        self._run(
+            self._command_service.execute(
+                command_intent_from_request(
+                    "set_powerstat",
+                    {"on": on},
+                    source="public_api",
+                )
+            )
+        )
 
     # ------------------------------------------------------------------
     # Scope

--- a/src/rigplane/runtime/sync.py
+++ b/src/rigplane/runtime/sync.py
@@ -63,6 +63,21 @@ class _SyncCommandExecutor:
             await radio.set_ptt(bool(params["ptt"]))
         elif intent.name == "set_split":
             await radio.set_split(bool(params["split"]))
+        elif intent.name == "set_attenuator_level":
+            await radio.set_attenuator_level(
+                int(params["att"]),
+                receiver=int(params.get("receiver", 0)),
+            )
+        elif intent.name == "set_preamp":
+            await radio.set_preamp(
+                int(params["preamp"]),
+                receiver=int(params.get("receiver", 0)),
+            )
+        elif intent.name == "set_squelch":
+            await radio.set_squelch(
+                int(params["squelch"]),
+                receiver=int(params.get("receiver", 0)),
+            )
         elif intent.name == "set_powerstat":
             await radio.set_powerstat(bool(params["power_on"]))
         else:
@@ -391,7 +406,15 @@ class IcomRadio:
 
     def set_attenuator_level(self, db: int) -> None:
         """Set attenuator level in dB."""
-        self._run(self._radio.set_attenuator_level(db))
+        self._run(
+            self._command_service.execute(
+                command_intent_from_request(
+                    "set_attenuator_level",
+                    {"db": db, "receiver": 0},
+                    source="public_api",
+                )
+            )
+        )
 
     def set_attenuator(self, on: bool) -> None:
         """Enable or disable the attenuator."""
@@ -403,7 +426,15 @@ class IcomRadio:
 
     def set_preamp(self, level: int = 1) -> None:
         """Set preamp level (0=off, 1=PREAMP1, 2=PREAMP2)."""
-        self._run(self._radio.set_preamp(level))
+        self._run(
+            self._command_service.execute(
+                command_intent_from_request(
+                    "set_preamp",
+                    {"level": level, "receiver": 0},
+                    source="public_api",
+                )
+            )
+        )
 
     def get_digisel(self) -> bool:
         """Read DIGI-SEL status."""
@@ -415,7 +446,15 @@ class IcomRadio:
 
     def set_squelch(self, level: int, receiver: int = 0) -> None:
         """Set squelch level (0-255, 0=open)."""
-        self._run(self._radio.set_squelch(level, receiver=receiver))
+        self._run(
+            self._command_service.execute(
+                command_intent_from_request(
+                    "set_squelch",
+                    {"level": level, "receiver": receiver},
+                    source="public_api",
+                )
+            )
+        )
 
     def get_data_off_mod_input(self) -> int:
         """Read the Data Off modulation input source."""

--- a/src/rigplane/runtime/sync.py
+++ b/src/rigplane/runtime/sync.py
@@ -13,9 +13,19 @@ Example::
 """
 
 import asyncio
+import time
+from dataclasses import dataclass
 from typing import Any, Callable, Coroutine, TypeVar
 
 from rigplane.audio import AudioPacket
+from rigplane.core.command_service import (
+    CommandExecutionResult,
+    CommandService,
+    command_intent_from_request,
+    command_response_observation,
+)
+from rigplane.core.state_pipeline_contracts import CommandIntent
+from rigplane.core.state_store import StateStore
 from .ic705 import (
     prepare_ic705_data_profile as _prepare_ic705_data_profile,
     restore_ic705_data_profile as _restore_ic705_data_profile,
@@ -27,6 +37,41 @@ from rigplane.core.types import AudioCodec, Mode, ScopeCompletionPolicy
 T = TypeVar("T")
 
 __all__ = ["IcomRadio"]
+
+
+@dataclass(slots=True)
+class _SyncCommandExecutor:
+    wrapper: "IcomRadio"
+
+    async def execute(self, intent: CommandIntent) -> CommandExecutionResult:
+        radio = self.wrapper._radio
+        params = intent.params
+        if intent.name == "set_freq":
+            await radio.set_freq(int(params["freq_hz"]))
+        elif intent.name == "set_filter":
+            await radio.set_filter(int(params["filter_num"]))
+        elif intent.name == "set_mode":
+            await radio.set_mode(params["mode"], params.get("filter_width"))
+        elif intent.name == "set_data_mode":
+            await radio.set_data_mode(
+                params["value"],
+                receiver=int(params.get("receiver", 0)),
+            )
+        elif intent.name == "set_rf_power":
+            await radio.set_rf_power(int(params["value"]))
+        else:
+            raise ValueError(f"unsupported public API command intent: {intent.name!r}")
+
+        observations = ()
+        if intent.target is not None:
+            observations = (
+                command_response_observation(
+                    intent,
+                    timestamp_monotonic=time.monotonic(),
+                    provider="public_api",
+                ),
+            )
+        return CommandExecutionResult(observations=observations)
 
 
 class IcomRadio:
@@ -71,6 +116,11 @@ class IcomRadio:
             audio_codec=audio_codec,
             audio_sample_rate=audio_sample_rate,
         )
+        self._state_store = StateStore()
+        self._command_service = CommandService(
+            executor=_SyncCommandExecutor(self),
+            state_store=self._state_store,
+        )
 
     def _run(self, coro: Coroutine[Any, Any, T]) -> T:
         """Run a coroutine on the internal event loop."""
@@ -111,7 +161,15 @@ class IcomRadio:
 
     def set_freq(self, freq_hz: int) -> None:
         """Set the operating frequency in Hz."""
-        self._run(self._radio.set_freq(freq_hz))
+        self._run(
+            self._command_service.execute(
+                command_intent_from_request(
+                    "set_freq",
+                    {"freq": freq_hz, "receiver": 0},
+                    source="public_api",
+                )
+            )
+        )
 
     # Backward-compat aliases
     get_frequency = get_freq
@@ -135,11 +193,28 @@ class IcomRadio:
 
     def set_filter(self, filter_width: int) -> None:
         """Set filter number (1-3) while keeping current mode."""
-        self._run(self._radio.set_filter(filter_width))
+        self._run(
+            self._command_service.execute(
+                command_intent_from_request(
+                    "set_filter",
+                    {"filter_num": filter_width, "receiver": 0},
+                    source="public_api",
+                )
+            )
+        )
 
     def set_mode(self, mode: str | Mode, filter_width: int | None = None) -> None:
         """Set the operating mode."""
-        self._run(self._radio.set_mode(mode, filter_width))
+        mode_name = mode.name if isinstance(mode, Mode) else str(mode)
+        self._run(
+            self._command_service.execute(
+                command_intent_from_request(
+                    "set_mode",
+                    {"mode": mode_name, "filter_width": filter_width, "receiver": 0},
+                    source="public_api",
+                )
+            )
+        )
 
     def get_data_mode(self) -> bool:
         """Read whether DATA mode is enabled."""
@@ -147,7 +222,15 @@ class IcomRadio:
 
     def set_data_mode(self, on: int | bool, receiver: int = 0) -> None:
         """Set DATA mode for the selected receiver."""
-        self._run(self._radio.set_data_mode(on, receiver=receiver))
+        self._run(
+            self._command_service.execute(
+                command_intent_from_request(
+                    "set_data_mode",
+                    {"value": on, "receiver": receiver},
+                    source="public_api",
+                )
+            )
+        )
 
     # ------------------------------------------------------------------
     # Power
@@ -167,7 +250,15 @@ class IcomRadio:
             raise AttributeError(
                 "set_rf_power requires a radio that implements PowerControlCapable"
             )
-        self._run(self._radio.set_rf_power(level))
+        self._run(
+            self._command_service.execute(
+                command_intent_from_request(
+                    "set_rf_power",
+                    {"value": level},
+                    source="public_api",
+                )
+            )
+        )
 
     # Backward-compat aliases
     get_power = get_rf_power

--- a/src/rigplane/web/_delta_encoder.py
+++ b/src/rigplane/web/_delta_encoder.py
@@ -86,7 +86,9 @@ class DeltaEncoder:
         """
         # Check if full state refresh is needed
         external_revision = state_revision is not None
-        revision_value = self._revision if state_revision is None else int(state_revision)
+        revision_value = (
+            self._revision if state_revision is None else int(state_revision)
+        )
         freshness_value = 0 if freshness_revision is None else int(freshness_revision)
 
         if (

--- a/src/rigplane/web/_delta_encoder.py
+++ b/src/rigplane/web/_delta_encoder.py
@@ -51,7 +51,12 @@ class DeltaEncoder:
         self._full_state_interval = full_state_interval
 
     def encode(
-        self, current_state: dict[str, Any], *, force_full: bool = False
+        self,
+        current_state: dict[str, Any],
+        *,
+        force_full: bool = False,
+        state_revision: int | None = None,
+        freshness_revision: int | None = None,
     ) -> dict[str, Any]:
         """Encode a state snapshot as a delta or full state.
 
@@ -80,6 +85,10 @@ class DeltaEncoder:
                 }
         """
         # Check if full state refresh is needed
+        external_revision = state_revision is not None
+        revision_value = self._revision if state_revision is None else int(state_revision)
+        freshness_value = 0 if freshness_revision is None else int(freshness_revision)
+
         if (
             force_full
             or self._previous_state is None
@@ -87,13 +96,18 @@ class DeltaEncoder:
         ):
             # Send full state
             self._previous_state = copy.deepcopy(current_state)
-            self._revision += 1
+            self._revision = revision_value if external_revision else self._revision + 1
             self._delta_count = 0
-            return {
+            full_result = {
                 "type": "full",
                 "data": dict(current_state),
                 "revision": self._revision,
             }
+            if state_revision is not None:
+                full_result["stateRevision"] = self._revision
+            if freshness_revision is not None:
+                full_result["freshnessRevision"] = freshness_value
+            return full_result
 
         # Compute delta
         changed: dict[str, Any] = {}
@@ -112,7 +126,7 @@ class DeltaEncoder:
 
         # Update previous state for next comparison
         self._previous_state = copy.deepcopy(current_state)
-        self._revision += 1
+        self._revision = revision_value if external_revision else self._revision + 1
         self._delta_count += 1
 
         # Build delta message
@@ -121,6 +135,10 @@ class DeltaEncoder:
             "changed": changed,
             "revision": self._revision,
         }
+        if state_revision is not None:
+            result["stateRevision"] = self._revision
+        if freshness_revision is not None:
+            result["freshnessRevision"] = freshness_value
         if removed:
             result["removed"] = removed
 

--- a/src/rigplane/web/discovery.py
+++ b/src/rigplane/web/discovery.py
@@ -109,6 +109,10 @@ class DiscoveryResponder:
             an additive ``radios[]`` array; the single-radio top-level fields
             stay populated (from radio_provider, or from the first fleet entry)
             for back-compatible parsers.
+        fleet_api_base: Optional reachable Fleet API base URL. When supplied,
+            emitted as ``urls.fleet``.
+        box_id: Optional stable box identifier. When supplied, emitted as
+            top-level ``box_id``.
         name: Human-readable instance name (default: auto from radio model).
         bind_host: Address to bind UDP socket (default: 0.0.0.0).
         discovery_port: UDP port to listen on (default: 8470).
@@ -123,11 +127,15 @@ class DiscoveryResponder:
         bind_host: str = "0.0.0.0",
         discovery_port: int = _DEFAULT_PORT,
         fleet_provider: Callable[[], list[FleetRadioInfo]] | None = None,
+        fleet_api_base: str | None = None,
+        box_id: str | None = None,
     ) -> None:
         self._web_port = web_port
         self._tls = tls
         self._radio_provider = radio_provider
         self._fleet_provider = fleet_provider
+        self._fleet_api_base = fleet_api_base
+        self._box_id = box_id
         self._name = name
         self._bind_host = bind_host
         self._discovery_port = discovery_port
@@ -201,19 +209,23 @@ class DiscoveryResponder:
         else:
             name = "RigPlane"
 
+        urls: dict[str, object] = {
+            "base": f"{scheme}://{local_ip}:{self._web_port}",
+            "health": f"{scheme}://{local_ip}:{self._web_port}/healthz",
+            "readiness": f"{scheme}://{local_ip}:{self._web_port}/readyz",
+            "runtime": (f"{scheme}://{local_ip}:{self._web_port}/api/v1/runtime"),
+            "station": (f"{scheme}://{local_ip}:{self._web_port}/api/v1/station"),
+        }
+        if self._fleet_api_base is not None:
+            urls["fleet"] = self._fleet_api_base
+
         payload: dict[str, object] = {
             "schema": "rigplane.station.discovery.v1",
             "service": "rigplane",
             "kind": "station_server",
             "version": __version__,
             "url": f"{scheme}://{local_ip}:{self._web_port}",
-            "urls": {
-                "base": f"{scheme}://{local_ip}:{self._web_port}",
-                "health": f"{scheme}://{local_ip}:{self._web_port}/healthz",
-                "readiness": f"{scheme}://{local_ip}:{self._web_port}/readyz",
-                "runtime": (f"{scheme}://{local_ip}:{self._web_port}/api/v1/runtime"),
-                "station": (f"{scheme}://{local_ip}:{self._web_port}/api/v1/station"),
-            },
+            "urls": urls,
             "name": name,
             "displayName": name,
             "instanceId": None,
@@ -246,6 +258,8 @@ class DiscoveryResponder:
                 else None
             ),
         }
+        if self._box_id is not None:
+            payload["box_id"] = self._box_id
 
         if fleet:
             payload["kind"] = "station_fleet"

--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -187,8 +187,47 @@ class _ControlCommandExecutor:
         result = await self.handler._enqueue_legacy_command(  # noqa: SLF001
             intent.name,
             dict(intent.params),
+            command_id=intent.id,
+            source=intent.source,
+            command_service=self.handler._command_service,  # noqa: SLF001
         )
         return CommandExecutionResult(details=result)
+
+
+@dataclass(frozen=True, slots=True)
+class _CommandMetadataQueue:
+    queue: Any
+    command_id: str
+    source: CommandSource
+    command_service: CommandService
+
+    def put(self, command: Any) -> None:
+        try:
+            self.queue.put(
+                command,
+                command_id=self.command_id,
+                source=self.source,
+                command_service=self.command_service,
+            )
+        except TypeError:
+            self.queue.put(command)
+
+    def put_ordered(
+        self,
+        command: Any,
+        *,
+        future: asyncio.Future[None] | None = None,
+    ) -> None:
+        try:
+            self.queue.put_ordered(
+                command,
+                future=future,
+                command_id=self.command_id,
+                source=self.source,
+                command_service=self.command_service,
+            )
+        except TypeError:
+            self.queue.put_ordered(command, future=future)
 
 
 class ControlHandler:
@@ -905,7 +944,13 @@ class ControlHandler:
         return dict(result.executor_result.details or {})
 
     async def _enqueue_legacy_command(
-        self, name: str, params: dict[str, Any]
+        self,
+        name: str,
+        params: dict[str, Any],
+        *,
+        command_id: str,
+        source: CommandSource,
+        command_service: CommandService,
     ) -> dict[str, Any]:
         """Build a Command dataclass, enqueue it, and return the ack result.
 
@@ -926,6 +971,12 @@ class ControlHandler:
         q = self._server.command_queue if self._server is not None else None
         if q is None:
             raise RuntimeError("no command queue available")
+        q = _CommandMetadataQueue(
+            q,
+            command_id=command_id,
+            source=source,
+            command_service=command_service,
+        )
 
         # Dispatch to group handlers
         for handler in (

--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -840,7 +840,9 @@ class ControlHandler:
         msg_out = {"type": "state_update", "data": payload}
         if self._server is not None:
             try:
-                msg_out["data"] = self._server.build_state_update_envelope(force_full=True)
+                msg_out["data"] = self._server.build_state_update_envelope(
+                    force_full=True
+                )
             except Exception as exc:
                 logger.debug("control: state_update envelope build failed: %s", exc)
         await self._ws.send_text(encode_json(msg_out))

--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -433,6 +433,7 @@ class ControlHandler:
         radio_model: str,
         server: Any = None,
         read_only: bool = False,
+        session_id: str | None = None,
     ) -> None:
         self._ws = ws
         self._radio = radio
@@ -440,6 +441,9 @@ class ControlHandler:
         self._radio_model = radio_model
         self._server = server
         self._read_only = read_only
+        self._session_id = (
+            session_id if session_id is not None else f"websocket-{time.monotonic_ns()}"
+        )
         self._subscribed_streams: set[str] = set()
         self._event_queue: BoundedQueue[dict[str, Any]] = BoundedQueue(
             maxsize=100,
@@ -948,6 +952,7 @@ class ControlHandler:
             intent_params,
             source=source,
             command_id=command_id,
+            session_id=self._session_id if source == "websocket" else None,
         )
         result = await self._command_service.execute(intent)
         return dict(result.executor_result.details or {})

--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -6,9 +6,17 @@ import asyncio
 import logging
 import time
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from ..._bounded_queue import BoundedQueue
+from ...core.command_service import (
+    CommandExecutionResult,
+    CommandService,
+    command_intent_from_request,
+)
+from ...core.state_pipeline_contracts import CommandIntent, CommandSource
+from ...core.state_store import StateStore
 from ...profiles import RadioProfile
 from ...radio_state import RadioState
 from ..protocol import (  # noqa: TID251
@@ -169,6 +177,18 @@ __all__ = ["ControlHandler"]
 
 logger = logging.getLogger(__name__)
 _MAX_CW_TEXT_CHARS = 512
+
+
+@dataclass(slots=True)
+class _ControlCommandExecutor:
+    handler: "ControlHandler"
+
+    async def execute(self, intent: CommandIntent) -> CommandExecutionResult:
+        result = await self.handler._enqueue_legacy_command(  # noqa: SLF001
+            intent.name,
+            dict(intent.params),
+        )
+        return CommandExecutionResult(details=result)
 
 
 class ControlHandler:
@@ -389,6 +409,13 @@ class ControlHandler:
         # Minimum interval between same command (seconds).
         # Continuous slider/knob drag sends dozens of set_* per second.
         self._CMD_MIN_INTERVAL = 0.05  # 50ms = max 20 commands/sec per client
+        state_store = getattr(server, "command_state_store", None)
+        if not isinstance(state_store, StateStore):
+            state_store = StateStore()
+        self._command_service = CommandService(
+            executor=_ControlCommandExecutor(self),
+            state_store=state_store,
+        )
 
     async def run(self) -> None:
         """Run the control channel lifecycle."""
@@ -824,7 +851,12 @@ class ControlHandler:
             return
 
         try:
-            result = await self._enqueue_command(name, params)
+            result = await self._enqueue_command(
+                name,
+                params,
+                command_id=str(cmd_id),
+                source="websocket",
+            )
             await self._ws.send_text(
                 encode_json(
                     {
@@ -856,6 +888,23 @@ class ControlHandler:
             )
 
     async def _enqueue_command(
+        self,
+        name: str,
+        params: dict[str, Any],
+        *,
+        command_id: str | None = None,
+        source: CommandSource = "websocket",
+    ) -> dict[str, Any]:
+        intent = command_intent_from_request(
+            name,
+            params,
+            source=source,
+            command_id=command_id,
+        )
+        result = await self._command_service.execute(intent)
+        return dict(result.executor_result.details or {})
+
+    async def _enqueue_legacy_command(
         self, name: str, params: dict[str, Any]
     ) -> dict[str, Any]:
         """Build a Command dataclass, enqueue it, and return the ack result.

--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -201,6 +201,7 @@ class _CommandMetadataQueue:
     queue: Any
     command_id: str
     source: CommandSource
+    session_id: str | None
     command_service: CommandService
 
     def put(self, command: Any) -> None:
@@ -209,6 +210,7 @@ class _CommandMetadataQueue:
                 command,
                 command_id=self.command_id,
                 source=self.source,
+                session_id=self.session_id,
                 command_service=self.command_service,
             )
         except TypeError:
@@ -226,6 +228,7 @@ class _CommandMetadataQueue:
                 future=future,
                 command_id=self.command_id,
                 source=self.source,
+                session_id=self.session_id,
                 command_service=self.command_service,
             )
         except TypeError:
@@ -989,6 +992,9 @@ class ControlHandler:
             q,
             command_id=command_id,
             source=source,
+            session_id=None
+            if params.get("session_id") is None
+            else str(params["session_id"]),
             command_service=command_service,
         )
 

--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -480,11 +480,9 @@ class ControlHandler:
         # and before the recv loop — no interleaving with command responses.
         if self._server is not None:
             try:
-                initial_state = self._server.build_public_state()
-                rev = self._server._delta_encoder.revision
                 msg = {
                     "type": "state_update",
-                    "data": {"type": "full", "data": initial_state, "revision": rev},
+                    "data": self._server.build_state_update_envelope(force_full=True),
                 }
                 await self._ws.send_text(encode_json(msg))
             except Exception:
@@ -832,6 +830,11 @@ class ControlHandler:
             )
 
         msg_out = {"type": "state_update", "data": payload}
+        if self._server is not None:
+            try:
+                msg_out["data"] = self._server.build_state_update_envelope(force_full=True)
+            except Exception as exc:
+                logger.debug("control: state_update envelope build failed: %s", exc)
         await self._ws.send_text(encode_json(msg_out))
         # Send current DX spots if available
         if self._server is not None and hasattr(self._server, "_spot_buffer"):

--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -2229,7 +2229,9 @@ class ControlHandler:
                     )
                 from ...types import MemoryChannel
 
-                mem = MemoryChannel(**params)
+                mem_params = dict(params)
+                mem_params.pop("session_id", None)
+                mem = MemoryChannel(**mem_params)
                 q.put(SetMemoryContents(mem))
                 return {"channel": mem.channel}
             case "set_bsr":
@@ -2240,7 +2242,9 @@ class ControlHandler:
                     )
                 from ...types import BandStackRegister
 
-                bsr = BandStackRegister(**params)
+                bsr_params = dict(params)
+                bsr_params.pop("session_id", None)
+                bsr = BandStackRegister(**bsr_params)
                 q.put(SetBsr(bsr))
                 return {"band": bsr.band, "register": bsr.register}
             case _:

--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -448,13 +448,17 @@ class ControlHandler:
         # Minimum interval between same command (seconds).
         # Continuous slider/knob drag sends dozens of set_* per second.
         self._CMD_MIN_INTERVAL = 0.05  # 50ms = max 20 commands/sec per client
-        state_store = getattr(server, "command_state_store", None)
-        if not isinstance(state_store, StateStore):
-            state_store = StateStore()
-        self._command_service = CommandService(
-            executor=_ControlCommandExecutor(self),
-            state_store=state_store,
-        )
+        shared_service = getattr(server, "command_service", None)
+        if isinstance(shared_service, CommandService):
+            self._command_service = shared_service
+        else:
+            state_store = getattr(server, "command_state_store", None)
+            if not isinstance(state_store, StateStore):
+                state_store = StateStore()
+            self._command_service = CommandService(
+                executor=_ControlCommandExecutor(self),
+                state_store=state_store,
+            )
 
     async def run(self) -> None:
         """Run the control channel lifecycle."""

--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -635,6 +635,9 @@ class ControlHandler:
         """Handle radio_connect request — reconnect the radio."""
         logger.info("radio_connect requested")
         msg_id = msg.get("id", "")
+        if self._read_only:
+            await self._send_read_only_rejection(msg_id, "radio_connect")
+            return
         if self._radio is None:
             await self._send_json(
                 {
@@ -704,6 +707,9 @@ class ControlHandler:
         """Handle radio_disconnect request — disconnect the radio."""
         logger.info("radio_disconnect requested")
         msg_id = msg.get("id", "")
+        if self._read_only:
+            await self._send_read_only_rejection(msg_id, "radio_disconnect")
+            return
         if self._radio is None:
             await self._send_json(
                 {
@@ -767,6 +773,17 @@ class ControlHandler:
     async def _send_json(self, obj: dict[str, Any]) -> None:
         """Send a JSON message to the WebSocket client."""
         await self._ws.send_text(encode_json(obj))
+
+    async def _send_read_only_rejection(self, msg_id: Any, name: str) -> None:
+        await self._send_json(
+            {
+                "type": "response",
+                "id": msg_id,
+                "ok": False,
+                "error": "read_only",
+                "message": f"read-only mode: {name} rejected",
+            }
+        )
 
     async def _handle_subscribe(self, msg: dict[str, Any]) -> None:
         streams = msg.get("streams", [])
@@ -837,6 +854,24 @@ class ControlHandler:
         name = msg.get("name", "")
         params = msg.get("params", {})
 
+        if name not in self._COMMANDS:
+            await self._ws.send_text(
+                encode_json(
+                    {
+                        "type": "response",
+                        "id": cmd_id,
+                        "ok": False,
+                        "error": "unknown_command",
+                        "message": f"unknown command: {name!r}",
+                    }
+                )
+            )
+            return
+
+        if self._read_only and not self._is_observer_safe_command(name):
+            await self._send_read_only_rejection(cmd_id, str(name))
+            return
+
         # ── Server-side rate limiting (per client, per command) ──
         # Only throttle SET commands (continuous slider/knob drag).
         # GET and read-only commands pass through.
@@ -867,20 +902,6 @@ class ControlHandler:
                 return
             self._cmd_last[name] = now
             self._cmd_drops[name] = 0
-
-        if name not in self._COMMANDS:
-            await self._ws.send_text(
-                encode_json(
-                    {
-                        "type": "response",
-                        "id": cmd_id,
-                        "ok": False,
-                        "error": "unknown_command",
-                        "message": f"unknown command: {name!r}",
-                    }
-                )
-            )
-            return
 
         if self._radio is None:
             await self._ws.send_text(

--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -184,9 +184,11 @@ class _ControlCommandExecutor:
     handler: "ControlHandler"
 
     async def execute(self, intent: CommandIntent) -> CommandExecutionResult:
+        params = dict(intent.params)
+        params.pop("_control_server", None)
         result = await self.handler._enqueue_legacy_command(  # noqa: SLF001
             intent.name,
-            dict(intent.params),
+            params,
             command_id=intent.id,
             source=intent.source,
             command_service=self.handler._command_service,  # noqa: SLF001
@@ -938,9 +940,12 @@ class ControlHandler:
         command_id: str | None = None,
         source: CommandSource = "websocket",
     ) -> dict[str, Any]:
+        intent_params = dict(params)
+        if self._server is not None:
+            intent_params["_control_server"] = self._server
         intent = command_intent_from_request(
             name,
-            params,
+            intent_params,
             source=source,
             command_id=command_id,
         )

--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -186,6 +186,7 @@ class _ControlCommandExecutor:
     async def execute(self, intent: CommandIntent) -> CommandExecutionResult:
         params = dict(intent.params)
         params.pop("_control_server", None)
+        params.pop("_control_read_only", None)
         result = await self.handler._enqueue_legacy_command(  # noqa: SLF001
             intent.name,
             params,
@@ -416,18 +417,6 @@ class ControlHandler:
         ]
     )
 
-    # Commands that can transmit or send arbitrary radio writes — rejected when read_only=True.
-    # set_tuner_status value=2 (TUNING) is handled inline in _enqueue_read_only.
-    _TX_COMMANDS: frozenset[str] = frozenset(
-        {
-            "ptt",
-            "ptt_on",
-            "ptt_off",
-            "send_civ",
-            "send_cw_text",
-        }
-    )
-
     def __init__(
         self,
         ws: Connection,
@@ -537,6 +526,8 @@ class ControlHandler:
             "radio": self._radio_model,
             "connected": raw_connected if isinstance(raw_connected, bool) else False,
             "radio_ready": self._radio_ready(),
+            "read_only": self._read_only,
+            "observer": self._read_only,
             "capabilities": caps,
         }
         await self._ws.send_text(encode_json(msg))
@@ -926,7 +917,9 @@ class ControlHandler:
             logger.warning("control: command %r failed: %s", name, exc)
             message = str(exc)
             error = (
-                "unsupported_command"
+                "read_only"
+                if isinstance(exc, PermissionError)
+                else "unsupported_command"
                 if "does not support" in message or "not supported" in message
                 else "command_failed"
             )
@@ -953,6 +946,8 @@ class ControlHandler:
         intent_params = dict(params)
         if self._server is not None:
             intent_params["_control_server"] = self._server
+        if self._read_only:
+            intent_params["_control_read_only"] = True
         intent = command_intent_from_request(
             name,
             intent_params,
@@ -979,8 +974,8 @@ class ControlHandler:
         logger.info("enqueue_command: %s params=%s", name, params)
         radio = self._radio
 
-        # Transmit safety gate — must come before any dispatch.
-        if self._read_only and name in self._TX_COMMANDS:
+        # Observer/read-only gate — must come before any command queue dispatch.
+        if self._read_only and not self._is_observer_safe_command(name):
             raise PermissionError(f"read-only mode: {name} rejected")
 
         # Read-only commands — bypass command queue
@@ -1018,6 +1013,10 @@ class ControlHandler:
                 return result
 
         raise ValueError(f"unhandled command: {name!r}")
+
+    @classmethod
+    def _is_observer_safe_command(cls, name: str) -> bool:
+        return name.startswith("get_") and name in cls._READ_ONLY_HANDLERS
 
     # ------------------------------------------------------------------
     # Read-only commands (no command queue needed)

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -180,6 +180,7 @@ _FAST_INTERVAL: float = 0.025  # meters — wfview queue interval for LAN (25ms)
 _FAST_INTERVAL_SERIAL: float = 0.100  # serial: 10 polls/sec for responsive meters
 _SLOW_INTERVAL: float = 0.25  # levels/settings — rarely change
 
+
 def _audio_tx_codec_and_rate(radio: Any) -> tuple[AudioCodec | None, int]:
     contract = getattr(radio, "audio_stream_contract", None)
     tx_codec = getattr(contract, "tx_codec", None)

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -2226,9 +2226,9 @@ class RadioPoller:
             return None
         if path.scope.value == "receiver" and path.family.value == "freq_mode":
             if path.name == "freq_hz":
-                return (0x03, None, receiver)
+                return (0x25, None, receiver)
             if path.name == "mode":
-                return (0x04, None, receiver)
+                return (0x26, None, receiver)
             return None
         if path.scope.value == "receiver" and path.family.value == "meters":
             if path.name == "s_meter":

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -406,6 +406,7 @@ class RadioPoller:
         *,
         command_id: str | None = None,
         source: CommandSource = "websocket",
+        session_id: str | None = None,
         command_service: CommandService | None = None,
     ) -> None:
         intent = command_intent_from_request(
@@ -413,6 +414,7 @@ class RadioPoller:
             params,
             source=source,
             command_id=command_id or f"web-poller-{name}-{time.monotonic_ns()}",
+            session_id=session_id,
         )
         if intent.target is None:
             return
@@ -771,6 +773,7 @@ class RadioPoller:
                                 cmd,
                                 command_id=entry.command_id,
                                 source=entry.source or "websocket",
+                                session_id=entry.session_id,
                                 command_service=entry.command_service,
                             )
                             if entry.future is not None and not entry.future.done():
@@ -894,6 +897,7 @@ class RadioPoller:
         *,
         command_id: str | None = None,
         source: CommandSource = "websocket",
+        session_id: str | None = None,
         command_service: CommandService | None = None,
     ) -> None:
         radio = self._radio
@@ -949,6 +953,7 @@ class RadioPoller:
                     {"freq": freq, "receiver": rx},
                     command_id=command_id,
                     source=source,
+                    session_id=session_id,
                     command_service=command_service,
                 )
                 # Compatibility mirror until web state delivery reads StateStore.
@@ -997,6 +1002,7 @@ class RadioPoller:
                     {"mode": mode, "filter_width": fw, "receiver": rx},
                     command_id=command_id,
                     source=source,
+                    session_id=session_id,
                     command_service=command_service,
                 )
                 # Compatibility mirror until web state delivery reads StateStore.
@@ -1019,6 +1025,7 @@ class RadioPoller:
                         {"filter_num": fn, "receiver": rx},
                         command_id=command_id,
                         source=source,
+                        session_id=session_id,
                         command_service=command_service,
                     )
             case SetFilterWidth(width=width, receiver=rx):
@@ -1035,6 +1042,7 @@ class RadioPoller:
                     {"width": width, "receiver": rx},
                     command_id=command_id,
                     source=source,
+                    session_id=session_id,
                     command_service=command_service,
                 )
                 self._apply_compatibility_mirror(
@@ -1092,6 +1100,7 @@ class RadioPoller:
                     {},
                     command_id=command_id,
                     source=source,
+                    session_id=session_id,
                     command_service=command_service,
                 )
             case PttOff():
@@ -1102,6 +1111,7 @@ class RadioPoller:
                     {},
                     command_id=command_id,
                     source=source,
+                    session_id=session_id,
                     command_service=command_service,
                 )
                 # Stop TX audio stream after PTT, then restart RX
@@ -1135,6 +1145,7 @@ class RadioPoller:
                         {"level": level},
                         command_id=command_id,
                         source=source,
+                        session_id=session_id,
                         command_service=command_service,
                     )
             case SetRfGain(level=level, receiver=rx):
@@ -1146,6 +1157,7 @@ class RadioPoller:
                         {"level": level, "receiver": rx},
                         command_id=command_id,
                         source=source,
+                        session_id=session_id,
                         command_service=command_service,
                     )
             case SetAfLevel(level=level, receiver=rx):
@@ -1157,6 +1169,7 @@ class RadioPoller:
                         {"level": level, "receiver": rx},
                         command_id=command_id,
                         source=source,
+                        session_id=session_id,
                         command_service=command_service,
                     )
             case SetSquelch(level=level, receiver=rx):
@@ -1168,6 +1181,7 @@ class RadioPoller:
                         {"level": level, "receiver": rx},
                         command_id=command_id,
                         source=source,
+                        session_id=session_id,
                         command_service=command_service,
                     )
             case SetNB(on=on, receiver=rx):
@@ -1179,6 +1193,7 @@ class RadioPoller:
                         {"on": on, "receiver": rx},
                         command_id=command_id,
                         source=source,
+                        session_id=session_id,
                         command_service=command_service,
                     )
                 self._apply_compatibility_mirror(
@@ -1199,6 +1214,7 @@ class RadioPoller:
                         {"on": on, "receiver": rx},
                         command_id=command_id,
                         source=source,
+                        session_id=session_id,
                         command_service=command_service,
                     )
                 self._apply_compatibility_mirror(
@@ -1231,6 +1247,7 @@ class RadioPoller:
                     {"db": db, "receiver": rx},
                     command_id=command_id,
                     source=source,
+                    session_id=session_id,
                     command_service=command_service,
                 )
                 self._apply_compatibility_mirror(
@@ -1253,6 +1270,7 @@ class RadioPoller:
                     {"level": level, "receiver": rx},
                     command_id=command_id,
                     source=source,
+                    session_id=session_id,
                     command_service=command_service,
                 )
                 self._apply_compatibility_mirror(
@@ -1273,6 +1291,7 @@ class RadioPoller:
                     {"level": level, "receiver": rx},
                     command_id=command_id,
                     source=source,
+                    session_id=session_id,
                     command_service=command_service,
                 )
                 self._apply_compatibility_mirror(
@@ -1293,6 +1312,7 @@ class RadioPoller:
                     {"level": level, "receiver": rx},
                     command_id=command_id,
                     source=source,
+                    session_id=session_id,
                     command_service=command_service,
                 )
                 self._apply_compatibility_mirror(
@@ -1510,6 +1530,7 @@ class RadioPoller:
                     {"on": on},
                     command_id=command_id,
                     source=source,
+                    session_id=session_id,
                     command_service=command_service,
                 )
                 if self._radio_state:
@@ -1688,6 +1709,7 @@ class RadioPoller:
                     {"vfo": vfo},
                     command_id=command_id,
                     source=source,
+                    session_id=session_id,
                     command_service=command_service,
                 )
                 if self._radio_state is not None:
@@ -1818,6 +1840,7 @@ class RadioPoller:
                         {"on": on},
                         command_id=command_id,
                         source=source,
+                        session_id=session_id,
                         command_service=command_service,
                     )
                     # Optimistic update: radio won't respond to polls when off

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -67,7 +67,12 @@ from ..capabilities import (
     CAP_VOX,
 )
 from .._queue_pressure import PRESSURE_THRESHOLD
+from ..core.command_service import (
+    command_intent_from_request,
+    command_response_observation,
+)
 from ..core.state_diagnostics import StateDiagnosticsRecorder
+from ..core.state_store import StateStore
 from .._state_queries import build_state_queries
 from ..profiles import RadioProfile, resolve_radio_profile
 from ..types import AudioCodec
@@ -327,11 +332,13 @@ class RadioPoller:
         on_state_event: Callable[[str, dict[str, Any]], None] | None = None,
         radio_state: "RadioState | None" = None,
         diagnostics: StateDiagnosticsRecorder | None = None,
+        state_store: StateStore | None = None,
     ) -> None:
         queue = legacy_queue if legacy_queue is not None else command_queue
         self._radio = radio
         self._radio_state = radio_state
         self._state_diagnostics = diagnostics
+        self._state_store = state_store or StateStore()
         self._queue = queue
         self._on_state_event = on_state_event
         self._poll_index: int = 0
@@ -362,6 +369,27 @@ class RadioPoller:
         # than once per _UNSELECTED_SLOT_INTERVAL.
         self._last_user_write_ts: float = 0.0
         self._last_unselected_poll: dict[int, float] = {}
+
+    def _apply_command_response_observation(
+        self,
+        name: str,
+        params: dict[str, Any],
+    ) -> None:
+        intent = command_intent_from_request(
+            name,
+            params,
+            source="websocket",
+            command_id=f"web-poller-{name}-{time.monotonic_ns()}",
+        )
+        if intent.target is None:
+            return
+        self._state_store.apply(
+            command_response_observation(
+                intent,
+                timestamp_monotonic=time.monotonic(),
+                provider="web_poller",
+            )
+        )
 
     def start(self) -> None:
         if self._task is not None and not self._task.done():
@@ -808,7 +836,11 @@ class RadioPoller:
                     if current != "MAIN" and self._profile.vfo_sub_code is not None:
                         await asyncio.sleep(self._gap)
                         await self._civ(0x07, data=bytes([self._profile.vfo_sub_code]))
-                # Optimistic state update for frequency
+                self._apply_command_response_observation(
+                    "set_freq",
+                    {"freq": freq, "receiver": rx},
+                )
+                # Compatibility mirror until web state delivery reads StateStore.
                 if self._radio_state:
                     target = (
                         self._radio_state.sub if rx != 0 else self._radio_state.main
@@ -849,7 +881,11 @@ class RadioPoller:
                     if current != "MAIN" and self._profile.vfo_sub_code is not None:
                         await asyncio.sleep(self._gap)
                         await self._civ(0x07, data=bytes([self._profile.vfo_sub_code]))
-                # Optimistic state update for mode
+                self._apply_command_response_observation(
+                    "set_mode",
+                    {"mode": mode, "filter_width": fw, "receiver": rx},
+                )
+                # Compatibility mirror until web state delivery reads StateStore.
                 if self._radio_state:
                     target = (
                         self._radio_state.sub if rx != 0 else self._radio_state.main

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -32,6 +32,7 @@ from typing import TYPE_CHECKING, Any, Callable
 
 from ..exceptions import CommandError
 from ..exceptions import ConnectionError as RadioConnectionError
+from ..core.exceptions import TimeoutError as RigplaneTimeoutError
 from ..capabilities import (
     CAP_AF_LEVEL,
     CAP_AGC,
@@ -180,6 +181,30 @@ def _audio_tx_codec_and_rate(radio: Any) -> tuple[AudioCodec | None, int]:
     if not isinstance(tx_sr, int) or isinstance(tx_sr, bool) or tx_sr <= 0:
         tx_sr = 48000
     return tx_codec, tx_sr
+
+
+def _apply_att_compatibility_mirror(
+    state: "RadioState",
+    *,
+    db: int,
+    receiver: int,
+) -> None:
+    target = state.sub if receiver != 0 else state.main
+    target.att = db
+    if db > 0:
+        target.preamp = 0
+
+
+def _apply_preamp_compatibility_mirror(
+    state: "RadioState",
+    *,
+    level: int,
+    receiver: int,
+) -> None:
+    target = state.sub if receiver != 0 else state.main
+    target.preamp = level
+    if level > 0:
+        target.att = 0
 
 
 # ------------------------------------------------------------------
@@ -428,10 +453,23 @@ class RadioPoller:
         if entry.command_service is None or entry.command_id is None:
             return
         message = str(exc) or None
+        params: dict[str, Any] = {
+            "message": message,
+            "timed_out": timed_out,
+        }
+        if entry.source is not None:
+            params["source"] = entry.source
+            for event in reversed(entry.command_service.lifecycle_events()):
+                if (
+                    event.command_id == entry.command_id
+                    and event.source == entry.source
+                    and "session_id" in (event.details or {})
+                ):
+                    params["session_id"] = event.details["session_id"]
+                    break
         entry.command_service.fail_command(
             entry.command_id,
-            message=message,
-            timed_out=timed_out,
+            **params,
         )
 
     def start(self) -> None:
@@ -738,7 +776,7 @@ class RadioPoller:
                             if entry.future is not None and not entry.future.done():
                                 entry.future.set_result(None)
                             _backoff = 0.0
-                        except TimeoutError as exc:
+                        except (TimeoutError, RigplaneTimeoutError) as exc:
                             self._mark_queued_command_failed(
                                 entry,
                                 exc,
@@ -1188,14 +1226,20 @@ class RadioPoller:
                 self._ensure_receiver_supported(rx, operation="set_attenuator")
                 if CAP_ATTENUATOR in self._caps:
                     await radio.set_attenuator_level(db, receiver=rx)
-                if self._radio_state:
-                    target = (
-                        self._radio_state.sub if rx != 0 else self._radio_state.main
+                self._apply_command_response_observation(
+                    "set_attenuator_level",
+                    {"db": db, "receiver": rx},
+                    command_id=command_id,
+                    source=source,
+                    command_service=command_service,
+                )
+                self._apply_compatibility_mirror(
+                    lambda state: _apply_att_compatibility_mirror(
+                        state,
+                        db=db,
+                        receiver=rx,
                     )
-                    target.att = db
-                    if db > 0:
-                        target.preamp = 0
-                    self.bump_revision()
+                )
                 if self._on_state_event:
                     self._on_state_event(
                         "attenuator_changed", {"db": db, "receiver": rx}
@@ -1204,14 +1248,20 @@ class RadioPoller:
                 self._ensure_receiver_supported(rx, operation="set_preamp")
                 if CAP_PREAMP in self._caps:
                     await radio.set_preamp(level, receiver=rx)
-                if self._radio_state:
-                    target = (
-                        self._radio_state.sub if rx != 0 else self._radio_state.main
+                self._apply_command_response_observation(
+                    "set_preamp",
+                    {"level": level, "receiver": rx},
+                    command_id=command_id,
+                    source=source,
+                    command_service=command_service,
+                )
+                self._apply_compatibility_mirror(
+                    lambda state: _apply_preamp_compatibility_mirror(
+                        state,
+                        level=level,
+                        receiver=rx,
                     )
-                    target.preamp = level
-                    if level > 0:
-                        target.att = 0
-                    self.bump_revision()
+                )
                 if self._on_state_event:
                     self._on_state_event(
                         "preamp_changed", {"level": level, "receiver": rx}

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -67,6 +67,7 @@ from ..capabilities import (
     CAP_VOX,
 )
 from .._queue_pressure import PRESSURE_THRESHOLD
+from ..core.state_diagnostics import StateDiagnosticsRecorder
 from .._state_queries import build_state_queries
 from ..profiles import RadioProfile, resolve_radio_profile
 from ..types import AudioCodec
@@ -325,10 +326,12 @@ class RadioPoller:
         *,
         on_state_event: Callable[[str, dict[str, Any]], None] | None = None,
         radio_state: "RadioState | None" = None,
+        diagnostics: StateDiagnosticsRecorder | None = None,
     ) -> None:
         queue = legacy_queue if legacy_queue is not None else command_queue
         self._radio = radio
         self._radio_state = radio_state
+        self._state_diagnostics = diagnostics
         self._queue = queue
         self._on_state_event = on_state_event
         self._poll_index: int = 0
@@ -408,6 +411,11 @@ class RadioPoller:
     def bump_revision(self) -> None:
         """Increment the revision counter (called on each state change)."""
         self._revision += 1
+        self._record_state_diagnostic(
+            "revision_producing_event",
+            "web.radio_poller",
+            revision=self._revision,
+        )
 
     def mark_polled(self, field: str) -> None:
         """Record the last successful poll time for a logical field."""
@@ -1878,6 +1886,21 @@ class RadioPoller:
                     cmd_byte, sub_byte = self._LOW_TIER[low_idx]
                 else:
                     cmd_byte, sub_byte = self._pick_high_meter(high_idx)
+            self._record_state_diagnostic(
+                "meter_cadence",
+                "web.radio_poller",
+                command=f"0x{cmd_byte:02x}",
+                sub=None if sub_byte is None else f"0x{sub_byte:02x}",
+                poll_index=self._poll_index,
+                serial=self._is_serial,
+            )
+            self._record_state_diagnostic(
+                "backend_read",
+                "web.radio_poller",
+                family="meters",
+                command=f"0x{cmd_byte:02x}",
+                sub=None if sub_byte is None else f"0x{sub_byte:02x}",
+            )
             await self._civ(cmd_byte, sub=sub_byte, data=b"")
         else:
             if not self._STATE_QUERIES:
@@ -1885,6 +1908,14 @@ class RadioPoller:
                 return
             state_idx = (self._poll_index // 2) % len(self._STATE_QUERIES)
             cmd_byte, sub_byte, receiver = self._STATE_QUERIES[state_idx]
+            self._record_state_diagnostic(
+                "backend_read",
+                "web.radio_poller",
+                family="state",
+                command=f"0x{cmd_byte:02x}",
+                sub=None if sub_byte is None else f"0x{sub_byte:02x}",
+                receiver=receiver,
+            )
             await self._send_one_state_query(cmd_byte, sub_byte, receiver)
         self._poll_index += 1
 
@@ -2003,3 +2034,7 @@ class RadioPoller:
     def _emit(self, name: str, data: dict[str, Any]) -> None:
         if self._on_state_event is not None:
             self._on_state_event(name, data)
+
+    def _record_state_diagnostic(self, kind: str, source: str, **details: Any) -> None:
+        if self._state_diagnostics is not None:
+            self._state_diagnostics.record(kind, source, **details)

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -28,7 +28,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from dataclasses import replace
 from typing import TYPE_CHECKING, Any, Callable
 
 from ..exceptions import CommandError
@@ -79,7 +78,7 @@ from ..core.acquisition_scheduler import (
     AcquisitionScheduler,
     MeterObservationCoalescer,
 )
-from ..core.state_pipeline_contracts import ChangeSet, CommandSource, FieldPath
+from ..core.state_pipeline_contracts import CommandSource, FieldPath
 from ..core.state_diagnostics import StateDiagnosticsRecorder
 from ..core.state_store import StateStore
 from .._state_queries import build_state_queries
@@ -2244,6 +2243,10 @@ class RadioPoller:
         if path.scope.value == "global" and path.family.value == "meters":
             sub = _GLOBAL_METER_QUERY_SUBS.get(path.name)
             return None if sub is None else (0x15, sub, None)
+        if path.scope.value == "global" and path.family.value == "tx_state":
+            if path.name == "ptt":
+                return (0x1C, 0x00, None)
+            return None
         if (
             path.scope.value == "global"
             and path.family.value == "operator_controls"
@@ -2251,17 +2254,6 @@ class RadioPoller:
             sub = _GLOBAL_LEVEL_QUERY_SUBS.get(path.name)
             return None if sub is None else (0x14, sub, None)
         return None
-
-    def _empty_acquisition_changeset(self, *, now: float) -> ChangeSet:
-        snapshot = self._state_store.snapshot()
-        return ChangeSet(
-            revision=snapshot.state_revision,
-            freshness_revision=snapshot.freshness_revision,
-            observation_seq=snapshot.observation_seq,
-            changes=(),
-            timestamp_monotonic=now,
-            sources=(),
-        )
 
     def _acquisition_request_expired(
         self,
@@ -2321,10 +2313,6 @@ class RadioPoller:
                         request_id=request.id,
                         path=str(path),
                         reason="no_civ_query_mapping",
-                    )
-                    scheduler.record_acquisition_result(
-                        replace(request, paths=(path,)),
-                        self._empty_acquisition_changeset(now=now),
                     )
                     continue
                 cmd_byte, sub_byte, receiver = query

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, Callable, cast
 
 from ..exceptions import CommandError
 from ..exceptions import ConnectionError as RadioConnectionError
@@ -74,8 +74,10 @@ from ..core.command_service import (
     command_response_observation,
 )
 from ..core.acquisition_scheduler import (
+    AcquisitionExecutor,
     AcquisitionRequest,
     AcquisitionScheduler,
+    IcomCivAcquisitionExecutor,
     MeterObservationCoalescer,
 )
 from ..core.state_pipeline_contracts import CommandSource, FieldPath
@@ -177,41 +179,6 @@ _DEFAULT_POLL_FIELD_TTL: float = 0.2
 _FAST_INTERVAL: float = 0.025  # meters — wfview queue interval for LAN (25ms)
 _FAST_INTERVAL_SERIAL: float = 0.100  # serial: 10 polls/sec for responsive meters
 _SLOW_INTERVAL: float = 0.25  # levels/settings — rarely change
-
-_RECEIVER_IDS: dict[str, int] = {
-    "0": 0,
-    "main": 0,
-    "1": 1,
-    "sub": 1,
-}
-_RECEIVER_LEVEL_QUERY_SUBS: dict[str, int] = {
-    "af_level": 0x01,
-    "rf_gain": 0x02,
-    "squelch": 0x03,
-    "apf_type_level": 0x05,
-    "nr_level": 0x06,
-    "pbt_inner": 0x07,
-    "pbt_outer": 0x08,
-    "nb_level": 0x12,
-    "digisel_shift": 0x13,
-}
-_GLOBAL_LEVEL_QUERY_SUBS: dict[str, int] = {
-    "power_level": 0x0A,
-    "mic_gain": 0x0B,
-    "notch_filter": 0x0D,
-    "compressor_level": 0x0E,
-    "break_in_delay": 0x0F,
-    "drive_gain": 0x14,
-    "monitor_gain": 0x15,
-    "vox_gain": 0x16,
-    "anti_vox_gain": 0x17,
-}
-_GLOBAL_METER_QUERY_SUBS: dict[str, int] = {
-    "power": 0x11,
-    "swr": 0x12,
-    "alc": 0x13,
-}
-
 
 def _audio_tx_codec_and_rate(radio: Any) -> tuple[AudioCodec | None, int]:
     contract = getattr(radio, "audio_stream_contract", None)
@@ -401,6 +368,7 @@ class RadioPoller:
         radio_state: "RadioState | None" = None,
         diagnostics: StateDiagnosticsRecorder | None = None,
         state_store: StateStore | None = None,
+        acquisition_executor: AcquisitionExecutor | None = None,
     ) -> None:
         queue = legacy_queue if legacy_queue is not None else command_queue
         self._radio = radio
@@ -411,6 +379,7 @@ class RadioPoller:
         self._acquisition_scheduler = (
             raw_scheduler if isinstance(raw_scheduler, AcquisitionScheduler) else None
         )
+        self._acquisition_executor = acquisition_executor
         self._acquisition_in_flight: dict[str, tuple[frozenset[FieldPath], float]] = {}
         self._queue = queue
         self._on_state_event = on_state_event
@@ -431,6 +400,19 @@ class RadioPoller:
             self._FAST_CMDS_SERIAL if self._is_serial else self._FAST_CMDS_LAN
         )
         self._STATE_QUERIES = self._build_state_queries()
+        if self._acquisition_executor is None:
+            raw_executor = getattr(radio, "__dict__", {}).get("_acquisition_executor")
+            execute = getattr(raw_executor, "execute", None)
+            if callable(execute):
+                self._acquisition_executor = cast(AcquisitionExecutor, raw_executor)
+        if (
+            self._acquisition_executor is None
+            and self._acquisition_scheduler is not None
+            and self._acquisition_scheduler.provider == "icom_civ"
+        ):
+            self._acquisition_executor = IcomCivAcquisitionExecutor(
+                self._send_one_state_query
+            )
         # Set by default — cleared at _run() start, re-set after initial fetch.
         # This prevents EnableScope from hanging in tests that don't call start().
         self._initial_fetch_done = asyncio.Event()
@@ -875,16 +857,18 @@ class RadioPoller:
                 # VFO slot on each receiver.  Fully gated (PTT, queue
                 # pressure, debounce, per-rx interval) so it cannot
                 # regress fast-poll cadence.
-                for _rx in range(self._profile.receiver_count):
-                    try:
-                        await self._poll_unselected_slot(_rx)
-                    except (ConnectionError, RadioConnectionError):
-                        _backoff = min(_backoff + 0.5, _MAX_BACKOFF)
-                        break
-                    except Exception:
-                        logger.debug(
-                            "radio-poller: unselected-slot poll error", exc_info=True
-                        )
+                if self._acquisition_scheduler is None:
+                    for _rx in range(self._profile.receiver_count):
+                        try:
+                            await self._poll_unselected_slot(_rx)
+                        except (ConnectionError, RadioConnectionError):
+                            _backoff = min(_backoff + 0.5, _MAX_BACKOFF)
+                            break
+                        except Exception:
+                            logger.debug(
+                                "radio-poller: unselected-slot poll error",
+                                exc_info=True,
+                            )
 
                 # 4. Wait for next cycle
                 await self._queue.wait(timeout=self._fast_interval)
@@ -2217,44 +2201,6 @@ class RadioPoller:
         except Exception:
             logger.debug("radio-poller: meter coalescer flush failed", exc_info=True)
 
-    def _query_for_acquisition_path(
-        self,
-        path: FieldPath,
-    ) -> tuple[int, int | None, int | None] | None:
-        receiver = _RECEIVER_IDS.get(path.receiver_id or "")
-        if path.scope.value == "receiver" and receiver is None:
-            return None
-        if path.scope.value == "receiver" and path.family.value == "freq_mode":
-            if path.name == "freq_hz":
-                return (0x25, None, receiver)
-            if path.name == "mode":
-                return (0x26, None, receiver)
-            return None
-        if path.scope.value == "receiver" and path.family.value == "meters":
-            if path.name == "s_meter":
-                return (0x15, 0x02, receiver)
-            return None
-        if (
-            path.scope.value == "receiver"
-            and path.family.value == "operator_controls"
-        ):
-            sub = _RECEIVER_LEVEL_QUERY_SUBS.get(path.name)
-            return None if sub is None else (0x14, sub, receiver)
-        if path.scope.value == "global" and path.family.value == "meters":
-            sub = _GLOBAL_METER_QUERY_SUBS.get(path.name)
-            return None if sub is None else (0x15, sub, None)
-        if path.scope.value == "global" and path.family.value == "tx_state":
-            if path.name == "ptt":
-                return (0x1C, 0x00, None)
-            return None
-        if (
-            path.scope.value == "global"
-            and path.family.value == "operator_controls"
-        ):
-            sub = _GLOBAL_LEVEL_QUERY_SUBS.get(path.name)
-            return None if sub is None else (0x14, sub, None)
-        return None
-
     def _acquisition_request_expired(
         self,
         request: AcquisitionRequest,
@@ -2291,43 +2237,64 @@ class RadioPoller:
                     now=now,
                 ):
                     self._record_state_diagnostic(
-                        "acquisition_resend",
+                        "acquisition_request_failed",
                         "web.radio_poller",
                         request_id=request.id,
                         paths=[str(path) for path in request.paths],
+                        reason="acquisition_request_timeout",
                     )
-                    sent_paths = frozenset()
+                    scheduler.record_acquisition_failure(
+                        request,
+                        reason="acquisition_request_timeout",
+                        failed_paths=sent_paths or frozenset(request.paths),
+                        now=now,
+                    )
+                    self._acquisition_in_flight.pop(request.id, None)
+                    continue
                 else:
                     sent_paths = sent_paths.intersection(request.paths)
-            paths_to_send = tuple(path for path in request.paths if path not in sent_paths)
-            if not paths_to_send:
+
+            if all(path in sent_paths for path in request.paths):
                 continue
 
-            newly_sent: list[FieldPath] = []
-            for path in paths_to_send:
-                query = self._query_for_acquisition_path(path)
-                if query is None:
-                    self._record_state_diagnostic(
-                        "acquisition_skip",
-                        "web.radio_poller",
-                        request_id=request.id,
-                        path=str(path),
-                        reason="no_civ_query_mapping",
-                    )
-                    continue
-                cmd_byte, sub_byte, receiver = query
+            executor = self._acquisition_executor
+            if executor is None:
                 self._record_state_diagnostic(
-                    "backend_read",
+                    "acquisition_executor_missing",
                     "web.radio_poller",
-                    family=path.family.value,
-                    path=str(path),
                     request_id=request.id,
-                    command=f"0x{cmd_byte:02x}",
-                    sub=None if sub_byte is None else f"0x{sub_byte:02x}",
-                    receiver=receiver,
+                    paths=[str(path) for path in request.paths],
+                    provider=request.provider,
                 )
-                await self._send_one_state_query(cmd_byte, sub_byte, receiver)
-                newly_sent.append(path)
+                scheduler.record_acquisition_failure(
+                    request,
+                    reason="acquisition_executor_missing",
+                    now=now,
+                )
+                continue
+
+            result = await executor.execute(
+                request,
+                already_sent_paths=sent_paths,
+            )
+            newly_sent = tuple(result.sent_paths)
+            failed_paths = tuple(result.failed_paths)
+            if failed_paths:
+                reason = result.failure_reason or "acquisition_request_failed"
+                self._record_state_diagnostic(
+                    "acquisition_request_failed",
+                    "web.radio_poller",
+                    request_id=request.id,
+                    paths=[str(path) for path in failed_paths],
+                    reason=reason,
+                    provider=request.provider,
+                )
+                scheduler.record_acquisition_failure(
+                    request,
+                    reason=reason,
+                    failed_paths=failed_paths,
+                    now=now,
+                )
 
             if newly_sent:
                 self._acquisition_in_flight[request.id] = (

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+from dataclasses import replace
 from typing import TYPE_CHECKING, Any, Callable
 
 from ..exceptions import CommandError
@@ -73,7 +74,12 @@ from ..core.command_service import (
     command_intent_from_request,
     command_response_observation,
 )
-from ..core.state_pipeline_contracts import CommandSource
+from ..core.acquisition_scheduler import (
+    AcquisitionRequest,
+    AcquisitionScheduler,
+    MeterObservationCoalescer,
+)
+from ..core.state_pipeline_contracts import ChangeSet, CommandSource, FieldPath
 from ..core.state_diagnostics import StateDiagnosticsRecorder
 from ..core.state_store import StateStore
 from .._state_queries import build_state_queries
@@ -172,6 +178,40 @@ _DEFAULT_POLL_FIELD_TTL: float = 0.2
 _FAST_INTERVAL: float = 0.025  # meters — wfview queue interval for LAN (25ms)
 _FAST_INTERVAL_SERIAL: float = 0.100  # serial: 10 polls/sec for responsive meters
 _SLOW_INTERVAL: float = 0.25  # levels/settings — rarely change
+
+_RECEIVER_IDS: dict[str, int] = {
+    "0": 0,
+    "main": 0,
+    "1": 1,
+    "sub": 1,
+}
+_RECEIVER_LEVEL_QUERY_SUBS: dict[str, int] = {
+    "af_level": 0x01,
+    "rf_gain": 0x02,
+    "squelch": 0x03,
+    "apf_type_level": 0x05,
+    "nr_level": 0x06,
+    "pbt_inner": 0x07,
+    "pbt_outer": 0x08,
+    "nb_level": 0x12,
+    "digisel_shift": 0x13,
+}
+_GLOBAL_LEVEL_QUERY_SUBS: dict[str, int] = {
+    "power_level": 0x0A,
+    "mic_gain": 0x0B,
+    "notch_filter": 0x0D,
+    "compressor_level": 0x0E,
+    "break_in_delay": 0x0F,
+    "drive_gain": 0x14,
+    "monitor_gain": 0x15,
+    "vox_gain": 0x16,
+    "anti_vox_gain": 0x17,
+}
+_GLOBAL_METER_QUERY_SUBS: dict[str, int] = {
+    "power": 0x11,
+    "swr": 0x12,
+    "alc": 0x13,
+}
 
 
 def _audio_tx_codec_and_rate(radio: Any) -> tuple[AudioCodec | None, int]:
@@ -368,6 +408,11 @@ class RadioPoller:
         self._radio_state = radio_state
         self._state_diagnostics = diagnostics
         self._state_store = state_store or StateStore()
+        raw_scheduler = getattr(radio, "_acquisition_scheduler", None)
+        self._acquisition_scheduler = (
+            raw_scheduler if isinstance(raw_scheduler, AcquisitionScheduler) else None
+        )
+        self._acquisition_in_flight: dict[str, tuple[frozenset[FieldPath], float]] = {}
         self._queue = queue
         self._on_state_event = on_state_event
         self._poll_index: int = 0
@@ -2160,7 +2205,160 @@ class RadioPoller:
             return self._HIGH_TIER_RX[0]
         return self._HIGH_TIER_TX[high_idx % len(self._HIGH_TIER_TX)]
 
+    def _flush_due_meter_observations(self) -> None:
+        coalescer = getattr(self._radio, "_meter_observation_coalescer", None)
+        if not isinstance(coalescer, MeterObservationCoalescer):
+            return
+        runtime = getattr(self._radio, "_civ_runtime", None)
+        flush_due = getattr(runtime, "flush_due_meter_observations", None)
+        if not callable(flush_due):
+            return
+        try:
+            flush_due(now=time.monotonic())
+        except Exception:
+            logger.debug("radio-poller: meter coalescer flush failed", exc_info=True)
+
+    def _query_for_acquisition_path(
+        self,
+        path: FieldPath,
+    ) -> tuple[int, int | None, int | None] | None:
+        receiver = _RECEIVER_IDS.get(path.receiver_id or "")
+        if path.scope.value == "receiver" and receiver is None:
+            return None
+        if path.scope.value == "receiver" and path.family.value == "freq_mode":
+            if path.name == "freq_hz":
+                return (0x03, None, receiver)
+            if path.name == "mode":
+                return (0x04, None, receiver)
+            return None
+        if path.scope.value == "receiver" and path.family.value == "meters":
+            if path.name == "s_meter":
+                return (0x15, 0x02, receiver)
+            return None
+        if (
+            path.scope.value == "receiver"
+            and path.family.value == "operator_controls"
+        ):
+            sub = _RECEIVER_LEVEL_QUERY_SUBS.get(path.name)
+            return None if sub is None else (0x14, sub, receiver)
+        if path.scope.value == "global" and path.family.value == "meters":
+            sub = _GLOBAL_METER_QUERY_SUBS.get(path.name)
+            return None if sub is None else (0x15, sub, None)
+        if (
+            path.scope.value == "global"
+            and path.family.value == "operator_controls"
+        ):
+            sub = _GLOBAL_LEVEL_QUERY_SUBS.get(path.name)
+            return None if sub is None else (0x14, sub, None)
+        return None
+
+    def _empty_acquisition_changeset(self, *, now: float) -> ChangeSet:
+        snapshot = self._state_store.snapshot()
+        return ChangeSet(
+            revision=snapshot.state_revision,
+            freshness_revision=snapshot.freshness_revision,
+            observation_seq=snapshot.observation_seq,
+            changes=(),
+            timestamp_monotonic=now,
+            sources=(),
+        )
+
+    def _acquisition_request_expired(
+        self,
+        request: AcquisitionRequest,
+        *,
+        sent_at: float,
+        now: float,
+    ) -> bool:
+        deadlines = [request.deadline_monotonic]
+        if request.timeout is not None:
+            deadlines.append(sent_at + request.timeout)
+        return now >= min(deadlines)
+
+    async def _send_scheduler_requests(self) -> None:
+        scheduler = self._acquisition_scheduler
+        if scheduler is None:
+            return
+        now = time.monotonic()
+        scheduler.due_requests(now=now)
+        pending = scheduler.pending_requests()
+        pending_ids = {request.id for request in pending}
+        for request_id in tuple(self._acquisition_in_flight):
+            if request_id not in pending_ids:
+                del self._acquisition_in_flight[request_id]
+
+        for request in pending:
+            sent_paths: frozenset[FieldPath] = frozenset()
+            sent_at = 0.0
+            existing = self._acquisition_in_flight.get(request.id)
+            if existing is not None:
+                sent_paths, sent_at = existing
+                if self._acquisition_request_expired(
+                    request,
+                    sent_at=sent_at,
+                    now=now,
+                ):
+                    self._record_state_diagnostic(
+                        "acquisition_resend",
+                        "web.radio_poller",
+                        request_id=request.id,
+                        paths=[str(path) for path in request.paths],
+                    )
+                    sent_paths = frozenset()
+                else:
+                    sent_paths = sent_paths.intersection(request.paths)
+            paths_to_send = tuple(path for path in request.paths if path not in sent_paths)
+            if not paths_to_send:
+                continue
+
+            newly_sent: list[FieldPath] = []
+            for path in paths_to_send:
+                query = self._query_for_acquisition_path(path)
+                if query is None:
+                    self._record_state_diagnostic(
+                        "acquisition_skip",
+                        "web.radio_poller",
+                        request_id=request.id,
+                        path=str(path),
+                        reason="no_civ_query_mapping",
+                    )
+                    scheduler.record_acquisition_result(
+                        replace(request, paths=(path,)),
+                        self._empty_acquisition_changeset(now=now),
+                    )
+                    continue
+                cmd_byte, sub_byte, receiver = query
+                self._record_state_diagnostic(
+                    "backend_read",
+                    "web.radio_poller",
+                    family=path.family.value,
+                    path=str(path),
+                    request_id=request.id,
+                    command=f"0x{cmd_byte:02x}",
+                    sub=None if sub_byte is None else f"0x{sub_byte:02x}",
+                    receiver=receiver,
+                )
+                await self._send_one_state_query(cmd_byte, sub_byte, receiver)
+                newly_sent.append(path)
+
+            if newly_sent:
+                self._acquisition_in_flight[request.id] = (
+                    sent_paths.union(newly_sent),
+                    now,
+                )
+                self._record_state_diagnostic(
+                    "acquisition_request_sent",
+                    "web.radio_poller",
+                    request_id=request.id,
+                    paths=[str(path) for path in newly_sent],
+                    pending_request_count=len(scheduler.pending_requests()),
+                )
+
     async def _send_query(self) -> None:
+        self._flush_due_meter_observations()
+        if self._acquisition_scheduler is not None:
+            await self._send_scheduler_requests()
+            return
         # Even cycles → meter query; odd cycles → state query.
         if self._poll_index % 2 == 0:
             if self._is_serial:

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -77,8 +77,8 @@ from ..core.acquisition_scheduler import (
     AcquisitionExecutor,
     AcquisitionRequest,
     AcquisitionScheduler,
-    IcomCivAcquisitionExecutor,
     MeterObservationCoalescer,
+    civ_acquisition_executor_for_provider,
 )
 from ..core.state_pipeline_contracts import CommandSource, FieldPath
 from ..core.state_diagnostics import StateDiagnosticsRecorder
@@ -408,10 +408,10 @@ class RadioPoller:
         if (
             self._acquisition_executor is None
             and self._acquisition_scheduler is not None
-            and self._acquisition_scheduler.provider == "icom_civ"
         ):
-            self._acquisition_executor = IcomCivAcquisitionExecutor(
-                self._send_one_state_query
+            self._acquisition_executor = civ_acquisition_executor_for_provider(
+                self._acquisition_scheduler.provider,
+                self._send_one_state_query,
             )
         # Set by default — cleared at _run() start, re-set after initial fetch.
         # This prevents EnableScope from hanging in tests that don't call start().

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -401,6 +401,39 @@ class RadioPoller:
         else:
             self._state_store.apply(observation)
 
+    def _apply_compatibility_mirror(
+        self,
+        apply: Callable[["RadioState"], None],
+    ) -> None:
+        """Mirror confirmed state into legacy RadioState delivery surfaces.
+
+        CommandService/StateStore observations remain the source of truth for
+        lifecycle, overlays, and reconciliation. This mirror only keeps the
+        existing web delivery path fed until MOR-341 finishes that migration.
+        """
+
+        state = self._radio_state
+        if state is None:
+            return
+        apply(state)
+        self.bump_revision()
+
+    def _mark_queued_command_failed(
+        self,
+        entry: CommandQueueEntry,
+        exc: BaseException,
+        *,
+        timed_out: bool = False,
+    ) -> None:
+        if entry.command_service is None or entry.command_id is None:
+            return
+        message = str(exc) or None
+        entry.command_service.fail_command(
+            entry.command_id,
+            message=message,
+            timed_out=timed_out,
+        )
+
     def start(self) -> None:
         if self._task is not None and not self._task.done():
             return
@@ -705,11 +738,26 @@ class RadioPoller:
                             if entry.future is not None and not entry.future.done():
                                 entry.future.set_result(None)
                             _backoff = 0.0
+                        except TimeoutError as exc:
+                            self._mark_queued_command_failed(
+                                entry,
+                                exc,
+                                timed_out=True,
+                            )
+                            if entry.future is not None and not entry.future.done():
+                                entry.future.set_exception(exc)
+                            logger.warning(
+                                "radio-poller: cmd timeout: %s",
+                                type(cmd).__name__,
+                                exc_info=True,
+                            )
                         except (ConnectionError, RadioConnectionError) as exc:
+                            self._mark_queued_command_failed(entry, exc)
                             if entry.future is not None and not entry.future.done():
                                 entry.future.set_exception(exc)
                             _backoff = min(_backoff + 0.5, _MAX_BACKOFF)
                         except Exception as exc:
+                            self._mark_queued_command_failed(entry, exc)
                             if entry.future is not None and not entry.future.done():
                                 entry.future.set_exception(exc)
                             logger.warning(
@@ -951,12 +999,13 @@ class RadioPoller:
                     source=source,
                     command_service=command_service,
                 )
-                if self._radio_state:
-                    target = (
-                        self._radio_state.sub if rx != 0 else self._radio_state.main
+                self._apply_compatibility_mirror(
+                    lambda state: setattr(
+                        state.sub if rx != 0 else state.main,
+                        "filter_width",
+                        width,
                     )
-                    target.filter_width = width
-                    self.bump_revision()
+                )
                 if self._on_state_event:
                     self._on_state_event(
                         "filter_width_changed", {"width": width, "receiver": rx}
@@ -1094,12 +1143,13 @@ class RadioPoller:
                         source=source,
                         command_service=command_service,
                     )
-                if self._radio_state:
-                    target = (
-                        self._radio_state.sub if rx != 0 else self._radio_state.main
+                self._apply_compatibility_mirror(
+                    lambda state: setattr(
+                        state.sub if rx != 0 else state.main,
+                        "nb",
+                        on,
                     )
-                    target.nb = on
-                    self.bump_revision()
+                )
                 if self._on_state_event:
                     self._on_state_event("nb_changed", {"on": on, "receiver": rx})
             case SetNR(on=on, receiver=rx):
@@ -1113,12 +1163,13 @@ class RadioPoller:
                         source=source,
                         command_service=command_service,
                     )
-                if self._radio_state:
-                    target = (
-                        self._radio_state.sub if rx != 0 else self._radio_state.main
+                self._apply_compatibility_mirror(
+                    lambda state: setattr(
+                        state.sub if rx != 0 else state.main,
+                        "nr",
+                        on,
                     )
-                    target.nr = on
-                    self.bump_revision()
+                )
                 if self._on_state_event:
                     self._on_state_event("nr_changed", {"on": on, "receiver": rx})
             case SetDigiSel(on=on, receiver=rx):
@@ -1174,12 +1225,13 @@ class RadioPoller:
                     source=source,
                     command_service=command_service,
                 )
-                if self._radio_state:
-                    target = (
-                        self._radio_state.sub if rx != 0 else self._radio_state.main
+                self._apply_compatibility_mirror(
+                    lambda state: setattr(
+                        state.sub if rx != 0 else state.main,
+                        "pbt_inner",
+                        level,
                     )
-                    target.pbt_inner = level
-                    self.bump_revision()
+                )
                 if self._on_state_event:
                     self._on_state_event(
                         "pbt_inner_changed", {"level": level, "receiver": rx}
@@ -1193,12 +1245,13 @@ class RadioPoller:
                     source=source,
                     command_service=command_service,
                 )
-                if self._radio_state:
-                    target = (
-                        self._radio_state.sub if rx != 0 else self._radio_state.main
+                self._apply_compatibility_mirror(
+                    lambda state: setattr(
+                        state.sub if rx != 0 else state.main,
+                        "pbt_outer",
+                        level,
                     )
-                    target.pbt_outer = level
-                    self.bump_revision()
+                )
                 if self._on_state_event:
                     self._on_state_event(
                         "pbt_outer_changed", {"level": level, "receiver": rx}

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -68,9 +68,11 @@ from ..capabilities import (
 )
 from .._queue_pressure import PRESSURE_THRESHOLD
 from ..core.command_service import (
+    CommandService,
     command_intent_from_request,
     command_response_observation,
 )
+from ..core.state_pipeline_contracts import CommandSource
 from ..core.state_diagnostics import StateDiagnosticsRecorder
 from ..core.state_store import StateStore
 from .._state_queries import build_state_queries
@@ -84,6 +86,7 @@ if TYPE_CHECKING:
 __all__ = [
     "RadioPoller",
     "CommandQueue",
+    "CommandQueueEntry",
     "SetAgcTimeConstant",
     "SetDataMode",
     "SetFilterWidth",
@@ -187,6 +190,7 @@ def _audio_tx_codec_and_rate(radio: Any) -> tuple[AudioCodec | None, int]:
 from .._poller_types import (  # noqa: E402
     Command,
     CommandQueue,
+    CommandQueueEntry,
     DisableScope,
     EnableScope,
     MemoryClear,
@@ -374,22 +378,28 @@ class RadioPoller:
         self,
         name: str,
         params: dict[str, Any],
+        *,
+        command_id: str | None = None,
+        source: CommandSource = "websocket",
+        command_service: CommandService | None = None,
     ) -> None:
         intent = command_intent_from_request(
             name,
             params,
-            source="websocket",
-            command_id=f"web-poller-{name}-{time.monotonic_ns()}",
+            source=source,
+            command_id=command_id or f"web-poller-{name}-{time.monotonic_ns()}",
         )
         if intent.target is None:
             return
-        self._state_store.apply(
-            command_response_observation(
-                intent,
-                timestamp_monotonic=time.monotonic(),
-                provider="web_poller",
-            )
+        observation = command_response_observation(
+            intent,
+            timestamp_monotonic=time.monotonic(),
+            provider="web_poller",
         )
+        if command_service is not None:
+            command_service.apply_observation(observation)
+        else:
+            self._state_store.apply(observation)
 
     def start(self) -> None:
         if self._task is not None and not self._task.done():
@@ -686,7 +696,12 @@ class RadioPoller:
                             )
                             continue
                         try:
-                            await self._execute(cmd)
+                            await self._execute(
+                                cmd,
+                                command_id=entry.command_id,
+                                source=entry.source or "websocket",
+                                command_service=entry.command_service,
+                            )
                             if entry.future is not None and not entry.future.done():
                                 entry.future.set_result(None)
                             _backoff = 0.0
@@ -787,7 +802,14 @@ class RadioPoller:
         _active = getattr(rs, "active", None) if rs is not None else None
         return _active if isinstance(_active, str) else "MAIN"
 
-    async def _execute(self, cmd: Command) -> None:
+    async def _execute(
+        self,
+        cmd: Command,
+        *,
+        command_id: str | None = None,
+        source: CommandSource = "websocket",
+        command_service: CommandService | None = None,
+    ) -> None:
         radio = self._radio
         _r: Any = radio  # cast for capability methods not on base Radio protocol
         from ..radio_protocol import (
@@ -839,6 +861,9 @@ class RadioPoller:
                 self._apply_command_response_observation(
                     "set_freq",
                     {"freq": freq, "receiver": rx},
+                    command_id=command_id,
+                    source=source,
+                    command_service=command_service,
                 )
                 # Compatibility mirror until web state delivery reads StateStore.
                 if self._radio_state:
@@ -884,6 +909,9 @@ class RadioPoller:
                 self._apply_command_response_observation(
                     "set_mode",
                     {"mode": mode, "filter_width": fw, "receiver": rx},
+                    command_id=command_id,
+                    source=source,
+                    command_service=command_service,
                 )
                 # Compatibility mirror until web state delivery reads StateStore.
                 if self._radio_state:
@@ -900,6 +928,13 @@ class RadioPoller:
                 if CAP_FILTER_WIDTH in self._caps:
                     self._ensure_receiver_supported(rx, operation="set_filter")
                     await radio.set_filter(fn, receiver=rx)
+                    self._apply_command_response_observation(
+                        "set_filter",
+                        {"filter_num": fn, "receiver": rx},
+                        command_id=command_id,
+                        source=source,
+                        command_service=command_service,
+                    )
             case SetFilterWidth(width=width, receiver=rx):
                 self._ensure_receiver_supported(rx, operation="set_filter_width")
                 if not 50 <= width <= 10000:
@@ -909,6 +944,13 @@ class RadioPoller:
                 # Hz↔index translation, profile-aware bounds + cmd29 wrapping
                 # are owned by the backend (P2-04). Issue #1101.
                 await radio.set_filter_width(width, receiver=rx)
+                self._apply_command_response_observation(
+                    "set_filter_width",
+                    {"width": width, "receiver": rx},
+                    command_id=command_id,
+                    source=source,
+                    command_service=command_service,
+                )
                 if self._radio_state:
                     target = (
                         self._radio_state.sub if rx != 0 else self._radio_state.main
@@ -958,9 +1000,23 @@ class RadioPoller:
                     except Exception as e:
                         logger.warning("poller: start TX audio failed: %s", e)
                 await radio.set_ptt(True)
+                self._apply_command_response_observation(
+                    "ptt_on",
+                    {},
+                    command_id=command_id,
+                    source=source,
+                    command_service=command_service,
+                )
             case PttOff():
                 logger.info("poller: PTT OFF")
                 await radio.set_ptt(False)
+                self._apply_command_response_observation(
+                    "ptt_off",
+                    {},
+                    command_id=command_id,
+                    source=source,
+                    command_service=command_service,
+                )
                 # Stop TX audio stream after PTT, then restart RX
                 if CAP_AUDIO in self._caps:
                     try:
@@ -987,22 +1043,57 @@ class RadioPoller:
                     )
                 if CAP_POWER_CONTROL in self._caps:
                     await radio.set_rf_power(level)
+                    self._apply_command_response_observation(
+                        "set_rf_power",
+                        {"level": level},
+                        command_id=command_id,
+                        source=source,
+                        command_service=command_service,
+                    )
             case SetRfGain(level=level, receiver=rx):
                 if CAP_RF_GAIN in self._caps:
                     self._ensure_receiver_supported(rx, operation="set_rf_gain")
                     await radio.set_rf_gain(level, receiver=rx)
+                    self._apply_command_response_observation(
+                        "set_rf_gain",
+                        {"level": level, "receiver": rx},
+                        command_id=command_id,
+                        source=source,
+                        command_service=command_service,
+                    )
             case SetAfLevel(level=level, receiver=rx):
                 if CAP_AF_LEVEL in self._caps:
                     self._ensure_receiver_supported(rx, operation="set_af_level")
                     await radio.set_af_level(level, receiver=rx)
+                    self._apply_command_response_observation(
+                        "set_af_level",
+                        {"level": level, "receiver": rx},
+                        command_id=command_id,
+                        source=source,
+                        command_service=command_service,
+                    )
             case SetSquelch(level=level, receiver=rx):
                 if CAP_SQUELCH in self._caps:
                     self._ensure_receiver_supported(rx, operation="set_squelch")
                     await radio.set_squelch(level, receiver=rx)
+                    self._apply_command_response_observation(
+                        "set_squelch",
+                        {"level": level, "receiver": rx},
+                        command_id=command_id,
+                        source=source,
+                        command_service=command_service,
+                    )
             case SetNB(on=on, receiver=rx):
                 self._ensure_receiver_supported(rx, operation="set_nb")
                 if CAP_NB in self._caps:
                     await radio.set_nb(on, receiver=rx)
+                    self._apply_command_response_observation(
+                        "set_nb",
+                        {"on": on, "receiver": rx},
+                        command_id=command_id,
+                        source=source,
+                        command_service=command_service,
+                    )
                 if self._radio_state:
                     target = (
                         self._radio_state.sub if rx != 0 else self._radio_state.main
@@ -1015,6 +1106,13 @@ class RadioPoller:
                 self._ensure_receiver_supported(rx, operation="set_nr")
                 if CAP_NR in self._caps:
                     await radio.set_nr(on, receiver=rx)
+                    self._apply_command_response_observation(
+                        "set_nr",
+                        {"on": on, "receiver": rx},
+                        command_id=command_id,
+                        source=source,
+                        command_service=command_service,
+                    )
                 if self._radio_state:
                     target = (
                         self._radio_state.sub if rx != 0 else self._radio_state.main
@@ -1069,6 +1167,13 @@ class RadioPoller:
                     )
             case SetPbtInner(level=level, receiver=rx):
                 await _r.set_pbt_inner(level, receiver=rx)
+                self._apply_command_response_observation(
+                    "set_pbt_inner",
+                    {"level": level, "receiver": rx},
+                    command_id=command_id,
+                    source=source,
+                    command_service=command_service,
+                )
                 if self._radio_state:
                     target = (
                         self._radio_state.sub if rx != 0 else self._radio_state.main
@@ -1081,6 +1186,13 @@ class RadioPoller:
                     )
             case SetPbtOuter(level=level, receiver=rx):
                 await _r.set_pbt_outer(level, receiver=rx)
+                self._apply_command_response_observation(
+                    "set_pbt_outer",
+                    {"level": level, "receiver": rx},
+                    command_id=command_id,
+                    source=source,
+                    command_service=command_service,
+                )
                 if self._radio_state:
                     target = (
                         self._radio_state.sub if rx != 0 else self._radio_state.main
@@ -1290,7 +1402,16 @@ class RadioPoller:
                     self._on_state_event("rit_freq_changed", {"hz": freq})
             case SetSplit(on=on):
                 await _r.set_split(on)
+                self._apply_command_response_observation(
+                    "set_split",
+                    {"on": on},
+                    command_id=command_id,
+                    source=source,
+                    command_service=command_service,
+                )
                 if self._radio_state:
+                    # Compatibility mirror until web state delivery reads
+                    # split directly from StateStore.
                     self._radio_state.split = on
                     self.bump_revision()
                 if self._on_state_event:
@@ -1459,6 +1580,17 @@ class RadioPoller:
                                 "radio-poller: scope follow failed",
                                 exc_info=True,
                             )
+                self._apply_command_response_observation(
+                    "set_vfo",
+                    {"vfo": vfo},
+                    command_id=command_id,
+                    source=source,
+                    command_service=command_service,
+                )
+                if self._radio_state is not None:
+                    # Compatibility mirror until web state delivery reads the
+                    # active-slot projection from StateStore.
+                    self._radio_state.main.active_slot = "B" if is_sub else "A"
                 if self._on_state_event:
                     self._on_state_event("vfo_changed", {"vfo": vfo})
             case VfoSwap():
@@ -1578,6 +1710,13 @@ class RadioPoller:
             case SetPowerstat(on=on):
                 if CAP_POWER_CONTROL in self._caps:
                     await radio.set_powerstat(on)
+                    self._apply_command_response_observation(
+                        "set_powerstat",
+                        {"on": on},
+                        command_id=command_id,
+                        source=source,
+                        command_service=command_service,
+                    )
                     # Optimistic update: radio won't respond to polls when off
                     if self._radio_state is not None:
                         self._radio_state.power_on = on

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -458,17 +458,10 @@ class RadioPoller:
         params: dict[str, Any] = {
             "message": message,
             "timed_out": timed_out,
+            "session_id": entry.session_id,
         }
         if entry.source is not None:
             params["source"] = entry.source
-            for event in reversed(entry.command_service.lifecycle_events()):
-                if (
-                    event.command_id == entry.command_id
-                    and event.source == entry.source
-                    and "session_id" in (event.details or {})
-                ):
-                    params["session_id"] = event.details["session_id"]
-                    break
         entry.command_service.fail_command(
             entry.command_id,
             **params,

--- a/src/rigplane/web/runtime_helpers.py
+++ b/src/rigplane/web/runtime_helpers.py
@@ -34,6 +34,20 @@ _SNAPSHOT_RECEIVER_IDS = {
     "sub": "sub",
 }
 _EMPTY_STATE_DICT = RadioState().to_dict()
+_RECEIVER_FREQ_MODE_FIELDS = {
+    "freq_hz": "freq",
+    "mode": "mode",
+    "filter": "filter",
+    "filter_num": "filter",
+    "data_mode": "data_mode",
+    "filter_width": "filter_width",
+}
+_VFO_SLOT_FIELDS = {
+    "freq_hz": "freq_hz",
+    "mode": "mode",
+    "filter_num": "filter_num",
+    "data_mode": "data_mode",
+}
 _RECEIVER_OPERATOR_CONTROL_FIELDS = {
     "af_level",
     "rf_gain",
@@ -46,10 +60,17 @@ _RECEIVER_OPERATOR_CONTROL_FIELDS = {
     "nb_level",
     "filter_width",
     "if_shift",
+    "agc",
     "agc_time_constant",
+    "audio_peak_filter",
     "apf_type_level",
+    "apf_freq",
+    "filter_shape",
+    "manual_notch_freq",
     "manual_notch_width",
     "digisel_shift",
+    "tone_freq",
+    "tsql_freq",
     "key_speed",
     "cw_pitch",
     "monitor_gain",
@@ -69,6 +90,19 @@ _RECEIVER_OPERATOR_TOGGLE_FIELDS = {
     "audio_peak_filter",
     "twin_peak_filter",
     "af_mute",
+    "ipplus",
+    "s_meter_sql_open",
+    "apf_on",
+    "narrow",
+    "repeater_tone",
+    "repeater_tsql",
+}
+_RECEIVER_SLOW_STATE_FIELDS = {
+    "vfo_a",
+    "vfo_b",
+    "active_slot",
+    "filter",
+    "contour",
 }
 _GLOBAL_TX_FIELDS = {
     "ptt",
@@ -88,12 +122,24 @@ _GLOBAL_OPERATOR_CONTROL_FIELDS = {
     "power_level",
     "tuner_status",
     "rit_freq",
+    "cw_pitch",
+    "mic_gain",
+    "key_speed",
+    "notch_filter",
+    "compressor_level",
+    "break_in_delay",
+    "break_in",
+    "drive_gain",
+    "monitor_gain",
+    "vox_gain",
+    "anti_vox_gain",
+    "vox_delay",
     "ssb_tx_bandwidth",
     "ref_adjust",
     "dash_ratio",
     "nb_depth",
     "nb_width",
-    "drive_gain",
+    "tx_antenna",
 }
 _GLOBAL_METER_FIELDS = {
     "alc",
@@ -102,6 +148,21 @@ _GLOBAL_METER_FIELDS = {
     "comp",
     "vd",
     "id",
+}
+_GLOBAL_SLOW_STATE_FIELDS = {
+    "active",
+    "scanning",
+    "scan_type",
+    "scan_resume_mode",
+    "tuning_step",
+    "overflow",
+    "cw_spot",
+    "vfo_select",
+    "rx_antenna_1",
+    "rx_antenna_2",
+    "tx_band_edges",
+    "scope_controls",
+    "yaesu",
 }
 
 
@@ -373,17 +434,26 @@ def _apply_snapshot_field(
         if receiver_key is None:
             return
         if path.family is FieldFamily.FREQ_MODE:
+            if path.slot in (VfoSlot.A, VfoSlot.B):
+                receiver = state.get(receiver_key)
+                if not isinstance(receiver, dict):
+                    return
+                slot_key = "vfo_a" if path.slot is VfoSlot.A else "vfo_b"
+                slot_state = receiver.get(slot_key)
+                if not isinstance(slot_state, dict):
+                    return
+                target = _VFO_SLOT_FIELDS.get(path.name)
+                if target is not None:
+                    slot_state[target] = value
+                return
             if path.slot not in (None, VfoSlot.ACTIVE):
                 return
-            mapping = {
-                "freq_hz": "freq",
-                "mode": "mode",
-                "data_mode": "data_mode",
-                "filter_width": "filter_width",
-            }
-            target = mapping.get(path.name)
+            target = _RECEIVER_FREQ_MODE_FIELDS.get(path.name)
             if target is not None:
                 _set_receiver_value(state, receiver_key, target, value)
+            return
+        if path.family is FieldFamily.VFO and path.name == "active_slot":
+            _set_receiver_value(state, receiver_key, "active_slot", value)
             return
         if path.family is FieldFamily.METERS and path.name == "s_meter":
             _set_receiver_value(state, receiver_key, "s_meter", value)
@@ -409,6 +479,12 @@ def _apply_snapshot_field(
             else:
                 _set_receiver_value(state, receiver_key, path.name, value)
             return
+        if (
+            path.family is FieldFamily.SLOW_STATE
+            and path.name in _RECEIVER_SLOW_STATE_FIELDS
+        ):
+            _set_receiver_value(state, receiver_key, path.name, value)
+            return
 
     if path.scope is FieldScope.GLOBAL:
         if path.family is FieldFamily.TX_STATE and path.name in _GLOBAL_TX_FIELDS:
@@ -422,6 +498,12 @@ def _apply_snapshot_field(
             return
         if path.family is FieldFamily.METERS and path.name in _GLOBAL_METER_FIELDS:
             state[f"{path.name}_meter"] = value
+            return
+        if (
+            path.family is FieldFamily.SLOW_STATE
+            and path.name in _GLOBAL_SLOW_STATE_FIELDS
+        ):
+            state[path.name] = value
             return
 
     if path.scope is FieldScope.SCOPE_CONTROLS and path.family is FieldFamily.DISPLAY:

--- a/src/rigplane/web/runtime_helpers.py
+++ b/src/rigplane/web/runtime_helpers.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import copy
 import datetime
 import time
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
+from ..core.state_pipeline_contracts import FieldFamily, FieldScope, FieldPath, VfoSlot
+from ..core.state_store import StateSnapshot
 from ..radio_protocol import (
     AudioCapable,
     DualReceiverCapable,
@@ -20,9 +23,86 @@ __all__ = [
     "radio_ready",
     "classify_radio_health",
     "build_public_state_payload",
+    "build_public_state_payload_from_snapshot",
 ]
 
 _RECEIVER_KEY_MAP = {"freq": "freqHz"}
+_SNAPSHOT_RECEIVER_IDS = {
+    "0": "main",
+    "1": "sub",
+    "main": "main",
+    "sub": "sub",
+}
+_EMPTY_STATE_DICT = RadioState().to_dict()
+_RECEIVER_OPERATOR_CONTROL_FIELDS = {
+    "af_level",
+    "rf_gain",
+    "squelch",
+    "att",
+    "preamp",
+    "pbt_inner",
+    "pbt_outer",
+    "nr_level",
+    "nb_level",
+    "filter_width",
+    "if_shift",
+    "agc_time_constant",
+    "apf_type_level",
+    "manual_notch_width",
+    "digisel_shift",
+    "key_speed",
+    "cw_pitch",
+    "monitor_gain",
+    "mic_gain",
+    "compressor_level",
+    "break_in_delay",
+    "vox_gain",
+    "anti_vox_gain",
+    "vox_delay",
+}
+_RECEIVER_OPERATOR_TOGGLE_FIELDS = {
+    "nb",
+    "nr",
+    "digisel",
+    "manual_notch",
+    "auto_notch",
+    "audio_peak_filter",
+    "twin_peak_filter",
+    "af_mute",
+}
+_GLOBAL_TX_FIELDS = {
+    "ptt",
+    "power_on",
+    "split",
+    "dual_watch",
+    "rit_on",
+    "rit_tx",
+    "monitor_on",
+    "vox_on",
+    "compressor_on",
+    "main_sub_tracking",
+    "dial_lock",
+    "tx_freq_monitor",
+}
+_GLOBAL_OPERATOR_CONTROL_FIELDS = {
+    "power_level",
+    "tuner_status",
+    "rit_freq",
+    "ssb_tx_bandwidth",
+    "ref_adjust",
+    "dash_ratio",
+    "nb_depth",
+    "nb_width",
+    "drive_gain",
+}
+_GLOBAL_METER_FIELDS = {
+    "alc",
+    "power",
+    "swr",
+    "comp",
+    "vd",
+    "id",
+}
 
 
 def runtime_capabilities(radio: "Radio | None") -> set[str]:
@@ -265,11 +345,169 @@ def _camel_case_state(d: dict[str, Any]) -> dict[str, Any]:
     return result
 
 
+def _snapshot_receiver_key(receiver_id: str | None) -> str | None:
+    if receiver_id is None:
+        return None
+    return _SNAPSHOT_RECEIVER_IDS.get(receiver_id)
+
+
+def _set_receiver_value(
+    state: dict[str, Any],
+    receiver_key: str,
+    name: str,
+    value: Any,
+) -> None:
+    receiver = state.get(receiver_key)
+    if not isinstance(receiver, dict):
+        return
+    receiver[name] = value
+
+
+def _apply_snapshot_field(
+    state: dict[str, Any],
+    path: FieldPath,
+    value: Any,
+) -> None:
+    if path.scope is FieldScope.RECEIVER:
+        receiver_key = _snapshot_receiver_key(path.receiver_id)
+        if receiver_key is None:
+            return
+        if path.family is FieldFamily.FREQ_MODE:
+            if path.slot not in (None, VfoSlot.ACTIVE):
+                return
+            mapping = {
+                "freq_hz": "freq",
+                "mode": "mode",
+                "data_mode": "data_mode",
+                "filter_width": "filter_width",
+            }
+            target = mapping.get(path.name)
+            if target is not None:
+                _set_receiver_value(state, receiver_key, target, value)
+            return
+        if path.family is FieldFamily.METERS and path.name == "s_meter":
+            _set_receiver_value(state, receiver_key, "s_meter", value)
+            return
+        if (
+            path.family is FieldFamily.OPERATOR_CONTROLS
+            and path.name in _RECEIVER_OPERATOR_CONTROL_FIELDS
+        ):
+            _set_receiver_value(state, receiver_key, path.name, value)
+            return
+        if (
+            path.family is FieldFamily.OPERATOR_TOGGLES
+            and path.name in _RECEIVER_OPERATOR_TOGGLE_FIELDS
+        ):
+            if path.name == "audio_peak_filter":
+                _set_receiver_value(state, receiver_key, "audio_peak_filter", value)
+            elif path.name == "twin_peak_filter":
+                _set_receiver_value(state, receiver_key, "twin_peak_filter", value)
+            elif path.name == "auto_notch":
+                _set_receiver_value(state, receiver_key, "auto_notch", value)
+            elif path.name == "af_mute":
+                _set_receiver_value(state, receiver_key, "af_mute", value)
+            else:
+                _set_receiver_value(state, receiver_key, path.name, value)
+            return
+
+    if path.scope is FieldScope.GLOBAL:
+        if path.family is FieldFamily.TX_STATE and path.name in _GLOBAL_TX_FIELDS:
+            state[path.name] = value
+            return
+        if (
+            path.family is FieldFamily.OPERATOR_CONTROLS
+            and path.name in _GLOBAL_OPERATOR_CONTROL_FIELDS
+        ):
+            state[path.name] = value
+            return
+        if path.family is FieldFamily.METERS and path.name in _GLOBAL_METER_FIELDS:
+            state[f"{path.name}_meter"] = value
+            return
+
+    if path.scope is FieldScope.SCOPE_CONTROLS and path.family is FieldFamily.DISPLAY:
+        scope_controls = state.get("scope_controls")
+        if not isinstance(scope_controls, dict):
+            return
+        if path.receiver_id is not None:
+            receiver_key = _snapshot_receiver_key(path.receiver_id)
+            if receiver_key == "main":
+                scope_controls["receiver"] = 0
+            elif receiver_key == "sub":
+                scope_controls["receiver"] = 1
+        if path.name == "span":
+            scope_controls["span"] = value
+
+
+def _project_snapshot_state_dict(snapshot: StateSnapshot) -> dict[str, Any]:
+    state = copy.deepcopy(_EMPTY_STATE_DICT)
+    for field in snapshot.fields:
+        _apply_snapshot_field(state, field.path, field.value)
+    return cast(dict[str, Any], state)
+
+
+def _build_public_state_payload_from_dict(
+    state: dict[str, Any],
+    *,
+    radio: "Radio | None",
+    revision: int,
+    state_revision: int,
+    freshness_revision: int,
+    receiver_count: int,
+    updated_at: str | None = None,
+    scope_clients: int = 0,
+    control_clients: int = 0,
+    audio_clients: int = 0,
+    radio_health: dict[str, Any] | None = None,
+    health_revision: int = 0,
+) -> dict[str, Any]:
+    state = copy.deepcopy(state)
+    raw_connected = getattr(radio, "connected", False) if radio else False
+    state["connected"] = raw_connected if isinstance(raw_connected, bool) else False
+    state["radio_ready"] = radio_ready(radio)
+    raw_control_connected = (
+        getattr(radio, "control_connected", False) if radio else False
+    )
+    state["control_connected"] = (
+        raw_control_connected if isinstance(raw_control_connected, bool) else False
+    )
+    state["revision"] = revision
+    state["state_revision"] = state_revision
+    state["freshness_revision"] = freshness_revision
+    state["health_revision"] = health_revision
+    state["updated_at"] = (
+        updated_at or datetime.datetime.now(datetime.timezone.utc).isoformat()
+    )
+    if receiver_count < 2:
+        state.pop("sub", None)
+
+    conn_state_val = getattr(radio, "conn_state", None) if radio else None
+    radio_status: str = "disconnected"
+    if conn_state_val is not None and hasattr(conn_state_val, "value"):
+        raw_val = conn_state_val.value
+        if isinstance(raw_val, str):
+            radio_status = raw_val
+    elif raw_connected:
+        radio_status = "connected"
+    state["radio_detail"] = {
+        "status": radio_status,
+    }
+    state["radio_health"] = radio_health or classify_radio_health(radio)
+    state["ws_clients"] = {
+        "scope": scope_clients,
+        "control": control_clients,
+        "audio": audio_clients,
+    }
+
+    return _camel_case_state(state)
+
+
 def build_public_state_payload(
     radio_state: RadioState,
     *,
     radio: "Radio | None",
     revision: int,
+    state_revision: int | None = None,
+    freshness_revision: int = 0,
     receiver_count: int,
     updated_at: str | None = None,
     scope_clients: int = 0,
@@ -284,43 +522,47 @@ def build_public_state_payload(
     consumers. During the migration away from StateCache, all public state
     should be derived here.
     """
-    state = radio_state.to_dict()
-    raw_connected = getattr(radio, "connected", False) if radio else False
-    state["connected"] = raw_connected if isinstance(raw_connected, bool) else False
-    state["radio_ready"] = radio_ready(radio)
-    raw_control_connected = (
-        getattr(radio, "control_connected", False) if radio else False
+    return _build_public_state_payload_from_dict(
+        radio_state.to_dict(),
+        radio=radio,
+        revision=revision,
+        state_revision=revision if state_revision is None else state_revision,
+        freshness_revision=freshness_revision,
+        receiver_count=receiver_count,
+        updated_at=updated_at,
+        scope_clients=scope_clients,
+        control_clients=control_clients,
+        audio_clients=audio_clients,
+        radio_health=radio_health,
+        health_revision=health_revision,
     )
-    state["control_connected"] = (
-        raw_control_connected if isinstance(raw_control_connected, bool) else False
-    )
-    state["revision"] = revision
-    state["health_revision"] = health_revision
-    state["updated_at"] = (
-        updated_at or datetime.datetime.now(datetime.timezone.utc).isoformat()
-    )
-    if receiver_count < 2:
-        state.pop("sub", None)
 
-    # Radio connection detail for status bar
-    conn_state_val = getattr(radio, "conn_state", None) if radio else None
-    radio_status: str = "disconnected"
-    if conn_state_val is not None and hasattr(conn_state_val, "value"):
-        raw_val = conn_state_val.value
-        if isinstance(raw_val, str):
-            radio_status = raw_val
-    elif raw_connected:
-        # Serial backends (Yaesu CAT) don't have conn_state enum;
-        # fall back to the connected boolean.
-        radio_status = "connected"
-    state["radio_detail"] = {
-        "status": radio_status,
-    }
-    state["radio_health"] = radio_health or classify_radio_health(radio)
-    state["ws_clients"] = {
-        "scope": scope_clients,
-        "control": control_clients,
-        "audio": audio_clients,
-    }
 
-    return _camel_case_state(state)
+def build_public_state_payload_from_snapshot(
+    snapshot: StateSnapshot,
+    *,
+    radio: "Radio | None",
+    receiver_count: int,
+    updated_at: str | None = None,
+    scope_clients: int = 0,
+    control_clients: int = 0,
+    audio_clients: int = 0,
+    radio_health: dict[str, Any] | None = None,
+    health_revision: int = 0,
+) -> dict[str, Any]:
+    """Build the public web payload from one StateStore snapshot."""
+
+    return _build_public_state_payload_from_dict(
+        _project_snapshot_state_dict(snapshot),
+        radio=radio,
+        revision=snapshot.state_revision,
+        state_revision=snapshot.state_revision,
+        freshness_revision=snapshot.freshness_revision,
+        receiver_count=receiver_count,
+        updated_at=updated_at,
+        scope_clients=scope_clients,
+        control_clients=control_clients,
+        audio_clients=audio_clients,
+        radio_health=radio_health,
+        health_revision=health_revision,
+    )

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -533,7 +533,7 @@ def _serialize_keyboard_config(profile: "RadioProfile") -> dict[str, object] | N
 
 def _runtime_capabilities(radio: "Radio | None") -> set[str]:
     """Backward-compatible alias to shared runtime_capabilities helper."""
-    return runtime_capabilities(radio)
+    return cast(set[str], runtime_capabilities(radio))
 
 
 def _supports_scope(radio: "Radio | None") -> bool:
@@ -1192,16 +1192,19 @@ class WebServer:
             and self._cached_public_state_payload is not None
         ):
             return copy.deepcopy(self._cached_public_state_payload)
-        payload = build_public_state_payload_from_snapshot(
-            snapshot,
-            radio=self._radio,
-            receiver_count=self._get_profile().receiver_count,
-            updated_at=updated_at,
-            scope_clients=len(self._scope_handlers),
-            control_clients=len(self._control_event_queues),
-            audio_clients=len(self._audio_broadcaster._clients),
-            radio_health=health,
-            health_revision=self._health_revision,
+        payload = cast(
+            dict[str, Any],
+            build_public_state_payload_from_snapshot(
+                snapshot,
+                radio=self._radio,
+                receiver_count=self._get_profile().receiver_count,
+                updated_at=updated_at,
+                scope_clients=len(self._scope_handlers),
+                control_clients=len(self._control_event_queues),
+                audio_clients=len(self._audio_broadcaster._clients),
+                radio_health=health,
+                health_revision=self._health_revision,
+            ),
         )
         if updated_at is None:
             self._cached_public_state_key = cache_key
@@ -1399,10 +1402,13 @@ class WebServer:
     def _build_radio_health(self) -> dict[str, Any]:
         """Build radio health and advance the health revision on transitions."""
         now = time.monotonic()
-        health = classify_radio_health(
-            self._radio,
-            server_reachable=True,
-            now_monotonic=now,
+        health = cast(
+            dict[str, Any],
+            classify_radio_health(
+                self._radio,
+                server_reachable=True,
+                now_monotonic=now,
+            ),
         )
         signature = (
             health.get("serverReachable"),

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -398,7 +398,9 @@ class _HttpCommandExecutor:
         params = intent.params
         if intent.name == "raw_civ_transaction":
             if not isinstance(radio, CivTransactionCapable):
-                raise RuntimeError("active backend does not support raw CI-V transactions")
+                raise RuntimeError(
+                    "active backend does not support raw CI-V transactions"
+                )
             result = await radio.send_civ_transaction(
                 int(params["command"]),
                 sub=params.get("sub"),
@@ -703,7 +705,9 @@ class WebServer:
         self._state_diagnostics = StateDiagnosticsRecorder(
             enabled=self._config.state_diagnostics
         )
-        raw_state_store = getattr(radio, "state_store", None) if radio is not None else None
+        raw_state_store = (
+            getattr(radio, "state_store", None) if radio is not None else None
+        )
         self.command_state_store = (
             raw_state_store if isinstance(raw_state_store, StateStore) else StateStore()
         )
@@ -742,7 +746,9 @@ class WebServer:
             try:
                 setattr(radio, "_state_diagnostics", self._state_diagnostics)
             except Exception:
-                logger.debug("state diagnostics: failed to attach to radio", exc_info=True)
+                logger.debug(
+                    "state diagnostics: failed to attach to radio", exc_info=True
+                )
         self._audio_broadcaster = AudioBroadcaster(radio)
         # Gated WebRTC transport session manager (A2.3 / MOR-307). Lazily
         # constructed on first use so the import stays out of the no-extra path.
@@ -1259,7 +1265,9 @@ class WebServer:
             self._cached_public_state_payload = copy.deepcopy(payload)
         return payload
 
-    def build_state_update_envelope(self, *, force_full: bool = False) -> dict[str, Any]:
+    def build_state_update_envelope(
+        self, *, force_full: bool = False
+    ) -> dict[str, Any]:
         """Return a WS state-update envelope from the canonical StateStore view."""
         self._sync_legacy_state_store_for_delivery()
         snapshot = self.command_state_store.snapshot()
@@ -1304,7 +1312,8 @@ class WebServer:
         state_dict = state.to_dict()
         baseline_dict = baseline.to_dict()
         observed_values = {
-            field.path: field.value for field in self.command_state_store.snapshot().fields
+            field.path: field.value
+            for field in self.command_state_store.snapshot().fields
         }
         provider = getattr(self._radio, "backend_id", None)
         source = SourceMetadata(

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -724,7 +724,7 @@ class WebServer:
         self._pending_state_broadcast_task: asyncio.Task[None] | None = None
         # Delta encoder for efficient state broadcasting
         self._delta_encoder: DeltaEncoder = DeltaEncoder(full_state_interval=100)
-        self._last_broadcast_state_key: tuple[int, int, int] | None = None
+        self._last_broadcast_state_key: tuple[object, ...] | None = None
         self._cached_public_state_key: tuple[object, ...] | None = None
         self._cached_public_state_payload: dict[str, Any] | None = None
         self._health_revision: int = 0
@@ -1062,6 +1062,7 @@ class WebServer:
             snapshot.state_revision,
             snapshot.freshness_revision,
             int(body.get("healthRevision", 0)),
+            *self._live_connection_metadata_key(),
         )
         if state_key == self._last_broadcast_state_key:
             return
@@ -1104,7 +1105,7 @@ class WebServer:
         snapshot = self.command_state_store.snapshot()
         return self._build_public_state_from_snapshot(snapshot, updated_at=updated_at)
 
-    def _public_state_live_connection_cache_key(
+    def _live_connection_metadata_key(
         self,
     ) -> tuple[bool, bool, bool, str | None]:
         radio = self._radio
@@ -1138,7 +1139,7 @@ class WebServer:
             len(self._scope_handlers),
             len(self._control_event_queues),
             len(self._audio_broadcaster._clients),
-            *self._public_state_live_connection_cache_key(),
+            *self._live_connection_metadata_key(),
         )
         if (
             updated_at is None

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -43,6 +43,7 @@ from ..core.acquisition_scheduler import (
     AcquisitionScheduler,
     MeterObservationCoalescer,
     RadioStateModelService,
+    StateFreshnessService,
 )
 from ..core.state_diagnostics import StateDiagnosticsRecorder
 from ..core.command_service import (
@@ -532,7 +533,7 @@ def _serialize_keyboard_config(profile: "RadioProfile") -> dict[str, object] | N
 
 def _runtime_capabilities(radio: "Radio | None") -> set[str]:
     """Backward-compatible alias to shared runtime_capabilities helper."""
-    return runtime_capabilities(radio)
+    return cast(set[str], runtime_capabilities(radio))
 
 
 def _supports_scope(radio: "Radio | None") -> bool:
@@ -654,6 +655,10 @@ class WebServer:
         raw_state_store = getattr(radio, "state_store", None) if radio is not None else None
         self.command_state_store = (
             raw_state_store if isinstance(raw_state_store, StateStore) else StateStore()
+        )
+        self._state_freshness_service = StateFreshnessService(
+            store=self.command_state_store,
+            on_delta=self._on_state_freshness_delta,
         )
         self._bootstrap_state_acquisition()
         self.command_service = CommandService(
@@ -840,9 +845,16 @@ class WebServer:
             store=self.command_state_store,
             scheduler=scheduler,
         )
+        freshness_service = StateFreshnessService(
+            store=self.command_state_store,
+            scheduler=scheduler,
+            on_delta=self._on_state_freshness_delta,
+        )
         coalescer = MeterObservationCoalescer()
+        self._state_freshness_service = freshness_service
         try:
             setattr(radio, "_state_model_service", service)
+            setattr(radio, "_state_freshness_service", freshness_service)
             setattr(radio, "_acquisition_scheduler", scheduler)
             setattr(radio, "_meter_observation_coalescer", coalescer)
         except Exception:
@@ -1194,7 +1206,7 @@ class WebServer:
         if updated_at is None:
             self._cached_public_state_key = cache_key
             self._cached_public_state_payload = copy.deepcopy(payload)
-        return payload
+        return cast(dict[str, Any], payload)
 
     def build_state_update_envelope(self, *, force_full: bool = False) -> dict[str, Any]:
         """Return a WS state-update envelope from the canonical StateStore view."""
@@ -1380,16 +1392,9 @@ class WebServer:
         for observation in observations:
             self.command_state_store.apply(observation)
 
-    async def _state_store_freshness_loop(self) -> None:
-        """Advance freshness-only revisions and broadcast resulting deltas."""
-        try:
-            while True:
-                await asyncio.sleep(0.05)
-                delta = self.command_state_store.mark_stale_due()
-                if delta.freshness or delta.reconciliation_requests:
-                    self._broadcast_state_update()
-        except asyncio.CancelledError:
-            pass
+    def _on_state_freshness_delta(self, _delta: object) -> None:
+        """React to StateStore freshness changes produced by the shared service."""
+        self._broadcast_state_update()
 
     def _build_radio_health(self) -> dict[str, Any]:
         """Build radio health and advance the health revision on transitions."""
@@ -1411,7 +1416,7 @@ class WebServer:
             self._health_revision += 1
             self._health_since_monotonic = now
         health["sinceMs"] = int(max(0.0, now - self._health_since_monotonic) * 1000)
-        return health
+        return cast(dict[str, Any], health)
 
     def broadcast_notification(
         self,

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -53,7 +53,7 @@ from ..core.state_pipeline_contracts import (
     Observation,
     SourceMetadata,
 )
-from ..core.state_store import StateStore
+from ..core.state_store import StateSnapshot, StateStore
 from ..radio_state import RadioState
 from ..capabilities import CAP_AUDIO, CAP_SCOPE
 from ..exceptions import TimeoutError as RigplaneTimeoutError
@@ -247,6 +247,28 @@ _LEGACY_GLOBAL_SLOW_STATE_FIELDS: tuple[tuple[str, str], ...] = (
 
 _CivTransactionExpect = Literal["none", "ack", "data"]
 _MISSING_BATCH_STEP_ID = object()
+
+
+def _changed_legacy_state_keys(
+    current: Any,
+    previous: Any,
+    *,
+    prefix: str = "",
+) -> set[str]:
+    if current == previous:
+        return set()
+    changed = {prefix} if prefix else set()
+    if isinstance(current, dict) and isinstance(previous, dict):
+        for key in current.keys() | previous.keys():
+            child_prefix = f"{prefix}.{key}" if prefix else str(key)
+            changed.update(
+                _changed_legacy_state_keys(
+                    current.get(key),
+                    previous.get(key),
+                    prefix=child_prefix,
+                )
+            )
+    return changed
 
 
 class _HttpBatchValidationError(ValueError):
@@ -653,6 +675,7 @@ class WebServer:
         self._radio_state: RadioState = (
             raw_radio_state if isinstance(raw_radio_state, RadioState) else RadioState()
         )
+        self._legacy_delivery_state_dict: dict[str, Any] = RadioState().to_dict()
         if radio is not None:
             try:
                 setattr(radio, "_state_diagnostics", self._state_diagnostics)
@@ -1032,9 +1055,9 @@ class WebServer:
         self._update_fft_scope_freq()
         self._update_fft_scope_mode()
 
-        self._ensure_legacy_state_store_seeded()
+        self._sync_legacy_state_store_for_delivery()
         snapshot = self.command_state_store.snapshot()
-        body = self.build_public_state()
+        body = self._build_public_state_from_snapshot(snapshot)
         state_key = (
             snapshot.state_revision,
             snapshot.freshness_revision,
@@ -1077,8 +1100,16 @@ class WebServer:
 
     def build_public_state(self, *, updated_at: str | None = None) -> dict[str, Any]:
         """Return the canonical public state payload for web consumers."""
-        self._ensure_legacy_state_store_seeded()
+        self._sync_legacy_state_store_for_delivery()
         snapshot = self.command_state_store.snapshot()
+        return self._build_public_state_from_snapshot(snapshot, updated_at=updated_at)
+
+    def _build_public_state_from_snapshot(
+        self,
+        snapshot: StateSnapshot,
+        *,
+        updated_at: str | None = None,
+    ) -> dict[str, Any]:
         health = self._build_radio_health()
         cache_key = (
             snapshot.state_revision,
@@ -1112,9 +1143,9 @@ class WebServer:
 
     def build_state_update_envelope(self, *, force_full: bool = False) -> dict[str, Any]:
         """Return a WS state-update envelope from the canonical StateStore view."""
-        self._ensure_legacy_state_store_seeded()
+        self._sync_legacy_state_store_for_delivery()
         snapshot = self.command_state_store.snapshot()
-        body = self.build_public_state()
+        body = self._build_public_state_from_snapshot(snapshot)
         encoder = (
             DeltaEncoder(full_state_interval=100) if force_full else self._delta_encoder
         )
@@ -1125,19 +1156,34 @@ class WebServer:
             freshness_revision=snapshot.freshness_revision,
         )
 
-    def _ensure_legacy_state_store_seeded(self) -> None:
-        """Seed the StateStore from legacy RadioState before delivery snapshots."""
-        if self.command_state_store.snapshot().observation_seq == 0:
-            self.sync_state_store_from_radio_state(self._radio_state)
+    def _sync_legacy_state_store_for_delivery(self) -> None:
+        """Reconcile legacy public RadioState fields before delivery snapshots."""
+        state_dict = self._radio_state.to_dict()
+        changed_legacy_keys = _changed_legacy_state_keys(
+            state_dict,
+            self._legacy_delivery_state_dict,
+        )
+        if not changed_legacy_keys:
+            return
+        self.sync_state_store_from_radio_state(
+            self._radio_state,
+            changed_legacy_keys=changed_legacy_keys,
+        )
+        self._legacy_delivery_state_dict = copy.deepcopy(state_dict)
 
-    def sync_state_store_from_radio_state(self, state: RadioState) -> None:
+    def sync_state_store_from_radio_state(
+        self,
+        state: RadioState,
+        *,
+        changed_legacy_keys: set[str] | None = None,
+    ) -> None:
         """Feed compatibility poller snapshots into the canonical StateStore."""
         timestamp = time.monotonic()
         baseline = RadioState()
         state_dict = state.to_dict()
         baseline_dict = baseline.to_dict()
-        observed_paths = {
-            field.path for field in self.command_state_store.snapshot().fields
+        observed_values = {
+            field.path: field.value for field in self.command_state_store.snapshot().fields
         }
         provider = getattr(self._radio, "backend_id", None)
         source = SourceMetadata(
@@ -1153,9 +1199,17 @@ class WebServer:
             path: FieldPath,
             value: Any,
             default: Any,
+            legacy_key: str,
             max_age: float | None = None,
         ) -> None:
-            if value == default and path not in observed_paths:
+            if (
+                changed_legacy_keys is not None
+                and legacy_key not in changed_legacy_keys
+            ):
+                return
+            if value == default and path not in observed_values:
+                return
+            if path in observed_values and observed_values[path] == value:
                 return
             observations.append(
                 Observation(
@@ -1169,6 +1223,7 @@ class WebServer:
 
         def append_receiver_snapshot(
             receiver_id: str,
+            receiver_key: str,
             receiver: Any,
             default_receiver: Any,
         ) -> None:
@@ -1177,11 +1232,13 @@ class WebServer:
                     path=FieldPath.active(receiver_id, "freq_mode", name),
                     value=getattr(receiver, attr),
                     default=getattr(default_receiver, attr),
+                    legacy_key=f"{receiver_key}.{attr}",
                 )
             for slot_name, slot, default_slot in (
                 ("A", receiver.vfo_a, default_receiver.vfo_a),
                 ("B", receiver.vfo_b, default_receiver.vfo_b),
             ):
+                slot_key = f"{receiver_key}.vfo_{slot_name.lower()}"
                 for attr, name in _LEGACY_VFO_SLOT_FIELDS:
                     append_if_changed(
                         path=FieldPath.vfo_slot(
@@ -1192,17 +1249,20 @@ class WebServer:
                         ),
                         value=getattr(slot, attr),
                         default=getattr(default_slot, attr),
+                        legacy_key=f"{slot_key}.{attr}",
                     )
             append_if_changed(
                 path=FieldPath.active_slot(receiver_id),
                 value=receiver.active_slot,
                 default=default_receiver.active_slot,
+                legacy_key=f"{receiver_key}.active_slot",
             )
             for attr, name, max_age in _LEGACY_RECEIVER_METER_FIELDS:
                 append_if_changed(
                     path=FieldPath.receiver(receiver_id, "meters", name),
                     value=getattr(receiver, attr),
                     default=getattr(default_receiver, attr),
+                    legacy_key=f"{receiver_key}.{attr}",
                     max_age=max_age,
                 )
             for attr, name in _LEGACY_RECEIVER_CONTROL_FIELDS:
@@ -1210,38 +1270,44 @@ class WebServer:
                     path=FieldPath.receiver(receiver_id, "operator_controls", name),
                     value=getattr(receiver, attr),
                     default=getattr(default_receiver, attr),
+                    legacy_key=f"{receiver_key}.{attr}",
                 )
             for attr, name in _LEGACY_RECEIVER_TOGGLE_FIELDS:
                 append_if_changed(
                     path=FieldPath.receiver(receiver_id, "operator_toggles", name),
                     value=getattr(receiver, attr),
                     default=getattr(default_receiver, attr),
+                    legacy_key=f"{receiver_key}.{attr}",
                 )
             for attr, name in _LEGACY_RECEIVER_SLOW_STATE_FIELDS:
                 append_if_changed(
                     path=FieldPath.receiver(receiver_id, "slow_state", name),
                     value=getattr(receiver, attr),
                     default=getattr(default_receiver, attr),
+                    legacy_key=f"{receiver_key}.{attr}",
                 )
 
-        append_receiver_snapshot("0", state.main, baseline.main)
+        append_receiver_snapshot("0", "main", state.main, baseline.main)
         for attr, name in _LEGACY_GLOBAL_TX_FIELDS:
             append_if_changed(
                 path=FieldPath.global_("tx_state", name),
                 value=getattr(state, attr),
                 default=getattr(baseline, attr),
+                legacy_key=attr,
             )
         for attr, name in _LEGACY_GLOBAL_CONTROL_FIELDS:
             append_if_changed(
                 path=FieldPath.global_("operator_controls", name),
                 value=getattr(state, attr),
                 default=getattr(baseline, attr),
+                legacy_key=attr,
             )
         for attr, name, max_age in _LEGACY_GLOBAL_METER_FIELDS:
             append_if_changed(
                 path=FieldPath.global_("meters", name),
                 value=getattr(state, attr),
                 default=getattr(baseline, attr),
+                legacy_key=attr,
                 max_age=max_age,
             )
         for attr, name in _LEGACY_GLOBAL_SLOW_STATE_FIELDS:
@@ -1249,9 +1315,10 @@ class WebServer:
                 path=FieldPath.global_("slow_state", name),
                 value=state_dict[attr],
                 default=baseline_dict[attr],
+                legacy_key=attr,
             )
         if self._get_profile().receiver_count > 1:
-            append_receiver_snapshot("1", state.sub, baseline.sub)
+            append_receiver_snapshot("1", "sub", state.sub, baseline.sub)
         for observation in observations:
             self.command_state_store.apply(observation)
 

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -39,6 +39,7 @@ from typing import TYPE_CHECKING, Any, Literal, TextIO
 from .. import __version__
 from .._bounded_queue import BoundedQueue
 from ..core.state_diagnostics import StateDiagnosticsRecorder
+from ..core.state_store import StateStore
 from ..radio_state import RadioState
 from ..capabilities import CAP_AUDIO, CAP_SCOPE
 from ..exceptions import TimeoutError as RigplaneTimeoutError
@@ -393,6 +394,7 @@ class WebServer:
         self._state_diagnostics = StateDiagnosticsRecorder(
             enabled=self._config.state_diagnostics
         )
+        self.command_state_store = StateStore()
         self._server: asyncio.Server | None = None
         self._runtime_started_at = time.monotonic()
         self._runtime_log_path: str | None = None
@@ -2512,6 +2514,8 @@ class WebServer:
             result = await self._control_handler_for()._enqueue_command(  # noqa: SLF001
                 raw_name,
                 raw_params,
+                command_id=None if payload.get("id") is None else str(payload["id"]),
+                source="http",
             )
         except PermissionError as exc:
             await self._send_json(
@@ -2591,6 +2595,7 @@ class WebServer:
         result = await self._control_handler_for(server=proxy_server)._enqueue_command(  # noqa: SLF001
             raw_name,
             raw_params,
+            source="http",
         )
         if len(collector.commands) != 1:
             raise _HttpBatchValidationError(

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -725,7 +725,7 @@ class WebServer:
         # Delta encoder for efficient state broadcasting
         self._delta_encoder: DeltaEncoder = DeltaEncoder(full_state_interval=100)
         self._last_broadcast_state_key: tuple[int, int, int] | None = None
-        self._cached_public_state_key: tuple[int, int, int, int, int, int] | None = None
+        self._cached_public_state_key: tuple[object, ...] | None = None
         self._cached_public_state_payload: dict[str, Any] | None = None
         self._health_revision: int = 0
         self._health_signature: tuple[object, ...] | None = None
@@ -1104,6 +1104,26 @@ class WebServer:
         snapshot = self.command_state_store.snapshot()
         return self._build_public_state_from_snapshot(snapshot, updated_at=updated_at)
 
+    def _public_state_live_connection_cache_key(
+        self,
+    ) -> tuple[bool, bool, bool, str | None]:
+        radio = self._radio
+        raw_connected = getattr(radio, "connected", False) if radio else False
+        connected = raw_connected if isinstance(raw_connected, bool) else False
+        raw_control_connected = (
+            getattr(radio, "control_connected", False) if radio else False
+        )
+        control_connected = (
+            raw_control_connected if isinstance(raw_control_connected, bool) else False
+        )
+        conn_state_val = getattr(radio, "conn_state", None) if radio else None
+        conn_state: str | None = None
+        if conn_state_val is not None and hasattr(conn_state_val, "value"):
+            raw_conn_state = conn_state_val.value
+            if isinstance(raw_conn_state, str):
+                conn_state = raw_conn_state
+        return (connected, control_connected, radio_ready(radio), conn_state)
+
     def _build_public_state_from_snapshot(
         self,
         snapshot: StateSnapshot,
@@ -1118,6 +1138,7 @@ class WebServer:
             len(self._scope_handlers),
             len(self._control_event_queues),
             len(self._audio_broadcaster._clients),
+            *self._public_state_live_connection_cache_key(),
         )
         if (
             updated_at is None

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -915,6 +915,7 @@ class WebServer:
         self._update_fft_scope_freq()
         self._update_fft_scope_mode()
 
+        self._ensure_legacy_state_store_seeded()
         snapshot = self.command_state_store.snapshot()
         body = self.build_public_state()
         state_key = (
@@ -959,10 +960,8 @@ class WebServer:
 
     def build_public_state(self, *, updated_at: str | None = None) -> dict[str, Any]:
         """Return the canonical public state payload for web consumers."""
+        self._ensure_legacy_state_store_seeded()
         snapshot = self.command_state_store.snapshot()
-        if snapshot.observation_seq == 0:
-            self.sync_state_store_from_radio_state(self._radio_state)
-            snapshot = self.command_state_store.snapshot()
         health = self._build_radio_health()
         cache_key = (
             snapshot.state_revision,
@@ -996,19 +995,31 @@ class WebServer:
 
     def build_state_update_envelope(self, *, force_full: bool = False) -> dict[str, Any]:
         """Return a WS state-update envelope from the canonical StateStore view."""
+        self._ensure_legacy_state_store_seeded()
         snapshot = self.command_state_store.snapshot()
         body = self.build_public_state()
-        return self._delta_encoder.encode(
+        encoder = (
+            DeltaEncoder(full_state_interval=100) if force_full else self._delta_encoder
+        )
+        return encoder.encode(
             body,
             force_full=force_full,
             state_revision=snapshot.state_revision,
             freshness_revision=snapshot.freshness_revision,
         )
 
+    def _ensure_legacy_state_store_seeded(self) -> None:
+        """Seed the StateStore from legacy RadioState before delivery snapshots."""
+        if self.command_state_store.snapshot().observation_seq == 0:
+            self.sync_state_store_from_radio_state(self._radio_state)
+
     def sync_state_store_from_radio_state(self, state: RadioState) -> None:
         """Feed compatibility poller snapshots into the canonical StateStore."""
         timestamp = time.monotonic()
         baseline = RadioState()
+        observed_paths = {
+            field.path for field in self.command_state_store.snapshot().fields
+        }
         provider = getattr(self._radio, "backend_id", None)
         source = SourceMetadata(
             source="state_poller",
@@ -1025,7 +1036,7 @@ class WebServer:
             default: Any,
             max_age: float | None = None,
         ) -> None:
-            if value == default:
+            if value == default and path not in observed_paths:
                 return
             observations.append(
                 Observation(

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -1496,7 +1496,7 @@ class WebServer:
         This is the PRIMARY update path.  Called whenever the radio sends
         a CI-V frame (solicited response or unsolicited change).
         """
-        if self._radio_poller is not None:
+        if self._radio_poller is not None and name != "state_store_changed":
             self._radio_poller.bump_revision()
         self.broadcast_event(name, data)
         self._broadcast_state_update()

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -2688,7 +2688,14 @@ class WebServer:
             )
 
         collector = _HttpCommandCollector()
-        proxy_server = type("_HttpBatchProxy", (), {"command_queue": collector})()
+        proxy_server = type(
+            "_HttpBatchProxy",
+            (),
+            {
+                "command_queue": collector,
+                "command_state_store": self.command_state_store,
+            },
+        )()
         result = await self._control_handler_for(server=proxy_server)._enqueue_command(  # noqa: SLF001
             raw_name,
             raw_params,

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -20,6 +20,7 @@ command dispatch and scope data delivery.
 from __future__ import annotations
 
 import asyncio
+import copy
 import gzip as _gzip
 import hmac
 import json
@@ -45,7 +46,13 @@ from ..core.command_service import (
     command_intent_from_request,
     command_response_observation,
 )
-from ..core.state_pipeline_contracts import CommandIntent, CommandSource
+from ..core.state_pipeline_contracts import (
+    CommandIntent,
+    CommandSource,
+    FieldPath,
+    Observation,
+    SourceMetadata,
+)
 from ..core.state_store import StateStore
 from ..radio_state import RadioState
 from ..capabilities import CAP_AUDIO, CAP_SCOPE
@@ -76,7 +83,7 @@ from .radio_poller import (  # noqa: TID251
     RadioPoller,
 )
 from .runtime_helpers import (  # noqa: TID251
-    build_public_state_payload,
+    build_public_state_payload_from_snapshot,
     classify_radio_health,
     radio_ready,
     runtime_capabilities,
@@ -500,7 +507,10 @@ class WebServer:
         self._state_diagnostics = StateDiagnosticsRecorder(
             enabled=self._config.state_diagnostics
         )
-        self.command_state_store = StateStore()
+        raw_state_store = getattr(radio, "state_store", None) if radio is not None else None
+        self.command_state_store = (
+            raw_state_store if isinstance(raw_state_store, StateStore) else StateStore()
+        )
         self.command_service = CommandService(
             executor=_SharedControlCommandExecutor(self),
             state_store=self.command_state_store,
@@ -566,12 +576,17 @@ class WebServer:
         self._command_queue: CommandQueue = CommandQueue()
         self._radio_poller: RadioPoller | None = None
         self._state_poller: Any | None = None  # StatePoller (lazy, optional)
+        self._state_store_freshness_task: asyncio.Task[None] | None = None
         # Control handler event queues
         self._control_event_queues: set[BoundedQueue[dict[str, Any]]] = set()
         # State broadcast throttle
         self._last_state_broadcast: float = 0.0
+        self._pending_state_broadcast_task: asyncio.Task[None] | None = None
         # Delta encoder for efficient state broadcasting
         self._delta_encoder: DeltaEncoder = DeltaEncoder(full_state_interval=100)
+        self._last_broadcast_state_key: tuple[int, int, int] | None = None
+        self._cached_public_state_key: tuple[int, int, int, int, int, int] | None = None
+        self._cached_public_state_payload: dict[str, Any] | None = None
         self._health_revision: int = 0
         self._health_signature: tuple[object, ...] | None = None
         self._health_since_monotonic: float = time.monotonic()
@@ -878,22 +893,52 @@ class WebServer:
 
         now = time.monotonic()
         if now - self._last_state_broadcast < 0.05:
+            try:
+                asyncio.get_running_loop()
+            except RuntimeError:
+                return
+            if (
+                self._pending_state_broadcast_task is None
+                or self._pending_state_broadcast_task.done()
+            ):
+                delay = max(0.0, 0.05 - (now - self._last_state_broadcast))
+                self._pending_state_broadcast_task = self._spawn(
+                    self._delayed_state_broadcast(delay)
+                )
             return
         self._last_state_broadcast = now
+        if self._pending_state_broadcast_task is not None:
+            self._pending_state_broadcast_task.cancel()
+            self._pending_state_broadcast_task = None
 
         # Keep audio FFT scope center freq and mode bandwidth in sync
         self._update_fft_scope_freq()
         self._update_fft_scope_mode()
 
+        snapshot = self.command_state_store.snapshot()
         body = self.build_public_state()
+        state_key = (
+            snapshot.state_revision,
+            snapshot.freshness_revision,
+            int(body.get("healthRevision", 0)),
+        )
+        if state_key == self._last_broadcast_state_key:
+            return
 
         # Encode state as delta to reduce bandwidth
-        delta = self._delta_encoder.encode(body)
+        delta = self._delta_encoder.encode(
+            body,
+            state_revision=snapshot.state_revision,
+            freshness_revision=snapshot.freshness_revision,
+        )
+        self._last_broadcast_state_key = state_key
         event = {"type": "state_update", "data": delta}
         self._state_diagnostics.record(
             "web_delivery_trigger",
             "web.websocket",
             revision=body.get("revision"),
+            state_revision=body.get("stateRevision"),
+            freshness_revision=body.get("freshnessRevision"),
             health_revision=body.get("healthRevision"),
             delta_type=delta.get("type"),
             clients=len(self._control_event_queues),
@@ -905,14 +950,37 @@ class WebServer:
             except asyncio.QueueFull:
                 logger.warning("control state queue full; dropping state_update")
 
+    async def _delayed_state_broadcast(self, delay: float) -> None:
+        try:
+            await asyncio.sleep(delay)
+            self._broadcast_state_update()
+        except asyncio.CancelledError:
+            pass
+
     def build_public_state(self, *, updated_at: str | None = None) -> dict[str, Any]:
         """Return the canonical public state payload for web consumers."""
-        revision = self._radio_poller.revision if self._radio_poller is not None else 0
+        snapshot = self.command_state_store.snapshot()
+        if snapshot.observation_seq == 0:
+            self.sync_state_store_from_radio_state(self._radio_state)
+            snapshot = self.command_state_store.snapshot()
         health = self._build_radio_health()
-        return build_public_state_payload(
-            self._radio_state,
+        cache_key = (
+            snapshot.state_revision,
+            snapshot.freshness_revision,
+            self._health_revision,
+            len(self._scope_handlers),
+            len(self._control_event_queues),
+            len(self._audio_broadcaster._clients),
+        )
+        if (
+            updated_at is None
+            and cache_key == self._cached_public_state_key
+            and self._cached_public_state_payload is not None
+        ):
+            return copy.deepcopy(self._cached_public_state_payload)
+        payload = build_public_state_payload_from_snapshot(
+            snapshot,
             radio=self._radio,
-            revision=revision,
             receiver_count=self._get_profile().receiver_count,
             updated_at=updated_at,
             scope_clients=len(self._scope_handlers),
@@ -921,6 +989,160 @@ class WebServer:
             radio_health=health,
             health_revision=self._health_revision,
         )
+        if updated_at is None:
+            self._cached_public_state_key = cache_key
+            self._cached_public_state_payload = copy.deepcopy(payload)
+        return payload
+
+    def build_state_update_envelope(self, *, force_full: bool = False) -> dict[str, Any]:
+        """Return a WS state-update envelope from the canonical StateStore view."""
+        snapshot = self.command_state_store.snapshot()
+        body = self.build_public_state()
+        return self._delta_encoder.encode(
+            body,
+            force_full=force_full,
+            state_revision=snapshot.state_revision,
+            freshness_revision=snapshot.freshness_revision,
+        )
+
+    def sync_state_store_from_radio_state(self, state: RadioState) -> None:
+        """Feed compatibility poller snapshots into the canonical StateStore."""
+        timestamp = time.monotonic()
+        baseline = RadioState()
+        provider = getattr(self._radio, "backend_id", None)
+        source = SourceMetadata(
+            source="state_poller",
+            provider=provider if isinstance(provider, str) else "web_state_poller",
+            transport="backend",
+            native_id="state_poller",
+        )
+        observations: list[Observation] = []
+
+        def append_if_changed(
+            *,
+            path: FieldPath,
+            value: Any,
+            default: Any,
+            max_age: float | None = None,
+        ) -> None:
+            if value == default:
+                return
+            observations.append(
+                Observation(
+                    path=path,
+                    value=value,
+                    source=source,
+                    timestamp_monotonic=timestamp,
+                    max_age=max_age,
+                )
+            )
+
+        append_if_changed(
+            path=FieldPath.active("0", "freq_mode", "freq_hz"),
+            value=state.main.freq,
+            default=baseline.main.freq,
+        )
+        append_if_changed(
+            path=FieldPath.active("0", "freq_mode", "mode"),
+            value=state.main.mode,
+            default=baseline.main.mode,
+        )
+        append_if_changed(
+            path=FieldPath.receiver("0", "meters", "s_meter"),
+            value=state.main.s_meter,
+            default=baseline.main.s_meter,
+            max_age=0.5,
+        )
+        append_if_changed(
+            path=FieldPath.receiver("0", "operator_controls", "af_level"),
+            value=state.main.af_level,
+            default=baseline.main.af_level,
+        )
+        append_if_changed(
+            path=FieldPath.receiver("0", "operator_controls", "rf_gain"),
+            value=state.main.rf_gain,
+            default=baseline.main.rf_gain,
+        )
+        append_if_changed(
+            path=FieldPath.receiver("0", "operator_controls", "squelch"),
+            value=state.main.squelch,
+            default=baseline.main.squelch,
+        )
+        append_if_changed(
+            path=FieldPath.receiver("0", "operator_toggles", "nb"),
+            value=state.main.nb,
+            default=baseline.main.nb,
+        )
+        append_if_changed(
+            path=FieldPath.receiver("0", "operator_toggles", "nr"),
+            value=state.main.nr,
+            default=baseline.main.nr,
+        )
+        append_if_changed(
+            path=FieldPath.global_("tx_state", "ptt"),
+            value=state.ptt,
+            default=baseline.ptt,
+        )
+        append_if_changed(
+            path=FieldPath.global_("tx_state", "power_on"),
+            value=state.power_on,
+            default=baseline.power_on,
+        )
+        append_if_changed(
+            path=FieldPath.global_("operator_controls", "power_level"),
+            value=state.power_level,
+            default=baseline.power_level,
+        )
+        append_if_changed(
+            path=FieldPath.global_("tx_state", "split"),
+            value=state.split,
+            default=baseline.split,
+        )
+        if self._get_profile().receiver_count > 1:
+            append_if_changed(
+                path=FieldPath.active("1", "freq_mode", "freq_hz"),
+                value=state.sub.freq,
+                default=baseline.sub.freq,
+            )
+            append_if_changed(
+                path=FieldPath.active("1", "freq_mode", "mode"),
+                value=state.sub.mode,
+                default=baseline.sub.mode,
+            )
+            append_if_changed(
+                path=FieldPath.receiver("1", "meters", "s_meter"),
+                value=state.sub.s_meter,
+                default=baseline.sub.s_meter,
+                max_age=0.5,
+            )
+            append_if_changed(
+                path=FieldPath.receiver("1", "operator_controls", "af_level"),
+                value=state.sub.af_level,
+                default=baseline.sub.af_level,
+            )
+            append_if_changed(
+                path=FieldPath.receiver("1", "operator_controls", "rf_gain"),
+                value=state.sub.rf_gain,
+                default=baseline.sub.rf_gain,
+            )
+            append_if_changed(
+                path=FieldPath.receiver("1", "operator_controls", "squelch"),
+                value=state.sub.squelch,
+                default=baseline.sub.squelch,
+            )
+        for observation in observations:
+            self.command_state_store.apply(observation)
+
+    async def _state_store_freshness_loop(self) -> None:
+        """Advance freshness-only revisions and broadcast resulting deltas."""
+        try:
+            while True:
+                await asyncio.sleep(0.05)
+                delta = self.command_state_store.mark_stale_due()
+                if delta.freshness or delta.reconciliation_requests:
+                    self._broadcast_state_update()
+        except asyncio.CancelledError:
+            pass
 
     def _build_radio_health(self) -> dict[str, Any]:
         """Build radio health and advance the health revision on transitions."""
@@ -1804,16 +2026,23 @@ class WebServer:
         self, writer: asyncio.StreamWriter, headers: dict[str, str] | None = None
     ) -> None:
         body_dict = self.build_public_state()
-        revision = int(body_dict.get("revision", 0))
+        revision = int(body_dict.get("stateRevision", body_dict.get("revision", 0)))
+        freshness_revision = int(body_dict.get("freshnessRevision", 0))
         health_revision = int(body_dict.get("healthRevision", 0))
         self._state_diagnostics.record(
             "web_delivery_trigger",
             "web.http_state",
             revision=revision,
+            freshness_revision=freshness_revision,
             health_revision=health_revision,
         )
         body = json.dumps(body_dict, separators=(",", ":")).encode()
-        await _send_json(writer, body, headers, etag=f'"{revision}-{health_revision}"')
+        await _send_json(
+            writer,
+            body,
+            headers,
+            etag=f'"{revision}-{freshness_revision}-{health_revision}"',
+        )
 
     async def _serve_audio_analysis(
         self, writer: asyncio.StreamWriter, headers: dict[str, str] | None = None

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -228,6 +228,25 @@ class _HttpCommandExecutor:
         raise ValueError(f"unsupported HTTP command intent: {intent.name!r}")
 
 
+@dataclass(slots=True)
+class _SharedControlCommandExecutor:
+    server: "WebServer"
+
+    async def execute(self, intent: CommandIntent) -> CommandExecutionResult:
+        params = dict(intent.params)
+        control_server = params.pop("_control_server", None)
+        result = await self.server._control_handler_for(  # noqa: SLF001
+            server=control_server,
+        )._enqueue_legacy_command(
+            intent.name,
+            params,
+            command_id=intent.id,
+            source=intent.source,
+            command_service=self.server.command_service,
+        )
+        return CommandExecutionResult(details=result)
+
+
 async def _read_capped_body(
     reader: asyncio.StreamReader,
     content_length: int,
@@ -478,6 +497,10 @@ class WebServer:
             enabled=self._config.state_diagnostics
         )
         self.command_state_store = StateStore()
+        self.command_service = CommandService(
+            executor=_SharedControlCommandExecutor(self),
+            state_store=self.command_state_store,
+        )
         self._http_command_service = CommandService(
             executor=_HttpCommandExecutor(self),
             state_store=self.command_state_store,
@@ -2694,6 +2717,7 @@ class WebServer:
             {
                 "command_queue": collector,
                 "command_state_store": self.command_state_store,
+                "command_service": self.command_service,
             },
         )()
         result = await self._control_handler_for(server=proxy_server)._enqueue_command(  # noqa: SLF001

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -2990,7 +2990,8 @@ class WebServer:
                     else str(payload["id"]),
                 )
             )
-            result = service_result.executor_result.details["transaction_result"]
+            details = service_result.executor_result.details or {}
+            result = details["transaction_result"]
         except (RigplaneTimeoutError, TimeoutError):
             await self._send_json(
                 writer,
@@ -3304,7 +3305,8 @@ class WebServer:
                     else str(step.step_id),
                 )
             )
-            result = service_result.executor_result.details["transaction_result"]
+            details = service_result.executor_result.details or {}
+            result = details["transaction_result"]
         except (RigplaneTimeoutError, TimeoutError):
             return self._failed_transaction_batch_result(
                 step,

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -35,10 +35,15 @@ import time
 import urllib.parse
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Literal, TextIO
+from typing import TYPE_CHECKING, Any, Literal, TextIO, cast
 
 from .. import __version__
 from .._bounded_queue import BoundedQueue
+from ..core.acquisition_scheduler import (
+    AcquisitionScheduler,
+    MeterObservationCoalescer,
+    RadioStateModelService,
+)
 from ..core.state_diagnostics import StateDiagnosticsRecorder
 from ..core.command_service import (
     CommandExecutionResult,
@@ -650,6 +655,7 @@ class WebServer:
         self.command_state_store = (
             raw_state_store if isinstance(raw_state_store, StateStore) else StateStore()
         )
+        self._bootstrap_state_acquisition()
         self.command_service = CommandService(
             executor=_SharedControlCommandExecutor(self),
             state_store=self.command_state_store,
@@ -814,6 +820,32 @@ class WebServer:
             return resolve_radio_profile(model=self._config.radio_model)
         except KeyError:
             return resolve_radio_profile(model="IC-7610")
+
+    def _bootstrap_state_acquisition(self) -> None:
+        """Attach shared StateStore-backed acquisition services when profiled."""
+        radio = self._radio
+        if radio is None:
+            return
+        try:
+            profile = self._get_profile()
+        except Exception:
+            logger.debug("state acquisition: failed to resolve profile", exc_info=True)
+            return
+        acquisition_profile = getattr(profile, "state_acquisition", None)
+        if acquisition_profile is None:
+            return
+        scheduler = AcquisitionScheduler(profile=acquisition_profile)
+        service = RadioStateModelService(
+            store=self.command_state_store,
+            scheduler=scheduler,
+        )
+        coalescer = MeterObservationCoalescer()
+        try:
+            setattr(radio, "_state_model_service", service)
+            setattr(radio, "_acquisition_scheduler", scheduler)
+            setattr(radio, "_meter_observation_coalescer", coalescer)
+        except Exception:
+            logger.debug("state acquisition: failed to attach services", exc_info=True)
 
     def _radio_ready(self) -> bool:
         """Backend view of radio readiness (CI-V healthy)."""
@@ -1171,11 +1203,14 @@ class WebServer:
         encoder = (
             DeltaEncoder(full_state_interval=100) if force_full else self._delta_encoder
         )
-        return encoder.encode(
-            body,
-            force_full=force_full,
-            state_revision=snapshot.state_revision,
-            freshness_revision=snapshot.freshness_revision,
+        return cast(
+            dict[str, Any],
+            encoder.encode(
+                body,
+                force_full=force_full,
+                state_revision=snapshot.state_revision,
+                freshness_revision=snapshot.freshness_revision,
+            ),
         )
 
     def _sync_legacy_state_store_for_delivery(self) -> None:
@@ -2196,6 +2231,29 @@ class WebServer:
             "stats": stats,
         }
 
+    def _state_acquisition_diagnostics_payload(self) -> dict[str, Any]:
+        radio = self._radio
+        scheduler = (
+            getattr(radio, "_acquisition_scheduler", None)
+            if radio is not None
+            else None
+        )
+        coalescer = (
+            getattr(radio, "_meter_observation_coalescer", None)
+            if radio is not None
+            else None
+        )
+        return {
+            "enabled": isinstance(scheduler, AcquisitionScheduler),
+            "scheduler": scheduler.diagnostics()
+            if isinstance(scheduler, AcquisitionScheduler)
+            else None,
+            "meterCoalescing": coalescer.diagnostics()
+            if isinstance(coalescer, MeterObservationCoalescer)
+            else None,
+            "events": self._state_diagnostics.snapshot(),
+        }
+
     async def _serve_runtime(
         self, writer: asyncio.StreamWriter, headers: dict[str, str] | None = None
     ) -> None:
@@ -2218,6 +2276,7 @@ class WebServer:
                     "address": self._runtime_rigctld_addr,
                 },
                 "bridge": self._runtime_bridge_payload(),
+                "stateAcquisition": self._state_acquisition_diagnostics_payload(),
                 "lastError": self._runtime_last_error,
             },
             separators=(",", ":"),

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -3146,6 +3146,13 @@ class WebServer:
             try:
                 await asyncio.wait_for(future, timeout=_COMMAND_BATCH_STEP_TIMEOUT)
             except TimeoutError as exc:
+                if step.command_service is not None and step.command_id is not None:
+                    step.command_service.fail_command(
+                        step.command_id,
+                        message=str(exc) or type(exc).__name__,
+                        timed_out=True,
+                        source=step.source,
+                    )
                 results.append(
                     {
                         "index": step.index,

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -532,7 +532,7 @@ def _serialize_keyboard_config(profile: "RadioProfile") -> dict[str, object] | N
 
 def _runtime_capabilities(radio: "Radio | None") -> set[str]:
     """Backward-compatible alias to shared runtime_capabilities helper."""
-    return cast(set[str], runtime_capabilities(radio))
+    return runtime_capabilities(radio)
 
 
 def _supports_scope(radio: "Radio | None") -> bool:
@@ -1194,7 +1194,7 @@ class WebServer:
         if updated_at is None:
             self._cached_public_state_key = cache_key
             self._cached_public_state_payload = copy.deepcopy(payload)
-        return cast(dict[str, Any], payload)
+        return payload
 
     def build_state_update_envelope(self, *, force_full: bool = False) -> dict[str, Any]:
         """Return a WS state-update envelope from the canonical StateStore view."""
@@ -1411,7 +1411,7 @@ class WebServer:
             self._health_revision += 1
             self._health_since_monotonic = now
         health["sinceMs"] = int(max(0.0, now - self._health_since_monotonic) * 1000)
-        return cast(dict[str, Any], health)
+        return health
 
     def broadcast_notification(
         self,

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -164,6 +164,7 @@ class _HttpCommandCollector:
         *,
         command_id: str | None = None,
         source: CommandSource | None = None,
+        session_id: str | None = None,
         command_service: CommandService | None = None,
     ) -> None:
         self.commands.append(command)
@@ -172,6 +173,7 @@ class _HttpCommandCollector:
                 command,
                 command_id=command_id,
                 source=source,
+                session_id=session_id,
                 command_service=command_service,
             )
         )
@@ -183,6 +185,7 @@ class _HttpCommandCollector:
         future: asyncio.Future[None] | None = None,
         command_id: str | None = None,
         source: CommandSource | None = None,
+        session_id: str | None = None,
         command_service: CommandService | None = None,
     ) -> None:
         del future
@@ -190,6 +193,7 @@ class _HttpCommandCollector:
             command,
             command_id=command_id,
             source=source,
+            session_id=session_id,
             command_service=command_service,
         )
 

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -428,8 +428,10 @@ class _SharedControlCommandExecutor:
     async def execute(self, intent: CommandIntent) -> CommandExecutionResult:
         params = dict(intent.params)
         control_server = params.pop("_control_server", None)
+        control_read_only = bool(params.pop("_control_read_only", False))
         result = await self.server._control_handler_for(  # noqa: SLF001
             server=control_server,
+            read_only=control_read_only,
         )._enqueue_legacy_command(
             intent.name,
             params,
@@ -476,6 +478,18 @@ def _redact_token_in_path(path: str) -> str:
         else:
             parts.append(pair)
     return f"{base}?{'&'.join(parts)}"
+
+
+def _query_flag(query: dict[str, list[str]] | None, *names: str) -> bool:
+    """Return True when any named query parameter is explicitly truthy."""
+    if not query:
+        return False
+    truthy = {"1", "true", "yes", "on"}
+    for name in names:
+        values = query.get(name, [])
+        if any(value.lower() in truthy for value in values):
+            return True
+    return False
 
 
 # Mode/filter lists moved to RadioProfile (profiles.py)
@@ -2900,14 +2914,19 @@ class WebServer:
             return None
         return payload
 
-    def _control_handler_for(self, *, server: Any | None = None) -> ControlHandler:
+    def _control_handler_for(
+        self,
+        *,
+        server: Any | None = None,
+        read_only: bool | None = None,
+    ) -> ControlHandler:
         return ControlHandler(
             None,  # type: ignore[arg-type]
             self._radio,
             __version__,
             self._config.radio_model,
             server=server if server is not None else self,
-            read_only=self._config.read_only,
+            read_only=self._config.read_only if read_only is None else read_only,
         )
 
     async def _handle_http_commands(
@@ -4628,13 +4647,20 @@ class WebServer:
         model = raw_model if isinstance(raw_model, str) else self._config.radio_model
 
         if path == "/api/v1/ws":
+            control_read_only = self._config.read_only or _query_flag(
+                query,
+                "read_only",
+                "readonly",
+                "readOnly",
+                "observer",
+            )
             handler: Any = ControlHandler(
                 ws,
                 self._radio,
                 __version__,
                 model,
                 server=self,
-                read_only=self._config.read_only,
+                read_only=control_read_only,
             )
         elif path == "/api/v1/scope":
             handler = ScopeHandler(ws, self._radio, server=self)

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -35,7 +35,7 @@ import time
 import urllib.parse
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Literal, TextIO, cast
+from typing import TYPE_CHECKING, Any, Literal, Protocol, TextIO, cast
 
 from .. import __version__
 from .._bounded_queue import BoundedQueue
@@ -111,6 +111,43 @@ if TYPE_CHECKING:
 __all__ = ["WebConfig", "WebServer", "run_web_server"]
 
 logger = logging.getLogger(__name__)
+
+
+class _RuntimeCapabilitiesFn(Protocol):
+    def __call__(self, radio: "Radio | None") -> set[str]: ...
+
+
+class _ClassifyRadioHealthFn(Protocol):
+    def __call__(
+        self,
+        radio: "Radio | None",
+        *,
+        server_reachable: bool = True,
+        now_monotonic: float | None = None,
+    ) -> dict[str, Any]: ...
+
+
+class _PublicStatePayloadFromSnapshotFn(Protocol):
+    def __call__(
+        self,
+        snapshot: StateSnapshot,
+        *,
+        radio: "Radio | None",
+        receiver_count: int,
+        updated_at: str | None = None,
+        scope_clients: int = 0,
+        control_clients: int = 0,
+        audio_clients: int = 0,
+        radio_health: dict[str, Any] | None = None,
+        health_revision: int = 0,
+    ) -> dict[str, Any]: ...
+
+
+_runtime_capabilities_impl: _RuntimeCapabilitiesFn = runtime_capabilities
+_classify_radio_health_impl: _ClassifyRadioHealthFn = classify_radio_health
+_build_public_state_payload_from_snapshot_impl: _PublicStatePayloadFromSnapshotFn = (
+    build_public_state_payload_from_snapshot
+)
 
 
 def _install_shutdown_signal_handlers(
@@ -533,7 +570,7 @@ def _serialize_keyboard_config(profile: "RadioProfile") -> dict[str, object] | N
 
 def _runtime_capabilities(radio: "Radio | None") -> set[str]:
     """Backward-compatible alias to shared runtime_capabilities helper."""
-    return cast(set[str], runtime_capabilities(radio))
+    return _runtime_capabilities_impl(radio)
 
 
 def _supports_scope(radio: "Radio | None") -> bool:
@@ -1192,19 +1229,16 @@ class WebServer:
             and self._cached_public_state_payload is not None
         ):
             return copy.deepcopy(self._cached_public_state_payload)
-        payload = cast(
-            dict[str, Any],
-            build_public_state_payload_from_snapshot(
-                snapshot,
-                radio=self._radio,
-                receiver_count=self._get_profile().receiver_count,
-                updated_at=updated_at,
-                scope_clients=len(self._scope_handlers),
-                control_clients=len(self._control_event_queues),
-                audio_clients=len(self._audio_broadcaster._clients),
-                radio_health=health,
-                health_revision=self._health_revision,
-            ),
+        payload = _build_public_state_payload_from_snapshot_impl(
+            snapshot,
+            radio=self._radio,
+            receiver_count=self._get_profile().receiver_count,
+            updated_at=updated_at,
+            scope_clients=len(self._scope_handlers),
+            control_clients=len(self._control_event_queues),
+            audio_clients=len(self._audio_broadcaster._clients),
+            radio_health=health,
+            health_revision=self._health_revision,
         )
         if updated_at is None:
             self._cached_public_state_key = cache_key
@@ -1402,13 +1436,10 @@ class WebServer:
     def _build_radio_health(self) -> dict[str, Any]:
         """Build radio health and advance the health revision on transitions."""
         now = time.monotonic()
-        health = cast(
-            dict[str, Any],
-            classify_radio_health(
-                self._radio,
-                server_reachable=True,
-                now_monotonic=now,
-            ),
+        health = _classify_radio_health_impl(
+            self._radio,
+            server_reachable=True,
+            now_monotonic=now,
         )
         signature = (
             health.get("serverReachable"),

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -127,6 +127,123 @@ _CIV_TRANSACTION_BATCH_STEP_TYPE = "raw_civ_transaction"
 _CIV_TRANSACTION_BATCH_STEP_KEYS = frozenset(
     {"type", "id", "command", "sub", "data", "expect", "timeout_ms"}
 )
+_LEGACY_RECEIVER_FREQ_MODE_FIELDS: tuple[tuple[str, str], ...] = (
+    ("freq", "freq_hz"),
+    ("mode", "mode"),
+    ("filter", "filter"),
+    ("data_mode", "data_mode"),
+    ("filter_width", "filter_width"),
+)
+_LEGACY_VFO_SLOT_FIELDS: tuple[tuple[str, str], ...] = (
+    ("freq_hz", "freq_hz"),
+    ("mode", "mode"),
+    ("filter_num", "filter_num"),
+    ("data_mode", "data_mode"),
+)
+_LEGACY_RECEIVER_METER_FIELDS: tuple[tuple[str, str, float | None], ...] = (
+    ("s_meter", "s_meter", 0.5),
+)
+_LEGACY_RECEIVER_CONTROL_FIELDS: tuple[tuple[str, str], ...] = (
+    ("af_level", "af_level"),
+    ("rf_gain", "rf_gain"),
+    ("squelch", "squelch"),
+    ("att", "att"),
+    ("preamp", "preamp"),
+    ("pbt_inner", "pbt_inner"),
+    ("pbt_outer", "pbt_outer"),
+    ("nr_level", "nr_level"),
+    ("nb_level", "nb_level"),
+    ("if_shift", "if_shift"),
+    ("agc", "agc"),
+    ("agc_time_constant", "agc_time_constant"),
+    ("audio_peak_filter", "audio_peak_filter"),
+    ("apf_type_level", "apf_type_level"),
+    ("apf_freq", "apf_freq"),
+    ("filter_shape", "filter_shape"),
+    ("manual_notch_freq", "manual_notch_freq"),
+    ("manual_notch_width", "manual_notch_width"),
+    ("digisel_shift", "digisel_shift"),
+    ("tone_freq", "tone_freq"),
+    ("tsql_freq", "tsql_freq"),
+)
+_LEGACY_RECEIVER_TOGGLE_FIELDS: tuple[tuple[str, str], ...] = (
+    ("nb", "nb"),
+    ("nr", "nr"),
+    ("digisel", "digisel"),
+    ("manual_notch", "manual_notch"),
+    ("auto_notch", "auto_notch"),
+    ("twin_peak_filter", "twin_peak_filter"),
+    ("af_mute", "af_mute"),
+    ("ipplus", "ipplus"),
+    ("s_meter_sql_open", "s_meter_sql_open"),
+    ("apf_on", "apf_on"),
+    ("narrow", "narrow"),
+    ("repeater_tone", "repeater_tone"),
+    ("repeater_tsql", "repeater_tsql"),
+)
+_LEGACY_RECEIVER_SLOW_STATE_FIELDS: tuple[tuple[str, str], ...] = (
+    ("contour", "contour"),
+)
+_LEGACY_GLOBAL_TX_FIELDS: tuple[tuple[str, str], ...] = (
+    ("ptt", "ptt"),
+    ("power_on", "power_on"),
+    ("split", "split"),
+    ("dual_watch", "dual_watch"),
+    ("rit_on", "rit_on"),
+    ("rit_tx", "rit_tx"),
+    ("monitor_on", "monitor_on"),
+    ("vox_on", "vox_on"),
+    ("compressor_on", "compressor_on"),
+    ("main_sub_tracking", "main_sub_tracking"),
+    ("dial_lock", "dial_lock"),
+    ("tx_freq_monitor", "tx_freq_monitor"),
+)
+_LEGACY_GLOBAL_CONTROL_FIELDS: tuple[tuple[str, str], ...] = (
+    ("power_level", "power_level"),
+    ("tuner_status", "tuner_status"),
+    ("rit_freq", "rit_freq"),
+    ("cw_pitch", "cw_pitch"),
+    ("mic_gain", "mic_gain"),
+    ("key_speed", "key_speed"),
+    ("notch_filter", "notch_filter"),
+    ("compressor_level", "compressor_level"),
+    ("break_in_delay", "break_in_delay"),
+    ("break_in", "break_in"),
+    ("drive_gain", "drive_gain"),
+    ("monitor_gain", "monitor_gain"),
+    ("vox_gain", "vox_gain"),
+    ("anti_vox_gain", "anti_vox_gain"),
+    ("vox_delay", "vox_delay"),
+    ("ssb_tx_bandwidth", "ssb_tx_bandwidth"),
+    ("ref_adjust", "ref_adjust"),
+    ("dash_ratio", "dash_ratio"),
+    ("nb_depth", "nb_depth"),
+    ("nb_width", "nb_width"),
+    ("tx_antenna", "tx_antenna"),
+)
+_LEGACY_GLOBAL_METER_FIELDS: tuple[tuple[str, str, float | None], ...] = (
+    ("alc_meter", "alc", 0.5),
+    ("power_meter", "power", 0.5),
+    ("swr_meter", "swr", 0.5),
+    ("comp_meter", "comp", 0.5),
+    ("vd_meter", "vd", 0.5),
+    ("id_meter", "id", 0.5),
+)
+_LEGACY_GLOBAL_SLOW_STATE_FIELDS: tuple[tuple[str, str], ...] = (
+    ("active", "active"),
+    ("scanning", "scanning"),
+    ("scan_type", "scan_type"),
+    ("scan_resume_mode", "scan_resume_mode"),
+    ("tuning_step", "tuning_step"),
+    ("overflow", "overflow"),
+    ("cw_spot", "cw_spot"),
+    ("vfo_select", "vfo_select"),
+    ("rx_antenna_1", "rx_antenna_1"),
+    ("rx_antenna_2", "rx_antenna_2"),
+    ("tx_band_edges", "tx_band_edges"),
+    ("scope_controls", "scope_controls"),
+    ("yaesu", "yaesu"),
+)
 
 _CivTransactionExpect = Literal["none", "ack", "data"]
 _MISSING_BATCH_STEP_ID = object()
@@ -1017,6 +1134,8 @@ class WebServer:
         """Feed compatibility poller snapshots into the canonical StateStore."""
         timestamp = time.monotonic()
         baseline = RadioState()
+        state_dict = state.to_dict()
+        baseline_dict = baseline.to_dict()
         observed_paths = {
             field.path for field in self.command_state_store.snapshot().fields
         }
@@ -1048,99 +1167,91 @@ class WebServer:
                 )
             )
 
-        append_if_changed(
-            path=FieldPath.active("0", "freq_mode", "freq_hz"),
-            value=state.main.freq,
-            default=baseline.main.freq,
-        )
-        append_if_changed(
-            path=FieldPath.active("0", "freq_mode", "mode"),
-            value=state.main.mode,
-            default=baseline.main.mode,
-        )
-        append_if_changed(
-            path=FieldPath.receiver("0", "meters", "s_meter"),
-            value=state.main.s_meter,
-            default=baseline.main.s_meter,
-            max_age=0.5,
-        )
-        append_if_changed(
-            path=FieldPath.receiver("0", "operator_controls", "af_level"),
-            value=state.main.af_level,
-            default=baseline.main.af_level,
-        )
-        append_if_changed(
-            path=FieldPath.receiver("0", "operator_controls", "rf_gain"),
-            value=state.main.rf_gain,
-            default=baseline.main.rf_gain,
-        )
-        append_if_changed(
-            path=FieldPath.receiver("0", "operator_controls", "squelch"),
-            value=state.main.squelch,
-            default=baseline.main.squelch,
-        )
-        append_if_changed(
-            path=FieldPath.receiver("0", "operator_toggles", "nb"),
-            value=state.main.nb,
-            default=baseline.main.nb,
-        )
-        append_if_changed(
-            path=FieldPath.receiver("0", "operator_toggles", "nr"),
-            value=state.main.nr,
-            default=baseline.main.nr,
-        )
-        append_if_changed(
-            path=FieldPath.global_("tx_state", "ptt"),
-            value=state.ptt,
-            default=baseline.ptt,
-        )
-        append_if_changed(
-            path=FieldPath.global_("tx_state", "power_on"),
-            value=state.power_on,
-            default=baseline.power_on,
-        )
-        append_if_changed(
-            path=FieldPath.global_("operator_controls", "power_level"),
-            value=state.power_level,
-            default=baseline.power_level,
-        )
-        append_if_changed(
-            path=FieldPath.global_("tx_state", "split"),
-            value=state.split,
-            default=baseline.split,
-        )
+        def append_receiver_snapshot(
+            receiver_id: str,
+            receiver: Any,
+            default_receiver: Any,
+        ) -> None:
+            for attr, name in _LEGACY_RECEIVER_FREQ_MODE_FIELDS:
+                append_if_changed(
+                    path=FieldPath.active(receiver_id, "freq_mode", name),
+                    value=getattr(receiver, attr),
+                    default=getattr(default_receiver, attr),
+                )
+            for slot_name, slot, default_slot in (
+                ("A", receiver.vfo_a, default_receiver.vfo_a),
+                ("B", receiver.vfo_b, default_receiver.vfo_b),
+            ):
+                for attr, name in _LEGACY_VFO_SLOT_FIELDS:
+                    append_if_changed(
+                        path=FieldPath.vfo_slot(
+                            receiver_id,
+                            slot_name,
+                            "freq_mode",
+                            name,
+                        ),
+                        value=getattr(slot, attr),
+                        default=getattr(default_slot, attr),
+                    )
+            append_if_changed(
+                path=FieldPath.active_slot(receiver_id),
+                value=receiver.active_slot,
+                default=default_receiver.active_slot,
+            )
+            for attr, name, max_age in _LEGACY_RECEIVER_METER_FIELDS:
+                append_if_changed(
+                    path=FieldPath.receiver(receiver_id, "meters", name),
+                    value=getattr(receiver, attr),
+                    default=getattr(default_receiver, attr),
+                    max_age=max_age,
+                )
+            for attr, name in _LEGACY_RECEIVER_CONTROL_FIELDS:
+                append_if_changed(
+                    path=FieldPath.receiver(receiver_id, "operator_controls", name),
+                    value=getattr(receiver, attr),
+                    default=getattr(default_receiver, attr),
+                )
+            for attr, name in _LEGACY_RECEIVER_TOGGLE_FIELDS:
+                append_if_changed(
+                    path=FieldPath.receiver(receiver_id, "operator_toggles", name),
+                    value=getattr(receiver, attr),
+                    default=getattr(default_receiver, attr),
+                )
+            for attr, name in _LEGACY_RECEIVER_SLOW_STATE_FIELDS:
+                append_if_changed(
+                    path=FieldPath.receiver(receiver_id, "slow_state", name),
+                    value=getattr(receiver, attr),
+                    default=getattr(default_receiver, attr),
+                )
+
+        append_receiver_snapshot("0", state.main, baseline.main)
+        for attr, name in _LEGACY_GLOBAL_TX_FIELDS:
+            append_if_changed(
+                path=FieldPath.global_("tx_state", name),
+                value=getattr(state, attr),
+                default=getattr(baseline, attr),
+            )
+        for attr, name in _LEGACY_GLOBAL_CONTROL_FIELDS:
+            append_if_changed(
+                path=FieldPath.global_("operator_controls", name),
+                value=getattr(state, attr),
+                default=getattr(baseline, attr),
+            )
+        for attr, name, max_age in _LEGACY_GLOBAL_METER_FIELDS:
+            append_if_changed(
+                path=FieldPath.global_("meters", name),
+                value=getattr(state, attr),
+                default=getattr(baseline, attr),
+                max_age=max_age,
+            )
+        for attr, name in _LEGACY_GLOBAL_SLOW_STATE_FIELDS:
+            append_if_changed(
+                path=FieldPath.global_("slow_state", name),
+                value=state_dict[attr],
+                default=baseline_dict[attr],
+            )
         if self._get_profile().receiver_count > 1:
-            append_if_changed(
-                path=FieldPath.active("1", "freq_mode", "freq_hz"),
-                value=state.sub.freq,
-                default=baseline.sub.freq,
-            )
-            append_if_changed(
-                path=FieldPath.active("1", "freq_mode", "mode"),
-                value=state.sub.mode,
-                default=baseline.sub.mode,
-            )
-            append_if_changed(
-                path=FieldPath.receiver("1", "meters", "s_meter"),
-                value=state.sub.s_meter,
-                default=baseline.sub.s_meter,
-                max_age=0.5,
-            )
-            append_if_changed(
-                path=FieldPath.receiver("1", "operator_controls", "af_level"),
-                value=state.sub.af_level,
-                default=baseline.sub.af_level,
-            )
-            append_if_changed(
-                path=FieldPath.receiver("1", "operator_controls", "rf_gain"),
-                value=state.sub.rf_gain,
-                default=baseline.sub.rf_gain,
-            )
-            append_if_changed(
-                path=FieldPath.receiver("1", "operator_controls", "squelch"),
-                value=state.sub.squelch,
-                default=baseline.sub.squelch,
-            )
+            append_receiver_snapshot("1", state.sub, baseline.sub)
         for observation in observations:
             self.command_state_store.apply(observation)
 

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -39,6 +39,13 @@ from typing import TYPE_CHECKING, Any, Literal, TextIO
 from .. import __version__
 from .._bounded_queue import BoundedQueue
 from ..core.state_diagnostics import StateDiagnosticsRecorder
+from ..core.command_service import (
+    CommandExecutionResult,
+    CommandService,
+    command_intent_from_request,
+    command_response_observation,
+)
+from ..core.state_pipeline_contracts import CommandIntent, CommandSource
 from ..core.state_store import StateStore
 from ..radio_state import RadioState
 from ..capabilities import CAP_AUDIO, CAP_SCOPE
@@ -61,7 +68,13 @@ from .handlers import (  # noqa: TID251
     ScopeHandler,
 )
 from .transport.webrtc import webrtc_available  # noqa: TID251
-from .radio_poller import CommandQueue, DisableScope, EnableScope, RadioPoller  # noqa: TID251
+from .radio_poller import (  # noqa: TID251
+    CommandQueue,
+    CommandQueueEntry,
+    DisableScope,
+    EnableScope,
+    RadioPoller,
+)
 from .runtime_helpers import (  # noqa: TID251
     build_public_state_payload,
     classify_radio_health,
@@ -124,6 +137,9 @@ class _HttpBatchStep:
     name: str
     command: Any
     result: dict[str, Any]
+    command_id: str | None = None
+    source: CommandSource | None = None
+    command_service: CommandService | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -140,9 +156,76 @@ class _HttpBatchTransactionStep:
 class _HttpCommandCollector:
     def __init__(self) -> None:
         self.commands: list[Any] = []
+        self.entries: list[CommandQueueEntry] = []
 
-    def put(self, command: Any) -> None:
+    def put(
+        self,
+        command: Any,
+        *,
+        command_id: str | None = None,
+        source: CommandSource | None = None,
+        command_service: CommandService | None = None,
+    ) -> None:
         self.commands.append(command)
+        self.entries.append(
+            CommandQueueEntry(
+                command,
+                command_id=command_id,
+                source=source,
+                command_service=command_service,
+            )
+        )
+
+    def put_ordered(
+        self,
+        command: Any,
+        *,
+        future: asyncio.Future[None] | None = None,
+        command_id: str | None = None,
+        source: CommandSource | None = None,
+        command_service: CommandService | None = None,
+    ) -> None:
+        del future
+        self.put(
+            command,
+            command_id=command_id,
+            source=source,
+            command_service=command_service,
+        )
+
+
+@dataclass(slots=True)
+class _HttpCommandExecutor:
+    server: "WebServer"
+
+    async def execute(self, intent: CommandIntent) -> CommandExecutionResult:
+        radio = self.server._radio
+        if radio is None:
+            raise RuntimeError("No radio configured")
+        params = intent.params
+        if intent.name == "raw_civ_transaction":
+            if not isinstance(radio, CivTransactionCapable):
+                raise RuntimeError("active backend does not support raw CI-V transactions")
+            result = await radio.send_civ_transaction(
+                int(params["command"]),
+                sub=params.get("sub"),
+                data=params["data"],
+                expect=params["expect"],
+                timeout=params.get("timeout"),
+            )
+            return CommandExecutionResult(details={"transaction_result": result})
+        if intent.name == "set_powerstat":
+            await radio.set_powerstat(bool(params["power_on"]))  # type: ignore[attr-defined]
+            return CommandExecutionResult(
+                observations=(
+                    command_response_observation(
+                        intent,
+                        timestamp_monotonic=time.monotonic(),
+                        provider="http",
+                    ),
+                )
+            )
+        raise ValueError(f"unsupported HTTP command intent: {intent.name!r}")
 
 
 async def _read_capped_body(
@@ -395,6 +478,10 @@ class WebServer:
             enabled=self._config.state_diagnostics
         )
         self.command_state_store = StateStore()
+        self._http_command_service = CommandService(
+            executor=_HttpCommandExecutor(self),
+            state_store=self.command_state_store,
+        )
         self._server: asyncio.Server | None = None
         self._runtime_started_at = time.monotonic()
         self._runtime_log_path: str | None = None
@@ -2420,13 +2507,23 @@ class WebServer:
 
         try:
             assert command is not None
-            result = await self._radio.send_civ_transaction(
-                command,
-                sub=sub,
-                data=data,
-                expect=raw_expect,
-                timeout=timeout,
+            service_result = await self._http_command_service.execute(
+                command_intent_from_request(
+                    "raw_civ_transaction",
+                    {
+                        "command": command,
+                        "sub": sub,
+                        "data": data,
+                        "expect": raw_expect,
+                        "timeout": timeout,
+                    },
+                    source="http",
+                    command_id=None
+                    if payload.get("id") is None
+                    else str(payload["id"]),
+                )
             )
+            result = service_result.executor_result.details["transaction_result"]
         except (RigplaneTimeoutError, TimeoutError):
             await self._send_json(
                 writer,
@@ -2602,11 +2699,15 @@ class WebServer:
                 "unsupported_in_batch",
                 f"command {raw_name!r} did not produce exactly one queued command",
             )
+        entry = collector.entries[0]
         return _HttpBatchStep(
             index=index,
             name=raw_name,
-            command=collector.commands[0],
+            command=entry.command,
             result=result,
+            command_id=entry.command_id,
+            source=entry.source,
+            command_service=entry.command_service,
         )
 
     def _prepare_http_batch_transaction_step(
@@ -2712,13 +2813,23 @@ class WebServer:
             )
 
         try:
-            result = await self._radio.send_civ_transaction(
-                step.command,
-                sub=step.sub,
-                data=step.data,
-                expect=step.expect,
-                timeout=step.timeout,
+            service_result = await self._http_command_service.execute(
+                command_intent_from_request(
+                    "raw_civ_transaction",
+                    {
+                        "command": step.command,
+                        "sub": step.sub,
+                        "data": step.data,
+                        "expect": step.expect,
+                        "timeout": step.timeout,
+                    },
+                    source="http",
+                    command_id=None
+                    if step.step_id is _MISSING_BATCH_STEP_ID
+                    else str(step.step_id),
+                )
             )
+            result = service_result.executor_result.details["transaction_result"]
         except (RigplaneTimeoutError, TimeoutError):
             return self._failed_transaction_batch_result(
                 step,
@@ -2994,7 +3105,13 @@ class WebServer:
 
             loop = asyncio.get_running_loop()
             future: asyncio.Future[None] = loop.create_future()
-            self._command_queue.put_ordered(step.command, future=future)
+            self._command_queue.put_ordered(
+                step.command,
+                future=future,
+                command_id=step.command_id,
+                source=step.source,
+                command_service=step.command_service,
+            )
             try:
                 await asyncio.wait_for(future, timeout=_COMMAND_BATCH_STEP_TIMEOUT)
             except TimeoutError as exc:
@@ -3165,8 +3282,17 @@ class WebServer:
                         logger.warning("power-on: reconnect failed: %s", conn_err)
                         # Try anyway — some radios accept CI-V on stale transport
                 is_on = power_state == "on"
-                await radio.set_powerstat(is_on)  # type: ignore[attr-defined]
-                # Optimistic state update: radio won't respond to polls when off
+                await self._http_command_service.execute(
+                    command_intent_from_request(
+                        "set_powerstat",
+                        {"on": is_on},
+                        source="http",
+                        command_id=f"http-power-{time.monotonic_ns()}",
+                    )
+                )
+                # Compatibility delivery mirror until web state responses read
+                # power directly from StateStore; command lifecycle and
+                # reconciliation are owned by CommandService.
                 if self._radio_state is not None:
                     self._radio_state.power_on = is_on
                 self._on_radio_state_change("powerstat_changed", {"power_on": is_on})

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -38,6 +38,7 @@ from typing import TYPE_CHECKING, Any, Literal, TextIO
 
 from .. import __version__
 from .._bounded_queue import BoundedQueue
+from ..core.state_diagnostics import StateDiagnosticsRecorder
 from ..radio_state import RadioState
 from ..capabilities import CAP_AUDIO, CAP_SCOPE
 from ..exceptions import TimeoutError as RigplaneTimeoutError
@@ -316,6 +317,7 @@ class WebConfig:
     read_only: bool = False  # reject PTT and other transmit commands
     emit_startup_event: bool = False  # emit JSON runtime startup event to stdout
     webrtc_enabled: bool = False  # enable the gated WebRTC transport entrypoint
+    state_diagnostics: bool = False  # enable behavior-neutral state diagnostics
 
 
 class ConnectionManager:
@@ -388,6 +390,9 @@ class WebServer:
     ) -> None:
         self._radio = radio
         self._config = config or WebConfig()
+        self._state_diagnostics = StateDiagnosticsRecorder(
+            enabled=self._config.state_diagnostics
+        )
         self._server: asyncio.Server | None = None
         self._runtime_started_at = time.monotonic()
         self._runtime_log_path: str | None = None
@@ -405,6 +410,11 @@ class WebServer:
         self._radio_state: RadioState = (
             raw_radio_state if isinstance(raw_radio_state, RadioState) else RadioState()
         )
+        if radio is not None:
+            try:
+                setattr(radio, "_state_diagnostics", self._state_diagnostics)
+            except Exception:
+                logger.debug("state diagnostics: failed to attach to radio", exc_info=True)
         self._audio_broadcaster = AudioBroadcaster(radio)
         # Gated WebRTC transport session manager (A2.3 / MOR-307). Lazily
         # constructed on first use so the import stays out of the no-extra path.
@@ -720,6 +730,11 @@ class WebServer:
         """Command queue consumed by RadioPoller."""
         return self._command_queue
 
+    @property
+    def state_diagnostics(self) -> StateDiagnosticsRecorder:
+        """Behavior-neutral state-pipeline diagnostics recorder."""
+        return self._state_diagnostics
+
     def register_control_event_queue(self, q: BoundedQueue[dict[str, Any]]) -> None:
         """Register a ControlHandler event queue for broadcast."""
         self._control_event_queues.add(q)
@@ -759,6 +774,14 @@ class WebServer:
         # Encode state as delta to reduce bandwidth
         delta = self._delta_encoder.encode(body)
         event = {"type": "state_update", "data": delta}
+        self._state_diagnostics.record(
+            "web_delivery_trigger",
+            "web.websocket",
+            revision=body.get("revision"),
+            health_revision=body.get("healthRevision"),
+            delta_type=delta.get("type"),
+            clients=len(self._control_event_queues),
+        )
 
         for q in list(self._control_event_queues):
             try:
@@ -1667,6 +1690,12 @@ class WebServer:
         body_dict = self.build_public_state()
         revision = int(body_dict.get("revision", 0))
         health_revision = int(body_dict.get("healthRevision", 0))
+        self._state_diagnostics.record(
+            "web_delivery_trigger",
+            "web.http_state",
+            revision=revision,
+            health_revision=health_revision,
+        )
         body = json.dumps(body_dict, separators=(",", ":")).encode()
         await _send_json(writer, body, headers, etag=f'"{revision}-{health_revision}"')
 

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -532,7 +532,7 @@ def _serialize_keyboard_config(profile: "RadioProfile") -> dict[str, object] | N
 
 def _runtime_capabilities(radio: "Radio | None") -> set[str]:
     """Backward-compatible alias to shared runtime_capabilities helper."""
-    return runtime_capabilities(radio)
+    return cast(set[str], runtime_capabilities(radio))
 
 
 def _supports_scope(radio: "Radio | None") -> bool:
@@ -767,6 +767,7 @@ class WebServer:
         self._zombie_reaper_task: asyncio.Task[None] | None = None
         # UDP discovery responder
         self._discovery: DiscoveryResponder | None = None
+        self._server_was_running: bool = False
         # Diagnostic upload session manager (preview/send/save/delete).
         # Sweeper task is started lazily on the first preview request and
         # explicitly stopped during web shutdown.
@@ -849,7 +850,7 @@ class WebServer:
 
     def _radio_ready(self) -> bool:
         """Backend view of radio readiness (CI-V healthy)."""
-        return radio_ready(self._radio)
+        return bool(radio_ready(self._radio))
 
     async def ensure_startup_ready(self, timeout: float = 5.0) -> None:
         """Assert that the attached radio is ready before exposing the server."""
@@ -1193,7 +1194,7 @@ class WebServer:
         if updated_at is None:
             self._cached_public_state_key = cache_key
             self._cached_public_state_payload = copy.deepcopy(payload)
-        return payload
+        return cast(dict[str, Any], payload)
 
     def build_state_update_envelope(self, *, force_full: bool = False) -> dict[str, Any]:
         """Return a WS state-update envelope from the canonical StateStore view."""
@@ -1410,7 +1411,7 @@ class WebServer:
             self._health_revision += 1
             self._health_since_monotonic = now
         health["sinceMs"] = int(max(0.0, now - self._health_since_monotonic) * 1000)
-        return health
+        return cast(dict[str, Any], health)
 
     def broadcast_notification(
         self,

--- a/src/rigplane/web/web_startup.py
+++ b/src/rigplane/web/web_startup.py
@@ -95,6 +95,11 @@ async def start_web_server(server: WebServer) -> None:
 
             def _state_cb(state: RadioState) -> None:
                 server._radio_state = state
+                server.state_diagnostics.record(
+                    "backend_read",
+                    "web.state_poller",
+                    backend=getattr(server._radio, "backend_id", None),
+                )
                 server._broadcast_state_update()
 
             server._state_poller = server._radio.create_state_poller(
@@ -115,6 +120,7 @@ async def start_web_server(server: WebServer) -> None:
                 server._command_queue,
                 on_state_event=server._on_poller_state_event,
                 radio_state=server._radio_state,
+                diagnostics=server.state_diagnostics,
             )
             server._radio_poller.start()
         if _supports_scope_local(server):

--- a/src/rigplane/web/web_startup.py
+++ b/src/rigplane/web/web_startup.py
@@ -121,6 +121,7 @@ async def start_web_server(server: WebServer) -> None:
                 on_state_event=server._on_poller_state_event,
                 radio_state=server._radio_state,
                 diagnostics=server.state_diagnostics,
+                state_store=server.command_state_store,
             )
             server._radio_poller.start()
         if _supports_scope_local(server):

--- a/src/rigplane/web/web_startup.py
+++ b/src/rigplane/web/web_startup.py
@@ -84,6 +84,7 @@ async def start_web_server(server: WebServer) -> None:
         reuse_address=True,
         reuse_port=_reuse_port_supported(),
     )
+    server._server_was_running = True
     addr = server._server.sockets[0].getsockname()
     scheme = "https" if ssl_ctx else "http"
     logger.info("web server listening on %s://%s:%d", scheme, addr[0], addr[1])
@@ -272,6 +273,7 @@ async def stop_web_server(server: WebServer) -> None:
         except TimeoutError:
             logger.warning("server.wait_closed() timed out after 2s")
         server._server = None
+    server._server_was_running = False
 
     # 8. Wait for cancelled tasks to finish (with timeout)
     if all_tasks:

--- a/src/rigplane/web/web_startup.py
+++ b/src/rigplane/web/web_startup.py
@@ -150,7 +150,7 @@ async def start_web_server(server: WebServer) -> None:
             server._config.dx_callsign,
         )
     server._state_store_freshness_task = asyncio.get_running_loop().create_task(
-        server._state_store_freshness_loop(), name="web-state-freshness"
+        server._state_freshness_service.run(), name="web-state-freshness"
     )
 
     # Start UDP discovery responder

--- a/src/rigplane/web/web_startup.py
+++ b/src/rigplane/web/web_startup.py
@@ -95,6 +95,7 @@ async def start_web_server(server: WebServer) -> None:
 
             def _state_cb(state: RadioState) -> None:
                 server._radio_state = state
+                server.sync_state_store_from_radio_state(state)
                 server.state_diagnostics.record(
                     "backend_read",
                     "web.state_poller",
@@ -147,6 +148,9 @@ async def start_web_server(server: WebServer) -> None:
             server._config.dx_cluster_port,
             server._config.dx_callsign,
         )
+    server._state_store_freshness_task = asyncio.get_running_loop().create_task(
+        server._state_store_freshness_loop(), name="web-state-freshness"
+    )
 
     # Start UDP discovery responder
     if server._config.discovery:
@@ -195,6 +199,13 @@ async def stop_web_server(server: WebServer) -> None:
         except TimeoutError:
             logger.warning("state poller stop timed out")
         server._state_poller = None
+    if server._state_store_freshness_task is not None:
+        server._state_store_freshness_task.cancel()
+        try:
+            await server._state_store_freshness_task
+        except asyncio.CancelledError:
+            pass
+        server._state_store_freshness_task = None
 
     # 2. Stop audio relay (stops AudioBus subscription → stop_audio_rx_opus)
     try:

--- a/tests/support/__init__.py
+++ b/tests/support/__init__.py
@@ -1,0 +1,2 @@
+"""Reusable support helpers for rigplane tests."""
+

--- a/tests/support/__init__.py
+++ b/tests/support/__init__.py
@@ -1,2 +1,1 @@
 """Reusable support helpers for rigplane tests."""
-

--- a/tests/support/state_pipeline.py
+++ b/tests/support/state_pipeline.py
@@ -204,6 +204,7 @@ class FakeStatePipeline:
         if observation.path in self._state and previous == observation.value:
             if previous_freshness == "fresh":
                 return None
+            assert freshness_transition is not None
             changeset = ChangeSet(
                 state_revision=self.state_revision,
                 freshness_revision=self.freshness_revision,

--- a/tests/support/state_pipeline.py
+++ b/tests/support/state_pipeline.py
@@ -1,0 +1,514 @@
+"""Deterministic fakes for radio state pipeline regression tests.
+
+These helpers model the state-pipeline contracts from the design spec without
+depending on a production StateStore implementation. They are intentionally
+small so Web, rigctld, backend adapter, scheduler, and command-service tests can
+share the same revision and freshness assertions while production code evolves.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Any, Literal
+
+ObservationSource = Literal[
+    "civ_unsolicited",
+    "command_response",
+    "poll_response",
+    "state_poller",
+    "hamlib_response",
+    "yaesu_poll_response",
+    "local_reconcile",
+]
+
+FreshnessState = Literal["unknown", "fresh", "stale"]
+
+
+@dataclass(frozen=True, order=True, slots=True)
+class FieldPath:
+    """Backend-neutral state path for tests."""
+
+    scope: str
+    receiver_id: str | None
+    slot: str | None
+    family: str
+    name: str
+
+    @classmethod
+    def receiver(
+        cls,
+        receiver: str,
+        slot: str | None,
+        family: str,
+        name: str,
+    ) -> FieldPath:
+        return cls(
+            scope="receiver",
+            receiver_id=receiver,
+            slot=slot,
+            family=family,
+            name=name,
+        )
+
+    @classmethod
+    def global_(cls, family: str, name: str) -> FieldPath:
+        return cls(
+            scope="global",
+            receiver_id=None,
+            slot=None,
+            family=family,
+            name=name,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class Observation:
+    """A decoded state-bearing sample from an acquisition source."""
+
+    path: FieldPath
+    value: Any
+    source: ObservationSource
+    timestamp_monotonic: float
+    quality: tuple[str, ...] = ("confirmed",)
+    correlation_id: str | None = None
+    max_age: float | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class FieldChange:
+    """One consumer-visible state value change."""
+
+    path: FieldPath
+    previous: Any
+    current: Any
+
+
+@dataclass(frozen=True, slots=True)
+class ChangeSet:
+    """Result of applying one or more observations to the fake state model."""
+
+    state_revision: int
+    freshness_revision: int
+    observation_seq: int
+    changes: tuple[FieldChange, ...]
+    timestamp_monotonic: float
+    sources: tuple[ObservationSource, ...]
+    coalesced: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class FreshnessTransition:
+    """A freshness-only transition visible to state consumers."""
+
+    path: FieldPath
+    previous: FreshnessState
+    current: FreshnessState
+    freshness_revision: int
+    timestamp_monotonic: float
+
+
+@dataclass(frozen=True, slots=True)
+class AcquisitionRequest:
+    """Fake acquisition request scheduled by an ensure-fresh call."""
+
+    paths: tuple[FieldPath, ...]
+    max_age: float
+    timeout: float
+    reason: str
+    requested_at: float
+    due_at: float
+
+
+@dataclass(frozen=True, slots=True)
+class PendingOverlay:
+    """Scoped pending value created by a command intent."""
+
+    source: str
+    session_id: str | None
+    command_id: str
+    path: FieldPath
+    value: Any
+    expires_at: float
+
+
+@dataclass(slots=True)
+class _FreshnessEntry:
+    state: FreshnessState
+    last_observed: float
+    source: ObservationSource
+    max_age: float | None
+
+
+class FakeClock:
+    """Manual monotonic clock for freshness and scheduler tests."""
+
+    def __init__(self, *, start: float = 0.0) -> None:
+        self._now = float(start)
+
+    def now(self) -> float:
+        return self._now
+
+    def advance(self, seconds: float) -> float:
+        if seconds < 0:
+            raise ValueError("fake time cannot move backwards")
+        self._now += seconds
+        return self._now
+
+
+class FakeStatePipeline:
+    """Small state model with spec-compatible revision counters."""
+
+    def __init__(self, *, clock: FakeClock | None = None) -> None:
+        self.clock = clock or FakeClock()
+        self.state_revision = 0
+        self.freshness_revision = 0
+        self.observation_seq = 0
+        self.observations: list[Observation] = []
+        self.consumer_deltas: list[ChangeSet] = []
+        self.freshness_events: list[FreshnessTransition] = []
+        self._state: dict[FieldPath, Any] = {}
+        self._freshness: dict[FieldPath, _FreshnessEntry] = {}
+
+    def apply(self, observation: Observation | None) -> ChangeSet | None:
+        """Apply an observation and return a delta only for real value changes."""
+
+        if observation is None:
+            return None
+
+        self.observation_seq += 1
+        self.observations.append(observation)
+
+        freshness_entry = self._freshness.get(observation.path)
+        previous_freshness = freshness_entry.state if freshness_entry else "unknown"
+        self._freshness[observation.path] = _FreshnessEntry(
+            state="fresh",
+            last_observed=observation.timestamp_monotonic,
+            source=observation.source,
+            max_age=observation.max_age,
+        )
+        if previous_freshness != "fresh":
+            self.freshness_revision += 1
+
+        previous = self._state.get(observation.path)
+        if observation.path in self._state and previous == observation.value:
+            return None
+
+        self._state[observation.path] = observation.value
+        self.state_revision += 1
+        changeset = ChangeSet(
+            state_revision=self.state_revision,
+            freshness_revision=self.freshness_revision,
+            observation_seq=self.observation_seq,
+            changes=(
+                FieldChange(
+                    path=observation.path,
+                    previous=previous,
+                    current=observation.value,
+                ),
+            ),
+            timestamp_monotonic=observation.timestamp_monotonic,
+            sources=(observation.source,),
+        )
+        self.consumer_deltas.append(changeset)
+        return changeset
+
+    def mark_stale_due(self) -> list[FreshnessTransition]:
+        """Advance freshness state for fields whose max-age deadline passed."""
+
+        now = self.clock.now()
+        transitions: list[FreshnessTransition] = []
+        for path, entry in sorted(self._freshness.items()):
+            if entry.state != "fresh" or entry.max_age is None:
+                continue
+            if now - entry.last_observed <= entry.max_age:
+                continue
+            self.freshness_revision += 1
+            self._freshness[path] = _FreshnessEntry(
+                state="stale",
+                last_observed=entry.last_observed,
+                source=entry.source,
+                max_age=entry.max_age,
+            )
+            transition = FreshnessTransition(
+                path=path,
+                previous="fresh",
+                current="stale",
+                freshness_revision=self.freshness_revision,
+                timestamp_monotonic=now,
+            )
+            transitions.append(transition)
+            self.freshness_events.append(transition)
+        return transitions
+
+    def snapshot(self) -> dict[FieldPath, Any]:
+        return dict(self._state)
+
+
+class FakeAcquisitionScheduler:
+    """Fake ensure-fresh scheduler with deterministic due times."""
+
+    def __init__(self, *, clock: FakeClock | None = None) -> None:
+        self.clock = clock or FakeClock()
+        self.requests: list[AcquisitionRequest] = []
+        self._requests_by_key: dict[tuple[FieldPath, ...], AcquisitionRequest] = {}
+
+    def ensure_fresh(
+        self,
+        paths: Iterable[FieldPath],
+        *,
+        max_age: float,
+        timeout: float,
+        reason: str,
+    ) -> AcquisitionRequest:
+        key = tuple(sorted(paths))
+        existing = self._requests_by_key.get(key)
+        if existing is not None:
+            return existing
+
+        requested_at = self.clock.now()
+        request = AcquisitionRequest(
+            paths=key,
+            max_age=max_age,
+            timeout=timeout,
+            reason=reason,
+            requested_at=requested_at,
+            due_at=requested_at + max_age,
+        )
+        self.requests.append(request)
+        self._requests_by_key[key] = request
+        return request
+
+    def due_requests(self) -> list[AcquisitionRequest]:
+        now = self.clock.now()
+        return [request for request in self.requests if request.due_at <= now]
+
+
+class FakePendingOverlayStore:
+    """Scoped pending overlay fake for command-service and rigctld tests."""
+
+    def __init__(self, *, clock: FakeClock | None = None) -> None:
+        self.clock = clock or FakeClock()
+        self.overlays: list[PendingOverlay] = []
+
+    def put(
+        self,
+        *,
+        source: str,
+        session_id: str | None,
+        command_id: str,
+        path: FieldPath,
+        value: Any,
+        ttl: float,
+    ) -> PendingOverlay:
+        overlay = PendingOverlay(
+            source=source,
+            session_id=session_id,
+            command_id=command_id,
+            path=path,
+            value=value,
+            expires_at=self.clock.now() + ttl,
+        )
+        self.overlays.append(overlay)
+        return overlay
+
+    def visible_value(
+        self,
+        *,
+        source: str,
+        session_id: str | None,
+        path: FieldPath,
+    ) -> Any | None:
+        now = self.clock.now()
+        for overlay in reversed(self.overlays):
+            if overlay.expires_at <= now:
+                continue
+            if (
+                overlay.source == source
+                and overlay.session_id == session_id
+                and overlay.path == path
+            ):
+                return overlay.value
+        return None
+
+    def confirm(self, path: FieldPath, value: Any) -> list[PendingOverlay]:
+        matched = [
+            overlay
+            for overlay in self.overlays
+            if overlay.path == path and overlay.value == value
+        ]
+        if matched:
+            self.overlays = [
+                overlay
+                for overlay in self.overlays
+                if not (overlay.path == path and overlay.value == value)
+            ]
+        return matched
+
+    def expire_due(self) -> list[PendingOverlay]:
+        now = self.clock.now()
+        expired = [overlay for overlay in self.overlays if overlay.expires_at <= now]
+        if expired:
+            self.overlays = [
+                overlay for overlay in self.overlays if overlay.expires_at > now
+            ]
+        return expired
+
+
+class FakeStateBackend:
+    """Base fake backend that emits observations for state pipeline tests."""
+
+    default_source: ObservationSource = "poll_response"
+    capabilities: frozenset[str] = frozenset()
+
+    def __init__(self, *, clock: FakeClock | None = None) -> None:
+        self.clock = clock or FakeClock()
+        self.emitted: list[Observation] = []
+        self.dropped: list[Observation] = []
+        self.command_log: list[str] = []
+        self._drop_next: set[FieldPath] = set()
+
+    def observation(
+        self,
+        path: FieldPath,
+        value: Any,
+        *,
+        source: ObservationSource | None = None,
+        correlation_id: str | None = None,
+        max_age: float | None = None,
+        quality: tuple[str, ...] = ("confirmed",),
+    ) -> Observation:
+        observation = Observation(
+            path=path,
+            value=value,
+            source=source or self.default_source,
+            timestamp_monotonic=self.clock.now(),
+            quality=quality,
+            correlation_id=correlation_id,
+            max_age=max_age,
+        )
+        self.emitted.append(observation)
+        return observation
+
+    def unsolicited(
+        self,
+        path: FieldPath,
+        value: Any,
+        *,
+        max_age: float | None = None,
+    ) -> Observation | None:
+        observation = self.observation(
+            path,
+            value,
+            source="civ_unsolicited",
+            max_age=max_age,
+        )
+        if path in self._drop_next:
+            self._drop_next.remove(path)
+            self.dropped.append(observation)
+            return None
+        return observation
+
+    def command_response(
+        self,
+        path: FieldPath,
+        value: Any,
+        *,
+        correlation_id: str | None = None,
+        max_age: float | None = None,
+    ) -> Observation:
+        if correlation_id is not None:
+            self.command_log.append(correlation_id)
+        return self.observation(
+            path,
+            value,
+            source="command_response",
+            correlation_id=correlation_id,
+            max_age=max_age,
+        )
+
+    def poll_response(self, path: FieldPath, value: Any) -> Observation:
+        return self.observation(path, value, source="poll_response")
+
+    def meter_sample(self, path: FieldPath, value: Any) -> Observation:
+        return self.observation(path, value, source=self.default_source)
+
+    def drop_next_unsolicited(self, path: FieldPath) -> None:
+        self._drop_next.add(path)
+
+
+class FakeCivPushBackend(FakeStateBackend):
+    """Icom-like fake backend with CI-V push support."""
+
+    default_source = "civ_unsolicited"
+    capabilities = frozenset({"civ_push", "command_response", "meters"})
+
+
+class FakeCommandResponseBackend(FakeStateBackend):
+    """Fake backend that reports confirmed state through command responses."""
+
+    default_source = "command_response"
+    capabilities = frozenset({"command_response"})
+
+
+class FakeDroppedUnsolicitedBackend(FakeCivPushBackend):
+    """CI-V push fake that can deterministically drop selected push samples."""
+
+    capabilities = frozenset({"civ_push", "drops_unsolicited", "poll_response"})
+
+
+class FakePollingOnlyBackend(FakeStateBackend):
+    """Backend fake for radios that never emit unsolicited state."""
+
+    default_source = "state_poller"
+    capabilities = frozenset({"polling_only"})
+
+    def poll_response(self, path: FieldPath, value: Any) -> Observation:
+        return self.observation(path, value, source="state_poller")
+
+
+class FakeYaesuLikeBackend(FakePollingOnlyBackend):
+    """Yaesu-like request/response fake for CAT poller tests."""
+
+    capabilities = frozenset({"yaesu_cat", "polling_only", "command_response"})
+
+    def poll_response(self, path: FieldPath, value: Any) -> Observation:
+        return self.observation(path, value, source="yaesu_poll_response")
+
+
+class FakeExternalRigctldClientBackend(FakeStateBackend):
+    """Fake external Hamlib rigctld-client backend response source."""
+
+    default_source = "hamlib_response"
+    capabilities = frozenset({"external_rigctld_client", "poll_response"})
+
+    def poll_response(self, path: FieldPath, value: Any) -> Observation:
+        return self.observation(path, value, source="hamlib_response")
+
+
+def assert_revision_counters(
+    pipeline: FakeStatePipeline,
+    *,
+    state_revision: int,
+    freshness_revision: int,
+    observation_seq: int,
+) -> None:
+    assert pipeline.state_revision == state_revision
+    assert pipeline.freshness_revision == freshness_revision
+    assert pipeline.observation_seq == observation_seq
+
+
+def assert_consumer_delta(
+    changeset: ChangeSet,
+    *,
+    path: FieldPath,
+    previous: Any,
+    current: Any,
+) -> None:
+    assert changeset.changes == (
+        FieldChange(path=path, previous=previous, current=current),
+    )
+
+
+def assert_no_consumer_delta(changeset: ChangeSet | None) -> None:
+    assert changeset is None

--- a/tests/support/state_pipeline.py
+++ b/tests/support/state_pipeline.py
@@ -232,9 +232,7 @@ class FakeStatePipeline:
             ),
             timestamp_monotonic=observation.timestamp_monotonic,
             sources=(observation.source,),
-            freshness=()
-            if freshness_transition is None
-            else (freshness_transition,),
+            freshness=() if freshness_transition is None else (freshness_transition,),
         )
         self.consumer_deltas.append(changeset)
         return changeset
@@ -383,9 +381,7 @@ class FakePendingOverlayStore:
         ]
         if matched:
             self.overlays = [
-                overlay
-                for overlay in self.overlays
-                if overlay not in matched
+                overlay for overlay in self.overlays if overlay not in matched
             ]
         return matched
 

--- a/tests/support/state_pipeline.py
+++ b/tests/support/state_pipeline.py
@@ -317,6 +317,7 @@ class FakePendingOverlayStore:
         *,
         source: str,
         session_id: str | None,
+        command_id: str,
         path: FieldPath,
     ) -> Any | None:
         now = self.clock.now()
@@ -326,22 +327,37 @@ class FakePendingOverlayStore:
             if (
                 overlay.source == source
                 and overlay.session_id == session_id
+                and overlay.command_id == command_id
                 and overlay.path == path
             ):
                 return overlay.value
         return None
 
-    def confirm(self, path: FieldPath, value: Any) -> list[PendingOverlay]:
+    def confirm(
+        self,
+        *,
+        source: str,
+        session_id: str | None,
+        command_id: str,
+        path: FieldPath,
+        value: Any,
+    ) -> list[PendingOverlay]:
         matched = [
             overlay
             for overlay in self.overlays
-            if overlay.path == path and overlay.value == value
+            if (
+                overlay.source == source
+                and overlay.session_id == session_id
+                and overlay.command_id == command_id
+                and overlay.path == path
+                and overlay.value == value
+            )
         ]
         if matched:
             self.overlays = [
                 overlay
                 for overlay in self.overlays
-                if not (overlay.path == path and overlay.value == value)
+                if overlay not in matched
             ]
         return matched
 

--- a/tests/support/state_pipeline.py
+++ b/tests/support/state_pipeline.py
@@ -94,6 +94,7 @@ class ChangeSet:
     changes: tuple[FieldChange, ...]
     timestamp_monotonic: float
     sources: tuple[ObservationSource, ...]
+    freshness: tuple[FreshnessTransition, ...] = ()
     coalesced: bool = False
 
 
@@ -171,7 +172,7 @@ class FakeStatePipeline:
         self._freshness: dict[FieldPath, _FreshnessEntry] = {}
 
     def apply(self, observation: Observation | None) -> ChangeSet | None:
-        """Apply an observation and return a delta only for real value changes."""
+        """Apply an observation and return value or freshness deltas."""
 
         if observation is None:
             return None
@@ -181,6 +182,7 @@ class FakeStatePipeline:
 
         freshness_entry = self._freshness.get(observation.path)
         previous_freshness = freshness_entry.state if freshness_entry else "unknown"
+        freshness_transition: FreshnessTransition | None = None
         self._freshness[observation.path] = _FreshnessEntry(
             state="fresh",
             last_observed=observation.timestamp_monotonic,
@@ -189,10 +191,30 @@ class FakeStatePipeline:
         )
         if previous_freshness != "fresh":
             self.freshness_revision += 1
+            freshness_transition = FreshnessTransition(
+                path=observation.path,
+                previous=previous_freshness,
+                current="fresh",
+                freshness_revision=self.freshness_revision,
+                timestamp_monotonic=observation.timestamp_monotonic,
+            )
+            self.freshness_events.append(freshness_transition)
 
         previous = self._state.get(observation.path)
         if observation.path in self._state and previous == observation.value:
-            return None
+            if previous_freshness == "fresh":
+                return None
+            changeset = ChangeSet(
+                state_revision=self.state_revision,
+                freshness_revision=self.freshness_revision,
+                observation_seq=self.observation_seq,
+                changes=(),
+                timestamp_monotonic=observation.timestamp_monotonic,
+                sources=(observation.source,),
+                freshness=(freshness_transition,),
+            )
+            self.consumer_deltas.append(changeset)
+            return changeset
 
         self._state[observation.path] = observation.value
         self.state_revision += 1
@@ -209,6 +231,9 @@ class FakeStatePipeline:
             ),
             timestamp_monotonic=observation.timestamp_monotonic,
             sources=(observation.source,),
+            freshness=()
+            if freshness_transition is None
+            else (freshness_transition,),
         )
         self.consumer_deltas.append(changeset)
         return changeset
@@ -342,11 +367,13 @@ class FakePendingOverlayStore:
         path: FieldPath,
         value: Any,
     ) -> list[PendingOverlay]:
+        now = self.clock.now()
         matched = [
             overlay
             for overlay in self.overlays
             if (
-                overlay.source == source
+                overlay.expires_at > now
+                and overlay.source == source
                 and overlay.session_id == session_id
                 and overlay.command_id == command_id
                 and overlay.path == path
@@ -528,3 +555,13 @@ def assert_consumer_delta(
 
 def assert_no_consumer_delta(changeset: ChangeSet | None) -> None:
     assert changeset is None
+
+
+def assert_freshness_only_delta(
+    changeset: ChangeSet | None,
+    *,
+    path: FieldPath,
+) -> None:
+    assert changeset is not None
+    assert changeset.changes == ()
+    assert tuple(event.path for event in changeset.freshness) == (path,)

--- a/tests/test_acquisition_scheduler.py
+++ b/tests/test_acquisition_scheduler.py
@@ -570,8 +570,7 @@ def test_mixed_pollable_and_unsolicited_paths_are_not_emitted_as_one_poll() -> N
     requests = scheduler.pending_requests()
     assert len(requests) == 2
     assert not any(
-        request.acquisition_method == "poll"
-        and set(request.paths) == {freq, ptt}
+        request.acquisition_method == "poll" and set(request.paths) == {freq, ptt}
         for request in requests
     )
     requests_by_path = {request.paths: request for request in requests}
@@ -724,7 +723,9 @@ def test_stale_unsolicited_field_queues_reconciliation_and_accepts_readback() ->
         priority="reconciliation",
         reason="missed-unsolicited",
     )
-    reconciled = store.apply(_observation(freq, 14_076_000, at=clock.now(), max_age=0.5))
+    reconciled = store.apply(
+        _observation(freq, 14_076_000, at=clock.now(), max_age=0.5)
+    )
 
     assert stale.changes == ()
     assert stale.reconciliation_requests[0].path == freq

--- a/tests/test_acquisition_scheduler.py
+++ b/tests/test_acquisition_scheduler.py
@@ -215,6 +215,46 @@ def test_same_family_requests_share_one_acquisition_request() -> None:
     assert scheduler.pending_requests() == (mode_result.request,)
 
 
+def test_recording_older_coalesced_request_preserves_newer_pending_paths() -> None:
+    clock = FreshnessClock(start=36.0)
+    freq = FieldPath.active("main", "freq_mode", "freq_hz")
+    mode = FieldPath.active("main", "freq_mode", "mode")
+    scheduler = AcquisitionScheduler(profile=_profile([freq, mode]), clock=clock)
+
+    freq_result = scheduler.ensure_fresh(
+        freq,
+        max_age=5.0,
+        priority="background",
+        reason="background-freq",
+        timeout=10.0,
+    )
+    assert freq_result.request is not None
+    stale_executor_copy = freq_result.request
+    mode_result = scheduler.ensure_fresh(
+        mode,
+        max_age=0.5,
+        priority="user",
+        reason="visible-mode",
+        timeout=2.0,
+    )
+    assert mode_result.request is not None
+    assert mode_result.request.id == stale_executor_copy.id
+    assert mode_result.request.paths == (freq, mode)
+
+    scheduler.record_acquisition_result(
+        stale_executor_copy,
+        _changeset(
+            changes=(FieldChange(path=freq, previous=7_074_000, current=14_074_000),),
+            at=clock.now(),
+        ),
+    )
+
+    pending = scheduler.pending_requests()
+    assert len(pending) == 1
+    assert pending[0].id == stale_executor_copy.id
+    assert pending[0].paths == (mode,)
+
+
 def test_user_facing_requests_preempt_background_telemetry() -> None:
     clock = FreshnessClock(start=40.0)
     meter = FieldPath.receiver("main", "meters", "s_meter")
@@ -726,6 +766,26 @@ def test_due_polling_emits_only_pollable_cadence_fields_and_groups_by_existing_k
     assert scheduler.pending_requests() == requests
 
 
+def test_due_polling_does_not_reemit_pending_cadence_request() -> None:
+    clock = FreshnessClock(start=202.0)
+    freq = FieldPath.active("main", "freq_mode", "freq_hz")
+    scheduler = AcquisitionScheduler(
+        profile=_profile(
+            [freq],
+            default_policy=AcquisitionPolicy(cadence_seconds=1.0),
+        ),
+        clock=clock,
+    )
+
+    first = scheduler.due_requests(now=clock.now())
+    second = scheduler.due_requests(now=clock.now())
+
+    assert len(first) == 1
+    assert first[0].paths == (freq,)
+    assert second == ()
+    assert scheduler.pending_requests() == first
+
+
 def test_due_polling_skips_unsupported_unhooked_and_unsolicited_only_fields() -> None:
     clock = FreshnessClock(start=205.0)
     supported = FieldPath.active("main", "freq_mode", "freq_hz")
@@ -874,7 +934,7 @@ def test_meter_coalescing_latest_sample_wins_and_exposes_drop_counts() -> None:
     coalescer.record(_observation(meter, 42, at=clock.now()), policy)
 
     assert coalescer.flush_due(store, now=clock.now() + 0.14) is None
-    changeset = coalescer.flush_due(store, now=clock.now() + 0.15)
+    changeset = coalescer.flush_due(store, now=clock.now() + 0.2)
 
     assert changeset is not None
     assert changeset.coalesced is True
@@ -885,3 +945,53 @@ def test_meter_coalescing_latest_sample_wins_and_exposes_drop_counts() -> None:
     assert diagnostics["droppedSampleCount"] == 1
     assert diagnostics["coalescedSampleCount"] == 1
     assert diagnostics["pendingSampleCount"] == 0
+
+
+def test_meter_coalescing_flush_uses_latest_batch_timestamp_not_last_path() -> None:
+    clock = FreshnessClock(start=250.0)
+    store = StateStore(freshness_clock=clock)
+    power = FieldPath.receiver("main", "meters", "power")
+    s_meter = FieldPath.receiver("main", "meters", "s_meter")
+    policy = MeterCoalescingPolicy(window_seconds=0.1)
+    coalescer = MeterObservationCoalescer()
+
+    coalescer.record(_observation(s_meter, 3, at=10.0), policy)
+    coalescer.record(_observation(power, 40, at=10.5), policy)
+
+    changeset = coalescer.flush(store)
+
+    assert changeset is not None
+    assert changeset.coalesced is True
+    assert changeset.timestamp_monotonic == 10.5
+    assert changeset.revision == 2
+    assert changeset.observation_seq == 2
+    assert {change.path for change in changeset.changes} == {power, s_meter}
+
+
+def test_meter_coalescing_flush_due_leaves_longer_window_samples_pending() -> None:
+    clock = FreshnessClock(start=260.0)
+    store = StateStore(freshness_clock=clock)
+    power = FieldPath.receiver("main", "meters", "power")
+    s_meter = FieldPath.receiver("main", "meters", "s_meter")
+    short_policy = MeterCoalescingPolicy(window_seconds=0.1)
+    long_policy = MeterCoalescingPolicy(window_seconds=1.0)
+    coalescer = MeterObservationCoalescer()
+
+    coalescer.record(_observation(power, 40, at=clock.now()), short_policy)
+    coalescer.record(_observation(s_meter, 3, at=clock.now()), long_policy)
+
+    first = coalescer.flush_due(store, now=clock.now() + 0.1)
+
+    assert first is not None
+    assert [change.path for change in first.changes] == [power]
+    assert store.snapshot().field(power).value == 40
+    diagnostics = coalescer.diagnostics()
+    assert diagnostics["pendingSampleCount"] == 1
+    assert diagnostics["pendingPaths"] == [str(s_meter)]
+
+    second = coalescer.flush_due(store, now=clock.now() + 1.0)
+
+    assert second is not None
+    assert [change.path for change in second.changes] == [s_meter]
+    assert store.snapshot().field(s_meter).value == 3
+    assert coalescer.diagnostics()["pendingSampleCount"] == 0

--- a/tests/test_acquisition_scheduler.py
+++ b/tests/test_acquisition_scheduler.py
@@ -243,6 +243,25 @@ def test_external_cat_pause_defers_conflicting_polling_and_resume_queues_it() ->
     assert scheduler.pending_requests() == resumed
 
 
+def test_external_cat_pause_hides_existing_conflicting_poll_request() -> None:
+    clock = FreshnessClock(start=51.0)
+    freq = FieldPath.active("main", "freq_mode", "freq_hz")
+    scheduler = AcquisitionScheduler(profile=_profile([freq]), clock=clock)
+
+    result = scheduler.ensure_fresh(
+        freq,
+        max_age=0.5,
+        priority="background",
+        reason="background-poll",
+    )
+    assert result.request is not None
+    assert scheduler.pending_requests() == (result.request,)
+
+    scheduler.pause_external_cat(owner="hamlib-client", reason="raw-cat-session")
+
+    assert scheduler.pending_requests() == ()
+
+
 def test_external_cat_continue_policy_allows_non_conflicting_request() -> None:
     clock = FreshnessClock(start=60.0)
     ptt = FieldPath.global_("tx_state", "ptt")
@@ -265,6 +284,30 @@ def test_external_cat_continue_policy_allows_non_conflicting_request() -> None:
     assert result.status is AcquisitionStatus.QUEUED
     assert result.request is not None
     assert result.request.external_cat_paused is True
+
+
+def test_external_cat_pause_preserves_existing_continue_policy_request() -> None:
+    clock = FreshnessClock(start=61.0)
+    ptt = FieldPath.global_("tx_state", "ptt")
+    profile = _profile(
+        [ptt],
+        default_policy=AcquisitionPolicy(
+            external_cat_pause=ExternalCatPauseBehavior.CONTINUE,
+        ),
+    )
+    scheduler = AcquisitionScheduler(profile=profile, clock=clock)
+
+    result = scheduler.ensure_fresh(
+        ptt,
+        max_age=1.0,
+        priority="reconciliation",
+        reason="ptt-reconcile",
+    )
+    assert result.request is not None
+
+    scheduler.pause_external_cat(owner="hamlib-client", reason="raw-cat-session")
+
+    assert scheduler.pending_requests() == (result.request,)
 
 
 def test_external_cat_pause_defers_only_pause_policy_groups() -> None:
@@ -303,6 +346,40 @@ def test_external_cat_pause_defers_only_pause_policy_groups() -> None:
     assert len(resumed) == 1
     assert resumed[0].paths == (freq,)
     assert scheduler.pending_requests() == (result.request, resumed[0])
+
+
+def test_external_cat_resume_requeues_existing_deferred_request_once() -> None:
+    clock = FreshnessClock(start=62.5)
+    freq = FieldPath.active("main", "freq_mode", "freq_hz")
+    scheduler = AcquisitionScheduler(profile=_profile([freq]), clock=clock)
+
+    result = scheduler.ensure_fresh(
+        freq,
+        max_age=0.5,
+        priority="background",
+        reason="background-poll",
+        timeout=2.0,
+    )
+    assert result.request is not None
+
+    scheduler.pause_external_cat(owner="hamlib-client", reason="raw-cat-session")
+    assert scheduler.pending_requests() == ()
+
+    resumed = scheduler.resume_external_cat()
+
+    assert len(resumed) == 1
+    assert resumed[0].paths == (freq,)
+    assert resumed[0].priority is AcquisitionPriority.BACKGROUND
+    assert resumed[0].reason == "background-poll"
+    assert resumed[0].reasons == ("background-poll",)
+    assert resumed[0].max_age == 0.5
+    assert resumed[0].timeout == 2.0
+    assert resumed[0].requested_at_monotonic == 62.5
+    assert resumed[0].deadline_monotonic == 63.0
+    assert resumed[0].external_cat_owner == "hamlib-client"
+    assert scheduler.pending_requests() == resumed
+    assert scheduler.resume_external_cat() == ()
+    assert scheduler.pending_requests() == resumed
 
 
 def test_external_cat_resume_dedupes_same_family_deferred_requests() -> None:

--- a/tests/test_acquisition_scheduler.py
+++ b/tests/test_acquisition_scheduler.py
@@ -995,3 +995,33 @@ def test_meter_coalescing_flush_due_leaves_longer_window_samples_pending() -> No
     assert [change.path for change in second.changes] == [s_meter]
     assert store.snapshot().field(s_meter).value == 3
     assert coalescer.diagnostics()["pendingSampleCount"] == 0
+
+
+def test_meter_coalescing_flush_due_defers_same_path_until_latest_window() -> None:
+    clock = FreshnessClock(start=270.0)
+    store = StateStore(freshness_clock=clock)
+    meter = FieldPath.receiver("main", "meters", "s_meter")
+    policy = MeterCoalescingPolicy(window_seconds=0.2)
+    coalescer = MeterObservationCoalescer()
+
+    coalescer.record(_observation(meter, 40, at=clock.now()), policy)
+    clock.advance(0.05)
+    coalescer.record(_observation(meter, 41, at=clock.now()), policy)
+
+    assert coalescer.flush_due(store, now=270.2) is None
+    diagnostics = coalescer.diagnostics()
+    assert diagnostics["coalescedSampleCount"] == 0
+    assert diagnostics["pendingSampleCount"] == 2
+    assert diagnostics["pendingPaths"] == [str(meter), str(meter)]
+    assert diagnostics["nextFlushMonotonic"] == 270.25
+
+    changeset = coalescer.flush_due(store, now=270.25)
+
+    assert changeset is not None
+    assert changeset.coalesced is True
+    assert changeset.changes[0].current == 41
+    assert store.snapshot().field(meter).value == 41
+    assert store.snapshot().state_revision == 1
+    diagnostics = coalescer.diagnostics()
+    assert diagnostics["coalescedSampleCount"] == 1
+    assert diagnostics["pendingSampleCount"] == 0

--- a/tests/test_acquisition_scheduler.py
+++ b/tests/test_acquisition_scheduler.py
@@ -25,7 +25,7 @@ from rigplane.core.state_pipeline_contracts import (
     Observation,
     SourceMetadata,
 )
-from rigplane.core.state_store import FreshnessClock, StateStore
+from rigplane.core.state_store import FreshnessClock, FreshnessState, StateStore
 
 
 def _source() -> SourceMetadata:
@@ -645,3 +645,32 @@ def test_model_service_queues_when_field_observation_max_age_expired_without_mar
     assert result.fields == ()
     assert result.request is not None
     assert result.request.paths == (freq,)
+
+
+def test_stale_unsolicited_field_queues_reconciliation_and_accepts_readback() -> None:
+    clock = FreshnessClock(start=110.0)
+    freq = FieldPath.active("main", "freq_mode", "freq_hz")
+    store = StateStore(freshness_clock=clock)
+    scheduler = AcquisitionScheduler(profile=_profile([freq]), clock=clock)
+    service = RadioStateModelService(store=store, scheduler=scheduler, clock=clock)
+
+    store.apply(_observation(freq, 14_074_000, at=clock.now(), max_age=0.5))
+    clock.advance(0.6)
+
+    stale = store.mark_stale_due()
+    queued = service.ensure_fresh(
+        freq,
+        max_age=0.5,
+        priority="reconciliation",
+        reason="missed-unsolicited",
+    )
+    reconciled = store.apply(_observation(freq, 14_076_000, at=clock.now(), max_age=0.5))
+
+    assert stale.changes == ()
+    assert stale.reconciliation_requests[0].path == freq
+    assert queued.status is AcquisitionStatus.QUEUED
+    assert queued.request is not None
+    assert queued.request.paths == (freq,)
+    assert reconciled.revision == 2
+    assert store.snapshot().field(freq).freshness is FreshnessState.FRESH
+    assert store.snapshot().field(freq).value == 14_076_000

--- a/tests/test_acquisition_scheduler.py
+++ b/tests/test_acquisition_scheduler.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from dataclasses import replace
 from typing import Any
 
 from rigplane.core.acquisition_scheduler import (
@@ -885,6 +886,74 @@ def test_semantic_change_resets_adaptive_cadence_to_base_policy() -> None:
     assert scheduler.due_requests() == ()
     clock.advance(0.1)
     assert scheduler.due_requests()[0].paths == (freq,)
+
+
+def test_grouped_partial_semantic_change_resets_adaptive_cadence_after_all_paths_complete() -> (
+    None
+):
+    policy = AcquisitionPolicy(
+        cadence_seconds=2.0,
+        freshness_ttl_seconds=10.0,
+        adaptive_decay=AdaptiveDecayPolicy(
+            enabled=True,
+            idle_multiplier=2.0,
+            max_cadence_seconds=8.0,
+        ),
+    )
+    freq = FieldPath.active("main", "freq_mode", "freq_hz")
+    mode = FieldPath.active("main", "freq_mode", "mode")
+    cases = (
+        (
+            FreshnessClock(start=230.0),
+            freq,
+            mode,
+            FieldChange(path=freq, previous=7_074_000, current=14_074_000),
+        ),
+        (
+            FreshnessClock(start=250.0),
+            mode,
+            freq,
+            FieldChange(path=mode, previous="USB", current="LSB"),
+        ),
+    )
+
+    for clock, changed_path, unchanged_path, change in cases:
+        scheduler = AcquisitionScheduler(
+            profile=_profile([changed_path, unchanged_path], default_policy=policy),
+            clock=clock,
+        )
+
+        first = scheduler.due_requests()[0]
+        scheduler.record_acquisition_result(first, _changeset(at=clock.now()))
+        clock.advance(4.0)
+
+        grouped = scheduler.due_requests()[0]
+        changed_slice = replace(
+            grouped,
+            paths=(changed_path,),
+            capability_ids=(str(changed_path),),
+        )
+        scheduler.record_acquisition_result(
+            changed_slice,
+            _changeset(changes=(change,), at=clock.now()),
+        )
+        unchanged_slice = scheduler.pending_requests()[0]
+        assert unchanged_slice.paths == (unchanged_path,)
+
+        scheduler.record_acquisition_result(
+            unchanged_slice,
+            _changeset(at=clock.now()),
+        )
+
+        diagnostics = scheduler.diagnostics()
+        assert (
+            diagnostics["cadenceByPath"][str(changed_path)]["currentCadenceSeconds"]
+            == 2.0
+        )
+        assert (
+            diagnostics["cadenceByPath"][str(unchanged_path)]["currentCadenceSeconds"]
+            == 2.0
+        )
 
 
 def test_diagnostics_include_cadence_next_due_pending_pressure_and_counts() -> None:

--- a/tests/test_acquisition_scheduler.py
+++ b/tests/test_acquisition_scheduler.py
@@ -1,0 +1,334 @@
+"""Minimal acquisition scheduler behavior for MOR-339."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from rigplane.core.acquisition_scheduler import (
+    AcquisitionPriority,
+    AcquisitionScheduler,
+    AcquisitionStatus,
+    RadioStateModelService,
+)
+from rigplane.core.state_acquisition_policy import (
+    AcquisitionPolicy,
+    ExternalCatPauseBehavior,
+    FieldAvailability,
+    FieldCapability,
+    MeterCoalescingPolicy,
+    RadioAcquisitionProfile,
+)
+from rigplane.core.state_pipeline_contracts import (
+    FieldPath,
+    Observation,
+    SourceMetadata,
+)
+from rigplane.core.state_store import FreshnessClock, StateStore
+
+
+def _source() -> SourceMetadata:
+    return SourceMetadata(source="poll_response", provider="test", transport="fake")
+
+
+def _observation(
+    path: FieldPath,
+    value: Any,
+    *,
+    at: float,
+    max_age: float | None = None,
+) -> Observation:
+    return Observation(
+        path=path,
+        value=value,
+        source=_source(),
+        timestamp_monotonic=at,
+        max_age=max_age,
+    )
+
+
+def _profile(
+    paths: Iterable[FieldPath],
+    *,
+    default_policy: AcquisitionPolicy | None = None,
+    field_policies: dict[FieldPath, AcquisitionPolicy] | None = None,
+) -> RadioAcquisitionProfile:
+    return RadioAcquisitionProfile(
+        provider="test_provider",
+        capabilities=tuple(
+            FieldCapability(
+                path=path,
+                polling=True,
+                stream_like=path.family.value == "meters",
+                command_response_observable=path.family.value == "operator_controls",
+                supported_controls=(
+                    ("set_level",) if path.family.value == "operator_controls" else ()
+                ),
+            )
+            for path in paths
+        ),
+        default_policy=default_policy or AcquisitionPolicy(),
+        field_policies=field_policies or {},
+    )
+
+
+def test_model_service_returns_fresh_snapshot_without_queueing_acquisition() -> None:
+    clock = FreshnessClock(start=10.0)
+    freq = FieldPath.active("main", "freq_mode", "freq_hz")
+    store = StateStore(freshness_clock=clock)
+    store.apply(_observation(freq, 14_074_000, at=clock.now(), max_age=5.0))
+    scheduler = AcquisitionScheduler(profile=_profile([freq]), clock=clock)
+    service = RadioStateModelService(store=store, scheduler=scheduler, clock=clock)
+
+    result = service.ensure_fresh(
+        freq,
+        max_age=2.0,
+        priority=AcquisitionPriority.USER,
+        reason="rigctld-get",
+    )
+
+    assert result.status is AcquisitionStatus.FRESH
+    assert result.fields[0].path == freq
+    assert result.fields[0].value == 14_074_000
+    assert result.request is None
+    assert scheduler.pending_requests() == ()
+
+
+def test_model_service_queues_backend_neutral_request_for_stale_field() -> None:
+    clock = FreshnessClock(start=20.0)
+    freq = FieldPath.active("main", "freq_mode", "freq_hz")
+    store = StateStore(freshness_clock=clock)
+    store.apply(_observation(freq, 7_074_000, at=clock.now(), max_age=0.5))
+    scheduler = AcquisitionScheduler(profile=_profile([freq]), clock=clock)
+    service = RadioStateModelService(store=store, scheduler=scheduler, clock=clock)
+    clock.advance(0.6)
+    store.mark_stale_due()
+
+    result = service.ensure_fresh(
+        freq,
+        max_age=0.25,
+        priority="user",
+        reason="web-snapshot",
+        timeout=1.5,
+    )
+
+    assert result.status is AcquisitionStatus.QUEUED
+    assert result.request is not None
+    assert result.request.paths == (freq,)
+    assert result.request.provider == "test_provider"
+    assert result.request.priority is AcquisitionPriority.USER
+    assert result.request.reason == "web-snapshot"
+    assert result.request.max_age == 0.25
+    assert result.request.timeout == 1.5
+    assert result.request.deadline_monotonic == 20.85
+    assert result.request.acquisition_method == "poll"
+    assert result.request.policy.freshness_ttl_seconds == 15.0
+    assert scheduler.pending_requests() == (result.request,)
+
+
+def test_duplicate_requests_coalesce_with_highest_priority_and_urgent_deadline() -> (
+    None
+):
+    clock = FreshnessClock(start=30.0)
+    freq = FieldPath.active("main", "freq_mode", "freq_hz")
+    scheduler = AcquisitionScheduler(profile=_profile([freq]), clock=clock)
+
+    low = scheduler.ensure_fresh(
+        freq,
+        max_age=5.0,
+        priority=AcquisitionPriority.BACKGROUND,
+        reason="telemetry",
+        timeout=10.0,
+    )
+    clock.advance(1.0)
+    high = scheduler.ensure_fresh(
+        freq,
+        max_age=0.5,
+        priority=AcquisitionPriority.USER,
+        reason="user-read",
+        timeout=2.0,
+    )
+
+    assert low.status is AcquisitionStatus.QUEUED
+    assert high.status is AcquisitionStatus.QUEUED
+    assert high.request is not None
+    assert low.request is not None
+    assert high.request.id == low.request.id
+    assert high.request.priority is AcquisitionPriority.USER
+    assert high.request.max_age == 0.5
+    assert high.request.deadline_monotonic == 31.5
+    assert high.request.reasons == ("telemetry", "user-read")
+    assert scheduler.pending_requests() == (high.request,)
+
+
+def test_user_facing_requests_preempt_background_telemetry() -> None:
+    clock = FreshnessClock(start=40.0)
+    meter = FieldPath.receiver("main", "meters", "s_meter")
+    mode = FieldPath.active("main", "freq_mode", "mode")
+    scheduler = AcquisitionScheduler(profile=_profile([meter, mode]), clock=clock)
+
+    background = scheduler.ensure_fresh(
+        meter,
+        max_age=1.0,
+        priority="background",
+        reason="meter-tick",
+    )
+    user = scheduler.ensure_fresh(
+        mode,
+        max_age=1.0,
+        priority="user",
+        reason="visible-mode",
+    )
+
+    assert background.request is not None
+    assert user.request is not None
+    assert scheduler.pending_requests() == (user.request, background.request)
+
+
+def test_external_cat_pause_defers_conflicting_polling_and_resume_queues_it() -> None:
+    clock = FreshnessClock(start=50.0)
+    freq = FieldPath.active("main", "freq_mode", "freq_hz")
+    scheduler = AcquisitionScheduler(profile=_profile([freq]), clock=clock)
+
+    scheduler.pause_external_cat(owner="hamlib-client", reason="raw-cat-session")
+    paused = scheduler.ensure_fresh(
+        freq,
+        max_age=0.5,
+        priority="user",
+        reason="rigctld-get",
+    )
+
+    assert paused.status is AcquisitionStatus.DEFERRED
+    assert paused.request is None
+    assert scheduler.pending_requests() == ()
+    resumed = scheduler.resume_external_cat()
+    assert len(resumed) == 1
+    assert resumed[0].paths == (freq,)
+    assert resumed[0].external_cat_owner == "hamlib-client"
+    assert scheduler.pending_requests() == resumed
+
+
+def test_external_cat_continue_policy_allows_non_conflicting_request() -> None:
+    clock = FreshnessClock(start=60.0)
+    ptt = FieldPath.global_("tx_state", "ptt")
+    profile = _profile(
+        [ptt],
+        default_policy=AcquisitionPolicy(
+            external_cat_pause=ExternalCatPauseBehavior.CONTINUE,
+        ),
+    )
+    scheduler = AcquisitionScheduler(profile=profile, clock=clock)
+
+    scheduler.pause_external_cat(owner="hamlib-client")
+    result = scheduler.ensure_fresh(
+        ptt,
+        max_age=1.0,
+        priority="reconciliation",
+        reason="ptt-reconcile",
+    )
+
+    assert result.status is AcquisitionStatus.QUEUED
+    assert result.request is not None
+    assert result.request.external_cat_paused is True
+
+
+def test_capability_metadata_reports_unavailable_without_backend_delivery() -> None:
+    clock = FreshnessClock(start=70.0)
+    power = FieldPath.global_("tx_state", "power_on")
+    profile = RadioAcquisitionProfile(
+        provider="external_rigctld",
+        capabilities=(
+            FieldCapability(
+                path=power,
+                availability=FieldAvailability.UNSUPPORTED,
+                diagnostic="Hamlib model does not expose power state",
+            ),
+        ),
+    )
+    scheduler = AcquisitionScheduler(profile=profile, clock=clock)
+
+    result = scheduler.ensure_fresh(
+        power,
+        max_age=1.0,
+        priority="user",
+        reason="startup-read",
+    )
+
+    assert result.status is AcquisitionStatus.UNAVAILABLE
+    assert result.request is None
+    assert "does not expose power state" in result.message
+
+
+def test_policy_inputs_for_meters_and_slow_controls_are_preserved_on_request() -> None:
+    clock = FreshnessClock(start=80.0)
+    meter = FieldPath.receiver("main", "meters", "s_meter")
+    af_level = FieldPath.receiver("main", "operator_controls", "af_level")
+    profile = _profile(
+        [meter, af_level],
+        field_policies={
+            meter: AcquisitionPolicy(
+                cadence_seconds=0.2,
+                freshness_ttl_seconds=0.6,
+                meter_coalescing=MeterCoalescingPolicy(window_seconds=0.1),
+            ),
+            af_level: AcquisitionPolicy(
+                cadence_seconds=30.0,
+                freshness_ttl_seconds=120.0,
+            ),
+        },
+    )
+    scheduler = AcquisitionScheduler(profile=profile, clock=clock)
+
+    meter_result = scheduler.ensure_fresh(
+        meter,
+        max_age=0.3,
+        priority="background",
+        reason="meter-refresh",
+    )
+    control_result = scheduler.ensure_fresh(
+        af_level,
+        max_age=60.0,
+        priority="normal",
+        reason="settings-panel",
+    )
+
+    assert meter_result.request is not None
+    assert control_result.request is not None
+    assert meter_result.request.policy.meter_coalescing is not None
+    assert meter_result.request.policy.meter_coalescing.window_seconds == 0.1
+    assert control_result.request.policy.cadence_seconds == 30.0
+    assert control_result.request.acquisition_method == "poll"
+
+
+def test_scheduler_output_can_return_observation_applied_through_state_store() -> None:
+    clock = FreshnessClock(start=90.0)
+    freq = FieldPath.active("main", "freq_mode", "freq_hz")
+    store = StateStore(freshness_clock=clock)
+    scheduler = AcquisitionScheduler(profile=_profile([freq]), clock=clock)
+    service = RadioStateModelService(store=store, scheduler=scheduler, clock=clock)
+
+    result = service.ensure_fresh(
+        freq,
+        max_age=1.0,
+        priority="user",
+        reason="initial-snapshot",
+    )
+    assert result.request is not None
+
+    change = store.apply(
+        Observation(
+            path=result.request.paths[0],
+            value=14_074_000,
+            source=SourceMetadata(
+                source="poll_response",
+                provider=result.request.provider,
+                transport="fake",
+                capability_id=result.request.capability_ids[0],
+            ),
+            timestamp_monotonic=clock.now(),
+            max_age=result.request.max_age,
+        )
+    )
+
+    assert change.revision == 1
+    assert store.snapshot().field(freq).value == 14_074_000

--- a/tests/test_acquisition_scheduler.py
+++ b/tests/test_acquisition_scheduler.py
@@ -18,6 +18,7 @@ from rigplane.core.state_acquisition_policy import (
     FieldCapability,
     MeterCoalescingPolicy,
     RadioAcquisitionProfile,
+    ReconciliationPriority,
 )
 from rigplane.core.state_pipeline_contracts import (
     FieldPath,
@@ -266,6 +267,80 @@ def test_external_cat_continue_policy_allows_non_conflicting_request() -> None:
     assert result.request.external_cat_paused is True
 
 
+def test_external_cat_pause_defers_only_pause_policy_groups() -> None:
+    clock = FreshnessClock(start=62.0)
+    freq = FieldPath.active("main", "freq_mode", "freq_hz")
+    ptt = FieldPath.global_("tx_state", "ptt")
+    profile = _profile(
+        [freq, ptt],
+        field_policies={
+            freq: AcquisitionPolicy(
+                external_cat_pause=ExternalCatPauseBehavior.PAUSE_POLLING,
+            ),
+            ptt: AcquisitionPolicy(
+                external_cat_pause=ExternalCatPauseBehavior.CONTINUE,
+            ),
+        },
+    )
+    scheduler = AcquisitionScheduler(profile=profile, clock=clock)
+
+    scheduler.pause_external_cat(owner="hamlib-client")
+    result = scheduler.ensure_fresh(
+        [ptt, freq],
+        max_age=1.0,
+        priority="user",
+        reason="mixed-snapshot",
+    )
+
+    assert result.status is AcquisitionStatus.QUEUED
+    assert result.request is not None
+    assert result.request.paths == (ptt,)
+    assert result.request.external_cat_paused is True
+    assert scheduler.pending_requests() == (result.request,)
+
+    resumed = scheduler.resume_external_cat()
+
+    assert len(resumed) == 1
+    assert resumed[0].paths == (freq,)
+    assert scheduler.pending_requests() == (result.request, resumed[0])
+
+
+def test_external_cat_resume_dedupes_same_family_deferred_requests() -> None:
+    clock = FreshnessClock(start=63.0)
+    freq = FieldPath.active("main", "freq_mode", "freq_hz")
+    mode = FieldPath.active("main", "freq_mode", "mode")
+    scheduler = AcquisitionScheduler(profile=_profile([freq, mode]), clock=clock)
+
+    scheduler.pause_external_cat(owner="hamlib-client")
+    freq_result = scheduler.ensure_fresh(
+        freq,
+        max_age=5.0,
+        priority="background",
+        reason="background-freq",
+    )
+    clock.advance(1.0)
+    mode_result = scheduler.ensure_fresh(
+        mode,
+        max_age=0.5,
+        priority="user",
+        reason="visible-mode",
+    )
+
+    assert freq_result.status is AcquisitionStatus.DEFERRED
+    assert mode_result.status is AcquisitionStatus.DEFERRED
+    assert scheduler.pending_requests() == ()
+
+    resumed = scheduler.resume_external_cat()
+
+    assert len(resumed) == 1
+    assert resumed[0].paths == (freq, mode)
+    assert resumed[0].priority is AcquisitionPriority.USER
+    assert resumed[0].max_age == 0.5
+    assert resumed[0].deadline_monotonic == 64.5
+    assert resumed[0].reasons == ("background-freq", "visible-mode")
+    assert scheduler.pending_requests() == resumed
+
+
 def test_capability_metadata_reports_unavailable_without_backend_delivery() -> None:
     clock = FreshnessClock(start=70.0)
     power = FieldPath.global_("tx_state", "power_on")
@@ -365,6 +440,38 @@ def test_mixed_pollable_and_unsolicited_paths_are_not_emitted_as_one_poll() -> N
     requests_by_path = {request.paths: request for request in requests}
     assert requests_by_path[(freq,)].acquisition_method == "poll"
     assert requests_by_path[(ptt,)].acquisition_method == "wait_for_unsolicited"
+
+
+def test_policy_preferred_command_response_beats_polling_capability() -> None:
+    clock = FreshnessClock(start=85.5)
+    mode = FieldPath.active("main", "freq_mode", "mode")
+    profile = RadioAcquisitionProfile(
+        provider="x6200_like",
+        capabilities=(
+            FieldCapability(
+                path=mode,
+                polling=True,
+                command_response_observable=True,
+            ),
+        ),
+        field_policies={
+            mode: AcquisitionPolicy(
+                reconciliation_priority=ReconciliationPriority.COMMAND_RESPONSE,
+            ),
+        },
+    )
+    scheduler = AcquisitionScheduler(profile=profile, clock=clock)
+
+    result = scheduler.ensure_fresh(
+        mode,
+        max_age=1.0,
+        priority="reconciliation",
+        reason="x6200-mode-reconcile",
+    )
+
+    assert result.status is AcquisitionStatus.QUEUED
+    assert result.request is not None
+    assert result.request.acquisition_method == "command_response"
 
 
 def test_mixed_meter_and_frequency_request_preserves_meter_coalescing_policy() -> None:

--- a/tests/test_acquisition_scheduler.py
+++ b/tests/test_acquisition_scheduler.py
@@ -161,6 +161,40 @@ def test_duplicate_requests_coalesce_with_highest_priority_and_urgent_deadline()
     assert scheduler.pending_requests() == (high.request,)
 
 
+def test_same_family_requests_share_one_acquisition_request() -> None:
+    clock = FreshnessClock(start=35.0)
+    freq = FieldPath.active("main", "freq_mode", "freq_hz")
+    mode = FieldPath.active("main", "freq_mode", "mode")
+    scheduler = AcquisitionScheduler(profile=_profile([freq, mode]), clock=clock)
+
+    freq_result = scheduler.ensure_fresh(
+        freq,
+        max_age=5.0,
+        priority="background",
+        reason="background-freq",
+        timeout=10.0,
+    )
+    clock.advance(1.0)
+    mode_result = scheduler.ensure_fresh(
+        mode,
+        max_age=0.5,
+        priority="user",
+        reason="visible-mode",
+        timeout=2.0,
+    )
+
+    assert freq_result.request is not None
+    assert mode_result.request is not None
+    assert mode_result.request.id == freq_result.request.id
+    assert mode_result.request.paths == (freq, mode)
+    assert mode_result.request.priority is AcquisitionPriority.USER
+    assert mode_result.request.deadline_monotonic == 36.5
+    assert mode_result.request.max_age == 0.5
+    assert mode_result.request.timeout == 2.0
+    assert mode_result.request.reasons == ("background-freq", "visible-mode")
+    assert scheduler.pending_requests() == (mode_result.request,)
+
+
 def test_user_facing_requests_preempt_background_telemetry() -> None:
     clock = FreshnessClock(start=40.0)
     meter = FieldPath.receiver("main", "meters", "s_meter")
@@ -300,6 +334,77 @@ def test_policy_inputs_for_meters_and_slow_controls_are_preserved_on_request() -
     assert control_result.request.acquisition_method == "poll"
 
 
+def test_mixed_pollable_and_unsolicited_paths_are_not_emitted_as_one_poll() -> None:
+    clock = FreshnessClock(start=85.0)
+    freq = FieldPath.active("main", "freq_mode", "freq_hz")
+    ptt = FieldPath.global_("tx_state", "ptt")
+    profile = RadioAcquisitionProfile(
+        provider="test_provider",
+        capabilities=(
+            FieldCapability(path=freq, polling=True),
+            FieldCapability(path=ptt, unsolicited_push=True),
+        ),
+    )
+    scheduler = AcquisitionScheduler(profile=profile, clock=clock)
+
+    result = scheduler.ensure_fresh(
+        [freq, ptt],
+        max_age=1.0,
+        priority="user",
+        reason="snapshot",
+    )
+
+    assert result.status is AcquisitionStatus.QUEUED
+    requests = scheduler.pending_requests()
+    assert len(requests) == 2
+    assert not any(
+        request.acquisition_method == "poll"
+        and set(request.paths) == {freq, ptt}
+        for request in requests
+    )
+    requests_by_path = {request.paths: request for request in requests}
+    assert requests_by_path[(freq,)].acquisition_method == "poll"
+    assert requests_by_path[(ptt,)].acquisition_method == "wait_for_unsolicited"
+
+
+def test_mixed_meter_and_frequency_request_preserves_meter_coalescing_policy() -> None:
+    clock = FreshnessClock(start=86.0)
+    meter = FieldPath.receiver("main", "meters", "s_meter")
+    freq = FieldPath.active("main", "freq_mode", "freq_hz")
+    profile = _profile(
+        [meter, freq],
+        field_policies={
+            meter: AcquisitionPolicy(
+                cadence_seconds=0.2,
+                freshness_ttl_seconds=0.6,
+                meter_coalescing=MeterCoalescingPolicy(window_seconds=0.1),
+            ),
+            freq: AcquisitionPolicy(
+                cadence_seconds=5.0,
+                freshness_ttl_seconds=15.0,
+            ),
+        },
+    )
+    scheduler = AcquisitionScheduler(profile=profile, clock=clock)
+
+    result = scheduler.ensure_fresh(
+        [meter, freq],
+        max_age=1.0,
+        priority="normal",
+        reason="mixed-panel",
+    )
+
+    assert result.status is AcquisitionStatus.QUEUED
+    requests = scheduler.pending_requests()
+    assert len(requests) == 2
+    requests_by_path = {request.paths: request for request in requests}
+    meter_request = requests_by_path[(meter,)]
+    freq_request = requests_by_path[(freq,)]
+    assert meter_request.policy.meter_coalescing is not None
+    assert meter_request.policy.meter_coalescing.window_seconds == 0.1
+    assert freq_request.policy.meter_coalescing is None
+
+
 def test_scheduler_output_can_return_observation_applied_through_state_store() -> None:
     clock = FreshnessClock(start=90.0)
     freq = FieldPath.active("main", "freq_mode", "freq_hz")
@@ -332,3 +437,27 @@ def test_scheduler_output_can_return_observation_applied_through_state_store() -
 
     assert change.revision == 1
     assert store.snapshot().field(freq).value == 14_074_000
+
+
+def test_model_service_queues_when_field_observation_max_age_expired_without_mark_stale() -> (
+    None
+):
+    clock = FreshnessClock(start=100.0)
+    freq = FieldPath.active("main", "freq_mode", "freq_hz")
+    store = StateStore(freshness_clock=clock)
+    store.apply(_observation(freq, 14_074_000, at=clock.now(), max_age=1.0))
+    scheduler = AcquisitionScheduler(profile=_profile([freq]), clock=clock)
+    service = RadioStateModelService(store=store, scheduler=scheduler, clock=clock)
+    clock.advance(1.1)
+
+    result = service.ensure_fresh(
+        freq,
+        max_age=10.0,
+        priority="user",
+        reason="snapshot",
+    )
+
+    assert result.status is AcquisitionStatus.QUEUED
+    assert result.fields == ()
+    assert result.request is not None
+    assert result.request.paths == (freq,)

--- a/tests/test_acquisition_scheduler.py
+++ b/tests/test_acquisition_scheduler.py
@@ -9,10 +9,12 @@ from rigplane.core.acquisition_scheduler import (
     AcquisitionPriority,
     AcquisitionScheduler,
     AcquisitionStatus,
+    MeterObservationCoalescer,
     RadioStateModelService,
 )
 from rigplane.core.state_acquisition_policy import (
     AcquisitionPolicy,
+    AdaptiveDecayPolicy,
     ExternalCatPauseBehavior,
     FieldAvailability,
     FieldCapability,
@@ -21,6 +23,8 @@ from rigplane.core.state_acquisition_policy import (
     ReconciliationPriority,
 )
 from rigplane.core.state_pipeline_contracts import (
+    ChangeSet,
+    FieldChange,
     FieldPath,
     Observation,
     SourceMetadata,
@@ -45,6 +49,21 @@ def _observation(
         source=_source(),
         timestamp_monotonic=at,
         max_age=max_age,
+    )
+
+
+def _changeset(
+    *,
+    changes: tuple[FieldChange, ...] = (),
+    at: float,
+) -> ChangeSet:
+    return ChangeSet(
+        revision=1 if changes else 0,
+        freshness_revision=1,
+        observation_seq=1,
+        changes=changes,
+        timestamp_monotonic=at,
+        sources=(_source(),),
     )
 
 
@@ -674,3 +693,195 @@ def test_stale_unsolicited_field_queues_reconciliation_and_accepts_readback() ->
     assert reconciled.revision == 2
     assert store.snapshot().field(freq).freshness is FreshnessState.FRESH
     assert store.snapshot().field(freq).value == 14_076_000
+
+
+def test_due_polling_emits_only_pollable_cadence_fields_and_groups_by_existing_key() -> (
+    None
+):
+    clock = FreshnessClock(start=200.0)
+    freq = FieldPath.active("main", "freq_mode", "freq_hz")
+    mode = FieldPath.active("main", "freq_mode", "mode")
+    ptt = FieldPath.global_("tx_state", "ptt")
+    profile = RadioAcquisitionProfile(
+        provider="test_provider",
+        capabilities=(
+            FieldCapability(path=freq, polling=True, unsolicited_push=True),
+            FieldCapability(path=mode, polling=True),
+            FieldCapability(path=ptt, unsolicited_push=True),
+        ),
+        default_policy=AcquisitionPolicy(
+            cadence_seconds=2.0,
+            freshness_ttl_seconds=6.0,
+        ),
+    )
+    scheduler = AcquisitionScheduler(profile=profile, clock=clock)
+
+    requests = scheduler.due_requests()
+
+    assert len(requests) == 1
+    assert requests[0].paths == (freq, mode)
+    assert requests[0].priority is AcquisitionPriority.BACKGROUND
+    assert requests[0].reason == "policy-cadence"
+    assert requests[0].acquisition_method == "poll"
+    assert scheduler.pending_requests() == requests
+
+
+def test_due_polling_skips_unsupported_unhooked_and_unsolicited_only_fields() -> None:
+    clock = FreshnessClock(start=205.0)
+    supported = FieldPath.active("main", "freq_mode", "freq_hz")
+    unsupported = FieldPath.global_("tx_state", "power_on")
+    unhooked = FieldPath.global_("health", "state")
+    unsolicited_only = FieldPath.global_("tx_state", "ptt")
+    profile = RadioAcquisitionProfile(
+        provider="test_provider",
+        capabilities=(
+            FieldCapability(path=supported, polling=True),
+            FieldCapability(
+                path=unsupported,
+                availability=FieldAvailability.UNSUPPORTED,
+                diagnostic="not exposed",
+            ),
+            FieldCapability(path=unhooked),
+            FieldCapability(path=unsolicited_only, unsolicited_push=True),
+        ),
+        default_policy=AcquisitionPolicy(cadence_seconds=1.0),
+    )
+    scheduler = AcquisitionScheduler(profile=profile, clock=clock)
+
+    requests = scheduler.due_requests()
+
+    assert len(requests) == 1
+    assert requests[0].paths == (supported,)
+
+
+def test_unchanged_acquisition_result_decays_cadence_exponentially_and_caps() -> None:
+    clock = FreshnessClock(start=210.0)
+    freq = FieldPath.active("main", "freq_mode", "freq_hz")
+    policy = AcquisitionPolicy(
+        cadence_seconds=2.0,
+        freshness_ttl_seconds=10.0,
+        adaptive_decay=AdaptiveDecayPolicy(
+            enabled=True,
+            idle_multiplier=2.0,
+            max_cadence_seconds=6.0,
+        ),
+    )
+    scheduler = AcquisitionScheduler(
+        profile=_profile([freq], default_policy=policy),
+        clock=clock,
+    )
+
+    first = scheduler.due_requests()[0]
+    scheduler.record_acquisition_result(first, _changeset(at=clock.now()))
+
+    diagnostics = scheduler.diagnostics()
+    assert diagnostics["cadenceByPath"][str(freq)]["currentCadenceSeconds"] == 4.0
+    assert diagnostics["cadenceByPath"][str(freq)]["nextDueMonotonic"] == 214.0
+    clock.advance(3.9)
+    assert scheduler.due_requests() == ()
+    clock.advance(0.1)
+
+    second = scheduler.due_requests()[0]
+    scheduler.record_acquisition_result(second, _changeset(at=clock.now()))
+
+    diagnostics = scheduler.diagnostics()
+    assert diagnostics["cadenceByPath"][str(freq)]["currentCadenceSeconds"] == 6.0
+    assert diagnostics["cadenceByPath"][str(freq)]["nextDueMonotonic"] == 220.0
+
+
+def test_semantic_change_resets_adaptive_cadence_to_base_policy() -> None:
+    clock = FreshnessClock(start=220.0)
+    freq = FieldPath.active("main", "freq_mode", "freq_hz")
+    policy = AcquisitionPolicy(
+        cadence_seconds=2.0,
+        freshness_ttl_seconds=10.0,
+        adaptive_decay=AdaptiveDecayPolicy(
+            enabled=True,
+            idle_multiplier=2.0,
+            max_cadence_seconds=8.0,
+        ),
+    )
+    scheduler = AcquisitionScheduler(
+        profile=_profile([freq], default_policy=policy),
+        clock=clock,
+    )
+    first = scheduler.due_requests()[0]
+    scheduler.record_acquisition_result(first, _changeset(at=clock.now()))
+    clock.advance(4.0)
+
+    second = scheduler.due_requests()[0]
+    scheduler.record_acquisition_result(
+        second,
+        _changeset(
+            changes=(FieldChange(path=freq, previous=7_074_000, current=14_074_000),),
+            at=clock.now(),
+        ),
+    )
+
+    diagnostics = scheduler.diagnostics()
+    assert diagnostics["cadenceByPath"][str(freq)]["currentCadenceSeconds"] == 2.0
+    assert diagnostics["cadenceByPath"][str(freq)]["nextDueMonotonic"] == 226.0
+    clock.advance(1.9)
+    assert scheduler.due_requests() == ()
+    clock.advance(0.1)
+    assert scheduler.due_requests()[0].paths == (freq,)
+
+
+def test_diagnostics_include_cadence_next_due_pending_pressure_and_counts() -> None:
+    clock = FreshnessClock(start=230.0)
+    freq = FieldPath.active("main", "freq_mode", "freq_hz")
+    meter = FieldPath.receiver("main", "meters", "s_meter")
+    profile = _profile(
+        [freq, meter],
+        field_policies={
+            meter: AcquisitionPolicy(
+                external_cat_pause=ExternalCatPauseBehavior.CONTINUE,
+            ),
+        },
+    )
+    scheduler = AcquisitionScheduler(profile=profile, clock=clock)
+
+    scheduler.due_requests()
+    scheduler.pause_external_cat(owner="external")
+    scheduler.ensure_fresh(
+        freq,
+        max_age=1.0,
+        priority="user",
+        reason="deferred-user-read",
+    )
+
+    diagnostics = scheduler.diagnostics()
+
+    assert diagnostics["queuedRequestCount"] == 1
+    assert diagnostics["deferredRequestCount"] == 1
+    assert diagnostics["cadenceByPath"][str(freq)]["baseCadenceSeconds"] == 5.0
+    assert diagnostics["cadenceByPath"][str(freq)]["nextDueMonotonic"] == 230.0
+    assert diagnostics["requestPressureByPriorityFamily"]["background:meters"] == 1
+    assert diagnostics["requestPressureByPriorityFamily"]["user:freq_mode"] == 1
+
+
+def test_meter_coalescing_latest_sample_wins_and_exposes_drop_counts() -> None:
+    clock = FreshnessClock(start=240.0)
+    store = StateStore(freshness_clock=clock)
+    meter = FieldPath.receiver("main", "meters", "s_meter")
+    policy = MeterCoalescingPolicy(window_seconds=0.2, max_samples=2)
+    coalescer = MeterObservationCoalescer()
+
+    coalescer.record(_observation(meter, 40, at=clock.now()), policy)
+    clock.advance(0.05)
+    coalescer.record(_observation(meter, 41, at=clock.now()), policy)
+    clock.advance(0.05)
+    coalescer.record(_observation(meter, 42, at=clock.now()), policy)
+
+    assert coalescer.flush_due(store, now=clock.now() + 0.14) is None
+    changeset = coalescer.flush_due(store, now=clock.now() + 0.15)
+
+    assert changeset is not None
+    assert changeset.coalesced is True
+    assert changeset.changes[0].current == 42
+    assert store.snapshot().field(meter).value == 42
+    assert store.snapshot().state_revision == 1
+    diagnostics = coalescer.diagnostics()
+    assert diagnostics["droppedSampleCount"] == 1
+    assert diagnostics["coalescedSampleCount"] == 1
+    assert diagnostics["pendingSampleCount"] == 0

--- a/tests/test_audio_backend.py
+++ b/tests/test_audio_backend.py
@@ -358,6 +358,27 @@ class TestPortAudioBackendDeps:
         assert devices[1].is_default_output is True
         assert devices[1].output_channels == 2
 
+    def test_list_devices_extracts_alsa_hardware_identifier(self) -> None:
+        class FakeSd:
+            class default:
+                device = [-1, -1]
+
+            @staticmethod
+            def query_devices() -> list[dict]:
+                return [
+                    {
+                        "index": 3,
+                        "name": "USB Audio CODEC: Audio (hw:3,0)",
+                        "max_input_channels": 2,
+                        "max_output_channels": 2,
+                        "default_samplerate": 48000,
+                    },
+                ]
+
+        backend = PortAudioBackend(dependency_loader=lambda: (FakeSd(), object()))
+        devices = backend.list_devices()
+        assert devices[0].platform_uid == "hw:3,0"
+
     def test_open_rx_returns_rx_stream(self) -> None:
         class FakeSd:
             class InputStream:

--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -41,6 +41,18 @@ from test_radio import MockTransport, _wrap_civ_in_udp
 from rigplane import IC_7610_ADDR
 from rigplane.runtime._civ_rx import CIV_HEADER_SIZE
 from rigplane.commands import CONTROLLER_ADDR, build_civ_frame
+from rigplane.core.acquisition_scheduler import (
+    AcquisitionScheduler,
+    MeterObservationCoalescer,
+)
+from rigplane.core.state_acquisition_policy import (
+    AcquisitionPolicy,
+    FieldCapability,
+    MeterCoalescingPolicy,
+    RadioAcquisitionProfile,
+)
+from rigplane.core.state_diagnostics import StateDiagnosticsRecorder
+from rigplane.core.state_pipeline_contracts import FieldPath
 from rigplane.exceptions import ConnectionError
 from rigplane.radio import IcomRadio
 from rigplane.radio_state import RadioState
@@ -92,6 +104,24 @@ def _bcd2(value: int) -> bytes:
     b0 = (int(d[0]) << 4) | int(d[1])
     b1 = (int(d[2]) << 4) | int(d[3])
     return bytes([b0, b1])
+
+
+def _acquisition_profile(
+    *paths: FieldPath,
+    policy: AcquisitionPolicy | None = None,
+) -> RadioAcquisitionProfile:
+    acquisition_policy = policy or AcquisitionPolicy(
+        cadence_seconds=1.0,
+        freshness_ttl_seconds=4.0,
+    )
+    return RadioAcquisitionProfile(
+        provider="icom_civ",
+        capabilities=tuple(
+            FieldCapability(path=path, polling=True, stream_like=path.family.value == "meters")
+            for path in paths
+        ),
+        default_policy=acquisition_policy,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -869,6 +899,85 @@ def test_update_state_cache_projects_supported_fields_into_state_store(
 
     assert field.value == expected
     assert field.source.source == expected_source
+
+
+def test_update_state_cache_records_scheduler_result_for_matching_pending_request(
+    radio: IcomRadio,
+) -> None:
+    class _SpyScheduler(AcquisitionScheduler):
+        def __init__(self, *, profile: RadioAcquisitionProfile) -> None:
+            super().__init__(profile=profile)
+            self.recorded_count = 0
+
+        def record_acquisition_result(self, request, change_set):  # type: ignore[no-untyped-def]
+            self.recorded_count += 1
+            return super().record_acquisition_result(request, change_set)
+
+    path = FieldPath.active("main", "freq_mode", "freq_hz")
+    scheduler = _SpyScheduler(profile=_acquisition_profile(path))
+    scheduler.due_requests(now=0.0)
+    radio._acquisition_scheduler = scheduler
+
+    radio._civ_runtime._update_state_cache_from_frame(
+        _make_frame(cmd=0x03, data=bcd_encode(14_074_000))
+    )
+
+    assert scheduler.recorded_count == 1
+    assert scheduler.pending_requests() == ()
+
+
+def test_meter_coalescing_applies_latest_due_sample_and_records_diagnostics(
+    radio: IcomRadio,
+) -> None:
+    path = FieldPath.receiver("main", "meters", "s_meter")
+    policy = AcquisitionPolicy(
+        cadence_seconds=1.0,
+        freshness_ttl_seconds=4.0,
+        meter_coalescing=MeterCoalescingPolicy(window_seconds=0.2, max_samples=2),
+    )
+    radio._acquisition_scheduler = AcquisitionScheduler(
+        profile=_acquisition_profile(path, policy=policy)
+    )
+    radio._meter_observation_coalescer = MeterObservationCoalescer()
+    radio._state_diagnostics = StateDiagnosticsRecorder(enabled=True)
+    events: list[tuple[str, dict[str, object]]] = []
+    radio._on_state_change = lambda name, data: events.append((name, data))
+
+    with patch(
+        "rigplane.runtime._civ_rx.time.monotonic",
+        side_effect=[100.0, 100.0, 100.1, 100.1],
+    ):
+        radio._civ_runtime._apply_state_store_observations(
+            _make_frame(cmd=0x15, sub=0x02, data=_bcd2(111))
+        )
+        radio._civ_runtime._apply_state_store_observations(
+            _make_frame(cmd=0x15, sub=0x02, data=_bcd2(222))
+        )
+
+    with pytest.raises(KeyError):
+        radio._state_store.snapshot().field("receiver.0.meters.s_meter")
+
+    radio._civ_runtime.flush_due_meter_observations(now=100.3)
+
+    assert radio._state_store.snapshot().field("receiver.0.meters.s_meter").value == 222
+    assert events == [
+        (
+            "state_store_changed",
+            {"coalesced": True, "paths": ["receiver.0.meters.s_meter"]},
+        )
+    ]
+    meter_events = [
+        event
+        for event in radio._state_diagnostics.events()
+        if event.kind == "meter_coalescing"
+    ]
+    assert meter_events[-1].details == {
+        "pendingSampleCount": 0,
+        "pendingPaths": [],
+        "droppedSampleCount": 0,
+        "coalescedSampleCount": 1,
+        "nextFlushMonotonic": None,
+    }
 
 
 @pytest.mark.parametrize(  # type: ignore[untyped-decorator]

--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -980,6 +980,77 @@ def test_meter_coalescing_applies_latest_due_sample_and_records_diagnostics(
     }
 
 
+def test_same_value_coalesced_meter_flush_completes_scheduler_request(
+    radio: IcomRadio,
+) -> None:
+    path = FieldPath.receiver("main", "meters", "s_meter")
+    stored_path = FieldPath.receiver("0", "meters", "s_meter")
+    policy = AcquisitionPolicy(
+        cadence_seconds=1.0,
+        freshness_ttl_seconds=4.0,
+        meter_coalescing=MeterCoalescingPolicy(window_seconds=0.2),
+    )
+    radio._state_store.apply(
+        radio._civ_runtime._observation(
+            stored_path,
+            111,
+            frame=_make_frame(cmd=0x15, sub=0x02, data=_bcd2(111)),
+        )
+    )
+    scheduler = AcquisitionScheduler(profile=_acquisition_profile(path, policy=policy))
+    scheduler.due_requests(now=100.0)
+    radio._acquisition_scheduler = scheduler
+    radio._meter_observation_coalescer = MeterObservationCoalescer()
+    radio._state_diagnostics = StateDiagnosticsRecorder(enabled=True)
+
+    with patch("rigplane.runtime._civ_rx.time.monotonic", return_value=100.0):
+        radio._civ_runtime._apply_state_store_observations(
+            _make_frame(cmd=0x15, sub=0x02, data=_bcd2(111))
+        )
+    changeset = radio._civ_runtime.flush_due_meter_observations(now=100.2)
+
+    assert changeset is not None
+    assert changeset.changes == ()
+    assert scheduler.pending_requests() == ()
+    assert scheduler.diagnostics()["cadenceByPath"][str(path)][
+        "nextDueMonotonic"
+    ] == 101.0
+    assert any(
+        event.kind == "acquisition_result"
+        and event.details["paths"] == [str(path)]
+        and event.details["changed"] is False
+        for event in radio._state_diagnostics.events()
+    )
+
+
+def test_same_value_stale_refresh_notifies_state_store_changed(
+    radio: IcomRadio,
+) -> None:
+    path = FieldPath.receiver("main", "meters", "s_meter")
+    events: list[tuple[str, dict[str, object]]] = []
+    radio._on_state_change = lambda name, data: events.append((name, data))
+
+    radio._state_store.apply(
+        radio._civ_runtime._observation(
+            path,
+            111,
+            frame=_make_frame(cmd=0x15, sub=0x02, data=_bcd2(111)),
+        )
+    )
+    radio._state_store.mark_stale_due(now=time.monotonic() + 1.0)
+
+    radio._civ_runtime._apply_state_store_observations(
+        _make_frame(cmd=0x15, sub=0x02, data=_bcd2(111))
+    )
+
+    assert events == [
+        (
+            "state_store_changed",
+            {"coalesced": False, "paths": ["receiver.0.meters.s_meter"]},
+        )
+    ]
+
+
 @pytest.mark.parametrize(  # type: ignore[untyped-decorator]
     ("frame", "field_name", "initial_value"),
     [

--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -118,7 +118,9 @@ def _acquisition_profile(
     return RadioAcquisitionProfile(
         provider="icom_civ",
         capabilities=tuple(
-            FieldCapability(path=path, polling=True, stream_like=path.family.value == "meters")
+            FieldCapability(
+                path=path, polling=True, stream_like=path.family.value == "meters"
+            )
             for path in paths
         ),
         default_policy=acquisition_policy,
@@ -1090,9 +1092,9 @@ def test_same_value_coalesced_meter_flush_completes_scheduler_request(
     assert changeset is not None
     assert changeset.changes == ()
     assert scheduler.pending_requests() == ()
-    assert scheduler.diagnostics()["cadenceByPath"][str(path)][
-        "nextDueMonotonic"
-    ] == 101.0
+    assert (
+        scheduler.diagnostics()["cadenceByPath"][str(path)]["nextDueMonotonic"] == 101.0
+    )
     assert any(
         event.kind == "acquisition_result"
         and event.details["paths"] == [str(path)]
@@ -1172,9 +1174,7 @@ def test_update_state_cache_uses_slot_specific_observation_path_when_override_ac
     )
 
     assert (
-        radio._state_store.snapshot()
-        .field("receiver.0.slot.B.freq_mode.freq_hz")
-        .value
+        radio._state_store.snapshot().field("receiver.0.slot.B.freq_mode.freq_hz").value
         == 14_250_000
     )
 

--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pytest
@@ -52,12 +53,12 @@ from rigplane.types import CivFrame, Mode, bcd_encode
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def transport() -> MockTransport:
     return MockTransport()
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def radio(transport: MockTransport) -> IcomRadio:
     r = IcomRadio("192.168.1.100")
     r._civ_transport = transport
@@ -708,9 +709,9 @@ def test_update_state_cache_cmd29_sub_bool_does_not_overwrite_main(
 
 def test_update_state_cache_ip_plus(radio: IcomRadio) -> None:
     """cmd 0x16 sub 0x65 fires IP+ change notification (lines 449-450)."""
-    notify_calls: dict = {}
+    notify_calls: dict[str, dict[str, object]] = {}
 
-    def _on_change(name: str, data: dict) -> None:
+    def _on_change(name: str, data: dict[str, object]) -> None:
         notify_calls[name] = data
 
     radio._on_state_change = _on_change
@@ -742,7 +743,7 @@ def test_update_state_cache_exception_suppressed(radio: IcomRadio) -> None:
     radio._civ_runtime._update_state_cache_from_frame(frame)
 
 
-@pytest.mark.parametrize(
+@pytest.mark.parametrize(  # type: ignore[untyped-decorator]
     ("frame", "path", "expected", "expected_source"),
     [
         (
@@ -791,6 +792,12 @@ def test_update_state_cache_exception_suppressed(radio: IcomRadio) -> None:
             _make_frame(cmd=0x15, sub=0x11, data=_bcd2(120)),
             "global.meters.power",
             120,
+            "command_response",
+        ),
+        (
+            _make_frame(cmd=0x15, sub=0x12, data=_bcd2(48)),
+            "global.meters.swr",
+            48,
             "command_response",
         ),
         (
@@ -847,12 +854,6 @@ def test_update_state_cache_exception_suppressed(radio: IcomRadio) -> None:
             True,
             "command_response",
         ),
-        (
-            _make_frame(cmd=0x07, data=bytes([0xD2, 0x01])),
-            "receiver.0.vfo.active_slot",
-            "B",
-            "command_response",
-        ),
     ],
 )
 def test_update_state_cache_projects_supported_fields_into_state_store(
@@ -868,6 +869,40 @@ def test_update_state_cache_projects_supported_fields_into_state_store(
 
     assert field.value == expected
     assert field.source.source == expected_source
+
+
+@pytest.mark.parametrize(  # type: ignore[untyped-decorator]
+    ("frame", "field_name", "initial_value"),
+    [
+        (_make_frame(cmd=0x03, data=bcd_encode(14_074_000)), "freq", 0),
+        (_make_frame(cmd=0x04, data=bytes([Mode.LSB.value, 2])), "mode", "USB"),
+        (_make_frame(cmd=0x1C, sub=0x00, data=b"\x01"), "ptt", False),
+        (_make_frame(cmd=0x18, data=b"\x01"), "powerstat", False),
+    ],
+)
+def test_update_state_cache_applies_state_store_before_legacy_cache_mirror(
+    radio: IcomRadio,
+    frame: CivFrame,
+    field_name: str,
+    initial_value: object,
+) -> None:
+    setattr(radio._state_cache, field_name, initial_value)
+    seen_legacy_values: list[object] = []
+    original_apply = type(radio._state_store).apply
+
+    def apply_and_record(store: object, observation: object) -> object:
+        seen_legacy_values.append(getattr(radio._state_cache, field_name))
+        return original_apply(store, observation)
+
+    with patch.object(
+        type(radio._state_store),
+        "apply",
+        autospec=True,
+        side_effect=apply_and_record,
+    ):
+        radio._civ_runtime._update_state_cache_from_frame(frame)
+
+    assert seen_legacy_values == [initial_value]
 
 
 def test_update_state_cache_uses_slot_specific_observation_path_when_override_active(
@@ -903,12 +938,56 @@ def test_update_state_cache_applies_command_response_observation_once(
     assert radio._radio_state.main.freq == 14_074_000
 
 
+@pytest.mark.parametrize(  # type: ignore[untyped-decorator]
+    "frame",
+    [
+        _make_frame(cmd=0x03, data=b"\x12\x34"),
+        _make_frame(cmd=0x04, data=b""),
+        _make_frame(cmd=0x04, data=bytes([0xFF, 0x01])),
+        _make_frame(cmd=0x26, data=bytes([0x00, 0xFF])),
+    ],
+)
+async def test_route_civ_frame_contains_observation_decode_failures(
+    radio: IcomRadio,
+    frame: CivFrame,
+) -> None:
+    published: list[Any] = []
+    radio._civ_request_tracker.resolve = MagicMock()
+
+    with patch.object(
+        radio._civ_runtime,
+        "_publish_civ_event",
+        side_effect=published.append,
+    ):
+        await radio._civ_runtime._route_civ_frame(frame, generation=17)
+
+    assert len(published) == 1
+    assert published[0].frame == frame
+    radio._civ_request_tracker.resolve.assert_called_once_with(
+        published[0], generation=17
+    )
+    assert radio._state_store.snapshot().observation_seq == 0
+
+
+def test_update_state_cache_cmd07_d2_keeps_legacy_active_receiver_without_state_store_projection(
+    radio: IcomRadio,
+) -> None:
+    radio._radio_state = RadioState()
+
+    radio._civ_runtime._update_state_cache_from_frame(
+        _make_frame(cmd=0x07, data=bytes([0xD2, 0x01]))
+    )
+
+    assert radio._radio_state.active == "SUB"
+    assert radio._state_store.snapshot().fields == ()
+
+
 # ---------------------------------------------------------------------------
 # _update_radio_state_from_frame (lines 470-622)
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def radio_with_state(radio: IcomRadio) -> IcomRadio:
     """Radio with RadioState set for testing _update_radio_state_from_frame."""
     radio._radio_state = RadioState()
@@ -1041,7 +1120,7 @@ def test_update_radio_state_cmd14_power_level(radio_with_state: IcomRadio) -> No
     assert rs.power_level == 128
 
 
-@pytest.mark.parametrize(
+@pytest.mark.parametrize(  # type: ignore[untyped-decorator]
     ("sub", "value", "field"),
     [
         (0x05, 90, "apf_type_level"),
@@ -1064,7 +1143,7 @@ def test_update_radio_state_cmd14_receiver_dsp_levels(
     assert getattr(rs.sub, field) == value
 
 
-@pytest.mark.parametrize(
+@pytest.mark.parametrize(  # type: ignore[untyped-decorator]
     ("sub", "raw", "field", "expected"),
     [
         (0x09, 128, "cw_pitch", 600),
@@ -1160,7 +1239,7 @@ def test_update_radio_state_cmd16_ipplus(radio_with_state: IcomRadio) -> None:
     assert rs.main.ipplus is True
 
 
-@pytest.mark.parametrize(
+@pytest.mark.parametrize(  # type: ignore[untyped-decorator]
     ("cmd", "sub", "data", "receiver", "target", "field", "expected"),
     [
         (0x15, 0x01, b"\x01", 0x01, "sub", "s_meter_sql_open", True),
@@ -1224,7 +1303,7 @@ def test_update_radio_state_cmd1a_sub06_data_mode(radio_with_state: IcomRadio) -
     assert rs.main.data_mode == 2
 
 
-@pytest.mark.parametrize(
+@pytest.mark.parametrize(  # type: ignore[untyped-decorator]
     ("data", "field", "expected"),
     [
         (b"\x00\x70\x05\x11", "ref_adjust", 511),
@@ -1389,7 +1468,7 @@ def test_update_radio_state_with_receiver_field_set(
 
 def test_update_radio_state_returns_when_no_radio_state(radio: IcomRadio) -> None:
     """When _radio_state is None (not set), method returns immediately (line 469)."""
-    radio._radio_state = None  # type: ignore[assignment]
+    radio._radio_state = None
     frame = _make_frame(cmd=0x03, data=bcd_encode(14_000_000))
     radio._civ_runtime._update_radio_state_from_frame(frame)  # should not raise
 
@@ -1401,9 +1480,9 @@ def test_update_radio_state_returns_when_no_radio_state(radio: IcomRadio) -> Non
 
 def test_notify_change_calls_callback(radio: IcomRadio) -> None:
     """_notify_change invokes _on_state_change callback (lines 628-632)."""
-    calls: list[tuple] = []
+    calls: list[tuple[str, dict[str, object]]] = []
 
-    def my_callback(event_name: str, data: dict) -> None:
+    def my_callback(event_name: str, data: dict[str, object]) -> None:
         calls.append((event_name, data))
 
     radio._on_state_change = my_callback
@@ -1414,7 +1493,7 @@ def test_notify_change_calls_callback(radio: IcomRadio) -> None:
 def test_notify_change_callback_exception_suppressed(radio: IcomRadio) -> None:
     """Exception in callback is suppressed (not propagated)."""
 
-    def failing_callback(event_name: str, data: dict) -> None:
+    def failing_callback(event_name: str, data: dict[str, object]) -> None:
         raise RuntimeError("callback error")
 
     radio._on_state_change = failing_callback

--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -44,6 +44,7 @@ from rigplane.exceptions import ConnectionError
 from rigplane.radio import IcomRadio
 from rigplane.radio_state import RadioState
 from rigplane.scope import ScopeFrame
+from rigplane.core.state_store import StateSnapshot
 from rigplane.types import CivFrame, Mode, bcd_encode
 
 # ---------------------------------------------------------------------------
@@ -739,6 +740,167 @@ def test_update_state_cache_exception_suppressed(radio: IcomRadio) -> None:
     frame = _make_frame(cmd=0x03, data=freq_data)
     # Should NOT raise, exception is swallowed
     radio._civ_runtime._update_state_cache_from_frame(frame)
+
+
+@pytest.mark.parametrize(
+    ("frame", "path", "expected", "expected_source"),
+    [
+        (
+            _make_frame(cmd=0x00, data=bcd_encode(7_074_000)),
+            "receiver.0.active.freq_mode.freq_hz",
+            7_074_000,
+            "civ_unsolicited",
+        ),
+        (
+            _make_frame(cmd=0x03, data=bcd_encode(14_074_000)),
+            "receiver.0.active.freq_mode.freq_hz",
+            14_074_000,
+            "command_response",
+        ),
+        (
+            _make_frame(cmd=0x01, data=bytes([Mode.USB.value, 1])),
+            "receiver.0.active.freq_mode.mode",
+            "USB",
+            "civ_unsolicited",
+        ),
+        (
+            _make_frame(cmd=0x04, data=bytes([Mode.LSB.value, 2])),
+            "receiver.0.active.freq_mode.mode",
+            "LSB",
+            "command_response",
+        ),
+        (
+            _make_frame(cmd=0x25, data=bytes([0x01]) + bcd_encode(21_074_000)),
+            "receiver.1.active.freq_mode.freq_hz",
+            21_074_000,
+            "command_response",
+        ),
+        (
+            _make_frame(cmd=0x26, data=bytes([0x01, Mode.CW.value, 0x00, 3])),
+            "receiver.1.active.freq_mode.mode",
+            "CW",
+            "command_response",
+        ),
+        (
+            _make_frame(cmd=0x15, sub=0x02, data=_bcd2(150), receiver=0x01),
+            "receiver.1.meters.s_meter",
+            150,
+            "command_response",
+        ),
+        (
+            _make_frame(cmd=0x15, sub=0x11, data=_bcd2(120)),
+            "global.meters.power",
+            120,
+            "command_response",
+        ),
+        (
+            _make_frame(cmd=0x15, sub=0x13, data=_bcd2(98)),
+            "global.meters.alc",
+            98,
+            "command_response",
+        ),
+        (
+            _make_frame(cmd=0x14, sub=0x01, data=_bcd2(87), receiver=0x01),
+            "receiver.1.operator_controls.af_level",
+            87,
+            "command_response",
+        ),
+        (
+            _make_frame(cmd=0x14, sub=0x02, data=_bcd2(111), receiver=0x01),
+            "receiver.1.operator_controls.rf_gain",
+            111,
+            "command_response",
+        ),
+        (
+            _make_frame(cmd=0x14, sub=0x07, data=_bcd2(142), receiver=0x01),
+            "receiver.1.operator_controls.pbt_inner",
+            142,
+            "command_response",
+        ),
+        (
+            _make_frame(cmd=0x14, sub=0x08, data=_bcd2(143), receiver=0x01),
+            "receiver.1.operator_controls.pbt_outer",
+            143,
+            "command_response",
+        ),
+        (
+            _make_frame(cmd=0x16, sub=0x22, data=b"\x01", receiver=0x01),
+            "receiver.1.operator_toggles.nb",
+            True,
+            "command_response",
+        ),
+        (
+            _make_frame(cmd=0x16, sub=0x40, data=b"\x00", receiver=0x01),
+            "receiver.1.operator_toggles.nr",
+            False,
+            "command_response",
+        ),
+        (
+            _make_frame(cmd=0x18, data=b"\x01"),
+            "global.tx_state.power_on",
+            True,
+            "command_response",
+        ),
+        (
+            _make_frame(cmd=0x1C, sub=0x00, data=b"\x01"),
+            "global.tx_state.ptt",
+            True,
+            "command_response",
+        ),
+        (
+            _make_frame(cmd=0x07, data=bytes([0xD2, 0x01])),
+            "receiver.0.vfo.active_slot",
+            "B",
+            "command_response",
+        ),
+    ],
+)
+def test_update_state_cache_projects_supported_fields_into_state_store(
+    radio: IcomRadio,
+    frame: CivFrame,
+    path: str,
+    expected: object,
+    expected_source: str,
+) -> None:
+    radio._civ_runtime._update_state_cache_from_frame(frame)
+
+    field = radio._state_store.snapshot().field(path)
+
+    assert field.value == expected
+    assert field.source.source == expected_source
+
+
+def test_update_state_cache_uses_slot_specific_observation_path_when_override_active(
+    radio: IcomRadio,
+) -> None:
+    radio._vfo_slot_override = {"MAIN": "B"}  # noqa: SLF001
+    radio._civ_runtime._update_state_cache_from_frame(
+        _make_frame(cmd=0x03, data=bcd_encode(14_250_000))
+    )
+
+    assert (
+        radio._state_store.snapshot()
+        .field("receiver.0.slot.B.freq_mode.freq_hz")
+        .value
+        == 14_250_000
+    )
+
+
+def test_update_state_cache_applies_command_response_observation_once(
+    radio: IcomRadio,
+) -> None:
+    frame = _make_frame(cmd=0x03, data=bcd_encode(14_074_000))
+
+    radio._civ_runtime._update_state_cache_from_frame(frame)
+
+    snapshot = radio._state_store.snapshot()
+    delta = radio._state_store.delta_since(StateSnapshot.empty())
+
+    assert snapshot.state_revision == 1
+    assert snapshot.observation_seq == 1
+    assert len(delta.changes) == 1
+    assert delta.changes[0].path == snapshot.fields[0].path
+    assert radio._radio_state.main.freq == 14_074_000
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -59,6 +59,7 @@ from rigplane.radio_state import RadioState
 from rigplane.scope import ScopeFrame
 from rigplane.core.state_store import StateSnapshot
 from rigplane.types import CivFrame, Mode, bcd_encode
+from rigplane.web.radio_poller import CommandQueue, RadioPoller
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -924,6 +925,83 @@ def test_update_state_cache_records_scheduler_result_for_matching_pending_reques
 
     assert scheduler.recorded_count == 1
     assert scheduler.pending_requests() == ()
+
+
+@pytest.mark.parametrize(  # type: ignore[untyped-decorator]
+    ("path", "cmd", "receiver", "payload", "stored_path", "expected"),
+    [
+        (
+            FieldPath.active("main", "freq_mode", "freq_hz"),
+            0x25,
+            0x00,
+            bcd_encode(14_074_000),
+            "receiver.0.active.freq_mode.freq_hz",
+            14_074_000,
+        ),
+        (
+            FieldPath.active("sub", "freq_mode", "freq_hz"),
+            0x25,
+            0x01,
+            bcd_encode(7_100_000),
+            "receiver.1.active.freq_mode.freq_hz",
+            7_100_000,
+        ),
+        (
+            FieldPath.active("main", "freq_mode", "mode"),
+            0x26,
+            0x00,
+            bytes([Mode.USB.value, 0x00, 1]),
+            "receiver.0.active.freq_mode.mode",
+            "USB",
+        ),
+        (
+            FieldPath.active("sub", "freq_mode", "mode"),
+            0x26,
+            0x01,
+            bytes([Mode.CW.value, 0x00, 3]),
+            "receiver.1.active.freq_mode.mode",
+            "CW",
+        ),
+    ],
+)
+async def test_scheduler_active_freq_mode_request_completes_from_civ_rx_loop(
+    radio: IcomRadio,
+    transport: MockTransport,
+    path: FieldPath,
+    cmd: int,
+    receiver: int,
+    payload: bytes,
+    stored_path: str,
+    expected: object,
+) -> None:
+    scheduler = AcquisitionScheduler(profile=_acquisition_profile(path))
+    radio._acquisition_scheduler = scheduler
+    poller = RadioPoller(radio, CommandQueue(), radio_state=RadioState())
+
+    await poller._send_query()  # noqa: SLF001
+
+    assert scheduler.pending_requests()[0].paths == (path,)
+
+    civ = build_civ_frame(
+        CONTROLLER_ADDR,
+        IC_7610_ADDR,
+        cmd,
+        data=bytes([receiver]) + payload,
+    )
+    transport.queue_response(_wrap_civ_in_udp(civ))
+
+    radio._civ_runtime.start_pump()
+    try:
+        for _ in range(20):
+            if scheduler.pending_requests() == ():
+                break
+            await asyncio.sleep(0.01)
+    finally:
+        await radio._civ_runtime.stop_pump()
+        radio._connected = False
+
+    assert scheduler.pending_requests() == ()
+    assert radio._state_store.snapshot().field(stored_path).value == expected
 
 
 def test_meter_coalescing_applies_latest_due_sample_and_records_diagnostics(

--- a/tests/test_command_service.py
+++ b/tests/test_command_service.py
@@ -427,6 +427,107 @@ def test_intended_correlated_observation_reconciles_pending_overlay() -> None:
     assert [event.command_id for event in reconciled] == ["cmd-a"]
 
 
+def test_same_command_id_reused_across_sources_requires_matching_source_metadata() -> (
+    None
+):
+    clock = FreshnessClock(start=59.0)
+    service = CommandService(
+        executor=FakeExecutor(),
+        state_store=StateStore(freshness_clock=clock),
+        clock=clock.now,
+    )
+    freq = _freq_path()
+    for source in ("websocket", "http"):
+        service.record_pending_overlay(
+            PendingOverlay(
+                source=cast(CommandSource, source),
+                session_id=None,
+                command_id="cmd-shared",
+                path=freq,
+                value=14_074_000,
+                expires_at_monotonic=60.0,
+            )
+        )
+
+    service.apply_observation(
+        Observation(
+            path=freq,
+            value=14_074_000,
+            source=SourceMetadata(
+                source="command_response",
+                provider="test",
+                transport="fake",
+                command_source="websocket",
+            ),
+            timestamp_monotonic=59.2,
+            correlation_id="cmd-shared",
+        )
+    )
+
+    assert service.pending_overlays(source="websocket", session_id=None) == ()
+    assert service.pending_overlays(source="http", session_id=None) == (
+        PendingOverlay(
+            source="http",
+            session_id=None,
+            command_id="cmd-shared",
+            path=freq,
+            value=14_074_000,
+            expires_at_monotonic=60.0,
+        ),
+    )
+
+
+def test_same_command_id_reused_across_sessions_requires_matching_session_metadata() -> (
+    None
+):
+    clock = FreshnessClock(start=60.0)
+    service = CommandService(
+        executor=FakeExecutor(),
+        state_store=StateStore(freshness_clock=clock),
+        clock=clock.now,
+    )
+    freq = _freq_path()
+    for session_id in ("ws-a", "ws-b"):
+        service.record_pending_overlay(
+            PendingOverlay(
+                source="websocket",
+                session_id=session_id,
+                command_id="cmd-shared",
+                path=freq,
+                value=14_074_000,
+                expires_at_monotonic=61.0,
+            )
+        )
+
+    service.apply_observation(
+        Observation(
+            path=freq,
+            value=14_074_000,
+            source=SourceMetadata(
+                source="command_response",
+                provider="test",
+                transport="fake",
+                command_source="websocket",
+                session_id="ws-a",
+            ),
+            timestamp_monotonic=60.2,
+            correlation_id="cmd-shared",
+        )
+    )
+
+    assert service.pending_overlays(source="websocket", session_id="ws-a") == ()
+    assert service.pending_overlays(source="websocket", session_id="ws-b") == (
+        PendingOverlay(
+            source="websocket",
+            session_id="ws-b",
+            command_id="cmd-shared",
+            path=freq,
+            value=14_074_000,
+            expires_at_monotonic=61.0,
+        ),
+    )
+
+
 def test_lifecycle_subscribers_observe_deterministic_events() -> None:
     clock = FreshnessClock(start=60.0)
     service = CommandService(
@@ -482,7 +583,27 @@ def test_command_response_observation_uses_command_response_source() -> None:
     assert observation.value == "USB"
     assert observation.source.source == "command_response"
     assert observation.source.provider == "rigctld"
+    assert observation.source.command_source == "rigctld"
+    assert observation.source.session_id is None
     assert observation.correlation_id == "rig-1"
+
+
+def test_command_response_observation_carries_session_metadata() -> None:
+    intent = command_intent_from_request(
+        "set_freq",
+        {"freq": 14_074_000, "receiver": 0, "session_id": "ws-a"},
+        source="websocket",
+        command_id="ws-1",
+    )
+
+    observation = command_response_observation(
+        intent,
+        timestamp_monotonic=43.0,
+        provider="web_poller",
+    )
+
+    assert observation.source.command_source == "websocket"
+    assert observation.source.session_id == "ws-a"
 
 
 @pytest.mark.parametrize(  # type: ignore[untyped-decorator]

--- a/tests/test_command_service.py
+++ b/tests/test_command_service.py
@@ -483,3 +483,59 @@ def test_command_response_observation_uses_command_response_source() -> None:
     assert observation.source.source == "command_response"
     assert observation.source.provider == "rigctld"
     assert observation.correlation_id == "rig-1"
+
+
+@pytest.mark.parametrize(  # type: ignore[untyped-decorator]
+    ("name", "params", "expected_path", "expected_value"),
+    [
+        ("set_filter", {"filter_num": 2}, "receiver.0.freq_mode.filter_width", 2),
+        ("set_ptt", {"on": True}, "global.tx_state.ptt", True),
+        ("ptt", {"state": True}, "global.tx_state.ptt", True),
+        ("ptt_on", {}, "global.tx_state.ptt", True),
+        ("ptt_off", {}, "global.tx_state.ptt", False),
+        ("set_rf_gain", {"level": 111}, "receiver.0.operator_controls.rf_gain", 111),
+        ("set_af_level", {"level": 87}, "receiver.0.operator_controls.af_level", 87),
+        ("set_squelch", {"level": 42}, "receiver.0.operator_controls.squelch", 42),
+        ("set_nb", {"on": True}, "receiver.0.operator_toggles.nb", True),
+        ("set_nr", {"on": False}, "receiver.0.operator_toggles.nr", False),
+        (
+            "set_pbt_inner",
+            {"level": 140},
+            "receiver.0.operator_controls.pbt_inner",
+            140,
+        ),
+        (
+            "set_pbt_outer",
+            {"level": 116},
+            "receiver.0.operator_controls.pbt_outer",
+            116,
+        ),
+        ("set_powerstat", {"on": False}, "global.tx_state.power_on", False),
+        ("set_rf_power", {"level": 88}, "global.operator_controls.power_level", 88),
+        ("set_power", {"level": 77}, "global.operator_controls.power_level", 77),
+        ("set_filter_width", {"width": 1500}, "receiver.0.freq_mode.filter_width", 1500),
+        ("set_split", {"on": True}, "global.tx_state.split", True),
+        ("set_vfo", {"vfo": "B"}, "receiver.0.vfo.active_slot", "B"),
+    ],
+)
+def test_command_intent_targets_observable_production_write_paths(
+    name: str,
+    params: dict[str, object],
+    expected_path: str,
+    expected_value: object,
+) -> None:
+    intent = command_intent_from_request(
+        name,
+        params,
+        source="http",
+        command_id=f"cmd-{name}",
+    )
+
+    assert str(intent.target) == expected_path
+    assert intent.pending_policy == "scoped"
+    observation = command_response_observation(
+        intent,
+        timestamp_monotonic=70.0,
+        provider="test",
+    )
+    assert observation.value == expected_value

--- a/tests/test_command_service.py
+++ b/tests/test_command_service.py
@@ -1,0 +1,287 @@
+"""Backend-neutral command service behavior."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any, cast
+
+import pytest
+
+from rigplane.core.command_service import (
+    CommandExecutionResult,
+    CommandService,
+    PendingOverlay,
+)
+from rigplane.core.state_pipeline_contracts import (
+    CommandIntent,
+    CommandLifecycleEvent,
+    CommandSource,
+    FieldPath,
+    Observation,
+    SourceMetadata,
+)
+from rigplane.core.state_store import FreshnessClock, StateStore
+
+
+class FakeExecutor:
+    def __init__(
+        self,
+        *,
+        observations: Sequence[Observation] = (),
+        fail: Exception | None = None,
+    ) -> None:
+        self.observations = tuple(observations)
+        self.fail = fail
+        self.intents: list[CommandIntent] = []
+
+    async def execute(self, intent: CommandIntent) -> CommandExecutionResult:
+        self.intents.append(intent)
+        if self.fail is not None:
+            raise self.fail
+        return CommandExecutionResult(observations=self.observations)
+
+
+def _freq_path() -> FieldPath:
+    return FieldPath.active("main", "freq_mode", "freq_hz")
+
+
+def _mode_path() -> FieldPath:
+    return FieldPath.active("main", "freq_mode", "mode")
+
+
+def _source() -> SourceMetadata:
+    return SourceMetadata(
+        source="command_response",
+        provider="test",
+        transport="fake",
+    )
+
+
+def _observation(path: FieldPath, value: Any, *, at: float) -> Observation:
+    return Observation(
+        path=path,
+        value=value,
+        source=_source(),
+        timestamp_monotonic=at,
+        correlation_id="cmd-1",
+    )
+
+
+def _intent(
+    *,
+    command_id: str = "cmd-1",
+    source: str = "websocket",
+    session_id: str | None = "ws-a",
+) -> CommandIntent:
+    return CommandIntent(
+        id=command_id,
+        name="set_freq",
+        params={
+            "freq_hz": 14_074_000,
+            "session_id": session_id,
+        },
+        source=cast(CommandSource, source),
+        target=_freq_path(),
+        priority="user",
+        timeout=2.0,
+        pending_policy="scoped",
+        expected_observations=(_freq_path(),),
+    )
+
+
+def _states(events: Sequence[CommandLifecycleEvent]) -> list[str]:
+    return [event.state for event in events]
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_execute_emits_lifecycle_events_and_applies_response_observations() -> None:
+    clock = FreshnessClock(start=10.0)
+    store = StateStore(freshness_clock=clock)
+    executor = FakeExecutor(
+        observations=(_observation(_freq_path(), 14_074_000, at=10.0),)
+    )
+    service = CommandService(executor=executor, state_store=store, clock=clock.now)
+
+    result = await service.execute(_intent())
+
+    assert executor.intents == [_intent()]
+    assert _states(service.lifecycle_events()) == [
+        "accepted",
+        "queued",
+        "sent",
+        "acknowledged",
+        "reconciled",
+    ]
+    assert result.observation_changes[0].changes[0].current == 14_074_000
+    assert store.snapshot().field(_freq_path()).value == 14_074_000
+    assert service.pending_overlays(source="websocket", session_id="ws-a") == ()
+
+
+def test_pending_overlays_are_projected_by_source_session_command_and_path() -> None:
+    clock = FreshnessClock(start=20.0)
+    store = StateStore(freshness_clock=clock)
+    service = CommandService(
+        executor=FakeExecutor(),
+        state_store=store,
+        clock=clock.now,
+    )
+    freq = _freq_path()
+    mode = _mode_path()
+
+    service.record_pending_overlay(
+        PendingOverlay(
+            source="websocket",
+            session_id="ws-a",
+            command_id="cmd-1",
+            path=freq,
+            value=14_074_000,
+            expires_at_monotonic=25.0,
+        )
+    )
+    service.record_pending_overlay(
+        PendingOverlay(
+            source="websocket",
+            session_id="ws-b",
+            command_id="cmd-2",
+            path=freq,
+            value=7_074_000,
+            expires_at_monotonic=25.0,
+        )
+    )
+    service.record_pending_overlay(
+        PendingOverlay(
+            source="rigctld",
+            session_id="rig-a",
+            command_id="cmd-3",
+            path=mode,
+            value="USB",
+            expires_at_monotonic=25.0,
+        )
+    )
+
+    assert service.project_pending_values(
+        source="websocket",
+        session_id="ws-a",
+        paths=(freq, mode),
+    ) == {freq: 14_074_000}
+    assert service.project_pending_values(
+        source="websocket",
+        session_id="ws-b",
+        paths=(freq,),
+    ) == {freq: 7_074_000}
+    assert service.project_pending_values(
+        source="rigctld",
+        session_id="rig-a",
+        paths=(mode,),
+    ) == {mode: "USB"}
+    assert service.pending_overlays(
+        source="websocket",
+        session_id="ws-a",
+        command_id="cmd-1",
+        path=freq,
+    )[0].value == 14_074_000
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_late_matching_observation_reconciles_pending_overlay_once() -> None:
+    clock = FreshnessClock(start=30.0)
+    store = StateStore(freshness_clock=clock)
+    service = CommandService(
+        executor=FakeExecutor(observations=()),
+        state_store=store,
+        clock=clock.now,
+    )
+
+    await service.execute(_intent())
+    assert service.project_pending_values(
+        source="websocket",
+        session_id="ws-a",
+        paths=(_freq_path(),),
+    ) == {_freq_path(): 14_074_000}
+
+    first = service.apply_observation(
+        _observation(_freq_path(), 14_074_000, at=30.5)
+    )
+    duplicate = service.apply_observation(
+        _observation(_freq_path(), 14_074_000, at=30.6)
+    )
+
+    assert first.changes[0].current == 14_074_000
+    assert duplicate.changes == ()
+    assert _states(service.lifecycle_events()).count("reconciled") == 1
+    assert service.pending_overlays(source="websocket", session_id="ws-a") == ()
+    assert store.snapshot().field(_freq_path()).value == 14_074_000
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_failed_and_timed_out_commands_expire_overlays() -> None:
+    clock = FreshnessClock(start=40.0)
+    store = StateStore(freshness_clock=clock)
+    failed = CommandService(
+        executor=FakeExecutor(fail=RuntimeError("radio rejected command")),
+        state_store=store,
+        clock=clock.now,
+    )
+
+    with pytest.raises(RuntimeError, match="radio rejected command"):
+        await failed.execute(_intent(command_id="cmd-failed"))
+
+    timeout = CommandService(
+        executor=FakeExecutor(fail=TimeoutError("command timed out")),
+        state_store=store,
+        clock=clock.now,
+    )
+
+    with pytest.raises(TimeoutError, match="command timed out"):
+        await timeout.execute(_intent(command_id="cmd-timeout"))
+
+    assert _states(failed.lifecycle_events())[-1] == "failed"
+    assert _states(timeout.lifecycle_events())[-1] == "timed_out"
+    assert failed.pending_overlays(source="websocket", session_id="ws-a") == ()
+    assert timeout.pending_overlays(source="websocket", session_id="ws-a") == ()
+
+
+def test_expired_pending_overlays_do_not_project_or_leak() -> None:
+    clock = FreshnessClock(start=50.0)
+    service = CommandService(
+        executor=FakeExecutor(),
+        state_store=StateStore(freshness_clock=clock),
+        clock=clock.now,
+    )
+    service.record_pending_overlay(
+        PendingOverlay(
+            source="public_api",
+            session_id=None,
+            command_id="cmd-1",
+            path=_freq_path(),
+            value=14_074_000,
+            expires_at_monotonic=50.5,
+        )
+    )
+
+    clock.advance(0.6)
+
+    assert service.project_pending_values(
+        source="public_api",
+        session_id=None,
+        paths=(_freq_path(),),
+    ) == {}
+    assert service.pending_overlays(source="public_api", session_id=None) == ()
+
+
+def test_lifecycle_subscribers_observe_deterministic_events() -> None:
+    clock = FreshnessClock(start=60.0)
+    service = CommandService(
+        executor=FakeExecutor(),
+        state_store=StateStore(freshness_clock=clock),
+        clock=clock.now,
+    )
+    seen: list[CommandLifecycleEvent] = []
+
+    unsubscribe = service.subscribe_lifecycle(seen.append)
+    service.emit_lifecycle(_intent(), "queued", message="queued by web adapter")
+    unsubscribe()
+    service.emit_lifecycle(_intent(), "sent", message="sent by fake executor")
+
+    assert _states(seen) == ["queued"]
+    assert _states(service.lifecycle_events()) == ["queued", "sent"]

--- a/tests/test_command_service.py
+++ b/tests/test_command_service.py
@@ -57,13 +57,19 @@ def _source() -> SourceMetadata:
     )
 
 
-def _observation(path: FieldPath, value: Any, *, at: float) -> Observation:
+def _observation(
+    path: FieldPath,
+    value: Any,
+    *,
+    at: float,
+    correlation_id: str | None = "cmd-1",
+) -> Observation:
     return Observation(
         path=path,
         value=value,
         source=_source(),
         timestamp_monotonic=at,
-        correlation_id="cmd-1",
+        correlation_id=correlation_id,
     )
 
 
@@ -267,6 +273,156 @@ def test_expired_pending_overlays_do_not_project_or_leak() -> None:
         paths=(_freq_path(),),
     ) == {}
     assert service.pending_overlays(source="public_api", session_id=None) == ()
+
+
+def test_same_path_value_across_sessions_reconciles_only_correlated_overlay() -> None:
+    clock = FreshnessClock(start=55.0)
+    service = CommandService(
+        executor=FakeExecutor(),
+        state_store=StateStore(freshness_clock=clock),
+        clock=clock.now,
+    )
+    freq = _freq_path()
+    for session_id, command_id in (("ws-a", "cmd-a"), ("ws-b", "cmd-b")):
+        service.record_pending_overlay(
+            PendingOverlay(
+                source="websocket",
+                session_id=session_id,
+                command_id=command_id,
+                path=freq,
+                value=14_074_000,
+                expires_at_monotonic=56.0,
+            )
+        )
+
+    service.apply_observation(
+        _observation(freq, 14_074_000, at=55.2, correlation_id="cmd-a")
+    )
+
+    assert service.pending_overlays(source="websocket", session_id="ws-a") == ()
+    assert service.pending_overlays(source="websocket", session_id="ws-b") == (
+        PendingOverlay(
+            source="websocket",
+            session_id="ws-b",
+            command_id="cmd-b",
+            path=freq,
+            value=14_074_000,
+            expires_at_monotonic=56.0,
+        ),
+    )
+    reconciled = [
+        event for event in service.lifecycle_events() if event.state == "reconciled"
+    ]
+    assert [event.command_id for event in reconciled] == ["cmd-a"]
+
+
+def test_same_path_value_across_command_ids_reconciles_only_correlated_command() -> None:
+    clock = FreshnessClock(start=56.0)
+    service = CommandService(
+        executor=FakeExecutor(),
+        state_store=StateStore(freshness_clock=clock),
+        clock=clock.now,
+    )
+    freq = _freq_path()
+    for command_id in ("cmd-a", "cmd-b"):
+        service.record_pending_overlay(
+            PendingOverlay(
+                source="websocket",
+                session_id="ws-a",
+                command_id=command_id,
+                path=freq,
+                value=14_074_000,
+                expires_at_monotonic=57.0,
+            )
+        )
+
+    service.apply_observation(
+        _observation(freq, 14_074_000, at=56.2, correlation_id="cmd-a")
+    )
+
+    assert service.pending_overlays(
+        source="websocket",
+        session_id="ws-a",
+        command_id="cmd-a",
+    ) == ()
+    assert service.pending_overlays(
+        source="websocket",
+        session_id="ws-a",
+        command_id="cmd-b",
+    ) == (
+        PendingOverlay(
+            source="websocket",
+            session_id="ws-a",
+            command_id="cmd-b",
+            path=freq,
+            value=14_074_000,
+            expires_at_monotonic=57.0,
+        ),
+    )
+    reconciled = [
+        event for event in service.lifecycle_events() if event.state == "reconciled"
+    ]
+    assert [event.command_id for event in reconciled] == ["cmd-a"]
+
+
+def test_uncorrelated_duplicate_observation_does_not_reconcile_pending_overlay() -> None:
+    clock = FreshnessClock(start=57.0)
+    service = CommandService(
+        executor=FakeExecutor(),
+        state_store=StateStore(freshness_clock=clock),
+        clock=clock.now,
+    )
+    freq = _freq_path()
+    overlay = PendingOverlay(
+        source="websocket",
+        session_id="ws-a",
+        command_id="cmd-a",
+        path=freq,
+        value=14_074_000,
+        expires_at_monotonic=58.0,
+    )
+    service.record_pending_overlay(overlay)
+
+    service.apply_observation(
+        _observation(freq, 14_074_000, at=57.2, correlation_id=None)
+    )
+
+    assert service.pending_overlays(source="websocket", session_id="ws-a") == (
+        overlay,
+    )
+    assert [
+        event for event in service.lifecycle_events() if event.state == "reconciled"
+    ] == []
+
+
+def test_intended_correlated_observation_reconciles_pending_overlay() -> None:
+    clock = FreshnessClock(start=58.0)
+    service = CommandService(
+        executor=FakeExecutor(),
+        state_store=StateStore(freshness_clock=clock),
+        clock=clock.now,
+    )
+    freq = _freq_path()
+    service.record_pending_overlay(
+        PendingOverlay(
+            source="websocket",
+            session_id="ws-a",
+            command_id="cmd-a",
+            path=freq,
+            value=14_074_000,
+            expires_at_monotonic=59.0,
+        )
+    )
+
+    service.apply_observation(
+        _observation(freq, 14_074_000, at=58.2, correlation_id="cmd-a")
+    )
+
+    assert service.pending_overlays(source="websocket", session_id="ws-a") == ()
+    reconciled = [
+        event for event in service.lifecycle_events() if event.state == "reconciled"
+    ]
+    assert [event.command_id for event in reconciled] == ["cmd-a"]
 
 
 def test_lifecycle_subscribers_observe_deterministic_events() -> None:

--- a/tests/test_command_service.py
+++ b/tests/test_command_service.py
@@ -11,6 +11,8 @@ from rigplane.core.command_service import (
     CommandExecutionResult,
     CommandService,
     PendingOverlay,
+    command_intent_from_request,
+    command_response_observation,
 )
 from rigplane.core.state_pipeline_contracts import (
     CommandIntent,
@@ -441,3 +443,43 @@ def test_lifecycle_subscribers_observe_deterministic_events() -> None:
 
     assert _states(seen) == ["queued"]
     assert _states(service.lifecycle_events()) == ["queued", "sent"]
+
+
+def test_command_intent_from_web_set_freq_request_targets_receiver_state() -> None:
+    intent = command_intent_from_request(
+        "set_freq",
+        {"freq": 14_074_000, "receiver": 1, "session_id": "ws-a"},
+        source="websocket",
+        command_id="ws-123",
+    )
+
+    assert intent.id == "ws-123"
+    assert intent.name == "set_freq"
+    assert intent.source == "websocket"
+    assert intent.params["freq_hz"] == 14_074_000
+    assert intent.params["receiver"] == 1
+    assert intent.params["session_id"] == "ws-a"
+    assert str(intent.target) == "receiver.1.freq_mode.freq_hz"
+    assert intent.pending_policy == "scoped"
+    assert intent.expected_observations == (intent.target,)
+
+
+def test_command_response_observation_uses_command_response_source() -> None:
+    intent = command_intent_from_request(
+        "set_mode",
+        {"mode": "USB", "filter_width": 2, "receiver": 0},
+        source="rigctld",
+        command_id="rig-1",
+    )
+
+    observation = command_response_observation(
+        intent,
+        timestamp_monotonic=42.0,
+        provider="rigctld",
+    )
+
+    assert str(observation.path) == "receiver.0.freq_mode.mode"
+    assert observation.value == "USB"
+    assert observation.source.source == "command_response"
+    assert observation.source.provider == "rigctld"
+    assert observation.correlation_id == "rig-1"

--- a/tests/test_command_service.py
+++ b/tests/test_command_service.py
@@ -249,6 +249,106 @@ async def test_failed_and_timed_out_commands_expire_overlays() -> None:
     assert timeout.pending_overlays(source="websocket", session_id="ws-a") == ()
 
 
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_execute_failure_with_reused_command_id_expires_only_matching_scope() -> None:
+    clock = FreshnessClock(start=41.0)
+    service = CommandService(
+        executor=FakeExecutor(fail=RuntimeError("radio rejected command")),
+        state_store=StateStore(freshness_clock=clock),
+        clock=clock.now,
+    )
+    freq = _freq_path()
+    service.record_pending_overlay(
+        PendingOverlay(
+            source="http",
+            session_id=None,
+            command_id="cmd-shared",
+            path=freq,
+            value=7_040_000,
+            expires_at_monotonic=42.0,
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="radio rejected command"):
+        await service.execute(_intent(command_id="cmd-shared"))
+
+    assert service.pending_overlays(source="websocket", session_id="ws-a") == ()
+    assert service.pending_overlays(source="http", session_id=None) == (
+        PendingOverlay(
+            source="http",
+            session_id=None,
+            command_id="cmd-shared",
+            path=freq,
+            value=7_040_000,
+            expires_at_monotonic=42.0,
+        ),
+    )
+
+
+def test_fail_command_with_reused_command_id_expires_only_matching_scope() -> None:
+    clock = FreshnessClock(start=42.0)
+    service = CommandService(
+        executor=FakeExecutor(),
+        state_store=StateStore(freshness_clock=clock),
+        clock=clock.now,
+    )
+    freq = _freq_path()
+    for source, session_id, value in (
+        ("websocket", "ws-a", 14_074_000),
+        ("websocket", "ws-b", 14_075_000),
+        ("http", None, 14_076_000),
+    ):
+        service.record_pending_overlay(
+            PendingOverlay(
+                source=cast(CommandSource, source),
+                session_id=session_id,
+                command_id="cmd-shared",
+                path=freq,
+                value=value,
+                expires_at_monotonic=43.0,
+            )
+        )
+
+    service.emit_lifecycle(_intent(command_id="cmd-shared", session_id="ws-a"), "queued")
+    service.emit_lifecycle(
+        _intent(command_id="cmd-shared", session_id="ws-b"),
+        "queued",
+    )
+    service.emit_lifecycle(
+        _intent(command_id="cmd-shared", source="http", session_id=None),
+        "queued",
+    )
+
+    assert service.fail_command(
+        "cmd-shared",
+        message="radio rejected command",
+        source="websocket",
+        session_id="ws-a",
+    )
+
+    assert service.pending_overlays(source="websocket", session_id="ws-a") == ()
+    assert service.pending_overlays(source="websocket", session_id="ws-b") == (
+        PendingOverlay(
+            source="websocket",
+            session_id="ws-b",
+            command_id="cmd-shared",
+            path=freq,
+            value=14_075_000,
+            expires_at_monotonic=43.0,
+        ),
+    )
+    assert service.pending_overlays(source="http", session_id=None) == (
+        PendingOverlay(
+            source="http",
+            session_id=None,
+            command_id="cmd-shared",
+            path=freq,
+            value=14_076_000,
+            expires_at_monotonic=43.0,
+        ),
+    )
+
+
 def test_expired_pending_overlays_do_not_project_or_leak() -> None:
     clock = FreshnessClock(start=50.0)
     service = CommandService(

--- a/tests/test_command_service.py
+++ b/tests/test_command_service.py
@@ -14,6 +14,7 @@ from rigplane.core.command_service import (
     command_intent_from_request,
     command_response_observation,
 )
+from rigplane.core.exceptions import TimeoutError as RigplaneTimeoutError
 from rigplane.core.state_pipeline_contracts import (
     CommandIntent,
     CommandLifecycleEvent,
@@ -247,6 +248,23 @@ async def test_failed_and_timed_out_commands_expire_overlays() -> None:
     assert _states(timeout.lifecycle_events())[-1] == "timed_out"
     assert failed.pending_overlays(source="websocket", session_id="ws-a") == ()
     assert timeout.pending_overlays(source="websocket", session_id="ws-a") == ()
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_core_timeout_error_is_classified_as_timed_out() -> None:
+    clock = FreshnessClock(start=40.5)
+    store = StateStore(freshness_clock=clock)
+    service = CommandService(
+        executor=FakeExecutor(fail=RigplaneTimeoutError("backend timed out")),
+        state_store=store,
+        clock=clock.now,
+    )
+
+    with pytest.raises(RigplaneTimeoutError, match="backend timed out"):
+        await service.execute(_intent(command_id="cmd-core-timeout"))
+
+    assert _states(service.lifecycle_events())[-1] == "timed_out"
+    assert service.pending_overlays(source="websocket", session_id="ws-a") == ()
 
 
 @pytest.mark.asyncio  # type: ignore[untyped-decorator]
@@ -717,6 +735,9 @@ def test_command_response_observation_carries_session_metadata() -> None:
         ("set_rf_gain", {"level": 111}, "receiver.0.operator_controls.rf_gain", 111),
         ("set_af_level", {"level": 87}, "receiver.0.operator_controls.af_level", 87),
         ("set_squelch", {"level": 42}, "receiver.0.operator_controls.squelch", 42),
+        ("set_att", {"db": 12}, "receiver.0.operator_controls.att", 12),
+        ("set_attenuator", {"level": 18}, "receiver.0.operator_controls.att", 18),
+        ("set_preamp", {"level": 2}, "receiver.0.operator_controls.preamp", 2),
         ("set_nb", {"on": True}, "receiver.0.operator_toggles.nb", True),
         ("set_nr", {"on": False}, "receiver.0.operator_toggles.nr", False),
         (

--- a/tests/test_command_service.py
+++ b/tests/test_command_service.py
@@ -103,7 +103,9 @@ def _states(events: Sequence[CommandLifecycleEvent]) -> list[str]:
 
 
 @pytest.mark.asyncio  # type: ignore[untyped-decorator]
-async def test_execute_emits_lifecycle_events_and_applies_response_observations() -> None:
+async def test_execute_emits_lifecycle_events_and_applies_response_observations() -> (
+    None
+):
     clock = FreshnessClock(start=10.0)
     store = StateStore(freshness_clock=clock)
     executor = FakeExecutor(
@@ -183,12 +185,15 @@ def test_pending_overlays_are_projected_by_source_session_command_and_path() -> 
         session_id="rig-a",
         paths=(mode,),
     ) == {mode: "USB"}
-    assert service.pending_overlays(
-        source="websocket",
-        session_id="ws-a",
-        command_id="cmd-1",
-        path=freq,
-    )[0].value == 14_074_000
+    assert (
+        service.pending_overlays(
+            source="websocket",
+            session_id="ws-a",
+            command_id="cmd-1",
+            path=freq,
+        )[0].value
+        == 14_074_000
+    )
 
 
 @pytest.mark.asyncio  # type: ignore[untyped-decorator]
@@ -208,9 +213,7 @@ async def test_late_matching_observation_reconciles_pending_overlay_once() -> No
         paths=(_freq_path(),),
     ) == {_freq_path(): 14_074_000}
 
-    first = service.apply_observation(
-        _observation(_freq_path(), 14_074_000, at=30.5)
-    )
+    first = service.apply_observation(_observation(_freq_path(), 14_074_000, at=30.5))
     duplicate = service.apply_observation(
         _observation(_freq_path(), 14_074_000, at=30.6)
     )
@@ -268,7 +271,9 @@ async def test_core_timeout_error_is_classified_as_timed_out() -> None:
 
 
 @pytest.mark.asyncio  # type: ignore[untyped-decorator]
-async def test_execute_failure_with_reused_command_id_expires_only_matching_scope() -> None:
+async def test_execute_failure_with_reused_command_id_expires_only_matching_scope() -> (
+    None
+):
     clock = FreshnessClock(start=41.0)
     service = CommandService(
         executor=FakeExecutor(fail=RuntimeError("radio rejected command")),
@@ -327,7 +332,9 @@ def test_fail_command_with_reused_command_id_expires_only_matching_scope() -> No
             )
         )
 
-    service.emit_lifecycle(_intent(command_id="cmd-shared", session_id="ws-a"), "queued")
+    service.emit_lifecycle(
+        _intent(command_id="cmd-shared", session_id="ws-a"), "queued"
+    )
     service.emit_lifecycle(
         _intent(command_id="cmd-shared", session_id="ws-b"),
         "queued",
@@ -387,11 +394,14 @@ def test_expired_pending_overlays_do_not_project_or_leak() -> None:
 
     clock.advance(0.6)
 
-    assert service.project_pending_values(
-        source="public_api",
-        session_id=None,
-        paths=(_freq_path(),),
-    ) == {}
+    assert (
+        service.project_pending_values(
+            source="public_api",
+            session_id=None,
+            paths=(_freq_path(),),
+        )
+        == {}
+    )
     assert service.pending_overlays(source="public_api", session_id=None) == ()
 
 
@@ -436,7 +446,9 @@ def test_same_path_value_across_sessions_reconciles_only_correlated_overlay() ->
     assert [event.command_id for event in reconciled] == ["cmd-a"]
 
 
-def test_same_path_value_across_command_ids_reconciles_only_correlated_command() -> None:
+def test_same_path_value_across_command_ids_reconciles_only_correlated_command() -> (
+    None
+):
     clock = FreshnessClock(start=56.0)
     service = CommandService(
         executor=FakeExecutor(),
@@ -460,11 +472,14 @@ def test_same_path_value_across_command_ids_reconciles_only_correlated_command()
         _observation(freq, 14_074_000, at=56.2, correlation_id="cmd-a")
     )
 
-    assert service.pending_overlays(
-        source="websocket",
-        session_id="ws-a",
-        command_id="cmd-a",
-    ) == ()
+    assert (
+        service.pending_overlays(
+            source="websocket",
+            session_id="ws-a",
+            command_id="cmd-a",
+        )
+        == ()
+    )
     assert service.pending_overlays(
         source="websocket",
         session_id="ws-a",
@@ -485,7 +500,9 @@ def test_same_path_value_across_command_ids_reconciles_only_correlated_command()
     assert [event.command_id for event in reconciled] == ["cmd-a"]
 
 
-def test_uncorrelated_duplicate_observation_does_not_reconcile_pending_overlay() -> None:
+def test_uncorrelated_duplicate_observation_does_not_reconcile_pending_overlay() -> (
+    None
+):
     clock = FreshnessClock(start=57.0)
     service = CommandService(
         executor=FakeExecutor(),
@@ -507,9 +524,7 @@ def test_uncorrelated_duplicate_observation_does_not_reconcile_pending_overlay()
         _observation(freq, 14_074_000, at=57.2, correlation_id=None)
     )
 
-    assert service.pending_overlays(source="websocket", session_id="ws-a") == (
-        overlay,
-    )
+    assert service.pending_overlays(source="websocket", session_id="ws-a") == (overlay,)
     assert [
         event for event in service.lifecycle_events() if event.state == "reconciled"
     ] == []
@@ -755,7 +770,12 @@ def test_command_response_observation_carries_session_metadata() -> None:
         ("set_powerstat", {"on": False}, "global.tx_state.power_on", False),
         ("set_rf_power", {"level": 88}, "global.operator_controls.power_level", 88),
         ("set_power", {"level": 77}, "global.operator_controls.power_level", 77),
-        ("set_filter_width", {"width": 1500}, "receiver.0.freq_mode.filter_width", 1500),
+        (
+            "set_filter_width",
+            {"width": 1500},
+            "receiver.0.freq_mode.filter_width",
+            1500,
+        ),
         ("set_split", {"on": True}, "global.tx_state.split", True),
         ("set_vfo", {"vfo": "B"}, "receiver.0.vfo.active_slot", "B"),
     ],

--- a/tests/test_discovery_responder.py
+++ b/tests/test_discovery_responder.py
@@ -263,6 +263,35 @@ class TestDiscoveryResponderFleet:
         assert data["station"]["radioAvailable"] is True
         assert data["station"]["readiness"] == "ready_with_radio"
 
+    async def test_fleet_metadata_emitted_when_supplied(self) -> None:
+        """MOR-387: station fleet datagrams can carry box and Fleet API data."""
+        fleet = [
+            FleetRadioInfo(
+                id="radio-a", model="IC-7610", web_port=8081, connected=True
+            ),
+        ]
+        r = DiscoveryResponder(
+            web_port=8080,
+            fleet_provider=lambda: fleet,
+            fleet_api_base="http://127.0.0.1:8090",
+            box_id="RP-354E-3168-2C7B",
+            bind_host="127.0.0.1",
+            discovery_port=0,
+        )
+        await r.start()
+        try:
+            raw = await _query(r.port, MAGIC)
+        finally:
+            await r.stop()
+        assert raw is not None
+        data = json.loads(raw)
+
+        assert data["kind"] == "station_fleet"
+        assert data["box_id"] == "RP-354E-3168-2C7B"
+        assert data["urls"]["fleet"] == "http://127.0.0.1:8090"
+        assert data["radio"]["model"] == "IC-7610"
+        assert data["radios"][0]["id"] == "radio-a"
+
     async def test_radio_provider_overrides_top_level_with_fleet(self) -> None:
         """When both providers are set, top-level uses radio_provider."""
         fleet = [

--- a/tests/test_handlers_coverage.py
+++ b/tests/test_handlers_coverage.py
@@ -259,10 +259,18 @@ def _control_handler(
     ws: object | None = None,
     radio: object | None = None,
     server: object | None = None,
+    session_id: str | None = None,
 ) -> ControlHandler:
     if ws is None:
         ws = SimpleNamespace(send_text=AsyncMock(), recv=AsyncMock())
-    return ControlHandler(ws, radio, "9.9.9", "IC-7610", server=server)
+    return ControlHandler(
+        ws,
+        radio,
+        "9.9.9",
+        "IC-7610",
+        server=server,
+        session_id=session_id,
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_handlers_coverage.py
+++ b/tests/test_handlers_coverage.py
@@ -975,6 +975,38 @@ async def test_handle_command_response_paths() -> None:
     assert msg["ok"] is False and msg["error"] == "command_failed"
 
 
+async def test_websocket_set_freq_enters_command_service_and_preserves_queue() -> None:
+    ws = SimpleNamespace(send_text=AsyncMock())
+    queue = _QueueRecorder()
+    handler = _control_handler(
+        ws=ws,
+        radio=SimpleNamespace(connected=True),
+        server=SimpleNamespace(command_queue=queue),
+    )
+
+    await handler._handle_command(
+        {
+            "id": "ws-set-freq",
+            "name": "set_freq",
+            "params": {"freq": 14_074_000, "receiver": 0},
+        }
+    )
+
+    msg = decode_json(ws.send_text.await_args_list[-1].args[0])
+    assert msg["ok"] is True
+    assert msg["result"] == {"freq": 14_074_000, "receiver": 0}
+    assert isinstance(queue.items[-1], SetFreq)
+    events = handler._command_service.lifecycle_events()  # noqa: SLF001
+    assert [event.state for event in events[:4]] == [
+        "accepted",
+        "queued",
+        "sent",
+        "acknowledged",
+    ]
+    assert events[0].command_id == "ws-set-freq"
+    assert events[0].source == "websocket"
+
+
 async def test_radio_connect_paths() -> None:
     ws = SimpleNamespace(send_text=AsyncMock())
 

--- a/tests/test_lifecycle_diagnostics.py
+++ b/tests/test_lifecycle_diagnostics.py
@@ -85,6 +85,8 @@ async def _force_gc_ready(server: WebServer) -> None:
         "_scope_health_task",
         "_scope_reenable_task",
         "_dx_client_task",
+        "_state_store_freshness_task",
+        "_pending_state_broadcast_task",
     ):
         task = getattr(server, attr, None)
         if task is not None and not task.done():
@@ -138,7 +140,9 @@ async def test_web_server_gc_after_stop_does_not_log_warning(
     with caplog.at_level(logging.WARNING, logger="rigplane.web.server"):
         server = WebServer(config=WebConfig(port=0, discovery=False))
         await server.start()
+        assert server._server_was_running is True  # type: ignore[attr-defined]
         await server.stop()
+        assert server._server_was_running is False  # type: ignore[attr-defined]
         del server
         gc.collect()
 

--- a/tests/test_memory_commands.py
+++ b/tests/test_memory_commands.py
@@ -466,6 +466,32 @@ class TestHandlerMemoryDispatch:
         assert cmds[0].mem.frequency_hz == 14_074_000
 
     @pytest.mark.asyncio
+    async def test_set_memory_contents_ignores_transport_session_id(self) -> None:
+        handler, q = self._make_handler()
+        params = {
+            "channel": 1,
+            "frequency_hz": 14_074_000,
+            "mode": 1,
+            "filter": 1,
+            "scan": 0,
+            "datamode": 0,
+            "tonemode": 0,
+            "name": "FT8",
+            "session_id": "ws-a",
+        }
+
+        result = await handler._enqueue_command("set_memory_contents", params)
+
+        assert result == {"channel": 1}
+        cmds = q.drain()
+        assert len(cmds) == 1
+        from rigplane.web.radio_poller import SetMemoryContents
+
+        assert isinstance(cmds[0], SetMemoryContents)
+        assert cmds[0].mem.channel == 1
+        assert cmds[0].mem.frequency_hz == 14_074_000
+
+    @pytest.mark.asyncio
     async def test_set_bsr_dispatch(self) -> None:
         handler, q = self._make_handler()
         params = {
@@ -476,6 +502,28 @@ class TestHandlerMemoryDispatch:
             "filter": 1,
         }
         result = await handler._enqueue_command("set_bsr", params)
+        assert result == {"band": 5, "register": 1}
+        cmds = q.drain()
+        assert len(cmds) == 1
+        from rigplane.web.radio_poller import SetBsr
+
+        assert isinstance(cmds[0], SetBsr)
+        assert cmds[0].bsr.band == 5
+
+    @pytest.mark.asyncio
+    async def test_set_bsr_ignores_transport_session_id(self) -> None:
+        handler, q = self._make_handler()
+        params = {
+            "band": 5,
+            "register": 1,
+            "frequency_hz": 14_074_000,
+            "mode": 1,
+            "filter": 1,
+            "session_id": "ws-a",
+        }
+
+        result = await handler._enqueue_command("set_bsr", params)
+
         assert result == {"band": 5, "register": 1}
         cmds = q.drain()
         assert len(cmds) == 1

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -8,6 +8,16 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from rigplane.core.acquisition_scheduler import (
+    AcquisitionScheduler,
+    MeterObservationCoalescer,
+)
+from rigplane.core.state_acquisition_policy import (
+    AcquisitionPolicy,
+    FieldCapability,
+    RadioAcquisitionProfile,
+)
+from rigplane.core.state_pipeline_contracts import FieldPath
 from rigplane.core.state_store import StateStore
 from rigplane.core.command_service import (
     CommandExecutionResult,
@@ -207,6 +217,23 @@ def _make_radio(active: str = "MAIN") -> MagicMock:
     return radio
 
 
+def _acquisition_profile(
+    *paths: FieldPath,
+    policy: AcquisitionPolicy | None = None,
+) -> RadioAcquisitionProfile:
+    acquisition_policy = policy or AcquisitionPolicy(
+        cadence_seconds=1.0,
+        freshness_ttl_seconds=4.0,
+    )
+    return RadioAcquisitionProfile(
+        provider="icom_civ",
+        capabilities=tuple(
+            FieldCapability(path=path, polling=True) for path in paths
+        ),
+        default_policy=acquisition_policy,
+    )
+
+
 @pytest.mark.asyncio
 async def test_execute_set_data_mode_updates_sub_receiver_state_and_sends_wire_value() -> (
     None
@@ -228,6 +255,103 @@ async def test_execute_set_data_mode_updates_sub_receiver_state_and_sends_wire_v
     assert state.main.data_mode == 0
     assert state.sub.data_mode == 3
     assert ("data_mode_changed", {"mode": 3, "receiver": 1}) in events
+
+
+@pytest.mark.asyncio
+async def test_scheduler_due_request_sends_supported_civ_query_once() -> None:
+    radio = _make_radio(active="MAIN")
+    path = FieldPath.receiver("main", "meters", "s_meter")
+    scheduler = AcquisitionScheduler(profile=_acquisition_profile(path))
+    radio._acquisition_scheduler = scheduler
+    poller = RadioPoller(radio, CommandQueue(), radio_state=RadioState())
+
+    await poller._send_query()  # noqa: SLF001
+    await poller._send_query()  # noqa: SLF001
+
+    radio.send_civ.assert_awaited_once_with(
+        0x29,
+        sub=None,
+        data=b"\x00\x15\x02",
+        wait_response=False,
+    )
+    assert scheduler.pending_requests()[0].paths == (path,)
+
+
+@pytest.mark.asyncio
+async def test_scheduler_unknown_query_mapping_is_recorded_and_completed() -> None:
+    radio = _make_radio(active="MAIN")
+    path = FieldPath.global_("slow_state", "overflow")
+    scheduler = AcquisitionScheduler(profile=_acquisition_profile(path))
+    radio._acquisition_scheduler = scheduler
+    diagnostics = []
+    poller = RadioPoller(
+        radio,
+        CommandQueue(),
+        radio_state=RadioState(),
+        diagnostics=SimpleNamespace(record=lambda *args, **kwargs: diagnostics.append((args, kwargs))),  # type: ignore[arg-type]
+    )
+
+    await poller._send_query()  # noqa: SLF001
+    await poller._send_query()  # noqa: SLF001
+
+    radio.send_civ.assert_not_awaited()
+    assert scheduler.pending_requests() == ()
+    assert any(
+        args[:2] == ("acquisition_skip", "web.radio_poller")
+        and kwargs["path"] == str(path)
+        for args, kwargs in diagnostics
+    )
+
+
+@pytest.mark.asyncio
+async def test_poller_falls_back_to_legacy_query_without_scheduler() -> None:
+    radio = _make_radio(active="MAIN")
+    poller = RadioPoller(radio, CommandQueue(), radio_state=RadioState())
+
+    await poller._send_query()  # noqa: SLF001
+
+    assert radio.send_civ.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_poller_flushes_due_meter_coalescer_on_query_tick() -> None:
+    radio = _make_radio(active="MAIN")
+    radio._meter_observation_coalescer = MeterObservationCoalescer()
+    radio._civ_runtime = SimpleNamespace(flush_due_meter_observations=MagicMock())
+    poller = RadioPoller(radio, CommandQueue(), radio_state=RadioState())
+
+    await poller._send_query()  # noqa: SLF001
+
+    radio._civ_runtime.flush_due_meter_observations.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_scheduler_polling_does_not_starve_user_command_queue() -> None:
+    order: list[str] = []
+    radio = _make_radio(active="MAIN")
+    radio.set_freq = AsyncMock(side_effect=lambda *args, **kwargs: order.append("cmd"))
+
+    async def _send_civ(*args: object, **kwargs: object) -> None:
+        order.append("poll")
+
+    radio.send_civ = AsyncMock(side_effect=_send_civ)
+    path = FieldPath.receiver("main", "meters", "s_meter")
+    radio._acquisition_scheduler = AcquisitionScheduler(
+        profile=_acquisition_profile(path)
+    )
+    queue = CommandQueue()
+    queue.put_ordered(SetFreq(14_074_000))
+    poller = RadioPoller(radio, queue, radio_state=RadioState())
+
+    async def _stop_after_first_wait(*args: object, **kwargs: object) -> None:
+        raise asyncio.CancelledError
+
+    queue.wait = _stop_after_first_wait  # type: ignore[method-assign]
+
+    await poller._run()  # noqa: SLF001
+
+    assert order[:2] == ["cmd", "poll"]
+    assert radio.send_civ.await_count == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -9,6 +9,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from rigplane.core.state_store import StateStore
+from rigplane.core.command_service import (
+    CommandExecutionResult,
+    CommandService,
+    command_intent_from_request,
+)
 from rigplane.exceptions import CommandError
 from rigplane.profiles import resolve_radio_profile
 from rigplane.radio_state import RadioState
@@ -24,6 +29,7 @@ from rigplane.web.radio_poller import (
     RadioPoller,
     SelectVfo,
     SendCiv,
+    SetAfLevel,
     SetAgc,
     SetAttenuator,
     SetDataMode,
@@ -35,15 +41,26 @@ from rigplane.web.radio_poller import (
     SetMode,
     SetNB,
     SetNR,
+    SetPbtInner,
+    SetPbtOuter,
     SetPower,
     SetPreamp,
+    SetRfGain,
     SetScopeEdge,
     SetScopeRbw,
     SetScopeVbw,
+    SetSplit,
+    SetSquelch,
     SwitchScopeReceiver,
     VfoEqualize,
     VfoSwap,
 )
+
+
+class _NoopCommandExecutor:
+    async def execute(self, intent: object) -> CommandExecutionResult:
+        del intent
+        return CommandExecutionResult()
 
 
 def _make_radio(active: str = "MAIN") -> MagicMock:
@@ -75,6 +92,8 @@ def _make_radio(active: str = "MAIN") -> MagicMock:
     radio.set_preamp = AsyncMock()
     radio.get_preamp = AsyncMock(return_value=0)
     radio.set_agc = AsyncMock()
+    radio.set_pbt_inner = AsyncMock()
+    radio.set_pbt_outer = AsyncMock()
     radio.set_antenna_1 = AsyncMock()
     radio.set_antenna_2 = AsyncMock()
     radio.set_rx_antenna_ant1 = AsyncMock()
@@ -219,6 +238,21 @@ async def test_command_queue_ordered_lane_preserves_repeated_commands() -> None:
         PttOn(),
         PttOff(),
     ]
+
+
+def test_command_queue_entries_preserve_command_correlation_metadata() -> None:
+    q = CommandQueue()
+    q.put(SetFreq(14_030_000), command_id="ws-freq", source="websocket")
+    q.put_ordered(SetMode("USB"), command_id="http-mode", source="http")
+
+    entries = q.drain_entries()
+
+    assert entries[0].command == SetFreq(14_030_000)
+    assert entries[0].command_id == "ws-freq"
+    assert entries[0].source == "websocket"
+    assert entries[1].command == SetMode("USB")
+    assert entries[1].command_id == "http-mode"
+    assert entries[1].source == "http"
 
 
 @pytest.mark.asyncio
@@ -897,6 +931,164 @@ async def test_set_freq_readback_is_applied_as_state_store_observation() -> None
     assert field.value == 14_074_000
     assert field.source.source == "command_response"
     assert state.main.freq == 14_074_000
+
+
+@pytest.mark.parametrize(  # type: ignore[untyped-decorator]
+    ("command", "expected_path", "expected_value"),
+    [
+        (SetRfGain(level=120, receiver=1), "receiver.1.operator_controls.rf_gain", 120),
+        (SetAfLevel(level=90, receiver=1), "receiver.1.operator_controls.af_level", 90),
+        (SetSquelch(level=33, receiver=1), "receiver.1.operator_controls.squelch", 33),
+        (SetNB(on=True, receiver=1), "receiver.1.operator_toggles.nb", True),
+        (SetNR(on=False, receiver=1), "receiver.1.operator_toggles.nr", False),
+        (
+            SetPbtInner(level=140, receiver=1),
+            "receiver.1.operator_controls.pbt_inner",
+            140,
+        ),
+        (
+            SetPbtOuter(level=116, receiver=1),
+            "receiver.1.operator_controls.pbt_outer",
+            116,
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_observable_queue_commands_apply_state_store_observations(
+    command: object,
+    expected_path: str,
+    expected_value: object,
+) -> None:
+    radio = _make_radio()
+    state = RadioState()
+    store = StateStore()
+    poller = RadioPoller(
+        radio,
+        StateCache(),
+        CommandQueue(),
+        radio_state=state,
+        state_store=store,
+    )
+
+    await poller._execute(command)  # noqa: SLF001[arg-type]
+
+    field = store.snapshot().field(expected_path)
+    assert field.value == expected_value
+    assert field.source.source == "command_response"
+
+
+@pytest.mark.asyncio
+async def test_set_freq_readback_uses_original_command_correlation() -> None:
+    radio = _make_radio()
+    state = RadioState()
+    store = StateStore()
+    service = CommandService(
+        executor=_NoopCommandExecutor(),
+        state_store=store,
+    )
+    poller = RadioPoller(
+        radio,
+        StateCache(),
+        CommandQueue(),
+        radio_state=state,
+        state_store=store,
+    )
+    await service.execute(
+        command_intent_from_request(
+            "set_freq",
+            {"freq": 14_074_000, "receiver": 0},
+            source="websocket",
+            command_id="ws-set-freq",
+        )
+    )
+    assert service.pending_overlays(source="websocket", session_id=None) != ()
+
+    await poller._execute(  # noqa: SLF001
+        SetFreq(freq=14_074_000, receiver=0),
+        command_id="ws-set-freq",
+        source="websocket",
+        command_service=service,
+    )
+
+    field = store.snapshot().field("receiver.0.freq_mode.freq_hz")
+    assert field.value == 14_074_000
+    assert service.pending_overlays(source="websocket", session_id=None) == ()
+
+
+@pytest.mark.asyncio
+async def test_set_split_readback_uses_original_command_correlation() -> None:
+    radio = _make_radio()
+    state = RadioState()
+    store = StateStore()
+    service = CommandService(
+        executor=_NoopCommandExecutor(),
+        state_store=store,
+    )
+    poller = RadioPoller(
+        radio,
+        StateCache(),
+        CommandQueue(),
+        radio_state=state,
+        state_store=store,
+    )
+    await service.execute(
+        command_intent_from_request(
+            "set_split",
+            {"on": True},
+            source="websocket",
+            command_id="ws-set-split",
+        )
+    )
+    assert service.pending_overlays(source="websocket", session_id=None) != ()
+
+    await poller._execute(  # noqa: SLF001
+        SetSplit(on=True),
+        command_id="ws-set-split",
+        source="websocket",
+        command_service=service,
+    )
+
+    field = store.snapshot().field("global.tx_state.split")
+    assert field.value is True
+    assert service.pending_overlays(source="websocket", session_id=None) == ()
+
+
+@pytest.mark.asyncio
+async def test_select_vfo_readback_uses_original_command_correlation() -> None:
+    radio = _make_radio()
+    state = RadioState()
+    store = StateStore()
+    service = CommandService(
+        executor=_NoopCommandExecutor(),
+        state_store=store,
+    )
+    poller = RadioPoller(
+        radio,
+        StateCache(),
+        CommandQueue(),
+        radio_state=state,
+        state_store=store,
+    )
+    await service.execute(
+        command_intent_from_request(
+            "set_vfo",
+            {"vfo": "SUB"},
+            source="websocket",
+            command_id="ws-set-vfo",
+        )
+    )
+    assert service.pending_overlays(source="websocket", session_id=None) != ()
+
+    await poller._execute(  # noqa: SLF001
+        SelectVfo(vfo="SUB"),
+        command_id="ws-set-vfo",
+        source="websocket",
+        command_service=service,
+    )
+
+    field = store.snapshot().field("receiver.0.vfo.active_slot")
+    assert field.value == "B"
+    assert service.pending_overlays(source="websocket", session_id=None) == ()
 
 
 @pytest.mark.asyncio

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -81,6 +81,9 @@ class _QueuedAckExecutor:
             ),
             command_id=intent.id,
             source=intent.source,
+            session_id=None
+            if intent.params.get("session_id") is None
+            else str(intent.params["session_id"]),
             command_service=self.command_service,
         )
         return CommandExecutionResult(details={"queued": True})
@@ -265,7 +268,12 @@ async def test_command_queue_ordered_lane_preserves_repeated_commands() -> None:
 
 def test_command_queue_entries_preserve_command_correlation_metadata() -> None:
     q = CommandQueue()
-    q.put(SetFreq(14_030_000), command_id="ws-freq", source="websocket")
+    q.put(
+        SetFreq(14_030_000),
+        command_id="ws-freq",
+        source="websocket",
+        session_id="ws-a",
+    )
     q.put_ordered(SetMode("USB"), command_id="http-mode", source="http")
 
     entries = q.drain_entries()
@@ -273,9 +281,11 @@ def test_command_queue_entries_preserve_command_correlation_metadata() -> None:
     assert entries[0].command == SetFreq(14_030_000)
     assert entries[0].command_id == "ws-freq"
     assert entries[0].source == "websocket"
+    assert entries[0].session_id == "ws-a"
     assert entries[1].command == SetMode("USB")
     assert entries[1].command_id == "http-mode"
     assert entries[1].source == "http"
+    assert entries[1].session_id is None
 
 
 @pytest.mark.asyncio
@@ -1140,6 +1150,52 @@ async def test_set_freq_readback_uses_original_command_correlation() -> None:
     field = store.snapshot().field("receiver.0.freq_mode.freq_hz")
     assert field.value == 14_074_000
     assert service.pending_overlays(source="websocket", session_id=None) == ()
+
+
+@pytest.mark.asyncio
+async def test_set_freq_readback_reconciles_only_matching_websocket_session_for_reused_command_id() -> (
+    None
+):
+    radio = _make_radio()
+    store = StateStore()
+    queue = CommandQueue()
+    executor = _QueuedAckExecutor(queue)
+    service = CommandService(executor=executor, state_store=store)
+    executor.command_service = service
+    poller = RadioPoller(
+        radio,
+        StateCache(),
+        queue,
+        radio_state=RadioState(),
+        state_store=store,
+    )
+
+    for session_id in ("ws-a", "ws-b"):
+        await service.execute(
+            command_intent_from_request(
+                "set_freq",
+                {"freq": 14_074_000, "receiver": 0},
+                source="websocket",
+                command_id="shared-id",
+                session_id=session_id,
+            )
+        )
+
+    assert len(service.pending_overlays(source="websocket", session_id="ws-a")) == 1
+    assert len(service.pending_overlays(source="websocket", session_id="ws-b")) == 1
+
+    entry = queue.drain_entries()[0]
+    await poller._execute(  # noqa: SLF001
+        entry.command,
+        command_id=entry.command_id,
+        source=entry.source or "websocket",
+        session_id=entry.session_id,
+        command_service=entry.command_service,
+    )
+
+    assert service.pending_overlays(source="websocket", session_id="ws-a") == ()
+    assert len(service.pending_overlays(source="websocket", session_id="ws-b")) == 1
+    assert service.pending_overlays(source="websocket", session_id="ws-b")[0].value == 14_074_000
 
 
 @pytest.mark.asyncio

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -99,6 +99,24 @@ class _QueuedAckExecutor:
         return CommandExecutionResult(details={"queued": True})
 
 
+class _InjectedAcquisitionExecutor:
+    def __init__(self) -> None:
+        self.calls: list[tuple[object, frozenset[FieldPath]]] = []
+
+    async def execute(
+        self,
+        request: object,
+        *,
+        already_sent_paths: frozenset[FieldPath],
+    ) -> object:
+        self.calls.append((request, already_sent_paths))
+        return SimpleNamespace(
+            sent_paths=tuple(getattr(request, "paths")),
+            failed_paths=(),
+            failure_reason="",
+        )
+
+
 def _make_radio(active: str = "MAIN") -> MagicMock:
     profile = resolve_radio_profile(model="IC-7610")
     radio = MagicMock()
@@ -277,6 +295,91 @@ async def test_scheduler_due_request_sends_supported_civ_query_once() -> None:
     assert scheduler.pending_requests()[0].paths == (path,)
 
 
+@pytest.mark.asyncio
+async def test_scheduler_due_request_timeout_is_terminal_not_resent_each_tick() -> None:
+    radio = _make_radio(active="MAIN")
+    path = FieldPath.receiver("main", "meters", "s_meter")
+    policy = AcquisitionPolicy(cadence_seconds=1.0, freshness_ttl_seconds=1.0)
+    scheduler = AcquisitionScheduler(profile=_acquisition_profile(path, policy=policy))
+    radio._acquisition_scheduler = scheduler
+    poller = RadioPoller(radio, CommandQueue(), radio_state=RadioState())
+
+    with patch(
+        "rigplane.web.radio_poller.time.monotonic",
+        side_effect=(100.0, 101.1, 101.2),
+    ):
+        await poller._send_query()  # noqa: SLF001
+        await poller._send_query()  # noqa: SLF001
+        await poller._send_query()  # noqa: SLF001
+
+    radio.send_civ.assert_awaited_once()
+    assert scheduler.pending_requests() == ()
+    diagnostics = scheduler.diagnostics()
+    assert diagnostics["failedRequestCount"] == 1
+    assert diagnostics["failureCountByReason"]["acquisition_request_timeout"] == 1
+
+
+@pytest.mark.asyncio
+async def test_scheduler_request_execution_uses_injected_executor_not_web_mapping() -> None:
+    radio = _make_radio(active="MAIN")
+    path = FieldPath.global_("slow_state", "value")
+    scheduler = AcquisitionScheduler(profile=_acquisition_profile(path))
+    radio._acquisition_scheduler = scheduler
+    executor = _InjectedAcquisitionExecutor()
+    poller = RadioPoller(
+        radio,
+        CommandQueue(),
+        radio_state=RadioState(),
+        acquisition_executor=executor,
+    )
+
+    await poller._send_query()  # noqa: SLF001
+
+    radio.send_civ.assert_not_awaited()
+    assert len(executor.calls) == 1
+    request, already_sent_paths = executor.calls[0]
+    assert getattr(request, "paths") == (path,)
+    assert already_sent_paths == frozenset()
+    assert scheduler.pending_requests()[0].paths == (path,)
+
+
+@pytest.mark.asyncio
+async def test_non_icom_scheduler_without_executor_fails_instead_of_web_civ_send() -> None:
+    radio = _make_radio(active="MAIN")
+    path = FieldPath.receiver("main", "meters", "s_meter")
+    scheduler = AcquisitionScheduler(
+        profile=RadioAcquisitionProfile(
+            provider="test_provider",
+            capabilities=(FieldCapability(path=path, polling=True),),
+            default_policy=AcquisitionPolicy(
+                cadence_seconds=1.0,
+                freshness_ttl_seconds=4.0,
+            ),
+        )
+    )
+    radio._acquisition_scheduler = scheduler
+    diagnostics = []
+    poller = RadioPoller(
+        radio,
+        CommandQueue(),
+        radio_state=RadioState(),
+        diagnostics=SimpleNamespace(record=lambda *args, **kwargs: diagnostics.append((args, kwargs))),  # type: ignore[arg-type]
+    )
+
+    await poller._send_query()  # noqa: SLF001
+
+    radio.send_civ.assert_not_awaited()
+    assert scheduler.pending_requests() == ()
+    assert scheduler.diagnostics()["failureCountByReason"][
+        "acquisition_executor_missing"
+    ] == 1
+    assert any(
+        args[:2] == ("acquisition_executor_missing", "web.radio_poller")
+        and kwargs["provider"] == "test_provider"
+        for args, kwargs in diagnostics
+    )
+
+
 @pytest.mark.parametrize(  # type: ignore[untyped-decorator]
     ("path", "expected_cmd", "expected_receiver"),
     [
@@ -310,7 +413,7 @@ async def test_scheduler_active_freq_mode_requests_use_receiver_payload(
 
 
 @pytest.mark.asyncio
-async def test_scheduler_unknown_query_mapping_is_recorded_and_left_pending() -> None:
+async def test_scheduler_unknown_query_mapping_is_recorded_and_failed() -> None:
     radio = _make_radio(active="MAIN")
     path = FieldPath.global_("slow_state", "overflow")
     scheduler = AcquisitionScheduler(profile=_acquisition_profile(path))
@@ -327,11 +430,14 @@ async def test_scheduler_unknown_query_mapping_is_recorded_and_left_pending() ->
     await poller._send_query()  # noqa: SLF001
 
     radio.send_civ.assert_not_awaited()
-    assert len(scheduler.pending_requests()) == 1
-    assert scheduler.pending_requests()[0].paths == (path,)
+    assert scheduler.pending_requests() == ()
+    assert scheduler.diagnostics()["failureCountByReason"][
+        "no_civ_query_mapping"
+    ] == 1
     assert any(
-        args[:2] == ("acquisition_skip", "web.radio_poller")
-        and kwargs["path"] == str(path)
+        args[:2] == ("acquisition_request_failed", "web.radio_poller")
+        and kwargs["request_id"] == "acq-1"
+        and kwargs["reason"] == "no_civ_query_mapping"
         for args, kwargs in diagnostics
     )
 
@@ -404,6 +510,30 @@ async def test_scheduler_polling_does_not_starve_user_command_queue() -> None:
 
     assert order[:2] == ["cmd", "poll"]
     assert radio.send_civ.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_run_does_not_raw_poll_unselected_slot_when_scheduler_attached() -> None:
+    radio = _make_radio(active="MAIN")
+    path = FieldPath.receiver("main", "meters", "s_meter")
+    radio._acquisition_scheduler = AcquisitionScheduler(
+        profile=_acquisition_profile(path)
+    )
+    queue = CommandQueue()
+    poller = RadioPoller(radio, queue, radio_state=RadioState())
+    poller._send_query = AsyncMock(return_value=None)  # noqa: SLF001
+    poller._poll_unselected_slot = AsyncMock(return_value=None)  # noqa: SLF001
+    poller._unselected_slot_gate = MagicMock(return_value=True)  # noqa: SLF001
+
+    async def _stop_after_first_wait(*args: object, **kwargs: object) -> None:
+        raise asyncio.CancelledError
+
+    queue.wait = _stop_after_first_wait  # type: ignore[method-assign]
+
+    await poller._run()  # noqa: SLF001
+
+    poller._unselected_slot_gate.assert_not_called()  # type: ignore[attr-defined]
+    poller._poll_unselected_slot.assert_not_awaited()  # type: ignore[attr-defined]
 
 
 @pytest.mark.asyncio

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -238,13 +238,14 @@ def _make_radio(active: str = "MAIN") -> MagicMock:
 def _acquisition_profile(
     *paths: FieldPath,
     policy: AcquisitionPolicy | None = None,
+    provider: str = "icom_civ",
 ) -> RadioAcquisitionProfile:
     acquisition_policy = policy or AcquisitionPolicy(
         cadence_seconds=1.0,
         freshness_ttl_seconds=4.0,
     )
     return RadioAcquisitionProfile(
-        provider="icom_civ",
+        provider=provider,
         capabilities=tuple(
             FieldCapability(path=path, polling=True) for path in paths
         ),
@@ -293,6 +294,68 @@ async def test_scheduler_due_request_sends_supported_civ_query_once() -> None:
         wait_response=False,
     )
     assert scheduler.pending_requests()[0].paths == (path,)
+
+
+@pytest.mark.asyncio
+async def test_x6200_scheduler_due_request_sends_civ_query_from_profile() -> None:
+    radio = _make_radio(active="MAIN")
+    profile = resolve_radio_profile(model="X6200")
+    assert profile.state_acquisition is not None
+    radio.profile = profile
+    radio.model = profile.model
+    radio.capabilities = set(profile.capabilities)
+    scheduler = AcquisitionScheduler(profile=profile.state_acquisition)
+    radio._acquisition_scheduler = scheduler
+    poller = RadioPoller(radio, CommandQueue(), radio_state=RadioState())
+
+    await poller._send_query()  # noqa: SLF001
+
+    assert radio.send_civ.await_count == 4
+    radio.send_civ.assert_any_await(
+        0x25,
+        sub=None,
+        data=b"\x00",
+        wait_response=False,
+    )
+    radio.send_civ.assert_any_await(
+        0x26,
+        sub=None,
+        data=b"\x00",
+        wait_response=False,
+    )
+    radio.send_civ.assert_any_await(
+        0x29,
+        sub=None,
+        data=b"\x00\x15\x02",
+        wait_response=False,
+    )
+    radio.send_civ.assert_any_await(
+        0x15,
+        sub=0x11,
+        data=b"",
+        wait_response=False,
+    )
+    assert scheduler.pending_requests()
+
+
+@pytest.mark.asyncio
+async def test_xiegu_civ_scheduler_due_request_uses_civ_executor() -> None:
+    radio = _make_radio(active="MAIN")
+    path = FieldPath.active("main", "freq_mode", "mode")
+    scheduler = AcquisitionScheduler(
+        profile=_acquisition_profile(path, provider="xiegu_civ")
+    )
+    radio._acquisition_scheduler = scheduler
+    poller = RadioPoller(radio, CommandQueue(), radio_state=RadioState())
+
+    await poller._send_query()  # noqa: SLF001
+
+    radio.send_civ.assert_awaited_once_with(
+        0x26,
+        sub=None,
+        data=b"\x00",
+        wait_response=False,
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from rigplane.core.state_store import StateStore
 from rigplane.exceptions import CommandError
 from rigplane.profiles import resolve_radio_profile
 from rigplane.radio_state import RadioState
@@ -875,6 +876,27 @@ async def test_command_error_propagates_from_execute() -> None:
     radio.set_freq.reset_mock()
     await poller._execute(SetFreq(freq=7_074_000, receiver=0))  # noqa: SLF001
     radio.set_freq.assert_awaited_once_with(7_074_000)
+
+
+@pytest.mark.asyncio
+async def test_set_freq_readback_is_applied_as_state_store_observation() -> None:
+    radio = _make_radio()
+    state = RadioState()
+    store = StateStore()
+    poller = RadioPoller(
+        radio,
+        StateCache(),
+        CommandQueue(),
+        radio_state=state,
+        state_store=store,
+    )
+
+    await poller._execute(SetFreq(freq=14_074_000, receiver=0))  # noqa: SLF001
+
+    field = store.snapshot().field("receiver.0.freq_mode.freq_hz")
+    assert field.value == 14_074_000
+    assert field.source.source == "command_response"
+    assert state.main.freq == 14_074_000
 
 
 @pytest.mark.asyncio

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -1377,6 +1377,63 @@ async def test_mark_queued_command_failed_scopes_reused_command_ids_by_source() 
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("timed_out", "expected_state"),
+    [(False, "failed"), (True, "timed_out")],
+)
+async def test_mark_queued_command_failed_scopes_reused_command_ids_by_session(
+    timed_out: bool,
+    expected_state: str,
+) -> None:
+    radio = _make_radio()
+    store = StateStore()
+    queue = CommandQueue()
+    executor = _QueuedAckExecutor(queue)
+    service = CommandService(executor=executor, state_store=store)
+    executor.command_service = service
+    poller = RadioPoller(
+        radio,
+        StateCache(),
+        queue,
+        radio_state=RadioState(),
+        state_store=store,
+    )
+
+    for session_id in ("ws-a", "ws-b"):
+        await service.execute(
+            command_intent_from_request(
+                "set_freq",
+                {"freq": 14_074_000, "receiver": 0},
+                source="websocket",
+                command_id="shared-id",
+                session_id=session_id,
+            )
+        )
+
+    entries = queue.drain_entries()
+    poller._mark_queued_command_failed(  # noqa: SLF001
+        entries[0],
+        TimeoutError("command timed out")
+        if timed_out
+        else RuntimeError("radio rejected command"),
+        timed_out=timed_out,
+    )
+
+    assert service.pending_overlays(source="websocket", session_id="ws-a") == ()
+    assert len(service.pending_overlays(source="websocket", session_id="ws-b")) == 1
+    assert service.pending_overlays(source="websocket", session_id="ws-b")[0].value == 14_074_000
+
+    terminal_events = [
+        event
+        for event in service.lifecycle_events()
+        if event.command_id == "shared-id" and event.state == expected_state
+    ]
+    assert len(terminal_events) == 1
+    assert terminal_events[0].source == "websocket"
+    assert terminal_events[0].details["session_id"] == "ws-a"
+
+
+@pytest.mark.asyncio
 async def test_select_vfo_readback_uses_original_command_correlation() -> None:
     radio = _make_radio()
     state = RadioState()

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -14,6 +14,7 @@ from rigplane.core.command_service import (
     CommandService,
     command_intent_from_request,
 )
+from rigplane.core.exceptions import TimeoutError as RigplaneTimeoutError
 from rigplane.core.state_pipeline_contracts import CommandIntent
 from rigplane.exceptions import CommandError
 from rigplane.profiles import resolve_radio_profile
@@ -1027,6 +1028,22 @@ async def test_observable_queue_commands_apply_state_store_observations(
             ("nr", False),
         ),
         (
+            "set_att",
+            {"db": 12, "receiver": 1},
+            SetAttenuator(12, receiver=1),
+            "receiver.1.operator_controls.att",
+            12,
+            ("att", 12),
+        ),
+        (
+            "set_preamp",
+            {"level": 2, "receiver": 1},
+            SetPreamp(2, receiver=1),
+            "receiver.1.operator_controls.preamp",
+            2,
+            ("preamp", 2),
+        ),
+        (
             "set_pbt_inner",
             {"level": 140, "receiver": 1},
             SetPbtInner(140, receiver=1),
@@ -1209,6 +1226,98 @@ async def test_queued_command_failure_emits_failed_lifecycle_and_expires_overlay
         "failed",
     ]
     assert service.pending_overlays(source="websocket", session_id=None) == ()
+
+
+@pytest.mark.asyncio
+async def test_queued_core_timeout_emits_timed_out_lifecycle_and_expires_overlay() -> (
+    None
+):
+    radio = _make_radio()
+    radio.set_freq.side_effect = RigplaneTimeoutError("backend timed out")
+    state = RadioState()
+    store = StateStore()
+    queue = CommandQueue()
+    executor = _QueuedAckExecutor(queue)
+    service = CommandService(executor=executor, state_store=store)
+    executor.command_service = service
+    poller = RadioPoller(
+        radio,
+        StateCache(),
+        queue,
+        radio_state=state,
+        state_store=store,
+    )
+
+    await service.execute(
+        command_intent_from_request(
+            "set_freq",
+            {"freq": 14_074_000, "receiver": 0},
+            source="websocket",
+            command_id="ws-timeout",
+        )
+    )
+    assert service.pending_overlays(source="websocket", session_id=None) != ()
+
+    poller._send_query = AsyncMock(return_value=None)  # noqa: SLF001
+    poller._queue.wait = AsyncMock(side_effect=asyncio.CancelledError())  # noqa: SLF001
+    with patch("rigplane.web.radio_poller.asyncio.sleep", new=AsyncMock()):
+        await poller._run()  # noqa: SLF001
+
+    events = [
+        event for event in service.lifecycle_events() if event.command_id == "ws-timeout"
+    ]
+    assert [event.state for event in events] == [
+        "accepted",
+        "queued",
+        "sent",
+        "acknowledged",
+        "timed_out",
+    ]
+    assert service.pending_overlays(source="websocket", session_id=None) == ()
+
+
+@pytest.mark.asyncio
+async def test_mark_queued_command_failed_scopes_reused_command_ids_by_source() -> None:
+    radio = _make_radio()
+    store = StateStore()
+    queue = CommandQueue()
+    executor = _QueuedAckExecutor(queue)
+    service = CommandService(executor=executor, state_store=store)
+    executor.command_service = service
+    poller = RadioPoller(
+        radio,
+        StateCache(),
+        queue,
+        radio_state=RadioState(),
+        state_store=store,
+    )
+
+    await service.execute(
+        command_intent_from_request(
+            "set_freq",
+            {"freq": 14_074_000, "receiver": 0},
+            source="websocket",
+            command_id="shared-id",
+        )
+    )
+    await service.execute(
+        command_intent_from_request(
+            "set_freq",
+            {"freq": 7_074_000, "receiver": 0},
+            source="http",
+            command_id="shared-id",
+        )
+    )
+
+    entries = queue.drain_entries()
+    poller._mark_queued_command_failed(  # noqa: SLF001
+        entries[0],
+        RuntimeError("radio rejected command"),
+    )
+
+    assert service.pending_overlays(source="websocket", session_id=None) == ()
+    assert len(service.pending_overlays(source="http", session_id=None)) == 1
+    assert service.pending_overlays(source="http", session_id=None)[0].value == 7_074_000
 
 
 @pytest.mark.asyncio

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -14,6 +14,7 @@ from rigplane.core.command_service import (
     CommandService,
     command_intent_from_request,
 )
+from rigplane.core.state_pipeline_contracts import CommandIntent
 from rigplane.exceptions import CommandError
 from rigplane.profiles import resolve_radio_profile
 from rigplane.radio_state import RadioState
@@ -61,6 +62,27 @@ class _NoopCommandExecutor:
     async def execute(self, intent: object) -> CommandExecutionResult:
         del intent
         return CommandExecutionResult()
+
+
+class _QueuedAckExecutor:
+    def __init__(self, queue: CommandQueue) -> None:
+        self.queue = queue
+        self.command_service: CommandService | None = None
+
+    async def execute(self, intent: CommandIntent) -> CommandExecutionResult:
+        assert self.command_service is not None
+        if intent.name != "set_freq":
+            raise AssertionError(f"unexpected intent {intent.name!r}")
+        self.queue.put_ordered(
+            SetFreq(
+                int(intent.params["freq_hz"]),
+                receiver=int(intent.params.get("receiver", 0)),
+            ),
+            command_id=intent.id,
+            source=intent.source,
+            command_service=self.command_service,
+        )
+        return CommandExecutionResult(details={"queued": True})
 
 
 def _make_radio(active: str = "MAIN") -> MagicMock:
@@ -977,6 +999,94 @@ async def test_observable_queue_commands_apply_state_store_observations(
     assert field.source.source == "command_response"
 
 
+@pytest.mark.parametrize(  # type: ignore[untyped-decorator]
+    ("name", "params", "command", "expected_path", "expected_value", "expected_mirror"),
+    [
+        (
+            "set_filter_width",
+            {"width": 1500, "receiver": 1},
+            SetFilterWidth(1500, receiver=1),
+            "receiver.1.freq_mode.filter_width",
+            1500,
+            ("filter_width", 1500),
+        ),
+        (
+            "set_nb",
+            {"on": True, "receiver": 1},
+            SetNB(True, receiver=1),
+            "receiver.1.operator_toggles.nb",
+            True,
+            ("nb", True),
+        ),
+        (
+            "set_nr",
+            {"on": False, "receiver": 1},
+            SetNR(False, receiver=1),
+            "receiver.1.operator_toggles.nr",
+            False,
+            ("nr", False),
+        ),
+        (
+            "set_pbt_inner",
+            {"level": 140, "receiver": 1},
+            SetPbtInner(140, receiver=1),
+            "receiver.1.operator_controls.pbt_inner",
+            140,
+            ("pbt_inner", 140),
+        ),
+        (
+            "set_pbt_outer",
+            {"level": 116, "receiver": 1},
+            SetPbtOuter(116, receiver=1),
+            "receiver.1.operator_controls.pbt_outer",
+            116,
+            ("pbt_outer", 116),
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_compatibility_mirror_commands_reconcile_from_state_store_observation(
+    name: str,
+    params: dict[str, object],
+    command: object,
+    expected_path: str,
+    expected_value: object,
+    expected_mirror: tuple[str, object],
+) -> None:
+    radio = _make_radio()
+    state = RadioState()
+    store = StateStore()
+    service = CommandService(executor=_NoopCommandExecutor(), state_store=store)
+    poller = RadioPoller(
+        radio,
+        StateCache(),
+        CommandQueue(),
+        radio_state=state,
+        state_store=store,
+    )
+    await service.execute(
+        command_intent_from_request(
+            name,
+            params,
+            source="websocket",
+            command_id="ws-compat",
+        )
+    )
+    assert service.pending_overlays(source="websocket", session_id=None) != ()
+
+    await poller._execute(  # noqa: SLF001[arg-type]
+        command,
+        command_id="ws-compat",
+        source="websocket",
+        command_service=service,
+    )
+
+    field = store.snapshot().field(expected_path)
+    assert field.value == expected_value
+    assert service.pending_overlays(source="websocket", session_id=None) == ()
+    assert getattr(state.sub, expected_mirror[0]) == expected_mirror[1]
+
+
 @pytest.mark.asyncio
 async def test_set_freq_readback_uses_original_command_correlation() -> None:
     radio = _make_radio()
@@ -1050,6 +1160,54 @@ async def test_set_split_readback_uses_original_command_correlation() -> None:
 
     field = store.snapshot().field("global.tx_state.split")
     assert field.value is True
+    assert service.pending_overlays(source="websocket", session_id=None) == ()
+
+
+@pytest.mark.asyncio
+async def test_queued_command_failure_emits_failed_lifecycle_and_expires_overlay() -> (
+    None
+):
+    radio = _make_radio()
+    radio.set_freq.side_effect = ConnectionError("down")
+    state = RadioState()
+    store = StateStore()
+    queue = CommandQueue()
+    executor = _QueuedAckExecutor(queue)
+    service = CommandService(executor=executor, state_store=store)
+    executor.command_service = service
+    poller = RadioPoller(
+        radio,
+        StateCache(),
+        queue,
+        radio_state=state,
+        state_store=store,
+    )
+
+    await service.execute(
+        command_intent_from_request(
+            "set_freq",
+            {"freq": 14_074_000, "receiver": 0},
+            source="websocket",
+            command_id="ws-fail",
+        )
+    )
+    assert service.pending_overlays(source="websocket", session_id=None) != ()
+
+    poller._send_query = AsyncMock(return_value=None)  # noqa: SLF001
+    poller._queue.wait = AsyncMock(side_effect=asyncio.CancelledError())  # noqa: SLF001
+    with patch("rigplane.web.radio_poller.asyncio.sleep", new=AsyncMock()):
+        await poller._run()  # noqa: SLF001
+
+    events = [
+        event for event in service.lifecycle_events() if event.command_id == "ws-fail"
+    ]
+    assert [event.state for event in events] == [
+        "accepted",
+        "queued",
+        "sent",
+        "acknowledged",
+        "failed",
+    ]
     assert service.pending_overlays(source="websocket", session_id=None) == ()
 
 

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -277,6 +277,38 @@ async def test_scheduler_due_request_sends_supported_civ_query_once() -> None:
     assert scheduler.pending_requests()[0].paths == (path,)
 
 
+@pytest.mark.parametrize(  # type: ignore[untyped-decorator]
+    ("path", "expected_cmd", "expected_receiver"),
+    [
+        (FieldPath.active("main", "freq_mode", "freq_hz"), 0x25, 0),
+        (FieldPath.active("main", "freq_mode", "mode"), 0x26, 0),
+        (FieldPath.active("sub", "freq_mode", "freq_hz"), 0x25, 1),
+        (FieldPath.active("sub", "freq_mode", "mode"), 0x26, 1),
+    ],
+)
+@pytest.mark.asyncio
+async def test_scheduler_active_freq_mode_requests_use_receiver_payload(
+    path: FieldPath,
+    expected_cmd: int,
+    expected_receiver: int,
+) -> None:
+    radio = _make_radio(active="MAIN")
+    scheduler = AcquisitionScheduler(profile=_acquisition_profile(path))
+    radio._acquisition_scheduler = scheduler
+    poller = RadioPoller(radio, CommandQueue(), radio_state=RadioState())
+
+    await poller._send_query()  # noqa: SLF001
+    await poller._send_query()  # noqa: SLF001
+
+    radio.send_civ.assert_awaited_once_with(
+        expected_cmd,
+        sub=None,
+        data=bytes([expected_receiver]),
+        wait_response=False,
+    )
+    assert scheduler.pending_requests()[0].paths == (path,)
+
+
 @pytest.mark.asyncio
 async def test_scheduler_unknown_query_mapping_is_recorded_and_left_pending() -> None:
     radio = _make_radio(active="MAIN")

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -278,7 +278,7 @@ async def test_scheduler_due_request_sends_supported_civ_query_once() -> None:
 
 
 @pytest.mark.asyncio
-async def test_scheduler_unknown_query_mapping_is_recorded_and_completed() -> None:
+async def test_scheduler_unknown_query_mapping_is_recorded_and_left_pending() -> None:
     radio = _make_radio(active="MAIN")
     path = FieldPath.global_("slow_state", "overflow")
     scheduler = AcquisitionScheduler(profile=_acquisition_profile(path))
@@ -295,12 +295,32 @@ async def test_scheduler_unknown_query_mapping_is_recorded_and_completed() -> No
     await poller._send_query()  # noqa: SLF001
 
     radio.send_civ.assert_not_awaited()
-    assert scheduler.pending_requests() == ()
+    assert len(scheduler.pending_requests()) == 1
+    assert scheduler.pending_requests()[0].paths == (path,)
     assert any(
         args[:2] == ("acquisition_skip", "web.radio_poller")
         and kwargs["path"] == str(path)
         for args, kwargs in diagnostics
     )
+
+
+@pytest.mark.asyncio
+async def test_scheduler_ptt_request_sends_civ_ptt_query() -> None:
+    radio = _make_radio(active="MAIN")
+    path = FieldPath.global_("tx_state", "ptt")
+    scheduler = AcquisitionScheduler(profile=_acquisition_profile(path))
+    radio._acquisition_scheduler = scheduler
+    poller = RadioPoller(radio, CommandQueue(), radio_state=RadioState())
+
+    await poller._send_query()  # noqa: SLF001
+
+    radio.send_civ.assert_awaited_once_with(
+        0x1C,
+        sub=0x00,
+        data=b"",
+        wait_response=False,
+    )
+    assert scheduler.pending_requests()[0].paths == (path,)
 
 
 @pytest.mark.asyncio

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -246,9 +246,7 @@ def _acquisition_profile(
     )
     return RadioAcquisitionProfile(
         provider=provider,
-        capabilities=tuple(
-            FieldCapability(path=path, polling=True) for path in paths
-        ),
+        capabilities=tuple(FieldCapability(path=path, polling=True) for path in paths),
         default_policy=acquisition_policy,
     )
 
@@ -383,7 +381,9 @@ async def test_scheduler_due_request_timeout_is_terminal_not_resent_each_tick() 
 
 
 @pytest.mark.asyncio
-async def test_scheduler_request_execution_uses_injected_executor_not_web_mapping() -> None:
+async def test_scheduler_request_execution_uses_injected_executor_not_web_mapping() -> (
+    None
+):
     radio = _make_radio(active="MAIN")
     path = FieldPath.global_("slow_state", "value")
     scheduler = AcquisitionScheduler(profile=_acquisition_profile(path))
@@ -407,7 +407,9 @@ async def test_scheduler_request_execution_uses_injected_executor_not_web_mappin
 
 
 @pytest.mark.asyncio
-async def test_non_icom_scheduler_without_executor_fails_instead_of_web_civ_send() -> None:
+async def test_non_icom_scheduler_without_executor_fails_instead_of_web_civ_send() -> (
+    None
+):
     radio = _make_radio(active="MAIN")
     path = FieldPath.receiver("main", "meters", "s_meter")
     scheduler = AcquisitionScheduler(
@@ -426,16 +428,19 @@ async def test_non_icom_scheduler_without_executor_fails_instead_of_web_civ_send
         radio,
         CommandQueue(),
         radio_state=RadioState(),
-        diagnostics=SimpleNamespace(record=lambda *args, **kwargs: diagnostics.append((args, kwargs))),  # type: ignore[arg-type]
+        diagnostics=SimpleNamespace(
+            record=lambda *args, **kwargs: diagnostics.append((args, kwargs))
+        ),  # type: ignore[arg-type]
     )
 
     await poller._send_query()  # noqa: SLF001
 
     radio.send_civ.assert_not_awaited()
     assert scheduler.pending_requests() == ()
-    assert scheduler.diagnostics()["failureCountByReason"][
-        "acquisition_executor_missing"
-    ] == 1
+    assert (
+        scheduler.diagnostics()["failureCountByReason"]["acquisition_executor_missing"]
+        == 1
+    )
     assert any(
         args[:2] == ("acquisition_executor_missing", "web.radio_poller")
         and kwargs["provider"] == "test_provider"
@@ -486,7 +491,9 @@ async def test_scheduler_unknown_query_mapping_is_recorded_and_failed() -> None:
         radio,
         CommandQueue(),
         radio_state=RadioState(),
-        diagnostics=SimpleNamespace(record=lambda *args, **kwargs: diagnostics.append((args, kwargs))),  # type: ignore[arg-type]
+        diagnostics=SimpleNamespace(
+            record=lambda *args, **kwargs: diagnostics.append((args, kwargs))
+        ),  # type: ignore[arg-type]
     )
 
     await poller._send_query()  # noqa: SLF001
@@ -494,9 +501,7 @@ async def test_scheduler_unknown_query_mapping_is_recorded_and_failed() -> None:
 
     radio.send_civ.assert_not_awaited()
     assert scheduler.pending_requests() == ()
-    assert scheduler.diagnostics()["failureCountByReason"][
-        "no_civ_query_mapping"
-    ] == 1
+    assert scheduler.diagnostics()["failureCountByReason"]["no_civ_query_mapping"] == 1
     assert any(
         args[:2] == ("acquisition_request_failed", "web.radio_poller")
         and kwargs["request_id"] == "acq-1"
@@ -1564,7 +1569,10 @@ async def test_set_freq_readback_reconciles_only_matching_websocket_session_for_
 
     assert service.pending_overlays(source="websocket", session_id="ws-a") == ()
     assert len(service.pending_overlays(source="websocket", session_id="ws-b")) == 1
-    assert service.pending_overlays(source="websocket", session_id="ws-b")[0].value == 14_074_000
+    assert (
+        service.pending_overlays(source="websocket", session_id="ws-b")[0].value
+        == 14_074_000
+    )
 
 
 @pytest.mark.asyncio
@@ -1689,7 +1697,9 @@ async def test_queued_core_timeout_emits_timed_out_lifecycle_and_expires_overlay
         await poller._run()  # noqa: SLF001
 
     events = [
-        event for event in service.lifecycle_events() if event.command_id == "ws-timeout"
+        event
+        for event in service.lifecycle_events()
+        if event.command_id == "ws-timeout"
     ]
     assert [event.state for event in events] == [
         "accepted",
@@ -1742,7 +1752,9 @@ async def test_mark_queued_command_failed_scopes_reused_command_ids_by_source() 
 
     assert service.pending_overlays(source="websocket", session_id=None) == ()
     assert len(service.pending_overlays(source="http", session_id=None)) == 1
-    assert service.pending_overlays(source="http", session_id=None)[0].value == 7_074_000
+    assert (
+        service.pending_overlays(source="http", session_id=None)[0].value == 7_074_000
+    )
 
 
 @pytest.mark.asyncio
@@ -1790,7 +1802,10 @@ async def test_mark_queued_command_failed_scopes_reused_command_ids_by_session(
 
     assert service.pending_overlays(source="websocket", session_id="ws-a") == ()
     assert len(service.pending_overlays(source="websocket", session_id="ws-b")) == 1
-    assert service.pending_overlays(source="websocket", session_id="ws-b")[0].value == 14_074_000
+    assert (
+        service.pending_overlays(source="websocket", session_id="ws-b")[0].value
+        == 14_074_000
+    )
 
     terminal_events = [
         event

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -86,6 +86,22 @@ class TestLoadRig:
         rig = load_rig(p)
         assert rig.model == "IC-7300"
 
+    def test_state_acquisition_provider_must_be_string(self, tmp_path):
+        p = _write_toml(
+            tmp_path,
+            _MINIMAL_TOML
+            + """
+
+[state_acquisition]
+provider = 123
+""",
+        )
+        with pytest.raises(
+            RigLoadError,
+            match=r"\[state_acquisition\].*provider must be a string",
+        ):
+            load_rig(p)
+
     def test_missing_radio_section(self, tmp_path):
         p = _write_toml(
             tmp_path,

--- a/tests/test_rigctld_client_observation_adapter.py
+++ b/tests/test_rigctld_client_observation_adapter.py
@@ -1,0 +1,115 @@
+"""Observation adapter coverage for the external rigctld client backend."""
+# mypy: disable-error-code=untyped-decorator
+
+from __future__ import annotations
+
+import pytest
+
+from fake_rigctld import FakeRigctldServer
+from rigplane.backends.rigctld_client import RigctldClientRadio
+from rigplane.backends.rigctld_client.observations import (
+    RigctldClientObservationAdapter,
+    build_external_rigctld_acquisition_profile,
+)
+from rigplane.core.acquisition_scheduler import AcquisitionScheduler, AcquisitionStatus
+from rigplane.core.command_service import command_intent_from_request
+from rigplane.core.state_pipeline_contracts import FieldPath
+
+
+def _clock() -> float:
+    return 50.0
+
+
+@pytest.mark.asyncio
+async def test_get_reads_emit_hamlib_observations() -> None:
+    async with FakeRigctldServer() as server:
+        radio = RigctldClientRadio(host=server.host, port=server.port)
+        await radio.connect()
+        try:
+            adapter = RigctldClientObservationAdapter(radio, clock=_clock)
+
+            observations = await adapter.read_freq_mode_controls()
+
+            assert [(str(item.path), item.value) for item in observations] == [
+                ("receiver.main.active.freq_mode.freq_hz", 14_074_000),
+                ("receiver.main.active.freq_mode.mode", "USB"),
+                ("receiver.main.active.freq_mode.filter_width", 2400),
+                ("receiver.main.operator_controls.rf_gain", 128),
+                ("receiver.main.operator_controls.af_level", 76),
+            ]
+            assert all(item.source.source == "hamlib_response" for item in observations)
+            assert all(
+                item.source.provider == "external_rigctld" for item in observations
+            )
+            assert all(item.source.transport == "rigctld" for item in observations)
+            assert all(item.timestamp_monotonic == 50.0 for item in observations)
+            assert observations[0].max_age == 8.0
+            assert observations[-1].max_age == 120.0
+        finally:
+            await radio.disconnect()
+
+
+def test_command_response_observations_use_external_rigctld_provider() -> None:
+    adapter = RigctldClientObservationAdapter(None, clock=_clock)
+    intent = command_intent_from_request(
+        "set_freq",
+        {"freq": 7_050_000},
+        source="rigctld",
+        command_id="rig-set-1",
+        session_id="client-1",
+    )
+
+    observation = adapter.command_response(intent)
+
+    assert str(observation.path) == "receiver.main.active.freq_mode.freq_hz"
+    assert observation.value == 7_050_000
+    assert observation.source.source == "command_response"
+    assert observation.source.provider == "external_rigctld"
+    assert observation.source.transport == "rigctld"
+    assert observation.source.command_source == "rigctld"
+    assert observation.source.session_id == "client-1"
+    assert observation.correlation_id == "rig-set-1"
+
+
+def test_capability_gaps_are_explicit_for_external_rigctld_profile() -> None:
+    profile = build_external_rigctld_acquisition_profile(vfo_supported=False)
+    power = FieldPath.global_("tx_state", "power_on")
+    active_slot = FieldPath.active_slot("main")
+    scheduler = AcquisitionScheduler(profile=profile)
+
+    power_result = scheduler.ensure_fresh(
+        power,
+        max_age=1.0,
+        priority="user",
+        reason="startup",
+    )
+    vfo_result = scheduler.ensure_fresh(
+        active_slot,
+        max_age=1.0,
+        priority="user",
+        reason="vfo-get",
+    )
+
+    assert power_result.status is AcquisitionStatus.UNAVAILABLE
+    assert "power state" in power_result.message
+    assert vfo_result.status is AcquisitionStatus.UNAVAILABLE
+    assert "VFO slot" in vfo_result.message
+
+
+@pytest.mark.asyncio
+async def test_vfo_observation_available_when_rigctld_supports_it() -> None:
+    async with FakeRigctldServer() as server:
+        radio = RigctldClientRadio(host=server.host, port=server.port)
+        await radio.connect()
+        try:
+            adapter = RigctldClientObservationAdapter(radio, clock=_clock)
+
+            observation = await adapter.read_active_vfo()
+
+            assert observation is not None
+            assert str(observation.path) == "receiver.main.vfo.active_slot"
+            assert observation.value == "A"
+            assert observation.source.source == "hamlib_response"
+            assert observation.max_age == 8.0
+        finally:
+            await radio.disconnect()

--- a/tests/test_rigctld_client_observation_adapter.py
+++ b/tests/test_rigctld_client_observation_adapter.py
@@ -71,6 +71,22 @@ def test_command_response_observations_use_external_rigctld_provider() -> None:
     assert observation.correlation_id == "rig-set-1"
 
 
+def test_command_response_normalizes_receiver_zero_control_paths() -> None:
+    adapter = RigctldClientObservationAdapter(None, clock=_clock)
+    intent = command_intent_from_request(
+        "set_preamp",
+        {"level": 2, "receiver": 0},
+        source="rigctld",
+        command_id="rig-preamp-1",
+    )
+
+    observation = adapter.command_response(intent)
+
+    assert str(observation.path) == "receiver.main.operator_controls.preamp"
+    assert observation.value == 2
+    assert observation.max_age == 120.0
+
+
 def test_capability_gaps_are_explicit_for_external_rigctld_profile() -> None:
     profile = build_external_rigctld_acquisition_profile(vfo_supported=False)
     power = FieldPath.global_("tx_state", "power_on")
@@ -96,6 +112,17 @@ def test_capability_gaps_are_explicit_for_external_rigctld_profile() -> None:
     assert "VFO slot" in vfo_result.message
 
 
+def test_filter_width_command_response_metadata_matches_adapter_behavior() -> None:
+    profile = build_external_rigctld_acquisition_profile(vfo_supported=True)
+    capability = profile.capability_for(
+        FieldPath.active("main", "freq_mode", "filter_width")
+    )
+
+    assert capability.can_poll is True
+    assert capability.command_response_observable is False
+    assert "poll" in capability.diagnostic.lower()
+
+
 @pytest.mark.asyncio
 async def test_vfo_observation_available_when_rigctld_supports_it() -> None:
     async with FakeRigctldServer() as server:
@@ -111,5 +138,38 @@ async def test_vfo_observation_available_when_rigctld_supports_it() -> None:
             assert observation.value == "A"
             assert observation.source.source == "hamlib_response"
             assert observation.max_age == 8.0
+        finally:
+            await radio.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_ptt_and_slow_control_reads_cover_declared_rigctld_capabilities() -> None:
+    async with FakeRigctldServer() as server:
+        server.state.ptt = 1
+        server.state.preamp_db = 12
+        server.state.att_db = 18
+        server.state.nb = 1
+        server.state.nr = 0
+        radio = RigctldClientRadio(host=server.host, port=server.port)
+        await radio.connect()
+        try:
+            adapter = RigctldClientObservationAdapter(radio, clock=_clock)
+
+            observations = (
+                await adapter.read_ptt(),
+                *(await adapter.read_slow_controls()),
+            )
+
+            assert [(str(item.path), item.value) for item in observations] == [
+                ("global.tx_state.ptt", True),
+                ("receiver.main.operator_controls.rf_gain", 128),
+                ("receiver.main.operator_controls.af_level", 76),
+                ("receiver.main.operator_controls.preamp", 1),
+                ("receiver.main.operator_controls.att", 18),
+                ("receiver.main.operator_toggles.nb", True),
+                ("receiver.main.operator_toggles.nr", False),
+            ]
+            assert observations[0].max_age == 8.0
+            assert all(item.max_age == 120.0 for item in observations[1:])
         finally:
             await radio.disconnect()

--- a/tests/test_rigctld_handler.py
+++ b/tests/test_rigctld_handler.py
@@ -876,6 +876,14 @@ async def test_set_rit_calls_radio(
     assert resp.ok
     mock_radio.set_rit_frequency.assert_awaited_once_with(500)
     mock_radio.set_rit_status.assert_awaited_once_with(True)
+    events = handler._command_service.lifecycle_events()  # noqa: SLF001
+    assert [event.state for event in events[:4]] == [
+        "accepted",
+        "queued",
+        "sent",
+        "acknowledged",
+    ]
+    assert events[0].source == "rigctld"
 
 
 @pytest.mark.asyncio
@@ -959,6 +967,14 @@ async def test_set_xit_calls_radio(
     assert resp.ok
     mock_radio.set_rit_frequency.assert_awaited_once_with(750)
     mock_radio.set_rit_tx_status.assert_awaited_once_with(True)
+    events = handler._command_service.lifecycle_events()  # noqa: SLF001
+    assert [event.state for event in events[:4]] == [
+        "accepted",
+        "queued",
+        "sent",
+        "acknowledged",
+    ]
+    assert events[0].source == "rigctld"
 
 
 @pytest.mark.asyncio

--- a/tests/test_rigctld_handler.py
+++ b/tests/test_rigctld_handler.py
@@ -1,3 +1,4 @@
+# mypy: disable-error-code=untyped-decorator
 """Tests for RigctldHandler — command dispatch, cache, read-only, exceptions."""
 
 from __future__ import annotations
@@ -10,6 +11,7 @@ import pytest
 from _caps import FULL_ICOM_CAPS
 from rigplane.exceptions import ConnectionError as IcomConnectionError
 from rigplane.exceptions import TimeoutError as IcomTimeoutError
+from rigplane.core.state_pipeline_contracts import FieldPath, Observation, SourceMetadata
 from rigplane.core.state_store import StateStore
 from rigplane.radio_state import RadioState
 from rigplane.rigctld.contract import HamlibError, RigctldCommand, RigctldConfig
@@ -94,6 +96,89 @@ class _ContractModeRadio:
         self.data_mode = bool(on)
 
 
+class _RecordingStateModelService:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    def ensure_fresh(
+        self,
+        paths: FieldPath | str | tuple[FieldPath | str, ...],
+        *,
+        max_age: float,
+        priority: str,
+        reason: str,
+        timeout: float | None = None,
+    ) -> object:
+        if isinstance(paths, tuple):
+            normalized = tuple(
+                str(path) if isinstance(path, FieldPath) else path for path in paths
+            )
+        else:
+            normalized = (
+                str(paths) if isinstance(paths, FieldPath) else paths,
+            )
+        self.calls.append(
+            {
+                "paths": normalized,
+                "max_age": max_age,
+                "priority": priority,
+                "reason": reason,
+                "timeout": timeout,
+            }
+        )
+        return object()
+
+
+def _apply_store_value(
+    store: StateStore,
+    path: str,
+    value: object,
+    *,
+    command_source: str | None = None,
+    correlation_id: str | None = None,
+    max_age: float | None = None,
+) -> None:
+    store.apply(
+        Observation(
+            path=FieldPath.parse(path),
+            value=value,
+            source=SourceMetadata(
+                source="test",
+                provider="tests",
+                command_source=command_source,
+            ),
+            timestamp_monotonic=1.0,
+            correlation_id=correlation_id,
+            max_age=max_age,
+        )
+    )
+
+
+def _apply_handler_value(
+    handler: RigctldHandler,
+    path: str,
+    value: object,
+    *,
+    command_source: str | None = None,
+    correlation_id: str | None = None,
+    max_age: float | None = None,
+) -> None:
+    handler._command_service.apply_observation(  # noqa: SLF001
+        Observation(
+            path=FieldPath.parse(path),
+            value=value,
+            source=SourceMetadata(
+                source="test",
+                provider="tests",
+                command_source=command_source,
+            ),
+            timestamp_monotonic=1.0,
+            correlation_id=correlation_id,
+            max_age=max_age,
+        )
+    )
+
+
 # ---------------------------------------------------------------------------
 # get_freq / set_freq
 # ---------------------------------------------------------------------------
@@ -123,6 +208,22 @@ async def test_get_freq_served_from_cache(
 
 
 @pytest.mark.asyncio
+async def test_get_freq_projects_state_store_snapshot(
+    mock_radio: AsyncMock,
+) -> None:
+    store = StateStore()
+    mock_radio._state_store = store
+    _apply_store_value(store, "receiver.0.freq_mode.freq_hz", 14_074_000)
+    handler = RigctldHandler(mock_radio, RigctldConfig())
+
+    resp = await handler.execute(get_cmd("get_freq"))
+
+    assert resp.ok
+    assert resp.values == ["14074000"]
+    mock_radio.get_freq.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_get_freq_prefers_radio_state(
     handler: RigctldHandler, mock_radio: AsyncMock
 ) -> None:
@@ -138,16 +239,28 @@ async def test_get_freq_prefers_radio_state(
 
 
 @pytest.mark.asyncio
-async def test_get_freq_cache_expires(mock_radio: AsyncMock) -> None:
-    config = RigctldConfig(cache_ttl=0.0)  # zero TTL → always expired
-    h = RigctldHandler(mock_radio, config)
-    mock_radio.get_freq.side_effect = [14_074_000, 7_050_000]
-    cmd = get_cmd("get_freq")
-    r1 = await h.execute(cmd)
-    r2 = await h.execute(cmd)
-    assert r1.values == ["14074000"]
-    assert r2.values == ["7050000"]
-    assert mock_radio.get_freq.await_count == 2
+async def test_get_freq_ensure_fresh_requests_bounded_projection(
+    mock_radio: AsyncMock,
+) -> None:
+    store = StateStore()
+    model_service = _RecordingStateModelService()
+    mock_radio._state_store = store
+    mock_radio._state_model_service = model_service
+    _apply_store_value(store, "receiver.0.freq_mode.freq_hz", 14_074_000, max_age=1.0)
+    handler = RigctldHandler(mock_radio, RigctldConfig(cache_ttl=0.25))
+
+    resp = await handler.execute(get_cmd("get_freq"))
+
+    assert resp.values == ["14074000"]
+    assert model_service.calls == [
+        {
+            "paths": ("receiver.0.freq_mode.freq_hz",),
+            "max_age": 0.25,
+            "priority": "user",
+            "reason": "rigctld.get_freq",
+            "timeout": None,
+        }
+    ]
 
 
 @pytest.mark.asyncio
@@ -248,6 +361,25 @@ async def test_get_mode_falls_back_to_core_radio_contract() -> None:
 
 
 @pytest.mark.asyncio
+async def test_get_mode_projects_state_store_snapshot(
+    mock_radio: AsyncMock,
+) -> None:
+    store = StateStore()
+    mock_radio._state_store = store
+    _apply_store_value(store, "receiver.0.freq_mode.mode", "USB")
+    _apply_store_value(store, "receiver.0.freq_mode.filter_width", 2)
+    _apply_store_value(store, "receiver.0.freq_mode.data_mode", True)
+    handler = RigctldHandler(mock_radio, RigctldConfig())
+
+    resp = await handler.execute(get_cmd("get_mode"))
+
+    assert resp.ok
+    assert resp.values == ["PKTUSB", "2400"]
+    mock_radio.get_mode_info.assert_not_awaited()
+    mock_radio.get_data_mode.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_get_mode_served_from_cache(
     handler: RigctldHandler, mock_radio: AsyncMock
 ) -> None:
@@ -277,13 +409,34 @@ async def test_get_mode_prefers_radio_state(
 
 
 @pytest.mark.asyncio
-async def test_get_mode_cache_expires(mock_radio: AsyncMock) -> None:
-    config = RigctldConfig(cache_ttl=0.0)
-    h = RigctldHandler(mock_radio, config)
-    mock_radio.get_mode_info.side_effect = [(Mode.USB, 1), (Mode.LSB, 1)]
-    await h.execute(get_cmd("get_mode"))
-    await h.execute(get_cmd("get_mode"))
-    assert mock_radio.get_mode_info.await_count == 2
+async def test_get_mode_ensure_fresh_requests_bounded_projection(
+    mock_radio: AsyncMock,
+) -> None:
+    store = StateStore()
+    model_service = _RecordingStateModelService()
+    mock_radio._state_store = store
+    mock_radio._state_model_service = model_service
+    _apply_store_value(store, "receiver.0.freq_mode.mode", "USB", max_age=1.0)
+    _apply_store_value(store, "receiver.0.freq_mode.filter_width", 2, max_age=1.0)
+    _apply_store_value(store, "receiver.0.freq_mode.data_mode", False, max_age=1.0)
+    handler = RigctldHandler(mock_radio, RigctldConfig(cache_ttl=0.5))
+
+    resp = await handler.execute(get_cmd("get_mode"))
+
+    assert resp.values == ["USB", "2400"]
+    assert model_service.calls == [
+        {
+            "paths": (
+                "receiver.0.freq_mode.data_mode",
+                "receiver.0.freq_mode.filter_width",
+                "receiver.0.freq_mode.mode",
+            ),
+            "max_age": 0.5,
+            "priority": "user",
+            "reason": "rigctld.get_mode",
+            "timeout": None,
+        }
+    ]
 
 
 @pytest.mark.asyncio
@@ -452,25 +605,56 @@ async def test_get_freq_keeps_optimistic_value_until_radio_state_catches_up(
 
 
 @pytest.mark.asyncio
-async def test_get_mode_keeps_optimistic_value_until_radio_state_catches_up(
-    handler: RigctldHandler, mock_radio: AsyncMock
+async def test_get_mode_read_after_write_uses_pending_overlays_until_reconciled(
+    mock_radio: AsyncMock,
 ) -> None:
-    state = RadioState()
-    state.main.freq = 14_074_000
-    state.main.mode = "USB"
-    state.main.filter = 1
-    state.main.data_mode = False
-    mock_radio.radio_state = state
+    store = StateStore()
+    mock_radio._state_store = store
+    _apply_store_value(store, "receiver.0.freq_mode.mode", "USB")
+    _apply_store_value(store, "receiver.0.freq_mode.filter_width", 1)
+    _apply_store_value(store, "receiver.0.freq_mode.data_mode", False)
+    handler = RigctldHandler(mock_radio, RigctldConfig())
 
-    await handler.execute(set_cmd("set_mode", "LSB", "2400"))
+    resp = await handler.execute(set_cmd("set_mode", "PKTUSB", "2400"))
 
-    resp = await handler.execute(get_cmd("get_mode"))
-    assert resp.values == ["LSB", "2400"]
+    assert resp.ok
+    before = await handler.execute(get_cmd("get_mode"))
+    assert before.values == ["PKTUSB", "2400"]
 
-    state.main.mode = "LSB"
-    state.main.filter = 2
-    resp = await handler.execute(get_cmd("get_mode"))
-    assert resp.values == ["LSB", "2400"]
+    overlays = handler._command_service.pending_overlays(  # noqa: SLF001
+        source="rigctld",
+        session_id=None,
+    )
+    overlay_ids = {str(item.path): item.command_id for item in overlays}
+    assert overlay_ids["receiver.0.freq_mode.filter_width"].startswith(
+        "rigctld-set-mode-"
+    )
+    assert overlay_ids["receiver.0.freq_mode.data_mode"].startswith(
+        "rigctld-set-mode-"
+    )
+
+    _apply_handler_value(
+        handler,
+        "receiver.0.freq_mode.filter_width",
+        2,
+        command_source="rigctld",
+        correlation_id=overlay_ids["receiver.0.freq_mode.filter_width"],
+    )
+    _apply_handler_value(
+        handler,
+        "receiver.0.freq_mode.data_mode",
+        True,
+        command_source="rigctld",
+        correlation_id=overlay_ids["receiver.0.freq_mode.data_mode"],
+    )
+
+    assert handler._command_service.pending_overlays(  # noqa: SLF001
+        source="rigctld",
+        session_id=None,
+    ) == ()
+
+    after = await handler.execute(get_cmd("get_mode"))
+    assert after.values == ["PKTUSB", "2400"]
 
 
 # ---------------------------------------------------------------------------
@@ -494,6 +678,21 @@ async def test_get_ptt_reads_radio_state(
     state = RadioState()
     state.ptt = True
     mock_radio.radio_state = state
+
+    resp = await handler.execute(get_cmd("get_ptt"))
+
+    assert resp.ok
+    assert resp.values == ["1"]
+
+
+@pytest.mark.asyncio
+async def test_get_ptt_projects_state_store_snapshot(
+    mock_radio: AsyncMock,
+) -> None:
+    store = StateStore()
+    mock_radio._state_store = store
+    _apply_store_value(store, "global.tx_state.ptt", True)
+    handler = RigctldHandler(mock_radio, RigctldConfig())
 
     resp = await handler.execute(get_cmd("get_ptt"))
 
@@ -583,6 +782,21 @@ async def test_get_vfo_returns_vfoa(
 
 
 @pytest.mark.asyncio
+async def test_get_vfo_projects_state_store_active_slot(
+    mock_radio: AsyncMock,
+) -> None:
+    store = StateStore()
+    mock_radio._state_store = store
+    _apply_store_value(store, "receiver.0.vfo.active_slot", "B")
+    handler = RigctldHandler(mock_radio, RigctldConfig())
+
+    resp = await handler.execute(get_cmd("get_vfo"))
+
+    assert resp.ok
+    assert resp.values == ["VFOB"]
+
+
+@pytest.mark.asyncio
 async def test_set_vfo_accepts_any_name(
     handler: RigctldHandler, mock_radio: AsyncMock
 ) -> None:
@@ -614,6 +828,22 @@ async def test_get_level_strength_prefers_radio_state(
     state.main.freq = 14_074_000
     state.main.s_meter = 120
     mock_radio.radio_state = state
+
+    resp = await handler.execute(get_cmd("get_level", "STRENGTH"))
+
+    assert resp.ok
+    assert int(resp.values[0]) == pytest.approx(3, abs=1)
+    mock_radio.get_s_meter.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_level_strength_projects_state_store_snapshot(
+    mock_radio: AsyncMock,
+) -> None:
+    store = StateStore()
+    mock_radio._state_store = store
+    _apply_store_value(store, "receiver.0.meters.s_meter", 120)
+    handler = RigctldHandler(mock_radio, RigctldConfig())
 
     resp = await handler.execute(get_cmd("get_level", "STRENGTH"))
 
@@ -657,6 +887,22 @@ async def test_get_level_rfpower_prefers_radio_state(
     assert resp.ok
     assert float(resp.values[0]) == pytest.approx(128 / 255.0, rel=1e-6)
     mock_radio.get_rf_power.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_level_af_projects_state_store_snapshot(
+    mock_radio: AsyncMock,
+) -> None:
+    store = StateStore()
+    mock_radio._state_store = store
+    _apply_store_value(store, "receiver.0.operator_controls.af_level", 128)
+    handler = RigctldHandler(mock_radio, RigctldConfig())
+
+    resp = await handler.execute(get_cmd("get_level", "AF"))
+
+    assert resp.ok
+    assert float(resp.values[0]) == pytest.approx(128 / 255.0, rel=1e-6)
+    mock_radio.get_af_level.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -730,6 +976,23 @@ async def test_get_split_vfo_reads_radio_state(
 
     assert resp.ok
     assert resp.values == ["1", "VFOA"]
+
+
+@pytest.mark.asyncio
+async def test_get_split_vfo_reads_state_store_split_and_protocol_local_tx_vfo(
+    mock_radio: AsyncMock,
+) -> None:
+    store = StateStore()
+    mock_radio._state_store = store
+    handler = RigctldHandler(mock_radio, RigctldConfig())
+    _apply_store_value(store, "global.tx_state.split", True)
+
+    set_resp = await handler.execute(set_cmd("set_split_vfo", "1", "VFOB"))
+    assert set_resp.ok
+
+    get_resp = await handler.execute(get_cmd("get_split_vfo"))
+    assert get_resp.ok
+    assert get_resp.values == ["1", "VFOB"]
 
 
 @pytest.mark.asyncio
@@ -1572,6 +1835,22 @@ async def test_get_func_nb_off(handler: RigctldHandler, mock_radio: AsyncMock) -
 
 
 @pytest.mark.asyncio
+async def test_get_func_projects_state_store_snapshot(
+    mock_radio: AsyncMock,
+) -> None:
+    store = StateStore()
+    mock_radio._state_store = store
+    _apply_store_value(store, "receiver.0.operator_toggles.nb", True)
+    handler = RigctldHandler(mock_radio, RigctldConfig())
+
+    resp = await handler.execute(get_cmd("get_func", "NB"))
+
+    assert resp.ok
+    assert resp.values == ["1"]
+    mock_radio.get_nb.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_get_func_nb_on(handler: RigctldHandler, mock_radio: AsyncMock) -> None:
     mock_radio.get_nb = AsyncMock(return_value=True)
     resp = await handler.execute(get_cmd("get_func", "NB"))
@@ -1650,7 +1929,7 @@ async def test_rigctld_get_func_lock_icom(config: RigctldConfig) -> None:
         async def get_dial_lock(self) -> bool:
             return True
 
-    handler = RigctldHandler(_IcomLikeRadio(), config)  # type: ignore[arg-type]
+    handler = RigctldHandler(_IcomLikeRadio(), config)
     resp = await handler.execute(get_cmd("get_func", "LOCK"))
     assert resp.ok
     assert resp.values[0] == "1"
@@ -1668,7 +1947,7 @@ async def test_rigctld_set_func_lock_icom(config: RigctldConfig) -> None:
         async def set_dial_lock(self, on: bool) -> None:
             calls.append(on)
 
-    handler = RigctldHandler(_IcomLikeRadio(), config)  # type: ignore[arg-type]
+    handler = RigctldHandler(_IcomLikeRadio(), config)
     resp = await handler.execute(set_cmd("set_func", "LOCK", "1"))
     assert resp.ok
     assert calls == [True]
@@ -1948,7 +2227,7 @@ async def test_send_raw_no_send_civ_raw_returns_enimpl(config: RigctldConfig) ->
     class _NoRawRadio:
         pass
 
-    handler = RigctldHandler(_NoRawRadio(), config)  # type: ignore[arg-type]
+    handler = RigctldHandler(_NoRawRadio(), config)
     resp = await handler.execute(
         get_cmd("send_raw", "FE", "FE", "98", "E0", "03", "FD")
     )
@@ -1962,7 +2241,7 @@ async def test_send_raw_no_send_civ_raw_returns_enimpl(config: RigctldConfig) ->
 from rigplane.backends.yaesu_cat.radio import YaesuCatRadio  # noqa: E402
 
 
-class _FakeYaesuRadio(YaesuCatRadio):
+class _FakeYaesuRadio(YaesuCatRadio):  # type: ignore[misc]
     """A YaesuCatRadio subclass that bypasses __init__ for testing."""
 
     def __init__(self) -> None:
@@ -3043,6 +3322,21 @@ class TestPerVfoRoutingFreq:
         assert resp.values == ["7100000"]
 
     @pytest.mark.asyncio
+    async def test_dual_rx_get_freq_vfob_projects_state_store_receiver_1(
+        self, dual_rx_radio: AsyncMock
+    ) -> None:
+        store = StateStore()
+        dual_rx_radio._state_store = store
+        _apply_store_value(store, "receiver.1.freq_mode.freq_hz", 7_100_000)
+        handler = RigctldHandler(dual_rx_radio, RigctldConfig())
+
+        resp = await handler.execute(_vfo_get_cmd("get_freq", "VFOB"))
+
+        assert resp.ok
+        assert resp.values == ["7100000"]
+        dual_rx_radio.get_freq.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_dual_rx_get_freq_currvfo_follows_active(
         self, dual_rx_handler: RigctldHandler, dual_rx_radio: AsyncMock
     ) -> None:
@@ -3134,6 +3428,22 @@ class TestPerVfoRoutingMode:
         resp = await dual_rx_handler.execute(_vfo_get_cmd("get_mode", "VFOB"))
         assert resp.ok
         # SUB: CW, filter 2 → 2400 Hz passband.
+        assert resp.values == ["CW", "2400"]
+
+    @pytest.mark.asyncio
+    async def test_dual_rx_get_mode_vfob_projects_state_store_receiver_1(
+        self, dual_rx_radio: AsyncMock
+    ) -> None:
+        store = StateStore()
+        dual_rx_radio._state_store = store
+        _apply_store_value(store, "receiver.1.freq_mode.mode", "CW")
+        _apply_store_value(store, "receiver.1.freq_mode.filter_width", 2)
+        _apply_store_value(store, "receiver.1.freq_mode.data_mode", False)
+        handler = RigctldHandler(dual_rx_radio, RigctldConfig())
+
+        resp = await handler.execute(_vfo_get_cmd("get_mode", "VFOB"))
+
+        assert resp.ok
         assert resp.values == ["CW", "2400"]
 
     @pytest.mark.asyncio

--- a/tests/test_rigctld_handler.py
+++ b/tests/test_rigctld_handler.py
@@ -21,7 +21,12 @@ from rigplane.core.state_acquisition_policy import (
 )
 from rigplane.exceptions import ConnectionError as IcomConnectionError
 from rigplane.exceptions import TimeoutError as IcomTimeoutError
-from rigplane.core.state_pipeline_contracts import FieldPath, Observation, SourceMetadata
+from rigplane.core.state_pipeline_contracts import (
+    CommandSource,
+    FieldPath,
+    Observation,
+    SourceMetadata,
+)
 from rigplane.core.state_store import StateStore
 from rigplane.radio_state import RadioState
 from rigplane.rigctld.contract import HamlibError, RigctldCommand, RigctldConfig
@@ -159,7 +164,7 @@ def _apply_store_value(
     path: str,
     value: object,
     *,
-    command_source: str | None = None,
+    command_source: CommandSource | None = None,
     correlation_id: str | None = None,
     max_age: float | None = None,
 ) -> None:
@@ -184,7 +189,7 @@ def _apply_handler_value(
     path: str,
     value: object,
     *,
-    command_source: str | None = None,
+    command_source: CommandSource | None = None,
     correlation_id: str | None = None,
     max_age: float | None = None,
 ) -> None:

--- a/tests/test_rigctld_handler.py
+++ b/tests/test_rigctld_handler.py
@@ -584,6 +584,27 @@ async def test_set_mode_pktrtty_maps_to_rtty_and_sets_data(
     mock_radio.set_data_mode.assert_awaited_once_with(True)
 
 
+@pytest.mark.parametrize(
+    ("packet_mode", "base_mode"),
+    (("PKTUSB", "USB"), ("PKTLSB", "LSB"), ("PKTRTTY", "RTTY")),
+)
+@pytest.mark.asyncio
+async def test_set_mode_packet_refreshes_data_mode_cache(
+    mock_radio: AsyncMock,
+    packet_mode: str,
+    base_mode: str,
+) -> None:
+    handler = RigctldHandler(mock_radio, RigctldConfig())
+
+    resp = await handler.execute(set_cmd("set_mode", packet_mode))
+
+    assert resp.ok
+    mock_radio.set_mode.assert_awaited_once_with(base_mode, filter_width=None)
+    mock_radio.set_data_mode.assert_awaited_once_with(True)
+    assert handler._cache.mode == base_mode  # noqa: SLF001
+    assert handler._cache.data_mode is True  # noqa: SLF001
+
+
 @pytest.mark.asyncio
 async def test_set_mode_uses_core_contract_string_values() -> None:
     radio = _ContractModeRadio(mode="USB", filter_width=1, data_mode=False)

--- a/tests/test_rigctld_handler.py
+++ b/tests/test_rigctld_handler.py
@@ -9,6 +9,16 @@ from unittest.mock import AsyncMock
 import pytest
 
 from _caps import FULL_ICOM_CAPS
+from rigplane.core.acquisition_scheduler import (
+    AcquisitionPriority,
+    AcquisitionScheduler,
+    RadioStateModelService,
+)
+from rigplane.core.state_acquisition_policy import (
+    AcquisitionPolicy,
+    FieldCapability,
+    RadioAcquisitionProfile,
+)
 from rigplane.exceptions import ConnectionError as IcomConnectionError
 from rigplane.exceptions import TimeoutError as IcomTimeoutError
 from rigplane.core.state_pipeline_contracts import FieldPath, Observation, SourceMetadata
@@ -129,6 +139,21 @@ class _RecordingStateModelService:
         return object()
 
 
+def _acquisition_profile(*paths: FieldPath) -> RadioAcquisitionProfile:
+    return RadioAcquisitionProfile(
+        provider="test_provider",
+        capabilities=tuple(
+            FieldCapability(
+                path=path,
+                polling=True,
+                command_response_observable=True,
+            )
+            for path in paths
+        ),
+        default_policy=AcquisitionPolicy(),
+    )
+
+
 def _apply_store_value(
     store: StateStore,
     path: str,
@@ -213,7 +238,7 @@ async def test_get_freq_projects_state_store_snapshot(
 ) -> None:
     store = StateStore()
     mock_radio._state_store = store
-    _apply_store_value(store, "receiver.0.freq_mode.freq_hz", 14_074_000)
+    _apply_store_value(store, "receiver.main.active.freq_mode.freq_hz", 14_074_000)
     handler = RigctldHandler(mock_radio, RigctldConfig())
 
     resp = await handler.execute(get_cmd("get_freq"))
@@ -246,7 +271,12 @@ async def test_get_freq_ensure_fresh_requests_bounded_projection(
     model_service = _RecordingStateModelService()
     mock_radio._state_store = store
     mock_radio._state_model_service = model_service
-    _apply_store_value(store, "receiver.0.freq_mode.freq_hz", 14_074_000, max_age=1.0)
+    _apply_store_value(
+        store,
+        "receiver.main.active.freq_mode.freq_hz",
+        14_074_000,
+        max_age=1.0,
+    )
     handler = RigctldHandler(mock_radio, RigctldConfig(cache_ttl=0.25))
 
     resp = await handler.execute(get_cmd("get_freq"))
@@ -254,13 +284,36 @@ async def test_get_freq_ensure_fresh_requests_bounded_projection(
     assert resp.values == ["14074000"]
     assert model_service.calls == [
         {
-            "paths": ("receiver.0.freq_mode.freq_hz",),
+            "paths": ("receiver.main.active.freq_mode.freq_hz",),
             "max_age": 0.25,
             "priority": "user",
             "reason": "rigctld.get_freq",
             "timeout": None,
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_get_freq_ensure_fresh_queues_canonical_request_with_real_service(
+    mock_radio: AsyncMock,
+) -> None:
+    store = StateStore()
+    freq = FieldPath.active("main", "freq_mode", "freq_hz")
+    scheduler = AcquisitionScheduler(profile=_acquisition_profile(freq))
+    model_service = RadioStateModelService(store=store, scheduler=scheduler)
+    mock_radio._state_store = store
+    mock_radio._state_model_service = model_service
+    mock_radio.get_freq.return_value = 14_074_000
+    handler = RigctldHandler(mock_radio, RigctldConfig(cache_ttl=0.25))
+
+    resp = await handler.execute(get_cmd("get_freq"))
+
+    assert resp.values == ["14074000"]
+    requests = scheduler.pending_requests()
+    assert len(requests) == 1
+    assert requests[0].paths == (freq,)
+    assert requests[0].priority is AcquisitionPriority.USER
+    assert requests[0].reason == "rigctld.get_freq"
 
 
 @pytest.mark.asyncio
@@ -366,9 +419,9 @@ async def test_get_mode_projects_state_store_snapshot(
 ) -> None:
     store = StateStore()
     mock_radio._state_store = store
-    _apply_store_value(store, "receiver.0.freq_mode.mode", "USB")
-    _apply_store_value(store, "receiver.0.freq_mode.filter_width", 2)
-    _apply_store_value(store, "receiver.0.freq_mode.data_mode", True)
+    _apply_store_value(store, "receiver.main.active.freq_mode.mode", "USB")
+    _apply_store_value(store, "receiver.main.active.freq_mode.filter_width", 2)
+    _apply_store_value(store, "receiver.main.active.freq_mode.data_mode", True)
     handler = RigctldHandler(mock_radio, RigctldConfig())
 
     resp = await handler.execute(get_cmd("get_mode"))
@@ -416,9 +469,19 @@ async def test_get_mode_ensure_fresh_requests_bounded_projection(
     model_service = _RecordingStateModelService()
     mock_radio._state_store = store
     mock_radio._state_model_service = model_service
-    _apply_store_value(store, "receiver.0.freq_mode.mode", "USB", max_age=1.0)
-    _apply_store_value(store, "receiver.0.freq_mode.filter_width", 2, max_age=1.0)
-    _apply_store_value(store, "receiver.0.freq_mode.data_mode", False, max_age=1.0)
+    _apply_store_value(store, "receiver.main.active.freq_mode.mode", "USB", max_age=1.0)
+    _apply_store_value(
+        store,
+        "receiver.main.active.freq_mode.filter_width",
+        2,
+        max_age=1.0,
+    )
+    _apply_store_value(
+        store,
+        "receiver.main.active.freq_mode.data_mode",
+        False,
+        max_age=1.0,
+    )
     handler = RigctldHandler(mock_radio, RigctldConfig(cache_ttl=0.5))
 
     resp = await handler.execute(get_cmd("get_mode"))
@@ -427,9 +490,9 @@ async def test_get_mode_ensure_fresh_requests_bounded_projection(
     assert model_service.calls == [
         {
             "paths": (
-                "receiver.0.freq_mode.data_mode",
-                "receiver.0.freq_mode.filter_width",
-                "receiver.0.freq_mode.mode",
+                "receiver.main.active.freq_mode.data_mode",
+                "receiver.main.active.freq_mode.filter_width",
+                "receiver.main.active.freq_mode.mode",
             ),
             "max_age": 0.5,
             "priority": "user",
@@ -610,9 +673,9 @@ async def test_get_mode_read_after_write_uses_pending_overlays_until_reconciled(
 ) -> None:
     store = StateStore()
     mock_radio._state_store = store
-    _apply_store_value(store, "receiver.0.freq_mode.mode", "USB")
-    _apply_store_value(store, "receiver.0.freq_mode.filter_width", 1)
-    _apply_store_value(store, "receiver.0.freq_mode.data_mode", False)
+    _apply_store_value(store, "receiver.main.active.freq_mode.mode", "USB")
+    _apply_store_value(store, "receiver.main.active.freq_mode.filter_width", 1)
+    _apply_store_value(store, "receiver.main.active.freq_mode.data_mode", False)
     handler = RigctldHandler(mock_radio, RigctldConfig())
 
     resp = await handler.execute(set_cmd("set_mode", "PKTUSB", "2400"))
@@ -626,26 +689,26 @@ async def test_get_mode_read_after_write_uses_pending_overlays_until_reconciled(
         session_id=None,
     )
     overlay_ids = {str(item.path): item.command_id for item in overlays}
-    assert overlay_ids["receiver.0.freq_mode.filter_width"].startswith(
+    assert overlay_ids["receiver.main.active.freq_mode.filter_width"].startswith(
         "rigctld-set-mode-"
     )
-    assert overlay_ids["receiver.0.freq_mode.data_mode"].startswith(
+    assert overlay_ids["receiver.main.active.freq_mode.data_mode"].startswith(
         "rigctld-set-mode-"
     )
 
     _apply_handler_value(
         handler,
-        "receiver.0.freq_mode.filter_width",
+        "receiver.main.active.freq_mode.filter_width",
         2,
         command_source="rigctld",
-        correlation_id=overlay_ids["receiver.0.freq_mode.filter_width"],
+        correlation_id=overlay_ids["receiver.main.active.freq_mode.filter_width"],
     )
     _apply_handler_value(
         handler,
-        "receiver.0.freq_mode.data_mode",
+        "receiver.main.active.freq_mode.data_mode",
         True,
         command_source="rigctld",
-        correlation_id=overlay_ids["receiver.0.freq_mode.data_mode"],
+        correlation_id=overlay_ids["receiver.main.active.freq_mode.data_mode"],
     )
 
     assert handler._command_service.pending_overlays(  # noqa: SLF001
@@ -655,6 +718,36 @@ async def test_get_mode_read_after_write_uses_pending_overlays_until_reconciled(
 
     after = await handler.execute(get_cmd("get_mode"))
     assert after.values == ["PKTUSB", "2400"]
+
+
+@pytest.mark.asyncio
+async def test_get_mode_pending_overlays_are_scoped_to_rigctld_session(
+    mock_radio: AsyncMock,
+) -> None:
+    store = StateStore()
+    mock_radio._state_store = store
+    _apply_store_value(store, "receiver.main.active.freq_mode.mode", "USB")
+    _apply_store_value(store, "receiver.main.active.freq_mode.filter_width", 1)
+    _apply_store_value(store, "receiver.main.active.freq_mode.data_mode", False)
+    handler = RigctldHandler(mock_radio, RigctldConfig())
+
+    resp = await handler.execute(
+        set_cmd("set_mode", "PKTUSB", "2400"),
+        session_id="rigctld-client-a",
+    )
+
+    assert resp.ok
+    client_a = await handler.execute(
+        get_cmd("get_mode"),
+        session_id="rigctld-client-a",
+    )
+    client_b = await handler.execute(
+        get_cmd("get_mode"),
+        session_id="rigctld-client-b",
+    )
+
+    assert client_a.values == ["PKTUSB", "2400"]
+    assert client_b.values == ["USB", "3000"]
 
 
 # ---------------------------------------------------------------------------
@@ -787,7 +880,7 @@ async def test_get_vfo_projects_state_store_active_slot(
 ) -> None:
     store = StateStore()
     mock_radio._state_store = store
-    _apply_store_value(store, "receiver.0.vfo.active_slot", "B")
+    _apply_store_value(store, "receiver.main.vfo.active_slot", "B")
     handler = RigctldHandler(mock_radio, RigctldConfig())
 
     resp = await handler.execute(get_cmd("get_vfo"))
@@ -895,7 +988,7 @@ async def test_get_level_af_projects_state_store_snapshot(
 ) -> None:
     store = StateStore()
     mock_radio._state_store = store
-    _apply_store_value(store, "receiver.0.operator_controls.af_level", 128)
+    _apply_store_value(store, "receiver.main.operator_controls.af_level", 128)
     handler = RigctldHandler(mock_radio, RigctldConfig())
 
     resp = await handler.execute(get_cmd("get_level", "AF"))
@@ -1840,7 +1933,7 @@ async def test_get_func_projects_state_store_snapshot(
 ) -> None:
     store = StateStore()
     mock_radio._state_store = store
-    _apply_store_value(store, "receiver.0.operator_toggles.nb", True)
+    _apply_store_value(store, "receiver.main.operator_toggles.nb", True)
     handler = RigctldHandler(mock_radio, RigctldConfig())
 
     resp = await handler.execute(get_cmd("get_func", "NB"))
@@ -3327,7 +3420,7 @@ class TestPerVfoRoutingFreq:
     ) -> None:
         store = StateStore()
         dual_rx_radio._state_store = store
-        _apply_store_value(store, "receiver.1.freq_mode.freq_hz", 7_100_000)
+        _apply_store_value(store, "receiver.sub.active.freq_mode.freq_hz", 7_100_000)
         handler = RigctldHandler(dual_rx_radio, RigctldConfig())
 
         resp = await handler.execute(_vfo_get_cmd("get_freq", "VFOB"))
@@ -3436,9 +3529,9 @@ class TestPerVfoRoutingMode:
     ) -> None:
         store = StateStore()
         dual_rx_radio._state_store = store
-        _apply_store_value(store, "receiver.1.freq_mode.mode", "CW")
-        _apply_store_value(store, "receiver.1.freq_mode.filter_width", 2)
-        _apply_store_value(store, "receiver.1.freq_mode.data_mode", False)
+        _apply_store_value(store, "receiver.sub.active.freq_mode.mode", "CW")
+        _apply_store_value(store, "receiver.sub.active.freq_mode.filter_width", 2)
+        _apply_store_value(store, "receiver.sub.active.freq_mode.data_mode", False)
         handler = RigctldHandler(dual_rx_radio, RigctldConfig())
 
         resp = await handler.execute(_vfo_get_cmd("get_mode", "VFOB"))

--- a/tests/test_rigctld_handler.py
+++ b/tests/test_rigctld_handler.py
@@ -506,6 +506,20 @@ async def test_set_ptt_on(handler: RigctldHandler, mock_radio: AsyncMock) -> Non
     resp = await handler.execute(set_cmd("set_ptt", "1"))
     assert resp.ok
     mock_radio.set_ptt.assert_awaited_once_with(True)
+    events = handler._command_service.lifecycle_events()  # noqa: SLF001
+    assert [event.state for event in events[:4]] == [
+        "accepted",
+        "queued",
+        "sent",
+        "acknowledged",
+    ]
+    assert events[0].source == "rigctld"
+    assert (
+        handler._command_service._state_store.snapshot()  # noqa: SLF001
+        .field("global.tx_state.ptt")
+        .value
+        is True
+    )
 
 
 @pytest.mark.asyncio
@@ -1828,6 +1842,15 @@ async def test_send_raw_returns_hex_response(
 
     assert resp.ok
     assert resp.values == ["FE FE E0 98 03 00 60 00 00 00 FD"]
+    events = handler._command_service.lifecycle_events()  # noqa: SLF001
+    assert [event.state for event in events[:4]] == [
+        "accepted",
+        "queued",
+        "sent",
+        "acknowledged",
+    ]
+    assert events[0].command_id.startswith("rigctld-send-raw-")
+    assert events[0].source == "rigctld"
 
 
 @pytest.mark.asyncio

--- a/tests/test_rigctld_handler.py
+++ b/tests/test_rigctld_handler.py
@@ -13,6 +13,7 @@ from rigplane.core.acquisition_scheduler import (
     AcquisitionPriority,
     AcquisitionScheduler,
     RadioStateModelService,
+    StateFreshnessService,
 )
 from rigplane.core.state_acquisition_policy import (
     AcquisitionPolicy,
@@ -349,6 +350,39 @@ async def test_get_freq_stale_store_value_falls_through_to_radio_readback(
     assert requests[0].paths == (freq,)
     assert requests[0].priority is AcquisitionPriority.USER
     assert requests[0].reason == "rigctld.get_freq"
+    mock_radio.get_freq.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_get_freq_headless_freshness_service_stale_value_queues_reconciliation(
+    mock_radio: AsyncMock,
+) -> None:
+    store = StateStore()
+    freq = FieldPath.active("main", "freq_mode", "freq_hz")
+    scheduler = AcquisitionScheduler(profile=_acquisition_profile(freq))
+    model_service = RadioStateModelService(store=store, scheduler=scheduler)
+    freshness_service = StateFreshnessService(store=store, scheduler=scheduler)
+    mock_radio._state_store = store
+    mock_radio._state_model_service = model_service
+    mock_radio._state_freshness_service = freshness_service
+    mock_radio.get_freq.return_value = 14_090_000
+    _apply_store_value(
+        store,
+        "receiver.main.active.freq_mode.freq_hz",
+        14_074_000,
+        max_age=0.25,
+    )
+    freshness_service.tick(now=2.0)
+    handler = RigctldHandler(mock_radio, RigctldConfig(cache_ttl=0.25))
+
+    resp = await handler.execute(get_cmd("get_freq"))
+
+    assert resp.values == ["14090000"]
+    requests = scheduler.pending_requests()
+    assert len(requests) == 1
+    assert requests[0].paths == (freq,)
+    assert requests[0].priority is AcquisitionPriority.USER
+    assert requests[0].reasons == ("stale", "rigctld.get_freq")
     mock_radio.get_freq.assert_awaited_once()
 
 

--- a/tests/test_rigctld_handler.py
+++ b/tests/test_rigctld_handler.py
@@ -317,6 +317,37 @@ async def test_get_freq_ensure_fresh_queues_canonical_request_with_real_service(
 
 
 @pytest.mark.asyncio
+async def test_get_freq_stale_store_value_falls_through_to_radio_readback(
+    mock_radio: AsyncMock,
+) -> None:
+    store = StateStore()
+    freq = FieldPath.active("main", "freq_mode", "freq_hz")
+    scheduler = AcquisitionScheduler(profile=_acquisition_profile(freq))
+    model_service = RadioStateModelService(store=store, scheduler=scheduler)
+    mock_radio._state_store = store
+    mock_radio._state_model_service = model_service
+    mock_radio.get_freq.return_value = 14_090_000
+    _apply_store_value(
+        store,
+        "receiver.main.active.freq_mode.freq_hz",
+        14_074_000,
+        max_age=0.25,
+    )
+    store.mark_stale_due(now=2.0)
+    handler = RigctldHandler(mock_radio, RigctldConfig(cache_ttl=0.25))
+
+    resp = await handler.execute(get_cmd("get_freq"))
+
+    assert resp.values == ["14090000"]
+    requests = scheduler.pending_requests()
+    assert len(requests) == 1
+    assert requests[0].paths == (freq,)
+    assert requests[0].priority is AcquisitionPriority.USER
+    assert requests[0].reason == "rigctld.get_freq"
+    mock_radio.get_freq.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_set_freq_calls_radio(
     handler: RigctldHandler, mock_radio: AsyncMock
 ) -> None:
@@ -1086,6 +1117,36 @@ async def test_get_split_vfo_reads_state_store_split_and_protocol_local_tx_vfo(
     get_resp = await handler.execute(get_cmd("get_split_vfo"))
     assert get_resp.ok
     assert get_resp.values == ["1", "VFOB"]
+
+
+@pytest.mark.asyncio
+async def test_get_split_vfo_scopes_tx_vfo_by_session_id(
+    dual_rx_handler: RigctldHandler,
+    dual_rx_radio: AsyncMock,
+) -> None:
+    state = RadioState()
+    state.split = True
+    dual_rx_radio.radio_state = state
+
+    set_resp = await dual_rx_handler.execute(
+        set_cmd("set_split_vfo", "1", "VFOB"),
+        session_id="rigctld-client-a",
+    )
+    assert set_resp.ok
+
+    resp_a = await dual_rx_handler.execute(
+        get_cmd("get_split_vfo"),
+        session_id="rigctld-client-a",
+    )
+    resp_b = await dual_rx_handler.execute(
+        get_cmd("get_split_vfo"),
+        session_id="rigctld-client-b",
+    )
+
+    assert resp_a.ok
+    assert resp_a.values == ["1", "VFOB"]
+    assert resp_b.ok
+    assert resp_b.values == ["1", "VFOA"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_rigctld_handler.py
+++ b/tests/test_rigctld_handler.py
@@ -10,6 +10,7 @@ import pytest
 from _caps import FULL_ICOM_CAPS
 from rigplane.exceptions import ConnectionError as IcomConnectionError
 from rigplane.exceptions import TimeoutError as IcomTimeoutError
+from rigplane.core.state_store import StateStore
 from rigplane.radio_state import RadioState
 from rigplane.rigctld.contract import HamlibError, RigctldCommand, RigctldConfig
 from rigplane.rigctld.handler import RigctldHandler
@@ -156,6 +157,30 @@ async def test_set_freq_calls_radio(
     resp = await handler.execute(set_cmd("set_freq", "14074000"))
     assert resp.ok
     mock_radio.set_freq.assert_awaited_once_with(14_074_000, receiver=0)
+
+
+@pytest.mark.asyncio
+async def test_set_freq_enters_command_service_and_applies_observation(
+    mock_radio: AsyncMock,
+) -> None:
+    store = StateStore()
+    mock_radio._state_store = store
+    handler = RigctldHandler(mock_radio, RigctldConfig())
+
+    resp = await handler.execute(set_cmd("set_freq", "14074000"))
+
+    assert resp.ok
+    events = handler._command_service.lifecycle_events()  # noqa: SLF001
+    assert [event.state for event in events[:4]] == [
+        "accepted",
+        "queued",
+        "sent",
+        "acknowledged",
+    ]
+    assert events[0].source == "rigctld"
+    field = store.snapshot().field("receiver.0.freq_mode.freq_hz")
+    assert field.value == 14_074_000
+    assert field.source.source == "command_response"
 
 
 @pytest.mark.asyncio

--- a/tests/test_rigctld_handler.py
+++ b/tests/test_rigctld_handler.py
@@ -1098,6 +1098,15 @@ async def test_timeout_error_becomes_etimeout(
 
 
 @pytest.mark.asyncio
+async def test_builtin_timeout_error_becomes_etimeout(
+    handler: RigctldHandler, mock_radio: AsyncMock
+) -> None:
+    mock_radio.get_freq.side_effect = TimeoutError("timeout")
+    resp = await handler.execute(get_cmd("get_freq"))
+    assert resp.error == HamlibError.ETIMEOUT
+
+
+@pytest.mark.asyncio
 async def test_value_error_becomes_einval(
     handler: RigctldHandler, mock_radio: AsyncMock
 ) -> None:

--- a/tests/test_rigctld_handler.py
+++ b/tests/test_rigctld_handler.py
@@ -3092,6 +3092,23 @@ async def test_get_vfo_dual_rx_sub_is_vfob(
 
 
 @pytest.mark.asyncio
+async def test_get_vfo_dual_rx_ignores_main_active_slot_projection(
+    dual_rx_radio: AsyncMock,
+) -> None:
+    store = StateStore()
+    dual_rx_radio._state_store = store
+    _apply_store_value(store, "receiver.main.vfo.active_slot", "B")
+    state = RadioState()
+    state.active = "MAIN"
+    dual_rx_radio.radio_state = state
+    handler = RigctldHandler(dual_rx_radio, RigctldConfig())
+
+    resp = await handler.execute(get_cmd("get_vfo"))
+
+    assert resp.values == ["VFOA"]
+
+
+@pytest.mark.asyncio
 async def test_get_vfo_single_rx_reflects_slot_b(
     single_rx_handler: RigctldHandler, single_rx_radio: AsyncMock
 ) -> None:
@@ -3509,6 +3526,24 @@ class TestPerVfoRoutingFreq:
         # so behaviour matches the pre-#1344 single-VFO path: MAIN freq.
         dual_rx_radio.radio_state = _dual_rx_state()
         resp = await dual_rx_handler.execute(_vfo_get_cmd("get_freq", None))
+        assert resp.ok
+        assert resp.values == ["14250000"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("vfo_arg", [None, "currVFO"])
+    async def test_dual_rx_get_freq_ignores_main_active_slot_projection(
+        self, dual_rx_radio: AsyncMock, vfo_arg: str | None
+    ) -> None:
+        store = StateStore()
+        dual_rx_radio._state_store = store
+        _apply_store_value(store, "receiver.main.vfo.active_slot", "B")
+        state = _dual_rx_state(main_freq=14_250_000, sub_freq=7_100_000)
+        state.active = "MAIN"
+        dual_rx_radio.radio_state = state
+        handler = RigctldHandler(dual_rx_radio, RigctldConfig())
+
+        resp = await handler.execute(_vfo_get_cmd("get_freq", vfo_arg))
+
         assert resp.ok
         assert resp.values == ["14250000"]
 

--- a/tests/test_rigctld_handler.py
+++ b/tests/test_rigctld_handler.py
@@ -130,9 +130,7 @@ class _RecordingStateModelService:
                 str(path) if isinstance(path, FieldPath) else path for path in paths
             )
         else:
-            normalized = (
-                str(paths) if isinstance(paths, FieldPath) else paths,
-            )
+            normalized = (str(paths) if isinstance(paths, FieldPath) else paths,)
         self.calls.append(
             {
                 "paths": normalized,
@@ -802,10 +800,13 @@ async def test_get_mode_read_after_write_uses_pending_overlays_until_reconciled(
         correlation_id=overlay_ids["receiver.main.active.freq_mode.data_mode"],
     )
 
-    assert handler._command_service.pending_overlays(  # noqa: SLF001
-        source="rigctld",
-        session_id=None,
-    ) == ()
+    assert (
+        handler._command_service.pending_overlays(  # noqa: SLF001
+            source="rigctld",
+            session_id=None,
+        )
+        == ()
+    )
 
     after = await handler.execute(get_cmd("get_mode"))
     assert after.values == ["PKTUSB", "2400"]

--- a/tests/test_rigctld_server.py
+++ b/tests/test_rigctld_server.py
@@ -1,3 +1,4 @@
+# mypy: disable-error-code=untyped-decorator
 """Tests for src/rigplane/rigctld/server.py.
 
 Strategy
@@ -12,6 +13,8 @@ Strategy
 from __future__ import annotations
 
 import asyncio
+from collections.abc import AsyncIterator
+from typing import Any, cast
 from unittest.mock import ANY, AsyncMock, MagicMock
 
 import pytest
@@ -46,7 +49,12 @@ _TIMEOUT_BYTES = b"RPRT -5\n"  # ETIMEOUT
 def _addr(server: RigctldServer) -> tuple[str, int]:
     """Return (host, port) for a started server."""
     assert server._server is not None
-    return server._server.sockets[0].getsockname()
+    sockname = server._server.sockets[0].getsockname()
+    assert isinstance(sockname, tuple)
+    host, port = sockname[:2]
+    assert isinstance(host, str)
+    assert isinstance(port, int)
+    return host, port
 
 
 async def _connect(
@@ -87,6 +95,15 @@ class _ContractPrewarmRadio:
 
     async def _set_data_mode(self, on: bool) -> None:
         self.data_mode = on
+
+
+class _CompatHandler:
+    def __init__(self) -> None:
+        self.calls: list[RigctldCommand] = []
+
+    async def execute(self, cmd: RigctldCommand) -> RigctldResponse:
+        self.calls.append(cmd)
+        return _FREQ_RESP
 
 
 # ---------------------------------------------------------------------------
@@ -135,17 +152,17 @@ def handler() -> MagicMock:
 @pytest.fixture
 async def server(
     mock_radio: MagicMock, cfg: RigctldConfig, proto: MagicMock, handler: MagicMock
-) -> RigctldServer:  # type: ignore[misc]
+) -> AsyncIterator[RigctldServer]:
     srv = RigctldServer(mock_radio, cfg, _protocol=proto, _handler=handler)
     await srv.start()
-    yield srv  # type: ignore[misc]
+    yield srv
     await srv.stop()
 
 
 @pytest.fixture
 async def server_serial_radio(
     cfg: RigctldConfig,
-) -> tuple[RigctldServer, SerialMockRadio]:
+) -> AsyncIterator[tuple[RigctldServer, SerialMockRadio]]:
     """RigctldServer running on top of a real SerialMockRadio core."""
     radio = SerialMockRadio()
     await radio.connect()
@@ -271,6 +288,29 @@ class TestAcceptResponse:
         assert call.args == (set_cmd,)
         assert call.kwargs["session_id"] == "rigctld-client-1"
         await _close(w)
+
+    async def test_legacy_handler_execute_without_session_id_still_runs(
+        self, mock_radio: MagicMock, cfg: RigctldConfig, proto: MagicMock
+    ) -> None:
+        compat_handler = _CompatHandler()
+        srv = RigctldServer(
+            mock_radio,
+            cfg,
+            _protocol=proto,
+            _handler=compat_handler,
+        )
+        await srv.start()
+        try:
+            r, w = await _connect(srv)
+            w.write(b"f\n")
+            await w.drain()
+
+            data = await asyncio.wait_for(r.read(4096), timeout=1.0)
+            assert data == _RESPONSE_BYTES
+            assert compat_handler.calls == [_FREQ_CMD]
+            await _close(w)
+        finally:
+            await srv.stop()
 
     async def test_format_response_receives_session(
         self, server: RigctldServer, proto: MagicMock
@@ -804,11 +844,12 @@ class TestRunRigctldServer:
         import rigplane.rigctld.server as server_mod
 
         orig_cls = server_mod.RigctldServer
+        server_mod_any = cast(Any, server_mod)
 
         def _patched_cls(radio: MagicMock, config: RigctldConfig) -> RigctldServer:
             return orig_cls(radio, config, _protocol=proto, _handler=hdl)
 
-        server_mod.RigctldServer = _patched_cls  # type: ignore[assignment]
+        server_mod_any.RigctldServer = _patched_cls
         try:
             task = asyncio.get_event_loop().create_task(
                 run_rigctld_server(mock_radio, host="127.0.0.1", port=0)
@@ -820,7 +861,7 @@ class TestRunRigctldServer:
             except (asyncio.CancelledError, asyncio.TimeoutError):
                 pass
         finally:
-            server_mod.RigctldServer = orig_cls  # type: ignore[assignment]
+            server_mod_any.RigctldServer = orig_cls
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_rigctld_server.py
+++ b/tests/test_rigctld_server.py
@@ -265,7 +265,11 @@ class TestAcceptResponse:
 
         data = await asyncio.wait_for(r.read(4096), timeout=1.0)
         assert data == b"RPRT 0\n"
-        handler.execute.assert_called_once_with(set_cmd)
+        handler.execute.assert_called_once()
+        call = handler.execute.call_args
+        assert call is not None
+        assert call.args == (set_cmd,)
+        assert call.kwargs["session_id"] == "rigctld-client-1"
         await _close(w)
 
     async def test_format_response_receives_session(

--- a/tests/test_state_acquisition_policy.py
+++ b/tests/test_state_acquisition_policy.py
@@ -145,6 +145,12 @@ def test_schema_from_dict_rejects_unknown_and_coerced_values() -> None:
     with pytest.raises(ValueError, match="polling must be a bool"):
         FieldCapability.from_dict({"path": freq, "polling": "false"})
 
+    with pytest.raises(ValueError, match="supportedControls must be a sequence of strings"):
+        FieldCapability.from_dict({"path": freq, "supportedControls": "set_freq"})
+
+    with pytest.raises(ValueError, match="supportedControls must be a sequence of strings"):
+        FieldCapability.from_dict({"path": freq, "supportedControls": [1]})
+
     with pytest.raises(ValueError, match="cadenceSeconds must be a number"):
         AcquisitionPolicy.from_dict({"cadenceSeconds": "1.0"})
 

--- a/tests/test_state_acquisition_policy.py
+++ b/tests/test_state_acquisition_policy.py
@@ -29,6 +29,32 @@ def _write_toml(tmp_path: Path, content: str, name: str = "test.toml") -> Path:
     return path
 
 
+def _minimal_state_acquisition_toml(state_acquisition: str) -> str:
+    return f"""
+    [radio]
+    id = "policy_schema_test"
+    model = "POLICY-SCHEMA-TEST"
+    civ_addr = 0x94
+    receiver_count = 1
+    has_lan = true
+    has_wifi = false
+
+    [capabilities]
+    features = ["audio"]
+
+    [modes]
+    list = ["USB"]
+
+    [filters]
+    list = ["FIL1"]
+
+    [vfo]
+    scheme = "ab"
+
+    {state_acquisition}
+    """
+
+
 def test_radio_acquisition_profile_serializes_capabilities_and_policy() -> None:
     freq = FieldPath.active("main", "freq_mode", "freq_hz")
     s_meter = FieldPath.receiver("main", "meters", "s_meter")
@@ -108,6 +134,29 @@ def test_invalid_capability_and_policy_combinations_are_rejected() -> None:
             )
         },
     )
+
+
+def test_schema_from_dict_rejects_unknown_and_coerced_values() -> None:
+    freq = "receiver.main.active.freq_mode.freq_hz"
+
+    with pytest.raises(ValueError, match="unknown keys.*pollin"):
+        FieldCapability.from_dict({"path": freq, "pollin": True})
+
+    with pytest.raises(ValueError, match="polling must be a bool"):
+        FieldCapability.from_dict({"path": freq, "polling": "false"})
+
+    with pytest.raises(ValueError, match="cadenceSeconds must be a number"):
+        AcquisitionPolicy.from_dict({"cadenceSeconds": "1.0"})
+
+    with pytest.raises(ValueError, match="enabled must be a bool"):
+        AcquisitionPolicy.from_dict(
+            {
+                "adaptiveDecay": {
+                    "enabled": "false",
+                    "idleMultiplier": 2.0,
+                }
+            }
+        )
 
 
 def test_missing_and_unsupported_capabilities_are_explicitly_unavailable() -> None:
@@ -240,6 +289,86 @@ def test_loader_rejects_polling_unsupported_fields(tmp_path: Path) -> None:
 
     with pytest.raises(RigLoadError, match="global.tx_state.power_on"):
         load_rig(_write_toml(tmp_path, toml))
+
+
+def test_loader_rejects_unknown_state_acquisition_keys(
+    tmp_path: Path,
+) -> None:
+    cases: tuple[tuple[str, str], ...] = (
+        (
+            """
+            [state_acquisition]
+            provider = "profile"
+            default_cadence_seconds = 1.0
+            default_freshness_ttl_seconds = 3.0
+            cadance_seconds = 99.0
+            """,
+            r"\[state_acquisition\].*unknown key.*cadance_seconds",
+        ),
+        (
+            """
+            [state_acquisition.capabilities]
+            polling = ["receiver.main.active.freq_mode.freq_hz"]
+            """,
+            r"\[state_acquisition.capabilities\].*unknown key.*polling",
+        ),
+        (
+            """
+            [state_acquisition.field_policies."receiver.main.active.freq_mode.freq_hz"]
+            cadance_seconds = 99.0
+            """,
+            r"\[state_acquisition.field_policies.receiver.main.active.freq_mode.freq_hz\].*unknown key.*cadance_seconds",
+        ),
+    )
+
+    for index, (state_acquisition, message) in enumerate(cases):
+        with pytest.raises(RigLoadError, match=message):
+            load_rig(
+                _write_toml(
+                    tmp_path,
+                    _minimal_state_acquisition_toml(state_acquisition),
+                    name=f"unknown-{index}.toml",
+                )
+            )
+
+
+def test_loader_rejects_coerced_state_acquisition_values(
+    tmp_path: Path,
+) -> None:
+    cases: tuple[tuple[str, str], ...] = (
+        (
+            """
+            [state_acquisition]
+            adaptive_decay = "false"
+            adaptive_decay_idle_multiplier = 2.0
+            """,
+            r"\[state_acquisition\].*adaptive_decay must be a bool",
+        ),
+        (
+            """
+            [state_acquisition]
+            default_cadence_seconds = "1.0"
+            """,
+            r"\[state_acquisition\].*default_cadence_seconds must be a number",
+        ),
+        (
+            """
+            [state_acquisition.field_policies."receiver.main.active.freq_mode.freq_hz"]
+            cadence_seconds = "1.0"
+            """,
+            r"\[state_acquisition.field_policies.receiver.main.active.freq_mode.freq_hz\].*cadence_seconds must be a number",
+        ),
+    )
+
+    for index, (state_acquisition, message) in enumerate(cases):
+        with pytest.raises(RigLoadError, match=message):
+            load_rig(
+                _write_toml(
+                    tmp_path,
+                    _minimal_state_acquisition_toml(state_acquisition),
+                    name=f"coerced-{index}.toml",
+                )
+            )
 
 
 def test_known_profiles_load_with_state_acquisition_compatibility() -> None:

--- a/tests/test_state_acquisition_policy.py
+++ b/tests/test_state_acquisition_policy.py
@@ -146,10 +146,14 @@ def test_schema_from_dict_rejects_unknown_and_coerced_values() -> None:
     with pytest.raises(ValueError, match="polling must be a bool"):
         FieldCapability.from_dict({"path": freq, "polling": "false"})
 
-    with pytest.raises(ValueError, match="supportedControls must be a sequence of strings"):
+    with pytest.raises(
+        ValueError, match="supportedControls must be a sequence of strings"
+    ):
         FieldCapability.from_dict({"path": freq, "supportedControls": "set_freq"})
 
-    with pytest.raises(ValueError, match="supportedControls must be a sequence of strings"):
+    with pytest.raises(
+        ValueError, match="supportedControls must be a sequence of strings"
+    ):
         FieldCapability.from_dict({"path": freq, "supportedControls": [1]})
 
     with pytest.raises(ValueError, match="cadenceSeconds must be a number"):
@@ -172,10 +176,14 @@ def test_schema_from_dict_rejects_unknown_and_coerced_values() -> None:
 def test_field_capability_direct_construction_rejects_coerced_controls() -> None:
     freq = FieldPath.active("main", "freq_mode", "freq_hz")
 
-    with pytest.raises(ValueError, match="supported_controls must be a sequence of strings"):
+    with pytest.raises(
+        ValueError, match="supported_controls must be a sequence of strings"
+    ):
         FieldCapability(path=freq, supported_controls="set_freq")
 
-    with pytest.raises(ValueError, match="supported_controls must be a sequence of strings"):
+    with pytest.raises(
+        ValueError, match="supported_controls must be a sequence of strings"
+    ):
         FieldCapability(path=freq, supported_controls=cast(tuple[str, ...], (123,)))
 
 
@@ -445,7 +453,5 @@ def test_ftx1_profile_declares_slow_control_policies_for_polling_adapter() -> No
     assert ftx1.state_acquisition.capability_for(af_level).can_poll is True
     assert ftx1.state_acquisition.capability_for(squelch).can_poll is True
     assert ftx1.state_acquisition.capability_for(ptt).can_poll is True
-    assert (
-        ftx1.state_acquisition.policy_for(af_level).freshness_ttl_seconds == 120.0
-    )
+    assert ftx1.state_acquisition.policy_for(af_level).freshness_ttl_seconds == 120.0
     assert ftx1.state_acquisition.policy_for(af_level).cadence_seconds == 30.0

--- a/tests/test_state_acquisition_policy.py
+++ b/tests/test_state_acquisition_policy.py
@@ -1,0 +1,257 @@
+"""Capability and acquisition-policy schema for MOR-344."""
+
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from rigplane.core.state_acquisition_policy import (
+    AcquisitionPolicy,
+    AdaptiveDecayPolicy,
+    FieldAvailability,
+    FieldCapability,
+    MeterCoalescingPolicy,
+    RadioAcquisitionProfile,
+)
+from rigplane.core.state_pipeline_contracts import FieldPath
+from rigplane.profiles import get_radio_profile
+from rigplane.rig_loader import RigLoadError, discover_rigs, load_rig
+
+RIGS_DIR = Path(__file__).resolve().parent.parent / "rigs"
+
+
+def _write_toml(tmp_path: Path, content: str, name: str = "test.toml") -> Path:
+    path = tmp_path / name
+    path.write_text(textwrap.dedent(content))
+    return path
+
+
+def test_radio_acquisition_profile_serializes_capabilities_and_policy() -> None:
+    freq = FieldPath.active("main", "freq_mode", "freq_hz")
+    s_meter = FieldPath.receiver("main", "meters", "s_meter")
+    profile = RadioAcquisitionProfile(
+        provider="icom_civ",
+        capabilities=(
+            FieldCapability(
+                path=freq,
+                unsolicited_push=True,
+                polling=True,
+                command_response_observable=True,
+                supported_controls=("set_freq",),
+            ),
+            FieldCapability(path=s_meter, polling=True, stream_like=True),
+        ),
+        default_policy=AcquisitionPolicy(
+            cadence_seconds=2.0,
+            freshness_ttl_seconds=6.0,
+            reconciliation_priority="unsolicited",
+            adaptive_decay=AdaptiveDecayPolicy(
+                enabled=True,
+                idle_multiplier=4.0,
+                max_cadence_seconds=30.0,
+            ),
+            meter_coalescing=MeterCoalescingPolicy(window_seconds=0.2),
+            external_cat_pause="pause_polling",
+        ),
+    )
+
+    payload = json.loads(json.dumps(profile.to_dict()))
+    restored = RadioAcquisitionProfile.from_dict(payload)
+
+    assert restored == profile
+    assert restored.capability_for(freq).can_poll is True
+    assert restored.capability_for(s_meter).stream_like is True
+    assert restored.policy_for(freq).freshness_ttl_seconds == 6.0
+
+
+def test_invalid_capability_and_policy_combinations_are_rejected() -> None:
+    freq = FieldPath.active("main", "freq_mode", "freq_hz")
+    meter = FieldPath.receiver("main", "meters", "s_meter")
+
+    with pytest.raises(ValueError, match="unavailable fields cannot be acquired"):
+        FieldCapability(
+            path=freq,
+            availability=FieldAvailability.UNSUPPORTED,
+            polling=True,
+        )
+
+    with pytest.raises(ValueError, match="stream_like fields must be meters"):
+        FieldCapability(path=freq, stream_like=True)
+
+    with pytest.raises(ValueError, match="freshness_ttl_seconds"):
+        AcquisitionPolicy(cadence_seconds=5.0, freshness_ttl_seconds=2.0)
+
+    with pytest.raises(ValueError, match="meter_coalescing requires meter fields"):
+        RadioAcquisitionProfile(
+            provider="icom_civ",
+            capabilities=(FieldCapability(path=freq, polling=True),),
+            field_policies={
+                freq: AcquisitionPolicy(
+                    cadence_seconds=1.0,
+                    freshness_ttl_seconds=2.0,
+                    meter_coalescing=MeterCoalescingPolicy(window_seconds=0.1),
+                )
+            },
+        )
+
+    RadioAcquisitionProfile(
+        provider="icom_civ",
+        capabilities=(FieldCapability(path=meter, polling=True, stream_like=True),),
+        field_policies={
+            meter: AcquisitionPolicy(
+                cadence_seconds=0.2,
+                freshness_ttl_seconds=1.0,
+                meter_coalescing=MeterCoalescingPolicy(window_seconds=0.1),
+            )
+        },
+    )
+
+
+def test_missing_and_unsupported_capabilities_are_explicitly_unavailable() -> None:
+    freq = FieldPath.active("main", "freq_mode", "freq_hz")
+    power = FieldPath.global_("tx_state", "power_on")
+    profile = RadioAcquisitionProfile(
+        provider="external_rigctld",
+        capabilities=(
+            FieldCapability(
+                path=power,
+                availability=FieldAvailability.UNSUPPORTED,
+                diagnostic="Hamlib model does not expose power control",
+            ),
+        ),
+    )
+
+    missing = profile.capability_for(freq)
+    unsupported = profile.capability_for(power)
+
+    assert missing.availability is FieldAvailability.UNKNOWN
+    assert missing.can_poll is False
+    assert "missing capability metadata" in missing.diagnostic
+    assert unsupported.availability is FieldAvailability.UNSUPPORTED
+    assert unsupported.can_poll is False
+    assert profile.pollable_paths() == ()
+
+
+def test_loader_parses_x6200_like_tuning_policy_without_delivery_branches(
+    tmp_path: Path,
+) -> None:
+    toml = """
+    [radio]
+    id = "x6200_like"
+    model = "X6200-LIKE"
+    civ_addr = 0xA4
+    receiver_count = 1
+    has_lan = false
+    has_wifi = true
+
+    [capabilities]
+    features = ["audio", "meters"]
+
+    [modes]
+    list = ["USB"]
+
+    [filters]
+    list = ["FIL1"]
+
+    [vfo]
+    scheme = "ab"
+
+    [[freq_ranges.ranges]]
+    label = "HF"
+    start_hz = 100000
+    end_hz = 54000000
+
+    [commands]
+    get_freq = [0x03]
+    set_freq = [0x05]
+    get_mode = [0x04]
+    set_mode = [0x06]
+    get_selected_mode = [0x26, 0x00]
+    set_selected_mode = [0x26, 0x00]
+
+    [state_acquisition]
+    provider = "xiegu_civ"
+    default_cadence_seconds = 2.0
+    default_freshness_ttl_seconds = 8.0
+    default_reconciliation_priority = "poll"
+    external_cat_pause = "pause_polling"
+
+    [state_acquisition.capabilities]
+    polling_only = [
+        "receiver.main.active.freq_mode.freq_hz",
+        "receiver.main.active.freq_mode.mode",
+    ]
+    command_response_observable = [
+        "receiver.main.active.freq_mode.freq_hz",
+        "receiver.main.active.freq_mode.mode",
+    ]
+    supported_controls = [
+        "receiver.main.active.freq_mode.freq_hz",
+        "receiver.main.active.freq_mode.mode",
+    ]
+
+    [state_acquisition.field_policies."receiver.main.active.freq_mode.mode"]
+    cadence_seconds = 1.0
+    freshness_ttl_seconds = 4.0
+    reconciliation_priority = "command_response"
+    external_cat_pause = "pause_polling"
+    """
+
+    profile = load_rig(_write_toml(tmp_path, toml)).to_profile()
+    policy = profile.state_acquisition
+    mode = FieldPath.active("main", "freq_mode", "mode")
+
+    assert policy is not None
+    assert policy.provider == "xiegu_civ"
+    assert policy.capability_for(mode).command_response_observable is True
+    assert policy.policy_for(mode).reconciliation_priority == "command_response"
+    assert profile.set_mode_via_selected is True
+
+
+def test_loader_rejects_polling_unsupported_fields(tmp_path: Path) -> None:
+    toml = """
+    [radio]
+    id = "bad_policy"
+    model = "BAD-POLICY"
+    civ_addr = 0x94
+    receiver_count = 1
+    has_lan = true
+    has_wifi = false
+
+    [capabilities]
+    features = ["audio"]
+
+    [modes]
+    list = ["USB"]
+
+    [filters]
+    list = ["FIL1"]
+
+    [vfo]
+    scheme = "ab"
+
+    [state_acquisition.capabilities]
+    polling_only = ["global.tx_state.power_on"]
+    unsupported = ["global.tx_state.power_on"]
+    """
+
+    with pytest.raises(RigLoadError, match="global.tx_state.power_on"):
+        load_rig(_write_toml(tmp_path, toml))
+
+
+def test_known_profiles_load_with_state_acquisition_compatibility() -> None:
+    profiles = {rig.model: rig.to_profile() for rig in discover_rigs(RIGS_DIR).values()}
+
+    for expected in ("IC-7610", "FTX-1", "X6200"):
+        assert expected in profiles
+        assert profiles[expected].state_acquisition is not None
+
+    x6200 = get_radio_profile("X6200")
+    mode = FieldPath.active("main", "freq_mode", "mode")
+    assert x6200.state_acquisition is not None
+    assert x6200.state_acquisition.policy_for(mode).reconciliation_priority == (
+        "command_response"
+    )

--- a/tests/test_state_acquisition_policy.py
+++ b/tests/test_state_acquisition_policy.py
@@ -168,6 +168,16 @@ def test_schema_from_dict_rejects_unknown_and_coerced_values() -> None:
         RadioAcquisitionProfile.from_dict({"provider": 123})
 
 
+def test_field_capability_direct_construction_rejects_coerced_controls() -> None:
+    freq = FieldPath.active("main", "freq_mode", "freq_hz")
+
+    with pytest.raises(ValueError, match="supported_controls must be a sequence of strings"):
+        FieldCapability(path=freq, supported_controls="set_freq")
+
+    with pytest.raises(ValueError, match="supported_controls must be a sequence of strings"):
+        FieldCapability(path=freq, supported_controls=(123,))  # type: ignore[arg-type]
+
+
 def test_missing_and_unsupported_capabilities_are_explicitly_unavailable() -> None:
     freq = FieldPath.active("main", "freq_mode", "freq_hz")
     power = FieldPath.global_("tx_state", "power_on")

--- a/tests/test_state_acquisition_policy.py
+++ b/tests/test_state_acquisition_policy.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import textwrap
 from pathlib import Path
+from typing import cast
 
 import pytest
 
@@ -175,7 +176,7 @@ def test_field_capability_direct_construction_rejects_coerced_controls() -> None
         FieldCapability(path=freq, supported_controls="set_freq")
 
     with pytest.raises(ValueError, match="supported_controls must be a sequence of strings"):
-        FieldCapability(path=freq, supported_controls=(123,))  # type: ignore[arg-type]
+        FieldCapability(path=freq, supported_controls=cast(tuple[str, ...], (123,)))
 
 
 def test_missing_and_unsupported_capabilities_are_explicitly_unavailable() -> None:
@@ -403,3 +404,20 @@ def test_known_profiles_load_with_state_acquisition_compatibility() -> None:
     assert x6200.state_acquisition.policy_for(mode).reconciliation_priority == (
         "command_response"
     )
+
+
+def test_ftx1_profile_declares_slow_control_policies_for_polling_adapter() -> None:
+    ftx1 = get_radio_profile("FTX-1")
+    assert ftx1.state_acquisition is not None
+
+    af_level = FieldPath.receiver("main", "operator_controls", "af_level")
+    squelch = FieldPath.receiver("sub", "operator_controls", "squelch")
+    ptt = FieldPath.global_("tx_state", "ptt")
+
+    assert ftx1.state_acquisition.capability_for(af_level).can_poll is True
+    assert ftx1.state_acquisition.capability_for(squelch).can_poll is True
+    assert ftx1.state_acquisition.capability_for(ptt).can_poll is True
+    assert (
+        ftx1.state_acquisition.policy_for(af_level).freshness_ttl_seconds == 120.0
+    )
+    assert ftx1.state_acquisition.policy_for(af_level).cadence_seconds == 30.0

--- a/tests/test_state_acquisition_policy.py
+++ b/tests/test_state_acquisition_policy.py
@@ -406,6 +406,34 @@ def test_known_profiles_load_with_state_acquisition_compatibility() -> None:
     )
 
 
+def test_known_profiles_stream_like_meters_use_fast_non_decaying_policies() -> None:
+    for model in ("IC-7610", "FTX-1", "X6200"):
+        profile = get_radio_profile(model)
+        acquisition = profile.state_acquisition
+        assert acquisition is not None
+        assert acquisition.default_policy.meter_coalescing is not None
+
+        stream_like = tuple(
+            capability
+            for capability in acquisition.capabilities
+            if capability.stream_like
+        )
+        assert stream_like
+
+        for capability in stream_like:
+            policy = acquisition.policy_for(capability.path)
+            assert policy.cadence_seconds is not None
+            assert policy.cadence_seconds <= 0.25
+            assert policy.freshness_ttl_seconds is not None
+            assert policy.freshness_ttl_seconds <= 1.0
+            assert policy.adaptive_decay.enabled is False
+            assert policy.meter_coalescing is not None
+            assert (
+                policy.meter_coalescing.window_seconds
+                == acquisition.default_policy.meter_coalescing.window_seconds
+            )
+
+
 def test_ftx1_profile_declares_slow_control_policies_for_polling_adapter() -> None:
     ftx1 = get_radio_profile("FTX-1")
     assert ftx1.state_acquisition is not None

--- a/tests/test_state_acquisition_policy.py
+++ b/tests/test_state_acquisition_policy.py
@@ -164,6 +164,9 @@ def test_schema_from_dict_rejects_unknown_and_coerced_values() -> None:
             }
         )
 
+    with pytest.raises(ValueError, match="provider must be a string"):
+        RadioAcquisitionProfile.from_dict({"provider": 123})
+
 
 def test_missing_and_unsupported_capabilities_are_explicitly_unavailable() -> None:
     freq = FieldPath.active("main", "freq_mode", "freq_hz")

--- a/tests/test_state_pipeline_contracts.py
+++ b/tests/test_state_pipeline_contracts.py
@@ -167,7 +167,11 @@ def test_observation_and_changeset_serialization_round_trip() -> None:
 @pytest.mark.parametrize(  # type: ignore[untyped-decorator]
     "payload",
     [
-        {"path": "receiver.main.meters.s_meter", "source": {}, "timestampMonotonic": 1.0},
+        {
+            "path": "receiver.main.meters.s_meter",
+            "source": {},
+            "timestampMonotonic": 1.0,
+        },
         {"path": "receiver.main.meters.s_meter", "previous": 1},
         {"path": "receiver.main.meters.s_meter", "current": 2},
     ],

--- a/tests/test_state_pipeline_contracts.py
+++ b/tests/test_state_pipeline_contracts.py
@@ -1,0 +1,207 @@
+"""Contracts for backend-neutral radio state pipeline values."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from rigplane.core.state_pipeline_contracts import (
+    CapabilityMetadata,
+    DEFAULT_FIELD_REGISTRY,
+    ChangeSet,
+    CommandIntent,
+    CommandLifecycleEvent,
+    FieldChange,
+    FieldFamily,
+    FieldPath,
+    FieldRegistry,
+    Observation,
+    SourceMetadata,
+)
+
+
+@pytest.mark.parametrize(  # type: ignore[untyped-decorator]
+    ("path", "expected"),
+    [
+        (
+            "receiver.main.slot.A.freq_mode.freq_hz",
+            FieldPath.vfo_slot("main", "A", "freq_mode", "freq_hz"),
+        ),
+        (
+            "receiver.sub.active.freq_mode.mode",
+            FieldPath.active("sub", "freq_mode", "mode"),
+        ),
+        ("receiver.main.vfo.active_slot", FieldPath.active_slot("main")),
+        ("global.tx_state.ptt", FieldPath.global_("tx_state", "ptt")),
+        (
+            "receiver.main.meters.s_meter",
+            FieldPath.receiver("main", "meters", "s_meter"),
+        ),
+        (
+            "scope_controls.receiver.main.display.span",
+            FieldPath.scope_control("display", "span", receiver_id="main"),
+        ),
+        (
+            "scope_controls.global.display.speed",
+            FieldPath.scope_control("display", "speed"),
+        ),
+    ],
+)
+def test_field_path_parse_and_format_round_trip(
+    path: str,
+    expected: FieldPath,
+) -> None:
+    parsed = FieldPath.parse(path)
+
+    assert parsed == expected
+    assert str(parsed) == path
+    assert parsed.to_dict()["path"] == path
+    assert FieldPath.from_dict(parsed.to_dict()) == expected
+
+
+@pytest.mark.parametrize(  # type: ignore[untyped-decorator]
+    "path",
+    [
+        "",
+        "receiver.main.freq_hz",
+        "receiver.main.slot.C.freq_mode.freq_hz",
+        "receiver.main.active_slot",
+        "global.ptt",
+        "scope_controls.main.display.span",
+        "receiver.MAIN.meters.s_meter",
+        "receiver.main.meters.s-meter",
+    ],
+)
+def test_invalid_field_paths_are_rejected(path: str) -> None:
+    with pytest.raises(ValueError):
+        FieldPath.parse(path)
+
+
+def test_registry_rejects_duplicate_and_ambiguous_paths() -> None:
+    first = FieldPath.global_("tx_state", "ptt")
+    duplicate = FieldPath.parse("global.tx_state.ptt")
+    ambiguous = FieldPath.global_("slow_state", "ptt")
+
+    with pytest.raises(ValueError, match="duplicate field path"):
+        FieldRegistry.from_paths([first, duplicate])
+
+    with pytest.raises(ValueError, match="ambiguous field name"):
+        FieldRegistry.from_paths([first, ambiguous])
+
+
+def test_default_registry_contains_representative_state_families() -> None:
+    examples = {
+        "frequency": FieldPath.active("main", "freq_mode", "freq_hz"),
+        "mode": FieldPath.active("main", "freq_mode", "mode"),
+        "s-meter": FieldPath.receiver("main", "meters", "s_meter"),
+        "alc": FieldPath.global_("meters", "alc"),
+        "power": FieldPath.global_("meters", "power"),
+        "nr": FieldPath.receiver("main", "operator_toggles", "nr"),
+        "nb": FieldPath.receiver("main", "operator_toggles", "nb"),
+        "volume": FieldPath.receiver("main", "operator_controls", "af_level"),
+        "rf gain": FieldPath.receiver("main", "operator_controls", "rf_gain"),
+        "pbt": FieldPath.receiver("main", "operator_controls", "pbt_inner"),
+    }
+
+    for path in examples.values():
+        assert DEFAULT_FIELD_REGISTRY.require(path).path == path
+
+    assert (
+        DEFAULT_FIELD_REGISTRY.require(examples["s-meter"]).family is FieldFamily.METERS
+    )
+    assert DEFAULT_FIELD_REGISTRY.require(examples["alc"]).family is FieldFamily.METERS
+    assert (
+        DEFAULT_FIELD_REGISTRY.require(examples["frequency"]).family
+        is FieldFamily.FREQ_MODE
+    )
+    assert (
+        DEFAULT_FIELD_REGISTRY.require(examples["volume"]).family
+        is FieldFamily.OPERATOR_CONTROLS
+    )
+
+
+def test_observation_and_changeset_serialization_round_trip() -> None:
+    source = SourceMetadata(
+        source="civ_unsolicited",
+        provider="icom",
+        transport="lan",
+        native_id="0x15/0x02",
+    )
+    observation = Observation(
+        path=FieldPath.receiver("main", "meters", "s_meter"),
+        value=82,
+        source=source,
+        timestamp_monotonic=42.5,
+        quality=("confirmed",),
+        correlation_id="rx-1",
+        max_age=0.5,
+    )
+    changeset = ChangeSet(
+        revision=7,
+        freshness_revision=3,
+        observation_seq=12,
+        changes=(
+            FieldChange(
+                path=observation.path,
+                previous=80,
+                current=82,
+            ),
+        ),
+        timestamp_monotonic=42.5,
+        sources=(source,),
+        coalesced=False,
+    )
+
+    payload = json.loads(json.dumps(changeset.to_dict()))
+
+    assert (
+        Observation.from_dict(json.loads(json.dumps(observation.to_dict())))
+        == observation
+    )
+    assert ChangeSet.from_dict(payload) == changeset
+
+
+def test_command_intent_and_lifecycle_event_serialization_round_trip() -> None:
+    intent = CommandIntent(
+        id="cmd-123",
+        name="set_freq",
+        params={"freq_hz": 14_074_000},
+        source="rigctld",
+        target=FieldPath.active("main", "freq_mode", "freq_hz"),
+        priority="user",
+        timeout=2.0,
+        pending_policy="scoped",
+        expected_observations=(FieldPath.active("main", "freq_mode", "freq_hz"),),
+    )
+    event = CommandLifecycleEvent(
+        command_id=intent.id,
+        state="confirmed",
+        timestamp_monotonic=45.0,
+        source="rigctld",
+        target=intent.target,
+        message="confirmed by matching observation",
+        details={"revision": 8},
+    )
+
+    assert CommandIntent.from_dict(json.loads(json.dumps(intent.to_dict()))) == intent
+    assert (
+        CommandLifecycleEvent.from_dict(json.loads(json.dumps(event.to_dict())))
+        == event
+    )
+
+
+def test_capability_metadata_serialization_round_trip() -> None:
+    capability = CapabilityMetadata(
+        path=FieldPath.active("main", "freq_mode", "freq_hz"),
+        sources=("civ_unsolicited", "poll_response"),
+        readable=True,
+        writable=True,
+        unsolicited=True,
+        max_age=2.5,
+    )
+
+    assert (
+        CapabilityMetadata.from_dict(json.loads(json.dumps(capability.to_dict())))
+        == capability
+    )

--- a/tests/test_state_pipeline_contracts.py
+++ b/tests/test_state_pipeline_contracts.py
@@ -69,6 +69,8 @@ def test_field_path_parse_and_format_round_trip(
         "receiver.main.active_slot",
         "global.ptt",
         "scope_controls.main.display.span",
+        "scope_controls.global.meters.s_meter",
+        "scope_controls.receiver.main.meters.s_meter",
         "receiver.MAIN.meters.s_meter",
         "receiver.main.meters.s-meter",
     ],
@@ -160,6 +162,49 @@ def test_observation_and_changeset_serialization_round_trip() -> None:
         == observation
     )
     assert ChangeSet.from_dict(payload) == changeset
+
+
+@pytest.mark.parametrize(  # type: ignore[untyped-decorator]
+    "payload",
+    [
+        {"path": "receiver.main.meters.s_meter", "source": {}, "timestampMonotonic": 1.0},
+        {"path": "receiver.main.meters.s_meter", "previous": 1},
+        {"path": "receiver.main.meters.s_meter", "current": 2},
+    ],
+)
+def test_value_bearing_contracts_reject_missing_required_values(
+    payload: dict[str, object],
+) -> None:
+    if "source" in payload:
+        with pytest.raises(KeyError):
+            Observation.from_dict(payload)
+    else:
+        with pytest.raises(KeyError):
+            FieldChange.from_dict(payload)
+
+
+def test_contract_bool_fields_reject_non_bool_payloads() -> None:
+    capability_payload = CapabilityMetadata(
+        path=FieldPath.active("main", "freq_mode", "freq_hz"),
+        sources=("civ_unsolicited",),
+    ).to_dict()
+    capability_payload["readable"] = "false"
+
+    changeset_payload = ChangeSet(
+        revision=1,
+        freshness_revision=1,
+        observation_seq=1,
+        changes=(),
+        timestamp_monotonic=1.0,
+        sources=(),
+        coalesced=False,
+    ).to_dict()
+    changeset_payload["coalesced"] = "false"
+
+    with pytest.raises(TypeError):
+        CapabilityMetadata.from_dict(capability_payload)
+    with pytest.raises(TypeError):
+        ChangeSet.from_dict(changeset_payload)
 
 
 def test_command_intent_and_lifecycle_event_serialization_round_trip() -> None:

--- a/tests/test_state_pipeline_diagnostics.py
+++ b/tests/test_state_pipeline_diagnostics.py
@@ -1,0 +1,97 @@
+"""Baseline diagnostics for legacy state/revision/cache paths."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from rigplane.core._bounded_queue import BoundedQueue
+from rigplane.core._state_cache import StateCache
+from rigplane.core.state_diagnostics import StateDiagnosticsRecorder
+from rigplane.radio_state import RadioState
+from rigplane.runtime._civ_rx import CivRuntime
+from rigplane.types import CivFrame
+from rigplane.web.server import WebConfig, WebServer
+
+
+class _FakeCivHost:
+    def __init__(self, diagnostics: StateDiagnosticsRecorder) -> None:
+        self._radio_state = RadioState()
+        self._state_cache = StateCache()
+        self._on_state_change = self._on_notify
+        self._notifications: list[tuple[str, dict[str, Any]]] = []
+        self._state_diagnostics = diagnostics
+        self._last_freq_hz = None
+        self._last_mode = None
+        self._last_vfo = None
+        self._filter_width = None
+
+    def _on_notify(self, name: str, data: dict[str, Any]) -> None:
+        self._notifications.append((name, data))
+
+
+def test_state_diagnostics_are_inert_until_enabled() -> None:
+    recorder = StateDiagnosticsRecorder()
+
+    recorder.record("direct_state_write", "unit", field="main.s_meter")
+
+    assert recorder.snapshot()["counts"] == {}
+    assert recorder.events() == ()
+
+
+def test_state_diagnostics_record_events_without_mutating_payloads() -> None:
+    recorder = StateDiagnosticsRecorder(enabled=True)
+    payload = {"field": "main.s_meter", "value": 42}
+
+    event = recorder.record("direct_state_write", "unit", **payload)
+
+    payload["value"] = 99
+    assert event is not None
+    assert event.kind == "direct_state_write"
+    assert event.source == "unit"
+    assert event.details == {"field": "main.s_meter", "value": 42}
+    assert recorder.snapshot()["counts"] == {"direct_state_write": 1}
+
+
+def test_civ_meter_write_records_diagnostic_without_notify_or_revision() -> None:
+    diagnostics = StateDiagnosticsRecorder(enabled=True)
+    host = _FakeCivHost(diagnostics)
+    runtime = CivRuntime(host)  # type: ignore[arg-type]
+    frame = CivFrame(to_addr=0xE0, from_addr=0x98, command=0x15, sub=0x02, data=b"\x00\x42")
+
+    runtime._update_state_cache_from_frame(frame)
+
+    assert host._radio_state.main.s_meter == 42
+    assert host._notifications == []
+    snapshot = diagnostics.snapshot()
+    assert snapshot["counts"] == {"direct_state_write": 1}
+    assert diagnostics.events()[0].details["field_family"] == "meters"
+
+
+def test_web_baseline_meter_write_waits_for_unrelated_delivery_trigger() -> None:
+    server = WebServer(config=WebConfig(state_diagnostics=True))
+    queue: BoundedQueue[dict[str, Any]] = BoundedQueue(maxsize=8)
+    server.register_control_event_queue(queue)
+
+    server._radio_state.main.s_meter = 42
+    server.state_diagnostics.record(
+        "direct_state_write",
+        "test",
+        field="main.s_meter",
+        field_family="meters",
+        revision=server.build_public_state()["revision"],
+    )
+
+    assert queue.empty()
+    assert server.build_public_state()["main"]["sMeter"] == 42
+    assert server.build_public_state()["revision"] == 0
+
+    server._on_radio_state_change("nb_changed", {"on": True})
+
+    queued = queue.get_nowait()
+    assert queued["type"] == "event"
+    queued = queue.get_nowait()
+    assert queued["type"] == "state_update"
+    assert server.state_diagnostics.snapshot()["counts"] == {
+        "direct_state_write": 1,
+        "web_delivery_trigger": 1,
+    }

--- a/tests/test_state_pipeline_diagnostics.py
+++ b/tests/test_state_pipeline_diagnostics.py
@@ -56,7 +56,9 @@ def test_civ_meter_write_records_diagnostic_without_notify_or_revision() -> None
     diagnostics = StateDiagnosticsRecorder(enabled=True)
     host = _FakeCivHost(diagnostics)
     runtime = CivRuntime(host)  # type: ignore[arg-type]
-    frame = CivFrame(to_addr=0xE0, from_addr=0x98, command=0x15, sub=0x02, data=b"\x00\x42")
+    frame = CivFrame(
+        to_addr=0xE0, from_addr=0x98, command=0x15, sub=0x02, data=b"\x00\x42"
+    )
 
     runtime._update_state_cache_from_frame(frame)
 
@@ -67,7 +69,9 @@ def test_civ_meter_write_records_diagnostic_without_notify_or_revision() -> None
     assert diagnostics.events()[0].details["field_family"] == "meters"
 
 
-def test_web_meter_write_delivers_state_store_revision_without_unrelated_trigger() -> None:
+def test_web_meter_write_delivers_state_store_revision_without_unrelated_trigger() -> (
+    None
+):
     server = WebServer(config=WebConfig(state_diagnostics=True))
     queue: BoundedQueue[dict[str, Any]] = BoundedQueue(maxsize=8)
     server.register_control_event_queue(queue)

--- a/tests/test_state_pipeline_diagnostics.py
+++ b/tests/test_state_pipeline_diagnostics.py
@@ -67,7 +67,7 @@ def test_civ_meter_write_records_diagnostic_without_notify_or_revision() -> None
     assert diagnostics.events()[0].details["field_family"] == "meters"
 
 
-def test_web_baseline_meter_write_waits_for_unrelated_delivery_trigger() -> None:
+def test_web_meter_write_delivers_state_store_revision_without_unrelated_trigger() -> None:
     server = WebServer(config=WebConfig(state_diagnostics=True))
     queue: BoundedQueue[dict[str, Any]] = BoundedQueue(maxsize=8)
     server.register_control_event_queue(queue)
@@ -81,16 +81,21 @@ def test_web_baseline_meter_write_waits_for_unrelated_delivery_trigger() -> None
         revision=server.build_public_state()["revision"],
     )
 
-    assert queue.empty()
-    assert server.build_public_state()["main"]["sMeter"] == 42
-    assert server.build_public_state()["revision"] == 0
+    payload = server.build_public_state()
+    assert payload["main"]["sMeter"] == 42
+    assert payload["revision"] == 1
+    assert payload["stateRevision"] == 1
+    assert payload["freshnessRevision"] == 1
 
-    server._on_radio_state_change("nb_changed", {"on": True})
+    server._broadcast_state_update()
 
-    queued = queue.get_nowait()
-    assert queued["type"] == "event"
     queued = queue.get_nowait()
     assert queued["type"] == "state_update"
+    assert queued["data"]["type"] == "full"
+    assert queued["data"]["stateRevision"] == 1
+    assert queued["data"]["freshnessRevision"] == 1
+    assert queued["data"]["data"]["main"]["sMeter"] == 42
+    assert queue.empty()
     assert server.state_diagnostics.snapshot()["counts"] == {
         "direct_state_write": 1,
         "web_delivery_trigger": 1,

--- a/tests/test_state_pipeline_harness.py
+++ b/tests/test_state_pipeline_harness.py
@@ -240,18 +240,55 @@ def test_backend_variants_and_pending_overlays_are_scoped() -> None:
         value=7_074_000,
         ttl=1.0,
     )
+    same_value_other_command = overlays.put(
+        source="rigctld",
+        session_id="rig-1",
+        command_id="cmd-rig-later",
+        path=MAIN_FREQ,
+        value=7_074_000,
+        ttl=1.0,
+    )
 
-    assert overlays.visible_value(source="websocket", session_id="web-1", path=MAIN_FREQ) == (
-        14_074_000
-    )
-    assert overlays.visible_value(source="rigctld", session_id="rig-1", path=MAIN_FREQ) == (
-        7_074_000
-    )
-    assert overlays.confirm(MAIN_FREQ, 7_074_000) == [rigctld]
-    assert overlays.visible_value(source="websocket", session_id="web-1", path=MAIN_FREQ) == (
-        14_074_000
-    )
+    assert overlays.visible_value(
+        source="websocket",
+        session_id="web-1",
+        command_id="cmd-web",
+        path=MAIN_FREQ,
+    ) == 14_074_000
+    assert overlays.visible_value(
+        source="rigctld",
+        session_id="rig-1",
+        command_id="cmd-rig",
+        path=MAIN_FREQ,
+    ) == 7_074_000
+    assert overlays.confirm(
+        source="rigctld",
+        session_id="rig-1",
+        command_id="cmd-rig",
+        path=MAIN_FREQ,
+        value=7_074_000,
+    ) == [rigctld]
+    assert overlays.visible_value(
+        source="websocket",
+        session_id="web-1",
+        command_id="cmd-web",
+        path=MAIN_FREQ,
+    ) == 14_074_000
+    assert overlays.visible_value(
+        source="rigctld",
+        session_id="rig-1",
+        command_id="cmd-rig-later",
+        path=MAIN_FREQ,
+    ) == 7_074_000
 
     clock.advance(1.001)
-    assert overlays.expire_due() == [web]
-    assert overlays.visible_value(source="websocket", session_id="web-1", path=MAIN_FREQ) is None
+    assert overlays.expire_due() == [web, same_value_other_command]
+    assert (
+        overlays.visible_value(
+            source="websocket",
+            session_id="web-1",
+            command_id="cmd-web",
+            path=MAIN_FREQ,
+        )
+        is None
+    )

--- a/tests/test_state_pipeline_harness.py
+++ b/tests/test_state_pipeline_harness.py
@@ -1,0 +1,257 @@
+"""Self-tests and examples for the radio state pipeline test harness."""
+
+from __future__ import annotations
+
+from support.state_pipeline import (
+    FakeAcquisitionScheduler,
+    FakeCivPushBackend,
+    FakeClock,
+    FakeCommandResponseBackend,
+    FakeDroppedUnsolicitedBackend,
+    FakeExternalRigctldClientBackend,
+    FakePendingOverlayStore,
+    FakePollingOnlyBackend,
+    FakeStatePipeline,
+    FakeYaesuLikeBackend,
+    FieldPath,
+    assert_consumer_delta,
+    assert_no_consumer_delta,
+    assert_revision_counters,
+)
+
+
+MAIN_FREQ = FieldPath.receiver("main", "active", "freq_mode", "freq_hz")
+MAIN_MODE = FieldPath.receiver("main", "active", "freq_mode", "mode")
+MAIN_S_METER = FieldPath.receiver("main", None, "meters", "s_meter")
+
+
+def test_fake_observations_and_command_responses_are_deterministic() -> None:
+    clock = FakeClock(start=100.0)
+    pipeline = FakeStatePipeline(clock=clock)
+    backend = FakeCommandResponseBackend(clock=clock)
+
+    freq_observation = backend.command_response(
+        MAIN_FREQ,
+        14_074_000,
+        correlation_id="cmd-1",
+    )
+    first = pipeline.apply(freq_observation)
+
+    clock.advance(0.250)
+    mode_observation = backend.command_response(
+        MAIN_MODE,
+        "USB",
+        correlation_id="cmd-2",
+    )
+    second = pipeline.apply(mode_observation)
+
+    assert first is not None
+    assert second is not None
+    assert first.observation_seq == 1
+    assert first.state_revision == 1
+    assert first.timestamp_monotonic == 100.0
+    assert second.observation_seq == 2
+    assert second.state_revision == 2
+    assert second.timestamp_monotonic == 100.250
+    assert backend.command_log == ["cmd-1", "cmd-2"]
+    assert_revision_counters(
+        pipeline,
+        state_revision=2,
+        freshness_revision=2,
+        observation_seq=2,
+    )
+
+
+def test_fake_time_drives_freshness_and_acquisition_scheduling() -> None:
+    clock = FakeClock(start=20.0)
+    pipeline = FakeStatePipeline(clock=clock)
+    scheduler = FakeAcquisitionScheduler(clock=clock)
+
+    pipeline.apply(
+        FakeCommandResponseBackend(clock=clock).command_response(
+            MAIN_FREQ,
+            7_074_000,
+            max_age=1.0,
+        )
+    )
+    request = scheduler.ensure_fresh(
+        [MAIN_FREQ],
+        max_age=0.5,
+        timeout=2.0,
+        reason="web-snapshot",
+    )
+    duplicate = scheduler.ensure_fresh(
+        [MAIN_FREQ],
+        max_age=0.5,
+        timeout=2.0,
+        reason="rigctld-get",
+    )
+
+    assert duplicate is request
+    assert scheduler.requests == [request]
+    assert scheduler.due_requests() == []
+    clock.advance(0.500)
+    assert scheduler.due_requests() == [request]
+    assert pipeline.mark_stale_due() == []
+
+    clock.advance(0.501)
+    transitions = pipeline.mark_stale_due()
+
+    assert [(item.path, item.previous, item.current) for item in transitions] == [
+        (MAIN_FREQ, "fresh", "stale")
+    ]
+    assert_revision_counters(
+        pipeline,
+        state_revision=1,
+        freshness_revision=2,
+        observation_seq=1,
+    )
+
+
+def test_dropped_unsolicited_event_and_poll_response_are_deterministic() -> None:
+    clock = FakeClock(start=0.0)
+    pipeline = FakeStatePipeline(clock=clock)
+    backend = FakeDroppedUnsolicitedBackend(clock=clock)
+
+    pipeline.apply(backend.unsolicited(MAIN_FREQ, 14_074_000, max_age=1.0))
+    backend.drop_next_unsolicited(MAIN_FREQ)
+
+    dropped = backend.unsolicited(MAIN_FREQ, 14_075_000, max_age=1.0)
+    assert dropped is None
+    assert pipeline.snapshot()[MAIN_FREQ] == 14_074_000
+
+    clock.advance(1.100)
+    assert pipeline.mark_stale_due()[0].path == MAIN_FREQ
+    reconciliation = pipeline.apply(backend.poll_response(MAIN_FREQ, 14_075_000))
+
+    assert reconciliation is not None
+    assert_consumer_delta(
+        reconciliation,
+        path=MAIN_FREQ,
+        previous=14_074_000,
+        current=14_075_000,
+    )
+    assert pipeline.snapshot()[MAIN_FREQ] == 14_075_000
+    assert_revision_counters(
+        pipeline,
+        state_revision=2,
+        freshness_revision=3,
+        observation_seq=2,
+    )
+
+
+def test_meter_updates_do_not_wait_for_unrelated_state_revisions() -> None:
+    clock = FakeClock()
+    pipeline = FakeStatePipeline(clock=clock)
+    backend = FakeCommandResponseBackend(clock=clock)
+
+    pipeline.apply(backend.command_response(MAIN_FREQ, 14_074_000))
+    meter_delta = pipeline.apply(backend.meter_sample(MAIN_S_METER, 0.42))
+    unchanged_freq = pipeline.apply(backend.command_response(MAIN_FREQ, 14_074_000))
+
+    assert meter_delta is not None
+    assert_consumer_delta(
+        meter_delta,
+        path=MAIN_S_METER,
+        previous=None,
+        current=0.42,
+    )
+    assert_no_consumer_delta(unchanged_freq)
+    assert_revision_counters(
+        pipeline,
+        state_revision=2,
+        freshness_revision=2,
+        observation_seq=3,
+    )
+
+
+def test_stale_field_reconciles_after_missed_unsolicited_event() -> None:
+    clock = FakeClock()
+    pipeline = FakeStatePipeline(clock=clock)
+    backend = FakeDroppedUnsolicitedBackend(clock=clock)
+
+    pipeline.apply(backend.unsolicited(MAIN_FREQ, 14_074_000, max_age=0.5))
+    backend.drop_next_unsolicited(MAIN_FREQ)
+    assert backend.unsolicited(MAIN_FREQ, 14_076_000, max_age=0.5) is None
+
+    clock.advance(0.600)
+    stale_transitions = pipeline.mark_stale_due()
+    reconciliation = pipeline.apply(backend.poll_response(MAIN_FREQ, 14_076_000))
+
+    assert [(item.path, item.current) for item in stale_transitions] == [
+        (MAIN_FREQ, "stale")
+    ]
+    assert reconciliation is not None
+    assert_consumer_delta(
+        reconciliation,
+        path=MAIN_FREQ,
+        previous=14_074_000,
+        current=14_076_000,
+    )
+    assert_revision_counters(
+        pipeline,
+        state_revision=2,
+        freshness_revision=3,
+        observation_seq=2,
+    )
+
+
+def test_backend_variants_and_pending_overlays_are_scoped() -> None:
+    clock = FakeClock()
+    variants = [
+        (
+            FakeCivPushBackend(clock=clock).unsolicited(MAIN_FREQ, 14_074_000),
+            "civ_unsolicited",
+        ),
+        (
+            FakePollingOnlyBackend(clock=clock).poll_response(MAIN_FREQ, 14_074_000),
+            "state_poller",
+        ),
+        (
+            FakeYaesuLikeBackend(clock=clock).poll_response(MAIN_FREQ, 14_074_000),
+            "yaesu_poll_response",
+        ),
+        (
+            FakeExternalRigctldClientBackend(clock=clock).poll_response(
+                MAIN_FREQ, 14_074_000
+            ),
+            "hamlib_response",
+        ),
+    ]
+
+    for observation, expected_source in variants:
+        assert observation is not None
+        assert observation.source == expected_source
+
+    overlays = FakePendingOverlayStore(clock=clock)
+    web = overlays.put(
+        source="websocket",
+        session_id="web-1",
+        command_id="cmd-web",
+        path=MAIN_FREQ,
+        value=14_074_000,
+        ttl=1.0,
+    )
+    rigctld = overlays.put(
+        source="rigctld",
+        session_id="rig-1",
+        command_id="cmd-rig",
+        path=MAIN_FREQ,
+        value=7_074_000,
+        ttl=1.0,
+    )
+
+    assert overlays.visible_value(source="websocket", session_id="web-1", path=MAIN_FREQ) == (
+        14_074_000
+    )
+    assert overlays.visible_value(source="rigctld", session_id="rig-1", path=MAIN_FREQ) == (
+        7_074_000
+    )
+    assert overlays.confirm(MAIN_FREQ, 7_074_000) == [rigctld]
+    assert overlays.visible_value(source="websocket", session_id="web-1", path=MAIN_FREQ) == (
+        14_074_000
+    )
+
+    clock.advance(1.001)
+    assert overlays.expire_due() == [web]
+    assert overlays.visible_value(source="websocket", session_id="web-1", path=MAIN_FREQ) is None

--- a/tests/test_state_pipeline_harness.py
+++ b/tests/test_state_pipeline_harness.py
@@ -15,6 +15,7 @@ from support.state_pipeline import (
     FakeYaesuLikeBackend,
     FieldPath,
     assert_consumer_delta,
+    assert_freshness_only_delta,
     assert_no_consumer_delta,
     assert_revision_counters,
 )
@@ -196,6 +197,26 @@ def test_stale_field_reconciles_after_missed_unsolicited_event() -> None:
     )
 
 
+def test_unchanged_stale_field_emits_freshness_only_delta() -> None:
+    clock = FakeClock()
+    pipeline = FakeStatePipeline(clock=clock)
+    backend = FakeDroppedUnsolicitedBackend(clock=clock)
+
+    pipeline.apply(backend.unsolicited(MAIN_FREQ, 14_074_000, max_age=0.5))
+    clock.advance(0.600)
+    assert pipeline.mark_stale_due()[0].path == MAIN_FREQ
+
+    refresh = pipeline.apply(backend.poll_response(MAIN_FREQ, 14_074_000))
+
+    assert_freshness_only_delta(refresh, path=MAIN_FREQ)
+    assert_revision_counters(
+        pipeline,
+        state_revision=1,
+        freshness_revision=3,
+        observation_seq=2,
+    )
+
+
 def test_backend_variants_and_pending_overlays_are_scoped() -> None:
     clock = FakeClock()
     variants = [
@@ -280,8 +301,15 @@ def test_backend_variants_and_pending_overlays_are_scoped() -> None:
         command_id="cmd-rig-later",
         path=MAIN_FREQ,
     ) == 7_074_000
-
     clock.advance(1.001)
+    assert overlays.confirm(
+        source="rigctld",
+        session_id="rig-1",
+        command_id="cmd-rig-later",
+        path=MAIN_FREQ,
+        value=7_074_000,
+    ) == []
+
     assert overlays.expire_due() == [web, same_value_other_command]
     assert (
         overlays.visible_value(

--- a/tests/test_state_pipeline_harness.py
+++ b/tests/test_state_pipeline_harness.py
@@ -270,18 +270,24 @@ def test_backend_variants_and_pending_overlays_are_scoped() -> None:
         ttl=1.0,
     )
 
-    assert overlays.visible_value(
-        source="websocket",
-        session_id="web-1",
-        command_id="cmd-web",
-        path=MAIN_FREQ,
-    ) == 14_074_000
-    assert overlays.visible_value(
-        source="rigctld",
-        session_id="rig-1",
-        command_id="cmd-rig",
-        path=MAIN_FREQ,
-    ) == 7_074_000
+    assert (
+        overlays.visible_value(
+            source="websocket",
+            session_id="web-1",
+            command_id="cmd-web",
+            path=MAIN_FREQ,
+        )
+        == 14_074_000
+    )
+    assert (
+        overlays.visible_value(
+            source="rigctld",
+            session_id="rig-1",
+            command_id="cmd-rig",
+            path=MAIN_FREQ,
+        )
+        == 7_074_000
+    )
     assert overlays.confirm(
         source="rigctld",
         session_id="rig-1",
@@ -289,26 +295,35 @@ def test_backend_variants_and_pending_overlays_are_scoped() -> None:
         path=MAIN_FREQ,
         value=7_074_000,
     ) == [rigctld]
-    assert overlays.visible_value(
-        source="websocket",
-        session_id="web-1",
-        command_id="cmd-web",
-        path=MAIN_FREQ,
-    ) == 14_074_000
-    assert overlays.visible_value(
-        source="rigctld",
-        session_id="rig-1",
-        command_id="cmd-rig-later",
-        path=MAIN_FREQ,
-    ) == 7_074_000
+    assert (
+        overlays.visible_value(
+            source="websocket",
+            session_id="web-1",
+            command_id="cmd-web",
+            path=MAIN_FREQ,
+        )
+        == 14_074_000
+    )
+    assert (
+        overlays.visible_value(
+            source="rigctld",
+            session_id="rig-1",
+            command_id="cmd-rig-later",
+            path=MAIN_FREQ,
+        )
+        == 7_074_000
+    )
     clock.advance(1.001)
-    assert overlays.confirm(
-        source="rigctld",
-        session_id="rig-1",
-        command_id="cmd-rig-later",
-        path=MAIN_FREQ,
-        value=7_074_000,
-    ) == []
+    assert (
+        overlays.confirm(
+            source="rigctld",
+            session_id="rig-1",
+            command_id="cmd-rig-later",
+            path=MAIN_FREQ,
+            value=7_074_000,
+        )
+        == []
+    )
 
     assert overlays.expire_due() == [web, same_value_other_command]
     assert (

--- a/tests/test_state_store.py
+++ b/tests/test_state_store.py
@@ -1,0 +1,186 @@
+"""Runtime StateStore behavior for the radio state pipeline."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from rigplane.core.state_pipeline_contracts import (
+    FieldPath,
+    Observation,
+    SourceMetadata,
+)
+from rigplane.core.state_store import (
+    FreshnessClock,
+    FreshnessState,
+    StateSnapshot,
+    StateStore,
+)
+
+
+def _source() -> SourceMetadata:
+    return SourceMetadata(
+        source="poll_response",
+        provider="test",
+        transport="fake",
+        native_id="meter",
+    )
+
+
+def _observation(
+    path: FieldPath,
+    value: Any,
+    *,
+    at: float,
+    max_age: float | None = None,
+) -> Observation:
+    return Observation(
+        path=path,
+        value=value,
+        source=_source(),
+        timestamp_monotonic=at,
+        max_age=max_age,
+    )
+
+
+def test_noop_observations_do_not_advance_state_revision() -> None:
+    store = StateStore()
+    path = FieldPath.receiver("main", "meters", "s_meter")
+
+    first = store.apply(_observation(path, 42, at=1.0, max_age=1.0))
+    second = store.apply(_observation(path, 42, at=1.2, max_age=1.0))
+
+    assert first.revision == 1
+    assert first.freshness_revision == 1
+    assert first.observation_seq == 1
+    assert len(first.changes) == 1
+    assert second.revision == 1
+    assert second.freshness_revision == 1
+    assert second.observation_seq == 2
+    assert second.changes == ()
+    assert store.snapshot().state_revision == 1
+    assert store.snapshot().observation_seq == 2
+
+
+def test_freshness_expiration_advances_freshness_without_state_change() -> None:
+    clock = FreshnessClock(start=10.0)
+    store = StateStore(freshness_clock=clock)
+    path = FieldPath.receiver("main", "meters", "s_meter")
+    store.apply(_observation(path, 42, at=clock.now(), max_age=1.0))
+    baseline = store.snapshot()
+
+    clock.advance(1.1)
+    delta = store.mark_stale_due()
+    snapshot = store.snapshot()
+
+    assert snapshot.state_revision == baseline.state_revision
+    assert snapshot.freshness_revision == baseline.freshness_revision + 1
+    assert snapshot.field(path).value == 42
+    assert snapshot.field(path).freshness == FreshnessState.STALE
+    assert delta.changes == ()
+    assert delta.freshness[0].previous is FreshnessState.FRESH
+    assert delta.freshness[0].current is FreshnessState.STALE
+
+
+def test_full_snapshot_and_delta_projection_agree_after_observation_sequence() -> None:
+    clock = FreshnessClock(start=0.0)
+    store = StateStore(freshness_clock=clock)
+    freq = FieldPath.active("main", "freq_mode", "freq_hz")
+    mode = FieldPath.active("main", "freq_mode", "mode")
+
+    store.apply(_observation(freq, 14_074_000, at=0.0, max_age=10.0))
+    store.apply(_observation(mode, "USB-D", at=0.1, max_age=10.0))
+    store.apply(_observation(freq, 14_074_000, at=0.2, max_age=10.0))
+    store.apply(_observation(freq, 14_075_000, at=0.3, max_age=10.0))
+
+    snapshot = store.snapshot()
+    delta = store.delta_since(StateSnapshot.empty())
+    projected_values: dict[FieldPath, Any] = {}
+    for change in delta.changes:
+        projected_values[change.path] = change.current
+
+    assert projected_values == {field.path: field.value for field in snapshot.fields}
+    assert delta.state_revision == snapshot.state_revision
+    assert delta.freshness_revision == snapshot.freshness_revision
+    assert delta.observation_seq == snapshot.observation_seq
+
+
+def test_snapshot_output_cannot_mutate_store_owned_state() -> None:
+    store = StateStore()
+    path = FieldPath.global_("health", "state")
+    payload = {"nested": ["initial"]}
+
+    store.apply(_observation(path, payload, at=1.0))
+    payload["nested"].append("external")
+    exported = store.snapshot().as_dict()
+    exported[str(path)]["value"]["nested"].append("snapshot")
+
+    assert store.snapshot().field(path).value == {"nested": ["initial"]}
+
+
+def test_returned_changes_cannot_mutate_delta_history() -> None:
+    store = StateStore()
+    path = FieldPath.global_("health", "state")
+    payload = {"nested": ["initial"]}
+
+    changeset = store.apply(_observation(path, payload, at=1.0))
+    changeset.changes[0].current["nested"].append("changeset")
+    delta = store.delta_since(StateSnapshot.empty())
+    delta.changes[0].current["nested"].append("delta")
+
+    assert store.delta_since(StateSnapshot.empty()).changes[0].current == {
+        "nested": ["initial"]
+    }
+    assert store.snapshot().field(path).value == {"nested": ["initial"]}
+
+
+def test_direct_writer_api_is_not_exposed() -> None:
+    public_callables = {
+        name
+        for name in dir(StateStore)
+        if not name.startswith("_") and callable(getattr(StateStore, name))
+    }
+
+    assert {"apply", "delta_since", "mark_stale_due", "snapshot"} <= public_callables
+    assert public_callables.isdisjoint({"set", "update", "mutate", "write"})
+
+
+def test_dropped_event_marks_stale_and_requests_reconciliation() -> None:
+    clock = FreshnessClock(start=20.0)
+    store = StateStore(freshness_clock=clock)
+    path = FieldPath.global_("tx_state", "ptt")
+    store.apply(_observation(path, False, at=clock.now(), max_age=0.5))
+
+    clock.advance(0.6)
+    delta = store.mark_stale_due()
+
+    assert store.snapshot().field(path).freshness == FreshnessState.STALE
+    assert delta.reconciliation_requests
+    assert delta.reconciliation_requests[0].path == path
+    assert delta.reconciliation_requests[0].reason == "stale"
+    assert delta.reconciliation_requests[0].state_revision == 1
+    assert delta.reconciliation_requests[0].freshness_revision == 2
+
+
+def test_observation_refreshes_stale_field_without_semantic_state_change() -> None:
+    clock = FreshnessClock(start=30.0)
+    store = StateStore(freshness_clock=clock)
+    path = FieldPath.receiver("main", "meters", "s_meter")
+    store.apply(_observation(path, 9, at=clock.now(), max_age=1.0))
+    clock.advance(1.1)
+    store.mark_stale_due()
+
+    refreshed = store.apply(_observation(path, 9, at=clock.now(), max_age=1.0))
+
+    assert refreshed.revision == 1
+    assert refreshed.freshness_revision == 3
+    assert refreshed.changes == ()
+    assert store.snapshot().field(path).freshness == FreshnessState.FRESH
+
+
+def test_freshness_clock_rejects_backwards_time() -> None:
+    clock = FreshnessClock(start=3.0)
+
+    with pytest.raises(ValueError, match="backwards"):
+        clock.advance(-0.1)

--- a/tests/test_state_store.py
+++ b/tests/test_state_store.py
@@ -11,6 +11,16 @@ from rigplane.core.state_pipeline_contracts import (
     Observation,
     SourceMetadata,
 )
+from rigplane.core.acquisition_scheduler import (
+    AcquisitionPriority,
+    AcquisitionScheduler,
+    StateFreshnessService,
+)
+from rigplane.core.state_acquisition_policy import (
+    AcquisitionPolicy,
+    FieldCapability,
+    RadioAcquisitionProfile,
+)
 from rigplane.core.state_store import (
     FreshnessClock,
     FreshnessState,
@@ -41,6 +51,21 @@ def _observation(
         source=_source(),
         timestamp_monotonic=at,
         max_age=max_age,
+    )
+
+
+def _acquisition_profile(*paths: FieldPath) -> RadioAcquisitionProfile:
+    return RadioAcquisitionProfile(
+        provider="test_provider",
+        capabilities=tuple(
+            FieldCapability(
+                path=path,
+                polling=True,
+                command_response_observable=True,
+            )
+            for path in paths
+        ),
+        default_policy=AcquisitionPolicy(),
     )
 
 
@@ -161,6 +186,29 @@ def test_dropped_event_marks_stale_and_requests_reconciliation() -> None:
     assert delta.reconciliation_requests[0].reason == "stale"
     assert delta.reconciliation_requests[0].state_revision == 1
     assert delta.reconciliation_requests[0].freshness_revision == 2
+
+
+def test_freshness_service_marks_stale_and_queues_reconciliation_without_web() -> None:
+    clock = FreshnessClock(start=50.0)
+    store = StateStore(freshness_clock=clock)
+    path = FieldPath.global_("tx_state", "ptt")
+    scheduler = AcquisitionScheduler(
+        profile=_acquisition_profile(path),
+        clock=clock,
+    )
+    service = StateFreshnessService(store=store, scheduler=scheduler)
+    store.apply(_observation(path, False, at=clock.now(), max_age=0.5))
+
+    clock.advance(0.6)
+    delta = service.tick()
+
+    assert store.snapshot().field(path).freshness is FreshnessState.STALE
+    assert delta.reconciliation_requests[0].path == path
+    requests = scheduler.pending_requests()
+    assert len(requests) == 1
+    assert requests[0].paths == (path,)
+    assert requests[0].priority is AcquisitionPriority.RECONCILIATION
+    assert requests[0].reason == "stale"
 
 
 def test_observation_refreshes_stale_field_without_semantic_state_change() -> None:

--- a/tests/test_state_store.py
+++ b/tests/test_state_store.py
@@ -179,6 +179,23 @@ def test_observation_refreshes_stale_field_without_semantic_state_change() -> No
     assert store.snapshot().field(path).freshness == FreshnessState.FRESH
 
 
+def test_meter_delta_is_visible_without_unrelated_follow_up_revision() -> None:
+    clock = FreshnessClock(start=40.0)
+    store = StateStore(freshness_clock=clock)
+    freq = FieldPath.active("main", "freq_mode", "freq_hz")
+    meter = FieldPath.receiver("main", "meters", "s_meter")
+
+    store.apply(_observation(freq, 14_074_000, at=clock.now(), max_age=10.0))
+    baseline = store.snapshot()
+    store.apply(_observation(meter, 42, at=clock.now() + 0.1, max_age=0.5))
+
+    delta = store.delta_since(baseline)
+
+    assert delta.state_revision == 2
+    assert delta.observation_seq == 2
+    assert [(change.path, change.current) for change in delta.changes] == [(meter, 42)]
+
+
 def test_freshness_clock_rejects_backwards_time() -> None:
     clock = FreshnessClock(start=3.0)
 

--- a/tests/test_sync_coverage.py
+++ b/tests/test_sync_coverage.py
@@ -158,9 +158,39 @@ def test_sync_wrappers_delegate_and_return_values() -> None:
         and str(event.target) == "receiver.0.freq_mode.freq_hz"
         for event in events
     )
+    assert any(
+        event.source == "public_api"
+        and event.target is not None
+        and str(event.target) == "global.tx_state.ptt"
+        for event in events
+    )
+    assert any(
+        event.source == "public_api"
+        and event.target is not None
+        and str(event.target) == "global.tx_state.split"
+        for event in events
+    )
+    assert any(
+        event.source == "public_api"
+        and event.target is not None
+        and str(event.target) == "global.tx_state.power_on"
+        for event in events
+    )
     assert (
         r._state_store.snapshot().field("receiver.0.freq_mode.freq_hz").value  # noqa: SLF001
         == 7100000
+    )
+    assert (
+        r._state_store.snapshot().field("global.tx_state.ptt").value  # noqa: SLF001
+        is True
+    )
+    assert (
+        r._state_store.snapshot().field("global.tx_state.split").value  # noqa: SLF001
+        is True
+    )
+    assert (
+        r._state_store.snapshot().field("global.tx_state.power_on").value  # noqa: SLF001
+        is False
     )
     r._loop.close()
 

--- a/tests/test_sync_coverage.py
+++ b/tests/test_sync_coverage.py
@@ -134,9 +134,9 @@ def test_sync_wrappers_delegate_and_return_values() -> None:
     r._radio.equalize_main_sub.assert_awaited_once()
     r._radio.swap_main_sub.assert_awaited_once()
     r._radio.set_split.assert_awaited_once_with(True)
-    r._radio.set_attenuator_level.assert_awaited_once_with(18)
+    r._radio.set_attenuator_level.assert_awaited_once_with(18, receiver=0)
     r._radio.set_attenuator.assert_awaited_once_with(True)
-    r._radio.set_preamp.assert_awaited_once_with(2)
+    r._radio.set_preamp.assert_awaited_once_with(2, receiver=0)
     r._radio.set_digisel.assert_awaited_once_with(True)
     r._radio.set_squelch.assert_awaited_once_with(100, receiver=1)
     r._radio.set_data_off_mod_input.assert_awaited_once_with(2)
@@ -176,6 +176,24 @@ def test_sync_wrappers_delegate_and_return_values() -> None:
         and str(event.target) == "global.tx_state.power_on"
         for event in events
     )
+    assert any(
+        event.source == "public_api"
+        and event.target is not None
+        and str(event.target) == "receiver.0.operator_controls.att"
+        for event in events
+    )
+    assert any(
+        event.source == "public_api"
+        and event.target is not None
+        and str(event.target) == "receiver.0.operator_controls.preamp"
+        for event in events
+    )
+    assert any(
+        event.source == "public_api"
+        and event.target is not None
+        and str(event.target) == "receiver.1.operator_controls.squelch"
+        for event in events
+    )
     assert (
         r._state_store.snapshot().field("receiver.0.freq_mode.freq_hz").value  # noqa: SLF001
         == 7100000
@@ -191,6 +209,18 @@ def test_sync_wrappers_delegate_and_return_values() -> None:
     assert (
         r._state_store.snapshot().field("global.tx_state.power_on").value  # noqa: SLF001
         is False
+    )
+    assert (
+        r._state_store.snapshot().field("receiver.0.operator_controls.att").value  # noqa: SLF001
+        == 18
+    )
+    assert (
+        r._state_store.snapshot().field("receiver.0.operator_controls.preamp").value  # noqa: SLF001
+        == 2
+    )
+    assert (
+        r._state_store.snapshot().field("receiver.1.operator_controls.squelch").value  # noqa: SLF001
+        == 100
     )
     r._loop.close()
 

--- a/tests/test_sync_coverage.py
+++ b/tests/test_sync_coverage.py
@@ -151,6 +151,17 @@ def test_sync_wrappers_delegate_and_return_values() -> None:
     )
     r._radio.set_scope_mode.assert_awaited_once_with(3)
     r._radio.set_scope_span.assert_awaited_once_with(6)
+    events = r._command_service.lifecycle_events()  # noqa: SLF001
+    assert any(
+        event.source == "public_api"
+        and event.target is not None
+        and str(event.target) == "receiver.0.freq_mode.freq_hz"
+        for event in events
+    )
+    assert (
+        r._state_store.snapshot().field("receiver.0.freq_mode.freq_hz").value  # noqa: SLF001
+        == 7100000
+    )
     r._loop.close()
 
 

--- a/tests/test_usb_audio_stub.py
+++ b/tests/test_usb_audio_stub.py
@@ -69,6 +69,100 @@ def test_select_usb_audio_devices_explicit_overrides_take_precedence() -> None:
     assert selected_tx.name == "A"
 
 
+def test_select_usb_audio_devices_override_accepts_device_index() -> None:
+    devices = [
+        UsbAudioDevice(
+            index=1, name="USB Audio CODEC", input_channels=2, output_channels=2
+        ),
+        UsbAudioDevice(
+            index=3, name="USB Audio CODEC", input_channels=2, output_channels=2
+        ),
+    ]
+    selected_rx, selected_tx = select_usb_audio_devices(
+        devices,
+        rx_device="3",
+        tx_device="3",
+    )
+    assert selected_rx.index == 3
+    assert selected_tx.index == 3
+
+
+def test_select_usb_audio_devices_override_accepts_hardware_identifier() -> None:
+    devices = [
+        UsbAudioDevice(
+            index=1,
+            name="USB Audio CODEC",
+            input_channels=2,
+            output_channels=2,
+            platform_uid="alsa:hw:1,0",
+        ),
+        UsbAudioDevice(
+            index=3,
+            name="USB Audio CODEC",
+            input_channels=2,
+            output_channels=2,
+            platform_uid="alsa:hw:3,0",
+        ),
+    ]
+    selected_rx, selected_tx = select_usb_audio_devices(
+        devices,
+        rx_device="hw:3,0",
+        tx_device="hw:3,0",
+    )
+    assert selected_rx.index == 3
+    assert selected_tx.index == 3
+
+
+def test_select_usb_audio_devices_duplicate_name_override_is_ambiguous() -> None:
+    devices = [
+        UsbAudioDevice(
+            index=1, name="USB Audio CODEC", input_channels=2, output_channels=2
+        ),
+        UsbAudioDevice(
+            index=3, name="USB Audio CODEC", input_channels=2, output_channels=2
+        ),
+    ]
+    with pytest.raises(AudioDeviceSelectionError, match="Ambiguous RX device override"):
+        select_usb_audio_devices(devices, rx_device="USB Audio CODEC")
+
+
+@pytest.mark.asyncio
+async def test_usb_audio_driver_override_uses_backend_hardware_identifier() -> None:
+    backend = FakeAudioBackend(
+        [
+            AudioDeviceInfo(
+                id=AudioDeviceId(1),
+                name="USB Audio CODEC",
+                input_channels=2,
+                output_channels=2,
+                platform_uid="alsa:hw:1,0",
+            ),
+            AudioDeviceInfo(
+                id=AudioDeviceId(3),
+                name="USB Audio CODEC",
+                input_channels=2,
+                output_channels=2,
+                platform_uid="alsa:hw:3,0",
+            ),
+        ]
+    )
+    driver = UsbAudioDriver(
+        backend=backend,
+        rx_device="hw:3,0",
+        tx_device="hw:3,0",
+    )
+
+    await driver.start_rx(lambda _: None)
+    await driver.start_tx()
+
+    assert driver.selected_rx_device is not None
+    assert driver.selected_rx_device.index == 3
+    assert driver.selected_tx_device is not None
+    assert driver.selected_tx_device.index == 3
+    await driver.stop_tx()
+    await driver.stop_rx()
+
+
 def test_select_usb_audio_devices_auto_detect_prefers_usb_audio_codec() -> None:
     # Generic "USB Audio CODEC" now ranks above vendor-specific names so the
     # driver works equally well for Icom, Yaesu and Kenwood radios (all use

--- a/tests/test_web_ptt_readonly.py
+++ b/tests/test_web_ptt_readonly.py
@@ -151,8 +151,21 @@ class TestWebTunerReadOnly:
     def _make_tuner_radio(self) -> MagicMock:
         radio = MagicMock()
         radio.capabilities = frozenset({CAP_TUNER})
+        radio.get_tuner_status = AsyncMock(return_value=1)
         radio.set_tuner_status = AsyncMock(return_value=None)
         return radio
+
+    @pytest.mark.asyncio
+    async def test_tuner_status_read_allowed_in_read_only_mode(self) -> None:
+        """get_tuner_status remains usable when read_only=True."""
+        radio = self._make_tuner_radio()
+        handler, q = _make_handler(read_only=True, radio=radio)
+
+        result = await handler._enqueue_command("get_tuner_status", {})
+
+        assert result == {"status": 1, "label": "ON"}
+        assert q.empty(), "read command must not touch the command queue"
+        radio.get_tuner_status.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_tuner_tune_rejected_in_read_only_mode(self) -> None:
@@ -165,26 +178,28 @@ class TestWebTunerReadOnly:
         assert q.empty(), "command queue must not be touched in read-only mode"
 
     @pytest.mark.asyncio
-    async def test_tuner_on_allowed_in_read_only_mode(self) -> None:
-        """set_tuner_status value=1 (ON) is allowed even when read_only=True."""
+    async def test_tuner_on_rejected_in_read_only_mode(self) -> None:
+        """set_tuner_status value=1 (ON) raises PermissionError when read_only=True."""
         radio = self._make_tuner_radio()
         handler, q = _make_handler(read_only=True, radio=radio)
 
-        result = await handler._enqueue_command("set_tuner_status", {"value": 1})
+        with pytest.raises(PermissionError, match="read-only"):
+            await handler._enqueue_command("set_tuner_status", {"value": 1})
 
-        assert result == {"value": 1, "label": "ON"}
-        radio.set_tuner_status.assert_awaited_once_with(1)
+        assert q.empty(), "command queue must not be touched in read-only mode"
+        radio.set_tuner_status.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_tuner_off_allowed_in_read_only_mode(self) -> None:
-        """set_tuner_status value=0 (OFF) is allowed even when read_only=True."""
+    async def test_tuner_off_rejected_in_read_only_mode(self) -> None:
+        """set_tuner_status value=0 (OFF) raises PermissionError when read_only=True."""
         radio = self._make_tuner_radio()
         handler, q = _make_handler(read_only=True, radio=radio)
 
-        result = await handler._enqueue_command("set_tuner_status", {"value": 0})
+        with pytest.raises(PermissionError, match="read-only"):
+            await handler._enqueue_command("set_tuner_status", {"value": 0})
 
-        assert result == {"value": 0, "label": "OFF"}
-        radio.set_tuner_status.assert_awaited_once_with(0)
+        assert q.empty(), "command queue must not be touched in read-only mode"
+        radio.set_tuner_status.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_tuner_tune_allowed_when_not_read_only(self) -> None:

--- a/tests/test_web_ptt_readonly.py
+++ b/tests/test_web_ptt_readonly.py
@@ -146,7 +146,7 @@ class TestWebCwReadOnly:
 
 
 class TestWebTunerReadOnly:
-    """read_only=True must reject set_tuner_status TUNING (value=2) only."""
+    """read_only=True must reject set_tuner_status writes."""
 
     def _make_tuner_radio(self) -> MagicMock:
         radio = MagicMock()

--- a/tests/test_web_runtime_helpers.py
+++ b/tests/test_web_runtime_helpers.py
@@ -14,7 +14,11 @@ from rigplane.web.runtime_helpers import (
     runtime_capabilities,
 )
 from rigplane.web.server import WebServer
-from rigplane.core.state_pipeline_contracts import FieldPath, Observation, SourceMetadata
+from rigplane.core.state_pipeline_contracts import (
+    FieldPath,
+    Observation,
+    SourceMetadata,
+)
 from rigplane.core.state_store import FreshnessClock, StateStore
 
 

--- a/tests/test_web_runtime_helpers.py
+++ b/tests/test_web_runtime_helpers.py
@@ -1,17 +1,21 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from typing import Any
 
 import pytest
 from unittest.mock import MagicMock
 
 from rigplane.web.runtime_helpers import (
+    build_public_state_payload_from_snapshot,
     classify_radio_health,
     radio_ready,
     runtime_capabilities,
 )
 from rigplane.web.server import WebServer
+from rigplane.core.state_pipeline_contracts import FieldPath, Observation, SourceMetadata
+from rigplane.core.state_store import FreshnessClock, StateStore
 
 
 class _FakeWriter:
@@ -36,6 +40,12 @@ class _FakeWriter:
 
 
 class _FakeRadio:
+    conn_state: str | None
+    _last_civ_data_received: float | None
+    _civ_ready_idle_timeout: float | None
+    _has_connected_once: bool
+    civ_stats: Callable[[], dict[str, int]] | None
+
     def __init__(
         self,
         *,
@@ -48,6 +58,36 @@ class _FakeRadio:
         self.radio_ready = radio_ready_flag
         self.control_connected = False
         self.model = "IC-TEST"
+        self.conn_state = None
+        self._last_civ_data_received = None
+        self._civ_ready_idle_timeout = None
+        self._has_connected_once = False
+        self.civ_stats = None
+
+
+def _source() -> SourceMetadata:
+    return SourceMetadata(
+        source="poll_response",
+        provider="test",
+        transport="fake",
+        native_id="test",
+    )
+
+
+def _observation(
+    path: FieldPath,
+    value: Any,
+    *,
+    at: float,
+    max_age: float | None = None,
+) -> Observation:
+    return Observation(
+        path=path,
+        value=value,
+        source=_source(),
+        timestamp_monotonic=at,
+        max_age=max_age,
+    )
 
 
 def test_runtime_capabilities_none_radio_returns_empty() -> None:
@@ -231,7 +271,7 @@ async def test_webserver_and_control_handler_use_same_capabilities_and_ready() -
 
     # HTTP: capture /api/v1/info JSON body
     writer = _FakeWriter()
-    await server._serve_info(writer)  # noqa: SLF001
+    await server._serve_info(writer)  # type: ignore[arg-type]  # noqa: SLF001
     text = writer.buffer.decode("ascii", errors="replace")
     body_start = text.index("\r\n\r\n") + 4
     info = json.loads(text[body_start:])
@@ -240,14 +280,14 @@ async def test_webserver_and_control_handler_use_same_capabilities_and_ready() -
     ws = MagicMock(spec=WebSocketConnection)
 
     async def _send_text(payload: str) -> None:
-        ws._last_payload = payload  # type: ignore[attr-defined]
+        setattr(ws, "_last_payload", payload)
 
-    ws.send_text = _send_text  # type: ignore[assignment]
+    ws.send_text = _send_text
 
     handler = ControlHandler(ws, radio, "0.0.0-test", radio.model, server=server)
-    await handler._send_hello()  # type: ignore[attr-defined]
+    await handler._send_hello()
 
-    hello = json.loads(ws._last_payload)  # type: ignore[attr-defined]
+    hello = json.loads(getattr(ws, "_last_payload"))
 
     # Capabilities: tags and hello list must match runtime_capabilities(radio)
     expected_caps = sorted(runtime_capabilities(radio))
@@ -258,3 +298,36 @@ async def test_webserver_and_control_handler_use_same_capabilities_and_ready() -
     expected_ready = radio_ready(radio)
     assert info["connection"]["radioReady"] is expected_ready
     assert hello["radio_ready"] is expected_ready
+
+
+def test_public_state_projection_uses_snapshot_revisions_and_meter_values() -> None:
+    clock = FreshnessClock(start=10.0)
+    store = StateStore(freshness_clock=clock)
+    store.apply(
+        _observation(
+            FieldPath.active("0", "freq_mode", "freq_hz"),
+            14_074_000,
+            at=clock.now(),
+            max_age=10.0,
+        )
+    )
+    store.apply(
+        _observation(
+            FieldPath.receiver("0", "meters", "s_meter"),
+            42,
+            at=clock.now(),
+            max_age=0.5,
+        )
+    )
+
+    payload = build_public_state_payload_from_snapshot(
+        store.snapshot(),
+        radio=None,
+        receiver_count=1,
+    )
+
+    assert payload["revision"] == 2
+    assert payload["stateRevision"] == 2
+    assert payload["freshnessRevision"] == 2
+    assert payload["main"]["freqHz"] == 14_074_000
+    assert payload["main"]["sMeter"] == 42

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -741,7 +741,7 @@ class TestControlChannel:
                 writer, json.dumps({"type": "subscribe", "streams": []})
             )
             _, payload = await _ws_recv_frame(reader)
-            data = json.loads(payload)["data"]
+            data = json.loads(payload)["data"]["data"]
             assert "active" in data
             assert "main" in data
             assert "ptt" in data

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -774,6 +774,46 @@ class TestControlChannel:
         finally:
             await _close_ws(writer)
 
+    async def test_observer_query_makes_control_channel_read_only(
+        self, server: WebServer
+    ) -> None:
+        host, port = _addr(server)
+        reader, writer, _ = await _ws_connect(host, port, "/api/v1/ws?observer=1")
+        try:
+            opcode, payload = await _ws_recv_frame(reader)
+            assert opcode == WS_OP_TEXT
+            hello = json.loads(payload)
+            assert hello["type"] == "hello"
+            assert hello["read_only"] is True
+            assert hello["observer"] is True
+
+            await _ws_skip_handshake(reader)
+            await _ws_send_text(
+                writer, json.dumps({"type": "subscribe", "streams": ["state"]})
+            )
+            opcode, payload = await _ws_recv_frame(reader)
+            assert opcode == WS_OP_TEXT
+            state = json.loads(payload)
+            assert state["type"] == "state_update"
+
+            cmd = {
+                "type": "cmd",
+                "id": "observer-set",
+                "name": "set_freq",
+                "params": {"vfo": "A", "freq": 14_074_000},
+            }
+            await _ws_send_text(writer, json.dumps(cmd))
+            response = await _ws_recv_cmd_response(reader)
+            assert response == {
+                "type": "response",
+                "id": "observer-set",
+                "ok": False,
+                "error": "read_only",
+                "message": "read-only mode: set_freq rejected",
+            }
+        finally:
+            await _close_ws(writer)
+
     async def test_command_set_mode(
         self, server: WebServer, mock_radio: MagicMock
     ) -> None:

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -814,6 +814,55 @@ class TestControlChannel:
         finally:
             await _close_ws(writer)
 
+    async def test_observer_repeated_set_commands_are_not_throttled_ok(
+        self, server: WebServer
+    ) -> None:
+        host, port = _addr(server)
+        reader, writer, _ = await _ws_connect(host, port, "/api/v1/ws?observer=1")
+        try:
+            await _ws_skip_handshake(reader)
+
+            for cmd_id in ("observer-set-1", "observer-set-2"):
+                cmd = {
+                    "type": "cmd",
+                    "id": cmd_id,
+                    "name": "set_freq",
+                    "params": {"vfo": "A", "freq": 14_074_000},
+                }
+                await _ws_send_text(writer, json.dumps(cmd))
+                response = await _ws_recv_cmd_response(reader)
+                assert response == {
+                    "type": "response",
+                    "id": cmd_id,
+                    "ok": False,
+                    "error": "read_only",
+                    "message": "read-only mode: set_freq rejected",
+                }
+        finally:
+            await _close_ws(writer)
+
+    async def test_observer_rejects_radio_lifecycle_messages(
+        self, server: WebServer
+    ) -> None:
+        host, port = _addr(server)
+        reader, writer, _ = await _ws_connect(host, port, "/api/v1/ws?observer=1")
+        try:
+            await _ws_skip_handshake(reader)
+
+            for msg_type in ("radio_connect", "radio_disconnect"):
+                msg = {"type": msg_type, "id": f"observer-{msg_type}"}
+                await _ws_send_text(writer, json.dumps(msg))
+                response = await _ws_recv_cmd_response(reader)
+                assert response == {
+                    "type": "response",
+                    "id": f"observer-{msg_type}",
+                    "ok": False,
+                    "error": "read_only",
+                    "message": f"read-only mode: {msg_type} rejected",
+                }
+        finally:
+            await _close_ws(writer)
+
     async def test_command_set_mode(
         self, server: WebServer, mock_radio: MagicMock
     ) -> None:

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -374,6 +374,81 @@ async def test_http_single_command_uses_http_command_service_source(
 
 
 @pytest.mark.asyncio
+async def test_http_raw_civ_transaction_enters_command_lifecycle() -> None:
+    frame = SimpleNamespace(command=0x03, sub=None, data=b"\x01")
+    radio = SimpleNamespace(
+        connected=True,
+        capabilities=set(),
+        send_civ_transaction=AsyncMock(
+            return_value=SimpleNamespace(
+                status="response",
+                frame=frame,
+                frame_bytes=b"\xfe\xfe\xe0\x98\x03\x01\xfd",
+            )
+        ),
+    )
+    srv = WebServer(radio, WebConfig())
+    writer = _FakeWriter()
+    payload = json.dumps(
+        {"id": "raw-1", "command": 0x03, "data": "", "expect": "data"}
+    ).encode()
+
+    await srv._handle_http_civ_transaction(  # noqa: SLF001
+        writer,
+        headers={"content-length": str(len(payload))},
+        reader=_reader_with(payload),
+    )
+
+    status, body = _response_json(writer)
+    assert status == 200
+    assert body["id"] == "raw-1"
+    radio.send_civ_transaction.assert_awaited_once_with(
+        0x03,
+        sub=None,
+        data=b"",
+        expect="data",
+        timeout=None,
+    )
+    events = srv._http_command_service.lifecycle_events()  # noqa: SLF001
+    assert [event.state for event in events[:4]] == [
+        "accepted",
+        "queued",
+        "sent",
+        "acknowledged",
+    ]
+    assert events[0].command_id == "raw-1"
+    assert events[0].source == "http"
+
+
+@pytest.mark.asyncio
+async def test_http_power_enters_command_service_and_keeps_delivery_mirror() -> None:
+    radio = SimpleNamespace(
+        connected=True,
+        control_connected=True,
+        capabilities={"power_control"},
+        set_powerstat=AsyncMock(),
+    )
+    srv = WebServer(radio, WebConfig())
+    writer = _FakeWriter()
+    payload = json.dumps({"state": "off"}).encode()
+
+    await srv._handle_http(  # noqa: SLF001
+        writer,
+        "POST",
+        "/api/v1/radio/power",
+        headers={"content-length": str(len(payload))},
+        reader=_reader_with(payload),
+    )
+
+    status, body = _response_json(writer)
+    assert status == 200
+    assert body == {"status": "ok", "power": "off"}
+    radio.set_powerstat.assert_awaited_once_with(False)
+    assert srv._radio_state.power_on is False  # noqa: SLF001
+    assert srv.command_state_store.snapshot().field("global.tx_state.power_on").value is False
+
+
+@pytest.mark.asyncio
 async def test_healthz_reports_process_liveness() -> None:
     srv = WebServer(None, WebConfig(host="127.0.0.1", port=0))
     writer = _FakeWriter()

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -250,6 +250,13 @@ def test_state_store_s_meter_change_broadcasts_without_legacy_revision_event() -
     radio.model = radio.profile.model
     radio.capabilities = set(radio.profile.capabilities)
     srv = WebServer(radio, WebConfig(state_diagnostics=True))
+    srv._radio_poller = SimpleNamespace(
+        bump_revision=lambda: srv.state_diagnostics.record(
+            "revision_producing_event",
+            "web.radio_poller",
+            revision=1,
+        )
+    )
     queue = BoundedQueue[dict[str, object]](maxsize=4)
     srv.register_control_event_queue(queue)
     path = FieldPath.receiver("0", "meters", "s_meter")
@@ -267,6 +274,52 @@ def test_state_store_s_meter_change_broadcasts_without_legacy_revision_event() -
     assert state_update["type"] == "state_update"
     payload = srv.build_public_state()
     assert payload["main"]["sMeter"] == 73
+    assert not any(
+        item.kind == "revision_producing_event"
+        for item in srv.state_diagnostics.events()
+    )
+
+
+def test_state_store_freshness_refresh_broadcasts_without_semantic_change() -> None:
+    radio = MagicMock()
+    radio.profile = resolve_radio_profile(model="IC-7610")
+    radio.model = radio.profile.model
+    radio.capabilities = set(radio.profile.capabilities)
+    srv = WebServer(radio, WebConfig(state_diagnostics=True))
+    srv._radio_poller = SimpleNamespace(
+        bump_revision=lambda: srv.state_diagnostics.record(
+            "revision_producing_event",
+            "web.radio_poller",
+            revision=1,
+        )
+    )
+    queue = BoundedQueue[dict[str, object]](maxsize=4)
+    srv.register_control_event_queue(queue)
+    path = FieldPath.receiver("0", "meters", "s_meter")
+    clock = FreshnessClock(start=10.0)
+    store = StateStore(freshness_clock=clock)
+    srv.command_state_store = store
+    store.apply(_store_observation(path, 73, at=clock.now(), max_age=0.5))
+    clock.advance(0.6)
+    store.mark_stale_due()
+    refreshed = store.apply(_store_observation(path, 73, at=clock.now(), max_age=0.5))
+
+    assert refreshed.changes == ()
+    srv._on_radio_state_change("state_store_changed", {"paths": [str(path)]})
+
+    event = queue.get_nowait()
+    state_update = queue.get_nowait()
+    assert event == {
+        "type": "event",
+        "name": "state_store_changed",
+        "data": {"paths": [str(path)]},
+    }
+    assert state_update["type"] == "state_update"
+    assert any(
+        item.kind == "web_delivery_trigger"
+        and item.details["freshness_revision"] == refreshed.freshness_revision
+        for item in srv.state_diagnostics.events()
+    )
     assert not any(
         item.kind == "revision_producing_event"
         for item in srv.state_diagnostics.events()

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -1176,6 +1176,45 @@ def test_legacy_state_store_sync_can_clear_default_boolean_values() -> None:
     assert srv.build_public_state()["ptt"] is False
 
 
+def test_legacy_state_store_sync_preserves_receiver_fields() -> None:
+    srv = WebServer(None)
+    legacy = RadioState()
+    legacy.main.data_mode = 2
+    legacy.main.filter_width = 1_800
+    legacy.main.nr_level = 42
+
+    srv.sync_state_store_from_radio_state(legacy)
+
+    public_state = srv.build_public_state()
+    assert public_state["main"]["dataMode"] == 2
+    assert public_state["main"]["filterWidth"] == 1_800
+    assert public_state["main"]["nrLevel"] == 42
+
+
+def test_legacy_state_store_sync_can_clear_default_receiver_values() -> None:
+    srv = WebServer(None)
+    legacy = RadioState()
+    legacy.main.data_mode = 2
+    srv.sync_state_store_from_radio_state(legacy)
+    assert srv.build_public_state()["main"]["dataMode"] == 2
+
+    cleared = RadioState()
+    cleared.main.data_mode = 0
+    srv.sync_state_store_from_radio_state(cleared)
+
+    assert srv.build_public_state()["main"]["dataMode"] == 0
+
+
+def test_legacy_state_store_sync_preserves_global_rit_on() -> None:
+    srv = WebServer(None)
+    legacy = RadioState()
+    legacy.rit_on = True
+
+    srv.sync_state_store_from_radio_state(legacy)
+
+    assert srv.build_public_state()["ritOn"] is True
+
+
 @pytest.mark.asyncio
 async def test_on_radio_reconnect_enables_scope_without_waiting_for_broadcast() -> None:
     """Reconnect must queue EnableScope even while ``radio_ready`` is False.

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -1208,6 +1208,37 @@ async def test_state_response_refreshes_live_connection_payload_without_revision
     assert connected_changed["connection"]["radioReady"] is True
 
 
+def test_broadcast_state_update_refreshes_live_connection_payload_without_revisions() -> (
+    None
+):
+    class _LiveConnectionRadio:
+        connected = True
+        control_connected = False
+        radio_ready = True
+        capabilities: set[str] = set()
+
+    radio = _LiveConnectionRadio()
+    srv = WebServer(radio)
+    q = asyncio.Queue()
+    srv.register_control_event_queue(q)
+
+    srv._broadcast_state_update()  # noqa: SLF001
+    first = q.get_nowait()
+    initial = first["data"]["data"]
+
+    radio.control_connected = True
+
+    srv._last_state_broadcast = 0.0  # noqa: SLF001
+    srv._broadcast_state_update()  # noqa: SLF001
+    event = q.get_nowait()
+
+    assert event["type"] == "state_update"
+    assert event["data"]["type"] == "delta"
+    assert event["data"]["stateRevision"] == initial["stateRevision"]
+    assert event["data"]["freshnessRevision"] == initial["freshnessRevision"]
+    assert event["data"]["changed"]["connection"]["controlConnected"] is True
+
+
 def test_legacy_state_store_sync_can_clear_default_boolean_values() -> None:
     srv = WebServer(None)
     transmitting = RadioState()

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -18,6 +18,7 @@ from rigplane.core.command_service import (
 )
 from rigplane.core.state_pipeline_contracts import FieldPath, Observation, SourceMetadata
 from rigplane.core.state_store import FreshnessClock, StateStore
+from rigplane.radio_state import RadioState
 from rigplane.web import server as server_module
 from rigplane.web.handlers.control import ControlHandler
 from rigplane.web.radio_poller import EnableScope
@@ -1098,6 +1099,81 @@ def test_freshness_only_state_store_change_emits_web_delta() -> None:
     assert event["data"]["type"] == "delta"
     assert event["data"]["changed"]["freshnessRevision"] == 2
     assert event["data"]["stateRevision"] == 1
+
+
+def test_initial_full_state_envelope_does_not_consume_broadcast_delta() -> None:
+    srv = WebServer(None)
+    q = asyncio.Queue()
+    srv.register_control_event_queue(q)
+    srv.command_state_store.apply(
+        _store_observation(
+            FieldPath.active("0", "freq_mode", "freq_hz"),
+            14_074_000,
+            at=1.0,
+        )
+    )
+    srv._broadcast_state_update()  # noqa: SLF001
+    q.get_nowait()
+
+    srv.command_state_store.apply(
+        _store_observation(
+            FieldPath.global_("tx_state", "ptt"),
+            True,
+            at=1.1,
+        )
+    )
+    initial = srv.build_state_update_envelope(force_full=True)
+    assert initial["type"] == "full"
+    assert initial["data"]["ptt"] is True
+
+    srv._last_state_broadcast = 0.0  # noqa: SLF001
+    srv._broadcast_state_update()  # noqa: SLF001
+    event = q.get_nowait()
+
+    assert event["data"]["type"] == "delta"
+    assert event["data"]["changed"]["ptt"] is True
+    assert event["data"]["stateRevision"] == 2
+
+
+@pytest.mark.asyncio
+async def test_initial_full_state_envelope_revisions_match_legacy_seeded_http_state() -> None:
+    srv = WebServer(None)
+    legacy = RadioState()
+    legacy.main.freq = 14_250_000
+    legacy.main.mode = "USB"
+    legacy.ptt = True
+    srv._radio_state = legacy  # noqa: SLF001
+
+    envelope = srv.build_state_update_envelope(force_full=True)
+    assert envelope["type"] == "full"
+    ws_state = envelope["data"]
+
+    assert envelope["revision"] == ws_state["stateRevision"]
+    assert envelope["stateRevision"] == ws_state["stateRevision"]
+    assert envelope["freshnessRevision"] == ws_state["freshnessRevision"]
+
+    writer = _FakeWriter()
+    await srv._serve_state(writer)  # noqa: SLF001
+    status, http_state = _response_json(writer)
+
+    assert status == 200
+    assert http_state == ws_state
+    assert http_state["revision"] == http_state["stateRevision"]
+    assert http_state["freshnessRevision"] == ws_state["freshnessRevision"]
+
+
+def test_legacy_state_store_sync_can_clear_default_boolean_values() -> None:
+    srv = WebServer(None)
+    transmitting = RadioState()
+    transmitting.ptt = True
+    srv.sync_state_store_from_radio_state(transmitting)
+    assert srv.build_public_state()["ptt"] is True
+
+    idle = RadioState()
+    idle.ptt = False
+    srv.sync_state_store_from_radio_state(idle)
+
+    assert srv.build_public_state()["ptt"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from rigplane.web import server as server_module
+from rigplane.web.handlers.control import ControlHandler
 from rigplane.web.radio_poller import EnableScope
 from rigplane.web.server import WebConfig, WebServer, _send_response, run_web_server
 
@@ -321,6 +322,55 @@ async def test_handle_http_routes_and_405_404() -> None:
     assert srv2._serve_station_status.await_count == 1
     assert srv2._serve_static.await_count == 2
     send_resp2.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_http_single_command_uses_http_command_service_source(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: dict[str, object] = {}
+
+    async def fake_enqueue(
+        self: ControlHandler,
+        name: str,
+        params: dict[str, object],
+        *,
+        command_id: str | None = None,
+        source: str = "websocket",
+    ) -> dict[str, object]:
+        del self
+        seen.update(
+            {
+                "name": name,
+                "params": params,
+                "command_id": command_id,
+                "source": source,
+            }
+        )
+        return {"freq": params["freq"], "receiver": params["receiver"]}
+
+    monkeypatch.setattr(ControlHandler, "_enqueue_command", fake_enqueue)
+    srv = WebServer(SimpleNamespace(connected=True, capabilities=set()), WebConfig())
+    writer = _FakeWriter()
+
+    await srv._handle_http_single_command(  # noqa: SLF001
+        writer,
+        {
+            "id": "http-set-freq",
+            "name": "set_freq",
+            "params": {"freq": 14_074_000, "receiver": 0},
+        },
+    )
+
+    status, body = _response_json(writer)
+    assert status == 200
+    assert body["ok"] is True
+    assert seen == {
+        "name": "set_freq",
+        "params": {"freq": 14_074_000, "receiver": 0},
+        "command_id": "http-set-freq",
+        "source": "http",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -22,7 +22,11 @@ from rigplane.core.acquisition_scheduler import (
     RadioStateModelService,
     StateFreshnessService,
 )
-from rigplane.core.state_pipeline_contracts import FieldPath, Observation, SourceMetadata
+from rigplane.core.state_pipeline_contracts import (
+    FieldPath,
+    Observation,
+    SourceMetadata,
+)
 from rigplane.core.state_store import FreshnessClock, StateStore
 from rigplane.profiles import resolve_radio_profile
 from rigplane.radio_state import RadioState
@@ -213,7 +217,9 @@ async def test_start_and_stop_with_radio_sets_callbacks() -> None:
 
 
 @pytest.mark.asyncio
-async def test_start_attaches_shared_state_model_service_for_acquisition_profile() -> None:
+async def test_start_attaches_shared_state_model_service_for_acquisition_profile() -> (
+    None
+):
     radio = _ProfiledStateNotifyRadio()
     radio.profile = resolve_radio_profile(model="IC-7610")
     radio.model = radio.profile.model
@@ -233,7 +239,9 @@ async def test_start_attaches_shared_state_model_service_for_acquisition_profile
             "rigplane.web.web_startup.asyncio.start_server",
             new=AsyncMock(return_value=fake_server),
         ),
-        patch("rigplane.web.web_startup.RadioPoller", return_value=fake_poller) as poller_cls,
+        patch(
+            "rigplane.web.web_startup.RadioPoller", return_value=fake_poller
+        ) as poller_cls,
     ):
         await srv.start()
         await srv.stop()
@@ -607,7 +615,10 @@ async def test_http_power_enters_command_service_and_keeps_delivery_mirror() -> 
     assert body == {"status": "ok", "power": "off"}
     radio.set_powerstat.assert_awaited_once_with(False)
     assert srv._radio_state.power_on is False  # noqa: SLF001
-    assert srv.command_state_store.snapshot().field("global.tx_state.power_on").value is False
+    assert (
+        srv.command_state_store.snapshot().field("global.tx_state.power_on").value
+        is False
+    )
 
 
 @pytest.mark.asyncio
@@ -1123,7 +1134,9 @@ async def test_scope_health_and_radio_state_event_paths() -> None:
 
 
 @pytest.mark.asyncio
-async def test_http_snapshot_matches_initial_ws_full_state_for_same_store_revision() -> None:
+async def test_http_snapshot_matches_initial_ws_full_state_for_same_store_revision() -> (
+    None
+):
     srv = WebServer(None)
     srv.command_state_store.apply(
         _store_observation(
@@ -1162,7 +1175,9 @@ async def test_http_snapshot_matches_initial_ws_full_state_for_same_store_revisi
     assert ws_body == http_body
 
 
-def test_meter_only_state_store_change_emits_web_delta_without_legacy_revision() -> None:
+def test_meter_only_state_store_change_emits_web_delta_without_legacy_revision() -> (
+    None
+):
     srv = WebServer(None)
     q = asyncio.Queue()
     srv.register_control_event_queue(q)
@@ -1266,7 +1281,9 @@ def test_initial_full_state_envelope_does_not_consume_broadcast_delta() -> None:
 
 
 @pytest.mark.asyncio
-async def test_initial_full_state_envelope_revisions_match_legacy_seeded_http_state() -> None:
+async def test_initial_full_state_envelope_revisions_match_legacy_seeded_http_state() -> (
+    None
+):
     srv = WebServer(None)
     legacy = RadioState()
     legacy.main.freq = 14_250_000
@@ -1293,7 +1310,9 @@ async def test_initial_full_state_envelope_revisions_match_legacy_seeded_http_st
 
 
 @pytest.mark.asyncio
-async def test_state_response_refreshes_live_connection_payload_without_revisions() -> None:
+async def test_state_response_refreshes_live_connection_payload_without_revisions() -> (
+    None
+):
     class _LiveConnectionRadio:
         connected = True
         control_connected = False
@@ -1439,7 +1458,9 @@ def test_public_state_syncs_legacy_active_after_state_store_observations() -> No
     assert public_state["active"] == "SUB"
 
 
-def test_public_state_syncs_legacy_global_toggle_after_state_store_observations() -> None:
+def test_public_state_syncs_legacy_global_toggle_after_state_store_observations() -> (
+    None
+):
     srv = WebServer(None)
     srv.command_state_store.apply(
         _store_observation(

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -453,7 +453,7 @@ async def test_http_power_enters_command_service_and_keeps_delivery_mirror() -> 
 
 
 @pytest.mark.asyncio
-async def test_http_command_batch_preparation_uses_shared_command_state_store(
+async def test_http_command_batch_preparation_uses_shared_command_service(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     radio = SimpleNamespace(connected=True, capabilities={"tuner"})
@@ -525,7 +525,7 @@ async def test_http_command_batch_preparation_uses_shared_command_state_store(
     assert body["results"][0]["ok"] is True
     assert isinstance(seen["command_id"], str)
     assert seen["source"] == "http"
-    assert seen["command_service"] is not None
+    assert seen["command_service"] is srv.command_service
     assert seen["command_service"]._state_store is srv.command_state_store  # noqa: SLF001
     assert seen["overlays"] != ()
     assert (

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -1215,6 +1215,86 @@ def test_legacy_state_store_sync_preserves_global_rit_on() -> None:
     assert srv.build_public_state()["ritOn"] is True
 
 
+def test_public_state_syncs_legacy_active_after_state_store_observations() -> None:
+    srv = WebServer(None)
+    srv.command_state_store.apply(
+        _store_observation(
+            FieldPath.active("0", "freq_mode", "freq_hz"),
+            14_074_000,
+            at=1.0,
+        )
+    )
+    srv._radio_state.active = "SUB"  # noqa: SLF001
+
+    public_state = srv.build_public_state()
+
+    assert public_state["main"]["freqHz"] == 14_074_000
+    assert public_state["active"] == "SUB"
+
+
+def test_public_state_syncs_legacy_global_toggle_after_state_store_observations() -> None:
+    srv = WebServer(None)
+    srv.command_state_store.apply(
+        _store_observation(
+            FieldPath.active("0", "freq_mode", "freq_hz"),
+            14_074_000,
+            at=1.0,
+        )
+    )
+    srv._radio_state.dual_watch = True  # noqa: SLF001
+
+    public_state = srv.build_public_state()
+
+    assert public_state["dualWatch"] is True
+
+
+def test_public_state_sync_can_clear_legacy_global_toggle_default() -> None:
+    srv = WebServer(None)
+    srv.command_state_store.apply(
+        _store_observation(
+            FieldPath.active("0", "freq_mode", "freq_hz"),
+            14_074_000,
+            at=1.0,
+        )
+    )
+    srv._radio_state.split = True  # noqa: SLF001
+    assert srv.build_public_state()["split"] is True
+
+    srv._radio_state.split = False  # noqa: SLF001
+
+    assert srv.build_public_state()["split"] is False
+
+
+@pytest.mark.asyncio
+async def test_http_and_ws_full_state_share_post_sync_legacy_snapshot() -> None:
+    srv = WebServer(None)
+    srv.command_state_store.apply(
+        _store_observation(
+            FieldPath.active("0", "freq_mode", "freq_hz"),
+            14_074_000,
+            at=1.0,
+        )
+    )
+    srv._radio_state.active = "SUB"  # noqa: SLF001
+    srv._radio_state.dual_watch = True  # noqa: SLF001
+
+    envelope = srv.build_state_update_envelope(force_full=True)
+    assert envelope["type"] == "full"
+    ws_state = envelope["data"]
+
+    writer = _FakeWriter()
+    await srv._serve_state(writer)  # noqa: SLF001
+    status, http_state = _response_json(writer)
+
+    assert status == 200
+    assert http_state == ws_state
+    assert http_state["active"] == "SUB"
+    assert http_state["dualWatch"] is True
+    assert envelope["revision"] == ws_state["stateRevision"]
+    assert envelope["stateRevision"] == ws_state["stateRevision"]
+    assert envelope["freshnessRevision"] == ws_state["freshnessRevision"]
+
+
 @pytest.mark.asyncio
 async def test_on_radio_reconnect_enables_scope_without_waiting_for_broadcast() -> None:
     """Reconnect must queue EnableScope even while ``radio_ready`` is False.

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -12,6 +12,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from rigplane.core.command_service import (
+    command_intent_from_request,
+    command_response_observation,
+)
 from rigplane.web import server as server_module
 from rigplane.web.handlers.control import ControlHandler
 from rigplane.web.radio_poller import EnableScope
@@ -446,6 +450,96 @@ async def test_http_power_enters_command_service_and_keeps_delivery_mirror() -> 
     radio.set_powerstat.assert_awaited_once_with(False)
     assert srv._radio_state.power_on is False  # noqa: SLF001
     assert srv.command_state_store.snapshot().field("global.tx_state.power_on").value is False
+
+
+@pytest.mark.asyncio
+async def test_http_command_batch_preparation_uses_shared_command_state_store(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    radio = SimpleNamespace(connected=True, capabilities={"tuner"})
+    srv = WebServer(radio, WebConfig())
+    writer = _FakeWriter()
+    seen: dict[str, object] = {}
+
+    def fake_put_ordered(
+        command: object,
+        *,
+        future: asyncio.Future[None] | None = None,
+        command_id: str | None = None,
+        source: str | None = None,
+        command_service=None,
+    ) -> None:
+        del command
+        seen.update(
+            {
+                "command_id": command_id,
+                "source": source,
+                "command_service": command_service,
+                "overlays": command_service.pending_overlays(
+                    source="http",
+                    session_id=None,
+                    command_id=command_id,
+                ),
+            }
+        )
+        assert command_id is not None
+        intent = command_intent_from_request(
+            "set_freq",
+            {"freq": 14_074_000, "receiver": 0},
+            source="http",
+            command_id=command_id,
+        )
+        command_service.apply_observation(
+            command_response_observation(
+                intent,
+                timestamp_monotonic=123.0,
+                provider="test",
+            )
+        )
+        assert future is not None
+        future.set_result(None)
+
+    monkeypatch.setattr(srv.command_queue, "put_ordered", fake_put_ordered)
+    payload = json.dumps(
+        {
+            "steps": [
+                {
+                    "id": "http-batch-freq",
+                    "name": "set_freq",
+                    "params": {"freq": 14_074_000, "receiver": 0},
+                }
+            ]
+        }
+    ).encode()
+
+    await srv._handle_http_commands(  # noqa: SLF001
+        "/api/v1/commands/batch",
+        writer,
+        headers={"content-length": str(len(payload))},
+        reader=_reader_with(payload),
+    )
+
+    status, body = _response_json(writer)
+    assert status == 200
+    assert body["ok"] is True
+    assert body["results"][0]["ok"] is True
+    assert isinstance(seen["command_id"], str)
+    assert seen["source"] == "http"
+    assert seen["command_service"] is not None
+    assert seen["command_service"]._state_store is srv.command_state_store  # noqa: SLF001
+    assert seen["overlays"] != ()
+    assert (
+        srv.command_state_store.snapshot().field("receiver.0.freq_mode.freq_hz").value
+        == 14_074_000
+    )
+    assert (
+        seen["command_service"].pending_overlays(
+            source="http",
+            session_id=None,
+            command_id=seen["command_id"],
+        )
+        == ()
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -543,6 +543,147 @@ async def test_http_command_batch_preparation_uses_shared_command_service(
 
 
 @pytest.mark.asyncio
+async def test_websocket_reused_command_ids_are_scoped_per_connection() -> None:
+    radio = SimpleNamespace(connected=True, capabilities=set())
+    srv = WebServer(radio, WebConfig())
+    handler_a = ControlHandler(
+        SimpleNamespace(send_text=AsyncMock(), recv=AsyncMock()),
+        radio,
+        "9.9.9",
+        "IC-7610",
+        server=srv,
+        session_id="ws-a",
+    )
+    handler_b = ControlHandler(
+        SimpleNamespace(send_text=AsyncMock(), recv=AsyncMock()),
+        radio,
+        "9.9.9",
+        "IC-7610",
+        server=srv,
+        session_id="ws-b",
+    )
+
+    await handler_a._enqueue_command(  # noqa: SLF001
+        "set_freq",
+        {"freq": 14_074_000, "receiver": 0},
+        command_id="ws-shared",
+        source="websocket",
+    )
+    await handler_b._enqueue_command(  # noqa: SLF001
+        "set_freq",
+        {"freq": 14_075_000, "receiver": 0},
+        command_id="ws-shared",
+        source="websocket",
+    )
+
+    overlays_a = srv.command_service.pending_overlays(
+        source="websocket",
+        session_id="ws-a",
+        command_id="ws-shared",
+    )
+    overlays_b = srv.command_service.pending_overlays(
+        source="websocket",
+        session_id="ws-b",
+        command_id="ws-shared",
+    )
+
+    assert len(overlays_a) == 1
+    assert overlays_a[0].value == 14_074_000
+    assert len(overlays_b) == 1
+    assert overlays_b[0].value == 14_075_000
+    accepted = [
+        event
+        for event in srv.command_service.lifecycle_events()
+        if event.command_id == "ws-shared" and event.state == "accepted"
+    ]
+    assert [event.details["session_id"] for event in accepted] == ["ws-a", "ws-b"]
+
+
+@pytest.mark.asyncio
+async def test_http_command_batch_timeout_marks_command_timed_out_and_expires_overlay(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    radio = SimpleNamespace(connected=True, capabilities=set())
+    srv = WebServer(radio, WebConfig())
+    writer = _FakeWriter()
+    seen: dict[str, object] = {}
+    real_wait_for = asyncio.wait_for
+
+    def fake_put_ordered(
+        command: object,
+        *,
+        future: asyncio.Future[None] | None = None,
+        command_id: str | None = None,
+        source: str | None = None,
+        command_service=None,
+    ) -> None:
+        del command
+        assert future is not None
+        seen.update(
+            {
+                "future": future,
+                "command_id": command_id,
+                "source": source,
+                "command_service": command_service,
+                "overlays": command_service.pending_overlays(
+                    source="http",
+                    session_id=None,
+                    command_id=command_id,
+                ),
+            }
+        )
+
+    async def fake_wait_for(awaitable, timeout):
+        if awaitable is seen.get("future"):
+            awaitable.cancel()
+            raise TimeoutError("batch step timed out")
+        return await real_wait_for(awaitable, timeout)
+
+    monkeypatch.setattr(srv.command_queue, "put_ordered", fake_put_ordered)
+    monkeypatch.setattr("rigplane.web.server.asyncio.wait_for", fake_wait_for)
+    payload = json.dumps(
+        {
+            "steps": [
+                {
+                    "id": "http-timeout",
+                    "name": "set_freq",
+                    "params": {"freq": 14_074_000, "receiver": 0},
+                }
+            ]
+        }
+    ).encode()
+
+    await srv._handle_http_commands(  # noqa: SLF001
+        "/api/v1/commands/batch",
+        writer,
+        headers={"content-length": str(len(payload))},
+        reader=_reader_with(payload),
+    )
+
+    status, body = _response_json(writer)
+    assert status == 200
+    assert body["ok"] is False
+    assert body["results"][0]["status"] == "timed_out"
+    assert seen["overlays"] != ()
+    assert (
+        srv.command_service.pending_overlays(
+            source="http",
+            session_id=None,
+            command_id=seen["command_id"],
+        )
+        == ()
+    )
+    timed_out = [
+        event
+        for event in srv.command_service.lifecycle_events()
+        if event.command_id == seen["command_id"] and event.state == "timed_out"
+    ]
+    assert len(timed_out) == 1
+    assert timed_out[0].source == "http"
+    assert timed_out[0].message == "batch step timed out"
+
+
+@pytest.mark.asyncio
 async def test_healthz_reports_process_liveness() -> None:
     srv = WebServer(None, WebConfig(host="127.0.0.1", port=0))
     writer = _FakeWriter()

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -16,6 +16,8 @@ from rigplane.core.command_service import (
     command_intent_from_request,
     command_response_observation,
 )
+from rigplane.core.state_pipeline_contracts import FieldPath, Observation, SourceMetadata
+from rigplane.core.state_store import FreshnessClock, StateStore
 from rigplane.web import server as server_module
 from rigplane.web.handlers.control import ControlHandler
 from rigplane.web.radio_poller import EnableScope
@@ -79,6 +81,31 @@ def _response_json(writer: _FakeWriter) -> tuple[int, dict]:
     status = int(text.split(" ", 2)[1])
     body_start = text.index("\r\n\r\n") + 4
     return status, json.loads(text[body_start:] or "{}")
+
+
+def _state_store_source() -> SourceMetadata:
+    return SourceMetadata(
+        source="poll_response",
+        provider="test",
+        transport="fake",
+        native_id="test",
+    )
+
+
+def _store_observation(
+    path: FieldPath,
+    value: object,
+    *,
+    at: float,
+    max_age: float | None = None,
+) -> Observation:
+    return Observation(
+        path=path,
+        value=value,
+        source=_state_store_source(),
+        timestamp_monotonic=at,
+        max_age=max_age,
+    )
 
 
 def _scope_radio(*, ready: bool = True, connected: bool = True) -> MagicMock:
@@ -962,6 +989,115 @@ async def test_scope_health_and_radio_state_event_paths() -> None:
     await asyncio.sleep(0.05)  # let the refetch task complete
     cmds = srv.command_queue.drain
     assert any(isinstance(c, EnableScope) for c in cmds())
+
+
+@pytest.mark.asyncio
+async def test_http_snapshot_matches_initial_ws_full_state_for_same_store_revision() -> None:
+    srv = WebServer(None)
+    srv.command_state_store.apply(
+        _store_observation(
+            FieldPath.active("0", "freq_mode", "freq_hz"),
+            14_074_000,
+            at=1.0,
+            max_age=10.0,
+        )
+    )
+    srv.command_state_store.apply(
+        _store_observation(
+            FieldPath.receiver("0", "meters", "s_meter"),
+            42,
+            at=1.1,
+            max_age=0.5,
+        )
+    )
+
+    writer = _FakeWriter()
+    await srv._serve_state(writer)  # noqa: SLF001
+    _, http_body = _response_json(writer)
+
+    ws = MagicMock()
+    sent: list[dict[str, object]] = []
+
+    async def _send_text(payload: str) -> None:
+        sent.append(json.loads(payload))
+
+    ws.send_text = _send_text
+
+    handler = ControlHandler(ws, None, "0.0.0-test", "IC-TEST", server=srv)
+    await handler._send_state_snapshot()  # noqa: SLF001
+
+    assert sent[0]["type"] == "state_update"
+    ws_body = sent[0]["data"]["data"]  # type: ignore[index]
+    assert ws_body == http_body
+
+
+def test_meter_only_state_store_change_emits_web_delta_without_legacy_revision() -> None:
+    srv = WebServer(None)
+    q = asyncio.Queue()
+    srv.register_control_event_queue(q)
+    srv.command_state_store.apply(
+        _store_observation(
+            FieldPath.active("0", "freq_mode", "freq_hz"),
+            14_074_000,
+            at=1.0,
+            max_age=10.0,
+        )
+    )
+    srv._broadcast_state_update()  # noqa: SLF001
+    q.get_nowait()
+
+    srv.command_state_store.apply(
+        _store_observation(
+            FieldPath.receiver("0", "meters", "s_meter"),
+            55,
+            at=1.1,
+            max_age=0.5,
+        )
+    )
+    srv._last_state_broadcast = 0.0  # noqa: SLF001
+    srv._broadcast_state_update()  # noqa: SLF001
+    event = q.get_nowait()
+
+    assert event["type"] == "state_update"
+    assert event["data"]["type"] == "delta"
+    assert event["data"]["changed"]["main"]["sMeter"] == 55
+    assert event["data"]["stateRevision"] == 2
+    assert event["data"]["revision"] == 2
+
+
+def test_freshness_only_state_store_change_emits_web_delta() -> None:
+    clock = FreshnessClock(start=5.0)
+    store = StateStore(freshness_clock=clock)
+    srv = WebServer(None)
+    srv.command_state_store = store
+    srv.command_service._state_store = store  # noqa: SLF001
+    srv._http_command_service._state_store = store  # noqa: SLF001
+    q = asyncio.Queue()
+    srv.register_control_event_queue(q)
+
+    store.apply(
+        _store_observation(
+            FieldPath.receiver("0", "meters", "s_meter"),
+            12,
+            at=clock.now(),
+            max_age=0.5,
+        )
+    )
+    srv._broadcast_state_update()  # noqa: SLF001
+    q.get_nowait()
+
+    clock.advance(0.6)
+    delta = store.mark_stale_due()
+    assert delta.freshness
+
+    srv._last_state_broadcast = 0.0  # noqa: SLF001
+    srv._broadcast_state_update()  # noqa: SLF001
+    event = q.get_nowait()
+
+    assert event["type"] == "state_update"
+    assert event["data"]["type"] == "delta"
+    assert event["data"]["changed"]["freshnessRevision"] == 2
+    assert event["data"]["stateRevision"] == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -20,6 +20,7 @@ from rigplane.core.command_service import (
 from rigplane.core.acquisition_scheduler import (
     AcquisitionScheduler,
     RadioStateModelService,
+    StateFreshnessService,
 )
 from rigplane.core.state_pipeline_contracts import FieldPath, Observation, SourceMetadata
 from rigplane.core.state_store import FreshnessClock, StateStore
@@ -240,6 +241,8 @@ async def test_start_attaches_shared_state_model_service_for_acquisition_profile
     assert srv.command_state_store is radio.state_store
     assert isinstance(radio._acquisition_scheduler, AcquisitionScheduler)
     assert isinstance(radio._state_model_service, RadioStateModelService)
+    assert isinstance(radio._state_freshness_service, StateFreshnessService)
+    assert srv._state_freshness_service is radio._state_freshness_service
     assert radio._meter_observation_coalescer is not None
     assert poller_cls.call_args.kwargs["state_store"] is radio.state_store
 

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -12,12 +12,18 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from rigplane._bounded_queue import BoundedQueue
 from rigplane.core.command_service import (
     command_intent_from_request,
     command_response_observation,
 )
+from rigplane.core.acquisition_scheduler import (
+    AcquisitionScheduler,
+    RadioStateModelService,
+)
 from rigplane.core.state_pipeline_contracts import FieldPath, Observation, SourceMetadata
 from rigplane.core.state_store import FreshnessClock, StateStore
+from rigplane.profiles import resolve_radio_profile
 from rigplane.radio_state import RadioState
 from rigplane.web import server as server_module
 from rigplane.web.handlers.control import ControlHandler
@@ -164,6 +170,12 @@ class _StateNotifyRadio(MagicMock):
         self._reconnect_callback = callback
 
 
+class _ProfiledStateNotifyRadio(_StateNotifyRadio):
+    @property
+    def state_store(self) -> StateStore:
+        return self._state_store
+
+
 @pytest.mark.asyncio
 async def test_start_and_stop_with_radio_sets_callbacks() -> None:
     radio = _StateNotifyRadio()
@@ -197,6 +209,68 @@ async def test_start_and_stop_with_radio_sets_callbacks() -> None:
     # responsibility via the context manager (async with radio:).
     radio.disconnect.assert_not_awaited()
     assert fake_server.closed is True
+
+
+@pytest.mark.asyncio
+async def test_start_attaches_shared_state_model_service_for_acquisition_profile() -> None:
+    radio = _ProfiledStateNotifyRadio()
+    radio.profile = resolve_radio_profile(model="IC-7610")
+    radio.model = radio.profile.model
+    radio.capabilities = set(radio.profile.capabilities)
+    radio._state_store = StateStore()
+    radio.state_cache = MagicMock()
+    radio.disconnect = AsyncMock()
+    radio.connected = True
+    radio.radio_ready = True
+    radio.control_connected = True
+    fake_server = _FakeAsyncServer()
+    fake_poller = MagicMock()
+
+    srv = WebServer(radio, WebConfig(host="127.0.0.1", port=0))
+    with (
+        patch(
+            "rigplane.web.web_startup.asyncio.start_server",
+            new=AsyncMock(return_value=fake_server),
+        ),
+        patch("rigplane.web.web_startup.RadioPoller", return_value=fake_poller) as poller_cls,
+    ):
+        await srv.start()
+        await srv.stop()
+
+    assert srv.command_state_store is radio.state_store
+    assert isinstance(radio._acquisition_scheduler, AcquisitionScheduler)
+    assert isinstance(radio._state_model_service, RadioStateModelService)
+    assert radio._meter_observation_coalescer is not None
+    assert poller_cls.call_args.kwargs["state_store"] is radio.state_store
+
+
+def test_state_store_s_meter_change_broadcasts_without_legacy_revision_event() -> None:
+    radio = MagicMock()
+    radio.profile = resolve_radio_profile(model="IC-7610")
+    radio.model = radio.profile.model
+    radio.capabilities = set(radio.profile.capabilities)
+    srv = WebServer(radio, WebConfig(state_diagnostics=True))
+    queue = BoundedQueue[dict[str, object]](maxsize=4)
+    srv.register_control_event_queue(queue)
+    path = FieldPath.receiver("0", "meters", "s_meter")
+    srv.command_state_store.apply(_store_observation(path, 73, at=time.monotonic()))
+
+    srv._on_radio_state_change("state_store_changed", {"paths": [str(path)]})
+
+    event = queue.get_nowait()
+    state_update = queue.get_nowait()
+    assert event == {
+        "type": "event",
+        "name": "state_store_changed",
+        "data": {"paths": [str(path)]},
+    }
+    assert state_update["type"] == "state_update"
+    payload = srv.build_public_state()
+    assert payload["main"]["sMeter"] == 73
+    assert not any(
+        item.kind == "revision_producing_event"
+        for item in srv.state_diagnostics.events()
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -1162,6 +1162,52 @@ async def test_initial_full_state_envelope_revisions_match_legacy_seeded_http_st
     assert http_state["freshnessRevision"] == ws_state["freshnessRevision"]
 
 
+@pytest.mark.asyncio
+async def test_state_response_refreshes_live_connection_payload_without_revisions() -> None:
+    class _LiveConnectionRadio:
+        connected = True
+        control_connected = False
+        radio_ready = True
+        capabilities: set[str] = set()
+
+    radio = _LiveConnectionRadio()
+    srv = WebServer(radio)
+
+    writer = _FakeWriter()
+    await srv._serve_state(writer)  # noqa: SLF001
+    status, initial = _response_json(writer)
+
+    assert status == 200
+    assert initial["connection"]["rigConnected"] is True
+    assert initial["connection"]["controlConnected"] is False
+    assert initial["connection"]["radioReady"] is True
+
+    radio.control_connected = True
+
+    writer2 = _FakeWriter()
+    await srv._serve_state(writer2)  # noqa: SLF001
+    status2, control_changed = _response_json(writer2)
+
+    assert status2 == 200
+    assert control_changed["stateRevision"] == initial["stateRevision"]
+    assert control_changed["freshnessRevision"] == initial["freshnessRevision"]
+    assert control_changed["healthRevision"] == initial["healthRevision"]
+    assert control_changed["connection"]["controlConnected"] is True
+
+    radio.connected = False
+
+    writer3 = _FakeWriter()
+    await srv._serve_state(writer3)  # noqa: SLF001
+    status3, connected_changed = _response_json(writer3)
+
+    assert status3 == 200
+    assert connected_changed["stateRevision"] == initial["stateRevision"]
+    assert connected_changed["freshnessRevision"] == initial["freshnessRevision"]
+    assert connected_changed["healthRevision"] == initial["healthRevision"]
+    assert connected_changed["connection"]["rigConnected"] is False
+    assert connected_changed["connection"]["radioReady"] is True
+
+
 def test_legacy_state_store_sync_can_clear_default_boolean_values() -> None:
     srv = WebServer(None)
     transmitting = RadioState()

--- a/tests/test_yaesu_cat_observation_adapter.py
+++ b/tests/test_yaesu_cat_observation_adapter.py
@@ -1,0 +1,105 @@
+"""Observation adapter coverage for the Yaesu CAT backend."""
+# mypy: disable-error-code=untyped-decorator
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from rigplane.core.state_acquisition_policy import RadioAcquisitionProfile
+from rigplane.profiles import get_radio_profile
+
+from rigplane.backends.yaesu_cat.observations import YaesuObservationAdapter
+
+
+def _clock() -> float:
+    return 123.456
+
+
+def _make_radio() -> MagicMock:
+    radio = MagicMock()
+    radio.capabilities = {
+        "dual_rx",
+        "af_level",
+        "rf_gain",
+        "squelch",
+        "meters",
+        "filter_width",
+        "tx",
+    }
+    radio.get_freq = AsyncMock(
+        side_effect=lambda receiver=0: 14_074_000 if receiver == 0 else 7_074_000
+    )
+    radio.get_mode = AsyncMock(
+        side_effect=lambda receiver=0: ("USB", None) if receiver == 0 else ("LSB", None)
+    )
+    radio.get_ptt = AsyncMock(return_value=False)
+    radio.get_af_level = AsyncMock(
+        side_effect=lambda receiver=0: 128 if receiver == 0 else 64
+    )
+    radio.get_rf_gain = AsyncMock(
+        side_effect=lambda receiver=0: 180 if receiver == 0 else 90
+    )
+    radio.get_squelch = AsyncMock(
+        side_effect=lambda receiver=0: 12 if receiver == 0 else 8
+    )
+    return radio
+
+
+def _profile_state_acquisition() -> RadioAcquisitionProfile:
+    profile = get_radio_profile("FTX-1")
+    assert profile.state_acquisition is not None
+    return profile.state_acquisition
+
+
+@pytest.mark.asyncio
+async def test_medium_poll_emits_frequency_mode_and_ptt_observations() -> None:
+    radio = _make_radio()
+    adapter = YaesuObservationAdapter(
+        radio,
+        profile=_profile_state_acquisition(),
+        clock=_clock,
+    )
+
+    observations = await adapter.poll_medium()
+
+    assert [(str(item.path), item.value) for item in observations] == [
+        ("receiver.main.active.freq_mode.freq_hz", 14_074_000),
+        ("receiver.main.active.freq_mode.mode", "USB"),
+        ("receiver.sub.active.freq_mode.freq_hz", 7_074_000),
+        ("receiver.sub.active.freq_mode.mode", "LSB"),
+        ("global.tx_state.ptt", False),
+    ]
+    assert {item.source.source for item in observations} == {"yaesu_poll_response"}
+    assert {item.source.provider for item in observations} == {"yaesu_cat"}
+    assert {item.source.transport for item in observations} == {"serial"}
+    assert all(item.timestamp_monotonic == 123.456 for item in observations)
+    assert all(item.max_age == 8.0 for item in observations)
+    assert all(item.source.capability_id == str(item.path) for item in observations)
+
+
+@pytest.mark.asyncio
+async def test_slow_poll_emits_declared_control_observations_only() -> None:
+    radio = _make_radio()
+    adapter = YaesuObservationAdapter(
+        radio,
+        profile=_profile_state_acquisition(),
+        clock=_clock,
+    )
+
+    observations = await adapter.poll_slow_controls()
+
+    assert [(str(item.path), item.value) for item in observations] == [
+        ("receiver.main.operator_controls.af_level", 128),
+        ("receiver.main.operator_controls.rf_gain", 180),
+        ("receiver.main.operator_controls.squelch", 12),
+        ("receiver.sub.operator_controls.af_level", 64),
+        ("receiver.sub.operator_controls.rf_gain", 90),
+        ("receiver.sub.operator_controls.squelch", 8),
+    ]
+    assert all(item.source.source == "yaesu_poll_response" for item in observations)
+    assert all(item.max_age == 120.0 for item in observations)
+    assert radio.get_af_level.await_count == 2
+    assert radio.get_rf_gain.await_count == 2
+    assert radio.get_squelch.await_count == 2

--- a/tests/test_yaesu_cat_observation_adapter.py
+++ b/tests/test_yaesu_cat_observation_adapter.py
@@ -106,7 +106,9 @@ async def test_slow_poll_emits_declared_control_observations_only() -> None:
 
 
 @pytest.mark.asyncio
-async def test_slow_poll_skips_sub_controls_without_matching_runtime_capability() -> None:
+async def test_slow_poll_skips_sub_controls_without_matching_runtime_capability() -> (
+    None
+):
     radio = _make_radio()
     radio.capabilities = {"dual_rx", "af_level", "tx"}
     adapter = YaesuObservationAdapter(

--- a/tests/test_yaesu_cat_observation_adapter.py
+++ b/tests/test_yaesu_cat_observation_adapter.py
@@ -103,3 +103,24 @@ async def test_slow_poll_emits_declared_control_observations_only() -> None:
     assert radio.get_af_level.await_count == 2
     assert radio.get_rf_gain.await_count == 2
     assert radio.get_squelch.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_slow_poll_skips_sub_controls_without_matching_runtime_capability() -> None:
+    radio = _make_radio()
+    radio.capabilities = {"dual_rx", "af_level", "tx"}
+    adapter = YaesuObservationAdapter(
+        radio,
+        profile=_profile_state_acquisition(),
+        clock=_clock,
+    )
+
+    observations = await adapter.poll_slow_controls()
+
+    assert [(str(item.path), item.value) for item in observations] == [
+        ("receiver.main.operator_controls.af_level", 128),
+        ("receiver.sub.operator_controls.af_level", 64),
+    ]
+    assert radio.get_af_level.await_count == 2
+    radio.get_rf_gain.assert_not_awaited()
+    radio.get_squelch.assert_not_awaited()

--- a/uv.lock
+++ b/uv.lock
@@ -1958,7 +1958,7 @@ wheels = [
 
 [[package]]
 name = "rigplane"
-version = "2.7.3"
+version = "2.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Implements three core-side follow-ups from the Station/LAN workflow:

- MOR-387: add generic `DiscoveryResponder` hooks for `urls.fleet` and top-level `box_id` in station discovery datagrams.
- MOR-388: add per-connection observer/read-only mode for the core control WebSocket via query flags, with write/lifecycle commands rejected before throttling.
- MOR-390: make core USB audio device selection robust for duplicate names by supporting indexes and stable hardware/platform IDs such as `hw:3,0`.

## Notes

This stays inside open-core boundaries: no station/pro supervisor ownership or mapping logic is added. Station can now pass discovery metadata into core; Pro/station can request observer control-WS mode; callers can select the intended USB audio device without relying on ambiguous display names.

## Verification

- `uv run pytest tests/test_discovery_responder.py tests/test_web_server.py tests/test_web_ptt_readonly.py tests/test_usb_audio_stub.py tests/test_audio_backend.py tests/test_macos_audio_uid.py -q --tb=short` -> 283 passed, 2 skipped
- `uv run ruff check src/ tests/` -> passed, with pre-existing invalid `# noqa` warnings in `tests/test_radio_poller_coverage.py`
- `uv run pytest tests/ -q --tb=short` -> 6851 passed, 126 skipped, 3 deselected, 11 xfailed, 1 xpassed

## Linear

- MOR-387
- MOR-388
- MOR-390
