### PR TITLE
fix: bound healthy-link acquisition false-timeout grace + gate adaptive decay (2.10.2 / MOR-874)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.10.2] — 2026-06-18
+
+### Fixed
+
+- IC-7610 state-acquisition regression with an external CAT master: when a
+  separate CAT client (e.g. WSJT-X via rigctld) was polling the radio, false
+  `acquisition_request_timeout`s drove the adaptive cadence of frequency,
+  mode and data-mode polling to decay all the way to 30 s, so the web VFO,
+  mode and DATA readouts went stale and appeared to "revert". The fix makes
+  acquisition deadlines send-relative, gates adaptive decay on transport
+  health, and adds a bounded grace before a healthy-link expiry is treated
+  as a real timeout (rigplane-pro#1198, MOR-874).
+
 ## [2.10.1] — 2026-06-17
 
 ### Fixed
@@ -1818,7 +1831,8 @@ These deprecation closures were announced in v0.19 and dropped on schedule.
 - Transport layer, authentication, CI-V commands, meters, PTT, keep-alive.
 - Clean-room Icom LAN UDP protocol implementation.
 
-[Unreleased]: https://github.com/rigplane/rigplane-core/compare/v2.10.1...HEAD
+[Unreleased]: https://github.com/rigplane/rigplane-core/compare/v2.10.2...HEAD
+[2.10.2]: https://github.com/rigplane/rigplane-core/compare/v2.10.1...v2.10.2
 [2.10.1]: https://github.com/rigplane/rigplane-core/compare/v2.10.0...v2.10.1
 [2.10.0]: https://github.com/rigplane/rigplane-core/compare/v2.9.0...v2.10.0
 [2.9.0]: https://github.com/rigplane/rigplane-core/compare/v2.8.0...v2.9.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "rigplane"
-version = "2.10.1"
+version = "2.10.2"
 description = "Multi-vendor radio control library and Web UI with native providers and planned Hamlib-backed CAT coverage"
 readme = "README.md"
 license = "MIT"

--- a/src/rigplane/core/acquisition_scheduler.py
+++ b/src/rigplane/core/acquisition_scheduler.py
@@ -672,10 +672,25 @@ class AcquisitionScheduler:
         reason: str,
         failed_paths: Iterable[FieldPath] | None = None,
         now: float | None = None,
+        link_healthy: bool = True,
     ) -> None:
-        """Complete failed paths and advance cadence to avoid immediate resend."""
+        """Complete failed paths and advance cadence to avoid immediate resend.
+
+        ``link_healthy`` gates the false-timeout path (MOR-874): an
+        ``acquisition_request_timeout`` reported while the underlying transport
+        is healthy (sub-second round-trips, no recovery in progress) is not a
+        real backend failure — the radio answered, the deadline simply fired
+        first under load. Such an event must NOT count as a failure, must NOT
+        drop the request from the pending queue, and must NOT advance cadence
+        (which is what later decays ``freq_mode``/``tx_state``/``slow_state`` to
+        the 30 s backoff ceiling). The caller leaves the request in flight so
+        the returning observation can still credit it.
+        """
 
         failure_reason = reason or "acquisition_failed"
+        if failure_reason == "acquisition_request_timeout" and link_healthy:
+            return
+
         requested_paths = frozenset(request.paths)
         failed = requested_paths if failed_paths is None else frozenset(failed_paths)
         failed = failed.intersection(requested_paths)

--- a/src/rigplane/rigctld/server.py
+++ b/src/rigplane/rigctld/server.py
@@ -477,11 +477,16 @@ class RigctldServer:
         if error_type is not None:
             details["error_type"] = error_type
         self._record_state_diagnostic(kind, "rigctld.server", **details)
+        # MOR-874: keep rigctld failure handling unchanged — the send-relative
+        # deadline + healthy-link gate is scoped to the web radio poller. Pass
+        # link_healthy=False so every reported failure (incl. timeouts) stays
+        # terminal here exactly as before this change.
         scheduler.record_acquisition_failure(
             request,
             reason=reason,
             failed_paths=failed_paths,
             now=now,
+            link_healthy=False,
         )
 
     async def _drain_state_acquisition_once(self) -> None:

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -185,6 +185,24 @@ _FAST_INTERVAL: float = 0.025  # meters — wfview queue interval for LAN (25ms)
 _FAST_INTERVAL_SERIAL: float = 0.100  # serial: 10 polls/sec for responsive meters
 _SLOW_INTERVAL: float = 0.25  # levels/settings — rarely change
 
+# MOR-874: how long a healthy-link in-flight acquisition request may stay
+# suppressed after its FIRST send-relative deadline expiry before being
+# treated as a REAL timeout. The healthy-link gate (see
+# ``_civ_link_healthy``) intentionally suppresses the false-timeout ->
+# adaptive-decay chain when the radio answered but the deadline raced under
+# load. But the gate reads the GLOBAL last-CI-V timestamp (refreshed by ANY
+# frame: meters/scope/transceive), so a link under external-CAT load reads
+# healthy ~permanently. Without a bound, a request whose specific answer is
+# genuinely lost (UDP drop / radio silently ignores that command) would stay
+# in flight forever — never re-sent, never failed. This bound caps the
+# suppression: a slightly-late answer (the common case) still credits within
+# the window with NO extra CI-V traffic, but once the window elapses with the
+# request still uncredited we fall back to a real timeout — drop it so the
+# scheduler re-queues/re-sends and the normal failure accounting/decay applies.
+# Sized to a couple of answer windows so a healthy radio's reply always lands
+# first; it does not add poll pressure for late-but-arriving answers.
+_ACQUISITION_HEALTHY_GRACE_SECONDS: float = 6.0
+
 # MOR-615: per-DATA-group MOD-input source fields (IC-7610 0x1A 05 00
 # 0x91-0x94). Field name == ``get_<name>`` / ``set_<name>`` radio method
 # suffix == legacy RadioState attribute == StateStore slow_state leaf.
@@ -394,6 +412,13 @@ class RadioPoller:
         )
         self._acquisition_executor = acquisition_executor
         self._acquisition_in_flight: dict[str, tuple[frozenset[FieldPath], float]] = {}
+        # MOR-874: monotonic time of the FIRST healthy-link deadline expiry per
+        # in-flight request id. Seeds the bounded grace window
+        # (``_ACQUISITION_HEALTHY_GRACE_SECONDS``) after which a still-uncredited
+        # request stops being suppressed and is treated as a real timeout.
+        # Entries are cleared when a request leaves flight (credited or dropped)
+        # so the map never leaks.
+        self._acquisition_healthy_grace_started: dict[str, float] = {}
         self._queue = queue
         self._on_state_event = on_state_event
         self._poll_index: int = 0
@@ -2293,6 +2318,9 @@ class RadioPoller:
         for request_id in tuple(self._acquisition_in_flight):
             if request_id not in pending_ids:
                 del self._acquisition_in_flight[request_id]
+                # MOR-874: request left flight (credited / dropped) — drop its
+                # grace bookkeeping so the map never leaks.
+                self._acquisition_healthy_grace_started.pop(request_id, None)
 
         for request in pending:
             sent_paths: frozenset[FieldPath] = frozenset()
@@ -2306,12 +2334,33 @@ class RadioPoller:
                     now=now,
                 ):
                     # MOR-874: when the deadline fires but the CI-V link is
-                    # healthy, this is a false timeout (the radio answered;
-                    # the deadline raced). Keep the request in flight so the
-                    # returning observation credits it, and do not decay
-                    # cadence. Only a genuinely unhealthy link is a real
-                    # acquisition timeout.
+                    # healthy, this is (usually) a false timeout — the radio
+                    # answered and the deadline raced under load. Suppress the
+                    # false-timeout -> adaptive-decay chain and keep the request
+                    # in flight so the returning observation can credit it.
+                    #
+                    # But the health gate reads the GLOBAL last-CI-V timestamp,
+                    # so under external-CAT load it reads healthy ~permanently;
+                    # a request whose specific answer is genuinely lost would
+                    # then be pinned forever. Bound the suppression with a grace
+                    # window: once it elapses with the request still uncredited,
+                    # fall back to a REAL timeout (drop it so the scheduler
+                    # re-queues/re-sends and normal failure accounting/decay
+                    # applies).
                     link_healthy = self._civ_link_healthy(now=now)
+                    grace_expired = False
+                    if link_healthy:
+                        grace_started = self._acquisition_healthy_grace_started.get(
+                            request.id
+                        )
+                        if grace_started is None:
+                            self._acquisition_healthy_grace_started[request.id] = now
+                            grace_started = now
+                        if now - grace_started >= _ACQUISITION_HEALTHY_GRACE_SECONDS:
+                            grace_expired = True
+                    # Treat a grace-expired healthy expiry exactly like an
+                    # unhealthy one: count it, drop it, let cadence advance.
+                    timeout_is_real = (not link_healthy) or grace_expired
                     self._record_state_diagnostic(
                         "acquisition_request_failed",
                         "web.radio_poller",
@@ -2319,18 +2368,22 @@ class RadioPoller:
                         paths=[str(path) for path in request.paths],
                         reason="acquisition_request_timeout",
                         link_healthy=link_healthy,
+                        grace_expired=grace_expired,
                     )
                     scheduler.record_acquisition_failure(
                         request,
                         reason="acquisition_request_timeout",
                         failed_paths=sent_paths or frozenset(request.paths),
                         now=now,
-                        link_healthy=link_healthy,
+                        link_healthy=not timeout_is_real,
                     )
-                    if not link_healthy:
+                    if timeout_is_real:
                         self._acquisition_in_flight.pop(request.id, None)
+                        self._acquisition_healthy_grace_started.pop(request.id, None)
                         continue
-                    # Healthy link: leave in flight, skip re-send this cycle.
+                    # Healthy link, still within grace: leave in flight, skip
+                    # re-send this cycle (no extra CI-V traffic — important not
+                    # to compete with external CAT).
                     sent_paths = sent_paths.intersection(request.paths)
                     if all(path in sent_paths for path in request.paths):
                         continue

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -2281,9 +2281,11 @@ class RadioPoller:
         # only expired ``timeout`` (or ``max_age`` when no explicit timeout is
         # set) seconds after its SEND time — never relative to enqueue time.
         if sent_at > 0.0:
-            window = request.timeout if request.timeout is not None else request.max_age
-            return now >= sent_at + window
-        return now >= request.deadline_monotonic
+            window: float = (
+                request.timeout if request.timeout is not None else request.max_age
+            )
+            return bool(now >= sent_at + window)
+        return bool(now >= request.deadline_monotonic)
 
     def _civ_link_healthy(self, *, now: float) -> bool:
         """Return True when the CI-V transport is demonstrably alive (MOR-874).

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -2247,11 +2247,40 @@ class RadioPoller:
         sent_at: float,
         now: float,
     ) -> bool:
-        deadlines = [request.deadline_monotonic]
-        if request.timeout is not None:
-            deadlines.append(sent_at + request.timeout)
-        deadline: float = min(deadlines)
-        return now >= deadline
+        # MOR-874: the deadline must be SEND-relative once the request has
+        # actually been dispatched. The enqueue-relative ``deadline_monotonic``
+        # only bounds requests still waiting to be sent (``sent_at == 0``);
+        # using it (or ``min`` with it) for a sent request fires a false
+        # timeout when the request sat queued under load and the radio's fast
+        # answer lands just after enqueue_time + max_age. A sent request is
+        # only expired ``timeout`` (or ``max_age`` when no explicit timeout is
+        # set) seconds after its SEND time — never relative to enqueue time.
+        if sent_at > 0.0:
+            window = request.timeout if request.timeout is not None else request.max_age
+            return now >= sent_at + window
+        return now >= request.deadline_monotonic
+
+    def _civ_link_healthy(self, *, now: float) -> bool:
+        """Return True when the CI-V transport is demonstrably alive (MOR-874).
+
+        Used to gate false acquisition timeouts: a request deadline that fires
+        while the link is healthy (recent CI-V data, no recovery in progress)
+        is a queueing artifact, not a backend failure, and must not decay the
+        adaptive cadence.
+        """
+
+        radio = self._radio
+        if bool(getattr(radio, "_civ_recovering", False)):
+            return False
+        last_civ = getattr(radio, "_last_civ_data_received", None)
+        if not isinstance(last_civ, (int, float)) or isinstance(last_civ, bool):
+            return False
+        ready_timeout = getattr(radio, "_civ_ready_idle_timeout", 2.0)
+        if not isinstance(ready_timeout, (int, float)) or isinstance(
+            ready_timeout, bool
+        ):
+            ready_timeout = 2.0
+        return (now - float(last_civ)) <= float(ready_timeout)
 
     async def _send_scheduler_requests(self) -> None:
         scheduler = self._acquisition_scheduler
@@ -2276,21 +2305,35 @@ class RadioPoller:
                     sent_at=sent_at,
                     now=now,
                 ):
+                    # MOR-874: when the deadline fires but the CI-V link is
+                    # healthy, this is a false timeout (the radio answered;
+                    # the deadline raced). Keep the request in flight so the
+                    # returning observation credits it, and do not decay
+                    # cadence. Only a genuinely unhealthy link is a real
+                    # acquisition timeout.
+                    link_healthy = self._civ_link_healthy(now=now)
                     self._record_state_diagnostic(
                         "acquisition_request_failed",
                         "web.radio_poller",
                         request_id=request.id,
                         paths=[str(path) for path in request.paths],
                         reason="acquisition_request_timeout",
+                        link_healthy=link_healthy,
                     )
                     scheduler.record_acquisition_failure(
                         request,
                         reason="acquisition_request_timeout",
                         failed_paths=sent_paths or frozenset(request.paths),
                         now=now,
+                        link_healthy=link_healthy,
                     )
-                    self._acquisition_in_flight.pop(request.id, None)
-                    continue
+                    if not link_healthy:
+                        self._acquisition_in_flight.pop(request.id, None)
+                        continue
+                    # Healthy link: leave in flight, skip re-send this cycle.
+                    sent_paths = sent_paths.intersection(request.paths)
+                    if all(path in sent_paths for path in request.paths):
+                        continue
                 else:
                     sent_paths = sent_paths.intersection(request.paths)
 

--- a/tests/test_acquisition_scheduler.py
+++ b/tests/test_acquisition_scheduler.py
@@ -1275,6 +1275,68 @@ def test_unchanged_acquisition_result_decays_cadence_exponentially_and_caps() ->
     assert diagnostics["cadenceByPath"][str(freq)]["nextDueMonotonic"] == 220.0
 
 
+def test_healthy_link_timeout_does_not_count_or_decay_cadence() -> None:
+    # MOR-874: an acquisition_request_timeout reported while the transport is
+    # healthy is a false timeout — the radio answered, the deadline raced. It
+    # must not be counted as a failure, must not drop the pending request, and
+    # must not advance/decay the freq_mode cadence toward the 30 s ceiling.
+    clock = FreshnessClock(start=300.0)
+    freq = FieldPath.active("main", "freq_mode", "freq_hz")
+    policy = AcquisitionPolicy(
+        cadence_seconds=2.0,
+        freshness_ttl_seconds=10.0,
+        adaptive_decay=AdaptiveDecayPolicy(
+            enabled=True,
+            idle_multiplier=2.0,
+            max_cadence_seconds=30.0,
+        ),
+    )
+    scheduler = AcquisitionScheduler(
+        profile=_profile([freq], default_policy=policy),
+        clock=clock,
+    )
+
+    request = scheduler.due_requests()[0]
+    scheduler.record_acquisition_failure(
+        request,
+        reason="acquisition_request_timeout",
+        now=clock.now(),
+        link_healthy=True,
+    )
+
+    diagnostics = scheduler.diagnostics()
+    # No failure counted, request still pending, cadence pinned at base 2.0 s.
+    assert diagnostics["failedRequestCount"] == 0
+    assert "acquisition_request_timeout" not in diagnostics["failureCountByReason"]
+    assert scheduler.pending_requests()[0].id == request.id
+    assert diagnostics["cadenceByPath"][str(freq)]["currentCadenceSeconds"] == 2.0
+
+
+def test_unhealthy_link_timeout_is_counted_and_drops_pending_request() -> None:
+    # MOR-874 (negative case): a real timeout (link NOT healthy) is still a
+    # terminal failure that is counted and clears the pending request.
+    clock = FreshnessClock(start=400.0)
+    freq = FieldPath.active("main", "freq_mode", "freq_hz")
+    policy = AcquisitionPolicy(cadence_seconds=2.0, freshness_ttl_seconds=10.0)
+    scheduler = AcquisitionScheduler(
+        profile=_profile([freq], default_policy=policy),
+        clock=clock,
+    )
+
+    request = scheduler.due_requests()[0]
+    scheduler.record_acquisition_failure(
+        request,
+        reason="acquisition_request_timeout",
+        now=clock.now(),
+        link_healthy=False,
+    )
+
+    diagnostics = scheduler.diagnostics()
+    assert diagnostics["failedRequestCount"] == 1
+    assert diagnostics["failureCountByReason"]["acquisition_request_timeout"] == 1
+    assert scheduler.pending_requests() == ()
+
+
 def test_semantic_change_resets_adaptive_cadence_to_base_policy() -> None:
     clock = FreshnessClock(start=220.0)
     freq = FieldPath.active("main", "freq_mode", "freq_hz")

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -15,6 +15,7 @@ from rigplane.core.acquisition_scheduler import (
 )
 from rigplane.core.state_acquisition_policy import (
     AcquisitionPolicy,
+    AdaptiveDecayPolicy,
     FieldCapability,
     RadioAcquisitionProfile,
 )
@@ -394,6 +395,154 @@ async def test_scheduler_due_request_timeout_is_terminal_not_resent_each_tick() 
     diagnostics = scheduler.diagnostics()
     assert diagnostics["failedRequestCount"] == 1
     assert diagnostics["failureCountByReason"]["acquisition_request_timeout"] == 1
+
+
+def _healthy_radio(active: str = "MAIN", *, last_civ: float) -> MagicMock:
+    # MOR-874: a radio whose CI-V link reads as healthy (recent data, not
+    # recovering) for the poller's _civ_link_healthy gate.
+    radio = _make_radio(active=active)
+    radio._civ_recovering = False
+    radio._last_civ_data_received = last_civ
+    radio._civ_ready_idle_timeout = 2.0
+    return radio
+
+
+@pytest.mark.asyncio
+async def test_sent_request_deadline_is_send_relative_not_enqueue_relative() -> None:
+    # MOR-874 fix 1: a request that sat queued and sent late must be judged
+    # from its SEND time, not enqueue time. With send_at far past
+    # enqueue + max_age, the request must NOT yet be expired while still
+    # inside its send-relative window.
+    radio = _make_radio(active="MAIN")
+    path = FieldPath.receiver("main", "meters", "s_meter")
+    policy = AcquisitionPolicy(cadence_seconds=1.0, freshness_ttl_seconds=1.0)
+    scheduler = AcquisitionScheduler(profile=_acquisition_profile(path, policy=policy))
+    radio._acquisition_scheduler = scheduler
+    poller = RadioPoller(radio, CommandQueue(), radio_state=RadioState())
+    request = scheduler.due_requests(now=100.0)[0]
+
+    # Enqueue-relative deadline is enqueue(100.0) + max_age(1.0) = 101.0, but
+    # the request was actually SENT at 200.0; at 200.5 (0.5 s after send) it is
+    # still well within the 1.0 s window and must not be expired.
+    sent_relative = poller._acquisition_request_expired(  # noqa: SLF001
+        request,
+        sent_at=200.0,
+        now=200.5,
+    )
+    assert sent_relative is False
+    # Past the send-relative window (200.0 + 1.0) it does expire.
+    assert (
+        poller._acquisition_request_expired(  # noqa: SLF001
+            request,
+            sent_at=200.0,
+            now=201.1,
+        )
+        is True
+    )
+    # A never-sent request (sent_at == 0) still uses the enqueue deadline.
+    assert (
+        poller._acquisition_request_expired(  # noqa: SLF001
+            request,
+            sent_at=0.0,
+            now=101.5,
+        )
+        is True
+    )
+
+
+@pytest.mark.asyncio
+async def test_credited_in_flight_request_is_cleared_and_does_not_expire() -> None:
+    # MOR-874 fix 2: once the returning observation credits the request
+    # (record_acquisition_result removes it from pending), the next send cycle
+    # clears the in-flight entry — it never expires as a timeout.
+    radio = _healthy_radio(last_civ=500.0)
+    path = FieldPath.receiver("main", "meters", "s_meter")
+    scheduler = AcquisitionScheduler(profile=_acquisition_profile(path))
+    radio._acquisition_scheduler = scheduler
+    executor = _InjectedAcquisitionExecutor()
+    poller = RadioPoller(
+        radio,
+        CommandQueue(),
+        radio_state=RadioState(),
+        acquisition_executor=executor,
+    )
+
+    with patch("rigplane.web.radio_poller.time.monotonic", return_value=500.0):
+        await poller._send_scheduler_requests()  # noqa: SLF001
+    assert len(poller._acquisition_in_flight) == 1  # noqa: SLF001
+    request = scheduler.pending_requests()[0]
+
+    # Returning observation credits the request (removes it from pending).
+    from rigplane.core.state_pipeline_contracts import ChangeSet, SourceMetadata
+
+    scheduler.record_acquisition_result(
+        request,
+        ChangeSet(
+            revision=1,
+            freshness_revision=1,
+            observation_seq=1,
+            changes=(),
+            timestamp_monotonic=500.0,
+            sources=(SourceMetadata(source="poll_response", provider="icom_civ"),),
+        ),
+    )
+
+    # Next cycle clears the in-flight entry; no timeout failure is recorded.
+    with patch("rigplane.web.radio_poller.time.monotonic", return_value=500.1):
+        await poller._send_scheduler_requests()  # noqa: SLF001
+    assert poller._acquisition_in_flight == {}  # noqa: SLF001
+    assert scheduler.diagnostics()["failedRequestCount"] == 0
+
+
+@pytest.mark.asyncio
+async def test_healthy_link_false_timeout_does_not_decay_freq_mode_cadence() -> None:
+    # MOR-874 fix 3 (integration): under a healthy CI-V link, a deadline that
+    # fires before the answer lands must NOT be counted as a timeout and must
+    # keep freq_mode cadence at base (no decay toward the 30 s ceiling). The
+    # request stays in flight for the late answer to credit.
+    path = FieldPath.active("main", "freq_mode", "freq_hz")
+    policy = AcquisitionPolicy(
+        cadence_seconds=2.0,
+        freshness_ttl_seconds=2.0,
+        adaptive_decay=AdaptiveDecayPolicy(
+            enabled=True,
+            idle_multiplier=2.0,
+            max_cadence_seconds=30.0,
+        ),
+    )
+    radio = _healthy_radio(last_civ=700.0)
+    scheduler = AcquisitionScheduler(profile=_acquisition_profile(path, policy=policy))
+    radio._acquisition_scheduler = scheduler
+    executor = _InjectedAcquisitionExecutor()
+    poller = RadioPoller(
+        radio,
+        CommandQueue(),
+        radio_state=RadioState(),
+        acquisition_executor=executor,
+    )
+
+    # Run many cycles. The clock advances 3 s per cycle (well past the 2 s
+    # send-relative window, so the deadline fires every cycle after the first),
+    # but the CI-V link stays healthy (last-civ kept within the 2 s readiness
+    # window of the advancing clock) — i.e. WSJT-X-style load with the radio
+    # answering fast but the deadline racing.
+    clock = {"t": 700.0}
+
+    def _now() -> float:
+        return clock["t"]
+
+    with patch("rigplane.web.radio_poller.time.monotonic", side_effect=_now):
+        for _ in range(8):
+            # Link stays healthy: last CI-V data is 0.1 s old vs the clock.
+            radio._last_civ_data_received = clock["t"] - 0.1
+            await poller._send_scheduler_requests()  # noqa: SLF001
+            clock["t"] += 3.0
+
+    diagnostics = scheduler.diagnostics()
+    # No false timeouts counted, cadence pinned at base 2.0 s (no decay).
+    assert "acquisition_request_timeout" not in diagnostics["failureCountByReason"]
+    assert diagnostics["failedRequestCount"] == 0
+    assert diagnostics["cadenceByPath"][str(path)]["currentCadenceSeconds"] == 2.0
 
 
 @pytest.mark.asyncio

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -521,28 +521,136 @@ async def test_healthy_link_false_timeout_does_not_decay_freq_mode_cadence() -> 
         acquisition_executor=executor,
     )
 
-    # Run many cycles. The clock advances 3 s per cycle (well past the 2 s
-    # send-relative window, so the deadline fires every cycle after the first),
-    # but the CI-V link stays healthy (last-civ kept within the 2 s readiness
-    # window of the advancing clock) — i.e. WSJT-X-style load with the radio
-    # answering fast but the deadline racing.
+    # Cycle 1 sends the request. Cycle 2 advances 3 s — past the 2 s
+    # send-relative window so the deadline fires — but the CI-V link stays
+    # healthy (last-civ kept within the 2 s readiness window of the advancing
+    # clock): a WSJT-X-style load with the radio answering fast but the deadline
+    # racing. The expiry is suppressed (still inside the bounded grace window),
+    # then the slightly-late answer arrives and CREDITS the request — the true
+    # happy path the grace exists to protect.
+    from rigplane.core.state_pipeline_contracts import (
+        ChangeSet,
+        FieldChange,
+        SourceMetadata,
+    )
+
     clock = {"t": 700.0}
 
     def _now() -> float:
         return clock["t"]
 
     with patch("rigplane.web.radio_poller.time.monotonic", side_effect=_now):
-        for _ in range(8):
-            # Link stays healthy: last CI-V data is 0.1 s old vs the clock.
-            radio._last_civ_data_received = clock["t"] - 0.1
-            await poller._send_scheduler_requests()  # noqa: SLF001
-            clock["t"] += 3.0
+        # Cycle 1: send.
+        radio._last_civ_data_received = clock["t"] - 0.1
+        await poller._send_scheduler_requests()  # noqa: SLF001
+        request = scheduler.pending_requests()[0]
+        clock["t"] += 3.0
 
+        # Cycle 2: deadline fires while healthy → suppressed within grace, no
+        # re-send (executor still called exactly once).
+        radio._last_civ_data_received = clock["t"] - 0.1
+        await poller._send_scheduler_requests()  # noqa: SLF001
+        assert len(executor.calls) == 1
+
+        # The slightly-late answer lands and credits the request (still well
+        # inside the 6 s grace window). It carries a value change, so cadence
+        # resets to base — proving the credit path ran and the suppressed
+        # false timeout never advanced/decayed cadence.
+        scheduler.record_acquisition_result(
+            request,
+            ChangeSet(
+                revision=1,
+                freshness_revision=1,
+                observation_seq=1,
+                changes=(
+                    FieldChange(path=path, previous=14_000_000, current=14_074_000),
+                ),
+                timestamp_monotonic=clock["t"],
+                sources=(SourceMetadata(source="poll_response", provider="icom_civ"),),
+            ),
+        )
+        clock["t"] += 0.1
+
+        # Next cycle clears the in-flight + grace bookkeeping.
+        radio._last_civ_data_received = clock["t"] - 0.1
+        await poller._send_scheduler_requests()  # noqa: SLF001
+
+    assert poller._acquisition_in_flight == {}  # noqa: SLF001
+    assert poller._acquisition_healthy_grace_started == {}  # noqa: SLF001
     diagnostics = scheduler.diagnostics()
     # No false timeouts counted, cadence pinned at base 2.0 s (no decay).
     assert "acquisition_request_timeout" not in diagnostics["failureCountByReason"]
     assert diagnostics["failedRequestCount"] == 0
     assert diagnostics["cadenceByPath"][str(path)]["currentCadenceSeconds"] == 2.0
+
+
+@pytest.mark.asyncio
+async def test_healthy_link_uncredited_request_is_resent_and_eventually_fails() -> None:
+    # MOR-874 regression (BLOCKING fix): the health gate reads the GLOBAL
+    # last-CI-V timestamp, so under external-CAT load it reads healthy
+    # ~permanently. A request whose SPECIFIC answer is genuinely lost (UDP drop
+    # / radio silently ignores the command) must NOT be pinned in flight
+    # forever. The bounded grace window
+    # (_ACQUISITION_HEALTHY_GRACE_SECONDS) caps the false-timeout suppression:
+    # once it elapses with the request still uncredited, the request is treated
+    # as a REAL timeout — dropped so the scheduler re-queues/re-sends it, with
+    # normal failure accounting. This proves recovery (executor called > 1) and
+    # that the loss is eventually accounted as a real failure (not pinned).
+    from rigplane.web.radio_poller import _ACQUISITION_HEALTHY_GRACE_SECONDS
+
+    path = FieldPath.active("main", "freq_mode", "freq_hz")
+    policy = AcquisitionPolicy(
+        cadence_seconds=2.0,
+        freshness_ttl_seconds=2.0,
+        adaptive_decay=AdaptiveDecayPolicy(
+            enabled=True,
+            idle_multiplier=2.0,
+            max_cadence_seconds=30.0,
+        ),
+    )
+    radio = _healthy_radio(last_civ=900.0)
+    scheduler = AcquisitionScheduler(profile=_acquisition_profile(path, policy=policy))
+    radio._acquisition_scheduler = scheduler
+    executor = _InjectedAcquisitionExecutor()
+    poller = RadioPoller(
+        radio,
+        CommandQueue(),
+        radio_state=RadioState(),
+        acquisition_executor=executor,
+    )
+
+    # The answer is NEVER credited. The link reads healthy every cycle. The
+    # clock advances past the grace window each lap, so each in-flight request
+    # eventually exceeds grace, falls back to a real timeout, is dropped, and
+    # the scheduler re-queues + re-sends it on a later cycle.
+    clock = {"t": 900.0}
+
+    def _now() -> float:
+        return clock["t"]
+
+    # Step well past the grace window per cycle so the bound is provably
+    # crossed within a small, bounded number of cycles.
+    step = _ACQUISITION_HEALTHY_GRACE_SECONDS + 2.0
+
+    with patch("rigplane.web.radio_poller.time.monotonic", side_effect=_now):
+        for _ in range(6):
+            radio._last_civ_data_received = clock["t"] - 0.1
+            await poller._send_scheduler_requests()  # noqa: SLF001
+            clock["t"] += step
+
+    # Recovery proven: the request was re-sent (executor called more than once).
+    assert len(executor.calls) > 1
+    # Eventually accounted as a real failure — NOT pinned forever.
+    diagnostics = scheduler.diagnostics()
+    assert diagnostics["failedRequestCount"] >= 1
+    assert (
+        diagnostics["failureCountByReason"].get("acquisition_request_timeout", 0) >= 1
+    )
+    # Grace bookkeeping for dropped requests does not leak.
+    assert all(
+        rid in {r.id for r in scheduler.pending_requests()}
+        for rid in poller._acquisition_healthy_grace_started  # noqa: SLF001
+    )
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -1958,7 +1958,7 @@ wheels = [
 
 [[package]]
 name = "rigplane"
-version = "2.10.0"
+version = "2.10.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Releases rigplane-core **2.10.2** (already published to PyPI from tag `v2.10.2` @ `02c74b48`).

Fixes the IC-7610 state-acquisition regression with an external CAT master (e.g. WSJT-X via rigctld): false `acquisition_request_timeout`s drove adaptive poll cadence (frequency / mode / data-mode) to decay to 30 s, making the web VFO/mode/DATA readouts go stale and appear to revert.

The fix:
- makes acquisition deadlines send-relative;
- gates adaptive decay on transport health;
- adds a bounded grace before a healthy-link expiry is treated as a real timeout.

Refs: rigplane-pro#1198, MOR-874.

## Commits
- `aa820d5c` send-relative deadline + gate adaptive decay on transport health
- `ed0af546` bound healthy-link acquisition false-timeout grace
- `0070b7e4` release: 2.10.2 (version bump + CHANGELOG)
- `02c74b48` fix(types): annotate `_acquisition_request_expired` -> bool (mypy --strict)
- `48a89fe3` chore: sync uv.lock rigplane version to 2.10.2

## Verification
- ruff check + format: clean
- mypy --strict src/rigplane/web: Success (24 files)
- lint-imports: 5 contracts kept, 0 broken
- pytest tests/ --ignore=tests/integration -n auto: 7967 passed, 73 skipped, 11 xfailed, 1 xpassed
- frontend: check 0 errors, vitest 2178 passed (126 files), build OK
- publish.yml run 27792614983: success; PyPI rigplane 2.10.2 live

## Boundary
open-core candidate (public rigplane-core fix + release).

## Out of scope
- 3.11 validate matrix leg remains disabled (pre-existing test-fixture issues, tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)