### PR TITLE
Gate MOD restore on authoritative PTT off

### DIFF
--- a/frontend/src/lib/runtime/__tests__/frontend-runtime.test.ts
+++ b/frontend/src/lib/runtime/__tests__/frontend-runtime.test.ts
@@ -42,8 +42,6 @@ vi.mock('$lib/stores/radio.svelte', () => ({
   patchActiveReceiver: vi.fn(),
   patchRadioState: vi.fn(),
   resetRadioState: vi.fn(),
-  // MOR-618: imported by adapters/mod-input-auto.svelte (bootstrap step 6).
-  subscribeRadioState: vi.fn(() => () => {}),
 }));
 
 vi.mock('$lib/stores/connection.svelte', () => ({
@@ -90,6 +88,10 @@ vi.mock('$lib/media/media-session', () => ({
   destroyMediaSession: vi.fn(),
 }));
 
+vi.mock('../adapters/mod-input-auto.svelte', () => ({
+  clearLegacyPendingModInputRestore: vi.fn(),
+}));
+
 // system-controller uses imports from above mocks — provide a lightweight stub
 vi.mock('./system-controller', async () => {
   const { systemController: _sc } = await vi.importActual<typeof import('../system-controller')>(
@@ -105,6 +107,7 @@ import { connect, sendRaw } from '$lib/transport/ws-client';
 import { setCapabilities } from '$lib/stores/capabilities.svelte';
 import { setRadioState } from '$lib/stores/radio.svelte';
 import { systemController } from '../system-controller';
+import { clearLegacyPendingModInputRestore } from '../adapters/mod-input-auto.svelte';
 
 // FrontendRuntime is a singleton — re-import fresh each time via a factory helper
 // so we can reset _bootstrapCleanup and _bootstrapInFlight between tests.
@@ -139,6 +142,7 @@ describe('FrontendRuntime.bootstrap()', () => {
 
     // 1. fetchCapabilities called
     expect(fetchCapabilities).toHaveBeenCalledTimes(1);
+    expect(clearLegacyPendingModInputRestore).toHaveBeenCalledTimes(1);
 
     // 2. capabilities pushed into store
     expect(setCapabilities).toHaveBeenCalledWith(fakeCaps);

--- a/frontend/src/lib/runtime/adapters/__tests__/mod-input-auto.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mod-input-auto.test.ts
@@ -7,10 +7,9 @@
  *     and != LAN(5): remember the previous source, set LAN via the existing
  *     per-group SET command, and suppress the MOR-617 warning (the
  *     optimistic LAN patch preempts the guard);
- *   - at TX stop, restore the remembered source (only if auto changed it,
- *     and only if the group is still on LAN);
- *   - the pending restore is persisted so a crash/disconnect mid-TX can be
- *     repaired best-effort on the next connect.
+ *   - after authoritative PTT-off confirmation, restore the remembered source
+ *     only if auto changed it and the group is still on LAN;
+ *   - pending restore state is memory-only and cannot replay on reconnect.
  *
  * When OFF, behavior is exactly MOR-617 (warn-only, no silent changes).
  */
@@ -18,7 +17,6 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('$lib/transport/ws-client', () => ({
   sendCommand: vi.fn(() => true),
-  isConnected: vi.fn(() => true),
 }));
 
 vi.mock('$lib/audio/audio-manager', () => ({
@@ -40,14 +38,14 @@ vi.mock('$lib/runtime/frontend-runtime', () => ({
   },
 }));
 
-import { sendCommand, isConnected } from '$lib/transport/ws-client';
+import { sendCommand } from '$lib/transport/ws-client';
 import { runtime } from '$lib/runtime/frontend-runtime';
 import { getRadioState, resetRadioState, setRadioState } from '$lib/stores/radio.svelte';
 import { setCapabilities } from '$lib/stores/capabilities.svelte';
 import {
   AUTO_LAN_PREF_KEY,
   PENDING_RESTORE_KEY,
-  applyPendingModInputRestoreOnConnect,
+  clearLegacyPendingModInputRestore,
   deriveAutoLanModInputProps,
   isAutoLanModInputEnabled,
   restoreModInputAfterTx,
@@ -57,7 +55,11 @@ import {
   deriveModInputTxGuardProps,
   dismissModInputTxGuard,
 } from '../mod-input-tx-guard.svelte';
-import { getTxAudioControl } from '../tx-adapter';
+import {
+  getTxAudioControl,
+  type AuthoritativePttObservation,
+  type PttObservationMarker,
+} from '../tx-adapter';
 import type { ServerState } from '$lib/types/state';
 
 function receiver(dataMode: number) {
@@ -117,13 +119,51 @@ function pendingInStorage(): unknown {
   return raw === null ? null : JSON.parse(raw);
 }
 
+const OFF_BARRIER: PttObservationMarker = {
+  authorityEpoch: 7,
+  pttObservationSeq: 41,
+  pttLastObservedMonotonic: 1_000,
+};
+
+function offObservation(
+  overrides: Partial<AuthoritativePttObservation> = {},
+): AuthoritativePttObservation {
+  return {
+    authorityEpoch: 7,
+    ptt: false,
+    pttObserved: true,
+    pttFreshness: 'fresh',
+    pttObservationSeq: 42,
+    pttLastObservedMonotonic: 1_001,
+    pttSource: 'radio-readback',
+    ...overrides,
+  };
+}
+
+function confirmOff(): void {
+  getTxAudioControl().restoreModAfterConfirmedOff({
+    barrier: OFF_BARRIER,
+    observation: offObservation(),
+  });
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 beforeEach(() => {
+  getTxAudioControl().stopLocalAudio();
   // Drain any pending restore left by a previous test, then wipe traces.
   restoreModInputAfterTx();
   localStorage.clear();
   vi.mocked(sendCommand).mockClear();
   vi.mocked(sendCommand).mockReturnValue(true);
-  vi.mocked(isConnected).mockReturnValue(true);
   vi.mocked(runtime.startTx).mockClear();
   vi.mocked(runtime.startTx).mockResolvedValue(null);
   vi.mocked(runtime.stopTx).mockClear();
@@ -177,7 +217,7 @@ describe('OFF behavior is exactly MOR-617 (MOR-618)', () => {
     expect(deriveModInputTxGuardProps().visible).toBe(true);
     expect(pendingInStorage()).toBeNull();
 
-    getTxAudioControl().stopTx();
+    getTxAudioControl().stopLocalAudio();
     expect(sendCommand).not.toHaveBeenCalled();
     expect(runtime.stopTx).toHaveBeenCalledTimes(1);
   });
@@ -195,17 +235,9 @@ describe('auto-set at TX start (MOR-618)', () => {
     // Optimistic patch preempts the MOR-617 guard — no warning.
     expect(getRadioState()?.data1ModInput).toBe(5);
     expect(deriveModInputTxGuardProps().visible).toBe(false);
-    // Pending restore persisted for crash robustness.
-    expect(pendingInStorage()).toEqual({
-      command: 'set_data1_mod_input',
-      key: 'data1ModInput',
-      source: 0,
-    });
-    // MOR-624: backend session-teardown net armed alongside the LAN set.
-    expect(sendCommand).toHaveBeenCalledWith('arm_mod_input_restore', {
-      command: 'set_data1_mod_input',
-      source: 0,
-    });
+    // The restore transaction is memory-only and cannot replay after reload.
+    expect(pendingInStorage()).toBeNull();
+    expect(sendCommand).not.toHaveBeenCalledWith('arm_mod_input_restore', expect.anything());
   });
 
   it('routes to the ACTIVE receiver group (SUB on D2)', async () => {
@@ -221,11 +253,7 @@ describe('auto-set at TX start (MOR-618)', () => {
     await getTxAudioControl().startTx();
 
     expect(sendCommand).toHaveBeenCalledWith('set_data2_mod_input', { source: 5 });
-    // MOR-624: the armed backend net carries the same group + previous source.
-    expect(sendCommand).toHaveBeenCalledWith('arm_mod_input_restore', {
-      command: 'set_data2_mod_input',
-      source: 3,
-    });
+    expect(sendCommand).not.toHaveBeenCalledWith('arm_mod_input_restore', expect.anything());
   });
 
   it('does nothing when the source is already LAN', async () => {
@@ -271,26 +299,149 @@ describe('auto-set at TX start (MOR-618)', () => {
   });
 });
 
-describe('restore at TX stop (MOR-618)', () => {
-  it('restores the remembered source and clears the pending restore', async () => {
+describe('confirmed restore after local TX audio stop (MOR-618, MOR-990)', () => {
+  it('treats startTx while already running as a side-effect-free success', async () => {
+    setAutoLanModInputEnabled(true);
+    setState({ main: receiver(1), data1ModInput: 0 });
+    const control = getTxAudioControl();
+    await control.startTx();
+
+    setState({
+      active: 'SUB',
+      main: receiver(1),
+      sub: receiver(2),
+      data1ModInput: 5,
+      data2ModInput: 3,
+    });
+    dismissModInputTxGuard();
+    vi.mocked(sendCommand).mockClear();
+    vi.mocked(runtime.startTx).mockClear();
+
+    await expect(control.startTx()).resolves.toBeNull();
+
+    expect(runtime.startTx).not.toHaveBeenCalled();
+    expect(sendCommand).not.toHaveBeenCalled();
+    expect(getRadioState()?.data2ModInput).toBe(3);
+    expect(deriveModInputTxGuardProps().visible).toBe(false);
+
+    control.stopLocalAudio();
+    control.stopLocalAudio();
+    expect(runtime.stopTx).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a second start while the first start is pending without side effects', async () => {
+    const pendingStart = deferred<string | null>();
+    vi.mocked(runtime.startTx).mockReturnValueOnce(pendingStart.promise);
+    setAutoLanModInputEnabled(true);
+    setState({ main: receiver(1), data1ModInput: 0 });
+    const control = getTxAudioControl();
+    const start = control.startTx();
+
+    setState({ main: receiver(1), data1ModInput: 0 });
+    dismissModInputTxGuard();
+    vi.mocked(sendCommand).mockClear();
+
+    await expect(control.startTx()).resolves.toBe('TX audio start already in progress');
+    expect(runtime.startTx).toHaveBeenCalledTimes(1);
+    expect(sendCommand).not.toHaveBeenCalled();
+    expect(deriveModInputTxGuardProps().visible).toBe(false);
+
+    control.stopLocalAudio();
+    pendingStart.resolve(null);
+    await start;
+  });
+
+  it('cleans immediately and defensively again after a cancelled start succeeds late', async () => {
+    const pendingStart = deferred<string | null>();
+    vi.mocked(runtime.startTx).mockReturnValueOnce(pendingStart.promise);
+    setAutoLanModInputEnabled(true);
+    setState({ main: receiver(1), data1ModInput: 0 });
+    const control = getTxAudioControl();
+
+    const start = control.startTx();
+    control.stopLocalAudio();
+    control.stopLocalAudio();
+
+    expect(runtime.stopTx).toHaveBeenCalledTimes(1);
+    expect(sendCommand).not.toHaveBeenCalledWith('set_data1_mod_input', { source: 0 });
+    expect(pendingInStorage()).toBeNull();
+
+    pendingStart.resolve(null);
+    await expect(start).resolves.toBeNull();
+    expect(runtime.stopTx).toHaveBeenCalledTimes(2);
+    expect(sendCommand).not.toHaveBeenCalledWith('set_data1_mod_input', { source: 0 });
+    confirmOff();
+    expect(sendCommand).toHaveBeenCalledWith('set_data1_mod_input', { source: 0 });
+  });
+
+  it('retains cancellation and cleanup when a late start returns an error', async () => {
+    const pendingStart = deferred<string | null>();
+    vi.mocked(runtime.startTx).mockReturnValueOnce(pendingStart.promise);
+    setAutoLanModInputEnabled(true);
+    setState({ main: receiver(1), data1ModInput: 0 });
+    const control = getTxAudioControl();
+
+    const start = control.startTx();
+    control.stopLocalAudio();
+    control.stopLocalAudio();
+    expect(runtime.stopTx).toHaveBeenCalledTimes(1);
+
+    pendingStart.resolve('TX MIC: capture failed');
+    await expect(start).resolves.toBe('TX MIC: capture failed');
+    expect(runtime.stopTx).toHaveBeenCalledTimes(2);
+    expect(sendCommand).not.toHaveBeenCalledWith('set_data1_mod_input', { source: 0 });
+    expect(pendingInStorage()).toBeNull();
+    confirmOff();
+    expect(sendCommand).toHaveBeenCalledWith('set_data1_mod_input', { source: 0 });
+  });
+
+  it('retains cancellation and cleanup when a late start rejects', async () => {
+    const pendingStart = deferred<string | null>();
+    vi.mocked(runtime.startTx).mockReturnValueOnce(pendingStart.promise);
+    setAutoLanModInputEnabled(true);
+    setState({ main: receiver(1), data1ModInput: 0 });
+    const control = getTxAudioControl();
+    const startError = new Error('capture rejected');
+
+    const start = control.startTx();
+    control.stopLocalAudio();
+    control.stopLocalAudio();
+    expect(runtime.stopTx).toHaveBeenCalledTimes(1);
+
+    pendingStart.reject(startError);
+    await expect(start).rejects.toBe(startError);
+    expect(runtime.stopTx).toHaveBeenCalledTimes(2);
+    expect(sendCommand).not.toHaveBeenCalledWith('set_data1_mod_input', { source: 0 });
+    expect(pendingInStorage()).toBeNull();
+    confirmOff();
+    expect(sendCommand).toHaveBeenCalledWith('set_data1_mod_input', { source: 0 });
+  });
+
+  it('stops local audio without restoring, then restores after confirmed OFF', async () => {
     setAutoLanModInputEnabled(true);
     setState({ main: receiver(1), data1ModInput: 0 });
     await getTxAudioControl().startTx();
     vi.mocked(sendCommand).mockClear();
 
-    getTxAudioControl().stopTx();
+    getTxAudioControl().stopLocalAudio();
 
     expect(runtime.stopTx).toHaveBeenCalledTimes(1);
+    expect(sendCommand).not.toHaveBeenCalled();
+    expect(pendingInStorage()).toBeNull();
+
+    confirmOff();
+
     expect(sendCommand).toHaveBeenCalledWith('set_data1_mod_input', { source: 0 });
-    // MOR-624: a clean stop owns the restore — backend teardown net cleared.
-    expect(sendCommand).toHaveBeenCalledWith('disarm_mod_input_restore', {});
+    expect(sendCommand).not.toHaveBeenCalledWith('disarm_mod_input_restore', expect.anything());
     expect(getRadioState()?.data1ModInput).toBe(0);
     expect(pendingInStorage()).toBeNull();
 
     // Restore is one-shot — a second stop sends nothing.
     vi.mocked(sendCommand).mockClear();
-    getTxAudioControl().stopTx();
+    getTxAudioControl().stopLocalAudio();
+    confirmOff();
     expect(sendCommand).not.toHaveBeenCalled();
+    expect(runtime.stopTx).toHaveBeenCalledTimes(1);
   });
 
   it('does not stomp a manual mid-TX change away from LAN', async () => {
@@ -303,12 +454,12 @@ describe('restore at TX stop (MOR-618)', () => {
     setState({ main: receiver(1), data1ModInput: 3 });
     vi.mocked(sendCommand).mockClear();
 
-    getTxAudioControl().stopTx();
+    getTxAudioControl().stopLocalAudio();
+    expect(sendCommand).not.toHaveBeenCalled();
+    confirmOff();
 
-    // The manual choice wins: no restore SET — but the backend teardown net
-    // is still cleared (MOR-624), the clean stop owns the restore decision.
-    expect(sendCommand).toHaveBeenCalledTimes(1);
-    expect(sendCommand).toHaveBeenCalledWith('disarm_mod_input_restore', {});
+    // The manual choice wins: no frontend or backend restore mutation.
+    expect(sendCommand).not.toHaveBeenCalled();
     expect(sendCommand).not.toHaveBeenCalledWith('set_data1_mod_input', expect.anything());
     expect(pendingInStorage()).toBeNull();
   });
@@ -320,12 +471,13 @@ describe('restore at TX stop (MOR-618)', () => {
     setAutoLanModInputEnabled(false);
     vi.mocked(sendCommand).mockClear();
 
-    getTxAudioControl().stopTx();
+    getTxAudioControl().stopLocalAudio();
+    confirmOff();
 
     expect(sendCommand).toHaveBeenCalledWith('set_data1_mod_input', { source: 0 });
   });
 
-  it('restores immediately when TX audio fails to start', async () => {
+  it('retains the pending restore when TX audio fails until OFF is confirmed', async () => {
     setAutoLanModInputEnabled(true);
     vi.mocked(runtime.startTx).mockResolvedValue('TX MIC: capture failed');
     setState({ main: receiver(1), data1ModInput: 0 });
@@ -334,84 +486,128 @@ describe('restore at TX stop (MOR-618)', () => {
 
     expect(err).toBe('TX MIC: capture failed');
     expect(sendCommand).toHaveBeenCalledWith('set_data1_mod_input', { source: 5 });
+    expect(sendCommand).not.toHaveBeenCalledWith('set_data1_mod_input', { source: 0 });
+    expect(pendingInStorage()).toBeNull();
+
+    confirmOff();
+    expect(sendCommand).toHaveBeenCalledWith('set_data1_mod_input', { source: 0 });
+    expect(pendingInStorage()).toBeNull();
+  });
+
+  it('rejects cached, stale, old-epoch, non-readback and unrelated evidence', async () => {
+    setAutoLanModInputEnabled(true);
+    setState({ main: receiver(1), data1ModInput: 0 });
+    await getTxAudioControl().startTx();
+    getTxAudioControl().stopLocalAudio();
+    vi.mocked(sendCommand).mockClear();
+
+    const rejected: AuthoritativePttObservation[] = [
+      offObservation({ pttObservationSeq: 41 }),
+      offObservation({ pttObservationSeq: 40 }),
+      offObservation({ pttFreshness: 'stale' }),
+      offObservation({ authorityEpoch: 6 }),
+      offObservation({ pttSource: 'command_response' }),
+      offObservation({ pttSource: 'ack' }),
+      offObservation({ pttSource: 'optimistic' }),
+      offObservation({ pttObserved: false }),
+      offObservation({ ptt: true }),
+      { ...offObservation({ pttObservationSeq: 41 }), stateRevision: 999_999 } as AuthoritativePttObservation,
+    ];
+    for (const observation of rejected) {
+      getTxAudioControl().restoreModAfterConfirmedOff({ barrier: OFF_BARRIER, observation });
+    }
+    expect(sendCommand).not.toHaveBeenCalled();
+    expect(pendingInStorage()).toBeNull();
+
+    confirmOff();
+    expect(sendCommand).toHaveBeenCalledWith('set_data1_mod_input', { source: 0 });
+  });
+
+  it('uses the field-specific monotonic marker when no PTT sequence exists', async () => {
+    setAutoLanModInputEnabled(true);
+    setState({ main: receiver(1), data1ModInput: 0 });
+    await getTxAudioControl().startTx();
+    getTxAudioControl().stopLocalAudio();
+    vi.mocked(sendCommand).mockClear();
+
+    getTxAudioControl().restoreModAfterConfirmedOff({
+      barrier: {
+        authorityEpoch: 7,
+        pttObservationSeq: null,
+        pttLastObservedMonotonic: 1_000,
+      },
+      observation: offObservation({
+        pttObservationSeq: null,
+        pttLastObservedMonotonic: 1_001,
+      }),
+    });
+
     expect(sendCommand).toHaveBeenCalledWith('set_data1_mod_input', { source: 0 });
     expect(pendingInStorage()).toBeNull();
   });
 });
 
-describe('best-effort restore on next connect (MOR-618)', () => {
-  it('applies a persisted pending restore once live state shows the group on LAN', () => {
+describe('legacy persisted restore migration (MOR-990)', () => {
+  it('clears a legacy record without mutating cached radio state', () => {
     localStorage.setItem(
       PENDING_RESTORE_KEY,
       JSON.stringify({ command: 'set_data1_mod_input', key: 'data1ModInput', source: 0 }),
     );
     setState({ main: receiver(1), data1ModInput: 5 });
 
-    applyPendingModInputRestoreOnConnect();
+    clearLegacyPendingModInputRestore();
 
-    expect(sendCommand).toHaveBeenCalledWith('set_data1_mod_input', { source: 0 });
+    expect(sendCommand).not.toHaveBeenCalled();
+    expect(getRadioState()?.data1ModInput).toBe(5);
     expect(pendingInStorage()).toBeNull();
   });
 
-  it('waits for state to arrive before restoring', () => {
+  it('cannot restore from later reconnect or cached-state updates', () => {
     localStorage.setItem(
       PENDING_RESTORE_KEY,
       JSON.stringify({ command: 'set_data1_mod_input', key: 'data1ModInput', source: 0 }),
     );
 
-    applyPendingModInputRestoreOnConnect();
-    expect(sendCommand).not.toHaveBeenCalled();
-
+    clearLegacyPendingModInputRestore();
+    setState({ main: receiver(1), data1ModInput: 5 });
     setState({ main: receiver(1), data1ModInput: 5 });
 
-    expect(sendCommand).toHaveBeenCalledWith('set_data1_mod_input', { source: 0 });
+    expect(sendCommand).not.toHaveBeenCalled();
+    expect(getRadioState()?.data1ModInput).toBe(5);
     expect(pendingInStorage()).toBeNull();
   });
 
-  it('drops the pending restore when the group is no longer on LAN', () => {
-    localStorage.setItem(
-      PENDING_RESTORE_KEY,
-      JSON.stringify({ command: 'set_data1_mod_input', key: 'data1ModInput', source: 0 }),
-    );
-    setState({ main: receiver(1), data1ModInput: 3 });
-
-    applyPendingModInputRestoreOnConnect();
-
-    expect(sendCommand).not.toHaveBeenCalled();
-    expect(pendingInStorage()).toBeNull();
-  });
-
-  it('does nothing when no pending restore is persisted', () => {
-    setState({ main: receiver(1), data1ModInput: 5 });
-
-    applyPendingModInputRestoreOnConnect();
-
-    expect(sendCommand).not.toHaveBeenCalled();
-  });
-
-  it('ignores malformed persisted data', () => {
+  it('clears malformed legacy data without radio effects', () => {
     localStorage.setItem(PENDING_RESTORE_KEY, '{not json');
     setState({ main: receiver(1), data1ModInput: 5 });
 
-    applyPendingModInputRestoreOnConnect();
+    clearLegacyPendingModInputRestore();
 
     expect(sendCommand).not.toHaveBeenCalled();
-  });
-
-  it('defers to the in-session clean-stop path while a TX is active', async () => {
-    setAutoLanModInputEnabled(true);
-    setState({ main: receiver(1), data1ModInput: 0 });
-    await getTxAudioControl().startTx();
-    vi.mocked(sendCommand).mockClear();
-
-    // A state update arrives mid-TX — the persisted pending must NOT be
-    // applied while the in-memory pending (current TX) owns the restore.
-    applyPendingModInputRestoreOnConnect();
-    setState({ main: receiver(1), data1ModInput: 5 });
-    expect(sendCommand).not.toHaveBeenCalled();
-
-    getTxAudioControl().stopTx();
-    expect(sendCommand).toHaveBeenCalledWith('set_data1_mod_input', { source: 0 });
+    expect(getRadioState()?.data1ModInput).toBe(5);
     expect(pendingInStorage()).toBeNull();
   });
+});
+
+it('keeps a hung cancelled start stopped and pending for reconciliation', async () => {
+  const pendingStart = deferred<string | null>();
+  vi.mocked(runtime.startTx).mockReturnValueOnce(pendingStart.promise);
+  setAutoLanModInputEnabled(true);
+  setState({ main: receiver(1), data1ModInput: 0 });
+  const control = getTxAudioControl();
+
+  const start = control.startTx();
+  control.stopLocalAudio();
+  control.stopLocalAudio();
+
+  expect(runtime.stopTx).toHaveBeenCalledTimes(1);
+  expect(sendCommand).not.toHaveBeenCalledWith('set_data1_mod_input', { source: 0 });
+  expect(pendingInStorage()).toBeNull();
+
+  // Settle only to keep this module-level adapter isolated from later files.
+  pendingStart.resolve('test cleanup');
+  await expect(start).resolves.toBe('test cleanup');
+  expect(runtime.stopTx).toHaveBeenCalledTimes(2);
+  confirmOff();
+  expect(sendCommand).toHaveBeenCalledWith('set_data1_mod_input', { source: 0 });
 });

--- a/frontend/src/lib/runtime/adapters/__tests__/mod-input-tx-guard.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mod-input-tx-guard.test.ts
@@ -100,6 +100,7 @@ function missingStatus() {
 }
 
 beforeEach(() => {
+  getTxAudioControl().stopLocalAudio();
   vi.mocked(sendCommand).mockClear();
   vi.mocked(runtime.startTx).mockClear();
   vi.mocked(runtime.stopTx).mockClear();

--- a/frontend/src/lib/runtime/adapters/mod-input-auto.svelte.ts
+++ b/frontend/src/lib/runtime/adapters/mod-input-auto.svelte.ts
@@ -9,25 +9,17 @@
  *     it, then set LAN through the same per-group SET command + optimistic
  *     patch as the ModePanel control (T1/MOR-615 backend, T2/MOR-616
  *     helpers). The optimistic LAN patch preempts the MOR-617 warning.
- *   - TX stop (`tx-adapter.stopTx`): restore the remembered source — only if
- *     auto changed it, and only if the group is still on LAN (a manual
- *     mid-TX change wins).
+ *   - after a field-specific authoritative PTT-off confirmation, restore the
+ *     remembered source only if the group is still on LAN (a manual mid-TX
+ *     change wins).
  *
- * Robustness: the clean stop above is the primary restore path. The pending
- * restore is also persisted to localStorage so that a crash / page reload /
- * disconnect mid-TX can be repaired best-effort on the next connect
- * (`applyPendingModInputRestoreOnConnect`, called from runtime bootstrap).
- * If that never fires, the radio stays on LAN — benign for network
- * operation, see the PR notes for the fully-robust backend follow-up.
+ * The pending transaction is intentionally memory-only. A disconnect,
+ * reload, or cached state cannot authorize MOD restoration.
  *
  * This module never touches the audio byte path.
  */
 
-import {
-  getRadioState,
-  patchRadioState,
-  subscribeRadioState,
-} from '$lib/stores/radio.svelte';
+import { getRadioState, patchRadioState } from '$lib/stores/radio.svelte';
 import { getCapabilities } from '$lib/stores/capabilities.svelte';
 import { getFieldAvailability } from '$lib/state/field-status';
 import {
@@ -37,13 +29,13 @@ import {
   type ModInputCommand,
   type ModInputStateKey,
 } from '$lib/radio/mod-input';
-import { isConnected, sendCommand } from '$lib/transport/ws-client';
+import { sendCommand } from '$lib/transport/ws-client';
 import type { ServerState } from '$lib/types/state';
 
 /** localStorage key of the opt-in preference ('true' / 'false'). */
 export const AUTO_LAN_PREF_KEY = 'rigplane:auto-lan-mod-input';
 
-/** localStorage key of the persisted pending restore (crash robustness). */
+/** Legacy localStorage key retained only for safe migration cleanup. */
 export const PENDING_RESTORE_KEY = 'rigplane:mod-input-tx-restore:v1';
 
 interface PendingRestore {
@@ -98,19 +90,10 @@ export function deriveAutoLanModInputProps(): AutoLanModInputProps {
   return { available, enabled };
 }
 
-/* ── Pending restore (memory + persisted) ────────────────────────── */
+/* ── Pending restore (memory only) ───────────────────────────────── */
 
 /** Set while a web TX keyed by auto-set is in flight; owns the restore. */
 let pending: PendingRestore | null = null;
-
-function persistPending(p: PendingRestore): void {
-  if (typeof localStorage === 'undefined') return;
-  try {
-    localStorage.setItem(PENDING_RESTORE_KEY, JSON.stringify(p));
-  } catch {
-    /* ignore */
-  }
-}
 
 function clearPersistedPending(): void {
   if (typeof localStorage === 'undefined') return;
@@ -119,25 +102,6 @@ function clearPersistedPending(): void {
   } catch {
     /* ignore */
   }
-}
-
-function readPersistedPending(): PendingRestore | null {
-  if (typeof localStorage === 'undefined') return null;
-  try {
-    const raw = localStorage.getItem(PENDING_RESTORE_KEY);
-    if (raw === null) return null;
-    const parsed = JSON.parse(raw) as Partial<PendingRestore>;
-    if (
-      typeof parsed?.command === 'string' &&
-      typeof parsed?.key === 'string' &&
-      typeof parsed?.source === 'number'
-    ) {
-      return parsed as PendingRestore;
-    }
-  } catch {
-    /* fall through */
-  }
-  return null;
 }
 
 /* ── Auto-set / restore engine ───────────────────────────────────── */
@@ -166,31 +130,21 @@ export function autoSetLanModInputForTx(): void {
   if (source === null || source === LAN_MOD_INPUT_SOURCE) return;
 
   pending = { command: modInputCommand(dataMode), key, source };
-  persistPending(pending);
   // Same optimistic-patch + per-group SET path as the ModePanel control
   // (MOR-616); the backend confirms via write-through readback (MOR-615).
   patchRadioState({ [key]: LAN_MOD_INPUT_SOURCE } as Partial<ServerState>);
   sendCommand(pending.command, { source: LAN_MOD_INPUT_SOURCE });
-  // MOR-624: arm a backend session-teardown restore so an abnormal disconnect
-  // mid-TX (this browser never reconnects) still restores the previous source.
-  sendCommand('arm_mod_input_restore', {
-    command: pending.command,
-    source: pending.source,
-  });
 }
 
 /**
- * TX-stop hook (clean restore path). One-shot: consumes the pending restore
- * whether or not a command is sent. Skips the SET when the group is known
- * to be off LAN already (the user changed it mid-TX — their choice wins).
+ * Confirmed-off hook. One-shot: consumes the pending restore whether or not a
+ * command is sent. Skips the SET when the group is known to be off LAN already.
  */
 export function restoreModInputAfterTx(): void {
   const p = pending;
   pending = null;
   clearPersistedPending();
   if (!p) return;
-  // MOR-624: a clean stop owns the restore — clear the backend teardown net.
-  sendCommand('disarm_mod_input_restore', {});
   const current = getRadioState()?.[p.key] ?? null;
   if (current !== null && current !== LAN_MOD_INPUT_SOURCE) return;
   patchRadioState({ [p.key]: p.source } as Partial<ServerState>);
@@ -198,50 +152,9 @@ export function restoreModInputAfterTx(): void {
 }
 
 /**
- * Best-effort repair after a crash / reload / disconnect mid-TX: if a
- * persisted pending restore is found, wait (via the radio-state
- * subscription) for live state on a connected control channel, then restore
- * the remembered source — but only when the group is still on LAN. Called
- * once from `FrontendRuntime.bootstrap()`.
+ * Remove pre-authority-gate restore records from older frontend versions.
+ * This migration never inspects cached radio state and never mutates the radio.
  */
-export function applyPendingModInputRestoreOnConnect(): void {
-  if (readPersistedPending() === null) return;
-
-  let finished = false;
-  let unsubscribe: (() => void) | null = null;
-  const finish = (): void => {
-    finished = true;
-    unsubscribe?.();
-  };
-
-  unsubscribe = subscribeRadioState((state) => {
-    if (finished) return;
-    const p = readPersistedPending();
-    if (!p) {
-      finish();
-      return;
-    }
-    // An in-flight TX in this session owns the restore (clean-stop path).
-    if (pending) return;
-    if (!state || !isConnected()) return;
-    const current = state[p.key] ?? null;
-    if (current === null) {
-      // Group not read yet — keep waiting, unless this radio never will.
-      if (getFieldAvailability(state, p.key) === 'missing') {
-        clearPersistedPending();
-        finish();
-      }
-      return;
-    }
-    if (current === LAN_MOD_INPUT_SOURCE) {
-      patchRadioState({ [p.key]: p.source } as Partial<ServerState>);
-      sendCommand(p.command, { source: p.source });
-    }
-    // Off LAN already → someone changed it; nothing to restore.
-    clearPersistedPending();
-    finish();
-  });
-  // subscribeRadioState invokes the handler synchronously — it may have
-  // finished before `unsubscribe` was assigned.
-  if (finished) unsubscribe();
+export function clearLegacyPendingModInputRestore(): void {
+  clearPersistedPending();
 }

--- a/frontend/src/lib/runtime/adapters/tx-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/tx-adapter.ts
@@ -11,27 +11,146 @@ import {
   restoreModInputAfterTx,
 } from './mod-input-auto.svelte';
 
+export interface PttObservationMarker {
+  authorityEpoch: number;
+  pttObservationSeq: number | null;
+  pttLastObservedMonotonic: number | null;
+}
+
+export interface AuthoritativePttObservation extends PttObservationMarker {
+  ptt: boolean;
+  pttObserved: boolean;
+  pttFreshness: 'fresh' | 'stale' | 'expired' | 'unknown';
+  pttSource: string;
+}
+
+export interface ConfirmedOffRestoreInput {
+  barrier: PttObservationMarker;
+  observation: AuthoritativePttObservation;
+}
+
+interface LocalAudioAttempt {
+  generation: number;
+  lifecycle: 'starting' | 'running';
+  stopRequested: boolean;
+}
+
+let nextLocalAudioGeneration = 0;
+let activeLocalAudioAttempt: LocalAudioAttempt | null = null;
+
+function markerIsStrictlyNewer(
+  barrier: PttObservationMarker,
+  observation: AuthoritativePttObservation,
+): boolean {
+  if (observation.authorityEpoch !== barrier.authorityEpoch) return false;
+
+  if (
+    barrier.pttObservationSeq !== null ||
+    observation.pttObservationSeq !== null
+  ) {
+    return (
+      barrier.pttObservationSeq !== null &&
+      observation.pttObservationSeq !== null &&
+      observation.pttObservationSeq > barrier.pttObservationSeq
+    );
+  }
+
+  return (
+    barrier.pttLastObservedMonotonic !== null &&
+    observation.pttLastObservedMonotonic !== null &&
+    observation.pttLastObservedMonotonic >
+      barrier.pttLastObservedMonotonic
+  );
+}
+
+function canRestoreModAfterConfirmedOff({
+  barrier,
+  observation,
+}: ConfirmedOffRestoreInput): boolean {
+  return (
+    observation.ptt === false &&
+    observation.pttObserved &&
+    observation.pttFreshness === 'fresh' &&
+    (observation.pttSource === 'radio-readback' ||
+      observation.pttSource === 'backend-observation') &&
+    markerIsStrictlyNewer(barrier, observation)
+  );
+}
+
+async function startTx(): Promise<string | null> {
+  if (activeLocalAudioAttempt?.lifecycle === 'starting') {
+    return 'TX audio start already in progress';
+  }
+  if (activeLocalAudioAttempt?.lifecycle === 'running') return null;
+
+  const attempt: LocalAudioAttempt = {
+    generation: ++nextLocalAudioGeneration,
+    lifecycle: 'starting',
+    stopRequested: false,
+  };
+  activeLocalAudioAttempt = attempt;
+
+  autoSetLanModInputForTx();
+  armModInputTxGuard();
+
+  let err: string | null;
+  try {
+    err = await runtime.startTx();
+  } catch (error) {
+    if (attempt.stopRequested) runtime.stopTx();
+    if (activeLocalAudioAttempt?.generation === attempt.generation) {
+      activeLocalAudioAttempt = null;
+    }
+    throw error;
+  }
+
+  if (attempt.stopRequested) {
+    runtime.stopTx();
+    if (activeLocalAudioAttempt?.generation === attempt.generation) {
+      activeLocalAudioAttempt = null;
+    }
+    return err;
+  }
+
+  if (err) {
+    if (activeLocalAudioAttempt?.generation === attempt.generation) {
+      activeLocalAudioAttempt = null;
+    }
+    return err;
+  }
+
+  attempt.lifecycle = 'running';
+  return null;
+}
+
+function stopLocalAudio(): void {
+  const attempt = activeLocalAudioAttempt;
+  if (!attempt || attempt.stopRequested) return;
+
+  attempt.stopRequested = true;
+  runtime.stopTx();
+  if (
+    attempt.lifecycle === 'running' &&
+    activeLocalAudioAttempt?.generation === attempt.generation
+  ) {
+    activeLocalAudioAttempt = null;
+  }
+}
+
+function restoreModAfterConfirmedOff(input: ConfirmedOffRestoreInput): void {
+  if (!canRestoreModAfterConfirmedOff(input)) return;
+  restoreModInputAfterTx();
+}
+
 export function getTxAudioControl() {
   return {
-    startTx: async (): Promise<string | null> => {
-      // MOR-618: opt-in auto-set runs first — its optimistic LAN patch
-      // preempts the MOR-617 warning (the guard then sees LAN and stays
-      // quiet). No-op while the toggle is OFF (default).
-      autoSetLanModInputForTx();
-      // MOR-617: preflight the MOD-input source at the moment of keying.
-      // Warn-only — never blocks or delays the actual TX audio start.
-      armModInputTxGuard();
-      const err = await runtime.startTx();
-      // TX audio failed to start — undo the auto-set right away
-      // (no-op when auto made no change).
-      if (err) restoreModInputAfterTx();
-      return err;
-    },
-    stopTx: () => {
-      runtime.stopTx();
-      // MOR-618: put the remembered MOD-input source back (no-op unless
-      // the auto-set changed it at TX start).
-      restoreModInputAfterTx();
-    },
+    startTx,
+    stopLocalAudio,
+    restoreModAfterConfirmedOff,
+    /**
+     * Transitional alias for the presentation-local PTT machines. Deliberately
+     * stops audio only; MOD restoration requires authoritative OFF evidence.
+     */
+    stopTx: stopLocalAudio,
   };
 }

--- a/frontend/src/lib/runtime/frontend-runtime.ts
+++ b/frontend/src/lib/runtime/frontend-runtime.ts
@@ -28,7 +28,7 @@ import { getAudioState, setVolume, setMuted, toggleMute } from '$lib/stores/audi
 import { sendCommand, connect, sendRaw } from '$lib/transport/ws-client';
 import { fetchCapabilities, startPolling, setPollingMultiplier } from '$lib/transport/http-client';
 import { audioManager } from '$lib/audio/audio-manager';
-import { applyPendingModInputRestoreOnConnect } from './adapters/mod-input-auto.svelte';
+import { clearLegacyPendingModInputRestore } from './adapters/mod-input-auto.svelte';
 import { systemController } from './system-controller';
 import { scopeController } from './scope-controller.svelte';
 import type { ScopeController } from './scope-controller.svelte';
@@ -162,6 +162,10 @@ class FrontendRuntime {
    * can be set before this async function starts.
    */
   private async _doBootstrap(): Promise<() => void> {
+    // Remove legacy pre-authority-gate restore records without consulting
+    // cached state or issuing any radio command.
+    clearLegacyPendingModInputRestore();
+
     // 1. Fetch capabilities and push into the store.
     const caps = await fetchCapabilities();
     setCapabilities(caps);
@@ -180,11 +184,6 @@ class FrontendRuntime {
 
     // 5. Subscribe to the events stream (re-sent automatically on reconnect by WsChannel).
     sendRaw({ type: 'subscribe', streams: ['events'] });
-
-    // 6. MOR-618: best-effort — if a previous session ended mid-TX after the
-    // opt-in auto MOD-input switch, restore the remembered source once live
-    // state arrives (no-op when nothing is pending).
-    applyPendingModInputRestoreOnConnect();
 
     // Only latch as started after the entire chain succeeds.
     this._bootstrapCleanup = stopPolling;


### PR DESCRIPTION
## Summary

- split immediate local TX-audio stop from MOD restore
- gate MOD restore on a strictly newer field-specific authoritative PTT=false observation
- make pending/hung/late-settling audio starts cancellation-safe
- make already-running start idempotent
- remove frontend legacy arm/disarm and reconnect/cached-state restore bypasses
- clear legacy persisted restore records without radio mutation

Linear: [MOR-990](https://linear.app/morozsm/issue/MOR-990/implementation-split-local-tx-audio-stop-from-confirmed-mod-restore)

Closes #1913

## Verification

- focused safety tests: 45/45 passed
- full frontend: 2184/2184 passed
- `npm run check`: 0 errors, 0 warnings
- full lint: passed
- forbidden-path search and `git diff --check`: clean
- independent agent review: PASS for `e878f9be`

## Scope note

The review-driven scope includes three cohesive production files and their adjacent tests. Production net growth is only 31 lines; most diff volume replaces unsafe legacy reconnect tests with the required race/evidence matrix. Direct backend/raw-WS legacy teardown is deliberately isolated to MOR-993 / #1917.
