### PR TITLE
feat: add the shared managed-TX ingress gate and refuse ownerless web keys

### DIFF
--- a/src/rigplane/runtime/managed_tx_ingress.py
+++ b/src/rigplane/runtime/managed_tx_ingress.py
@@ -1,0 +1,119 @@
+"""The managed-TX ingress gate: which ingress may key a managed radio.
+
+One question, asked identically by every ingress: does this request carry an
+identity the supervisor can hold a lease against? Web asks it here, rigctld
+(MOR-1014) and the CLI/SDK (MOR-1190) will ask the same helpers rather than
+grow a third copy of the two-step supervisor read — the duplication MOR-1198
+exists to remove, and the one three call sites already got wrong in three
+different ways (MOR-1187, MOR-1193, MOR-1196).
+
+It lives in ``runtime`` because ``runtime`` sits below ``backends`` and below
+both UI servers, so every one of those callers can reach it while it reaches
+nothing but ``core``. Putting it in ``web`` would have made rigctld's copy the
+third one.
+
+**The gate is deliberately one-sided: it NEVER refuses an unkey.** Refusing a
+key costs an operator one denied transmission, which is recoverable and
+visible. Refusing an unkey leaves a transmitter on the air that nobody can take
+off — the same asymmetry ``_refuse_key_from_gone_session`` is built on. Nothing
+here is consulted from an unkey path, and nothing here should ever be.
+"""
+
+from __future__ import annotations
+
+from inspect import getattr_static
+from typing import cast
+
+from rigplane.core.radio_protocol import (
+    ManagedTxApi,
+    ManagedTxCapable,
+    ManagedTxSupervisor,
+)
+from rigplane.core.state_pipeline_contracts import CommandSource
+from rigplane.core.tx_safety import TxOwner, TxSource
+
+__all__ = ["bind_managed_tx", "refuse_key_without_owner", "resolve_supervisor"]
+
+
+def resolve_supervisor(radio: object) -> ManagedTxSupervisor | None:
+    """Read ``radio``'s managed TX supervisor; ``None`` when it is unmanaged.
+
+    The owner-free half of :meth:`ManagedTxApi.bind`, for callers asking only
+    *whether* a radio is managed — and the canonical copy of that two-step read
+    (MOR-1198).
+
+    Both steps carry their own discipline. ``getattr_static`` settles absence
+    without running the accessor, so the single explicit read below is the only
+    backend code this touches, and **its failures propagate**: a raising
+    ``managed_tx`` is a broken accessor, not a positive finding of "unmanaged".
+    Collapsing the pair into ``getattr(radio, "managed_tx", None)`` is the bug
+    :class:`ManagedTxCapable` documents — the default absorbs an
+    ``AttributeError`` raised *inside* the property and hands a managed rig to
+    the unsupervised legacy write. ``isinstance`` cannot draw the line either:
+    3.11 probes a non-callable protocol member with ``hasattr`` (gh-102433).
+
+    ``None`` at either step — no such member, or a backend publishing one that
+    holds ``None`` — is a positive determination that the radio is unmanaged.
+    """
+    if getattr_static(radio, "managed_tx", None) is None:
+        return None  # no such member, or a backend that publishes none
+    return cast(ManagedTxCapable, radio).managed_tx
+
+
+def _stable_owner(source: CommandSource, session_id: str | None) -> TxOwner | None:
+    """The ingress identity a lease can be held against, or ``None``.
+
+    Only a websocket control session has one: its long-lived
+    ``ControlHandler._session_id``, not the throwaway the shared executor mints
+    per request, which owner-matched ``release_owner`` would miss — stranding
+    the rig keyed. Every other ingress (HTTP params may even carry a
+    ``session_id``) has no teardown hook, so its lease would be unreleasable.
+    """
+    if source != "websocket" or not session_id:
+        return None
+    return TxOwner(TxSource.WEBSOCKET, session_id)
+
+
+def bind_managed_tx(
+    radio: object, source: CommandSource, session_id: str | None
+) -> ManagedTxApi | None:
+    """Bind this ingress's managed TX facade; ``None`` if it cannot hold one.
+
+    ``None`` covers two different findings that the caller must not conflate:
+    an ingress with no stable owner (checked first, so the common path runs no
+    backend code at all), and an unmanaged radio. On a managed rig the first is
+    exactly the case :func:`refuse_key_without_owner` answers, because falling
+    through to the raw ``set_ptt`` write there would key a managed rig with no
+    lease, no owner and no watchdog.
+    """
+    owner = _stable_owner(source, session_id)
+    if owner is None:
+        return None
+    return ManagedTxApi.bind(radio, owner)
+
+
+def refuse_key_without_owner(
+    radio: object, source: CommandSource, session_id: str | None
+) -> bool:
+    """Must this ingress be refused the KEY? Never asked about an unkey.
+
+    ``True`` only where both halves hold: the radio publishes a supervisor, and
+    the request carries no identity that supervisor could release later. Either
+    half alone is not a refusal — an owned ingress keys through the supervisor,
+    and an unmanaged rig keeps the legacy write every shipped backend still
+    uses.
+
+    The owner test comes first so a managed websocket key never pays for the
+    supervisor read, and a broken accessor cannot turn a perfectly keyable
+    session into an error. When the read does happen it happens under
+    :func:`resolve_supervisor`'s discipline: a failure propagates rather than
+    reading as "unmanaged", so a broken backend denies the key instead of
+    silently granting an unsupervised one.
+
+    Callers must ask this only on the key path. An unkey refused for lacking an
+    owner strands a keyed transmitter, which is strictly worse than the
+    unsupervised de-key it would be preventing.
+    """
+    if _stable_owner(source, session_id) is not None:
+        return False
+    return resolve_supervisor(radio) is not None

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -89,9 +89,10 @@ from ..core.state_pipeline_contracts import (
 from ..core.radio_protocol import ManagedTxApi
 from ..core.state_diagnostics import StateDiagnosticsRecorder
 from ..core.state_store import StateStore
-from ..core.tx_safety import TxOutcome, TxOwner, TxSource
+from ..core.tx_safety import TxOutcome
 from .._state_queries import build_state_queries
 from ..profiles import RadioProfile, resolve_radio_profile
+from ..runtime.managed_tx_ingress import bind_managed_tx, refuse_key_without_owner
 from ..types import AudioCodec
 
 if TYPE_CHECKING:
@@ -1177,15 +1178,14 @@ class RadioPoller:
     ) -> ManagedTxApi | None:
         """Bind this control session's managed TX facade; ``None`` if unmanaged.
 
-        Only a websocket session has a STABLE owner identity: its long-lived
-        ``ControlHandler._session_id``, not the throwaway the shared executor
-        mints per request, which owner-matched ``release_owner`` would miss —
-        stranding the rig keyed. Every other ingress (HTTP params may even
-        carry a ``session_id``) has no teardown hook: its lease is unreleasable.
+        The rule it applies — only a websocket session carries an owner identity
+        stable enough to release the lease it takes — now lives in
+        ``runtime.managed_tx_ingress`` with the rest of the gate, because
+        rigctld (MOR-1014) and the CLI/SDK (MOR-1190) must apply the same one
+        and the two-step supervisor read behind it belongs in exactly one place
+        (MOR-1198).
         """
-        if source != "websocket" or not session_id:
-            return None
-        return ManagedTxApi.bind(self._radio, TxOwner(TxSource.WEBSOCKET, session_id))
+        return bind_managed_tx(self._radio, source, session_id)
 
     def _refuse_key_from_gone_session(
         self, source: CommandSource, session_id: str | None
@@ -1433,6 +1433,32 @@ class RadioPoller:
                     except Exception as e:
                         logger.warning("poller: start TX audio failed: %s", e)
                 if managed is None:
+                    # Binding nothing is two findings, and only one may reach
+                    # the raw write: an unmanaged rig (every shipped backend,
+                    # unchanged), or an ingress with no owner a lease could be
+                    # released against — which on a managed rig would key with
+                    # no lease, no owner and no watchdog, the unsupervised
+                    # bypass management exists to close. Resolving a supervisor
+                    # is backend code that can fail (MOR-1187) and runs with the
+                    # TX audio leg above already armed, so refusal and failed
+                    # resolution alike disarm it on the way out, mirroring the
+                    # managed refusal below: a refused key leaves no trace on
+                    # the air.
+                    try:
+                        if refuse_key_without_owner(radio, command_source, session_id):
+                            logger.warning(
+                                "poller: refusing PTT ON from %s ingress: this "
+                                "radio is managed and the request carries no "
+                                "releasable owner",
+                                command_source,
+                            )
+                            raise CommandError(
+                                f"managed TX refused PTT ON from {command_source}: "
+                                "no owner identity to hold the lease"
+                            )
+                    except BaseException:
+                        await self._stop_tx_audio_leg()
+                        raise
                     await radio.set_ptt(True)
                 else:
                     transition = await managed.set_ptt(True)
@@ -1462,6 +1488,12 @@ class RadioPoller:
                 try:
                     managed = self._managed_tx(command_source, session_id)
                     if managed is None:
+                        # No owner gate here, and there must never be one: the
+                        # key arm above refuses an ownerless ingress, but an
+                        # unkey refused for the same reason strands a keyed
+                        # transmitter with nobody able to take it off the air
+                        # (the ``_refuse_key_from_gone_session`` asymmetry).
+                        # Ownerless de-keys keep the unconditional legacy write.
                         await radio.set_ptt(False)
                     else:
                         # A refused release answers STALE: nothing was keyed, or

--- a/tests/test_web_managed_tx_owner.py
+++ b/tests/test_web_managed_tx_owner.py
@@ -22,12 +22,22 @@ MOR-1185 closes the last hole in the pair: the teardown unkey went onto the RAW
 queue, so it reached the drain owner-less and de-keyed the rig without ever
 giving the lease back. Routed through the metadata wrapper it releases what it
 took — and, deliberately, drops the unconditional write it used to make.
+
+MOR-1016 PR 5 turns the owner gate into an ingress gate. Until assembly there
+was no managed backend, so "binds no owner" could keep falling through to the
+raw ``set_ptt`` write; once a rig publishes a supervisor that fallthrough is an
+unsupervised key on a managed rig. The gate lives in
+``rigplane.runtime.managed_tx_ingress`` — below the poller, so rigctld
+(MOR-1014) and the CLI/SDK (MOR-1190) reuse it instead of growing a third copy
+of the same two-step read (MOR-1198) — and it is deliberately one-sided: keys
+are refusable, unkeys never are.
 """
 
 from __future__ import annotations
 
 import asyncio
 import time
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -35,7 +45,7 @@ import pytest
 
 from rigplane.core.capabilities import CAP_AUDIO
 from rigplane.core.exceptions import CommandError
-from rigplane.core.radio_protocol import ManagedTxApi
+from rigplane.core.radio_protocol import ManagedTxApi, PrivilegedTxApi
 from rigplane.core.tx_safety import (
     ProviderAttemptKind,
     ProviderPttObservation,
@@ -48,6 +58,13 @@ from rigplane.core.tx_safety import (
     TxTransition,
 )
 from rigplane.profiles import resolve_radio_profile
+from rigplane.runtime import managed_tx_ingress
+from rigplane.runtime.managed_tx_ingress import (
+    bind_managed_tx,
+    refuse_key_without_owner,
+    resolve_supervisor,
+)
+from rigplane.web import radio_poller as radio_poller_module
 from rigplane.web.handlers.control import ControlHandler
 from rigplane.web.radio_poller import CommandQueue, PttOff, PttOn, RadioPoller
 
@@ -307,18 +324,83 @@ async def test_a_websocket_unkey_without_a_session_id_stays_unmanaged() -> None:
     assert radio.calls == ["set_ptt(False)", *_TEARDOWN]
 
 
-async def test_http_ingress_never_binds_an_owner() -> None:
+async def test_http_ingress_never_binds_an_owner_and_is_refused_the_key() -> None:
     """HTTP has no session and no teardown hook, so a lease taken there could
-    never be released — and its params are caller-supplied, not a session."""
+    never be released — and its params are caller-supplied, not a session.
+
+    MOR-1016 PR 5 draws the consequence the bind alone could not: on a MANAGED
+    rig, "binds no owner" used to mean "falls through to the raw
+    ``set_ptt(True)``" — an unsupervised key with no lease, no owner and no
+    watchdog behind it, which is the bypass management exists to close. So an
+    ingress that cannot hold a lease is refused the key outright, and the
+    supervisor never hears about it.
+    """
     supervisor = _Supervisor()
     poller, radio = _poller(supervisor)
 
-    await poller._execute(PttOn(), source="http", session_id=None)
-    await poller._execute(PttOn(), source="http", session_id="forged")
+    with pytest.raises(CommandError, match="no owner"):
+        await poller._execute(PttOn(), source="http", session_id=None)
+    # A caller-supplied ``session_id`` is not a session: same refusal.
+    with pytest.raises(CommandError, match="http"):
+        await poller._execute(PttOn(), source="http", session_id="forged")
+
+    # No lease attempt, and above all no provider write: the refusal leaves no
+    # trace on the air, and each armed TX audio leg is disarmed behind it.
+    assert supervisor.entries == []
+    assert "set_ptt(True)" not in radio.calls
+    assert radio.calls == ["start_tx", *_TEARDOWN, "start_tx", *_TEARDOWN]
+
+
+async def test_an_http_unkey_on_a_managed_rig_still_writes_the_legacy_off() -> None:
+    """The asymmetry, stated: a refused unkey strands a keyed transmitter.
+
+    The key gate above and this are deliberately not symmetric — the same
+    doctrine ``_refuse_key_from_gone_session`` is built on. Refusing a key costs
+    an operator one denied transmission; refusing an unkey leaves the rig on the
+    air with nobody able to take it off. So the ``PttOff`` arm keeps the
+    unconditional legacy write for every ingress that binds no owner, managed
+    rig or not.
+    """
+    supervisor = _Supervisor()
+    poller, radio = _poller(supervisor)
+
     await poller._execute(PttOff(), source="http", session_id=None)
 
     assert supervisor.entries == []
-    assert radio.calls == [*_KEY, *_KEY, "set_ptt(False)", *_TEARDOWN]
+    assert radio.calls == ["set_ptt(False)", *_TEARDOWN]
+
+
+async def test_an_unmanaged_rig_keeps_the_legacy_http_path_on_both_arms() -> None:
+    """Every shipped backend is still unmanaged, so HTTP PTT is untouched.
+
+    The gate asks the radio, not the request: with no supervisor published there
+    is nothing to be refused on behalf of, and refusing here would break HTTP
+    PTT for every rig in the field.
+    """
+    poller, radio = _poller(None)
+
+    await poller._execute(PttOn(), source="http", session_id=None)
+    await poller._execute(PttOff(), source="http", session_id=None)
+
+    assert radio.calls == [*_KEY, "set_ptt(False)", *_TEARDOWN]
+
+
+async def test_a_raising_accessor_on_the_key_path_disarms_the_tx_leg_too() -> None:
+    """The gate resolves a supervisor, so it runs backend code that can fail.
+
+    MOR-1187's lesson applied to the other arm: the resolution happens with the
+    TX audio leg already armed, so it belongs inside the guard that disarms it.
+    A failed resolution is not "unmanaged" — it propagates — but it must not
+    leave modulation flowing towards a rig this ingress never keyed.
+    """
+    radio = _BrokenSupervisorRadio(None)
+    poller = RadioPoller(radio, CommandQueue())  # type: ignore[arg-type]
+
+    with pytest.raises(RuntimeError, match="accessor exploded"):
+        await poller._execute(PttOn(), source="http", session_id=None)
+
+    assert "set_ptt(True)" not in radio.calls
+    assert radio.calls == ["start_tx", *_TEARDOWN]
 
 
 async def test_a_key_from_a_gone_session_costs_nothing() -> None:
@@ -521,3 +603,99 @@ async def test_an_unmanaged_teardown_still_writes_the_unconditional_unkey() -> N
     await _drain(poller)
 
     assert radio.calls == ["set_ptt(False)", *_TEARDOWN]
+
+
+# --- the ingress gate itself (rigplane.runtime.managed_tx_ingress) ----------
+
+
+def test_resolve_supervisor_propagates_a_raising_accessor() -> None:
+    """A broken accessor is a broken backend, never a positive 'unmanaged'.
+
+    This is the whole reason the two-step read exists rather than
+    ``getattr(radio, "managed_tx", None)``, whose default absorbs an
+    ``AttributeError`` raised *inside* the property and hands a managed rig to
+    the unsupervised write (MOR-1187, MOR-1193, MOR-1196).
+    """
+    with pytest.raises(RuntimeError, match="accessor exploded"):
+        resolve_supervisor(_BrokenSupervisorRadio(None))
+
+
+def test_resolve_supervisor_reads_absence_and_a_published_none_as_unmanaged() -> None:
+    """Both unmanaged shapes: no such member, and a member holding ``None``."""
+    assert resolve_supervisor(object()) is None
+    assert resolve_supervisor(_Radio(None)) is None
+
+
+def test_resolve_supervisor_answers_a_supervisor_with_no_privileged_surface() -> None:
+    """``ManagedTxSupervisor`` is the guaranteed minimum, and it is enough.
+
+    ``_Supervisor`` publishes ``request_on``/``release_owner`` and nothing else,
+    so ``PrivilegedTxApi`` correctly declines it. The gate must not: requiring
+    ``force_unkey`` here would read a conformant managed backend as unmanaged
+    and reopen the very fallthrough this gate closes.
+    """
+    supervisor = _Supervisor()
+    radio = _Radio(supervisor)
+
+    assert resolve_supervisor(radio) is supervisor
+    assert PrivilegedTxApi.bind(radio, _WS1) is None
+
+
+def test_bind_managed_tx_binds_only_a_stable_owner() -> None:
+    """The poller's old ``_managed_tx`` body, now shared and unchanged."""
+    supervisor = _Supervisor()
+    radio = _Radio(supervisor)
+
+    managed = bind_managed_tx(radio, "websocket", "ws-1")
+    assert managed is not None
+    assert managed.owner == _WS1
+    assert managed.supervisor is supervisor
+
+    # No stable owner anywhere else: HTTP (with or without a forged id), and a
+    # websocket entry that carries no id at all.
+    assert bind_managed_tx(radio, "http", None) is None
+    assert bind_managed_tx(radio, "http", "forged") is None
+    assert bind_managed_tx(radio, "websocket", None) is None
+    assert bind_managed_tx(radio, "websocket", "") is None
+    # Unmanaged radios bind nothing even from a stable owner.
+    assert bind_managed_tx(_Radio(None), "websocket", "ws-1") is None
+
+
+def test_refuse_key_without_owner_is_exactly_managed_minus_ownable() -> None:
+    """Refuse only where both halves hold: managed rig, unownable ingress.
+
+    An owned ingress is not refused — it keys through the supervisor — and an
+    unmanaged rig is not refused either, or HTTP PTT would break for every radio
+    in the field. The supervisor is resolved only once the ingress has already
+    failed the owner test, so the common websocket path runs no backend code.
+    """
+    managed_radio, unmanaged_radio = _Radio(_Supervisor()), _Radio(None)
+
+    assert refuse_key_without_owner(managed_radio, "http", None) is True
+    assert refuse_key_without_owner(managed_radio, "http", "forged") is True
+    assert refuse_key_without_owner(managed_radio, "websocket", None) is True
+    assert refuse_key_without_owner(managed_radio, "websocket", "ws-1") is False
+    assert refuse_key_without_owner(unmanaged_radio, "http", None) is False
+    assert refuse_key_without_owner(unmanaged_radio, "websocket", None) is False
+    # An owned ingress never resolves a supervisor, so a broken accessor on the
+    # radio cannot turn a keyable session into an error.
+    owned = refuse_key_without_owner(_BrokenSupervisorRadio(None), "websocket", "ws-1")
+    assert owned is False
+
+
+def test_the_poller_carries_no_second_copy_of_the_supervisor_read() -> None:
+    """MOR-1198: one two-step read, in the layer every ingress can reach.
+
+    A structural assertion because the duplication is what the bug is made of:
+    three call sites resolved the supervisor independently and two of them got
+    the failure discipline wrong. The poller now asks the gate; it builds no
+    ``TxOwner`` and reads no ``managed_tx`` member of its own.
+    """
+    gate_src = Path(managed_tx_ingress.__file__).read_text()
+    poller_src = Path(radio_poller_module.__file__).read_text()
+
+    assert "getattr_static" in gate_src  # the canonical read lives here
+    assert "getattr_static" not in poller_src
+    assert "ManagedTxApi.bind(" not in poller_src
+    assert "TxOwner(" not in poller_src
+    assert "managed_tx_ingress" in poller_src


### PR DESCRIPTION
MOR-1016 PR 5 of 8. Adds the shared managed-TX ingress gate so web key requests without a managed owner are refused instead of reaching the transport.

Chain: p1 #2132, p2 #2143, p3 #2144, p4 #2146 (all merged). Stacked on p4; diff vs main is this PR's commits only.

Verification: full suite green locally at the chain tip 653701ac on Python 3.11 (8722 passed / 0 failed), lifecycle e2e 11/11; earlier per-PR verification on 3.11–3.13. Note: quick.yml is queued — the self-hosted linux runner is currently unregistered (0 runners at org/repo level), so Actions cannot pick jobs up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)