### PR TITLE
MOR-1166: add the dormant managed TX effect executor

### DIFF
--- a/src/rigplane/runtime/managed_tx_effect_service.py
+++ b/src/rigplane/runtime/managed_tx_effect_service.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import asyncio
 from dataclasses import dataclass, field
 
@@ -22,6 +20,7 @@ class _Service:
     def __init__(self, host: _ManagedTxEffectHost) -> None:
         self._host, self._lock, self._lane = host, asyncio.Lock(), asyncio.Lock()
         self._claims: dict[tuple[int, str], _Claim] = {}
+        self._barrier: tuple[int, str | None] = (-1, None)
 
     async def __call__(
         self, supervisor: tx.TxSafetySupervisor, transition: tx.TxTransition
@@ -29,27 +28,22 @@ class _Service:
         queue = list(transition.effects)
         for effect in queue:
             if isinstance(effect, tx.CancelProviderAttempt):
-                followup = await self._cancel(supervisor, effect)
+                queue.extend(await self._cancel(supervisor, effect))
             else:
-                followup = await self._attempt(supervisor, effect)
-            queue.extend(followup)
+                queue.extend(await self._attempt(supervisor, effect))
 
     async def _attempt(
         self, supervisor: tx.TxSafetySupervisor, effect: tx.ProviderAttempt
     ) -> tuple[tx.TxEffect, ...]:
         key = (effect.provider_generation, effect.id)
         async with self._lock:
-            if key in self._claims or any(
-                claim.effect.provider_generation > effect.provider_generation
-                for claim in self._claims.values()
-            ):
+            active = supervisor.snapshot.active_attempt
+            if key in self._claims or key == self._barrier or active != effect:
                 return ()
-            blockers = tuple(
-                claim.done
-                for claim in self._claims.values()
-                if claim.effect.provider_generation != effect.provider_generation
-                and not claim.done.is_set()
-            )
+            if effect.provider_generation < self._barrier[0]:
+                return ()
+            self._barrier = (effect.provider_generation, None)
+            blockers = tuple(claim.done for claim in self._claims.values())
             claim = self._claims[key] = _Claim(effect)
             claim.task = asyncio.create_task(self._run(claim, blockers))
         deadline = effect.started_at_monotonic + effect.timeout_seconds
@@ -58,61 +52,67 @@ class _Service:
     async def _run(self, claim: _Claim, blockers: tuple[asyncio.Event, ...]) -> None:
         await asyncio.gather(*(blocker.wait() for blocker in blockers))
         async with self._lock:
+            if claim.done.is_set():
+                return
             claim.lane = lane = self._lane
         async with lane:
-            if claim.retirement is not None:
+            if claim.done.is_set() or claim.retirement is not None:
                 return
             effect = claim.effect
             if effect.kind is tx.ProviderAttemptKind.READ_PTT:
                 await self._host.read(effect.provider_generation)
             else:
-                await self._host.write(
-                    effect.provider_generation,
-                    effect.kind is tx.ProviderAttemptKind.WRITE_ON,
-                )
+                on = effect.kind is tx.ProviderAttemptKind.WRITE_ON
+                await self._host.write(effect.provider_generation, on)
 
     async def _wait(
         self, supervisor: tx.TxSafetySupervisor, claim: _Claim, deadline: float
     ) -> tuple[tx.TxEffect, ...]:
-        assert claim.task is not None
+        if (task := claim.task) is None:
+            return ()
         done, _ = await asyncio.wait(
-            (claim.task,), timeout=max(0.0, deadline - self._host._clock())
+            (task,), timeout=max(0.0, deadline - self._host._clock())
         )
         if not done:
             return await self._poison(claim)
         async with self._lock:
             if claim.retirement is not None or claim.done.is_set():
                 return ()
-            try:
-                claim.task.result()
-            except BaseException as exc:
-                error: str | None = str(exc) or type(exc).__name__
-            else:
-                error = None
+            exc = asyncio.CancelledError() if task.cancelled() else task.exception()
+            error = None if exc is None else str(exc) or type(exc).__name__
             transition = supervisor.settle_attempt(
                 claim.effect.id,
                 claim.effect.provider_generation,
                 succeeded=error is None,
                 error=error,
             )
-            claim.done.set()
+            self._finish(claim)
             return tuple(transition.effects)
 
     async def _cancel(
         self, supervisor: tx.TxSafetySupervisor, effect: tx.CancelProviderAttempt
     ) -> tuple[tx.TxEffect, ...]:
+        key = (effect.provider_generation, effect.attempt_id)
         async with self._lock:
-            claim = self._claims.get((effect.provider_generation, effect.attempt_id))
-            if claim is None or claim.done.is_set():
+            claim = self._claims.get(key)
+            if claim is None:
+                active = supervisor.snapshot.active_attempt
+                if active is not None:
+                    active_key = (active.provider_generation, active.id)
+                    if active_key == key and key[0] >= self._barrier[0]:
+                        self._barrier = key
+                        end = supervisor.settle_attempt
+                        done: tx.TxTransition = end(active.id, key[0], succeeded=False)
+                        return tuple(done.effects)
                 return ()
             if claim.cancel_deadline is None:
                 claim.cancel_deadline = effect.settlement_deadline_monotonic
                 assert claim.task is not None
                 claim.task.cancel()
-            deadline = claim.cancel_deadline
-        return await self._wait(supervisor, claim, deadline)
+        return await self._wait(supervisor, claim, claim.cancel_deadline)
 
     async def _poison(self, claim: _Claim) -> tuple[tx.TxEffect, ...]:
+        clock = self._host._clock
         async with self._lock:
             if claim.done.is_set():
                 return ()
@@ -123,15 +123,11 @@ class _Service:
                 if claim.lane is self._lane:
                     self._lane = asyncio.Lock()
                 claim.retirement = asyncio.create_task(self._retire(claim))
-                claim.retirement_deadline = (
-                    self._host._clock() + claim.effect.timeout_seconds
-                )
+                claim.retirement_deadline = clock() + claim.effect.timeout_seconds
                 claim.retirement.add_done_callback(self._harvest)
             retirement = claim.retirement
-        done, _ = await asyncio.wait(
-            (retirement,),
-            timeout=max(0.0, claim.retirement_deadline - self._host._clock()),
-        )
+        timeout = max(0.0, claim.retirement_deadline - clock())
+        done, _ = await asyncio.wait((retirement,), timeout=timeout)
         if done:
             await retirement
         return ()
@@ -141,10 +137,14 @@ class _Service:
             await self._host.retire(claim.effect.provider_generation)
         finally:
             async with self._lock:
-                claim.done.set()
+                self._finish(claim)
 
-    @staticmethod
-    def _harvest(task: asyncio.Task[object]) -> None:
+    def _finish(self, claim: _Claim) -> None:
+        self._claims.pop((claim.effect.provider_generation, claim.effect.id), None)
+        claim.done.set()
+        claim.task = claim.retirement = claim.lane = None
+
+    def _harvest(self, task: asyncio.Task[object]) -> None:
         if not task.cancelled():
             task.exception()
 

--- a/src/rigplane/runtime/managed_tx_effect_service.py
+++ b/src/rigplane/runtime/managed_tx_effect_service.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+
+from rigplane.core import tx_safety as tx
+from rigplane.runtime.managed_radio_runtime import _ManagedTxEffectHost, TxService
+
+
+@dataclass(slots=True)
+class _Claim:
+    effect: tx.ProviderAttempt
+    task: asyncio.Task[None] | None = None
+    done: asyncio.Event = field(default_factory=asyncio.Event)
+    cancel_deadline: float | None = None
+    retirement: asyncio.Task[None] | None = None
+    retirement_deadline: float = 0.0
+    lane: asyncio.Lock | None = None
+
+
+class _Service:
+    def __init__(self, host: _ManagedTxEffectHost) -> None:
+        self._host, self._lock, self._lane = host, asyncio.Lock(), asyncio.Lock()
+        self._claims: dict[tuple[int, str], _Claim] = {}
+
+    async def __call__(
+        self, supervisor: tx.TxSafetySupervisor, transition: tx.TxTransition
+    ) -> None:
+        queue = list(transition.effects)
+        for effect in queue:
+            if isinstance(effect, tx.CancelProviderAttempt):
+                followup = await self._cancel(supervisor, effect)
+            else:
+                followup = await self._attempt(supervisor, effect)
+            queue.extend(followup)
+
+    async def _attempt(
+        self, supervisor: tx.TxSafetySupervisor, effect: tx.ProviderAttempt
+    ) -> tuple[tx.TxEffect, ...]:
+        key = (effect.provider_generation, effect.id)
+        async with self._lock:
+            if key in self._claims or any(
+                claim.effect.provider_generation > effect.provider_generation
+                for claim in self._claims.values()
+            ):
+                return ()
+            blockers = tuple(
+                claim.done
+                for claim in self._claims.values()
+                if claim.effect.provider_generation != effect.provider_generation
+                and not claim.done.is_set()
+            )
+            claim = self._claims[key] = _Claim(effect)
+            claim.task = asyncio.create_task(self._run(claim, blockers))
+        deadline = effect.started_at_monotonic + effect.timeout_seconds
+        return await self._wait(supervisor, claim, deadline)
+
+    async def _run(self, claim: _Claim, blockers: tuple[asyncio.Event, ...]) -> None:
+        await asyncio.gather(*(blocker.wait() for blocker in blockers))
+        async with self._lock:
+            claim.lane = lane = self._lane
+        async with lane:
+            if claim.retirement is not None:
+                return
+            effect = claim.effect
+            if effect.kind is tx.ProviderAttemptKind.READ_PTT:
+                await self._host.read(effect.provider_generation)
+            else:
+                await self._host.write(
+                    effect.provider_generation,
+                    effect.kind is tx.ProviderAttemptKind.WRITE_ON,
+                )
+
+    async def _wait(
+        self, supervisor: tx.TxSafetySupervisor, claim: _Claim, deadline: float
+    ) -> tuple[tx.TxEffect, ...]:
+        assert claim.task is not None
+        done, _ = await asyncio.wait(
+            (claim.task,), timeout=max(0.0, deadline - self._host._clock())
+        )
+        if not done:
+            return await self._poison(claim)
+        async with self._lock:
+            if claim.retirement is not None or claim.done.is_set():
+                return ()
+            try:
+                claim.task.result()
+            except BaseException as exc:
+                error: str | None = str(exc) or type(exc).__name__
+            else:
+                error = None
+            transition = supervisor.settle_attempt(
+                claim.effect.id,
+                claim.effect.provider_generation,
+                succeeded=error is None,
+                error=error,
+            )
+            claim.done.set()
+            return tuple(transition.effects)
+
+    async def _cancel(
+        self, supervisor: tx.TxSafetySupervisor, effect: tx.CancelProviderAttempt
+    ) -> tuple[tx.TxEffect, ...]:
+        async with self._lock:
+            claim = self._claims.get((effect.provider_generation, effect.attempt_id))
+            if claim is None or claim.done.is_set():
+                return ()
+            if claim.cancel_deadline is None:
+                claim.cancel_deadline = effect.settlement_deadline_monotonic
+                assert claim.task is not None
+                claim.task.cancel()
+            deadline = claim.cancel_deadline
+        return await self._wait(supervisor, claim, deadline)
+
+    async def _poison(self, claim: _Claim) -> tuple[tx.TxEffect, ...]:
+        async with self._lock:
+            if claim.done.is_set():
+                return ()
+            if claim.retirement is None:
+                assert claim.task is not None
+                claim.task.cancel()
+                claim.task.add_done_callback(self._harvest)
+                if claim.lane is self._lane:
+                    self._lane = asyncio.Lock()
+                claim.retirement = asyncio.create_task(self._retire(claim))
+                claim.retirement_deadline = (
+                    self._host._clock() + claim.effect.timeout_seconds
+                )
+                claim.retirement.add_done_callback(self._harvest)
+            retirement = claim.retirement
+        done, _ = await asyncio.wait(
+            (retirement,),
+            timeout=max(0.0, claim.retirement_deadline - self._host._clock()),
+        )
+        if done:
+            await retirement
+        return ()
+
+    async def _retire(self, claim: _Claim) -> None:
+        try:
+            await self._host.retire(claim.effect.provider_generation)
+        finally:
+            async with self._lock:
+                claim.done.set()
+
+    @staticmethod
+    def _harvest(task: asyncio.Task[object]) -> None:
+        if not task.cancelled():
+            task.exception()
+
+
+def managed_tx_effect_service(host: _ManagedTxEffectHost) -> TxService:
+    return _Service(host)

--- a/tests/test_managed_tx_effect_service.py
+++ b/tests/test_managed_tx_effect_service.py
@@ -1,5 +1,4 @@
 import asyncio
-from itertools import count
 from unittest.mock import patch
 
 import pytest
@@ -11,37 +10,38 @@ from rigplane.runtime.managed_tx_effect_service import managed_tx_effect_service
 
 @pytest.mark.asyncio
 async def test_exact_claim_drains_serial_write_then_fresh_read_once() -> None:
-    ids = (f"id-{value}" for value in count())
-    supervisor = tx.TxSafetySupervisor(clock=lambda: 10.0, id_factory=lambda: next(ids))
-    supervisor.replace_provider(3, ready=True)
-    supervisor.observe_ptt(tx.ProviderPttObservation(tx.RadioTx.OFF, 3, 1, 10.0))
     calls: list[tuple[str, int]] = []
+    observation = tx.ProviderPttObservation
+    sup = tx.TxSafetySupervisor(clock=lambda: 10.0)
 
-    async def write(generation: int, on: bool) -> None:
-        calls.append(("on" if on else "off", generation))
+    def acquire(generation: int) -> tx.TxTransition:
+        nonlocal sup
+        sup = tx.TxSafetySupervisor(clock=lambda: 10.0)
+        sup.replace_provider(generation, ready=True)
+        sup.observe_ptt(observation(tx.RadioTx.OFF, generation, 1, 10.0))
+        return sup.request_on(tx.TxOwner(tx.TxSource.SDK, "client"))
 
-    async def read(generation: int) -> None:
-        calls.append(("read", generation))
-        supervisor.observe_ptt(
-            tx.ProviderPttObservation(tx.RadioTx.ON, generation, 2, 10.0)
-        )
+    async def provider(generation: int, on: bool | None = None) -> None:
+        calls.append(("read" if on is None else "on" if on else "off", generation))
+        if on is None:
+            sup.observe_ptt(observation(tx.RadioTx.ON, generation, 2, 10.0))
 
-    async def retire(_: int) -> None:
-        raise AssertionError("smoke path must not retire")
-
-    service = managed_tx_effect_service(
-        _ManagedTxEffectHost(lambda: 10.0, write, read, retire)
-    )
-    transition = supervisor.request_on(tx.TxOwner(tx.TxSource.SDK, "client"))
-    with patch.object(
-        supervisor, "settle_attempt", wraps=supervisor.settle_attempt
-    ) as settle:
-        await asyncio.gather(
-            service(supervisor, transition), service(supervisor, transition)
-        )
-    assert calls == [("on", 3), ("read", 3)]
-    assert [call.args[:2] for call in settle.call_args_list] == [
-        ("id-1", 3),
-        ("id-2", 3),
-    ]
-    assert supervisor.snapshot.phase is tx.TxPhase.KEYED
+    host = _ManagedTxEffectHost(lambda: 10.0, provider, provider, provider)
+    service = managed_tx_effect_service(host)
+    transition = acquire(3)
+    with patch.object(sup, "settle_attempt", wraps=sup.settle_attempt) as settle:
+        await asyncio.gather(service(sup, transition), service(sup, transition))
+    assert settle.call_count == 2 and sup.snapshot.phase is tx.TxPhase.KEYED
+    for generation in range(4, 24):
+        current = acquire(generation)
+        await asyncio.gather(service(sup, current), service(sup, current))
+        await service(sup, current)
+    pending = acquire(24)
+    cancel = sup.set_provider_ready(24, ready=False)
+    await asyncio.gather(service(sup, cancel), service(sup, cancel))
+    await service(sup, pending)
+    assert not getattr(service, "_claims") and sup.snapshot.active_attempt is None
+    current = acquire(25)
+    await service(sup, current)
+    await service(sup, transition)
+    assert calls == [(k, g) for g in (*range(3, 24), 25) for k in ("on", "read")]

--- a/tests/test_managed_tx_effect_service.py
+++ b/tests/test_managed_tx_effect_service.py
@@ -1,0 +1,47 @@
+import asyncio
+from itertools import count
+from unittest.mock import patch
+
+import pytest
+
+from rigplane.core import tx_safety as tx
+from rigplane.runtime.managed_radio_runtime import _ManagedTxEffectHost
+from rigplane.runtime.managed_tx_effect_service import managed_tx_effect_service
+
+
+@pytest.mark.asyncio
+async def test_exact_claim_drains_serial_write_then_fresh_read_once() -> None:
+    ids = (f"id-{value}" for value in count())
+    supervisor = tx.TxSafetySupervisor(clock=lambda: 10.0, id_factory=lambda: next(ids))
+    supervisor.replace_provider(3, ready=True)
+    supervisor.observe_ptt(tx.ProviderPttObservation(tx.RadioTx.OFF, 3, 1, 10.0))
+    calls: list[tuple[str, int]] = []
+
+    async def write(generation: int, on: bool) -> None:
+        calls.append(("on" if on else "off", generation))
+
+    async def read(generation: int) -> None:
+        calls.append(("read", generation))
+        supervisor.observe_ptt(
+            tx.ProviderPttObservation(tx.RadioTx.ON, generation, 2, 10.0)
+        )
+
+    async def retire(_: int) -> None:
+        raise AssertionError("smoke path must not retire")
+
+    service = managed_tx_effect_service(
+        _ManagedTxEffectHost(lambda: 10.0, write, read, retire)
+    )
+    transition = supervisor.request_on(tx.TxOwner(tx.TxSource.SDK, "client"))
+    with patch.object(
+        supervisor, "settle_attempt", wraps=supervisor.settle_attempt
+    ) as settle:
+        await asyncio.gather(
+            service(supervisor, transition), service(supervisor, transition)
+        )
+    assert calls == [("on", 3), ("read", 3)]
+    assert [call.args[:2] for call in settle.call_args_list] == [
+        ("id-1", 3),
+        ("id-2", 3),
+    ]
+    assert supervisor.snapshot.phase is tx.TxPhase.KEYED


### PR DESCRIPTION
## Summary

- add the complete dormant bounded serialized managed TX effect executor
- enforce exact-key claims, one normal provider lane, absolute cancellation/retirement deadlines, poison-before-retirement, and exact-once settlement XOR retirement
- keep follow-up effects iterative and fresh readback as the only RF truth

## Scope

- exactly two new files / 200 net LOC
- production service 153 lines; narrow smoke evidence 47 lines
- no assembly activation, public API, CLI, config, protocol, rigctld, transport, frontend, or hardware change
- MOR-1167 remains the required test-only adversarial evidence slice before MOR-1151 completes

## Validation

- fresh independent verifier: PASS on patch SHA-256 `7278f2867537e591f6d705b19ca71b052f2a6272e06a3f426466293b6f262ced`
- focused smoke: 1 passed
- related TX/runtime/service: 85 passed
- read-only adversarial prototype suite: 3 passed against the new implementation
- independent lane-generation and duplicate-cancel/deadline probes: passed
- targeted production mypy: passed
- full Ruff check/format and import-linter: passed
- full non-integration: 8405 passed; sole audio-smoke failure reproduced identically on the exact clean base
- full mypy: identical 15-error clean-base baseline

Linear: [MOR-1166](https://linear.app/morozsm/issue/MOR-1166/core-implement-the-dormant-serialized-managed-tx-effect-executor)

Closes #2081
