### PR TITLE
test: read full HTTP response in test_web_server _http_get helper

### DIFF
--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -75,6 +75,36 @@ def _ws_accept(key: str) -> str:
     return base64.b64encode(hashlib.sha1(raw).digest()).decode("ascii")
 
 
+async def _read_http_response(
+    reader: asyncio.StreamReader,
+) -> tuple[int, dict[str, str], bytes]:
+    """Read one complete HTTP response from ``reader``.
+
+    A single ``reader.read(n)`` returns whatever one TCP segment happened to
+    carry, so bodies larger than a segment (``/api/v1/state`` is ~32 KiB) were
+    silently truncated mid-JSON. Read the headers up to the blank line, then
+    take either ``Content-Length`` body bytes or everything until EOF (callers
+    send ``Connection: close``, and the server always sets ``Content-Length``).
+    """
+    header_bytes = (await reader.readuntil(b"\r\n\r\n"))[:-4]
+
+    lines = header_bytes.decode("ascii", errors="replace").split("\r\n")
+    status_code = int(lines[0].split(" ", 2)[1])
+    headers: dict[str, str] = {}
+    for line in lines[1:]:
+        if ":" in line:
+            k, _, v = line.partition(":")
+            headers[k.strip().lower()] = v.strip()
+
+    raw_length = headers.get("content-length")
+    if raw_length is None:
+        body = await reader.read()  # until EOF
+    else:
+        body = await reader.readexactly(int(raw_length))
+
+    return status_code, headers, body
+
+
 async def _http_get(
     host: str, port: int, path: str
 ) -> tuple[int, dict[str, str], bytes]:
@@ -87,29 +117,13 @@ async def _http_get(
         writer.write(request.encode())
         await writer.drain()
 
-        raw = await asyncio.wait_for(reader.read(65536), timeout=5.0)
+        return await asyncio.wait_for(_read_http_response(reader), timeout=5.0)
     finally:
         writer.close()
         try:
             await writer.wait_closed()
         except Exception:
             pass
-
-    # Parse response
-    header_end = raw.find(b"\r\n\r\n")
-    header_bytes = raw[:header_end]
-    body = raw[header_end + 4 :]
-
-    lines = header_bytes.decode("ascii", errors="replace").split("\r\n")
-    status_line = lines[0]
-    status_code = int(status_line.split(" ", 2)[1])
-    headers: dict[str, str] = {}
-    for line in lines[1:]:
-        if ":" in line:
-            k, _, v = line.partition(":")
-            headers[k.strip().lower()] = v.strip()
-
-    return status_code, headers, body
 
 
 async def _ws_connect(


### PR DESCRIPTION
## Problem

`_http_get` in `tests/test_web_server.py` performed a single
`await asyncio.wait_for(reader.read(65536), timeout=5.0)` and treated whatever
bytes arrived as the complete HTTP response. It neither looped until EOF nor
honoured `Content-Length`, so any body larger than one TCP segment was
silently truncated.

Observed once as `TestHttpEndpoints::test_info_and_state_flow_from_serial_mock_radio`
failing while parsing the `/api/v1/state` body:

```
json.decoder.JSONDecodeError: Unterminated string starting at: line 1 column 32235 (char 32234)
```

— i.e. cut at roughly a 32 KiB segment boundary. The same test passed 8/8 on
re-runs, so it is a low-frequency flake rather than a deterministic failure.

## Change

Test infrastructure only — `src/` is untouched.

Extracted `_read_http_response`:

- headers via `readuntil(b"\r\n\r\n")`;
- body via `readexactly(Content-Length)`, falling back to `read()` until EOF
  when the header is absent (the request already sends `Connection: close`);
- the 5 s `wait_for` now bounds the whole read instead of one `read()` call;
- the `(status_code, headers, body)` return shape is unchanged, so none of the
  ~20 call sites needed touching.

`web/server.py::_send_response` always sets `Content-Length` (including `0` for
204/304), so `readexactly` is the normal path. The only response without it is
the 101 Switching Protocols upgrade, which `_http_get` never requests — that
path goes through `_ws_connect`.

## Verification

The suite passed before this change too, so passing tests alone prove nothing.
A standalone harness served a 200 KiB JSON body in 4 KiB chunks with awaits in
between and ran both helper versions against it:

```
OLD: body=4096/200021   complete=False  JSONDecodeError: Unterminated string starting at: line 1 column 10
NEW: body=200021/200021 complete=True   json-ok
NEW empty-body: status=204 body=b'' ok=True
```

The old helper reproduces the exact reported failure class; the new one reads
the body whole, and a zero-length (204) body still works.

| Check | Result |
|---|---|
| `uv run pytest tests/test_web_server.py -q` x5 | 194 passed, 2 skipped (5/5) |
| same, 6 concurrent runs x2 | 12/12 green |
| same at HEAD with the diff stashed | 5/5 and 12/12 — baseline clean |
| `uv run pytest tests/ -q --ignore=tests/integration` | 8479 passed, 1 failed (see below) |
| `uv run ruff check src/ tests/` + `ruff format --check` | clean |

## Two pre-existing reds, neither caused by this diff

1. `tests/smoke/test_audio_path_smoke.py::test_session_lifecycle_via_bridge_and_web_tx_lease`
   fails ("web TX start never acquired a lease on the shared session"). Verified
   to fail identically at HEAD with this diff stashed, and it uses its own local
   `_http_get_json` helper, so it cannot be affected by this change.
2. On the very first run in a cold worktree (22.9 s vs the usual 13.8 s),
   `test_info_endpoint_status` hit `TimeoutError`; 17 subsequent runs including
   the concurrent ones were green. The 5 s `wait_for` predates this change, so a
   stalled response times out on either version. Separate cold-start flake.

## Follow-ups (not in this PR)

- The same one-shot-read pattern still lives in `tests/test_dx_cluster.py:450`,
  `tests/test_serial_backend_smoke.py:165`, `tests/test_security_headers.py:61`
  and `tests/smoke/test_audio_path_smoke.py:193`. Fixing all five files at once
  would exceed the 3-file guardrail, so they are tracked separately.
- Running the Python suite regenerates
  `frontend/src/lib/state/__tests__/fixtures/empty-store-field-status.json` with
  an extra `txTarget` key, i.e. the committed golden is stale w.r.t. the backend
  projection and every full run dirties the tree. Reverted here to keep the diff
  clean; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)