### PR TITLE
MOR-1173: stop denying TX audio start when the Opus decoder is missing

### DIFF
--- a/src/rigplane/web/handlers/audio.py
+++ b/src/rigplane/web/handlers/audio.py
@@ -1440,9 +1440,22 @@ class AudioHandler:
                     await self._send_error("audio_start: TX audio unavailable")
                     return
                 if not transcoder_ready:
-                    await self._abort_tx_start(previous_facts, was_active)
-                    await self._send_error("audio_start: TX transcoder unavailable")
-                    return
+                    # MOR-1173: a missing Opus→PCM transcoder must not deny the
+                    # whole session.  ``audio_start`` cannot know which codec the
+                    # browser will actually send, and browser PCM16 → radio PCM16
+                    # is forwarded in ``_handle_tx_audio`` with no transcoder at
+                    # all — ``tx-mic.ts`` deliberately falls back to PCM16 where
+                    # WebCodecs is unreliable.  The real hazard, a browser Opus
+                    # frame with no decoder, is already dropped fail-closed per
+                    # frame (``action=dropped_no_transcoder``, #1569), so arm the
+                    # session and let that guard do its job.  Warn loudly so an
+                    # operator can still diagnose a missing native opus codec.
+                    logger.warning(
+                        "audio: TX Opus decoder unavailable at %d Hz "
+                        "(native opus codec missing?) — browser PCM16 TX still "
+                        "works, browser Opus TX frames will be dropped",
+                        self._tx_sample_rate(),
+                    )
                 assert facts.lifecycle is not None
                 start = facts.lifecycle[0]
                 try:

--- a/tests/test_handlers_coverage.py
+++ b/tests/test_handlers_coverage.py
@@ -1728,6 +1728,38 @@ def _make_neutral_tx_radio(contract: AudioStreamContract) -> _NeutralWebTxRadio:
     return _NeutralWebTxRadio(contract)
 
 
+class _WebTxLease:
+    """Minimal stand-in for the AudioSession TX lease (MOR-580)."""
+
+    def __init__(self) -> None:
+        self.released = False
+        self.pushed: list[bytes] = []
+
+    async def push(self, data: bytes) -> None:
+        self.pushed.append(data)
+
+    async def release(self) -> None:
+        self.released = True
+
+
+class _WebTxSession:
+    def __init__(self, lease: _WebTxLease) -> None:
+        self._lease = lease
+        self.acquired: list[str] = []
+
+    async def acquire_tx(self, client: str) -> _WebTxLease:
+        self.acquired.append(client)
+        return self._lease
+
+
+class _SessionTxRadio(_NeutralWebTxRadio):
+    """Neutral fake radio that also owns an AudioSession → ``path="session"``."""
+
+    def __init__(self, contract: AudioStreamContract, lease: _WebTxLease) -> None:
+        super().__init__(contract)
+        self.audio_session = _WebTxSession(lease)
+
+
 async def test_browser_tx_audio_endpoint_matches_real_provider_facts(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1780,14 +1812,26 @@ async def test_browser_tx_audio_uses_one_snapshot_after_radio_swap(
     replacement._stop_tx.assert_not_awaited()
 
 
-async def test_transcoder_failure_denies_before_arm_and_keeps_reader_rx(
+async def test_transcoder_failure_arms_tx_and_drops_only_opus_frames(
     monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    radio = _make_neutral_tx_radio(_make_web_tx_contract(AudioCodec.PCM_1CH_16BIT))
+    """MOR-1173: a missing Opus decoder must not deny the whole session.
+
+    ``audio_start`` cannot know which codec the browser will send, and the
+    radio here speaks PCM16 — so browser PCM16 needs no transcoder and must
+    reach the radio through a real lease.  Only a browser *Opus* frame stays
+    fail-closed (#1569), dropped per frame rather than by denying the arm.
+    """
+    lease = _WebTxLease()
+    contract = _make_web_tx_contract(AudioCodec.PCM_1CH_16BIT)
+    radio = _SessionTxRadio(contract, lease)
     start = (WS_OP_TEXT, b'{"type":"audio_start","direction":"tx"}')
+    opus = (WS_OP_BINARY, _make_web_tx_audio_frame(AUDIO_CODEC_OPUS, b"opus-frame"))
+    pcm = (WS_OP_BINARY, _make_web_tx_audio_frame(AUDIO_CODEC_PCM16, b"pcm-frame"))
     stats = (WS_OP_TEXT, b'{"type":"audio_stats","rtt":1}')
     ws = SimpleNamespace(
-        recv=AsyncMock(side_effect=[start, stats, EOFError()]),
+        recv=AsyncMock(side_effect=[start, opus, pcm, stats, EOFError()]),
         send_text=AsyncMock(),
     )
     handler = AudioHandler(ws, radio, SimpleNamespace(record_client_stats=MagicMock()))
@@ -1798,13 +1842,22 @@ async def test_transcoder_failure_denies_before_arm_and_keeps_reader_rx(
         MagicMock(side_effect=RuntimeError("factory failed")),
     )
 
-    await handler._reader_loop()
+    with caplog.at_level("WARNING", logger="rigplane.web.handlers.audio"):
+        await handler._reader_loop()
 
-    assert ws.recv.await_count == 3
+    assert ws.recv.await_count == 5
     assert handler._rx_active is True
-    assert handler._tx_active is False
-    radio._start_tx.assert_not_awaited()
-    assert decode_json(ws.send_text.await_args.args[0])["type"] == "error"
+    # Armed despite the missing decoder, and the TX lease really was taken.
+    assert handler._tx_active is True
+    assert handler._transcoder is None
+    assert radio.audio_session.acquired == ["web"]
+    assert handler._tx_lease is lease
+    # PCM16 reached the radio; the Opus frame stayed fail-closed.
+    assert lease.pushed == [b"pcm-frame"]
+    ws.send_text.assert_not_awaited()
+    messages = [record.message for record in caplog.records]
+    assert any("action=dropped_no_transcoder" in message for message in messages)
+    assert any("TX Opus decoder unavailable" in message for message in messages)
 
 
 @pytest.mark.parametrize("failure", ["denial", "runtime", "base", "cancel"])


### PR DESCRIPTION
Closes #2098 · Linear [MOR-1173](https://linear.app/morozsm/issue/MOR-1173/web-tx-start-never-acquires-a-lease-on-the-shared-session-audio-path)

Fixes a regression that makes Web TX unusable on any host without resolvable native libopus, and — as the review established — removes a "keyed with no modulation" failure mode rather than creating one.

## Root cause, bisected

Commit `1b02d7b8` ("feat(#1999): enforce browser TX audio snapshots", 2026-07-27) turned `_ensure_tx_transcoder()` from fire-and-forget into a hard start-time gate at `audio_start direction=tx`.

Read-only `git archive` exports, `PYTHONPATH`-redirected with `rigplane.__file__` verified against each export:

| Tree | Result |
|---|---|
| `5cf5062d` (parent) | **1 passed** in 0.34 s |
| `1b02d7b8` | **1 failed** |
| `5f07436d` | 1 failed |

The test file is byte-identical (`sha1 07a680b3…`) across all three. **Production changed under an unchanged test.**

CI never caught it: no workflow installs libopus and Ubuntu runners resolve `libopus.so.0` via ldconfig. It surfaces on macOS without `brew install opus` — and per `docs/opuslib-macos-fix.md` also *with* Homebrew opus, since `find_library` misses `/opt/homebrew/lib`.

## Why the gate is wrong

The transcoder is needed only when the browser actually sends Opus and the radio wants PCM16. The start-time gate cannot know what the browser will send; it guesses from the radio codec alone. Two facts make the guess unnecessary:

- browser-PCM16 → radio-PCM16 is forwarded with **no transcoder involvement at all**, and `frontend/src/lib/audio/tx-mic.ts` deliberately sends `CODEC_PCM16` as a fallback because WebCodecs is unreliable in embedded WebViews;
- Opus-in-with-no-transcoder is **already** handled per frame with `action=dropped_no_transcoder`, added in `c86da7b0` ("fix(#1569): fail closed on Opus TX without transcoder").

## The change

2 files, **net +66 LOC**. One production hunk: the abort/deny/return becomes a `logger.warning` and fall-through, so the session arms and the lease is taken. Everything else in `audio.py` is untouched — the reviewer AST-compared all 62 function definitions and found exactly one differs.

## Safety: this is an availability gate, not a fail-closed gate

Independently re-derived by the reviewer rather than accepted from the description.

- **`audio_start direction=tx` does not key the radio.** PTT is asserted on a separate path — `web/radio_poller.py:1352` on a `PttOn()` control command. `grep set_ptt src/rigplane/web/handlers/audio.py` returns zero hits, as does `audio/session.py`. `acquire_tx` adds TX *demand*; it never asserts PTT.
- **The per-frame guard is byte-identical**, merely shifted by +13 lines, and still fed a `None` transcoder on construction failure. `_ensure_tx_transcoder()` still runs on every PCM16-codec arm, so a stale wrong-rate transcoder cannot survive into the frame path.
- **No path can push garbage.** Opus bytes reach `_push_tx` only where `tx_codec != PCM_1CH_16BIT`, which is exactly the case where `transcoder_ready` was already True and the new code never runs.

**The risk direction is reversed by this fix.** On `main`, a PCM16-capable browser on a libopus-less host is denied the audio session *yet can still press PTT via the control WS* — keying the transmitter with no modulation, the symptom `docs/guide/troubleshooting.md:443-450` documents. This change removes that failure mode for PCM16 clients and leaves Opus-without-libopus exactly where it was.

## Evidence

**Red before, green after, on a host that genuinely lacks libopus** (`ctypes.util.find_library('opus')` → `None`; the real factory raises `AudioCodecBackendError`). No Opus stub at any point.

- base `src` via `PYTHONPATH` shadow: `1 failed, 6 passed, 1 skipped` — fails at `test_audio_path_smoke.py:557`
- working tree: **`7 passed, 1 skipped`**

**Mutations, all out-of-tree:**

| Mutation | Result |
|---|---|
| revert the production hunk | new test **FAILS** (`_tx_active is False`) — the test genuinely pins the fix |
| delete the per-frame Opus guard | **FAILS** — degrades to `dropped_transcode_failed` on a `None` transcoder |
| replace the guard with a raw pass-through (true fail-open) | **FAILS** — `[b'opus-frame', b'pcm-frame'] != [b'pcm-frame']` |

`lease.pushed == [b"pcm-frame"]` is two-sided: it catches an extra Opus push and a missing PCM push with one assertion.

**Gates, all re-run independently by the reviewer:** smoke 7 passed/1 skipped · `test_handlers_coverage.py` 154 passed · web-server + audio-session batch 336 passed/2 skipped · broad blast-radius batch 428 passed/3 skipped · ruff clean · `lint-imports` 5 kept / 0 broken · `mypy --strict src/rigplane/web` clean · `mypy src/` baseline re-derived out-of-tree with **byte-identical sorted error lists** (15 in 4 files both sides, none in `audio.py`).

## The re-pointed test

`test_transcoder_failure_denies_before_arm_and_keeps_reader_rx` → `test_transcoder_failure_arms_tx_and_drops_only_opus_frames`. Rewritten, not deleted, and strictly stronger. The old test used a neutral-path radio with no lease at all — which is exactly why it could never have caught this regression, despite being nominally about transcoder failure. It also never sent a single audio frame, so it never exercised the fail-closed property it was named for.

Preserved: reader survives to EOF (strengthened from 3 to 5 messages), RX untouched. Added: `_transcoder is None` so the test cannot pass vacuously, real session-path lease acquisition, per-frame codec discrimination, `action=dropped_no_transcoder` present, and `ws.send_text.assert_not_awaited()`.

## The removed error envelope had no consumers

`audio_start: TX transcoder unavailable` has zero remaining references in the repo, and `frontend/src/lib/audio/audio-manager.ts:277-281` discards text frames outright — so it was never surfaced to the operator. Replacing it with a server-side warning is a net gain in diagnosability. The unchanged DEBUG line that `troubleshooting.md` documents is a different message and still fires.

## Known unrelated issue, not touched

`tests/test_web_server.py:78-101` `_http_get` does a single `reader.read(65536)` with no EOF loop, so a large `/api/v1/state` body can be truncated at a segment boundary, giving an intermittent `JSONDecodeError`. Pre-existing, confirmed independently, tracked separately.

## Hardware boundary

Software evidence only, from fakes and local execution on a host whose lack of resolvable libopus is itself the condition under test. No hardware was run and no hardware claim is made. MOR-1033 remains the same-release FTX-1 physical acceptance gate.
