### PR TITLE
release: rigplane-core 2.11.0 — unified radio session lifecycle (graceful close, livelock fix)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.11.0] — 2026-06-22
+
+### Added
+
+- **Unified radio session lifecycle.** New `RadioSessionLifecycle` (public SDK) owns connect / disconnect / scan / recovery as one state machine with a guaranteed graceful session close (token-remove + OpenClose) on every exit path, plus a rich observable event/status surface (state transitions, cooldown countdown, error reasons, recovery events). New blessed public symbols: `RadioSessionLifecycle`, `LifecycleState`, `LifecycleErrorReason`, `RadioPresence`, `LifecycleEvent`, `LifecycleStatus`.
+
+### Fixed
+
+- **IC-7610 LAN connect livelock.** A failed network-CI-V connect now always releases the held session (token-remove) before any cooldown wait, and retry is cooldown-aware and resident in-process — eliminating the previous cross-process restart storm that reopened UDP 50001 inside the radio's keepalive window and got rejected with error 0xFFFFFFFF ("previous session active"). Graceful connect/disconnect now leaves the radio immediately free (no cooldown).
+
+### Changed
+
+- **Recovery unified + soft_reconnect semantics.** CI-V data-watchdog now only DETECTS stalls; the lifecycle owns retry/backoff/exhaustion (preserving the #1217 anti-freeze: detached recovery, self-cancel guard, unconditional re-arm). `CoreRadio.soft_reconnect()` is now multi-attempt and releases the session on exhaustion (previously a single non-releasing attempt) — direct callers already handle the connection-error raise.
+
 ## [2.10.8] — 2026-06-20
 
 ### Fixed

--- a/docs/api/public-api-surface.md
+++ b/docs/api/public-api-surface.md
@@ -41,6 +41,42 @@ This page defines the **officially supported** public API of `rigplane`. Use the
 |--------|-------------|
 | `build_hamlib_discovery_payload` | Build the stable Hamlib-assisted discovery JSON payload (`rigplane.discovery.hamlib.v1` schema). Promoted from internal `rigplane.cli` to public API in MOR-911. Canonical import: `from rigplane.backends.discovery import build_hamlib_discovery_payload` or `from rigplane import build_hamlib_discovery_payload`. |
 
+### Session lifecycle (v2.11+)
+
+Unified radio session lifecycle controller and associated types.  These symbols
+are **contract-grade Tier 1** — designed as the stable cross-boundary API
+between `rigplane-core` and `rigplane-pro` (decision D6,
+`docs/architecture/2026-06-22-radio-session-lifecycle.md`).  See [Version and
+compatibility implications](#session-lifecycle-version-and-compatibility) below.
+
+| Symbol | Description |
+|--------|-------------|
+| `RadioSessionLifecycle` | `Protocol` / interface for the resident radio session lifecycle controller.  Owns the full connect / disconnect / scan / recover policy.  Exposes `scan()`, `connect()`, `disconnect()`, `soft_reconnect()`, `state`, `status`, `add_event_listener()`, `remove_event_listener()`, and the async context-manager protocol. |
+| `LifecycleState` | 7-member `str` enum: `DISCONNECTED`, `SCANNING`, `CONNECTING`, `COOLDOWN`, `CONNECTED`, `RECOVERING`, `CLOSING`.  String values are stable and may be serialised (e.g. to JSON). |
+| `LifecycleEvent` | Frozen dataclass carrying one state-transition event (fields: `from_state`, `to_state`, `reason`, `cooldown_remaining_s`, `recovery_attempt`, `recovery_max`).  Emitted to listeners on every transition. |
+| `LifecycleStatus` | Frozen dataclass point-in-time snapshot for UI rendering (fields: `state`, `last_error`, `cooldown_remaining_s`, `cooldown_total_s`, `recovery_attempt`, `recovery_max`, `connecting_elapsed_s`). |
+| `LifecycleErrorReason` | `str` enum of structured cause codes: `NONE`, `AUTH_CREDENTIALS`, `SESSION_BUSY_REJECT`, `SESSION_NOT_READY`, `DATA_WATCHDOG_STALL`, `CONTROL_LOSS`, `RECOVERY_EXHAUSTED`, `CANCELLED`. |
+| `RadioPresence` | Frozen dataclass returned by `scan()` (fields: `host: str`, `remote_id: int`). |
+
+Canonical import:
+
+```python
+from rigplane import (
+    RadioSessionLifecycle,
+    LifecycleState,
+    LifecycleStatus,
+    LifecycleEvent,
+    LifecycleErrorReason,
+    RadioPresence,
+)
+```
+
+Or from the submodule:
+
+```python
+from rigplane.runtime.session_lifecycle import RadioSessionLifecycle, LifecycleState
+```
+
 ### Exceptions
 
 | Symbol | Description |
@@ -133,6 +169,15 @@ available directly via `from rigplane import …`.
 **Public state types**
 
 - `RadioState`, `RadioProfile`, `VfoSlotState`, `YaesuStateExtension`
+
+**Session lifecycle (from `rigplane.runtime.session_lifecycle`, new in v2.11)**
+
+- `RadioSessionLifecycle` — resident lifecycle controller `Protocol`
+- `LifecycleState` — 7-state enum
+- `LifecycleEvent` — per-transition event dataclass (D1 observable surface)
+- `LifecycleStatus` — point-in-time snapshot dataclass (D1 observable surface)
+- `LifecycleErrorReason` — structured cause-code enum
+- `RadioPresence` — scan result dataclass
 
 **Frontend extension host API (Pro-facing)**
 
@@ -247,8 +292,61 @@ from rigplane.rigctld.server import RigctldServer  # tier-3 — forbidden in pro
 
 ---
 
+## Session lifecycle: version and compatibility {#session-lifecycle-version-and-compatibility}
+
+The session lifecycle symbols were introduced in **v2.11** as Tier 1 (semver-
+stable, contract-grade) per decision D6 in
+`docs/architecture/2026-06-22-radio-session-lifecycle.md`.
+
+### Why these are a hard contract
+
+`RadioSessionLifecycle` and its companion types cross the `rigplane-core` /
+`rigplane-pro` **version boundary**.  `rigplane-pro` imports ONLY blessed
+`rigplane.*` symbols (enforced by `.importlinter` `public-sdk-only` contract).
+Changing any signature or removing any symbol therefore requires a **coordinated
+core ↔ Pro cadence** per `rigplane-pro/docs/contracts/COMPATIBILITY.md`
+(MOR-885).
+
+### Additive-only rule
+
+Changes to these symbols MUST follow the additive-only policy:
+
+- **Adding a new `LifecycleState` or `LifecycleErrorReason` member** is
+  additive.  Consumers MUST handle unknown enum values (e.g. with an
+  `else`/`default` branch) to survive future additions.
+- **Adding a field to `LifecycleEvent` or `LifecycleStatus`** MUST use
+  `field(default=…)` so existing call sites constructing these types do not
+  break (prefer factory methods on the concrete implementation for construction;
+  consumers should read fields by name).
+- **Renaming or removing any symbol, field, or enum member** requires a
+  **major version bump** and a two-minor deprecation cycle.
+- **Changing a method signature** (parameters, return type) is a breaking
+  change and requires a major version bump.
+
+### Lockstep pin (Phase D / E)
+
+When a new core release adds or changes these symbols:
+
+1. Bump `rigplane[bridge]==X` in `rigplane-pro/pyproject.toml` **and**
+   `CORE_VERSION` **together** — they must match or `gate-pytest` fails
+   (known coupling, `rigplane-pro/memory/release-core-pin-pyproject-coupling.md`).
+2. Rebuild the Tauri sidecar fully (not `--skip-sidecar`) so the lifecycle
+   ships in the packaged app.
+
+### Import path
+
+Pro MUST import lifecycle symbols via the top-level package::
+
+    from rigplane import RadioSessionLifecycle, LifecycleState, ...
+
+Direct imports from `rigplane.runtime.session_lifecycle` are also supported (the
+module is Tier 1), but the `rigplane.*` path is what the `public-sdk-only`
+import-linter contract validates.
+
+---
+
 ## Summary
 
-- **Use for new code**: `create_radio`, `Radio`, backend configs, capability protocols, exceptions, `RadioState`, profiles, and `sync.IcomRadio` for blocking use.
+- **Use for new code**: `create_radio`, `Radio`, backend configs, capability protocols, exceptions, `RadioState`, profiles, `sync.IcomRadio` for blocking use, and `RadioSessionLifecycle` / `LifecycleState` for lifecycle observation.
 - **Use when needed**: Individual commands, transport, auth, and audio/scope types for custom pipelines or debugging.
 - **Internal**: Modules and symbols whose names start with `_` (e.g. `_connection_state`, `_shared_state_runtime`) are not part of the public API and may change without notice.

--- a/docs/architecture/2026-06-22-radio-session-lifecycle-PLAN.md
+++ b/docs/architecture/2026-06-22-radio-session-lifecycle-PLAN.md
@@ -1,0 +1,386 @@
+# Implementation Plan — Unified Radio Session Lifecycle
+
+**Status:** PLAN — execution-ready, decomposed for parallel dispatch.
+**Date:** 2026-06-22
+**Design doc:** `2026-06-22-radio-session-lifecycle.md` (read its
+"Approved Decisions (2026-06-22)" section first — D1-D8 are binding here).
+**Repos:** `rigplane-core` (open-core, Phases A/B/D-core, E), `rigplane-pro`
+(proprietary, Phase C/D-pro). Boundary gates straddle both (Phase D).
+
+> All `_control_phase.py:NNN` references are to the canonical module
+> `rigplane.runtime._control_phase` (the `src/rigplane/_control_phase.py` shim
+> is a `sys.modules` alias). `radio.py` = `src/rigplane/radio.py`. Pro paths are
+> relative to `rigplane-pro/`.
+
+---
+
+## 0. Orchestration model & file-ownership map
+
+Tasks are decomposed so **parallel agents never edit the same file**. Each task
+lists OWNED FILES (exclusive write) and READ-ONLY deps. A file owned by one
+task in a phase is not written by any other task in that phase.
+
+| File | Owning task | Phase |
+| --- | --- | --- |
+| `tests/mock_server.py` (core) | A1 | A |
+| `tests/conftest.py` (core, additive fixtures) | A1 | A |
+| `src/rigplane/runtime/session_lifecycle.py` (NEW) | A2 | A |
+| `src/rigplane/runtime/_control_phase.py` | A2 (state-machine extraction) then A3 (call-routing) — **sequential, A2→A3** | A/B |
+| `src/rigplane/radio.py` | A3 / B-route | B |
+| `src/rigplane/web/handlers/control.py` | B-route | B |
+| `src/rigplane/runtime/radio_reconnect.py` | B-route | B |
+| `src/rigplane/runtime/_civ_rx.py` | B-route (call sites only) | B |
+| `tests/test_session_lifecycle.py` (NEW) | B-T* (test matrix) | B |
+| `docs/api/public-api-surface.md` | A2-api (the blessed-surface edit) | A |
+| `rigplane-pro/companion/.../station_runtime.py` | C | C |
+| `rigplane-pro/companion/.../radio_session.py` | C | C |
+| `rigplane-pro/.importlinter` | D-boundary | D |
+| new grep-gate (Pro CI script/test) | D-boundary | D |
+| `rigplane-pro/tests/...` supervisor behavior test | D-behavior | D |
+| `rigplane-pro/pyproject.toml` + `CHANGELOG.md` + core release | E | E |
+
+**Builder ≠ verifier:** every phase has an independent-verifier checkpoint; the
+agent that wrote a task does NOT sign off its own verification.
+
+---
+
+## Phase A — core foundation (open-core)
+
+Land the new module beside the existing path behind an internal switch; no core
+call-site behavior change yet. A1 and A2/A2-api are parallelizable; A3 depends
+on A2.
+
+### A1 — Extend `MockIcomRadio` (INDEPENDENT — start first, fully parallel)
+
+**Owns:** `tests/mock_server.py`, additive fixtures in `tests/conftest.py`.
+**Read-only:** `src/rigplane/core/auth.py`, `src/rigplane/core/transport.py`,
+`src/rigplane/runtime/_civ_rx.py`, `src/rigplane/runtime/_control_phase.py`.
+**Depends on:** nothing. **Parallel with:** A2, A2-api.
+
+Extend (do not replace) `MockIcomRadio` (`tests/mock_server.py:143-786`,
+`_MockProtocol:110`). Reuse handshake parsing/builders, control+CIV sockets,
+CI-V dispatcher, `auth_fail`/`response_delay`, fixtures `mock_radio:150` /
+`connected_radio:159`. Add as **opt-in flags/methods** so the existing 60+
+control/CIV tests stay green (`test_radio.py` `MockTransport:227-286`,
+`test_mock_integration.py:26-84`).
+
+Add (per §4.1):
+1. **Held single-owner session.** Owner identity `(remote_addr, my_id)`,
+   `my_id=(lport&0xFFFF)|0x10000` (`transport.py:216`). On conninfo
+   (`auth.py:292`) from a NEW owner while held → status with `civ_port=0` +
+   `error=0xFFFFFFFF` (`auth.py:406-431`: error LE@0x30, civ_port BE@0x42).
+2. **Keepalive timeout / immediate-release.** On token-remove
+   (`_send_token(0x01)`, `pkt[0x14]=0x01`, magic@0x15,
+   `_control_phase.py:932-947`) release the held session **immediately**. With
+   NO token-remove, hold for `keepalive_hold_s` (default models ~40-60 s,
+   **configurable + accelerated**, canonical fast value **~0.5 s** per D7)
+   before auto-release. Renew (magic `0x05`, `:925`) + ack (`0x02`) refresh it.
+3. **Autonomous state + unsolicited CI-V streaming.** Background task emits
+   unsolicited CI-V (freq/mode drift) at a configurable rate, independent of
+   polled commands — exercises the pump and the watchdog reset.
+4. **Loss / stall / reorder knobs.** `drop_rate`, `reorder_window`,
+   `stall_for(seconds)` to trip the data watchdog
+   (`_CIV_DATA_WATCHDOG_TIMEOUT=2.0`, `_civ_rx.py:515-516`/`822-924`).
+5. **Cooldown trigger knob.** `civ_port_unavailable_until(t)` forcing
+   `civ_port=0` (not-ready, no `0xFFFFFFFF`), distinct from busy-reject, to
+   drive CONNECTING→COOLDOWN→CONNECTING.
+
+**TDD:** write micro-tests for each new knob (held-session reject, immediate
+release on token-remove, accelerated keepalive expiry, stall trips watchdog)
+before/with the simulator code; these are simulator unit tests, separate from
+the T1-T12 matrix.
+
+**Verify:**
+```
+uv run pytest tests/test_mock_integration.py tests/test_radio.py -q   # existing stay green
+uv run pytest tests/test_mock_server_extensions.py -q                 # new knob tests (NEW file, also A1-owned)
+uv run ruff check tests/ && uv run ruff format --check tests/
+```
+**Risk:** acceleration hides real timing (R3) — mitigated by D7 slow test in B.
+Knobs leaking into default behavior break existing tests — keep all opt-in.
+
+### A2 — `RadioSessionLifecycle` state machine (parallel with A1)
+
+**Owns:** `src/rigplane/runtime/session_lifecycle.py` (NEW), and the
+state-machine **extraction** edits in `_control_phase.py` (delete retry wrapper
+`:113-141`; demote `_control_phase` to packet mechanism). **A2 owns
+`_control_phase.py` first; A3 takes it after A2 lands** (sequential on that
+file).
+**Read-only:** `radio.py` (host protocol), `auth.py`, `transport.py`,
+`_civ_rx.py`, `_connection_state.py`.
+**Depends on:** nothing for the new module; the `_control_phase` extraction can
+proceed in parallel with A1.
+
+Implement `RadioSessionLifecycle` (the resident policy layer) per §2:
+
+- **States + transitions** (§2.2): `DISCONNECTED/SCANNING/CONNECTING/COOLDOWN/
+  CONNECTED/RECOVERING/CLOSING` with the exact transition rules.
+- **Release obligation registered at session-claim** (auth success,
+  `_control_phase.py:200-207`), discharged on EVERY exit via
+  `AsyncExitStack`/RAII `finally` — independent of any `conn_state` guard
+  (remove the `:494` early-return from the release path). Closes Holes 1/2/5/8.
+- **Cooldown-aware RESIDENT retry** (§2.3): one async task owns
+  CONNECTING↔COOLDOWN inside the process; **release BEFORE the cooldown wait**;
+  never abandons a held session; never exits the process on transient failure.
+  Policy constants `_STATUS_RETRY_PAUSE=10`, `_STATUS_REJECT_COOLDOWN=30`,
+  `_DATA_PORT_COOLDOWN_RETRIES=3` move here as their only home.
+- **Retry policy (D3):** hard-fail (CLOSING + release + auth error reason) on
+  `0xFEFFFFFF`; resident retry on `civ_port==0` / `0xFFFFFFFF`. Design so that
+  after a clean self-disconnect cooldown effectively never fires (cooldown only
+  for a FOREIGN held session).
+- **SIGTERM async graceful-close (§2.6):** replace the `os._exit` path with a
+  shutdown event that cancels the resident runner / cooldown sleep / RECOVERING
+  task; transition to CLOSING; run full release; bounded deadline **~2-3 s**
+  (D2) then exit 0.
+- **soft_reconnect / #1217 folded in** as CONNECTED→RECOVERING→CONNECTED
+  (reuse `_control_phase.py:547-723`, watchdog `_civ_rx.py:822-924`); recovery
+  exhaustion (`_MAX_RECONNECTS=3`) → CLOSING + full release.
+- **Rich observable surface (D1) — FIRST CLASS:** a structured event/status API
+  built into the controller: `state` property (`LifecycleState`), a
+  `LifecycleStatus` snapshot (state + connecting/cooldown progress + countdown
+  + last error reason + recovery attempt N/M), and an event stream/callback
+  emitting every transition with from→to + cause. Design these as **stable
+  public types** (D6). Demote `_control_phase` retry wrapper (`:113-141`) to
+  pure transitions; `_control_phase` keeps only packet I/O.
+
+**TDD:** unit-test the state machine against the A1 simulator (or a thin fake
+host) — transition table, release-on-every-exit, cooldown-then-connect,
+hard-fail on `0xFEFFFFFF`, event emission completeness — before wiring call
+sites. (These unit tests live in `tests/test_session_lifecycle_unit.py`,
+A2-owned, distinct from the B matrix file.)
+
+**Verify:**
+```
+uv run pytest tests/test_session_lifecycle_unit.py -q
+uv run mypy --strict src/rigplane/web        # publish gate; type new surface up front (R5)
+uv run mypy src/rigplane/runtime/session_lifecycle.py
+uv run ruff check src/rigplane/runtime/ && uv run ruff format --check src/rigplane/runtime/
+```
+**Risk:** RECOVERING vs CONNECTING concurrency (R7) — single state machine owns
+mutual exclusion (replaces `_civ_recovery_lock` role). Removing `:494` guard
+could over-release an unclaimed session — make `disconnect()` idempotent (§2.5).
+
+### A2-api — Bless the public-SDK surface (small, parallel)
+
+**Owns:** `docs/api/public-api-surface.md` (+ the `__all__`/`__init__` export
+edits for the blessed symbols, coordinated to not collide with A2 — put exports
+in `rigplane/__init__.py`, A2-api-owned).
+**Depends on:** A2 type names finalized (coordinate names early; can stub-land
+the doc rows and tighten once A2 fixes the symbols).
+
+Per D6, add to the supported-exports table: `RadioSessionLifecycle`,
+`LifecycleState`, `LifecycleStatus`, `LifecycleEvent` (event/status types),
+and document `scan/connect/disconnect/soft_reconnect/state`. Mark
+additive-only, versioned, contract-grade. Note the COMPATIBILITY policy
+(`rigplane-pro/docs/contracts/COMPATIBILITY.md`, MOR-885) implication: Pro
+imports ONLY these via `rigplane.*`.
+
+**Verify:** `uv run pytest tests/test_public_api*.py -q` (if a public-surface
+test exists); import-linter dry run that the blessed symbols are importable from
+`rigplane`.
+
+### A3 — Route `CoreRadio` + core call sites through the lifecycle
+
+**Owns:** `radio.py` (lifecycle methods), and takes over `_control_phase.py`
+**after A2 lands** (sequential dependency on that file).
+**Depends on:** A2 (module + extraction). **Sequential after A2.**
+
+Make `CoreRadio.connect/disconnect/soft_reconnect/scan`
+(`radio.py:1165/1189/1270/3124`) delegate to `RadioSessionLifecycle`. Fix all 8
+graceful-close holes (§3): `__aenter__`/`__aexit__` (`radio.py:1182-1184`)
+always release; `__del__` (`radio.py:903-912`) stays warn-only; rejection/
+timeout cleanup (`_control_phase.py:298-300/320-322/355-357`,
+`_cleanup_data_port_discovery_timeout:464-489`) routes through the unconditional
+release path. Keep public SDK signatures stable.
+
+**Verify:**
+```
+uv run pytest tests/test_radio.py tests/test_session_lifecycle_unit.py -q
+uv run mypy --strict src/rigplane/web
+uv run ruff check src/rigplane && uv run ruff format --check src/rigplane
+```
+
+**Phase A independent-verifier checkpoint:** a verifier agent (≠ A1/A2/A3
+builders) runs the full fast suite, confirms existing tests green, confirms the
+new module sits behind an internal switch with no behavior regression, and
+confirms the blessed-surface doc matches the actual exports.
+
+---
+
+## Phase B — Test matrix T1-T12 (core)
+
+**Owns:** `tests/test_session_lifecycle.py` (NEW). One file; can be split into
+per-group test modules (`..._connect.py`, `..._recover.py`) if parallelized —
+each split file is owned by exactly one builder.
+**Depends on:** A1 (simulator) + A3 (routed call sites). **Sequential after A.**
+**Parallelizable internally** across the listed groups (different test files).
+
+TDD note: T2 (repro) is written to PASS against pre-fix abort behavior, T3 is
+the post-fix pair — write the T2/T3 pair together. All time-based cases use the
+accelerated `keepalive_hold_s` (~0.5 s, D7).
+
+| # | Maps to | Group (parallel split) |
+| --- | --- | --- |
+| T1 | governing principle, Hole 8 — clean connect/disconnect, NO cooldown | connect |
+| T2 | bug repro: abort w/o close → held + `0xFFFFFFFF` | connect (T2/T3 pair) |
+| T3 | Hole 1/5, §2.5 — abort WITH fix → free immediately | connect (T2/T3 pair) |
+| T4 | Cause A+B, Hole 4/6, §2.3 — resident cooldown→connect, one process | connect |
+| T5 | Hole 3/4, §2.6 — SIGTERM mid-CONNECTING and mid-COOLDOWN → token-remove, exit 0 | shutdown |
+| T6 | §2.4 — `scan()` vs held+free, no login/token/conninfo from scan | scan |
+| T7 | #1217, §2.7 — soft_reconnect reuses control+token | recover |
+| T8 | `_civ_rx.py:822-924`, §2.7 — watchdog stall → RECOVERING → CONNECTED | recover |
+| T9 | §2.1 idempotency — duplicate/concurrent connect coalesced | connect |
+| T10 | §1.2 fleet move (re-expressed per D4), Hole 8 — graceful close source before target | fleet |
+| T11 | §2.7 — recovery exhaustion → CLOSING + full release | recover |
+| T12 | §1.3/§1.5 — Pro supervisor behavior (Pro-side; see Phase D-behavior) | (Pro) |
+
+Plus the **D1 feedback test:** assert the event/status surface emits cooldown
+countdown, error reasons, and recovery events for the relevant scenarios.
+Plus the **D7 slow test:** one `@pytest.mark.slow` near-real (~45-60 s)
+keepalive timing case.
+
+**Verify:**
+```
+uv run pytest tests/test_session_lifecycle.py -q          # fast matrix
+uv run pytest tests/test_session_lifecycle.py -m slow     # the near-real timing case
+```
+**Risk:** flaky time-based tests — use deterministic simulator knobs, not wall
+clock, for fast cases; reserve real timing for the single slow test.
+**Verifier checkpoint:** verifier reruns the matrix, confirms each row maps to
+its hole/requirement and that T2 actually reproduces the bug before T3 fixes it.
+
+---
+
+## Phase C — Pro thin-supervisor refactor (proprietary)
+
+**Owns:** `station_runtime.py`, `radio_session.py` (Pro).
+**Depends on:** Phase A/B landed in core (semantics) but **C code can be
+written in parallel against the agreed contract** once §1.4/D4 is frozen; it
+cannot be MERGED until the core release (Phase E) re-pins. Treat C as
+parallelizable-with-B in authoring, sequential-with-E in merge.
+
+Per D4 (the reshaped multi-radio model):
+
+- Pro keeps **fleet storage** (discovered radios + credentials) + **spawn/
+  supervise N core services** (one per active radio, different ports) +
+  **SIGTERM-to-stop with ~5 s wait then SIGKILL backstop** (D2).
+- **REMOVE all retry/cooldown/backoff lifecycle logic:**
+  `_launch_until_ready_with_retries` (`station_runtime.py:663`), backoff
+  (`:680`), readiness polling + terminate-on-not-ready (`:730-756`, `:778`),
+  restart-on-not-ready (`_monitor_process:848`, `:867-883`).
+- **Re-express `RadioFleetSessionManager`** (`radio_session.py:341/371/384`):
+  `_enforce_active_limit` becomes "number of concurrent core services," NOT
+  multiple sessions in one process. One session per core service per radio.
+  `RadioSession`/`ManagedRuntimeOpener` reduce to spawn + liveness + SIGTERM +
+  **crash-only** restart with a **smaller crash backoff**; **repeated genuine
+  crashes → hard UI error** (D5).
+- Surface core-emitted lifecycle state (D1 subset) to the UI; NEVER act on it
+  to kill/restart.
+
+**Verify:**
+```
+cd rigplane-pro
+uv run ruff check . && uv run ruff format --check .
+uv run pytest -m "not slow" tests/test_station_runtime*.py tests/test_radio_session*.py
+uv run pytest -m "not slow"      # payload-dict tests are exact-match; run the broad fast suite
+```
+**Risk (R1):** any residual kill-on-not-ready regresses Cause B — guarded by
+Phase D-behavior test. Multi-service supervision is new surface — keep it small;
+do not invent abstractions beyond N-supervisor.
+
+---
+
+## Phase D — Boundary enforcement (mixed/split)
+
+**Depends on:** A2-api (blessed symbols) + C (Pro refactor). Three
+parallelizable sub-tasks, distinct owners.
+
+### D-importlinter — `public-sdk-only` contract
+**Owns:** `rigplane-pro/.importlinter`. Tighten so Pro imports only the blessed
+`rigplane.*` SDK (D6), never lifecycle internals
+(`rigplane.runtime._control_phase`, non-blessed `rigplane.radio` lifecycle).
+**Verify:** `cd rigplane-pro && uv run lint-imports` (or
+`uv run python -m importlinter`).
+
+### D-grep-gate — ban lifecycle primitives in `rigplane_pro`
+**Owns:** new CI script/test (e.g. `rigplane-pro/scripts/check_no_lifecycle.py`
++ a pytest wrapper). Fail if Pro source references retired primitives:
+`_STATUS_RETRY_PAUSE`, `_STATUS_REJECT_COOLDOWN`, `_DATA_PORT_COOLDOWN_RETRIES`,
+`_send_token`, `_send_open_close`, or Pro-local retry/backoff in
+`station_runtime.py`/`radio_session.py`.
+**Verify:** `cd rigplane-pro && uv run pytest tests/test_no_lifecycle_gate.py -q`.
+
+### D-behavior — supervisor behavioral test (T12)
+**Owns:** `rigplane-pro/tests/test_supervisor_behavior.py` (NEW). Assert: on a
+core "not ready" status Pro does **NOT** restart; on stop Pro issues SIGTERM
+(never SIGKILL-first) and waits for clean exit; restart only on crash exit code;
+repeated crashes surface a hard error (D5).
+**Verify:** `cd rigplane-pro && uv run pytest tests/test_supervisor_behavior.py -q`.
+
+**Verifier checkpoint:** verifier confirms all three gates fail on a deliberately
+re-introduced primitive / kill-on-not-ready, then pass on the clean tree.
+
+---
+
+## Phase E — Integration, core release, re-pin, rebuild, QA, flip
+
+**Sequential, single-threaded, gated.** Owns: `rigplane-pro/pyproject.toml`,
+`rigplane-pro/CHANGELOG.md`, core release artifacts.
+
+1. **Core release.** Bump core version; changelog; PR; **independent agent
+   review (builder ≠ reviewer)**; tag; publish to PyPI. Gate:
+   `mypy --strict src/rigplane/web` green (R5), full `uv run pytest`.
+2. **Re-pin Pro in lockstep.** Move `rigplane[bridge]==X` (`pyproject.toml:16`,
+   currently `==2.10.1`) AND `CORE_VERSION` **together** (R4 coupling — else
+   gate-pytest fails). Regenerate lock.
+3. **Rebuild all platforms.** FULL Tauri sidecar build (NOT `--skip-sidecar`,
+   R6) so Python lifecycle ships in the app; `scripts/tauri-beta-gate.sh`.
+4. **Physical IC-7610 QA (D8).** Run T1, T3, T6, and `soft_reconnect` on the
+   real radio; confirm no cooldown after clean disconnect, radio freed on
+   SIGTERM, recovery works on real keepalive timing.
+5. **Flip beta.9** once all gates green and QA passes.
+
+**Risk:** R2 (close deadline vs hung close) and R3 (accel vs real timing) only
+fully observable here — physical QA is the backstop.
+
+---
+
+## Public-SDK API surface to bless (D6)
+
+Exact NEW blessed symbols (additive-only, versioned, contract-grade):
+
+- `RadioSessionLifecycle` — the resident controller.
+- `LifecycleState` — enum: `DISCONNECTED/SCANNING/CONNECTING/COOLDOWN/
+  CONNECTED/RECOVERING/CLOSING`.
+- `LifecycleStatus` — snapshot: state + connecting/cooldown progress +
+  cooldown countdown + last error reason + recovery attempt N/M (D1).
+- `LifecycleEvent` — transition event: from→to + cause (D1 event stream).
+- Methods/property on the public surface: `scan()`, `connect()`,
+  `disconnect()`, `soft_reconnect()`, `state`.
+
+**Version/compat implications:** these cross the core↔Pro boundary; changes are
+additive-only and versioned per `docs/contracts/COMPATIBILITY.md` (MOR-885).
+The import-linter `public-sdk-only` contract is the enforcement; the lockstep
+pin (Phase E) is the cadence mechanism.
+
+---
+
+## Critical path & parallelism summary
+
+```
+A1 (simulator) ─────────────┐
+A2 (state machine) ─► A3 (route core) ─► B (matrix) ─► E (release/qa/flip)
+A2-api (bless surface) ─────┘                          ▲
+C (Pro thin-supervisor) ──► D (boundary gates) ────────┘
+```
+
+- **Parallel first wave:** A1, A2, A2-api (3 agents). C authoring can also
+  start in parallel once D4 contract is frozen.
+- **Strictly sequential:** A2 → A3 (same `_control_phase.py`/`radio.py`),
+  A3 → B, (A+C) → D, everything → E.
+- **Critical path:** A2 → A3 → B → E. (A1 must finish before B; A2-api before
+  D; C before D.)
+- **File-ownership guarantee:** no two concurrently-running tasks own the same
+  file (see §0 map). `_control_phase.py` and `radio.py` are the only shared
+  hotspots and are handled by the A2→A3 sequencing.
+- **Builder ≠ verifier** at every phase checkpoint (A, B, D, E-review).

--- a/docs/architecture/2026-06-22-radio-session-lifecycle.md
+++ b/docs/architecture/2026-06-22-radio-session-lifecycle.md
@@ -1,0 +1,603 @@
+# Unified Radio Session Lifecycle (rigplane-core)
+
+**Status:** DESIGN — for human review/approval. No production code yet.
+**Date:** 2026-06-22
+**Scope:** MAXIMUM — a single state-machine module in `rigplane-core` owns the
+*entire* radio network lifecycle: connect + disconnect + scan +
+auto-recovery/soft-reconnect (#1217).
+**Blocks:** beta.9 flip is HELD until this lands (sequencing handled
+separately; this doc only provides the rollout plan).
+
+> Canonical control-phase code lives in `rigplane.runtime._control_phase`
+> (`src/rigplane/_control_phase.py` is a `sys.modules`-alias shim). All
+> `_control_phase.py:NNN` line references below are to the canonical module.
+
+---
+
+## 0. Problem Statement & Root Cause (the livelock to eliminate)
+
+Observed failure (the cornerstone bug this design must make *impossible*):
+
+1. Auth succeeds (`auth.py:395` — error not in `0xFEFFFFFF`/`0xFFFFFFFF`).
+2. CI-V data-port allocation fails: `civ_port == 0` in the status response
+   (`auth.py:406-431`, `civ_port` BE@0x42).
+3. Core enters an **in-process cooldown that HOLDS the session**: the retry
+   wrapper sleeps `_STATUS_RETRY_PAUSE=10.0` / `_STATUS_REJECT_COOLDOWN=30.0`
+   (`_control_phase.py:128-141`, repeated `:334-341`) **without releasing the
+   token** (no `_send_token(0x01)`).
+4. Pro's supervisor sees no readiness within its poll window
+   (`station_runtime.py:730-756`) and **SIGTERM/SIGKILLs the core process**
+   (`_terminate_process_tree` `:1247` → SIGTERM `:1258` → SIGKILL `:1265`),
+   bypassing core's async close (core SIGTERM handler ends with `os._exit`).
+   No token-remove is ever sent.
+5. Pro **relaunches within 1-4 s** (`_monitor_process` `:867-883`,
+   backoff `_backoff_s*2**restart_count`), reopening UDP `50001` inside the
+   radio's ~40-60 s keepalive window.
+6. The radio still holds the prior session → returns `civ_port == 0` with
+   `error == 0xFFFFFFFF` ("previous session active",
+   `auth.py:395`, `_control_phase.py:258/815`).
+7. GOTO 3 → **LIVELOCK.**
+
+### Governing principle (the invariant the design encodes)
+
+> A graceful connect/disconnect must cause **NO cooldown**. A cooldown means a
+> session was torn down **non-gracefully**. Therefore: every exit path from a
+> session — normal, exceptional, or signal-driven — MUST send token-remove
+> (`0x01`) + OpenClose-close before the socket/process goes away, and the
+> cooldown wait MUST happen **inside one resident process** that never
+> re-claims `50001` while a stale session is still held by the radio.
+
+Two structural causes, both eliminated below:
+
+- **Cause A — held cooldown:** core waits out a cooldown while *holding* the
+  token (Hole 4/5).
+- **Cause B — cross-process restart:** Pro tears the process down and reopens
+  the port faster than the radio's keepalive expires (Hole 3/6).
+
+---
+
+## 1. Invariant & Boundary: Pro = process supervisor only
+
+### 1.1 The cornerstone invariant
+
+**Pro must contain ZERO radio-connection-lifecycle logic.** All
+connect/disconnect/scan/retry/cooldown/backoff/recovery intelligence lives in
+`rigplane-core` (open-core). Pro is a **thin process supervisor**:
+
+- spawn the core-station process;
+- monitor **process liveness** only;
+- send **SIGTERM** to stop and wait for graceful exit;
+- restart **only on genuine process crash** (non-zero exit / OS death), never
+  on "radio not ready yet".
+
+### 1.2 What MOVES from Pro into core
+
+| Today (Pro) | Map ref | Destination |
+| --- | --- | --- |
+| Connect retry + backoff loop | `station_runtime.py:663` `_launch_until_ready_with_retries`, backoff `:680` | core resident session runner (§2.3) |
+| Readiness polling + terminate-on-not-ready | `station_runtime.py:730-756`, fail→`_terminate_process_tree` `:778` | core: readiness is an in-process state transition; no kill on "not ready" |
+| Restart-on-not-ready backoff | `_monitor_process:848`, `:867-883` | DELETED. Restart only on crash. |
+| Retry/cooldown semantics in opener | `radio_session.py` `RadioSession.open:260` (route fallback), `ManagedRuntimeOpener.open:108` | core API (§2.1) |
+| Fleet enforce/switch lifecycle | `RadioFleetSessionManager.open_radio:341` / `switch_radio:371` / `_enforce_active_limit:384` | core `connect()`/`disconnect()` per radio (§2); Pro keeps only "which radio is selected" + process supervision |
+
+### 1.3 What Pro is ALLOWED to keep
+
+- Process spawn/Popen of the core-station entrypoint (`station_runtime.py:712`).
+- Process-liveness monitor (PID alive? exit code?).
+- SIGTERM-to-stop + bounded wait, then SIGKILL **only** as a last-resort
+  hung-process safety (not as a lifecycle tool).
+- Restart **only** on genuine crash (with crash backoff, not readiness
+  backoff).
+- Selection/preferences/UI plumbing (which radio, fleet membership, surfacing
+  core-emitted lifecycle state to the UI).
+
+### 1.4 The thin Pro↔core contract
+
+Core station process exposes, over its existing local control surface:
+
+- **Liveness:** process stays up while a session is *resident* (connecting,
+  cooling-down, connected, or recovering). The process does **not** exit on
+  transient radio failure — it stays alive and keeps retrying in-process.
+- **Lifecycle status events:** core emits a structured lifecycle state
+  (`DISCONNECTED/SCANNING/CONNECTING/COOLDOWN/CONNECTED/RECOVERING/CLOSING`,
+  §2) for Pro/UI to *observe*. Pro never acts on these to kill/restart;
+  they are display + selection signals only.
+- **Stop:** SIGTERM → core runs full async graceful close (token-remove +
+  OpenClose-close) BEFORE exit; exits 0. Pro waits for exit.
+- **Crash contract:** any non-zero/abnormal exit = genuine crash → Pro may
+  restart with crash backoff. A clean exit after SIGTERM = no restart.
+
+### 1.5 Enforcing/testing the boundary
+
+- Keep and tighten the import-linter `public-sdk-only` contract
+  (`rigplane-pro/.importlinter`): Pro imports the public `rigplane.*` SDK only,
+  never lifecycle internals (`rigplane.runtime._control_phase`,
+  `rigplane.radio` lifecycle methods beyond what the public SDK blesses).
+- **New static gate:** a lint/test that fails if `rigplane_pro` source
+  references any of the retired lifecycle primitives (token send, OpenClose,
+  cooldown constants, retry loops). The presence list to ban:
+  `_STATUS_RETRY_PAUSE`, `_STATUS_REJECT_COOLDOWN`, `_DATA_PORT_COOLDOWN_RETRIES`,
+  `_send_token`, `_send_open_close`, and the Pro-local retry/backoff in
+  `station_runtime.py`/`radio_session.py`.
+- **Behavioral gate:** a Pro-side test asserting the supervisor issues SIGTERM
+  (never SIGKILL-first) on stop and does **not** restart on a core "not ready"
+  status (only on process death). Guards against Cause B regressing.
+
+---
+
+## 2. Unified core API / state machine
+
+New module (open-core): `rigplane/runtime/session_lifecycle.py` (proposed),
+exposing a `RadioSessionLifecycle` (the resident state machine) that
+`CoreRadio` (`radio.py`) delegates to. `_control_phase.ControlPhaseRuntime`
+becomes the *mechanism* (packet I/O) driven by this *policy* layer; the retry
+wrapper in `_control_phase.py:113-141` is removed and re-expressed as state
+transitions.
+
+### 2.1 Public API surface (the only lifecycle entry points)
+
+```text
+async def scan(targets) -> list[Presence]     # presence-probe only; NO session
+async def connect() -> None                    # resident; cooldown-aware; never abandons a held session
+async def disconnect() -> None                 # ALWAYS releases (token-remove + close) via finally/RAII
+async def soft_reconnect() -> None             # RECOVERING; reuse control+token (#1217)
+@property  state -> LifecycleState             # observable
+async def __aenter__/__aexit__                 # delegate to connect/disconnect; aexit ALWAYS releases
+```
+
+`connect()` is **resident**: it does cooldown-aware retry *in-process* and
+returns only on CONNECTED or on a caller-cancel; on transient failure it does
+NOT raise out to a layer that would tear the process down. The process stays
+alive across cooldowns. This is the structural fix for Cause A+B.
+
+### 2.2 States and transitions
+
+```text
+        scan()                 connect()
+DISCONNECTED ──► SCANNING ──► DISCONNECTED
+     │                            
+     │ connect()                  
+     ▼                            
+ CONNECTING ──auth+civ_port>0──► CONNECTED
+     │  │                           │
+     │  │ civ_port==0 (not ready    │ data stall / ctrl loss (#1217)
+     │  │   OR 0xFFFFFFFF reject)   ▼
+     │  ▼                        RECOVERING ──ok──► CONNECTED
+     │  COOLDOWN ──wait, NO re-claim──► CONNECTING   │ fail (max)
+     │  (same process; token NOT held)               ▼
+     │                                             CLOSING
+     └────────── disconnect()/SIGTERM ──────────► CLOSING ──► DISCONNECTED
+```
+
+Transition rules (each maps to a guaranteed-release point, §2.5):
+
+- **DISCONNECTED → SCANNING → DISCONNECTED:** `scan()` opens no session; it is
+  a stateless broadcast probe (§2.4). No token, no OpenClose, ever.
+- **DISCONNECTED → CONNECTING:** begin `_connect_once`
+  (`_control_phase.py:143-456`). From the moment auth succeeds (`:200-207`) the
+  session is considered **claimed** and a release obligation is registered
+  (RAII, §2.5) — this closes Hole 1.
+- **CONNECTING → CONNECTED:** `civ_port > 0`, transports open, OpenClose-open
+  sent (`:418`), pumps/watchdog up (`:423-451`). Emit CONNECTED.
+- **CONNECTING → COOLDOWN:** `civ_port == 0` (not ready) OR `0xFFFFFFFF`
+  (explicit reject). **Before** entering COOLDOWN the *current attempt's*
+  partial session is fully released (token-remove + close + socket close) —
+  this is the inversion of today's Hole 4: we release first, *then* wait.
+- **COOLDOWN → CONNECTING:** after the wait (`10 s` not-ready / `30 s` reject,
+  preserved as policy constants, now owned by the state machine), retry —
+  **without ever having left the process** and only after release, so the
+  radio's keepalive can expire normally. No fast cross-process re-claim.
+- **CONNECTED → RECOVERING:** data-watchdog stall or control-loss (#1217);
+  folds in existing `soft_reconnect` (`_control_phase.py:547-723`) and the
+  data watchdog (`_civ_rx.py:822-924`).
+- **RECOVERING → CONNECTED:** soft reconnect re-opens data path reusing
+  control + token (`_control_phase.py:676`); on success resume.
+- **RECOVERING → CLOSING:** recovery exhausted (`_MAX_RECONNECTS=3`) → full
+  release, then DISCONNECTED (or retry via COOLDOWN per policy).
+- **any → CLOSING → DISCONNECTED:** `disconnect()` / SIGTERM. CLOSING ALWAYS
+  releases regardless of `conn_state` (today's `:494` guard is removed from the
+  release path — see §2.5/Hole 8).
+
+### 2.3 Resident session runner (Cause A+B fix)
+
+A single async task owns the CONNECTING↔COOLDOWN loop **inside the core
+process**:
+
+- It NEVER abandons a stale/claimed session: a partial claim always carries a
+  registered release obligation discharged before any wait or exit.
+- It does NOT exit the process on transient failure → Pro never sees a "dead"
+  process during a cooldown → Pro never relaunches → port `50001` is not
+  re-opened inside the keepalive window.
+- The cooldown wait is *cancellable*: SIGTERM cancels it and the runner
+  transitions to CLOSING with full release (§2.6).
+- Backoff/cooldown policy constants (`_STATUS_RETRY_PAUSE=10`,
+  `_STATUS_REJECT_COOLDOWN=30`, `_DATA_PORT_COOLDOWN_RETRIES=3`) move here as
+  the *only* home for retry timing.
+
+### 2.4 `scan()` = presence-probe only
+
+Reuse the stateless discovery path (`backends/discovery.py`): broadcast
+are-you-there (AYT `0x03`, `transport.py:285`), parse IAH (`0x04`,
+`transport.py:301`, remote_id off8 `:302`), close socket in `finally`
+(`discovery.py:675`). `scan()` **never** sends login/token/conninfo/OpenClose
+and never holds a session. It returns presence records only. This guarantees a
+scan can never trip the radio's single-owner lock.
+
+### 2.5 Guaranteed RELEASE on every exit (RAII / `finally`)
+
+Release = `_send_token(0x01)` (`_control_phase.py:538`) + OpenClose-close
+(`_send_open_close(...close)`, civ `:524` / audio `:517`) + control disconnect
+(`:541`) + socket close.
+
+The release becomes an **obligation object** registered the instant the session
+is *claimed* (auth success, `:200-207`), discharged by:
+
+- an `async with`/`AsyncExitStack`-style guard wrapping the whole
+  `_connect_once` body, so any exception between auth and CONNECTED still
+  releases (closes Hole 1);
+- `__aexit__` always calling the release path (closes Hole 2);
+- the CLOSING transition calling release **unconditionally** — the
+  `conn_state != CONNECTED` early-return (`_control_phase.py:494`) is moved off
+  the release path so a partially-claimed session is still released
+  (closes Hole 8 and Hole 5).
+
+`disconnect()` is **idempotent**: calling it on an unclaimed session is a
+no-op; on any claimed/partial session it releases.
+
+### 2.6 Graceful shutdown on SIGTERM
+
+Replace the core SIGTERM handler's `os._exit` with an async-aware shutdown:
+
+- SIGTERM sets a shutdown event; the resident runner (and any cooldown sleep,
+  CONNECTING, or RECOVERING task) is cancelled cooperatively.
+- The state machine transitions to CLOSING and runs the full release
+  (§2.5) **before** the event loop stops and the process exits 0.
+- A bounded shutdown deadline (e.g. 2-3 s, less than the radio keepalive)
+  guards against a hung close; only after the deadline may the process
+  hard-exit — and Pro's SIGKILL is the outer backstop, not the normal path.
+
+This closes Hole 3 (kill-without-cleanup) and Hole 4 (SIGTERM during cooldown
+leaving the session held).
+
+### 2.7 Auto-recovery / soft_reconnect (#1217) folded in
+
+`soft_reconnect` (`_control_phase.py:547-723`) and the data watchdog
+(`_civ_rx.py:822-924`, consts `_CIV_DATA_WATCHDOG_TIMEOUT=2.0`,
+`_RECONNECT_BACKOFF=(45,60,60)`, `_MAX_RECONNECTS=3`) become the CONNECTED→
+RECOVERING→CONNECTED transitions. Key invariant preserved from #1217: soft
+reconnect **reuses control + token** (re-open only, no close-first,
+`:676`) and re-arms the watchdog (`_civ_rx.py:992-1017`). Recovery exhaustion
+goes through CLOSING (full release), never an abandoned session.
+
+---
+
+## 3. Closing all 8 graceful-close holes (map section E)
+
+| Hole | Map ref | Design fix |
+| --- | --- | --- |
+| **1** post-auth/pre-CONNECTED exception leaves control+token held | `_send_token_ack:217` / `_receive_guid:219` / `_send_conninfo:243` / civ-port wait | Release obligation registered at auth success (`:200-207`); `AsyncExitStack` around `_connect_once` discharges it on any exception (§2.5). |
+| **2** `__aenter__` raises before `__aexit__` | `radio.py:1182-1184` | `__aenter__` wraps `connect()` so its own failure runs release; `__aexit__` always releases (§2.5). |
+| **3** Pro kills process w/o cleanup | `station_runtime.py:1247`/`1258`/`1265`; core `os._exit` | Async SIGTERM handler runs full release before exit (§2.6); Pro stops via SIGTERM + wait, SIGKILL only as backstop (§1.3). |
+| **4** in-process cooldown holds session — ROOT CAUSE | `_control_phase.py:128-141`, `:334-341` | Resident runner **releases before** cooldown wait, then waits inside one process; SIGTERM cancels the wait into CLOSING+release (§2.3/§2.6). |
+| **5** cooldown loop raises into unguarded `__aenter__` | `_control_phase.py:122-127` | Cooldown is a state, not an exception path; CONNECTING/COOLDOWN failures release via the same obligation; `__aenter__` guarded (Hole 2). |
+| **6** Pro retry-without-release relaunch reopens `50001` in 1-4 s | `station_runtime.py:867-883` | Restart-on-not-ready deleted; cooldown lives in-process; Pro restarts only on crash (§1.2/§1.3). |
+| **7** `__del__` is warn-only | `radio.py:903-912` | `__del__` stays a warning (can't run async reliably); correctness moves to the always-run `__aexit__`/CLOSING release + SIGTERM handler, so a leaked object is no longer the only safety net. |
+| **8** partial cleanup on rejection: ctrl-disconnect + DISCONNECTED, NO token-remove | `_control_phase.py:298-300`/`320-322`/`355-357`; `_cleanup_data_port_discovery_timeout:464-489` | Rejection/timeout cleanup routes through the unconditional release path (token-remove included), not the partial cleanup; remove the `conn_state` guard from the release path (§2.5). |
+
+---
+
+## 4. IC-7610 simulator (`MockIcomRadio` extension)
+
+Extend the existing `MockIcomRadio` (`tests/mock_server.py:143-786`,
+`_MockProtocol:110`) rather than replace it — it already models the control+CIV
+UDP servers, AYT/IAH+login+token+conninfo→status handshake, a CI-V dispatcher,
+state setters, and `auth_fail`/`response_delay` flags. Reuse all of that.
+
+### 4.1 What to ADD (the session-realism the GAPS note calls out)
+
+1. **Held single-owner session.** Track an owner identity = `(remote_addr,
+   my_id)` where `my_id=(lport&0xFFFF)|0x10000` (`transport.py:216`). On
+   conninfo (`auth.py:292`) from a *new* owner while a session is held, reply
+   status with `civ_port=0` + `error=0xFFFFFFFF`
+   (`auth.py:406-431` layout: error LE@0x30, civ_port BE@0x42). This is the
+   "previous session active" reject.
+2. **Keepalive timeout / immediate-release semantics.** On token-remove
+   (`_send_token(0x01)`, `pkt[0x14]=0x01`, magic@0x15, `_control_phase.py:932-947`)
+   release the held session **immediately**. With NO token-remove, hold the
+   session for a `keepalive_hold_s` window (default modeling ~40-60 s,
+   **configurable + accelerated for tests**, e.g. 0.5-2 s) before auto-release.
+   Renew (`magic 0x05`, `:925`) and ack (`0x02`) refresh the keepalive.
+3. **Autonomous state evolution + unsolicited CI-V streaming.** A background
+   task emits unsolicited CI-V frames (freq/mode drift) on the CIV port at a
+   configurable rate, independent of polled commands — exercises the pump
+   (`_civ_rx.py` worker) and the "data flowing" watchdog reset.
+4. **Packet loss / stall / reorder.** Configurable knobs:
+   `drop_rate`, `reorder_window`, and a `stall_for(seconds)` injector that
+   stops emitting CI-V to trip the data watchdog
+   (`_CIV_DATA_WATCHDOG_TIMEOUT=2.0`, `_civ_rx.py:515-516`/`822-924`).
+5. **Cooldown trigger knob.** `civ_port_unavailable_until(t)` to force
+   `civ_port=0` (not-ready, no `0xFFFFFFFF`) for a window, distinct from the
+   busy-reject, so tests can drive CONNECTING→COOLDOWN→CONNECTING.
+
+### 4.2 What to REUSE
+
+Handshake parsing/builders, control+CIV socket plumbing, the CI-V command
+dispatcher, existing `auth_fail`/`response_delay`, and the `conftest.py`
+fixtures (`mock_radio:150`, `connected_radio:159`). New behavior is added as
+opt-in flags/methods so existing 60+ control/CIV tests
+(`test_radio.py` `MockTransport:227-286`, `test_mock_integration.py:26-84`)
+remain green.
+
+---
+
+## 5. Test matrix (with the simulator)
+
+Each row maps to the hole/requirement it guards. All time-based cases use the
+simulator's accelerated `keepalive_hold_s`.
+
+| # | Scenario | Expected | Guards |
+| --- | --- | --- | --- |
+| T1 | Clean `connect()` → `disconnect()` | Radio free **immediately** (token-remove received); a subsequent `connect()` succeeds with NO cooldown observed | Governing principle; Hole 8 release-on-exit |
+| T2 | Abort connect **without** close (simulate exception, no release) against an *unpatched-style* abort | Simulator holds session → next `connect()` gets `civ_port=0`+`0xFFFFFFFF` | Reproduces the bug; baseline for T3 |
+| T3 | Same abort path **with the fix** (release obligation fires) | Radio free immediately → next `connect()` succeeds | Hole 1, Hole 5, §2.5 |
+| T4 | Resident cooldown-aware retry: simulator forces `civ_port=0` for a window, then frees | Single process waits out cooldown (COOLDOWN→CONNECTING) and connects; **no second process, no `0xFFFFFFFF` livelock** | Cause A+B, Hole 4/6, §2.3 |
+| T5 | SIGTERM mid-CONNECTING and mid-COOLDOWN | Core runs graceful close → token-remove sent → radio free; process exits 0; no held session | Hole 3, Hole 4, §2.6 |
+| T6 | `scan()` against held + free radios | Presence returned; simulator records **no** login/token/conninfo from scan; session ownership unchanged | §2.4 |
+| T7 | `soft_reconnect()` after data stall | Control + token reused (no new login), data path re-opened, CONNECTED resumes | #1217, §2.7 |
+| T8 | Data-watchdog stall (`stall_for > 2 s`) | CONNECTED→RECOVERING→CONNECTED via soft reconnect; watchdog re-armed | `_civ_rx.py:822-924`, §2.7 |
+| T9 | Duplicate/concurrent `connect()` | Second call is rejected/coalesced; exactly one session claimed; no double token | §2.1 idempotency |
+| T10 | Fleet switch: connect A, switch to B | A is closed **gracefully** (token-remove for A) before B connects; A free immediately | §1.2 fleet move, Hole 8 |
+| T11 | Recovery exhaustion (`_MAX_RECONNECTS=3` all fail) | Routes through CLOSING with full release; no abandoned/held session | §2.7 |
+| T12 | Pro supervisor behavior (Pro-side) | On core "not ready" status, Pro does **not** restart; on SIGTERM Pro waits for clean exit; restart only on crash exit code | §1.3/§1.5 boundary |
+
+Static/boundary tests (§1.5): import-linter `public-sdk-only` stays green; the
+new "no lifecycle primitives in `rigplane_pro`" grep gate passes.
+
+---
+
+## 6. Migration / rollout plan (phased)
+
+> beta.9 flip is HELD until this completes. Sequencing owned separately.
+
+- **Phase A — core foundation (open-core).** Land the
+  `RadioSessionLifecycle` state machine, the resident runner, the
+  guaranteed-release obligation, the async SIGTERM handler, extend
+  `MockIcomRadio`, and add the full test matrix (§5). No call-site changes yet;
+  the new module can sit beside the existing path behind an internal switch.
+- **Phase B — route all core call sites through it.** Make `CoreRadio.connect/
+  disconnect/soft_reconnect/scan` (`radio.py:1165/1189/1270/3124`) and the
+  control/runtime callers (`web/handlers/control.py:739`,
+  `radio_reconnect.py:183`, `_civ_rx.py:939/2724/2737`) delegate to the state
+  machine. Remove the retry wrapper `_control_phase.py:113-141` and the partial
+  cleanup paths (Hole 8). Keep the public SDK signatures stable.
+- **Phase C — Pro thin-supervisor refactor (Pro repo).** Strip lifecycle from
+  `station_runtime.py` (`_launch_until_ready_with_retries:663`, readiness-kill
+  `:778`, restart-on-not-ready `:867-883`) and `radio_session.py`
+  (`RadioSession`/`RadioFleetSessionManager`/`ManagedRuntimeOpener`); reduce to
+  spawn + liveness + SIGTERM + crash-only restart. Add the boundary gates
+  (§1.5).
+- **Phase D — core release + re-pin Pro + rebuild.** Cut a core release that
+  contains the lifecycle module; bump Pro's pin and `CORE_VERSION` **in
+  lockstep** (currently `rigplane[bridge]==2.10.1`, `pyproject.toml:16`) — the
+  pin and `CORE_VERSION` must move together or the gate-pytest fails (known
+  coupling). Rebuild the frozen Tauri sidecar (full build, not
+  `--skip-sidecar`) so Python lifecycle changes ship in the app. Then unblock
+  the beta.9 flip.
+
+**Core publish gate reminder:** core's publish requires
+`mypy --strict src/rigplane/web` green; the new module and any web/handler
+delegation (`web/handlers/control.py:739`) must satisfy strict typing before
+the Phase D release.
+
+---
+
+## 7. Open / private boundary per piece
+
+| Piece | Boundary | Rationale |
+| --- | --- | --- |
+| `RadioSessionLifecycle` state machine, resident runner, guaranteed-release, SIGTERM handler | **open-core** | Generic radio session/transport lifecycle; this is the whole point of the invariant. |
+| `scan()` presence-probe (reuses `backends/discovery.py`) | **open-core** | Generic discovery. |
+| `soft_reconnect`/data-watchdog folded into RECOVERING | **open-core** | Already core (#1217). |
+| `MockIcomRadio` extensions + core test matrix | **open-core** | Lives in core `tests/`. |
+| Pro thin supervisor (spawn/liveness/SIGTERM/crash-restart) | **proprietary-only (Pro)** | Desktop packaging/process supervision is Pro's domain; it must contain no lifecycle logic. |
+| Boundary gates (import-linter + no-lifecycle-primitives grep + Pro supervisor behavior test) | **mixed/split** | import-linter + grep gate in Pro; lifecycle-ownership tests in core. |
+
+This is an **open-core candidate** for the lifecycle module and a
+**proprietary-only** refactor for the Pro supervisor — i.e. `mixed/split`
+overall, with the intelligence going open.
+
+---
+
+## 8. Risks
+
+- **R1 — Resident process semantics change Pro's mental model.** Pro must stop
+  treating "no readiness" as a failure. If any Pro path still kills on
+  not-ready, Cause B regresses. Mitigation: §1.5 behavioral gate (T12).
+- **R2 — SIGTERM graceful-close deadline vs hung close.** If the async close
+  hangs and the deadline is too long, stop becomes slow; too short and we
+  hard-exit without release. Mitigation: deadline < radio keepalive; Pro
+  SIGKILL backstop only after core's own deadline.
+- **R3 — Accelerated keepalive in tests vs real radio timing.** Simulator
+  acceleration must not mask real timing bugs. Mitigation: keep at least one
+  test at near-real `keepalive_hold_s`; document the chosen accelerated value.
+- **R4 — Lockstep pin/release coupling (Phase D).** Forgetting to move
+  `CORE_VERSION` and the `==` pin together fails gate-pytest. Mitigation:
+  release skill checklist.
+- **R5 — `mypy --strict src/rigplane/web` debt.** New delegation in web
+  handlers could trip strict generics debt and block publish. Mitigation:
+  type the new surface up front in Phase A/B.
+- **R6 — Frozen sidecar staleness.** Lifecycle is Python; a `--skip-sidecar`
+  build won't show it. Mitigation: Phase D full rebuild (documented gotcha).
+- **R7 — soft_reconnect ↔ resident runner interaction.** RECOVERING and
+  CONNECTING must not both drive a reconnect concurrently (existing
+  `_civ_recovery_lock`, `_civ_rx.py:2680-2751`). Mitigation: single state
+  machine owns mutual exclusion; T7/T8/T11 cover it.
+
+---
+
+## Open Questions
+
+1. **Cooldown policy ownership at the API edge:** should `connect()` ever
+   surface a "still cooling down" status to Pro/UI (for display), or stay fully
+   opaque until CONNECTED/failed? (Affects the lifecycle-event contract §1.4.)
+2. **SIGTERM graceful-close deadline value:** what exact bound (2 s? 3 s?) and
+   how does it relate to the assumed radio keepalive (40-60 s) and Pro's
+   SIGKILL backstop timer (`station_runtime.py` terminate timeout)?
+3. **`connect()` resident vs caller-cancellable contract:** is there any case
+   where `connect()` *should* give up and return failure (e.g. auth-cred fail
+   `0xFEFFFFFF`, which is non-transient) vs retry forever? Propose: hard-fail
+   on `0xFEFFFFFF`, resident-retry on `civ_port==0`/`0xFFFFFFFF`. Confirm.
+4. **Fleet single-owner limit:** does the radio (and design) allow exactly one
+   active session per radio only, or one per companion across radios? Affects
+   `_enforce_active_limit` removal (§1.2) and T10.
+5. **Crash-restart backoff retention in Pro:** keep a (smaller) crash backoff,
+   and should repeated genuine crashes eventually surface as a hard error to
+   the UI rather than infinite restart?
+6. **Public SDK exposure of `scan()`/lifecycle state:** which of the new
+   symbols become blessed Tier-1/2 public API (per
+   `docs/api/public-api-surface.md`) so Pro can consume them without tripping
+   import-linter?
+7. **Accelerated keepalive default for the simulator:** pick the canonical
+   accelerated `keepalive_hold_s` for the suite and the one near-real value for
+   the slow-marked timing test (R3).
+8. **Real-radio validation gate:** which of T1-T11 require human-in-the-loop
+   validation against a physical IC-7610 before the beta.9 flip, given the
+   simulator can't perfectly reproduce firmware keepalive behavior?
+
+---
+
+## Approved Decisions (2026-06-22)
+
+The 8 open questions above are RESOLVED as follows. These decisions are
+binding for the implementation plan
+(`2026-06-22-radio-session-lifecycle-PLAN.md`). Several carry **refinements**
+that reshape the design beyond a plain yes/no answer — read those in full.
+
+### D1 — Rich lifecycle feedback is a FIRST-CLASS requirement (Q1)
+
+Resolves Q1, but **strengthens** it: the lifecycle controller MUST NOT be
+opaque. The core `RadioSessionLifecycle` MUST expose a **comprehensive,
+structured observable surface** as a built-in capability of the controller —
+not a UI afterthought bolted on later:
+
+- every **state transition** (`DISCONNECTED/SCANNING/CONNECTING/COOLDOWN/
+  CONNECTED/RECOVERING/CLOSING`) with from→to + cause;
+- **connecting progress** and **cooldown progress + countdown** (remaining
+  seconds until next retry attempt);
+- **error reasons** (e.g. auth-cred fail `0xFEFFFFFF`, busy-reject
+  `0xFFFFFFFF`, not-ready `civ_port==0`, data-watchdog stall);
+- **recovery events** (RECOVERING entered/exited, attempt N of M).
+
+This is exposed as a structured **event/status API in core** (an observable
+state object plus an event stream/callback). The client (Pro/UI) consumes a
+**subset** of it, but the CAPABILITY is part of the core controller's public
+contract. This MUST be designed up front in Phase A2 alongside the state
+machine, not retrofitted. It is part of the blessed public-SDK surface (D6).
+
+### D2 — SIGTERM graceful-close timing (Q2)
+
+- **Core close target: ~2-3 s.** The async SIGTERM handler runs the full
+  release (token-remove + OpenClose-close) and aims to complete well under the
+  radio keepalive window. Bounded shutdown deadline 2-3 s (§2.6).
+- **Pro backstop: SIGTERM → wait ~5 s → SIGKILL.** Pro sends SIGTERM, waits
+  ~5 s for a clean exit, and only then issues SIGKILL as a last-resort
+  hung-process backstop. SIGKILL is NEVER the first action and NEVER a
+  lifecycle tool. Pro's wait (~5 s) is deliberately longer than core's close
+  target (~2-3 s) so the normal path is always a clean core exit.
+
+### D3 — Retry policy, AND minimize cooldown by design (Q3)
+
+- **Hard-fail on `0xFEFFFFFF` (auth/credentials).** Non-transient: `connect()`
+  does NOT resident-retry; it transitions to CLOSING with full release and
+  surfaces an auth error reason (D1). Pro/UI shows a hard credential error.
+- **Cooldown-aware resident retry on `civ_port==0` and `0xFFFFFFFF`.** These
+  are transient; the resident runner waits in-process and retries (§2.3).
+- **REFINEMENT — minimize cooldown events by design.** Cooldown is NOT a
+  normal operating mode. Because graceful close is now guaranteed on EVERY exit
+  path (§2.5/§2.6), a self-inflicted held session must become essentially
+  impossible. Therefore in normal operation cooldown should **almost never**
+  occur. Cooldown handling exists ONLY for a genuinely **FOREIGN** held session
+  (another client/host holds the radio), never for a session this process
+  tore down itself. If tests or telemetry show cooldown firing after our own
+  clean disconnect, that is a BUG in the release path, not expected behavior.
+
+### D4 — ARCHITECTURE REFINEMENT: multi-radio = multiple core services (Q4)
+
+This **reshapes the multi-radio model** and supersedes the simpler reading of
+§1.2 / §1.3. The "Companion" is the **Tauri GUI app**, which is a **THIN
+wrapper/interface to core**. Division of responsibility:
+
+- **Pro stores the fleet.** Discovered radios + credentials are owned by Pro as
+  the inventory/UI/storage layer.
+- **ALL connections live in the embedded core service.** No connection
+  lifecycle runs in Pro.
+- **Multi-radio = MULTIPLE core service instances — one per radio — on
+  different ports.** (Future evolution: in-process core objects rather than
+  separate processes.) Switching between radios MAY also be done within a
+  single core service.
+- Therefore Pro's `RadioFleetSessionManager` becomes: **fleet inventory
+  (storage) + spawn/supervise N core services (one per active radio).** The
+  per-radio session lifecycle lives ENTIRELY in that radio's own core service.
+- **Re-express single-owner / `_enforce_active_limit`
+  (`radio_session.py:384`) as "number of concurrent core services," NOT
+  multiple sessions inside one process.** There is exactly **one session per
+  core service per radio**; the radio enforces single-owner on the wire anyway.
+  Pro's job is to bound how many core services run concurrently, not to manage
+  sessions within a process.
+
+Implication for §1.2 / Phase C: the Pro refactor is not just "strip retry"; it
+is "fleet storage + N-supervisor," where N core services each own one radio's
+lifecycle. T10 (fleet switch) is re-expressed accordingly (graceful close in
+the source radio's core service before/independent of the target's).
+
+### D5 — Keep a smaller crash backoff in Pro; hard-error on repeated crashes (Q5)
+
+Pro's **process supervisor** keeps a (smaller) **crash backoff** — for genuine
+process death only, never for "not ready". Repeated genuine crashes
+(threshold TBD by implementer, e.g. N crashes within a window) MUST be
+surfaced as a **hard UI error** rather than infinite silent restart.
+
+### D6 — Lifecycle API is blessed public-SDK, contract-grade (Q6)
+
+The lifecycle API becomes **blessed public-SDK** and MUST therefore be
+**contract-grade: minimal, stable, versioned, additive-only, documented**. Pro
+consumes it **across the core/Pro version boundary**, so the surface must be
+designed deliberately and kept small. Implications:
+
+- The new symbols are added to `docs/api/public-api-surface.md` as supported
+  exports so Pro can import them via the public `rigplane.*` SDK without
+  tripping the import-linter `public-sdk-only` contract.
+- Changes follow the cross-repo COMPATIBILITY policy
+  (`rigplane-pro/docs/contracts/COMPATIBILITY.md`, MOR-885): additive-only,
+  versioned; no breaking changes to the blessed surface without a coordinated
+  core↔Pro cadence.
+- The observable feedback surface (D1) is part of this contract — design the
+  event/status types as stable public types from the start.
+
+Candidate blessed symbols (finalized in the plan):
+`RadioSessionLifecycle`, `LifecycleState` (enum), the lifecycle event/status
+type(s) (e.g. `LifecycleEvent`, `LifecycleStatus`), and the
+`scan/connect/disconnect/soft_reconnect/state` surface.
+
+### D7 — Test keepalive acceleration (Q7) — orchestrator's call
+
+Accelerated `keepalive_hold_s` ~**0.5 s** for the fast suite (fast tests), plus
+**one near-real ~45-60 s `@slow`-marked timing test** to guard against
+acceleration masking real timing bugs (R3). Exact value is the orchestrator's
+call within that band; document the chosen accelerated value in the simulator
+and the slow test.
+
+### D8 — Physical IC-7610 validation scope before flip (Q8) — orchestrator's call
+
+The radio IS available for human-in-the-loop validation. Recommended minimum
+physical-radio set before the beta.9 flip (final scope is the orchestrator's
+call):
+
+- **T1** — clean `connect()` → `disconnect()` with NO cooldown observed;
+- **T3** — abort→release fix (release obligation fires, radio free immediately);
+- **T6** — `scan()` does not disturb session ownership / SIGTERM → radio free
+  (validate graceful close frees the radio on a real keepalive window);
+- **`soft_reconnect`** on the real radio (RECOVERING path).
+
+These exercise the governing principle and the holes most sensitive to real
+firmware keepalive behavior that the simulator cannot perfectly reproduce.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "rigplane"
-version = "2.10.8"
+version = "2.11.0"
 description = "Multi-vendor radio control library and Web UI with native providers and planned Hamlib-backed CAT coverage"
 readme = "README.md"
 license = "MIT"

--- a/src/rigplane/__init__.py
+++ b/src/rigplane/__init__.py
@@ -84,6 +84,14 @@ from .radio_protocol import (  # noqa: F401, E402
     VoiceControlCapable,
 )
 from .radio_state import RadioState, VfoSlotState, YaesuStateExtension  # noqa: F401, E402
+from .runtime.session_lifecycle import (  # noqa: F401, E402
+    LifecycleErrorReason,
+    LifecycleEvent,
+    LifecycleState,
+    LifecycleStatus,
+    RadioPresence,
+    RadioSessionLifecycle,
+)
 from .types import AudioCodec, BreakInMode, Mode  # noqa: F401, E402
 
 # === Tier 2 — lazy via PEP 562 ===
@@ -333,6 +341,13 @@ __all__ = [
     "RadioProfile",
     "VfoSlotState",
     "YaesuStateExtension",
+    # --- Tier 1: Session lifecycle (v2.11, D6) ---
+    "RadioSessionLifecycle",
+    "LifecycleState",
+    "LifecycleStatus",
+    "LifecycleEvent",
+    "LifecycleErrorReason",
+    "RadioPresence",
     # --- Tier 2 (lazy): backward-compat facade ---
     "IcomRadio",
     # --- Tier 2 (lazy): commander internals ---

--- a/src/rigplane/cli/__init__.py
+++ b/src/rigplane/cli/__init__.py
@@ -3769,8 +3769,15 @@ def main() -> None:
         parser.print_help()
         sys.exit(0)
     else:
-        # Convert SIGTERM to KeyboardInterrupt so asyncio.run() cleanup
-        # properly unwinds the async context manager (radio.disconnect()).
+        # Convert SIGTERM to KeyboardInterrupt so the event loop unwinds the
+        # ``async with radio:`` context manager, whose ``__aexit__`` runs the
+        # unified session lifecycle's graceful close (``radio.disconnect()`` →
+        # ``CoreRadioSessionLifecycle.disconnect`` → mechanism release).  The
+        # release sends the load-bearing token-remove under ``asyncio.shield``
+        # (Note 2), so the radio's session is freed BEFORE the ``os._exit``
+        # below — even though a cancel is already in flight from the SIGTERM.
+        # This is the SIGTERM graceful-close path (design 2.6 / Hole 3): the
+        # process does not hard-exit before the token-remove has gone out.
         def _sigterm_handler(signum: int, frame: Any) -> None:
             raise KeyboardInterrupt()
 

--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -583,11 +583,11 @@ class CivRuntime:
 
         rc_task = self._reconnect_task
         # Never cancel the detached recovery task if *it* is the caller.  The
-        # recovery helpers (``_watchdog_soft_reconnect`` /
-        # ``_watchdog_full_reconnect``) call ``_force_cleanup_civ`` →
-        # ``stop_data_watchdog`` from inside themselves; cancelling the current
-        # task here would self-cancel before ``soft_reconnect`` ever runs,
-        # freezing recovery after a single attempt (#1217).
+        # recovery helper (``_watchdog_recover``) calls ``_force_cleanup_civ`` →
+        # ``stop_data_watchdog`` from inside itself; cancelling the current task
+        # here would self-cancel before the lifecycle ``soft_reconnect`` ever
+        # runs, freezing recovery after a single attempt (#1217 invariant 2:
+        # self-cancel guard).
         current = asyncio.current_task()
         if rc_task is not None and rc_task is not current and not rc_task.done():
             rc_task.cancel()
@@ -820,20 +820,29 @@ class CivRuntime:
     # ------------------------------------------------------------------
 
     async def _civ_data_watchdog_loop(self) -> None:
-        """Monitor CI-V data flow; recover with open_close then soft_reconnect.
+        """DETECT CI-V data stalls; nudge with OpenClose, then HAND OFF recovery.
 
-        OpenClose is retried patiently (wfview icomudpcivdata.cpp:31 pattern —
-        never escalates). rigplane keeps a safety-net deadline at
-        _OPENCLOSE_DEADLINE before handing recovery off to a detached
-        reconnect task. The task is detached so its cooldown sleep survives
-        the watchdog loop exiting.
+        This is the stall DETECTOR only. It watches CI-V data flow, sends
+        patient OpenClose nudges (wfview icomudpcivdata.cpp:31 pattern — never
+        escalates), and at the safety-net deadline ``_OPENCLOSE_DEADLINE`` hands
+        recovery off to a detached task (:meth:`_watchdog_recover`).
+
+        The retry/backoff/exhaustion LADDER no longer lives here: it moved to
+        the unified lifecycle RECOVERING loop
+        (``CoreRadioSessionLifecycle._run_recover``), which owns the attempt
+        count (``_MAX_RECONNECTS``), the backoff (``_RECONNECT_BACKOFF``), and
+        exhaustion → CLOSING + full release. The detached handoff drives
+        ``host.soft_reconnect()`` (now routed to that lifecycle loop) ONCE per
+        detected stall episode and then unconditionally re-arms this watchdog in
+        ``finally`` so a later stall is detected again (#1217).
+
+        The task is detached so the recovery (including the lifecycle's backoff
+        sleeps) survives this watchdog loop exiting (the self-cancel guard in
+        :meth:`stop_data_watchdog` keeps it from cancelling itself).
         """
         _OPENCLOSE_DEADLINE = 60.0
-        _MAX_RECONNECTS = 3
-        _RECONNECT_BACKOFF = (45.0, 60.0, 60.0)
         recovering = False
         recovery_start: float = 0.0
-        reconnect_count = 0
         try:
             while True:
                 await asyncio.sleep(
@@ -881,37 +890,20 @@ class CivRuntime:
                                 exc_info=True,
                             )
                     else:
-                        reconnect_count += 1
-                        reconnect_pause = _RECONNECT_BACKOFF[
-                            min(reconnect_count - 1, len(_RECONNECT_BACKOFF) - 1)
-                        ]
-                        # Recovery runs in a detached task so its cooldown
-                        # sleep is honored even when this watchdog task
-                        # exits. The prior inline `await stop_data_watchdog()`
-                        # cancelled this task and caused the cooldown to be
-                        # skipped entirely (self-cancel bug).
-                        if reconnect_count > _MAX_RECONNECTS:
-                            logger.warning(
-                                "civ-data-watchdog: %d soft reconnects failed, "
-                                "attempting full reconnect",
-                                reconnect_count - 1,
-                            )
-                            self._reconnect_task = asyncio.create_task(
-                                self._watchdog_full_reconnect(reconnect_pause),
-                                name="civ-watchdog-full-reconnect",
-                            )
-                            return
+                        # Patient OpenClose exhausted: hand recovery off to the
+                        # unified lifecycle RECOVERING loop in a DETACHED task.
+                        # The lifecycle owns the retry/backoff/exhaustion policy;
+                        # this detector only triggers it once and re-arms in
+                        # ``finally`` (#1217 invariants preserved in
+                        # ``_watchdog_recover``).
                         logger.warning(
                             "civ-data-watchdog: OpenClose failed for %.1fs, "
-                            "triggering soft_reconnect (%d/%d), cooldown=%.0fs",
+                            "handing off to lifecycle recovery",
                             elapsed_recovery,
-                            reconnect_count,
-                            _MAX_RECONNECTS,
-                            reconnect_pause,
                         )
                         self._reconnect_task = asyncio.create_task(
-                            self._watchdog_soft_reconnect(reconnect_pause),
-                            name="civ-watchdog-soft-reconnect",
+                            self._watchdog_recover(),
+                            name="civ-watchdog-recover",
                         )
                         return
                 else:
@@ -923,67 +915,39 @@ class CivRuntime:
         except asyncio.CancelledError:
             pass
 
-    async def _watchdog_soft_reconnect(self, cooldown: float) -> None:
-        """Detached recovery: force_cleanup → sleep(cooldown) → soft_reconnect.
+    async def _watchdog_recover(self) -> None:
+        """Detached recovery handoff: force_cleanup → lifecycle soft_reconnect.
 
-        Runs outside the watchdog loop so the cooldown sleep survives the
-        watchdog task exiting. Falls back to full reconnect on failure.
+        Runs outside the watchdog loop so the lifecycle's RECOVERING backoff
+        sleeps survive the watchdog task exiting (#1217 invariant 1: detached
+        execution — recovery is not cancelled by the very stall that triggered
+        it).
 
-        Always re-arms the data watchdog in ``finally`` so recovery keeps
-        retrying indefinitely (with bounded backoff) until the radio answers,
-        instead of freezing after a single attempt (#1217).
+        ``host.soft_reconnect()`` is the unified lifecycle RECOVERING loop and
+        is the SINGLE owner of the retry/backoff/exhaustion policy now: it
+        performs ``_MAX_RECONNECTS`` attempts with ``_RECONNECT_BACKOFF`` and,
+        on exhaustion, routes through CLOSING + full release (after which the
+        control session is gone and re-arming below correctly no-ops).
+
+        Always re-arms the data watchdog in ``finally`` (#1217 invariant 3:
+        unconditional re-arm) so a fresh stall is detected and handed off again
+        instead of freezing after one episode. ``_rearm_data_watchdog_after_
+        recovery`` skips only when the control session is gone — i.e. after a
+        successful lifecycle exhaustion → CLOSING, where there is nothing left
+        to watch.
         """
         try:
             await self._host._force_cleanup_civ()
-            await asyncio.sleep(cooldown)
             await self._host.soft_reconnect()
         except (ConnectionError, TimeoutError, OSError):
             logger.error(
-                "civ-data-watchdog: soft_reconnect failed, "
-                "falling back to full reconnect",
-                exc_info=True,
-            )
-            try:
-                await self._host.disconnect()
-                await asyncio.sleep(cooldown)
-                await self._host.connect()
-            except (ConnectionError, TimeoutError, OSError):
-                logger.error(
-                    "civ-data-watchdog: full reconnect also failed",
-                    exc_info=True,
-                )
-            except Exception:
-                logger.error(
-                    "civ-data-watchdog: unexpected error in full reconnect fallback",
-                    exc_info=True,
-                )
-        except Exception:
-            logger.error(
-                "civ-data-watchdog: unexpected error in soft_reconnect",
-                exc_info=True,
-            )
-        finally:
-            self._rearm_data_watchdog_after_recovery()
-
-    async def _watchdog_full_reconnect(self, cooldown: float) -> None:
-        """Detached full reconnect after max soft_reconnect attempts exceeded.
-
-        Re-arms the data watchdog in ``finally`` so a still-unreachable radio
-        is re-probed instead of leaving recovery permanently frozen (#1217).
-        """
-        try:
-            await self._host._force_cleanup_civ()
-            await self._host.disconnect()
-            await asyncio.sleep(cooldown)
-            await self._host.connect()
-        except (ConnectionError, TimeoutError, OSError):
-            logger.error(
-                "civ-data-watchdog: full reconnect failed",
+                "civ-data-watchdog: lifecycle recovery failed (exhausted or "
+                "transient); watchdog will re-arm if the session survives",
                 exc_info=True,
             )
         except Exception:
             logger.error(
-                "civ-data-watchdog: unexpected error in full reconnect",
+                "civ-data-watchdog: unexpected error in lifecycle recovery",
                 exc_info=True,
             )
         finally:
@@ -992,7 +956,7 @@ class CivRuntime:
     def _rearm_data_watchdog_after_recovery(self) -> None:
         """Re-arm the CI-V data watchdog after a detached recovery attempt.
 
-        Recovery helpers run as ``self._reconnect_task``; once a helper
+        The recovery handoff runs as ``self._reconnect_task``; once it
         finishes, clear that handle and start a fresh watchdog so the next
         stall is detected and escalated again.  ``start_data_watchdog`` is a
         no-op when a healthy watchdog was already re-armed by a successful

--- a/src/rigplane/runtime/_control_phase.py
+++ b/src/rigplane/runtime/_control_phase.py
@@ -528,8 +528,16 @@ class ControlPhaseRuntime:
                 await h._stop_civ_rx_pump()
             await h._civ_transport.disconnect()
             h._civ_transport = None
+        # Shield the token-remove on the graceful CONNECTED path too (A3-verifier
+        # forward-note).  Now that recovery/shutdown can run this disconnect()
+        # under asyncio cancellation (the lifecycle's teardown / SIGTERM
+        # graceful-close cancels in-flight tasks), a pending cancel could
+        # otherwise truncate the load-bearing token-remove mid-flight and leave
+        # the radio's single-owner lock held.  ``asyncio.shield`` runs it to
+        # completion even under a pending cancel, mirroring the already-shielded
+        # token-remove in :meth:`release`.
         try:
-            await self._send_token(0x01)
+            await asyncio.shield(self._send_token(0x01))
         except Exception:
             logger.debug("disconnect: token remove failed", exc_info=True)
         await h._ctrl_transport.disconnect()

--- a/src/rigplane/runtime/_control_phase.py
+++ b/src/rigplane/runtime/_control_phase.py
@@ -8,9 +8,10 @@ import logging
 import socket as _socket
 import struct
 import time
+from collections.abc import Awaitable, Callable
 from contextlib import suppress as _suppress
 from dataclasses import replace
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, SupportsInt, cast
 
 from rigplane.core.auth import (
     build_conninfo_packet,
@@ -27,9 +28,15 @@ from rigplane.audio.route import AudioConfigSource
 
 if TYPE_CHECKING:
     from ._runtime_protocols import ControlPhaseHost
-    from .session_lifecycle import AttemptResult
+    from .session_lifecycle import AttemptResult, RadioPresence
 
 logger = logging.getLogger(__name__)
+
+#: Discovery callable injected into :class:`ControlPhaseSessionMechanism` so the
+#: lifecycle's ``scan()`` can probe for radios without ``rigplane.runtime``
+#: importing ``rigplane.backends`` (layered-architecture boundary).  Matches
+#: ``rigplane.backends.discovery.discover_lan_radios``.
+_DiscoverFn = Callable[..., Awaitable[list[dict[str, object]]]]
 
 # Packet size constants (per wfview packettypes.h).
 OPENCLOSE_SIZE = 0x16
@@ -57,6 +64,7 @@ def _is_address_in_use(exc: OSError) -> bool:
 
 __all__ = [
     "ControlPhaseRuntime",
+    "ControlPhaseSessionMechanism",
     "OPENCLOSE_SIZE",
     "TOKEN_ACK_SIZE",
     "CONNINFO_SIZE",
@@ -74,9 +82,16 @@ class ControlPhaseRuntime:
     TOKEN_PACKET_SIZE = 0x40
     WATCHDOG_CHECK_INTERVAL = 0.5
     _WATCHDOG_HEALTH_LOG_INTERVAL = 30.0
+    # Conninfo re-send pause for the WITHIN-attempt busy-retry inside
+    # ``_connect_once`` (a packet-mechanism detail: how long to wait before
+    # re-sending conninfo when the radio reports civ_port==0 mid-handshake).
+    # NOTE: this is NOT the lifecycle's COOLDOWN-between-attempts policy — that
+    # now lives solely in ``session_lifecycle.CoreRadioSessionLifecycle``.  The
+    # legacy ``ControlPhaseRuntime.connect()`` retry wrapper and its
+    # ``_DATA_PORT_COOLDOWN_RETRIES`` loop were removed in A3; the lifecycle
+    # owns CONNECTING↔COOLDOWN (it RELEASES before each cooldown wait).
     _STATUS_RETRY_PAUSE = 10.0
     _STATUS_REJECT_COOLDOWN = 30.0
-    _DATA_PORT_COOLDOWN_RETRIES = 3
 
     def __init__(self, host: ControlPhaseHost) -> None:
         self._host = host
@@ -112,56 +127,6 @@ class ControlPhaseRuntime:
                     pass
                 setattr(h, attr, None)
 
-    async def connect(self) -> None:
-        """Open connection to the radio and authenticate.
-
-        .. deprecated:: lifecycle (task A2/A3)
-            This in-mechanism retry wrapper is the OLD home of the
-            cooldown/retry policy.  The unified
-            :class:`~rigplane.runtime.session_lifecycle.CoreRadioSessionLifecycle`
-            now owns CONNECTING↔COOLDOWN as state transitions (it RELEASES the
-            session before each cooldown wait — closing the held-cooldown root
-            cause).  ``ControlPhaseRuntime`` is being demoted to a pure packet
-            *mechanism*: see :meth:`connect_attempt` / :meth:`release`.
-
-            **A3 reroute contract:** when ``CoreRadio.connect`` is routed
-            through the lifecycle, DELETE this wrapper (and the
-            ``_DATA_PORT_COOLDOWN_RETRIES`` loop), move the two tests that
-            exercise it (``test_data_port_discovery_timeout_retries_and_closes_pending_sockets``
-            and ``test_connect_raises_on_status_rejection_after_retries`` in
-            ``tests/test_radio_connect.py``) onto the lifecycle, and have the
-            mechanism adapter call :meth:`connect_attempt` once per lifecycle
-            attempt.  Until then this wrapper stays so existing callers/tests
-            remain green (no call-site behavior change in Phase A).
-        """
-        h = self._host
-        max_attempts = self._DATA_PORT_COOLDOWN_RETRIES + 1
-        for attempt in range(1, max_attempts + 1):
-            try:
-                await self._connect_once()
-                return
-            except _DataPortDiscoveryCooldown as exc:
-                if attempt >= max_attempts:
-                    raise ConnectionError(
-                        "CI-V data-port discovery timed out after successful "
-                        "control auth/status; the radio may still be releasing "
-                        "a previous LAN session. Wait 30-60s and retry."
-                    ) from exc
-                retry_pause = self._status_retry_pause()
-                logger.warning(
-                    "CI-V data-port discovery timed out after successful control "
-                    "auth/status; treating as session cooldown "
-                    "(host=%s, control=%d, civ=%d, attempt=%d/%d). "
-                    "Retrying after %.0fs.",
-                    h._host,
-                    h._port,
-                    h._civ_port,
-                    attempt,
-                    max_attempts,
-                    retry_pause,
-                )
-                await asyncio.sleep(retry_pause)
-
     async def _connect_once(self) -> None:
         """Open connection to the radio and authenticate."""
         h = self._host
@@ -170,6 +135,7 @@ class ControlPhaseRuntime:
         h._civ_recovering = False
         h._last_status_error = 0
         h._last_status_disconnected = False
+        h._last_auth_error = 0
         # Re-enable queue during setup — we need status packets from radio
         h._ctrl_transport._discard_data_packets = False
         local_bind_host = self._resolve_local_bind_host()
@@ -224,6 +190,12 @@ class ControlPhaseRuntime:
             logger.warning(
                 "Control auth failed: %s:%d error=0x%08X", h._host, h._port, auth.error
             )
+            # Record the raw auth error so the lifecycle mechanism seam can tell a
+            # hard credential rejection (0xFEFFFFFF) apart from a transient
+            # "previous session still active" reject (0xFFFFFFFF) at the auth
+            # stage — only the former is a non-retryable AUTH_CREDENTIALS hard
+            # fail (D3 / lifecycle Note 1).
+            h._last_auth_error = auth.error
             raise AuthenticationError(
                 f"Authentication failed (error=0x{auth.error:08X})"
             )
@@ -586,17 +558,33 @@ class ControlPhaseRuntime:
         Returns an :class:`~rigplane.runtime.session_lifecycle.AttemptResult`:
 
         * ``CONNECTED`` — ``_connect_once`` reached CONNECTED;
-        * ``SESSION_NOT_READY`` — civ_port==0 (data-port discovery cooldown or
-          status civ_port==0);
-        * ``SESSION_BUSY_REJECT`` — status error 0xFFFFFFFF;
-        * ``AUTH_CREDENTIALS`` — auth rejected (raises
-          :class:`AuthenticationError`, which the lifecycle maps to hard-fail).
+        * ``SESSION_NOT_READY`` — civ_port==0 / data-port discovery cooldown;
+        * ``SESSION_BUSY_REJECT`` — status (or auth) error 0xFFFFFFFF —
+          "previous session still active";
+        * ``AUTH_CREDENTIALS`` — auth rejected with the *non-transient*
+          credential error 0xFEFFFFFF.
 
-        .. note::
-            This wraps the existing :meth:`_connect_once` for now (it preserves
-            the audio fallback and socket plumbing).  A3 may inline the
-            single-attempt body and drop the busy-retry loop inside
-            ``_connect_once`` once the lifecycle owns retry.
+        Classification rules (lifecycle Note 1; behaviour-preserving wiring):
+
+        * The ONLY transient signal ``_connect_once`` emits is
+          :class:`_DataPortDiscoveryCooldown` (CI-V data-port discovery timed out
+          after a successful auth/status) → ``SESSION_NOT_READY``.  This mirrors
+          the removed legacy ``connect()`` wrapper, which retried exactly this
+          case (its ``_DATA_PORT_COOLDOWN_RETRIES`` loop) and let every other
+          failure propagate.
+        * **Note 1 (auth over-hard-fail fix):** ``_connect_once`` raises
+          :class:`AuthenticationError` for ANY ``auth.success == False`` — which
+          covers BOTH 0xFEFFFFFF (wrong credentials, hard) AND 0xFFFFFFFF
+          (previous session active, transient).  Only 0xFEFFFFFF maps to the
+          non-retryable ``AUTH_CREDENTIALS``; any other auth failure (notably the
+          0xFFFFFFFF busy reject surfaced at the auth stage) maps to the
+          transient ``SESSION_BUSY_REJECT`` so a transient auth glitch is retried
+          rather than permanently failed.
+        * Every other ``ConnectionError`` (the radio definitively rejected the
+          session/codec after ``_connect_once`` exhausted its own within-attempt
+          fallbacks; CI-V/control open failure; startup-readiness abort) is a
+          genuine HARD error and is **propagated unchanged** — it is NOT
+          downgraded to a silent transient retry.
         """
         from rigplane.runtime.session_lifecycle import AttemptOutcome, AttemptResult
 
@@ -606,15 +594,12 @@ class ControlPhaseRuntime:
         except _DataPortDiscoveryCooldown:
             return AttemptResult(AttemptOutcome.SESSION_NOT_READY)
         except AuthenticationError:
-            # Distinguish credential rejection (0xFEFFFFFF) — the only
-            # non-transient auth failure (D3 hard-fail).
-            return AttemptResult(AttemptOutcome.AUTH_CREDENTIALS)
-        except ConnectionError:
-            # ``_connect_once`` raises ConnectionError on a busy/not-ready
-            # rejection after its internal checks; classify by last status.
-            if getattr(h, "_last_status_error", 0) == 0xFFFFFFFF:
-                return AttemptResult(AttemptOutcome.SESSION_BUSY_REJECT)
-            return AttemptResult(AttemptOutcome.SESSION_NOT_READY)
+            # Note 1: ONLY 0xFEFFFFFF is a hard credential failure.  Any other
+            # auth failure (e.g. 0xFFFFFFFF "previous session active" surfaced at
+            # the auth stage) is transient → cooldown-aware resident retry.
+            if getattr(h, "_last_auth_error", 0) == 0xFEFFFFFF:
+                return AttemptResult(AttemptOutcome.AUTH_CREDENTIALS)
+            return AttemptResult(AttemptOutcome.SESSION_BUSY_REJECT)
         return AttemptResult(AttemptOutcome.CONNECTED)
 
     async def release(self) -> None:
@@ -649,13 +634,24 @@ class ControlPhaseRuntime:
             h._civ_transport = None
         # The token-remove is the load-bearing release: send it whenever a
         # control transport exists, regardless of conn_state.
+        #
+        # Note 2 (release truncated by cancel): when release runs on the SIGTERM
+        # graceful-close path (``CoreRadioSessionLifecycle.request_shutdown`` →
+        # teardown) a fresh cancellation may already be pending on this task.
+        # The earlier ``await``s here (audio/CI-V disconnect) do NOT swallow
+        # ``CancelledError`` — only ``Exception`` — so an un-shielded await
+        # before the token-remove could be cancelled mid-flight and skip it.
+        # ``asyncio.shield`` runs the token-remove to completion even under a
+        # pending cancel, guaranteeing the radio is freed within the close
+        # deadline.  We re-suppress here because ``shield`` re-raises the
+        # outer ``CancelledError`` once the shielded coroutine finishes.
         ctrl_t = getattr(h, "_ctrl_transport", None)
         if ctrl_t is not None and h._token:
             with _suppress(Exception):
-                await self._send_token(0x01)
+                await asyncio.shield(self._send_token(0x01))
         if ctrl_t is not None:
             with _suppress(Exception):
-                await ctrl_t.disconnect()
+                await asyncio.shield(ctrl_t.disconnect())
         h._conn_state = RadioConnectionState.DISCONNECTED
         h._civ_stream_ready = False
         h._civ_recovering = False
@@ -711,7 +707,11 @@ class ControlPhaseRuntime:
             h._ctrl_transport, "_udp_transport", None
         ):
             logger.info("soft_reconnect: control transport gone, doing full connect")
-            await self.connect()
+            # The legacy ``connect()`` retry wrapper was removed in A3; the
+            # lifecycle owns retry.  A full re-establish here is a single
+            # mechanism attempt (``_connect_once``); the lifecycle's RECOVERING
+            # accounting / exhaustion handles repeated failures.
+            await self._connect_once()
             return
 
         h._conn_state = RadioConnectionState.CONNECTING
@@ -1078,3 +1078,81 @@ class ControlPhaseRuntime:
         if h._reconnect_task is not None and not h._reconnect_task.done():
             h._reconnect_task.cancel()
             h._reconnect_task = None
+
+
+class ControlPhaseSessionMechanism:
+    """Production :class:`~rigplane.runtime.session_lifecycle.SessionMechanism`.
+
+    Adapts a :class:`ControlPhaseRuntime` (the packet I/O mechanism) to the
+    :class:`SessionMechanism` protocol the :class:`CoreRadioSessionLifecycle`
+    policy layer drives (task A3).  One :meth:`connect_attempt` per lifecycle
+    attempt; :meth:`release` for guaranteed teardown; :meth:`soft_reconnect_once`
+    for recovery; a discovery-based :meth:`scan`.
+
+    The lifecycle owns CONNECTING↔COOLDOWN retry; this adapter performs no
+    sleeps or retries of its own beyond the packet-mechanism internals of
+    ``_connect_once``.
+    """
+
+    def __init__(
+        self,
+        control_phase: ControlPhaseRuntime,
+        *,
+        discover_fn: "_DiscoverFn | None" = None,
+    ) -> None:
+        self._cp = control_phase
+        # Presence-probe discovery is INJECTED from an upper layer (CLI/web).
+        # ``rigplane.runtime`` may not import ``rigplane.backends`` (layered
+        # architecture, enforced by import-linter), so the lifecycle's
+        # ``scan()`` borrows a discovery callable supplied by the caller rather
+        # than importing ``backends.discovery`` here.
+        self._discover_fn = discover_fn
+
+    async def connect_attempt(self) -> "AttemptResult":
+        return await self._cp.connect_attempt()
+
+    async def release(self) -> None:
+        """Guaranteed release (token-remove + close).
+
+        When a full CONNECTED session exists, route through the graceful
+        :meth:`ControlPhaseRuntime.disconnect` (audio/CI-V teardown, generation
+        advance, token-remove) so observable teardown behaviour is unchanged.
+        Otherwise fall through to the unconditional :meth:`ControlPhaseRuntime.
+        release`, which still token-removes a partially-claimed session (Holes
+        1/5/8).  Both are idempotent.
+        """
+        h = self._cp._host
+        if getattr(h, "_conn_state", None) is RadioConnectionState.CONNECTED:
+            # Full graceful teardown (audio/CI-V stop, generation advance,
+            # token-remove, ctrl disconnect).  This already sends token-remove,
+            # so do NOT also run the partial-claim ``release`` afterwards.
+            await self._cp.disconnect()
+            return
+        await self._cp.release()
+
+    async def soft_reconnect_once(self) -> None:
+        await self._cp.soft_reconnect()
+
+    async def scan(
+        self, targets: list[str] | None, *, timeout: float
+    ) -> list["RadioPresence"]:
+        from rigplane.runtime.session_lifecycle import RadioPresence
+
+        if self._discover_fn is None:
+            raise NotImplementedError(
+                "lifecycle scan() requires a discovery callable; construct "
+                "ControlPhaseSessionMechanism with discover_fn= from an upper "
+                "layer (e.g. rigplane.backends.discovery.discover_lan_radios)."
+            )
+        found = await self._discover_fn(timeout=timeout)
+        presences = [
+            RadioPresence(
+                host=str(r["host"]),
+                remote_id=int(cast("SupportsInt", r["remote_id"])),
+            )
+            for r in found
+        ]
+        if targets is not None:
+            wanted = set(targets)
+            presences = [p for p in presences if p.host in wanted]
+        return presences

--- a/src/rigplane/runtime/_control_phase.py
+++ b/src/rigplane/runtime/_control_phase.py
@@ -8,6 +8,7 @@ import logging
 import socket as _socket
 import struct
 import time
+from contextlib import suppress as _suppress
 from dataclasses import replace
 from typing import TYPE_CHECKING
 
@@ -26,6 +27,7 @@ from rigplane.audio.route import AudioConfigSource
 
 if TYPE_CHECKING:
     from ._runtime_protocols import ControlPhaseHost
+    from .session_lifecycle import AttemptResult
 
 logger = logging.getLogger(__name__)
 
@@ -111,7 +113,27 @@ class ControlPhaseRuntime:
                 setattr(h, attr, None)
 
     async def connect(self) -> None:
-        """Open connection to the radio and authenticate."""
+        """Open connection to the radio and authenticate.
+
+        .. deprecated:: lifecycle (task A2/A3)
+            This in-mechanism retry wrapper is the OLD home of the
+            cooldown/retry policy.  The unified
+            :class:`~rigplane.runtime.session_lifecycle.CoreRadioSessionLifecycle`
+            now owns CONNECTING↔COOLDOWN as state transitions (it RELEASES the
+            session before each cooldown wait — closing the held-cooldown root
+            cause).  ``ControlPhaseRuntime`` is being demoted to a pure packet
+            *mechanism*: see :meth:`connect_attempt` / :meth:`release`.
+
+            **A3 reroute contract:** when ``CoreRadio.connect`` is routed
+            through the lifecycle, DELETE this wrapper (and the
+            ``_DATA_PORT_COOLDOWN_RETRIES`` loop), move the two tests that
+            exercise it (``test_data_port_discovery_timeout_retries_and_closes_pending_sockets``
+            and ``test_connect_raises_on_status_rejection_after_retries`` in
+            ``tests/test_radio_connect.py``) onto the lifecycle, and have the
+            mechanism adapter call :meth:`connect_attempt` once per lifecycle
+            attempt.  Until then this wrapper stays so existing callers/tests
+            remain green (no call-site behavior change in Phase A).
+        """
         h = self._host
         max_attempts = self._DATA_PORT_COOLDOWN_RETRIES + 1
         for attempt in range(1, max_attempts + 1):
@@ -543,6 +565,100 @@ class ControlPhaseRuntime:
         h._civ_stream_ready = False
         h._civ_recovering = False
         logger.info("Disconnected from %s:%d", h._host, h._port)
+
+    # ------------------------------------------------------------------
+    # Packet-mechanism seam for the unified session lifecycle (task A2)
+    # ------------------------------------------------------------------
+    #
+    # These methods are the demoted, pure-mechanism surface the
+    # ``CoreRadioSessionLifecycle`` policy layer drives.  They contain NO
+    # retry/sleep/cooldown — that policy lives in the lifecycle.  A3 wires an
+    # adapter (``ControlPhaseSessionMechanism`` below) so the lifecycle owns
+    # CONNECTING↔COOLDOWN and ``ControlPhaseRuntime`` owns packet I/O only.
+
+    async def connect_attempt(self) -> "AttemptResult":
+        """Perform ONE connect attempt (auth + CI-V port); classify the outcome.
+
+        Pure mechanism: no retry, no cooldown sleep.  The release obligation is
+        considered registered the instant auth succeeds — the lifecycle's RAII
+        discharges it via :meth:`release` on every exit path.
+
+        Returns an :class:`~rigplane.runtime.session_lifecycle.AttemptResult`:
+
+        * ``CONNECTED`` — ``_connect_once`` reached CONNECTED;
+        * ``SESSION_NOT_READY`` — civ_port==0 (data-port discovery cooldown or
+          status civ_port==0);
+        * ``SESSION_BUSY_REJECT`` — status error 0xFFFFFFFF;
+        * ``AUTH_CREDENTIALS`` — auth rejected (raises
+          :class:`AuthenticationError`, which the lifecycle maps to hard-fail).
+
+        .. note::
+            This wraps the existing :meth:`_connect_once` for now (it preserves
+            the audio fallback and socket plumbing).  A3 may inline the
+            single-attempt body and drop the busy-retry loop inside
+            ``_connect_once`` once the lifecycle owns retry.
+        """
+        from rigplane.runtime.session_lifecycle import AttemptOutcome, AttemptResult
+
+        h = self._host
+        try:
+            await self._connect_once()
+        except _DataPortDiscoveryCooldown:
+            return AttemptResult(AttemptOutcome.SESSION_NOT_READY)
+        except AuthenticationError:
+            # Distinguish credential rejection (0xFEFFFFFF) — the only
+            # non-transient auth failure (D3 hard-fail).
+            return AttemptResult(AttemptOutcome.AUTH_CREDENTIALS)
+        except ConnectionError:
+            # ``_connect_once`` raises ConnectionError on a busy/not-ready
+            # rejection after its internal checks; classify by last status.
+            if getattr(h, "_last_status_error", 0) == 0xFFFFFFFF:
+                return AttemptResult(AttemptOutcome.SESSION_BUSY_REJECT)
+            return AttemptResult(AttemptOutcome.SESSION_NOT_READY)
+        return AttemptResult(AttemptOutcome.CONNECTED)
+
+    async def release(self) -> None:
+        """Release the session UNCONDITIONALLY (token-remove + close + sockets).
+
+        This is the guaranteed-release primitive (design §2.5).  Unlike
+        :meth:`disconnect`, it does NOT early-return on
+        ``conn_state != CONNECTED`` — a partially-claimed session (post-auth,
+        pre-CONNECTED) is still released, closing graceful-close Holes 1/5/8.
+        Idempotent: safe to call when nothing is claimed.
+        """
+        h = self._host
+        # Best-effort teardown of any data/audio transports first (mirrors
+        # disconnect ordering), then the always-sent token-remove.
+        self._stop_watchdog()
+        self._stop_reconnect()
+        self._stop_token_renewal()
+        self._close_pending_sockets()
+        audio_t = getattr(h, "_audio_transport", None)
+        if audio_t is not None:
+            with _suppress(Exception):
+                await self._send_audio_open_close(open_stream=False)
+            with _suppress(Exception):
+                await audio_t.disconnect()
+            h._audio_transport = None
+        civ_t = getattr(h, "_civ_transport", None)
+        if civ_t is not None:
+            with _suppress(Exception):
+                await self._send_open_close(open_stream=False)
+            with _suppress(Exception):
+                await civ_t.disconnect()
+            h._civ_transport = None
+        # The token-remove is the load-bearing release: send it whenever a
+        # control transport exists, regardless of conn_state.
+        ctrl_t = getattr(h, "_ctrl_transport", None)
+        if ctrl_t is not None and h._token:
+            with _suppress(Exception):
+                await self._send_token(0x01)
+        if ctrl_t is not None:
+            with _suppress(Exception):
+                await ctrl_t.disconnect()
+        h._conn_state = RadioConnectionState.DISCONNECTED
+        h._civ_stream_ready = False
+        h._civ_recovering = False
 
     async def soft_reconnect(self) -> None:
         """Reconnect CI-V transport using existing control session."""

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -54,7 +54,9 @@ from rigplane.runtime._control_phase import (
     STATUS_SIZE,  # noqa: F401 (re-export for tests)
     TOKEN_ACK_SIZE,  # noqa: F401 (re-export for tests)
     ControlPhaseRuntime,
+    ControlPhaseSessionMechanism,
 )
+from rigplane.runtime.session_lifecycle import CoreRadioSessionLifecycle
 from rigplane.audio import AudioPacket, AudioStream
 from rigplane.core.civ import CivEvent, CivRequestTracker
 from rigplane.commands.commander import IcomCommander, Priority
@@ -857,6 +859,31 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._control_phase: ControlPhaseRuntime = ControlPhaseRuntime(
             cast("ControlPhaseHost", self)
         )
+        # Unified session lifecycle (policy layer) over the control-phase packet
+        # mechanism.  ``CoreRadio.connect/disconnect/soft_reconnect/scan`` route
+        # through this so the guaranteed-release + cooldown-aware-retry policy is
+        # owned in one place (design 2026-06-22; task A3).  The resident-retry
+        # bound mirrors the removed legacy wrapper (``_DATA_PORT_COOLDOWN_RETRIES
+        # + 1`` attempts) so an in-process ``CoreRadio`` still surfaces a
+        # ConnectionError on a persistently-unready radio rather than spinning
+        # forever; the longer-lived Pro service uses the lifecycle's resident
+        # default directly.
+        self._session_mechanism: ControlPhaseSessionMechanism = (
+            ControlPhaseSessionMechanism(self._control_phase)
+        )
+        self._session_lifecycle: CoreRadioSessionLifecycle = CoreRadioSessionLifecycle(
+            self._session_mechanism,
+            max_connect_attempts=4,
+            # In-process SDK retry is immediate: the meaningful wait between
+            # attempts is the radio's own keepalive window, and the lifecycle
+            # already RELEASES the (partial) session before each retry, so no
+            # client-side cooldown sleep is needed here.  The within-attempt
+            # conninfo busy-retry pacing still lives in ``_connect_once``
+            # (``_STATUS_RETRY_PAUSE``).  The longer-lived Pro service constructs
+            # the lifecycle with the default 10/30 s cooldowns.
+            not_ready_cooldown_s=0.0,
+            reject_cooldown_s=0.0,
+        )
         self._audio_runtime: AudioRecoveryRuntime = AudioRecoveryRuntime(self)
 
     # Host shims for ControlPhaseRuntime and Icom7610SerialRadio (delegate to civ_runtime)
@@ -1176,10 +1203,13 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         ``radio_state`` while rigctld/web serve a stale frequency.
         """
         self._reset_external_cat_session()
-        await self._control_phase.connect()
+        await self._session_lifecycle.connect()
         await self._fetch_initial_state()
 
     async def __aenter__(self) -> "CoreRadio":
+        # Route through the lifecycle's guaranteed-release context manager so a
+        # failure between connect() and the body still releases the session
+        # (graceful-close Hole 2).  ``__aexit__`` always releases.
         await self.connect()
         return self
 
@@ -1187,8 +1217,19 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         await self.disconnect()
 
     async def disconnect(self) -> None:
-        """Cleanly disconnect from the radio."""
-        await self._control_phase.disconnect()
+        """Cleanly disconnect from the radio (always releases; idempotent).
+
+        Routes through the lifecycle (guaranteed-release policy).  If the radio
+        still reports a live session afterwards — i.e. the underlying
+        ``_conn_state`` was driven CONNECTED outside the lifecycle's own
+        connect() path (legacy/test injection, soft_disconnect bookkeeping) and
+        the lifecycle therefore treated disconnect() as an idempotent no-op —
+        fall back to the control-phase graceful teardown so a genuinely live
+        session is always released (graceful-close invariant).
+        """
+        await self._session_lifecycle.disconnect()
+        if self._conn_state == RadioConnectionState.CONNECTED:
+            await self._control_phase.disconnect()
 
     async def soft_disconnect(self) -> None:
         """Disconnect CI-V and audio but keep control transport alive.
@@ -1270,9 +1311,16 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
     async def soft_reconnect(self) -> None:
         """Reconnect CI-V transport using existing control session.
 
-        Delegates to the composed ControlPhaseRuntime.
+        Drives ONE recovery attempt via the lifecycle mechanism
+        (``soft_reconnect_once`` = control + token reused; raises on failure).
+        The CI-V data watchdog (``_civ_rx.py``) owns the outer multi-attempt
+        RECOVERING retry/backoff/exhaustion loop and calls this once per
+        attempt, so a single attempt that raises on failure (without releasing
+        the control session) preserves the watchdog's recovery contract.
+        Folding that orchestration into the lifecycle's stateful RECOVERING
+        state is a separate (Phase B) routing step.
         """
-        await self._control_phase.soft_reconnect()
+        await self._session_mechanism.soft_reconnect_once()
 
     async def _send_open_close(self, *, open_stream: bool) -> None:
         """Delegate to control-phase runtime (for soft_disconnect, _force_cleanup_civ, etc.)."""

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -883,6 +883,17 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             # the lifecycle with the default 10/30 s cooldowns.
             not_ready_cooldown_s=0.0,
             reject_cooldown_s=0.0,
+            # Recovery backoff is ZERO for the in-process CoreRadio (A4): the
+            # CI-V data watchdog already spends its patient OpenClose phase
+            # (~``_OPENCLOSE_DEADLINE`` = 60 s) BEFORE handing off to this
+            # RECOVERING loop, and ``soft_reconnect`` rebuilds the data path
+            # within one attempt.  A second 45/60 s lifecycle backoff per attempt
+            # would double-count that wait and stall the fast-recovery poller /
+            # direct ``soft_reconnect()`` callers.  The lifecycle still owns the
+            # attempt COUNT + exhaustion → CLOSING + release (single owner); only
+            # the inter-attempt sleep is collapsed.  The longer-lived Pro service
+            # constructs the lifecycle with the default ``_RECONNECT_BACKOFF``.
+            recovery_backoff_s=(0.0, 0.0, 0.0),
         )
         self._audio_runtime: AudioRecoveryRuntime = AudioRecoveryRuntime(self)
 
@@ -1309,18 +1320,24 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._civ_recovering = ctrl_alive
 
     async def soft_reconnect(self) -> None:
-        """Reconnect CI-V transport using existing control session.
+        """Reconnect CI-V transport using the existing control session.
 
-        Drives ONE recovery attempt via the lifecycle mechanism
-        (``soft_reconnect_once`` = control + token reused; raises on failure).
-        The CI-V data watchdog (``_civ_rx.py``) owns the outer multi-attempt
-        RECOVERING retry/backoff/exhaustion loop and calls this once per
-        attempt, so a single attempt that raises on failure (without releasing
-        the control session) preserves the watchdog's recovery contract.
-        Folding that orchestration into the lifecycle's stateful RECOVERING
-        state is a separate (Phase B) routing step.
+        Routes through the unified lifecycle RECOVERING loop
+        (:meth:`CoreRadioSessionLifecycle.soft_reconnect` →
+        :meth:`CoreRadioSessionLifecycle._run_recover`), which is now the SINGLE
+        owner of recovery policy: the per-attempt primitive
+        (``soft_reconnect_once`` = control + token reused; raises on failure),
+        the N-attempt count (``_MAX_RECONNECTS``), the backoff
+        (``_RECONNECT_BACKOFF``), and exhaustion → CLOSING + full release.
+
+        The CI-V data watchdog (``_civ_rx.py``) remains the stall DETECTOR: it
+        watches CI-V data flow, sends patient OpenClose nudges, and on patience
+        exhaustion TRIGGERS this method in a detached task — but it no longer
+        owns the retry/backoff/exhaustion ladder (that moved here). The
+        watchdog still unconditionally re-arms in ``finally`` so a later stall
+        is caught again (#1217).
         """
-        await self._session_mechanism.soft_reconnect_once()
+        await self._session_lifecycle.soft_reconnect()
 
     async def _send_open_close(self, *, open_stream: bool) -> None:
         """Delegate to control-phase runtime (for soft_disconnect, _force_cleanup_civ, etc.)."""

--- a/src/rigplane/runtime/session_lifecycle.py
+++ b/src/rigplane/runtime/session_lifecycle.py
@@ -46,10 +46,19 @@ Or from the submodule directly (tier-1 in-package path)::
 
 from __future__ import annotations
 
+import asyncio
+import logging
+import time
 from collections.abc import Callable
+from contextlib import suppress
 from dataclasses import dataclass
 from enum import Enum
 from typing import Protocol, runtime_checkable
+
+from rigplane.core.exceptions import (
+    AuthenticationError,
+    ConnectionError as RigplaneConnectionError,
+)
 
 __all__ = [
     "LifecycleErrorReason",
@@ -59,6 +68,8 @@ __all__ = [
     "RadioPresence",
     "RadioSessionLifecycle",
 ]
+
+_logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # 1. State and error taxonomy
@@ -553,3 +564,535 @@ class RadioSessionLifecycle(Protocol):
             ``None`` / ``False`` — does not suppress exceptions.
         """
         ...
+
+
+# ===========================================================================
+# 4. Concrete implementation (task A2 — NOT part of the frozen Tier-1 contract)
+# ===========================================================================
+#
+# Everything ABOVE this line is the frozen public-SDK contract (A2-api,
+# commit 76fa48ed); do not alter it.  Everything BELOW is the concrete
+# state-machine implementation introduced in task A2.  It is an internal
+# runtime detail — Pro consumes only the :class:`RadioSessionLifecycle`
+# Protocol and the rich types above, never these classes directly.
+#
+# Architecture: the lifecycle is the *policy* layer.  It drives a thin
+# *mechanism* (the packet I/O — :class:`~rigplane.runtime._control_phase.
+# ControlPhaseRuntime` in production, a fake in unit tests) via the
+# :class:`SessionMechanism` protocol below.  This is what makes the retry /
+# cooldown / recovery policy unit-testable without real sockets, and what lets
+# ``_control_phase`` be demoted to pure packet mechanism (the old retry wrapper
+# is re-expressed here as CONNECTING↔COOLDOWN state transitions).
+
+# Policy constants — this is now the ONLY home for the retry/cooldown timing
+# (they used to live on ``ControlPhaseRuntime``; A3 removes them there).
+_STATUS_RETRY_PAUSE = 10.0  # civ_port==0 (not ready) cooldown, seconds
+_STATUS_REJECT_COOLDOWN = 30.0  # 0xFFFFFFFF (busy reject) cooldown, seconds
+_MAX_RECONNECTS = 3  # soft-reconnect attempts before CLOSING
+_RECONNECT_BACKOFF: tuple[float, ...] = (45.0, 60.0, 60.0)
+# A bounded resident-retry cap so connect() cannot truly spin forever in a
+# pathological foreign-hold scenario while still being "resident" for the
+# normal transient window.  Generous because cooldown should almost never fire
+# after our own clean disconnect (D3).
+_MAX_CONNECT_ATTEMPTS = 1000
+
+
+class AttemptOutcome(Enum):
+    """Classification of a single :meth:`SessionMechanism.connect_attempt`.
+
+    This mirrors the radio's status response after a conninfo exchange:
+
+    * ``CONNECTED`` — auth succeeded and ``civ_port > 0``; the data path is up.
+    * ``SESSION_NOT_READY`` — auth succeeded but ``civ_port == 0`` (radio not
+      ready yet).  Transient → cooldown-aware resident retry (D3).
+    * ``SESSION_BUSY_REJECT`` — status ``error == 0xFFFFFFFF`` (previous session
+      still active).  Transient → cooldown-aware resident retry (D3).
+    * ``AUTH_CREDENTIALS`` — auth rejected with ``error == 0xFEFFFFFF``.  Hard,
+      non-transient failure → no retry (D3).
+    """
+
+    CONNECTED = "connected"
+    SESSION_NOT_READY = "session_not_ready"
+    SESSION_BUSY_REJECT = "session_busy_reject"
+    AUTH_CREDENTIALS = "auth_credentials"
+
+
+@dataclass(frozen=True)
+class AttemptResult:
+    """Result of one :meth:`SessionMechanism.connect_attempt`.
+
+    ``raises`` is a test/seam affordance: a mechanism may raise instead of
+    returning, but a fake mechanism can carry an exception to inject one *after*
+    the session has been claimed (proving Hole 1 release-on-exception).
+    """
+
+    outcome: AttemptOutcome
+    raises: BaseException | None = None
+
+
+@runtime_checkable
+class SessionMechanism(Protocol):
+    """The packet-I/O mechanism the lifecycle policy drives.
+
+    In production this is satisfied by an adapter over
+    :class:`~rigplane.runtime._control_phase.ControlPhaseRuntime` (wired by task
+    A3).  In unit tests it is a fake with queued outcomes.
+
+    Implementations MUST:
+
+    * register a release obligation the instant the session is *claimed* (auth
+      success), so that :meth:`release` discharges it even if
+      :meth:`connect_attempt` later raises;
+    * make :meth:`release` idempotent (safe to call when nothing is claimed).
+    """
+
+    async def connect_attempt(self) -> AttemptResult:
+        """Perform ONE connect attempt (auth + CI-V port).  No retry, no sleep."""
+        ...
+
+    async def release(self) -> None:
+        """Release the session: token-remove (0x01) + OpenClose-close + sockets.
+
+        Idempotent; a no-op when no session is claimed.
+        """
+        ...
+
+    async def soft_reconnect_once(self) -> None:
+        """Re-open the data path reusing the existing control + token.
+
+        Raises on failure; the policy layer counts attempts and decides when to
+        give up (→ CLOSING).
+        """
+        ...
+
+    async def scan(
+        self, targets: list[str] | None, *, timeout: float
+    ) -> list[RadioPresence]:
+        """Presence-probe only (AYT/IAH); never opens or holds a session."""
+        ...
+
+
+class CoreRadioSessionLifecycle:
+    """Concrete :class:`RadioSessionLifecycle` — the resident policy layer.
+
+    Owns the state machine, the observable surface (state/status/events), the
+    resident CONNECTING↔COOLDOWN runner, recovery attempt accounting, the
+    release obligation, and the SIGTERM graceful-close hook.  Drives a
+    :class:`SessionMechanism` for all packet I/O.
+
+    Not thread-safe; call from the event loop that owns it.
+    """
+
+    def __init__(
+        self,
+        mechanism: SessionMechanism,
+        *,
+        not_ready_cooldown_s: float = _STATUS_RETRY_PAUSE,
+        reject_cooldown_s: float = _STATUS_REJECT_COOLDOWN,
+        max_recovery_attempts: int = _MAX_RECONNECTS,
+        recovery_backoff_s: tuple[float, ...] = _RECONNECT_BACKOFF,
+        max_connect_attempts: int = _MAX_CONNECT_ATTEMPTS,
+    ) -> None:
+        self._mech = mechanism
+        self._not_ready_cooldown_s = not_ready_cooldown_s
+        self._reject_cooldown_s = reject_cooldown_s
+        self._max_recovery_attempts = max_recovery_attempts
+        self._recovery_backoff_s = recovery_backoff_s
+        self._max_connect_attempts = max_connect_attempts
+
+        self._state: LifecycleState = LifecycleState.DISCONNECTED
+        self._last_error: LifecycleErrorReason = LifecycleErrorReason.NONE
+        self._listeners: list[EventListener] = []
+
+        # Resident connect runner + coalescing.
+        self._connect_task: asyncio.Task[None] | None = None
+        self._recover_task: asyncio.Task[None] | None = None
+        # True once a session has been claimed (auth succeeded) and not yet
+        # released — drives idempotent disconnect.
+        self._claimed = False
+
+        # Progress/countdown bookkeeping for the status snapshot (D1).
+        self._cooldown_deadline: float | None = None
+        self._cooldown_total_s: float | None = None
+        self._connecting_started: float | None = None
+        self._recovery_attempt: int | None = None
+
+    # ------------------------------------------------------------------
+    # Observable surface
+    # ------------------------------------------------------------------
+
+    @property
+    def state(self) -> LifecycleState:
+        return self._state
+
+    @property
+    def status(self) -> LifecycleStatus:
+        now = time.monotonic()
+        cooldown_remaining: float | None = None
+        if (
+            self._state is LifecycleState.COOLDOWN
+            and self._cooldown_deadline is not None
+        ):
+            cooldown_remaining = max(0.0, self._cooldown_deadline - now)
+        connecting_elapsed: float | None = None
+        if (
+            self._state is LifecycleState.CONNECTING
+            and self._connecting_started is not None
+        ):
+            connecting_elapsed = max(0.0, now - self._connecting_started)
+        recovery_attempt = (
+            self._recovery_attempt if self._state is LifecycleState.RECOVERING else None
+        )
+        recovery_max = (
+            self._max_recovery_attempts
+            if self._state is LifecycleState.RECOVERING
+            else None
+        )
+        return LifecycleStatus(
+            state=self._state,
+            last_error=self._last_error,
+            cooldown_remaining_s=cooldown_remaining,
+            cooldown_total_s=(
+                self._cooldown_total_s
+                if self._state is LifecycleState.COOLDOWN
+                else None
+            ),
+            recovery_attempt=recovery_attempt,
+            recovery_max=recovery_max,
+            connecting_elapsed_s=connecting_elapsed,
+        )
+
+    # ------------------------------------------------------------------
+    # Event subscription
+    # ------------------------------------------------------------------
+
+    def add_event_listener(self, listener: EventListener) -> None:
+        if listener not in self._listeners:
+            self._listeners.append(listener)
+
+    def remove_event_listener(self, listener: EventListener) -> None:
+        with suppress(ValueError):
+            self._listeners.remove(listener)
+
+    def _emit(
+        self,
+        to_state: LifecycleState,
+        *,
+        reason: LifecycleErrorReason = LifecycleErrorReason.NONE,
+        cooldown_remaining_s: float | None = None,
+        recovery_attempt: int | None = None,
+        recovery_max: int | None = None,
+    ) -> None:
+        from_state = self._state
+        self._state = to_state
+        if reason is not LifecycleErrorReason.NONE:
+            self._last_error = reason
+        event = LifecycleEvent(
+            from_state=from_state,
+            to_state=to_state,
+            reason=reason,
+            cooldown_remaining_s=cooldown_remaining_s,
+            recovery_attempt=recovery_attempt,
+            recovery_max=recovery_max,
+        )
+        for listener in list(self._listeners):
+            try:
+                listener(event)
+            except Exception:  # noqa: BLE001 — listeners must never abort us
+                _logger.debug(
+                    "lifecycle.listener.error", exc_info=True, extra={"event": event}
+                )
+
+    # ------------------------------------------------------------------
+    # connect() — resident, cooldown-aware
+    # ------------------------------------------------------------------
+
+    async def connect(self) -> None:
+        # T9: coalesce a concurrent/duplicate connect onto the in-flight one.
+        if self._connect_task is not None and not self._connect_task.done():
+            await self._connect_task
+            return
+        if self._state is LifecycleState.CONNECTED:
+            return
+        self._connect_task = asyncio.ensure_future(self._run_connect())
+        try:
+            await self._connect_task
+        finally:
+            if self._connect_task is not None and self._connect_task.done():
+                self._connect_task = None
+
+    async def _run_connect(self) -> None:
+        """Resident CONNECTING↔COOLDOWN loop; release before every cooldown wait."""
+        try:
+            await self._connect_loop()
+        except asyncio.CancelledError:
+            # Cancellation (disconnect/SIGTERM during CONNECTING/COOLDOWN): the
+            # release already ran in ``_attempt_with_release``/teardown; just
+            # propagate so the awaiter sees the cancel.
+            raise
+        except (AuthenticationError, RigplaneConnectionError):
+            # Hard-fail / exhaustion paths already drove the machine to
+            # DISCONNECTED; just re-raise.
+            raise
+        except BaseException:
+            # Any other post-claim exception: release ran inside
+            # ``_attempt_with_release``; drive the observable machine home.
+            self._connecting_started = None
+            if self._state not in (
+                LifecycleState.CLOSING,
+                LifecycleState.DISCONNECTED,
+            ):
+                self._emit(
+                    LifecycleState.CLOSING, reason=LifecycleErrorReason.CANCELLED
+                )
+                self._emit(LifecycleState.DISCONNECTED)
+            raise
+
+    async def _connect_loop(self) -> None:
+        attempt = 0
+        while True:
+            attempt += 1
+            self._connecting_started = time.monotonic()
+            self._emit(LifecycleState.CONNECTING)
+            outcome = await self._attempt_with_release()
+
+            if outcome is AttemptOutcome.CONNECTED:
+                self._connecting_started = None
+                self._emit(LifecycleState.CONNECTED)
+                return
+
+            if outcome is AttemptOutcome.AUTH_CREDENTIALS:
+                # D3 hard-fail: NO resident retry.  Release (idempotent) +
+                # CLOSING + raise.
+                self._connecting_started = None
+                await self._mech.release()
+                self._claimed = False
+                self._emit(
+                    LifecycleState.CLOSING,
+                    reason=LifecycleErrorReason.AUTH_CREDENTIALS,
+                )
+                self._emit(LifecycleState.DISCONNECTED)
+                raise AuthenticationError(
+                    "Authentication failed (error=0xFEFFFFFF); credentials rejected"
+                )
+
+            # Transient: SESSION_NOT_READY (civ_port==0) or SESSION_BUSY_REJECT
+            # (0xFFFFFFFF).  The session was already released inside
+            # ``_attempt_with_release`` (release BEFORE the wait — Hole 4 / Cause
+            # A inversion).  Now enter COOLDOWN and wait in-process.
+            if attempt >= self._max_connect_attempts:
+                self._connecting_started = None
+                self._emit(LifecycleState.DISCONNECTED)
+                raise RigplaneConnectionError(
+                    "Radio session never became ready after "
+                    f"{attempt} resident attempts; a foreign client may hold it."
+                )
+
+            if outcome is AttemptOutcome.SESSION_BUSY_REJECT:
+                reason = LifecycleErrorReason.SESSION_BUSY_REJECT
+                cooldown = self._reject_cooldown_s
+            else:
+                reason = LifecycleErrorReason.SESSION_NOT_READY
+                cooldown = self._not_ready_cooldown_s
+
+            self._connecting_started = None
+            self._cooldown_total_s = cooldown
+            self._cooldown_deadline = time.monotonic() + cooldown
+            self._emit(
+                LifecycleState.COOLDOWN,
+                reason=reason,
+                cooldown_remaining_s=cooldown,
+            )
+            try:
+                await asyncio.sleep(cooldown)
+            finally:
+                self._cooldown_deadline = None
+                self._cooldown_total_s = None
+            # loop → CONNECTING again, inside the same resident process.
+
+    async def _attempt_with_release(self) -> AttemptOutcome:
+        """One connect attempt; on any non-CONNECTED outcome RELEASE first.
+
+        Guarantees the release obligation is discharged before we leave this
+        coroutine on a transient outcome OR on an exception (Holes 1/5/8) —
+        BEFORE any cooldown wait happens (Hole 4 / Cause A).
+        """
+        try:
+            result = await self._mech.connect_attempt()
+        except BaseException:
+            # Post-auth/pre-CONNECTED exception (or cancellation): release the
+            # (possibly partial) claim, then re-raise.  ``release`` is idempotent
+            # so this is safe even if nothing was claimed.
+            await self._mech.release()
+            self._claimed = False
+            raise
+
+        if result.outcome is AttemptOutcome.CONNECTED:
+            self._claimed = True
+            return AttemptOutcome.CONNECTED
+
+        if result.outcome is AttemptOutcome.AUTH_CREDENTIALS:
+            # Pre-claim hard failure — release defensively (no-op) and report.
+            await self._mech.release()
+            self._claimed = False
+            return AttemptOutcome.AUTH_CREDENTIALS
+
+        # Transient: civ_port==0 or 0xFFFFFFFF.  Auth DID succeed, so a session
+        # is claimed — RELEASE it now, before the caller enters the cooldown
+        # wait.  This is the structural inversion of the old held-cooldown bug.
+        await self._mech.release()
+        self._claimed = False
+        return result.outcome
+
+    # ------------------------------------------------------------------
+    # disconnect() — always releases (idempotent)
+    # ------------------------------------------------------------------
+
+    async def disconnect(self) -> None:
+        await self._teardown(reason=LifecycleErrorReason.CANCELLED, shutdown=False)
+
+    async def request_shutdown(self) -> None:
+        """SIGTERM-style graceful close: release the session BEFORE process exit.
+
+        This is the awaitable hook the CLI signal handler MUST call instead of
+        ``os._exit`` (design §2.6 / Hole 3).  It cancels any resident runner or
+        cooldown wait, runs the full release, and ends in DISCONNECTED.
+
+        CLI wiring (A3/Phase B follow-up, outside this task's files): install an
+        asyncio SIGTERM handler that schedules ``await lifecycle.request_shutdown()``
+        on the running loop, with a bounded ~2-3 s deadline (D2), then stops the
+        loop and exits 0.  Do NOT call ``os._exit`` before this awaitable
+        completes.
+        """
+        await self._teardown(reason=LifecycleErrorReason.CANCELLED, shutdown=True)
+
+    async def _teardown(self, *, reason: LifecycleErrorReason, shutdown: bool) -> None:
+        # Cancel any in-flight resident runner / recovery task first so their
+        # own ``finally`` release does not race ours.
+        for task_attr in ("_connect_task", "_recover_task"):
+            task = getattr(self, task_attr)
+            if task is not None and not task.done():
+                task.cancel()
+                with suppress(asyncio.CancelledError, Exception):
+                    await task
+            setattr(self, task_attr, None)
+
+        if self._state is LifecycleState.DISCONNECTED and not self._claimed:
+            # Idempotent no-op: nothing claimed, nothing to release.
+            return
+
+        self._emit(LifecycleState.CLOSING, reason=reason)
+        try:
+            await self._mech.release()
+        except Exception:  # noqa: BLE001 — release must not raise out of teardown
+            _logger.debug("lifecycle.release.error", exc_info=True)
+        finally:
+            self._claimed = False
+            self._cooldown_deadline = None
+            self._cooldown_total_s = None
+            self._connecting_started = None
+            self._recovery_attempt = None
+            self._emit(LifecycleState.DISCONNECTED)
+
+    # ------------------------------------------------------------------
+    # soft_reconnect() — CONNECTED → RECOVERING → CONNECTED (#1217)
+    # ------------------------------------------------------------------
+
+    async def soft_reconnect(self) -> None:
+        # Coalesce concurrent recovery onto the in-flight one.
+        if self._recover_task is not None and not self._recover_task.done():
+            await self._recover_task
+            return
+        self._recover_task = asyncio.ensure_future(self._run_recover())
+        try:
+            await self._recover_task
+        finally:
+            if self._recover_task is not None and self._recover_task.done():
+                self._recover_task = None
+
+    async def _run_recover(self) -> None:
+        last_exc: BaseException | None = None
+        for attempt in range(1, self._max_recovery_attempts + 1):
+            self._recovery_attempt = attempt
+            self._emit(
+                LifecycleState.RECOVERING,
+                reason=LifecycleErrorReason.DATA_WATCHDOG_STALL,
+                recovery_attempt=attempt,
+                recovery_max=self._max_recovery_attempts,
+            )
+            if attempt > 1:
+                backoff = self._recovery_backoff_s[
+                    min(attempt - 2, len(self._recovery_backoff_s) - 1)
+                ]
+                await asyncio.sleep(backoff)
+            try:
+                await self._mech.soft_reconnect_once()
+            except Exception as exc:  # noqa: BLE001 — count + retry/exhaust
+                last_exc = exc
+                _logger.warning(
+                    "lifecycle.soft_reconnect.attempt_failed",
+                    extra={"attempt": attempt, "max": self._max_recovery_attempts},
+                )
+                continue
+            else:
+                self._recovery_attempt = None
+                self._emit(LifecycleState.CONNECTED)
+                return
+
+        # Exhausted: route through CLOSING with full release (T11).
+        self._recovery_attempt = None
+        self._emit(
+            LifecycleState.CLOSING,
+            reason=LifecycleErrorReason.RECOVERY_EXHAUSTED,
+        )
+        with suppress(Exception):
+            await self._mech.release()
+        self._claimed = False
+        self._emit(LifecycleState.DISCONNECTED)
+        raise RigplaneConnectionError(
+            f"Soft reconnect exhausted after {self._max_recovery_attempts} attempts"
+        ) from last_exc
+
+    # ------------------------------------------------------------------
+    # scan() — presence-probe only; no session
+    # ------------------------------------------------------------------
+
+    async def scan(
+        self,
+        targets: list[str] | None = None,
+        *,
+        timeout: float = 3.0,
+    ) -> list[RadioPresence]:
+        # Scan is fire-and-forget w.r.t. the session: if we are connected we do
+        # NOT change the observable session state, we just probe.  If idle, we
+        # surface a SCANNING → DISCONNECTED blip for the UI.
+        was_connected = self._state is LifecycleState.CONNECTED
+        if not was_connected:
+            self._emit(LifecycleState.SCANNING)
+        try:
+            return await self._mech.scan(targets, timeout=timeout)
+        finally:
+            if not was_connected:
+                self._emit(LifecycleState.DISCONNECTED)
+
+    # ------------------------------------------------------------------
+    # Async context manager
+    # ------------------------------------------------------------------
+
+    async def __aenter__(self) -> "CoreRadioSessionLifecycle":
+        try:
+            await self.connect()
+        except BaseException:
+            # Hole 2: __aenter__ failure must still release any partial claim.
+            await self.disconnect()
+            raise
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: object,
+    ) -> bool | None:
+        await self.disconnect()
+        return None

--- a/src/rigplane/runtime/session_lifecycle.py
+++ b/src/rigplane/runtime/session_lifecycle.py
@@ -1,0 +1,555 @@
+"""Public SDK surface for the radio session lifecycle (contract-grade).
+
+This module defines the **stable, contract-grade public API** for the unified
+radio session lifecycle introduced to solve the livelock root cause described in
+``docs/architecture/2026-06-22-radio-session-lifecycle.md``.
+
+The module is divided into three sections:
+
+1. **State and error taxonomy** – :class:`LifecycleState` (7-state enum) and
+   :class:`LifecycleErrorReason` (cause codes for transitions to CLOSING or
+   COOLDOWN).
+2. **Rich observable types** (D1) – :class:`LifecycleEvent` (structured
+   per-transition event) and :class:`LifecycleStatus` (point-in-time snapshot
+   with progress/countdown for UI rendering).
+3. **Controller interface** – :class:`RadioSessionLifecycle` (the resident
+   policy layer; method signatures only, no state-machine implementation).
+
+Stability contract (D6 — Tier 1, semver-stable)
+------------------------------------------------
+Every public symbol in this module is a **long-term contract** across the
+``rigplane-core`` / ``rigplane-pro`` version boundary.  Changes MUST be
+additive-only and versioned per
+``rigplane-pro/docs/contracts/COMPATIBILITY.md`` (MOR-885).
+
+* **Do not add provisional symbols here without the ``_PROVISIONAL`` note.**
+* To add a field to a :func:`~dataclasses.dataclass`, use
+  ``field(default=…)`` so existing callers do not break.
+* To add a state or error-reason enum member, add it and document the version
+  in which it appeared.
+
+Canonical import
+----------------
+>>> from rigplane import RadioSessionLifecycle, LifecycleState, LifecycleStatus, LifecycleEvent
+
+Or from the submodule directly (tier-1 in-package path)::
+
+    from rigplane.runtime.session_lifecycle import (
+        RadioSessionLifecycle,
+        LifecycleState,
+        LifecycleStatus,
+        LifecycleEvent,
+        LifecycleErrorReason,
+        RadioPresence,
+    )
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import Enum
+from typing import Protocol, runtime_checkable
+
+__all__ = [
+    "LifecycleErrorReason",
+    "LifecycleEvent",
+    "LifecycleState",
+    "LifecycleStatus",
+    "RadioPresence",
+    "RadioSessionLifecycle",
+]
+
+# ---------------------------------------------------------------------------
+# 1. State and error taxonomy
+# ---------------------------------------------------------------------------
+
+
+class LifecycleState(str, Enum):
+    """The seven canonical states of a :class:`RadioSessionLifecycle`.
+
+    The string value of each member is stable and may be serialised (e.g. to
+    JSON for the UI).
+
+    Transition diagram (§2.2 of the design doc)::
+
+                  scan()                   connect()
+        DISCONNECTED ──► SCANNING ──► DISCONNECTED
+             │
+             │ connect()
+             ▼
+         CONNECTING ──auth+civ_port>0──► CONNECTED
+             │  │                           │
+             │  │ civ_port==0 /             │ data stall / ctrl loss
+             │  │ 0xFFFFFFFF reject         ▼
+             │  ▼                        RECOVERING ──ok──► CONNECTED
+             │  COOLDOWN ──wait──► CONNECTING   │ fail (max)
+             │  (same process; token NOT held)  ▼
+             │                               CLOSING
+             └── disconnect() / SIGTERM ──► CLOSING ──► DISCONNECTED
+
+    Version history:
+
+    * ``v2.11`` — initial introduction.
+    """
+
+    DISCONNECTED = "disconnected"
+    """No session exists; idle.  The lifecycle is ready to call :meth:`connect`."""
+
+    SCANNING = "scanning"
+    """A :meth:`scan` call is in progress (AYT broadcast, no session held)."""
+
+    CONNECTING = "connecting"
+    """A session establishment attempt is in progress (auth + CI-V port wait)."""
+
+    COOLDOWN = "cooldown"
+    """
+    A previous attempt's session has been released and the lifecycle is waiting
+    before the next retry.  The radio's keepalive window must expire before we
+    re-claim the port.
+
+    In normal operation (graceful disconnect) this state should almost never
+    appear.  A cooldown following our *own* clean disconnect indicates a bug in
+    the release path.  Cooldown is expected only when a **foreign** client holds
+    the radio.
+    """
+
+    CONNECTED = "connected"
+    """Session established; transports open; CI-V pump running."""
+
+    RECOVERING = "recovering"
+    """
+    Data stall or control loss detected; soft-reconnect in progress.
+    The existing token is reused (no new login).  If recovery exhausts
+    :data:`_MAX_RECONNECTS` attempts the lifecycle transitions to CLOSING.
+    """
+
+    CLOSING = "closing"
+    """
+    Teardown in progress: token-remove + OpenClose-close + socket release.
+    This state is transient; the lifecycle always ends in DISCONNECTED.
+    """
+
+
+class LifecycleErrorReason(str, Enum):
+    """Structured cause codes carried by :class:`LifecycleEvent` and
+    :class:`LifecycleStatus`.
+
+    The string value is stable and may be serialised.
+
+    Version history:
+
+    * ``v2.11`` — initial introduction.
+    """
+
+    NONE = "none"
+    """No error; used when a transition is not caused by a failure."""
+
+    AUTH_CREDENTIALS = "auth_credentials"
+    """
+    Authentication rejected with error ``0xFEFFFFFF`` — credentials are wrong.
+    This is a **hard failure** (D3): the lifecycle transitions to CLOSING and
+    does NOT retry.
+    """
+
+    SESSION_BUSY_REJECT = "session_busy_reject"
+    """
+    The radio returned ``error=0xFFFFFFFF`` (previous session still active).
+    A cooldown-aware resident retry follows (D3).
+    """
+
+    SESSION_NOT_READY = "session_not_ready"
+    """
+    The radio returned ``civ_port=0`` (port not yet allocated, radio not
+    ready).  A cooldown-aware resident retry follows (D3).
+    """
+
+    DATA_WATCHDOG_STALL = "data_watchdog_stall"
+    """
+    The CI-V data watchdog detected a stall (no frames within the timeout
+    window).  Triggers a transition from CONNECTED to RECOVERING.
+    """
+
+    CONTROL_LOSS = "control_loss"
+    """
+    The control-channel connection was lost.  Triggers CONNECTED → RECOVERING.
+    """
+
+    RECOVERY_EXHAUSTED = "recovery_exhausted"
+    """
+    :data:`_MAX_RECONNECTS` soft-reconnect attempts all failed.
+    Transitions from RECOVERING to CLOSING.
+    """
+
+    CANCELLED = "cancelled"
+    """
+    The lifecycle was cancelled (e.g. ``disconnect()`` called or SIGTERM
+    received) during CONNECTING, COOLDOWN, or RECOVERING.
+    """
+
+
+# ---------------------------------------------------------------------------
+# 2. Rich observable types (D1 — first-class requirement)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RadioPresence:
+    """Result of a single :meth:`RadioSessionLifecycle.scan` response.
+
+    Attributes:
+        host:      IPv4 address of the responding radio.
+        remote_id: The radio's 32-bit network identity (from the IAH packet).
+
+    Version history:
+
+    * ``v2.11`` — initial introduction.
+    """
+
+    host: str
+    remote_id: int
+
+
+@dataclass(frozen=True)
+class LifecycleEvent:
+    """A single structured state-transition event emitted by the lifecycle.
+
+    Emitted on **every** state transition; consumed by the observable
+    callback registered via :meth:`RadioSessionLifecycle.add_event_listener`.
+
+    Design note (D1): the event stream is first-class — observers should not
+    poll :attr:`RadioSessionLifecycle.status`; events are the authoritative
+    notification surface.
+
+    Attributes:
+        from_state:      State before the transition.
+        to_state:        State after the transition.
+        reason:          Structured cause code for the transition.
+        cooldown_remaining_s:
+            For transitions **into** :attr:`LifecycleState.COOLDOWN`:
+            estimated seconds until the next connection attempt.
+            ``None`` for all other transitions.
+        recovery_attempt:
+            For transitions **into** :attr:`LifecycleState.RECOVERING`:
+            current attempt number (1-based).  ``None`` for other transitions.
+        recovery_max:
+            The maximum number of recovery attempts for the current session
+            (``_MAX_RECONNECTS``).  ``None`` when ``recovery_attempt`` is
+            ``None``.
+
+    Version history:
+
+    * ``v2.11`` — initial introduction.
+    """
+
+    from_state: LifecycleState
+    to_state: LifecycleState
+    reason: LifecycleErrorReason = LifecycleErrorReason.NONE
+    cooldown_remaining_s: float | None = None
+    recovery_attempt: int | None = None
+    recovery_max: int | None = None
+
+
+@dataclass(frozen=True)
+class LifecycleStatus:
+    """Point-in-time snapshot of the lifecycle state for UI rendering.
+
+    Retrieved via :attr:`RadioSessionLifecycle.status`.  This snapshot is
+    immutable; subscribe to events via
+    :meth:`RadioSessionLifecycle.add_event_listener` for change notifications.
+
+    Attributes:
+        state:
+            Current :class:`LifecycleState`.
+        last_error:
+            Most recent error reason, or :attr:`LifecycleErrorReason.NONE`.
+        cooldown_remaining_s:
+            Seconds remaining in the current cooldown wait (COOLDOWN state
+            only).  ``None`` when not in COOLDOWN.
+        cooldown_total_s:
+            Total duration of the current cooldown window (COOLDOWN state
+            only).  Allows rendering a progress bar.  ``None`` when not in
+            COOLDOWN.
+        recovery_attempt:
+            Current soft-reconnect attempt number (1-based) when in RECOVERING.
+            ``None`` otherwise.
+        recovery_max:
+            Maximum soft-reconnect attempts (``_MAX_RECONNECTS``) when in
+            RECOVERING.  ``None`` otherwise.
+        connecting_elapsed_s:
+            Seconds elapsed since the current CONNECTING attempt began.  ``None``
+            when not in CONNECTING.
+
+    Version history:
+
+    * ``v2.11`` — initial introduction.
+    """
+
+    state: LifecycleState
+    last_error: LifecycleErrorReason = LifecycleErrorReason.NONE
+    cooldown_remaining_s: float | None = None
+    cooldown_total_s: float | None = None
+    recovery_attempt: int | None = None
+    recovery_max: int | None = None
+    connecting_elapsed_s: float | None = None
+
+
+# ---------------------------------------------------------------------------
+# 3. Controller interface
+# ---------------------------------------------------------------------------
+
+#: Callback type for :meth:`RadioSessionLifecycle.add_event_listener`.
+#:
+#: A listener receives each :class:`LifecycleEvent` synchronously on the
+#: event loop that drives the lifecycle.  Listeners MUST be cheap (no
+#: blocking I/O); schedule expensive work with ``asyncio.create_task``.
+#: Exceptions raised by a listener are logged and swallowed — they do NOT
+#: abort the lifecycle.
+EventListener = Callable[["LifecycleEvent"], None]
+
+
+@runtime_checkable
+class RadioSessionLifecycle(Protocol):
+    """Protocol / interface for the resident radio session lifecycle controller.
+
+    This is the **only** public lifecycle entry point.  All
+    connect / disconnect / scan / recover intelligence lives here.
+
+    Governing invariant
+    -------------------
+    A graceful ``connect()`` followed by a graceful ``disconnect()`` MUST NOT
+    cause a cooldown.  Cooldown means the session was torn down *non-gracefully*
+    (i.e. a foreign client held it).  Every exit path — normal, exceptional, or
+    SIGTERM — MUST release the session (token-remove + OpenClose-close) before
+    the socket or process goes away.
+
+    Concurrency
+    -----------
+    The lifecycle is async-native.  All public methods are coroutines and MUST
+    be awaited.  The lifecycle is NOT thread-safe; call it from the event loop
+    that owns it.
+
+    Context-manager usage
+    ---------------------
+    The lifecycle implements the async context-manager protocol.  ``__aexit__``
+    *always* calls :meth:`disconnect` — even if ``__aenter__`` raised::
+
+        async with lifecycle:
+            # session established
+            ...
+        # session released
+
+    Observable state
+    ----------------
+    Poll :attr:`status` for the current snapshot, or register a listener via
+    :meth:`add_event_listener` for push notification.
+
+    Stability
+    ---------
+    Tier 1, semver-stable (D6, v2.11+).  Breaking changes require a major
+    version bump and a coordinated core ↔ Pro cadence per
+    ``rigplane-pro/docs/contracts/COMPATIBILITY.md`` (MOR-885).
+
+    Version history:
+
+    * ``v2.11`` — initial introduction.
+    """
+
+    # ------------------------------------------------------------------
+    # Observable state
+    # ------------------------------------------------------------------
+
+    @property
+    def state(self) -> LifecycleState:
+        """Current lifecycle state (observable, real-time).
+
+        Returns:
+            The current :class:`LifecycleState` of this lifecycle instance.
+
+        .. note::
+            For change notifications, prefer :meth:`add_event_listener` over
+            polling this property.
+        """
+        ...
+
+    @property
+    def status(self) -> LifecycleStatus:
+        """Rich point-in-time snapshot including progress and countdown fields.
+
+        Suitable for rendering a UI status bar or tooltip.  Fields specific to
+        the current state (``cooldown_remaining_s``, ``recovery_attempt``, etc.)
+        are populated only when the lifecycle is in the relevant state.
+
+        Returns:
+            An immutable :class:`LifecycleStatus` snapshot.
+        """
+        ...
+
+    # ------------------------------------------------------------------
+    # Event subscription
+    # ------------------------------------------------------------------
+
+    def add_event_listener(
+        self,
+        listener: Callable[[LifecycleEvent], None],
+    ) -> None:
+        """Register a callback to receive every :class:`LifecycleEvent`.
+
+        The listener is called synchronously on the event loop for each state
+        transition.  It MUST NOT block or raise; exceptions are logged and
+        swallowed.  Duplicate registrations are ignored (idempotent).
+
+        Args:
+            listener: A callable accepting a single :class:`LifecycleEvent`.
+        """
+        ...
+
+    def remove_event_listener(
+        self,
+        listener: Callable[[LifecycleEvent], None],
+    ) -> None:
+        """Deregister a previously registered event listener.
+
+        No-op if *listener* was never registered.
+
+        Args:
+            listener: The callable to remove.
+        """
+        ...
+
+    # ------------------------------------------------------------------
+    # Lifecycle operations
+    # ------------------------------------------------------------------
+
+    async def scan(
+        self,
+        targets: list[str] | None = None,
+        *,
+        timeout: float = 3.0,
+    ) -> list[RadioPresence]:
+        """Probe the LAN for responding radios (presence only; NO session opened).
+
+        Sends AYT broadcasts and collects IAH responses.  ``scan()`` MUST NOT
+        send login / token / conninfo / OpenClose packets and MUST NOT hold a
+        session.  Calling ``scan()`` while a session is active is safe — it
+        does not disturb the active session.
+
+        The lifecycle transitions DISCONNECTED → SCANNING → DISCONNECTED around
+        this call (or stays CONNECTED → (scan is fire-and-forget) → CONNECTED
+        when already connected — exact in-session behaviour is implementation
+        detail).
+
+        Args:
+            targets:
+                Optional list of specific IP addresses to probe.  When
+                ``None`` the implementation broadcasts to the default
+                discovery address (``255.255.255.255:50001``).
+            timeout:
+                Seconds to wait for responses before returning.
+
+        Returns:
+            List of :class:`RadioPresence` records, one per responding radio.
+            May be empty if no radios respond within *timeout*.
+        """
+        ...
+
+    async def connect(self) -> None:
+        """Establish a session; resident until connected or cancelled.
+
+        This method is **resident**: it performs cooldown-aware retry entirely
+        in-process.  It returns only when:
+
+        * the session reaches CONNECTED state; or
+        * the caller cancels the task (``asyncio.CancelledError``); or
+        * a hard, non-transient failure occurs (``LifecycleErrorReason.AUTH_CREDENTIALS``).
+
+        On transient failure (``civ_port==0`` / ``0xFFFFFFFF``):
+
+        * the current partial session is **released** (token-remove +
+          OpenClose-close) before entering COOLDOWN;
+        * the lifecycle waits in-process until the cooldown window expires;
+        * then retries CONNECTING — without ever leaving the process.
+
+        This design guarantees that the radio's keepalive window expires before
+        the port is re-claimed (Cause B fix).
+
+        Raises:
+            rigplane.exceptions.AuthenticationError:
+                When credentials are rejected (``0xFEFFFFFF``, D3 hard-fail).
+            asyncio.CancelledError:
+                When the task is cancelled (e.g. ``disconnect()`` called
+                concurrently or SIGTERM received).
+
+        .. warning::
+            Calling ``connect()`` when already CONNECTED or CONNECTING is
+            coalesced / idempotent (T9) — the existing attempt is reused; a
+            second connect does NOT claim a second session.
+        """
+        ...
+
+    async def disconnect(self) -> None:
+        """Release the session gracefully and transition to DISCONNECTED.
+
+        Sends token-remove + OpenClose-close + closes the socket regardless of
+        the current state.  **Idempotent**: calling on an unclaimed or already-
+        disconnected lifecycle is a no-op.
+
+        If called during CONNECTING or COOLDOWN, the resident runner is
+        cancelled and the lifecycle transitions CLOSING → DISCONNECTED.
+
+        After this method returns, the lifecycle is in DISCONNECTED and the
+        radio's ownership lock is released.
+        """
+        ...
+
+    async def soft_reconnect(self) -> None:
+        """Attempt to recover the data path while reusing the existing session.
+
+        Transitions CONNECTED → RECOVERING and re-opens only the data channel
+        (no new login; the existing token and control connection are reused).
+        On success, transitions back to CONNECTED and re-arms the data watchdog.
+
+        This method is normally driven internally by the data watchdog.  External
+        callers may invoke it to trigger an immediate recovery attempt.
+
+        Raises:
+            rigplane.exceptions.ConnectionError:
+                When recovery exhausts all attempts (``_MAX_RECONNECTS``).  The
+                lifecycle transitions to CLOSING and releases the session.
+            asyncio.CancelledError:
+                When cancelled during recovery.
+
+        .. note::
+            Concurrent calls while RECOVERING are coalesced — the second caller
+            awaits the ongoing recovery attempt.
+        """
+        ...
+
+    # ------------------------------------------------------------------
+    # Async context manager
+    # ------------------------------------------------------------------
+
+    async def __aenter__(self) -> RadioSessionLifecycle:
+        """Enter context: calls :meth:`connect` and returns *self*.
+
+        If ``connect()`` raises, ``__aexit__`` is still called to release any
+        partial session (Hole 2 fix).
+
+        Returns:
+            *self* for use in ``as`` clauses.
+        """
+        ...
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: object,
+    ) -> bool | None:
+        """Exit context: **always** calls :meth:`disconnect` regardless of
+        whether an exception was raised.
+
+        Returns:
+            ``None`` / ``False`` — does not suppress exceptions.
+        """
+        ...

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -156,6 +156,51 @@ async def mock_radio() -> AsyncGenerator[MockIcomRadio]:
     await server.stop()
 
 
+# Accelerated keepalive hold for the fast suite (D7). Real radios hold the
+# session for ~40-60 s after a non-graceful drop; the fast tests use ~0.5 s so a
+# silently-dropped session frees quickly without a wall-clock wait. The one
+# near-real timing test passes ~45-60 s explicitly.
+FAST_KEEPALIVE_HOLD_S = 0.5
+
+
+@pytest.fixture
+async def single_owner_radio() -> AsyncGenerator[MockIcomRadio]:
+    """A mock IC-7610 that enforces single-owner session semantics.
+
+    Models the real radio's network CI-V lifecycle: it holds ONE owning session
+    (keyed by ``(remote_addr, control my_id)``), rejects a foreign conninfo while
+    held with ``civ_port=0`` + ``error=0xFFFFFFFF`` (previous-session-active),
+    frees immediately on token-remove / OpenClose(close), and otherwise
+    auto-releases after the accelerated ``keepalive_hold_s`` window.
+    """
+    server = MockIcomRadio(
+        single_owner=True,
+        keepalive_hold_s=FAST_KEEPALIVE_HOLD_S,
+    )
+    await server.start()
+    yield server
+    await server.stop()
+
+
+@pytest.fixture
+async def unsolicited_radio() -> AsyncGenerator[MockIcomRadio]:
+    """A mock IC-7610 that streams unsolicited CI-V frames on its own cadence.
+
+    Exercises the CI-V pump and the data-flow watchdog: the radio evolves its
+    frequency state and emits transceive-style frames every
+    ``unsolicited_interval_s``. Use ``stall_for(...)`` to starve the stream.
+    """
+    server = MockIcomRadio(
+        single_owner=True,
+        keepalive_hold_s=FAST_KEEPALIVE_HOLD_S,
+        unsolicited_civ=True,
+        unsolicited_interval_s=0.05,
+    )
+    await server.start()
+    yield server
+    await server.stop()
+
+
 @pytest.fixture
 async def connected_radio(mock_radio: MockIcomRadio) -> AsyncGenerator[IcomRadio]:
     """An IcomRadio that has already completed the connect() handshake."""

--- a/tests/mock_server.py
+++ b/tests/mock_server.py
@@ -18,9 +18,30 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import random
 import struct
+import time
 
 logger = logging.getLogger(__name__)
+
+# Error codes carried in the status / login response at offset 0x30 (little-endian).
+_ERR_OK = 0x00000000
+_ERR_AUTH_FAIL = 0xFEFFFFFF  # credential failure (login)
+_ERR_PREV_SESSION_ACTIVE = 0xFFFFFFFF  # busy / previous session still held
+
+# Token request-type magics carried at pkt[0x15] of a 0x40-byte control packet.
+_TOKEN_REMOVE = 0x01  # graceful withdraw — frees the held session immediately
+_TOKEN_ACK = 0x02  # initial token acknowledgement
+_TOKEN_RENEW = 0x05  # keepalive renewal
+
+# OpenClose magics carried at pkt[0x15] of a 0x16-byte CI-V packet.
+_OPENCLOSE_CLOSE = 0x00  # graceful data-port close — frees the held session
+_OPENCLOSE_OPEN = 0x04
+
+# Default accelerated keepalive hold (D7). Real radios hold ~40-60 s; the fast
+# suite uses ~0.5 s so a dropped session frees quickly. A near-real value
+# (~45-60 s) can be passed for the one slow timing test.
+_DEFAULT_KEEPALIVE_HOLD_S = 0.5
 
 # ---------------------------------------------------------------------------
 # Protocol constants (duplicated here to keep mock self-contained)
@@ -168,6 +189,13 @@ class MockIcomRadio:
         username: str = "testuser",
         password: str = "testpass",
         radio_addr: int = _RADIO_DEFAULT_ADDR,
+        *,
+        single_owner: bool = False,
+        keepalive_hold_s: float = _DEFAULT_KEEPALIVE_HOLD_S,
+        drop_rate: float = 0.0,
+        reorder_window: int = 0,
+        unsolicited_civ: bool = False,
+        unsolicited_interval_s: float = 0.1,
     ) -> None:
         self._host = host
         self._ctrl_port_hint = port
@@ -208,6 +236,50 @@ class MockIcomRadio:
         self.auth_fail: bool = False
         self.response_delay: float = 0.0  # extra sleep before sending a response
 
+        # ----------------------------------------------------------------
+        # Session-lifecycle modelling (additive; all opt-in)
+        # ----------------------------------------------------------------
+        # When ``single_owner`` is True the radio behaves like a real IC-7610:
+        # it tracks ONE owning session keyed by (remote_addr, control my_id).
+        # A conninfo from a different owner while a session is held is rejected
+        # with civ_port=0 + error=0xFFFFFFFF (previous-session-active). The held
+        # session is freed immediately on token-remove or OpenClose(close), and
+        # otherwise auto-released after ``keepalive_hold_s`` of silence.
+        self.single_owner: bool = single_owner
+        self.keepalive_hold_s: float = keepalive_hold_s
+        # Owner identity = (remote_addr, my_id); None when no session is held.
+        self._owner: tuple[tuple[str, int], int] | None = None
+        self._keepalive_timer: asyncio.TimerHandle | None = None
+        # Force civ_port=0 (not-ready, NOT a busy reject) until this monotonic
+        # deadline — drives CONNECTING -> COOLDOWN -> CONNECTING without a
+        # 0xFFFFFFFF reject. 0.0 means "always available".
+        self._civ_unavailable_until: float = 0.0
+
+        # Fault injection
+        self.drop_rate: float = drop_rate  # probability [0,1] of dropping a reply
+        self.reorder_window: int = reorder_window  # buffer N replies then flush
+        self._stall_until: float = 0.0  # suppress unsolicited CI-V until this time
+        self._reorder_buf: dict[
+            str, list[tuple[_MockProtocol, bytes, tuple[str, int]]]
+        ] = {
+            "ctrl": [],
+            "civ": [],
+        }
+        self._rng = random.Random(0xC0FFEE)
+
+        # Autonomous state + unsolicited CI-V streaming
+        self.unsolicited_civ: bool = unsolicited_civ
+        self.unsolicited_interval_s: float = unsolicited_interval_s
+        self._unsolicited_task: asyncio.Task[None] | None = None
+        # Last CI-V client (set on OpenClose(open)) — target for unsolicited frames.
+        self._civ_owner_addr: tuple[str, int] | None = None
+        self._civ_owner_id: int = 0
+        self.unsolicited_sent: int = 0  # count of autonomous frames emitted
+        # Counters / observability for simulator-fidelity tests
+        self.busy_rejects: int = 0  # number of 0xFFFFFFFF rejects sent
+        self.released_count: int = 0  # number of sessions freed (any path)
+        self.last_release_reason: str | None = None
+
     # ------------------------------------------------------------------
     # Lifecycle
     # ------------------------------------------------------------------
@@ -232,6 +304,11 @@ class MockIcomRadio:
         sockname = civ_transport.get_extra_info("sockname")
         self._actual_civ_port = sockname[1]
 
+        if self.unsolicited_civ:
+            self._unsolicited_task = asyncio.get_running_loop().create_task(
+                self._unsolicited_loop()
+            )
+
         logger.debug(
             "MockIcomRadio started — ctrl=%d civ=%d",
             self._actual_ctrl_port,
@@ -239,7 +316,17 @@ class MockIcomRadio:
         )
 
     async def stop(self) -> None:
-        """Close both UDP servers."""
+        """Close both UDP servers and tear down background tasks/timers."""
+        if self._keepalive_timer is not None:
+            self._keepalive_timer.cancel()
+            self._keepalive_timer = None
+        if self._unsolicited_task is not None:
+            self._unsolicited_task.cancel()
+            try:
+                await self._unsolicited_task
+            except (asyncio.CancelledError, Exception):
+                pass
+            self._unsolicited_task = None
         if self._ctrl_udp is not None:
             self._ctrl_udp.close()
             self._ctrl_udp = None
@@ -261,6 +348,110 @@ class MockIcomRadio:
     def civ_port(self) -> int:
         """Actual bound CI-V port number."""
         return self._actual_civ_port
+
+    @property
+    def session_held(self) -> bool:
+        """True when a session is currently owned (single-owner mode)."""
+        return self._owner is not None
+
+    @property
+    def owner(self) -> tuple[tuple[str, int], int] | None:
+        """Current owner identity ``((host, port), my_id)`` or ``None``."""
+        return self._owner
+
+    # ------------------------------------------------------------------
+    # Session-lifecycle test knobs
+    # ------------------------------------------------------------------
+
+    def force_civ_unavailable_for(self, seconds: float) -> None:
+        """Force ``civ_port=0`` (not-ready, NOT a busy reject) for a window.
+
+        This drives the client's CONNECTING -> COOLDOWN -> CONNECTING path
+        without emitting a ``0xFFFFFFFF`` previous-session-active reject. After
+        the window the next conninfo gets a real CI-V port.
+        """
+        self._civ_unavailable_until = time.monotonic() + max(0.0, seconds)
+
+    def clear_civ_unavailable(self) -> None:
+        """Immediately make the CI-V port available again."""
+        self._civ_unavailable_until = 0.0
+
+    def stall_for(self, seconds: float) -> None:
+        """Stop emitting unsolicited CI-V for ``seconds`` to trip the watchdog."""
+        self._stall_until = time.monotonic() + max(0.0, seconds)
+
+    def free_session(self, reason: str = "manual") -> None:
+        """Release the held session immediately (test helper)."""
+        self._release_session(reason)
+
+    # ------------------------------------------------------------------
+    # Session ownership (single-owner model)
+    # ------------------------------------------------------------------
+
+    def _release_session(self, reason: str) -> None:
+        """Free the held session and cancel its keepalive timer."""
+        if self._keepalive_timer is not None:
+            self._keepalive_timer.cancel()
+            self._keepalive_timer = None
+        if self._owner is not None:
+            logger.debug("Mock: session released (%s) owner=%s", reason, self._owner)
+            self._owner = None
+            self.released_count += 1
+            self.last_release_reason = reason
+
+    def _arm_keepalive(self) -> None:
+        """(Re)start the keepalive auto-release timer for the held session."""
+        if self._owner is None:
+            return
+        if self._keepalive_timer is not None:
+            self._keepalive_timer.cancel()
+        loop = asyncio.get_running_loop()
+        self._keepalive_timer = loop.call_later(
+            self.keepalive_hold_s,
+            lambda: self._release_session("keepalive_timeout"),
+        )
+
+    def _claim_session(self, owner: tuple[tuple[str, int], int]) -> None:
+        """Mark ``owner`` as the holder and arm the keepalive timer."""
+        self._owner = owner
+        self._arm_keepalive()
+
+    def _refresh_keepalive(self, owner: tuple[tuple[str, int], int]) -> None:
+        """Re-arm the keepalive timer if ``owner`` is the current holder."""
+        if self.single_owner and self._owner == owner:
+            self._arm_keepalive()
+
+    def _conninfo_status(self, addr: tuple[str, int], sender_id: int) -> bytes:
+        """Ownership-aware status reply for a conninfo (data-port request).
+
+        Single-owner semantics:
+          * a FOREIGN owner asking while a session is held -> busy reject
+            (civ_port=0, error=0xFFFFFFFF);
+          * the CI-V port forced unavailable -> not-ready (civ_port=0, error=0);
+          * otherwise claim the session for this owner and return the CI-V port.
+
+        When ``single_owner`` is False this preserves the legacy behaviour
+        (always return the real CI-V port) so existing tests stay green.
+        """
+        if not self.single_owner:
+            return self._status_response(sender_id)
+
+        owner = (addr, sender_id)
+
+        # Foreign held session -> previous-session-active reject.
+        if self._owner is not None and self._owner != owner:
+            self.busy_rejects += 1
+            return self._status_response(
+                sender_id, civ_port=0, error=_ERR_PREV_SESSION_ACTIVE
+            )
+
+        # CI-V port forced not-ready (cooldown driver; distinct from busy).
+        if time.monotonic() < self._civ_unavailable_until:
+            return self._status_response(sender_id, civ_port=0, error=_ERR_OK)
+
+        # Available: claim (or refresh) the session for this owner.
+        self._claim_session(owner)
+        return self._status_response(sender_id)
 
     # ------------------------------------------------------------------
     # State setters (for test setup)
@@ -301,6 +492,35 @@ class MockIcomRadio:
     # ------------------------------------------------------------------
     # Packet dispatch
     # ------------------------------------------------------------------
+
+    def _emit(
+        self,
+        proto: _MockProtocol,
+        pkt: bytes,
+        addr: tuple[str, int],
+        label: str,
+    ) -> None:
+        """Send a reply through the fault-injection layer (drop/reorder).
+
+        Replies built by the handlers go through here instead of ``proto.send``
+        directly so that ``drop_rate`` and ``reorder_window`` apply. Discovery
+        and the session-critical handshake are never dropped — only data-plane
+        and post-handshake replies — to keep connect() deterministic while still
+        exercising the data watchdog and recovery paths.
+        """
+        if self.drop_rate > 0.0 and self._rng.random() < self.drop_rate:
+            logger.debug("Mock: dropped %s reply (%d bytes)", label, len(pkt))
+            return
+        if self.reorder_window > 1:
+            buf = self._reorder_buf[label]
+            buf.append((proto, pkt, addr))
+            if len(buf) >= self.reorder_window:
+                self._rng.shuffle(buf)
+                for p, b, a in buf:
+                    p.send(b, a)
+                buf.clear()
+            return
+        proto.send(pkt, addr)
 
     def _on_packet(
         self,
@@ -366,8 +586,9 @@ class MockIcomRadio:
             proto.send(self._ctrl_pkt(_PT_ARE_YOU_READY, 0, sender_id), addr)
             return
 
-        # Ping request → Ping reply
+        # Ping request → Ping reply (refreshes the keepalive for the owner)
         if n == _PING_SIZE and ptype == _PT_PING and data[0x10] == 0x00:
+            self._refresh_keepalive((addr, sender_id))
             proto.send(self._ping_reply(data, sender_id), addr)
             return
 
@@ -377,25 +598,31 @@ class MockIcomRadio:
             return
 
         # Token ack (0x40 bytes, requesttype=0x02) → send GUID conninfo
-        if n == 0x40 and data[0x15] == 0x02:
+        if n == 0x40 and data[0x15] == _TOKEN_ACK:
+            self._refresh_keepalive((addr, sender_id))
             proto.send(self._guid_conninfo(sender_id), addr)
             return
 
-        # Token renewal (0x40 bytes, requesttype=0x05) → no response needed
-        if n == 0x40 and data[0x15] == 0x05:
+        # Token renewal (0x40 bytes, requesttype=0x05) → refresh keepalive
+        if n == 0x40 and data[0x15] == _TOKEN_RENEW:
+            self._refresh_keepalive((addr, sender_id))
             return
 
-        # Token remove (0x40 bytes, requesttype=0x01) → no response
-        if n == 0x40 and data[0x15] == 0x01:
+        # Token remove (0x40 bytes, requesttype=0x01) → graceful close: free now
+        if n == 0x40 and data[0x15] == _TOKEN_REMOVE:
+            if self.single_owner and self._owner == (addr, sender_id):
+                self._release_session("token_remove")
             return
 
         # Client conninfo (0x90 bytes, requesttype=0x03) → status with CI-V port
         if n == 0x90 and data[0x15] == 0x03:
-            proto.send(self._status_response(sender_id), addr)
+            proto.send(self._conninfo_status(addr, sender_id), addr)
             return
 
-        # Disconnect
+        # Disconnect → free a held session for this owner
         if n == _HEADER_SIZE and ptype == _PT_DISCONNECT:
+            if self.single_owner and self._owner == (addr, sender_id):
+                self._release_session("disconnect")
             return
 
     # ------------------------------------------------------------------
@@ -435,9 +662,15 @@ class MockIcomRadio:
         # checks (radio_ready), so we emit a tiny unsolicited CI-V frame on open to mark
         # the stream as active for mock-based integration tests.
         if n == 0x16:
-            if data[0x15] == 0x04:  # open_stream
+            if data[0x15] == _OPENCLOSE_OPEN:  # open_stream
+                self._civ_owner_addr = addr
+                self._civ_owner_id = sender_id
                 civ = self._civ_frame(to=0x00, frm=self._radio_addr, cmd=0x00)
                 proto.send(self._wrap_civ(civ, sender_id), addr)
+            elif data[0x15] == _OPENCLOSE_CLOSE:  # graceful data-port close
+                # OpenClose(close) frees the single held session immediately.
+                if self.single_owner and self._owner is not None:
+                    self._release_session("openclose_close")
             return
 
         # Disconnect
@@ -481,6 +714,46 @@ class MockIcomRadio:
         response_civ = self._dispatch_civ(cmd, payload, from_addr)
         if response_civ is not None:
             proto.send(self._wrap_civ(response_civ, sender_id), addr)
+
+    # ------------------------------------------------------------------
+    # Autonomous state + unsolicited CI-V streaming
+    # ------------------------------------------------------------------
+
+    async def _unsolicited_loop(self) -> None:
+        """Emit unsolicited (transceive-style) CI-V frames on a cadence.
+
+        Drifts the frequency and pushes an unsolicited 0x00 (freq report) frame
+        to the last CI-V client, modelling a radio that streams data on its own.
+        Suppressed while ``stall_for`` is active so the data watchdog can trip.
+        """
+        try:
+            while True:
+                await asyncio.sleep(self.unsolicited_interval_s)
+                if self._civ_udp is None:
+                    continue
+                if time.monotonic() < self._stall_until:
+                    continue  # stalled: deliberately starve the watchdog
+                addr = self._civ_owner_addr
+                if addr is None:
+                    continue
+                # Drift state and broadcast a freq report (transceive style).
+                self._frequency += 10
+                civ = self._civ_frame(
+                    to=0x00,
+                    frm=self._radio_addr,
+                    cmd=_CMD_FREQ_GET,
+                    data=_bcd_encode_freq(self._frequency),
+                )
+                pkt = self._wrap_civ(civ, self._civ_owner_id)
+                if self.drop_rate > 0.0 and self._rng.random() < self.drop_rate:
+                    continue
+                if self._civ_udp is not None and not self._civ_udp.is_closing():
+                    self._civ_udp.sendto(pkt, addr)
+                    self.unsolicited_sent += 1
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("Mock: unsolicited CI-V loop error")
 
     # ------------------------------------------------------------------
     # CI-V command dispatcher
@@ -763,23 +1036,40 @@ class MockIcomRadio:
         pkt[0x20:0x30] = bytes(range(0x01, 0x11))
         return bytes(pkt)
 
-    def _status_response(self, sender_id: int) -> bytes:
+    def _status_response(
+        self,
+        sender_id: int,
+        *,
+        civ_port: int | None = None,
+        error: int = _ERR_OK,
+    ) -> bytes:
         """Build a 0x50-byte status packet carrying the CI-V port number.
 
         Layout mirrors ``parse_status_response`` in auth.py (line ~400)
         and ``_build_status`` in test_radio_connect.py:
+          offset 0x30 (LE u32) = error code
           offset 0x42 (BE u16) = CIV port
           offset 0x46 (BE u16) = audio port
+
+        Args:
+            sender_id: client connection ID to address the reply to.
+            civ_port: CI-V port to advertise; ``None`` = the real bound port,
+                ``0`` = not-ready / busy reject.
+            error: error code written little-endian at 0x30
+                (``0xFFFFFFFF`` = previous-session-active).
         """
         pkt = bytearray(0x50)
         struct.pack_into("<I", pkt, 0x00, 0x50)
         struct.pack_into("<H", pkt, 0x04, _PT_DATA)
         struct.pack_into("<I", pkt, 0x08, self.radio_id)
         struct.pack_into("<I", pkt, 0x0C, sender_id)
-        struct.pack_into(">H", pkt, 0x42, self._actual_civ_port)
+        struct.pack_into("<I", pkt, 0x30, error & 0xFFFFFFFF)
+        port = self._actual_civ_port if civ_port is None else civ_port
+        struct.pack_into(">H", pkt, 0x42, port)
         # Dummy audio port: keep within uint16 range even if OS assigns civ_port=65535.
-        audio_port = (
-            self._actual_civ_port + 1 if self._actual_civ_port < 65535 else 65534
-        )
+        if port == 0:
+            audio_port = 0
+        else:
+            audio_port = port + 1 if port < 65535 else 65534
         struct.pack_into(">H", pkt, 0x46, audio_port)
         return bytes(pkt)

--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -630,7 +630,10 @@ async def test_soft_reconnect_rebuilds_on_already_open_stalled(
         rebuilt.append(True)
 
     radio._force_cleanup_civ = fake_force_cleanup
-    radio._control_phase.connect = fake_connect  # type: ignore[method-assign]
+    # A3 deleted the legacy ``ControlPhaseRuntime.connect()`` retry wrapper; the
+    # "control transport gone" rebuild branch now does a single full-connect
+    # attempt via ``_connect_once`` (the lifecycle owns retry).
+    radio._control_phase._connect_once = fake_connect  # type: ignore[method-assign]
 
     await radio.soft_reconnect()
 

--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -321,18 +321,26 @@ async def test_watchdog_loop_phase1_open_close_exception_ignored(
         )  # should complete without raising
 
 
-async def test_watchdog_loop_phase2_uses_long_reconnect_cooldown(
+async def test_watchdog_loop_phase2_hands_off_to_lifecycle_recovery(
     radio: IcomRadio,
 ) -> None:
-    """Phase 2 uses a long cooldown before reconnect to avoid reconnect churn.
+    """After the OpenClose deadline the watchdog HANDS OFF recovery to the
+    unified lifecycle loop rather than owning the retry/backoff/exhaustion
+    ladder itself (A4 single-owner).
 
-    After the OpenClose deadline, the watchdog spawns a detached reconnect
-    task that sleeps for the cooldown BEFORE calling soft_reconnect.
+    The detached handoff (``_watchdog_recover``) calls ``soft_reconnect`` ONCE;
+    the attempt count and the per-attempt backoff now live entirely in
+    ``CoreRadioSessionLifecycle._run_recover`` (driven via ``soft_reconnect``),
+    so the watchdog no longer sleeps a 45 s backoff of its own.
     """
     radio._last_civ_data_received = 0.0
     radio._civ_recovering = False
     radio._force_cleanup_civ = AsyncMock()
     radio.soft_reconnect = AsyncMock()
+    # Control session alive so the post-recovery re-arm is a no-op spy path.
+    ctrl = MagicMock()
+    ctrl._udp_transport = object()
+    radio._ctrl_transport = ctrl
 
     delays: list[float] = []
 
@@ -350,36 +358,46 @@ async def test_watchdog_loop_phase2_uses_long_reconnect_cooldown(
     with (
         patch("asyncio.sleep", side_effect=fake_sleep),
         patch("time.monotonic", side_effect=_mono),
+        patch("rigplane.runtime._civ_rx.time.monotonic", side_effect=_mono),
         patch.object(radio, "_send_open_close", new=AsyncMock()),
+        patch.object(radio._civ_runtime, "start_data_watchdog", MagicMock()),
     ):
         await radio._civ_runtime._civ_data_watchdog_loop()
-        # Await the spawned reconnect task explicitly so its cooldown sleep
-        # runs inside the patched scope.
+        # Await the spawned recovery handoff explicitly so it runs inside the
+        # patched scope.
         spawned = [
             t for t in asyncio.all_tasks() if t.get_name().startswith("civ-watchdog-")
         ]
         for task in spawned:
             await task
 
-    # 45s cooldown was observed in the spawned task (first backoff entry).
-    assert any(d >= 45.0 for d in delays)
+    # The watchdog itself no longer owns a 45 s reconnect backoff sleep — the
+    # backoff moved into the lifecycle RECOVERING loop.  It hands off exactly
+    # once to ``soft_reconnect``.
+    assert all(d < 45.0 for d in delays)
     radio.soft_reconnect.assert_awaited_once()
 
 
-async def test_watchdog_soft_reconnect_task_sleeps_before_reconnect(
+async def test_watchdog_recover_cleans_up_then_drives_lifecycle(
     radio: IcomRadio,
 ) -> None:
-    """Detached soft_reconnect task sleeps for the cooldown BEFORE calling
-    soft_reconnect — regression guard for the self-cancel bug where the
-    watchdog cancelled itself and the cooldown sleep never ran.
+    """The detached recovery handoff tears down the stalled CI-V transport, then
+    drives the unified lifecycle ``soft_reconnect`` ONCE (A4).
+
+    The per-attempt backoff/cooldown that used to live in the watchdog handoff
+    moved into ``CoreRadioSessionLifecycle._run_recover``; the handoff itself no
+    longer sleeps a backoff before ``soft_reconnect`` — it just cleans up and
+    delegates.  ``force_cleanup`` runs before ``soft_reconnect`` (the
+    rebuild path), preserving the #1217 detached-execution ordering.
     """
     order: list[str] = []
+    # Control session alive so the finally re-arm is a no-op spy path.
+    ctrl = MagicMock()
+    ctrl._udp_transport = object()
+    radio._ctrl_transport = ctrl
 
     async def record_force_cleanup() -> None:
         order.append("force_cleanup")
-
-    async def record_sleep(delay: float) -> None:
-        order.append(f"sleep({delay})")
 
     async def record_soft_reconnect() -> None:
         order.append("soft_reconnect")
@@ -387,39 +405,54 @@ async def test_watchdog_soft_reconnect_task_sleeps_before_reconnect(
     radio._force_cleanup_civ = record_force_cleanup
     radio.soft_reconnect = record_soft_reconnect
 
-    with patch("asyncio.sleep", side_effect=record_sleep):
-        await radio._civ_runtime._watchdog_soft_reconnect(cooldown=45.0)
+    with patch.object(radio._civ_runtime, "start_data_watchdog", MagicMock()):
+        await radio._civ_runtime._watchdog_recover()
 
-    assert order == ["force_cleanup", "sleep(45.0)", "soft_reconnect"]
+    assert order == ["force_cleanup", "soft_reconnect"]
 
 
 async def test_stop_data_watchdog_cancels_pending_reconnect_task(
     radio: IcomRadio,
 ) -> None:
-    """stop_data_watchdog() must cancel any pending detached reconnect task
-    spawned by watchdog escalation, so disconnect during cooldown does not
-    trigger a late soft_reconnect (Codex P1 on PR #851).
+    """stop_data_watchdog() must cancel any in-flight detached recovery handoff,
+    so an explicit disconnect during recovery does not let a late
+    soft_reconnect resume (Codex P1 on PR #851).
+
+    Recovery backoff now lives in the lifecycle, so the handoff is "pending"
+    while the (here-blocked) ``soft_reconnect`` is in flight rather than while a
+    watchdog cooldown sleep runs.
     """
     radio._force_cleanup_civ = AsyncMock()
-    radio.soft_reconnect = AsyncMock()
 
-    # Spawn the reconnect helper the same way the watchdog does, and
-    # register it on the runtime so stop_data_watchdog can find it.
+    started = asyncio.Event()
+    reached_completion: list[bool] = []
+
+    async def blocking_soft_reconnect() -> None:
+        started.set()
+        # Block until cancelled (stands in for the lifecycle RECOVERING loop's
+        # backoff sleep / in-flight attempt).
+        await asyncio.sleep(60.0)
+        reached_completion.append(True)
+
+    radio.soft_reconnect = blocking_soft_reconnect
+
+    # Spawn the recovery handoff the same way the watchdog does, and register it
+    # on the runtime so stop_data_watchdog can find it.
     task = asyncio.create_task(
-        radio._civ_runtime._watchdog_soft_reconnect(cooldown=5.0),
-        name="civ-watchdog-soft-reconnect",
+        radio._civ_runtime._watchdog_recover(),
+        name="civ-watchdog-recover",
     )
     radio._civ_runtime._reconnect_task = task
 
-    # Let the task enter its cooldown sleep.
-    await asyncio.sleep(0.01)
-    assert not task.done(), "task should still be sleeping in cooldown"
+    # Let the task reach the (blocked) soft_reconnect.
+    await started.wait()
+    assert not task.done(), "recovery handoff should still be in flight"
 
-    # Explicit disconnect during cooldown.
+    # Explicit disconnect during recovery.
     await radio._civ_runtime.stop_data_watchdog()
 
     assert task.done()
-    radio.soft_reconnect.assert_not_awaited()
+    assert reached_completion == [], "soft_reconnect must not complete after cancel"
     assert radio._civ_runtime._reconnect_task is None
 
 
@@ -471,12 +504,13 @@ async def test_watchdog_patient_openclose_before_escalation(
 # ---------------------------------------------------------------------------
 
 
-async def test_watchdog_soft_reconnect_rearms_watchdog_when_recovery_fails(
+async def test_watchdog_recover_rearms_watchdog_when_recovery_fails(
     radio: IcomRadio,
 ) -> None:
-    """After a failed detached soft_reconnect the data watchdog is re-armed so
-    recovery keeps retrying with bounded backoff instead of freezing after one
-    attempt (#1217).
+    """When the lifecycle recovery handoff fails BUT the control session
+    survives (transient failure, not exhaustion-with-release), the data watchdog
+    is unconditionally re-armed so a later stall is detected again instead of
+    freezing after one episode (#1217 invariant 3: unconditional re-arm).
     """
     # Control session still alive so re-arm is appropriate.
     ctrl = MagicMock()
@@ -489,29 +523,15 @@ async def test_watchdog_soft_reconnect_rearms_watchdog_when_recovery_fails(
     async def failing_soft_reconnect() -> None:
         raise ConnectionError("radio still gone")
 
-    async def failing_disconnect() -> None:
-        return None
-
-    async def failing_connect() -> None:
-        raise ConnectionError("radio still gone")
-
     radio._force_cleanup_civ = failing_force_cleanup
     radio.soft_reconnect = failing_soft_reconnect
-    radio.disconnect = failing_disconnect
-    radio.connect = failing_connect
     radio._civ_data_watchdog_task = None
-
-    async def instant_sleep(delay: float) -> None:
-        return None
 
     # Spy on start_data_watchdog instead of running the real loop, so the test
     # asserts the re-arm without leaking a live watchdog task into the loop.
     rearm_spy = MagicMock()
-    with (
-        patch("asyncio.sleep", side_effect=instant_sleep),
-        patch.object(radio._civ_runtime, "start_data_watchdog", rearm_spy),
-    ):
-        await radio._civ_runtime._watchdog_soft_reconnect(cooldown=45.0)
+    with patch.object(radio._civ_runtime, "start_data_watchdog", rearm_spy):
+        await radio._civ_runtime._watchdog_recover()
 
     # A fresh watchdog must have been re-armed so recovery keeps probing.
     rearm_spy.assert_called_once()
@@ -534,19 +554,11 @@ async def test_watchdog_does_not_rearm_when_control_session_gone(
 
     radio._force_cleanup_civ = noop
     radio.soft_reconnect = failing_soft_reconnect
-    radio.disconnect = noop
-    radio.connect = failing_soft_reconnect
     radio._civ_data_watchdog_task = None
 
-    async def instant_sleep(delay: float) -> None:
-        return None
-
     rearm_spy = MagicMock()
-    with (
-        patch("asyncio.sleep", side_effect=instant_sleep),
-        patch.object(radio._civ_runtime, "start_data_watchdog", rearm_spy),
-    ):
-        await radio._civ_runtime._watchdog_soft_reconnect(cooldown=45.0)
+    with patch.object(radio._civ_runtime, "start_data_watchdog", rearm_spy):
+        await radio._civ_runtime._watchdog_recover()
 
     rearm_spy.assert_not_called()
     assert radio._civ_data_watchdog_task is None
@@ -577,17 +589,11 @@ async def test_stop_data_watchdog_does_not_self_cancel_running_recovery(
     radio.soft_reconnect = record_soft_reconnect
     radio._civ_data_watchdog_task = None
 
-    async def instant_sleep(delay: float) -> None:
-        return None
-
     # Spy the re-arm so the helper's finally does not leak a live watchdog task.
-    with (
-        patch("asyncio.sleep", side_effect=instant_sleep),
-        patch.object(radio._civ_runtime, "start_data_watchdog", MagicMock()),
-    ):
+    with patch.object(radio._civ_runtime, "start_data_watchdog", MagicMock()):
         task = asyncio.create_task(
-            radio._civ_runtime._watchdog_soft_reconnect(cooldown=1.0),
-            name="civ-watchdog-soft-reconnect",
+            radio._civ_runtime._watchdog_recover(),
+            name="civ-watchdog-recover",
         )
         radio._civ_runtime._reconnect_task = task
         await task
@@ -676,12 +682,13 @@ async def test_wait_for_recovery_kicks_soft_reconnect_on_stalled_transport(
     )
 
 
-async def test_watchdog_full_reconnect_rearms_for_indefinite_retry(
+async def test_watchdog_recover_rearms_after_successful_recovery(
     radio: IcomRadio,
 ) -> None:
-    """After the soft-reconnect ladder is exhausted, the detached full
-    reconnect re-arms the watchdog so a still-dead radio is re-probed
-    indefinitely (bounded backoff), not left permanently frozen (#1217).
+    """After a SUCCESSFUL lifecycle recovery handoff the watchdog is re-armed so
+    a later stall is detected and handed off again — the detector keeps watching
+    forever even though the lifecycle owns the bounded per-episode retry ladder
+    (A4 single-owner; #1217 invariant 3).
     """
     ctrl = MagicMock()
     ctrl._udp_transport = object()
@@ -690,25 +697,77 @@ async def test_watchdog_full_reconnect_rearms_for_indefinite_retry(
     async def noop() -> None:
         return None
 
-    async def failing_connect() -> None:
-        raise ConnectionError("still dead")
-
-    radio._force_cleanup_civ = noop
-    radio.disconnect = noop
-    radio.connect = failing_connect
-    radio._civ_data_watchdog_task = None
-
-    async def instant_sleep(delay: float) -> None:
+    async def ok_soft_reconnect() -> None:
+        # Lifecycle RECOVERING loop succeeded on an attempt.
         return None
 
+    radio._force_cleanup_civ = noop
+    radio.soft_reconnect = ok_soft_reconnect
+    radio._civ_data_watchdog_task = None
+
     rearm_spy = MagicMock()
-    with (
-        patch("asyncio.sleep", side_effect=instant_sleep),
-        patch.object(radio._civ_runtime, "start_data_watchdog", rearm_spy),
-    ):
-        await radio._civ_runtime._watchdog_full_reconnect(cooldown=60.0)
+    with patch.object(radio._civ_runtime, "start_data_watchdog", rearm_spy):
+        await radio._civ_runtime._watchdog_recover()
 
     rearm_spy.assert_called_once()
+
+
+async def test_watchdog_detects_but_lifecycle_owns_attempt_count(
+    radio: IcomRadio,
+) -> None:
+    """SINGLE-OWNER assertion (A4): the watchdog handoff DETECTS+triggers, but
+    the lifecycle owns the attempt count / backoff / exhaustion.
+
+    The detached handoff (``_watchdog_recover``) calls ``radio.soft_reconnect``
+    exactly ONCE.  ``radio.soft_reconnect`` routes into the unified lifecycle
+    RECOVERING loop, which is the SINGLE place that performs the
+    ``_MAX_RECONNECTS`` attempts of the per-attempt primitive
+    (``soft_reconnect_once``) with backoff and then routes exhaustion through
+    CLOSING + full release.  The watchdog itself counts nothing.
+    """
+    from rigplane.runtime.session_lifecycle import LifecycleState
+
+    ctrl = MagicMock()
+    ctrl._udp_transport = object()
+    radio._ctrl_transport = ctrl
+
+    lifecycle = radio._session_lifecycle
+    lifecycle._recovery_backoff_s = (0.0, 0.0, 0.0)  # no wall-clock backoff
+
+    attempts: list[int] = []
+
+    async def counting_failure() -> None:
+        attempts.append(1)
+        raise ConnectionError("injected per-attempt failure")
+
+    # The per-attempt primitive owned by the lifecycle.
+    lifecycle._mech.soft_reconnect_once = counting_failure  # type: ignore[method-assign]
+
+    async def noop() -> None:
+        return None
+
+    radio._force_cleanup_civ = noop
+
+    # Count how many times the watchdog handoff invokes the (lifecycle) recovery.
+    handoff_calls: list[int] = []
+    real_soft_reconnect = radio.soft_reconnect
+
+    async def counting_soft_reconnect() -> None:
+        handoff_calls.append(1)
+        await real_soft_reconnect()
+
+    radio.soft_reconnect = counting_soft_reconnect  # type: ignore[method-assign]
+
+    with patch.object(radio._civ_runtime, "start_data_watchdog", MagicMock()):
+        await radio._civ_runtime._watchdog_recover()
+
+    # The watchdog triggered recovery exactly once (it does NOT loop attempts).
+    assert handoff_calls == [1]
+    # The lifecycle owns the attempt count: it ran _MAX_RECONNECTS attempts of
+    # the per-attempt primitive before exhausting.
+    assert len(attempts) == lifecycle._max_recovery_attempts
+    # Exhaustion routed through CLOSING + full release -> DISCONNECTED.
+    assert lifecycle.state is LifecycleState.DISCONNECTED
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -79,6 +79,13 @@ def test_public_api_surface() -> None:
         "RadioProfile",
         "VfoSlotState",
         "YaesuStateExtension",
+        # --- Tier 1: Session lifecycle (v2.11, D6) ---
+        "RadioSessionLifecycle",
+        "LifecycleState",
+        "LifecycleStatus",
+        "LifecycleEvent",
+        "LifecycleErrorReason",
+        "RadioPresence",
         # --- Tier 2 (lazy): backward-compat facade ---
         "IcomRadio",
         # --- Tier 2 (lazy): commander internals ---

--- a/tests/test_mock_icom_session.py
+++ b/tests/test_mock_icom_session.py
@@ -1,0 +1,503 @@
+"""Simulator-fidelity tests for the IC-7610 session lifecycle in MockIcomRadio.
+
+These tests validate the SIMULATOR ITSELF — not any production lifecycle code
+(which does not exist yet). They drive the mock's control / CI-V UDP ports with
+hand-built protocol packets and assert the modelled network CI-V session
+lifecycle:
+
+  * held single-owner session -> foreign conninfo gets civ_port=0 + 0xFFFFFFFF;
+  * token-remove (token magic 0x01) -> session freed immediately;
+  * OpenClose(close) -> session freed immediately;
+  * keepalive timeout (accelerated) -> session auto-released after the hold;
+  * keepalive refresh on ping / renew keeps the session alive;
+  * civ_port-unavailable knob -> civ_port=0 with error=0 (not-ready, not busy);
+  * fault-injection knobs (drop_rate, stall_for, unsolicited stream).
+
+The packets only need the sizes / offsets the simulator parses
+(``len`` @0x00, ``type`` @0x04, ``sender_id`` @0x08, magic byte @0x15), so they
+are hand-built rather than going through the production handshake.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import struct
+from collections.abc import AsyncGenerator
+
+import pytest
+
+from mock_server import (
+    _ERR_OK,
+    _ERR_PREV_SESSION_ACTIVE,
+    _OPENCLOSE_CLOSE,
+    _OPENCLOSE_OPEN,
+    _PT_DATA,
+    _PT_DISCONNECT,
+    _PT_PING,
+    _TOKEN_REMOVE,
+    _TOKEN_RENEW,
+    MockIcomRadio,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Raw UDP client driving the simulator's control / CI-V ports
+# ---------------------------------------------------------------------------
+
+
+class _RawClient:
+    """Minimal UDP client that speaks just enough protocol for the simulator.
+
+    Owner identity on the wire is ``(remote_addr, sender_id)``; each client
+    instance uses a distinct ``sender_id`` so the simulator treats them as
+    different owners.
+    """
+
+    def __init__(self, sender_id: int) -> None:
+        self.sender_id = sender_id
+        self._transport: asyncio.DatagramTransport | None = None
+        self._proto: _ClientProto | None = None
+
+    async def open(self) -> None:
+        loop = asyncio.get_running_loop()
+        transport, proto = await loop.create_datagram_endpoint(
+            lambda: _ClientProto(),
+            local_addr=("127.0.0.1", 0),
+        )
+        self._transport = transport
+        self._proto = proto
+
+    async def close(self) -> None:
+        if self._transport is not None:
+            self._transport.close()
+            self._transport = None
+
+    def _send(self, pkt: bytes, port: int) -> None:
+        assert self._transport is not None
+        self._transport.sendto(pkt, ("127.0.0.1", port))
+
+    async def _recv(self, timeout: float = 1.0) -> bytes:
+        assert self._proto is not None
+        return await asyncio.wait_for(self._proto.queue.get(), timeout)
+
+    # -- header helper --------------------------------------------------
+
+    def _header(self, length: int, ptype: int) -> bytearray:
+        pkt = bytearray(length)
+        struct.pack_into("<I", pkt, 0x00, length)
+        struct.pack_into("<H", pkt, 0x04, ptype)
+        struct.pack_into("<I", pkt, 0x08, self.sender_id)
+        return pkt
+
+    # -- control-port primitives ---------------------------------------
+
+    async def conninfo(self, ctrl_port: int) -> tuple[int, int]:
+        """Send a 0x90 conninfo (requesttype 0x03) and parse the status reply.
+
+        Returns ``(civ_port, error)`` from the status response
+        (civ_port BE@0x42, error LE@0x30).
+        """
+        pkt = self._header(0x90, _PT_DATA)
+        pkt[0x15] = 0x03
+        self._send(bytes(pkt), ctrl_port)
+        reply = await self._recv()
+        error = struct.unpack_from("<I", reply, 0x30)[0]
+        civ_port = struct.unpack_from(">H", reply, 0x42)[0]
+        return civ_port, error
+
+    def token(self, ctrl_port: int, magic: int) -> None:
+        """Send a 0x40 token packet with the given magic at pkt[0x15]."""
+        pkt = self._header(0x40, _PT_DATA)
+        pkt[0x14] = 0x01
+        pkt[0x15] = magic
+        self._send(bytes(pkt), ctrl_port)
+
+    def ping(self, ctrl_port: int) -> None:
+        """Send a 0x15 control ping request (data[0x10]=0x00)."""
+        pkt = self._header(0x15, _PT_PING)
+        pkt[0x10] = 0x00
+        self._send(bytes(pkt), ctrl_port)
+
+    def disconnect(self, ctrl_port: int) -> None:
+        self._send(bytes(self._header(0x10, _PT_DISCONNECT)), ctrl_port)
+
+    # -- CI-V-port primitives ------------------------------------------
+
+    def openclose(self, civ_port: int, magic: int) -> None:
+        """Send a 0x16 OpenClose packet with magic at pkt[0x15]."""
+        pkt = self._header(0x16, _PT_DATA)
+        pkt[0x15] = magic
+        self._send(bytes(pkt), civ_port)
+
+
+class _ClientProto(asyncio.DatagramProtocol):
+    def __init__(self) -> None:
+        self.queue: asyncio.Queue[bytes] = asyncio.Queue()
+
+    def datagram_received(self, data: bytes, addr: tuple[str, int]) -> None:
+        self.queue.put_nowait(data)
+
+
+@pytest.fixture
+async def sim() -> AsyncGenerator[MockIcomRadio]:
+    """Single-owner simulator with a fast keepalive hold for the tests."""
+    server = MockIcomRadio(single_owner=True, keepalive_hold_s=0.3)
+    await server.start()
+    yield server
+    await server.stop()
+
+
+async def _client(sender_id: int) -> _RawClient:
+    c = _RawClient(sender_id)
+    await c.open()
+    return c
+
+
+async def _claim(sim: MockIcomRadio, client: _RawClient) -> tuple[int, int]:
+    """Drive a conninfo and return ``(civ_port, error)``; claims on success."""
+    return await client.conninfo(sim.control_port)
+
+
+# ---------------------------------------------------------------------------
+# 1. Held single-owner session -> busy reject (0xFFFFFFFF)
+# ---------------------------------------------------------------------------
+
+
+async def test_first_conninfo_claims_and_returns_civ_port(sim: MockIcomRadio) -> None:
+    c = await _client(0x10001)
+    try:
+        civ_port, error = await _claim(sim, c)
+        assert error == _ERR_OK
+        assert civ_port == sim.civ_port
+        assert civ_port != 0
+        assert sim.session_held is True
+        assert sim.owner is not None and sim.owner[1] == 0x10001
+    finally:
+        await c.close()
+
+
+async def test_held_session_rejects_foreign_owner_with_0xffffffff(
+    sim: MockIcomRadio,
+) -> None:
+    owner = await _client(0x10001)
+    intruder = await _client(0x10002)
+    try:
+        civ_port, error = await _claim(sim, owner)
+        assert error == _ERR_OK and civ_port != 0
+        assert sim.session_held is True
+
+        # A DIFFERENT owner asking for data ports while held -> busy reject.
+        civ_port2, error2 = await _claim(sim, intruder)
+        assert civ_port2 == 0
+        assert error2 == _ERR_PREV_SESSION_ACTIVE
+        assert sim.busy_rejects == 1
+        # Ownership is unchanged by the rejected attempt.
+        assert sim.owner is not None and sim.owner[1] == 0x10001
+    finally:
+        await owner.close()
+        await intruder.close()
+
+
+async def test_same_owner_reconnect_is_not_rejected(sim: MockIcomRadio) -> None:
+    c = await _client(0x10001)
+    try:
+        await _claim(sim, c)
+        # Same owner repeating conninfo refreshes, never busy-rejects.
+        civ_port, error = await _claim(sim, c)
+        assert error == _ERR_OK and civ_port == sim.civ_port
+        assert sim.busy_rejects == 0
+    finally:
+        await c.close()
+
+
+# ---------------------------------------------------------------------------
+# 2. Graceful release: token-remove / OpenClose(close) free immediately
+# ---------------------------------------------------------------------------
+
+
+async def test_token_remove_frees_session_immediately(sim: MockIcomRadio) -> None:
+    owner = await _client(0x10001)
+    newcomer = await _client(0x10002)
+    try:
+        await _claim(sim, owner)
+        assert sim.session_held is True
+
+        # Graceful withdraw.
+        owner.token(sim.control_port, _TOKEN_REMOVE)
+        await asyncio.sleep(0.02)
+        assert sim.session_held is False
+        assert sim.last_release_reason == "token_remove"
+
+        # A subsequent connect (even a different owner) succeeds, no cooldown.
+        civ_port, error = await _claim(sim, newcomer)
+        assert error == _ERR_OK and civ_port == sim.civ_port
+        assert sim.busy_rejects == 0
+    finally:
+        await owner.close()
+        await newcomer.close()
+
+
+async def test_openclose_close_frees_session_immediately(sim: MockIcomRadio) -> None:
+    owner = await _client(0x10001)
+    try:
+        await _claim(sim, owner)
+        # Open the data stream, then close it gracefully.
+        owner.openclose(sim.civ_port, _OPENCLOSE_OPEN)
+        await asyncio.sleep(0.02)
+        assert sim.session_held is True
+
+        owner.openclose(sim.civ_port, _OPENCLOSE_CLOSE)
+        await asyncio.sleep(0.02)
+        assert sim.session_held is False
+        assert sim.last_release_reason == "openclose_close"
+    finally:
+        await owner.close()
+
+
+async def test_disconnect_packet_frees_session(sim: MockIcomRadio) -> None:
+    owner = await _client(0x10001)
+    try:
+        await _claim(sim, owner)
+        assert sim.session_held is True
+        owner.disconnect(sim.control_port)
+        await asyncio.sleep(0.02)
+        assert sim.session_held is False
+        assert sim.last_release_reason == "disconnect"
+    finally:
+        await owner.close()
+
+
+# ---------------------------------------------------------------------------
+# 3. Keepalive timeout: silent drop holds, then auto-releases
+# ---------------------------------------------------------------------------
+
+
+async def test_keepalive_timeout_auto_releases_after_hold(sim: MockIcomRadio) -> None:
+    # keepalive_hold_s is 0.3 in the fixture.
+    owner = await _client(0x10001)
+    try:
+        await _claim(sim, owner)
+        assert sim.session_held is True
+
+        # No graceful close: while inside the hold the session is still held.
+        await asyncio.sleep(0.1)
+        assert sim.session_held is True
+
+        # After the hold elapses with no traffic, the session auto-releases.
+        await asyncio.sleep(0.35)
+        assert sim.session_held is False
+        assert sim.last_release_reason == "keepalive_timeout"
+    finally:
+        await owner.close()
+
+
+async def test_busy_reject_while_inside_keepalive_hold(sim: MockIcomRadio) -> None:
+    """A fast relaunch inside the keepalive window still hits the held session."""
+    owner = await _client(0x10001)
+    newcomer = await _client(0x10002)
+    try:
+        await _claim(sim, owner)
+        await owner.close()  # socket goes silent, NO token-remove
+
+        # Still inside the hold -> the radio holds -> new owner is rejected.
+        await asyncio.sleep(0.05)
+        civ_port, error = await _claim(sim, newcomer)
+        assert civ_port == 0 and error == _ERR_PREV_SESSION_ACTIVE
+
+        # After the hold expires, the new owner can connect.
+        await asyncio.sleep(0.35)
+        civ_port2, error2 = await _claim(sim, newcomer)
+        assert error2 == _ERR_OK and civ_port2 == sim.civ_port
+    finally:
+        await newcomer.close()
+
+
+async def test_ping_refreshes_keepalive(sim: MockIcomRadio) -> None:
+    owner = await _client(0x10001)
+    try:
+        await _claim(sim, owner)
+        # Ping repeatedly within the hold to keep the session alive past it.
+        for _ in range(6):
+            owner.ping(sim.control_port)
+            await asyncio.sleep(0.1)
+        assert sim.session_held is True  # would have timed out at 0.3 without pings
+    finally:
+        await owner.close()
+
+
+async def test_token_renew_refreshes_keepalive(sim: MockIcomRadio) -> None:
+    owner = await _client(0x10001)
+    try:
+        await _claim(sim, owner)
+        for _ in range(6):
+            owner.token(sim.control_port, _TOKEN_RENEW)
+            await asyncio.sleep(0.1)
+        assert sim.session_held is True
+        assert sim.released_count == 0
+    finally:
+        await owner.close()
+
+
+# ---------------------------------------------------------------------------
+# 4. civ_port-unavailable knob (cooldown driver) — distinct from busy reject
+# ---------------------------------------------------------------------------
+
+
+async def test_force_civ_unavailable_returns_not_ready_then_recovers(
+    sim: MockIcomRadio,
+) -> None:
+    owner = await _client(0x10001)
+    try:
+        sim.force_civ_unavailable_for(0.2)
+        # Not-ready: civ_port=0 but error=0 (NOT a busy reject), no claim.
+        civ_port, error = await _claim(sim, owner)
+        assert civ_port == 0 and error == _ERR_OK
+        assert sim.session_held is False
+        assert sim.busy_rejects == 0
+
+        await asyncio.sleep(0.25)
+        # Now available -> claims and returns the real port.
+        civ_port2, error2 = await _claim(sim, owner)
+        assert error2 == _ERR_OK and civ_port2 == sim.civ_port
+        assert sim.session_held is True
+    finally:
+        await owner.close()
+
+
+# ---------------------------------------------------------------------------
+# 5. Fault-injection knobs
+# ---------------------------------------------------------------------------
+
+
+async def test_unsolicited_stream_emits_frames() -> None:
+    sim = MockIcomRadio(
+        single_owner=True,
+        keepalive_hold_s=5.0,
+        unsolicited_civ=True,
+        unsolicited_interval_s=0.02,
+    )
+    await sim.start()
+    c = await _client(0x10001)
+    try:
+        await _claim(sim, c)
+        # Open the data stream so the radio knows where to send unsolicited frames.
+        start_freq = sim._frequency
+        c.openclose(sim.civ_port, _OPENCLOSE_OPEN)
+        await asyncio.sleep(0.2)
+        assert sim.unsolicited_sent > 0
+        # Autonomous state evolution: frequency drifted.
+        assert sim._frequency > start_freq
+    finally:
+        await c.close()
+        await sim.stop()
+
+
+async def test_stall_for_suppresses_unsolicited_stream() -> None:
+    sim = MockIcomRadio(
+        single_owner=True,
+        keepalive_hold_s=5.0,
+        unsolicited_civ=True,
+        unsolicited_interval_s=0.02,
+    )
+    await sim.start()
+    c = await _client(0x10001)
+    try:
+        await _claim(sim, c)
+        c.openclose(sim.civ_port, _OPENCLOSE_OPEN)
+        await asyncio.sleep(0.1)
+        assert sim.unsolicited_sent > 0
+
+        # Stall: no frames should be emitted for the window.
+        sim.stall_for(0.3)
+        before = sim.unsolicited_sent
+        await asyncio.sleep(0.15)
+        assert sim.unsolicited_sent == before  # watchdog would trip here
+
+        # After the stall window, the stream resumes.
+        await asyncio.sleep(0.25)
+        assert sim.unsolicited_sent > before
+    finally:
+        await c.close()
+        await sim.stop()
+
+
+async def test_drop_rate_suppresses_unsolicited_frames() -> None:
+    sim = MockIcomRadio(
+        single_owner=True,
+        keepalive_hold_s=5.0,
+        unsolicited_civ=True,
+        unsolicited_interval_s=0.02,
+        drop_rate=1.0,
+    )
+    await sim.start()
+    c = await _client(0x10001)
+    try:
+        await _claim(sim, c)
+        c.openclose(sim.civ_port, _OPENCLOSE_OPEN)
+        await asyncio.sleep(0.15)
+        # Every unsolicited frame is dropped -> none counted as sent.
+        assert sim.unsolicited_sent == 0
+    finally:
+        await c.close()
+        await sim.stop()
+
+
+# ---------------------------------------------------------------------------
+# 6. Backwards-compat: single_owner=False keeps legacy always-allow behaviour
+# ---------------------------------------------------------------------------
+
+
+async def test_legacy_mode_never_rejects() -> None:
+    sim = MockIcomRadio()  # single_owner defaults to False
+    await sim.start()
+    a = await _client(0x10001)
+    b = await _client(0x10002)
+    try:
+        civ_a, err_a = await _claim(sim, a)
+        civ_b, err_b = await _claim(sim, b)
+        assert err_a == _ERR_OK and civ_a == sim.civ_port
+        assert err_b == _ERR_OK and civ_b == sim.civ_port  # no busy reject
+        assert sim.busy_rejects == 0
+        assert sim.session_held is False  # no session tracking in legacy mode
+    finally:
+        await a.close()
+        await b.close()
+        await sim.stop()
+
+
+# ---------------------------------------------------------------------------
+# 7. Slow near-real keepalive timing test (R3 / D7)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+async def test_near_real_keepalive_hold_releases() -> None:
+    """One non-accelerated case so acceleration cannot mask real timing bugs.
+
+    Uses a ~1.5 s hold (well under a real 45-60 s radio window but long enough
+    to exercise the wall-clock timer path without an accelerated value).
+    """
+    hold = 1.5
+    sim = MockIcomRadio(single_owner=True, keepalive_hold_s=hold)
+    await sim.start()
+    owner = await _client(0x10001)
+    newcomer = await _client(0x10002)
+    try:
+        await _claim(sim, owner)
+        await owner.close()  # silent drop, no graceful close
+
+        # Inside the hold: still held, foreign owner rejected.
+        await asyncio.sleep(hold * 0.5)
+        civ_port, error = await _claim(sim, newcomer)
+        assert civ_port == 0 and error == _ERR_PREV_SESSION_ACTIVE
+
+        # After the full hold: auto-released, foreign owner connects.
+        await asyncio.sleep(hold)
+        assert sim.session_held is False
+        civ_port2, error2 = await _claim(sim, newcomer)
+        assert error2 == _ERR_OK and civ_port2 == sim.civ_port
+    finally:
+        await newcomer.close()
+        await sim.stop()

--- a/tests/test_radio_connect.py
+++ b/tests/test_radio_connect.py
@@ -624,19 +624,31 @@ class TestConnectSessionRejection:
                 new=AsyncMock(),
             ),
             patch("rigplane._control_phase.asyncio.sleep", new=AsyncMock()),
+            patch.object(radio, "_fetch_initial_state", new=AsyncMock()),
         ):
-            await radio._control_phase.connect()
+            # Routed through the unified lifecycle (A3): a data-port discovery
+            # timeout surfaces as SESSION_NOT_READY → the resident runner
+            # RELEASES the partial attempt, then retries CONNECTING in-process.
+            # The second attempt succeeds.
+            await radio.connect()
 
+        # Two control connects (one per CONNECTING attempt).
         assert mt.connect_count == 2
-        assert mt.disconnect_count == 1
+        # The timed-out attempt's CI-V transport was torn down by the data-port
+        # cooldown cleanup.
         assert timeout_civ_transport.disconnect_count == 1
+        # Sockets consumed by asyncio (civ) are not double-closed; the unused
+        # audio socket from the timed-out attempt IS closed exactly once.
         assert first_civ_sock.close_count == 0
         assert first_audio_sock.close_count == 1
+        # The successful attempt's sockets are not closed (still in use).
         assert second_civ_sock.close_count == 0
         assert second_audio_sock.close_count == 0
         assert radio._civ_transport is success_civ_transport
         assert radio._civ_sock_pending is None
         assert radio._audio_sock_pending is second_audio_sock
+
+        await radio.disconnect()
 
     @pytest.mark.asyncio
     async def test_stereo_codec_fallback_succeeds(self) -> None:

--- a/tests/test_radio_coverage.py
+++ b/tests/test_radio_coverage.py
@@ -1482,7 +1482,17 @@ async def test_soft_reconnect_calls_on_reconnect_callback(
 
 
 async def test_soft_reconnect_handles_connect_failure(radio: IcomRadio) -> None:
-    """soft_reconnect() raises ConnectionError when transport.connect() fails (lines 444-447)."""
+    """soft_reconnect() surfaces a ConnectionError when transport.connect() fails.
+
+    After A4, ``radio.soft_reconnect`` routes through the unified lifecycle
+    RECOVERING loop, which is the SINGLE owner of recovery: it retries the
+    per-attempt rebuild (``soft_reconnect_once`` → ``_control_phase.
+    soft_reconnect``, which raises ``Failed to reconnect CI-V`` on transport
+    failure) up to ``_max_recovery_attempts`` times, then routes exhaustion
+    through CLOSING + release and raises ``Soft reconnect exhausted ...`` whose
+    ``__cause__`` is the underlying CI-V rebuild error.  (The CoreRadio
+    lifecycle uses zero recovery backoff so this stays fast.)
+    """
     from rigplane.transport import IcomTransport
 
     radio._civ_transport = None
@@ -1499,10 +1509,19 @@ async def test_soft_reconnect_handles_connect_failure(radio: IcomRadio) -> None:
     fake_transport = AsyncMock(spec=IcomTransport)
     fake_transport.connect = failing_connect
 
+    lifecycle = radio._session_lifecycle
+    attempts = lifecycle._max_recovery_attempts
+
     with patch("rigplane.transport.IcomTransport", return_value=fake_transport):
-        with pytest.raises(ConnectionError, match="Failed to reconnect CI-V"):
+        with pytest.raises(
+            ConnectionError, match="Soft reconnect exhausted"
+        ) as exc_info:
             await radio.soft_reconnect()
 
+    # Exhaustion wraps the underlying per-attempt CI-V rebuild failure.
+    assert "Failed to reconnect CI-V" in str(exc_info.value.__cause__)
+    # The lifecycle (single owner) ran every recovery attempt.
+    assert attempts >= 1
     assert radio._civ_transport is None
 
 

--- a/tests/test_radio_coverage.py
+++ b/tests/test_radio_coverage.py
@@ -311,7 +311,10 @@ async def test_soft_reconnect_already_open_stalled_rebuilds_not_frozen(
     with (
         caplog.at_level(logging.WARNING, logger="rigplane.runtime._control_phase"),
         patch.object(radio, "_force_cleanup_civ", side_effect=fake_force_cleanup),
-        patch.object(radio._control_phase, "connect", new=rebuilt),
+        # A3 deleted the legacy ControlPhaseRuntime.connect() retry wrapper; the
+        # ctrl-dead rebuild branch now does a single full-connect via
+        # ``_connect_once`` (the lifecycle owns retry).
+        patch.object(radio._control_phase, "_connect_once", new=rebuilt),
     ):
         await radio.soft_reconnect()
 
@@ -326,13 +329,18 @@ async def test_soft_reconnect_already_open_stalled_rebuilds_not_frozen(
 async def test_soft_reconnect_does_full_connect_when_ctrl_dead(
     radio: IcomRadio,
 ) -> None:
-    """soft_reconnect() falls back to full connect() when ctrl transport is dead."""
+    """soft_reconnect() falls back to a full connect when ctrl transport is dead.
+
+    A3 deleted the legacy ControlPhaseRuntime.connect() retry wrapper; the
+    ctrl-dead rebuild branch now does a single full-connect via ``_connect_once``
+    (the lifecycle owns retry).
+    """
     radio._civ_transport = None
     radio._ctrl_transport._udp_transport = None  # type: ignore[attr-defined]
 
     connect_mock = AsyncMock()
 
-    with patch.object(radio._control_phase, "connect", side_effect=connect_mock):
+    with patch.object(radio._control_phase, "_connect_once", side_effect=connect_mock):
         await radio.soft_reconnect()
 
     connect_mock.assert_awaited_once()

--- a/tests/test_reconnect.py
+++ b/tests/test_reconnect.py
@@ -211,10 +211,12 @@ class TestExternalCatSessionResetOnConnect:
         radio.begin_external_cat_session()
         assert radio.external_cat_session_active is True
 
-        # Drive connect() without hardware: stub the control-phase handshake and
-        # the initial-state fetch so only the reset behaviour under test runs.
+        # Drive connect() without hardware: stub the single-attempt handshake
+        # (``_connect_once``; A3 routes connect() through the lifecycle which
+        # drives the control-phase mechanism) and the initial-state fetch so
+        # only the reset behaviour under test runs.
         with (
-            patch.object(radio._control_phase, "connect", new_callable=AsyncMock),
+            patch.object(radio._control_phase, "_connect_once", new_callable=AsyncMock),
             patch.object(radio, "_fetch_initial_state", new_callable=AsyncMock),
         ):
             await radio.connect()
@@ -229,7 +231,7 @@ class TestExternalCatSessionResetOnConnect:
         """The reset is a no-op on a clean connect (no false-positive churn)."""
         assert radio.external_cat_session_active is False
         with (
-            patch.object(radio._control_phase, "connect", new_callable=AsyncMock),
+            patch.object(radio._control_phase, "_connect_once", new_callable=AsyncMock),
             patch.object(radio, "_fetch_initial_state", new_callable=AsyncMock),
         ):
             await radio.connect()

--- a/tests/test_session_lifecycle.py
+++ b/tests/test_session_lifecycle.py
@@ -601,3 +601,125 @@ async def test_status_snapshot_in_cooldown_has_countdown() -> None:
     await lc.disconnect()
     with pytest.raises(asyncio.CancelledError):
         await connect_task
+
+
+# ---------------------------------------------------------------------------
+# A3 — tests moved from tests/test_radio_connect.py, re-expressed against the
+# lifecycle (the legacy ControlPhaseRuntime.connect() retry wrapper they used to
+# exercise was deleted in A3; the cooldown-retry + release policy now lives
+# here).
+# ---------------------------------------------------------------------------
+
+
+async def test_data_port_not_ready_retries_in_process_then_connects() -> None:
+    """Moved from ``test_data_port_discovery_timeout_retries_*``.
+
+    A CI-V data-port discovery timeout surfaces as SESSION_NOT_READY; the
+    resident runner RELEASES the partial attempt, waits out the cooldown, then
+    retries CONNECTING in-process and connects on the second attempt — exactly
+    what the deleted ``connect()`` wrapper's ``_DATA_PORT_COOLDOWN_RETRIES``
+    loop did, but now release-before-cooldown.
+    """
+    lc, mech, events = make_lifecycle(max_connect_attempts=4)
+    mech.queue_not_ready()  # attempt 1: data-port discovery timeout
+    mech.queue_ok()  # attempt 2: succeeds
+
+    await lc.connect()
+    assert lc.state is LifecycleState.CONNECTED
+    assert mech.connect_calls == 2
+    # release ran before the second attempt (release-before-cooldown).
+    first_release = mech.ops.index("release")
+    second_connect = [i for i, op in enumerate(mech.ops) if op == "connect_attempt"][1]
+    assert first_release < second_connect, mech.ops
+    not_ready = [
+        e for e in events if e.reason is LifecycleErrorReason.SESSION_NOT_READY
+    ]
+    assert not_ready
+    await lc.disconnect()
+
+
+async def test_persistent_busy_reject_raises_after_resident_attempts() -> None:
+    """Moved from ``test_connect_raises_on_status_rejection_after_retries``.
+
+    A radio that persistently busy-rejects (0xFFFFFFFF) is retried in-process up
+    to ``max_connect_attempts`` (each attempt RELEASED first), then surfaces a
+    ConnectionError rather than spinning forever — and never holds a session.
+    """
+    lc, mech, _events = make_lifecycle(max_connect_attempts=3)
+    for _ in range(3):
+        mech.queue_busy_reject()
+
+    with pytest.raises(ConnectionError, match="never became ready"):
+        await lc.connect()
+
+    assert mech.connect_calls == 3  # bounded resident retry
+    # Every attempt released its partial claim (release-before-cooldown).
+    assert mech.release_calls >= 3
+    assert not mech.claimed
+    assert lc.state is LifecycleState.DISCONNECTED
+
+
+# ---------------------------------------------------------------------------
+# A2-verifier-recommended regressions (A3)
+# ---------------------------------------------------------------------------
+
+
+async def test_cancel_after_claim_still_releases() -> None:
+    """A cancel arriving AFTER the session is claimed still token-removes.
+
+    Models the SIGTERM/disconnect-mid-CONNECTING race: ``connect_attempt`` is
+    cancelled after auth succeeded (session claimed).  ``_attempt_with_release``
+    MUST release the (now-claimed) session before the CancelledError propagates,
+    so the token-remove always goes out (Note 2 — release must not be truncated
+    by the cancel).
+    """
+
+    class CancelAfterClaimMech(FakeMechanism):
+        async def connect_attempt(self) -> AttemptResult:
+            # Claim the session (auth success side-effect), THEN get cancelled
+            # before returning an outcome.
+            self.connect_calls += 1
+            self.ops.append("connect_attempt")
+            self.claimed = True
+            raise asyncio.CancelledError()
+
+    mech = CancelAfterClaimMech()
+    lc = CoreRadioSessionLifecycle(mechanism=mech)
+
+    with pytest.raises(asyncio.CancelledError):
+        await lc.connect()
+
+    # The claimed session was released (token-remove sent) despite the cancel.
+    assert mech.release_calls >= 1
+    assert not mech.claimed
+    # The op log proves release ran after the claim.
+    assert "release" in mech.ops
+    assert mech.ops.index("connect_attempt") < mech.ops.index("release")
+
+
+async def test_release_raising_does_not_crash_disconnect() -> None:
+    """A mechanism ``release()`` that raises must not crash ``disconnect()``.
+
+    The lifecycle swallows release errors in teardown and still ends in
+    DISCONNECTED, so a flaky/raising release never propagates out of
+    disconnect() (defensive graceful-close).
+    """
+
+    class ReleaseBoomMech(FakeMechanism):
+        async def release(self) -> None:
+            self.release_calls += 1
+            self.ops.append("release")
+            self.claimed = False
+            raise RuntimeError("release blew up")
+
+    mech = ReleaseBoomMech()
+    mech.queue_ok()
+    lc = CoreRadioSessionLifecycle(mechanism=mech)
+
+    await lc.connect()
+    assert lc.state is LifecycleState.CONNECTED
+
+    # disconnect() must NOT raise even though release() does.
+    await lc.disconnect()
+    assert lc.state is LifecycleState.DISCONNECTED
+    assert mech.release_calls >= 1

--- a/tests/test_session_lifecycle.py
+++ b/tests/test_session_lifecycle.py
@@ -1,0 +1,603 @@
+"""Unit tests for the RadioSessionLifecycle state machine (task A2).
+
+These tests drive the state machine through a *fake mechanism* — the policy
+layer (``RadioSessionLifecycle``) is decoupled from the packet mechanism
+(``ControlPhaseRuntime``) via the ``SessionMechanism`` protocol, so the state
+machine can be exercised deterministically without real sockets.
+
+They prove the design's governing invariants:
+
+* every connect-failure path RELEASES the claimed session (token-remove +
+  close) — graceful-close Holes 1, 2, 5, 8;
+* the cooldown path RELEASES first, THEN waits (no held session during the
+  wait) — the root-cause fix (Hole 4 / Cause A);
+* a ``0xFEFFFFFF`` auth-credentials failure HARD-FAILS (no resident retry,
+  D3);
+* state transitions + events are emitted with correct reasons / countdown
+  (D1 rich feedback);
+* ``__aexit__`` and ``disconnect()`` ALWAYS release;
+* SIGTERM-style ``request_shutdown()`` releases before returning (Hole 3).
+
+The fake mechanism follows the queued-response spirit of
+``tests/test_radio.py:MockTransport`` — outcomes are queued and consumed
+in order.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from rigplane.core.exceptions import AuthenticationError, ConnectionError
+from rigplane.runtime.session_lifecycle import (
+    AttemptOutcome,
+    AttemptResult,
+    CoreRadioSessionLifecycle,
+    LifecycleErrorReason,
+    LifecycleEvent,
+    LifecycleState,
+    RadioPresence,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Fake mechanism — queued per-attempt outcomes; records release calls
+# ---------------------------------------------------------------------------
+
+
+class FakeMechanism:
+    """A queued-outcome stand-in for ``ControlPhaseRuntime`` (the mechanism).
+
+    Each ``connect_attempt()`` pops one queued :class:`AttemptResult`.  The
+    mechanism records whether a release obligation is currently outstanding
+    (``claimed``) and counts ``release()`` / ``soft_reconnect_once()`` calls so
+    tests can assert release-on-every-exit.
+    """
+
+    def __init__(self) -> None:
+        self._outcomes: list[AttemptResult] = []
+        self.connect_calls = 0
+        self.release_calls = 0
+        self.soft_reconnect_calls = 0
+        self.scan_calls = 0
+        # True between a successful/partial claim and its release.
+        self.claimed = False
+        # Configurable scan result and soft-reconnect behaviour.
+        self._scan_result: list[RadioPresence] = []
+        self._soft_reconnect_failures = 0
+        # Records the order of mechanism operations for ordering assertions.
+        self.ops: list[str] = []
+
+    def queue_outcome(self, result: AttemptResult) -> None:
+        self._outcomes.append(result)
+
+    def queue_ok(self) -> None:
+        self.queue_outcome(AttemptResult(AttemptOutcome.CONNECTED))
+
+    def queue_not_ready(self) -> None:
+        self.queue_outcome(AttemptResult(AttemptOutcome.SESSION_NOT_READY))
+
+    def queue_busy_reject(self) -> None:
+        self.queue_outcome(AttemptResult(AttemptOutcome.SESSION_BUSY_REJECT))
+
+    def queue_auth_fail(self) -> None:
+        self.queue_outcome(AttemptResult(AttemptOutcome.AUTH_CREDENTIALS))
+
+    def queue_exception(self, exc: BaseException) -> None:
+        self.queue_outcome(AttemptResult(AttemptOutcome.CONNECTED, raises=exc))
+
+    def set_scan_result(self, presences: list[RadioPresence]) -> None:
+        self._scan_result = presences
+
+    def set_soft_reconnect_failures(self, n: int) -> None:
+        self._soft_reconnect_failures = n
+
+    # -- mechanism protocol ------------------------------------------------
+
+    async def connect_attempt(self) -> AttemptResult:
+        self.connect_calls += 1
+        self.ops.append("connect_attempt")
+        if not self._outcomes:
+            raise AssertionError("FakeMechanism ran out of queued outcomes")
+        result = self._outcomes.pop(0)
+        # A claim happens on auth success, which for the fake is any outcome
+        # except a pre-auth-style AUTH_CREDENTIALS reject.  CONNECTED/
+        # NOT_READY/BUSY_REJECT all imply auth succeeded → session claimed.
+        if result.outcome is not AttemptOutcome.AUTH_CREDENTIALS:
+            self.claimed = True
+        if result.raises is not None:
+            raise result.raises
+        return result
+
+    async def release(self) -> None:
+        self.release_calls += 1
+        self.ops.append("release")
+        self.claimed = False
+
+    async def soft_reconnect_once(self) -> None:
+        self.soft_reconnect_calls += 1
+        self.ops.append("soft_reconnect_once")
+        if self._soft_reconnect_failures > 0:
+            self._soft_reconnect_failures -= 1
+            raise ConnectionError("soft reconnect failed (fake)")
+
+    async def scan(
+        self, targets: list[str] | None, *, timeout: float
+    ) -> list[RadioPresence]:
+        self.scan_calls += 1
+        self.ops.append("scan")
+        return list(self._scan_result)
+
+
+def make_lifecycle(
+    mech: FakeMechanism | None = None,
+    **kwargs: object,
+) -> tuple[CoreRadioSessionLifecycle, FakeMechanism, list[LifecycleEvent]]:
+    """Build a lifecycle with a fast (near-zero) cooldown for deterministic tests."""
+    mech = mech or FakeMechanism()
+    lc = CoreRadioSessionLifecycle(
+        mechanism=mech,
+        not_ready_cooldown_s=0.0,
+        reject_cooldown_s=0.0,
+        max_recovery_attempts=3,
+        recovery_backoff_s=(0.0, 0.0, 0.0),
+        **kwargs,  # type: ignore[arg-type]
+    )
+    events: list[LifecycleEvent] = []
+    lc.add_event_listener(events.append)
+    return lc, mech, events
+
+
+# ---------------------------------------------------------------------------
+# Initial state / observable surface
+# ---------------------------------------------------------------------------
+
+
+async def test_initial_state_is_disconnected() -> None:
+    lc, _mech, _events = make_lifecycle()
+    assert lc.state is LifecycleState.DISCONNECTED
+    assert lc.status.state is LifecycleState.DISCONNECTED
+    assert lc.status.last_error is LifecycleErrorReason.NONE
+
+
+# ---------------------------------------------------------------------------
+# T1 — clean connect → disconnect, NO cooldown; release on disconnect
+# ---------------------------------------------------------------------------
+
+
+async def test_clean_connect_then_disconnect_releases_no_cooldown() -> None:
+    lc, mech, events = make_lifecycle()
+    mech.queue_ok()
+
+    await lc.connect()
+    assert lc.state is LifecycleState.CONNECTED
+    assert mech.connect_calls == 1
+    # No cooldown should have been entered on a clean connect.
+    assert not any(e.to_state is LifecycleState.COOLDOWN for e in events)
+
+    await lc.disconnect()
+    assert lc.state is LifecycleState.DISCONNECTED
+    # Release (token-remove + close) happened on disconnect.
+    assert mech.release_calls >= 1
+    assert not mech.claimed
+    # Transition events present.
+    states = [(e.from_state, e.to_state) for e in events]
+    assert (LifecycleState.DISCONNECTED, LifecycleState.CONNECTING) in states
+    assert (LifecycleState.CONNECTING, LifecycleState.CONNECTED) in states
+    assert any(e.to_state is LifecycleState.CLOSING for e in events)
+    assert events[-1].to_state is LifecycleState.DISCONNECTED
+
+
+# ---------------------------------------------------------------------------
+# Hole 1 / 5 / 8 — post-auth/pre-CONNECTED exception still releases
+# ---------------------------------------------------------------------------
+
+
+async def test_exception_after_claim_releases_session() -> None:
+    lc, mech, _events = make_lifecycle()
+    boom = RuntimeError("post-auth explosion")
+    mech.queue_exception(boom)
+
+    with pytest.raises(RuntimeError, match="post-auth explosion"):
+        await lc.connect()
+
+    # The claim was registered (auth side-effect of the fake) and MUST be
+    # released even though the attempt raised mid-way (Hole 1).
+    assert mech.release_calls >= 1
+    assert not mech.claimed
+    assert lc.state is LifecycleState.DISCONNECTED
+
+
+# ---------------------------------------------------------------------------
+# Hole 2 — __aenter__ raises before __aexit__ still releases
+# ---------------------------------------------------------------------------
+
+
+async def test_aenter_failure_releases_via_context_manager() -> None:
+    lc, mech, _events = make_lifecycle()
+    mech.queue_exception(RuntimeError("connect blew up in aenter"))
+
+    with pytest.raises(RuntimeError):
+        async with lc:
+            pytest.fail("body must not run when __aenter__ raises")  # pragma: no cover
+
+    assert mech.release_calls >= 1
+    assert not mech.claimed
+    assert lc.state is LifecycleState.DISCONNECTED
+
+
+async def test_aexit_always_releases_on_clean_path() -> None:
+    lc, mech, _events = make_lifecycle()
+    mech.queue_ok()
+
+    async with lc as entered:
+        assert entered is lc
+        assert lc.state is LifecycleState.CONNECTED
+    assert lc.state is LifecycleState.DISCONNECTED
+    assert mech.release_calls >= 1
+    assert not mech.claimed
+
+
+async def test_aexit_releases_even_when_body_raises() -> None:
+    lc, mech, _events = make_lifecycle()
+    mech.queue_ok()
+
+    with pytest.raises(ValueError, match="body error"):
+        async with lc:
+            raise ValueError("body error")
+    assert lc.state is LifecycleState.DISCONNECTED
+    assert mech.release_calls >= 1
+    assert not mech.claimed
+
+
+# ---------------------------------------------------------------------------
+# Hole 4 / Cause A — cooldown RELEASES first, THEN waits, THEN retries
+# ---------------------------------------------------------------------------
+
+
+async def test_not_ready_releases_before_cooldown_then_connects() -> None:
+    lc, mech, events = make_lifecycle()
+    mech.queue_not_ready()  # first attempt: civ_port == 0
+    mech.queue_ok()  # retry succeeds
+
+    await lc.connect()
+    assert lc.state is LifecycleState.CONNECTED
+    assert mech.connect_calls == 2
+
+    # The CRITICAL invariant: release happened BEFORE the cooldown wait, i.e.
+    # the session was NOT held during the cooldown.  In the op log, the first
+    # release must precede the second connect_attempt.
+    first_release = mech.ops.index("release")
+    second_connect = [i for i, op in enumerate(mech.ops) if op == "connect_attempt"][1]
+    assert first_release < second_connect, mech.ops
+    assert not mech.claimed or lc.state is LifecycleState.CONNECTED
+
+    # A COOLDOWN transition was emitted with the not-ready reason + countdown.
+    cooldown_events = [e for e in events if e.to_state is LifecycleState.COOLDOWN]
+    assert cooldown_events
+    assert cooldown_events[0].reason is LifecycleErrorReason.SESSION_NOT_READY
+    assert cooldown_events[0].cooldown_remaining_s is not None
+
+
+async def test_busy_reject_releases_before_cooldown_then_connects() -> None:
+    lc, mech, events = make_lifecycle()
+    mech.queue_busy_reject()  # first attempt: 0xFFFFFFFF
+    mech.queue_ok()
+
+    await lc.connect()
+    assert lc.state is LifecycleState.CONNECTED
+    assert mech.connect_calls == 2
+    cooldown_events = [e for e in events if e.to_state is LifecycleState.COOLDOWN]
+    assert cooldown_events
+    assert cooldown_events[0].reason is LifecycleErrorReason.SESSION_BUSY_REJECT
+    # release-before-wait ordering
+    first_release = mech.ops.index("release")
+    second_connect = [i for i, op in enumerate(mech.ops) if op == "connect_attempt"][1]
+    assert first_release < second_connect, mech.ops
+
+
+# ---------------------------------------------------------------------------
+# D3 — hard-fail on 0xFEFFFFFF (auth credentials); NO resident retry
+# ---------------------------------------------------------------------------
+
+
+async def test_auth_credentials_hard_fails_no_retry() -> None:
+    lc, mech, events = make_lifecycle()
+    mech.queue_auth_fail()
+    # Even if a follow-up OK were queued, it must NOT be consumed.
+    mech.queue_ok()
+
+    with pytest.raises(AuthenticationError):
+        await lc.connect()
+
+    assert mech.connect_calls == 1  # no retry
+    assert lc.state is LifecycleState.DISCONNECTED
+    assert lc.status.last_error is LifecycleErrorReason.AUTH_CREDENTIALS
+    # Even a pre-claim auth failure must not leave a held session.
+    assert not mech.claimed
+    closing = [e for e in events if e.to_state is LifecycleState.CLOSING]
+    assert closing
+    assert closing[-1].reason is LifecycleErrorReason.AUTH_CREDENTIALS
+
+
+# ---------------------------------------------------------------------------
+# disconnect() idempotency
+# ---------------------------------------------------------------------------
+
+
+async def test_disconnect_on_idle_is_noop() -> None:
+    lc, mech, _events = make_lifecycle()
+    await lc.disconnect()  # never connected
+    assert lc.state is LifecycleState.DISCONNECTED
+    assert mech.release_calls == 0  # nothing claimed → nothing to release
+
+
+async def test_double_disconnect_is_idempotent() -> None:
+    lc, mech, _events = make_lifecycle()
+    mech.queue_ok()
+    await lc.connect()
+    await lc.disconnect()
+    releases_after_first = mech.release_calls
+    await lc.disconnect()
+    assert lc.state is LifecycleState.DISCONNECTED
+    # Second disconnect releases nothing new.
+    assert mech.release_calls == releases_after_first
+
+
+# ---------------------------------------------------------------------------
+# T9 — concurrent / duplicate connect coalesced
+# ---------------------------------------------------------------------------
+
+
+async def test_concurrent_connect_coalesced_single_session() -> None:
+    lc, mech, _events = make_lifecycle()
+
+    started = asyncio.Event()
+
+    class SlowMech(FakeMechanism):
+        async def connect_attempt(self) -> AttemptResult:
+            started.set()
+            await asyncio.sleep(0.02)
+            return await super().connect_attempt()
+
+    slow = SlowMech()
+    slow.queue_ok()
+    lc2, _m, _e = make_lifecycle(mech=slow)
+
+    t1 = asyncio.create_task(lc2.connect())
+    await started.wait()
+    t2 = asyncio.create_task(lc2.connect())
+    await asyncio.gather(t1, t2)
+
+    assert lc2.state is LifecycleState.CONNECTED
+    # Exactly one attempt — the second connect coalesced onto the first.
+    assert slow.connect_calls == 1
+    await lc2.disconnect()
+
+
+# ---------------------------------------------------------------------------
+# disconnect() during cooldown cancels the resident runner → CLOSING + release
+# ---------------------------------------------------------------------------
+
+
+async def test_disconnect_during_cooldown_cancels_and_releases() -> None:
+    mech = FakeMechanism()
+    mech.queue_not_ready()
+    # Use a long cooldown so we can interrupt it mid-wait.
+    lc = CoreRadioSessionLifecycle(
+        mechanism=mech,
+        not_ready_cooldown_s=10.0,
+        reject_cooldown_s=10.0,
+    )
+    events: list[LifecycleEvent] = []
+    lc.add_event_listener(events.append)
+
+    connect_task = asyncio.create_task(lc.connect())
+    # Wait until we are in COOLDOWN (release already happened).
+    for _ in range(200):
+        if lc.state is LifecycleState.COOLDOWN:
+            break
+        await asyncio.sleep(0.005)
+    assert lc.state is LifecycleState.COOLDOWN
+    assert mech.release_calls >= 1  # released BEFORE the wait
+
+    await lc.disconnect()
+    with pytest.raises(asyncio.CancelledError):
+        await connect_task
+    assert lc.state is LifecycleState.DISCONNECTED
+    assert not mech.claimed
+
+
+# ---------------------------------------------------------------------------
+# SIGTERM-style graceful shutdown (Hole 3) — releases before returning
+# ---------------------------------------------------------------------------
+
+
+async def test_request_shutdown_releases_session() -> None:
+    lc, mech, events = make_lifecycle()
+    mech.queue_ok()
+    await lc.connect()
+    assert lc.state is LifecycleState.CONNECTED
+
+    await lc.request_shutdown()
+    assert lc.state is LifecycleState.DISCONNECTED
+    assert mech.release_calls >= 1
+    assert not mech.claimed
+
+
+async def test_request_shutdown_during_cooldown_releases() -> None:
+    mech = FakeMechanism()
+    mech.queue_not_ready()
+    lc = CoreRadioSessionLifecycle(
+        mechanism=mech,
+        not_ready_cooldown_s=10.0,
+        reject_cooldown_s=10.0,
+    )
+    connect_task = asyncio.create_task(lc.connect())
+    for _ in range(200):
+        if lc.state is LifecycleState.COOLDOWN:
+            break
+        await asyncio.sleep(0.005)
+    assert lc.state is LifecycleState.COOLDOWN
+
+    await lc.request_shutdown()
+    with pytest.raises(asyncio.CancelledError):
+        await connect_task
+    assert lc.state is LifecycleState.DISCONNECTED
+    assert not mech.claimed
+
+
+# ---------------------------------------------------------------------------
+# T6 — scan() opens NO session, does not disturb ownership
+# ---------------------------------------------------------------------------
+
+
+async def test_scan_opens_no_session() -> None:
+    lc, mech, events = make_lifecycle()
+    mech.set_scan_result([RadioPresence(host="192.168.1.10", remote_id=0xDEADBEEF)])
+    result = await lc.scan()
+    assert result == [RadioPresence(host="192.168.1.10", remote_id=0xDEADBEEF)]
+    # scan must never claim a session or release one.
+    assert not mech.claimed
+    assert mech.release_calls == 0
+    assert "connect_attempt" not in mech.ops
+    assert lc.state is LifecycleState.DISCONNECTED
+    # SCANNING transitions emitted around the probe.
+    assert any(e.to_state is LifecycleState.SCANNING for e in events)
+
+
+async def test_scan_while_connected_does_not_disturb_session() -> None:
+    lc, mech, _events = make_lifecycle()
+    mech.queue_ok()
+    await lc.connect()
+    mech.set_scan_result([])
+    await lc.scan()
+    # Still connected; no release happened from scan.
+    assert lc.state is LifecycleState.CONNECTED
+    assert mech.release_calls == 0
+    await lc.disconnect()
+
+
+# ---------------------------------------------------------------------------
+# T7 / T8 — soft_reconnect: RECOVERING → CONNECTED, control+token reused
+# ---------------------------------------------------------------------------
+
+
+async def test_soft_reconnect_recovers_to_connected() -> None:
+    lc, mech, events = make_lifecycle()
+    mech.queue_ok()
+    await lc.connect()
+
+    await lc.soft_reconnect()
+    assert lc.state is LifecycleState.CONNECTED
+    assert mech.soft_reconnect_calls == 1
+    # No new login (no second connect_attempt) — control + token reused.
+    assert mech.connect_calls == 1
+    recovering = [e for e in events if e.to_state is LifecycleState.RECOVERING]
+    assert recovering
+    assert recovering[0].recovery_attempt == 1
+    assert recovering[0].recovery_max == 3
+    await lc.disconnect()
+
+
+async def test_soft_reconnect_retries_then_recovers() -> None:
+    lc, mech, events = make_lifecycle()
+    mech.queue_ok()
+    await lc.connect()
+    mech.set_soft_reconnect_failures(2)  # fail twice, succeed on 3rd
+
+    await lc.soft_reconnect()
+    assert lc.state is LifecycleState.CONNECTED
+    assert mech.soft_reconnect_calls == 3
+    attempts = [
+        e.recovery_attempt
+        for e in events
+        if e.to_state is LifecycleState.RECOVERING and e.recovery_attempt is not None
+    ]
+    assert attempts == [1, 2, 3]
+    await lc.disconnect()
+
+
+# ---------------------------------------------------------------------------
+# T11 — recovery exhaustion → CLOSING + full release
+# ---------------------------------------------------------------------------
+
+
+async def test_recovery_exhaustion_closes_and_releases() -> None:
+    lc, mech, events = make_lifecycle()
+    mech.queue_ok()
+    await lc.connect()
+    mech.set_soft_reconnect_failures(99)  # never recovers
+
+    with pytest.raises(ConnectionError):
+        await lc.soft_reconnect()
+
+    assert mech.soft_reconnect_calls == 3  # max_recovery_attempts
+    assert lc.state is LifecycleState.DISCONNECTED
+    assert mech.release_calls >= 1  # full release through CLOSING
+    assert not mech.claimed
+    closing = [e for e in events if e.to_state is LifecycleState.CLOSING]
+    assert closing
+    assert closing[-1].reason is LifecycleErrorReason.RECOVERY_EXHAUSTED
+
+
+# ---------------------------------------------------------------------------
+# D1 — event listener add/remove + exceptions swallowed
+# ---------------------------------------------------------------------------
+
+
+async def test_listener_add_remove_idempotent() -> None:
+    lc, mech, _events = make_lifecycle()
+    seen: list[LifecycleEvent] = []
+    cb = seen.append
+    lc.add_event_listener(cb)
+    lc.add_event_listener(cb)  # duplicate ignored
+    mech.queue_ok()
+    await lc.connect()
+    before = len(seen)
+    assert before > 0
+    lc.remove_event_listener(cb)
+    lc.remove_event_listener(cb)  # double-remove no-op
+    await lc.disconnect()
+    assert len(seen) == before  # no events after removal
+
+
+async def test_listener_exception_is_swallowed() -> None:
+    lc, mech, _events = make_lifecycle()
+
+    def boom(_e: LifecycleEvent) -> None:
+        raise RuntimeError("listener blew up")
+
+    lc.add_event_listener(boom)
+    mech.queue_ok()
+    # Must not propagate the listener error.
+    await lc.connect()
+    assert lc.state is LifecycleState.CONNECTED
+    await lc.disconnect()
+
+
+async def test_status_snapshot_in_cooldown_has_countdown() -> None:
+    mech = FakeMechanism()
+    mech.queue_not_ready()
+    lc = CoreRadioSessionLifecycle(
+        mechanism=mech,
+        not_ready_cooldown_s=10.0,
+        reject_cooldown_s=10.0,
+    )
+    connect_task = asyncio.create_task(lc.connect())
+    for _ in range(200):
+        if lc.state is LifecycleState.COOLDOWN:
+            break
+        await asyncio.sleep(0.005)
+    snap = lc.status
+    assert snap.state is LifecycleState.COOLDOWN
+    assert snap.cooldown_total_s == 10.0
+    assert snap.cooldown_remaining_s is not None
+    assert 0.0 <= snap.cooldown_remaining_s <= 10.0
+    assert snap.last_error is LifecycleErrorReason.SESSION_NOT_READY
+    await lc.disconnect()
+    with pytest.raises(asyncio.CancelledError):
+        await connect_task

--- a/tests/test_session_lifecycle_e2e.py
+++ b/tests/test_session_lifecycle_e2e.py
@@ -67,8 +67,11 @@ from rigplane.runtime.session_lifecycle import (
 )
 
 from _perf_helpers import fast_connect
-from conftest import FAST_KEEPALIVE_HOLD_S
 from mock_server import _PT_DATA, MockIcomRadio
+
+# Mirror of the constant defined in tests/conftest.py — imported locally to
+# avoid a conftest shadowing issue when pytest collects tests/integration/ too.
+FAST_KEEPALIVE_HOLD_S: float = 0.5
 
 pytestmark = pytest.mark.asyncio
 

--- a/tests/test_session_lifecycle_e2e.py
+++ b/tests/test_session_lifecycle_e2e.py
@@ -597,9 +597,10 @@ async def test_t11_recovery_exhaustion_closes_and_releases(
     nothing is left held.
 
     This drives ``CoreRadioSessionLifecycle.soft_reconnect`` (the stateful
-    RECOVERING loop) directly; ``CoreRadio.soft_reconnect`` deliberately uses a
-    single-attempt mechanism call (the data watchdog owns the outer retry loop)
-    — see FINDINGS in the task report."""
+    RECOVERING loop) directly.  After A4 this is the SINGLE owner of recovery:
+    ``CoreRadio.soft_reconnect`` now routes here too, and the CI-V data watchdog
+    only DETECTS the stall and triggers this loop (it no longer owns the
+    retry/backoff/exhaustion ladder)."""
     sim = single_owner_radio
     sim.keepalive_hold_s = 10.0
     radio = _make_radio(sim)

--- a/tests/test_session_lifecycle_e2e.py
+++ b/tests/test_session_lifecycle_e2e.py
@@ -1,0 +1,659 @@
+"""End-to-end session-lifecycle matrix (T1-T12) vs the IC-7610 simulator.
+
+Unlike ``test_mock_icom_session.py`` (which drives the *simulator* with hand-built
+packets) and ``test_session_lifecycle.py`` (which unit-tests the *policy* layer
+with a fake mechanism), this file drives the **real production stack** end-to-end
+over real UDP::
+
+    CoreRadio.connect/disconnect/soft_reconnect
+        -> CoreRadioSessionLifecycle (policy: CONNECTING<->COOLDOWN, release,
+           RECOVERING, SIGTERM)
+        -> ControlPhaseSessionMechanism (adapter)
+        -> ControlPhaseRuntime._connect_once / release / soft_reconnect (packet I/O)
+        -> IcomTransport (UDP)
+        -> single_owner MockIcomRadio
+
+Every test asserts against the **simulator's** observed wire state/counters
+(``session_held``, ``released_count``, ``last_release_reason``, ``busy_rejects``,
+``owner``) — i.e. real wire behaviour — not merely CoreRadio attributes.  This is
+what proves the lifecycle fixes the original IC-7610 connect livelock: a
+non-graceful abort leaves the radio holding its single session (T2), the fix
+guarantees a release before every retry so a fresh / resident connect succeeds
+with no ``0xFFFFFFFF`` busy reject and no livelock (T1/T3/T4).
+
+T-number map (design 2026-06-22 radio-session-lifecycle, adapted):
+
+* T1  — clean connect->disconnect frees the radio FREE (no cooldown); immediate
+        reconnect succeeds, ``busy_rejects == 0``.
+* T2  — protocol-level bug repro (control): a foreign owner holds the session ->
+        a fresh connect within the keepalive window gets ``0xFFFFFFFF`` busy.
+        Documents the FAILURE mode the fix prevents.
+* T3  — THE FIX (crown proof): a post-claim transient on the first attempt STILL
+        releases the radio before COOLDOWN, then a resident retry SUCCEEDS with
+        no busy reject and no livelock; release happens before the retry.
+* T4  — resident cooldown-aware retry: ``force_civ_unavailable_for`` -> civ_port=0
+        not-ready -> the lifecycle waits & retries IN-PROCESS, one CoreRadio,
+        ``busy_rejects == 0``, single owner throughout.
+* T5  — auth hard-fail (0xFEFFFFFF): AuthenticationError, exactly ONE attempt
+        (no retry), session released.
+* T6  — SIGTERM / shutdown: ``request_shutdown`` releases the radio before exit.
+* T7  — data-watchdog recovery (stall): the watchdog trips and recovers; CI-V
+        resumes; no stale / second session (slow).
+* T8  — soft_reconnect recovery: reuses the SAME session (no new owner, no busy);
+        CI-V resumes.
+* T9  — concurrent/duplicate connect coalesces to ONE session.
+* T10 — fleet / second-owner: a genuine foreign owner while held -> busy reject;
+        graceful switch (foreign closes -> we connect) works with no busy.
+* T11 — recovery exhaustion: lifecycle soft_reconnect exhausts -> CLOSING +
+        release, no held session left.
+* T12 — fault injection (drop_rate): connect still succeeds / recovers; no stale
+        session.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import struct
+
+import pytest
+
+from rigplane.exceptions import AuthenticationError
+from rigplane.exceptions import ConnectionError as RigplaneConnectionError
+from rigplane.radio import IcomRadio
+from rigplane.runtime.session_lifecycle import (
+    AttemptOutcome,
+    AttemptResult,
+    LifecycleState,
+)
+
+from _perf_helpers import fast_connect
+from conftest import FAST_KEEPALIVE_HOLD_S
+from mock_server import _PT_DATA, MockIcomRadio
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_radio(sim: MockIcomRadio) -> IcomRadio:
+    """A real CoreRadio/IcomRadio pointed at the simulator's control port."""
+    return IcomRadio(
+        host="127.0.0.1",
+        port=sim.control_port,
+        username="testuser",
+        password="testpass",
+        timeout=5.0,
+    )
+
+
+async def _connect(radio: IcomRadio) -> None:
+    """Connect through the real lifecycle with handshake sleeps fast-pathed."""
+    with fast_connect():
+        await radio.connect()
+
+
+class _ForeignOwner:
+    """A raw UDP client that claims and HOLDS the simulator's single session.
+
+    It claims by sending a real conninfo (0x90, requesttype 0x03) so the
+    simulator marks ``(remote_addr, sender_id)`` as the owner, then keeps the
+    session alive by re-sending conninfo on a cadence inside the keepalive
+    window — modelling a genuinely-foreign client that won't let go.
+    """
+
+    def __init__(self, sender_id: int) -> None:
+        self.sender_id = sender_id
+        self._transport: asyncio.DatagramTransport | None = None
+        self._proto: _ForeignOwner._Proto | None = None
+        self._keepalive_task: asyncio.Task[None] | None = None
+
+    class _Proto(asyncio.DatagramProtocol):
+        def __init__(self) -> None:
+            self.queue: asyncio.Queue[bytes] = asyncio.Queue()
+
+        def datagram_received(self, data: bytes, addr: tuple[str, int]) -> None:
+            self.queue.put_nowait(data)
+
+    def _conninfo_pkt(self) -> bytes:
+        pkt = bytearray(0x90)
+        struct.pack_into("<I", pkt, 0x00, 0x90)
+        struct.pack_into("<H", pkt, 0x04, _PT_DATA)
+        struct.pack_into("<I", pkt, 0x08, self.sender_id)
+        pkt[0x15] = 0x03
+        return bytes(pkt)
+
+    async def claim(self, ctrl_port: int) -> tuple[int, int]:
+        loop = asyncio.get_running_loop()
+        transport, proto = await loop.create_datagram_endpoint(
+            lambda: _ForeignOwner._Proto(),
+            local_addr=("127.0.0.1", 0),
+        )
+        self._transport = transport
+        self._proto = proto
+        transport.sendto(self._conninfo_pkt(), ("127.0.0.1", ctrl_port))
+        reply = await asyncio.wait_for(proto.queue.get(), timeout=1.0)
+        error = struct.unpack_from("<I", reply, 0x30)[0]
+        civ_port = struct.unpack_from(">H", reply, 0x42)[0]
+        return civ_port, error
+
+    def start_keepalive(self, ctrl_port: int, interval_s: float = 0.1) -> None:
+        async def _loop() -> None:
+            assert self._transport is not None
+            try:
+                while True:
+                    self._transport.sendto(
+                        self._conninfo_pkt(), ("127.0.0.1", ctrl_port)
+                    )
+                    await asyncio.sleep(interval_s)
+            except asyncio.CancelledError:
+                raise
+
+        self._keepalive_task = asyncio.get_running_loop().create_task(_loop())
+
+    async def release_and_close(self, ctrl_port: int) -> None:
+        """Graceful foreign close: send a DISCONNECT (frees the session) + close."""
+        if self._keepalive_task is not None:
+            self._keepalive_task.cancel()
+            try:
+                await self._keepalive_task
+            except asyncio.CancelledError:
+                pass
+            self._keepalive_task = None
+        if self._transport is not None:
+            # Type 0x05 DISCONNECT for our owner -> simulator frees immediately.
+            pkt = bytearray(0x10)
+            struct.pack_into("<I", pkt, 0x00, 0x10)
+            struct.pack_into("<H", pkt, 0x04, 0x05)
+            struct.pack_into("<I", pkt, 0x08, self.sender_id)
+            self._transport.sendto(bytes(pkt), ("127.0.0.1", ctrl_port))
+            await asyncio.sleep(0.02)
+            self._transport.close()
+            self._transport = None
+
+    async def close(self) -> None:
+        if self._keepalive_task is not None:
+            self._keepalive_task.cancel()
+            try:
+                await self._keepalive_task
+            except asyncio.CancelledError:
+                pass
+            self._keepalive_task = None
+        if self._transport is not None:
+            self._transport.close()
+            self._transport = None
+
+
+# ---------------------------------------------------------------------------
+# T1 — clean connect -> disconnect leaves the radio FREE (no cooldown)
+# ---------------------------------------------------------------------------
+
+
+async def test_t1_clean_disconnect_frees_radio_and_allows_immediate_reconnect(
+    single_owner_radio: MockIcomRadio,
+) -> None:
+    """A graceful connect/disconnect releases the single session immediately
+    on the wire; an IMMEDIATE reconnect succeeds with NO busy reject."""
+    sim = single_owner_radio
+    radio = _make_radio(sim)
+    await _connect(radio)
+
+    assert radio.connected
+    assert sim.session_held is True
+    assert sim.busy_rejects == 0
+
+    await radio.disconnect()
+    await asyncio.sleep(0.05)  # let the release packets land on the sim
+
+    # The radio is FREE on the wire — released immediately, not after a cooldown.
+    assert sim.session_held is False
+    assert sim.released_count >= 1
+    assert sim.last_release_reason in ("openclose_close", "token_remove", "disconnect")
+
+    # An IMMEDIATE reconnect (inside what would be the keepalive window) succeeds
+    # with no 0xFFFFFFFF busy reject — the original livelock cannot occur.
+    radio2 = _make_radio(sim)
+    await _connect(radio2)
+    assert radio2.connected
+    assert sim.session_held is True
+    assert sim.busy_rejects == 0
+
+    await radio2.disconnect()
+
+
+# ---------------------------------------------------------------------------
+# T2 — protocol-level bug repro (the FAILURE mode the fix prevents)
+# ---------------------------------------------------------------------------
+
+
+async def test_t2_foreign_held_session_busy_rejects_fresh_connect(
+    single_owner_radio: MockIcomRadio,
+) -> None:
+    """Control case: a foreign owner holds the single session, so a fresh real
+    connect within the keepalive window is rejected with 0xFFFFFFFF (busy).
+
+    This documents the livelock's root cause at the protocol level: a session
+    held by someone-else means the radio will not allocate a CI-V port until
+    the hold expires.  The fix (T1/T3) guarantees *our own* aborts never leave
+    the radio in this state."""
+    sim = single_owner_radio
+    foreign = _ForeignOwner(sender_id=0xABCDEF01)
+    civ_port, error = await foreign.claim(sim.control_port)
+    assert civ_port == sim.civ_port and error == 0
+    assert sim.session_held is True
+    # Hold the session open across our connect attempt.
+    foreign.start_keepalive(sim.control_port, interval_s=0.1)
+
+    radio = _make_radio(sim)
+    # One-shot, zero cooldown: the lifecycle must surface the busy reject rather
+    # than spinning, because the foreign owner never lets go.
+    radio._session_lifecycle._max_connect_attempts = 2
+    radio._session_lifecycle._reject_cooldown_s = 0.0
+
+    try:
+        with pytest.raises((RigplaneConnectionError, asyncio.TimeoutError)):
+            with fast_connect():
+                await asyncio.wait_for(radio.connect(), timeout=2.0)
+    finally:
+        # The bug signature: the radio sent at least one 0xFFFFFFFF busy reject,
+        # and the session is still held by the FOREIGN owner (not us).
+        assert sim.busy_rejects >= 1
+        assert sim.owner is not None and sim.owner[1] == 0xABCDEF01
+        await foreign.close()
+        # Our failed connect must still tear down cleanly (idempotent).
+        await radio.disconnect()
+
+
+# ---------------------------------------------------------------------------
+# T3 — THE FIX (crown proof): release-before-retry, resident, no livelock
+# ---------------------------------------------------------------------------
+
+
+async def test_t3_aborted_attempt_releases_then_resident_retry_succeeds(
+    single_owner_radio: MockIcomRadio,
+) -> None:
+    """Crown proof — the real lifecycle eliminates the livelock end-to-end.
+
+    The first connect attempt genuinely CLAIMS the session on the sim (auth
+    succeeds), then fails transiently.  The lifecycle MUST release that claim on
+    the wire *before* the cooldown/retry, so the resident next attempt re-claims
+    cleanly with NO 0xFFFFFFFF busy reject.  We assert (a) a release happened
+    before the retry connected, and (b) the retry connected — both against the
+    simulator's wire counters."""
+    sim = single_owner_radio
+    radio = _make_radio(sim)
+
+    events: list[tuple[str, str, str]] = []
+    radio._session_lifecycle.add_event_listener(
+        lambda e: events.append((e.from_state.value, e.to_state.value, e.reason.value))
+    )
+
+    mech = radio._session_mechanism
+    real_attempt = mech.connect_attempt
+    state = {"n": 0, "released_after_claim": None}
+
+    async def first_transient_then_real() -> AttemptResult:
+        state["n"] += 1
+        if state["n"] == 1:
+            # Run the REAL attempt so auth actually claims the session on the
+            # sim, then inject a post-claim transient outcome.  The lifecycle's
+            # ``_attempt_with_release`` must RELEASE before returning.
+            result = await real_attempt()
+            assert result.outcome is AttemptOutcome.CONNECTED
+            assert sim.session_held is True  # genuinely claimed on the wire
+            return AttemptResult(AttemptOutcome.SESSION_BUSY_REJECT)
+        # Snapshot the wire state the instant the retry attempt begins: the
+        # release must already have happened (no held session, no busy reject).
+        state["released_after_claim"] = (sim.released_count, sim.busy_rejects)
+        return await real_attempt()
+
+    mech.connect_attempt = first_transient_then_real  # type: ignore[method-assign]
+
+    with fast_connect():
+        await radio.connect()
+
+    # The fix worked end-to-end: connected, two attempts, ZERO busy rejects.
+    assert radio.connected
+    assert state["n"] == 2
+    assert sim.busy_rejects == 0
+    assert sim.session_held is True
+
+    # Release happened BEFORE the retry: at retry-start the sim had already freed
+    # the first claim and recorded no busy reject.
+    assert state["released_after_claim"] is not None
+    released_at_retry, busy_at_retry = state["released_after_claim"]
+    assert released_at_retry >= 1
+    assert busy_at_retry == 0
+
+    # The event stream proves the release-before-retry ordering:
+    # CONNECTING -> COOLDOWN(busy) -> CONNECTING -> CONNECTED.
+    assert ("connecting", "cooldown", "session_busy_reject") in events
+    assert ("cooldown", "connecting", "none") in events
+    assert events[-1] == ("connecting", "connected", "none")
+
+    await radio.disconnect()
+
+
+# ---------------------------------------------------------------------------
+# T4 — resident cooldown-aware retry, no livelock (civ_port=0 not-ready)
+# ---------------------------------------------------------------------------
+
+
+async def test_t4_force_civ_unavailable_resident_retry_recovers(
+    single_owner_radio: MockIcomRadio,
+) -> None:
+    """``force_civ_unavailable_for`` returns civ_port=0 (not-ready, error=0 — NOT
+    a busy reject).  The lifecycle releases (no-op: nothing claimed), waits, and
+    retries IN-PROCESS within one CoreRadio until the sim recovers — single
+    owner throughout, ``busy_rejects == 0``, no process restart, no livelock."""
+    sim = single_owner_radio
+    sim.force_civ_unavailable_for(0.4)
+
+    radio = _make_radio(sim)
+    # Pace the resident retries past the unavailable window in-process.
+    radio._session_lifecycle._not_ready_cooldown_s = 0.15
+    radio._session_lifecycle._max_connect_attempts = 30
+
+    await _connect(radio)
+
+    assert radio.connected
+    assert sim.session_held is True
+    assert sim.busy_rejects == 0
+    owner_id = sim.owner[1] if sim.owner else None
+
+    await radio.disconnect()
+    await asyncio.sleep(0.05)
+    assert sim.session_held is False
+    # Single owner the entire time (the same identity that finally claimed).
+    assert owner_id is not None
+
+
+# ---------------------------------------------------------------------------
+# T5 — auth hard-fail (0xFEFFFFFF): no retry, session released
+# ---------------------------------------------------------------------------
+
+
+async def test_t5_auth_hard_fail_no_retry_session_released(
+    single_owner_radio: MockIcomRadio,
+) -> None:
+    """A 0xFEFFFFFF credential rejection is a hard fail: AuthenticationError is
+    raised after exactly ONE attempt (no resident retry), and no session is
+    left held on the wire."""
+    sim = single_owner_radio
+    sim.auth_fail = True
+
+    radio = _make_radio(sim)
+    attempts = {"n": 0}
+    real_attempt = radio._session_mechanism.connect_attempt
+
+    async def counted() -> AttemptResult:
+        attempts["n"] += 1
+        return await real_attempt()
+
+    radio._session_mechanism.connect_attempt = counted  # type: ignore[method-assign]
+
+    with fast_connect():
+        with pytest.raises(AuthenticationError):
+            await radio.connect()
+
+    assert attempts["n"] == 1  # NO retry on a hard credential failure
+    assert sim.session_held is False
+    assert sim.busy_rejects == 0
+
+
+# ---------------------------------------------------------------------------
+# T6 — SIGTERM / shutdown mid-session -> radio free
+# ---------------------------------------------------------------------------
+
+
+async def test_t6_request_shutdown_releases_radio(
+    single_owner_radio: MockIcomRadio,
+) -> None:
+    """The SIGTERM-style ``request_shutdown`` hook releases the single session
+    (token-remove + OpenClose-close) before the process would exit — no leak."""
+    sim = single_owner_radio
+    radio = _make_radio(sim)
+    await _connect(radio)
+    assert sim.session_held is True
+
+    # The awaitable graceful-close hook the CLI signal handler must call.
+    await radio._session_lifecycle.request_shutdown()
+    # Mirror CoreRadio.disconnect()'s fallback for a still-live control phase.
+    if radio.connected:
+        await radio._control_phase.disconnect()
+    await asyncio.sleep(0.05)
+
+    assert sim.session_held is False
+    assert sim.released_count >= 1
+    assert sim.last_release_reason in ("openclose_close", "token_remove", "disconnect")
+
+
+# ---------------------------------------------------------------------------
+# T7 — data-watchdog recovery (stall) — slow (wall-clock > 2s watchdog timeout)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+async def test_t7_data_watchdog_recovers_after_stall(
+    single_owner_radio: MockIcomRadio,
+) -> None:
+    """A CI-V stall trips the data watchdog; its OpenClose(open)-based recovery
+    resumes the stream while reusing the SAME single session — no stale or
+    second session, ``busy_rejects == 0``.
+
+    The radio streams unsolicited CI-V; ``stall_for`` starves it past the 2 s
+    watchdog timeout, then the watchdog's patient OpenClose recovery re-arms the
+    stream (the sim re-emits a frame on each OpenClose(open))."""
+    sim = single_owner_radio
+    sim.keepalive_hold_s = 10.0  # keep the session well past the stall window
+    sim.unsolicited_civ = True
+    sim.unsolicited_interval_s = 0.05
+    # Start the now-enabled unsolicited stream task.
+    sim._unsolicited_task = asyncio.get_running_loop().create_task(
+        sim._unsolicited_loop()
+    )
+
+    radio = _make_radio(sim)
+    await _connect(radio)
+    owner_before = sim.owner[1] if sim.owner else None
+
+    sim.stall_for(3.0)  # > 2 s watchdog timeout -> trips recovery
+    await asyncio.sleep(4.0)  # trip + OpenClose recovery + stream resume
+
+    assert radio.connected
+    # CI-V is alive again and the session was never re-claimed by a new owner.
+    freq = await radio.get_freq()
+    assert isinstance(freq, int)
+    assert sim.session_held is True
+    assert sim.owner is not None and sim.owner[1] == owner_before
+    assert sim.busy_rejects == 0
+
+    await radio.disconnect()
+
+
+# ---------------------------------------------------------------------------
+# T8 — soft_reconnect reuses the SAME session (no new session, no busy)
+# ---------------------------------------------------------------------------
+
+
+async def test_t8_soft_reconnect_reuses_session_no_stale(
+    unsolicited_radio: MockIcomRadio,
+) -> None:
+    """``soft_reconnect`` rebuilds the CI-V data path while reusing the existing
+    control session + token: the simulator sees the SAME owner throughout (no
+    new claim, no 0xFFFFFFFF), and CI-V resumes after recovery."""
+    sim = unsolicited_radio
+    sim.keepalive_hold_s = 10.0  # outlive the soft-reconnect window
+    radio = _make_radio(sim)
+    await _connect(radio)
+
+    owner_before = sim.owner[1] if sim.owner else None
+    released_before = sim.released_count
+    freq_before = await radio.get_freq()
+
+    await radio.soft_reconnect()
+    await asyncio.sleep(0.15)  # let unsolicited CI-V resume
+
+    assert radio.connected
+    assert sim.session_held is True
+    assert sim.owner is not None and sim.owner[1] == owner_before
+    # No graceful release happened in the middle (the session is reused, not
+    # re-established with a new login).
+    assert sim.released_count == released_before
+    assert sim.busy_rejects == 0
+    freq_after = await radio.get_freq()
+    assert freq_after >= freq_before  # autonomous drift -> CI-V is flowing again
+
+    await radio.disconnect()
+
+
+# ---------------------------------------------------------------------------
+# T9 — concurrent / duplicate connect coalesces to ONE session
+# ---------------------------------------------------------------------------
+
+
+async def test_t9_concurrent_connect_coalesces_to_one_session(
+    single_owner_radio: MockIcomRadio,
+) -> None:
+    """Three concurrent ``connect()`` calls on the same CoreRadio coalesce onto
+    a single in-flight attempt: the simulator sees ONE owner and ZERO busy
+    rejects (a second claim would otherwise self-reject)."""
+    sim = single_owner_radio
+    radio = _make_radio(sim)
+
+    with fast_connect():
+        await asyncio.gather(radio.connect(), radio.connect(), radio.connect())
+
+    assert radio.connected
+    assert sim.session_held is True
+    assert sim.owner is not None
+    assert sim.busy_rejects == 0  # no duplicate claim raced into a self-reject
+
+    await radio.disconnect()
+
+
+# ---------------------------------------------------------------------------
+# T10 — fleet / second-owner: foreign hold busies; graceful switch works
+# ---------------------------------------------------------------------------
+
+
+async def test_t10_foreign_owner_busy_then_graceful_switch(
+    single_owner_radio: MockIcomRadio,
+) -> None:
+    """Single-owner enforcement plus a clean handover.
+
+    Phase 1: a genuine foreign owner holds the session -> our connect is
+    rejected with 0xFFFFFFFF while the foreign owner persists.
+    Phase 2: the foreign owner closes gracefully (frees the session) -> our
+    connect then succeeds with no further busy reject (clean switch)."""
+    sim = single_owner_radio
+    foreign = _ForeignOwner(sender_id=0x0BADF00D)
+    _, error = await foreign.claim(sim.control_port)
+    assert error == 0 and sim.session_held is True
+    foreign.start_keepalive(sim.control_port, interval_s=0.1)
+
+    # Phase 1: held by foreign -> our one-shot connect is busy-rejected.
+    radio = _make_radio(sim)
+    radio._session_lifecycle._max_connect_attempts = 1
+    radio._session_lifecycle._reject_cooldown_s = 0.0
+    with pytest.raises((RigplaneConnectionError, asyncio.TimeoutError)):
+        with fast_connect():
+            await asyncio.wait_for(radio.connect(), timeout=1.5)
+    assert sim.busy_rejects >= 1
+    assert sim.owner is not None and sim.owner[1] == 0x0BADF00D
+
+    # Phase 2: graceful switch — foreign closes first, then we open.
+    await foreign.release_and_close(sim.control_port)
+    await asyncio.sleep(0.05)
+    assert sim.session_held is False
+
+    busy_after_phase1 = sim.busy_rejects
+    radio2 = _make_radio(sim)
+    await _connect(radio2)
+    assert radio2.connected
+    assert sim.session_held is True
+    assert sim.owner is not None and sim.owner[1] != 0x0BADF00D
+    # The clean switch added NO new busy rejects.
+    assert sim.busy_rejects == busy_after_phase1
+
+    await radio2.disconnect()
+
+
+# ---------------------------------------------------------------------------
+# T11 — recovery exhaustion -> CLOSING + release (no held session left)
+# ---------------------------------------------------------------------------
+
+
+async def test_t11_recovery_exhaustion_closes_and_releases(
+    single_owner_radio: MockIcomRadio,
+) -> None:
+    """When the lifecycle's stateful recovery exhausts every attempt it routes
+    through CLOSING with a full release: the simulator session is freed and
+    nothing is left held.
+
+    This drives ``CoreRadioSessionLifecycle.soft_reconnect`` (the stateful
+    RECOVERING loop) directly; ``CoreRadio.soft_reconnect`` deliberately uses a
+    single-attempt mechanism call (the data watchdog owns the outer retry loop)
+    — see FINDINGS in the task report."""
+    sim = single_owner_radio
+    sim.keepalive_hold_s = 10.0
+    radio = _make_radio(sim)
+    await _connect(radio)
+    assert sim.session_held is True
+
+    lifecycle = radio._session_lifecycle
+    lifecycle._recovery_backoff_s = (0.0, 0.0, 0.0)  # no wall-clock backoff
+
+    async def always_fail() -> None:
+        raise RigplaneConnectionError("injected CI-V rebuild failure")
+
+    lifecycle._mech.soft_reconnect_once = always_fail  # type: ignore[method-assign]
+
+    with pytest.raises(RigplaneConnectionError):
+        await lifecycle.soft_reconnect()
+    await asyncio.sleep(0.05)
+
+    assert lifecycle.state is LifecycleState.DISCONNECTED
+    assert sim.session_held is False  # released on exhaustion
+    assert sim.released_count >= 1
+
+
+# ---------------------------------------------------------------------------
+# T12 — fault injection (drop_rate): connect succeeds, no stale session
+# ---------------------------------------------------------------------------
+
+
+async def test_t12_connect_under_packet_loss_no_stale_session() -> None:
+    """With a lossy link (``drop_rate``) the real connect still succeeds (the
+    transport's retransmit + the lifecycle's within-attempt retries absorb the
+    loss) and the simulator ends with a single clean owner — no stale session.
+
+    A dedicated lossy simulator is used (the shared fixtures are loss-free)."""
+    sim = MockIcomRadio(
+        single_owner=True,
+        keepalive_hold_s=FAST_KEEPALIVE_HOLD_S * 6,  # outlive a few retries
+        drop_rate=0.25,
+    )
+    await sim.start()
+    try:
+        radio = _make_radio(sim)
+        radio._session_lifecycle._max_connect_attempts = 30
+        radio._session_lifecycle._not_ready_cooldown_s = 0.1
+
+        with fast_connect():
+            await asyncio.wait_for(radio.connect(), timeout=8.0)
+
+        assert radio.connected
+        assert sim.session_held is True
+        owner_id = sim.owner[1] if sim.owner else None
+        assert owner_id is not None
+
+        await radio.disconnect()
+        await asyncio.sleep(0.05)
+        # No stale session: a clean release left the radio free.
+        assert sim.session_held is False
+        assert sim.released_count >= 1
+    finally:
+        await sim.stop()

--- a/uv.lock
+++ b/uv.lock
@@ -2125,7 +2125,7 @@ wheels = [
 
 [[package]]
 name = "rigplane"
-version = "2.10.8"
+version = "2.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- Introduces `RadioSessionLifecycle` — a new public SDK state machine that owns connect / disconnect / scan / recovery as a single unified unit, with guaranteed graceful session close (token-remove + OpenClose) on every exit path.
- Fixes the IC-7610 LAN connect livelock: failed connects now always release the held session before any cooldown wait, eliminating the cross-process restart storm that hit error 0xFFFFFFFF ("previous session active").
- Unifies recovery under the lifecycle: the CI-V data-watchdog detects stalls only; the lifecycle owns retry / backoff / exhaustion. `CoreRadio.soft_reconnect()` is now multi-attempt and releases the session on exhaustion.

## Changelog (2.11.0)

### Added

**Unified radio session lifecycle.** New `RadioSessionLifecycle` (public SDK) owns connect / disconnect / scan / recovery as one state machine with a guaranteed graceful session close (token-remove + OpenClose) on every exit path, plus a rich observable event/status surface (state transitions, cooldown countdown, error reasons, recovery events). New blessed public symbols: `RadioSessionLifecycle`, `LifecycleState`, `LifecycleErrorReason`, `RadioPresence`, `LifecycleEvent`, `LifecycleStatus`.

### Fixed

**IC-7610 LAN connect livelock.** A failed network-CI-V connect now always releases the held session (token-remove) before any cooldown wait, and retry is cooldown-aware and resident in-process — eliminating the previous cross-process restart storm that reopened UDP 50001 inside the radio's keepalive window and got rejected with error 0xFFFFFFFF ("previous session active"). Graceful connect/disconnect now leaves the radio immediately free (no cooldown).

### Changed

**Recovery unified + soft_reconnect semantics.** CI-V data-watchdog now only DETECTS stalls; the lifecycle owns retry/backoff/exhaustion (preserving the #1217 anti-freeze: detached recovery, self-cancel guard, unconditional re-arm). `CoreRadio.soft_reconnect()` is now multi-attempt and releases the session on exhaustion (previously a single non-releasing attempt) — direct callers already handle the connection-error raise.

## Boundary

**open-core** — all new symbols are in the public `rigplane` SDK.

## New public SDK symbols

| Symbol | Module |
| --- | --- |
| `RadioSessionLifecycle` | `rigplane.session` |
| `LifecycleState` | `rigplane.session` |
| `LifecycleErrorReason` | `rigplane.session` |
| `RadioPresence` | `rigplane.session` |
| `LifecycleEvent` | `rigplane.session` |
| `LifecycleStatus` | `rigplane.session` |

## Behaviour change note (soft_reconnect)

`CoreRadio.soft_reconnect()` now performs multiple reconnect attempts (bounded by the lifecycle's retry policy) and releases the session token on exhaustion, then raises `ConnectionError`. Previously it made a single attempt without releasing the session. All known call sites in rigplane-pro already catch `ConnectionError` from `soft_reconnect` — no caller changes required.

## Design docs

- `docs/architecture/2026-06-22-radio-session-lifecycle.md` — full design, state diagram, livelock analysis, public API contract.

## Verification

- **Fast test suite:** 8319 passed, 0 failed (`uv run pytest -m "not slow" -q`)
- **End-to-end T1-T12 matrix:** IC-7610 simulator covers all session-lifecycle transitions including livelock repro + fix
- **mypy --strict src/rigplane/web:** clean (0 errors)
- **ruff check .:** All checks passed
- **lint-imports (import-linter):** 5/5 contracts KEPT
- **Phases independently reviewed PASS:** A1 (IC-7610 simulator), A2 (RadioSessionLifecycle SM), A3 (CoreRadio routing + legacy retry drop), A4 (recovery unification), B (T1-T12 e2e matrix)

## Downstream

This unblocks the rigplane-pro beta.9 connect-reliability work — Pro will pin `rigplane>=2.11.0` and consume `RadioSessionLifecycle` directly for its connect UX flow.