### PR TITLE
MOR-1152: prove provider and shutdown fences

### DIFF
--- a/tests/test_managed_radio_runtime.py
+++ b/tests/test_managed_radio_runtime.py
@@ -228,8 +228,9 @@ async def test_request_off_service_error_propagates_and_retains_durable_off() ->
     assert repeated.outcome is TxOutcome.IDEMPOTENT and rt.tx_snapshot.lease_id == lease
 
 
-@pytest.mark.asyncio
-async def test_shutdown_fences_readiness_and_terminal_reason() -> None:
+@pytest.mark.timeout(2)
+@pytest.mark.parametrize("replace", [False, True], ids=["ready", "replacement"])
+async def test_shutdown_fences_readiness_and_terminal_reason(replace: bool) -> None:
     provider, started, finish = ProviderLifecycle(), asyncio.Event(), asyncio.Event()
     armed = False
 
@@ -246,30 +247,48 @@ async def test_shutdown_fences_readiness_and_terminal_reason() -> None:
     await rt.request_off(owner, lease)
     await rt.replace_provider(ready=False)
     armed = True
-    readiness = asyncio.create_task(rt.set_provider_ready(ready=True))
-    await asyncio.wait_for(started.wait(), 0.2)
-    shutdown = asyncio.create_task(
-        rt.shutdown(release_provider=lambda: asyncio.sleep(0))
+    readiness = asyncio.create_task(
+        rt.replace_provider(ready=True)
+        if replace
+        else rt.set_provider_ready(ready=True)
     )
-    await asyncio.sleep(0)
-    with pytest.raises(ConnectionError, match="stale"):
-        await rt._effect_host.write(2, True)
-    late = await asyncio.gather(
-        rt.request_off(owner, lease),
-        rt.release_owner(owner, reason=TxReleaseReason.SOURCE_DETACHED),
-        rt.set_provider_ready(ready=False),
-        rt.set_provider_ready(ready=True),
-    )
-    assert not readiness.done() and provider.writes
-    assert all(not on for _generation, on in provider.writes)
-    assert [item.outcome for item in late[2:]] == [TxOutcome.NOT_READY] * 2
-    assert all(
-        item.snapshot.terminal_release_reason is TxReleaseReason.SERVER_SHUTDOWN
-        for item in late
-    )
-    finish.set()
-    assert (await readiness).outcome is TxOutcome.NOT_READY
-    assert (await shutdown).snapshot.phase is TxPhase.RELEASE_REQUIRED
+    shutdown: asyncio.Task[TxTransition] | None = None
+    try:
+        await asyncio.wait_for(started.wait(), 0.2)
+        shutdown = asyncio.create_task(
+            rt.shutdown(release_provider=lambda: asyncio.sleep(0))
+        )
+        await asyncio.sleep(0)
+        with pytest.raises(ConnectionError, match="stale"):
+            await rt._effect_host.write(rt.tx_snapshot.provider_generation, True)
+        late = await asyncio.gather(
+            rt.request_off(owner, lease),
+            rt.release_owner(owner, reason=TxReleaseReason.SOURCE_DETACHED),
+            rt.set_provider_ready(ready=False),
+            rt.set_provider_ready(ready=True),
+        )
+        assert not readiness.done() and provider.writes
+        assert all(not on for _generation, on in provider.writes)
+        assert [item.outcome for item in late[2:]] == [TxOutcome.NOT_READY] * 2
+        assert all(
+            item.snapshot.terminal_release_reason is TxReleaseReason.SERVER_SHUTDOWN
+            for item in late
+        )
+        finish.set()
+        assert (await asyncio.wait_for(readiness, 0.5)).outcome is TxOutcome.NOT_READY
+        assert shutdown is not None
+        assert (
+            await asyncio.wait_for(shutdown, 0.5)
+        ).snapshot.phase is TxPhase.RELEASE_REQUIRED
+    finally:
+        finish.set()
+        for task in (readiness, shutdown):
+            if task is not None and not task.done():
+                task.cancel()
+        await asyncio.gather(
+            *(task for task in (readiness, shutdown) if task is not None),
+            return_exceptions=True,
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -730,9 +730,9 @@ class TestPtt:
     """Test PTT toggle."""
 
     @pytest.mark.timeout(2)
-    @pytest.mark.parametrize("poison_only", [False, True], ids=["rebind", "poison"])
+    @pytest.mark.parametrize("invalidation", ["rebind", "poison", "reconnect"])
     async def test_managed_ptt_port_token_safety(
-        self, radio: IcomRadio, poison_only: bool
+        self, radio: IcomRadio, invalidation: str
     ) -> None:
         sent: list[bytes] = []
         responses: asyncio.Queue[bytes] = asyncio.Queue()
@@ -753,6 +753,76 @@ class TestPtt:
         observations: list[tx.ProviderPttObservation] = []
         observer = observations.append
         assert radio._capture_managed_tx_port(11, observer)
+        runtime = radio._civ_runtime
+        token = runtime._managed_tx_ports[11]
+        if invalidation == "reconnect":
+            replacement = MockTransport()
+            checks = 0
+            paced, release = asyncio.Event(), asyncio.Event()
+            pending: asyncio.Task[None] | None = None
+            current = runtime._managed_tx_port_is_current
+
+            def reconnect_after_validation(candidate: object) -> bool:
+                nonlocal checks
+                checks += 1
+                valid = current(candidate)  # type: ignore[arg-type]
+                if checks == 2:
+                    radio._civ_transport = replacement
+                return valid
+
+            async def blocked_pacing(_delay: float) -> None:
+                paced.set()
+                await release.wait()
+
+            send_release.set()
+            link.disconnect.side_effect = None
+            try:
+                with patch.object(
+                    runtime,
+                    "_managed_tx_port_is_current",
+                    reconnect_after_validation,
+                ):
+                    await asyncio.wait_for(radio._write_managed_ptt(11, True), 0.5)
+                if radio._civ_transport is not replacement:
+                    radio._civ_transport = replacement
+                await asyncio.wait_for(radio._retire_managed_tx_port(11), 0.5)
+                assert link.send.await_count == 1
+                assert replacement.sent_packets == []
+                assert not replacement.disconnected
+                assert radio._civ_transport is replacement
+                await runtime.stop_pump()
+
+                assert radio._capture_managed_tx_port(12, observer)
+                paced_token = runtime._managed_tx_ports[12]
+                radio._last_civ_send_monotonic = asyncio.get_running_loop().time()
+                radio._civ_min_interval = 1.0
+                frame = build_civ_frame(
+                    IC_7610_ADDR,
+                    CONTROLLER_ADDR,
+                    _CMD_PTT,
+                    sub=_SUB_PTT,
+                    data=b"\x01",
+                )
+                with patch("rigplane.runtime._civ_rx.asyncio.sleep", blocked_pacing):
+                    pending = asyncio.create_task(
+                        runtime._send_civ_frame_now(frame, owner=paced_token)
+                    )
+                    await asyncio.wait_for(paced.wait(), 0.2)
+                    runtime._poison_managed_tx_port(paced_token)
+                    release.set()
+                    with pytest.raises(ConnectionError, match="before dispatch"):
+                        await asyncio.wait_for(pending, 0.5)
+                assert replacement.sent_packets == []
+            finally:
+                release.set()
+                if pending is not None and not pending.done():
+                    pending.cancel()
+                    await asyncio.gather(pending, return_exceptions=True)
+                if 12 in runtime._managed_tx_ports:
+                    await asyncio.wait_for(radio._retire_managed_tx_port(12), 0.5)
+                await runtime.stop_pump()
+            return
+
         read = radio._request_authoritative_ptt_read
         send_release.set()
         pending_read = asyncio.create_task(read(11, observer))
@@ -762,9 +832,7 @@ class TestPtt:
         pending_write = asyncio.create_task(radio._write_managed_ptt(11, True))
         while link.send.await_count < 2:
             await asyncio.sleep(0)
-        runtime = radio._civ_runtime
-        token = runtime._managed_tx_ports[11]
-        if poison_only:
+        if invalidation == "poison":
             assert runtime._managed_tx_port_is_current(token)
             runtime._poison_managed_tx_port(token)
             assert runtime._managed_tx_ports[11] is token


### PR DESCRIPTION
## Summary

- strengthen the owning provider-token test around post-pacing invalidation and captured-A/current-B routing
- strengthen the managed-runtime replacement race around final post-service shutdown precedence
- close the three mutation-sensitive gaps found by the frozen 14-row MOR-1152 conformance audit

## Scope

- exactly two test files, net +87 LOC
- zero production, assembly, protocol, frontend, or hardware change

## Verification

- fresh independent pre-commit verifier PASS at patch-id `c820816fc4f81d5284af78644b7720cae3d5a21c`
- corrected rows 20/20 repetitions (40/40 cases)
- focused composite 91/91
- Ruff check/format and import-linter 5/5
- independent full non-integration: 8472 passed; sole unchanged audio-smoke baseline reproduced/attributed
- three precise mutants killed: removed post-pacing revalidation, current-B routing, removed final shutdown check

Software/fakes only; no hardware, RF, serial, or on-air validation.

Closes #2091

Linear: MOR-1152
