### PR TITLE
MOR-1142: expose canonical default-scope status through FrontendRuntime

### DIFF
--- a/frontend/src/lib/runtime/__tests__/frontend-runtime.test.ts
+++ b/frontend/src/lib/runtime/__tests__/frontend-runtime.test.ts
@@ -443,7 +443,6 @@ describe('FrontendRuntime canonical default scope status', () => {
     });
     const rt = await freshRuntime();
     await rt.bootstrap();
-
     expect(presentationResources.snapshot('hardware-scope')).toMatchObject({
       available: true, selected: true, demand: 0,
     });
@@ -455,7 +454,7 @@ describe('FrontendRuntime canonical default scope status', () => {
       lifecycle: 'inactive', transport: 'disconnected', frameSeen: false,
     });
     presentationResources.configure('hardware-scope', { available: false, selected: true });
-    expect(rt.defaultScopeStatus).toMatchObject({ source: 'hardware', available: false });
+    expect(rt.defaultScopeStatus).toMatchObject({ source: 'hardware', available: false, resourceSelected: true });
     presentationResources.configure('hardware-scope', { available: true, selected: true });
 
     const hardwareLease = rt.acquireHardwareScope('viewer');
@@ -496,7 +495,7 @@ describe('FrontendRuntime canonical default scope status', () => {
   it('publishes the audio default and inert facts without fallback', async () => {
     (getChannel as ReturnType<typeof vi.fn>).mockReturnValue(makeScopeChannel());
     (fetchCapabilities as ReturnType<typeof vi.fn>).mockResolvedValue({
-      ...fakeCaps, scope: false, capabilities: ['audio'], scopeSource: 'audio_fft',
+      ...fakeCaps, scope: true, capabilities: ['audio', 'scope'], scopeSource: 'audio_fft',
     });
     const rt = await freshRuntime();
     await rt.bootstrap();
@@ -504,6 +503,7 @@ describe('FrontendRuntime canonical default scope status', () => {
       source: 'audio_fft', available: true, resourceSelected: true, demand: 0,
       lifecycle: 'inactive', transport: 'disconnected', frameSeen: false,
     });
+    expect(presentationResources.snapshot('hardware-scope')).toMatchObject({ available: true, selected: true, demand: 0 });
     expect(getChannel).not.toHaveBeenCalled();
     (getChannel as ReturnType<typeof vi.fn>).mockImplementationOnce(() => {
       throw new Error('offline');

--- a/frontend/src/lib/runtime/__tests__/frontend-runtime.test.ts
+++ b/frontend/src/lib/runtime/__tests__/frontend-runtime.test.ts
@@ -432,7 +432,14 @@ describe('FrontendRuntime canonical default scope status', () => {
     vi.clearAllMocks();
     (startPolling as ReturnType<typeof vi.fn>).mockReturnValue(fakeStopPolling);
   });
-
+  it('keeps capability-denied hardware inert', async () => {
+    (fetchCapabilities as ReturnType<typeof vi.fn>).mockResolvedValue(fakeCaps);
+    const rt = await freshRuntime();
+    await rt.bootstrap();
+    expect(presentationResources.snapshot('hardware-scope')).toMatchObject({
+      available: false, selected: false, demand: 0, health: 'inactive',
+    });
+  });
   it('keeps both sources eligible while summarizing only the hardware default', async () => {
     const hardware = makeScopeChannel(), audio = makeScopeChannel();
     (getChannel as ReturnType<typeof vi.fn>).mockImplementation(
@@ -456,7 +463,6 @@ describe('FrontendRuntime canonical default scope status', () => {
     presentationResources.configure('hardware-scope', { available: false, selected: true });
     expect(rt.defaultScopeStatus).toMatchObject({ source: 'hardware', available: false, resourceSelected: true });
     presentationResources.configure('hardware-scope', { available: true, selected: true });
-
     const hardwareLease = rt.acquireHardwareScope('viewer');
     const hardwareShared = rt.acquireHardwareScope('shared');
     const audioLease = presentationResources.acquire('audio-fft', 'supplemental');
@@ -469,20 +475,17 @@ describe('FrontendRuntime canonical default scope status', () => {
       selected: true, demand: 1, health: 'streaming',
     });
     expect(rt.defaultScopeStatus.lifecycle).toBe('streaming');
-
     for (const state of ['connecting', 'connected', 'reconnecting', 'disconnected'] as const) {
       hardware.setState(state);
       expect(rt.defaultScopeStatus.transport).toBe(state);
       expect(rt.defaultScopeStatus.frameSeen).toBe(false);
     }
     hardware.setState('connected');
-    expect(rt.defaultScopeStatus.frameSeen).toBe(false);
     hardware.frame();
     expect(rt.defaultScopeStatus.frameSeen).toBe(true);
     hardware.setState('reconnecting');
     hardware.setState('connected');
     expect(rt.defaultScopeStatus.frameSeen).toBe(false);
-
     rt.releaseHardwareScope(hardwareLease);
     expect(rt.defaultScopeStatus.demand).toBe(1);
     expect(hardware.disconnect).not.toHaveBeenCalled();
@@ -491,7 +494,6 @@ describe('FrontendRuntime canonical default scope status', () => {
     await settle();
     expect(hardware.disconnect).toHaveBeenCalledTimes(1);
   });
-
   it('publishes the audio default and inert facts without fallback', async () => {
     (getChannel as ReturnType<typeof vi.fn>).mockReturnValue(makeScopeChannel());
     (fetchCapabilities as ReturnType<typeof vi.fn>).mockResolvedValue({
@@ -512,7 +514,6 @@ describe('FrontendRuntime canonical default scope status', () => {
     await settle();
     expect(rt.defaultScopeStatus.lifecycle).toBe('failed');
     presentationResources.release(failedLease);
-
     (fetchCapabilities as ReturnType<typeof vi.fn>).mockResolvedValue({
       ...fakeCaps, scope: true, capabilities: ['audio', 'scope'], scopeSource: 'invalid',
       audioFftAvailable: false,
@@ -526,9 +527,11 @@ describe('FrontendRuntime canonical default scope status', () => {
     expect(presentationResources.snapshot('hardware-scope')).toMatchObject({
       available: true, selected: true, demand: 0,
     });
+    expect(presentationResources.snapshot('audio-fft')).toMatchObject({
+      available: false, selected: false, demand: 0,
+    });
     expect(getChannel).toHaveBeenCalledExactlyOnceWith('audio-scope');
   });
-
   it('shares, coalesces, and exactly tears down the reactive bridge', async () => {
     const hardware = makeScopeChannel();
     (getChannel as ReturnType<typeof vi.fn>).mockReturnValue(hardware);
@@ -542,7 +545,6 @@ describe('FrontendRuntime canonical default scope status', () => {
     const observe = () => effect_root(() => {
       render_effect(() => { rt.defaultScopeStatus; reads += 1; });
     });
-
     expect(rt.defaultScopeStatus.demand).toBe(0);
     expect([hostListeners.size, healthListeners.size]).toEqual([0, 0]);
     const stopFirst = observe(), stopShared = observe();
@@ -561,7 +563,6 @@ describe('FrontendRuntime canonical default scope status', () => {
     expect(rt.defaultScopeStatus).toMatchObject({
       demand: 1, lifecycle: 'streaming', transport: 'connected', frameSeen: false,
     });
-
     stopFirst(); await settle();
     expect([hostListeners.size, healthListeners.size]).toEqual([1, 1]);
     stopShared(); await settle();
@@ -573,7 +574,6 @@ describe('FrontendRuntime canonical default scope status', () => {
     expect([hostListeners.size, healthListeners.size]).toEqual([0, 0]);
   });
 });
-
 describe('FrontendRuntime RX LIVE intent', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/frontend/src/lib/runtime/__tests__/frontend-runtime.test.ts
+++ b/frontend/src/lib/runtime/__tests__/frontend-runtime.test.ts
@@ -8,6 +8,9 @@
 
 import { readFileSync } from 'node:fs';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { flushSync } from 'svelte';
+// @ts-expect-error -- Svelte does not publish types for its test-only effect harness.
+import { effect_root, render_effect } from 'svelte/internal/client';
 
 // ── Mock transport and store modules before importing the runtime ──
 
@@ -64,6 +67,7 @@ vi.mock('$lib/stores/connection.svelte', () => ({
   setRadioReady: vi.fn(),
   setControlConnected: vi.fn(),
   markStateUpdated: vi.fn(),
+  markScopeFrame: vi.fn(),
 }));
 
 vi.mock('$lib/stores/audio.svelte', () => ({
@@ -113,6 +117,7 @@ import { systemController } from '../system-controller';
 import { clearLegacyPendingModInputRestore } from '../adapters/mod-input-auto.svelte';
 import { PresentationResourceHost } from '../resource-host';
 import { presentationResources } from '../frontend-runtime';
+import { scopeController } from '../scope-controller.svelte';
 import { makeRxAudioHandlers } from '../commands/panel-commands';
 
 // FrontendRuntime is a singleton — re-import fresh each time via a factory helper
@@ -158,6 +163,24 @@ const deferred = <T>() => {
   return { promise, resolve };
 };
 const settle = async () => { await Promise.resolve(); await Promise.resolve(); };
+function makeScopeChannel() {
+  const binary = new Set<(data: ArrayBuffer) => void>();
+  const states = new Set<(state: any) => void>();
+  let state = 'disconnected';
+  return {
+    get state() { return state; },
+    connect: vi.fn(), disconnect: vi.fn(),
+    onBinary: vi.fn((handler) => { binary.add(handler); return () => binary.delete(handler); }),
+    onStateChange: vi.fn((handler) => { states.add(handler); return () => states.delete(handler); }),
+    setState(next: any) { state = next; for (const handler of states) handler(next); },
+    frame() {
+      const data = new ArrayBuffer(20), view = new DataView(data);
+      view.setUint8(0, 1); view.setUint32(3, 14_100_000, true);
+      view.setUint32(7, 14_200_000, true); view.setUint16(14, 4, true);
+      for (const handler of binary) handler(data);
+    },
+  };
+}
 describe('PresentationResourceHost', () => {
   it('is inert until first demand, shares the handle, and stops on last release', async () => {
     const handle = {};
@@ -374,59 +397,6 @@ describe('FrontendRuntime hardware scope and DX facades', () => {
     (startPolling as ReturnType<typeof vi.fn>).mockReturnValue(fakeStopPolling);
   });
 
-  it('derives unavailable/default selection and keeps bootstrap inert', async () => {
-    const rt = await freshRuntime();
-    await rt.bootstrap();
-
-    expect(presentationResources.snapshot('hardware-scope')).toMatchObject({
-      available: false,
-      selected: false,
-      demand: 0,
-      health: 'inactive',
-    });
-    expect(getChannel).not.toHaveBeenCalled();
-  });
-
-  it('starts only for exact shared demand and stops on the last valid release', async () => {
-    const channel = {
-      state: 'disconnected',
-      connect: vi.fn(),
-      disconnect: vi.fn(),
-      onBinary: vi.fn(() => vi.fn()),
-      onStateChange: vi.fn(() => vi.fn()),
-    };
-    (getChannel as ReturnType<typeof vi.fn>).mockReturnValue(channel);
-    (fetchCapabilities as ReturnType<typeof vi.fn>).mockResolvedValue({
-      ...fakeCaps,
-      scope: true,
-      capabilities: ['audio', 'scope'],
-      scopeSource: 'hardware',
-    });
-    const rt = await freshRuntime();
-    await rt.bootstrap();
-
-    expect(presentationResources.snapshot('hardware-scope')).toMatchObject({
-      available: true,
-      selected: true,
-      demand: 0,
-    });
-    expect(getChannel).not.toHaveBeenCalled();
-
-    const first = rt.acquireHardwareScope('first');
-    const shared = rt.acquireHardwareScope('shared');
-    await settle();
-    expect(getChannel).toHaveBeenCalledExactlyOnceWith('scope');
-    expect(channel.connect).toHaveBeenCalledExactlyOnceWith('/api/v1/scope');
-    expect(presentationResources.snapshot('hardware-scope').demand).toBe(2);
-
-    expect(rt.releaseHardwareScope(first)).toBe(true);
-    expect(rt.releaseHardwareScope(first)).toBe(false);
-    expect(channel.disconnect).not.toHaveBeenCalled();
-    expect(rt.releaseHardwareScope(shared)).toBe(true);
-    await settle();
-    expect(channel.disconnect).toHaveBeenCalledTimes(1);
-  });
-
   it('shares one filtered control subscription and unsubscribes exactly', async () => {
     let controlHandler: ((message: unknown) => void) | undefined;
     const controlUnsubscribe = vi.fn();
@@ -454,6 +424,153 @@ describe('FrontendRuntime hardware scope and DX facades', () => {
     expect(controlUnsubscribe).not.toHaveBeenCalled();
     unsubscribeSecond();
     expect(controlUnsubscribe).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('FrontendRuntime canonical default scope status', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (startPolling as ReturnType<typeof vi.fn>).mockReturnValue(fakeStopPolling);
+  });
+
+  it('keeps both sources eligible while summarizing only the hardware default', async () => {
+    const hardware = makeScopeChannel(), audio = makeScopeChannel();
+    (getChannel as ReturnType<typeof vi.fn>).mockImplementation(
+      (name) => name === 'scope' ? hardware : audio,
+    );
+    (fetchCapabilities as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ...fakeCaps, capabilities: ['audio', 'scope'], scopeSource: 'hardware',
+    });
+    const rt = await freshRuntime();
+    await rt.bootstrap();
+
+    expect(presentationResources.snapshot('hardware-scope')).toMatchObject({
+      available: true, selected: true, demand: 0,
+    });
+    expect(presentationResources.snapshot('audio-fft')).toMatchObject({
+      available: true, selected: true, demand: 0,
+    });
+    expect(rt.defaultScopeStatus).toEqual({
+      source: 'hardware', available: true, resourceSelected: true, demand: 0,
+      lifecycle: 'inactive', transport: 'disconnected', frameSeen: false,
+    });
+    presentationResources.configure('hardware-scope', { available: false, selected: true });
+    expect(rt.defaultScopeStatus).toMatchObject({ source: 'hardware', available: false });
+    presentationResources.configure('hardware-scope', { available: true, selected: true });
+
+    const hardwareLease = rt.acquireHardwareScope('viewer');
+    const hardwareShared = rt.acquireHardwareScope('shared');
+    const audioLease = presentationResources.acquire('audio-fft', 'supplemental');
+    expect(rt.defaultScopeStatus).toMatchObject({
+      source: 'hardware', demand: 2, lifecycle: 'starting',
+      transport: 'disconnected', frameSeen: false,
+    });
+    await settle();
+    expect(presentationResources.snapshot('audio-fft')).toMatchObject({
+      selected: true, demand: 1, health: 'streaming',
+    });
+    expect(rt.defaultScopeStatus.lifecycle).toBe('streaming');
+
+    for (const state of ['connecting', 'connected', 'reconnecting', 'disconnected'] as const) {
+      hardware.setState(state);
+      expect(rt.defaultScopeStatus.transport).toBe(state);
+      expect(rt.defaultScopeStatus.frameSeen).toBe(false);
+    }
+    hardware.setState('connected');
+    expect(rt.defaultScopeStatus.frameSeen).toBe(false);
+    hardware.frame();
+    expect(rt.defaultScopeStatus.frameSeen).toBe(true);
+    hardware.setState('reconnecting');
+    hardware.setState('connected');
+    expect(rt.defaultScopeStatus.frameSeen).toBe(false);
+
+    rt.releaseHardwareScope(hardwareLease);
+    expect(rt.defaultScopeStatus.demand).toBe(1);
+    expect(hardware.disconnect).not.toHaveBeenCalled();
+    rt.releaseHardwareScope(hardwareShared);
+    presentationResources.release(audioLease);
+    await settle();
+    expect(hardware.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('publishes the audio default and inert facts without fallback', async () => {
+    (getChannel as ReturnType<typeof vi.fn>).mockReturnValue(makeScopeChannel());
+    (fetchCapabilities as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ...fakeCaps, scope: false, capabilities: ['audio'], scopeSource: 'audio_fft',
+    });
+    const rt = await freshRuntime();
+    await rt.bootstrap();
+    expect(rt.defaultScopeStatus).toEqual({
+      source: 'audio_fft', available: true, resourceSelected: true, demand: 0,
+      lifecycle: 'inactive', transport: 'disconnected', frameSeen: false,
+    });
+    expect(getChannel).not.toHaveBeenCalled();
+    (getChannel as ReturnType<typeof vi.fn>).mockImplementationOnce(() => {
+      throw new Error('offline');
+    });
+    const failedLease = presentationResources.acquire('audio-fft', 'failed');
+    await settle();
+    expect(rt.defaultScopeStatus.lifecycle).toBe('failed');
+    presentationResources.release(failedLease);
+
+    (fetchCapabilities as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ...fakeCaps, scope: true, capabilities: ['audio', 'scope'], scopeSource: 'invalid',
+      audioFftAvailable: false,
+    });
+    const invalid = await freshRuntime();
+    await invalid.bootstrap();
+    expect(invalid.defaultScopeStatus).toEqual({
+      source: null, available: false, resourceSelected: false, demand: 0,
+      lifecycle: 'inactive', transport: 'disconnected', frameSeen: false,
+    });
+    expect(presentationResources.snapshot('hardware-scope')).toMatchObject({
+      available: true, selected: true, demand: 0,
+    });
+    expect(getChannel).toHaveBeenCalledExactlyOnceWith('audio-scope');
+  });
+
+  it('shares, coalesces, and exactly tears down the reactive bridge', async () => {
+    const hardware = makeScopeChannel();
+    (getChannel as ReturnType<typeof vi.fn>).mockReturnValue(hardware);
+    (fetchCapabilities as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ...fakeCaps, capabilities: ['audio', 'scope'], scopeSource: 'hardware',
+    });
+    const rt = await freshRuntime();
+    const hostListeners = (presentationResources as any).listeners as Set<unknown>;
+    const healthListeners = (scopeController as any)._healthSubscribers as Map<unknown, unknown>;
+    let reads = 0;
+    const observe = () => effect_root(() => {
+      render_effect(() => { rt.defaultScopeStatus; reads += 1; });
+    });
+
+    expect(rt.defaultScopeStatus.demand).toBe(0);
+    expect([hostListeners.size, healthListeners.size]).toEqual([0, 0]);
+    const stopFirst = observe(), stopShared = observe();
+    expect([hostListeners.size, healthListeners.size]).toEqual([1, 1]);
+    (fetchCapabilities as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('offline'));
+    await expect(rt.bootstrap()).rejects.toThrow('offline');
+    expect([hostListeners.size, healthListeners.size]).toEqual([1, 1]);
+    await rt.bootstrap();
+    const lease = rt.acquireHardwareScope('viewer');
+    await settle();
+    const before = reads;
+    hardware.setState('connecting');
+    hardware.setState('connected');
+    flushSync();
+    expect(reads).toBe(before + 2);
+    expect(rt.defaultScopeStatus).toMatchObject({
+      demand: 1, lifecycle: 'streaming', transport: 'connected', frameSeen: false,
+    });
+
+    stopFirst(); await settle();
+    expect([hostListeners.size, healthListeners.size]).toEqual([1, 1]);
+    stopShared(); await settle();
+    expect([hostListeners.size, healthListeners.size]).toEqual([0, 0]);
+    const stopRemount = observe();
+    expect([hostListeners.size, healthListeners.size]).toEqual([1, 1]);
+    rt.releaseHardwareScope(lease);
+    stopRemount(); await settle();
+    expect([hostListeners.size, healthListeners.size]).toEqual([0, 0]);
   });
 });
 
@@ -555,6 +672,12 @@ describe('FrontendRuntime RX LIVE intent', () => {
     (onMessage as ReturnType<typeof vi.fn>).mockReturnValue(unsubscribeDx);
     const rt = await freshRuntime();
     await rt.bootstrap();
+    const hostListeners = (presentationResources as any).listeners as Set<unknown>;
+    const healthListeners = (scopeController as any)._healthSubscribers as Map<unknown, unknown>;
+    const stopStatus = effect_root(() => {
+      render_effect(() => { rt.defaultScopeStatus; });
+    });
+    expect([hostListeners.size, healthListeners.size]).toEqual([1, 1]);
     rt.setRxLive(true);
     const hardwareLease = rt.acquireHardwareScope('SpectrumPanel');
     rt.subscribeDx(vi.fn());
@@ -571,6 +694,7 @@ describe('FrontendRuntime RX LIVE intent', () => {
     expect(audioManager.stopRx).toHaveBeenCalledTimes(1);
     expect(channel.disconnect).toHaveBeenCalledTimes(1);
     expect(unsubscribeDx).toHaveBeenCalledTimes(1);
+    expect([hostListeners.size, healthListeners.size]).toEqual([0, 0]);
     expect(rt.releaseHardwareScope(hardwareLease)).toBe(false);
     expect(() => rt.acquireHardwareScope('late')).toThrow('torn down');
     expect(() => rt.subscribeDx(vi.fn())).toThrow('torn down');
@@ -579,5 +703,11 @@ describe('FrontendRuntime RX LIVE intent', () => {
       health: 'inactive',
       activeHandle: undefined,
     });
+    stopStatus(); await settle();
+    const stopAfterFinal = effect_root(() => {
+      render_effect(() => { rt.defaultScopeStatus; });
+    });
+    expect([hostListeners.size, healthListeners.size]).toEqual([0, 0]);
+    stopAfterFinal(); await settle();
   });
 });

--- a/frontend/src/lib/runtime/frontend-runtime.ts
+++ b/frontend/src/lib/runtime/frontend-runtime.ts
@@ -32,12 +32,14 @@ import { clearLegacyPendingModInputRestore } from './adapters/mod-input-auto.sve
 import { derivePresentationCapabilities } from './adapters/presentation-capabilities';
 import { systemController } from './system-controller';
 import { scopeController } from './scope-controller.svelte';
-import type { ScopeController } from './scope-controller.svelte';
+import type { ScopeController, ScopeSource } from './scope-controller.svelte';
 import { PresentationResourceHost } from './resource-host';
-import type { ResourceLease } from './resource-demand';
+import type { ResourceHealth, ResourceLease } from './resource-demand';
+import { createSubscriber } from 'svelte/reactivity';
 import type { ServerState, ReceiverState } from '$lib/types/state';
 import type { Capabilities } from '$lib/types/capabilities';
 import type { WsIncoming } from '$lib/types/protocol';
+import type { ConnectionState } from '$lib/transport/ws-client';
 export const presentationResources = new PresentationResourceHost<unknown>('app');
 // ── Types ──
 
@@ -54,6 +56,15 @@ export interface ConnectionSnapshot {
   radioPowerOn: boolean | null;
 }
 
+export interface DefaultScopeStatus {
+  source: ScopeSource | null;
+  available: boolean;
+  resourceSelected: boolean;
+  demand: number;
+  lifecycle: ResourceHealth;
+  transport: ConnectionState;
+  frameSeen: boolean;
+}
 
 // ── Runtime class ──
 
@@ -65,6 +76,30 @@ class FrontendRuntime {
   private _dxSubscribers = new Map<number, (message: DxMessage) => void>();
   private _dxControlUnsubscribe: (() => void) | null = null;
   private _nextDxSubscriber = 0;
+  private _defaultScopeSource: ScopeSource | null = null;
+  private _defaultScopeSnapshot: DefaultScopeStatus = {
+    source: null, available: false, resourceSelected: false, demand: 0,
+    lifecycle: 'inactive', transport: 'disconnected', frameSeen: false,
+  };
+  private _defaultScopeStop: (() => void) | null = null;
+  private _defaultScopeSubscribe = createSubscriber((update) => {
+    if (this._ended) return;
+    const notify = () => {
+      this._defaultScopeSnapshot = this._readDefaultScopeStatus();
+      update();
+    };
+    const unsubscribeHost = presentationResources.subscribe(() => notify());
+    const unsubscribeHealth = scopeController.subscribeHealth(() => notify());
+    let active = true;
+    const stop = () => {
+      if (!active) return;
+      active = false;
+      try { unsubscribeHost(); } finally { unsubscribeHealth(); }
+      if (this._defaultScopeStop === stop) this._defaultScopeStop = null;
+    };
+    this._defaultScopeStop = stop;
+    return stop;
+  });
 
   constructor() {
     presentationResources.configure('hardware-scope', {
@@ -72,6 +107,7 @@ class FrontendRuntime {
       selected: false,
       driver: scopeController.hardwareScopeDriver,
     });
+    scopeController.registerPresentationDriver(presentationResources);
     presentationResources.configure('rx-audio', {
       available: false,
       selected: true,
@@ -154,6 +190,28 @@ class FrontendRuntime {
     return scopeController;
   }
 
+  get defaultScopeStatus(): DefaultScopeStatus {
+    this._defaultScopeSubscribe();
+    this._defaultScopeSnapshot = this._readDefaultScopeStatus();
+    return this._defaultScopeSnapshot;
+  }
+
+  private _readDefaultScopeStatus(): DefaultScopeStatus {
+    const source = this._defaultScopeSource;
+    if (source === null) return {
+      source, available: false, resourceSelected: false, demand: 0,
+      lifecycle: 'inactive', transport: 'disconnected', frameSeen: false,
+    };
+    const resource = source === 'hardware' ? 'hardware-scope' : 'audio-fft';
+    const host = presentationResources.snapshot(resource);
+    const health = scopeController.snapshotHealth(source);
+    return {
+      source, available: host.available, resourceSelected: host.selected,
+      demand: host.demand, lifecycle: host.health,
+      transport: health.transport, frameSeen: health.frameSeen,
+    };
+  }
+
   // ── Bootstrap ──
 
   /**
@@ -201,9 +259,14 @@ class FrontendRuntime {
     const caps = await fetchCapabilities();
     setCapabilities(caps);
     const presentationCaps = derivePresentationCapabilities(caps);
+    this._defaultScopeSource = presentationCaps.scope.defaultSource;
     presentationResources.configure('hardware-scope', {
       available: presentationCaps.scope.hardwareScopeAvailable,
-      selected: presentationCaps.scope.defaultSource === 'hardware',
+      selected: presentationCaps.scope.hardwareScopeAvailable,
+    });
+    presentationResources.configure('audio-fft', {
+      available: presentationCaps.scope.audioFftAvailable,
+      selected: presentationCaps.scope.audioFftAvailable,
     });
     presentationResources.configure('rx-audio', {
       available: caps.audio === true && caps.capabilities.includes('audio'),
@@ -234,7 +297,11 @@ class FrontendRuntime {
       const unsubscribeDx = this._dxControlUnsubscribe;
       this._dxControlUnsubscribe = null;
       try { unsubscribeDx?.(); } finally {
-        try { await presentationResources.teardown(); } finally { stopPolling(); }
+        const stopScopeStatus = this._defaultScopeStop;
+        this._defaultScopeStop = null;
+        try { stopScopeStatus?.(); } finally {
+          try { await presentationResources.teardown(); } finally { stopPolling(); }
+        }
       }
     })();
     this._bootstrapCleanup = cleanup;

--- a/frontend/src/lib/runtime/frontend-runtime.ts
+++ b/frontend/src/lib/runtime/frontend-runtime.ts
@@ -107,7 +107,10 @@ class FrontendRuntime {
       selected: false,
       driver: scopeController.hardwareScopeDriver,
     });
-    scopeController.registerPresentationDriver(presentationResources);
+    scopeController.registerPresentationDriver(presentationResources, {
+      available: false,
+      selected: false,
+    });
     presentationResources.configure('rx-audio', {
       available: false,
       selected: true,


### PR DESCRIPTION
## Summary

- centrally register the existing hardware and audio FFT scope drivers as authority-inert (`available:false`, `selected:false`, zero demand, inactive lifecycle)
- make bootstrap the only authority that enables either scope resource, using one canonical presentation-capability derivation
- preserve independent hardware/audio eligibility after bootstrap, including supplemental audio FFT when hardware is the server default
- expose reactive `defaultScopeStatus` facts for the validated server default only, preserving availability, resource eligibility, demand, lifecycle, transport, and frame evidence as separate axes
- tear down the shared host/controller bridge exactly across consumer churn, bootstrap failure, final teardown, and remount

The default source is observational only. This adds no selected-source preference, fallback, demand acquisition, or physical-active claim.

## RED / GREEN

RED characterization before implementation:

- `NODE_OPTIONS=--no-experimental-webstorage npm test -- --run src/lib/runtime/__tests__/frontend-runtime.test.ts`
- 3 expected failures: audio FFT was not centrally configured, `defaultScopeStatus` was absent, and the reactive bridge was absent; 18 existing tests passed

GREEN focused evidence:

- FrontendRuntime: 19 passed
- FrontendRuntime + ScopeController + ResourceDemand + canonical MOR-1145 LCD fixture: 59 passed
- the same 59 focused tests passed shuffled with seed `1142` and `--no-file-parallelism`
- divergent host facts explicitly prove `available:false` remains distinct from `resourceSelected:true`
- audio FFT default is covered while hardware remains simultaneously available, selected, and at zero demand
- capability-denied hardware and audio resources remain unavailable, unselected, and at zero demand
- a bounded four-boolean mutation probe failed exactly those two denial assertions; the production probe was then fully restored

## Gates

- full frontend: 134 files / 2,391 tests passed with local Node 26 and `NODE_OPTIONS=--no-experimental-webstorage`
- `npm run check` passed (0 errors, 0 warnings)
- `npm run lint` passed
- `npm run lint:boundaries` passed
- `npm run i18n:check` passed
- `npm run build` passed
- `git diff --check` passed
- exact scope: 2 files, +200 net LOC against `0621ad75f126d6a03510d0f09106e7629a9ca958`
- exact head: `a42ec06cec02c080b67551392834a5443c4db7d0`
- exact-head GitHub `Tests (quick)` passed

No hardware validation is claimed.

Closes #2045
Linear: MOR-1142
