### PR TITLE
feat: require TxTarget in backend public-state schema

### DIFF
--- a/src/rigplane/web/state_schema.py
+++ b/src/rigplane/web/state_schema.py
@@ -335,12 +335,7 @@ class ServerStatePublic(_Strict):
     data3ModInput: int | None = None
     txBandEdges: list[dict[str, int]] = Field(default_factory=list)
     scopeControls: ScopeControlsPublic
-    # Additive staging field: both producers publish it in MOR-1106, after
-    # which MOR-1107 makes it required. The non-null default keeps current
-    # producer payloads conformant while explicit ``null`` still fails.
-    txTarget: TxTargetPublic = Field(
-        default_factory=lambda: UnknownTxTargetPublic(reason="not-observed")
-    )
+    txTarget: TxTargetPublic
 
     # Receivers. ``sub`` is dropped from the payload when ``receiver_count < 2``.
     main: ReceiverStatePublic

--- a/tests/web/test_state_schema_conformance.py
+++ b/tests/web/test_state_schema_conformance.py
@@ -68,6 +68,22 @@ def test_dataclass_path_conforms(receiver_count: int) -> None:
     ServerStatePublic.model_validate(payload)
 
 
+def test_public_tx_target_is_required_after_producer_parity() -> None:
+    payload = build_public_state_payload(
+        RadioState(),
+        radio=None,
+        revision=7,
+        receiver_count=2,
+    )
+    assert payload.pop("txTarget") == {
+        "status": "unknown",
+        "reason": "not-observed",
+    }
+
+    with pytest.raises(ValueError):
+        ServerStatePublic.model_validate(payload)
+
+
 @pytest.mark.parametrize(
     "tx_target",
     [


### PR DESCRIPTION
## Summary

- remove the staging default now that both public-state producer paths always emit `txTarget`
- make a missing top-level `txTarget` fail strict `ServerStatePublic` validation
- add the focused red-before/green conformance characterization without duplicating the merged runtime matrix

## Requirement-to-test map

- missing field is rejected: `test_public_tx_target_is_required_after_producer_parity`
- dataclass producer emits a conformant value: existing `test_dataclass_path_conforms`
- snapshot producer and `fieldStatus` remain conformant: existing `test_snapshot_path_conforms`
- exact known/unknown union and invalid-shape rejection remain covered by the existing TxTarget schema parameter matrices
- missing/fresh/stale/unsupported/contradiction/malformed/duplicate-tie runtime behavior remains covered by `tests/test_web_runtime_helpers.py` from MOR-1106

## Scope

- 2 files
- +17/-6, net +11 LOC
- no codegen policy or generated TypeScript change; blocked follow-up MOR-1114 owns those two surfaces
- no runtime/provider/selector/component/capability/model/split/selected-RX change

## Verification

- red-before: missing `txTarget` was accepted on base
- focused schema + runtime: 65 passed
- full non-integration backend suite: 8544 passed, 73 skipped, 112 deselected, 11 xfailed, 1 xpassed
- Ruff check and format check: pass
- strict web mypy: pass
- import-linter: 5 contracts kept
- diff/scope checks: pass

Linear: MOR-1113

Closes #1977