### PR TITLE
Own LCD audio FFT presentation demand

### DIFF
--- a/frontend/src/components-v2/panels/lcd/AmberCockpit.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberCockpit.svelte
@@ -14,7 +14,7 @@
   import AmberTelemetryStrip from './AmberTelemetryStrip.svelte';
   import AmberMemoryStrip from './AmberMemoryStrip.svelte';
   import type { IndToken } from './AmberIndStrip.svelte';
-  import { runtime } from '$lib/runtime';
+  import { presentationResources, runtime } from '$lib/runtime/frontend-runtime';
   import { isFieldAvailable } from '$lib/state/field-status';
   import { formatOffsetKHz } from '../rit-utils';
 
@@ -218,11 +218,20 @@
   $effect(() => {
     if (!cockpitProps.hasAudioFft) return;
 
-    return runtime.scope.subscribe((frame) => {
+    runtime.scope.registerPresentationDriver(presentationResources);
+    const lease = presentationResources.acquire('audio-fft', 'AmberCockpit');
+    const unsubscribe = runtime.scope.subscribe((frame) => {
       fftPixels = frame.pixels;
       fftBandwidth = frame.endFreq > frame.startFreq ? frame.endFreq - frame.startFreq : undefined;
       fftPush?.(frame.pixels);
     });
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      unsubscribe();
+      presentationResources.release(lease);
+    };
   });
 
   // Record active-receiver frequency changes into the local QSY history

--- a/frontend/src/components-v2/panels/lcd/AmberCockpit.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberCockpit.svelte
@@ -216,7 +216,7 @@
 
   // Scope subscription — delegates lifecycle to ScopeController (ADR INV-2, INV-5)
   $effect(() => {
-    if (!cockpitProps.hasAudioFft) return;
+    if (!showFft) return;
 
     runtime.scope.registerPresentationDriver(presentationResources);
     const lease = presentationResources.acquire('audio-fft', 'AmberCockpit');

--- a/frontend/src/components-v2/panels/lcd/AmberScope.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberScope.svelte
@@ -173,7 +173,7 @@
 
   // Scope subscription — delegates lifecycle to ScopeController (ADR INV-2, INV-5)
   $effect(() => {
-    if (!scopeProps.hasAudioFft) return;
+    if (!showFft) return;
 
     runtime.scope.registerPresentationDriver(presentationResources);
     const lease = presentationResources.acquire('audio-fft', 'AmberScope');

--- a/frontend/src/components-v2/panels/lcd/AmberScope.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberScope.svelte
@@ -9,7 +9,7 @@
   import AmberIndStrip from './AmberIndStrip.svelte';
   import AmberSmeter from './AmberSmeter.svelte';
   import type { IndToken } from './AmberIndStrip.svelte';
-  import { runtime } from '$lib/runtime';
+  import { presentationResources, runtime } from '$lib/runtime/frontend-runtime';
   import { isFieldAvailable } from '$lib/state/field-status';
 
   // Band lookup by frequency (LCD-specific, mirrors AmberCockpit)
@@ -175,11 +175,20 @@
   $effect(() => {
     if (!scopeProps.hasAudioFft) return;
 
-    return runtime.scope.subscribe((frame) => {
+    runtime.scope.registerPresentationDriver(presentationResources);
+    const lease = presentationResources.acquire('audio-fft', 'AmberScope');
+    const unsubscribe = runtime.scope.subscribe((frame) => {
       fftPixels = frame.pixels;
       fftBandwidth = frame.endFreq > frame.startFreq ? frame.endFreq - frame.startFreq : undefined;
       fftPush?.(frame.pixels);
     });
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      unsubscribe();
+      presentationResources.release(lease);
+    };
   });
 </script>
 

--- a/frontend/src/components-v2/panels/lcd/__tests__/audio-fft-demand.test.ts
+++ b/frontend/src/components-v2/panels/lcd/__tests__/audio-fft-demand.test.ts
@@ -1,87 +1,181 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
-import { PresentationResourceHost } from '$lib/runtime/resource-host';
-import { ScopeController } from '$lib/runtime/scope-controller.svelte';
+import { flushSync, mount, unmount } from 'svelte';
 
-const lcdSources = [
-  ['AmberScope', 'src/components-v2/panels/lcd/AmberScope.svelte'],
-  ['AmberCockpit', 'src/components-v2/panels/lcd/AmberCockpit.svelte'],
-] as const;
-
-function makeChannel() {
-  const binaryHandlers = new Set<(data: ArrayBuffer) => void>();
+const channel = vi.hoisted(() => {
+  const handlers = new Set<(data: ArrayBuffer) => void>();
   return {
     connect: vi.fn(),
     disconnect: vi.fn(),
     onBinary: vi.fn((handler: (data: ArrayBuffer) => void) => {
-      binaryHandlers.add(handler);
-      return () => { binaryHandlers.delete(handler); };
+      handlers.add(handler);
+      return () => { handlers.delete(handler); };
     }),
-    handlerCount: () => binaryHandlers.size,
+    handlerCount: () => handlers.size,
+  };
+});
+
+vi.mock('$lib/transport/ws-client', () => ({
+  getChannel: () => channel,
+  sendCommand: vi.fn(() => true),
+  connect: vi.fn(),
+  sendRaw: vi.fn(),
+  disconnectAll: vi.fn(),
+  reconnectAll: vi.fn(),
+}));
+
+import AmberScope from '../AmberScope.svelte';
+import AmberCockpit from '../AmberCockpit.svelte';
+import { presentationResources, runtime } from '$lib/runtime/frontend-runtime';
+import { PresentationResourceHost } from '$lib/runtime/resource-host';
+import { ScopeController } from '$lib/runtime/scope-controller.svelte';
+import { setCapabilities } from '$lib/stores/capabilities.svelte';
+import { resetRadioState, setRadioState } from '$lib/stores/radio.svelte';
+
+const variants = [
+  ['AmberCockpit', AmberCockpit],
+  ['AmberScope', AmberScope],
+] as const;
+let revision = 0;
+vi.stubGlobal('ResizeObserver', class {
+  observe() {}
+  disconnect() {}
+});
+
+function capabilities(audioFftAvailable: boolean) {
+  return {
+    model: 'test', capabilities: [], receivers: 1, vfoScheme: 'single',
+    scope: false, audio: true, audioFftAvailable,
+    scopeSource: audioFftAvailable ? 'audio_fft' : null,
+    tx: false, modes: ['USB'], filters: ['FIL1'],
+  } as never;
+}
+
+function radioState() {
+  revision += 1;
+  const receiver = {
+    freqHz: 14_074_000 + revision, mode: 'USB', filter: 1, filterWidth: 2400,
+    dataMode: 0, sMeter: 0, att: 0, preamp: 0, nb: false, nr: false,
+    afLevel: 128, rfGain: 255, squelch: 0, agc: 2,
+  };
+  return {
+    revision, stateRevision: revision, active: 'MAIN',
+    main: receiver, sub: { ...receiver },
+  } as never;
+}
+
+function makeChannel() {
+  const handlers = new Set<(data: ArrayBuffer) => void>();
+  return {
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    onBinary: vi.fn((handler: (data: ArrayBuffer) => void) => {
+      handlers.add(handler);
+      return () => { handlers.delete(handler); };
+    }),
+    handlerCount: () => handlers.size,
   };
 }
 
 describe('LCD audio-FFT demand ownership', () => {
-  it.each(lcdSources)('%s owns one demand lease and one frame subscription', (name, path) => {
-    const source = readFileSync(resolve(path), 'utf8');
-    expect(source).toContain(
-      "import { presentationResources, runtime } from '$lib/runtime/frontend-runtime'",
-    );
-    expect(source).toContain('runtime.scope.registerPresentationDriver(presentationResources)');
-    expect(source).toContain(`presentationResources.acquire('audio-fft', '${name}')`);
-    expect(source.match(/runtime\.scope\.subscribe\(/g)).toHaveLength(1);
-    expect(source).toContain('unsubscribe()');
-    expect(source).toContain('presentationResources.release(lease)');
-    expect(source).toContain('if (released) return');
-    expect(source).not.toMatch(/\$lib\/transport|hardware-scope/);
-    expect(source).not.toMatch(/acquire\('audio-fft',\s*(fftPush|frame|unsubscribe)/);
+  it('keeps each mounted LCD lease stable across unrelated state updates', async () => {
+    const acquire = vi.spyOn(presentationResources, 'acquire');
+    const release = vi.spyOn(presentationResources, 'release');
+    const register = vi.spyOn(runtime.scope, 'registerPresentationDriver');
+    const subscribe = vi.spyOn(runtime.scope, 'subscribe');
+
+    for (const [name, Component] of variants) {
+      setCapabilities(capabilities(true));
+      setRadioState(radioState());
+      const target = document.createElement('div');
+      document.body.appendChild(target);
+      const component = mount(Component, { target });
+      flushSync();
+
+      await vi.waitFor(() => expect(channel.connect).toHaveBeenCalledTimes(1));
+      expect(acquire).toHaveBeenCalledExactlyOnceWith('audio-fft', name);
+      expect(register).toHaveBeenCalledTimes(1);
+      expect(subscribe).toHaveBeenCalledTimes(1);
+
+      for (let update = 0; update < 5; update += 1) {
+        setRadioState(radioState());
+        flushSync();
+      }
+      await Promise.resolve();
+      expect(acquire).toHaveBeenCalledTimes(1);
+      expect(release).not.toHaveBeenCalled();
+      expect(channel.connect).toHaveBeenCalledTimes(1);
+      expect(channel.disconnect).not.toHaveBeenCalled();
+
+      setCapabilities(capabilities(false));
+      flushSync();
+      await vi.waitFor(() => expect(channel.disconnect).toHaveBeenCalledTimes(1));
+      expect(release).toHaveBeenCalledTimes(1);
+
+      setCapabilities(capabilities(true));
+      flushSync();
+      await vi.waitFor(() => expect(channel.connect).toHaveBeenCalledTimes(2));
+      expect(acquire).toHaveBeenCalledTimes(2);
+
+      unmount(component);
+      await vi.waitFor(() => expect(channel.disconnect).toHaveBeenCalledTimes(2));
+      expect(release).toHaveBeenCalledTimes(2);
+      expect(channel.handlerCount()).toBe(0);
+
+      target.remove();
+      resetRadioState();
+      acquire.mockClear();
+      release.mockClear();
+      register.mockClear();
+      subscribe.mockClear();
+      vi.clearAllMocks();
+    }
   });
 
-  it('shares one channel until the final panel or LCD lease is released', async () => {
-    const channel = makeChannel();
-    const controller = new ScopeController(() => channel as never);
+  it('shares one channel through panel removal, final release, and duplicate cleanup', async () => {
+    const localChannel = makeChannel();
+    const controller = new ScopeController(() => localChannel as never);
     const host = new PresentationResourceHost<unknown>('test');
     controller.registerPresentationDriver(host);
-
     const panel = host.acquire('audio-fft', 'AudioSpectrumPanel');
-    controller.registerPresentationDriver(host);
     const scope = host.acquire('audio-fft', 'AmberScope');
-    controller.registerPresentationDriver(host);
     const cockpit = host.acquire('audio-fft', 'AmberCockpit');
     const unsubscribeScope = controller.subscribe(vi.fn());
     const unsubscribeCockpit = controller.subscribe(vi.fn());
 
     expect(new Set([panel, scope, cockpit]).size).toBe(3);
-    await vi.waitFor(() => expect(channel.connect).toHaveBeenCalledTimes(1));
-    expect(channel.handlerCount()).toBe(1);
+    await vi.waitFor(() => expect(localChannel.connect).toHaveBeenCalledTimes(1));
     expect(host.release(panel)).toBe(true);
-    expect(channel.disconnect).not.toHaveBeenCalled();
+    expect(localChannel.disconnect).not.toHaveBeenCalled();
     unsubscribeScope();
     expect(host.release(scope)).toBe(true);
-    expect(channel.disconnect).not.toHaveBeenCalled();
+    expect(localChannel.disconnect).not.toHaveBeenCalled();
     unsubscribeCockpit();
     expect(host.release(cockpit)).toBe(true);
-    await vi.waitFor(() => expect(channel.disconnect).toHaveBeenCalledTimes(1));
-    expect(channel.handlerCount()).toBe(0);
+    await vi.waitFor(() => expect(localChannel.disconnect).toHaveBeenCalledTimes(1));
+    expect(localChannel.handlerCount()).toBe(0);
     expect(host.release(cockpit)).toBe(false);
-    expect(channel.disconnect).toHaveBeenCalledTimes(1);
+    expect(localChannel.disconnect).toHaveBeenCalledTimes(1);
   });
 
-  it('opens no channel when audio FFT is unavailable', async () => {
-    const channel = makeChannel();
-    const controller = new ScopeController(() => channel as never);
+  it('opens nothing when unavailable and contains no hardware fallback', async () => {
+    const localChannel = makeChannel();
+    const controller = new ScopeController(() => localChannel as never);
     const host = new PresentationResourceHost<unknown>('test');
     host.configure('audio-fft', {
-      available: false,
-      selected: true,
-      driver: controller.audioFftDriver,
+      available: false, selected: true, driver: controller.audioFftDriver,
     });
-
     const lease = host.acquire('audio-fft', 'AmberScope');
     await Promise.resolve();
-    expect(channel.connect).not.toHaveBeenCalled();
+    expect(localChannel.connect).not.toHaveBeenCalled();
     expect(host.release(lease)).toBe(true);
-    expect(channel.disconnect).not.toHaveBeenCalled();
+    expect(localChannel.disconnect).not.toHaveBeenCalled();
+    for (const [name] of variants) {
+      const source = readFileSync(
+        resolve(`src/components-v2/panels/lcd/${name}.svelte`), 'utf8',
+      );
+      expect(source).not.toMatch(/\$lib\/transport|hardware-scope/);
+    }
   });
 });

--- a/frontend/src/components-v2/panels/lcd/__tests__/audio-fft-demand.test.ts
+++ b/frontend/src/components-v2/panels/lcd/__tests__/audio-fft-demand.test.ts
@@ -1,0 +1,87 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import { PresentationResourceHost } from '$lib/runtime/resource-host';
+import { ScopeController } from '$lib/runtime/scope-controller.svelte';
+
+const lcdSources = [
+  ['AmberScope', 'src/components-v2/panels/lcd/AmberScope.svelte'],
+  ['AmberCockpit', 'src/components-v2/panels/lcd/AmberCockpit.svelte'],
+] as const;
+
+function makeChannel() {
+  const binaryHandlers = new Set<(data: ArrayBuffer) => void>();
+  return {
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    onBinary: vi.fn((handler: (data: ArrayBuffer) => void) => {
+      binaryHandlers.add(handler);
+      return () => { binaryHandlers.delete(handler); };
+    }),
+    handlerCount: () => binaryHandlers.size,
+  };
+}
+
+describe('LCD audio-FFT demand ownership', () => {
+  it.each(lcdSources)('%s owns one demand lease and one frame subscription', (name, path) => {
+    const source = readFileSync(resolve(path), 'utf8');
+    expect(source).toContain(
+      "import { presentationResources, runtime } from '$lib/runtime/frontend-runtime'",
+    );
+    expect(source).toContain('runtime.scope.registerPresentationDriver(presentationResources)');
+    expect(source).toContain(`presentationResources.acquire('audio-fft', '${name}')`);
+    expect(source.match(/runtime\.scope\.subscribe\(/g)).toHaveLength(1);
+    expect(source).toContain('unsubscribe()');
+    expect(source).toContain('presentationResources.release(lease)');
+    expect(source).toContain('if (released) return');
+    expect(source).not.toMatch(/\$lib\/transport|hardware-scope/);
+    expect(source).not.toMatch(/acquire\('audio-fft',\s*(fftPush|frame|unsubscribe)/);
+  });
+
+  it('shares one channel until the final panel or LCD lease is released', async () => {
+    const channel = makeChannel();
+    const controller = new ScopeController(() => channel as never);
+    const host = new PresentationResourceHost<unknown>('test');
+    controller.registerPresentationDriver(host);
+
+    const panel = host.acquire('audio-fft', 'AudioSpectrumPanel');
+    controller.registerPresentationDriver(host);
+    const scope = host.acquire('audio-fft', 'AmberScope');
+    controller.registerPresentationDriver(host);
+    const cockpit = host.acquire('audio-fft', 'AmberCockpit');
+    const unsubscribeScope = controller.subscribe(vi.fn());
+    const unsubscribeCockpit = controller.subscribe(vi.fn());
+
+    expect(new Set([panel, scope, cockpit]).size).toBe(3);
+    await vi.waitFor(() => expect(channel.connect).toHaveBeenCalledTimes(1));
+    expect(channel.handlerCount()).toBe(1);
+    expect(host.release(panel)).toBe(true);
+    expect(channel.disconnect).not.toHaveBeenCalled();
+    unsubscribeScope();
+    expect(host.release(scope)).toBe(true);
+    expect(channel.disconnect).not.toHaveBeenCalled();
+    unsubscribeCockpit();
+    expect(host.release(cockpit)).toBe(true);
+    await vi.waitFor(() => expect(channel.disconnect).toHaveBeenCalledTimes(1));
+    expect(channel.handlerCount()).toBe(0);
+    expect(host.release(cockpit)).toBe(false);
+    expect(channel.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens no channel when audio FFT is unavailable', async () => {
+    const channel = makeChannel();
+    const controller = new ScopeController(() => channel as never);
+    const host = new PresentationResourceHost<unknown>('test');
+    host.configure('audio-fft', {
+      available: false,
+      selected: true,
+      driver: controller.audioFftDriver,
+    });
+
+    const lease = host.acquire('audio-fft', 'AmberScope');
+    await Promise.resolve();
+    expect(channel.connect).not.toHaveBeenCalled();
+    expect(host.release(lease)).toBe(true);
+    expect(channel.disconnect).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Linear: MOR-1130

## Summary
- give AmberScope and AmberCockpit independent App-session audio-FFT leases
- bind ownership effects to the narrowed `showFft` capability token so unrelated radio-state replacements cannot churn demand
- idempotently register the existing ScopeController driver and keep one frame subscription per LCD consumer
- release the exact opaque lease and unsubscribe once on cleanup

## Scope
Exactly 3 owned files, 205 insertions / 6 deletions (net +199 LOC). No controller, resource-host, layout, transport, hardware-scope, RX-audio, App, or registry changes.

## Verification
- RED-before: both real mounted LCD variants reacquired 6 times after five unrelated state updates
- focused mounted lifecycle tests: 3/3 passed
- related LCD, ScopeController, ResourceDemand, and FrontendRuntime tests: 56/56 passed
- frontend full: 2312/2312 passed
- svelte-check: 0 errors / 0 warnings
- ESLint: passed
- Vite build: passed
- Ruff and import-linter contracts passed on the foundation head
- Python non-integration is not claimed green: the sole prior audio smoke failure was reproduced identically on a fresh detached exact-base worktree and is unrelated to this frontend-only diff

No real-hardware validation was performed or claimed.

Closes #2017