### PR TITLE
MOR-1157: provide TxController browser dependencies

### DIFF
--- a/frontend/src/lib/runtime/tx-controller/__tests__/browser-dependencies.test.ts
+++ b/frontend/src/lib/runtime/tx-controller/__tests__/browser-dependencies.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { CommandDeliveryEvent, ControlSessionTransition } from '$lib/transport/ws-client';
+const h = vi.hoisted(() => ({
+  radio: null as any, caps: null as any, deliveries: new Set<(event: CommandDeliveryEvent) => void>(),
+  sessions: new Set<(event: ControlSessionTransition) => void>(), send: vi.fn((_name: string, _params: Record<string, unknown>, _id?: string) => true),
+  start: vi.fn(async () => null), stop: vi.fn(), restore: vi.fn(), ids: 0,
+}));
+vi.mock('$lib/stores/radio.svelte', () => ({ getRadioState: () => h.radio }));
+vi.mock('$lib/stores/capabilities.svelte', () => ({ getCapabilities: () => h.caps }));
+vi.mock('$lib/types/protocol', () => ({ makeCommandId: () => `cmd-${++h.ids}` }));
+vi.mock('$lib/runtime/adapters/tx-adapter', () => ({ getTxAudioControl: () => ({
+  startTx: h.start, stopLocalAudio: h.stop, restoreModAfterConfirmedOff: h.restore,
+}) }));
+vi.mock('$lib/transport/ws-client', () => ({
+  sendCommand: h.send,
+  onCommandDelivery: (fn: (event: CommandDeliveryEvent) => void) => {
+    h.deliveries.add(fn); return () => h.deliveries.delete(fn);
+  },
+  onControlSessionTransition: (fn: (event: ControlSessionTransition) => void) => {
+    h.sessions.add(fn); return () => h.sessions.delete(fn);
+  },
+}));
+import { createBrowserTxControllerDependencies } from '../browser-dependencies';
+const field = (at: number) => ({ observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: at, source: { source: 'poll_response' } });
+const target = { receiver: 'SUB' as const, slot: 'B' as const, frequencyHz: 150 };
+const correlation = { leaseId: 'lease', generation: 1, originalEpoch: 4, target };
+function resetFacts() {
+  h.radio = { revision: 1, ptt: false, active: 'SUB', txTarget: { status: 'known', ...target },
+    main: { dataMode: 0 }, sub: { dataMode: 1 }, data1ModInput: 5,
+    fieldStatus: { ptt: field(1), txTarget: field(1), data1ModInput: field(1) } };
+  h.caps = { tx: true, audioTx: true, capabilities: ['tx', 'mod_input_routing'],
+    vfoScheme: 'main_sub', audioTxRequiredModInputSource: 5, txBands: [{ start: 100, end: 200 }] } as Capabilities;
+}
+const emit = (event: CommandDeliveryEvent) => [...h.deliveries].forEach((fn) => fn(event));
+beforeEach(() => {
+  vi.useFakeTimers(); resetFacts(); h.deliveries.clear(); h.sessions.clear(); h.send.mockReset().mockReturnValue(true);
+  h.start.mockClear(); h.stop.mockClear(); h.restore.mockClear(); h.ids = 0;
+});
+describe('browser TxController dependencies', () => {
+  it('is dormant, exposes removable synchronous seams, delegates audio, and disposes timers', async () => {
+    const factory = createBrowserTxControllerDependencies();
+    expect([h.deliveries.size, h.sessions.size, h.start.mock.calls.length, vi.getTimerCount()]).toEqual([0, 0, 0, 0]);
+    expect(factory.projectAuthority({ state: 'connected', epoch: 4 }).eligibility.target).toEqual(target); expect(factory.dependencies.commandId('on')).toBe('cmd-1');
+    const seen: number[] = []; const offSession = factory.subscribeSession((projection) => seen.push(projection.epoch));
+    [...h.sessions][0]({ state: 'connected', epoch: 5 }); expect(seen).toEqual([5]); offSession(); expect(h.sessions.size).toBe(0);
+    let lifecycle!: () => void; let releases = 0; const unsubscribe = vi.fn();
+    factory.bindLifecycleRelease((fn) => { lifecycle = fn; return unsubscribe; }, () => releases++);
+    lifecycle(); expect(releases).toBe(1);
+    await expect(factory.dependencies.startAudio()).resolves.toBeNull(); factory.dependencies.stopLocalAudio();
+    factory.dependencies.restoreMod({ authorityEpoch: 5, pttObservationSeq: 1, pttLastObservedMonotonic: 1 },
+      { value: false, observed: true, fresh: true, source: 'radio-readback',
+        marker: { authorityEpoch: 5, pttObservationSeq: 2, pttLastObservedMonotonic: 2 } });
+    expect([h.start.mock.calls.length, h.stop.mock.calls.length, h.restore.mock.calls.length]).toEqual([1, 1, 1]);
+    const canceled = vi.fn(); const clear = vi.spyOn(globalThis, 'clearTimeout');
+    const canceledHandle = factory.dependencies.schedule(canceled, 10); factory.dependencies.cancel(canceledHandle);
+    expect(clear).toHaveBeenCalledWith(canceledHandle); vi.advanceTimersByTime(20); expect(canceled).not.toHaveBeenCalled();
+    const fired = vi.fn(); factory.dependencies.schedule(fired, 10); factory.subscribeSession(vi.fn());
+    factory.dispose(); factory.dispose(); vi.advanceTimersByTime(20); lifecycle();
+    expect([fired.mock.calls.length, h.sessions.size, h.deliveries.size, vi.getTimerCount(), unsubscribe.mock.calls.length, releases])
+      .toEqual([0, 0, 0, 0, 1, 1]);
+    factory.dependencies.sendPtt('on', 'disposed', correlation, vi.fn()); expect(h.send).not.toHaveBeenCalled();
+    clear.mockRestore();
+  });
+  it('registers before send, freezes lease correlation, and maps only delivery evidence', () => {
+    const factory = createBrowserTxControllerDependencies();
+    factory.projectAuthority({ state: 'connected', epoch: 4 });
+    h.radio = { ...h.radio, revision: 9_999, txTarget: { status: 'known', receiver: 'MAIN', slot: 'A', frequencyHz: 199 },
+      fieldStatus: { ...h.radio.fieldStatus, ptt: field(2) } };
+    h.send.mockImplementation((_name, _params, id) => {
+      emit({ commandId: id!, kind: 'transport-sent', originalEpoch: 4, eventEpoch: 7 }); return true;
+    });
+    const reports: any[] = [];
+    factory.dependencies.sendPtt('on', 'on-1', correlation, (report) => reports.push(report));
+    expect(h.send).toHaveBeenCalledWith('ptt_on', { target, originalEpoch: 4 }, 'on-1');
+    expect(reports).toEqual([{ outcome: 'sent', eventEpoch: 7,
+      barrier: { authorityEpoch: 7, pttObservationSeq: 2, pttLastObservedMonotonic: 2 } }]);
+    emit({ commandId: 'foreign', kind: 'error', originalEpoch: 4, eventEpoch: 7 });
+    emit({ commandId: 'on-1', kind: 'ack', originalEpoch: 3, eventEpoch: 7 }); expect(reports).toHaveLength(1);
+    for (const [kind, outcome] of [['ack', 'ack'], ['response-ok', 'response-ok']] as const) {
+      emit({ commandId: 'on-1', kind, originalEpoch: 4, eventEpoch: 7 });
+      expect(reports.at(-1)).toEqual({ outcome, eventEpoch: 7, barrier: null });
+    }
+    expect(h.restore).not.toHaveBeenCalled(); expect(h.deliveries.size).toBe(0);
+    emit({ commandId: 'on-1', kind: 'error', originalEpoch: 4, eventEpoch: 7 }); expect(reports).toHaveLength(3);
+  });
+  it('fails ON closed but keeps OFF queued with its original lease epoch across reconnect', () => {
+    const factory = createBrowserTxControllerDependencies(); factory.projectAuthority({ state: 'connected', epoch: 4 });
+    h.send.mockReturnValue(false); const on: any[] = []; const off: any[] = [];
+    factory.dependencies.sendPtt('on', 'on-refused', correlation, (report) => on.push(report));
+    factory.dependencies.sendPtt('off', 'off-queued', correlation, (report) => off.push(report));
+    expect(on).toEqual([{ outcome: 'transport-error', eventEpoch: 4, barrier: null }]); expect(off).toEqual([]);
+    expect(h.send.mock.calls[1]).toEqual(['ptt_off', { target, originalEpoch: 4 }, 'off-queued']);
+    h.radio = { ...h.radio, fieldStatus: { ...h.radio.fieldStatus, ptt: field(3) } };
+    emit({ commandId: 'off-queued', kind: 'transport-sent', originalEpoch: 4, eventEpoch: 6 });
+    expect(off[0]).toMatchObject({ outcome: 'sent', eventEpoch: 6, barrier: { authorityEpoch: 6 } });
+    for (const [id, kind, outcome] of [['off-error', 'response-error', 'response-error'], ['off-throw', 'error', 'transport-error']] as const) {
+      factory.dependencies.sendPtt('off', id, correlation, (report) => off.push(report));
+      emit({ commandId: id, kind, originalEpoch: 4, eventEpoch: 6 });
+      expect(off.at(-1)).toEqual({ outcome, eventEpoch: 6, barrier: null });
+    }
+    factory.dispose(); expect(h.deliveries.size).toBe(0);
+  });
+});

--- a/frontend/src/lib/runtime/tx-controller/browser-dependencies.ts
+++ b/frontend/src/lib/runtime/tx-controller/browser-dependencies.ts
@@ -1,0 +1,96 @@
+import { getCapabilities } from '$lib/stores/capabilities.svelte';
+import { getRadioState } from '$lib/stores/radio.svelte';
+import { getTxAudioControl } from '$lib/runtime/adapters/tx-adapter';
+import { makeCommandId } from '$lib/types/protocol';
+import { onCommandDelivery, onControlSessionTransition, sendCommand, type CommandDeliveryEvent, type ControlSessionTransition } from '$lib/transport/ws-client';
+import { createAppAuthorityProjector, type AppAuthorityProjection } from './app-authority';
+import type { TxControllerDependencies } from './controller';
+import type { PttMarker, PttObservation } from './model';
+type Unsubscribe = () => void;
+type LifecycleSource = (release: () => void) => Unsubscribe;
+const noop = () => {};
+const commandName = { on: 'ptt_on', off: 'ptt_off' } as const;
+const outcome = { 'transport-sent': 'sent', ack: 'ack', 'response-ok': 'response-ok',
+  'response-error': 'response-error', error: 'transport-error' } as const;
+export function createBrowserTxControllerDependencies() {
+  const project = createAppAuthorityProjector();
+  const audio = getTxAudioControl();
+  const cleanups = new Set<Unsubscribe>();
+  const timers = new Set<ReturnType<typeof globalThis.setTimeout>>();
+  let disposed = false;
+  const track = (unsubscribe: Unsubscribe): Unsubscribe => {
+    if (disposed) { unsubscribe(); return noop; }
+    let active = true;
+    const remove = () => {
+      if (!active) return;
+      active = false; cleanups.delete(remove); unsubscribe();
+    };
+    cleanups.add(remove); return remove;
+  };
+  const projectAuthority = (session: ControlSessionTransition): AppAuthorityProjection => project(getRadioState(), getCapabilities(), session);
+  const dependencies: TxControllerDependencies = {
+    startAudio: () => disposed ? Promise.resolve('TX browser dependencies disposed') : audio.startTx(),
+    stopLocalAudio: () => { if (!disposed) audio.stopLocalAudio(); },
+    restoreMod: (barrier: PttMarker, observation: PttObservation) => {
+      if (!disposed) audio.restoreModAfterConfirmedOff({ barrier, observation: {
+        ptt: observation.value, pttObserved: observation.observed,
+        pttFreshness: observation.fresh ? 'fresh' : 'unknown', pttSource: observation.source,
+        ...observation.marker,
+      } });
+    },
+    commandId: () => makeCommandId(),
+    schedule: (callback, delayMs) => {
+      if (disposed) return null;
+      let handle: ReturnType<typeof globalThis.setTimeout>;
+      handle = globalThis.setTimeout(() => {
+        timers.delete(handle); if (!disposed) callback();
+      }, delayMs);
+      timers.add(handle); return handle;
+    },
+    cancel: (handle) => {
+      if (handle == null) return;
+      const timer = handle as ReturnType<typeof globalThis.setTimeout>;
+      timers.delete(timer); globalThis.clearTimeout(timer);
+    },
+    timeoutMs: { 'audio-start': 5_000, 'on-confirmation': 5_000, 'off-confirmation': 5_000 },
+    sendPtt: (command, commandId, correlation, report) => {
+      if (disposed) return;
+      let terminal = false; let remove = noop;
+      const delivery = (event: CommandDeliveryEvent) => {
+        if (event.commandId !== commandId || event.originalEpoch !== correlation.originalEpoch) return;
+        const isSent = event.kind === 'transport-sent';
+        terminal = event.kind === 'response-ok' || event.kind === 'response-error' || event.kind === 'error';
+        if (terminal) remove();
+        report({
+          outcome: outcome[event.kind],
+          eventEpoch: event.eventEpoch,
+          barrier: isSent ? projectAuthority({ state: 'connected', epoch: event.eventEpoch }).ptt.marker : null,
+        });
+      };
+      remove = track(onCommandDelivery(delivery));
+      try {
+        const accepted = sendCommand(commandName[command], {
+          target: { ...correlation.target }, originalEpoch: correlation.originalEpoch,
+        }, commandId);
+        if (!accepted && command === 'on' && !terminal) {
+          remove(); report({ outcome: 'transport-error', eventEpoch: correlation.originalEpoch, barrier: null });
+        }
+      } catch {
+        remove();
+        if (!terminal) report({ outcome: 'transport-error', eventEpoch: correlation.originalEpoch, barrier: null });
+      }
+    },
+  };
+  return {
+    dependencies, projectAuthority,
+    subscribeSession: (handler: (projection: AppAuthorityProjection, session: ControlSessionTransition) => void) => disposed
+      ? noop : track(onControlSessionTransition((session) => { if (!disposed) handler(projectAuthority(session), session); })),
+    bindLifecycleRelease: (source: LifecycleSource, release: () => void) =>
+      disposed ? noop : track(source(() => { if (!disposed) release(); })),
+    dispose: () => {
+      if (disposed) return;
+      disposed = true; for (const remove of [...cleanups]) try { remove(); } catch { /* disposal remains idempotent */ }
+      for (const timer of timers) globalThis.clearTimeout(timer); timers.clear();
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- add a dormant production browser dependency factory for the future sole App-owned `TxController`
- preserve lease-captured target and epoch across command delivery and reconnect
- reuse the canonical App authority projector, accepted audio adapter, browser timers, and removable lifecycle/session seams

## Scope

- exactly two new files / 200 net LOC
- no controller construction, module activation, pre-disconnect barrier owner, surface/layout ownership, or global listener
- browser routing/correlation only; no backend target-enforcement, physical de-key, parity, or hardware claim

## Validation

- fresh post-remediation independent verifier: PASS on patch SHA-256 `820aacca012f110caf653a6dbabe0920b71e6c3a5859f342754f570f5dad5dee`
- focused Vitest: 3/3 passed
- related frontend TX safety: 173/173 passed
- `npm run check`: 0 errors / 0 warnings
- changed-file ESLint: passed
- frontend boundary lint: passed
- lifecycle active-through-dispose, stale callback inertness, repeated-dispose unsubscribe, and timer cancellation are explicitly covered

Linear: [MOR-1157](https://linear.app/morozsm/issue/MOR-1157/core-tx-app-provide-production-browser-dependencies-for-txcontroller)

Closes #2080
