### PR TITLE
feat: migrate MobileRadioLayout TX to the App-owned controller

### DIFF
--- a/frontend/src/components-v2/layout/MobileRadioLayout.svelte
+++ b/frontend/src/components-v2/layout/MobileRadioLayout.svelte
@@ -1,3 +1,14 @@
+<script module lang="ts">
+  /**
+   * Per-surface PTT lease identity. The portrait FAB and the landscape strip
+   * are separate recognizer instances and a rotation swaps one for the other,
+   * so each needs its own sourceId: the App TX controller keys lease ownership
+   * by sourceId, and a shared id would let a torn-down surface release — or
+   * latch — a lease the freshly created one, or another source entirely, owns.
+   */
+  let mobilePttSeq = 0;
+</script>
+
 <script lang="ts">
   import { runtime } from '$lib/runtime';
   import { t } from '$lib/i18n';
@@ -47,12 +58,12 @@
     makeRfFrontEndHandlers, makeModeHandlers, makeFilterHandlers,
     makeAgcHandlers, makeRitXitHandlers, makeBandHandlers, makePresetHandlers,
     makeRxAudioHandlers, makeDspHandlers, makeTxHandlers, makeCwPanelHandlers,
-    makeSystemHandlers, makeAntennaHandlers, makeScanHandlers,
+    makeAntennaHandlers, makeScanHandlers,
   } from '../wiring/command-bus';
   import { getKeyboardConfig } from '$lib/stores/capabilities.svelte';
-  import { getTxAudioControl } from '$lib/runtime/adapters/tx-adapter';
-  const txAudio = getTxAudioControl();
-  import { onMount, onDestroy, untrack } from 'svelte';
+  import { getAppTxController } from '$lib/runtime/tx-controller/app-host';
+  import { createPttGesture, type PttGesture } from '../wiring/tx-ptt-gesture';
+  import { onMount, onDestroy } from 'svelte';
   import Toast from '../../components/shared/Toast.svelte';
 
   // ── State — via runtime ──
@@ -97,7 +108,6 @@
   const cwHandlers = makeCwPanelHandlers();
   const antennaHandlers = makeAntennaHandlers();
   const scanHandlers = makeScanHandlers();
-  const systemHandlers = makeSystemHandlers();
 
   // ── VFO layout ──
   let receiverDeckElement = $state<HTMLElement | null>(null);
@@ -304,133 +314,96 @@
     };
   });
 
-  // ── PTT ──
-  // Modes: 'idle' | 'held' (touch held down) | 'latched' (double-tap locked)
-  let pttMode = $state<'idle' | 'held' | 'latched'>('idle');
-  let pttActive = $derived(pttMode !== 'idle');
+  // ── PTT — App TX controller (MOR-1012) ──
+  // This layout owns no TX state. Audio start, key confirmation, safety
+  // deadlines and fail-closed release all live in the App TX controller; the
+  // mobile surfaces only render that state and feed it gesture intent, exactly
+  // as TxPanel does (MOR-1011). What used to live here — a local held/latched
+  // machine, a 3-minute safety timer and raw ptt_on/ptt_off commands — could
+  // dekey a lease owned by another source, so it is gone rather than adapted.
+  const txCtl = getAppTxController();
+  let txState = $state.raw(txCtl.snapshot());
+  const stopWatchingTx = txCtl.subscribe((next) => { txState = next; });
+  // Registered BEFORE the recognizer effect below on purpose: Svelte tears
+  // effects down in creation order, so the subscription is dropped first and
+  // the teardown release runs to completion inside the controller instead of
+  // bouncing back into a component that is already being destroyed.
+  onDestroy(stopWatchingTx);
 
-  // ── TX color (depends on mainVfo, tx, pttActive — declared above) ──
+  let owned = $derived(txState.guard !== null);
+  let latched = $derived(txState.intent === 'latched');
+  // "The rig is keyed" for display purposes: our own lease, or an observed
+  // radio-side TX that may well belong to a different source.
+  let txKeyed = $derived(owned || txState.radioTx === 'on');
+  // PttFab's visual contract is unchanged — it still takes idle/held/latched.
+  let pttMode: 'idle' | 'held' | 'latched' = $derived(
+    latched ? 'latched' : owned ? 'held' : 'idle'
+  );
+
+  // ── TX color (depends on mainVfo, tx, txKeyed — declared above) ──
   let txPermit = $derived(getTxPermit(mainVfo.freq, caps?.txBands));
   let txIndicatorColor = $derived(
-    (tx.txActive || pttActive) ? 'var(--v2-accent-red, #ef4444)' :
+    (tx.txActive || txKeyed) ? 'var(--v2-accent-red, #ef4444)' :
     txPermit === 'allowed' ? 'var(--v2-accent-green, #4ade80)' :
     'var(--v2-text-dim, #555)'
   );
-  let lastPttDown = 0;
-  let pttPressActive = false;
-  let txStartToken = 0;
-  const DOUBLE_TAP_MS = 350;
-  const PTT_SAFETY_TIMEOUT_MS = 3 * 60 * 1000; // 3 minutes
-  let pttSafetyTimer: ReturnType<typeof setTimeout> | null = null;
 
-  function clearPttSafety() {
-    if (pttSafetyTimer) {
-      clearTimeout(pttSafetyTimer);
-      pttSafetyTimer = null;
-    }
-  }
+  // One recognizer per input surface. The portrait FAB and the landscape strip
+  // are never mounted together and a rotation swaps one for the other; a shared
+  // recognizer would carry an armed release window across that swap, where the
+  // first press on the new surface would be misread as the second half of a
+  // double-tap. Re-keying the effect on the surface destroys the old recognizer
+  // instead — `destroy()` releases a live lease exactly once, which is why
+  // rotating away while keyed or latched now drops TX rather than stranding it.
+  let pttSurface: 'none' | 'portrait' | 'landscape' = $derived(
+    !txCapable ? 'none' : isLandscape ? 'landscape' : 'portrait'
+  );
+  let ptt: PttGesture | null = null;
 
-  function startPttSafety() {
-    clearPttSafety();
-    pttSafetyTimer = setTimeout(() => {
-      // Safety: force PTT off after timeout
-      pttMode = 'idle';
-      disengageTx();
-    }, PTT_SAFETY_TIMEOUT_MS);
-  }
-
-  async function engageTx(token: number): Promise<boolean> {
-    const err = await txAudio.startTx();
-    if (token !== txStartToken || pttMode !== 'held' || !pttPressActive) {
-      if (!err) txAudio.stopTx();
-      return false;
-    }
-    if (err) {
-      console.warn('TX audio did not start:', err);
-      return false;
-    }
-    systemHandlers.onPttOn();
-    return true;
-  }
-
-  function disengageTx() {
-    systemHandlers.onPttOff();
-    txAudio.stopTx();
-  }
-
-  async function pttDown() {
-    const now = Date.now();
-    if (pttMode === 'latched') {
-      // Tap while latched → unlock, go idle
-      pttPressActive = false;
-      txStartToken += 1;
-      pttMode = 'idle';
-      disengageTx();
-      clearPttSafety();
-      return;
-    }
-    if (now - lastPttDown < DOUBLE_TAP_MS && pttMode === 'held') {
-      // Double-tap → latch
-      pttPressActive = false;
-      pttMode = 'latched';
-      startPttSafety();
-      lastPttDown = 0;
-      return;
-    }
-    // Normal press → held
-    lastPttDown = now;
-    pttPressActive = true;
-    pttMode = 'held';
-    const token = ++txStartToken;
-    if (await engageTx(token)) {
-      startPttSafety();
-    } else {
-      pttMode = 'idle';
-      lastPttDown = 0;
-    }
-  }
-
-  function pttUp() {
-    pttPressActive = false;
-    txStartToken += 1;
-    if (pttMode === 'held') {
-      // Release after single tap → off
-      // But give a moment for double-tap detection
-      setTimeout(() => {
-        if (pttMode === 'held') {
-          pttMode = 'idle';
-          disengageTx();
-          clearPttSafety();
-        }
-      }, DOUBLE_TAP_MS);
-    }
-    // If latched, don't turn off on release
-  }
-
-  // Orientation-change safety net (codex P1 on PR #931 / #934 regression).
-  // PttFab is conditionally mounted on `!isLandscape`; rotation removes
-  // the component so its `pointerup` never fires. Without this guard,
-  // an in-progress press would leave `pttMode === 'held'` and TX keyed
-  // until the 3-minute safety timer.
-  //
-  // Must fire ONLY on the transition `portrait → landscape`, not on
-  // every `pttMode` change — otherwise landscape hold-to-talk engages
-  // and is instantly released by this same effect (codex P1 on PR #934).
-  //
-  // Plain `let` for prevIsLandscape so it doesn't become a reactive
-  // dep; `untrack` on `pttMode` so only orientation changes re-run the
-  // effect body.
-  let prevIsLandscape = false;
   $effect(() => {
-    const nowLandscape = isLandscape;
-    const enteredLandscape = !prevIsLandscape && nowLandscape;
-    prevIsLandscape = nowLandscape;
-    if (enteredLandscape && untrack(() => pttMode) === 'held') {
-      pttMode = 'idle';
-      disengageTx();
-      clearPttSafety();
-    }
+    const surface = pttSurface;
+    if (surface === 'none') return;
+    const sourceId = `mobile-ptt-${surface}-${++mobilePttSeq}`;
+    let leaseSeq = 0;
+    const gesture = createPttGesture(
+      // Read the controller DIRECTLY rather than the subscribed `txState`:
+      // teardown runs after the subscription has already been dropped, and a
+      // stale snapshot there would release a guard that has since moved on.
+      {
+        guard: () => txCtl.snapshot().guard,
+        latched: () => txCtl.snapshot().intent === 'latched',
+      },
+      {
+        start: () => {
+          // A stale fault would swallow the start (the model only leaves
+          // 'failed' on an explicit reset), so clear it as part of the press —
+          // otherwise one denied press bricks mobile TX for the session.
+          if (txCtl.snapshot().phase === 'failed') txCtl.resetFault();
+          txCtl.start(sourceId, `${sourceId}-${++leaseSeq}`, 'momentary');
+        },
+        latch: (guard) => txCtl.setIntent(sourceId, guard, 'latched'),
+        release: (guard) => txCtl.release(sourceId, guard),
+      },
+      {
+        schedule: (callback, ms) => setTimeout(callback, ms),
+        cancel: (handle) => clearTimeout(handle as ReturnType<typeof setTimeout>),
+      },
+    );
+    ptt = gesture;
+    return () => { ptt = null; gesture.destroy(); };
   });
+
+  // PttFab's 50 ms hold timer is not cleared when it unmounts, so a press that
+  // began in portrait can still fire onDown() after a rotation has already
+  // swapped in the landscape recognizer. Both FAB entry points therefore check
+  // that portrait is still the live surface before touching the recognizer.
+  function fabDown() {
+    if (pttSurface === 'portrait') ptt?.down();
+  }
+
+  function fabUp() {
+    if (pttSurface === 'portrait') ptt?.up();
+  }
 
   // ── Landscape PTT guards (#843 parity with FAB) ──
   // Adds pointermove-8px cancel + haptic + TX-permit dim-state so the
@@ -444,8 +417,8 @@
 
   function lsPttPointerDown(event: PointerEvent) {
     if (pttMode === 'latched') {
-      // Tap-to-unlatch — delegate to shared state machine.
-      pttDown();
+      // Tap-to-unlatch — the recognizer releases the live lease on a down().
+      ptt?.down();
       return;
     }
     if (txPermit === 'denied' && pttMode === 'idle') {
@@ -464,7 +437,7 @@
     if (typeof navigator !== 'undefined' && typeof navigator.vibrate === 'function') {
       try { navigator.vibrate(10); } catch { /* noop */ }
     }
-    pttDown();
+    ptt?.down();
   }
 
   function lsPttPointerMove(event: PointerEvent) {
@@ -473,14 +446,14 @@
     const dy = event.clientY - lsPttStartY;
     if (dx * dx + dy * dy > LS_PTT_MOVE_CANCEL_PX * LS_PTT_MOVE_CANCEL_PX) {
       lsPttEngaged = false;
-      pttUp();
+      ptt?.up();
     }
   }
 
   function lsPttPointerUp() {
     if (!lsPttEngaged) return;
     lsPttEngaged = false;
-    pttUp();
+    ptt?.up();
   }
 
   let lsLastDeniedPressAt = 0;
@@ -556,8 +529,8 @@
       {#if txCapable}
         <button
           class="m-ls-ptt"
-          class:m-ptt-held={pttMode === 'held'}
-          class:m-ptt-latched={pttMode === 'latched'}
+          class:m-ptt-held={owned && !latched}
+          class:m-ptt-latched={latched}
           class:m-ls-ptt-dim={txPermit === 'denied' && pttMode === 'idle'}
           onpointerdown={lsPttPointerDown}
           onpointermove={lsPttPointerMove}
@@ -736,7 +709,7 @@
             <!-- Power readout (tap → power modal) -->
             <button type="button" class="m-tx-info" disabled={!tx.rfPowerAvailable} onclick={() => (powerModalOpen = true)}>
               <span class="m-tx-power-value">{tx.rfPowerAvailable ? formatPower(tx.rfPower) : '—'}</span>
-              {#if tx.txActive || pttActive}
+              {#if tx.txActive || txKeyed}
                 <span class="m-tx-swr-value">SWR {meter.swr > 0 ? (meter.swr / 10).toFixed(1) : '—'}</span>
               {/if}
             </button>
@@ -764,7 +737,7 @@
             <!-- Inline PTT button removed (#840) — PttFab at bottom-right
                  is the persistent, guarded TX affordance. -->
           </div>
-          {#if tx.txActive || pttActive}
+          {#if tx.txActive || txKeyed}
             <div class="m-tx-meter">
               <DockMeterPanel
                 sValue={mainVfo.sValue}
@@ -938,13 +911,14 @@
   <!-- Guarded sticky PTT FAB (#840) — persistent 1-tap TX in portrait only.
        Landscape has its own guarded `.m-ls-ptt` button (#843); mounting
        FAB there would give two simultaneous TX controls (codex P1 on
-       PR #928). Layered guards live in the FAB component. State machine
-       stays in the parent (pttMode + 3-min safety timer + double-tap). -->
+       PR #928). Layered guards (50 ms hold, 8 px move-cancel, haptics,
+       TX-permit two-step) live in the FAB component; the TX state machine
+       lives in the App TX controller (MOR-1012). -->
   <PttFab
     mode={pttMode}
     txPermit={txPermit}
-    onDown={pttDown}
-    onUp={pttUp}
+    onDown={fabDown}
+    onUp={fabUp}
   />
 {/if}
 

--- a/frontend/src/components-v2/layout/__tests__/MobileRadioLayout.component.svelte.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/MobileRadioLayout.component.svelte.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mount, unmount, flushSync } from 'svelte';
+import { TxController } from '$lib/runtime/tx-controller/controller';
+import type { TxControllerDependencies } from '$lib/runtime/tx-controller/controller';
 
 // -- Child component stubs --
 vi.mock('../../../components/spectrum/SpectrumPanel.svelte', async () => {
@@ -14,6 +16,9 @@ vi.mock('../controls/BottomSheet.svelte', () => ({ default: function S() { retur
 vi.mock('../controls/BandSelector.svelte', () => ({ default: function S() { return {}; } }));
 vi.mock('../panels/FilterPanel.svelte', () => ({ default: function S() { return {}; } }));
 vi.mock('../panels/RxAudioPanel.svelte', () => ({ default: function S() { return {}; } }));
+// TxPanel stays stubbed: it is a lease source in its own right (MOR-1011) and
+// mounting the real one inside the TX-settings sheet would put a second
+// recognizer on the same controller, which is not what these tests are about.
 vi.mock('../panels/TxPanel.svelte', () => ({ default: function S() { return {}; } }));
 vi.mock('../panels/DspPanel.svelte', () => ({ default: function S() { return {}; } }));
 vi.mock('../panels/AgcPanel.svelte', () => ({ default: function S() { return {}; } }));
@@ -26,6 +31,9 @@ vi.mock('../panels/DockMeterPanel.svelte', () => ({ default: function S() { retu
 vi.mock('./KeyboardHandler.svelte', () => ({ default: function S() { return {}; } }));
 // Note: ../panels/EssentialsPanel.svelte and ./mobile-chip-bar.svelte are intentionally
 // NOT mocked — the chip-scroll IA contract (#839) is part of what these tests cover.
+// ../controls/PttFab.svelte is intentionally NOT mocked either: its layered
+// guards (50 ms hold, 8 px move-cancel, TX-permit two-step) are half of the
+// mobile PTT contract under test.
 vi.mock('$lib/Button', () => ({ HardwareButton: function S() { return {}; } }));
 vi.mock('lucide-svelte', () => {
   const S = function () { return {}; };
@@ -84,20 +92,9 @@ vi.mock('$lib/stores/capabilities.svelte', () => ({
 const {
   onMainVfoClickSpy,
   onSubVfoClickSpy,
-  mobileSystemHandlers,
-  mobileTxAudioControl,
 } = vi.hoisted(() => ({
   onMainVfoClickSpy: vi.fn(),
   onSubVfoClickSpy: vi.fn(),
-  mobileSystemHandlers: {
-    onPowerOff: vi.fn(),
-    onPttOn: vi.fn(),
-    onPttOff: vi.fn(),
-  },
-  mobileTxAudioControl: {
-    startTx: vi.fn(),
-    stopTx: vi.fn(),
-  },
 }));
 vi.mock('../../wiring/command-bus', () => {
   const n = vi.fn();
@@ -119,12 +116,19 @@ vi.mock('../../wiring/command-bus', () => {
     makeCwPanelHandlers: () => ({ onSpeedChange: n }),
     makeAntennaHandlers: () => ({ onAntennaSelect: n }),
     makeScanHandlers: () => ({ onScanStart: n, onScanStop: n, onDfSpanChange: n, onResumeChange: n }),
-    makeSystemHandlers: () => mobileSystemHandlers,
   };
 });
-vi.mock('$lib/runtime/adapters/tx-adapter', () => ({
-  getTxAudioControl: () => mobileTxAudioControl,
+
+// MOR-1012: the layout owns no PTT state any more — it renders the App TX
+// controller and feeds it gesture intent. Only the *host* (the context lookup)
+// is mocked; behind it sits a REAL TxController over stub dependencies, so
+// these tests exercise the production state machine instead of a double.
+const txHost = vi.hoisted(() => ({ current: undefined as unknown as TxHostFacade }));
+
+vi.mock('$lib/runtime/tx-controller/app-host', () => ({
+  getAppTxController: () => txHost.current,
 }));
+
 vi.mock('../wiring/state-adapter', () => {
   const vfo = { freq: 14074000, mode: 'USB', filter: 'FIL1', sValue: 0, badges: {}, receiver: 'main', isActive: true };
   return {
@@ -144,10 +148,115 @@ vi.mock('../wiring/state-adapter', () => {
 });
 
 import MobileRadioLayout from '../MobileRadioLayout.svelte';
+import mobileLayoutSource from '../MobileRadioLayout.svelte?raw';
 import { hasTx, hasDualReceiver } from '$lib/stores/capabilities.svelte';
 import { radio } from '$lib/stores/radio.svelte';
+import { getTxPermit } from '$lib/utils/tx-permit';
 
+// ---------------------------------------------------------------------------
+// Real-controller harness
+//
+// Copied verbatim (bar this note) from
+// src/components-v2/panels/__tests__/TxPanel.test.ts, which in turn follows
+// tx-controller/__tests__/controller-contract. Duplicated rather than shared
+// because the two suites live in different pools and a shared helper module
+// would pin the controller in the ``isolate: false`` cache for siblings that
+// mock it — see vite.config.ts / #771. Keep the two copies in step.
+// ---------------------------------------------------------------------------
+
+type TxEvent = Parameters<TxController['dispatch']>[0];
+type StartEvent = Extract<TxEvent, { type: 'start' }>;
+type Eligibility = StartEvent['eligibility'];
+type Observation = StartEvent['ptt'];
+type Intent = StartEvent['intent'];
+type Guard = Extract<TxEvent, { type: 'intent' }>['guard'];
+type Command = Parameters<TxControllerDependencies['sendPtt']>[0];
+type Report = Parameters<TxControllerDependencies['sendPtt']>[3];
+type TxHostFacade = ReturnType<typeof createTxHarness>['facade'];
+
+const marker = (seq: number) => ({
+  authorityEpoch: 1, pttObservationSeq: seq, pttLastObservedMonotonic: seq,
+});
+const allowed: Eligibility = {
+  catPtt: true, browserTxAudio: true, controlLive: true, permit: 'allowed',
+  target: { receiver: 'MAIN', slot: 'A', frequencyHz: 14_074_000 },
+};
+const observe = (value: boolean, seq: number): Observation =>
+  ({ value, observed: true, fresh: true, source: 'radio-readback', marker: marker(seq) });
+
+/** Mirrors the deep-frozen snapshot/subscribe payloads app-host hands out. */
+function deepFreeze<T>(value: T): T {
+  if (value === null || typeof value !== 'object') return value;
+  const copy = Object.fromEntries(Object.entries(value as Record<string, unknown>)
+    .map(([key, child]) => [key, deepFreeze(child)]));
+  return Object.freeze(copy) as unknown as T;
+}
+
+function createTxHarness() {
+  const sends: Array<{ command: Command; report: Report }> = [];
+  const audio: { next: Promise<string | null> } = { next: Promise.resolve(null) };
+  const eligibility = { current: allowed };
+  let id = 0;
+  let seq = 0;
+  const dependencies: TxControllerDependencies = {
+    startAudio: vi.fn(() => audio.next),
+    sendPtt: vi.fn((command, _commandId, _correlation, report) => { sends.push({ command, report }); }),
+    stopLocalAudio: vi.fn(),
+    restoreMod: vi.fn(),
+    commandId: vi.fn((command) => `${command}-${++id}`),
+    schedule: vi.fn((callback, delay) => setTimeout(callback, delay)),
+    cancel: vi.fn((handle) => clearTimeout(handle as ReturnType<typeof setTimeout>)),
+    // Far beyond the 300 ms gesture window so controller deadlines never race it.
+    timeoutMs: { 'audio-start': 60_000, 'on-confirmation': 60_000, 'off-confirmation': 60_000 },
+  };
+  const controller = new TxController(1, marker(0), dependencies);
+  const facade = {
+    snapshot: () => deepFreeze(controller.snapshot()),
+    subscribe: (listener: (state: unknown) => void) =>
+      controller.subscribe((state) => listener(deepFreeze(state))),
+    start: (sourceId: string, leaseId: string, intent: Intent) => controller.dispatch({
+      type: 'start', sourceId, leaseId, intent,
+      eligibility: eligibility.current, ptt: observe(false, ++seq),
+    }),
+    setIntent: (sourceId: string, guard: Guard, intent: Intent) =>
+      controller.dispatch({ type: 'intent', sourceId, guard: { ...guard }, intent }),
+    release: (sourceId: string, guard: Guard) => controller.dispatch({
+      type: 'release', sourceId, guard: { ...guard }, commandId: dependencies.commandId('off'),
+    }),
+    resetFault: () => controller.dispatch({ type: 'reset-fault' }),
+  };
+  return {
+    controller, dependencies, sends, facade, audio, eligibility,
+    /** Feed an authoritative PTT readback (what the App host does on session updates). */
+    authority: (value: boolean) => controller.dispatch({
+      type: 'authority', epoch: 1, ptt: observe(value, ++seq),
+      eligibility: eligibility.current, offCommandId: dependencies.commandId('off'),
+    }),
+    /** Report the most recent command of `command` as delivered. */
+    confirm: (command: Command) => {
+      const send = [...sends].reverse().find((item) => item.command === command);
+      expect(send).toBeDefined();
+      send!.report({ outcome: 'sent', eventEpoch: 1, barrier: marker(++seq) });
+    },
+    /** A competing lease source (e.g. a desktop TxPanel on the same session). */
+    startOther: (leaseId: string) => controller.dispatch({
+      type: 'start', sourceId: 'other-panel', leaseId, intent: 'momentary',
+      eligibility: eligibility.current, ptt: observe(false, ++seq),
+    }),
+  };
+}
+
+let tx: ReturnType<typeof createTxHarness>;
 let components: ReturnType<typeof mount>[] = [];
+
+/** PttFab's press-and-hold guard, and the recognizer's double-tap window. */
+const HOLD_MS = 50;
+const GESTURE_WINDOW_MS = 300;
+
+function setViewport(landscape: boolean) {
+  Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: landscape ? 844 : 390 });
+  Object.defineProperty(window, 'innerHeight', { writable: true, configurable: true, value: landscape ? 390 : 844 });
+}
 
 function mountMobile(): HTMLElement {
   const t = document.createElement('div');
@@ -157,21 +266,29 @@ function mountMobile(): HTMLElement {
   return t;
 }
 
+function mountLandscape(): HTMLElement {
+  setViewport(true);
+  return mountMobile();
+}
+
+/** Rotate the device. jsdom has no fullscreen API; the layout guards for it. */
+function rotate(landscape: boolean) {
+  setViewport(landscape);
+  window.dispatchEvent(new Event('resize'));
+  flushSync();
+}
+
 beforeEach(() => {
   components = [];
-  Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 390 });
-  Object.defineProperty(window, 'innerHeight', { writable: true, configurable: true, value: 844 });
+  setViewport(false);
+  tx = createTxHarness();
+  txHost.current = tx.facade;
   vi.mocked(hasTx).mockReturnValue(true);
   vi.mocked(hasDualReceiver).mockReturnValue(false);
+  vi.mocked(getTxPermit).mockReturnValue('allowed');
   (radio as unknown as { current: { active?: 'MAIN' | 'SUB' } | null }).current = null;
   onMainVfoClickSpy.mockClear();
   onSubVfoClickSpy.mockClear();
-  mobileSystemHandlers.onPowerOff.mockReset();
-  mobileSystemHandlers.onPttOn.mockReset();
-  mobileSystemHandlers.onPttOff.mockReset();
-  mobileTxAudioControl.startTx.mockReset();
-  mobileTxAudioControl.stopTx.mockReset();
-  mobileTxAudioControl.startTx.mockResolvedValue(null);
 });
 
 afterEach(() => {
@@ -272,30 +389,6 @@ describe('MobileRadioLayout TX gating', () => {
     // ESSENTIALS chip should now be the active one in the chip bar.
     const active = t.querySelector('.m-chip-bar .m-chip-active');
     expect(active?.textContent?.trim()).toBe('ESSENTIALS');
-  });
-
-  it('does not key PTT when released before TX audio startup finishes', async () => {
-    vi.useFakeTimers();
-    let resolveStart!: (value: string | null) => void;
-    mobileTxAudioControl.startTx.mockReturnValueOnce(new Promise((resolve) => {
-      resolveStart = resolve;
-    }));
-
-    const t = mountMobile();
-    const ptt = t.querySelector<HTMLButtonElement>('.ptt-fab')!;
-    ptt.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, pointerId: 1 }));
-    vi.advanceTimersByTime(60);
-    ptt.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, pointerId: 1 }));
-    resolveStart(null);
-    await Promise.resolve();
-    await Promise.resolve();
-    flushSync();
-
-    expect(mobileSystemHandlers.onPttOn).not.toHaveBeenCalled();
-    expect(mobileTxAudioControl.stopTx).toHaveBeenCalledOnce();
-
-    vi.runOnlyPendingTimers();
-    vi.useRealTimers();
   });
 });
 
@@ -409,5 +502,368 @@ describe('MobileRadioLayout receiver selector (#719)', () => {
     } finally {
       Element.prototype.scrollIntoView = origScroll;
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PTT — driven entirely by the App TX controller (MOR-1012)
+// ---------------------------------------------------------------------------
+
+describe('mobile PTT via the App TX controller (MOR-1012)', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  const fabEl = (t: HTMLElement) => t.querySelector<HTMLButtonElement>('.ptt-fab')!;
+  const stripEl = (t: HTMLElement) => t.querySelector<HTMLButtonElement>('.m-ls-ptt')!;
+  const offs = () => tx.sends.filter((item) => item.command === 'off').length;
+  const flushAudio = async () => { await Promise.resolve(); await Promise.resolve(); flushSync(); };
+
+  function pointer(el: Element, type: string, init: PointerEventInit = {}) {
+    el.dispatchEvent(new PointerEvent(type, {
+      bubbles: true, pointerId: 1, clientX: 0, clientY: 0, ...init,
+    }));
+    flushSync();
+  }
+
+  /** A completed FAB press: PttFab only calls onDown() past its 50 ms guard. */
+  function fabPress(t: HTMLElement) {
+    pointer(fabEl(t), 'pointerdown');
+    vi.advanceTimersByTime(HOLD_MS);
+    flushSync();
+  }
+  const fabRelease = (t: HTMLElement) => pointer(fabEl(t), 'pointerup');
+
+  /** Press and hold the FAB until the radio has acknowledged the ON command. */
+  async function hold(t: HTMLElement) {
+    fabPress(t);
+    await flushAudio();
+    tx.confirm('on');
+    flushSync();
+  }
+
+  /** Hold, then double-tap the FAB into the latched lock. */
+  async function latch(t: HTMLElement) {
+    await hold(t);
+    fabRelease(t);
+    vi.advanceTimersByTime(100);
+    fabPress(t);
+  }
+
+  /** Same two gestures, on the landscape strip (no 50 ms hold guard there). */
+  async function holdStrip(t: HTMLElement) {
+    pointer(stripEl(t), 'pointerdown');
+    await flushAudio();
+    tx.confirm('on');
+    flushSync();
+  }
+
+  async function latchStrip(t: HTMLElement) {
+    await holdStrip(t);
+    pointer(stripEl(t), 'pointerup');
+    vi.advanceTimersByTime(100);
+    pointer(stripEl(t), 'pointerdown');
+  }
+
+  function selectChip(t: HTMLElement, label: string) {
+    const chip = Array.from(t.querySelectorAll<HTMLButtonElement>('.m-chip'))
+      .find((b) => b.textContent?.trim() === label);
+    expect(chip, `chip ${label} should exist`).toBeDefined();
+    chip!.click();
+    flushSync();
+  }
+
+  // -- A: portrait FAB ------------------------------------------------------
+
+  it('keys a FAB hold through audio start and the ON confirmation', async () => {
+    const t = mountMobile();
+    fabPress(t);
+    expect(tx.dependencies.startAudio).toHaveBeenCalledOnce();
+    expect(tx.controller.snapshot().phase).toBe('audio-start-pending');
+    await flushAudio();
+    tx.confirm('on');
+    flushSync();
+    expect(tx.controller.snapshot().phase).toBe('key-confirm-pending');
+    expect(fabEl(t).classList.contains('ptt-fab-held')).toBe(true);
+    tx.authority(true);
+    flushSync();
+    expect(tx.controller.snapshot().phase).toBe('active');
+    // No local safety timer any more — the controller owns every deadline.
+    vi.advanceTimersByTime(5 * 60 * 1000);
+    expect(offs()).toBe(0);
+  });
+
+  it('ignores a press released before the FAB 50 ms hold guard closes', () => {
+    const t = mountMobile();
+    pointer(fabEl(t), 'pointerdown');
+    vi.advanceTimersByTime(HOLD_MS - 20);
+    pointer(fabEl(t), 'pointerup');
+    vi.advanceTimersByTime(HOLD_MS);
+    flushSync();
+    expect(tx.dependencies.startAudio).not.toHaveBeenCalled();
+    expect(tx.controller.snapshot().phase).toBe('idle');
+  });
+
+  it('holds the lease for 299 ms after release and drops it at 300 ms', async () => {
+    const t = mountMobile();
+    await hold(t);
+    fabRelease(t);
+    vi.advanceTimersByTime(GESTURE_WINDOW_MS - 1);
+    flushSync();
+    expect(offs()).toBe(0);
+    expect(tx.controller.snapshot().phase).toBe('key-confirm-pending');
+    vi.advanceTimersByTime(1);
+    flushSync();
+    expect(offs()).toBe(1);
+    expect(tx.controller.snapshot().phase).toBe('releasing');
+  });
+
+  it('latches on a double tap without starting a second lease', async () => {
+    const t = mountMobile();
+    await latch(t);
+    expect(tx.controller.snapshot().intent).toBe('latched');
+    expect(tx.dependencies.startAudio).toHaveBeenCalledOnce();
+    expect(fabEl(t).classList.contains('ptt-fab-latched')).toBe(true);
+    // Confirm the key on the radio, then sit on it far longer than the retired
+    // 3-minute local safety timer: a latched lease must stay up.
+    tx.authority(true);
+    flushSync();
+    vi.advanceTimersByTime(5 * 60 * 1000);
+    expect(offs()).toBe(0);
+  });
+
+  it('unlatches on the next tap instead of starting a new lease', async () => {
+    const t = mountMobile();
+    await latch(t);
+    fabRelease(t);
+    pointer(fabEl(t), 'pointerdown'); // latched → PttFab delegates immediately
+    expect(offs()).toBe(1);
+    expect(tx.controller.snapshot().phase).toBe('releasing');
+    expect(tx.dependencies.startAudio).toHaveBeenCalledOnce();
+  });
+
+  it('drops a quick tap taken while TX audio is still pending, and never keys late', async () => {
+    let resolveAudio!: (value: string | null) => void;
+    tx.audio.next = new Promise((resolve) => { resolveAudio = resolve; });
+    const t = mountMobile();
+    fabPress(t);
+    expect(tx.controller.snapshot().phase).toBe('audio-start-pending');
+    fabRelease(t);
+    vi.advanceTimersByTime(GESTURE_WINDOW_MS);
+    flushSync();
+    expect(tx.controller.snapshot().phase).toBe('releasing');
+    resolveAudio(null);
+    await flushAudio();
+    expect(tx.sends.filter((item) => item.command === 'on')).toHaveLength(0);
+  });
+
+  it('needs the documented two-step press when the UI TX permit is denied', () => {
+    vi.mocked(getTxPermit).mockReturnValue('denied');
+    const t = mountMobile();
+    fabPress(t);
+    expect(tx.dependencies.startAudio).not.toHaveBeenCalled();
+    expect(fabEl(t).classList.contains('ptt-fab-armed')).toBe(true);
+    fabPress(t); // second press inside the 2 s arm window engages
+    expect(tx.dependencies.startAudio).toHaveBeenCalledOnce();
+  });
+
+  // A.6b — without resetFault() in the recognizer's start command, one denied
+  // press leaves the model in 'failed' and every later press is swallowed:
+  // mobile TX would be bricked for the rest of the session.
+  it('clears a stale controller fault on the next press instead of bricking TX', async () => {
+    tx.eligibility.current = { ...allowed, permit: 'denied' };
+    const t = mountMobile();
+    fabPress(t);
+    expect(tx.controller.snapshot()).toMatchObject({ phase: 'failed', fault: 'not-eligible' });
+    fabRelease(t);
+
+    tx.eligibility.current = allowed;
+    fabPress(t);
+    await flushAudio();
+    expect(tx.controller.snapshot()).toMatchObject({ fault: null, phase: 'audio-start-pending' });
+  });
+
+  // -- B: landscape strip ---------------------------------------------------
+
+  it('keys and releases from the landscape strip', async () => {
+    const t = mountLandscape();
+    await holdStrip(t);
+    expect(tx.controller.snapshot().phase).toBe('key-confirm-pending');
+    expect(stripEl(t).classList.contains('m-ptt-held')).toBe(true);
+    pointer(stripEl(t), 'pointerup');
+    vi.advanceTimersByTime(GESTURE_WINDOW_MS);
+    flushSync();
+    expect(offs()).toBe(1);
+    expect(tx.controller.snapshot().phase).toBe('releasing');
+  });
+
+  it('cancels the landscape press only once the finger slides past 8 px', async () => {
+    const t = mountLandscape();
+    await holdStrip(t);
+    pointer(stripEl(t), 'pointermove', { clientX: 5, clientY: 0 });
+    vi.advanceTimersByTime(GESTURE_WINDOW_MS);
+    flushSync();
+    expect(offs()).toBe(0);
+    pointer(stripEl(t), 'pointermove', { clientX: 20, clientY: 0 });
+    vi.advanceTimersByTime(GESTURE_WINDOW_MS);
+    flushSync();
+    expect(offs()).toBe(1);
+  });
+
+  it('treats pointercancel, lostpointercapture and pointerup as one release', async () => {
+    const t = mountLandscape();
+    await holdStrip(t);
+    pointer(stripEl(t), 'pointercancel');
+    pointer(stripEl(t), 'lostpointercapture');
+    pointer(stripEl(t), 'pointerup');
+    vi.advanceTimersByTime(GESTURE_WINDOW_MS * 2);
+    flushSync();
+    expect(offs()).toBe(1);
+  });
+
+  // -- C: surface lifecycle -------------------------------------------------
+
+  // C.10 — the portrait recognizer is destroyed by the rotation, and destroy()
+  // releases the live lease. Before MOR-1012 this depended on a bespoke
+  // orientation $effect that only covered portrait → landscape while 'held'.
+  it('releases TX when a rotation to landscape tears the portrait recognizer down', async () => {
+    const t = mountMobile();
+    await hold(t);
+    expect(tx.controller.snapshot().phase).toBe('key-confirm-pending');
+    rotate(true);
+    expect(offs()).toBe(1);
+    expect(tx.controller.snapshot().phase).toBe('releasing');
+  });
+
+  // C.11 — the direction and the state the old orientation guard did NOT cover.
+  // Documented behaviour change: rotating while latched drops TX.
+  it('drops a LATCHED TX when the operator rotates back to portrait', async () => {
+    const t = mountLandscape();
+    await latchStrip(t);
+    expect(tx.controller.snapshot().intent).toBe('latched');
+    rotate(false);
+    expect(offs()).toBe(1);
+    expect(tx.controller.snapshot().phase).toBe('releasing');
+  });
+
+  it('releases TX when the radio stops reporting TX capability', async () => {
+    const capable = $state({ on: true });
+    vi.mocked(hasTx).mockImplementation(() => capable.on);
+    const t = mountMobile();
+    await hold(t);
+    capable.on = false;
+    flushSync();
+    expect(offs()).toBe(1);
+    expect(tx.controller.snapshot().phase).toBe('releasing');
+  });
+
+  // C.13 — the layout imported onDestroy but never used it, so an unmount left
+  // the rig keyed and the safety timer armed.
+  it('releases TX when the layout unmounts', async () => {
+    const t = mountMobile();
+    await hold(t);
+    expect(tx.controller.snapshot().phase).toBe('key-confirm-pending');
+    unmount(components.pop()!);
+    expect(offs()).toBe(1);
+    expect(tx.controller.snapshot().phase).toBe('releasing');
+  });
+
+  // C.14 — PttFab does not clear its 50 ms hold timer on unmount (R3), so the
+  // orphaned timer still calls onDown() after the rotation.
+  it('ignores a stale FAB hold timer that fires after a rotation to landscape', () => {
+    const t = mountMobile();
+    pointer(fabEl(t), 'pointerdown');
+    rotate(true);
+    vi.advanceTimersByTime(HOLD_MS);
+    flushSync();
+    expect(tx.dependencies.startAudio).not.toHaveBeenCalled();
+    expect(tx.controller.snapshot().phase).toBe('idle');
+  });
+
+  // -- D: other lease sources on the same controller -------------------------
+
+  // D.15 — the guard alone always matches (it is the single live lease), so the
+  // per-surface sourceId is the only thing stopping mobile from releasing or
+  // latching a lease a desktop panel owns.
+  it('cannot release or latch a lease owned by another source', async () => {
+    const t = mountMobile();
+    tx.startOther('desktop-panel-lease');
+    flushSync();
+    const owner = tx.controller.snapshot().sourceId;
+
+    fabPress(t);   // start() is a silent no-op — the model is not idle
+    fabRelease(t); // arms a window against the DESKTOP guard
+    vi.advanceTimersByTime(100);
+    fabPress(t);   // a double tap that would latch if the sourceId were shared
+    vi.advanceTimersByTime(GESTURE_WINDOW_MS * 2);
+    flushSync();
+
+    expect(offs()).toBe(0);
+    expect(tx.dependencies.startAudio).toHaveBeenCalledOnce();
+    expect(tx.controller.snapshot()).toMatchObject({
+      sourceId: owner, intent: 'momentary', phase: 'audio-start-pending',
+    });
+  });
+
+  // D.16 — the two failures the old machine had here: the orphaned FAB timer
+  // engaged TX unconditionally, and its release path issued a raw ptt_off that
+  // bypassed the controller and could dekey whoever actually owned the key.
+  it('cannot key or dekey a desktop owner when a stale FAB timer fires after a rotation', () => {
+    const t = mountMobile();
+    pointer(fabEl(t), 'pointerdown'); // press starts, hold timer armed
+    rotate(true);                     // PttFab unmounts; its timer is NOT cleared
+    tx.startOther('desktop-panel-lease');
+    flushSync();
+    const owner = tx.controller.snapshot().sourceId;
+
+    vi.advanceTimersByTime(HOLD_MS);  // the orphaned FAB timer fires here
+    flushSync();
+    vi.advanceTimersByTime(GESTURE_WINDOW_MS * 2);
+    flushSync();
+
+    expect(tx.dependencies.startAudio).toHaveBeenCalledOnce(); // only the desktop start
+    expect(offs()).toBe(0);
+    expect(tx.controller.snapshot()).toMatchObject({
+      sourceId: owner, phase: 'audio-start-pending',
+    });
+  });
+
+  // D.17 — the recognizer effect is keyed on the surface alone, so unrelated
+  // sheet/chip churn must neither recreate it nor disturb the live lease.
+  it('keeps one live lease across TX sheet and chip churn', async () => {
+    const t = mountMobile();
+    await hold(t);
+    const guard = tx.controller.snapshot().guard;
+
+    selectChip(t, 'TX');
+    t.querySelector<HTMLButtonElement>('.m-tx-settings-btn')!.click();
+    flushSync();
+    selectChip(t, 'BAND');
+    selectChip(t, 'ESSENTIALS');
+
+    expect(offs()).toBe(0);
+    expect(tx.controller.snapshot().guard).toEqual(guard);
+
+    fabRelease(t);
+    vi.advanceTimersByTime(GESTURE_WINDOW_MS);
+    flushSync();
+    expect(offs()).toBe(1);
+  });
+
+  // -- E: source-level proof the legacy machine is gone ----------------------
+
+  it('no longer references the retired local PTT machinery', () => {
+    expect(mobileLayoutSource).not.toContain('tx-adapter');
+    expect(mobileLayoutSource).not.toContain('getTxAudioControl');
+    expect(mobileLayoutSource).not.toContain('systemHandlers');
+    expect(mobileLayoutSource).not.toContain('engageTx');
+    expect(mobileLayoutSource).not.toContain('disengageTx');
+    expect(mobileLayoutSource).not.toContain('pttSafetyTimer');
+    expect(mobileLayoutSource).not.toContain('PTT_SAFETY_TIMEOUT_MS');
+    expect(mobileLayoutSource).not.toContain('txStartToken');
+    expect(mobileLayoutSource).not.toContain('lastPttDown');
+    // Deliberately NOT asserting on 'ptt' as a bare substring — PttFab and the
+    // landscape lsPtt* handlers legitimately keep it.
+    expect(mobileLayoutSource).toContain('getAppTxController');
+    expect(mobileLayoutSource).toContain('createPttGesture');
   });
 });


### PR DESCRIPTION
MOR-1012 — the last blocker of MOR-1089. Deletes the duplicate mobile TX state machine and timers; the portrait FAB and landscape strip now key through per-surface gesture recognizers over the shared App TX controller.

## Safety content
- Two live defects closed: unmount left the rig keyed (onDestroy imported, never used); the orphaned 3-minute timer could raw-ptt_off a desktop owner. Both now pinned by tests (C.13, D.16).
- Orientation/presentation removal is lease-qualified: rotation either direction, txCapable drop, unmount (C.10-C.13); rotating while LATCHED now drops TX — intentional fail-closed behavior change.
- Cross-surface isolation: per-surface sourceIds; D.15/D.16 prove a stale mobile timer or press cannot disturb a desktop-owned lease (defence-in-depth with the model's sourceId check, independently pinned).
- ?raw source assertions prove no tx-adapter/audio/raw-command import remains.

## Verification (independent verifier, fresh context)
43/43 component tests; regression scopes 50/50 + 83/83; panels+layout+wiring 839/48 vs base 820/48; check/lint:boundaries/i18n/build clean; full-suite failure sets byte-identical to clean base (known localStorage env family only). Three mutations re-run independently (surface guard -> only C.14 dies; gesture.destroy -> C.10-C.13 die; resetFault -> A.6b dies).

## Notes
- Deliberate divergence from TxPanel: gesture view reads txCtl.snapshot() directly (teardown ordering); documented in-code — do not unify backwards.
- Field risk (pre-existing posture, now shared with desktop): mobile start requires an authoritative fresh PTT readback; verify on the IC-7610 before release.
- 2 files, +430 net LOC under an explicit owner exemption (2026-08-01): production net −26; the overage is the test matrix.
- Follow-ups: PR C dead-code sweep (command-bus/panel-commands/tx-adapter PTT remnants), PttFab onDestroy timer cleanup, mobile fault surface ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)