### PR TITLE
refactor: remove the dead presentation-side PTT command remnants

### DIFF
--- a/frontend/src/components-v2/wiring/command-bus.ts
+++ b/frontend/src/components-v2/wiring/command-bus.ts
@@ -600,8 +600,6 @@ export function makeTxHandlers() {
       patchRadioState({ driveGain: level });
       cmd('set_drive_gain', { level });
     },
-    onPttOn: () => cmd('ptt_on'),
-    onPttOff: () => cmd('ptt_off'),
   };
 }
 
@@ -757,8 +755,6 @@ export function makeMeterHandlers() {
 
 export function makeSystemHandlers() {
   return {
-    onPttOn: () => cmd('ptt_on'),
-    onPttOff: () => cmd('ptt_off'),
     onDialLock: (on: boolean) => cmd('set_dial_lock', { on }),
     onPowerOff: () => cmd('set_powerstat', { on: false }),
     onSpeak: () => cmd('speak', { mode: 0 }),

--- a/frontend/src/lib/runtime/adapters/tx-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/tx-adapter.ts
@@ -147,10 +147,5 @@ export function getTxAudioControl() {
     startTx,
     stopLocalAudio,
     restoreModAfterConfirmedOff,
-    /**
-     * Transitional alias for the presentation-local PTT machines. Deliberately
-     * stops audio only; MOD restoration requires authoritative OFF evidence.
-     */
-    stopTx: stopLocalAudio,
   };
 }

--- a/frontend/src/lib/runtime/commands/panel-commands.ts
+++ b/frontend/src/lib/runtime/commands/panel-commands.ts
@@ -454,8 +454,6 @@ export function makeTxHandlers() {
       patchRadioState({ driveGain: level });
       cmd('set_drive_gain', { level });
     },
-    onPttOn: () => cmd('ptt_on'),
-    onPttOff: () => cmd('ptt_off'),
   };
 }
 


### PR DESCRIPTION
MOR-1012 PR C (final piece). Deletions only (-11): the raw onPttOn/onPttOff pairs (command-bus makeTxHandlers + makeSystemHandlers, panel-commands makeTxHandlers) and tx-adapter's stopTx transitional alias — all consumer-free since #2128/#2134 put both TX surfaces on the App-owned controller. makeSystemHandlers keeps onDialLock/onPowerOff/onSpeak (live in RadioLayout).

Verified independently: pinned hashes, full-diff review, gate greps (zero onPttOn/onPttOff; .stopTx( hits are the real audio API only), consumer greps, scoped vitest baseline-identical (localStorage env family only), check/lint:boundaries/build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)