### PR TITLE
release: rigplane-core 2.10.7 — CI-V control reconnect auto-recovery (#1217)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.10.7] — 2026-06-20
+
+### Fixed
+
+- **Radio control link now auto-recovers after the radio drops.** After a radio power-cycle or network blip, the CI-V control reconnect stalled after a single attempt (`already_open_stalled`) and the watchdog never re-armed, so the "Radio link recovering" state hung until a manual retry or app restart. Reconnect now rebuilds and keeps retrying with bounded backoff, recovering automatically once the radio answers again. (#1217)
+
+### Added
+
+- **Distinguish "radio reachable but remote-control server not responding" from "radio offline".** When the radio's IP is up but its CI-V/remote-control server isn't answering (e.g. Network/Remote control left off after a power-cycle), the app now reports a distinct cause so it can show an actionable hint instead of a generic recovering message. (#1217)
+
 ## [2.10.6] — 2026-06-19
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "rigplane"
-version = "2.10.6"
+version = "2.10.7"
 description = "Multi-vendor radio control library and Web UI with native providers and planned Hamlib-backed CAT coverage"
 readme = "README.md"
 license = "MIT"

--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -582,13 +582,22 @@ class CivRuntime:
         self._host._civ_data_watchdog_task = None
 
         rc_task = self._reconnect_task
-        if rc_task is not None and not rc_task.done():
+        # Never cancel the detached recovery task if *it* is the caller.  The
+        # recovery helpers (``_watchdog_soft_reconnect`` /
+        # ``_watchdog_full_reconnect``) call ``_force_cleanup_civ`` →
+        # ``stop_data_watchdog`` from inside themselves; cancelling the current
+        # task here would self-cancel before ``soft_reconnect`` ever runs,
+        # freezing recovery after a single attempt (#1217).
+        current = asyncio.current_task()
+        if rc_task is not None and rc_task is not current and not rc_task.done():
             rc_task.cancel()
             try:
                 await rc_task
             except asyncio.CancelledError:
                 pass
-        self._reconnect_task = None
+            self._reconnect_task = None
+        elif rc_task is not current:
+            self._reconnect_task = None
 
     def advance_generation(self, reason: str) -> None:
         """Advance CI-V request generation and fail stale waiters."""
@@ -919,6 +928,10 @@ class CivRuntime:
 
         Runs outside the watchdog loop so the cooldown sleep survives the
         watchdog task exiting. Falls back to full reconnect on failure.
+
+        Always re-arms the data watchdog in ``finally`` so recovery keeps
+        retrying indefinitely (with bounded backoff) until the radio answers,
+        instead of freezing after a single attempt (#1217).
         """
         try:
             await self._host._force_cleanup_civ()
@@ -949,9 +962,15 @@ class CivRuntime:
                 "civ-data-watchdog: unexpected error in soft_reconnect",
                 exc_info=True,
             )
+        finally:
+            self._rearm_data_watchdog_after_recovery()
 
     async def _watchdog_full_reconnect(self, cooldown: float) -> None:
-        """Detached full reconnect after max soft_reconnect attempts exceeded."""
+        """Detached full reconnect after max soft_reconnect attempts exceeded.
+
+        Re-arms the data watchdog in ``finally`` so a still-unreachable radio
+        is re-probed instead of leaving recovery permanently frozen (#1217).
+        """
         try:
             await self._host._force_cleanup_civ()
             await self._host.disconnect()
@@ -965,6 +984,35 @@ class CivRuntime:
         except Exception:
             logger.error(
                 "civ-data-watchdog: unexpected error in full reconnect",
+                exc_info=True,
+            )
+        finally:
+            self._rearm_data_watchdog_after_recovery()
+
+    def _rearm_data_watchdog_after_recovery(self) -> None:
+        """Re-arm the CI-V data watchdog after a detached recovery attempt.
+
+        Recovery helpers run as ``self._reconnect_task``; once a helper
+        finishes, clear that handle and start a fresh watchdog so the next
+        stall is detected and escalated again.  ``start_data_watchdog`` is a
+        no-op when a healthy watchdog was already re-armed by a successful
+        ``soft_reconnect``/``connect``, so this is safe to call unconditionally.
+
+        Skipped only when the control session is gone (explicit disconnect) —
+        there is nothing left to watch and re-arming would fight teardown.
+        """
+        current = asyncio.current_task()
+        if self._reconnect_task is current:
+            self._reconnect_task = None
+        ctrl = getattr(self._host, "_ctrl_transport", None)
+        ctrl_alive = bool(ctrl and getattr(ctrl, "_udp_transport", None) is not None)
+        if not ctrl_alive:
+            return
+        try:
+            self.start_data_watchdog()
+        except Exception:
+            logger.debug(
+                "civ-data-watchdog: re-arm after recovery failed",
                 exc_info=True,
             )
 
@@ -2653,13 +2701,25 @@ class CivRuntime:
             if civ_t is not None and getattr(self._host, "_connected", False):
                 return
 
-            if civ_t is None and not fast_attempted:
+            # Kick a fast soft_reconnect not only when the transport is gone,
+            # but also when a transport object lingers in a stalled state
+            # (``already_open_stalled``): the radio dropped, the stream is dead,
+            # yet the FD still exists.  Previously this branch only fired for a
+            # ``None`` transport, so a stalled transport spun here to timeout
+            # without ever progressing recovery — the #1217 freeze.  With the
+            # rebuild-on-stall fix in ``soft_reconnect``, kicking it now makes
+            # the poller actively drive recovery.
+            stalled = civ_t is not None and not getattr(self._host, "_connected", False)
+            if (civ_t is None or stalled) and not fast_attempted:
                 fast_attempted = True
                 lock = getattr(self._host, "_civ_recovery_lock", None)
                 if isinstance(lock, asyncio.Lock):
                     async with lock:
                         civ_t2 = getattr(self._host, "_civ_transport", None)
-                        if civ_t2 is None and ctrl_alive:
+                        still_stalled = civ_t2 is not None and not getattr(
+                            self._host, "_connected", False
+                        )
+                        if (civ_t2 is None or still_stalled) and ctrl_alive:
                             try:
                                 await self._host.soft_reconnect()
                             except (ConnectionError, TimeoutError, OSError) as exc:

--- a/src/rigplane/runtime/_control_phase.py
+++ b/src/rigplane/runtime/_control_phase.py
@@ -571,15 +571,26 @@ class ControlPhaseRuntime:
                         "civ_idle_seconds": now - float(last_data),
                     },
                 )
-            else:
-                logger.warning(
-                    "civ.soft_reconnect.already_open_stalled",
-                    extra={
-                        "transport_open": transport_open,
-                        "data_flowing": data_flowing,
-                    },
-                )
-            return
+                return
+            # Transport object exists but the stream is stalled (no data is
+            # flowing).  Returning here is the freeze bug (#1217): recovery
+            # would never progress past one attempt because the watchdog has
+            # already exited and nothing re-arms it.  Tear the stalled
+            # transport down so this call falls through to the genuine rebuild
+            # path below, which re-establishes CI-V and re-arms the watchdog.
+            logger.warning(
+                "civ.soft_reconnect.already_open_stalled",
+                extra={
+                    "transport_open": transport_open,
+                    "data_flowing": data_flowing,
+                    "action": "tearing_down_stalled_transport_for_rebuild",
+                },
+            )
+            await h._force_cleanup_civ()
+            if h._civ_transport is not None:
+                # Defensive: _force_cleanup_civ normally nulls the transport.
+                # If a subclass/mock left it set, do not loop forever — bail.
+                return
         if not h._ctrl_transport or not getattr(
             h._ctrl_transport, "_udp_transport", None
         ):

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -943,6 +943,36 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         return getattr(ctrl, "_udp_transport", None) is not None
 
     @property
+    def remote_control_unreachable(self) -> bool:
+        """Whether the radio's host is reachable but its CI-V/remote-control
+        network server is not accepting the session.
+
+        After a radio power-cycle the IP comes back up (pings/ARP resolve) but
+        the CI-V network server on the control/CI-V UDP port may not be
+        listening yet.  On a *connected* UDP socket the kernel surfaces the
+        peer's ICMP port-unreachable as ``error_received`` (e.g.
+        ``[Errno 32] Broken pipe`` / ``[Errno 111] Connection refused``), which
+        increments ``_udp_error_count``.  A truly unreachable host produces no
+        ICMP at all — sends simply time out and the error counter stays at 0.
+
+        This property is therefore True when the control transport socket is
+        open (so the host route exists) and has accumulated port-unreachable
+        errors while the session is not established — i.e. the remote-control
+        server is refusing/ignoring us rather than the network being gone.
+        """
+        if self._conn_state == RadioConnectionState.CONNECTED:
+            return False
+        ctrl = self._ctrl_transport
+        if ctrl is None:
+            return False
+        # Socket open == route to host exists (or recently existed); a closed
+        # socket means we never got that far.
+        if getattr(ctrl, "_udp_transport", None) is None:
+            return False
+        error_count = getattr(ctrl, "_udp_error_count", 0)
+        return isinstance(error_count, int) and error_count >= _UDP_ERROR_THRESHOLD
+
+    @property
     def radio_ready(self) -> bool:
         """Whether CI-V stream is healthy enough for client operations."""
         if not self.connected:

--- a/src/rigplane/web/runtime_helpers.py
+++ b/src/rigplane/web/runtime_helpers.py
@@ -619,11 +619,23 @@ def classify_radio_health(
         }
 
     if radio_link in {"reconnecting", "disconnected"}:
+        # Distinguish "host reachable but the radio's CI-V/remote-control
+        # server is not listening" (e.g. right after a power-cycle, before the
+        # network server comes up: ICMP port-unreachable / EPIPE on a connected
+        # UDP socket, no "Are You There" answer) from a full network loss.
+        # The former is actionable — the user can enable Network/Remote control
+        # on the radio — so surface a distinct cause.
+        remote_unreachable = _bool_attr(radio, "remote_control_unreachable")
+        likely_cause = (
+            "radio_remote_control_unreachable"
+            if remote_unreachable
+            else "radio_network_lost"
+        )
         return {
             "serverReachable": True,
             "radioLink": radio_link,
             "readiness": "recovering" if radio_link == "reconnecting" else "stalled",
-            "likelyCause": "radio_network_lost",
+            "likelyCause": likely_cause,
             "sinceMs": 0,
             "lastError": last_error_value,
         }

--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -467,6 +467,248 @@ async def test_watchdog_patient_openclose_before_escalation(
 
 
 # ---------------------------------------------------------------------------
+# #1217 — recovery must keep retrying after already_open_stalled / one attempt.
+# ---------------------------------------------------------------------------
+
+
+async def test_watchdog_soft_reconnect_rearms_watchdog_when_recovery_fails(
+    radio: IcomRadio,
+) -> None:
+    """After a failed detached soft_reconnect the data watchdog is re-armed so
+    recovery keeps retrying with bounded backoff instead of freezing after one
+    attempt (#1217).
+    """
+    # Control session still alive so re-arm is appropriate.
+    ctrl = MagicMock()
+    ctrl._udp_transport = object()
+    radio._ctrl_transport = ctrl
+
+    async def failing_force_cleanup() -> None:
+        return None
+
+    async def failing_soft_reconnect() -> None:
+        raise ConnectionError("radio still gone")
+
+    async def failing_disconnect() -> None:
+        return None
+
+    async def failing_connect() -> None:
+        raise ConnectionError("radio still gone")
+
+    radio._force_cleanup_civ = failing_force_cleanup
+    radio.soft_reconnect = failing_soft_reconnect
+    radio.disconnect = failing_disconnect
+    radio.connect = failing_connect
+    radio._civ_data_watchdog_task = None
+
+    async def instant_sleep(delay: float) -> None:
+        return None
+
+    # Spy on start_data_watchdog instead of running the real loop, so the test
+    # asserts the re-arm without leaking a live watchdog task into the loop.
+    rearm_spy = MagicMock()
+    with (
+        patch("asyncio.sleep", side_effect=instant_sleep),
+        patch.object(radio._civ_runtime, "start_data_watchdog", rearm_spy),
+    ):
+        await radio._civ_runtime._watchdog_soft_reconnect(cooldown=45.0)
+
+    # A fresh watchdog must have been re-armed so recovery keeps probing.
+    rearm_spy.assert_called_once()
+
+
+async def test_watchdog_does_not_rearm_when_control_session_gone(
+    radio: IcomRadio,
+) -> None:
+    """If the control session is gone (explicit disconnect) the watchdog is not
+    re-armed — there is nothing left to watch."""
+    ctrl = MagicMock()
+    ctrl._udp_transport = None
+    radio._ctrl_transport = ctrl
+
+    async def noop() -> None:
+        return None
+
+    async def failing_soft_reconnect() -> None:
+        raise ConnectionError("gone")
+
+    radio._force_cleanup_civ = noop
+    radio.soft_reconnect = failing_soft_reconnect
+    radio.disconnect = noop
+    radio.connect = failing_soft_reconnect
+    radio._civ_data_watchdog_task = None
+
+    async def instant_sleep(delay: float) -> None:
+        return None
+
+    rearm_spy = MagicMock()
+    with (
+        patch("asyncio.sleep", side_effect=instant_sleep),
+        patch.object(radio._civ_runtime, "start_data_watchdog", rearm_spy),
+    ):
+        await radio._civ_runtime._watchdog_soft_reconnect(cooldown=45.0)
+
+    rearm_spy.assert_not_called()
+    assert radio._civ_data_watchdog_task is None
+
+
+async def test_stop_data_watchdog_does_not_self_cancel_running_recovery(
+    radio: IcomRadio,
+) -> None:
+    """stop_data_watchdog() must NOT cancel the detached recovery task when it
+    is *itself* the caller.  The recovery helper calls _force_cleanup_civ ->
+    stop_data_watchdog from inside itself; self-cancelling there froze recovery
+    before soft_reconnect ever ran (#1217 root cause).
+    """
+    reached_soft_reconnect: list[bool] = []
+    ctrl = MagicMock()
+    ctrl._udp_transport = object()
+    radio._ctrl_transport = ctrl
+
+    async def real_force_cleanup() -> None:
+        # Mirror the production call chain: cleanup stops the data watchdog,
+        # which in turn inspects _reconnect_task (the current task).
+        await radio._civ_runtime.stop_data_watchdog()
+
+    async def record_soft_reconnect() -> None:
+        reached_soft_reconnect.append(True)
+
+    radio._force_cleanup_civ = real_force_cleanup
+    radio.soft_reconnect = record_soft_reconnect
+    radio._civ_data_watchdog_task = None
+
+    async def instant_sleep(delay: float) -> None:
+        return None
+
+    # Spy the re-arm so the helper's finally does not leak a live watchdog task.
+    with (
+        patch("asyncio.sleep", side_effect=instant_sleep),
+        patch.object(radio._civ_runtime, "start_data_watchdog", MagicMock()),
+    ):
+        task = asyncio.create_task(
+            radio._civ_runtime._watchdog_soft_reconnect(cooldown=1.0),
+            name="civ-watchdog-soft-reconnect",
+        )
+        radio._civ_runtime._reconnect_task = task
+        await task
+
+    # soft_reconnect was reached — the self-cancel did NOT abort recovery.
+    assert reached_soft_reconnect == [True]
+
+
+async def test_soft_reconnect_rebuilds_on_already_open_stalled(
+    radio: IcomRadio,
+) -> None:
+    """soft_reconnect must not freeze on already_open_stalled: it tears the
+    stalled CI-V transport down and falls through to a genuine rebuild (#1217).
+
+    Previously the stalled branch logged ``already_open_stalled`` and returned,
+    so recovery never progressed.  Now it must call ``_force_cleanup_civ`` and
+    proceed into the rebuild path (here observed via the control-gone full
+    connect, stubbed so it stays off the network).
+    """
+    # A lingering CI-V transport object with an open socket but no data flow.
+    stalled = MagicMock()
+    stalled._udp_transport = object()
+    radio._civ_transport = stalled
+    radio._last_civ_data_received = time.monotonic() - 999.0  # stalled
+    radio._civ_ready_idle_timeout = 3.0
+
+    # No live control session → the rebuild takes the full-connect branch,
+    # which we stub on the control-phase runtime to keep it off the network.
+    radio._ctrl_transport = None
+
+    force_cleanup_called: list[bool] = []
+
+    async def fake_force_cleanup() -> None:
+        force_cleanup_called.append(True)
+        radio._civ_transport = None  # genuine teardown nulls the transport
+
+    rebuilt: list[bool] = []
+
+    async def fake_connect() -> None:
+        rebuilt.append(True)
+
+    radio._force_cleanup_civ = fake_force_cleanup
+    radio._control_phase.connect = fake_connect  # type: ignore[method-assign]
+
+    await radio.soft_reconnect()
+
+    assert force_cleanup_called == [True], (
+        "already_open_stalled must tear down the stalled transport, not freeze"
+    )
+    # After teardown the rebuild path runs a (stubbed) full connect.
+    assert rebuilt == [True]
+
+
+async def test_wait_for_recovery_kicks_soft_reconnect_on_stalled_transport(
+    radio: IcomRadio,
+) -> None:
+    """The poller's recovery-wait must drive soft_reconnect when a transport
+    object lingers in a stalled state, not only when it is None (#1217).
+    Previously a non-None stalled transport spun to timeout without progress.
+    """
+    ctrl = MagicMock()
+    ctrl._udp_transport = object()
+    radio._ctrl_transport = ctrl
+
+    # Transport object present but radio not connected == stalled.
+    radio._civ_transport = MagicMock()
+    radio._conn_state = radio._conn_state.__class__.RECONNECTING
+    radio._civ_recovering = True
+
+    soft_calls: list[bool] = []
+
+    async def record_soft_reconnect() -> None:
+        soft_calls.append(True)
+        # Simulate recovery succeeding so the wait can return.
+        radio._conn_state = radio._conn_state.__class__.CONNECTED
+
+    radio.soft_reconnect = record_soft_reconnect
+
+    await radio._civ_runtime._wait_for_civ_transport_recovery(timeout=2.0)
+
+    assert soft_calls == [True], (
+        "stalled (non-None) transport must trigger a soft_reconnect kick"
+    )
+
+
+async def test_watchdog_full_reconnect_rearms_for_indefinite_retry(
+    radio: IcomRadio,
+) -> None:
+    """After the soft-reconnect ladder is exhausted, the detached full
+    reconnect re-arms the watchdog so a still-dead radio is re-probed
+    indefinitely (bounded backoff), not left permanently frozen (#1217).
+    """
+    ctrl = MagicMock()
+    ctrl._udp_transport = object()
+    radio._ctrl_transport = ctrl
+
+    async def noop() -> None:
+        return None
+
+    async def failing_connect() -> None:
+        raise ConnectionError("still dead")
+
+    radio._force_cleanup_civ = noop
+    radio.disconnect = noop
+    radio.connect = failing_connect
+    radio._civ_data_watchdog_task = None
+
+    async def instant_sleep(delay: float) -> None:
+        return None
+
+    rearm_spy = MagicMock()
+    with (
+        patch("asyncio.sleep", side_effect=instant_sleep),
+        patch.object(radio._civ_runtime, "start_data_watchdog", rearm_spy),
+    ):
+        await radio._civ_runtime._watchdog_full_reconnect(cooldown=60.0)
+
+    rearm_spy.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
 # _ensure_civ_runtime (line 244)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_radio_coverage.py
+++ b/tests/test_radio_coverage.py
@@ -278,11 +278,16 @@ async def test_soft_reconnect_noops_when_open_transport_is_receiving_data(
     assert not any("already open" in r.message for r in caplog.records)
 
 
-async def test_soft_reconnect_already_open_stalled_keeps_recovering(
+async def test_soft_reconnect_already_open_stalled_rebuilds_not_frozen(
     radio: IcomRadio,
     mock_transport: MockTransport,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
+    """#1217: a stalled CI-V transport (transport open, no data flowing) must
+    NOT freeze soft_reconnect.  The old behavior returned early after logging
+    ``already_open_stalled``, so recovery never progressed.  The fix tears the
+    stalled transport down and falls through to a genuine rebuild.
+    """
     import logging
     import time
 
@@ -294,15 +299,28 @@ async def test_soft_reconnect_already_open_stalled_keeps_recovering(
     radio._civ_recovering = True
     radio._last_civ_data_received = time.monotonic() - 60.0
 
-    with caplog.at_level(logging.WARNING, logger="rigplane.runtime._control_phase"):
+    cleanup_called: list[bool] = []
+
+    async def fake_force_cleanup() -> None:
+        cleanup_called.append(True)
+        radio._civ_transport = None
+        radio._ctrl_transport._udp_transport = None  # force full-connect branch
+
+    rebuilt = AsyncMock()
+
+    with (
+        caplog.at_level(logging.WARNING, logger="rigplane.runtime._control_phase"),
+        patch.object(radio, "_force_cleanup_civ", side_effect=fake_force_cleanup),
+        patch.object(radio._control_phase, "connect", new=rebuilt),
+    ):
         await radio.soft_reconnect()
 
-    assert radio._conn_state == RadioConnectionState.RECONNECTING
-    assert radio._civ_stream_ready is False
-    assert radio._civ_recovering is True
+    # Logged the stall, but then tore the stalled transport down and rebuilt.
     assert any(
         r.message == "civ.soft_reconnect.already_open_stalled" for r in caplog.records
     )
+    assert cleanup_called == [True]
+    rebuilt.assert_awaited_once()
 
 
 async def test_soft_reconnect_does_full_connect_when_ctrl_dead(

--- a/tests/test_web_runtime_helpers.py
+++ b/tests/test_web_runtime_helpers.py
@@ -67,6 +67,7 @@ class _FakeRadio:
         self._civ_ready_idle_timeout = None
         self._has_connected_once = False
         self.civ_stats = None
+        self.remote_control_unreachable = False
 
 
 def _source(*, provider: str = "test") -> SourceMetadata:
@@ -209,6 +210,37 @@ def test_radio_health_classifies_network_loss_separately_from_server_loss() -> N
     assert health["serverReachable"] is True
     assert health["radioLink"] == "reconnecting"
     assert health["readiness"] == "recovering"
+    assert health["likelyCause"] == "radio_network_lost"
+
+
+def test_radio_health_classifies_remote_control_unreachable_when_host_reachable() -> (
+    None
+):
+    """Host reachable but the radio's CI-V/remote-control server not listening
+    (EPIPE / ICMP port-unreachable, no Are-You-There answer) → distinct
+    actionable cause, not a generic network loss (#1217 diagnosis B).
+    """
+    radio = _FakeRadio(connected=False, radio_ready_flag=False)
+    radio.conn_state = "reconnecting"
+    radio.remote_control_unreachable = True
+
+    health = classify_radio_health(radio, server_reachable=True, now_monotonic=100.0)
+
+    assert health["serverReachable"] is True
+    assert health["radioLink"] == "reconnecting"
+    assert health["readiness"] == "recovering"
+    assert health["likelyCause"] == "radio_remote_control_unreachable"
+
+
+def test_radio_health_keeps_network_lost_when_host_unreachable() -> None:
+    """Without the remote-control-unreachable signal a reconnecting radio is a
+    plain network loss (host truly unreachable)."""
+    radio = _FakeRadio(connected=False, radio_ready_flag=False)
+    radio.conn_state = "reconnecting"
+    radio.remote_control_unreachable = False
+
+    health = classify_radio_health(radio, server_reachable=True, now_monotonic=100.0)
+
     assert health["likelyCause"] == "radio_network_lost"
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -2125,7 +2125,7 @@ wheels = [
 
 [[package]]
 name = "rigplane"
-version = "2.10.6"
+version = "2.10.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Releases rigplane-core 2.10.7. Bundles the CI-V control reconnect auto-recovery and the new `remote_control_unreachable` radio-cause classification reviewed and approved in issue #1217 (rigplane-pro).

### Changes in 2.10.7

**Fixed — radio control link now auto-recovers after the radio drops.**
After a radio power-cycle or network blip, the CI-V control reconnect stalled after a single attempt (`already_open_stalled`) and the watchdog never re-armed, leaving the "Radio link recovering" state hung until a manual retry or app restart. Reconnect now rebuilds and keeps retrying with bounded backoff, recovering automatically once the radio answers again.

**Added — distinguish "radio reachable but remote-control server not responding" from "radio offline".**
When the radio's IP is up but its CI-V/remote-control server isn't answering (e.g. Network/Remote control left off after a power-cycle), the app now reports a distinct cause (`remote_control_unreachable`) so it can show an actionable hint instead of a generic recovering message.

## Boundary

open-core — changes are in the public rigplane-core package only.

## Verification

- CI-V reconnect tests pass (test_civ_reconnect_recovery / related suite)
- `uv run ruff check .` clean
- `uv run ruff format --check .` clean
- Publishes 2.10.7 to PyPI on merge

## References

rigplane-pro #1217 (fix reviewed and approved — reference only, no auto-close)