### PR TITLE
MOR-1013 Slice 1: stop TX audio even when the unkey fails

### DIFF
--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -1352,38 +1352,51 @@ class RadioPoller:
                 await radio.set_ptt(True)
             case PttOff():
                 logger.info("poller: PTT OFF")
-                await radio.set_ptt(False)
-                # Stop TX audio stream after PTT, then restart RX
-                if CAP_AUDIO in self._caps:
-                    try:
-                        stop_tx = getattr(radio, "stop_tx", None)
-                        if stop_tx is not None:
-                            # Neutral AudioTransport surface (MOR-543).
-                            await stop_tx()
-                        else:
-                            # Legacy per-codec fallback.
-                            tx_codec, _tx_sr = _audio_tx_codec_and_rate(radio)
-                            if tx_codec == AudioCodec.PCM_1CH_16BIT:
-                                await radio.stop_audio_tx_pcm()
+                # The unkey is a fire-and-forget CI-V write and can raise
+                # (connection/timeout/transport). The audio teardown below must
+                # run anyway: a failed de-key with the TX audio leg still
+                # pumping modulation into the rig is the worst outcome
+                # available (MOR-1013). ``finally`` keeps the original unkey
+                # exception intact — it propagates unwrapped so the caller's
+                # ``_mark_queued_command_failed`` classification is unchanged —
+                # while the teardown's own ``except Exception`` guarantees a
+                # failing teardown can never replace it.
+                try:
+                    await radio.set_ptt(False)
+                finally:
+                    # Stop TX audio stream after PTT, then restart RX
+                    if CAP_AUDIO in self._caps:
+                        try:
+                            stop_tx = getattr(radio, "stop_tx", None)
+                            if stop_tx is not None:
+                                # Neutral AudioTransport surface (MOR-543).
+                                await stop_tx()
                             else:
-                                await radio.stop_audio_tx_opus()
-                        logger.info("poller: TX audio stream stopped")
+                                # Legacy per-codec fallback.
+                                tx_codec, _tx_sr = _audio_tx_codec_and_rate(radio)
+                                if tx_codec == AudioCodec.PCM_1CH_16BIT:
+                                    await radio.stop_audio_tx_pcm()
+                                else:
+                                    await radio.stop_audio_tx_opus()
+                            logger.info("poller: TX audio stream stopped")
 
-                        # Re-arm RX through the AudioBus so the real
-                        # subscriber callback is reinstated rather than a
-                        # throwaway no-op clobbering the single-slot RX
-                        # callback (MOR-506). The LAN stream itself IS
-                        # full-duplex; the re-arm currently fires for every
-                        # audio_duplex_mode (including "full") until skipping
-                        # it is verified on real IC-7610 hardware — that flip
-                        # is a hardware-gated follow-up to MOR-543, one line
-                        # inside _should_restart_rx.
-                        duplex_mode = getattr(radio, "audio_duplex_mode", "half")
-                        if _should_restart_rx(duplex_mode):
-                            await radio.audio_bus.restart_rx()
-                            logger.info("poller: RX audio stream restarted")
-                    except Exception as e:
-                        logger.debug("poller: audio stream transition failed: %s", e)
+                            # Re-arm RX through the AudioBus so the real
+                            # subscriber callback is reinstated rather than a
+                            # throwaway no-op clobbering the single-slot RX
+                            # callback (MOR-506). The LAN stream itself IS
+                            # full-duplex; the re-arm currently fires for every
+                            # audio_duplex_mode (including "full") until
+                            # skipping it is verified on real IC-7610 hardware
+                            # — that flip is a hardware-gated follow-up to
+                            # MOR-543, one line inside _should_restart_rx.
+                            duplex_mode = getattr(radio, "audio_duplex_mode", "half")
+                            if _should_restart_rx(duplex_mode):
+                                await radio.audio_bus.restart_rx()
+                                logger.info("poller: RX audio stream restarted")
+                        except Exception as e:
+                            logger.debug(
+                                "poller: audio stream transition failed: %s", e
+                            )
             case SetPower(level=level, unit=unit):
                 if unit != "raw_255":
                     raise ValueError(

--- a/tests/test_web_ptt_audio_teardown.py
+++ b/tests/test_web_ptt_audio_teardown.py
@@ -1,0 +1,169 @@
+"""MOR-1013: PTT-OFF audio teardown must survive a failed unkey.
+
+Bug: ``RadioPoller._execute`` ran ``await radio.set_ptt(False)`` OUTSIDE the
+``try`` that stops the TX audio leg and re-arms RX. ``set_ptt`` is a
+fire-and-forget CI-V write that can raise (``ConnectionError``,
+``TimeoutError``, transport errors), and when it did the entire audio
+teardown was skipped: ``stop_tx()`` never ran and RX was never re-armed. That
+left the LAN TX audio leg pumping modulation into a rig whose de-key had just
+failed — the worst combination available.
+
+Acceptance (MOR-1013): "Provider-native voice TX stops even when OFF fails."
+
+The unkey failure must still reach the caller unchanged: ``_run`` classifies
+it (timeout vs connection vs generic) for ``_mark_queued_command_failed`` and
+for the queued command's future, so the original exception object — not a
+wrapper — has to propagate.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from rigplane.core.capabilities import CAP_AUDIO
+from rigplane.profiles import resolve_radio_profile
+from rigplane.web.radio_poller import CommandQueue, PttOff, RadioPoller
+
+CallRecord = list[tuple[str, tuple[Any, ...]]]
+
+
+class _UnkeyFailed(ConnectionError):
+    """Transport-style failure raised by ``set_ptt(False)``."""
+
+
+class _TeardownFailed(RuntimeError):
+    """Failure raised by the TX-audio teardown itself."""
+
+
+def _make_radio(
+    calls: CallRecord,
+    *,
+    audio: bool = True,
+    set_ptt_error: BaseException | None = None,
+    stop_tx_error: BaseException | None = None,
+) -> SimpleNamespace:
+    """Hand-written duck-typed radio recording ordered calls with arguments.
+
+    Deliberately not a ``MagicMock``: on Python 3.11 a bare mock satisfies
+    ``runtime_checkable`` protocols and would hide capability-gate bugs.
+    """
+
+    profile = resolve_radio_profile(model="IC-7610")
+
+    async def set_ptt(state: bool) -> None:
+        calls.append(("set_ptt", (state,)))
+        if set_ptt_error is not None:
+            raise set_ptt_error
+
+    async def stop_tx() -> None:
+        calls.append(("stop_tx", ()))
+        if stop_tx_error is not None:
+            raise stop_tx_error
+
+    async def restart_rx() -> None:
+        calls.append(("restart_rx", ()))
+
+    return SimpleNamespace(
+        profile=profile,
+        model=profile.model,
+        capabilities={CAP_AUDIO} if audio else set(),
+        set_ptt=set_ptt,
+        stop_tx=stop_tx,
+        audio_bus=SimpleNamespace(restart_rx=restart_rx),
+        audio_duplex_mode="half",
+    )
+
+
+def _make_poller(radio: SimpleNamespace) -> RadioPoller:
+    return RadioPoller(radio, CommandQueue())
+
+
+async def test_ptt_off_stops_tx_audio_when_unkey_raises() -> None:
+    """Failed unkey must still stop TX audio and re-arm RX (MOR-1013)."""
+    calls: CallRecord = []
+    unkey_error = _UnkeyFailed("civ write failed")
+    poller = _make_poller(_make_radio(calls, set_ptt_error=unkey_error))
+
+    with pytest.raises(_UnkeyFailed) as excinfo:
+        await poller._execute(PttOff())
+
+    # The caller's ``_mark_queued_command_failed`` bookkeeping keys off the
+    # exception type/identity — it must arrive unwrapped.
+    assert excinfo.value is unkey_error
+    assert calls == [
+        ("set_ptt", (False,)),
+        ("stop_tx", ()),
+        ("restart_rx", ()),
+    ]
+
+
+async def test_ptt_off_ordering_unchanged_when_unkey_succeeds() -> None:
+    """Happy path keeps the unkey-first ordering the PttOn arm depends on."""
+    calls: CallRecord = []
+    poller = _make_poller(_make_radio(calls))
+
+    await poller._execute(PttOff())
+
+    assert calls == [
+        ("set_ptt", (False,)),
+        ("stop_tx", ()),
+        ("restart_rx", ()),
+    ]
+
+
+async def test_ptt_off_without_audio_capability_touches_no_audio() -> None:
+    """The CAP_AUDIO gate still suppresses the teardown entirely."""
+    calls: CallRecord = []
+    poller = _make_poller(_make_radio(calls, audio=False))
+
+    await poller._execute(PttOff())
+
+    assert calls == [("set_ptt", (False,))]
+
+
+async def test_ptt_off_without_audio_capability_still_propagates_unkey() -> None:
+    """Gate-off path must not invent audio calls nor swallow the failure."""
+    calls: CallRecord = []
+    unkey_error = _UnkeyFailed("civ write failed")
+    poller = _make_poller(_make_radio(calls, audio=False, set_ptt_error=unkey_error))
+
+    with pytest.raises(_UnkeyFailed) as excinfo:
+        await poller._execute(PttOff())
+
+    assert excinfo.value is unkey_error
+    assert calls == [("set_ptt", (False,))]
+
+
+async def test_unkey_failure_wins_over_teardown_failure() -> None:
+    """A failing teardown must never mask the failed de-key."""
+    calls: CallRecord = []
+    unkey_error = _UnkeyFailed("civ write failed")
+    poller = _make_poller(
+        _make_radio(
+            calls,
+            set_ptt_error=unkey_error,
+            stop_tx_error=_TeardownFailed("stop_tx exploded"),
+        )
+    )
+
+    with pytest.raises(_UnkeyFailed) as excinfo:
+        await poller._execute(PttOff())
+
+    assert excinfo.value is unkey_error
+    # ``stop_tx`` raising short-circuits the re-arm — pre-existing behaviour.
+    assert calls == [("set_ptt", (False,)), ("stop_tx", ())]
+
+
+async def test_teardown_failure_alone_is_still_swallowed() -> None:
+    """Audio-teardown errors stay non-fatal when the unkey succeeded."""
+    calls: CallRecord = []
+    poller = _make_poller(
+        _make_radio(calls, stop_tx_error=_TeardownFailed("stop_tx exploded"))
+    )
+
+    await poller._execute(PttOff())
+
+    assert calls == [("set_ptt", (False,)), ("stop_tx", ())]


### PR DESCRIPTION
Closes #2104 · Linear [MOR-1013](https://linear.app/morozsm/issue/MOR-1013/core-route-web-tx-and-poller-recovery-through-the-shared-safety) — Slice 1 of 6.

A live safety defect in the shipped Web TX path. Independent of the managed-TX programme; it ships regardless.

## The defect

`src/rigplane/web/radio_poller.py`, `case PttOff():` — `await radio.set_ptt(False)` sat **outside** the audio-teardown block. Any raise skipped `stop_tx()` and the RX re-arm entirely, leaving the LAN TX audio leg pumping into a rig whose de-key had just failed.

## Why `try/finally` rather than catch-and-re-raise

Nothing anywhere catches this exception, so `finally` is the shape that changes least. The independent review verified that empirically rather than by reading:

- **Object identity survives** — the caught object `is` the raised object; type unchanged.
- **The traceback is undistorted** — the `_execute` frame still names the *original raise site*, not the `finally`.
- **`__context__` and `__cause__` are both `None`** — the teardown's inner `except Exception` does not pollute exception chaining.
- **No silent swallow path** — AST-verified that the `finally` contains no `return`/`break`/`continue`.
- The caller was traced by driving the real `_run` loop with a real `CommandQueueEntry` for all four exception classes: in every case `future.exception() is` the original object and `fail_command` received identical parameters, with `timed_out=True` only for `TimeoutError`.

## Cancellation behaviour, established rather than assumed

`finally` also runs the teardown when the unkey is **cancelled** — a deliberate behaviour change in the safe direction for a de-key path. The reviewer measured what actually happens:

- Cancel delivered at `await radio.set_ptt(False)`: the teardown **runs to completion** and the task still ends `cancelled() == True`. The cancellation is not swallowed. Base behaviour skipped the teardown entirely.
- The hang question is real but bounded: `LanAudioStream.stop_tx` is pure state mutation with no blocking await; `AudioBus.restart_rx` takes a lock, catches `Exception`, and its worst case is `asyncio.wait_for`-bounded. Decisively, `RadioPoller.stop()` cancels **without awaiting** the task and `stop_web_server` never awaits it either — so even a pathological teardown cannot block server shutdown.

## Structural verification

AST comparison, not eyeballing: `ast.dump(base_If) == ast.dump(new_If)` for the moved teardown block — **identical**. With the `PttOff` arm elided, the rest of the module is AST-identical to base, including `_run`. Comments are identical once whitespace-normalised.

One correction to my own commit message's spirit: it is not *literally* byte-identical apart from indentation — the deeper indent forced two cosmetic reflows (a `logger.debug` split across three lines, one comment rewrapped). Structurally and semantically identical, which is what matters.

## Evidence

**Red-before, reproduced independently** by the reviewer: base tree extracted out-of-tree via `git archive`, new tests copied in, `PYTHONPATH` forced to the base `src` → **2 failed, 4 passed**, exactly the two teardown-after-failed-unkey assertions, both missing `('stop_tx', ())` / `('restart_rx', ())`.

**Mutation: 9 mutants, 8 killed.**

| Mutant | Verdict |
|---|---|
| revert the `finally` | KILLED |
| teardown runs *before* the unkey | KILLED |
| drop the `CAP_AUDIO` gate | KILLED |
| swallow the unkey exception | KILLED |
| `finally` → `except Exception` + reraise | KILLED |
| drop the RX re-arm | KILLED |
| `set_ptt(True)` instead of `(False)` | KILLED 6/6 |
| drop the unkey entirely | KILLED 6/6 |
| inner `except Exception` → `except BaseException` | **survived** |

The survivor mutates a **pre-existing** base line, not the new logic, and is the "teardown could swallow a cancellation" edge. Worth a follow-up test; not introduced here.

**Gates, all re-run by the reviewer:** new tests 6 passed · `test_radio_poller_coverage.py` + `test_web_server.py` 308 passed / 2 skipped · `test_audio_rx_tx_transition.py` + new file 19 passed · ruff clean · `lint-imports` 5 kept / 0 broken · `mypy src/` **delta 0** against a baseline re-derived out-of-tree from `git archive`, sorted error sets diffed empty · `mypy --strict src/rigplane/web` clean · new tests also pass on **Python 3.11.13**, the interpreter `quick.yml` pins.

Tests use hand-written `SimpleNamespace` radios with real async closures appending `(name, args)` to an ordered list — no `MagicMock`, so the 3.11 `runtime_checkable` divergence is not in play. Assertions compare full ordered call lists with arguments, not counts.

## Pre-existing defect confirmed on the way, tracked separately

The reviewer confirmed the `PttOn` arm has **two** mirror-image faults, both verified by driving the real `_execute`:

1. A `start_tx()` failure is swallowed and `set_ptt(True)` keys anyway — and the queued command's future resolves **successfully**, so the UI reports PTT-ON as succeeded. The rig keys with no modulation path; the only signal is a server-side WARNING.
2. `set_ptt(True)` is itself outside any `try`, so a key that fails after `start_tx()` succeeded leaves the TX audio leg open with no `stop_tx` anywhere — `LanAudioStream` stays in `TRANSMITTING` and a later PttOn hits a swallowed `AudioAlreadyStartedError`.

Both are pre-existing and out of scope here. Tracked as **MOR-1178**, which also records that this operator symptom has now reached production through seven distinct mechanisms.

## Hardware boundary

Software evidence only; every radio in the verification is a hand-written duck-typed fake. No hardware was run and no hardware claim is made. MOR-1033 remains the same-release FTX-1 physical acceptance gate.
