### PR TITLE
fix: emit authoritative IC-7610 PTT observations

### DIFF
--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+from collections.abc import Callable
 from dataclasses import dataclass
 from dataclasses import replace as _replace_dataclass
 from typing import TYPE_CHECKING, Any
@@ -46,6 +47,7 @@ from rigplane.commands import (
 )
 from rigplane.commands.levels import _cw_pitch_from_level, _key_speed_from_level
 from rigplane.core.exceptions import ConnectionError, TimeoutError
+from rigplane.core.tx_safety import ProviderPttObservation, RadioTx
 from rigplane.core.state_pipeline_contracts import (
     ChangeSet,
     FieldChange,
@@ -531,6 +533,11 @@ class CivRuntime:
         # (Codex P1 on PR #851).
         self._reconnect_task: asyncio.Task[None] | None = None
         self._raw_received_frame_bytes: dict[int, bytes] = {}
+        self._ptt_observer: Callable[[ProviderPttObservation], None] | None = None
+        self._ptt_observer_provider_generation: int | None = None
+        self._ptt_observer_civ_generation: int | None = None
+        self._ptt_observation_seq = 0
+        self._active_rx_source_generation: int | None = None
 
     # ------------------------------------------------------------------
     # Public API (design doc)
@@ -539,7 +546,28 @@ class CivRuntime:
     def start_pump(self) -> None:
         """Start always-on CI-V receive pump."""
         if self._host._civ_rx_task is None or self._host._civ_rx_task.done():
-            self._host._civ_rx_task = asyncio.create_task(self._civ_rx_loop())
+            self._host._civ_rx_task = asyncio.create_task(
+                self._civ_rx_loop(source_generation=self._host._civ_epoch)
+            )
+
+    def bind_ptt_observer(
+        self,
+        *,
+        provider_generation: int,
+        observer: Callable[[ProviderPttObservation], None],
+    ) -> None:
+        """Bind authoritative PTT readback to this CI-V transport generation."""
+        if provider_generation < 0:
+            raise ValueError("provider_generation must be non-negative")
+        if provider_generation != self._ptt_observer_provider_generation:
+            self._ptt_observation_seq = 0
+        self._ptt_observer = observer
+        self._ptt_observer_provider_generation = provider_generation
+        self._ptt_observer_civ_generation = self._host._civ_epoch
+
+    def unbind_ptt_observer(self) -> None:
+        """Detach the callback while preserving this provider's sequence."""
+        self._ptt_observer = None
 
     async def stop_pump(self) -> None:
         """Stop CI-V receive pump and fail pending request futures."""
@@ -1040,9 +1068,10 @@ class CivRuntime:
         )
         return non_scope_packets + kept_scope
 
-    async def _civ_rx_loop(self) -> None:
+    async def _civ_rx_loop(self, *, source_generation: int) -> None:
         """Continuously consume CI-V transport packets and route events."""
         assert self._host._civ_transport is not None
+        self._active_rx_source_generation = source_generation
         self._host._last_civ_data_received = time.monotonic()
         try:
             while self._host._civ_transport is not None:
@@ -1090,6 +1119,9 @@ class CivRuntime:
                 self._cleanup_stale_civ_waiters()
         except asyncio.CancelledError:
             pass
+        finally:
+            if self._active_rx_source_generation == source_generation:
+                self._active_rx_source_generation = None
 
     async def _route_civ_frame(self, frame: CivFrame, *, generation: int) -> None:
         """Route one parsed CI-V frame into command/scope event paths."""
@@ -1128,9 +1160,45 @@ class CivRuntime:
             event = CivEvent(type=CivEventType.NAK, frame=frame)
         else:
             event = CivEvent(type=CivEventType.RESPONSE, frame=frame)
+            self._emit_authoritative_ptt(
+                frame,
+                source_generation=(
+                    generation
+                    if self._active_rx_source_generation is None
+                    else self._active_rx_source_generation
+                ),
+            )
             self._update_state_cache_from_frame(frame)
         self._publish_civ_event(event)
         self._host._civ_request_tracker.resolve(event, generation=generation)
+
+    def _emit_authoritative_ptt(
+        self, frame: CivFrame, *, source_generation: int
+    ) -> None:
+        """Publish only exact, generation-bound CI-V PTT state responses."""
+        observer = self._ptt_observer
+        provider_generation = self._ptt_observer_provider_generation
+        if (
+            observer is None
+            or provider_generation is None
+            or source_generation != self._ptt_observer_civ_generation
+            or frame.command != 0x1C
+            or frame.sub != 0x00
+            or len(frame.data) != 1
+            or frame.data[0] not in (0x00, 0x01)
+        ):
+            return
+        self._ptt_observation_seq += 1
+        observation = ProviderPttObservation(
+            value=RadioTx.ON if frame.data[0] else RadioTx.OFF,
+            provider_generation=provider_generation,
+            ptt_observation_seq=self._ptt_observation_seq,
+            observed_at_monotonic=time.monotonic(),
+        )
+        try:
+            observer(observation)
+        except Exception:  # noqa: BLE001 - observer failure must not break CI-V RX
+            logger.exception("Authoritative PTT observer raised")
 
     def deliver_raw_civ(self, frame_bytes: bytes) -> None:
         """Forward a raw inbound CI-V frame to registered raw-pipe listeners.

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 
     from rigplane._runtime_protocols import ControlPhaseHost
     from rigplane.core.acquisition_scheduler import RadioStateModelService
+    from rigplane.core.tx_safety import ProviderPttObservation
 
 from . import radio_initial_state as _initial_state
 from . import radio_reconnect as _reconnect
@@ -2932,7 +2933,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         """Toggle PTT (Push-To-Talk).
 
         Fire-and-forget: the command is sent at IMMEDIATE priority without
-        blocking for an ACK.  The state cache is updated optimistically.
+        blocking for an ACK. PTT state changes only on decoded radio readback.
 
         Args:
             on: True for TX, False for RX.
@@ -2944,8 +2945,23 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             else ptt_off(to_addr=self._radio_addr)
         )
         await self._send_civ_raw(civ, priority=Priority.IMMEDIATE, wait_response=False)
-        self._state_cache.update_ptt(on)
         logger.debug("set_ptt(%s) sent (fire-and-forget)", on)
+
+    def _bind_authoritative_ptt_observer(
+        self,
+        *,
+        provider_generation: int,
+        observer: "Callable[[ProviderPttObservation], None]",
+    ) -> None:
+        """Bind decoded PTT readback to a managed-provider generation."""
+        self._civ_runtime.bind_ptt_observer(
+            provider_generation=provider_generation,
+            observer=observer,
+        )
+
+    def _unbind_authoritative_ptt_observer(self) -> None:
+        """Detach the managed-provider PTT readback observer."""
+        self._civ_runtime.unbind_ptt_observer()
 
     # ------------------------------------------------------------------
     # Transceiver status family (#136)

--- a/tests/test_backend_contract_matrix.py
+++ b/tests/test_backend_contract_matrix.py
@@ -206,11 +206,11 @@ async def test_backend_contract_power(backend_fixture: _BackendFixture) -> None:
 
 
 @pytest.mark.asyncio
-async def test_backend_contract_ptt_updates_state_cache(
+async def test_backend_contract_ptt_cache_behavior(
     backend_fixture: _BackendFixture,
 ) -> None:
     await backend_fixture.radio.set_ptt(True)
-    backend_fixture.assert_ptt(True)
+    backend_fixture.assert_ptt(backend_fixture.name == "serial")
     await backend_fixture.radio.set_ptt(False)
     backend_fixture.assert_ptt(False)
 

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -24,6 +24,7 @@ from rigplane.commands import (
 )
 from rigplane.commander import Priority
 from rigplane.exceptions import ConnectionError, TimeoutError
+from rigplane.core import tx_safety as tx
 from rigplane.radio import IcomRadio
 from rigplane.types import (
     AgcMode,
@@ -90,6 +91,19 @@ def _ptt_response(on: bool) -> bytes:
         data=bytes([0x01 if on else 0x00]),
     )
     return _wrap_civ_in_udp(civ)
+
+
+async def _route_ptt(
+    radio: IcomRadio,
+    data: bytes,
+    *,
+    to_addr: int = CONTROLLER_ADDR,
+    from_addr: int = IC_7610_ADDR,
+) -> None:
+    await radio._civ_runtime._route_civ_frame(
+        CivFrame(to_addr, from_addr, 0x1C, sub=0x00, data=data),
+        generation=radio._civ_epoch,
+    )
 
 
 def _bcd_bytes(value: int, digits: int = 4) -> bytes:
@@ -742,16 +756,117 @@ class TestPtt:
         assert mock_raw.call_args.kwargs["priority"] == Priority.IMMEDIATE
 
     @pytest.mark.asyncio
-    async def test_set_ptt_updates_state_cache(
+    async def test_set_ptt_does_not_update_state_cache_optimistically(
         self, radio: IcomRadio, mock_transport: MockTransport
     ) -> None:
-        """set_ptt updates the state cache optimistically."""
+        """A local write is not authoritative PTT state."""
         await radio.set_ptt(True)
-        assert radio.state_cache.ptt is True
-        assert radio.state_cache.ptt_ts > 0.0
+        assert radio.state_cache.ptt is False
+        assert radio.state_cache.ptt_ts == 0.0
 
         await radio.set_ptt(False)
         assert radio.state_cache.ptt is False
+        assert radio.state_cache.ptt_ts == 0.0
+
+    @pytest.mark.asyncio
+    async def test_ptt_authority_requires_exact_radio_response(
+        self, radio: IcomRadio
+    ) -> None:
+        observations: list[tx.ProviderPttObservation] = []
+        radio._bind_authoritative_ptt_observer(
+            provider_generation=7, observer=observations.append
+        )
+
+        for data in (b"", b"\x02", b"\x01\x00"):
+            await _route_ptt(radio, data)
+        for to_addr, from_addr in (
+            (CONTROLLER_ADDR, 0x99),
+            (0x99, IC_7610_ADDR),
+        ):
+            await _route_ptt(radio, b"\x01", to_addr=to_addr, from_addr=from_addr)
+        await radio._civ_runtime._route_civ_frame(
+            CivFrame(
+                to_addr=CONTROLLER_ADDR,
+                from_addr=IC_7610_ADDR,
+                command=0xFB,
+            ),
+            generation=radio._civ_epoch,
+        )
+        assert observations == []
+
+        for value in (b"\x01", b"\x01", b"\x00"):
+            await _route_ptt(radio, value)
+        assert [item.value for item in observations] == [
+            tx.RadioTx.ON,
+            tx.RadioTx.ON,
+            tx.RadioTx.OFF,
+        ]
+        assert [item.ptt_observation_seq for item in observations] == [1, 2, 3]
+        assert {item.provider_generation for item in observations} == {7}
+
+        replaced: list[tx.ProviderPttObservation] = []
+        radio._bind_authoritative_ptt_observer(
+            provider_generation=7, observer=replaced.append
+        )
+        await _route_ptt(radio, b"\x00")
+        assert replaced[0].ptt_observation_seq == 4
+
+        rebound: list[tx.ProviderPttObservation] = []
+        radio._bind_authoritative_ptt_observer(
+            provider_generation=9, observer=rebound.append
+        )
+        await _route_ptt(radio, b"\x00")
+        assert rebound[0].provider_generation == 9
+        assert rebound[0].ptt_observation_seq == 1
+
+    @pytest.mark.asyncio
+    async def test_same_generation_rebind_off_crosses_supervisor_boundary(
+        self, radio: IcomRadio
+    ) -> None:
+        supervisor = tx.TxSafetySupervisor()
+        supervisor.replace_provider(7, ready=True)
+        radio._bind_authoritative_ptt_observer(
+            provider_generation=7, observer=supervisor.observe_ptt
+        )
+        await _route_ptt(radio, b"\x00")
+        owner = tx.TxOwner(tx.TxSource.INTERNAL, "same-generation-rebind")
+        acquired = supervisor.request_on(owner)
+        await _route_ptt(radio, b"\x01")
+        assert acquired.snapshot.lease_id is not None
+        supervisor.request_off(owner, acquired.snapshot.lease_id)
+        assert supervisor.snapshot.phase is tx.TxPhase.RELEASE_REQUIRED
+
+        radio._unbind_authoritative_ptt_observer()
+        radio._bind_authoritative_ptt_observer(
+            provider_generation=7, observer=supervisor.observe_ptt
+        )
+        await _route_ptt(radio, b"\x00")
+        assert supervisor.snapshot.phase is tx.TxPhase.IDLE
+
+    @pytest.mark.asyncio
+    async def test_ptt_authority_rejects_old_rx_pump_generation(
+        self, radio: IcomRadio, mock_transport: MockTransport
+    ) -> None:
+        observations: list[tx.ProviderPttObservation] = []
+        radio._civ_runtime.start_pump()
+        radio._civ_runtime.advance_generation("unit-test-reconnect")
+        radio._bind_authoritative_ptt_observer(
+            provider_generation=8, observer=observations.append
+        )
+        mock_transport.queue_response(_ptt_response(False))
+        await asyncio.sleep(0.01)
+        assert observations == []
+
+        await radio._civ_runtime.stop_pump()
+        radio._civ_runtime.start_pump()
+        mock_transport.queue_response(_ptt_response(False))
+        await asyncio.sleep(0.01)
+        try:
+            assert len(observations) == 1
+            assert observations[0].value is tx.RadioTx.OFF
+            assert observations[0].provider_generation == 8
+        finally:
+            await radio._civ_runtime.stop_pump()
 
 
 class TestTimeout:


### PR DESCRIPTION
## Summary

- remove optimistic IC-7610 PTT cache mutation from `set_ptt`
- emit generation-bound `ProviderPttObservation` only from exact decoded CI-V `0x1C/0x00` radio frames
- capture the RX-pump source generation so stale transport packets cannot be relabeled after reconnect
- keep PTT sequence monotonic across same-provider callback replacement/unbind/rebind; reset only for a new provider generation
- preserve legacy decoded StateStore/cache/RadioState projection

## Safety properties

- writes and ACK/NAK frames cannot emit PTT authority
- malformed, unrelated, foreign-address, unbound, and stale-generation frames cannot emit authority
- repeated same-value readbacks receive distinct PTT-only sequence numbers
- same-generation observer lifecycle preserves sequence; a genuinely new provider generation starts at sequence 1
- a fresh OFF after same-generation rebind crosses the real `TxSafetySupervisor` release boundary

## Validation

- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run mypy --strict src/rigplane/web`
- `uv run lint-imports` — 5 kept, 0 broken
- `uv run pytest tests/ --ignore=tests/integration -n auto -q --tb=short --timeout=300 --timeout-method=thread`
  - 8283 passed, 73 skipped, 11 xfailed, 1 xpassed
- 199 net LOC across 4 issue-scoped files

Linear: [MOR-1010](https://linear.app/morozsm/issue/MOR-1010/core-make-ic-7610-ptt-readback-authoritative-for-tx-safety)

Closes #1947
