### PR TITLE
Core: bind managed TX effect service and request seam

### DIFF
--- a/src/rigplane/runtime/managed_radio_runtime.py
+++ b/src/rigplane/runtime/managed_radio_runtime.py
@@ -7,6 +7,7 @@ from rigplane.core.tx_safety import (
     Clock,
     IdFactory,
     TxOutcome,
+    TxOwner,
     TxReleaseReason,
     TxSafetySupervisor,
     TxTransition,
@@ -21,6 +22,7 @@ class ManagedRadioRuntime:
         self,
         target_id: str,
         *,
+        service: TxService,
         clock: Clock | None = None,
         id_factory: IdFactory | None = None,
         shutdown_timeout_seconds: float = 3.0,
@@ -29,6 +31,7 @@ class ManagedRadioRuntime:
             raise ValueError("shutdown_timeout_seconds must be finite-positive")
         self.target_id = target_id
         self._tx_safety = TxSafetySupervisor(clock=clock, id_factory=id_factory)
+        self._service = service
         self._provider_generation = 0
         self._shutdown_timeout = shutdown_timeout_seconds
 
@@ -36,37 +39,56 @@ class ManagedRadioRuntime:
     def tx_safety(self) -> TxSafetySupervisor:
         return self._tx_safety
 
-    async def replace_provider(
-        self, *, ready: bool, service: TxService
-    ) -> TxTransition:
+    async def _service_effects(self, transition: TxTransition) -> None:
+        if transition.effects:
+            await self._service(self._tx_safety, transition)
+
+    async def replace_provider(self, *, ready: bool) -> TxTransition:
         self._provider_generation += 1
         transition = self.tx_safety.replace_provider(
             self._provider_generation, ready=ready
         )
-        if transition.effects:
-            await service(self.tx_safety, transition)
+        await self._service_effects(transition)
         return transition
 
-    async def set_provider_ready(
-        self, *, ready: bool, service: TxService
-    ) -> TxTransition:
+    async def set_provider_ready(self, *, ready: bool) -> TxTransition:
         transition = self.tx_safety.set_provider_ready(
             self._provider_generation, ready=ready
         )
-        if transition.effects:
-            await service(self.tx_safety, transition)
+        await self._service_effects(transition)
         return transition
 
-    async def shutdown(
-        self, *, dekey: TxService, release_provider: ProviderRelease
+    async def request_on(self, owner: TxOwner) -> TxTransition:
+        transition = self._tx_safety.request_on(owner)
+        await self._service_effects(transition)
+        return transition
+
+    async def request_off(
+        self,
+        owner: TxOwner,
+        lease_id: str,
+        *,
+        reason: TxReleaseReason = TxReleaseReason.OPERATOR_RELEASE,
     ) -> TxTransition:
+        transition = self._tx_safety.request_off(owner, lease_id, reason=reason)
+        await self._service_effects(transition)
+        return transition
+
+    async def release_owner(
+        self, owner: TxOwner, *, reason: TxReleaseReason
+    ) -> TxTransition:
+        transition = self._tx_safety.release_owner(owner, reason=reason)
+        await self._service_effects(transition)
+        return transition
+
+    async def shutdown(self, *, release_provider: ProviderRelease) -> TxTransition:
         transition = self.tx_safety.emergency_release(
             reason=TxReleaseReason.SERVER_SHUTDOWN
         )
         try:
             if transition.outcome is not TxOutcome.NOOP:
                 await asyncio.wait_for(
-                    dekey(self.tx_safety, transition),
+                    self._service_effects(transition),
                     timeout=self._shutdown_timeout,
                 )
         except TimeoutError:

--- a/src/rigplane/runtime/managed_radio_runtime.py
+++ b/src/rigplane/runtime/managed_radio_runtime.py
@@ -9,6 +9,7 @@ from rigplane.core.tx_safety import (
     TxOutcome,
     TxOwner,
     TxReleaseReason,
+    TxSafetySnapshot,
     TxSafetySupervisor,
     TxTransition,
 )
@@ -36,8 +37,8 @@ class ManagedRadioRuntime:
         self._shutdown_timeout = shutdown_timeout_seconds
 
     @property
-    def tx_safety(self) -> TxSafetySupervisor:
-        return self._tx_safety
+    def tx_snapshot(self) -> TxSafetySnapshot:
+        return self._tx_safety.snapshot
 
     async def _service_effects(self, transition: TxTransition) -> None:
         if transition.effects:
@@ -45,14 +46,14 @@ class ManagedRadioRuntime:
 
     async def replace_provider(self, *, ready: bool) -> TxTransition:
         self._provider_generation += 1
-        transition = self.tx_safety.replace_provider(
+        transition = self._tx_safety.replace_provider(
             self._provider_generation, ready=ready
         )
         await self._service_effects(transition)
         return transition
 
     async def set_provider_ready(self, *, ready: bool) -> TxTransition:
-        transition = self.tx_safety.set_provider_ready(
+        transition = self._tx_safety.set_provider_ready(
             self._provider_generation, ready=ready
         )
         await self._service_effects(transition)
@@ -82,7 +83,7 @@ class ManagedRadioRuntime:
         return transition
 
     async def shutdown(self, *, release_provider: ProviderRelease) -> TxTransition:
-        transition = self.tx_safety.emergency_release(
+        transition = self._tx_safety.emergency_release(
             reason=TxReleaseReason.SERVER_SHUTDOWN
         )
         try:

--- a/tests/test_managed_radio_runtime.py
+++ b/tests/test_managed_radio_runtime.py
@@ -9,11 +9,14 @@ from rigplane.core.tx_safety import (
     ProviderPttObservation,
     RadioTx,
     TxOwner,
+    TxOutcome,
     TxPhase,
+    TxReleaseReason,
     TxSafetySupervisor,
     TxSource,
+    TxTransition,
 )
-from rigplane.runtime.managed_radio_runtime import ManagedRadioRuntime
+from rigplane.runtime.managed_radio_runtime import ManagedRadioRuntime, TxService
 
 
 def ids() -> Iterator[str]:
@@ -23,25 +26,33 @@ def ids() -> Iterator[str]:
         yield f"id-{index}"
 
 
-def runtime(target: str = "radio-a", *, timeout: float = 0.01) -> ManagedRadioRuntime:
+async def no_effects(
+    _supervisor: TxSafetySupervisor, _transition: TxTransition
+) -> None:
+    pass
+
+
+def runtime(
+    target: str = "radio-a",
+    *,
+    timeout: float = 0.01,
+    service: TxService = no_effects,
+) -> ManagedRadioRuntime:
     generated = ids()
     return ManagedRadioRuntime(
         target,
+        service=service,
         clock=lambda: 10.0,
         id_factory=lambda: next(generated),
         shutdown_timeout_seconds=timeout,
     )
 
 
-async def no_effects(_supervisor: TxSafetySupervisor, transition: object) -> None:
-    assert not getattr(transition, "effects")
-
-
 async def acquire(rt: ManagedRadioRuntime) -> tuple[TxOwner, ProviderAttempt]:
-    await rt.replace_provider(ready=True, service=no_effects)
+    await rt.replace_provider(ready=True)
     rt.tx_safety.observe_ptt(ProviderPttObservation(RadioTx.OFF, 1, 1, 10.0))
     owner = TxOwner(TxSource.WEBSOCKET, "web-1")
-    attempt = rt.tx_safety.request_on(owner).effects[0]
+    attempt = (await rt.request_on(owner)).effects[0]
     assert isinstance(attempt, ProviderAttempt)
     return owner, attempt
 
@@ -59,7 +70,7 @@ async def test_target_owns_one_supervisor_across_consumers_and_generations() -> 
     await acquire(first)
     lease = first.tx_safety.snapshot.lease_id
 
-    changed = await first.replace_provider(ready=False, service=no_effects)
+    changed = await first.replace_provider(ready=False)
 
     assert first.tx_safety is supervisor is not second.tx_safety
     assert changed.snapshot.lease_id == lease
@@ -68,39 +79,91 @@ async def test_target_owns_one_supervisor_across_consumers_and_generations() -> 
 
 @pytest.mark.asyncio
 async def test_ready_provider_services_pending_off_before_return() -> None:
-    rt = runtime()
-    owner, attempt = await acquire(rt)
-    lease = rt.tx_safety.snapshot.lease_id or ""
-    rt.tx_safety.request_off(owner, lease)
     order: list[str] = []
 
     async def service(_supervisor: TxSafetySupervisor, transition: object) -> None:
         effect = getattr(transition, "effects")[0]
-        assert effect.kind is ProviderAttemptKind.WRITE_OFF
-        order.append("off")
+        order.append(getattr(effect, "kind", "cancel"))
 
-    await rt.replace_provider(ready=False, service=no_effects)
-    await rt.set_provider_ready(ready=True, service=service)
+    rt = runtime(service=service)
+    owner, attempt = await acquire(rt)
+    lease = rt.tx_safety.snapshot.lease_id or ""
+    await rt.request_off(owner, lease)
+
+    await rt.replace_provider(ready=False)
+    await rt.set_provider_ready(ready=True)
     order.append("ordinary")
 
-    assert order == ["off", "ordinary"]
+    assert order[-2:] == [ProviderAttemptKind.WRITE_OFF, "ordinary"]
     assert rt.tx_safety.snapshot.active_attempt != attempt
 
 
 @pytest.mark.asyncio
-async def test_shutdown_bounds_dekey_before_provider_release() -> None:
-    rt = runtime()
-    await acquire(rt)
-    order: list[str] = []
+async def test_managed_requests_service_once_and_return_owner_lease_identity() -> None:
+    serviced: list[TxTransition] = []
 
-    async def dekey(_supervisor: TxSafetySupervisor, _transition: object) -> None:
+    async def service(supervisor: TxSafetySupervisor, transition: TxTransition) -> None:
+        assert supervisor is rt.tx_safety
+        serviced.append(transition)
+
+    rt = runtime(service=service)
+    await rt.replace_provider(ready=True)
+    rt.tx_safety.observe_ptt(ProviderPttObservation(RadioTx.OFF, 1, 1, 10.0))
+    owner = TxOwner(TxSource.SDK, "sdk-1")
+
+    keyed = await rt.request_on(owner)
+    released = await rt.release_owner(owner, reason=TxReleaseReason.SOURCE_DETACHED)
+
+    assert serviced == [keyed, released]
+    assert keyed.snapshot.owner == owner
+    assert keyed.snapshot.lease_id
+    assert released.snapshot.lease_id == keyed.snapshot.lease_id
+    assert released.snapshot.release_reason is TxReleaseReason.SOURCE_DETACHED
+
+
+@pytest.mark.asyncio
+async def test_request_off_service_error_propagates_and_retains_durable_off() -> None:
+    fail = False
+
+    async def service(
+        _supervisor: TxSafetySupervisor, _transition: TxTransition
+    ) -> None:
+        if fail:
+            raise RuntimeError("provider service failed")
+
+    rt = runtime(service=service)
+    owner, _ = await acquire(rt)
+    lease = rt.tx_safety.snapshot.lease_id or ""
+    fail = True
+
+    with pytest.raises(RuntimeError, match="provider service failed"):
+        await rt.request_off(owner, lease)
+
+    assert rt.tx_safety.snapshot.phase is TxPhase.RELEASE_REQUIRED
+    repeated = await rt.request_off(owner, lease)
+    assert repeated.outcome is TxOutcome.IDEMPOTENT
+    assert rt.tx_safety.snapshot.lease_id == lease
+
+
+@pytest.mark.asyncio
+async def test_shutdown_bounds_dekey_before_provider_release() -> None:
+    order: list[str] = []
+    armed = False
+
+    async def service(_supervisor: TxSafetySupervisor, transition: object) -> None:
+        if not armed or not getattr(transition, "effects"):
+            return
         order.append("dekey")
         await asyncio.Event().wait()
+
+    rt = runtime(service=service)
+    await acquire(rt)
+    armed = True
 
     async def release() -> None:
         order.append("release")
 
-    result = await rt.shutdown(dekey=dekey, release_provider=release)
+    result = await rt.shutdown(release_provider=release)
 
     assert order == ["dekey", "release"]
     assert result.snapshot.phase is TxPhase.RELEASE_REQUIRED
@@ -108,17 +171,22 @@ async def test_shutdown_bounds_dekey_before_provider_release() -> None:
 
 @pytest.mark.asyncio
 async def test_shutdown_error_still_releases_provider() -> None:
-    rt = runtime()
-    await acquire(rt)
     released = False
 
-    async def fail(_supervisor: TxSafetySupervisor, _transition: object) -> None:
-        raise RuntimeError("dekey failed")
+    armed = False
+
+    async def service(_supervisor: TxSafetySupervisor, transition: object) -> None:
+        if armed and getattr(transition, "effects"):
+            raise RuntimeError("dekey failed")
+
+    rt = runtime(service=service)
+    await acquire(rt)
+    armed = True
 
     async def release() -> None:
         nonlocal released
         released = True
 
     with pytest.raises(RuntimeError, match="dekey failed"):
-        await rt.shutdown(dekey=fail, release_provider=release)
+        await rt.shutdown(release_provider=release)
     assert released

--- a/tests/test_managed_radio_runtime.py
+++ b/tests/test_managed_radio_runtime.py
@@ -1,5 +1,6 @@
 import asyncio
 from collections.abc import Iterator
+from dataclasses import FrozenInstanceError
 
 import pytest
 
@@ -50,7 +51,7 @@ def runtime(
 
 async def acquire(rt: ManagedRadioRuntime) -> tuple[TxOwner, ProviderAttempt]:
     await rt.replace_provider(ready=True)
-    rt.tx_safety.observe_ptt(ProviderPttObservation(RadioTx.OFF, 1, 1, 10.0))
+    rt._tx_safety.observe_ptt(ProviderPttObservation(RadioTx.OFF, 1, 1, 10.0))
     owner = TxOwner(TxSource.WEBSOCKET, "web-1")
     attempt = (await rt.request_on(owner)).effects[0]
     assert isinstance(attempt, ProviderAttempt)
@@ -64,15 +65,29 @@ def test_shutdown_timeout_must_be_bounded(timeout: float) -> None:
 
 
 @pytest.mark.asyncio
+async def test_runtime_does_not_expose_mutable_supervisor() -> None:
+    rt = runtime()
+    await rt.replace_provider(ready=True)
+    snapshot = rt.tx_snapshot
+
+    assert not hasattr(rt, "tx_safety")
+    assert not hasattr(snapshot, "request_on")
+    assert not hasattr(snapshot, "replace_provider")
+    with pytest.raises(FrozenInstanceError):
+        setattr(snapshot, "provider_generation", 999)
+    assert rt.tx_snapshot.provider_generation == 1
+
+
+@pytest.mark.asyncio
 async def test_target_owns_one_supervisor_across_consumers_and_generations() -> None:
     first, second = runtime("a"), runtime("b")
-    supervisor = first.tx_safety
+    supervisor = first._tx_safety
     await acquire(first)
-    lease = first.tx_safety.snapshot.lease_id
+    lease = first.tx_snapshot.lease_id
 
     changed = await first.replace_provider(ready=False)
 
-    assert first.tx_safety is supervisor is not second.tx_safety
+    assert first._tx_safety is supervisor is not second._tx_safety
     assert changed.snapshot.lease_id == lease
     assert changed.snapshot.phase is TxPhase.RELEASE_REQUIRED
 
@@ -87,7 +102,7 @@ async def test_ready_provider_services_pending_off_before_return() -> None:
 
     rt = runtime(service=service)
     owner, attempt = await acquire(rt)
-    lease = rt.tx_safety.snapshot.lease_id or ""
+    lease = rt.tx_snapshot.lease_id or ""
     await rt.request_off(owner, lease)
 
     await rt.replace_provider(ready=False)
@@ -95,7 +110,7 @@ async def test_ready_provider_services_pending_off_before_return() -> None:
     order.append("ordinary")
 
     assert order[-2:] == [ProviderAttemptKind.WRITE_OFF, "ordinary"]
-    assert rt.tx_safety.snapshot.active_attempt != attempt
+    assert rt.tx_snapshot.active_attempt != attempt
 
 
 @pytest.mark.asyncio
@@ -103,12 +118,12 @@ async def test_managed_requests_service_once_and_return_owner_lease_identity() -
     serviced: list[TxTransition] = []
 
     async def service(supervisor: TxSafetySupervisor, transition: TxTransition) -> None:
-        assert supervisor is rt.tx_safety
+        assert supervisor is rt._tx_safety
         serviced.append(transition)
 
     rt = runtime(service=service)
     await rt.replace_provider(ready=True)
-    rt.tx_safety.observe_ptt(ProviderPttObservation(RadioTx.OFF, 1, 1, 10.0))
+    rt._tx_safety.observe_ptt(ProviderPttObservation(RadioTx.OFF, 1, 1, 10.0))
     owner = TxOwner(TxSource.SDK, "sdk-1")
 
     keyed = await rt.request_on(owner)
@@ -133,16 +148,16 @@ async def test_request_off_service_error_propagates_and_retains_durable_off() ->
 
     rt = runtime(service=service)
     owner, _ = await acquire(rt)
-    lease = rt.tx_safety.snapshot.lease_id or ""
+    lease = rt.tx_snapshot.lease_id or ""
     fail = True
 
     with pytest.raises(RuntimeError, match="provider service failed"):
         await rt.request_off(owner, lease)
 
-    assert rt.tx_safety.snapshot.phase is TxPhase.RELEASE_REQUIRED
+    assert rt.tx_snapshot.phase is TxPhase.RELEASE_REQUIRED
     repeated = await rt.request_off(owner, lease)
     assert repeated.outcome is TxOutcome.IDEMPOTENT
-    assert rt.tx_safety.snapshot.lease_id == lease
+    assert rt.tx_snapshot.lease_id == lease
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #1945

Linear: https://linear.app/morozsm/issue/MOR-1040/core-bind-provider-effect-service-and-expose-managed-tx-requests-on
Blocks parent: https://linear.app/morozsm/issue/MOR-1009/core-route-managed-sdk-ptt-through-managedtxapi
Prerequisite: #1940

## What changed

- Bind one private `TxService` when `ManagedRadioRuntime` is constructed.
- Route provider replacement, readiness, shutdown, and managed TX requests through that same executor.
- Add narrow async `request_on`, `request_off`, and `release_owner` methods that reduce once, service emitted effects once, and return the supervisor transition with owner/lease identity.
- Preserve durable OFF state when the provider service raises while propagating the error.

## Safety properties

- No provider object or bare `set_ptt` callback is exposed.
- The effect executor receives only the owned supervisor and emitted transition, so it cannot recurse through a facade.
- Supervisor reduction happens before service; service failures cannot roll back release state.
- Shutdown remains bounded and releases the provider in `finally`.

## Scope

Exactly two approved files, +130/-40 (net +90). No `radio_protocol.py`, sync facade, Web, rigctld, IC-7610, poller, frontend, or provider-specific integration.

## Verification

- focused managed runtime: 9 passed
- full non-integration: 8343 passed, 12 skipped, 5 deselected, 11 xfailed, 1 xpassed
- Ruff check: passed
- Ruff format check: passed
- targeted mypy for changed runtime: passed
- import-linter: 5/5 contracts kept
- diff check: passed

Full `mypy src/` retains the known baseline of 13 errors in three untouched files: `_control_phase.py`, `_audio_runtime_mixin.py`, and `_civ_rx.py`.

Independent safety review is required before this draft is made ready.