### PR TITLE
MOR-1125: host RX audio LIVE lifetime

### DIFF
--- a/frontend/src/lib/runtime/__tests__/frontend-runtime.test.ts
+++ b/frontend/src/lib/runtime/__tests__/frontend-runtime.test.ts
@@ -6,6 +6,7 @@
  * into the shared module cache used by the `fast` project.
  */
 
+import { readFileSync } from 'node:fs';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // ── Mock transport and store modules before importing the runtime ──
@@ -74,6 +75,7 @@ vi.mock('$lib/stores/audio.svelte', () => ({
 
 vi.mock('$lib/audio/audio-manager', () => ({
   audioManager: {
+    rxEnabled: false,
     startRx: vi.fn(),
     stopRx: vi.fn(),
     startTx: vi.fn(),
@@ -106,10 +108,12 @@ import { fetchCapabilities, startPolling } from '$lib/transport/http-client';
 import { connect, sendRaw } from '$lib/transport/ws-client';
 import { setCapabilities } from '$lib/stores/capabilities.svelte';
 import { setRadioState } from '$lib/stores/radio.svelte';
+import { audioManager } from '$lib/audio/audio-manager';
 import { systemController } from '../system-controller';
 import { clearLegacyPendingModInputRestore } from '../adapters/mod-input-auto.svelte';
 import { PresentationResourceHost } from '../resource-host';
 import { presentationResources } from '../frontend-runtime';
+import { makeRxAudioHandlers } from '../commands/panel-commands';
 
 // FrontendRuntime is a singleton — re-import fresh each time via a factory helper
 // so we can reset _bootstrapCleanup and _bootstrapInFlight between tests.
@@ -117,15 +121,27 @@ async function freshRuntime() {
   // Dynamic import after vi.mock registrations ensures mocks are active.
   const mod = await import('../frontend-runtime');
   // Reset private state between tests by casting to access both sentinels
-  const rt = mod.runtime as unknown as { _bootstrapCleanup: null; _bootstrapInFlight: null };
+  const rt = mod.runtime as unknown as {
+    _bootstrapCleanup: null;
+    _bootstrapInFlight: null;
+    _rxAudioLease: null;
+    _rxAudioEnded: boolean;
+  };
   rt._bootstrapCleanup = null;
   rt._bootstrapInFlight = null;
+  rt._rxAudioLease = null;
+  rt._rxAudioEnded = false;
   return mod.runtime;
 }
 
 // ── Fixtures ──
 
-const fakeCaps = { modes: ['USB', 'LSB'], scope: false } as any;
+const fakeCaps = {
+  modes: ['USB', 'LSB'],
+  scope: false,
+  audio: true,
+  capabilities: ['audio'],
+} as any;
 const fakeStopPolling = vi.fn();
 const deferred = <T>() => {
   let resolve!: (value: T) => void;
@@ -339,5 +355,107 @@ describe('FrontendRuntime.bootstrap()', () => {
     // Both callers get the same cleanup function
     expect(cleanup1).toBe(cleanup2);
     expect(cleanup1).not.toBe(fakeStopPolling);
+  });
+});
+
+describe('FrontendRuntime RX LIVE intent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (fetchCapabilities as ReturnType<typeof vi.fn>).mockResolvedValue(fakeCaps);
+    (startPolling as ReturnType<typeof vi.fn>).mockReturnValue(fakeStopPolling);
+    presentationResources.retry('rx-audio');
+  });
+
+  it('keeps panel commands behind the runtime authority', () => {
+    const source = readFileSync('src/lib/runtime/commands/panel-commands.ts', 'utf8');
+    expect(source).not.toMatch(/audioManager\.(startRx|stopRx)\(/);
+  });
+
+  it('shares one LIVE lease and ignores duplicate and late exits', async () => {
+    const rt = await freshRuntime();
+    await rt.bootstrap();
+    const panelA = makeRxAudioHandlers();
+    const panelB = makeRxAudioHandlers();
+
+    panelA.onMonitorModeChange('live');
+    panelA.onMonitorModeChange('live');
+    panelB.onMonitorModeChange('live');
+    await settle();
+
+    expect(audioManager.startRx).toHaveBeenCalledTimes(1);
+    expect(presentationResources.snapshot('rx-audio')).toMatchObject({
+      demand: 1,
+      health: 'streaming',
+      activeHandle: audioManager,
+    });
+
+    panelB.onMonitorModeChange('radio');
+    panelB.onMonitorModeChange('radio');
+    panelA.onMonitorModeChange('radio');
+    await settle();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(audioManager.stopRx).toHaveBeenCalledTimes(1);
+    expect(presentationResources.snapshot('rx-audio').demand).toBe(0);
+
+    panelA.onMonitorModeChange('mute');
+    await settle();
+    expect(presentationResources.snapshot('rx-audio').demand).toBe(0);
+    expect(audioManager.startRx).toHaveBeenCalledTimes(1);
+    expect(audioManager.stopRx).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not start while unavailable or implicitly retry a rejected start', async () => {
+    const unavailable = await freshRuntime();
+    (fetchCapabilities as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ...fakeCaps,
+      audio: false,
+      capabilities: [],
+    });
+    await unavailable.bootstrap();
+    unavailable.setRxLive(true);
+    await settle();
+    expect(audioManager.startRx).not.toHaveBeenCalled();
+    unavailable.setRxLive(false);
+
+    const failed = await freshRuntime();
+    await failed.bootstrap();
+    (audioManager.startRx as ReturnType<typeof vi.fn>).mockImplementationOnce(() => {
+      throw new Error('offline');
+    });
+    failed.setRxLive(true);
+    await settle();
+    failed.setRxLive(true);
+    await settle();
+
+    expect(audioManager.startRx).toHaveBeenCalledTimes(1);
+    expect(presentationResources.snapshot('rx-audio')).toMatchObject({
+      demand: 1,
+      health: 'failed',
+      activeHandle: undefined,
+    });
+    failed.setRxLive(false);
+  });
+
+  it('tears down once, in order, and never restarts after final cleanup', async () => {
+    const rt = await freshRuntime();
+    await rt.bootstrap();
+    rt.setRxLive(true);
+    await settle();
+
+    const cleanup = await rt.bootstrap();
+    await cleanup();
+    await cleanup();
+    rt.setRxLive(true);
+    await settle();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(audioManager.startRx).toHaveBeenCalledTimes(1);
+    expect(audioManager.stopRx).toHaveBeenCalledTimes(1);
+    expect(presentationResources.snapshot('rx-audio')).toMatchObject({
+      demand: 0,
+      health: 'inactive',
+      activeHandle: undefined,
+    });
   });
 });

--- a/frontend/src/lib/runtime/commands/panel-commands.ts
+++ b/frontend/src/lib/runtime/commands/panel-commands.ts
@@ -20,8 +20,7 @@ import {
   patchRadioState,
 } from '$lib/stores/radio.svelte';
 import { getCapabilities, getControlRange } from '$lib/stores/capabilities.svelte';
-import { audioManager } from '$lib/audio/audio-manager';
-import { setMuted, setVolume } from '$lib/stores/audio.svelte';
+import { runtime } from '../frontend-runtime';
 import { consumePendingFocus } from '$lib/radio/pending-focus';
 import { getModeFilter } from '$lib/radio/mode-filter-memory';
 import { modInputCommand, modInputStateKey } from '$lib/radio/mod-input';
@@ -620,26 +619,26 @@ export function makeRxAudioHandlers() {
   return {
     onMonitorModeChange: (mode: string) => {
       if (mode === 'live') {
-        setMuted(false);
+        runtime.setMuted(false);
         if (savedAfLevel !== null) {
           cmd('set_af_level', { level: savedAfLevel, receiver: activeReceiverParam() });
           savedAfLevel = null;
         }
-        audioManager.startRx();
+        runtime.setRxLive(true);
         return;
       }
 
-      audioManager.stopRx();
+      runtime.setRxLive(false);
 
       if (mode === 'mute') {
-        setMuted(true);
+        runtime.setMuted(true);
         const rx = getRadioState();
         const key = rx?.active === 'SUB' ? 'sub' : 'main';
         const currentAf = rx?.[key]?.afLevel ?? 0.5;
         if (savedAfLevel === null) savedAfLevel = currentAf;
         cmd('set_af_level', { level: 0, receiver: activeReceiverParam() });
       } else {
-        setMuted(false);
+        runtime.setMuted(false);
         if (savedAfLevel !== null) {
           cmd('set_af_level', { level: savedAfLevel, receiver: activeReceiverParam() });
           patchActiveReceiver({ afLevel: savedAfLevel }, true);
@@ -648,9 +647,9 @@ export function makeRxAudioHandlers() {
       }
     },
     onAfLevelChange: (level: number) => {
-      if (audioManager.rxEnabled) {
-        audioManager.setRxVolume(level);
-        setVolume(Math.round(level * 100));
+      if (runtime.rxEnabled) {
+        runtime.setRxVolume(level);
+        runtime.setVolume(Math.round(level * 100));
       } else {
         const receiver = activeReceiverParam();
         patchActiveReceiver({ afLevel: level }, true);

--- a/frontend/src/lib/runtime/frontend-runtime.ts
+++ b/frontend/src/lib/runtime/frontend-runtime.ts
@@ -33,6 +33,7 @@ import { systemController } from './system-controller';
 import { scopeController } from './scope-controller.svelte';
 import type { ScopeController } from './scope-controller.svelte';
 import { PresentationResourceHost } from './resource-host';
+import type { ResourceLease } from './resource-demand';
 import type { ServerState, ReceiverState } from '$lib/types/state';
 import type { Capabilities } from '$lib/types/capabilities';
 export const presentationResources = new PresentationResourceHost<unknown>('app');
@@ -55,6 +56,24 @@ export interface ConnectionSnapshot {
 class FrontendRuntime {
   private _bootstrapCleanup: (() => void) | null = null;
   private _bootstrapInFlight: Promise<() => void> | null = null;
+  private _rxAudioLease: ResourceLease | null = null;
+  private _rxAudioEnded = false;
+
+  constructor() {
+    presentationResources.configure('rx-audio', {
+      available: false,
+      selected: true,
+      driver: {
+        start: () => {
+          audioManager.startRx();
+          return audioManager;
+        },
+        stop: () => {
+          audioManager.stopRx();
+        },
+      },
+    });
+  }
 
   // ── Reactive state reads ──
   // These return live $state references — Svelte 5 tracks them automatically.
@@ -169,6 +188,10 @@ class FrontendRuntime {
     // 1. Fetch capabilities and push into the store.
     const caps = await fetchCapabilities();
     setCapabilities(caps);
+    presentationResources.configure('rx-audio', {
+      available: caps.audio === true && caps.capabilities.includes('audio'),
+      selected: true,
+    });
 
     // 2. Register polling lifecycle with SystemController so connect/disconnect works.
     systemController.registerPolling(() =>
@@ -188,6 +211,7 @@ class FrontendRuntime {
     // Only latch as started after the entire chain succeeds.
     let cleanupInFlight: Promise<void> | undefined;
     const cleanup = () => cleanupInFlight ??= (async () => {
+      this._rxAudioEnded = true;
       await presentationResources.teardown();
       stopPolling();
     })();
@@ -216,12 +240,21 @@ class FrontendRuntime {
 
   // ── Audio control ──
 
-  startRx(): void {
-    audioManager.startRx();
+  setRxLive(live: boolean): void {
+    if (live) {
+      if (!this._rxAudioEnded && this._rxAudioLease === null) {
+        this._rxAudioLease = presentationResources.acquire('rx-audio', 'presentation');
+      }
+      return;
+    }
+
+    const lease = this._rxAudioLease;
+    this._rxAudioLease = null;
+    if (lease) presentationResources.release(lease);
   }
 
-  stopRx(): void {
-    audioManager.stopRx();
+  get rxEnabled(): boolean {
+    return audioManager.rxEnabled;
   }
 
   setRxVolume(v: number): void {


### PR DESCRIPTION
Linear: https://linear.app/morozsm/issue/MOR-1125/cut-rx-audio-live-intent-over-to-the-app-session-resource-host

Closes #2012

## Summary
- route panel LIVE intent through `FrontendRuntime.setRxLive`
- own one opaque `rx-audio` lease in the app-session presentation resource host
- keep `AudioManager` as the sole RX WebSocket and playback executor
- gate availability on canonical backend audio capabilities and make final teardown restart-proof

## Exact scope
- base: `0a3341589b003cf9dfaa31466435ca2aecc2e936`
- head: `40054e2cfa9c3b0a91f5049a2ad1c89490eddb21`
- 3 files, 166 insertions, 16 deletions, +150 net LOC

## Evidence
- red-before: 4 expected failures covering direct panel bypass, duplicate starts, missing semantic LIVE API, and final teardown
- focused runtime: 15/15
- related wiring/resource/audio: 124/124
- full frontend: 132 files, 2314/2314
- `pnpm check`
- `pnpm lint`
- `pnpm build`
- `git diff --check`

No real-hardware acceptance is claimed by this PR.