### PR TITLE
MOR-1187: bind the managed TX facade inside the unkey teardown guard

### DIFF
--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -1441,17 +1441,20 @@ class RadioPoller:
                         )
             case PttOff():
                 logger.info("poller: PTT OFF")
-                managed = self._managed_tx(command_source, session_id)
                 # The unkey is a fire-and-forget CI-V write and can raise
-                # (connection/timeout/transport). The audio teardown below must
-                # run anyway: a failed de-key with the TX audio leg still
+                # (connection/timeout/transport). So can the bind below it:
+                # resolving the supervisor runs backend code — a ``managed_tx``
+                # accessor is free to fail — so it binds INSIDE this guard, not
+                # above it (MOR-1187). The audio teardown must run through
+                # either failure: a failed de-key with the TX audio leg still
                 # pumping modulation into the rig is the worst outcome
-                # available (MOR-1013). ``finally`` keeps the original unkey
+                # available (MOR-1013). ``finally`` keeps the original
                 # exception intact — it propagates unwrapped so the caller's
                 # ``_mark_queued_command_failed`` classification is unchanged —
                 # while the teardown's own ``except Exception`` guarantees a
                 # failing teardown can never replace it.
                 try:
+                    managed = self._managed_tx(command_source, session_id)
                     if managed is None:
                         await radio.set_ptt(False)
                     else:

--- a/tests/test_web_managed_tx_owner.py
+++ b/tests/test_web_managed_tx_owner.py
@@ -13,6 +13,10 @@ queue carries the liveness record because it is the one object both ends
 already hold — the handler registers on connect and unregisters on every
 teardown path, and the poller refuses a key on behalf of a session gone by
 drain time. ON only: an unkey refused for being late strands the rig keyed.
+
+MOR-1187 closes what both leave open on the unkey: binding is not a lookup but
+backend code that can fail, so it belongs inside slice 1's teardown guard rather
+than above it. It also pins the two managed behaviours that had no test at all.
 """
 
 from __future__ import annotations
@@ -96,6 +100,23 @@ class _Radio:
         self.calls.append("restart_rx")
 
 
+class _BrokenSupervisorRadio(_Radio):
+    """Backend whose supervisor accessor itself raises.
+
+    ``ManagedTxApi.bind`` reads ``managed_tx`` twice over: once through the
+    ``runtime_checkable`` ``isinstance`` (3.11 calls the getter; 3.12+ reads it
+    statically) and once directly. Either read is enough to make binding fail.
+    """
+
+    @property
+    def managed_tx(self) -> _Supervisor | None:
+        raise RuntimeError("managed_tx accessor exploded")
+
+    @managed_tx.setter
+    def managed_tx(self, value: _Supervisor | None) -> None:
+        """Absorb ``_Radio.__init__``'s assignment; the getter is the point."""
+
+
 def _poller(supervisor: _Supervisor | None) -> tuple[RadioPoller, _Radio]:
     radio = _Radio(supervisor)
     return RadioPoller(radio, CommandQueue()), radio  # type: ignore[arg-type]
@@ -165,6 +186,24 @@ async def test_a_second_session_gets_its_own_owner_and_is_refused() -> None:
     assert radio.calls == ["start_tx", "start_tx", *_TEARDOWN]
 
 
+async def test_a_same_owner_re_key_is_accepted_and_keeps_its_leg_armed() -> None:
+    """IDEMPOTENT answers 'already yours', which is acceptance, not refusal.
+
+    Read as a refusal it would trip the disarm above — tearing down a LIVE audio
+    leg mid-transmission while the lease, and the rig, stay keyed: the operator
+    is still on the air with nothing feeding it.
+    """
+    supervisor = _Supervisor()
+    poller, radio = _poller(supervisor)
+
+    await poller._execute(PttOn(), command_id="c1", session_id="ws-1")
+    await poller._execute(PttOn(), command_id="c2", session_id="ws-1")
+
+    assert supervisor.entries == [(True, _WS1), (True, _WS1)]
+    assert supervisor.outcomes == [TxOutcome.ACCEPTED, TxOutcome.IDEMPOTENT]
+    assert radio.calls == ["start_tx", "start_tx"]  # no _TEARDOWN
+
+
 async def test_a_refused_release_is_tolerated_and_still_tears_down() -> None:
     """STALE means nothing of ours is keyed; raising would break ``finally``."""
     supervisor = _Supervisor()
@@ -174,6 +213,40 @@ async def test_a_refused_release_is_tolerated_and_still_tears_down() -> None:
 
     assert supervisor.outcomes == [TxOutcome.STALE]
     assert radio.calls == _TEARDOWN
+
+
+async def test_a_raising_managed_tx_accessor_still_tears_the_tx_leg_down() -> None:
+    """MOR-1187: the bind belongs INSIDE the guard it depends on.
+
+    Binding is not a read-only lookup — it runs backend code that can fail. Bound
+    above the ``try``, a raising accessor skips the ``finally`` outright, and the
+    unkey path loses the one thing it must never lose: modulation kept flowing
+    into a rig the operator believes is unkeyed. The error must still surface.
+    """
+    radio = _BrokenSupervisorRadio(None)
+    poller = RadioPoller(radio, CommandQueue())  # type: ignore[arg-type]
+
+    with pytest.raises(RuntimeError, match="accessor exploded"):
+        await poller._execute(PttOff(), command_id="c1", session_id="ws-1")
+
+    assert radio.calls == _TEARDOWN
+
+
+async def test_a_websocket_unkey_without_a_session_id_stays_unmanaged() -> None:
+    """The ``session_id`` half of the gate carries its own weight.
+
+    A sourceless entry defaults to ``source="websocket"`` at drain, so on the
+    teardown unkey (MOR-1185) only the emptiness check stands between the drain
+    and ``TxOwner``'s empty-id ``ValueError``. The test above buys the teardown
+    back from such a raise, but nothing can buy back the de-key it replaces.
+    """
+    supervisor = _Supervisor()
+    poller, radio = _poller(supervisor)
+
+    await poller._execute(PttOff(), command_id="c1", session_id=None)
+
+    assert supervisor.entries == []
+    assert radio.calls == ["set_ptt(False)", *_TEARDOWN]
 
 
 async def test_http_ingress_never_binds_an_owner() -> None:


### PR DESCRIPTION
Blocks MOR-1016. 2 files, **+76 net LOC**. Production change is one line moved.

## The defect

`ManagedTxApi.bind` runs an `isinstance` against a `runtime_checkable` Protocol, which reads the `managed_tx` property — backend code that is free to fail. In `case PttOff():` the bind sat **above** the `try` whose `finally` runs `_stop_tx_audio_leg()`, so a backend with a raising accessor lost the teardown entirely.

At base the teardown always ran. This narrowed exactly the invariant MOR-1013 Slices 1 and 2 established — *a failed de-key with the TX audio leg still pumping modulation into the rig is the worst outcome available* — and it did so silently, because nothing in `src/` publishes `managed_tx` yet.

## The fix

Move the bind to be the first statement inside the `try`. Sandbox, both interpreters:

| | 3.11 | 3.12 |
|---|---|---|
| base poller | **1 failed**, 14 passed | **1 failed**, 14 passed |
| head poller | **15 passed** | **15 passed** |

The single failure is the teardown assertion — `assert [] == ['stop_tx', 'restart_rx']` — and nothing else; `pytest.raises` matched at base too, so the delta is exactly the lost teardown.

**The original exception still propagates unwrapped.** Verified as the *same object* with `__cause__` and `__context__` both `None`, across `TimeoutError`, `ConnectionError` and `RuntimeError`. `_mark_queued_command_failed` uses only `str(exc)` plus a `timed_out` flag set by except-clause ordering, so classification is unchanged.

## The mechanism differs by interpreter, and the test covers both

The verifier instrumented the getter and dumped frames:

- **3.11** — `isinstance` *itself raises*; the getter is invoked once from `typing.py` `hasattr` inside `__instancecheck__`.
- **3.12** — `isinstance` returns `True` with the getter invoked **zero** times; the raise comes from `bind`'s own `radio.managed_tx` read.

Two genuinely different mechanisms, both landing inside `_managed_tx`, so one test is valid on both.

## Two behaviours pinned

Both survived mutation in the Slice 4 review; the implementations were already correct.

- **`IDEMPOTENT` in `_KEY_ACCEPTED`** — without it a same-owner re-key reads as a refusal and tears down its own **live** TX audio leg mid-transmission while the rig stays keyed. The verifier checked the failure *shape* matches: `CommandError: managed TX rejected PTT ON: idempotent`, raised only after `_stop_tx_audio_leg()`.
- **The `not session_id` guard.** A ticket premise of mine was wrong here and the author corrected it: a Slice 5 test already exercises websocket + `None` and already kills that mutation. The verifier then built the experiment that settles whether the new test still earns its lines — mutating the guard **plus** removing `TxOwner.__post_init__`'s empty-id `ValueError`: the pre-existing test stops killing it entirely, because it only ever killed it *incidentally* via a validator two modules away. The new test still kills it, running a real supervisor and asserting `entries == []`.

## Evidence

**10 mutations, all killed** — 5 re-derived, 5 written by the verifier. The "exactly one test" claim was confirmed against the **full suite** in isolated sandboxes:

```
M1 (bind moved back outside the try): 1 failed, 8536 passed
M3 (IDEMPOTENT removed):              1 failed, 8536 passed
```

Neither hole was catchable anywhere else in 8537 tests.

Slice 1/2/4/5 behaviours re-checked by mutation: the `finally` teardown, the `_managed_tx` source gate, `_refuse_key_from_gone_session` first in `PttOn`, `start_tx`-before-key, and the refused-key disarm — all killed.

| gate | 3.11 | 3.12 |
|---|---|---|
| `pytest tests/ --ignore=tests/integration` — base | 8534 passed | 8534 passed |
| same — head | **8537 passed** | **8537 passed** |
| `ruff check` / `format --check` | clean | clean |
| `lint-imports` | 5 kept, 0 broken | 5 kept, 0 broken |
| `mypy src/` | 15 errors, `diff` vs base clean | same |

## `PttOn` is deliberately untouched

Probed rather than reasoned, both interpreters:

```
A: managed_tx accessor raises -> RuntimeError; calls=[]
B: set_ptt(True) raises       -> ConnectionError; calls=['start_tx', 'set_ptt(True)']
```

(A) No exposure — the bind precedes `start_tx`, so a raising accessor arms nothing and fails closed. (B) is the real `PttOn` leak and is MOR-1178's shape, out of scope here.

## Non-blocking

1. **[MOR-1193](https://linear.app/rigplane/issue/MOR-1193)** — `ManagedTxApi.bind` diverges across interpreters for `AttributeError` specifically: 3.11's `hasattr` swallows it and the poller silently takes the *unmanaged* path, 3.12+ raises. Pre-existing in `bind`; this change strictly improves the 3.12 side.
2. **When the bind fails, the rig stays keyed** — audio torn down, rig still on the air. Strictly better than base by MOR-1013's own worst-outcome reasoning, and the new test's docstring says so plainly. A raw `set_ptt(False)` fallback would bypass the supervisor and is well outside this ticket.
3. The comment's *"can never replace it"* holds for `Exception`, not `BaseException` — a `CancelledError` from the teardown does demote the original to `__context__`. Pre-existing unchanged context, and propagating a cancellation is arguably correct.

## Hardware boundary

Software only. No hardware was run and no hardware claim is made. MOR-1033 remains the FTX-1 physical acceptance gate.

Linear: MOR-1187