### PR TITLE
MOR-1013 Slice 6: service a pending durable TX OFF before recovered work

### DIFF
--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -1781,6 +1781,32 @@ class WebServer:
                     code="radioDisconnected",
                 )
 
+    async def _service_managed_tx_release(self) -> None:
+        """Service a pending managed durable OFF; must precede recovered work.
+
+        ``soft_reconnect`` advances the CI-V generation, which poisons the bound
+        managed TX port, so a release armed before the drop is re-armed against
+        a fresh causal boundary only once the provider is rebound.  Awaiting the
+        rebind here is what puts the OFF in front of ordinary recovered work:
+        ``ManagedRadioRuntime.replace_provider`` services the re-armed release
+        before it returns, so the write has reached the radio by the time the
+        refetch, the poller readiness signal and the scope re-enable start.
+
+        Unmanaged radios publish no supervisor and keep today's behaviour
+        exactly — no backend assembles a managed runtime until MOR-1016.
+        """
+        supervisor = getattr(self._radio, "managed_tx", None)
+        rebind = getattr(supervisor, "replace_provider", None)
+        if rebind is None:
+            return
+        try:
+            await rebind(ready=True)
+        except Exception:
+            # A release that cannot be serviced stays pending in the supervisor
+            # and is re-armed by the next reconnect; blocking recovery on it
+            # would only keep the link that has to carry the OFF down.
+            logger.warning("reconnect: managed TX release failed", exc_info=True)
+
     def _on_radio_reconnect(self) -> None:
         """Called after soft_reconnect — refetch state and re-enable scope."""
         # Clear poller readiness so scope waits for refetch to complete
@@ -1788,7 +1814,8 @@ class WebServer:
             self._radio_poller._initial_fetch_done.clear()
 
         async def _refetch_and_reenable() -> None:
-            """Refetch state, signal readiness, then re-enable scope."""
+            """Release TX first, then refetch state, signal readiness and scope."""
+            await self._service_managed_tx_release()
             try:
                 if self._radio is not None and hasattr(
                     self._radio, "_fetch_initial_state"

--- a/tests/test_web_recovery_durable_off.py
+++ b/tests/test_web_recovery_durable_off.py
@@ -1,0 +1,173 @@
+"""MOR-1013 slice 6: the durable OFF goes first on recovery.
+
+``soft_reconnect`` advances the CI-V generation, which poisons the bound
+managed TX port, so a release armed before the drop is re-armed against a fresh
+causal boundary only once the provider is rebound. The Web recovery hook is
+where that has to happen: everything else ``_on_radio_reconnect`` does — the
+state refetch, the poller readiness signal it gates, the scope re-enable — is
+ordinary recovered work that would otherwise reach a rig still keyed.
+
+A real ``ManagedRadioRuntime`` over the real supervisor and the real effect
+service drives these tests; a scripted double would report whatever order it
+was told to, and the order is the whole claim. The provider is hand-rolled
+rather than a ``MagicMock`` because a bare mock answers every ``getattr`` and
+so could never show the unmanaged path staying unmanaged.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Callable
+
+from rigplane.core.tx_safety import (
+    ProviderPttObservation,
+    RadioTx,
+    TxOwner,
+    TxPhase,
+    TxSource,
+)
+from rigplane.runtime.managed_radio_runtime import ManagedRadioRuntime
+from rigplane.runtime.managed_tx_effect_service import managed_tx_effect_service
+from rigplane.web.server import WebServer
+
+_OWNER = TxOwner(TxSource.WEBSOCKET, "ws-1")
+_Observer = Callable[[ProviderPttObservation], None]
+
+
+class _Provider:
+    """Hand-rolled ``ProviderTxLifecycle`` logging every wire-facing call."""
+
+    def __init__(self, log: list[str]) -> None:
+        self.log, self._seq, self._keyed = log, 0, False
+        self.write_failures = self.capture_failures = 0
+
+    def _unbind_authoritative_ptt_observer(self) -> None:
+        return None
+
+    def _capture_managed_tx_port(self, generation: int, observer: _Observer) -> bool:
+        if self.capture_failures:
+            self.capture_failures -= 1
+            raise ConnectionError("managed TX port capture failed")
+        return True
+
+    async def _write_managed_ptt(self, generation: int, on: bool) -> None:
+        self.log.append(f"ptt({'on' if on else 'off'})")
+        if self.write_failures:
+            self.write_failures -= 1
+            raise ConnectionError("managed PTT write failed")
+        self._keyed = on
+
+    async def _request_authoritative_ptt_read(
+        self, *, provider_generation: int, observer: _Observer
+    ) -> None:
+        self.log.append("read_ptt")
+        self._seq += 1
+        observer(
+            ProviderPttObservation(
+                RadioTx.ON if self._keyed else RadioTx.OFF,
+                provider_generation,
+                self._seq,
+                time.monotonic(),
+            )
+        )
+
+    async def _retire_managed_tx_port(self, generation: int) -> None:
+        return None
+
+
+class _Radio:
+    """Duck-typed radio; a managed backend publishes its runtime here."""
+
+    def __init__(self, log: list[str], managed_tx: object | None = None) -> None:
+        self.log, self.connected, self.radio_ready = log, True, True
+        self.capabilities: set[str] = set()
+        if managed_tx is not None:
+            self.managed_tx = managed_tx
+
+    async def _fetch_initial_state(self) -> None:
+        self.log.append("refetch")
+
+
+async def _managed(
+    *, keyed: bool = False
+) -> tuple[WebServer, ManagedRadioRuntime, _Provider, list[str]]:
+    """A web server over a managed radio, optionally keyed and then cut off."""
+    log: list[str] = []
+    provider = _Provider(log)
+    runtime = ManagedRadioRuntime(
+        "web", service_factory=managed_tx_effect_service, provider_lifecycle=provider
+    )
+    await runtime.replace_provider(ready=True)
+    if keyed:
+        await runtime.request_fresh_ptt()  # seeds the OFF ``request_on`` demands
+        await runtime.request_on(_OWNER)
+        await runtime.set_provider_ready(ready=False)  # the control link drops
+        assert runtime.tx_snapshot.phase is TxPhase.RELEASE_REQUIRED
+    log.clear()
+    return WebServer(_Radio(log, runtime)), runtime, provider, log  # type: ignore[arg-type]
+
+
+async def _recover(server: WebServer) -> None:
+    server._on_radio_reconnect()  # noqa: SLF001
+    await asyncio.gather(*list(server._bg_tasks))  # noqa: SLF001
+
+
+async def test_the_durable_off_precedes_recovered_work() -> None:
+    """The release armed by the drop reaches the rig before the refetch."""
+    server, runtime, _provider, log = await _managed(keyed=True)
+
+    await _recover(server)
+
+    assert log == ["ptt(off)", "read_ptt", "refetch"]
+    assert runtime.tx_snapshot.phase is TxPhase.IDLE
+
+
+async def test_a_failed_first_off_still_goes_first_on_the_retry() -> None:
+    """A refused OFF keeps its place in line — it does not lose its turn."""
+    server, runtime, provider, log = await _managed(keyed=True)
+    provider.write_failures = 1
+
+    await _recover(server)
+    assert log == ["ptt(off)", "refetch"]
+    # Recovery is not blocked by the failure, and the release outlives it.
+    assert runtime.tx_snapshot.phase is TxPhase.FAULTED
+
+    log.clear()
+    await _recover(server)
+    assert log == ["ptt(off)", "read_ptt", "refetch"]
+    assert runtime.tx_snapshot.phase is TxPhase.IDLE
+
+
+async def test_a_rebind_that_raises_neither_keys_nor_bricks_recovery() -> None:
+    """No OFF reaches the rig, the refetch still runs, the release survives."""
+    server, runtime, provider, log = await _managed(keyed=True)
+    provider.capture_failures = 1
+
+    await _recover(server)
+
+    assert log == ["refetch"]
+    assert runtime.tx_snapshot.phase is TxPhase.RELEASE_REQUIRED
+
+
+async def test_recovery_with_nothing_pending_only_does_recovered_work() -> None:
+    """No lease, no release: the hook must not invent a write of its own."""
+    server, _runtime, _provider, log = await _managed()
+
+    await _recover(server)
+
+    assert log == ["refetch"]
+
+
+async def test_an_unmanaged_radio_recovers_exactly_as_it_does_today(caplog) -> None:
+    """Every shipped backend until MOR-1016 publishes no supervisor at all."""
+    log: list[str] = []
+    radio = _Radio(log)
+    assert not hasattr(radio, "managed_tx")
+
+    await _recover(WebServer(radio))  # type: ignore[arg-type]
+
+    assert log == ["refetch"]
+    # Skipped outright, not attempted and swallowed: a swallowed failure would
+    # put a warning and a traceback in every reconnect of every shipped rig.
+    assert not [r for r in caplog.records if "managed TX" in r.getMessage()]


### PR DESCRIPTION
Last of six slices on MOR-1013. Owns the final acceptance criterion **"OFF is first on recovery."** 2 files, **200 net LOC** — exactly at the ceiling.

## What was actually wrong

Half the ordering was already guaranteed and half was not, and the half that mattered was the web half.

**Already true:** `ManagedRadioRuntime.replace_provider` awaits `_service_effects(transition)` before returning, and the effect service drains cascading effects inside that same await. So any caller that awaits the rebind gets the `WRITE_OFF` **and** its confirming `READ_PTT` completed before its next statement.

**Not true:** nothing in `src/` ever called it. The verifier established this by AST scan rather than grep — `ManagedRadioRuntime` appears in the base tree in exactly two places, its own `class` statement and a docstring cross-reference. It is never imported and never instantiated in production, so no instance could exist and the method could not be reached by any route, including `getattr` (zero `"replace_provider"` string literals in `src/`).

So a durable OFF armed by a control-transport drop was never re-armed *or* serviced on a web reconnect. There was no OFF on that path to be first or last.

## The change

`WebServer._service_managed_tx_release()` resolves `radio.managed_tx` → `replace_provider`, returns immediately when absent, else awaits `rebind(ready=True)` with a `logger.warning` swallow. It is awaited as the **first statement** of `_refetch_and_reenable`.

"Ordinary recovered work" is concretely three things, and the verifier observed the OFF preceding all of them rather than reading the code:

```
["ptt(off)", "read_ptt", "refetch", "poller_ready_signalled", "scope_cb_set", "queued(EnableScope)"]
```

A second probe made the refetch raise; the OFF still precedes the readiness signal and the scope re-enable.

**The swallow is required by the placement**, not merely defensible: the await sits *outside* the `try/finally` that sets `_initial_fetch_done`, so an escaping exception would leave the scope gate closed forever. A failed rebind cannot masquerade as a serviced OFF — capture failure leaves the phase `RELEASE_REQUIRED`, write failure leaves `FAULTED`, never `IDLE`. `except Exception` correctly lets `CancelledError` propagate.

**Unmanaged radios are byte-identical.** Both `getattr`s and the guard are synchronous with no await before the return, confirmed empirically — base and head schedule identically (`ticks_before_refetch: 10` on both), so no concurrent-interleaving change on shipped backends.

## Evidence

Independent verification at max effort, both files sha256-pinned and unchanged.

**8 mutations, all killed** — 4 re-derived plus 4 the verifier wrote, including reversing the ordering, replacing the `await` with a spawn, and typoing the `managed_tx` attribute. They added a mutation specifically because the first seven left one shipped test unkilled; with it, **all five tests have demonstrated kill power**.

**Red-before reproduced** against pristine base `src/`: 2 failed, 3 passed. The three that pass at base assert *no change* — but the mutation matrix shows each kills a distinct mutant, so they are load-bearing rather than decorative.

| gate | 3.11.13 | 3.12.11 |
|---|---|---|
| `pytest tests/ --ignore=tests/integration` — base | 8529 passed | 8529 passed |
| same — head | **8534 passed** | **8534 passed** |
| `ruff check` / `format --check` | clean | clean |
| `lint-imports` | 5 kept, 0 broken | 5 kept, 0 broken |
| `mypy src/` | 15 errors, `diff` vs base identical | same |

## Scope limit — same as slices 4 and 5

`set_reconnect_callback(server._on_radio_reconnect)` is registered only in the Icom CI-V branch of `web_startup.py`, further gated on `StateNotifyCapable`. Yaesu CAT and the rigctld client take the observation/state-poller branches and register **no reconnect callback at all**, so they get no durable-OFF servicing on recovery. Tracked as [MOR-1190](https://linear.app/rigplane/issue/MOR-1190).

## Follow-ups filed, all blocking MOR-1016

- **[MOR-1191](https://linear.app/rigplane/issue/MOR-1191)** — `TxSafetySupervisor.tick()` has no production caller, so the max-key-down watchdog never fires and a failed OFF's retry schedule never runs. Independently confirmed by this review with a controllable clock: an hour past the deadline, zero writes; the instant `tick()` is called, `backend_max_key_down`. This slice's reconnect is currently the **only** thing that re-drives a failed OFF.
- **[MOR-1192](https://linear.app/rigplane/issue/MOR-1192)** — three properties of this helper that become live at MOR-1016: it cannot distinguish "no supervisor" from "supervisor lacking the method"; the rebind await is unbounded and uncancellable; and the ordering is per-task rather than global under concurrent reconnects.

None of these is reachable today — every shipped backend returns at the guard, and the one concrete managed type in the tree behaves exactly as claimed.

## Hardware boundary

Software only. No hardware was run and no hardware claim is made. MOR-1033 remains the FTX-1 physical acceptance gate; see MOR-1190 before interpreting its result.

Linear: MOR-1013 (Slice 6 of 6)