### PR TITLE
MOR-1196: resolve the managed supervisor inside the guard that owns the gate

### DIFF
--- a/src/rigplane/core/radio_protocol.py
+++ b/src/rigplane/core/radio_protocol.py
@@ -536,10 +536,12 @@ class ManagedTxSupervisor(Protocol):
 class ManagedTxCapable(Protocol):
     """Radio that publishes a managed TX supervisor for every ingress.
 
-    Backends assembled with a managed runtime expose it here so Web, rigctld,
-    and the SDK route through :class:`ManagedTxApi` instead of writing PTT
-    themselves.  Backends without one expose no ``managed_tx`` attribute (or
-    return ``None``) and keep the legacy :meth:`Radio.set_ptt` path unchanged.
+    Backends assembled with a managed runtime expose it here so Web, the SDK
+    and the CLI route through :class:`ManagedTxApi` instead of writing PTT
+    themselves.  rigctld does not yet — its executor writes PTT directly, so a
+    rigctld key takes no lease and no watchdog covers it (MOR-1014).  Backends
+    without a runtime expose no ``managed_tx`` attribute (or return ``None``)
+    and keep the legacy :meth:`Radio.set_ptt` path unchanged.
 
     Publish it as a real class or instance member, never through
     ``__getattr__``: :meth:`ManagedTxApi.bind` settles absence without running
@@ -547,6 +549,16 @@ class ManagedTxCapable(Protocol):
     with ``isinstance`` instead — 3.11 answers that with ``hasattr``, which
     reads a conjured attribute as present and a raising one as absent, which
     is the bypass MOR-1193 exists to close.
+
+    For consumers the rule is that resolving a supervisor is a fallible
+    operation and not an attribute lookup: the accessor is backend code and may
+    raise anything.  So no call site may read a failed resolution as absence —
+    ``getattr(radio, "managed_tx", None)`` does exactly that, its default
+    absorbing an ``AttributeError`` raised *inside* the property — nor let one
+    escape a guard that owns cleanup.  Three call sites got this wrong
+    independently (MOR-1187, MOR-1193, MOR-1196).  Bind through
+    :meth:`ManagedTxApi.bind` wherever an owner identity is in hand; where one
+    is not, repeat its two-step read rather than collapsing it to a ``getattr``.
     """
 
     @property

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -35,6 +35,7 @@ import time
 import urllib.parse
 from collections.abc import Callable, Collection, Coroutine
 from dataclasses import dataclass, field
+from inspect import getattr_static
 from typing import TYPE_CHECKING, Any, Literal, Protocol, TextIO
 
 from .. import __version__
@@ -1818,7 +1819,17 @@ class WebServer:
         Unmanaged radios publish no supervisor and keep today's behaviour
         exactly — no backend assembles a managed runtime until MOR-1016.
         """
-        supervisor = getattr(self._radio, "managed_tx", None)
+        # Resolving the supervisor is backend code, not an attribute lookup.
+        # ``getattr_static`` settles absence without running the accessor, so
+        # the one explicit read below is the only thing here that can fail, and
+        # it fails outward.  ``getattr(..., None)`` could not tell "publishes no
+        # supervisor" from an ``AttributeError`` raised *inside* the property —
+        # a typo on a nested attribute will do — and answered "unmanaged",
+        # leaving a keyed rig's armed OFF unattempted (MOR-1193, MOR-1196).
+        radio: Any = self._radio
+        if getattr_static(radio, "managed_tx", None) is None:
+            return  # no such member, or a backend that publishes none
+        supervisor = radio.managed_tx
         if supervisor is None:
             return
         rebind = getattr(supervisor, "replace_provider", None)
@@ -1884,14 +1895,23 @@ class WebServer:
 
         async def _refetch_and_reenable() -> None:
             """Release TX first, then refetch state, signal readiness and scope."""
-            await self._service_managed_tx_release()
             try:
-                if self._radio is not None and hasattr(
-                    self._radio, "_fetch_initial_state"
-                ):
-                    await self._radio._fetch_initial_state()
-            except Exception:
-                logger.warning("reconnect: refetch failed", exc_info=True)
+                # Inside the guard, not above it (MOR-1187's shape, MOR-1196):
+                # servicing the release resolves the supervisor, which is
+                # backend code and free to raise anything.  Above the
+                # ``finally`` it escapes with the gate still clear, and since
+                # this closure is the only thing in ``src/`` that ever re-sets
+                # the gate, the poller defers and re-queues ``EnableScope`` for
+                # good.  The failure still propagates — the point is that
+                # cleanup runs first, not that anything is swallowed.
+                await self._service_managed_tx_release()
+                try:
+                    if self._radio is not None and hasattr(
+                        self._radio, "_fetch_initial_state"
+                    ):
+                        await self._radio._fetch_initial_state()
+                except Exception:
+                    logger.warning("reconnect: refetch failed", exc_info=True)
             finally:
                 if self._radio_poller is not None:
                     self._radio_poller._initial_fetch_done.set()

--- a/tests/test_web_recovery_durable_off.py
+++ b/tests/test_web_recovery_durable_off.py
@@ -16,6 +16,10 @@ so could never show the unmanaged path staying unmanaged.
 MOR-1192 hardens the same hook against the three ways it fails once MOR-1016
 publishes a supervisor: a supervisor of the wrong shape read as "unmanaged", a
 rebind that never returns, and two reconnects racing each other.
+
+MOR-1196 settles the read itself: resolving the supervisor is a fallible
+operation, not an attribute lookup, so it may neither be read as absence when
+it fails nor escape the guard that re-opens the scope gate.
 """
 
 from __future__ import annotations
@@ -24,6 +28,8 @@ import asyncio
 import logging
 import time
 from collections.abc import Callable
+
+import pytest
 
 from rigplane.core.radio_protocol import ManagedTxSupervisor
 from rigplane.core.tx_safety import (
@@ -121,6 +127,39 @@ class _Radio:
 
     async def _fetch_initial_state(self) -> None:
         self.log.append("refetch")
+
+
+class _RaisingSupervisorRadio(_Radio):
+    """Backend whose supervisor accessor raises instead of answering.
+
+    Neither hypothetical nor new: ``tests/test_web_managed_tx_owner.py`` models
+    the same backend for the poller's unkey (MOR-1187). A property is free to
+    read the transport, and a transport read is free to fail.
+    """
+
+    def __init__(self, log: list[str], error: BaseException) -> None:
+        super().__init__(log)
+        self._error = error
+
+    @property
+    def managed_tx(self) -> object:
+        raise self._error
+
+
+class _SupervisorLessRadio(_Radio):
+    """Backend that publishes the member and answers ``None`` from it.
+
+    ``ManagedTxCapable`` documents this shape in as many words — "expose no
+    ``managed_tx`` attribute (or return ``None``)" — and it is the one shape
+    plain ``_Radio`` cannot model, because it stores the supervisor only when
+    there is one, so ``None`` there means no member at all. The static probe
+    finds this property, so past it the explicit read is the only thing left
+    that can settle the radio as unmanaged.
+    """
+
+    @property
+    def managed_tx(self) -> None:
+        return None
 
 
 async def _managed(
@@ -268,6 +307,69 @@ async def test_a_supervisor_without_replace_provider_is_reported_not_ignored(
     # one, and the operator is left keyed with nothing in the log to say so.
     assert log == ["refetch"]
     assert [r for r in caplog.records if "managed TX" in r.getMessage()]
+
+
+async def test_a_raising_accessor_still_opens_the_scope_gate() -> None:
+    """MOR-1196: the resolution belongs inside the guard that re-opens the gate.
+
+    ``ConnectionError``, not ``AttributeError``: ``getattr(..., None)`` already
+    absorbs the latter, so only a different exception shows whether the read is
+    guarded at all. Resolved above the ``finally``, it escapes with the gate
+    still clear, and ``EnableScope`` is deferred and re-queued for good — the
+    operator's scope goes dark and stays dark. The error must still surface.
+    """
+    log: list[str] = []
+    server = WebServer(_RaisingSupervisorRadio(log, ConnectionError("boom")))  # type: ignore[arg-type]
+    server._radio_poller = poller = _Poller()  # type: ignore[assignment]
+
+    server._on_radio_reconnect()  # noqa: SLF001
+    with pytest.raises(ConnectionError, match="boom"):
+        await asyncio.gather(*list(server._bg_tasks))  # noqa: SLF001
+
+    # Nothing downstream of the failure ran, and the gate opened regardless.
+    assert log == []
+    assert poller._initial_fetch_done.is_set()
+
+
+async def test_an_attributeerror_inside_the_accessor_is_not_absence() -> None:
+    """The other half of the rule: a failed read is not a ``None``.
+
+    ``getattr(radio, "managed_tx", None)`` cannot tell "this backend publishes
+    no supervisor" from a typo on a nested attribute inside the property — the
+    identical bypass MOR-1193 closed in ``ManagedTxApi.bind``. Silently
+    unmanaged is the worse outcome of the two: the armed OFF is never even
+    attempted, and unlike the shapeless-supervisor branch nothing says so.
+    """
+    log: list[str] = []
+    server = WebServer(_RaisingSupervisorRadio(log, AttributeError("typo")))  # type: ignore[arg-type]
+    server._radio_poller = poller = _Poller()  # type: ignore[assignment]
+
+    server._on_radio_reconnect()  # noqa: SLF001
+    with pytest.raises(AttributeError, match="typo"):
+        await asyncio.gather(*list(server._bg_tasks))  # noqa: SLF001
+
+    assert log == []
+    assert poller._initial_fetch_done.is_set()
+
+
+async def test_a_backend_that_answers_none_is_unmanaged_and_stays_quiet(
+    caplog,
+) -> None:
+    """A ``None`` from the accessor is a supervisor-less rig, not a broken one.
+
+    Past the static probe the read is the only thing that can still settle
+    this, so dropping the ``None`` check hands ``NoneType`` to the shapeless-
+    supervisor branch, which warns that an armed durable OFF cannot be re-armed
+    — on a rig that never had a supervisor to arm one with. A warning that
+    fires on a healthy backend is how the one that matters stops being read.
+    """
+    log: list[str] = []
+
+    with caplog.at_level(logging.WARNING):
+        await _recover(WebServer(_SupervisorLessRadio(log)))  # type: ignore[arg-type]
+
+    assert log == ["refetch"]
+    assert not [r for r in caplog.records if "managed TX" in r.getMessage()]
 
 
 async def test_a_rebind_that_never_returns_does_not_wedge_recovery(


### PR DESCRIPTION
Blocks MOR-1016. 3 files, **+134 net LOC**.

## The defect, and why it is filed as a class

`WebServer._service_managed_tx_release` resolved the supervisor with `getattr(self._radio, "managed_tx", None)` **outside** the `try/finally` that sets `_initial_fetch_done`. `getattr(..., default)` swallows only `AttributeError`, so an accessor raising anything else — `ConnectionError`, a transport `TimeoutError` from inside the property — escaped with the gate still clear.

This is the **third** instance of one shape:

| where | ticket |
|---|---|
| `RadioPoller`, `case PttOff()` — bind above the `try`, so a raising accessor cost the audio teardown | MOR-1187 |
| `ManagedTxApi.bind` — 3.11's `hasattr` swallowed `AttributeError` and read a managed rig as unmanaged | MOR-1193 |
| `WebServer._service_managed_tx_release` — resolution above the `finally`, bricking the scope gate | **this** |

Three independent call sites, one cause: **resolving the supervisor is backend code that can fail, and every site treated it as a cheap attribute read.**

## The operator-visible consequence, reproduced end to end

The verifier ran it against a **real `RadioPoller`, real `CommandQueue`, real `EnableScope` dispatch**, with a radio whose `managed_tx` property raises `ConnectionError`:

| | base | head |
|---|---|---|
| error propagated | `ConnectionError` | `ConnectionError` |
| gate open after reconnect | **False** | **True** |
| scope enabled | **False** — 50/50 rounds re-queued | **True** — round 2 |

**base: SCOPE DARK. head: SCOPE LIT.** Both propagate; nothing is swallowed.

They also established *why* the deferral is unbounded rather than merely slow: the re-queue at `radio_poller.py:1909` reuses the **same** generation, and `_scope_demand_is_stale` sets `_scope_demand_generation = generation` then returns `False` for `generation >= latest` — so the re-queued demand never goes stale and loops forever.

## Both halves of the same line

1. The call moves **inside** the `try`, so a failure reaches the `finally` and the gate opens before the error propagates. The refetch keeps its own nested `except Exception`, so a release failure is not mislabelled `reconnect: refetch failed` — both modes constructed and confirmed.
2. `getattr(..., None)` is replaced by the two-step `getattr_static` read, the same one `ManagedTxApi.bind` uses. That default could not distinguish "publishes no supervisor" from an `AttributeError` raised *inside* the property.

## The rule moved to where the attribute is declared

Three authors reached for `getattr`/`hasattr` independently because the attribute *looks* like an attribute. The rule now lives on `ManagedTxCapable`'s docstring — the one file all three would have read — rather than in three call-site comments only the person already at that call site will see.

The same docstring's first paragraph was **wrong twice**: it claimed rigctld routes through `ManagedTxApi` (it does not — `rigctld/handler.py:352` writes PTT directly), and omitted the CLI (which does, since MOR-1170). Corrected. The verifier confirmed all four claims independently, including that `src/rigplane/rigctld/` contains **zero** references to `managed_tx`, `ManagedTxApi`, `watchdog`, `lease`, `tx_safety` or `TxOwner`.

## Evidence

**Red-before was precise, not incidental**: `pytest.raises(ConnectionError)` already *passed* against the unfixed code — the error propagated fine — and the failure was on `assert poller._initial_fetch_done.is_set()`. Error out, gate shut. That is the defect.

**6 mutations, all killed.** The one that matters most is M4: the naive fix — putting the release inside the refetch's own `except Exception` — passes the gate assertion and is killed only by the `pytest.raises`.

**M6, found by the verifier and closed on their recommendation**: dropping `if supervisor is None: return` survived the whole suite. Not a no-op — under it, a `managed_tx` property returning `None` emits a false *"supervisor NoneType exposes no replace_provider; an armed durable OFF cannot be re-armed and the rig may stay keyed"* warning. That shape is documented as supported by the very docstring being extended, and plain `_Radio` cannot express it because `if managed_tx is not None` collapses `None` into "no member". A `_SupervisorLessRadio` subclass with a genuine `None`-returning property now pins it.

**Audit — independent AST scan of all 291 files in `src/`**, covering `.managed_tx` nodes, `getattr`/`getattr_static`/`hasattr`/`setattr`/`delattr` with literals, and every bare `"managed_tx"` string. Four direct reads, all hardened; three indirect through `bind`. **Zero remaining `getattr(..., "managed_tx", None)` and zero `isinstance(..., ManagedTxCapable)` in `src/`.** No fourth un-hardened instance.

**Divergence check**: a differential classifier built from both two-step implementations verbatim, over 10 object shapes on 3.11 and 3.13 plus the real `bind` — **0 divergences**. They are semantically identical. Factoring them into one owner-free resolver is filed as [MOR-1198](https://linear.app/rigplane/issue/MOR-1198); it is a drift surface, not a defect.

| gate | 3.11 | 3.13 |
|---|---|---|
| `pytest tests/ --ignore=tests/integration` | 8559 collected, see note | **8559 passed, 0 failed** |
| `ruff` / `lint-imports` | clean | clean |
| `mypy src/` | 15 errors, re-run at base, byte-identical | same |

Apples-to-apples in one sandbox: base 8554 → head 8556 on both interpreters, exactly the 2 tests added at that point.

## Nothing from Slice 6 or MOR-1192 regressed

The durable OFF still precedes the refetch, the readiness signal and the scope re-enable. MOR-1192's `_managed_tx_rebind_lock` still covers **the rebind alone, below the unmanaged guard** — hoisting it over the whole pass deadlocks one pinning test and fails the other. Inserting an `await asyncio.sleep(0)` before the unmanaged guard returns is killed.

## Two load flakes, neither this change

No single 3.11 full run came back clean, with a **different** single failure each time on a byte-identical tree:

- `test_audit.py::TestLogCommand::test_msg_is_audit_record` — [MOR-1197](https://linear.app/rigplane/issue/MOR-1197)
- `test_civ_command_profiling.py::TestLatencyDistribution::test_frame_creation_latency_distribution` — [MOR-1176](https://linear.app/rigplane/issue/MOR-1176), a wall-clock percentile assertion over 100 samples

Both pass in isolation, both already tracked, neither reachable from this diff. Reported rather than rounded up to green.

## Hardware boundary

Software only. No hardware was run and no hardware claim is made. MOR-1033 remains the FTX-1 physical acceptance gate.

Linear: MOR-1196