### PR TITLE
feat(#1941): derive presentation capability facts

### DIFF
--- a/frontend/src/lib/runtime/adapters/__tests__/presentation-capabilities.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/presentation-capabilities.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import type { Capabilities } from '$lib/types/capabilities';
+import { derivePresentationCapabilities } from '../presentation-capabilities';
+
+function caps(overrides: Partial<Capabilities> = {}): Capabilities {
+  return {
+    model: 'fixture', scope: true, audio: true, tx: true,
+    capabilities: ['scope', 'audio', 'tx', 'dual_rx'],
+    receivers: 2, vfoScheme: 'main_sub', freqRanges: [], modes: [], filters: [],
+    audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
+    webrtc: { available: false, enabled: false }, txBands: null,
+    scopeSource: 'hardware', audioFftAvailable: true, ...overrides,
+  };
+}
+
+describe('derivePresentationCapabilities', () => {
+  it.each([
+    ['single', 1, ['MAIN'], { MAIN: null }],
+    ['ab', 1, ['MAIN'], { MAIN: ['A', 'B'] }],
+    ['ab_shared', 2, ['MAIN', 'SUB'], { MAIN: null, SUB: null }],
+    ['main_sub', 2, ['MAIN', 'SUB'], { MAIN: ['A', 'B'], SUB: ['A', 'B'] }],
+  ] as const)('maps %s topology exactly', (scheme, receivers, structuralReceivers, slots) => {
+    const capabilities = scheme === 'single' || scheme === 'ab'
+      ? ['scope', 'audio', 'tx']
+      : ['scope', 'audio', 'tx', 'dual_rx'];
+    expect(derivePresentationCapabilities(caps({
+      vfoScheme: scheme, receivers, capabilities,
+    })).topology).toEqual({
+      scheme, structuralCount: receivers, structuralReceivers,
+      operationalReceivers: structuralReceivers, slots,
+    });
+  });
+
+  it('keeps structural dual RX while failing operational SUB closed', () => {
+    const result = derivePresentationCapabilities(caps({
+      capabilities: ['scope', 'audio', 'tx'],
+    }));
+    expect(result.topology).toMatchObject({
+      structuralCount: 2,
+      structuralReceivers: ['MAIN', 'SUB'],
+      operationalReceivers: ['MAIN'],
+    });
+    expect(result.diagnostics).toContain('dual-rx-unavailable');
+  });
+
+  it('ignores contradictory dual_rx on a one-receiver topology', () => {
+    const result = derivePresentationCapabilities(caps({
+      vfoScheme: 'ab', receivers: 1,
+    }));
+    expect(result.topology?.operationalReceivers).toEqual(['MAIN']);
+    expect(result.diagnostics).toContain('dual-rx-contradiction');
+  });
+
+  it.each([
+    ['single', 2], ['ab', 2], ['ab_shared', 1], ['main_sub', 1],
+    ['unknown', 1], ['single', 0],
+  ])('fails closed for malformed topology %s/%s', (scheme, receivers) => {
+    const result = derivePresentationCapabilities(caps({
+      vfoScheme: scheme as Capabilities['vfoScheme'], receivers,
+    }));
+    expect(result.topology).toBeNull();
+    expect(result.diagnostics).toContain('invalid-topology');
+  });
+
+  it.each([
+    [false, false, null, []],
+    [true, false, 'hardware', ['hardware']],
+    [false, true, 'audio_fft', ['audio_fft']],
+    [true, true, 'hardware', ['hardware', 'audio_fft']],
+  ] as const)('keeps hardware=%s and FFT=%s independent', (scope, fft, source, sources) => {
+    const tags = [scope && 'scope', 'audio', 'tx'].filter(Boolean) as string[];
+    const result = derivePresentationCapabilities(caps({
+      scope, audioFftAvailable: fft, scopeSource: source, capabilities: tags,
+    }));
+    expect(result.scope).toEqual({
+      hardwareScopeAvailable: scope,
+      audioFftAvailable: fft,
+      availableSources: sources,
+      defaultSource: source,
+    });
+  });
+
+  it('fails scope and audio contradictions closed without inventing a default', () => {
+    const result = derivePresentationCapabilities(caps({
+      scope: true, audio: false, capabilities: ['audio'], scopeSource: 'hardware',
+    }));
+    expect(result.scope).toEqual({
+      hardwareScopeAvailable: false, audioFftAvailable: false,
+      availableSources: [], defaultSource: null,
+    });
+    expect(result.diagnostics).toEqual(expect.arrayContaining([
+      'scope-capability-contradiction', 'audio-capability-contradiction',
+      'audio-fft-without-audio', 'invalid-scope-source',
+    ]));
+  });
+
+  it('does not mutate or return the raw capability object', () => {
+    const input = caps({ extensionFact: { preserved: true } });
+    const before = structuredClone(input);
+    const result = derivePresentationCapabilities(input);
+    expect(input).toEqual(before);
+    expect(result).not.toBe(input);
+    expect(result).not.toHaveProperty('extensionFact');
+  });
+});

--- a/frontend/src/lib/runtime/adapters/presentation-capabilities.ts
+++ b/frontend/src/lib/runtime/adapters/presentation-capabilities.ts
@@ -1,0 +1,93 @@
+import type { Capabilities, VfoScheme } from '$lib/types/capabilities';
+
+export type ReceiverId = 'MAIN' | 'SUB';
+export type VfoSlotId = 'A' | 'B';
+export type ScopeSource = 'hardware' | 'audio_fft';
+export type CapabilityDiagnostic =
+  | 'invalid-topology' | 'malformed-capability-tags'
+  | 'dual-rx-contradiction'
+  | 'dual-rx-unavailable'
+  | 'scope-capability-contradiction'
+  | 'audio-capability-contradiction'
+  | 'malformed-audio-fft' | 'audio-fft-without-audio' | 'invalid-scope-source';
+export interface ReceiverTopology {
+  scheme: VfoScheme;
+  structuralCount: 1 | 2;
+  structuralReceivers: readonly ReceiverId[];
+  operationalReceivers: readonly ReceiverId[];
+  slots: Readonly<Partial<Record<ReceiverId, readonly VfoSlotId[] | null>>>;
+}
+export interface PresentationCapabilities {
+  topology: ReceiverTopology | null;
+  scope: {
+    hardwareScopeAvailable: boolean;
+    audioFftAvailable: boolean;
+    availableSources: readonly ScopeSource[];
+    defaultSource: ScopeSource | null;
+  };
+  diagnostics: readonly CapabilityDiagnostic[];
+}
+export function derivePresentationCapabilities(caps: Capabilities): PresentationCapabilities {
+  const diagnostics: CapabilityDiagnostic[] = [];
+  const validTags = Array.isArray(caps.capabilities)
+    && caps.capabilities.every((tag) => typeof tag === 'string');
+  const tags = new Set(validTags ? caps.capabilities : []);
+  if (!validTags) diagnostics.push('malformed-capability-tags');
+
+  const expectedCount = caps.vfoScheme === 'single' || caps.vfoScheme === 'ab' ? 1
+    : caps.vfoScheme === 'ab_shared' || caps.vfoScheme === 'main_sub' ? 2 : null;
+  let topology: ReceiverTopology | null = null;
+  if (expectedCount === null || caps.receivers !== expectedCount) {
+    diagnostics.push('invalid-topology');
+  } else {
+    const dual = tags.has('dual_rx');
+    const structuralReceivers: ReceiverId[] = expectedCount === 2 ? ['MAIN', 'SUB'] : ['MAIN'];
+    const slots = caps.vfoScheme === 'ab'
+      ? { MAIN: ['A', 'B'] as const }
+      : caps.vfoScheme === 'main_sub'
+        ? { MAIN: ['A', 'B'] as const, SUB: ['A', 'B'] as const }
+        : expectedCount === 2 ? { MAIN: null, SUB: null } : { MAIN: null };
+    let operationalReceivers = structuralReceivers;
+    if (expectedCount === 1 && dual) diagnostics.push('dual-rx-contradiction');
+    if (expectedCount === 2 && !dual) {
+      diagnostics.push('dual-rx-unavailable');
+      operationalReceivers = ['MAIN'];
+    }
+    topology = {
+      scheme: caps.vfoScheme, structuralCount: expectedCount,
+      structuralReceivers, operationalReceivers, slots,
+    };
+  }
+
+  function agreed(value: unknown, tag: string, diagnostic: CapabilityDiagnostic): boolean {
+    const tagPresent = tags.has(tag);
+    if (typeof value !== 'boolean' || value !== tagPresent) {
+      diagnostics.push(diagnostic);
+      return false;
+    }
+    return value;
+  }
+
+  const hardwareScopeAvailable = agreed(
+    caps.scope, 'scope', 'scope-capability-contradiction',
+  );
+  const runtimeAudio = agreed(caps.audio, 'audio', 'audio-capability-contradiction');
+  const rawFft = caps.audioFftAvailable ?? false;
+  if (typeof rawFft !== 'boolean') diagnostics.push('malformed-audio-fft');
+  if (rawFft === true && !runtimeAudio) diagnostics.push('audio-fft-without-audio');
+  const audioFftAvailable = rawFft === true && runtimeAudio;
+  const availableSources: ScopeSource[] = [
+    ...(hardwareScopeAvailable ? ['hardware' as const] : []),
+    ...(audioFftAvailable ? ['audio_fft' as const] : []),
+  ];
+  const source = caps.scopeSource;
+  const defaultSource = (source === 'hardware' && hardwareScopeAvailable)
+    || (source === 'audio_fft' && audioFftAvailable) ? source : null;
+  if (source != null && defaultSource === null) diagnostics.push('invalid-scope-source');
+
+  return {
+    topology,
+    scope: { hardwareScopeAvailable, audioFftAvailable, availableSources, defaultSource },
+    diagnostics,
+  };
+}


### PR DESCRIPTION
## Summary

- derive exact receiver/VFO topology for all four validated v1 schemes
- separate structural receivers from runtime-operational dual RX
- expose independent hardware-scope and proven audio-FFT availability/default facts
- fail affected selector facts closed on malformed topology and scalar/tag contradictions

## Scope

Exactly two new pure adapter files. No UI, store, transport, persistence, controller, TX, backend, or wire-schema changes.

## Verification

- focused selector: 18/18 passed
- full frontend with Node 26 webstorage workaround: 128 files, 2266/2266 passed
- `npm run check`: 0 errors / 0 warnings
- `npm run lint`: passed
- `git diff --check`: passed
- diff: 2 files, +198/-0

Linear: MOR-1037
Parent: MOR-984
Decision: MOR-988

Closes #1941