### PR TITLE
feat: publish an inert managed_tx member on CoreRadio

### DIFF
--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -24,7 +24,26 @@ if TYPE_CHECKING:
 
     from rigplane._runtime_protocols import ControlPhaseHost
     from rigplane.core.acquisition_scheduler import RadioStateModelService
+    from rigplane.core.radio_protocol import ManagedTxSupervisor
     from rigplane.core.tx_safety import ProviderPttObservation
+    from rigplane.runtime.managed_radio_runtime import ManagedRadioRuntime
+
+    def _managed_tx_runtime_satisfies_supervisor(
+        runtime: ManagedRadioRuntime,
+    ) -> ManagedTxSupervisor:
+        """Mypy-only: fails to type-check if ``ManagedRadioRuntime`` drifts
+        from :class:`~rigplane.core.radio_protocol.ManagedTxSupervisor`.
+
+        Guarded by ``TYPE_CHECKING`` — never defined and never called at
+        runtime, so it costs nothing until PR2 arms
+        ``self._managed_tx_runtime`` (MOR-1016). Its only job is to turn a
+        ``request_on``/``release_owner`` signature drift on either side into
+        a ``uv run mypy src/`` error here, since the assembly-time
+        ``getattr_static`` two-step (:meth:`ManagedTxApi.bind`) only checks
+        member presence, never shape.
+        """
+        return runtime
+
 
 from . import radio_initial_state as _initial_state
 from . import radio_reconnect as _reconnect
@@ -897,6 +916,10 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             recovery_backoff_s=(0.0, 0.0, 0.0),
         )
         self._audio_runtime: AudioRecoveryRuntime = AudioRecoveryRuntime(self)
+        # Managed TX supervisor (MOR-1016 PR1): inert until PR2 constructs and
+        # arms it in connect(). ``managed_tx`` below always answers ``None``
+        # until then, so every ingress keeps using the legacy set_ptt path.
+        self._managed_tx_runtime: ManagedRadioRuntime | None = None
 
     # Host shims for ControlPhaseRuntime and Icom7610SerialRadio (delegate to civ_runtime)
     def _advance_civ_generation(self, reason: str) -> None:
@@ -1022,6 +1045,21 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         if not isinstance(last, (int, float)):
             return False
         return (time.monotonic() - float(last)) <= self._civ_ready_idle_timeout
+
+    @property
+    def managed_tx(self) -> ManagedTxSupervisor | None:
+        """The radio's managed TX supervisor, or ``None`` when unmanaged.
+
+        Structural implementation of
+        :class:`~rigplane.core.radio_protocol.ManagedTxCapable`: a real class
+        member, never conjured through ``__getattr__``, so
+        :meth:`~rigplane.core.radio_protocol.ManagedTxApi.bind`'s
+        ``getattr_static`` read finds it. Inert until MOR-1016 PR2 constructs
+        and arms ``self._managed_tx_runtime`` at connect time — until then
+        every radio here answers ``None`` and every ingress keeps using the
+        legacy :meth:`set_ptt` path unchanged.
+        """
+        return self._managed_tx_runtime
 
     # ------------------------------------------------------------------
     # Backwards-compatible property shims for _connected / _intentional_disconnect

--- a/tests/test_cli_async.py
+++ b/tests/test_cli_async.py
@@ -36,7 +36,7 @@ from rigplane.cli import (
     _run,
     main,
 )
-from rigplane.core.radio_protocol import ManagedTxApi, ManagedTxCapable
+from rigplane.core.radio_protocol import ManagedTxApi
 from rigplane.core.tx_safety import (
     TxOutcome,
     TxOwner,
@@ -575,15 +575,18 @@ class TestCmdPttManagedIngress:
     async def test_shipped_radio_keeps_the_legacy_direct_write(
         self, held, capsys
     ) -> None:
-        # No backend assembles a managed runtime yet (MOR-1016): the radio the
-        # CLI ships must reach its own ``set_ptt``, with today's codes and lines.
+        # No backend assembles a managed runtime yet (MOR-1016 PR2): the radio
+        # the CLI ships must reach its own ``set_ptt``, with today's codes and
+        # lines. (MOR-1016 PR1 gives CoreRadio a real, inert ``managed_tx``
+        # member, so ``isinstance(..., ManagedTxCapable)`` now reads True
+        # structurally -- the probe the protocol's own docstring says not to
+        # trust. ``bind()`` returning ``None`` is the invariant that matters.)
         shipped = RuntimeIcomRadio("127.0.0.1")
         writes: list[bool] = []
 
         async def _record(on: bool) -> None:
             writes.append(on)
 
-        assert not isinstance(shipped, ManagedTxCapable)
         assert ManagedTxApi.bind(shipped, TxOwner(TxSource.SDK, "probe")) is None
         shipped.set_ptt = _record
 

--- a/tests/test_managed_tx_api.py
+++ b/tests/test_managed_tx_api.py
@@ -9,7 +9,6 @@ import pytest
 from rigplane.core.exceptions import CommandError
 from rigplane.core.radio_protocol import (
     ManagedTxApi,
-    ManagedTxCapable,
     ManagedTxSupervisor,
 )
 from rigplane.core.tx_safety import (
@@ -78,11 +77,14 @@ class FakeRadio:
 
 
 def test_shipped_radio_is_dormant() -> None:
-    # No backend attaches a managed runtime yet (MOR-1016), so the facade must
-    # refuse to bind and leave the legacy provider path untouched.
+    # MOR-1016 PR1 gives CoreRadio a real (inert) ``managed_tx`` member, so
+    # ``isinstance(..., ManagedTxCapable)`` now reads True structurally --
+    # exactly the probe the protocol's own docstring says not to trust.  What
+    # must still hold is the invariant that matters: nothing constructs or
+    # arms a runtime until PR2, so the facade refuses to bind and the legacy
+    # provider path stays untouched.
     shipped = IcomRadio("127.0.0.1")
 
-    assert not isinstance(shipped, ManagedTxCapable)
     assert ManagedTxApi.bind(shipped, _OWNER) is None
     assert ManagedTxApi.bind(object(), _OWNER) is None
     assert ManagedTxApi.bind(FakeRadio(False), _OWNER) is None
@@ -221,14 +223,16 @@ def _attach(wrapper: SyncIcomRadio, provider: FakeRadio) -> FakeRadio:
 def test_shipped_ingress_keeps_the_legacy_direct_write(
     wrapper: SyncIcomRadio,
 ) -> None:
-    # Nothing assembles a managed runtime yet (MOR-1016), so the backend the
-    # SDK actually ships must still reach its own ``set_ptt``, unchanged.
+    # Nothing assembles a managed runtime yet (MOR-1016 PR2), so the backend
+    # the SDK actually ships must still reach its own ``set_ptt``, unchanged.
+    # (``isinstance(..., ManagedTxCapable)`` reads True once PR1 lands the
+    # inert member -- see ``test_shipped_radio_is_dormant`` -- so ``bind()``
+    # returning ``None`` is the invariant checked here, not isinstance.)
     writes: list[bool] = []
 
     async def _record(on: bool) -> None:
         writes.append(on)
 
-    assert not isinstance(wrapper._radio, ManagedTxCapable)
     assert ManagedTxApi.bind(wrapper._radio, wrapper._tx_owner) is None
     wrapper._radio.set_ptt = _record  # type: ignore[method-assign]
 

--- a/tests/test_managed_tx_assembly.py
+++ b/tests/test_managed_tx_assembly.py
@@ -1,0 +1,148 @@
+"""MOR-1016 PR1: the inert ``managed_tx`` member on ``CoreRadio``.
+
+Nothing under ``src`` constructs a :class:`ManagedRadioRuntime` yet -- that is
+PR2's job (arming happens in ``connect()``, after ``_civ_transport`` exists).
+This PR only gives ``CoreRadio`` the real class member
+:class:`~rigplane.core.radio_protocol.ManagedTxCapable` requires, so it must
+prove two things and nothing more:
+
+1. the member is a real property -- visible to
+   :func:`inspect.getattr_static` without running it, never conjured through
+   ``__getattr__`` (the exact trap ``ManagedTxCapable``'s docstring warns
+   about); and
+2. every consumer of it (``ManagedTxApi.bind``, the Web reconnect hook) still
+   sees ``None`` and falls through to the legacy, unsupervised ``set_ptt``
+   path -- because a freshly constructed radio armed with nothing keeps
+   ``self._managed_tx_runtime`` at its ``None`` default.
+
+No ``MagicMock`` stands in for a protocol-shaped object here (a mock answers
+every ``getattr``, so it could never show the unmanaged path staying
+unmanaged); every radio below is the real ``CoreRadio``/``IcomRadio``.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from rigplane.core.radio_protocol import ManagedTxApi
+from rigplane.core.tx_safety import TxOwner, TxSource
+from rigplane.runtime import radio as radio_module
+from rigplane.runtime.radio import CoreRadio, IcomRadio
+from rigplane.web.server import WebServer
+
+_OWNER = TxOwner(TxSource.SDK, "session")
+
+
+def _unconnected_radio() -> IcomRadio:
+    """A constructed-but-never-connected radio -- no transport, no runtime."""
+    return IcomRadio("127.0.0.1")
+
+
+# --- (a) real class member, not a conjured attribute -----------------------
+
+
+def test_managed_tx_is_a_real_class_member_not_a_conjured_attribute() -> None:
+    # ``getattr_static`` bypasses ``__getattribute__``/``__getattr__``
+    # entirely, so it only finds ``managed_tx`` if some class in the MRO
+    # actually defines it (as a property, here). If a subclass ever "adds"
+    # the attribute dynamically instead, this is exactly what stops seeing
+    # it -- which is the point: ``ManagedTxApi.bind`` relies on the same
+    # read to settle absence without running any accessor.
+    radio = _unconnected_radio()
+
+    static = inspect.getattr_static(radio, "managed_tx", None)
+
+    assert static is not None
+    assert isinstance(static, property)
+
+
+def test_managed_tx_member_lives_on_core_radio_not_a_subclass() -> None:
+    # The property must be on ``CoreRadio`` itself so every backend built on
+    # it (not just ``IcomRadio``) inherits the same structural surface.
+    assert isinstance(vars(CoreRadio).get("managed_tx"), property)
+
+
+# --- (b) constructed-but-unconnected radio: managed_tx is None -------------
+
+
+def test_unconnected_radio_managed_tx_is_none() -> None:
+    radio = _unconnected_radio()
+
+    assert radio.managed_tx is None
+
+
+def test_bare_core_radio_managed_tx_is_none() -> None:
+    # Not just the LAN subclass -- the member is inert on the shared base too.
+    radio = CoreRadio("127.0.0.1")
+
+    assert radio.managed_tx is None
+
+
+# --- (c) ManagedTxApi.bind still declines: legacy path preserved -----------
+
+
+def test_bind_on_unconnected_radio_returns_none() -> None:
+    # Unmanaged is a positive finding here, not a fallback from a failed
+    # read: the member exists (case a/b) and answers ``None``, so ``bind``
+    # must decline without touching ``set_ptt`` or anything else on the
+    # radio.
+    radio = _unconnected_radio()
+
+    assert ManagedTxApi.bind(radio, _OWNER) is None
+
+
+async def test_legacy_set_ptt_is_still_the_only_write_path() -> None:
+    # With no supervisor bound, a caller that goes through ``ManagedTxApi``
+    # gets nothing to call; the legacy ``set_ptt`` on the radio itself must
+    # remain the sole write path, completely unaffected by the new member.
+    radio = _unconnected_radio()
+    writes: list[bool] = []
+
+    async def _record(on: bool) -> None:
+        writes.append(on)
+
+    radio.set_ptt = _record  # type: ignore[method-assign]
+
+    assert ManagedTxApi.bind(radio, _OWNER) is None
+    await radio.set_ptt(True)
+    await radio.set_ptt(False)
+
+    assert writes == [True, False]
+
+
+# --- (d) the Web reconnect consumer sees None and no-ops -------------------
+
+
+async def test_web_managed_tx_release_hook_no_ops_on_an_inert_radio() -> None:
+    # ``WebServer._service_managed_tx_release`` is the one production
+    # consumer already wired to the ``getattr_static`` two-step (MOR-1192/
+    # MOR-1196). Against a radio with the new-but-inert member it must take
+    # the same "unmanaged" early return it always has -- no exception, no
+    # rebind attempted, no lock contention.
+    radio = _unconnected_radio()
+    server = WebServer(radio)  # type: ignore[arg-type]
+
+    result = await server._service_managed_tx_release()
+
+    assert result is None
+    assert not server._managed_tx_rebind_lock.locked()
+
+
+# --- (e) static protocol-conformance guard lives in radio.py, mypy-checked -
+
+
+def test_static_supervisor_conformance_guard_is_mypy_only() -> None:
+    # ``radio.py`` carries a ``TYPE_CHECKING``-guarded function whose only
+    # job is to make ``uv run mypy src/`` fail if ``ManagedRadioRuntime``
+    # ever stops satisfying ``ManagedTxSupervisor`` -- signature drift that
+    # ``ManagedTxApi.bind``'s ``getattr_static`` read cannot catch, since it
+    # only checks member *presence*, never shape. It must not exist at
+    # runtime (guarded by ``TYPE_CHECKING``, so it costs nothing today), and
+    # its source must actually reference the supervisor protocol for the
+    # mypy check to mean anything.
+    assert not hasattr(radio_module, "_managed_tx_runtime_satisfies_supervisor")
+
+    source = inspect.getsource(radio_module)
+    assert "_managed_tx_runtime_satisfies_supervisor" in source
+    assert "ManagedTxSupervisor" in source
+    assert "ManagedRadioRuntime" in source


### PR DESCRIPTION
MOR-1016 PR 1 of 7 (managed TX runtime assembly).

## What
- Real `managed_tx` property on `CoreRadio` returning `_managed_tx_runtime` (always `None` in this PR — nothing constructs the runtime yet).
- TYPE_CHECKING-only conformance guard: mypy fails if `ManagedRadioRuntime` drifts off the `ManagedTxSupervisor` protocol (liveness proven by mutating its annotation).
- New `tests/test_managed_tx_assembly.py` (8 tests): getattr_static finds a real property; unconnected radios read None; `ManagedTxApi.bind()` returns None; the production `WebServer._service_managed_tx_release` no-ops on an inert radio.
- Two pre-existing tests updated: their `isinstance(ManagedTxCapable)` assertions (an anti-pattern per that protocol's own docstring, and factually false once a real member exists) are replaced by the invariant that matters and was already asserted alongside: `bind() is None` + legacy `set_ptt` remains the sole write path. Their comments had named MOR-1016 as the trigger.

## Zero behavior change — evidence
Independent verifier (fresh context): pinned-hash review; radio.py diff is 38 insertions / 0 deletions; full suite 8601 passed; mypy identical to an independently reproduced origin/main baseline (15 errors / 4 pre-existing files); ruff/format/lint-imports clean; behavior-zero script constructing CoreRadio + IcomRadio confirms property present, value None, bind None.

4 files under an explicit owner exemption (2026-08-01): the overage is test-only fixups whose necessity the touched tests' own comments predicted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)