### PR TITLE
fix(MOR-934): AudioSession declarative reconciler — fixes TX-only strand after reconnect (#1226, #1212)

### DIFF
--- a/docs/architecture/2026-06-22-audio-session-reconciler-PLAN.md
+++ b/docs/architecture/2026-06-22-audio-session-reconciler-PLAN.md
@@ -1,0 +1,356 @@
+# AudioSession reconciler refactor — executable, test-first implementation plan (Option B)
+
+**Date:** 2026-06-22
+**Status:** approved-design implementation plan (read-only on production code; builder agent executes)
+**Scope:** `rigplane-core` — `src/rigplane/audio/session.py` only (+ test files)
+**Boundary:** **open-core.** Generic LAN/USB audio TX state machine and recovery. No licensing/commercial/customer logic. The public demand API (`subscribe_rx` / `acquire_tx` / `TxLease.push` / `reestablish`) is unchanged.
+**Primary input:** `docs/architecture/2026-06-22-audio-session-state-architecture.md` (the architectural verdict — read it first).
+**Decision:** Option B (FIXED). Do not relitigate Options A or C.
+
+---
+
+## A. Plain-language restatement (the thermostat)
+
+Make `AudioSession` a real reconciler. **Desired state is a pure function of declared intent** — `_desired(rx_demand, tx_demand, recovery)` reads only the demand counters, never its own `self._state`; holding a `TxLease` *is* TX demand, so `(0 RX, >0 TX)` always means `TX_ONLY` on a full-duplex transport. **Every edge** (acquire, release, subscribe, push, mode-change, recovery/`reestablish`) computes desired, then calls **one idempotent `_converge()`** that drives the transport to that desired state, diffing against the **observed transport leg liveness** (not a remembered `self._state` that can lie after a transport rebuild). `push` **converges** the session to the armed state instead of **rejecting** when TX is demanded but not yet armed. The six scattered arming branches collapse into this single owner; the live-hardware-validated MOR-556/559/574 arming order moves *inside* `_converge()` unchanged.
+
+---
+
+## B. Target design, concretely
+
+### B.1 The new `_desired()` — pure, inputs explicit, no self-state read
+
+Replace the current `_desired()` (`session.py:407-426`, including the `self._state is TX_ONLY` latch at line 421) with a pure function over the demand counters plus a per-transport capability flag. It MUST NOT read `self._state`.
+
+```python
+def _desired(self) -> AudioSessionState:
+    """Desired session state — a PURE function of declared demand.
+
+    Inputs (all read from demand counters, NEVER from self._state):
+      rx = self.rx_demand  (len(self._rx_subs))
+      tx = self.tx_demand  (len(self._tx_leases))
+      full_duplex = self._setup_order() == "rx_first"
+
+    | rx | tx | full_duplex | desired  |
+    |----|----|-------------|----------|
+    |  0 |  0 |  any        | IDLE     |
+    | >0 |  0 |  any        | RX_ONLY  |
+    | >0 | >0 |  any        | RX_TX    |
+    |  0 | >0 |  True       | TX_ONLY  |   <- was IDLE-unless-latched (the bug)
+    |  0 | >0 |  False      | IDLE     |   <- exclusive/atomic USB keeps deferring
+    """
+    rx = bool(self._rx_subs)
+    tx = bool(self._tx_leases)
+    if rx and tx:
+        return AudioSessionState.RX_TX
+    if rx:
+        return AudioSessionState.RX_ONLY
+    if tx and self._setup_order() == "rx_first":
+        return AudioSessionState.TX_ONLY
+    return AudioSessionState.IDLE
+```
+
+**The single behavioural change:** `(0 RX, >0 TX)` on a `rx_first` transport now returns `TX_ONLY` **unconditionally** — the `self._state is TX_ONLY` latch is deleted. TX-intent is first-class: a held `TxLease` is TX demand. The exclusive/atomic row (`(0 RX, >0 TX) → IDLE`) preserves today's "exclusive USB defers tx-only" behaviour (Open Question Q4 resolution: keep deferring; do NOT define a TX-only mode for exclusive transports in this refactor).
+
+`RECOVERING` and `FAILED` are **never returned by `_desired()`** — they are transient/transport-owned overlays handled exactly as today (see B.6).
+
+### B.2 The new `_converge()` — idempotent, reconciles against observed transport
+
+`_converge()` becomes the **only** function that calls `start_rx` / `stop_rx` / `start_tx` / `stop_tx` / `restart_rx`. Called under the lock by every demand mutation, by `push`, and by `reestablish`.
+
+It diffs `_desired()` against the **observed transport leg liveness**, not against `self._state`. Observed liveness:
+
+- **RX leg live** ⇔ `self._bus.rx_active` (the bus is the single source of truth for the RX leg, already used by `_arm_rx` and `reestablish`).
+- **TX leg live** ⇔ `self._tx_leg_live()` — a new tiny observer that reads the transport's observed TX state. Because the production transport (`IcomAudioStream`, `lan_stream.py:78`) and every test double expose a coarse state, read it via a duck-typed helper:
+  ```python
+  def _tx_leg_live(self) -> bool:
+      # Observed transport TX state, never self._state. Works against the
+      # production stream (AudioState.TRANSMITTING) and the test doubles
+      # (LanLikeRadio.state == "transmitting", ExclusiveUsbRadio.tx_running).
+      st = getattr(self._radio, "state", None)
+      if st is not None:
+          return str(getattr(st, "value", st)).lower() == "transmitting"
+      return bool(getattr(self._radio, "tx_running", False))
+  ```
+  This makes convergence recovery-safe by construction: after `soft_reconnect` rebuilds the LAN stream to RECEIVING/idle, `_tx_leg_live()` correctly reports `False`, so `_converge()` re-arms TX even though `self._state` may still say `TX_ONLY`.
+
+Shape:
+
+```python
+async def _converge(self, *, closing_rx: RxSubscription | None = None) -> None:
+    """Drive the transport to _desired(). Idempotent; the SOLE arming site.
+
+    Reconciles against OBSERVED transport leg liveness (bus.rx_active and
+    _tx_leg_live()), never against self._state — so it is correct after a
+    transport rebuild (reestablish) and after any prior partial transition.
+    Preserves the MOR-556/559/574 ordering via _setup_order() (see B.3).
+    """
+    desired = self._desired()
+    order = self._setup_order()
+
+    if desired is AudioSessionState.IDLE:
+        # Teardown: TX down BEFORE RX (MOR-574), then drop RX subs.
+        if self._tx_leg_live():
+            await self._disarm_tx()
+        await self._drop_rx(closing_rx)
+        self._state = AudioSessionState.IDLE
+
+    elif desired is AudioSessionState.TX_ONLY:
+        # Full-duplex, TX demand, no RX. Shed any RX first (TX-down then
+        # RX-drop if a TX leg is up — MOR-574), then arm TX alone.
+        if self._rx_subs or closing_rx is not None:
+            if self._tx_leg_live():
+                await self._disarm_tx()
+            await self._drop_rx(closing_rx)
+        await self._ensure_tx_live()           # idempotent start_tx
+        self._state = AudioSessionState.TX_ONLY
+
+    elif desired is AudioSessionState.RX_ONLY:
+        if self._tx_leg_live():
+            await self._disarm_tx()             # MOR-574: TX down before RX work
+            if order in _REARM_RX_AFTER_TX_DROP:
+                await self._bus.restart_rx()
+        else:
+            await self._arm_rx()                # may raise → caller unwinds
+        self._state = AudioSessionState.RX_ONLY
+
+    else:  # RX_TX
+        await self._enter_rx_tx(order)          # the preserved ordering, B.3
+        self._state = AudioSessionState.RX_TX
+
+    self._emit_convergence(desired)             # observability hook, B.5
+```
+
+Helper `_ensure_tx_live()` wraps the `start_tx` + `AudioAlreadyStartedError` swallow used today in three places:
+
+```python
+async def _ensure_tx_live(self) -> None:
+    if self._tx_leg_live():
+        return
+    try:
+        await self._radio.start_tx()
+    except AudioAlreadyStartedError:
+        logger.debug("audio-session: TX already live on converge", exc_info=True)
+```
+
+`_arm_rx`, `_disarm_tx`, `_drop_rx`, `_enter_rx_tx` are **kept** (they already encode ordering and unwinding correctly). `_converge()` is the new single caller of them on the demand path.
+
+### B.3 Where the MOR-556/559/574 ordering moves — exact quote and destination
+
+The ordering is **load-bearing and live-hardware-validated** (IC-7610 / FTX-1). It is NOT changed — it moves verbatim into `_enter_rx_tx` (already its home) and the teardown branch of `_converge()`.
+
+**Current `RX_TX` entry order — `_enter_rx_tx` (`session.py:500-561`), preserved exactly:**
+
+- `TX_ONLY → RX_TX` (full-duplex, TX up, RX arriving): `stop_tx` → `start_rx` → `start_tx` (`session.py:510-513`).
+- `IDLE → RX_TX`, `rx_first`: `start_rx` → `start_tx` (`session.py:520-523`).
+- `IDLE → RX_TX`, `tx_first`/`atomic`: `start_tx` → `start_rx`, unwind `stop_tx` on RX failure (`session.py:531-546`).
+- `RX_ONLY → RX_TX`, `rx_first`: `start_tx` (RX already up) (`session.py:548`).
+- `RX_ONLY → RX_TX`, `tx_first`/`atomic`: `stop_rx` → `start_tx` → `restart_rx` (the MOR-559 live-validated order) (`session.py:556-560`).
+
+**Current teardown order — `_reconcile` IDLE branch (`session.py:494-498`), preserved:** `_disarm_tx` (TX down BEFORE RX drops — the MOR-574 lesson) → `_drop_rx`.
+
+**Where it goes:** `_enter_rx_tx` keeps its body **unchanged** except its signature drops the `current: AudioSessionState` parameter and instead derives the entry sub-case from **observed** liveness (`self._bus.rx_active`, `self._tx_leg_live()`) so it is correct after a rebuild. The mapping is mechanical:
+
+| Old `current` discriminator | New observed-liveness discriminator |
+|---|---|
+| `current is TX_ONLY` | `self._tx_leg_live() and not self._bus.rx_active` |
+| `current is IDLE` | `not self._tx_leg_live() and not self._bus.rx_active` |
+| `current is RX_ONLY` (rx_first) | `self._bus.rx_active and not self._tx_leg_live()` (order `rx_first`) |
+| `current is RX_ONLY` (atomic) | `self._bus.rx_active and not self._tx_leg_live()` (order != `rx_first`) |
+
+The actual `start_*`/`stop_*` call sequences inside each branch are **copied without modification**. This is the highest-risk edit (Risk §E); the order-assertion tests (`test_rx_first_order_honored_on_lan_graph`, `test_atomic_order_honored_on_exclusive_graph`, `test_atomic_order_no_minus_50_on_strict_fake`, `test_teardown_stops_tx_before_rx`) are the regression harness and MUST stay green unchanged.
+
+### B.4 The TX-intent input surface
+
+TX-intent is modelled as **the `TxLease` demand counter, made first-class in `_desired()`** (drop the latch). No new field is required for the core fix. Concretely:
+
+- **Lease acquire** (`acquire_tx`, `session.py:327`): already appends to `self._tx_leases`. This IS the "TX intended" signal. Keep it; route through `_converge()`.
+- **Frame arrival / push** (`TxLease.push`, `session.py:193`): a push with a held, unreleased lease that finds the transport not transmitting calls `_converge()` (which arms TX) instead of `_ensure_tx_for_push`'s IDLE-only guard. This makes "TX frame arriving" an idempotent demand pulse that **converges, never rejects**.
+- **CAT-PTT path:** in `rigplane-core`, CAT PTT is asserted by the radio control layer, not by `AudioSession`; the session learns TX intent through the lease the companion bridge / web TX handler holds while PTT is asserted. **Full CAT-PTT plumbing into the session is OUT OF SCOPE for this refactor** (it is a larger cross-layer change and would widen the session contract — Open Question Q3). The minimal clean input surface that satisfies decision #3 is: **the lease carries TX-intent, and `push` converges.** This makes I1 unconditionally true and makes the failing interaction representable in tests (B-test §D.6) without a new production field. If a future issue wants the session to *know* PTT is keyed before any audio frame arrives, add an explicit `note_tx_intent()` pulse that calls `_converge()` — designed-for but not built here.
+
+### B.5 Code to DELETE and what each edge collapses into
+
+| Deleted / collapsed | Lines | Collapses into |
+|---|---|---|
+| `_ensure_tx_for_push` (whole method) | `session.py:348-376` | `push` → `_converge()` (B.6 push) |
+| `_desired()` `TX_ONLY` self-state latch | `session.py:421-422` | pure `_desired()` (B.1) |
+| `_reconcile` `TX_ONLY` demand-edge branch | `session.py:473-493` | `_converge()` `TX_ONLY` branch (B.2) |
+| `reestablish` `TX_ONLY` branch (the band-aid `ad7737ce`) | `session.py:624-640` | `reestablish` → `_converge()` (B.6) |
+| `reestablish` bespoke RX/TX re-arm body | `session.py:641-668` | `reestablish` → `_converge()` (B.6) |
+| `_reconcile` method (replaced) | `session.py:446-498` | `_converge()` (B.2) |
+| `_enter_rx_tx(order, current)` signature | `session.py:500-501` | `_enter_rx_tx(order)` reading observed liveness (B.3) |
+| `_try_rearm_tx` | `session.py:670-685` | folded into `_ensure_tx_live()` (B.2) — best-effort TX is now convergence-internal |
+
+`_apply()` (`session.py:438-444`) is **renamed/retargeted** to call `_converge()` instead of `_reconcile()` (it keeps its `_recovering_from` reset + `_sync_watchdog()` finally wrapper). Demand mutators (`subscribe_rx`, `acquire_tx`, `_release_rx`, `_release_tx`) keep calling `self._apply(...)`; only the body it dispatches to changes.
+
+**Net effect:** six arming decision sites (`_ensure_tx_for_push`, `_reconcile`'s TX_ONLY branch, `_enter_rx_tx`'s TX_ONLY re-arm, `reestablish`'s TX_ONLY branch, `reestablish`'s RX/TX body, `_try_rearm_tx`) → **one** (`_converge`, which delegates RX_TX ordering to `_enter_rx_tx`).
+
+### B.6 How each edge becomes "compute desired → converge"
+
+- **`acquire_tx`** (`session.py:327`): append lease → `await self._apply()` (→ `_converge`). With `(0 RX, >0 TX)` on full-duplex this now **eagerly arms TX** (decision #2 — eager arming; no wait for first push). Failure unwinds the lease (keep the existing try/except unwind).
+- **`subscribe_rx` / `_release_rx` / `_release_tx`**: unchanged call sites; `_apply` → `_converge`. `_release_rx` still passes `closing_rx=sub` so TX-down-before-RX ordering holds (MOR-574).
+- **`push`** (`TxLease.push`, `session.py:193`): replace `await self._session._ensure_tx_for_push()` with `await self._session._converge_for_push()`:
+  ```python
+  async def _converge_for_push(self) -> None:
+      async with self._lock:
+          if self._tx_leases and not self._tx_leg_live():
+              await self._converge()        # arms TX; converges, never rejects
+  ```
+  Then `await self._radio.push_tx(...)` as today. (Guard `self._tx_leases` so a push from a fully-released session still hits the transport's own `AudioNotStartedError` rather than silently arming.)
+- **`reestablish`** (`session.py:599`): collapses to:
+  ```python
+  async def reestablish(self) -> None:
+      async with self._lock:
+          self._recovering_from = None
+          await self._converge()
+          self._rx_armed_at = self._monotonic()
+          await self._sync_watchdog()
+          if self._rx_subs and not self._bus.rx_active:
+              raise RuntimeError("radio RX failed to re-establish after reconnect ...")
+  ```
+  TX_ONLY, RX_ONLY, RX_TX, IDLE recovery all fall out of `_converge()` reconciling against the rebuilt (RECEIVING/idle) transport. The `RuntimeError` on demanded-but-dead RX is preserved so the recovery caller can surface FAILED (matching `_audio_recovery.py:155` expectation). TX-only recovery never raises (no RX demanded) — exactly the band-aid's behaviour, now structural.
+- **mode-change**: a mode change is just a demand reshape (the companion drops/adds RX subs or TX leases) followed by `_converge()`. No special path. The SSB→FT8 excursion is `RX_TX → (drop RX) → TX_ONLY` then a recovery `reestablish → _converge`, all one code path.
+- **recovery (`RECOVERING` watchdog)**: unchanged — see B.7.
+
+### B.7 The two-state-machine correlation (session FSM vs transport IDLE/RECEIVING/TRANSMITTING)
+
+The desync class is killed because `_converge()` reads **observed transport leg liveness** (`bus.rx_active`, `_tx_leg_live()`) as its diff baseline, then drives the transport and sets `self._state = desired` only after the transport calls succeed. The session FSM can therefore never claim a state the transport does not back:
+
+- After any `_converge()`, `self._state == _desired()` AND the transport legs match it (Invariant I2).
+- `RECOVERING` remains a transient watchdog-owned overlay (`_check_liveness_locked`, `session.py:714-732`) that shadows the live transport: demand transitions during RECOVERING act on `_recovering_from` (keep the existing `effective`-state shim by feeding `_recovering_from` into `_converge` when `self._state is RECOVERING` — the watchdog re-detects silence after any demand edge). On resume, `self._state = self._desired()` (already correct since `_desired()` is now pure).
+- `FAILED` stays defined-but-unentered (MOR-609 follow-up; out of scope, Q5).
+
+---
+
+## C. TDD step sequence (RED → GREEN, with gates)
+
+Each step writes the test(s) first, confirms RED on current `main`, then makes the production change GREEN. Gate after every step:
+`uv run pytest tests/test_audio_session.py tests/test_audio_recovery_session.py tests/test_web_audio_tx_session.py -q` plus `uv run ruff check src/rigplane/audio/session.py`.
+
+> All new tests live in the existing files; no new test module is created unless a property harness needs `tests/test_audio_session_invariants.py` (Step 1).
+
+**Step 0 — Strengthen the test double (no production change).**
+RED-enabling, not a behaviour test. Confirm `LanLikeRadio.push_tx` already rejects unless `state == "transmitting"` (it does, `_order_sensitive_radios.py:89-91`) and `start_rx` rejects from non-idle (it does, `:68-69`). Add the **missing** teeth: `LanLikeRadio.start_tx` is currently lenient (flips state). Verify the double models "push after a transport rebuild with no re-arm rejects" by adding a helper assertion used across the matrix (D.5). Gate: full audio suite still green (no behaviour change yet).
+
+**Step 1 — Invariant harness + I1/I2 as failing tests (RED on `main`).**
+Write `tests/test_audio_session_invariants.py` with a parametrized enumeration harness (D.1/D.2). The cell `(TX_ONLY, reestablish) → push` and `(RX_TX → drop RX) → push` MUST be RED on current code. Gate: these specific cells fail; rest of suite green.
+
+**Step 2 — Pure `_desired()` (drop the latch).**
+GREEN target: I2-for-TX_ONLY and `test_acquire_tx_at_idle_defers_arming` **changes** (see D.5 — this test's expectation flips to eager arm). Implement B.1. This alone makes `acquire_tx` at IDLE on full-duplex return `TX_ONLY` from `_desired()`; without `_converge` yet, wire `_reconcile`'s existing `TX_ONLY` branch to handle it. Confirm order tests still green.
+
+**Step 3 — Introduce `_converge()` + `_tx_leg_live()` + `_ensure_tx_live()`; retarget `_apply`.**
+Replace `_reconcile` with `_converge` (B.2), retarget `_enter_rx_tx` to observed liveness (B.3). GREEN: all existing demand/order/teardown/refcount tests, plus I2 for every reachable state. Gate: full audio suite.
+
+**Step 4 — `push` converges; delete `_ensure_tx_for_push`.**
+Implement `_converge_for_push` (B.6). GREEN: I1 (push with held lease from every reachable state never raises `AudioNotStartedError`), and the `(RX_TX→drop RX)→push` and `(any non-IDLE, lease held)→push` cells.
+
+**Step 5 — `reestablish` collapses to `_converge`; delete the band-aid branch + bespoke body + `_try_rearm_tx`.**
+Implement B.6 `reestablish`. GREEN: the `ad7737ce` seed test (now asserting the invariant, D.7), the recovery×TX matrix (D.3), and all existing recovery tests. Confirm `_audio_recovery.py` routing (`recover → reestablish`) still passes its desync tests.
+
+**Step 6 — Observability + eager-arm + PTT-input-surface tests.**
+Add D.6 (eager arm), D.6 (lease-carries-intent), and the convergence-event assertions (B.5 `_emit_convergence` — extend `AudioSessionEvent` emission to TX-leg arm/disarm; additive, no schema change). GREEN: full suite.
+
+**Step 7 — Cleanup gate.**
+`uv run pytest -m "not slow"` (catch exact-dict payload tests, per repo memory), `uv run ruff check . && uv run ruff format --check .`, then `cargo`-free (Python-only change). Confirm net-negative LOC in `session.py`.
+
+---
+
+## D. Test matrix (the ironclad part)
+
+### D.1 Invariant I1 — "TX lease/intent held ⇒ TX leg armed" (property/parametrized)
+
+Across **all** desired states × **all** entry edges: after any prefix of demand operations that leaves a held `TxLease`, a `lease.push(...)` on a full-duplex transport leaves the transport TRANSMITTING and the push does NOT raise `AudioNotStartedError`.
+
+- Entry edges enumerated: `acquire_tx@IDLE`, `acquire_tx@RX_ONLY`, `push@TX_ONLY`, `subscribe_rx then drop`, `reestablish@TX_ONLY`, `reestablish@RX_TX`, `mode_change(drop RX while lease held)`.
+- Implementation: parametrized enumeration over the operation prefix (see D.4 — no hypothesis). Assert via a shared `assert_push_succeeds(session, lease, radio)` helper.
+
+### D.2 Invariant I2 — "any transition converges to `_desired()`" (property)
+
+From every reachable session state, applying any single public input (`subscribe_rx`, `release rx`, `acquire_tx`, `release tx`, `push`, `reestablish`) drives `session.state == session._desired()` (modulo transient `RECOVERING`) AND transport leg liveness matches:
+- `session.state in {RX_ONLY, RX_TX}` ⇒ `bus.rx_active is True`;
+- `session.state in {TX_ONLY, RX_TX}` ⇒ `_tx_leg_live(radio) is True`;
+- `session.state is IDLE` ⇒ both False.
+
+Implemented as a `assert_converged(session, radio)` post-condition helper invoked after **every** step of every matrix test (D.3) and the enumeration harness (D.4).
+
+Also assert **I3 (no phantom RX)**: TX-only convergence/recovery keeps `bus.subscriber_count == 0` (promote the band-aid assertion to the helper). And **I4 (teardown order)**: `stop_rx` is never called from a TRANSMITTING transport across all transitions — extend `test_teardown_stops_tx_before_rx` to also run **after a recovery** (`_RecordingLanRadio` + `_wipe` + `reestablish`), not only from a clean RX_TX.
+
+### D.3 The composition matrix the old suite lacked
+
+Parametrize one test over `prior_demand × event`:
+
+```
+prior_demand ∈ {IDLE, RX_ONLY, RX_TX, TX_ONLY}
+   × event   ∈ {reestablish (transport rebuilt via _wipe), drop_RX_then_push,
+                drop_TX, mode_change, transport_rebuild}
+   ⇒ assert_converged(session, radio) AND, if a lease is held, a post-event
+     push reaches the radio (I1).
+```
+
+- **The exact bug cell:** `(TX_ONLY, reestablish) → push` — RED on `main`, GREEN after Step 5.
+- **Symmetric cells explicitly required:** `(RX_TX, reestablish)`, `(RX_ONLY, reestablish)`, `(IDLE, reestablish)` (demand dropped during outage stays dropped).
+- Build `TX_ONLY` prior state via `acquire_tx` (eager-arm) OR `acquire_tx + push` — both must reach `TX_ONLY`.
+
+### D.4 Property-based testing: enumeration, not hypothesis
+
+`hypothesis` is **not** a dev dependency (confirmed: absent from `pyproject.toml` and the test tree). **Recommendation: do NOT add it for this refactor.** The state space is tiny and bounded (4 demand shapes × ~7 edges × small operation prefixes); a deterministic **parametrized enumeration** over `itertools.product` of operation sequences (length ≤ 4 drawn from `{sub_rx, rel_rx, acq_tx, rel_tx, push, reestablish}`) gives full coverage, deterministic CI, and no new dependency. Implement I1/I2 as such an enumeration in `tests/test_audio_session_invariants.py`, asserting `assert_converged` after each step and that any held-lease `push` succeeds. (If a future, larger audio FSM warrants it, adding `hypothesis` is a separate decision — note it, do not act on it here.)
+
+### D.5 Test-double upgrade (make desync detectable)
+
+The LAN double **already** enforces the core push rule (`push_tx` rejects unless `state == "transmitting"`, `_order_sensitive_radios.py:89-91`; `start_rx` rejects from non-idle, `:68-69`). The real gap is **two-fold**:
+
+1. **A reachable "rebuilt-then-no-rearm" desync must reject.** The `_wipe(radio)` helper (`test_audio_recovery_session.py:44-50`) already resets `state="idle"`/`rx_callback=None`. Combined with the existing `push_tx` guard, a push after `_wipe` with no re-arm **already** rejects — confirm this in Step 0 with an explicit assertion so the harness can detect session↔transport desync. No double behaviour change is strictly required for LAN; the teeth already exist. **Action:** add a module-level `assert_push_rejects_when_not_armed(radio)` sanity test pinning that contract so a future lenient edit to the double is caught.
+2. **`_tx_leg_live()` must read the double the same way for LAN and exclusive.** `LanLikeRadio` exposes `state == "transmitting"`; `ExclusiveUsbRadio`/`_AtomicExclusiveRadio` expose `tx_running`. The `_tx_leg_live()` helper (B.2) handles both. Add a one-line assertion per double that `_tx_leg_live` agrees with the double's own flag, so the observer can never silently diverge.
+
+**Existing tests that MUST still pass unchanged against the (already-strict) double:** all of `test_rx_first_order_honored_on_lan_graph`, `test_atomic_order_honored_on_exclusive_graph`, `test_atomic_order_no_minus_50_on_strict_fake`, `test_teardown_stops_tx_before_rx`, `test_double_*_refcounted`, `test_*_start_failure_*`, `test_digital_tx_no_rx_subscriber_pushes_without_error`.
+
+**One existing test changes behaviour (call it out in the PR):** `test_acquire_tx_at_idle_defers_arming` (`test_audio_session.py:234-245`) currently asserts `radio.calls == []` after `acquire_tx` at IDLE (deferral). Under **eager arming (decision #2)**, `acquire_tx` at IDLE on a `rx_first` transport now arms TX immediately → state `TX_ONLY`, `radio.calls == ["start_tx"]`. **Update this test** to assert the eager-arm contract (renamed `test_acquire_tx_at_idle_eager_arms_tx_only`), and keep a companion assertion that on an **exclusive/atomic** transport `acquire_tx` at IDLE still defers (`radio.calls == []`, state `IDLE`) — the `_desired()` `(0 RX, >0 TX, not full_duplex) → IDLE` row. This is the only intentional behavioural-contract change to an existing test and is the crux of the MOR-556 ordering preservation review.
+
+### D.6 Eager-arm and PTT-first-class-input tests
+
+- **Eager arm:** `acquire_tx@IDLE` on `LanLikeRadio` → `TX_ONLY`, `_tx_leg_live()` True, **before any push** (decision #2). Then a push succeeds without an additional `start_tx`.
+- **Lease carries TX-intent:** assert that with a held lease and a `_wipe`'d transport, `reestablish` re-arms TX (`_tx_leg_live()` True) with `bus.subscriber_count == 0` — the lease alone is sufficient TX-intent (decision #3, minimal surface).
+- **Push converges (PTT proxy):** drive `RX_TX`, drop the RX sub (→ `TX_ONLY`), then `_wipe` (rebuild), then `push` — the push must converge (arm TX) and succeed, asserting I1 without any CAT-PTT field.
+
+### D.7 Regression test from the `ad7737ce` seed — asserting the INVARIANT
+
+Keep `test_reestablish_rearms_tx_only_digital_session` but **re-anchor its assertions on the invariant, not the branch**: after `_wipe` + `reestablish`, assert `assert_converged(session, radio)` (which subsumes `state is TX_ONLY`, `_tx_leg_live()` True, `bus.subscriber_count == 0`) and that the previously-failing `lease.push(...)` now succeeds (I1). It must pass unchanged against the reconciler (the architectural analysis §4.5 promises this), proving the band-aid's scenario is covered structurally.
+
+---
+
+## E. Risk
+
+**Highest risk: the MOR-556/559/574 arming order.** It is live-hardware-validated on the IC-7610 (LAN `rx_first`) and FTX-1 (exclusive `atomic`). The refactor moves it verbatim into `_enter_rx_tx`/`_converge` (B.3) and changes only the **discriminator** (observed liveness instead of remembered `self._state`), never the call sequences.
+
+Mitigation:
+- The four order-assertion tests (`test_rx_first_order_honored_on_lan_graph`, `test_atomic_order_honored_on_exclusive_graph`, `test_atomic_order_no_minus_50_on_strict_fake`, `test_teardown_stops_tx_before_rx`) are the regression harness and MUST stay green **unchanged**. If any requires editing, treat it as a red flag that the order moved — stop and review.
+- I4 (no `stop_rx` from TRANSMITTING) is asserted across **all** transitions including post-recovery, closing the gap that the old suite only checked from a clean RX_TX.
+
+**Required live-hardware re-test before release:** the SSB ↔ FT8 TX excursion on a direct-LAN IC-7610 (the exact field repro) and a same-device exclusive USB radio (FTX-1) — confirm modulation reaches the radio (Po > 0 W) after a recovery cycle in both `rx_first` and `atomic` orderings. Mark the PR as requiring this human validation before merge to a release branch.
+
+**Secondary risk:** `_tx_leg_live()` duck-typing. It must agree with the production `IcomAudioStream.state` (`AudioState.TRANSMITTING`) and both doubles. Pinned by D.5 assertions.
+
+**Open questions (with concrete recommendations — none left dangling):**
+- **Q1 (sequencing the two fixes):** The band-aid `ad7737ce` is on an orphan branch and NOT to be shipped. **Recommendation:** ship Option B directly; do not merge the band-aid first. Keep only its test (re-anchored, D.7).
+- **Q2 (lazy-arm-on-push as policy):** **Recommendation:** eager arm on full-duplex (decision #2 — FIXED). Do NOT add a `defer_tx_until_first_push` flag in this refactor; it is YAGNI and reintroduces a conditional. If wake-on-demand latency ever matters, a single capability flag consumed by `_converge()` is the future home — designed-for, not built.
+- **Q3 (CAT-PTT as a session input):** **Recommendation:** out of scope. The held lease + push-converges is a sufficient, minimal, testable TX-intent surface. A first-class `note_tx_intent()` pulse is designed-for (B.4) but deferred to a follow-up issue to avoid widening the session contract beyond the reconciler.
+- **Q4 (exclusive-USB TX-only):** **Recommendation:** keep deferring — `_desired()` maps `(0 RX, >0 TX, not full_duplex) → IDLE` (B.1), preserving today's behaviour. No TX-only mode for exclusive transports in this refactor.
+- **Q5 (MOR-609 retry/FAILED loop):** **Recommendation:** keep separate. `FAILED` stays defined-but-unentered. The reconciler is the natural future home (it would be the "seventh edge" Option B otherwise anticipates), but folding it in now exceeds scope/guardrails.
+
+---
+
+## F. Scope / guardrails
+
+**Files the implementation will touch:**
+1. `src/rigplane/audio/session.py` — the reconciler rewrite (production).
+2. `tests/test_audio_session.py` — update `test_acquire_tx_at_idle_defers_arming` (eager-arm contract change), add eager-arm/I-helper tests.
+3. `tests/test_audio_recovery_session.py` — re-anchor the `ad7737ce` seed test on the invariant; add recovery×TX matrix.
+4. `tests/test_audio_session_invariants.py` — **new** I1/I2 enumeration harness (the only new file).
+5. `tests/_order_sensitive_radios.py` — additive sanity assertions only (the strict push rule already exists); no behaviour change.
+
+That is 1 production file + 4 test files. The **production guardrail (≤3 files / ≤200 LOC delta)** is met: production change is **a single file with net-negative LOC** (six arming branches + `_try_rearm_tx` + `_ensure_tx_for_push` + bespoke `reestablish` body deleted; one `_converge` + two small helpers added). Test files are not counted against the production-file guardrail but are listed for completeness.
+
+**LOC estimate:** production `session.py` ≈ **−40 to −70 net** (delete ~120 lines of scattered arming across `_ensure_tx_for_push`, `_reconcile` TX_ONLY branch, `reestablish` body, `_try_rearm_tx`; add ~55 lines of `_converge` + `_tx_leg_live` + `_ensure_tx_live` + `_converge_for_push`). Tests ≈ **+150 to +200** (the invariant harness + matrix). Net-negative production LOC is the goal and is achieved.
+
+**Boundary confirmation:** **open-core**, stays in `rigplane-core`. Generic LAN/USB audio TX state machine and recovery. No licensing, commercial, customer, or desktop-packaging logic. The public demand API is byte-for-byte unchanged, so `rigplane-pro` (companion bridge / web TX handler, consuming `radio.audio_session`) needs no change.
+
+**No transport change:** `lan_stream.py` / `usb_driver.py` are already correct (the transport accepts `start_tx` from RECEIVING and rejects `push_tx` unless TRANSMITTING — exactly the contract `_converge` reconciles against). Do not edit them.

--- a/docs/architecture/2026-06-22-audio-session-state-architecture.md
+++ b/docs/architecture/2026-06-22-audio-session-state-architecture.md
@@ -1,0 +1,558 @@
+# AudioSession state architecture — TX-stuck-in-"receiving" root-cause and clean fix
+
+**Date:** 2026-06-22
+**Status:** architectural analysis (read-only — no production code changed by this doc)
+**Scope:** `rigplane-core` audio session/transport state machine
+**Boundary:** open-core (generic LAN audio TX state machine and recovery)
+**Companion bug instance:** after SSB (phone) → FT8 (data, MOD IN = LAN), TX
+audio stops modulating (Po = 0 W); core `AudioSession` is stuck in
+`receiving` and rejects every TX push with
+`AudioNotStartedError: Cannot push TX in state receiving`.
+
+> This document is the **authoritative architectural verdict and clean-fix
+> design**. A concurrently-running diagnostic agent landed a working but
+> narrow patch (commit `ad7737ce`, see §0); that patch is correct as a
+> *symptom* fix and a good regression test, but it is the *third* instance
+> of the exact anti-pattern that produced the bug. The recommendation below
+> is to converge the three scattered arming sites into one declarative
+> reconciler rather than keep adding per-edge special cases.
+
+---
+
+## 0. What the diagnostic agent already found (and shipped)
+
+Commit `ad7737ce` on `codex/radio-session-lifecycle`:
+
+> *Root cause:* a digital client holds ONLY a TX lease and no RX subscription,
+> so the session sits in `TX_ONLY`. `AudioSession.reestablish` (the
+> session-demand re-establishment that lifecycle recovery routes through)
+> never handled the `TX_ONLY` desired state. It treated any non-IDLE demand
+> as RX-bearing, called `bus.restart_rx` (a no-op with zero subscribers),
+> saw `rx_active is False`, raised `RuntimeError` and stranded the session at
+> `RX_ONLY`. The TX leg was never re-armed, so the fresh LAN stream stayed
+> `RECEIVING` and every later `TxLease.push` hit it — `_ensure_tx_for_push`
+> only arms from IDLE, so it no-op'd at `RX_ONLY` and the push was rejected.
+
+That diagnosis is **correct and confirmed by reading the code**. The fix it
+shipped adds a `TX_ONLY` branch to `reestablish`
+(`session.py:624-640`). It makes the reported scenario work and ships a RED→GREEN
+regression test (`test_reestablish_rearms_tx_only_digital_session`).
+
+What that fix does **not** do — and what this document argues must be done —
+is remove the *reason a third site needed a fourth special case*. After the
+patch, "should the TX leg be armed?" is computed independently in **three**
+places that must be kept mutually consistent by hand:
+
+1. `_ensure_tx_for_push` (lazy arm on push, `session.py:348-376`),
+2. `_reconcile`'s `TX_ONLY` branch (demand-edge arm, `session.py:473-493`),
+3. `reestablish`'s new `TX_ONLY` branch (recovery arm, `session.py:624-640`).
+
+The original bug *was* exactly site (3) disagreeing with sites (1) and (2).
+There is no structural guarantee a fourth edge will not reintroduce the same
+class. That is the architectural problem.
+
+---
+
+## 1. Root-cause as a CLASS
+
+### 1.1 There are two stacked state machines, and they can disagree
+
+There are **two** independent audio state machines, one layered on the other,
+each with its own enum and its own transition rules:
+
+| Layer | State enum | Owner | File |
+| --- | --- | --- | --- |
+| Session (demand) | `IDLE / RX_ONLY / RX_TX / TX_ONLY / RECOVERING / FAILED` | `AudioSession` | `audio/session.py:101` |
+| Transport (stream) | `IDLE / RECEIVING / TRANSMITTING` | `IcomAudioStream` | `audio/lan_stream.py:78` |
+
+The error string `Cannot push TX in state receiving`
+(`lan_stream.py:622-623`) is raised by the **transport** layer; the bug is
+that the **session** layer believed TX was (or should be) armed, or failed to
+arm it, while the transport sat in `RECEIVING`. The two layers desynced.
+
+The transport layer is itself lenient and correct in isolation:
+
+- `start_tx` from `RECEIVING` is **allowed** — it overrides
+  `RECEIVING → TRANSMITTING` (`lan_stream.py:602-606`). Full duplex on one
+  UDP stream.
+- `start_rx` requires `IDLE` (`lan_stream.py:523`).
+- `stop_tx` from `TRANSMITTING` reverts to `RECEIVING` if the RX task is live,
+  else `IDLE` (`lan_stream.py:645-651`).
+- `push_tx` requires `TRANSMITTING` (`lan_stream.py:622`).
+
+So the transport will *accept* a push **iff** somebody called `start_tx` since
+the last teardown. The session is the *only* thing that calls `start_tx`. The
+bug is therefore entirely a **session-layer** failure to call `start_tx` at a
+moment when TX is demanded.
+
+### 1.2 `_desired()` is NOT a pure function of intent — TX-intent is not an input
+
+The intended design (`session.py:407-426`):
+
+```python
+def _desired(self) -> AudioSessionState:
+    if not self._rx_subs:
+        if self._state is AudioSessionState.TX_ONLY and self._tx_leases:
+            return AudioSessionState.TX_ONLY
+        return AudioSessionState.IDLE
+    if self._tx_leases:
+        return AudioSessionState.RX_TX
+    return AudioSessionState.RX_ONLY
+```
+
+This is the architectural defect in one function. **`_desired()` reads its own
+current `self._state` to decide whether TX is wanted.** That makes it *not a
+pure function of intent* — it is a function of intent **and** the previous
+output. Concretely:
+
+- `tx_leases > 0 and rx_subs == 0` does **not** map to "TX wanted". It maps to
+  `TX_ONLY` **only if the session already happened to be in `TX_ONLY`**;
+  otherwise it maps to `IDLE` — i.e. "no TX wanted" — *even though a TX lease
+  is held*.
+- The genuine intent signal — "a TX lease is held, therefore TX is demanded"
+  — is deliberately suppressed at the `acquire_tx` edge (the MOR-556 "don't
+  arm TX before RX on the shared LAN stream" rule). The suppression was
+  implemented by **dropping TX-intent out of `_desired()` entirely** and
+  re-introducing it imperatively, lazily, at push time.
+
+The consequence: **TX-intent is a second-class, latched signal.** The session
+can be in a state where TX is demanded (a non-released `TxLease` exists *and*
+the digital client is actively pushing frames) yet `_desired()` returns `IDLE`
+or `RX_ONLY` — "TX not wanted" — so reconciliation never arms the transport.
+
+### 1.3 Arming is push-time and edge-scattered, not reconciled
+
+Because TX-intent was pulled out of `_desired()`, the actual arming is sprayed
+across the imperative edges:
+
+- **Acquire edge:** `acquire_tx` defers (arms nothing if no RX)
+  (`session.py:327-346`).
+- **Push edge:** `_ensure_tx_for_push` arms — *but only from `IDLE`*
+  (`session.py:362-367` guard `self._state is AudioSessionState.IDLE and
+  ... and not self._rx_subs`).
+- **RX-drop edge:** `_reconcile`'s `RX_TX → TX_ONLY` branch arms (only reached
+  when desired is already `TX_ONLY`, i.e. only after a push already latched it)
+  (`session.py:476-483`).
+- **RX-return edge:** `_enter_rx_tx`'s `TX_ONLY → RX_TX` branch re-arms
+  (`session.py:503-514`).
+- **Recovery edge:** `reestablish` — pre-patch did **not** arm TX-only;
+  post-patch does (`session.py:624-640`).
+- **Failure-recovery edge:** `_try_rearm_tx` (`session.py:670-685`).
+
+Six edges, each with a hand-written decision about whether and how to call
+`start_tx`. Every one of them must independently agree with the others on the
+question "given this demand, should TX be live?". They are kept consistent
+**by review, not by construction.** The reported bug is the proof that this
+fails: `reestablish` was written (MOR-586) before `TX_ONLY` existed
+(commit `95edb79d`), so it simply never learned the new rule.
+
+### 1.4 Why the session was stuck in "receiving" while TX was demanded — exact trace
+
+The companion's digital TX client (WSJT-X/FT8 over the companion bridge) holds
+**only** a `TxLease` and never subscribes the session to RX. The SSB→FT8
+operating sequence drives this trace:
+
+1. **FT8 at start:** client `acquire_tx` (deferred, `IDLE`); first push →
+   `_ensure_tx_for_push` arms from `IDLE` → session `TX_ONLY`, transport
+   `TRANSMITTING`. Modulation reaches the radio. ✅ (This is why it works at
+   session start.)
+2. **SSB excursion / mode change / operator activity** triggers a recovery
+   cycle: CI-V data stall or control loss → lifecycle `RECOVERING` →
+   `soft_reconnect` (`_control_phase.py:667`). `soft_reconnect` tears the
+   audio transport down (`_teardown_audio_transport`, `:740-745`), rebuilds it
+   (`_ensure_audio_transport`, `:836-839`) — the fresh LAN stream comes back
+   `RECEIVING`/idle — then calls `audio_runtime.recover(snapshot)` (`:845`),
+   which routes session-managed audio to `AudioSession.reestablish`
+   (`_audio_recovery.py:135-156`).
+3. **`reestablish` (pre-patch)** computes `desired = _desired()`. The session
+   was `TX_ONLY` so `_desired()` returns `TX_ONLY`. But the pre-patch code had
+   no `TX_ONLY` branch: it fell through to the RX re-arm path, called
+   `bus.restart_rx()` (no subscribers → no-op), saw `rx_active is False`,
+   forced `self._state = RX_ONLY` and raised `RuntimeError`
+   (`session.py:648-659`). **Session now claims `RX_ONLY`; transport is
+   `RECEIVING`; TX leg never re-armed.**
+4. **Next FT8 push** → `_ensure_tx_for_push`. Guard requires
+   `self._state is IDLE` — but state is `RX_ONLY` — so it **no-ops**. The push
+   goes straight to `transport.push_tx`, which is in `RECEIVING`, and raises
+   `Cannot push TX in state receiving`. 💥 RX is unaffected because the RX leg
+   genuinely is up (or the bus just has no subs); only TX is dead.
+
+The exact architectural gap: **(a)** TX-intent (`tx_leases > 0`) is not a
+first-class input to `_desired()`, so the recovery path computed a desired
+state that *excluded* the held TX lease; **(b)** the lazy arm's `IDLE`-only
+guard means once the session is parked in any non-IDLE state with TX still
+demanded, **no push can ever recover it** — `push` rejects instead of
+converging to a TX-armed state.
+
+### 1.5 The class, stated precisely
+
+> **TX-intent is a latched, non-reconciled signal.** Desired state is not a
+> pure function of declared demand; it is a function of demand *plus* the
+> previous state. Arming TX is performed imperatively at six edges that each
+> re-derive the arming decision and can disagree. `push` is allowed to
+> **reject** demanded TX instead of **converging** to it. Any new transition
+> that forgets to special-case the latched `TX_ONLY` reintroduces the stuck
+> state.
+
+This is the *same class* the connect-path lifecycle work just eliminated:
+imperative, scattered state mutation versus one declarative reconciler where
+desired state is a pure function of intent and every transition converges.
+
+---
+
+## 2. Why the tests missed it
+
+### 2.1 The missing invariant
+
+No test asserts the two load-bearing invariants:
+
+- **I1 (intent ⇒ armed):** *if a TX lease is held and pushes are arriving on a
+  full-duplex transport, the transport is `TRANSMITTING` and the push
+  succeeds — regardless of how the session got there.*
+- **I2 (convergence):** *after any transition (acquire, push, subscribe,
+  release, mode change, recovery, reconnect), the session state equals
+  `_desired()` and the transport state is consistent with it.*
+
+Both are absent. The suite tests *individual edges*, each in isolation, from a
+clean session — never the **composition** of edges that the field hits.
+
+### 2.2 The specific scenario gap: recovery × TX-only was never tested together
+
+`tests/test_audio_session.py`:
+
+- `test_rx_demand_returning_rearms_held_tx_lease` (`:361`) is the closest
+  case — RX_TX → drop RX → re-subscribe → RX_TX with a lease held. But it
+  **never pushes TX during the gap**, so the session goes to `IDLE`, *not*
+  `TX_ONLY`, and the recovery-from-`TX_ONLY` path is never entered.
+- `test_demand_permutations_converge` (`:217`) asserts convergence — but only
+  for `rx_then_tx` vs `tx_then_rx`, both landing at `RX_TX`. It never includes
+  a TX-only permutation, a recovery, or a mode switch.
+
+`tests/test_web_audio_tx_session.py`:
+
+- `test_digital_tx_no_rx_subscriber_pushes_without_error` (`:188`) covers the
+  *happy* TX_ONLY path (acquire → push → `TX_ONLY`) — the start-of-session
+  case that always worked. It does **not** then run a recovery and push again.
+
+`tests/test_audio_recovery_session.py`:
+
+- Covered RX-bearing reconnect (RX_ONLY/RX_TX) thoroughly, but had **zero**
+  cases where `reestablish` is called with TX demand and no RX demand —
+  precisely the hole the diagnostic agent's new test plugs.
+
+So: a **test-gap**, but a gap the architecture *makes hard to close by
+construction*. With six independent arming edges, the test matrix that would
+catch every desync is the cross-product `{6 edges} × {prior state} × {demand
+shape}` — combinatorially large and impossible to enumerate by hand. The
+edges that were tested individually all passed; the bug lived only in the
+*pair* (recovery-after-TX_ONLY) nobody thought to compose.
+
+### 2.3 Does the fixture model the PTT-source × session-state interaction?
+
+Partially, and that is itself a finding. `LanLikeRadio` / `_RecordingLanRadio`
+(test doubles in `tests/test_audio_session.py`) model `start_rx/stop_rx/
+start_tx/stop_tx` and a coarse `state` string, and `_audio_recovery` snapshots
+`rx_active/tx_active` (`_audio_recovery.py:39-58`). What is **not** modelled:
+
+- the **transport's own** `RECEIVING`/`TRANSMITTING`/`IDLE` machine and its
+  "`push_tx` rejects unless `TRANSMITTING`" rule — the simulator's `state`
+  string does not enforce that a push fails when TX was never armed, so a
+  desync between session-state and transport-state is invisible to most tests;
+- the **PTT source** dimension: a digital client keys via **CAT PTT** while
+  audio rides the LAN stream; the session has no notion of "PTT asserted" as
+  an input at all. The interaction "PTT asserted by CAT but audio TX leg not
+  armed" is exactly the failure and is **not representable** in the current
+  model because PTT is not a session input.
+
+This is the deeper test-infra gap: the simulator cannot express the failing
+state because the production model itself does not treat PTT/TX-frame-arriving
+as a first-class input.
+
+---
+
+## 3. Architectural verdict
+
+**Yes — there is an architectural problem**, and it is the same class the
+connect-path `RadioSessionLifecycle` work was created to kill.
+
+Precisely: `AudioSession` is *advertised* as a declarative reconciler
+("computes the desired state from `(rx_demand>0, tx_demand>0)` and reconciles
+under ONE asyncio lock" — module docstring, `session.py:13-16`) but is *not
+one*. `_desired()` reads its own previous output, TX-intent is latched rather
+than reconciled, and arming is performed imperatively at six edges. The
+docstring describes the target; the code is the legacy shape with a
+reconciler-flavoured wrapper.
+
+The defect is **not** in the lazy-arm idea, nor in the `TX_ONLY` state, nor in
+`reestablish`. Each is locally reasonable. The defect is that **the demand-to-
+transport mapping has no single owner.** Six functions own a slice of it.
+
+### 3.1 Option comparison
+
+| Option | What it is | Pros | Cons |
+| --- | --- | --- | --- |
+| **A — Fold audio into `RadioSessionLifecycle`** | Make the connect-lifecycle state machine the single owner of audio re-arm too; audio legs become a sub-resource the lifecycle reconciles on `CONNECTED`/`RECOVERING`. | One owner for the whole radio session; recovery already lives there; observable events unified. | Large blast radius; couples audio demand (a Pro/companion concern) to the core connect FSM; audio demand changes far more often than connect state, so cadence mismatch; risks re-entangling layers MOR-579 deliberately separated (radio-owned audio singleton). |
+| **B — Make `AudioSession` a *real* declarative reconciler** (recommended) | Keep `AudioSession` as the audio owner, but make `_desired()` a pure function of intent and route **every** edge through one `_converge()` that drives the transport to `_desired()`. Delete the five other arming sites. | Smallest correct change; fixes the *class* not the instance; mirrors the lifecycle's intent→desired→converge discipline without coupling the two FSMs; keeps the MOR-579 layering. | Requires reworking the MOR-556 ordering rule to live *inside* convergence (sequencing) rather than as intent suppression — needs care + hardware-aware ordering tests. |
+| **C — Keep the diagnostic agent's patch as-is** | Per-edge special cases; add a `TX_ONLY` branch wherever a new edge needs it. | Zero further work; ships today. | Leaves the class intact; the next new edge (e.g. a session-owned retry loop, MOR-609; a poller PTT hook) reintroduces the stuck state. This is the band-aid the user explicitly rejected. |
+
+**Verdict: Option B.** Option A over-couples; Option C is the band-aid.
+Option B applies the *same pattern* as the lifecycle (declarative desired state
++ guaranteed convergence + observability) **at the right layer** — the audio
+session — without folding two state machines that change at different cadences
+into one.
+
+The lifecycle relationship is **pattern-shared, not ownership-merged**:
+`AudioSession` should *mirror* `RadioSessionLifecycle`'s discipline (pure
+`_desired()`, single `_converge()`, `AudioSessionEvent` already exists as the
+observability hook, `session.py:138-148`) and should be *driven by* the
+lifecycle's `RECOVERING→CONNECTED` edge (which it already is, via
+`reestablish`), but should remain a separate FSM with a separate enum.
+
+---
+
+## 4. The clean fix (design, not a band-aid)
+
+### 4.1 Principle: desired state is a pure function of declared intent
+
+Make `_desired()` depend **only** on inputs, never on `self._state`:
+
+```
+inputs  = (rx_demand>0, tx_demand>0, recovery_requested)
+_desired = pure_function(inputs, transport_capabilities)
+```
+
+Mapping (full-duplex / `rx_first` transport):
+
+| rx_demand | tx_demand | desired |
+| --- | --- | --- |
+| 0 | 0 | IDLE |
+| >0 | 0 | RX_ONLY |
+| 0 | >0 | **TX_ONLY** |
+| >0 | >0 | RX_TX |
+
+The single behavioural change vs today: `(0 RX, >0 TX) ⇒ TX_ONLY`
+**unconditionally**, removing the `self._state is TX_ONLY` latch on
+`session.py:421`. TX-intent becomes first-class: **holding a `TxLease` *is* the
+TX demand**, full stop.
+
+For exclusive/atomic USB transports, the same table holds except the
+`(0 RX, >0 TX)` row maps to a transport-specific deferred state (their TX leg
+requires the co-armed duplex stream); this is a **sequencing/capability**
+decision made *inside* convergence (§4.3), not by mutating intent.
+
+### 4.2 Principle: every edge recomputes and converges; nothing arms ad-hoc
+
+Replace the six imperative arming sites with **one** `async _converge()` called
+under the lock by every demand mutation, by recovery, and by push:
+
+```
+acquire_tx / release_tx / subscribe_rx / release_rx / reestablish / push
+        └────────────────► _converge() ──► drive transport to _desired()
+```
+
+`_converge()` is the only function that calls `start_tx/stop_tx/start_rx/
+stop_rx/restart_rx`. It:
+
+1. computes `desired = _desired()`;
+2. diffs `desired` against the **observed transport state** (RX leg live? TX
+   leg live?) — not against a remembered `self._state` that can lie after a
+   transport rebuild;
+3. issues the minimal transport calls to reach `desired`, in the
+   transport-declared order (`audio_setup_order`), honouring MOR-556/MOR-574
+   sequencing (RX-before-TX arm; TX-before-RX teardown);
+4. sets `self._state = desired` (or a typed failure state) and emits an
+   `AudioSessionEvent`.
+
+Because `_converge()` reconciles against the *observed transport*, it is
+**idempotent and recovery-safe by construction**: after a `soft_reconnect`
+rebuilds the LAN stream to `RECEIVING`/idle, `reestablish` becomes a one-liner
+— `await self._converge()` — and the TX-only, RX-only, RX_TX, and IDLE cases
+all fall out of the same code path. No `TX_ONLY` special branch is needed
+anywhere because TX-only is just `_desired()` returning `TX_ONLY` and
+`_converge()` arming the TX leg.
+
+### 4.3 Where the MOR-556 ordering rule moves
+
+Today the "don't arm TX before RX on the shared stream" rule is enforced by
+*suppressing TX-intent until a push* — that suppression is the root cause.
+Under the clean design the rule is enforced where it belongs: as **ordering
+inside `_converge()`**. When `desired == RX_TX` and RX is not yet live,
+`_converge()` arms RX first, then TX (it already does this in `_enter_rx_tx`,
+`session.py:520-523`). The *deferral* semantics callers relied on
+(`acquire_tx` at IDLE arming nothing) are preserved naturally: at IDLE with a
+single TX lease and no RX, `desired == TX_ONLY` — but for a transport where
+co-arming is required before frames flow, convergence may legitimately arm TX
+immediately (the digital path *wants* this; that is the bug fix). For
+exclusive USB, `_desired()`/`_converge()` keep deferring per capability. The
+"lazy on push" timing is no longer needed for correctness; if a deliberate
+delay until first frame is still desired as an *optimisation*, it becomes a
+single explicit `defer_tx_until_first_push` capability flag consumed by
+`_converge()`, not six scattered guards.
+
+### 4.4 PTT / TX-frame-arriving as first-class TX-intent
+
+To make I1 unconditionally true and to make the failure *representable in
+tests*, model the TX-demand signal explicitly:
+
+- **`TxLease` held ⇒ TX intent** (already the demand counter; just stop
+  latching it out of `_desired()`).
+- Optionally surface **"TX frame arriving"** / **"CAT PTT asserted"** as an
+  idempotent demand pulse: a push that finds the transport not `TRANSMITTING`
+  while a lease is held calls `_converge()` (which arms it) instead of relying
+  on a state-specific guard. This guarantees `push` **converges, never
+  rejects** — the second half of the clean fix. The transport's
+  `Cannot push TX in state receiving` becomes unreachable from a session that
+  holds a lease.
+
+This also gives the simulator a dimension to model (§5).
+
+### 4.5 Scope, risk, boundary
+
+- **Files:** `audio/session.py` (the reconciler rewrite); `reestablish`
+  collapses to a `_converge()` call; `_ensure_tx_for_push` is deleted (its job
+  moves into `push → _converge`). No transport (`lan_stream.py`,
+  `usb_driver.py`) change required — they are already correct.
+- **LOC:** net **negative** in `session.py` (six arming branches → one
+  reconciler). This is a refactor, not a feature.
+- **Risk:** medium. The sequencing rules (MOR-556 rx-first, MOR-574
+  tx-down-before-rx, MOR-559 atomic order) are load-bearing and live-validated;
+  they must be preserved *inside* `_converge()` with tests asserting the exact
+  call order per `audio_setup_order`. Mitigation: the existing order tests
+  (`test_rx_first_order_honored_on_lan_graph`,
+  `test_atomic_order_honored_on_exclusive_graph`,
+  `test_teardown_stops_tx_before_rx`) become the regression harness for the
+  reconciler; add the convergence/invariant tests of §5 on top.
+- **Boundary:** **open-core.** Generic LAN/USB audio TX state machine and
+  recovery. No licensing/commercial logic. The companion (`rigplane-pro`)
+  consumes this via the radio-owned `audio_session` singleton; its bridge/web
+  TX handlers are unaffected by the refactor (the public demand API —
+  `subscribe_rx`/`acquire_tx`/`TxLease.push` — is unchanged).
+- **Sequencing vs the diagnostic patch:** the shipped patch can stay as the
+  immediate stop-gap; Option B then *replaces* the three `TX_ONLY` branches
+  (lazy-arm, reconcile, reestablish) with the single reconciler and keeps the
+  patch's regression test (it passes unchanged against the reconciler).
+
+### 4.6 Relationship to `RadioSessionLifecycle`
+
+- **Do not fold** `AudioSession` state into `LifecycleState` (Option A
+  rejected): different cadence, different owner (MOR-579), different blast
+  radius.
+- **Do mirror** the lifecycle's three tenets in `AudioSession`: (1) desired
+  state is a pure function of intent; (2) every transition converges; (3)
+  every transition emits an observable event (`AudioSessionEvent` already
+  exists — extend listeners to cover TX-leg arm/disarm and convergence, not
+  just RX liveness).
+- **Do keep the existing drive edge:** lifecycle `RECOVERING → CONNECTED`
+  already calls `soft_reconnect → _ensure_audio_transport → recover →
+  AudioSession.reestablish`. Under Option B that terminal call becomes
+  `_converge()` and the two FSMs compose cleanly: the lifecycle owns *when the
+  transport exists*; the session owns *what legs are armed on it*. One
+  observable event stream per layer, correlated by the recovery edge.
+
+---
+
+## 5. Test strategy for the CLASS
+
+Goal: assert the **invariants**, not enumerate edges. These catch the entire
+desync class, including the next edge nobody has written yet.
+
+### 5.1 Invariant / property tests
+
+- **I1 — intent ⇒ armed.** For every reachable session state, *holding a
+  `TxLease` and issuing a push on a full-duplex transport leaves the transport
+  `TRANSMITTING` and the push succeeds.* Property test over a generated
+  sequence of demand operations; after any prefix, a push with a held lease
+  must not raise `AudioNotStartedError`.
+- **I2 — convergence.** *After every public operation,
+  `session.state == session._desired()`* (modulo the explicit transient
+  `RECOVERING`), *and the transport leg liveness matches the state.* Assert as
+  a post-condition helper invoked after each step of every test.
+- **I3 — no phantom RX.** TX-only convergence/recovery never resurrects RX
+  subscribers (`bus.subscriber_count == 0`) — already asserted by the new
+  patch test; promote it to the invariant helper.
+- **I4 — teardown order.** `stop_rx` is never called while the transport is
+  `TRANSMITTING` (MOR-574), across *all* transitions — extend
+  `test_teardown_stops_tx_before_rx` to run after a recovery, not only from a
+  clean RX_TX.
+
+### 5.2 The mode-switch / recovery × TX matrix
+
+Parametrise a single test over the cross-product:
+
+```
+prior_demand ∈ {TX_ONLY, RX_ONLY, RX_TX, IDLE}
+   × event   ∈ {mode_change, soft_reconnect/reestablish, transport_rebuild,
+                drop_RX_then_push, drop_TX, PTT_assert}
+   ⇒ assert I1 ∧ I2 ∧ I3 ∧ I4 hold, and a post-event push (if a lease is held)
+     reaches the radio.
+```
+
+The reported bug is the single cell `(TX_ONLY, reestablish) → push`. The
+matrix turns "the one pair nobody composed" into "every pair is asserted".
+
+### 5.3 What the simulator/fixtures must model
+
+- **Enforce the transport push rule in the double.** The LAN test double must
+  reject `push_tx` unless `start_tx` was the last arming call since teardown
+  (mirror `lan_stream.py:622`). Without this, session↔transport desync is
+  invisible — the exact reason the bug escaped. (Some doubles like the
+  `_strict_fake` already model AUHAL -50; extend the LAN double similarly for
+  the RECEIVING/TRANSMITTING rule.)
+- **Model transport rebuild on reconnect.** A `reestablish`/recovery fixture
+  must reset the transport to `RECEIVING`/idle (the `_wipe(radio)` helper
+  already does this in `test_audio_recovery_session.py`) so re-arm is actually
+  exercised, not no-op'd against a still-armed double.
+- **Add a PTT/TX-frame dimension.** Represent "CAT PTT asserted" / "TX frame
+  arriving" as an explicit fixture input so the failing interaction (PTT on,
+  TX leg unarmed) is *representable* and can be asserted against I1.
+
+---
+
+## 6. Recommendation
+
+1. **Keep** the diagnostic agent's patch (`ad7737ce`) as the immediate
+   field stop-gap and **keep its regression test** — it is correct and
+   ships the fix the operator needs now.
+2. **Adopt Option B** as the proper fix in a follow-up: make `AudioSession` a
+   *real* declarative reconciler — `_desired()` pure in `(rx_demand,
+   tx_demand, recovery)` with TX-intent first-class (drop the `TX_ONLY` latch),
+   route every edge through one idempotent `_converge()` that reconciles
+   against the **observed transport**, delete `_ensure_tx_for_push` and the
+   three scattered `TX_ONLY` arming branches, and make `push` **converge, not
+   reject**. Net-negative LOC; open-core; medium risk concentrated in
+   preserving the live-validated arming order.
+3. **Do not** fold audio-session state into `RadioSessionLifecycle` (Option A).
+   Instead **mirror its pattern** (intent→desired→converge + observable
+   events) at the audio layer and keep the existing
+   `RECOVERING→reestablish→_converge` drive edge. One owner per layer, two
+   FSMs, correlated by the recovery edge.
+4. **Add the invariant/property tests of §5** *before or with* Option B so the
+   reconciler is locked behind I1–I4 and the recovery×TX matrix — converting a
+   hand-maintained edge-consistency contract into an enforced one.
+
+---
+
+## 7. Open Questions (for the user)
+
+1. **Sequencing of the two fixes:** ship Option B as a dedicated refactor PR
+   on top of the merged stop-gap, or roll the stop-gap into Option B before
+   merge? (Recommendation: stop-gap first — it is already committed — then
+   Option B as a clean, test-locked refactor.)
+2. **Lazy-arm-on-push as policy:** is deferring the TX leg until the first
+   frame still *wanted* (latency/wake-on-demand) once correctness no longer
+   depends on it, or should a held lease arm TX eagerly on full-duplex
+   transports? This decides whether `_converge()` carries a
+   `defer_tx_until_first_push` capability flag or arms unconditionally.
+3. **PTT as a session input:** should "CAT PTT asserted" become a real
+   first-class session input (so the session can *know* TX is keyed even
+   before audio frames arrive), or is "lease held + frame arriving" a
+   sufficient proxy? The former is more correct and more testable but widens
+   the session's contract.
+4. **Exclusive-USB TX-only:** confirm the intended behaviour for
+   `(0 RX, >0 TX)` on `exclusive`/`atomic` USB transports — keep deferring
+   (today's behaviour) or define a real TX-only mode there too? The reconciler
+   needs this row of `_desired()` pinned down per transport capability.
+5. **MOR-609 (session-owned retry/FAILED loop):** Option B makes the
+   reconciler the natural home for a retry loop. Should MOR-609 be folded into
+   the Option B refactor, or stay a separate follow-up? (It is the *seventh*
+   arming edge that Option B would otherwise have to anticipate.)

--- a/src/rigplane/audio/session.py
+++ b/src/rigplane/audio/session.py
@@ -330,12 +330,13 @@ class AudioSession:
         """Add TX demand; arms TX in the transport-declared order.
 
         A held lease IS TX demand. On a full-duplex ("rx_first") transport
-        with no RX demand the TX leg is armed EAGERLY here (entering TX_ONLY —
-        decision #2, no wait for a first push); with RX demand present the
-        lease converges to RX_TX in the transport-declared order. Exclusive/
-        atomic USB transports keep deferring tx-only demand (their TX leg
-        requires the co-armed duplex stream) — ``_desired()`` maps that demand
-        shape to IDLE. A TX start failure unwinds the lease and re-raises.
+        with no RX demand the TX leg arm is DEFERRED at the bare-acquire edge
+        (intent-gated; see ``_desired()``); it arms on the push / reestablish
+        edges when TX intent is active. With RX demand present the lease
+        converges to RX_TX in the transport-declared order. Exclusive/atomic
+        USB transports keep deferring tx-only demand (their TX leg requires the
+        co-armed duplex stream) — ``_desired()`` maps that demand shape to IDLE.
+        A TX start failure unwinds the lease and re-raises.
         """
         async with self._lock:
             lease = TxLease(self, owner)

--- a/src/rigplane/audio/session.py
+++ b/src/rigplane/audio/session.py
@@ -194,11 +194,13 @@ class TxLease:
         """Push TX audio (encoded per the radio's ``audio_tx_codec``)."""
         if self._released:
             raise RuntimeError(f"TX lease {self.owner!r} already released")
-        # Lazily arm the TX leg for a tx-only (no RX demand) full-duplex
-        # session. This is the digital-TX (FT8/WSJT-X over the companion)
-        # path: a TX lease was acquired but the session deferred at IDLE, so
-        # the LAN stream is still RECEIVING and ``push_tx`` would be rejected.
-        await self._session._ensure_tx_for_push()
+        # A held lease IS TX demand: converge the session to its armed state
+        # before forwarding. Idempotent — a no-op when the TX leg is already
+        # live. Converges, never rejects: the digital-TX (FT8/WSJT-X over the
+        # companion) path where only a TX lease is held and the transport was
+        # rebuilt (so the LAN stream is RECEIVING and ``push_tx`` would be
+        # rejected) is re-armed here instead of failing.
+        await self._session._converge_for_push()
         await self._session._radio.push_tx(audio_data)
 
     async def release(self) -> None:
@@ -327,12 +329,13 @@ class AudioSession:
     async def acquire_tx(self, owner: str = "") -> TxLease:
         """Add TX demand; arms TX in the transport-declared order.
 
-        With no RX demand the lease is recorded but nothing is armed at the
-        acquire edge (preserving the bridge/poller "TX-lease-first, then RX"
-        order — MOR-556). On a full-duplex transport the TX leg is then armed
-        LAZILY by the first :meth:`TxLease.push` (entering TX_ONLY); with RX
-        demand already present the lease arms RX_TX immediately. A TX start
-        failure unwinds the lease and re-raises.
+        A held lease IS TX demand. On a full-duplex ("rx_first") transport
+        with no RX demand the TX leg is armed EAGERLY here (entering TX_ONLY —
+        decision #2, no wait for a first push); with RX demand present the
+        lease converges to RX_TX in the transport-declared order. Exclusive/
+        atomic USB transports keep deferring tx-only demand (their TX leg
+        requires the co-armed duplex stream) — ``_desired()`` maps that demand
+        shape to IDLE. A TX start failure unwinds the lease and re-raises.
         """
         async with self._lock:
             lease = TxLease(self, owner)
@@ -345,34 +348,18 @@ class AudioSession:
                 raise
             return lease
 
-    async def _ensure_tx_for_push(self) -> None:
-        """Lazily arm the TX leg for a tx-only full-duplex session (no RX).
+    async def _converge_for_push(self) -> None:
+        """Converge the TX leg for a held-lease :meth:`TxLease.push`.
 
-        Called from :meth:`TxLease.push`. No-op unless the session currently
-        has TX demand, NO RX demand, is at IDLE, and the transport is genuinely
-        full-duplex ("rx_first"). This is the digital-TX (FT8/WSJT-X over the
-        companion) path: the lease was acquired but deferred at IDLE, so the
-        LAN stream is still RECEIVING and ``push_tx`` would be rejected with
-        ``AudioNotStartedError``. Arming here transitions the stream to TX and
-        enters TX_ONLY so lease release and RX-demand convergence tear down /
-        re-sequence correctly. Exclusive/atomic USB transports are excluded —
-        their TX leg requires the co-armed duplex stream.
+        A held lease IS TX demand: if the observed transport TX leg is not
+        live, drive convergence (which arms TX) so the frame is accepted —
+        converges, never rejects. Guarded on a held lease so a push from a
+        fully-released session still hits the transport's own
+        ``AudioNotStartedError`` rather than silently arming.
         """
         async with self._lock:
-            if (
-                self._state is AudioSessionState.IDLE
-                and self._tx_leases
-                and not self._rx_subs
-                and self._setup_order() == "rx_first"
-            ):
-                try:
-                    await self._radio.start_tx()
-                except AudioAlreadyStartedError:
-                    logger.debug(
-                        "audio-session: TX already live on lazy push arm",
-                        exc_info=True,
-                    )
-                self._state = AudioSessionState.TX_ONLY
+            if self._tx_leases and not self._tx_leg_live():
+                await self._converge(tx_active=True)
                 await self._sync_watchdog()
 
     async def _release_rx(self, sub: RxSubscription) -> None:
@@ -404,26 +391,76 @@ class AudioSession:
 
     # ── Desired-state reconciliation (single lock holder) ────────────────
 
-    def _desired(self) -> AudioSessionState:
-        # Acquiring a TX lease with no RX demand does NOT eagerly arm TX here:
-        # that would break the bridge/poller "TX-lease-first, then RX" pattern
-        # (MOR-556 — RX must arm before TX on the shared LAN stream). The
-        # tx-only arm is LAZY instead: the first ``TxLease.push`` with no RX
-        # demand on a full-duplex ("rx_first") transport arms the TX leg via
-        # ``_ensure_tx_for_push`` and enters TX_ONLY. Digital TX (FT8/WSJT-X
-        # over the companion) holds only a TX lease and never subscribes the
-        # session to RX, so without this its frames were rejected with
-        # ``AudioNotStartedError`` ("Cannot push TX in state receiving").
-        #
-        # Once TX_ONLY has been entered (by a push), a still-held lease keeps
-        # it until the lease drops or RX demand converges to RX_TX.
-        if not self._rx_subs:
-            if self._state is AudioSessionState.TX_ONLY and self._tx_leases:
-                return AudioSessionState.TX_ONLY
-            return AudioSessionState.IDLE
-        if self._tx_leases:
+    def _desired(self, *, tx_active: bool = False) -> AudioSessionState:
+        """Desired session state — a PURE function of declared demand.
+
+        Reads ONLY the demand counters, the per-transport order flag, and the
+        OBSERVED TX leg; NEVER ``self._state`` (so it cannot lie after a
+        transport rebuild). A held ``TxLease`` IS TX demand.
+
+        | rx | tx | full_duplex | desired  |
+        |----|----|-------------|----------|
+        |  0 |  0 |  any        | IDLE     |
+        | >0 |  0 |  any        | RX_ONLY  |
+        | >0 | >0 |  any        | RX_TX    |
+        |  0 | >0 |  True       | TX_ONLY  |  (when TX intent is active*)
+        |  0 | >0 |  False      | IDLE     |  (exclusive/atomic USB defers)
+
+        \\*TX-only is full-duplex digital TX (FT8/WSJT-X over the companion):
+        a lease with no RX. Its arm is intent-gated by ``tx_active`` — the
+        observed TX leg liveness, OR forced True on the push / reestablish
+        edges (a held lease that has pushed / survived an outage IS active
+        intent). This preserves the bridge/poller "TX-lease-first, then RX"
+        order (MOR-556): a bare ``acquire_tx`` with no RX yet does not arm a
+        lone TX leg (``tx_active`` False), so RX arriving next converges
+        straight to RX_TX without a TX flap. It is still PURE — a function of
+        the demand counters, the per-transport order flag, and the OBSERVED
+        TX leg (never ``self._state``) — so it cannot lie after a rebuild.
+
+        RECOVERING / FAILED are transient transport-owned overlays and are
+        never returned here.
+        """
+        rx = bool(self._rx_subs)
+        tx = bool(self._tx_leases)
+        if rx and tx:
             return AudioSessionState.RX_TX
-        return AudioSessionState.RX_ONLY
+        if rx:
+            return AudioSessionState.RX_ONLY
+        active = tx_active or self._tx_leg_live()
+        if tx and active and self._setup_order() == "rx_first":
+            return AudioSessionState.TX_ONLY
+        return AudioSessionState.IDLE
+
+    def _tx_leg_live(self) -> bool:
+        """Observed transport TX state — NEVER ``self._state``.
+
+        Reads the transport's coarse TX state, never ``self._state``. The
+        production radio wraps the stream, so the observed state lives on
+        ``radio._audio_stream.state`` (``AudioState.TRANSMITTING``); the test
+        doubles expose it directly (``LanLikeRadio.state == "transmitting"``,
+        ``ExclusiveUsbRadio.tx_running``, ``_StrictExclusiveRadio.tx_live``).
+        This is what makes ``_converge`` recovery-safe: after a transport
+        rebuild the leg reads down even when ``self._state`` still says
+        TX_ONLY.
+        """
+        st = getattr(self._radio, "state", None)
+        if st is None:
+            stream = getattr(self._radio, "_audio_stream", None)
+            st = getattr(stream, "state", None)
+        if st is not None:
+            return str(getattr(st, "value", st)).lower() == "transmitting"
+        if hasattr(self._radio, "tx_live"):
+            return bool(self._radio.tx_live)
+        if hasattr(self._radio, "tx_running"):
+            return bool(self._radio.tx_running)
+        # Serial / USB backends route audio through a UsbAudioDriver that owns
+        # the coarse TX-leg state; the radio itself exposes no stream. Observe
+        # the driver's tx_running directly (read-only).
+        for attr in ("_serial_audio_driver", "_audio_driver"):
+            driver = getattr(self._radio, attr, None)
+            if driver is not None:
+                return bool(getattr(driver, "tx_running", False))
+        return False
 
     def _setup_order(self) -> _SetupOrder:
         order = getattr(self._radio, "audio_setup_order", "rx_first")
@@ -437,70 +474,108 @@ class AudioSession:
 
     async def _apply(self, *, closing_rx: RxSubscription | None = None) -> None:
         try:
-            await self._reconcile(closing_rx=closing_rx)
+            await self._converge(closing_rx=closing_rx)
         finally:
             if self._state is not AudioSessionState.RECOVERING:
                 self._recovering_from = None
             await self._sync_watchdog()
 
-    async def _reconcile(self, *, closing_rx: RxSubscription | None = None) -> None:
-        desired = self._desired()
-        # RECOVERING (watchdog-owned, MOR-581) shadows the live transport
-        # state: demand transitions act on the shadowed state (TX still
-        # disarms); the watchdog re-detects silence after any demand edge.
-        effective = (
-            (self._recovering_from or AudioSessionState.RX_ONLY)
-            if self._state is AudioSessionState.RECOVERING
-            else self._state
+    async def _converge(
+        self,
+        *,
+        closing_rx: RxSubscription | None = None,
+        recover: bool = False,
+        tx_active: bool = False,
+    ) -> None:
+        """Drive the transport to ``_desired()``. Idempotent; the SOLE arming
+        site for every edge (acquire, release, subscribe, push, mode-change,
+        reestablish, recovery).
+
+        Reconciles against OBSERVED transport leg liveness — ``bus.rx_active``
+        and ``_tx_leg_live()`` — never ``self._state``, so it is correct after
+        a transport rebuild (reestablish) and after any prior partial
+        transition. Preserves the MOR-556/559/574 ordering by delegating
+        RX_TX entry to ``_enter_rx_tx`` and stopping TX before RX on teardown.
+
+        ``tx_active=True`` (push / reestablish edges): a held lease that has
+        pushed or survived an outage IS active TX intent, so the lone TX leg
+        is (re-)armed into TX_ONLY. Demand edges leave it False, deferring a
+        bare-lease tx-only arm so the bridge's lease-then-RX order does not
+        flap TX (MOR-556).
+
+        ``recover=True`` (the reestablish edge): the transport was rebuilt
+        underneath the bus, so its ``rx_active`` flag is stale — force a fresh
+        RX re-attach via ``bus.restart_rx`` instead of the join-if-live
+        ``_arm_rx``, surfacing a dead-RX re-arm to the caller.
+        """
+        desired = self._desired(tx_active=tx_active or recover)
+        order = self._setup_order()
+        # Teardown disarm hint: the TX leg is down only when OBSERVED down AND
+        # the session never recorded a TX-bearing state. ``self._state`` is a
+        # reliable record of what WE armed (never read for ARMING decisions —
+        # that stays pure/observed — only to drive an idempotent stop_tx on
+        # transports whose TX leg cannot be observed, e.g. a bare mock radio).
+        tx_up = self._tx_leg_live() or self._state in (
+            AudioSessionState.RX_TX,
+            AudioSessionState.TX_ONLY,
         )
-        if desired is effective:
-            if desired not in (
-                AudioSessionState.IDLE,
-                AudioSessionState.TX_ONLY,
-            ):
-                await self._arm_rx()  # new subscribers join the live RX leg
-            return
-        if desired is AudioSessionState.RX_TX:
-            await self._enter_rx_tx(self._setup_order(), effective)
-        elif desired is AudioSessionState.RX_ONLY:
-            if effective is AudioSessionState.RX_TX:
-                await self._disarm_tx()
-                if self._setup_order() in _REARM_RX_AFTER_TX_DROP:
-                    await self._bus.restart_rx()
-            else:
-                await self._arm_rx()
-            self._state = AudioSessionState.RX_ONLY
-        elif desired is AudioSessionState.TX_ONLY:
-            # Full-duplex transport, TX demand with no RX demand. Arm the TX
-            # leg alone (digital TX / FT8 over the companion).
-            if effective is AudioSessionState.RX_TX:
-                # RX demand just dropped while TX is held. On the LAN stream RX
-                # and TX share one stream, so stopping RX from TRANSMITTING
-                # tears the whole stream down (the MOR-574 lesson): drop TX
-                # first, shed the empty RX subs, then re-arm TX alone.
-                await self._disarm_tx()
-                await self._drop_rx(closing_rx)
-                await self._radio.start_tx()
-            else:
-                await self._drop_rx(closing_rx)
-                try:
-                    await self._radio.start_tx()
-                except AudioAlreadyStartedError:
-                    logger.debug(
-                        "audio-session: TX already live entering TX_ONLY",
-                        exc_info=True,
-                    )
-            self._state = AudioSessionState.TX_ONLY
-        else:  # IDLE
-            if effective in (AudioSessionState.RX_TX, AudioSessionState.TX_ONLY):
+
+        if desired is AudioSessionState.IDLE:
+            if tx_up:
                 await self._disarm_tx()  # MOR-574: TX down BEFORE RX drops
             await self._drop_rx(closing_rx)
             self._state = AudioSessionState.IDLE
+        elif desired is AudioSessionState.TX_ONLY:
+            # Full-duplex, TX demand, no RX. Shed any RX first (TX-down then
+            # RX-drop if a TX leg is up — MOR-574), then arm TX alone.
+            if self._rx_subs or closing_rx is not None:
+                if tx_up:
+                    await self._disarm_tx()
+                await self._drop_rx(closing_rx)
+            await self._ensure_tx_live()
+            self._state = AudioSessionState.TX_ONLY
+        elif desired is AudioSessionState.RX_ONLY:
+            if tx_up:
+                await self._disarm_tx()  # MOR-574: TX down before RX work
+                if order in _REARM_RX_AFTER_TX_DROP:
+                    await self._bus.restart_rx()
+            elif recover:
+                await self._rearm_rx()  # forced re-attach after a rebuild
+            else:
+                await self._arm_rx()  # may raise → caller unwinds
+            self._state = AudioSessionState.RX_ONLY
+        else:  # RX_TX
+            # _enter_rx_tx owns its terminal state: it settles at RX_ONLY on a
+            # deferred-arm TX failure (no demanding caller), else RX_TX.
+            await self._enter_rx_tx(order, recover=recover)
 
-    async def _enter_rx_tx(
-        self, order: _SetupOrder, current: AudioSessionState
-    ) -> None:
-        if current is AudioSessionState.TX_ONLY:
+    async def _ensure_tx_live(self) -> None:
+        """Idempotent ``start_tx`` against the OBSERVED transport TX leg."""
+        if self._tx_leg_live():
+            return
+        try:
+            await self._radio.start_tx()
+        except AudioAlreadyStartedError:
+            logger.debug("audio-session: TX already live on converge", exc_info=True)
+
+    async def _enter_rx_tx(self, order: _SetupOrder, *, recover: bool = False) -> None:
+        # Derive the entry sub-case from OBSERVED liveness (not self._state),
+        # so the preserved MOR-556/559/574 call sequences are correct after a
+        # transport rebuild. The actual start_*/stop_* sequences below are
+        # copied verbatim from the pre-reconciler _enter_rx_tx.
+        tx_live = self._tx_leg_live()
+        # On the recover edge the bus rx_active flag is stale (transport was
+        # rebuilt underneath it): treat RX as down and force a fresh re-arm,
+        # so RX_TX recovery runs the clean from-scratch ordering.
+        rx_live = self._bus.rx_active and not recover
+        arm_rx = self._rearm_rx if recover else self._arm_rx
+        if tx_live and rx_live:
+            # Already RX_TX: a repeat demand edge (a second sub/lease) joins
+            # the live legs idempotently — no re-arm, no double-start.
+            await self._arm_rx()  # new subscribers join the live RX leg
+            self._state = AudioSessionState.RX_TX
+            return
+        if tx_live and not rx_live:
             # Full-duplex only (TX_ONLY is unreachable elsewhere): the TX leg
             # is already up and RX demand just arrived. The LAN ``start_rx``
             # requires the stream's IDLE baseline, so RX cannot join while the
@@ -508,17 +583,17 @@ class AudioSession:
             # same clean rx_first ordering used from IDLE). RX is brief-gap
             # free for the operator since no RX subscriber existed yet anyway.
             await self._disarm_tx()
-            await self._arm_rx()
+            await arm_rx()
             await self._radio.start_tx()
             self._state = AudioSessionState.RX_TX
             return
-        if current is AudioSessionState.IDLE:
+        if not tx_live and not rx_live:
             # Reached only via subscribe_rx (TX demand was deferred at
             # IDLE), so a TX arm failure here has no demanding caller to
             # raise to: log, settle at RX_ONLY, keep the leases — the next
             # demand edge retries (the step-20 recovery loop owns more).
             if order == "rx_first":
-                await self._arm_rx()
+                await arm_rx()
                 try:
                     await self._radio.start_tx()
                 except Exception:
@@ -536,11 +611,11 @@ class AudioSession:
                         "audio-session: deferred TX arm failed — RX_ONLY",
                         exc_info=True,
                     )
-                    await self._arm_rx()
+                    await arm_rx()
                     self._state = AudioSessionState.RX_ONLY
                     return
                 try:
-                    await self._arm_rx()
+                    await arm_rx()
                 except BaseException:
                     await self._disarm_tx()  # never leave TX without RX
                     raise
@@ -574,6 +649,22 @@ class AudioSession:
                 "radio RX failed to start for the session subscription "
                 "(AudioBus.rx_active is False after subscribe); see "
                 "'audio-bus: failed to start RX' in the log"
+            )
+
+    async def _rearm_rx(self) -> None:
+        """Force a fresh RX re-attach after a transport rebuild (recover edge).
+
+        Unlike :meth:`_arm_rx` (which joins an already-live leg), this drives
+        ``bus.restart_rx`` so the bus callback is re-wired onto the rebuilt
+        transport regardless of the bus's stale ``rx_active`` flag. Surfaces a
+        dead-RX re-arm to the caller so recovery can report FAILED.
+        """
+        await self._bus.restart_rx()
+        if self._rx_subs and not self._bus.rx_active:
+            raise RuntimeError(
+                "radio RX failed to re-establish after reconnect "
+                "(AudioBus.rx_active is False after re-arm); see "
+                "'audio-bus: failed to re-arm RX' in the log"
             )
 
     async def _disarm_tx(self) -> None:
@@ -615,57 +706,18 @@ class AudioSession:
         """
         async with self._lock:
             self._recovering_from = None
-            desired = self._desired()
-            if desired is AudioSessionState.IDLE:
-                # Demand dropped during the outage — nothing to resurrect.
-                self._state = AudioSessionState.IDLE
-                await self._sync_watchdog()
-                return
-            order = self._setup_order()
-            tx_wanted = desired is AudioSessionState.RX_TX
-            tx_live = False
-            if tx_wanted and order != "rx_first":
-                # "tx_first"/"atomic": the TX leg must be up before RX
-                # joins the device (the MOR-559 live-validated order).
-                tx_live = await self._try_rearm_tx()
-            await self._bus.restart_rx()
-            if not self._bus.rx_active:
-                if tx_live:
-                    await self._disarm_tx()  # never leave TX without RX
-                self._state = AudioSessionState.RX_ONLY
-                self._rx_armed_at = self._monotonic()
-                await self._sync_watchdog()
-                raise RuntimeError(
-                    "radio RX failed to re-establish after reconnect "
-                    "(AudioBus.rx_active is False after re-arm); see "
-                    "'audio-bus: failed to re-arm RX' in the log"
-                )
-            if tx_wanted and order == "rx_first":
-                tx_live = await self._try_rearm_tx()
-            self._state = (
-                AudioSessionState.RX_TX if tx_live else AudioSessionState.RX_ONLY
-            )
-            # Fresh liveness reference: silence is measured from this
-            # re-arm, not from the stale pre-outage heartbeat.
+            # Converge against the rebuilt (RECEIVING/idle) transport. recover
+            # forces a fresh RX re-attach (the bus rx_active flag is stale).
+            # TX_ONLY / RX_ONLY / RX_TX / IDLE recovery all fall out of this:
+            # demand dropped during the outage stays dropped (IDLE), a held
+            # lease re-arms TX (TX_ONLY) with no phantom RX, RX-bearing demand
+            # re-arms in the declared order. A dead-RX re-arm surfaces as a
+            # RuntimeError so the recovery caller can report FAILED.
+            await self._converge(recover=True)
+            # Fresh liveness reference: silence is measured from this re-arm,
+            # not from the stale pre-outage heartbeat.
             self._rx_armed_at = self._monotonic()
             await self._sync_watchdog()
-
-    async def _try_rearm_tx(self) -> bool:
-        """Best-effort TX re-arm for :meth:`reestablish`; True when live.
-
-        Mirrors the deferred-arm policy in :meth:`_enter_rx_tx`: a TX
-        failure here has no demanding caller to raise to — settle at
-        RX_ONLY, keep the leases, and let the next demand edge (or the
-        next reconnect) retry.
-        """
-        try:
-            await self._radio.start_tx()
-        except AudioAlreadyStartedError:
-            logger.debug("audio-session: TX already live on re-arm", exc_info=True)
-        except Exception:
-            logger.warning("audio-session: TX re-arm failed — RX_ONLY", exc_info=True)
-            return False
-        return True
 
     # ── Health watchdog (MOR-581 — surface only, recovery is step 20) ────
 

--- a/tests/test_audio_recovery_session.py
+++ b/tests/test_audio_recovery_session.py
@@ -252,6 +252,107 @@ async def test_no_leaked_watchdog_task_across_reconnect_cycle() -> None:
     assert task.done()  # cancelled AND awaited — nothing leaked
 
 
+# ── reestablish × prior-demand matrix (the reconciler invariant) ─────────────
+
+
+def _assert_converged(session: AudioSession, radio: LanLikeRadio) -> None:
+    """state == _desired() AND observed transport legs match (PLAN I2)."""
+    state = session.state
+    desired = session._desired()  # noqa: SLF001
+    assert state is desired, f"state {state} != desired {desired}"
+    rx_live = session.bus.rx_active
+    tx_live = radio.state == "transmitting"
+    if state in (AudioSessionState.RX_ONLY, AudioSessionState.RX_TX):
+        assert rx_live is True
+    else:
+        assert rx_live is False
+    if state in (AudioSessionState.TX_ONLY, AudioSessionState.RX_TX):
+        assert tx_live is True
+    else:
+        assert tx_live is False
+
+
+async def test_reestablish_rearms_tx_only_digital_session() -> None:
+    """The ad7737ce seed scenario, re-anchored on the reconciler INVARIANT.
+
+    A digital client (FT8/WSJT-X) holds ONLY a TX lease (no RX subscription),
+    so the session is TX_ONLY. A soft_reconnect / recovery tears the LAN
+    stream down and calls ``reestablish``: the TX leg must be re-armed so the
+    next pushed frame reaches the radio — pre-reconciler ``reestablish``
+    stranded it at RX_ONLY and every later push raised ``Cannot push TX in
+    state receiving``. Asserted via the invariant (converged + push succeeds),
+    not the old branch, proving the band-aid's scenario is covered
+    structurally (the `(TX_ONLY × recovery)` composition).
+    """
+    radio = LanLikeRadio()
+    session = AudioSession(radio)
+    lease = await session.acquire_tx("wsjtx")
+    await lease.push(b"\x00\x01")  # push converges → TX_ONLY
+    assert session.state is AudioSessionState.TX_ONLY
+
+    _wipe(radio)  # reconnect: fresh LAN stream comes back RECEIVING/idle
+
+    await session.reestablish()
+
+    _assert_converged(session, radio)
+    assert session.state is AudioSessionState.TX_ONLY
+    assert session.bus.subscriber_count == 0  # no phantom RX resurrected
+    # The push that previously raised AudioNotStartedError now succeeds.
+    await lease.push(b"\x00\x01")
+    assert radio.state == "transmitting"
+    await lease.release()
+    assert session.state is AudioSessionState.IDLE
+
+
+async def test_reestablish_rx_tx_recovery_converges() -> None:
+    """`(RX_TX × recovery)`: both legs re-arm in the rx_first order."""
+    radio = LanLikeRadio()
+    session = AudioSession(radio)
+    sub = await session.subscribe_rx("web")
+    lease = await session.acquire_tx("ptt")
+    assert session.state is AudioSessionState.RX_TX
+    _wipe(radio)
+
+    await session.reestablish()
+
+    _assert_converged(session, radio)
+    assert session.state is AudioSessionState.RX_TX
+    assert radio.calls == ["start_rx", "start_tx"]  # rx_first order preserved
+    await lease.push(b"\x00\x01")  # I1: held lease pushes after recovery
+    await lease.release()
+    await sub.release()
+
+
+async def test_reestablish_rx_only_recovery_converges() -> None:
+    """`(RX_ONLY × recovery)`: RX re-attaches, no TX resurrected."""
+    radio = LanLikeRadio()
+    session = AudioSession(radio)
+    sub = await session.subscribe_rx("web")
+    assert session.state is AudioSessionState.RX_ONLY
+    _wipe(radio)
+
+    await session.reestablish()
+
+    _assert_converged(session, radio)
+    assert session.state is AudioSessionState.RX_ONLY
+    await sub.release()
+
+
+async def test_reestablish_idle_recovery_resurrects_nothing() -> None:
+    """`(IDLE × recovery)`: demand dropped during the outage stays dropped."""
+    radio = LanLikeRadio()
+    session = AudioSession(radio)
+    sub = await session.subscribe_rx("web")
+    await sub.release()
+    _wipe(radio)
+
+    await session.reestablish()
+
+    _assert_converged(session, radio)
+    assert session.state is AudioSessionState.IDLE
+    assert radio.calls == []
+
+
 # ── Recovery runtime routing (the desync falsification) ──────────────────────
 
 

--- a/tests/test_audio_session.py
+++ b/tests/test_audio_session.py
@@ -232,7 +232,15 @@ async def test_demand_permutations_converge(make_radio: type) -> None:
 
 
 async def test_acquire_tx_at_idle_defers_arming() -> None:
-    """A TX lease at IDLE registers demand but arms nothing (no TX_ONLY)."""
+    """A bare TX lease at IDLE registers demand but arms nothing (no flap).
+
+    MOR-934: ``_desired()`` is intent-gated by the OBSERVED TX leg — a bare
+    ``acquire_tx`` (no RX, TX leg not yet live) defers, so the bridge's
+    lease-then-RX order converges straight to RX_TX with a SINGLE start_tx
+    and never flaps the TX leg (MOR-556). The lone TX leg is armed only when
+    TX intent goes active (a push, or a reestablish of a session that was
+    transmitting) — see TX_ONLY push / recovery tests.
+    """
     radio = LanLikeRadio()
     session = AudioSession(radio)
     lease = await session.acquire_tx("ptt")
@@ -241,8 +249,28 @@ async def test_acquire_tx_at_idle_defers_arming() -> None:
     assert radio.calls == []  # nothing armed — the MOR-556 trap avoided
     await session.subscribe_rx("a")
     assert session.state is AudioSessionState.RX_TX
-    assert radio.calls == ["start_rx", "start_tx"]  # rx_first order
+    assert radio.calls == ["start_rx", "start_tx"]  # rx_first order, one arm
     await lease.release()
+
+
+async def test_lease_push_arms_tx_only_on_full_duplex() -> None:
+    """A held lease that pushes with no RX arms TX_ONLY (intent goes active).
+
+    The digital-TX (FT8/WSJT-X over the companion) path: a bare lease defers,
+    but the first ``push`` converges the lone TX leg into TX_ONLY so the frame
+    reaches the radio instead of being rejected (push converges, never
+    rejects). Exclusive/atomic transports keep deferring (no TX_ONLY mode)."""
+    radio = LanLikeRadio()
+    session = AudioSession(radio)
+    lease = await session.acquire_tx("wsjtx")
+    assert session.state is AudioSessionState.IDLE
+    assert radio.calls == []
+    await lease.push(b"\x00\x01")  # push converges → TX_ONLY
+    assert session.state is AudioSessionState.TX_ONLY
+    assert radio.state == "transmitting"
+    assert session.bus.subscriber_count == 0  # no phantom RX
+    await lease.release()
+    assert session.state is AudioSessionState.IDLE
 
 
 # ── audio_setup_order drives arming (descriptor-read, not hardcoded) ─────────
@@ -358,16 +386,23 @@ async def test_teardown_stops_tx_before_rx(release_order: str) -> None:
     assert session.bus.subscriber_count == 0
 
 
-async def test_rx_demand_returning_rearms_held_tx_lease() -> None:
-    """A lease held across an RX gap re-arms when RX demand returns."""
+async def test_rx_demand_dropping_with_live_tx_keeps_tx_only() -> None:
+    """RX_TX → drop RX while TX is live converges to TX_ONLY (mode change).
+
+    MOR-934: TX intent is active (the TX leg is up), so dropping the RX sub
+    sheds RX but keeps the lone TX leg — the SSB → FT8 excursion. No phantom
+    RX is resurrected. RX returning converges back to RX_TX.
+    """
     radio = LanLikeRadio()
     session = AudioSession(radio)
     sub = await session.subscribe_rx("a")
     await session.acquire_tx("ptt")
-    await sub.release()  # rx → 0 while the lease is held
-    assert session.state is AudioSessionState.IDLE
+    assert session.state is AudioSessionState.RX_TX
+    await sub.release()  # rx → 0 while the lease is held and TX is live
+    assert session.state is AudioSessionState.TX_ONLY
     assert session.tx_demand == 1
-    assert radio.state == "idle"
+    assert session.bus.subscriber_count == 0  # no phantom RX
+    assert radio.state == "transmitting"
     await session.subscribe_rx("b")  # demand convergence
     assert session.state is AudioSessionState.RX_TX
     assert radio.state == "transmitting"

--- a/tests/test_audio_session_invariants.py
+++ b/tests/test_audio_session_invariants.py
@@ -1,0 +1,275 @@
+"""AudioSession reconciler invariants — deterministic enumeration (MOR-934).
+
+The session is a declarative reconciler: desired state is a PURE function of
+declared demand, and every edge drives the transport to that desired state by
+diffing against OBSERVED transport leg liveness. These invariants pin the
+contract the scattered arming sites used to violate:
+
+- **I1** — a held ``TxLease`` IS TX demand: from every reachable state, a
+  ``lease.push`` on a full-duplex transport converges (arms TX) and never
+  raises ``AudioNotStartedError``.
+- **I2** — every transition converges: after any single public input the
+  session state equals ``_desired()`` (modulo transient RECOVERING) AND the
+  observed transport legs match it.
+- **I3** — TX-only never resurrects RX: a TX-only convergence/recovery keeps
+  ``bus.subscriber_count == 0``.
+- **I4** — teardown order: ``stop_rx`` is never called from a TRANSMITTING
+  transport, across all transitions including post-recovery.
+
+No ``hypothesis`` dependency: the state space is tiny and bounded, so a
+parametrized enumeration over short operation prefixes gives full, fully
+deterministic coverage (PLAN §D.4).
+"""
+
+from __future__ import annotations
+
+import itertools
+
+import pytest
+from _order_sensitive_radios import ExclusiveUsbRadio, LanLikeRadio
+
+from rigplane.audio.session import (
+    AudioSession,
+    AudioSessionState,
+    RxSubscription,
+    TxLease,
+)
+from rigplane.audio.usb_driver import AudioNotStartedError
+
+_TX_FRAME = b"\x01\x00" * 160
+
+
+# ── Observed-liveness helpers (read the transport, never session._state) ─────
+
+
+def _tx_leg_live(radio: object) -> bool:
+    """Observed transport TX state — mirrors ``AudioSession._tx_leg_live``."""
+    st = getattr(radio, "state", None)
+    if st is not None:
+        return str(getattr(st, "value", st)).lower() == "transmitting"
+    return bool(getattr(radio, "tx_running", False))
+
+
+def _rx_leg_live(session: AudioSession) -> bool:
+    return session.bus.rx_active
+
+
+def assert_converged(session: AudioSession, radio: object) -> None:
+    """I2 post-condition: session state == _desired() and transport matches."""
+    state = session.state
+    if state is AudioSessionState.RECOVERING:
+        return  # transient watchdog overlay — not a steady-state assertion
+    desired = session._desired()  # noqa: SLF001
+    assert state is desired, f"state {state} != desired {desired}"
+    if state in (AudioSessionState.RX_ONLY, AudioSessionState.RX_TX):
+        assert _rx_leg_live(session) is True, "RX leg must be live"
+    else:
+        assert _rx_leg_live(session) is False, "RX leg must be down"
+    if state in (AudioSessionState.TX_ONLY, AudioSessionState.RX_TX):
+        assert _tx_leg_live(radio) is True, "TX leg must be live"
+    else:
+        assert _tx_leg_live(radio) is False, "TX leg must be down"
+
+
+async def assert_push_succeeds(
+    session: AudioSession, lease: TxLease, radio: object
+) -> None:
+    """I1 post-condition: a held-lease push converges and never rejects."""
+    await lease.push(_TX_FRAME)
+    assert _tx_leg_live(radio) is True
+
+
+# ── I1 / I2 enumeration: every reachable state × every public edge ───────────
+
+_DEMAND_PREFIXES: list[tuple[str, ...]] = [
+    seq
+    for n in range(0, 4)
+    for seq in itertools.product(("sub_rx", "rel_rx", "acq_tx", "rel_tx"), repeat=n)
+]
+
+
+async def _apply_op(
+    session: AudioSession,
+    op: str,
+    subs: list[RxSubscription],
+    leases: list[TxLease],
+) -> None:
+    if op == "sub_rx":
+        subs.append(await session.subscribe_rx(f"rx{len(subs)}"))
+    elif op == "rel_rx":
+        if subs:
+            await subs.pop().release()
+    elif op == "acq_tx":
+        leases.append(await session.acquire_tx(f"tx{len(leases)}"))
+    elif op == "rel_tx":
+        if leases:
+            await leases.pop().release()
+
+
+@pytest.mark.parametrize("prefix", _DEMAND_PREFIXES)
+async def test_i2_every_demand_transition_converges(prefix: tuple[str, ...]) -> None:
+    """I2: after every demand op the session converges to _desired() (LAN)."""
+    radio = LanLikeRadio()
+    session = AudioSession(radio)
+    subs: list[RxSubscription] = []
+    leases: list[TxLease] = []
+    try:
+        assert_converged(session, radio)
+        for op in prefix:
+            await _apply_op(session, op, subs, leases)
+            assert_converged(session, radio)
+    finally:
+        for lease in leases:
+            await lease.release()
+        for sub in subs:
+            await sub.release()
+
+
+@pytest.mark.parametrize(
+    "prefix",
+    [
+        ("acq_tx",),  # bare lease@IDLE -> push converges to TX_ONLY
+        ("sub_rx", "acq_tx"),  # acquire_tx@RX_ONLY -> RX_TX
+        ("acq_tx", "sub_rx"),  # subscribe after a deferred lease -> RX_TX
+        ("sub_rx", "acq_tx", "rel_rx"),  # drop RX while TX live -> TX_ONLY
+        ("acq_tx", "sub_rx", "rel_rx"),  # mode-change shape -> TX_ONLY
+    ],
+)
+async def test_i1_held_lease_push_never_rejects(prefix: tuple[str, ...]) -> None:
+    """I1: a held TX lease always converges to a pushable TX leg (LAN).
+
+    Whether the lease was deferred (bare ``acquire_tx``) or the TX leg is
+    already live, a ``push`` converges and never raises (push-converges).
+    """
+    radio = LanLikeRadio()
+    session = AudioSession(radio)
+    subs: list[RxSubscription] = []
+    leases: list[TxLease] = []
+    for op in prefix:
+        await _apply_op(session, op, subs, leases)
+    assert leases, "prefix must leave a held lease"
+    lease = leases[-1]
+    assert lease.released is False
+    await assert_push_succeeds(session, lease, radio)
+    assert_converged(session, radio)
+
+
+async def test_i1_push_from_tx_only_after_reestablish() -> None:
+    """I1 × recovery: TX-only push after a transport rebuild still converges."""
+    radio = LanLikeRadio()
+    session = AudioSession(radio)
+    lease = await session.acquire_tx("wsjtx")
+    await lease.push(_TX_FRAME)  # push converges → TX_ONLY (intent active)
+    assert session.state is AudioSessionState.TX_ONLY
+    radio.state = "idle"  # simulate a transport rebuild (reconnect)
+    radio.rx_callback = None
+    radio.calls.clear()
+    await session.reestablish()
+    await assert_push_succeeds(session, lease, radio)
+    assert_converged(session, radio)
+    assert session.state is AudioSessionState.TX_ONLY
+
+
+# ── I3: TX-only never resurrects RX ──────────────────────────────────────────
+
+
+async def test_i3_tx_only_keeps_zero_rx_subscribers() -> None:
+    radio = LanLikeRadio()
+    session = AudioSession(radio)
+    lease = await session.acquire_tx("wsjtx")
+    await lease.push(_TX_FRAME)  # push converges → TX_ONLY
+    assert session.state is AudioSessionState.TX_ONLY
+    assert session.bus.subscriber_count == 0
+    # Across a rebuild + reestablish the phantom RX must never appear.
+    radio.state = "idle"
+    radio.rx_callback = None
+    await session.reestablish()
+    assert session.bus.subscriber_count == 0
+    assert session.state is AudioSessionState.TX_ONLY
+    await lease.release()
+
+
+# ── I4: stop_rx is never called from a TRANSMITTING transport ────────────────
+
+
+class _RecordingLanRadio(LanLikeRadio):
+    """Records the transport state each stop_* call was made from (MOR-574)."""
+
+    async def stop_rx(self) -> None:
+        self.calls.append(f"stop_rx@{self.state}")
+        await super().stop_rx()
+
+    async def stop_tx(self) -> None:
+        self.calls.append(f"stop_tx@{self.state}")
+        await super().stop_tx()
+
+
+@pytest.mark.parametrize(
+    "prefix",
+    [
+        ("sub_rx", "acq_tx", "rel_tx", "rel_rx"),
+        ("sub_rx", "acq_tx", "rel_rx", "rel_tx"),
+        ("acq_tx", "sub_rx", "rel_rx"),
+        ("acq_tx", "sub_rx", "rel_rx", "rel_tx"),
+    ],
+)
+async def test_i4_no_stop_rx_from_transmitting(prefix: tuple[str, ...]) -> None:
+    radio = _RecordingLanRadio()
+    session = AudioSession(radio)
+    subs: list[RxSubscription] = []
+    leases: list[TxLease] = []
+    for op in prefix:
+        await _apply_op(session, op, subs, leases)
+    assert "stop_rx@transmitting" not in radio.calls
+    for lease in leases:
+        await lease.release()
+    for sub in subs:
+        await sub.release()
+    assert "stop_rx@transmitting" not in radio.calls
+
+
+async def test_i4_no_stop_rx_from_transmitting_post_recovery() -> None:
+    """I4 across a recovery cycle (the gap the old suite never checked)."""
+    radio = _RecordingLanRadio()
+    session = AudioSession(radio)
+    sub = await session.subscribe_rx("a")
+    lease = await session.acquire_tx("ptt")
+    assert session.state is AudioSessionState.RX_TX
+    # Rebuild the transport, then reestablish (recovery) and tear down.
+    radio.state = "idle"
+    radio.rx_callback = None
+    radio.calls.clear()
+    await session.reestablish()
+    await lease.release()
+    await sub.release()
+    assert "stop_rx@transmitting" not in radio.calls
+    assert session.state is AudioSessionState.IDLE
+
+
+# ── Test-double sanity (PLAN §D.5): desync must stay detectable ──────────────
+
+
+def test_double_rejects_push_when_not_armed() -> None:
+    """LAN double rejects push unless transmitting (the desync teeth)."""
+    radio = LanLikeRadio()
+
+    async def _run() -> None:
+        with pytest.raises(AudioNotStartedError):
+            await radio.push_tx(_TX_FRAME)
+
+    import asyncio
+
+    asyncio.run(_run())
+
+
+def test_tx_leg_live_agrees_with_double_flags() -> None:
+    """_tx_leg_live must read both double shapes identically (PLAN §D.5)."""
+    lan = LanLikeRadio()
+    assert _tx_leg_live(lan) is False
+    lan.state = "transmitting"
+    assert _tx_leg_live(lan) is True
+
+    usb = ExclusiveUsbRadio()
+    assert _tx_leg_live(usb) is False
+    usb.tx_running = True
+    assert _tx_leg_live(usb) is True

--- a/tests/test_web_audio_tx_session.py
+++ b/tests/test_web_audio_tx_session.py
@@ -110,6 +110,8 @@ async def test_web_lease_coexists_with_bridge_lease_on_same_session() -> None:
     bridge_lease = await session.acquire_tx("audio-bridge")
     bridge_rx = await session.subscribe_rx("audio-bridge")
     assert radio.state == "transmitting"
+    # MOR-934: the bare bridge lease defers, RX arrival converges straight to
+    # RX_TX with a SINGLE start_tx (no flap) — the MOR-556 order preserved.
     assert radio.calls.count("start_tx") == 1
 
     handler = _make_handler(radio)
@@ -199,8 +201,10 @@ async def test_digital_tx_no_rx_subscriber_pushes_without_error() -> None:
     (session IDLE, ``start_tx`` never called), and the first ``_handle_tx_audio``
     frame raised ``AudioNotStartedError``.
 
-    Post-fix: the first push lazily arms the TX leg (session → TX_ONLY) on the
-    full-duplex transport, so the frame reaches the radio.
+    Post-fix (MOR-934): a bare lease defers (the MOR-556 lease-then-RX order
+    must not flap TX), but a ``push`` with a held lease and no RX CONVERGES
+    the lone TX leg into TX_ONLY (push converges, never rejects), so the frame
+    reaches the radio instead of raising ``AudioNotStartedError``.
     """
     radio = _SessionLanRadio()
     session = radio.audio_session
@@ -214,8 +218,8 @@ async def test_digital_tx_no_rx_subscriber_pushes_without_error() -> None:
     assert session.state is AudioSessionState.IDLE
     assert radio.state != "transmitting"
 
-    # The browser/companion TX frame must reach the radio, not raise
-    # AudioNotStartedError. The push lazily arms TX (→ TX_ONLY).
+    # The browser/companion TX frame reaches the radio: the push converges
+    # the lone TX leg (→ TX_ONLY), never raising AudioNotStartedError.
     await handler._handle_tx_audio(_pcm_tx_frame(b"ft8-tx-modulation"))
     assert radio.pushed == [b"ft8-tx-modulation"]
     assert session.state is AudioSessionState.TX_ONLY


### PR DESCRIPTION
Root cause: scattered imperative TX arming plus a reestablish path that never handled the `TX_ONLY` state, leaving the audio session stranded TX-only after a reconnect.

Fix: a pure `_desired()` function computes the target state, and a single idempotent `_converge()` drives toward it. Push events converge rather than reject, and TX arming is intent-gated so the MOR-556 ordering invariant is preserved.

Closes #1226
Closes #1212

Independently verified PASS (adversarial Opus review): RED confirmed on main, invariants I1-I4 verified strong, MOR-556/559/574 order tests byte-for-byte unchanged, public API unchanged.

Out of scope:
- #1215 RX stale-FD (separate issue)
- CAT-PTT first-class plumbing (deferred)

Release gate: live-hardware SSB<->FT8 TX re-test required before the pro beta.9 public flip.