### PR TITLE
feat: assemble the managed TX runtime at connect

### DIFF
--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -25,8 +25,7 @@ if TYPE_CHECKING:
     from rigplane._runtime_protocols import ControlPhaseHost
     from rigplane.core.acquisition_scheduler import RadioStateModelService
     from rigplane.core.radio_protocol import ManagedTxSupervisor
-    from rigplane.core.tx_safety import ProviderPttObservation
-    from rigplane.runtime.managed_radio_runtime import ManagedRadioRuntime
+    from rigplane.core.tx_safety import ProviderPttObservation, TxSafetySnapshot
 
     def _managed_tx_runtime_satisfies_supervisor(
         runtime: ManagedRadioRuntime,
@@ -35,8 +34,8 @@ if TYPE_CHECKING:
         from :class:`~rigplane.core.radio_protocol.ManagedTxSupervisor`.
 
         Guarded by ``TYPE_CHECKING`` — never defined and never called at
-        runtime, so it costs nothing until PR2 arms
-        ``self._managed_tx_runtime`` (MOR-1016). Its only job is to turn a
+        runtime, so it costs nothing now that :meth:`CoreRadio._arm_managed_tx`
+        builds ``self._managed_tx_runtime`` (MOR-1016). Its only job is to turn a
         ``request_on``/``release_owner`` signature drift on either side into
         a ``uv run mypy src/`` error here, since the assembly-time
         ``getattr_static`` two-step (:meth:`ManagedTxApi.bind`) only checks
@@ -65,6 +64,8 @@ from rigplane.runtime._civ_rx import (
 )
 from rigplane.runtime._dual_rx_runtime import DualRxRuntimeMixin
 from rigplane.runtime._scope_runtime import ScopeRuntimeMixin
+from rigplane.runtime.managed_radio_runtime import ManagedRadioRuntime
+from rigplane.runtime.managed_tx_effect_service import managed_tx_effect_service
 
 # Import split modules
 from rigplane.runtime._connection_state import RadioConnectionState
@@ -300,6 +301,7 @@ from rigplane.commands import set_tsql_freq as _set_tsql_freq_cmd
 from rigplane.commands import set_vfo as _select_vfo_cmd
 from rigplane.core.exceptions import CommandError, TimeoutError
 from rigplane.core.state_store import StateStore
+from rigplane.core.tx_safety import TxOutcome
 from rigplane.runtime.meter_cal import interpolate_swr
 from rigplane.profiles import RadioProfile, resolve_radio_profile
 from rigplane.core.radio_state import RadioState
@@ -349,6 +351,14 @@ _DEFAULT_CACHE_TTL: dict[str, float] = {"freq": 10.0, "mode": 10.0, "rf_power": 
 # cumulative and only the 30s watchdog resets it via ``soft_reconnect``.
 # Require >=3 accumulated errors before reporting ``connected = False``.
 _UDP_ERROR_THRESHOLD: int = 3
+
+# Deadline for the managed-TX arming probe (MOR-1016).  Deliberately shorter
+# than ``_civ_get_timeout``: by the time it runs the rig has already answered
+# a full initial-state fetch, so a PTT read that does not come back promptly
+# means the command is unsupported rather than merely slow — and the whole
+# point of the probe is to settle that *without* holding up ``connect()``.
+# Being wrong here costs supervised TX for one epoch, never the session.
+_MANAGED_TX_PROBE_TIMEOUT_S: float = 0.5
 
 
 class RawCivSubscription:
@@ -916,10 +926,16 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             recovery_backoff_s=(0.0, 0.0, 0.0),
         )
         self._audio_runtime: AudioRecoveryRuntime = AudioRecoveryRuntime(self)
-        # Managed TX supervisor (MOR-1016 PR1): inert until PR2 constructs and
-        # arms it in connect(). ``managed_tx`` below always answers ``None``
-        # until then, so every ingress keeps using the legacy set_ptt path.
+        # Managed TX supervisor (MOR-1016).  Built once, by the first
+        # ``connect()`` that reaches ``_arm_managed_tx`` — never here: arming
+        # needs a live ``_civ_transport`` to capture, which does not exist
+        # until the control phase has run.  From that point on the member is
+        # non-None for the life of the radio: a failed arm degrades it to
+        # NOT_READY, never back to ``None`` (see ``_arm_managed_tx``).
         self._managed_tx_runtime: ManagedRadioRuntime | None = None
+        # CI-V epoch the last arming attempt was made against; ``None`` until
+        # the first attempt.  Bounds arming to one attempt per epoch.
+        self._managed_tx_armed_epoch: int | None = None
 
     # Host shims for ControlPhaseRuntime and Icom7610SerialRadio (delegate to civ_runtime)
     def _advance_civ_generation(self, reason: str) -> None:
@@ -1054,12 +1070,158 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         :class:`~rigplane.core.radio_protocol.ManagedTxCapable`: a real class
         member, never conjured through ``__getattr__``, so
         :meth:`~rigplane.core.radio_protocol.ManagedTxApi.bind`'s
-        ``getattr_static`` read finds it. Inert until MOR-1016 PR2 constructs
-        and arms ``self._managed_tx_runtime`` at connect time — until then
-        every radio here answers ``None`` and every ingress keeps using the
-        legacy :meth:`set_ptt` path unchanged.
+        ``getattr_static`` read finds it. ``None`` only before the first
+        ``connect()`` — every ingress keeps using the legacy :meth:`set_ptt`
+        path until then. Once :meth:`_arm_managed_tx` has run this answers the
+        radio's own runtime for good, whether or not that arming succeeded:
+        a rig whose provider never came ready refuses keys with ``NOT_READY``
+        rather than reverting to an unsupervised write (MOR-1193).
         """
         return self._managed_tx_runtime
+
+    @property
+    def tx_snapshot(self) -> "TxSafetySnapshot | None":
+        """Current managed TX state, or ``None`` when no runtime exists yet.
+
+        Read-only passthrough to the supervisor's snapshot so presentation
+        (MOR-1015) can render *why* a key was refused — unarmed provider,
+        someone else's lease, a rig that is not observably OFF — without
+        reaching into ``_managed_tx_runtime`` or re-deriving TX state from
+        the legacy poller's PTT mirror.
+        """
+        runtime = self._managed_tx_runtime
+        return None if runtime is None else runtime.tx_snapshot
+
+    @property
+    def _managed_tx_target_id(self) -> str:
+        """Stable identity of the physical rig this radio's TX runtime owns.
+
+        One managed runtime supervises one rig, so the id has to separate two
+        radios that a single process holds at once and stay the same across
+        that rig's reconnects. For a LAN radio that is the backend family plus
+        the CI-V endpoint (``_host`` is the rig's address and ``_civ_port`` the
+        data port the control phase negotiated); serial radios carry the OS
+        device path instead, since ``_IcomSerialRadioBase`` passes the device
+        as ``host`` with no ports at all and ``f"…:{host}:0"`` would read as a
+        LAN rig on port zero. That branch is inert today — the serial backend
+        overrides ``connect()`` without calling ``super()``, so nothing arms
+        it (MOR-1190) — and exists so the id is right the day it does.
+        """
+        device = getattr(self, "_serial_device", None)
+        if isinstance(device, str) and device:
+            return f"serial:{device}"
+        return f"{self.backend_id}:{self._host}:{self._civ_port}"
+
+    async def _managed_tx_provider_answers_ptt(self) -> bool:
+        """Ask the rig for PTT once, unmanaged, before any port is captured.
+
+        The guard on the retirement trap. ``request_fresh_ptt`` treats "the
+        provider could not prove PTT state" as grounds to retire the managed
+        port, and ``CivRuntime.retire_managed_tx_port`` implements retirement
+        by advancing the CI-V epoch and **disconnecting the transport itself**
+        — correct for a port that was armed and is now suspect, catastrophic
+        for one that failed its very first read: it would close the CI-V
+        socket ``connect()`` opened moments earlier and hand the caller back a
+        radio that reports ``connected is False``.
+
+        So the rig proves it answers ``0x1C 0x00`` on the ordinary command
+        path first, where a timeout costs one ``CommandError`` and nothing
+        else. Only then is the runtime given a port it can retire. A rig that
+        does not implement the command — or is not answering at all — never
+        reaches step 2, and keeps its session.
+
+        This narrows the trap rather than closing it: a rig that answers the
+        probe and then drops the seed reply still loses the socket. Closing it
+        for good means teaching either ``request_fresh_ptt`` or
+        ``retire_managed_tx_port`` that an unarmed port is not a suspect one,
+        which is a change to modules this PR does not touch.
+        """
+        civ = build_civ_frame(self._radio_addr, CONTROLLER_ADDR, 0x1C, sub=0x00)
+        try:
+            await self._send_civ_expect(
+                civ, label="managed_tx_ptt_probe", timeout=_MANAGED_TX_PROBE_TIMEOUT_S
+            )
+        except Exception:
+            return False
+        return True
+
+    async def _arm_managed_tx(self) -> None:
+        """Build, bind and seed the managed TX runtime for this CI-V epoch.
+
+        Four steps, all of which must land before a key is allowed:
+
+        1. construct the runtime — once per radio, never per connect, so every
+           ingress that already bound a facade keeps pointing at the same
+           supervisor across a reconnect;
+        2. prove the rig answers PTT reads at all
+           (:meth:`_managed_tx_provider_answers_ptt`) — the guard that keeps a
+           failed arm from costing the CI-V session;
+        3. ``replace_provider(ready=True)`` — captures the *current* CI-V
+           transport as the managed port, which is why this runs at the end of
+           ``connect()`` and never in ``__init__``;
+        4. ``request_fresh_ptt()`` — one CI-V ``0x1C 0x00`` whose answer seeds
+           the authoritative OFF observation. Not optional and not cosmetic:
+           nothing polls PTT periodically, and ``request_on`` refuses with
+           ``RADIO_NOT_OFF`` until an observation exists, so a runtime armed
+           without this step can never key at all.
+
+        Failure at any step never propagates: a rig that cannot supervise TX
+        must still be usable for RX, tuning and audio. It degrades to
+        provider-not-ready and *stays published* — dropping the runtime would
+        hand the next key to the legacy unsupervised ``set_ptt`` with no lease,
+        no owner and no watchdog, which is the exact bypass MOR-1193 closed.
+
+        Bounded to one attempt per CI-V epoch: the marker is written before
+        the first await, so a re-entrant call is a no-op. A step-4 failure
+        retires the managed port, which advances the epoch by itself — so the
+        radio is immediately eligible for a fresh attempt on the next
+        ``connect()``/rearm rather than being latched off for good.
+        """
+        epoch = self._civ_epoch
+        if self._managed_tx_armed_epoch == epoch:
+            return
+        self._managed_tx_armed_epoch = epoch
+        runtime = self._managed_tx_runtime
+        if runtime is None:
+            runtime = ManagedRadioRuntime(
+                self._managed_tx_target_id,
+                service_factory=managed_tx_effect_service,
+                provider_lifecycle=self,
+            )
+            self._managed_tx_runtime = runtime
+        step = "ptt_probe"
+        try:
+            if await self._managed_tx_provider_answers_ptt():
+                step = "replace_provider"
+                if (await runtime.replace_provider(ready=True)).snapshot.provider_ready:
+                    step = "request_fresh_ptt"
+                    if (await runtime.request_fresh_ptt()).outcome is TxOutcome.APPLIED:
+                        return
+            logger.error(
+                "managed TX arming for %s did not complete at %s; TX stays "
+                "refused until a later connect re-arms it",
+                runtime.target_id,
+                step,
+            )
+        except Exception:
+            logger.error(
+                "managed TX arming for %s raised at %s; TX stays refused until "
+                "a later connect re-arms it",
+                runtime.target_id,
+                step,
+                exc_info=True,
+            )
+        # Degrade, never disappear.  A step-4 failure has already retired the
+        # port and marked the (new) provider not-ready, so this is a no-op
+        # there; the probe and capture paths need it stated explicitly.
+        try:
+            await runtime.set_provider_ready(ready=False)
+        except Exception:
+            logger.debug(
+                "managed TX degrade-to-not-ready failed for %s",
+                runtime.target_id,
+                exc_info=True,
+            )
 
     # ------------------------------------------------------------------
     # Backwards-compatible property shims for _connected / _intentional_disconnect
@@ -1251,10 +1413,16 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         ``end_external_cat_session()`` (managed-runtime crash/restart, a dropped
         Hamlib bridge) would keep cooperating pollers paused forever, freezing
         ``radio_state`` while rigctld/web serve a stale frequency.
+
+        Managed TX is armed last (MOR-1016): it captures the CI-V transport
+        this connect just built, and it must not delay the state fetch every
+        consumer waits on. It never raises — see :meth:`_arm_managed_tx` — so
+        ``connect()`` returns with ``managed_tx`` published either way.
         """
         self._reset_external_cat_session()
         await self._session_lifecycle.connect()
         await self._fetch_initial_state()
+        await self._arm_managed_tx()
 
     async def __aenter__(self) -> "CoreRadio":
         # Route through the lifecycle's guaranteed-release context manager so a

--- a/tests/test_managed_tx_assembly.py
+++ b/tests/test_managed_tx_assembly.py
@@ -1,34 +1,54 @@
-"""MOR-1016 PR1: the inert ``managed_tx`` member on ``CoreRadio``.
+"""MOR-1016: the ``managed_tx`` member on ``CoreRadio``, and its assembly.
 
-Nothing under ``src`` constructs a :class:`ManagedRadioRuntime` yet -- that is
-PR2's job (arming happens in ``connect()``, after ``_civ_transport`` exists).
-This PR only gives ``CoreRadio`` the real class member
-:class:`~rigplane.core.radio_protocol.ManagedTxCapable` requires, so it must
-prove two things and nothing more:
+PR1 gave ``CoreRadio`` the real class member
+:class:`~rigplane.core.radio_protocol.ManagedTxCapable` requires, inert:
 
 1. the member is a real property -- visible to
    :func:`inspect.getattr_static` without running it, never conjured through
    ``__getattr__`` (the exact trap ``ManagedTxCapable``'s docstring warns
    about); and
-2. every consumer of it (``ManagedTxApi.bind``, the Web reconnect hook) still
-   sees ``None`` and falls through to the legacy, unsupervised ``set_ptt``
-   path -- because a freshly constructed radio armed with nothing keeps
-   ``self._managed_tx_runtime`` at its ``None`` default.
+2. before the first ``connect()`` every consumer of it (``ManagedTxApi.bind``,
+   the Web reconnect hook) sees ``None`` and falls through to the legacy,
+   unsupervised ``set_ptt`` path -- because a radio that was never connected
+   keeps ``self._managed_tx_runtime`` at its ``None`` default.
+
+PR2 makes it real: ``connect()`` builds the runtime, captures the CI-V
+transport it just opened and seeds the authoritative OFF, so a connected radio
+publishes a supervisor every ingress binds. What that adds here is the
+three-step handshake and, more importantly, its failure mode -- a rig that
+cannot be supervised must degrade to refusing TX, never back to ``None``,
+because ``None`` hands the next key to the unsupervised legacy write with no
+lease, no owner and no watchdog (MOR-1193).
 
 No ``MagicMock`` stands in for a protocol-shaped object here (a mock answers
 every ``getattr``, so it could never show the unmanaged path staying
-unmanaged); every radio below is the real ``CoreRadio``/``IcomRadio``.
+unmanaged, and it satisfies a ``runtime_checkable`` protocol on 3.11 but not
+on 3.12+ -- gh-102433); every radio below is a real ``CoreRadio``. The wire is
+the hand-rolled ``_Provider`` the watchdog suite already uses, driving a real
+:class:`~rigplane.runtime.managed_radio_runtime.ManagedRadioRuntime` over the
+real effect service.
 """
 
 from __future__ import annotations
 
 import inspect
+from collections.abc import Iterator
 
+import pytest
+
+from rigplane.backends.icom7610 import Icom7610SerialRadio
 from rigplane.core.radio_protocol import ManagedTxApi
-from rigplane.core.tx_safety import TxOwner, TxSource
+from rigplane.core.tx_safety import (
+    RadioTx,
+    TxOutcome,
+    TxOwner,
+    TxSource,
+)
+from rigplane.exceptions import CommandError
 from rigplane.runtime import radio as radio_module
 from rigplane.runtime.radio import CoreRadio, IcomRadio
 from rigplane.web.server import WebServer
+from test_web_recovery_durable_off import _Observer, _Provider
 
 _OWNER = TxOwner(TxSource.SDK, "session")
 
@@ -146,3 +166,341 @@ def test_static_supervisor_conformance_guard_is_mypy_only() -> None:
     assert "_managed_tx_runtime_satisfies_supervisor" in source
     assert "ManagedTxSupervisor" in source
     assert "ManagedRadioRuntime" in source
+
+
+def test_unconnected_radio_publishes_no_tx_snapshot() -> None:
+    # The MOR-1015 seam follows the member: no runtime, no snapshot -- and no
+    # exception, so a presentation layer can read it unconditionally.
+    assert _unconnected_radio().tx_snapshot is None
+
+
+# ===========================================================================
+# PR2 -- connect() builds, binds and seeds the runtime
+# ===========================================================================
+
+
+class _Session:
+    """The session lifecycle reduced to what ``connect()`` observes.
+
+    A real ``CoreRadioSessionLifecycle`` wants a rig on the other end of a
+    socket. All ``_arm_managed_tx`` needs from it is the state a completed
+    control phase leaves behind: a negotiated CI-V data port and a fresh CI-V
+    epoch (the same ``_advance_civ_generation`` the real path calls).
+    """
+
+    def __init__(self, radio: CoreRadio) -> None:
+        self._radio, self.connects = radio, 0
+
+    async def connect(self) -> None:
+        self.connects += 1
+        self._radio._civ_port = 50002
+        self._radio._civ_transport = object()  # type: ignore[assignment]
+        self._radio._advance_civ_generation("test-connect")
+        self._radio._connected = True
+
+
+class _AssembledRadio(CoreRadio):
+    """A real ``CoreRadio`` whose CI-V wire is a hand-rolled provider.
+
+    Everything MOR-1016 assembles is genuine here -- ``connect()``, the
+    runtime, the effect service, the supervisor. Only the five
+    ``ProviderTxLifecycle`` methods and the probe's one command send are
+    re-pointed at the double, which is where the CI-V frames would go;
+    ``tests/test_civ_rx_coverage.py`` owns that layer, and routing through it
+    here would test the transport twice while proving nothing about the
+    assembly.
+    """
+
+    def __init__(self, provider: _Provider, *, answers_probe: bool = True) -> None:
+        super().__init__("127.0.0.1")
+        self.provider = provider
+        self.answers_probe = answers_probe
+        self.probes: list[bytes] = []
+        self._session_lifecycle = _Session(self)  # type: ignore[assignment]
+
+    async def _fetch_initial_state(self) -> None:
+        return None
+
+    async def _send_civ_expect(self, civ_frame: bytes, **kwargs: object) -> object:
+        # The ordinary command path the arming probe rides on. A rig that does
+        # not implement 0x1C 0x00 answers nothing and the real helper raises.
+        self.probes.append(civ_frame)
+        if not self.answers_probe:
+            raise CommandError("No response for managed_tx_ptt_probe")
+        return object()
+
+    def _unbind_authoritative_ptt_observer(self) -> None:
+        self.provider._unbind_authoritative_ptt_observer()
+
+    def _capture_managed_tx_port(
+        self, provider_generation: int, observer: _Observer
+    ) -> bool:
+        return self.provider._capture_managed_tx_port(provider_generation, observer)
+
+    async def _write_managed_ptt(self, provider_generation: int, on: bool) -> None:
+        await self.provider._write_managed_ptt(provider_generation, on)
+
+    async def _request_authoritative_ptt_read(
+        self, provider_generation: int, observer: _Observer
+    ) -> None:
+        await self.provider._request_authoritative_ptt_read(
+            provider_generation=provider_generation, observer=observer
+        )
+
+    async def _retire_managed_tx_port(self, provider_generation: int) -> None:
+        await self.provider._retire_managed_tx_port(provider_generation)
+        # What the real ``CivRuntime.retire_managed_tx_port`` does to the
+        # radio, and the reason a failed arm is not a dead end: retiring the
+        # port drops the CI-V transport and advances the epoch, so the next
+        # ``connect()`` is a genuinely new epoch and may attempt arming again.
+        self._advance_civ_generation("managed TX physical port retired")
+        self._civ_transport = None
+
+
+class _MutePtt(_Provider):
+    """A rig that passes the probe, captures its port, then goes quiet.
+
+    Exactly what ``CoreRadio._request_authoritative_ptt_read`` raises when the
+    response is not authoritative for the request -- the shape of a seed
+    failure on an already-captured port, which is the one that walks into the
+    retirement trap.
+    """
+
+    async def _request_authoritative_ptt_read(
+        self, *, provider_generation: int, observer: _Observer
+    ) -> None:
+        self.log.append("read_ptt")
+        raise CommandError("PTT response was not authoritative for this request")
+
+
+_LIVE: list[_AssembledRadio] = []
+
+
+@pytest.fixture(autouse=True)
+def _release_assembled_radios() -> Iterator[None]:
+    """Keep ``CoreRadio.__del__``'s forgotten-teardown WARN out of the log."""
+    yield
+    while _LIVE:
+        _LIVE.pop()._connected = False
+
+
+async def _connected(
+    provider: _Provider | None = None, *, answers_probe: bool = True
+) -> _AssembledRadio:
+    radio = _AssembledRadio(provider or _Provider([]), answers_probe=answers_probe)
+    _LIVE.append(radio)
+    await radio.connect()
+    return radio
+
+
+# --- (a) a connected radio is armed, ready and seeded ----------------------
+
+
+async def test_connect_publishes_an_armed_supervisor() -> None:
+    radio = await _connected()
+
+    assert radio.managed_tx is not None
+    assert radio.managed_tx is radio._managed_tx_runtime
+    # A successful arm captures the CI-V transport connect() just built and
+    # leaves it exactly where it found it -- no retirement, no epoch churn.
+    assert radio.connected
+    snapshot = radio.tx_snapshot
+    assert snapshot is not None
+    assert snapshot.provider_ready is True
+    # The seed landed: the supervisor has an authoritative OFF, which is the
+    # difference between a runtime that can key and one that cannot.
+    assert snapshot.radio_tx is RadioTx.OFF
+    # Exactly one authoritative read, and nothing keyed the rig on the way.
+    assert radio.provider.log == ["read_ptt"]
+
+
+async def test_target_id_names_the_civ_endpoint_of_a_lan_radio() -> None:
+    # The port is the one the control phase negotiated, not the constructor's
+    # control port -- two rigs behind one host still get distinct runtimes.
+    radio = await _connected()
+
+    assert radio._managed_tx_runtime is not None
+    assert radio._managed_tx_runtime.target_id == "rigplane:127.0.0.1:50002"
+
+
+def test_target_id_names_the_device_of_a_serial_radio() -> None:
+    # ``_IcomSerialRadioBase`` passes the device path as ``host`` with no
+    # ports, so the LAN form would render it as a rig on port zero.
+    radio = Icom7610SerialRadio(device="/dev/tty.usbserial-1", civ_link=_FakeCivLink())
+
+    assert radio._managed_tx_target_id == "serial:/dev/tty.usbserial-1"
+
+
+class _FakeCivLink:
+    """Enough of ``SerialCivLink`` to construct a serial radio, never used."""
+
+    connected = ready = healthy = False
+
+    async def connect(self) -> None:  # pragma: no cover - never connected
+        raise AssertionError("the serial target-id test must not open a port")
+
+    async def disconnect(self) -> None:  # pragma: no cover - never connected
+        return None
+
+    async def send(self, frame: bytes) -> None:  # pragma: no cover
+        return None
+
+    async def receive(self, timeout: float | None = None) -> bytes | None:
+        return None  # pragma: no cover
+
+
+# --- (c) the seed is what makes a key possible -----------------------------
+
+
+async def test_the_seeded_off_is_what_lets_a_key_through() -> None:
+    # Nothing polls PTT periodically, so ``request_on`` would answer
+    # RADIO_NOT_OFF forever if arming skipped the ``request_fresh_ptt`` step.
+    # This is the test that pins step 3: drop the seed and every key on every
+    # managed rig is refused, silently and permanently.
+    radio = await _connected()
+    api = ManagedTxApi.bind(radio, _OWNER)
+    assert api is not None
+
+    transition = await api.set_ptt(True)
+
+    assert transition.outcome is TxOutcome.ACCEPTED
+    assert transition.snapshot.lease_id is not None
+    assert "ptt(on)" in radio.provider.log
+
+    await api.set_ptt(False)
+
+
+# --- (b) a rig that cannot be supervised degrades, never disappears --------
+
+
+async def test_a_rig_that_never_answers_ptt_stays_managed_and_refuses_tx() -> None:
+    # A rig that does not implement 0x1C 0x00 at all: the probe settles it
+    # before any port is captured.
+    radio = await _connected(answers_probe=False)
+
+    # connect() returned normally -- the arming failure never propagated --
+    # and the member is still published.
+    assert radio.managed_tx is not None
+    snapshot = radio.tx_snapshot
+    assert snapshot is not None
+    assert snapshot.provider_ready is False
+
+    api = ManagedTxApi.bind(radio, _OWNER)
+    assert api is not None  # NOT the legacy path: bind still finds a supervisor
+
+    transition = await api.set_ptt(True)
+
+    # Fail closed: refused for a stated reason, and nothing reached the wire.
+    assert transition.outcome is TxOutcome.NOT_READY
+    assert transition.snapshot.lease_id is None
+    assert radio.provider.log == []
+
+
+async def test_a_rig_that_fails_the_probe_keeps_its_civ_session() -> None:
+    # The guard on the retirement trap. Retirement disconnects the CI-V
+    # transport, so an arming attempt that captures a port it cannot seed
+    # closes the socket ``connect()`` just opened and hands the caller back a
+    # radio that reports ``connected is False``. The probe runs on the
+    # ordinary command path, before any capture, so a rig that cannot answer
+    # never gets that far and keeps the session it just built.
+    radio = await _connected(answers_probe=False)
+
+    assert len(radio.probes) == 1  # exactly one probe, not a retry storm
+    assert radio._civ_transport is not None
+    assert radio.connected
+    # Never captured means never retired: the epoch is the one connect() left.
+    assert radio._managed_tx_armed_epoch == radio._civ_epoch
+
+
+async def test_a_failed_seed_leaves_the_radio_armable_on_the_next_epoch() -> None:
+    # The residual exposure the probe narrows but cannot close: a rig that
+    # answers the probe and then drops the seed reply. The retirement fires,
+    # which advances the CI-V epoch by itself. That must read as "eligible
+    # again", not as a latched-off radio: the same runtime object arms cleanly
+    # next time, so every facade already bound to it starts working without
+    # rebinding.
+    radio = await _connected(_MutePtt([]))
+    runtime = radio._managed_tx_runtime
+    assert runtime is not None
+    assert radio.tx_snapshot is not None
+    assert radio.tx_snapshot.provider_ready is False
+    # The stated cost: the retirement took the CI-V transport with it, so the
+    # data watchdog will reconnect. That reconnect is what supplies the next
+    # epoch -- the attempt is not silently retried on a dead port, and it is
+    # not latched off either.
+    assert radio._civ_transport is None
+    assert radio._managed_tx_armed_epoch != radio._civ_epoch
+
+    radio.provider = _Provider(radio.provider.log)
+    await radio._arm_managed_tx()
+
+    assert radio._managed_tx_runtime is runtime
+    snapshot = radio.tx_snapshot
+    assert snapshot is not None
+    assert (snapshot.provider_ready, snapshot.radio_tx) == (True, RadioTx.OFF)
+
+
+# --- (d) one arming attempt per CI-V epoch ---------------------------------
+
+
+async def test_arming_is_bounded_to_one_attempt_per_civ_epoch() -> None:
+    # ``replace_provider`` is not free and not idempotent: a second one
+    # retires the port the first captured, taking the live CI-V transport with
+    # it. On an unchanged epoch, re-arming must not happen at all.
+    radio = await _connected()
+    runtime = radio._managed_tx_runtime
+    assert runtime is not None
+    replacements: list[bool] = []
+    replace_provider = runtime.replace_provider
+
+    async def _counted(*, ready: bool):  # type: ignore[no-untyped-def]
+        replacements.append(ready)
+        return await replace_provider(ready=ready)
+
+    runtime.replace_provider = _counted  # type: ignore[method-assign]
+
+    await radio._arm_managed_tx()
+    await radio._arm_managed_tx()
+
+    assert replacements == []
+    assert radio.provider.log == ["read_ptt"]  # and no second seed either
+
+
+async def test_a_fresh_epoch_re_arms_the_very_same_runtime() -> None:
+    # Per *epoch*, not once per process: a reconnect gets a new managed port,
+    # but the supervisor object survives it, so an ingress that bound a facade
+    # before the drop still holds the right one afterwards.
+    radio = await _connected()
+    runtime = radio._managed_tx_runtime
+
+    await radio.connect()
+
+    assert radio._managed_tx_runtime is runtime
+    assert radio.provider.log == ["read_ptt", "read_ptt"]
+    snapshot = radio.tx_snapshot
+    assert snapshot is not None
+    assert (snapshot.provider_ready, snapshot.radio_tx) == (True, RadioTx.OFF)
+
+
+# --- (e) every ingress binds the radio's own supervisor --------------------
+
+
+async def test_bind_returns_a_facade_over_the_radios_own_runtime() -> None:
+    radio = await _connected()
+
+    api = ManagedTxApi.bind(radio, _OWNER)
+
+    assert api is not None
+    # Identity, not equality: two supervisors over one rig is two independent
+    # leases over one PTT line, which is the failure managed TX exists to
+    # prevent.
+    assert api.supervisor is radio._managed_tx_runtime
+
+
+async def test_two_radios_get_two_independent_supervisors() -> None:
+    first, second = await _connected(), await _connected()
+
+    one, two = ManagedTxApi.bind(first, _OWNER), ManagedTxApi.bind(second, _OWNER)
+
+    assert one is not None and two is not None
+    assert one.supervisor is not two.supervisor


### PR DESCRIPTION
MOR-1016 PR 2 of 7 — the assembly step. One ManagedRadioRuntime per CoreRadio, armed at connect via probe → construct → replace_provider → seed.

## The deviation, adjudicated
The plan's 3-step handshake was unshippable: the seed's failure path retires the current port and retirement disconnects the CI-V transport (verifier re-derived the chain from _civ_rx.py:723-743 and constructively proved it — reverting the probe reproduces 40 failures across the connect-hygiene families). The shipped pre-probe (same 0x1C 0x00 frame, ordinary path, 0.5 s bound) keeps a retirable port out of the runtime's hands until the rig demonstrates it answers PTT reads. Residual (probe answers, seed drops — incl. the sharper deterministic variant where the payload fails the seed's stricter acceptance) is bounded, degrades per the invariant except the socket loss, and is filed as MOR-1206.

## Invariant
Managed-eligible ⇒ managed_tx non-None from connect() to disconnect; all failures degrade to published-but-NOT_READY, never None (bind() over a degraded runtime refuses with NOT_READY, zero provider writes — no silent legacy fallback). Verified row-by-row against the code.

## Verification (independent, fresh context)
20/20 assembly tests; 17-file/899-test superset of the blast-radius candidates green; the previously-failing families green ×3 repeats (0.5 s constant timing-stable); full suite 8929/0; mypy baseline identical; ruff/lint-imports clean; mutations Mnull/Mseed/Mepoch/Mprobe all killed (Mprobe = the literal planned handshake → 40 failures). No cmd29 anywhere; no keep-alive cadence interaction (one-shot GET after _fetch_initial_state).

## Carried to PR 3
The one-attempt-per-epoch guard must key off the BINDING, not _managed_tx_armed_epoch, once rearm_managed_tx() becomes a second caller (re-arm over a bound provider advances the epoch mid-call). Harmless here: connect() is the sole caller.

[full-ci] on the commit — local verification was 3.13-only; the 3.11/3.12/3.13 matrix is required for this ticket (MOR-1193).

🤖 Generated with [Claude Code](https://claude.com/claude-code)