### PR TITLE
MOR-1150 Slice A: bind the managed TX effect host

### DIFF
--- a/src/rigplane/runtime/managed_radio_runtime.py
+++ b/src/rigplane/runtime/managed_radio_runtime.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, replace
 from typing import Literal, Protocol
 
 from rigplane.core.tx_safety import (
@@ -23,15 +25,31 @@ _ProviderLifecycleState = Literal["unbound", "bound", "invalidating"]
 
 
 class ProviderTxLifecycle(Protocol):
-    def _bind_authoritative_ptt_observer(
-        self, *, provider_generation: int, observer: _PttObserver
-    ) -> None: ...
-
     def _unbind_authoritative_ptt_observer(self) -> None: ...
 
     async def _request_authoritative_ptt_read(
         self, *, provider_generation: int, observer: _PttObserver
     ) -> None: ...
+
+    def _capture_managed_tx_port(
+        self, provider_generation: int, observer: _PttObserver
+    ) -> bool: ...
+
+    async def _write_managed_ptt(self, provider_generation: int, on: bool) -> None: ...
+
+    async def _retire_managed_tx_port(self, provider_generation: int) -> None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class _ManagedTxEffectHost:
+    _clock: Clock
+    write: Callable[[int, bool], Awaitable[None]]
+    read: Callable[[int], Awaitable[None]]
+    retire: Callable[[int], Awaitable[None]]
+
+
+TxServiceFactory = Callable[[_ManagedTxEffectHost], TxService]
+_ShutdownTask = asyncio.Task[tuple[TxTransition, BaseException | None]]
 
 
 class ManagedRadioRuntime:
@@ -39,7 +57,7 @@ class ManagedRadioRuntime:
         self,
         target_id: str,
         *,
-        service: TxService,
+        service_factory: TxServiceFactory,
         provider_lifecycle: ProviderTxLifecycle | None = None,
         clock: Clock | None = None,
         id_factory: IdFactory | None = None,
@@ -47,19 +65,23 @@ class ManagedRadioRuntime:
     ) -> None:
         if not 0 < shutdown_timeout_seconds < float("inf"):
             raise ValueError("shutdown_timeout_seconds must be finite-positive")
-        self.target_id = target_id
-        self._tx_safety = TxSafetySupervisor(clock=clock, id_factory=id_factory)
-        self._service = service
-        self._provider_lifecycle = provider_lifecycle
-        self._provider_generation = 0
+        self.target_id, self._clock = target_id, clock or time.monotonic
+        self._tx_safety = TxSafetySupervisor(clock=self._clock, id_factory=id_factory)
+        self._provider_lifecycle, self._provider_generation = provider_lifecycle, 0
         self._bound_generation: int | None = None
         self._provider_state: _ProviderLifecycleState = "unbound"
         self._provider_observer = self._observe_ptt
-        self._lifecycle_lock = asyncio.Lock()
+        self._lifecycle_lock, self._lifecycle_change = asyncio.Lock(), asyncio.Lock()
+        self._retirement_task: asyncio.Task[None] | None = None
+        self._retirement_generation: int | None = None
+        self._retirement_error: BaseException | None = None
         self._observation_version = 0
-        self._terminal = False
-        self._shutdown_transition: TxTransition | None = None
-        self._shutdown_timeout = shutdown_timeout_seconds
+        self._shutdown_task: _ShutdownTask | None = None
+        self._shutdown_pending, self._shutdown_timeout = False, shutdown_timeout_seconds
+        self._effect_host = _ManagedTxEffectHost(
+            self._clock, self._host_write, self._host_read, self._host_retire
+        )
+        self._service = service_factory(self._effect_host)
 
     @property
     def tx_snapshot(self) -> TxSafetySnapshot:
@@ -74,121 +96,200 @@ class ManagedRadioRuntime:
 
     def _observe_ptt(self, observation: ProviderPttObservation) -> None:
         if (
-            not self._terminal
+            not self._shutdown_pending
             and self._provider_state == "bound"
             and observation.provider_generation
             == self._bound_generation
             == self._provider_generation
         ):
-            transition = self._tx_safety.observe_ptt(observation)
+            transition = self._tx_safety.observe_ptt(
+                replace(observation, observed_at_monotonic=self._clock())
+            )
             if transition.outcome is TxOutcome.APPLIED:
                 self._observation_version += 1
 
-    def _unbind(self) -> BaseException | None:
-        lifecycle = self._provider_lifecycle
-        if self._provider_state != "bound" or lifecycle is None:
-            return None
-        self._provider_state = "invalidating"
-        self._bound_generation = None
-        try:
-            lifecycle._unbind_authoritative_ptt_observer()
-        except BaseException as exc:
-            return exc
-        return None
-
-    def _advance_provider(self) -> tuple[TxTransition, BaseException | None]:
-        unbind_error = self._unbind()
-        self._provider_generation += 1
-        transition = self._tx_safety.replace_provider(
-            self._provider_generation, ready=False
+    def _host_is_current(self, provider_generation: int) -> bool:
+        return self._provider_state == "bound" and (
+            provider_generation == self._bound_generation == self._provider_generation
         )
+
+    async def _host_write(self, provider_generation: int, on: bool) -> None:
+        if (
+            (lifecycle := self._provider_lifecycle) is None
+            or (on and self._shutdown_pending)
+            or not self._host_is_current(provider_generation)
+        ):
+            raise ConnectionError("managed TX effect host is stale")
+        await lifecycle._write_managed_ptt(provider_generation, on)
+
+    async def _host_read(self, provider_generation: int) -> None:
+        lifecycle = self._provider_lifecycle
+        if lifecycle is None or not self._host_is_current(provider_generation):
+            raise ConnectionError("managed TX effect host is stale")
+        await lifecycle._request_authoritative_ptt_read(
+            provider_generation=provider_generation, observer=self._provider_observer
+        )
+
+    def _advance_provider(self) -> TxTransition:
+        self._provider_generation += 1
+        return self._tx_safety.replace_provider(self._provider_generation, ready=False)
+
+    def _begin_retirement(self) -> asyncio.Task[None] | None:
+        if self._provider_state == "invalidating":
+            return self._retirement_task
+        lifecycle, generation = self._provider_lifecycle, self._bound_generation
+        self._bound_generation, self._provider_state = None, "invalidating"
+        if lifecycle is None or generation is None:
+            self._provider_state = "unbound"
+            return None
+        task = asyncio.create_task(lifecycle._retire_managed_tx_port(generation))
+        self._retirement_task, self._retirement_generation = task, generation
+        self._retirement_error = None
+        return task
+
+    async def _await_retirement(
+        self, task: asyncio.Task[None] | None
+    ) -> BaseException | None:
+        if task is None:
+            return None
+        if task is self._retirement_task and self._retirement_error is not None:
+            return self._retirement_error
+        cancellation: BaseException | None = None
+        while not task.done():
+            try:
+                await asyncio.shield(task)
+            except BaseException as exc:
+                if not task.cancelled():
+                    cancellation = exc
+        try:
+            error = task.exception()
+        except asyncio.CancelledError as exc:
+            error = exc
+        if error is not None:
+            self._retirement_error = error
+            return error
+        self._retirement_task = self._retirement_generation = None
         self._provider_state = "unbound"
-        return transition, unbind_error
+        return cancellation
+
+    async def _host_retire(self, provider_generation: int) -> None:
+        async with self._lifecycle_change:
+            async with self._lifecycle_lock:
+                if (
+                    self._provider_state == "invalidating"
+                    and provider_generation == self._retirement_generation
+                ):
+                    task = self._retirement_task
+                else:
+                    if not self._host_is_current(provider_generation):
+                        raise ConnectionError("managed TX effect host is stale")
+                    task = self._begin_retirement()
+                    self._advance_provider()
+            if error := await self._await_retirement(task):
+                raise error
 
     async def replace_provider(self, *, ready: bool) -> TxTransition:
-        async with self._lifecycle_lock:
-            if self._terminal:
-                return self._not_ready()
-            transition, unbind_error = self._advance_provider()
-            if unbind_error is not None:
-                raise unbind_error
-            lifecycle = self._provider_lifecycle
-            if lifecycle is None:
-                return transition
-            self._provider_observer = self._observe_ptt
-            try:
-                lifecycle._bind_authoritative_ptt_observer(
-                    provider_generation=self._provider_generation,
-                    observer=self._provider_observer,
-                )
-            except BaseException:
+        async with self._lifecycle_change:
+            async with self._lifecycle_lock:
+                if self._shutdown_pending:
+                    return self._not_ready()
+                task, transition = self._begin_retirement(), self._advance_provider()
+            error = await self._await_retirement(task)
+            async with self._lifecycle_lock:
+                if self._shutdown_pending:
+                    return self._not_ready()
+                if error is not None:
+                    raise error
+                lifecycle = self._provider_lifecycle
+                if lifecycle is None:
+                    return transition
                 try:
-                    lifecycle._unbind_authoritative_ptt_observer()
+                    captured = lifecycle._capture_managed_tx_port(
+                        self._provider_generation, self._provider_observer
+                    )
                 except BaseException:
-                    pass
-                raise
-            self._bound_generation = self._provider_generation
-            self._provider_state = "bound"
-            if ready:
-                transition = self._tx_safety.set_provider_ready(
-                    self._provider_generation, ready=True
-                )
-            await self._service_effects(transition)
-            return transition
+                    try:
+                        lifecycle._unbind_authoritative_ptt_observer()
+                    except BaseException:
+                        pass
+                    raise
+                if captured:
+                    self._bound_generation = self._provider_generation
+                    self._provider_state = "bound"
+                    if ready:
+                        transition = self._tx_safety.set_provider_ready(
+                            self._provider_generation, ready=True
+                        )
+        await self._service_effects(transition)
+        return self._not_ready() if self._shutdown_pending else transition
 
     async def invalidate_provider(self, provider_generation: int) -> TxTransition:
-        async with self._lifecycle_lock:
-            if self._terminal:
-                return self._not_ready()
-            if provider_generation != self._provider_generation:
-                return TxTransition(TxOutcome.STALE, self.tx_snapshot)
-            transition, unbind_error = self._advance_provider()
-            if unbind_error is not None:
-                raise unbind_error
+        async with self._lifecycle_change:
+            async with self._lifecycle_lock:
+                if self._shutdown_pending:
+                    return self._not_ready()
+                if provider_generation != self._provider_generation:
+                    return TxTransition(TxOutcome.STALE, self.tx_snapshot)
+                task, transition = self._begin_retirement(), self._advance_provider()
+            error = await self._await_retirement(task)
+            async with self._lifecycle_lock:
+                if self._shutdown_pending:
+                    return self._not_ready()
+            if error is not None:
+                raise error
             return transition
 
     async def request_fresh_ptt(self) -> TxTransition:
-        async with self._lifecycle_lock:
-            lifecycle = self._provider_lifecycle
-            if (
-                self._terminal
-                or lifecycle is None
-                or self._provider_state != "bound"
-                or self._bound_generation != self._provider_generation
-            ):
-                return self._not_ready()
-            version = self._observation_version
+        async with self._lifecycle_change:
+            async with self._lifecycle_lock:
+                generation = self._provider_generation
+                if self._shutdown_pending or not self._host_is_current(generation):
+                    return self._not_ready()
+                version = self._observation_version
+            error: BaseException | None = None
             try:
-                await lifecycle._request_authoritative_ptt_read(
-                    provider_generation=self._provider_generation,
-                    observer=self._provider_observer,
-                )
-                if self._observation_version == version:
-                    raise RuntimeError("provider returned no authoritative PTT")
-            except BaseException:
+                await self._effect_host.read(generation)
+            except BaseException as exc:
+                error = exc
+            async with self._lifecycle_lock:
+                if self._shutdown_pending:
+                    return self._not_ready()
+                if not self._host_is_current(generation):
+                    return self._not_ready()
+                if error is None and self._observation_version != version:
+                    return TxTransition(TxOutcome.APPLIED, self.tx_snapshot)
+                retirement_task = self._begin_retirement()
                 self._advance_provider()
-                raise
-            return TxTransition(TxOutcome.APPLIED, self.tx_snapshot)
+            retirement_error = await self._await_retirement(retirement_task)
+            async with self._lifecycle_lock:
+                if self._shutdown_pending:
+                    return self._not_ready()
+            if retirement_error is not None:
+                raise retirement_error
+            if error is not None:
+                raise error
+            raise RuntimeError("provider returned no authoritative PTT")
 
     async def set_provider_ready(self, *, ready: bool) -> TxTransition:
-        if ready and (
-            self._provider_state != "bound"
-            or self._bound_generation != self._provider_generation
-        ):
-            return self._not_ready()
-        transition = self._tx_safety.set_provider_ready(
-            self._provider_generation, ready=ready
-        )
+        async with self._lifecycle_lock:
+            if self._shutdown_pending or (
+                ready and not self._host_is_current(self._provider_generation)
+            ):
+                return self._not_ready()
+            transition = self._tx_safety.set_provider_ready(
+                self._provider_generation, ready=ready
+            )
         await self._service_effects(transition)
-        return transition
+        async with self._lifecycle_lock:
+            return self._not_ready() if self._shutdown_pending else transition
 
     async def request_on(self, owner: TxOwner) -> TxTransition:
-        if (
-            self._provider_state != "bound"
-            or self._bound_generation != self._provider_generation
-        ):
-            return self._not_ready()
-        transition = self._tx_safety.request_on(owner)
+        async with self._lifecycle_lock:
+            if self._shutdown_pending or not self._host_is_current(
+                self._provider_generation
+            ):
+                return self._not_ready()
+            transition = self._tx_safety.request_on(owner)
         await self._service_effects(transition)
         return transition
 
@@ -199,43 +300,62 @@ class ManagedRadioRuntime:
         *,
         reason: TxReleaseReason = TxReleaseReason.OPERATOR_RELEASE,
     ) -> TxTransition:
-        transition = self._tx_safety.request_off(owner, lease_id, reason=reason)
+        async with self._lifecycle_lock:
+            if self._shutdown_pending:
+                return TxTransition(TxOutcome.IDEMPOTENT, self.tx_snapshot)
+            transition = self._tx_safety.request_off(owner, lease_id, reason=reason)
         await self._service_effects(transition)
         return transition
 
     async def release_owner(
         self, owner: TxOwner, *, reason: TxReleaseReason
     ) -> TxTransition:
-        transition = self._tx_safety.release_owner(owner, reason=reason)
+        async with self._lifecycle_lock:
+            if self._shutdown_pending:
+                return TxTransition(TxOutcome.IDEMPOTENT, self.tx_snapshot)
+            transition = self._tx_safety.release_owner(owner, reason=reason)
         await self._service_effects(transition)
         return transition
 
     async def shutdown(self, *, release_provider: ProviderRelease) -> TxTransition:
         async with self._lifecycle_lock:
-            if self._shutdown_transition is not None:
-                return self._shutdown_transition
-            transition = self._tx_safety.emergency_release(
-                reason=TxReleaseReason.SERVER_SHUTDOWN
-            )
-            self._shutdown_transition = transition
-            error: BaseException | None = None
-            try:
-                if transition.outcome is not TxOutcome.NOOP:
-                    await asyncio.wait_for(
-                        self._service_effects(transition),
-                        timeout=self._shutdown_timeout,
-                    )
-            except TimeoutError:
-                pass
-            except BaseException as exc:
-                error = exc
-            self._terminal = True
-            _, unbind_error = self._advance_provider()
-            try:
-                await release_provider()
-            except BaseException as exc:
-                error = error or exc
-            error = error or unbind_error
-            if error is not None:
-                raise error
-            return transition
+            task = self._shutdown_task
+            if task is None:
+                self._shutdown_pending = True
+                transition = self._tx_safety.emergency_release(
+                    reason=TxReleaseReason.SERVER_SHUTDOWN
+                )
+                task = asyncio.create_task(
+                    self._complete_shutdown(transition, release_provider)
+                )
+                self._shutdown_task = task
+        transition, error = await asyncio.shield(task)
+        if error is not None:
+            raise error
+        return transition
+
+    async def _complete_shutdown(
+        self, transition: TxTransition, release_provider: ProviderRelease
+    ) -> tuple[TxTransition, BaseException | None]:
+        error: BaseException | None = None
+        try:
+            if transition.outcome is not TxOutcome.NOOP:
+                await asyncio.wait_for(
+                    self._service_effects(transition),
+                    timeout=self._shutdown_timeout,
+                )
+        except TimeoutError:
+            pass
+        except BaseException as exc:
+            error = exc
+        async with self._lifecycle_change:
+            async with self._lifecycle_lock:
+                task = self._begin_retirement()
+                self._advance_provider()
+            retirement_error = await self._await_retirement(task)
+            error = error or retirement_error
+        try:
+            await release_provider()
+        except BaseException as exc:
+            error = error or exc
+        return transition, error

--- a/tests/test_managed_radio_runtime.py
+++ b/tests/test_managed_radio_runtime.py
@@ -33,10 +33,15 @@ class ProviderLifecycle:
         self.bind_error = self.unbind_error = False
         self.unbinds = 0
         self.reads: list[tuple[int, Callable[[ProviderPttObservation], None]]] = []
-        self.read_started = asyncio.Event()
-        self.read_release = asyncio.Event()
-        self.read_blocked = False
+        self.read_started, self.read_release = asyncio.Event(), asyncio.Event()
+        self.read_blocked, self.emit_read_observation = False, True
         self.read_error: BaseException | None = None
+        self.captures, self.capture_result = 0, True
+        self.writes: list[tuple[int, bool]] = []
+        self.retirements: list[int] = []
+        self.retire_started, self.retire_release = asyncio.Event(), asyncio.Event()
+        self.retire_error: BaseException | None = None
+        self.retire_release.set()
 
     def _bind_authoritative_ptt_observer(
         self,
@@ -72,7 +77,32 @@ class ProviderLifecycle:
             await self.read_release.wait()
         if self.read_error is not None:
             raise self.read_error
-        observer(ProviderPttObservation(RadioTx.OFF, provider_generation, 1, 10.0))
+        if self.emit_read_observation:
+            observer(ProviderPttObservation(RadioTx.OFF, provider_generation, 2, 10.0))
+
+    def _capture_managed_tx_port(
+        self,
+        provider_generation: int,
+        observer: Callable[[ProviderPttObservation], None],
+    ) -> bool:
+        self.captures += 1
+        self._bind_authoritative_ptt_observer(
+            provider_generation=provider_generation, observer=observer
+        )
+        if not self.capture_result:
+            self._unbind_authoritative_ptt_observer()
+        return self.capture_result
+
+    async def _write_managed_ptt(self, provider_generation: int, on: bool) -> None:
+        self.writes.append((provider_generation, on))
+
+    async def _retire_managed_tx_port(self, provider_generation: int) -> None:
+        self.retirements.append(provider_generation)
+        self.retire_started.set()
+        await self.retire_release.wait()
+        if self.retire_error is not None:
+            raise self.retire_error
+        self._unbind_authoritative_ptt_observer()
 
 
 def ids() -> Iterator[str]:
@@ -98,7 +128,7 @@ def runtime(
     generated = ids()
     return ManagedRadioRuntime(
         target,
-        service=service,
+        service_factory=lambda _host: service,
         provider_lifecycle=lifecycle or ProviderLifecycle(),
         clock=lambda: 10.0,
         id_factory=lambda: next(generated),
@@ -150,27 +180,6 @@ async def test_target_owns_one_supervisor_across_consumers_and_generations() -> 
 
 
 @pytest.mark.asyncio
-async def test_ready_provider_services_pending_off_before_return() -> None:
-    order: list[str] = []
-
-    async def service(_supervisor: TxSafetySupervisor, transition: object) -> None:
-        effect = getattr(transition, "effects")[0]
-        order.append(getattr(effect, "kind", "cancel"))
-
-    rt = runtime(service=service)
-    owner, attempt = await acquire(rt)
-    lease = rt.tx_snapshot.lease_id or ""
-    await rt.request_off(owner, lease)
-
-    await rt.replace_provider(ready=False)
-    await rt.set_provider_ready(ready=True)
-    order.append("ordinary")
-
-    assert order[-2:] == [ProviderAttemptKind.WRITE_OFF, "ordinary"]
-    assert rt.tx_snapshot.active_attempt != attempt
-
-
-@pytest.mark.asyncio
 async def test_managed_requests_service_once_and_return_owner_lease_identity() -> None:
     serviced: list[TxTransition] = []
 
@@ -213,64 +222,86 @@ async def test_request_off_service_error_propagates_and_retains_durable_off() ->
 
     assert rt.tx_snapshot.phase is TxPhase.RELEASE_REQUIRED
     repeated = await rt.request_off(owner, lease)
-    assert repeated.outcome is TxOutcome.IDEMPOTENT
-    assert rt.tx_snapshot.lease_id == lease
+    assert repeated.outcome is TxOutcome.IDEMPOTENT and rt.tx_snapshot.lease_id == lease
 
 
 @pytest.mark.asyncio
-async def test_shutdown_bounds_dekey_before_provider_release() -> None:
-    order: list[str] = []
+async def test_shutdown_fences_readiness_and_terminal_reason() -> None:
+    provider, started, finish = ProviderLifecycle(), asyncio.Event(), asyncio.Event()
     armed = False
 
     async def service(_supervisor: TxSafetySupervisor, transition: object) -> None:
         if not armed or not getattr(transition, "effects"):
             return
-        order.append("dekey")
-        await asyncio.Event().wait()
+        await rt._effect_host.write(rt.tx_snapshot.provider_generation, False)
+        started.set()
+        await finish.wait()
 
-    rt = runtime(service=service)
-    await acquire(rt)
+    rt = runtime(service=service, lifecycle=provider)
+    owner, _ = await acquire(rt)
+    lease = rt.tx_snapshot.lease_id or ""
+    await rt.request_off(owner, lease)
+    await rt.replace_provider(ready=False)
     armed = True
+    readiness = asyncio.create_task(rt.set_provider_ready(ready=True))
+    await asyncio.wait_for(started.wait(), 0.2)
+    shutdown = asyncio.create_task(
+        rt.shutdown(release_provider=lambda: asyncio.sleep(0))
+    )
+    await asyncio.sleep(0)
+    with pytest.raises(ConnectionError, match="stale"):
+        await rt._effect_host.write(2, True)
+    late = await asyncio.gather(
+        rt.request_off(owner, lease),
+        rt.release_owner(owner, reason=TxReleaseReason.SOURCE_DETACHED),
+        rt.set_provider_ready(ready=False),
+        rt.set_provider_ready(ready=True),
+    )
+    assert not readiness.done() and provider.writes
+    assert all(not on for _generation, on in provider.writes)
+    assert [item.outcome for item in late[2:]] == [TxOutcome.NOT_READY] * 2
+    assert all(
+        item.snapshot.terminal_release_reason is TxReleaseReason.SERVER_SHUTDOWN
+        for item in late
+    )
+    finish.set()
+    assert (await readiness).outcome is TxOutcome.NOT_READY
+    assert (await shutdown).snapshot.phase is TxPhase.RELEASE_REQUIRED
 
-    async def release() -> None:
-        order.append("release")
 
-    result = await rt.shutdown(release_provider=release)
-
-    assert order == ["dekey", "release"]
-    assert result.snapshot.phase is TxPhase.RELEASE_REQUIRED
-
-
+@pytest.mark.parametrize(
+    "error", [RuntimeError("dekey failed"), asyncio.CancelledError("retire-cancelled")]
+)
 @pytest.mark.asyncio
-async def test_shutdown_error_still_releases_provider() -> None:
-    released = False
-
-    armed = False
-
-    async def service(_supervisor: TxSafetySupervisor, transition: object) -> None:
-        if armed and getattr(transition, "effects"):
-            raise RuntimeError("dekey failed")
-
-    rt = runtime(service=service)
+async def test_shutdown_error_is_shared(error: BaseException) -> None:
+    provider = ProviderLifecycle()
+    provider.retire_error = error
+    provider.retire_release.clear()
+    rt = runtime(lifecycle=provider)
     await acquire(rt)
-    armed = True
 
-    async def release() -> None:
-        nonlocal released
-        released = True
+    async def capture() -> BaseException:
+        try:
+            await rt.shutdown(release_provider=lambda: asyncio.sleep(0))
+        except BaseException as raised:
+            return raised
+        raise AssertionError("shutdown did not propagate retirement failure")
 
-    with pytest.raises(RuntimeError, match="dekey failed"):
-        await rt.shutdown(release_provider=release)
-    assert released
+    waiter = asyncio.create_task(rt.shutdown(release_provider=lambda: asyncio.sleep(0)))
+    await provider.retire_started.wait()
+    assert waiter.cancel()
+    await asyncio.gather(waiter, return_exceptions=True)
+    errors = asyncio.gather(capture(), capture())
+    provider.retire_release.set()
+    caught = await errors
+    assert caught[0] is caught[1] is error and provider.retirements == [1]
 
 
 @pytest.mark.asyncio
 async def test_real_core_radio_keyword_port_binds_effectless_generation() -> None:
     radio = CoreRadio("127.0.0.1")
     rt = runtime(lifecycle=radio)
-
     changed = await rt.replace_provider(ready=False)
-
     assert changed.snapshot.provider_generation == 1
     assert radio._civ_runtime._ptt_observer_provider_generation == 1
     await rt.invalidate_provider(1)
@@ -285,13 +316,10 @@ async def test_real_core_radio_fresh_read_preserves_healthy_generation() -> None
     rt = runtime(lifecycle=radio)
     await rt.replace_provider(ready=True)
     transport.queue_response(_ptt_response(False))
-
     result = await rt.request_fresh_ptt()
 
-    assert result.outcome is TxOutcome.APPLIED
-    assert len(transport.sent_packets) == 1
-    assert rt.tx_snapshot.provider_generation == 1
-    assert rt.tx_snapshot.provider_ready
+    assert result.outcome is TxOutcome.APPLIED and len(transport.sent_packets) == 1
+    assert rt.tx_snapshot.provider_generation == 1 and rt.tx_snapshot.provider_ready
     assert rt.tx_snapshot.radio_tx is RadioTx.OFF
     radio._connected = False
 
@@ -303,13 +331,14 @@ async def test_unbound_bind_failure_and_stale_callback_fail_closed() -> None:
     owner = TxOwner(TxSource.SDK, "sdk")
     assert (await rt.request_on(owner)).outcome is TxOutcome.NOT_READY
 
+    provider.capture_result = False
+    assert (await rt.replace_provider(ready=True)).snapshot.provider_ready is False
+    provider.capture_result = True
     provider.bind_error = True
     with pytest.raises(RuntimeError, match="bind failed"):
         await rt.replace_provider(ready=True)
     generation, observer = provider.bindings[-1]
-    assert rt.tx_snapshot.provider_generation == generation == 1
-    assert rt.tx_snapshot.provider_ready is False
-    assert callable(observer)
+    assert rt.tx_snapshot.provider_generation == generation == 2
     observer(ProviderPttObservation(RadioTx.ON, generation, 1, 10.0))
     assert rt.tx_snapshot.radio_tx is RadioTx.UNKNOWN
     assert (await rt.request_on(owner)).outcome is TxOutcome.NOT_READY
@@ -328,25 +357,75 @@ async def test_unbind_failure_still_invalidates_host_and_old_callback() -> None:
         await rt.invalidate_provider(generation)
 
     assert rt.tx_snapshot.provider_generation == 2
-    assert rt.tx_snapshot.provider_ready is False
-    assert callable(observer)
     observer(ProviderPttObservation(RadioTx.ON, generation, 1, 10.0))
     assert rt.tx_snapshot.radio_tx is RadioTx.UNKNOWN
     assert (await rt.set_provider_ready(ready=True)).outcome is TxOutcome.NOT_READY
 
 
 @pytest.mark.asyncio
-async def test_replacement_rejects_old_generation_callback() -> None:
+async def test_factory_clock_capture_and_stale_host_are_generation_safe() -> None:
+    provider = ProviderLifecycle()
+    hosts: list[object] = []
+
+    def clock() -> float:
+        return 23.0
+
+    rt = ManagedRadioRuntime(
+        "radio",
+        service_factory=lambda host: hosts.append(host) or no_effects,
+        provider_lifecycle=provider,
+        clock=clock,
+    )
+    await rt.replace_provider(ready=True)
+    generation, observer = provider.bindings[-1]
+    observer(ProviderPttObservation(RadioTx.OFF, generation, 1, 1.0))
+    assert rt._tx_safety._observation.observed_at_monotonic == 23.0
+    host = rt._effect_host
+    await rt.replace_provider(ready=True)
+    observer(ProviderPttObservation(RadioTx.ON, generation, 1, 10.0))
+    for call in (
+        host.write(generation, True),
+        host.read(generation),
+        host.retire(generation),
+    ):
+        with pytest.raises(ConnectionError, match="stale"):
+            await call
+    assert len(hosts) == 1 and provider.captures == 2
+    assert host._clock is rt._tx_safety._clock is clock
+    assert rt._tx_safety._observation is None
+    assert (provider.writes, provider.reads, provider.retirements) == ([], [], [1])
+    assert not any(
+        hasattr(host, name) for name in ("runtime", "provider", "transport", "set_ptt")
+    )
+
+
+@pytest.mark.parametrize(
+    "retire_error", [RuntimeError("retire failed"), asyncio.CancelledError("cancelled")]
+)
+@pytest.mark.asyncio
+async def test_failed_retirement_retry_observes_latched_outcome(
+    retire_error: BaseException,
+) -> None:
     provider = ProviderLifecycle()
     rt = runtime(lifecycle=provider)
     await rt.replace_provider(ready=True)
-    generation, observer = provider.bindings[-1]
+    provider.retire_error = retire_error
+    tasks, errors = [], []
+    for _attempt in range(2):
+        with pytest.raises(type(retire_error), match=str(retire_error)) as raised:
+            await rt._effect_host.retire(1)
+        tasks.append(rt._retirement_task)
+        errors.append(raised.value)
 
-    await rt.replace_provider(ready=True)
-    observer(ProviderPttObservation(RadioTx.ON, generation, 1, 10.0))
-
-    assert rt.tx_snapshot.provider_generation == 2
-    assert rt.tx_snapshot.radio_tx is RadioTx.UNKNOWN
+    assert tasks[0] is tasks[1] and tasks[0] is not None and tasks[0].done()
+    assert errors[0] is errors[1] is retire_error
+    assert provider.retirements == [1] and rt._provider_state == "invalidating"
+    assert not rt._lifecycle_lock.locked()
+    assert rt.tx_snapshot.provider_generation == 2 and not rt.tx_snapshot.provider_ready
+    for stale in (0, 2):
+        with pytest.raises(ConnectionError, match="stale"):
+            await rt._effect_host.retire(stale)
+    assert provider.retirements == [1]
 
 
 @pytest.mark.asyncio
@@ -443,10 +522,10 @@ async def test_shutdown_is_terminal_and_cleans_up_exactly_once() -> None:
 
     assert first is second
     assert len(serviced) == provider.unbinds == releases == 1
-    assert rt.tx_snapshot.provider_generation == 2
-    assert rt.tx_snapshot.provider_ready is False
+    assert rt.tx_snapshot.provider_generation == 2 and not rt.tx_snapshot.provider_ready
     assert rt.tx_snapshot.radio_tx is RadioTx.UNKNOWN
-    assert rt.tx_snapshot.lease_id is None
+    assert rt.tx_snapshot.lease_id == first.snapshot.lease_id
+    assert rt.tx_snapshot.terminal_release_reason is TxReleaseReason.SERVER_SHUTDOWN
     assert (await rt.replace_provider(ready=True)).outcome is TxOutcome.NOT_READY
     assert (await rt.request_fresh_ptt()).outcome is TxOutcome.NOT_READY
     assert (await rt.set_provider_ready(ready=True)).outcome is TxOutcome.NOT_READY


### PR DESCRIPTION
## Summary

- bind one private generation-qualified managed TX effect host per provider generation
- serialize terminal retirement and preserve shutdown precedence across replacement races
- add direct mock-based coverage for the bounded Slice A behavior

## Scope

This is MOR-1150 Slice A only. The dependent test-only Slice B remains tracked separately in MOR-1163 / #2073.

Refs #2069
Refs #2073

## Compatibility and evidence boundary

- no public API, CLI/config, protocol/rigctld, transport, frontend, or hardware change
- software/mock evidence only; this PR makes no real-hardware validation claim
- no MOR-1151 executor lane or claims

## Verification

- exact diff guard: 2 owned files, +199 net LOC
- pre-publication full-index patch SHA-256: `7d505572c2f7c7d494bb27da808070201f29911df58490c5c626d9a182a9176e`
- fresh exact-head independent review and required CI will be recorded before Ready/merge
