### PR TITLE
docs: record the SerialMockRadio move in the changelog

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -49,6 +49,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   panel unmounts, and on mobile also when the device rotates while latched
   (fail-closed).
 
+### Removed
+
+- **`rigplane.backends.icom7610.drivers.serial_stub` no longer ships in the
+  package (#2129, #2131).** `SerialMockRadio` and the serial framing test
+  doubles were test-only code living inside the wheel; they moved to
+  `tests/serial_stub.py` (non-shipping) so TX-safety audits of the shipping
+  package (`grep -rn "\.set_ptt(" src/`, MOR-999/MOR-1015/MOR-1016) contain no
+  test-double false positives. Nothing in the shipping package imported the
+  module and it was never a documented public API; external code that imported
+  the old path should vendor the double from the repo's test tree instead.
+
 ## [2.11.1] — 2026-06-22
 
 ### Fixed


### PR DESCRIPTION
## Context

Follow-up to #2129 / #2131 (SerialMockRadio moved from `src/rigplane/backends/icom7610/drivers/serial_stub.py` to `tests/serial_stub.py`). Doc-sync sweep to make documentation match the actual state:

- Living docs already updated in #2131 (`radio-state-pipeline-validation.md` recipe, `legacy-state-writer-inventory.md` row) — verified still accurate.
- `radio-state-pipeline-regression-matrix.md` mentions `SerialMockRadio` by class name only (no path) — accurate as-is.
- Frozen `docs/plans/` discovery snapshots intentionally untouched (historical point-in-time artifacts).
- rigplane-pro checked: no imports of the old path.

## This PR

Adds the missing piece: an `Unreleased / Removed` changelog entry — the old import path disappears from the wheel at the next release, which is user-visible and must be in the release notes. Single file, +11 lines (`CHANGELOG.md` at repo root is a symlink to `docs/CHANGELOG.md`; the real file is edited).

## Verification

Repo-wide sweep: outside `docs/plans/` snapshots and the historical changelog entries, no references to the old path remain anywhere (docs, src, guides, CONTRIBUTING, mkdocs nav).

🤖 Generated with [Claude Code](https://claude.com/claude-code)