### PR TITLE
release: rigplane-core 2.10.3

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.10.3] — 2026-06-18
+
+### Fixed
+
+- **rigctld `get_mode` no longer clobbers canonical StateStore.** The WSJT-X
+  CAT `get_mode` poll was a read that wrote back `bool(data_mode)` and the
+  filter number into the `filter_width` slot of the canonical StateStore,
+  corrupting `/api/v1/state` mid-session (DATA mode blanked on the web UI,
+  filter forced to "1", scope/passband narrowed) whenever WSJT-X connected.
+  `get_mode`/`set_mode` are now read-only on the data_mode/filter projection;
+  `data_mode` stays an int (PR #1884).
+- **rigctld `get_vfo` first-connect and mid-session EIO resolved.** `get_vfo`
+  returned `RPRT -6` (EIO / "IO error") when the VFO projection was stale or
+  not yet fresh, dropping active WSJT-X FT8 sessions mid-run; it now returns
+  the active VFO name (VFOA). The `get_mode` passband now reads the
+  filter-number projection instead of `filter_width` (Hz), and `set_mode`
+  overlays the filter-number path (PR #1884).
+
+### Added
+
+- Canonical state-payload schema with TypeScript codegen as a reference
+  contract pattern (MOR-881, dev tooling; PR #1883).
+
 ## [2.10.2] — 2026-06-18
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "rigplane"
-version = "2.10.2"
+version = "2.10.3"
 description = "Multi-vendor radio control library and Web UI with native providers and planned Hamlib-backed CAT coverage"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -2084,7 +2084,7 @@ wheels = [
 
 [[package]]
 name = "rigplane"
-version = "2.10.2"
+version = "2.10.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Publishes rigplane 2.10.3 to PyPI. This release ships two already-merged bug-fix PRs and one dev-tooling addition that landed on `main` since the 2.10.2 tag:

- **rigctld `get_mode` StateStore clobber fix (PR #1884)** — the WSJT-X CAT `get_mode` poll was inadvertently writing `bool(data_mode)` and the filter number into the `filter_width` slot of the canonical StateStore, corrupting `/api/v1/state` mid-session (DATA mode blanked on the web UI, filter forced to "1", passband narrowed). `get_mode`/`set_mode` are now read-only on the data_mode/filter projection; `data_mode` stays an int.
- **rigctld `get_vfo` EIO fix (PR #1884)** — `get_vfo` returned `RPRT -6` (EIO / "IO error") when the VFO projection was stale or not yet fresh, dropping active WSJT-X FT8 sessions mid-run. It now returns the active VFO name (VFOA). The `get_mode` passband now reads the filter-number projection instead of `filter_width` (Hz), and `set_mode` overlays the filter-number path.
- **Canonical state-payload schema + TypeScript codegen (MOR-881, PR #1883)** — reference contract pattern for dev tooling; no runtime behaviour change.

## Files changed

- `pyproject.toml` — `version` bumped `2.10.2` → `2.10.3`
- `uv.lock` — rigplane self-version entry updated to `2.10.3` (minimal diff, no dep upgrades)
- `docs/CHANGELOG.md` — new `[2.10.3] — 2026-06-18` section added under `[Unreleased]`

## Verification

```
uv run ruff check .      # All checks passed
uv run ruff format --check .  # Only pre-existing unrelated files flagged (docs/plans artifacts, hooks/sitemap_noindex.py — not touched by this PR)
```

The diff is metadata-only (version bump + changelog); no Python source logic was changed so a full pytest run is not required locally.

## Boundary

`open-core` (rigplane-core / rigplane PyPI package)