### PR TITLE
MOR-1192: harden the recovery durable-OFF helper

### DIFF
--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -174,6 +174,16 @@ _RADIO_MODEL_UNSPECIFIED = "unspecified"
 _MAX_POST_BODY = 256 * 1024  # 256 KiB — hard ceiling for all POST body reads
 _MAX_COMMAND_BATCH_STEPS = 128
 _COMMAND_BATCH_STEP_TIMEOUT = 10.0
+# Ceiling on the managed TX rebind that fronts recovery, derived from what the
+# rebind actually costs: one provider retirement (a transport disconnect) plus
+# one serviced effect chain — the durable OFF write and the authoritative PTT
+# read confirming it, that read itself capped by ``_civ_get_timeout``, at most
+# 2.0s.  ``ManagedRadioRuntime`` budgets 3.0s for the effect chain alone at
+# shutdown, so 5.0s is that budget plus room for the retirement it excludes.
+# Past it the link is not slow, it is gone: the OFF is abandoned exactly as a
+# refused one is, stays pending in the supervisor for the next reconnect to
+# re-arm, and recovery goes on and reopens the scope gate it would have shut.
+_MANAGED_TX_REBIND_TIMEOUT = 5.0
 _CIV_TRANSACTION_BATCH_STEP_TYPE = "raw_civ_transaction"
 _CIV_TRANSACTION_BATCH_STEP_KEYS = frozenset(
     {"type", "id", "command", "sub", "data", "expect", "timeout_ms"}
@@ -767,6 +777,17 @@ class ConnectionManager:
         return dead
 
 
+def _log_late_managed_tx_rebind(task: "asyncio.Task[Any]") -> None:
+    """Report a rebind that failed after recovery stopped waiting on it.
+
+    Attached only once the wait has timed out, so it never double-reports a
+    failure the awaiting side already logged; without it the outcome is never
+    retrieved and asyncio reports it as an unhandled task exception instead.
+    """
+    if not task.cancelled() and (error := task.exception()) is not None:
+        logger.warning("reconnect: managed TX rebind failed late", exc_info=error)
+
+
 class WebServer:
     """Asyncio HTTP + WebSocket server for the rigplane Web UI.
 
@@ -911,6 +932,8 @@ class WebServer:
         self._scope_reenable_timeout: float = 30.0
         # prevent GC of fire-and-forget tasks
         self._bg_tasks: set[asyncio.Task[Any]] = set()
+        # Serialises the managed TX rebind; see _service_managed_tx_release.
+        self._managed_tx_rebind_lock: asyncio.Lock = asyncio.Lock()
         self._scope_health_max_retries: int = 3  # give up after N failed re-enables
         # Band plan registry
         from .band_plan import BandPlanRegistry  # noqa: TID251
@@ -1796,16 +1819,62 @@ class WebServer:
         exactly — no backend assembles a managed runtime until MOR-1016.
         """
         supervisor = getattr(self._radio, "managed_tx", None)
+        if supervisor is None:
+            return
         rebind = getattr(supervisor, "replace_provider", None)
         if rebind is None:
+            # ``ManagedTxSupervisor`` declares ``request_on``/``release_owner``
+            # only, so a facade satisfying exactly that protocol lands here.
+            # Returning through the unmanaged branch would leave a keyed rig
+            # keyed with nothing logged; "unmanaged" is a positive
+            # determination, never a fallback from a failure to look.
+            logger.warning(
+                "reconnect: managed TX supervisor %s exposes no replace_provider; "
+                "an armed durable OFF cannot be re-armed and the rig may stay keyed",
+                type(supervisor).__name__,
+            )
             return
-        try:
-            await rebind(ready=True)
-        except Exception:
-            # A release that cannot be serviced stays pending in the supervisor
-            # and is re-armed by the next reconnect; blocking recovery on it
-            # would only keep the link that has to carry the OFF down.
-            logger.warning("reconnect: managed TX release failed", exc_info=True)
+        # The rebind runs as its own task and is awaited through a shield
+        # because it is not cancellable: ``ManagedRadioRuntime._await_retirement``
+        # re-awaits a shielded retirement in a loop that absorbs cancellation,
+        # so a plain ``wait_for`` would itself hang where the bound is needed.
+        # Timing out therefore abandons the wait, not the rebind, which is what
+        # lets the refetch and the readiness signal below it proceed.
+        # Serialised, because two overlapping reconnects otherwise let the
+        # second advance the provider generation while the first is still
+        # servicing its transition: the first pass's OFF is superseded and its
+        # refetch reaches a rig that is still keyed.  The lock is taken here,
+        # below the unmanaged guard and around the rebind alone, rather than
+        # around the recovery pass — a pass also refetches, unbounded, and a
+        # lock held across that would queue every later pass behind a stall
+        # the ``finally`` below has not reached yet, leaving the scope gate
+        # shut for good.  Here the only await it covers is bounded, and no
+        # unmanaged radio ever reaches it.
+        async with self._managed_tx_rebind_lock:
+            rebind_task: asyncio.Task[Any] | None = None
+            try:
+                # Starting the rebind is inside the guard because it is backend
+                # code: resolving the coroutine and handing it to ``create_task``
+                # can each fail, and this helper runs above the ``finally`` that
+                # signals readiness, so an escape here shuts the scope gate.
+                rebind_task = self._spawn(rebind(ready=True))
+                await asyncio.wait_for(
+                    asyncio.shield(rebind_task), _MANAGED_TX_REBIND_TIMEOUT
+                )
+            except TimeoutError:
+                if rebind_task is not None:  # a sync ``OSError`` from ``rebind``
+                    rebind_task.add_done_callback(_log_late_managed_tx_rebind)
+                logger.warning(
+                    "reconnect: managed TX rebind still running after %.1fs; "
+                    "continuing recovery with the release still pending",
+                    _MANAGED_TX_REBIND_TIMEOUT,
+                )
+            except Exception:
+                # A release that cannot be serviced stays pending in the
+                # supervisor and is re-armed by the next reconnect; blocking
+                # recovery on it would only keep the link that has to carry
+                # the OFF down.
+                logger.warning("reconnect: managed TX release failed", exc_info=True)
 
     def _on_radio_reconnect(self) -> None:
         """Called after soft_reconnect — refetch state and re-enable scope."""

--- a/tests/test_web_recovery_durable_off.py
+++ b/tests/test_web_recovery_durable_off.py
@@ -12,23 +12,32 @@ service drives these tests; a scripted double would report whatever order it
 was told to, and the order is the whole claim. The provider is hand-rolled
 rather than a ``MagicMock`` because a bare mock answers every ``getattr`` and
 so could never show the unmanaged path staying unmanaged.
+
+MOR-1192 hardens the same hook against the three ways it fails once MOR-1016
+publishes a supervisor: a supervisor of the wrong shape read as "unmanaged", a
+rebind that never returns, and two reconnects racing each other.
 """
 
 from __future__ import annotations
 
 import asyncio
+import logging
 import time
 from collections.abc import Callable
 
+from rigplane.core.radio_protocol import ManagedTxSupervisor
 from rigplane.core.tx_safety import (
     ProviderPttObservation,
     RadioTx,
     TxOwner,
     TxPhase,
+    TxReleaseReason,
     TxSource,
+    TxTransition,
 )
 from rigplane.runtime.managed_radio_runtime import ManagedRadioRuntime
 from rigplane.runtime.managed_tx_effect_service import managed_tx_effect_service
+from rigplane.web import server as web_server
 from rigplane.web.server import WebServer
 
 _OWNER = TxOwner(TxSource.WEBSOCKET, "ws-1")
@@ -76,6 +85,31 @@ class _Provider:
         return None
 
 
+class _ShapelessSupervisor:
+    """Exactly ``ManagedTxSupervisor`` and nothing more.
+
+    The protocol declares ``request_on`` and ``release_owner`` only, so this is
+    the narrowest surface a managed backend may legally publish — and recovery
+    finds no ``replace_provider`` on it. Not hypothetical: the ``_Supervisor``
+    in ``tests/test_web_managed_tx_owner.py`` already has exactly this shape.
+    """
+
+    async def request_on(self, owner: TxOwner) -> TxTransition:
+        raise AssertionError("recovery must never key the rig")
+
+    async def release_owner(
+        self, owner: TxOwner, *, reason: TxReleaseReason
+    ) -> TxTransition:
+        raise AssertionError("recovery must not route a release through here")
+
+
+class _Poller:
+    """Only the readiness gate the hook clears and the scope enable waits on."""
+
+    def __init__(self) -> None:
+        self._initial_fetch_done = asyncio.Event()
+
+
 class _Radio:
     """Duck-typed radio; a managed backend publishes its runtime here."""
 
@@ -111,6 +145,18 @@ async def _managed(
 async def _recover(server: WebServer) -> None:
     server._on_radio_reconnect()  # noqa: SLF001
     await asyncio.gather(*list(server._bg_tasks))  # noqa: SLF001
+
+
+def _warned(caplog, phrase: str) -> bool:
+    """Whether a managed TX warning carries ``phrase``.
+
+    Every branch here logs, so matching the phrase and not merely "managed TX"
+    is what tells the timeout apart from the generic failure.
+    """
+    return any(
+        "managed TX" in record.getMessage() and phrase in record.getMessage()
+        for record in caplog.records
+    )
 
 
 async def test_the_durable_off_precedes_recovered_work() -> None:
@@ -164,10 +210,142 @@ async def test_an_unmanaged_radio_recovers_exactly_as_it_does_today(caplog) -> N
     log: list[str] = []
     radio = _Radio(log)
     assert not hasattr(radio, "managed_tx")
+    server = WebServer(radio)  # type: ignore[arg-type]
+    # Held for the whole pass, so this says by construction what no tick count
+    # can: the guard returns above the lock, and an unmanaged radio that
+    # reached it would be waiting here instead of finishing.
+    await server._managed_tx_rebind_lock.acquire()  # noqa: SLF001
 
-    await _recover(WebServer(radio))  # type: ignore[arg-type]
+    await _recover(server)
 
     assert log == ["refetch"]
     # Skipped outright, not attempted and swallowed: a swallowed failure would
     # put a warning and a traceback in every reconnect of every shipped rig.
     assert not [r for r in caplog.records if "managed TX" in r.getMessage()]
+
+
+async def test_a_stalled_unmanaged_pass_does_not_hold_up_the_next_one() -> None:
+    """Recovery must queue on nothing — no shipped rig publishes a supervisor."""
+    log: list[str] = []
+    stalled = asyncio.Event()
+    radio = _Radio(log)
+
+    async def _wedge_the_first_refetch() -> None:
+        log.append("refetch")
+        if len(log) == 1:
+            await stalled.wait()
+
+    radio._fetch_initial_state = _wedge_the_first_refetch  # type: ignore[method-assign]
+    server = WebServer(radio)  # type: ignore[arg-type]
+    server._radio_poller = poller = _Poller()  # type: ignore[assignment]
+    server._on_radio_reconnect()  # noqa: SLF001
+    await asyncio.sleep(0)
+    server._on_radio_reconnect()  # noqa: SLF001
+    await asyncio.sleep(0)
+
+    # Serialising the pass rather than the rebind queues the second one behind
+    # the stall, and ``_refetch_and_reenable`` is the only thing in ``src/``
+    # that ever re-sets the gate — so the scope stays dark for good.
+    assert log == ["refetch", "refetch"]
+    assert poller._initial_fetch_done.is_set()
+    stalled.set()
+
+
+async def test_a_supervisor_without_replace_provider_is_reported_not_ignored(
+    caplog,
+) -> None:
+    """Unmanaged is a positive determination, never a fallback from failure."""
+    supervisor = _ShapelessSupervisor()
+    assert isinstance(supervisor, ManagedTxSupervisor)
+    assert not hasattr(supervisor, "replace_provider")
+    log: list[str] = []
+
+    with caplog.at_level(logging.WARNING):
+        await _recover(WebServer(_Radio(log, supervisor)))  # type: ignore[arg-type]
+
+    # Recovery still runs; what must not happen is silence. A managed rig whose
+    # armed OFF was never even attempted looks exactly like a shipped unmanaged
+    # one, and the operator is left keyed with nothing in the log to say so.
+    assert log == ["refetch"]
+    assert [r for r in caplog.records if "managed TX" in r.getMessage()]
+
+
+async def test_a_rebind_that_never_returns_does_not_wedge_recovery(
+    caplog, monkeypatch
+) -> None:
+    """The rebind is bounded, so readiness is still signalled — and it is loud."""
+    server, _runtime, provider, log = await _managed(keyed=True)
+    server._radio_poller = poller = _Poller()  # type: ignore[assignment]
+    never = asyncio.Event()
+
+    async def _never_retires(generation: int) -> None:
+        await never.wait()
+
+    provider._retire_managed_tx_port = _never_retires  # type: ignore[method-assign]
+    monkeypatch.setattr(web_server, "_MANAGED_TX_REBIND_TIMEOUT", 0.05)
+
+    with caplog.at_level(logging.WARNING):
+        await asyncio.wait_for(_recover(server), timeout=5.0)
+
+    # The OFF is abandoned exactly as a refused one is — but recovery finishes,
+    # and the scope gate the refetch guards is open again rather than stuck shut.
+    assert log == ["refetch"]
+    assert poller._initial_fetch_done.is_set()
+    # Specifically the timeout, not the generic failure path: ``TimeoutError``
+    # is an ``OSError`` is an ``Exception``, so deleting the timeout branch
+    # outright still logs, and a laxer assertion would not notice.
+    assert _warned(caplog, "still running after")
+
+    never.set()
+    await asyncio.gather(*list(server._bg_tasks), return_exceptions=True)
+    # Abandoned, not cancelled. A cancel lands in ``_await_retirement``'s loop,
+    # which returns it as the rebind's own failure and loses the OFF for good;
+    # left alone, the write still reaches the rig when the link comes back.
+    assert log == ["refetch", "ptt(off)", "read_ptt"]
+
+
+async def test_a_rebind_that_fails_after_the_timeout_is_still_reported(
+    caplog, monkeypatch
+) -> None:
+    """Nothing awaits it any more, so its failure has to find its own way out."""
+    server, _runtime, provider, _log = await _managed(keyed=True)
+    fail = asyncio.Event()
+
+    async def _fails_once_nobody_is_listening(generation: int) -> None:
+        await fail.wait()
+        raise ConnectionError("retirement failed after the wait gave up")
+
+    provider._retire_managed_tx_port = _fails_once_nobody_is_listening  # type: ignore[method-assign]
+    monkeypatch.setattr(web_server, "_MANAGED_TX_REBIND_TIMEOUT", 0.05)
+
+    with caplog.at_level(logging.WARNING):
+        await asyncio.wait_for(_recover(server), timeout=5.0)
+        fail.set()
+        await asyncio.gather(*list(server._bg_tasks), return_exceptions=True)
+
+    # Unharvested this surfaces only as asyncio's "Task exception was never
+    # retrieved" at collection time, detached from the reconnect that caused it.
+    assert _warned(caplog, "failed late")
+
+
+async def test_overlapping_reconnects_do_not_interleave() -> None:
+    """A second reconnect must not reach the provider mid-way through the first."""
+    server, runtime, provider, log = await _managed(keyed=True)
+
+    async def _logged_retire(generation: int) -> None:
+        log.append(f"retire[{generation}]")
+
+    provider._retire_managed_tx_port = _logged_retire  # type: ignore[method-assign]
+
+    server._on_radio_reconnect()  # noqa: SLF001
+    server._on_radio_reconnect()  # noqa: SLF001
+    await asyncio.gather(*list(server._bg_tasks))  # noqa: SLF001
+
+    # The first pass's OFF is written *and* confirmed before the second pass
+    # touches the provider at all. Overlapped, ``retire[2]`` lands first and
+    # supersedes the transition the first pass is still servicing — and note
+    # the write alone is not enough to assert on: unserialised it can still
+    # precede the refetch while its confirming read lands after.
+    assert log.count("refetch") == 2
+    assert log.index("read_ptt") < log.index("retire[2]")
+    assert runtime.tx_snapshot.phase is TxPhase.IDLE


### PR DESCRIPTION
Blocks MOR-1016. 2 files, **247 net LOC** — over the 200 guardrail under an exemption granted for the test work, explained at the end.

Three properties of `WebServer._service_managed_tx_release`, none reachable today because nothing in `src/` publishes `managed_tx`. All become live at MOR-1016.

## 1. The guard conflated "unmanaged" with "managed but wrong shape"

`ManagedTxSupervisor` declares only `request_on` and `release_owner`, so a facade satisfying exactly that protocol has no `replace_provider`. The helper returned silently through the same branch as a genuinely absent supervisor:

```
log == ["refetch"]                   # the OFF was never attempted
phase == RELEASE_REQUIRED            # the rig is still keyed
caplog "managed TX" records == []    # nothing logged
```

That facade shape **already exists in-tree** (`tests/test_web_managed_tx_owner.py`). Absence and wrong-shape are now different branches, and only the first is silent.

## 2. The rebind was unbounded and uncancellable

`ManagedRadioRuntime._await_retirement` re-awaits `asyncio.shield(task)` in a loop that absorbs cancellation, so a provider whose retirement never returns wedged recovery **ahead of** the `finally` that sets `_initial_fetch_done` — scope gate shut forever, task not cancellable. At base this was impossible.

Bounded at 5.0 s, **derived rather than picked** and verified at the code: `shutdown_timeout_seconds = 3.0` applies to `_service_effects` only — `_await_retirement` sits outside that `wait_for` — and `_civ_get_timeout` caps the confirming read at ≤2.0 s.

The timeout **abandons the wait, not the rebind**. Verified by execution across all four legs: recovery completed in 0.302 s against a 0.30 s bound, refetch ran, `_initial_fetch_done` set, and the abandoned task was `done=False cancelled=False`. A late failure logs with `exc_info` and the loop exception handler recorded **0** contexts — no "never retrieved". The release is never lost; whether the next reconnect re-arms it is identical at base and head across all three failure modes.

`asyncio.shield` is load-bearing, not decoration: dropping it hangs the wedge test outright.

## 3. Overlapping reconnects — and the first attempt at this was a strict regression

Two overlapping passes let the first task's transition be superseded, so a refetch reached a still-keyed rig.

**My first fix serialised the whole recovery pass, and the independent review blocked it.** The root cause turned out to be worse than "unbounded critical section": the verifier's own scripts drive an **unmanaged** radio, so the lock was serialising recovery for every shipped rig — where there is no OFF to order at all. A first pass that stalled then blocked every later one, and since `_refetch_and_reenable` is the only code in `src/` that re-sets `_initial_fetch_done` after the synchronous clear, the scope went dark **permanently** where base self-heals:

```
=== BASE ===                              === HEAD (blocked version) ===
  refetch attempts : 6                      refetch attempts : 1
  completions      : 5                      completions      : 0
  SCOPE GATE OPEN  : True                   SCOPE GATE OPEN  : False
  => scope RESTORED                         => scope DARK FOREVER
```

The lock now covers **the rebind alone, below the unmanaged guard**. `_on_radio_reconnect` is byte-identical to base. No unmanaged radio can reach the lock by construction. Both verifier scripts now match base exactly on both interpreters.

Backlog-collapse was rejected for a concrete reason rather than taste: it drops recovery passes, and the storm script counts them on an unmanaged radio — head would have diverged from base on the very script that has to match.

## Evidence

**10 mutations, 10 killed**, including three the review found surviving (the late-failure harvest, the whole `except TimeoutError` block, and abandon-vs-cancel) and `mD` — moving the lock back around the whole pass.

`mD` mattered: **it passed the entire unit suite while the regression was live.** It is now killed by two tests for two different reasons:

- one states the operator-visible harm — unmanaged radio, first refetch wedges, second reconnect must still refetch and reopen the gate;
- the other **holds the real lock for a whole unmanaged pass**, so a radio that could reach it would be waiting there instead of finishing. That is the structural claim, enforced rather than observed — no timing, no scheduling assumption.

`m7` initially survived the rework and the assertion had to be corrected by measurement: unserialised, the OFF *write* still precedes the refetch while its confirming *read* lands after. The assertion now pins `read_ptt` before the second pass touches the provider.

| gate | 3.11.13 | 3.13.5 |
|---|---|---|
| `pytest tests/ --ignore=tests/integration` — base | 8541 | 8541 |
| same — head | **8546** | **8546** |
| `ruff` / `lint-imports` / `mypy` | clean, byte-identical to base | same |

Unmanaged `ticks_before_refetch` = 1 at base and head on both — no event-loop yield added to the shipped path.

## A third file was proposed and then dropped

An earlier revision changed `tests/test_audit.py`, attributing a 3.11-only failure to GC epochs shifted by one extra `asyncio.Lock` allocation. The verifier could not reproduce it and instrumented the test to show no stray record. With item 3 reworked the suite is green with that file at base, so it was dropped — which also removes an assertion the verifier flagged as narrowly weakened. A one-machine, one-run correlation was not enough to spend a file on.

## Budget

**247 net LOC** against 200. An exemption to ~234 was granted for adding the `mD` guard; the final figure is 13 over that. Production is unchanged since the pre-exemption submission at +69 — **the entire overage is test material**, and specifically the two guards the review and I asked for. Nothing was compressed to fit, deliberately: the alternative to over-budget tests here is a blocked regression with no permanent guard.

## Still open, reported not fixed

`_await_retirement`'s cancellation-absorbing loop (needs its own ticket); a raising `managed_tx` accessor still escapes above the readiness `finally` ([MOR-1196](https://linear.app/rigplane/issue/MOR-1196), the third instance of that class); `_fetch_initial_state()` remains unbounded; a second absorbing `shield` in `retire_managed_tx_port`; shutdown's 3.0 s grace that a wedged rebind will not honour.

## Hardware boundary

Software only. No hardware was run and no hardware claim is made. MOR-1033 remains the FTX-1 physical acceptance gate.

Linear: MOR-1192