### PR TITLE
feat: add the PrivilegedTxApi surface for operator-forced unkey

### DIFF
--- a/src/rigplane/core/radio_protocol.py
+++ b/src/rigplane/core/radio_protocol.py
@@ -101,6 +101,8 @@ __all__ = [
     "ManagedTxSupervisor",
     "MetersCapable",
     "PowerControlCapable",
+    "PrivilegedTxApi",
+    "PrivilegedTxSupervisor",
     "RigctldFallbackCache",
     "RigctldRoutable",
     "RigctldRoutingStrategy",
@@ -559,6 +561,13 @@ class ManagedTxCapable(Protocol):
     independently (MOR-1187, MOR-1193, MOR-1196).  Bind through
     :meth:`ManagedTxApi.bind` wherever an owner identity is in hand; where one
     is not, repeat its two-step read rather than collapsing it to a ``getattr``.
+
+    The published supervisor MAY additionally satisfy
+    :class:`PrivilegedTxSupervisor` — a managed runtime does, publishing
+    ``force_unkey`` alongside ``request_on``/``release_owner`` — but
+    :class:`ManagedTxSupervisor` remains the guaranteed minimum every managed
+    backend publishes.  Ordinary ingress binds :class:`ManagedTxApi` and never
+    sees the extra surface; only :meth:`PrivilegedTxApi.bind` looks for it.
     """
 
     @property
@@ -606,6 +615,95 @@ class ManagedTxApi:
         if on:
             return await self.supervisor.request_on(self.owner)
         return await self.supervisor.release_owner(self.owner, reason=reason)
+
+
+@runtime_checkable
+class PrivilegedTxSupervisor(Protocol):
+    """Force-unkey surface of a radio's managed TX runtime.
+
+    Deliberately NOT a member of :class:`ManagedTxSupervisor`. Every ingress —
+    Web, the SDK, the CLI — binds through :class:`ManagedTxApi`, whose
+    ``supervisor`` is typed as :class:`ManagedTxSupervisor`; adding
+    ``force_unkey`` there would hand force semantics to all of them,
+    including two that must never get it. rigctld's executor issues a plain
+    housekeeping ``set_ptt(False)`` between overs with no :class:`TxOwner`
+    behind it — an implicit force there would let ordinary release traffic
+    escalate into adopting someone else's lease. The SDK is automation-shaped
+    with no operator attached to a session either; an author who actually
+    wants force names :class:`PrivilegedTxApi` explicitly rather than
+    inheriting it silently from the ordinary managed path. Splitting the two
+    protocols is what keeps :class:`ManagedTxSupervisor` the guaranteed
+    minimum every managed backend publishes, while force stays reachable only
+    to the one facade that asks for it by name.
+    """
+
+    async def force_unkey(
+        self, owner: TxOwner, *, reason: TxReleaseReason
+    ) -> TxTransition:
+        """Adopt an unowned/idle key and drive a durable release for it."""
+        ...
+
+
+@dataclass(frozen=True, slots=True)
+class PrivilegedTxApi:
+    """One force-unkey facade bound to one stable ingress identity.
+
+    Distinct from :class:`ManagedTxApi`: it does not publish or read a second
+    attribute on the radio, it re-reads the same ``managed_tx`` member and
+    additionally probes the supervisor object it finds for ``force_unkey``. A
+    supervisor satisfying only :class:`ManagedTxSupervisor`
+    (``request_on``/``release_owner``, nothing else) binds ``ManagedTxApi``
+    but not this one — ``bind`` answers ``None``, a positive finding that the
+    backend publishes no privileged surface, not a failure to resolve one.
+    """
+
+    supervisor: PrivilegedTxSupervisor
+    owner: TxOwner
+
+    @staticmethod
+    def bind(radio: object, owner: TxOwner) -> PrivilegedTxApi | None:
+        """Bind ``owner`` to ``radio``'s privileged surface; ``None`` when absent.
+
+        Two reads, two different failure disciplines, mirroring
+        :meth:`ManagedTxApi.bind`.
+
+        The first is the same ``managed_tx`` *property* that facade reads:
+        ``getattr_static`` settles absence — no such member, or a backend
+        that publishes ``None`` — without running the accessor, so the one
+        explicit property read below is the only backend code this touches
+        and its failures propagate. A raising ``managed_tx`` is a broken
+        accessor, not "no privileged surface"; swallowing it here would
+        repeat the bug :class:`ManagedTxCapable` documents (MOR-1187,
+        MOR-1193, MOR-1196) one layer up.
+
+        The second is a plain ``getattr`` shape-probe for ``force_unkey`` — a
+        coroutine *method*, not a property, so the probe runs no accessor
+        body at all (precedent: the ``replace_provider`` probe in
+        ``web/server.py``'s ``_service_managed_tx_release``). A supervisor
+        with no ``force_unkey`` answers ``None`` here — a positive finding,
+        never a fallback from a failed read.
+        """
+        if getattr_static(radio, "managed_tx", None) is None:
+            return None  # no such member, or a backend that publishes none
+        supervisor = cast(ManagedTxCapable, radio).managed_tx
+        if supervisor is None:
+            return None  # backend publishes the member but no supervisor
+        if getattr(supervisor, "force_unkey", None) is None:
+            return None  # exactly ManagedTxSupervisor; no privileged surface
+        return PrivilegedTxApi(cast(PrivilegedTxSupervisor, supervisor), owner)
+
+    async def force_unkey(self) -> TxTransition:
+        """Force-unkey ``owner``'s target, hardcoded to the operator reason.
+
+        Takes no parameters: :attr:`TxReleaseReason.OPERATOR_FORCED_UNKEY` is
+        the only reason this may ever carry. A caller-supplied ``reason``
+        would let any holder of this facade launder a system-attributed
+        release through the one path meant for an operator reaching for the
+        kill switch.
+        """
+        return await self.supervisor.force_unkey(
+            self.owner, reason=TxReleaseReason.OPERATOR_FORCED_UNKEY
+        )
 
 
 @runtime_checkable

--- a/tests/test_privileged_tx_api.py
+++ b/tests/test_privileged_tx_api.py
@@ -1,0 +1,274 @@
+"""MOR-1175: ``PrivilegedTxApi`` binds a force-unkey facade, not a key one.
+
+Binding discipline mirrors ``ManagedTxApi.bind`` exactly (MOR-1193's fix,
+repeated one layer up): the ``managed_tx`` *property* read is backend code
+whose failures propagate, while the ``force_unkey`` *method* probe on the
+supervisor it finds is a plain shape check that runs no accessor body. Only
+a supervisor that goes beyond ``ManagedTxSupervisor`` -- publishing
+``force_unkey`` alongside ``request_on``/``release_owner`` -- binds here; the
+narrower shape is a positive "no privileged surface" finding, not an error.
+
+No ``MagicMock``: every double below is either a hand-rolled class shaped to
+expose exactly one structural fact, or the real ``ManagedRadioRuntime`` (the
+one production supervisor that actually satisfies ``PrivilegedTxSupervisor``).
+The wiring test reuses the ``_Provider`` double and effect service from
+``test_managed_tx_force_unkey.py`` rather than re-deriving the retry ladder
+that suite already covers -- this file only proves the facade reaches the
+runtime and the runtime reaches the wire, once, with the hardcoded reason.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from rigplane.core.radio_protocol import (
+    ManagedTxApi,
+    ManagedTxSupervisor,
+    PrivilegedTxApi,
+    PrivilegedTxSupervisor,
+)
+from rigplane.core.tx_safety import (
+    TxOutcome,
+    TxOwner,
+    TxReleaseReason,
+    TxSource,
+    TxTransition,
+)
+from rigplane.runtime.managed_radio_runtime import ManagedRadioRuntime
+from rigplane.runtime.managed_tx_effect_service import managed_tx_effect_service
+from test_web_recovery_durable_off import _Provider
+
+_OWNER = TxOwner(TxSource.WEBSOCKET, "operator-1")
+
+
+# --- Doubles -----------------------------------------------------------
+
+
+class _ManagedOnlySupervisor:
+    """Exactly ``ManagedTxSupervisor``: ``request_on``/``release_owner``, no more.
+
+    The narrowest surface a managed backend may legally publish -- and the
+    one ``PrivilegedTxApi.bind`` must refuse, because handing force semantics
+    to a supervisor that never advertised it would bypass the whole point of
+    splitting the two protocols.
+    """
+
+    async def request_on(self, owner: TxOwner) -> TxTransition:
+        raise AssertionError("bind must not call into the supervisor")
+
+    async def release_owner(
+        self, owner: TxOwner, *, reason: TxReleaseReason
+    ) -> TxTransition:
+        raise AssertionError("bind must not call into the supervisor")
+
+
+class _PrivilegedSupervisor:
+    """Satisfies ``PrivilegedTxSupervisor``: adds ``force_unkey`` to the pair."""
+
+    async def request_on(self, owner: TxOwner) -> TxTransition:
+        raise AssertionError("bind must not call into the supervisor")
+
+    async def release_owner(
+        self, owner: TxOwner, *, reason: TxReleaseReason
+    ) -> TxTransition:
+        raise AssertionError("bind must not call into the supervisor")
+
+    async def force_unkey(
+        self, owner: TxOwner, *, reason: TxReleaseReason
+    ) -> TxTransition:
+        raise AssertionError("bind must not call into the supervisor")
+
+
+class _UnmanagedRadio:
+    """Publishes the ``managed_tx`` member but answers ``None`` -- unmanaged."""
+
+    @property
+    def managed_tx(self) -> object | None:
+        return None
+
+
+class _RaisingRadio:
+    """Provider whose ``managed_tx`` accessor fails instead of answering."""
+
+    def __init__(self, error: type[Exception]) -> None:
+        self._error = error
+
+    @property
+    def managed_tx(self) -> object | None:
+        raise self._error("supervisor accessor exploded")
+
+
+class _NarrowRadio:
+    """Managed radio publishing a supervisor of the given shape."""
+
+    def __init__(self, supervisor: object) -> None:
+        self.managed_tx = supervisor
+
+
+class _CountingRadio:
+    """Managed radio that counts every read of its ``managed_tx`` accessor."""
+
+    def __init__(self, supervisor: object) -> None:
+        self.reads = 0
+        self._supervisor = supervisor
+
+    @property
+    def managed_tx(self) -> object:
+        self.reads += 1
+        return self._supervisor
+
+
+class _Clock:
+    """Monotonic only when the test says so (same shape as the force-unkey suite)."""
+
+    def __init__(self) -> None:
+        self.now = 1_000.0
+
+    def __call__(self) -> float:
+        return self.now
+
+
+class _ManagedRadio:
+    """Radio publishing a real ``ManagedRadioRuntime`` as its ``managed_tx``."""
+
+    def __init__(self, runtime: ManagedRadioRuntime) -> None:
+        self.managed_tx = runtime
+
+
+async def _bound_runtime() -> tuple[ManagedRadioRuntime, list[str]]:
+    """A real, ready ``ManagedRadioRuntime`` over a hand-rolled provider.
+
+    Never observed, already transmitting -- MOR-1182's exact starting point --
+    so a successful force here is not resting on an observation the runtime
+    happens to already have.
+    """
+    log: list[str] = []
+    provider = _Provider(log)
+    runtime = ManagedRadioRuntime(
+        "privileged-test",
+        service_factory=managed_tx_effect_service,
+        provider_lifecycle=provider,
+        clock=_Clock(),
+        tick_interval_seconds=0.01,
+    )
+    await runtime.replace_provider(ready=True)
+    provider._keyed = True  # the rig transmits; nothing here has observed it
+    log.clear()
+    return runtime, log
+
+
+# --- bind() matrix -------------------------------------------------------
+
+
+def test_a_radio_with_no_managed_tx_member_has_no_privileged_surface() -> None:
+    assert PrivilegedTxApi.bind(object(), _OWNER) is None
+
+
+def test_managed_tx_present_but_none_is_unmanaged() -> None:
+    assert PrivilegedTxApi.bind(_UnmanagedRadio(), _OWNER) is None
+
+
+@pytest.mark.parametrize("error", [AttributeError, RuntimeError, ValueError, KeyError])
+def test_a_raising_managed_tx_accessor_propagates(error: type[Exception]) -> None:
+    # A supervisor that cannot be resolved is not "no privileged surface":
+    # answering None here would mask a broken accessor as an ordinary,
+    # unmanaged radio. AttributeError is the trap this must not swallow --
+    # see ManagedTxCapable's docstring and MOR-1187/1193/1196.
+    with pytest.raises(error, match="exploded"):
+        PrivilegedTxApi.bind(_RaisingRadio(error), _OWNER)
+
+
+def test_a_managed_tx_supervisor_only_double_has_no_privileged_surface() -> None:
+    radio = _NarrowRadio(_ManagedOnlySupervisor())
+
+    assert PrivilegedTxApi.bind(radio, _OWNER) is None
+
+
+def test_bind_reads_the_managed_tx_accessor_exactly_once() -> None:
+    radio = _CountingRadio(_PrivilegedSupervisor())
+
+    api = PrivilegedTxApi.bind(radio, _OWNER)
+
+    assert api is not None
+    assert radio.reads == 1
+
+
+async def test_a_real_managed_radio_runtime_binds() -> None:
+    runtime, _log = await _bound_runtime()
+    radio = _ManagedRadio(runtime)
+
+    api = PrivilegedTxApi.bind(radio, _OWNER)
+
+    assert api is not None
+    assert api.supervisor is runtime
+    assert api.owner is _OWNER
+
+
+# --- force_unkey() wiring -------------------------------------------------
+
+
+async def test_force_unkey_reaches_the_runtime_with_operator_forced_unkey() -> None:
+    runtime, log = await _bound_runtime()
+    api = PrivilegedTxApi.bind(_ManagedRadio(runtime), _OWNER)
+    assert api is not None
+
+    forced = await api.force_unkey()
+
+    assert forced.outcome is TxOutcome.ACCEPTED
+    assert forced.snapshot.owner == _OWNER
+    assert (
+        forced.snapshot.terminal_release_reason is TxReleaseReason.OPERATOR_FORCED_UNKEY
+    )
+    # The OFF and its confirming read reached the provider, exactly once.
+    assert log == ["ptt(off)", "read_ptt"]
+
+
+def test_force_unkey_takes_no_parameters() -> None:
+    # No ``reason`` (or anything else) may reach the caller: a parameter here
+    # would let any holder of this facade launder a system-attributed release
+    # through the one path meant for an operator's kill switch.
+    sig = inspect.signature(PrivilegedTxApi.force_unkey)
+    assert list(sig.parameters) == ["self"]
+
+
+async def test_force_unkey_rejects_an_attempted_reason_override() -> None:
+    api = PrivilegedTxApi(_PrivilegedSupervisor(), _OWNER)
+    override = TxReleaseReason.OPERATOR_RELEASE
+
+    with pytest.raises(TypeError):
+        await api.force_unkey(reason=override)  # type: ignore[call-arg]
+
+
+# --- Surface shape --------------------------------------------------------
+
+
+def test_managed_tx_supervisor_protocol_attrs_pinned() -> None:
+    # Guards against MOR-1175 (or anything else) widening the guaranteed
+    # minimum every managed backend publishes: adding ``force_unkey`` to
+    # ``ManagedTxSupervisor`` itself would hand force semantics to every
+    # ingress that binds ``ManagedTxApi``, defeating the whole split.
+    # 3.12+ only; see test_audio_transport_conformance.py
+    protocol_attrs = getattr(ManagedTxSupervisor, "__protocol_attrs__", None)
+    if protocol_attrs is not None:
+        assert set(protocol_attrs) == {"request_on", "release_owner"}
+
+
+def test_privileged_tx_supervisor_protocol_attrs_pinned() -> None:
+    protocol_attrs = getattr(PrivilegedTxSupervisor, "__protocol_attrs__", None)
+    if protocol_attrs is not None:
+        assert set(protocol_attrs) == {"force_unkey"}
+
+
+def test_privileged_tx_api_exposes_no_key_operation() -> None:
+    api = PrivilegedTxApi(_PrivilegedSupervisor(), _OWNER)
+
+    assert not hasattr(api, "set_ptt")
+
+
+def test_managed_tx_api_has_no_force_reach() -> None:
+    api = ManagedTxApi(_ManagedOnlySupervisor(), _OWNER)
+
+    assert not hasattr(api, "force_unkey")
+    assert not hasattr(ManagedTxApi, "force_unkey")


### PR DESCRIPTION
MOR-1175 PR 3 of 4 (ratified policy: operator-only surface; no key op; hardcoded OPERATOR_FORCED_UNKEY; live foreign lease refused at the supervisor). Purely additive +98 in radio_protocol.py (zero deletions; existing ManagedTx* byte-identical) + 16 tests.

Verified independently (fresh context): read-discipline correctness (getattr_static vs shape-probe on the right members, proven by a one-read counting double); the ManagedTxApi barrier caught by mypy in-tree; the .supervisor field judged non-escalating (holder already has the radio; the reason frozenset rejects laundering independent of caller; the field NARROWS — no request_on on the privileged protocol); gh-102433 divergence measured empirically on 3.11 vs 3.13 and the tests shown immune; mutations Ma/Ma2/Mb/Mc each kill exactly the named tests; full suite 8905 green; mypy baseline identical.

Known note for full-CI: the protocol-attrs pins are vacuous on 3.11 (no __protocol_attrs__) — Mc-class drift is caught by full.yml's 3.12/3.13 legs, per the repo's existing conformance-test convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)