### PR TITLE
MOR-1109: bind authoritative PTT reads to observer epoch

### DIFF
--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -641,7 +641,7 @@ class CivRuntime:
         return (
             self._active_ptt_read in (None, read)
             and self._ptt_observer_binding_epoch == read.binding_epoch
-            and self._ptt_observer == read.observer
+            and self._ptt_observer is read.observer
             and self._ptt_observer_provider_generation == read.provider_generation
             and self._ptt_observer_civ_generation == read.source_generation
             and self._host._civ_epoch == read.source_generation
@@ -1352,7 +1352,7 @@ class CivRuntime:
         )
         try:
             observer(observation)
-        except Exception:  # noqa: BLE001 - observer failure must not break CI-V RX
+        except (Exception, asyncio.CancelledError):  # noqa: BLE001
             logger.exception("Authoritative PTT observer raised")
             return False
         return True

--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -165,11 +165,21 @@ class _CivDataTransaction:
 
     response: asyncio.Future[CivFrame]
     nak: asyncio.Future[CivFrame]
+    owner: object | None = None
     frame: CivFrame | None = None
 
     @property
     def futures(self) -> tuple[asyncio.Future[CivFrame], ...]:
         return (self.response, self.nak)
+
+
+@dataclass(frozen=True, slots=True)
+class _AuthoritativePttRead:
+    observer: Callable[[ProviderPttObservation], None]
+    provider_generation: int
+    binding_epoch: int
+    source_generation: int
+    transport: object
 
 
 _CMD14_RECEIVER_LEVEL_FIELDS = {
@@ -550,7 +560,10 @@ class CivRuntime:
         self._ptt_observer: Callable[[ProviderPttObservation], None] | None = None
         self._ptt_observer_provider_generation: int | None = None
         self._ptt_observer_civ_generation: int | None = None
+        self._ptt_observer_binding_epoch = 0
         self._ptt_observation_seq = 0
+        self._ptt_read_lock = asyncio.Lock()
+        self._active_ptt_read: _AuthoritativePttRead | None = None
         self._active_rx_source_generation: int | None = None
         self._civ_data_transaction: _CivDataTransaction | None = None
 
@@ -576,13 +589,64 @@ class CivRuntime:
             raise ValueError("provider_generation must be non-negative")
         if provider_generation != self._ptt_observer_provider_generation:
             self._ptt_observation_seq = 0
+        self._ptt_observer_binding_epoch += 1
         self._ptt_observer = observer
         self._ptt_observer_provider_generation = provider_generation
         self._ptt_observer_civ_generation = self._host._civ_epoch
 
     def unbind_ptt_observer(self) -> None:
         """Detach the callback while preserving this provider's sequence."""
+        self._ptt_observer_binding_epoch += 1
         self._ptt_observer = None
+
+    async def request_authoritative_ptt_read(
+        self,
+        civ_frame: bytes,
+        *,
+        provider_generation: int,
+        observer: Callable[[ProviderPttObservation], None],
+    ) -> bool:
+        """Publish one exact PTT response only while its binding stays current."""
+        async with self._ptt_read_lock:
+            transport = self._host._civ_transport
+            read = _AuthoritativePttRead(
+                observer=observer,
+                provider_generation=provider_generation,
+                binding_epoch=self._ptt_observer_binding_epoch,
+                source_generation=self._host._civ_epoch,
+                transport=transport,
+            )
+            if transport is None or not self._ptt_read_is_current(read):
+                return False
+            self._active_ptt_read = read
+            try:
+                result = await self.execute_civ_transaction(
+                    civ_frame, expect="data", owner=read
+                )
+                return (
+                    result.status == "response"
+                    and result.frame is not None
+                    and self._ptt_read_is_current(read)
+                    and self._emit_authoritative_ptt(
+                        result.frame,
+                        source_generation=read.source_generation,
+                        expected=read,
+                    )
+                )
+            finally:
+                if self._active_ptt_read is read:
+                    self._active_ptt_read = None
+
+    def _ptt_read_is_current(self, read: _AuthoritativePttRead) -> bool:
+        return (
+            self._active_ptt_read in (None, read)
+            and self._ptt_observer_binding_epoch == read.binding_epoch
+            and self._ptt_observer == read.observer
+            and self._ptt_observer_provider_generation == read.provider_generation
+            and self._ptt_observer_civ_generation == read.source_generation
+            and self._host._civ_epoch == read.source_generation
+            and self._host._civ_transport is read.transport
+        )
 
     async def stop_pump(self) -> None:
         """Stop CI-V receive pump and fail pending request futures."""
@@ -667,6 +731,7 @@ class CivRuntime:
         *,
         expect: RawCivExpectation,
         timeout: float | None = None,
+        owner: object | None = None,
     ) -> RawCivTransactionResult:
         """Execute one explicitly-scoped raw CI-V transaction.
 
@@ -692,7 +757,7 @@ class CivRuntime:
 
         if expect == "none":
             self.start_pump()
-            await self._send_civ_frame_now(civ_frame)
+            await self._send_civ_frame_now(civ_frame, owner=owner)
             return RawCivTransactionResult(status="sent")
 
         await self._drain_ack_sinks_before_blocking()
@@ -719,10 +784,11 @@ class CivRuntime:
                 pending_waiters.append(pending_or_token)
             else:
                 data_transaction = self._register_civ_data_transaction(request_key)
+                data_transaction.owner = owner
                 pending_waiters.extend(data_transaction.futures)
 
             self.start_pump()
-            await self._send_civ_frame_now(civ_frame)
+            await self._send_civ_frame_now(civ_frame, owner=owner)
             remaining = deadline_monotonic - time.monotonic()
             if remaining <= 0:
                 raise asyncio.TimeoutError("CI-V response timed out")
@@ -796,24 +862,30 @@ class CivRuntime:
             self._host._civ_request_tracker.unregister(future)
             if not future.done():
                 future.cancel()
+            elif not future.cancelled():
+                future.exception()
 
-    def _claim_civ_data_transaction(self, event: CivEvent) -> None:
+    def _claim_civ_data_transaction(
+        self, event: CivEvent
+    ) -> _CivDataTransaction | None:
         """Synchronously claim the first routed response or NAK."""
         transaction = self._civ_data_transaction
         if transaction is None or event.type == CivEventType.ACK:
-            return
+            return None
         winner = (
             transaction.nak if event.type == CivEventType.NAK else transaction.response
         )
         if winner.cancelled() or not winner.done():
-            return
+            return None
         try:
             frame = winner.result()
         except Exception:
-            return
+            return None
         if frame is event.frame:
             transaction.frame = frame
             self._close_civ_data_transaction(transaction)
+            return transaction
+        return None
 
     async def send_civ_raw(
         self,
@@ -837,7 +909,9 @@ class CivRuntime:
             wait_dispatch=wait_dispatch,
         )
 
-    async def _send_civ_frame_now(self, civ_frame: bytes) -> None:
+    async def _send_civ_frame_now(
+        self, civ_frame: bytes, *, owner: object | None = None
+    ) -> None:
         """Send one CI-V frame directly through the runtime transport."""
         assert self._host._civ_transport is not None
         now = time.monotonic()
@@ -845,8 +919,14 @@ class CivRuntime:
         if delta < self._host._civ_min_interval:
             await asyncio.sleep(self._host._civ_min_interval - delta)
 
+        if isinstance(owner, _AuthoritativePttRead) and not self._ptt_read_is_current(
+            owner
+        ):
+            raise ConnectionError("PTT observer binding changed before dispatch")
         pkt = self._wrap_civ(civ_frame)
-        await self._host._civ_transport.send_tracked(pkt)
+        transport = self._host._civ_transport
+        assert transport is not None
+        await transport.send_tracked(pkt)
         self._host._last_civ_send_monotonic = time.monotonic()
 
     @staticmethod
@@ -1224,6 +1304,14 @@ class CivRuntime:
             event = CivEvent(type=CivEventType.NAK, frame=frame)
         else:
             event = CivEvent(type=CivEventType.RESPONSE, frame=frame)
+            self._update_state_cache_from_frame(frame)
+        self._publish_civ_event(event)
+        claimed: _CivDataTransaction | None = None
+        if self._host._civ_request_tracker.resolve(event, generation=generation):
+            claimed = self._claim_civ_data_transaction(event)
+        if event.type is CivEventType.RESPONSE and not isinstance(
+            claimed.owner if claimed is not None else None, _AuthoritativePttRead
+        ):
             self._emit_authoritative_ptt(
                 frame,
                 source_generation=(
@@ -1232,27 +1320,29 @@ class CivRuntime:
                     else self._active_rx_source_generation
                 ),
             )
-            self._update_state_cache_from_frame(frame)
-        self._publish_civ_event(event)
-        if self._host._civ_request_tracker.resolve(event, generation=generation):
-            self._claim_civ_data_transaction(event)
 
     def _emit_authoritative_ptt(
-        self, frame: CivFrame, *, source_generation: int
-    ) -> None:
+        self,
+        frame: CivFrame,
+        *,
+        source_generation: int,
+        expected: _AuthoritativePttRead | None = None,
+    ) -> bool:
         """Publish only exact, generation-bound CI-V PTT state responses."""
         observer = self._ptt_observer
         provider_generation = self._ptt_observer_provider_generation
         if (
-            observer is None
+            (expected is not None and not self._ptt_read_is_current(expected))
+            or observer is None
             or provider_generation is None
             or source_generation != self._ptt_observer_civ_generation
+            or source_generation != self._host._civ_epoch
             or frame.command != 0x1C
             or frame.sub != 0x00
             or len(frame.data) != 1
             or frame.data[0] not in (0x00, 0x01)
         ):
-            return
+            return False
         self._ptt_observation_seq += 1
         observation = ProviderPttObservation(
             value=RadioTx.ON if frame.data[0] else RadioTx.OFF,
@@ -1264,6 +1354,8 @@ class CivRuntime:
             observer(observation)
         except Exception:  # noqa: BLE001 - observer failure must not break CI-V RX
             logger.exception("Authoritative PTT observer raised")
+            return False
+        return True
 
     def deliver_raw_civ(self, frame_bytes: bytes) -> None:
         """Forward a raw inbound CI-V frame to registered raw-pipe listeners.

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -2963,6 +2963,21 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         """Detach the managed-provider PTT readback observer."""
         self._civ_runtime.unbind_ptt_observer()
 
+    async def _request_authoritative_ptt_read(
+        self,
+        *,
+        provider_generation: int,
+        observer: "Callable[[ProviderPttObservation], None]",
+    ) -> None:
+        self._check_connected()
+        civ = build_civ_frame(self._radio_addr, CONTROLLER_ADDR, 0x1C, sub=0x00)
+        if not await self._civ_runtime.request_authoritative_ptt_read(
+            civ,
+            provider_generation=provider_generation,
+            observer=observer,
+        ):
+            raise CommandError("PTT response was not authoritative for this request")
+
     # ------------------------------------------------------------------
     # Transceiver status family (#136)
     # ------------------------------------------------------------------

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -23,7 +23,7 @@ from rigplane.commands import (
     build_cmd29_frame,
 )
 from rigplane.commander import Priority
-from rigplane.exceptions import ConnectionError, TimeoutError
+from rigplane.exceptions import CommandError, ConnectionError, TimeoutError
 from rigplane.core import tx_safety as tx
 from rigplane.radio import IcomRadio
 from rigplane.types import (
@@ -867,6 +867,92 @@ class TestPtt:
             assert observations[0].provider_generation == 8
         finally:
             await radio._civ_runtime.stop_pump()
+
+    @pytest.mark.asyncio
+    async def test_fresh_ptt_read_rejects_identical_unbind_rebind(
+        self, radio: IcomRadio, mock_transport: MockTransport
+    ) -> None:
+        observations: list[tx.ProviderPttObservation] = []
+        observer = observations.append
+        radio._bind_authoritative_ptt_observer(provider_generation=8, observer=observer)
+        await _route_ptt(radio, b"\x01")
+        pending = asyncio.create_task(
+            radio._request_authoritative_ptt_read(
+                provider_generation=8, observer=observer
+            )
+        )
+        while not mock_transport.sent_packets:
+            await asyncio.sleep(0)
+        radio._unbind_authoritative_ptt_observer()
+        radio._bind_authoritative_ptt_observer(provider_generation=8, observer=observer)
+        mock_transport.queue_response(_ptt_response(False))
+
+        with pytest.raises(CommandError, match="authoritative"):
+            await pending
+        await _route_ptt(radio, b"\x00")
+        assert [item.ptt_observation_seq for item in observations] == [1, 2]
+
+    @pytest.mark.asyncio
+    async def test_fresh_ptt_read_rechecks_binding_before_dispatch(
+        self, radio: IcomRadio, mock_transport: MockTransport
+    ) -> None:
+        observations: list[tx.ProviderPttObservation] = []
+        observer = observations.append
+        radio._bind_authoritative_ptt_observer(provider_generation=9, observer=observer)
+        entered = asyncio.Event()
+        release = asyncio.Event()
+        send = radio._civ_runtime._send_civ_frame_now
+
+        async def gated_send(frame: bytes, **kwargs: object) -> None:
+            entered.set()
+            await release.wait()
+            await send(frame, **kwargs)
+
+        with patch.object(radio._civ_runtime, "_send_civ_frame_now", gated_send):
+            pending = asyncio.create_task(
+                radio._request_authoritative_ptt_read(
+                    provider_generation=9, observer=observer
+                )
+            )
+            await entered.wait()
+            radio._unbind_authoritative_ptt_observer()
+            release.set()
+            with pytest.raises((CommandError, ConnectionError)):
+                await pending
+        assert mock_transport.sent_packets == []
+        assert observations == []
+
+    @pytest.mark.asyncio
+    async def test_fresh_ptt_read_fails_closed_on_callback_and_reconnect(
+        self, radio: IcomRadio, mock_transport: MockTransport
+    ) -> None:
+        def broken(_observation: tx.ProviderPttObservation) -> None:
+            raise RuntimeError("observer")
+
+        radio._bind_authoritative_ptt_observer(provider_generation=10, observer=broken)
+        mock_transport.queue_response(_ptt_response(True))
+        with pytest.raises(CommandError, match="authoritative"):
+            await radio._request_authoritative_ptt_read(
+                provider_generation=10, observer=broken
+            )
+
+        observations: list[tx.ProviderPttObservation] = []
+        observer = observations.append
+        radio._bind_authoritative_ptt_observer(
+            provider_generation=10, observer=observer
+        )
+        pending = asyncio.create_task(
+            radio._request_authoritative_ptt_read(
+                provider_generation=10, observer=observer
+            )
+        )
+        while len(mock_transport.sent_packets) < 2:
+            await asyncio.sleep(0)
+        radio._civ_runtime.advance_generation("test-reconnect")
+        mock_transport.queue_response(_ptt_response(False))
+        with pytest.raises(ConnectionError):
+            await pending
+        assert observations == []
 
 
 class TestTimeout:

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -888,8 +888,12 @@ class TestPtt:
         await _route_ptt(radio, b"\x00")
         assert [item.ptt_observation_seq for item in observations] == [1, 2]
 
-        class EqualObserver(list[tx.ProviderPttObservation]):
-            __call__ = list.append
+        class EqualObserver:
+            def __init__(self) -> None:
+                self.calls: list[tx.ProviderPttObservation] = []
+
+            def __call__(self, observation: tx.ProviderPttObservation) -> None:
+                self.calls.append(observation)
 
             def __eq__(self, _other: object) -> bool:
                 return True
@@ -899,7 +903,8 @@ class TestPtt:
         mock_transport.queue_response(_ptt_response(False))
         with pytest.raises(CommandError, match="authoritative"):
             await read(provider_generation=8, observer=collision)
-        assert not bound
+        assert not bound.calls
+        radio._unbind_authoritative_ptt_observer()
 
     @pytest.mark.asyncio
     async def test_fresh_ptt_read_rechecks_binding_before_dispatch(
@@ -910,6 +915,7 @@ class TestPtt:
         entered = asyncio.Event()
         release = asyncio.Event()
         send = radio._civ_runtime._send_civ_frame_now
+        read = radio._request_authoritative_ptt_read
 
         async def gated_send(frame: bytes, **kwargs: object) -> None:
             entered.set()
@@ -918,9 +924,7 @@ class TestPtt:
 
         with patch.object(radio._civ_runtime, "_send_civ_frame_now", gated_send):
             pending = asyncio.create_task(
-                radio._request_authoritative_ptt_read(
-                    provider_generation=9, observer=observer
-                )
+                read(provider_generation=9, observer=observer)
             )
             await entered.wait()
             radio._unbind_authoritative_ptt_observer()
@@ -945,14 +949,11 @@ class TestPtt:
 
         observations: list[tx.ProviderPttObservation] = []
         observer = observations.append
+        read = radio._request_authoritative_ptt_read
         radio._bind_authoritative_ptt_observer(
             provider_generation=10, observer=observer
         )
-        pending = asyncio.create_task(
-            radio._request_authoritative_ptt_read(
-                provider_generation=10, observer=observer
-            )
-        )
+        pending = asyncio.create_task(read(provider_generation=10, observer=observer))
         while len(mock_transport.sent_packets) < 2:
             await asyncio.sleep(0)
         radio._civ_runtime.advance_generation("test-reconnect")

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -1,7 +1,7 @@
 """Tests for IcomRadio high-level API."""
 
 import asyncio
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -869,7 +869,7 @@ class TestPtt:
             await radio._civ_runtime.stop_pump()
 
     @pytest.mark.asyncio
-    async def test_fresh_ptt_read_rejects_identical_unbind_rebind(
+    async def test_fresh_ptt_read_rejects_rebind_and_equal_distinct_observer(
         self, radio: IcomRadio, mock_transport: MockTransport
     ) -> None:
         observations: list[tx.ProviderPttObservation] = []
@@ -886,18 +886,25 @@ class TestPtt:
         radio._unbind_authoritative_ptt_observer()
         radio._bind_authoritative_ptt_observer(provider_generation=8, observer=observer)
         mock_transport.queue_response(_ptt_response(False))
-
         with pytest.raises(CommandError, match="authoritative"):
             await pending
         await _route_ptt(radio, b"\x00")
         assert [item.ptt_observation_seq for item in observations] == [1, 2]
 
+        bound, collision = MagicMock(), MagicMock()
+        bound.__eq__.return_value = True
+        radio._bind_authoritative_ptt_observer(provider_generation=8, observer=bound)
+        mock_transport.queue_response(_ptt_response(False))
+        with pytest.raises(CommandError, match="authoritative"):
+            await radio._request_authoritative_ptt_read(
+                provider_generation=8, observer=collision
+            )
+
     @pytest.mark.asyncio
     async def test_fresh_ptt_read_rechecks_binding_before_dispatch(
         self, radio: IcomRadio, mock_transport: MockTransport
     ) -> None:
-        observations: list[tx.ProviderPttObservation] = []
-        observer = observations.append
+        observer = MagicMock()
         radio._bind_authoritative_ptt_observer(provider_generation=9, observer=observer)
         entered = asyncio.Event()
         release = asyncio.Event()
@@ -920,14 +927,13 @@ class TestPtt:
             with pytest.raises((CommandError, ConnectionError)):
                 await pending
         assert mock_transport.sent_packets == []
-        assert observations == []
 
     @pytest.mark.asyncio
-    async def test_fresh_ptt_read_fails_closed_on_callback_and_reconnect(
+    async def test_fresh_ptt_read_fails_closed_on_callback_cancel_and_reconnect(
         self, radio: IcomRadio, mock_transport: MockTransport
     ) -> None:
         def broken(_observation: tx.ProviderPttObservation) -> None:
-            raise RuntimeError("observer")
+            raise asyncio.CancelledError("observer")
 
         radio._bind_authoritative_ptt_observer(provider_generation=10, observer=broken)
         mock_transport.queue_response(_ptt_response(True))

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -1,7 +1,7 @@
 """Tests for IcomRadio high-level API."""
 
 import asyncio
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -874,13 +874,10 @@ class TestPtt:
     ) -> None:
         observations: list[tx.ProviderPttObservation] = []
         observer = observations.append
+        read = radio._request_authoritative_ptt_read
         radio._bind_authoritative_ptt_observer(provider_generation=8, observer=observer)
         await _route_ptt(radio, b"\x01")
-        pending = asyncio.create_task(
-            radio._request_authoritative_ptt_read(
-                provider_generation=8, observer=observer
-            )
-        )
+        pending = asyncio.create_task(read(provider_generation=8, observer=observer))
         while not mock_transport.sent_packets:
             await asyncio.sleep(0)
         radio._unbind_authoritative_ptt_observer()
@@ -891,20 +888,24 @@ class TestPtt:
         await _route_ptt(radio, b"\x00")
         assert [item.ptt_observation_seq for item in observations] == [1, 2]
 
-        bound, collision = MagicMock(), MagicMock()
-        bound.__eq__.return_value = True
+        class EqualObserver(list[tx.ProviderPttObservation]):
+            __call__ = list.append
+
+            def __eq__(self, _other: object) -> bool:
+                return True
+
+        bound, collision = EqualObserver(), EqualObserver()
         radio._bind_authoritative_ptt_observer(provider_generation=8, observer=bound)
         mock_transport.queue_response(_ptt_response(False))
         with pytest.raises(CommandError, match="authoritative"):
-            await radio._request_authoritative_ptt_read(
-                provider_generation=8, observer=collision
-            )
+            await read(provider_generation=8, observer=collision)
+        assert not bound
 
     @pytest.mark.asyncio
     async def test_fresh_ptt_read_rechecks_binding_before_dispatch(
         self, radio: IcomRadio, mock_transport: MockTransport
     ) -> None:
-        observer = MagicMock()
+        observer = [].append
         radio._bind_authoritative_ptt_observer(provider_generation=9, observer=observer)
         entered = asyncio.Event()
         release = asyncio.Event()

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -868,7 +868,6 @@ class TestPtt:
         finally:
             await radio._civ_runtime.stop_pump()
 
-    @pytest.mark.asyncio
     async def test_fresh_ptt_read_rejects_rebind_and_equal_distinct_observer(
         self, radio: IcomRadio, mock_transport: MockTransport
     ) -> None:

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -900,11 +900,10 @@ class TestPtt:
 
         bound, collision = EqualObserver(), EqualObserver()
         radio._bind_authoritative_ptt_observer(provider_generation=8, observer=bound)
-        mock_transport.queue_response(_ptt_response(False))
         with pytest.raises(CommandError, match="authoritative"):
             await read(provider_generation=8, observer=collision)
         assert not bound.calls
-        radio._unbind_authoritative_ptt_observer()
+        await radio._civ_runtime.stop_pump()
 
     @pytest.mark.asyncio
     async def test_fresh_ptt_read_rechecks_binding_before_dispatch(


### PR DESCRIPTION
## Summary
- add an observer binding epoch that advances on every bind and unbind without resetting same-provider observation sequence
- bind each fresh PTT read to one observer/provider/source/transport snapshot and revalidate it before dispatch and publication
- attach the fresh read to MOR-1108 exact data-transaction ownership so its response cannot publish through the ordinary observation path

## Verification
- red-first lifecycle tests for identical callback unbind/rebind, pre-dispatch invalidation, callback failure, reconnect, and sequence continuity
- `uv run pytest tests/test_raw_civ_transaction.py tests/test_civ_transaction_ownership.py tests/test_radio.py -q` (259 passed)
- `uv run pytest -q -m "not integration" -n auto` (8562 passed, 73 skipped, 11 xfailed, 1 xpassed)
- `uv run ruff check src/rigplane/runtime/_civ_rx.py src/rigplane/runtime/radio.py tests/test_radio.py`
- `uv run ruff format --check src/rigplane/runtime/_civ_rx.py src/rigplane/runtime/radio.py tests/test_radio.py`
- import smoke for `CivRuntime` and `CoreRadio`
- `git diff --check`

Draft pending CI and independent review. Full MOR-1103 provider-attempt wrapper remains out of scope.

Closes #1990
Linear: MOR-1109