### PR TITLE
feat: compute dormant browser TX-audio facts

### DIFF
--- a/src/rigplane/web/handlers/audio.py
+++ b/src/rigplane/web/handlers/audio.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 import time
 from collections.abc import AsyncIterator, Awaitable
@@ -11,6 +12,7 @@ from typing import TYPE_CHECKING, Any, Callable, Protocol, cast
 
 from rigplane.audio._codecs import decode_ulaw_to_pcm16
 from rigplane.audio._transcoder import PcmOpusTranscoder, create_pcm_opus_transcoder
+from ...audio import route as audio_route
 from ...audio.bus import STAGE_RX_POST_DSP
 from ...audio.session import RxSubscription
 from ...audio.usb_driver import AudioAlreadyStartedError
@@ -39,6 +41,7 @@ if TYPE_CHECKING:
     from ...radio_protocol import Radio
 
 from ...capabilities import CAP_AUDIO, CAP_LAN_DUAL_RX_AUDIO_ROUTING
+from ...capabilities import CAP_MOD_INPUT_ROUTING, CAP_TX
 
 __all__ = ["AudioBroadcaster", "AudioHandler", "RxPcmTapSource"]
 
@@ -107,6 +110,114 @@ class RxPcmTapSource:
 
     codec: AudioCodec
     sample_rate: int
+
+
+@dataclass(frozen=True, slots=True)
+class BrowserTxAudioFacts:
+    available: bool
+    route: str | None
+    required_mod_input_source: int | None
+    codec: AudioCodec | None = None
+    path: str | None = None
+    lifecycle: tuple[Any, ...] | None = None
+
+
+def _tx_codec_for_radio(radio: object) -> AudioCodec | None:
+    codec = getattr(radio, "audio_tx_codec", None)
+    if codec is None:
+        codec = getattr(getattr(radio, "audio_stream_contract", None), "tx_codec", None)
+    if codec is None:
+        codec = getattr(radio, "audio_codec", None)
+    supported = (AudioCodec.PCM_1CH_16BIT, AudioCodec.OPUS_1CH)
+    return codec if isinstance(codec, AudioCodec) and codec in supported else None
+
+
+def _concrete_async_method(owner: object, name: str, method: object) -> Any | None:
+    if not callable(method) or not asyncio.iscoroutinefunction(method):
+        return None
+    if name in getattr(owner, "__dict__", {}):
+        return None
+    base = next((cls for cls in type(owner).__mro__ if name in cls.__dict__), None)
+    if (
+        base is None
+        or getattr(base, "_is_protocol", False)
+        or getattr(base.__dict__[name], "__isabstractmethod__", False)
+    ):
+        return None
+    if getattr(method, "__self__", None) is not owner:
+        return None
+    args = (b"",) if "push" in name else ("web",) if name == "acquire_tx" else ()
+    kwargs = {"sample_rate": 48_000} if name == "start_audio_tx_pcm" else {}
+    try:
+        inspect.signature(method).bind(*args, **kwargs)
+    except (TypeError, ValueError):
+        return None
+    return method
+
+
+def _lifecycle(
+    owner: object, names: tuple[str, ...]
+) -> tuple[tuple[Any, ...] | None, bool]:
+    raw = tuple(getattr(owner, name, None) for name in names)
+    methods = tuple(
+        _concrete_async_method(owner, name, method)
+        for name, method in zip(names, raw, strict=True)
+    )
+    return (methods if all(methods) else None), any(item is not None for item in raw)
+
+
+def _tx_path(radio: object, codec: AudioCodec) -> tuple[str, tuple[Any, ...]] | None:
+    neutral, has_neutral = _lifecycle(radio, ("start_tx", "push_tx", "stop_tx"))
+    session = getattr(radio, "audio_session", None)
+    if session is not None:
+        acquire_raw = getattr(session, "acquire_tx", None)
+        acquire = _concrete_async_method(session, "acquire_tx", acquire_raw)
+        return ("session", (acquire, *neutral[1:])) if acquire and neutral else None
+    if has_neutral:
+        return ("neutral", neutral) if neutral is not None else None
+    suffix = "pcm" if codec == AudioCodec.PCM_1CH_16BIT else "opus"
+    lifecycle, _ = _lifecycle(
+        radio, tuple(f"{op}_audio_tx_{suffix}" for op in ("start", "push", "stop"))
+    )
+    return (suffix, lifecycle) if lifecycle is not None else None
+
+
+def browser_tx_audio_facts(radio: "Radio | None") -> BrowserTxAudioFacts:
+    """Resolve the exact fail-closed structural snapshot for HTTP and audio WS."""
+    unavailable = BrowserTxAudioFacts(False, None, None)
+    caps = runtime_capabilities(radio)
+    if radio is None or not {CAP_AUDIO, CAP_TX}.issubset(caps):
+        return unavailable
+    try:
+        codec = _tx_codec_for_radio(radio)
+        if codec is None or (path := _tx_path(radio, codec)) is None:
+            return unavailable
+        route = audio_route.resolve_audio_route(radio)
+        source, policy = route.tx_audio_source, route.data_mode_policy
+        if (source, policy) not in {
+            (audio_route.TxAudioSource.LAN, audio_route.DataModePolicy.DATA2_LAN),
+            (audio_route.TxAudioSource.LAN, audio_route.DataModePolicy.LEGACY),
+            (audio_route.TxAudioSource.USB, audio_route.DataModePolicy.DATA1_USB),
+            (audio_route.TxAudioSource.ACC, audio_route.DataModePolicy.LEGACY),
+        }:
+            return unavailable
+        required = (
+            audio_route.rigctld_wsjtx_policy(route)[1]
+            if CAP_MOD_INPUT_ROUTING in caps
+            else None
+        )
+        if required is not None and (
+            source is not audio_route.TxAudioSource.LAN
+            or not isinstance(required, int)
+            or isinstance(required, bool)
+            or not 0 <= required <= 9_007_199_254_740_991
+        ):
+            return unavailable
+        return BrowserTxAudioFacts(
+            True, source.value, required, codec, path[0], path[1]
+        )
+    except Exception:
+        return unavailable
 
 
 def _is_benign_tx_restart(exc: RuntimeError) -> bool:

--- a/tests/test_web_capability_guards.py
+++ b/tests/test_web_capability_guards.py
@@ -6,10 +6,16 @@ TDD: these tests were written FIRST, then the backend was modified to pass them.
 from __future__ import annotations
 
 import json
-from dataclasses import replace
+from dataclasses import astuple, replace
+from types import SimpleNamespace
 
 import pytest
 
+from rigplane.backends.yaesu_cat.radio import YaesuCatRadio
+from rigplane.radio_protocol import AudioCapable
+from rigplane.runtime.radio import IcomRadio
+from rigplane.types import AudioCodec
+from rigplane.web.handlers.audio import browser_tx_audio_facts
 from rigplane.web.server import WebServer
 
 
@@ -290,6 +296,86 @@ class TestCapabilitiesEndpoint:
         await srv._serve_capabilities(writer)  # noqa: SLF001
         data = _parse_json_body(writer)
         assert data["antennas"] == 1
+
+
+def _yaesu(cls=YaesuCatRadio):
+    return cls("/dev/null", audio_driver=SimpleNamespace())
+
+
+def test_browser_tx_audio_facts_fail_closed():
+    no_tx = type(
+        "NoTx",
+        (YaesuCatRadio,),
+        {"capabilities": property(lambda _: {"audio"})},
+    )
+    bad_codec = type(
+        "BadCodec",
+        (YaesuCatRadio,),
+        {
+            "audio_tx_codec": property(lambda _: None),
+            "audio_codec": property(lambda _: None),
+        },
+    )
+    variants = (
+        _yaesu(no_tx),
+        _yaesu(bad_codec),
+        _yaesu(type("Partial", (YaesuCatRadio,), {"push_tx": None})),
+        _yaesu(type("SyncPush", (YaesuCatRadio,), {"push_tx": lambda *_: None})),
+        _yaesu(
+            type("WrongArity", (YaesuCatRadio,), {"push_tx": YaesuCatRadio.stop_tx})
+        ),
+    )
+    assert all(not browser_tx_audio_facts(radio).available for radio in variants)
+
+
+def test_browser_tx_audio_facts_reject_stubs_and_instance_callables():
+    class StubRadio(AudioCapable):
+        capabilities = {"audio", "tx"}
+        backend_id = "yaesu_cat"
+        has_usb_audio = True
+        audio_tx_codec = AudioCodec.OPUS_1CH
+
+    assert browser_tx_audio_facts(StubRadio()).available is False
+    donor, victim = _yaesu(), _yaesu()
+    victim.start_tx = donor.start_tx
+    assert browser_tx_audio_facts(victim).available is False
+
+    victim = _yaesu()
+    victim.push_tx = YaesuCatRadio.stop_tx
+    assert browser_tx_audio_facts(victim).available is False
+
+
+class _CountingRadio(YaesuCatRadio):
+    reads: dict[str, int]
+
+    def __getattribute__(self, name: str):
+        if name in {"start_tx", "push_tx", "stop_tx"}:
+            reads = object.__getattribute__(self, "reads")
+            reads[name] += 1
+        return super().__getattribute__(name)
+
+
+def test_browser_tx_audio_facts_reads_each_lifecycle_method_once():
+    radio = _yaesu(_CountingRadio)
+    radio.reads = dict.fromkeys(("start_tx", "push_tx", "stop_tx"), 0)
+    facts = browser_tx_audio_facts(radio)
+    assert facts.available is True
+    assert radio.reads == {"start_tx": 1, "push_tx": 1, "stop_tx": 1}
+
+
+def test_browser_tx_audio_facts_pin_real_provider_snapshots():
+    icom = browser_tx_audio_facts(IcomRadio("192.168.55.40", model="IC-7610"))
+    yaesu = browser_tx_audio_facts(
+        YaesuCatRadio("/dev/null", audio_driver=SimpleNamespace())
+    )
+    assert astuple(icom)[:-1] == (True, "lan", 5, AudioCodec.PCM_1CH_16BIT, "session")
+    assert astuple(yaesu)[:-1] == (
+        True,
+        "usb",
+        None,
+        AudioCodec.PCM_1CH_16BIT,
+        "session",
+    )
 
 
 # ── /api/v1/state tests ───────────────────────────────────────


### PR DESCRIPTION
Closes #1998
Linear: MOR-1126
Parent: #1958 / MOR-1050
Consumer follow-up: #1999 / MOR-1127

## Summary

- define one immutable, fail-closed `BrowserTxAudioFacts` snapshot containing the future public tuple plus the validated codec, selected path, and concrete async lifecycle callables
- accept only class-defined bound async methods owned by the evaluated object and compatible with the exact future call shape
- reject Protocol/abstract/partial/synchronous/wrong-arity/foreign-bound/unbound lifecycle evidence, unsupported codecs, and malformed or contradictory routes
- evaluate each lifecycle attribute exactly once per snapshot
- pin real IC-7610 and FTX-1 provider snapshots

## Dormant boundary

This slice has no production consumer and makes no behavior or wire change. `browser_tx_audio_facts` is defined only in `src/rigplane/web/handlers/audio.py`; `/api/v1/capabilities` remains unchanged and audio WS still uses its existing behavior.

MOR-1127/#1999 atomically owns both the first public `audioTx` projection and the WS snapshot enforcement. Public capability cannot appear before enforcement.

## Scope

Exactly 2 files, `+198/-1`, net `+197` LOC. All unrelated protocol comments/docstrings remain intact.

## Verification

- focused facts test file: 29 passed
- focused web/audio matrix: PASS
- full non-integration: 8433 passed, 12 skipped, 5 deselected, 11 xfailed, 1 xpassed
- Ruff check/format, strict web mypy, import-linter 5/5, and diff check: PASS
- exact-head CI pending

PR remains Draft pending fresh independent Opus 5 max review. No readiness or merge action.