### PR TITLE
fix(MOR-1220): max-key-down backstop for unmanaged radios

### DIFF
--- a/src/rigplane/core/tx_safety.py
+++ b/src/rigplane/core/tx_safety.py
@@ -18,6 +18,12 @@ from typing import TypeAlias
 Clock = Callable[[], float]
 IdFactory = Callable[[], str]
 
+#: Longest a managed key-down may last before the watchdog releases it with
+#: :attr:`TxReleaseReason.BACKEND_MAX_KEY_DOWN`. Named, not inlined as a default,
+#: because ``web.radio_poller``'s unmanaged backstop (MOR-1220) is the SAME
+#: bound: one key-down limit per operator, not one per backend class.
+BACKEND_MAX_KEY_DOWN_SECONDS: float = 180.0
+
 
 class TxSource(StrEnum):
     WEBSOCKET = "websocket"
@@ -221,7 +227,7 @@ class TxSafetySupervisor:
         *,
         clock: Clock | None = None,
         id_factory: IdFactory | None = None,
-        watchdog_seconds: float | None = 180.0,
+        watchdog_seconds: float | None = BACKEND_MAX_KEY_DOWN_SECONDS,
         write_timeout_seconds: float = 2.0,
         read_timeout_seconds: float = 2.0,
         cancel_timeout_seconds: float = 0.5,

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -89,7 +89,7 @@ from ..core.state_pipeline_contracts import (
 from ..core.radio_protocol import ManagedTxApi
 from ..core.state_diagnostics import StateDiagnosticsRecorder
 from ..core.state_store import StateStore
-from ..core.tx_safety import TxOutcome
+from ..core.tx_safety import BACKEND_MAX_KEY_DOWN_SECONDS, TxOutcome
 from .._state_queries import build_state_queries
 from ..profiles import RadioProfile, resolve_radio_profile
 from ..runtime.managed_tx_ingress import bind_managed_tx, refuse_key_without_owner
@@ -197,6 +197,15 @@ _KEY_ACCEPTED = frozenset({TxOutcome.ACCEPTED, TxOutcome.IDEMPOTENT})  # lease i
 # the disconnect that then spends that 5 s on the managed release. 2.0 s matches
 # every other bound there and dwarfs a fire-and-forget CI-V unkey.
 _SHUTDOWN_TX_DRAIN_TIMEOUT_S: float = 2.0
+
+# MOR-1220: max key-down for a radio that arms NO supervisor — every shipped
+# serial/USB Icom backend (``_IcomSerialRadioBase.connect`` never calls
+# ``_arm_managed_tx``). Since MOR-1011/1012 deleted the frontend's 3-minute
+# ``PTT_SAFETY_MS`` timers those rigs had NO key-down bound anywhere in the
+# product. Restored here, where the key is issued, at the managed watchdog's own
+# duration — imported, not re-spelled. The managed path keeps its own bound; a
+# key this poller never issued is not its to time out.
+_MAX_KEY_DOWN_SECONDS: float = BACKEND_MAX_KEY_DOWN_SECONDS
 
 # MOR-874: how long a healthy-link in-flight acquisition request may stay
 # suppressed after its FIRST send-relative deadline expiry before being
@@ -478,6 +487,10 @@ class RadioPoller:
         # MOR-615: (main, sub) data_mode pair seen at the last MOD-input fetch;
         # a change triggers a refetch of the per-DATA-group MOD-input sources.
         self._mod_input_data_modes: tuple[int, int] | None = None
+        # MOR-1220: the unmanaged max-key-down backstop. Per-instance, so a new
+        # connect starts unarmed; overridable for tests.
+        self._max_key_down_seconds: float = _MAX_KEY_DOWN_SECONDS
+        self._max_key_down_timer: asyncio.TimerHandle | None = None
 
     def _apply_bsr_readback_observations(
         self,
@@ -557,6 +570,44 @@ class RadioPoller:
             **params,
         )
 
+    def _arm_max_key_down(self, source: CommandSource, session_id: str | None) -> None:
+        """Bound a key this poller just issued on an unmanaged radio (MOR-1220).
+
+        Restart-on-key: a re-key replaces the pending bound. The key's ingress
+        identity rides along, so the forced unkey binds what the operator's own
+        unkey would have.
+        """
+        self._cancel_max_key_down()
+        seconds = self._max_key_down_seconds
+        self._max_key_down_timer = asyncio.get_running_loop().call_later(
+            seconds, self._on_max_key_down, seconds, source, session_id
+        )
+
+    def _cancel_max_key_down(self) -> None:
+        """Disarm the backstop; safe to call when nothing is armed."""
+        if self._max_key_down_timer is not None:
+            self._max_key_down_timer.cancel()
+            self._max_key_down_timer = None
+
+    def _on_max_key_down(
+        self, seconds: float, source: CommandSource, session_id: str | None
+    ) -> None:
+        """Force the unkey the operator did not send.
+
+        ENQUEUED, never written here: the loop then gives it the audio teardown
+        and the managed/legacy split every other unkey gets, and a shutdown
+        racing this expiry finds a ``PttOff`` in the queue — exactly what
+        MOR-1181's drain exists to deliver.
+        """
+        self._max_key_down_timer = None
+        logger.error(
+            "radio-poller: max key-down (%gs) exceeded on unmanaged radio; "
+            "forcing unkey",
+            seconds,
+        )
+        self._queue.put(PttOff(), source=source, session_id=session_id)
+        self._emit("tx_max_key_down", {"seconds": seconds, "session_id": session_id})
+
     def start(self) -> None:
         if self._task is not None and not self._task.done():
             return
@@ -574,6 +625,12 @@ class RadioPoller:
         caller keeps the poller and awaits :meth:`drain_tx_safety_commands` once
         those tasks have been gathered (MOR-1181, ``stop_web_server``).
         """
+        # MOR-1220: an unfired backstop must not outlive its poller. What it
+        # enqueued BEFORE this survives — a ``PttOff`` the final drain still
+        # delivers — but minting one after promises what nothing is left to keep.
+        # On this path the teardown ``PttOff`` is the whole cover for an
+        # unmanaged rig: ``CoreRadio.disconnect`` de-keys the managed path only.
+        self._cancel_max_key_down()
         if self._task is not None:
             self._task.cancel()
             self._task = None
@@ -1201,6 +1258,10 @@ class RadioPoller:
             # transmitter. Covers every cancellation of this task; the shutdown
             # ORDERING — the teardown unkey is not enqueued until long after
             # this runs — is the caller's half, in ``stop_web_server``.
+            # MOR-1220: same disarm as ``stop()`` — this covers cancellations
+            # that never went through it. Ahead of the drain, which still
+            # delivers an expiry already in the queue.
+            self._cancel_max_key_down()
             await self.drain_tx_safety_commands()
         except Exception:
             logger.exception(
@@ -1571,6 +1632,11 @@ class RadioPoller:
                         await self._stop_tx_audio_leg()
                         raise
                     await radio.set_ptt(True)
+                    # MOR-1220: only now, and only here. After the write, so a
+                    # key that never reached the rig arms no bound; on this arm
+                    # only, so the managed path keeps the supervisor's watchdog
+                    # as its single bound and an EXTERNAL key stays untouched.
+                    self._arm_max_key_down(command_source, session_id)
                 else:
                     transition = await managed.set_ptt(True)
                     if transition.outcome not in _KEY_ACCEPTED:
@@ -1611,6 +1677,11 @@ class RadioPoller:
                         # another owner holds the lease. Neither is actionable,
                         # and raising would break defensive unkeys in ``finally``.
                         await managed.set_ptt(False)
+                    # MOR-1220: every unkey this poller issues disarms the
+                    # backstop — operator, teardown and drain all reach here.
+                    # Below the write, never in the ``finally``: an unkey that
+                    # RAISED left the rig keyed, and must not drop the bound.
+                    self._cancel_max_key_down()
                 finally:
                     await self._stop_tx_audio_leg()
             case SetPower(level=level, unit=unit):

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+from collections.abc import Callable
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -73,7 +75,12 @@ from rigplane.web.radio_poller import (
     VfoEqualize,
     VfoSwap,
 )
-from rigplane.core.tx_safety import TxOutcome, TxOwner, TxSource
+from rigplane.core.tx_safety import (
+    BACKEND_MAX_KEY_DOWN_SECONDS,
+    TxOutcome,
+    TxOwner,
+    TxSource,
+)
 from rigplane.web.handlers.control import ControlHandler
 from rigplane.web.web_startup import stop_web_server
 
@@ -3251,3 +3258,145 @@ async def test_server_shutdown_delivers_the_unkey_its_client_enqueues_late() -> 
     assert supervisor.outcomes[-1] is TxOutcome.ACCEPTED
     assert radio.calls == ["start_tx", *_TEARDOWN]
     assert queue.has_commands is False
+
+
+# --- MOR-1220: the unmanaged max-key-down backstop -------------------------
+# MOR-1165 finding A1-1: shipped serial/USB Icom backends arm no supervisor, and
+# MOR-1011/1012 deleted the frontend's 3-minute PTT timers, so a latched web TX
+# on one had no key-down limit anywhere. These pin the bound that restores it —
+# at the poller, legacy arm only, through the queue MOR-1181's drain reads.
+
+_BACKSTOP = 0.05  # test-scale stand-in for BACKEND_MAX_KEY_DOWN_SECONDS
+
+
+async def _until(ready: Callable[[], bool], timeout: float = 2.0) -> None:
+    """Wait on *ready*, so no test here sleeps out the real 180 s bound."""
+    deadline = time.monotonic() + timeout
+    while not ready():
+        assert time.monotonic() < deadline, "condition never became true"
+        await asyncio.sleep(0.005)
+
+
+def _keyed(supervisor: _Supervisor | None) -> tuple[RadioPoller, _Radio, CommandQueue]:
+    """A poller on a test-scale bound, its real loop running, PTT ON queued."""
+    poller, radio, queue = _tx_poller(supervisor)
+    poller._max_key_down_seconds = _BACKSTOP  # noqa: SLF001
+    poller.start()
+    queue.put(PttOn(), source="websocket", session_id="ws-1")
+    return poller, radio, queue
+
+
+@pytest.mark.asyncio
+async def test_backstop_forces_the_unkey_a_latched_legacy_key_never_sends(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A1-1's case: an unmanaged rig keyed and never unkeyed. The bound takes it
+    off the air through the real loop, names it at ERROR, and surfaces it on the
+    state-event lane the operator's UI reads."""
+    events: list[tuple[str, dict[str, Any]]] = []
+    poller, radio, _ = _keyed(None)
+    poller._on_state_event = lambda n, d: events.append((n, d))  # noqa: SLF001
+
+    with caplog.at_level(logging.ERROR, logger="rigplane.web.radio_poller"):
+        await _until(lambda: radio.calls[-1:] == ["restart_rx"])  # incl. teardown
+    poller.stop()
+
+    assert radio.calls == [*_KEY, "set_ptt(False)", *_TEARDOWN]
+    assert "max key-down (0.05s) exceeded on unmanaged radio; forcing" in caplog.text
+    assert events[-1] == (
+        "tx_max_key_down",
+        {"seconds": _BACKSTOP, "session_id": "ws-1"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_an_operator_unkey_disarms_the_backstop() -> None:
+    """A backstop, not a second unkey: a forced unkey after the operator's own
+    would, on a re-key, take the NEXT transmission off the air."""
+    poller, radio, queue = _keyed(None)
+    queue.put(PttOff(), source="websocket", session_id="ws-1")
+
+    await _until(lambda: "set_ptt(False)" in radio.calls)
+    await asyncio.sleep(_BACKSTOP * 4)  # well past the disarmed expiry
+    poller.stop()
+
+    assert radio.calls == [*_KEY, "set_ptt(False)", *_TEARDOWN]  # exactly one
+    assert poller._max_key_down_timer is None  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_the_managed_path_arms_no_backstop() -> None:
+    """The supervisor owns the managed bound (``BACKEND_MAX_KEY_DOWN``, driven by
+    the runtime ticker); a second timer here de-keys a lease it does not hold."""
+    supervisor = _Supervisor()
+    poller, radio, _ = _keyed(supervisor)
+
+    await _until(lambda: radio.calls == ["start_tx"])
+    await asyncio.sleep(_BACKSTOP * 4)  # long enough for a wrongly-armed bound
+    poller.stop()
+
+    assert poller._max_key_down_timer is None  # noqa: SLF001
+    assert radio.calls == ["start_tx"]  # no raw unkey behind the supervisor
+    assert supervisor.entries == [(True, TxOwner(TxSource.WEBSOCKET, "ws-1"))]
+
+
+@pytest.mark.asyncio
+async def test_an_expiry_that_races_shutdown_is_delivered_by_the_drain() -> None:
+    """Why the expiry ENQUEUES: shutdown stops the loop at step 1 and drains at
+    step 9 (MOR-1181), so an unkey already minted rides that drain out."""
+    poller, radio, queue = _tx_poller(None)
+    poller._max_key_down_seconds = _BACKSTOP  # noqa: SLF001
+    await poller._execute(PttOn(), session_id="ws-1")  # noqa: SLF001
+
+    await _until(lambda: queue.has_commands)  # the expiry minted it, undrained
+    poller.stop()  # shutdown races it
+    assert radio.calls == _KEY  # nothing delivered it yet
+    await poller.drain_tx_safety_commands()
+
+    assert radio.calls == [*_KEY, "set_ptt(False)", *_TEARDOWN]
+
+
+@pytest.mark.asyncio
+async def test_a_retired_pollers_backstop_does_not_leak_into_the_next_connect() -> None:
+    """A new connect builds a new poller (``start_web_server``); the retired
+    one's unfired bound must not outlive it — nothing reads that queue again."""
+    retired, radio, queue = _tx_poller(None)
+    retired._max_key_down_seconds = _BACKSTOP  # noqa: SLF001
+    await retired._execute(PttOn(), session_id="ws-1")  # noqa: SLF001
+    retired.stop()
+
+    fresh = RadioPoller(radio, queue)  # type: ignore[arg-type]
+    await asyncio.sleep(_BACKSTOP * 4)  # past the retired bound
+
+    assert retired._max_key_down_timer is None  # noqa: SLF001
+    assert fresh._max_key_down_timer is None  # noqa: SLF001
+    assert queue.has_commands is False  # the retired timer minted nothing
+    assert radio.calls == _KEY
+    bound = fresh._max_key_down_seconds  # noqa: SLF001  (production, not test)
+    assert bound == BACKEND_MAX_KEY_DOWN_SECONDS == 180.0
+
+
+@pytest.mark.asyncio
+async def test_a_lost_operator_unkey_keeps_the_backstop_armed() -> None:
+    """Why the disarm sits BELOW the write: an unkey that RAISED did not reach the
+    rig, and dropping the bound on it strands a keyed transmitter."""
+    poller, radio, queue = _keyed(None)
+    poller._max_key_down_seconds = 0.4  # noqa: SLF001  (outlast the lost unkey)
+    eaten: list[bool] = []
+
+    async def _lossy_set_ptt(on: bool) -> None:  # the rig eats exactly ONE unkey
+        if not on and not eaten:
+            eaten.append(True)
+            radio.calls.append("set_ptt(False:LOST)")
+            raise ConnectionError("unkey never reached the rig")
+        await _Radio.set_ptt(radio, on)
+
+    radio.set_ptt = _lossy_set_ptt  # type: ignore[method-assign]
+    queue.put(PttOff(), source="websocket", session_id="ws-1")  # drains after the key
+    await _until(lambda: "set_ptt(False:LOST)" in radio.calls)
+
+    await _until(lambda: "set_ptt(False)" in radio.calls, timeout=6.0)
+    poller.stop()
+
+    lost, forced = ["set_ptt(False:LOST)", *_TEARDOWN], ["set_ptt(False)", *_TEARDOWN]
+    assert radio.calls == [*_KEY, *lost, *forced]


### PR DESCRIPTION
## Summary

MOR-1165 audit Round 1 lead finding **A1-1 (High)**, remediation route chosen by the owner: the four shipped serial/USB Icom backends key via the legacy poller branch with no lease, no owner arbitration, and — after MOR-1011/1012 deleted the 3-minute presentation timers — **no key-down limit anywhere in the product**. This restores a bound at the poller.

Linear: [MOR-1220](https://linear.app/morozsm/issue/MOR-1220). The full serial managed-arm design work is [MOR-1219](https://linear.app/morozsm/issue/MOR-1219) (this backstop then becomes defence-in-depth).

## Behavior

- The poller arms a **180 s** bound when it issues a legacy `set_ptt(True)` (`managed is None` path only).
- On expiry: a `PttOff` is **enqueued through the poller's own queue** — so MOR-1181's shutdown drain delivers it if a teardown races — with an ERROR log and a `tx_max_key_down` event.
- Any poller-issued unkey disarms the bound, **below the write**: an unkey that failed to reach the rig keeps the backstop armed, and it still fires (pinned by a dedicated test the verifier designed and proved).
- Managed-path keys (the supervisor owns `BACKEND_MAX_KEY_DOWN`) and external keys the poller never issued are untouched; `stop()`/`_run` cancellation disarm an unfired timer; no state leaks across reconnects.
- The 180 s value is single-sourced: `BACKEND_MAX_KEY_DOWN_SECONDS` extracted in `core/tx_safety.py` from the managed watchdog's inline default (zero behavior change, verified).

## Classification & cap note

226 net LOC / 3 files — 26 over the audit's ≤200 remediation cap, all of it the verifier-required disarm-ordering test (the rest of the diff was pre-condensed to exactly 200). Classified per the audit contract's provision as new work under its own ticket with its own review (this PR).

## Evidence

- Builder: full suite **8747 passed / 0 failed**; targeted 358 passed (MOR-1178/MOR-1181 test regions byte-identical); ruff/format/mypy/lint-imports clean.
- Independent verifier (separate agent context, non-author; one BLOCKED round, then PASS): fire-path state analysis across all four poller states (parked/mid-command/shutdown-racing/stopped — no state where the timer fires with neither an unkey nor an ERROR); disarm-ordering re-derivation; mutation battery — drop-expiry-unkey, drop-disarm, arm-on-managed, drop-stop-disarm, plus its own additions — all killed, including mutation G (disarm-above-write) which survived the first draft and is now killed by exactly the new `test_a_lost_operator_unkey_keeps_the_backstop_armed`. Review posted as a PR comment.

Software evidence only; MOR-1033 remains the FTX-1 hardware gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
