### PR TITLE
MOR-1193: make unmanaged a positive finding in ManagedTxApi.bind

### DIFF
--- a/src/rigplane/core/radio_protocol.py
+++ b/src/rigplane/core/radio_protocol.py
@@ -42,6 +42,7 @@ Standard capability tags:
 from __future__ import annotations
 
 from dataclasses import dataclass
+from inspect import getattr_static
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -52,6 +53,7 @@ from typing import (
     Literal,
     Protocol,
     Sequence,
+    cast,
     runtime_checkable,
 )
 
@@ -538,6 +540,13 @@ class ManagedTxCapable(Protocol):
     and the SDK route through :class:`ManagedTxApi` instead of writing PTT
     themselves.  Backends without one expose no ``managed_tx`` attribute (or
     return ``None``) and keep the legacy :meth:`Radio.set_ptt` path unchanged.
+
+    Publish it as a real class or instance member, never through
+    ``__getattr__``: :meth:`ManagedTxApi.bind` settles absence without running
+    the accessor, so a conjured attribute reads as absent there.  Do not probe
+    with ``isinstance`` instead — 3.11 answers that with ``hasattr``, which
+    reads a conjured attribute as present and a raising one as absent, which
+    is the bypass MOR-1193 exists to close.
     """
 
     @property
@@ -560,10 +569,22 @@ class ManagedTxApi:
 
     @staticmethod
     def bind(radio: object, owner: TxOwner) -> ManagedTxApi | None:
-        """Bind ``owner`` to ``radio``'s supervisor; ``None`` when unmanaged."""
-        if not isinstance(radio, ManagedTxCapable):
-            return None
-        supervisor = radio.managed_tx
+        """Bind ``owner`` to ``radio``'s supervisor; ``None`` when unmanaged.
+
+        Unmanaged is a positive finding, never a fallback from a failed read.
+        ``getattr_static`` settles absence without running the accessor, so the
+        single explicit read below is the only backend code this touches and
+        its failures propagate.  ``isinstance(radio, ManagedTxCapable)`` cannot
+        draw that line: 3.11 probes the non-callable member with ``hasattr``,
+        which turns an ``AttributeError`` raised *inside* the property — a typo
+        on a nested attribute will do — into "no supervisor", handing a managed
+        rig to the legacy write with no lease, no owner and no watchdog.  3.12+
+        reads the member statically and raised instead, leaving the silent
+        bypass on the one interpreter the per-PR gate pins (MOR-1193).
+        """
+        if getattr_static(radio, "managed_tx", None) is None:
+            return None  # no such member, or a backend that publishes none
+        supervisor = cast(ManagedTxCapable, radio).managed_tx
         return None if supervisor is None else ManagedTxApi(supervisor, owner)
 
     async def set_ptt(

--- a/tests/test_managed_tx_api.py
+++ b/tests/test_managed_tx_api.py
@@ -124,6 +124,82 @@ def test_managed_runtime_satisfies_the_supervisor_protocol() -> None:
     assert isinstance(runtime, ManagedTxSupervisor)
 
 
+# --- Supervisor resolution (MOR-1193) --------------------------------------
+
+
+class RaisingRadio:
+    """Provider whose supervisor accessor fails instead of answering."""
+
+    def __init__(self, error: type[Exception]) -> None:
+        self._error = error
+
+    @property
+    def managed_tx(self) -> ManagedTxSupervisor | None:
+        raise self._error("supervisor accessor exploded")
+
+
+class SupervisorLessRadio:
+    """Managed-capable provider that publishes no supervisor of its own."""
+
+    @property
+    def managed_tx(self) -> ManagedTxSupervisor | None:
+        return None
+
+
+class CountingRadio(FakeRadio):
+    """Managed provider that counts every read of its supervisor accessor."""
+
+    def __init__(self) -> None:
+        self.reads = 0
+        super().__init__(True)
+
+    @property
+    def managed_tx(self) -> FakeSupervisor:
+        self.reads += 1
+        return self.supervisor
+
+    @managed_tx.setter
+    def managed_tx(self, value: FakeSupervisor | None) -> None:
+        """Absorb ``FakeRadio.__init__``'s assignment; the getter is the point."""
+
+
+@pytest.mark.parametrize("error", [AttributeError, RuntimeError, ValueError, KeyError])
+def test_a_failing_supervisor_accessor_is_never_read_as_unmanaged(
+    error: type[Exception],
+) -> None:
+    # A supervisor that cannot be resolved is not the same as no supervisor:
+    # answering ``None`` here sends a managed rig down the legacy write with no
+    # lease, no owner and no watchdog.  ``AttributeError`` is the trap — a typo
+    # on a nested attribute inside the property body raises it just as a
+    # missing member does — and 3.11 alone swallowed it, through the ``hasattr``
+    # that ``isinstance`` probes a non-callable protocol member with.  The other
+    # three always propagated: ``hasattr`` catches nothing else.
+    with pytest.raises(error, match="exploded"):
+        ManagedTxApi.bind(RaisingRadio(error), _OWNER)
+
+
+def test_a_supervisor_less_backend_reads_unmanaged_through_its_property() -> None:
+    # ``ManagedTxCapable`` declares ``managed_tx`` a property, so a backend
+    # with no supervisor answers ``None`` from code rather than storing it —
+    # and that answer must still mean unmanaged (MOR-1013).  Binding a ``None``
+    # supervisor instead would defer the failure to the first key, with the
+    # operator's finger on it.
+    assert ManagedTxApi.bind(SupervisorLessRadio(), _OWNER) is None
+
+
+def test_binding_reads_the_supervisor_accessor_exactly_once() -> None:
+    # The only accessor call is bind's own explicit read.  A second one means
+    # the protocol machinery is probing the object as well — and that probe is
+    # the ``hasattr`` which turns the raise above into "unmanaged".
+    radio = CountingRadio()
+
+    managed = ManagedTxApi.bind(radio, _OWNER)
+
+    assert managed is not None
+    assert managed.supervisor is radio.supervisor
+    assert radio.reads == 1
+
+
 # --- SDK sync ingress (MOR-1171) -------------------------------------------
 
 

--- a/tests/test_web_managed_tx_owner.py
+++ b/tests/test_web_managed_tx_owner.py
@@ -109,9 +109,9 @@ class _Radio:
 class _BrokenSupervisorRadio(_Radio):
     """Backend whose supervisor accessor itself raises.
 
-    ``ManagedTxApi.bind`` reads ``managed_tx`` twice over: once through the
-    ``runtime_checkable`` ``isinstance`` (3.11 calls the getter; 3.12+ reads it
-    statically) and once directly. Either read is enough to make binding fail.
+    ``ManagedTxApi.bind`` reads ``managed_tx`` exactly once, explicitly, and
+    settles absence without running it (MOR-1193), so the accessor's failure is
+    the bind's failure on every interpreter.
     """
 
     @property


### PR DESCRIPTION
Blocks MOR-1016. 3 files, **+97 net LOC**. `bind` is the single function every managed TX ingress binds through — SDK, CLI and Web — so blast radius is high even though the corrected path is dormant until MOR-1016.

## The defect

`bind` decided managed-ness with `isinstance` against a `runtime_checkable` Protocol. On 3.11 that probes the non-callable member with `hasattr`, which **swallows an `AttributeError` raised inside the property** and answers "no supervisor". The caller then takes the legacy write — no lease, no owner, no watchdog.

```
3.11: accessor raises AttributeError -> NO raise; calls=['set_ptt(False)','stop_tx','restart_rx']
3.12: accessor raises AttributeError -> AttributeError; calls=[]
```

`quick.yml` pins `UV_PYTHON: "3.11"`, so the silent-bypass face is the one the per-PR gate exercises and the loud one is what only `full.yml` and developer machines see. Any `AttributeError` from inside the property body does this, including a typo on a nested attribute.

## The fix

```python
if getattr_static(radio, "managed_tx", None) is None:
    return None
supervisor = cast(ManagedTxCapable, radio).managed_tx
return None if supervisor is None else ManagedTxApi(supervisor, owner)
```

`getattr_static` settles *absence* without invoking the descriptor — the same mechanism the stdlib's own protocol machinery uses from 3.12. The single explicit read is then the only backend code `bind` touches, and its failures propagate on every interpreter.

**Unmanaged is a positive finding, never a fallback from a failed read.**

## Evidence

Independently verified across **29 configurations × base/head × 3.11/3.12/3.13**.

> **Cases where head differs from base-3.12: NONE.** Head is uniform across all three interpreters in all 29 cases.

Exactly four cases diverged at base on 3.11, all removed:

| case | base-3.11 | base-3.12/3.13 | head (all three) |
|---|---|---|---|
| property raises `AttributeError` | UNMANAGED | raise | raise |
| `__slots__` declared but unset | UNMANAGED | raise | raise |
| `__getattr__`-conjured supervisor | MANAGED | UNMANAGED | UNMANAGED |
| bare `MagicMock` | MANAGED | UNMANAGED | UNMANAGED |

The last two are **wider than the ticket's framing** and worth naming explicitly: they are not regressions — both match what 3.12+ already did — and both are covered by a green full suite on all three interpreters. The `MagicMock` row is the root cause of the exercise MOR-1013 Slice 3 went through; the five doubles that pin `managed_tx = None` are deliberate and untouched.

**Everything that reads unmanaged today still does:** absent, instance `= None`, class `= None`, property→`None`, `MagicMock` with `managed_tx = None`, plain `object()`, `__slots__` set to `None`, data-descriptor→`None`, `cached_property`→`None` — UNMANAGED in all six columns.

**The `is None` sentinel was hunted for a false negative.** The only static-`None` configs whose live read yields a supervisor are `__getattr__`-based, which match base-3.12/3.13. The shadowing case is safe: a class attribute `None` shadowed by an instance supervisor gives `getattr_static` the *instance* value → MANAGED everywhere. The four `__getattr__` definitions in `src/` are module-level PEP 562 lazy-import shims, not class-level.

**9 mutations, all killed** on all three interpreters. `M1` (revert to the `isinstance` form) is killable **only on 3.11** — which is the author's framing of the defect, confirmed rather than assumed.

**Red-before is interpreter-specific**, as it must be for a divergence bug: 3.11 → 2 failed / 4 passed; 3.12 and 3.13 → 6 passed. Not a generic red.

| gate | 3.11 | 3.12 | 3.13 |
|---|---|---|---|
| `pytest tests/ --ignore=tests/integration` | **8547 passed, 0 failed** | same | same |
| `ruff check` / `format --check` | clean | clean | clean |
| `lint-imports` | 5 kept, 0 broken | same | same |
| `mypy src/` | 15 errors, `diff` vs base empty | same | same |

## This was BLOCKED first, on a docstring

The first review passed every behavioural check and then **blocked on check #10** — docstring claims verified against each interpreter's `typing.py`.

The new `ManagedTxCapable` contract line asserted that absence is settled without running the accessor *"here and in the protocol machinery itself"*. That is false on 3.11: measured, `isinstance(conjured, ManagedTxCapable)` is `True` on 3.11 and `False` on 3.12/3.13. It would have told a backend author that `isinstance` is a safe absence probe — **the very bypass this change closes** — and it contradicted the `bind` docstring 30 lines below it.

The line now warns against `isinstance` by name and scopes the static-absence claim to `bind`.

A focused non-author confirmation established the fix is docstring-only by comparing **compiled code objects**, not by reading the diff: 310 code objects before and after, 8424 bytecode bytes both, every `co_code` byte-identical, and a single changed constant — `ManagedTxCapable`'s docstring, 602 → 799 chars.

## Corrected from the author's report

The reported cost figures were **inverted**. Measured over 200k iterations: on 3.11 head is **1.55 µs faster** (2.92 → 1.37 µs); on 3.12/3.13 it is 0.4 µs slower (0.30 → 0.70 µs). Base is cheap on 3.12+ because `_ProtocolMeta.__instancecheck__` hits the ABC cache; on 3.11 it re-walks `hasattr` every call. Immaterial either way against a millisecond-scale I/O path, once per PTT command — but the direction is the opposite of what was claimed.

## Non-blocking

`isinstance(radio, ManagedTxCapable)` itself still diverges for a raising accessor (3.11 `False`, 3.12+ `True`). `bind` no longer depends on it and `ManagedTxCapable` has no consumer in `src/` outside `radio_protocol.py`, but tests assert on it and no future production code should route on it — which is now what the docstring says.

## Hardware boundary

Software only. No hardware was run and no hardware claim is made. MOR-1033 remains the FTX-1 physical acceptance gate.

Linear: MOR-1193