### PR TITLE
MOR-1013 Slice 4: give Web control sessions a managed TX owner identity

### DIFF
--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -86,8 +86,10 @@ from ..core.state_pipeline_contracts import (
     Observation,
     SourceMetadata,
 )
+from ..core.radio_protocol import ManagedTxApi
 from ..core.state_diagnostics import StateDiagnosticsRecorder
 from ..core.state_store import StateStore
+from ..core.tx_safety import TxOutcome, TxOwner, TxSource
 from .._state_queries import build_state_queries
 from ..profiles import RadioProfile, resolve_radio_profile
 from ..types import AudioCodec
@@ -184,6 +186,8 @@ _DEFAULT_POLL_FIELD_TTL: float = 0.2
 _FAST_INTERVAL: float = 0.025  # meters — wfview queue interval for LAN (25ms)
 _FAST_INTERVAL_SERIAL: float = 0.100  # serial: 10 polls/sec for responsive meters
 _SLOW_INTERVAL: float = 0.25  # levels/settings — rarely change
+
+_KEY_ACCEPTED = frozenset({TxOutcome.ACCEPTED, TxOutcome.IDEMPOTENT})  # lease is ours
 
 # MOR-874: how long a healthy-link in-flight acquisition request may stay
 # suppressed after its FIRST send-relative deadline expiry before being
@@ -1168,6 +1172,54 @@ class RadioPoller:
         self._scope_demand_generation = generation
         return False
 
+    def _managed_tx(
+        self, source: CommandSource, session_id: str | None
+    ) -> ManagedTxApi | None:
+        """Bind this control session's managed TX facade; ``None`` if unmanaged.
+
+        Only a websocket session has a STABLE owner identity: its long-lived
+        ``ControlHandler._session_id``, not the throwaway the shared executor
+        mints per request, which owner-matched ``release_owner`` would miss —
+        stranding the rig keyed. Every other ingress (HTTP params may even
+        carry a ``session_id``) has no teardown hook: its lease is unreleasable.
+        """
+        if source != "websocket" or not session_id:
+            return None
+        return ManagedTxApi.bind(self._radio, TxOwner(TxSource.WEBSOCKET, session_id))
+
+    async def _stop_tx_audio_leg(self) -> None:
+        """Stop the TX audio stream and re-arm RX; never raises."""
+        radio = self._radio
+        if CAP_AUDIO not in self._caps:
+            return
+        try:
+            stop_tx = getattr(radio, "stop_tx", None)
+            if stop_tx is not None:
+                # Neutral AudioTransport surface (MOR-543).
+                await stop_tx()
+            else:
+                # Legacy per-codec fallback.
+                tx_codec, _tx_sr = _audio_tx_codec_and_rate(radio)
+                if tx_codec == AudioCodec.PCM_1CH_16BIT:
+                    await radio.stop_audio_tx_pcm()
+                else:
+                    await radio.stop_audio_tx_opus()
+            logger.info("poller: TX audio stream stopped")
+
+            # Re-arm RX through the AudioBus so the real subscriber callback is
+            # reinstated rather than a throwaway no-op clobbering the
+            # single-slot RX callback (MOR-506). The LAN stream itself IS
+            # full-duplex; the re-arm currently fires for every
+            # audio_duplex_mode (including "full") until skipping it is
+            # verified on real IC-7610 hardware — that flip is a hardware-gated
+            # follow-up to MOR-543, one line inside _should_restart_rx.
+            duplex_mode = getattr(radio, "audio_duplex_mode", "half")
+            if _should_restart_rx(duplex_mode):
+                await radio.audio_bus.restart_rx()
+                logger.info("poller: RX audio stream restarted")
+        except Exception as e:
+            logger.debug("poller: audio stream transition failed: %s", e)
+
     async def _execute(
         self,
         cmd: Command,
@@ -1322,6 +1374,7 @@ class RadioPoller:
                     )
             case PttOn():
                 logger.info("poller: PTT ON")
+                managed = self._managed_tx(command_source, session_id)
                 # Start TX audio stream before PTT (LAN audio requires this)
                 if CAP_AUDIO in self._caps:
                     try:
@@ -1349,9 +1402,22 @@ class RadioPoller:
                             )
                     except Exception as e:
                         logger.warning("poller: start TX audio failed: %s", e)
-                await radio.set_ptt(True)
+                if managed is None:
+                    await radio.set_ptt(True)
+                else:
+                    transition = await managed.set_ptt(True)
+                    if transition.outcome not in _KEY_ACCEPTED:
+                        # The TX audio leg above is armed but the rig is not
+                        # ours: disarm it, or modulation keeps flowing towards
+                        # a rig nobody keyed. Reported, never swallowed — the
+                        # operator must not believe they are on the air.
+                        await self._stop_tx_audio_leg()
+                        raise CommandError(
+                            f"managed TX rejected PTT ON: {transition.outcome}"
+                        )
             case PttOff():
                 logger.info("poller: PTT OFF")
+                managed = self._managed_tx(command_source, session_id)
                 # The unkey is a fire-and-forget CI-V write and can raise
                 # (connection/timeout/transport). The audio teardown below must
                 # run anyway: a failed de-key with the TX audio leg still
@@ -1362,41 +1428,15 @@ class RadioPoller:
                 # while the teardown's own ``except Exception`` guarantees a
                 # failing teardown can never replace it.
                 try:
-                    await radio.set_ptt(False)
+                    if managed is None:
+                        await radio.set_ptt(False)
+                    else:
+                        # A refused release answers STALE: nothing was keyed, or
+                        # another owner holds the lease. Neither is actionable,
+                        # and raising would break defensive unkeys in ``finally``.
+                        await managed.set_ptt(False)
                 finally:
-                    # Stop TX audio stream after PTT, then restart RX
-                    if CAP_AUDIO in self._caps:
-                        try:
-                            stop_tx = getattr(radio, "stop_tx", None)
-                            if stop_tx is not None:
-                                # Neutral AudioTransport surface (MOR-543).
-                                await stop_tx()
-                            else:
-                                # Legacy per-codec fallback.
-                                tx_codec, _tx_sr = _audio_tx_codec_and_rate(radio)
-                                if tx_codec == AudioCodec.PCM_1CH_16BIT:
-                                    await radio.stop_audio_tx_pcm()
-                                else:
-                                    await radio.stop_audio_tx_opus()
-                            logger.info("poller: TX audio stream stopped")
-
-                            # Re-arm RX through the AudioBus so the real
-                            # subscriber callback is reinstated rather than a
-                            # throwaway no-op clobbering the single-slot RX
-                            # callback (MOR-506). The LAN stream itself IS
-                            # full-duplex; the re-arm currently fires for every
-                            # audio_duplex_mode (including "full") until
-                            # skipping it is verified on real IC-7610 hardware
-                            # — that flip is a hardware-gated follow-up to
-                            # MOR-543, one line inside _should_restart_rx.
-                            duplex_mode = getattr(radio, "audio_duplex_mode", "half")
-                            if _should_restart_rx(duplex_mode):
-                                await radio.audio_bus.restart_rx()
-                                logger.info("poller: RX audio stream restarted")
-                        except Exception as e:
-                            logger.debug(
-                                "poller: audio stream transition failed: %s", e
-                            )
+                    await self._stop_tx_audio_leg()
             case SetPower(level=level, unit=unit):
                 if unit != "raw_255":
                     raise ValueError(

--- a/tests/test_web_managed_tx_owner.py
+++ b/tests/test_web_managed_tx_owner.py
@@ -1,0 +1,158 @@
+"""MOR-1013 slice 4: managed owner identity on the Web TX path.
+
+The poller keys on behalf of the control session (D1-a), so the owner must be
+the STABLE session id on the queue entry — not the throwaway
+``ControlHandler._session_id`` the shared command executor mints per request:
+``release_owner`` matches on the owner alone, so a mismatch strands the rig
+keyed. A real ``TxSafetySupervisor`` drives these tests because a scripted
+fake would answer ACCEPTED to any owner and could never show that.
+"""
+
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from rigplane.core.capabilities import CAP_AUDIO
+from rigplane.core.exceptions import CommandError
+from rigplane.core.radio_protocol import ManagedTxApi
+from rigplane.core.tx_safety import (
+    ProviderPttObservation,
+    RadioTx,
+    TxOutcome,
+    TxOwner,
+    TxReleaseReason,
+    TxSafetySupervisor,
+    TxSource,
+    TxTransition,
+)
+from rigplane.profiles import resolve_radio_profile
+from rigplane.web.radio_poller import CommandQueue, PttOff, PttOn, RadioPoller
+
+_KEY, _TEARDOWN = ["start_tx", "set_ptt(True)"], ["stop_tx", "restart_rx"]
+_WS1, _WS2 = TxOwner(TxSource.WEBSOCKET, "ws-1"), TxOwner(TxSource.WEBSOCKET, "ws-2")
+
+
+class _Supervisor:
+    """Async ``ManagedTxSupervisor`` over the real single-target policy."""
+
+    def __init__(self) -> None:
+        self.inner = TxSafetySupervisor(watchdog_seconds=None)
+        self.inner.replace_provider(0, ready=True)
+        self.inner.observe_ptt(
+            ProviderPttObservation(RadioTx.OFF, 0, 1, time.monotonic())
+        )
+        self.entries: list[tuple[bool, TxOwner]] = []
+        self.outcomes: list[TxOutcome] = []
+
+    def _record(self, on: bool, owner: TxOwner, t: TxTransition) -> TxTransition:
+        self.entries.append((on, owner))
+        self.outcomes.append(t.outcome)
+        return t
+
+    async def request_on(self, owner: TxOwner) -> TxTransition:
+        return self._record(True, owner, self.inner.request_on(owner))
+
+    async def release_owner(
+        self, owner: TxOwner, *, reason: TxReleaseReason
+    ) -> TxTransition:
+        released = self.inner.release_owner(owner, reason=reason)
+        return self._record(False, owner, released)
+
+
+class _Radio:
+    """Duck-typed provider; deliberately not a ``MagicMock``, which satisfies
+    a ``runtime_checkable`` protocol on 3.11 but not on 3.12+ (gh-102433)."""
+
+    def __init__(self, supervisor: _Supervisor | None) -> None:
+        self.profile = resolve_radio_profile(model="IC-7610")
+        self.capabilities = {CAP_AUDIO}
+        self.managed_tx = supervisor
+        self.calls: list[str] = []
+        self.audio_bus = SimpleNamespace(restart_rx=self._restart_rx)
+
+    async def set_ptt(self, on: bool) -> None:
+        self.calls.append(f"set_ptt({on})")
+
+    async def start_tx(self) -> None:
+        self.calls.append("start_tx")
+
+    async def stop_tx(self) -> None:
+        self.calls.append("stop_tx")
+
+    async def _restart_rx(self) -> None:
+        self.calls.append("restart_rx")
+
+
+def _poller(supervisor: _Supervisor | None) -> tuple[RadioPoller, _Radio]:
+    radio = _Radio(supervisor)
+    return RadioPoller(radio, CommandQueue()), radio  # type: ignore[arg-type]
+
+
+async def test_unmanaged_radio_keeps_the_legacy_write_and_ordering() -> None:
+    """Every shipped radio binds to ``None`` and keeps today's behaviour."""
+    poller, radio = _poller(None)
+
+    assert ManagedTxApi.bind(radio, _WS1) is None
+    await poller._execute(PttOn(), command_id="c1", session_id="ws-1")
+    await poller._execute(PttOff(), command_id="c2", session_id="ws-1")
+
+    # start_tx strictly before the key; teardown after the unkey.
+    assert radio.calls == [*_KEY, "set_ptt(False)", *_TEARDOWN]
+
+
+async def test_key_and_release_share_one_stable_owner() -> None:
+    """A real supervisor accepts the release only if the owner matches."""
+    supervisor = _Supervisor()
+    poller, radio = _poller(supervisor)
+
+    await poller._execute(PttOn(), command_id="c1", session_id="ws-1")
+    await poller._execute(PttOff(), command_id="c2", session_id="ws-1")
+
+    assert supervisor.entries == [(True, _WS1), (False, _WS1)]
+    # STALE would mean the release missed its own lease.
+    assert supervisor.outcomes == [TxOutcome.ACCEPTED, TxOutcome.ACCEPTED]
+    # No bypass: the supervisor's own effect path owns the provider write.
+    assert radio.calls == ["start_tx", *_TEARDOWN]
+
+
+async def test_a_second_session_gets_its_own_owner_and_is_refused() -> None:
+    """Two sessions, two owners — and a refused key disarms the TX leg."""
+    supervisor = _Supervisor()
+    poller, radio = _poller(supervisor)
+
+    await poller._execute(PttOn(), command_id="c1", session_id="ws-1")
+    with pytest.raises(CommandError, match=TxOutcome.BUSY):
+        await poller._execute(PttOn(), command_id="c2", session_id="ws-2")
+
+    assert supervisor.entries == [(True, _WS1), (True, _WS2)]
+    assert supervisor.outcomes == [TxOutcome.ACCEPTED, TxOutcome.BUSY]
+    # Refusal must not leave modulation flowing towards a rig nobody keyed.
+    assert radio.calls == ["start_tx", "start_tx", *_TEARDOWN]
+
+
+async def test_a_refused_release_is_tolerated_and_still_tears_down() -> None:
+    """STALE means nothing of ours is keyed; raising would break ``finally``."""
+    supervisor = _Supervisor()
+    poller, radio = _poller(supervisor)
+
+    await poller._execute(PttOff(), command_id="c1", session_id="ws-1")
+
+    assert supervisor.outcomes == [TxOutcome.STALE]
+    assert radio.calls == _TEARDOWN
+
+
+async def test_http_ingress_never_binds_an_owner() -> None:
+    """HTTP has no session and no teardown hook, so a lease taken there could
+    never be released — and its params are caller-supplied, not a session."""
+    supervisor = _Supervisor()
+    poller, radio = _poller(supervisor)
+
+    await poller._execute(PttOn(), source="http", session_id=None)
+    await poller._execute(PttOn(), source="http", session_id="forged")
+    await poller._execute(PttOff(), source="http", session_id=None)
+
+    assert supervisor.entries == []
+    assert radio.calls == [*_KEY, *_KEY, "set_ptt(False)", *_TEARDOWN]


### PR DESCRIPTION
Fourth of six slices on MOR-1013. 2 files, **198 net LOC** against a 200 ceiling.

## What it does

The Web poller wrote PTT through the bare provider, so the TX safety supervisor never learned a control session had asked for TX — no lease, no owner identity, no watchdog. SDK ([#2099](https://github.com/rigplane/rigplane-core/pull/2099)) and CLI ([#2109](https://github.com/rigplane/rigplane-core/pull/2109)) ingress already route through `ManagedTxApi`; Web did not.

`RadioPoller._managed_tx(source, session_id)` binds the facade with `TxOwner(TxSource.WEBSOCKET, session_id)`, returning `None` unless the source is `"websocket"` **and** the session id is truthy. `PttOn`/`PttOff` use the facade when bound and the legacy `radio.set_ptt` write when not.

## The two things that make this non-obvious

**1. The stable session id is on the queue entry, not on `self`.** The shared `CommandService` executor builds a throwaway `ControlHandler` per command, each with its own fresh `_session_id`. Only `params["session_id"]` survives to `entry.session_id`. `release_owner` matches on the owner alone, so a per-request owner keys under one identity and releases under another — the stuck-transmitter mode.

The verifier drove this through the real executor, handler, service and queue, stubbing only `WebServer`:

```
live handler _session_id     : STABLE-SESSION-42
throwaway handler ids minted : ['websocket-193089150317250']
queue entry .session_id      : 'STABLE-SESSION-42'   ← the stable one
```

**2. The gate is on source *and* session id, not session id alone.** `command_service.py` only overwrites `params["session_id"]` when it is not `None`, and the HTTP handler passes the client's `params` through unfiltered. Measured:

```
source=http  handler_passed=None  ->  queue entry .session_id: 'CLIENT-FORGED'
```

So a `session_id`-only gate would let `POST /api/v1/commands {"name":"ptt_on","params":{"session_id":"x"}}` mint `TxOwner(WEBSOCKET,"x")` and take a lease no teardown can release. HTTP has no teardown hook, so it stays on the legacy path.

## Behaviour

- **Refused key** disarms the TX audio leg, then raises `CommandError` — modulation must not keep flowing towards a rig nobody keyed. Verified end-to-end: the error reaches `CommandService.fail_command`, and the state store's optimistic `global.tx_state.ptt` overlay is cleared, so nothing claims the operator is on the air.
- **Refused release** does not raise. `STALE` means nothing of ours is keyed; raising would break defensive unkeys in a `finally`.
- **`_stop_tx_audio_leg`** is the existing `PttOff` teardown body extracted so the refusal branch can reuse it. AST of the moved `try` body and the comment word-sequence both proved **identical** to base; only indentation and line wrapping changed.

## Dormancy

No backend defines `managed_tx` — AST scan of 289 files found the name only on the Protocol itself, no `self.managed_tx =` assignment anywhere in `src/`, and no class-level `__getattr__`. 13 concrete backends measured: `bind()` → `None`. Every shipped radio keeps the legacy write, with `start_tx` still strictly before the key and the teardown still in the `finally`.

## Evidence

Independent verification at max effort on the exact content (both files sha256-pinned, unchanged by the review).

**16 mutations, 14 killed** — including a per-request owner (the stuck-transmitter mode), the refusal raising before disarming, `start_tx` moved after the key, and the teardown losing its RX re-arm. The two survivors are coverage gaps with correct implementations, filed as [MOR-1187](https://linear.app/rigplane/issue/MOR-1187).

| gate | 3.11.13 | 3.13.5 |
|---|---|---|
| `pytest tests/ --ignore=tests/integration` | 8512 passed | 8512 passed |
| same, at base | 8507 passed | — |
| `ruff check` / `format --check` | clean | clean |
| `lint-imports` | 5 kept, 0 broken | 5 kept, 0 broken |
| `mypy src/` | 15 errors, `diff` vs base empty | same |

Head − base = +5, exactly the five new tests; no existing test changed status.

## Known follow-ups, both blocking MOR-1016

- **[MOR-1185](https://linear.app/rigplane/issue/MOR-1185)** — the control-session teardown unkey goes onto the raw queue and carries no session id, so after MOR-1016 a disconnecting session de-keys the rig but never releases its lease. This slice neither creates nor fixes it, and the `not session_id` guard bounds the blast radius: the teardown degrades to the legacy de-key rather than raising `ValueError` from `TxOwner` and losing the de-key *and* the teardown.
- **[MOR-1187](https://linear.app/rigplane/issue/MOR-1187)** — `_managed_tx()` sits outside the `PttOff` `try/finally`, so a backend with a *raising* `managed_tx` accessor would lose the audio teardown. Unreachable today; the one-line fix plus its regression test plus the two coverage tests is ~25 LOC and does not fit this slice's remaining 2.

## Hardware boundary

Software only. No hardware was run and no hardware claim is made. MOR-1033 remains the FTX-1 physical acceptance gate.

Linear: MOR-1013 (Slice 4 of 6)