### PR TITLE
fix: preserve release barrier during teardown

### DIFF
--- a/frontend/src/lib/runtime/__tests__/system-controller.test.ts
+++ b/frontend/src/lib/runtime/__tests__/system-controller.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { SystemController } from '../system-controller';
+
+const teardown = [
+  'audio',
+  'ws:disconnect',
+  'http:disconnect',
+  'media:destroy',
+  'radio:disconnect',
+  'radio:reset',
+];
+
+function deferred() {
+  let resolve!: () => void;
+  let reject!: (reason: Error) => void;
+  const promise = new Promise<void>((ok, fail) => {
+    resolve = ok;
+    reject = fail;
+  });
+  return { promise, resolve, reject };
+}
+
+function fixture() {
+  const calls: string[] = [];
+  const mark = (name: string) => () => calls.push(name);
+  const controller = new SystemController({
+    destroyAudio: mark('audio'),
+    disconnectWebSockets: mark('ws:disconnect'),
+    setHttpDisconnected: mark('http:disconnect'),
+    destroyMediaSession: mark('media:destroy'),
+    setRadioDisconnected: mark('radio:disconnect'),
+    resetRadioState: mark('radio:reset'),
+    initMediaSession: mark('media:init'),
+    clearEtag: mark('etag'),
+    reconnectWebSockets: mark('ws:reconnect'),
+  });
+  return { calls, controller };
+}
+
+describe('SystemController disconnect lifecycle', () => {
+  it('keeps the no-barrier teardown synchronous and in legacy order', async () => {
+    const { calls, controller } = fixture();
+    controller.setStopPolling(() => calls.push('polling'));
+
+    const result = controller.disconnect();
+
+    expect(calls).toEqual([...teardown.slice(0, 2), 'polling', ...teardown.slice(2)]);
+    await expect(result).resolves.toBeUndefined();
+  });
+
+  it('coalesces deferred and reentrant disconnects before teardown', async () => {
+    const { calls, controller } = fixture();
+    const gate = deferred();
+    let reentrant: Promise<void> | undefined;
+    const barrier = vi.fn(() => {
+      calls.push('barrier');
+      reentrant = controller.disconnect();
+      return gate.promise;
+    });
+    controller.registerPreDisconnectBarrier(barrier);
+
+    const first = controller.disconnect();
+    const duplicate = controller.disconnect();
+    controller.connect();
+
+    expect(duplicate).toBe(first);
+    expect(barrier).not.toHaveBeenCalled();
+    expect(calls).toEqual([]);
+    await Promise.resolve();
+    expect(reentrant).toBe(first);
+    expect(barrier).toHaveBeenCalledOnce();
+    expect(calls).toEqual(['barrier']);
+
+    gate.resolve();
+    await first;
+    expect(calls).toEqual(['barrier', ...teardown]);
+  });
+
+  it('tears down once before propagating a barrier rejection', async () => {
+    const { calls, controller } = fixture();
+    const failure = new Error('release uncertain');
+    controller.registerPreDisconnectBarrier(() => Promise.reject(failure));
+
+    const result = controller.disconnect();
+
+    await expect(result).rejects.toBe(failure);
+    expect(calls).toEqual(teardown);
+    await expect(controller.disconnect()).resolves.toBeUndefined();
+    expect(calls).toHaveLength(teardown.length);
+  });
+
+  it('uses exclusive exact registration and a captured barrier', async () => {
+    const { controller } = fixture();
+    const gate = deferred();
+    const barrier = vi.fn(() => gate.promise);
+    const replacement = vi.fn(() => Promise.resolve());
+    const staleUnregister = controller.registerPreDisconnectBarrier(barrier);
+    expect(() => controller.registerPreDisconnectBarrier(replacement)).toThrow();
+    staleUnregister();
+    staleUnregister();
+
+    const unregister = controller.registerPreDisconnectBarrier(barrier);
+    staleUnregister();
+    const result = controller.disconnect();
+    unregister();
+    controller.registerPreDisconnectBarrier(replacement);
+    unregister();
+    await Promise.resolve();
+    gate.resolve();
+    await result;
+
+    expect(barrier).toHaveBeenCalledOnce();
+    expect(replacement).not.toHaveBeenCalled();
+    controller.connect();
+    await controller.disconnect();
+    expect(replacement).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/lib/runtime/system-controller.ts
+++ b/frontend/src/lib/runtime/system-controller.ts
@@ -25,10 +25,26 @@ export interface EibiResult {
   stations: EibiStation[];
 }
 
-class SystemController {
+export class SystemController {
   private _stopPolling: (() => void) | null = null;
   private _startPolling: (() => (() => void)) | null = null;
   private _clientConnected = true;
+  private _releaseBarrier: { run: () => Promise<void> } | null = null;
+  private _disconnectInFlight: Promise<void> | null = null;
+
+  constructor(
+    private readonly _effects = {
+      destroyAudio: () => audioManager.destroy(),
+      disconnectWebSockets: () => wsDisconnectAll(),
+      setHttpDisconnected: () => setHttpConnected(false),
+      destroyMediaSession: () => destroyMediaSession(),
+      setRadioDisconnected: () => setRadioStatus('disconnected'),
+      resetRadioState: () => resetRadioState(),
+      initMediaSession: () => initMediaSession(),
+      clearEtag: () => clearEtag(),
+      reconnectWebSockets: () => wsReconnectAll(),
+    },
+  ) {}
 
   get clientConnected(): boolean {
     return this._clientConnected;
@@ -42,6 +58,18 @@ class SystemController {
   /** Register an active polling stop handle (called from App.svelte after startPolling). */
   setStopPolling(stopFn: (() => void) | null): void {
     this._stopPolling = stopFn;
+  }
+
+  /** Register the sole opaque barrier awaited before disconnect teardown. */
+  registerPreDisconnectBarrier(barrier: () => Promise<void>): () => void {
+    if (this._releaseBarrier) {
+      throw new Error('A pre-disconnect barrier is already registered');
+    }
+    const registration = { run: barrier };
+    this._releaseBarrier = registration;
+    return () => {
+      if (this._releaseBarrier === registration) this._releaseBarrier = null;
+    };
   }
 
   async powerOn(): Promise<void> {
@@ -63,45 +91,65 @@ class SystemController {
   }
 
   /** Disconnect all frontend channels: WS, audio, polling, MediaSession. */
-  disconnect(): void {
-    if (!this._clientConnected) return;
+  disconnect(): Promise<void> {
+    if (this._disconnectInFlight) return this._disconnectInFlight;
+    if (!this._clientConnected) return Promise.resolve();
     this._clientConnected = false;
+    const barrier = this._releaseBarrier?.run;
+    if (!barrier) {
+      this._teardown();
+      return Promise.resolve();
+    }
 
+    const inFlight = Promise.resolve()
+      .then(barrier)
+      .finally(() => {
+        try {
+          this._teardown();
+        } finally {
+          this._disconnectInFlight = null;
+        }
+      });
+    this._disconnectInFlight = inFlight;
+    return inFlight;
+  }
+
+  private _teardown(): void {
     // 1. Stop audio (RX/TX playback + audio WS)
-    audioManager.destroy();
+    this._effects.destroyAudio();
 
     // 2. Close all WebSocket channels (control + scope + any named)
-    wsDisconnectAll();
+    this._effects.disconnectWebSockets();
 
     // 3. Stop HTTP polling
     this._stopPolling?.();
     this._stopPolling = null;
-    setHttpConnected(false);
+    this._effects.setHttpDisconnected();
 
     // 4. Stop MediaSession silent audio loop
-    destroyMediaSession();
+    this._effects.destroyMediaSession();
 
     // 5. Clear stale state
-    setRadioStatus('disconnected');
-    resetRadioState();
+    this._effects.setRadioDisconnected();
+    this._effects.resetRadioState();
   }
 
   /** Reconnect all frontend channels. */
   connect(): void {
-    if (this._clientConnected) return;
+    if (this._disconnectInFlight || this._clientConnected) return;
     this._clientConnected = true;
 
     // 1. Restart MediaSession
-    initMediaSession();
+    this._effects.initMediaSession();
 
     // 2. Restart HTTP polling
-    clearEtag();
+    this._effects.clearEtag();
     if (this._startPolling) {
       this._stopPolling = this._startPolling();
     }
 
     // 3. Reconnect all WebSocket channels (control + scope + any named)
-    wsReconnectAll();
+    this._effects.reconnectWebSockets();
   }
 
   async identifyFrequency(freqHz: number): Promise<EibiResult | null> {


### PR DESCRIPTION
Closes #2068

MOR-1154: make the system-controller release barrier exclusive across coalesced disconnects and teardown-on-rejection, while suppressing connects during teardown.

The patch leaves the seam dormant outside teardown and makes no real-hardware claim.

Validation completed before publication:
- targeted frontend behavior tests
- full frontend gates
- mutant evidence

This is an atomic two-file, +167 net LOC slice.