### PR TITLE
fix: don't let commander worker swallow its own teardown cancel

### DIFF
--- a/src/rigplane/commands/commander.py
+++ b/src/rigplane/commands/commander.py
@@ -265,10 +265,18 @@ class IcomCommander:
                         resp = await execute_task
                     except asyncio.CancelledError:
                         # Distinguish caller-driven cancel from worker
-                        # teardown (c.stop()): on caller-cancel, item.future
-                        # is already in cancelled state; on worker stop, the
-                        # outer except below handles it.
-                        if item.future.cancelled():
+                        # teardown (c.stop()).  item.future.cancelled() alone
+                        # is not a safe discriminator: when a caller timeout
+                        # has already cancelled both the future and the
+                        # in-flight execute, stop()'s worker.cancel() is
+                        # delivered through this same await — swallowing it
+                        # would park _loop on queue.get() forever and hang
+                        # stop().  Task.cancelling() (3.11+) exposes the
+                        # worker's own pending cancel request.
+                        worker = asyncio.current_task()
+                        if item.future.cancelled() and not (
+                            worker is not None and worker.cancelling()
+                        ):
                             # Packet was sent on the wire — honor pacing
                             # for the next item.
                             self._last_send = asyncio.get_running_loop().time()

--- a/tests/test_commander.py
+++ b/tests/test_commander.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 
 import pytest
 
@@ -438,3 +439,82 @@ async def test_cancelled_queued_request_is_not_executed() -> None:
         assert seen == [b"block"]
     finally:
         await c.stop()
+
+
+async def _assert_stop_completes(c: IcomCommander) -> None:
+    """Await c.stop() via asyncio.wait, failing loudly if it wedges.
+
+    Deliberately NOT asyncio.wait_for(c.stop(), ...): on the buggy path
+    wait_for's timeout cancels the stop task, and that cancel cascades into
+    a second worker.cancel() delivered at queue.get() — un-wedging the
+    worker and letting wait_for return normally, masking the hang.
+    asyncio.wait leaves the pending task untouched, so the wedge is visible.
+    """
+    stop_task = asyncio.ensure_future(c.stop())
+    done, _pending = await asyncio.wait({stop_task}, timeout=2.0)
+    if stop_task not in done:
+        stop_task.cancel()  # cascade un-wedges the worker for cleanup
+        with contextlib.suppress(asyncio.CancelledError):
+            await stop_task
+        pytest.fail("stop() hung: worker swallowed its own teardown cancel")
+
+
+@pytest.mark.asyncio
+async def test_stop_unblocks_when_caller_cancel_races_teardown() -> None:
+    """Worker teardown must win when it races a caller-driven cancel.
+
+    A caller timeout/disconnect cancels item.future and, via the worker's
+    done-callback, the in-flight execute task.  If stop() cancels the worker
+    while it is still parked on that already-cancelled execute, the worker's
+    own CancelledError arrives through the same await — treating it as the
+    caller-cancel case (continue) swallows the teardown request, _loop goes
+    back to queue.get(), and stop() hangs forever on await self._worker.
+    """
+    started = asyncio.Event()
+    hang = asyncio.Event()
+
+    async def execute(cmd: bytes, wait_response: bool = True) -> CivFrame | None:
+        started.set()
+        await hang.wait()
+        return None
+
+    c = IcomCommander(execute, min_interval=0.0)
+    c.start()
+
+    send_task = asyncio.create_task(c.send(b"never-answered"))
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+
+    # Caller goes away: cancels item.future, which propagates into the
+    # in-flight execute task via the worker's done-callback.
+    send_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await send_task
+
+    # No yields between here and stop(): the worker must still be parked
+    # on the already-cancelled execute when its own cancel arrives.
+    await _assert_stop_completes(c)
+
+
+@pytest.mark.asyncio
+async def test_stop_returns_after_send_timeout_without_yield() -> None:
+    """Field repro (Python 3.11): timed-out send immediately followed by
+    stop() must not wedge the worker.
+
+    3.11's wait_for unwinds the timed-out caller in fewer loop ticks than
+    3.12+, leaving the worker still parked on the cancelled execute when
+    stop()'s worker.cancel() lands.
+    """
+    hang = asyncio.Event()
+
+    async def execute(cmd: bytes, wait_response: bool = True) -> CivFrame | None:
+        await hang.wait()
+        return None
+
+    c = IcomCommander(execute, min_interval=0.0)
+    c.start()
+
+    with pytest.raises(asyncio.TimeoutError):
+        await c.send(b"no-reply", timeout=0.05)
+
+    # No yields between the timeout and stop().
+    await _assert_stop_completes(c)


### PR DESCRIPTION
## Problem

`IcomCommander._loop` distinguishes a caller-driven cancel from worker teardown by `item.future.cancelled()` alone. That discriminator is unreliable: when a caller's `send(..., timeout=T)` has already timed out (cancelling `item.future` and, via the `_propagate_cancel` done-callback, the in-flight `execute_task`), the worker can still be parked on `await execute_task` when `stop()` calls `self._worker.cancel()`. The teardown cancel is then delivered through the already-cancelled inner task, the caller-cancel branch reads `item.future.cancelled() is True` and `continue`s — swallowing the worker's own cancellation. `_loop` parks on `queue.get()` forever and `stop()` hangs on `await self._worker`, wedging everything downstream (`ControlPhaseRuntime.disconnect` → `CivRuntime.stop_worker`, lifecycle release, SIGTERM graceful close).

Observed live on Python 3.11.13 while implementing MOR-1016 PR8 (task stuck as `<Task cancelling ...>` with `task.cancelling() == 1`). The window is timing-dependent, not version-semantic: the deterministic regression test wedges on both 3.11 and 3.13; the literal field scenario (timeout then immediate stop, no yield) wedges on 3.13 locally and on 3.11 in the field.

## Fix

Additionally check the worker task's own pending cancel request via `Task.cancelling()` (3.11+): if the worker itself has been asked to cancel, re-raise so teardown proceeds through the existing outer handler.

## Tests

- `test_stop_unblocks_when_caller_cancel_races_teardown` — deterministic interleaving (caller cancel → immediate stop while the worker is still parked on the cancelled execute). Red on 3.11.13 and 3.13.5 before the fix, green after.
- `test_stop_returns_after_send_timeout_without_yield` — the literal field repro shape.
- Both deliberately avoid `asyncio.wait_for(stop(), ...)` for the assertion: on the buggy path wait_for's own timeout-cancel cascades into a second `worker.cancel()` at `queue.get()`, un-wedging the worker and masking the hang. `asyncio.wait` keeps the wedge observable.

## Verification

- `uv run pytest tests/ -q --ignore=tests/integration` — 8668 passed, 0 failed (3.13.5)
- `uv run --python 3.11 --isolated pytest tests/test_commander.py` — 15 passed (3.11.13, field version)
- ruff check/format clean, mypy clean on changed file
- Commit tagged `[full-ci]` for the full 3.11/3.12/3.13 matrix given the version-sensitive timing

🤖 Generated with [Claude Code](https://claude.com/claude-code)