### PR TITLE
docs: document the ptt hold, --for, and recovery semantics

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -480,12 +480,29 @@ rigplane levels
 
 ### `ptt`
 
-Toggle Push-To-Talk.
+Key or unkey the transmitter.
 
 ```bash
 rigplane ptt on
+```
+
+`ptt on` keys the rig and **blocks**, holding the key for as long as the command runs. Press Ctrl-C to unkey and exit; SIGTERM and SIGHUP do the same. The exit code says which one ended the hold — `130` (Ctrl-C / SIGINT), `143` (SIGTERM), `129` (SIGHUP) — while a signal arriving before the key completes skips the key entirely, so the rig never transmits.
+
+For a timed or scripted transmission, use `--for` instead of waiting on a signal:
+
+```bash
+rigplane ptt --for 10
+```
+
+This keys the rig, holds for 10 seconds, then unkeys on its own and exits `0` — `on` is implied by `--for`, so it doesn't need to be written out.
+
+Either way, the unkey on the way out is bounded to 5 seconds. If it fails or hangs past that, the command exits `1` and warns that the radio may still be transmitting.
+
+```bash
 rigplane ptt off
 ```
+
+`ptt off` is unchanged: it unkeys immediately and returns right away. Use it to recover a rig left keyed by a crash, a killed process, or an older rigplane build — it never blocks, so it always gets the chance to run.
 
 !!! danger "Caution"
     Activating PTT will key your transmitter. Ensure your antenna is connected and you are authorized to transmit on the current frequency.

--- a/docs/guide/ic7610-usb-setup.md
+++ b/docs/guide/ic7610-usb-setup.md
@@ -177,8 +177,13 @@ rigplane --backend serial freq 7.074m
 # Set mode
 rigplane --backend serial mode USB
 
-# PTT on/off
-rigplane --backend serial ptt on
+# PTT test: key for 3 seconds, then unkey automatically (exits 0)
+rigplane --backend serial ptt --for 3
+
+# rigplane ptt on (no --for) keys and blocks until you press Ctrl-C —
+# use that form instead when you want to hold the key down by hand
+# ptt off unkeys immediately: the recovery command if a crash or an
+# older rigplane build left the rig transmitting
 rigplane --backend serial ptt off
 
 # CW keying

--- a/src/rigplane/cli/__init__.py
+++ b/src/rigplane/cli/__init__.py
@@ -961,12 +961,19 @@ def _build_parser() -> argparse.ArgumentParser:
     )
 
     # ptt
-    ptt_p = sub.add_parser("ptt", help="PTT control")
+    ptt_p = sub.add_parser(
+        "ptt",
+        help="PTT control ('on' holds until interrupted; 'off' is immediate)",
+    )
     ptt_p.add_argument(
         "state",
         nargs="?",
         choices=["on", "off"],
-        help="PTT state ('on' is implied by --for)",
+        help=(
+            "'on' keys the rig and holds until Ctrl-C/SIGTERM/SIGHUP or --for "
+            "expires; 'off' unkeys immediately and recovers a rig left keyed "
+            "('on' is implied by --for)"
+        ),
     )
     ptt_p.add_argument(
         "--for",


### PR DESCRIPTION
## Summary

MOR-1184, PR 3 of 3. Documents the `ptt` behavior change shipped in
#2121/#2124 (`ptt on` now holds the key until interrupted). Touches
only docs and CLI help strings — no behavior change.

- `docs/guide/cli.md` — rewrites the `ptt` section: `ptt on` blocks and
  holds until Ctrl-C/SIGTERM/SIGHUP (exit 130/143/129), a pre-key
  signal skips the key entirely, `--for SEC` (implies `on`, exits `0`
  on completion), the unkey is bounded to 5 s (exit `1` + warning on
  timeout), and `ptt off` stays an immediate, non-blocking recovery
  path.
- `docs/guide/ic7610-usb-setup.md` — swaps the cheat-sheet's PTT
  example for `ptt --for 3` as the quick, self-terminating test, with
  a comment pointing at `ptt on`/`ptt off` for the manual-hold and
  recovery cases.
- `src/rigplane/cli/__init__.py` — updates the `ptt` subparser and
  `state` argument `help=` strings to match (no argparse structure or
  behavior change).

## Fact-check evidence

Verified every claim in the docs diff against `src/rigplane/cli/__init__.py`:

- Signal set and exit codes: `_PTT_HOLD_SIGNALS` = SIGINT/SIGTERM/SIGHUP;
  `_PttArm.exit_code` = `128 + signum` → 130/143/129. Matches.
- Pre-key signal race: `_hold_ptt` checks `arm.signum is not None` before
  keying and returns without ever calling `set_ptt(True)` — "never
  transmits" is accurate.
- 5 s bounded unkey: `_PTT_RELEASE_TIMEOUT = 5.0`; `_hold_ptt` wraps
  `_ptt_release` in `asyncio.wait_for(..., timeout=_PTT_RELEASE_TIMEOUT)`
  and returns `1` with an "may still be transmitting" message on
  `TimeoutError`. Matches.
- `--for` implies `on`: `_finalize_ptt_args` sets `args.state = "on"`
  when `state is None` and `hold_seconds is not None`; a bare `ptt`
  (neither) is a parser error. Matches.
- `ptt off` unchanged: `_cmd_ptt` takes the immediate branch for
  `state == "off"` with no signal arming and no timeout. Matches.
- Rendered `uv run rigplane ptt --help` after `uv sync --all-extras`
  matches the help strings the docs describe verbatim.

Diff of `src/rigplane/cli/__init__.py` vs `origin/main` confirmed to
touch only two `help=` string literals — no argparse wiring, no
runtime logic.

## Test plan

- [x] `uv run pytest tests/test_cli.py tests/test_cli_async.py -q --tb=short` → 207 passed
- [x] `uv run ruff check src/ tests/` → all checks passed
- [x] `uv run ruff format --check src/ tests/` → 634 files already formatted
- [x] `uv run rigplane ptt --help` rendered and compared against the docs by hand

## Notes

MOR-1200 was filed separately for an unrelated stale REPL section in
`docs/guide/ic705-usb-setup.md` (different radio, different doc) —
out of scope here, left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)