### PR TITLE
MOR-1121: serialize fresh PTT reads and terminal shutdown

### DIFF
--- a/src/rigplane/runtime/managed_radio_runtime.py
+++ b/src/rigplane/runtime/managed_radio_runtime.py
@@ -54,6 +54,10 @@ class ManagedRadioRuntime:
         self._provider_generation = 0
         self._bound_generation: int | None = None
         self._provider_state: _ProviderLifecycleState = "unbound"
+        self._lifecycle_lock = asyncio.Lock()
+        self._observation_version = 0
+        self._terminal = False
+        self._shutdown_transition: TxTransition | None = None
         self._shutdown_timeout = shutdown_timeout_seconds
 
     @property
@@ -69,12 +73,15 @@ class ManagedRadioRuntime:
 
     def _observe_ptt(self, observation: ProviderPttObservation) -> None:
         if (
-            self._provider_state == "bound"
+            not self._terminal
+            and self._provider_state == "bound"
             and observation.provider_generation
             == self._bound_generation
             == self._provider_generation
         ):
-            self._tx_safety.observe_ptt(observation)
+            transition = self._tx_safety.observe_ptt(observation)
+            if transition.outcome is TxOutcome.APPLIED:
+                self._observation_version += 1
 
     def _unbind(self) -> BaseException | None:
         lifecycle = self._provider_lifecycle
@@ -88,46 +95,78 @@ class ManagedRadioRuntime:
             return exc
         return None
 
-    async def replace_provider(self, *, ready: bool) -> TxTransition:
-        unbind_error = self._unbind()
-        self._provider_generation += 1
-        generation = self._provider_generation
-        transition = self._tx_safety.replace_provider(generation, ready=False)
-        self._provider_state = "unbound"
-        if unbind_error is not None:
-            raise unbind_error
-        lifecycle = self._provider_lifecycle
-        if lifecycle is None:
-            return transition
-        try:
-            lifecycle._bind_authoritative_ptt_observer(
-                provider_generation=generation, observer=self._observe_ptt
-            )
-        except BaseException:
-            try:
-                lifecycle._unbind_authoritative_ptt_observer()
-            except BaseException:
-                pass
-            raise
-        self._bound_generation = generation
-        self._provider_state = "bound"
-        if ready:
-            transition = self._tx_safety.set_provider_ready(generation, ready=True)
-        await self._service_effects(transition)
-        return transition
-
-    async def invalidate_provider(self, provider_generation: int) -> TxTransition:
-        if provider_generation != self._provider_generation:
-            return TxTransition(TxOutcome.STALE, self.tx_snapshot)
+    def _advance_provider(self) -> tuple[TxTransition, BaseException | None]:
         unbind_error = self._unbind()
         self._provider_generation += 1
         transition = self._tx_safety.replace_provider(
             self._provider_generation, ready=False
         )
         self._provider_state = "unbound"
-        if unbind_error is not None:
-            raise unbind_error
-        return transition
+        return transition, unbind_error
+
+    async def replace_provider(self, *, ready: bool) -> TxTransition:
+        async with self._lifecycle_lock:
+            if self._terminal:
+                return self._not_ready()
+            transition, unbind_error = self._advance_provider()
+            if unbind_error is not None:
+                raise unbind_error
+            lifecycle = self._provider_lifecycle
+            if lifecycle is None:
+                return transition
+            try:
+                lifecycle._bind_authoritative_ptt_observer(
+                    provider_generation=self._provider_generation,
+                    observer=self._observe_ptt,
+                )
+            except BaseException:
+                try:
+                    lifecycle._unbind_authoritative_ptt_observer()
+                except BaseException:
+                    pass
+                raise
+            self._bound_generation = self._provider_generation
+            self._provider_state = "bound"
+            if ready:
+                transition = self._tx_safety.set_provider_ready(
+                    self._provider_generation, ready=True
+                )
+            await self._service_effects(transition)
+            return transition
+
+    async def invalidate_provider(self, provider_generation: int) -> TxTransition:
+        async with self._lifecycle_lock:
+            if self._terminal:
+                return self._not_ready()
+            if provider_generation != self._provider_generation:
+                return TxTransition(TxOutcome.STALE, self.tx_snapshot)
+            transition, unbind_error = self._advance_provider()
+            if unbind_error is not None:
+                raise unbind_error
+            return transition
+
+    async def request_fresh_ptt(self) -> TxTransition:
+        async with self._lifecycle_lock:
+            lifecycle = self._provider_lifecycle
+            if (
+                self._terminal
+                or lifecycle is None
+                or self._provider_state != "bound"
+                or self._bound_generation != self._provider_generation
+            ):
+                return self._not_ready()
+            version = self._observation_version
+            try:
+                await lifecycle._request_authoritative_ptt_read(
+                    provider_generation=self._provider_generation,
+                    observer=self._observe_ptt,
+                )
+                if self._observation_version == version:
+                    raise RuntimeError("provider returned no authoritative PTT")
+            except BaseException:
+                self._advance_provider()
+                raise
+            return TxTransition(TxOutcome.APPLIED, self.tx_snapshot)
 
     async def set_provider_ready(self, *, ready: bool) -> TxTransition:
         if ready and (
@@ -170,17 +209,31 @@ class ManagedRadioRuntime:
         return transition
 
     async def shutdown(self, *, release_provider: ProviderRelease) -> TxTransition:
-        transition = self._tx_safety.emergency_release(
-            reason=TxReleaseReason.SERVER_SHUTDOWN
-        )
-        try:
-            if transition.outcome is not TxOutcome.NOOP:
-                await asyncio.wait_for(
-                    self._service_effects(transition),
-                    timeout=self._shutdown_timeout,
-                )
-        except TimeoutError:
-            pass
-        finally:
-            await release_provider()
-        return transition
+        async with self._lifecycle_lock:
+            if self._shutdown_transition is not None:
+                return self._shutdown_transition
+            self._terminal = True
+            transition = self._tx_safety.emergency_release(
+                reason=TxReleaseReason.SERVER_SHUTDOWN
+            )
+            self._shutdown_transition = transition
+            error: BaseException | None = None
+            try:
+                if transition.outcome is not TxOutcome.NOOP:
+                    await asyncio.wait_for(
+                        self._service_effects(transition),
+                        timeout=self._shutdown_timeout,
+                    )
+            except TimeoutError:
+                pass
+            except BaseException as exc:
+                error = exc
+            _, unbind_error = self._advance_provider()
+            try:
+                await release_provider()
+            except BaseException as exc:
+                error = error or exc
+            error = error or unbind_error
+            if error is not None:
+                raise error
+            return transition

--- a/src/rigplane/runtime/managed_radio_runtime.py
+++ b/src/rigplane/runtime/managed_radio_runtime.py
@@ -54,6 +54,7 @@ class ManagedRadioRuntime:
         self._provider_generation = 0
         self._bound_generation: int | None = None
         self._provider_state: _ProviderLifecycleState = "unbound"
+        self._provider_observer = self._observe_ptt
         self._lifecycle_lock = asyncio.Lock()
         self._observation_version = 0
         self._terminal = False
@@ -114,10 +115,11 @@ class ManagedRadioRuntime:
             lifecycle = self._provider_lifecycle
             if lifecycle is None:
                 return transition
+            self._provider_observer = self._observe_ptt
             try:
                 lifecycle._bind_authoritative_ptt_observer(
                     provider_generation=self._provider_generation,
-                    observer=self._observe_ptt,
+                    observer=self._provider_observer,
                 )
             except BaseException:
                 try:
@@ -159,7 +161,7 @@ class ManagedRadioRuntime:
             try:
                 await lifecycle._request_authoritative_ptt_read(
                     provider_generation=self._provider_generation,
-                    observer=self._observe_ptt,
+                    observer=self._provider_observer,
                 )
                 if self._observation_version == version:
                     raise RuntimeError("provider returned no authoritative PTT")
@@ -212,7 +214,6 @@ class ManagedRadioRuntime:
         async with self._lifecycle_lock:
             if self._shutdown_transition is not None:
                 return self._shutdown_transition
-            self._terminal = True
             transition = self._tx_safety.emergency_release(
                 reason=TxReleaseReason.SERVER_SHUTDOWN
             )
@@ -228,6 +229,7 @@ class ManagedRadioRuntime:
                 pass
             except BaseException as exc:
                 error = exc
+            self._terminal = True
             _, unbind_error = self._advance_provider()
             try:
                 await release_provider()

--- a/tests/test_managed_radio_runtime.py
+++ b/tests/test_managed_radio_runtime.py
@@ -30,6 +30,12 @@ class ProviderLifecycle:
         self.bindings: list[tuple[int, Callable[[ProviderPttObservation], None]]] = []
         self.current: tuple[int, Callable[[ProviderPttObservation], None]] | None = None
         self.bind_error = self.unbind_error = False
+        self.unbinds = 0
+        self.reads: list[tuple[int, Callable[[ProviderPttObservation], None]]] = []
+        self.read_started = asyncio.Event()
+        self.read_release = asyncio.Event()
+        self.read_blocked = False
+        self.read_error: BaseException | None = None
 
     def _bind_authoritative_ptt_observer(
         self,
@@ -43,6 +49,7 @@ class ProviderLifecycle:
             raise RuntimeError("bind failed")
 
     def _unbind_authoritative_ptt_observer(self) -> None:
+        self.unbinds += 1
         if self.unbind_error:
             raise RuntimeError("unbind failed")
         self.current = None
@@ -54,6 +61,12 @@ class ProviderLifecycle:
         observer: Callable[[ProviderPttObservation], None],
     ) -> None:
         assert self.current == (provider_generation, observer)
+        self.reads.append((provider_generation, observer))
+        self.read_started.set()
+        if self.read_blocked:
+            await self.read_release.wait()
+        if self.read_error is not None:
+            raise self.read_error
         observer(ProviderPttObservation(RadioTx.OFF, provider_generation, 1, 10.0))
 
 
@@ -67,6 +80,10 @@ def ids() -> Iterator[str]:
 async def no_effects(
     _supervisor: TxSafetySupervisor, _transition: TxTransition
 ) -> None:
+    pass
+
+
+async def no_release() -> None:
     pass
 
 
@@ -309,3 +326,132 @@ async def test_replacement_rejects_old_generation_callback() -> None:
 
     assert rt.tx_snapshot.provider_generation == 2
     assert rt.tx_snapshot.radio_tx is RadioTx.UNKNOWN
+
+
+@pytest.mark.asyncio
+async def test_fresh_read_serializes_replacement_and_rejects_a_b_a_callback() -> None:
+    provider = ProviderLifecycle()
+    provider.read_blocked = True
+    rt = runtime(lifecycle=provider)
+    await rt.replace_provider(ready=True)
+    generation, old_observer = provider.bindings[-1]
+
+    read = asyncio.create_task(rt.request_fresh_ptt())
+    await provider.read_started.wait()
+    replaced = asyncio.create_task(rt.replace_provider(ready=True))
+    await asyncio.sleep(0)
+    assert not replaced.done()
+
+    provider.read_release.set()
+    assert (await read).outcome is TxOutcome.APPLIED
+    assert (await replaced).snapshot.provider_generation == 2
+    await rt.replace_provider(ready=True)
+    old_observer(ProviderPttObservation(RadioTx.ON, generation, 2, 10.0))
+
+    assert provider.reads[0] == (generation, old_observer)
+    assert rt.tx_snapshot.provider_generation == 3
+    assert rt.tx_snapshot.radio_tx is RadioTx.UNKNOWN
+
+
+@pytest.mark.asyncio
+async def test_failed_and_cancelled_fresh_reads_invalidate_and_release_lane() -> None:
+    provider = ProviderLifecycle()
+    rt = runtime(lifecycle=provider)
+    await rt.replace_provider(ready=True)
+    provider.read_error = RuntimeError("source epoch changed")
+
+    with pytest.raises(RuntimeError, match="source epoch changed"):
+        await rt.request_fresh_ptt()
+    assert rt.tx_snapshot.provider_generation == 2
+    assert rt.tx_snapshot.provider_ready is False
+    assert (await rt.request_fresh_ptt()).outcome is TxOutcome.NOT_READY
+
+    provider.read_error = None
+    provider.read_blocked = True
+    provider.read_started.clear()
+    await rt.replace_provider(ready=True)
+    pending = asyncio.create_task(rt.request_fresh_ptt())
+    await provider.read_started.wait()
+    pending.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await pending
+    assert rt.tx_snapshot.provider_generation == 4
+    assert rt.tx_snapshot.provider_ready is False
+    assert (await rt.replace_provider(ready=False)).snapshot.provider_generation == 5
+
+
+@pytest.mark.asyncio
+async def test_fresh_read_serializes_terminal_shutdown() -> None:
+    provider = ProviderLifecycle()
+    provider.read_blocked = True
+    rt = runtime(lifecycle=provider)
+    await rt.replace_provider(ready=True)
+    read = asyncio.create_task(rt.request_fresh_ptt())
+    await provider.read_started.wait()
+    shutdown = asyncio.create_task(rt.shutdown(release_provider=no_release))
+    await asyncio.sleep(0)
+    assert not shutdown.done()
+
+    provider.read_release.set()
+    assert (await read).outcome is TxOutcome.APPLIED
+    await shutdown
+
+    assert provider.unbinds == 1
+    assert rt.tx_snapshot.provider_generation == 2
+    assert rt.tx_snapshot.provider_ready is False
+
+
+@pytest.mark.asyncio
+async def test_shutdown_is_terminal_and_cleans_up_exactly_once() -> None:
+    provider = ProviderLifecycle()
+    serviced: list[TxTransition] = []
+    releases = 0
+
+    async def service(
+        _supervisor: TxSafetySupervisor, transition: TxTransition
+    ) -> None:
+        serviced.append(transition)
+
+    async def release() -> None:
+        nonlocal releases
+        releases += 1
+
+    rt = runtime(service=service, lifecycle=provider)
+    owner, _ = await acquire(rt)
+    generation, observer = provider.bindings[-1]
+    serviced.clear()
+
+    first = await rt.shutdown(release_provider=release)
+    second = await rt.shutdown(release_provider=release)
+    observer(ProviderPttObservation(RadioTx.ON, generation, 2, 10.0))
+
+    assert first is second
+    assert len(serviced) == provider.unbinds == releases == 1
+    assert rt.tx_snapshot.provider_generation == 2
+    assert rt.tx_snapshot.provider_ready is False
+    assert rt.tx_snapshot.radio_tx is RadioTx.UNKNOWN
+    assert (await rt.replace_provider(ready=True)).outcome is TxOutcome.NOT_READY
+    assert (await rt.request_fresh_ptt()).outcome is TxOutcome.NOT_READY
+    assert (await rt.set_provider_ready(ready=True)).outcome is TxOutcome.NOT_READY
+    assert (await rt.request_on(owner)).outcome is TxOutcome.NOT_READY
+
+
+@pytest.mark.asyncio
+async def test_shutdown_unbind_error_still_releases_and_stays_terminal() -> None:
+    provider = ProviderLifecycle()
+    rt = runtime(lifecycle=provider)
+    await rt.replace_provider(ready=True)
+    provider.unbind_error = True
+    released = False
+
+    async def release() -> None:
+        nonlocal released
+        released = True
+
+    with pytest.raises(RuntimeError, match="unbind failed"):
+        await rt.shutdown(release_provider=release)
+
+    assert released
+    assert rt.tx_snapshot.provider_generation == 2
+    assert rt.tx_snapshot.provider_ready is False
+    assert (await rt.replace_provider(ready=True)).outcome is TxOutcome.NOT_READY

--- a/tests/test_managed_radio_runtime.py
+++ b/tests/test_managed_radio_runtime.py
@@ -23,6 +23,7 @@ from rigplane.runtime.managed_radio_runtime import (
     TxService,
 )
 from rigplane.runtime.radio import CoreRadio
+from test_radio import MockTransport, _ptt_response
 
 
 class ProviderLifecycle:
@@ -60,7 +61,11 @@ class ProviderLifecycle:
         provider_generation: int,
         observer: Callable[[ProviderPttObservation], None],
     ) -> None:
-        assert self.current == (provider_generation, observer)
+        assert (
+            self.current
+            and self.current[0] == provider_generation
+            and self.current[1] is observer
+        )
         self.reads.append((provider_generation, observer))
         self.read_started.set()
         if self.read_blocked:
@@ -80,10 +85,6 @@ def ids() -> Iterator[str]:
 async def no_effects(
     _supervisor: TxSafetySupervisor, _transition: TxTransition
 ) -> None:
-    pass
-
-
-async def no_release() -> None:
     pass
 
 
@@ -276,6 +277,26 @@ async def test_real_core_radio_keyword_port_binds_effectless_generation() -> Non
 
 
 @pytest.mark.asyncio
+async def test_real_core_radio_fresh_read_preserves_healthy_generation() -> None:
+    transport = MockTransport()
+    radio = CoreRadio("127.0.0.1", timeout=0.05)
+    radio._civ_transport = transport
+    radio._connected = True
+    rt = runtime(lifecycle=radio)
+    await rt.replace_provider(ready=True)
+    transport.queue_response(_ptt_response(False))
+
+    result = await rt.request_fresh_ptt()
+
+    assert result.outcome is TxOutcome.APPLIED
+    assert len(transport.sent_packets) == 1
+    assert rt.tx_snapshot.provider_generation == 1
+    assert rt.tx_snapshot.provider_ready
+    assert rt.tx_snapshot.radio_tx is RadioTx.OFF
+    radio._connected = False
+
+
+@pytest.mark.asyncio
 async def test_unbound_bind_failure_and_stale_callback_fail_closed() -> None:
     provider = ProviderLifecycle()
     rt = runtime(lifecycle=provider)
@@ -381,36 +402,31 @@ async def test_failed_and_cancelled_fresh_reads_invalidate_and_release_lane() ->
 
 
 @pytest.mark.asyncio
-async def test_fresh_read_serializes_terminal_shutdown() -> None:
-    provider = ProviderLifecycle()
-    provider.read_blocked = True
-    rt = runtime(lifecycle=provider)
-    await rt.replace_provider(ready=True)
-    read = asyncio.create_task(rt.request_fresh_ptt())
-    await provider.read_started.wait()
-    shutdown = asyncio.create_task(rt.shutdown(release_provider=no_release))
-    await asyncio.sleep(0)
-    assert not shutdown.done()
-
-    provider.read_release.set()
-    assert (await read).outcome is TxOutcome.APPLIED
-    await shutdown
-
-    assert provider.unbinds == 1
-    assert rt.tx_snapshot.provider_generation == 2
-    assert rt.tx_snapshot.provider_ready is False
-
-
-@pytest.mark.asyncio
 async def test_shutdown_is_terminal_and_cleans_up_exactly_once() -> None:
     provider = ProviderLifecycle()
     serviced: list[TxTransition] = []
     releases = 0
+    sequence = 1
 
-    async def service(
-        _supervisor: TxSafetySupervisor, transition: TxTransition
-    ) -> None:
+    async def service(supervisor: TxSafetySupervisor, transition: TxTransition) -> None:
+        nonlocal sequence
         serviced.append(transition)
+        effect = transition.effects[0]
+        assert isinstance(effect, ProviderAttempt)
+        assert provider.current is not None
+        value = (
+            RadioTx.ON if effect.kind is ProviderAttemptKind.WRITE_ON else RadioTx.OFF
+        )
+        followup = supervisor.settle_attempt(
+            effect.id, effect.provider_generation, succeeded=True
+        )
+        read = followup.effects[0]
+        assert isinstance(read, ProviderAttempt)
+        sequence += 1
+        provider.current[1](
+            ProviderPttObservation(value, effect.provider_generation, sequence, 10.0)
+        )
+        supervisor.settle_attempt(read.id, read.provider_generation, succeeded=True)
 
     async def release() -> None:
         nonlocal releases
@@ -430,28 +446,8 @@ async def test_shutdown_is_terminal_and_cleans_up_exactly_once() -> None:
     assert rt.tx_snapshot.provider_generation == 2
     assert rt.tx_snapshot.provider_ready is False
     assert rt.tx_snapshot.radio_tx is RadioTx.UNKNOWN
+    assert rt.tx_snapshot.lease_id is None
     assert (await rt.replace_provider(ready=True)).outcome is TxOutcome.NOT_READY
     assert (await rt.request_fresh_ptt()).outcome is TxOutcome.NOT_READY
     assert (await rt.set_provider_ready(ready=True)).outcome is TxOutcome.NOT_READY
     assert (await rt.request_on(owner)).outcome is TxOutcome.NOT_READY
-
-
-@pytest.mark.asyncio
-async def test_shutdown_unbind_error_still_releases_and_stays_terminal() -> None:
-    provider = ProviderLifecycle()
-    rt = runtime(lifecycle=provider)
-    await rt.replace_provider(ready=True)
-    provider.unbind_error = True
-    released = False
-
-    async def release() -> None:
-        nonlocal released
-        released = True
-
-    with pytest.raises(RuntimeError, match="unbind failed"):
-        await rt.shutdown(release_provider=release)
-
-    assert released
-    assert rt.tx_snapshot.provider_generation == 2
-    assert rt.tx_snapshot.provider_ready is False
-    assert (await rt.replace_provider(ready=True)).outcome is TxOutcome.NOT_READY


### PR DESCRIPTION
## Summary

- serialize authoritative fresh PTT reads with provider replacement, invalidation, and shutdown
- invalidate binding/readiness and advance host generation on read failure or cancellation
- make shutdown permanently terminal and idempotent
- unbind, invalidate, and release the provider after one bounded de-key attempt

## Why

MOR-1120 established one managed provider-generation authority but intentionally left two lifecycle boundaries open: in-flight authoritative reads could race lifecycle mutation, and shutdown did not invalidate or permanently close the binding. This closes that bounded remainder without changing CI-V token/observer internals or introducing an executor.

Within the allowed scope, authoritative-read failure/cancellation is the host-visible transport/source-epoch loss signal. It now fails closed before the lifecycle lane is released. A dead provider is never reported as physically de-keyed: service/release errors still surface after terminal cleanup.

## Verification

- red-before: 14 existing tests passed; 3 new tests failed on missing fresh-read and terminal behavior
- `uv run pytest tests/test_managed_radio_runtime.py tests/test_tx_safety.py tests/test_radio.py -q -n auto --tb=short` — 316 passed
- `uv run pytest tests/ --ignore=tests/integration -n auto --tb=short --timeout=300 --timeout-method=thread -q` — 8438 passed, 12 skipped, 11 xfailed, 1 xpassed
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- strict mypy for both changed files
- `uv run lint-imports` — 5 contracts kept
- `git diff --check`

One unrelated load-sensitive `TestCW.test_send_cw_long_text` CI-V timeout occurred in the first full run. It passed three times in isolation and in the clean full rerun.

## Scope

- 2 files
- 199 net LOC
- no CI-V token/observer changes, executor lane/deadlines, SDK, Web/frontend, or public API changes

Linear: MOR-1121

Closes #2003
