### PR TITLE
MOR-1171: route SDK sync PTT ingress through ManagedTxApi

### DIFF
--- a/src/rigplane/runtime/sync.py
+++ b/src/rigplane/runtime/sync.py
@@ -14,6 +14,7 @@ Example::
 
 import asyncio
 import time
+import uuid
 from dataclasses import dataclass
 from typing import Any, Callable, Coroutine, TypeVar
 
@@ -24,8 +25,11 @@ from rigplane.core.command_service import (
     command_intent_from_request,
     command_response_observation,
 )
+from rigplane.core.exceptions import CommandError
+from rigplane.core.radio_protocol import ManagedTxApi
 from rigplane.core.state_pipeline_contracts import CommandIntent, Observation
 from rigplane.core.state_store import StateStore
+from rigplane.core.tx_safety import TxOutcome, TxOwner, TxSource
 from .ic705 import (
     prepare_ic705_data_profile as _prepare_ic705_data_profile,
     restore_ic705_data_profile as _restore_ic705_data_profile,
@@ -37,6 +41,8 @@ from rigplane.core.types import AudioCodec, Mode, ScopeCompletionPolicy
 T = TypeVar("T")
 
 __all__ = ["IcomRadio"]
+
+_KEY_ACCEPTED = frozenset({TxOutcome.ACCEPTED, TxOutcome.IDEMPOTENT})
 
 
 @dataclass(slots=True)
@@ -60,7 +66,7 @@ class _SyncCommandExecutor:
         elif intent.name == "set_rf_power":
             await radio.set_rf_power(int(params["value"]))
         elif intent.name == "set_ptt":
-            await radio.set_ptt(bool(params["ptt"]))
+            await self.wrapper._execute_ptt(bool(params["ptt"]))
         elif intent.name == "set_split":
             await radio.set_split(bool(params["split"]))
         elif intent.name == "set_attenuator_level":
@@ -148,6 +154,10 @@ class IcomRadio:
             executor=_SyncCommandExecutor(self),
             state_store=self._state_store,
         )
+        # One TX identity per SDK session (MOR-1009): the managed supervisor
+        # matches a release against the owner that took the lease, so this is
+        # bound once here rather than minted per request.
+        self._tx_owner = TxOwner(TxSource.SDK, uuid.uuid4().hex)
 
     def _run(self, coro: Coroutine[Any, Any, T]) -> T:
         """Run a coroutine on the internal event loop."""
@@ -356,6 +366,30 @@ class IcomRadio:
                 )
             )
         )
+
+    async def _execute_ptt(self, on: bool) -> None:
+        """Route one PTT request through the managed supervisor when present.
+
+        Radios without a managed runtime keep the legacy direct provider
+        write. The supervisor reports refusal through the returned outcome
+        rather than by raising, so both directions inspect it explicitly.
+        """
+        managed = ManagedTxApi.bind(self._radio, self._tx_owner)
+        if managed is None:
+            await self._radio.set_ptt(on)
+            return
+        transition = await managed.set_ptt(on)
+        if not on:
+            # A refused release answers STALE, which means either nothing was
+            # keyed or another owner holds the lease. Neither is actionable
+            # here — a non-owner cannot force a release by design — and raising
+            # would break the defensive unkey callers put in ``finally``.
+            return
+        if transition.outcome not in _KEY_ACCEPTED:
+            # ``set_ptt`` returns nothing, so swallowing a refusal would leave
+            # the caller believing it is on the air while the rig is not
+            # transmitting on its behalf.
+            raise CommandError(f"managed TX rejected set_ptt: {transition.outcome}")
 
     # ------------------------------------------------------------------
     # VFO / Split

--- a/tests/test_managed_tx_api.py
+++ b/tests/test_managed_tx_api.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+
+import pytest
+
+from rigplane.core.exceptions import CommandError
 from rigplane.core.radio_protocol import (
     ManagedTxApi,
     ManagedTxCapable,
@@ -17,38 +22,52 @@ from rigplane.core.tx_safety import (
 )
 from rigplane.runtime.managed_radio_runtime import ManagedRadioRuntime
 from rigplane.runtime.radio import IcomRadio
+from rigplane.runtime.sync import IcomRadio as SyncIcomRadio
 
 _IDLE = TxSafetySupervisor().snapshot
 _OWNER = TxOwner(TxSource.SDK, "session")
+# Every answer ``request_on`` can give when the caller did *not* get the rig.
+_KEY_REJECTIONS = (
+    TxOutcome.BUSY,
+    TxOutcome.NOT_READY,
+    TxOutcome.RADIO_NOT_OFF,
+    TxOutcome.RELEASE_PENDING,
+    TxOutcome.STALE,
+)
 
 
 class FakeSupervisor:
     """Managed entry point; drives the provider's private write hook."""
 
-    def __init__(self, radio: "FakeRadio") -> None:
-        self._radio = radio
+    def __init__(self, radio: "FakeRadio", on: TxOutcome, off: TxOutcome) -> None:
+        self._radio, self._on, self._off = radio, on, off
         self.calls: list[tuple[bool, TxOwner, TxReleaseReason | None]] = []
 
     async def request_on(self, owner: TxOwner) -> TxTransition:
         self.calls.append((True, owner, None))
         await self._radio._write_managed_ptt(0, True)
-        return TxTransition(TxOutcome.ACCEPTED, _IDLE)
+        return TxTransition(self._on, _IDLE)
 
     async def release_owner(
         self, owner: TxOwner, *, reason: TxReleaseReason
     ) -> TxTransition:
         self.calls.append((False, owner, reason))
         await self._radio._write_managed_ptt(0, False)
-        return TxTransition(TxOutcome.ACCEPTED, _IDLE)
+        return TxTransition(self._off, _IDLE)
 
 
 class FakeRadio:
     """Provider whose bare ``set_ptt`` managed ingress must never reach."""
 
-    def __init__(self, managed: bool) -> None:
+    def __init__(
+        self,
+        managed: bool,
+        on: TxOutcome = TxOutcome.ACCEPTED,
+        off: TxOutcome = TxOutcome.ACCEPTED,
+    ) -> None:
         self.bare_writes: list[bool] = []
         self.managed_writes: list[bool] = []
-        self.supervisor = FakeSupervisor(self)
+        self.supervisor = FakeSupervisor(self, on, off)
         self.managed_tx = self.supervisor if managed else None
 
     async def set_ptt(self, on: bool) -> None:
@@ -103,3 +122,113 @@ def test_managed_runtime_satisfies_the_supervisor_protocol() -> None:
     runtime = ManagedRadioRuntime("target", service_factory=lambda _host: _service)
 
     assert isinstance(runtime, ManagedTxSupervisor)
+
+
+# --- SDK sync ingress (MOR-1171) -------------------------------------------
+
+
+@pytest.fixture
+def wrapper() -> Iterator[SyncIcomRadio]:
+    """One SDK session; the sync facade owns a private event loop."""
+    radio = SyncIcomRadio("127.0.0.1")
+    try:
+        yield radio
+    finally:
+        radio._loop.close()
+
+
+def _attach(wrapper: SyncIcomRadio, provider: FakeRadio) -> FakeRadio:
+    wrapper._radio = provider  # type: ignore[assignment]
+    return provider
+
+
+def test_shipped_ingress_keeps_the_legacy_direct_write(
+    wrapper: SyncIcomRadio,
+) -> None:
+    # Nothing assembles a managed runtime yet (MOR-1016), so the backend the
+    # SDK actually ships must still reach its own ``set_ptt``, unchanged.
+    writes: list[bool] = []
+
+    async def _record(on: bool) -> None:
+        writes.append(on)
+
+    assert not isinstance(wrapper._radio, ManagedTxCapable)
+    assert ManagedTxApi.bind(wrapper._radio, wrapper._tx_owner) is None
+    wrapper._radio.set_ptt = _record  # type: ignore[method-assign]
+
+    wrapper.set_ptt(True)
+    wrapper.set_ptt(False)
+
+    assert writes == [True, False]
+
+
+@pytest.mark.parametrize("outcome", [TxOutcome.ACCEPTED, TxOutcome.IDEMPOTENT])
+def test_managed_ingress_enters_the_supervisor_exactly_once(
+    wrapper: SyncIcomRadio, outcome: TxOutcome
+) -> None:
+    # IDEMPOTENT means this owner already holds the lease, so the request did
+    # land — it is an accepting outcome, not a rejection.
+    provider = _attach(wrapper, FakeRadio(True, on=outcome, off=outcome))
+
+    wrapper.set_ptt(True)
+    wrapper.set_ptt(False)
+
+    owner = wrapper._tx_owner
+    assert provider.supervisor.calls == [
+        (True, owner, None),
+        (False, owner, TxReleaseReason.OPERATOR_RELEASE),
+    ]
+    # No bypass and no re-entry: the effect path owns the provider write.
+    assert provider.bare_writes == []
+    assert provider.managed_writes == [True, False]
+
+
+def test_owner_identity_is_stable_per_session(wrapper: SyncIcomRadio) -> None:
+    provider = _attach(wrapper, FakeRadio(True))
+    other = SyncIcomRadio("127.0.0.1")
+
+    wrapper.set_ptt(True)
+    wrapper.set_ptt(False)
+    wrapper.set_ptt(True)
+
+    try:
+        # A per-request owner would make ``release_owner`` miss its own lease
+        # and strand the rig keyed until the watchdog fires.
+        assert [owner for _, owner, _ in provider.supervisor.calls] == [
+            wrapper._tx_owner
+        ] * 3
+        assert wrapper._tx_owner.source is other._tx_owner.source is TxSource.SDK
+        assert other._tx_owner != wrapper._tx_owner
+    finally:
+        other._loop.close()
+
+
+@pytest.mark.parametrize("outcome", _KEY_REJECTIONS)
+def test_a_key_the_supervisor_refused_raises(
+    wrapper: SyncIcomRadio, outcome: TxOutcome
+) -> None:
+    # ``set_ptt`` returns nothing, so a swallowed rejection would leave the
+    # caller believing it is on the air while the rig is not transmitting.
+    provider = _attach(wrapper, FakeRadio(True, on=outcome))
+
+    with pytest.raises(CommandError, match=str(outcome)):
+        wrapper.set_ptt(True)
+
+    assert provider.supervisor.calls == [(True, wrapper._tx_owner, None)]
+    assert provider.bare_writes == []
+
+
+def test_a_release_the_supervisor_refused_is_tolerated(
+    wrapper: SyncIcomRadio,
+) -> None:
+    # STALE covers both "nothing was keyed" and "another owner holds it". A
+    # non-owner cannot force a release by design, so an unkey is best effort
+    # and must not throw out of a caller's ``finally`` block.
+    provider = _attach(wrapper, FakeRadio(True, off=TxOutcome.STALE))
+
+    wrapper.set_ptt(False)
+
+    assert provider.supervisor.calls == [
+        (False, wrapper._tx_owner, TxReleaseReason.OPERATOR_RELEASE)
+    ]
+    assert provider.bare_writes == []


### PR DESCRIPTION
Closes #2097 · Linear [MOR-1171](https://linear.app/morozsm/issue/MOR-1171/core-tx-sdk-route-sync-ptt-ingress-through-managedtxapi-mor-1009-slice) — Slice B of MOR-1009.

Slice A (#2095) landed the dormant `ManagedTxApi` contract. This routes the SDK sync ingress through it — the first and only production consumer of that facade, and the only `TxSource.SDK` construction in the repo.

## Scope

2 files, **+163 net LOC** including tests (`src/rigplane/runtime/sync.py` +35/−1, `tests/test_managed_tx_api.py` +135/−6). No new abstraction or layer.

## Design decisions, and why

**Owner bound once per wrapper, not per request.** `release_owner` matches on owner alone (`core/tx_safety.py:391-394`). A per-request owner would miss its own lease — the key goes down under one identity, the release arrives under another, the supervisor refuses it, and the rig is left keyed. That is the failure mode this choice exists to prevent.

**A refused key raises `CommandError`; a refused release does not.** This asymmetry was the main thing the independent review was asked to attack, and it survived with direct evidence rather than argument.

## The OFF-path question, settled empirically

The reviewer enumerated `release_owner`'s reachable outcomes statically and then **fuzzed the real, unmodified `TxSafetySupervisor`** — 400 seeds × 300 randomized operations:

```
release_owner(SDK) over 10,046 calls:  accepted 298 · idempotent 787 · stale 8961
request_on(SDK):  accepted 1316 · idempotent 282 · provider_not_ready 1995
                  radio_not_off 3996 · release_pending 1597 · tx_busy 1000
```

Two conclusions:

- **`RELEASE_PENDING` is unreachable on the OFF path.** It is emitted only by `request_on` — the path that *does* raise. The specific worry "a release refused while the rig is still keyed" does not exist here.
- **`STALE` can never mean our own key is still up.** `_clear_managed()` is the sole call site that drops a lease and fires only on an accepted OFF observation. Measured: **2456 lease drops, 0 of them not preceded by an OFF observation.** The only case where `STALE` coexists with a transmitting rig is `EXTERNAL_UNOWNED` — a key held by nobody's lease, which `release_owner` refuses by design.

Raising on the non-`ACCEPTED` subset would also be a *false* discrimination: `ACCEPTED` itself only means a `WRITE_OFF` effect was emitted, not that the rig de-keyed. No OFF outcome distinguishes "de-keyed" from "de-keying in progress", and the pre-existing `await radio.set_ptt(False) -> None` carried exactly the same non-guarantee. No signal is lost.

**Nothing retryable is dropped.** `_schedule_retry` is reachable only from `settle_attempt`, the provider-I/O completion callback owned by the runtime — entirely downstream of the value the ingress sees. A physically failed de-key still routes to `tick()` → `_service_release`.

## Dormancy

`bind()` returns `None` for every shipped radio until MOR-1016 assembles runtimes, and the legacy direct write is unchanged. Proven against the real shipped `IcomRadio`, driven through the public `wrapper.set_ptt`. The test file contains zero `Mock`/`patch` references, so the 3.11-vs-3.12 `isinstance(Mock, runtime_checkable Protocol)` divergence cannot apply.

## Evidence

**TDD reproduced by the reviewer:** with only the new test file dropped onto a pristine HEAD tree, **10 failed, 4 passed** — all 10 new tests fail, all pre-existing pass.

**14 mutants, 14 dead.** Including: swapped ON/OFF mapping, dropped ON-path raise, `bind()` always yielding a facade, **fresh owner per request** (the stuck-transmitter mode), dropped dormant fallback, wrong release reason, widened accept set, managed-route-plus-legacy-bypass, owner shared across sessions, tolerating only `STALE` on OFF, OFF never entering the supervisor, `IDEMPOTENT` treated as rejection, OFF entering twice, and a fallback that writes `not on`.

**Gates, all re-run independently by the reviewer:** focused 14 passed · ruff clean · lint-imports 5 kept / 0 broken · `mypy src/` **delta 0** against a baseline the reviewer re-derived itself via `git archive` · 252 adjacent tests · 24 `set_ptt`-touching files: 1721 passed on the diff vs 1711 on pristine base, delta exactly the 10 new tests.

**Python 3.11** — the interpreter `quick.yml` pins — run in an isolated env: focused 14 passed, adjacent 251 passed. No divergence.

## Public API note

After MOR-1016 wires a managed runtime, `sync.IcomRadio.set_ptt(True)` gains a new trigger for `CommandError`. The exception type is already established for SDK setters through the same facade, so this is not a new exception class, but it is a new condition and is called out here per `AGENTS.md`.

## Follow-up identified, not fixed here

Once a radio assembles a managed runtime, `set_ptt(False)` will silently no-op when the rig is keyed by an **external, unowned** source, where the legacy path would have written a raw CI-V PTT-off. `release_owner` refuses non-owners by design and `emergency_release` is deliberately absent from `ManagedTxSupervisor`. Raising in the ingress would not close it — it needs a privileged unkey surface. Tracked separately; it becomes reachable only when MOR-1016 lands.

## Hardware boundary

Software evidence only, from source reading plus an in-process fuzz of the real supervisor. No hardware was run and no hardware claim is made. MOR-1033 remains the same-release FTX-1 physical acceptance gate.
