### PR TITLE
Resolve broadcaster RX routes and narrow PCM tap eligibility

### DIFF
--- a/src/rigplane/web/handlers/audio.py
+++ b/src/rigplane/web/handlers/audio.py
@@ -408,26 +408,29 @@ class AudioBroadcaster:
     def _resolve_rx_route(self) -> tuple[str, Any] | None:
         """Resolve the exact session-first RX source used by the relay."""
         radio = self._radio
-        try:
-            if radio is None or CAP_AUDIO not in runtime_capabilities(radio):
-                return None
-            session = getattr(radio, "audio_session", None)
-            if session is not None:
-                subscribe_rx = getattr(session, "subscribe_rx", None)
-                return ("session", session) if callable(subscribe_rx) else None
-            bus = getattr(radio, "audio_bus", None)
-            subscribe = getattr(bus, "subscribe", None)
-            return ("bus", bus) if callable(subscribe) else None
-        except Exception:
+        if radio is None or CAP_AUDIO not in runtime_capabilities(radio):
             return None
+        session = getattr(radio, "audio_session", None)
+        if session is not None:
+            if not callable(getattr(session, "subscribe_rx", None)):
+                raise TypeError("audio_session.subscribe_rx must be callable")
+            return ("session", session)
+        bus = getattr(radio, "audio_bus", None)
+        if bus is None:
+            return None
+        if not callable(getattr(bus, "subscribe", None)):
+            raise TypeError("audio_bus.subscribe must be callable")
+        return ("bus", bus)
 
     @property
     def rx_pcm_tap_source(self) -> RxPcmTapSource | None:
         """Return a descriptor only when the selected route yields PCM16."""
         radio = self._radio
-        if radio is None or self._resolve_rx_route() is None:
+        if radio is None:
             return None
         try:
+            if self._resolve_rx_route() is None:
+                return None
             codec = radio.audio_codec  # type: ignore[attr-defined]
             sample_rate = radio.audio_sample_rate  # type: ignore[attr-defined]
         except Exception:
@@ -951,14 +954,15 @@ class AudioBroadcaster:
             )
 
     async def _start_relay(self) -> None:
-        route = self._resolve_rx_route()
-        if self._radio is None or route is None:
+        if self._radio is None:
             return
 
-        await self._apply_phones_mix_off()
-        self._refresh_codec_state(first=True)
-
         try:
+            route = self._resolve_rx_route()
+            if route is None:
+                return
+            await self._apply_phones_mix_off()
+            self._refresh_codec_state(first=True)
             route_kind, source = route
             if route_kind == "session":
                 # Session-routed RX demand (MOR-608, ADR §3.2 option a):

--- a/src/rigplane/web/handlers/audio.py
+++ b/src/rigplane/web/handlers/audio.py
@@ -417,7 +417,7 @@ class AudioBroadcaster:
             return ("session", session)
         bus = getattr(radio, "audio_bus", None)
         if bus is None:
-            return None
+            raise TypeError("audio_bus is required for runtime audio")
         if not callable(getattr(bus, "subscribe", None)):
             raise TypeError("audio_bus.subscribe must be callable")
         return ("bus", bus)

--- a/src/rigplane/web/handlers/audio.py
+++ b/src/rigplane/web/handlers/audio.py
@@ -29,6 +29,7 @@ from ..protocol import (  # noqa: TID251
     encode_audio_frame,
     encode_json,
 )
+from ..runtime_helpers import runtime_capabilities  # noqa: TID251
 from ..transport import Connection  # noqa: TID251
 from ..websocket import WS_OP_BINARY, WS_OP_TEXT  # noqa: TID251
 
@@ -39,11 +40,19 @@ if TYPE_CHECKING:
 
 from ...capabilities import CAP_AUDIO, CAP_LAN_DUAL_RX_AUDIO_ROUTING
 
-__all__ = ["AudioBroadcaster", "AudioHandler"]
+__all__ = ["AudioBroadcaster", "AudioHandler", "RxPcmTapSource"]
 
 logger = logging.getLogger(__name__)
 
 _TX_CLEANUP_STOP_TIMEOUT_SECONDS = 2.0
+_PCM_TAP_CODECS = frozenset(
+    {
+        AudioCodec.PCM_1CH_16BIT,
+        AudioCodec.PCM_2CH_16BIT,
+        AudioCodec.ULAW_1CH,
+        AudioCodec.ULAW_2CH,
+    }
+)
 
 # Adaptive egress codec controller windows (MOR-588, ADR §3.6).
 # Degradation must be SUSTAINED for DEGRADE_WINDOW_S before PCM16→Opus
@@ -90,6 +99,14 @@ class _AdaptiveEgressState:
     # underrun delta, ws_queue_drops delta).
     degrade_samples: list[tuple[float, int, int]] = field(default_factory=list)
     degrade_threshold_met: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class RxPcmTapSource:
+    """Validated source format for the broadcaster's decoded-PCM tap."""
+
+    codec: AudioCodec
+    sample_rate: int
 
 
 def _is_benign_tx_restart(exc: RuntimeError) -> bool:
@@ -387,6 +404,43 @@ class AudioBroadcaster:
         :meth:`rigplane.audio.bus.AudioBus.taps`.
         """
         return self._stage_taps[stage]
+
+    def _resolve_rx_route(self) -> tuple[str, Any] | None:
+        """Resolve the exact session-first RX source used by the relay."""
+        radio = self._radio
+        try:
+            if radio is None or CAP_AUDIO not in runtime_capabilities(radio):
+                return None
+            session = getattr(radio, "audio_session", None)
+            if session is not None:
+                subscribe_rx = getattr(session, "subscribe_rx", None)
+                return ("session", session) if callable(subscribe_rx) else None
+            bus = getattr(radio, "audio_bus", None)
+            subscribe = getattr(bus, "subscribe", None)
+            return ("bus", bus) if callable(subscribe) else None
+        except Exception:
+            return None
+
+    @property
+    def rx_pcm_tap_source(self) -> RxPcmTapSource | None:
+        """Return a descriptor only when the selected route yields PCM16."""
+        radio = self._radio
+        if radio is None or self._resolve_rx_route() is None:
+            return None
+        try:
+            codec = radio.audio_codec  # type: ignore[attr-defined]
+            sample_rate = radio.audio_sample_rate  # type: ignore[attr-defined]
+        except Exception:
+            return None
+        if (
+            not isinstance(codec, AudioCodec)
+            or codec not in _PCM_TAP_CODECS
+            or not isinstance(sample_rate, int)
+            or isinstance(sample_rate, bool)
+            or sample_rate <= 0
+        ):
+            return None
+        return RxPcmTapSource(codec=codec, sample_rate=sample_rate)
 
     def set_pcm_tap(self, callback: "Callable[[bytes], None] | None") -> None:
         """Register a tap that receives decoded PCM16 audio data.
@@ -897,27 +951,27 @@ class AudioBroadcaster:
             )
 
     async def _start_relay(self) -> None:
-        if not self._radio or CAP_AUDIO not in self._radio.capabilities:
+        route = self._resolve_rx_route()
+        if self._radio is None or route is None:
             return
 
         await self._apply_phones_mix_off()
         self._refresh_codec_state(first=True)
 
         try:
-            session = getattr(self._radio, "audio_session", None)
-            if session is not None:
+            route_kind, source = route
+            if route_kind == "session":
                 # Session-routed RX demand (MOR-608, ADR §3.2 option a):
                 # subscribing through the radio-owned AudioSession registers
                 # this relay's demand (session leaves IDLE → RX_ONLY), so
                 # the MOR-581 health watchdog covers browser-only listeners
                 # and reconnects go through ``AudioSession.reestablish()``.
                 # Mirrors the MOR-580 TX-lease pattern in AudioHandler.
-                self._subscription = await session.subscribe_rx("web-audio")
+                self._subscription = await source.subscribe_rx("web-audio")
             else:
                 # Legacy bus path for radios without a session (bare test
                 # doubles, not-yet-migrated backends).
-                bus = self._radio.audio_bus  # type: ignore[attr-defined]
-                subscription = cast(_AudioBus, bus).subscribe(name="web-audio")
+                subscription = cast(_AudioBus, source).subscribe(name="web-audio")
                 await subscription.start()
                 self._subscription = subscription
             self._relay_task = asyncio.create_task(self._relay_loop())

--- a/tests/test_tap_surface.py
+++ b/tests/test_tap_surface.py
@@ -14,8 +14,9 @@ asking for them must fail loudly rather than silently swallow frames.
 
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import numpy as np
 import pytest
@@ -23,7 +24,7 @@ import pytest
 from rigplane.audio import AudioPacket
 from rigplane.audio.bus import STAGE_RX_PCM, STAGE_RX_POST_DSP, AudioBus
 from rigplane.capabilities import CAP_AUDIO
-from rigplane.radio_protocol import AudioCapable, UsbAudioCapable
+from rigplane.radio_protocol import AudioCapable
 from rigplane.types import AudioCodec
 from rigplane.web.handlers.audio import AudioBroadcaster, RxPcmTapSource
 
@@ -98,40 +99,26 @@ class TestRxPostDspStage:
             broadcaster.taps("rx.egress")
 
 
-class _Subscription:
-    started = False
-
-    async def start(self) -> None:
-        self.started = True
-
-    def stop(self) -> None:
-        pass
-
-    def __aiter__(self):
-        async def _empty():
-            if False:
-                yield None
-
-        return _empty()
-
-
-class _Bus:
+class _Route:
     def __init__(self) -> None:
-        self.subscription = _Subscription()
+        sub = self.subscription = AsyncMock()
+        sub.started = False
+        sub.start.side_effect = lambda: setattr(sub, "started", True)
+        sub.stop = Mock()
+        sub.__aiter__.return_value = []
+        self.subscribe_calls = 0
 
-    def subscribe(self, name: str = "") -> _Subscription:  # noqa: ARG002
+    def subscribe(self, name: str = ""):  # noqa: ARG002
+        self.subscribe_calls += 1
         return self.subscription
 
-
-class _Session:
-    def __init__(self) -> None:
-        self.subscription = _Subscription()
-
-    async def subscribe_rx(self, name: str) -> _Subscription:  # noqa: ARG002
+    async def subscribe_rx(self, name: str):  # noqa: ARG002
         return self.subscription
 
 
 class _PcmRadio(AudioCapable):
+    audio_bus: object = None
+
     def __init__(
         self,
         *,
@@ -139,11 +126,13 @@ class _PcmRadio(AudioCapable):
         sample_rate: object = 48_000,
         bus: object = ...,
         session: object = ...,
+        raising: str | None = None,
     ) -> None:
         self.capabilities = {CAP_AUDIO}
         self._codec = codec
         self._sample_rate = sample_rate
-        self._bus = _Bus() if bus is ... else bus
+        self.audio_bus = _Route() if bus is ... else bus
+        self._raising = raising
         if session is not ...:
             self.audio_session = session
 
@@ -155,40 +144,24 @@ class _PcmRadio(AudioCapable):
     def audio_sample_rate(self):
         return self._sample_rate
 
-    @property
-    def audio_bus(self):
-        return self._bus
+    def __getattribute__(self, name: str):
+        if name == object.__getattribute__(self, "_raising"):
+            raise RuntimeError(f"{name.removeprefix('audio_')} route unavailable")
+        return object.__getattribute__(self, name)
 
 
-class _MarkerOnlyRadio(UsbAudioCapable):
-    capabilities = {CAP_AUDIO}
-    has_usb_audio = True
-
-
-class _RaisingRouteRadio(_PcmRadio):
-    @property
-    def audio_bus(self):
-        raise RuntimeError("route unavailable")
-
-
-@pytest.mark.parametrize(
-    "codec",
-    [
+def test_pcm_tap_source_preserves_descriptor_matrix() -> None:
+    accepted = (
         AudioCodec.PCM_1CH_16BIT,
         AudioCodec.PCM_2CH_16BIT,
         AudioCodec.ULAW_1CH,
         AudioCodec.ULAW_2CH,
-    ],
-)
-def test_pcm_tap_source_accepts_proven_pcm_route(codec: AudioCodec) -> None:
-    assert AudioBroadcaster(_PcmRadio(codec=codec)).rx_pcm_tap_source == (
-        RxPcmTapSource(codec=codec, sample_rate=48_000)
     )
-
-
-@pytest.mark.parametrize(
-    "radio",
-    [
+    for codec in accepted:
+        assert AudioBroadcaster(_PcmRadio(codec=codec)).rx_pcm_tap_source == (
+            RxPcmTapSource(codec=codec, sample_rate=48_000)
+        )
+    rejected = (
         _PcmRadio(codec=AudioCodec.PCM_1CH_8BIT),
         _PcmRadio(codec=AudioCodec.PCM_2CH_8BIT),
         _PcmRadio(codec=AudioCodec.OPUS_1CH),
@@ -198,36 +171,60 @@ def test_pcm_tap_source_accepts_proven_pcm_route(codec: AudioCodec) -> None:
             capabilities={CAP_AUDIO},
             audio_codec=AudioCodec.PCM_1CH_16BIT,
             audio_sample_rate=48_000,
-            audio_bus=_Bus(),
+            audio_bus=_Route(),
         ),
         _PcmRadio(sample_rate=True),
         _PcmRadio(sample_rate=48_000.0),
         _PcmRadio(bus=None),
         _PcmRadio(bus=SimpleNamespace(subscribe=None)),
-        _RaisingRouteRadio(),
-        _MarkerOnlyRadio(),
-    ],
-)
-def test_pcm_tap_source_fails_closed_without_exact_pcm_route(radio) -> None:
-    assert AudioBroadcaster(radio).rx_pcm_tap_source is None
+        _PcmRadio(session=SimpleNamespace(subscribe_rx=None)),
+        _PcmRadio(raising="audio_session"),
+        _PcmRadio(raising="audio_bus"),
+        SimpleNamespace(capabilities={CAP_AUDIO}, has_usb_audio=True),
+    )
+    assert all(AudioBroadcaster(radio).rx_pcm_tap_source is None for radio in rejected)
 
 
 @pytest.mark.asyncio
 async def test_relay_route_prefers_session_then_falls_back_to_bus() -> None:
-    session = _Session()
-    session_radio = _PcmRadio(session=session)
-    session_broadcaster = AudioBroadcaster(session_radio)
-    await session_broadcaster._start_relay()
-    assert session_broadcaster._subscription is session.subscription
-    assert session_radio.audio_bus.subscription.started is False
-    await session_broadcaster._relay_task
+    session = _Route()
+    bus = _Route()
+    for radio, route, bus_started in (
+        (_PcmRadio(session=session), session, False),
+        (_PcmRadio(bus=bus), bus, True),
+    ):
+        broadcaster = AudioBroadcaster(radio)
+        await broadcaster._start_relay()
+        assert broadcaster._subscription is route.subscription
+        assert radio.audio_bus.subscription.started is bus_started
+        await broadcaster._relay_task
 
-    bus_radio = _PcmRadio()
-    bus_broadcaster = AudioBroadcaster(bus_radio)
-    await bus_broadcaster._start_relay()
-    assert bus_broadcaster._subscription is bus_radio.audio_bus.subscription
-    assert bus_radio.audio_bus.subscription.started is True
-    await bus_broadcaster._relay_task
+
+@pytest.mark.asyncio
+async def test_malformed_selected_relay_routes_notify_without_fallback() -> None:
+    cases = [
+        (
+            _PcmRadio(session=SimpleNamespace(subscribe_rx=None)),
+            "audio_session.subscribe_rx must be callable",
+        ),
+        (_PcmRadio(raising="audio_session"), "session route unavailable"),
+        (
+            _PcmRadio(bus=SimpleNamespace(subscribe=None)),
+            "audio_bus.subscribe must be callable",
+        ),
+        (_PcmRadio(raising="audio_bus"), "bus route unavailable"),
+    ]
+    for radio, expected in cases:
+        ws = SimpleNamespace(send_text=AsyncMock(), is_alive=lambda: True)
+        broadcaster = AudioBroadcaster(radio)
+        await broadcaster.subscribe(ws=ws)
+        assert broadcaster._subscription is broadcaster._relay_task is None
+        if "session" in expected:
+            assert radio.__dict__["audio_bus"].subscribe_calls == 0
+        assert json.loads(ws.send_text.await_args.args[0]) == {
+            "type": "error",
+            "message": f"audio_start: RX audio failed to start: {expected}",
+        }
 
 
 @pytest.mark.asyncio

--- a/tests/test_tap_surface.py
+++ b/tests/test_tap_surface.py
@@ -151,13 +151,12 @@ class _PcmRadio(AudioCapable):
 
 
 def test_pcm_tap_source_preserves_descriptor_matrix() -> None:
-    accepted = (
+    for codec in (
         AudioCodec.PCM_1CH_16BIT,
         AudioCodec.PCM_2CH_16BIT,
         AudioCodec.ULAW_1CH,
         AudioCodec.ULAW_2CH,
-    )
-    for codec in accepted:
+    ):
         assert AudioBroadcaster(_PcmRadio(codec=codec)).rx_pcm_tap_source == (
             RxPcmTapSource(codec=codec, sample_rate=48_000)
         )
@@ -175,12 +174,10 @@ def test_pcm_tap_source_preserves_descriptor_matrix() -> None:
         ),
         _PcmRadio(sample_rate=True),
         _PcmRadio(sample_rate=48_000.0),
-        _PcmRadio(bus=None),
         _PcmRadio(bus=SimpleNamespace(subscribe=None)),
         _PcmRadio(session=SimpleNamespace(subscribe_rx=None)),
         _PcmRadio(raising="audio_session"),
         _PcmRadio(raising="audio_bus"),
-        SimpleNamespace(capabilities={CAP_AUDIO}, has_usb_audio=True),
     )
     assert all(AudioBroadcaster(radio).rx_pcm_tap_source is None for radio in rejected)
 
@@ -202,7 +199,7 @@ async def test_relay_route_prefers_session_then_falls_back_to_bus() -> None:
 
 @pytest.mark.asyncio
 async def test_malformed_selected_relay_routes_notify_without_fallback() -> None:
-    cases = [
+    for radio, expected in (
         (
             _PcmRadio(session=SimpleNamespace(subscribe_rx=None)),
             "audio_session.subscribe_rx must be callable",
@@ -213,10 +210,15 @@ async def test_malformed_selected_relay_routes_notify_without_fallback() -> None
             "audio_bus.subscribe must be callable",
         ),
         (_PcmRadio(raising="audio_bus"), "bus route unavailable"),
-    ]
-    for radio, expected in cases:
+        (_PcmRadio(bus=None), "audio_bus is required for runtime audio"),
+        (
+            SimpleNamespace(capabilities={CAP_AUDIO}, has_usb_audio=True),
+            "audio_bus is required for runtime audio",
+        ),
+    ):
         ws = SimpleNamespace(send_text=AsyncMock(), is_alive=lambda: True)
         broadcaster = AudioBroadcaster(radio)
+        assert broadcaster.rx_pcm_tap_source is None
         await broadcaster.subscribe(ws=ws)
         assert broadcaster._subscription is broadcaster._relay_task is None
         if "session" in expected:

--- a/tests/test_tap_surface.py
+++ b/tests/test_tap_surface.py
@@ -23,7 +23,9 @@ import pytest
 from rigplane.audio import AudioPacket
 from rigplane.audio.bus import STAGE_RX_PCM, STAGE_RX_POST_DSP, AudioBus
 from rigplane.capabilities import CAP_AUDIO
-from rigplane.web.handlers.audio import AudioBroadcaster
+from rigplane.radio_protocol import AudioCapable, UsbAudioCapable
+from rigplane.types import AudioCodec
+from rigplane.web.handlers.audio import AudioBroadcaster, RxPcmTapSource
 
 
 @pytest.fixture
@@ -94,6 +96,147 @@ class TestRxPostDspStage:
         broadcaster = AudioBroadcaster(radio=None)
         with pytest.raises(KeyError):
             broadcaster.taps("rx.egress")
+
+
+class _Subscription:
+    started = False
+
+    async def start(self) -> None:
+        self.started = True
+
+    def stop(self) -> None:
+        pass
+
+    def __aiter__(self):
+        async def _empty():
+            if False:
+                yield None
+
+        return _empty()
+
+
+class _Bus:
+    def __init__(self) -> None:
+        self.subscription = _Subscription()
+
+    def subscribe(self, name: str = "") -> _Subscription:  # noqa: ARG002
+        return self.subscription
+
+
+class _Session:
+    def __init__(self) -> None:
+        self.subscription = _Subscription()
+
+    async def subscribe_rx(self, name: str) -> _Subscription:  # noqa: ARG002
+        return self.subscription
+
+
+class _PcmRadio(AudioCapable):
+    def __init__(
+        self,
+        *,
+        codec: object = AudioCodec.PCM_1CH_16BIT,
+        sample_rate: object = 48_000,
+        bus: object = ...,
+        session: object = ...,
+    ) -> None:
+        self.capabilities = {CAP_AUDIO}
+        self._codec = codec
+        self._sample_rate = sample_rate
+        self._bus = _Bus() if bus is ... else bus
+        if session is not ...:
+            self.audio_session = session
+
+    @property
+    def audio_codec(self):
+        return self._codec
+
+    @property
+    def audio_sample_rate(self):
+        return self._sample_rate
+
+    @property
+    def audio_bus(self):
+        return self._bus
+
+
+class _MarkerOnlyRadio(UsbAudioCapable):
+    capabilities = {CAP_AUDIO}
+    has_usb_audio = True
+
+
+class _RaisingRouteRadio(_PcmRadio):
+    @property
+    def audio_bus(self):
+        raise RuntimeError("route unavailable")
+
+
+@pytest.mark.parametrize(
+    "codec",
+    [
+        AudioCodec.PCM_1CH_16BIT,
+        AudioCodec.PCM_2CH_16BIT,
+        AudioCodec.ULAW_1CH,
+        AudioCodec.ULAW_2CH,
+    ],
+)
+def test_pcm_tap_source_accepts_proven_pcm_route(codec: AudioCodec) -> None:
+    assert AudioBroadcaster(_PcmRadio(codec=codec)).rx_pcm_tap_source == (
+        RxPcmTapSource(codec=codec, sample_rate=48_000)
+    )
+
+
+@pytest.mark.parametrize(
+    "radio",
+    [
+        _PcmRadio(codec=AudioCodec.PCM_1CH_8BIT),
+        _PcmRadio(codec=AudioCodec.PCM_2CH_8BIT),
+        _PcmRadio(codec=AudioCodec.OPUS_1CH),
+        _PcmRadio(codec="pcm16"),
+        _PcmRadio(sample_rate=0),
+        SimpleNamespace(
+            capabilities={CAP_AUDIO},
+            audio_codec=AudioCodec.PCM_1CH_16BIT,
+            audio_sample_rate=48_000,
+            audio_bus=_Bus(),
+        ),
+        _PcmRadio(sample_rate=True),
+        _PcmRadio(sample_rate=48_000.0),
+        _PcmRadio(bus=None),
+        _PcmRadio(bus=SimpleNamespace(subscribe=None)),
+        _RaisingRouteRadio(),
+        _MarkerOnlyRadio(),
+    ],
+)
+def test_pcm_tap_source_fails_closed_without_exact_pcm_route(radio) -> None:
+    assert AudioBroadcaster(radio).rx_pcm_tap_source is None
+
+
+@pytest.mark.asyncio
+async def test_relay_route_prefers_session_then_falls_back_to_bus() -> None:
+    session = _Session()
+    session_radio = _PcmRadio(session=session)
+    session_broadcaster = AudioBroadcaster(session_radio)
+    await session_broadcaster._start_relay()
+    assert session_broadcaster._subscription is session.subscription
+    assert session_radio.audio_bus.subscription.started is False
+    await session_broadcaster._relay_task
+
+    bus_radio = _PcmRadio()
+    bus_broadcaster = AudioBroadcaster(bus_radio)
+    await bus_broadcaster._start_relay()
+    assert bus_broadcaster._subscription is bus_radio.audio_bus.subscription
+    assert bus_radio.audio_bus.subscription.started is True
+    await bus_broadcaster._relay_task
+
+
+@pytest.mark.asyncio
+async def test_native_opus_route_is_relayable_without_pcm_tap() -> None:
+    broadcaster = AudioBroadcaster(_PcmRadio(codec=AudioCodec.OPUS_1CH))
+    assert broadcaster.rx_pcm_tap_source is None
+    await broadcaster._start_relay()
+    assert broadcaster._subscription is not None
+    await broadcaster._relay_task
 
 
 # ── FFT scope behavior preservation ──────────────────────────────────────────


### PR DESCRIPTION
Closes #1927

Linear: [MOR-997](https://linear.app/morozsm/issue/MOR-997/implementation-add-broadcaster-rx-route-resolver-and-pcm-tap-predicate)

## What changed

- resolve the broadcaster RX source once with the existing session-first, bus-fallback policy
- require runtime audio plus a callable selected route before relay or PCM-tap admission
- expose a PCM tap descriptor only for PCM16/u-law with a positive non-bool sample rate
- preserve native Opus relay startup while returning no PCM tap descriptor
- fail closed for PCM8, marker-only USB, missing/raising/non-callable routes, and invalid codec/rate values

## Scope

This intentionally does not change WebServer FFT construction, tap lifecycle, or capability serialization; those remain MOR-998.

## Compatibility

No public API, CLI, configuration, rigctld wire, or documentation changes. Native Opus relay behavior is preserved.

## Validation

- `uv run pytest tests/test_tap_surface.py -q --tb=short` — 26 passed
- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 8280 passed, 12 skipped, 5 deselected, 11 xfailed, 1 xpassed
- `uv run ruff check src/ tests/` — passed
- `uv run ruff format --check src/ tests/` — passed
- `uv run lint-imports` — 5 contracts kept
- `git diff --check` — passed

Targeted mypy reports the same nine pre-existing `no-any-return` findings in `audio.py` as clean `origin/main`; this patch adds no new mypy finding.
