### PR TITLE
MOR-1119: make Yaesu TxTarget fixture profile-aware

### DIFF
--- a/tests/test_yaesu_cat_poller.py
+++ b/tests/test_yaesu_cat_poller.py
@@ -399,11 +399,13 @@ def _tx_target_radio() -> MagicMock:
     radio = make_radio()
     profile = _profile_state_acquisition()
     target_path = FieldPath.global_("tx_state", "tx_target")
-    radio.profile.state_acquisition = replace(
-        profile,
-        capabilities=profile.capabilities
-        + (FieldCapability(path=target_path, polling=True),),
-    )
+    if not profile.capability_for(target_path).can_poll:
+        profile = replace(
+            profile,
+            capabilities=profile.capabilities
+            + (FieldCapability(path=target_path, polling=True),),
+        )
+    radio.profile.state_acquisition = profile
     radio._transport = SimpleNamespace(
         stats=SimpleNamespace(reconnects=0),
         reconnect=AsyncMock(),


### PR DESCRIPTION
## Summary

- make the Yaesu TxTarget invalidation fixture reuse the real profile declaration when present
- append the synthetic polling capability only for profiles that still lack TxTarget
- preserve every existing invalidation, generation, callback-failure, and late-observation assertion

Closes #1991
Linear: MOR-1119

## Scope

- test-only prerequisite for MOR-1049 / PR #1974
- exactly one file
- +7/-5, net +2 LOC
- no production, profile, adapter, runtime, or behavior changes

## Verification

- red-before corrected MOR-1049 overlay: 6 duplicate-path failures
- current-main full poller module: 45 passed
- corrected MOR-1049 overlay, full poller + adapter modules: 102 passed
- Ruff check and format check: pass
- diff check: pass

This PR intentionally remains Draft pending independent review.