### PR TITLE
test: route SerialMockRadio imports through tests-local serial_stub seam

### DIFF
--- a/tests/integration/test_rigctld_golden_replay.py
+++ b/tests/integration/test_rigctld_golden_replay.py
@@ -47,7 +47,7 @@ from pathlib import Path
 
 import pytest
 
-from rigplane.backends.icom7610.drivers.serial_stub import SerialMockRadio
+from serial_stub import SerialMockRadio
 from rigplane.rigctld.contract import RigctldConfig
 from rigplane.rigctld.server import RigctldServer
 

--- a/tests/integration/test_rigctld_wsjtx.py
+++ b/tests/integration/test_rigctld_wsjtx.py
@@ -32,7 +32,7 @@ from collections.abc import AsyncGenerator
 
 import pytest
 
-from rigplane.backends.icom7610.drivers.serial_stub import SerialMockRadio
+from serial_stub import SerialMockRadio
 from rigplane.rigctld.contract import RigctldConfig
 from rigplane.rigctld.server import RigctldServer
 

--- a/tests/serial_stub.py
+++ b/tests/serial_stub.py
@@ -1,0 +1,28 @@
+"""Test-tree import seam for the deterministic serial test doubles.
+
+Transitional re-export shim: tests import ``SerialMockRadio`` (and the
+serial framing helpers) from here instead of from the shipping package,
+so the double can move out of ``src/`` in a follow-up mechanical-move PR
+without touching the test modules again. Once the move lands, this file
+holds the actual implementation.
+"""
+
+from __future__ import annotations
+
+from rigplane.backends.icom7610.drivers.serial_stub import (
+    DeterministicSerialCivLink,
+    SerialFrameCodec,
+    SerialFrameError,
+    SerialFrameOverflowError,
+    SerialFrameTimeoutError,
+    SerialMockRadio,
+)
+
+__all__ = [
+    "DeterministicSerialCivLink",
+    "SerialFrameCodec",
+    "SerialFrameError",
+    "SerialFrameOverflowError",
+    "SerialFrameTimeoutError",
+    "SerialMockRadio",
+]

--- a/tests/test_backend_contract_matrix.py
+++ b/tests/test_backend_contract_matrix.py
@@ -9,7 +9,7 @@ from typing import Protocol
 import pytest
 
 from rigplane import IC_7610_ADDR
-from rigplane.backends.icom7610.drivers.serial_stub import SerialMockRadio
+from serial_stub import SerialMockRadio
 from rigplane.commands import (
     CONTROLLER_ADDR,
     _CMD_LEVEL,

--- a/tests/test_ic705_backend.py
+++ b/tests/test_ic705_backend.py
@@ -5,7 +5,7 @@ import pytest
 from rigplane.backends.config import SerialBackendConfig
 from rigplane.backends.factory import create_radio
 from rigplane.backends.ic705.serial import Ic705SerialRadio
-from rigplane.backends.icom7610.drivers.serial_stub import SerialMockRadio
+from serial_stub import SerialMockRadio
 from rigplane.backends.icom7610.serial import Icom7610SerialRadio
 from rigplane.exceptions import CommandError
 

--- a/tests/test_lifecycle_diagnostics.py
+++ b/tests/test_lifecycle_diagnostics.py
@@ -12,7 +12,7 @@ import logging
 import pytest
 
 from rigplane.runtime._connection_state import RadioConnectionState
-from rigplane.backends.icom7610.drivers.serial_stub import SerialMockRadio
+from serial_stub import SerialMockRadio
 from rigplane.radio import IcomRadio
 from rigplane.rigctld.contract import RigctldConfig
 from rigplane.rigctld.server import RigctldServer

--- a/tests/test_rigctld_server.py
+++ b/tests/test_rigctld_server.py
@@ -19,7 +19,7 @@ from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 
-from rigplane.backends.icom7610.drivers.serial_stub import SerialMockRadio
+from serial_stub import SerialMockRadio
 from rigplane.core.acquisition_scheduler import (
     AcquisitionExecutionResult,
     AcquisitionPriority,

--- a/tests/test_serial_backend_smoke.py
+++ b/tests/test_serial_backend_smoke.py
@@ -13,7 +13,7 @@ import pytest
 from rigplane.audio.backend import AudioDeviceId, AudioDeviceInfo, FakeAudioBackend
 from rigplane.audio_bridge import AudioBridge
 from rigplane.backends.icom7610 import Icom7610SerialRadio
-from rigplane.backends.icom7610.drivers.serial_stub import SerialMockRadio
+from serial_stub import SerialMockRadio
 from rigplane.rigctld.contract import RigctldConfig
 from rigplane.rigctld.server import RigctldServer
 from rigplane.web.handlers import AudioBroadcaster

--- a/tests/test_serial_stub_framing.py
+++ b/tests/test_serial_stub_framing.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from rigplane.backends.icom7610.drivers.serial_stub import (
+from serial_stub import (
     DeterministicSerialCivLink,
     SerialFrameCodec,
     SerialFrameOverflowError,

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -23,7 +23,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from rigplane.backends.icom7610.drivers.serial_stub import SerialMockRadio
+from serial_stub import SerialMockRadio
 from rigplane.radio_state import RadioState
 from rigplane.rigctld.state_cache import StateCache
 from rigplane.scope import ScopeFrame


### PR DESCRIPTION
## Context

`SerialMockRadio` (deterministic serial test double) lives in `src/rigplane/backends/icom7610/drivers/serial_stub.py` but is imported **only** by 9 test modules — nothing under `src/` imports it (the two `src/` mentions are comments in `web/radio_poller.py` and `rigctld/handler.py`; packaging, `.importlinter`, and workflows don't reference it).

Because it ships inside the package, its poller-style dispatch contains `await radio.set_ptt(True/False)` (serial_stub.py:771-773), which is a **permanent false positive** in the MOR-999 managed-TX bypass sweep (`grep -rn "\.set_ptt(" src/` — MOR-1016 Verify / MOR-1015 "no bare set_ptt bypass" acceptance) that every auditor must re-triage.

## This PR (1 of 2 — import-update)

- Add `tests/serial_stub.py` as a thin re-export seam over the current src location, following the existing flat-helper convention (`mock_server.py`, `fake_rigctld.py`; `tests/` is on `sys.path` via the root conftest — no `__init__.py` layout).
- Switch all 9 importing test modules (`from rigplane.backends.icom7610.drivers.serial_stub import …` → `from serial_stub import …`). One mechanical line per module.

No behavior change to the double. PR 2 of 2 will `git mv` the implementation out of `src/` onto this seam (rewriting its relative imports to absolute), making the TX bypass sweep clean.

Split per the CLAUDE.md 3-file guardrail: the import updates inherently touch 9 test files, so the move and the import swap are separated into two mechanical, individually-green PRs.

## Verification

- `uv run pytest tests/ -q --tb=short` — 8856 passed, 68 skipped, 11 xfailed, 0 failures
- `uv run ruff check src/ tests/` — clean; `ruff format --check` on all 10 touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)