### PR TITLE
MOR-1133: bind hardware-scope demand to viewer generation

### DIFF
--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -1783,7 +1783,6 @@ class WebServer:
 
     def _on_radio_reconnect(self) -> None:
         """Called after soft_reconnect — refetch state and re-enable scope."""
-        generation = self._scope_demand_generation
         # Clear poller readiness so scope waits for refetch to complete
         if self._radio_poller is not None:
             self._radio_poller._initial_fetch_done.clear()
@@ -1812,13 +1811,14 @@ class WebServer:
             # own, which is strictly better than a silent 30-second wait
             # every reconnect cycle.
             if (
-                generation == self._scope_demand_generation
-                and self._scope_handlers
+                self._scope_handlers
                 and self._radio is not None
                 and self._hardware_scope_available
             ):
                 self._set_scope_data_callback(self._broadcast_scope)
-                self._command_queue.put(EnableScope(generation=generation))
+                self._command_queue.put(
+                    EnableScope(generation=self._scope_demand_generation)
+                )
                 self._scope_enabled = True
                 logger.info(
                     "scope: re-enable queued after reconnect (%d handlers)",

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -817,6 +817,7 @@ class WebServer:
         self._scope_handlers: set["ScopeHandler"] = set()
         self._audio_scope_handlers: set["ScopeHandler"] = set()
         self._scope_enabled = False
+        self._scope_demand_generation = 0
         self._scope_enable_lock: asyncio.Lock = asyncio.Lock()
         self._scope_disable_grace: float = 2.0
         raw_radio_state = (
@@ -1055,8 +1056,12 @@ class WebServer:
         is needed — frames are generated from the audio stream.
         """
         async with self._scope_enable_lock:
+            was_empty = not self._scope_handlers
             was_registered = handler in self._scope_handlers
             self._scope_handlers.add(handler)
+            if was_empty and not was_registered:
+                self._scope_demand_generation += 1
+            generation = self._scope_demand_generation
             if not was_registered:
                 self._broadcast_ws_client_state_update()
             if self._radio is not None:
@@ -1074,11 +1079,13 @@ class WebServer:
                     )
                     return
                 if self._radio_ready():
-                    self._command_queue.put(EnableScope())
+                    self._command_queue.put(EnableScope(generation=generation))
                     self._scope_enabled = True
                     logger.info("scope: enable queued")
                 else:
-                    self._schedule_scope_enable_when_ready(reason="handler_connect")
+                    self._schedule_scope_enable_when_ready(
+                        reason="handler_connect", generation=generation
+                    )
                     logger.info("scope: defer enable until radio_ready")
 
     def unregister_scope_handler(self, handler: "ScopeHandler") -> None:
@@ -1087,6 +1094,9 @@ class WebServer:
         self._scope_handlers.discard(handler)
         if was_registered:
             self._broadcast_ws_client_state_update()
+        if was_registered and not self._scope_handlers:
+            self._scope_demand_generation += 1
+            self._cancel_scope_reenable_task()
         if (
             not self._scope_handlers
             and self._radio is not None
@@ -1094,9 +1104,11 @@ class WebServer:
         ):
             self._set_scope_data_callback(None)
             if self._scope_enabled:
-                self._spawn(self._disable_scope_async())
+                self._spawn(
+                    self._disable_scope_async(generation=self._scope_demand_generation)
+                )
 
-    async def _disable_scope_async(self) -> None:
+    async def _disable_scope_async(self, *, generation: int) -> None:
         """Disable scope on the radio when no more handlers are connected."""
         if self._radio is None or not self._hardware_scope_available:
             return
@@ -1106,7 +1118,10 @@ class WebServer:
             if self._radio is not None:
                 self._set_scope_data_callback(self._broadcast_scope)
             return
-        self._command_queue.put(DisableScope())
+        if generation != self._scope_demand_generation:
+            logger.debug("scope: disable task superseded by newer viewer demand")
+            return
+        self._command_queue.put(DisableScope(generation=generation))
         if not self._scope_handlers:
             self._scope_enabled = False
             logger.info("scope: disable queued (no active handlers)")
@@ -1768,6 +1783,7 @@ class WebServer:
 
     def _on_radio_reconnect(self) -> None:
         """Called after soft_reconnect — refetch state and re-enable scope."""
+        generation = self._scope_demand_generation
         # Clear poller readiness so scope waits for refetch to complete
         if self._radio_poller is not None:
             self._radio_poller._initial_fetch_done.clear()
@@ -1796,12 +1812,13 @@ class WebServer:
             # own, which is strictly better than a silent 30-second wait
             # every reconnect cycle.
             if (
-                self._scope_handlers
+                generation == self._scope_demand_generation
+                and self._scope_handlers
                 and self._radio is not None
                 and self._hardware_scope_available
             ):
                 self._set_scope_data_callback(self._broadcast_scope)
-                self._command_queue.put(EnableScope())
+                self._command_queue.put(EnableScope(generation=generation))
                 self._scope_enabled = True
                 logger.info(
                     "scope: re-enable queued after reconnect (%d handlers)",
@@ -1810,7 +1827,16 @@ class WebServer:
 
         self._spawn(_refetch_and_reenable())
 
-    def _schedule_scope_enable_when_ready(self, *, reason: str) -> None:
+    def _cancel_scope_reenable_task(self) -> None:
+        """Cancel readiness work invalidated by a last-viewer transition."""
+        task = self._scope_reenable_task
+        self._scope_reenable_task = None
+        if task is not None and not task.done():
+            task.cancel()
+
+    def _schedule_scope_enable_when_ready(
+        self, *, reason: str, generation: int
+    ) -> None:
         """Schedule delayed scope enable once radio becomes ready."""
         if (
             self._scope_reenable_task is not None
@@ -1819,24 +1845,29 @@ class WebServer:
             return
         loop = asyncio.get_running_loop()
         self._scope_reenable_task = loop.create_task(
-            self._wait_and_enable_scope(reason=reason),
+            self._wait_and_enable_scope(reason=reason, generation=generation),
             name="scope-reenable-when-ready",
         )
 
-    async def _wait_and_enable_scope(self, *, reason: str) -> None:
+    async def _wait_and_enable_scope(self, *, reason: str, generation: int) -> None:
         """Wait until radio_ready before queuing EnableScope."""
         import time
 
+        current_task = asyncio.current_task()
         deadline = time.monotonic() + self._scope_reenable_timeout
         try:
             while True:
-                if not self._scope_handlers or self._radio is None:
+                if (
+                    generation != self._scope_demand_generation
+                    or not self._scope_handlers
+                    or self._radio is None
+                ):
                     return
                 if not self._hardware_scope_available:
                     return
                 if self._radio_ready():
                     self._set_scope_data_callback(self._broadcast_scope)
-                    self._command_queue.put(EnableScope())
+                    self._command_queue.put(EnableScope(generation=generation))
                     self._scope_enabled = True
                     logger.info(
                         "scope: enable queued after %s (%d handlers)",
@@ -1855,7 +1886,8 @@ class WebServer:
         except asyncio.CancelledError:
             pass
         finally:
-            self._scope_reenable_task = None
+            if self._scope_reenable_task is current_task:
+                self._scope_reenable_task = None
 
     def _scope_health_check(self, frame: Any) -> None:
         """Track whether scope frames contain real data (non-zero pixels)."""
@@ -1909,7 +1941,9 @@ class WebServer:
                             )
                             retries += 1  # log once
                         continue
-                    self._command_queue.put(EnableScope())
+                    self._command_queue.put(
+                        EnableScope(generation=self._scope_demand_generation)
+                    )
                     self._scope_last_nonzero = now  # reset to avoid spam
                     retries += 1
                     logger.warning(

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -2262,24 +2262,33 @@ class TestScopeLifecycle:
         radio = MagicMock()
         radio.capabilities = {"scope"}
         _add_scope_capable_attrs(radio)
+        radio.connected = True
+        radio.radio_ready = True
 
         server = WebServer(radio)
         server._scope_disable_grace = 0
-        server._scope_enabled = True
 
         h = MagicMock()
-        server._scope_handlers.add(h)
+        await server.ensure_scope_enabled(h)
 
         server.unregister_scope_handler(h)
         await asyncio.sleep(0.05)  # let async task complete
 
         # DisableScope goes through command queue, not direct radio call
-        from rigplane.web.radio_poller import DisableScope
+        from rigplane.web.radio_poller import DisableScope, EnableScope, RadioPoller
 
         cmds = server._command_queue.drain()
-        assert any(isinstance(c, DisableScope) for c in cmds), (
-            "DisableScope should be in queue"
-        )
+        enable = next(c for c in cmds if isinstance(c, EnableScope))
+        disable = next(c for c in cmds if isinstance(c, DisableScope))
+        assert disable.generation > enable.generation
+
+        # A delayed old enable cannot roll back the queue watermark or revive
+        # hardware after the authoritative last-viewer disable.
+        server._command_queue.put(enable)
+        poller = RadioPoller(radio, server._command_queue, radio_state=RadioState())
+        for command in server._command_queue.drain():
+            await poller._execute(command)  # noqa: SLF001
+        radio.enable_scope.assert_not_awaited()
         assert not server._scope_enabled
 
     async def test_scope_flag_reset_on_disable(self) -> None:
@@ -2601,6 +2610,10 @@ class TestScopeReconnect:
 
         h1 = MagicMock()
         await server.ensure_scope_enabled(h1)
+        from rigplane.web.radio_poller import EnableScope
+
+        (initial_enable,) = server._command_queue.drain()
+        assert isinstance(initial_enable, EnableScope)
 
         # Unregister h1 — schedules disable task but doesn't await it yet
         server.unregister_scope_handler(h1)
@@ -2614,6 +2627,8 @@ class TestScopeReconnect:
 
         # disable_scope must NOT have been called — h2 is still connected
         radio.disable_scope.assert_not_awaited()
+        assert not server._command_queue.has_commands
+        assert server._scope_demand_generation > initial_enable.generation
         assert server._scope_enabled
 
     async def test_broadcast_scope_reaches_new_handler_after_reconnect(
@@ -2641,6 +2656,154 @@ class TestScopeReconnect:
 
         h2.enqueue_frame.assert_called_once_with(frame)
         h1.enqueue_frame.assert_not_called()
+
+
+class TestScopeDemandGeneration:
+    async def test_last_disconnect_cancels_pending_readiness_enable(self) -> None:
+        radio = MagicMock()
+        radio.capabilities = {"scope"}
+        _add_scope_capable_attrs(radio)
+        radio.radio_ready = False
+        server = WebServer(radio)
+
+        handler = MagicMock()
+        await server.ensure_scope_enabled(handler)
+        pending = server._scope_reenable_task
+        assert pending is not None
+
+        server.unregister_scope_handler(handler)
+        assert pending.cancelling()
+        await asyncio.sleep(0)
+
+        assert pending.done()
+        assert server._scope_reenable_task is None
+        assert not server._command_queue.has_commands
+
+    async def test_scope_health_without_viewer_queues_nothing(self) -> None:
+        radio = MagicMock()
+        radio.capabilities = {"scope"}
+        _add_scope_capable_attrs(radio)
+        radio.radio_ready = True
+        server = WebServer(radio)
+        server._scope_health_interval = 0
+        server._scope_last_nonzero = -1
+
+        monitor = asyncio.create_task(server._scope_health_monitor())
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        monitor.cancel()
+        await monitor
+
+        assert not server._command_queue.has_commands
+
+    async def test_scope_health_recovery_uses_current_generation(self) -> None:
+        radio = MagicMock()
+        radio.capabilities = {"scope"}
+        _add_scope_capable_attrs(radio)
+        radio.radio_ready = True
+        server = WebServer(radio)
+        handler = MagicMock()
+        await server.ensure_scope_enabled(handler)
+
+        from rigplane.web.radio_poller import EnableScope
+
+        (initial_enable,) = server._command_queue.drain()
+        assert isinstance(initial_enable, EnableScope)
+        server._scope_health_interval = 0
+        server._scope_health_max_retries = 1
+        server._scope_last_nonzero = -1
+
+        monitor = asyncio.create_task(server._scope_health_monitor())
+        for _ in range(10):
+            await asyncio.sleep(0)
+            if server._command_queue.has_commands:
+                break
+        monitor.cancel()
+        await monitor
+
+        (recovery,) = server._command_queue.drain()
+        assert isinstance(recovery, EnableScope)
+        assert recovery.generation == initial_enable.generation > 0
+
+    async def test_reconnect_enable_uses_current_generation(self) -> None:
+        radio = MagicMock()
+        radio.capabilities = {"scope"}
+        _add_scope_capable_attrs(radio)
+        radio.radio_ready = True
+        radio._fetch_initial_state = AsyncMock()
+        server = WebServer(radio)
+        handler = MagicMock()
+        await server.ensure_scope_enabled(handler)
+
+        from rigplane.web.radio_poller import EnableScope
+
+        (initial_enable,) = server._command_queue.drain()
+        server._on_radio_reconnect()
+        await asyncio.gather(*list(server._bg_tasks))
+
+        (reconnect_enable,) = server._command_queue.drain()
+        assert isinstance(reconnect_enable, EnableScope)
+        assert reconnect_enable.generation == initial_enable.generation
+
+    async def test_reconnect_inside_grace_invalidates_old_reenable(self) -> None:
+        radio = MagicMock()
+        radio.capabilities = {"scope"}
+        _add_scope_capable_attrs(radio)
+        radio.radio_ready = True
+        fetch_started = asyncio.Event()
+        release_fetch = asyncio.Event()
+
+        async def delayed_fetch() -> None:
+            fetch_started.set()
+            await release_fetch.wait()
+
+        radio._fetch_initial_state = delayed_fetch
+        server = WebServer(radio)
+        server._scope_disable_grace = 0.01
+        first = MagicMock()
+        await server.ensure_scope_enabled(first)
+        (initial_enable,) = server._command_queue.drain()
+
+        server._on_radio_reconnect()
+        await fetch_started.wait()
+        server.unregister_scope_handler(first)
+        await server.ensure_scope_enabled(MagicMock())
+        release_fetch.set()
+        await asyncio.sleep(0.02)
+
+        assert not server._command_queue.has_commands
+        assert server._scope_enabled
+        assert server._scope_demand_generation > initial_enable.generation
+
+    async def test_superseded_disable_never_emits_lower_generation(self) -> None:
+        radio = MagicMock()
+        radio.capabilities = {"scope"}
+        _add_scope_capable_attrs(radio)
+        radio.radio_ready = True
+        server = WebServer(radio)
+        server._scope_disable_grace = 0.01
+        first, second = MagicMock(), MagicMock()
+        await server.ensure_scope_enabled(first)
+        server._command_queue.drain()
+
+        from rigplane.web.radio_poller import DisableScope
+
+        with patch.object(
+            server._command_queue, "put", wraps=server._command_queue.put
+        ) as put_spy:
+            server.unregister_scope_handler(first)
+            await server.ensure_scope_enabled(second)
+            server.unregister_scope_handler(second)
+            await asyncio.sleep(0.02)
+
+        disables = [
+            call.args[0]
+            for call in put_spy.call_args_list
+            if isinstance(call.args[0], DisableScope)
+        ]
+        assert [command.generation for command in disables] == [
+            server._scope_demand_generation
+        ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -2659,12 +2659,16 @@ class TestScopeReconnect:
 
 
 class TestScopeDemandGeneration:
-    async def test_last_disconnect_cancels_pending_readiness_enable(self) -> None:
+    @staticmethod
+    def _make_server(*, ready: bool = True) -> tuple[WebServer, MagicMock]:
         radio = MagicMock()
         radio.capabilities = {"scope"}
         _add_scope_capable_attrs(radio)
-        radio.radio_ready = False
-        server = WebServer(radio)
+        radio.radio_ready = ready
+        return WebServer(radio), radio
+
+    async def test_last_disconnect_cancels_pending_readiness_enable(self) -> None:
+        server, _ = self._make_server(ready=False)
 
         handler = MagicMock()
         await server.ensure_scope_enabled(handler)
@@ -2680,11 +2684,7 @@ class TestScopeDemandGeneration:
         assert not server._command_queue.has_commands
 
     async def test_scope_health_without_viewer_queues_nothing(self) -> None:
-        radio = MagicMock()
-        radio.capabilities = {"scope"}
-        _add_scope_capable_attrs(radio)
-        radio.radio_ready = True
-        server = WebServer(radio)
+        server, _ = self._make_server()
         server._scope_health_interval = 0
         server._scope_last_nonzero = -1
 
@@ -2697,11 +2697,7 @@ class TestScopeDemandGeneration:
         assert not server._command_queue.has_commands
 
     async def test_scope_health_recovery_uses_current_generation(self) -> None:
-        radio = MagicMock()
-        radio.capabilities = {"scope"}
-        _add_scope_capable_attrs(radio)
-        radio.radio_ready = True
-        server = WebServer(radio)
+        server, _ = self._make_server()
         handler = MagicMock()
         await server.ensure_scope_enabled(handler)
 
@@ -2726,12 +2722,8 @@ class TestScopeDemandGeneration:
         assert recovery.generation == initial_enable.generation > 0
 
     async def test_reconnect_enable_uses_current_generation(self) -> None:
-        radio = MagicMock()
-        radio.capabilities = {"scope"}
-        _add_scope_capable_attrs(radio)
-        radio.radio_ready = True
+        server, radio = self._make_server()
         radio._fetch_initial_state = AsyncMock()
-        server = WebServer(radio)
         handler = MagicMock()
         await server.ensure_scope_enabled(handler)
 
@@ -2745,11 +2737,11 @@ class TestScopeDemandGeneration:
         assert isinstance(reconnect_enable, EnableScope)
         assert reconnect_enable.generation == initial_enable.generation
 
-    async def test_reconnect_inside_grace_invalidates_old_reenable(self) -> None:
-        radio = MagicMock()
-        radio.capabilities = {"scope"}
-        _add_scope_capable_attrs(radio)
-        radio.radio_ready = True
+    @pytest.mark.parametrize("viewer_returns", [False, True])
+    async def test_reconnect_refetch_uses_current_viewer_demand(
+        self, viewer_returns: bool
+    ) -> None:
+        server, radio = self._make_server()
         fetch_started = asyncio.Event()
         release_fetch = asyncio.Event()
 
@@ -2758,7 +2750,6 @@ class TestScopeDemandGeneration:
             await release_fetch.wait()
 
         radio._fetch_initial_state = delayed_fetch
-        server = WebServer(radio)
         server._scope_disable_grace = 0.01
         first = MagicMock()
         await server.ensure_scope_enabled(first)
@@ -2767,20 +2758,28 @@ class TestScopeDemandGeneration:
         server._on_radio_reconnect()
         await fetch_started.wait()
         server.unregister_scope_handler(first)
-        await server.ensure_scope_enabled(MagicMock())
+        if viewer_returns:
+            await server.ensure_scope_enabled(MagicMock())
         release_fetch.set()
         await asyncio.sleep(0.02)
 
-        assert not server._command_queue.has_commands
-        assert server._scope_enabled
-        assert server._scope_demand_generation > initial_enable.generation
+        from rigplane.web.radio_poller import EnableScope
+
+        enables = [
+            command
+            for command in server._command_queue.drain()
+            if isinstance(command, EnableScope)
+        ]
+        if viewer_returns:
+            assert len(enables) == 1
+            assert enables[0].generation == server._scope_demand_generation
+            assert enables[0].generation > initial_enable.generation
+        else:
+            assert not server._scope_handlers
+            assert not enables
 
     async def test_superseded_disable_never_emits_lower_generation(self) -> None:
-        radio = MagicMock()
-        radio.capabilities = {"scope"}
-        _add_scope_capable_attrs(radio)
-        radio.radio_ready = True
-        server = WebServer(radio)
+        server, _ = self._make_server()
         server._scope_disable_grace = 0.01
         first, second = MagicMock(), MagicMock()
         await server.ensure_scope_enabled(first)


### PR DESCRIPTION
## Summary

- advance a monotonic hardware-scope demand generation on every authoritative first-viewer and last-viewer transition
- generation-qualify handler connect, readiness recovery, reconnect recovery, health recovery, and last-viewer disable commands
- cancel pending readiness work and invalidate superseded disable work so stale commands cannot revive scope
- after reconnect refetch, follow live viewer demand and stamp recovery with the current generation
- preserve same-generation health recovery and reconnect-inside-grace behavior without disable/enable churn

## Why

A delayed scope command could outlive the viewer lifecycle that requested it. PR #2024 made the poller reject stale generations; this producer slice makes every WebServer scope-demand transition and recovery path publish the correct generation while preserving reconnect liveness for a surviving viewer.

## Scope and safety

- 2 files, +215/-19 = +196 net LOC
- no poller type/implementation, frontend, resource-host, audio, TX, provider, or protocol-documentation changes
- CommandQueue and RadioPoller construction/lifetimes are unchanged
- no hardware run or hardware-evidence claim
- this remains Draft pending exact-head CI and a fresh independent Claude Opus 5 max review

## Validation

Exact implementation head: `8ab90e7c161227dd1c52c2f6c857454e14224b2b`

- bounded reconnect-churn probe — 25 iterations × 2 cases passed
- `uv run pytest tests/test_web_server.py -q --tb=short -k "Scope or scope" -p no:randomly` — 82 passed
- `uv run pytest tests/test_web_server.py tests/test_radio_poller_coverage.py -q --tb=short` — 308 passed, 2 skipped
- `uv run ruff check src/ tests/` and `uv run ruff format --check src/ tests/` — passed
- `uv run lint-imports` — 5 contracts kept
- targeted server mypy reports the same untouched pre-existing error documented on the exact base
- the two HTTP tests that timed out only when two full WebServer suites were run concurrently both passed immediately in the required sequential mode

Linear: [MOR-1133](https://linear.app/morozsm/issue/MOR-1133/invalidate-pending-hardware-scope-recovery-on-viewer-lifecycle-changes)

Closes #2023
