### PR TITLE
MOR-1185: give the teardown unkey the session identity it needs to release the lease

### DIFF
--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -1034,6 +1034,21 @@ class ControlHandler:
         The ``_server``/``queue`` checks are structural (no transport to enqueue
         onto), not policy. Enqueue failures are swallowed so teardown stays
         bounded.
+
+        Enqueued through the same metadata wrapper as every other unkey, so the
+        entry reaches the drain carrying this session's STABLE id (MOR-1185). On
+        a managed runtime that id IS the owner ``release_owner`` matches, so the
+        disconnect gives the lease back instead of only de-keying the rig and
+        leaving the next session to wait out MOR-1191's watchdog. It also
+        replaces today's unconditional write: a session holding no lease answers
+        STALE and nothing reaches the rig — which is the point, because one
+        session's disconnect must not de-key another's transmission. The
+        unmanaged path binds no owner and writes exactly as it does now.
+
+        The command id is synthetic: no client acked this OFF, and the poller
+        uses the id only to report a failure back to a command that does not
+        exist here. Liveness cannot refuse it — the gate covers ``PttOn`` alone,
+        and this is always drained after its own author has been unregistered.
         """
         if self._read_only or self._server is None:
             return
@@ -1041,7 +1056,13 @@ class ControlHandler:
         if queue is None:
             return
         try:
-            queue.put(PttOff())
+            _CommandMetadataQueue(
+                queue,
+                command_id=f"teardown-ptt-off-{self._session_id}",
+                source="websocket",
+                session_id=self._session_id,
+                command_service=self._command_service,
+            ).put(PttOff())
         except Exception:
             logger.debug("control: teardown PTT OFF enqueue failed", exc_info=True)
         else:

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -1195,9 +1195,15 @@ class RadioPoller:
         The entry outlives its author: a session can enqueue PTT ON and drop
         before this drain, and the supervisor grants a lease to any owner, alive
         or dead. Gated on the same pair as ``_managed_tx`` — only a websocket
-        session publishes liveness, and ``session_id is None`` (HTTP PTT, and
-        the teardown unkey) carries none to check, so it passes through. ON
-        only: an unkey refused for being late would strand the rig keyed.
+        session publishes liveness, and ``session_id is None`` (HTTP PTT)
+        carries none to check, so it passes through. ON only: an unkey refused
+        for being late would strand the rig keyed.
+
+        That last sentence is the whole reason the teardown unkey is safe, and
+        it is the only reason: since MOR-1185 it arrives carrying its session's
+        id, and by drain time that session is already unregistered. Hoisting
+        this call anywhere the ``PttOff`` arm can reach would strand a keyed
+        rig on every disconnect.
 
         This narrows the window; it does not close it. A session can still die
         between this check and the write it guards.

--- a/tests/test_web_managed_tx_owner.py
+++ b/tests/test_web_managed_tx_owner.py
@@ -17,6 +17,11 @@ drain time. ON only: an unkey refused for being late strands the rig keyed.
 MOR-1187 closes what both leave open on the unkey: binding is not a lookup but
 backend code that can fail, so it belongs inside slice 1's teardown guard rather
 than above it. It also pins the two managed behaviours that had no test at all.
+
+MOR-1185 closes the last hole in the pair: the teardown unkey went onto the RAW
+queue, so it reached the drain owner-less and de-keyed the rig without ever
+giving the lease back. Routed through the metadata wrapper it releases what it
+took — and, deliberately, drops the unconditional write it used to make.
 """
 
 from __future__ import annotations
@@ -32,6 +37,7 @@ from rigplane.core.capabilities import CAP_AUDIO
 from rigplane.core.exceptions import CommandError
 from rigplane.core.radio_protocol import ManagedTxApi
 from rigplane.core.tx_safety import (
+    ProviderAttemptKind,
     ProviderPttObservation,
     RadioTx,
     TxOutcome,
@@ -122,9 +128,11 @@ def _poller(supervisor: _Supervisor | None) -> tuple[RadioPoller, _Radio]:
     return RadioPoller(radio, CommandQueue()), radio  # type: ignore[arg-type]
 
 
-def _run_handler() -> tuple[ControlHandler, CommandQueue]:
+def _run_handler(
+    queue: CommandQueue | None = None,
+) -> tuple[ControlHandler, CommandQueue]:
     """A handler whose ``run()`` reaches teardown on the first ``recv``."""
-    queue = CommandQueue()
+    queue = CommandQueue() if queue is None else queue
 
     async def recv() -> tuple[int, bytes]:
         await asyncio.sleep(0.01)  # let the event-sender task run before EOF
@@ -142,6 +150,55 @@ def _run_handler() -> tuple[ControlHandler, CommandQueue]:
             build_state_update_envelope=MagicMock(return_value={}),
         ),
     ), queue
+
+
+def _wired(
+    supervisor: _Supervisor | None,
+) -> tuple[ControlHandler, RadioPoller, _Radio]:
+    """One control session and one poller over the queue the server shares."""
+    handler, queue = _run_handler()
+    radio = _Radio(supervisor)
+    return handler, RadioPoller(radio, queue), radio  # type: ignore[arg-type]
+
+
+def _owner(handler: ControlHandler) -> TxOwner:
+    return TxOwner(TxSource.WEBSOCKET, handler._session_id)
+
+
+async def _drain(poller: RadioPoller) -> None:
+    """Execute queued entries exactly as ``_run``'s drain does — including its
+    default of ``source="websocket"`` for an entry that carries no source."""
+    for entry in poller._queue.drain_entries():
+        await poller._execute(
+            entry.command,
+            command_id=entry.command_id,
+            source=entry.source or "websocket",
+            session_id=entry.session_id,
+            command_service=entry.command_service,
+        )
+
+
+def _settle_release(supervisor: _Supervisor) -> list[ProviderAttemptKind]:
+    """Drive the started de-key to completion and report the provider work.
+
+    The policy is pure: ``release_owner`` only STARTS the release. Undriven, the
+    lease sits in RELEASE_PENDING and the next session is refused for a reason
+    that is not BUSY but is still a refusal, which would prove nothing. Every
+    attempt this settles belongs to the de-key, so observing the rig OFF after
+    each one is what the runtime's effect service sees on a rig that obeyed.
+    """
+    kinds: list[ProviderAttemptKind] = []
+    seq = 1
+    while (attempt := supervisor.inner.snapshot.active_attempt) is not None:
+        kinds.append(attempt.kind)
+        supervisor.inner.settle_attempt(
+            attempt.id, attempt.provider_generation, succeeded=True
+        )
+        seq += 1
+        supervisor.inner.observe_ptt(
+            ProviderPttObservation(RadioTx.OFF, 0, seq, time.monotonic())
+        )
+    return kinds
 
 
 async def test_unmanaged_radio_keeps_the_legacy_write_and_ordering() -> None:
@@ -235,10 +292,11 @@ async def test_a_raising_managed_tx_accessor_still_tears_the_tx_leg_down() -> No
 async def test_a_websocket_unkey_without_a_session_id_stays_unmanaged() -> None:
     """The ``session_id`` half of the gate carries its own weight.
 
-    A sourceless entry defaults to ``source="websocket"`` at drain, so on the
-    teardown unkey (MOR-1185) only the emptiness check stands between the drain
-    and ``TxOwner``'s empty-id ``ValueError``. The test above buys the teardown
-    back from such a raise, but nothing can buy back the de-key it replaces.
+    A sourceless entry defaults to ``source="websocket"`` at drain, so for any
+    entry that carries no id — every non-websocket ingress, and the teardown
+    unkey before MOR-1185 routed it through the metadata wrapper — only the
+    emptiness check stands between the drain and ``TxOwner``'s empty-id
+    ``ValueError``, which would replace a de-key with a raise.
     """
     supervisor = _Supervisor()
     poller, radio = _poller(supervisor)
@@ -305,10 +363,10 @@ async def test_a_queue_no_session_registered_on_assumes_nobody_is_gone() -> None
 
 
 async def test_a_command_with_no_session_id_keys_and_unkeys() -> None:
-    """HTTP PTT and the teardown unkey (MOR-1185) carry no session at all, so
-    they have no liveness to check even once the queue is tracking sessions.
-    Both source arms matter: the teardown unkey goes onto the RAW queue, and
-    the drain defaults a sourceless entry to ``source="websocket"``."""
+    """HTTP PTT carries no session at all, so it has no liveness to check even
+    once the queue is tracking sessions. Both source arms matter, because the
+    drain defaults a sourceless entry to ``source="websocket"`` — the arm the
+    teardown unkey took until MOR-1185 gave it the metadata wrapper."""
     poller, radio = _poller(None)
     poller._queue.register_session("ws-1")
     poller._queue.unregister_session("ws-1")
@@ -361,3 +419,105 @@ async def test_teardown_marks_the_session_gone_through_a_dead_egress_socket() ->
         await handler.run()
 
     assert not queue.session_is_live(handler._session_id)
+
+
+async def test_a_disconnect_releases_the_lease_it_took_not_just_the_rig() -> None:
+    """MOR-1185, acceptance 1 and 2: the next session keys without waiting.
+
+    The teardown OFF used to go onto the RAW server queue, so it reached the
+    drain sourceless and session-less, took the legacy write, and left the lease
+    with a session that no longer exists. MOR-1191's watchdog clears that after
+    ``watchdog_seconds`` — a backstop, not a fix: three minutes of denied TX
+    after every disconnect. A real supervisor drives this, so an owner that did
+    not match would answer STALE here rather than quietly passing.
+
+    Consequence C rides along: the finally unregisters the session immediately
+    after enqueuing the unkey, so the entry is always drained on behalf of an
+    author already gone. ``_refuse_key_from_gone_session`` covers ``PttOn`` only
+    and must keep to it — an OFF refused for being late strands a transmitter.
+    """
+    supervisor = _Supervisor()
+    handler, poller, radio = _wired(supervisor)
+    handler._publish_session_liveness(live=True)
+
+    await handler._enqueue_command("ptt_on", {})
+    await _drain(poller)
+    await handler.run()  # EOF on the first recv: the session disconnects
+    assert not poller._queue.session_is_live(handler._session_id)
+    await _drain(poller)
+
+    assert supervisor.entries == [(True, _owner(handler)), (False, _owner(handler))]
+    assert supervisor.outcomes == [TxOutcome.ACCEPTED, TxOutcome.ACCEPTED]
+    # The de-key is the supervisor's own WRITE_OFF, not a raw defensive write.
+    assert _settle_release(supervisor) == [
+        ProviderAttemptKind.WRITE_ON,  # the key attempt, cancelled by the release
+        ProviderAttemptKind.WRITE_OFF,
+    ]
+    assert "set_ptt(False)" not in radio.calls
+
+    second, _ = _run_handler(poller._queue)
+    second._publish_session_liveness(live=True)
+    await second._enqueue_command("ptt_on", {})
+    await _drain(poller)
+
+    # ACCEPTED, not BUSY and not RELEASE_PENDING: the lease is genuinely gone.
+    assert supervisor.entries[-1] == (True, _owner(second))
+    assert supervisor.outcomes[-1] is TxOutcome.ACCEPTED
+
+
+async def test_the_lease_is_released_through_a_dead_egress_socket() -> None:
+    """Acceptance 3: slice 2's guarantee, now with a lease behind it.
+
+    ``await event_task`` re-raises the sender's error and skips everything
+    behind it, which is why the release is the FIRST statement of the finally.
+    """
+    supervisor = _Supervisor()
+    handler, poller, radio = _wired(supervisor)
+    handler._publish_session_liveness(live=True)
+    await handler._enqueue_command("ptt_on", {})
+    await _drain(poller)
+    handler._ws.send_text = AsyncMock(
+        side_effect=[None, None, ConnectionResetError("egress socket closed")]
+    )
+    handler._event_queue.put_nowait({"type": "state_update"})
+
+    with pytest.raises(ConnectionResetError):
+        await handler.run()
+    await _drain(poller)
+
+    assert supervisor.entries[-1] == (False, _owner(handler))
+    assert supervisor.outcomes[-1] is TxOutcome.ACCEPTED
+
+
+async def test_a_session_that_never_keyed_writes_nothing_to_a_managed_rig() -> None:
+    """Consequence A, stated: this REMOVES a defensive write that fires today.
+
+    ``release_owner`` on a session holding no lease answers STALE and emits no
+    WRITE_OFF, so nothing reaches the rig. Correct when it is idle, and required
+    when it is not: under management the lease is the authority on who is on the
+    air, and one session's disconnect must not de-key another's transmission.
+    The rig keyed by something outside the supervisor's knowledge
+    (``TxPhase.EXTERNAL_UNOWNED``, still without consumers) stays MOR-1175's to
+    close — a per-session blind write is not the instrument for it.
+    """
+    supervisor = _Supervisor()
+    handler, poller, radio = _wired(supervisor)
+
+    await handler.run()
+    await _drain(poller)
+
+    assert supervisor.entries == [(False, _owner(handler))]
+    assert supervisor.outcomes == [TxOutcome.STALE]
+    assert _settle_release(supervisor) == []  # no provider write of any kind
+    assert radio.calls == _TEARDOWN
+
+
+async def test_an_unmanaged_teardown_still_writes_the_unconditional_unkey() -> None:
+    """Acceptance 4: no shipped backend assembles a managed runtime until
+    MOR-1016, so the unconditional legacy OFF is what production still gets."""
+    handler, poller, radio = _wired(None)
+
+    await handler.run()
+    await _drain(poller)
+
+    assert radio.calls == ["set_ptt(False)", *_TEARDOWN]

--- a/tests/test_web_mod_input_restore.py
+++ b/tests/test_web_mod_input_restore.py
@@ -324,7 +324,15 @@ class TestTeardownPttRelease:
 
         _teardown(handler)
 
-        queue.put.assert_called_once_with(PttOff())
+        # MOR-1185: enqueued through the metadata wrapper, so the entry carries
+        # this session's stable id — the owner a managed release has to match.
+        assert queue.put.call_count == 1
+        args, kwargs = queue.put.call_args
+        assert args == (PttOff(),)
+        assert (kwargs["source"], kwargs["session_id"]) == (
+            "websocket",
+            handler._session_id,
+        )
         assert handler._mod_input_restore is None
 
 


### PR DESCRIPTION
Blocks MOR-1016. **4 files, 195 net LOC** — one file over the guardrail, explained below.

## The defect

`_release_ptt_on_teardown` enqueued `PttOff()` on the **raw** server queue, so the entry reached the drain with no source and no session id. Because `_managed_tx` requires a truthy session id, the defensive unkey took the legacy write. After MOR-1016 that means a disconnecting session de-keys the rig but never releases its lease, and the next session is refused until MOR-1191's watchdog expires.

## The change

Enqueue through the same `_CommandMetadataQueue` wrapper every other unkey uses, carrying the handler's stable `_session_id`. Verified against the **shipped drain**, not a double:

```
{'cmd': 'PttOn',  'command_id': 'websocket-212559642296208',              'session_id': 'websocket-212559642270375'}
{'cmd': 'PttOff', 'command_id': 'teardown-ptt-off-websocket-212559642270375', 'session_id': 'websocket-212559642270375'}
```

The contrast is the ticket: the **command_id** is a per-request throwaway, the **session_id** is stable and identical on both.

Shape 2 — releasing the lease directly from teardown — is not reachable here: `release_owner` is `async` and `_release_ptt_on_teardown` is a sync method called from `run()`'s `finally`, so it would mean spawning a task during teardown and splitting lease bookkeeping from the physical write across two layers.

## The behaviour change, accepted deliberately

This replaces today's unconditional defensive write **on the managed path**, and that is the point rather than a cost: a blind `set_ptt(False)` from one session's teardown would de-key **another session's live transmission**. Under management the lease is the authority on who is on the air.

Confirmed both ways by the verifier against a real `ManagedRadioRuntime` + real effect service + real `RadioPoller._run()`:

| | base | head |
|---|---|---|
| A transmitting, B disconnects | `['RAW set_ptt(False)']` — blind de-key while A is on the air | `[]` — A keeps the lease and stays keyed |
| single session, lease intact | de-keyed | de-keyed via the supervisor's own `WRITE_OFF`, lease `None`, phase idle |
| **rig keyed by external CAT, no lease** | `['RAW set_ptt(False)']` | **`[]` — nothing** |

**The third row is a real reduction in defensive coverage and is stated plainly.** `TxPhase.EXTERNAL_UNOWNED` has zero production consumers, and both `tick()` and `emergency_release()` require `self._lease` — so neither MOR-1191's watchdog nor shutdown covers a leaseless keyed rig. After this change the Web layer has no defensive de-key for a rig keyed outside the supervisor's knowledge. That is MOR-1175's to close, and it stops being latent when MOR-1016 lands. Recorded there.

Latent today: `grep -rn "ManagedRadioRuntime(" src/` = 0 hits, and the unmanaged teardown still writes `RAW set_ptt(False)` on both base and head.

## Evidence

- **Slice 2 preserved** — with a dead egress socket, `run()` re-raised and afterwards `phase=idle lease=None`, de-key via the supervisor with no raw write. The **lease**, not merely the enqueue, is released through a dead socket.
- **Slice 5 preserved** — `_refuse_key_from_gone_session` is called from exactly one site, inside `case PttOn()`. Executable proof: `session_is_live` was already `False` at drain time and the teardown still de-keyed. Mutation extending the gate to `PttOff` is killed by 5 tests.
- **The synthetic `command_id` is inert on both paths** — on failure `_mark_queued_command_failed` fires, `fail_command` returns `False` for an unknown id, `emit_lifecycle` is called 0 times, and service state is byte-identical before and after.
- **8 mutations killed, 2 negative controls survived.** A suite where everything fails is as uninformative as one where nothing does.

| gate | 3.11 | 3.13 |
|---|---|---|
| `pytest tests/ --ignore=tests/integration` — base | 8541 | 8545 |
| same — head | **8545** | **8549** |
| `ruff` / `lint-imports` / `mypy` | clean, `diff` vs base empty | same |

## The fourth file, and why

The verifier found that this diff **falsifies** an existing docstring in `radio_poller.py`: `_refuse_key_from_gone_session` says the teardown unkey passes the gate because it *carries no session id*. It now carries one. It passes for a different and weaker reason — the gate is reached only from the `PttOn` arm — and anyone who later hoisted that call to somewhere `PttOff` reaches would strand a keyed rig on every disconnect.

I corrected it here rather than filing it, because this change is what made it false. Three lines, in a file the diff otherwise does not touch. Net LOC stays under 200.

## Also corrected from the verifier's findings

The `_drain` test helper claimed to execute "exactly as `_run`'s drain does" while omitting `command_service=entry.command_service`, which the real drain passes — so the new tests never reached `_mark_queued_command_failed`. Now it does pass it, and the helper's claim is true.

## Scope caveat, stated by the author and confirmed

`release_owner` only *starts* the de-key. Undriven, the lease sits in `RELEASE_PENDING` and a second session is refused with `RELEASE_PENDING`, not `BUSY` — a different refusal, not an acceptance. The verifier proved acceptance with **no in-test driver at all** on the real runtime: A disconnects → `lease=None` → B's `request_on` = `accepted`.

## Non-blocking

1. `_CommandMetadataQueue.put`'s bare `except TypeError` catches TypeErrors raised *inside* a queue's `put` body, silently retrying without metadata — which would silently restore the old behaviour. Pre-existing, now inherited by a safety path. Verifier instrumented the whole suite: teardown fallbacks = **0**, production queues all take the metadata path.
2. `TxPhase.EXTERNAL_UNOWNED` coverage loss — record against MOR-1175 before MOR-1016.

## Hardware boundary

Software only. No hardware was run and no hardware claim is made. MOR-1033 remains the FTX-1 physical acceptance gate.

Linear: MOR-1185