### PR TITLE
MOR-1053: add the TX reducer effect controller

### DIFF
--- a/frontend/src/lib/runtime/tx-controller/__tests__/controller.test.ts
+++ b/frontend/src/lib/runtime/tx-controller/__tests__/controller.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { TxController, type TxControllerDependencies } from '../controller';
+import type { Eligibility, PttMarker, PttObservation, TxEvent } from '../model';
+const marker = (seq: number, epoch = 1): PttMarker => ({ authorityEpoch: epoch, pttObservationSeq: seq, pttLastObservedMonotonic: seq });
+const ptt = (value: boolean, seq: number): PttObservation => ({ value, observed: true, fresh: true, source: 'radio-readback', marker: marker(seq) });
+const eligible: Eligibility = { catPtt: true, browserTxAudio: true, controlLive: true, permit: 'allowed', target: { receiver: 'MAIN', slot: 'A', frequencyHz: 14_074_000 } };
+const start = (): TxEvent => ({ type: 'start', sourceId: 'desktop', leaseId: 'lease', intent: 'momentary', eligibility: eligible, ptt: ptt(false, 1) });
+
+function harness(audio: Promise<string | null> = Promise.resolve(null), failure: 'off' | 'cancel' | 10 | 20 | 30 | null = null) {
+  const log: string[] = []; const reports: Array<{ command: 'on' | 'off'; report: Parameters<TxControllerDependencies['sendPtt']>[3] }> = [];
+  let id = 0;
+  const dependencies: TxControllerDependencies = {
+    startAudio: vi.fn(() => { log.push('audio'); return audio; }),
+    sendPtt: vi.fn((command, _id, _correlation, report) => { log.push(command); reports.push({ command, report }); if (command === 'off' && failure === 'off') throw new Error('closed'); }),
+    stopLocalAudio: vi.fn(() => { log.push('stop'); }), restoreMod: vi.fn(() => { log.push('restore'); }),
+    commandId: vi.fn((command) => `${command}-${++id}`), schedule: vi.fn((callback, delay) => { if (delay === failure) throw new Error('clock'); return setTimeout(callback, delay); }),
+    cancel: vi.fn((handle) => { clearTimeout(handle as ReturnType<typeof setTimeout>); if (failure === 'cancel') throw new Error('cancel'); }),
+    timeoutMs: { 'audio-start': 10, 'on-confirmation': 20, 'off-confirmation': 30 },
+  };
+  return { controller: new TxController(1, marker(0), dependencies), dependencies, log, reports };
+}
+const flush = async () => { await Promise.resolve(); await Promise.resolve(); };
+
+describe('TxController', () => {
+  afterEach(() => vi.useRealTimers());
+
+  it('runs audio before one ON and command acknowledgements never create RF truth', async () => {
+    vi.useFakeTimers(); const h = harness(); h.controller.dispatch(start()); expect(h.log).toEqual(['audio']);
+    await flush(); expect(h.log).toEqual(['audio', 'on']); expect(h.reports.filter((item) => item.command === 'on')).toHaveLength(1);
+    const sent = h.reports[0].report; sent({ outcome: 'sent', eventEpoch: 1, barrier: marker(2) }); sent({ outcome: 'ack', eventEpoch: 1, barrier: null });
+    expect(h.controller.snapshot()).toMatchObject({ phase: 'key-confirm-pending', radioTx: 'off', mayOwnKey: true });
+  });
+
+  it('delivers the exact audio timeout and suppresses its late async completion', async () => {
+    vi.useFakeTimers(); let resolve!: (value: string | null) => void; const h = harness(new Promise((done) => { resolve = done; }));
+    h.controller.dispatch(start()); vi.advanceTimersByTime(10);
+    expect(h.controller.snapshot()).toMatchObject({ phase: 'failed', fault: 'audio-timeout' }); expect(h.log).toEqual(['audio', 'stop']);
+    resolve(null); await flush(); expect(h.log).toEqual(['audio', 'stop']); expect(h.reports).toHaveLength(0);
+  });
+
+  it('delivers correlated ON and OFF deadlines at their exact fake-clock durations', async () => {
+    vi.useFakeTimers(); const h = harness(); h.controller.dispatch(start()); await flush();
+    vi.advanceTimersByTime(20);
+    expect(h.controller.snapshot()).toMatchObject({ phase: 'releasing', fault: 'on-timeout' }); expect(h.log).toEqual(['audio', 'on', 'off', 'stop']);
+    vi.advanceTimersByTime(30);
+    expect(h.controller.snapshot()).toMatchObject({ phase: 'failed', fault: 'release-not-confirmed' });
+  });
+
+  it('coalesces release, attempts OFF before stop, and cleans up after a synchronous send failure', async () => {
+    vi.useFakeTimers(); const h = harness(Promise.resolve(null), 'off'); h.controller.dispatch(start()); await flush();
+    const guard = h.controller.snapshot().guard!; h.controller.dispatch({ type: 'release', guard, commandId: 'off-release' });
+    expect(h.log).toEqual(['audio', 'on', 'off', 'stop']); expect(h.controller.snapshot()).toMatchObject({ phase: 'failed', fault: 'release-not-confirmed' });
+    h.controller.dispatch({ type: 'release', guard: h.controller.snapshot().guard!, commandId: 'off-duplicate' });
+    h.reports.find((item) => item.command === 'on')!.report({ outcome: 'sent', eventEpoch: 1, barrier: marker(2) });
+    expect(h.log.filter((item) => item === 'off')).toHaveLength(1); expect(h.log.filter((item) => item === 'stop')).toHaveLength(1);
+  });
+
+  it('isolates throwing observers and timer cancellation so release still performs OFF then stop', async () => {
+    vi.useFakeTimers(); const cases = [harness(), harness(Promise.resolve(null), 'cancel')]; cases[0].controller.subscribe(() => { throw new Error('observer'); });
+    for (const h of cases) { h.controller.dispatch(start()); await flush(); h.controller.dispatch({ type: 'release', guard: h.controller.snapshot().guard!, commandId: 'off' }); expect(h.log).toEqual(['audio', 'on', 'off', 'stop']); }
+    expect(vi.mocked(cases[1].dependencies.cancel)).toHaveBeenCalled();
+  });
+
+  it('fails closed with exact qualified audio, ON, and OFF events when scheduling throws', async () => {
+    vi.useFakeTimers(); const audio = harness(Promise.resolve(null), 10); audio.controller.dispatch(start()); await flush(); expect(audio.controller.snapshot()).toMatchObject({ phase: 'failed', fault: 'audio-timeout' }); expect(audio.log).toEqual(['audio', 'stop']);
+    const on = harness(Promise.resolve(null), 20); on.controller.dispatch(start()); await flush(); expect(on.controller.snapshot()).toMatchObject({ phase: 'releasing', fault: 'on-timeout' }); expect(on.log).toEqual(['audio', 'on', 'off', 'stop']);
+    on.reports[0].report({ outcome: 'sent', eventEpoch: 1, barrier: marker(2) }); expect(on.log).toEqual(['audio', 'on', 'off', 'stop']);
+    const off = harness(Promise.resolve(null), 30); off.controller.dispatch(start()); await flush(); off.controller.dispatch({ type: 'release', guard: off.controller.snapshot().guard!, commandId: 'off' });
+    expect(off.controller.snapshot()).toMatchObject({ phase: 'failed', fault: 'release-not-confirmed' }); expect(off.log).toEqual(['audio', 'on', 'off', 'stop']);
+  });
+
+  it('never replays ON when a pre-key lease is released before audio completes', async () => {
+    vi.useFakeTimers(); let resolve!: (value: string | null) => void; const h = harness(new Promise((done) => { resolve = done; }));
+    h.controller.dispatch(start()); h.controller.dispatch({ type: 'release', guard: h.controller.snapshot().guard!, commandId: 'off-cancel' });
+    resolve(null); await flush(); vi.runAllTimers();
+    expect(h.log).toEqual(['audio', 'stop']); expect(h.reports).toHaveLength(0); expect(h.controller.snapshot().mayOwnKey).toBe(false);
+  });
+
+  it('restores MOD only from the reducer obligation after post-OFF authority', async () => {
+    vi.useFakeTimers(); const h = harness(); h.controller.dispatch(start()); await flush();
+    h.reports[0].report({ outcome: 'sent', eventEpoch: 1, barrier: marker(2) });
+    h.controller.dispatch({ type: 'authority', epoch: 1, ptt: ptt(true, 3), eligibility: eligible, offCommandId: 'off-a' });
+    h.controller.dispatch({ type: 'release', guard: h.controller.snapshot().guard!, commandId: 'off-a' });
+    h.reports.find((item) => item.command === 'off')!.report({ outcome: 'sent', eventEpoch: 1, barrier: marker(3) });
+    const cancelled = vi.mocked(h.dependencies.cancel).mock.calls.length; h.controller.dispatch({ type: 'authority', epoch: 1, ptt: ptt(false, 4), eligibility: eligible, offCommandId: 'off-a' }); expect(vi.mocked(h.dependencies.cancel).mock.calls).toHaveLength(cancelled + 2); expect(vi.getTimerCount()).toBe(0);
+    h.controller.dispatch({ type: 'authority', epoch: 1, ptt: ptt(false, 5), eligibility: eligible, offCommandId: 'off-a' });
+    expect(h.log.filter((item) => item === 'restore')).toHaveLength(1); expect(h.controller.snapshot().phase).toBe('idle');
+  });
+});

--- a/frontend/src/lib/runtime/tx-controller/__tests__/controller.test.ts
+++ b/frontend/src/lib/runtime/tx-controller/__tests__/controller.test.ts
@@ -5,47 +5,39 @@ const marker = (seq: number, epoch = 1): PttMarker => ({ authorityEpoch: epoch, 
 const ptt = (value: boolean, seq: number): PttObservation => ({ value, observed: true, fresh: true, source: 'radio-readback', marker: marker(seq) });
 const eligible: Eligibility = { catPtt: true, browserTxAudio: true, controlLive: true, permit: 'allowed', target: { receiver: 'MAIN', slot: 'A', frequencyHz: 14_074_000 } };
 const start = (): TxEvent => ({ type: 'start', sourceId: 'desktop', leaseId: 'lease', intent: 'momentary', eligibility: eligible, ptt: ptt(false, 1) });
-
-function harness(audio: Promise<string | null> = Promise.resolve(null), failure: 'off' | 'cancel' | 10 | 20 | 30 | null = null) {
+function harness(audio: Promise<string | null> = Promise.resolve(null), failure: 'off' | 'on' | 'cancel' | 'audio' | 'reentrant' | 'callback-throw' | 10 | 20 | 30 | null = null) {
   const log: string[] = []; const reports: Array<{ command: 'on' | 'off'; report: Parameters<TxControllerDependencies['sendPtt']>[3] }> = [];
   let id = 0;
   const dependencies: TxControllerDependencies = {
-    startAudio: vi.fn(() => { log.push('audio'); return audio; }),
-    sendPtt: vi.fn((command, _id, _correlation, report) => { log.push(command); reports.push({ command, report }); if (command === 'off' && failure === 'off') throw new Error('closed'); }),
+    startAudio: vi.fn(() => { log.push('audio'); if (failure === 'audio') throw new Error('audio'); return audio; }),
+    sendPtt: vi.fn((command, _id, _correlation, report) => { log.push(command); reports.push({ command, report }); if (failure === 'reentrant') report({ outcome: command === 'on' ? 'sent' : 'transport-error', eventEpoch: 1, barrier: command === 'on' ? marker(2) : null }); if (command === failure) throw new Error('closed'); }),
     stopLocalAudio: vi.fn(() => { log.push('stop'); }), restoreMod: vi.fn(() => { log.push('restore'); }),
-    commandId: vi.fn((command) => `${command}-${++id}`), schedule: vi.fn((callback, delay) => { if (delay === failure) throw new Error('clock'); return setTimeout(callback, delay); }),
+    commandId: vi.fn((command) => `${command}-${++id}`), schedule: vi.fn((callback, delay) => { if (failure === 'callback-throw') { callback(); throw new Error('clock'); } if (delay === failure) throw new Error('clock'); return setTimeout(callback, delay); }),
     cancel: vi.fn((handle) => { clearTimeout(handle as ReturnType<typeof setTimeout>); if (failure === 'cancel') throw new Error('cancel'); }),
     timeoutMs: { 'audio-start': 10, 'on-confirmation': 20, 'off-confirmation': 30 },
   };
   return { controller: new TxController(1, marker(0), dependencies), dependencies, log, reports };
 }
 const flush = async () => { await Promise.resolve(); await Promise.resolve(); };
-
 describe('TxController', () => {
   afterEach(() => vi.useRealTimers());
-
   it('runs audio before one ON and command acknowledgements never create RF truth', async () => {
     vi.useFakeTimers(); const h = harness(); h.controller.dispatch(start()); expect(h.log).toEqual(['audio']);
     await flush(); expect(h.log).toEqual(['audio', 'on']); expect(h.reports.filter((item) => item.command === 'on')).toHaveLength(1);
     const sent = h.reports[0].report; sent({ outcome: 'sent', eventEpoch: 1, barrier: marker(2) }); sent({ outcome: 'ack', eventEpoch: 1, barrier: null });
     expect(h.controller.snapshot()).toMatchObject({ phase: 'key-confirm-pending', radioTx: 'off', mayOwnKey: true });
   });
-
   it('delivers the exact audio timeout and suppresses its late async completion', async () => {
     vi.useFakeTimers(); let resolve!: (value: string | null) => void; const h = harness(new Promise((done) => { resolve = done; }));
     h.controller.dispatch(start()); vi.advanceTimersByTime(10);
     expect(h.controller.snapshot()).toMatchObject({ phase: 'failed', fault: 'audio-timeout' }); expect(h.log).toEqual(['audio', 'stop']);
     resolve(null); await flush(); expect(h.log).toEqual(['audio', 'stop']); expect(h.reports).toHaveLength(0);
   });
-
   it('delivers correlated ON and OFF deadlines at their exact fake-clock durations', async () => {
     vi.useFakeTimers(); const h = harness(); h.controller.dispatch(start()); await flush();
-    vi.advanceTimersByTime(20);
-    expect(h.controller.snapshot()).toMatchObject({ phase: 'releasing', fault: 'on-timeout' }); expect(h.log).toEqual(['audio', 'on', 'off', 'stop']);
-    vi.advanceTimersByTime(30);
-    expect(h.controller.snapshot()).toMatchObject({ phase: 'failed', fault: 'release-not-confirmed' });
+    vi.advanceTimersByTime(20); expect(h.controller.snapshot()).toMatchObject({ phase: 'releasing', fault: 'on-timeout' }); expect(h.log).toEqual(['audio', 'on', 'off', 'stop']);
+    vi.advanceTimersByTime(30); expect(h.controller.snapshot()).toMatchObject({ phase: 'failed', fault: 'release-not-confirmed' });
   });
-
   it('coalesces release, attempts OFF before stop, and cleans up after a synchronous send failure', async () => {
     vi.useFakeTimers(); const h = harness(Promise.resolve(null), 'off'); h.controller.dispatch(start()); await flush();
     const guard = h.controller.snapshot().guard!; h.controller.dispatch({ type: 'release', guard, commandId: 'off-release' });
@@ -54,13 +46,11 @@ describe('TxController', () => {
     h.reports.find((item) => item.command === 'on')!.report({ outcome: 'sent', eventEpoch: 1, barrier: marker(2) });
     expect(h.log.filter((item) => item === 'off')).toHaveLength(1); expect(h.log.filter((item) => item === 'stop')).toHaveLength(1);
   });
-
   it('isolates throwing observers and timer cancellation so release still performs OFF then stop', async () => {
     vi.useFakeTimers(); const cases = [harness(), harness(Promise.resolve(null), 'cancel')]; cases[0].controller.subscribe(() => { throw new Error('observer'); });
     for (const h of cases) { h.controller.dispatch(start()); await flush(); h.controller.dispatch({ type: 'release', guard: h.controller.snapshot().guard!, commandId: 'off' }); expect(h.log).toEqual(['audio', 'on', 'off', 'stop']); }
     expect(vi.mocked(cases[1].dependencies.cancel)).toHaveBeenCalled();
   });
-
   it('fails closed with exact qualified audio, ON, and OFF events when scheduling throws', async () => {
     vi.useFakeTimers(); const audio = harness(Promise.resolve(null), 10); audio.controller.dispatch(start()); await flush(); expect(audio.controller.snapshot()).toMatchObject({ phase: 'failed', fault: 'audio-timeout' }); expect(audio.log).toEqual(['audio', 'stop']);
     const on = harness(Promise.resolve(null), 20); on.controller.dispatch(start()); await flush(); expect(on.controller.snapshot()).toMatchObject({ phase: 'releasing', fault: 'on-timeout' }); expect(on.log).toEqual(['audio', 'on', 'off', 'stop']);
@@ -68,14 +58,25 @@ describe('TxController', () => {
     const off = harness(Promise.resolve(null), 30); off.controller.dispatch(start()); await flush(); off.controller.dispatch({ type: 'release', guard: off.controller.snapshot().guard!, commandId: 'off' });
     expect(off.controller.snapshot()).toMatchObject({ phase: 'failed', fault: 'release-not-confirmed' }); expect(off.log).toEqual(['audio', 'on', 'off', 'stop']);
   });
-
+  it('fails audio without ON for resolved errors, rejected promises, and synchronous throws', async () => {
+    vi.useFakeTimers(); const cases = [() => harness(Promise.resolve('denied')), () => harness(Promise.reject(new Error('audio'))), () => harness(Promise.resolve(null), 'audio')];
+    for (const make of cases) { const h = make(); h.controller.dispatch(start()); await flush(); expect(h.controller.snapshot()).toMatchObject({ phase: 'failed', fault: 'audio-failed' }); expect(h.dependencies.sendPtt).not.toHaveBeenCalled(); expect(h.log).toEqual(['audio', 'stop']); expect(vi.getTimerCount()).toBe(0); }
+  });
+  it('queues synchronous reports and normalizes synchronous ON send failure', async () => {
+    vi.useFakeTimers(); const queued = harness(Promise.resolve(null), 'reentrant'); queued.controller.dispatch(start()); await flush(); queued.controller.dispatch({ type: 'release', guard: queued.controller.snapshot().guard!, commandId: 'off' });
+    expect(queued.log).toEqual(['audio', 'on', 'off', 'stop']); expect(queued.dependencies.sendPtt).toHaveBeenCalledTimes(2); expect(queued.controller.snapshot()).toMatchObject({ phase: 'failed', fault: 'release-not-confirmed' }); expect(vi.getTimerCount()).toBe(0);
+    const thrown = harness(Promise.resolve(null), 'on'); thrown.controller.dispatch(start()); await flush(); expect(thrown.controller.snapshot()).toMatchObject({ phase: 'releasing', fault: 'on-command-failed' }); expect(thrown.log).toEqual(['audio', 'on', 'off', 'stop']); expect(thrown.dependencies.sendPtt).toHaveBeenCalledTimes(2);
+  });
+  it('delivers callback-then-throw scheduling once at the dispatch boundary', () => {
+    vi.useFakeTimers(); const h = harness(new Promise(() => {}), 'callback-throw'); const seen = vi.fn(); h.controller.subscribe(seen); h.controller.dispatch(start());
+    expect(seen).toHaveBeenCalledTimes(2); expect(h.controller.snapshot()).toMatchObject({ phase: 'failed', fault: 'audio-timeout' }); expect(h.log).toEqual(['audio', 'stop']); expect(vi.getTimerCount()).toBe(0);
+  });
   it('never replays ON when a pre-key lease is released before audio completes', async () => {
     vi.useFakeTimers(); let resolve!: (value: string | null) => void; const h = harness(new Promise((done) => { resolve = done; }));
     h.controller.dispatch(start()); h.controller.dispatch({ type: 'release', guard: h.controller.snapshot().guard!, commandId: 'off-cancel' });
     resolve(null); await flush(); vi.runAllTimers();
     expect(h.log).toEqual(['audio', 'stop']); expect(h.reports).toHaveLength(0); expect(h.controller.snapshot().mayOwnKey).toBe(false);
   });
-
   it('restores MOD only from the reducer obligation after post-OFF authority', async () => {
     vi.useFakeTimers(); const h = harness(); h.controller.dispatch(start()); await flush();
     h.reports[0].report({ outcome: 'sent', eventEpoch: 1, barrier: marker(2) });

--- a/frontend/src/lib/runtime/tx-controller/controller.ts
+++ b/frontend/src/lib/runtime/tx-controller/controller.ts
@@ -4,7 +4,6 @@ type Timer = 'audio-start' | 'on-confirmation' | 'off-confirmation';
 type CommandReport = { outcome: 'sent' | 'ack' | 'response-ok' | 'response-error' | 'transport-error'; eventEpoch: number; barrier: PttMarker | null };
 type CommandCorrelation = { leaseId: string; generation: number; originalEpoch: number };
 type TimerRecord = { handle: unknown; guard: TxGuard; cancelGuard: TxGuard };
-
 export interface TxControllerDependencies {
   startAudio(): Promise<string | null>;
   sendPtt(command: Command, commandId: string, correlation: CommandCorrelation, report: (result: CommandReport) => void): void;

--- a/frontend/src/lib/runtime/tx-controller/controller.ts
+++ b/frontend/src/lib/runtime/tx-controller/controller.ts
@@ -1,0 +1,111 @@
+import { initialTxState, transition, type PttMarker, type PttObservation, type TxEffect, type TxEvent, type TxGuard, type TxState } from './model';
+type Command = 'on' | 'off';
+type Timer = 'audio-start' | 'on-confirmation' | 'off-confirmation';
+type CommandReport = { outcome: 'sent' | 'ack' | 'response-ok' | 'response-error' | 'transport-error'; eventEpoch: number; barrier: PttMarker | null };
+type CommandCorrelation = { leaseId: string; generation: number; originalEpoch: number };
+type TimerRecord = { handle: unknown; guard: TxGuard; cancelGuard: TxGuard };
+
+export interface TxControllerDependencies {
+  startAudio(): Promise<string | null>;
+  sendPtt(command: Command, commandId: string, correlation: CommandCorrelation, report: (result: CommandReport) => void): void;
+  stopLocalAudio(): void;
+  restoreMod(barrier: PttMarker, observation: PttObservation): void;
+  commandId(command: Command): string;
+  schedule(callback: () => void, delayMs: number): unknown;
+  cancel(handle: unknown): void;
+  timeoutMs: Record<Timer, number>;
+}
+const sameGuard = (a: TxGuard, b: TxGuard) =>
+  a.leaseId === b.leaseId && a.generation === b.generation && a.authorityEpoch === b.authorityEpoch;
+export class TxController {
+  #state: TxState;
+  #timers = new Set<TimerRecord>();
+  #listeners = new Set<(state: TxState) => void>();
+  #events: TxEvent[] = [];
+  #processing = false;
+  constructor(authorityEpoch: number, baseline: PttMarker, private readonly dependencies: TxControllerDependencies) {
+    this.#state = initialTxState(authorityEpoch, baseline);
+  }
+  snapshot(): TxState { return this.#state; }
+  subscribe(listener: (state: TxState) => void): () => void {
+    this.#listeners.add(listener);
+    return () => this.#listeners.delete(listener);
+  }
+  dispatch(event: TxEvent): void {
+    this.#events.push(event);
+    if (this.#processing) return;
+    this.#processing = true;
+    try {
+      while (this.#events.length) {
+        const current = this.#events.shift()!;
+        const result = transition(this.#state, current);
+        this.#state = result.state;
+        for (const listener of this.#listeners) try { listener(this.#state); } catch { /* observers cannot block safety effects */ }
+        this.#run(result.effects, current);
+      }
+    } finally { this.#processing = false; }
+  }
+  #run(effects: TxEffect[], cause: TxEvent): void {
+    const failures: Array<{ effect: TxEffect; command: Command; offCommandId: string; eventEpoch: number }> = [];
+    let stopped = false;
+    try {
+      for (const effect of effects) {
+        if (effect.type === 'stop-local-audio') stopped = true;
+        if (effect.type === 'dispatch-on' || effect.type === 'dispatch-off') {
+          const command = effect.type === 'dispatch-on' ? 'on' : 'off';
+          const offCommandId = command === 'off' ? effect.commandId! : this.dependencies.commandId('off');
+          try { this.#send(effect, command, offCommandId); }
+          catch { failures.push({ effect, command, offCommandId, eventEpoch: this.#state.authorityEpoch }); }
+        } else {
+          this.#effect(effect, cause);
+        }
+      }
+    } finally {
+      if (!stopped && effects.some((effect) => effect.type === 'stop-local-audio')) this.dependencies.stopLocalAudio();
+    }
+    for (const failure of failures) this.#commandResult(failure.effect, failure.command, failure.offCommandId, {
+      outcome: 'transport-error', eventEpoch: failure.eventEpoch, barrier: null,
+    });
+  }
+  #send(effect: TxEffect, command: Command, offCommandId: string): void {
+    const guard = effect.guard!;
+    const correlation = { leaseId: guard.leaseId, generation: guard.generation, originalEpoch: guard.authorityEpoch };
+    this.dependencies.sendPtt(command, effect.commandId!, correlation,
+      (report) => this.#commandResult(effect, command, offCommandId, report));
+  }
+  #commandResult(effect: TxEffect, command: Command, offCommandId: string, report: CommandReport): void {
+    const guard = effect.guard!;
+    this.dispatch({ type: 'command-result', command, commandId: effect.commandId!, offCommandId,
+      leaseId: guard.leaseId, generation: guard.generation, originalEpoch: guard.authorityEpoch,
+      eventEpoch: report.eventEpoch, outcome: report.outcome, barrier: report.barrier });
+  }
+  #effect(effect: TxEffect, cause: TxEvent): void {
+    const guard = effect.guard!;
+    if (effect.type === 'start-audio') {
+      let pending: Promise<string | null>;
+      try { pending = this.dependencies.startAudio(); }
+      catch { this.dispatch({ type: 'fail', guard, fault: 'audio-failed', offCommandId: this.dependencies.commandId('off') }); return; }
+      void pending.then((error) => this.dispatch(error
+        ? { type: 'fail', guard, fault: 'audio-failed', offCommandId: this.dependencies.commandId('off') }
+        : { type: 'audio-ready', guard, commandId: this.dependencies.commandId('on') }),
+      () => this.dispatch({ type: 'fail', guard, fault: 'audio-failed', offCommandId: this.dependencies.commandId('off') }));
+    } else if (effect.type.startsWith('arm-')) {
+      const timer = effect.type === 'arm-audio-timeout' ? 'audio-start' : effect.type === 'arm-on-timeout' ? 'on-confirmation' : 'off-confirmation';
+      const eventEpoch = this.#state.authorityEpoch;
+      const offCommandId = timer === 'off-confirmation' ? effect.commandId! : this.dependencies.commandId('off');
+      const record: TimerRecord = { handle: null, guard, cancelGuard: this.#state.cleanupGuard ?? guard };
+      let fired = false; const fire = () => { if (fired) return; fired = true; this.#timers.delete(record); this.dispatch({
+          type: 'timer-fired', timer, commandId: effect.commandId ?? null, armRevision: effect.armRevision!,
+          leaseId: guard.leaseId, generation: guard.generation, originalEpoch: guard.authorityEpoch, eventEpoch, offCommandId });
+      };
+      this.#timers.add(record); try { record.handle = this.dependencies.schedule(fire, this.dependencies.timeoutMs[timer]); }
+      catch { fire(); }
+    } else if (effect.type === 'cancel-timers') {
+      for (const timer of this.#timers) if (sameGuard(timer.guard, guard) || sameGuard(timer.cancelGuard, guard)) {
+        this.#timers.delete(timer);
+        try { this.dependencies.cancel(timer.handle); } catch { /* deadline invalidation remains authoritative */ }
+      }
+    } else if (effect.type === 'stop-local-audio') this.dependencies.stopLocalAudio();
+    else if (effect.type === 'restore-mod' && cause.type === 'authority') this.dependencies.restoreMod(effect.barrier!, cause.ptt);
+  }
+}


### PR DESCRIPTION
## Summary

Add the dependency-injected effect controller around the merged pure TX reducer.

Linear: https://linear.app/morozsm/issue/MOR-1053/core-tx-controller-coordinate-audio-ptt-effects-timers-and-stale
Closes #2060

## Scope

- `frontend/src/lib/runtime/tx-controller/controller.ts`
- `frontend/src/lib/runtime/tx-controller/__tests__/controller.test.ts`
- exactly 2 files, +200/-0 = net +200 LOC
- reducer `model.ts` and `model.test.ts` unchanged

## Behavior

- executes reducer effects in exact order through a reentrancy-safe event queue
- prepares audio before one ON; stale completion cannot replay ON
- preserves reducer-owned OFF coalescing and OFF-before-local-stop ordering
- normalizes synchronous PTT send failures into exact qualified command results
- delivers exact lease/generation/epoch/command/revision-qualified timer and transport callbacks
- isolates throwing subscribers and timer cancellation so they cannot suppress OFF/stop obligations
- converts scheduling failure into the same one-shot qualified timer event for audio, ON, and OFF deadlines
- cancels timer records by exact guard or cleanup lineage without crossing a new lease generation
- executes MOD restoration only for the reducer restore obligation caused by authoritative evidence

## Verification

- focused controller + reducer: 51/51
- full frontend: 136 files, 2467/2467
- independent mutation verification: all 6 B1-B3 mutant families killed non-vacuously
- prior independent P0 adversarial probes: 8/8 pass
- check: 0 errors, 0 warnings
- lint, boundaries, i18n, build, and local diff guard: pass
- latest remediation adds the proof rows and removes one production blank line; controller behavior is unchanged from `4a90aef39398be348b22a1cf5bc4bbe7b7b4c161`

The B1-B3 remediation proves audio resolve/reject/synchronous throw, truly synchronous/reentrant transport callbacks and ON throw, fired one-shot behavior, and direct exact-guard cancellation. `commandId`, `stopLocalAudio`, and `restoreMod` remain total synchronous DI operations; MOR-1053 does not add adapter failure policy for those hooks. No App/component/source migration, production transport/audio adapter, capability policy, reducer policy, protocol, or hardware change. No hardware evidence is claimed.

Fresh exact-head Claude Opus 5 max review: PASS for `c5b8a0b46714f68b59115b0a83c1f3103fb5b54e`. All required CI must remain green before merge.