### PR TITLE
fix: run the managed TX teardown on every lifecycle release path

### DIFF
--- a/src/rigplane/runtime/_control_phase.py
+++ b/src/rigplane/runtime/_control_phase.py
@@ -1152,8 +1152,17 @@ class ControlPhaseSessionMechanism:
         Otherwise fall through to the unconditional :meth:`ControlPhaseRuntime.
         release`, which still token-removes a partially-claimed session (Holes
         1/5/8).  Both are idempotent.
+
+        Supervised TX is stopped first (MOR-1016).  This is the single funnel
+        every lifecycle path that gives the session up goes through, and it is
+        the only one of them ``CoreRadio.disconnect()`` does not sit above:
+        ``request_shutdown()`` (the SIGTERM hook) and recovery exhaustion reach
+        it directly, and before this they closed the transport with the
+        supervisor still armed over the captured CI-V port — a SIGTERM'd
+        process left a possibly-keyed rig with no release even attempted.
         """
         h = self._cp._host
+        await self._shutdown_supervised_tx(h)
         if getattr(h, "_conn_state", None) is RadioConnectionState.CONNECTED:
             # Full graceful teardown (audio/CI-V stop, generation advance,
             # token-remove, ctrl disconnect).  This already sends token-remove,
@@ -1161,6 +1170,57 @@ class ControlPhaseSessionMechanism:
             await self._cp.disconnect()
             return
         await self._cp.release()
+
+    @staticmethod
+    async def _shutdown_supervised_tx(host: object) -> None:
+        """Run the host's managed-TX teardown ahead of the session release.
+
+        Ordering, boundedness and fail-softness all belong to
+        ``CoreRadio._shutdown_managed_tx`` — the durable OFF must go out while
+        the CI-V path can still carry it, and a supervisor wedged on a rig that
+        stopped answering must not hold the socket close (the de-key of last
+        resort) open behind it.  Nothing is re-implemented here; this is only
+        the second call site, and deliberately without a second ``except``:
+        that method already catches its own timeout and every ``Exception``
+        around the shutdown and clears its members in ``finally``, so wrapping
+        it again could only hide a break in that contract — and would hide it
+        from the very ordering assertion below, since an exception raised here
+        skips the session close this method is supposed to precede.
+
+        **Idempotent by construction, and relied upon as such.**
+        ``CoreRadio.disconnect()`` runs the same teardown one level above,
+        because the lifecycle may treat its own ``disconnect()`` as a no-op
+        (nothing claimed) and never reach this method at all.  When both do
+        run, the second finds ``_managed_tx_runtime is None`` — the first
+        call's ``finally`` cleared it — and returns without touching anything.
+
+        ``getattr`` rather than a direct call: ``ControlPhaseHost`` is a
+        Protocol, and a host that never assembles managed TX (a backend, a test
+        double) simply has nothing to tear down.  Same idiom as
+        ``_stop_audio_watchdog`` in :meth:`ControlPhaseRuntime.disconnect`.
+
+        Side benefit worth naming, because it looks accidental otherwise: this
+        await also unwedges a 3.11-only teardown hang.  ``_arm_managed_tx``'s
+        PTT probe is the last thing ``connect()`` does, and when it times out
+        its ``asyncio.wait_for`` cancels the in-flight CI-V execute task.  On
+        3.12+ ``wait_for`` is built on ``asyncio.timeouts``, which unwinds the
+        probing task through ``__aexit__`` and costs enough loop ticks for the
+        commander worker to drain that cancelled execute before ``connect()``
+        returns.  3.11's future-juggling ``wait_for`` returns in fewer ticks,
+        so the worker is still parked on ``await execute_task`` when teardown
+        arrives — and ``IcomCommander._loop`` classifies the cancel it then
+        receives by ``item.future.cancelled()``, which the probe's timeout
+        already set.  The worker's own ``stop()`` cancel is read as the
+        caller's, swallowed by the ``continue``, and ``stop()`` waits on a
+        worker that has gone back to ``queue.get()`` forever.  Any yield before
+        the release closes that window; this one is here for the production
+        reason above, and the commander's cancel classification is the real
+        (pre-existing, managed-TX-independent) bug behind the hang.
+        """
+        shutdown = getattr(host, "_shutdown_managed_tx", None)
+        if shutdown is None:
+            return
+        await shutdown()
 
     async def soft_reconnect_once(self) -> None:
         await self._cp.soft_reconnect()

--- a/tests/test_managed_tx_assembly.py
+++ b/tests/test_managed_tx_assembly.py
@@ -58,8 +58,14 @@ from rigplane.core.tx_safety import (
 )
 from rigplane.exceptions import CommandError
 from rigplane.runtime import radio as radio_module
+from rigplane.runtime._control_phase import ControlPhaseSessionMechanism
 from rigplane.runtime.managed_tx_ingress import bind_managed_tx
 from rigplane.runtime.radio import CoreRadio, IcomRadio
+from rigplane.runtime.session_lifecycle import (
+    AttemptOutcome,
+    AttemptResult,
+    CoreRadioSessionLifecycle,
+)
 from rigplane.web.server import WebServer
 from test_web_recovery_durable_off import _Observer, _Provider
 
@@ -846,6 +852,178 @@ async def test_an_unmanaged_radio_disconnects_through_the_real_lifecycle() -> No
 
     assert radio.managed_tx is None
     assert not radio.connected
+
+
+# ===========================================================================
+# PR8 -- every path that gives the session up runs the managed teardown
+# ===========================================================================
+#
+# PR4 hung the teardown off ``CoreRadio.disconnect()``, which is one of the
+# ways a session ends and not the one that matters most: the SIGTERM hook
+# (``CoreRadioSessionLifecycle.request_shutdown``) and recovery exhaustion both
+# reach the release without passing through it, so a killed process closed the
+# transport with the supervisor still armed over the captured CI-V port and a
+# possibly-held lease -- no OFF, not even attempted. The teardown therefore
+# moved down to ``ControlPhaseSessionMechanism.release()``, the single funnel
+# all three go through, and ``disconnect()``'s own call stayed where it is
+# (the lifecycle can treat its teardown as an idempotent no-op and never reach
+# the mechanism at all). Which makes running it twice the ordinary case, not
+# the exceptional one -- pinned below.
+
+
+class _ControlPhase:
+    """The packet mechanism reduced to what the session adapter drives.
+
+    ``_Session`` above stands in for the whole policy layer, which is right for
+    everything PR4 claims but cannot state PR8's: ``request_shutdown`` is a
+    method on the *real* lifecycle, and the teardown now lives in the *real*
+    ``ControlPhaseSessionMechanism``. So both of those are genuine here and the
+    stub moves one layer down, to the UDP packet I/O -- the same line
+    ``_AssembledRadio`` already draws.
+
+    ``disconnect`` logs into the provider's log for the same reason
+    ``_Session.disconnect`` does: the claim is an *ordering* one -- the durable
+    OFF against the close of the session that carries it -- and one list is the
+    only way to state it.
+    """
+
+    def __init__(self, radio: _AssembledRadio) -> None:
+        self._host = radio
+        self.closes = 0
+
+    async def connect_attempt(self) -> AttemptResult:
+        radio = self._host
+        radio._civ_port = 50002
+        radio._civ_transport = _CivPort()  # type: ignore[assignment]
+        radio._advance_civ_generation("test-connect")
+        radio._connected = True
+        return AttemptResult(outcome=AttemptOutcome.CONNECTED)
+
+    async def disconnect(self) -> None:
+        radio = self._host
+        if not radio._connected:
+            return
+        self.closes += 1
+        radio.provider.log.append("session_close")
+        radio._civ_transport = None
+        radio._connected = False
+
+    async def release(self) -> None:
+        # The partial-claim branch of the adapter; nothing here is claimed
+        # differently, so it closes the same way.
+        await self.disconnect()
+
+    async def soft_reconnect(self) -> None:
+        raise AssertionError("no test below drives recovery through this stub")
+
+
+class _LifecycleRadio(_RegistryRadio):
+    """A registry-real radio driven by the production lifecycle + adapter."""
+
+    def __init__(self, provider: _Provider) -> None:
+        super().__init__(provider)
+        self.control_phase = _ControlPhase(self)
+        self._session_lifecycle = CoreRadioSessionLifecycle(  # type: ignore[assignment]
+            ControlPhaseSessionMechanism(self.control_phase)  # type: ignore[arg-type]
+        )
+
+
+async def _connected_over_the_real_lifecycle() -> _LifecycleRadio:
+    radio = _LifecycleRadio(_Provider([]))
+    _LIVE.append(radio)
+    await radio.connect()
+    return radio
+
+
+async def _keyed(radio: _LifecycleRadio) -> None:
+    api = ManagedTxApi.bind(radio, _OWNER)
+    assert api is not None
+    assert (await api.set_ptt(True)).outcome is TxOutcome.ACCEPTED
+    assert radio.provider._keyed is True
+
+
+async def test_request_shutdown_releases_the_tx_it_finds_armed() -> None:
+    # The gap PR8 closes, stated on the same log PR4 used for disconnect(): a
+    # SIGTERM'd process owes the rig the OFF its held lease implies, and owes
+    # it *before* the transport that carries it goes away.
+    radio = await _connected_over_the_real_lifecycle()
+    await _keyed(radio)
+    log = radio.provider.log
+
+    await radio._session_lifecycle.request_shutdown()
+
+    assert "ptt(off)" in log
+    assert log.index("ptt(off)") < log.index("session_close")
+    # Not merely written: the confirming read settled it, so the rig is
+    # observably unkeyed rather than optimistically assumed to be.
+    assert radio.provider._keyed is False
+    assert radio.control_phase.closes == 1
+
+
+async def test_request_shutdown_leaves_no_managed_tx_behind() -> None:
+    # The other half of the teardown: the members and the CI-V layer's
+    # generation-keyed registry. A shutdown path that carried the OFF out but
+    # left the port registered would advertise a supervisor over a closed
+    # socket and collide with the next session's generation 1.
+    radio = await _connected_over_the_real_lifecycle()
+    await _keyed(radio)
+    civ = radio._civ_runtime
+    assert list(civ._managed_tx_ports) == [1]
+
+    await radio._session_lifecycle.request_shutdown()
+
+    assert radio.managed_tx is None
+    assert radio._managed_tx_bound_port is None
+    assert radio._managed_tx_armed_epoch is None
+    assert civ._managed_tx_ports == {}
+    assert civ._poisoned_managed_tx_generations == set()
+    assert civ._managed_tx_sends == {}
+    assert civ._managed_tx_retirements == {}
+
+
+async def test_a_shut_down_radio_arms_a_fresh_supervisor_on_the_next_connect() -> None:
+    # Armed is not the claim; keyable is. A process that came back after a
+    # SIGTERM-shaped close has to get supervision back with it, which is only
+    # true if the shutdown released the registry as well as the runtime.
+    radio = await _connected_over_the_real_lifecycle()
+    await _keyed(radio)
+    first = radio.managed_tx
+    assert first is not None
+
+    await radio._session_lifecycle.request_shutdown()
+    await radio.connect()
+
+    second = radio.managed_tx
+    assert second is not None and second is not first
+    snapshot = radio.tx_snapshot
+    assert snapshot is not None
+    assert (snapshot.provider_ready, snapshot.radio_tx) == (True, RadioTx.OFF)
+    api = ManagedTxApi.bind(radio, _OWNER)
+    assert api is not None
+    assert (await api.set_ptt(True)).outcome is TxOutcome.ACCEPTED
+
+    await api.set_ptt(False)
+
+
+async def test_disconnect_runs_the_managed_teardown_twice_and_it_shows_once() -> None:
+    # ``CoreRadio.disconnect()`` keeps its own call *and* reaches the adapter's,
+    # so the double-run is the ordinary path and idempotence is load-bearing
+    # rather than defensive. Two failure shapes are pinned at once: a second
+    # run that re-emits would put a second ``ptt(off)`` on the log, and one
+    # that raises would escape ``release()`` before the session close it is
+    # supposed to precede -- leaving no ``session_close`` at all, because the
+    # lifecycle's teardown suppresses what comes out of ``release()``.
+    radio = await _connected_over_the_real_lifecycle()
+    await _keyed(radio)
+    log = radio.provider.log
+
+    await radio.disconnect()
+
+    assert log.count("ptt(off)") == 1
+    assert log.index("ptt(off)") < log.index("session_close")
+    assert radio.control_phase.closes == 1
+    assert radio.managed_tx is None
+    assert radio._civ_runtime._managed_tx_ports == {}
 
 
 # ===========================================================================


### PR DESCRIPTION
MOR-1016 PR 8 of 8 (unplanned; found by the local 3.11 matrix). ControlPhaseSessionMechanism.release() now awaits the radio's bounded managed shutdown before the session close, so request_shutdown() (SIGTERM) and recovery exhaustion tear managed TX down exactly like an explicit disconnect(). Idempotent with disconnect()'s own call. Also unwedges test_t6 on 3.11 (commander cancel-classification defect behind the hang tracked as MOR-1208, fix in #2145).

Chain: stacked on p7. Final PR of the MOR-1016 chain.

Verification: at this exact commit on Python 3.11 — tests/test_session_lifecycle_e2e.py 11 passed; full suite 8722 passed / 0 failed (5:50). Reproduced the SIGTERM gap on pre-chain main (test_t6 pytest-timeout). Runner outage note as in #2147.

🤖 Generated with [Claude Code](https://claude.com/claude-code)