### PR TITLE
MOR-1013 Slice 2: release PTT on control-session teardown regardless of MOD arming

### DIFF
--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -474,7 +474,8 @@ class ControlHandler:
         )
         self._subscribed_streams: set[str] = set()
         # MOR-624: (command_name, previous_source) armed by the frontend auto-LAN
-        # feature at TX start; MOR-993 permits teardown PTT OFF only.
+        # feature at TX start. MOR-993 forbids replaying it on teardown; MOR-1013
+        # moved the teardown PTT OFF off this state entirely.
         self._mod_input_restore: tuple[str, int] | None = None
         self._event_queue: BoundedQueue[dict[str, Any]] = BoundedQueue(
             maxsize=100,
@@ -538,7 +539,10 @@ class ControlHandler:
                 pass
             if self._server is not None:
                 self._server.unregister_control_event_queue(self._event_queue)
-            self._restore_mod_input_on_teardown()
+            # Release first: unkeying is the safe direction and must never be
+            # reachable only via MOD-input bookkeeping (MOR-1013).
+            self._release_ptt_on_teardown()
+            self._clear_mod_input_restore_on_teardown()
 
     async def _event_sender_loop(self) -> None:
         """Drain event queue and forward events to WebSocket."""
@@ -983,8 +987,9 @@ class ControlHandler:
         """Arm/disarm the transitional session teardown intent (MOR-624/MOR-993).
 
         Writable-session ``arm`` keeps the legacy payload for wire compatibility,
-        but teardown may use it only to request emergency PTT OFF. It never
-        authorizes a MOD SET. ``disarm`` clears the intent idempotently.
+        but the arm authorizes nothing: it never authorizes a MOD SET (MOR-993),
+        and since MOR-1013 the teardown PTT OFF no longer depends on it either.
+        ``disarm`` clears the intent idempotently.
         """
         if name == "disarm_mod_input_restore":
             self._mod_input_restore = None
@@ -1005,16 +1010,24 @@ class ControlHandler:
         self._mod_input_restore = (command, source)
         return {"armed": True}
 
-    def _restore_mod_input_on_teardown(self) -> None:
-        """Consume the legacy arm and request best-effort PTT OFF only (MOR-993).
+    def _release_ptt_on_teardown(self) -> None:
+        """Request best-effort PTT OFF whenever a writable session tears down.
 
-        Queue order, ACK, timeout, and cached state do not prove RF de-key. Until
-        MOR-986 supplies fresh authoritative PTT confirmation, teardown must
-        never enqueue the remembered MOD SET.
+        Unconditional by design (MOR-1013). This release used to be reachable
+        only through the MOD-input arm, so a session that keyed the radio but
+        never armed a restore disconnected with no unkey enqueued at all and
+        stranded the rig in TX. Unkeying is the safe direction, so no session
+        state may gate it — see the same rule for ``_ensure_tx_session_ready``.
+
+        Read-only sessions are excluded: ``ptt_off`` is a ``_TX_COMMANDS``
+        member they may never issue, so they cannot have keyed, and an
+        unsolicited OFF from a passive monitor would de-key another operator.
+
+        The ``_server``/``queue`` checks are structural (no transport to enqueue
+        onto), not policy. Enqueue failures are swallowed so teardown stays
+        bounded.
         """
-        armed = self._mod_input_restore
-        self._mod_input_restore = None
-        if armed is None or self._server is None:
+        if self._read_only or self._server is None:
             return
         queue = getattr(self._server, "command_queue", None)
         if queue is None:
@@ -1024,11 +1037,17 @@ class ControlHandler:
         except Exception:
             logger.debug("control: teardown PTT OFF enqueue failed", exc_info=True)
         else:
-            logger.info(
-                "control: requested PTT OFF on armed session teardown; "
-                "MOD restore suppressed pending authoritative OFF (session=%s)",
-                self._session_id,
-            )
+            logger.info("control: requested PTT OFF on control session teardown")
+
+    def _clear_mod_input_restore_on_teardown(self) -> None:
+        """Consume the legacy MOD-input arm without acting on it (MOR-993).
+
+        Queue order, ACK, timeout, and cached state do not prove RF de-key. Until
+        MOR-986 supplies fresh authoritative PTT confirmation, teardown must
+        never enqueue the remembered MOD SET. Bookkeeping only — this method
+        never touches the command queue.
+        """
+        self._mod_input_restore = None
 
     async def _enqueue_command(
         self,

--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -532,6 +532,12 @@ class ControlHandler:
         except EOFError:
             pass
         finally:
+            # Ahead of every step that can raise out of this block: on a dead
+            # socket ``await event_task`` re-raises the sender's error and
+            # unregister broadcasts, so either would skip the unkey on exactly
+            # the abrupt drops that need it most. The release needs neither.
+            self._release_ptt_on_teardown()
+            self._clear_mod_input_restore_on_teardown()
             event_task.cancel()
             try:
                 await event_task
@@ -539,10 +545,6 @@ class ControlHandler:
                 pass
             if self._server is not None:
                 self._server.unregister_control_event_queue(self._event_queue)
-            # Release first: unkeying is the safe direction and must never be
-            # reachable only via MOD-input bookkeeping (MOR-1013).
-            self._release_ptt_on_teardown()
-            self._clear_mod_input_restore_on_teardown()
 
     async def _event_sender_loop(self) -> None:
         """Drain event queue and forward events to WebSocket."""
@@ -1037,7 +1039,10 @@ class ControlHandler:
         except Exception:
             logger.debug("control: teardown PTT OFF enqueue failed", exc_info=True)
         else:
-            logger.info("control: requested PTT OFF on control session teardown")
+            logger.info(
+                "control: requested PTT OFF on control session teardown (session=%s)",
+                self._session_id,
+            )
 
     def _clear_mod_input_restore_on_teardown(self) -> None:
         """Consume the legacy MOD-input arm without acting on it (MOR-993).

--- a/tests/test_web_mod_input_restore.py
+++ b/tests/test_web_mod_input_restore.py
@@ -14,6 +14,7 @@ Two concerns share the teardown path and are deliberately kept apart:
 
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -51,6 +52,28 @@ def _teardown(handler: ControlHandler) -> None:
     """Run the teardown steps in the same order as ``run()``'s finally block."""
     handler._release_ptt_on_teardown()
     handler._clear_mod_input_restore_on_teardown()
+
+
+def _make_run_handler(*, unregister: Any = None) -> tuple[ControlHandler, CommandQueue]:
+    """Build a handler whose ``run()`` reaches teardown on the first ``recv``."""
+    command_queue = CommandQueue()
+
+    async def recv() -> tuple[int, bytes]:
+        await asyncio.sleep(0.01)  # let the event-sender task run before EOF
+        raise EOFError
+
+    return ControlHandler(
+        ws=SimpleNamespace(send_text=AsyncMock(), recv=recv),
+        radio=SimpleNamespace(connected=True, radio_ready=True),
+        server_version="test",
+        radio_model="IC-7610",
+        server=SimpleNamespace(
+            command_queue=command_queue,
+            register_control_event_queue=MagicMock(),
+            unregister_control_event_queue=unregister or MagicMock(),
+            build_state_update_envelope=MagicMock(return_value={}),
+        ),
+    ), command_queue
 
 
 def _provider_poller(error: Exception | None) -> tuple[RadioPoller, MagicMock]:
@@ -300,32 +323,35 @@ class TestTeardownPttRelease:
 
 
 class TestRunTeardownWiring:
-    """run()'s finally block must reach the release, not just the bookkeeping."""
+    """run()'s finally must reach the release before any step that can raise."""
 
     @pytest.mark.asyncio
     async def test_run_releases_ptt_on_disconnect_without_arm(self) -> None:
-        command_queue = CommandQueue()
-        server = SimpleNamespace(
-            command_queue=command_queue,
-            register_control_event_queue=MagicMock(),
-            unregister_control_event_queue=MagicMock(),
-            build_state_update_envelope=MagicMock(return_value={}),
-        )
-        ws = SimpleNamespace(
-            send_text=AsyncMock(),
-            recv=AsyncMock(side_effect=EOFError()),
-        )
-        handler = ControlHandler(
-            ws=ws,
-            radio=SimpleNamespace(connected=True, radio_ready=True),
-            server_version="test",
-            radio_model="IC-7610",
-            server=server,
-        )
-
+        handler, q = _make_run_handler()
         await handler.run()
+        assert q.drain() == [PttOff()]
 
-        assert command_queue.drain() == [PttOff()]
+    @pytest.mark.asyncio
+    async def test_release_survives_dead_egress_socket(self) -> None:
+        """A dead egress socket kills the sender; ``await event_task`` re-raises."""
+        handler, q = _make_run_handler()
+        handler._ws.send_text = AsyncMock(
+            side_effect=[None, None, ConnectionResetError("egress socket closed")]
+        )
+        handler._enqueue_rc_power("ptt_on", {}, q, handler._radio)
+        handler._event_queue.put_nowait({"type": "state_update"})
+        with pytest.raises(ConnectionResetError):
+            await handler.run()
+        assert q.drain() == [PttOn(), PttOff()]
+
+    @pytest.mark.asyncio
+    async def test_release_survives_unregister_failure(self) -> None:
+        """``unregister_control_event_queue`` broadcasts; it is not raise-free."""
+        handler, q = _make_run_handler(unregister=MagicMock(side_effect=RuntimeError))
+        handler._enqueue_rc_power("ptt_on", {}, q, handler._radio)
+        with pytest.raises(RuntimeError):
+            await handler.run()
+        assert q.drain() == [PttOn(), PttOff()]
 
 
 class TestCommandRouting:

--- a/tests/test_web_mod_input_restore.py
+++ b/tests/test_web_mod_input_restore.py
@@ -1,21 +1,28 @@
-"""Tests for backend session-teardown MOD handling (MOR-624/MOR-993).
+"""Tests for control-session teardown (MOR-624/MOR-993/MOR-1013).
 
-The frontend auto-LAN feature (MOR-618) arms a restore on the backend
-session at TX start and disarms it on a clean TX stop. If the session
-tears down while still armed, the handler enqueues PttOff only; no command
-outcome or queue ordering authorizes a previous-source MOD SET.
+Two concerns share the teardown path and are deliberately kept apart:
+
+* **PTT release** — a writable session that disconnects always requests PTT
+  OFF. Unkeying is the safe direction, so no session state may gate it
+  (MOR-1013). Read-only sessions are excluded: ``ptt_off`` is a
+  ``_TX_COMMANDS`` member they may never issue, so they cannot have keyed.
+* **MOD-input bookkeeping** — the frontend auto-LAN feature (MOR-618) arms a
+  restore at TX start and disarms it on a clean TX stop. Teardown consumes the
+  arm and discards it; no command outcome or queue ordering authorizes a
+  previous-source MOD SET (MOR-993).
 """
 
 from __future__ import annotations
 
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from rigplane.profiles import resolve_radio_profile
 from rigplane.web.handlers.control import ControlHandler
-from rigplane.web.radio_poller import CommandQueue, PttOff, RadioPoller
+from rigplane.web.radio_poller import CommandQueue, PttOff, PttOn, RadioPoller
 
 _MOD_COMMANDS = (
     "set_data_off_mod_input",
@@ -38,6 +45,12 @@ def _make_handler(*, read_only: bool = False) -> tuple[ControlHandler, CommandQu
         read_only=read_only,
     )
     return handler, command_queue
+
+
+def _teardown(handler: ControlHandler) -> None:
+    """Run the teardown steps in the same order as ``run()``'s finally block."""
+    handler._release_ptt_on_teardown()
+    handler._clear_mod_input_restore_on_teardown()
 
 
 def _provider_poller(error: Exception | None) -> tuple[RadioPoller, MagicMock]:
@@ -106,27 +119,42 @@ class TestArmDisarm:
         assert handler._apply_mod_input_restore_cmd(
             "arm_mod_input_restore", invalid
         ) == {"armed": False}
-        handler._restore_mod_input_on_teardown()
+        handler._clear_mod_input_restore_on_teardown()
         assert handler._mod_input_restore is None
+        # Bookkeeping alone never reaches the command queue.
         assert not q.has_commands
 
 
-class TestTeardownRestore:
-    """An armed teardown consumes its state and enqueues PTT OFF only."""
+class TestTeardownModRestoreInvariant:
+    """MOR-993: teardown may never replay the remembered MOD SET."""
 
     @pytest.mark.parametrize("command", _MOD_COMMANDS)
-    def test_teardown_when_armed_enqueues_one_ptt_off(self, command: str) -> None:
+    def test_teardown_when_armed_enqueues_ptt_off_and_no_mod_set(
+        self, command: str
+    ) -> None:
         handler, q = _make_handler()
         handler._apply_mod_input_restore_cmd(
             "arm_mod_input_restore",
             {"command": command, "source": 0},
         )
 
-        handler._restore_mod_input_on_teardown()
-        handler._restore_mod_input_on_teardown()
+        _teardown(handler)
 
+        # Exact list equality: a MOD SET of any kind would show up here.
         assert q.drain() == [PttOff()]
         assert handler._mod_input_restore is None
+
+    def test_clearing_bookkeeping_never_enqueues_anything(self) -> None:
+        handler, q = _make_handler()
+        handler._apply_mod_input_restore_cmd(
+            "arm_mod_input_restore",
+            {"command": "set_data2_mod_input", "source": 4},
+        )
+
+        handler._clear_mod_input_restore_on_teardown()
+
+        assert handler._mod_input_restore is None
+        assert q.drain() == []
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -147,7 +175,7 @@ class TestTeardownRestore:
             "arm_mod_input_restore",
             {"command": "set_data3_mod_input", "source": 3},
         )
-        handler._restore_mod_input_on_teardown()
+        _teardown(handler)
         commands = q.drain()
         assert commands == [PttOff()]
 
@@ -160,14 +188,24 @@ class TestTeardownRestore:
         for name in _MOD_COMMANDS:
             getattr(radio, name).assert_not_awaited()
 
-    def test_teardown_when_not_armed_enqueues_nothing(self) -> None:
+
+class TestTeardownPttRelease:
+    """MOR-1013: the teardown unkey is not gated on any session state."""
+
+    def test_teardown_when_not_armed_enqueues_ptt_off(self) -> None:
+        """Behaviour change: this used to assert that nothing was enqueued.
+
+        A session that keyed but never armed a MOD restore previously
+        disconnected with no PTT OFF at all, leaving the rig transmitting.
+        """
         handler, q = _make_handler()
 
-        handler._restore_mod_input_on_teardown()
+        _teardown(handler)
 
-        assert not q.has_commands
+        assert q.drain() == [PttOff()]
 
-    def test_teardown_after_disarm_enqueues_nothing(self) -> None:
+    def test_teardown_after_disarm_enqueues_ptt_off(self) -> None:
+        """A clean TX stop disarms; the teardown unkey must survive it."""
         handler, q = _make_handler()
         handler._apply_mod_input_restore_cmd(
             "arm_mod_input_restore",
@@ -175,9 +213,119 @@ class TestTeardownRestore:
         )
         handler._apply_mod_input_restore_cmd("disarm_mod_input_restore", {})
 
-        handler._restore_mod_input_on_teardown()
+        _teardown(handler)
 
-        assert not q.has_commands
+        assert q.drain() == [PttOff()]
+
+    def test_keyed_session_without_arm_is_released_on_teardown(self) -> None:
+        """The reported defect: key via ptt_on, never arm, then disconnect."""
+        handler, q = _make_handler()
+
+        handler._enqueue_rc_power("ptt_on", {}, q, handler._radio)
+        assert handler._mod_input_restore is None
+        _teardown(handler)
+
+        assert q.drain() == [PttOn(), PttOff()]
+
+    def test_release_is_not_suppressed_by_prior_release(self) -> None:
+        """No consume-once flag: re-entering teardown re-requests the unkey.
+
+        Idempotency state would be another gate able to swallow the release;
+        a duplicate OFF is harmless, a missing one is not.
+        """
+        handler, q = _make_handler()
+
+        _teardown(handler)
+        _teardown(handler)
+
+        assert q.drain() == [PttOff(), PttOff()]
+
+    def test_read_only_teardown_enqueues_nothing(self) -> None:
+        """A read-only session may never issue ptt_off, so it cannot have keyed.
+
+        Releasing here would de-key whoever is actually transmitting.
+        """
+        handler, q = _make_handler(read_only=True)
+
+        _teardown(handler)
+
+        assert q.drain() == []
+
+    def test_teardown_without_server_does_not_raise(self) -> None:
+        handler = ControlHandler(
+            ws=MagicMock(),
+            radio=MagicMock(),
+            server_version="test",
+            radio_model="IC-7610",
+            server=None,
+        )
+
+        _teardown(handler)
+
+        assert handler._mod_input_restore is None
+
+    def test_teardown_without_command_queue_does_not_raise(self) -> None:
+        handler = ControlHandler(
+            ws=MagicMock(),
+            radio=MagicMock(),
+            server_version="test",
+            radio_model="IC-7610",
+            server=SimpleNamespace(),
+        )
+
+        _teardown(handler)
+
+        assert handler._mod_input_restore is None
+
+    def test_teardown_survives_queue_put_failure(self) -> None:
+        """Teardown stays bounded: an enqueue failure must not escape."""
+        queue = MagicMock()
+        queue.put.side_effect = RuntimeError("queue is gone")
+        handler = ControlHandler(
+            ws=MagicMock(),
+            radio=MagicMock(),
+            server_version="test",
+            radio_model="IC-7610",
+            server=SimpleNamespace(command_queue=queue),
+        )
+        handler._apply_mod_input_restore_cmd(
+            "arm_mod_input_restore",
+            {"command": "set_data1_mod_input", "source": 1},
+        )
+
+        _teardown(handler)
+
+        queue.put.assert_called_once_with(PttOff())
+        assert handler._mod_input_restore is None
+
+
+class TestRunTeardownWiring:
+    """run()'s finally block must reach the release, not just the bookkeeping."""
+
+    @pytest.mark.asyncio
+    async def test_run_releases_ptt_on_disconnect_without_arm(self) -> None:
+        command_queue = CommandQueue()
+        server = SimpleNamespace(
+            command_queue=command_queue,
+            register_control_event_queue=MagicMock(),
+            unregister_control_event_queue=MagicMock(),
+            build_state_update_envelope=MagicMock(return_value={}),
+        )
+        ws = SimpleNamespace(
+            send_text=AsyncMock(),
+            recv=AsyncMock(side_effect=EOFError()),
+        )
+        handler = ControlHandler(
+            ws=ws,
+            radio=SimpleNamespace(connected=True, radio_ready=True),
+            server_version="test",
+            radio_model="IC-7610",
+            server=server,
+        )
+
+        await handler.run()
+
+        assert command_queue.drain() == [PttOff()]
 
 
 class TestCommandRouting:
@@ -198,7 +346,7 @@ class TestCommandRouting:
 
         assert handler._mod_input_restore == ("set_data2_mod_input", 3)
         handler._ws.send_text.assert_awaited_once()
-        sent = handler._ws.send_text.await_args.args[0]
+        sent: Any = handler._ws.send_text.await_args.args[0]
         assert '"ok":true' in sent and '"armed":true' in sent
 
     @pytest.mark.asyncio
@@ -213,9 +361,9 @@ class TestCommandRouting:
                 "id": "x",
             }
         )
-        handler._restore_mod_input_on_teardown()
+        _teardown(handler)
 
         assert handler._mod_input_restore is None
         assert not q.has_commands
-        sent = handler._ws.send_text.await_args.args[0]
+        sent: Any = handler._ws.send_text.await_args.args[0]
         assert '"ok":true' in sent and '"armed":false' in sent


### PR DESCRIPTION
Closes #2106 · Linear [MOR-1013](https://linear.app/morozsm/issue/MOR-1013/core-route-web-tx-and-poller-recovery-through-the-shared-safety) — Slice 2 of 6.

## The defect, and it is larger than the ticket text suggested

The teardown PTT OFF was gated on the MOD-input restore having been armed, so a session that keyed the radio but never armed disconnected with the rig still transmitting.

The independent review then established something the ticket did not know: **the shipped frontend never arms it at all.** `frontend/src/lib/runtime/adapters/mod-input-auto.svelte.ts` keeps the MOD transaction memory-only and never sends `arm_mod_input_restore` — the only frontend references are three negative assertions in its own tests. So `_mod_input_restore` was **always `None`** in production and the old teardown enqueued `PttOff` **never, in any session**.

Unkey-on-disconnect has never actually worked. This slice turns it on for the first time.

## The change

2 files, **+167 net LOC** (`control.py` +19 net). The entangled function is split into two single-job methods, both called from `run()`'s `finally`, **release first** so the safety action does not sit behind bookkeeping:

- `_release_ptt_on_teardown()` — enqueues `PttOff()` with no dependency on `armed`; the `_server is None` / `queue is None` guards and the exception-swallowing `queue.put` are preserved.
- `_clear_mod_input_restore_on_teardown()` — pure bookkeeping, never touches the queue.

Ordering and failure isolation were tested rather than read: release genuinely precedes bookkeeping; a bookkeeping failure cannot prevent the release (the queue already holds `PttOff()` when it raises); a release failure cannot prevent bookkeeping.

## The one judgement call, surfaced deliberately

The release is gated on `not self._read_only`. That was not in the brief — removing the `armed` gate makes the read-only path newly reachable, so a decision had to be made, and it is recorded here rather than buried.

The review verified every link by enumeration rather than trust:

- **A read-only session provably cannot have keyed.** Both `PttOn()` producers sit behind two independent read-only gates, and all five construction routes (WS, WebRTC, HTTP `/commands`, `/batch`, the shared `CommandService` executor) converge on the same guarded path. Empirically: `ptt`, `ptt_on`, `send_civ`, `send_cw_text` all raise `PermissionError` on a read-only handler.
- **`self._read_only` is trustworthy here**, unlike `self._session_id`. `WebConfig.read_only` has **zero assignments anywhere in the codebase** — immutable for the process lifetime — and every construction site passes it explicitly.
- The reviewer also found a **stronger justification than the one I gave**: the gate's soundness does not rest on `read_only` being a server-wide config, but on the per-instance invariant *"`self._read_only is True` ⇒ this handler rejected every `_TX_COMMANDS` call it ever saw"*, which holds even for a read-only handler on a writable server.

The gate is also categorically different from the `armed` gate it replaces: `armed` suppressed the release on sessions that **could** have keyed; `read_only` suppresses it only on sessions that provably **could not**.

## A real risk this slice introduces, demonstrated end-to-end

The `command_queue` is process-wide and session-agnostic. With two writable handlers on one server and a real `RadioPoller`, the reviewer showed:

```
session A keys (ptt_on), session B (never keyed, never armed) tears down
  shared queue   = [PttOn(), PttOff()]
  radio.set_ptt  = [call(True), call(False)]      <-- B de-keyed A
read-only B teardown -> queue = [PttOn()]         <-- the gate holds the line
```

A second writable session closing — a backgrounded phone tab, a reload, a WS timeout on a flaky link — now drops another session's in-progress transmission.

Accepted for this slice, deliberately: stuck TX after a disconnect is strictly worse than a dropped over (unattended continuous transmission, regulatory exposure, PA/ATU thermal risk); the codebase already carries this policy explicitly at `control.py:666` — *"PTT OFF intentionally bypasses this gate — unkeying is the safe direction and must always be attempted"*; and Core has no TX-ownership concept at all today, so concurrent writable sessions keying one rig is already unarbitrated.

Tracked as its own follow-up. The fix is session-scoped PTT accounting, which is MOR-986 territory and cannot fit a 2-file slice.

Bounding the blast radius: the throwaway `_control_handler_for` handlers never `await run()` — only two `run()` call sites exist — so HTTP commands do **not** each emit a teardown `PttOff`. Only real WS/WebRTC control sessions do.

## MOR-993 stays pinned

Teardown must never enqueue the remembered MOD SET. The pinning tests are not decorative: a mutation that replays the MOD SET from the bookkeeping half **kills 10 tests**, including all four parametrised `..._enqueues_ptt_off_and_no_mod_set` cases. The exact-list-equality assertions (`q.drain() == [PttOff()]`) are what make that work.

## Inverted tests

Two tests previously asserted `not q.has_commands` — they **pinned the defect itself**. Both were inverted, not deleted, and carry docstrings naming the behaviour change. Nothing was lost: the replacements use exact list equality, which is strictly stronger than the old negative assertion, and six tests were added.

## Evidence

**Red-before**, reproduced independently out-of-tree with only `control.py` reverted: the rename-independent behavioural proof is the wiring test driving the real `run()` on old code → `assert [] == [PttOff()]`. Empty queue after a full session lifecycle.

**Mutation: 8 mutants, 7 killed** — old `armed` gate re-inserted, `read_only` guard dropped, `queue.put` failure aborting teardown, MOD-SET replay, consume-once flag, release unwired from `run()`. The one survivor (bookkeeping before release) is behaviourally unobservable in shipped code because bookkeeping is a bare assignment that cannot raise; the ordering is a correct defensive choice that is not test-pinned.

**Gates, all re-run by the reviewer:** 28 passed (was 20) · `test_web_ptt_readonly.py` + `test_handlers_coverage.py` 167 passed · **all 15 remaining `ControlHandler` test files: 572 passed, 3 skipped** · the other `PttOff` consumers 127 passed · ruff clean · `lint-imports` 5 kept / 0 broken · `mypy --strict src/rigplane/web` clean · `mypy src/` **delta 0** against a baseline re-derived from `git archive origin/main`, sorted error lists identical.

## Vestigial state confirmed, not fixed

`_mod_input_restore` now has **five writers and zero production readers** — only tests read it. Combined with the frontend never arming, the `arm_mod_input_restore`/`disarm_mod_input_restore` wire pair is dead on **both** sides: a wire-compatibility shim with no live producer and no live consumer. Removal belongs after the MOR-986 authoritative-PTT work.

## Hardware boundary

Software evidence only, from source analysis, in-process probes with mocked radios, and the test suite. No hardware was run and no hardware claim is made. MOR-1033 remains the same-release FTX-1 physical acceptance gate.
