### PR TITLE
Cut audio FFT over to presentation demand

### DIFF
--- a/frontend/src/components-v2/panels/audio-scope/AudioSpectrumPanel.svelte
+++ b/frontend/src/components-v2/panels/audio-scope/AudioSpectrumPanel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { runtime } from '$lib/runtime';
+  import { presentationResources, runtime } from '$lib/runtime/frontend-runtime';
   import { deriveAudioSpectrumProps } from '$lib/runtime/adapters/panel-adapters';
   import AudioSpectrumCanvas from './AudioSpectrumCanvas.svelte';
 
@@ -13,15 +13,24 @@
   let fftBandwidth = $state(48000);
   let fftPush: ((data: Uint8Array) => void) | null = null;
 
-  // Scope subscription — delegates lifecycle to ScopeController (ADR INV-2, INV-5)
+  // Scope frames and resource demand have separate lifetimes (ADR INV-2, INV-5).
   $effect(() => {
-    return runtime.scope.subscribe((frame) => {
+    runtime.scope.registerPresentationDriver(presentationResources);
+    const lease = presentationResources.acquire('audio-fft', 'AudioSpectrumPanel');
+    const unsubscribe = runtime.scope.subscribe((frame) => {
       fftPixels = frame.pixels;
       if (frame.endFreq > frame.startFreq) {
         fftBandwidth = frame.endFreq - frame.startFreq;
       }
       fftPush?.(frame.pixels);
     });
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      unsubscribe();
+      presentationResources.release(lease);
+    };
   });
 </script>
 

--- a/frontend/src/lib/runtime/__tests__/scope-controller.test.ts
+++ b/frontend/src/lib/runtime/__tests__/scope-controller.test.ts
@@ -6,7 +6,10 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { ScopeController } from '../scope-controller.svelte';
+import { PresentationResourceHost } from '../resource-host';
 import type { ScopeFrame } from '../scope-controller.svelte';
 
 // ── Helpers ──
@@ -50,40 +53,40 @@ describe('ScopeController', () => {
     ctrl = new ScopeController(() => channel as any);
   });
 
-  it('subscribe() opens the WS channel on first subscriber', () => {
+  it('keeps frame subscriptions lifetime-neutral', () => {
     expect(channel.connect).not.toHaveBeenCalled();
 
-    ctrl.subscribe(vi.fn());
+    const unsubscribe = ctrl.subscribe(vi.fn());
+    unsubscribe();
+    unsubscribe();
 
-    expect(channel.connect).toHaveBeenCalledTimes(1);
-    expect(channel.connect).toHaveBeenCalledWith('/api/v1/audio-scope');
-  });
-
-  it('second subscribe() reuses the existing channel without reconnecting', () => {
-    ctrl.subscribe(vi.fn());
-    ctrl.subscribe(vi.fn());
-
-    expect(channel.connect).toHaveBeenCalledTimes(1);
-    expect(channel.onBinary).toHaveBeenCalledTimes(1);
-  });
-
-  it('last unsubscribe() closes the channel', () => {
-    const unsub1 = ctrl.subscribe(vi.fn());
-    const unsub2 = ctrl.subscribe(vi.fn());
-
-    unsub1();
+    expect(channel.connect).not.toHaveBeenCalled();
     expect(channel.disconnect).not.toHaveBeenCalled();
-
-    unsub2();
-    expect(channel.disconnect).toHaveBeenCalledTimes(1);
   });
 
-  it('both subscribers receive parsed frames', () => {
+  it('registers one exact-handle driver for first/shared/last demand', async () => {
+    const host = new PresentationResourceHost<unknown>('session');
+    ctrl.registerPresentationDriver(host);
+    const first = host.acquire('audio-fft', 'first');
+    const shared = host.acquire('audio-fft', 'shared');
+    await vi.waitFor(() => expect(channel.connect).toHaveBeenCalledTimes(1));
+    expect(channel.connect).toHaveBeenCalledWith('/api/v1/audio-scope');
+    expect(host.snapshot('audio-fft').activeHandle).toBe(channel);
+
+    expect(host.release(first)).toBe(true);
+    expect(channel.disconnect).not.toHaveBeenCalled();
+    expect(host.release(shared)).toBe(true);
+    await vi.waitFor(() => expect(channel.disconnect).toHaveBeenCalledTimes(1));
+    expect(host.release(shared)).toBe(false);
+  });
+
+  it('both subscribers receive parsed frames', async () => {
     const h1 = vi.fn<(frame: ScopeFrame) => void>();
     const h2 = vi.fn<(frame: ScopeFrame) => void>();
 
     ctrl.subscribe(h1);
     ctrl.subscribe(h2);
+    await ctrl.audioFftDriver.start();
 
     channel._fire(makeScopeFrameBuffer());
 
@@ -95,12 +98,13 @@ describe('ScopeController', () => {
     expect(frame.endFreq).toBe(14_200_000);
   });
 
-  it('unsubscribed handler no longer receives frames', () => {
+  it('unsubscribed handler no longer receives frames', async () => {
     const h1 = vi.fn();
     const h2 = vi.fn();
 
     const unsub1 = ctrl.subscribe(h1);
     ctrl.subscribe(h2);
+    await ctrl.audioFftDriver.start();
 
     unsub1();
     channel._fire(makeScopeFrameBuffer());
@@ -109,9 +113,10 @@ describe('ScopeController', () => {
     expect(h2).toHaveBeenCalledTimes(1);
   });
 
-  it('ignores malformed frames (wrong magic byte)', () => {
+  it('ignores malformed frames (wrong magic byte)', async () => {
     const handler = vi.fn();
     ctrl.subscribe(handler);
+    await ctrl.audioFftDriver.start();
 
     // Bad magic — parseScopeFrame returns null
     const bad = new ArrayBuffer(20);
@@ -120,35 +125,30 @@ describe('ScopeController', () => {
     expect(handler).not.toHaveBeenCalled();
   });
 
-  it('reopens the channel after all subscribers leave and a new one joins', () => {
-    const unsub = ctrl.subscribe(vi.fn());
-    unsub();
+  it('does not let a stale exact-handle stop close the current channel', async () => {
+    const next = makeMockChannel();
+    ctrl = new ScopeController(vi.fn()
+      .mockReturnValueOnce(channel as any)
+      .mockReturnValueOnce(next as any));
+    const first = await ctrl.audioFftDriver.start();
+    await ctrl.audioFftDriver.stop(first);
+    const current = await ctrl.audioFftDriver.start();
+    await ctrl.audioFftDriver.stop(first);
 
     expect(channel.disconnect).toHaveBeenCalledTimes(1);
-
-    ctrl.subscribe(vi.fn());
-    expect(channel.connect).toHaveBeenCalledTimes(2);
+    expect(next.disconnect).not.toHaveBeenCalled();
+    await ctrl.audioFftDriver.stop(current);
+    expect(next.disconnect).toHaveBeenCalledTimes(1);
   });
 
-  it('counts subscriptions: same handler reference subscribed twice requires two unsubscribes', () => {
-    const handler = vi.fn<(frame: ScopeFrame) => void>();
-
-    const unsub1 = ctrl.subscribe(handler);
-    const unsub2 = ctrl.subscribe(handler);
-
-    expect(channel.connect).toHaveBeenCalledTimes(1);
-    expect(channel.disconnect).not.toHaveBeenCalled();
-
-    // Fire a frame — both subscriptions should receive it
-    channel._fire(makeScopeFrameBuffer());
-    expect(handler).toHaveBeenCalledTimes(2);
-
-    // First unsubscribe — channel stays open
-    unsub1();
-    expect(channel.disconnect).not.toHaveBeenCalled();
-
-    // Second unsubscribe — now channel closes
-    unsub2();
-    expect(channel.disconnect).toHaveBeenCalledTimes(1);
+  it('keeps the panel on one demand lease without transport or hardware fallback', () => {
+    const source = readFileSync(
+      resolve('src/components-v2/panels/audio-scope/AudioSpectrumPanel.svelte'),
+      'utf8',
+    );
+    expect(source).toContain("acquire('audio-fft'");
+    expect(source).toContain('release(lease)');
+    expect(source).toContain('registerPresentationDriver');
+    expect(source).not.toMatch(/\$lib\/transport|hardware-scope/);
   });
 });

--- a/frontend/src/lib/runtime/__tests__/scope-controller.test.ts
+++ b/frontend/src/lib/runtime/__tests__/scope-controller.test.ts
@@ -27,6 +27,9 @@ function makeMockChannel() {
     _fire(buf: ArrayBuffer) {
       for (const h of binaryHandlers) h(buf);
     },
+    _handlerCount() {
+      return binaryHandlers.size;
+    },
   };
 }
 
@@ -71,12 +74,13 @@ describe('ScopeController', () => {
     const shared = host.acquire('audio-fft', 'shared');
     await vi.waitFor(() => expect(channel.connect).toHaveBeenCalledTimes(1));
     expect(channel.connect).toHaveBeenCalledWith('/api/v1/audio-scope');
-    expect(host.snapshot('audio-fft').activeHandle).toBe(channel);
+    expect(host.snapshot('audio-fft').activeHandle).not.toBe(channel);
 
     expect(host.release(first)).toBe(true);
     expect(channel.disconnect).not.toHaveBeenCalled();
     expect(host.release(shared)).toBe(true);
     await vi.waitFor(() => expect(channel.disconnect).toHaveBeenCalledTimes(1));
+    expect(channel._handlerCount()).toBe(0);
     expect(host.release(shared)).toBe(false);
   });
 
@@ -113,6 +117,20 @@ describe('ScopeController', () => {
     expect(h2).toHaveBeenCalledTimes(1);
   });
 
+  it('keeps repeated subscriptions of the same handler independent', async () => {
+    const handler = vi.fn();
+    const first = ctrl.subscribe(handler);
+    const second = ctrl.subscribe(handler);
+    const handle = await ctrl.audioFftDriver.start();
+    first();
+    channel._fire(makeScopeFrameBuffer());
+    expect(handler).toHaveBeenCalledTimes(1);
+    second();
+    channel._fire(makeScopeFrameBuffer());
+    expect(handler).toHaveBeenCalledTimes(1);
+    await ctrl.audioFftDriver.stop(handle);
+  });
+
   it('ignores malformed frames (wrong magic byte)', async () => {
     const handler = vi.fn();
     ctrl.subscribe(handler);
@@ -125,20 +143,71 @@ describe('ScopeController', () => {
     expect(handler).not.toHaveBeenCalled();
   });
 
-  it('does not let a stale exact-handle stop close the current channel', async () => {
-    const next = makeMockChannel();
-    ctrl = new ScopeController(vi.fn()
-      .mockReturnValueOnce(channel as any)
-      .mockReturnValueOnce(next as any));
-    const first = await ctrl.audioFftDriver.start();
-    await ctrl.audioFftDriver.stop(first);
-    const current = await ctrl.audioFftDriver.start();
-    await ctrl.audioFftDriver.stop(first);
+  it('disposes an orphaned repeated start on the memoized channel', async () => {
+    const host = new PresentationResourceHost<unknown>('session');
+    ctrl.registerPresentationDriver(host);
+    const warm = host.acquire('audio-fft', 'warm');
+    await vi.waitFor(() => expect(host.snapshot('audio-fft').health).toBe('streaming'));
+    const firstHandle = host.snapshot('audio-fft').activeHandle;
+    host.release(warm);
+    await vi.waitFor(() => expect(channel.disconnect).toHaveBeenCalledTimes(1));
 
-    expect(channel.disconnect).toHaveBeenCalledTimes(1);
-    expect(next.disconnect).not.toHaveBeenCalled();
-    await ctrl.audioFftDriver.stop(current);
-    expect(next.disconnect).toHaveBeenCalledTimes(1);
+    const orphan = host.acquire('audio-fft', 'orphan');
+    host.release(orphan);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(channel.connect).toHaveBeenCalledTimes(2);
+    expect(channel.disconnect).toHaveBeenCalledTimes(2);
+    expect(channel._handlerCount()).toBe(0);
+    expect(host.snapshot('audio-fft').activeHandle).toBeUndefined();
+    const next = await ctrl.audioFftDriver.start();
+    expect(next).not.toBe(firstHandle);
+    await ctrl.audioFftDriver.stop(next);
+  });
+
+  it('remounts with one callback after an orphaned start', async () => {
+    const host = new PresentationResourceHost<unknown>('session');
+    const subscriber = vi.fn();
+    ctrl.subscribe(subscriber);
+    ctrl.registerPresentationDriver(host);
+    const warm = host.acquire('audio-fft', 'warm');
+    await vi.waitFor(() => expect(host.snapshot('audio-fft').health).toBe('streaming'));
+    host.release(warm);
+    await vi.waitFor(() => expect(channel.disconnect).toHaveBeenCalledTimes(1));
+    const orphan = host.acquire('audio-fft', 'orphan');
+    host.release(orphan);
+    await Promise.resolve();
+    await Promise.resolve();
+    const remount = host.acquire('audio-fft', 'remount');
+    await vi.waitFor(() => expect(host.snapshot('audio-fft').health).toBe('streaming'));
+
+    expect(channel._handlerCount()).toBe(1);
+    channel._fire(makeScopeFrameBuffer());
+    expect(subscriber).toHaveBeenCalledTimes(1);
+    host.release(remount);
+    await vi.waitFor(() => expect(channel.disconnect).toHaveBeenCalledTimes(3));
+    expect(channel._handlerCount()).toBe(0);
+  });
+
+  it('teardown racing a repeated start prevents later publication', async () => {
+    const host = new PresentationResourceHost<unknown>('session');
+    const subscriber = vi.fn();
+    ctrl.subscribe(subscriber);
+    ctrl.registerPresentationDriver(host);
+    const warm = host.acquire('audio-fft', 'warm');
+    await vi.waitFor(() => expect(host.snapshot('audio-fft').health).toBe('streaming'));
+    host.release(warm);
+    await vi.waitFor(() => expect(channel.disconnect).toHaveBeenCalledTimes(1));
+    host.acquire('audio-fft', 'racing');
+    await host.teardown();
+
+    channel._fire(makeScopeFrameBuffer());
+    expect(channel.connect).toHaveBeenCalledTimes(2);
+    expect(channel.disconnect).toHaveBeenCalledTimes(2);
+    expect(channel._handlerCount()).toBe(0);
+    expect(subscriber).not.toHaveBeenCalled();
+    expect(ctrl.audioScopeFrame).toBeNull();
   });
 
   it('keeps the panel on one demand lease without transport or hardware fallback', () => {

--- a/frontend/src/lib/runtime/scope-controller.svelte.ts
+++ b/frontend/src/lib/runtime/scope-controller.svelte.ts
@@ -17,6 +17,7 @@ import { markScopeFrame } from '$lib/stores/connection.svelte';
 import { parseScopeFrame } from '$lib/runtime/adapters/scope-adapter';
 import type { ScopeFrame } from '$lib/runtime/adapters/scope-adapter';
 import type { WsChannel } from '$lib/transport/ws-client';
+import type { PresentationResourceDriver, PresentationResourceHost } from './resource-host';
 
 export type { ScopeFrame };
 
@@ -35,9 +36,14 @@ export class ScopeController {
 
   private _subscribers = new Map<number, FrameHandler>();
   private _nextId = 0;
-  private _unsubBinary: (() => void) | null = null;
-  private _channel: WsChannel | null = null;
+  private _bindings = new Map<WsChannel, () => void>();
+  private _activeChannel: WsChannel | null = null;
   private _getChannel: ChannelFactory;
+  readonly audioFftDriver: PresentationResourceDriver<unknown> = {
+    start: () => this._connect(),
+    stop: (handle) => this._disconnect(handle as WsChannel),
+    dispose: (handle) => this._disconnect(handle as WsChannel),
+  };
 
   constructor(channelFactory: ChannelFactory = getChannel) {
     this._getChannel = channelFactory;
@@ -45,48 +51,64 @@ export class ScopeController {
 
   /**
    * Subscribe to parsed scope frames.
-   * Opens the WS channel on the first subscriber.
+   * Channel lifetime is owned by presentation resource demand.
    * Returns an `unsubscribe` function — call it to stop receiving frames.
    * Each subscribe() call creates an independent subscription, even for the same handler reference.
    */
   subscribe(handler: FrameHandler): () => void {
     const id = this._nextId++;
     this._subscribers.set(id, handler);
-
-    if (this._subscribers.size === 1) {
-      this._connect();
-    }
-
-    return () => {
-      this._subscribers.delete(id);
-      if (this._subscribers.size === 0) {
-        this._disconnect();
-      }
-    };
+    return () => { this._subscribers.delete(id); };
   }
 
-  private _connect(): void {
-    const ch = this._getChannel('audio-scope');
-    this._channel = ch;
-    ch.connect('/api/v1/audio-scope');
-    this._unsubBinary = ch.onBinary((buf: ArrayBuffer) => {
-      markScopeFrame();
-      const frame = parseScopeFrame(buf);
-      if (frame) {
-        this.audioScopeFrame = frame;
-        for (const h of this._subscribers.values()) {
-          h(frame);
-        }
-      }
+  registerPresentationDriver(host: Pick<PresentationResourceHost<unknown>, 'configure'>): void {
+    host.configure('audio-fft', {
+      available: this.audioScopeAvailable,
+      selected: this.activeScope === 'audio-fft',
+      driver: this.audioFftDriver,
     });
   }
 
-  private _disconnect(): void {
-    this._unsubBinary?.();
-    this._unsubBinary = null;
-    this._channel?.disconnect();
-    this._channel = null;
-    this.audioScopeFrame = null;
+  private _connect(): WsChannel {
+    const ch = this._getChannel('audio-scope');
+    try {
+      ch.connect('/api/v1/audio-scope');
+      const unsubscribe = ch.onBinary((buf: ArrayBuffer) => {
+        if (this._activeChannel !== ch) return;
+        markScopeFrame();
+        const frame = parseScopeFrame(buf);
+        if (frame) {
+          this.audioScopeFrame = frame;
+          for (const h of this._subscribers.values()) {
+            h(frame);
+          }
+        }
+      });
+      this._bindings.set(ch, unsubscribe);
+      this._activeChannel = ch;
+      return ch;
+    } catch (error) {
+      ch.disconnect();
+      throw error;
+    }
+  }
+
+  private _disconnect(ch: WsChannel): void {
+    const unsubscribe = this._bindings.get(ch);
+    if (!unsubscribe) return;
+    this._bindings.delete(ch);
+    try {
+      unsubscribe();
+    } finally {
+      try {
+        ch.disconnect();
+      } finally {
+        if (this._activeChannel === ch) {
+          this._activeChannel = null;
+          this.audioScopeFrame = null;
+        }
+      }
+    }
   }
 }
 

--- a/frontend/src/lib/runtime/scope-controller.svelte.ts
+++ b/frontend/src/lib/runtime/scope-controller.svelte.ts
@@ -1,8 +1,8 @@
 /**
  * ScopeController — singleton owner of the audio-scope WebSocket channel.
  *
- * Opens `/api/v1/audio-scope` lazily when the first subscriber attaches and
- * closes it when the last subscriber detaches. Parses binary frames with
+ * Opens `/api/v1/audio-scope` lazily on first presentation demand and closes
+ * it on last release. Parses binary frames with
  * `parseScopeFrame()` from `scope-adapter.ts` and stores the latest frame as
  * a reactive `$state` property that Svelte components can read via `$derived`.
  *
@@ -23,6 +23,8 @@ export type { ScopeFrame };
 
 type FrameHandler = (frame: ScopeFrame) => void;
 type ChannelFactory = (name: string) => WsChannel;
+type AudioFftHandle = Readonly<{ token: symbol }>;
+type ChannelBinding = { channel: WsChannel; unsubscribe: () => void };
 
 export class ScopeController {
   /** Latest parsed audio-scope frame (Svelte 5 reactive). */
@@ -36,13 +38,13 @@ export class ScopeController {
 
   private _subscribers = new Map<number, FrameHandler>();
   private _nextId = 0;
-  private _bindings = new Map<WsChannel, () => void>();
-  private _activeChannel: WsChannel | null = null;
+  private _bindings = new Map<AudioFftHandle, ChannelBinding>();
+  private _activeHandle: AudioFftHandle | null = null;
   private _getChannel: ChannelFactory;
   readonly audioFftDriver: PresentationResourceDriver<unknown> = {
     start: () => this._connect(),
-    stop: (handle) => this._disconnect(handle as WsChannel),
-    dispose: (handle) => this._disconnect(handle as WsChannel),
+    stop: (handle) => this._disconnect(handle as AudioFftHandle),
+    dispose: (handle) => this._disconnect(handle as AudioFftHandle),
   };
 
   constructor(channelFactory: ChannelFactory = getChannel) {
@@ -69,12 +71,13 @@ export class ScopeController {
     });
   }
 
-  private _connect(): WsChannel {
+  private _connect(): AudioFftHandle {
     const ch = this._getChannel('audio-scope');
+    const handle = Object.freeze({ token: Symbol('audio-fft') });
     try {
       ch.connect('/api/v1/audio-scope');
       const unsubscribe = ch.onBinary((buf: ArrayBuffer) => {
-        if (this._activeChannel !== ch) return;
+        if (this._activeHandle !== handle) return;
         markScopeFrame();
         const frame = parseScopeFrame(buf);
         if (frame) {
@@ -84,27 +87,32 @@ export class ScopeController {
           }
         }
       });
-      this._bindings.set(ch, unsubscribe);
-      this._activeChannel = ch;
-      return ch;
+      this._bindings.set(handle, { channel: ch, unsubscribe });
+      this._activeHandle = handle;
+      return handle;
     } catch (error) {
-      ch.disconnect();
+      if (![...this._bindings.values()].some((binding) => binding.channel === ch)) {
+        ch.disconnect();
+      }
       throw error;
     }
   }
 
-  private _disconnect(ch: WsChannel): void {
-    const unsubscribe = this._bindings.get(ch);
-    if (!unsubscribe) return;
-    this._bindings.delete(ch);
+  private _disconnect(handle: AudioFftHandle): void {
+    const binding = this._bindings.get(handle);
+    if (!binding) return;
+    this._bindings.delete(handle);
+    const shared = [...this._bindings.values()].some(
+      (candidate) => candidate.channel === binding.channel,
+    );
     try {
-      unsubscribe();
+      binding.unsubscribe();
     } finally {
       try {
-        ch.disconnect();
+        if (!shared) binding.channel.disconnect();
       } finally {
-        if (this._activeChannel === ch) {
-          this._activeChannel = null;
+        if (this._activeHandle === handle) {
+          this._activeHandle = null;
           this.audioScopeFrame = null;
         }
       }


### PR DESCRIPTION
## Summary
- keep ScopeController as the sole `/api/v1/audio-scope` channel, parser, and broadcaster driver
- use a unique opaque token for every start while retaining the one memoized named `WsChannel`
- make frame subscribe/unsubscribe lifetime-neutral and give AudioSpectrumPanel one opaque `audio-fft` lease plus one subscription

## Control plane
- Linear: MOR-1123
- GitHub: Closes #2013

## Exact scope
- Base: `58bbf21eae6c9f7d1917e9fa96023b0d4329aa55`
- Head: `6b47a8c9c33e0b6df21d534786a359cc1bc71b06`
- 3 files, +186/-78, net +108 LOC
- no App.svelte, registry, layout, hardware scope, RX audio, resource-demand, resource-host, or adapter-factory changes

## Remediation of independent review BLOCKED
- Red-before on a production-shaped memoized channel: 4 failures/9 tests reproduced channel-handle aliasing, orphan leak, duplicate callback remount, and teardown-race publication
- ScopeController now maps each unique per-start token to the exact memoized channel callback/unsubscribe binding
- stop/dispose removes only the captured token binding and disconnects the shared physical channel only after its last binding is removed
- stale/orphan callbacks cannot publish because only the current token may broadcast frames

## Evidence
- Focused ScopeController: 10/10 passed
- Related ScopeController + PresentationResourceHost + ResourceDemand: 34/34 passed
- Full frontend fresh bounded run: 132 files, 2309/2309 passed
- One prior bounded aggregate run exposed the known `mod-input-tx-guard` order flake; its exact test passes 13/13 alone, and the final fresh full run is all green
- `npm run check`: 0 errors, 0 warnings
- `npm run lint`: passed
- `npm run build`: passed
- Diff guard: exactly 3 owned files, net +108 LOC; panel has no transport import or hardware-scope fallback

## Compatibility and hardware boundary
No public API, CLI, config, backend, or wire change. No real-radio or hardware acceptance was run or claimed; FTX-1 hardware acceptance remains outside this slice and remains a release gate.

Closes #2013