### PR TITLE
refactor: consolidate RX audio command authority

### DIFF
--- a/frontend/src/components-v2/wiring/__tests__/rx-audio-authority.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/rx-audio-authority.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+vi.mock('$lib/transport/ws-client', () => ({
+  sendCommand: vi.fn(),
+}));
+
+vi.mock('$lib/stores/radio.svelte', () => ({
+  getActiveReceiver: vi.fn(() => null),
+  getRadioState: vi.fn(() => ({ active: 'MAIN', main: { afLevel: 0.42 } })),
+  patchActiveReceiver: vi.fn(),
+  patchRadioState: vi.fn(),
+  patchReceiver: vi.fn(),
+}));
+
+vi.mock('$lib/audio/audio-manager', () => ({
+  audioManager: {
+    rxEnabled: false,
+    setAudioConfig: vi.fn(),
+    setRxVolume: vi.fn(),
+    startRx: vi.fn(),
+    stopRx: vi.fn(),
+  },
+}));
+
+vi.mock('$lib/stores/audio.svelte', () => ({
+  setMuted: vi.fn(),
+  setVolume: vi.fn(),
+}));
+
+import { audioManager } from '$lib/audio/audio-manager';
+import { setMuted, setVolume } from '$lib/stores/audio.svelte';
+import { patchActiveReceiver } from '$lib/stores/radio.svelte';
+import { sendCommand } from '$lib/transport/ws-client';
+import { makeRxAudioHandlers as makeRuntimeRxAudioHandlers } from '$lib/runtime/commands/panel-commands';
+import { makeRxAudioHandlers as makeWiringRxAudioHandlers } from '../command-bus';
+
+const commandBusSource = readFileSync('src/components-v2/wiring/command-bus.ts', 'utf8');
+
+describe('RX-audio presentation command authority (MOR-1124)', () => {
+  beforeEach(() => {
+    vi.mocked(sendCommand).mockClear();
+    vi.mocked(patchActiveReceiver).mockClear();
+    vi.mocked(setMuted).mockClear();
+    vi.mocked(setVolume).mockClear();
+    vi.mocked(audioManager.startRx).mockClear();
+    vi.mocked(audioManager.stopRx).mockClear();
+    vi.mocked(audioManager.setRxVolume).mockClear();
+    Object.defineProperty(audioManager, 'rxEnabled', { configurable: true, value: false });
+  });
+
+  it('exports the runtime factory through the wiring compatibility path', () => {
+    expect(makeWiringRxAudioHandlers).toBe(makeRuntimeRxAudioHandlers);
+  });
+
+  it('keeps no local saved-AF state or direct RX execution calls in command-bus', () => {
+    expect(commandBusSource).not.toMatch(/\bsavedAfLevel\b/);
+    expect(commandBusSource).not.toMatch(/audioManager\.(startRx|stopRx)\(/);
+  });
+
+  it('shares one saved AF value across repeated handlers from both public paths', () => {
+    makeWiringRxAudioHandlers().onMonitorModeChange('mute');
+    makeRuntimeRxAudioHandlers().onMonitorModeChange('radio');
+
+    expect(sendCommand).toHaveBeenNthCalledWith(1, 'set_af_level', { level: 0, receiver: 0 });
+    expect(sendCommand).toHaveBeenNthCalledWith(2, 'set_af_level', { level: 0.42, receiver: 0 });
+    expect(patchActiveReceiver).toHaveBeenCalledWith({ afLevel: 0.42 }, true);
+    expect(setMuted).toHaveBeenNthCalledWith(1, true);
+    expect(setMuted).toHaveBeenNthCalledWith(2, false);
+  });
+
+  it('keeps LIVE start, exit stop, and browser-volume semantics on the shared authority', () => {
+    const desktop = makeWiringRxAudioHandlers();
+    const essentials = makeRuntimeRxAudioHandlers();
+
+    essentials.onMonitorModeChange('live');
+    Object.defineProperty(audioManager, 'rxEnabled', { configurable: true, value: true });
+    desktop.onAfLevelChange(0.37);
+    desktop.onMonitorModeChange('radio');
+
+    expect(audioManager.startRx).toHaveBeenCalledTimes(1);
+    expect(audioManager.stopRx).toHaveBeenCalledTimes(1);
+    expect(audioManager.setRxVolume).toHaveBeenCalledWith(0.37);
+    expect(setVolume).toHaveBeenCalledWith(37);
+  });
+});

--- a/frontend/src/components-v2/wiring/command-bus.ts
+++ b/frontend/src/components-v2/wiring/command-bus.ts
@@ -15,7 +15,7 @@ import type { ReceiverState, ServerState } from '$lib/types/state';
 import { getCapabilities } from '$lib/stores/capabilities.svelte';
 import { adjustTuningStep, getTuningStep } from '$lib/stores/tuning.svelte';
 import { audioManager } from '$lib/audio/audio-manager';
-import { setMuted, setVolume } from '$lib/stores/audio.svelte';
+export { makeRxAudioHandlers } from '$lib/runtime/commands/panel-commands';
 import type { KeyboardActionConfig } from '../layout/keyboard-map';
 import { mapIfShiftToPbt, pbtHzToRaw } from '../panels/filter-controls';
 import { nbDepthDisplayToRaw, nrDisplayToRaw } from '$lib/radio/filter-controls';
@@ -602,59 +602,6 @@ export function makeTxHandlers() {
     },
     onPttOn: () => cmd('ptt_on'),
     onPttOff: () => cmd('ptt_off'),
-  };
-}
-
-/* ── RX Audio Handlers ───────────────────────────────────────── */
-
-let savedAfLevel: number | null = null;
-
-export function makeRxAudioHandlers() {
-  return {
-    onMonitorModeChange: (mode: string) => {
-      if (mode === 'live') {
-        setMuted(false);
-        // Restore radio AF if was muted
-        if (savedAfLevel !== null) {
-          cmd('set_af_level', { level: savedAfLevel, receiver: activeReceiverParam() });
-          savedAfLevel = null;
-        }
-        audioManager.startRx();
-        return;
-      }
-
-      audioManager.stopRx();
-
-      if (mode === 'mute') {
-        setMuted(true);
-        // Save current AF level and mute radio
-        const rx = getRadioState();
-        const key = rx?.active === 'SUB' ? 'sub' : 'main';
-        const currentAf = rx?.[key]?.afLevel ?? 0.5;
-        if (savedAfLevel === null) savedAfLevel = currentAf;
-        cmd('set_af_level', { level: 0, receiver: activeReceiverParam() });
-      } else {
-        // Radio mode — restore AF if was muted
-        setMuted(false);
-        if (savedAfLevel !== null) {
-          cmd('set_af_level', { level: savedAfLevel, receiver: activeReceiverParam() });
-          patchActiveReceiver({ afLevel: savedAfLevel }, true);
-          savedAfLevel = null;
-        }
-      }
-    },
-    onAfLevelChange: (level: number) => {
-      if (audioManager.rxEnabled) {
-        // Live mode: browser volume only
-        audioManager.setRxVolume(level);
-        setVolume(Math.round(level * 100));
-      } else {
-        // Radio mode: CI-V AF level
-        const receiver = activeReceiverParam();
-        patchActiveReceiver({ afLevel: level }, true);
-        cmd('set_af_level', { level, receiver });
-      }
-    },
   };
 }
 


### PR DESCRIPTION
Closes #2009

Linear: MOR-1124

## Scope
- re-export the canonical runtime `makeRxAudioHandlers` factory from `command-bus`
- remove the duplicate wiring RX command policy and saved-AF state
- add identity, cross-path saved-AF, LIVE transition, browser-volume, and source-ownership regression coverage

## Exact base/head
- base: `d70a1e3887b42ca79ebdb60487f59fb06bec95f2` (`origin/main`)
- head: `3af3040da344886691e6333c54705036a421a463`

## Validation
- focused new test: 4/4
- related wiring tests: 54/54
- `pnpm run check`
- `pnpm run lint`
- `pnpm run build`
- `git diff --check`

Full `pnpm test` is blocked by four pre-existing i18n/layout test-isolation failures in this worktree; the initial run also exposed the Node localStorage-file environment issue. No hardware run or hardware acceptance is claimed.