### PR TITLE
test(#2108): state the unmanaged provider explicitly in web test doubles

### DIFF
--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -129,11 +129,10 @@ def _make_radio(active: str = "MAIN") -> MagicMock:
     radio.capabilities = set(profile.capabilities)
     radio._radio_state = SimpleNamespace(active=active)
     # No managed TX runtime: this double stands in for an unmanaged provider,
-    # so the legacy ``set_ptt`` path stays in charge. ``None`` is the one value
-    # that reads unmanaged on every interpreter; a bare Mock does not, because
-    # runtime-checkable protocols use hasattr on 3.11 and getattr_static on
-    # 3.12+ (gh-102433). Full note: the ``mock_radio`` fixture in
-    # tests/test_web_server.py.
+    # so the legacy ``set_ptt`` path stays in charge. ``None`` reads unmanaged
+    # on every interpreter; a bare Mock does not, because runtime-checkable
+    # protocols use hasattr on 3.11 and getattr_static on 3.12+ (gh-102433).
+    # Full note: the ``mock_radio`` fixture in tests/test_web_server.py.
     radio.managed_tx = None
     radio.send_civ = AsyncMock()
     radio.set_freq = AsyncMock()

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -128,6 +128,13 @@ def _make_radio(active: str = "MAIN") -> MagicMock:
     radio.model = profile.model
     radio.capabilities = set(profile.capabilities)
     radio._radio_state = SimpleNamespace(active=active)
+    # No managed TX runtime: this double stands in for an unmanaged provider,
+    # so the legacy ``set_ptt`` path stays in charge. ``None`` is the one value
+    # that reads unmanaged on every interpreter; a bare Mock does not, because
+    # runtime-checkable protocols use hasattr on 3.11 and getattr_static on
+    # 3.12+ (gh-102433). Full note: the ``mock_radio`` fixture in
+    # tests/test_web_server.py.
+    radio.managed_tx = None
     radio.send_civ = AsyncMock()
     radio.set_freq = AsyncMock()
     radio.set_mode = AsyncMock()

--- a/tests/test_web_mod_input_restore.py
+++ b/tests/test_web_mod_input_restore.py
@@ -80,6 +80,12 @@ def _provider_poller(error: Exception | None) -> tuple[RadioPoller, MagicMock]:
     radio = MagicMock()
     radio.profile = resolve_radio_profile(model="IC-7610")
     radio.capabilities = set(radio.profile.capabilities) - {"audio"}
+    # No managed TX runtime: the teardown unkey under test is the legacy
+    # ``set_ptt`` write. ``None`` is the one value that reads unmanaged on
+    # every interpreter; a bare Mock does not, because runtime-checkable
+    # protocols use hasattr on 3.11 and getattr_static on 3.12+ (gh-102433).
+    # Full note: the ``mock_radio`` fixture in tests/test_web_server.py.
+    radio.managed_tx = None
     radio.set_ptt = AsyncMock(side_effect=error)
     for name in _MOD_COMMANDS:
         setattr(radio, name, AsyncMock())

--- a/tests/test_web_mod_input_restore.py
+++ b/tests/test_web_mod_input_restore.py
@@ -81,9 +81,9 @@ def _provider_poller(error: Exception | None) -> tuple[RadioPoller, MagicMock]:
     radio.profile = resolve_radio_profile(model="IC-7610")
     radio.capabilities = set(radio.profile.capabilities) - {"audio"}
     # No managed TX runtime: the teardown unkey under test is the legacy
-    # ``set_ptt`` write. ``None`` is the one value that reads unmanaged on
-    # every interpreter; a bare Mock does not, because runtime-checkable
-    # protocols use hasattr on 3.11 and getattr_static on 3.12+ (gh-102433).
+    # ``set_ptt`` write. ``None`` reads unmanaged on every interpreter; a bare
+    # Mock does not, because runtime-checkable protocols use hasattr on 3.11
+    # and getattr_static on 3.12+ (gh-102433).
     # Full note: the ``mock_radio`` fixture in tests/test_web_server.py.
     radio.managed_tx = None
     radio.set_ptt = AsyncMock(side_effect=error)

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -362,6 +362,16 @@ def mock_radio() -> MagicMock:
     }
     _add_scope_capable_attrs(radio)
     _del_poller_factory_attrs(radio)
+    # No managed TX runtime: this fixture drives the poller's legacy
+    # ``set_ptt`` for every PTT a control session issues — the explicit
+    # ``test_command_ptt`` key and, far more often, the teardown unkey. Stated
+    # explicitly because a bare Mock satisfies the runtime-checkable
+    # ``ManagedTxCapable`` on 3.11 (hasattr) but not on 3.12+ (getattr_static,
+    # gh-102433), and the per-PR gate pins 3.11 while dev runs newer. ``None``
+    # still passes isinstance on both — ``managed_tx`` is a non-callable
+    # protocol member — but ``ManagedTxApi.bind`` then returns ``None`` on
+    # both, and bind, not a bare isinstance, is the gate managed ingress uses.
+    radio.managed_tx = None
     radio.get_freq = AsyncMock(return_value=14_074_000)
     radio.get_mode = AsyncMock(return_value=MagicMock(name="USB"))
     radio.get_mode.return_value.name = "USB"
@@ -2836,6 +2846,11 @@ class TestRadioPoller:
         radio.model = profile.model
         radio.capabilities = set(profile.capabilities)
         radio._radio_state = SimpleNamespace(active="MAIN")
+        # No managed TX runtime — same reason as the ``mock_radio`` fixture
+        # above. No test in this class keys through a poller yet, but
+        # ``set_ptt`` is wired below: an unmanaged provider states this whether
+        # or not a test happens to key today.
+        radio.managed_tx = None
         mode_mock = MagicMock()
         mode_mock.name = "USB"
         radio.get_freq = AsyncMock(return_value=14074000)
@@ -3025,6 +3040,11 @@ class TestSwitchScopeReceiver:
         radio.model = profile.model
         radio.capabilities = set(profile.capabilities)
         radio._radio_state = SimpleNamespace(active="MAIN")
+        # No managed TX runtime — same reason as the ``mock_radio`` fixture
+        # above. No test in this class keys through a poller yet, but
+        # ``set_ptt`` is wired below: an unmanaged provider states this whether
+        # or not a test happens to key today.
+        radio.managed_tx = None
         radio.send_civ = AsyncMock()
         radio.state_cache = StateCache()
         radio.enable_scope = AsyncMock()


### PR DESCRIPTION
Preparation slice for the Web TX ingress (MOR-1013 Slice 4). Tests only — `git diff -- src/` is 0 bytes.

## Problem

Five radio doubles that feed `RadioPoller` leave `managed_tx` unset. A bare `MagicMock` answers any attribute, so a `runtime_checkable` protocol check against them is interpreter dependent — 3.11 uses `hasattr` and says yes, 3.12+ uses `inspect.getattr_static` and says no ([gh-102433](https://github.com/python/cpython/issues/102433)).

`quick.yml` pins `UV_PYTHON: "3.11"`, the permissive interpreter. So when managed ingress reaches this path, the divergence lands as **green on the PR gate and red on a developer machine** — the worst direction for discovery cost. This session hit it twice with two independent agents.

## Change

`managed_tx = None` in every factory that wires `set_ptt`:

| site | file |
|---|---|
| A | `tests/test_radio_poller_coverage.py::_make_radio` |
| C | `tests/test_web_mod_input_restore.py::_provider_poller` |
| D | `tests/test_web_server.py::TestRadioPoller::_make_radio` |
| E | `tests/test_web_server.py::TestSwitchScopeReceiver::_make_radio` |
| F | `tests/test_web_server.py::mock_radio` |

(`_healthy_radio` delegates to A and needs no line of its own — it wires no `set_ptt` itself.)

`None` is the one value that reads unmanaged on both interpreters. `isinstance` still returns `True` — `managed_tx` is a non-callable protocol member, so neither version's None-blocking branch applies — but `ManagedTxApi.bind()` returns `None`, and bind is the gate managed ingress uses.

## Evidence

Independent verifier probed `ManagedTxApi.bind()` against all six doubles on both interpreters, base vs head:

- base: 6/6 BOUND on 3.11, 6/6 UNMANAGED on 3.13 → **divergent**
- head: 6/6 UNMANAGED on both → **converged**

Controls: a bare `MagicMock()` still diverges (the mechanism is real); a genuinely absent attribute fails `isinstance` on both (the divergence is Mock-specific, not attribute-absence in general).

Gates, both 3.11.13 and 3.13.5: **338 passed, 2 skipped** — identical to base. `ruff check` and `ruff format --check` clean. The slice is behaviourally inert today, as a preparation slice should be.

## Note for the reviewer

The verifier passed and then measured the comment prose: 33 lines for 5 statements, with a byte-identical 398-char tail triplicated and the volatile CI fact (`the gate pins 3.11`) restated three times with nothing linking the copies. I applied their recommended compression myself after their PASS — sites A and C now carry a short self-contained note plus a pointer, and the full mechanism lives once at F, which is the load-bearing site (17 of 23 binds). I also corrected one clause they flagged as imprecise: "bind is the branch production takes" was not yet literally true of these doubles, since the poller still calls `radio.set_ptt()` directly; it now reads "bind, not a bare isinstance, is the gate managed ingress uses."

Comment text only — the five statement lines are byte-identical to what was verified, and gates were re-run after the edit. Please review the compressed comments as unverified authorship.

Linear: MOR-1013 (Slice 3 of 6)