### PR TITLE
fix(#2064): bind managed TX port token

### DIFF
--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -174,12 +174,18 @@ class _CivDataTransaction:
 
 
 @dataclass(frozen=True, slots=True)
-class _AuthoritativePttRead:
-    observer: Callable[[ProviderPttObservation], None]
+class _ManagedTxPortToken:
     provider_generation: int
     binding_epoch: int
-    source_generation: int
-    transport: object
+    civ_source_generation: int
+    transport: Any
+
+
+@dataclass(frozen=True, slots=True)
+class _AuthoritativePttRead:
+    observer: Callable[[ProviderPttObservation], None]
+    token: _ManagedTxPortToken
+    managed: bool
 
 
 _CMD14_RECEIVER_LEVEL_FIELDS = {
@@ -566,6 +572,10 @@ class CivRuntime:
         self._active_ptt_read: _AuthoritativePttRead | None = None
         self._active_rx_source_generation: int | None = None
         self._civ_data_transaction: _CivDataTransaction | None = None
+        self._managed_tx_ports: dict[int, _ManagedTxPortToken] = {}
+        self._poisoned_managed_tx_generations: set[int] = set()
+        self._managed_tx_sends: dict[int, set[asyncio.Task[None]]] = {}
+        self._managed_tx_retirements: dict[int, asyncio.Task[None]] = {}
 
     # ------------------------------------------------------------------
     # Public API (design doc)
@@ -587,6 +597,9 @@ class CivRuntime:
         """Bind authoritative PTT readback to this CI-V transport generation."""
         if provider_generation < 0:
             raise ValueError("provider_generation must be non-negative")
+        self._poison_bound_managed_tx_port()
+        if provider_generation in self._poisoned_managed_tx_generations:
+            raise ConnectionError("managed TX provider generation is terminal")
         if provider_generation != self._ptt_observer_provider_generation:
             self._ptt_observation_seq = 0
         self._ptt_observer_binding_epoch += 1
@@ -594,8 +607,32 @@ class CivRuntime:
         self._ptt_observer_provider_generation = provider_generation
         self._ptt_observer_civ_generation = self._host._civ_epoch
 
+    def capture_managed_port(
+        self,
+        provider_generation: int,
+        observer: Callable[[ProviderPttObservation], None],
+    ) -> bool:
+        if provider_generation in self._managed_tx_ports:
+            raise ConnectionError("managed TX provider generation already captured")
+        self.bind_ptt_observer(
+            provider_generation=provider_generation, observer=observer
+        )
+        transport = self._host._civ_transport
+        if transport is None:
+            self.unbind_ptt_observer()
+            return False
+        token = _ManagedTxPortToken(
+            provider_generation,
+            self._ptt_observer_binding_epoch,
+            self._host._civ_epoch,
+            transport,
+        )
+        self._managed_tx_ports[provider_generation] = token
+        return True
+
     def unbind_ptt_observer(self) -> None:
         """Detach the callback while preserving this provider's sequence."""
+        self._poison_bound_managed_tx_port()
         self._ptt_observer_binding_epoch += 1
         self._ptt_observer = None
 
@@ -608,15 +645,19 @@ class CivRuntime:
     ) -> bool:
         """Publish one exact PTT response only while its binding stays current."""
         async with self._ptt_read_lock:
-            transport = self._host._civ_transport
-            read = _AuthoritativePttRead(
-                observer=observer,
-                provider_generation=provider_generation,
-                binding_epoch=self._ptt_observer_binding_epoch,
-                source_generation=self._host._civ_epoch,
-                transport=transport,
-            )
-            if transport is None or not self._ptt_read_is_current(read):
+            token = self._managed_tx_ports.get(provider_generation)
+            managed = token is not None
+            if token is None:
+                token = _ManagedTxPortToken(
+                    provider_generation,
+                    self._ptt_observer_binding_epoch,
+                    self._host._civ_epoch,
+                    self._host._civ_transport,
+                )
+            elif not self._managed_tx_port_is_current(token):
+                return False
+            read = _AuthoritativePttRead(observer, token, managed)
+            if token.transport is None or not self._ptt_read_is_current(read):
                 return False
             self._active_ptt_read = read
             try:
@@ -629,7 +670,7 @@ class CivRuntime:
                     and self._ptt_read_is_current(read)
                     and self._emit_authoritative_ptt(
                         result.frame,
-                        source_generation=read.source_generation,
+                        source_generation=read.token.civ_source_generation,
                         expected=read,
                     )
                 )
@@ -638,15 +679,68 @@ class CivRuntime:
                     self._active_ptt_read = None
 
     def _ptt_read_is_current(self, read: _AuthoritativePttRead) -> bool:
+        token = read.token
         return (
             self._active_ptt_read in (None, read)
-            and self._ptt_observer_binding_epoch == read.binding_epoch
+            and (not read.managed or self._managed_tx_port_is_current(token))
+            and self._ptt_observer_binding_epoch == token.binding_epoch
             and self._ptt_observer is read.observer
-            and self._ptt_observer_provider_generation == read.provider_generation
-            and self._ptt_observer_civ_generation == read.source_generation
-            and self._host._civ_epoch == read.source_generation
-            and self._host._civ_transport is read.transport
+            and self._ptt_observer_provider_generation == token.provider_generation
+            and self._ptt_observer_civ_generation == token.civ_source_generation
+            and self._host._civ_epoch == token.civ_source_generation
+            and self._host._civ_transport is token.transport
         )
+
+    def _managed_tx_port_is_current(self, token: _ManagedTxPortToken) -> bool:
+        return (
+            self._managed_tx_ports.get(token.provider_generation) is token
+            and token.provider_generation not in self._poisoned_managed_tx_generations
+            and self._ptt_observer_provider_generation == token.provider_generation
+            and self._ptt_observer_binding_epoch == token.binding_epoch
+            and self._ptt_observer_civ_generation == token.civ_source_generation
+            and self._host._civ_epoch == token.civ_source_generation
+            and self._host._civ_transport is token.transport
+        )
+
+    def _poison_managed_tx_port(self, token: _ManagedTxPortToken) -> None:
+        self._poisoned_managed_tx_generations.add(token.provider_generation)
+        for task in self._managed_tx_sends.get(token.provider_generation, ()):
+            task.cancel()
+
+    def _poison_bound_managed_tx_port(self) -> None:
+        generation = self._ptt_observer_provider_generation
+        if generation is not None and (token := self._managed_tx_ports.get(generation)):
+            self._poison_managed_tx_port(token)
+
+    async def write_managed_ptt(
+        self, civ_frame: bytes, provider_generation: int
+    ) -> None:
+        token = self._managed_tx_ports.get(provider_generation)
+        if token is None or not self._managed_tx_port_is_current(token):
+            raise ConnectionError("managed TX physical port is stale")
+        await self.execute_civ_transaction(civ_frame, expect="none", owner=token)
+
+    async def retire_managed_tx_port(self, provider_generation: int) -> None:
+        token = self._managed_tx_ports.get(provider_generation)
+        if token is None:
+            raise ConnectionError("managed TX physical port was not captured")
+        self._poison_managed_tx_port(token)
+        if (
+            self._ptt_observer_provider_generation == provider_generation
+            and self._ptt_observer_binding_epoch == token.binding_epoch
+        ):
+            self.unbind_ptt_observer()
+        if self._host._civ_epoch == token.civ_source_generation:
+            self.advance_generation("managed TX physical port retired")
+        if self._host._civ_transport is token.transport:
+            self._host._civ_transport = None
+        barrier = self._managed_tx_retirements.get(provider_generation)
+        if barrier is None or (
+            barrier.done() and (barrier.cancelled() or barrier.exception() is not None)
+        ):
+            barrier = asyncio.create_task(token.transport.disconnect())
+            self._managed_tx_retirements[provider_generation] = barrier
+        await asyncio.shield(barrier)
 
     async def stop_pump(self) -> None:
         """Stop CI-V receive pump and fail pending request futures."""
@@ -708,9 +802,13 @@ class CivRuntime:
 
     def advance_generation(self, reason: str) -> None:
         """Advance CI-V request generation and fail stale waiters."""
+        source_generation = self._host._civ_epoch
         self._host._civ_epoch = self._host._civ_request_tracker.advance_generation(
             ConnectionError(f"CI-V generation advanced: {reason}")
         )
+        for token in self._managed_tx_ports.values():
+            if token.civ_source_generation == source_generation:
+                self._poison_managed_tx_port(token)
 
     async def execute_civ_raw(
         self,
@@ -919,14 +1017,32 @@ class CivRuntime:
         if delta < self._host._civ_min_interval:
             await asyncio.sleep(self._host._civ_min_interval - delta)
 
+        token = owner if isinstance(owner, _ManagedTxPortToken) else None
+        if isinstance(owner, _AuthoritativePttRead) and owner.managed:
+            token = owner.token
+        if token is not None and not self._managed_tx_port_is_current(token):
+            raise ConnectionError("managed TX physical port changed before dispatch")
         if isinstance(owner, _AuthoritativePttRead) and not self._ptt_read_is_current(
             owner
         ):
             raise ConnectionError("PTT observer binding changed before dispatch")
         pkt = self._wrap_civ(civ_frame)
-        transport = self._host._civ_transport
+        transport = token.transport if token is not None else self._host._civ_transport
         assert transport is not None
-        await transport.send_tracked(pkt)
+        task = asyncio.create_task(transport.send_tracked(pkt))
+        tasks = None
+        if token is not None:
+            tasks = self._managed_tx_sends.setdefault(token.provider_generation, set())
+            tasks.add(task)
+        try:
+            await task
+        except asyncio.CancelledError:
+            if token is not None and not self._managed_tx_port_is_current(token):
+                raise ConnectionError("managed TX send invalidated") from None
+            raise
+        finally:
+            if tasks is not None:
+                tasks.discard(task)
         self._host._last_civ_send_monotonic = time.monotonic()
 
     @staticmethod

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -2959,13 +2959,26 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             observer=observer,
         )
 
+    def _capture_managed_tx_port(
+        self,
+        provider_generation: int,
+        observer: "Callable[[ProviderPttObservation], None]",
+    ) -> bool:
+        return self._civ_runtime.capture_managed_port(provider_generation, observer)
+
+    async def _write_managed_ptt(self, provider_generation: int, on: bool) -> None:
+        civ = (ptt_on if on else ptt_off)(to_addr=self._radio_addr)
+        await self._civ_runtime.write_managed_ptt(civ, provider_generation)
+
+    async def _retire_managed_tx_port(self, provider_generation: int) -> None:
+        await self._civ_runtime.retire_managed_tx_port(provider_generation)
+
     def _unbind_authoritative_ptt_observer(self) -> None:
         """Detach the managed-provider PTT readback observer."""
         self._civ_runtime.unbind_ptt_observer()
 
     async def _request_authoritative_ptt_read(
         self,
-        *,
         provider_generation: int,
         observer: "Callable[[ProviderPttObservation], None]",
     ) -> None:

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -1,11 +1,12 @@
 """Tests for IcomRadio high-level API."""
 
 import asyncio
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from rigplane import IC_7610_ADDR
+from rigplane.backends.icom7610.drivers import serial_session as serial
 from rigplane.commands import (
     _CMD_ACK,
     _CMD_FREQ_GET,
@@ -727,6 +728,76 @@ class TestSquelch:
 
 class TestPtt:
     """Test PTT toggle."""
+
+    @pytest.mark.timeout(2)
+    @pytest.mark.parametrize("poison_only", [False, True], ids=["rebind", "poison"])
+    async def test_managed_ptt_port_token_safety(
+        self, radio: IcomRadio, poison_only: bool
+    ) -> None:
+        sent: list[bytes] = []
+        responses: asyncio.Queue[bytes] = asyncio.Queue()
+        send_release, disconnect_release = asyncio.Event(), asyncio.Event()
+
+        async def send(frame: bytes) -> None:
+            await send_release.wait()
+            sent.append(frame)
+
+        async def receive(**_kwargs: float) -> bytes:
+            return await responses.get()
+
+        link = AsyncMock()
+        link.send.side_effect = send
+        link.receive.side_effect = receive
+        link.disconnect.side_effect = OSError("pre-disconnect failure")
+        radio._civ_transport = serial.SerialCivTransport(link)
+        observations: list[tx.ProviderPttObservation] = []
+        observer = observations.append
+        assert radio._capture_managed_tx_port(11, observer)
+        read = radio._request_authoritative_ptt_read
+        send_release.set()
+        pending_read = asyncio.create_task(read(11, observer))
+        while not sent:
+            await asyncio.sleep(0)
+        send_release.clear()
+        pending_write = asyncio.create_task(radio._write_managed_ptt(11, True))
+        while link.send.await_count < 2:
+            await asyncio.sleep(0)
+        runtime = radio._civ_runtime
+        token = runtime._managed_tx_ports[11]
+        if poison_only:
+            assert runtime._managed_tx_port_is_current(token)
+            runtime._poison_managed_tx_port(token)
+            assert runtime._managed_tx_ports[11] is token
+        else:
+            runtime.bind_ptt_observer(provider_generation=12, observer=lambda _: None)
+        send_release.set()
+        with pytest.raises(ConnectionError):
+            await asyncio.wait_for(pending_write, 0.5)
+        assert len(sent) == 1
+        responses.put_nowait(serial._unwrap_civ_frame(_ptt_response(True)))
+        with pytest.raises(CommandError, match="authoritative"):
+            await asyncio.wait_for(pending_read, 0.5)
+        assert not observations
+        replacement = MockTransport()
+        radio._civ_transport = replacement
+        with pytest.raises(OSError, match="pre-disconnect"):
+            await asyncio.wait_for(radio._retire_managed_tx_port(11), 0.5)
+        link.disconnect.side_effect = disconnect_release.wait
+        retry = asyncio.create_task(radio._retire_managed_tx_port(11))
+        while link.disconnect.await_count < 2:
+            await asyncio.sleep(0)
+        duplicate = asyncio.create_task(radio._retire_managed_tx_port(11))
+        await asyncio.sleep(0)
+        retry.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await retry
+        assert not duplicate.done() and link.disconnect.await_count == 2
+        disconnect_release.set()
+        await asyncio.wait_for(duplicate, 0.5)
+        assert not replacement.disconnected and radio._civ_transport is replacement
+        with pytest.raises(ConnectionError):
+            radio._capture_managed_tx_port(11, observer)
+        await radio._civ_runtime.stop_pump()
 
     @pytest.mark.asyncio
     async def test_set_ptt_on(


### PR DESCRIPTION
Closes #2064

MOR-1153: binds each managed TX physical port to an exact provider-generation, binding-epoch, CI-V-generation, and transport identity token. Rebind and poison-only evidence scenarios prove that stale managed TX work cannot enqueue a physical CI-V frame; invalidated sends normalize to `ConnectionError`, and stale authoritative reads produce no observation.

The regression exercises both bind/rebind and poison-only invalidation, including a mutant-evidence path. Baseline and targeted verification passed before this exact diff was committed; no real-hardware claim is made.

Scope: 3 files, +200 net LOC. This branch base is currently behind `main`; it was intentionally not rebased so the independently verified content remains unchanged.