### PR TITLE
MOR-1055: validate browser TX-audio capability fields

### DIFF
--- a/frontend/src/lib/transport/__tests__/http-client.test.ts
+++ b/frontend/src/lib/transport/__tests__/http-client.test.ts
@@ -149,7 +149,7 @@ describe('fetchCapabilities', () => {
     [false, null, null, ['scope', 'audio', 'tx']],
     [true, 'usb', null, ['scope', 'audio', 'tx']],
     [true, 'lan', 5, ['scope', 'audio', 'tx', 'mod_input_routing']],
-    [true, 'acc', Number.MAX_SAFE_INTEGER, ['audio', 'tx', 'mod_input_routing']],
+    [true, 'lan', Number.MAX_SAFE_INTEGER, ['audio', 'tx', 'mod_input_routing']],
     [true, 'lan', null, ['audio', 'tx', 'mod_input_routing']],
   ])('accepts and preserves a complete TX-audio tuple', async (
     audioTx,
@@ -214,6 +214,8 @@ describe('fetchCapabilities', () => {
     ['false with a route', { audioTx: false, audioTxRoute: 'lan', audioTxRequiredModInputSource: null }],
     ['false with a source', { audioTx: false, audioTxRoute: null, audioTxRequiredModInputSource: 5 }],
     ['true with a null route', { audioTx: true, audioTxRoute: null, audioTxRequiredModInputSource: null }],
+    ['a source on the USB route', { audioTx: true, audioTxRoute: 'usb', audioTxRequiredModInputSource: 5 }],
+    ['a source on the ACC route', { audioTx: true, audioTxRoute: 'acc', audioTxRequiredModInputSource: 5 }],
     ['a source without MOD routing', { audioTx: true, audioTxRoute: 'lan', audioTxRequiredModInputSource: 5, capabilities: ['audio', 'tx'] }],
     ['a false audio scalar', { audioTx: true, audioTxRoute: 'lan', audioTxRequiredModInputSource: null, audio: false }],
     ['a missing audio tag', { audioTx: true, audioTxRoute: 'lan', audioTxRequiredModInputSource: null, capabilities: ['tx'] }],

--- a/frontend/src/lib/transport/__tests__/http-client.test.ts
+++ b/frontend/src/lib/transport/__tests__/http-client.test.ts
@@ -146,6 +146,89 @@ describe('fetchCapabilities', () => {
   });
 
   it.each([
+    [false, null, null, ['scope', 'audio', 'tx']],
+    [true, 'usb', null, ['scope', 'audio', 'tx']],
+    [true, 'lan', 5, ['scope', 'audio', 'tx', 'mod_input_routing']],
+    [true, 'acc', Number.MAX_SAFE_INTEGER, ['audio', 'tx', 'mod_input_routing']],
+    [true, 'lan', null, ['audio', 'tx', 'mod_input_routing']],
+  ])('accepts and preserves a complete TX-audio tuple', async (
+    audioTx,
+    audioTxRoute,
+    audioTxRequiredModInputSource,
+    capabilities,
+  ) => {
+    const caps = makeCapabilities({
+      audioTx,
+      audioTxRoute,
+      audioTxRequiredModInputSource,
+      capabilities,
+      futureTxFact: { additive: true },
+    });
+    mockCapabilities(caps);
+    const { fetchCapabilities } = await import('../http-client');
+    const result = await fetchCapabilities();
+    expect(result).toBe(caps);
+    expect(result.futureTxFact).toEqual({ additive: true });
+  });
+
+  it('keeps an old capability document absent and never synthesizes audioTx', async () => {
+    const caps = makeCapabilities({
+      capabilities: ['audio', 'tx', 'voice_tx', 'mod_input_routing'],
+    });
+    mockCapabilities(caps);
+    const { fetchCapabilities } = await import('../http-client');
+    const result = await fetchCapabilities();
+    expect(result).toBe(caps);
+    expect(Object.hasOwn(result, 'audioTx')).toBe(false);
+  });
+
+  it.each([
+    [{ audioTx: true, audioTxRoute: 'lan' }],
+    [{ audioTx: true, audioTxRequiredModInputSource: null }],
+    [{ audioTxRoute: 'lan', audioTxRequiredModInputSource: null }],
+  ])('rejects a partial TX-audio tuple', async (overrides) => {
+    mockCapabilities(makeCapabilities(overrides));
+    const { fetchCapabilities } = await import('../http-client');
+    await expect(fetchCapabilities()).rejects.toThrow('TX-audio capability group');
+  });
+
+  it.each([
+    ['$.audioTx', { audioTx: 'yes', audioTxRoute: 'lan', audioTxRequiredModInputSource: null }],
+    ['$.audioTxRoute', { audioTx: true, audioTxRoute: 'network', audioTxRequiredModInputSource: null }],
+    ['$.audioTxRoute', { audioTx: true, audioTxRoute: 1, audioTxRequiredModInputSource: null }],
+    ['$.audioTxRequiredModInputSource', { audioTx: true, audioTxRoute: 'lan', audioTxRequiredModInputSource: '5' }],
+    ['$.audioTxRequiredModInputSource', { audioTx: true, audioTxRoute: 'lan', audioTxRequiredModInputSource: -1 }],
+    ['$.audioTxRequiredModInputSource', { audioTx: true, audioTxRoute: 'lan', audioTxRequiredModInputSource: 1.5 }],
+    ['$.audioTxRequiredModInputSource', { audioTx: true, audioTxRoute: 'lan', audioTxRequiredModInputSource: Number.POSITIVE_INFINITY }],
+    ['$.audioTxRequiredModInputSource', { audioTx: true, audioTxRoute: 'lan', audioTxRequiredModInputSource: Number.MAX_SAFE_INTEGER + 1 }],
+  ])('rejects malformed TX-audio field %s', async (path, overrides) => {
+    mockCapabilities(makeCapabilities({
+      capabilities: ['audio', 'tx', 'mod_input_routing'],
+      ...overrides,
+    }));
+    const { fetchCapabilities } = await import('../http-client');
+    await expect(fetchCapabilities()).rejects.toThrow(path);
+  });
+
+  it.each([
+    ['false with a route', { audioTx: false, audioTxRoute: 'lan', audioTxRequiredModInputSource: null }],
+    ['false with a source', { audioTx: false, audioTxRoute: null, audioTxRequiredModInputSource: 5 }],
+    ['true with a null route', { audioTx: true, audioTxRoute: null, audioTxRequiredModInputSource: null }],
+    ['a source without MOD routing', { audioTx: true, audioTxRoute: 'lan', audioTxRequiredModInputSource: 5, capabilities: ['audio', 'tx'] }],
+    ['a false audio scalar', { audioTx: true, audioTxRoute: 'lan', audioTxRequiredModInputSource: null, audio: false }],
+    ['a missing audio tag', { audioTx: true, audioTxRoute: 'lan', audioTxRequiredModInputSource: null, capabilities: ['tx'] }],
+    ['a false TX scalar', { audioTx: true, audioTxRoute: 'lan', audioTxRequiredModInputSource: null, tx: false }],
+    ['a missing TX tag', { audioTx: true, audioTxRoute: 'lan', audioTxRequiredModInputSource: null, capabilities: ['audio'] }],
+  ])('rejects contradictory TX-audio facts: %s', async (_label, overrides) => {
+    mockCapabilities(makeCapabilities({
+      capabilities: ['audio', 'tx', 'mod_input_routing'],
+      ...overrides,
+    }));
+    const { fetchCapabilities } = await import('../http-client');
+    await expect(fetchCapabilities()).rejects.toThrow('contradictory TX-audio capability facts');
+  });
+
+  it.each([
     ['single', 1],
     ['ab', 1],
     ['ab_shared', 2],

--- a/frontend/src/lib/types/capabilities.ts
+++ b/frontend/src/lib/types/capabilities.ts
@@ -230,7 +230,10 @@ export function validateCapabilities(value: unknown): Capabilities {
         || !tags.includes('tx')
         || (
           raw.audioTxRequiredModInputSource !== null
-          && !tags.includes('mod_input_routing')
+          && (
+            raw.audioTxRoute !== 'lan'
+            || !tags.includes('mod_input_routing')
+          )
         )
       )
     ) {

--- a/frontend/src/lib/types/capabilities.ts
+++ b/frontend/src/lib/types/capabilities.ts
@@ -95,6 +95,9 @@ export interface Capabilities {
   scope: boolean;
   audio: boolean;
   tx: boolean;
+  audioTx?: boolean;
+  audioTxRoute?: 'lan' | 'usb' | 'acc' | null;
+  audioTxRequiredModInputSource?: number | null;
   capabilities: string[];
   receivers: number;
   vfoScheme: VfoScheme;
@@ -181,6 +184,59 @@ export function validateCapabilities(value: unknown): Capabilities {
   requireBoolean(raw.tx, '$.tx');
   requireStringArray(raw.capabilities, '$.capabilities');
   requireInteger(raw.receivers, '$.receivers', true);
+
+  const txAudioFields = [
+    'audioTx',
+    'audioTxRoute',
+    'audioTxRequiredModInputSource',
+  ] as const;
+  const presentTxAudioFields = txAudioFields.filter((field) =>
+    Object.prototype.hasOwnProperty.call(raw, field),
+  );
+  if (presentTxAudioFields.length !== 0 && presentTxAudioFields.length !== txAudioFields.length) {
+    invalid('$', 'a complete or absent TX-audio capability group');
+  }
+  if (presentTxAudioFields.length === txAudioFields.length) {
+    requireBoolean(raw.audioTx, '$.audioTx');
+    const routes = ['lan', 'usb', 'acc'] as const;
+    if (raw.audioTxRoute !== null && !routes.includes(raw.audioTxRoute as typeof routes[number])) {
+      invalid('$.audioTxRoute', 'lan | usb | acc | null');
+    }
+    if (
+      raw.audioTxRequiredModInputSource !== null
+      && (
+        typeof raw.audioTxRequiredModInputSource !== 'number'
+        || !Number.isSafeInteger(raw.audioTxRequiredModInputSource)
+        || raw.audioTxRequiredModInputSource < 0
+      )
+    ) {
+      invalid('$.audioTxRequiredModInputSource', 'a safe non-negative integer or null');
+    }
+
+    const tags = raw.capabilities as string[];
+    if (
+      raw.audioTx === false
+      && (raw.audioTxRoute !== null || raw.audioTxRequiredModInputSource !== null)
+    ) {
+      invalid('$.audioTx', 'non-contradictory TX-audio capability facts');
+    }
+    if (
+      raw.audioTx === true
+      && (
+        raw.audioTxRoute === null
+        || raw.audio !== true
+        || raw.tx !== true
+        || !tags.includes('audio')
+        || !tags.includes('tx')
+        || (
+          raw.audioTxRequiredModInputSource !== null
+          && !tags.includes('mod_input_routing')
+        )
+      )
+    ) {
+      invalid('$.audioTx', 'non-contradictory TX-audio capability facts');
+    }
+  }
 
   const schemes: readonly VfoScheme[] = ['single', 'ab', 'ab_shared', 'main_sub'];
   if (!schemes.includes(raw.vfoScheme as VfoScheme)) {


### PR DESCRIPTION
## Summary
- validate the canonical optional browser TX-audio capability tuple on raw v1 input
- reject partial, malformed, and contradictory tuples fail-closed
- preserve old-server absence and unknown additive fields without synthesizing audioTx

## Scope
- exactly 2 files, +139 net LOC
- no second capability schema/profile/store
- no selector/controller/UI/provider/backend changes

Closes #2025
Linear: https://linear.app/morozsm/issue/MOR-1055/validate-additive-browser-tx-audio-fields-fail-closed-in-frontend

## Review contract
This PR remains Draft pending fresh independent Claude Opus 5 max exact-head review. No hardware validation performed or claimed.