### PR TITLE
MOR-1136: canonicalize hardware-scope frame decoding

### DIFF
--- a/frontend/src/components-v2/panels/lcd/__tests__/scope-frame.test.ts
+++ b/frontend/src/components-v2/panels/lcd/__tests__/scope-frame.test.ts
@@ -1,33 +1,11 @@
 /**
  * Tests for scope frame parsing and bandwidth derivation in AmberLcdDisplay.
  *
- * parseScopeFrame is defined inline in the component, so this file tests the
- * same parsing logic as a standalone pure function to verify correctness of the
- * binary protocol and bandwidth computation that drives AmberAfScope.
+ * The runtime adapter owns scope-frame parsing. These tests verify that canonical
+ * decoder and the bandwidth computation that drives AmberAfScope.
  */
 import { describe, it, expect } from 'vitest';
-
-// ── Re-implement parseScopeFrame as a pure function for testing ───────────────
-
-interface ScopeFrame {
-  receiver: number;
-  mode: number;
-  startFreq: number;
-  endFreq: number;
-  pixels: Uint8Array;
-}
-
-function parseScopeFrame(buf: ArrayBuffer): ScopeFrame | null {
-  const view = new DataView(buf);
-  if (view.byteLength < 16 || view.getUint8(0) !== 0x01) return null;
-  const receiver = view.getUint8(1);
-  const mode = view.getUint8(2);
-  const startFreq = view.getUint32(3, true);
-  const endFreq = view.getUint32(7, true);
-  const pixelCount = view.getUint16(14, true);
-  if (16 + pixelCount > view.byteLength) return null;
-  return { receiver, mode, startFreq, endFreq, pixels: new Uint8Array(buf, 16, pixelCount) };
-}
+import { parseScopeFrame, type ScopeFrame } from '$lib/runtime/adapters/scope-adapter';
 
 /** Encode a scope frame in the binary wire format. */
 function encodeFrame(
@@ -69,12 +47,14 @@ describe('parseScopeFrame', () => {
     expect(parseScopeFrame(buf.slice(0, 20))).toBeNull();
   });
 
-  it('parses receiver, startFreq, endFreq, and pixels from a valid frame', () => {
+  it('parses immutable receiver, mode, frequency, and pixel facts from a valid frame', () => {
     const pixels = new Uint8Array([10, 20, 30, 40, 50]);
     const buf = encodeFrame(0, 14_050_000, 14_098_000, pixels);
     const frame = parseScopeFrame(buf);
     expect(frame).not.toBeNull();
+    expect(Object.isFrozen(frame)).toBe(true);
     expect(frame!.receiver).toBe(0);
+    expect(frame!.mode).toBe(0);
     expect(frame!.startFreq).toBe(14_050_000);
     expect(frame!.endFreq).toBe(14_098_000);
     expect(Array.from(frame!.pixels)).toEqual([10, 20, 30, 40, 50]);

--- a/frontend/src/components/spectrum/spectrum-logic.ts
+++ b/frontend/src/components/spectrum/spectrum-logic.ts
@@ -2,33 +2,9 @@
  * Pure logic extracted from SpectrumPanel.svelte for testability.
  */
 
-// --- Scope frame binary protocol ---
-export interface ScopeFrame {
-  receiver: number;
-  mode: number;       // 0=CTR, 1=FIX, 2=SCROLL-C, 3=SCROLL-F
-  startFreq: number;
-  endFreq: number;
-  pixels: Uint8Array;
-}
-
-export function parseScopeFrame(buf: ArrayBuffer): ScopeFrame | null {
-  const view = new DataView(buf);
-  // Magic byte 0x01, minimum 16-byte header
-  if (view.byteLength < 16 || view.getUint8(0) !== 0x01) return null;
-  const receiver = view.getUint8(1);
-  const mode = view.getUint8(2);
-  const startFreq = view.getUint32(3, true);
-  const endFreq = view.getUint32(7, true);
-  const pixelCount = view.getUint16(14, true);
-  if (16 + pixelCount > view.byteLength) return null;
-  return {
-    receiver,
-    mode,
-    startFreq,
-    endFreq,
-    pixels: new Uint8Array(buf, 16, pixelCount),
-  };
-}
+// Compatibility exports: the runtime adapter owns the binary wire decoder.
+export { parseScopeFrame } from '$lib/runtime/adapters/scope-adapter';
+export type { ScopeFrame } from '$lib/runtime/adapters/scope-adapter';
 
 // --- Scale helpers ---
 export function formatFreqOffset(hz: number): string {

--- a/frontend/src/lib/runtime/adapters/scope-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/scope-adapter.ts
@@ -1,62 +1,27 @@
-/**
- * Scope adapter — encapsulates audio-scope WS channel lifecycle.
- *
- * Replaces direct getChannel('audio-scope') usage in AudioSpectrumPanel
- * and AmberLcdDisplay. Parses binary scope frames in one place.
- *
- * Usage in a Svelte $effect:
- *   const scope = createAudioScopeConnection(frame => { ... });
- *   return () => scope.disconnect();
- */
-
-import { getChannel } from '$lib/transport/ws-client';
-import { markScopeFrame } from '$lib/stores/connection.svelte';
-
-let _scopeInstanceId = 0;
+/** Runtime-owned decoder for binary audio-scope frames. */
 
 export interface ScopeFrame {
-  receiver: number;
-  startFreq: number;
-  endFreq: number;
-  pixels: Uint8Array;
+  readonly receiver: number;
+  readonly mode: number;
+  readonly startFreq: number;
+  readonly endFreq: number;
+  readonly pixels: Uint8Array;
 }
 
 export function parseScopeFrame(buf: ArrayBuffer): ScopeFrame | null {
   const view = new DataView(buf);
   if (view.byteLength < 16 || view.getUint8(0) !== 0x01) return null;
   const receiver = view.getUint8(1);
+  const mode = view.getUint8(2);
   const startFreq = view.getUint32(3, true);
   const endFreq = view.getUint32(7, true);
   const pixelCount = view.getUint16(14, true);
   if (16 + pixelCount > view.byteLength) return null;
-  return { receiver, startFreq, endFreq, pixels: new Uint8Array(buf, 16, pixelCount) };
-}
-
-export interface AudioScopeHandle {
-  disconnect: () => void;
-}
-
-/**
- * Open audio-scope WS channel and deliver parsed frames to the callback.
- * Returns a handle with disconnect() for cleanup.
- */
-export function createAudioScopeConnection(
-  onFrame: (frame: ScopeFrame) => void,
-): AudioScopeHandle {
-  // Each caller gets its own channel to avoid lifecycle conflicts
-  // when multiple components mount/unmount independently.
-  const ch = getChannel(`audio-scope-${++_scopeInstanceId}`);
-  ch.connect('/api/v1/audio-scope');
-  const unsubBinary = ch.onBinary((buf) => {
-    markScopeFrame();
-    const frame = parseScopeFrame(buf);
-    if (frame) onFrame(frame);
+  return Object.freeze({
+    receiver,
+    mode,
+    startFreq,
+    endFreq,
+    pixels: new Uint8Array(buf, 16, pixelCount),
   });
-
-  return {
-    disconnect: () => {
-      unsubBinary();
-      ch.disconnect();
-    },
-  };
 }


### PR DESCRIPTION
Closes #2034

## Scope
- move the complete binary scope-frame decoder and `ScopeFrame` type to the runtime adapter, including `mode`
- retain `spectrum-logic` compatibility exports without a second parser
- delete the obsolete per-caller audio-scope connection factory
- make LCD parsing tests exercise the canonical decoder

## Verification
- `NODE_OPTIONS="--localstorage-file=/tmp/rigplane-mor1136-localstorage" pnpm exec vitest run --project fast src/components-v2/panels/lcd/__tests__/scope-frame.test.ts src/components/spectrum/__tests__/spectrum-panel-logic.test.ts src/components/spectrum/__tests__/tuning-indicator.test.ts src/lib/runtime/__tests__/scope-controller.test.ts` (64 passed)
- `NODE_OPTIONS="--localstorage-file=/tmp/rigplane-mor1136-localstorage" pnpm test` (133 files, 2351 tests passed)
- `pnpm check`
- `pnpm lint`
- `pnpm build`
- static source check: one `parseScopeFrame` definition; no `createAudioScopeConnection` references

No lifecycle, transport, server, protocol, hardware, ResourceHost, ScopeController, or panel behavior changes.