### PR TITLE
test(frontend): fix fast-pool cross-test state leakage (publish validate flake)

### DIFF
--- a/frontend/src/lib/radio/mode-filter-memory.ts
+++ b/frontend/src/lib/radio/mode-filter-memory.ts
@@ -37,13 +37,14 @@ const modeFilter = new Map<string, number>();
 // `$lib/stores/radio.svelte` without `subscribeRadioState`, and the lookup
 // must remain a no-throw best-effort side effect.
 let seedingStarted = false;
+let unsubscribeSeeding: (() => void) | null = null;
 export function startModeFilterSeeding(): void {
   if (seedingStarted) {
     return;
   }
   seedingStarted = true;
   try {
-    subscribeRadioState((state) => seedFromState(state));
+    unsubscribeSeeding = subscribeRadioState((state) => seedFromState(state));
   } catch {
     // Store subscription unavailable (e.g. unit-test mock) — the map still
     // works via explicit recordModeFilter()/seedFromState() calls.
@@ -92,5 +93,19 @@ export function seedFromState(state: ServerState | null): void {
 /** Test hook — clear the session map and re-arm lazy seeding. */
 export function _resetModeFilterMemory(): void {
   modeFilter.clear();
+  // Tear down any live real-store subscription. Under the non-isolated test
+  // pool (vite.config ``isolate: false``) the module singleton is shared across
+  // test files: a sibling test that exercises a live mode handler attaches the
+  // real ``subscribeRadioState`` seeder, which then keeps recording entries
+  // into the shared map after this reset — re-populating it mid-test and making
+  // map assertions flaky. Releasing the subscription here makes the reset total.
+  if (unsubscribeSeeding) {
+    try {
+      unsubscribeSeeding();
+    } catch {
+      // best-effort teardown
+    }
+    unsubscribeSeeding = null;
+  }
   seedingStarted = false;
 }

--- a/frontend/src/lib/transport/__tests__/ws-client-store.integration.test.ts
+++ b/frontend/src/lib/transport/__tests__/ws-client-store.integration.test.ts
@@ -180,6 +180,13 @@ describe('ws-client → real radio store gate (integration)', () => {
     originalWebSocket = globalThis.WebSocket;
     // @ts-expect-error install the mock as the global WebSocket constructor
     globalThis.WebSocket = MockWebSocket;
+    // Reset the module graph BEFORE each test, not only after. Under the
+    // ``fast`` project (``isolate: false``) a sibling test file that imported
+    // ``radio.svelte`` first leaves the real store singleton at a non-zero
+    // revision in the shared module cache; without a pre-test reset the first
+    // ``loadModules()`` here would pick up that stale singleton and the
+    // revision-gate assertions drift (e.g. ``expected 6 to be 5``).
+    vi.resetModules();
   });
 
   afterEach(() => {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -101,6 +101,41 @@ export default defineConfig({
             // MobileRadioLayout / BandPlanOverlay component tests.
             'src/**/*.component.test.ts',
             'src/**/*.component.svelte.test.ts',
+            // Module-scope ``vi.mock(...)`` files that are NOT named
+            // ``*.component*`` and so were not caught by the glob above. Under
+            // ``isolate: false`` a hoisted ``vi.mock`` becomes a no-op when a
+            // sibling test imports the real module first (it pins the real
+            // module in the shared cache), and a *partial* mock leaks its
+            // missing-export surface into sibling tests that import the real
+            // store (e.g. "No setWsConnected export is defined on the mock").
+            // The publish validate job (2-core, low parallelism) hit a rotating
+            // cast of these — mode-filter-memory / TxPanel / FilterPanel /
+            // DspPanel / SendReportDialog / vfo-header / ws-client* / http-client
+            // — a different file per run. Route every fast-pool file that does
+            // module-scope ``vi.mock`` through the isolated pool so the mock is
+            // authoritative and cannot leak. See #771.
+            'src/components-v2/controls/__tests__/BandSelector.test.ts',
+            'src/components-v2/dialogs/__tests__/SendReportDialog.test.ts',
+            'src/components-v2/layout/__tests__/RadioLayout.test.ts',
+            'src/components-v2/layout/__tests__/top-row-visual-regression.test.ts',
+            'src/components-v2/layout/__tests__/vfo-header.test.ts',
+            'src/components-v2/panels/__tests__/DockMeterPanel.test.ts',
+            'src/components-v2/panels/__tests__/DspPanel.test.ts',
+            'src/components-v2/panels/__tests__/FilterPanel.test.ts',
+            'src/components-v2/panels/__tests__/MeterPanel.test.ts',
+            'src/components-v2/panels/__tests__/MetersDockPanel.test.ts',
+            'src/components-v2/panels/__tests__/ModePanel.test.ts',
+            'src/components-v2/panels/__tests__/RitXitPanel.test.ts',
+            'src/components-v2/panels/__tests__/RxAudioPanel.test.ts',
+            'src/components-v2/panels/__tests__/TxPanel.test.ts',
+            'src/components-v2/panels/lcd/__tests__/AmberTelemetryStrip.test.ts',
+            'src/components-v2/panels/lcd/__tests__/lcd-availability.test.ts',
+            'src/components-v2/panels/lcd/__tests__/lcd-components.test.ts',
+            'src/components-v2/panels/vfo/__tests__/DualVfoDisplay.test.ts',
+            'src/components-v2/vfo/__tests__/VfoPanel.test.ts',
+            'src/lib/media/__tests__/media-session.test.ts',
+            'src/lib/radio/mode-filter-memory.test.ts',
+            'src/lib/transport/__tests__/ws-client.test.ts',
           ],
           pool: 'threads',
           isolate: false,
@@ -132,6 +167,31 @@ export default defineConfig({
             'src/lib/i18n/__tests__/pseudo.test.ts',
             'src/**/*.component.test.ts',
             'src/**/*.component.svelte.test.ts',
+            // Mirror of the fast-pool exclude additions above: every fast-pool
+            // file doing module-scope ``vi.mock`` runs isolated so its mock is
+            // authoritative and cannot leak under ``isolate: false``. See #771.
+            'src/components-v2/controls/__tests__/BandSelector.test.ts',
+            'src/components-v2/dialogs/__tests__/SendReportDialog.test.ts',
+            'src/components-v2/layout/__tests__/RadioLayout.test.ts',
+            'src/components-v2/layout/__tests__/top-row-visual-regression.test.ts',
+            'src/components-v2/layout/__tests__/vfo-header.test.ts',
+            'src/components-v2/panels/__tests__/DockMeterPanel.test.ts',
+            'src/components-v2/panels/__tests__/DspPanel.test.ts',
+            'src/components-v2/panels/__tests__/FilterPanel.test.ts',
+            'src/components-v2/panels/__tests__/MeterPanel.test.ts',
+            'src/components-v2/panels/__tests__/MetersDockPanel.test.ts',
+            'src/components-v2/panels/__tests__/ModePanel.test.ts',
+            'src/components-v2/panels/__tests__/RitXitPanel.test.ts',
+            'src/components-v2/panels/__tests__/RxAudioPanel.test.ts',
+            'src/components-v2/panels/__tests__/TxPanel.test.ts',
+            'src/components-v2/panels/lcd/__tests__/AmberTelemetryStrip.test.ts',
+            'src/components-v2/panels/lcd/__tests__/lcd-availability.test.ts',
+            'src/components-v2/panels/lcd/__tests__/lcd-components.test.ts',
+            'src/components-v2/panels/vfo/__tests__/DualVfoDisplay.test.ts',
+            'src/components-v2/vfo/__tests__/VfoPanel.test.ts',
+            'src/lib/media/__tests__/media-session.test.ts',
+            'src/lib/radio/mode-filter-memory.test.ts',
+            'src/lib/transport/__tests__/ws-client.test.ts',
           ],
           pool: 'threads',
           isolate: true,


### PR DESCRIPTION
Follow-up to PR #1880. The v2.10.1 publish validate kept failing on different flaky vitest files due to module-state leakage in the non-isolated fast pool. This lands the deterministic fix on main (already in the published v2.10.1 tag at 6dcf17b6).

- mode-filter-memory.ts: tear down the live subscribeRadioState handler in _resetModeFilterMemory() so resets are total.
- ws-client-store.integration.test.ts: vi.resetModules() in beforeEach.
- vite.config.ts: route the 22 module-scope vi.mock fast-pool files into the existing isolated project (maintainers' curated exclude/include pattern; no global isolate change).

Verified deterministic: 2178/2178 across single-worker, 2-worker, and 10 shuffle-seed runs + check + build; publish.yml green on this commit. Boundary: open-core (test infra).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>