### PR TITLE
Web: stage strict public TxTarget schema and generated union

### DIFF
--- a/frontend/src/lib/types/state.ts
+++ b/frontend/src/lib/types/state.ts
@@ -77,6 +77,7 @@ export interface ServerStatePublic {
     [k: string]: number;
   }[];
   scopeControls?: ScopeControlsPublic;
+  txTarget?: KnownTxTargetPublic | UnknownTxTargetPublic;
   main: ReceiverStatePublic;
   sub?: ReceiverStatePublic | null;
   connection: ConnectionPublic;
@@ -114,6 +115,22 @@ export interface FixedEdgePublic {
   edge: number;
   startHz: number;
   endHz: number;
+}
+/**
+ * Fresh backend-neutral transmit-target identity.
+ */
+export interface KnownTxTargetPublic {
+  status: "known";
+  receiver: "MAIN" | "SUB";
+  slot: ("A" | "B") | null;
+  frequencyHz: number | null;
+}
+/**
+ * Fail-closed transmit target when current identity is unavailable.
+ */
+export interface UnknownTxTargetPublic {
+  status: "unknown";
+  reason: "not-observed" | "stale" | "unsupported" | "contradiction";
 }
 /**
  * Per-receiver (``main`` / ``sub``) public state.

--- a/src/rigplane/web/state_schema.py
+++ b/src/rigplane/web/state_schema.py
@@ -28,7 +28,7 @@ live request path.
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Annotated, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -38,6 +38,9 @@ __all__ = [
     "FixedEdgePublic",
     "ScopeControlsPublic",
     "FieldStatusPublic",
+    "KnownTxTargetPublic",
+    "UnknownTxTargetPublic",
+    "TxTargetPublic",
     "ConnectionPublic",
     "RadioHealthPublic",
     "RadioDetailPublic",
@@ -184,6 +187,33 @@ class FieldStatusPublic(_Strict):
     quality: list[str] = Field(default_factory=list)
 
 
+class KnownTxTargetPublic(_Strict):
+    """Fresh backend-neutral transmit-target identity."""
+
+    status: Literal["known"]
+    receiver: Literal["MAIN", "SUB"]
+    slot: Literal["A", "B"] | None
+    frequencyHz: Annotated[int, Field(strict=True, gt=0)] | None
+
+
+class UnknownTxTargetPublic(_Strict):
+    """Fail-closed transmit target when current identity is unavailable."""
+
+    status: Literal["unknown"] = "unknown"
+    reason: Literal[
+        "not-observed",
+        "stale",
+        "unsupported",
+        "contradiction",
+    ]
+
+
+TxTargetPublic = Annotated[
+    KnownTxTargetPublic | UnknownTxTargetPublic,
+    Field(discriminator="status"),
+]
+
+
 class ConnectionPublic(_Strict):
     """Synthetic connection object injected from the backend connection scalars."""
 
@@ -305,6 +335,12 @@ class ServerStatePublic(_Strict):
     data3ModInput: int | None = None
     txBandEdges: list[dict[str, int]] = Field(default_factory=list)
     scopeControls: ScopeControlsPublic
+    # Additive staging field: both producers publish it in MOR-1106, after
+    # which MOR-1107 makes it required. The non-null default keeps current
+    # producer payloads conformant while explicit ``null`` still fails.
+    txTarget: TxTargetPublic = Field(
+        default_factory=lambda: UnknownTxTargetPublic(reason="not-observed")
+    )
 
     # Receivers. ``sub`` is dropped from the payload when ``receiver_count < 2``.
     main: ReceiverStatePublic

--- a/tests/web/test_state_schema_conformance.py
+++ b/tests/web/test_state_schema_conformance.py
@@ -68,6 +68,123 @@ def test_dataclass_path_conforms(receiver_count: int) -> None:
     ServerStatePublic.model_validate(payload)
 
 
+@pytest.mark.parametrize(
+    "tx_target",
+    [
+        {
+            "status": "known",
+            "receiver": "MAIN",
+            "slot": None,
+            "frequencyHz": None,
+        },
+        {
+            "status": "known",
+            "receiver": "SUB",
+            "slot": "B",
+            "frequencyHz": 14_074_000,
+        },
+        {"status": "unknown", "reason": "not-observed"},
+        {"status": "unknown", "reason": "stale"},
+        {"status": "unknown", "reason": "unsupported"},
+        {"status": "unknown", "reason": "contradiction"},
+    ],
+)
+def test_public_tx_target_schema_accepts_exact_canonical_shapes(
+    tx_target: dict[str, object],
+) -> None:
+    payload = build_public_state_payload(
+        RadioState(),
+        radio=None,
+        revision=7,
+        receiver_count=2,
+    )
+    payload["txTarget"] = tx_target
+
+    validated = ServerStatePublic.model_validate(payload)
+
+    assert validated.txTarget is not None
+    assert validated.txTarget.model_dump() == tx_target
+
+
+@pytest.mark.parametrize(
+    "tx_target",
+    [
+        None,
+        {"status": "other"},
+        {
+            "status": "known",
+            "receiver": "main",
+            "slot": None,
+            "frequencyHz": None,
+        },
+        {
+            "status": "known",
+            "receiver": "MAIN",
+            "slot": "a",
+            "frequencyHz": None,
+        },
+        {
+            "status": "known",
+            "receiver": "MAIN",
+            "slot": None,
+            "frequencyHz": True,
+        },
+        {
+            "status": "known",
+            "receiver": "MAIN",
+            "slot": None,
+            "frequencyHz": 0,
+        },
+        {
+            "status": "known",
+            "receiver": "MAIN",
+            "slot": None,
+            "frequencyHz": -1,
+        },
+        {
+            "status": "known",
+            "receiver": "MAIN",
+            "slot": None,
+            "frequencyHz": 14_074_000.0,
+        },
+        {
+            "status": "known",
+            "receiver": "MAIN",
+            "slot": None,
+            "frequencyHz": float("nan"),
+        },
+        {
+            "status": "known",
+            "receiver": "MAIN",
+            "slot": None,
+            "frequencyHz": float("inf"),
+        },
+        {
+            "status": "known",
+            "receiver": "MAIN",
+            "slot": None,
+            "frequencyHz": None,
+            "backend": "icom",
+        },
+        {"status": "unknown", "reason": "missing"},
+        {"status": "unknown", "reason": "stale", "receiver": "MAIN"},
+    ],
+)
+def test_public_tx_target_schema_rejects_noncanonical_shapes(
+    tx_target: object,
+) -> None:
+    payload = build_public_state_payload(
+        RadioState(),
+        radio=None,
+        revision=7,
+        receiver_count=2,
+    )
+    payload["txTarget"] = tx_target
+
+    with pytest.raises(ValueError):
+        ServerStatePublic.model_validate(payload)
+
+
 @pytest.mark.parametrize("receiver_count", [1, 2])
 def test_snapshot_path_conforms(receiver_count: int) -> None:
     """``build_public_state_payload_from_snapshot`` validates.


### PR DESCRIPTION
## Summary

- define the strict public `KnownTxTargetPublic` / `UnknownTxTargetPublic` discriminated union
- expose additive optional, explicitly non-null `txTarget` in `ServerStatePublic` during staged migration
- regenerate the frontend generated contract and add a strict acceptance/rejection matrix

Linear: [MOR-1105](https://linear.app/morozsm/issue/MOR-1105/stage-strict-public-txtarget-schema-and-generated-frontend-union)
Parent: [MOR-1051](https://linear.app/morozsm/issue/MOR-1051/project-fresh-txtarget-through-canonical-public-state-schema)

Closes #1960

## Staging boundary

This PR intentionally does not change runtime producers. MOR-1106 will make both producer paths emit freshness-aware `txTarget`; MOR-1107 will then make the top-level field required. This decomposition preserves the repository three-file guardrail without dropping committed tests.

## Contract

- known: `MAIN|SUB`, `A|B|null`, strict positive integer `frequencyHz|null`
- unknown: `not-observed|stale|unsupported|contradiction`
- extra fields, invalid discriminants, bool/zero/negative/float/non-finite frequencies, and explicit top-level null are rejected
- no provider/model/split/selected-RX, capability, selector, component, or TX lifecycle logic

## Verification

- red-first focused run: 6 expected failures before schema implementation
- `uv run pytest tests/web/test_state_schema_conformance.py -q --tb=short` — 24 passed
- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 8319 passed, 73 skipped, 5 deselected, 11 xfailed, 1 xpassed
- `uv run python scripts/gen_state_types.py --check`
- `NODE_OPTIONS=--no-experimental-webstorage npm --prefix frontend run check` — 0 errors/warnings
- `NODE_OPTIONS=--no-experimental-webstorage npm --prefix frontend test` — 2286 passed
- `npm --prefix frontend run lint`
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run mypy --strict src/rigplane/web/state_schema.py`
- `uv run lint-imports` — 5 contracts kept
- `git diff --check`

## Guardrails

- exactly 3 files changed
- 171 insertions, 1 deletion: 170 net LOC
- draft only; independent exact-head review required before merge