### PR TITLE
release: rigplane-core 2.10.6 — fix web RX audio silence after reconnect

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.10.6] — 2026-06-19
+
+### Fixed
+
+- **Web RX audio went silent after a reconnect until app restart.** On reconnect the
+  browser reopened the audio WebSocket, but the prior half-open socket was not reaped
+  (it still reported alive until the pong timeout), so the audio broadcaster kept a
+  zombie subscriber and the live tab stopped rendering audio. A stable per-client audio
+  identity now coalesces a reconnecting client's prior subscription (dropping the
+  superseded socket), so web audio recovers automatically without an app restart. (#1216)
+
 ## [2.10.5] — 2026-06-19
 
 ### Fixed

--- a/frontend/src/lib/audio/__tests__/audio-manager.test.ts
+++ b/frontend/src/lib/audio/__tests__/audio-manager.test.ts
@@ -76,6 +76,19 @@ class FakeWebSocket {
     this.readyState = FakeWebSocket.OPEN;
     this.onopen?.();
   }
+
+  /** Simulate the server dropping this socket (soft_reconnect / audio
+   *  re-arm): fires onclose so the manager's reconnect path runs. */
+  serverClose(code = 1006, reason = 'rearm') {
+    this.readyState = 3;
+    this.onclose?.({ code, reason });
+  }
+}
+
+function rxStartMessages(ws: FakeWebSocket): Array<Record<string, unknown>> {
+  return ws.sent
+    .map((s) => JSON.parse(s as string) as Record<string, unknown>)
+    .filter((m) => m.type === 'audio_start' && m.direction === 'rx');
 }
 
 describe('AudioManager websocket subscriptions', () => {
@@ -97,11 +110,13 @@ describe('AudioManager websocket subscriptions', () => {
 
     audioManager.startRx();
 
-    expect(ws.sent).toContain(JSON.stringify({
-      type: 'audio_start',
-      direction: 'rx',
-      preferred_rx_codec: 'pcm16',
-    }));
+    expect(rxStartMessages(ws)).toContainEqual(
+      expect.objectContaining({
+        type: 'audio_start',
+        direction: 'rx',
+        preferred_rx_codec: 'pcm16',
+      }),
+    );
   });
 
   it('sends rx audio_stop before closing an open websocket', async () => {
@@ -125,11 +140,13 @@ describe('AudioManager websocket subscriptions', () => {
     const ws = FakeWebSocket.instances[0];
     ws.open();
 
-    expect(ws.sent).toContain(JSON.stringify({
-      type: 'audio_start',
-      direction: 'rx',
-      preferred_rx_codec: 'opus',
-    }));
+    expect(rxStartMessages(ws)).toContainEqual(
+      expect.objectContaining({
+        type: 'audio_start',
+        direction: 'rx',
+        preferred_rx_codec: 'opus',
+      }),
+    );
   });
 
   it('requests pcm16 inside the Tauri shell even when AudioDecoder is available', async () => {
@@ -141,11 +158,13 @@ describe('AudioManager websocket subscriptions', () => {
     const ws = FakeWebSocket.instances[0];
     ws.open();
 
-    expect(ws.sent).toContain(JSON.stringify({
-      type: 'audio_start',
-      direction: 'rx',
-      preferred_rx_codec: 'pcm16',
-    }));
+    expect(rxStartMessages(ws)).toContainEqual(
+      expect.objectContaining({
+        type: 'audio_start',
+        direction: 'rx',
+        preferred_rx_codec: 'pcm16',
+      }),
+    );
   });
 });
 
@@ -217,5 +236,53 @@ describe('AudioManager audio_stats uplink (MOR-585)', () => {
     vi.advanceTimersByTime(10000);
     expect(statsMessages(ws)).toEqual([]);
     expect(vi.getTimerCount()).toBe(0);
+  });
+});
+
+describe('AudioManager reconnect coalescing (MOR-924)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllGlobals();
+    vi.useFakeTimers();
+    FakeWebSocket.instances = [];
+    vi.stubGlobal('WebSocket', FakeWebSocket);
+    vi.stubGlobal('location', { protocol: 'http:', host: 'localhost:5173' });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('re-sends audio_start with the SAME stable client_id after a server-side reconnect', async () => {
+    const { audioManager } = await import('../audio-manager');
+
+    // Initial RX subscribe.
+    audioManager.startRx();
+    const first = FakeWebSocket.instances[0];
+    first.open();
+    const firstStart = rxStartMessages(first);
+    expect(firstStart).toHaveLength(1);
+    const clientId = firstStart[0].client_id;
+    // Identity must be a non-empty stable token sent on the wire.
+    expect(typeof clientId).toBe('string');
+    expect(clientId).not.toBe('');
+
+    // Server drops the socket (soft_reconnect / audio re-arm). The manager
+    // schedules a backoff reconnect.
+    first.serverClose();
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    vi.advanceTimersByTime(600); // > BACKOFF_MIN
+    expect(FakeWebSocket.instances).toHaveLength(2);
+
+    // The reconnected socket opens and must re-subscribe with the SAME
+    // identity so the broadcaster can drop the prior zombie subscription
+    // (instead of fanning RX out to two subscribers — the silent-audio bug).
+    const second = FakeWebSocket.instances[1];
+    second.open();
+    const secondStart = rxStartMessages(second);
+    expect(secondStart).toHaveLength(1);
+    expect(secondStart[0].client_id).toBe(clientId);
+
+    audioManager.stopRx();
   });
 });

--- a/frontend/src/lib/audio/audio-manager.ts
+++ b/frontend/src/lib/audio/audio-manager.ts
@@ -29,6 +29,19 @@ const BACKOFF_MAX = 10000;
 // message per 1.5 s while RX is active.
 const AUDIO_STATS_INTERVAL_MS = 1500;
 
+/** Stable per-page-context token so the server can coalesce this audio
+ *  manager's reconnects (MOR-924). A soft_reconnect / audio re-arm drops the
+ *  audio WS; the browser reopens it and re-sends ``audio_start`` carrying the
+ *  same ``client_id``, letting the broadcaster drop the prior (now-zombie)
+ *  subscription synchronously instead of fanning RX out to two subscribers
+ *  until the half-open socket finally times out. Distinct AudioManager
+ *  instances (a genuine second tab) get distinct ids and are NOT coalesced. */
+function makeClientId(): string {
+  const c = (globalThis as { crypto?: { randomUUID?: () => string } }).crypto;
+  if (c?.randomUUID) return c.randomUUID();
+  return `audio-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
 function preferredRxCodec(): 'opus' | 'pcm16' {
   const globals = globalThis as typeof globalThis & {
     __TAURI__?: unknown;
@@ -50,6 +63,8 @@ class AudioManager {
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private statsTimer: ReturnType<typeof setInterval> | null = null;
   private _listeners: Set<() => void> = new Set();
+  // Stable identity for reconnect coalescing (MOR-924); see makeClientId.
+  private readonly clientId = makeClientId();
 
   // Reactive state (read externally)
   get rxEnabled(): boolean { return this._rxEnabled; }
@@ -111,6 +126,7 @@ class AudioManager {
         type: 'audio_start',
         direction: 'rx',
         preferred_rx_codec: preferredRxCodec(),
+        client_id: this.clientId,
       }));
     }
     this.notify();
@@ -240,6 +256,7 @@ class AudioManager {
           type: 'audio_start',
           direction: 'rx',
           preferred_rx_codec: preferredRxCodec(),
+          client_id: this.clientId,
         }));
       }
       if (this._txEnabled) {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "rigplane"
-version = "2.10.5"
+version = "2.10.6"
 description = "Multi-vendor radio control library and Web UI with native providers and planned Hamlib-backed CAT coverage"
 readme = "README.md"
 license = "MIT"

--- a/src/rigplane/web/handlers/audio.py
+++ b/src/rigplane/web/handlers/audio.py
@@ -118,6 +118,20 @@ def _parse_preferred_rx_codec(msg: dict[str, Any]) -> int | None:
     return None
 
 
+def _parse_client_identity(msg: dict[str, Any]) -> str | None:
+    """Stable per-browser token from an ``audio_start`` (MOR-924).
+
+    Used for reconnect coalescing: a browser sends the same ``client_id``
+    on every (re)subscribe so the broadcaster can drop its prior, now-stale
+    subscription. Absent/blank/non-string is treated as "no identity" — old
+    clients that never send one keep the pre-MOR-924 behavior unchanged.
+    """
+    value = msg.get("client_id")
+    if isinstance(value, str) and value:
+        return value
+    return None
+
+
 class _AudioPacketLike(Protocol):
     data: bytes
 
@@ -157,6 +171,14 @@ class AudioBroadcaster:
         self._clients: dict[int, asyncio.Queue[bytes]] = {}
         self._client_ws: dict[int, Connection] = {}
         self._client_rx_codec: dict[int, int] = {}
+        # Stable per-browser identity supplied by the client on audio_start
+        # (MOR-924 reconnect coalescing). When a browser's audio WS drops on
+        # a soft_reconnect / audio re-arm and the client reconnects, the new
+        # subscribe carries the same identity; the prior (now-zombie)
+        # subscription is dropped synchronously so subscribers converge to
+        # exactly one per browser instead of waiting up to the 60 s pong
+        # timeout for ``reap_dead_clients`` to notice the half-open socket.
+        self._client_identity: dict[int, str] = {}
         # RX source handle: a session-routed RxSubscription when the radio
         # owns an AudioSession (MOR-608 — registers RX demand so the
         # MOR-581 watchdog covers browser-only listeners), or a legacy
@@ -234,14 +256,35 @@ class AudioBroadcaster:
         ws: Connection | None = None,
         *,
         preferred_rx_codec: int | None = None,
+        identity: str | None = None,
     ) -> asyncio.Queue[bytes]:
-        """Register a new WebSocket client and start relaying if first."""
+        """Register a new WebSocket client and start relaying if first.
+
+        ``identity`` is a stable per-browser token (MOR-924). When set, any
+        EXISTING client carrying the same identity — a stale subscription
+        left behind by the same browser's previous WS before its half-open
+        socket is reaped — is dropped and its WS closed before the new
+        client is registered, so subscribers converge to exactly one per
+        browser on reconnect instead of leaking a zombie fan-out target.
+        """
         queue: asyncio.Queue[bytes] = asyncio.Queue(maxsize=self.HIGH_WATERMARK)
         client_id = id(queue)
+        stale_ws: list[Connection] = []
         async with self._lock:
+            if identity is not None:
+                for old_id in [
+                    cid
+                    for cid, ident in self._client_identity.items()
+                    if ident == identity
+                ]:
+                    old_ws = self._drop_client(old_id)
+                    if old_ws is not None:
+                        stale_ws.append(old_ws)
             self._clients[client_id] = queue
             if ws is not None:
                 self._client_ws[client_id] = ws
+            if identity is not None:
+                self._client_identity[client_id] = identity
             if preferred_rx_codec is not None:
                 self._client_rx_codec[client_id] = preferred_rx_codec
             if self._adaptive_egress and preferred_rx_codec == AUDIO_CODEC_OPUS:
@@ -263,23 +306,59 @@ class AudioBroadcaster:
                     await self._release_subscription()
                 if self._radio:
                     await self._start_relay()
+        # Close any superseded sockets OUTSIDE the lock — the close awaits a
+        # drain and must never block subscribe under the broadcaster lock.
+        for old_ws in stale_ws:
+            try:
+                await old_ws.close(1001, "superseded by reconnect")
+            except Exception:
+                logger.debug(
+                    "audio-broadcaster: superseded ws close failed", exc_info=True
+                )
+        if stale_ws:
+            logger.info(
+                "audio-broadcaster: dropped %d superseded client(s) on reconnect "
+                "(identity=%s)",
+                len(stale_ws),
+                identity,
+            )
         self._notify_client_count_change()
         logger.info("audio-broadcaster: client added (total=%d)", len(self._clients))
         return queue
+
+    def _drop_client(self, client_id: int) -> Connection | None:
+        """Remove ALL per-client state for ``client_id``. Returns its ws (if any).
+
+        Single source of truth for per-client teardown — used by the
+        reconnect-coalescing path in :meth:`subscribe`, :meth:`unsubscribe`,
+        :meth:`reap_dead_clients`, and the relay loop's mid-stream dead-client
+        sweep, so a new per-client dict can never be forgotten in one of them.
+
+        Callers that mutate the client maps concurrently
+        (subscribe/unsubscribe/reap_dead_clients) hold ``self._lock``; the
+        relay loop calls this WITHOUT the lock, which is safe because every
+        map mutation here is an idempotent ``.pop(id, None)`` (this mirrors
+        the prior inline sweep, which was also lock-free). Closing the
+        returned ws is the caller's job and must happen outside the lock.
+        """
+        ws = self._client_ws.pop(client_id, None)
+        self._clients.pop(client_id, None)
+        self._client_identity.pop(client_id, None)
+        self._client_rx_codec.pop(client_id, None)
+        self._client_opus_transcoders.pop(client_id, None)
+        self._client_opus_pcm_buffers.pop(client_id, None)
+        self._client_link_quality.pop(client_id, None)
+        self._client_queue_drops.pop(client_id, None)
+        self._client_adaptive.pop(client_id, None)
+        return ws
 
     async def unsubscribe(self, queue: asyncio.Queue[bytes]) -> None:
         """Unregister a client and stop relay if last (unless PCM tap is active)."""
         client_id = id(queue)
         removed = False
         async with self._lock:
-            removed = self._clients.pop(client_id, None) is not None
-            self._client_ws.pop(client_id, None)
-            self._client_rx_codec.pop(client_id, None)
-            self._client_opus_transcoders.pop(client_id, None)
-            self._client_opus_pcm_buffers.pop(client_id, None)
-            self._client_link_quality.pop(client_id, None)
-            self._client_queue_drops.pop(client_id, None)
-            self._client_adaptive.pop(client_id, None)
+            removed = client_id in self._clients
+            self._drop_client(client_id)
             if (
                 not self._clients
                 and self._subscription is not None
@@ -387,14 +466,7 @@ class AudioBroadcaster:
                 cid for cid, ws in list(self._client_ws.items()) if not ws.is_alive()
             ]
             for cid in dead_ids:
-                self._clients.pop(cid, None)
-                self._client_ws.pop(cid, None)
-                self._client_rx_codec.pop(cid, None)
-                self._client_opus_transcoders.pop(cid, None)
-                self._client_opus_pcm_buffers.pop(cid, None)
-                self._client_link_quality.pop(cid, None)
-                self._client_queue_drops.pop(cid, None)
-                self._client_adaptive.pop(cid, None)
+                self._drop_client(cid)
             # Stop relay if no clients remain (and no PCM tap active)
             if (
                 not self._clients
@@ -999,14 +1071,7 @@ class AudioBroadcaster:
                                 pass
                 self._seq = (self._seq + 1) & 0xFFFF
                 for client_id in dead_ids:
-                    self._clients.pop(client_id, None)
-                    self._client_ws.pop(client_id, None)
-                    self._client_rx_codec.pop(client_id, None)
-                    self._client_opus_transcoders.pop(client_id, None)
-                    self._client_opus_pcm_buffers.pop(client_id, None)
-                    self._client_link_quality.pop(client_id, None)
-                    self._client_queue_drops.pop(client_id, None)
-                    self._client_adaptive.pop(client_id, None)
+                    self._drop_client(client_id)
                     logger.info("audio-broadcaster: removed dead client during relay")
                 if dead_ids:
                     self._notify_client_count_change()
@@ -1183,7 +1248,10 @@ class AudioHandler:
 
         if msg_type == "audio_start":
             if direction == "rx":
-                await self._start_rx(preferred_rx_codec=_parse_preferred_rx_codec(msg))
+                await self._start_rx(
+                    preferred_rx_codec=_parse_preferred_rx_codec(msg),
+                    identity=_parse_client_identity(msg),
+                )
             elif direction == "tx":
                 if self._radio and CAP_AUDIO in self._radio.capabilities:
                     self._ensure_tx_transcoder()
@@ -1526,7 +1594,12 @@ class AudioHandler:
         else:
             await getattr(self._radio, legacy_method)(data)
 
-    async def _start_rx(self, *, preferred_rx_codec: int | None = None) -> None:
+    async def _start_rx(
+        self,
+        *,
+        preferred_rx_codec: int | None = None,
+        identity: str | None = None,
+    ) -> None:
         """Subscribe to audio broadcaster for RX frames."""
         if not self._broadcaster:
             return
@@ -1534,6 +1607,7 @@ class AudioHandler:
         self._frame_queue = await self._broadcaster.subscribe(
             ws=self._ws,
             preferred_rx_codec=preferred_rx_codec,
+            identity=identity,
         )
         # Per-connection negotiation ack (MOR-584): tell the client which
         # wire codec/format it will receive.  Advisory and fire-and-forget

--- a/tests/test_web_audio_reconnect_coalesce.py
+++ b/tests/test_web_audio_reconnect_coalesce.py
@@ -1,0 +1,100 @@
+"""Reconnect subscriber coalescing on the RX broadcaster (MOR-924).
+
+Falsification suite for the silent-web-audio regression: after a
+``soft_reconnect`` / audio re-arm the browser's audio WS drops and the
+client reconnects, re-sending ``audio_start`` with the SAME stable
+``client_id``. Before the fix the broadcaster registered the new
+subscription while the prior one's half-open socket was still
+``is_alive()`` (pong timeout up to 60 s), so RX fanned out to TWO
+subscribers on TWO sockets — the live tab's player and an abandoned
+zombie — and stayed at ``total=2`` for the rest of the session until a
+full app restart (the user-observed symptom).
+
+The broadcaster must instead drop the prior subscription carrying the
+same identity SYNCHRONOUSLY on the new subscribe, converging to exactly
+one subscriber per browser, and must close the superseded socket so its
+handler unwinds.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+from rigplane.audio_bus import AudioBus
+from rigplane.radio_protocol import AudioCapable
+from rigplane.types import AudioCodec
+from rigplane.web.handlers import AudioBroadcaster
+from rigplane.web.websocket import WebSocketConnection
+
+
+def _make_radio() -> tuple[Any, AudioBus]:
+    radio = MagicMock(spec=AudioCapable)
+    radio.capabilities = {"audio"}
+    radio.audio_codec = AudioCodec.PCM_1CH_16BIT
+    radio.audio_sample_rate = 48000
+    bus = AudioBus(radio)
+    radio.audio_bus = bus
+    return radio, bus
+
+
+def _make_ws(alive: bool = True) -> MagicMock:
+    ws = MagicMock(spec=WebSocketConnection)
+    ws.send_text = AsyncMock()
+    ws.send_binary = AsyncMock()
+    ws.close = AsyncMock()
+    # Half-open zombie: the socket still reports alive (pong not yet timed
+    # out) — the exact condition under which reap_dead_clients is a no-op.
+    ws.is_alive.return_value = alive
+    return ws
+
+
+class TestReconnectCoalescing:
+    async def test_same_identity_reconnect_drops_prior_subscriber(self) -> None:
+        """A reconnect with the same client_id converges to exactly 1 client."""
+        radio, _bus = _make_radio()
+        broadcaster = AudioBroadcaster(radio)
+
+        old_ws = _make_ws(alive=True)  # zombie: still "alive" at TCP level
+        old_q = await broadcaster.subscribe(ws=old_ws, identity="tab-A")
+        assert len(broadcaster._clients) == 1
+
+        # Same browser reconnects (new socket, SAME identity) before the
+        # old half-open socket is reaped.
+        new_ws = _make_ws(alive=True)
+        new_q = await broadcaster.subscribe(ws=new_ws, identity="tab-A")
+
+        # Converged to exactly one subscriber — the new one.
+        assert len(broadcaster._clients) == 1
+        assert id(new_q) in broadcaster._clients
+        assert id(old_q) not in broadcaster._clients
+        # The superseded socket was closed so its handler unwinds.
+        old_ws.close.assert_awaited_once()
+        new_ws.close.assert_not_called()
+        # No per-client state leaked for the dropped client.
+        assert id(old_q) not in broadcaster._client_ws
+        assert id(old_q) not in broadcaster._client_identity
+
+    async def test_distinct_identities_are_not_coalesced(self) -> None:
+        """Two genuinely different browsers keep two subscribers."""
+        radio, _bus = _make_radio()
+        broadcaster = AudioBroadcaster(radio)
+
+        ws_a = _make_ws()
+        ws_b = _make_ws()
+        await broadcaster.subscribe(ws=ws_a, identity="tab-A")
+        await broadcaster.subscribe(ws=ws_b, identity="tab-B")
+
+        assert len(broadcaster._clients) == 2
+        ws_a.close.assert_not_called()
+        ws_b.close.assert_not_called()
+
+    async def test_no_identity_preserves_legacy_behavior(self) -> None:
+        """Clients that send no client_id are never coalesced (old clients)."""
+        radio, _bus = _make_radio()
+        broadcaster = AudioBroadcaster(radio)
+
+        await broadcaster.subscribe(ws=_make_ws(), identity=None)
+        await broadcaster.subscribe(ws=_make_ws(), identity=None)
+
+        assert len(broadcaster._clients) == 2

--- a/uv.lock
+++ b/uv.lock
@@ -2125,7 +2125,7 @@ wheels = [
 
 [[package]]
 name = "rigplane"
-version = "2.10.5"
+version = "2.10.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- Bumps `rigplane` to **2.10.6** and adds the CHANGELOG entry.
- Publishes 2.10.6 to PyPI once merged and tagged.

## Fix — web RX audio silence after reconnect (#1216)

On reconnect the browser reopened the audio WebSocket, but the prior
half-open socket was not reaped (it still reported alive until the pong
timeout). The audio broadcaster kept a zombie subscriber, so the live tab
stopped rendering audio until an app restart.

A stable per-client audio identity now coalesces a reconnecting client's
prior subscription — the superseded socket is dropped immediately — so
web audio recovers automatically without an app restart.

References rigplane/rigplane-pro#1216.

## Diff

```
docs/CHANGELOG.md | 11 +++++++++++
pyproject.toml    |  2 +-
uv.lock           |  2 +-
3 files changed, 13 insertions(+), 2 deletions(-)
```

## Verification

- `uv run ruff check .` — clean ✓
- `uv run ruff format --check .` — 4 pre-existing unrelated files flag; no new violations introduced by this commit ✓
- Fix carries its own tests committed in bd1a72f0 (the preceding fix commit); those tests cover stable identity coalescing
- `uv lock --no-upgrade` — only self-version line changed ✓

## Boundary

**open-core candidate** — web audio reconnect logic is in the public core library.

## Out of scope / follow-ups

- Merge, tag, PyPI publish: to be done after required checks are green and Agent Review: PASS is posted.
- The pre-existing `ruff format` failures in `docs/plans/discovery-artifacts/` and `hooks/sitemap_noindex.py` are tracked separately.