### PR TITLE
MOR-1120: bind managed provider generation fail closed

### DIFF
--- a/src/rigplane/runtime/managed_radio_runtime.py
+++ b/src/rigplane/runtime/managed_radio_runtime.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Awaitable, Callable
+from typing import Literal, Protocol
 
 from rigplane.core.tx_safety import (
     Clock,
     IdFactory,
+    ProviderPttObservation,
     TxOutcome,
     TxOwner,
     TxReleaseReason,
@@ -16,6 +18,20 @@ from rigplane.core.tx_safety import (
 
 TxService = Callable[[TxSafetySupervisor, TxTransition], Awaitable[None]]
 ProviderRelease = Callable[[], Awaitable[None]]
+_PttObserver = Callable[[ProviderPttObservation], None]
+_ProviderLifecycleState = Literal["unbound", "bound", "invalidating"]
+
+
+class ProviderTxLifecycle(Protocol):
+    def _bind_authoritative_ptt_observer(
+        self, *, provider_generation: int, observer: _PttObserver
+    ) -> None: ...
+
+    def _unbind_authoritative_ptt_observer(self) -> None: ...
+
+    async def _request_authoritative_ptt_read(
+        self, *, provider_generation: int, observer: _PttObserver
+    ) -> None: ...
 
 
 class ManagedRadioRuntime:
@@ -24,6 +40,7 @@ class ManagedRadioRuntime:
         target_id: str,
         *,
         service: TxService,
+        provider_lifecycle: ProviderTxLifecycle | None = None,
         clock: Clock | None = None,
         id_factory: IdFactory | None = None,
         shutdown_timeout_seconds: float = 3.0,
@@ -33,7 +50,10 @@ class ManagedRadioRuntime:
         self.target_id = target_id
         self._tx_safety = TxSafetySupervisor(clock=clock, id_factory=id_factory)
         self._service = service
+        self._provider_lifecycle = provider_lifecycle
         self._provider_generation = 0
+        self._bound_generation: int | None = None
+        self._provider_state: _ProviderLifecycleState = "unbound"
         self._shutdown_timeout = shutdown_timeout_seconds
 
     @property
@@ -44,15 +64,77 @@ class ManagedRadioRuntime:
         if transition.effects:
             await self._service(self._tx_safety, transition)
 
+    def _not_ready(self) -> TxTransition:
+        return TxTransition(TxOutcome.NOT_READY, self.tx_snapshot)
+
+    def _observe_ptt(self, observation: ProviderPttObservation) -> None:
+        if (
+            self._provider_state == "bound"
+            and observation.provider_generation
+            == self._bound_generation
+            == self._provider_generation
+        ):
+            self._tx_safety.observe_ptt(observation)
+
+    def _unbind(self) -> BaseException | None:
+        lifecycle = self._provider_lifecycle
+        if self._provider_state != "bound" or lifecycle is None:
+            return None
+        self._provider_state = "invalidating"
+        self._bound_generation = None
+        try:
+            lifecycle._unbind_authoritative_ptt_observer()
+        except BaseException as exc:
+            return exc
+        return None
+
     async def replace_provider(self, *, ready: bool) -> TxTransition:
+        unbind_error = self._unbind()
         self._provider_generation += 1
-        transition = self._tx_safety.replace_provider(
-            self._provider_generation, ready=ready
-        )
+        generation = self._provider_generation
+        transition = self._tx_safety.replace_provider(generation, ready=False)
+        self._provider_state = "unbound"
+        if unbind_error is not None:
+            raise unbind_error
+        lifecycle = self._provider_lifecycle
+        if lifecycle is None:
+            return transition
+        try:
+            lifecycle._bind_authoritative_ptt_observer(
+                provider_generation=generation, observer=self._observe_ptt
+            )
+        except BaseException:
+            try:
+                lifecycle._unbind_authoritative_ptt_observer()
+            except BaseException:
+                pass
+            raise
+        self._bound_generation = generation
+        self._provider_state = "bound"
+        if ready:
+            transition = self._tx_safety.set_provider_ready(generation, ready=True)
         await self._service_effects(transition)
         return transition
 
+    async def invalidate_provider(self, provider_generation: int) -> TxTransition:
+        if provider_generation != self._provider_generation:
+            return TxTransition(TxOutcome.STALE, self.tx_snapshot)
+        unbind_error = self._unbind()
+        self._provider_generation += 1
+        transition = self._tx_safety.replace_provider(
+            self._provider_generation, ready=False
+        )
+        self._provider_state = "unbound"
+        if unbind_error is not None:
+            raise unbind_error
+        return transition
+
     async def set_provider_ready(self, *, ready: bool) -> TxTransition:
+        if ready and (
+            self._provider_state != "bound"
+            or self._bound_generation != self._provider_generation
+        ):
+            return self._not_ready()
         transition = self._tx_safety.set_provider_ready(
             self._provider_generation, ready=ready
         )
@@ -60,6 +142,11 @@ class ManagedRadioRuntime:
         return transition
 
     async def request_on(self, owner: TxOwner) -> TxTransition:
+        if (
+            self._provider_state != "bound"
+            or self._bound_generation != self._provider_generation
+        ):
+            return self._not_ready()
         transition = self._tx_safety.request_on(owner)
         await self._service_effects(transition)
         return transition

--- a/tests/test_managed_radio_runtime.py
+++ b/tests/test_managed_radio_runtime.py
@@ -1,5 +1,5 @@
 import asyncio
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from dataclasses import FrozenInstanceError
 
 import pytest
@@ -17,7 +17,44 @@ from rigplane.core.tx_safety import (
     TxSource,
     TxTransition,
 )
-from rigplane.runtime.managed_radio_runtime import ManagedRadioRuntime, TxService
+from rigplane.runtime.managed_radio_runtime import (
+    ManagedRadioRuntime,
+    ProviderTxLifecycle,
+    TxService,
+)
+from rigplane.runtime.radio import CoreRadio
+
+
+class ProviderLifecycle:
+    def __init__(self) -> None:
+        self.bindings: list[tuple[int, Callable[[ProviderPttObservation], None]]] = []
+        self.current: tuple[int, Callable[[ProviderPttObservation], None]] | None = None
+        self.bind_error = self.unbind_error = False
+
+    def _bind_authoritative_ptt_observer(
+        self,
+        *,
+        provider_generation: int,
+        observer: Callable[[ProviderPttObservation], None],
+    ) -> None:
+        self.current = (provider_generation, observer)
+        self.bindings.append(self.current)
+        if self.bind_error:
+            raise RuntimeError("bind failed")
+
+    def _unbind_authoritative_ptt_observer(self) -> None:
+        if self.unbind_error:
+            raise RuntimeError("unbind failed")
+        self.current = None
+
+    async def _request_authoritative_ptt_read(
+        self,
+        *,
+        provider_generation: int,
+        observer: Callable[[ProviderPttObservation], None],
+    ) -> None:
+        assert self.current == (provider_generation, observer)
+        observer(ProviderPttObservation(RadioTx.OFF, provider_generation, 1, 10.0))
 
 
 def ids() -> Iterator[str]:
@@ -38,11 +75,13 @@ def runtime(
     *,
     timeout: float = 0.01,
     service: TxService = no_effects,
+    lifecycle: ProviderTxLifecycle | None = None,
 ) -> ManagedRadioRuntime:
     generated = ids()
     return ManagedRadioRuntime(
         target,
         service=service,
+        provider_lifecycle=lifecycle or ProviderLifecycle(),
         clock=lambda: 10.0,
         id_factory=lambda: next(generated),
         shutdown_timeout_seconds=timeout,
@@ -205,3 +244,68 @@ async def test_shutdown_error_still_releases_provider() -> None:
     with pytest.raises(RuntimeError, match="dekey failed"):
         await rt.shutdown(release_provider=release)
     assert released
+
+
+@pytest.mark.asyncio
+async def test_real_core_radio_keyword_port_binds_effectless_generation() -> None:
+    radio = CoreRadio("127.0.0.1")
+    rt = runtime(lifecycle=radio)
+
+    changed = await rt.replace_provider(ready=False)
+
+    assert changed.snapshot.provider_generation == 1
+    assert radio._civ_runtime._ptt_observer_provider_generation == 1
+    await rt.invalidate_provider(1)
+
+
+@pytest.mark.asyncio
+async def test_unbound_bind_failure_and_stale_callback_fail_closed() -> None:
+    provider = ProviderLifecycle()
+    rt = runtime(lifecycle=provider)
+    owner = TxOwner(TxSource.SDK, "sdk")
+    assert (await rt.request_on(owner)).outcome is TxOutcome.NOT_READY
+
+    provider.bind_error = True
+    with pytest.raises(RuntimeError, match="bind failed"):
+        await rt.replace_provider(ready=True)
+    generation, observer = provider.bindings[-1]
+    assert rt.tx_snapshot.provider_generation == generation == 1
+    assert rt.tx_snapshot.provider_ready is False
+    assert callable(observer)
+    observer(ProviderPttObservation(RadioTx.ON, generation, 1, 10.0))
+    assert rt.tx_snapshot.radio_tx is RadioTx.UNKNOWN
+    assert (await rt.request_on(owner)).outcome is TxOutcome.NOT_READY
+    assert (await rt.set_provider_ready(ready=True)).outcome is TxOutcome.NOT_READY
+
+
+@pytest.mark.asyncio
+async def test_unbind_failure_still_invalidates_host_and_old_callback() -> None:
+    provider = ProviderLifecycle()
+    rt = runtime(lifecycle=provider)
+    await rt.replace_provider(ready=True)
+    generation, observer = provider.bindings[-1]
+    provider.unbind_error = True
+
+    with pytest.raises(RuntimeError, match="unbind failed"):
+        await rt.invalidate_provider(generation)
+
+    assert rt.tx_snapshot.provider_generation == 2
+    assert rt.tx_snapshot.provider_ready is False
+    assert callable(observer)
+    observer(ProviderPttObservation(RadioTx.ON, generation, 1, 10.0))
+    assert rt.tx_snapshot.radio_tx is RadioTx.UNKNOWN
+    assert (await rt.set_provider_ready(ready=True)).outcome is TxOutcome.NOT_READY
+
+
+@pytest.mark.asyncio
+async def test_replacement_rejects_old_generation_callback() -> None:
+    provider = ProviderLifecycle()
+    rt = runtime(lifecycle=provider)
+    await rt.replace_provider(ready=True)
+    generation, observer = provider.bindings[-1]
+
+    await rt.replace_provider(ready=True)
+    observer(ProviderPttObservation(RadioTx.ON, generation, 1, 10.0))
+
+    assert rt.tx_snapshot.provider_generation == 2
+    assert rt.tx_snapshot.radio_tx is RadioTx.UNKNOWN


### PR DESCRIPTION
## Summary

- add a private, consumer-defined provider lifecycle port to `ManagedRadioRuntime`
- bind an exact provider generation before readiness or ON can be admitted
- invalidate host authority even when provider unbind fails
- reject partial-bind and old-generation callbacks fail closed

## Why

MOR-1104's full lifecycle boundary exceeded the repository's 200 net LOC guardrail. This PR is the first bounded child slice: generation binding and fail-closed readiness. Fresh-read serialization and terminal shutdown remain in MOR-1121.

## Verification

- `uv run pytest tests/test_managed_radio_runtime.py tests/test_tx_safety.py tests/test_radio.py -q -n auto --tb=short` — 311 passed
- `uv run pytest tests/ --ignore=tests/integration -n auto --tb=short --timeout=300 --timeout-method=thread -q` — 8433 passed, 12 skipped, 11 xfailed, 1 xpassed
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- strict mypy for both changed files
- `uv run lint-imports` — 5 contracts kept
- `git diff --check`

## Scope

- 2 files
- 191 net LOC
- no fresh-read await/serialization, terminal shutdown, CI-V/token, executor, SDK, Web/frontend, or public API changes

Linear: MOR-1120

Closes #1996
