### PR TITLE
test(MOR-1217): answer CI-V 0x1C in the mock and give t4 keepalive headroom

### DIFF
--- a/tests/mock_server.py
+++ b/tests/mock_server.py
@@ -76,6 +76,7 @@ _CMD_METER = 0x15
 _CMD_ATT = 0x11
 _CMD_PREAMP = 0x16
 _CMD_CMD29 = 0x29
+_CMD_PTT = 0x1C
 _CMD_ACK = 0xFB
 _CMD_NAK = 0xFA
 _SUB_RF_POWER = 0x0A
@@ -84,6 +85,7 @@ _SUB_SWR_METER = 0x12
 _SUB_ALC_METER = 0x13
 _SUB_PREAMP_STATUS = 0x02
 _SUB_DIGISEL_STATUS = 0x4E
+_SUB_PTT = 0x00
 
 
 # ---------------------------------------------------------------------------
@@ -845,6 +847,25 @@ class MockIcomRadio:
                     _CMD_METER,
                     sub=_SUB_ALC_METER,
                     data=_level_bcd_encode(self._alc),
+                )
+            return self._civ_nak(to, frm)
+
+        # --- PTT / Transceiver status (0x1C) ---
+        if cmd == _CMD_PTT:
+            if not payload:
+                return self._civ_nak(to, frm)
+            sub = payload[0]
+            rest = payload[1:]
+            if sub == _SUB_PTT and not rest:  # 0x00 GET only
+                # The managed-TX arming probe (MOR-1016) reads PTT once,
+                # unmanaged, before any port is captured — and
+                # ``request_fresh_ptt`` reads it again right after capture to
+                # seed the authoritative observation. Always answer PTT OFF so
+                # a rig that can in fact be supervised is recognised as such
+                # (MOR-1217); a SET or an unrecognised sub-command NAKs, same
+                # as an unimplemented command.
+                return self._civ_frame(
+                    to, frm, _CMD_PTT, sub=_SUB_PTT, data=bytes([0x00])
                 )
             return self._civ_nak(to, frm)
 

--- a/tests/test_session_lifecycle_e2e.py
+++ b/tests/test_session_lifecycle_e2e.py
@@ -352,6 +352,7 @@ async def test_t4_force_civ_unavailable_resident_retry_recovers(
     retries IN-PROCESS within one CoreRadio until the sim recovers — single
     owner throughout, ``busy_rejects == 0``, no process restart, no livelock."""
     sim = single_owner_radio
+    sim.keepalive_hold_s = 10.0  # outlive the resident not-ready retry window
     sim.force_civ_unavailable_for(0.4)
 
     radio = _make_radio(sim)
@@ -371,6 +372,29 @@ async def test_t4_force_civ_unavailable_resident_retry_recovers(
     assert sim.session_held is False
     # Single owner the entire time (the same identity that finally claimed).
     assert owner_id is not None
+
+
+async def test_managed_tx_arms_via_mock_civ_ptt_probe(
+    single_owner_radio: MockIcomRadio,
+) -> None:
+    """MOR-1217 coverage-gap closure: the MOR-1016 arming probe (0x1C 0x00,
+    ``_managed_tx_provider_answers_ptt``) and the seeding read that follows it
+    (``request_fresh_ptt``) both round-trip against the mock server, so
+    managed TX actually ARMS on a normal e2e connect instead of silently
+    degrading to provider-not-ready. Fails if ``tests/mock_server.py`` stops
+    answering CI-V ``0x1C 0x00``."""
+    sim = single_owner_radio
+    radio = _make_radio(sim)
+
+    await _connect(radio)
+
+    assert radio.connected
+    assert radio.managed_tx is not None
+    snapshot = radio.tx_snapshot
+    assert snapshot is not None
+    assert snapshot.provider_ready is True
+
+    await radio.disconnect()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Test-side fix for the ~10-15%/run full-matrix flake in `test_t4_force_civ_unavailable_resident_retry_recovers`, plus closure of the e2e coverage gap it exposed. Production is correct; both causes were in the test infrastructure.

Linear: [MOR-1217](https://linear.app/morozsm/issue/MOR-1217) (mechanism fully pinned by a containerized investigation; repro image `rigplane-repro:py313` retained). Related: MOR-1216 (t4's dead cooldown path — deliberately NOT folded in, and still observably dead in the CI trace).

## The two stacked causes, both fixed

1. **`tests/mock_server.py` lacked CI-V `0x1C`** — the MOR-1016 arm probe (`_managed_tx_provider_answers_ptt`, 0.5s timeout) timed out on every mock e2e connect, because the mock's fall-through NAK can never resolve a response waiter (`CivRequestTracker._matches` demands a real `0x1C 0x00` response frame). Cost: +0.5s per connect, and the managed arm path **never succeeded in any mock e2e test**. The mock now answers the bare GET with `FE FE E0 98 1C 00 00 FD` (PTT OFF) — the exact frame `_publish_authoritative_ptt` validates (`len(data)==1`, value in `(0,1)`); SETs and other subs still NAK, byte-identical to before.
2. **Zero-margin keepalive in t4**: `FAST_KEEPALIVE_HOLD_S == PING_PERIOD == 0.5`, so the probe stall between session claim and assertion consumed the entire hold budget under matrix load. t4 now sets `sim.keepalive_hold_s = 10.0` — the exact idiom t7/t8/t11 already use. Headroom, not coverage loss: the 0.5s hold is a test accelerant (real rigs hold 40-60s) and t4 is a lifecycle/retry test, not a keepalive-cadence test.

New pinning test `test_managed_tx_arms_via_mock_civ_ptt_probe` asserts `provider_ready is True` — a whole-chain assertion (probe answered → provider captured → fresh-PTT seed `APPLIED`) that fails if the 0x1C handler is removed, so the coverage gap cannot silently reopen.

## Evidence

- Builder: patched tree **0/20 failures** under 3× contention in the retained container image; full suite 8725 passed / 0 failed; ruff clean; e2e file wall time −0.46s/connect.
- Independent verifier (separate agent context, non-author): protocol correctness re-derived byte-by-byte from `src/` (incl. why the pre-patch NAK burned the full timeout); 6-way mutation battery (handler removed, 5 reply corruptions) — every one kills the pinning test; hold=10.0 proven in effect at claim time; timing reproduced (17.94s vs 23.04s). Causality adjudicated honestly: CI run 30713471027 attempt 1 (today) shows **both causes composing in a single trace**; retained A/B logs show 5/68 fails at head, all `keepalive_timeout`, vs 0/20 pre-probe and 0/12 with the kill switch. Local busy-loop reproduction is not faithful to the linux-aarch64 runner (0/28 unpatched control), so the signed claim is "the failure mechanism is directly observed and the diff removes both of its inputs", not "flake statistically proven eliminated". The next full-matrix runs on main are the confirming instrument.

Software evidence only; MOR-1033 remains the FTX-1 hardware gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
