### PR TITLE
test: extract shared fake-WS backend harness for transport tests

### DIFF
--- a/frontend/src/lib/transport/__tests__/support/fake-ws-backend.ts
+++ b/frontend/src/lib/transport/__tests__/support/fake-ws-backend.ts
@@ -1,0 +1,64 @@
+// ─── Shared fake WebSocket backend for ws-client tests ───────────────────────
+//
+// Used by both the unit suite (``ws-client.test.ts``, which mocks the store
+// modules) and the integration suite (``ws-client-store.integration.test.ts``,
+// which drives the real store). Previously each file kept its own copy of
+// this class; this module is the single source of truth (superset of both
+// copies' behavior — includes ``simulateClose``/``simulateError``, which the
+// integration suite's copy didn't need but the unit suite does).
+//
+// ``instances`` is exported alongside the class because both suites index
+// into it directly (e.g. ``instances[0].simulateOpen()``) after installing
+// ``MockWebSocket`` as ``globalThis.WebSocket``.
+
+export class MockWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+
+  readyState = MockWebSocket.CONNECTING;
+  binaryType = 'blob';
+  url: string;
+  sent: string[] = [];
+
+  onopen: (() => void) | null = null;
+  onmessage: ((e: MessageEvent) => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  constructor(url: string) {
+    this.url = url;
+    instances.push(this);
+  }
+
+  send(data: string) {
+    this.sent.push(data);
+  }
+
+  close() {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.();
+  }
+
+  // Test helpers
+  simulateOpen() {
+    this.readyState = MockWebSocket.OPEN;
+    this.onopen?.();
+  }
+
+  simulateMessage(data: string | ArrayBuffer) {
+    this.onmessage?.({ data } as MessageEvent);
+  }
+
+  simulateClose() {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.();
+  }
+
+  simulateError() {
+    this.onerror?.();
+  }
+}
+
+export const instances: MockWebSocket[] = [];

--- a/frontend/src/lib/transport/__tests__/ws-client-store.integration.test.ts
+++ b/frontend/src/lib/transport/__tests__/ws-client-store.integration.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { ReceiverState, ServerState } from '../../types/state';
+import { MockWebSocket, instances } from './support/fake-ws-backend';
 
 // ─── End-to-end fidelity test: REAL ws-client → REAL radio.svelte store ──────
 //
@@ -28,50 +29,6 @@ type ServerStateWithObservation = ServerState & {
   publicStateSeq?: number;
   fieldStatus?: Record<string, unknown>;
 };
-
-// ─── Minimal WebSocket mock (shapes copied from ws-client.test.ts) ───────────
-
-class MockWebSocket {
-  static CONNECTING = 0;
-  static OPEN = 1;
-  static CLOSING = 2;
-  static CLOSED = 3;
-
-  readyState = MockWebSocket.CONNECTING;
-  binaryType = 'blob';
-  url: string;
-  sent: string[] = [];
-
-  onopen: (() => void) | null = null;
-  onmessage: ((e: MessageEvent) => void) | null = null;
-  onclose: (() => void) | null = null;
-  onerror: (() => void) | null = null;
-
-  constructor(url: string) {
-    this.url = url;
-    instances.push(this);
-  }
-
-  send(data: string) {
-    this.sent.push(data);
-  }
-
-  close() {
-    this.readyState = MockWebSocket.CLOSED;
-    this.onclose?.();
-  }
-
-  simulateOpen() {
-    this.readyState = MockWebSocket.OPEN;
-    this.onopen?.();
-  }
-
-  simulateMessage(data: string | ArrayBuffer) {
-    this.onmessage?.({ data } as MessageEvent);
-  }
-}
-
-const instances: MockWebSocket[] = [];
 
 // ─── Envelope/state fixtures (shapes copied from ws-client.test.ts) ──────────
 

--- a/frontend/src/lib/transport/__tests__/ws-client.test.ts
+++ b/frontend/src/lib/transport/__tests__/ws-client.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { WsCommand, WsMessage } from '../../types/protocol';
 import type { ReceiverState, ServerState } from '../../types/state';
 import type { CommandDeliveryEvent, ControlSessionTransition } from '../ws-client';
+import { MockWebSocket, instances } from './support/fake-ws-backend';
 
 type ServerStateWithObservation = ServerState & {
   observationSeq?: number;
@@ -94,58 +95,6 @@ beforeEach(() => {
 
 // ─── Minimal WebSocket mock ──────────────────────────────────────────────────
 type WsEventName = 'open' | 'message' | 'close' | 'error';
-
-class MockWebSocket {
-  static CONNECTING = 0;
-  static OPEN = 1;
-  static CLOSING = 2;
-  static CLOSED = 3;
-
-  readyState = MockWebSocket.CONNECTING;
-  binaryType = 'blob';
-  url: string;
-  sent: string[] = [];
-
-  onopen: (() => void) | null = null;
-  onmessage: ((e: MessageEvent) => void) | null = null;
-  onclose: (() => void) | null = null;
-  onerror: (() => void) | null = null;
-
-  constructor(url: string) {
-    this.url = url;
-    instances.push(this);
-  }
-
-  send(data: string) {
-    this.sent.push(data);
-  }
-
-  close() {
-    this.readyState = MockWebSocket.CLOSED;
-    this.onclose?.();
-  }
-
-  // Test helpers
-  simulateOpen() {
-    this.readyState = MockWebSocket.OPEN;
-    this.onopen?.();
-  }
-
-  simulateMessage(data: string | ArrayBuffer) {
-    this.onmessage?.({ data } as MessageEvent);
-  }
-
-  simulateClose() {
-    this.readyState = MockWebSocket.CLOSED;
-    this.onclose?.();
-  }
-
-  simulateError() {
-    this.onerror?.();
-  }
-}
-
-const instances: MockWebSocket[] = [];
 
 function makeReceiver(overrides: Partial<ReceiverState> = {}): ReceiverState {
   return {


### PR DESCRIPTION
## Summary

- Extracts the duplicated `MockWebSocket` fake (previously hand-copied into both `ws-client.test.ts` and `ws-client-store.integration.test.ts`) into a single shared `frontend/src/lib/transport/__tests__/support/fake-ws-backend.ts`.
- The shared class is a superset of both prior copies (includes `simulateClose`/`simulateError`, which the integration suite's copy didn't need but the unit suite did); no methods, timings, or semantics were dropped or changed.
- Pure de-duplication — no production code touched. This is MOR-1089 groundwork (U0): upcoming MOR-1089 integration tests need a shared harness instead of a third hand-copied fake.
- Net -30 LOC (66 insertions / 96 deletions across 3 files).

## Verification evidence

- Independent baseline on `origin/main` (fresh worktree + `npm install`): `npx vitest run src/lib/transport` → 3 files / 134 tests, all passing.
- Same command on this branch: 3 files / 134 tests, all passing (identical to baseline).
- `--project fast`: 93 tests passing. `--project isolated`: 41 tests passing. Both match the claimed counts.
- `npx vitest list src/lib/transport`: 134 tests total, all from `http-client.test.ts`, `ws-client.test.ts`, `ws-client-store.integration.test.ts` — none collected from `support/fake-ws-backend.ts`.
- `npm run check`: 0 errors, 0 warnings.
- `npx eslint` on all three changed/added files: clean.
- Line-by-line diff review confirms the new shared class is a faithful superset of both deleted local copies (no dropped methods, no changed timings/semantics), and is test-support only.

## Test plan

- [x] `npx vitest run src/lib/transport` — 134/134 passing
- [x] `npx vitest run src/lib/transport --project fast` — 93/93 passing
- [x] `npx vitest run src/lib/transport --project isolated` — 41/41 passing
- [x] `npx vitest list src/lib/transport` — no tests collected from the new support file
- [x] `npm run check` — 0 errors
- [x] `npx eslint` on the three changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)