### PR TITLE
docs(MOR-1225): state the managed-TX boundary honestly everywhere

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -49,6 +49,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   panel unmounts, and on mobile also when the device rotates while latched
   (fail-closed).
 
+- **Max-key-down coverage after the presentation-timer removal (MOR-1220).**
+  The 3-minute presentation-local timers removed above were UI-side and
+  backend-agnostic, so deleting them (MOR-1011/MOR-1012) traded that
+  frontend bound for the managed TX runtime's own supervisor watchdog on the
+  managed path — coverage that only exists where a runtime is armed. A 180s
+  backstop (`BACKEND_MAX_KEY_DOWN_SECONDS`) is now armed around the legacy
+  PTT write on the web UI's Icom poller, so a serial/USB Icom rig keyed from
+  the Web UI is bounded again. Current boundary: managed TX is armed on the
+  LAN `IcomRadio` path only (the supervisor watchdog covers it everywhere,
+  not just Web); serial/USB Icom is legacy, covered only by this 180s
+  web-poller backstop, with full managed arm pending MOR-1219; Yaesu CAT,
+  the rigctld-client backend, and the CLI hold path (`ptt on --for`) are
+  legacy and unbounded on unmanaged rigs, pending MOR-1190 (acceptance
+  amended to include the key-down bound; MOR-1190 gates the MOR-1033 FTX-1
+  hardware cert in the same release).
+
 ### Removed
 
 - **`rigplane.backends.icom7610.drivers.serial_stub` no longer ships in the

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -511,7 +511,7 @@ Its exit code answers one question: did an unkey reach the radio?
 | `0` | An unkey reached the wire, or one was already in flight. |
 | `1` | rigplane did not get an unkey out — **the rig may still be transmitting.** |
 
-The refusal worth calling out is a busy radio. If another TX session holds a *live* lease on this rig, `ptt off` exits `1` and refuses rather than cutting that transmission off: recovering a stranded key is not the same thing as preempting somebody who is talking. Stop that session and retry, or wait for its max-key-down watchdog.
+The refusal worth calling out is a busy radio. If another TX session holds a *live* lease on this rig, `ptt off` exits `1` and refuses rather than cutting that transmission off: recovering a stranded key is not the same thing as preempting somebody who is talking. Stop that session and retry. On a managed rig (the LAN Icom path) you can also wait for its max-key-down watchdog; legacy serial/USB Icom, Yaesu CAT, and rigctld-client rigs have no such watchdog to wait for (pending MOR-1219/MOR-1190), so stopping the offending session is the only recovery there.
 
 !!! danger "Caution"
     Activating PTT will key your transmitter. Ensure your antenna is connected and you are authorized to transmit on the current frequency.

--- a/src/rigplane/cli/__init__.py
+++ b/src/rigplane/cli/__init__.py
@@ -520,10 +520,11 @@ def _ptt_hold_seconds(raw: str) -> float:
     Zero and negatives would key the rig for a hot-switch transient or not at
     all; ``inf`` and ``nan`` would turn a bounded flag into an unbounded hold.
     There is deliberately no upper bound: the 180 s key-down watchdog belongs
-    to ``TxSafetySupervisor``, is configurable there, and does not exist at
-    all on the unmanaged path every shipped radio still takes — a second limit
-    invented here would imply a guarantee the CLI cannot make. What bounds
-    this hold is the process, and interrupting it always unkeys.
+    to ``TxSafetySupervisor`` and is configurable there, but does not exist at
+    all on the unmanaged path a legacy serial/USB Icom, Yaesu CAT, or
+    rigctld-client radio still takes (pending MOR-1219/MOR-1190) — a second
+    limit invented here would imply a guarantee the CLI cannot make. What
+    bounds this hold is the process, and interrupting it always unkeys.
     """
     try:
         seconds = float(raw)

--- a/src/rigplane/core/radio_protocol.py
+++ b/src/rigplane/core/radio_protocol.py
@@ -538,12 +538,13 @@ class ManagedTxSupervisor(Protocol):
 class ManagedTxCapable(Protocol):
     """Radio that publishes a managed TX supervisor for every ingress.
 
-    Backends assembled with a managed runtime expose it here so Web, the SDK
-    and the CLI route through :class:`ManagedTxApi` instead of writing PTT
-    themselves.  rigctld does not yet — its executor writes PTT directly, so a
-    rigctld key takes no lease and no watchdog covers it (MOR-1014).  Backends
-    without a runtime expose no ``managed_tx`` attribute (or return ``None``)
-    and keep the legacy :meth:`Radio.set_ptt` path unchanged.
+    Backends assembled with a managed runtime expose it here so Web, the SDK,
+    the CLI and rigctld all route through :class:`ManagedTxApi` instead of
+    writing PTT themselves when the rig is managed (rigctld's routing landed
+    under MOR-1014, #2148).  Backends without a runtime expose no
+    ``managed_tx`` attribute (or return ``None``) and keep the legacy
+    :meth:`Radio.set_ptt` path unchanged — the path a rigctld key on an
+    unmanaged rig still takes, with no lease and no watchdog.
 
     Publish it as a real class or instance member, never through
     ``__getattr__``: :meth:`ManagedTxApi.bind` settles absence without running
@@ -622,13 +623,13 @@ class PrivilegedTxSupervisor(Protocol):
     """Force-unkey surface of a radio's managed TX runtime.
 
     Deliberately NOT a member of :class:`ManagedTxSupervisor`. Every ingress —
-    Web, the SDK, the CLI — binds through :class:`ManagedTxApi`, whose
+    Web, the SDK, the CLI, rigctld — binds through :class:`ManagedTxApi`, whose
     ``supervisor`` is typed as :class:`ManagedTxSupervisor`; adding
     ``force_unkey`` there would hand force semantics to all of them,
-    including two that must never get it. rigctld's executor issues a plain
-    housekeeping ``set_ptt(False)`` between overs with no :class:`TxOwner`
-    behind it — an implicit force there would let ordinary release traffic
-    escalate into adopting someone else's lease. The SDK is automation-shaped
+    including two that must never get it. rigctld's own session-scoped
+    :class:`TxOwner` (MOR-1014, landed #2148) only releases the lease that
+    owner itself took; an implicit force there would let ordinary release
+    traffic escalate into adopting someone else's lease. The SDK is automation-shaped
     with no operator attached to a session either; an author who actually
     wants force names :class:`PrivilegedTxApi` explicitly rather than
     inheriting it silently from the ordinary managed path. Splitting the two

--- a/src/rigplane/rigctld/handler.py
+++ b/src/rigplane/rigctld/handler.py
@@ -1033,8 +1033,14 @@ class RigctldHandler:
 
         Fail-soft by construction: this runs on the teardown path of a socket
         that is already gone, so there is nobody left to report an error to,
-        and raising would only skip the rest of that teardown. A rig genuinely
-        still keyed after this is the watchdog's problem, not this method's.
+        and raising would only skip the rest of that teardown. On an
+        unmanaged radio nothing here or elsewhere de-keys it: MOR-1220's
+        backstop bounds only keys the web poller itself issued, not a
+        rigctld-issued key, so a client that keys a serial/USB Icom and
+        drops leaves it transmitting with no bound anywhere in the product.
+        The ticketed path to coverage is MOR-1219 (serial Icom managed arm)
+        and MOR-1190 (Yaesu CAT, rigctld-client — amended to include the
+        key-down bound).
         """
         try:
             managed = bind_managed_tx(self._radio, "rigctld", session_id)
@@ -1419,9 +1425,12 @@ class RigctldHandler:
 
         Three outcomes, deliberately asymmetric between key and unkey.
 
-        **No facade to bind.** Either the rig is unmanaged — every shipped
-        backend today, and the legacy write below is byte-identical to what
-        rigctld has always sent — or the request carries no owner. On a managed
+        **No facade to bind.** Either the rig is unmanaged — serial/USB Icom
+        (legacy, MOR-1220's 180s web-poller backstop does not cover a
+        rigctld-issued key, full arm pending MOR-1219), Yaesu CAT, or
+        rigctld-client (legacy, no key-down bound, pending MOR-1190) — and
+        the legacy write below is byte-identical to what rigctld has always
+        sent — or the request carries no owner. On a managed
         rig an ownerless KEY is refused, because falling through would key with
         no lease, no owner and no watchdog: the unsupervised bypass management
         exists to close. An ownerless UNKEY still writes, because an unkey

--- a/src/rigplane/runtime/managed_tx_ingress.py
+++ b/src/rigplane/runtime/managed_tx_ingress.py
@@ -2,10 +2,11 @@
 
 One question, asked identically by every ingress: does this request carry an
 identity the supervisor can hold a lease against? Web asks it here, rigctld
-(MOR-1014) asks the same helpers, and the CLI/SDK (MOR-1190) will — rather than
-grow a third copy of the two-step supervisor read, the duplication MOR-1198
-exists to remove, and the one three call sites already got wrong in three
-different ways (MOR-1187, MOR-1193, MOR-1196).
+(MOR-1014) asks the same helpers, and the CLI/SDK already do too, having
+landed under MOR-1170/MOR-1171 — rather than grow a third copy of the
+two-step supervisor read, the duplication MOR-1198 exists to remove, and the
+one three call sites already got wrong in three different ways (MOR-1187,
+MOR-1193, MOR-1196).
 
 It lives in ``runtime`` because ``runtime`` sits below ``backends`` and below
 both UI servers, so every one of those callers can reach it while it reaches
@@ -115,8 +116,9 @@ def refuse_key_without_owner(
     ``True`` only where both halves hold: the radio publishes a supervisor, and
     the request carries no identity that supervisor could release later. Either
     half alone is not a refusal — an owned ingress keys through the supervisor,
-    and an unmanaged rig keeps the legacy write every shipped backend still
-    uses.
+    and an unmanaged rig (serial/USB Icom, Yaesu CAT, or rigctld-client —
+    legacy, pending MOR-1219/MOR-1190) keeps the legacy write those backends
+    still use.
 
     The owner test comes first so a managed websocket key never pays for the
     supervisor read, and a broken accessor cannot turn a perfectly keyable

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -1138,7 +1138,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         as ``host`` with no ports at all and ``f"…:{host}:0"`` would read as a
         LAN rig on port zero. That branch is inert today — the serial backend
         overrides ``connect()`` without calling ``super()``, so nothing arms
-        it (MOR-1190) — and exists so the id is right the day it does.
+        it (MOR-1219) — and exists so the id is right the day it does.
         """
         device = getattr(self, "_serial_device", None)
         if isinstance(device, str) and device:

--- a/src/rigplane/validation/hardware.py
+++ b/src/rigplane/validation/hardware.py
@@ -780,20 +780,14 @@ async def _actuate_tuner_tune(
     report transient/idle states once the cycle completes.
 
     **Documented carve-out from MOR-1222's managed-TX routing.** Unlike
-    ``tx.ptt``, this path asserts no PTT: the radio's own firmware keys, sweeps
-    and unkeys autonomously once the tune command lands, so the emission is an
-    EXTERNAL-class RF event the supervisor observes rather than one an ingress
-    causes. Wrapping it in a supervisor lease would make it strictly more
-    dangerous, not less — taking the lease writes PTT ON at the *operator's*
-    power into a load that is by definition unmatched, a key legacy never
-    asserted and one that sits outside the minimum-power-first mitigation
-    MOR-1165 Auditor A credited for this module. So this actuator keeps the
-    legacy behaviour verbatim (``set_tuner_status`` only, no lease, no PTT
-    write) under Auditor A's sanctioned alternative for this site: an explicit
-    carve-out with its residual risk named. Residual risk: the tune cycle runs
-    with no lease and therefore no ``BACKEND_MAX_KEY_DOWN``; it is bounded
-    instead by the rig's own firmware timeout, by ``tuner_allowed`` plus the
-    full ``--tx-actuate`` gate stack, and by the interactive ``confirm()``.
+    ``tx.ptt``, this path asserts no PTT: the tune cycle is a
+    radio-internal EXTERNAL-class RF event, and a supervisor lease here
+    would assert an operator-power key into an unmatched load legacy never
+    had (the recorded MOR-1222 decision). So this actuator keeps legacy
+    behaviour verbatim (``set_tuner_status`` only, no lease, no PTT write).
+    Residual risk: no lease means no ``BACKEND_MAX_KEY_DOWN``; the
+    firmware-managed hazard (autonomous key/sweep/unkey timing) is
+    UNVERIFIED on hardware, not asserted as safe.
     """
     _set_tuner_attr = getattr(radio, "set_tuner_status", None)
     if not callable(_set_tuner_attr):

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -1338,9 +1338,9 @@ class RadioPoller:
         The rule it applies — only a websocket session carries an owner identity
         stable enough to release the lease it takes — now lives in
         ``runtime.managed_tx_ingress`` with the rest of the gate, because
-        rigctld (MOR-1014) and the CLI/SDK (MOR-1190) must apply the same one
-        and the two-step supervisor read behind it belongs in exactly one place
-        (MOR-1198).
+        rigctld (MOR-1014) and the CLI/SDK (routed under MOR-1170/MOR-1171)
+        apply the same one and the two-step supervisor read behind it belongs
+        in exactly one place (MOR-1198).
         """
         return bind_managed_tx(self._radio, source, session_id)
 
@@ -1606,8 +1606,10 @@ class RadioPoller:
                         ) from e
                 if managed is None:
                     # Binding nothing is two findings, and only one may reach
-                    # the raw write: an unmanaged rig (every shipped backend,
-                    # unchanged), or an ingress with no owner a lease could be
+                    # the raw write: an unmanaged rig (every shipped
+                    # serial/USB Icom backend this poller serves; bounded
+                    # below by MOR-1220's 180s backstop, full managed arm
+                    # pending MOR-1219), or an ingress with no owner a lease could be
                     # released against — which on a managed rig would key with
                     # no lease, no owner and no watchdog, the unsupervised
                     # bypass management exists to close. Resolving a supervisor

--- a/tests/test_rigctld_managed_tx.py
+++ b/tests/test_rigctld_managed_tx.py
@@ -240,7 +240,8 @@ async def test_a_declined_unkey_reports_ok_and_writes_nothing(
 
 
 async def test_an_unmanaged_radio_keeps_the_legacy_write_both_ways() -> None:
-    """Every shipped backend today: byte-identical to what rigctld always sent."""
+    """Legacy unmanaged backends (serial/USB Icom, Yaesu CAT, rigctld-client):
+    byte-identical to what rigctld always sent."""
     radio = _Radio()
     handler = RigctldHandler(radio, RigctldConfig())  # type: ignore[arg-type]
 

--- a/tests/test_web_managed_tx_owner.py
+++ b/tests/test_web_managed_tx_owner.py
@@ -28,9 +28,12 @@ was no managed backend, so "binds no owner" could keep falling through to the
 raw ``set_ptt`` write; once a rig publishes a supervisor that fallthrough is an
 unsupervised key on a managed rig. The gate lives in
 ``rigplane.runtime.managed_tx_ingress`` — below the poller, so rigctld
-(MOR-1014) and the CLI/SDK (MOR-1190) reuse it instead of growing a third copy
-of the same two-step read (MOR-1198) — and it is deliberately one-sided: keys
-are refusable, unkeys never are.
+(MOR-1014) and the CLI/SDK (already routed, landed under MOR-1170/MOR-1171)
+reuse it instead of growing a third copy of the same two-step read (MOR-1198)
+— and it is deliberately one-sided: keys are refusable, unkeys never are. The
+serial-backend arm gap this owner/ingress gate does not itself touch is a
+separate ticket: MOR-1219 (serial Icom managed arm), with MOR-1190 covering
+its Yaesu CAT / rigctld-client siblings.
 """
 
 from __future__ import annotations
@@ -371,11 +374,12 @@ async def test_an_http_unkey_on_a_managed_rig_still_writes_the_legacy_off() -> N
 
 
 async def test_an_unmanaged_rig_keeps_the_legacy_http_path_on_both_arms() -> None:
-    """Every shipped backend is still unmanaged, so HTTP PTT is untouched.
+    """Legacy unmanaged backends publish no supervisor, so HTTP PTT is untouched.
 
     The gate asks the radio, not the request: with no supervisor published there
     is nothing to be refused on behalf of, and refusing here would break HTTP
-    PTT for every rig in the field.
+    PTT for every serial/USB Icom, Yaesu CAT, or rigctld-client rig in the
+    field — the LAN Icom path is managed and does not take this branch.
     """
     poller, radio = _poller(None)
 

--- a/tests/test_web_recovery_durable_off.py
+++ b/tests/test_web_recovery_durable_off.py
@@ -276,7 +276,9 @@ async def test_recovery_with_nothing_pending_only_does_recovered_work() -> None:
 
 
 async def test_an_unmanaged_radio_recovers_exactly_as_it_does_today(caplog) -> None:
-    """Every shipped backend until MOR-1016 publishes no supervisor at all."""
+    """Legacy unmanaged backends (serial/USB Icom, Yaesu CAT, rigctld-client)
+    publish no supervisor at all, matching every backend's behavior before
+    MOR-1016."""
     log: list[str] = []
     radio = _Radio(log)
     assert not hasattr(radio, "managed_tx")


### PR DESCRIPTION
## Summary

MOR-1165 audit Round-2 remediation **R5**: documentation-only slice making every managed-TX boundary statement in the tree honest. Round-2 findings A5-1/A5-2 (Auditor A) and B-1..B-6 (Auditor B) — cross-confirmed — located nine source sites plus three test docstrings stating a boundary that was neither the retracted E8 claim nor the corrected one, three of them still claiming "every shipped backend is unmanaged" (false since MOR-1016).

Linear: [MOR-1225](https://linear.app/morozsm/issue/MOR-1225).

## Changes (comments/docstrings/markdown only — zero executable change)

- The honest boundary, stated at every present-tense site: managed TX armed on the **LAN `IcomRadio`** path only; serial/USB Icoms legacy + MOR-1220 backstop pending [MOR-1219](https://linear.app/morozsm/issue/MOR-1219); Yaesu CAT / rigctld-client / CLI-hold legacy without a key-down bound pending [MOR-1190](https://linear.app/morozsm/issue/MOR-1190) (acceptance amended 2026-08-02 to include the bound; gates MOR-1033).
- `_actuate_tuner_tune` docstring: unbacked rig-firmware safety claim removed; "Auditor A sanctioned" provenance (a spent BLOCKED audit) removed; hazard stated as unverified on hardware.
- `rigctld/handler.py` teardown comment: no longer claims watchdog coverage the unmanaged path lacks.
- `docs/CHANGELOG.md`: records the MOR-1011/1012 presentation-timer → supervisor-watchdog trade, the MOR-1220 backstop's actual (web Icom poller) scope, and the MOR-1190/MOR-1219 path to full coverage.
- MOR-1219 now referenced at six source sites (was zero — Round-2 finding B-5).

## Guardrail note

12 files vs the ≤3-file guardrail — a deliberate, recorded documentation-only exception: +86/−54 (net +32) with **provably zero behavioural blast radius**: every touched `.py` file is `ast.dump`-identical after docstring-strip, verified independently by builder and verifier with separate tooling (docstring counts and non-docstring string constants also identical; per-hunk line-walk all comment/docstring/blank).

## Evidence

- Builder: full suite 8757 passed / 0 failed; ruff/format clean; per-site before/after quotes in the build report.
- Independent verifier (separate agent context, non-author; PASS, then PASS sustained after a delta closing 4 more sites it found via case-insensitive grep): own AST-identity scripts; coverage map finding→hunk complete; content fidelity checked against contract §9, source, and Linear (MOR-1222 decision, MOR-1190 amendment); `grep -rni "every shipped backend" src/ tests/` → zero. Review posted as a PR comment.

Software evidence only; MOR-1033 remains the FTX-1 hardware gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
