### PR TITLE
MOR-1132: qualify hardware-scope commands by demand generation

### DIFF
--- a/src/rigplane/runtime/_poller_types.py
+++ b/src/rigplane/runtime/_poller_types.py
@@ -465,11 +465,12 @@ class VfoEqualize:
 @dataclass(frozen=True, slots=True)
 class EnableScope:
     policy: str = "fast"
+    generation: int = 0
 
 
 @dataclass(frozen=True, slots=True)
 class DisableScope:
-    pass
+    generation: int = 0
 
 
 @dataclass(frozen=True, slots=True)
@@ -999,6 +1000,14 @@ class CommandQueue:
     def __init__(self) -> None:
         self._segments: list[_CommandQueueSegment] = []
         self._notify: asyncio.Event = asyncio.Event()
+        self._scope_demand_generation = 0
+
+    def _record_scope_demand(self, cmd: Command) -> None:
+        if isinstance(cmd, (EnableScope, DisableScope)):
+            self._scope_demand_generation = max(
+                self._scope_demand_generation,
+                cmd.generation,
+            )
 
     def _coalesced_tail(self) -> _CommandQueueSegment:
         if self._segments and self._segments[-1].kind == "coalesced":
@@ -1016,6 +1025,7 @@ class CommandQueue:
         session_id: str | None = None,
         command_service: Any | None = None,
     ) -> None:
+        self._record_scope_demand(cmd)
         entry = CommandQueueEntry(
             cmd,
             command_id=command_id,
@@ -1040,6 +1050,7 @@ class CommandQueue:
         session_id: str | None = None,
         command_service: Any | None = None,
     ) -> None:
+        self._record_scope_demand(cmd)
         self._segments.append(
             _CommandQueueSegment.ordered_entry(
                 CommandQueueEntry(
@@ -1069,6 +1080,10 @@ class CommandQueue:
     @property
     def has_commands(self) -> bool:
         return any(segment.has_commands for segment in self._segments)
+
+    @property
+    def latest_scope_demand_generation(self) -> int:
+        return self._scope_demand_generation
 
     async def wait(self, timeout: float | None = None) -> None:
         try:

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -455,6 +455,7 @@ class RadioPoller:
         self._initial_fetch_done = asyncio.Event()
         self._initial_fetch_done.set()
         self._scope_enable_deferred = False
+        self._scope_demand_generation = queue.latest_scope_demand_generation
         # Issue #715: track user-initiated freq/mode writes so the unselected-
         # slot poll subroutine can debounce around them, and per-receiver
         # timestamps so each receiver's unselected slot is refreshed no more
@@ -1152,6 +1153,21 @@ class RadioPoller:
         _active = getattr(rs, "active", None) if rs is not None else None
         return _active if isinstance(_active, str) else "MAIN"
 
+    def _scope_demand_is_stale(self, generation: int) -> bool:
+        latest = max(
+            self._scope_demand_generation,
+            self._queue.latest_scope_demand_generation,
+        )
+        if generation < latest:
+            logger.debug(
+                "radio-poller: dropping stale scope demand generation %d (current=%d)",
+                generation,
+                latest,
+            )
+            return True
+        self._scope_demand_generation = generation
+        return False
+
     async def _execute(
         self,
         cmd: Command,
@@ -1792,23 +1808,31 @@ class RadioPoller:
                 self._last_user_write_ts = time.monotonic()
                 if CAP_DUAL_RX in self._caps:
                     await radio.equalize_main_sub()
-            case EnableScope(policy=policy):
+            case EnableScope(policy=policy, generation=generation):
                 if CAP_SCOPE in self._caps:
                     # Defer scope enable during initial fetch to avoid
                     # CI-V packet queue overflow (scope data + fetch).
                     if not self._initial_fetch_done.is_set():
+                        if self._scope_demand_is_stale(generation):
+                            return
                         if not self._scope_enable_deferred:
                             logger.info(
                                 "radio-poller: deferring scope enable until initial fetch completes"
                             )
                             self._scope_enable_deferred = True
-                        self._queue.put(EnableScope(policy=policy))
+                        self._queue.put(
+                            EnableScope(policy=policy, generation=generation)
+                        )
                     else:
+                        if self._scope_demand_is_stale(generation):
+                            return
                         await radio.enable_scope(policy=policy)
                         logger.info("radio-poller: scope enabled")
                         await self._fetch_scope_controls()
-            case DisableScope():
+            case DisableScope(generation=generation):
                 if CAP_SCOPE in self._caps:
+                    if self._scope_demand_is_stale(generation):
+                        return
                     await radio.disable_scope()
                     logger.info("radio-poller: scope disabled")
             case SwitchScopeReceiver(receiver=receiver):

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -1581,6 +1581,57 @@ async def test_enable_scope_executes_after_initial_fetch_done() -> None:
 
 
 @pytest.mark.asyncio
+async def test_stale_deferred_enable_cannot_requeue_after_newer_disable() -> None:
+    radio = _make_radio()
+    queue = CommandQueue()
+    poller = RadioPoller(radio, StateCache(), queue, radio_state=RadioState())
+    poller._initial_fetch_done.clear()  # noqa: SLF001
+
+    queue.put(EnableScope(policy="fast", generation=1))
+    (old_enable,) = queue.drain()
+    await poller._execute(old_enable)  # noqa: SLF001
+    assert queue.has_commands is True
+
+    queue.put(DisableScope(generation=2))
+    for command in queue.drain():
+        await poller._execute(command)  # noqa: SLF001
+
+    radio.enable_scope.assert_not_awaited()
+    radio.disable_scope.assert_awaited_once()
+    assert queue.has_commands is False
+
+
+@pytest.mark.asyncio
+async def test_stale_disable_is_inert_after_newer_enable_demand() -> None:
+    radio = _make_radio()
+    queue = CommandQueue()
+    poller = RadioPoller(radio, StateCache(), queue, radio_state=RadioState())
+
+    queue.put(DisableScope(generation=3))
+    (old_disable,) = queue.drain()
+    queue.put(EnableScope(policy="fast", generation=4))
+
+    await poller._execute(old_disable)  # noqa: SLF001
+    for command in queue.drain():
+        await poller._execute(command)  # noqa: SLF001
+
+    radio.disable_scope.assert_not_awaited()
+    radio.enable_scope.assert_awaited_once_with(policy="fast")
+
+
+@pytest.mark.asyncio
+async def test_current_scope_generation_preserves_recovery_enable() -> None:
+    radio = _make_radio()
+    queue = CommandQueue()
+    poller = RadioPoller(radio, StateCache(), queue, radio_state=RadioState())
+
+    await poller._execute(EnableScope(generation=5))  # noqa: SLF001
+    await poller._execute(EnableScope(generation=5))  # noqa: SLF001
+
+    assert radio.enable_scope.await_count == 2
+
+
+@pytest.mark.asyncio
 async def test_set_freq_not_blocked_by_deferred_enable_scope() -> None:
     """SetFreq must execute during initial fetch even when EnableScope is deferred.
 


### PR DESCRIPTION
## Summary

- carry a scope-demand generation on `EnableScope` and `DisableScope`
- retain the newest queued generation as a poller-visible watermark
- reject stale enable/disable commands before hardware execution and before deferred requeue
- preserve equal-generation recovery enables and generation-zero compatibility for the later server-lifecycle slice

## Why

An `EnableScope` deferred during initial fetch could remain queued after a newer last-viewer `DisableScope`, then revive the physical spectrum scope. Generation qualification makes the newest viewer-demand epoch authoritative without changing server lifecycle ownership in this foundation slice.

## Scope and safety

- 3 files, +90 net LOC
- no server, frontend, resource-host, audio, TX, transport, provider, or protocol-documentation changes
- no hardware run or hardware-evidence claim
- this remains Draft pending exact-head CI and a fresh independent Claude Opus 5 max review

## Validation

- `uv run pytest tests/test_radio_poller_coverage.py tests/test_rigctld_client_observation_adapter.py -q --tb=short` — 137 passed
- `uv run ruff check src/ tests/` — passed
- `uv run ruff format --check src/ tests/` — 627 files formatted
- `uv run mypy src/rigplane/runtime/_poller_types.py src/rigplane/web/radio_poller.py` — passed
- `uv run lint-imports` — 5 contracts kept
- full non-integration Python run — 8,451 passed; one unrelated audio smoke failure reproduced identically on exact `origin/main` (`test_session_lifecycle_via_bridge_and_web_tx_lease`)
- full-project mypy reports the same 15 errors in four untouched files on both this branch and exact `origin/main`

Linear: [MOR-1132](https://linear.app/morozsm/issue/MOR-1132/qualify-hardware-scope-poller-commands-by-demand-generation)

Closes #2022
