### PR TITLE
MOR-1131: defer scope channel lookup until first demand

### DIFF
--- a/frontend/src/lib/runtime/__tests__/scope-controller.test.ts
+++ b/frontend/src/lib/runtime/__tests__/scope-controller.test.ts
@@ -220,4 +220,19 @@ describe('ScopeController', () => {
     expect(source).toContain('registerPresentationDriver');
     expect(source).not.toMatch(/\$lib\/transport|hardware-scope/);
   });
+
+  it('keeps default construction inert and resolves transport on first start', async () => {
+    const source = readFileSync(resolve('src/lib/runtime/scope-controller.svelte.ts'), 'utf8');
+    expect(source).not.toContain('channelFactory: ChannelFactory = getChannel');
+    const defaultChannel = makeMockChannel();
+    const lookup = vi.fn(() => defaultChannel as any);
+    const defaultController = new ScopeController(lookup);
+    expect(lookup).not.toHaveBeenCalled();
+
+    const handle = await defaultController.audioFftDriver.start();
+    expect(lookup).toHaveBeenCalledTimes(1);
+    expect(lookup).toHaveBeenCalledWith('audio-scope');
+    expect(defaultChannel.connect).toHaveBeenCalledWith('/api/v1/audio-scope');
+    await defaultController.audioFftDriver.stop(handle);
+  });
 });

--- a/frontend/src/lib/runtime/scope-controller.svelte.ts
+++ b/frontend/src/lib/runtime/scope-controller.svelte.ts
@@ -47,7 +47,7 @@ export class ScopeController {
     dispose: (handle) => this._disconnect(handle as AudioFftHandle),
   };
 
-  constructor(channelFactory: ChannelFactory = getChannel) {
+  constructor(channelFactory: ChannelFactory = (name) => getChannel(name)) {
     this._getChannel = channelFactory;
   }
 


### PR DESCRIPTION
## Summary

- Linear MOR-1131: make ScopeController construction and import transport-inert.
- Defer the default `getChannel` binding access until the first real `audioFftDriver.start()`.
- Preserve injected factories, unique handles, shared physical channels, callbacks, stop/dispose, and host teardown behavior.

Closes #2018

## Exact evidence

- Base: `313eea03c720849b1c7c73a17abdb90f97ad29cf`
- Head: `92b4ca47889f0ade3151d320c378ceefed28a916`
- Scope: 2 files, +16 / -1 lines (net +15).

## Verification

- Red-before: partial transport mock failed during singleton construction at the eager default binding.
- Focused ScopeController: 11/11 passed.
- Controller + resource host + demand model: 36/36 passed.
- All wiring suites: 103/103 passed, including the six previously blocked partial-mock suites.
- Full frontend suite, serialized with a unique localStorage file: 132 files and 2310 tests passed.
- `pnpm check`: 0 errors, 0 warnings.
- `pnpm lint`: passed.
- `pnpm build`: passed (existing chunk-size warnings only).
- Exact-path scope and diff checks: passed.

## Bounded mutation evidence

- With a partial `ws-client` mock lacking `getChannel`, module import succeeded after the change; an actual audio-FFT driver start still threw the missing dependency honestly.
- With temporary future panel-to-runtime routing, all wiring suites remained green at 103/103.
- All temporary probe changes were restored; the final diff contains only the two owned MOR-1131 files.

No hardware behavior changed or hardware evidence claimed.
