### PR TITLE
fix: core quick-wins — broadcast flood (#1876), diag log default (#1879), idle state-build gate (#1877)

### DIFF
--- a/src/rigplane/diagnostics/_logging.py
+++ b/src/rigplane/diagnostics/_logging.py
@@ -82,7 +82,9 @@ def configure_diagnostic_logging() -> None:
         # The handler's own level is DEBUG, so any record the logger doesn't
         # filter still hits the file — see spec §4.1.
         if icom_logger.level == logging.NOTSET:
-            icom_logger.setLevel(logging.DEBUG)
+            icom_logger.setLevel(
+                logging.INFO
+            )  # was DEBUG: avoids ~40-57 disk writes/s on the loop (see issue #1879)
     except Exception as exc:  # noqa: BLE001 — best-effort init, swallow all
         sys.stderr.write(f"rigplane: diagnostic logging disabled: {exc}\n")
 

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -1347,10 +1347,9 @@ class WebServer:
 
         target_queues = self._control_event_queues if queues is None else queues
         for q in list(target_queues):
-            try:
-                q.put_nowait(event)
-            except asyncio.QueueFull:
-                logger.warning("control state queue full; dropping state_update")
+            # A state_update supersedes older queued state; coalesce-to-latest on a
+            # stalled/slow consumer instead of dropping the freshest + log-flooding.
+            q.put_drop_oldest(event)
 
     async def _delayed_state_broadcast(self, delay: float) -> None:
         try:

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -1316,6 +1316,10 @@ class WebServer:
         # from the same canonical snapshot used for Web delivery.
         self._update_fft_scope_freq(snapshot)
         self._update_fft_scope_mode(snapshot)
+        # Skip the public-state build/delta/fan-out when no control client is
+        # subscribed (a connecting client gets initial state on connect via force=True).
+        if not force and not self._control_event_queues:
+            return
         body = self._build_public_state_from_snapshot(snapshot)
         state_key = self._public_state_delivery_key(
             snapshot,

--- a/tests/test_diagnostics_logging.py
+++ b/tests/test_diagnostics_logging.py
@@ -132,7 +132,7 @@ def test_log_file_writes_to_platformdirs_cache(
     monkeypatch.setattr(platformdirs, "user_cache_path", lambda app: tmp_path)
     configure_diagnostic_logging()
     logger = logging.getLogger("rigplane.test")
-    logger.debug("hello")
+    logger.info("hello")  # use INFO: default level is now INFO (not DEBUG, see #1879)
     log_file = tmp_path / "logs" / "rigplane.log"
     assert log_file.exists()
     assert "hello" in log_file.read_text(encoding="utf-8")
@@ -147,7 +147,9 @@ def test_log_file_honors_rigplane_log_dir(
 
     configure_diagnostic_logging()
     logger = logging.getLogger("rigplane.test")
-    logger.debug("hello from env")
+    logger.info(
+        "hello from env"
+    )  # use INFO: default level is now INFO (not DEBUG, see #1879)
 
     log_file = log_dir / "rigplane.log"
     assert log_file.exists()
@@ -175,12 +177,17 @@ def test_preset_logger_level_preserved(
         icom_logger.setLevel(logging.NOTSET)
 
 
-def test_unset_logger_level_set_to_debug(
+def test_unset_logger_level_set_to_info(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """When the logger level is NOTSET, init promotes it to DEBUG."""
+    """When the logger level is NOTSET, init promotes it to INFO (not DEBUG).
+
+    Changed in #1879: defaulting to DEBUG caused ~40-57 disk writes/sec on
+    the event loop at idle. INFO is the new production default; DEBUG remains
+    opt-in via an explicit setLevel call before configure_diagnostic_logging.
+    """
     monkeypatch.setattr(platformdirs, "user_cache_path", lambda app: tmp_path)
     icom_logger = logging.getLogger("rigplane")
     icom_logger.setLevel(logging.NOTSET)
     configure_diagnostic_logging()
-    assert icom_logger.level == logging.DEBUG
+    assert icom_logger.level == logging.INFO

--- a/tests/test_diagnostics_logging.py
+++ b/tests/test_diagnostics_logging.py
@@ -18,13 +18,20 @@ from rigplane.diagnostics._logging import (
 
 @pytest.fixture(autouse=True)
 def _enable_diagnostic_logging(monkeypatch: pytest.MonkeyPatch) -> Any:
-    """Re-enable diagnostic logging locally for each test, then clean up."""
+    """Re-enable diagnostic logging locally for each test, then clean up.
+
+    Also snapshots and restores the ``rigplane`` logger level so that tests
+    calling ``configure_diagnostic_logging()`` (which promotes NOTSET → INFO
+    since #1879) do not pollute the logger state for subsequent tests.
+    """
     monkeypatch.delenv("RIGPLANE_DISABLE_DIAGNOSTIC_LOGGING", raising=False)
-    yield
     icom_logger = logging.getLogger("rigplane")
+    saved_level = icom_logger.level
+    yield
     icom_logger.handlers = [
         h for h in icom_logger.handlers if not isinstance(h, SafeRotatingFileHandler)
     ]
+    icom_logger.setLevel(saved_level)
 
 
 def test_handler_attached_to_icom_lan_logger_not_root(

--- a/tests/test_quickwins_regression.py
+++ b/tests/test_quickwins_regression.py
@@ -1,0 +1,203 @@
+"""Regression tests for three quick-win infra fixes.
+
+Issues:
+- #1876: control-state broadcast floods logs when a subscriber stalls
+- #1879: diagnostic logging forced to DEBUG by default
+- #1877 (2a only): state-broadcast does heavy work even with zero subscribers
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import platformdirs
+import pytest
+
+from rigplane._bounded_queue import BoundedQueue
+from rigplane.diagnostics._logging import (
+    SafeRotatingFileHandler,
+    configure_diagnostic_logging,
+)
+from rigplane.web.server import WebServer
+
+
+# ---------------------------------------------------------------------------
+# Fix A (#1876) — stalled subscriber must NOT produce log warnings
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=False)
+def _fresh_icom_logger() -> Any:
+    """Ensure the rigplane logger is clean between tests."""
+    icom_logger = logging.getLogger("rigplane")
+    original_level = icom_logger.level
+    original_handlers = list(icom_logger.handlers)
+    yield icom_logger
+    icom_logger.handlers = original_handlers
+    icom_logger.setLevel(original_level)
+
+
+def test_stalled_subscriber_no_log_warnings_on_overflow() -> None:
+    """Fix A (#1876): put_drop_oldest replaces put_nowait + warning.
+
+    A stalled (non-draining) control queue that is full must NOT produce
+    'control state queue full' log warnings. Verify by filling a queue to
+    maxsize and calling _broadcast_state_update many times — zero warnings
+    should be emitted, and the server must not raise.
+    """
+    srv = WebServer(None)
+    stalled: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=4)
+    srv.register_control_event_queue(stalled)
+
+    # Drain the initial state_update pushed by register_control_event_queue
+    while not stalled.empty():
+        stalled.get_nowait()
+
+    # Fill the queue to maxsize with dummy items so it is "stalled"
+    for _ in range(stalled.maxsize):
+        stalled.put_nowait({"type": "state_update", "data": {}})
+
+    assert stalled.full(), "pre-condition: queue must be full"
+
+    warning_count = 0
+    original_warning = logging.getLogger("rigplane.web.server").warning
+
+    def _count_warning(msg: str, *args: object, **kwargs: object) -> None:
+        nonlocal warning_count
+        if "control state queue full" in str(msg):
+            warning_count += 1
+        original_warning(msg, *args, **kwargs)
+
+    with patch.object(
+        logging.getLogger("rigplane.web.server"),
+        "warning",
+        side_effect=_count_warning,
+    ):
+        # Broadcast many times with the queue still full
+        for _ in range(10):
+            srv._broadcast_state_update(force=True)  # noqa: SLF001
+
+    assert warning_count == 0, (
+        f"Expected 0 'control state queue full' warnings, got {warning_count}. "
+        "Fix A (#1876): replace put_nowait+warning with put_drop_oldest."
+    )
+
+    # The queue must not be empty — drop-oldest ensures the newest event wins
+    assert not stalled.empty(), "Queue should still contain items after drop-oldest"
+
+
+# ---------------------------------------------------------------------------
+# Fix B (#1879) — default effective level must be INFO, not DEBUG
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def _isolated_icom_logger(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Any:
+    """Isolate the rigplane logger for diagnostic-logging tests."""
+    monkeypatch.delenv("RIGPLANE_DISABLE_DIAGNOSTIC_LOGGING", raising=False)
+    monkeypatch.setattr(platformdirs, "user_cache_path", lambda app: tmp_path)
+    icom_logger = logging.getLogger("rigplane")
+    original_level = icom_logger.level
+    icom_logger.setLevel(logging.NOTSET)
+    yield icom_logger
+    icom_logger.handlers = [
+        h for h in icom_logger.handlers if not isinstance(h, SafeRotatingFileHandler)
+    ]
+    icom_logger.setLevel(original_level)
+
+
+def test_default_effective_level_is_info_not_debug(
+    _isolated_icom_logger: logging.Logger,
+) -> None:
+    """Fix B (#1879): when logger level is NOTSET, configure_diagnostic_logging
+    must set it to INFO (not DEBUG) to avoid ~40-57 disk writes/sec on the loop.
+    """
+    configure_diagnostic_logging()
+    level = _isolated_icom_logger.level
+    assert level == logging.INFO, (
+        f"Expected effective level INFO ({logging.INFO}), got {level}. "
+        "Fix B (#1879): change 'setLevel(logging.DEBUG)' to 'setLevel(logging.INFO)'."
+    )
+
+
+def test_env_var_forces_debug_when_set(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Fix B (#1879): ICOM_LOG_LEVEL=DEBUG must still opt-in to DEBUG.
+
+    The env var escape hatch for debugging must continue to work
+    after the default is changed to INFO.
+    """
+    monkeypatch.delenv("RIGPLANE_DISABLE_DIAGNOSTIC_LOGGING", raising=False)
+    monkeypatch.setattr(platformdirs, "user_cache_path", lambda app: tmp_path)
+    icom_logger = logging.getLogger("rigplane")
+    original_level = icom_logger.level
+    try:
+        # Pre-set to DEBUG as if the env var or caller forced it
+        icom_logger.setLevel(logging.DEBUG)
+        configure_diagnostic_logging()
+        # configure_diagnostic_logging must NOT override a level already set
+        assert icom_logger.level == logging.DEBUG, (
+            "Level explicitly set to DEBUG before configure_diagnostic_logging "
+            "must be preserved (DEBUG is already set, not NOTSET)."
+        )
+    finally:
+        icom_logger.handlers = [
+            h
+            for h in icom_logger.handlers
+            if not isinstance(h, SafeRotatingFileHandler)
+        ]
+        icom_logger.setLevel(original_level)
+
+
+# ---------------------------------------------------------------------------
+# Fix C (#1877 part 2a) — skip expensive build when no subscribers
+# ---------------------------------------------------------------------------
+
+
+def test_no_subscribers_skips_build(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fix C (#1877 2a): with zero control subscribers and force=False,
+    _build_public_state_from_snapshot must NOT be called.
+    """
+    srv = WebServer(None)
+    assert not srv._control_event_queues, "pre-condition: no subscribers"  # noqa: SLF001
+
+    build_calls: list[object] = []
+    original_build = srv._build_public_state_from_snapshot  # noqa: SLF001
+
+    def _spy_build(*args: object, **kwargs: object) -> object:
+        build_calls.append(True)
+        return original_build(*args, **kwargs)
+
+    monkeypatch.setattr(srv, "_build_public_state_from_snapshot", _spy_build)
+
+    srv._broadcast_state_update(force=False)  # noqa: SLF001
+
+    assert len(build_calls) == 0, (
+        f"Expected _build_public_state_from_snapshot NOT called with zero "
+        f"subscribers and force=False, but was called {len(build_calls)} time(s). "
+        "Fix C (#1877 2a): add 'if not force and not self._control_event_queues: return'."
+    )
+
+
+def test_connecting_client_still_gets_initial_state() -> None:
+    """Fix C (#1877 2a): force=True (used on connect) must still build and deliver."""
+    srv = WebServer(None)
+    q: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=8)
+    srv.register_control_event_queue(q)
+
+    # Drain the connect-time event
+    while not q.empty():
+        q.get_nowait()
+
+    # force=True path must always build
+    srv._broadcast_state_update(force=True)  # noqa: SLF001
+    assert not q.empty(), (
+        "force=True must deliver a state_update even with one subscriber. "
+        "Fix C (#1877 2a): ensure force=True bypasses the subscriber-count gate."
+    )
+    event = q.get_nowait()
+    assert event["type"] == "state_update"

--- a/tests/test_state_pipeline_contracts.py
+++ b/tests/test_state_pipeline_contracts.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import json
 from typing import Any
 
@@ -26,6 +25,7 @@ from rigplane.core.state_pipeline_contracts import (
 from rigplane.radio_state import RadioState
 from rigplane.web.radio_poller import RadioPoller
 from rigplane.web.runtime_helpers import build_public_state_payload_from_snapshot
+from rigplane._bounded_queue import BoundedQueue
 from rigplane.web.server import WebConfig, WebServer
 
 _LEGACY_POLLER_REVISION = 987_654
@@ -742,7 +742,7 @@ async def test_web_delivery_payloads_use_snapshot_not_legacy_state_or_revision()
     assert envelope["type"] == "full"
     _assert_delivered_from_snapshot(envelope["data"], snapshot)
 
-    queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+    queue: BoundedQueue[dict[str, Any]] = BoundedQueue(maxsize=16)
     server.register_control_event_queue(queue)
     server._last_state_broadcast = 0.0  # noqa: SLF001
     server._broadcast_state_update()  # noqa: SLF001
@@ -765,7 +765,7 @@ async def test_web_delivery_payloads_use_snapshot_not_legacy_state_or_revision()
 
 def test_web_state_change_callback_broadcasts_snapshot_without_revision_path() -> None:
     server, snapshot = _server_with_conflicting_legacy_state()
-    queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+    queue: BoundedQueue[dict[str, Any]] = BoundedQueue(maxsize=16)
     server.register_control_event_queue(queue)
 
     server._on_radio_state_change(  # noqa: SLF001

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -1922,7 +1922,7 @@ def test_meter_only_state_store_change_emits_web_delta_without_legacy_revision()
     None
 ):
     srv = WebServer(None)
-    q = asyncio.Queue()
+    q: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=16)
     srv.register_control_event_queue(q)
     srv.command_state_store.apply(
         _store_observation(
@@ -1961,7 +1961,7 @@ def test_freshness_only_state_store_change_emits_web_delta() -> None:
     srv.command_state_store = store
     srv.command_service._state_store = store  # noqa: SLF001
     srv._http_command_service._state_store = store  # noqa: SLF001
-    q = asyncio.Queue()
+    q: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=16)
     srv.register_control_event_queue(q)
 
     store.apply(
@@ -1995,7 +1995,7 @@ def test_freshness_only_state_store_change_emits_web_delta() -> None:
 
 def test_same_value_observation_metadata_change_emits_web_delta() -> None:
     srv = WebServer(None)
-    q = asyncio.Queue()
+    q: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=16)
     srv.register_control_event_queue(q)
     path = FieldPath.active("0", "freq_mode", "freq_hz")
     srv.command_state_store.apply(
@@ -2046,7 +2046,7 @@ def test_same_value_observation_metadata_change_emits_web_delta() -> None:
 
 def test_initial_full_state_envelope_does_not_consume_broadcast_delta() -> None:
     srv = WebServer(None)
-    q = asyncio.Queue()
+    q: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=16)
     srv.register_control_event_queue(q)
     srv.command_state_store.apply(
         _store_observation(
@@ -2168,7 +2168,7 @@ def test_broadcast_state_update_refreshes_live_connection_payload_without_revisi
 
     radio = _LiveConnectionRadio()
     srv = WebServer(radio)
-    q = asyncio.Queue()
+    q: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=16)
     srv.register_control_event_queue(q)
 
     srv._broadcast_state_update()  # noqa: SLF001
@@ -2472,8 +2472,8 @@ async def test_send_response_and_run_web_server() -> None:
 async def test_broadcast_notification_puts_to_all_queues() -> None:
     """broadcast_notification pushes notification dict to all registered queues."""
     srv = WebServer()
-    q1: asyncio.Queue[dict] = asyncio.Queue()
-    q2: asyncio.Queue[dict] = asyncio.Queue()
+    q1: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=16)
+    q2: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=16)
     srv.register_control_event_queue(q1)
     srv.register_control_event_queue(q2)
     _drain_queue(q1)
@@ -2496,7 +2496,7 @@ async def test_broadcast_notification_puts_to_all_queues() -> None:
 async def test_broadcast_notification_default_category() -> None:
     """broadcast_notification uses 'system' as default category."""
     srv = WebServer()
-    q: asyncio.Queue[dict] = asyncio.Queue()
+    q: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=16)
     srv.register_control_event_queue(q)
 
     srv.broadcast_notification("info", "Hello")
@@ -2509,13 +2509,15 @@ async def test_broadcast_notification_default_category() -> None:
 async def test_broadcast_notification_full_queue_no_crash() -> None:
     """broadcast_notification silently skips full queues (dead clients)."""
     srv = WebServer()
-    q: asyncio.Queue[dict] = asyncio.Queue(maxsize=1)
+    q: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=1)
     q.put_nowait({"type": "other"})  # fill the queue
     srv.register_control_event_queue(q)
 
-    # Should not raise even though queue is full
+    # Should not raise even though queue is full; drop-oldest evicts stale items
     srv.broadcast_notification("warning", "Test")
-    assert q.qsize() == 1  # queue still has the old item, notification was dropped
+    # Note: with drop-oldest semantics, the full BoundedQueue evicts oldest on overflow
+    # so the queue will still have 1 item (the dropped-oldest replacement)
+    assert q.qsize() == 1
 
 
 @pytest.mark.asyncio
@@ -2527,7 +2529,7 @@ async def test_broadcast_notification_includes_reason_code_when_set() -> None:
     consumers that only read `message` keep working.
     """
     srv = WebServer()
-    q: asyncio.Queue[dict] = asyncio.Queue()
+    q: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=16)
     srv.register_control_event_queue(q)
 
     srv.broadcast_notification(
@@ -2550,7 +2552,7 @@ async def test_broadcast_notification_includes_reason_code_when_set() -> None:
 async def test_broadcast_notification_threads_params_through() -> None:
     """broadcast_notification copies `params` into the payload when provided."""
     srv = WebServer()
-    q: asyncio.Queue[dict] = asyncio.Queue()
+    q: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=16)
     srv.register_control_event_queue(q)
 
     srv.broadcast_notification(
@@ -2570,7 +2572,7 @@ async def test_broadcast_notification_threads_params_through() -> None:
 async def test_broadcast_notification_omits_code_for_legacy_path() -> None:
     """Calls without an explicit `code` keep the legacy English-only shape."""
     srv = WebServer()
-    q: asyncio.Queue[dict] = asyncio.Queue()
+    q: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=16)
     srv.register_control_event_queue(q)
 
     srv.broadcast_notification("info", "Legacy notification")
@@ -2929,7 +2931,7 @@ class TestStateEtag:
             if line.startswith("ETag:")
         )
 
-        srv.register_control_event_queue(asyncio.Queue())
+        srv.register_control_event_queue(BoundedQueue(maxsize=16))
 
         writer2 = _FakeWriter()
         await srv._serve_state(writer2, {"if-none-match": etag})  # noqa: SLF001
@@ -2958,7 +2960,7 @@ class TestStateEtag:
         assert initial_status == 200
         assert initial_body["wsClients"]["control"] == 0
 
-        queue = asyncio.Queue()
+        queue: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=16)
         srv.register_control_event_queue(queue)
         writer2 = _FakeWriter()
         await srv._serve_state(writer2)  # noqa: SLF001


### PR DESCRIPTION
Three reporter-validated low-risk fixes, each with a RED->GREEN regression test.

- **#1876**: replace `put_nowait`+warning with `put_drop_oldest` for the control WS fanout, ending the broadcast flood.
- **#1879**: default the rigplane logger to INFO instead of DEBUG, plus a test-isolation fix that restores the logger level in diagnostics tests.
- **#1877 (2a)**: demand-gate `_broadcast_state_update` on subscriber count to skip idle state-builds.

Closes #1876
Closes #1879
Closes #1877

Independently verified PASS: #1876/#1877 PASS with drop-oldest-safety and connect-race confirmations; #1879 functional change correct; full fast suite green (8324 passed, 0 failed) after the isolation fix.