### PR TITLE
Move presentation resolution from RadioLayout to App

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -5,6 +5,9 @@
   import LocalExtensionsHost from './lib/local-extensions/LocalExtensionsHost.svelte';
   import { initMediaSession, destroyMediaSession } from './lib/media/media-session';
   import { runtime } from './lib/runtime/frontend-runtime';
+  import { hasAnyScope } from './lib/stores/capabilities.svelte';
+  import { getLayoutMode } from './lib/stores/layout.svelte';
+  import { resolveSkinId, type SkinId } from './skins/registry';
   import { t } from '$lib/i18n';
   import './app.css';
 
@@ -18,6 +21,19 @@
   const demoMode = typeof window !== 'undefined'
     ? new URLSearchParams(window.location.search).get('demo')
     : null;
+  let windowWidth = $state(typeof window !== 'undefined' ? window.innerWidth : 1200);
+  let windowHeight = $state(typeof window !== 'undefined' ? window.innerHeight : 800);
+  // Mobile = narrow portrait OR short landscape (touch device rotated)
+  let isMobile = $derived(
+    Math.min(windowWidth, windowHeight) < 640 ||
+    ('ontouchstart' in globalThis && Math.min(windowWidth, windowHeight) < 500)
+  );
+  let skinId = $derived<SkinId>(resolveSkinId({
+    capabilities: runtime.caps,
+    layoutPreference: getLayoutMode(),
+    isMobile,
+    hasAnyScope: hasAnyScope(),
+  }));
 
   onMount(() => {
     if (demoMode === 'control-buttons') {
@@ -37,6 +53,11 @@
     let cleanupBootstrap: (() => void) | null = null;
     let cleanupBattery: (() => void) | null = null;
     let retryTimer: ReturnType<typeof setTimeout> | null = null;
+    const handleResize = () => {
+      windowWidth = window.innerWidth;
+      windowHeight = window.innerHeight;
+    };
+    window.addEventListener('resize', handleResize);
 
     initBatteryMonitor((multiplier) => {
       runtime.setPollingMultiplier(multiplier);
@@ -68,6 +89,7 @@
       cleanupBattery?.();
       cleanupBootstrap?.();
       if (retryTimer) clearTimeout(retryTimer);
+      window.removeEventListener('resize', handleResize);
     };
   });
 </script>
@@ -90,7 +112,7 @@
     </div>
   </div>
 {:else}
-  <RadioLayoutV2 />
+  <RadioLayoutV2 {skinId} />
 {/if}
 
 {#if demoMode !== 'control-buttons' && !backendError}

--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -14,9 +14,8 @@
   
   import { runtime } from '$lib/runtime';
   import { applyModeDefault } from '$lib/stores/tuning.svelte';
-  import { getKeyboardConfig, hasCapability, hasAnyScope, hasSpectrum } from '$lib/stores/capabilities.svelte';
-  import { getLayoutMode } from '$lib/stores/layout.svelte';
-  import { resolveSkinId, type SkinId } from '../../skins/registry';
+  import { getKeyboardConfig, hasCapability, hasSpectrum } from '$lib/stores/capabilities.svelte';
+  import type { SkinId } from '../../skins/registry';
   import SpectrumPanel from '../../components/spectrum/SpectrumPanel.svelte';
   import LeftSidebar from './LeftSidebar.svelte';
   import RightSidebar from './RightSidebar.svelte';
@@ -56,6 +55,8 @@
   import { HardwareButton } from '$lib/Button';
   import Toast from '../../components/shared/Toast.svelte';
 
+  let { skinId = 'desktop-v2' }: { skinId?: SkinId } = $props();
+
   // Reactive state + capabilities — via runtime
   let radioState = $derived(runtime.state);
   let caps = $derived(runtime.caps);
@@ -89,26 +90,10 @@
   let mainVfo = $derived(toVfoProps(radioState, 'main'));
   let subVfo = $derived(toVfoProps(radioState, 'sub'));
   let vfoOps = $derived(toVfoOpsProps(radioState, caps));
-  let windowWidth = $state(typeof window !== 'undefined' ? window.innerWidth : 1200);
-  let windowHeight = $state(typeof window !== 'undefined' ? window.innerHeight : 800);
-  // Mobile = narrow portrait OR short landscape (touch device rotated)
-  let isMobile = $derived(
-    Math.min(windowWidth, windowHeight) < 640 ||
-    ('ontouchstart' in globalThis && Math.min(windowWidth, windowHeight) < 500)
-  );
   let isLandscape = $state(false);
   let landscapeSpectrumDismissed = $state(false);
   let landscapeAutoLocked = $state(false);
-  let spectrumLandscape = $derived(isMobile && isLandscape && !landscapeSpectrumDismissed && !landscapeAutoLocked);
   let connectionStatus = $derived(runtime.connectionStatus);
-
-  // Skin resolution — determines which layout to render
-  let skinId = $derived<SkinId>(resolveSkinId({
-    capabilities: caps,
-    layoutPreference: getLayoutMode(),
-    isMobile,
-    hasAnyScope: hasAnyScope(),
-  }));
 
   let activeReceiverLabel = $derived(radioState?.active === 'SUB' ? 'SUB' : 'MAIN');
   let activeModeLabel = $derived(radioState?.active === 'SUB' ? (radioState?.sub?.mode ?? '') : (radioState?.main?.mode ?? ''));
@@ -162,12 +147,6 @@
     // Theme already applied at module load
     manualVfoScaleOverrides = parseVfoLayoutScaleOverrides(window.location.search);
 
-    const handleResize = () => {
-      windowWidth = window.innerWidth;
-      windowHeight = window.innerHeight;
-    };
-    window.addEventListener('resize', handleResize);
-
     const mql = window.matchMedia?.('(orientation: landscape)');
     const handleOrientationChange = (e: MediaQueryListEvent) => {
       isLandscape = e.matches;
@@ -180,7 +159,6 @@
 
     if (!receiverDeckElement) {
       return () => {
-        window.removeEventListener('resize', handleResize);
         mql?.removeEventListener('change', handleOrientationChange);
       };
     }
@@ -189,7 +167,6 @@
 
     if (typeof ResizeObserver === 'undefined') {
       return () => {
-        window.removeEventListener('resize', handleResize);
         mql?.removeEventListener('change', handleOrientationChange);
       };
     }
@@ -205,7 +182,6 @@
 
     observer.observe(receiverDeckElement);
     return () => {
-      window.removeEventListener('resize', handleResize);
       mql?.removeEventListener('change', handleOrientationChange);
       observer.disconnect();
     };

--- a/frontend/src/components-v2/layout/__tests__/RadioLayout.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/RadioLayout.test.ts
@@ -6,6 +6,11 @@ vi.mock('../../../components/spectrum/SpectrumPanel.svelte', async () => {
   return { default: stub.default };
 });
 
+vi.mock('../../../lib/local-extensions/LocalExtensionsHost.svelte', async () => {
+  const stub = await import('./SpectrumPanelStub.svelte');
+  return { default: stub.default };
+});
+
 vi.mock('$lib/stores/layout.svelte', () => ({
   useLcdLayout: vi.fn(() => false),
   getLayoutMode: vi.fn(() => 'standard'),
@@ -15,6 +20,29 @@ vi.mock('$lib/stores/layout.svelte', () => ({
 
 vi.mock('../../../skins/registry', () => ({
   resolveSkinId: vi.fn(() => 'desktop-v2'),
+}));
+
+vi.mock('../../../lib/utils/battery', () => ({
+  initBatteryMonitor: vi.fn(async () => vi.fn()),
+}));
+
+vi.mock('../../../lib/media/media-session', () => ({
+  initMediaSession: vi.fn(),
+  destroyMediaSession: vi.fn(),
+}));
+
+vi.mock('../../../lib/runtime/frontend-runtime', () => ({
+  runtime: {
+    state: null,
+    caps: { scope: true },
+    connectionStatus: 'disconnected',
+    radioPowerOn: null,
+    connection: { status: 'disconnected', radioPowerOn: null },
+    audio: { rxEnabled: false, txEnabled: false, volume: 50, muted: false },
+    bootstrap: vi.fn(async () => vi.fn()),
+    setPollingMultiplier: vi.fn(),
+    send: vi.fn(),
+  },
 }));
 
 vi.mock('$lib/runtime', () => ({
@@ -51,8 +79,10 @@ vi.mock('$lib/stores/tuning.svelte', () => ({
 }));
 
 import RadioLayout from '../RadioLayout.svelte';
+import App from '../../../App.svelte';
 import { extractVfoState, extractMeterState, hasLiveAudioFromState } from '../layout-utils';
 import { radio } from '$lib/stores/radio.svelte';
+import { resolveSkinId, type SkinId } from '../../../skins/registry';
 
 // ---------------------------------------------------------------------------
 // extractVfoState
@@ -283,10 +313,10 @@ import { hasDualReceiver } from '$lib/stores/capabilities.svelte';
 
 let components: ReturnType<typeof mount>[] = [];
 
-function mountLayout() {
+function mountLayout(skinId: SkinId = 'desktop-v2') {
   const t = document.createElement('div');
   document.body.appendChild(t);
-  const component = mount(RadioLayout, { target: t });
+  const component = mount(RadioLayout, { target: t, props: { skinId } });
   flushSync();
   components.push(component);
   return t;
@@ -296,6 +326,7 @@ beforeEach(() => {
   components = [];
   radio.current = null;
   vi.mocked(hasDualReceiver).mockReturnValue(false);
+  vi.mocked(resolveSkinId).mockReturnValue('desktop-v2');
   // JSDOM defaults to 0x0 — force desktop dimensions so isMobile stays false
   Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1440 });
   Object.defineProperty(window, 'innerHeight', { writable: true, configurable: true, value: 900 });
@@ -307,6 +338,11 @@ afterEach(() => {
 });
 
 describe('RadioLayout structure', () => {
+  it('renders the SDR branch from its skinId prop', () => {
+    const t = mountLayout('sdr-test');
+    expect(t.querySelector('.radio-layout.sdr-test')).not.toBeNull();
+  });
+
   it('renders the root .radio-layout element', () => {
     const t = mountLayout();
     expect(t.querySelector('.radio-layout')).not.toBeNull();
@@ -352,6 +388,26 @@ describe('RadioLayout structure', () => {
   it('renders .vfo-header inside .receiver-deck', () => {
     const t = mountLayout();
     expect(t.querySelector('.receiver-deck .vfo-header')).not.toBeNull();
+  });
+});
+
+describe('App presentation selection', () => {
+  it('owns the resolver inputs and passes the resolved skinId to RadioLayout', () => {
+    vi.mocked(resolveSkinId).mockReturnValue('sdr-test');
+
+    const t = document.createElement('div');
+    document.body.appendChild(t);
+    const component = mount(App, { target: t });
+    flushSync();
+    components.push(component);
+
+    expect(resolveSkinId).toHaveBeenLastCalledWith({
+      capabilities: { scope: true },
+      layoutPreference: 'standard',
+      isMobile: false,
+      hasAnyScope: false,
+    });
+    expect(t.querySelector('.radio-layout.sdr-test')).not.toBeNull();
   });
 });
 


### PR DESCRIPTION
Closes #1942

Linear: https://linear.app/morozsm/issue/MOR-1039/move-presentation-resolution-from-radiolayout-to-app
Parent: https://linear.app/morozsm/issue/MOR-981/establish-the-app-presentation-selection-seam
Depends on merged PR #1910.

## What changed

- Moved the existing viewport/touch mobile calculation and registry policy inputs into `App.svelte`.
- `App` now resolves a typed `SkinId` from `runtime.caps`, `LayoutMode`, and `hasAnyScope()` and passes it to `RadioLayout`.
- `RadioLayout` now renders from its typed prop and no longer resolves presentation or owns the resize inputs.
- Added focused coverage for the App policy handoff and prop-driven SDR branch.

## Preserved behavior

- Existing mobile, LCD cockpit/scope, desktop, and SDR branches and eager mount topology are unchanged.
- Bootstrap/retry/demo mode, MediaSession, extensions, transports, scope/audio lifetime, and visuals are unchanged.
- `loadSkin` remains inactive.
- The temporary `desktop-v2` prop default preserves existing wrapper compatibility until MOR-981 step 3 adds explicit desktop/SDR entrypoint props and tests.

## Scope

Exactly 3 files, +85/-31 (net +54). No `main.ts`, registry-policy, `StatusBar`, skin entrypoint, or legacy-normalization changes.

## Checks

- `NODE_OPTIONS=--no-experimental-webstorage npm test -- --run src/components-v2/layout/__tests__/RadioLayout.test.ts` — 39 passed
- `NODE_OPTIONS=--no-experimental-webstorage npm test` — 127 files, 2250 passed
- `npm run check` — 0 errors, 0 warnings
- `npm run lint` — passed
- `npm run build` — passed
- `git diff --check` — passed