### PR TITLE
feat: publish FTX-1 native FT readback as TxTarget

### DIFF
--- a/rigs/ftx1.toml
+++ b/rigs/ftx1.toml
@@ -77,6 +77,7 @@ polling_only = [
     "receiver.sub.active.freq_mode.freq_hz",
     "receiver.sub.active.freq_mode.mode",
     "global.tx_state.ptt",
+    "global.tx_state.tx_target",
     "receiver.main.operator_controls.af_level",
     "receiver.main.operator_controls.rf_gain",
     "receiver.main.operator_controls.squelch",

--- a/src/rigplane/backends/yaesu_cat/observations.py
+++ b/src/rigplane/backends/yaesu_cat/observations.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Protocol, TypeVar
 from rigplane.core.observation_adapter import ProviderObservationAdapter
 from rigplane.core.state_acquisition_policy import RadioAcquisitionProfile
 from rigplane.core.state_pipeline_contracts import FieldPath, Observation
+from rigplane.core.tx_target import KnownTxTarget, TxTarget, UnknownTxTarget
 from rigplane.runtime.meter_cal import interpolate_meter
 
 from .parser import CatFormatError, CatParseError
@@ -32,6 +33,7 @@ _MAIN_MODE = FieldPath.active("main", "freq_mode", "mode")
 _SUB_FREQ = FieldPath.active("sub", "freq_mode", "freq_hz")
 _SUB_MODE = FieldPath.active("sub", "freq_mode", "mode")
 _PTT = FieldPath.global_("tx_state", "ptt")
+_TX_TARGET = FieldPath.global_("tx_state", "tx_target")
 _MAIN_AF = FieldPath.receiver("main", "operator_controls", "af_level")
 _MAIN_RF = FieldPath.receiver("main", "operator_controls", "rf_gain")
 _MAIN_SQL = FieldPath.receiver("main", "operator_controls", "squelch")
@@ -182,6 +184,8 @@ class YaesuObservationRadio(Protocol):
 
     async def read_ptt(self) -> bool: ...
 
+    async def get_tx_func(self) -> int: ...
+
     async def read_af_level(self, receiver: int = 0) -> int: ...
 
     async def read_rf_gain(self, receiver: int = 0) -> int: ...
@@ -313,6 +317,14 @@ class YaesuObservationAdapter:
                 observations.append(
                     adapter.observation(_SUB_MODE, result[0], native_id="read_mode")
                 )
+        if self._can_poll(_TX_TARGET):
+            observations.append(
+                adapter.observation(
+                    _TX_TARGET,
+                    await self._read_tx_target(),
+                    native_id="get_tx_func",
+                )
+            )
         if self._can_poll(_PTT):
             ok, value = await self._safe_read("ptt", self.radio.read_ptt())
             if ok:
@@ -336,6 +348,61 @@ class YaesuObservationAdapter:
                     )
                 )
         return tuple(observations)
+
+    async def _read_tx_func(self) -> int | UnknownTxTarget:
+        method = getattr(self.radio, "get_tx_func", None)
+        if not callable(method):
+            return UnknownTxTarget(reason="unsupported")
+        try:
+            tx_func = await method()
+        except (AttributeError, NotImplementedError, CatCommandRejected):
+            return UnknownTxTarget(reason="unsupported")
+        except (CatParseError, CatFormatError, ValueError, KeyError):
+            return UnknownTxTarget(reason="contradiction")
+        if tx_func is None:
+            return UnknownTxTarget(reason="not-observed")
+        if type(tx_func) is not int or tx_func not in (0, 1):
+            return UnknownTxTarget(reason="contradiction")
+        return tx_func
+
+    async def _read_tx_target(self) -> TxTarget:
+        """Bracket the selected frequency with stable native FT authority."""
+        if not self._has_runtime_capability("tx"):
+            return UnknownTxTarget(reason="unsupported")
+        stats = getattr(getattr(self.radio, "_transport", None), "stats", None)
+        reconnects = getattr(stats, "reconnects", 0)
+        generation = (
+            self.profile.provider,
+            reconnects if type(reconnects) is int else 0,
+        )
+        before = await self._read_tx_func()
+        if isinstance(before, UnknownTxTarget):
+            return before
+        ok, raw_frequency = await self._safe_read(
+            "tx_target.freq", self.radio.read_freq(before)
+        )
+        after = await self._read_tx_func()
+        current_reconnects = getattr(stats, "reconnects", 0)
+        current_generation = (
+            self.profile.provider,
+            current_reconnects if type(current_reconnects) is int else 0,
+        )
+        if generation != current_generation:
+            return UnknownTxTarget(reason="not-observed")
+        if isinstance(after, UnknownTxTarget):
+            return after
+        if after != before:
+            return UnknownTxTarget(reason="contradiction")
+        frequency = (
+            raw_frequency
+            if ok and type(raw_frequency) is int and raw_frequency > 0
+            else None
+        )
+        return KnownTxTarget(
+            receiver="MAIN" if before == 0 else "SUB",
+            slot=None,
+            frequency_hz=frequency,
+        )
 
     async def poll_rx_meters(
         self,

--- a/tests/test_yaesu_cat_observation_adapter.py
+++ b/tests/test_yaesu_cat_observation_adapter.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 
 from dataclasses import replace
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, call
 
 import pytest
 
 from rigplane.core.state_acquisition_policy import RadioAcquisitionProfile
+from rigplane.core.tx_target import KnownTxTarget, TxReceiver, UnknownTxTarget
 from rigplane.core.types import BreakInMode
 from rigplane.profiles import get_radio_profile
 from rigplane.radio_state import RadioState
@@ -17,6 +18,7 @@ from rigplane.radio_state import RadioState
 from rigplane.backends.yaesu_cat.observations import YaesuObservationAdapter
 from rigplane.backends.yaesu_cat.parser import CatParseError
 from rigplane.backends.yaesu_cat.radio import RadioConnectionError, YaesuCatRadio
+from rigplane.backends.yaesu_cat.transport import CatCommandRejected
 
 
 def _clock() -> float:
@@ -147,6 +149,7 @@ def _make_radio() -> MagicMock:
     radio.read_split = AsyncMock(return_value=True)
     radio.get_vfo_select = AsyncMock(return_value=1)
     radio.read_vfo_select = AsyncMock(return_value=1)
+    radio.get_tx_func = AsyncMock(return_value=0)
     # Clarifier RIT/XIT observation reads (MOR-454). ``read_clarifier`` returns
     # the (rx, tx) clarifier flags; ``read_clarifier_freq`` returns the signed
     # Hz offset on the device scale.
@@ -287,6 +290,10 @@ class _SideEffectingYaesuRadio:
         value = await self.read_ptt()
         self.radio_state.ptt = value
         return value
+
+    async def get_tx_func(self) -> int:
+        # Unlike legacy getters, FT readback has no RadioState side effect.
+        return 0
 
     async def read_s_meter(self, receiver: int = 0) -> int:
         return 150 if receiver == 0 else 75
@@ -573,6 +580,10 @@ async def test_medium_poll_emits_frequency_mode_and_ptt_observations() -> None:
         ("receiver.main.active.freq_mode.mode", "USB"),
         ("receiver.sub.active.freq_mode.freq_hz", 7_074_000),
         ("receiver.sub.active.freq_mode.mode", "LSB"),
+        (
+            "global.tx_state.tx_target",
+            KnownTxTarget(receiver="MAIN", slot=None, frequency_hz=14_074_000),
+        ),
         ("global.tx_state.ptt", False),
         ("receiver.main.active.freq_mode.filter_width", 500),
     ]
@@ -587,9 +598,125 @@ async def test_medium_poll_emits_frequency_mode_and_ptt_observations() -> None:
     # it shares the freq/mode lane (MOR-445).
     by_path = {str(item.path): item for item in observations}
     assert by_path["global.tx_state.ptt"].max_age == 8.0
+    assert by_path["global.tx_state.tx_target"].max_age == 8.0
     assert by_path["receiver.main.active.freq_mode.freq_hz"].max_age == 8.0
     assert by_path["receiver.main.active.freq_mode.filter_width"].max_age == 120.0
     assert all(item.source.capability_id == str(item.path) for item in observations)
+
+
+@pytest.mark.parametrize(
+    ("ft", "frequency_response", "frequency_command", "receiver", "frequency"),
+    [
+        ("0", "FA014074000", "FA;", "MAIN", 14_074_000),
+        ("1", "FB007074000", "FB;", "SUB", 7_074_000),
+    ],
+)
+@pytest.mark.asyncio
+async def test_real_ftx1_parser_brackets_selected_frequency(
+    ft: str,
+    frequency_response: str,
+    frequency_command: str,
+    receiver: TxReceiver,
+    frequency: int,
+) -> None:
+    radio = YaesuCatRadio("/dev/null", audio_driver=MagicMock())
+    radio._transport._connected = True
+    radio._transport.query = AsyncMock(  # type: ignore[method-assign]
+        side_effect=[f"FT{ft}", frequency_response, f"FT{ft}"]
+    )
+    target = await YaesuObservationAdapter.from_radio(radio)._read_tx_target()
+
+    assert target == KnownTxTarget(receiver=receiver, slot=None, frequency_hz=frequency)
+    assert radio._transport.query.await_args_list == [
+        call("FT;"),
+        call(frequency_command),
+        call("FT;"),
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("tx_func", [True, False, 0.0, 1.0, -1, 2, 2**63])
+async def test_invalid_ft_type_or_range_is_contradiction(tx_func: object) -> None:
+    radio = _make_radio()
+    radio.get_tx_func.return_value = tx_func
+
+    target = await YaesuObservationAdapter(
+        radio, profile=_profile_state_acquisition(), clock=_clock
+    )._read_tx_target()
+
+    assert target == UnknownTxTarget(reason="contradiction")
+    radio.read_freq.assert_not_awaited()
+    assert radio.read_split.await_count == radio.read_vfo_select.await_count == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("result", "expected"),
+    [
+        (None, UnknownTxTarget(reason="not-observed")),
+        (
+            CatParseError("FT{vfo};", "FTX;", "invalid vfo"),
+            UnknownTxTarget(reason="contradiction"),
+        ),
+        (CatCommandRejected("?;"), UnknownTxTarget(reason="unsupported")),
+        (NotImplementedError(), UnknownTxTarget(reason="unsupported")),
+        ("missing", UnknownTxTarget(reason="unsupported")),
+    ],
+)
+async def test_missing_or_unsupported_ft_is_unknown(
+    result: object, expected: UnknownTxTarget
+) -> None:
+    radio = _make_radio()
+    if result == "missing":
+        radio.get_tx_func = None
+    elif isinstance(result, Exception):
+        radio.get_tx_func.side_effect = result
+    else:
+        radio.get_tx_func.return_value = result
+
+    target = await YaesuObservationAdapter(
+        radio, profile=_profile_state_acquisition(), clock=_clock
+    )._read_tx_target()
+
+    assert target == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("boundary", ["ft", "generation", "missing-frequency"])
+async def test_tx_target_mid_cycle_change_or_missing_frequency(boundary: str) -> None:
+    radio = _make_radio()
+    radio._transport = SimpleNamespace(stats=SimpleNamespace(reconnects=0))
+    radio.get_tx_func.side_effect = [0, 1 if boundary == "ft" else 0]
+    if boundary == "generation":
+        radio.read_freq.side_effect = lambda _receiver: (
+            setattr(radio._transport.stats, "reconnects", 1) or 14_074_000
+        )
+    elif boundary == "missing-frequency":
+        radio.read_freq.side_effect = ValueError("bad selected frequency")
+
+    target = await YaesuObservationAdapter(
+        radio, profile=_profile_state_acquisition(), clock=_clock
+    )._read_tx_target()
+
+    expected = (
+        UnknownTxTarget(reason="contradiction")
+        if boundary == "ft"
+        else UnknownTxTarget(reason="not-observed")
+        if boundary == "generation"
+        else KnownTxTarget(receiver="MAIN", slot=None, frequency_hz=None)
+    )
+    assert target == expected
+
+
+@pytest.mark.asyncio
+async def test_tx_target_connection_failure_propagates() -> None:
+    radio = _make_radio()
+    radio.get_tx_func.side_effect = RadioConnectionError("link reset")
+    adapter = YaesuObservationAdapter(
+        radio, profile=_profile_state_acquisition(), clock=_clock
+    )
+    with pytest.raises(RadioConnectionError, match="link reset"):
+        await adapter._read_tx_target()
 
 
 @pytest.mark.asyncio
@@ -1074,6 +1201,10 @@ async def test_adapter_uses_read_only_yaesu_paths_when_getters_mutate_state() ->
         ("receiver.main.active.freq_mode.mode", "USB"),
         ("receiver.sub.active.freq_mode.freq_hz", 7_074_000),
         ("receiver.sub.active.freq_mode.mode", "LSB"),
+        (
+            "global.tx_state.tx_target",
+            KnownTxTarget(receiver="MAIN", slot=None, frequency_hz=14_074_000),
+        ),
         ("global.tx_state.ptt", True),
         ("receiver.main.meters.s_meter", 150),
         ("receiver.sub.meters.s_meter", 75),


### PR DESCRIPTION
Closes #1969

Linear: MOR-1049
Depends on merged MOR-1119 / #1992.

## Summary
- publish FTX-1 native FT readback as the authoritative MAIN/SUB `TxTarget`
- bracket the selected receiver frequency with FT-before / selected-frequency / FT-after and reject a changed FT or CAT generation fail closed
- require exact `int` FT values 0/1, rejecting bool/float/out-of-range evidence; map missing/not-implemented/rejected FT support to explicit unknown
- keep `ab_shared` slot null and rely on the merged poller generation invalidation to expire prior authority on reconnect/provider changes

## Scope
- exact owned 3 files, 200 insertions / 1 deletion = 199 net LOC
- no schema, frontend, audio, poller, or public provider API changes

## Verification
- focused adapter + current poller + state contracts: 302 passed
- production Yaesu parser: 42 passed
- Ruff lint + format check
- strict mypy on changed production source
- import-linter: 5 contracts kept
- `git diff --check`
- exact-head GitHub quick + grep checks

Fresh independent exact-head review is still required before this Draft may become ready or merge.
