### PR TITLE
MOR-1139: cut SpectrumPanel over to runtime scope demand

### DIFF
--- a/frontend/src/components-v2/layout/StatusBar.svelte
+++ b/frontend/src/components-v2/layout/StatusBar.svelte
@@ -10,6 +10,7 @@
     | 'failed'
     | 'disconnected'
     | 'connected';
+  export type IndicatorTone = 'green' | 'yellow' | 'red' | 'neutral';
 
   export function deriveScopeIndicatorState(
     status: DefaultScopeStatus,
@@ -29,6 +30,25 @@
     if (status.transport === 'disconnected') return 'disconnected';
     if (!status.frameSeen) return 'waiting';
     return status.lifecycle === 'streaming' ? 'connected' : 'inactive';
+  }
+
+  export function indicatorTone(state: string): IndicatorTone {
+    switch (state) {
+      case 'connected':
+        return 'green';
+      case 'connecting':
+      case 'starting':
+      case 'waiting':
+      case 'reconnecting':
+      case 'partial':
+      case 'degraded':
+        return 'yellow';
+      case 'disconnected':
+      case 'failed':
+        return 'red';
+      default:
+        return 'neutral';
+    }
   }
 </script>
 
@@ -145,18 +165,12 @@
   );
 
   function stateColor(state: string): string {
-    switch (state) {
-      case 'connected':
+    switch (indicatorTone(state)) {
+      case 'green':
         return 'var(--v2-accent-green, #4ade80)';
-      case 'connecting':
-      case 'starting':
-      case 'waiting':
-      case 'reconnecting':
-      case 'partial':
-      case 'degraded':
+      case 'yellow':
         return 'var(--v2-accent-yellow, #facc15)';
-      case 'disconnected':
-      case 'failed':
+      case 'red':
         return 'var(--v2-accent-red, #ef4444)';
       default:
         return 'var(--v2-text-dim, #666)';

--- a/frontend/src/components-v2/layout/StatusBar.svelte
+++ b/frontend/src/components-v2/layout/StatusBar.svelte
@@ -1,3 +1,37 @@
+<script module lang="ts">
+  import type { DefaultScopeStatus } from '$lib/runtime/frontend-runtime';
+
+  export type ScopeIndicatorState =
+    | 'inactive'
+    | 'starting'
+    | 'connecting'
+    | 'waiting'
+    | 'reconnecting'
+    | 'failed'
+    | 'disconnected'
+    | 'connected';
+
+  export function deriveScopeIndicatorState(
+    status: DefaultScopeStatus,
+    isPoweredOff: boolean,
+  ): ScopeIndicatorState {
+    if (isPoweredOff) return 'disconnected';
+    if (
+      status.source === null
+      || !status.available
+      || !status.resourceSelected
+      || status.demand === 0
+    ) return 'inactive';
+    if (status.lifecycle === 'failed') return 'failed';
+    if (status.lifecycle === 'starting') return 'starting';
+    if (status.transport === 'connecting') return 'connecting';
+    if (status.transport === 'reconnecting') return 'reconnecting';
+    if (status.transport === 'disconnected') return 'disconnected';
+    if (!status.frameSeen) return 'waiting';
+    return status.lifecycle === 'streaming' ? 'connected' : 'inactive';
+  }
+</script>
+
 <script lang="ts">
   import { Radio, Cable, Activity, Volume2, ArrowDownUp, Power, Unplug, Palette, Monitor, Tv, Settings, Bug } from 'lucide-svelte';
   import ThemePicker from '../controls/ThemePicker.svelte';
@@ -7,7 +41,6 @@
   import {
     getRadioStatus,
     getConnectionStatus,
-    isScopeConnected,
     isAudioConnected,
     getHttpConnected,
     getRadioPowerOn,
@@ -62,7 +95,9 @@
   // When radio is powered off, override statuses that depend on the radio
   let radioState = $derived(isPoweredOff ? 'disconnected' : getRadioStatus());
   let controlState = $derived(getConnectionStatus()); // server link — always real
-  let scopeState = $derived(isPoweredOff ? 'disconnected' : (isScopeConnected() ? 'connected' : 'disconnected'));
+  let scopeState = $derived(
+    deriveScopeIndicatorState(runtime.defaultScopeStatus, isPoweredOff),
+  );
   let audioState = $derived(isPoweredOff ? 'disconnected' : (isAudioConnected() ? 'connected' : 'disconnected'));
   let httpState = $derived(getHttpConnected() ? 'connected' : 'disconnected'); // server link — always real
   let rigConnected = $derived(getRigConnected());
@@ -114,11 +149,14 @@
       case 'connected':
         return 'var(--v2-accent-green, #4ade80)';
       case 'connecting':
+      case 'starting':
+      case 'waiting':
       case 'reconnecting':
       case 'partial':
       case 'degraded':
         return 'var(--v2-accent-yellow, #facc15)';
       case 'disconnected':
+      case 'failed':
         return 'var(--v2-accent-red, #ef4444)';
       default:
         return 'var(--v2-text-dim, #666)';

--- a/frontend/src/components/spectrum/SpectrumPanel.svelte
+++ b/frontend/src/components/spectrum/SpectrumPanel.svelte
@@ -12,8 +12,7 @@
     type WaterfallOptions,
     type ColorSchemeName,
   } from '../../lib/renderers/waterfall-renderer';
-  import { getChannel, onMessage, sendCommand } from '../../lib/transport/ws-client';
-  import { setScopeConnected, markScopeFrame, isScopeConnected } from '../../lib/stores/connection.svelte';
+  import { runtime } from '../../lib/runtime/frontend-runtime';
   import { type DxSpot } from '../../lib/types/protocol';
   import { patchActiveReceiver, patchReceiver, radio } from '../../lib/stores/radio.svelte';
   import { getFilterWidthHz } from '../../lib/utils/filter-width';
@@ -31,12 +30,10 @@
     getPassbandGeometry,
   } from './passband-geometry';
   import {
-    parseScopeFrame,
     formatFreqOffset,
     deriveFreqTicks,
     getDragInterval,
     isFixedScope as isFixedScopeFn,
-    type ScopeFrame,
   } from './spectrum-logic';
 
   // --- Props ---
@@ -48,10 +45,9 @@
   let { hideSourceControls = false } = $props();
 
   // --- Component state ---
-  let scopeConnected = $derived(isScopeConnected());
+  let scopeConnected = $derived(runtime.scope.hardwareScopeConnected);
   let scopeDemandOn = $state(true);
-  let scopeChannel: ReturnType<typeof getChannel> | null = null;
-  let ownsScopeDemand = false;
+  let scopeLease: ReturnType<typeof runtime.acquireHardwareScope> | null = null;
   let scopePixels = $state<Uint8Array | null>(null);
   let enableAvg = $state(true);
   let enablePeakHold = $state(true);
@@ -158,7 +154,7 @@
     }
 
     patchActiveReceiver({ filterWidth: width }, true);
-    sendCommand('set_filter_width', { width });
+    runtime.send('set_filter_width', { width });
   }
 
   function handlePassbandResizeStart(event: PointerEvent): void {
@@ -205,17 +201,14 @@
   }
 
   function acquireScopeDemand(): void {
-    if (!scopeChannel || ownsScopeDemand) return;
-    ownsScopeDemand = true;
-    scopeChannel.connect('/api/v1/scope');
+    if (scopeLease) return;
+    scopeLease = runtime.acquireHardwareScope('SpectrumPanel');
   }
 
-  function releaseScopeDemand(closeIfLive = false): void {
-    if (!scopeChannel) return;
-    if (!ownsScopeDemand && !(closeIfLive && scopeChannel.state !== 'disconnected')) return;
-    ownsScopeDemand = false;
-    scopeChannel.disconnect();
-    setScopeConnected(false);
+  function releaseScopeDemand(): void {
+    const lease = scopeLease;
+    scopeLease = null;
+    if (lease) runtime.releaseHardwareScope(lease);
   }
 
   function setScopeDemand(enabled: boolean): void {
@@ -231,7 +224,7 @@
     if (freq <= 0) return;
     const receiver = radio.current?.active === 'SUB' ? 1 : 0;
     patchReceiver(receiver, { freqHz: freq }, true);
-    sendCommand('set_freq', { freq, receiver });
+    runtime.send('set_freq', { freq, receiver });
   }
 
   // --- Scroll-to-tune (mouse wheel on spectrum/waterfall) ---
@@ -321,7 +314,7 @@
     lastDragSendFreq = newFreq;
     const receiver = radio.current?.active === 'SUB' ? 1 : 0;
     patchReceiver(receiver, { freqHz: newFreq }, true);
-    sendCommand('set_freq', { freq: newFreq, receiver });
+    runtime.send('set_freq', { freq: newFreq, receiver });
   }
 
   function handleDragEnd(event: PointerEvent): void {
@@ -332,7 +325,7 @@
       if (dragFreq > 0 && dragFreq !== lastDragSendFreq) {
         const receiver = radio.current?.active === 'SUB' ? 1 : 0;
         patchReceiver(receiver, { freqHz: dragFreq }, true);
-        sendCommand('set_freq', { freq: dragFreq, receiver });
+        runtime.send('set_freq', { freq: dragFreq, receiver });
       }
     }
     // Tap-to-tune is handled exclusively by WaterfallCanvas gesture onTap
@@ -344,23 +337,10 @@
     dragSpeed = 0;
   }
 
-  // --- Lifecycle: connect scope WS + subscribe to DX spots ---
+  // --- Lifecycle: demand scope runtime + subscribe to frames and DX spots ---
   onMount(() => {
-    // Scope data arrives on its own WebSocket channel
-    scopeChannel = getChannel('scope');
-    const unsubState = scopeChannel.onStateChange((s) => {
-      if (!scopeDemandOn) {
-        setScopeConnected(false);
-        if (s === 'connected') scopeChannel?.disconnect();
-        return;
-      }
-      setScopeConnected(s === 'connected');
-    });
-    const unsubBinary = scopeChannel.onBinary((buf) => {
+    const unsubHardware = runtime.scope.subscribeHardware((frame) => {
       if (!scopeDemandOn) return;
-      markScopeFrame();
-      const frame = parseScopeFrame(buf);
-      if (!frame) return;
       if (frame.mode !== frameScopeMode) frameScopeMode = frame.mode;
       if (frame.startFreq !== startFreq || frame.endFreq !== endFreq) {
         startFreq = frame.startFreq;
@@ -374,8 +354,7 @@
     });
     acquireScopeDemand();
 
-    // DX spots come through the main control WebSocket as JSON messages
-    const unsubMsg = onMessage((msg) => {
+    const unsubDx = runtime.subscribeDx((msg) => {
       if (msg.type === 'dx_spot') {
         const spot = (msg as unknown as { spot: DxSpot }).spot;
         if (spot) dxSpots = [...dxSpots.slice(-49), spot];
@@ -386,11 +365,9 @@
     });
 
     return () => {
-      unsubState();
-      unsubBinary();
-      unsubMsg();
-      releaseScopeDemand(true);
-      scopeChannel = null;
+      unsubHardware();
+      unsubDx();
+      releaseScopeDemand();
     };
   });
 </script>

--- a/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
+++ b/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
@@ -97,45 +97,59 @@ Object.defineProperty(globalThis, 'localStorage', {
 // Module mocks
 // ---------------------------------------------------------------------------
 
-let capturedOnBinary: ((buf: ArrayBuffer) => void) | null = null;
-let capturedOnState: ((state: string) => void) | null = null;
-let mockScopeConnected = true;
-let mockScopeState = 'disconnected';
+type TestLease = Readonly<{ resource: 'hardware-scope'; sessionEpoch: string; id: number }>;
+type TestScopeFrame = Readonly<{
+  receiver: number;
+  mode: number;
+  startFreq: number;
+  endFreq: number;
+  pixels: Uint8Array;
+}>;
 
-const mockScopeChannel = {
-  get state() { return mockScopeState; },
-  connect: vi.fn(() => { mockScopeState = 'connecting'; }),
-  disconnect: vi.fn(() => { mockScopeState = 'disconnected'; }),
-  onStateChange: vi.fn((cb: (state: string) => void) => {
-    capturedOnState = cb;
-    return noop;
-  }),
-  onBinary: vi.fn((cb: (buf: ArrayBuffer) => void) => {
-    capturedOnBinary = cb;
-    return noop;
-  }),
-};
+const runtimeHarness = vi.hoisted(() => {
+  const state = {
+    capturedHardwareFrame: null as ((frame: TestScopeFrame) => void) | null,
+    mockScopeConnected: true,
+    mockTuneBy: 0,
+    nextLeaseId: 0,
+    hardwareUnsubscribe: vi.fn(),
+    dxUnsubscribe: vi.fn(),
+  };
+  const runtime = {
+    scope: {
+      get hardwareScopeConnected() { return state.mockScopeConnected; },
+      subscribeHardware: vi.fn((handler: (frame: TestScopeFrame) => void) => {
+        state.capturedHardwareFrame = handler;
+        return state.hardwareUnsubscribe;
+      }),
+    },
+    acquireHardwareScope: vi.fn(() => Object.freeze({
+      resource: 'hardware-scope' as const,
+      sessionEpoch: 'test',
+      id: ++state.nextLeaseId,
+    })),
+    releaseHardwareScope: vi.fn((_lease: TestLease) => true),
+    subscribeDx: vi.fn((_handler: (message: unknown) => void) => state.dxUnsubscribe),
+    send: vi.fn(),
+  };
+  return { state, runtime };
+});
 
-vi.mock('$lib/transport/ws-client', () => ({
-  getChannel: vi.fn(() => mockScopeChannel),
-  onMessage: vi.fn(() => noop),
-  sendCommand: vi.fn(),
-}));
+const mockRuntime = runtimeHarness.runtime;
 
-vi.mock('$lib/stores/connection.svelte', () => ({
-  setScopeConnected: vi.fn(),
-  markScopeFrame: vi.fn(),
-  isScopeConnected: vi.fn(() => mockScopeConnected),
+vi.mock('$lib/runtime/frontend-runtime', () => ({
+  runtime: runtimeHarness.runtime,
 }));
 
 vi.mock('$lib/stores/radio.svelte', () => ({
   radio: { current: null },
   patchActiveReceiver: vi.fn(),
+  patchReceiver: vi.fn(),
 }));
 
 vi.mock('$lib/stores/tuning.svelte', () => ({
   snapToStep: vi.fn((hz: number) => hz),
-  tuneBy: vi.fn(() => 0),
+  tuneBy: vi.fn(() => runtimeHarness.state.mockTuneBy),
   getTuningStep: vi.fn(() => 100),
   adjustTuningStep: vi.fn(),
   isAutoStep: vi.fn(() => true),
@@ -171,8 +185,6 @@ vi.mock('../../../../components-v2/wiring/state-adapter', () => ({
 // ---------------------------------------------------------------------------
 
 import SpectrumPanel from '../SpectrumPanel.svelte';
-import { getChannel, sendCommand } from '$lib/transport/ws-client';
-import { markScopeFrame, setScopeConnected } from '$lib/stores/connection.svelte';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -191,9 +203,12 @@ function mountPanel() {
 
 beforeEach(() => {
   components = [];
-  capturedOnState = null;
-  mockScopeConnected = true;
-  mockScopeState = 'disconnected';
+  runtimeHarness.state.capturedHardwareFrame = null;
+  runtimeHarness.state.mockScopeConnected = true;
+  runtimeHarness.state.mockTuneBy = 0;
+  runtimeHarness.state.nextLeaseId = 0;
+  runtimeHarness.state.hardwareUnsubscribe = vi.fn();
+  runtimeHarness.state.dxUnsubscribe = vi.fn();
   vi.clearAllMocks();
 });
 
@@ -241,17 +256,18 @@ describe('SpectrumPanel component', () => {
     expect(labels).toEqual(['0', '-20', '-40', '-60']);
   });
 
-  it('connects scope WebSocket channel on mount', () => {
+  it('acquires one runtime hardware-scope lease and lifetime-neutral subscriptions on mount', () => {
     mountPanel();
-    expect(getChannel).toHaveBeenCalledWith('scope');
-    expect(mockScopeChannel.connect).toHaveBeenCalledWith('/api/v1/scope');
-    expect(mockScopeChannel.onBinary).toHaveBeenCalled();
-    expect(mockScopeChannel.onStateChange).toHaveBeenCalled();
+    expect(mockRuntime.acquireHardwareScope).toHaveBeenCalledTimes(1);
+    expect(mockRuntime.acquireHardwareScope).toHaveBeenCalledWith('SpectrumPanel');
+    expect(mockRuntime.scope.subscribeHardware).toHaveBeenCalledTimes(1);
+    expect(mockRuntime.subscribeDx).toHaveBeenCalledTimes(1);
   });
 
-  it('releases and reacquires viewer demand through the existing scope channel', () => {
+  it('releases the exact lease on OFF and acquires a fresh lease on ON', () => {
     const target = mountPanel();
     const toggle = target.querySelector<HTMLButtonElement>('.scope-demand-toggle')!;
+    const firstLease = mockRuntime.acquireHardwareScope.mock.results[0].value;
 
     expect(toggle).not.toBeNull();
     expect(toggle.getAttribute('aria-pressed')).toBe('true');
@@ -259,67 +275,51 @@ describe('SpectrumPanel component', () => {
     toggle.click();
     flushSync();
     expect(toggle.getAttribute('aria-pressed')).toBe('false');
-    expect(mockScopeChannel.disconnect).toHaveBeenCalledTimes(1);
-    expect(setScopeConnected).toHaveBeenLastCalledWith(false);
+    expect(mockRuntime.releaseHardwareScope).toHaveBeenCalledTimes(1);
+    expect(mockRuntime.releaseHardwareScope).toHaveBeenLastCalledWith(firstLease);
 
     toggle.click();
     flushSync();
     expect(toggle.getAttribute('aria-pressed')).toBe('true');
-    expect(getChannel).toHaveBeenCalledTimes(1);
-    expect(mockScopeChannel.connect).toHaveBeenCalledTimes(2);
-    expect(mockScopeChannel.connect).toHaveBeenLastCalledWith('/api/v1/scope');
-  });
-
-  it('rejects frames and immediately closes an externally resurrected channel while OFF', () => {
-    const target = mountPanel();
-    target.querySelector<HTMLButtonElement>('.scope-demand-toggle')!.click();
-    flushSync();
-
-    capturedOnBinary?.(new ArrayBuffer(16));
-    expect(markScopeFrame).not.toHaveBeenCalled();
-
-    mockScopeState = 'connected';
-    capturedOnState?.('connected');
-    expect(mockScopeChannel.connect).toHaveBeenCalledTimes(1);
-    expect(mockScopeChannel.disconnect).toHaveBeenCalledTimes(2);
-    expect(setScopeConnected).toHaveBeenLastCalledWith(false);
+    expect(mockRuntime.acquireHardwareScope).toHaveBeenCalledTimes(2);
+    const currentLease = mockRuntime.acquireHardwareScope.mock.results[1].value;
+    expect(currentLease).not.toBe(firstLease);
 
     const component = components.pop()!;
     unmount(component);
-    expect(mockScopeChannel.disconnect).toHaveBeenCalledTimes(2);
+    expect(mockRuntime.releaseHardwareScope).toHaveBeenCalledTimes(2);
+    expect(mockRuntime.releaseHardwareScope).toHaveBeenLastCalledWith(currentLease);
+    expect(runtimeHarness.state.hardwareUnsubscribe).toHaveBeenCalledTimes(1);
+    expect(runtimeHarness.state.dxUnsubscribe).toHaveBeenCalledTimes(1);
   });
 
-  it('closes a resurrected live channel during teardown even without a state notification', () => {
-    const target = mountPanel();
-    target.querySelector<HTMLButtonElement>('.scope-demand-toggle')!.click();
-    flushSync();
-    expect(mockScopeChannel.disconnect).toHaveBeenCalledTimes(1);
-
-    mockScopeState = 'connected';
-    const component = components.pop()!;
-    unmount(component);
-    expect(mockScopeChannel.disconnect).toHaveBeenCalledTimes(2);
-  });
-
-  it('keeps demand intent ON across channel disconnect and reconnect health changes', () => {
+  it('keeps OFF intent inert across runtime health, teardown, and remount', () => {
     const target = mountPanel();
     const toggle = target.querySelector<HTMLButtonElement>('.scope-demand-toggle')!;
+    const releasedLease = mockRuntime.acquireHardwareScope.mock.results[0].value;
 
-    mockScopeState = 'disconnected';
-    capturedOnState?.('disconnected');
-    mockScopeState = 'connected';
-    capturedOnState?.('connected');
+    toggle.click();
+    runtimeHarness.state.mockScopeConnected = false;
+    runtimeHarness.state.mockScopeConnected = true;
     flushSync();
 
-    expect(toggle.getAttribute('aria-pressed')).toBe('true');
-    expect(mockScopeChannel.connect).toHaveBeenCalledTimes(1);
-    expect(mockScopeChannel.disconnect).not.toHaveBeenCalled();
-    expect(setScopeConnected).toHaveBeenNthCalledWith(1, false);
-    expect(setScopeConnected).toHaveBeenNthCalledWith(2, true);
+    expect(toggle.getAttribute('aria-pressed')).toBe('false');
+    expect(mockRuntime.acquireHardwareScope).toHaveBeenCalledTimes(1);
+    expect(mockRuntime.releaseHardwareScope).toHaveBeenCalledTimes(1);
+
+    unmount(components.pop()!);
+    expect(mockRuntime.releaseHardwareScope).toHaveBeenCalledTimes(1);
+    expect(mockRuntime.releaseHardwareScope).toHaveBeenLastCalledWith(releasedLease);
+
+    mountPanel();
+    const remountLease = mockRuntime.acquireHardwareScope.mock.results[1].value;
+    expect(remountLease).not.toBe(releasedLease);
+    unmount(components.pop()!);
+    expect(mockRuntime.releaseHardwareScope).toHaveBeenNthCalledWith(2, remountLease);
   });
 
   it('renders demand ON without claiming an inactive channel is live', () => {
-    mockScopeConnected = false;
+    runtimeHarness.state.mockScopeConnected = false;
     const target = mountPanel();
 
     expect(
@@ -348,8 +348,8 @@ describe('SpectrumPanel component', () => {
     target.remove();
   });
 
-  it('wheel event on panel triggers tuning command', async () => {
-    const { sendCommand } = await import('$lib/transport/ws-client');
+  it('wheel event routes tuning command through runtime.send', () => {
+    runtimeHarness.state.mockTuneBy = 14_074_000;
     const target = mountPanel();
     const panel = target.querySelector('.spectrum-panel')!;
     const wheelEvent = new WheelEvent('wheel', {
@@ -358,34 +358,22 @@ describe('SpectrumPanel component', () => {
       cancelable: true,
     });
     panel.dispatchEvent(wheelEvent);
-    // Wheel handler should send a tuning command via sendCommand
-    // (may not fire if no freq data — just verify no crash)
-    expect(panel).toBeTruthy();
+    expect(mockRuntime.send).toHaveBeenCalledWith('set_freq', {
+      freq: 14_074_000,
+      receiver: 0,
+    });
   });
 
-  it('renders freq-axis after receiving binary scope frame', () => {
+  it('renders freq-axis after receiving a runtime hardware scope frame', () => {
     const target = mountPanel();
-    // Build a minimal scope frame header (16 bytes) + 475 pixels
-    // Header: seq(1) + id(1) + startFreq(4, LE) + endFreq(4, LE) + flags(6)
-    const headerSize = 16;
-    const pixelCount = 475;
-    const buf = new ArrayBuffer(headerSize + pixelCount);
-    const view = new DataView(buf);
-    view.setUint8(0, 1);  // seq = 1 (single-packet frame)
-    view.setUint8(1, 0);  // id
-    view.setUint32(2, 14_000_000, true);  // startFreq LE
-    view.setUint32(6, 14_350_000, true);  // endFreq LE
-    // Fill pixels with mid-level data
-    const pixels = new Uint8Array(buf, headerSize);
-    pixels.fill(64);
-
-    // Deliver frame via captured binary handler
-    if (capturedOnBinary) {
-      capturedOnBinary(buf);
-      flushSync();
-    }
-    // After a frame with valid span, the component should update
-    // (exact DOM depends on rAF scheduling — verify no crash at minimum)
-    expect(target.querySelector('.spectrum-panel')).not.toBeNull();
+    runtimeHarness.state.capturedHardwareFrame?.({
+      receiver: 0,
+      mode: 1,
+      startFreq: 14_000_000,
+      endFreq: 14_350_000,
+      pixels: new Uint8Array(475).fill(64),
+    });
+    flushSync();
+    expect(target.querySelector('.freq-axis')).not.toBeNull();
   });
 });

--- a/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
+++ b/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
@@ -192,6 +192,7 @@ import SpectrumPanel from '../SpectrumPanel.svelte';
 import spectrumPanelSource from '../SpectrumPanel.svelte?raw';
 import {
   deriveScopeIndicatorState,
+  indicatorTone,
 } from '../../../components-v2/layout/StatusBar.svelte';
 import statusBarSource from '../../../components-v2/layout/StatusBar.svelte?raw';
 
@@ -341,6 +342,20 @@ describe('SpectrumPanel component', () => {
     expect(target.querySelector('.scope-demand-off-overlay')).toBeNull();
   });
 
+  it('ignores shared runtime frames while VIEW is OFF', () => {
+    const target = mountPanel();
+    target.querySelector<HTMLButtonElement>('.scope-demand-toggle')!.click();
+    runtimeHarness.state.capturedHardwareFrame?.({
+      receiver: 0,
+      mode: 1,
+      startFreq: 14_000_000,
+      endFreq: 14_350_000,
+      pixels: new Uint8Array(475).fill(64),
+    });
+    flushSync();
+    expect(target.querySelector('.freq-axis')).toBeNull();
+  });
+
   it('does not render freq-axis when no span data', () => {
     const target = mountPanel();
     // Without scope frames, spanHz = 0, so freq-axis is not rendered
@@ -447,6 +462,7 @@ describe('StatusBar default scope status consumption', () => {
 
   it.each([
     ['power-off override', scopeStatus(), true, 'disconnected'],
+    ['power-off precedes inactive facts', scopeStatus({ source: null, demand: 0 }), true, 'disconnected'],
     ['no default source', scopeStatus({ source: null }), false, 'inactive'],
     ['unavailable default', scopeStatus({ available: false }), false, 'inactive'],
     ['unselected resource', scopeStatus({ resourceSelected: false }), false, 'inactive'],
@@ -459,8 +475,21 @@ describe('StatusBar default scope status consumption', () => {
     ['disconnected transport under demand', scopeStatus({ transport: 'disconnected', frameSeen: false }), false, 'disconnected'],
     ['healthy hardware default', scopeStatus(), false, 'connected'],
     ['healthy audio default uses identical facts', scopeStatus({ source: 'audio_fft' }), false, 'connected'],
-    ['streaming host alone is not green', scopeStatus({ transport: 'connecting', frameSeen: false }), false, 'connecting'],
+    ['non-streaming lifecycle is not green', scopeStatus({ lifecycle: 'inactive' }), false, 'inactive'],
   ] as const)('%s maps to %s', (_label, status, poweredOff, expected) => {
     expect(deriveScopeIndicatorState(status, poweredOff)).toBe(expected);
+  });
+
+  it.each([
+    ['inactive', 'neutral'],
+    ['starting', 'yellow'],
+    ['connecting', 'yellow'],
+    ['waiting', 'yellow'],
+    ['reconnecting', 'yellow'],
+    ['failed', 'red'],
+    ['disconnected', 'red'],
+    ['connected', 'green'],
+  ] as const)('%s uses the %s tone', (state, expected) => {
+    expect(indicatorTone(state)).toBe(expected);
   });
 });

--- a/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
+++ b/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
@@ -109,6 +109,7 @@ type TestScopeFrame = Readonly<{
 const runtimeHarness = vi.hoisted(() => {
   const state = {
     capturedHardwareFrame: null as ((frame: TestScopeFrame) => void) | null,
+    capturedDxMessage: null as ((message: unknown) => void) | null,
     mockScopeConnected: true,
     mockTuneBy: 0,
     nextLeaseId: 0,
@@ -129,7 +130,10 @@ const runtimeHarness = vi.hoisted(() => {
       id: ++state.nextLeaseId,
     })),
     releaseHardwareScope: vi.fn((_lease: TestLease) => true),
-    subscribeDx: vi.fn((_handler: (message: unknown) => void) => state.dxUnsubscribe),
+    subscribeDx: vi.fn((handler: (message: unknown) => void) => {
+      state.capturedDxMessage = handler;
+      return state.dxUnsubscribe;
+    }),
     send: vi.fn(),
   };
   return { state, runtime };
@@ -185,6 +189,11 @@ vi.mock('../../../../components-v2/wiring/state-adapter', () => ({
 // ---------------------------------------------------------------------------
 
 import SpectrumPanel from '../SpectrumPanel.svelte';
+import spectrumPanelSource from '../SpectrumPanel.svelte?raw';
+import {
+  deriveScopeIndicatorState,
+} from '../../../components-v2/layout/StatusBar.svelte';
+import statusBarSource from '../../../components-v2/layout/StatusBar.svelte?raw';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -204,6 +213,7 @@ function mountPanel() {
 beforeEach(() => {
   components = [];
   runtimeHarness.state.capturedHardwareFrame = null;
+  runtimeHarness.state.capturedDxMessage = null;
   runtimeHarness.state.mockScopeConnected = true;
   runtimeHarness.state.mockTuneBy = 0;
   runtimeHarness.state.nextLeaseId = 0;
@@ -271,10 +281,12 @@ describe('SpectrumPanel component', () => {
 
     expect(toggle).not.toBeNull();
     expect(toggle.getAttribute('aria-pressed')).toBe('true');
+    expect(toggle.textContent).toContain('VIEW ON');
 
     toggle.click();
     flushSync();
     expect(toggle.getAttribute('aria-pressed')).toBe('false');
+    expect(toggle.textContent).toContain('VIEW OFF');
     expect(mockRuntime.releaseHardwareScope).toHaveBeenCalledTimes(1);
     expect(mockRuntime.releaseHardwareScope).toHaveBeenLastCalledWith(firstLease);
 
@@ -364,7 +376,7 @@ describe('SpectrumPanel component', () => {
     });
   });
 
-  it('renders freq-axis after receiving a runtime hardware scope frame', () => {
+  it('renders runtime hardware frames and DX spots', () => {
     const target = mountPanel();
     runtimeHarness.state.capturedHardwareFrame?.({
       receiver: 0,
@@ -375,5 +387,80 @@ describe('SpectrumPanel component', () => {
     });
     flushSync();
     expect(target.querySelector('.freq-axis')).not.toBeNull();
+
+    runtimeHarness.state.capturedDxMessage?.({
+      type: 'dx_spot',
+      spot: {
+        spotter: 'N0CALL',
+        freq: 14_175_000,
+        call: 'K1ABC',
+        comment: 'test',
+        time_utc: '1200',
+        timestamp: 1,
+      },
+    });
+    flushSync();
+    expect(target.querySelector('.dx-badge')?.textContent).toContain('K1ABC');
+  });
+
+  it('keeps all scope transport and health authority behind the runtime facade', () => {
+    for (const legacyAuthority of [
+      'getChannel',
+      'onMessage',
+      'sendCommand',
+      'setScopeConnected',
+      'markScopeFrame',
+    ]) {
+      expect(spectrumPanelSource).not.toContain(legacyAuthority);
+    }
+    expect(spectrumPanelSource).toContain('runtime.acquireHardwareScope');
+    expect(spectrumPanelSource).toContain('runtime.scope.subscribeHardware');
+    expect(spectrumPanelSource).toContain('runtime.subscribeDx');
+    expect(spectrumPanelSource).toContain('runtime.send');
+  });
+});
+
+type ScopeStatusProbe = Parameters<typeof deriveScopeIndicatorState>[0];
+
+function scopeStatus(
+  overrides: Partial<ScopeStatusProbe> = {},
+): ScopeStatusProbe {
+  return {
+    source: 'hardware',
+    available: true,
+    resourceSelected: true,
+    demand: 1,
+    lifecycle: 'streaming',
+    transport: 'connected',
+    frameSeen: true,
+    ...overrides,
+  };
+}
+
+describe('StatusBar default scope status consumption', () => {
+  it('uses only the canonical runtime default and removes the legacy reader', () => {
+    expect(statusBarSource).toContain('runtime.defaultScopeStatus');
+    expect(statusBarSource).not.toContain('isScopeConnected');
+    expect(statusBarSource).not.toContain('hardwareScopeConnected');
+    expect(statusBarSource).not.toContain('audioScopeFrame');
+  });
+
+  it.each([
+    ['power-off override', scopeStatus(), true, 'disconnected'],
+    ['no default source', scopeStatus({ source: null }), false, 'inactive'],
+    ['unavailable default', scopeStatus({ available: false }), false, 'inactive'],
+    ['unselected resource', scopeStatus({ resourceSelected: false }), false, 'inactive'],
+    ['zero demand', scopeStatus({ demand: 0 }), false, 'inactive'],
+    ['starting host', scopeStatus({ lifecycle: 'starting', transport: 'disconnected', frameSeen: false }), false, 'starting'],
+    ['connecting transport', scopeStatus({ transport: 'connecting', frameSeen: false }), false, 'connecting'],
+    ['reconnecting transport', scopeStatus({ transport: 'reconnecting', frameSeen: false }), false, 'reconnecting'],
+    ['waiting for current frame', scopeStatus({ frameSeen: false }), false, 'waiting'],
+    ['failed host under demand', scopeStatus({ lifecycle: 'failed' }), false, 'failed'],
+    ['disconnected transport under demand', scopeStatus({ transport: 'disconnected', frameSeen: false }), false, 'disconnected'],
+    ['healthy hardware default', scopeStatus(), false, 'connected'],
+    ['healthy audio default uses identical facts', scopeStatus({ source: 'audio_fft' }), false, 'connected'],
+    ['streaming host alone is not green', scopeStatus({ transport: 'connecting', frameSeen: false }), false, 'connecting'],
+  ] as const)('%s maps to %s', (_label, status, poweredOff, expected) => {
+    expect(deriveScopeIndicatorState(status, poweredOff)).toBe(expected);
   });
 });


### PR DESCRIPTION
## Summary

- update the existing `SpectrumPanel` cutover onto current `main` and retain App-owned `hardware-scope` demand
- acquire one opaque lease for VIEW ON, clear its identity before exact OFF/final release, and require a fresh lease for later ON
- keep hardware frame and DX subscriptions lifetime-neutral and route panel commands through `runtime.send`
- cut `StatusBar` from the legacy `isScopeConnected` reader to the canonical `runtime.defaultScopeStatus`
- preserve toolbar behavior, VIEW ON/OFF accessibility, rendering, tuning, overlays, labels, and unrelated status indicators

## Default scope indicator policy

- neutral/inactive when there is no default source, the source is unavailable, its resource is not selected, or demand is zero
- yellow for starting, connecting, reconnecting, or connected while waiting for a current-interval frame
- red only for failed/disconnected under demand, plus the existing explicit radio power-off override
- green only when demand is positive, lifecycle is `streaming`, transport is `connected`, and `frameSeen` is true
- the same facts apply to hardware and audio defaults; the StatusBar does not inspect supplemental channels or apply fallback policy

## Scope

- exact head: `037fb10205ae09fa5785d9cd45e1bd9c7ca1e805`
- current base: `320b2899a1ba2dc00a4b1dbd2d6a4b44584e897e`
- exactly 3 files, +294/-161, net +133 LOC against current `main`

## Verification

- RED: the expanded focused file produced 15 failures / 15 passes against the legacy StatusBar reader seam
- PASS: focused SpectrumPanel/StatusBar tests — 40/40
- PASS: focused FrontendRuntime, ScopeController, resource, presentation-capability, and MOR-1145 fixture tests — 107/107
- PASS: full frontend with `NODE_OPTIONS=--no-experimental-webstorage` — 134 files, 2416 tests
- PASS: `npm run check`
- PASS: `npm run lint`
- PASS: `npm run lint:boundaries`
- PASS: `npm run i18n:check`
- PASS: `npm run build`
- PASS: `uv run ruff check src/ tests/`
- PASS: `uv run ruff format --check src/ tests/` — 627 files already formatted
- PASS: `uv run lint-imports` — 5 contracts kept
- PASS: static scans show no legacy direct scope authority in `SpectrumPanel` and no legacy/source-specific scope reader in `StatusBar`
- PASS: bounded mutation probes P1, P2b, P10, and P11 are killed by the focused suite; the folded P5 OFF-frame guard probe is also killed

### Local Python environment note

On parent head `cd599655bc01ded90206cb6f9efd142813228638`, the first local full Python run failed only at `tests/smoke/test_audio_path_smoke.py::test_session_lifecycle_via_bridge_and_web_tx_lease` because this Mac did not expose Homebrew's native Opus library to `opuslib`. Read-only diagnosis reproduced the same deterministic failure on clean current `main` and this branch, before any frontend/static asset boundary. With the installed library exposed only for verification via `DYLD_LIBRARY_PATH=/opt/homebrew/lib`:

- the exact smoke test passed 1/1
- the full Python suite passed: 8726 passed, 64 skipped, 5 deselected, 11 xfailed, 1 xpassed

No Python file, repository configuration, or environment configuration changed in this follow-up. Exact-head `quick` and `grep-gate` checks passed; the review-gate status remains expectedly pending a fresh independent verdict.

No hardware probes were run and no physical-active or hardware-acceptance evidence is claimed. This PR intentionally remains Draft pending fresh independent exact-head review.

Closes #2040
Linear: https://linear.app/morozsm/issue/MOR-1139
