### PR TITLE
refactor(#1951): canonicalize persisted presentation aliases

### DIFF
--- a/frontend/src/lib/stores/__tests__/layout.test.ts
+++ b/frontend/src/lib/stores/__tests__/layout.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const LAYOUT_KEY = 'rigplane-layout';
+const LEGACY_SKIN_KEY = 'rigplane-skin';
+
+async function loadStore() {
+  vi.resetModules();
+  return import('../layout.svelte');
+}
+
+describe('layout preference normalization', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it.each([
+    ['lcd', 'lcd-cockpit'],
+    ['amber-lcd', 'lcd-cockpit'],
+    ['spectrum', 'standard'],
+    ['desktop-v2', 'standard'],
+    ['auto', 'auto'],
+    ['lcd-cockpit', 'lcd-cockpit'],
+    ['lcd-scope', 'lcd-scope'],
+    ['standard', 'standard'],
+    ['sdr-test', 'sdr-test'],
+    ['unknown', 'auto'],
+    ['toString', 'auto'],
+    [null, 'auto'],
+  ] as const)('normalizes %s to %s', async (input, expected) => {
+    const { normalizeLayoutMode } = await loadStore();
+    expect(normalizeLayoutMode(input)).toBe(expected);
+  });
+
+  it('restores the primary layout preference before the legacy skin fallback', async () => {
+    localStorage.setItem(LAYOUT_KEY, 'lcd-scope');
+    localStorage.setItem(LEGACY_SKIN_KEY, 'amber-lcd');
+
+    const { getLayoutMode } = await loadStore();
+
+    expect(getLayoutMode()).toBe('lcd-scope');
+  });
+
+  it('restores a migrated legacy skin when no layout preference exists', async () => {
+    localStorage.setItem(LEGACY_SKIN_KEY, 'amber-lcd');
+
+    const { getLayoutMode } = await loadStore();
+
+    expect(getLayoutMode()).toBe('lcd-cockpit');
+  });
+
+  it('persists canonical values for legacy callers', async () => {
+    const { getLayoutMode, setLayoutMode } = await loadStore();
+
+    setLayoutMode('lcd');
+
+    expect(getLayoutMode()).toBe('lcd-cockpit');
+    expect(localStorage.getItem(LAYOUT_KEY)).toBe('lcd-cockpit');
+  });
+
+  it('preserves the visible cycle and no-scope fallback using canonical values', async () => {
+    const { cycleLayoutMode, getLayoutMode } = await loadStore();
+
+    cycleLayoutMode(true);
+    expect(getLayoutMode()).toBe('lcd-cockpit');
+    cycleLayoutMode(true);
+    expect(getLayoutMode()).toBe('standard');
+    cycleLayoutMode(true);
+    expect(getLayoutMode()).toBe('auto');
+
+    cycleLayoutMode(false);
+    expect(getLayoutMode()).toBe('lcd-cockpit');
+  });
+});

--- a/frontend/src/lib/stores/layout.svelte.ts
+++ b/frontend/src/lib/stores/layout.svelte.ts
@@ -1,29 +1,57 @@
 /**
  * Layout preference store.
  * 'auto'        = standard layout when any scope available (HW or audio FFT), LCD otherwise
- * 'lcd'         = force LCD layout — cockpit variant (legacy alias for 'lcd-cockpit')
+ * 'lcd'         = legacy alias for 'lcd-cockpit'
  * 'lcd-cockpit' = force LCD cockpit (TS-990S-style dual-cockpit)
  * 'lcd-scope'   = force LCD scope (IC-7300-style scope-dominant)
  * 'standard'    = force standard layout
  *
- * Legacy 'lcd' persisted values are mapped to 'lcd-cockpit' by resolveSkinId().
+ * Raw persisted aliases are normalized here before presentation policy reads
+ * the preference.
  */
 
 const STORAGE_KEY = 'rigplane-layout';
+const LEGACY_SKIN_STORAGE_KEY = 'rigplane-skin';
 
 export type LayoutMode = 'auto' | 'lcd' | 'lcd-cockpit' | 'lcd-scope' | 'standard' | 'sdr-test';
+export type CanonicalLayoutMode = Exclude<LayoutMode, 'lcd'>;
 
-let mode = $state<LayoutMode>(loadMode());
+const CANONICAL_LAYOUT_MODES = new Set<CanonicalLayoutMode>([
+  'auto',
+  'lcd-cockpit',
+  'lcd-scope',
+  'standard',
+  'sdr-test',
+]);
 
-function loadMode(): LayoutMode {
-  if (typeof window === 'undefined') return 'auto';
-  const saved = localStorage.getItem(STORAGE_KEY);
-  if (saved === 'lcd' || saved === 'lcd-cockpit' || saved === 'lcd-scope' || saved === 'standard' || saved === 'sdr-test') {
-    return saved;
+const LEGACY_LAYOUT_ALIASES: Record<string, CanonicalLayoutMode> = {
+  lcd: 'lcd-cockpit',
+  'amber-lcd': 'lcd-cockpit',
+  spectrum: 'standard',
+  'desktop-v2': 'standard',
+};
+
+export function normalizeLayoutMode(value: 'lcd' | 'amber-lcd'): 'lcd-cockpit';
+export function normalizeLayoutMode(value: 'spectrum' | 'desktop-v2'): 'standard';
+export function normalizeLayoutMode(value: unknown): CanonicalLayoutMode;
+export function normalizeLayoutMode(value: unknown): CanonicalLayoutMode {
+  if (typeof value !== 'string') return 'auto';
+  if (Object.hasOwn(LEGACY_LAYOUT_ALIASES, value)) {
+    return LEGACY_LAYOUT_ALIASES[value];
   }
-  // Migrate old 'spectrum' value to 'standard'
-  if (saved === 'spectrum') return 'standard';
+  if (CANONICAL_LAYOUT_MODES.has(value as CanonicalLayoutMode)) {
+    return value as CanonicalLayoutMode;
+  }
   return 'auto';
+}
+
+let mode = $state<CanonicalLayoutMode>(loadMode());
+
+function loadMode(): CanonicalLayoutMode {
+  if (typeof window === 'undefined') return 'auto';
+  const saved = localStorage.getItem(STORAGE_KEY)
+    ?? localStorage.getItem(LEGACY_SKIN_STORAGE_KEY);
+  return normalizeLayoutMode(saved);
 }
 
 export function getLayoutMode(): LayoutMode {
@@ -31,21 +59,21 @@ export function getLayoutMode(): LayoutMode {
 }
 
 export function setLayoutMode(m: LayoutMode): void {
-  mode = m;
+  mode = normalizeLayoutMode(m);
   if (typeof window !== 'undefined') {
-    localStorage.setItem(STORAGE_KEY, m);
+    localStorage.setItem(STORAGE_KEY, mode);
   }
 }
 
 export function cycleLayoutMode(hasAnyScope: boolean): void {
   if (hasAnyScope) {
-    // auto → lcd → standard → auto
-    const order: LayoutMode[] = ['auto', 'lcd', 'standard'];
+    // auto → LCD cockpit → standard → auto
+    const order: CanonicalLayoutMode[] = ['auto', 'lcd-cockpit', 'standard'];
     const idx = order.indexOf(mode);
     setLayoutMode(order[(idx + 1) % order.length]);
   } else {
     // No scope at all: always LCD, no toggle needed
-    setLayoutMode('lcd');
+    setLayoutMode('lcd-cockpit');
   }
 }
 

--- a/frontend/src/skins/registry.ts
+++ b/frontend/src/skins/registry.ts
@@ -9,7 +9,10 @@
 
 import type { Component } from 'svelte';
 import type { Capabilities } from '$lib/types/capabilities';
-import type { LayoutMode } from '$lib/stores/layout.svelte';
+import {
+  normalizeLayoutMode,
+  type LayoutMode,
+} from '$lib/stores/layout.svelte';
 
 export type SkinId = 'desktop-v2' | 'lcd-cockpit' | 'lcd-scope' | 'mobile' | 'sdr-test';
 
@@ -39,10 +42,11 @@ export interface SkinResolutionContext {
  */
 export function resolveSkinId(ctx: SkinResolutionContext): SkinId {
   if (ctx.isMobile) return 'mobile';
-  if (ctx.layoutPreference === 'sdr-test') return 'sdr-test';
-  if (ctx.layoutPreference === 'lcd' || ctx.layoutPreference === 'lcd-cockpit') return 'lcd-cockpit';
-  if (ctx.layoutPreference === 'lcd-scope') return 'lcd-scope';
-  if (ctx.layoutPreference === 'standard') return 'desktop-v2';
+  const layoutPreference = normalizeLayoutMode(ctx.layoutPreference);
+  if (layoutPreference === 'sdr-test') return 'sdr-test';
+  if (layoutPreference === 'lcd-cockpit') return 'lcd-cockpit';
+  if (layoutPreference === 'lcd-scope') return 'lcd-scope';
+  if (layoutPreference === 'standard') return 'desktop-v2';
   // auto: scope available → desktop, otherwise LCD
   return ctx.hasAnyScope ? 'desktop-v2' : 'lcd-cockpit';
 }
@@ -72,7 +76,7 @@ const SKIN_LOADERS: Record<SkinId, () => Promise<{ default: Component }>> = {
  * preferences.
  */
 export function resolvePersistedSkinId(id: PersistedSkinId): SkinId {
-  if (id === 'amber-lcd') return 'lcd-cockpit';
+  if (id === 'amber-lcd') return normalizeLayoutMode(id);
   return id;
 }
 


### PR DESCRIPTION
Closes #1951
Linear: [MOR-1042](https://linear.app/morozsm/issue/MOR-1042/canonicalize-persisted-presentation-aliases-at-the-layout-store)
Parent: [MOR-981](https://linear.app/morozsm/issue/MOR-981/establish-the-app-presentation-selection-seam)

## What changed

- made the layout store the authoritative normalization boundary for raw
  presentation preferences
- canonicalized `lcd` / `amber-lcd` to `lcd-cockpit` and `spectrum` /
  `desktop-v2` to `standard`
- restored migrated `rigplane-skin` only when `rigplane-layout` is absent
- persisted canonical values and preserved the visible layout cycle
- made registry resolution reuse the same normalizer
- added focused persistence, precedence, alias, unknown-value, and cycle tests

## Compatibility

No visual or selection-policy change for current values. Mobile remains
viewport-owned. No `main.ts`, App, RadioLayout, entrypoint, lazy-loading,
mount-topology, runtime, transport, backend, CLI, config-schema, or wire change.
Existing legacy browser storage remains readable and is not destructively
rewritten.

## Scope

Exactly 3 files, +126/-21 (net +105 LOC).

## Verification

- red-before: focused test produced 14 expected failures before implementation
- focused: 70 passed
- full frontend: 2286 passed
- `npm run check`: 0 errors / 0 warnings
- `npm run lint`: passed
- `npm run build`: passed (existing chunk-size and mixed-import warnings only)
- `uv run ruff check src/ tests/`: passed
- `uv run pytest tests/ -q --tb=short`: 8543 passed, 129 skipped,
  5 deselected, 11 xfailed, 1 xpassed
- `git diff --check`: passed
