### PR TITLE
fix(MOR-1181): deliver the teardown unkey through server shutdown

### DIFF
--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -190,6 +190,14 @@ _SLOW_INTERVAL: float = 0.25  # levels/settings — rarely change
 
 _KEY_ACCEPTED = frozenset({TxOutcome.ACCEPTED, TxOutcome.IDEMPOTENT})  # lease is ours
 
+# MOR-1181: how long the shutdown TX-safety drain may hold teardown open.
+# ``CoreRadio._shutdown_managed_tx``'s doctrine — a wedged rig must not hold
+# shutdown open, since closing the socket is itself the de-key of last resort —
+# at a shorter bound than its 5 s: this runs inside ``stop_web_server``, ahead of
+# the disconnect that then spends that 5 s on the managed release. 2.0 s matches
+# every other bound there and dwarfs a fire-and-forget CI-V unkey.
+_SHUTDOWN_TX_DRAIN_TIMEOUT_S: float = 2.0
+
 # MOR-874: how long a healthy-link in-flight acquisition request may stay
 # suppressed after its FIRST send-relative deadline expiry before being
 # treated as a REAL timeout. The healthy-link gate (see
@@ -558,10 +566,94 @@ class RadioPoller:
         logger.info("radio-poller: started")
 
     def stop(self) -> None:
+        """Cancel the loop and drop the task; deliberately synchronous.
+
+        Draining the queue is not this method's job, and cannot be: on a full
+        server shutdown the writable session's teardown ``PttOff`` is not
+        enqueued until the client tasks are cancelled, well after this call. The
+        caller keeps the poller and awaits :meth:`drain_tx_safety_commands` once
+        those tasks have been gathered (MOR-1181, ``stop_web_server``).
+        """
         if self._task is not None:
             self._task.cancel()
             self._task = None
             logger.info("radio-poller: stopped")
+
+    async def drain_tx_safety_commands(
+        self, *, timeout: float = _SHUTDOWN_TX_DRAIN_TIMEOUT_S
+    ) -> None:
+        """Execute pending unkeys on the way out; discard everything else.
+
+        MOR-1181. The loop exits with entries still queued, and exactly one class
+        of them is still worth running: a ``PttOff``, because the alternative is
+        a transmitter left keyed by a process that is gone. Stale freq/mode/level
+        writes must not fire on the way out, and a pending ``PttOn`` must NEVER
+        run here — keying a rig this process is abandoning is the worst outcome
+        this path can produce. Non-unkeys are discarded, counted and logged.
+
+        Shielded because this runs on an already-cancelled task, which loop
+        teardown would otherwise re-cancel mid-write; the bound therefore
+        abandons the wait, not the write, and names at ERROR what it could not
+        confirm.
+        """
+        entries = self._queue.drain_entries()
+        undelivered = [e for e in entries if isinstance(e.command, PttOff)]
+        discarded = [
+            type(e.command).__name__
+            for e in entries
+            if not isinstance(e.command, PttOff)
+        ]
+        if discarded:
+            logger.info(
+                "radio-poller: shutdown discarded %d pending command(s) — the "
+                "TX-safety drain executes PttOff only: %s",
+                len(discarded),
+                ", ".join(discarded),
+            )
+        if not undelivered:
+            return
+        try:
+            await asyncio.wait_for(
+                asyncio.shield(self._execute_pending_unkeys(undelivered)),
+                timeout=timeout,
+            )
+        except (TimeoutError, asyncio.TimeoutError):
+            logger.error(
+                "radio-poller: shutdown TX drain did not settle within %.1fs; "
+                "%d unkey(s) unconfirmed, the rig may still be keyed: %s",
+                timeout,
+                len(undelivered),
+                ", ".join(e.command_id or "PttOff" for e in undelivered),
+            )
+
+    async def _execute_pending_unkeys(self, pending: list[CommandQueueEntry]) -> None:
+        """Run each queued unkey, dropping it from *pending* once it has run.
+
+        *pending* is the caller's own list, so what is left in it when the bound
+        expires is exactly what the ERROR line has to name.
+        """
+        while pending:
+            entry = pending[0]
+            try:
+                await self._execute(
+                    entry.command,
+                    command_id=entry.command_id,
+                    source=entry.source or "websocket",
+                    session_id=entry.session_id,
+                    command_service=entry.command_service,
+                )
+            except Exception as exc:
+                logger.error(
+                    "radio-poller: shutdown unkey failed: %s", exc, exc_info=True
+                )
+                self._mark_queued_command_failed(entry, exc)
+                if entry.future is not None and not entry.future.done():
+                    entry.future.set_exception(exc)
+            else:
+                if entry.future is not None and not entry.future.done():
+                    entry.future.set_result(None)
+            finally:
+                pending.pop(0)
 
     @property
     def running(self) -> bool:
@@ -1105,7 +1197,11 @@ class RadioPoller:
                 # 4. Wait for next cycle
                 await self._queue.wait(timeout=self._fast_interval)
         except asyncio.CancelledError:
-            pass
+            # MOR-1181: an unkey abandoned in the queue here is a keyed
+            # transmitter. Covers every cancellation of this task; the shutdown
+            # ORDERING — the teardown unkey is not enqueued until long after
+            # this runs — is the caller's half, in ``stop_web_server``.
+            await self.drain_tx_safety_commands()
         except Exception:
             logger.exception(
                 "radio-poller: FATAL — task crashed, commands will stop working"

--- a/src/rigplane/web/web_startup.py
+++ b/src/rigplane/web/web_startup.py
@@ -211,9 +211,14 @@ async def stop_web_server(server: WebServer) -> None:
     Mirrors the original :meth:`WebServer.stop` body verbatim — the method
     now delegates here so the public API is preserved.
     """
-    # 1. Stop poller first (no more CI-V queries)
-    if server._radio_poller is not None:
-        server._radio_poller.stop()
+    # 1. Stop poller first (no more CI-V queries). The reference outlives the
+    #    call deliberately (MOR-1181): a session's teardown PttOff is enqueued
+    #    only when its client task is cancelled at step 6, so the poller is
+    #    already dead when the unkey arrives and its own CancelledError handler
+    #    finds an empty queue. Step 9 drains it, after those tasks tear down.
+    radio_poller = server._radio_poller
+    if radio_poller is not None:
+        radio_poller.stop()
         server._radio_poller = None
     if server._state_poller is not None:
         try:
@@ -306,6 +311,12 @@ async def stop_web_server(server: WebServer) -> None:
         except TimeoutError:
             logger.warning("tasks did not finish in 3s, continuing shutdown")
     server._bg_tasks.clear()
+
+    # 9. Now — and only now — the teardown unkeys those client tasks enqueued on
+    #    their way out are in the queue. Bounded, TX-safety only: this executes
+    #    pending PttOff entries and discards the rest (MOR-1181).
+    if radio_poller is not None:
+        await radio_poller.drain_tx_safety_commands()
 
     # Radio disconnect is handled by the caller's context manager
     # (async with radio: in _run). Do NOT disconnect here.

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import logging
+import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -71,6 +73,13 @@ from rigplane.web.radio_poller import (
     VfoEqualize,
     VfoSwap,
 )
+from rigplane.core.tx_safety import TxOutcome, TxOwner, TxSource
+from rigplane.web.handlers.control import ControlHandler
+from rigplane.web.web_startup import stop_web_server
+
+# MOR-1181 asserts on ordered ``radio.calls`` against a REAL supervisor, so it
+# reuses MOR-1013's harness rather than re-mocking either of them.
+from test_web_managed_tx_owner import _KEY, _TEARDOWN, _poller, _Radio, _Supervisor
 
 
 class _NoopCommandExecutor:
@@ -3052,3 +3061,187 @@ async def test_set_data1_mod_input_dispatch_reads_back_confirmed_value() -> None
     snapshot = store.snapshot()
     assert snapshot.field(FieldPath.global_("slow_state", "data1_mod_input")).value == 5
     assert state.data1_mod_input == 5
+
+
+# --- MOR-1181: the shutdown TX-safety drain --------------------------------
+
+
+def _tx_poller(
+    supervisor: _Supervisor | None,
+) -> tuple[RadioPoller, _Radio, CommandQueue]:
+    poller, radio = _poller(supervisor)
+    return poller, radio, poller._queue  # noqa: SLF001
+
+
+def _cancel_run_with_queued(queue: CommandQueue, *pending: object) -> None:
+    """Cancel the real ``_run`` at its wait, leaving *pending* queued behind it —
+    the file's own cancellation idiom, enqueuing where production does."""
+
+    async def _wait(*args: object, **kwargs: object) -> None:
+        for cmd in pending:
+            queue.put(cmd, source="websocket", session_id="ws-1")  # type: ignore[arg-type]
+        raise asyncio.CancelledError
+
+    queue.wait = _wait  # type: ignore[method-assign]
+
+
+@pytest.mark.parametrize("managed", [True, False])
+@pytest.mark.asyncio
+async def test_shutdown_drain_delivers_an_unkey_queued_at_cancellation(
+    managed: bool,
+) -> None:
+    """MOR-1181: a cancelled poller must not abandon a queued PttOff — the
+    handler was ``pass``, so the entry died with the task and left a keyed
+    transmitter behind a gone process. Both paths matter: the managed one gives
+    the lease back, and the legacy one (kill switch off, or a backend publishing
+    no supervisor) is the residual with no other de-key at all."""
+    supervisor = _Supervisor() if managed else None
+    poller, radio, queue = _tx_poller(supervisor)
+    await poller._execute(PttOn(), session_id="ws-1")  # noqa: SLF001
+    _cancel_run_with_queued(queue, PttOff())
+
+    await poller._run()  # noqa: SLF001
+
+    assert queue.has_commands is False
+    if supervisor is not None:
+        assert supervisor.entries[-1] == (False, TxOwner(TxSource.WEBSOCKET, "ws-1"))
+        assert supervisor.outcomes[-1] is TxOutcome.ACCEPTED
+        assert radio.calls == ["start_tx", *_TEARDOWN]
+    else:
+        assert radio.calls == [*_KEY, "set_ptt(False)", *_TEARDOWN]
+
+
+@pytest.mark.asyncio
+async def test_shutdown_drain_never_executes_a_pending_key() -> None:
+    """The safety-critical negative: keying a rig this process is abandoning is
+    the worst outcome this path can produce, so a pending PttOn is discarded."""
+    supervisor = _Supervisor()
+    poller, radio, queue = _tx_poller(supervisor)
+    _cancel_run_with_queued(queue, PttOn())
+
+    await poller._run()  # noqa: SLF001
+
+    assert radio.calls == []  # no start_tx, no key, no lease attempt
+    assert supervisor.entries == []
+    assert queue.has_commands is False
+
+
+@pytest.mark.asyncio
+async def test_shutdown_drain_discards_and_reports_non_tx_commands(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Stale freq/mode/level writes must not fire on the way out — but they are
+    counted and named, because a silently dropped command is its own defect."""
+    poller, radio, queue = _tx_poller(None)
+    _cancel_run_with_queued(queue, SetFreq(14_074_000), PttOff())
+
+    with caplog.at_level(logging.INFO, logger="rigplane.web.radio_poller"):
+        await poller._run()  # noqa: SLF001
+
+    assert radio.calls == ["set_ptt(False)", *_TEARDOWN]
+    assert "discarded 1 pending command(s)" in caplog.text
+    assert "SetFreq" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_shutdown_drain_abandons_the_wait_not_the_write_on_timeout(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A wedged rig must not hold shutdown open; the bound reports what it could
+    not confirm, and the shield leaves the OFF still trying behind it."""
+    poller, radio, queue = _tx_poller(None)
+    gate = asyncio.Event()
+
+    async def _wedged_set_ptt(on: bool) -> None:
+        radio.calls.append(f"set_ptt({on})")
+        await gate.wait()
+
+    radio.set_ptt = _wedged_set_ptt  # type: ignore[method-assign]
+    queue.put(PttOff(), command_id="teardown-ptt-off-ws-1", source="websocket")
+
+    started = time.monotonic()
+    with caplog.at_level(logging.ERROR, logger="rigplane.web.radio_poller"):
+        await poller.drain_tx_safety_commands(timeout=0.05)
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 1.0
+    assert "may still be keyed" in caplog.text
+    assert "teardown-ptt-off-ws-1" in caplog.text
+    assert radio.calls == ["set_ptt(False)"]
+    gate.set()
+    await asyncio.sleep(0.01)  # the shielded write completes behind the bound
+    assert radio.calls == ["set_ptt(False)", *_TEARDOWN]
+
+
+def _writable_control_session(queue: CommandQueue) -> ControlHandler:
+    """A writable control session whose ``run()`` ends only when cancelled —
+    which is exactly when ``stop_web_server`` cancels its client tasks."""
+
+    async def recv() -> tuple[int, bytes]:
+        await asyncio.Event().wait()
+        raise EOFError  # pragma: no cover - unreachable, keeps the return type
+
+    return ControlHandler(
+        ws=SimpleNamespace(send_text=AsyncMock(), recv=recv),
+        radio=SimpleNamespace(connected=True, radio_ready=True),
+        server_version="test",
+        radio_model="IC-7610",
+        server=SimpleNamespace(
+            command_queue=queue,
+            register_control_event_queue=MagicMock(),
+            unregister_control_event_queue=MagicMock(),
+            build_state_update_envelope=MagicMock(return_value={}),
+        ),
+    )
+
+
+def _shutdown_server(
+    poller: RadioPoller, client_tasks: list[asyncio.Task[None]]
+) -> SimpleNamespace:
+    """The subset of ``WebServer`` that ``stop_web_server`` actually touches."""
+    return SimpleNamespace(
+        _radio_poller=poller,
+        _state_poller=None,
+        _state_store_freshness_task=None,
+        _audio_broadcaster=SimpleNamespace(_stop_relay=AsyncMock()),
+        _webrtc_sessions=None,
+        _diagnostics=SimpleNamespace(stop=AsyncMock()),
+        _audio_bridge=None,
+        _discovery=None,
+        _dx_client=None,
+        _dx_client_task=None,
+        _zombie_reaper_task=None,
+        _scope_health_task=None,
+        _scope_reenable_task=None,
+        _bg_tasks=[],
+        _client_tasks=client_tasks,
+        _server=None,
+        _server_was_running=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_server_shutdown_delivers_the_unkey_its_client_enqueues_late() -> None:
+    """MOR-1181's production case, and why the drain alone is not enough:
+    ``stop_web_server`` cancels the poller at step 1, but the teardown PttOff
+    does not exist until ``ControlHandler.run()``'s finally runs at step 6. The
+    poller's own CancelledError handler therefore finds an empty queue every
+    time, deterministically — only the awaited final drain delivers the unkey."""
+    supervisor = _Supervisor()
+    radio = _Radio(supervisor)
+    queue = CommandQueue()
+    poller = RadioPoller(radio, queue)  # type: ignore[arg-type]
+    handler = _writable_control_session(queue)
+    client: asyncio.Task[None] = asyncio.create_task(handler.run())
+    await asyncio.sleep(0.01)  # run() reaches the recv loop and publishes itself
+    await poller._execute(PttOn(), session_id=handler._session_id)  # noqa: SLF001
+    poller.start()
+    await asyncio.sleep(0.01)  # the loop is genuinely running when it is stopped
+
+    await stop_web_server(_shutdown_server(poller, [client]))  # type: ignore[arg-type]
+
+    owner = TxOwner(TxSource.WEBSOCKET, handler._session_id)
+    assert supervisor.entries == [(True, owner), (False, owner)]
+    assert supervisor.outcomes[-1] is TxOutcome.ACCEPTED
+    assert radio.calls == ["start_tx", *_TEARDOWN]
+    assert queue.has_commands is False

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -288,7 +288,9 @@ async def test_start_and_stop_with_radio_sets_callbacks() -> None:
     radio.radio_ready = True
     radio.control_connected = True
     fake_server = _FakeAsyncServer()
-    fake_poller = MagicMock()
+    # MOR-1181: stop_web_server now awaits a final TX-safety drain on the
+    # poller it stopped, so the stand-in has to answer that call too.
+    fake_poller = MagicMock(drain_tx_safety_commands=AsyncMock())
 
     srv = WebServer(radio, WebConfig(host="127.0.0.1", port=0))
     with (
@@ -329,7 +331,7 @@ async def test_start_attaches_shared_state_model_service_for_acquisition_profile
     radio.radio_ready = True
     radio.control_connected = True
     fake_server = _FakeAsyncServer()
-    fake_poller = MagicMock()
+    fake_poller = MagicMock(drain_tx_safety_commands=AsyncMock())  # MOR-1181
 
     srv = WebServer(radio, WebConfig(host="127.0.0.1", port=0))
     with (
@@ -604,7 +606,7 @@ async def test_stop_handles_disconnect_failure_and_cancels_client_tasks() -> Non
     radio.disconnect = AsyncMock(side_effect=RuntimeError("disconnect failed"))
     srv = WebServer(radio)
     srv._server = _FakeAsyncServer()
-    srv._radio_poller = MagicMock()
+    srv._radio_poller = MagicMock(drain_tx_safety_commands=AsyncMock())
 
     blocker = asyncio.Event()
 


### PR DESCRIPTION
## Summary

Implements the recorded MOR-1181 decision: a keyed session plus a full server shutdown no longer loses the teardown unkey. Two halves, both required — the investigation proved the ticket's original preferred design (drain in the poller's `CancelledError` handler) is deterministically insufficient alone, because `stop_web_server` cancelled the poller at step 1 while the teardown `PttOff` is only enqueued when the client tasks are cancelled later.

Linear: [MOR-1181](https://linear.app/morozsm/issue/MOR-1181) (decision recorded on the ticket, 2026-08-01, against base `b0252d4b`).

## Changes

- `src/rigplane/web/radio_poller.py` — `drain_tx_safety_commands()`: executes pending `PttOff` entries ONLY (a pending `PttOn` is structurally unreachable — never executed during shutdown); every non-unkey entry discarded, counted, logged at INFO; `asyncio.shield` inside `asyncio.wait_for(2.0s)` so the bound abandons the wait, never the write; expiry logs at ERROR naming the undelivered unkeys ("the rig may still be keyed"). Called from `_run`'s `CancelledError` handler. `stop()` stays synchronous (docstring only).
- `src/rigplane/web/web_startup.py` — `stop_web_server` holds the poller reference and awaits the drain again after the client-task gather (new step 9), which is when `ControlHandler.run()`'s `finally` enqueues the teardown `PttOff`.
- `tests/test_radio_poller_coverage.py` — 5 tests (6 IDs) driving the real `_run()`/real `stop_web_server` with ordered `radio.calls` against the real `TxSafetySupervisor`: unkey-delivered (managed+legacy), PttOn-never-executed negative, non-TX discard+log, timeout path, and the production-ordering test over `stop_web_server`.
- `tests/test_web_server_coverage.py` — three bare-`MagicMock` poller stand-ins gain `drain_tx_safety_commands=AsyncMock()` (no assertions changed).

The 2.0 s bound follows `_shutdown_managed_tx`'s doctrine at `stop_web_server`'s own scale (every other bound in that function is 2.0 s; this drain runs ahead of the managed teardown's 5 s, capping the serial worst case at 7 s). Scope note: on the default managed path a lease-held key is already released by `CoreRadio._shutdown_managed_tx` (MOR-1016 P8); this closes the poller-level hole that strands a legacy-path key, where `emergency_release` answers `NOOP`.

## Guardrail note (302 net LOC vs the ticket's ≤200; 4 files)

Verifier-confirmed exemptions: the overage buys the only test that exercises the real `stop_web_server` ordering (sole proof of the production case) and the safety-critical `PttOn`-never-executed negative — neither removable without hollowing the ticket's own acceptance criteria; production is 107 net LOC, total 302 within CLAUDE.md's ≤400. The 4th file is a 3-hunk `AsyncMock` repair forced by the new awaited call, preserving every original assertion.

## Evidence

- Builder: full suite (worktree, py3.11) **8730 passed, 0 failed**; targeted 493 passed; ruff/format/lint-imports/mypy clean.
- Independent verifier (separate agent context, non-author): sha256-pinned tree; asyncio semantics re-derived AND measured on 3.11/3.12/3.13 (`wait_for(shield(...))` on a genuinely cancelled task → `TimeoutError`, shielded write lands; the 3.12+ `Task.uncancel()` arithmetic holds); `_run` exit contract unchanged vs base; 7-mutation battery in a `git archive` sandbox (revert-ordering, revert-drain, drain-executes-PttOn, unbounded, shield-removed, INFO-dropped, ERROR-dropped) — each killed by a named test. Review posted as a PR comment, incl. 5 non-blocking observations.

Software evidence only; MOR-1033 remains the FTX-1 hardware gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
