### PR TITLE
feat: add resource demand foundation

### DIFF
--- a/frontend/src/lib/runtime/__tests__/resource-demand.test.ts
+++ b/frontend/src/lib/runtime/__tests__/resource-demand.test.ts
@@ -1,71 +1,71 @@
 import { describe, expect, it } from 'vitest';
-import { ResourceDemand } from '../resource-demand';
+import { ResourceDemand, type AppResource } from '../resource-demand';
 const one = (model: ResourceDemand<string>) => {
   const operations = model.takeOperations();
   expect(operations).toHaveLength(1);
   return operations[0];
 };
-const cleanupOrderings = ['stop-before-stale', 'stale-before-stop'] as const;
+const supersede = (model: ResourceDemand<string>, resource: AppResource, consumer: string) => {
+  const lease = model.acquire(resource, consumer);
+  const start = one(model);
+  model.release(lease);
+  return start;
+};
+const cleanupCases = [
+  [false, ['rx-audio', 'rx-audio'], ['H', 'H'], ['rx-audio:H']],
+  [true, ['rx-audio', 'rx-audio'], ['H', 'H'], ['rx-audio:H']],
+  [false, ['rx-audio', 'rx-audio'], ['A', 'B'], ['rx-audio:A', 'rx-audio:B']],
+  [false, ['rx-audio', 'hardware-scope'], ['H', 'H'], ['rx-audio:H', 'hardware-scope:H']],
+] as const;
 describe('ResourceDemand foundation', () => {
-  it('uses exact leases and emits only first start and last stop', () => {
+  it('uses exact leases and remembers adopted handles across cleanup drains', () => {
     const model = new ResourceDemand<string>('session-1');
-    model.configure('hardware-scope', { available: true, selected: true });
-    const first = model.acquire('hardware-scope', 'first');
-    const start = one(model);
-    const second = model.acquire('hardware-scope', 'second');
-    expect(second).not.toBe(first);
-    expect(model.takeOperations()).toEqual([]);
-    expect(model.completeStart(start, { handle: 'scope' })).toBe(true);
-    expect(model.release(first)).toBe(true);
-    expect(model.takeOperations()).toEqual([]);
-    expect(model.release({ ...second } as typeof second)).toBe(false);
-    expect(new ResourceDemand<string>('session-2').release(second)).toBe(false);
-    expect(model.release(second)).toBe(true);
-    expect(one(model)).toMatchObject({ kind: 'stop', handle: 'scope' });
-  });
-  it('keeps unavailable resources idle and copies only public configuration', () => {
-    const model = new ResourceDemand<string>('session-1');
-    const widerConfig = { available: false, selected: true, demand: 99, activeHandle: 'ghost' };
-    model.configure('audio-fft', widerConfig);
+    const wider = { available: false, selected: true, demand: 99, activeHandle: 'ghost' };
+    model.configure('audio-fft', wider);
     model.acquire('audio-fft', 'panel');
-    expect(model.takeOperations()).toEqual([]);
     expect(model.snapshot('audio-fft')).toEqual({
       available: false, selected: true, demand: 1, health: 'inactive',
     });
-    model.configure('audio-fft', { available: true, selected: true });
-    expect(one(model).kind).toBe('start');
-  });
-  it.each(cleanupOrderings)('dedupes stable-handle cleanup for %s ordering', (ordering) => {
-    const model = new ResourceDemand<string>('session-1');
-    model.configure('hardware-scope', { available: true, selected: true });
-    const first = model.acquire('hardware-scope', 'A');
-    const startA = one(model);
-    expect(model.completeStart({ ...startA }, { handle: 'fake' })).toBe(false);
-    model.release(first);
-    const second = model.acquire('hardware-scope', 'B');
-    const startB = one(model);
-    if (ordering === 'stop-before-stale') {
-      expect(model.completeStart(startB, { handle: 'stable' })).toBe(true);
-      expect(model.completeStart(startB, { handle: 'stable' })).toBe(false);
-      model.release(second);
-      expect(model.completeStart(startA, { handle: 'stable' })).toBe(false);
-    } else {
-      expect(model.completeStart(startA, { handle: 'stable' })).toBe(false);
-      expect(model.completeStart(startB, { handle: 'stable' })).toBe(true);
-      model.release(second);
-    }
-    expect(one(model)).toMatchObject({ kind: 'stop', handle: 'stable' });
-  });
-  it('rejects a stale stop when replacement demand overlaps it', () => {
-    const model = new ResourceDemand<string>('session-1');
     model.configure('rx-audio', { available: true, selected: true });
-    const first = model.acquire('rx-audio', 'A');
-    model.completeStart(one(model), { handle: 'A' });
-    model.release(first);
-    const oldStop = one(model);
-    model.acquire('rx-audio', 'B');
-    model.completeStart(one(model), { handle: 'B' });
-    expect(model.completeStop(oldStop)).toBe(false);
-    expect(model.snapshot('rx-audio')).toMatchObject({ activeHandle: 'B', health: 'streaming' });
+    const staleA = supersede(model, 'rx-audio', 'A');
+    const late = ['B', 'C'].map((consumer) => supersede(model, 'rx-audio', consumer));
+    const first = model.acquire('rx-audio', 'first');
+    const start = one(model);
+    const shared = model.acquire('rx-audio', 'shared');
+    expect(model.takeOperations()).toEqual([]);
+    expect(model.release({ ...shared } as typeof shared)).toBe(false);
+    expect(new ResourceDemand<string>('session-1').release(shared)).toBe(false);
+    expect(model.completeStart({ ...start }, { handle: 'fake' })).toBe(false);
+    expect(model.completeStart(staleA, { handle: 'stable' })).toBe(false);
+    expect(model.takeOperations()).toEqual([]);
+    expect(model.completeStart(start, { handle: 'stable' })).toBe(true);
+    expect(model.completeStart(start, { handle: 'stable' })).toBe(false);
+    expect(model.takeOperations()).toEqual([]);
+    expect(model.release(first)).toBe(true);
+    expect(model.takeOperations()).toEqual([]);
+    expect(model.release(shared)).toBe(true);
+    const stop = one(model);
+    expect(model.completeStop(stop)).toBe(true);
+    for (const operation of late)
+      expect(model.completeStart(operation, { handle: 'stable' })).toBe(false);
+    expect(model.takeOperations()).toEqual([]);
+    const replacement = model.acquire('rx-audio', 'replacement');
+    model.completeStart(one(model), { handle: 'next' });
+    model.release(replacement);
+    const staleStop = one(model);
+    model.acquire('rx-audio', 'overlap');
+    model.completeStart(one(model), { handle: 'latest' });
+    expect(model.completeStop(staleStop)).toBe(false);
+  });
+  it.each(cleanupCases)('dedupes orphan cleanup %#', (drain, resources, handles, expected) => {
+    const model = new ResourceDemand<string>('session-1');
+    resources.forEach((resource) => model.configure(resource, { available: true, selected: true }));
+    const starts = resources.map((resource, index) => supersede(model, resource, String(index)));
+    const emitted = starts.flatMap((start, index) => {
+      model.completeStart(start, { handle: handles[index] });
+      return drain ? model.takeOperations() : [];
+    });
+    emitted.push(...model.takeOperations());
+    expect(emitted.map((op) => 'handle' in op && `${op.resource}:${op.handle}`)).toEqual(expected);
   });
 });

--- a/frontend/src/lib/runtime/__tests__/resource-demand.test.ts
+++ b/frontend/src/lib/runtime/__tests__/resource-demand.test.ts
@@ -6,48 +6,38 @@ const one = (model: ResourceDemand<string>) => {
   return operations[0];
 };
 const supersede = (model: ResourceDemand<string>, resource: AppResource, consumer: string) => {
-  const lease = model.acquire(resource, consumer);
-  const start = one(model);
+  const lease = model.acquire(resource, consumer), start = one(model);
   model.release(lease);
   return start;
 };
-const cleanupCases = [
-  [false, ['rx-audio', 'rx-audio'], ['H', 'H'], ['rx-audio:H']],
+const cleanupCases = [[false, ['rx-audio', 'rx-audio'], ['H', 'H'], ['rx-audio:H']],
   [true, ['rx-audio', 'rx-audio'], ['H', 'H'], ['rx-audio:H']],
   [false, ['rx-audio', 'rx-audio'], ['A', 'B'], ['rx-audio:A', 'rx-audio:B']],
-  [false, ['rx-audio', 'hardware-scope'], ['H', 'H'], ['rx-audio:H', 'hardware-scope:H']],
-] as const;
+  [false, ['rx-audio', 'hardware-scope'], ['H', 'H'], ['rx-audio:H', 'hardware-scope:H']]] as const;
 describe('ResourceDemand foundation', () => {
   it('uses exact leases and remembers adopted handles across cleanup drains', () => {
     const model = new ResourceDemand<string>('session-1');
     const wider = { available: false, selected: true, demand: 99, activeHandle: 'ghost' };
     model.configure('audio-fft', wider);
     model.acquire('audio-fft', 'panel');
-    expect(model.snapshot('audio-fft')).toEqual({
-      available: false, selected: true, demand: 1, health: 'inactive',
-    });
+    expect(model.snapshot('audio-fft')).toEqual({ available: false, selected: true, demand: 1, health: 'inactive' });
     model.configure('rx-audio', { available: true, selected: true });
     const staleA = supersede(model, 'rx-audio', 'A');
     const late = ['B', 'C'].map((consumer) => supersede(model, 'rx-audio', consumer));
-    const first = model.acquire('rx-audio', 'first');
-    const start = one(model);
+    const first = model.acquire('rx-audio', 'first'), start = one(model);
     const shared = model.acquire('rx-audio', 'shared');
     expect(model.takeOperations()).toEqual([]);
     expect(model.release({ ...shared } as typeof shared)).toBe(false);
     expect(new ResourceDemand<string>('session-1').release(shared)).toBe(false);
     expect(model.completeStart({ ...start }, { handle: 'fake' })).toBe(false);
     expect(model.completeStart(staleA, { handle: 'stable' })).toBe(false);
-    expect(model.takeOperations()).toEqual([]);
     expect(model.completeStart(start, { handle: 'stable' })).toBe(true);
     expect(model.completeStart(start, { handle: 'stable' })).toBe(false);
-    expect(model.takeOperations()).toEqual([]);
     expect(model.release(first)).toBe(true);
-    expect(model.takeOperations()).toEqual([]);
     expect(model.release(shared)).toBe(true);
     const stop = one(model);
     expect(model.completeStop(stop)).toBe(true);
-    for (const operation of late)
-      expect(model.completeStart(operation, { handle: 'stable' })).toBe(false);
+    for (const operation of late) expect(model.completeStart(operation, { handle: 'stable' })).toBe(false);
     expect(model.takeOperations()).toEqual([]);
     const replacement = model.acquire('rx-audio', 'replacement');
     model.completeStart(one(model), { handle: 'next' });
@@ -67,5 +57,15 @@ describe('ResourceDemand foundation', () => {
     });
     emitted.push(...model.takeOperations());
     expect(emitted.map((op) => 'handle' in op && `${op.resource}:${op.handle}`)).toEqual(expected);
+  });
+  it('defers singleton cleanup until pending adoption', () => {
+    const model = new ResourceDemand<string>('session-1');
+    model.configure('rx-audio', { available: true, selected: true });
+    const staleStart = supersede(model, 'rx-audio', 'stale');
+    const liveLease = model.acquire('rx-audio', 'live'), liveStart = one(model);
+    expect(model.completeStart(staleStart, { handle: 'stable' })).toBe(false);
+    expect([model.takeOperations(), model.takeOperations()]).toEqual([[], []]);
+    expect(model.completeStart(liveStart, { handle: 'stable' })).toBe(true);
+    model.release(liveLease); expect(model.takeOperations().map((op) => op.kind)).toEqual(['stop']);
   });
 });

--- a/frontend/src/lib/runtime/__tests__/resource-demand.test.ts
+++ b/frontend/src/lib/runtime/__tests__/resource-demand.test.ts
@@ -1,17 +1,15 @@
 import { describe, expect, it } from 'vitest';
-import { ResourceDemand, type AppResource } from '../resource-demand';
-const ready = (model: ResourceDemand<string>, resource: AppResource) => {
-  model.configure(resource, { available: true, selected: true });
-};
+import { ResourceDemand } from '../resource-demand';
 const one = (model: ResourceDemand<string>) => {
   const operations = model.takeOperations();
   expect(operations).toHaveLength(1);
   return operations[0];
 };
+const cleanupOrderings = ['stop-before-stale', 'stale-before-stop'] as const;
 describe('ResourceDemand foundation', () => {
   it('uses exact leases and emits only first start and last stop', () => {
     const model = new ResourceDemand<string>('session-1');
-    ready(model, 'hardware-scope');
+    model.configure('hardware-scope', { available: true, selected: true });
     const first = model.acquire('hardware-scope', 'first');
     const start = one(model);
     const second = model.acquire('hardware-scope', 'second');
@@ -31,34 +29,36 @@ describe('ResourceDemand foundation', () => {
     model.configure('audio-fft', widerConfig);
     model.acquire('audio-fft', 'panel');
     expect(model.takeOperations()).toEqual([]);
-    expect(model.snapshot('audio-fft')).toMatchObject({
+    expect(model.snapshot('audio-fft')).toEqual({
       available: false, selected: true, demand: 1, health: 'inactive',
     });
-    expect(model.snapshot('audio-fft').activeHandle).toBeUndefined();
-    ready(model, 'audio-fft');
+    model.configure('audio-fft', { available: true, selected: true });
     expect(one(model).kind).toBe('start');
   });
-  it('ignores fake and duplicate starts and protects a stable aliased handle', () => {
+  it.each(cleanupOrderings)('dedupes stable-handle cleanup for %s ordering', (ordering) => {
     const model = new ResourceDemand<string>('session-1');
-    ready(model, 'hardware-scope');
+    model.configure('hardware-scope', { available: true, selected: true });
     const first = model.acquire('hardware-scope', 'A');
     const startA = one(model);
     expect(model.completeStart({ ...startA }, { handle: 'fake' })).toBe(false);
     model.release(first);
     const second = model.acquire('hardware-scope', 'B');
     const startB = one(model);
-    expect(model.completeStart(startA, { handle: 'stable' })).toBe(false);
-    expect(model.takeOperations()).toEqual([]);
-    expect(model.completeStart(startB, { handle: 'stable' })).toBe(true);
-    expect(model.completeStart(startB, { handle: 'stable' })).toBe(false);
-    expect(model.takeOperations()).toEqual([]);
-    expect(model.snapshot('hardware-scope')).toMatchObject({ activeHandle: 'stable', health: 'streaming' });
-    model.release(second);
+    if (ordering === 'stop-before-stale') {
+      expect(model.completeStart(startB, { handle: 'stable' })).toBe(true);
+      expect(model.completeStart(startB, { handle: 'stable' })).toBe(false);
+      model.release(second);
+      expect(model.completeStart(startA, { handle: 'stable' })).toBe(false);
+    } else {
+      expect(model.completeStart(startA, { handle: 'stable' })).toBe(false);
+      expect(model.completeStart(startB, { handle: 'stable' })).toBe(true);
+      model.release(second);
+    }
     expect(one(model)).toMatchObject({ kind: 'stop', handle: 'stable' });
   });
   it('rejects a stale stop when replacement demand overlaps it', () => {
     const model = new ResourceDemand<string>('session-1');
-    ready(model, 'rx-audio');
+    model.configure('rx-audio', { available: true, selected: true });
     const first = model.acquire('rx-audio', 'A');
     model.completeStart(one(model), { handle: 'A' });
     model.release(first);

--- a/frontend/src/lib/runtime/__tests__/resource-demand.test.ts
+++ b/frontend/src/lib/runtime/__tests__/resource-demand.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { ResourceDemand, type AppResource } from '../resource-demand';
+const ready = (model: ResourceDemand<string>, resource: AppResource) => {
+  model.configure(resource, { available: true, selected: true });
+};
+const one = (model: ResourceDemand<string>) => {
+  const operations = model.takeOperations();
+  expect(operations).toHaveLength(1);
+  return operations[0];
+};
+describe('ResourceDemand foundation', () => {
+  it('uses exact leases and emits only first start and last stop', () => {
+    const model = new ResourceDemand<string>('session-1');
+    ready(model, 'hardware-scope');
+    const first = model.acquire('hardware-scope', 'first');
+    const start = one(model);
+    const second = model.acquire('hardware-scope', 'second');
+    expect(second).not.toBe(first);
+    expect(model.takeOperations()).toEqual([]);
+    expect(model.completeStart(start, { handle: 'scope' })).toBe(true);
+    expect(model.release(first)).toBe(true);
+    expect(model.takeOperations()).toEqual([]);
+    expect(model.release({ ...second } as typeof second)).toBe(false);
+    expect(new ResourceDemand<string>('session-2').release(second)).toBe(false);
+    expect(model.release(second)).toBe(true);
+    expect(one(model)).toMatchObject({ kind: 'stop', handle: 'scope' });
+  });
+  it('keeps unavailable resources idle and copies only public configuration', () => {
+    const model = new ResourceDemand<string>('session-1');
+    const widerConfig = { available: false, selected: true, demand: 99, activeHandle: 'ghost' };
+    model.configure('audio-fft', widerConfig);
+    model.acquire('audio-fft', 'panel');
+    expect(model.takeOperations()).toEqual([]);
+    expect(model.snapshot('audio-fft')).toMatchObject({
+      available: false, selected: true, demand: 1, health: 'inactive',
+    });
+    expect(model.snapshot('audio-fft').activeHandle).toBeUndefined();
+    ready(model, 'audio-fft');
+    expect(one(model).kind).toBe('start');
+  });
+  it('ignores fake and duplicate starts and protects a stable aliased handle', () => {
+    const model = new ResourceDemand<string>('session-1');
+    ready(model, 'hardware-scope');
+    const first = model.acquire('hardware-scope', 'A');
+    const startA = one(model);
+    expect(model.completeStart({ ...startA }, { handle: 'fake' })).toBe(false);
+    model.release(first);
+    const second = model.acquire('hardware-scope', 'B');
+    const startB = one(model);
+    expect(model.completeStart(startA, { handle: 'stable' })).toBe(false);
+    expect(model.takeOperations()).toEqual([]);
+    expect(model.completeStart(startB, { handle: 'stable' })).toBe(true);
+    expect(model.completeStart(startB, { handle: 'stable' })).toBe(false);
+    expect(model.takeOperations()).toEqual([]);
+    expect(model.snapshot('hardware-scope')).toMatchObject({ activeHandle: 'stable', health: 'streaming' });
+    model.release(second);
+    expect(one(model)).toMatchObject({ kind: 'stop', handle: 'stable' });
+  });
+  it('rejects a stale stop when replacement demand overlaps it', () => {
+    const model = new ResourceDemand<string>('session-1');
+    ready(model, 'rx-audio');
+    const first = model.acquire('rx-audio', 'A');
+    model.completeStart(one(model), { handle: 'A' });
+    model.release(first);
+    const oldStop = one(model);
+    model.acquire('rx-audio', 'B');
+    model.completeStart(one(model), { handle: 'B' });
+    expect(model.completeStop(oldStop)).toBe(false);
+    expect(model.snapshot('rx-audio')).toMatchObject({ activeHandle: 'B', health: 'streaming' });
+  });
+});

--- a/frontend/src/lib/runtime/resource-demand.ts
+++ b/frontend/src/lib/runtime/resource-demand.ts
@@ -56,7 +56,9 @@ export class ResourceDemand<H> {
       if (operation.kind !== 'dispose') return true;
       const state = this.state(operation.resource);
       if (state.pending?.kind !== 'start')
-        return !Object.is(state.activeHandle, operation.handle);
+        return !Object.is(state.activeHandle, operation.handle) && !queued.some((candidate) =>
+          candidate.kind === 'stop' && candidate.resource === operation.resource
+            && Object.is(candidate.handle, operation.handle));
       this.operations.push(operation);
       return false;
     });
@@ -103,7 +105,7 @@ export class ResourceDemand<H> {
     if (!wanted) {
       if (state.pending?.kind === 'start') state.pending = undefined;
       if (state.activeHandle !== undefined) {
-        const stop = this.operation('stop', resource, state, state.activeHandle);
+        const stop = this.operation('stop', resource, state.activeHandle);
         state.activeHandle = undefined;
         state.pending = stop;
         this.operations.push(stop);
@@ -112,14 +114,12 @@ export class ResourceDemand<H> {
     }
     if (state.health === 'failed' || state.activeHandle !== undefined || state.pending?.kind === 'start')
       return;
-    const start = this.operation('start', resource, state);
+    const start = this.operation('start', resource);
     state.pending = start;
     state.health = 'starting';
     this.operations.push(start);
   }
-  private operation(
-    kind: 'start' | 'stop', resource: AppResource, state: State<H>, handle?: H,
-  ): ResourceOperation<H> {
+  private operation(kind: 'start' | 'stop', resource: AppResource, handle?: H): ResourceOperation<H> {
     const base = { kind, resource, sessionEpoch: this.sessionEpoch };
     const operation = (kind === 'start' ? base : { ...base, handle: handle as H }) as ResourceOperation<H>;
     if (kind === 'start') this.issuedStarts.add(operation);

--- a/frontend/src/lib/runtime/resource-demand.ts
+++ b/frontend/src/lib/runtime/resource-demand.ts
@@ -24,8 +24,8 @@ export class ResourceDemand<H> {
   private readonly leases = new Set<ResourceLease>();
   private readonly issuedStarts = new WeakSet<object>();
   private readonly cleanupLedger: [AppResource, H][] = [];
+  private readonly adoptedLedger: [AppResource, H][] = [];
   private operations: ResourceOperation<H>[] = [];
-
   constructor(readonly sessionEpoch: string) {}
   configure(resource: AppResource, config: { available: boolean; selected: boolean }): void {
     const state = this.state(resource);
@@ -53,7 +53,7 @@ export class ResourceDemand<H> {
       if (operation.kind !== 'dispose') return true;
       const state = this.state(operation.resource);
       if (state.pending?.kind !== 'start')
-        return !Object.is(state.activeHandle, operation.handle);
+        return !this.adoptedLedger.some(([r, h]) => r === operation.resource && Object.is(h, operation.handle));
       this.operations.push(operation);
       return false;
     });
@@ -71,6 +71,7 @@ export class ResourceDemand<H> {
     if ('error' in result) state.health = 'failed';
     else {
       this.claimCleanup(op.resource, result.handle);
+      this.adoptedLedger.push([op.resource, result.handle]);
       state.activeHandle = result.handle;
       state.health = 'streaming';
     }
@@ -87,7 +88,6 @@ export class ResourceDemand<H> {
   snapshot(resource: AppResource): Readonly<State<H>> {
     return { ...this.state(resource) };
   }
-
   private state(resource: AppResource): State<H> {
     let state = this.states.get(resource);
     if (!state) {

--- a/frontend/src/lib/runtime/resource-demand.ts
+++ b/frontend/src/lib/runtime/resource-demand.ts
@@ -1,0 +1,128 @@
+export type AppResource = 'hardware-scope' | 'audio-fft' | 'rx-audio';
+export type ResourceHealth = 'inactive' | 'starting' | 'streaming' | 'failed';
+declare const leaseBrand: unique symbol;
+export interface ResourceLease {
+  readonly resource: AppResource;
+  readonly sessionEpoch: string;
+  readonly [leaseBrand]: never;
+}
+export type ResourceOperation<H> =
+  | { kind: 'start'; resource: AppResource; sessionEpoch: string }
+  | { kind: 'stop'; resource: AppResource; sessionEpoch: string; handle: H }
+  | { kind: 'dispose'; resource: AppResource; sessionEpoch: string; handle: H };
+interface State<H> {
+  available: boolean;
+  selected: boolean;
+  demand: number;
+  health: ResourceHealth;
+  activeHandle?: H;
+  pending?: ResourceOperation<H>;
+}
+/** Pure foundation model. Callers execute operations; this class has no side effects. */
+export class ResourceDemand<H> {
+  private readonly states = new Map<AppResource, State<H>>();
+  private readonly leases = new Set<ResourceLease>();
+  private readonly issuedStarts = new WeakSet<object>();
+  private operations: ResourceOperation<H>[] = [];
+
+  constructor(readonly sessionEpoch: string) {}
+  configure(resource: AppResource, config: { available: boolean; selected: boolean }): void {
+    const state = this.state(resource);
+    state.available = config.available;
+    state.selected = config.selected;
+    this.reconcile(resource, state);
+  }
+  acquire(resource: AppResource, _consumer: string): ResourceLease {
+    const lease = Object.freeze({
+      resource, sessionEpoch: this.sessionEpoch,
+    }) as ResourceLease;
+    this.leases.add(lease);
+    const state = this.state(resource);
+    state.demand++;
+    this.reconcile(resource, state);
+    return lease;
+  }
+  release(lease: ResourceLease): boolean {
+    if (lease.sessionEpoch !== this.sessionEpoch || !this.leases.delete(lease)) return false;
+    const state = this.state(lease.resource);
+    state.demand--;
+    this.reconcile(lease.resource, state);
+    return true;
+  }
+  takeOperations(): ResourceOperation<H>[] {
+    const queued = this.operations;
+    this.operations = [];
+    return queued.filter((operation) => {
+      if (operation.kind !== 'dispose') return true;
+      const state = this.state(operation.resource);
+      if (state.pending?.kind !== 'start')
+        return !Object.is(state.activeHandle, operation.handle);
+      this.operations.push(operation);
+      return false;
+    });
+  }
+  completeStart(op: ResourceOperation<H>, result: { handle: H } | { error: string }): boolean {
+    if (op.kind !== 'start' || op.sessionEpoch !== this.sessionEpoch || !this.issuedStarts.delete(op))
+      return false;
+    const state = this.state(op.resource);
+    if (state.pending !== op) {
+      if ('handle' in result && !Object.is(state.activeHandle, result.handle))
+        this.operations.push({ ...op, kind: 'dispose', handle: result.handle });
+      return false;
+    }
+    state.pending = undefined;
+    if ('error' in result) state.health = 'failed';
+    else {
+      state.activeHandle = result.handle;
+      state.health = 'streaming';
+    }
+    return true;
+  }
+  completeStop(op: ResourceOperation<H>): boolean {
+    const state = this.state(op.resource);
+    if (op.kind !== 'stop' || op.sessionEpoch !== this.sessionEpoch || state.pending !== op)
+      return false;
+    state.pending = undefined;
+    state.health = 'inactive';
+    return true;
+  }
+  snapshot(resource: AppResource): Readonly<State<H>> {
+    return { ...this.state(resource) };
+  }
+
+  private state(resource: AppResource): State<H> {
+    let state = this.states.get(resource);
+    if (!state) {
+      state = { available: false, selected: false, demand: 0, health: 'inactive' };
+      this.states.set(resource, state);
+    }
+    return state;
+  }
+  private reconcile(resource: AppResource, state: State<H>): void {
+    const wanted = state.demand > 0 && state.selected && state.available;
+    if (!wanted) {
+      if (state.pending?.kind === 'start') state.pending = undefined;
+      if (state.activeHandle !== undefined) {
+        const stop = this.operation('stop', resource, state, state.activeHandle);
+        state.activeHandle = undefined;
+        state.pending = stop;
+        this.operations.push(stop);
+      } else if (state.health !== 'failed') state.health = 'inactive';
+      return;
+    }
+    if (state.health === 'failed' || state.activeHandle !== undefined || state.pending?.kind === 'start')
+      return;
+    const start = this.operation('start', resource, state);
+    state.pending = start;
+    state.health = 'starting';
+    this.operations.push(start);
+  }
+  private operation(
+    kind: 'start' | 'stop', resource: AppResource, state: State<H>, handle?: H,
+  ): ResourceOperation<H> {
+    const base = { kind, resource, sessionEpoch: this.sessionEpoch };
+    const operation = (kind === 'start' ? base : { ...base, handle: handle as H }) as ResourceOperation<H>;
+    if (kind === 'start') this.issuedStarts.add(operation);
+    return operation;
+  }
+}

--- a/frontend/src/lib/runtime/resource-demand.ts
+++ b/frontend/src/lib/runtime/resource-demand.ts
@@ -23,6 +23,7 @@ export class ResourceDemand<H> {
   private readonly states = new Map<AppResource, State<H>>();
   private readonly leases = new Set<ResourceLease>();
   private readonly issuedStarts = new WeakSet<object>();
+  private readonly cleanupLedger: [AppResource, H][] = [];
   private operations: ResourceOperation<H>[] = [];
 
   constructor(readonly sessionEpoch: string) {}
@@ -33,9 +34,7 @@ export class ResourceDemand<H> {
     this.reconcile(resource, state);
   }
   acquire(resource: AppResource, _consumer: string): ResourceLease {
-    const lease = Object.freeze({
-      resource, sessionEpoch: this.sessionEpoch,
-    }) as ResourceLease;
+    const lease = Object.freeze({ resource, sessionEpoch: this.sessionEpoch }) as ResourceLease;
     this.leases.add(lease);
     const state = this.state(resource);
     state.demand++;
@@ -50,15 +49,11 @@ export class ResourceDemand<H> {
     return true;
   }
   takeOperations(): ResourceOperation<H>[] {
-    const queued = this.operations;
-    this.operations = [];
-    return queued.filter((operation) => {
+    return this.operations.splice(0).filter((operation) => {
       if (operation.kind !== 'dispose') return true;
       const state = this.state(operation.resource);
       if (state.pending?.kind !== 'start')
-        return !Object.is(state.activeHandle, operation.handle) && !queued.some((candidate) =>
-          candidate.kind === 'stop' && candidate.resource === operation.resource
-            && Object.is(candidate.handle, operation.handle));
+        return !Object.is(state.activeHandle, operation.handle);
       this.operations.push(operation);
       return false;
     });
@@ -68,13 +63,14 @@ export class ResourceDemand<H> {
       return false;
     const state = this.state(op.resource);
     if (state.pending !== op) {
-      if ('handle' in result && !Object.is(state.activeHandle, result.handle))
+      if ('handle' in result && this.claimCleanup(op.resource, result.handle))
         this.operations.push({ ...op, kind: 'dispose', handle: result.handle });
       return false;
     }
     state.pending = undefined;
     if ('error' in result) state.health = 'failed';
     else {
+      this.claimCleanup(op.resource, result.handle);
       state.activeHandle = result.handle;
       state.health = 'streaming';
     }
@@ -99,6 +95,11 @@ export class ResourceDemand<H> {
       this.states.set(resource, state);
     }
     return state;
+  }
+  private claimCleanup(resource: AppResource, handle: H): boolean {
+    const claimed = this.cleanupLedger.some(([r, h]) => r === resource && Object.is(h, handle));
+    if (!claimed) this.cleanupLedger.push([resource, handle]);
+    return !claimed;
   }
   private reconcile(resource: AppResource, state: State<H>): void {
     const wanted = state.demand > 0 && state.selected && state.available;


### PR DESCRIPTION
## Summary

- add a pure, side-effect-free resource-demand foundation model
- declare exact opaque leases and first/shared/last demand operations
- qualify start/stop completions by issued operation identity and session epoch
- persist per-resource cleanup ownership for the full session using `Object.is(handle)` identity
- give adopted handles stop ownership and orphan handles at most one dispose ownership
- keep configuration limited to the public `available` and `selected` fields

This is a Foundation-only slice. It is intentionally unimported and **not integration-ready**: no runtime, Svelte, channel, audio, transport, TX, retry, teardown, or session-finalization consumer is included.

## Scope guard

- exactly 2 new files
- 200 added LOC versus `main` (129 model + 71 focused tests)
- no production consumers or imports
- closes only the Foundation issue; umbrella #1994 remains open

Linear: [MOR-1129](https://linear.app/morozsm/issue/MOR-1129/mor-1056-foundation-pure-resource-demand-model-baseline)

Closes #2001

## Cleanup ledger contract

Exact head: `73dd51041a4638693dd72923be0fb8022406d8ef`

- ledger lifetime is one `ResourceDemand` session and identity is `(resource, Object.is(handle))`
- a handle accepted active is reserved for cleanup by `stop`; late stale completions can never add a later `dispose`
- an orphan handle can claim `dispose` only once, including across separate operation drains
- equal handle identities under different resources are independent
- pending-start deferral and the live-handle guard preserve stable A→B→A stop priority when a stale completion arrives before the active completion

The ledger is intentionally session-bounded and retains one identity entry per distinct adopted or orphan-cleaned handle until the model is discarded. Retry, terminal teardown, and session finalization remain later hardening scope.

The non-blocking operation-freezing observation is explicitly deferred; issued-operation identity guards remain load-bearing and no mutable-operation behavior was expanded in this remediation.

## Regression evidence

- adopted stable handle: one stale completion is deferred before adoption, then two late same-handle completions after drained and acknowledged stop emit no dispose
- duplicate orphan identity: one dispose both when completions precede one drain and when they span separate drains
- distinct orphan identities: one dispose each
- equal identity across `rx-audio` and `hardware-scope`: one independent dispose per resource
- prior exact/foreign lease, fake/duplicate completion, first/shared/last, configuration whitelist, stable alias, and replacement-overlap guards remain in the consolidated scenarios

## Validation

- focused Vitest: 5/5 passed (one contract scenario plus four cleanup-ledger cases)
- `npm run check`: passed, 0 errors and 0 warnings
- `npm run lint`: passed
- `npm run build`: passed
- full frontend with a fresh local-storage file: 2290/2291; the pre-existing order-dependent `mod-input-tx-guard.test.ts` failed
- isolated `mod-input-tx-guard.test.ts` with a fresh local-storage file: 13/13 passed
- `git diff --check`: passed
- no-consumer/import guard: passed
- exact-head GitHub `grep-gate`: passed in 5s (run 30303942796)
- exact-head GitHub `quick`: passed in 1m35s (run 30303942536)

The PR remains Draft pending a fresh independent review. The Agent Review Gate is expectedly blocked because no PASS comment exists for this exact head.