### PR TITLE
Disable raw MediaSession PTT handlers

### DIFF
--- a/frontend/src/lib/media/__tests__/media-session.test.ts
+++ b/frontend/src/lib/media/__tests__/media-session.test.ts
@@ -43,21 +43,43 @@ describe('media-session', () => {
   let wsMod: typeof import('../../transport/ws-client');
 
   const handlers = new Map<string, MediaSessionActionHandler | null>();
+  const existingPlayHandler = vi.fn<MediaSessionActionHandler>();
+  const existingPauseHandler = vi.fn<MediaSessionActionHandler>();
   let mockAudio: ReturnType<typeof createMockAudioContext>;
+  let audioContexts: ReturnType<typeof createMockAudioContext>[];
+
+  function expectNoPttCommands(): void {
+    const pttCommands = new Set(['ptt', 'ptt_on', 'ptt_off']);
+    const commands = vi.mocked(wsMod.sendCommand).mock.calls.map(([command]) => command);
+    expect(commands.filter((command) => pttCommands.has(command))).toEqual([]);
+  }
 
   beforeEach(async () => {
     vi.resetModules();
+    vi.clearAllMocks();
     handlers.clear();
+    handlers.set('play', existingPlayHandler);
+    handlers.set('pause', existingPauseHandler);
 
     mockAudio = createMockAudioContext();
+    audioContexts = [];
     // AudioContext and MediaMetadata are used with `new`, so mock as classes
     vi.stubGlobal(
       'AudioContext',
       class {
-        createOscillator = mockAudio.ctx.createOscillator;
-        createGain = mockAudio.ctx.createGain;
-        destination = mockAudio.ctx.destination;
-        close = mockAudio.ctx.close;
+        createOscillator;
+        createGain;
+        destination;
+        close;
+
+        constructor() {
+          const audio = audioContexts.length === 0 ? mockAudio : createMockAudioContext();
+          audioContexts.push(audio);
+          this.createOscillator = audio.ctx.createOscillator;
+          this.createGain = audio.ctx.createGain;
+          this.destination = audio.ctx.destination;
+          this.close = audio.ctx.close;
+        }
       },
     );
     vi.stubGlobal(
@@ -95,13 +117,13 @@ describe('media-session', () => {
     mod.destroyMediaSession();
   });
 
-  it('registers all four action handlers on init', () => {
+  it('registers only tuning action handlers on init', () => {
     mod.initMediaSession();
 
     expect(handlers.has('previoustrack')).toBe(true);
     expect(handlers.has('nexttrack')).toBe(true);
-    expect(handlers.has('play')).toBe(true);
-    expect(handlers.has('pause')).toBe(true);
+    expect(handlers.get('play')).toBe(existingPlayHandler);
+    expect(handlers.get('pause')).toBe(existingPauseHandler);
   });
 
   it('sets MediaSession metadata', () => {
@@ -161,33 +183,77 @@ describe('media-session', () => {
     expect(radioMod.patchActiveReceiver).not.toHaveBeenCalled();
   });
 
-  it('play handler sends PTT on', () => {
+  it('never emits legacy or preferred PTT commands', () => {
     mod.initMediaSession();
-    const handler = handlers.get('play')!;
-    handler({ action: 'play' } as MediaSessionActionDetails);
 
-    expect(wsMod.sendCommand).toHaveBeenCalledWith('ptt', { state: true });
+    handlers.get('previoustrack')?.({
+      action: 'previoustrack',
+    } as MediaSessionActionDetails);
+    handlers.get('nexttrack')?.({ action: 'nexttrack' } as MediaSessionActionDetails);
+    mod.destroyMediaSession();
+
+    expectNoPttCommands();
   });
 
-  it('pause handler sends PTT off', () => {
+  it('is idempotent across repeated init calls', () => {
     mod.initMediaSession();
-    const handler = handlers.get('pause')!;
-    handler({ action: 'pause' } as MediaSessionActionDetails);
+    mod.initMediaSession();
 
-    expect(wsMod.sendCommand).toHaveBeenCalledWith('ptt', { state: false });
+    expect(mockAudio.ctx.createOscillator).toHaveBeenCalledTimes(1);
+    expect(mockAudio.ctx.createGain).toHaveBeenCalledTimes(1);
+    expect(navigator.mediaSession.setActionHandler).toHaveBeenCalledTimes(2);
   });
 
   it('destroyMediaSession clears handlers and stops audio', () => {
     mod.initMediaSession();
     mod.destroyMediaSession();
 
-    // All handlers should be cleared (set to null)
+    // Only the handlers owned by this module are cleared (set to null).
     const setHandler = navigator.mediaSession.setActionHandler as ReturnType<typeof vi.fn>;
     const calls = setHandler.mock.calls as Array<[string, MediaSessionActionHandler | null]>;
-    const nullCalls = calls.filter((call) => call[1] === null);
-    expect(nullCalls.length).toBe(4);
+    const clearedActions = calls.filter((call) => call[1] === null).map(([action]) => action);
+    expect(clearedActions).toEqual(['previoustrack', 'nexttrack']);
+    expect(calls.map(([action]) => action)).not.toContain('play');
+    expect(calls.map(([action]) => action)).not.toContain('pause');
+    expect(handlers.get('play')).toBe(existingPlayHandler);
+    expect(handlers.get('pause')).toBe(existingPauseHandler);
     expect(mockAudio.oscillator.stop).toHaveBeenCalled();
     expect(mockAudio.ctx.close).toHaveBeenCalled();
+    expectNoPttCommands();
+  });
+
+  it('is idempotent across repeated destroy calls', () => {
+    mod.initMediaSession();
+    mod.destroyMediaSession();
+    mod.destroyMediaSession();
+
+    const setHandler = navigator.mediaSession.setActionHandler as ReturnType<typeof vi.fn>;
+    const calls = setHandler.mock.calls as Array<[string, MediaSessionActionHandler | null]>;
+    expect(mockAudio.oscillator.stop).toHaveBeenCalledTimes(1);
+    expect(mockAudio.ctx.close).toHaveBeenCalledTimes(1);
+    expect(calls.map(([action, handler]) => ({ action, clears: handler === null }))).toEqual([
+      { action: 'previoustrack', clears: false },
+      { action: 'nexttrack', clears: false },
+      { action: 'previoustrack', clears: true },
+      { action: 'nexttrack', clears: true },
+    ]);
+  });
+
+  it('starts a fresh owned session after init, destroy, init', () => {
+    mod.initMediaSession();
+    const firstPreviousTrackHandler = handlers.get('previoustrack');
+    mod.destroyMediaSession();
+    mod.initMediaSession();
+
+    expect(audioContexts).toHaveLength(2);
+    expect(audioContexts[0]).not.toBe(audioContexts[1]);
+    expect(audioContexts[0].oscillator.stop).toHaveBeenCalledTimes(1);
+    expect(audioContexts[1].oscillator.start).toHaveBeenCalledTimes(1);
+    expect(handlers.get('previoustrack')).not.toBe(firstPreviousTrackHandler);
+    expect(handlers.get('nexttrack')).toEqual(expect.any(Function));
+    expect(handlers.get('play')).toBe(existingPlayHandler);
+    expect(handlers.get('pause')).toBe(existingPauseHandler);
+    expectNoPttCommands();
   });
 
   describe('without MediaSession API', () => {

--- a/frontend/src/lib/media/media-session.ts
+++ b/frontend/src/lib/media/media-session.ts
@@ -2,7 +2,6 @@
  * MediaSession API integration for mobile radio control.
  *
  * - Volume keys (previoustrack/nexttrack) -> frequency tuning
- * - Headphone play/pause button -> PTT toggle
  *
  * A silent audio loop keeps the MediaSession active on mobile browsers.
  */
@@ -16,6 +15,7 @@ const TAG = '[media-session]';
 let audioCtx: AudioContext | null = null;
 let oscillator: OscillatorNode | null = null;
 let gainNode: GainNode | null = null;
+let isInitialized = false;
 
 /** Tune the active receiver by `steps` increments and send to radio. */
 function tuneStep(steps: number): void {
@@ -57,7 +57,7 @@ function stopSilentAudio(): void {
 }
 
 /**
- * Initialize MediaSession handlers for volume-key tuning and headphone PTT.
+ * Initialize MediaSession handlers for volume-key tuning.
  * Call once on app startup. Safe to call in environments without MediaSession.
  */
 export function initMediaSession(): void {
@@ -65,7 +65,11 @@ export function initMediaSession(): void {
     console.debug(TAG, 'MediaSession API not available');
     return;
   }
+  if (isInitialized) {
+    return;
+  }
 
+  isInitialized = true;
   startSilentAudio();
 
   navigator.mediaSession.metadata = new MediaMetadata({
@@ -84,29 +88,19 @@ export function initMediaSession(): void {
     tuneStep(1);
   });
 
-  // Headphone play/pause -> PTT
-  navigator.mediaSession.setActionHandler('play', () => {
-    console.debug(TAG, 'play -> PTT on');
-    sendCommand('ptt', { state: true });
-  });
-
-  navigator.mediaSession.setActionHandler('pause', () => {
-    console.debug(TAG, 'pause -> PTT off');
-    sendCommand('ptt', { state: false });
-  });
-
-  console.info(TAG, 'handlers registered (tuning + PTT)');
+  console.info(TAG, 'handlers registered (tuning only)');
 }
 
 /**
  * Remove MediaSession handlers and stop the silent audio loop.
  */
 export function destroyMediaSession(): void {
-  if (!('mediaSession' in navigator)) return;
+  if (!('mediaSession' in navigator) || !isInitialized) return;
 
   stopSilentAudio();
+  isInitialized = false;
 
-  for (const action of ['previoustrack', 'nexttrack', 'play', 'pause'] as MediaSessionAction[]) {
+  for (const action of ['previoustrack', 'nexttrack'] as MediaSessionAction[]) {
     try {
       navigator.mediaSession.setActionHandler(action, null);
     } catch {


### PR DESCRIPTION
## Summary

- remove MediaSession play/pause raw PTT handlers
- preserve previous/next tuning behavior
- make init/destroy idempotent and clean up only module-owned handlers
- prove preferred and legacy PTT commands cannot be emitted

Linear: [MOR-989](https://linear.app/morozsm/issue/MOR-989/implementation-disable-raw-mediasession-ptt)

Closes #1912

## Verification

- focused MediaSession Vitest: 13/13 passed
- `npm run check`: 0 errors, 0 warnings
- `git diff --check`: clean
- independent agent review: PASS for `9c4b24d5`

## Scope

Only the MediaSession module and its focused test. No transport or TX-controller changes.
