### PR TITLE
feat: route rigctld PTT through the managed TX facade

### DIFF
--- a/src/rigplane/rigctld/handler.py
+++ b/src/rigplane/rigctld/handler.py
@@ -37,9 +37,11 @@ from ..core.state_pipeline_contracts import (
     SourceMetadata,
 )
 from ..core.state_store import FreshnessState, StateStore, StateSnapshot
+from ..core.tx_safety import TxOutcome, TxReleaseReason
 from ..exceptions import ConnectionError, TimeoutError as RigplaneTimeoutError
 from ..radio_protocol import StateModelCapable, StateModelService, StateStoreCapable
 from ..radio_state import RadioState, ReceiverState
+from ..runtime.managed_tx_ingress import bind_managed_tx, refuse_key_without_owner
 from ..types import Mode
 from .contract import (  # noqa: TID251
     CIV_TO_HAMLIB_MODE,
@@ -218,6 +220,12 @@ def _passband_to_filter(passband_hz: int) -> int | None:
     return 3
 
 
+# The supervisor took the request: a lease is ours (key), or a durable OFF is
+# owed and will be retried until the rig confirms it (unkey). Anything else and
+# nothing reached the wire.
+_TX_ACCEPTED = frozenset({TxOutcome.ACCEPTED, TxOutcome.IDEMPOTENT})
+
+
 def _ok() -> RigctldResponse:
     return RigctldResponse(error=HamlibError.OK)
 
@@ -349,7 +357,16 @@ class _RigctldCommandExecutor:
             if bool(params.get("packet_mode", False)):
                 await self.handler._apply_packet_data_mode(receiver=receiver)
         elif intent.name == "set_ptt":
-            await self.handler._radio.set_ptt(bool(params["ptt"]))
+            # The owner identity rides on the intent, not on the handler's
+            # context var: the ingress recorded it there, ``CommandService``
+            # already matches overlays on it, and it survives an executor that
+            # is ever awaited from a task other than the one that parsed the
+            # command.
+            raised_by = params.get("session_id")
+            await self.handler._route_ptt(
+                bool(params["ptt"]),
+                session_id=None if raised_by is None else str(raised_by),
+            )
         elif intent.name == "set_rit":
             hz = int(params["hz"])
             await self.handler._radio.set_rit_frequency(hz)
@@ -1002,6 +1019,35 @@ class RigctldHandler:
         finally:
             _RIGCTLD_SESSION_ID.reset(token)
 
+    async def release_session_tx(self, session_id: str) -> None:
+        """Hand back any managed TX lease ``session_id`` still holds.
+
+        The TCP server calls this when a client connection ends, however it
+        ends. Without it a WSJT-X that drops mid-over leaves its lease standing
+        until the max key-down watchdog expires: the rig does come off the air,
+        but far later than it needs to, and until then no other client can key.
+
+        Unmanaged radios are left completely alone — no legacy ``set_ptt(False)``
+        is invented here. rigctld has never written to the rig on disconnect,
+        and starting now would de-key an over some *other* ingress is running.
+
+        Fail-soft by construction: this runs on the teardown path of a socket
+        that is already gone, so there is nobody left to report an error to,
+        and raising would only skip the rest of that teardown. A rig genuinely
+        still keyed after this is the watchdog's problem, not this method's.
+        """
+        try:
+            managed = bind_managed_tx(self._radio, "rigctld", session_id)
+            if managed is None:
+                return
+            await managed.set_ptt(False, reason=TxReleaseReason.CLIENT_DISCONNECTED)
+        except Exception:
+            logger.warning(
+                "rigctld: managed TX release for session %s failed",
+                session_id,
+                exc_info=True,
+            )
+
     # ------------------------------------------------------------------
     # Frequency commands
     # ------------------------------------------------------------------
@@ -1362,6 +1408,69 @@ class RigctldHandler:
             )
             return RigctldResponse(values=[str(int(state.ptt))])
         return RigctldResponse(values=["0"])
+
+    async def _route_ptt(self, on: bool, *, session_id: str | None) -> None:
+        """Key or unkey the rig, through the supervisor when the rig has one.
+
+        A rigctld connection id is a lease-bearing owner identity (MOR-1014):
+        the TCP server mints it once per accepted socket and
+        :meth:`release_session_tx` gives the lease back when that socket goes,
+        so a lease taken here is always releasable.
+
+        Three outcomes, deliberately asymmetric between key and unkey.
+
+        **No facade to bind.** Either the rig is unmanaged — every shipped
+        backend today, and the legacy write below is byte-identical to what
+        rigctld has always sent — or the request carries no owner. On a managed
+        rig an ownerless KEY is refused, because falling through would key with
+        no lease, no owner and no watchdog: the unsupervised bypass management
+        exists to close. An ownerless UNKEY still writes, because an unkey
+        refused for lacking an owner strands a keyed transmitter, and nothing
+        on this path may ever do that.
+
+        **Facade bound, key declined.** ``BUSY`` / ``NOT_READY`` /
+        ``RADIO_NOT_OFF`` — the rig is not ours and nothing reached the wire, so
+        the answer has to be an RPRT error. ``RPRT 0`` for a key that never
+        happened tells WSJT-X it is transmitting when it is not.
+
+        **Facade bound, unkey declined.** ``STALE``: nothing is keyed, or the
+        lease belongs to somebody else. This answers ``RPRT 0`` and writes
+        nothing, and both halves are the decision, not an oversight. Nothing is
+        written because rigctld holds no privileged surface (MOR-1175): a raw
+        ``set_ptt(False)`` here would be precisely the unsupervised bypass the
+        facade exists to close, taking another owner's transmission down behind
+        the supervisor's back and leaving that owner's lease — and its
+        watchdog — believing the rig is still keyed. ``RPRT 0`` because the
+        command *was* processed and the supervisor declined it by policy, while
+        WSJT-X reads a nonzero RPRT mid-sequence as a hard rig-control failure.
+        The corner this leaves — a rig keyed by an owner rigctld cannot reach —
+        is bounded by that owner's own teardown and by the max key-down
+        watchdog, which is exactly where MOR-1175 put it.
+        """
+        managed = bind_managed_tx(self._radio, "rigctld", session_id)
+        if managed is None:
+            if on and refuse_key_without_owner(self._radio, "rigctld", session_id):
+                logger.warning(
+                    "rigctld: refusing PTT ON — this radio is managed and the "
+                    "request carries no releasable owner (session_id=%r)",
+                    session_id,
+                )
+                raise _RigctldCommandFailure(HamlibError.EACCESS)
+            await self._radio.set_ptt(on)
+            return
+        transition = await managed.set_ptt(on)
+        if transition.outcome in _TX_ACCEPTED:
+            return
+        if on:
+            logger.warning(
+                "rigctld: managed TX rejected PTT ON: %s", transition.outcome
+            )
+            raise _RigctldCommandFailure(HamlibError.ERJCTED)
+        logger.warning(
+            "rigctld: managed TX declined the unkey (%s) — the lease is not "
+            "this session's and rigctld does not force; reporting RPRT 0",
+            transition.outcome,
+        )
 
     async def _cmd_set_ptt(self, cmd: RigctldCommand) -> RigctldResponse:
         if not cmd.args:

--- a/src/rigplane/rigctld/server.py
+++ b/src/rigplane/rigctld/server.py
@@ -195,6 +195,33 @@ class RigctldServer:
                     )
         return cast(Coroutine[Any, Any, Any], execute(cmd))
 
+    async def _release_session_tx(self, session_id: str) -> None:
+        """Give a departing client's managed TX lease back at teardown.
+
+        The connection id is the owner identity the handler keys under
+        (MOR-1014), and this is the teardown hook that makes it releasable: a
+        client that drops mid-over would otherwise leave its lease standing
+        until the max key-down watchdog expires, blocking every other client
+        meanwhile.
+
+        Probed rather than called outright, and never allowed to raise, for the
+        same reason ``_handler_execute_call`` probes ``session_id``:
+        ``_rig_handler`` is an injected ``Any``, and a handler that predates
+        this hook must keep working. Failure here cannot be reported to a
+        socket that is already gone, and must not skip the rest of teardown.
+        """
+        release = getattr(self._rig_handler, "release_session_tx", None)
+        if release is None:
+            return
+        try:
+            result = release(session_id)
+            if inspect.isawaitable(result):
+                await result
+        except Exception:
+            logger.warning(
+                "session %s: managed TX release failed", session_id, exc_info=True
+            )
+
     def __del__(self) -> None:
         """Emit WARN if instance is collected while TCP server/poller is still active."""
         try:
@@ -839,6 +866,10 @@ class RigctldServer:
             client_id=client_id,
             peername=f"{peer[0]}:{peer[1]}",
         )
+        # Minted once per accepted socket and released in this coroutine's
+        # ``finally``: that pairing is what makes it a lease-bearing managed TX
+        # owner identity rather than a throwaway request id (MOR-1014).
+        session_id = f"rigctld-client-{client_id}"
         logger.info("client #%d connected from %s", client_id, session.peername)
 
         try:
@@ -909,10 +940,7 @@ class RigctldServer:
                 t_start = time.monotonic()
                 try:
                     resp = await asyncio.wait_for(
-                        self._handler_execute_call(
-                            cmd,
-                            session_id=f"rigctld-client-{client_id}",
-                        ),
+                        self._handler_execute_call(cmd, session_id=session_id),
                         timeout=self._config.command_timeout,
                     )
                 except asyncio.TimeoutError:
@@ -989,6 +1017,7 @@ class RigctldServer:
             )
         finally:
             self._rate_windows.pop(client_id, None)
+            await self._release_session_tx(session_id)
             try:
                 writer.close()
                 await writer.wait_closed()

--- a/src/rigplane/runtime/managed_tx_ingress.py
+++ b/src/rigplane/runtime/managed_tx_ingress.py
@@ -1,0 +1,119 @@
+"""The managed-TX ingress gate: which ingress may key a managed radio.
+
+One question, asked identically by every ingress: does this request carry an
+identity the supervisor can hold a lease against? Web asks it here, rigctld
+(MOR-1014) and the CLI/SDK (MOR-1190) will ask the same helpers rather than
+grow a third copy of the two-step supervisor read — the duplication MOR-1198
+exists to remove, and the one three call sites already got wrong in three
+different ways (MOR-1187, MOR-1193, MOR-1196).
+
+It lives in ``runtime`` because ``runtime`` sits below ``backends`` and below
+both UI servers, so every one of those callers can reach it while it reaches
+nothing but ``core``. Putting it in ``web`` would have made rigctld's copy the
+third one.
+
+**The gate is deliberately one-sided: it NEVER refuses an unkey.** Refusing a
+key costs an operator one denied transmission, which is recoverable and
+visible. Refusing an unkey leaves a transmitter on the air that nobody can take
+off — the same asymmetry ``_refuse_key_from_gone_session`` is built on. Nothing
+here is consulted from an unkey path, and nothing here should ever be.
+"""
+
+from __future__ import annotations
+
+from inspect import getattr_static
+from typing import cast
+
+from rigplane.core.radio_protocol import (
+    ManagedTxApi,
+    ManagedTxCapable,
+    ManagedTxSupervisor,
+)
+from rigplane.core.state_pipeline_contracts import CommandSource
+from rigplane.core.tx_safety import TxOwner, TxSource
+
+__all__ = ["bind_managed_tx", "refuse_key_without_owner", "resolve_supervisor"]
+
+
+def resolve_supervisor(radio: object) -> ManagedTxSupervisor | None:
+    """Read ``radio``'s managed TX supervisor; ``None`` when it is unmanaged.
+
+    The owner-free half of :meth:`ManagedTxApi.bind`, for callers asking only
+    *whether* a radio is managed — and the canonical copy of that two-step read
+    (MOR-1198).
+
+    Both steps carry their own discipline. ``getattr_static`` settles absence
+    without running the accessor, so the single explicit read below is the only
+    backend code this touches, and **its failures propagate**: a raising
+    ``managed_tx`` is a broken accessor, not a positive finding of "unmanaged".
+    Collapsing the pair into ``getattr(radio, "managed_tx", None)`` is the bug
+    :class:`ManagedTxCapable` documents — the default absorbs an
+    ``AttributeError`` raised *inside* the property and hands a managed rig to
+    the unsupervised legacy write. ``isinstance`` cannot draw the line either:
+    3.11 probes a non-callable protocol member with ``hasattr`` (gh-102433).
+
+    ``None`` at either step — no such member, or a backend publishing one that
+    holds ``None`` — is a positive determination that the radio is unmanaged.
+    """
+    if getattr_static(radio, "managed_tx", None) is None:
+        return None  # no such member, or a backend that publishes none
+    return cast(ManagedTxCapable, radio).managed_tx
+
+
+def _stable_owner(source: CommandSource, session_id: str | None) -> TxOwner | None:
+    """The ingress identity a lease can be held against, or ``None``.
+
+    Only a websocket control session has one: its long-lived
+    ``ControlHandler._session_id``, not the throwaway the shared executor mints
+    per request, which owner-matched ``release_owner`` would miss — stranding
+    the rig keyed. Every other ingress (HTTP params may even carry a
+    ``session_id``) has no teardown hook, so its lease would be unreleasable.
+    """
+    if source != "websocket" or not session_id:
+        return None
+    return TxOwner(TxSource.WEBSOCKET, session_id)
+
+
+def bind_managed_tx(
+    radio: object, source: CommandSource, session_id: str | None
+) -> ManagedTxApi | None:
+    """Bind this ingress's managed TX facade; ``None`` if it cannot hold one.
+
+    ``None`` covers two different findings that the caller must not conflate:
+    an ingress with no stable owner (checked first, so the common path runs no
+    backend code at all), and an unmanaged radio. On a managed rig the first is
+    exactly the case :func:`refuse_key_without_owner` answers, because falling
+    through to the raw ``set_ptt`` write there would key a managed rig with no
+    lease, no owner and no watchdog.
+    """
+    owner = _stable_owner(source, session_id)
+    if owner is None:
+        return None
+    return ManagedTxApi.bind(radio, owner)
+
+
+def refuse_key_without_owner(
+    radio: object, source: CommandSource, session_id: str | None
+) -> bool:
+    """Must this ingress be refused the KEY? Never asked about an unkey.
+
+    ``True`` only where both halves hold: the radio publishes a supervisor, and
+    the request carries no identity that supervisor could release later. Either
+    half alone is not a refusal — an owned ingress keys through the supervisor,
+    and an unmanaged rig keeps the legacy write every shipped backend still
+    uses.
+
+    The owner test comes first so a managed websocket key never pays for the
+    supervisor read, and a broken accessor cannot turn a perfectly keyable
+    session into an error. When the read does happen it happens under
+    :func:`resolve_supervisor`'s discipline: a failure propagates rather than
+    reading as "unmanaged", so a broken backend denies the key instead of
+    silently granting an unsupervised one.
+
+    Callers must ask this only on the key path. An unkey refused for lacking an
+    owner strands a keyed transmitter, which is strictly worse than the
+    unsupervised de-key it would be preventing.
+    """
+    if _stable_owner(source, session_id) is not None:
+        return False
+    return resolve_supervisor(radio) is not None

--- a/src/rigplane/runtime/managed_tx_ingress.py
+++ b/src/rigplane/runtime/managed_tx_ingress.py
@@ -2,8 +2,8 @@
 
 One question, asked identically by every ingress: does this request carry an
 identity the supervisor can hold a lease against? Web asks it here, rigctld
-(MOR-1014) and the CLI/SDK (MOR-1190) will ask the same helpers rather than
-grow a third copy of the two-step supervisor read — the duplication MOR-1198
+(MOR-1014) asks the same helpers, and the CLI/SDK (MOR-1190) will — rather than
+grow a third copy of the two-step supervisor read, the duplication MOR-1198
 exists to remove, and the one three call sites already got wrong in three
 different ways (MOR-1187, MOR-1193, MOR-1196).
 
@@ -60,18 +60,33 @@ def resolve_supervisor(radio: object) -> ManagedTxSupervisor | None:
     return cast(ManagedTxCapable, radio).managed_tx
 
 
+_STABLE_OWNER_SOURCES: dict[CommandSource, TxSource] = {
+    "websocket": TxSource.WEBSOCKET,
+    "rigctld": TxSource.RIGCTLD,
+}
+
+
 def _stable_owner(source: CommandSource, session_id: str | None) -> TxOwner | None:
     """The ingress identity a lease can be held against, or ``None``.
 
-    Only a websocket control session has one: its long-lived
+    Two ingresses qualify, and for one reason: the id names a *connection* that
+    something is obliged to tear down, so a lease taken under it is releasable.
+
+    A websocket control session carries its long-lived
     ``ControlHandler._session_id``, not the throwaway the shared executor mints
     per request, which owner-matched ``release_owner`` would miss — stranding
-    the rig keyed. Every other ingress (HTTP params may even carry a
-    ``session_id``) has no teardown hook, so its lease would be unreleasable.
+    the rig keyed. A rigctld connection carries the ``rigctld-client-N`` id its
+    TCP server mints once per accepted socket and releases on that socket's
+    teardown, however the socket ends (MOR-1014).
+
+    Every other ingress has no teardown hook — HTTP params may even carry a
+    ``session_id``, and nothing would ever hand its lease back — so its lease
+    would be unreleasable and it gets no owner here.
     """
-    if source != "websocket" or not session_id:
+    tx_source = _STABLE_OWNER_SOURCES.get(source)
+    if tx_source is None or not session_id:
         return None
-    return TxOwner(TxSource.WEBSOCKET, session_id)
+    return TxOwner(tx_source, session_id)
 
 
 def bind_managed_tx(

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -89,9 +89,10 @@ from ..core.state_pipeline_contracts import (
 from ..core.radio_protocol import ManagedTxApi
 from ..core.state_diagnostics import StateDiagnosticsRecorder
 from ..core.state_store import StateStore
-from ..core.tx_safety import TxOutcome, TxOwner, TxSource
+from ..core.tx_safety import TxOutcome
 from .._state_queries import build_state_queries
 from ..profiles import RadioProfile, resolve_radio_profile
+from ..runtime.managed_tx_ingress import bind_managed_tx, refuse_key_without_owner
 from ..types import AudioCodec
 
 if TYPE_CHECKING:
@@ -1177,15 +1178,14 @@ class RadioPoller:
     ) -> ManagedTxApi | None:
         """Bind this control session's managed TX facade; ``None`` if unmanaged.
 
-        Only a websocket session has a STABLE owner identity: its long-lived
-        ``ControlHandler._session_id``, not the throwaway the shared executor
-        mints per request, which owner-matched ``release_owner`` would miss —
-        stranding the rig keyed. Every other ingress (HTTP params may even
-        carry a ``session_id``) has no teardown hook: its lease is unreleasable.
+        The rule it applies — only a websocket session carries an owner identity
+        stable enough to release the lease it takes — now lives in
+        ``runtime.managed_tx_ingress`` with the rest of the gate, because
+        rigctld (MOR-1014) and the CLI/SDK (MOR-1190) must apply the same one
+        and the two-step supervisor read behind it belongs in exactly one place
+        (MOR-1198).
         """
-        if source != "websocket" or not session_id:
-            return None
-        return ManagedTxApi.bind(self._radio, TxOwner(TxSource.WEBSOCKET, session_id))
+        return bind_managed_tx(self._radio, source, session_id)
 
     def _refuse_key_from_gone_session(
         self, source: CommandSource, session_id: str | None
@@ -1433,6 +1433,32 @@ class RadioPoller:
                     except Exception as e:
                         logger.warning("poller: start TX audio failed: %s", e)
                 if managed is None:
+                    # Binding nothing is two findings, and only one may reach
+                    # the raw write: an unmanaged rig (every shipped backend,
+                    # unchanged), or an ingress with no owner a lease could be
+                    # released against — which on a managed rig would key with
+                    # no lease, no owner and no watchdog, the unsupervised
+                    # bypass management exists to close. Resolving a supervisor
+                    # is backend code that can fail (MOR-1187) and runs with the
+                    # TX audio leg above already armed, so refusal and failed
+                    # resolution alike disarm it on the way out, mirroring the
+                    # managed refusal below: a refused key leaves no trace on
+                    # the air.
+                    try:
+                        if refuse_key_without_owner(radio, command_source, session_id):
+                            logger.warning(
+                                "poller: refusing PTT ON from %s ingress: this "
+                                "radio is managed and the request carries no "
+                                "releasable owner",
+                                command_source,
+                            )
+                            raise CommandError(
+                                f"managed TX refused PTT ON from {command_source}: "
+                                "no owner identity to hold the lease"
+                            )
+                    except BaseException:
+                        await self._stop_tx_audio_leg()
+                        raise
                     await radio.set_ptt(True)
                 else:
                     transition = await managed.set_ptt(True)
@@ -1462,6 +1488,12 @@ class RadioPoller:
                 try:
                     managed = self._managed_tx(command_source, session_id)
                     if managed is None:
+                        # No owner gate here, and there must never be one: the
+                        # key arm above refuses an ownerless ingress, but an
+                        # unkey refused for the same reason strands a keyed
+                        # transmitter with nobody able to take it off the air
+                        # (the ``_refuse_key_from_gone_session`` asymmetry).
+                        # Ownerless de-keys keep the unconditional legacy write.
                         await radio.set_ptt(False)
                     else:
                         # A refused release answers STALE: nothing was keyed, or

--- a/tests/test_rigctld_managed_tx.py
+++ b/tests/test_rigctld_managed_tx.py
@@ -1,0 +1,355 @@
+"""MOR-1014 (MOR-1016 PR 6): the rigctld PTT route through the supervisor.
+
+rigctld is the second ingress onto a managed rig and the one an operator never
+watches: WSJT-X keys and unkeys on its own schedule and reads a bare ``RPRT``
+back. So the two things this route may not do are report success for a key that
+never reached the wire, and take another owner's transmission down behind the
+supervisor's back.
+
+The owner identity is the per-connection ``rigctld-client-N`` id. It qualifies
+for a lease under the same rule the Web session does (``managed_tx_ingress``):
+the TCP server mints it once per accepted socket and releases it on that
+socket's teardown, so the lease is always releasable. A per-request id would
+not be, and neither is anything the read paths mint.
+
+A real ``ManagedRadioRuntime`` over the real supervisor and the real effect
+service drives every case, and the provider is the hand-rolled one from
+``test_web_recovery_durable_off`` — the wire log is the whole claim, and a
+scripted double would report whatever outcome it was told to while a
+``MagicMock`` answers every ``getattr`` and so could never show the unmanaged
+path staying unmanaged (nor a ``runtime_checkable`` probe failing on 3.12+,
+gh-102433).
+
+MOR-1175 is what makes the declined-unkey case a decision rather than a gap:
+rigctld gets no privileged force-unkey, so a ``STALE`` release stays a no-op at
+the supervisor and the rig-left-keyed corner is covered by the other owner's
+teardown and the max key-down watchdog instead.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import AsyncIterator, Awaitable, Callable
+
+import pytest
+
+from rigplane.core.tx_safety import (
+    TxOutcome,
+    TxOwner,
+    TxPhase,
+    TxSource,
+)
+from rigplane.profiles import resolve_radio_profile
+from rigplane.rigctld import protocol as rigctld_protocol
+from rigplane.rigctld.contract import HamlibError, RigctldCommand, RigctldConfig
+from rigplane.rigctld.handler import RigctldHandler
+from rigplane.rigctld.server import RigctldServer
+from rigplane.runtime.managed_radio_runtime import ManagedRadioRuntime
+from rigplane.runtime.managed_tx_effect_service import managed_tx_effect_service
+from test_web_recovery_durable_off import _Provider
+
+_SESSION = "rigctld-client-1"
+_MINE = TxOwner(TxSource.RIGCTLD, _SESSION)
+_OTHER = TxOwner(TxSource.WEBSOCKET, "ws-1")
+_KEY_WIRE = ["ptt(on)", "read_ptt"]
+_UNKEY_WIRE = ["ptt(off)", "read_ptt"]
+
+
+class _Radio:
+    """Duck-typed radio recording every *legacy* (unsupervised) PTT write.
+
+    Deliberately not a ``MagicMock``: one satisfies a ``runtime_checkable``
+    protocol on 3.11 but not on 3.12+ (gh-102433), and it would answer the
+    ``managed_tx`` probe on both, so the unmanaged case could never be shown.
+    The member is assigned only when there is a supervisor, which is what makes
+    the unmanaged instance genuinely memberless.
+    """
+
+    def __init__(self, managed_tx: object | None = None) -> None:
+        self.profile = resolve_radio_profile(model="IC-7610")
+        self.capabilities: set[str] = set()
+        self.legacy_writes: list[bool] = []
+        if managed_tx is not None:
+            self.managed_tx = managed_tx
+
+    async def set_ptt(self, on: bool) -> None:
+        self.legacy_writes.append(on)
+
+
+class _Managed:
+    """A managed rig plus the two views the assertions need: wire and policy."""
+
+    def __init__(self, runtime: ManagedRadioRuntime, wire: list[str]) -> None:
+        self.runtime, self.wire = runtime, wire
+        self.radio = _Radio(runtime)
+        self.handler = RigctldHandler(self.radio, RigctldConfig())  # type: ignore[arg-type]
+
+    @property
+    def owner(self) -> TxOwner | None:
+        return self.runtime.tx_snapshot.owner
+
+
+_MakeManaged = Callable[..., Awaitable[_Managed]]
+
+
+@pytest.fixture
+async def managed() -> AsyncIterator[_MakeManaged]:
+    """Build managed rigs and retire their watchdog tickers afterwards.
+
+    ``request_on`` arms a real 0.25 s ticker task; shutting the runtime down is
+    what keeps it from outliving the test's event loop. Nothing here waits on
+    that clock — every case settles inside the awaits it makes.
+    """
+    runtimes: list[ManagedRadioRuntime] = []
+
+    async def _make(*, keyed_by: TxOwner | None = None) -> _Managed:
+        wire: list[str] = []
+        runtime = ManagedRadioRuntime(
+            "rigctld-test",
+            service_factory=managed_tx_effect_service,
+            provider_lifecycle=_Provider(wire),
+        )
+        runtimes.append(runtime)
+        await runtime.replace_provider(ready=True)
+        await runtime.request_fresh_ptt()  # seeds the OFF ``request_on`` demands
+        if keyed_by is not None:
+            assert (await runtime.request_on(keyed_by)).outcome is TxOutcome.ACCEPTED
+        wire.clear()
+        return _Managed(runtime, wire)
+
+    yield _make
+
+    async def _noop() -> None:
+        return None
+
+    for runtime in runtimes:
+        await runtime.shutdown(release_provider=_noop)
+
+
+def _ptt(value: str) -> RigctldCommand:
+    return RigctldCommand(short_cmd="T", long_cmd="set_ptt", args=(value,), is_set=True)
+
+
+def _warned(caplog: pytest.LogCaptureFixture, phrase: str) -> bool:
+    """Whether a warning carries ``phrase``.
+
+    Every refusal branch logs, so the phrase — not the word "managed" — is what
+    tells a declined unkey apart from a rejected key apart from an ownerless one.
+    """
+    return any(
+        record.levelno >= logging.WARNING and phrase in record.getMessage()
+        for record in caplog.records
+    )
+
+
+# ---------------------------------------------------------------------------
+# The key
+# ---------------------------------------------------------------------------
+
+
+async def test_a_key_takes_a_lease_under_this_connection_id(
+    managed: _MakeManaged,
+) -> None:
+    """The lease is held by the rigctld connection, not by a request."""
+    rig = await managed()
+
+    resp = await rig.handler.execute(_ptt("1"), session_id=_SESSION)
+
+    assert resp.error == HamlibError.OK
+    assert rig.wire == _KEY_WIRE
+    assert rig.owner == _MINE
+    assert rig.runtime.tx_snapshot.phase is TxPhase.KEYED
+    # The whole point: a managed rig is never keyed by the raw write.
+    assert rig.radio.legacy_writes == []
+
+
+@pytest.mark.parametrize("declined_by", ["busy", "not_ready"])
+async def test_a_refused_key_answers_rprt_and_never_reaches_the_rig(
+    managed: _MakeManaged, caplog: pytest.LogCaptureFixture, declined_by: str
+) -> None:
+    """A key the supervisor declines must not come back as ``RPRT 0``.
+
+    Nothing reached the wire, so reporting success would leave WSJT-X sending
+    audio into a rig it never keyed — and, on the next unkey, releasing a lease
+    it never held.
+    """
+    rig = await managed(keyed_by=_OTHER if declined_by == "busy" else None)
+    if declined_by == "not_ready":
+        await rig.runtime.set_provider_ready(ready=False)
+
+    with caplog.at_level(logging.WARNING):
+        resp = await rig.handler.execute(_ptt("1"), session_id=_SESSION)
+
+    assert resp.error == HamlibError.ERJCTED
+    assert rig.wire == []
+    assert rig.radio.legacy_writes == []
+    assert rig.owner != _MINE
+    assert _warned(caplog, "rejected PTT ON")
+
+
+# ---------------------------------------------------------------------------
+# The unkey
+# ---------------------------------------------------------------------------
+
+
+async def test_an_unkey_gives_this_session_lease_back_and_reaches_the_rig(
+    managed: _MakeManaged,
+) -> None:
+    """The ordinary case: our lease, released through the facade."""
+    rig = await managed()
+    await rig.handler.execute(_ptt("1"), session_id=_SESSION)
+    rig.wire.clear()
+
+    resp = await rig.handler.execute(_ptt("0"), session_id=_SESSION)
+
+    assert resp.error == HamlibError.OK
+    assert rig.wire == _UNKEY_WIRE
+    assert rig.owner is None
+    assert rig.runtime.tx_snapshot.phase is TxPhase.IDLE
+    assert rig.radio.legacy_writes == []
+
+
+async def test_a_declined_unkey_reports_ok_and_writes_nothing(
+    managed: _MakeManaged, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Someone else's lease is not rigctld's to break (MOR-1175).
+
+    Two claims in one, and both are the ratified policy rather than an
+    accident. No write of any kind: rigctld has no privileged force, so
+    escalating a ``STALE`` release into a raw ``set_ptt(False)`` would end
+    another owner's over behind the supervisor's back. And ``RPRT 0``: the
+    command was processed and declined by policy, while WSJT-X reads a nonzero
+    RPRT mid-sequence as a hard rig-control failure.
+    """
+    rig = await managed(keyed_by=_OTHER)
+
+    with caplog.at_level(logging.WARNING):
+        resp = await rig.handler.execute(_ptt("0"), session_id=_SESSION)
+
+    assert resp.error == HamlibError.OK
+    assert rig.wire == []
+    assert rig.radio.legacy_writes == []
+    assert rig.owner == _OTHER  # the foreign lease is untouched
+    assert _warned(caplog, "declined the unkey")
+
+
+# ---------------------------------------------------------------------------
+# The two fall-throughs
+# ---------------------------------------------------------------------------
+
+
+async def test_an_unmanaged_radio_keeps_the_legacy_write_both_ways() -> None:
+    """Every shipped backend today: byte-identical to what rigctld always sent."""
+    radio = _Radio()
+    handler = RigctldHandler(radio, RigctldConfig())  # type: ignore[arg-type]
+
+    key = await handler.execute(_ptt("1"), session_id=_SESSION)
+    unkey = await handler.execute(_ptt("0"), session_id=_SESSION)
+
+    assert (key.error, unkey.error) == (HamlibError.OK, HamlibError.OK)
+    assert radio.legacy_writes == [True, False]
+
+
+async def test_an_ownerless_key_is_refused_and_an_ownerless_unkey_is_not(
+    managed: _MakeManaged, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The asymmetry, on the one path that can reach a managed rig ownerless.
+
+    No session id means no identity a lease could be released against, so the
+    key would be unsupervised — refused. The unkey is never refused for the
+    same reason: an unkey turned away for lacking an owner strands a keyed
+    transmitter, which is strictly worse than the unsupervised de-key it would
+    be preventing.
+    """
+    rig = await managed()
+
+    with caplog.at_level(logging.WARNING):
+        key = await rig.handler.execute(_ptt("1"))
+        unkey = await rig.handler.execute(_ptt("0"))
+
+    assert key.error == HamlibError.EACCESS
+    assert rig.wire == []  # refused before anything was written
+    assert rig.owner is None
+    assert _warned(caplog, "no releasable owner")
+
+    assert unkey.error == HamlibError.OK
+    assert rig.radio.legacy_writes == [False]
+
+
+# ---------------------------------------------------------------------------
+# Teardown
+# ---------------------------------------------------------------------------
+
+
+async def _settle(predicate: Callable[[], bool], *, what: str) -> None:
+    """Await a real socket teardown, bounded. Not a clock: no case waits on one."""
+    for _ in range(400):
+        if predicate():
+            return
+        await asyncio.sleep(0.005)
+    raise AssertionError(f"{what} never happened")
+
+
+async def test_a_dropped_connection_hands_the_lease_to_the_next_client(
+    managed: _MakeManaged,
+) -> None:
+    """A WSJT-X that dies mid-over must not park the rig on the watchdog.
+
+    Driven over the real ``_handle_client`` loop, the real protocol module, the
+    real handler and a real socket, because the claim is about what the *server*
+    does when a connection ends — the one thing a handler-level call could only
+    assert about itself.
+    """
+    rig = await managed()
+    server = RigctldServer(
+        rig.radio,  # type: ignore[arg-type]
+        RigctldConfig(),
+        _protocol=rigctld_protocol,
+        _handler=rig.handler,
+    )
+    tcp = await asyncio.start_server(
+        server._handle_client,  # noqa: SLF001
+        host="127.0.0.1",
+        port=0,
+    )
+    port = int(tcp.sockets[0].getsockname()[1])
+    live: list[asyncio.StreamWriter] = []
+
+    async def _key() -> tuple[bytes, asyncio.StreamWriter]:
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        live.append(writer)
+        writer.write(b"T 1\n")
+        await writer.drain()
+        return await reader.readline(), writer
+
+    async def _drop(writer: asyncio.StreamWriter) -> None:
+        live.remove(writer)
+        writer.close()
+        await writer.wait_closed()
+
+    try:
+        answer, first = await _key()
+        assert answer == b"RPRT 0\n"
+        assert rig.owner == TxOwner(TxSource.RIGCTLD, "rigctld-client-1")
+
+        await _drop(first)  # the operator's laptop sleeps mid-transmission
+        await _settle(lambda: rig.owner is None, what="the lease handback")
+        assert rig.wire[-2:] == _UNKEY_WIRE
+
+        # ``RPRT -9`` here would mean the dead client's lease is still standing.
+        answer, second = await _key()
+        assert answer == b"RPRT 0\n"
+        assert rig.owner == TxOwner(TxSource.RIGCTLD, "rigctld-client-2")
+        await _drop(second)
+        await _settle(lambda: rig.owner is None, what="the second handback")
+    finally:
+        # Every accepted socket must be shut before ``wait_closed``: since 3.12
+        # it waits on the handlers too, so a client left open by a failing
+        # assertion would hang the teardown rather than report the failure.
+        for writer in live:
+            writer.close()
+        for writer in live:
+            await writer.wait_closed()
+        tcp.close()
+        await tcp.wait_closed()

--- a/tests/test_web_managed_tx_owner.py
+++ b/tests/test_web_managed_tx_owner.py
@@ -22,12 +22,22 @@ MOR-1185 closes the last hole in the pair: the teardown unkey went onto the RAW
 queue, so it reached the drain owner-less and de-keyed the rig without ever
 giving the lease back. Routed through the metadata wrapper it releases what it
 took — and, deliberately, drops the unconditional write it used to make.
+
+MOR-1016 PR 5 turns the owner gate into an ingress gate. Until assembly there
+was no managed backend, so "binds no owner" could keep falling through to the
+raw ``set_ptt`` write; once a rig publishes a supervisor that fallthrough is an
+unsupervised key on a managed rig. The gate lives in
+``rigplane.runtime.managed_tx_ingress`` — below the poller, so rigctld
+(MOR-1014) and the CLI/SDK (MOR-1190) reuse it instead of growing a third copy
+of the same two-step read (MOR-1198) — and it is deliberately one-sided: keys
+are refusable, unkeys never are.
 """
 
 from __future__ import annotations
 
 import asyncio
 import time
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -35,7 +45,7 @@ import pytest
 
 from rigplane.core.capabilities import CAP_AUDIO
 from rigplane.core.exceptions import CommandError
-from rigplane.core.radio_protocol import ManagedTxApi
+from rigplane.core.radio_protocol import ManagedTxApi, PrivilegedTxApi
 from rigplane.core.tx_safety import (
     ProviderAttemptKind,
     ProviderPttObservation,
@@ -48,6 +58,13 @@ from rigplane.core.tx_safety import (
     TxTransition,
 )
 from rigplane.profiles import resolve_radio_profile
+from rigplane.runtime import managed_tx_ingress
+from rigplane.runtime.managed_tx_ingress import (
+    bind_managed_tx,
+    refuse_key_without_owner,
+    resolve_supervisor,
+)
+from rigplane.web import radio_poller as radio_poller_module
 from rigplane.web.handlers.control import ControlHandler
 from rigplane.web.radio_poller import CommandQueue, PttOff, PttOn, RadioPoller
 
@@ -307,18 +324,83 @@ async def test_a_websocket_unkey_without_a_session_id_stays_unmanaged() -> None:
     assert radio.calls == ["set_ptt(False)", *_TEARDOWN]
 
 
-async def test_http_ingress_never_binds_an_owner() -> None:
+async def test_http_ingress_never_binds_an_owner_and_is_refused_the_key() -> None:
     """HTTP has no session and no teardown hook, so a lease taken there could
-    never be released — and its params are caller-supplied, not a session."""
+    never be released — and its params are caller-supplied, not a session.
+
+    MOR-1016 PR 5 draws the consequence the bind alone could not: on a MANAGED
+    rig, "binds no owner" used to mean "falls through to the raw
+    ``set_ptt(True)``" — an unsupervised key with no lease, no owner and no
+    watchdog behind it, which is the bypass management exists to close. So an
+    ingress that cannot hold a lease is refused the key outright, and the
+    supervisor never hears about it.
+    """
     supervisor = _Supervisor()
     poller, radio = _poller(supervisor)
 
-    await poller._execute(PttOn(), source="http", session_id=None)
-    await poller._execute(PttOn(), source="http", session_id="forged")
+    with pytest.raises(CommandError, match="no owner"):
+        await poller._execute(PttOn(), source="http", session_id=None)
+    # A caller-supplied ``session_id`` is not a session: same refusal.
+    with pytest.raises(CommandError, match="http"):
+        await poller._execute(PttOn(), source="http", session_id="forged")
+
+    # No lease attempt, and above all no provider write: the refusal leaves no
+    # trace on the air, and each armed TX audio leg is disarmed behind it.
+    assert supervisor.entries == []
+    assert "set_ptt(True)" not in radio.calls
+    assert radio.calls == ["start_tx", *_TEARDOWN, "start_tx", *_TEARDOWN]
+
+
+async def test_an_http_unkey_on_a_managed_rig_still_writes_the_legacy_off() -> None:
+    """The asymmetry, stated: a refused unkey strands a keyed transmitter.
+
+    The key gate above and this are deliberately not symmetric — the same
+    doctrine ``_refuse_key_from_gone_session`` is built on. Refusing a key costs
+    an operator one denied transmission; refusing an unkey leaves the rig on the
+    air with nobody able to take it off. So the ``PttOff`` arm keeps the
+    unconditional legacy write for every ingress that binds no owner, managed
+    rig or not.
+    """
+    supervisor = _Supervisor()
+    poller, radio = _poller(supervisor)
+
     await poller._execute(PttOff(), source="http", session_id=None)
 
     assert supervisor.entries == []
-    assert radio.calls == [*_KEY, *_KEY, "set_ptt(False)", *_TEARDOWN]
+    assert radio.calls == ["set_ptt(False)", *_TEARDOWN]
+
+
+async def test_an_unmanaged_rig_keeps_the_legacy_http_path_on_both_arms() -> None:
+    """Every shipped backend is still unmanaged, so HTTP PTT is untouched.
+
+    The gate asks the radio, not the request: with no supervisor published there
+    is nothing to be refused on behalf of, and refusing here would break HTTP
+    PTT for every rig in the field.
+    """
+    poller, radio = _poller(None)
+
+    await poller._execute(PttOn(), source="http", session_id=None)
+    await poller._execute(PttOff(), source="http", session_id=None)
+
+    assert radio.calls == [*_KEY, "set_ptt(False)", *_TEARDOWN]
+
+
+async def test_a_raising_accessor_on_the_key_path_disarms_the_tx_leg_too() -> None:
+    """The gate resolves a supervisor, so it runs backend code that can fail.
+
+    MOR-1187's lesson applied to the other arm: the resolution happens with the
+    TX audio leg already armed, so it belongs inside the guard that disarms it.
+    A failed resolution is not "unmanaged" — it propagates — but it must not
+    leave modulation flowing towards a rig this ingress never keyed.
+    """
+    radio = _BrokenSupervisorRadio(None)
+    poller = RadioPoller(radio, CommandQueue())  # type: ignore[arg-type]
+
+    with pytest.raises(RuntimeError, match="accessor exploded"):
+        await poller._execute(PttOn(), source="http", session_id=None)
+
+    assert "set_ptt(True)" not in radio.calls
+    assert radio.calls == ["start_tx", *_TEARDOWN]
 
 
 async def test_a_key_from_a_gone_session_costs_nothing() -> None:
@@ -521,3 +603,99 @@ async def test_an_unmanaged_teardown_still_writes_the_unconditional_unkey() -> N
     await _drain(poller)
 
     assert radio.calls == ["set_ptt(False)", *_TEARDOWN]
+
+
+# --- the ingress gate itself (rigplane.runtime.managed_tx_ingress) ----------
+
+
+def test_resolve_supervisor_propagates_a_raising_accessor() -> None:
+    """A broken accessor is a broken backend, never a positive 'unmanaged'.
+
+    This is the whole reason the two-step read exists rather than
+    ``getattr(radio, "managed_tx", None)``, whose default absorbs an
+    ``AttributeError`` raised *inside* the property and hands a managed rig to
+    the unsupervised write (MOR-1187, MOR-1193, MOR-1196).
+    """
+    with pytest.raises(RuntimeError, match="accessor exploded"):
+        resolve_supervisor(_BrokenSupervisorRadio(None))
+
+
+def test_resolve_supervisor_reads_absence_and_a_published_none_as_unmanaged() -> None:
+    """Both unmanaged shapes: no such member, and a member holding ``None``."""
+    assert resolve_supervisor(object()) is None
+    assert resolve_supervisor(_Radio(None)) is None
+
+
+def test_resolve_supervisor_answers_a_supervisor_with_no_privileged_surface() -> None:
+    """``ManagedTxSupervisor`` is the guaranteed minimum, and it is enough.
+
+    ``_Supervisor`` publishes ``request_on``/``release_owner`` and nothing else,
+    so ``PrivilegedTxApi`` correctly declines it. The gate must not: requiring
+    ``force_unkey`` here would read a conformant managed backend as unmanaged
+    and reopen the very fallthrough this gate closes.
+    """
+    supervisor = _Supervisor()
+    radio = _Radio(supervisor)
+
+    assert resolve_supervisor(radio) is supervisor
+    assert PrivilegedTxApi.bind(radio, _WS1) is None
+
+
+def test_bind_managed_tx_binds_only_a_stable_owner() -> None:
+    """The poller's old ``_managed_tx`` body, now shared and unchanged."""
+    supervisor = _Supervisor()
+    radio = _Radio(supervisor)
+
+    managed = bind_managed_tx(radio, "websocket", "ws-1")
+    assert managed is not None
+    assert managed.owner == _WS1
+    assert managed.supervisor is supervisor
+
+    # No stable owner anywhere else: HTTP (with or without a forged id), and a
+    # websocket entry that carries no id at all.
+    assert bind_managed_tx(radio, "http", None) is None
+    assert bind_managed_tx(radio, "http", "forged") is None
+    assert bind_managed_tx(radio, "websocket", None) is None
+    assert bind_managed_tx(radio, "websocket", "") is None
+    # Unmanaged radios bind nothing even from a stable owner.
+    assert bind_managed_tx(_Radio(None), "websocket", "ws-1") is None
+
+
+def test_refuse_key_without_owner_is_exactly_managed_minus_ownable() -> None:
+    """Refuse only where both halves hold: managed rig, unownable ingress.
+
+    An owned ingress is not refused — it keys through the supervisor — and an
+    unmanaged rig is not refused either, or HTTP PTT would break for every radio
+    in the field. The supervisor is resolved only once the ingress has already
+    failed the owner test, so the common websocket path runs no backend code.
+    """
+    managed_radio, unmanaged_radio = _Radio(_Supervisor()), _Radio(None)
+
+    assert refuse_key_without_owner(managed_radio, "http", None) is True
+    assert refuse_key_without_owner(managed_radio, "http", "forged") is True
+    assert refuse_key_without_owner(managed_radio, "websocket", None) is True
+    assert refuse_key_without_owner(managed_radio, "websocket", "ws-1") is False
+    assert refuse_key_without_owner(unmanaged_radio, "http", None) is False
+    assert refuse_key_without_owner(unmanaged_radio, "websocket", None) is False
+    # An owned ingress never resolves a supervisor, so a broken accessor on the
+    # radio cannot turn a keyable session into an error.
+    owned = refuse_key_without_owner(_BrokenSupervisorRadio(None), "websocket", "ws-1")
+    assert owned is False
+
+
+def test_the_poller_carries_no_second_copy_of_the_supervisor_read() -> None:
+    """MOR-1198: one two-step read, in the layer every ingress can reach.
+
+    A structural assertion because the duplication is what the bug is made of:
+    three call sites resolved the supervisor independently and two of them got
+    the failure discipline wrong. The poller now asks the gate; it builds no
+    ``TxOwner`` and reads no ``managed_tx`` member of its own.
+    """
+    gate_src = Path(managed_tx_ingress.__file__).read_text()
+    poller_src = Path(radio_poller_module.__file__).read_text()
+
+    assert "getattr_static" in gate_src  # the canonical read lives here
+    assert "getattr_static" not in poller_src
+    assert "ManagedTxApi.bind(" not in poller_src
+    assert "TxOwner(" not in poller_src
+    assert "managed_tx_ingress" in poller_src


### PR DESCRIPTION
MOR-1016 PR 6 of 8. rigctld PTT now goes through the managed TX facade (handler.py, server.py, managed_tx_ingress.py) instead of bypassing supervision.

Chain: stacked on p5 (#2147). Diff vs main narrows to this PR's commit once #2147 merges.

Verification: full suite green locally at the chain tip 653701ac on Python 3.11 (8722/0); mutation probes on the rigctld path in the build session. Runner outage note as in #2147.

🤖 Generated with [Claude Code](https://claude.com/claude-code)