### PR TITLE
Fail closed on teardown MOD restore

### DIFF
--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -177,7 +177,7 @@ logger = logging.getLogger(__name__)
 _MAX_CW_TEXT_CHARS = 512
 
 # MOR-624: maps the per-DATA-group MOD-input SET command name (as sent by the
-# frontend auto-restore) to its poller action, for session-teardown restore.
+# frontend auto-restore) to its allowed teardown arm name (MOR-993).
 _MOD_INPUT_RESTORE_ACTIONS: dict[str, Any] = {
     "set_data_off_mod_input": SetDataOffModInput,
     "set_data1_mod_input": SetData1ModInput,
@@ -474,7 +474,7 @@ class ControlHandler:
         )
         self._subscribed_streams: set[str] = set()
         # MOR-624: (command_name, previous_source) armed by the frontend auto-LAN
-        # feature at TX start; restored on abnormal session teardown. None = nothing armed.
+        # feature at TX start; MOR-993 permits teardown PTT OFF only.
         self._mod_input_restore: tuple[str, int] | None = None
         self._event_queue: BoundedQueue[dict[str, Any]] = BoundedQueue(
             maxsize=100,
@@ -980,53 +980,53 @@ class ControlHandler:
     def _apply_mod_input_restore_cmd(
         self, name: str, params: dict[str, Any]
     ) -> dict[str, Any]:
-        """Arm/disarm the session MOD-input restore (MOR-624).
+        """Arm/disarm the transitional session teardown intent (MOR-624/MOR-993).
 
-        Session-local bookkeeping only — never touches the radio. ``arm`` records
-        the per-group SET command + the previous source to re-apply if this session
-        tears down before a clean disarm; ``disarm`` (clean TX stop owns the
-        restore) clears it.
+        Writable-session ``arm`` keeps the legacy payload for wire compatibility,
+        but teardown may use it only to request emergency PTT OFF. It never
+        authorizes a MOD SET. ``disarm`` clears the intent idempotently.
         """
         if name == "disarm_mod_input_restore":
             self._mod_input_restore = None
             return {}
+        self._mod_input_restore = None
+        if self._read_only:
+            return {"armed": False}
         command = str(params.get("command", ""))
         if command not in _MOD_INPUT_RESTORE_ACTIONS:
-            self._mod_input_restore = None
             return {"armed": False}
-        self._mod_input_restore = (command, int(params.get("source", 0)))
+        source = params.get("source")
+        if (
+            isinstance(source, bool)
+            or not isinstance(source, int)
+            or not 0 <= source <= 5
+        ):
+            return {"armed": False}
+        self._mod_input_restore = (command, source)
         return {"armed": True}
 
     def _restore_mod_input_on_teardown(self) -> None:
-        """Restore the armed MOD-input source on abnormal session teardown (MOR-624).
+        """Consume the legacy arm and request best-effort PTT OFF only (MOR-993).
 
-        A clean TX stop disarms (see ``_apply_mod_input_restore_cmd``), so a still-armed
-        restore here means the client vanished mid-TX. Enqueue PttOff first — restoring a
-        non-LAN source while the rig is still keyed would re-trigger the open-mic footgun
-        MOR-614 fixed — then the previous-source SET. Best-effort: the shared poller may be
-        shutting down too.
+        Queue order, ACK, timeout, and cached state do not prove RF de-key. Until
+        MOR-986 supplies fresh authoritative PTT confirmation, teardown must
+        never enqueue the remembered MOD SET.
         """
-        restore = self._mod_input_restore
+        armed = self._mod_input_restore
         self._mod_input_restore = None
-        if restore is None or self._server is None or self._radio is None:
+        if armed is None or self._server is None:
             return
         queue = getattr(self._server, "command_queue", None)
         if queue is None:
             return
-        command, source = restore
-        action = _MOD_INPUT_RESTORE_ACTIONS.get(command)
-        if action is None:
-            return
         try:
             queue.put(PttOff())
-            queue.put(action(source))
         except Exception:
-            logger.debug("control: MOD-input teardown restore failed", exc_info=True)
+            logger.debug("control: teardown PTT OFF enqueue failed", exc_info=True)
         else:
             logger.info(
-                "control: restored MOD-input %s=%d on session teardown (session=%s)",
-                command,
-                source,
+                "control: requested PTT OFF on armed session teardown; "
+                "MOD restore suppressed pending authoritative OFF (session=%s)",
                 self._session_id,
             )
 

--- a/tests/test_web_mod_input_restore.py
+++ b/tests/test_web_mod_input_restore.py
@@ -1,55 +1,53 @@
-"""Tests for backend session-teardown MOD-input restore (MOR-624).
+"""Tests for backend session-teardown MOD handling (MOR-624/MOR-993).
 
 The frontend auto-LAN feature (MOR-618) arms a restore on the backend
 session at TX start and disarms it on a clean TX stop. If the session
-tears down while still armed (abnormal mid-TX disconnect), the handler
-enqueues PttOff followed by the previous-source SET on the shared
-command queue.
+tears down while still armed, the handler enqueues PttOff only; no command
+outcome or queue ordering authorizes a previous-source MOD SET.
 """
 
 from __future__ import annotations
 
-from queue import Queue
 from types import SimpleNamespace
-from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from rigplane.profiles import resolve_radio_profile
 from rigplane.web.handlers.control import ControlHandler
-from rigplane.web.radio_poller import (
-    PttOff,
-    SetDataOffModInput,
-    SetData1ModInput,
-    SetData2ModInput,
+from rigplane.web.radio_poller import CommandQueue, PttOff, RadioPoller
+
+_MOD_COMMANDS = (
+    "set_data_off_mod_input",
+    "set_data1_mod_input",
+    "set_data2_mod_input",
+    "set_data3_mod_input",
 )
 
 
-def _make_handler() -> tuple[ControlHandler, Queue[Any]]:
-    """Build a ControlHandler with a fake server and return (handler, command_queue)."""
-    ws = MagicMock()
-
-    command_queue: Queue[Any] = Queue()
-
-    server = SimpleNamespace(
-        command_queue=command_queue,
-    )
-
+def _make_handler(*, read_only: bool = False) -> tuple[ControlHandler, CommandQueue]:
+    """Build a ControlHandler with a real command queue."""
+    command_queue = CommandQueue()
+    server = SimpleNamespace(command_queue=command_queue)
     handler = ControlHandler(
-        ws=ws,
+        ws=MagicMock(),
         radio=MagicMock(),
         server_version="test",
         radio_model="IC-7610",
         server=server,
+        read_only=read_only,
     )
     return handler, command_queue
 
 
-def _drain(q: Queue[Any]) -> list[Any]:
-    items: list[Any] = []
-    while not q.empty():
-        items.append(q.get_nowait())
-    return items
+def _provider_poller(error: Exception | None) -> tuple[RadioPoller, MagicMock]:
+    radio = MagicMock()
+    radio.profile = resolve_radio_profile(model="IC-7610")
+    radio.capabilities = set(radio.profile.capabilities) - {"audio"}
+    radio.set_ptt = AsyncMock(side_effect=error)
+    for name in _MOD_COMMANDS:
+        setattr(radio, name, AsyncMock())
+    return RadioPoller(radio, CommandQueue()), radio
 
 
 class TestArmDisarm:
@@ -77,7 +75,7 @@ class TestArmDisarm:
         assert handler._mod_input_restore is None
         assert result == {"armed": False}
 
-    def test_disarm_clears_armed_state(self) -> None:
+    def test_disarm_clears_armed_state_idempotently(self) -> None:
         handler, _ = _make_handler()
         handler._apply_mod_input_restore_cmd(
             "arm_mod_input_restore",
@@ -85,50 +83,89 @@ class TestArmDisarm:
         )
 
         result = handler._apply_mod_input_restore_cmd("disarm_mod_input_restore", {})
+        repeated = handler._apply_mod_input_restore_cmd("disarm_mod_input_restore", {})
 
         assert handler._mod_input_restore is None
-        assert result == {}
+        assert result == repeated == {}
+
+    @pytest.mark.parametrize("source", [True, "2", -1, 6, None])
+    def test_invalid_source_is_rejected_and_clears_existing_arm(
+        self, source: object
+    ) -> None:
+        handler, q = _make_handler()
+        invalid = {"command": "set_data1_mod_input", "source": source}
+        valid = {"command": "set_data1_mod_input", "source": 2}
+
+        assert handler._apply_mod_input_restore_cmd(
+            "arm_mod_input_restore", invalid
+        ) == {"armed": False}
+        assert handler._mod_input_restore is None
+        assert handler._apply_mod_input_restore_cmd("arm_mod_input_restore", valid) == {
+            "armed": True
+        }
+        assert handler._apply_mod_input_restore_cmd(
+            "arm_mod_input_restore", invalid
+        ) == {"armed": False}
+        handler._restore_mod_input_on_teardown()
+        assert handler._mod_input_restore is None
+        assert not q.has_commands
 
 
 class TestTeardownRestore:
-    """_restore_mod_input_on_teardown enqueues PttOff then the restore SET."""
+    """An armed teardown consumes its state and enqueues PTT OFF only."""
 
-    def test_teardown_when_armed_enqueues_ptt_off_then_restore(self) -> None:
+    @pytest.mark.parametrize("command", _MOD_COMMANDS)
+    def test_teardown_when_armed_enqueues_one_ptt_off(self, command: str) -> None:
         handler, q = _make_handler()
         handler._apply_mod_input_restore_cmd(
             "arm_mod_input_restore",
-            {"command": "set_data_off_mod_input", "source": 0},
+            {"command": command, "source": 0},
         )
 
         handler._restore_mod_input_on_teardown()
+        handler._restore_mod_input_on_teardown()
 
-        items = _drain(q)
-        assert len(items) == 2
-        assert isinstance(items[0], PttOff)
-        assert isinstance(items[1], SetDataOffModInput)
-        assert items[1].source == 0
+        assert q.drain() == [PttOff()]
         assert handler._mod_input_restore is None
 
-    def test_teardown_carries_armed_source(self) -> None:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "error",
+        [
+            None,
+            TimeoutError("OFF timed out"),
+            ConnectionError("radio unreachable"),
+            RuntimeError("provider failure"),
+        ],
+        ids=["success", "timeout", "unreachable", "provider-failure"],
+    )
+    async def test_off_outcome_never_invokes_mod_provider(
+        self, error: Exception | None
+    ) -> None:
         handler, q = _make_handler()
         handler._apply_mod_input_restore_cmd(
             "arm_mod_input_restore",
-            {"command": "set_data1_mod_input", "source": 3},
+            {"command": "set_data3_mod_input", "source": 3},
         )
-
         handler._restore_mod_input_on_teardown()
+        commands = q.drain()
+        assert commands == [PttOff()]
 
-        items = _drain(q)
-        assert isinstance(items[0], PttOff)
-        assert isinstance(items[1], SetData1ModInput)
-        assert items[1].source == 3
+        poller, radio = _provider_poller(error)
+        try:
+            await poller._execute(commands[0])
+        except Exception as exc:
+            assert exc is error
+        radio.set_ptt.assert_awaited_once_with(False)
+        for name in _MOD_COMMANDS:
+            getattr(radio, name).assert_not_awaited()
 
     def test_teardown_when_not_armed_enqueues_nothing(self) -> None:
         handler, q = _make_handler()
 
         handler._restore_mod_input_on_teardown()
 
-        assert q.empty(), "nothing armed — teardown must not touch the queue"
+        assert not q.has_commands
 
     def test_teardown_after_disarm_enqueues_nothing(self) -> None:
         handler, q = _make_handler()
@@ -140,7 +177,7 @@ class TestTeardownRestore:
 
         handler._restore_mod_input_on_teardown()
 
-        assert q.empty(), "clean disarm owns the restore — teardown must be a no-op"
+        assert not q.has_commands
 
 
 class TestCommandRouting:
@@ -162,11 +199,11 @@ class TestCommandRouting:
         assert handler._mod_input_restore == ("set_data2_mod_input", 3)
         handler._ws.send_text.assert_awaited_once()
         sent = handler._ws.send_text.await_args.args[0]
-        assert '"ok": true' in sent or '"ok":true' in sent
+        assert '"ok":true' in sent and '"armed":true' in sent
 
     @pytest.mark.asyncio
-    async def test_teardown_after_routed_arm_restores(self) -> None:
-        handler, q = _make_handler()
+    async def test_read_only_routed_arm_has_no_teardown_effect(self) -> None:
+        handler, q = _make_handler(read_only=True)
         handler._ws.send_text = AsyncMock()
 
         await handler._handle_command(
@@ -178,8 +215,7 @@ class TestCommandRouting:
         )
         handler._restore_mod_input_on_teardown()
 
-        items = _drain(q)
-        assert len(items) == 2
-        assert isinstance(items[0], PttOff)
-        assert isinstance(items[1], SetData2ModInput)
-        assert items[1].source == 3
+        assert handler._mod_input_restore is None
+        assert not q.has_commands
+        sent = handler._ws.send_text.await_args.args[0]
+        assert '"ok":true' in sent and '"armed":false' in sent


### PR DESCRIPTION
## Summary

- preserve transition-compatible arm/disarm responses
- reduce armed teardown to one best-effort `PttOff`
- never enqueue or invoke teardown-generated MOD input SET
- prevent read-only and invalid raw WS arms from creating teardown side effects
- clear stale arm state before parsing a replacement arm

Linear: [MOR-993](https://linear.app/morozsm/issue/MOR-993/interim-safety-disable-ungated-backend-mod-restore-on-session-teardown)

Closes #1917

## Verification

- focused safety matrix: 36 passed
- full non-hardware suite: 8176 passed
- Ruff and format: passed
- import-linter: 5/5 contracts kept
- changed production mypy: passed
- `git diff --check`: clean
- independent agent review: PASS for `b41ee2bb`

Full `mypy src` retains 13 pre-existing errors in unchanged runtime files, identical to baseline.

## Scope

Exactly two files and 198 changed LOC. No poller, queue, provider, frontend, or full supervisor changes. MOR-986 later replaces the one-shot OFF with lease-qualified durable release.
