### PR TITLE
Enforce receiver/VFO topology pairs in profile loader

### DIFF
--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -1013,6 +1013,17 @@ def load_rig(path: Path) -> RigConfig:
             f"{filename}: [vfo].scheme must be one of {VALID_VFO_SCHEMES}, "
             f"got {scheme!r}"
         )
+    expected_receiver_count = 1 if scheme in {"single", "ab"} else 2
+    receiver_count = radio["receiver_count"]
+    if (
+        not isinstance(receiver_count, int)
+        or isinstance(receiver_count, bool)
+        or receiver_count != expected_receiver_count
+    ):
+        raise RigLoadError(
+            f"{filename}: [radio].receiver_count = {receiver_count!r} is incompatible "
+            f"with [vfo].scheme = {scheme!r}; expected {expected_receiver_count}"
+        )
 
     # Validate [modes]
     modes = data["modes"].get("list", [])
@@ -1369,7 +1380,7 @@ def load_rig(path: Path) -> RigConfig:
         id=radio["id"],
         model=radio["model"],
         civ_addr=civ_addr,
-        receiver_count=radio["receiver_count"],
+        receiver_count=receiver_count,
         transceiver_count=int(radio.get("transceiver_count", 1)),
         hamlib_model_id=int(radio.get("hamlib_model_id", 2028)),
         has_lan=radio["has_lan"],

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -168,6 +168,70 @@ provider = 123
         with pytest.raises(RigLoadError, match="vfo.*scheme"):
             load_rig(p)
 
+    @pytest.mark.parametrize(
+        ("scheme", "receiver_count"),
+        [
+            ("single", 1),
+            ("ab", 1),
+            ("ab_shared", 2),
+            ("main_sub", 2),
+        ],
+    )
+    def test_valid_receiver_count_vfo_scheme_pairs(
+        self,
+        tmp_path,
+        scheme,
+        receiver_count,
+    ):
+        toml = _MINIMAL_TOML.replace(
+            "receiver_count = 1",
+            f"receiver_count = {receiver_count}",
+        ).replace('scheme = "ab"', f'scheme = "{scheme}"')
+        rig = load_rig(_write_toml(tmp_path, toml))
+
+        assert rig.receiver_count == receiver_count
+        assert rig.vfo_scheme == scheme
+
+    @pytest.mark.parametrize(
+        ("scheme", "receiver_count", "expected_count"),
+        [
+            ("single", 2, 1),
+            ("ab", 2, 1),
+            ("ab_shared", 1, 2),
+            ("main_sub", 1, 2),
+            *[
+                (scheme, receiver_count, expected_count)
+                for scheme, expected_count in [
+                    ("single", 1),
+                    ("ab", 1),
+                    ("ab_shared", 2),
+                    ("main_sub", 2),
+                ]
+                for receiver_count in (0, -1, 3)
+            ],
+        ],
+    )
+    def test_invalid_receiver_count_vfo_scheme_pairs(
+        self,
+        tmp_path,
+        scheme,
+        receiver_count,
+        expected_count,
+    ):
+        toml = _MINIMAL_TOML.replace(
+            "receiver_count = 1",
+            f"receiver_count = {receiver_count}",
+        ).replace('scheme = "ab"', f'scheme = "{scheme}"')
+
+        with pytest.raises(
+            RigLoadError,
+            match=(
+                rf"\[radio\]\.receiver_count = {receiver_count} is incompatible "
+                rf"with \[vfo\]\.scheme = '{scheme}'; expected {expected_count}"
+            ),
+        ):
+            load_rig(_write_toml(tmp_path, toml))
+
     def test_file_not_found(self, tmp_path):
         with pytest.raises(RigLoadError, match="not found"):
             load_rig(tmp_path / "nonexistent.toml")

--- a/tests/test_rig_multi_vendor.py
+++ b/tests/test_rig_multi_vendor.py
@@ -253,7 +253,9 @@ class TestVfoSchemes:
     """Extended VFO schemes."""
 
     def test_ab_shared_scheme(self, tmp_path):
-        toml = _BASE_TOML.replace('scheme = "ab"', 'scheme = "ab_shared"')
+        toml = _BASE_TOML.replace("receiver_count = 1", "receiver_count = 2").replace(
+            'scheme = "ab"', 'scheme = "ab_shared"'
+        )
         p = _write_toml(tmp_path, toml)
         rig = load_rig(p)
         assert rig.vfo_scheme == "ab_shared"


### PR DESCRIPTION
## Summary

- enforce the accepted structural topology pairs during profile load
- reject invalid receiver counts and non-integer/bool values before runtime construction
- add a complete valid/invalid matrix without changing runtime `dual_rx` or web dispatch

Linear: [MOR-991](https://linear.app/morozsm/issue/MOR-991/implementation-enforce-exact-receivervfo-topology-pairs-in-profile)

Closes #1914

## Verification

- focused loader/multi-vendor tests: 145 passed
- full non-integration suite: passed
- all 8 checked-in profiles load
- Ruff check and format check: passed
- mypy: passed
- import-linter: 5/5 contracts kept
- `git diff --check`: clean

## Review

Independent agent review: PASS for commit `dc1c6a77`.

## Scope

Only `rig_loader.py` and focused tests. No runtime, web, or profile TOML changes.
