### PR TITLE
MOR-1013 Slice 5: refuse a PTT key enqueued by a control session that is gone

### DIFF
--- a/src/rigplane/runtime/_poller_types.py
+++ b/src/rigplane/runtime/_poller_types.py
@@ -1001,6 +1001,30 @@ class CommandQueue:
         self._segments: list[_CommandQueueSegment] = []
         self._notify: asyncio.Event = asyncio.Event()
         self._scope_demand_generation = 0
+        # MOR-1013: ids of the control sessions currently connected. An entry
+        # outlives its author, and the poller keys on behalf of a session it
+        # cannot otherwise see (decision D1-a), so the queue that carries the
+        # entry from ingress to drain carries the liveness record too.
+        # ``None`` until the first registration: a queue no session ever
+        # registered on knows nothing and must not answer "gone" for ids it was
+        # never told about. Once any session registers the set is authoritative
+        # even when empty — that is the every-session-gone case, not ignorance.
+        self._live_sessions: set[str] | None = None
+
+    def register_session(self, session_id: str) -> None:
+        """Mark a control session live for as long as it stays connected."""
+        if self._live_sessions is None:
+            self._live_sessions = set()
+        self._live_sessions.add(session_id)
+
+    def unregister_session(self, session_id: str) -> None:
+        """Mark a control session gone; must run on every teardown path."""
+        if self._live_sessions is not None:
+            self._live_sessions.discard(session_id)
+
+    def session_is_live(self, session_id: str) -> bool:
+        """Whether ``session_id`` still has a connected control session."""
+        return self._live_sessions is None or session_id in self._live_sessions
 
     def _record_scope_demand(self, cmd: Command) -> None:
         if isinstance(cmd, (EnableScope, DisableScope)):

--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -23,6 +23,7 @@ from ..protocol import (  # noqa: TID251
     encode_json,
 )
 from ..radio_poller import (  # noqa: TID251
+    CommandQueue,
     PttOff,
     PttOn,
     ScanSetDfSpan,
@@ -525,6 +526,10 @@ class ControlHandler:
                 logger.debug("control: failed to send initial state", exc_info=True)
         event_task: asyncio.Task[None] = asyncio.create_task(self._event_sender_loop())
         try:
+            # Inside the try, so the finally below owns every exit from here on;
+            # ahead of the recv loop, so no command of ours can be enqueued
+            # before the poller can see who enqueued it.
+            self._publish_session_liveness(live=True)
             while True:
                 opcode, payload = await self._ws.recv()
                 if opcode == WS_OP_TEXT:
@@ -537,6 +542,7 @@ class ControlHandler:
             # unregister broadcasts, so either would skip the unkey on exactly
             # the abrupt drops that need it most. The release needs neither.
             self._release_ptt_on_teardown()
+            self._publish_session_liveness(live=False)
             self._clear_mod_input_restore_on_teardown()
             event_task.cancel()
             try:
@@ -1043,6 +1049,25 @@ class ControlHandler:
                 "control: requested PTT OFF on control session teardown (session=%s)",
                 self._session_id,
             )
+
+    def _publish_session_liveness(self, *, live: bool) -> None:
+        """Publish this session's liveness on the queue the poller drains.
+
+        The poller keys on behalf of a session it cannot see (MOR-1013 D1-a), so
+        the command queue — the one object both ends already hold — carries the
+        record. Teardown calls this from the top of ``run()``'s finally, beside
+        the PTT release and ahead of ``await event_task``: a dead egress socket
+        re-raises there, and a session left marked live is a session that can
+        still key. Structural check only (a server with no real queue has no
+        poller to gate), and raise-free, so it can never displace the unkey.
+        """
+        queue = getattr(self._server, "command_queue", None)
+        if not isinstance(queue, CommandQueue):
+            return
+        if live:
+            queue.register_session(self._session_id)
+        else:
+            queue.unregister_session(self._session_id)
 
     def _clear_mod_input_restore_on_teardown(self) -> None:
         """Consume the legacy MOD-input arm without acting on it (MOR-993).

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -1187,6 +1187,27 @@ class RadioPoller:
             return None
         return ManagedTxApi.bind(self._radio, TxOwner(TxSource.WEBSOCKET, session_id))
 
+    def _refuse_key_from_gone_session(
+        self, source: CommandSource, session_id: str | None
+    ) -> None:
+        """Reject a key enqueued by a control session that is already gone.
+
+        The entry outlives its author: a session can enqueue PTT ON and drop
+        before this drain, and the supervisor grants a lease to any owner, alive
+        or dead. Gated on the same pair as ``_managed_tx`` — only a websocket
+        session publishes liveness, and ``session_id is None`` (HTTP PTT, and
+        the teardown unkey) carries none to check, so it passes through. ON
+        only: an unkey refused for being late would strand the rig keyed.
+
+        This narrows the window; it does not close it. A session can still die
+        between this check and the write it guards.
+        """
+        if source != "websocket" or not session_id:
+            return
+        if self._queue.session_is_live(session_id):
+            return
+        raise CommandError(f"control session {session_id} is gone: PTT ON refused")
+
     async def _stop_tx_audio_leg(self) -> None:
         """Stop the TX audio stream and re-arm RX; never raises."""
         radio = self._radio
@@ -1373,6 +1394,9 @@ class RadioPoller:
                         "filter_shape_changed", {"shape": shape, "receiver": rx}
                     )
             case PttOn():
+                # Before the log line, the TX audio leg, and the lease: a
+                # refused key must leave no trace on the air or in the rig.
+                self._refuse_key_from_gone_session(command_source, session_id)
                 logger.info("poller: PTT ON")
                 managed = self._managed_tx(command_source, session_id)
                 # Start TX audio stream before PTT (LAN audio requires this)

--- a/tests/test_web_managed_tx_owner.py
+++ b/tests/test_web_managed_tx_owner.py
@@ -1,4 +1,4 @@
-"""MOR-1013 slice 4: managed owner identity on the Web TX path.
+"""MOR-1013 slices 4 and 5: owner identity and liveness on the Web TX path.
 
 The poller keys on behalf of the control session (D1-a), so the owner must be
 the STABLE session id on the queue entry — not the throwaway
@@ -6,12 +6,21 @@ the STABLE session id on the queue entry — not the throwaway
 ``release_owner`` matches on the owner alone, so a mismatch strands the rig
 keyed. A real ``TxSafetySupervisor`` drives these tests because a scripted
 fake would answer ACCEPTED to any owner and could never show that.
+
+Slice 5 adds the other half of that identity: the queue entry outlives its
+author, and the supervisor grants a lease to any owner, alive or dead. The
+queue carries the liveness record because it is the one object both ends
+already hold — the handler registers on connect and unregisters on every
+teardown path, and the poller refuses a key on behalf of a session gone by
+drain time. ON only: an unkey refused for being late strands the rig keyed.
 """
 
 from __future__ import annotations
 
+import asyncio
 import time
 from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -29,6 +38,7 @@ from rigplane.core.tx_safety import (
     TxTransition,
 )
 from rigplane.profiles import resolve_radio_profile
+from rigplane.web.handlers.control import ControlHandler
 from rigplane.web.radio_poller import CommandQueue, PttOff, PttOn, RadioPoller
 
 _KEY, _TEARDOWN = ["start_tx", "set_ptt(True)"], ["stop_tx", "restart_rx"]
@@ -89,6 +99,28 @@ class _Radio:
 def _poller(supervisor: _Supervisor | None) -> tuple[RadioPoller, _Radio]:
     radio = _Radio(supervisor)
     return RadioPoller(radio, CommandQueue()), radio  # type: ignore[arg-type]
+
+
+def _run_handler() -> tuple[ControlHandler, CommandQueue]:
+    """A handler whose ``run()`` reaches teardown on the first ``recv``."""
+    queue = CommandQueue()
+
+    async def recv() -> tuple[int, bytes]:
+        await asyncio.sleep(0.01)  # let the event-sender task run before EOF
+        raise EOFError
+
+    return ControlHandler(
+        ws=SimpleNamespace(send_text=AsyncMock(), recv=recv),
+        radio=SimpleNamespace(connected=True, radio_ready=True),
+        server_version="test",
+        radio_model="IC-7610",
+        server=SimpleNamespace(
+            command_queue=queue,
+            register_control_event_queue=MagicMock(),
+            unregister_control_event_queue=MagicMock(),
+            build_state_update_envelope=MagicMock(return_value={}),
+        ),
+    ), queue
 
 
 async def test_unmanaged_radio_keeps_the_legacy_write_and_ordering() -> None:
@@ -156,3 +188,103 @@ async def test_http_ingress_never_binds_an_owner() -> None:
 
     assert supervisor.entries == []
     assert radio.calls == [*_KEY, *_KEY, "set_ptt(False)", *_TEARDOWN]
+
+
+async def test_a_key_from_a_gone_session_costs_nothing() -> None:
+    """Slice 5: the queue entry outlives its author; the key must not."""
+    supervisor = _Supervisor()
+    poller, radio = _poller(supervisor)
+    poller._queue.register_session("ws-1")
+    poller._queue.unregister_session("ws-1")
+
+    with pytest.raises(CommandError, match="ws-1"):
+        await poller._execute(PttOn(), command_id="c1", session_id="ws-1")
+
+    # Refused ahead of the TX audio leg and ahead of the lease. Raising is the
+    # poller's failure channel (``_mark_queued_command_failed`` plus
+    # ``future.set_exception``), so a refusal can never be read as success.
+    assert supervisor.entries == []
+    assert radio.calls == []
+
+
+async def test_a_live_session_keys_exactly_as_it_does_today() -> None:
+    """The gate is invisible to the session that is actually connected."""
+    supervisor = _Supervisor()
+    poller, radio = _poller(supervisor)
+    poller._queue.register_session("ws-1")
+
+    await poller._execute(PttOn(), command_id="c1", session_id="ws-1")
+    await poller._execute(PttOff(), command_id="c2", session_id="ws-1")
+
+    assert supervisor.entries == [(True, _WS1), (False, _WS1)]
+    assert supervisor.outcomes == [TxOutcome.ACCEPTED, TxOutcome.ACCEPTED]
+    assert radio.calls == ["start_tx", *_TEARDOWN]
+
+
+async def test_a_queue_no_session_registered_on_assumes_nobody_is_gone() -> None:
+    """No registration means no knowledge — not 'every session is dead'."""
+    poller, radio = _poller(None)
+
+    await poller._execute(PttOn(), command_id="c1", session_id="ws-1")
+
+    assert poller._queue.session_is_live("ws-1")
+    assert radio.calls == _KEY
+
+
+async def test_a_command_with_no_session_id_keys_and_unkeys() -> None:
+    """HTTP PTT and the teardown unkey (MOR-1185) carry no session at all, so
+    they have no liveness to check even once the queue is tracking sessions.
+    Both source arms matter: the teardown unkey goes onto the RAW queue, and
+    the drain defaults a sourceless entry to ``source="websocket"``."""
+    poller, radio = _poller(None)
+    poller._queue.register_session("ws-1")
+    poller._queue.unregister_session("ws-1")
+
+    await poller._execute(PttOn(), source="http", session_id=None)
+    await poller._execute(PttOn(), session_id=None)
+    await poller._execute(PttOff(), session_id=None)
+
+    assert radio.calls == [*_KEY, *_KEY, "set_ptt(False)", *_TEARDOWN]
+
+
+async def test_a_gone_session_may_still_unkey() -> None:
+    """Gating OFF would strand the rig keyed — the opposite of the point."""
+    poller, radio = _poller(None)
+    poller._queue.register_session("ws-1")
+    poller._queue.unregister_session("ws-1")
+
+    await poller._execute(PttOff(), command_id="c1", session_id="ws-1")
+
+    assert radio.calls == ["set_ptt(False)", *_TEARDOWN]
+
+
+async def test_a_session_is_registered_for_the_whole_of_its_run() -> None:
+    """Published before the recv loop can accept a single command of its own."""
+    handler, queue = _run_handler()
+    seen: list[bool] = []
+
+    async def recv() -> tuple[int, bytes]:
+        seen.append(queue.session_is_live(handler._session_id))
+        raise EOFError
+
+    handler._ws.recv = recv
+    await handler.run()
+
+    assert seen == [True]
+    assert not queue.session_is_live(handler._session_id)
+
+
+async def test_teardown_marks_the_session_gone_through_a_dead_egress_socket() -> None:
+    """``await event_task`` re-raises here and skips everything behind it — the
+    trap slice 2 moved the PTT release out of. A session left marked live is a
+    session that can still key."""
+    handler, queue = _run_handler()
+    handler._ws.send_text = AsyncMock(
+        side_effect=[None, None, ConnectionResetError("egress socket closed")]
+    )
+    handler._event_queue.put_nowait({"type": "state_update"})
+
+    with pytest.raises(ConnectionResetError):
+        await handler.run()
+
+    assert not queue.session_is_live(handler._session_id)


### PR DESCRIPTION
Fifth of six slices on MOR-1013. Owns the acceptance criterion **"dead-session ON cannot execute."**

**Guardrail exemption:** 4 files and 205 net LOC against budgets of 3 and 200, granted explicitly by the repo owner and [recorded on MOR-1013](https://linear.app/rigplane/issue/MOR-1013). The 3-file budget is structurally unsatisfiable — registry, producer and consumer are three source files before a single test exists. The tests went into Slice 4's existing web-TX module rather than a new file, reusing its doubles verbatim, which took the slice from 253 net to 205.

## The problem

A queue entry outlives its author. A session can enqueue `PttOn` and disconnect before the poller drains it, and `TxSafetySupervisor.request_on` grants a lease to any owner, alive or dead — the supervisor has no notion of session liveness and never will. That was the accepted consequence of decision **D1-a**, where the poller keys on behalf of the session rather than the ingress keying directly, so this registry is permanent architecture, not a shim.

## The design

`CommandQueue` carries a `_live_sessions: set[str] | None` registry. It is the one object both ends already hold, and it lives in `rigplane.runtime`, below `web/`, so nothing imports upward (`lint-imports`: 5 kept, 0 broken).

`ControlHandler` publishes liveness inside `run()`'s `try` and clears it at the **top** of the `finally`, beside the PTT release and ahead of `await event_task` — a dead egress socket re-raises there, and a session left marked live is a session that can still key. That is the same trap Slice 2 moved the PTT release out of.

`RadioPoller._refuse_key_from_gone_session` raises `CommandError` as the first statement of `case PttOn()` — ahead of the log line, the TX audio leg and the lease.

**ON only.** An unkey refused for being late would strand the rig keyed, the exact inversion of the point.

**Same gate pair as `_managed_tx`:** `source == "websocket"` and a truthy `session_id`. The set of commands that can take a session-owned lease is exactly the set that is liveness-checked. `session_id is None` passes through — HTTP PTT carries none, and neither does the teardown unkey.

**Fail-open until first registration.** A queue nobody registered on cannot refuse keys it was never told about. Fail-closed would be a total TX outage on any unregistered queue.

## Evidence

Independent verification at max effort on the exact content, all four files sha256-pinned and unchanged by the review.

**The load-bearing question — is the registry written and read on the same object in production?** If not, the handler registers into one and the poller reads another, and the whole slice is a silent no-op that every test still passes. Established by identity against the real `WebServer` and the real `start_web_server()`, on both interpreters:

```
poller._queue IS server.command_queue    PASS   id = 0x10a1b7810
poller._queue IS server._command_queue   PASS
after live=True:  poller's queue says sess-A live      PASS
a never-registered id is reported GONE                 PASS
after live=False: poller's queue says sess-A GONE      PASS
```

`web_startup.py` is the only `RadioPoller(` construction in `src/`; `legacy_queue` appears nowhere by keyword and exists only to absorb a test-only positional form. WebRTC registers correctly too.

**Race characterisation demonstrated, not read:**

```
session dies AFTER enqueue, BEFORE drain -> REFUSED, radio.calls == []
session dies AFTER the gate, mid-await   -> NOT refused, ['start_tx','set_ptt(True)']
```

Narrowed, not closed — and bounded in consequence, because `_release_ptt_on_teardown()` enqueues its `PttOff` *before* the unregister, so that unkey is already queued and drains next. A brief unintended key, not a stranded carrier.

**Red-before, verified directly on the shipped test file** against base `src/`: 7 failed, 5 passed — exactly the 7 new tests, with Slice 4's 5 still green.

**13 mutations, all killed**, including five the verifier wrote: registration moved after the recv loop, the gate reading the wrong queue object, the gate raising for a *live* session, the handler publishing to a different queue (the silent-no-op mode), and the gate keyed on the wrong source arm.

| gate | 3.11.13 | 3.13.5 |
|---|---|---|
| `pytest tests/ --ignore=tests/integration` — base | 8522 passed | 8522 passed |
| same — head | **8529 passed** | **8529 passed** |
| `ruff check` / `format --check` | clean | clean |
| `lint-imports` | 5 kept, 0 broken | 5 kept, 0 broken |
| `mypy src/` | 15 errors, byte-identical to base | same |

+7 on both, exactly the seven new tests.

## Scope limit, stated because the criterion is broader than what ships

The gate lives in `web/radio_poller.py::_execute`, the Icom CI-V path. The Yaesu and rigctld-client poller branches drain the **same** queue and key through `_execute_command(self, cmd)`, a signature that receives neither `source` nor `session_id`. So "dead-session ON cannot execute" holds for Icom only.

This is inherited scope — Slice 4's managed owner identity has exactly the same limit — and it regresses nothing. It matters for the FTX-1, which is Yaesu. Tracked separately.

## Known follow-ups

- Nothing pins `poller._queue is server.command_queue` in a test. Combined with fail-open, a refactor giving the poller its own queue would silently disable the gate with all 8529 tests green. A one-line identity assertion closes it; filed rather than folded in, to keep the granted exemption at exactly 205.
- The `isinstance` bail in `_publish_session_liveness` is silent — no log, no counter.
- [MOR-1189](https://linear.app/rigplane/issue/MOR-1189), independently confirmed by this review at `server.py:4308` and `:4321`.

## Hardware boundary

Software only. No hardware was run and no hardware claim is made. MOR-1033 remains the FTX-1 physical acceptance gate.

Linear: MOR-1013 (Slice 5 of 6)