### PR TITLE
test: align transcoder-rate fixture with strict TX codec

### DIFF
--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1879,6 +1879,7 @@ class TestAudioHandlerTxTranscoderRate:
     @staticmethod
     def _make_handler(sample_rate: int | None) -> Any:
         from rigplane.radio_protocol import AudioCapable
+        from rigplane.types import AudioCodec
         from rigplane.web.handlers import AudioBroadcaster, AudioHandler
         from rigplane.web.websocket import WebSocketConnection
 
@@ -1886,12 +1887,15 @@ class TestAudioHandlerTxTranscoderRate:
         mock_radio = MagicMock(spec=AudioCapable)
         mock_radio.capabilities = {"audio", "tx"}
         mock_radio.backend_id = "yaesu_cat"
+        mock_radio.audio_codec = AudioCodec.PCM_1CH_16BIT
         if sample_rate is None:
             # Simulate a radio that does not expose audio_sample_rate
             del mock_radio.audio_sample_rate
         else:
             mock_radio.audio_sample_rate = sample_rate
-        mock_radio.start_audio_tx_opus = AsyncMock()
+        mock_radio.start_audio_tx_pcm = AsyncMock()
+        mock_radio.push_audio_tx_pcm = AsyncMock()
+        mock_radio.stop_audio_tx_pcm = AsyncMock()
 
         broadcaster = AudioBroadcaster(mock_radio)
         handler = AudioHandler(mock_ws, mock_radio, broadcaster)


### PR DESCRIPTION
Closes #1986
Linear: MOR-1118

## Summary
- declare the transcoder-rate fixture as an explicit PCM_1CH_16BIT TX radio
- replace the unrelated Opus start mock with concrete PCM start/push/stop lifecycle mocks
- preserve the 24 kHz, 48 kHz, and missing-rate fallback factory assertions

## Why
The corrected MOR-1050 / PR #1973 admission contract rejects missing or unsupported codec authority and does not guess Opus. The previous Protocol-spec mock had no explicit codec and relied on inherited lifecycle stubs, causing three honest red-before failures under the corrected overlay.

## Scope
- exactly `tests/test_web_server.py`
- +5/-1, net +4 LOC
- no production changes

## Verification
- `TestAudioHandlerTxTranscoderRate`: 4 passed
- full `tests/test_web_server.py`: 187 passed, 2 skipped
- corrected MOR-1050 overlay adjacent capability/handler/route/session/server matrix: 382 passed, 2 skipped
- corrected overlay Ruff check/format, strict web mypy, import-linter, and diff check: passed

Draft pending independent review; no self-review or merge.