### PR TITLE
feat(web): add canonical PTT authority projector

### DIFF
--- a/frontend/src/lib/runtime/tx-controller/__tests__/app-authority.test.ts
+++ b/frontend/src/lib/runtime/tx-controller/__tests__/app-authority.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { ServerState } from '$lib/types/state';
+import { createAppAuthorityProjector } from '../app-authority';
+const session = (epoch: number, state: 'connected' | 'disconnected' = 'connected') => ({ epoch, state } as const);
+const capabilities = (overrides: Partial<Capabilities> = {}): Capabilities => ({
+  model: 'fixture', scope: false, audio: true, tx: true, audioTx: true,
+  audioTxRoute: 'lan', audioTxRequiredModInputSource: 5,
+  capabilities: ['tx', 'mod_input_routing'], receivers: 2, vfoScheme: 'main_sub',
+  freqRanges: [], modes: [], filters: [], audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
+  webrtc: { available: false, enabled: false },
+  txBands: [{ name: 'test', start: 100, end: 200 }], ...overrides,
+});
+const field = (at: number, source = 'poll_response', overrides: Record<string, unknown> = {}) => ({
+  storePath: 'global.tx_state.ptt', observed: true, freshness: 'fresh',
+  availability: 'available', lastObservedMonotonic: at, source: { source, provider: 'fixture' }, ...overrides,
+});
+function radio(overrides: Record<string, unknown> = {}): ServerState {
+  return {
+    ptt: false, active: 'SUB',
+    txTarget: { status: 'known', receiver: 'SUB', slot: 'B', frequencyHz: 150 },
+    main: { dataMode: 0 }, sub: { dataMode: 1 }, data1ModInput: 5,
+    fieldStatus: { txTarget: field(1), data1ModInput: field(1), ptt: field(1) }, ...overrides,
+  } as unknown as ServerState;
+}
+const withPtt = (evidence: unknown, ptt = false) => radio({ ptt, fieldStatus: { ...radio().fieldStatus, ptt: evidence } });
+describe('App TX authority projector', () => {
+  it('reuses canonical capability, target, MOD-input, and session facts fail closed', () => {
+    const project = createAppAuthorityProjector();
+    const state = radio();
+    const before = structuredClone(state);
+    const result = project(state, capabilities(), session(1));
+    expect(result).toMatchObject({
+      epoch: 1, modInputSource: { status: 'known', source: 5 },
+      facts: {
+        catPttAvailable: true, browserTxAudioAvailable: true,
+        modInputReadiness: { status: 'ready', source: 5 },
+        txTarget: { status: 'known', receiver: 'SUB', slot: 'B', frequencyHz: 150 },
+      },
+      eligibility: {
+        catPtt: true, browserTxAudio: true, controlLive: true,
+        permit: 'allowed', target: { receiver: 'SUB', slot: 'B', frequencyHz: 150 },
+      },
+    });
+    expect(state).toEqual(before);
+    const stale = radio({ fieldStatus: {
+      ...state.fieldStatus, txTarget: field(2, 'poll_response', { availability: 'stale' }),
+    } });
+    expect(project(stale, capabilities(), session(1)).eligibility.target).toBeNull();
+    expect(project(state, capabilities({ vfoScheme: 'single', receivers: 1 }), session(1)).facts?.txTarget.status).toBe('unknown');
+    expect(project(radio({ fieldStatus: { ...state.fieldStatus, data1ModInput: field(2, 'poll_response', { availability: 'stale' }) } }), capabilities(), session(1)).modInputSource).toEqual({ status: 'unknown' });
+    expect(project(stale, capabilities({ tx: false }), session(1)).eligibility.catPtt).toBe(false);
+    expect(project(null, null, session(1, 'disconnected'))).toMatchObject({
+      eligibility: { catPtt: false, browserTxAudio: false, controlLive: false, target: null },
+      facts: null, modInputSource: { status: 'unknown' },
+    });
+  });
+  it('advances only for genuinely newer qualifying field-specific evidence', () => {
+    const project = createAppAuthorityProjector();
+    expect(project(radio(), capabilities(), session(1)).ptt).toMatchObject({
+      observed: true, fresh: false, source: 'radio-readback',
+      marker: { pttObservationSeq: 1 },
+    });
+    const newer = withPtt(field(2, 'civ_unsolicited'));
+    expect(project(newer, capabilities(), session(1)).ptt).toMatchObject({
+      value: false, observed: true, fresh: true, source: 'backend-observation',
+      marker: { pttObservationSeq: 2, pttLastObservedMonotonic: 2 },
+    });
+    const duplicate = project(radio({ ptt: true, revision: 1_000, fieldStatus: { ...radio().fieldStatus, ptt: field(2, 'civ_unsolicited') } }), capabilities(), session(1));
+    expect(duplicate.ptt).toMatchObject({ value: true, fresh: false, marker: { pttObservationSeq: 2 } });
+    for (const malicious of ['toString', 'constructor', '__proto__'])
+      expect(project(withPtt(field(3, malicious)), capabilities(), session(1)).ptt).toMatchObject({ source: 'other', fresh: false, marker: { pttObservationSeq: 2, pttLastObservedMonotonic: 2 } });
+    expect(project(withPtt(field(3, 'hamlib_response')), capabilities(), session(1)).ptt.source).toBe('radio-readback');
+    expect(project(withPtt(field(4, 'yaesu_poll_response')), capabilities(), session(1)).ptt.fresh).toBe(true);
+  });
+  it('rejects bad evidence and retains a per-epoch baseline against stale epochs', () => {
+    const rejected = [
+      field(2, 'command_response'), field(3, 'state_poller'),
+      field(4, 'local_reconcile'), field(5, 'test'), field(6, 'unknown'),
+      field(Number.NaN), field(7, 'poll_response', { observed: false }),
+      field(8, 'poll_response', { freshness: 'stale' }),
+      field(9, 'poll_response', { availability: 'missing' }), undefined,
+    ];
+    for (const evidence of rejected) {
+      const project = createAppAuthorityProjector();
+      const first = project(withPtt(evidence), capabilities(), session(1));
+      expect(first.ptt).toMatchObject({ fresh: false, marker: { pttObservationSeq: 0 } });
+    }
+    const project = createAppAuthorityProjector();
+    project(radio(), capabilities(), session(1));
+    project(withPtt(field(2)), capabilities(), session(1));
+    const baseline = project(withPtt(field(10)), capabilities(), session(2));
+    expect(baseline.ptt).toMatchObject({ fresh: false, marker: { authorityEpoch: 2, pttObservationSeq: 3 } });
+    expect(project(withPtt(field(11)), capabilities(), session(1)))
+      .toMatchObject({ epoch: 2, eligibility: { controlLive: false }, ptt: { fresh: false } });
+    expect(project(withPtt(field(10)), capabilities(), session(2)).ptt.fresh).toBe(false);
+    expect(project(withPtt(field(12), true), capabilities(), session(2)).ptt)
+      .toMatchObject({ value: true, fresh: true, marker: { pttObservationSeq: 4 } });
+  });
+});

--- a/frontend/src/lib/runtime/tx-controller/app-authority.ts
+++ b/frontend/src/lib/runtime/tx-controller/app-authority.ts
@@ -1,0 +1,100 @@
+import { modInputStateKey } from '$lib/radio/mod-input';
+import { deriveTxCapabilities, type ModInputSource, type TxCapabilityFacts } from '$lib/runtime/adapters/tx-capabilities';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { ServerState, UnknownTxTargetPublic } from '$lib/types/state';
+import type { ControlSessionTransition } from '$lib/transport/ws-client';
+import type { Eligibility, PttObservation, TxTarget } from './model';
+export interface AppAuthorityProjection {
+  epoch: number; facts: TxCapabilityFacts | null; modInputSource: ModInputSource;
+  eligibility: Eligibility; ptt: PttObservation;
+}
+type AuthoritySource = PttObservation['source'];
+function authoritySource(source: unknown): AuthoritySource {
+  switch (source) {
+    case 'civ_unsolicited': return 'backend-observation';
+    case 'poll_response': case 'hamlib_response': case 'yaesu_poll_response': return 'radio-readback';
+    default: return 'other';
+  }
+}
+function available(state: ServerState, key: string): boolean {
+  const status = state.fieldStatus?.[key];
+  return status?.observed === true && status.freshness === 'fresh'
+    && status.availability === 'available';
+}
+function projectInputs(state: ServerState | null) {
+  if (!state) {
+    return {
+      txTarget: { status: 'unknown', reason: 'not-observed' } as UnknownTxTargetPublic,
+      modInputSource: { status: 'unknown' } as ModInputSource,
+    };
+  }
+  const txTarget = available(state, 'txTarget') ? state.txTarget : {
+    status: 'unknown' as const,
+    reason: state.fieldStatus?.txTarget?.availability === 'stale' ? 'stale' as const : 'not-observed' as const,
+  };
+  const receiver = state.active === 'SUB' ? state.sub : state.main;
+  const key = modInputStateKey(receiver?.dataMode ?? 0);
+  const source = state[key];
+  const modInputSource: ModInputSource = available(state, key)
+    && typeof source === 'number' && Number.isSafeInteger(source)
+    ? { status: 'known', source }
+    : { status: 'unknown' };
+  return { txTarget, modInputSource };
+}
+function controllerTarget(facts: TxCapabilityFacts | null): TxTarget {
+  const target = facts?.txTarget;
+  return target?.status === 'known' && typeof target.frequencyHz === 'number'
+    && Number.isFinite(target.frequencyHz)
+    ? { receiver: target.receiver, slot: target.slot, frequencyHz: target.frequencyHz }
+    : null;
+}
+export function createAppAuthorityProjector() {
+  let epoch = -1; let ordinal = 0;
+  let lastPttAt: number | null = null;
+  let needsBaseline = true;
+  return (state: ServerState | null, capabilities: Capabilities | null,
+    session: ControlSessionTransition): AppAuthorityProjection => {
+    const validEpoch = Number.isSafeInteger(session.epoch) && session.epoch >= 0;
+    const lowerEpoch = !validEpoch || session.epoch < epoch;
+    if (!lowerEpoch && session.epoch > epoch) {
+      epoch = session.epoch;
+      lastPttAt = null;
+      needsBaseline = true;
+    }
+    const currentSession = validEpoch && session.epoch === epoch;
+    const controlLive = currentSession && session.state === 'connected';
+    const inputs = projectInputs(state);
+    const facts = capabilities ? deriveTxCapabilities(capabilities, inputs) : null;
+    const target = controllerTarget(facts);
+    const eligibility: Eligibility = {
+      catPtt: facts?.catPttAvailable ?? false, browserTxAudio: facts?.browserTxAudioAvailable ?? false,
+      controlLive, permit: facts?.frequencyPermit.status ?? 'unknown', target,
+    };
+    const status = state?.fieldStatus?.ptt;
+    const source = authoritySource(status?.source?.source);
+    const at = status?.lastObservedMonotonic;
+    const qualifies = controlLive
+      && typeof state?.ptt === 'boolean'
+      && status?.observed === true
+      && status.freshness === 'fresh'
+      && status.availability === 'available'
+      && typeof at === 'number'
+      && Number.isFinite(at)
+      && source !== 'other'
+      && (lastPttAt === null || at > lastPttAt);
+    const baseline = qualifies && needsBaseline;
+    if (qualifies) { ordinal += 1; lastPttAt = at; needsBaseline = false; }
+    return {
+      epoch, facts, modInputSource: inputs.modInputSource, eligibility,
+      ptt: {
+        value: typeof state?.ptt === 'boolean' ? state.ptt : false,
+        observed: status?.observed === true, fresh: qualifies && !baseline, source,
+        marker: {
+          authorityEpoch: epoch,
+          pttObservationSeq: ordinal,
+          pttLastObservedMonotonic: lastPttAt,
+        },
+      },
+    };
+  };
+}


### PR DESCRIPTION
Closes #2071

Implements MOR-1156 as a dormant, canonical authority projection for PTT state.

- fail-closed source mapping with epoch baseline
- closes the prototype/production authority boundary
- includes focused mutant-resistant tests

No activation, surface-parity wiring, or hardware claim in this slice.

Checks: independent verification PASS, six mutation probes PASS, frontend gates PASS.