### PR TITLE
MOR-1194: let the ticker own its own slot, and stop claiming a dead watchdog

### DIFF
--- a/src/rigplane/core/tx_safety.py
+++ b/src/rigplane/core/tx_safety.py
@@ -491,6 +491,10 @@ class TxSafetySupervisor:
         outcome = TxOutcome.APPLIED if effects or self._release else TxOutcome.NOOP
         return self._result(outcome, effects)
 
+    def retire_driver(self) -> None:
+        """The driver of ``tick`` is gone; stop claiming a watchdog with it."""
+        self._driven = False
+
     def _release_current(self, reason: TxReleaseReason) -> TxTransition:
         if self._release:
             self._release = replace(self._release, terminal_reason=reason)

--- a/src/rigplane/runtime/managed_radio_runtime.py
+++ b/src/rigplane/runtime/managed_radio_runtime.py
@@ -103,18 +103,28 @@ class ManagedRadioRuntime:
     async def _tick_loop(self) -> None:
         """The production driver of ``tick``: max key-down plus the timed retry.
 
-        Only ``_lifecycle_lock`` is taken, and only around the reducer call: it
-        is the lock that guards supervisor mutation, while ``_lifecycle_change``
-        guards provider identity, which a tick never changes. Waiting on the
-        latter would park the watchdog behind a retirement — exactly when a
-        keyed rig most needs it. The loop retires itself once the lease is gone
-        so an idle target costs nothing and leaves no task behind.
+        Only ``_lifecycle_lock`` is taken, and on the normal path only around
+        the reducer call: it is the lock that guards supervisor mutation, while
+        ``_lifecycle_change`` guards provider identity, which a tick never
+        changes. Waiting on the latter would park the watchdog behind a
+        retirement — exactly when a keyed rig most needs it. The loop retires
+        itself once the lease is gone so an idle target costs nothing and
+        leaves no task behind.
+
+        The ``finally`` below is the exception: when a cancel or a shutdown
+        ends the loop it retires outside the lock, because the canceller may
+        already hold it. Safe only because the two writes it makes have no
+        ``await`` between them and the loop is single-threaded.
+
+        The interval bounds retry latency rather than setting it: an OFF that
+        failed comes due one ``retry_schedule_seconds[0]`` after the failure and
+        is picked up by the next tick, so it lands within one interval of that.
         """
         try:
             while True:
                 async with self._lifecycle_lock:
                     if self._shutdown_pending or self.tx_snapshot.lease_id is None:
-                        self._tick_task = None
+                        self._retire_ticker()
                         return
                     transition = self._tx_safety.tick()
                 try:
@@ -124,6 +134,19 @@ class ManagedRadioRuntime:
                 await asyncio.sleep(self._tick_interval)
         except asyncio.CancelledError:
             pass
+        finally:
+            self._retire_ticker()
+
+    def _retire_ticker(self) -> None:
+        """The loop owns its own slot, so no canceller can strand the watchdog.
+
+        Withdrawing the drive with it is what keeps ``watchdog_enabled`` honest:
+        clearing the slot alone still leaves the flag latched on by the last
+        tick, advertising a watchdog that is no longer running.
+        """
+        if self._tick_task is asyncio.current_task():
+            self._tick_task = None
+            self._tx_safety.retire_driver()
 
     def _not_ready(self) -> TxTransition:
         return TxTransition(TxOutcome.NOT_READY, self.tx_snapshot)
@@ -375,8 +398,7 @@ class ManagedRadioRuntime:
     ) -> tuple[TxTransition, BaseException | None]:
         error: BaseException | None = None
         if (ticker := self._tick_task) is not None:
-            self._tick_task = None
-            ticker.cancel()
+            ticker.cancel()  # the loop clears the slot on its way out
             await asyncio.gather(ticker, return_exceptions=True)
         try:
             if transition.outcome is not TxOutcome.NOOP:

--- a/tests/test_managed_tx_watchdog_ticker.py
+++ b/tests/test_managed_tx_watchdog_ticker.py
@@ -48,16 +48,19 @@ class _Clock:
 class _Managed:
     """A managed runtime plus everything the tests need to watch it."""
 
-    def __init__(self) -> None:
+    def __init__(self, *, tick: float = _TICK, shutdown: float = 3.0) -> None:
         self.clock, self.log = _Clock(), []
         self.serviced: list[TxTransition] = []
+        self.park: asyncio.Event | None = None
+        self.entered = asyncio.Event()
         self.provider = _Provider(self.log)
         self.runtime = ManagedRadioRuntime(
             "watchdog",
             service_factory=self._factory,
             provider_lifecycle=self.provider,
             clock=self.clock,
-            tick_interval_seconds=_TICK,
+            shutdown_timeout_seconds=shutdown,
+            tick_interval_seconds=tick,
         )
 
     def _factory(self, host: object) -> TxService:
@@ -65,14 +68,25 @@ class _Managed:
 
         async def service(sup: TxSafetySupervisor, moved: TxTransition) -> None:
             self.serviced.append(moved)
-            await inner(sup, moved)
+            if (park := self.park) is None:
+                await inner(sup, moved)
+                return
+            self.entered.set()
+            try:
+                await park.wait()  # a provider call that outlives its caller...
+            except asyncio.CancelledError:
+                pass  # ...and swallows the cancel meant to stop it
+            finally:
+                self.entered.clear()
 
         return service
 
 
-async def _armed(*, key: bool = True) -> _Managed:
+async def _armed(
+    *, key: bool = True, tick: float = _TICK, shutdown: float = 3.0
+) -> _Managed:
     """Bring the provider up, seed the OFF ``request_on`` demands, then key."""
-    managed = _Managed()
+    managed = _Managed(tick=tick, shutdown=shutdown)
     await managed.runtime.replace_provider(ready=True)
     await managed.runtime.request_fresh_ptt()
     if key:
@@ -88,6 +102,34 @@ async def _settles(predicate: Callable[[], bool], timeout: float = 2.0) -> None:
     while not predicate():
         assert time.monotonic() < deadline, "the ticker never got there"
         await asyncio.sleep(_TICK)
+
+
+async def _parked(*, shutdown: float = 3.0) -> _Managed:
+    """Hold the ticker inside the provider call its own watchdog just made."""
+    managed = await _armed(shutdown=shutdown)
+    managed.park = asyncio.Event()
+    managed.clock.now += 181.0  # the watchdog is due, so this tick has effects
+    await asyncio.wait_for(managed.entered.wait(), timeout=2.0)
+    return managed
+
+
+async def _cancelled(managed: _Managed) -> asyncio.Task[None] | None:
+    """Cancel the ticker the way a caller that forgets to clear the slot would."""
+    ticker = managed.runtime._tick_task
+    assert ticker is not None
+    ticker.cancel()
+    await asyncio.gather(ticker, return_exceptions=True)
+    return ticker
+
+
+async def _quiesce(managed: _Managed) -> None:
+    """Reap the ticker whatever the test found: a parked one eats its cancel,
+    and loop teardown cancels only once, so a failure would hang, not report."""
+    if managed.park is not None:
+        managed.park.set()
+        await _settles(lambda: not managed.entered.is_set())
+    if managed.runtime._tick_task is not None:
+        await _cancelled(managed)
 
 
 async def test_a_lease_held_past_max_key_down_is_dekeyed_on_the_wire() -> None:
@@ -150,3 +192,95 @@ async def test_nothing_ticks_until_a_lease_exists_and_the_signal_says_so() -> No
     await managed.runtime.request_on(_OWNER)
     await _settles(lambda: managed.runtime.tx_snapshot.watchdog_enabled)
     assert managed.runtime._tick_task is not None
+
+
+async def test_a_cancelled_ticker_frees_its_slot_and_claims_no_watchdog() -> None:
+    """MOR-1194 item 1: the loop owns its slot, so no canceller can strand it.
+
+    Only ``_complete_shutdown`` cancels today, and it clears the slot first --
+    which makes a permanently dead watchdog depend on every future canceller
+    remembering to do the same. Cancel it the careless way instead.
+    """
+    managed = await _armed()
+    await _settles(lambda: managed.runtime.tx_snapshot.watchdog_enabled)
+    await _cancelled(managed)
+
+    assert managed.runtime._tick_task is None
+    snapshot = managed.runtime.tx_snapshot
+    # Item 2 of the acceptance: still keyed, and honest that nothing watches it.
+    assert snapshot.lease_id is not None and not snapshot.watchdog_enabled
+
+
+async def test_the_next_request_rearms_a_watchdog_that_still_fires() -> None:
+    """MOR-1194 item 1: re-arming must restore the watchdog, not just a task."""
+    managed = await _armed()
+    await _settles(lambda: managed.runtime.tx_snapshot.watchdog_enabled)
+    ticker = await _cancelled(managed)
+
+    await managed.runtime.request_on(_OWNER)  # idempotent on the lease it holds
+    assert managed.runtime._tick_task not in (None, ticker)
+
+    managed.clock.now += 181.0
+    await _settles(lambda: managed.runtime.tx_snapshot.phase is TxPhase.IDLE)
+    assert managed.log == ["ptt(off)", "read_ptt"]
+    await _settles(lambda: managed.runtime._tick_task is None)
+
+
+async def test_shutdown_returns_even_when_the_service_swallows_its_cancel() -> None:
+    """MOR-1194 item 2: the ``_shutdown_pending`` fence is the only stop left.
+
+    A service that survives cancellation puts the ticker straight back into the
+    loop, and the lease outlives the emergency release, so without the fence it
+    ticks forever and the gather in ``_complete_shutdown`` never returns.
+    """
+    managed = await _parked(shutdown=0.05)
+    try:
+        await asyncio.wait_for(
+            managed.runtime.shutdown(release_provider=lambda: asyncio.sleep(0)),
+            timeout=5.0,
+        )
+        assert managed.runtime._tick_task is None
+        assert not managed.runtime.tx_snapshot.watchdog_enabled
+    finally:
+        await _quiesce(managed)
+
+
+async def test_the_ticker_waits_its_interval_between_ticks() -> None:
+    """MOR-1194 item 3: four wakeups a second, not an unbounded hot loop.
+
+    Only real time can show this. The fake clock does not move on its own, so a
+    loop that never sleeps reaches all the same states -- thousands of times a
+    second on a keyed rig, and no other assertion here would notice.
+    """
+    managed = await _armed(tick=5.0)
+    supervisor, ticks = managed.runtime._tx_safety, 0
+    real = supervisor.tick
+
+    def counted() -> TxTransition:
+        nonlocal ticks
+        ticks += 1
+        return real()
+
+    supervisor.tick = counted
+    await asyncio.sleep(0.05)
+
+    assert managed.runtime._tick_task is not None  # alive, and still not spinning
+    assert ticks <= 1, f"the interval is not awaited: {ticks} ticks in 50 ms"
+
+
+async def test_effects_are_serviced_with_the_lifecycle_lock_released() -> None:
+    """MOR-1194 item 4: a provider that stops answering must not stall the rest.
+
+    Retirement needs ``_lifecycle_lock``. Hold it across the service call and
+    the one provider already refusing to answer also blocks every attempt to
+    replace it -- ``_provider_state`` stuck at ``bound`` instead of ``unbound``.
+    """
+    managed = await _parked()
+    try:
+        await asyncio.wait_for(
+            managed.runtime.invalidate_provider(managed.runtime._provider_generation),
+            timeout=1.0,
+        )
+        assert managed.runtime._provider_state == "unbound"
+    finally:
+        await _quiesce(managed)


### PR DESCRIPTION
Blocks MOR-1016. 3 files, **174 net LOC**.

## The defect

MOR-1191 gave `TxSafetySupervisor.tick()` a production driver for the first time — before it, the max-key-down watchdog never fired and a failed OFF never retried on a timer. The loop it added ended in `except asyncio.CancelledError: pass`, returning **without clearing `_tick_task`**.

So after any cancel that did not clear the slot first: the task is done, the slot is not `None`, `request_on` never re-arms, and **the watchdog is permanently dead for that runtime** — while `watchdog_enabled` still reports `True`. The same class of defect MOR-1191 exists to fix, one level up.

## Clearing the slot is not enough — established by measurement

The obvious fix is a `finally` that clears the slot. It is insufficient, and the author proved it by applying it **in isolation**:

```
keyed lease, ticker cancelled externally → phase=KEYED, watchdog_deadline=1180.0, watchdog_enabled=True
after a completed shutdown               → phase=RELEASE_REQUIRED, watchdog_enabled=True
```

`_driven` stays latched by the last tick, so the flag still advertises a watchdog that is not running. The verifier reproduced this independently against three trees with the real effect service:

| tree | after a careless cancel | verdict |
|---|---|---|
| base (MOR-1191) | `tick_task=live lease=yes watchdog_enabled=True` | slot stranded, re-arm impossible |
| slot-clear only | `tick_task=None lease=yes watchdog_enabled=True` | **lies** |
| head | `tick_task=None lease=yes watchdog_enabled=False` | honest |

So the supervisor gains `retire_driver()`, and the loop withdraws the drive along with the slot.

**Placement:** on the supervisor rather than as an override in `ManagedRadioRuntime.tx_snapshot`, because every API returns `TxTransition.snapshot` straight from the supervisor — a runtime-side override would leave transitions disagreeing with the property. `_driven` is written only by `__init__`, `tick` and `retire_driver`, and **read only by `snapshot()`**, so no control-flow decision depends on it and withdrawing the drive cannot suppress a real de-key. Verified by AST scan.

**Shutdown:** `_complete_shutdown` no longer pre-clears the slot. That is what makes the two not fight — with the pre-clear the identity guard fails, `retire_driver` never runs, and the drive stays latched. Restoring the pre-clear is killed by a test.

## The in-lock retirement is kept — but not for the reason first given

The author kept the in-lock `_retire_ticker()` on the grounds that a `request_on` could take the lock between the loop deciding to retire and the `finally` running, see a stale slot, and decline to arm. They reported honestly that they could not pin it.

**The verifier established that window does not exist.** `asyncio.Lock.__aexit__` releases synchronously, so a waiter cannot run between the in-lock `return` and the `finally`:

```
0. holder: in-lock, about to return
1. holder: finally
2. waiter: ACQUIRED LOCK
waiter ran BEFORE holder's finally? False
```

Backed by 5000 rounds of the `request_off`/`request_on` race hunting `lease_id is not None ⇒ live ticker` — zero violations on head *and* on the mutant. It is an equivalent mutant, not a hard-to-reach one, which is why no test could pin it.

The line still earns its place, for a different reason the verifier measured:

```
natural (lease gone)   retire_driver calls=1  lock_held=[True]
careless cancel        retire_driver calls=1  lock_held=[False]
shutdown()             retire_driver calls=1  lock_held=[False]
```

Exactly one supervisor mutation, under the lock on the normal path. Coherent lock discipline, just not what was claimed. The commit message and the `_tick_loop` docstring now say that instead — the docstring's "only around the reducer call" was made inaccurate by this very change, since the `finally` retires outside the lock when a canceller may already hold it.

## Evidence

**12 mutations, 10 killed, 2 survivors** — both equivalent, both disclosed. The author's report said 9 run / 8 killed / 1 survivor; the verifier found an **undisclosed** survivor (removing the identity guard) and corrected the count. Neither survivor is a defect: the guard cannot misfire and is what makes the old pre-clear dangerous, so guard and shutdown-reordering are a matched pair.

**No timing fragility:** 84 runs of the new test file — 30× on 3.11, 30× on 3.12, 12× each under ~20 CPU burners with 1-minute load peaking at 137, plus an 8-way xdist run. Zero failures.

**Docstrings verified by phase-swept measurement**, not by reading — the interval *bounds* retry latency rather than setting it:

```
tick=0.05  latency after due: min= 11.6 ms  max= 50.4 ms  (bound= 50 ms)
tick=0.4   latency after due: min= 81.3 ms  max=401.8 ms  (bound=400 ms)
```

| gate | 3.11.13 | 3.12.11 |
|---|---|---|
| `pytest tests/ --ignore=tests/integration` | **8561 passed** | **8561 passed** |
| sandbox controlled pair | base 8554 → head 8559 = **+5** | same |
| `ruff` / `lint-imports` | clean | clean |
| `mypy src/` | 15 errors, identical to base | same |

**No shipped behaviour change:** AST scan finds **0** `ManagedRadioRuntime` construction sites in `src/`, and `retire_driver` has exactly one caller.

## Non-blocking, carried forward

- A task cancelled before its first step skips its `finally` entirely, so the slot would be left set — a latent edge the old pre-clear did not have. Unreachable today: `create_task` FIFO guarantees the ticker steps before any later-created canceller, and `_shutdown_pending` makes a stale slot inert.
- `retire_driver()` is public and unguarded; a stray caller could report no watchdog while one runs. Fail-safe direction, one caller today.
- `watchdog_enabled` still has **no production consumer** — only tests read it. This fix is forward-looking for MOR-1016, which bounds its present-day impact.

## Hardware boundary

Software only. No hardware was run and no hardware claim is made. MOR-1033 remains the FTX-1 physical acceptance gate.

Linear: MOR-1194