### PR TITLE
Validate frontend capability v1 payload at the HTTP boundary

### DIFF
--- a/frontend/src/lib/stores/__tests__/capabilities.test.ts
+++ b/frontend/src/lib/stores/__tests__/capabilities.test.ts
@@ -8,9 +8,14 @@ function makeCaps(overrides: Partial<Capabilities> = {}): Capabilities {
     audio: true,
     tx: true,
     capabilities: ['scope', 'dual_rx', 'tx', 'tuner', 'cw'],
+    receivers: 2,
+    vfoScheme: 'main_sub',
     freqRanges: [{ start: 1800000, end: 30000000, label: 'HF' }],
     modes: ['USB', 'LSB', 'CW', 'AM', 'FM'],
     filters: ['FIL1', 'FIL2', 'FIL3'],
+    audioConfig: { sampleRate: 48000, channels: 1, codecs: ['opus'] },
+    webrtc: { available: true, enabled: false },
+    txBands: null,
     ...overrides,
   };
 }

--- a/frontend/src/lib/transport/__tests__/http-client.test.ts
+++ b/frontend/src/lib/transport/__tests__/http-client.test.ts
@@ -113,7 +113,12 @@ describe('fetchCapabilities', () => {
       capabilities: ['scope', 'dual_rx'],
       receivers: 2,
       vfoScheme: 'main_sub',
-      freqRanges: [],
+      freqRanges: [{
+        start: 100000,
+        end: 60000000,
+        label: 'HF',
+        bands: [{ name: '20m', start: 14000000, end: 14350000, default: 14074000, bsrCode: 5 }],
+      }],
       modes: ['USB', 'LSB'],
       filters: ['FIL1'],
       audioConfig: { sampleRate: 48000, channels: 1, codecs: ['opus'] },
@@ -162,6 +167,21 @@ describe('fetchCapabilities', () => {
     expect(result.txBands).toBe(txBands);
   });
 
+  it('accepts finite numeric range values without imposing ordering rules', async () => {
+    const freqRanges = [{
+      start: 2.5,
+      end: -1,
+      label: 'Synthetic',
+      bands: [{ name: 'Synthetic', start: 3.5, end: -2, default: 0.5, bsrCode: -1 }],
+    }];
+    const caps = makeCapabilities({ freqRanges });
+    mockCapabilities(caps);
+    const { fetchCapabilities } = await import('../http-client');
+    const result = await fetchCapabilities();
+    expect(result).toBe(caps);
+    expect(result.freqRanges).toBe(freqRanges);
+  });
+
   it.each([
     ['$.receivers', { receivers: undefined }],
     ['$.receivers', { receivers: true }],
@@ -170,6 +190,21 @@ describe('fetchCapabilities', () => {
     ['$.vfoScheme', { vfoScheme: undefined }],
     ['$.vfoScheme', { vfoScheme: 'unknown' }],
     ['$.vfoScheme', { vfoScheme: 'single', receivers: 2 }],
+    ['$.freqRanges[0]', { freqRanges: [null] }],
+    ['$.freqRanges[0].start', { freqRanges: [{}] }],
+    ['$.freqRanges[0].start', { freqRanges: [{ start: true, end: 2, label: 'HF' }] }],
+    ['$.freqRanges[0].start', { freqRanges: [{ start: Number.NaN, end: 2, label: 'HF' }] }],
+    ['$.freqRanges[0].end', { freqRanges: [{ start: 1, end: false, label: 'HF' }] }],
+    ['$.freqRanges[0].end', { freqRanges: [{ start: 1, end: Number.POSITIVE_INFINITY, label: 'HF' }] }],
+    ['$.freqRanges[0].label', { freqRanges: [{ start: 1, end: 2, label: false }] }],
+    ['$.freqRanges[0].bands', { freqRanges: [{ start: 1, end: 2, label: 'HF', bands: {} }] }],
+    ['$.freqRanges[0].bands[0]', { freqRanges: [{ start: 1, end: 2, label: 'HF', bands: [null] }] }],
+    ['$.freqRanges[0].bands[0].name', { freqRanges: [{ start: 1, end: 2, label: 'HF', bands: [{}] }] }],
+    ['$.freqRanges[0].bands[0].start', { freqRanges: [{ start: 1, end: 2, label: 'HF', bands: [{ name: '20m', start: true, end: 4, default: 3 }] }] }],
+    ['$.freqRanges[0].bands[0].end', { freqRanges: [{ start: 1, end: 2, label: 'HF', bands: [{ name: '20m', start: 2, end: false, default: 3 }] }] }],
+    ['$.freqRanges[0].bands[0].default', { freqRanges: [{ start: 1, end: 2, label: 'HF', bands: [{ name: '20m', start: 2, end: 4, default: true }] }] }],
+    ['$.freqRanges[0].bands[0].default', { freqRanges: [{ start: 1, end: 2, label: 'HF', bands: [{ name: '20m', start: 2, end: 4, default: Number.NEGATIVE_INFINITY }] }] }],
+    ['$.freqRanges[0].bands[0].bsrCode', { freqRanges: [{ start: 1, end: 2, label: 'HF', bands: [{ name: '20m', start: 2, end: 4, default: 3, bsrCode: false }] }] }],
     ['$.audioConfig.channels', { audioConfig: { sampleRate: 48000, channels: true, codecs: ['opus'] } }],
     ['$.audioConfig.codecs[0]', { audioConfig: { sampleRate: 48000, channels: 1, codecs: [1] } }],
     ['$.webrtc.available', { webrtc: { available: 1, enabled: false } }],

--- a/frontend/src/lib/transport/__tests__/http-client.test.ts
+++ b/frontend/src/lib/transport/__tests__/http-client.test.ts
@@ -104,25 +104,85 @@ describe('fetchState', () => {
 describe('fetchCapabilities', () => {
   afterEach(() => vi.restoreAllMocks());
 
-  it('returns parsed Capabilities', async () => {
-    const caps = {
+  function makeCapabilities(overrides: Record<string, unknown> = {}) {
+    return {
       model: 'IC-7610',
       scope: true,
       audio: true,
       tx: true,
       capabilities: ['scope', 'dual_rx'],
+      receivers: 2,
+      vfoScheme: 'main_sub',
       freqRanges: [],
       modes: ['USB', 'LSB'],
       filters: ['FIL1'],
+      audioConfig: { sampleRate: 48000, channels: 1, codecs: ['opus'] },
+      webrtc: { available: true, enabled: false },
+      txBands: [{ name: '20m', start: 14000000, end: 14350000 }],
+      ...overrides,
     };
+  }
+
+  function mockCapabilities(payload: unknown) {
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve(caps),
+      json: () => Promise.resolve(payload),
     });
+  }
 
+  it('returns the same validated raw object with additive extensions intact', async () => {
+    const caps = makeCapabilities({ extension: { future: true } });
+    mockCapabilities(caps);
     const { fetchCapabilities } = await import('../http-client');
     const result = await fetchCapabilities();
-    expect(result.model).toBe('IC-7610');
+    expect(result).toBe(caps);
+    expect(result.extension).toEqual({ future: true });
+  });
+
+  it.each([
+    ['single', 1],
+    ['ab', 1],
+    ['ab_shared', 2],
+    ['main_sub', 2],
+  ])('accepts the %s topology', async (vfoScheme, receivers) => {
+    mockCapabilities(makeCapabilities({ vfoScheme, receivers }));
+    const { fetchCapabilities } = await import('../http-client');
+    await expect(fetchCapabilities()).resolves.toMatchObject({ vfoScheme, receivers });
+  });
+
+  it.each([
+    ['null', null],
+    ['an explicit empty list', []],
+  ])('accepts txBands as %s without normalizing it', async (_label, txBands) => {
+    const caps = makeCapabilities({ txBands });
+    mockCapabilities(caps);
+    const { fetchCapabilities } = await import('../http-client');
+    const result = await fetchCapabilities();
+    expect(result).toBe(caps);
+    expect(result.txBands).toBe(txBands);
+  });
+
+  it.each([
+    ['$.receivers', { receivers: undefined }],
+    ['$.receivers', { receivers: true }],
+    ['$.receivers', { receivers: 0 }],
+    ['$.receivers', { receivers: 1.5 }],
+    ['$.vfoScheme', { vfoScheme: undefined }],
+    ['$.vfoScheme', { vfoScheme: 'unknown' }],
+    ['$.vfoScheme', { vfoScheme: 'single', receivers: 2 }],
+    ['$.audioConfig.channels', { audioConfig: { sampleRate: 48000, channels: true, codecs: ['opus'] } }],
+    ['$.audioConfig.codecs[0]', { audioConfig: { sampleRate: 48000, channels: 1, codecs: [1] } }],
+    ['$.webrtc.available', { webrtc: { available: 1, enabled: false } }],
+    ['$.webrtc.enabled', { webrtc: { available: true } }],
+    ['$.txBands', { txBands: undefined }],
+    ['$.txBands[0].name', { txBands: [{ name: 20, start: 1, end: 2 }] }],
+    ['$.txBands[0].start', { txBands: [{ name: '20m', start: true, end: 2 }] }],
+    ['$.txBands[0].end', { txBands: [{ name: '20m', start: 1, end: false }] }],
+    ['$.txBands[0].end', { txBands: [{ name: '20m', start: 1, end: 2.5 }] }],
+  ])('rejects malformed required field %s', async (path, overrides) => {
+    mockCapabilities(makeCapabilities(overrides));
+    const { fetchCapabilities } = await import('../http-client');
+    await expect(fetchCapabilities()).rejects.toThrow(path);
   });
 });
 

--- a/frontend/src/lib/transport/http-client.ts
+++ b/frontend/src/lib/transport/http-client.ts
@@ -1,5 +1,5 @@
 import type { ServerState } from '../types/state';
-import type { Capabilities } from '../types/capabilities';
+import { validateCapabilities, type Capabilities } from '../types/capabilities';
 import type { InfoResponse } from '../types/protocol';
 import { markStateUpdated, setHttpConnected, setRadioHealth, setRadioStatus, setReconnecting } from '../stores/connection.svelte';
 
@@ -114,7 +114,7 @@ export async function fetchCapabilities(): Promise<Capabilities> {
   const res = await fetch(`${BASE}/capabilities`, { headers: getAuthHeaders() });
   if (res.status === 401) { handleUnauthorized(); throw new Error('Unauthorized'); }
   if (!res.ok) throw new Error(`fetchCapabilities: ${res.status}`);
-  return res.json() as Promise<Capabilities>;
+  return validateCapabilities(await res.json());
 }
 
 /** Fetch server info (version, uptime). Used by StatusBar component (Sprint 2). */

--- a/frontend/src/lib/types/capabilities.ts
+++ b/frontend/src/lib/types/capabilities.ts
@@ -76,15 +76,28 @@ export interface ControlRange {
   style?: string;
 }
 
+export type VfoScheme = 'single' | 'ab' | 'ab_shared' | 'main_sub';
+
+export interface WebRtcCapabilities {
+  available: boolean;
+  enabled: boolean;
+}
+
+export interface TxBand {
+  name: string;
+  start: number;
+  end: number;
+}
+
 export interface Capabilities {
+  [extension: string]: unknown;
   model: string;
   scope: boolean;
   audio: boolean;
   tx: boolean;
   capabilities: string[];
-  receivers?: number;      // 1 = single, 2 = dual receiver
-  vfoScheme?: string;      // "ab" or "main_sub"
-  hasLan?: boolean;        // Radio has LAN connectivity
+  receivers: number;
+  vfoScheme: VfoScheme;
   freqRanges: FreqRange[];
   modes: string[];
   filters: string[];
@@ -104,9 +117,10 @@ export interface Capabilities {
   scopeSource?: string | null;  // "hardware", "audio_fft", or null
   audioFftAvailable?: boolean;  // true when audio FFT scope is available (even with hardware scope)
   scopeConfig?: ScopeConfig;
-  audioConfig?: AudioConfig;
+  audioConfig: AudioConfig;
+  webrtc: WebRtcCapabilities;
   controls?: Record<string, ControlRange>;
-  txBands?: { name: string; start: number; end: number }[];
+  txBands: TxBand[] | null;
   meterCalibrations?: Record<string, MeterCalPoint[]>;
   meterRedlines?: Record<string, number>;
 }
@@ -115,4 +129,84 @@ export interface MeterCalPoint {
   raw: number;
   actual: number;
   label: string;
+}
+
+function invalid(path: string, expected: string): never {
+  throw new TypeError(`Invalid capabilities payload at ${path}: expected ${expected}`);
+}
+
+function requireRecord(value: unknown, path: string): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    invalid(path, 'an object');
+  }
+  return value as Record<string, unknown>;
+}
+
+function requireString(value: unknown, path: string): void {
+  if (typeof value !== 'string') invalid(path, 'a string');
+}
+
+function requireBoolean(value: unknown, path: string): void {
+  if (typeof value !== 'boolean') invalid(path, 'a boolean');
+}
+
+function requireStringArray(value: unknown, path: string): void {
+  if (!Array.isArray(value)) invalid(path, 'an array');
+  value.forEach((item, index) => requireString(item, `${path}[${index}]`));
+}
+
+function requireInteger(value: unknown, path: string, positive = false): void {
+  if (
+    typeof value !== 'number'
+    || !Number.isInteger(value)
+    || !Number.isFinite(value)
+    || (positive && value <= 0)
+  ) {
+    invalid(path, positive ? 'a positive integer' : 'an integer');
+  }
+}
+
+export function validateCapabilities(value: unknown): Capabilities {
+  const raw = requireRecord(value, '$');
+
+  requireString(raw.model, '$.model');
+  requireBoolean(raw.scope, '$.scope');
+  requireBoolean(raw.audio, '$.audio');
+  requireBoolean(raw.tx, '$.tx');
+  requireStringArray(raw.capabilities, '$.capabilities');
+  requireInteger(raw.receivers, '$.receivers', true);
+
+  const schemes: readonly VfoScheme[] = ['single', 'ab', 'ab_shared', 'main_sub'];
+  if (!schemes.includes(raw.vfoScheme as VfoScheme)) {
+    invalid('$.vfoScheme', schemes.join(' | '));
+  }
+  const expectedReceivers = raw.vfoScheme === 'single' || raw.vfoScheme === 'ab' ? 1 : 2;
+  if (raw.receivers !== expectedReceivers) {
+    invalid('$.vfoScheme', `${String(raw.vfoScheme)} with receivers=${expectedReceivers}`);
+  }
+
+  if (!Array.isArray(raw.freqRanges)) invalid('$.freqRanges', 'an array');
+  requireStringArray(raw.modes, '$.modes');
+  requireStringArray(raw.filters, '$.filters');
+
+  const audioConfig = requireRecord(raw.audioConfig, '$.audioConfig');
+  requireInteger(audioConfig.sampleRate, '$.audioConfig.sampleRate', true);
+  requireInteger(audioConfig.channels, '$.audioConfig.channels', true);
+  requireStringArray(audioConfig.codecs, '$.audioConfig.codecs');
+
+  const webrtc = requireRecord(raw.webrtc, '$.webrtc');
+  requireBoolean(webrtc.available, '$.webrtc.available');
+  requireBoolean(webrtc.enabled, '$.webrtc.enabled');
+
+  if (raw.txBands !== null) {
+    if (!Array.isArray(raw.txBands)) invalid('$.txBands', 'an array or null');
+    raw.txBands.forEach((value, index) => {
+      const band = requireRecord(value, `$.txBands[${index}]`);
+      requireString(band.name, `$.txBands[${index}].name`);
+      requireInteger(band.start, `$.txBands[${index}].start`);
+      requireInteger(band.end, `$.txBands[${index}].end`);
+    });
+  }
+
+  return raw as unknown as Capabilities;
 }

--- a/frontend/src/lib/types/capabilities.ts
+++ b/frontend/src/lib/types/capabilities.ts
@@ -166,6 +166,12 @@ function requireInteger(value: unknown, path: string, positive = false): void {
   }
 }
 
+function requireFiniteNumber(value: unknown, path: string): void {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    invalid(path, 'a finite number');
+  }
+}
+
 export function validateCapabilities(value: unknown): Capabilities {
   const raw = requireRecord(value, '$');
 
@@ -186,6 +192,27 @@ export function validateCapabilities(value: unknown): Capabilities {
   }
 
   if (!Array.isArray(raw.freqRanges)) invalid('$.freqRanges', 'an array');
+  raw.freqRanges.forEach((value, rangeIndex) => {
+    const rangePath = `$.freqRanges[${rangeIndex}]`;
+    const range = requireRecord(value, rangePath);
+    requireFiniteNumber(range.start, `${rangePath}.start`);
+    requireFiniteNumber(range.end, `${rangePath}.end`);
+    requireString(range.label, `${rangePath}.label`);
+    if ('bands' in range) {
+      if (!Array.isArray(range.bands)) invalid(`${rangePath}.bands`, 'an array');
+      range.bands.forEach((value, bandIndex) => {
+        const bandPath = `${rangePath}.bands[${bandIndex}]`;
+        const band = requireRecord(value, bandPath);
+        requireString(band.name, `${bandPath}.name`);
+        requireFiniteNumber(band.start, `${bandPath}.start`);
+        requireFiniteNumber(band.end, `${bandPath}.end`);
+        requireFiniteNumber(band.default, `${bandPath}.default`);
+        if ('bsrCode' in band) {
+          requireFiniteNumber(band.bsrCode, `${bandPath}.bsrCode`);
+        }
+      });
+    }
+  });
   requireStringArray(raw.modes, '$.modes');
   requireStringArray(raw.filters, '$.filters');
 


### PR DESCRIPTION
Closes #1928

Linear: https://linear.app/morozsm/issue/MOR-1036/implementation-validate-frontend-capability-v1-payload-and-preserve

## What changed

- Added additive-compatible runtime validation for the authoritative `/api/v1/capabilities` v1 payload.
- Made receiver count, the four accepted VFO schemes, WebRTC metadata, and nullable TX-band ranges explicit in the frontend raw type.
- Replaced the unchecked HTTP cast with validation that returns the original raw object by identity, preserving unknown extension fields.
- Removed the obsolete `/info`-only `hasLan` claim from the authoritative capability type.

## Safety and compatibility

- Exact structural topology pairs fail closed: `single|ab -> 1`, `ab_shared|main_sub -> 2`.
- Boolean-as-number and malformed range boundaries fail with JSON-path-specific errors.
- `txBands:null` and explicit `txBands:[]` remain distinct and unchanged.
- No backend payload, selector, UI, store behavior, persistence, refresh, or transport-policy change.

## Checks

- `npm test -- --run src/lib/transport/__tests__/http-client.test.ts src/lib/stores/__tests__/capabilities.test.ts` — 77 passed
- `npm run check` — 0 errors, 0 warnings
- `npm run lint` — passed
- `NODE_OPTIONS=--no-experimental-webstorage npm test` — 2229 passed
- `git diff --check` — passed

## Review status

Draft pending independent agent review.