### PR TITLE
Normalize concrete audio FFT and scope fixtures

### DIFF
--- a/tests/test_audio_scope_dispatch.py
+++ b/tests/test_audio_scope_dispatch.py
@@ -35,7 +35,9 @@ from rigplane.audio.backend import (
 from rigplane.audio.usb_driver import UsbAudioDriver
 from rigplane.backends.ic705.serial import Ic705SerialRadio
 from rigplane.capabilities import CAP_AUDIO, CAP_SCOPE
+from rigplane.radio import IcomRadio
 from rigplane.scope import ScopeFrame
+from rigplane.types import AudioCodec
 from rigplane.web.server import WebConfig, WebServer
 
 
@@ -119,21 +121,19 @@ class _FakeSerialCivLink:
         return None
 
 
-class _HardwareScopeRadio:
-    """Minimal fake radio that advertises BOTH audio and hardware scope.
+def _make_hardware_and_pcm_radio() -> IcomRadio:
+    """Build an unconnected radio with BOTH hardware scope and concrete PCM.
 
     Used to prove the IC-7610-class non-regression: a hardware-scope radio
     must still receive audio-scope frames but must NOT have the audio FFT
     drive ``/api/v1/scope`` (its main spectrum comes from the real scope).
     """
-
-    def __init__(self) -> None:
-        from rigplane.radio_state import RadioState
-
-        self.capabilities = frozenset({CAP_AUDIO, CAP_SCOPE})
-        self.radio_state = RadioState()
-        self.audio_codec = None
-        self.audio_sample_rate = 48_000
+    return IcomRadio(
+        "127.0.0.1",
+        model="IC-7610",
+        audio_codec=AudioCodec.PCM_1CH_16BIT,
+        audio_sample_rate=48_000,
+    )
 
 
 class _FakeScopeHandler:
@@ -153,7 +153,7 @@ def _make_pcm_noise(num_samples: int, amplitude: int = 5000) -> bytes:
     """Generate PCM16 mono white noise frames (radio RX shape)."""
     rng = np.random.default_rng(241)
     samples = (rng.uniform(-1, 1, num_samples) * amplitude).astype(np.int16)
-    return samples.tobytes()
+    return bytes(samples.tobytes())
 
 
 def _feed_pcm_through_tap(server: WebServer, total_samples: int) -> None:
@@ -179,7 +179,7 @@ def _feed_pcm_through_tap(server: WebServer, total_samples: int) -> None:
 # ── X6200 (no hardware scope) ────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_x6200_audio_scope_receives_fft_frames() -> None:
     """Non-hardware-scope X6200 must relay FFT frames to /api/v1/audio-scope.
 
@@ -201,6 +201,9 @@ async def test_x6200_audio_scope_receives_fft_frames() -> None:
         # Sanity: X6200 has audio FFT but no hardware scope.
         assert CAP_AUDIO in radio.capabilities
         assert CAP_SCOPE not in radio.capabilities
+        assert callable(radio.audio_session.subscribe_rx)
+        assert radio.audio_codec == AudioCodec.PCM_1CH_16BIT
+        assert radio.audio_sample_rate > 0
 
         server = WebServer(radio=radio, config=WebConfig())
         assert server._audio_fft_scope is not None, "audio FFT scope not wired"
@@ -241,7 +244,12 @@ def test_hardware_scope_radio_audio_fft_only_on_audio_scope() -> None:
     audio-scope path but must NEVER be pushed to /api/v1/scope (whose
     frames come from the real hardware scope).
     """
-    radio = _HardwareScopeRadio()
+    radio = _make_hardware_and_pcm_radio()
+    assert {CAP_AUDIO, CAP_SCOPE} <= radio.capabilities
+    assert callable(radio.audio_session.subscribe_rx)
+    assert radio.audio_codec == AudioCodec.PCM_1CH_16BIT
+    assert radio.audio_sample_rate > 0
+
     server = WebServer(radio=radio, config=WebConfig())
     assert server._audio_fft_scope is not None
 

--- a/tests/test_fft_scope_center_freq.py
+++ b/tests/test_fft_scope_center_freq.py
@@ -23,11 +23,13 @@ asserting the scope's center freq / bandwidth.
 
 from __future__ import annotations
 
+from rigplane.audio_bus import AudioBus
 from rigplane.capabilities import CAP_AUDIO
 from rigplane.core.state_pipeline_contracts import FieldPath, SourceMetadata
 from rigplane.core.state_store import FieldSnapshot, FreshnessState, StateSnapshot
 from rigplane.profiles import resolve_radio_profile
 from rigplane.radio_state import RadioState
+from rigplane.types import AudioCodec
 from rigplane.web.server import WebConfig, WebServer
 
 _SOURCE = SourceMetadata(
@@ -39,15 +41,19 @@ _SOURCE = SourceMetadata(
 
 
 class _AudioOnlyRadio:
-    """Minimal fake radio: audio capability (so the FFT scope is wired), no
-    hardware scope. Carries a real profile so mode-bandwidth resolution works.
+    """Concrete wrapped-USB PCM supplier with no hardware scope.
+
+    Carries a real profile so mode-bandwidth resolution works.
     """
 
+    has_usb_audio = True
+
     def __init__(self, *, model: str) -> None:
-        self.capabilities = frozenset({CAP_AUDIO})
+        self.capabilities = {CAP_AUDIO}
         self.radio_state = RadioState()
-        self.audio_codec = None
+        self.audio_codec = AudioCodec.PCM_1CH_16BIT
         self.audio_sample_rate = 48_000
+        self.audio_bus = AudioBus(self)
         self.model = model
         self.profile = resolve_radio_profile(model=model)
 
@@ -85,7 +91,11 @@ def _mode_field(receiver_id: str, mode: str) -> FieldSnapshot:
 
 
 def _make_server(*, model: str) -> WebServer:
-    server = WebServer(radio=_AudioOnlyRadio(model=model), config=WebConfig())
+    radio = _AudioOnlyRadio(model=model)
+    assert callable(radio.audio_bus.subscribe)
+    assert radio.audio_codec == AudioCodec.PCM_1CH_16BIT
+    assert radio.audio_sample_rate > 0
+    server = WebServer(radio=radio, config=WebConfig())
     assert server._audio_fft_scope is not None, "audio FFT scope must be wired"
     return server
 


### PR DESCRIPTION
## Summary

- replace tag-only FFT/scope fixtures with concrete PCM suppliers
- model real AudioSession and AudioBus routes with supported codec/rate
- preserve hardware+audio, audio-only, dispatch, center-frequency, bandwidth, and named-tap behavior

Linear: [MOR-996](https://linear.app/morozsm/issue/MOR-996/test-prerequisite-normalize-concrete-fftscope-fixtures)

Closes #1922

## Verification

- focused/relevant: 45 passed
- full non-hardware: 8165 passed
- Ruff and format: passed
- import-linter: 5/5 contracts kept
- diff/check: clean
- independent agent review: PASS for `e2ea73d6`

Full `mypy src` retains 13 baseline errors in unrelated runtime files; this test-only commit adds none.

## Scope

Exactly two test files, 54 changed LOC, no production changes or model-specific bypasses.
