### PR TITLE
test(web): declare TX facts for transcoder fixture

### DIFF
--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1884,7 +1884,8 @@ class TestAudioHandlerTxTranscoderRate:
 
         mock_ws = MagicMock(spec=WebSocketConnection)
         mock_radio = MagicMock(spec=AudioCapable)
-        mock_radio.capabilities = {"audio"}
+        mock_radio.capabilities = {"audio", "tx"}
+        mock_radio.backend_id = "yaesu_cat"
         if sample_rate is None:
             # Simulate a radio that does not expose audio_sample_rate
             del mock_radio.audio_sample_rate


### PR DESCRIPTION
## Summary

- make the positive TX transcoder-rate fixture advertise canonical `audio` + `tx`
- declare the Yaesu-style USB route matching its legacy Opus transport
- keep production behavior unchanged

Closes #1964
Prerequisite for #1958 / Linear MOR-1050.

## Verification

- `uv run pytest tests/test_web_server.py::TestAudioHandlerTxTranscoderRate -q --tb=short` (4 passed)
- focused Ruff check and format check
- `git diff --check`
