### PR TITLE
Publish synchronous control-session epoch transitions

### DIFF
--- a/frontend/src/lib/transport/__tests__/ws-client.test.ts
+++ b/frontend/src/lib/transport/__tests__/ws-client.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { WsCommand, WsMessage } from '../../types/protocol';
 import type { ReceiverState, ServerState } from '../../types/state';
-import type { CommandDeliveryEvent } from '../ws-client';
+import type { CommandDeliveryEvent, ControlSessionTransition } from '../ws-client';
 
 type ServerStateWithObservation = ServerState & {
   observationSeq?: number;
@@ -510,6 +510,72 @@ describe('control channel singleton', () => {
     globalThis.WebSocket = originalWebSocket;
     vi.useRealTimers();
     vi.resetModules();
+  });
+
+  it('publishes each control session epoch before draining a pinned OFF', async () => {
+    const {
+      connect,
+      disconnect,
+      onCommandDelivery,
+      onControlSessionTransition,
+      sendCommand,
+    } = await import('../ws-client');
+    const transitions: ControlSessionTransition[] = [];
+    const order: string[] = [];
+    onControlSessionTransition((transition) => {
+      transitions.push(transition);
+      order.push(`session:${transition.state}:${transition.epoch}`);
+    });
+    onCommandDelivery((event) => {
+      order.push(`delivery:${event.commandId}:${event.eventEpoch}`);
+    });
+
+    expect(sendCommand('ptt_off', {}, 'off-1')).toBe(false);
+    connect('ws://test/api/v1/ws');
+    instances[0].simulateOpen();
+    instances[0].simulateClose();
+    expect(sendCommand('ptt_off', {}, 'off-2')).toBe(false);
+    vi.advanceTimersByTime(1300);
+    instances[1].simulateOpen();
+    disconnect();
+
+    expect(transitions).toEqual([
+      { state: 'connecting', epoch: 0 },
+      { state: 'connected', epoch: 1 },
+      { state: 'disconnected', epoch: 1 },
+      { state: 'reconnecting', epoch: 1 },
+      { state: 'connected', epoch: 2 },
+      { state: 'disconnected', epoch: 2 },
+    ]);
+    expect(order).toEqual([
+      'session:connecting:0',
+      'session:connected:1',
+      'delivery:off-1:1',
+      'session:disconnected:1',
+      'session:reconnecting:1',
+      'session:connected:2',
+      'delivery:off-2:2',
+      'session:disconnected:2',
+    ]);
+  });
+
+  it('unsubscribes the control session transition handler idempotently', async () => {
+    const { connect, disconnect, onControlSessionTransition } = await import('../ws-client');
+    const transitions: ControlSessionTransition[] = [];
+    const unsubscribe = onControlSessionTransition((transition) => transitions.push(transition));
+
+    connect('ws://test/api/v1/ws');
+    instances[0].simulateOpen();
+    unsubscribe();
+    unsubscribe();
+    disconnect();
+    connect('ws://test/api/v1/ws');
+    instances[1].simulateOpen();
+
+    expect(transitions).toEqual([
+      { state: 'connecting', epoch: 0 },
+      { state: 'connected', epoch: 1 },
+    ]);
   });
 
   it('applies optimistic data mode updates before sending', async () => {

--- a/frontend/src/lib/transport/__tests__/ws-client.test.ts
+++ b/frontend/src/lib/transport/__tests__/ws-client.test.ts
@@ -440,6 +440,66 @@ describe('WsChannel', () => {
     expect(ch.state).toBe('disconnected');
   });
 
+  it('snapshots control session subscribers for each transition', async () => {
+    const { WsChannel } = await import('../ws-client');
+    const ch = new WsChannel();
+    const order: string[] = [];
+    let added = false;
+    ch.onSessionTransition((transition) => {
+      order.push(`first:${transition.state}`);
+      if (!added) {
+        added = true;
+        ch.onSessionTransition((next) => order.push(`late:${next.state}`));
+      }
+    });
+    ch.onSessionTransition((transition) => order.push(`second:${transition.state}`));
+
+    ch.connect('ws://test');
+    expect(order).toEqual(['first:connecting', 'second:connecting']);
+
+    instances[0].simulateOpen();
+    expect(order).toEqual([
+      'first:connecting',
+      'second:connecting',
+      'first:connected',
+      'second:connected',
+      'late:connected',
+    ]);
+  });
+
+  it('serializes reentrant transitions and aborts open work after callback disconnect', async () => {
+    const { WsChannel } = await import('../ws-client');
+    const ch = new WsChannel();
+    const order: string[] = [];
+    const deliveries: CommandDeliveryEvent[] = [];
+    ch.onSessionTransition((transition) => {
+      order.push(`first:${transition.state}`);
+      if (transition.state === 'connected') ch.disconnect();
+    });
+    ch.onSessionTransition((transition) => order.push(`second:${transition.state}`));
+    ch.onCommandDelivery((event) => deliveries.push(event));
+
+    expect(ch.send({ type: 'cmd', name: 'ptt_off', id: 'off', params: {} })).toBe(false);
+    ch.connect('ws://test');
+    instances[0].simulateOpen();
+    expect(vi.getTimerCount()).toBe(0);
+    vi.advanceTimersByTime(30_001);
+
+    expect(order).toEqual([
+      'first:connecting',
+      'second:connecting',
+      'first:connected',
+      'second:connected',
+      'first:disconnected',
+      'second:disconnected',
+    ]);
+    expect(ch.state).toBe('disconnected');
+    expect(instances).toHaveLength(1);
+    expect(instances[0].sent).toEqual([]);
+    expect(deliveries).toEqual([]);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
   it('keeps the connection alive by sending periodic ping frames', async () => {
     const { WsChannel } = await import('../ws-client');
     const ch = new WsChannel();

--- a/frontend/src/lib/transport/ws-client.ts
+++ b/frontend/src/lib/transport/ws-client.ts
@@ -4,6 +4,10 @@ import { isLiveRadioAvailable, setWsConnected, setHttpConnected, markStateUpdate
 import { getRadioState, patchActiveReceiver, patchRadioState, resetRadioState, setRadioState } from '../stores/radio.svelte';
 
 export type ConnectionState = 'disconnected' | 'connecting' | 'connected' | 'reconnecting';
+export interface ControlSessionTransition {
+  state: ConnectionState;
+  epoch: number;
+}
 export type CommandDeliveryKind = 'transport-sent' | 'ack' | 'response-ok' | 'response-error' | 'error';
 export interface CommandDeliveryEvent {
   commandId: string;
@@ -15,6 +19,7 @@ export interface CommandDeliveryEvent {
 type MessageHandler = (msg: WsIncoming) => void;
 type BinaryHandler = (data: ArrayBuffer) => void;
 type StateHandler = (state: ConnectionState) => void;
+export type ControlSessionTransitionHandler = (transition: ControlSessionTransition) => void;
 type CommandDeliveryHandler = (event: CommandDeliveryEvent) => void;
 type PendingPttRelease = { command: WsCommand; originalEpoch: number };
 type TrackedPttCommand = PendingPttRelease & {
@@ -59,6 +64,7 @@ export class WsChannel {
   private messageHandlers = new Set<MessageHandler>();
   private binaryHandlers = new Set<BinaryHandler>();
   private stateHandlers = new Set<StateHandler>();
+  private sessionTransitionHandlers = new Set<ControlSessionTransitionHandler>();
   private _state: ConnectionState = 'disconnected';
   private url = '';
   private _subscribeMsg: Record<string, unknown> | null = null;
@@ -73,8 +79,13 @@ export class WsChannel {
   }
 
   private setState(s: ConnectionState) {
+    const changed = this._state !== s;
     this._state = s;
     this.stateHandlers.forEach((h) => h(s));
+    if (changed) {
+      const transition = { state: s, epoch: this.transportEpoch };
+      this.sessionTransitionHandlers.forEach((h) => h(transition));
+    }
   }
 
   connect(url: string) {
@@ -243,6 +254,11 @@ export class WsChannel {
   onStateChange(handler: StateHandler): () => void {
     this.stateHandlers.add(handler);
     return () => this.stateHandlers.delete(handler);
+  }
+
+  onSessionTransition(handler: ControlSessionTransitionHandler): () => void {
+    this.sessionTransitionHandlers.add(handler);
+    return () => this.sessionTransitionHandlers.delete(handler);
   }
 
   onCommandDelivery(handler: CommandDeliveryHandler): () => void {
@@ -548,6 +564,10 @@ export function disconnect() {
 
 export function onCommandDelivery(handler: CommandDeliveryHandler): () => void {
   return _ctrl.onCommandDelivery(handler);
+}
+
+export function onControlSessionTransition(handler: ControlSessionTransitionHandler): () => void {
+  return _ctrl.onSessionTransition(handler);
 }
 
 export function sendCommand(name: string, params: Record<string, unknown> = {}, id?: string): boolean {

--- a/frontend/src/lib/transport/ws-client.ts
+++ b/frontend/src/lib/transport/ws-client.ts
@@ -65,6 +65,8 @@ export class WsChannel {
   private binaryHandlers = new Set<BinaryHandler>();
   private stateHandlers = new Set<StateHandler>();
   private sessionTransitionHandlers = new Set<ControlSessionTransitionHandler>();
+  private sessionTransitionQueue: ControlSessionTransition[] = [];
+  private dispatchingSessionTransition = false;
   private _state: ConnectionState = 'disconnected';
   private url = '';
   private _subscribeMsg: Record<string, unknown> | null = null;
@@ -83,8 +85,21 @@ export class WsChannel {
     this._state = s;
     this.stateHandlers.forEach((h) => h(s));
     if (changed) {
-      const transition = { state: s, epoch: this.transportEpoch };
-      this.sessionTransitionHandlers.forEach((h) => h(transition));
+      this._emitSessionTransition({ state: s, epoch: this.transportEpoch });
+    }
+  }
+
+  private _emitSessionTransition(transition: ControlSessionTransition): void {
+    this.sessionTransitionQueue.push(transition);
+    if (this.dispatchingSessionTransition) return;
+    this.dispatchingSessionTransition = true;
+    try {
+      while (this.sessionTransitionQueue.length > 0) {
+        const next = this.sessionTransitionQueue.shift()!;
+        for (const handler of [...this.sessionTransitionHandlers]) handler(next);
+      }
+    } finally {
+      this.dispatchingSessionTransition = false;
     }
   }
 
@@ -107,6 +122,12 @@ export class WsChannel {
       socketEpoch = ++this.transportEpoch;
       this.attempt = 0;
       this.setState('connected');
+      if (
+        this.ws !== ws
+        || ws.readyState !== WebSocket.OPEN
+        || this._state !== 'connected'
+        || socketEpoch !== this.transportEpoch
+      ) return;
       this._resetHeartbeat();
       this._startKeepalive();
       // drain send queue


### PR DESCRIPTION
## Summary

Publishes synchronous control-session transition notifications from the canonical WebSocket control channel. Each distinct connection-state transition carries the current transport epoch.

## Why

Lifecycle consumers can now correlate their own control-session state with queued command delivery. The transition is emitted synchronously after the state handler notification and before pinned `ptt_off` delivery is drained on reconnection, preserving the de-key safety ordering.

## Scope

- Adds the public transition type and subscription seam in `ws-client.ts`.
- Covers connect, reconnect, disconnect, epoch progression, OFF delivery ordering, and idempotent unsubscribe.
- Leaves consumers dormant: this atomic slice exposes the canonical seam without changing UI behavior.

## Verification

Fresh independent verifier passed the exact uncommitted patch before publication:

- Scope: 2 files, +86 net LOC.
- Stable patch-id: `ea227a6dc234bde57d48e422e5b3cf04f05b521d`.
- Targeted frontend test suite passed; no source/test edits after verification.
- `git diff --cached --check` passed before commit.

Closes #2065

Linear: [MOR-1155](https://linear.app/morozsm/issue/MOR-1155)