### PR TITLE
fix(MOR-1222): route validation-tool PTT through the managed facade

### DIFF
--- a/src/rigplane/validation/hardware.py
+++ b/src/rigplane/validation/hardware.py
@@ -27,6 +27,7 @@ import asyncio
 import dataclasses
 import datetime
 import logging
+import uuid
 from collections.abc import Awaitable, Callable, Sequence
 from typing import Any, TypeVar, cast
 
@@ -42,12 +43,14 @@ from rigplane.core.radio_protocol import (
     AudioCapable,
     DspControlCapable,
     LevelsCapable,
+    ManagedTxApi,
     Radio,
     RitXitCapable,
     ScopeCapable,
     SystemControlCapable,
     UsbAudioCapable,
 )
+from rigplane.core.tx_safety import TxOutcome, TxOwner, TxSource, TxTransition
 from rigplane.core.types import AgcMode
 from rigplane.validation.interactive import InteractivePrompter
 from rigplane.validation.registry import CheckKind, CheckSpec, ValueRule, get_spec
@@ -154,6 +157,20 @@ _TUNER_SETTLE_SECONDS = 1.0
 # The check_ids whose actuation transmits; gated by ``--tx-actuate`` + confirm.
 # VOX is deliberately excluded (stays MANUAL — out of MOR-666 scope).
 _TX_ACTUATE_CHECK_IDS = frozenset({"tx.ptt", "tuner.tune"})
+
+# MOR-1222 — one TX identity for the whole validation process, minted here for
+# the same reason the CLI mints ``_CLI_TX_OWNER`` once (MOR-1170): the
+# supervisor matches a release against the owner that TOOK the lease, so a
+# per-actuation owner could miss its own lease and strand the rig keyed.
+# ``rigplane validate`` is a one-shot process, so one process is one TX session.
+# ``TxSource`` has no validation member and this deliberately adds none — the
+# harness is an in-process consumer of the public SDK surface, exactly as the
+# CLI is, so it borrows ``SDK`` and distinguishes itself by the owner id.
+_VALIDATION_TX_OWNER = TxOwner(TxSource.SDK, f"validation:{uuid.uuid4().hex}")
+
+# Supervisor outcomes that mean the request reached the transmitter: ACCEPTED
+# for a state change, IDEMPOTENT for a request that found the rig already there.
+_TX_ACCEPTED_OUTCOMES = frozenset({TxOutcome.ACCEPTED, TxOutcome.IDEMPOTENT})
 
 # MOR-668 — RX-audio probes that run for real against a live captured RX-PCM
 # window (supplied via ``audio_probe_frames``). ``audio.tx.byte_perfect`` is
@@ -526,7 +543,59 @@ def _manual_required_result(
 # TX actuation handlers (MOR-666) — reached ONLY after the full gate stack and
 # an explicit interactive confirm() YES. Each guarantees the radio is left in a
 # safe (un-keyed, power-restored) state via a finally that never raises.
+#
+# MOR-1222: every PTT *assertion* below goes through the radio's managed TX
+# supervisor when it publishes one. A raw ``set_ptt`` here took no lease, so
+# nothing applied ``BACKEND_MAX_KEY_DOWN`` to the key and a SIGKILL between the
+# key and the unkey left the rig transmitting with nothing in the product able
+# to stop it; and the raw OFF could de-key another owner's *managed*
+# transmission behind the supervisor's back (the MOR-1179 class of defect). The
+# legacy write survives only where ``ManagedTxApi.bind`` returns ``None`` — a
+# positive finding that the backend is unmanaged, never a fallback from a
+# failed read.
+#
+# ``_actuate_tuner_tune`` asserts no PTT and is a documented carve-out; its
+# docstring carries the reasoning and the named residual risk.
 # ---------------------------------------------------------------------------
+
+
+def _tx_refusal(transition: TxTransition, action: str) -> str | None:
+    """An operator-facing reason when the supervisor refused, else ``None``."""
+    if transition.outcome in _TX_ACCEPTED_OUTCOMES:
+        return None
+    return f"managed TX refused the {action} ({transition.outcome})"
+
+
+async def _release_validation_lease(
+    managed: ManagedTxApi,
+    evidence: dict[str, object],
+    *,
+    per_check_timeout: float,
+) -> bool:
+    """Hand this harness's TX lease back. ALWAYS attempted, never gated.
+
+    Called even after a REFUSED key: an unkey withheld on the theory that
+    nothing was keyed is how a transmitter gets stranded, and asking the
+    supervisor to release a lease this owner never took is free (it answers
+    ``STALE`` and touches no wire).
+
+    A refusal is recorded, never escalated. ``force_unkey`` exists for a rig an
+    *external* process left keyed (MOR-1182); reaching for it here would let
+    the validation harness adopt — and de-key — a live transmission belonging
+    to somebody else. This tool only ever releases keys it took itself.
+    """
+    try:
+        transition = await asyncio.wait_for(
+            managed.set_ptt(False), timeout=per_check_timeout
+        )
+    except _RESTORE_ERRORS as exc:
+        evidence["unkey_error"] = str(exc)
+        return False
+    refusal = _tx_refusal(transition, "release")
+    if refusal is not None:
+        evidence["unkey_error"] = refusal
+        return False
+    return True
 
 
 async def _actuate_tx_ptt(
@@ -543,6 +612,11 @@ async def _actuate_tx_ptt(
     never raises (contained by ``_RESTORE_ERRORS``, which includes ``OSError``),
     so a mid-check exception/timeout/LAN drop can never leave the radio keyed or
     at the wrong power.
+
+    MOR-1222: on a managed rig both the key and the unkey go through the
+    supervisor under :data:`_VALIDATION_TX_OWNER`. A refused key is a FAIL, not
+    a licence to write PTT directly — the supervisor refuses precisely when
+    somebody else is on the air, which is the one moment a raw key is worst.
     """
     _set_ptt_attr = getattr(radio, "set_ptt", None)
     if not callable(_set_ptt_attr):
@@ -552,6 +626,11 @@ async def _actuate_tx_ptt(
             evidence={"reason": "radio has no set_ptt op"},
         )
     set_ptt = cast(Callable[[bool], Awaitable[None]], _set_ptt_attr)
+    # Bound before the power dance so a backend whose ``managed_tx`` accessor
+    # raises fails the check with the rig still un-keyed. The run loop's
+    # backstop turns that into an errored check; it must never read as
+    # "unmanaged" and hand a supervised rig to the legacy write (MOR-1193).
+    managed = ManagedTxApi.bind(radio, _VALIDATION_TX_OWNER)
 
     _get_power_attr = getattr(radio, "get_rf_power", None)
     _set_power_attr = getattr(radio, "set_rf_power", None)
@@ -559,11 +638,16 @@ async def _actuate_tx_ptt(
     get_power = cast(Callable[[], Awaitable[int]], _get_power_attr)
     set_power = cast(Callable[[int], Awaitable[None]], _set_power_attr)
 
-    evidence: dict[str, object] = {"tx_actuated": True, "keyed": False}
+    evidence: dict[str, object] = {
+        "tx_actuated": True,
+        "keyed": False,
+        "managed_tx": managed is not None,
+    }
     original_power: int | None = None
     power_set_to_min = False
     keyed = False
     verify_error: str | None = None
+    key_refusal: str | None = None
 
     if has_power:
         original_power, fail = await _guard(
@@ -599,26 +683,42 @@ async def _actuate_tx_ptt(
         )
 
     try:
-        # Key the transmitter.
-        await asyncio.wait_for(set_ptt(True), timeout=per_check_timeout)
-        keyed = True
-        # Brief, bounded key window.
-        await asyncio.sleep(_TX_PTT_KEY_SECONDS)
-        # Verify the keyed state from published radio state (best-effort).
-        evidence["ptt_state"] = bool(radio.radio_state.ptt)
-        keyed = bool(radio.radio_state.ptt)
-        evidence["keyed"] = keyed
+        # Key the transmitter — through the supervisor when there is one, so
+        # the emission carries a lease, an owner and a max-key-down watchdog.
+        if managed is None:
+            await asyncio.wait_for(set_ptt(True), timeout=per_check_timeout)
+        else:
+            transition = await asyncio.wait_for(
+                managed.set_ptt(True), timeout=per_check_timeout
+            )
+            key_refusal = _tx_refusal(transition, "key")
+            if key_refusal is not None:
+                evidence["key_refused"] = key_refusal
+        if key_refusal is None:
+            keyed = True
+            # Brief, bounded key window.
+            await asyncio.sleep(_TX_PTT_KEY_SECONDS)
+            # Verify the keyed state from published radio state (best-effort).
+            evidence["ptt_state"] = bool(radio.radio_state.ptt)
+            keyed = bool(radio.radio_state.ptt)
+            evidence["keyed"] = keyed
     except _RESTORE_ERRORS as exc:
         verify_error = str(exc)
         evidence["actuate_error"] = verify_error
     finally:
         # ALWAYS unkey, no matter what — the radio must never be left keyed.
+        # Never gated on whether the key was believed to succeed.
         unkeyed = False
-        try:
-            await asyncio.wait_for(set_ptt(False), timeout=per_check_timeout)
-            unkeyed = True
-        except _RESTORE_ERRORS as exc:
-            evidence["unkey_error"] = str(exc)
+        if managed is not None:
+            unkeyed = await _release_validation_lease(
+                managed, evidence, per_check_timeout=per_check_timeout
+            )
+        else:
+            try:
+                await asyncio.wait_for(set_ptt(False), timeout=per_check_timeout)
+                unkeyed = True
+            except _RESTORE_ERRORS as exc:
+                evidence["unkey_error"] = str(exc)
         evidence["unkeyed"] = unkeyed
         # ALWAYS restore the original power if we lowered it.
         power_restored = not power_set_to_min
@@ -636,6 +736,16 @@ async def _actuate_tx_ptt(
                 evidence["power_restore_error"] = str(exc)
         evidence["power_restored"] = power_restored
 
+    if key_refusal is not None:
+        # The supervisor said no. Reported as a failed check — the one thing
+        # that must NOT happen is a retry through the raw provider write.
+        return _base_result(
+            entry,
+            CheckStatus.FAIL,
+            failure_domain=FailureDomain.COMMAND_EXECUTION,
+            evidence=evidence,
+            error=f"refusing to transmit: {key_refusal}",
+        )
     if verify_error is not None:
         return _base_result(
             entry,
@@ -668,6 +778,22 @@ async def _actuate_tuner_tune(
     settle window, read the tuner status back (best-effort), and record it. A
     NAK/timeout-free trigger is the PASS signal — the radio's own readback can
     report transient/idle states once the cycle completes.
+
+    **Documented carve-out from MOR-1222's managed-TX routing.** Unlike
+    ``tx.ptt``, this path asserts no PTT: the radio's own firmware keys, sweeps
+    and unkeys autonomously once the tune command lands, so the emission is an
+    EXTERNAL-class RF event the supervisor observes rather than one an ingress
+    causes. Wrapping it in a supervisor lease would make it strictly more
+    dangerous, not less — taking the lease writes PTT ON at the *operator's*
+    power into a load that is by definition unmatched, a key legacy never
+    asserted and one that sits outside the minimum-power-first mitigation
+    MOR-1165 Auditor A credited for this module. So this actuator keeps the
+    legacy behaviour verbatim (``set_tuner_status`` only, no lease, no PTT
+    write) under Auditor A's sanctioned alternative for this site: an explicit
+    carve-out with its residual risk named. Residual risk: the tune cycle runs
+    with no lease and therefore no ``BACKEND_MAX_KEY_DOWN``; it is bounded
+    instead by the rig's own firmware timeout, by ``tuner_allowed`` plus the
+    full ``--tx-actuate`` gate stack, and by the interactive ``confirm()``.
     """
     _set_tuner_attr = getattr(radio, "set_tuner_status", None)
     if not callable(_set_tuner_attr):

--- a/tests/test_validation_hardware_tx.py
+++ b/tests/test_validation_hardware_tx.py
@@ -1,0 +1,387 @@
+"""Managed-TX routing for the ``validate`` hardware harness (MOR-1222).
+
+``validation/hardware.py`` is the last TX-causing surface that keyed the rig
+with a raw ``Radio.set_ptt`` write: no lease, so no ``BACKEND_MAX_KEY_DOWN``
+covering the key, and a raw OFF able to de-key another owner's *managed*
+transmission behind the supervisor's back (the MOR-1179 class of defect).
+
+These tests pin the three properties that fix has to hold:
+
+* a managed rig is keyed and unkeyed **only** through the supervisor, under a
+  stable validation owner;
+* an unmanaged rig keeps the legacy ordering verbatim;
+* a refused key fails the check and **never** retries through the raw write —
+  the supervisor refuses exactly when somebody else is on the air, which is the
+  one moment a raw key is worst.
+
+Every assertion is on the ordered call log shared by the radio and the
+supervisor, so a bypass shows up as a call in the wrong place rather than
+merely a missing one. No hardware is touched.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from rigplane.core.radio_protocol import Radio
+from rigplane.core.radio_state import RadioState
+from rigplane.core.tx_safety import (
+    TxOutcome,
+    TxOwner,
+    TxReleaseReason,
+    TxSafetySupervisor,
+    TxSource,
+    TxTransition,
+)
+from rigplane.validation.hardware import execute_hardware_checks
+from rigplane.validation.interactive import InteractivePrompter
+from rigplane.validation.schema import (
+    CapabilityDeclaration,
+    CapabilityDeclarationEntry,
+    CheckStatus,
+    MatrixTemplate,
+    OperatorSafetyBlock,
+    RadioTarget,
+    ValidationLevel,
+)
+
+_IDLE_TX_SNAPSHOT = TxSafetySupervisor().snapshot
+_FULL_SAFETY = OperatorSafetyBlock(tx_allowed=True, tuner_allowed=True)
+_START_POWER = 200
+
+
+class _RecordingSupervisor:
+    """A ``ManagedTxSupervisor`` that logs, answers, and mirrors PTT state.
+
+    Hand written rather than a ``MagicMock``: an ``AsyncMock`` satisfies a
+    ``runtime_checkable`` Protocol on 3.11 but not on 3.12+ (gh-102433), so a
+    mocked supervisor would make these tests pass for the wrong reason on one
+    interpreter and fail on the other.
+
+    ``request_on``/``release_owner`` mirror into ``RadioState.ptt`` because the
+    real supervisor owns the provider write: the harness reads that mirror back
+    to verify the rig actually keyed, and a fake that only records would make a
+    correctly routed key look like a failed one.
+    """
+
+    def __init__(
+        self,
+        log: list[tuple[str, object]],
+        state: RadioState,
+        *,
+        on: TxOutcome = TxOutcome.ACCEPTED,
+        off: TxOutcome = TxOutcome.ACCEPTED,
+    ) -> None:
+        self._log = log
+        self._state = state
+        self._on = on
+        self._off = off
+        self.owners: list[TxOwner] = []
+        self.reasons: list[TxReleaseReason] = []
+
+    async def request_on(self, owner: TxOwner) -> TxTransition:
+        self.owners.append(owner)
+        self._log.append(("supervisor.request_on", owner))
+        if self._on in (TxOutcome.ACCEPTED, TxOutcome.IDEMPOTENT):
+            self._state.ptt = True
+        return TxTransition(self._on, _IDLE_TX_SNAPSHOT)
+
+    async def release_owner(
+        self, owner: TxOwner, *, reason: TxReleaseReason
+    ) -> TxTransition:
+        self.owners.append(owner)
+        self.reasons.append(reason)
+        self._log.append(("supervisor.release_owner", owner))
+        if self._off in (TxOutcome.ACCEPTED, TxOutcome.IDEMPOTENT):
+            self._state.ptt = False
+        return TxTransition(self._off, _IDLE_TX_SNAPSHOT)
+
+
+def _tx_radio(
+    *,
+    managed: bool,
+    on: TxOutcome = TxOutcome.ACCEPTED,
+    off: TxOutcome = TxOutcome.ACCEPTED,
+):
+    """Stateful fake rig plus the ordered log of everything it was asked to do.
+
+    ``managed_tx`` is assigned as a real instance attribute, which is what
+    ``getattr_static`` (used by ``ManagedTxApi.bind``) requires: a value
+    conjured by ``__getattr__`` reads as absent there, and an unmanaged rig
+    must have no such member at all rather than a mock child.
+    """
+    log: list[tuple[str, object]] = []
+    state = RadioState()
+    power = {"value": _START_POWER}
+
+    radio = MagicMock(spec=Radio)
+    radio.connected = True
+    radio.model = "X6200"
+    radio.capabilities = {"tx", "tuner"}
+    radio.radio_state = state
+
+    async def _set_ptt(value: bool) -> None:
+        log.append(("radio.set_ptt", bool(value)))
+        state.ptt = bool(value)
+
+    async def _get_rf_power() -> int:
+        log.append(("radio.get_rf_power", power["value"]))
+        return power["value"]
+
+    async def _set_rf_power(level: int) -> None:
+        log.append(("radio.set_rf_power", int(level)))
+        power["value"] = int(level)
+
+    async def _set_tuner_status(value: int) -> None:
+        log.append(("radio.set_tuner_status", int(value)))
+        state.tuner_status = int(value)
+
+    async def _get_tuner_status() -> int:
+        log.append(("radio.get_tuner_status", state.tuner_status))
+        return state.tuner_status
+
+    radio.set_ptt = AsyncMock(side_effect=_set_ptt)
+    radio.get_rf_power = AsyncMock(side_effect=_get_rf_power)
+    radio.set_rf_power = AsyncMock(side_effect=_set_rf_power)
+    radio.set_tuner_status = AsyncMock(side_effect=_set_tuner_status)
+    radio.get_tuner_status = AsyncMock(side_effect=_get_tuner_status)
+
+    supervisor: _RecordingSupervisor | None = None
+    if managed:
+        supervisor = _RecordingSupervisor(log, state, on=on, off=off)
+        radio.managed_tx = supervisor
+    return radio, supervisor, log, power
+
+
+def _tx_template() -> MatrixTemplate:
+    return MatrixTemplate(
+        radio=RadioTarget(model="X6200", profile_id="x6200"),
+        entries=[
+            CapabilityDeclarationEntry(
+                check_id="tx.ptt",
+                capability="tx",
+                level=ValidationLevel.STRESS_RECOVERY,
+                declaration=CapabilityDeclaration.MANUAL_REQUIRED,
+                summary="ptt",
+                tx_adjacent=True,
+            ),
+            CapabilityDeclarationEntry(
+                check_id="tuner.tune",
+                capability="tuner",
+                level=ValidationLevel.STRESS_RECOVERY,
+                declaration=CapabilityDeclaration.MANUAL_REQUIRED,
+                summary="tuner tune",
+                tx_adjacent=True,
+            ),
+        ],
+    )
+
+
+def _confirm_yes() -> InteractivePrompter:
+    return InteractivePrompter(input_fn=lambda _p: "YES", output_fn=lambda _m: None)
+
+
+async def _run(radio):
+    levels = await execute_hardware_checks(
+        radio,
+        _tx_template(),
+        _FULL_SAFETY,
+        allow_writes=True,
+        tx_actuate=True,
+        prompter=_confirm_yes(),
+    )
+    return {check.check_id: check for level in levels for check in level.checks}
+
+
+def _names(log: list[tuple[str, object]]) -> list[str]:
+    return [name for name, _payload in log]
+
+
+# ---------------------------------------------------------------------------
+# 1. Managed rig — every emission goes through the supervisor.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_managed_rig_keys_and_unkeys_through_the_supervisor():
+    radio, supervisor, log, power = _tx_radio(managed=True)
+
+    checks = await _run(radio)
+
+    ptt = checks["tx.ptt"]
+    assert ptt.status is CheckStatus.PASS
+    assert ptt.evidence["managed_tx"] is True
+    assert ptt.evidence["keyed"] is True
+    assert ptt.evidence["unkeyed"] is True
+
+    # The one property the whole ticket exists for: not a single raw provider
+    # write. The supervisor's own effect path is the only thing entitled to it.
+    assert radio.set_ptt.await_count == 0
+
+    # Ordered, not merely present: the lease is taken AFTER power is at minimum
+    # and handed back BEFORE power is restored.
+    assert _names(log) == [
+        "radio.get_rf_power",
+        "radio.set_rf_power",  # -> minimum
+        "supervisor.request_on",
+        "supervisor.release_owner",
+        "radio.set_rf_power",  # -> restored
+        "radio.set_tuner_status",
+        "radio.get_tuner_status",
+    ]
+    assert power["value"] == _START_POWER
+    assert radio.radio_state.ptt is False
+
+
+@pytest.mark.asyncio
+async def test_every_lease_is_taken_under_one_stable_validation_owner():
+    """One identity for the whole run, or a release cannot match its own key."""
+    radio, supervisor, _log, _power = _tx_radio(managed=True)
+
+    await _run(radio)
+
+    assert supervisor is not None
+    assert len(supervisor.owners) == 2  # key + release, for the one PTT check
+    assert len(set(supervisor.owners)) == 1
+    owner = supervisor.owners[0]
+    # `TxSource` gains no validation member: the harness is an in-process
+    # consumer of the public SDK surface, exactly as the CLI is (MOR-1170).
+    assert owner.source is TxSource.SDK
+    assert owner.session_id.startswith("validation:")
+    assert supervisor.reasons == [TxReleaseReason.OPERATOR_RELEASE]
+
+
+@pytest.mark.asyncio
+async def test_the_tuner_tune_cycle_takes_no_lease_and_asserts_no_ptt():
+    """The documented carve-out, pinned so it cannot drift back either way.
+
+    ``tuner.tune`` is the one TX-causing actuator MOR-1222 deliberately leaves
+    on the legacy path: the rig's firmware keys, sweeps and unkeys itself, so
+    the emission is an EXTERNAL-class event rather than an ingress assertion.
+    Taking a lease around it would write PTT ON at the *operator's* power into
+    a by-definition unmatched load — a key legacy never asserted, and one
+    outside the minimum-power-first mitigation this module is credited for.
+    """
+    radio, supervisor, log, _power = _tx_radio(managed=True)
+
+    checks = await _run(radio)
+
+    tune = checks["tuner.tune"]
+    assert tune.status is CheckStatus.PASS
+    assert tune.evidence["tune_triggered"] is True
+    # No lease is claimed for the tune cycle, and it carries no managed-TX
+    # evidence key at all — it is not routed, by design.
+    assert "managed_tx" not in tune.evidence
+
+    # Ordered log, from the tune command onwards: the cycle is triggered and
+    # read back with no supervisor entry after the PTT check released its lease.
+    names = _names(log)
+    tail = names[names.index("radio.set_tuner_status") :]
+    assert tail == ["radio.set_tuner_status", "radio.get_tuner_status"]
+    assert "supervisor.request_on" not in tail
+    # Exactly one lease in the whole run, and it belongs to `tx.ptt`.
+    assert names.count("supervisor.request_on") == 1
+    assert radio.set_ptt.await_count == 0
+    assert radio.radio_state.ptt is False
+
+
+# ---------------------------------------------------------------------------
+# 2. Unmanaged rig — the legacy path, verbatim.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unmanaged_rig_keeps_the_legacy_direct_write_verbatim():
+    radio, supervisor, log, power = _tx_radio(managed=False)
+
+    checks = await _run(radio)
+
+    assert supervisor is None
+    assert checks["tx.ptt"].status is CheckStatus.PASS
+    assert checks["tx.ptt"].evidence["managed_tx"] is False
+    assert checks["tuner.tune"].status is CheckStatus.PASS
+    assert "managed_tx" not in checks["tuner.tune"].evidence  # carve-out
+
+    # Same ops, same order, same values as before MOR-1222 — an unmanaged
+    # backend must not notice that the managed path exists.
+    assert log == [
+        ("radio.get_rf_power", _START_POWER),
+        ("radio.set_rf_power", 0),
+        ("radio.set_ptt", True),
+        ("radio.set_ptt", False),
+        ("radio.set_rf_power", _START_POWER),
+        ("radio.set_tuner_status", 2),
+        ("radio.get_tuner_status", 2),
+    ]
+    assert power["value"] == _START_POWER
+    assert radio.radio_state.ptt is False
+
+
+# ---------------------------------------------------------------------------
+# 3. Refused key — fail closed, never bypass an active supervisor.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "refusal",
+    [
+        TxOutcome.BUSY,  # another owner holds the rig
+        TxOutcome.NOT_READY,
+        TxOutcome.RADIO_NOT_OFF,
+        TxOutcome.RELEASE_PENDING,
+    ],
+)
+@pytest.mark.asyncio
+async def test_a_refused_key_fails_the_check_and_never_falls_back_to_a_raw_key(
+    refusal,
+):
+    radio, supervisor, log, _power = _tx_radio(managed=True, on=refusal)
+
+    checks = await _run(radio)
+
+    ptt = checks["tx.ptt"]
+    assert ptt.status is CheckStatus.FAIL
+    assert refusal.value in str(ptt.error)
+    assert refusal.value in str(ptt.evidence["key_refused"])
+    assert ptt.evidence["keyed"] is False
+
+    # Fail closed. No raw key anywhere, and no raw OFF either: writing OFF here
+    # would de-key whatever the supervisor was protecting (MOR-1179).
+    assert radio.set_ptt.await_count == 0
+    # Exactly one key attempt and one release — no retry, no second identity.
+    assert [name for name in _names(log) if name.startswith("supervisor.")] == [
+        "supervisor.request_on",
+        "supervisor.release_owner",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_the_release_is_attempted_even_after_the_key_was_refused():
+    """Never gated. An unkey withheld because "nothing was keyed" strands rigs."""
+    radio, supervisor, log, _power = _tx_radio(managed=True, on=TxOutcome.BUSY)
+
+    await _run(radio)
+
+    assert supervisor is not None
+    assert _names(log).count("supervisor.release_owner") == 1
+
+
+@pytest.mark.asyncio
+async def test_a_refused_release_is_recorded_and_never_escalated_to_force():
+    """``force_unkey`` is for keys this process did not take (MOR-1182).
+
+    Reaching for it here would let the validation harness adopt — and de-key —
+    a live transmission belonging to somebody else. ``_RecordingSupervisor``
+    has no ``force_unkey`` at all, so any escalation is an ``AttributeError``.
+    """
+    radio, _supervisor, _log, _power = _tx_radio(managed=True, off=TxOutcome.STALE)
+
+    checks = await _run(radio)
+
+    ptt = checks["tx.ptt"]
+    assert ptt.evidence["unkeyed"] is False
+    assert TxOutcome.STALE.value in str(ptt.evidence["unkey_error"])
+    assert ptt.status is CheckStatus.FAIL
+    assert radio.set_ptt.await_count == 0


### PR DESCRIPTION
## Summary

MOR-1165 audit Round 1 finding **A5-1** (Medium): `validation/hardware.py` keyed the transmitter via raw `set_ptt`, outside the managed supervisor and outside the permitted legacy set. The two PTT actuation sites (`:603`/`:618` at the audit base) now bind `ManagedTxApi` with a process-scoped `TxOwner(TxSource.SDK, "validation:<uuid>")` — mirroring the CLI ingress precedent (`_CLI_TX_OWNER`, MOR-1170) — when the radio publishes a managed runtime; the legacy write survives only when unmanaged; unkeys are never gated; a refused lease fails the validation step **closed** (no raw fallback past an active supervisor).

Linear: [MOR-1222](https://linear.app/morozsm/issue/MOR-1222).

**`_actuate_tuner_tune` deliberately keeps its legacy body byte-identical** (docstring-only carve-out): the radio-internal tune cycle keys autonomously (EXTERNAL-class RF event, `TxPhase.EXTERNAL_UNOWNED`), and wrapping it in a supervisor lease would assert an operator-power key into an unmatched load that legacy never had. This follows the audit's sanctioned alternative for that site; the first draft that did add a tuner lease was BLOCKED by the independent verifier on exactly this hazard and reverted.

## Classification & cap note

Production +126 net LOC; combined +513 with the 10-test battery — over the audit's ≤200 remediation cap, therefore classified per the contract's own provision as **new work under its own ticket with its own review** (this PR), not a §5 remediation slice. The classification affects the audit restart's record-keeping only.

## Evidence

- Builder: full suite **8751 passed / 0 failed**; new file 10 passed; ruff/format/mypy/lint-imports clean. `ManagedTxApi.bind` chosen over `runtime/managed_tx_ingress` deliberately — verifier confirmed it is *required* (`_stable_owner` maps only websocket/rigctld and would silently return None) and preserves the module's core-only import contract.
- Independent verifier (separate agent context, non-author; one BLOCKED round on the tuner-lease hazard, then PASS): tuner body byte-identity proven via AST-extracted body hash vs base; carve-out docstring fact-checked against `tx_safety.py`; mutation battery — routing-revert, refusal-fallback, unkey-gating, per-actuation owner, tuner-lease re-add, raw-tuner-PTT-leak — all killed except one non-blocking test-witness nicety (m5, recorded in the review with a one-line hardening suggestion). Review posted as a PR comment.

**Live-validation note:** the managed `--tx-actuate` path on real hardware (IC-7610/X6200) remains owner-gated and should get a live pass in the post-cutover hardware window.

Software evidence only; MOR-1033 remains the FTX-1 hardware gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
