### PR TITLE
MOR-1138: wire hardware scope demand and DX runtime facade

### DIFF
--- a/frontend/src/lib/runtime/__tests__/frontend-runtime.test.ts
+++ b/frontend/src/lib/runtime/__tests__/frontend-runtime.test.ts
@@ -105,7 +105,7 @@ vi.mock('./system-controller', async () => {
 // ── Import modules under test after mocks are hoisted ──
 
 import { fetchCapabilities, startPolling } from '$lib/transport/http-client';
-import { connect, sendRaw } from '$lib/transport/ws-client';
+import { connect, getChannel, onMessage, sendRaw } from '$lib/transport/ws-client';
 import { setCapabilities } from '$lib/stores/capabilities.svelte';
 import { setRadioState } from '$lib/stores/radio.svelte';
 import { audioManager } from '$lib/audio/audio-manager';
@@ -125,12 +125,17 @@ async function freshRuntime() {
     _bootstrapCleanup: null;
     _bootstrapInFlight: null;
     _rxAudioLease: null;
-    _rxAudioEnded: boolean;
+    _ended: boolean;
+    _dxSubscribers: Map<number, unknown>;
+    _dxControlUnsubscribe: (() => void) | null;
   };
+  rt._dxControlUnsubscribe?.();
+  rt._dxSubscribers?.clear();
   rt._bootstrapCleanup = null;
   rt._bootstrapInFlight = null;
   rt._rxAudioLease = null;
-  rt._rxAudioEnded = false;
+  rt._ended = false;
+  rt._dxControlUnsubscribe = null;
   return mod.runtime;
 }
 
@@ -138,9 +143,13 @@ async function freshRuntime() {
 
 const fakeCaps = {
   modes: ['USB', 'LSB'],
-  scope: false,
+  scope: true,
   audio: true,
   capabilities: ['audio'],
+  receivers: 1,
+  vfoScheme: 'ab',
+  scopeSource: 'audio_fft',
+  audioFftAvailable: true,
 } as any;
 const fakeStopPolling = vi.fn();
 const deferred = <T>() => {
@@ -358,6 +367,96 @@ describe('FrontendRuntime.bootstrap()', () => {
   });
 });
 
+describe('FrontendRuntime hardware scope and DX facades', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (fetchCapabilities as ReturnType<typeof vi.fn>).mockResolvedValue(fakeCaps);
+    (startPolling as ReturnType<typeof vi.fn>).mockReturnValue(fakeStopPolling);
+  });
+
+  it('derives unavailable/default selection and keeps bootstrap inert', async () => {
+    const rt = await freshRuntime();
+    await rt.bootstrap();
+
+    expect(presentationResources.snapshot('hardware-scope')).toMatchObject({
+      available: false,
+      selected: false,
+      demand: 0,
+      health: 'inactive',
+    });
+    expect(getChannel).not.toHaveBeenCalled();
+  });
+
+  it('starts only for exact shared demand and stops on the last valid release', async () => {
+    const channel = {
+      state: 'disconnected',
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      onBinary: vi.fn(() => vi.fn()),
+      onStateChange: vi.fn(() => vi.fn()),
+    };
+    (getChannel as ReturnType<typeof vi.fn>).mockReturnValue(channel);
+    (fetchCapabilities as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ...fakeCaps,
+      scope: true,
+      capabilities: ['audio', 'scope'],
+      scopeSource: 'hardware',
+    });
+    const rt = await freshRuntime();
+    await rt.bootstrap();
+
+    expect(presentationResources.snapshot('hardware-scope')).toMatchObject({
+      available: true,
+      selected: true,
+      demand: 0,
+    });
+    expect(getChannel).not.toHaveBeenCalled();
+
+    const first = rt.acquireHardwareScope('first');
+    const shared = rt.acquireHardwareScope('shared');
+    await settle();
+    expect(getChannel).toHaveBeenCalledExactlyOnceWith('scope');
+    expect(channel.connect).toHaveBeenCalledExactlyOnceWith('/api/v1/scope');
+    expect(presentationResources.snapshot('hardware-scope').demand).toBe(2);
+
+    expect(rt.releaseHardwareScope(first)).toBe(true);
+    expect(rt.releaseHardwareScope(first)).toBe(false);
+    expect(channel.disconnect).not.toHaveBeenCalled();
+    expect(rt.releaseHardwareScope(shared)).toBe(true);
+    await settle();
+    expect(channel.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('shares one filtered control subscription and unsubscribes exactly', async () => {
+    let controlHandler: ((message: unknown) => void) | undefined;
+    const controlUnsubscribe = vi.fn();
+    (onMessage as ReturnType<typeof vi.fn>).mockImplementation((handler) => {
+      controlHandler = handler;
+      return controlUnsubscribe;
+    });
+    const rt = await freshRuntime();
+    const first = vi.fn();
+    const second = vi.fn();
+    const unsubscribeFirst = rt.subscribeDx(first);
+    const unsubscribeSecond = rt.subscribeDx(second);
+
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    controlHandler?.({ type: 'state', data: {} });
+    controlHandler?.({ type: 'dx_spot', spot: { call: 'K1ABC' } });
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+
+    unsubscribeFirst();
+    unsubscribeFirst();
+    controlHandler?.({ type: 'dx_spots', spots: [] });
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(2);
+    expect(controlUnsubscribe).not.toHaveBeenCalled();
+    unsubscribeSecond();
+    expect(controlUnsubscribe).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('FrontendRuntime RX LIVE intent', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -438,9 +537,27 @@ describe('FrontendRuntime RX LIVE intent', () => {
   });
 
   it('tears down once, in order, and never restarts after final cleanup', async () => {
+    const channel = {
+      state: 'disconnected',
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      onBinary: vi.fn(() => vi.fn()),
+      onStateChange: vi.fn(() => vi.fn()),
+    };
+    (getChannel as ReturnType<typeof vi.fn>).mockReturnValue(channel);
+    (fetchCapabilities as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ...fakeCaps,
+      scope: true,
+      capabilities: ['audio', 'scope'],
+      scopeSource: 'hardware',
+    });
+    const unsubscribeDx = vi.fn();
+    (onMessage as ReturnType<typeof vi.fn>).mockReturnValue(unsubscribeDx);
     const rt = await freshRuntime();
     await rt.bootstrap();
     rt.setRxLive(true);
+    const hardwareLease = rt.acquireHardwareScope('SpectrumPanel');
+    rt.subscribeDx(vi.fn());
     await settle();
 
     const cleanup = await rt.bootstrap();
@@ -452,6 +569,11 @@ describe('FrontendRuntime RX LIVE intent', () => {
 
     expect(audioManager.startRx).toHaveBeenCalledTimes(1);
     expect(audioManager.stopRx).toHaveBeenCalledTimes(1);
+    expect(channel.disconnect).toHaveBeenCalledTimes(1);
+    expect(unsubscribeDx).toHaveBeenCalledTimes(1);
+    expect(rt.releaseHardwareScope(hardwareLease)).toBe(false);
+    expect(() => rt.acquireHardwareScope('late')).toThrow('torn down');
+    expect(() => rt.subscribeDx(vi.fn())).toThrow('torn down');
     expect(presentationResources.snapshot('rx-audio')).toMatchObject({
       demand: 0,
       health: 'inactive',

--- a/frontend/src/lib/runtime/frontend-runtime.ts
+++ b/frontend/src/lib/runtime/frontend-runtime.ts
@@ -25,10 +25,11 @@ import {
   getRadioPowerOn,
 } from '$lib/stores/connection.svelte';
 import { getAudioState, setVolume, setMuted, toggleMute } from '$lib/stores/audio.svelte';
-import { sendCommand, connect, sendRaw } from '$lib/transport/ws-client';
+import { sendCommand, connect, onMessage, sendRaw } from '$lib/transport/ws-client';
 import { fetchCapabilities, startPolling, setPollingMultiplier } from '$lib/transport/http-client';
 import { audioManager } from '$lib/audio/audio-manager';
 import { clearLegacyPendingModInputRestore } from './adapters/mod-input-auto.svelte';
+import { derivePresentationCapabilities } from './adapters/presentation-capabilities';
 import { systemController } from './system-controller';
 import { scopeController } from './scope-controller.svelte';
 import type { ScopeController } from './scope-controller.svelte';
@@ -36,8 +37,11 @@ import { PresentationResourceHost } from './resource-host';
 import type { ResourceLease } from './resource-demand';
 import type { ServerState, ReceiverState } from '$lib/types/state';
 import type { Capabilities } from '$lib/types/capabilities';
+import type { WsIncoming } from '$lib/types/protocol';
 export const presentationResources = new PresentationResourceHost<unknown>('app');
 // ── Types ──
+
+export type DxMessage = Extract<WsIncoming, { type: 'dx_spot' | 'dx_spots' }>;
 
 export interface ConnectionSnapshot {
   status: 'connected' | 'partial' | 'disconnected';
@@ -57,9 +61,17 @@ class FrontendRuntime {
   private _bootstrapCleanup: (() => void) | null = null;
   private _bootstrapInFlight: Promise<() => void> | null = null;
   private _rxAudioLease: ResourceLease | null = null;
-  private _rxAudioEnded = false;
+  private _ended = false;
+  private _dxSubscribers = new Map<number, (message: DxMessage) => void>();
+  private _dxControlUnsubscribe: (() => void) | null = null;
+  private _nextDxSubscriber = 0;
 
   constructor() {
+    presentationResources.configure('hardware-scope', {
+      available: false,
+      selected: false,
+      driver: scopeController.hardwareScopeDriver,
+    });
     presentationResources.configure('rx-audio', {
       available: false,
       selected: true,
@@ -188,6 +200,11 @@ class FrontendRuntime {
     // 1. Fetch capabilities and push into the store.
     const caps = await fetchCapabilities();
     setCapabilities(caps);
+    const presentationCaps = derivePresentationCapabilities(caps);
+    presentationResources.configure('hardware-scope', {
+      available: presentationCaps.scope.hardwareScopeAvailable,
+      selected: presentationCaps.scope.defaultSource === 'hardware',
+    });
     presentationResources.configure('rx-audio', {
       available: caps.audio === true && caps.capabilities.includes('audio'),
       selected: true,
@@ -211,9 +228,14 @@ class FrontendRuntime {
     // Only latch as started after the entire chain succeeds.
     let cleanupInFlight: Promise<void> | undefined;
     const cleanup = () => cleanupInFlight ??= (async () => {
-      this._rxAudioEnded = true;
-      await presentationResources.teardown();
-      stopPolling();
+      this._ended = true;
+      this._rxAudioLease = null;
+      this._dxSubscribers.clear();
+      const unsubscribeDx = this._dxControlUnsubscribe;
+      this._dxControlUnsubscribe = null;
+      try { unsubscribeDx?.(); } finally {
+        try { await presentationResources.teardown(); } finally { stopPolling(); }
+      }
     })();
     this._bootstrapCleanup = cleanup;
     return cleanup;
@@ -240,9 +262,46 @@ class FrontendRuntime {
 
   // ── Audio control ──
 
+  acquireHardwareScope(consumer: string): ResourceLease {
+    if (this._ended) throw new Error('frontend runtime is torn down');
+    return presentationResources.acquire('hardware-scope', consumer);
+  }
+
+  releaseHardwareScope(lease: ResourceLease): boolean {
+    return lease.resource === 'hardware-scope' && presentationResources.release(lease);
+  }
+
+  subscribeDx(handler: (message: DxMessage) => void): () => void {
+    if (this._ended) throw new Error('frontend runtime is torn down');
+    const id = this._nextDxSubscriber++;
+    this._dxSubscribers.set(id, handler);
+    if (this._dxControlUnsubscribe === null) {
+      try {
+        this._dxControlUnsubscribe = onMessage((message) => {
+          if (message.type !== 'dx_spot' && message.type !== 'dx_spots') return;
+          for (const subscriber of [...this._dxSubscribers.values()]) subscriber(message);
+        });
+      } catch (error) {
+        this._dxSubscribers.delete(id);
+        throw error;
+      }
+    }
+    let active = true;
+    return () => {
+      if (!active) return;
+      active = false;
+      this._dxSubscribers.delete(id);
+      if (this._dxSubscribers.size === 0) {
+        const unsubscribe = this._dxControlUnsubscribe;
+        this._dxControlUnsubscribe = null;
+        unsubscribe?.();
+      }
+    };
+  }
+
   setRxLive(live: boolean): void {
     if (live) {
-      if (!this._rxAudioEnded && this._rxAudioLease === null) {
+      if (!this._ended && this._rxAudioLease === null) {
         this._rxAudioLease = presentationResources.acquire('rx-audio', 'presentation');
       }
       return;


### PR DESCRIPTION
Closes #2038
Linear: MOR-1138

## Summary
- register the existing ScopeController hardware driver as `hardware-scope` in the single App-session resource host
- derive hardware availability and default selection from authoritative presentation capabilities
- expose exact hardware demand lease and shared filtered DX subscription facades through FrontendRuntime
- make final runtime teardown unsubscribe DX, invalidate resource leases, and stop active hardware/RX resources exactly once

## Safety and lifecycle evidence
- bootstrap is inert: it does not look up or connect the named scope channel without demand
- first/shared/last demand uses one hardware channel and ignores duplicate stale releases
- one control-channel callback is shared across DX subscribers and unsubscribed exactly on last/final release
- no App, component, ScopeController, transport, server, provider, command-policy, or hardware-acceptance change
- legacy SpectrumPanel ownership remains until MOR-1139; this slice does not auto-acquire it

## Verification
- focused runtime/resource-host/scope: 47 passed
- full frontend: 134 files / 2383 tests passed (`NODE_OPTIONS=--no-experimental-webstorage`, required by local Node 26)
- `npm run check`: 0 errors / 0 warnings
- `npm run lint`: passed
- `npm run build`: passed
- `npm run i18n:check`: passed
- `uv run ruff check src/ tests/`: passed
- `uv run lint-imports`: 5 contracts kept
- additional backend run on exact origin/main backend sources: 7878 passed before bounded stop at 93%; one unrelated existing audio smoke failure (`test_session_lifecycle_via_bridge_and_web_tx_lease`), with no `src/` or `tests/` diff in this PR

No real-hardware evidence is claimed.