### PR TITLE
MOR-1134: add explicit scope viewer-demand toggle

### DIFF
--- a/frontend/src/components/spectrum/SpectrumPanel.svelte
+++ b/frontend/src/components/spectrum/SpectrumPanel.svelte
@@ -49,6 +49,9 @@
 
   // --- Component state ---
   let scopeConnected = $derived(isScopeConnected());
+  let scopeDemandOn = $state(true);
+  let scopeChannel: ReturnType<typeof getChannel> | null = null;
+  let ownsScopeDemand = false;
   let scopePixels = $state<Uint8Array | null>(null);
   let enableAvg = $state(true);
   let enablePeakHold = $state(true);
@@ -201,6 +204,26 @@
     resizingPointerId = null;
   }
 
+  function acquireScopeDemand(): void {
+    if (!scopeChannel || ownsScopeDemand) return;
+    ownsScopeDemand = true;
+    scopeChannel.connect('/api/v1/scope');
+  }
+
+  function releaseScopeDemand(): void {
+    if (!scopeChannel || !ownsScopeDemand) return;
+    ownsScopeDemand = false;
+    scopeChannel.disconnect();
+    setScopeConnected(false);
+  }
+
+  function setScopeDemand(enabled: boolean): void {
+    if (scopeDemandOn === enabled) return;
+    scopeDemandOn = enabled;
+    if (enabled) acquireScopeDemand();
+    else releaseScopeDemand();
+  }
+
   // --- Click-to-tune ---
   function handleTune(hz: number): void {
     const freq = snapToStep(Math.round(hz));
@@ -323,12 +346,11 @@
   // --- Lifecycle: connect scope WS + subscribe to DX spots ---
   onMount(() => {
     // Scope data arrives on its own WebSocket channel
-    const scopeCh = getChannel('scope');
-    scopeCh.connect('/api/v1/scope');
-    const unsubState = scopeCh.onStateChange((s) => {
-      setScopeConnected(s === 'connected');
+    scopeChannel = getChannel('scope');
+    const unsubState = scopeChannel.onStateChange((s) => {
+      setScopeConnected(scopeDemandOn && s === 'connected');
     });
-    const unsubBinary = scopeCh.onBinary((buf) => {
+    const unsubBinary = scopeChannel.onBinary((buf) => {
       markScopeFrame();
       const frame = parseScopeFrame(buf);
       if (!frame) return;
@@ -343,6 +365,7 @@
       spectrumPush?.(frame.pixels);
       waterfallPush?.(frame.pixels);
     });
+    acquireScopeDemand();
 
     // DX spots come through the main control WebSocket as JSON messages
     const unsubMsg = onMessage((msg) => {
@@ -359,7 +382,8 @@
       unsubState();
       unsubBinary();
       unsubMsg();
-      scopeCh.disconnect();
+      releaseScopeDemand();
+      scopeChannel = null;
     };
   });
 </script>
@@ -371,7 +395,7 @@
 />
 
 <div class="spectrum-panel" class:fullscreen onwheel={handleWheel}>
-  <SpectrumToolbar bind:enableAvg bind:enablePeakHold bind:brtLevel bind:colorScheme bind:fullscreen bind:showBandPlan bind:hiddenLayers bind:showEiBi {hideSourceControls} />
+  <SpectrumToolbar bind:enableAvg bind:enablePeakHold bind:brtLevel bind:colorScheme bind:fullscreen bind:showBandPlan bind:hiddenLayers bind:showEiBi {scopeDemandOn} onScopeDemandChange={setScopeDemand} {hideSourceControls} />
   <div class="spectrum-with-scales">
     <div class="db-scale">
       {#each DB_TICKS as tick}
@@ -379,7 +403,9 @@
       {/each}
     </div>
     <div class="spectrum-area" class:panning={dragging} bind:this={spectrumArea} onpointerdown={handleDragStart} role="presentation">
-      {#if !scopeConnected}
+      {#if !scopeDemandOn}
+        <div class="scope-disconnected-overlay scope-demand-off-overlay">Scope viewer OFF</div>
+      {:else if !scopeConnected}
         <div class="scope-disconnected-overlay">{t('core.overlay.scopeDisconnected')}</div>
       {/if}
       <BandPlanOverlay {startFreq} {endFreq} visible={showBandPlan} {hiddenLayers} />

--- a/frontend/src/components/spectrum/SpectrumPanel.svelte
+++ b/frontend/src/components/spectrum/SpectrumPanel.svelte
@@ -210,8 +210,9 @@
     scopeChannel.connect('/api/v1/scope');
   }
 
-  function releaseScopeDemand(): void {
-    if (!scopeChannel || !ownsScopeDemand) return;
+  function releaseScopeDemand(closeIfLive = false): void {
+    if (!scopeChannel) return;
+    if (!ownsScopeDemand && !(closeIfLive && scopeChannel.state !== 'disconnected')) return;
     ownsScopeDemand = false;
     scopeChannel.disconnect();
     setScopeConnected(false);
@@ -348,9 +349,15 @@
     // Scope data arrives on its own WebSocket channel
     scopeChannel = getChannel('scope');
     const unsubState = scopeChannel.onStateChange((s) => {
-      setScopeConnected(scopeDemandOn && s === 'connected');
+      if (!scopeDemandOn) {
+        setScopeConnected(false);
+        if (s === 'connected') scopeChannel?.disconnect();
+        return;
+      }
+      setScopeConnected(s === 'connected');
     });
     const unsubBinary = scopeChannel.onBinary((buf) => {
+      if (!scopeDemandOn) return;
       markScopeFrame();
       const frame = parseScopeFrame(buf);
       if (!frame) return;
@@ -382,7 +389,7 @@
       unsubState();
       unsubBinary();
       unsubMsg();
-      releaseScopeDemand();
+      releaseScopeDemand(true);
       scopeChannel = null;
     };
   });

--- a/frontend/src/components/spectrum/SpectrumToolbar.svelte
+++ b/frontend/src/components/spectrum/SpectrumToolbar.svelte
@@ -28,6 +28,8 @@
     showBandPlan = $bindable(true),
     hiddenLayers = $bindable([] as string[]),
     showEiBi = $bindable(false),
+    scopeDemandOn = true,
+    onScopeDemandChange = (_enabled: boolean) => {},
     /**
      * Hide the DUAL + MAIN/SUB scope-source controls. Set by layouts that
      * surface these controls elsewhere (e.g. v2 desktop VfoHeader bridge,
@@ -172,6 +174,14 @@
     <div class="toolbar-separator"></div>
     <!-- Group B: Scope mode (cyan wash) -->
     <div class="toolbar-group-b">
+      <button
+        class="toolbar-btn scope-demand-toggle"
+        class:active={scopeDemandOn}
+        aria-pressed={scopeDemandOn}
+        onclick={() => onScopeDemandChange(!scopeDemandOn)}
+        title="Request scope viewer data"
+      >VIEW {scopeDemandOn ? 'ON' : 'OFF'}</button>
+      <div class="toolbar-sub-separator"></div>
       <div class="toolbar-group">
         {#each MODE_BUTTONS as [m, label]}
           <button

--- a/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
+++ b/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
@@ -98,11 +98,16 @@ Object.defineProperty(globalThis, 'localStorage', {
 // ---------------------------------------------------------------------------
 
 let capturedOnBinary: ((buf: ArrayBuffer) => void) | null = null;
+let capturedOnState: ((state: string) => void) | null = null;
+let mockScopeConnected = true;
 
 const mockScopeChannel = {
   connect: vi.fn(),
   disconnect: vi.fn(),
-  onStateChange: vi.fn(() => noop),
+  onStateChange: vi.fn((cb: (state: string) => void) => {
+    capturedOnState = cb;
+    return noop;
+  }),
   onBinary: vi.fn((cb: (buf: ArrayBuffer) => void) => {
     capturedOnBinary = cb;
     return noop;
@@ -118,7 +123,7 @@ vi.mock('$lib/transport/ws-client', () => ({
 vi.mock('$lib/stores/connection.svelte', () => ({
   setScopeConnected: vi.fn(),
   markScopeFrame: vi.fn(),
-  isScopeConnected: vi.fn(() => true),
+  isScopeConnected: vi.fn(() => mockScopeConnected),
 }));
 
 vi.mock('$lib/stores/radio.svelte', () => ({
@@ -137,7 +142,7 @@ vi.mock('$lib/stores/tuning.svelte', () => ({
 
 vi.mock('$lib/stores/capabilities.svelte', () => ({
   getCapabilities: vi.fn(() => ({})),
-  hasCapability: vi.fn(() => false),
+  hasCapability: vi.fn((name: string) => name === 'scope'),
   hasDualReceiver: vi.fn(() => false),
 }));
 
@@ -165,6 +170,7 @@ vi.mock('../../../../components-v2/wiring/state-adapter', () => ({
 
 import SpectrumPanel from '../SpectrumPanel.svelte';
 import { getChannel, sendCommand } from '$lib/transport/ws-client';
+import { setScopeConnected } from '$lib/stores/connection.svelte';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -183,6 +189,8 @@ function mountPanel() {
 
 beforeEach(() => {
   components = [];
+  capturedOnState = null;
+  mockScopeConnected = true;
   vi.clearAllMocks();
 });
 
@@ -236,6 +244,68 @@ describe('SpectrumPanel component', () => {
     expect(mockScopeChannel.connect).toHaveBeenCalledWith('/api/v1/scope');
     expect(mockScopeChannel.onBinary).toHaveBeenCalled();
     expect(mockScopeChannel.onStateChange).toHaveBeenCalled();
+  });
+
+  it('releases and reacquires viewer demand through the existing scope channel', () => {
+    const target = mountPanel();
+    const toggle = target.querySelector<HTMLButtonElement>('.scope-demand-toggle')!;
+
+    expect(toggle).not.toBeNull();
+    expect(toggle.getAttribute('aria-pressed')).toBe('true');
+
+    toggle.click();
+    flushSync();
+    expect(toggle.getAttribute('aria-pressed')).toBe('false');
+    expect(mockScopeChannel.disconnect).toHaveBeenCalledTimes(1);
+    expect(setScopeConnected).toHaveBeenLastCalledWith(false);
+
+    toggle.click();
+    flushSync();
+    expect(toggle.getAttribute('aria-pressed')).toBe('true');
+    expect(getChannel).toHaveBeenCalledTimes(1);
+    expect(mockScopeChannel.connect).toHaveBeenCalledTimes(2);
+    expect(mockScopeChannel.connect).toHaveBeenLastCalledWith('/api/v1/scope');
+  });
+
+  it('does not disconnect viewer demand twice after OFF during teardown', () => {
+    const target = mountPanel();
+    target.querySelector<HTMLButtonElement>('.scope-demand-toggle')!.click();
+    flushSync();
+
+    capturedOnState?.('reconnecting');
+    capturedOnState?.('connected');
+    expect(mockScopeChannel.connect).toHaveBeenCalledTimes(1);
+    expect(setScopeConnected).toHaveBeenLastCalledWith(false);
+
+    const component = components.pop()!;
+    unmount(component);
+    expect(mockScopeChannel.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps demand intent ON across channel disconnect and reconnect health changes', () => {
+    const target = mountPanel();
+    const toggle = target.querySelector<HTMLButtonElement>('.scope-demand-toggle')!;
+
+    capturedOnState?.('disconnected');
+    capturedOnState?.('connected');
+    flushSync();
+
+    expect(toggle.getAttribute('aria-pressed')).toBe('true');
+    expect(mockScopeChannel.connect).toHaveBeenCalledTimes(1);
+    expect(mockScopeChannel.disconnect).not.toHaveBeenCalled();
+    expect(setScopeConnected).toHaveBeenNthCalledWith(1, false);
+    expect(setScopeConnected).toHaveBeenNthCalledWith(2, true);
+  });
+
+  it('renders demand ON without claiming an inactive channel is live', () => {
+    mockScopeConnected = false;
+    const target = mountPanel();
+
+    expect(
+      target.querySelector<HTMLButtonElement>('.scope-demand-toggle')?.getAttribute('aria-pressed'),
+    ).toBe('true');
+    expect(target.querySelector('.scope-disconnected-overlay')).not.toBeNull();
+    expect(target.querySelector('.scope-demand-off-overlay')).toBeNull();
   });
 
   it('does not render freq-axis when no span data', () => {

--- a/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
+++ b/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
@@ -100,10 +100,12 @@ Object.defineProperty(globalThis, 'localStorage', {
 let capturedOnBinary: ((buf: ArrayBuffer) => void) | null = null;
 let capturedOnState: ((state: string) => void) | null = null;
 let mockScopeConnected = true;
+let mockScopeState = 'disconnected';
 
 const mockScopeChannel = {
-  connect: vi.fn(),
-  disconnect: vi.fn(),
+  get state() { return mockScopeState; },
+  connect: vi.fn(() => { mockScopeState = 'connecting'; }),
+  disconnect: vi.fn(() => { mockScopeState = 'disconnected'; }),
   onStateChange: vi.fn((cb: (state: string) => void) => {
     capturedOnState = cb;
     return noop;
@@ -170,7 +172,7 @@ vi.mock('../../../../components-v2/wiring/state-adapter', () => ({
 
 import SpectrumPanel from '../SpectrumPanel.svelte';
 import { getChannel, sendCommand } from '$lib/transport/ws-client';
-import { setScopeConnected } from '$lib/stores/connection.svelte';
+import { markScopeFrame, setScopeConnected } from '$lib/stores/connection.svelte';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -191,6 +193,7 @@ beforeEach(() => {
   components = [];
   capturedOnState = null;
   mockScopeConnected = true;
+  mockScopeState = 'disconnected';
   vi.clearAllMocks();
 });
 
@@ -267,26 +270,44 @@ describe('SpectrumPanel component', () => {
     expect(mockScopeChannel.connect).toHaveBeenLastCalledWith('/api/v1/scope');
   });
 
-  it('does not disconnect viewer demand twice after OFF during teardown', () => {
+  it('rejects frames and immediately closes an externally resurrected channel while OFF', () => {
     const target = mountPanel();
     target.querySelector<HTMLButtonElement>('.scope-demand-toggle')!.click();
     flushSync();
 
-    capturedOnState?.('reconnecting');
+    capturedOnBinary?.(new ArrayBuffer(16));
+    expect(markScopeFrame).not.toHaveBeenCalled();
+
+    mockScopeState = 'connected';
     capturedOnState?.('connected');
     expect(mockScopeChannel.connect).toHaveBeenCalledTimes(1);
+    expect(mockScopeChannel.disconnect).toHaveBeenCalledTimes(2);
     expect(setScopeConnected).toHaveBeenLastCalledWith(false);
 
     const component = components.pop()!;
     unmount(component);
+    expect(mockScopeChannel.disconnect).toHaveBeenCalledTimes(2);
+  });
+
+  it('closes a resurrected live channel during teardown even without a state notification', () => {
+    const target = mountPanel();
+    target.querySelector<HTMLButtonElement>('.scope-demand-toggle')!.click();
+    flushSync();
     expect(mockScopeChannel.disconnect).toHaveBeenCalledTimes(1);
+
+    mockScopeState = 'connected';
+    const component = components.pop()!;
+    unmount(component);
+    expect(mockScopeChannel.disconnect).toHaveBeenCalledTimes(2);
   });
 
   it('keeps demand intent ON across channel disconnect and reconnect health changes', () => {
     const target = mountPanel();
     const toggle = target.querySelector<HTMLButtonElement>('.scope-demand-toggle')!;
 
+    mockScopeState = 'disconnected';
     capturedOnState?.('disconnected');
+    mockScopeState = 'connected';
     capturedOnState?.('connected');
     flushSync();
 


### PR DESCRIPTION
Linear: https://linear.app/morozsm/issue/MOR-1134/add-explicit-web-ui-hardware-scope-viewer-demand-toggle

Closes #2021

## Summary
- add an explicit VIEW ON/OFF demand control for the existing named scope channel
- close the current /api/v1/scope viewer demand on OFF and reacquire the same channel on ON
- keep user demand intent distinct from scope-channel health and avoid optimistic hardware-active claims
- make OFF and teardown cleanup idempotent while preserving automatic network reconnect only when demand remains ON

## Scope
- 3 files
- 117 insertions, 11 deletions (106 net LOC)
- no server, poller, provider, App, runtime host, transport, capability-schema, or protocol changes

## Verification
- RED before implementation: 4 new focused component checks failed
- npm test -- --run src/components/spectrum/__tests__/SpectrumPanel.component.test.ts — 15 passed
- npm test -- --run src/components/spectrum — 200 passed
- NODE_OPTIONS=--localstorage-file=/tmp/rigplane-mor1134-localstorage.json npm test -- --run — 2,350 passed
- npm run check — 0 errors, 0 warnings
- npm run lint — passed
- npm run build — passed (existing chunk-size warning only)
- npm run i18n:check — passed
- git diff --check — passed

## Evidence boundary
No real-hardware validation or hardware-active claim is made. Fresh exact-head independent Claude Opus 5 max review remains required before Ready/merge.