### PR TITLE
MOR-1191: drive the TX safety supervisor so the watchdog can fire

### DIFF
--- a/src/rigplane/core/tx_safety.py
+++ b/src/rigplane/core/tx_safety.py
@@ -146,6 +146,8 @@ class TxSafetySnapshot:
     release_last_error: str | None
     active_attempt: ProviderAttempt | None
     watchdog_deadline_monotonic: float | None
+    # Configured *and* driven: a watchdog nothing ticks cannot fire, and this
+    # field must never advertise one (MOR-1191).
     watchdog_enabled: bool
     external_conflict: bool
 
@@ -249,6 +251,7 @@ class TxSafetySupervisor:
         self._active: ProviderAttempt | None = None
         self._cancel_pending: CancelProviderAttempt | None = None
         self._watchdog_deadline: float | None = None
+        self._driven = False
 
     @property
     def snapshot(self) -> TxSafetySnapshot:
@@ -290,7 +293,7 @@ class TxSafetySupervisor:
             release_last_error=self._release.error if self._release else None,
             active_attempt=self._active,
             watchdog_deadline_monotonic=self._watchdog_deadline,
-            watchdog_enabled=self._watchdog_seconds is not None,
+            watchdog_enabled=self._watchdog_seconds is not None and self._driven,
             external_conflict=managed_on and not confirmed,
         )
 
@@ -470,6 +473,7 @@ class TxSafetySupervisor:
         return self._result(TxOutcome.APPLIED)
 
     def tick(self) -> TxTransition:
+        self._driven = True
         now = self._clock()
         effects: tuple[TxEffect, ...] = ()
         if (

--- a/src/rigplane/runtime/managed_radio_runtime.py
+++ b/src/rigplane/runtime/managed_radio_runtime.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, replace
@@ -17,6 +18,8 @@ from rigplane.core.tx_safety import (
     TxSafetySupervisor,
     TxTransition,
 )
+
+logger = logging.getLogger(__name__)
 
 TxService = Callable[[TxSafetySupervisor, TxTransition], Awaitable[None]]
 ProviderRelease = Callable[[], Awaitable[None]]
@@ -62,9 +65,13 @@ class ManagedRadioRuntime:
         clock: Clock | None = None,
         id_factory: IdFactory | None = None,
         shutdown_timeout_seconds: float = 3.0,
+        tick_interval_seconds: float = 0.25,
     ) -> None:
-        if not 0 < shutdown_timeout_seconds < float("inf"):
-            raise ValueError("shutdown_timeout_seconds must be finite-positive")
+        if not all(
+            0 < seconds < float("inf")
+            for seconds in (shutdown_timeout_seconds, tick_interval_seconds)
+        ):
+            raise ValueError("shutdown timeout and tick interval must be positive")
         self.target_id, self._clock = target_id, clock or time.monotonic
         self._tx_safety = TxSafetySupervisor(clock=self._clock, id_factory=id_factory)
         self._provider_lifecycle, self._provider_generation = provider_lifecycle, 0
@@ -78,6 +85,8 @@ class ManagedRadioRuntime:
         self._observation_version = 0
         self._shutdown_task: _ShutdownTask | None = None
         self._shutdown_pending, self._shutdown_timeout = False, shutdown_timeout_seconds
+        self._tick_interval = tick_interval_seconds
+        self._tick_task: asyncio.Task[None] | None = None
         self._effect_host = _ManagedTxEffectHost(
             self._clock, self._host_write, self._host_read, self._host_retire
         )
@@ -90,6 +99,31 @@ class ManagedRadioRuntime:
     async def _service_effects(self, transition: TxTransition) -> None:
         if transition.effects:
             await self._service(self._tx_safety, transition)
+
+    async def _tick_loop(self) -> None:
+        """The production driver of ``tick``: max key-down plus the timed retry.
+
+        Only ``_lifecycle_lock`` is taken, and only around the reducer call: it
+        is the lock that guards supervisor mutation, while ``_lifecycle_change``
+        guards provider identity, which a tick never changes. Waiting on the
+        latter would park the watchdog behind a retirement — exactly when a
+        keyed rig most needs it. The loop retires itself once the lease is gone
+        so an idle target costs nothing and leaves no task behind.
+        """
+        try:
+            while True:
+                async with self._lifecycle_lock:
+                    if self._shutdown_pending or self.tx_snapshot.lease_id is None:
+                        self._tick_task = None
+                        return
+                    transition = self._tx_safety.tick()
+                try:
+                    await self._service_effects(transition)
+                except Exception:
+                    logger.warning("managed TX tick service failed", exc_info=True)
+                await asyncio.sleep(self._tick_interval)
+        except asyncio.CancelledError:
+            pass
 
     def _not_ready(self) -> TxTransition:
         return TxTransition(TxOutcome.NOT_READY, self.tx_snapshot)
@@ -290,6 +324,8 @@ class ManagedRadioRuntime:
             ):
                 return self._not_ready()
             transition = self._tx_safety.request_on(owner)
+            if self._tick_task is None and transition.snapshot.lease_id is not None:
+                self._tick_task = asyncio.create_task(self._tick_loop())
         await self._service_effects(transition)
         return transition
 
@@ -338,6 +374,10 @@ class ManagedRadioRuntime:
         self, transition: TxTransition, release_provider: ProviderRelease
     ) -> tuple[TxTransition, BaseException | None]:
         error: BaseException | None = None
+        if (ticker := self._tick_task) is not None:
+            self._tick_task = None
+            ticker.cancel()
+            await asyncio.gather(ticker, return_exceptions=True)
         try:
             if transition.outcome is not TxOutcome.NOOP:
                 await asyncio.wait_for(

--- a/tests/test_managed_tx_watchdog_ticker.py
+++ b/tests/test_managed_tx_watchdog_ticker.py
@@ -1,0 +1,152 @@
+"""MOR-1191: the managed TX max-key-down watchdog needs a production driver.
+
+``TxSafetySupervisor.tick`` is the only path to the watchdog and to the timed
+retry of a failed OFF, and nothing under ``src`` ever called it: a rig keyed
+through the managed path stayed keyed with no bound at all. No test here calls
+``tick`` -- the whole defect is that nothing did -- so each one advances a fake
+clock, lets the loop run, and watches the wire.
+
+A real supervisor, the real effect service and a hand-rolled provider drive
+every case: a scripted double would answer whatever it was told, and a
+``MagicMock`` satisfies a ``runtime_checkable`` protocol on 3.11 but not on
+3.12+ (gh-102433). ``_Provider`` is imported rather than copied so both suites
+watch the same wire.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Callable
+
+from rigplane.core.tx_safety import (
+    TxOwner,
+    TxPhase,
+    TxReleaseReason,
+    TxSafetySupervisor,
+    TxSource,
+    TxTransition,
+)
+from rigplane.runtime.managed_radio_runtime import ManagedRadioRuntime, TxService
+from rigplane.runtime.managed_tx_effect_service import managed_tx_effect_service
+from test_web_recovery_durable_off import _Provider
+
+_OWNER = TxOwner(TxSource.WEBSOCKET, "ws-1")
+_TICK = 0.002
+
+
+class _Clock:
+    """Monotonic only when the test says so."""
+
+    def __init__(self) -> None:
+        self.now = 1_000.0
+
+    def __call__(self) -> float:
+        return self.now
+
+
+class _Managed:
+    """A managed runtime plus everything the tests need to watch it."""
+
+    def __init__(self) -> None:
+        self.clock, self.log = _Clock(), []
+        self.serviced: list[TxTransition] = []
+        self.provider = _Provider(self.log)
+        self.runtime = ManagedRadioRuntime(
+            "watchdog",
+            service_factory=self._factory,
+            provider_lifecycle=self.provider,
+            clock=self.clock,
+            tick_interval_seconds=_TICK,
+        )
+
+    def _factory(self, host: object) -> TxService:
+        inner = managed_tx_effect_service(host)
+
+        async def service(sup: TxSafetySupervisor, moved: TxTransition) -> None:
+            self.serviced.append(moved)
+            await inner(sup, moved)
+
+        return service
+
+
+async def _armed(*, key: bool = True) -> _Managed:
+    """Bring the provider up, seed the OFF ``request_on`` demands, then key."""
+    managed = _Managed()
+    await managed.runtime.replace_provider(ready=True)
+    await managed.runtime.request_fresh_ptt()
+    if key:
+        assert (await managed.runtime.request_on(_OWNER)).snapshot.lease_id
+    managed.log.clear()
+    managed.serviced.clear()
+    return managed
+
+
+async def _settles(predicate: Callable[[], bool], timeout: float = 2.0) -> None:
+    """Let real tick intervals elapse until the driver has done its work."""
+    deadline = time.monotonic() + timeout
+    while not predicate():
+        assert time.monotonic() < deadline, "the ticker never got there"
+        await asyncio.sleep(_TICK)
+
+
+async def test_a_lease_held_past_max_key_down_is_dekeyed_on_the_wire() -> None:
+    """Acceptance 1: the OFF reaches the provider, with no call from the test."""
+    managed = await _armed()
+    assert managed.runtime.tx_snapshot.phase is TxPhase.KEYED
+
+    managed.clock.now += 181.0
+    await _settles(lambda: managed.runtime.tx_snapshot.phase is TxPhase.IDLE)
+
+    assert managed.log == ["ptt(off)", "read_ptt"]
+    assert len(managed.serviced) == 1  # the effects reached the provider, not a void
+    reason = managed.serviced[0].snapshot.release_reason
+    assert reason is TxReleaseReason.BACKEND_MAX_KEY_DOWN
+    # Nothing left to watch: the driver retires instead of idling forever.
+    await _settles(lambda: managed.runtime._tick_task is None)
+
+
+async def test_a_refused_off_retries_on_its_own_schedule() -> None:
+    """Acceptance 2: the clock brings it back -- no reconnect, no second call."""
+    managed = await _armed()
+    managed.provider.write_failures = 1
+
+    lease = managed.runtime.tx_snapshot.lease_id or ""
+    await managed.runtime.request_off(_OWNER, lease)
+    assert managed.log == ["ptt(off)"]
+    assert managed.runtime.tx_snapshot.phase is TxPhase.FAULTED
+
+    await asyncio.sleep(_TICK * 20)  # many ticks, but the retry is not due yet
+    assert managed.log == ["ptt(off)"]
+
+    managed.clock.now += 0.25  # retry_schedule_seconds[0]
+    await _settles(lambda: managed.runtime.tx_snapshot.phase is TxPhase.IDLE)
+    assert managed.log == ["ptt(off)", "ptt(off)", "read_ptt"]
+
+
+async def test_the_ticker_stops_at_shutdown_and_never_fires_again() -> None:
+    """Acceptance 3: shutdown owns the last word and leaves no live task."""
+    managed = await _armed()
+    ticker = managed.runtime._tick_task
+    assert ticker is not None
+
+    await managed.runtime.shutdown(release_provider=lambda: asyncio.sleep(0))
+
+    assert managed.log == ["ptt(off)", "read_ptt"]
+    assert managed.runtime._tick_task is None and ticker.done()
+    managed.clock.now += 10_000.0
+    await asyncio.sleep(_TICK * 20)
+    assert managed.log == ["ptt(off)", "read_ptt"]
+
+
+async def test_nothing_ticks_until_a_lease_exists_and_the_signal_says_so() -> None:
+    """Acceptance 4 and 5: no lease, no driver, no cost, no watchdog claimed."""
+    managed = await _armed(key=False)
+
+    await asyncio.sleep(_TICK * 20)
+    assert managed.runtime._tick_task is None and managed.log == []
+    assert not managed.runtime.tx_snapshot.watchdog_enabled
+
+    await managed.runtime.request_on(_OWNER)
+    await _settles(lambda: managed.runtime.tx_snapshot.watchdog_enabled)
+    assert managed.runtime._tick_task is not None


### PR DESCRIPTION
**Urgent, blocks MOR-1016.** 3 files, **196 net LOC**.

## The defect

`TxSafetySupervisor.tick()` had **no caller in `src/`**. It is the sole path to two things:

- firing the `BACKEND_MAX_KEY_DOWN` watchdog — `_watchdog_deadline` is read nowhere else;
- driving `_service_release(force=False)`, the timed retry of a failed OFF — every other release call site passes `force=True`.

So a rig keyed through the managed path stayed keyed **indefinitely**, and a failed de-key set a `retry_due` that nothing ever came back for. The machinery was correct the whole time; nothing drove it.

```
watchdog_enabled           : True
watchdog_deadline (t=1000) : 1180.0
after +3600s, writes seen  : []          <- an hour past the deadline
effects when tick() called : ['ProviderAttempt:write_off']
release reason after tick  : backend_max_key_down
```

## The design

The ticker lives in `ManagedRadioRuntime` and is **armed lazily by `request_on`**.

Deliberately *not* a `run()`/`start()` hook in the `AcquisitionScheduler` shape: an AST scan finds **zero** `ManagedRadioRuntime` constructions in `src/`, so a start hook would be one more thing MOR-1016 could forget — and forgetting it silently restores exactly this defect. Arming inside `request_on` is complete because `_Lease` is constructed at exactly one site, inside `request_on`, confirmed by AST rather than grep.

The loop **retires itself** once the lease is gone. Measured:

```
idle target  = 0 reducer calls, 0 ticker tasks    <- free in the strong sense: no task exists
keyed target = 3.5 reducer calls/s, 0 wire writes
watchdog deadline overshoot = 8 ms (interval 250 ms)
```

**Interval 0.25 s** = `retry_schedule_seconds[0]`, the finest granularity the supervisor's own retry schedule can express; a longer interval would make the first `_schedule_retry` step unrepresentable.

**Locking:** only `_lifecycle_lock`, and only around the reducer call. `_lifecycle_change` guards provider *identity*, which a tick never changes, and waiting on it would park the watchdog behind a retirement — exactly when a keyed rig most needs it. Effects are serviced outside the lock.

`watchdog_enabled` now means **configured and driven**: only a real `tick()` sets `_driven`. The field can no longer advertise a watchdog nothing runs, which is how this defect stayed invisible.

## Evidence

Independent verification at max effort, all three files sha256-pinned and unchanged. Every experiment ran in an isolated `git archive` tree with its own venv, each asserting its `rigplane` resolution before use.

**The load-bearing question — can a pending release outlive the ticker?** The loop retires on `lease_id is None`, so if the lease could be cleared while a release was still retrying, acceptance criterion 2 would silently not hold. AST scan found `_lease` written at exactly three sites; `_release` is cleared **only** by the same chained assignment that clears `_lease`. Then run, not rested on:

| probe | result |
|---|---|
| invariant asserted after every reducer entry point, incl. 6 failed-retry rounds | never stranded |
| key → fail OFF → advance 0.25 s | `['ptt(off)','ptt(off)','read_ptt']`, ends IDLE — **the retry reaches the wire** |
| **compound**: watchdog fires, then **its own** OFF fails 3× | the same ticker carries it through the 0.25/1.0/2.0 backoff → 4 writes, ends IDLE, then retires |

**Concurrency:** 60 seeded randomized interleavings of `request_off` / `release_owner` / `replace_provider` / `shutdown` against a due watchdog at randomized sub-interval offsets — **0 anomalies, 0 leftover tasks**. Plus 25 operator-vs-watchdog races with never a duplicate `WRITE_OFF`.

One case was initially flagged — `replace_provider` on a due watchdog emitting two OFFs — and the reviewer ran the same scenario in a **pure-base tree with no ticker at all** and got the identical sequence. Pre-existing MOR-1013 Slice 6 recovery semantics; their assertion was too strict, not the code.

**12 mutations, 9 killed.** Both mutations I specifically demanded are killed: *tick called but the transition dropped*, and *the ticker never retires*. So the tests catch a regression, not merely the absence of the feature.

**Red-before stage 2 verified independently**: with base source plus *only* the ctor knob (no loop, no arming, no cancel — grep-confirmed), all four tests fail on the defect itself.

| gate | 3.11.13 | 3.13.5 |
|---|---|---|
| `pytest tests/ --ignore=tests/integration` — base | **8534** | **8534** |
| same — head | **8538** | **8538** |
| `ruff check` / `format --check` | clean | clean |
| `lint-imports` | 5 kept, 0 broken | 5 kept, 0 broken |
| `mypy src/` | 15 errors, byte-identical list to base | identical |

New test file run **80×** across both interpreters, 20 of them under load average 4.1 — **0 failures**. Not timing-fragile.

**Inert for shipped behaviour, provably:** `ManagedRadioRuntime` has zero construction sites in `src/`; `TxSafetySupervisor` is constructed in exactly one place, inside it; `watchdog_enabled` has zero consumers in `src/` and `TxSafetySnapshot` never reaches a wire or API payload.

## The author's disclosed non-kill, and what the reviewer did with it

The author reported mutation M3 — *ticker ignores the `_shutdown_pending` fence* — as **SURVIVED**, could not kill it, kept the guard on judgement, and reported 6/7 rather than claiming 7/7.

The reviewer reproduced the author's hypothesised scenario and settled it: with a service that swallows `CancelledError` and the ticker parked inside `_service_effects`, removing the fence makes `shutdown()` **never return** — the loop survives its cancel, `lease_id` is still non-`None`, and `_complete_shutdown`'s `gather` hangs. The fence is not redundant. The author's "could not kill it" was a gap in the test, not a property of the code.

## Follow-up filed — [MOR-1194](https://linear.app/rigplane/issue/MOR-1194), blocking MOR-1016

The reviewer's findings, none reachable today:

1. **`_tick_task` dangles after any external cancel.** The loop catches `CancelledError` and returns without clearing `_tick_task`, so `request_on` never re-arms and the watchdog is permanently dead for that runtime — while `watchdog_enabled` still reports `True`. Only `_complete_shutdown` cancels in-tree and it clears first, so this is latent — but it is the exact failure mode this feature exists to prevent, which is why it blocks MOR-1016 rather than sitting in Backlog.
2. Adopt the reviewer's shutdown-hang test, which kills M3.
3. The interval is unpinned — `sleep(0)` passes all four tests, so a busy-spin regression would ship silently.
4. Servicing effects *inside* the lock passes; it does not deadlock but does stall provider retirement. The out-of-lock choice is right and materially better, just unpinned.

## Hardware boundary

Software only. No hardware was run and no hardware claim is made. MOR-1033 remains the FTX-1 physical acceptance gate.

Linear: MOR-1191