### PR TITLE
test(MOR-1179): pin cross-session de-key protection and the legacy residual

### DIFF
--- a/tests/test_web_managed_tx_owner.py
+++ b/tests/test_web_managed_tx_owner.py
@@ -595,14 +595,123 @@ async def test_a_session_that_never_keyed_writes_nothing_to_a_managed_rig() -> N
 
 
 async def test_an_unmanaged_teardown_still_writes_the_unconditional_unkey() -> None:
-    """Acceptance 4: no shipped backend assembles a managed runtime until
-    MOR-1016, so the unconditional legacy OFF is what production still gets."""
+    """Acceptance 4, corrected for MOR-1179.
+
+    This docstring used to say "no shipped backend assembles a managed runtime
+    until MOR-1016" — that is stale. MOR-1016 has merged and managed TX is ON
+    by default (``RIGPLANE_MANAGED_TX`` is an opt-out, ``core/env_config.py``),
+    so this is no longer what production's common case does. What it still
+    pins is the LEGACY residual behind the kill switch: with no supervisor
+    published (``RIGPLANE_MANAGED_TX=0``, or a backend that assembles none),
+    teardown keeps the unconditional legacy OFF, unchanged. See the two-session
+    tests below for the managed-path counterpart this residual sits next to.
+    """
     handler, poller, radio = _wired(None)
 
     await handler.run()
     await _drain(poller)
 
     assert radio.calls == ["set_ptt(False)", *_TEARDOWN]
+
+
+async def test_a_second_session_teardown_does_not_de_key_a_live_first_session() -> None:
+    """MOR-1179: a closing session must not de-key another session's live TX.
+
+    The acceptance gap this closes: the merged evidence
+    (``test_a_session_that_never_keyed_writes_nothing_to_a_managed_rig``, above)
+    only shows a closer holding NO lease leaves an idle rig alone. MOR-1179
+    wants the case where session A actually IS transmitting when session B — a
+    second writable session sharing the same queue — disconnects. Doctrine: one
+    session's disconnect must not de-key another session's live transmission;
+    ownership arbitration is the managed lease (``release_owner`` matching on
+    ``TxOwner``), not the queue B's teardown entry happens to share with A.
+
+    Structurally this is a straight read of ``release_owner``
+    (``core/tx_safety.py``): it answers STALE on any owner mismatch and emits
+    no effect, so B's teardown never reaches the provider. Confirmed live here,
+    not just asserted from the policy: a real ``TxSafetySupervisor`` drives it,
+    and A's lease is proven to still be live afterwards (a repeat key from A is
+    IDEMPOTENT; a key from a third owner is BUSY), not merely "not released".
+    """
+    supervisor = _Supervisor()
+    handler_a, poller, radio = _wired(supervisor)
+    handler_a._publish_session_liveness(live=True)
+    await handler_a._enqueue_command("ptt_on", {})
+    await _drain(poller)  # A is keyed, ACCEPTED
+
+    assert supervisor.outcomes[-1] is TxOutcome.ACCEPTED
+    assert "set_ptt(False)" not in radio.calls
+    a_write_on = supervisor.inner.snapshot.active_attempt  # A's own, still unsettled
+
+    handler_b, _ = _run_handler(poller._queue)  # second writable session, SAME queue
+    handler_b._publish_session_liveness(live=True)
+    await handler_b.run()  # EOF on first recv -> B tears down, enqueues its own PttOff
+    await _drain(poller)
+
+    assert supervisor.entries[-1] == (False, _owner(handler_b))
+    assert supervisor.outcomes[-1] is TxOutcome.STALE
+    # The load-bearing pair is the STALE outcome above plus release_reason
+    # below — NOT the identity check that follows on its own. A genuine,
+    # owner-matched release also leaves ``active_attempt`` as the same object:
+    # ``_release_current`` cancels it via ``_cancel()`` (``core/tx_safety.py``),
+    # which records a ``CancelProviderAttempt`` effect but never clears or
+    # replaces ``self._active``. So identity alone cannot tell "STALE, nothing
+    # happened" apart from "a real release just started". ``release_reason``
+    # can: it is set only by ``_begin_release``, which STALE's early return
+    # never reaches, so it stays ``None`` here and would flip to the release's
+    # reason the moment ownership resolution let a mismatched release through.
+    # (``radio.calls`` alone cannot prove any of this either: this harness's
+    # ``_Supervisor`` never calls ``radio.set_ptt`` on the managed path at
+    # all, so "set_ptt(False) not in radio.calls" would hold regardless of
+    # whether the release actually touched anything.)
+    assert supervisor.inner.snapshot.active_attempt is a_write_on
+    assert supervisor.inner.snapshot.release_reason is None
+    # A's transmission survives: no de-key reaches the provider. The leg is
+    # only ever disarmed defensively behind the refusal, never keyed off.
+    assert "set_ptt(False)" not in radio.calls
+    assert radio.calls == ["start_tx", *_TEARDOWN]
+
+    # A's lease is still live, proven two ways: a repeat key from A answers
+    # IDEMPOTENT (already-yours acceptance, not a fresh grant)...
+    await handler_a._enqueue_command("ptt_on", {})
+    await _drain(poller)
+    assert supervisor.entries[-1] == (True, _owner(handler_a))
+    assert supervisor.outcomes[-1] is TxOutcome.IDEMPOTENT
+
+    # ...and a third owner attempting to key while A holds the lease is BUSY,
+    # not refused as gone (the queue is authoritative once any session has
+    # registered, so the third owner must register too).
+    poller._queue.register_session("ws-third")
+    with pytest.raises(CommandError, match=TxOutcome.BUSY):
+        await poller._execute(PttOn(), command_id="c-third", session_id="ws-third")
+    assert supervisor.entries[-1] == (True, TxOwner(TxSource.WEBSOCKET, "ws-third"))
+    assert supervisor.outcomes[-1] is TxOutcome.BUSY
+
+
+async def test_a_second_sessions_teardown_still_de_keys_on_the_legacy_path() -> None:
+    """MOR-1179 legacy counterpart: pins the residual behind the kill switch.
+
+    Same two-session shape as the managed test above, but with
+    ``_wired(None)`` — no supervisor published, so ``PttOff`` always takes the
+    unconditional legacy write regardless of which session's teardown enqueued
+    it. This is the documented residual exposure MOR-1179's decision leaves in
+    place deliberately (interim legacy-path mitigation was explicitly declined,
+    to keep the kill switch's "no lease, no owner" contract honest): with
+    ``RIGPLANE_MANAGED_TX=0``, session B's disconnect DOES de-key session A.
+    """
+    handler_a, poller, radio = _wired(None)
+    handler_a._publish_session_liveness(live=True)
+    await handler_a._enqueue_command("ptt_on", {})
+    await _drain(poller)  # A is keyed via the raw legacy write
+
+    handler_b, _ = _run_handler(poller._queue)  # second writable session, SAME queue
+    handler_b._publish_session_liveness(live=True)
+    await handler_b.run()  # EOF on first recv -> B tears down, enqueues its own PttOff
+    await _drain(poller)
+
+    # The residual, pinned rather than latent: B's teardown de-keys A.
+    assert "set_ptt(False)" in radio.calls
+    assert radio.calls == [*_KEY, "set_ptt(False)", *_TEARDOWN]
 
 
 # --- the ingress gate itself (rigplane.runtime.managed_tx_ingress) ----------


### PR DESCRIPTION
## Summary

MOR-1179 ships as **decision + pinning tests, zero production change**. Investigation at `b0252d4b` (empirical probes against the real supervisor) confirmed the ticket's own prediction: since MOR-1016 merged, the managed default path already prevents a closing writable session from de-keying another session's live transmission — the teardown `PttOff` binds `TxOwner(WEBSOCKET, session_id)` and `release_owner` answers `STALE` on an owner mismatch (`core/tx_safety.py:401-404`). What was missing was the pinning evidence.

Linear: [MOR-1179](https://linear.app/morozsm/issue/MOR-1179) (decision recorded on the ticket, 2026-08-01: superseded-on-default-path; no interim legacy mitigation — the kill-switch contract stays crisp; no operator indication needed; MOR-1175 `EXTERNAL_UNOWNED` interaction stated).

## Changes (1 file, tests only)

`tests/test_web_managed_tx_owner.py`:
- **Two-session live-lease test** (the acceptance gap — no merged test drove two sessions with one keyed): A keys through the real poller/queue (`ACCEPTED`), a second writable handler B on the same queue tears down via the production path (`run()` → `finally` → `_release_ptt_on_teardown`); asserts B's release is `STALE`, A's in-flight provider attempt is untouched **with `release_reason is None` as the discriminating check** (object identity alone cannot discriminate — `_cancel()` never clears `_active`), A re-keys `IDEMPOTENT`, a third owner gets `BUSY`.
- **Legacy negative**: with managed TX off (`_wired(None)`), B's teardown still de-keys A — pins the documented kill-switch residual instead of leaving it latent.
- **Docstring correction**: the unmanaged-teardown test's stale claim ("no shipped backend assembles a managed runtime until MOR-1016") rewritten; it now pins the legacy residual per the decision.

Already-merged evidence for the other acceptance bullets is cited, not re-implemented: `test_a_session_that_never_keyed_writes_nothing_to_a_managed_rig`, `test_a_disconnect_releases_the_lease_it_took_not_just_the_rig`, `test_the_lease_is_released_through_a_dead_egress_socket`, read-only exclusion via `test_read_only_teardown_enqueues_nothing` + `TestWebPttReadOnly`.

## Evidence

- Builder: target file 30 passed; full suite (worktree, py3.11) **8726 passed, 0 failed**; ruff check + format clean.
- Independent verifier (separate agent context, non-author; three review rounds): sha256-pinned; every assertion's discriminating power proven by mutation in a `git archive` sandbox — including an owner-bind mutation that earlier drafts *survived* and the final `release_reason` assertion catches on its own (F1/F2/F3 + M1/M2/V2 in the review). Review posted as a PR comment documents the full history, including two rejected strengthening attempts.

Software evidence only; MOR-1033 remains the FTX-1 hardware gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
