### PR TITLE
MOR-1125 Slice A2: add RX runtime mock contract

### DIFF
--- a/frontend/src/components-v2/wiring/__tests__/rx-audio-authority.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/rx-audio-authority.test.ts
@@ -28,6 +28,23 @@ vi.mock('$lib/stores/audio.svelte', () => ({
   setVolume: vi.fn(),
 }));
 
+vi.mock('$lib/runtime/frontend-runtime', async () => {
+  const { audioManager } = await import('$lib/audio/audio-manager');
+  const { setMuted, setVolume } = await import('$lib/stores/audio.svelte');
+  return {
+    runtime: {
+      setRxLive: vi.fn((live: boolean) => {
+        if (live) audioManager.startRx();
+        else audioManager.stopRx();
+      }),
+      get rxEnabled() { return audioManager.rxEnabled; },
+      setRxVolume: vi.fn((level: number) => { audioManager.setRxVolume(level); }),
+      setVolume: vi.fn((level: number) => { setVolume(level); }),
+      setMuted: vi.fn((muted: boolean) => { setMuted(muted); }),
+    },
+  };
+});
+
 import { audioManager } from '$lib/audio/audio-manager';
 import { setMuted, setVolume } from '$lib/stores/audio.svelte';
 import { patchActiveReceiver } from '$lib/stores/radio.svelte';
@@ -83,6 +100,9 @@ describe('RX-audio presentation command authority (MOR-1124)', () => {
       () => expect(audioManager.stopRx).toHaveBeenCalledTimes(1),
       { timeout: 100, interval: 1 },
     );
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(audioManager.stopRx).toHaveBeenCalledTimes(1);
     expect(audioManager.setRxVolume).toHaveBeenCalledWith(0.37);
     expect(setVolume).toHaveBeenCalledWith(37);
   });


### PR DESCRIPTION
## Summary

- Test-only prerequisite Slice A2 for Linear MOR-1125; related implementation issue: #2012.
- Adds the future FrontendRuntime RX semantic mock contract while preserving current direct-production assertions.
- Adds a fixed post-settlement checkpoint that reasserts the exact single stop count.

## Ordering

Merge this prerequisite before the MOR-1125 Slice B implementation. Issue #2012 remains for Slice B.

## Exact evidence

- Base: `7237fec0224cb5f1c0cf050dcd0d20b3961b3d9f`
- Head: `8b2213299320f44a439a75354c7cab1e22801590`
- Scope: 1 test file, +20 / -0 lines; no production code.

## Verification

- Focused RX authority baseline: 4/4 passed.
- Related wiring tests: 103/103 passed.
- `pnpm check`: 0 errors, 0 warnings.
- `pnpm lint`: passed.
- `pnpm build`: passed (existing chunk-size warnings only).
- Exact-path scope and diff checks: passed.

## Bounded mutation evidence

- A temporary throwing runtime-mock factory still produced 4/4, proving current production does not load the new mock.
- A temporary semantic-runtime panel routing mutation produced 4/4, proving the mock supports Slice B without loading unrelated runtime dependencies.
- Both temporary mutations were fully restored; final diff contains only the test contract.

No hardware behavior changed or hardware evidence claimed.
