### PR TITLE
feat: project freshness-safe TX target state

### DIFF
--- a/src/rigplane/web/runtime_helpers.py
+++ b/src/rigplane/web/runtime_helpers.py
@@ -4,6 +4,7 @@ import copy
 import datetime
 import time
 from collections.abc import Mapping
+from dataclasses import replace
 from typing import TYPE_CHECKING, Any, cast
 
 from ..core.state_pipeline_contracts import FieldFamily, FieldScope, FieldPath, VfoSlot
@@ -810,6 +811,22 @@ def _project_tx_target(field: FieldSnapshot) -> dict[str, object]:
     return cast(dict[str, object], target.to_dict())
 
 
+def _canonical_snapshot_fields(snapshot: StateSnapshot) -> tuple[FieldSnapshot, ...]:
+    path = FieldPath.global_("tx_state", "tx_target")
+    targets = tuple(field for field in snapshot.fields if field.path == path)
+    if len(targets) < 2:
+        return cast(tuple[FieldSnapshot, ...], snapshot.fields)
+    newest_at = max(field.last_observed_monotonic for field in targets)
+    newest = tuple(f for f in targets if f.last_observed_monotonic == newest_at)
+    rank = (FreshnessState.FRESH, FreshnessState.UNKNOWN, FreshnessState.STALE)
+    winner = max(newest, key=lambda f: (rank.index(f.freshness), repr(f.to_dict())))
+    if winner.freshness is FreshnessState.FRESH and any(
+        field.value != winner.value for field in newest
+    ):
+        winner = replace(winner, value={"status": "unknown", "reason": "contradiction"})
+    return tuple(field for field in snapshot.fields if field.path != path) + (winner,)
+
+
 def _apply_snapshot_field(
     state: dict[str, Any],
     field: FieldSnapshot,
@@ -1052,6 +1069,7 @@ def build_public_state_payload_from_snapshot(
 ) -> dict[str, Any]:
     """Build the public web payload from one StateStore snapshot."""
 
+    snapshot = replace(snapshot, fields=_canonical_snapshot_fields(snapshot))
     state = _project_snapshot_state_dict(snapshot, radio=radio)
     state["field_status"] = _build_snapshot_field_status(
         snapshot,

--- a/src/rigplane/web/runtime_helpers.py
+++ b/src/rigplane/web/runtime_helpers.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import copy
 import datetime
 import time
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, cast
 
 from ..core.state_pipeline_contracts import FieldFamily, FieldScope, FieldPath, VfoSlot
 from ..core.state_store import FieldSnapshot, FreshnessState, StateSnapshot
+from ..core.tx_target import TxTarget, tx_target_from_dict, validate_tx_target
 from ..radio_protocol import (
     AudioCapable,
     DualReceiverCapable,
@@ -123,6 +125,7 @@ _GLOBAL_TX_FIELDS = {
     "main_sub_tracking",
     "dial_lock",
     "tx_freq_monitor",
+    "tx_target",
 }
 _GLOBAL_OPERATOR_CONTROL_FIELDS = {
     "power_level",
@@ -791,6 +794,22 @@ def _power_level_max_value(field: FieldSnapshot, radio: "Radio | None") -> float
     return 255.0
 
 
+def _project_tx_target(field: FieldSnapshot) -> dict[str, object]:
+    if field.freshness is FreshnessState.STALE:
+        return {"status": "unknown", "reason": "stale"}
+    if field.freshness is not FreshnessState.FRESH:
+        return {"status": "unknown", "reason": "not-observed"}
+    try:
+        target: TxTarget = (
+            tx_target_from_dict(field.value)
+            if isinstance(field.value, Mapping)
+            else validate_tx_target(field.value)
+        )
+    except (TypeError, ValueError):
+        return {"status": "unknown", "reason": "contradiction"}
+    return cast(dict[str, object], target.to_dict())
+
+
 def _apply_snapshot_field(
     state: dict[str, Any],
     field: FieldSnapshot,
@@ -866,6 +885,9 @@ def _apply_snapshot_field(
             return
 
     if path.scope is FieldScope.GLOBAL:
+        if path.family is FieldFamily.TX_STATE and path.name == "tx_target":
+            state[path.name] = _project_tx_target(field)
+            return
         if path.family is FieldFamily.TX_STATE and path.name in _GLOBAL_TX_FIELDS:
             state[path.name] = value
             return
@@ -932,6 +954,10 @@ def _build_public_state_payload_from_dict(
     health_revision: int = 0,
 ) -> dict[str, Any]:
     state = copy.deepcopy(state)
+    state.setdefault(
+        "tx_target",
+        {"status": "unknown", "reason": "not-observed"},
+    )
     raw_connected = getattr(radio, "connected", False) if radio else False
     state["connected"] = raw_connected if isinstance(raw_connected, bool) else False
     state["radio_ready"] = radio_ready(radio)

--- a/tests/test_web_runtime_helpers.py
+++ b/tests/test_web_runtime_helpers.py
@@ -8,6 +8,7 @@ import pytest
 from unittest.mock import MagicMock
 
 from rigplane.web.runtime_helpers import (
+    build_public_state_payload,
     build_public_state_payload_from_snapshot,
     classify_radio_health,
     radio_ready,
@@ -19,7 +20,15 @@ from rigplane.core.state_pipeline_contracts import (
     Observation,
     SourceMetadata,
 )
-from rigplane.core.state_store import FreshnessClock, StateSnapshot, StateStore
+from rigplane.core.state_store import (
+    FieldSnapshot,
+    FreshnessClock,
+    FreshnessState,
+    StateSnapshot,
+    StateStore,
+)
+from rigplane.core.tx_target import KnownTxTarget, TxTarget, UnknownTxTarget
+from rigplane.radio_state import RadioState
 
 
 class _FakeWriter:
@@ -370,6 +379,122 @@ def test_public_state_projection_uses_snapshot_revisions_and_meter_values() -> N
     assert payload["freshnessRevision"] == 2
     assert payload["main"]["freqHz"] == 14_074_000
     assert payload["main"]["sMeter"] == 42
+
+
+def test_tx_target_missing_is_explicit_in_both_public_producers() -> None:
+    expected = {"status": "unknown", "reason": "not-observed"}
+
+    dataclass_payload = build_public_state_payload(
+        RadioState(), radio=None, revision=0, receiver_count=1
+    )
+    snapshot_payload = build_public_state_payload_from_snapshot(
+        StateSnapshot.empty(), radio=None, receiver_count=1
+    )
+
+    assert dataclass_payload["txTarget"] == expected
+    assert snapshot_payload["txTarget"] == expected
+    assert snapshot_payload["fieldStatus"]["txTarget"] == {
+        "storePath": "global.tx_state.tx_target",
+        "observed": False,
+        "freshness": "unknown",
+        "availability": "missing",
+    }
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        KnownTxTarget(receiver="SUB", slot="B", frequency_hz=14_074_000),
+        UnknownTxTarget(reason="unsupported"),
+        UnknownTxTarget(reason="contradiction"),
+    ],
+)
+def test_tx_target_fresh_projection_is_lossless_and_available(
+    target: TxTarget,
+) -> None:
+    clock = FreshnessClock(start=10.0)
+    store = StateStore(freshness_clock=clock)
+    store.apply(
+        _observation(
+            FieldPath.global_("tx_state", "tx_target"),
+            target,
+            at=clock.now(),
+            max_age=1.0,
+        )
+    )
+
+    payload = build_public_state_payload_from_snapshot(
+        store.snapshot(), radio=None, receiver_count=2
+    )
+
+    assert payload["txTarget"] == target.to_dict()
+    status = payload["fieldStatus"]["txTarget"]
+    assert status["storePath"] == "global.tx_state.tx_target"
+    assert status["observed"] is True
+    assert status["freshness"] == "fresh"
+    assert status["availability"] == "available"
+
+
+def test_tx_target_stale_projection_never_leaks_known_identity() -> None:
+    clock = FreshnessClock(start=10.0)
+    store = StateStore(freshness_clock=clock)
+    store.apply(
+        _observation(
+            FieldPath.global_("tx_state", "tx_target"),
+            KnownTxTarget(receiver="SUB", slot="A", frequency_hz=7_074_000),
+            at=clock.now(),
+            max_age=0.5,
+        )
+    )
+    fresh = build_public_state_payload_from_snapshot(
+        store.snapshot(), radio=None, receiver_count=2
+    )
+    assert fresh["txTarget"]["receiver"] == "SUB"
+
+    clock.advance(0.6)
+    store.mark_stale_due()
+    stale = build_public_state_payload_from_snapshot(
+        store.snapshot(), radio=None, receiver_count=2
+    )
+
+    assert stale["txTarget"] == {"status": "unknown", "reason": "stale"}
+    assert not {"receiver", "slot", "frequencyHz"} & stale["txTarget"].keys()
+    assert stale["fieldStatus"]["txTarget"]["freshness"] == "stale"
+    assert stale["fieldStatus"]["txTarget"]["availability"] == "stale"
+
+
+def test_tx_target_malformed_impossible_snapshot_fails_closed() -> None:
+    path = FieldPath.global_("tx_state", "tx_target")
+    snapshot = StateSnapshot(
+        state_revision=1,
+        freshness_revision=1,
+        observation_seq=1,
+        generated_at_monotonic=10.0,
+        fields=(
+            FieldSnapshot(
+                path=path,
+                value={
+                    "status": "known",
+                    "receiver": "MAIN",
+                    "slot": "A",
+                    "frequencyHz": 7_074_000,
+                    "backend": "icom",
+                },
+                freshness=FreshnessState.FRESH,
+                last_observed_monotonic=10.0,
+                max_age=1.0,
+                source=_source(),
+            ),
+        ),
+    )
+
+    payload = build_public_state_payload_from_snapshot(
+        snapshot, radio=None, receiver_count=1
+    )
+
+    assert payload["txTarget"] == {"status": "unknown", "reason": "contradiction"}
+    assert payload["fieldStatus"]["txTarget"]["freshness"] == "fresh"
+    assert payload["fieldStatus"]["txTarget"]["availability"] == "available"
 
 
 def test_public_field_status_exposes_quality_flags() -> None:

--- a/tests/test_web_runtime_helpers.py
+++ b/tests/test_web_runtime_helpers.py
@@ -107,6 +107,13 @@ def _observation(
     )
 
 
+def _tx_target_field(
+    value: Any, *, at: float, freshness: FreshnessState = FreshnessState.FRESH
+) -> FieldSnapshot:
+    path = FieldPath.global_("tx_state", "tx_target")
+    return FieldSnapshot(path, value, freshness, at, 1.0, _source())
+
+
 def test_runtime_capabilities_none_radio_returns_empty() -> None:
     assert runtime_capabilities(None) == set()
 
@@ -383,17 +390,16 @@ def test_public_state_projection_uses_snapshot_revisions_and_meter_values() -> N
 
 def test_tx_target_missing_is_explicit_in_both_public_producers() -> None:
     expected = {"status": "unknown", "reason": "not-observed"}
-
     dataclass_payload = build_public_state_payload(
         RadioState(), radio=None, revision=0, receiver_count=1
     )
     snapshot_payload = build_public_state_payload_from_snapshot(
         StateSnapshot.empty(), radio=None, receiver_count=1
     )
-
+    status = snapshot_payload["fieldStatus"]["txTarget"]
     assert dataclass_payload["txTarget"] == expected
     assert snapshot_payload["txTarget"] == expected
-    assert snapshot_payload["fieldStatus"]["txTarget"] == {
+    assert status == {
         "storePath": "global.tx_state.tx_target",
         "observed": False,
         "freshness": "unknown",
@@ -422,11 +428,9 @@ def test_tx_target_fresh_projection_is_lossless_and_available(
             max_age=1.0,
         )
     )
-
     payload = build_public_state_payload_from_snapshot(
         store.snapshot(), radio=None, receiver_count=2
     )
-
     assert payload["txTarget"] == target.to_dict()
     status = payload["fieldStatus"]["txTarget"]
     assert status["storePath"] == "global.tx_state.tx_target"
@@ -450,51 +454,77 @@ def test_tx_target_stale_projection_never_leaks_known_identity() -> None:
         store.snapshot(), radio=None, receiver_count=2
     )
     assert fresh["txTarget"]["receiver"] == "SUB"
-
     clock.advance(0.6)
     store.mark_stale_due()
     stale = build_public_state_payload_from_snapshot(
         store.snapshot(), radio=None, receiver_count=2
     )
-
+    status = stale["fieldStatus"]["txTarget"]
     assert stale["txTarget"] == {"status": "unknown", "reason": "stale"}
     assert not {"receiver", "slot", "frequencyHz"} & stale["txTarget"].keys()
-    assert stale["fieldStatus"]["txTarget"]["freshness"] == "stale"
-    assert stale["fieldStatus"]["txTarget"]["availability"] == "stale"
+    assert (status["freshness"], status["availability"]) == ("stale", "stale")
 
 
 def test_tx_target_malformed_impossible_snapshot_fails_closed() -> None:
-    path = FieldPath.global_("tx_state", "tx_target")
     snapshot = StateSnapshot(
-        state_revision=1,
-        freshness_revision=1,
-        observation_seq=1,
-        generated_at_monotonic=10.0,
-        fields=(
-            FieldSnapshot(
-                path=path,
-                value={
+        1,
+        1,
+        1,
+        10.0,
+        (
+            _tx_target_field(
+                {
                     "status": "known",
                     "receiver": "MAIN",
                     "slot": "A",
                     "frequencyHz": 7_074_000,
                     "backend": "icom",
                 },
-                freshness=FreshnessState.FRESH,
-                last_observed_monotonic=10.0,
-                max_age=1.0,
-                source=_source(),
+                at=10.0,
             ),
         ),
     )
-
     payload = build_public_state_payload_from_snapshot(
         snapshot, radio=None, receiver_count=1
     )
-
+    status = payload["fieldStatus"]["txTarget"]
     assert payload["txTarget"] == {"status": "unknown", "reason": "contradiction"}
-    assert payload["fieldStatus"]["txTarget"]["freshness"] == "fresh"
-    assert payload["fieldStatus"]["txTarget"]["availability"] == "available"
+    assert (status["freshness"], status["availability"]) == ("fresh", "available")
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        (20.0, FreshnessState.STALE, {"malformed": True}, "stale"),
+        (
+            10.0,
+            FreshnessState.FRESH,
+            KnownTxTarget("SUB", None, None),
+            "contradiction",
+        ),
+        (10.0, FreshnessState.STALE, KnownTxTarget("SUB", None, None), "stale"),
+    ],
+)
+@pytest.mark.parametrize("reverse", [False, True])
+def test_tx_target_duplicate_path_selection_is_order_safe_and_consistent(
+    case: tuple[float, FreshnessState, Any, str],
+    reverse: bool,
+) -> None:
+    at, freshness, value, reason = case
+    older = _tx_target_field(
+        KnownTxTarget(receiver="MAIN", slot="B", frequency_hz=14_074_000), at=10.0
+    )
+    contender = _tx_target_field(value, at=at, freshness=freshness)
+    fields = (contender, older) if reverse else (older, contender)
+    payload = build_public_state_payload_from_snapshot(
+        StateSnapshot(1, 1, 2, max(10.0, at), fields),
+        radio=None,
+        receiver_count=2,
+    )
+    assert payload["txTarget"] == {"status": "unknown", "reason": reason}
+    s = payload["fieldStatus"]["txTarget"]
+    availability = "available" if freshness is FreshnessState.FRESH else "stale"
+    assert (s["freshness"], s["availability"]) == (freshness.value, availability)
 
 
 def test_public_field_status_exposes_quality_flags() -> None:


### PR DESCRIPTION
## Summary

- always emit the staged camelCase `txTarget` field from both public-state producer paths
- project fresh canonical StateStore targets losslessly through the merged backend-neutral domain
- replace stale targets with explicit unknown/stale before serialization, preventing receiver/slot/frequency leakage
- keep `fieldStatus.txTarget` on the existing canonical freshness/status path
- fail closed as unknown/contradiction for impossible malformed snapshot values

## Freshness contract

`FieldSnapshot.freshness` is the only freshness authority. Missing data emits unknown/not-observed. Fresh values serialize through the MOR-1047 TxTarget validator. Stale data is discarded before reading target identity and emits only unknown/stale. `fieldStatus.txTarget` is generated from the same snapshot by the existing diagnostic projection and never supplies target identity.

## Scope

- 2 files
- +152 / -1, net +151 LOC
- no provider acquisition, schema/codegen, frontend selector/component, capability, selected-RX, split, model, or TX lifecycle changes

## Validation

- red-first target matrix: 6 expected failures on base
- focused runtime + schema: 58 passed
- focused runtime + schema + web server: 245 passed, 2 skipped
- full non-integration: 8325 passed, 73 skipped, 5 deselected, 11 xfailed, 1 xpassed
- Ruff check and format: passed
- strict web mypy: passed
- import-linter: 5 kept, 0 broken
- state type codegen check: passed
- diff check: passed

Linear: MOR-1106

Closes #1968
