### PR TITLE
MOR-1170: route CLI PTT ingress through the managed TX facade

### DIFF
--- a/src/rigplane/cli/__init__.py
+++ b/src/rigplane/cli/__init__.py
@@ -36,6 +36,7 @@ import sys
 from collections.abc import Sequence
 from pathlib import Path
 import time
+import uuid
 import wave
 from typing import Any
 
@@ -98,11 +99,20 @@ from rigplane.cli._convert import (  # noqa: E402
     add_subparser as _add_convert_subparser,
     run as _run_convert,
 )
-from rigplane.core.radio_protocol import Radio  # noqa: E402
+from rigplane.core.radio_protocol import ManagedTxApi, Radio  # noqa: E402
+from rigplane.core.tx_safety import TxOutcome, TxOwner, TxSource  # noqa: E402
 from rigplane.core.types import Mode, get_audio_capabilities  # noqa: E402
 
 _AUDIO_FRAME_MS = 20
 _PCM_SAMPLE_WIDTH_BYTES = 2
+
+# One TX identity for the whole CLI process (MOR-1170): the supervisor matches
+# a release against the owner that took the lease, so a per-request owner would
+# miss its own lease and could strand the rig keyed. One `rigplane` invocation
+# is one TX session, hence minted here and not in the handler. `TxSource` has
+# no CLI member; the CLI is an in-process consumer of the public SDK surface.
+_CLI_TX_OWNER = TxOwner(TxSource.SDK, f"cli-{uuid.uuid4().hex}")
+_TX_KEY_ACCEPTED = frozenset({TxOutcome.ACCEPTED, TxOutcome.IDEMPOTENT})
 
 
 def _get_env(name: str, default: str = "") -> str:
@@ -2718,8 +2728,35 @@ async def _cmd_meter(radio: Radio, args: argparse.Namespace) -> int:
 
 
 async def _cmd_ptt(radio: Radio, args: argparse.Namespace) -> int:
+    """Key or unkey the radio, through the managed supervisor when there is one.
+
+    Radios without a managed runtime keep the legacy direct provider write; the
+    supervisor reports refusal by return value, so both directions inspect it.
+    """
     on = args.state == "on"
-    await radio.set_ptt(on)
+    managed = ManagedTxApi.bind(radio, _CLI_TX_OWNER)
+    if managed is None:
+        await radio.set_ptt(on)
+    else:
+        transition = await managed.set_ptt(on)
+        if transition.outcome not in _TX_KEY_ACCEPTED:
+            if on:
+                # Printing "PTT ON" here would tell the operator the rig is
+                # transmitting when the supervisor refused the key.
+                print(
+                    f"Error: managed TX refused PTT on ({transition.outcome}).",
+                    file=sys.stderr,
+                )
+                return 1
+            # A refused release answers STALE, which means either nothing was
+            # keyed or another owner holds the lease. Neither is actionable
+            # here — a non-owner cannot force a release by design — so report
+            # it and still succeed, rather than failing a defensive unkey.
+            print(
+                f"Warning: managed TX released no lease for this session "
+                f"({transition.outcome}); another session may still hold TX.",
+                file=sys.stderr,
+            )
     print(f"PTT {'ON' if on else 'OFF'}")
     return 0
 

--- a/tests/test_cli_async.py
+++ b/tests/test_cli_async.py
@@ -24,7 +24,17 @@ from rigplane.cli import (
     _run,
     main,
 )
+from rigplane.core.radio_protocol import ManagedTxApi, ManagedTxCapable
+from rigplane.core.tx_safety import (
+    TxOutcome,
+    TxOwner,
+    TxReleaseReason,
+    TxSafetySupervisor,
+    TxSource,
+    TxTransition,
+)
 from rigplane.exceptions import TimeoutError as IcomTimeout
+from rigplane.runtime.radio import IcomRadio as RuntimeIcomRadio
 
 
 # ---------------------------------------------------------------------------
@@ -126,6 +136,11 @@ def mock_radio():
     radio.start_audio_tx_pcm = AsyncMock()
     radio.stop_audio_tx_pcm = AsyncMock()
     radio.push_audio_tx_pcm = AsyncMock()
+    # Unmanaged on purpose: no backend assembles a managed TX runtime yet
+    # (MOR-1016). Left unset, an AsyncMock auto-satisfies ``ManagedTxCapable``
+    # on 3.11 and not on 3.12+ (gh-102433), which would make every PTT test in
+    # this file interpreter dependent — and the PR gate runs 3.11.
+    radio.managed_tx = None
     _add_capability_protocols(radio)
     return radio
 
@@ -491,6 +506,154 @@ class TestCmdPtt:
         assert rc == 0
         mock_radio.set_ptt.assert_called_once_with(False)
         assert "OFF" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# _cmd_ptt — managed TX ingress (MOR-1170)
+# ---------------------------------------------------------------------------
+
+_IDLE_TX_SNAPSHOT = TxSafetySupervisor().snapshot
+_ACCEPTED = TxOutcome.ACCEPTED
+# Every answer ``request_on`` can give when the caller did *not* get the rig.
+_TX_KEY_REJECTIONS = (
+    TxOutcome.BUSY,
+    TxOutcome.NOT_READY,
+    TxOutcome.RADIO_NOT_OFF,
+    TxOutcome.RELEASE_PENDING,
+    TxOutcome.STALE,
+)
+
+
+class _FakeTxSupervisor:
+    """Hand written: a MagicMock satisfies ManagedTxCapable on 3.11, not 3.12+."""
+
+    def __init__(self, on: TxOutcome, off: TxOutcome) -> None:
+        self._on, self._off = on, off
+        self.calls: list[tuple[bool, TxOwner, TxReleaseReason | None]] = []
+
+    async def request_on(self, owner: TxOwner) -> TxTransition:
+        self.calls.append((True, owner, None))
+        return TxTransition(self._on, _IDLE_TX_SNAPSHOT)
+
+    async def release_owner(
+        self, owner: TxOwner, *, reason: TxReleaseReason
+    ) -> TxTransition:
+        self.calls.append((False, owner, reason))
+        return TxTransition(self._off, _IDLE_TX_SNAPSHOT)
+
+
+class _FakeManagedRadio:
+    """Radio whose bare ``set_ptt`` the managed ingress must never reach."""
+
+    def __init__(self, on: TxOutcome = _ACCEPTED, off: TxOutcome = _ACCEPTED) -> None:
+        self.bare_writes: list[bool] = []
+        self.supervisor = _FakeTxSupervisor(on, off)
+        self.managed_tx = self.supervisor
+
+    async def set_ptt(self, on: bool) -> None:
+        self.bare_writes.append(on)
+
+
+def _kinds(sup: _FakeTxSupervisor) -> list[tuple[bool, TxReleaseReason | None]]:
+    return [(keyed, reason) for keyed, _owner, reason in sup.calls]
+
+
+class TestCmdPttManagedIngress:
+    @pytest.mark.asyncio
+    async def test_shipped_radio_keeps_the_legacy_direct_write(self, capsys) -> None:
+        # No backend assembles a managed runtime yet (MOR-1016): the radio the
+        # CLI ships must reach its own ``set_ptt``, with today's codes and lines.
+        shipped = RuntimeIcomRadio("127.0.0.1")
+        writes: list[bool] = []
+
+        async def _record(on: bool) -> None:
+            writes.append(on)
+
+        assert not isinstance(shipped, ManagedTxCapable)
+        assert ManagedTxApi.bind(shipped, TxOwner(TxSource.SDK, "probe")) is None
+        shipped.set_ptt = _record
+
+        assert await _cmd_ptt(shipped, Namespace(state="on")) == 0
+        assert await _cmd_ptt(shipped, Namespace(state="off")) == 0
+
+        assert writes == [True, False]
+        captured = capsys.readouterr()
+        assert captured.out.splitlines() == ["PTT ON", "PTT OFF"]
+        assert captured.err == ""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("outcome", [TxOutcome.ACCEPTED, TxOutcome.IDEMPOTENT])
+    async def test_managed_ingress_enters_the_supervisor_exactly_once(
+        self, outcome: TxOutcome, capsys
+    ) -> None:
+        # IDEMPOTENT means this owner already holds the lease, so the request
+        # did land — it is an accepting outcome, not a rejection.
+        radio = _FakeManagedRadio(on=outcome, off=outcome)
+
+        assert await _cmd_ptt(radio, Namespace(state="on")) == 0
+        assert await _cmd_ptt(radio, Namespace(state="off")) == 0
+
+        assert _kinds(radio.supervisor) == [
+            (True, None),
+            (False, TxReleaseReason.OPERATOR_RELEASE),
+        ]
+        assert radio.bare_writes == []  # no bypass: the effect path writes
+        captured = capsys.readouterr()
+        assert captured.out.splitlines() == ["PTT ON", "PTT OFF"]
+        assert captured.err == ""
+
+    @pytest.mark.asyncio
+    async def test_tx_owner_is_one_stable_identity_per_process(self) -> None:
+        first, second = _FakeManagedRadio(), _FakeManagedRadio()
+
+        await _cmd_ptt(first, Namespace(state="on"))
+        await _cmd_ptt(first, Namespace(state="off"))
+        await _cmd_ptt(second, Namespace(state="on"))
+
+        calls = first.supervisor.calls + second.supervisor.calls
+        owners = [owner for _keyed, owner, _reason in calls]
+        assert len(owners) == 3
+        # ``release_owner`` matches on the owner alone, so a per-request (or
+        # per-radio) owner would miss its own lease and could strand the rig
+        # keyed until the watchdog fires.
+        assert all(owner is owners[0] for owner in owners)
+        assert owners[0].source is TxSource.SDK
+        assert owners[0].session_id
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("outcome", _TX_KEY_REJECTIONS)
+    async def test_a_key_the_supervisor_refused_exits_non_zero(
+        self, outcome: TxOutcome, capsys
+    ) -> None:
+        # The supervisor reports refusal by return value, not by raising: a
+        # caller that ignores it prints a cheerful "PTT ON" and exits 0 while
+        # the rig is not transmitting on its behalf.
+        radio = _FakeManagedRadio(on=outcome)
+
+        rc = await _cmd_ptt(radio, Namespace(state="on"))
+
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert "Error" in captured.err and str(outcome) in captured.err
+        assert _kinds(radio.supervisor) == [(True, None)]
+        assert radio.bare_writes == []
+
+    @pytest.mark.asyncio
+    async def test_a_release_the_supervisor_refused_succeeds(self, capsys) -> None:
+        # STALE covers both "nothing was keyed" and "another owner holds it".
+        # A non-owner cannot force a release by design, so the unkey is best
+        # effort: it reports, but it must not fail the command.
+        radio = _FakeManagedRadio(off=TxOutcome.STALE)
+
+        rc = await _cmd_ptt(radio, Namespace(state="off"))
+
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert captured.out.splitlines() == ["PTT OFF"]
+        assert str(TxOutcome.STALE) in captured.err
+        assert _kinds(radio.supervisor) == [(False, TxReleaseReason.OPERATOR_RELEASE)]
+        assert radio.bare_writes == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli_async.py
+++ b/tests/test_cli_async.py
@@ -635,7 +635,7 @@ class TestCmdPttManagedIngress:
         assert rc == 1
         captured = capsys.readouterr()
         assert captured.out == ""
-        assert "Error" in captured.err and str(outcome) in captured.err
+        assert "Error" in captured.err and f"({outcome})" in captured.err
         assert _kinds(radio.supervisor) == [(True, None)]
         assert radio.bare_writes == []
 
@@ -651,7 +651,7 @@ class TestCmdPttManagedIngress:
         assert rc == 0
         captured = capsys.readouterr()
         assert captured.out.splitlines() == ["PTT OFF"]
-        assert str(TxOutcome.STALE) in captured.err
+        assert f"({TxOutcome.STALE})" in captured.err
         assert _kinds(radio.supervisor) == [(False, TxReleaseReason.OPERATOR_RELEASE)]
         assert radio.bare_writes == []
 

--- a/tests/test_cli_async.py
+++ b/tests/test_cli_async.py
@@ -651,7 +651,7 @@ class TestCmdPttManagedIngress:
         assert rc == 0
         captured = capsys.readouterr()
         assert captured.out.splitlines() == ["PTT OFF"]
-        assert f"({TxOutcome.STALE})" in captured.err
+        assert "Warning" in captured.err and f"({TxOutcome.STALE})" in captured.err
         assert _kinds(radio.supervisor) == [(False, TxReleaseReason.OPERATOR_RELEASE)]
         assert radio.bare_writes == []
 


### PR DESCRIPTION
Closes #2108 · Linear [MOR-1170](https://linear.app/morozsm/issue/MOR-1170/core-route-cli-ptt-ingress-through-the-managed-tx-facade)

Routes the CLI `ptt` subcommand through the `ManagedTxApi` facade. 2 files, **exactly 200 net LOC** against a hard 200.

## Why this ingress existed unowned

MOR-1009 covered SDK/sync, MOR-1013 covers Web, MOR-1014 covers rigctld. MOR-1009's acceptance grep was scoped to "Web, rigctld, bridge, and sync ingress", so `_cmd_ptt` fell through every net. `grep set_ptt src/rigplane/cli/` returns 2 hits, both inside it, so this closes the CLI completely.

## The operator-visible half

`_cmd_ptt` returned `0` unconditionally and printed `PTT ON`. Under a managed runtime a refused key would have told the operator the rig is transmitting when it is not.

- **Refused key** → nothing on stdout, `Error: managed TX refused PTT on (tx_busy).` on stderr, exit **1**. `TxOutcome` is a `StrEnum`, so the operator sees `tx_busy`, not `TxOutcome.BUSY`. All five rejection outcomes covered.
- **Refused release** → `PTT OFF`, exit **0**, plus a stderr warning. A non-owner cannot force a release by design, so failing the command would be wrong — but silence there is misleading.

Verified end to end that rc 1 reaches the shell: `_run` → `exit_code = loop.run_until_complete(...)` → `os._exit(exit_code)`. Message conventions match the file's existing 83 `return 1` sites and its `Warning:` stderr idiom rather than inventing new ones.

## Owner identity for a one-shot process

`_CLI_TX_OWNER` is minted **once at module scope** — one process is one TX session. Reviewer checks: not in `__all__`; import cost is one `uuid4()` and a frozen dataclass, so the `aiohttp` lazy-import regression test still passes; a re-import returns the same owner object, and only `importlib.reload()` mints a new one, which nothing in `tests/` does. Proven that the same owner reaches the supervisor across three calls spanning **two different radios** in one process.

`TxSource` has no `CLI` member and adding one would touch `core/tx_safety.py`, a third file. `TxSource.SDK` is used, and the reviewer confirmed three ways that nothing branches on `owner.source`: `inspect.getsource(TxSafetySupervisor)` contains zero occurrences of `.source`; `owner.source` appears nowhere in `src/rigplane/`; and `TxOwner` is a frozen slots dataclass, so `source` participates in `__eq__`/`__hash__` and is only ever compared as part of a whole `TxOwner`. `runtime/sync.py:160` already uses `TxSource.SDK` for the in-process wrapper, so this is precedent rather than invention. A dedicated `TxSource.CLI` is a clean follow-up.

## Dormancy

`bind()` returning `None` leaves `await radio.set_ptt(on)` byte-identical. Proven against the **real shipped** `rigplane.runtime.radio.IcomRadio`, not a mock — asserting `not isinstance(shipped, ManagedTxCapable)`, `bind(...) is None`, `writes == [True, False]`, `stdout == ["PTT ON", "PTT OFF"]`, `stderr == ""`. Independently confirmed no radio class defines `managed_tx`: `grep 'def managed_tx' src/` matches only the Protocol declaration.

## The 3.11 trap, hit and fixed mid-slice

`quick.yml` pins `UV_PYTHON: "3.11"`, where a bare Mock auto-satisfies a `runtime_checkable` Protocol (gh-102433 — 3.11 uses `hasattr`, 3.12+ uses `getattr_static`). The pre-existing `mock_radio` fixture went red **on 3.11 only** once `bind()` was wired; fixed with `radio.managed_tx = None`.

The reviewer reproduced this by deleting that line in an out-of-tree copy: on 3.11 the tests fail with `Error: managed TX refused PTT on (<AsyncMock name='mock.managed_tx.request_on().outcome'>)` — the mock auto-satisfied the protocol and the CLI routed into a phantom supervisor. On 3.12 all pass. The fix is test-side and makes the mock faithfully represent a shipped, unmanaged radio.

## Evidence

**LOC computed two ways** — `--numstat` sum and a `-U0 | awk` classification — both **202 added / 2 deleted = 200**. The reviewer flagged the trap: `grep -c '^+[^+]'` returns 168 because 34 added lines are blank and appear as a bare `+`; a verifier trusting that grep would have reported 198 and passed the budget on a wrong number.

**Trim integrity.** An earlier revision measured 203 and three lines were reclaimed from prose only. AST-diff of base versus current: **no test function removed, no parametrization changed**, 36 → 46 collected, 27 assertions across the 5 new tests. The reviewer disclosed an honest limitation — no artifact of the 203-line version exists, so it could not diff 203→200 textually, and established integrity behaviourally via the mutation table instead.

**Mutation: 10 mutants, 10 dead, zero survivors.** Dropping the ON-path `return 1`; swallowing the outcome entirely; minting the owner per call; `bind()` always returning a facade; removing the dormant fallback; wrong release reason; printing `PTT ON` on refusal; warning to stdout instead of stderr; dropping `IDEMPOTENT` from the accepted set; managed path also performing the bare write.

**Gates, all re-run by the reviewer in its own isolated envs:** `tests/test_cli_async.py` 46 passed on **3.11.13** and **3.12.11**; 14 CLI/managed-TX/tx-safety/sync modules **436 passed** on both; ruff clean; `lint-imports` 5 kept / 0 broken; `mypy src/` baseline re-derived out-of-tree with **identical** full output, 0 errors in `cli/`.

## Findings filed, not fixed here

The CLI builds a fresh radio — and therefore a fresh supervisor — per invocation. Once MOR-1016 attaches real runtimes, `rigplane ptt on` in one process takes a lease that dies with it, and a later `rigplane ptt off` presents a different owner to a supervisor holding no lease → `STALE` → **no `WRITE_OFF` is emitted at all**. Verified against the real supervisor. Tracked as **MOR-1182**, blocked by **MOR-1175**.

The open product question — may `rigplane ptt on` leave the rig keyed after exit? — is deliberately **not** answered here and no auto-unkey-on-exit is implemented. The only change is that the OFF path now says so on stderr instead of printing a bare, misleading `PTT OFF`.

## Hardware boundary

Software evidence only; the shipped-radio dormancy test constructs `IcomRadio("127.0.0.1")` without connecting. No hardware was run and no hardware claim is made. MOR-1033 remains the same-release FTX-1 physical acceptance gate.
