### PR TITLE
test: read full HTTP response in the four remaining one-shot-read test helpers

### DIFF
--- a/tests/smoke/test_audio_path_smoke.py
+++ b/tests/smoke/test_audio_path_smoke.py
@@ -184,18 +184,47 @@ async def _close_writer(writer: asyncio.StreamWriter) -> None:
         pass
 
 
+async def _read_http_response(
+    reader: asyncio.StreamReader,
+) -> tuple[int, dict[str, str], bytes]:
+    """Read one complete HTTP response from ``reader``.
+
+    A single ``reader.read(n)`` returns whatever one TCP segment happened to
+    carry, so bodies larger than a segment (``/api/v1/runtime`` grows past one)
+    were silently truncated mid-JSON. Read the headers up to the blank line,
+    then take either ``Content-Length`` body bytes or everything until EOF
+    (callers send ``Connection: close``, and the server always sets
+    ``Content-Length``).
+    """
+    header_bytes = (await reader.readuntil(b"\r\n\r\n"))[:-4]
+    lines = header_bytes.decode("ascii", errors="replace").split("\r\n")
+    status = int(lines[0].split(" ", 2)[1])
+    headers: dict[str, str] = {}
+    for line in lines[1:]:
+        if ":" in line:
+            key, _, value = line.partition(":")
+            headers[key.strip().lower()] = value.strip()
+    raw_length = headers.get("content-length")
+    if raw_length is None:
+        body = await reader.read()  # until EOF
+    else:
+        body = await reader.readexactly(int(raw_length))
+    return status, headers, body
+
+
 async def _http_get_json(host: str, port: int, path: str) -> dict[str, Any]:
     reader, writer = await asyncio.open_connection(host, port)
     try:
         req = f"GET {path} HTTP/1.1\r\nHost: {host}:{port}\r\nConnection: close\r\n\r\n"
         writer.write(req.encode("ascii"))
         await writer.drain()
-        raw = await asyncio.wait_for(reader.read(65536), timeout=2.0)
+        status, _headers, body = await asyncio.wait_for(
+            _read_http_response(reader), timeout=2.0
+        )
     finally:
         await _close_writer(writer)
-    status = int(raw.split(b" ", 2)[1])
     assert status == 200, f"GET {path} -> {status}"
-    return json.loads(raw[raw.find(b"\r\n\r\n") + 4 :])
+    return json.loads(body)
 
 
 def _noise_pcm(num_samples: int, seed: int = 583, amplitude: int = 5000) -> bytes:

--- a/tests/test_dx_cluster.py
+++ b/tests/test_dx_cluster.py
@@ -20,6 +20,41 @@ from rigplane.web.dx_cluster import DXClusterClient, DXSpot, SpotBuffer, parse_s
 
 
 # ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _read_http_response(
+    reader: asyncio.StreamReader,
+) -> tuple[int, dict[str, str], bytes]:
+    """Read one complete HTTP response from ``reader``.
+
+    A single ``reader.read(n)`` returns whatever one TCP segment happened to
+    carry, so bodies larger than a segment were silently truncated mid-JSON.
+    Read the headers up to the blank line, then take either ``Content-Length``
+    body bytes or everything until EOF (callers send ``Connection: close``, and
+    the server always sets ``Content-Length``).
+    """
+    header_bytes = (await reader.readuntil(b"\r\n\r\n"))[:-4]
+
+    lines = header_bytes.decode("ascii", errors="replace").split("\r\n")
+    status_code = int(lines[0].split(" ", 2)[1])
+    headers: dict[str, str] = {}
+    for line in lines[1:]:
+        if ":" in line:
+            k, _, v = line.partition(":")
+            headers[k.strip().lower()] = v.strip()
+
+    raw_length = headers.get("content-length")
+    if raw_length is None:
+        body = await reader.read()  # until EOF
+    else:
+        body = await reader.readexactly(int(raw_length))
+
+    return status_code, headers, body
+
+
+# ---------------------------------------------------------------------------
 # Task 1: parse_spot
 # ---------------------------------------------------------------------------
 
@@ -447,20 +482,18 @@ class TestWebServerDXBroadcast:
         request = f"GET /api/v1/dx/spots HTTP/1.1\r\nHost: {host}:{port}\r\nConnection: close\r\n\r\n"
         writer.write(request.encode())
         await writer.drain()
-        raw = await asyncio.wait_for(reader.read(65536), timeout=5.0)
+        status, _headers, body = await asyncio.wait_for(
+            _read_http_response(reader), timeout=5.0
+        )
         writer.close()
         try:
             await writer.wait_closed()
         except Exception:
             pass
 
-        header_end = raw.find(b"\r\n\r\n")
-        status_line = raw[:header_end].decode("ascii").split("\r\n")[0]
-        body = raw[header_end + 4 :]
-
         await srv.stop()
 
-        assert "200" in status_line
+        assert status == 200
         data = json.loads(body)
         assert "spots" in data
         assert len(data["spots"]) == 1

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -47,6 +47,36 @@ def _addr(server: WebServer) -> tuple[str, int]:
     return server._server.sockets[0].getsockname()
 
 
+async def _read_http_response(
+    reader: asyncio.StreamReader,
+) -> tuple[int, dict[str, str], bytes]:
+    """Read one complete HTTP response from ``reader``.
+
+    A single ``reader.read(n)`` returns whatever one TCP segment happened to
+    carry, so bodies larger than a segment (``/api/v1/state`` is ~32 KiB) were
+    silently truncated mid-JSON. Read the headers up to the blank line, then
+    take either ``Content-Length`` body bytes or everything until EOF (callers
+    send ``Connection: close``, and the server always sets ``Content-Length``).
+    """
+    header_bytes = (await reader.readuntil(b"\r\n\r\n"))[:-4]
+
+    lines = header_bytes.decode("ascii", errors="replace").split("\r\n")
+    status_code = int(lines[0].split(" ", 2)[1])
+    headers: dict[str, str] = {}
+    for line in lines[1:]:
+        if ":" in line:
+            k, _, v = line.partition(":")
+            headers[k.strip().lower()] = v.strip()
+
+    raw_length = headers.get("content-length")
+    if raw_length is None:
+        body = await reader.read()  # until EOF
+    else:
+        body = await reader.readexactly(int(raw_length))
+
+    return status_code, headers, body
+
+
 async def _http_get(
     host: str, port: int, path: str
 ) -> tuple[int, dict[str, str], bytes]:
@@ -58,27 +88,13 @@ async def _http_get(
         )
         writer.write(request.encode())
         await writer.drain()
-        raw = await asyncio.wait_for(reader.read(65536), timeout=5.0)
+        return await asyncio.wait_for(_read_http_response(reader), timeout=5.0)
     finally:
         writer.close()
         try:
             await writer.wait_closed()
         except Exception:
             pass
-
-    header_end = raw.find(b"\r\n\r\n")
-    header_bytes = raw[:header_end]
-    body = raw[header_end + 4 :]
-
-    lines = header_bytes.decode("ascii", errors="replace").split("\r\n")
-    status_code = int(lines[0].split(" ", 2)[1])
-    headers: dict[str, str] = {}
-    for line in lines[1:]:
-        if ":" in line:
-            k, _, v = line.partition(":")
-            headers[k.strip().lower()] = v.strip()
-
-    return status_code, headers, body
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_serial_backend_smoke.py
+++ b/tests/test_serial_backend_smoke.py
@@ -154,6 +154,33 @@ async def _yield_until(predicate, timeout: float = 1.0) -> None:  # type: ignore
         await asyncio.sleep(0)
 
 
+async def _read_http_response(
+    reader: asyncio.StreamReader,
+) -> tuple[int, dict[str, str], bytes]:
+    """Read one complete HTTP response from ``reader``.
+
+    A single ``reader.read(n)`` returns whatever one TCP segment happened to
+    carry, so bodies larger than a segment (``/api/v1/state`` is ~32 KiB) were
+    silently truncated mid-JSON. Read the headers up to the blank line, then
+    take either ``Content-Length`` body bytes or everything until EOF (callers
+    send ``Connection: close``, and the server always sets ``Content-Length``).
+    """
+    header_bytes = (await reader.readuntil(b"\r\n\r\n"))[:-4]
+    lines = header_bytes.decode("ascii", errors="replace").split("\r\n")
+    status = int(lines[0].split(" ", 2)[1])
+    headers: dict[str, str] = {}
+    for line in lines[1:]:
+        if ":" in line:
+            key, _, value = line.partition(":")
+            headers[key.strip().lower()] = value.strip()
+    raw_length = headers.get("content-length")
+    if raw_length is None:
+        body = await reader.read()  # until EOF
+    else:
+        body = await reader.readexactly(int(raw_length))
+    return status, headers, body
+
+
 async def _http_get(
     host: str, port: int, path: str
 ) -> tuple[int, dict[str, str], bytes]:
@@ -162,19 +189,10 @@ async def _http_get(
         req = f"GET {path} HTTP/1.1\r\nHost: {host}:{port}\r\nConnection: close\r\n\r\n"
         writer.write(req.encode("ascii"))
         await writer.drain()
-        raw = await asyncio.wait_for(reader.read(65536), timeout=2.0)
+        return await asyncio.wait_for(_read_http_response(reader), timeout=2.0)
     finally:
         writer.close()
         await writer.wait_closed()
-    header_end = raw.find(b"\r\n\r\n")
-    header_bytes = raw[:header_end].decode("ascii", errors="replace").split("\r\n")
-    status = int(header_bytes[0].split(" ", 2)[1])
-    headers: dict[str, str] = {}
-    for line in header_bytes[1:]:
-        if ":" in line:
-            key, _, value = line.partition(":")
-            headers[key.strip().lower()] = value.strip()
-    return status, headers, raw[header_end + 4 :]
 
 
 async def _ws_connect(


### PR DESCRIPTION
## What

`tests/test_web_server.py::_http_get` was recently fixed (commit `90e05e4a`) because it did a single `await asyncio.wait_for(reader.read(65536), ...)` and treated whatever one TCP segment carried as the complete HTTP response — truncating bodies at ~32 KiB segment boundaries and flaking as `json.decoder.JSONDecodeError: Unterminated string`.

Four sibling helpers still had the same one-shot-read pattern. This PR ports the same `_read_http_response` fix to all of them:

| File | Helper | Timeout | Return shape |
|---|---|---|---|
| `tests/test_dx_cluster.py` | inline in `test_dx_spots_rest_endpoint` | 5.0s (unchanged) | inline |
| `tests/test_security_headers.py` | `_http_get` | 5.0s (unchanged) | `(status, headers, body)` (unchanged) |
| `tests/test_serial_backend_smoke.py` | `_http_get` | 2.0s (unchanged) | `(status, headers, body)` (unchanged) |
| `tests/smoke/test_audio_path_smoke.py` | `_http_get_json` | 2.0s (unchanged) | `dict[str, Any]` (unchanged) |

Read headers with `readuntil(b"\r\n\r\n")`, then `readexactly(Content-Length)` bytes, falling back to `read()` until EOF when the header is absent. `web/server.py::_send_response` always sets `Content-Length`, so `readexactly` is the normal path; the EOF fallback exists only so the helper cannot hang on a hypothetical response without it.

Test-infrastructure only — no `src/` changes. Follows the per-file private-helper shape of the `test_web_server.py` fix rather than introducing a shared test-util module.

## Why this matters

`/api/v1/state` (serial-smoke, security-headers) and `/api/v1/runtime` (audio-path smoke) are exactly the payloads that outgrow a single segment. These helpers were latent flakes, not currently-red tests.

## Verification

Beyond "the suite is still green" (which it was before the fix too), the helpers were driven against a server that deliberately dribbles a 209,601-byte JSON body in 4 KiB slices:

```
baseline: one-shot read() got 4096/209601 body bytes -> TRUNCATED
  ok  test_dx_cluster            [Content-Length]: 209601 bytes, JSON parsed
  ok  test_serial_backend_smoke  [Content-Length]: 209601 bytes, JSON parsed
  ok  test_security_headers      [Content-Length]: 209601 bytes, JSON parsed
  ok  test_audio_path_smoke      [Content-Length]: 209601 bytes, JSON parsed
  (same four again for the EOF-terminated / no-Content-Length path)
PROOF PASSED
```

The old pattern truncates this response at the first segment; every patched helper reassembles it in full on both paths.

Suite results:

- `uv run pytest tests/ -q --ignore=tests/integration` -> `1 failed, 8428 passed, 73 skipped, 5 deselected, 11 xfailed, 1 xpassed`
- `uv run ruff check tests/ src/` -> clean; `ruff format --check` -> clean

## Known pre-existing failure

`tests/smoke/test_audio_path_smoke.py::test_session_lifecycle_via_bridge_and_web_tx_lease` fails with `web TX start never acquired a lease on the shared session`. This is **not** caused by this PR: restoring the pristine file from `71d9cff3` (`git show 71d9cff3:tests/smoke/test_audio_path_smoke.py > ...`) and running that single test reproduces the identical assertion. It has been red locally since at least 2026-07-29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)