### PR TITLE
MOR-1146: implement TX reducer lease and authority foundation

### DIFF
--- a/frontend/src/lib/runtime/tx-controller/__tests__/model.test.ts
+++ b/frontend/src/lib/runtime/tx-controller/__tests__/model.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import { initialTxState, transition, type Eligibility, type PttObservation, type TxEvent, type TxState } from '../model';
+const marker = (seq: number, authorityEpoch = 1) => ({ authorityEpoch, pttObservationSeq: seq, pttLastObservedMonotonic: seq });
+const target = { receiver: 'MAIN', slot: 'A', frequencyHz: 14_074_000 } as const;
+const eligible: Eligibility = { catPtt: true, browserTxAudio: true, controlLive: true, permit: 'allowed', target };
+const ptt = (value: boolean, seq: number, epoch = 1): PttObservation => ({ value, observed: true, fresh: true, source: 'radio-readback', marker: marker(seq, epoch) });
+const start = (state = initialTxState(1, marker(1)), overrides = {}) => transition(state, { type: 'start', sourceId: 'desktop', leaseId: 'lease', intent: 'momentary', eligibility: eligible, ptt: ptt(false, 2), ...overrides });
+const types = (result: ReturnType<typeof transition>) => result.effects.map((effect) => effect.type);
+function active(): TxState {
+  let result = start(); const guard = result.state.guard!; result = transition(result.state, { type: 'intent', sourceId: 'desktop', guard, intent: 'latched' }); expect(result.state.intent).toBe('latched');
+  result = transition(result.state, { type: 'audio-ready', guard, commandId: 'on' }); result = transition(result.state, { type: 'on-sent', guard, commandId: 'on', barrier: marker(2) }); expect(result.state.phase).toBe('key-confirm-pending'); return transition(result.state, { type: 'authority', epoch: 1, ptt: ptt(true, 3), eligibility: eligible, offCommandId: 'off' }).state;
+}
+function keyPending(): TxState { const pending = start(); const guard = pending.state.guard!; const dispatched = transition(pending.state, { type: 'audio-ready', guard, commandId: 'on' }); return transition(dispatched.state, { type: 'on-sent', guard, commandId: 'on', barrier: marker(2) }).state; }
+function complete(state: TxState, seq: number): TxState {
+  const begun = start(state, { leaseId: `lease-${seq}`, ptt: ptt(false, seq) }); const guard = begun.state.guard!; const dispatched = transition(begun.state, { type: 'audio-ready', guard, commandId: `on-${seq}` }); expect(types(dispatched)).toContain('dispatch-on');
+  const sent = transition(dispatched.state, { type: 'on-sent', guard, commandId: `on-${seq}`, barrier: marker(seq) }); const keyed = transition(sent.state, { type: 'authority', epoch: 1, ptt: ptt(true, seq + 1), eligibility: eligible, offCommandId: 'off' });
+  const released = transition(keyed.state, { type: 'release', guard, commandId: `off-${seq}` }); const off = released.state.pendingOff!; const delivered = transition(released.state, { type: 'off-sent', ...off, eventEpoch: 1, barrier: marker(seq + 2) }); return transition(delivered.state, { type: 'authority', epoch: 1, ptt: ptt(false, seq + 3), eligibility: eligible, offCommandId: 'off' }).state;
+}
+describe('TX reducer', () => {
+  it.each([['CAT PTT', { ...eligible, catPtt: false }, ptt(false, 2)], ['browser audio', { ...eligible, browserTxAudio: false }, ptt(false, 2)],
+    ['live control', { ...eligible, controlLive: false }, ptt(false, 2)], ['known permit', { ...eligible, permit: 'unknown' }, ptt(false, 2)],
+    ['known target', { ...eligible, target: null }, ptt(false, 2)], ['fresh OFF', eligible, ptt(false, 1)]] as const)('fails closed without %s', (_name, eligibility, observation) => {
+    const result = start(initialTxState(1, marker(1)), { eligibility, ptt: observation }); expect(result).toMatchObject({ state: { phase: 'failed', fault: 'not-eligible', txRisk: 'none', leaseId: null }, effects: [] });
+  });
+  it('models the happy path without optimistic RF truth', () => {
+    const result = start(); expect(result.state).toMatchObject({ phase: 'audio-start-pending', intent: 'momentary', sourceId: 'desktop', leaseId: 'lease', generation: 1,
+      authorityEpoch: 1, leaseTarget: target, startPttBaseline: marker(2), modBarrier: marker(2), radioTx: 'off', mayOwnKey: false, pendingOff: null });
+    expect(types(result)).toEqual(['start-audio', 'arm-audio-timeout']);
+    expect(start(result.state, { sourceId: 'mobile', leaseId: 'other' })).toEqual({ state: result.state, effects: [] });
+    const guard = result.state.guard!; expect(transition(result.state, { type: 'intent', sourceId: 'mobile', guard, intent: 'latched' })).toEqual({ state: result.state, effects: [] }); expect(transition(result.state, { type: 'release', sourceId: 'mobile', guard, commandId: 'off' })).toEqual({ state: result.state, effects: [] });
+    const released = transition(result.state, { type: 'release', guard, commandId: 'off' }); expect(transition(released.state, { type: 'intent', sourceId: 'desktop', guard: released.state.guard!, intent: 'latched' })).toEqual({ state: released.state, effects: [] });
+    expect(active()).toMatchObject({ phase: 'active', intent: 'latched', radioTx: 'on', onConfirmed: marker(3) });
+  });
+  it('rejects stale start evidence without regressing authoritative truth', () => { const external = transition(initialTxState(1, marker(1)), { type: 'authority', epoch: 1, ptt: ptt(true, 10), eligibility: eligible, offCommandId: 'off' }); const stale = start(external.state, { ptt: ptt(false, 2) }); expect(stale.state).toMatchObject({ phase: 'failed', fault: 'not-eligible', pttMarker: marker(10), radioTx: 'on' }); });
+  it('supports consecutive successful leases without retained markers', () => { const once = complete(initialTxState(1, marker(1)), 2); const twice = complete(once, 6); expect(twice).toMatchObject({ phase: 'idle', generation: 4, leaseTarget: null, startPttBaseline: null, modBarrier: null, onCommandId: null, onDispatch: null, onConfirmed: null, fault: null }); });
+  it('cancels pre-key without OFF and coalesces qualified release', () => {
+    const pending = start(); const cancelled = transition(pending.state, { type: 'release', sourceId: 'desktop', guard: pending.state.guard!, commandId: 'off-pre' });
+    expect(types(cancelled)).toEqual(['cancel-timers', 'stop-local-audio']);
+    const keyed = active(); const released = transition(keyed, { type: 'release', sourceId: 'desktop', guard: keyed.guard!, commandId: 'off' });
+    expect(types(released)).toEqual(['cancel-timers', 'dispatch-off', 'arm-off-timeout', 'stop-local-audio']); expect(released.state.phase).toBe('releasing');
+    expect(released.state).toMatchObject({ phase: 'releasing', generation: 2, pendingOff: { commandId: 'off', leaseId: 'lease', generation: 2,
+      originalEpoch: 1, deliveryEpoch: null, deliveryPttBarrier: null, deliveryRebound: false } });
+    const opened = transition(released.state, { type: 'epoch', epoch: 2, baseline: marker(1, 2), offCommandId: 'other' }); const premature = transition(opened.state, { type: 'authority', epoch: 2, ptt: ptt(false, 2, 2), eligibility: eligible, offCommandId: 'other' }); expect(types(premature)).toEqual([]); const off = opened.state.pendingOff!; const sent = { type: 'off-sent' as const, ...off, eventEpoch: 2, barrier: marker(2, 2) }; const delivered = transition(opened.state, sent); expect(types(delivered)).toEqual(['arm-off-timeout']); expect(delivered.state.pendingOff?.deliveryRebound).toBe(true); expect(transition(delivered.state, sent)).toEqual({ state: delivered.state, effects: [] });
+    expect(transition(released.state, { type: 'release', sourceId: 'desktop', guard: released.state.guard!, commandId: 'other' })).toEqual({ state: released.state, effects: [] });
+  });
+  it('retains exactly one OFF obligation from ON dispatch through teardown', () => {
+    const pending = start(); const guard = pending.state.guard!; const dispatched = transition(pending.state, { type: 'audio-ready', guard, commandId: 'on' });
+    expect(dispatched.state).toMatchObject({ mayOwnKey: true, txRisk: 'uncertain', onDispatch: marker(2) }); expect(types(dispatched)).toEqual(['cancel-timers', 'dispatch-on', 'arm-on-timeout']); expect(transition(dispatched.state, { type: 'audio-ready', guard, commandId: 'duplicate' })).toEqual({ state: dispatched.state, effects: [] });
+    const routes: TxEvent[] = [{ type: 'release', sourceId: 'desktop', guard, commandId: 'off' }, { type: 'fail', guard, fault: 'ptt-on-rejected', offCommandId: 'off' }, { type: 'fail', guard, fault: 'audio-failed', offCommandId: 'off' },
+      { type: 'epoch', epoch: 2, baseline: marker(1, 2), offCommandId: 'off' }, { type: 'authority', epoch: 1, ptt: ptt(false, 2), eligibility: { ...eligible, controlLive: false }, offCommandId: 'off' }];
+    for (const event of routes) {
+      const released = transition(dispatched.state, event); expect(types(released)).toEqual(['cancel-timers', 'dispatch-off', 'arm-off-timeout', 'stop-local-audio']); expect(released.state.pendingOff).toMatchObject({ commandId: 'off', deliveryPttBarrier: null });
+      expect(transition(released.state, { type: 'on-sent', guard, commandId: 'on', barrier: marker(3) })).toEqual({ state: released.state, effects: [] });
+    }
+  });
+  it('handles external and locally-correlated authoritative ON races', () => {
+    const pending = start(); const external = transition(pending.state, { type: 'authority', epoch: 1, ptt: ptt(true, 3), eligibility: eligible, offCommandId: 'off' });
+    expect(types(external)).toEqual(['cancel-timers', 'stop-local-audio']); expect(external.state).toMatchObject({ phase: 'releasing', radioTx: 'on', mayOwnKey: false, modRestorePending: true });
+    const settled = transition(external.state, { type: 'authority', epoch: 1, ptt: ptt(false, 4), eligibility: eligible, offCommandId: 'off' }); expect(types(settled)).toContain('restore-mod');
+    const begun = start(); const guard = begun.state.guard!; const dispatched = transition(begun.state, { type: 'audio-ready', guard, commandId: 'on' }); const confirmed = transition(dispatched.state, { type: 'authority', epoch: 1, ptt: ptt(true, 3), eligibility: eligible, offCommandId: 'off' });
+    expect(confirmed.state).toMatchObject({ phase: 'audio-start-pending', txRisk: 'confirmed-on', onConfirmed: marker(3) });
+    const rebound = transition(confirmed.state, { type: 'on-sent', guard, commandId: 'on', barrier: marker(3) }); expect(rebound.state.phase).toBe('active'); expect(types(rebound)).toEqual(['arm-on-timeout']); expect(transition(rebound.state, { type: 'on-sent', guard, commandId: 'on', barrier: marker(3) })).toEqual({ state: rebound.state, effects: [] });
+    const dekeyed = transition(rebound.state, { type: 'authority', epoch: 1, ptt: ptt(false, 4), eligibility: eligible, offCommandId: 'off' }); expect(dekeyed.state.fault).toBe('backend-dekeyed'); const released = transition(dispatched.state, { type: 'release', guard, commandId: 'off' }); const raced = transition(released.state, { type: 'authority', epoch: 1, ptt: ptt(true, 3), eligibility: eligible, offCommandId: 'off' });
+    expect(raced.state).toMatchObject({ phase: 'releasing', radioTx: 'on', txRisk: 'confirmed-on', onConfirmed: marker(3) });
+  });
+  it('qualifies post-ON failures and rejects stale epochs while rebasing pre-key MOD cleanup', () => {
+    for (const fault of ['ptt-on-rejected', 'audio-failed'] as const) {
+      const keyed = keyPending(); const rejected = transition(keyed, { type: 'fail', guard: keyed.guard!, fault, offCommandId: 'off' });
+      expect(rejected.state).toMatchObject({ phase: 'releasing', fault, mayOwnKey: true, pendingOff: { commandId: 'off' } }); expect(types(rejected)).toContain('dispatch-off'); const off = rejected.state.pendingOff!; const sent = transition(rejected.state, { type: 'off-sent', ...off, eventEpoch: 1, barrier: marker(3) }); const idle = transition(sent.state, { type: 'authority', epoch: 1, ptt: ptt(false, 4), eligibility: eligible, offCommandId: 'off' }); expect(idle.state).toMatchObject({ phase: 'idle', fault: null, onCommandId: null, modBarrier: null });
+    }
+    const pending = start(); const opened = transition(pending.state, { type: 'epoch', epoch: 2, baseline: marker(1, 2), offCommandId: 'off' });
+    expect(opened.state.modBarrier).toEqual(marker(1, 2)); for (const [epoch, baselineEpoch] of [[2, 2], [1, 1], [3, 2]] as const) expect(transition(opened.state, { type: 'epoch', epoch, baseline: marker(9, baselineEpoch), offCommandId: 'stale' })).toEqual({ state: opened.state, effects: [] });
+    expect(types(transition(opened.state, { type: 'authority', epoch: 2, ptt: ptt(false, 2, 2), eligibility: eligible, offCommandId: 'off' }))).toContain('restore-mod');
+  });
+  it.each([['receiver', { ...eligible, target: { ...target, receiver: 'SUB' as const } }], ['slot', { ...eligible, target: { ...target, slot: 'B' as const } }], ['frequency', { ...eligible, target: { ...target, frequencyHz: target.frequencyHz + 1 } }], ['unknown', { ...eligible, target: null }], ['permit', { ...eligible, permit: 'unknown' }]] as const)('routes %s loss by key ownership', (_name, eligibility) => {
+    const pending = start(); expect(types(transition(pending.state, { type: 'authority', epoch: 1, ptt: ptt(false, 2), eligibility, offCommandId: 'off' }))).not.toContain('dispatch-off');
+    expect(types(transition(active(), { type: 'authority', epoch: 1, ptt: ptt(true, 3), eligibility, offCommandId: 'off' }))).toContain('dispatch-off');
+  });
+  it('treats qualifying backend de-key and later re-key as external', () => { const dekeyed = transition(active(), { type: 'authority', epoch: 1, ptt: ptt(false, 4), eligibility: eligible, offCommandId: 'off' }); expect(dekeyed.state).toMatchObject({ phase: 'failed', fault: 'backend-dekeyed', txRisk: 'none', leaseId: null, radioTx: 'off', modRestorePending: false }); expect(types(dekeyed)).toEqual(['cancel-timers', 'stop-local-audio', 'restore-mod']); const rekeyed = transition(dekeyed.state, { type: 'authority', epoch: 1, ptt: ptt(true, 5), eligibility: eligible, offCommandId: 'off' }); expect(rekeyed).toMatchObject({ state: { radioTx: 'on', leaseId: null }, effects: [] }); });
+  it('resets only discharged faults and preserves authority truth', () => {
+    const rejected = start(initialTxState(1, marker(1)), { eligibility: { ...eligible, permit: 'unknown' } }); const reset = transition(rejected.state, { type: 'reset-fault' }); expect(reset.state).toMatchObject({ phase: 'idle', intent: null, fault: null, generation: rejected.state.generation, authorityEpoch: 1, pttMarker: rejected.state.pttMarker, radioTx: 'unknown' }); expect(start(reset.state).state.phase).toBe('audio-start-pending');
+    const dekeyed = transition(active(), { type: 'authority', epoch: 1, ptt: ptt(false, 4), eligibility: eligible, offCommandId: 'off' }); const recovered = transition(dekeyed.state, { type: 'reset-fault' }); expect(recovered.state).toMatchObject({ phase: 'idle', fault: null, radioTx: 'off', onCommandId: null }); expect(start(recovered.state, { ptt: ptt(false, 5) }).state.phase).toBe('audio-start-pending');
+    const pending = start(); const failed = transition(pending.state, { type: 'fail', guard: pending.state.guard!, fault: 'audio-failed', offCommandId: 'off' }); expect(transition(failed.state, { type: 'reset-fault' })).toEqual({ state: failed.state, effects: [] });
+    const keyed = active(); const released = transition(keyed, { type: 'release', guard: keyed.guard!, commandId: 'off' }); expect(transition(released.state, { type: 'reset-fault' })).toEqual({ state: released.state, effects: [] });
+  });
+});

--- a/frontend/src/lib/runtime/tx-controller/model.ts
+++ b/frontend/src/lib/runtime/tx-controller/model.ts
@@ -1,0 +1,114 @@
+export type TxPhase = 'idle' | 'audio-start-pending' | 'key-confirm-pending' | 'active' | 'releasing' | 'failed';
+export type TxIntent = 'momentary' | 'latched' | null;
+export type TxTarget = { receiver: 'MAIN' | 'SUB'; slot: 'A' | 'B' | null; frequencyHz: number } | null;
+export type PttMarker = { authorityEpoch: number; pttObservationSeq: number | null; pttLastObservedMonotonic: number | null };
+export type PttObservation = { value: boolean; observed: boolean; fresh: boolean; source: 'radio-readback' | 'backend-observation' | 'other'; marker: PttMarker };
+export type Eligibility = { catPtt: boolean; browserTxAudio: boolean; controlLive: boolean; permit: 'allowed' | 'denied' | 'unknown'; target: TxTarget };
+export type TxGuard = { leaseId: string; generation: number; authorityEpoch: number };
+export type PendingOff = { commandId: string; leaseId: string; generation: number; originalEpoch: number; deliveryEpoch: number | null; deliveryPttBarrier: PttMarker | null; deliveryRebound: boolean };
+export type TxFault = 'not-eligible' | 'audio-failed' | 'ptt-on-rejected' | 'backend-dekeyed' | null;
+export interface TxState {
+  phase: TxPhase; intent: TxIntent; sourceId: string | null; leaseId: string | null; generation: number; guard: TxGuard | null;
+  authorityEpoch: number; epochBaseline: PttMarker; pttMarker: PttMarker; leaseTarget: TxTarget;
+  startPttBaseline: PttMarker | null; modBarrier: PttMarker | null; onCommandId: string | null; onDispatch: PttMarker | null; onConfirmed: PttMarker | null;
+  localAudio: 'stopped' | 'starting' | 'streaming'; radioTx: 'off' | 'on' | 'unknown'; txRisk: 'none' | 'uncertain' | 'confirmed-on';
+  mayOwnKey: boolean; modRestorePending: boolean; pendingOff: PendingOff | null; fault: TxFault; }
+export type TxEffectType = 'start-audio' | 'dispatch-on' | 'dispatch-off' | 'stop-local-audio' | 'restore-mod' | 'arm-audio-timeout' | 'arm-on-timeout' | 'arm-off-timeout' | 'cancel-timers';
+export type TxEffect = { type: TxEffectType; guard?: TxGuard; commandId?: string; barrier?: PttMarker };
+export type TxEvent =
+  | { type: 'start'; sourceId: string; leaseId: string; intent: Exclude<TxIntent, null>; eligibility: Eligibility; ptt: PttObservation }
+  | { type: 'intent'; sourceId: string; guard: TxGuard; intent: Exclude<TxIntent, null> }
+  | { type: 'audio-ready'; guard: TxGuard; commandId: string }
+  | { type: 'fail'; guard: TxGuard; fault: 'audio-failed' | 'ptt-on-rejected'; offCommandId: string }
+  | { type: 'on-sent'; guard: TxGuard; commandId: string; barrier: PttMarker }
+  | { type: 'release'; sourceId?: string; guard: TxGuard; commandId: string }
+  | { type: 'off-sent'; commandId: string; leaseId: string; generation: number; originalEpoch: number; eventEpoch: number; barrier: PttMarker }
+  | { type: 'authority'; epoch: number; ptt: PttObservation; eligibility: Eligibility; offCommandId: string }
+  | { type: 'reset-fault' }
+  | { type: 'epoch'; epoch: number; baseline: PttMarker; offCommandId: string };
+export type TxTransition = { state: TxState; effects: TxEffect[] };
+export function initialTxState(authorityEpoch: number, baseline: PttMarker): TxState {
+  return { phase: 'idle', intent: null, sourceId: null, leaseId: null, generation: 0, guard: null, authorityEpoch, epochBaseline: baseline, pttMarker: baseline, leaseTarget: null, startPttBaseline: null, modBarrier: null, onCommandId: null, onDispatch: null, onConfirmed: null, localAudio: 'stopped', radioTx: 'unknown', txRisk: 'none', mayOwnKey: false, modRestorePending: false, pendingOff: null, fault: null };
+}
+const sameGuard = (state: TxState, guard: TxGuard) => state.guard?.leaseId === guard.leaseId && state.guard.generation === guard.generation && state.guard.authorityEpoch === guard.authorityEpoch;
+const sameTarget = (a: TxTarget, b: TxTarget) => a !== null && b !== null && a.receiver === b.receiver && a.slot === b.slot && a.frequencyHz === b.frequencyHz;
+const newer = (barrier: PttMarker, observation: PttObservation) => {
+  if (observation.marker.authorityEpoch !== barrier.authorityEpoch) return false;
+  const { pttObservationSeq: seq, pttLastObservedMonotonic: at } = observation.marker;
+  if (barrier.pttObservationSeq !== null || seq !== null) return barrier.pttObservationSeq !== null && seq !== null && seq > barrier.pttObservationSeq;
+  return barrier.pttLastObservedMonotonic !== null && at !== null && at > barrier.pttLastObservedMonotonic;
+};
+const authoritative = (observation: PttObservation) => observation.observed && observation.fresh && (observation.source === 'radio-readback' || observation.source === 'backend-observation');
+const ready = (eligibility: Eligibility) => eligibility.catPtt && eligibility.browserTxAudio && eligibility.controlLive && eligibility.permit === 'allowed' && eligibility.target !== null;
+const effect = (type: TxEffectType, state: TxState, commandId?: string, barrier?: PttMarker): TxEffect => ({ type, ...(state.guard ? { guard: state.guard } : {}), ...(commandId ? { commandId } : {}), ...(barrier ? { barrier } : {}) });
+const clearLease = (state: TxState): TxState => ({ ...state, intent: null, sourceId: null, leaseId: null, guard: null, leaseTarget: null, startPttBaseline: null, modBarrier: null, onCommandId: null, onDispatch: null, onConfirmed: null, localAudio: 'stopped', mayOwnKey: false, pendingOff: null });
+
+function release(state: TxState, commandId: string): TxTransition {
+  if (!state.guard || state.phase === 'releasing' || state.pendingOff) return { state, effects: [] };
+  const generation = state.generation + 1;
+  const guard = { ...state.guard, generation };
+  const next = { ...state, phase: 'releasing' as const, intent: null, generation, guard, localAudio: 'stopped' as const };
+  const effects = [effect('cancel-timers', next)];
+  if (state.mayOwnKey) {
+    next.pendingOff = { commandId, leaseId: guard.leaseId, generation, originalEpoch: state.authorityEpoch, deliveryEpoch: null, deliveryPttBarrier: null, deliveryRebound: false };
+    next.txRisk = state.radioTx === 'on' ? 'confirmed-on' : 'uncertain';
+    effects.push(effect('dispatch-off', next, commandId), effect('arm-off-timeout', next, commandId));
+  }
+  effects.push(effect('stop-local-audio', next));
+  return { state: next, effects };
+}
+
+export function transition(state: TxState, event: TxEvent): TxTransition {
+  if (event.type === 'start') {
+    if (state.phase !== 'idle') return { state, effects: [] };
+    const ok = ready(event.eligibility) && event.ptt.value === false && authoritative(event.ptt) && newer(state.pttMarker, event.ptt) && event.ptt.marker.authorityEpoch === state.authorityEpoch;
+    if (!ok) return { state: { ...state, phase: 'failed', fault: 'not-eligible', txRisk: 'none', sourceId: null, leaseId: null, guard: null }, effects: [] };
+    const generation = state.generation + 1;
+    const guard = { leaseId: event.leaseId, generation, authorityEpoch: state.authorityEpoch };
+    const next = { ...clearLease(state), phase: 'audio-start-pending' as const, intent: event.intent, sourceId: event.sourceId, leaseId: event.leaseId, generation, guard, leaseTarget: event.eligibility.target, startPttBaseline: event.ptt.marker, modBarrier: event.ptt.marker, pttMarker: event.ptt.marker, localAudio: 'starting' as const, radioTx: 'off' as const, txRisk: 'none' as const, modRestorePending: true, fault: null };
+    return { state: next, effects: [effect('start-audio', next), effect('arm-audio-timeout', next)] };
+  }
+  if (event.type === 'intent') return sameGuard(state, event.guard) && event.sourceId === state.sourceId && state.phase !== 'releasing' && state.phase !== 'failed' ? { state: { ...state, intent: event.intent }, effects: [] } : { state, effects: [] };
+  if (event.type === 'release') return sameGuard(state, event.guard) && (event.sourceId === undefined || event.sourceId === state.sourceId) ? release(state, event.commandId) : { state, effects: [] };
+  if (event.type === 'reset-fault' && state.phase === 'failed' && !state.pendingOff && !state.modRestorePending && !state.mayOwnKey) return { state: { ...clearLease(state), phase: 'idle', txRisk: 'none', fault: null }, effects: [] };
+  if (event.type === 'audio-ready' && sameGuard(state, event.guard) && state.phase === 'audio-start-pending' && state.onCommandId === null) {
+    const next = { ...state, localAudio: 'streaming' as const, onCommandId: event.commandId, onDispatch: state.pttMarker, mayOwnKey: true, txRisk: 'uncertain' as const };
+    return { state: next, effects: [effect('cancel-timers', next), effect('dispatch-on', next, event.commandId), effect('arm-on-timeout', next, event.commandId)] };
+  }
+  if (event.type === 'fail' && sameGuard(state, event.guard)) {
+    if (state.mayOwnKey) return release({ ...state, fault: event.fault }, event.offCommandId);
+    const next = { ...state, phase: 'failed' as const, intent: null, sourceId: null, leaseId: null, generation: state.generation + 1, guard: null, localAudio: 'stopped' as const, fault: event.fault };
+    return { state: next, effects: [effect('cancel-timers', state), effect('stop-local-audio', state)] };
+  }
+  if (event.type === 'on-sent' && sameGuard(state, event.guard) && state.phase === 'audio-start-pending' && state.onCommandId === event.commandId && event.barrier.authorityEpoch === state.authorityEpoch) {
+    const next = { ...state, phase: state.onConfirmed ? 'active' as const : 'key-confirm-pending' as const, onDispatch: event.barrier };
+    return { state: next, effects: [effect('arm-on-timeout', next, event.commandId)] };
+  }
+  if (event.type === 'off-sent') {
+    const off = state.pendingOff;
+    if (!off || off.deliveryEpoch !== null || off.commandId !== event.commandId || off.leaseId !== event.leaseId || off.generation !== event.generation || off.originalEpoch !== event.originalEpoch || event.eventEpoch !== state.authorityEpoch || event.barrier.authorityEpoch !== event.eventEpoch) return { state, effects: [] };
+    const next = { ...state, pendingOff: { ...off, deliveryEpoch: event.eventEpoch, deliveryPttBarrier: event.barrier, deliveryRebound: event.eventEpoch !== off.originalEpoch } };
+    return { state: next, effects: [effect('arm-off-timeout', next, event.commandId)] };
+  }
+  if (event.type === 'epoch' && event.epoch > state.authorityEpoch && event.baseline.authorityEpoch === event.epoch) {
+    const released = state.guard ? release(state, event.offCommandId) : { state, effects: [] };
+    return { state: { ...released.state, authorityEpoch: event.epoch, epochBaseline: event.baseline, pttMarker: event.baseline, modBarrier: released.state.modRestorePending && !released.state.pendingOff ? event.baseline : released.state.modBarrier, radioTx: 'unknown' }, effects: released.effects };
+  }
+  if (event.type === 'authority' && event.epoch === state.authorityEpoch && authoritative(event.ptt) && newer(state.pttMarker, event.ptt)) {
+    let next: TxState = { ...state, pttMarker: event.ptt.marker, radioTx: event.ptt.value ? 'on' : 'off' };
+    if (state.phase === 'audio-start-pending' && !state.mayOwnKey && event.ptt.value) return release(next, event.offCommandId);
+    if (event.ptt.value && state.mayOwnKey) next = { ...next, ...(state.phase === 'key-confirm-pending' ? { phase: 'active' as const } : {}), txRisk: 'confirmed-on', onConfirmed: event.ptt.marker };
+    if (state.phase !== 'releasing' && state.phase !== 'failed' && state.mayOwnKey && !event.ptt.value && state.onConfirmed && newer(state.onConfirmed, event.ptt)) {
+      next = { ...clearLease(next), phase: 'failed', generation: state.generation + 1, txRisk: 'none', modRestorePending: false, fault: 'backend-dekeyed' };
+      return { state: next, effects: [effect('cancel-timers', state), effect('stop-local-audio', state), effect('restore-mod', state, undefined, state.onConfirmed)] };
+    }
+    if ((state.phase === 'releasing' || state.phase === 'failed') && !event.ptt.value && state.modRestorePending) {
+      const barrier = state.pendingOff ? state.pendingOff.deliveryPttBarrier : state.modBarrier;
+      if (barrier && newer(barrier, event.ptt)) return { state: state.phase === 'releasing' ? { ...clearLease(next), phase: 'idle', txRisk: 'none', modRestorePending: false, fault: null } : { ...next, modRestorePending: false }, effects: [effect('cancel-timers', state), effect('restore-mod', state, undefined, barrier)] };
+    }
+    if (state.guard && (!ready(event.eligibility) || !sameTarget(state.leaseTarget, event.eligibility.target))) return release(next, event.offCommandId);
+    return { state: next, effects: [] };
+  }
+  if (event.type === 'authority' && event.epoch === state.authorityEpoch && state.guard && (!ready(event.eligibility) || !sameTarget(state.leaseTarget, event.eligibility.target))) return release(state, event.offCommandId);
+  return { state, effects: [] };
+}


### PR DESCRIPTION
## Summary

- add the pure MOR-1146 TX reducer foundation for source-qualified lease
  ownership, monotonic PTT authority, ON/OFF dispatch obligations,
  target/permit loss, backend de-key, and queued-OFF release correlation
- keep the model unused and I/O-free until the dependency-ordered reducer
  completion and effect-runner slices land
- preserve the full accepted MOR-982 contract through #2057 / MOR-1148 rather
  than compressing correlated timer/command/fault behavior past the 200-line
  safety cap

## Current remediation required

Formal Claude Opus 5 review on the current head identified foundation defects
that must be fixed before PASS: consecutive-lease marker cleanup, latest-PTT
start monotonicity, release risk escalation, and ON dispatch timeout arming.
The updated Linear/GitHub acceptance also requires source-qualified intent and
external-ON preparation handling.

## Scope

- 2 files
- maximum 200 total net lines
- no I/O, timer implementation, transport/audio implementation,
  Svelte/App/component, vendor/provider/profile, protocol, or hardware change

## Validation required

- focused reducer tests including two complete consecutive leases and authority races (20/20 passed)
- `npm run check`
- `npm run lint`
- `git diff --check`
- exact-head CI
- fresh independent Claude Opus 5 max `Agent Review: PASS`

Prior BLOCKED comments apply only to their recorded exact heads; no PASS is
claimed for the current head.

Linear: [MOR-1146](https://linear.app/morozsm/issue/MOR-1146/tx-reducer-foundation-lease-authority-dispatch-and-release-correlation)
Program: [MOR-1052](https://linear.app/morozsm/issue/MOR-1052/program-deliver-the-pure-tx-reducer-and-adversarial-proof)
Next production slice: [MOR-1148](https://linear.app/morozsm/issue/MOR-1148/tx-reducer-add-correlated-command-timer-and-fault-completion) / #2057

No hardware evidence is claimed.

Closes #2054
