### PR TITLE
MOR-1141: expose source-qualified scope health facts

### DIFF
--- a/frontend/src/lib/runtime/__tests__/scope-controller.test.ts
+++ b/frontend/src/lib/runtime/__tests__/scope-controller.test.ts
@@ -99,6 +99,74 @@ describe('ScopeController', () => {
     expect(host.release(shared)).toBe(false);
   });
 
+  it('registers audio FFT once per host without overwriting central config', () => {
+    const host = new PresentationResourceHost<unknown>('session');
+    const configure = vi.spyOn(host, 'configure');
+
+    ctrl.registerPresentationDriver(host, { available: false, selected: false });
+    ctrl.registerPresentationDriver(host);
+
+    expect(configure).toHaveBeenCalledTimes(1);
+    expect(host.snapshot('audio-fft')).toMatchObject({ available: false, selected: false });
+    host.acquire('audio-fft', 'panel');
+    expect(channel.connect).not.toHaveBeenCalled();
+  });
+
+  it('publishes immutable audio health for the observed connected interval', async () => {
+    const listener = vi.fn();
+    const unsubscribe = ctrl.subscribeHealth(listener);
+    expect(ctrl.snapshotHealth('audio_fft')).toEqual({
+      demanded: false, transport: 'disconnected', frameSeen: false,
+    });
+    expect(Object.isFrozen(ctrl.snapshotHealth('audio_fft'))).toBe(true);
+
+    const handle = await ctrl.audioFftDriver.start();
+    expect(ctrl.snapshotHealth('audio_fft')).toEqual({
+      demanded: true, transport: 'disconnected', frameSeen: false,
+    });
+    for (const state of ['connecting', 'reconnecting', 'disconnected'] as const) {
+      channel._setState(state);
+      channel._fire(makeScopeFrameBuffer());
+      expect(ctrl.snapshotHealth('audio_fft')).toEqual({
+        demanded: true, transport: state, frameSeen: false,
+      });
+    }
+    channel._setState('connected');
+    channel._fire(makeScopeFrameBuffer());
+    expect(ctrl.snapshotHealth('audio_fft')).toEqual({
+      demanded: true, transport: 'connected', frameSeen: true,
+    });
+    channel._setState('reconnecting');
+    expect(ctrl.snapshotHealth('audio_fft').frameSeen).toBe(false);
+
+    unsubscribe();
+    unsubscribe();
+    const calls = listener.mock.calls.length;
+    await ctrl.audioFftDriver.stop(handle);
+    expect(ctrl.snapshotHealth('audio_fft')).toEqual({
+      demanded: false, transport: 'disconnected', frameSeen: false,
+    });
+    expect(listener).toHaveBeenCalledTimes(calls);
+    expect(channel._handlerCount()).toBe(0);
+    expect(channel._stateHandlerCount()).toBe(0);
+  });
+
+  it('keeps repeated health subscriptions exact and independently removable', async () => {
+    const listener = vi.fn();
+    const first = ctrl.subscribeHealth(listener);
+    const second = ctrl.subscribeHealth(listener);
+    const handle = await ctrl.audioFftDriver.start();
+    expect(listener).toHaveBeenCalledTimes(2);
+    first();
+    first();
+    channel._setState('connecting');
+    expect(listener).toHaveBeenCalledTimes(3);
+    second();
+    channel._setState('connected');
+    expect(listener).toHaveBeenCalledTimes(3);
+    await ctrl.audioFftDriver.stop(handle);
+  });
+
   it('both subscribers receive parsed frames', async () => {
     const h1 = vi.fn<(frame: ScopeFrame) => void>();
     const h2 = vi.fn<(frame: ScopeFrame) => void>();
@@ -106,6 +174,7 @@ describe('ScopeController', () => {
     ctrl.subscribe(h1);
     ctrl.subscribe(h2);
     await ctrl.audioFftDriver.start();
+    channel._setState('connected');
 
     channel._fire(makeScopeFrameBuffer());
 
@@ -124,6 +193,7 @@ describe('ScopeController', () => {
     const unsub1 = ctrl.subscribe(h1);
     ctrl.subscribe(h2);
     await ctrl.audioFftDriver.start();
+    channel._setState('connected');
 
     unsub1();
     channel._fire(makeScopeFrameBuffer());
@@ -137,6 +207,7 @@ describe('ScopeController', () => {
     const first = ctrl.subscribe(handler);
     const second = ctrl.subscribe(handler);
     const handle = await ctrl.audioFftDriver.start();
+    channel._setState('connected');
     first();
     channel._fire(makeScopeFrameBuffer());
     expect(handler).toHaveBeenCalledTimes(1);
@@ -150,6 +221,7 @@ describe('ScopeController', () => {
     const handler = vi.fn();
     ctrl.subscribe(handler);
     await ctrl.audioFftDriver.start();
+    channel._setState('connected');
 
     // Bad magic — parseScopeFrame returns null
     const bad = new ArrayBuffer(20);
@@ -198,6 +270,7 @@ describe('ScopeController', () => {
     await vi.waitFor(() => expect(host.snapshot('audio-fft').health).toBe('streaming'));
 
     expect(channel._handlerCount()).toBe(1);
+    channel._setState('connected');
     channel._fire(makeScopeFrameBuffer());
     expect(subscriber).toHaveBeenCalledTimes(1);
     host.release(remount);
@@ -269,6 +342,10 @@ describe('ScopeController', () => {
       controller.hardwareScopeConnected,
       controller.hardwareScopeFrameLive,
     ]).toEqual([true, false, false]);
+    channels.scope._fire(makeScopeFrameBuffer());
+    expect(controller.snapshotHealth('hardware')).toEqual({
+      demanded: true, transport: 'disconnected', frameSeen: false,
+    });
 
     channels.scope._setState('connected');
     expect(controller.hardwareScopeConnected).toBe(true);
@@ -354,5 +431,45 @@ describe('ScopeController', () => {
     expect(controller.hardwareScopeConnected).toBe(true);
     expect(controller.hardwareScopeFrameLive).toBe(false);
     await controller.hardwareScopeDriver.stop(current);
+  });
+
+  it('qualifies audio callbacks and cleanup across A to B to A handles', async () => {
+    const audio = makeMockChannel();
+    const controller = new ScopeController(() => audio as any);
+    const subscriber = vi.fn();
+    controller.subscribe(subscriber);
+    const firstA = await controller.audioFftDriver.start();
+    const b = await controller.audioFftDriver.start();
+    const currentA = await controller.audioFftDriver.start();
+    const [staleAFrame, staleBFrame, currentFrame] = audio._binaryHistory;
+    const [staleAState, staleBState, currentState] = audio._stateHistory;
+
+    await controller.audioFftDriver.stop(firstA);
+    await controller.audioFftDriver.dispose?.(b);
+    staleAState('connected');
+    staleBState('connected');
+    staleAFrame(makeScopeFrameBuffer());
+    staleBFrame(makeScopeFrameBuffer());
+    expect(controller.snapshotHealth('audio_fft')).toEqual({
+      demanded: true, transport: 'disconnected', frameSeen: false,
+    });
+    expect(subscriber).not.toHaveBeenCalled();
+
+    currentFrame(makeScopeFrameBuffer());
+    expect(subscriber).not.toHaveBeenCalled();
+    currentState('connected');
+    currentFrame(makeScopeFrameBuffer());
+    expect(controller.snapshotHealth('audio_fft').frameSeen).toBe(true);
+    currentState('reconnecting');
+    staleAState('connected');
+    staleAFrame(makeScopeFrameBuffer());
+    expect(controller.snapshotHealth('audio_fft')).toEqual({
+      demanded: true, transport: 'reconnecting', frameSeen: false,
+    });
+    await controller.audioFftDriver.stop(currentA);
+    expect(controller.snapshotHealth('audio_fft')).toEqual({
+      demanded: false, transport: 'disconnected', frameSeen: false,
+    });
+    expect(audio.disconnect).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/lib/runtime/scope-controller.svelte.ts
+++ b/frontend/src/lib/runtime/scope-controller.svelte.ts
@@ -15,6 +15,7 @@
 import { getChannel } from '$lib/transport/ws-client';
 import { markScopeFrame } from '$lib/stores/connection.svelte';
 import { parseScopeFrame } from '$lib/runtime/adapters/scope-adapter';
+import { untrack } from 'svelte';
 import type { ScopeFrame } from '$lib/runtime/adapters/scope-adapter';
 import type { ConnectionState, WsChannel } from '$lib/transport/ws-client';
 import type { PresentationResourceDriver, PresentationResourceHost } from './resource-host';
@@ -23,10 +24,16 @@ export type { ScopeFrame };
 
 type FrameHandler = (frame: ScopeFrame) => void;
 type ChannelFactory = (name: string) => WsChannel;
+export type ScopeSource = 'hardware' | 'audio_fft';
+export type ScopeHealth = Readonly<{
+  demanded: boolean; transport: ConnectionState; frameSeen: boolean;
+}>;
+type HealthHandler = (source: ScopeSource, health: ScopeHealth) => void;
 type AudioFftHandle = Readonly<{ token: symbol }>;
-type ChannelBinding = { channel: WsChannel; unsubscribe: () => void };
+type ChannelBinding = {
+  channel: WsChannel; unsubscribeBinary: () => void; unsubscribeState: () => void;
+};
 type HardwareHandle = Readonly<{ generation: number }>;
-type HardwareBinding = { channel: WsChannel; unsubscribeBinary: () => void; unsubscribeState: () => void };
 
 export class ScopeController {
   /** Latest parsed audio-scope frame (Svelte 5 reactive). */
@@ -37,18 +44,24 @@ export class ScopeController {
   readonly audioScopeAvailable = true;
   readonly activeScope: 'hardware' | 'audio-fft' | null = 'audio-fft';
   scopeFrame: ScopeFrame | null = $state(null);
-  hardwareScopeDemanded = $state(false);
-  hardwareScopeConnected = $state(false);
-  hardwareScopeFrameLive = $state(false);
+  get hardwareScopeDemanded() { return this._health.hardware.demanded; }
+  get hardwareScopeConnected() { return this._health.hardware.transport === 'connected'; }
+  get hardwareScopeFrameLive() { return this._health.hardware.frameSeen; }
 
   private _subscribers = new Map<number, FrameHandler>();
   private _hardwareSubscribers = new Map<number, FrameHandler>();
+  private _healthSubscribers = new Map<number, HealthHandler>();
   private _nextId = 0;
   private _bindings = new Map<AudioFftHandle, ChannelBinding>();
   private _activeHandle: AudioFftHandle | null = null;
-  private _hardwareBindings = new Map<HardwareHandle, HardwareBinding>();
+  private _hardwareBindings = new Map<HardwareHandle, ChannelBinding>();
   private _activeHardwareHandle: HardwareHandle | null = null;
   private _hardwareGeneration = 0;
+  private _registeredHosts = new WeakSet<object>();
+  private _health: Record<ScopeSource, ScopeHealth> = $state({
+    hardware: { demanded: false, transport: 'disconnected', frameSeen: false },
+    audio_fft: { demanded: false, transport: 'disconnected', frameSeen: false },
+  });
   private _getChannel: ChannelFactory;
   readonly audioFftDriver: PresentationResourceDriver<unknown> = {
     start: () => this._connect(),
@@ -82,10 +95,26 @@ export class ScopeController {
     return () => { this._hardwareSubscribers.delete(id); };
   }
 
-  registerPresentationDriver(host: Pick<PresentationResourceHost<unknown>, 'configure'>): void {
+  snapshotHealth(source: ScopeSource): ScopeHealth {
+    return Object.freeze({ ...this._readHealth(source) });
+  }
+
+  subscribeHealth(handler: HealthHandler): () => void {
+    const id = this._nextId++; this._healthSubscribers.set(id, handler);
+    return () => { this._healthSubscribers.delete(id); };
+  }
+
+  registerPresentationDriver(
+    host: Pick<PresentationResourceHost<unknown>, 'configure'>,
+    initialConfig?: { available: boolean; selected: boolean },
+  ): void {
+    if (this._registeredHosts.has(host)) return;
+    this._registeredHosts.add(host);
     host.configure('audio-fft', {
-      available: this.audioScopeAvailable,
-      selected: this.activeScope === 'audio-fft',
+      ...(initialConfig ?? {
+        available: this.audioScopeAvailable,
+        selected: this.activeScope === 'audio-fft',
+      }),
       driver: this.audioFftDriver,
     });
   }
@@ -93,23 +122,45 @@ export class ScopeController {
   private _connect(): AudioFftHandle {
     const ch = this._getChannel('audio-scope');
     const handle = Object.freeze({ token: Symbol('audio-fft') });
+    let unsubscribeBinary = () => {}, unsubscribeState = () => {};
+    this._activeHandle = handle;
+    this.audioScopeFrame = null;
+    this._setHealth('audio_fft', {
+      demanded: true, transport: ch.state, frameSeen: false,
+    });
     try {
-      ch.connect('/api/v1/audio-scope');
-      const unsubscribe = ch.onBinary((buf: ArrayBuffer) => {
+      unsubscribeState = ch.onStateChange((state) => {
         if (this._activeHandle !== handle) return;
-        markScopeFrame();
+        if (state !== 'connected') this.audioScopeFrame = null;
+        this._setHealth('audio_fft', {
+          demanded: true, transport: state,
+          frameSeen: state === 'connected' && this._readHealth('audio_fft').frameSeen,
+        });
+      });
+      unsubscribeBinary = ch.onBinary((buf: ArrayBuffer) => {
+        if (this._activeHandle !== handle || this._readHealth('audio_fft').transport !== 'connected') return;
         const frame = parseScopeFrame(buf);
         if (frame) {
+          markScopeFrame();
           this.audioScopeFrame = frame;
+          this._setHealth('audio_fft', { ...this._readHealth('audio_fft'), frameSeen: true });
           for (const h of this._subscribers.values()) {
             h(frame);
           }
         }
       });
-      this._bindings.set(handle, { channel: ch, unsubscribe });
-      this._activeHandle = handle;
+      this._bindings.set(handle, { channel: ch, unsubscribeBinary, unsubscribeState });
+      ch.connect('/api/v1/audio-scope');
       return handle;
     } catch (error) {
+      this._bindings.delete(handle);
+      try { unsubscribeBinary(); } finally { unsubscribeState(); }
+      if (this._activeHandle === handle) {
+        this._activeHandle = null;
+        this._setHealth('audio_fft', {
+          demanded: false, transport: 'disconnected', frameSeen: false,
+        });
+      }
       if (![...this._bindings.values()].some((binding) => binding.channel === ch)) {
         ch.disconnect();
       }
@@ -124,16 +175,20 @@ export class ScopeController {
     const shared = [...this._bindings.values()].some(
       (candidate) => candidate.channel === binding.channel,
     );
+    if (this._activeHandle === handle) {
+      this._activeHandle = null;
+      this.audioScopeFrame = null;
+      this._setHealth('audio_fft', {
+        demanded: false, transport: 'disconnected', frameSeen: false,
+      });
+    }
     try {
-      binding.unsubscribe();
+      binding.unsubscribeBinary();
     } finally {
       try {
-        if (!shared) binding.channel.disconnect();
+        binding.unsubscribeState();
       } finally {
-        if (this._activeHandle === handle) {
-          this._activeHandle = null;
-          this.audioScopeFrame = null;
-        }
+        if (!shared) binding.channel.disconnect();
       }
     }
   }
@@ -142,38 +197,48 @@ export class ScopeController {
     const channel = this._getChannel('scope');
     const handle = Object.freeze({ generation: ++this._hardwareGeneration });
     let unsubscribeBinary = () => {}, unsubscribeState = () => {};
+    this._activeHardwareHandle = handle;
+    this.scopeFrame = null;
+    this._setHealth('hardware', {
+      demanded: true, transport: channel.state, frameSeen: false,
+    });
     try {
       unsubscribeBinary = channel.onBinary((buf) => {
-        if (this._activeHardwareHandle !== handle) return;
+        if (
+          this._activeHardwareHandle !== handle
+          || this._readHealth('hardware').transport !== 'connected'
+        ) return;
         const frame = parseScopeFrame(buf);
         if (!frame) return;
         markScopeFrame();
         this.scopeFrame = frame;
-        this.hardwareScopeFrameLive = true;
+        this._setHealth('hardware', { ...this._readHealth('hardware'), frameSeen: true });
         for (const subscriber of this._hardwareSubscribers.values()) subscriber(frame);
       });
       unsubscribeState = channel.onStateChange((state: ConnectionState) => {
         if (this._activeHardwareHandle !== handle) return;
-        this.hardwareScopeConnected = state === 'connected';
-        if (state !== 'connected') {
-          this.hardwareScopeFrameLive = false;
-          this.scopeFrame = null;
-        }
+        if (state !== 'connected') this.scopeFrame = null;
+        this._setHealth('hardware', {
+          demanded: true, transport: state,
+          frameSeen: state === 'connected' && this._readHealth('hardware').frameSeen,
+        });
       });
+      this._hardwareBindings.set(handle, { channel, unsubscribeBinary, unsubscribeState });
       channel.connect('/api/v1/scope');
     } catch (error) {
+      this._hardwareBindings.delete(handle);
       try { unsubscribeBinary(); } finally { unsubscribeState(); }
+      if (this._activeHardwareHandle === handle) {
+        this._activeHardwareHandle = null;
+        this._setHealth('hardware', {
+          demanded: false, transport: 'disconnected', frameSeen: false,
+        });
+      }
       if (![...this._hardwareBindings.values()].some((item) => item.channel === channel)) {
         channel.disconnect();
       }
       throw error;
     }
-    this._hardwareBindings.set(handle, { channel, unsubscribeBinary, unsubscribeState });
-    this._activeHardwareHandle = handle;
-    this.hardwareScopeDemanded = true;
-    this.hardwareScopeConnected = channel.state === 'connected';
-    this.hardwareScopeFrameLive = false;
-    this.scopeFrame = null;
     return handle;
   }
 
@@ -183,10 +248,10 @@ export class ScopeController {
     this._hardwareBindings.delete(handle);
     if (this._activeHardwareHandle === handle) {
       this._activeHardwareHandle = null;
-      this.hardwareScopeDemanded = false;
-      this.hardwareScopeConnected = false;
-      this.hardwareScopeFrameLive = false;
       this.scopeFrame = null;
+      this._setHealth('hardware', {
+        demanded: false, transport: 'disconnected', frameSeen: false,
+      });
     }
     try {
       binding.unsubscribeBinary();
@@ -197,6 +262,22 @@ export class ScopeController {
         }
       }
     }
+  }
+
+  private _setHealth(source: ScopeSource, next: ScopeHealth): void {
+    const current = this._readHealth(source);
+    if (
+      current.demanded === next.demanded
+      && current.transport === next.transport
+      && current.frameSeen === next.frameSeen
+    ) return;
+    this._health[source] = next;
+    const snapshot = this.snapshotHealth(source);
+    for (const listener of this._healthSubscribers.values()) listener(source, snapshot);
+  }
+
+  private _readHealth(source: ScopeSource): ScopeHealth {
+    return untrack(() => this._health[source]);
   }
 }
 


### PR DESCRIPTION
## Summary

- expose immutable, source-qualified `{ demanded, transport, frameSeen }` snapshots and exact health subscriptions from the existing `ScopeController`
- qualify audio and hardware state/frame callbacks by the exact active handle and current observed connected interval
- add symmetric audio binary/state teardown, reconnect resets, and stale A→B→A resistance
- preserve hardware compatibility getters from the same canonical health facts
- make audio-FFT driver registration once-per-host while preserving the first legacy configuration or a future central capability-derived configuration

## Scope

- exactly 2 files changed
- 234 additions, 36 deletions (198 net LOC)
- no ResourceHost, FrontendRuntime, panel, transport API, server, protocol, capabilities, TX, App, StatusBar, SpectrumPanel, profile, or hardware behavior changes
- no fallback and no continuous-freshness or WebSocket-epoch claim

## Validation

RED characterization before implementation:

- focused ScopeController suite: 4 failed / 14 passed (missing health API, audio state handling, stale callback protection, and once-per-host registration)

PASS on Node 26 with `NODE_OPTIONS=--no-experimental-webstorage`:

- `npx vitest run src/lib/runtime/__tests__/scope-controller.test.ts` — 18 passed
- `npx vitest run src/components-v2/panels/lcd/__tests__/audio-fft-demand.test.ts` — 3 passed
- `npm test` — 134 files, 2387 tests passed
- `npm run check` — 0 errors, 0 warnings
- `npm run lint` — passed
- `npm run lint:boundaries` — passed
- `npm run i18n:check` — passed
- `npm run build` — passed
- `git diff --check` — passed

No real-hardware validation was performed or claimed.

Closes #2044
Linear: MOR-1141
