### PR TITLE
feat: add a leaseless force_unkey primitive to TxSafetySupervisor

### DIFF
--- a/src/rigplane/core/tx_safety.py
+++ b/src/rigplane/core/tx_safety.py
@@ -57,6 +57,7 @@ class TxOutcome(StrEnum):
 
 class TxReleaseReason(StrEnum):
     OPERATOR_RELEASE = "operator_release"
+    OPERATOR_FORCED_UNKEY = "operator_forced_unkey"
     SOURCE_DETACHED = "source_detached"
     PRESENTATION_REPLACED = "presentation_replaced"
     CLIENT_DISCONNECTED = "client_disconnected"
@@ -204,6 +205,12 @@ _SYSTEM_RELEASE_REASONS = frozenset(
         TxReleaseReason.ADMIN_EMERGENCY_STOP,
     }
 )
+
+# Forcing an unkey is an operator act, so it carries one operator-attributed
+# reason the system lane must never be able to claim: ``emergency_release``
+# keeps rejecting ``OPERATOR_FORCED_UNKEY``, and ``force_unkey`` keeps
+# rejecting ``OPERATOR_RELEASE``.
+_FORCE_UNKEY_REASONS = _SYSTEM_RELEASE_REASONS | {TxReleaseReason.OPERATOR_FORCED_UNKEY}
 
 
 class TxSafetySupervisor:
@@ -403,6 +410,41 @@ class TxSafetySupervisor:
             self._release_current(reason)
             if self._lease
             else self._result(TxOutcome.NOOP)
+        )
+
+    def force_unkey(self, owner: TxOwner, *, reason: TxReleaseReason) -> TxTransition:
+        """Adopt an unowned key so the durable OFF has a lease to run under.
+
+        The minted lease is a release obligation, never a key-down: it exists
+        only so the OFF inherits the retry ladder, generation-change survival
+        and readiness-loss parking every managed release already gets, and it
+        self-clears on the confirming observation.
+
+        This must never gate on ``TxPhase.EXTERNAL_UNOWNED`` nor require a
+        fresh PTT read first. A supervisor in a freshly started process has no
+        observation at all, so it reports ``IDLE``/``UNKNOWN`` while the rig is
+        keyed -- exactly the case this exists for (MOR-1182) -- and the read
+        that would settle the question may be broken by the same fault. Live
+        leases are refused rather than preempted; preemption is MOR-1179's
+        territory, reached by exposing ``emergency_release``.
+        """
+        if reason not in _FORCE_UNKEY_REASONS:
+            raise ValueError("forced unkey requires a trusted or operator reason")
+        if self._release is not None:
+            # A durable OFF is already owed; routing this through
+            # ``_release_current`` would rewrite a foreign terminal reason.
+            return self._result(TxOutcome.IDEMPOTENT)
+        if self._lease is not None:
+            return self._result(TxOutcome.BUSY)
+        if self._active is not None:
+            return self._result(TxOutcome.BUSY)
+        if not self._ready or self._generation is None:
+            return self._result(TxOutcome.NOT_READY)
+        now = self._clock()
+        self._lease = _Lease(self._id_factory(), owner)
+        self._begin_release(reason, now)
+        return self._result(
+            TxOutcome.ACCEPTED, self._service_release(force=True, now=now)
         )
 
     def settle_attempt(

--- a/tests/test_tx_safety.py
+++ b/tests/test_tx_safety.py
@@ -563,6 +563,205 @@ def test_unqualified_release_rejects_untrusted_reason(
         supervisor.emergency_release(reason=reason)
 
 
+@pytest.mark.parametrize(
+    "reason",
+    [
+        TxReleaseReason.OPERATOR_RELEASE,
+        TxReleaseReason.SOURCE_DETACHED,
+        TxReleaseReason.PRESENTATION_REPLACED,
+        TxReleaseReason.CLIENT_DISCONNECTED,
+        TxReleaseReason.FRONTEND_SAFETY_TIMEOUT,
+    ],
+)
+def test_forced_unkey_rejects_untrusted_reason(
+    supervisor: TxSafetySupervisor,
+    clock: Clock,
+    owner: TxOwner,
+    reason: TxReleaseReason,
+) -> None:
+    supervisor.replace_provider(1, ready=True)
+    observe(supervisor, clock, RadioTx.ON)
+    with pytest.raises(ValueError):
+        supervisor.force_unkey(owner, reason=reason)
+    assert supervisor.snapshot.lease_id is None
+
+
+def test_unqualified_release_still_rejects_the_forced_unkey_reason(
+    supervisor: TxSafetySupervisor, clock: Clock, owner: TxOwner
+) -> None:
+    acquire(supervisor, clock, owner)
+    with pytest.raises(ValueError):
+        supervisor.emergency_release(reason=TxReleaseReason.OPERATOR_FORCED_UNKEY)
+
+
+def test_forced_unkey_during_a_release_keeps_its_terminal_reason(
+    supervisor: TxSafetySupervisor,
+    clock: Clock,
+    owner: TxOwner,
+    other: TxOwner,
+) -> None:
+    lease, _ = acquire(supervisor, clock, owner)
+    supervisor.request_off(owner, lease, reason=TxReleaseReason.CLIENT_DISCONNECTED)
+    before = supervisor.snapshot
+    result = supervisor.force_unkey(other, reason=TxReleaseReason.OPERATOR_FORCED_UNKEY)
+    assert result.outcome is TxOutcome.IDEMPOTENT
+    assert result.effects == ()
+    assert result.snapshot == before
+    assert (
+        result.snapshot.terminal_release_reason is TxReleaseReason.CLIENT_DISCONNECTED
+    )
+
+
+@pytest.mark.parametrize("holder", ["same-owner", "foreign-owner"])
+def test_forced_unkey_never_preempts_a_live_lease(
+    supervisor: TxSafetySupervisor,
+    clock: Clock,
+    owner: TxOwner,
+    other: TxOwner,
+    holder: str,
+) -> None:
+    lease, on = acquire(supervisor, clock, owner)
+    read = settle_on(supervisor, on)
+    supervisor.settle_attempt(read.id, 1, succeeded=True)
+    clock.advance(0.01)
+    observe(supervisor, clock, RadioTx.ON, sequence=2)
+    before = supervisor.snapshot
+    assert before.phase is TxPhase.KEYED
+    assert before.active_attempt is None
+    result = supervisor.force_unkey(
+        owner if holder == "same-owner" else other,
+        reason=TxReleaseReason.OPERATOR_FORCED_UNKEY,
+    )
+    assert result.outcome is TxOutcome.BUSY
+    assert result.effects == ()
+    assert result.snapshot == before
+    assert result.snapshot.lease_id == lease
+
+
+def test_forced_unkey_is_busy_while_the_attempt_lane_settles(
+    supervisor: TxSafetySupervisor, clock: Clock, owner: TxOwner
+) -> None:
+    lease, active = acquire(supervisor, clock, owner)
+    supervisor.request_off(owner, lease)
+    clock.advance(0.01)
+    cleared = observe(supervisor, clock, RadioTx.OFF, sequence=2)
+    assert cleared.snapshot.lease_id is None
+    assert cleared.snapshot.active_attempt == active
+    result = supervisor.force_unkey(owner, reason=TxReleaseReason.OPERATOR_FORCED_UNKEY)
+    assert result.outcome is TxOutcome.BUSY
+    assert result.effects == ()
+    assert result.snapshot.lease_id is None
+
+
+@pytest.mark.parametrize(
+    "generation", [None, 1], ids=["no-generation", "provider-not-ready"]
+)
+def test_forced_unkey_mints_no_lease_without_a_ready_provider(
+    supervisor: TxSafetySupervisor, owner: TxOwner, generation: int | None
+) -> None:
+    if generation is not None:
+        supervisor.replace_provider(generation, ready=False)
+    result = supervisor.force_unkey(owner, reason=TxReleaseReason.OPERATOR_FORCED_UNKEY)
+    assert result.outcome is TxOutcome.NOT_READY
+    assert result.effects == ()
+    assert result.snapshot.lease_id is None
+    assert supervisor.snapshot.lease_id is None
+
+
+@pytest.mark.parametrize(
+    "reason",
+    [TxReleaseReason.OPERATOR_FORCED_UNKEY, TxReleaseReason.ADMIN_EMERGENCY_STOP],
+    ids=["operator-forced", "trusted-system"],
+)
+def test_forced_unkey_adopts_an_external_unowned_key(
+    supervisor: TxSafetySupervisor,
+    clock: Clock,
+    owner: TxOwner,
+    reason: TxReleaseReason,
+) -> None:
+    supervisor.replace_provider(1, ready=True)
+    observe(supervisor, clock, RadioTx.ON)
+    assert supervisor.snapshot.phase is TxPhase.EXTERNAL_UNOWNED
+    result = supervisor.force_unkey(owner, reason=reason)
+    assert result.outcome is TxOutcome.ACCEPTED
+    assert len(result.effects) == 1
+    off = result.effects[0]
+    assert isinstance(off, ProviderAttempt)
+    assert off.kind is ProviderAttemptKind.WRITE_OFF
+    assert result.snapshot.lease_id == off.lease_id
+    assert result.snapshot.owner == owner
+    assert result.snapshot.release_reason is reason
+    assert result.snapshot.terminal_release_reason is reason
+    assert result.snapshot.phase is TxPhase.RELEASE_REQUIRED
+    assert result.snapshot.watchdog_deadline_monotonic is None
+    assert not result.snapshot.external_conflict
+    assert supervisor._acquisition is None
+
+
+def test_forced_unkey_adopts_an_idle_radio_that_reads_off(
+    supervisor: TxSafetySupervisor, clock: Clock, owner: TxOwner
+) -> None:
+    ready_off(supervisor, clock)
+    assert supervisor.snapshot.phase is TxPhase.IDLE
+    assert supervisor.snapshot.radio_tx is RadioTx.OFF
+    result = supervisor.force_unkey(owner, reason=TxReleaseReason.OPERATOR_FORCED_UNKEY)
+    assert result.outcome is TxOutcome.ACCEPTED
+    assert [effect.kind for effect in result.effects] == [ProviderAttemptKind.WRITE_OFF]
+    assert result.snapshot.watchdog_deadline_monotonic is None
+    assert supervisor._acquisition is None
+
+
+def test_a_supervisor_that_has_never_observed_anything_still_forces_an_off(
+    supervisor: TxSafetySupervisor, owner: TxOwner
+) -> None:
+    supervisor.replace_provider(1, ready=True)
+    assert supervisor.snapshot.radio_tx is RadioTx.UNKNOWN
+    assert supervisor.snapshot.phase is TxPhase.IDLE
+    result = supervisor.force_unkey(owner, reason=TxReleaseReason.OPERATOR_FORCED_UNKEY)
+    assert result.outcome is TxOutcome.ACCEPTED
+    assert len(result.effects) == 1
+    off = result.effects[0]
+    assert isinstance(off, ProviderAttempt)
+    assert off.kind is ProviderAttemptKind.WRITE_OFF
+    assert result.snapshot.watchdog_deadline_monotonic is None
+    assert not result.snapshot.external_conflict
+
+
+def test_forced_unkey_uses_one_clock_instant(owner: TxOwner) -> None:
+    clock = AdvancingClock()
+    generated = ids()
+    supervisor = TxSafetySupervisor(clock=clock, id_factory=lambda: next(generated))
+    supervisor.replace_provider(1, ready=True)
+    before, instant = clock.calls, clock.now
+    result = supervisor.force_unkey(owner, reason=TxReleaseReason.OPERATOR_FORCED_UNKEY)
+    assert clock.calls == before + 1
+    off = result.effects[0]
+    assert isinstance(off, ProviderAttempt)
+    assert off.started_at_monotonic == instant
+    assert result.snapshot.watchdog_deadline_monotonic is None
+
+
+def test_the_adopted_lease_self_clears_on_the_confirming_off(
+    supervisor: TxSafetySupervisor, clock: Clock, owner: TxOwner
+) -> None:
+    supervisor.replace_provider(1, ready=True)
+    observe(supervisor, clock, RadioTx.ON)
+    off = supervisor.force_unkey(
+        owner, reason=TxReleaseReason.OPERATOR_FORCED_UNKEY
+    ).effects[0]
+    read = supervisor.settle_attempt(off.id, 1, succeeded=True).effects[0]
+    assert read.kind is ProviderAttemptKind.READ_PTT
+    clock.advance(0.01)
+    cleared = observe(supervisor, clock, RadioTx.OFF, sequence=2)
+    assert cleared.snapshot.phase is TxPhase.IDLE
+    assert cleared.snapshot.lease_id is None
+    assert cleared.snapshot.owner is None
+    assert cleared.snapshot.release_reason is None
+    assert cleared.snapshot.terminal_release_reason is None
+    assert cleared.snapshot.release_attempt_count == 0
+    assert cleared.snapshot.watchdog_deadline_monotonic is None
+
+
 def test_acquisition_uses_one_clock_instant(owner: TxOwner) -> None:
     clock = AdvancingClock()
     generated = ids()


### PR DESCRIPTION
MOR-1175 PR 1 of 4. Adds the reducer primitive only — purely additive, and unreachable from any ingress until PR 3 publishes the operator surface.

## What this is

`TxSafetySupervisor.force_unkey(owner, *, reason)` adopts an **unowned** key so a durable OFF has a lease to run under. The minted lease is a *release obligation*, never a key-down: it exists only so the OFF inherits the retry ladder, generation-change survival and readiness-loss parking that every managed release already gets, and it self-clears on the confirming observation via `_clear_managed`.

Today an externally keyed rig — or a rig keyed by a process that has since died (MOR-1182) — cannot be unkeyed through the managed path at all: `request_off`/`release_owner` need a lease, and `emergency_release` NOOPs without one.

## Ratified policy (2026-08-01)

| Decision | Rationale |
|---|---|
| Live lease → `BUSY`, **no preempt** | Preemption is MOR-1179's territory, reached by exposing `emergency_release` — never by loosening this guard. |
| New `TxReleaseReason.OPERATOR_FORCED_UNKEY`, **not** in `_SYSTEM_RELEASE_REASONS` | One-way door. `emergency_release(OPERATOR_FORCED_UNKEY)` keeps raising `ValueError`; `force_unkey(..., OPERATOR_RELEASE)` also raises. Neither lane can launder the other's attribution. |
| Never gate on `TxPhase.EXTERNAL_UNOWNED`; never require a fresh PTT read | A supervisor in a freshly started process has no observation, so it reports `IDLE`/`UNKNOWN` while the rig is keyed — exactly the MOR-1182 case — and the read that would settle it may be broken by the same fault. |

## State machine (guards in `request_on` order)

| # | Condition | Outcome |
|---|---|---|
| 0 | `reason not in _FORCE_UNKEY_REASONS` (`_SYSTEM ∪ {OPERATOR_FORCED_UNKEY}`) | `ValueError` |
| 1 | `_release is not None` (incl. foreign) | `IDEMPOTENT`, **no mutation** — routing through `_release_current` would rewrite a foreign terminal reason |
| 2 | `_lease is not None` | `BUSY` (no preempt) |
| 3 | `_active is not None` (attempt lane settling) | `BUSY` (transient; `_start` would raise) |
| 4 | `not _ready or _generation is None` | `NOT_READY`, **no lease minted** — an unservable lease is a phantom obligation |
| 5 | otherwise | `ACCEPTED`: one clock read → mint `_Lease` → `_begin_release` → `_service_release(force=True, now=now)` → **exactly one `WRITE_OFF`** |

Invariants held on the adopt path: one clock read; `_acquisition` stays `None`; `external_conflict` `False`; the watchdog deadline stays `None` (`_begin_release` nulls it — an adopted lease is an obligation, not a key-down); `_boundary` tolerates a `None` observation.

`request_on`'s `RADIO_NOT_OFF` guard is untouched — keying is still refused while the rig is externally keyed. Only the *unkey* direction loses the observation gate.

## Scope

Three hunks, all additions: the enum member, the `_FORCE_UNKEY_REASONS` frozenset, and the method. `git diff -U0 src/rigplane/core/tx_safety.py | grep -c '^-[^-]'` → `0`; every existing method is byte-identical.

## Evidence

- `uv run pytest tests/test_tx_safety.py -q` → **79 passed** (61 on the base tree; +18 new).
- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` → **8611 passed, 12 skipped, 5 deselected, 11 xfailed, 1 xpassed**, zero failures.
- `uv run mypy src/` → 15 errors in 4 files, **identical to the baseline** measured independently on a clean checkout of the base commit (`_control_phase.py`, `_audio_runtime_mixin.py`, `_civ_rx.py`, `web/runtime_helpers.py`). No new errors; none in `tx_safety.py`.
- `uv run ruff check src/ tests/` → clean · `ruff format --check` → 634 files already formatted · `uv run lint-imports` → 5 contracts kept, 0 broken.

## Mutation probes

Each mutation was applied to a pristine `git archive` sandbox with its own venv (`rigplane.__file__` asserted inside it), re-hashed to the reviewed content before and after, and had to kill at least one test.

| # | Mutation | Killed by |
|---|---|---|
| M3 | adopt emits nothing while still `ACCEPTED` | `..._adopts_an_external_unowned_key` ×2, `..._adopts_an_idle_radio_that_reads_off`, `..._never_observed_anything_still_forces_an_off`, `..._uses_one_clock_instant`, `..._self_clears_on_the_confirming_off` |
| M4 | live-lease guard falls through (preempt) | `..._never_preempts_a_live_lease[same-owner]`, `[foreign-owner]` |
| M9 | adopt gated on `phase is EXTERNAL_UNOWNED` | `..._adopts_an_idle_radio_that_reads_off`, `..._never_observed_anything_still_forces_an_off`, `..._uses_one_clock_instant` |
| M6a | `OPERATOR_RELEASE` accepted by `force_unkey` | `..._rejects_untrusted_reason[operator_release]` |
| M6b | `OPERATOR_FORCED_UNKEY` leaked into `_SYSTEM_RELEASE_REASONS` | `..._unqualified_release_still_rejects_the_forced_unkey_reason` |
| Mwd | adopted lease arms the key-down watchdog | `..._adopts_an_external_unowned_key` ×2, `..._adopts_an_idle_radio_that_reads_off`, `..._never_observed_anything_still_forces_an_off`, `..._uses_one_clock_instant` |
| Mt1 | guard 1 routes through `_release_current` | `..._during_a_release_keeps_its_terminal_reason` |
| Mnr | lease minted before the `NOT_READY` refusal | `..._mints_no_lease_without_a_ready_provider` ×2 |
| M2c | adopt takes a second clock reading | `..._uses_one_clock_instant` |

## Follow-ups

PR 2 wires `managed_radio_runtime`, PR 3 adds `PrivilegedTxSupervisor`/`PrivilegedTxApi`, PR 4 the CLI slice with its exit-code table and docs. Web operator control is a separate ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
