### PR TITLE
MOR-1009 Slice A: managed TX capability contract and facade

### DIFF
--- a/src/rigplane/core/radio_protocol.py
+++ b/src/rigplane/core/radio_protocol.py
@@ -41,6 +41,7 @@ Standard capability tags:
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -55,6 +56,7 @@ from typing import (
 )
 
 from .radio_state import RadioState, VfoSlotState
+from .tx_safety import TxOwner, TxReleaseReason, TxTransition
 from .types import AudioCodec, BreakInMode, Mode
 
 if TYPE_CHECKING:
@@ -92,6 +94,9 @@ __all__ = [
     "SystemControlCapable",
     "RepeaterControlCapable",
     "LevelsCapable",
+    "ManagedTxApi",
+    "ManagedTxCapable",
+    "ManagedTxSupervisor",
     "MetersCapable",
     "PowerControlCapable",
     "RigctldFallbackCache",
@@ -498,6 +503,76 @@ class SplitCapable(Protocol):
     async def set_split(self, on: bool) -> None:
         """Enable (``True``) or disable (``False``) split mode."""
         ...
+
+
+# --- Managed TX (supervised PTT) -------------------------------------------
+
+
+@runtime_checkable
+class ManagedTxSupervisor(Protocol):
+    """Supervised PTT surface of a radio's managed TX runtime.
+
+    Structural surface of
+    :class:`~rigplane.runtime.managed_radio_runtime.ManagedRadioRuntime`.
+    Managed ingress keys and unkeys through these methods only; the bare
+    :meth:`Radio.set_ptt` write stays private to the supervisor's own effect
+    path, so an ingress request never re-enters the supervisor.
+    """
+
+    async def request_on(self, owner: TxOwner) -> TxTransition:
+        """Request TX for ``owner`` — one supervisor entry per call."""
+        ...
+
+    async def release_owner(
+        self, owner: TxOwner, *, reason: TxReleaseReason
+    ) -> TxTransition:
+        """Release ``owner``'s TX lease — one supervisor entry per call."""
+        ...
+
+
+@runtime_checkable
+class ManagedTxCapable(Protocol):
+    """Radio that publishes a managed TX supervisor for every ingress.
+
+    Backends assembled with a managed runtime expose it here so Web, rigctld,
+    and the SDK route through :class:`ManagedTxApi` instead of writing PTT
+    themselves.  Backends without one expose no ``managed_tx`` attribute (or
+    return ``None``) and keep the legacy :meth:`Radio.set_ptt` path unchanged.
+    """
+
+    @property
+    def managed_tx(self) -> ManagedTxSupervisor | None:
+        """The radio's managed TX supervisor, or ``None`` when unmanaged."""
+        ...
+
+
+@dataclass(frozen=True, slots=True)
+class ManagedTxApi:
+    """One managed PTT facade bound to one stable ingress identity.
+
+    ``owner`` is bound once per ingress session: the supervisor matches a
+    release against the owner that took the lease, so a per-request owner
+    would fail that match and strand the radio keyed.
+    """
+
+    supervisor: ManagedTxSupervisor
+    owner: TxOwner
+
+    @staticmethod
+    def bind(radio: object, owner: TxOwner) -> ManagedTxApi | None:
+        """Bind ``owner`` to ``radio``'s supervisor; ``None`` when unmanaged."""
+        if not isinstance(radio, ManagedTxCapable):
+            return None
+        supervisor = radio.managed_tx
+        return None if supervisor is None else ManagedTxApi(supervisor, owner)
+
+    async def set_ptt(
+        self, on: bool, *, reason: TxReleaseReason = TxReleaseReason.OPERATOR_RELEASE
+    ) -> TxTransition:
+        """Route one key/unkey request into the supervisor exactly once."""
+        if on:
+            return await self.supervisor.request_on(self.owner)
+        return await self.supervisor.release_owner(self.owner, reason=reason)
 
 
 @runtime_checkable

--- a/tests/test_managed_tx_api.py
+++ b/tests/test_managed_tx_api.py
@@ -1,0 +1,105 @@
+"""Managed PTT facade contract: one supervisor entry, one bound owner."""
+
+from __future__ import annotations
+
+from rigplane.core.radio_protocol import (
+    ManagedTxApi,
+    ManagedTxCapable,
+    ManagedTxSupervisor,
+)
+from rigplane.core.tx_safety import (
+    TxOutcome,
+    TxOwner,
+    TxReleaseReason,
+    TxSafetySupervisor,
+    TxSource,
+    TxTransition,
+)
+from rigplane.runtime.managed_radio_runtime import ManagedRadioRuntime
+from rigplane.runtime.radio import IcomRadio
+
+_IDLE = TxSafetySupervisor().snapshot
+_OWNER = TxOwner(TxSource.SDK, "session")
+
+
+class FakeSupervisor:
+    """Managed entry point; drives the provider's private write hook."""
+
+    def __init__(self, radio: "FakeRadio") -> None:
+        self._radio = radio
+        self.calls: list[tuple[bool, TxOwner, TxReleaseReason | None]] = []
+
+    async def request_on(self, owner: TxOwner) -> TxTransition:
+        self.calls.append((True, owner, None))
+        await self._radio._write_managed_ptt(0, True)
+        return TxTransition(TxOutcome.ACCEPTED, _IDLE)
+
+    async def release_owner(
+        self, owner: TxOwner, *, reason: TxReleaseReason
+    ) -> TxTransition:
+        self.calls.append((False, owner, reason))
+        await self._radio._write_managed_ptt(0, False)
+        return TxTransition(TxOutcome.ACCEPTED, _IDLE)
+
+
+class FakeRadio:
+    """Provider whose bare ``set_ptt`` managed ingress must never reach."""
+
+    def __init__(self, managed: bool) -> None:
+        self.bare_writes: list[bool] = []
+        self.managed_writes: list[bool] = []
+        self.supervisor = FakeSupervisor(self)
+        self.managed_tx = self.supervisor if managed else None
+
+    async def set_ptt(self, on: bool) -> None:
+        self.bare_writes.append(on)
+
+    async def _write_managed_ptt(self, provider_generation: int, on: bool) -> None:
+        self.managed_writes.append(on)
+
+
+def test_shipped_radio_is_dormant() -> None:
+    # No backend attaches a managed runtime yet (MOR-1016), so the facade must
+    # refuse to bind and leave the legacy provider path untouched.
+    shipped = IcomRadio("127.0.0.1")
+
+    assert not isinstance(shipped, ManagedTxCapable)
+    assert ManagedTxApi.bind(shipped, _OWNER) is None
+    assert ManagedTxApi.bind(object(), _OWNER) is None
+    assert ManagedTxApi.bind(FakeRadio(False), _OWNER) is None
+
+
+def test_facade_binds_the_supervisor_and_owner_once() -> None:
+    radio = FakeRadio(True)
+
+    managed = ManagedTxApi.bind(radio, _OWNER)
+
+    assert managed is not None
+    assert managed.supervisor is radio.supervisor
+    assert managed.owner is _OWNER
+
+
+async def test_each_request_enters_the_supervisor_exactly_once() -> None:
+    radio = FakeRadio(True)
+    managed = ManagedTxApi.bind(radio, _OWNER)
+    assert managed is not None
+
+    await managed.set_ptt(True)
+    await managed.set_ptt(False)
+
+    assert radio.supervisor.calls == [
+        (True, _OWNER, None),
+        (False, _OWNER, TxReleaseReason.OPERATOR_RELEASE),
+    ]
+    # No bypass and no re-entry: the effect path owns the provider write.
+    assert radio.bare_writes == []
+    assert radio.managed_writes == [True, False]
+
+
+def test_managed_runtime_satisfies_the_supervisor_protocol() -> None:
+    async def _service(supervisor: object, transition: object) -> None:
+        return None
+
+    runtime = ManagedRadioRuntime("target", service_factory=lambda _host: _service)
+
+    assert isinstance(runtime, ManagedTxSupervisor)


### PR DESCRIPTION
Closes #2093 · Linear [MOR-1009](https://linear.app/morozsm/issue/MOR-1009/core-route-managed-sdk-ptt-through-managedtxapi)

## Slice A of 2 — additive dormant contract only

MOR-1009 was implemented as one diff and measured at 3 files / **254 net LOC** including tests, breaching the hard 3-file / 200-net guardrail (repo precedent MOR-1153 landed at +199 net **including** a +70 test file). Compressing further would have cost a safety assertion, so it was split with the established Slice A / Slice B pattern.

Slice B — routing the SDK sync ingress through this facade — is [MOR-1171](https://linear.app/morozsm/issue/MOR-1171/core-tx-sdk-route-sync-ptt-ingress-through-managedtxapi-mor-1009-slice), with the original implementation preserved verbatim.

## What this adds

`src/rigplane/core/radio_protocol.py`, following the file's existing `@runtime_checkable` capability-protocol idiom:

- `ManagedTxSupervisor` — structural surface of `ManagedRadioRuntime` (`request_on`, `release_owner`)
- `ManagedTxCapable` — the `managed_tx` discovery contract MOR-1016 will conform to
- `ManagedTxApi` — frozen facade; `bind()` returns `None` when unmanaged, `set_ptt` maps on to `request_on` and off to `release_owner(OPERATOR_RELEASE)`

## Dormancy

Nothing constructs the facade. Runtime behavior is unchanged for every shipped radio. This matters because `ManagedRadioRuntime` is not assembled in production until MOR-1016, so the legacy `Radio.set_ptt` path remains the only live TX path and must not be disturbed.

Independently verified: the three symbols appear only in this module and its test; no shipped class exposes `managed_tx` (`hasattr(IcomRadio(...), "managed_tx")` is `False`); no instance-level `__getattr__` exists in `src/` that could produce an accidental structural match; `rigplane.ManagedTxApi` raises `AttributeError` and `rigplane.__all__` is unchanged at 73 entries.

## Guardrail

2 files, **180 net LOC** (75 production + 105 tests). `src/rigplane/runtime/sync.py` is at HEAD — the Slice B revert is proven by an empty `git diff --stat` on that path.

## Evidence

A fresh non-author independent verifier returned PASS on this exact tree, re-running every gate itself rather than accepting reported numbers:

- mypy baseline independently re-derived via `git archive HEAD` into a scratch tree: baseline 15 errors / 4 files, current 15 / 4, sorted outputs byte-identical — **delta 0**, zero errors in the changed file
- `ruff check` and `ruff format --check` clean; `lint-imports` 5 kept / 0 broken
- focused 4 passed; public-API and contract guards 153 passed
- full non-integration suite 8476 passed, 1 failed (see below)

Test non-vacuity was mutation-tested rather than argued. Dropping the unmanaged guard, binding the radio instead of the supervisor, double-entering the supervisor, and corrupting the release reason each fail at least one test. The exactly-once test asserts on an ordered call list with arguments, not a bare count.

## Known pre-existing failure, not from this branch

`tests/smoke/test_audio_path_smoke.py::test_session_lifecycle_via_bridge_and_web_tx_lease` fails deterministically. Three independent agents reproduced it against **pristine `origin/main`** source, one via a PYTHONPATH override onto a `git archive` baseline tree. It is not introduced here and is being tracked separately.

## Hardware boundary

Software evidence only. No hardware was run and no hardware claim is made. MOR-1033 remains the same-release FTX-1 physical acceptance gate.
