### PR TITLE
MOR-1038: derive pure TX capability and tri-state permit facts

### DIFF
--- a/frontend/src/lib/runtime/adapters/__tests__/tx-capabilities.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/tx-capabilities.test.ts
@@ -1,11 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import type { Capabilities } from '$lib/types/capabilities';
 import type { KnownTxTargetPublic } from '$lib/types/state';
-import { getFrequencyPermit } from '$lib/utils/tx-permit';
-import {
-  deriveTxCapabilities,
-  type TxCapabilityInput,
-} from '../tx-capabilities';
+import { getFrequencyPermit, getTxPermit } from '$lib/utils/tx-permit';
+import { deriveTxCapabilities, type TxCapabilityInput } from '../tx-capabilities';
 const TARGET: KnownTxTargetPublic = {
   status: 'known', receiver: 'MAIN', slot: 'A', frequencyHz: 150,
 };
@@ -40,7 +37,6 @@ describe('deriveTxCapabilities', () => {
       catPttAvailable: expected, browserTxAudioAvailable: expected,
     });
   });
-
   it('keeps browser audio, native voice, and MOD routing independent', () => {
     const present = derive({ capabilities: ['audio', 'tx', 'voice_tx', 'mod_input_routing'] });
     expect(present).toMatchObject({
@@ -58,7 +54,6 @@ describe('deriveTxCapabilities', () => {
       modInputReadiness: { status: 'not-applicable' },
     });
   });
-
   it.each([
     ['single', 1, { status: 'known', receiver: 'MAIN', slot: null, frequencyHz: 150 }],
     ['ab', 1, { status: 'known', receiver: 'MAIN', slot: 'A', frequencyHz: 150 }],
@@ -69,7 +64,6 @@ describe('deriveTxCapabilities', () => {
       txTarget, modInputSource: { status: 'unknown' },
     }).txTarget).toEqual(txTarget);
   });
-
   it.each([
     [null, { status: 'known', source: 5 }, 'not-applicable'],
     [5, { status: 'unknown' }, 'unknown'],
@@ -81,7 +75,6 @@ describe('deriveTxCapabilities', () => {
       { txTarget: TARGET, modInputSource },
     ).modInputReadiness.status).toBe(status);
   });
-
   it.each([
     [{ status: 'unknown', reason: 'stale' }, 'unknown', 'tx-target-unknown'],
     [{ ...TARGET, frequencyHz: null }, 'known', 'tx-target-unknown'],
@@ -94,7 +87,6 @@ describe('deriveTxCapabilities', () => {
     expect(result.txTarget.status).toBe(targetStatus);
     expect(result.frequencyPermit).toMatchObject({ status: 'unknown', reason: permitReason });
   });
-
   it('does not mutate capability, target, or band inputs', () => {
     const capabilities = caps();
     const input: TxCapabilityInput = {
@@ -106,25 +98,34 @@ describe('deriveTxCapabilities', () => {
     expect({ capabilities, input }).toEqual(before);
   });
 });
-
 describe('getFrequencyPermit', () => {
   it('distinguishes inclusive ranges, deny-all, and unknown inputs without mutation', () => {
     const bands = [{ name: 'test', start: 100, end: 200 }];
     const before = structuredClone(bands);
     expect(getFrequencyPermit(100, bands)).toEqual({ status: 'allowed', band: 'test' });
     expect(getFrequencyPermit(200, bands)).toEqual({ status: 'allowed', band: 'test' });
-    expect(getFrequencyPermit(99, bands)).toEqual({
-      status: 'denied', reason: 'outside-configured-ranges',
-    });
-    expect(getFrequencyPermit(150, [])).toEqual({
-      status: 'denied', reason: 'outside-configured-ranges',
-    });
-    expect(getFrequencyPermit(150, null)).toEqual({
-      status: 'unknown', reason: 'ranges-unconfigured',
-    });
-    expect(getFrequencyPermit(null, bands)).toEqual({
-      status: 'unknown', reason: 'tx-target-unknown',
-    });
+    expect(getFrequencyPermit(99, bands)).toEqual(
+      { status: 'denied', reason: 'outside-configured-ranges' },
+    );
+    expect(getFrequencyPermit(150, [])).toEqual(
+      { status: 'denied', reason: 'outside-configured-ranges' },
+    );
+    expect(getFrequencyPermit(150, null)).toEqual(
+      { status: 'unknown', reason: 'ranges-unconfigured' },
+    );
+    expect(getFrequencyPermit(null, bands)).toEqual(
+      { status: 'unknown', reason: 'tx-target-unknown' },
+    );
     expect(bands).toEqual(before);
+  });
+  it.each([
+    [150, undefined, 'denied'], [150, null, 'denied'], [150, [], 'denied'],
+    [Number.NaN, [{ name: 'test', start: 100, end: 200 }], 'denied'],
+    [Infinity, [{ name: 'test', start: 100, end: 200 }], 'denied'],
+    [99, [{ name: 'test', start: 100, end: 200 }], 'denied'],
+    [100, [{ name: 'test', start: 100, end: 200 }], 'allowed'],
+    [200, [{ name: 'test', start: 100, end: 200 }], 'allowed'],
+  ] as const)('keeps transitional permit fail-closed at %s Hz', (freq, bands, expected) => {
+    expect(getTxPermit(freq, bands)).toBe(expected);
   });
 });

--- a/frontend/src/lib/runtime/adapters/__tests__/tx-capabilities.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/tx-capabilities.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { KnownTxTargetPublic } from '$lib/types/state';
+import { getFrequencyPermit } from '$lib/utils/tx-permit';
+import {
+  deriveTxCapabilities,
+  type TxCapabilityInput,
+} from '../tx-capabilities';
+const TARGET: KnownTxTargetPublic = {
+  status: 'known', receiver: 'MAIN', slot: 'A', frequencyHz: 150,
+};
+function caps(overrides: Partial<Capabilities> = {}): Capabilities {
+  return {
+    model: 'fixture', scope: false, audio: true, tx: true,
+    audioTx: true, audioTxRoute: 'lan', audioTxRequiredModInputSource: 5,
+    capabilities: ['audio', 'tx', 'mod_input_routing'],
+    receivers: 2, vfoScheme: 'main_sub', freqRanges: [], modes: [], filters: [],
+    audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
+    webrtc: { available: false, enabled: false },
+    txBands: [{ name: 'test', start: 100, end: 200 }],
+    ...overrides,
+  };
+}
+function derive(
+  overrides: Partial<Capabilities> = {},
+  input: TxCapabilityInput = {
+    txTarget: TARGET, modInputSource: { status: 'known', source: 5 },
+  },
+) {
+  return deriveTxCapabilities(caps(overrides), input);
+}
+describe('deriveTxCapabilities', () => {
+  it.each([
+    [true, ['tx'], true],
+    [false, [], false],
+    [true, [], false],
+    [false, ['tx'], false],
+  ] as const)('requires canonical tx=%s/tag agreement', (tx, capabilities, expected) => {
+    expect(derive({ tx, capabilities: [...capabilities] })).toMatchObject({
+      catPttAvailable: expected, browserTxAudioAvailable: expected,
+    });
+  });
+
+  it('keeps browser audio, native voice, and MOD routing independent', () => {
+    const present = derive({ capabilities: ['audio', 'tx', 'voice_tx', 'mod_input_routing'] });
+    expect(present).toMatchObject({
+      catPttAvailable: true, browserTxAudioAvailable: true,
+      nativeVoiceTxAvailable: true, modInputRoutingAvailable: true,
+    });
+    const absentAudioTx = derive({
+      audioTx: undefined, audioTxRoute: undefined,
+      audioTxRequiredModInputSource: undefined,
+      capabilities: ['audio', 'tx', 'voice_tx'],
+    });
+    expect(absentAudioTx).toMatchObject({
+      catPttAvailable: true, browserTxAudioAvailable: false,
+      nativeVoiceTxAvailable: true, modInputRoutingAvailable: false,
+      modInputReadiness: { status: 'not-applicable' },
+    });
+  });
+
+  it.each([
+    ['single', 1, { status: 'known', receiver: 'MAIN', slot: null, frequencyHz: 150 }],
+    ['ab', 1, { status: 'known', receiver: 'MAIN', slot: 'A', frequencyHz: 150 }],
+    ['ab_shared', 2, { status: 'known', receiver: 'SUB', slot: null, frequencyHz: 150 }],
+    ['main_sub', 2, { status: 'known', receiver: 'SUB', slot: 'B', frequencyHz: 150 }],
+  ] as const)('accepts explicit %s target identity', (vfoScheme, receivers, txTarget) => {
+    expect(derive({ vfoScheme, receivers }, {
+      txTarget, modInputSource: { status: 'unknown' },
+    }).txTarget).toEqual(txTarget);
+  });
+
+  it.each([
+    [null, { status: 'known', source: 5 }, 'not-applicable'],
+    [5, { status: 'unknown' }, 'unknown'],
+    [5, { status: 'known', source: 5 }, 'ready'],
+    [5, { status: 'known', source: 2 }, 'mismatch'],
+  ] as const)('derives required source %s readiness as %s', (required, modInputSource, status) => {
+    expect(derive(
+      { audioTxRequiredModInputSource: required },
+      { txTarget: TARGET, modInputSource },
+    ).modInputReadiness.status).toBe(status);
+  });
+
+  it.each([
+    [{ status: 'unknown', reason: 'stale' }, 'unknown', 'tx-target-unknown'],
+    [{ ...TARGET, frequencyHz: null }, 'known', 'tx-target-unknown'],
+    [{ ...TARGET, slot: null }, 'unknown', 'tx-target-unknown'],
+  ] as const)('fails %s target closed', (txTarget, targetStatus, permitReason) => {
+    const result = derive({}, {
+      txTarget: txTarget as TxCapabilityInput['txTarget'],
+      modInputSource: { status: 'unknown' },
+    });
+    expect(result.txTarget.status).toBe(targetStatus);
+    expect(result.frequencyPermit).toMatchObject({ status: 'unknown', reason: permitReason });
+  });
+
+  it('does not mutate capability, target, or band inputs', () => {
+    const capabilities = caps();
+    const input: TxCapabilityInput = {
+      txTarget: structuredClone(TARGET),
+      modInputSource: { status: 'known', source: 5 },
+    };
+    const before = structuredClone({ capabilities, input });
+    deriveTxCapabilities(capabilities, input);
+    expect({ capabilities, input }).toEqual(before);
+  });
+});
+
+describe('getFrequencyPermit', () => {
+  it('distinguishes inclusive ranges, deny-all, and unknown inputs without mutation', () => {
+    const bands = [{ name: 'test', start: 100, end: 200 }];
+    const before = structuredClone(bands);
+    expect(getFrequencyPermit(100, bands)).toEqual({ status: 'allowed', band: 'test' });
+    expect(getFrequencyPermit(200, bands)).toEqual({ status: 'allowed', band: 'test' });
+    expect(getFrequencyPermit(99, bands)).toEqual({
+      status: 'denied', reason: 'outside-configured-ranges',
+    });
+    expect(getFrequencyPermit(150, [])).toEqual({
+      status: 'denied', reason: 'outside-configured-ranges',
+    });
+    expect(getFrequencyPermit(150, null)).toEqual({
+      status: 'unknown', reason: 'ranges-unconfigured',
+    });
+    expect(getFrequencyPermit(null, bands)).toEqual({
+      status: 'unknown', reason: 'tx-target-unknown',
+    });
+    expect(bands).toEqual(before);
+  });
+});

--- a/frontend/src/lib/runtime/adapters/tx-capabilities.ts
+++ b/frontend/src/lib/runtime/adapters/tx-capabilities.ts
@@ -1,0 +1,75 @@
+import type { Capabilities } from '$lib/types/capabilities';
+import type { KnownTxTargetPublic, UnknownTxTargetPublic } from '$lib/types/state';
+import { getFrequencyPermit, type FrequencyPermit } from '$lib/utils/tx-permit';
+
+type TxTarget = KnownTxTargetPublic | UnknownTxTargetPublic;
+export type ModInputSource =
+  | { status: 'known'; source: number }
+  | { status: 'unknown' };
+export type ModInputReadiness =
+  | { status: 'not-applicable' }
+  | { status: 'ready'; source: number }
+  | { status: 'mismatch'; source: number }
+  | { status: 'unknown' };
+export interface TxCapabilityInput {
+  txTarget: TxTarget;
+  modInputSource: ModInputSource;
+}
+export interface TxCapabilityFacts {
+  catPttAvailable: boolean;
+  browserTxAudioAvailable: boolean;
+  nativeVoiceTxAvailable: boolean;
+  modInputRoutingAvailable: boolean;
+  modInputReadiness: ModInputReadiness;
+  txTarget: TxTarget;
+  frequencyPermit: FrequencyPermit;
+}
+
+function normalizeTarget(caps: Capabilities, target: TxTarget): TxTarget {
+  if (target.status === 'unknown') return { ...target };
+  const receiver = target.receiver;
+  const slot = target.slot;
+  const valid = caps.vfoScheme === 'single'
+    ? receiver === 'MAIN' && slot === null
+    : caps.vfoScheme === 'ab'
+      ? receiver === 'MAIN' && (slot === 'A' || slot === 'B')
+      : caps.vfoScheme === 'ab_shared'
+        ? slot === null && (receiver === 'MAIN' || receiver === 'SUB')
+        : caps.vfoScheme === 'main_sub'
+          && (receiver === 'MAIN' || receiver === 'SUB')
+          && (slot === 'A' || slot === 'B');
+  return valid ? { ...target } : { status: 'unknown', reason: 'contradiction' };
+}
+
+export function deriveTxCapabilities(
+  caps: Capabilities,
+  input: TxCapabilityInput,
+): TxCapabilityFacts {
+  const tags = new Set(caps.capabilities);
+  const catPttAvailable = caps.tx === true && tags.has('tx');
+  const modInputRoutingAvailable = tags.has('mod_input_routing');
+  const requiredSource = caps.audioTxRequiredModInputSource;
+  let modInputReadiness: ModInputReadiness;
+  if (!modInputRoutingAvailable || requiredSource == null) {
+    modInputReadiness = { status: 'not-applicable' };
+  } else if (input.modInputSource.status === 'unknown') {
+    modInputReadiness = { status: 'unknown' };
+  } else if (input.modInputSource.source === requiredSource) {
+    modInputReadiness = { status: 'ready', source: input.modInputSource.source };
+  } else {
+    modInputReadiness = { status: 'mismatch', source: input.modInputSource.source };
+  }
+  const txTarget = normalizeTarget(caps, input.txTarget);
+  return {
+    catPttAvailable,
+    browserTxAudioAvailable: caps.audioTx === true && catPttAvailable,
+    nativeVoiceTxAvailable: tags.has('voice_tx'),
+    modInputRoutingAvailable,
+    modInputReadiness,
+    txTarget,
+    frequencyPermit: getFrequencyPermit(
+      txTarget.status === 'known' ? txTarget.frequencyHz : null,
+      caps.txBands,
+    ),
+  };
+}

--- a/frontend/src/lib/utils/tx-permit.ts
+++ b/frontend/src/lib/utils/tx-permit.ts
@@ -1,44 +1,37 @@
-/**
- * TX permission check based on radio's band capabilities.
- *
- * Uses txBands from capabilities API (radio profile) when available,
- * falls back to US amateur radio allocations.
- */
+import type { TxBand } from '$lib/types/capabilities';
 
-interface TxBand {
-  name: string;
-  start: number; // Hz
-  end: number;   // Hz
+export type FrequencyPermit =
+  | { status: 'allowed'; band: string | null }
+  | { status: 'denied'; reason: 'outside-configured-ranges' }
+  | { status: 'unknown'; reason: 'ranges-unconfigured' | 'tx-target-unknown' };
+
+/**
+ * Evaluate only an explicit TX-target frequency against configured ranges.
+ * `null` ranges are unknown; an explicit empty list is deny-all.
+ */
+export function getFrequencyPermit(
+  freqHz: number | null,
+  txBands: readonly TxBand[] | null,
+): FrequencyPermit {
+  if (freqHz === null || !Number.isFinite(freqHz)) {
+    return { status: 'unknown', reason: 'tx-target-unknown' };
+  }
+  if (txBands === null) {
+    return { status: 'unknown', reason: 'ranges-unconfigured' };
+  }
+  const band = txBands.find(({ start, end }) => freqHz >= start && freqHz <= end);
+  return band
+    ? { status: 'allowed', band: band.name || null }
+    : { status: 'denied', reason: 'outside-configured-ranges' };
 }
 
-// Fallback: US Amateur Extra class TX allocations (Hz)
-const US_TX_BANDS: TxBand[] = [
-  { name: '160m', start: 1_800_000, end: 2_000_000 },
-  { name: '80m', start: 3_500_000, end: 4_000_000 },
-  { name: '60m', start: 5_330_500, end: 5_405_000 },
-  { name: '40m', start: 7_000_000, end: 7_300_000 },
-  { name: '30m', start: 10_100_000, end: 10_150_000 },
-  { name: '20m', start: 14_000_000, end: 14_350_000 },
-  { name: '17m', start: 18_068_000, end: 18_168_000 },
-  { name: '15m', start: 21_000_000, end: 21_450_000 },
-  { name: '12m', start: 24_890_000, end: 24_990_000 },
-  { name: '10m', start: 28_000_000, end: 29_700_000 },
-  { name: '6m', start: 50_000_000, end: 54_000_000 },
-];
-
+/** Transitional binary view for the pre-v3 mobile caller; unknown fails closed. */
 export type TxPermit = 'allowed' | 'denied';
-
-/**
- * Check if TX is permitted at the given frequency (Hz).
- * Uses radio's txBands from capabilities when provided,
- * otherwise falls back to hardcoded US bands.
- */
-export function getTxPermit(freqHz: number, txBands?: TxBand[] | null): TxPermit {
-  const bands = txBands && txBands.length > 0 ? txBands : US_TX_BANDS;
-  for (const band of bands) {
-    if (freqHz >= band.start && freqHz <= band.end) {
-      return 'allowed';
-    }
-  }
-  return 'denied';
+export function getTxPermit(
+  freqHz: number,
+  txBands?: readonly TxBand[] | null,
+): TxPermit {
+  return getFrequencyPermit(freqHz, txBands ?? null).status === 'allowed'
+    ? 'allowed'
+    : 'denied';
 }


### PR DESCRIPTION
Linear: https://linear.app/morozsm/issue/MOR-1038/derive-pure-tx-capability-and-tri-state-frequency-permit-facts

Closes #2031

## Summary
- derive independent CAT PTT, explicit browser audio TX, native voice TX, and MOD-routing/readiness facts from the validated capability document
- accept only explicit backend-neutral known/unknown TX targets and validate their scheme-sensitive receiver/slot identity without inferring from RX, split, model, or VFO state
- replace implicit US allocation fallback with structured tri-state permit semantics at the explicit target frequency (`null` ranges unknown, `[]` deny-all, inclusive boundaries)
- retain a transitional binary helper for the pre-v3 mobile caller; it collapses `unknown` to `denied` fail-closed until the separate controller/mobile integration slice

## Scope
- 3 files
- 236 insertions, 38 deletions = +198 net LOC
- no UI, store, transport, command bus, controller, backend, or persistence changes

## Verification
- `NODE_OPTIONS=--no-experimental-webstorage npm test` — 134 files / 2364 tests passed on Node 26.4.0
- `npm test -- --run src/lib/runtime/adapters/__tests__/tx-capabilities.test.ts` — 18 tests passed
- `npm run check`
- `npm run lint`
- `npm run build`
- `git diff --check`

No hardware evidence is claimed.