### PR TITLE
feat: managed teardown at disconnect with session-boundary registry reset

### DIFF
--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -712,6 +712,54 @@ class CivRuntime:
         if generation is not None and (token := self._managed_tx_ports.get(generation)):
             self._poison_managed_tx_port(token)
 
+    def reset_managed_tx_generations(self) -> None:
+        """Forget the managed-TX bookkeeping of a finished connect session.
+
+        Four structures here are keyed by *provider generation*: the captured
+        ports, the numbers retirement marked terminal, the in-flight sends, and
+        the transport-close barriers. That key is a counter owned by a
+        ``ManagedRadioRuntime``, and it starts at 1. While one runtime owned a
+        radio for the life of the process the key was effectively unique and
+        keeping entries forever was the safe choice — every mark blocked a
+        stale caller from presenting a retired generation again.
+
+        MOR-1016 ends that: ``CoreRadio.disconnect`` shuts the managed runtime
+        down and drops it, and the next ``connect()`` builds a new one whose
+        first generation is 1 again. Session 1's marks then answer for session
+        2's numbers — ``capture_managed_port`` raises "already captured",
+        ``bind_ptt_observer`` raises "terminal", the arming path swallows both
+        as an arming failure, and the radio refuses TX for the rest of its
+        life. So the bookkeeping has to end with the session that generated it.
+
+        Clearing is safe because presence was never what made a retired port
+        unusable — identity is. Every currency check compares
+        ``_managed_tx_ports.get(generation) is token`` against the *token*, so a
+        port from the finished session fails it whether the slot is empty or
+        refilled by a successor. What clearing has to rule out is a stale
+        caller *capturing* a freed number, and only a runtime can: capture has
+        exactly one caller (``ManagedRadioRuntime.replace_provider``), under
+        that runtime's lifecycle locks, presenting ``_provider_generation`` —
+        a monotonic counter advanced immediately before every capture, so a
+        live runtime never offers a generation twice. The runtime whose
+        session this was cannot capture at all: its ``_shutdown_pending`` fence
+        turns ``replace_provider`` into a NOT_READY no-op, permanently.
+
+        Called by :meth:`~rigplane.runtime.radio.CoreRadio._shutdown_managed_tx`
+        as it drops the runtime — the one moment the counter restarts — and
+        never during a session, where retirement's own marks are load-bearing
+        (a port whose close failed stays registered so the retirement can be
+        retried). A retirement still in flight when this runs cannot undo it:
+        everything it writes here happens before its one ``await``, the
+        transport close, and that close is all it has left to do.
+        """
+        for tasks in self._managed_tx_sends.values():
+            for task in tasks:
+                task.cancel()
+        self._managed_tx_ports.clear()
+        self._poisoned_managed_tx_generations.clear()
+        self._managed_tx_sends.clear()
+        self._managed_tx_retirements.clear()
+
     async def write_managed_ptt(
         self, civ_frame: bytes, provider_generation: int
     ) -> None:

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -360,6 +360,29 @@ _UDP_ERROR_THRESHOLD: int = 3
 # Being wrong here costs supervised TX for one epoch, never the session.
 _MANAGED_TX_PROBE_TIMEOUT_S: float = 0.5
 
+# Deadline for the managed-TX teardown waits (MOR-1016): the shutdown that
+# carries a held lease's OFF out through a still-open CI-V path, and the
+# provider-park that shuts the gate ahead of a soft_disconnect.  Deliberately
+# longer than ``ManagedRadioRuntime``'s own 3 s effect-service bound, which is
+# what the durable OFF and its retries actually run under: an outer wait that
+# expired first would cut the release short rather than bound a wedged one, and
+# the remaining headroom covers ticker cancellation and port retirement.
+_MANAGED_TX_TEARDOWN_TIMEOUT_S: float = 5.0
+
+
+async def _managed_tx_provider_released_by_disconnect() -> None:
+    """``ManagedRadioRuntime.shutdown``'s release hook, deliberately empty.
+
+    The hook exists for an owner whose provider outlives the runtime — a server
+    handing a shared rig back. ``disconnect()`` is the other case: the shutdown
+    has already retired the managed CI-V port by the time this runs, and the
+    session under it is released on the very next line, so there is nothing
+    left here to hand back. Clearing the radio's own managed-TX members is
+    deliberately *not* done here: the shutdown task is shielded, so on the
+    bounded path this may run long after ``disconnect()`` returned.
+    """
+    return None
+
 
 class RawCivSubscription:
     """Handle for a raw CI-V listener registered via ``add_raw_civ_listener``.
@@ -1078,10 +1101,11 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         :class:`~rigplane.core.radio_protocol.ManagedTxCapable`: a real class
         member, never conjured through ``__getattr__``, so
         :meth:`~rigplane.core.radio_protocol.ManagedTxApi.bind`'s
-        ``getattr_static`` read finds it. ``None`` only before the first
-        ``connect()`` — every ingress keeps using the legacy :meth:`set_ptt`
-        path until then. Once :meth:`_arm_managed_tx` has run this answers the
-        radio's own runtime for good, whether or not that arming succeeded:
+        ``getattr_static`` read finds it. ``None`` outside a connect session —
+        before the first ``connect()`` and again after :meth:`disconnect` —
+        where every ingress keeps using the legacy :meth:`set_ptt` path.
+        Within one, from :meth:`_arm_managed_tx` to teardown, this answers that
+        session's runtime for good, whether or not the arming succeeded:
         a rig whose provider never came ready refuses keys with ``NOT_READY``
         rather than reverting to an unsupervised write (MOR-1193).
         """
@@ -1202,8 +1226,16 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         runtime and refuses TX rather than falling back to the unsupervised
         legacy write (MOR-1193). Failures never propagate, so a caller on a
         recovery path can await it without guarding.
+
+        A radio with no CI-V transport is not re-armable at all, and that is
+        what makes a disconnected one inert: :meth:`disconnect` clears the
+        runtime, so a re-arm that ran anyway would *build a second one* and
+        republish ``managed_tx`` on a radio with nothing to bind it to — a
+        supervisor whose port was captured from a closed session, which is a
+        worse answer than the honest ``None``. Only ``connect()`` brings a
+        runtime back.
         """
-        if self._managed_tx_binding_is_live():
+        if self._civ_transport is None or self._managed_tx_binding_is_live():
             return
         async with self._managed_tx_arm_lock:
             # Re-checked under the lock: the holder this caller queued behind
@@ -1229,9 +1261,16 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
 
         Four steps, all of which must land before a key is allowed:
 
-        1. construct the runtime — once per radio, never per connect, so every
-           ingress that already bound a facade keeps pointing at the same
-           supervisor across a reconnect;
+        1. construct the runtime — once per *connect session*, never per arm,
+           so every ingress that already bound a facade keeps pointing at the
+           same supervisor across a reconnect, a re-arm or a soft_disconnect.
+           The session, not the radio, is the bound: :meth:`disconnect` shuts
+           the runtime down and clears it (PR4), and the next ``connect()``
+           builds a new one. A fresh runtime's provider generations start again
+           at 1, which is why teardown also clears the CI-V layer's
+           generation-keyed registry — marks left by the previous session would
+           otherwise read as this one's and fail every arm from here on
+           (:meth:`~rigplane.runtime._civ_rx.CivRuntime.reset_managed_tx_generations`);
         2. prove the rig answers PTT reads at all
            (:meth:`_managed_tx_provider_answers_ptt`) — the guard that keeps a
            failed arm from costing the CI-V session;
@@ -1305,6 +1344,93 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         except Exception:
             logger.debug(
                 "managed TX degrade-to-not-ready failed for %s",
+                runtime.target_id,
+                exc_info=True,
+            )
+
+    async def _shutdown_managed_tx(self) -> None:
+        """Stop supervised TX while the CI-V path can still carry the OFF.
+
+        Ordered ahead of the session teardown in :meth:`disconnect` for the one
+        reason that matters: ``shutdown`` emergency-releases a held lease, and
+        a WRITE_OFF issued after the transport is gone is a rig left keyed with
+        nobody watching it. Bounded for the mirror-image reason — a supervisor
+        wedged on a rig that stopped answering must not hold ``disconnect()``
+        open, since closing the socket is itself the de-key of last resort.
+        The runtime shields its own shutdown task, so the bound abandons the
+        wait rather than the release: the OFF keeps trying behind us.
+
+        Clearing the three managed-TX members afterwards is the other half of
+        the MOR-1193 invariant, not a weakening of it. "Managed-eligible means
+        ``managed_tx`` is never ``None``" holds *from connect to disconnect*;
+        past disconnect there is no session to supervise, and the next
+        ``connect()`` arms a fresh runtime. Keeping this one published would
+        advertise a supervisor over a closed port — and leave the re-arm path
+        able to rebuild a binding for a rig that is gone.
+
+        Dropping the runtime is also what restarts its provider-generation
+        counter, which the CI-V layer uses as a registry key — so the session's
+        entries there have to go with it, or session 2's generation 1 collides
+        with session 1's and every arm from here on fails
+        (:meth:`~rigplane.runtime._civ_rx.CivRuntime.reset_managed_tx_generations`).
+        Ordered inside the ``finally`` with the members it belongs to, so a
+        shutdown that timed out or raised still leaves a connectable radio.
+        """
+        runtime = self._managed_tx_runtime
+        if runtime is None:
+            return
+        try:
+            await asyncio.wait_for(
+                runtime.shutdown(
+                    release_provider=_managed_tx_provider_released_by_disconnect
+                ),
+                timeout=_MANAGED_TX_TEARDOWN_TIMEOUT_S,
+            )
+        except asyncio.TimeoutError:
+            logger.error(
+                "managed TX shutdown for %s did not settle within %.1fs; "
+                "disconnecting anyway — the rig may still be keyed",
+                runtime.target_id,
+                _MANAGED_TX_TEARDOWN_TIMEOUT_S,
+            )
+        except Exception:
+            logger.error(
+                "managed TX shutdown for %s failed; disconnecting anyway",
+                runtime.target_id,
+                exc_info=True,
+            )
+        finally:
+            self._managed_tx_runtime = None
+            self._managed_tx_bound_port = None
+            self._managed_tx_armed_epoch = None
+            self._civ_runtime.reset_managed_tx_generations()
+
+    async def _park_managed_tx(self) -> None:
+        """Refuse keys for the length of a CI-V gap, without unpublishing.
+
+        ``soft_disconnect`` takes the data path down and expects it back, so
+        the runtime outlives it — but in between, a lease granted on the
+        strength of a provider still marked ready would have its WRITE_ON land
+        on a socket that is already closing, which is a key the supervisor
+        believes in and the rig never saw. Marking the provider not-ready first
+        makes ``request_on`` answer ``NOT_READY`` for the length of the gap,
+        and turns a lease held across it into the release that
+        :meth:`rearm_managed_tx` services against the repaired port.
+
+        Bounded and fail-soft: a gate that will not shut is not a reason to
+        refuse to tear down the path it guards.
+        """
+        runtime = self._managed_tx_runtime
+        if runtime is None:
+            return
+        try:
+            await asyncio.wait_for(
+                runtime.set_provider_ready(ready=False),
+                timeout=_MANAGED_TX_TEARDOWN_TIMEOUT_S,
+            )
+        except Exception:
+            logger.warning(
+                "managed TX did not park for %s ahead of soft_disconnect",
                 runtime.target_id,
                 exc_info=True,
             )
@@ -1530,7 +1656,13 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         the lifecycle therefore treated disconnect() as an idempotent no-op —
         fall back to the control-phase graceful teardown so a genuinely live
         session is always released (graceful-close invariant).
+
+        Managed TX is shut down first (MOR-1016), bounded, because the OFF a
+        held lease owes the rig has to go out over a transport that is still
+        open — see :meth:`_shutdown_managed_tx`, which is also where the radio
+        stops being managed until the next ``connect()``.
         """
+        await self._shutdown_managed_tx()
         await self._session_lifecycle.disconnect()
         if self._conn_state == RadioConnectionState.CONNECTED:
             await self._control_phase.disconnect()
@@ -1540,9 +1672,15 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
 
         This allows fast reconnect without re-authentication — the radio
         keeps the session open on the control port.
+
+        Managed TX is parked, not shut down (MOR-1016): the runtime survives
+        the gap and is re-armed against the repaired port, so the only thing
+        that changes here is that it stops accepting keys — see
+        :meth:`_park_managed_tx`.
         """
         if self._conn_state != RadioConnectionState.CONNECTED:
             return
+        await self._park_managed_tx()
         self._conn_state = RadioConnectionState.DISCONNECTING
         self._civ_runtime.advance_generation("soft_disconnect")
 

--- a/tests/test_managed_tx_assembly.py
+++ b/tests/test_managed_tx_assembly.py
@@ -31,7 +31,9 @@ real effect service.
 
 from __future__ import annotations
 
+import asyncio
 import inspect
+import logging
 from collections.abc import Iterator
 
 import pytest
@@ -179,24 +181,55 @@ def test_unconnected_radio_publishes_no_tx_snapshot() -> None:
 # ===========================================================================
 
 
+class _CivPort:
+    """A CI-V data transport stand-in; its identity is all the radio reads.
+
+    ``soft_disconnect`` is the one path that calls a method on it, so the close
+    is real (and idempotent) rather than an attribute error swallowed by the
+    teardown's ``except``.
+    """
+
+    def __init__(self) -> None:
+        self.closed = False
+
+    async def disconnect(self) -> None:
+        self.closed = True
+
+
 class _Session:
-    """The session lifecycle reduced to what ``connect()`` observes.
+    """The session lifecycle reduced to what connect/disconnect observe.
 
     A real ``CoreRadioSessionLifecycle`` wants a rig on the other end of a
     socket. All ``_arm_managed_tx`` needs from it is the state a completed
     control phase leaves behind: a negotiated CI-V data port and a fresh CI-V
     epoch (the same ``_advance_civ_generation`` the real path calls).
+
+    ``disconnect()`` is the mirror, and the reason it logs into the provider's
+    log rather than one of its own: PR4's claim is an *ordering* one — the
+    durable OFF against the closing of the session that carries it — and one
+    list is the only way to state it. It keys off its own connected flag, not
+    the transport, because by the time it runs the managed shutdown has
+    already retired that port; the session close is what is left, and it is a
+    no-op on a radio that never connected (as the real lifecycle's is).
     """
 
     def __init__(self, radio: CoreRadio) -> None:
-        self._radio, self.connects = radio, 0
+        self._radio, self.connects, self.closes = radio, 0, 0
 
     async def connect(self) -> None:
         self.connects += 1
         self._radio._civ_port = 50002
-        self._radio._civ_transport = object()  # type: ignore[assignment]
+        self._radio._civ_transport = _CivPort()  # type: ignore[assignment]
         self._radio._advance_civ_generation("test-connect")
         self._radio._connected = True
+
+    async def disconnect(self) -> None:
+        if not self._radio._connected:
+            return
+        self.closes += 1
+        self._radio.provider.log.append("session_close")  # type: ignore[attr-defined]
+        self._radio._civ_transport = None
+        self._radio._connected = False
 
 
 class _AssembledRadio(CoreRadio):
@@ -504,3 +537,290 @@ async def test_two_radios_get_two_independent_supervisors() -> None:
 
     assert one is not None and two is not None
     assert one.supervisor is not two.supervisor
+
+
+# ===========================================================================
+# PR4 -- teardown: the OFF goes out before the path does
+# ===========================================================================
+#
+# ``disconnect()`` is the first production caller of ``shutdown``, which makes
+# two things true here for the first time: a held lease is emergency-released
+# on the way out, and the radio stops being managed. The order of the first
+# against the session close is the whole point -- a WRITE_OFF issued after the
+# transport is gone is a rig left keyed -- and the second is bounded, because a
+# supervisor wedged on a rig that stopped answering must not be able to hold
+# the socket close (the de-key of last resort) open behind it.
+#
+# ``soft_disconnect`` is the deliberate asymmetry: the path is coming back, so
+# the runtime is parked rather than shut down.
+
+
+async def test_a_keyed_rig_gets_its_off_before_the_session_closes() -> None:
+    # The ordering claim, on one log: the durable OFF and the close of the
+    # session that carries it. Reversed, the write goes out over a transport
+    # that is already gone and the rig stays keyed with nobody supervising it
+    # -- and disconnect() is precisely when nobody is left to notice.
+    radio = await _connected()
+    api = ManagedTxApi.bind(radio, _OWNER)
+    assert api is not None
+    assert (await api.set_ptt(True)).outcome is TxOutcome.ACCEPTED
+    log = radio.provider.log
+
+    await radio.disconnect()
+
+    assert "ptt(off)" in log
+    assert log.index("ptt(off)") < log.index("session_close")
+    # Not merely written: the confirming read settled it, so the rig is
+    # observably unkeyed rather than optimistically assumed to be.
+    assert radio.provider._keyed is False
+    assert radio._session_lifecycle.closes == 1  # type: ignore[attr-defined]
+
+
+async def test_a_wedged_supervisor_cannot_hold_disconnect_open(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # The bound is the whole reason the shutdown may go first at all. A rig
+    # that stopped answering mid-release is exactly the case where the release
+    # cannot complete *and* the socket close is the only de-key left, so the
+    # wait has to be abandonable. ``shutdown`` shields its own task, so what is
+    # abandoned is this wait, not the OFF: it keeps retrying behind us.
+    #
+    # Over the real port registry (defined below), because a shutdown that
+    # never ran also never retired its port: teardown has to release the
+    # session's CI-V bookkeeping on this path too, or a wedged supervisor
+    # leaves behind a radio that can never arm again.
+    radio = await _connected_over_the_real_registry()
+    runtime = radio._managed_tx_runtime
+    assert runtime is not None
+    monkeypatch.setattr(radio_module, "_MANAGED_TX_TEARDOWN_TIMEOUT_S", 0.05)
+    wedged = asyncio.Event()
+
+    async def _never_settles(*, release_provider: object) -> None:
+        await wedged.wait()  # a supervisor that never comes back
+
+    runtime.shutdown = _never_settles  # type: ignore[method-assign]
+
+    with caplog.at_level(logging.ERROR, logger="rigplane.runtime.radio"):
+        # The outer bound is the test's own tripwire: without the inner one
+        # this call never returns at all.
+        await asyncio.wait_for(radio.disconnect(), timeout=2.0)
+
+    assert radio._session_lifecycle.closes == 1  # type: ignore[attr-defined]
+    assert radio.managed_tx is None  # and the radio is unmanaged either way
+    assert any(
+        "managed TX shutdown" in record.getMessage() for record in caplog.records
+    )
+
+    # And the radio is still reconnectable: a wedged supervisor costs this
+    # session's supervision, not every session after it.
+    await radio.connect()
+
+    snapshot = radio.tx_snapshot
+    assert snapshot is not None
+    assert (snapshot.provider_ready, snapshot.radio_tx) == (True, RadioTx.OFF)
+
+
+async def test_soft_disconnect_parks_the_provider_and_recovery_re_arms_it() -> None:
+    # The asymmetry with disconnect(): the CI-V path is coming back, so the
+    # runtime stays published and every facade bound to it stays valid. What
+    # changes is that the gap refuses keys instead of accepting a lease whose
+    # WRITE_ON would land on a socket that is already closing -- a key the
+    # supervisor believes in and the rig never saw.
+    radio = await _connected()
+    runtime = radio._managed_tx_runtime
+    api = ManagedTxApi.bind(radio, _OWNER)
+    assert api is not None
+    bound_before = radio._managed_tx_bound_port
+
+    await radio.soft_disconnect()
+
+    assert radio.managed_tx is runtime  # parked, never unpublished
+    transition = await api.set_ptt(True)
+    assert transition.outcome is TxOutcome.NOT_READY
+    assert transition.snapshot.lease_id is None
+    assert "ptt(on)" not in radio.provider.log
+
+    # What ``soft_reconnect`` then does: a rebuilt CI-V port on a fresh
+    # generation, and the re-arm it drives before any consumer's recovery (that
+    # call's ordering is pinned in ``test_web_recovery_durable_off``).
+    radio._civ_transport = _CivPort()  # type: ignore[assignment]
+    radio._advance_civ_generation("soft_reconnect")
+    await radio.rearm_managed_tx()
+
+    assert radio._managed_tx_bound_port != bound_before  # the binding moved
+    assert (await api.set_ptt(True)).outcome is TxOutcome.ACCEPTED
+    assert radio.provider.log.count("ptt(on)") == 1
+
+    await api.set_ptt(False)
+
+
+async def test_disconnect_unpublishes_and_a_new_connect_arms_a_new_runtime() -> None:
+    # The MOR-1193 invariant is bounded by the session, not by the process:
+    # "managed-eligible means never ``None``" holds from connect to disconnect,
+    # and past disconnect there is no session to supervise. Keeping the runtime
+    # would advertise a supervisor over a closed port -- and the next connect()
+    # would arm a rig through a provider bound to the previous one.
+    radio = await _connected()
+    first = radio.managed_tx
+    assert first is not None
+
+    await radio.disconnect()
+
+    assert radio.managed_tx is None
+    assert radio.tx_snapshot is None
+    assert radio._managed_tx_bound_port is None
+    assert radio._managed_tx_armed_epoch is None
+
+    await radio.connect()
+
+    second = radio.managed_tx
+    assert second is not None
+    assert second is not first  # identity: a new session gets a new supervisor
+    snapshot = radio.tx_snapshot
+    assert snapshot is not None
+    assert (snapshot.provider_ready, snapshot.radio_tx) == (True, RadioTx.OFF)
+
+
+async def test_re_arming_a_disconnected_radio_does_nothing_at_all() -> None:
+    # A reconnect callback that fires after teardown, or a consumer holding the
+    # radio past its session. Re-arm must not resurrect managed TX here: the
+    # arming path builds a runtime when it finds none, so an unguarded re-arm
+    # would publish a supervisor whose port was captured from a closed session
+    # -- live-but-unusable, and worse than the honest ``None``.
+    radio = await _connected()
+    await radio.disconnect()
+    log_before = list(radio.provider.log)
+
+    await radio.rearm_managed_tx()
+
+    assert radio.managed_tx is None
+    assert radio._managed_tx_bound_port is None
+    assert radio.provider.log == log_before  # no capture, no seed
+    assert len(radio.probes) == 1  # and no second arming probe
+
+
+async def test_a_facade_bound_before_disconnect_refuses_keys_after_it() -> None:
+    # The other half of the same question, asked from the ingress side: a
+    # binding taken while the radio was managed outlives the session it was
+    # taken in. It must fail closed -- refused, with nothing on the wire --
+    # rather than key a rig through a supervisor whose port is gone.
+    radio = await _connected()
+    api = ManagedTxApi.bind(radio, _OWNER)
+    assert api is not None
+
+    await radio.disconnect()
+    transition = await api.set_ptt(True)
+
+    assert transition.outcome is not TxOutcome.ACCEPTED
+    assert transition.snapshot.lease_id is None
+    assert "ptt(on)" not in radio.provider.log
+
+
+async def test_disconnecting_an_unmanaged_radio_touches_no_managed_state() -> None:
+    # The unmanaged path is unchanged: a radio that never connected has no
+    # runtime, so teardown does exactly what it did before MOR-1016 -- no
+    # shutdown, no wait, no wire traffic.
+    radio = _AssembledRadio(_Provider([]))
+    _LIVE.append(radio)
+    assert radio.managed_tx is None
+
+    await radio.disconnect()
+
+    assert radio.managed_tx is None
+    assert radio._managed_tx_bound_port is None
+    assert radio.provider.log == []
+    assert radio._session_lifecycle.closes == 0  # type: ignore[attr-defined]
+
+
+class _RegistryRadio(_AssembledRadio):
+    """An assembled radio whose port capture/retirement is the *real* one.
+
+    ``_AssembledRadio`` answers ``_capture_managed_tx_port`` with a bare
+    ``True``, which is right for the arming cases it pins and blind to the one
+    thing PR4 changed underneath it: ``CivRuntime`` keeps a registry of managed
+    ports **keyed by provider generation**, and a runtime's generation counter
+    starts at 1. Clearing the runtime at disconnect means the next session's
+    first generation is 1 again -- straight into whatever session 1 left in
+    that registry. Only the real hooks can show it, so these three are put back
+    (the write and the authoritative read stay on the provider double: they are
+    the CI-V wire, which ``tests/test_civ_rx_coverage.py`` owns).
+    """
+
+    _capture_managed_tx_port = CoreRadio._capture_managed_tx_port
+    _retire_managed_tx_port = CoreRadio._retire_managed_tx_port
+    _unbind_authoritative_ptt_observer = CoreRadio._unbind_authoritative_ptt_observer
+
+
+async def _connected_over_the_real_registry() -> _RegistryRadio:
+    radio = _RegistryRadio(_Provider([]))
+    _LIVE.append(radio)
+    await radio.connect()
+    return radio
+
+
+async def test_a_second_session_arms_over_the_real_civ_port_registry() -> None:
+    # The regression that clearing the runtime at disconnect introduces if the
+    # CI-V registry outlives it: session 2's runtime presents generation 1,
+    # session 1's entry for generation 1 is still there, ``capture_managed_port``
+    # raises "already captured", ``_run_managed_tx_arm`` swallows it as an
+    # arming failure -- and the radio is provider-not-ready for the rest of its
+    # life. Production-reachable with one radio object and a disconnect/connect
+    # cycle (the Web API exposes exactly that pair).
+    radio = await _connected_over_the_real_registry()
+    first = radio.managed_tx
+    assert first is not None
+    assert radio.tx_snapshot is not None and radio.tx_snapshot.provider_ready
+
+    await radio.disconnect()
+    await radio.connect()
+
+    second = radio.managed_tx
+    assert second is not None
+    assert second is not first
+    snapshot = radio.tx_snapshot
+    assert snapshot is not None
+    assert (snapshot.provider_ready, snapshot.radio_tx) == (True, RadioTx.OFF)
+
+    # Armed is not the claim; keyable is. A second session that cannot key is
+    # the same outage as one that never armed.
+    api = ManagedTxApi.bind(radio, _OWNER)
+    assert api is not None
+    assert (await api.set_ptt(True)).outcome is TxOutcome.ACCEPTED
+
+    await api.set_ptt(False)
+
+
+async def test_a_finished_session_leaves_no_managed_tx_generations_behind() -> None:
+    # The contract underneath the case above. Four CI-V structures are keyed by
+    # provider generation, and that key is a per-runtime counter that restarts
+    # at 1 -- so all four have to end with the session that generated them, not
+    # just the port token: the terminal marker ``bind_ptt_observer`` refuses on
+    # would fail session 2's bind, and a completed retirement barrier would be
+    # read as session 2's transport already closing and skip that close.
+    #
+    # Within a session these marks stay load-bearing (a port whose close failed
+    # is deliberately left registered so the retirement can be retried, which
+    # ``test_radio.py::TestPtt::test_managed_ptt_port_token_safety`` pins) --
+    # teardown is the only point where the counter restarts.
+    radio = await _connected_over_the_real_registry()
+    civ = radio._civ_runtime
+    assert list(civ._managed_tx_ports) == [1]
+
+    await radio.disconnect()
+
+    assert civ._managed_tx_ports == {}
+    assert civ._poisoned_managed_tx_generations == set()
+    assert civ._managed_tx_sends == {}
+    assert civ._managed_tx_retirements == {}
+
+
+async def test_an_unmanaged_radio_disconnects_through_the_real_lifecycle() -> None:
+    # And the same over the production wiring rather than the double: the
+    # real ``CoreRadioSessionLifecycle`` still treats teardown on an unclaimed
+    # radio as the idempotent no-op it always was.
+    radio = _unconnected_radio()
+
+    await radio.disconnect()
+
+    assert radio.managed_tx is None
+    assert not radio.connected


### PR DESCRIPTION
MOR-1016 PR 4 of 8 — the first production release_provider caller. Bounded managed shutdown before the session closes; soft_disconnect parks the provider; session-boundary reset of the CI-V registry's four generation-keyed structures (without it, disconnect→connect kills managed TX forever — found by review through the real hooks — and a stale retirement barrier leaks the next session's socket, proven by a three-session counterfactual).

Verified independently through a BLOCKED→remediation round: the reviewer's own recommended fix was counterfactually disproven (two more never-cleared structures), the eviction-at-retire alternative shown to break two pinned contracts; 7 mutations killed; full suite green incl. the real-registry regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)