### PR TITLE
Make desktop and SDR skin entrypoints explicit

### DIFF
--- a/frontend/src/skins/__tests__/entrypoints.test.ts
+++ b/frontend/src/skins/__tests__/entrypoints.test.ts
@@ -1,0 +1,32 @@
+import { mount, unmount } from 'svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { SkinId } from '../registry';
+
+const mountedSkinIds = vi.hoisted(() => [] as SkinId[]);
+
+vi.mock('../../components-v2/layout/RadioLayout.svelte', () => ({
+  default: (_anchor: unknown, props: { skinId?: SkinId }) => {
+    if (props.skinId) mountedSkinIds.push(props.skinId);
+  },
+}));
+
+import DesktopSkin from '../desktop-v2/DesktopSkin.svelte';
+import SdrTestSkin from '../sdr-test/SdrTestSkin.svelte';
+
+const components: Record<string, unknown>[] = [];
+
+afterEach(() => {
+  while (components.length) unmount(components.pop()!);
+  mountedSkinIds.length = 0;
+});
+
+describe('desktop skin entrypoints', () => {
+  it.each([
+    [DesktopSkin, 'desktop-v2'],
+    [SdrTestSkin, 'sdr-test'],
+  ] as const)('passes its stable skin ID explicitly', (component, skinId) => {
+    const target = document.createElement('div');
+    components.push(mount(component, { target }));
+    expect(mountedSkinIds).toEqual([skinId]);
+  });
+});

--- a/frontend/src/skins/desktop-v2/DesktopSkin.svelte
+++ b/frontend/src/skins/desktop-v2/DesktopSkin.svelte
@@ -10,4 +10,4 @@
   import RadioLayout from '../../components-v2/layout/RadioLayout.svelte';
 </script>
 
-<RadioLayout />
+<RadioLayout skinId="desktop-v2" />

--- a/frontend/src/skins/sdr-test/SdrTestSkin.svelte
+++ b/frontend/src/skins/sdr-test/SdrTestSkin.svelte
@@ -11,4 +11,4 @@
   import RadioLayout from '../../components-v2/layout/RadioLayout.svelte';
 </script>
 
-<RadioLayout />
+<RadioLayout skinId="sdr-test" />


### PR DESCRIPTION
## Summary

- pass stable `desktop-v2` and `sdr-test` IDs explicitly from their skin wrappers
- characterize both real wrappers with a bounded RadioLayout contract test
- remove the SDR wrapper dependency on RadioLayout's temporary compatibility default

## Scope

Exactly three owned files, +34/-2 (net +32). Both wrappers retain one eager static import and one RadioLayout mount. No resolver, loader, App, RadioLayout, registry, StatusBar, main, runtime, transport, lifetime, visual, workspace, or persistence change.

## Verification

- focused entrypoint + registry + RadioLayout: 56/56 passed
- full frontend with Node 26 webstorage workaround: 129 files, 2270/2270 passed
- `npm run check`: 0 errors / 0 warnings
- `npm run lint`: passed
- `npm run build`: passed
- `git diff --check`: passed

Linear: MOR-1041
Parent: MOR-981
Depends on: MOR-1039 / merged PR #1944

Closes #1946