### PR TITLE
MOR-1169: pin executor attempt deadline and barrier read

### DIFF
--- a/tests/test_managed_tx_effect_service.py
+++ b/tests/test_managed_tx_effect_service.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 from dataclasses import replace
 from itertools import count
 from unittest.mock import patch
@@ -245,3 +246,126 @@ async def test_failed_off_and_stale_readback_remain_durable_and_retryable() -> N
     assert supervisor.snapshot.phase is tx.TxPhase.IDLE
     retry = [("off", 11), ("read", 11)]
     assert calls == [("on", 11), ("read", 11), ("off", 11)] + retry * 2
+
+
+@pytest.mark.asyncio
+async def test_uncancelled_write_off_poisons_at_metadata_attempt_deadline() -> None:
+    now = [10.0]
+    supervisor, acquire = _acquire(13, now, attempt_timeout=0.5)
+    hang, retirements, cancellations = asyncio.Event(), [], 0
+    calls: list[tuple[str, int]] = []
+
+    async def write(generation: int, on: bool) -> None:
+        nonlocal cancellations
+        calls.append(("on" if on else "off", generation))
+        if not on:
+            try:
+                await hang.wait()
+            except asyncio.CancelledError:
+                cancellations += 1
+                raise
+
+    async def read(generation: int) -> None:
+        calls.append(("read", generation))
+        supervisor.observe_ptt(
+            tx.ProviderPttObservation(tx.RadioTx.ON, generation, 2, now[0])
+        )
+
+    async def retire(generation: int) -> None:
+        retirements.append(generation)
+
+    service = make_service(Host(lambda: now[0], write, read, retire))
+    await service(supervisor, acquire)
+    assert supervisor.snapshot.phase is tx.TxPhase.KEYED
+    release = _release(supervisor)
+    attempt = release.effects[0]
+    assert isinstance(attempt, tx.ProviderAttempt) and release.effects == (attempt,)
+    residual = 0.04
+    now[0] = attempt.started_at_monotonic + attempt.timeout_seconds - residual
+    with patch.object(
+        supervisor, "settle_attempt", wraps=supervisor.settle_attempt
+    ) as settle:
+        budget = attempt.timeout_seconds / 2
+        started = time.monotonic()
+        try:
+            await asyncio.wait_for(service(supervisor, release), budget)
+        finally:
+            hang.set()
+        elapsed = time.monotonic() - started
+    assert residual <= elapsed < budget
+    assert settle.call_count == 0 and cancellations == 1 and retirements == [13]
+    assert calls == [("on", 13), ("read", 13), ("off", 13)]
+    assert not getattr(service, "_claims")
+
+
+@pytest.mark.asyncio
+async def test_barrier_generation_floor_rejects_stale_attempt_and_cancel() -> None:
+    now = [10.0]
+    current, keyed = _acquire(10, now)
+    old, pending = _acquire(9, now)
+    calls: list[tuple[str, int]] = []
+
+    async def write(generation: int, on: bool) -> None:
+        calls.append(("on" if on else "off", generation))
+
+    async def read(generation: int) -> None:
+        calls.append(("read", generation))
+        current.observe_ptt(
+            tx.ProviderPttObservation(tx.RadioTx.ON, generation, 2, now[0])
+        )
+
+    async def retire(_: int) -> None:
+        raise AssertionError("stale-generation effects must never reach the provider")
+
+    service = make_service(Host(lambda: now[0], write, read, retire))
+    await service(current, keyed)
+    assert current.snapshot.phase is tx.TxPhase.KEYED
+    assert getattr(service, "_barrier") == (10, None)
+    stale = pending.effects[0]
+    assert old.snapshot.active_attempt == stale
+    with patch.object(old, "settle_attempt", wraps=old.settle_attempt) as settle:
+        await service(old, pending)
+        assert calls == [("on", 10), ("read", 10)] and settle.call_count == 0
+        cancel = _release(old)
+        assert isinstance(cancel.effects[0], tx.CancelProviderAttempt)
+        await service(old, cancel)
+    assert settle.call_count == 0 and old.snapshot.active_attempt == stale
+    assert getattr(service, "_barrier") == (10, None)
+    assert calls == [("on", 10), ("read", 10)] and not getattr(service, "_claims")
+
+
+@pytest.mark.asyncio
+async def test_claim_barrier_rejects_replay_the_identity_guard_would_admit() -> None:
+    now = [10.0]
+    supervisor, acquire = _acquire(5, now)
+    calls: list[tuple[str, int]] = []
+
+    async def write(generation: int, on: bool) -> None:
+        calls.append(("on" if on else "off", generation))
+
+    async def read(generation: int) -> None:
+        calls.append(("read", generation))
+        supervisor.observe_ptt(
+            tx.ProviderPttObservation(tx.RadioTx.ON, generation, 2, now[0])
+        )
+
+    async def retire(_: int) -> None:
+        raise AssertionError("a barred attempt must never reach the provider")
+
+    service = make_service(Host(lambda: now[0], write, read, retire))
+    await service(supervisor, acquire)
+    barred = _release(supervisor).effects[0]
+    assert isinstance(barred, tx.ProviderAttempt)
+    await service(supervisor, supervisor.set_provider_ready(5, ready=False))
+    assert getattr(service, "_barrier") == (5, barred.id)
+    twin, twin_acquire = _acquire(5, now)
+    readback = twin.settle_attempt(twin_acquire.effects[0].id, 5, succeeded=True)
+    twin.observe_ptt(tx.ProviderPttObservation(tx.RadioTx.ON, 5, 2, now[0]))
+    twin.settle_attempt(readback.effects[0].id, 5, succeeded=True)
+    replay = _release(twin)
+    assert replay.effects == (barred,) and twin.snapshot.active_attempt == barred
+    with patch.object(twin, "settle_attempt", wraps=twin.settle_attempt) as settle:
+        await service(twin, replay)
+    assert settle.call_count == 0 and twin.snapshot.active_attempt == barred
+    assert getattr(service, "_barrier") == (5, barred.id)
+    assert calls == [("on", 5), ("read", 5)] and not getattr(service, "_claims")


### PR DESCRIPTION
Closes #2094 · Linear [MOR-1169](https://linear.app/morozsm/issue/MOR-1169/verification-pin-the-managed-tx-executor-attempt-deadline-and-barrier)

## Verification only — one file, zero production change

`tests/test_managed_tx_effect_service.py`, **+124 / −0**. `git status --porcelain -- src/ frontend/` is empty.

Closes two mutation-coverage gaps surfaced by the MOR-1043 closeout audit. Neither was a correctness defect — the implementation is correct by inspection, mypy-clean and import-linter-clean. What was missing was a test that pins it.

## Gap 1 — the attempt deadline was not pinned

`src/rigplane/runtime/managed_tx_effect_service.py:49` derives the attempt deadline from supervisor effect metadata. Hardcoding it to 10 s, or setting it to infinity, left the entire focused suite green: every hang the suite exercised resolved through the *cancellation* settlement deadline at `:109`, never through the attempt deadline.

Latent risk on regression: a `WRITE_OFF` or `READ_PTT` that hangs with **no** accompanying cancellation would never poison the claim, `_active` would stay set, and `_service_release` (`src/rigplane/core/tx_safety.py:526-531`) would early-return forever — the durable-OFF retry loop stalls with the key down.

## Gap 2 — the claim barrier was written but never proven read

Existing tests asserted the barrier is written, never that it is read. Every admission the suite exercised was already rejected by the `active != effect` identity guard plus the supervisor's own STALE guard, so the barrier reads were unreachable by test.

## What the three new tests do

Each reaches a state where the guard under test is the **sole** rejector:

1. `test_uncancelled_write_off_poisons_at_metadata_attempt_deadline` — hangs a `WRITE_OFF` with no cancel; the fake clock is advanced to `started_at + timeout_seconds − 0.04`, so the only correct residual wait is 0.04 s. Brackets the observed wait against metadata, not a constant.
2. `test_barrier_generation_floor_rejects_stale_attempt_and_cancel` — a stale gen-9 attempt where the identity guard passes and only the generation floor can reject, plus the matching stale cancel.
3. `test_claim_barrier_rejects_replay_the_identity_guard_would_admit` — a replay where the identity guard would admit and the barrier key comparison is the only thing between it and the provider.

## Evidence — independently reproduced, not accepted

A fresh non-author verifier **wrote its own mutant probe** by exact source transformation of the production file, asserting every anchor unique and every transform non-no-op, rather than reusing the probe that produced the finding.

| Mutant | With new tests | Without new tests |
|---|---|---|
| M1 drop barrier key | **DIED** | survives |
| M6 hardcoded 10 s deadline | **DIED** | survives |
| M10 drop generation floor in `_attempt` | **DIED** | survives |
| M15 infinite deadline | **DIED** | survives |
| M16 drop generation floor in `_cancel` | **DIED** | survives |
| M17 drop both barrier reads | **DIED** ×2 | survives |

All six also survive the broader 329-test pre-existing suite with the new tests deselected — so the gap closure is real, not incidental coverage.

Three extra mutants the verifier added, all **DIED**, showing the deadline bracket is two-sided and not accidental: hardcoding the deadline to the file's own 0.2 s default (kills via the **lower** bound), using the right metadata with the wrong time base, and doubling the timeout.

The highest vacuity risk — test 3's claim that it reaches a state the identity guard would admit — was confirmed by instrumenting the guard itself: at the replay, the barrier-key hit is `True` while the identity guard and the generation floor both evaluate to admit.

## Timing robustness

Bracket is `0.04 ≤ elapsed < 0.25`. Verifier measurements: 30 idle runs (max 0.0423), 20 runs at **load average 92** on 10 cores (max 0.0443), and 24 concurrent full-file runs — **zero flakes across 63 full-file and 50 single-test executions**. 5.6× headroom on the upper bound under load; the lower bound is protected by ~2.1 ms of strictly positive pre-wait overhead against a measured 42 ns loop clock resolution. Also clean under `PYTHONASYNCIODEBUG=1 -W error::RuntimeWarning`.

## Gates

Focused 8 passed · focused+runtime+tx_safety+radio 332 passed · `ruff check` and `ruff format --check` clean · `lint-imports` 5 kept / 0 broken · full suite 8737 passed with the one pre-existing smoke failure below.

## Two pre-existing defects on `main`, confirmed and out of scope

1. `tests/smoke/test_audio_path_smoke.py::test_session_lifecycle_via_bridge_and_web_tx_lease` fails deterministically. Proven against genuinely pristine base source via a read-only `git archive` export with `PYTHONPATH` redirection. Not introduced here.
2. `tests/test_field_status_frontend_fixture.py:69-80` writes the fixture and then asserts against what it just wrote — a tautology that can never fail, so it provides no drift protection. The committed fixture is stale (missing the `global.tx_state.tx_target` leaf), so a normal full-suite run dirties a tracked file. The verifier confirmed this read-only, without dirtying anything, and ran the full suite with that test deselected.

Both are being tracked separately.

## Hardware boundary

Software and fake-clock evidence only. No hardware was run and no hardware claim is made. MOR-1033 remains the same-release FTX-1 physical acceptance gate.
