### PR TITLE
test(MOR-1226): pin the remaining managed-TX identity surface

### DIFF
--- a/frontend/src/lib/runtime/tx-controller/__tests__/app-host.test.ts
+++ b/frontend/src/lib/runtime/tx-controller/__tests__/app-host.test.ts
@@ -108,4 +108,19 @@ describe('App TxController host', () => {
       leaseTarget: { receiver: 'MAIN', slot: 'A', frequencyHz: 100 } });
     facade.release('desktop', later.guard!); expect(h.effects).toEqual(['audio', 'on', 'off', 'stop']);
   });
+  it('releases a held guard on dispose, not only through an explicit release() call', async () => {
+    // MOR-1226 (MOR-1165 audit remediation R2, A6-1): dispose()'s `void
+    // release()` was unpinned -- deleting it left all 13 TX test files
+    // green, including the two tests above, because neither calls
+    // dispose() while a guard is still held. This one does.
+    const host = provideAppTxControllerHost(bindings()); const facade = getAppTxController();
+    h.session!(projection({ state: 'connected', epoch: 1 }, 1), { state: 'connected', epoch: 1 });
+    host.refreshAuthority();
+    facade.start('desktop', 'lease', 'momentary');
+    await Promise.resolve(); await Promise.resolve();
+    expect(h.effects).toEqual(['audio', 'on']);
+    host.dispose();
+    expect(h.events).toContain('release');
+    expect(h.effects).toEqual(['audio', 'on', 'off', 'stop']);
+  });
 });

--- a/tests/test_managed_tx_identity_pins.py
+++ b/tests/test_managed_tx_identity_pins.py
@@ -30,15 +30,64 @@ extraction (see ``mor1221-a42-pacing-test.patch`` in the build scratchpad).
 No ``MagicMock`` stands in for a protocol-shaped object: ``_ManagedRadio``/
 ``_Provider`` (from ``test_web_recovery_durable_off``) and the real
 ``IcomRadio``/``MockTransport`` pair (from ``test_radio``) drive every case.
+
+---
+
+MOR-1226 (MOR-1165 audit remediation R2): pin the rest of the same guard,
+per Auditor A's Round-2 report §A4/§A8 (and §A3 for the binding triple):
+
+* **A4-1, the four remaining ``_managed_tx_port_is_current`` fields.** R1
+  pinned :699 (binding epoch) and :702 (exact transport, as a *deletion*).
+  The other four comparisons at ``_civ_rx.py:696-701`` -- registry
+  identity, observer provider-generation, observer CI-V generation, host
+  CI-V epoch -- were each individually deletable with the full 9020-test
+  suite green. Pinned below by direct manipulation of the one field under
+  test, exactly the style ``test_binding_epoch_divergence_makes_the_managed_port_stale``
+  already uses, so each mutation is isolated from the other six.
+* **A4-1, the post-response READ revalidation (:670).** Whole-block
+  deletion survived the full suite too -- because ``_emit_authoritative_ptt``
+  happens to re-derive an equivalent check through its own ``expected``
+  argument for this one call site, so the *return value* and the *observer*
+  side effect are unaffected either way. Pinned as an architectural
+  property instead of a value: a spy stands in for
+  ``_emit_authoritative_ptt`` and proves :670 -- not the coincidence
+  downstream -- is what stops it from being reached once the binding moved
+  underneath an in-flight read.
+* **A3-1 / A4-1, the two ``is``-vs-``==`` weakenings.** Confirmed still
+  unpinned at both the binding triple (``radio.py:1208``, Low) and the
+  managed-port guard's own transport check (``_civ_rx.py:702``,
+  Medium-High) because no shipped transport type
+  (``IcomTransport``/serial's ``SerialCivTransport``/``MockTransport``)
+  overrides ``__eq__`` -- ``is`` and ``==`` agree on every transport object
+  the suite ever constructs, so the weakening is invisible to every
+  existing test by construction, not because the guard doesn't need it.
+  ``_EqTransport`` below is the "obvious route" attempted before any
+  documented-skip: an equal-but-distinct transport double, on the same
+  synthetic footing as R1's ``_NoOpRetireBackend`` -- no shipped transport
+  behaves this way, but the guard must not depend on that being true.
+
+No ``MagicMock`` stands in for a protocol-shaped object here either: the
+same real ``IcomRadio``/``MockTransport`` pair, and ``_ManagedRadio``/
+``_Provider``, drive every new case; ``_EqTransport`` is a minimal value
+double, not a mock.
 """
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
 
 from rigplane import IC_7610_ADDR
+from rigplane.commands import CONTROLLER_ADDR
 from rigplane.exceptions import ConnectionError as RigConnectionError
 from rigplane.radio import IcomRadio
+from rigplane.runtime._civ_rx import (
+    RawCivTransactionResult,
+    _AuthoritativePttRead,
+    _ManagedTxPortToken,
+)
+from rigplane.types import CivFrame
 from test_radio import MockTransport
 from test_web_recovery_durable_off import _armed, _ManagedRadio, _Provider
 
@@ -194,3 +243,309 @@ async def test_binding_epoch_divergence_makes_the_managed_port_stale(
     assert civ_runtime._managed_tx_port_is_current(token) is False
     with pytest.raises(RigConnectionError, match="managed TX physical port is stale"):
         await radio._write_managed_ptt(11, True)
+
+
+# ===========================================================================
+# MOR-1226 (R2) -- the four remaining _managed_tx_port_is_current fields
+# (:696, :698, :700, :701), each isolated by direct manipulation of the one
+# field under test -- the same style as the binding-epoch pin above.
+# ===========================================================================
+
+
+async def test_registry_identity_divergence_makes_the_managed_port_stale(
+    radio: IcomRadio,
+) -> None:
+    """A token whose registry slot (``_civ_rx.py:696``) now holds a
+    *different* token object -- same generation, same field values, but not
+    the one this caller is holding -- must read stale on its own. This is
+    the only one of the seven comparisons that distinguishes a freshly
+    recaptured port (``reset_managed_tx_generations`` clears the registry
+    and a later capture refills the same-numbered slot) from a stale
+    in-flight write still holding the old token: the replacement token is
+    field-identical by construction, so nothing else in the guard would
+    catch it.
+    """
+    observations: list[object] = []
+    assert radio._capture_managed_tx_port(11, observations.append)
+    civ_runtime = radio._civ_runtime
+    token = civ_runtime._managed_tx_ports[11]
+    assert civ_runtime._managed_tx_port_is_current(token) is True
+
+    civ_runtime._managed_tx_ports[11] = _ManagedTxPortToken(
+        token.provider_generation,
+        token.binding_epoch,
+        token.civ_source_generation,
+        token.transport,
+    )
+
+    assert civ_runtime._managed_tx_port_is_current(token) is False
+    # ``write_managed_ptt`` re-fetches its token by generation on every call,
+    # so it can never hold a registry-stale one -- the caller that matters
+    # here is the dispatch-time re-validation, which *does* hold a token
+    # across an await and is exactly what :696 exists to catch.
+    with pytest.raises(
+        RigConnectionError, match="managed TX physical port changed before dispatch"
+    ):
+        await civ_runtime._send_civ_frame_now(b"\x00", owner=token)
+
+
+async def test_observer_provider_generation_divergence_makes_the_managed_port_stale(
+    radio: IcomRadio,
+) -> None:
+    """``_civ_rx.py:698`` in isolation: the observer's own recorded provider
+    generation moves away from the token's, independent of the registry
+    slot, the binding epoch and the transport -- e.g. a second
+    ``bind_ptt_observer`` for a different generation lands between capture
+    and write.
+    """
+    observations: list[object] = []
+    assert radio._capture_managed_tx_port(11, observations.append)
+    civ_runtime = radio._civ_runtime
+    token = civ_runtime._managed_tx_ports[11]
+    assert civ_runtime._managed_tx_port_is_current(token) is True
+
+    civ_runtime._ptt_observer_provider_generation = 999
+
+    assert civ_runtime._managed_tx_port_is_current(token) is False
+    with pytest.raises(RigConnectionError, match="managed TX physical port is stale"):
+        await radio._write_managed_ptt(11, True)
+
+
+async def test_observer_civ_generation_divergence_makes_the_managed_port_stale(
+    radio: IcomRadio,
+) -> None:
+    """``_civ_rx.py:700`` in isolation: the observer's own recorded CI-V
+    generation moves away from the token's, independent of the *host's*
+    live ``_civ_epoch`` (:701, pinned separately below) and everything
+    else.
+    """
+    observations: list[object] = []
+    assert radio._capture_managed_tx_port(11, observations.append)
+    civ_runtime = radio._civ_runtime
+    token = civ_runtime._managed_tx_ports[11]
+    assert civ_runtime._managed_tx_port_is_current(token) is True
+
+    civ_runtime._ptt_observer_civ_generation += 1
+
+    assert civ_runtime._managed_tx_port_is_current(token) is False
+    with pytest.raises(RigConnectionError, match="managed TX physical port is stale"):
+        await radio._write_managed_ptt(11, True)
+
+
+async def test_host_civ_epoch_divergence_makes_the_managed_port_stale(
+    radio: IcomRadio,
+) -> None:
+    """``_civ_rx.py:701`` in isolation: the *host's* live CI-V epoch moves
+    away from the token's recorded generation without going through
+    ``advance_generation`` (which would also poison the token via :697,
+    already pinned) -- proving :701 catches a bare epoch bump entirely on
+    its own.
+    """
+    observations: list[object] = []
+    assert radio._capture_managed_tx_port(11, observations.append)
+    civ_runtime = radio._civ_runtime
+    token = civ_runtime._managed_tx_ports[11]
+    assert civ_runtime._managed_tx_port_is_current(token) is True
+
+    radio._civ_epoch += 1
+
+    assert civ_runtime._managed_tx_port_is_current(token) is False
+    with pytest.raises(RigConnectionError, match="managed TX physical port is stale"):
+        await radio._write_managed_ptt(11, True)
+
+
+# ===========================================================================
+# MOR-1226 (R2) -- the post-response READ revalidation (:670): whole-block
+# deletion survived the full suite because _emit_authoritative_ptt happens
+# to re-derive an equivalent predicate through its own ``expected`` kwarg
+# for this call site. Pin the guard itself with a spy that skips that
+# downstream re-check, proving :670 -- not the coincidence -- is what stops
+# a stale response from reaching it.
+# ===========================================================================
+
+
+async def test_the_post_response_revalidation_stops_a_response_the_binding_moved_past(
+    radio: IcomRadio,
+) -> None:
+    """A genuine CI-V response arrives (``result.status == "response"``,
+    a real frame), but the observer was rebound to a different generation
+    *while the round trip was in flight* -- the exact race a reconnect or a
+    second ``bind_ptt_observer`` opens between a read's dispatch and its
+    reply. ``_emit_authoritative_ptt`` must never even be reached in that
+    case; a spy in its place proves the direct check at ``_civ_rx.py:670``
+    is what stops it, independent of whatever the callee would itself have
+    decided.
+    """
+    civ_runtime = radio._civ_runtime
+    observations: list[object] = []
+    observer = observations.append
+    assert radio._capture_managed_tx_port(11, observer)
+
+    emit_calls: list[object] = []
+
+    def spying_emit(*args: object, **kwargs: object) -> bool:
+        # Deliberately does not re-derive currency the way the real
+        # _emit_authoritative_ptt (:1499) happens to for this call site
+        # today -- that is the coincidence :670 must not depend on.
+        emit_calls.append(kwargs.get("expected"))
+        return True
+
+    async def race_then_respond(
+        *args: object, **kwargs: object
+    ) -> RawCivTransactionResult:
+        # The binding moves while the round trip is in flight.
+        civ_runtime.bind_ptt_observer(
+            provider_generation=12, observer=lambda _obs: None
+        )
+        return RawCivTransactionResult(
+            status="response",
+            frame=CivFrame(
+                to_addr=CONTROLLER_ADDR,
+                from_addr=IC_7610_ADDR,
+                command=0x1C,
+                sub=0x00,
+                data=bytes([0x01]),
+            ),
+        )
+
+    with (
+        patch.object(civ_runtime, "_emit_authoritative_ptt", spying_emit),
+        patch.object(civ_runtime, "execute_civ_transaction", race_then_respond),
+    ):
+        result = await civ_runtime.request_authoritative_ptt_read(
+            b"\x00", provider_generation=11, observer=observer
+        )
+
+    assert result is False
+    assert emit_calls == []  # :670 must stop this before _emit_authoritative_ptt runs
+    assert observations == []
+
+
+# ===========================================================================
+# MOR-1226 (R2) -- the two ``is``-vs-``==`` weakenings, both confirmed still
+# unpinned because no shipped transport overrides __eq__. _EqTransport is
+# the equal-but-distinct double: same synthetic footing as R1's
+# _NoOpRetireBackend above.
+# ===========================================================================
+
+
+class _EqTransport:
+    """A transport double whose equality is defined by a shared marker, not
+    identity. No shipped transport (``IcomTransport``, serial's
+    ``SerialCivTransport``, ``MockTransport``) overrides ``__eq__`` -- every
+    one of them compares by identity by default -- so nothing in the
+    existing suite can tell an ``is`` check apart from an ``==`` check on a
+    real transport object. This double breaks that coincidence: two
+    distinct instances that compare equal must still be told apart, because
+    ``==`` on a future or third-party transport type could otherwise let a
+    write reach a different physical connection than the one authorised.
+    """
+
+    def __init__(self, marker: str) -> None:
+        self.marker = marker
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, _EqTransport) and other.marker == self.marker
+
+    def __hash__(self) -> int:
+        return hash(self.marker)
+
+
+async def test_transport_equality_is_not_enough_the_managed_port_check_is_identity(
+    radio: IcomRadio,
+) -> None:
+    """``_civ_rx.py:702`` weakened from ``is`` to ``==`` survives the full
+    9020-test suite (Auditor A, A4-M8) purely because no shipped transport
+    type defines value equality. Prove the check is genuinely identity by
+    handing it two distinct, but equal, transport objects.
+    """
+    transport_a = _EqTransport("port-x")
+    radio._civ_transport = transport_a
+    observations: list[object] = []
+    assert radio._capture_managed_tx_port(11, observations.append)
+    civ_runtime = radio._civ_runtime
+    token = civ_runtime._managed_tx_ports[11]
+    assert civ_runtime._managed_tx_port_is_current(token) is True
+
+    transport_b = _EqTransport("port-x")
+    assert transport_b == transport_a
+    assert transport_b is not transport_a
+    radio._civ_transport = transport_b
+
+    assert civ_runtime._managed_tx_port_is_current(token) is False
+    with pytest.raises(RigConnectionError, match="managed TX physical port is stale"):
+        await radio._write_managed_ptt(11, True)
+
+
+async def test_transport_equality_is_not_enough_for_binding_liveness() -> None:
+    """``_managed_tx_binding_is_live``'s transport comparison
+    (``runtime/radio.py:1208``) weakened from ``is`` to ``==`` also
+    survives the full 828-test identity-pin superset (Auditor A, A3-M3,
+    recorded at Low as "protected by review only"). Same double, same
+    reasoning as the ``_civ_rx.py:702`` pin above: a same-generation,
+    same-epoch rebind that nonetheless lands on a *different* transport
+    object must not read as still live merely because the two compare
+    equal.
+    """
+    radio = _ManagedRadio(_Provider([]))
+    radio._civ_transport = _EqTransport("port-x")
+    await radio.rearm_managed_tx()
+    runtime = radio._managed_tx_runtime
+    assert runtime is not None
+    _generation, _epoch, bound_transport = radio._managed_tx_bound_port
+    assert bound_transport is radio._civ_transport
+
+    twin = _EqTransport("port-x")
+    assert twin == bound_transport
+    assert twin is not bound_transport
+    radio._civ_transport = twin
+
+    assert radio._managed_tx_binding_is_live() is False
+
+
+# ===========================================================================
+# MOR-1226 addendum (R6 verifier finding) -- _emit_authoritative_ptt's own
+# ``expected`` re-check (:1499) is a second, independent belt to :670's
+# braces, not implied by it. The verifier's combination probe found that
+# with :670 intact, disabling *only* :1499's ``expected`` term still
+# survives the full 8764-test suite: the sole call site that passes
+# ``expected`` (:671) is already gated by :670 immediately before it,
+# synchronously, so :1499's own check is never independently exercised
+# through either of its two call sites (the other, :1479, never passes
+# ``expected`` at all). Pin :1499 directly, bypassing both callers.
+# ===========================================================================
+
+
+async def test_emit_authoritative_ptt_refuses_a_stale_expected_read_on_its_own(
+    radio: IcomRadio,
+) -> None:
+    """Call ``_emit_authoritative_ptt`` itself with an ``expected`` whose
+    currency has already lapsed -- skipping :670 entirely -- and assert
+    :1499 refuses on its own: no observation reaches the real registered
+    observer, and the sequence counter does not advance.
+    """
+    civ_runtime = radio._civ_runtime
+    observations: list[object] = []
+    observer = observations.append
+    assert radio._capture_managed_tx_port(11, observer)
+    token = civ_runtime._managed_tx_ports[11]
+    stale_read = _AuthoritativePttRead(observer, token, True)
+    seq_before = civ_runtime._ptt_observation_seq
+
+    civ_runtime._ptt_observer_binding_epoch += 1  # the binding moved
+    assert civ_runtime._ptt_read_is_current(stale_read) is False
+
+    frame = CivFrame(
+        to_addr=CONTROLLER_ADDR,
+        from_addr=IC_7610_ADDR,
+        command=0x1C,
+        sub=0x00,
+        data=bytes([0x01]),
+    )
+    result = civ_runtime._emit_authoritative_ptt(
+        frame, source_generation=token.civ_source_generation, expected=stale_read
+    )
+
+    assert result is False
+    assert observations == []
+    assert civ_runtime._ptt_observation_seq == seq_before


### PR DESCRIPTION
## Summary

MOR-1165 audit Round-2 remediation **R6**: pin every element of the managed-TX identity surface that Auditor A found individually deletable with the full suite green (findings A4-1/A8-1 Medium-High, A3-1/A6-1 Low). The Round-2 lesson applied: no sampling — each element gets its own mutation-verified killer, and one surface the verifier discovered mid-review (`:1499` callee re-check, deletable ALONE) was closed in-slice instead of ticketed away.

Linear: [MOR-1226](https://linear.app/morozsm/issue/MOR-1226).

## What is pinned (12 tests total in the pin file; production byte-identical to base)

- `_civ_rx.py:696/:698/:700/:701` — the remaining registry/observer currency fields, one focused test each.
- `_civ_rx.py:702` and `runtime/radio.py:1208` — the `is`→`==` weakenings, killed via equal-but-distinct doubles constructed on the real guard paths (no shipped transport overrides `__eq__` — verified).
- `_civ_rx.py:670` — the post-response READ revalidation block, pinned architecturally (guard-before-callee) since the value outcome is near-equivalent at that call site.
- `_civ_rx.py:1499` — the callee's own `expected` re-check, which survived alone: pinned value-based (lapsed read driven to the refusal). The `:670`+`:1499` belt-and-braces pair now kills in both directions.
- `frontend .../app-host.ts` `dispose()` release — one vitest pin (localStorage baseline-diff discipline; the failing union is exactly the 10 disclosed environmental files, the new test never among them).

## Classification & cap note

370 net LOC / 2 test files — over the audit's ≤200 remediation cap; the code-only floor (213) already exceeds it, so per the contract's own provision this is **new work under its own ticket with its own independent review** (this PR). Disclosed, not evasion.

## Evidence

- Builder: every mutation applied in a git-archive sandbox → its test fails on the invariant assertion → restore re-hashed; full suite 8765 passed / 0 failed; ruff/format/lint-imports/frontend lint clean.
- Independent verifier (separate agent context, non-author; PASS, delta PASS): re-ran all mutations itself — 8/8 then the `:1499` addition, each 1F/11P with zero collateral; adjudicated the `:670` spy pin as genuinely load-bearing via a combination probe; **found and neutralized a methodology hazard** — size-preserving mutations restored same-second silently reuse stale pyc bytecode and fake kills; all batteries re-run with `PYTHONDONTWRITEBYTECODE=1` (now recorded as standing practice). Review posted as a PR comment.

Software evidence only; MOR-1033 remains the FTX-1 hardware gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
