### PR TITLE
release: rigplane-core 2.10.8 — freq/mode display tracks radio during external CAT (#1219)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.10.8] — 2026-06-20
+
+### Fixed
+
+- **Operating-UI frequency/mode display stuck during an external CAT session.** During a WSJT-X / external-CAT session the display could remain pinned to the last value tuned via the Pro UI while the radio was actually on a different frequency, because the optimistic command overlay was never displaced (the readback poller is paused for the session). The optimistic overlay is now suppressed during an external-CAT session, so the display tracks the radio's real frequency/mode from CI-V readback. Normal Pro-dial responsiveness is unchanged when no external-CAT session is active. (#1219)
+
 ## [2.10.7] — 2026-06-20
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "rigplane"
-version = "2.10.7"
+version = "2.10.8"
 description = "Multi-vendor radio control library and Web UI with native providers and planned Hamlib-backed CAT coverage"
 readme = "README.md"
 license = "MIT"

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -456,6 +456,20 @@ class _SharedControlCommandExecutor:
     def _optimistic_observations(
         self, intent: CommandIntent
     ) -> tuple[Observation, ...]:
+        # During an external-CAT session (e.g. WSJT-X via the Hamlib/rigctld
+        # bridge) the external master owns the wire: RigPlane's poller pauses
+        # (radio_poller._run gate) and rigctld get_freq serves the cached store
+        # projection without eliciting a fresh radio readback. An optimistic
+        # command-response overlay published here can therefore never be
+        # reconciled by a readback — it pins a fabricated freq/mode the radio is
+        # not on and the operating-UI display sticks at the command echo for the
+        # whole session. Suppress the overlay so the projection keeps tracking
+        # the radio's real last-known/live value (bridge CI-V readbacks still
+        # land via _civ_rx, and post-session reconcile_state refreshes it).
+        # Normal (non-external-CAT) responsiveness is unchanged: the poller
+        # readback continues to displace the overlay via last-writer-wins.
+        if getattr(self.server._radio, "external_cat_session_active", False) is True:
+            return ()
         receiver = str(int(intent.params.get("receiver", 0)))
         session_id = (
             str(intent.params["session_id"])

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -1037,6 +1037,78 @@ async def test_set_freq_command_overlay_yields_to_newer_external_readback() -> N
 
 
 @pytest.mark.asyncio
+async def test_set_freq_optimistic_overlay_suppressed_during_external_cat() -> None:
+    # Regression: during an external-CAT session (WSJT-X/rigctld owns the wire),
+    # RigPlane's own poller pauses and rigctld get_freq serves the cached store
+    # projection — so an optimistic set_freq overlay can never be reconciled by a
+    # readback and pins a fabricated freq the radio is not on. The freq display
+    # then sticks at the command echo for the whole session. The overlay must NOT
+    # be planted while an external-CAT session is active: the projection must
+    # keep tracking the radio's real last-known/live frequency instead.
+    radio = SimpleNamespace(
+        connected=True,
+        capabilities=set(),
+        external_cat_session_active=True,
+    )
+    srv = WebServer(radio, WebConfig())
+    srv.command_queue.put = lambda *a, **k: None  # type: ignore[method-assign]
+
+    freq_path = FieldPath.active("0", "freq_mode", "freq_hz")
+    # Seed the store with the radio's REAL frequency (last poll readback before
+    # the external-CAT pause took hold).
+    srv.command_service.apply_observation(
+        Observation(
+            path=freq_path,
+            value=14_074_000,
+            source=SourceMetadata(source="poll_response", provider="icom_civ"),
+            timestamp_monotonic=time.monotonic(),
+            correlation_id=None,
+        )
+    )
+
+    # A web set_freq fires during the external-CAT session, commanding a freq the
+    # radio is NOT on (the live-log 14.260 echo).
+    intent = command_intent_from_request(
+        "set_freq",
+        {"freq": 14_260_000, "receiver": 0},
+        source="websocket",
+        command_id="ws-freq-extcat",
+    )
+    await srv.command_service.execute(intent)
+
+    # The real frequency must survive: no un-reconcilable optimistic overlay.
+    assert srv.command_state_store.snapshot().field(freq_path).value == 14_074_000
+    assert srv.build_public_state()["main"]["freqHz"] == 14_074_000
+
+
+@pytest.mark.asyncio
+async def test_set_freq_optimistic_overlay_kept_without_external_cat() -> None:
+    # Guard: with NO external-CAT session, the optimistic overlay must still be
+    # planted immediately so a web dial-spin feels instant (the normal poller
+    # readback displaces it later via last-writer-wins). The external-CAT
+    # suppression must not regress normal responsiveness.
+    radio = SimpleNamespace(
+        connected=True,
+        capabilities=set(),
+        external_cat_session_active=False,
+    )
+    srv = WebServer(radio, WebConfig())
+    srv.command_queue.put = lambda *a, **k: None  # type: ignore[method-assign]
+
+    intent = command_intent_from_request(
+        "set_freq",
+        {"freq": 14_260_000, "receiver": 0},
+        source="websocket",
+        command_id="ws-freq-normal",
+    )
+    await srv.command_service.execute(intent)
+
+    freq_path = FieldPath.active("0", "freq_mode", "freq_hz")
+    assert srv.command_state_store.snapshot().field(freq_path).value == 14_260_000
+    assert srv.build_public_state()["main"]["freqHz"] == 14_260_000
+
+
+@pytest.mark.asyncio
 async def test_set_freq_failure_does_not_publish_command_overlay() -> None:
     # MOR-485: the optimistic overlay is emitted ONLY on enqueue success — a
     # raised enqueue must leave the command_state_store untouched.

--- a/uv.lock
+++ b/uv.lock
@@ -2125,7 +2125,7 @@ wheels = [
 
 [[package]]
 name = "rigplane"
-version = "2.10.7"
+version = "2.10.8"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Bumps `rigplane` to **2.10.8**. This is a single-fix patch release on top of 2.10.7.

### What changed

**Fix — operating-UI frequency/mode display stuck during an external CAT session (#1219)**

During a WSJT-X / external-CAT session the display could remain pinned to the last value tuned via the Pro UI while the radio was actually on a different frequency. Root cause: the optimistic command overlay was never displaced because the readback poller is paused for the duration of the external-CAT session.

The optimistic overlay is now suppressed during an external-CAT session, so the display tracks the radio's real frequency/mode from CI-V readback. Normal Pro-dial responsiveness is unchanged when no external-CAT session is active.

### Changelog entry (docs/CHANGELOG.md)

```
## [2.10.8] — 2026-06-20

### Fixed

- **Operating-UI frequency/mode display stuck during an external CAT session.**
  During a WSJT-X / external-CAT session the display could remain pinned to the
  last value tuned via the Pro UI while the radio was actually on a different
  frequency, because the optimistic command overlay was never displaced (the
  readback poller is paused for the session). The optimistic overlay is now
  suppressed during an external-CAT session, so the display tracks the radio's
  real frequency/mode from CI-V readback. Normal Pro-dial responsiveness is
  unchanged when no external-CAT session is active. (#1219)
```

## Boundary

`open-core` — frequency display reconciliation during external-CAT is a generic radio-control library concern; no proprietary Pro logic.

## Verification

- `uv run ruff check .` — **clean**
- `uv run ruff format --check .` — 4 pre-existing files flagged (not in this diff; present on base commit)
- Fix-specific tests from commit `cad0dab3` pass with the fix in place
- `git diff --stat`: `docs/CHANGELOG.md +6 -0`, `pyproject.toml 2.10.7→2.10.8`, `uv.lock 2.10.7→2.10.8`

## Publishing

This PR, once merged and tagged `v2.10.8`, will publish `rigplane==2.10.8` to PyPI via the standard release workflow.

## References

- Fixes #1219
- Fix commit: `cad0dab3` — _fix(state): reconcile freq display against radio readback during external-CAT_