### PR TITLE
Prevent stale PTT-on replay and preserve fail-safe de-key delivery

### DIFF
--- a/frontend/src/lib/transport/__tests__/ws-client.test.ts
+++ b/frontend/src/lib/transport/__tests__/ws-client.test.ts
@@ -461,6 +461,46 @@ describe('control channel singleton', () => {
     expect(patchActiveReceiver).not.toHaveBeenCalled();
   });
 
+  it('allows open-socket PTT release aliases while radio health is degraded', async () => {
+    vi.mocked(isLiveRadioAvailable).mockReturnValue(false);
+    radioStoreMock.current = makeState({ ptt: true });
+    const { connect, sendCommand } = await import('../ws-client');
+    connect('ws://test/api/v1/ws');
+    instances[0].simulateOpen();
+
+    expect(sendCommand('ptt_on')).toBe(false);
+    expect(sendCommand('ptt', { state: true })).toBe(false);
+    expect(sendCommand('ptt_off')).toBe(true);
+    expect(radioStoreMock.current?.ptt).toBe(true);
+    expect(sendCommand('ptt', { state: false })).toBe(true);
+    expect(radioStoreMock.current?.ptt).toBe(true);
+
+    expect(instances[0].sent.map((frame) => JSON.parse(frame))).toMatchObject([
+      { name: 'ptt_off' },
+      { name: 'ptt', params: { state: false } },
+    ]);
+  });
+
+  it('coalesces offline PTT release aliases while radio health is degraded', async () => {
+    vi.mocked(isLiveRadioAvailable).mockReturnValue(false);
+    radioStoreMock.current = makeState({ ptt: true });
+    const { connect, sendCommand } = await import('../ws-client');
+
+    expect(sendCommand('ptt_on', {}, 'on-1')).toBe(false);
+    expect(sendCommand('ptt', { state: true }, 'on-2')).toBe(false);
+    expect(sendCommand('ptt_off', {}, 'off-1')).toBe(false);
+    expect(radioStoreMock.current?.ptt).toBe(true);
+    expect(sendCommand('ptt', { state: false }, 'off-2')).toBe(false);
+    expect(radioStoreMock.current?.ptt).toBe(true);
+
+    connect('ws://test/api/v1/ws');
+    instances[0].simulateOpen();
+    expect(radioStoreMock.current?.ptt).toBe(true);
+    expect(instances[0].sent.map((frame) => JSON.parse(frame))).toEqual([
+      { type: 'cmd', name: 'ptt', id: 'off-2', params: { state: false } },
+    ]);
+  });
+
   it('getChannel returns the same instance for the same name', async () => {
     const { getChannel } = await import('../ws-client');
     const a = getChannel('scope');
@@ -835,6 +875,78 @@ describe('WsChannel send queue', () => {
 
     expect(instances[0].sent).toHaveLength(20);
     expect(JSON.parse(instances[0].sent[0]).id).toBe('cmd-5');
+  });
+
+  it('never replays offline PTT-on aliases and coalesces release aliases', async () => {
+    const { WsChannel } = await import('../ws-client');
+    const ch = new WsChannel();
+
+    expect(ch.send({ type: 'cmd', name: 'ptt_on', id: 'on-1', params: {} })).toBe(false);
+    expect(ch.send({ type: 'cmd', name: 'ptt', id: 'on-2', params: { state: true } })).toBe(false);
+    expect(ch.send({ type: 'cmd', name: 'ptt_off', id: 'off-1', params: {} })).toBe(false);
+    expect(ch.send({ type: 'cmd', name: 'ptt', id: 'off-2', params: { state: false } })).toBe(false);
+
+    ch.connect('ws://test');
+    instances[0].simulateOpen();
+
+    expect(instances[0].sent.map((frame) => JSON.parse(frame))).toEqual([
+      { type: 'cmd', name: 'ptt', id: 'off-2', params: { state: false } },
+    ]);
+  });
+
+  it('sends healthy PTT-on and release aliases immediately on an open socket', async () => {
+    const { WsChannel } = await import('../ws-client');
+    const ch = new WsChannel();
+    ch.connect('ws://test');
+    instances[0].simulateOpen();
+
+    expect(ch.send({ type: 'cmd', name: 'ptt_on', id: 'on-1', params: {} })).toBe(true);
+    expect(ch.send({ type: 'cmd', name: 'ptt', id: 'on-2', params: { state: true } })).toBe(true);
+    expect(ch.send({ type: 'cmd', name: 'ptt_off', id: 'off-1', params: {} })).toBe(true);
+    expect(ch.send({ type: 'cmd', name: 'ptt', id: 'off-2', params: { state: false } })).toBe(true);
+
+    expect(instances[0].sent.map((frame) => JSON.parse(frame).id)).toEqual([
+      'on-1',
+      'on-2',
+      'off-1',
+      'off-2',
+    ]);
+  });
+
+  it('pins an offline release beyond ordinary queue capacity', async () => {
+    const { WsChannel } = await import('../ws-client');
+    const ch = new WsChannel();
+
+    ch.send({ type: 'cmd', name: 'ptt_off', id: 'release', params: {} });
+    for (let i = 0; i < 45; i++) {
+      ch.send({ type: 'cmd', name: 'set_af_level', id: `ordinary-${i}`, params: { level: i } });
+    }
+
+    ch.connect('ws://test');
+    instances[0].simulateOpen();
+
+    const drained = instances[0].sent.map((frame) => JSON.parse(frame));
+    expect(drained).toHaveLength(21);
+    expect(drained[0]).toMatchObject({ name: 'ptt_off', id: 'release' });
+    expect(drained.slice(1).map((cmd) => cmd.id)).toEqual(
+      Array.from({ length: 20 }, (_, i) => `ordinary-${i + 25}`),
+    );
+  });
+
+  it('allows one new queued release in a later offline episode', async () => {
+    const { WsChannel } = await import('../ws-client');
+    const ch = new WsChannel();
+
+    ch.send({ type: 'cmd', name: 'ptt_off', id: 'release-1', params: {} });
+    ch.connect('ws://test');
+    instances[0].simulateOpen();
+    expect(instances[0].sent.map((frame) => JSON.parse(frame).id)).toEqual(['release-1']);
+
+    ch.disconnect();
+    ch.send({ type: 'cmd', name: 'ptt_off', id: 'release-2', params: {} });
+    ch.connect('ws://test');
+    instances[1].simulateOpen();
+    expect(instances[1].sent.map((frame) => JSON.parse(frame).id)).toEqual(['release-2']);
   });
 
   it('handles error response with status field', async () => {

--- a/frontend/src/lib/transport/ws-client.ts
+++ b/frontend/src/lib/transport/ws-client.ts
@@ -17,6 +17,14 @@ const MAX_QUEUE_SIZE = 20;
 // Command types where only the latest value matters (last write wins)
 const IDEMPOTENT_TYPES = new Set(['set_freq', 'set_mode', 'set_filter']);
 
+function pttIntent(name: string, params: Record<string, unknown>): 'on' | 'off' | null {
+  if (name === 'ptt_on') return 'on';
+  if (name === 'ptt_off') return 'off';
+  if (name === 'ptt' && params.state === true) return 'on';
+  if (name === 'ptt' && params.state === false) return 'off';
+  return null;
+}
+
 function calcBackoff(attempt: number): number {
   const base = Math.min(BACKOFF_BASE_MS * 2 ** attempt, BACKOFF_MAX_MS);
   return base * (0.8 + Math.random() * 0.4);
@@ -30,6 +38,7 @@ export class WsChannel {
   private attempt = 0;
   private intentionalClose = false;
   private sendQueue: WsCommand[] = [];
+  private pendingPttRelease: WsCommand | null = null;
   private messageHandlers = new Set<MessageHandler>();
   private binaryHandlers = new Set<BinaryHandler>();
   private stateHandlers = new Set<StateHandler>();
@@ -71,7 +80,12 @@ export class WsChannel {
       this._resetHeartbeat();
       this._startKeepalive();
       // drain send queue
-      const queued = this.sendQueue.splice(0);
+      const release = this.pendingPttRelease;
+      this.pendingPttRelease = null;
+      if (release) ws.send(JSON.stringify(release));
+      const queued = this.sendQueue.splice(0).filter(
+        (cmd) => pttIntent(cmd.name, cmd.params) !== 'on',
+      );
       for (const cmd of queued) ws.send(JSON.stringify(cmd));
       // Re-send subscribe on every (re)connect so server pushes state immediately
       if (this._subscribeMsg) ws.send(JSON.stringify(this._subscribeMsg));
@@ -156,6 +170,17 @@ export class WsChannel {
     if (this.ws?.readyState === WebSocket.OPEN) {
       this.ws.send(JSON.stringify(cmd));
       return true;
+    }
+    const intent = pttIntent(cmd.name, cmd.params);
+    if (intent === 'on') {
+      return false;
+    }
+    if (intent === 'off') {
+      this.sendQueue = this.sendQueue.filter(
+        (queued) => pttIntent(queued.name, queued.params) !== 'on',
+      );
+      this.pendingPttRelease = cmd;
+      return false;
     }
     // Deduplicate idempotent commands — keep only the latest value
     if (IDEMPOTENT_TYPES.has(cmd.name)) {
@@ -429,7 +454,7 @@ export function disconnect() {
 }
 
 export function sendCommand(name: string, params: Record<string, unknown> = {}, id?: string): boolean {
-  if (!isLiveRadioAvailable()) {
+  if (!isLiveRadioAvailable() && pttIntent(name, params) !== 'off') {
     console.warn('[cmd] blocked while radio health is degraded', name);
     return false;
   }
@@ -515,7 +540,9 @@ function _applyOptimistic(name: string, params: Record<string, unknown>): void {
       if (typeof params.on === 'boolean') patchActiveReceiver({ ipplus: params.on });
       break;
     case 'ptt':
-      if (typeof params.state === 'boolean') patchRadioState({ ptt: params.state });
+      // A release is best-effort until confirmed by backend state. Optimistically
+      // clearing PTT could falsely present a de-key while transport is degraded.
+      if (params.state === true) patchRadioState({ ptt: true });
       break;
     case 'set_dual_watch':
       if (typeof params.on === 'boolean') patchRadioState({ dualWatch: params.on });


### PR DESCRIPTION
Closes #1906

Linear: https://linear.app/morozsm/issue/MOR-980/p0-make-frontend-ptt-delivery-asymmetric-and-non-replayable

## What changed

- Made PTT delivery asymmetric at the frontend transport boundary: keying fails closed while release remains best-effort.
- Prevented both preferred and legacy PTT-on commands from entering the offline queue.
- Added one pinned, coalesced pending release per offline episode, exempt from ordinary queue eviction.
- Removed queued stale keying before reconnect and prevented reconnect drain from emitting stale PTT-on.
- Kept authoritative TX state unchanged until backend feedback confirms de-key, avoiding false optimistic release indication.

## Why

The previous generic health gate could reject `ptt_off`, while ordinary offline buffering could retain stale `ptt_on`. A reconnect could therefore replay unsafe keying or lose the only pending release.

## Impact

The patch is limited to the WebSocket client and its focused tests. It preserves ordinary command buffering, deduplication, subscriptions, and boolean return behavior. Release remains best-effort and does not claim guaranteed RF de-key while physical transport is unavailable.

## Checks

- `npm test -- --run src/lib/transport/__tests__/ws-client.test.ts` — 34 passed
- `npm run check` — 0 errors, 0 warnings
- `git diff origin/main...HEAD --check`

