### PR TITLE
Construct and advertise audio FFT from proven PCM service

### DIFF
--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -60,7 +60,7 @@ from ..core.state_pipeline_contracts import (
 )
 from ..core.state_store import StateSnapshot, StateStore
 from ..radio_state import RadioState
-from ..capabilities import CAP_AUDIO, CAP_SCOPE
+from ..capabilities import CAP_AUDIO
 from ..exceptions import TimeoutError as RigplaneTimeoutError
 from ..audio.bus import STAGE_RX_POST_DSP
 from ..audio.session import AudioSession, AudioSessionEvent
@@ -836,6 +836,7 @@ class WebServer:
             on_client_count_change=self._broadcast_ws_client_state_update,
             adaptive_egress=self._config.audio_adaptive_egress,
         )
+        self._hardware_scope_available = _supports_scope(radio)
         # Gated WebRTC transport session manager (A2.3 / MOR-307). Lazily
         # constructed on first use so the import stays out of the no-extra path.
         self._webrtc_sessions: WebRtcSessionManager | None = None
@@ -845,20 +846,25 @@ class WebServer:
         # PCM tap is lazy — enabled only when audio-scope clients connect.
         self._audio_fft_scope: AudioFftScope | None = None
         _has_audio = (CAP_AUDIO in radio.capabilities) if radio is not None else False
-        _has_scope = (CAP_SCOPE in radio.capabilities) if radio is not None else False
-        if radio is not None and _has_audio:
-            self._audio_fft_scope = AudioFftScope(fft_size=2048, fps=20, avg_count=2)
+        pcm_tap_source = self._audio_broadcaster.rx_pcm_tap_source
+        if pcm_tap_source is not None:
+            self._audio_fft_scope = AudioFftScope(
+                fft_size=2048,
+                fps=20,
+                avg_count=2,
+                sample_rate=pcm_tap_source.sample_rate,
+            )
             # AudioFftScope.on_frame() is a single-slot setter: register one
             # dispatch method that fans out to BOTH broadcasters. Registering
             # twice would clobber the first callback (MOR-241).
             self._audio_fft_scope.on_frame(self._dispatch_audio_fft_frame)
-            if not _has_scope:
+            if not self._hardware_scope_available:
                 # No hardware scope — audio FFT also feeds /api/v1/scope.
                 self._audio_broadcaster.set_pcm_tap(self._audio_fft_scope.feed_audio)
             logger.info(
                 "Audio FFT scope available (has_audio=%s, has_hw_scope=%s)",
-                _has_audio,
-                _has_scope,
+                True,
+                self._hardware_scope_available,
             )
         # Audio analyzer: lightweight SNR estimator, tapped from PCM stream.
         self._audio_analyzer: AudioAnalyzer | None = None
@@ -1033,7 +1039,7 @@ class WebServer:
 
     def _set_scope_data_callback(self, callback: Any) -> None:
         """Set the scope data callback on the radio if it supports it."""
-        if self._radio is not None and CAP_SCOPE in self._radio.capabilities:
+        if self._radio is not None and self._hardware_scope_available:
             self._radio.on_scope_data(callback)  # type: ignore[attr-defined]
 
     # ------------------------------------------------------------------
@@ -1053,7 +1059,7 @@ class WebServer:
             if not was_registered:
                 self._broadcast_ws_client_state_update()
             if self._radio is not None:
-                if not _supports_scope(self._radio):
+                if not self._hardware_scope_available:
                     logger.info(
                         "scope: active radio does not expose runtime scope support"
                     )
@@ -1083,7 +1089,7 @@ class WebServer:
         if (
             not self._scope_handlers
             and self._radio is not None
-            and _supports_scope(self._radio)
+            and self._hardware_scope_available
         ):
             self._set_scope_data_callback(None)
             if self._scope_enabled:
@@ -1091,7 +1097,7 @@ class WebServer:
 
     async def _disable_scope_async(self) -> None:
         """Disable scope on the radio when no more handlers are connected."""
-        if self._radio is None or not _supports_scope(self._radio):
+        if self._radio is None or not self._hardware_scope_available:
             return
         await asyncio.sleep(self._scope_disable_grace)
         if self._scope_handlers:
@@ -1122,10 +1128,7 @@ class WebServer:
         the real scope, so the audio FFT never touches it (MOR-241).
         """
         self._broadcast_audio_scope(frame)
-        _has_scope = (
-            CAP_SCOPE in self._radio.capabilities if self._radio is not None else False
-        )
-        if not _has_scope:
+        if not self._hardware_scope_available:
             self._broadcast_scope(frame)
 
     def _broadcast_scope(self, frame: Any) -> None:
@@ -1166,12 +1169,7 @@ class WebServer:
         self._audio_scope_handlers.discard(handler)
         if not self._audio_scope_handlers and self._audio_fft_scope is not None:
             # Only disable tap for hardware-scope radios (non-hw radios keep tap always on)
-            _has_scope = (
-                CAP_SCOPE in self._radio.capabilities
-                if self._radio is not None
-                else False
-            )
-            if _has_scope:
+            if self._hardware_scope_available:
                 self._audio_broadcaster.set_pcm_tap(None)
                 logger.info("audio-scope: PCM tap disabled (no clients)")
         logger.info(
@@ -1799,7 +1797,7 @@ class WebServer:
             if (
                 self._scope_handlers
                 and self._radio is not None
-                and _supports_scope(self._radio)
+                and self._hardware_scope_available
             ):
                 self._set_scope_data_callback(self._broadcast_scope)
                 self._command_queue.put(EnableScope())
@@ -1833,7 +1831,7 @@ class WebServer:
             while True:
                 if not self._scope_handlers or self._radio is None:
                     return
-                if not _supports_scope(self._radio):
+                if not self._hardware_scope_available:
                     return
                 if self._radio_ready():
                     self._set_scope_data_callback(self._broadcast_scope)
@@ -1887,7 +1885,7 @@ class WebServer:
                 await asyncio.sleep(self._scope_health_interval)
                 if not self._scope_handlers or self._radio is None:
                     continue
-                if not _supports_scope(self._radio):
+                if not self._hardware_scope_available:
                     continue
                 # Don't re-enable scope while radio is disconnected
                 if not self._radio_ready():
@@ -2781,7 +2779,7 @@ class WebServer:
                 "keyboard": _serialize_keyboard_config(profile),
                 "scopeSource": (
                     "hardware"
-                    if "scope" in caps
+                    if self._hardware_scope_available
                     else ("audio_fft" if self._audio_fft_scope is not None else None)
                 ),
                 "audioFftAvailable": self._audio_fft_scope is not None,

--- a/tests/test_tap_surface.py
+++ b/tests/test_tap_surface.py
@@ -23,8 +23,8 @@ import pytest
 
 from rigplane.audio import AudioPacket
 from rigplane.audio.bus import STAGE_RX_PCM, STAGE_RX_POST_DSP, AudioBus
-from rigplane.capabilities import CAP_AUDIO
-from rigplane.radio_protocol import AudioCapable
+from rigplane.capabilities import CAP_AUDIO, CAP_SCOPE
+from rigplane.radio_protocol import AudioCapable, ScopeCapable
 from rigplane.types import AudioCodec
 from rigplane.web.handlers.audio import AudioBroadcaster, RxPcmTapSource
 
@@ -241,16 +241,39 @@ async def test_native_opus_route_is_relayable_without_pcm_tap() -> None:
 # ── FFT scope behavior preservation ──────────────────────────────────────────
 
 
-class _AudioOnlyRadio:
-    """Minimal fake radio with audio but no hardware scope."""
-
-    def __init__(self) -> None:
+class _MatrixRadio(_PcmRadio, ScopeCapable):
+    def __init__(
+        self, *, hardware: bool, audio: bool, sample_rate: int = 32_000
+    ) -> None:
+        super().__init__(sample_rate=sample_rate)
         from rigplane.radio_state import RadioState
 
-        self.capabilities = frozenset({CAP_AUDIO})
+        self.capabilities = {
+            capability
+            for capability, enabled in ((CAP_SCOPE, hardware), (CAP_AUDIO, audio))
+            if enabled
+        }
         self.radio_state = RadioState()
-        self.audio_codec = None
-        self.audio_sample_rate = 48_000
+        self.scope_callback = None
+
+    def on_scope_data(self, callback) -> None:
+        self.scope_callback = callback
+
+
+class _Writer:
+    def __init__(self) -> None:
+        self.buffer = bytearray()
+
+    def write(self, data: bytes) -> None:
+        self.buffer.extend(data)
+
+    async def drain(self) -> None:
+        pass
+
+
+def _json_body(writer: _Writer) -> dict:
+    payload = writer.buffer.decode("ascii", errors="replace")
+    return json.loads(payload[payload.index("\r\n\r\n") + 4 :])
 
 
 class _FakeScopeHandler:
@@ -268,7 +291,7 @@ def test_fft_scope_receives_frames_via_named_post_dsp_stage() -> None:
     """
     from rigplane.web.server import WebConfig, WebServer
 
-    radio = _AudioOnlyRadio()
+    radio = _MatrixRadio(hardware=False, audio=True, sample_rate=48_000)
     server = WebServer(radio=radio, config=WebConfig())
     scope = server._audio_fft_scope
     assert scope is not None, "audio FFT scope not wired"
@@ -286,3 +309,86 @@ def test_fft_scope_receives_frames_via_named_post_dsp_stage() -> None:
         registry.feed(pcm)
 
     assert len(handler.frames) >= 1, "FFT scope stopped receiving via rx.post_dsp"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("hardware", "audio", "scope_source"),
+    [
+        (True, False, "hardware"),
+        (False, True, "audio_fft"),
+        (True, True, "hardware"),
+        (False, False, None),
+    ],
+)
+async def test_scope_service_lifecycle_and_serializer_matrix(
+    hardware: bool, audio: bool, scope_source: str | None
+) -> None:
+    from rigplane.web.server import WebServer
+
+    server = WebServer(_MatrixRadio(hardware=hardware, audio=audio))
+    scope = server._audio_fft_scope
+    assert (scope is not None) is audio
+    if scope is not None:
+        assert scope._sample_rate == 32_000
+
+    broadcaster = server._audio_broadcaster
+    assert (broadcaster._legacy_tap_handle is not None) is (audio and not hardware)
+    main_handler = _FakeScopeHandler()
+    audio_handler = _FakeScopeHandler()
+    server._scope_handlers.add(main_handler)
+    await server.ensure_audio_scope_enabled(audio_handler)
+    assert (broadcaster._legacy_tap_handle is not None) is audio
+    if scope is not None:
+        frame = object()
+        server._dispatch_audio_fft_frame(frame)
+        assert audio_handler.frames == [frame]
+        assert main_handler.frames == ([] if hardware else [frame])
+    server.unregister_audio_scope_handler(audio_handler)
+    assert (broadcaster._legacy_tap_handle is not None) is (audio and not hardware)
+
+    writer = _Writer()
+    await server._serve_capabilities(writer)
+    capabilities = _json_body(writer)
+    assert capabilities["scope"] is hardware
+    assert capabilities["audio"] is audio
+    assert capabilities["audioFftAvailable"] is audio
+    assert capabilities["scopeSource"] == scope_source
+
+
+@pytest.mark.asyncio
+async def test_runtime_hardware_scope_is_cached_for_dispatch_and_teardown() -> None:
+    from rigplane.web.server import WebServer
+
+    radio = _MatrixRadio(hardware=True, audio=True)
+    server = WebServer(radio)
+    audio_handler = _FakeScopeHandler()
+    main_handler = _FakeScopeHandler()
+    server._scope_handlers.add(main_handler)
+    await server.ensure_audio_scope_enabled(audio_handler)
+    radio.capabilities.clear()
+
+    frame = object()
+    server._dispatch_audio_fft_frame(frame)
+    assert audio_handler.frames == [frame]
+    assert main_handler.frames == []
+    server.unregister_audio_scope_handler(audio_handler)
+    assert server._audio_broadcaster._legacy_tap_handle is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("hardware", [False, True])
+async def test_audio_tag_without_proven_route_does_not_advertise_fft(
+    hardware: bool,
+) -> None:
+    from rigplane.web.server import WebServer
+
+    radio = _MatrixRadio(hardware=hardware, audio=True)
+    radio.audio_bus = None
+    server = WebServer(radio)
+    writer = _Writer()
+    await server._serve_capabilities(writer)
+    capabilities = _json_body(writer)
+    assert server._audio_fft_scope is None
+    assert capabilities["audioFftAvailable"] is False
+    assert capabilities["scopeSource"] == ("hardware" if hardware else None)


### PR DESCRIPTION
Closes #1933

Linear: [MOR-998](https://linear.app/morozsm/issue/MOR-998/implementation-construct-and-advertise-audio-fft-from-proven-pcm)

## What changed

- construct `AudioFftScope` only from the merged broadcaster `rx_pcm_tap_source` descriptor
- pass the descriptor validated sample rate into the FFT service
- cache runtime hardware-scope support and reuse it for scope lifecycle, dispatch, teardown, and serialization
- derive `audioFftAvailable` and `scopeSource` from constructed services rather than raw tags
- preserve eager audio-only and lazy hardware+audio tap behavior

## Scope

Exactly two owned files. No frontend/selectors, route-predicate duplication, public API, CLI, config, rigctld wire, or documentation changes.

Net diff: +104 lines, below the 200-line guardrail.

## Verification

- focused tap and capability matrix: 44 passed
- full non-integration suite: 8,273 passed, 12 skipped, 5 deselected, 11 xfailed, 1 xpassed
- Ruff check and format: passed
- import-lint: 5 contracts kept
- targeted mypy: same one pre-existing `no-any-return` finding on exact base and head; no new finding
- git diff check: passed