### PR TITLE
feat: render TxPanel from the App-owned TX controller

### DIFF
--- a/frontend/src/components-v2/layout/__tests__/RadioLayout.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/RadioLayout.test.ts
@@ -276,6 +276,26 @@ describe('extractVfoState partial data', () => {
 // RadioLayout component
 // ---------------------------------------------------------------------------
 
+// MOR-1011: TxPanel resolves the App TX controller from Svelte context, which
+// only App.svelte provides. RadioLayout is mounted here without that provider,
+// so stub the host lookup — the layout still renders the real panel tree.
+// (Partial mock: the App-mount test below still needs the real provider.)
+vi.mock('$lib/runtime/tx-controller/app-host', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('$lib/runtime/tx-controller/app-host')>();
+  const idle = { phase: 'idle', intent: null, guard: null, radioTx: 'unknown', fault: null };
+  return {
+    ...actual,
+    getAppTxController: () => ({
+      snapshot: () => idle,
+      subscribe: () => () => {},
+      start: vi.fn(),
+      setIntent: vi.fn(),
+      release: vi.fn(),
+      resetFault: vi.fn(),
+    }),
+  };
+});
+
 vi.mock('$lib/stores/capabilities.svelte', () => ({
   hasTx: vi.fn(() => true),
   hasDualReceiver: vi.fn(() => false),

--- a/frontend/src/components-v2/layout/__tests__/top-row-visual-regression.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/top-row-visual-regression.test.ts
@@ -8,6 +8,23 @@ vi.mock('$lib/stores/layout.svelte', () => ({
   setLayoutMode: vi.fn(),
 }));
 
+// MOR-1011: TxPanel resolves the App TX controller from Svelte context, which
+// only App.svelte provides. RadioLayout is mounted here without that provider,
+// so stub the host lookup — the layout still renders the real panel tree.
+vi.mock('$lib/runtime/tx-controller/app-host', () => {
+  const idle = { phase: 'idle', intent: null, guard: null, radioTx: 'unknown', fault: null };
+  return {
+    getAppTxController: () => ({
+      snapshot: () => idle,
+      subscribe: () => () => {},
+      start: vi.fn(),
+      setIntent: vi.fn(),
+      release: vi.fn(),
+      resetFault: vi.fn(),
+    }),
+  };
+});
+
 vi.mock('../../../skins/registry', () => ({
   resolveSkinId: vi.fn(() => 'desktop-v2'),
 }));

--- a/frontend/src/components-v2/panels/TxPanel.svelte
+++ b/frontend/src/components-v2/panels/TxPanel.svelte
@@ -1,9 +1,21 @@
+<script module lang="ts">
+  /**
+   * Per-instance TX lease identity. Both sidebars list a draggable "tx" panel,
+   * so two TxPanel instances can be mounted at once; the App TX controller keys
+   * lease ownership by sourceId, and a shared id would let one instance release
+   * the other's lease.
+   */
+  let panelSeq = 0;
+</script>
+
 <script lang="ts">
+  import { onDestroy } from 'svelte';
   import { HardwareButton } from '$lib/Button';
   import { ValueControl, normalizedPercentDisplay, rawToPercentDisplay } from '../controls/value-control';
   import { txStatusColor } from './tx-utils';
-  import { getTxAudioControl } from '$lib/runtime/adapters/tx-adapter';
   import { deriveTxProps, getTxHandlers } from '$lib/runtime/adapters/panel-adapters';
+  import { getAppTxController } from '$lib/runtime/tx-controller/app-host';
+  import { createPttGesture } from './tx-ptt-gesture';
   import {
     deriveAutoLanModInputProps,
     setAutoLanModInputEnabled,
@@ -11,13 +23,11 @@
   import { t } from '$lib/i18n';
   import ModInputTxWarning from './ModInputTxWarning.svelte';
 
-  const txAudio = getTxAudioControl();
   const handlers = getTxHandlers();
   let p = $derived(deriveTxProps());
   // MOR-618: opt-in auto LAN MOD-input toggle (shown in the settings modal).
   let autoLan = $derived(deriveAutoLanModInputProps());
 
-  let txActive = $derived(p.txActive);
   let rfPower = $derived(p.rfPower);
   let micGain = $derived(p.micGain);
   let atuActive = $derived(p.atuActive);
@@ -38,8 +48,6 @@
   const onMonToggle = handlers.onMonToggle;
   const onMonLevelChange = handlers.onMonLevelChange;
   const onDriveGainChange = handlers.onDriveGainChange;
-  const onPttOn = handlers.onPttOn;
-  const onPttOff = handlers.onPttOff;
 
   let tuneButtonColor = $derived(txStatusColor(atuActive, atuTuning));
   let showTx = $derived(p.hasTx);
@@ -54,68 +62,54 @@
   let driveGainAvailable = $derived(p.driveGainAvailable ?? true);
 
   // ── PTT (hold-to-talk + double-tap latch) ──
-  const PTT_DOUBLE_TAP_MS = 300;
-  const PTT_SAFETY_MS = 3 * 60 * 1000;
-  let pttMode = $state<'idle' | 'held' | 'latched'>('idle');
-  let lastPttDown = 0;
-  let pttStarting = $state(false);
-  let txError = $state('');
-  let pttPressActive = false;
-  let txStartToken = 0;
-  let pttSafetyTimer: ReturnType<typeof setTimeout> | null = null;
+  // MOR-1011: this panel owns no TX state. It is one lease source among several
+  // (mobile layout, keyboard, future hardware key), so audio start, key
+  // confirmation, safety deadlines and fail-closed release all live in the App
+  // TX controller; the panel only renders that state and feeds it gesture intent.
+  const tx = getAppTxController();
+  const sourceId = `tx-panel-${++panelSeq}`;
+  let leaseSeq = 0;
+  let txState = $state.raw(tx.snapshot());
+  const stopWatchingTx = tx.subscribe((next) => { txState = next; });
 
-  function startPttSafety() {
-    clearPttSafety();
-    pttSafetyTimer = setTimeout(() => { pttMode = 'idle'; onPttOff?.(); txAudio.stopTx(); }, PTT_SAFETY_MS);
-  }
-  function clearPttSafety() {
-    if (pttSafetyTimer) { clearTimeout(pttSafetyTimer); pttSafetyTimer = null; }
-  }
+  const ptt = createPttGesture(
+    { guard: () => txState.guard, latched: () => txState.intent === 'latched' },
+    {
+      start: () => {
+        // A stale fault would swallow the start (the model only leaves 'failed'
+        // on an explicit reset), so clear it as part of the same press.
+        if (txState.phase === 'failed') tx.resetFault();
+        tx.start(sourceId, `${sourceId}-${++leaseSeq}`, 'momentary');
+      },
+      latch: (guard) => tx.setIntent(sourceId, guard, 'latched'),
+      release: (guard) => tx.release(sourceId, guard),
+    },
+    {
+      schedule: (callback, ms) => setTimeout(callback, ms),
+      cancel: (handle) => clearTimeout(handle as ReturnType<typeof setTimeout>),
+    },
+  );
 
-  async function engageTx(token: number): Promise<boolean> {
-    pttStarting = true;
-    txError = '';
-    const err = await txAudio.startTx();
-    pttStarting = false;
-    if (token !== txStartToken || pttMode !== 'held' || !pttPressActive) {
-      if (!err) txAudio.stopTx();
-      return false;
-    }
-    if (err) {
-      txError = err;
-      pttMode = 'idle';
-      lastPttDown = 0;
-      return false;
-    }
-    onPttOn?.();
-    return true;
-  }
+  // Unsubscribe BEFORE the teardown release: the release is fail-closed and must
+  // run to completion inside the controller, not bounce back into a component
+  // that is already being destroyed.
+  onDestroy(() => { stopWatchingTx(); ptt.destroy(); });
 
-  async function pttDown() {
-    if (pttStarting) return;
-    const now = Date.now();
-    if (pttMode === 'latched') { pttPressActive = false; txStartToken += 1; pttMode = 'idle'; onPttOff?.(); txAudio.stopTx(); clearPttSafety(); return; }
-    if (now - lastPttDown < PTT_DOUBLE_TAP_MS && pttMode === 'held') {
-      pttPressActive = false; pttMode = 'latched'; startPttSafety(); lastPttDown = 0; return;
-    }
-    lastPttDown = now;
-    pttPressActive = true;
-    pttMode = 'held';
-    const token = ++txStartToken;
-    if (await engageTx(token)) {
-      startPttSafety();
-    }
-  }
-
-  function pttUp() {
-    pttPressActive = false;
-    txStartToken += 1;
-    if (pttMode === 'held') {
-      setTimeout(() => {
-        if (pttMode === 'held') { pttMode = 'idle'; onPttOff?.(); txAudio.stopTx(); clearPttSafety(); }
-      }, PTT_DOUBLE_TAP_MS);
-    }
-  }
+  let owned = $derived(txState.guard !== null);
+  let starting = $derived(txState.phase === 'audio-start-pending');
+  let keyed = $derived(txState.phase === 'key-confirm-pending' || txState.phase === 'active');
+  let latched = $derived(txState.intent === 'latched');
+  let busy = $derived(txState.phase === 'releasing');
+  let fault = $derived(txState.fault);
+  // Controller authority wins; the props snapshot is only a fallback for the
+  // idle case, where the controller never observes PTT at all.
+  let rf = $derived(
+    txState.radioTx !== 'unknown'
+      ? txState.radioTx
+      : (p.txActiveAvailable ?? true)
+        ? (p.txActive ? 'on' : 'off')
+        : 'unknown',
+  );
 
   // Settings modal
   let settingsOpen = $state(false);
@@ -155,23 +149,23 @@
 {#if showTx}
   <div class="tx-panel" bind:this={modalAnchor}>
     <!-- TX indicator strip -->
-    <div class="tx-strip" class:tx-active={txActive}>
-      {txActive ? '● TX' : '○ RX'}
+    <div class="tx-strip" class:tx-active={rf === 'on'} data-testid="tx-strip" data-rf={rf}>
+      {rf === 'on' ? '● TX' : rf === 'off' ? '○ RX' : '○ ---'}
     </div>
 
     <button
       class="ptt-button"
-      class:ptt-held={pttMode === 'held'}
-      class:ptt-latched={pttMode === 'latched'}
-      aria-disabled={pttStarting}
-      onpointerdown={(e) => { e.preventDefault(); pttDown(); }}
-      onpointerup={(e) => { e.preventDefault(); pttUp(); }}
-      onpointerleave={() => { if (pttMode === 'held') pttUp(); }}
+      class:ptt-held={owned && !latched}
+      class:ptt-latched={latched}
+      aria-disabled={starting || busy}
+      onpointerdown={(e) => { e.preventDefault(); ptt.down(); }}
+      onpointerup={(e) => { e.preventDefault(); ptt.up(); }}
+      onpointerleave={() => ptt.cancel()}
     >
-      {pttStarting ? 'MIC...' : pttMode === 'latched' ? 'TX 🔒' : pttMode === 'held' ? 'TX' : 'PTT'}
+      {starting ? 'MIC…' : latched ? 'TX 🔒' : keyed ? 'TX' : busy ? 'UNKEYING…' : 'PTT'}
     </button>
-    {#if txError}
-      <div class="tx-error">{txError}</div>
+    {#if fault}
+      <div class="tx-error" data-testid="tx-fault" data-fault={fault}>TX FAULT: {fault}</div>
     {/if}
 
     <!-- MOR-617: warn when TX was keyed with a non-LAN MOD input -->

--- a/frontend/src/components-v2/panels/__tests__/TxPanel.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/TxPanel.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mount, unmount, flushSync } from 'svelte';
 import { txStatusColor } from '../tx-utils';
+import { TxController } from '$lib/runtime/tx-controller/controller';
+import type { TxControllerDependencies } from '$lib/runtime/tx-controller/controller';
 
 // ---------------------------------------------------------------------------
 // txStatusColor
@@ -45,6 +47,7 @@ it('returns danger red when tuning', () => {
 
 const mockProps = {
   txActive: false,
+  txActiveAvailable: true,
   rfPower: 0.5,
   micGain: 128,
   atuActive: false,
@@ -71,22 +74,21 @@ const mockHandlers = {
   onMonToggle: vi.fn(),
   onMonLevelChange: vi.fn(),
   onDriveGainChange: vi.fn(),
-  onPttOn: vi.fn(),
-  onPttOff: vi.fn(),
 };
-
-const mockTxAudioControl = vi.hoisted(() => ({
-  startTx: vi.fn(),
-  stopTx: vi.fn(),
-}));
 
 vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
   deriveTxProps: () => mockProps,
   getTxHandlers: () => mockHandlers,
 }));
 
-vi.mock('$lib/runtime/adapters/tx-adapter', () => ({
-  getTxAudioControl: () => mockTxAudioControl,
+// MOR-1011: the panel owns no PTT state any more — it renders the App TX
+// controller and feeds it gesture intent. Only the *host* (the context lookup)
+// is mocked; behind it sits a REAL TxController over stub dependencies, so
+// these tests exercise the production state machine instead of a double.
+const txHost = vi.hoisted(() => ({ current: undefined as unknown as TxHostFacade }));
+
+vi.mock('$lib/runtime/tx-controller/app-host', () => ({
+  getAppTxController: () => txHost.current,
 }));
 
 // MOR-617: TxPanel mounts ModInputTxWarning, whose real adapter pulls in the
@@ -107,7 +109,95 @@ vi.mock('$lib/runtime/adapters/mod-input-auto.svelte', () => ({
 }));
 
 import TxPanel from '../TxPanel.svelte';
+import txPanelSource from '../TxPanel.svelte?raw';
 
+// ---------------------------------------------------------------------------
+// Real-controller harness (pattern: tx-controller/__tests__/controller-contract)
+// ---------------------------------------------------------------------------
+
+type TxEvent = Parameters<TxController['dispatch']>[0];
+type StartEvent = Extract<TxEvent, { type: 'start' }>;
+type Eligibility = StartEvent['eligibility'];
+type Observation = StartEvent['ptt'];
+type Intent = StartEvent['intent'];
+type Guard = Extract<TxEvent, { type: 'intent' }>['guard'];
+type Command = Parameters<TxControllerDependencies['sendPtt']>[0];
+type Report = Parameters<TxControllerDependencies['sendPtt']>[3];
+type TxHostFacade = ReturnType<typeof createTxHarness>['facade'];
+
+const marker = (seq: number) => ({
+  authorityEpoch: 1, pttObservationSeq: seq, pttLastObservedMonotonic: seq,
+});
+const allowed: Eligibility = {
+  catPtt: true, browserTxAudio: true, controlLive: true, permit: 'allowed',
+  target: { receiver: 'MAIN', slot: 'A', frequencyHz: 14_074_000 },
+};
+const observe = (value: boolean, seq: number): Observation =>
+  ({ value, observed: true, fresh: true, source: 'radio-readback', marker: marker(seq) });
+
+/** Mirrors the deep-frozen snapshot/subscribe payloads app-host hands out. */
+function deepFreeze<T>(value: T): T {
+  if (value === null || typeof value !== 'object') return value;
+  const copy = Object.fromEntries(Object.entries(value as Record<string, unknown>)
+    .map(([key, child]) => [key, deepFreeze(child)]));
+  return Object.freeze(copy) as unknown as T;
+}
+
+function createTxHarness() {
+  const sends: Array<{ command: Command; report: Report }> = [];
+  const audio: { next: Promise<string | null> } = { next: Promise.resolve(null) };
+  const eligibility = { current: allowed };
+  let id = 0;
+  let seq = 0;
+  const dependencies: TxControllerDependencies = {
+    startAudio: vi.fn(() => audio.next),
+    sendPtt: vi.fn((command, _commandId, _correlation, report) => { sends.push({ command, report }); }),
+    stopLocalAudio: vi.fn(),
+    restoreMod: vi.fn(),
+    commandId: vi.fn((command) => `${command}-${++id}`),
+    schedule: vi.fn((callback, delay) => setTimeout(callback, delay)),
+    cancel: vi.fn((handle) => clearTimeout(handle as ReturnType<typeof setTimeout>)),
+    // Far beyond the 300 ms gesture window so controller deadlines never race it.
+    timeoutMs: { 'audio-start': 60_000, 'on-confirmation': 60_000, 'off-confirmation': 60_000 },
+  };
+  const controller = new TxController(1, marker(0), dependencies);
+  const facade = {
+    snapshot: () => deepFreeze(controller.snapshot()),
+    subscribe: (listener: (state: unknown) => void) =>
+      controller.subscribe((state) => listener(deepFreeze(state))),
+    start: (sourceId: string, leaseId: string, intent: Intent) => controller.dispatch({
+      type: 'start', sourceId, leaseId, intent,
+      eligibility: eligibility.current, ptt: observe(false, ++seq),
+    }),
+    setIntent: (sourceId: string, guard: Guard, intent: Intent) =>
+      controller.dispatch({ type: 'intent', sourceId, guard: { ...guard }, intent }),
+    release: (sourceId: string, guard: Guard) => controller.dispatch({
+      type: 'release', sourceId, guard: { ...guard }, commandId: dependencies.commandId('off'),
+    }),
+    resetFault: () => controller.dispatch({ type: 'reset-fault' }),
+  };
+  return {
+    controller, dependencies, sends, facade, audio, eligibility,
+    /** Feed an authoritative PTT readback (what the App host does on session updates). */
+    authority: (value: boolean) => controller.dispatch({
+      type: 'authority', epoch: 1, ptt: observe(value, ++seq),
+      eligibility: eligibility.current, offCommandId: dependencies.commandId('off'),
+    }),
+    /** Report the most recent command of `command` as delivered. */
+    confirm: (command: Command) => {
+      const send = [...sends].reverse().find((item) => item.command === command);
+      expect(send).toBeDefined();
+      send!.report({ outcome: 'sent', eventEpoch: 1, barrier: marker(++seq) });
+    },
+    /** A competing lease source (e.g. the mobile layout or a second panel). */
+    startOther: (leaseId: string) => controller.dispatch({
+      type: 'start', sourceId: 'other-panel', leaseId, intent: 'momentary',
+      eligibility: eligibility.current, ptt: observe(false, ++seq),
+    }),
+  };
+}
+
+let tx: ReturnType<typeof createTxHarness>;
 let components: ReturnType<typeof mount>[] = [];
 
 function mountPanel(overrides?: Partial<typeof mockProps>) {
@@ -129,8 +219,10 @@ function openTxSettings(container: HTMLElement) {
 
 beforeEach(() => {
   components = [];
+  tx = createTxHarness();
+  txHost.current = tx.facade;
   Object.assign(mockProps, {
-    txActive: false, rfPower: 0.5, micGain: 128, atuActive: false,
+    txActive: false, txActiveAvailable: true, rfPower: 0.5, micGain: 128, atuActive: false,
     atuTuning: false, voxActive: false, compActive: false, compLevel: 64,
     monActive: false, monLevel: 64, driveGain: 128,
     hasTx: true, hasTuner: true, hasMonitor: true,
@@ -145,11 +237,6 @@ beforeEach(() => {
   mockHandlers.onMonToggle = vi.fn();
   mockHandlers.onMonLevelChange = vi.fn();
   mockHandlers.onDriveGainChange = vi.fn();
-  mockHandlers.onPttOn = vi.fn();
-  mockHandlers.onPttOff = vi.fn();
-  mockTxAudioControl.startTx.mockReset();
-  mockTxAudioControl.stopTx.mockReset();
-  mockTxAudioControl.startTx.mockResolvedValue(null);
   mockAutoLanProps.available = false;
   mockAutoLanProps.enabled = false;
   mockSetAutoLan.mockReset();
@@ -329,65 +416,252 @@ describe('callbacks', () => {
 
     expect(mockHandlers.onMicGainChange).toHaveBeenCalled();
   });
+});
 
-  it('starts TX audio before keying PTT', async () => {
-    const order: string[] = [];
-    mockTxAudioControl.startTx.mockImplementationOnce(async () => {
-      order.push('audio');
-      return null;
-    });
-    mockHandlers.onPttOn.mockImplementationOnce(() => {
-      order.push('ptt');
-    });
+// ---------------------------------------------------------------------------
+// PTT — driven entirely by the App TX controller (MOR-1011)
+// ---------------------------------------------------------------------------
 
-    const t = mountPanel();
-    const ptt = t.querySelector<HTMLButtonElement>('.ptt-button')!;
-    ptt.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
-    await Promise.resolve();
-    await Promise.resolve();
+describe('PTT via the App TX controller (MOR-1011)', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  const button = (t: HTMLElement) => t.querySelector<HTMLButtonElement>('.ptt-button')!;
+  const label = (t: HTMLElement) => button(t).textContent?.trim();
+  const down = (t: HTMLElement) => {
+    button(t).dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
     flushSync();
+  };
+  const up = (t: HTMLElement) => {
+    button(t).dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
+    flushSync();
+  };
+  const offs = () => tx.sends.filter((item) => item.command === 'off').length;
+  const flushAudio = async () => { await Promise.resolve(); await Promise.resolve(); flushSync(); };
 
-    expect(mockTxAudioControl.startTx).toHaveBeenCalledOnce();
-    expect(mockHandlers.onPttOn).toHaveBeenCalledOnce();
-    expect(order).toEqual(['audio', 'ptt']);
+  /** Press and hold until the radio has acknowledged the ON command. */
+  async function hold(t: HTMLElement) {
+    down(t);
+    await flushAudio();
+    tx.confirm('on');
+    flushSync();
+  }
+
+  /** Hold, then double-tap into the latched lock. */
+  async function latch(t: HTMLElement) {
+    await hold(t);
+    up(t);
+    vi.advanceTimersByTime(100);
+    down(t);
+    flushSync();
+  }
+
+  it('keys a hold through audio → ON and stays keyed', async () => {
+    const t = mountPanel();
+    down(t);
+    expect(tx.dependencies.startAudio).toHaveBeenCalledOnce();
+    expect(label(t)).toBe('MIC…');
+    expect(button(t).getAttribute('aria-disabled')).toBe('true');
+    await flushAudio();
+    tx.confirm('on');
+    flushSync();
+    expect(label(t)).toBe('TX');
+    expect(button(t).classList.contains('ptt-held')).toBe(true);
+    expect(button(t).getAttribute('aria-disabled')).toBe('false');
+    tx.authority(true);
+    flushSync();
+    expect(tx.controller.snapshot().phase).toBe('active');
+    vi.advanceTimersByTime(1000);
+    expect(offs()).toBe(0);
   });
 
-  it('does not key PTT when TX audio startup fails', async () => {
-    mockTxAudioControl.startTx.mockResolvedValueOnce('TX MIC: microphone capture not supported');
+  it('holds the lease for 299 ms after release and drops it at 300 ms', async () => {
     const t = mountPanel();
-    const ptt = t.querySelector<HTMLButtonElement>('.ptt-button')!;
-    ptt.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
-    await Promise.resolve();
-    await Promise.resolve();
+    await hold(t);
+    up(t);
+    vi.advanceTimersByTime(299);
     flushSync();
-
-    expect(mockHandlers.onPttOn).not.toHaveBeenCalled();
-    expect(t.textContent).toContain('TX MIC: microphone capture not supported');
+    expect(offs()).toBe(0);
+    expect(tx.controller.snapshot().phase).toBe('key-confirm-pending');
+    vi.advanceTimersByTime(1);
+    flushSync();
+    expect(offs()).toBe(1);
+    expect(tx.controller.snapshot().phase).toBe('releasing');
+    expect(label(t)).toBe('UNKEYING…');
   });
 
-  it('does not key PTT when released before TX audio startup finishes', async () => {
-    vi.useFakeTimers();
-    let resolveStart!: (value: string | null) => void;
-    mockTxAudioControl.startTx.mockReturnValueOnce(new Promise((resolve) => {
-      resolveStart = resolve;
-    }));
-
+  it('latches on a double tap without starting a second lease', async () => {
     const t = mountPanel();
-    const ptt = t.querySelector<HTMLButtonElement>('.ptt-button')!;
-    ptt.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
-    flushSync();
-    expect(ptt.disabled).toBe(false);
-    expect(ptt.getAttribute('aria-disabled')).toBe('true');
-    ptt.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
-    resolveStart(null);
-    await Promise.resolve();
-    await Promise.resolve();
-    flushSync();
+    await latch(t);
+    expect(tx.controller.snapshot().intent).toBe('latched');
+    expect(tx.dependencies.startAudio).toHaveBeenCalledOnce();
+    expect(label(t)).toBe('TX 🔒');
+    expect(button(t).classList.contains('ptt-latched')).toBe(true);
+    vi.advanceTimersByTime(1000);
+    expect(offs()).toBe(0);
+  });
 
-    expect(mockHandlers.onPttOn).not.toHaveBeenCalled();
-    expect(mockTxAudioControl.stopTx).toHaveBeenCalledOnce();
+  it('unlatches on the next press instead of starting a new lease', async () => {
+    const t = mountPanel();
+    await latch(t);
+    up(t);
+    down(t);
+    expect(offs()).toBe(1);
+    expect(tx.controller.snapshot().phase).toBe('releasing');
+    expect(tx.dependencies.startAudio).toHaveBeenCalledOnce();
+  });
 
-    vi.runOnlyPendingTimers();
-    vi.useRealTimers();
+  it('drops a quick tap taken while audio is still pending, and never keys late', async () => {
+    let resolveAudio!: (value: string | null) => void;
+    tx.audio.next = new Promise((resolve) => { resolveAudio = resolve; });
+    const t = mountPanel();
+    down(t);
+    expect(label(t)).toBe('MIC…');
+    up(t);
+    vi.advanceTimersByTime(300);
+    flushSync();
+    expect(tx.controller.snapshot().phase).toBe('releasing');
+    resolveAudio(null);
+    await flushAudio();
+    expect(tx.sends.filter((item) => item.command === 'on')).toHaveLength(0);
+  });
+
+  it('releases the lease when the panel unmounts', async () => {
+    const t = mountPanel();
+    await hold(t);
+    expect(tx.controller.snapshot().phase).toBe('key-confirm-pending');
+    unmount(components.pop()!);
+    expect(offs()).toBe(1);
+    expect(tx.controller.snapshot().phase).toBe('releasing');
+  });
+
+  it('cannot disturb a newer owner when its stale release window fires', async () => {
+    const t = mountPanel();
+    await hold(t);
+    tx.authority(true);
+    flushSync();
+    up(t); // arms a 300 ms window against the guard live RIGHT NOW
+    // Meanwhile the lease is torn down and re-taken by a different source.
+    tx.controller.dispatch({
+      type: 'release', guard: tx.controller.snapshot().guard!, commandId: 'off-external',
+    });
+    tx.confirm('off');
+    tx.authority(false);
+    flushSync();
+    expect(tx.controller.snapshot().phase).toBe('idle');
+    tx.startOther('other-lease');
+    flushSync();
+    const before = offs();
+    vi.advanceTimersByTime(300);
+    flushSync();
+    expect(offs()).toBe(before);
+    expect(tx.controller.snapshot()).toMatchObject({
+      sourceId: 'other-panel', phase: 'audio-start-pending',
+    });
+  });
+
+  it('renders a controller fault and clears it on the next press', async () => {
+    tx.eligibility.current = { ...allowed, permit: 'denied' };
+    const t = mountPanel();
+    down(t);
+    const fault = t.querySelector('[data-testid="tx-fault"]');
+    expect(fault).not.toBeNull();
+    expect(fault!.getAttribute('data-fault')).toBe('not-eligible');
+    expect(label(t)).toBe('PTT');
+    up(t);
+    tx.eligibility.current = allowed;
+    down(t);
+    await flushAudio();
+    expect(t.querySelector('[data-testid="tx-fault"]')).toBeNull();
+    expect(tx.controller.snapshot()).toMatchObject({ fault: null, phase: 'audio-start-pending' });
+  });
+
+  it('takes RF state from controller authority and falls back to panel props', async () => {
+    let t = mountPanel({ txActive: false, txActiveAvailable: false });
+    expect(t.querySelector('.tx-strip')!.getAttribute('data-rf')).toBe('unknown');
+    unmount(components.pop()!);
+
+    t = mountPanel({ txActive: true, txActiveAvailable: true });
+    expect(t.querySelector('.tx-strip')!.getAttribute('data-rf')).toBe('on');
+    expect(t.querySelector('[data-testid="tx-strip"]')!.textContent?.trim()).toBe('● TX');
+    unmount(components.pop()!);
+
+    // Controller authority wins over a props snapshot that still says RX.
+    t = mountPanel({ txActive: false, txActiveAvailable: true });
+    expect(t.querySelector('.tx-strip')!.getAttribute('data-rf')).toBe('off');
+    await hold(t);
+    tx.authority(true);
+    flushSync();
+    expect(t.querySelector('.tx-strip')!.getAttribute('data-rf')).toBe('on');
+  });
+
+  // Both sidebars list a draggable "tx" panel, so two instances can be mounted
+  // at once against one controller. Every guarantee below rests on each
+  // instance owning a DISTINCT sourceId: the guard alone always matches (it is
+  // the single live lease), so sourceId is the only thing stopping the idle
+  // panel from releasing, latching or tearing down the busy panel's TX.
+  describe('two mounted panels', () => {
+    it('gives each instance its own lease identity', async () => {
+      const a = mountPanel();
+      const b = mountPanel();
+      await hold(a);
+      const first = tx.controller.snapshot().sourceId;
+      unmount(components.shift()!); // A releases its own lease, then drains
+      tx.confirm('off');
+      tx.authority(false);
+      flushSync();
+      expect(tx.controller.snapshot().phase).toBe('idle');
+      down(b);
+      expect(tx.controller.snapshot().sourceId).not.toBe(first);
+    });
+
+    it('does not let an idle panel release the other panel lease', async () => {
+      const a = mountPanel();
+      const b = mountPanel();
+      await hold(a);
+      const owner = tx.controller.snapshot().sourceId;
+      down(b);
+      up(b); // arms B's window against A's live guard
+      vi.advanceTimersByTime(1000);
+      flushSync();
+      expect(offs()).toBe(0);
+      expect(tx.controller.snapshot()).toMatchObject({
+        sourceId: owner, phase: 'key-confirm-pending',
+      });
+      expect(tx.dependencies.startAudio).toHaveBeenCalledOnce();
+    });
+
+    it('does not let an idle panel unmount release the other panel lease', async () => {
+      const a = mountPanel();
+      mountPanel();
+      await hold(a);
+      const owner = tx.controller.snapshot().sourceId;
+      unmount(components.pop()!); // unmount B, which never owned anything
+      flushSync();
+      expect(offs()).toBe(0);
+      expect(tx.controller.snapshot()).toMatchObject({
+        sourceId: owner, phase: 'key-confirm-pending',
+      });
+    });
+
+    it('does not let an idle panel latch the other panel lease', async () => {
+      const a = mountPanel();
+      const b = mountPanel();
+      await hold(a);
+      down(b);
+      up(b);
+      vi.advanceTimersByTime(100);
+      down(b); // a double tap that would latch if the sourceId were shared
+      flushSync();
+      expect(tx.controller.snapshot().intent).toBe('momentary');
+      expect(offs()).toBe(0);
+    });
+  });
+
+  it('no longer references the retired local PTT machinery', () => {
+    expect(txPanelSource).not.toContain('tx-adapter');
+    expect(txPanelSource).not.toContain('getTxAudioControl');
+    expect(txPanelSource).not.toContain('onPtt');
+    expect(txPanelSource).toContain('getAppTxController');
   });
 });


### PR DESCRIPTION
MOR-1011, **PR B of 2** (PR A merged the gesture recognizer in #2125).

## What changes

The desktop TX panel no longer owns any TX state. It reads the App TX controller and feeds it gesture intent; audio start, key confirmation, safety deadlines and fail-closed release all live in the controller.

**Deleted from `TxPanel.svelte`:** `pttMode` / `lastPttDown` / `pttStarting` / `txError` / `pttPressActive` / `txStartToken`, `engageTx` / `pttDown` / `pttUp`, the `getTxAudioControl` `startTx`/`stopTx` calls, the `onPttOn`/`onPttOff` handler reads, and the local 3-minute PTT safety timer (`PTT_SAFETY_MS`) — that timer was a duplicate of the controller's deadline handling, and `TxSafetySupervisor` is its successor.

**Kept unchanged:** the ⚙ LEVELS long-press, `ModInputTxWarning`, the settings modal, and the entire `<style>` block — verified byte-identical to `main` (both 3318 bytes, both `913c91cb…`), so zero CSS churn.

Gesture translation goes through the merged recognizer (`panels/tx-ptt-gesture.ts`) with real `setTimeout`/`clearTimeout` deps, so hold, quick-tap and double-tap-to-latch keep their existing semantics while the lease stays open across the 300 ms window.

## Per-instance lease identity

Each mounted instance takes its own `sourceId` (module-level counter). Both sidebars list a draggable "tx" panel, so two instances can be live at once — and the live guard alone *always* matches, because there is only ever one lease. `sourceId` is the only thing stopping an idle panel from releasing, latching or tearing down the busy panel's TX (enforced at `tx-controller/model.ts:100-101`).

## The two layout-test mocks

`TxPanel` now resolves the controller from Svelte context, which only `App.svelte` provides, so two layout tests that mount `RadioLayout` bare needed a host stub:

- **`RadioLayout.test.ts`** — *partial* mock via `importOriginal`: it keeps the **real** `provideAppTxControllerHost` (its `App` mount at line 420 needs it) and stubs only `getAppTxController` for the bare `mount(RadioLayout, …)` sites.
- **`top-row-visual-regression.test.ts`** — never mounts `App`, so a plain stub suffices.

Both keep the **real** `TxPanel` in the rendered tree, and neither file asserts anything TX-related (they cover VFO/meter extraction, skin resolution, dock structure and top-row scale). The stub snapshot carries exactly the five fields the panel reads.

## Guardrail

Four files under an **explicit owner exemption** to the 3-file guardrail. Two of the four are test-only mocks, and the production source delta is **net −6 lines** (`TxPanel.svelte` +72/−78); the bulk of the diff is tests.

## Test evidence

| Command | Result |
|---|---|
| `npx vitest run …/panels/__tests__/TxPanel.test.ts` | **40/40 passed** |
| `npx vitest run panels layout tx-controller` | **794/794 passed** (46 files) |
| `npm run check` | 4286 files, **0 errors, 0 warnings** |
| `npm run lint:boundaries` | clean (exit 0) |
| `npm run i18n:check` | OK, 3 locales / 166 keys |
| `npm run build` | ✓ succeeded (only pre-existing chunk-size / dynamic-import warnings) |

**Baseline diff (full local suite, both trees).** The local suite is flaky without `--localstorage-file`, so the claim is a set-difference, not a pass count: clean tree 2456 tests / 106 failed, with-change 2463 / 106 failed, **0 new failures and 0 disappeared**. All 106 share the identical first line `TypeError: Cannot read properties of undefined (reading 'clear')` — the known `localStorage` env family.

## Mutation evidence

Each mutation applied to a copy, then restored and re-hashed:

| Mutation | Result |
|---|---|
| `onDestroy` drops `ptt.destroy()` | ✅ kills `releases the lease when the panel unmounts` |
| Release window passes the **live** guard instead of the captured one | ✅ kills `tx-ptt-gesture.test.ts` `fires the release window with the guard captured at arm time, not the live one` |
| Drop `resetFault` before `start` | ✅ kills `renders a controller fault and clears it on the next press` |
| `sourceId` → shared module constant | ✅ kills **exactly** the 4 `two mounted panels` cases (4 failed / 36 passed) |

**Defence-in-depth note on the live-guard mutation.** `cannot disturb a newer owner when its stale release window fires` *survives* that mutation, because the model's `sourceId` check independently rejects the stale release (the competing lease uses `sourceId: 'other-panel'`). Verified by construction: with the mutation applied **and** the competing lease sharing `tx-panel-1`, that test does fail. So the captured-guard defence is genuinely pinned — by PR A's recognizer test — and the two defences are independent, as designed.

## Behavior notes

- **R1** — re-keying requires a strictly newer authoritative PTT observation, so a re-key attempt during teardown renders `UNKEYING…` or a fault token rather than keying immediately.
- **R3** — a latched TX is released on unmount. This is the required fail-closed behavior, not a regression.

## Carry-over notes

- **R4** — `MobileRadioLayout.svelte:919` also mounts a bare `<TxPanel/>` (inside the TX-settings bottom sheet), so on mobile that panel is now controller-driven while the FAB and landscape strip keep the legacy `pttMode` machine (`:352,357`). Two independent TX paths coexist. This is pre-existing duplication — both were independent machines before — and unifying them is **MOR-1012**.
- **R6** — `panel-commands.ts:457-458` `onPttOn`/`onPttOff` are now dead (nothing reads `getTxHandlers().onPtt*`). `command-bus.ts:603-604,760-761` are **not** dead: `MobileRadioLayout` still calls `systemHandlers.onPttOn/onPttOff`. Both deliberately left for MOR-1012.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
