### PR TITLE
feat: add TX press-gesture recognizer for the App-owned controller

### DIFF
--- a/frontend/src/components-v2/panels/__tests__/tx-ptt-gesture.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/tx-ptt-gesture.test.ts
@@ -1,0 +1,250 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  createPttGesture,
+  type Guard,
+  type PttGestureCommands,
+  type PttGestureDeps,
+  type PttGestureView,
+} from '../tx-ptt-gesture';
+
+function guard(leaseId: string, generation = 1, authorityEpoch = 1): Guard {
+  return { leaseId, generation, authorityEpoch };
+}
+
+interface Harness {
+  view: PttGestureView;
+  commands: PttGestureCommands;
+  deps: PttGestureDeps;
+  setGuard(g: Guard | null): void;
+  setLatched(v: boolean): void;
+  getGuard(): Guard | null;
+}
+
+/**
+ * Builds a fully-controllable fake view/commands/deps triple. `start()`
+ * simulates a synchronous, successful lease acquisition (as the real
+ * TxController does) by installing `startResult` as the live guard — pass
+ * `startResult: null` to simulate a refused start.
+ */
+function makeHarness(options: { startResult?: Guard | null } = {}): Harness {
+  let currentGuard: Guard | null = null;
+  let latched = false;
+  const startResult = options.startResult === undefined ? guard('lease-1') : options.startResult;
+
+  const view: PttGestureView = {
+    guard: () => currentGuard,
+    latched: () => latched,
+  };
+  const commands: PttGestureCommands = {
+    start: vi.fn(() => {
+      currentGuard = startResult;
+    }),
+    latch: vi.fn(() => {
+      latched = true;
+    }),
+    release: vi.fn(() => {
+      latched = false;
+    }),
+  };
+  const deps: PttGestureDeps = {
+    schedule: vi.fn((callback: () => void, ms: number) => setTimeout(callback, ms)),
+    cancel: vi.fn((handle: unknown) => clearTimeout(handle as ReturnType<typeof setTimeout>)),
+  };
+
+  return {
+    view,
+    commands,
+    deps,
+    setGuard: (g) => {
+      currentGuard = g;
+    },
+    setLatched: (v) => {
+      latched = v;
+    },
+    getGuard: () => currentGuard,
+  };
+}
+
+describe('createPttGesture', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('arms nothing on a hold — only up() schedules the release window', () => {
+    const h = makeHarness();
+    const gesture = createPttGesture(h.view, h.commands, h.deps);
+
+    gesture.down();
+
+    expect(h.commands.start).toHaveBeenCalledTimes(1);
+    expect(h.deps.schedule).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(10_000);
+    expect(h.commands.release).not.toHaveBeenCalled();
+  });
+
+  it('arms the window from up(), not down() — long hold then quick re-press still latches', () => {
+    // Pins the timing source: the double-tap window must be measured from
+    // up() (arm time), never from down()-to-down() elapsed time. A
+    // down-to-down gate would treat this long hold + fast re-press as two
+    // unrelated fresh presses (start() again) instead of a latch.
+    const h = makeHarness();
+    const gesture = createPttGesture(h.view, h.commands, h.deps);
+
+    gesture.down();
+    vi.advanceTimersByTime(5_000); // hold far longer than the window
+    gesture.up();
+    vi.advanceTimersByTime(50); // re-press inside the up()-armed window
+    gesture.down();
+
+    expect(h.commands.latch).toHaveBeenCalledTimes(1); // legacy timing would start() again
+    expect(h.commands.start).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(10_000);
+    expect(h.commands.release).not.toHaveBeenCalled();
+  });
+
+  it('releases exactly once at the window boundary (nothing at 299ms, fires at 300ms)', () => {
+    const h = makeHarness();
+    const gesture = createPttGesture(h.view, h.commands, h.deps);
+
+    gesture.down();
+    gesture.up();
+
+    vi.advanceTimersByTime(299);
+    expect(h.commands.release).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(h.commands.release).toHaveBeenCalledTimes(1);
+    expect(h.commands.release).toHaveBeenCalledWith(h.getGuard());
+  });
+
+  it('a second down() inside the window cancels the pending release and latches once', () => {
+    const h = makeHarness();
+    const gesture = createPttGesture(h.view, h.commands, h.deps);
+
+    gesture.down();
+    gesture.up();
+    gesture.down();
+
+    expect(h.deps.cancel).toHaveBeenCalledTimes(1);
+    expect(h.commands.latch).toHaveBeenCalledTimes(1);
+    expect(h.commands.start).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(10_000);
+    expect(h.commands.release).not.toHaveBeenCalled();
+  });
+
+  it('a tap while latched releases directly, without calling start() again', () => {
+    const h = makeHarness();
+    h.setGuard(guard('lease-1'));
+    h.setLatched(true);
+    const gesture = createPttGesture(h.view, h.commands, h.deps);
+
+    gesture.down();
+
+    expect(h.commands.start).not.toHaveBeenCalled();
+    expect(h.commands.release).toHaveBeenCalledTimes(1);
+    expect(h.commands.release).toHaveBeenCalledWith(guard('lease-1'));
+
+    // The up() that follows the unlatch tap must not arm a window either.
+    gesture.up();
+    expect(h.deps.schedule).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(10_000);
+    expect(h.commands.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires the release window with the guard captured at arm time, not the live one', () => {
+    const captured = guard('lease-1', 1, 1);
+    const h = makeHarness({ startResult: captured });
+    const gesture = createPttGesture(h.view, h.commands, h.deps);
+
+    gesture.down();
+    gesture.up();
+
+    // Simulate the live lease moving on (e.g. re-keyed to a new generation)
+    // by some other path entirely, without going through this recognizer.
+    const moved = guard('lease-1', 2, 1);
+    h.setGuard(moved);
+
+    vi.advanceTimersByTime(300);
+
+    expect(h.commands.release).toHaveBeenCalledTimes(1);
+    const releasedWith = (h.commands.release as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+    expect(releasedWith).toBe(captured);
+    expect(releasedWith).not.toBe(moved);
+  });
+
+  it('a bumped token suppresses a stale pending fire even if cancel() is ineffective', () => {
+    const h = makeHarness();
+    // Make cancel a no-op spy so it records the call but does NOT actually
+    // clear the real timer — isolating the token defence from the
+    // explicit-cancellation defence.
+    h.deps.cancel = vi.fn();
+    const gesture = createPttGesture(h.view, h.commands, h.deps);
+
+    gesture.down();
+    gesture.up();
+    gesture.down();
+
+    expect(h.commands.latch).toHaveBeenCalledTimes(1);
+    expect(h.deps.cancel).toHaveBeenCalledTimes(1);
+
+    // The original real timer is still alive (cancel didn't clear it), but
+    // the token no longer matches — it must no-op instead of releasing.
+    vi.advanceTimersByTime(300);
+    expect(h.commands.release).not.toHaveBeenCalled();
+  });
+
+  it('destroy() cancels a pending window, releases the live guard once, then goes inert', () => {
+    const h = makeHarness();
+    const gesture = createPttGesture(h.view, h.commands, h.deps);
+
+    gesture.down();
+    gesture.up();
+
+    gesture.destroy();
+
+    expect(h.deps.cancel).toHaveBeenCalledTimes(1);
+    expect(h.commands.release).toHaveBeenCalledTimes(1);
+    expect(h.commands.release).toHaveBeenCalledWith(h.getGuard());
+
+    gesture.destroy();
+    gesture.down();
+    gesture.up();
+    gesture.cancel();
+
+    expect(h.commands.release).toHaveBeenCalledTimes(1);
+    expect(h.commands.start).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(10_000);
+    expect(h.commands.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancel() behaves exactly like up()', () => {
+    const h = makeHarness();
+    const gesture = createPttGesture(h.view, h.commands, h.deps);
+
+    gesture.down();
+    gesture.cancel();
+
+    expect(h.deps.schedule).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(300);
+    expect(h.commands.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('a refused start arms nothing, and the next press is a fresh start, not a latch', () => {
+    const h = makeHarness({ startResult: null });
+    const gesture = createPttGesture(h.view, h.commands, h.deps);
+
+    gesture.down();
+    expect(h.commands.start).toHaveBeenCalledTimes(1);
+
+    gesture.up();
+    expect(h.deps.schedule).not.toHaveBeenCalled();
+    expect(h.commands.release).not.toHaveBeenCalled();
+
+    gesture.down();
+    expect(h.commands.start).toHaveBeenCalledTimes(2);
+    expect(h.commands.latch).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components-v2/panels/tx-ptt-gesture.ts
+++ b/frontend/src/components-v2/panels/tx-ptt-gesture.ts
@@ -1,0 +1,169 @@
+/**
+ * PTT gesture recognizer — translates raw press/release input (down / up /
+ * cancel) into TX intent commands (start / latch / release).
+ *
+ * This is pure gesture-to-intent translation: it knows nothing about the DOM,
+ * transport, or the TX controller itself. It only talks to the small
+ * `view`/`commands` seams below, so it can be unit-tested without mounting
+ * anything and reused by any input surface (mouse, touch, hardware key).
+ *
+ * Gesture semantics:
+ *  - A fresh `down()` (no pending window, not latched) starts a new lease.
+ *  - `up()` after a successful start arms a `doubleTapMs` release window
+ *    instead of releasing immediately (see WHY below). If nothing else
+ *    happens, the window firing releases the lease — a plain hold-and-let-go.
+ *  - A second `down()` that lands inside that window cancels the pending
+ *    release and latches the SAME lease instead (double-tap-to-lock).
+ *  - A `down()` while latched releases immediately (tap-to-unlock) and does
+ *    not start a new lease.
+ *  - `cancel()` is exactly `up()` — a physical release, however it was
+ *    detected.
+ *  - `destroy()` cancels any pending window and releases the live lease
+ *    (if any) exactly once, then every method becomes an inert no-op.
+ *
+ * WHY the window holds the lease instead of releasing on pointerup:
+ * releasing flips the TX model to phase `'releasing'`, and starting a new
+ * lease while the model is anywhere but `'idle'` is a silent no-op
+ * (tx-controller/model.ts `transition()`, the `'start'` branch). If `up()`
+ * released right away, a fast double-tap would try to `start()` a second
+ * lease while the first was still winding down — that call would simply be
+ * swallowed, and double-tap-to-latch would never be reachable. Holding the
+ * lease open behind a deferred, cancellable release keeps it alive long
+ * enough for a same-lease `latch()` to land instead.
+ */
+
+/** Structurally identical to `TxGuard` in `$lib/runtime/tx-controller/model` — declared locally so this file stays import-free. */
+export type Guard = Readonly<{
+  leaseId: string;
+  generation: number;
+  authorityEpoch: number;
+}>;
+
+export interface PttGestureView {
+  /** Current live TX lease guard, or `null` when no lease is held. */
+  guard(): Guard | null;
+  /** Whether the current lease is latched (locked key-down). */
+  latched(): boolean;
+}
+
+export interface PttGestureCommands {
+  start(): void;
+  latch(guard: Guard): void;
+  release(guard: Guard): void;
+}
+
+export interface PttGestureDeps {
+  schedule(callback: () => void, ms: number): unknown;
+  cancel(handle: unknown): void;
+  /** Double-tap-to-latch window, in ms. Defaults to 300. */
+  doubleTapMs?: number;
+}
+
+export interface PttGesture {
+  down(): void;
+  up(): void;
+  cancel(): void;
+  destroy(): void;
+}
+
+const DEFAULT_DOUBLE_TAP_MS = 300;
+
+export function createPttGesture(
+  view: PttGestureView,
+  commands: PttGestureCommands,
+  deps: PttGestureDeps,
+): PttGesture {
+  const doubleTapMs = deps.doubleTapMs ?? DEFAULT_DOUBLE_TAP_MS;
+
+  let pending: { handle: unknown; guard: Guard } | null = null;
+  let token = 0;
+  let destroyed = false;
+  // True only right after a fresh, successful start() — gates whether the
+  // next up() is allowed to arm a release window at all. False after a
+  // latch, a tap-while-latched release, or a refused start, so the up()
+  // that follows any of those is a plain no-op.
+  let armableOnUp = false;
+
+  function clearPending(): void {
+    if (pending) {
+      deps.cancel(pending.handle);
+      pending = null;
+    }
+  }
+
+  function down(): void {
+    if (destroyed) return;
+    // Defence #2 (token): bump on every down(), independent of the explicit
+    // `clearPending()` cancel below. A timer already in flight from an
+    // earlier up() compares its captured token against this on fire — if a
+    // new down() happened since, the bump alone makes that fire inert even
+    // if cancellation somehow didn't stick.
+    token += 1;
+
+    if (pending) {
+      // Second tap landed inside the window a prior up() armed: cancel the
+      // deferred release and latch onto the still-live lease instead.
+      clearPending();
+      const guard = view.guard();
+      if (guard) commands.latch(guard);
+      armableOnUp = false;
+      return;
+    }
+
+    if (view.latched()) {
+      // Tap-to-unlatch: release immediately, no window, no start().
+      const guard = view.guard();
+      if (guard) commands.release(guard);
+      armableOnUp = false;
+      return;
+    }
+
+    // Fresh press. Starting while a lease is already in flight anywhere but
+    // idle is a silent no-op in the model, so a refused start just leaves
+    // view.guard() null below — armableOnUp then stays false and the
+    // following up() does nothing.
+    commands.start();
+    armableOnUp = view.guard() !== null;
+  }
+
+  function up(): void {
+    if (destroyed) return;
+    if (!armableOnUp) return;
+    armableOnUp = false;
+
+    const guard = view.guard();
+    if (!guard) return;
+
+    // Assign `pending` BEFORE calling deps.schedule(): if `schedule` ever
+    // fired synchronously, filling `pending` only from its return value
+    // would strand a non-null `pending` behind an already-fired timer —
+    // a phantom window that would misread the next down() as a double-tap.
+    const myToken = token;
+    const entry: { handle: unknown; guard: Guard } = { handle: null, guard };
+    pending = entry;
+    entry.handle = deps.schedule(() => {
+      // Defence #2 (token): a down() since arming bumps `token` — a stale
+      // fire no-ops instead of releasing a lease that's moved on.
+      if (myToken !== token) return;
+      pending = null;
+      // Defence #1 (captured guard): release the guard snapshotted AT ARM
+      // TIME, never a fresh `view.guard()` read here — the live lease may
+      // already be a different generation by the time this fires.
+      commands.release(guard);
+    }, doubleTapMs);
+  }
+
+  function cancel(): void {
+    up();
+  }
+
+  function destroy(): void {
+    if (destroyed) return;
+    clearPending();
+    const guard = view.guard();
+    if (guard) commands.release(guard);
+    destroyed = true;
+  }
+
+  return { down, up, cancel, destroy };
+}


### PR DESCRIPTION
MOR-1011, **PR A of 2**. Adds the PTT gesture recognizer that PR B will wire `TxPanel` onto.

## What

A pure gesture-to-intent translator: raw press input (`down` / `up` / `cancel` / `destroy`) becomes TX intent calls (`start` / `latch` / `release`) against three small seams — `PttGestureView` (`guard()`, `latched()`), `PttGestureCommands`, and `PttGestureDeps` (`schedule` / `cancel` / optional `doubleTapMs`). It knows nothing about the DOM, transport, or the controller, so it unit-tests without mounting anything and can be reused by any input surface (mouse, touch, hardware key) — including the mobile layout in MOR-1012.

## Why here, why now

The double-tap-to-latch logic currently lives inline in `TxPanel.svelte` as a local state machine. Extracting it first, with its own tests, keeps PR B a mechanical atomic flip (local machine out, controller in) rather than a rewrite-and-rewire in one diff.

## Inertness guarantee

- The module has **zero imports of any kind** — no runtime import of `$lib/runtime/tx-controller/*`, nothing at all. The `Guard` type is declared structurally.
- **Nothing imports the module** except its own test. Verified: `grep -rn 'tx-ptt-gesture' frontend/src` returns only `__tests__/tx-ptt-gesture.test.ts`.
- Net effect on the running app in this PR: none.

`Guard` was confirmed bidirectionally assignable with `TxGuard` from `tx-controller/model.ts` (same key set, same types) by a standalone `tsc --strict` probe covering all four wiring directions PR B needs, with a negative control to prove the probe had teeth.

## Deliberate behaviour change vs the legacy machine

The double-tap window is armed by **`up()`**, not compared **`down()`-to-`down()`** as the legacy `TxPanel` machine did.

Releasing on pointerup flips the model to phase `'releasing'`, and `start()` during any non-idle phase is a silent no-op (`tx-controller/model.ts`, `transition()`, `'start'` branch). A literal down-to-down gate would therefore fire the release and then have the follow-up `start()` swallowed — a dead key. The `up()`-armed window instead holds the lease open behind a deferred, cancellable release, so a same-lease `latch()` can land.

**Consequence:** a hold longer than the window followed by a re-press inside it now latches, where the legacy machine would have started a new momentary lease. This is the safer of the two simple options (no dead key), the latched state is visible in the UI, and a single tap clears it. It is pinned by a dedicated test so it cannot be silently reverted.

## Two stale-callback defences

1. **Captured guard** — the deferred release fires with the guard snapshotted *at arm time*, never a fresh `view.guard()` read. A lease that has moved on is rejected by the model's `sameGuard` check instead of being released out from under its new owner.
2. **Per-down token** — every `down()` bumps a local token; the pending timer no-ops on mismatch, independently of whether explicit cancellation stuck.

`pending` is also assigned *before* `deps.schedule()` (handle backfilled), so a hypothetical synchronously-firing scheduler cannot strand a phantom window that the next `down()` would misread as a double-tap.

## Test evidence

- `vitest src/components-v2/panels/__tests__/tx-ptt-gesture.test.ts` — **10/10**
- `vitest src/components-v2/panels` — **532/532** across 29 files
- `npm run check` — 4286 files, **0 errors, 0 warnings**
- `npm run lint:boundaries` — clean

## Mutation evidence

Every defence was verified by mutating the source and confirming a test goes red:

| mutation | result |
|---|---|
| release the **live** guard on window expiry instead of the captured one | killed |
| remove the token mismatch check | killed |
| `destroy()` skips the release | killed |
| `down()` while latched calls `start()` instead of `release()` | killed |
| swap the `up()`-armed window for legacy down-to-down timing | killed |

The last row is the point of the timing test: before it existed, that mutation passed the whole suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)