### PR TITLE
MOR-1184 PR 2: --for, arm-before-key, bounded release, per-signal exit codes

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking changes
+
+- **CLI: `rigplane ptt on` no longer returns while the rig is keyed.** The
+  command now holds the key for as long as the process runs and unkeys on the
+  way out, so the process that keyed the rig is the one that releases it. A
+  script that ran `rigplane ptt on`, did some work, and then ran
+  `rigplane ptt off` must move to `rigplane ptt on --for SEC` (or keep the
+  `ptt on` process alive for the length of the transmission) — the old shape
+  now blocks at the first command. SIGINT / SIGTERM / SIGHUP unkey and exit
+  128 + the signal (130 / 143 / 129); a duration that simply runs out exits 0;
+  a failed or stuck unkey exits 1 with a warning that the radio may still be
+  transmitting. `ptt off` is unchanged and immediate — it remains the recovery
+  path for a rig left transmitting by some other process (MOR-1184, MOR-1199).
+
 ## [2.11.1] — 2026-06-22
 
 ### Fixed

--- a/src/rigplane/cli/__init__.py
+++ b/src/rigplane/cli/__init__.py
@@ -12,7 +12,7 @@ Usage:
     rigplane audio loopback [--seconds 10]
     rigplane att [VALUE] [--host HOST] [--user USER] [--pass PASS]
     rigplane preamp [VALUE] [--host HOST] [--user USER] [--pass PASS]
-    rigplane ptt {on,off} [--host HOST] [--user USER] [--pass PASS]
+    rigplane ptt [on|off] [--for SEC] [--host HOST] [--user USER] [--pass PASS]
     rigplane antenna [--ant1 on|off] [--ant2 on|off] [--rx-ant1 on|off] [--rx-ant2 on|off]
     rigplane date [YYYY-MM-DD]
     rigplane time [HH:MM]
@@ -30,6 +30,7 @@ import ipaddress
 import json
 import logging
 from logging.handlers import RotatingFileHandler
+from math import isfinite
 import os
 import signal
 import sys
@@ -508,6 +509,50 @@ def _apply_managed_runtime_defaults(args: argparse.Namespace) -> None:
         args.web_rigctld = True
 
 
+def _ptt_hold_seconds(raw: str) -> float:
+    """Parse ``--for``: a finite, positive number of seconds and nothing else.
+
+    Zero and negatives would key the rig for a hot-switch transient or not at
+    all; ``inf`` and ``nan`` would turn a bounded flag into an unbounded hold.
+    There is deliberately no upper bound: the 180 s key-down watchdog belongs
+    to ``TxSafetySupervisor``, is configurable there, and does not exist at
+    all on the unmanaged path every shipped radio still takes — a second limit
+    invented here would imply a guarantee the CLI cannot make. What bounds
+    this hold is the process, and interrupting it always unkeys.
+    """
+    try:
+        seconds = float(raw)
+    except ValueError:
+        raise argparse.ArgumentTypeError(
+            f"{raw!r} is not a number of seconds"
+        ) from None
+    if not isfinite(seconds) or seconds <= 0:
+        raise argparse.ArgumentTypeError(
+            f"{raw!r} must be a positive, finite number of seconds"
+        )
+    return seconds
+
+
+def _finalize_ptt_args(
+    parser: argparse.ArgumentParser, args: argparse.Namespace
+) -> None:
+    """Settle the ``ptt`` argv shapes a declarative parser cannot express.
+
+    ``ptt --for 5`` implies ``on``; a bare ``ptt`` stays an error so that a
+    truncated command line can never key the rig; and ``ptt off --for 5`` is
+    refused rather than quietly ignored, because ``ptt off`` is the recovery
+    path for a rig some other build left transmitting and must stay immediate.
+    """
+    if getattr(args, "command", None) != "ptt":
+        return
+    if args.state == "off" and args.hold_seconds is not None:
+        parser.error("--for applies to 'ptt on'; 'ptt off' unkeys immediately")
+    if args.state is None:
+        if args.hold_seconds is None:
+            parser.error("ptt needs 'on' or 'off', or --for SEC (which implies 'on')")
+        args.state = "on"
+
+
 def _build_parser() -> argparse.ArgumentParser:
     p = _RigplaneArgumentParser(
         prog="rigplane",
@@ -918,8 +963,17 @@ def _build_parser() -> argparse.ArgumentParser:
     ptt_p = sub.add_parser("ptt", help="PTT control")
     ptt_p.add_argument(
         "state",
+        nargs="?",
         choices=["on", "off"],
-        help="PTT state",
+        help="PTT state ('on' is implied by --for)",
+    )
+    ptt_p.add_argument(
+        "--for",
+        dest="hold_seconds",
+        type=_ptt_hold_seconds,
+        default=None,
+        metavar="SEC",
+        help="Transmit for SEC seconds, then unkey (default: until interrupted)",
     )
 
     # cw
@@ -2737,9 +2791,16 @@ _PTT_HOLD_SIGNALS: tuple[signal.Signals, ...] = tuple(
 )
 
 
-async def _ptt_hold(stop: asyncio.Event) -> None:
-    """Wait until a signal ends the hold."""
-    await stop.wait()
+async def _ptt_hold(stop: asyncio.Event, seconds: float | None) -> bool:
+    """Wait out the hold; ``True`` when ``stop`` ended it rather than the clock."""
+    if seconds is None:
+        await stop.wait()
+        return True
+    try:
+        await asyncio.wait_for(stop.wait(), timeout=seconds)
+    except TimeoutError:
+        return False
+    return True
 
 
 async def _ptt_release(radio: Radio, managed: ManagedTxApi | None) -> str | None:
@@ -2759,7 +2820,9 @@ async def _ptt_release(radio: Radio, managed: ManagedTxApi | None) -> str | None
     return f"managed TX refused this session's release ({transition.outcome})"
 
 
-async def _hold_ptt(radio: Radio, managed: ManagedTxApi | None) -> int:
+async def _hold_ptt(
+    radio: Radio, managed: ManagedTxApi | None, seconds: float | None
+) -> int:
     """Hold the key for as long as this command runs, then unkey (MOR-1184).
 
     The signals are handled here rather than left to ``main()``: its
@@ -2779,9 +2842,14 @@ async def _hold_ptt(radio: Radio, managed: ManagedTxApi | None) -> int:
     restore = [(sig, signal.getsignal(sig)) for sig in _PTT_HOLD_SIGNALS]
     for sig in _PTT_HOLD_SIGNALS:
         signal.signal(sig, _wake)
-    print("Transmitting — press Ctrl-C to unkey.", file=sys.stderr)
+    print(
+        "Transmitting — press Ctrl-C to unkey."
+        if seconds is None
+        else f"Transmitting for {seconds:g} s — press Ctrl-C to unkey early.",
+        file=sys.stderr,
+    )
     try:
-        await _ptt_hold(stop)
+        interrupted = await _ptt_hold(stop, seconds)
     finally:
         # Every exit path, including an exception out of the hold.
         failure = await _ptt_release(radio, managed)
@@ -2793,7 +2861,7 @@ async def _hold_ptt(radio: Radio, managed: ManagedTxApi | None) -> int:
         )
         return 1
     print("PTT OFF")
-    return 130  # 128 + SIGINT: only a signal ends the hold
+    return 130 if interrupted else 0  # 128 + SIGINT, or a duration that ran out
 
 
 async def _cmd_ptt(radio: Radio, args: argparse.Namespace) -> int:
@@ -2801,8 +2869,8 @@ async def _cmd_ptt(radio: Radio, args: argparse.Namespace) -> int:
 
     Radios without a managed runtime keep the legacy direct provider write; the
     supervisor reports refusal by return value, so both directions inspect it.
-    ``ptt on`` then holds the key until it is interrupted, so the process that
-    took the lease is the process that releases it.
+    ``ptt on`` then holds the key until it is interrupted or ``--for`` runs out,
+    so the process that took the lease is the process that releases it.
     """
     on = args.state == "on"
     managed = ManagedTxApi.bind(radio, _CLI_TX_OWNER)
@@ -2831,7 +2899,7 @@ async def _cmd_ptt(radio: Radio, args: argparse.Namespace) -> int:
     print(f"PTT {'ON' if on else 'OFF'}")
     if not on:
         return 0
-    return await _hold_ptt(radio, managed)
+    return await _hold_ptt(radio, managed, args.hold_seconds)
 
 
 async def _cmd_cw(radio: Radio, args: argparse.Namespace) -> int:
@@ -3775,6 +3843,7 @@ def main() -> None:
 
     parser = _build_parser()
     args = parser.parse_args()
+    _finalize_ptt_args(parser, args)
 
     # Enable debug logging with ICOM_DEBUG=1 or any truthy value
     # ICOM_LOG_FILE=/path/to/file.log — log to file (default: platform cache logs)

--- a/src/rigplane/cli/__init__.py
+++ b/src/rigplane/cli/__init__.py
@@ -24,7 +24,8 @@ __all__ = ["main", "check_ports_available"]
 
 import argparse
 import asyncio
-from dataclasses import replace
+from contextlib import contextmanager
+from dataclasses import dataclass, field, replace
 import errno
 import ipaddress
 import json
@@ -34,7 +35,7 @@ from math import isfinite
 import os
 import signal
 import sys
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
 from pathlib import Path
 import time
 import uuid
@@ -2791,13 +2792,61 @@ _PTT_HOLD_SIGNALS: tuple[signal.Signals, ...] = tuple(
 )
 
 
-async def _ptt_hold(stop: asyncio.Event, seconds: float | None) -> bool:
-    """Wait out the hold; ``True`` when ``stop`` ended it rather than the clock."""
+# The hold keeps these signals across the unkey — a second Ctrl-C must not walk
+# away from a transmitting rig — so a release that never returns would leave
+# SIGKILL as the only way out, and SIGKILL unkeys nothing. Five seconds is far
+# longer than a CI-V or managed-TX write takes and still an answer.
+_PTT_RELEASE_TIMEOUT = 5.0
+
+
+@dataclass
+class _PttArm:
+    """What a held transmission is armed with, before it keys (MOR-1199)."""
+
+    stop: asyncio.Event = field(default_factory=asyncio.Event)
+    signum: int | None = None
+
+    @property
+    def exit_code(self) -> int:
+        """128 + the signal that ended the hold — what a shell reports itself."""
+        return 0 if self.signum is None else 128 + self.signum
+
+
+@contextmanager
+def _armed_for_ptt_hold() -> Iterator[_PttArm]:
+    """Own the hold's signals from before the key until after the release.
+
+    Arming ahead of the key is what makes the gap between them survivable: a
+    signal landing in it finds either a rig that never transmitted (the key is
+    skipped) or a hold already in place to unkey it. Restoring only after the
+    release keeps the same guarantee over the unkey.
+    """
+    loop = asyncio.get_running_loop()
+    arm = _PttArm()
+
+    def _wake(signum: int, frame: Any) -> None:
+        # Recorded synchronously: ``stop`` is only set on the loop's next pass,
+        # which is already too late for the check ahead of the key.
+        arm.signum = signum
+        loop.call_soon_threadsafe(arm.stop.set)
+
+    restore = [(sig, signal.getsignal(sig)) for sig in _PTT_HOLD_SIGNALS]
+    for sig in _PTT_HOLD_SIGNALS:
+        signal.signal(sig, _wake)
+    try:
+        yield arm
+    finally:
+        for sig, handler in restore:
+            signal.signal(sig, handler)
+
+
+async def _ptt_hold(arm: _PttArm, seconds: float | None) -> bool:
+    """Wait out the hold; ``True`` when a signal ended it rather than the clock."""
     if seconds is None:
-        await stop.wait()
+        await arm.stop.wait()
         return True
     try:
-        await asyncio.wait_for(stop.wait(), timeout=seconds)
+        await asyncio.wait_for(arm.stop.wait(), timeout=seconds)
     except TimeoutError:
         return False
     return True
@@ -2821,27 +2870,39 @@ async def _ptt_release(radio: Radio, managed: ManagedTxApi | None) -> str | None
 
 
 async def _hold_ptt(
-    radio: Radio, managed: ManagedTxApi | None, seconds: float | None
+    radio: Radio, managed: ManagedTxApi | None, seconds: float | None, arm: _PttArm
 ) -> int:
-    """Hold the key for as long as this command runs, then unkey (MOR-1184).
+    """Key, hold for as long as this command runs, then unkey (MOR-1184).
 
-    The signals are handled here rather than left to ``main()``: its
-    ``KeyboardInterrupt`` path force-exits through ``os._exit`` about a second
-    later, which truncates any unkey still in flight, and it has already fixed
-    the exit code by then, so a failed unkey could be neither awaited nor
-    reported. Owning them keeps the unkey on the ordinary return path. They
-    stay installed across the unkey too — a second Ctrl-C must not walk away
-    from a transmitting rig.
+    Runs inside ``_armed_for_ptt_hold``, which owns the signals rather than
+    leaving them to ``main()``: its ``KeyboardInterrupt`` path force-exits
+    through ``os._exit`` about a second later, which truncates any unkey still
+    in flight, and it has already fixed the exit code by then, so a failed
+    unkey could be neither awaited nor reported. Arming outside this call is
+    what lets the key be skipped when the signal beat it here.
     """
-    loop = asyncio.get_running_loop()
-    stop = asyncio.Event()
-
-    def _wake(signum: int, frame: Any) -> None:
-        loop.call_soon_threadsafe(stop.set)
-
-    restore = [(sig, signal.getsignal(sig)) for sig in _PTT_HOLD_SIGNALS]
-    for sig in _PTT_HOLD_SIGNALS:
-        signal.signal(sig, _wake)
+    if arm.signum is not None:
+        # Signalled between the arming and the key. A rig that never
+        # transmitted needs no unkey, and keying on the way out of the process
+        # is the one outcome the ordering exists to prevent.
+        return arm.exit_code
+    if managed is None:
+        await radio.set_ptt(True)
+    else:
+        transition = await managed.set_ptt(True)
+        if transition.outcome not in _TX_KEY_ACCEPTED:
+            # Announcing a transmission here would tell the operator the rig
+            # is keyed when the supervisor refused the key.
+            print(
+                f"Error: managed TX refused PTT on ({transition.outcome}).",
+                file=sys.stderr,
+            )
+            return 1
+    # Ordering invariant: both lines announce a rig that is keyed AND a process
+    # that already owns its signals, so neither may move above the arming or
+    # the key. The signal tests use the hint as their handshake — printed
+    # early, it invites a signal the process cannot yet answer with an unkey.
+    print("PTT ON")
     print(
         "Transmitting — press Ctrl-C to unkey."
         if seconds is None
@@ -2849,19 +2910,25 @@ async def _hold_ptt(
         file=sys.stderr,
     )
     try:
-        interrupted = await _ptt_hold(stop, seconds)
+        interrupted = await _ptt_hold(arm, seconds)
     finally:
-        # Every exit path, including an exception out of the hold.
-        failure = await _ptt_release(radio, managed)
-        for sig, handler in restore:
-            signal.signal(sig, handler)
+        # Every exit path, including an exception out of the hold, and bounded
+        # (see ``_PTT_RELEASE_TIMEOUT``) so a stuck release is an answer.
+        try:
+            failure = await asyncio.wait_for(
+                _ptt_release(radio, managed), timeout=_PTT_RELEASE_TIMEOUT
+            )
+        except TimeoutError:
+            failure = f"unkey timed out after {_PTT_RELEASE_TIMEOUT:g} s"
     if failure is not None:
         print(
             f"Error: {failure}; the radio may still be transmitting.", file=sys.stderr
         )
         return 1
     print("PTT OFF")
-    return 130 if interrupted else 0  # 128 + SIGINT, or a duration that ran out
+    # 130 / 143 / 129 for the signal that ended it, 0 for a duration that ran
+    # out — a caller cannot tell a Ctrl-C from a SIGTERM if both report 130.
+    return arm.exit_code if interrupted else 0
 
 
 async def _cmd_ptt(radio: Radio, args: argparse.Namespace) -> int:
@@ -2869,24 +2936,20 @@ async def _cmd_ptt(radio: Radio, args: argparse.Namespace) -> int:
 
     Radios without a managed runtime keep the legacy direct provider write; the
     supervisor reports refusal by return value, so both directions inspect it.
-    ``ptt on`` then holds the key until it is interrupted or ``--for`` runs out,
-    so the process that took the lease is the process that releases it.
+    ``ptt on`` arms its signals, keys, then holds until it is interrupted or
+    ``--for`` runs out, so the process that took the lease is the process that
+    releases it. ``ptt off`` owns no signals and stays immediate: it is the
+    recovery path for a rig some other process left transmitting.
     """
-    on = args.state == "on"
     managed = ManagedTxApi.bind(radio, _CLI_TX_OWNER)
+    if args.state == "on":
+        with _armed_for_ptt_hold() as arm:
+            return await _hold_ptt(radio, managed, args.hold_seconds, arm)
     if managed is None:
-        await radio.set_ptt(on)
+        await radio.set_ptt(False)
     else:
-        transition = await managed.set_ptt(on)
+        transition = await managed.set_ptt(False)
         if transition.outcome not in _TX_KEY_ACCEPTED:
-            if on:
-                # Printing "PTT ON" here would tell the operator the rig is
-                # transmitting when the supervisor refused the key.
-                print(
-                    f"Error: managed TX refused PTT on ({transition.outcome}).",
-                    file=sys.stderr,
-                )
-                return 1
             # A refused release answers STALE, which means either nothing was
             # keyed or another owner holds the lease. Neither is actionable
             # here — a non-owner cannot force a release by design — so report
@@ -2896,10 +2959,8 @@ async def _cmd_ptt(radio: Radio, args: argparse.Namespace) -> int:
                 f"({transition.outcome}); another session may still hold TX.",
                 file=sys.stderr,
             )
-    print(f"PTT {'ON' if on else 'OFF'}")
-    if not on:
-        return 0
-    return await _hold_ptt(radio, managed, args.hold_seconds)
+    print("PTT OFF")
+    return 0
 
 
 async def _cmd_cw(radio: Radio, args: argparse.Namespace) -> int:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,6 +13,7 @@ from rigplane.cli import (
     _HOST_NOT_SET,
     _build_backend_config,
     _build_parser,
+    _finalize_ptt_args,
     _parse_frequency,
     _resolve_password,
     check_ports_available,
@@ -202,6 +203,41 @@ class TestBuildParser:
         p = _build_parser()
         args = p.parse_args(["ptt", "off"])
         assert args.state == "off"
+
+    def test_ptt_for_implies_on(self):
+        # ``rigplane ptt --for 5`` is the shape the operator reaches for; the
+        # positional stays available so ``ptt on --for 5`` means the same.
+        p = _build_parser()
+        for argv in (["ptt", "--for", "5"], ["ptt", "on", "--for", "5"]):
+            args = p.parse_args(argv)
+            _finalize_ptt_args(p, args)
+            assert (args.state, args.hold_seconds) == ("on", 5.0)
+
+    def test_ptt_on_without_for_holds_indefinitely(self):
+        p = _build_parser()
+        args = p.parse_args(["ptt", "on"])
+        _finalize_ptt_args(p, args)
+        assert (args.state, args.hold_seconds) == ("on", None)
+
+    @pytest.mark.parametrize(
+        "argv",
+        [
+            ["ptt"],  # bare ``ptt`` must not key the rig by accident
+            ["ptt", "--for", "0"],  # a 0 s key is a hot-switch transient
+            ["ptt", "--for", "-1"],
+            ["ptt", "--for", "inf"],  # a bounded flag that never ends
+            ["ptt", "--for", "nan"],
+            ["ptt", "--for", "soon"],
+            # ``ptt off`` is the recovery path for a rig another build left
+            # keyed; a duration on it is meaningless, so reject it explicitly.
+            ["ptt", "off", "--for", "5"],
+        ],
+    )
+    def test_ptt_rejects_unusable_argv(self, argv):
+        p = _build_parser()
+        with pytest.raises(SystemExit) as exc:
+            _finalize_ptt_args(p, p.parse_args(argv))
+        assert exc.value.code == 2
 
     def test_cw(self):
         p = _build_parser()

--- a/tests/test_cli_async.py
+++ b/tests/test_cli_async.py
@@ -501,7 +501,7 @@ class TestCmdMeter:
 class TestCmdPtt:
     @pytest.mark.asyncio
     async def test_ptt_on(self, mock_radio, held, capsys) -> None:
-        args = Namespace(state="on")
+        args = Namespace(state="on", hold_seconds=None)
         rc = await _cmd_ptt(mock_radio, args)
         assert rc == 130
         assert mock_radio.set_ptt.await_args_list == [call(True), call(False)]
@@ -584,7 +584,7 @@ class TestCmdPttManagedIngress:
         assert ManagedTxApi.bind(shipped, TxOwner(TxSource.SDK, "probe")) is None
         shipped.set_ptt = _record
 
-        assert await _cmd_ptt(shipped, Namespace(state="on")) == 130
+        assert await _cmd_ptt(shipped, Namespace(state="on", hold_seconds=None)) == 130
         assert writes == [True, False]  # the hold keys and unkeys through it
         assert capsys.readouterr().out.splitlines() == ["PTT ON", "PTT OFF"]
 
@@ -603,7 +603,7 @@ class TestCmdPttManagedIngress:
         # did land — it is an accepting outcome, not a rejection.
         radio = _FakeManagedRadio(on=outcome, off=outcome)
 
-        assert await _cmd_ptt(radio, Namespace(state="on")) == 130
+        assert await _cmd_ptt(radio, Namespace(state="on", hold_seconds=None)) == 130
         assert _kinds(radio.supervisor) == [
             (True, None),
             (False, TxReleaseReason.OPERATOR_RELEASE),  # the hold's own unkey
@@ -621,9 +621,9 @@ class TestCmdPttManagedIngress:
     async def test_tx_owner_is_one_stable_identity_per_process(self, held) -> None:
         first, second = _FakeManagedRadio(), _FakeManagedRadio()
 
-        await _cmd_ptt(first, Namespace(state="on"))
+        await _cmd_ptt(first, Namespace(state="on", hold_seconds=None))
         await _cmd_ptt(first, Namespace(state="off"))
-        await _cmd_ptt(second, Namespace(state="on"))
+        await _cmd_ptt(second, Namespace(state="on", hold_seconds=None))
 
         calls = first.supervisor.calls + second.supervisor.calls
         owners = [owner for _keyed, owner, _reason in calls]
@@ -645,7 +645,7 @@ class TestCmdPttManagedIngress:
         # the rig is not transmitting on its behalf.
         radio = _FakeManagedRadio(on=outcome)
 
-        rc = await _cmd_ptt(radio, Namespace(state="on"))
+        rc = await _cmd_ptt(radio, Namespace(state="on", hold_seconds=None))
 
         assert rc == 1
         captured = capsys.readouterr()
@@ -693,14 +693,15 @@ class _FakeShippedRadio:
 
 @pytest.fixture
 def held(monkeypatch):
-    """End the hold at once — no test may block on a real signal."""
-    entered: list[asyncio.Event] = []
+    """Drive the hold by hand — no test may block, or wait out a duration."""
+    seen: list[float | None] = []
 
-    async def _hold(stop: asyncio.Event) -> None:
-        entered.append(stop)
+    async def _hold(stop: asyncio.Event, seconds: float | None) -> bool:
+        seen.append(seconds)
+        return seconds is None  # only a signal can end an unbounded hold
 
     monkeypatch.setattr(cli_module, "_ptt_hold", _hold)
-    return entered
+    return seen
 
 
 class TestCmdPttHold:
@@ -709,10 +710,10 @@ class TestCmdPttHold:
         before = [signal.getsignal(sig) for sig in _PTT_HOLD_SIGNALS]
         radio = _FakeShippedRadio()
 
-        rc = await _cmd_ptt(radio, Namespace(state="on"))
+        rc = await _cmd_ptt(radio, Namespace(state="on", hold_seconds=None))
 
         assert rc == 130  # 128 + SIGINT, as any interrupted command reports
-        assert len(held) == 1
+        assert held == [None]  # unbounded: no --for was given
         assert radio.writes == [True, False]  # the keying process is the unkeying one
         captured = capsys.readouterr()
         assert captured.out.splitlines() == ["PTT ON", "PTT OFF"]
@@ -730,12 +731,25 @@ class TestCmdPttHold:
         }
 
     @pytest.mark.asyncio
+    async def test_for_bounds_the_hold_and_exits_zero(self, held, capsys) -> None:
+        rc = await _cmd_ptt(
+            radio := _FakeShippedRadio(), Namespace(state="on", hold_seconds=5.0)
+        )
+
+        assert rc == 0  # the duration ran out; nothing went wrong
+        assert held == [5.0]  # and it is the duration that was asked for
+        assert radio.writes == [True, False]
+        captured = capsys.readouterr()
+        assert captured.out.splitlines() == ["PTT ON", "PTT OFF"]
+        assert "5 s" in captured.err  # the deadline is on screen while it holds
+
+    @pytest.mark.asyncio
     async def test_a_refused_key_never_enters_the_hold(self, held, capsys) -> None:
         # Holding on a key the supervisor refused would block on a rig that is
         # not transmitting, then "release" a lease this session never took.
         radio = _FakeManagedRadio(on=TxOutcome.BUSY)
 
-        rc = await _cmd_ptt(radio, Namespace(state="on"))
+        rc = await _cmd_ptt(radio, Namespace(state="on", hold_seconds=None))
 
         assert rc == 1
         assert held == []
@@ -750,7 +764,7 @@ class TestCmdPttHold:
         # transmitting and the operator has been told the command finished.
         radio = _FakeShippedRadio(unkey_error=OSError("transport gone"))
 
-        rc = await _cmd_ptt(radio, Namespace(state="on"))
+        rc = await _cmd_ptt(radio, Namespace(state="on", hold_seconds=None))
 
         assert rc == 1
         captured = capsys.readouterr()
@@ -765,7 +779,7 @@ class TestCmdPttHold:
         # lease, so a refused release means the rig may still be keyed on it.
         radio = _FakeManagedRadio(off=TxOutcome.STALE)
 
-        rc = await _cmd_ptt(radio, Namespace(state="on"))
+        rc = await _cmd_ptt(radio, Namespace(state="on", hold_seconds=None))
 
         assert rc == 1
         captured = capsys.readouterr()
@@ -788,7 +802,7 @@ class TestCmdPttHold:
 
         radio.set_ptt = _watch  # type: ignore[method-assign]
 
-        assert await _cmd_ptt(radio, Namespace(state="on")) == 130
+        assert await _cmd_ptt(radio, Namespace(state="on", hold_seconds=None)) == 130
         assert during and during[0] is not before  # the hold's, not the default
         assert signal.getsignal(signal.SIGINT) is before  # and restored after
 
@@ -796,22 +810,24 @@ class TestCmdPttHold:
     async def test_the_unkey_runs_when_the_hold_itself_raises(
         self, monkeypatch
     ) -> None:
-        async def _boom(stop: asyncio.Event) -> None:
+        async def _boom(stop: asyncio.Event, seconds: float | None) -> bool:
             raise RuntimeError("hold blew up")
 
         monkeypatch.setattr(cli_module, "_ptt_hold", _boom)
         radio = _FakeShippedRadio()
 
         with pytest.raises(RuntimeError):
-            await _cmd_ptt(radio, Namespace(state="on"))
+            await _cmd_ptt(radio, Namespace(state="on", hold_seconds=None))
 
         assert radio.writes == [True, False]
 
     @pytest.mark.asyncio
-    async def test_the_hold_ends_when_its_event_is_set(self) -> None:
+    async def test_the_hold_distinguishes_its_clock_from_its_event(self) -> None:
         stop = asyncio.Event()
+        assert await _ptt_hold(stop, 0.01) is False  # ran out, nobody asked
         stop.set()
-        await _ptt_hold(stop)  # the real waiter, and it returns
+        assert await _ptt_hold(stop, None) is True  # unbounded, ended by event
+        assert await _ptt_hold(stop, 3600.0) is True  # event beats the clock
 
 
 _PTT_SIGNAL_CHILD = '''\

--- a/tests/test_cli_async.py
+++ b/tests/test_cli_async.py
@@ -1,6 +1,7 @@
 """Tests for CLI async command handlers using mocked IcomRadio."""
 
 import asyncio
+import contextlib
 import json
 import os
 import signal
@@ -28,8 +29,10 @@ from rigplane.cli import (
     _cmd_ptt,
     _cmd_scope,
     _cmd_status,
+    _armed_for_ptt_hold,
     _PTT_HOLD_SIGNALS,
     _ptt_hold,
+    _PttArm,
     _run,
     main,
 )
@@ -696,9 +699,12 @@ def held(monkeypatch):
     """Drive the hold by hand — no test may block, or wait out a duration."""
     seen: list[float | None] = []
 
-    async def _hold(stop: asyncio.Event, seconds: float | None) -> bool:
+    async def _hold(arm: _PttArm, seconds: float | None) -> bool:
         seen.append(seconds)
-        return seconds is None  # only a signal can end an unbounded hold
+        if seconds is not None:
+            return False  # the clock ran out
+        arm.signum = int(signal.SIGINT)  # only a signal ends an unbounded hold
+        return True
 
     monkeypatch.setattr(cli_module, "_ptt_hold", _hold)
     return seen
@@ -823,11 +829,87 @@ class TestCmdPttHold:
 
     @pytest.mark.asyncio
     async def test_the_hold_distinguishes_its_clock_from_its_event(self) -> None:
-        stop = asyncio.Event()
-        assert await _ptt_hold(stop, 0.01) is False  # ran out, nobody asked
-        stop.set()
-        assert await _ptt_hold(stop, None) is True  # unbounded, ended by event
-        assert await _ptt_hold(stop, 3600.0) is True  # event beats the clock
+        arm = _PttArm()
+        assert await _ptt_hold(arm, 0.01) is False  # ran out, nobody asked
+        arm.stop.set()
+        assert await _ptt_hold(arm, None) is True  # unbounded, ended by event
+        assert await _ptt_hold(arm, 3600.0) is True  # event beats the clock
+
+
+# ---------------------------------------------------------------------------
+# _cmd_ptt — arm before the key, bound the unkey, report the signal (MOR-1199)
+# ---------------------------------------------------------------------------
+
+
+class TestCmdPttArming:
+    @pytest.mark.asyncio
+    async def test_a_signal_before_the_key_never_transmits(
+        self, held, monkeypatch, capsys
+    ) -> None:
+        # Arming first only buys anything if the key is then skipped: a
+        # process that has already been told to stop must not go on to key a
+        # rig it will not be around to unkey.
+        @contextlib.contextmanager
+        def _already_signalled():
+            with _armed_for_ptt_hold() as arm:
+                arm.signum = int(signal.SIGTERM)
+                yield arm
+
+        monkeypatch.setattr(cli_module, "_armed_for_ptt_hold", _already_signalled)
+        radio = _FakeShippedRadio()
+
+        rc = await _cmd_ptt(radio, Namespace(state="on", hold_seconds=None))
+
+        assert rc == 143  # 128 + SIGTERM
+        assert radio.writes == []  # never keyed, so there is nothing to unkey
+        assert held == []  # and no hold was entered
+        assert capsys.readouterr().out == ""  # nor was anything announced
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "signum, code",
+        [(signal.SIGINT, 130), (signal.SIGHUP, 129), (signal.SIGTERM, 143)],
+    )
+    async def test_the_exit_code_reflects_the_signal_that_ended_the_hold(
+        self, signum, code, monkeypatch
+    ) -> None:
+        # A wrapper that retries on Ctrl-C but obeys a SIGTERM cannot tell the
+        # two apart if every ending reports 130.
+        async def _hold(arm: _PttArm, seconds: float | None) -> bool:
+            arm.signum = int(signum)
+            return True
+
+        monkeypatch.setattr(cli_module, "_ptt_hold", _hold)
+        radio = _FakeShippedRadio()
+
+        assert await _cmd_ptt(radio, Namespace(state="on", hold_seconds=None)) == code
+        assert radio.writes == [True, False]
+
+    @pytest.mark.asyncio
+    async def test_a_hanging_unkey_is_bounded_and_reported(
+        self, held, monkeypatch, capsys
+    ) -> None:
+        # The hold still owns the signals across the release, so an unbounded
+        # wait on a transport that never answers leaves the operator SIGKILL
+        # — which unkeys nothing — as the only way out.
+        monkeypatch.setattr(cli_module, "_PTT_RELEASE_TIMEOUT", 0.05)
+        radio = _FakeShippedRadio()
+        keyed = radio.set_ptt
+
+        async def _hang(on: bool) -> None:
+            if not on:
+                await asyncio.Event().wait()  # a transport that never answers
+            await keyed(on)
+
+        radio.set_ptt = _hang  # type: ignore[method-assign]
+
+        rc = await _cmd_ptt(radio, Namespace(state="on", hold_seconds=None))
+
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert "PTT OFF" not in captured.out  # it did not claim to have unkeyed
+        assert "timed out" in captured.err
+        assert "may still be transmitting" in captured.err
 
 
 _PTT_SIGNAL_CHILD = '''\
@@ -837,6 +919,7 @@ import sys
 import rigplane.cli as cli
 
 JOURNAL = sys.argv[1]
+WIDEN = float(sys.argv[2]) if len(sys.argv) > 2 else None
 
 
 def note(line):
@@ -863,32 +946,56 @@ class FakeRadio:
 
 
 cli.create_radio = lambda config: FakeRadio()
+
+if WIDEN is not None:  # widen the arm-to-key window so a signal lands inside it
+    import contextlib
+    import time
+
+    armed = cli._armed_for_ptt_hold
+
+    @contextlib.contextmanager
+    def slow_arm():
+        with armed() as arm:
+            note("armed")
+            time.sleep(WIDEN)
+            yield arm
+
+    cli._armed_for_ptt_hold = slow_arm
+
 sys.argv = ["rigplane", "--host", "127.0.0.1", "ptt", "on"]
 cli.main()
 '''
 
 
-@pytest.mark.parametrize("signum", [signal.SIGINT, signal.SIGTERM, signal.SIGHUP])
-def test_a_real_signal_unkeys_the_rig(signum, tmp_path) -> None:
-    # ``main()`` ends in ``os._exit`` and force-exits about a second after a
-    # signal, so a handler that merely exists is no evidence that it is
-    # installed or that the unkey survives. Send the real signal to a real
-    # ``main()`` and read back what the radio saw.
+def _signal_a_real_ptt_hold(
+    tmp_path, signum: signal.Signals, widen: float | None = None
+) -> tuple[int, list[str], list[str]]:
+    """Run a real ``rigplane ptt on``, signal it, and report what it did."""
     child = tmp_path / "child.py"
     child.write_text(_PTT_SIGNAL_CHILD)
     journal, err_path = tmp_path / "journal.txt", tmp_path / "err.txt"
+    journal.write_text("")
+    argv = [sys.executable, str(child), str(journal)]
+    argv += [] if widen is None else [str(widen)]
     with err_path.open("w") as err_fh:
         proc = subprocess.Popen(
-            [sys.executable, str(child), str(journal)],
+            argv,
             stdout=subprocess.PIPE,
             stderr=err_fh,
             text=True,
             env={**os.environ, "PYTHONUNBUFFERED": "1", "ICOM_DEBUG": "0"},
         )
-        # The hint is printed once the hold owns both signals, so it is the
-        # handshake that makes this test free of a race with process start-up.
+
+        # Handshake, so the signal cannot race process start-up: the hint is
+        # printed once the hold owns the signals and the rig is keyed, and
+        # the journal's "armed" line once they are owned but before the key.
+        def _reached() -> bool:
+            if widen is not None:
+                return "armed" in journal.read_text()
+            return "Ctrl-C" in err_path.read_text()
+
         deadline = time.monotonic() + 60
-        while "Ctrl-C" not in err_path.read_text():
+        while not _reached():
             assert proc.poll() is None and time.monotonic() < deadline, (
                 f"child never reached the hold: {err_path.read_text()}"
             )
@@ -898,10 +1005,40 @@ def test_a_real_signal_unkeys_the_rig(signum, tmp_path) -> None:
         # ``os._exit``, which flushes no stdio, so a piped stdout is lost
         # without it. Pre-existing and not specific to ``ptt``.
         out, _ = proc.communicate(timeout=60)
+    return proc.returncode, out.splitlines(), journal.read_text().split()
 
-    assert journal.read_text().split() == ["key", "unkey"]
-    assert out.splitlines() == ["PTT ON", "PTT OFF"]
-    assert proc.returncode == 130
+
+@pytest.mark.parametrize("signum", [signal.SIGINT, signal.SIGTERM, signal.SIGHUP])
+def test_a_real_signal_unkeys_the_rig(signum, tmp_path) -> None:
+    # ``main()`` ends in ``os._exit`` and force-exits about a second after a
+    # signal, so a handler that merely exists is no evidence that it is
+    # installed or that the unkey survives. Send the real signal to a real
+    # ``main()`` and read back what the radio saw.
+    rc, out, journal = _signal_a_real_ptt_hold(tmp_path, signum)
+
+    assert journal == ["key", "unkey"]
+    assert out == ["PTT ON", "PTT OFF"]
+    assert rc == 128 + signum  # 130 / 143 / 129, the code a shell reports
+
+
+@pytest.mark.parametrize("signum", [signal.SIGINT, signal.SIGTERM, signal.SIGHUP])
+def test_a_signal_before_the_key_leaves_the_rig_unkeyed(signum, tmp_path) -> None:
+    # The window between owning the signals and issuing the key is real, and
+    # in it the process is interruptible while the rig is not yet keyed. It is
+    # widened here because unwidened it is too short to hit on purpose — and a
+    # rig keyed by a process on its way out is what the ordering prevents.
+    #
+    # All three signals, because SIGINT alone cannot tell arming-first from
+    # arming-after-the-key: unhandled, it raises KeyboardInterrupt, which
+    # unwinds ahead of the key into ``main()``'s own 130 — the same journal,
+    # the same output, the same code. Unhandled SIGHUP kills the process and
+    # unhandled SIGTERM lands in ``main()``'s handler, so only these two prove
+    # the hold's handlers were already installed when the signal arrived.
+    rc, out, journal = _signal_a_real_ptt_hold(tmp_path, signum, widen=1.0)
+
+    assert journal == ["armed"]  # it never keyed, so there was nothing to unkey
+    assert out == []  # and it never announced a transmission
+    assert rc == 128 + signum
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Second PR on MOR-1184. Builds on the merged #2121 (`rigplane ptt on` holds the
key for as long as the process runs and unkeys on SIGINT/SIGTERM/SIGHUP) and
closes the four gaps MOR-1199 tracked between "a signal arrives" and "the rig
is not transmitting", plus the `--for SEC` duration flag.

- **`--for SEC`** — `rigplane ptt --for 5` implies `on`; a bare `ptt` stays an
  error so a truncated command line cannot key the rig; `ptt off --for 5` is
  refused rather than quietly ignored. Zero, negative, `inf` and `nan` are
  rejected at parse time.
- **Arm before keying** — `_armed_for_ptt_hold` installs the handlers *before*
  the key goes out, and `_PttArm` records the signal number **synchronously**
  in the handler (`stop` is only set on the loop's next pass, already too late
  for a check that must happen ahead of the key). A signal landing in the
  arm-to-key window means the rig is never keyed: no write, no hold, no unkey.
- **Bounded release** — `_ptt_release` runs under `asyncio.wait_for` with a 5 s
  `_PTT_RELEASE_TIMEOUT`. The hold keeps its handlers across the unkey (a
  second Ctrl-C must not walk away from a transmitting rig), so an unbounded
  release would leave SIGKILL as the only way out — and SIGKILL unkeys nothing.
  A timed-out release exits 1, warns that the radio may still be transmitting,
  and does not print `PTT OFF`.
- **Per-signal exit codes** — 128 + the signal: 130 SIGINT, 143 SIGTERM,
  129 SIGHUP. A duration that runs out still exits 0. Handlers are restored
  only *after* the release, preserving the second-interrupt property.

`ptt off` is untouched and stays immediate — it remains the recovery path for a
rig some other process left transmitting.

## Why

The window between owning the signals and issuing the key was real: a signal
in it left the rig keyed by a process already on its way out. And because the
hold deliberately holds its handlers across the unkey, a release that never
returned was unrecoverable by any signal the operator could send.

## Breaking change

`rigplane ptt on` no longer returns while the rig is keyed. Scripts that ran
`ptt on`, did work, then `ptt off` must move to `ptt on --for SEC` or keep the
`ptt on` process alive. Written up in **`docs/CHANGELOG.md`, `## [Unreleased]`
-> `### Breaking changes`**.

## Acceptance evidence

Independent verification (separate agent, own probes — not the builder's):

| Property | Evidence |
|---|---|
| Pre-key signal leaves rig unkeyed | Real subprocess, widened arm-to-key window, all three signals: journal `['armed']`, stdout `[]`, rc 130/143/129 |
| Real-signal unkey during the hold | SIGINT/SIGHUP/SIGTERM -> journal `['key','unkey']`, stdout `['PTT ON','PTT OFF']`, rc 130/129/143 |
| Exit code reflects the signal | as above, plus unit parametrization |
| Hanging unkey bounded + reported | rc 1, `timed out` + `may still be transmitting` on stderr, no `PTT OFF` |
| Second-interrupt property | double SIGINT still yields `['key','unkey']` |
| Non-zero on failed unkey / no hold after refused key / one owner per process | unit tests green |

Suite: **8593 passed**, 12 skipped, 5 deselected, 11 xfailed, 1 xpassed
(`pytest tests/ --ignore=tests/integration`). `ruff check` clean,
`ruff format --check` 634 files formatted, `lint-imports` 5 contracts kept /
0 broken.

## Mutation results

Five mutations in a throwaway `git archive` sandbox with its own venv; each
must make at least one test fail.

| # | Mutation | Result | Killed by |
|---|---|---|---|
| a | remove the pre-key signum check | KILLED | `test_a_signal_before_the_key_never_transmits` |
| b | install handlers *after* keying | KILLED | `test_a_signal_before_the_key_leaves_the_rig_unkeyed[SIGTERM]` (130 != 143), `[SIGHUP]` (-1 != 129) |
| c | hard-code exit 130 | KILLED | `test_the_exit_code_reflects_the_signal_that_ended_the_hold[1-129]` |
| d | remove the `wait_for` bound | KILLED | `test_a_hanging_unkey_is_bounded_and_reported` (hung to the 90 s timeout) |
| e | announce above the arming check | KILLED | `test_a_key_the_supervisor_refused_exits_non_zero[tx_busy]` |

Mutation (b) initially **survived**: the pre-key test covered SIGINT only, and
unhandled SIGINT raises `KeyboardInterrupt` that unwinds ahead of the key into
`main()`'s own 130 — same journal, same output, same code, so it passed for
the wrong reason. Parametrizing that test over SIGTERM and SIGHUP (whose
default dispositions differ observably) now pins the arm-before-key invariant.

## Guardrails

Net **319 LOC** vs `git merge-base origin/main HEAD` excluding
`docs/CHANGELOG.md`, against the 400 limit. Three files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
