### PR TITLE
fix(#1934): expose authority-aware PTT delivery events

### DIFF
--- a/frontend/src/lib/transport/__tests__/ws-client.test.ts
+++ b/frontend/src/lib/transport/__tests__/ws-client.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { WsCommand, WsMessage } from '../../types/protocol';
 import type { ReceiverState, ServerState } from '../../types/state';
+import type { CommandDeliveryEvent } from '../ws-client';
 
 type ServerStateWithObservation = ServerState & {
   observationSeq?: number;
@@ -286,6 +287,81 @@ describe('WsChannel', () => {
     expect(received[0].type).toBe('ack');
   });
 
+  it('emits correlated PTT delivery events without fabricating RF state', async () => {
+    const { WsChannel } = await import('../ws-client');
+    const ch = new WsChannel();
+    const events: CommandDeliveryEvent[] = [];
+    ch.onCommandDelivery((event) => events.push(event));
+    ch.connect('ws://test');
+    instances[0].simulateOpen();
+
+    expect(ch.send({ type: 'cmd', name: 'ptt_on', id: 'on', params: {} })).toBe(true);
+    instances[0].simulateMessage(JSON.stringify({ type: 'ack', id: 'on' }));
+    instances[0].simulateMessage(JSON.stringify({ type: 'ack', id: 'on' }));
+    instances[0].simulateMessage(JSON.stringify({ type: 'response', id: 'on', ok: true }));
+    expect(ch.send({ type: 'cmd', name: 'ptt_off', id: 'off', params: {} })).toBe(true);
+    instances[0].simulateMessage(JSON.stringify({ type: 'response', id: 'off', ok: false }));
+    instances[0].simulateMessage(JSON.stringify({ type: 'error', id: 'off', message: 'rejected' }));
+
+    expect(events).toMatchObject([
+      { commandId: 'on', kind: 'transport-sent', originalEpoch: 1, eventEpoch: 1 },
+      { commandId: 'on', kind: 'ack', originalEpoch: 1, eventEpoch: 1 },
+      { commandId: 'on', kind: 'response-ok', originalEpoch: 1, eventEpoch: 1 },
+      { commandId: 'off', kind: 'transport-sent', originalEpoch: 1, eventEpoch: 1 },
+      { commandId: 'off', kind: 'response-error', originalEpoch: 1, eventEpoch: 1 },
+      { commandId: 'off', kind: 'error', originalEpoch: 1, eventEpoch: 1, error: 'rejected' },
+    ]);
+  });
+
+  it('preserves queued OFF identity and distinguishes stale reconnect events', async () => {
+    const { WsChannel } = await import('../ws-client');
+    const ch = new WsChannel();
+    const events: CommandDeliveryEvent[] = [];
+    ch.onCommandDelivery((event) => events.push(event));
+
+    ch.send({ type: 'cmd', name: 'ptt_off', id: 'off-1', params: {} });
+    ch.send({ type: 'cmd', name: 'ptt', id: 'off-2', params: { state: false } });
+    expect(events).toEqual([]);
+    ch.connect('ws://test');
+    instances[0].simulateOpen();
+    expect(events[0]).toMatchObject({
+      commandId: 'off-2', kind: 'transport-sent', originalEpoch: 0, eventEpoch: 1,
+    });
+
+    instances[0].simulateClose();
+    ch.send({ type: 'cmd', name: 'ptt_off', id: 'off-3', params: {} });
+    vi.advanceTimersByTime(1300);
+    instances[1].simulateOpen();
+    instances[0].simulateMessage(JSON.stringify({ type: 'ack', id: 'off-2' }));
+    instances[0].simulateMessage(JSON.stringify({ type: 'ack', id: 'off-2' }));
+    instances[0].simulateMessage(JSON.stringify({ type: 'response', id: 'off-2', ok: true }));
+    instances[0].simulateMessage(JSON.stringify({ type: 'response', id: 'off-2', ok: true }));
+    instances[0].simulateMessage(JSON.stringify({ type: 'error', id: 'off-2', message: 'stale' }));
+    instances[0].simulateMessage(JSON.stringify({ type: 'error', id: 'off-2', message: 'stale' }));
+
+    expect(events.slice(1)).toMatchObject([
+      { commandId: 'off-3', kind: 'transport-sent', originalEpoch: 1, eventEpoch: 2 },
+      { commandId: 'off-2', kind: 'ack', originalEpoch: 0, eventEpoch: 1 },
+      { commandId: 'off-2', kind: 'response-ok', originalEpoch: 0, eventEpoch: 1 },
+      { commandId: 'off-2', kind: 'error', originalEpoch: 0, eventEpoch: 1 },
+    ]);
+  });
+
+  it('reports a synchronous PTT send failure without a sent event', async () => {
+    const { WsChannel } = await import('../ws-client');
+    const ch = new WsChannel();
+    const events: CommandDeliveryEvent[] = [];
+    ch.onCommandDelivery((event) => events.push(event));
+    ch.connect('ws://test');
+    instances[0].simulateOpen();
+    instances[0].send = () => { throw new Error('socket failed'); };
+
+    expect(ch.send({ type: 'cmd', name: 'ptt_on', id: 'on', params: {} })).toBe(false);
+    expect(events).toEqual([{
+      commandId: 'on', kind: 'error', originalEpoch: 1, eventEpoch: 1, error: 'socket failed',
+    }]);
+  });
+
   it('routes binary messages to onBinary handlers', async () => {
     const { WsChannel } = await import('../ws-client');
     const ch = new WsChannel();
@@ -567,14 +643,19 @@ describe('control channel singleton', () => {
     expect(radioStoreMock.current?.ptt).toBe(true);
   });
 
-  it('merges a valid delta from the accepted server accumulator, not optimistic store state', async () => {
+  it('does not optimistically mutate PTT before authoritative state arrives', async () => {
     const { connect, sendCommand } = await import('../ws-client');
     connect('ws://test/api/v1/ws');
     instances[0].simulateOpen();
 
     sendStateUpdate(instances[0], fullEnvelope(makeState({ revision: 5, ptt: false, split: false })));
+    vi.mocked(patchRadioState).mockClear();
+    sendCommand('ptt_on');
     sendCommand('ptt', { state: true });
-    expect(radioStoreMock.current?.ptt).toBe(true);
+    sendCommand('ptt_off');
+    sendCommand('ptt', { state: false });
+    expect(patchRadioState).not.toHaveBeenCalled();
+    expect(radioStoreMock.current?.ptt).toBe(false);
     vi.mocked(setRadioState).mockClear();
 
     sendStateUpdate(instances[0], deltaEnvelope(makeState({ revision: 6 }), { split: true }));

--- a/frontend/src/lib/transport/ws-client.ts
+++ b/frontend/src/lib/transport/ws-client.ts
@@ -4,15 +4,29 @@ import { isLiveRadioAvailable, setWsConnected, setHttpConnected, markStateUpdate
 import { getRadioState, patchActiveReceiver, patchRadioState, resetRadioState, setRadioState } from '../stores/radio.svelte';
 
 export type ConnectionState = 'disconnected' | 'connecting' | 'connected' | 'reconnecting';
+export type CommandDeliveryKind = 'transport-sent' | 'ack' | 'response-ok' | 'response-error' | 'error';
+export interface CommandDeliveryEvent {
+  commandId: string;
+  kind: CommandDeliveryKind;
+  originalEpoch: number;
+  eventEpoch: number;
+  error?: string;
+}
 type MessageHandler = (msg: WsIncoming) => void;
 type BinaryHandler = (data: ArrayBuffer) => void;
 type StateHandler = (state: ConnectionState) => void;
+type CommandDeliveryHandler = (event: CommandDeliveryEvent) => void;
+type PendingPttRelease = { command: WsCommand; originalEpoch: number };
+type TrackedPttCommand = PendingPttRelease & {
+  seen: Set<CommandDeliveryKind>;
+};
 
 const BACKOFF_BASE_MS = 1_000;
 const BACKOFF_MAX_MS = 30_000;
 const HEARTBEAT_TIMEOUT_MS = 30_000;  // server may be idle on control WS
 const KEEPALIVE_INTERVAL_MS = 15_000; // send ping to prevent idle timeout
 const MAX_QUEUE_SIZE = 20;
+const MAX_TRACKED_PTT_COMMANDS = 100;
 
 // Command types where only the latest value matters (last write wins)
 const IDEMPOTENT_TYPES = new Set(['set_freq', 'set_mode', 'set_filter']);
@@ -38,7 +52,10 @@ export class WsChannel {
   private attempt = 0;
   private intentionalClose = false;
   private sendQueue: WsCommand[] = [];
-  private pendingPttRelease: WsCommand | null = null;
+  private pendingPttRelease: PendingPttRelease | null = null;
+  private transportEpoch = 0;
+  private trackedPttCommands = new Map<string, TrackedPttCommand>();
+  private commandDeliveryHandlers = new Set<CommandDeliveryHandler>();
   private messageHandlers = new Set<MessageHandler>();
   private binaryHandlers = new Set<BinaryHandler>();
   private stateHandlers = new Set<StateHandler>();
@@ -71,10 +88,12 @@ export class WsChannel {
   private _open() {
     this.setState(this.attempt === 0 ? 'connecting' : 'reconnecting');
     const ws = new WebSocket(this.url);
+    let socketEpoch = 0;
     ws.binaryType = 'arraybuffer';
     this.ws = ws;
 
     ws.onopen = () => {
+      socketEpoch = ++this.transportEpoch;
       this.attempt = 0;
       this.setState('connected');
       this._resetHeartbeat();
@@ -82,7 +101,7 @@ export class WsChannel {
       // drain send queue
       const release = this.pendingPttRelease;
       this.pendingPttRelease = null;
-      if (release) ws.send(JSON.stringify(release));
+      if (release) this._sendPtt(ws, release, socketEpoch);
       const queued = this.sendQueue.splice(0).filter(
         (cmd) => pttIntent(cmd.name, cmd.params) !== 'on',
       );
@@ -92,12 +111,13 @@ export class WsChannel {
     };
 
     ws.onmessage = (event: MessageEvent) => {
-      this._resetHeartbeat();
+      if (this.ws === ws) this._resetHeartbeat();
       if (event.data instanceof ArrayBuffer) {
         this.binaryHandlers.forEach((h) => h(event.data as ArrayBuffer));
       } else {
         try {
           const raw = JSON.parse(event.data as string) as Record<string, unknown>;
+          this._emitCommandResult(raw, socketEpoch);
           // Handle status-based error responses ({"status":"error", ...})
           if (raw['status'] === 'error') {
             const errorMsg = (raw['message'] as string) || (raw['error'] as string) || 'Command failed';
@@ -168,8 +188,20 @@ export class WsChannel {
 
   send(cmd: WsCommand): boolean {
     if (this.ws?.readyState === WebSocket.OPEN) {
-      this.ws.send(JSON.stringify(cmd));
-      return true;
+      const intent = pttIntent(cmd.name, cmd.params);
+      if (intent) {
+        return this._sendPtt(
+          this.ws,
+          { command: cmd, originalEpoch: this.transportEpoch },
+          this.transportEpoch,
+        );
+      }
+      try {
+        this.ws.send(JSON.stringify(cmd));
+        return true;
+      } catch {
+        return false;
+      }
     }
     const intent = pttIntent(cmd.name, cmd.params);
     if (intent === 'on') {
@@ -179,7 +211,7 @@ export class WsChannel {
       this.sendQueue = this.sendQueue.filter(
         (queued) => pttIntent(queued.name, queued.params) !== 'on',
       );
-      this.pendingPttRelease = cmd;
+      this.pendingPttRelease = { command: cmd, originalEpoch: this.transportEpoch };
       return false;
     }
     // Deduplicate idempotent commands — keep only the latest value
@@ -211,6 +243,67 @@ export class WsChannel {
   onStateChange(handler: StateHandler): () => void {
     this.stateHandlers.add(handler);
     return () => this.stateHandlers.delete(handler);
+  }
+
+  onCommandDelivery(handler: CommandDeliveryHandler): () => void {
+    this.commandDeliveryHandlers.add(handler);
+    return () => this.commandDeliveryHandlers.delete(handler);
+  }
+
+  private _sendPtt(ws: WebSocket, pending: PendingPttRelease, eventEpoch: number): boolean {
+    try {
+      ws.send(JSON.stringify(pending.command));
+    } catch (error) {
+      this._emitDelivery({
+        commandId: pending.command.id,
+        kind: 'error',
+        originalEpoch: pending.originalEpoch,
+        eventEpoch,
+        error: error instanceof Error ? error.message : 'WebSocket send failed',
+      });
+      return false;
+    }
+    const tracked: TrackedPttCommand = { ...pending, seen: new Set() };
+    if (this.trackedPttCommands.size >= MAX_TRACKED_PTT_COMMANDS) {
+      this.trackedPttCommands.delete(this.trackedPttCommands.keys().next().value!);
+    }
+    this.trackedPttCommands.set(pending.command.id, tracked);
+    this._emitTracked(tracked, 'transport-sent', eventEpoch);
+    return true;
+  }
+
+  private _emitCommandResult(raw: Record<string, unknown>, eventEpoch: number): void {
+    const id = raw.id;
+    if (typeof id !== 'string') return;
+    const tracked = this.trackedPttCommands.get(id);
+    if (!tracked) return;
+    if (raw.type === 'ack') this._emitTracked(tracked, 'ack', eventEpoch);
+    else if (raw.type === 'response') {
+      this._emitTracked(tracked, raw.ok === false ? 'response-error' : 'response-ok', eventEpoch);
+    } else if (raw.type === 'error' || raw.status === 'error') {
+      this._emitTracked(tracked, 'error', eventEpoch, String(raw.message ?? raw.error ?? 'Command failed'));
+    }
+  }
+
+  private _emitTracked(
+    tracked: TrackedPttCommand,
+    kind: CommandDeliveryKind,
+    eventEpoch: number,
+    error?: string,
+  ): void {
+    if (tracked.seen.has(kind)) return;
+    tracked.seen.add(kind);
+    this._emitDelivery({
+      commandId: tracked.command.id,
+      kind,
+      originalEpoch: tracked.originalEpoch,
+      eventEpoch,
+      ...(error ? { error } : {}),
+    });
+  }
+
+  private _emitDelivery(event: CommandDeliveryEvent): void {
+    this.commandDeliveryHandlers.forEach((handler) => handler(event));
   }
 
   private _resetHeartbeat() {
@@ -453,6 +546,10 @@ export function disconnect() {
   _ctrl.disconnect();
 }
 
+export function onCommandDelivery(handler: CommandDeliveryHandler): () => void {
+  return _ctrl.onCommandDelivery(handler);
+}
+
 export function sendCommand(name: string, params: Record<string, unknown> = {}, id?: string): boolean {
   if (!isLiveRadioAvailable() && pttIntent(name, params) !== 'off') {
     console.warn('[cmd] blocked while radio health is degraded', name);
@@ -538,11 +635,6 @@ function _applyOptimistic(name: string, params: Record<string, unknown>): void {
     case 'set_ip_plus':
     case 'set_ipplus':  // backward-compat alias
       if (typeof params.on === 'boolean') patchActiveReceiver({ ipplus: params.on });
-      break;
-    case 'ptt':
-      // A release is best-effort until confirmed by backend state. Optimistically
-      // clearing PTT could falsely present a de-key while transport is degraded.
-      if (params.state === true) patchRadioState({ ptt: true });
       break;
     case 'set_dual_watch':
       if (typeof params.on === 'boolean') patchRadioState({ dualWatch: params.on });


### PR DESCRIPTION
Linear: MOR-1004
Closes #1934
Decision: MOR-982

## Summary
- expose typed local PTT delivery events for transport-sent, ACK, response success/failure, and errors
- preserve command identity plus original and actual delivery epochs across immediate sends and coalesced offline OFF drain
- suppress duplicate lifecycle events and keep stale old-socket events distinguishable by epoch
- remove legacy optimistic PTT state mutation while retaining MOR-980 non-replayable ON and pinned/coalesced OFF behavior

## Scope
- frontend/src/lib/transport/ws-client.ts
- frontend/src/lib/transport/__tests__/ws-client.test.ts

Net diff: +173 LOC; 2 files.

## Verification
- focused ws-client: 37/37 passed
- npm run check: passed
- npm run lint: passed
- git diff --check: passed
- full frontend: 2247/2248 on feature and 2244/2245 on clean origin/main; the same unrelated mod-input-tx-guard isolated-pool test fails in both, while that file passes 13/13 alone

No controller, component, store, capability, backend, or wire-schema changes.