### PR TITLE
MOR-1148: complete TX reducer timer and fault correlation

### DIFF
--- a/frontend/src/lib/runtime/tx-controller/__tests__/model.test.ts
+++ b/frontend/src/lib/runtime/tx-controller/__tests__/model.test.ts
@@ -156,6 +156,7 @@ describe('TX reducer', () => {
   it('preserves empty command IDs through ON and OFF correlation paths', () => {
     const pending = start(); const guard = pending.state.guard!; const dispatched = transition(pending.state, { type: 'audio-ready', guard, commandId: '' });
     expect(dispatched.effects.filter((item) => item.type === 'dispatch-on' || item.type === 'arm-on-timeout').map((item) => item.commandId)).toEqual(['', '']);
+    const legacyEmpty = transition(dispatched.state, { type: 'on-sent', guard, commandId: '', barrier: marker(2) }); expect(legacyEmpty.state.phase).toBe('key-confirm-pending'); expect(legacyEmpty.effects[0]?.commandId).toBe('');
     const onSentEvent = { type: 'command-result' as const, command: 'on' as const, outcome: 'sent' as const, barrier: marker(2), ...correlation(dispatched.state, ''), offCommandId: '' }; const sent = transition(dispatched.state, onSentEvent);
     expect(sent.state.phase).toBe('key-confirm-pending'); expect(sent.effects[0]?.commandId).toBe('');
     const onError = transition(dispatched.state, { ...onSentEvent, outcome: 'response-error', barrier: null }); expect(onError.state.pendingOff?.commandId).toBe(''); expect(onError.effects.filter((item) => item.type === 'dispatch-off' || item.type === 'arm-off-timeout').map((item) => item.commandId)).toEqual(['', '']);
@@ -167,8 +168,10 @@ describe('TX reducer', () => {
     expect(transition(released.state, { ...offSentEvent, outcome: 'response-error', barrier: null }).state.fault).toBe('release-not-confirmed'); expect(transition(delivered.state, { ...timerEvent(delivered.state, 'off-confirmation', ''), offCommandId: '' }).state.fault).toBe('release-not-confirmed');
   });
   it('rejects malformed runtime command IDs before state mutation', () => {
+    const preDispatch = start(); for (const commandId of ['', 'wrong']) expect(transition(preDispatch.state, { type: 'on-sent', guard: preDispatch.state.guard!, commandId, barrier: marker(2) })).toEqual({ state: preDispatch.state, effects: [] });
     for (const invalid of [null, 42] as const) {
       const pending = start(); const badAudio = { type: 'audio-ready', guard: pending.state.guard!, commandId: invalid } as unknown as TxEvent; expect(transition(pending.state, badAudio)).toEqual({ state: pending.state, effects: [] }); expect(pending.state.mayOwnKey).toBe(false);
+      const badOnSent = { type: 'on-sent', guard: pending.state.guard!, commandId: invalid, barrier: marker(2) } as unknown as TxEvent; expect(transition(pending.state, badOnSent)).toEqual({ state: pending.state, effects: [] });
       const keyed = active(); const badRelease = { type: 'release', guard: keyed.guard!, commandId: invalid } as unknown as TxEvent; expect(transition(keyed, badRelease)).toEqual({ state: keyed, effects: [] }); expect(keyed.pendingOff).toBeNull();
       const dispatched = transition(pending.state, { type: 'audio-ready', guard: pending.state.guard!, commandId: 'on' }); const base = correlation(dispatched.state, 'on');
       const malformed = [
@@ -180,6 +183,7 @@ describe('TX reducer', () => {
       ] as unknown as TxEvent[];
       for (const event of malformed) expect(transition(dispatched.state, event)).toEqual({ state: dispatched.state, effects: [] });
     }
+    const normal = start(); const normalGuard = normal.state.guard!; const normalDispatched = transition(normal.state, { type: 'audio-ready', guard: normalGuard, commandId: 'on' }); expect(transition(normalDispatched.state, { type: 'on-sent', guard: normalGuard, commandId: 'on', barrier: marker(2) }).state.phase).toBe('key-confirm-pending');
   });
   it('rejects stale identity on every timer family', () => {
     const audio = start(); const guard = audio.state.guard!; const dispatched = transition(audio.state, { type: 'audio-ready', guard, commandId: 'on' }); const keyed = active(); const released = transition(keyed, { type: 'release', guard: keyed.guard!, commandId: 'off' });

--- a/frontend/src/lib/runtime/tx-controller/__tests__/model.test.ts
+++ b/frontend/src/lib/runtime/tx-controller/__tests__/model.test.ts
@@ -6,6 +6,8 @@ const eligible: Eligibility = { catPtt: true, browserTxAudio: true, controlLive:
 const ptt = (value: boolean, seq: number, epoch = 1): PttObservation => ({ value, observed: true, fresh: true, source: 'radio-readback', marker: marker(seq, epoch) });
 const start = (state = initialTxState(1, marker(1)), overrides = {}) => transition(state, { type: 'start', sourceId: 'desktop', leaseId: 'lease', intent: 'momentary', eligibility: eligible, ptt: ptt(false, 2), ...overrides });
 const types = (result: ReturnType<typeof transition>) => result.effects.map((effect) => effect.type);
+const correlation = <const T extends string | null>(state: TxState, commandId: T) => ({ commandId, leaseId: state.guard!.leaseId, generation: state.guard!.generation, originalEpoch: state.guard!.authorityEpoch, eventEpoch: state.authorityEpoch, offCommandId: 'off' });
+const timerEvent = (state: TxState, timer: 'audio-start' | 'on-confirmation' | 'off-confirmation', commandId: string | null) => ({ type: 'timer-fired' as const, timer, armRevision: timer === 'audio-start' ? state.timerRevision.audio : timer === 'on-confirmation' ? state.timerRevision.on : state.timerRevision.off, ...correlation(state, commandId) });
 function active(): TxState {
   let result = start(); const guard = result.state.guard!; result = transition(result.state, { type: 'intent', sourceId: 'desktop', guard, intent: 'latched' }); expect(result.state.intent).toBe('latched');
   result = transition(result.state, { type: 'audio-ready', guard, commandId: 'on' }); result = transition(result.state, { type: 'on-sent', guard, commandId: 'on', barrier: marker(2) }); expect(result.state.phase).toBe('key-confirm-pending'); return transition(result.state, { type: 'authority', epoch: 1, ptt: ptt(true, 3), eligibility: eligible, offCommandId: 'off' }).state;
@@ -82,5 +84,110 @@ describe('TX reducer', () => {
     const dekeyed = transition(active(), { type: 'authority', epoch: 1, ptt: ptt(false, 4), eligibility: eligible, offCommandId: 'off' }); const recovered = transition(dekeyed.state, { type: 'reset-fault' }); expect(recovered.state).toMatchObject({ phase: 'idle', fault: null, radioTx: 'off', onCommandId: null }); expect(start(recovered.state, { ptt: ptt(false, 5) }).state.phase).toBe('audio-start-pending');
     const pending = start(); const failed = transition(pending.state, { type: 'fail', guard: pending.state.guard!, fault: 'audio-failed', offCommandId: 'off' }); expect(transition(failed.state, { type: 'reset-fault' })).toEqual({ state: failed.state, effects: [] });
     const keyed = active(); const released = transition(keyed, { type: 'release', guard: keyed.guard!, commandId: 'off' }); expect(transition(released.state, { type: 'reset-fault' })).toEqual({ state: released.state, effects: [] });
+  });
+  it('correlates audio deadlines and performs one local failure cleanup', () => {
+    const pending = start(); const timer = timerEvent(pending.state, 'audio-start', null);
+    const stale = transition(pending.state, { ...timer, generation: timer.generation + 1 }); expect(stale).toEqual({ state: pending.state, effects: [] });
+    const failed = transition(pending.state, timer);
+    expect(failed.state).toMatchObject({ phase: 'failed', fault: 'audio-timeout', mayOwnKey: false, modRestorePending: true, pendingOff: null });
+    expect(types(failed)).toEqual(['cancel-timers', 'stop-local-audio']); expect(transition(failed.state, timer)).toEqual({ state: failed.state, effects: [] });
+    expect(types(transition(failed.state, { type: 'audio-ready', guard: pending.state.guard!, commandId: 'late-on' }))).not.toContain('dispatch-on');
+    const audioFailed = transition(pending.state, { type: 'fail', guard: pending.state.guard!, fault: 'audio-failed', offCommandId: 'off' }); expect(audioFailed.state.fault).toBe('audio-failed'); expect(types(audioFailed)).not.toContain('dispatch-off');
+  });
+  it('correlates ON command results and errors without RF truth or retry', () => {
+    const pending = start(); const guard = pending.state.guard!; const dispatched = transition(pending.state, { type: 'audio-ready', guard, commandId: 'on' });
+    const premature = { type: 'command-result', command: 'on', outcome: 'sent', barrier: marker(2), ...correlation(pending.state, null) } as unknown as TxEvent;
+    expect(transition(pending.state, premature)).toEqual({ state: pending.state, effects: [] });
+    const base = correlation(dispatched.state, 'on'); const sentEvent = { type: 'command-result' as const, command: 'on' as const, outcome: 'sent' as const, barrier: marker(2), ...base };
+    for (const outcome of ['ack', 'response-ok'] as const) expect(transition(dispatched.state, { ...sentEvent, outcome, barrier: null })).toEqual({ state: dispatched.state, effects: [] });
+    for (const patch of [{ command: 'off' as const }, { commandId: 'wrong' }, { leaseId: 'wrong' }, { generation: base.generation + 1 }, { originalEpoch: 2 }, { eventEpoch: 2 }, { barrier: marker(2, 2) }]) expect(transition(dispatched.state, { ...sentEvent, ...patch })).toEqual({ state: dispatched.state, effects: [] });
+    const sent = transition(dispatched.state, sentEvent); expect(sent.state).toMatchObject({ phase: 'key-confirm-pending', radioTx: 'off', onConfirmed: null }); expect(types(sent)).toEqual(['arm-on-timeout']); expect(sent.effects[0]?.armRevision).toBe(sent.state.timerRevision.on);
+    expect(transition(sent.state, sentEvent)).toEqual({ state: sent.state, effects: [] });
+    for (const outcome of ['response-error', 'transport-error'] as const) {
+      const failed = transition(dispatched.state, { ...sentEvent, outcome, barrier: null }); expect(failed.state).toMatchObject({ phase: 'releasing', fault: 'on-command-failed', radioTx: 'off', onConfirmed: null, pendingOff: { commandId: 'off' } });
+      expect(types(failed).filter((type) => type === 'dispatch-off')).toEqual(['dispatch-off']); expect(transition(failed.state, { ...sentEvent, outcome, barrier: null })).toEqual({ state: failed.state, effects: [] });
+    }
+    const timer = timerEvent(dispatched.state, 'on-confirmation', 'on'); const timed = transition(dispatched.state, timer); expect(timed.state).toMatchObject({ phase: 'releasing', fault: 'on-timeout' }); expect(types(timed)).not.toContain('dispatch-on'); expect(transition(timed.state, timer)).toEqual({ state: timed.state, effects: [] });
+    const timedAfterSent = transition(sent.state, timer); expect(timedAfterSent).toEqual({ state: sent.state, effects: [] }); expect(transition(sent.state, timerEvent(sent.state, 'on-confirmation', 'on')).state.fault).toBe('on-timeout');
+  });
+  it('preserves failed OFF obligations for errors and exact deadlines', () => {
+    const keyed = active(); const released = transition(keyed, { type: 'release', guard: keyed.guard!, commandId: 'off' }); const base = correlation(released.state, 'off');
+    const dispatchTimer = timerEvent(released.state, 'off-confirmation', 'off');
+    const sentEvent = { type: 'command-result' as const, command: 'off' as const, outcome: 'sent' as const, barrier: marker(4), ...base };
+    for (const outcome of ['ack', 'response-ok'] as const) expect(transition(released.state, { ...sentEvent, outcome, barrier: null })).toEqual({ state: released.state, effects: [] });
+    for (const patch of [{ command: 'on' as const }, { commandId: 'wrong' }, { leaseId: 'wrong' }, { generation: base.generation + 1 }, { originalEpoch: 2 }, { eventEpoch: 2 }, { barrier: marker(4, 2) }]) expect(transition(released.state, { ...sentEvent, ...patch })).toEqual({ state: released.state, effects: [] });
+    const delivered = transition(released.state, sentEvent); expect(delivered.state.pendingOff).toMatchObject({ deliveryEpoch: 1, deliveryPttBarrier: marker(4) }); expect(delivered.effects[0]?.armRevision).toBe(delivered.state.timerRevision.off); expect(transition(delivered.state, dispatchTimer)).toEqual({ state: delivered.state, effects: [] });
+    for (const trigger of [
+      { type: 'command-result' as const, command: 'off' as const, outcome: 'response-error' as const, barrier: null, ...base },
+      { type: 'command-result' as const, command: 'off' as const, outcome: 'transport-error' as const, barrier: null, ...base },
+      timerEvent(delivered.state, 'off-confirmation', 'off'),
+    ]) {
+      const failed = transition(delivered.state, trigger); expect(failed.state).toMatchObject({ phase: 'failed', fault: 'release-not-confirmed', pendingOff: delivered.state.pendingOff, mayOwnKey: true, modRestorePending: true });
+      expect(types(failed)).not.toContain('dispatch-off'); expect(transition(failed.state, trigger)).toEqual({ state: failed.state, effects: [] });
+    }
+    const failedBeforeSent = transition(released.state, { ...sentEvent, outcome: 'response-error', barrier: null }); const lateSent = transition(failedBeforeSent.state, sentEvent); expect(lateSent.state.pendingOff?.deliveryPttBarrier).toEqual(marker(4));
+  });
+  it('discharges failed release only from qualifying authoritative OFF', () => {
+    const keyed = active(); const released = transition(keyed, { type: 'release', guard: keyed.guard!, commandId: 'off' }); const base = correlation(released.state, 'off');
+    const delivered = transition(released.state, { type: 'command-result', command: 'off', outcome: 'sent', barrier: marker(4), ...base });
+    const failed = transition(delivered.state, timerEvent(delivered.state, 'off-confirmation', 'off'));
+    expect(transition(failed.state, { type: 'reset-fault' })).toEqual({ state: failed.state, effects: [] });
+    const cached = transition(failed.state, { type: 'authority', epoch: 1, ptt: ptt(false, 4), eligibility: eligible, offCommandId: 'off' }); expect(cached.state.pendingOff).not.toBeNull(); expect(types(cached)).toEqual([]);
+    const other = transition(cached.state, { type: 'authority', epoch: 1, ptt: { ...ptt(false, 5), source: 'other' }, eligibility: eligible, offCommandId: 'off' }); expect(other).toEqual({ state: cached.state, effects: [] });
+    const wrongEpoch = transition(cached.state, { type: 'authority', epoch: 2, ptt: ptt(false, 5, 2), eligibility: eligible, offCommandId: 'off' }); expect(wrongEpoch).toEqual({ state: cached.state, effects: [] });
+    const discharged = transition(cached.state, { type: 'authority', epoch: 1, ptt: ptt(false, 5), eligibility: eligible, offCommandId: 'off' });
+    expect(discharged.state).toMatchObject({ phase: 'failed', fault: 'release-not-confirmed', pendingOff: null, mayOwnKey: false, modRestorePending: false, txRisk: 'none' }); expect(types(discharged)).toEqual(['cancel-timers', 'restore-mod']); expect(discharged.effects.every((item) => item.guard?.generation === released.state.cleanupGuard!.generation)).toBe(true);
+    expect(transition(discharged.state, { type: 'authority', epoch: 1, ptt: ptt(false, 5), eligibility: eligible, offCommandId: 'off' })).toEqual({ state: discharged.state, effects: [] });
+    expect(transition(discharged.state, { type: 'reset-fault' }).state.phase).toBe('idle');
+  });
+  it('normalizes cleanup guards across generation invalidation', () => {
+    for (const route of ['audio-failed', 'audio-timeout'] as const) {
+      const pending = start(); const cleanupGuard = pending.state.cleanupGuard!;
+      const failed = route === 'audio-failed' ? transition(pending.state, { type: 'fail', guard: pending.state.guard!, fault: route, offCommandId: 'off' }) : transition(pending.state, timerEvent(pending.state, 'audio-start', null));
+      expect(failed.state).toMatchObject({ phase: 'failed', guard: null, cleanupGuard, modRestorePending: true }); expect(failed.effects.every((item) => item.guard === cleanupGuard)).toBe(true); expect(transition(failed.state, { type: 'reset-fault' })).toEqual({ state: failed.state, effects: [] });
+      const opened = transition(failed.state, { type: 'epoch', epoch: 2, baseline: marker(1, 2), offCommandId: 'off' }); expect(opened.state).toMatchObject({ cleanupGuard, modBarrier: marker(1, 2) });
+      const authority = { type: 'authority' as const, epoch: 2, ptt: ptt(false, 2, 2), eligibility: eligible, offCommandId: 'off' }; const discharged = transition(opened.state, authority);
+      expect(discharged.state).toMatchObject({ phase: 'failed', cleanupGuard: null, modRestorePending: false }); expect(discharged.effects.every((item) => item.guard === cleanupGuard)).toBe(true); expect(transition(discharged.state, authority)).toEqual({ state: discharged.state, effects: [] }); expect(transition(discharged.state, { type: 'reset-fault' }).state.phase).toBe('idle');
+    }
+    const keyed = active(); const released = transition(keyed, { type: 'release', guard: keyed.guard!, commandId: 'off' });
+    expect(released.effects.filter((item) => item.type === 'cancel-timers' || item.type === 'stop-local-audio').every((item) => item.guard?.generation === keyed.guard!.generation)).toBe(true);
+    expect(released.effects.filter((item) => item.type === 'dispatch-off' || item.type === 'arm-off-timeout').every((item) => item.guard?.generation === released.state.guard!.generation)).toBe(true);
+  });
+  it('preserves empty command IDs through ON and OFF correlation paths', () => {
+    const pending = start(); const guard = pending.state.guard!; const dispatched = transition(pending.state, { type: 'audio-ready', guard, commandId: '' });
+    expect(dispatched.effects.filter((item) => item.type === 'dispatch-on' || item.type === 'arm-on-timeout').map((item) => item.commandId)).toEqual(['', '']);
+    const onSentEvent = { type: 'command-result' as const, command: 'on' as const, outcome: 'sent' as const, barrier: marker(2), ...correlation(dispatched.state, ''), offCommandId: '' }; const sent = transition(dispatched.state, onSentEvent);
+    expect(sent.state.phase).toBe('key-confirm-pending'); expect(sent.effects[0]?.commandId).toBe('');
+    const onError = transition(dispatched.state, { ...onSentEvent, outcome: 'response-error', barrier: null }); expect(onError.state.pendingOff?.commandId).toBe(''); expect(onError.effects.filter((item) => item.type === 'dispatch-off' || item.type === 'arm-off-timeout').map((item) => item.commandId)).toEqual(['', '']);
+    const onTimed = transition(sent.state, { ...timerEvent(sent.state, 'on-confirmation', ''), offCommandId: '' }); expect(onTimed.state.pendingOff?.commandId).toBe('');
+    const keyed = active(); const released = transition(keyed, { type: 'release', guard: keyed.guard!, commandId: '' });
+    expect(released.effects.filter((item) => item.type === 'dispatch-off' || item.type === 'arm-off-timeout').map((item) => item.commandId)).toEqual(['', '']);
+    const offSentEvent = { type: 'command-result' as const, command: 'off' as const, outcome: 'sent' as const, barrier: marker(4), ...correlation(released.state, ''), offCommandId: '' }; const delivered = transition(released.state, offSentEvent);
+    expect(delivered.state.pendingOff?.deliveryPttBarrier).toEqual(marker(4)); expect(delivered.effects[0]?.commandId).toBe('');
+    expect(transition(released.state, { ...offSentEvent, outcome: 'response-error', barrier: null }).state.fault).toBe('release-not-confirmed'); expect(transition(delivered.state, { ...timerEvent(delivered.state, 'off-confirmation', ''), offCommandId: '' }).state.fault).toBe('release-not-confirmed');
+  });
+  it('rejects malformed runtime command IDs before state mutation', () => {
+    for (const invalid of [null, 42] as const) {
+      const pending = start(); const badAudio = { type: 'audio-ready', guard: pending.state.guard!, commandId: invalid } as unknown as TxEvent; expect(transition(pending.state, badAudio)).toEqual({ state: pending.state, effects: [] }); expect(pending.state.mayOwnKey).toBe(false);
+      const keyed = active(); const badRelease = { type: 'release', guard: keyed.guard!, commandId: invalid } as unknown as TxEvent; expect(transition(keyed, badRelease)).toEqual({ state: keyed, effects: [] }); expect(keyed.pendingOff).toBeNull();
+      const dispatched = transition(pending.state, { type: 'audio-ready', guard: pending.state.guard!, commandId: 'on' }); const base = correlation(dispatched.state, 'on');
+      const malformed = [
+        { type: 'fail', guard: dispatched.state.guard!, fault: 'audio-failed', offCommandId: invalid },
+        { ...timerEvent(dispatched.state, 'on-confirmation', 'on'), offCommandId: invalid },
+        { type: 'command-result', command: 'on', outcome: 'response-error', barrier: null, ...base, offCommandId: invalid },
+        { type: 'epoch', epoch: 2, baseline: marker(1, 2), offCommandId: invalid },
+        { type: 'authority', epoch: 1, ptt: ptt(false, 3), eligibility: { ...eligible, controlLive: false }, offCommandId: invalid },
+      ] as unknown as TxEvent[];
+      for (const event of malformed) expect(transition(dispatched.state, event)).toEqual({ state: dispatched.state, effects: [] });
+    }
+  });
+  it('rejects stale identity on every timer family', () => {
+    const audio = start(); const guard = audio.state.guard!; const dispatched = transition(audio.state, { type: 'audio-ready', guard, commandId: 'on' }); const keyed = active(); const released = transition(keyed, { type: 'release', guard: keyed.guard!, commandId: 'off' });
+    const timers = [
+      [audio.state, timerEvent(audio.state, 'audio-start', null)],
+      [dispatched.state, timerEvent(dispatched.state, 'on-confirmation', 'on')],
+      [released.state, timerEvent(released.state, 'off-confirmation', 'off')],
+    ] as const;
+    for (const [state, timer] of timers) for (const patch of [{ leaseId: 'wrong' }, { generation: timer.generation + 1 }, { originalEpoch: 2 }, { eventEpoch: 2 }, { commandId: 'wrong' }]) expect(transition(state, { ...timer, ...patch })).toEqual({ state, effects: [] });
   });
 });

--- a/frontend/src/lib/runtime/tx-controller/model.ts
+++ b/frontend/src/lib/runtime/tx-controller/model.ts
@@ -6,15 +6,18 @@ export type PttObservation = { value: boolean; observed: boolean; fresh: boolean
 export type Eligibility = { catPtt: boolean; browserTxAudio: boolean; controlLive: boolean; permit: 'allowed' | 'denied' | 'unknown'; target: TxTarget };
 export type TxGuard = { leaseId: string; generation: number; authorityEpoch: number };
 export type PendingOff = { commandId: string; leaseId: string; generation: number; originalEpoch: number; deliveryEpoch: number | null; deliveryPttBarrier: PttMarker | null; deliveryRebound: boolean };
-export type TxFault = 'not-eligible' | 'audio-failed' | 'ptt-on-rejected' | 'backend-dekeyed' | null;
+export type TxFault = 'not-eligible' | 'audio-failed' | 'audio-timeout' | 'ptt-on-rejected' | 'on-command-failed' | 'on-timeout' | 'release-not-confirmed' | 'backend-dekeyed' | null;
 export interface TxState {
   phase: TxPhase; intent: TxIntent; sourceId: string | null; leaseId: string | null; generation: number; guard: TxGuard | null;
+  cleanupGuard: TxGuard | null; timerRevision: { audio: number; on: number; off: number };
   authorityEpoch: number; epochBaseline: PttMarker; pttMarker: PttMarker; leaseTarget: TxTarget;
   startPttBaseline: PttMarker | null; modBarrier: PttMarker | null; onCommandId: string | null; onDispatch: PttMarker | null; onConfirmed: PttMarker | null;
   localAudio: 'stopped' | 'starting' | 'streaming'; radioTx: 'off' | 'on' | 'unknown'; txRisk: 'none' | 'uncertain' | 'confirmed-on';
   mayOwnKey: boolean; modRestorePending: boolean; pendingOff: PendingOff | null; fault: TxFault; }
 export type TxEffectType = 'start-audio' | 'dispatch-on' | 'dispatch-off' | 'stop-local-audio' | 'restore-mod' | 'arm-audio-timeout' | 'arm-on-timeout' | 'arm-off-timeout' | 'cancel-timers';
-export type TxEffect = { type: TxEffectType; guard?: TxGuard; commandId?: string; barrier?: PttMarker };
+export type TxEffect = { type: TxEffectType; guard?: TxGuard; commandId?: string; barrier?: PttMarker; armRevision?: number };
+export type TxCorrelation = { leaseId: string; generation: number; originalEpoch: number; eventEpoch: number; offCommandId: string };
+type TxCommandIdentity = TxCorrelation & { commandId: string | null };
 export type TxEvent =
   | { type: 'start'; sourceId: string; leaseId: string; intent: Exclude<TxIntent, null>; eligibility: Eligibility; ptt: PttObservation }
   | { type: 'intent'; sourceId: string; guard: TxGuard; intent: Exclude<TxIntent, null> }
@@ -24,11 +27,13 @@ export type TxEvent =
   | { type: 'release'; sourceId?: string; guard: TxGuard; commandId: string }
   | { type: 'off-sent'; commandId: string; leaseId: string; generation: number; originalEpoch: number; eventEpoch: number; barrier: PttMarker }
   | { type: 'authority'; epoch: number; ptt: PttObservation; eligibility: Eligibility; offCommandId: string }
+  | ({ type: 'timer-fired'; timer: 'audio-start' | 'on-confirmation' | 'off-confirmation'; commandId: string | null; armRevision: number } & TxCorrelation)
+  | ({ type: 'command-result'; command: 'on' | 'off'; outcome: 'sent' | 'ack' | 'response-ok' | 'response-error' | 'transport-error'; commandId: string; barrier: PttMarker | null } & TxCorrelation)
   | { type: 'reset-fault' }
   | { type: 'epoch'; epoch: number; baseline: PttMarker; offCommandId: string };
 export type TxTransition = { state: TxState; effects: TxEffect[] };
 export function initialTxState(authorityEpoch: number, baseline: PttMarker): TxState {
-  return { phase: 'idle', intent: null, sourceId: null, leaseId: null, generation: 0, guard: null, authorityEpoch, epochBaseline: baseline, pttMarker: baseline, leaseTarget: null, startPttBaseline: null, modBarrier: null, onCommandId: null, onDispatch: null, onConfirmed: null, localAudio: 'stopped', radioTx: 'unknown', txRisk: 'none', mayOwnKey: false, modRestorePending: false, pendingOff: null, fault: null };
+  return { phase: 'idle', intent: null, sourceId: null, leaseId: null, generation: 0, guard: null, cleanupGuard: null, timerRevision: { audio: 0, on: 0, off: 0 }, authorityEpoch, epochBaseline: baseline, pttMarker: baseline, leaseTarget: null, startPttBaseline: null, modBarrier: null, onCommandId: null, onDispatch: null, onConfirmed: null, localAudio: 'stopped', radioTx: 'unknown', txRisk: 'none', mayOwnKey: false, modRestorePending: false, pendingOff: null, fault: null };
 }
 const sameGuard = (state: TxState, guard: TxGuard) => state.guard?.leaseId === guard.leaseId && state.guard.generation === guard.generation && state.guard.authorityEpoch === guard.authorityEpoch;
 const sameTarget = (a: TxTarget, b: TxTarget) => a !== null && b !== null && a.receiver === b.receiver && a.slot === b.slot && a.frequencyHz === b.frequencyHz;
@@ -40,55 +45,93 @@ const newer = (barrier: PttMarker, observation: PttObservation) => {
 };
 const authoritative = (observation: PttObservation) => observation.observed && observation.fresh && (observation.source === 'radio-readback' || observation.source === 'backend-observation');
 const ready = (eligibility: Eligibility) => eligibility.catPtt && eligibility.browserTxAudio && eligibility.controlLive && eligibility.permit === 'allowed' && eligibility.target !== null;
-const effect = (type: TxEffectType, state: TxState, commandId?: string, barrier?: PttMarker): TxEffect => ({ type, ...(state.guard ? { guard: state.guard } : {}), ...(commandId ? { commandId } : {}), ...(barrier ? { barrier } : {}) });
-const clearLease = (state: TxState): TxState => ({ ...state, intent: null, sourceId: null, leaseId: null, guard: null, leaseTarget: null, startPttBaseline: null, modBarrier: null, onCommandId: null, onDispatch: null, onConfirmed: null, localAudio: 'stopped', mayOwnKey: false, pendingOff: null });
+const effect = (type: TxEffectType, state: TxState, commandId?: string, barrier?: PttMarker, guard: TxGuard | null = state.guard): TxEffect => ({ type, ...(guard ? { guard } : {}), ...(commandId !== undefined ? { commandId } : {}), ...(barrier ? { barrier } : {}) });
+const armEffect = (type: 'arm-audio-timeout' | 'arm-on-timeout' | 'arm-off-timeout', state: TxState, armRevision: number, commandId?: string, barrier?: PttMarker): TxEffect => ({ ...effect(type, state, commandId, barrier), armRevision });
+const clearLease = (state: TxState): TxState => ({ ...state, intent: null, sourceId: null, leaseId: null, guard: null, cleanupGuard: null, timerRevision: { audio: 0, on: 0, off: 0 }, leaseTarget: null, startPttBaseline: null, modBarrier: null, onCommandId: null, onDispatch: null, onConfirmed: null, localAudio: 'stopped', mayOwnKey: false, pendingOff: null });
+const matchesCurrent = (state: TxState, event: TxCorrelation) => state.guard?.leaseId === event.leaseId && state.guard.generation === event.generation && state.guard.authorityEpoch === event.originalEpoch && state.authorityEpoch === event.eventEpoch;
+const matchesOff = (state: TxState, event: TxCommandIdentity) => state.pendingOff?.commandId === event.commandId && event.offCommandId === event.commandId && state.pendingOff.leaseId === event.leaseId && state.pendingOff.generation === event.generation && state.pendingOff.originalEpoch === event.originalEpoch && state.authorityEpoch === event.eventEpoch;
+
+function failLocal(state: TxState, fault: 'audio-failed' | 'audio-timeout' | 'ptt-on-rejected'): TxTransition {
+  const cleanupGuard = state.cleanupGuard ?? state.guard;
+  const next = { ...state, phase: 'failed' as const, intent: null, sourceId: null, leaseId: null, generation: state.generation + 1, guard: null, timerRevision: { audio: state.timerRevision.audio + 1, on: state.timerRevision.on + 1, off: state.timerRevision.off + 1 }, localAudio: 'stopped' as const, fault };
+  return { state: next, effects: [effect('cancel-timers', state, undefined, undefined, cleanupGuard), effect('stop-local-audio', state, undefined, undefined, cleanupGuard)] };
+}
+function failRelease(state: TxState): TxTransition {
+  const next = { ...state, phase: 'failed' as const, timerRevision: { ...state.timerRevision, off: state.timerRevision.off + 1 }, fault: 'release-not-confirmed' as const };
+  return { state: next, effects: [effect('cancel-timers', state)] };
+}
+function bindOn(state: TxState, commandId: string, barrier: PttMarker): TxTransition {
+  const next = { ...state, phase: state.onConfirmed ? 'active' as const : 'key-confirm-pending' as const, onDispatch: barrier, timerRevision: { ...state.timerRevision, on: state.timerRevision.on + 1 } };
+  return { state: next, effects: [armEffect('arm-on-timeout', next, next.timerRevision.on, commandId)] };
+}
+function bindOff(state: TxState, event: TxCommandIdentity, barrier: PttMarker): TxTransition {
+  const off = state.pendingOff!;
+  const next = { ...state, pendingOff: { ...off, deliveryEpoch: event.eventEpoch, deliveryPttBarrier: barrier, deliveryRebound: event.eventEpoch !== off.originalEpoch }, timerRevision: { ...state.timerRevision, off: state.timerRevision.off + 1 } };
+  return { state: next, effects: [armEffect('arm-off-timeout', next, next.timerRevision.off, off.commandId)] };
+}
 
 function release(state: TxState, commandId: string): TxTransition {
   if (!state.guard || state.phase === 'releasing' || state.pendingOff) return { state, effects: [] };
   const generation = state.generation + 1;
   const guard = { ...state.guard, generation };
-  const next = { ...state, phase: 'releasing' as const, intent: null, generation, guard, localAudio: 'stopped' as const };
-  const effects = [effect('cancel-timers', next)];
+  const cleanupGuard = state.cleanupGuard ?? state.guard;
+  const next: TxState = { ...state, phase: 'releasing', intent: null, generation, guard, cleanupGuard, timerRevision: { audio: state.timerRevision.audio + 1, on: state.timerRevision.on + 1, off: state.timerRevision.off + (state.mayOwnKey ? 1 : 0) }, localAudio: 'stopped' };
+  const effects = [effect('cancel-timers', next, undefined, undefined, cleanupGuard)];
   if (state.mayOwnKey) {
     next.pendingOff = { commandId, leaseId: guard.leaseId, generation, originalEpoch: state.authorityEpoch, deliveryEpoch: null, deliveryPttBarrier: null, deliveryRebound: false };
     next.txRisk = state.radioTx === 'on' ? 'confirmed-on' : 'uncertain';
-    effects.push(effect('dispatch-off', next, commandId), effect('arm-off-timeout', next, commandId));
+    effects.push(effect('dispatch-off', next, commandId), armEffect('arm-off-timeout', next, next.timerRevision.off, commandId));
   }
-  effects.push(effect('stop-local-audio', next));
+  effects.push(effect('stop-local-audio', next, undefined, undefined, cleanupGuard));
   return { state: next, effects };
 }
 
 export function transition(state: TxState, event: TxEvent): TxTransition {
+  if (('offCommandId' in event && typeof event.offCommandId !== 'string') || ((event.type === 'audio-ready' || event.type === 'release') && typeof event.commandId !== 'string')) return { state, effects: [] };
   if (event.type === 'start') {
     if (state.phase !== 'idle') return { state, effects: [] };
     const ok = ready(event.eligibility) && event.ptt.value === false && authoritative(event.ptt) && newer(state.pttMarker, event.ptt) && event.ptt.marker.authorityEpoch === state.authorityEpoch;
     if (!ok) return { state: { ...state, phase: 'failed', fault: 'not-eligible', txRisk: 'none', sourceId: null, leaseId: null, guard: null }, effects: [] };
     const generation = state.generation + 1;
     const guard = { leaseId: event.leaseId, generation, authorityEpoch: state.authorityEpoch };
-    const next = { ...clearLease(state), phase: 'audio-start-pending' as const, intent: event.intent, sourceId: event.sourceId, leaseId: event.leaseId, generation, guard, leaseTarget: event.eligibility.target, startPttBaseline: event.ptt.marker, modBarrier: event.ptt.marker, pttMarker: event.ptt.marker, localAudio: 'starting' as const, radioTx: 'off' as const, txRisk: 'none' as const, modRestorePending: true, fault: null };
-    return { state: next, effects: [effect('start-audio', next), effect('arm-audio-timeout', next)] };
+    const next = { ...clearLease(state), phase: 'audio-start-pending' as const, intent: event.intent, sourceId: event.sourceId, leaseId: event.leaseId, generation, guard, cleanupGuard: guard, timerRevision: { audio: 1, on: 0, off: 0 }, leaseTarget: event.eligibility.target, startPttBaseline: event.ptt.marker, modBarrier: event.ptt.marker, pttMarker: event.ptt.marker, localAudio: 'starting' as const, radioTx: 'off' as const, txRisk: 'none' as const, modRestorePending: true, fault: null };
+    return { state: next, effects: [effect('start-audio', next), armEffect('arm-audio-timeout', next, next.timerRevision.audio)] };
   }
   if (event.type === 'intent') return sameGuard(state, event.guard) && event.sourceId === state.sourceId && state.phase !== 'releasing' && state.phase !== 'failed' ? { state: { ...state, intent: event.intent }, effects: [] } : { state, effects: [] };
   if (event.type === 'release') return sameGuard(state, event.guard) && (event.sourceId === undefined || event.sourceId === state.sourceId) ? release(state, event.commandId) : { state, effects: [] };
-  if (event.type === 'reset-fault' && state.phase === 'failed' && !state.pendingOff && !state.modRestorePending && !state.mayOwnKey) return { state: { ...clearLease(state), phase: 'idle', txRisk: 'none', fault: null }, effects: [] };
+  if (event.type === 'reset-fault' && state.phase === 'failed' && !state.pendingOff && !state.modRestorePending && !state.mayOwnKey && !state.cleanupGuard) return { state: { ...clearLease(state), phase: 'idle', txRisk: 'none', fault: null }, effects: [] };
   if (event.type === 'audio-ready' && sameGuard(state, event.guard) && state.phase === 'audio-start-pending' && state.onCommandId === null) {
-    const next = { ...state, localAudio: 'streaming' as const, onCommandId: event.commandId, onDispatch: state.pttMarker, mayOwnKey: true, txRisk: 'uncertain' as const };
-    return { state: next, effects: [effect('cancel-timers', next), effect('dispatch-on', next, event.commandId), effect('arm-on-timeout', next, event.commandId)] };
+    const next = { ...state, localAudio: 'streaming' as const, onCommandId: event.commandId, onDispatch: state.pttMarker, mayOwnKey: true, txRisk: 'uncertain' as const, timerRevision: { ...state.timerRevision, audio: state.timerRevision.audio + 1, on: state.timerRevision.on + 1 } };
+    return { state: next, effects: [effect('cancel-timers', next), effect('dispatch-on', next, event.commandId), armEffect('arm-on-timeout', next, next.timerRevision.on, event.commandId)] };
+  }
+  if (event.type === 'timer-fired') {
+    if (event.timer === 'audio-start' && event.armRevision === state.timerRevision.audio && event.commandId === null && matchesCurrent(state, event) && state.phase === 'audio-start-pending' && state.onCommandId === null) return failLocal(state, 'audio-timeout');
+    if (event.timer === 'on-confirmation' && event.armRevision === state.timerRevision.on && matchesCurrent(state, event) && event.commandId === state.onCommandId && state.mayOwnKey && (state.phase === 'audio-start-pending' || state.phase === 'key-confirm-pending')) return release({ ...state, fault: 'on-timeout' }, event.offCommandId);
+    if (event.timer === 'off-confirmation' && event.armRevision === state.timerRevision.off && matchesOff(state, event) && state.phase === 'releasing') return failRelease(state);
+    return { state, effects: [] };
+  }
+  if (event.type === 'command-result') {
+    if (event.command === 'on' && state.onCommandId !== null && state.mayOwnKey && matchesCurrent(state, event) && event.commandId === state.onCommandId) {
+      if (event.outcome === 'sent' && event.barrier?.authorityEpoch === event.eventEpoch && state.phase === 'audio-start-pending') return bindOn(state, event.commandId, event.barrier);
+      if ((event.outcome === 'response-error' || event.outcome === 'transport-error') && state.mayOwnKey && state.phase !== 'releasing' && state.phase !== 'failed') return release({ ...state, fault: 'on-command-failed' }, event.offCommandId);
+    }
+    if (event.command === 'off' && matchesOff(state, event)) {
+      if (event.outcome === 'sent' && state.pendingOff?.deliveryEpoch === null && event.barrier?.authorityEpoch === event.eventEpoch) return bindOff(state, event, event.barrier);
+      if ((event.outcome === 'response-error' || event.outcome === 'transport-error') && state.phase === 'releasing') return failRelease(state);
+    }
+    return { state, effects: [] };
   }
   if (event.type === 'fail' && sameGuard(state, event.guard)) {
     if (state.mayOwnKey) return release({ ...state, fault: event.fault }, event.offCommandId);
-    const next = { ...state, phase: 'failed' as const, intent: null, sourceId: null, leaseId: null, generation: state.generation + 1, guard: null, localAudio: 'stopped' as const, fault: event.fault };
-    return { state: next, effects: [effect('cancel-timers', state), effect('stop-local-audio', state)] };
+    return failLocal(state, event.fault);
   }
   if (event.type === 'on-sent' && sameGuard(state, event.guard) && state.phase === 'audio-start-pending' && state.onCommandId === event.commandId && event.barrier.authorityEpoch === state.authorityEpoch) {
-    const next = { ...state, phase: state.onConfirmed ? 'active' as const : 'key-confirm-pending' as const, onDispatch: event.barrier };
-    return { state: next, effects: [effect('arm-on-timeout', next, event.commandId)] };
+    return bindOn(state, event.commandId, event.barrier);
   }
   if (event.type === 'off-sent') {
     const off = state.pendingOff;
     if (!off || off.deliveryEpoch !== null || off.commandId !== event.commandId || off.leaseId !== event.leaseId || off.generation !== event.generation || off.originalEpoch !== event.originalEpoch || event.eventEpoch !== state.authorityEpoch || event.barrier.authorityEpoch !== event.eventEpoch) return { state, effects: [] };
-    const next = { ...state, pendingOff: { ...off, deliveryEpoch: event.eventEpoch, deliveryPttBarrier: event.barrier, deliveryRebound: event.eventEpoch !== off.originalEpoch } };
-    return { state: next, effects: [effect('arm-off-timeout', next, event.commandId)] };
+    return bindOff(state, { ...event, offCommandId: event.commandId }, event.barrier);
   }
   if (event.type === 'epoch' && event.epoch > state.authorityEpoch && event.baseline.authorityEpoch === event.epoch) {
     const released = state.guard ? release(state, event.offCommandId) : { state, effects: [] };
@@ -99,12 +142,17 @@ export function transition(state: TxState, event: TxEvent): TxTransition {
     if (state.phase === 'audio-start-pending' && !state.mayOwnKey && event.ptt.value) return release(next, event.offCommandId);
     if (event.ptt.value && state.mayOwnKey) next = { ...next, ...(state.phase === 'key-confirm-pending' ? { phase: 'active' as const } : {}), txRisk: 'confirmed-on', onConfirmed: event.ptt.marker };
     if (state.phase !== 'releasing' && state.phase !== 'failed' && state.mayOwnKey && !event.ptt.value && state.onConfirmed && newer(state.onConfirmed, event.ptt)) {
+      const cleanupGuard = state.cleanupGuard ?? state.guard;
       next = { ...clearLease(next), phase: 'failed', generation: state.generation + 1, txRisk: 'none', modRestorePending: false, fault: 'backend-dekeyed' };
-      return { state: next, effects: [effect('cancel-timers', state), effect('stop-local-audio', state), effect('restore-mod', state, undefined, state.onConfirmed)] };
+      return { state: next, effects: [effect('cancel-timers', state, undefined, undefined, cleanupGuard), effect('stop-local-audio', state, undefined, undefined, cleanupGuard), effect('restore-mod', state, undefined, state.onConfirmed, cleanupGuard)] };
     }
     if ((state.phase === 'releasing' || state.phase === 'failed') && !event.ptt.value && state.modRestorePending) {
       const barrier = state.pendingOff ? state.pendingOff.deliveryPttBarrier : state.modBarrier;
-      if (barrier && newer(barrier, event.ptt)) return { state: state.phase === 'releasing' ? { ...clearLease(next), phase: 'idle', txRisk: 'none', modRestorePending: false, fault: null } : { ...next, modRestorePending: false }, effects: [effect('cancel-timers', state), effect('restore-mod', state, undefined, barrier)] };
+      if (barrier && newer(barrier, event.ptt)) {
+        const cleanupGuard = state.cleanupGuard ?? state.guard;
+        const discharged = state.phase === 'releasing' ? { ...clearLease(next), phase: 'idle' as const, txRisk: 'none' as const, modRestorePending: false, fault: null } : state.fault === 'release-not-confirmed' ? { ...clearLease(next), phase: 'failed' as const, txRisk: 'none' as const, modRestorePending: false, fault: state.fault } : { ...next, cleanupGuard: null, modRestorePending: false };
+        return { state: discharged, effects: [effect('cancel-timers', state, undefined, undefined, cleanupGuard), effect('restore-mod', state, undefined, barrier, cleanupGuard)] };
+      }
     }
     if (state.guard && (!ready(event.eligibility) || !sameTarget(state.leaseTarget, event.eligibility.target))) return release(next, event.offCommandId);
     return { state: next, effects: [] };

--- a/frontend/src/lib/runtime/tx-controller/model.ts
+++ b/frontend/src/lib/runtime/tx-controller/model.ts
@@ -87,7 +87,7 @@ function release(state: TxState, commandId: string): TxTransition {
 }
 
 export function transition(state: TxState, event: TxEvent): TxTransition {
-  if (('offCommandId' in event && typeof event.offCommandId !== 'string') || ((event.type === 'audio-ready' || event.type === 'release') && typeof event.commandId !== 'string')) return { state, effects: [] };
+  if (('offCommandId' in event && typeof event.offCommandId !== 'string') || ((event.type === 'audio-ready' || event.type === 'release' || event.type === 'on-sent') && typeof event.commandId !== 'string')) return { state, effects: [] };
   if (event.type === 'start') {
     if (state.phase !== 'idle') return { state, effects: [] };
     const ok = ready(event.eligibility) && event.ptt.value === false && authoritative(event.ptt) && newer(state.pttMarker, event.ptt) && event.ptt.marker.authorityEpoch === state.authorityEpoch;
@@ -125,7 +125,7 @@ export function transition(state: TxState, event: TxEvent): TxTransition {
     if (state.mayOwnKey) return release({ ...state, fault: event.fault }, event.offCommandId);
     return failLocal(state, event.fault);
   }
-  if (event.type === 'on-sent' && sameGuard(state, event.guard) && state.phase === 'audio-start-pending' && state.onCommandId === event.commandId && event.barrier.authorityEpoch === state.authorityEpoch) {
+  if (event.type === 'on-sent' && state.onCommandId !== null && state.mayOwnKey && sameGuard(state, event.guard) && state.phase === 'audio-start-pending' && state.onCommandId === event.commandId && event.barrier.authorityEpoch === state.authorityEpoch) {
     return bindOn(state, event.commandId, event.barrier);
   }
   if (event.type === 'off-sent') {


### PR DESCRIPTION
Linear control plane: [MOR-1148](https://linear.app/morozsm/issue/MOR-1148/tx-reducer-add-correlated-command-timer-and-fault-completion)

Closes #2057

## Summary

- add lease/generation/authority-qualified audio, ON, and OFF timer events with exact arm revisions
- add exact ON/OFF command-result correlation while keeping ACK/response evidence separate from RF truth
- preserve failed-release ownership, risk, pending OFF, and MOD obligations until authoritative discharge
- retain cleanup correlation after generation invalidation and reject malformed runtime command identities

## Scope

Exactly two files and 155 total net LOC:

- `frontend/src/lib/runtime/tx-controller/model.ts`
- `frontend/src/lib/runtime/tx-controller/__tests__/model.test.ts`

Pure reducer/declarative effects only. No App, transport, audio implementation, capability profile, provider, protocol, or hardware changes.

## Verification

- focused Vitest: 28/28
- `npm run check`: 0 errors, 0 warnings
- lint and boundary lint: pass
- i18n check: pass
- production build: pass (existing chunk warnings only)
- `git diff --check`: clean
- independent bounded verifier: PASS across exact correlation, timer re-arm staleness, cleanup guards, failed-release discharge, no retry, malformed IDs, and MOR-1146 regressions

No hardware evidence was reviewed or claimed. Fresh exact-head Claude Opus 5 max review is required before Ready/merge.