### PR TITLE
fix: bind exact CI-V data transaction futures

### DIFF
--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -159,12 +159,13 @@ class RawCivTransactionResult:
     frame_bytes: bytes | None = None
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(slots=True)
 class _CivDataTransaction:
-    """Exact tracker futures owned by one data-returning CI-V request."""
+    """Exact tracker state owned by one data-returning CI-V request."""
 
     response: asyncio.Future[CivFrame]
     nak: asyncio.Future[CivFrame]
+    frame: CivFrame | None = None
 
     @property
     def futures(self) -> tuple[asyncio.Future[CivFrame], ...]:
@@ -551,6 +552,7 @@ class CivRuntime:
         self._ptt_observer_civ_generation: int | None = None
         self._ptt_observation_seq = 0
         self._active_rx_source_generation: int | None = None
+        self._civ_data_transaction: _CivDataTransaction | None = None
 
     # ------------------------------------------------------------------
     # Public API (design doc)
@@ -731,7 +733,13 @@ class CivRuntime:
             )
             if not done:
                 raise asyncio.TimeoutError("CI-V response timed out")
-            frame = next(iter(done)).result()
+            if data_transaction is not None:
+                frame = data_transaction.frame
+                if frame is None:
+                    data_transaction.response.result()
+                    frame = data_transaction.nak.result()
+            else:
+                frame = pending_waiters[0].result()
         except asyncio.TimeoutError:
             self._host._civ_request_tracker.note_timeout()
             logger.debug(
@@ -763,6 +771,8 @@ class CivRuntime:
         self, request_key: CivRequestKey
     ) -> _CivDataTransaction:
         """Register exact response and NAK identities for one data request."""
+        if self._civ_data_transaction is not None:
+            raise RuntimeError("CI-V data transaction already active")
         tracker = self._host._civ_request_tracker
         response = tracker.register_response(request_key)
         nak_or_token = tracker.register_ack(
@@ -774,14 +784,36 @@ class CivRuntime:
             tracker.unregister(response)
             response.cancel()
             raise RuntimeError("ACK waiter registration returned sink token")
-        return _CivDataTransaction(response=response, nak=nak_or_token)
+        transaction = _CivDataTransaction(response=response, nak=nak_or_token)
+        self._civ_data_transaction = transaction
+        return transaction
 
     def _close_civ_data_transaction(self, transaction: _CivDataTransaction) -> None:
-        """Atomically detach and settle both futures owned by a transaction."""
+        """Idempotently detach and settle every future without yielding."""
+        if self._civ_data_transaction is transaction:
+            self._civ_data_transaction = None
         for future in transaction.futures:
             self._host._civ_request_tracker.unregister(future)
             if not future.done():
                 future.cancel()
+
+    def _claim_civ_data_transaction(self, event: CivEvent) -> None:
+        """Synchronously claim the first routed response or NAK."""
+        transaction = self._civ_data_transaction
+        if transaction is None or event.type == CivEventType.ACK:
+            return
+        winner = (
+            transaction.nak if event.type == CivEventType.NAK else transaction.response
+        )
+        if winner.cancelled() or not winner.done():
+            return
+        try:
+            frame = winner.result()
+        except Exception:
+            return
+        if frame is event.frame:
+            transaction.frame = frame
+            self._close_civ_data_transaction(transaction)
 
     async def send_civ_raw(
         self,
@@ -1202,7 +1234,8 @@ class CivRuntime:
             )
             self._update_state_cache_from_frame(frame)
         self._publish_civ_event(event)
-        self._host._civ_request_tracker.resolve(event, generation=generation)
+        if self._host._civ_request_tracker.resolve(event, generation=generation):
+            self._claim_civ_data_transaction(event)
 
     def _emit_authoritative_ptt(
         self, frame: CivFrame, *, source_generation: int

--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -18,6 +18,7 @@ from rigplane.core.acquisition_scheduler import (
 from rigplane.core.civ import (
     CivEvent,
     CivEventType,
+    CivRequestKey,
     iter_civ_frames,
     request_key_from_frame,
 )
@@ -156,6 +157,18 @@ class RawCivTransactionResult:
     status: RawCivTransactionStatus
     frame: CivFrame | None = None
     frame_bytes: bytes | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _CivDataTransaction:
+    """Exact tracker futures owned by one data-returning CI-V request."""
+
+    response: asyncio.Future[CivFrame]
+    nak: asyncio.Future[CivFrame]
+
+    @property
+    def futures(self) -> tuple[asyncio.Future[CivFrame], ...]:
+        return (self.response, self.nak)
 
 
 _CMD14_RECEIVER_LEVEL_FIELDS = {
@@ -692,6 +705,7 @@ class CivRuntime:
             raise asyncio.TimeoutError("CI-V response timed out")
 
         pending_waiters: list[asyncio.Future[CivFrame]] = []
+        data_transaction: _CivDataTransaction | None = None
         try:
             if expect == "ack":
                 pending_or_token = self._host._civ_request_tracker.register_ack(
@@ -702,17 +716,8 @@ class CivRuntime:
                     raise RuntimeError("ACK waiter registration returned sink token")
                 pending_waiters.append(pending_or_token)
             else:
-                pending_waiters.append(
-                    self._host._civ_request_tracker.register_response(request_key)
-                )
-                nak_pending_or_token = self._host._civ_request_tracker.register_ack(
-                    wait=True,
-                    consume_backlog=False,
-                    nak_only=True,
-                )
-                if isinstance(nak_pending_or_token, int):
-                    raise RuntimeError("ACK waiter registration returned sink token")
-                pending_waiters.append(nak_pending_or_token)
+                data_transaction = self._register_civ_data_transaction(request_key)
+                pending_waiters.extend(data_transaction.futures)
 
             self.start_pump()
             await self._send_civ_frame_now(civ_frame)
@@ -735,8 +740,11 @@ class CivRuntime:
             )
             raise asyncio.TimeoutError("CI-V response timed out") from None
         finally:
-            for pending in pending_waiters:
-                self._host._civ_request_tracker.unregister(pending)
+            if data_transaction is not None:
+                self._close_civ_data_transaction(data_transaction)
+            else:
+                for pending in pending_waiters:
+                    self._host._civ_request_tracker.unregister(pending)
 
         if frame.command == 0xFA:
             status: RawCivTransactionStatus = "nak"
@@ -750,6 +758,30 @@ class CivRuntime:
             frame_bytes=self._take_raw_received_frame_bytes(frame)
             or self._civ_frame_to_bytes(frame),
         )
+
+    def _register_civ_data_transaction(
+        self, request_key: CivRequestKey
+    ) -> _CivDataTransaction:
+        """Register exact response and NAK identities for one data request."""
+        tracker = self._host._civ_request_tracker
+        response = tracker.register_response(request_key)
+        nak_or_token = tracker.register_ack(
+            wait=True,
+            consume_backlog=False,
+            nak_only=True,
+        )
+        if isinstance(nak_or_token, int):
+            tracker.unregister(response)
+            response.cancel()
+            raise RuntimeError("ACK waiter registration returned sink token")
+        return _CivDataTransaction(response=response, nak=nak_or_token)
+
+    def _close_civ_data_transaction(self, transaction: _CivDataTransaction) -> None:
+        """Atomically detach and settle both futures owned by a transaction."""
+        for future in transaction.futures:
+            self._host._civ_request_tracker.unregister(future)
+            if not future.done():
+                future.cancel()
 
     async def send_civ_raw(
         self,

--- a/tests/test_raw_civ_transaction.py
+++ b/tests/test_raw_civ_transaction.py
@@ -317,32 +317,37 @@ async def test_raw_civ_transaction_session_releases_on_cancellation(
     assert radio._civ_request_tracker.timeout_count == 0
 
 
-async def test_data_transaction_nak_token_cannot_be_resurrected(
+@pytest.mark.parametrize(
+    ("first", "late", "expected"),
+    [(_ptt(), _nak(), "response"), (_nak(), _ptt(), "nak")],
+)
+@pytest.mark.parametrize("close_between", [False, True])
+async def test_data_transaction_first_terminal_frame_wins(
     radio: IcomRadio,
+    monkeypatch: pytest.MonkeyPatch,
+    first: bytes,
+    late: bytes,
+    expected: str,
+    close_between: bool,
 ) -> None:
-    observations = []
-    radio._civ_runtime.bind_ptt_observer(
-        provider_generation=1, observer=observations.append
+    runtime = radio._civ_runtime
+    captured = _capture_data_transaction(radio, monkeypatch)
+    task = asyncio.create_task(
+        radio.send_civ_transaction(0x1C, sub=0x00, expect="data", timeout=1.0)
     )
-    request = parse_civ_frame(
-        build_civ_frame(IC_7610_ADDR, CONTROLLER_ADDR, 0x1C, sub=0x00)
-    )
-    transaction = radio._civ_runtime._register_civ_data_transaction(
-        request_key_from_frame(request)
-    )
-
-    await radio._civ_runtime._route_civ_frame(
-        parse_civ_frame(_nak()), generation=radio._civ_epoch
-    )
-    assert transaction.nak.done()
-    radio._civ_runtime._close_civ_data_transaction(transaction)
-    assert transaction.response.cancelled()
-
-    await radio._civ_runtime._route_civ_frame(
-        parse_civ_frame(_ptt()), generation=radio._civ_epoch
-    )
-    assert transaction.response.cancelled()
-    assert len(observations) == 1
+    while not captured:
+        await asyncio.sleep(0)
+    await runtime._route_civ_frame(parse_civ_frame(first), generation=radio._civ_epoch)
+    if close_between:
+        runtime._close_civ_data_transaction(captured[0])
+    await runtime._route_civ_frame(parse_civ_frame(late), generation=radio._civ_epoch)
+    result = await task
+    response, nak = captured[0].response, captured[0].nak
+    winner, loser = (response, nak) if expected == "response" else (nak, response)
+    assert result.status == expected
+    assert result.frame_bytes == first
+    assert winner.done() and not winner.cancelled()
+    assert loser.cancelled()
 
 
 async def test_data_transaction_identity_does_not_steal_older_same_command(
@@ -357,6 +362,8 @@ async def test_data_transaction_identity_does_not_steal_older_same_command(
     )
     older = radio._civ_request_tracker.register_response(key)
     transaction = radio._civ_runtime._register_civ_data_transaction(key)
+    with pytest.raises(RuntimeError, match="already active"):
+        radio._civ_runtime._register_civ_data_transaction(key)
 
     await radio._civ_runtime._route_civ_frame(
         parse_civ_frame(_ptt()), generation=radio._civ_epoch

--- a/tests/test_raw_civ_transaction.py
+++ b/tests/test_raw_civ_transaction.py
@@ -12,11 +12,13 @@ from rigplane.commands import CONTROLLER_ADDR, build_civ_frame, parse_civ_frame
 from rigplane.core.civ import (
     CivEvent,
     CivEventType,
+    CivRequestKey,
     CivRequestTracker,
     request_key_from_frame,
 )
 from rigplane.core.exceptions import ConnectionError as RigplaneConnectionError
 from rigplane.radio import IcomRadio
+from rigplane.runtime._civ_rx import _CivDataTransaction
 from rigplane.types import bcd_encode
 
 
@@ -45,6 +47,29 @@ def _ack() -> bytes:
 
 def _nak() -> bytes:
     return build_civ_frame(CONTROLLER_ADDR, IC_7610_ADDR, 0xFA)
+
+
+def _ptt(value: int = 0) -> bytes:
+    return build_civ_frame(
+        CONTROLLER_ADDR, IC_7610_ADDR, 0x1C, sub=0x00, data=bytes([value])
+    )
+
+
+def _capture_data_transaction(
+    radio: IcomRadio,
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[_CivDataTransaction]:
+    captured: list[_CivDataTransaction] = []
+    runtime = radio._civ_runtime
+    register = runtime._register_civ_data_transaction
+
+    def capture(key: CivRequestKey) -> _CivDataTransaction:
+        transaction = register(key)
+        captured.append(transaction)
+        return transaction
+
+    monkeypatch.setattr(runtime, "_register_civ_data_transaction", capture)
+    return captured
 
 
 async def test_raw_civ_transaction_ack_success_releases_owner(
@@ -290,6 +315,108 @@ async def test_raw_civ_transaction_session_releases_on_cancellation(
     assert radio.external_cat_session_active is False
     assert radio._civ_request_tracker.pending_count == 0
     assert radio._civ_request_tracker.timeout_count == 0
+
+
+async def test_data_transaction_nak_token_cannot_be_resurrected(
+    radio: IcomRadio,
+) -> None:
+    observations = []
+    radio._civ_runtime.bind_ptt_observer(
+        provider_generation=1, observer=observations.append
+    )
+    request = parse_civ_frame(
+        build_civ_frame(IC_7610_ADDR, CONTROLLER_ADDR, 0x1C, sub=0x00)
+    )
+    transaction = radio._civ_runtime._register_civ_data_transaction(
+        request_key_from_frame(request)
+    )
+
+    await radio._civ_runtime._route_civ_frame(
+        parse_civ_frame(_nak()), generation=radio._civ_epoch
+    )
+    assert transaction.nak.done()
+    radio._civ_runtime._close_civ_data_transaction(transaction)
+    assert transaction.response.cancelled()
+
+    await radio._civ_runtime._route_civ_frame(
+        parse_civ_frame(_ptt()), generation=radio._civ_epoch
+    )
+    assert transaction.response.cancelled()
+    assert len(observations) == 1
+
+
+async def test_data_transaction_identity_does_not_steal_older_same_command(
+    radio: IcomRadio,
+) -> None:
+    observations = []
+    radio._civ_runtime.bind_ptt_observer(
+        provider_generation=1, observer=observations.append
+    )
+    key = request_key_from_frame(
+        parse_civ_frame(build_civ_frame(IC_7610_ADDR, CONTROLLER_ADDR, 0x1C, sub=0x00))
+    )
+    older = radio._civ_request_tracker.register_response(key)
+    transaction = radio._civ_runtime._register_civ_data_transaction(key)
+
+    await radio._civ_runtime._route_civ_frame(
+        parse_civ_frame(_ptt()), generation=radio._civ_epoch
+    )
+    assert older.done()
+    assert not transaction.response.done()
+    assert len(observations) == 1
+
+    await radio._civ_runtime._route_civ_frame(
+        parse_civ_frame(_ptt(1)), generation=radio._civ_epoch
+    )
+    assert transaction.response.done()
+    assert len(observations) == 2
+    radio._civ_runtime._close_civ_data_transaction(transaction)
+
+
+async def test_data_transaction_timeout_settles_token_before_late_response(
+    radio: IcomRadio,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observations = []
+    radio._civ_runtime.bind_ptt_observer(
+        provider_generation=1, observer=observations.append
+    )
+    captured = _capture_data_transaction(radio, monkeypatch)
+    with pytest.raises(TimeoutError):
+        await radio.send_civ_transaction(0x1C, sub=0x00, expect="data", timeout=0.01)
+
+    assert captured[0].response.cancelled()
+    assert captured[0].nak.cancelled()
+    await radio._civ_runtime._route_civ_frame(
+        parse_civ_frame(_ptt()), generation=radio._civ_epoch
+    )
+    assert len(observations) == 1
+
+
+async def test_data_transaction_cancel_settles_token_before_late_response(
+    radio: IcomRadio,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observations = []
+    radio._civ_runtime.bind_ptt_observer(
+        provider_generation=1, observer=observations.append
+    )
+    captured = _capture_data_transaction(radio, monkeypatch)
+    task = asyncio.create_task(
+        radio.send_civ_transaction(0x1C, sub=0x00, expect="data", timeout=1.0)
+    )
+    while not captured:
+        await asyncio.sleep(0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert captured[0].response.cancelled()
+    assert captured[0].nak.cancelled()
+    await radio._civ_runtime._route_civ_frame(
+        parse_civ_frame(_ptt()), generation=radio._civ_epoch
+    )
+    assert len(observations) == 1
 
 
 def _wrap(civ_frame: bytes) -> bytes:


### PR DESCRIPTION
## Summary

- keep one exact CI-V data transaction record for the keyed response future and corresponding NAK future
- let the routing boundary synchronously claim the first resolved terminal frame, store it on the record, unregister both tracker identities, and cancel the losing future before the waiter can resume
- reject concurrent data-record registration fail-closed while preserving tracker FIFO ordering for older generic/raw waiters
- preserve MOR-1010 unsolicited PTT observation and ordinary raw request routing

## Terminal arbitration contract

The tracker still chooses the exact eligible waiter. Immediately after tracker resolution, the router accepts a terminal frame only when the active record's corresponding owned future was resolved with that same frame object. It stores that first outcome and closes the record synchronously. The transaction task reads the stored outcome rather than selecting from an unordered completed-future set. Response then late NAK cannot overwrite success; NAK then matching unsolicited PTT cannot resurrect the response token. Timeout, cancellation, repeated close, and late frames remain safe.

## Scope

- exactly 2 owned files
- +214 / -15, net +199 LOC against the PR base
- no global lock, observer epoch, reconnect invalidation, transport capture, full fresh-read work, frontend, or public API change

## Validation

- red-before production race: back-to-back response→NAK completed both futures; NAK→PTT returned the late response instead of the first NAK
- new four-case production regression: both terminal orders, with and without explicit close-between
- `uv run pytest tests/test_raw_civ_transaction.py -q --tb=short` — 20 passed
- `uv run pytest tests/test_raw_civ_transaction.py tests/test_radio.py -q --tb=short` — 253 passed
- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 8307 passed, 73 skipped, 5 deselected, 11 xfailed, 1 xpassed
- `uv run ruff check src/ tests/` — passed
- `uv run ruff format --check src/ tests/` — 626 files formatted
- `uv run lint-imports` — 5 kept, 0 broken
- changed-source mypy — same 6 pre-existing `_civ_rx.py` diagnostics on base and head; no new diagnostics
- `git diff --check` — passed

Linear: MOR-1108

Closes #1965
