### PR TITLE
Core: add backend-neutral TxTarget StateStore contract

### DIFF
--- a/src/rigplane/core/state_pipeline_contracts.py
+++ b/src/rigplane/core/state_pipeline_contracts.py
@@ -11,6 +11,8 @@ from dataclasses import dataclass
 from enum import StrEnum
 from typing import Any, Literal, cast, get_args
 
+from rigplane.core.tx_target import tx_target_from_dict, validate_tx_target
+
 __all__ = [
     "CapabilityMetadata",
     "ChangeSet",
@@ -71,6 +73,7 @@ _COMMAND_SOURCES: frozenset[str] = frozenset(get_args(CommandSource))
 _COMMAND_PRIORITIES: frozenset[str] = frozenset(get_args(CommandPriority))
 _PENDING_POLICIES: frozenset[str] = frozenset(get_args(PendingPolicy))
 _COMMAND_STATES: frozenset[str] = frozenset(get_args(CommandLifecycleState))
+_TX_TARGET_PATH = "global.tx_state.tx_target"
 
 
 class FieldScope(StrEnum):
@@ -642,11 +645,23 @@ class Observation:
             raise ValueError("max_age must be non-negative")
         for item in self.quality:
             _validate_token(item, label="quality")
+        if str(self.path) == _TX_TARGET_PATH:
+            target = (
+                tx_target_from_dict(self.value)
+                if isinstance(self.value, Mapping)
+                else validate_tx_target(self.value)
+            )
+            object.__setattr__(self, "value", target)
 
     def to_dict(self) -> dict[str, Any]:
+        value = (
+            validate_tx_target(self.value).to_dict()
+            if str(self.path) == _TX_TARGET_PATH
+            else self.value
+        )
         return {
             "path": str(self.path),
-            "value": self.value,
+            "value": value,
             "source": self.source.to_dict(),
             "timestampMonotonic": self.timestamp_monotonic,
             "quality": list(self.quality),
@@ -1110,6 +1125,7 @@ def _global_specs() -> tuple[FieldSpec, ...]:
         )
 
     return (
+        spec(FieldPath.global_("tx_state", "tx_target"), "object"),
         spec(FieldPath.global_("tx_state", "ptt"), "bool", writable=True),
         spec(FieldPath.global_("tx_state", "power_on"), "bool", writable=True),
         spec(FieldPath.global_("tx_state", "rit_on"), "bool", writable=True),

--- a/src/rigplane/core/tx_target.py
+++ b/src/rigplane/core/tx_target.py
@@ -1,0 +1,96 @@
+"""Backend-neutral transmit-target state values."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, ClassVar, Literal, cast
+
+TxReceiver = Literal["MAIN", "SUB"]
+TxSlot = Literal["A", "B"]
+TxTargetUnknownReason = Literal[
+    "not-observed",
+    "stale",
+    "unsupported",
+    "contradiction",
+]
+
+_RECEIVERS = frozenset(("MAIN", "SUB"))
+_SLOTS = frozenset(("A", "B"))
+_UNKNOWN_REASONS = frozenset(("not-observed", "stale", "unsupported", "contradiction"))
+_KNOWN_KEYS = frozenset(("status", "receiver", "slot", "frequencyHz"))
+_UNKNOWN_KEYS = frozenset(("status", "reason"))
+
+
+@dataclass(frozen=True, slots=True)
+class KnownTxTarget:
+    status: ClassVar[Literal["known"]] = "known"
+    receiver: TxReceiver
+    slot: TxSlot | None
+    frequency_hz: int | None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.receiver, str) or self.receiver not in _RECEIVERS:
+            raise ValueError(f"invalid TX target receiver: {self.receiver!r}")
+        if self.slot is not None and (
+            not isinstance(self.slot, str) or self.slot not in _SLOTS
+        ):
+            raise ValueError(f"invalid TX target slot: {self.slot!r}")
+        frequency = self.frequency_hz
+        if frequency is not None and (
+            not isinstance(frequency, int)
+            or isinstance(frequency, bool)
+            or frequency <= 0
+        ):
+            raise ValueError(
+                "TX target frequency_hz must be a positive integer or None"
+            )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "status": self.status,
+            "receiver": self.receiver,
+            "slot": self.slot,
+            "frequencyHz": self.frequency_hz,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class UnknownTxTarget:
+    status: ClassVar[Literal["unknown"]] = "unknown"
+    reason: TxTargetUnknownReason
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.reason, str) or self.reason not in _UNKNOWN_REASONS:
+            raise ValueError(f"invalid unknown TX target reason: {self.reason!r}")
+
+    def to_dict(self) -> dict[str, object]:
+        return {"status": self.status, "reason": self.reason}
+
+
+TxTarget = KnownTxTarget | UnknownTxTarget
+
+
+def tx_target_from_dict(value: Mapping[str, Any]) -> TxTarget:
+    status = value.get("status")
+    if status == "known":
+        if frozenset(value) != _KNOWN_KEYS:
+            raise ValueError("known TX target must contain only its canonical fields")
+        return KnownTxTarget(
+            receiver=cast(TxReceiver, value["receiver"]),
+            slot=cast(TxSlot | None, value["slot"]),
+            frequency_hz=cast(int | None, value["frequencyHz"]),
+        )
+    if status == "unknown":
+        if frozenset(value) != _UNKNOWN_KEYS:
+            raise ValueError("unknown TX target must contain only status and reason")
+        return UnknownTxTarget(
+            reason=cast(TxTargetUnknownReason, value["reason"]),
+        )
+    raise ValueError(f"invalid TX target status: {status!r}")
+
+
+def validate_tx_target(value: object) -> TxTarget:
+    if not isinstance(value, (KnownTxTarget, UnknownTxTarget)):
+        raise TypeError("TX target observation value must be a TxTarget")
+    return value

--- a/tests/test_state_pipeline_contracts.py
+++ b/tests/test_state_pipeline_contracts.py
@@ -3,11 +3,17 @@
 from __future__ import annotations
 
 import json
+from dataclasses import FrozenInstanceError
 from typing import Any
 
 import pytest
 
 from rigplane.core.state_store import StateSnapshot, StateStore
+from rigplane.core.tx_target import (
+    KnownTxTarget,
+    UnknownTxTarget,
+    tx_target_from_dict,
+)
 from rigplane.core.state_pipeline_contracts import (
     CapabilityMetadata,
     DEFAULT_FIELD_REGISTRY,
@@ -245,6 +251,86 @@ def test_default_registry_contains_representative_state_families() -> None:
         DEFAULT_FIELD_REGISTRY.require(examples["volume"]).family
         is FieldFamily.OPERATOR_CONTROLS
     )
+
+
+def test_tx_target_values_are_immutable_and_serialize_exactly() -> None:
+    known = KnownTxTarget(receiver="SUB", slot="B", frequency_hz=14_074_000)
+    unknown = UnknownTxTarget(reason="contradiction")
+
+    assert known.to_dict() == {
+        "status": "known",
+        "receiver": "SUB",
+        "slot": "B",
+        "frequencyHz": 14_074_000,
+    }
+    assert unknown.to_dict() == {"status": "unknown", "reason": "contradiction"}
+    assert tx_target_from_dict(known.to_dict()) == known
+    assert tx_target_from_dict(unknown.to_dict()) == unknown
+    with pytest.raises(FrozenInstanceError):
+        known.receiver = "MAIN"  # type: ignore[misc]
+
+
+@pytest.mark.parametrize(  # type: ignore[untyped-decorator]
+    "kwargs",
+    [
+        {"receiver": "main", "slot": None, "frequency_hz": None},
+        {"receiver": "MAIN", "slot": "C", "frequency_hz": None},
+        {"receiver": "MAIN", "slot": None, "frequency_hz": True},
+        {"receiver": "MAIN", "slot": None, "frequency_hz": 0},
+        {"receiver": "MAIN", "slot": None, "frequency_hz": -1},
+        {"receiver": "MAIN", "slot": None, "frequency_hz": 14_074_000.0},
+        {"receiver": "MAIN", "slot": None, "frequency_hz": float("inf")},
+    ],
+)
+def test_known_tx_target_rejects_invalid_values(kwargs: dict[str, object]) -> None:
+    with pytest.raises(ValueError):
+        KnownTxTarget(**kwargs)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(  # type: ignore[untyped-decorator]
+    "payload",
+    [
+        {"status": "unknown", "reason": "missing"},
+        {"status": "unknown", "reason": "stale", "receiver": "MAIN"},
+        {
+            "status": "known",
+            "receiver": "MAIN",
+            "slot": None,
+            "frequencyHz": None,
+            "backend": "icom",
+        },
+        {"status": "known", "receiver": "MAIN", "slot": None},
+        {"status": "other"},
+    ],
+)
+def test_tx_target_decoder_rejects_invalid_or_extra_fields(
+    payload: dict[str, object],
+) -> None:
+    with pytest.raises(ValueError):
+        tx_target_from_dict(payload)
+
+
+def test_tx_target_registry_and_observation_contract() -> None:
+    path = FieldPath.global_("tx_state", "tx_target")
+    spec = DEFAULT_FIELD_REGISTRY.require(path)
+    target = KnownTxTarget(receiver="MAIN", slot=None, frequency_hz=None)
+    store = StateStore()
+
+    assert spec.family is FieldFamily.TX_STATE
+    assert spec.value_type == "object"
+    assert spec.readable is True
+    assert spec.writable is False
+
+    observation = _store_observation(path, target, at=1.0)
+    store.apply(observation)
+    assert store.snapshot().field(path).value == target
+    assert Observation.from_dict(observation.to_dict()) == observation
+
+    decoded = _store_observation(path, target.to_dict(), at=2.0)
+    assert decoded.value == target
+
+    with pytest.raises(ValueError, match="canonical fields"):
+        _store_observation(path, {**target.to_dict(), "backend": "icom"}, at=3.0)
 
 
 def test_global_dial_lock_registered_as_tx_state_bool() -> None:


### PR DESCRIPTION
## Summary

- add immutable backend-neutral `KnownTxTarget` and `UnknownTxTarget` values
- enforce the exact known/unknown serialization shapes and reject non-canonical fields
- register read-only `global.tx_state.tx_target` and canonicalize observations before StateStore storage

Linear: [MOR-1047](https://linear.app/morozsm/issue/MOR-1047/define-backend-neutral-txtarget-domain-and-statestore-contract)

Closes #1955

## Contract

- known: `receiver=MAIN|SUB`, `slot=A|B|null`, `frequencyHz=positive integer|null`
- unknown: `reason=not-observed|stale|unsupported|contradiction`
- no provider acquisition, capability, Web/frontend, TX executor, vendor, split, or selected-RX changes

## Verification

- red-first focused test failed before the domain module existed
- `uv run pytest tests/test_state_pipeline_contracts.py -q --tb=short` — 200 passed
- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 8300 passed, 73 skipped, 5 deselected, 11 xfailed, 1 xpassed
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run mypy src/rigplane/core/tx_target.py src/rigplane/core/state_pipeline_contracts.py`
- `uv run lint-imports`
- `git diff --check`

Full `uv run mypy src/` still reports 13 pre-existing errors in unrelated runtime files; the two changed source files pass mypy.

## Guardrails

- exactly 3 files changed
- 199 insertions, 1 deletion: 198 net LOC
- draft only; independent review required before merge
