### PR TITLE
feat: escalate ptt off to an operator-forced unkey when no lease matches

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,10 +22,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now blocks at the first command. SIGINT / SIGTERM / SIGHUP unkey and exit
   128 + the signal (130 / 143 / 129); a duration that simply runs out exits 0;
   a failed or stuck unkey exits 1 with a warning that the radio may still be
-  transmitting. `ptt off` is unchanged and immediate — it remains the recovery
-  path for a rig left transmitting by some other process (MOR-1184, MOR-1199).
+  transmitting. `ptt off` remains the recovery path for a rig left transmitting
+  by some other process; under a managed runtime it now escalates to an
+  operator-forced unkey (see Changed below) and its exit code is meaningful
+  (MOR-1184, MOR-1199).
 
 ### Changed
+
+- **CLI: `rigplane ptt off` forces an unkey when no lease of its own matches
+  (MOR-1175, MOR-1182).** Under the managed TX runtime a rig keyed by a process
+  that has since died holds a lease no other invocation can match, so the
+  ordinary release was refused and the command warned and exited 0 — the crash
+  recovery `ptt off` exists for was gone. It now escalates to an
+  operator-forced unkey (attributed as such, never as a system release), and
+  its exit code becomes meaningful: `0` only when an unkey reached the wire or
+  was already in flight, `1` — with what the rig may still be doing — when it
+  did not. A *live* lease held by another TX session is refused rather than
+  preempted. `ptt on` is unaffected: its own teardown never escalates.
 
 - **Browser TX surfaces unified (PRs #2125, #2128, #2130, #2134).** Both desktop
   TxPanel and mobile FAB + landscape strip now key through the single App-owned

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -502,7 +502,16 @@ Either way, the unkey on the way out is bounded to 5 seconds. If it fails or han
 rigplane ptt off
 ```
 
-`ptt off` is unchanged: it unkeys immediately and returns right away. Use it to recover a rig left keyed by a crash, a killed process, or an older rigplane build — it never blocks, so it always gets the chance to run.
+`ptt off` unkeys immediately and returns promptly — it never holds the key the way `ptt on` does, and a forced unkey is bounded at 5 seconds, so it always gets the chance to run. Use it to recover a rig left keyed by a crash, a killed process, or an older rigplane build: when no TX lease of this invocation's own matches — the normal case for a rig some *other* process keyed — it escalates to an operator-forced unkey instead of giving up, and says so on stderr.
+
+Its exit code answers one question: did an unkey reach the radio?
+
+| Code | Meaning |
+|---|---|
+| `0` | An unkey reached the wire, or one was already in flight. |
+| `1` | rigplane did not get an unkey out — **the rig may still be transmitting.** |
+
+The refusal worth calling out is a busy radio. If another TX session holds a *live* lease on this rig, `ptt off` exits `1` and refuses rather than cutting that transmission off: recovering a stranded key is not the same thing as preempting somebody who is talking. Stop that session and retry, or wait for its max-key-down watchdog.
 
 !!! danger "Caution"
     Activating PTT will key your transmitter. Ensure your antenna is connected and you are authorized to transmit on the current frequency.

--- a/src/rigplane/cli/__init__.py
+++ b/src/rigplane/cli/__init__.py
@@ -101,7 +101,11 @@ from rigplane.cli._convert import (  # noqa: E402
     add_subparser as _add_convert_subparser,
     run as _run_convert,
 )
-from rigplane.core.radio_protocol import ManagedTxApi, Radio  # noqa: E402
+from rigplane.core.radio_protocol import (  # noqa: E402
+    ManagedTxApi,
+    PrivilegedTxApi,
+    Radio,
+)
 from rigplane.core.tx_safety import TxOutcome, TxOwner, TxSource  # noqa: E402
 from rigplane.core.types import Mode, get_audio_capabilities  # noqa: E402
 
@@ -2870,10 +2874,97 @@ async def _ptt_release(radio: Radio, managed: ManagedTxApi | None) -> str | None
         return f"unkey failed ({exc!r})"
     if transition.outcome in _TX_KEY_ACCEPTED:
         return None
-    # A bare ``ptt off`` may legitimately find nothing to release and warns.
-    # This session is known to have taken the lease, so a refusal here means
-    # the lease is gone from under it and the rig may still be transmitting.
+    # A bare ``ptt off`` may legitimately find nothing to release, and escalates
+    # to a forced unkey (``_ptt_force_unkey``). This path must never escalate.
+    # This session is known to have taken the lease, so a refusal here means the
+    # lease was taken from under the hold — and forcing would let one process's
+    # teardown adopt, and unkey, whatever took it. Preempting a live foreign
+    # transmission is MOR-1179 territory, never a side effect of ``ptt on``
+    # exiting. So the rig may still be transmitting, and this reports it.
     return f"managed TX refused this session's release ({transition.outcome})"
+
+
+async def _ptt_force_unkey(radio: Radio, ordinary_outcome: TxOutcome) -> int:
+    """Escalate a ``ptt off`` the ordinary managed release refused (MOR-1182).
+
+    Reached only from the bare ``ptt off``, and only once the ordinary release
+    has found no lease of this session's to release — which is exactly what a
+    rig keyed by a process that has since died looks like from a freshly
+    started one. Before the managed runtime, ``ptt off`` simply wrote OFF;
+    without this escalation the recovery path the command exists for stops at a
+    warning while the rig keeps transmitting.
+
+    The escalation stays narrow: a live foreign lease is refused rather than
+    preempted (preemption is MOR-1179's), and the exit code now answers the one
+    question worth asking — did an unkey reach the wire?
+    """
+    privileged = PrivilegedTxApi.bind(radio, _CLI_TX_OWNER)
+    if privileged is None:
+        print(
+            f"Error: managed TX released no lease for this session "
+            f"({ordinary_outcome}) and publishes no privileged unkey; "
+            "the rig may still be transmitting.",
+            file=sys.stderr,
+        )
+        return 1
+    try:
+        # Bounded like every other unkey here (see ``_PTT_RELEASE_TIMEOUT``): a
+        # force that never returns tells the operator no more than a rig that
+        # never stops.
+        transition = await asyncio.wait_for(
+            privileged.force_unkey(), timeout=_PTT_RELEASE_TIMEOUT
+        )
+    except TimeoutError:
+        print(
+            f"Error: forced unkey timed out after {_PTT_RELEASE_TIMEOUT:g} s; "
+            "the radio may still be transmitting.",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception as exc:  # noqa: BLE001 — a failed unkey is reported, not raised
+        print(
+            f"Error: forced unkey failed ({exc!r}); "
+            "the radio may still be transmitting.",
+            file=sys.stderr,
+        )
+        return 1
+    outcome = transition.outcome
+    if outcome is TxOutcome.ACCEPTED:
+        print(
+            "Note: no TX lease for this session; forced an unkey of a rig "
+            "keyed elsewhere.",
+            file=sys.stderr,
+        )
+        return 0
+    if outcome is TxOutcome.IDEMPOTENT:
+        print(
+            "Note: an unkey is already in progress; nothing further sent.",
+            file=sys.stderr,
+        )
+        return 0
+    if outcome is TxOutcome.BUSY:
+        print(
+            f"Error: another TX session holds this radio ({outcome}); refusing "
+            "to preempt a live transmission. Stop that session and retry, or "
+            "wait for the max-key-down watchdog.",
+            file=sys.stderr,
+        )
+        return 1
+    if outcome is TxOutcome.NOT_READY:
+        print(
+            f"Error: the radio link is not ready ({outcome}); no unkey was "
+            "attempted and the rig may still be transmitting.",
+            file=sys.stderr,
+        )
+        return 1
+    # No other outcome is reachable from ``force_unkey`` today; a new one must
+    # fail closed rather than report an unkey nobody saw.
+    print(
+        f"Error: forced unkey was refused ({outcome}); "
+        "the radio may still be transmitting.",
+        file=sys.stderr,
+    )
+    return 1
 
 
 async def _hold_ptt(
@@ -2946,7 +3037,8 @@ async def _cmd_ptt(radio: Radio, args: argparse.Namespace) -> int:
     ``ptt on`` arms its signals, keys, then holds until it is interrupted or
     ``--for`` runs out, so the process that took the lease is the process that
     releases it. ``ptt off`` owns no signals and stays immediate: it is the
-    recovery path for a rig some other process left transmitting.
+    recovery path for a rig some other process left transmitting, and the only
+    caller allowed to escalate to a forced unkey when no lease matches.
     """
     managed = ManagedTxApi.bind(radio, _CLI_TX_OWNER)
     if args.state == "on":
@@ -2957,15 +3049,12 @@ async def _cmd_ptt(radio: Radio, args: argparse.Namespace) -> int:
     else:
         transition = await managed.set_ptt(False)
         if transition.outcome not in _TX_KEY_ACCEPTED:
-            # A refused release answers STALE, which means either nothing was
-            # keyed or another owner holds the lease. Neither is actionable
-            # here — a non-owner cannot force a release by design — so report
-            # it and still succeed, rather than failing a defensive unkey.
-            print(
-                f"Warning: managed TX released no lease for this session "
-                f"({transition.outcome}); another session may still hold TX.",
-                file=sys.stderr,
-            )
+            # A refused release answers STALE: nothing of this session's was
+            # there to release. On the recovery path that is the normal case,
+            # not a dead end — a rig left keyed by a dead process has a lease
+            # nobody can match — so escalate rather than warn and exit 0.
+            if rc := await _ptt_force_unkey(radio, transition.outcome):
+                return rc
     print("PTT OFF")
     return 0
 

--- a/tests/test_cli_async.py
+++ b/tests/test_cli_async.py
@@ -38,15 +38,20 @@ from rigplane.cli import (
 )
 from rigplane.core.radio_protocol import ManagedTxApi
 from rigplane.core.tx_safety import (
+    RadioTx,
     TxOutcome,
     TxOwner,
+    TxPhase,
     TxReleaseReason,
     TxSafetySupervisor,
     TxSource,
     TxTransition,
 )
 from rigplane.exceptions import TimeoutError as IcomTimeout
+from rigplane.runtime.managed_radio_runtime import ManagedRadioRuntime
+from rigplane.runtime.managed_tx_effect_service import managed_tx_effect_service
 from rigplane.runtime.radio import IcomRadio as RuntimeIcomRadio
+from test_web_recovery_durable_off import _Provider
 
 
 # ---------------------------------------------------------------------------
@@ -661,18 +666,23 @@ class TestCmdPttManagedIngress:
         assert radio.bare_writes == []
 
     @pytest.mark.asyncio
-    async def test_a_release_the_supervisor_refused_succeeds(self, capsys) -> None:
+    async def test_a_refused_release_with_no_privileged_surface_exits_non_zero(
+        self, capsys
+    ) -> None:
         # STALE covers both "nothing was keyed" and "another owner holds it".
-        # A non-owner cannot force a release by design, so the unkey is best
-        # effort: it reports, but it must not fail the command.
+        # This supervisor is exactly ``ManagedTxSupervisor`` — no
+        # ``force_unkey`` — so there is nothing left to escalate to and no
+        # unkey reached the wire. Reporting success here would tell the
+        # operator the rig is quiet on no evidence at all.
         radio = _FakeManagedRadio(off=TxOutcome.STALE)
 
         rc = await _cmd_ptt(radio, Namespace(state="off"))
 
-        assert rc == 0
+        assert rc == 1
         captured = capsys.readouterr()
-        assert captured.out.splitlines() == ["PTT OFF"]
-        assert "Warning" in captured.err and f"({TxOutcome.STALE})" in captured.err
+        assert "PTT OFF" not in captured.out
+        assert "Error" in captured.err and f"({TxOutcome.STALE})" in captured.err
+        assert "publishes no privileged unkey" in captured.err
         assert _kinds(radio.supervisor) == [(False, TxReleaseReason.OPERATOR_RELEASE)]
         assert radio.bare_writes == []
 
@@ -1042,6 +1052,338 @@ def test_a_signal_before_the_key_leaves_the_rig_unkeyed(signum, tmp_path) -> Non
     assert journal == ["armed"]  # it never keyed, so there was nothing to unkey
     assert out == []  # and it never announced a transmission
     assert rc == 128 + signum
+
+
+# ---------------------------------------------------------------------------
+# _cmd_ptt — ``ptt off`` escalates to a forced unkey (MOR-1175, MOR-1182)
+# ---------------------------------------------------------------------------
+
+
+class _FakePrivilegedTxSupervisor(_FakeTxSupervisor):
+    """What a managed runtime really publishes: the pair plus ``force_unkey``.
+
+    ``force`` is the outcome the force answers, an exception it raises, or
+    ``None`` for a force that never returns — the case the caller must bound.
+    """
+
+    def __init__(
+        self,
+        on: TxOutcome,
+        off: TxOutcome,
+        force: TxOutcome | Exception | None,
+    ) -> None:
+        super().__init__(on, off)
+        self._force = force
+        self.forced: list[tuple[TxOwner, TxReleaseReason]] = []
+
+    async def force_unkey(
+        self, owner: TxOwner, *, reason: TxReleaseReason
+    ) -> TxTransition:
+        self.forced.append((owner, reason))
+        if isinstance(self._force, Exception):
+            raise self._force
+        if self._force is None:
+            await asyncio.Event().wait()  # never returns; the caller bounds it
+            raise AssertionError("unreachable: the wait above never completes")
+        return TxTransition(self._force, _IDLE_TX_SNAPSHOT)
+
+
+class _FakePrivilegedRadio(_FakeManagedRadio):
+    """Managed radio whose supervisor also carries the privileged surface."""
+
+    def __init__(
+        self,
+        on: TxOutcome = _ACCEPTED,
+        off: TxOutcome = _ACCEPTED,
+        force: TxOutcome | Exception | None = _ACCEPTED,
+    ) -> None:
+        super().__init__(on, off)
+        self.supervisor = _FakePrivilegedTxSupervisor(on, off, force)
+        self.managed_tx = self.supervisor
+
+
+class TestCmdPttOffForcedUnkey:
+    """The exit-code table for ``ptt off``: 0 only when an unkey is on the wire.
+
+    ``ptt off`` used to exit 0 whatever happened. It is the command an operator
+    reaches for when a rig will not stop transmitting, so its exit code now
+    carries exactly one meaning — an unkey reached the wire, or is already in
+    flight — and every other answer is 1 with what the rig may still be doing.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("outcome", [TxOutcome.ACCEPTED, TxOutcome.IDEMPOTENT])
+    async def test_an_accepted_ordinary_release_never_escalates(
+        self, outcome: TxOutcome, capsys
+    ) -> None:
+        # The ordinary path is the one that runs on every normal unkey. Routing
+        # it through the force would adopt leases nobody asked about and put a
+        # "forced an unkey" note on screen for a release that just worked.
+        radio = _FakePrivilegedRadio(off=outcome)
+
+        rc = await _cmd_ptt(radio, Namespace(state="off"))
+
+        assert rc == 0
+        assert radio.supervisor.forced == []
+        captured = capsys.readouterr()
+        assert captured.out.splitlines() == ["PTT OFF"]
+        assert captured.err == ""
+
+    @pytest.mark.asyncio
+    async def test_an_unmanaged_radio_keeps_the_legacy_direct_write(
+        self, capsys
+    ) -> None:
+        # Nothing to escalate to and nothing to escalate from: an unmanaged
+        # backend still writes OFF once and exits 0, silently, as it always has.
+        radio = _FakeShippedRadio()
+
+        rc = await _cmd_ptt(radio, Namespace(state="off"))
+
+        assert rc == 0
+        assert radio.writes == [False]
+        captured = capsys.readouterr()
+        assert captured.out.splitlines() == ["PTT OFF"]
+        assert captured.err == ""
+
+    @pytest.mark.asyncio
+    async def test_a_refused_release_forces_an_unkey_and_reports_it(
+        self, capsys
+    ) -> None:
+        # The MOR-1182 case in miniature: no lease of ours matched, so the
+        # rig is keyed by someone who is not here to release it.
+        radio = _FakePrivilegedRadio(off=TxOutcome.STALE, force=TxOutcome.ACCEPTED)
+
+        rc = await _cmd_ptt(radio, Namespace(state="off"))
+
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert captured.out.splitlines() == ["PTT OFF"]
+        assert "Note" in captured.err and "keyed elsewhere" in captured.err
+        (owner, reason), *rest = radio.supervisor.forced
+        assert rest == []  # exactly one force, never a retry loop of its own
+        assert reason is TxReleaseReason.OPERATOR_FORCED_UNKEY
+        # The same process identity the ordinary release carried: a force under
+        # a fresh owner would mint a lease this session could not then release.
+        assert owner is radio.supervisor.calls[0][1]
+        assert radio.bare_writes == []
+
+    @pytest.mark.asyncio
+    async def test_a_force_that_finds_an_unkey_in_flight_succeeds(self, capsys) -> None:
+        # A durable OFF is already owed and being retried. Nothing more is sent,
+        # and failing here would send the operator chasing a rig already being
+        # dekeyed.
+        radio = _FakePrivilegedRadio(off=TxOutcome.STALE, force=TxOutcome.IDEMPOTENT)
+
+        rc = await _cmd_ptt(radio, Namespace(state="off"))
+
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert captured.out.splitlines() == ["PTT OFF"]
+        assert "Note" in captured.err and "already in progress" in captured.err
+
+    @pytest.mark.asyncio
+    async def test_a_live_foreign_lease_is_refused_not_preempted(self, capsys) -> None:
+        # Somebody is transmitting on purpose. Cutting that off from another
+        # terminal is preemption (MOR-1179), not recovery, so it is refused —
+        # and the operator is told how the transmission does end.
+        radio = _FakePrivilegedRadio(off=TxOutcome.STALE, force=TxOutcome.BUSY)
+
+        rc = await _cmd_ptt(radio, Namespace(state="off"))
+
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert "PTT OFF" not in captured.out
+        assert "Error" in captured.err and "refusing to preempt" in captured.err
+        assert "watchdog" in captured.err
+
+    @pytest.mark.asyncio
+    async def test_a_link_that_is_not_ready_reports_a_rig_that_may_be_keyed(
+        self, capsys
+    ) -> None:
+        # No unkey was attempted at all, so the one thing that must not happen
+        # is a "PTT OFF" and an exit 0 over a rig nothing has written to.
+        radio = _FakePrivilegedRadio(off=TxOutcome.STALE, force=TxOutcome.NOT_READY)
+
+        rc = await _cmd_ptt(radio, Namespace(state="off"))
+
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert "PTT OFF" not in captured.out
+        assert "Error" in captured.err and "not ready" in captured.err
+        assert f"({TxOutcome.NOT_READY})" in captured.err
+        assert "may still be transmitting" in captured.err
+
+    @pytest.mark.asyncio
+    async def test_a_force_that_raises_is_reported_and_exits_non_zero(
+        self, capsys
+    ) -> None:
+        radio = _FakePrivilegedRadio(
+            off=TxOutcome.STALE, force=OSError("transport gone")
+        )
+
+        rc = await _cmd_ptt(radio, Namespace(state="off"))
+
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert "PTT OFF" not in captured.out
+        assert "Error" in captured.err and "transport gone" in captured.err
+
+    @pytest.mark.asyncio
+    async def test_a_force_that_never_returns_is_bounded(
+        self, monkeypatch, capsys
+    ) -> None:
+        # The rig this runs against is, by construction, one that has already
+        # misbehaved. An unbounded wait would hang the recovery command itself.
+        monkeypatch.setattr(cli_module, "_PTT_RELEASE_TIMEOUT", 0.05)
+        radio = _FakePrivilegedRadio(off=TxOutcome.STALE, force=None)
+
+        rc = await _cmd_ptt(radio, Namespace(state="off"))
+
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert "PTT OFF" not in captured.out
+        assert "Error" in captured.err and "timed out after" in captured.err
+
+    @pytest.mark.asyncio
+    async def test_the_holds_own_unkey_never_escalates(self, held, capsys) -> None:
+        # ``ptt on``'s teardown is the one release that must not escalate: a
+        # refusal there means the lease was taken from under this session, and
+        # forcing would let one process's exit adopt and unkey whatever took
+        # it — preemption smuggled in through a hold ending (MOR-1179).
+        radio = _FakePrivilegedRadio(off=TxOutcome.STALE, force=TxOutcome.ACCEPTED)
+
+        rc = await _cmd_ptt(radio, Namespace(state="on", hold_seconds=None))
+
+        assert rc == 1
+        assert radio.supervisor.forced == []
+        captured = capsys.readouterr()
+        assert "PTT OFF" not in captured.out
+        assert "Error" in captured.err and f"({TxOutcome.STALE})" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# _cmd_ptt — ``ptt off`` against a real managed runtime and a real wire
+# ---------------------------------------------------------------------------
+
+
+class _RuntimeRadio:
+    """Managed backend shape: a real ``ManagedRadioRuntime`` as ``managed_tx``."""
+
+    def __init__(self, runtime: ManagedRadioRuntime) -> None:
+        self.managed_tx = runtime
+        self.bare_writes: list[bool] = []
+
+    async def set_ptt(self, on: bool) -> None:
+        self.bare_writes.append(on)
+
+
+async def _ready_runtime(provider: _Provider, target: str) -> ManagedRadioRuntime:
+    """A real runtime, bound and ready over ``provider``'s wire."""
+    runtime = ManagedRadioRuntime(
+        target,
+        service_factory=managed_tx_effect_service,
+        provider_lifecycle=provider,
+        tick_interval_seconds=0.01,
+    )
+    await runtime.replace_provider(ready=True)
+    return runtime
+
+
+async def _process_gone(runtime: ManagedRadioRuntime) -> None:
+    """The keying process dies: its ticker stops, its lease is never released."""
+    ticker = runtime._tick_task
+    assert ticker is not None  # keying armed it
+    ticker.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await ticker
+
+
+async def _ticker_retired(runtime: ManagedRadioRuntime) -> None:
+    """Let the ticker the force armed notice the lease is gone and leave."""
+    deadline = time.monotonic() + 2.0
+    while runtime._tick_task is not None:
+        assert time.monotonic() < deadline, "the ticker never retired"
+        await asyncio.sleep(0.01)
+
+
+@pytest.mark.asyncio
+async def test_an_externally_keyed_rig_refuses_the_key_and_forces_the_unkey(
+    held, capsys
+) -> None:
+    """The unkey direction loses the observation gate; the key direction keeps it.
+
+    One rig, one runtime, two commands apart: ``ptt on`` must still refuse to
+    key a transmitter someone else is using (RADIO_NOT_OFF, no write at all),
+    while ``ptt off`` must still get an OFF onto the wire. Letting the force's
+    reach spread into ``request_on`` would turn this into a rig the CLI keys
+    over the top of.
+    """
+    log: list[str] = []
+    provider = _Provider(log)
+    provider._keyed = True  # someone else is transmitting, and this rig says so
+    runtime = await _ready_runtime(provider, "externally-keyed")
+    await runtime.request_fresh_ptt()
+    assert runtime.tx_snapshot.phase is TxPhase.EXTERNAL_UNOWNED
+    radio = _RuntimeRadio(runtime)
+    log.clear()
+
+    assert await _cmd_ptt(radio, Namespace(state="on", hold_seconds=None)) == 1
+    assert log == []  # refused before any write; nothing keyed over
+    assert held == []  # and no hold entered on a rig this session never took
+    assert f"({TxOutcome.RADIO_NOT_OFF})" in capsys.readouterr().err
+
+    assert await _cmd_ptt(radio, Namespace(state="off")) == 0
+
+    assert log == ["ptt(off)", "read_ptt"]  # the OFF and its confirming read
+    assert provider._keyed is False
+    captured = capsys.readouterr()
+    assert captured.out.splitlines() == ["PTT OFF"]
+    assert "Note" in captured.err and "keyed elsewhere" in captured.err
+    assert radio.bare_writes == []
+    await _ticker_retired(runtime)
+
+
+@pytest.mark.asyncio
+async def test_a_second_process_unkeys_a_rig_the_first_left_transmitting(
+    capsys,
+) -> None:
+    """MOR-1182 end to end: two runtimes, two supervisors, one shared wire.
+
+    Process A's lease lives in a supervisor that dies with it, so process B's
+    ``ptt off`` finds nothing of its own to release — and, never having read
+    the rig, reports ``IDLE``/``UNKNOWN``, indistinguishable from an idle
+    radio. The OFF still has to reach the wire, or the crash recovery this
+    command exists for is gone. Two separately constructed runtimes are what
+    make that real: a single shared runtime would still hold the lease and
+    could release it the ordinary way.
+    """
+    log: list[str] = []
+    provider = _Provider(log)
+    runtime_a = await _ready_runtime(provider, "process-a")
+    await runtime_a.request_fresh_ptt()
+    keying = ManagedTxApi.bind(_RuntimeRadio(runtime_a), TxOwner(TxSource.SDK, "cli-a"))
+    assert keying is not None
+    assert (await keying.set_ptt(True)).outcome is TxOutcome.ACCEPTED
+    assert provider._keyed is True
+    await _process_gone(runtime_a)
+
+    runtime_b = await _ready_runtime(provider, "process-b")  # never observed
+    before = runtime_b.tx_snapshot
+    assert (before.phase, before.radio_tx) == (TxPhase.IDLE, RadioTx.UNKNOWN)
+    radio_b = _RuntimeRadio(runtime_b)
+    log.clear()
+
+    rc = await _cmd_ptt(radio_b, Namespace(state="off"))
+
+    assert rc == 0
+    assert provider._keyed is False  # the OFF reached the wire process A keyed
+    assert log == ["ptt(off)", "read_ptt"]
+    captured = capsys.readouterr()
+    assert captured.out.splitlines() == ["PTT OFF"]
+    assert "Note" in captured.err and "keyed elsewhere" in captured.err
+    assert runtime_b.tx_snapshot.lease_id is None  # the adopted lease self-cleared
+    assert radio_b.bare_writes == []
+    await _ticker_retired(runtime_b)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
MOR-1175 PR 4 of 4 — closes MOR-1182 (the last de-key precondition of the MOR-1016 assembly, per the owner decision of 2026-08-01).

Ordinary release first, unchanged; escalation only on non-accepting outcomes via PrivilegedTxApi (5 s bound, fail-closed default arm). Unmanaged path byte-identical. _ptt_release never escalates (MOR-1179 rationale at the site). Exit codes: 0 = unkey on the wire or in flight; 1 = nothing went out, rig may still be transmitting (was always 0).

Verified independently (fresh context): the whole exit-code table row by row; (tx_busy) interpolation judged consistent (StrEnum value, matches the spec's own provider_not_ready row); legacy rc-0 path proven gone repo-wide; both real-runtime acceptance tests scrutinized (RADIO_NOT_OFF: rc 1 with EMPTY provider log; MOR-1182: two runtimes over one provider, B pinned at IDLE/UNKNOWN before forcing — the M9 trap); docs fact-checked (two one-clause fixes the review required were applied post-review: cli.md 5-s bound wording, CHANGELOG cross-entry consistency); mutations M1/M12/M2' re-run in an independent harness, each killing exactly the named tests; full suite 8917 green; mypy baseline identical.

Note: the escalation is dormant until MOR-1016 PR 2 assembles a managed runtime (every shipped radio's managed_tx is still None) — same posture as the rest of the MOR-1175 series.

4 files under an explicit owner exemption (docs ship atomically with the behavior change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)