### PR TITLE
MOR-1159: activate the sole application TX host

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -5,6 +5,8 @@
   import LocalExtensionsHost from './lib/local-extensions/LocalExtensionsHost.svelte';
   import { initMediaSession, destroyMediaSession } from './lib/media/media-session';
   import { runtime } from './lib/runtime/frontend-runtime';
+  import { systemController } from '$lib/runtime/system-controller';
+  import { provideAppTxControllerHost } from '$lib/runtime/tx-controller/app-host';
   import { hasAnyScope } from './lib/stores/capabilities.svelte';
   import { getLayoutMode } from './lib/stores/layout.svelte';
   import { resolveSkinId, type SkinId } from './skins/registry';
@@ -35,9 +37,39 @@
     hasAnyScope: hasAnyScope(),
   }));
 
+  const txHost = provideAppTxControllerHost({
+    registerPreDisconnectBarrier: (barrier) =>
+      systemController.registerPreDisconnectBarrier(barrier),
+    lifecycleReleaseSource: (release) => {
+      if (typeof window === 'undefined' || typeof document === 'undefined') {
+        return () => {};
+      }
+      const onPageHide = () => release();
+      const onVisibilityLoss = () => {
+        if (document.visibilityState === 'hidden') release();
+      };
+      window.addEventListener('pagehide', onPageHide);
+      document.addEventListener('visibilitychange', onVisibilityLoss);
+      return () => {
+        window.removeEventListener('pagehide', onPageHide);
+        document.removeEventListener('visibilitychange', onVisibilityLoss);
+      };
+    },
+  });
+  let txAuthorityReady = $state(false);
+  $effect(() => {
+    const state = runtime.state, caps = runtime.caps;
+    void JSON.stringify([
+      state?.stateRevision, state?.freshnessRevision, state?.observationSeq, state?.ptt,
+      state?.active, state?.main?.dataMode, state?.sub?.dataMode, state?.txTarget, state?.fieldStatus,
+      caps?.tx, caps?.audioTx, caps?.audioTxRequiredModInputSource, caps?.capabilities, caps?.vfoScheme, caps?.txBands,
+    ]);
+    if (txAuthorityReady) txHost.refreshAuthority();
+  });
+
   onMount(() => {
     if (demoMode === 'control-buttons') {
-      return;
+      return () => txHost.dispose();
     }
 
     // Stale-bookmark notice: ?ui=v1 is no longer supported (v0.20+). Emit once per session.
@@ -53,6 +85,7 @@
     let cleanupBootstrap: (() => void) | null = null;
     let cleanupBattery: (() => void) | null = null;
     let retryTimer: ReturnType<typeof setTimeout> | null = null;
+    let mounted = true;
     const handleResize = () => {
       windowWidth = window.innerWidth;
       windowHeight = window.innerHeight;
@@ -66,6 +99,8 @@
     (async () => {
       try {
         cleanupBootstrap = await runtime.bootstrap();
+        if (!mounted) return cleanupBootstrap();
+        txAuthorityReady = true;
         backendError = null;
       } catch (err) {
         console.error('init error:', err);
@@ -85,6 +120,9 @@
     })();
 
     return () => {
+      mounted = false;
+      txAuthorityReady = false;
+      txHost.dispose();
       destroyMediaSession();
       cleanupBattery?.();
       cleanupBootstrap?.();

--- a/frontend/src/lib/runtime/tx-controller/__tests__/app-lifecycle.component.test.ts
+++ b/frontend/src/lib/runtime/tx-controller/__tests__/app-lifecycle.component.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+const h = vi.hoisted(() => ({
+  order: [] as string[],
+  provide: vi.fn(),
+  registerBarrier: vi.fn(),
+  bootstrap: vi.fn(),
+  bootstrapCleanup: vi.fn(),
+  initBattery: vi.fn(),
+  batteryCleanup: vi.fn(),
+  initMedia: vi.fn(),
+  destroyMedia: vi.fn(),
+  resolveSkin: vi.fn(),
+  radio: null as { stateRevision: number; freshnessRevision: number; observationSeq: number; ptt: boolean } | null,
+  caps: null as { tx: boolean; capabilities: string[] } | null,
+  notifyRuntime: () => {},
+  barrier: undefined as (() => Promise<void>) | undefined,
+  host: undefined as {
+    refreshAuthority: ReturnType<typeof vi.fn>;
+    release: ReturnType<typeof vi.fn>;
+    dispose: ReturnType<typeof vi.fn>;
+  } | undefined,
+  inFlight: null as Promise<void> | null,
+}));
+vi.mock('../../../../components-v2/layout/RadioLayout.svelte', async () => {
+  const stub = await import('../../../../components-v2/layout/__tests__/SpectrumPanelStub.svelte');
+  return { default: stub.default };
+});
+vi.mock('../../../../lib/local-extensions/LocalExtensionsHost.svelte', async () => {
+  const stub = await import('../../../../components-v2/layout/__tests__/SpectrumPanelStub.svelte');
+  return { default: stub.default };
+});
+vi.mock('$lib/stores/capabilities.svelte', () => ({ hasAnyScope: () => false }));
+vi.mock('$lib/stores/layout.svelte', () => ({ getLayoutMode: () => 'standard' }));
+vi.mock('../../../../skins/registry', () => ({ resolveSkinId: h.resolveSkin }));
+vi.mock('../../../../lib/utils/battery', () => ({ initBatteryMonitor: h.initBattery }));
+vi.mock('../../../../lib/media/media-session', () => ({ initMediaSession: h.initMedia, destroyMediaSession: h.destroyMedia }));
+vi.mock('../../../../lib/runtime/frontend-runtime', async () => {
+  const { createSubscriber } = await import('svelte/reactivity');
+  let update = () => {};
+  const subscribe = createSubscriber((notify) => { update = notify; return () => {}; });
+  h.notifyRuntime = () => update();
+  return { runtime: {
+    get state() { subscribe(); return h.radio; },
+    get caps() { subscribe(); return h.caps; },
+    bootstrap: h.bootstrap, setPollingMultiplier: vi.fn(),
+  } };
+});
+vi.mock('$lib/runtime/system-controller', () => ({ systemController: { registerPreDisconnectBarrier: h.registerBarrier } }));
+vi.mock('$lib/i18n', () => ({ t: (key: string) => key }));
+vi.mock('../app-host', () => ({ provideAppTxControllerHost: h.provide }));
+import App from '../../../../App.svelte';
+const settle = async () => { await Promise.resolve(); await Promise.resolve(); };
+function mountApp() {
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+  const component = mount(App, { target });
+  flushSync();
+  return component;
+}
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.order.length = 0;
+  h.barrier = undefined;
+  h.host = undefined;
+  h.inFlight = null;
+  h.radio = { stateRevision: 1, freshnessRevision: 1, observationSeq: 1, ptt: false };
+  h.caps = { tx: true, capabilities: ['tx'] };
+  document.body.innerHTML = '';
+  Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1200 });
+  Object.defineProperty(window, 'innerHeight', { configurable: true, value: 800 });
+  Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'visible' });
+  h.resolveSkin.mockImplementation(({ isMobile }: { isMobile: boolean }) => isMobile ? 'mobile' : 'desktop-v2');
+  h.bootstrapCleanup.mockImplementation(() => { h.order.push('runtime'); });
+  h.bootstrap.mockResolvedValue(h.bootstrapCleanup);
+  h.batteryCleanup.mockImplementation(() => { h.order.push('battery'); });
+  h.initBattery.mockResolvedValue(h.batteryCleanup);
+  h.destroyMedia.mockImplementation(() => { h.order.push('media'); });
+  h.registerBarrier.mockImplementation((barrier: () => Promise<void>) => {
+    h.barrier = barrier;
+    return () => { if (h.barrier === barrier) h.barrier = undefined; };
+  });
+  h.provide.mockImplementation((bindings) => {
+    const release = vi.fn(() => {
+      if (h.inFlight) return h.inFlight;
+      h.order.push('off');
+      let bounded!: Promise<void>;
+      bounded = Promise.resolve().finally(() => {
+        if (h.inFlight === bounded) h.inFlight = null;
+      });
+      return (h.inFlight = bounded);
+    });
+    const offBarrier = bindings.registerPreDisconnectBarrier(release);
+    const offLifecycle = bindings.lifecycleReleaseSource(() => { void release(); });
+    const host = {
+      refreshAuthority: vi.fn(() => { h.order.push('refresh'); }),
+      release,
+      dispose: vi.fn(() => {
+        void release();
+        offBarrier();
+        offLifecycle();
+        h.order.push('host:dispose');
+      }),
+    };
+    h.host = host;
+    return host;
+  });
+});
+describe('App TX lifecycle', () => {
+  it('keeps one owner while presentation changes and coalesces every release route', async () => {
+    const component = mountApp();
+    expect(h.host!.refreshAuthority).not.toHaveBeenCalled();
+    await settle();
+    expect(h.provide).toHaveBeenCalledOnce();
+    expect(h.host!.refreshAuthority).toHaveBeenCalledOnce();
+    h.radio!.ptt = true;
+    h.radio!.observationSeq++;
+    h.caps!.capabilities.push('voice_tx');
+    h.notifyRuntime();
+    await settle();
+    expect(h.host!.refreshAuthority).toHaveBeenCalledTimes(2);
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 390 });
+    window.dispatchEvent(new Event('resize'));
+    flushSync();
+    expect(h.provide).toHaveBeenCalledOnce();
+
+    Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'hidden' });
+    document.dispatchEvent(new Event('visibilitychange'));
+    window.dispatchEvent(new Event('pagehide'));
+    const shutdown = h.barrier!();
+    expect(h.host!.release).toHaveBeenCalledTimes(3);
+    expect(h.order.filter((entry) => entry === 'off')).toHaveLength(1);
+    await shutdown;
+    unmount(component);
+  });
+  it('attempts release before local and late runtime cleanup, then detaches lifecycle paths', async () => {
+    let resolveBootstrap!: (cleanup: () => void) => void;
+    h.bootstrap.mockImplementationOnce(() => new Promise((resolve) => { resolveBootstrap = resolve; }));
+    const component = mountApp();
+    await settle();
+    h.order.length = 0;
+    unmount(component);
+    expect(h.host!.dispose).toHaveBeenCalledOnce();
+    expect(h.order.indexOf('off')).toBeLessThan(h.order.indexOf('media'));
+    const calls = h.host!.release.mock.calls.length;
+    window.dispatchEvent(new Event('pagehide'));
+    expect(h.host!.release).toHaveBeenCalledTimes(calls);
+    expect(h.barrier).toBeUndefined();
+    resolveBootstrap(h.bootstrapCleanup);
+    await settle();
+    expect(h.order.indexOf('off')).toBeLessThan(h.order.indexOf('runtime'));
+    expect(h.bootstrapCleanup).toHaveBeenCalledOnce();
+    expect(h.host!.refreshAuthority).not.toHaveBeenCalled();
+    h.radio!.ptt = false;
+    h.caps!.capabilities.push('mod_input_routing');
+    h.notifyRuntime();
+    await settle();
+    expect(h.host!.refreshAuthority).not.toHaveBeenCalled();
+    expect(h.bootstrapCleanup).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary

- activate the accepted sole application-lifetime TX host from `App.svelte`
- bind the exclusive system pre-disconnect barrier plus pagehide/visibility release sources
- refresh controller authority reactively from canonical runtime state/capability changes
- dispose the host before media/runtime cleanup, including deferred-bootstrap unmount

## Scope

- exactly two frontend files, net +199 LOC
- no controller/model/browser-dependency, surface, layout, backend, protocol, or public API change
- no optimistic RF-truth reconciliation

## Verification

- fresh independent pre-commit verifier PASS at combined hash `69879477bb8c06a642bb5c6f20332732485e8e382fa2c399d3172e96d73c7da7`
- focused lifecycle 2/2
- explicit ten-file TX/App/System matrix 142/142
- `npm run check`: 0 errors/warnings
- changed-file ESLint and boundary lint passed
- adversarial reactive-authority and deferred-bootstrap cleanup rows passed

No hardware or on-air validation was performed.

Closes #2087

Linear: MOR-1159
