### PR TITLE
feat: make rearm_managed_tx the sole re-arm path with a binding-keyed no-op

### DIFF
--- a/src/rigplane/runtime/_control_phase.py
+++ b/src/rigplane/runtime/_control_phase.py
@@ -821,6 +821,30 @@ class ControlPhaseRuntime:
             h._start_civ_worker()
             h._start_civ_data_watchdog()
         logger.info("Soft reconnect to %s (civ=%d)", h._host, h._civ_port)
+
+        # Managed TX is re-armed here, ahead of every reconnect consumer, so
+        # the durable OFF a drop armed reaches the wire before any recovered
+        # work does — and so it happens at all on a headless rig, which has no
+        # ``_on_reconnect`` consumer to piggyback on. The rebind captures the
+        # CI-V port this method just rebuilt, which is why it cannot run any
+        # earlier. ``rearm_managed_tx`` is the only re-arm path there is: a
+        # consumer that replaced the provider itself would retire the port this
+        # call captured, taking the repaired transport down with it.
+        #
+        # Fail-soft, and by a different rule than the callback below: arming
+        # already fails closed inside the radio (TX stays refused, the
+        # supervisor stays published), so an exception escaping it is a
+        # surprise worth a warning rather than a debug line — but never worth
+        # failing a CI-V reconnect that otherwise succeeded.
+        rearm_managed_tx = getattr(h, "rearm_managed_tx", None)
+        if rearm_managed_tx is not None:
+            try:
+                await rearm_managed_tx()
+            except Exception:
+                logger.warning(
+                    "soft_reconnect: managed TX re-arm failed", exc_info=True
+                )
+
         on_reconnect = getattr(h, "_on_reconnect", None)
         if on_reconnect is not None:
             try:

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -936,6 +936,14 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         # CI-V epoch the last arming attempt was made against; ``None`` until
         # the first attempt.  Bounds arming to one attempt per epoch.
         self._managed_tx_armed_epoch: int | None = None
+        # Identity of the port the runtime is bound to, recorded the moment
+        # ``replace_provider`` captured it: (provider generation, CI-V epoch,
+        # transport).  Never cleared — every way a binding dies moves one of
+        # the three (see ``_managed_tx_binding_is_live``).
+        self._managed_tx_bound_port: tuple[int | None, int, object] | None = None
+        # Serialises the arming steps, so two callers cannot both find the
+        # binding dead and both replace the provider.
+        self._managed_tx_arm_lock = asyncio.Lock()
 
     # Host shims for ControlPhaseRuntime and Icom7610SerialRadio (delegate to civ_runtime)
     def _advance_civ_generation(self, reason: str) -> None:
@@ -1145,7 +1153,78 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             return False
         return True
 
+    def _managed_tx_binding_is_live(self) -> bool:
+        """Whether the runtime's provider is bound to *this* CI-V port, now.
+
+        The one question a re-arm may key off, and the reason
+        ``_managed_tx_armed_epoch`` cannot answer it: that marker is written
+        before arming's first await, and arming's own retirement step can
+        advance the CI-V epoch before the capture that follows it. A perfectly
+        successful arm can therefore leave the marker one epoch behind a live
+        binding — at which point an epoch-keyed guard waves the *next* caller
+        through into exactly the second ``replace_provider`` this exists to
+        prevent, one call later than the naive case. That second call retires a
+        current port, and retirement advances the generation and disconnects
+        the transport, so the redundant re-arm is what breaks the connection
+        the reconnect just repaired.
+
+        The three facts recorded at capture are compared against the live ones
+        instead, which is also why nothing has to clear them: a retirement
+        advances the supervisor's provider generation, a CI-V recovery advances
+        the epoch, and a rebuilt data path replaces the transport object. Any
+        one of the three moving means the recorded port is no longer the bound
+        one, and the answer flips to "re-arm" on its own.
+        """
+        runtime, bound = self._managed_tx_runtime, self._managed_tx_bound_port
+        if runtime is None or bound is None or self._civ_transport is None:
+            return False
+        generation, epoch, transport = bound
+        return (
+            transport is self._civ_transport
+            and epoch == self._civ_epoch
+            and generation == runtime.tx_snapshot.provider_generation
+        )
+
+    async def rearm_managed_tx(self) -> None:
+        """Re-arm managed TX after a repaired CI-V path. The sole re-arm path.
+
+        Every consumer that used to reach for ``replace_provider`` of its own
+        accord routes here instead — the control phase ahead of its reconnect
+        callbacks, the Web recovery hook behind them — and exactly one of them
+        does the work: a caller that finds the provider already bound to the
+        live port returns having touched nothing. That no-op is the point.
+        Rebinding is not idempotent, and the cost of the redundant call is not
+        a wasted round trip but the transport itself
+        (:meth:`_managed_tx_binding_is_live`).
+
+        Past the guard this is arming unchanged — probe, capture, seed, and the
+        same degradation: a rig that cannot be supervised keeps its published
+        runtime and refuses TX rather than falling back to the unsupervised
+        legacy write (MOR-1193). Failures never propagate, so a caller on a
+        recovery path can await it without guarding.
+        """
+        if self._managed_tx_binding_is_live():
+            return
+        async with self._managed_tx_arm_lock:
+            # Re-checked under the lock: the holder this caller queued behind
+            # may have been the one that armed the very port it came to replace.
+            if not self._managed_tx_binding_is_live():
+                await self._run_managed_tx_arm()
+
     async def _arm_managed_tx(self) -> None:
+        """Arm managed TX from ``connect()``, once per CI-V epoch.
+
+        The epoch bound belongs to this entry point, not to the arming steps:
+        a fresh connect is the one caller with nothing to compare a binding
+        against, so "have I already tried on this epoch" is the only cheap
+        question it can ask. Re-arm callers ask a sharper one — see
+        :meth:`rearm_managed_tx`.
+        """
+        async with self._managed_tx_arm_lock:
+            if self._managed_tx_armed_epoch != self._civ_epoch:
+                await self._run_managed_tx_arm()
+
+    async def _run_managed_tx_arm(self) -> None:
         """Build, bind and seed the managed TX runtime for this CI-V epoch.
 
         Four steps, all of which must land before a key is allowed:
@@ -1171,16 +1250,13 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         hand the next key to the legacy unsupervised ``set_ptt`` with no lease,
         no owner and no watchdog, which is the exact bypass MOR-1193 closed.
 
-        Bounded to one attempt per CI-V epoch: the marker is written before
-        the first await, so a re-entrant call is a no-op. A step-4 failure
-        retires the managed port, which advances the epoch by itself — so the
-        radio is immediately eligible for a fresh attempt on the next
-        ``connect()``/rearm rather than being latched off for good.
+        Serialised by ``_managed_tx_arm_lock``, so the steps below never
+        interleave with a second attempt. A step-4 failure retires the managed
+        port, which advances the epoch by itself — so the radio is immediately
+        eligible for a fresh attempt on the next ``connect()``/rearm rather
+        than being latched off for good.
         """
-        epoch = self._civ_epoch
-        if self._managed_tx_armed_epoch == epoch:
-            return
-        self._managed_tx_armed_epoch = epoch
+        self._managed_tx_armed_epoch = self._civ_epoch
         runtime = self._managed_tx_runtime
         if runtime is None:
             runtime = ManagedRadioRuntime(
@@ -1193,7 +1269,17 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         try:
             if await self._managed_tx_provider_answers_ptt():
                 step = "replace_provider"
-                if (await runtime.replace_provider(ready=True)).snapshot.provider_ready:
+                bound = (await runtime.replace_provider(ready=True)).snapshot
+                if bound.provider_ready:
+                    # Identity of the port just captured, for the re-arm guard.
+                    # Recorded here rather than inside
+                    # ``_capture_managed_tx_port`` so a backend that overrides
+                    # that lifecycle hook cannot silently lose it.
+                    self._managed_tx_bound_port = (
+                        bound.provider_generation,
+                        self._civ_epoch,
+                        self._civ_transport,
+                    )
                     step = "request_fresh_ptt"
                     if (await runtime.request_fresh_ptt()).outcome is TxOutcome.APPLIED:
                         return

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -1812,12 +1812,21 @@ class WebServer:
         managed TX port, so a release armed before the drop is re-armed against
         a fresh causal boundary only once the provider is rebound.  Awaiting the
         rebind here is what puts the OFF in front of ordinary recovered work:
-        ``ManagedRadioRuntime.replace_provider`` services the re-armed release
-        before it returns, so the write has reached the radio by the time the
-        refetch, the poller readiness signal and the scope re-enable start.
+        the re-arm services the re-armed release before it returns, so the write
+        has reached the radio by the time the refetch, the poller readiness
+        signal and the scope re-enable start.
+
+        The rebind goes through the radio's own ``rearm_managed_tx`` rather than
+        ``replace_provider`` on the supervisor (MOR-1016).  Both would rebind,
+        but only the radio's knows whether the provider is *already* bound to
+        the port the reconnect just repaired — and a second ``replace_provider``
+        over a live binding retires that port, advancing the CI-V generation and
+        disconnecting the transport.  ``soft_reconnect`` re-arms on its own way
+        past, so this pass is very often the second caller.
 
         Unmanaged radios publish no supervisor and keep today's behaviour
-        exactly — no backend assembles a managed runtime until MOR-1016.
+        exactly — Yaesu, the rigctld client and the serial backends assemble no
+        managed runtime.
         """
         # Resolving the supervisor is backend code, not an attribute lookup.
         # ``getattr_static`` settles absence without running the accessor, so
@@ -1832,16 +1841,20 @@ class WebServer:
         supervisor = radio.managed_tx
         if supervisor is None:
             return
-        rebind = getattr(supervisor, "replace_provider", None)
+        rebind = getattr(radio, "rearm_managed_tx", None)
         if rebind is None:
-            # ``ManagedTxSupervisor`` declares ``request_on``/``release_owner``
-            # only, so a facade satisfying exactly that protocol lands here.
+            # A backend that publishes a supervisor but re-arms it somewhere
+            # this hook cannot reach — ``ManagedTxSupervisor`` declares
+            # ``request_on``/``release_owner`` only, so a facade satisfying
+            # exactly that protocol over a radio without the re-arm lands here.
             # Returning through the unmanaged branch would leave a keyed rig
             # keyed with nothing logged; "unmanaged" is a positive
             # determination, never a fallback from a failure to look.
             logger.warning(
-                "reconnect: managed TX supervisor %s exposes no replace_provider; "
-                "an armed durable OFF cannot be re-armed and the rig may stay keyed",
+                "reconnect: managed TX radio %s over supervisor %s exposes no "
+                "rearm_managed_tx; an armed durable OFF cannot be re-armed and "
+                "the rig may stay keyed",
+                type(radio).__name__,
                 type(supervisor).__name__,
             )
             return
@@ -1868,7 +1881,7 @@ class WebServer:
                 # code: resolving the coroutine and handing it to ``create_task``
                 # can each fail, and this helper runs above the ``finally`` that
                 # signals readiness, so an escape here shuts the scope gate.
-                rebind_task = self._spawn(rebind(ready=True))
+                rebind_task = self._spawn(rebind())
                 await asyncio.wait_for(
                     asyncio.shield(rebind_task), _MANAGED_TX_REBIND_TIMEOUT
                 )

--- a/tests/test_web_recovery_durable_off.py
+++ b/tests/test_web_recovery_durable_off.py
@@ -20,6 +20,15 @@ rebind that never returns, and two reconnects racing each other.
 MOR-1196 settles the read itself: resolving the supervisor is a fallible
 operation, not an attribute lookup, so it may neither be read as absence when
 it fails nor escape the guard that re-opens the scope gate.
+
+MOR-1016 PR3 gives the hook a second re-arm caller: ``soft_reconnect`` now
+re-arms the radio itself, before any consumer's recovery, so this pass is very
+often the *second* one. Both are routed onto ``CoreRadio.rearm_managed_tx``,
+whose no-op-when-already-bound guard is what keeps the second from retiring the
+port the first captured — a rebind that would take the repaired CI-V transport
+down with it. Those cases run over a real ``CoreRadio`` and the real
+``soft_reconnect``, because the ordering and the guard are both claims about
+production wiring that a double could only assert about itself.
 """
 
 from __future__ import annotations
@@ -31,6 +40,7 @@ from collections.abc import Callable
 
 import pytest
 
+from rigplane import transport as transport_module
 from rigplane.core.radio_protocol import ManagedTxSupervisor
 from rigplane.core.tx_safety import (
     ProviderPttObservation,
@@ -43,8 +53,14 @@ from rigplane.core.tx_safety import (
 )
 from rigplane.runtime.managed_radio_runtime import ManagedRadioRuntime
 from rigplane.runtime.managed_tx_effect_service import managed_tx_effect_service
+from rigplane.runtime.radio import CoreRadio
 from rigplane.web import server as web_server
 from rigplane.web.server import WebServer
+from test_audio_reconnect_rearm import (
+    _FakeCivTransport,
+    _SoftReconnectHost,
+    _TestControlPhaseRuntime,
+)
 
 _OWNER = TxOwner(TxSource.WEBSOCKET, "ws-1")
 _Observer = Callable[[ProviderPttObservation], None]
@@ -129,6 +145,21 @@ class _Radio:
         self.log.append("refetch")
 
 
+class _ManagedTxRadio(_Radio):
+    """A backend that re-arms its own managed port, as ``CoreRadio`` now does.
+
+    Recovery stopped reaching for ``replace_provider`` on the supervisor in
+    MOR-1016: only the radio can tell whether the provider is already bound to
+    the port the reconnect repaired, so only the radio may decide to rebind.
+    The forwarder is deliberately thin — the real method's degradation is
+    pinned on the real ``CoreRadio`` further down, and a double that swallowed
+    failures here would hide the rebind failures these cases were written for.
+    """
+
+    async def rearm_managed_tx(self) -> None:
+        await self.managed_tx.replace_provider(ready=True)
+
+
 class _RaisingSupervisorRadio(_Radio):
     """Backend whose supervisor accessor raises instead of answering.
 
@@ -178,7 +209,7 @@ async def _managed(
         await runtime.set_provider_ready(ready=False)  # the control link drops
         assert runtime.tx_snapshot.phase is TxPhase.RELEASE_REQUIRED
     log.clear()
-    return WebServer(_Radio(log, runtime)), runtime, provider, log  # type: ignore[arg-type]
+    return WebServer(_ManagedTxRadio(log, runtime)), runtime, provider, log  # type: ignore[arg-type]
 
 
 async def _recover(server: WebServer) -> None:
@@ -451,3 +482,204 @@ async def test_overlapping_reconnects_do_not_interleave() -> None:
     assert log.count("refetch") == 2
     assert log.index("read_ptt") < log.index("retire[2]")
     assert runtime.tx_snapshot.phase is TxPhase.IDLE
+
+
+# ===========================================================================
+# MOR-1016 PR3 -- one re-arm per repaired path, and it goes first
+# ===========================================================================
+
+
+class _CivPort:
+    """A CI-V data transport stand-in; its identity is all the guard reads."""
+
+
+class _ManagedRadio(CoreRadio):
+    """A real ``CoreRadio`` whose managed port keeps the CI-V bookkeeping.
+
+    ``_AssembledRadio`` in ``test_managed_tx_assembly`` retires
+    unconditionally, which is right for the arming failures it pins. What the
+    re-arm guard turns on is the *conditional* half of
+    ``CivRuntime.retire_managed_tx_port``: the epoch advances, and the
+    transport is dropped, only when the port being retired is the current one.
+    Retiring a port from an older epoch, or one whose transport has since been
+    replaced, leaves both alone — and telling that apart from a live binding is
+    the entire job of the guard under test.
+    """
+
+    def __init__(self, provider: _Provider) -> None:
+        super().__init__("127.0.0.1")
+        self.provider = provider
+        self._civ_transport = _CivPort()  # type: ignore[assignment]
+        self._ports: dict[int, tuple[int, object]] = {}
+
+    async def _send_civ_expect(self, civ_frame: bytes, **kwargs: object) -> object:
+        return object()  # the arming probe: this rig answers 0x1C 0x00
+
+    def _unbind_authoritative_ptt_observer(self) -> None:
+        self.provider._unbind_authoritative_ptt_observer()
+
+    def _capture_managed_tx_port(self, generation: int, observer: _Observer) -> bool:
+        if self._civ_transport is None:
+            # What ``CivRuntime.capture_managed_port`` answers with nothing to
+            # capture — the state a destructive second rebind leaves behind.
+            self._unbind_authoritative_ptt_observer()
+            return False
+        if not self.provider._capture_managed_tx_port(generation, observer):
+            return False
+        self._ports[generation] = (self._civ_epoch, self._civ_transport)
+        return True
+
+    async def _write_managed_ptt(self, generation: int, on: bool) -> None:
+        await self.provider._write_managed_ptt(generation, on)
+
+    async def _request_authoritative_ptt_read(
+        self, provider_generation: int, observer: _Observer
+    ) -> None:
+        await self.provider._request_authoritative_ptt_read(
+            provider_generation=provider_generation, observer=observer
+        )
+
+    async def _retire_managed_tx_port(self, generation: int) -> None:
+        await self.provider._retire_managed_tx_port(generation)
+        epoch, transport = self._ports.pop(generation, (None, None))
+        if epoch == self._civ_epoch:
+            self._advance_civ_generation("managed TX physical port retired")
+        if transport is self._civ_transport:
+            self._civ_transport = None
+
+
+async def _armed() -> tuple[_ManagedRadio, ManagedRadioRuntime, list[bool]]:
+    """A radio armed through the public path, counting every rebind after it."""
+    radio = _ManagedRadio(_Provider([]))
+    await radio.rearm_managed_tx()
+    runtime = radio._managed_tx_runtime
+    assert runtime is not None
+    assert radio.tx_snapshot is not None and radio.tx_snapshot.provider_ready
+    rebinds: list[bool] = []
+    replace_provider = runtime.replace_provider
+
+    async def _counted(*, ready: bool) -> TxTransition:
+        rebinds.append(ready)
+        return await replace_provider(ready=ready)
+
+    runtime.replace_provider = _counted  # type: ignore[method-assign]
+    return radio, runtime, rebinds
+
+
+async def test_a_second_rearm_over_a_live_binding_touches_nothing() -> None:
+    """The no-op is the feature: two recovery callers, one of them does work."""
+    radio, _runtime, rebinds = await _armed()
+    port = radio._civ_transport
+
+    await radio.rearm_managed_tx()
+
+    assert rebinds == []  # zero ``replace_provider`` calls reach the runtime
+    assert radio._civ_transport is port
+    assert radio.provider.log == ["read_ptt"]  # and no second seed either
+
+
+async def test_web_and_the_control_phase_rebind_a_reconnect_once_between_them() -> None:
+    """R2: ``soft_reconnect`` re-arms and the Web hook re-arms; one may land."""
+    radio, _runtime, rebinds = await _armed()
+    server = WebServer(radio)  # type: ignore[arg-type]
+    # What ``soft_reconnect`` leaves behind: a fresh CI-V socket on a fresh
+    # generation, with the pre-drop binding stale against both.
+    radio._civ_transport = port = _CivPort()  # type: ignore[assignment]
+    radio._advance_civ_generation("soft_reconnect")
+
+    await radio.rearm_managed_tx()  # the control phase, ahead of the callbacks
+    await server._service_managed_tx_release()  # the Web hook, right behind it
+
+    # A second rebind would retire the port the first captured — current epoch,
+    # current transport — which advances the generation and disconnects the
+    # socket the reconnect just repaired, undoing the recovery it rode in on.
+    assert rebinds == [True]
+    assert radio._civ_transport is port
+    snapshot = radio.tx_snapshot
+    assert snapshot is not None and snapshot.provider_ready
+
+
+async def test_an_arm_that_moved_the_epoch_does_not_invite_another_rebind() -> None:
+    """The guard reads the binding, not ``_managed_tx_armed_epoch``.
+
+    ``_managed_tx_armed_epoch`` survives the plain two-caller race above — it
+    happens to agree there — and is wrong on both sides of this one, which is
+    why that race cannot be the only case here. The marker is written before
+    arming's first await and answers "have I tried on this epoch", not "is the
+    provider bound". A port whose transport was rebuilt under it is dead on an
+    unchanged epoch, so keying off the marker refuses the re-arm that would
+    revive it; and arming a replacement retires a port of the *current* epoch,
+    which advances the epoch before the capture that follows — leaving a wholly
+    successful arm with its marker one epoch behind a live binding, where the
+    marker now reads "never armed here" and waves the destructive rebind
+    through.
+    """
+    radio, _runtime, rebinds = await _armed()
+    # The window ``soft_reconnect`` passes through between binding the new CI-V
+    # socket and advancing the generation: transport replaced, epoch not yet.
+    radio._civ_transport = port = _CivPort()  # type: ignore[assignment]
+    epoch_before = radio._civ_epoch
+
+    await radio.rearm_managed_tx()
+
+    # Re-armed, because the binding was dead — the marker would have said no.
+    assert rebinds == [True]
+    assert radio._civ_epoch != epoch_before  # the retirement moved it mid-call
+    assert radio._managed_tx_armed_epoch == epoch_before  # the marker did not
+    assert radio._civ_transport is port
+
+    await radio.rearm_managed_tx()
+
+    # And not re-armed, because the binding is live — the marker would have
+    # said yes, retiring a current port and disconnecting a working transport.
+    assert rebinds == [True]
+    assert radio._civ_transport is port
+    snapshot = radio.tx_snapshot
+    assert snapshot is not None and snapshot.provider_ready
+
+
+async def test_soft_reconnect_re_arms_before_it_calls_any_consumer(monkeypatch) -> None:
+    """The durable OFF goes in front of every consumer's recovery, not one.
+
+    The Web hook put it in front of the Web's own recovered work; nothing put
+    it in front of a headless consumer's, and nothing serviced it at all on a
+    rig with no ``_on_reconnect`` at all. The real ``soft_reconnect`` runs here
+    because the ordering claim is about that method's body and nothing else.
+    """
+    monkeypatch.setattr(transport_module, "IcomTransport", _FakeCivTransport)
+    order: list[str] = []
+    host = _SoftReconnectHost()
+    host._on_reconnect = lambda: order.append("on_reconnect")
+
+    async def _rearm() -> None:
+        order.append("rearm")
+
+    host.rearm_managed_tx = _rearm  # type: ignore[attr-defined]
+
+    await _TestControlPhaseRuntime(host).soft_reconnect()  # type: ignore[arg-type]
+
+    assert order == ["rearm", "on_reconnect"]
+
+
+async def test_a_re_arm_that_raises_does_not_fail_the_reconnect(
+    monkeypatch, caplog
+) -> None:
+    """Fail-soft: arming already fails closed, so nothing here may fail hard."""
+    monkeypatch.setattr(transport_module, "IcomTransport", _FakeCivTransport)
+    order: list[str] = []
+    host = _SoftReconnectHost()
+    host._on_reconnect = lambda: order.append("on_reconnect")
+
+    async def _raises() -> None:
+        raise ConnectionError("the rig went away again")
+
+    host.rearm_managed_tx = _raises  # type: ignore[attr-defined]
+
+    with caplog.at_level(logging.WARNING):
+        await _TestControlPhaseRuntime(host).soft_reconnect()  # type: ignore[arg-type]
+
+    # The CI-V path is repaired and every consumer still gets its callback; a
+    # rig that cannot supervise TX is still a rig that must receive.
+    assert order == ["on_reconnect"]
+    assert host._civ_transport is not None
+    assert _warned(caplog, "re-arm failed")


### PR DESCRIPTION
MOR-1016 PR 3 of 8 — closes the R2 double-rebind hazard. rearm_managed_tx() is the single public re-arm path with a no-op keyed on the live (generation, epoch, transport) binding triple (an epoch marker provably cannot work — a successful arm advances the epoch mid-call); soft_reconnect re-arms before any consumer recovers; web/server.py's hardened rebind (MOR-1192/1196 structure preserved verbatim) now spawns the radio's rearm instead of calling replace_provider itself.

Verified independently: the no-clearing death-path audit re-derived from source (all five retirement sites pair with generation advance synchronously under the lock); mutations Midem/Mepoch2 (the third-call discriminator)/Morder/Mweb all killed; full suite green; MOR-1192/1196 cases pass unmodified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)