### PR TITLE
MOR-1137: add hardware scope lifecycle to ScopeController

### DIFF
--- a/frontend/src/lib/runtime/__tests__/scope-controller.test.ts
+++ b/frontend/src/lib/runtime/__tests__/scope-controller.test.ts
@@ -16,20 +16,35 @@ import type { ScopeFrame } from '../scope-controller.svelte';
 
 function makeMockChannel() {
   const binaryHandlers = new Set<(buf: ArrayBuffer) => void>();
+  const stateHandlers = new Set<(state: string) => void>();
+  const binaryHistory: Array<(buf: ArrayBuffer) => void> = [];
+  const stateHistory: Array<(state: string) => void> = [];
+  let state = 'disconnected';
   return {
+    get state() { return state; },
     connect: vi.fn(),
     disconnect: vi.fn(),
     onBinary: vi.fn((handler: (buf: ArrayBuffer) => void) => {
       binaryHandlers.add(handler);
+      binaryHistory.push(handler);
       return () => { binaryHandlers.delete(handler); };
+    }),
+    onStateChange: vi.fn((handler: (next: string) => void) => {
+      stateHandlers.add(handler);
+      stateHistory.push(handler);
+      return () => { stateHandlers.delete(handler); };
     }),
     /** Fire a binary message to all registered handlers. */
     _fire(buf: ArrayBuffer) {
       for (const h of binaryHandlers) h(buf);
     },
-    _handlerCount() {
-      return binaryHandlers.size;
+    _setState(next: string) {
+      state = next;
+      for (const h of stateHandlers) h(next);
     },
+    _binaryHistory: binaryHistory, _stateHistory: stateHistory,
+    _handlerCount() { return binaryHandlers.size; },
+    _stateHandlerCount() { return stateHandlers.size; },
   };
 }
 
@@ -234,5 +249,110 @@ describe('ScopeController', () => {
     expect(lookup).toHaveBeenCalledWith('audio-scope');
     expect(defaultChannel.connect).toHaveBeenCalledWith('/api/v1/audio-scope');
     await defaultController.audioFftDriver.stop(handle);
+  });
+
+  it('owns hardware first/shared/last demand without claiming frame liveness', async () => {
+    const channels = { scope: makeMockChannel(), 'audio-scope': makeMockChannel() };
+    const lookup = vi.fn((name: string) => channels[name as keyof typeof channels] as any);
+    const controller = new ScopeController(lookup);
+    const host = new PresentationResourceHost<unknown>('hardware');
+    host.configure('hardware-scope', { available: true, selected: true, driver: controller.hardwareScopeDriver });
+    expect(lookup).not.toHaveBeenCalled();
+
+    const first = host.acquire('hardware-scope', 'first');
+    const shared = host.acquire('hardware-scope', 'shared');
+    await vi.waitFor(() => expect(channels.scope.connect).toHaveBeenCalledTimes(1));
+    expect(lookup).toHaveBeenCalledWith('scope');
+    expect(channels.scope.connect).toHaveBeenCalledWith('/api/v1/scope');
+    expect([
+      controller.hardwareScopeDemanded,
+      controller.hardwareScopeConnected,
+      controller.hardwareScopeFrameLive,
+    ]).toEqual([true, false, false]);
+
+    channels.scope._setState('connected');
+    expect(controller.hardwareScopeConnected).toBe(true);
+    expect(controller.hardwareScopeFrameLive).toBe(false);
+    channels.scope._fire(makeScopeFrameBuffer());
+    expect(controller.scopeFrame?.startFreq).toBe(14_100_000);
+    expect(controller.hardwareScopeFrameLive).toBe(true);
+
+    expect(host.release(first)).toBe(true);
+    expect(channels.scope.disconnect).not.toHaveBeenCalled();
+    expect(host.release(shared)).toBe(true);
+    await vi.waitFor(() => expect(channels.scope.disconnect).toHaveBeenCalledTimes(1));
+    expect(host.release(shared)).toBe(false);
+    expect([
+      controller.hardwareScopeDemanded,
+      controller.hardwareScopeConnected,
+      controller.hardwareScopeFrameLive,
+      controller.scopeFrame,
+    ]).toEqual([false, false, false, null]);
+    expect(channels.scope._handlerCount()).toBe(0);
+    expect(channels.scope._stateHandlerCount()).toBe(0);
+    expect(channels['audio-scope'].connect).not.toHaveBeenCalled();
+
+    const pending = host.acquire('hardware-scope', 'pending');
+    expect(host.release(pending)).toBe(true);
+    await vi.waitFor(() => expect(channels.scope.disconnect).toHaveBeenCalledTimes(2));
+    expect(channels.scope._handlerCount()).toBe(0);
+    expect(controller.hardwareScopeDemanded).toBe(false);
+  });
+
+  it('qualifies hardware callbacks and cleanup across A to B to A handles', async () => {
+    const hardware = makeMockChannel();
+    const controller = new ScopeController(() => hardware as any);
+    const subscriber = vi.fn();
+    controller.subscribeHardware(subscriber);
+    const firstA = await controller.hardwareScopeDriver.start();
+    const b = await controller.hardwareScopeDriver.start();
+    const currentA = await controller.hardwareScopeDriver.start();
+    const [staleAFrame, staleBFrame, currentFrame] = hardware._binaryHistory;
+    const [staleAState, staleBState, currentState] = hardware._stateHistory;
+
+    await controller.hardwareScopeDriver.stop(firstA);
+    await controller.hardwareScopeDriver.dispose?.(b);
+    staleAState('connected');
+    staleBState('connected');
+    staleAFrame(makeScopeFrameBuffer());
+    staleBFrame(makeScopeFrameBuffer());
+    expect(controller.hardwareScopeConnected).toBe(false);
+    expect(controller.scopeFrame).toBeNull();
+    expect(subscriber).not.toHaveBeenCalled();
+    expect(hardware.disconnect).not.toHaveBeenCalled();
+
+    currentState('connected');
+    currentFrame(makeScopeFrameBuffer());
+    expect(controller.hardwareScopeConnected).toBe(true);
+    expect(controller.hardwareScopeFrameLive).toBe(true);
+    expect(subscriber).toHaveBeenCalledTimes(1);
+    await controller.hardwareScopeDriver.stop(currentA);
+    expect(hardware.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not let stale reconnect callbacks revive current hardware state', async () => {
+    const hardware = makeMockChannel();
+    const controller = new ScopeController(() => hardware as any);
+    const stale = await controller.hardwareScopeDriver.start();
+    const staleState = hardware._stateHistory[0];
+    await controller.hardwareScopeDriver.stop(stale);
+    const current = await controller.hardwareScopeDriver.start();
+    const currentState = hardware._stateHistory[1];
+
+    staleState('connected');
+    expect(controller.hardwareScopeConnected).toBe(false);
+    currentState('connected');
+    hardware._fire(makeScopeFrameBuffer());
+    expect(controller.hardwareScopeFrameLive).toBe(true);
+    currentState('reconnecting');
+    expect([
+      controller.hardwareScopeConnected,
+      controller.hardwareScopeFrameLive,
+      controller.scopeFrame,
+    ]).toEqual([false, false, null]);
+    currentState('connected');
+    expect(controller.hardwareScopeConnected).toBe(true);
+    expect(controller.hardwareScopeFrameLive).toBe(false);
+    await controller.hardwareScopeDriver.stop(current);
   });
 });

--- a/frontend/src/lib/runtime/scope-controller.svelte.ts
+++ b/frontend/src/lib/runtime/scope-controller.svelte.ts
@@ -1,8 +1,8 @@
 /**
- * ScopeController — singleton owner of the audio-scope WebSocket channel.
+ * ScopeController — singleton owner of hardware and audio-scope WebSockets.
  *
- * Opens `/api/v1/audio-scope` lazily on first presentation demand and closes
- * it on last release. Parses binary frames with
+ * Opens each scope channel lazily on first presentation demand and closes it
+ * on last release. Parses binary frames with
  * `parseScopeFrame()` from `scope-adapter.ts` and stores the latest frame as
  * a reactive `$state` property that Svelte components can read via `$derived`.
  *
@@ -16,7 +16,7 @@ import { getChannel } from '$lib/transport/ws-client';
 import { markScopeFrame } from '$lib/stores/connection.svelte';
 import { parseScopeFrame } from '$lib/runtime/adapters/scope-adapter';
 import type { ScopeFrame } from '$lib/runtime/adapters/scope-adapter';
-import type { WsChannel } from '$lib/transport/ws-client';
+import type { ConnectionState, WsChannel } from '$lib/transport/ws-client';
 import type { PresentationResourceDriver, PresentationResourceHost } from './resource-host';
 
 export type { ScopeFrame };
@@ -25,26 +25,40 @@ type FrameHandler = (frame: ScopeFrame) => void;
 type ChannelFactory = (name: string) => WsChannel;
 type AudioFftHandle = Readonly<{ token: symbol }>;
 type ChannelBinding = { channel: WsChannel; unsubscribe: () => void };
+type HardwareHandle = Readonly<{ generation: number }>;
+type HardwareBinding = { channel: WsChannel; unsubscribeBinary: () => void; unsubscribeState: () => void };
 
 export class ScopeController {
   /** Latest parsed audio-scope frame (Svelte 5 reactive). */
   audioScopeFrame: ScopeFrame | null = $state(null);
 
-  /** Hardware scope — not yet implemented; always false for now. */
+  /** Capability selection is wired by a later slice; lifecycle state stays factual. */
   readonly hardwareScopeAvailable = false;
   readonly audioScopeAvailable = true;
   readonly activeScope: 'hardware' | 'audio-fft' | null = 'audio-fft';
-  readonly scopeFrame: ScopeFrame | null = null;
+  scopeFrame: ScopeFrame | null = $state(null);
+  hardwareScopeDemanded = $state(false);
+  hardwareScopeConnected = $state(false);
+  hardwareScopeFrameLive = $state(false);
 
   private _subscribers = new Map<number, FrameHandler>();
+  private _hardwareSubscribers = new Map<number, FrameHandler>();
   private _nextId = 0;
   private _bindings = new Map<AudioFftHandle, ChannelBinding>();
   private _activeHandle: AudioFftHandle | null = null;
+  private _hardwareBindings = new Map<HardwareHandle, HardwareBinding>();
+  private _activeHardwareHandle: HardwareHandle | null = null;
+  private _hardwareGeneration = 0;
   private _getChannel: ChannelFactory;
   readonly audioFftDriver: PresentationResourceDriver<unknown> = {
     start: () => this._connect(),
     stop: (handle) => this._disconnect(handle as AudioFftHandle),
     dispose: (handle) => this._disconnect(handle as AudioFftHandle),
+  };
+  readonly hardwareScopeDriver: PresentationResourceDriver<unknown> = {
+    start: () => this._connectHardware(),
+    stop: (handle) => this._disconnectHardware(handle as HardwareHandle),
+    dispose: (handle) => this._disconnectHardware(handle as HardwareHandle),
   };
 
   constructor(channelFactory: ChannelFactory = (name) => getChannel(name)) {
@@ -61,6 +75,11 @@ export class ScopeController {
     const id = this._nextId++;
     this._subscribers.set(id, handler);
     return () => { this._subscribers.delete(id); };
+  }
+
+  subscribeHardware(handler: FrameHandler): () => void {
+    const id = this._nextId++; this._hardwareSubscribers.set(id, handler);
+    return () => { this._hardwareSubscribers.delete(id); };
   }
 
   registerPresentationDriver(host: Pick<PresentationResourceHost<unknown>, 'configure'>): void {
@@ -114,6 +133,67 @@ export class ScopeController {
         if (this._activeHandle === handle) {
           this._activeHandle = null;
           this.audioScopeFrame = null;
+        }
+      }
+    }
+  }
+
+  private _connectHardware(): HardwareHandle {
+    const channel = this._getChannel('scope');
+    const handle = Object.freeze({ generation: ++this._hardwareGeneration });
+    let unsubscribeBinary = () => {}, unsubscribeState = () => {};
+    try {
+      unsubscribeBinary = channel.onBinary((buf) => {
+        if (this._activeHardwareHandle !== handle) return;
+        const frame = parseScopeFrame(buf);
+        if (!frame) return;
+        markScopeFrame();
+        this.scopeFrame = frame;
+        this.hardwareScopeFrameLive = true;
+        for (const subscriber of this._hardwareSubscribers.values()) subscriber(frame);
+      });
+      unsubscribeState = channel.onStateChange((state: ConnectionState) => {
+        if (this._activeHardwareHandle !== handle) return;
+        this.hardwareScopeConnected = state === 'connected';
+        if (state !== 'connected') {
+          this.hardwareScopeFrameLive = false;
+          this.scopeFrame = null;
+        }
+      });
+      channel.connect('/api/v1/scope');
+    } catch (error) {
+      try { unsubscribeBinary(); } finally { unsubscribeState(); }
+      if (![...this._hardwareBindings.values()].some((item) => item.channel === channel)) {
+        channel.disconnect();
+      }
+      throw error;
+    }
+    this._hardwareBindings.set(handle, { channel, unsubscribeBinary, unsubscribeState });
+    this._activeHardwareHandle = handle;
+    this.hardwareScopeDemanded = true;
+    this.hardwareScopeConnected = channel.state === 'connected';
+    this.hardwareScopeFrameLive = false;
+    this.scopeFrame = null;
+    return handle;
+  }
+
+  private _disconnectHardware(handle: HardwareHandle): void {
+    const binding = this._hardwareBindings.get(handle);
+    if (!binding) return;
+    this._hardwareBindings.delete(handle);
+    if (this._activeHardwareHandle === handle) {
+      this._activeHardwareHandle = null;
+      this.hardwareScopeDemanded = false;
+      this.hardwareScopeConnected = false;
+      this.hardwareScopeFrameLive = false;
+      this.scopeFrame = null;
+    }
+    try {
+      binding.unsubscribeBinary();
+    } finally {
+      try { binding.unsubscribeState(); } finally {
+        if (![...this._hardwareBindings.values()].some((item) => item.channel === binding.channel)) {
+          binding.channel.disconnect();
         }
       }
     }


### PR DESCRIPTION
## Summary
- add an exact-generation hardware-scope driver to the existing singleton `ScopeController`
- keep hardware and audio channels, handles, frames, and subscribers independent
- expose separate demand, transport-connection, and current-connection frame-liveness facts
- reject stale A→B→A callbacks and prevent stale cleanup from closing the current named `scope` channel

## Scope
- 2 files
- 208 additions / 8 deletions = 200 net LOC
- base: `9a857e90aff934d688a0755851da89c91dfd82dd`
- no capability selection, ResourceHost registration, App/runtime wiring, transport/server/provider changes, or hardware-evidence claim

## Verification
- RED evidence: 3 new hardware lifecycle test groups failed before implementation
- `npm test -- --run src/lib/runtime/__tests__/scope-controller.test.ts` — 14/14 PASS
- `NODE_OPTIONS=--localstorage-file=/tmp/rigplane-mor1137-localstorage.json npm test` — 134 files / 2380 tests PASS
- `npm run check` — 0 errors / 0 warnings
- `npm run lint` — PASS
- `npm run lint:boundaries` — PASS
- `npm run i18n:check` — PASS
- `npm run build` — PASS
- `git diff --check` — PASS

Closes #2036
Linear: MOR-1137