### PR TITLE
test(MOR-1176): drop flaky worst-of-100 p99 assert from frame-latency gate

### DIFF
--- a/tests/test_civ_command_profiling.py
+++ b/tests/test_civ_command_profiling.py
@@ -250,7 +250,20 @@ class TestLatencyDistribution:
     """Analyze latency distribution of critical operations."""
 
     def test_frame_creation_latency_distribution(self):
-        """Measure frame creation latency percentiles."""
+        """Measure frame creation latency percentiles.
+
+        Gates the MOR-416 frame-building performance SLO on p50/p95, which
+        both carry a >20x margin over baseline (~0.17µs / ~0.38µs vs the
+        10µs / 30µs budgets below) and stay stable even on a contended
+        CI runner.
+
+        p99 with only 100 samples is not a statistical percentile -- index
+        99 of a 100-sample sort is literally the single worst sample, so a
+        lone scheduler preemption on a shared runner can move it 10-30x
+        with zero change in actual latency (observed locally; see MOR-1176
+        for a CI run where it hit 155µs against p50=0.17µs/p95=0.38µs).
+        Report it for visibility; do not gate on it.
+        """
         latencies_ms = []
 
         for _ in range(100):
@@ -265,7 +278,7 @@ class TestLatencyDistribution:
 
         p50 = latencies_ms[50]
         p95 = latencies_ms[95]
-        p99 = latencies_ms[99]
+        p99 = latencies_ms[99]  # worst-of-100 sample; reported only, see above
 
         print(
             f"  Frame creation latency: p50={p50:.2f}µs, p95={p95:.2f}µs, p99={p99:.2f}µs"
@@ -274,4 +287,3 @@ class TestLatencyDistribution:
         # Latency should be consistently low
         assert p50 < 10, f"Median latency too high: {p50:.2f}µs"
         assert p95 < 30, f"95th percentile too high: {p95:.2f}µs"
-        assert p99 < 100, f"99th percentile too high: {p99:.2f}µs"


### PR DESCRIPTION
## Summary

- `tests/test_civ_command_profiling.py`: remove `assert p99 < 100` from the frame-creation latency distribution test — p99 of 100 samples is a single worst-of-N draw and flakes under CI scheduler preemption (observed 155µs spike against a 0.17µs median). The gating SLO assertions `p50 < 10µs` / `p95 < 30µs` are untouched; p99 is still measured and printed for observability.
- This is the ticket's sanctioned option 1. Zero production LOC; one test file, +15/−3.

## Independent verification

- **Discrimination retained:** injected-delay probes into `build_civ_frame` — an ~11µs and a 15µs median regression both FAIL the test via p50; detection threshold ≈10µs added median. The removed `p99 < 100` assert was 10× coarser, so no median-regression power was lost.
- **What is consciously lost:** a 1-in-100 × ~150µs stall now passes (printed, not asserted) — exactly the class indistinguishable from scheduler preemption; sanctioned by the ticket.
- **Independent SLO intact:** `tests/test_performance_regressions.py:209` still gates `build_civ_frame` at >1000 frames/ms (best-of-5, GC off) — ~10× tighter than the removed assert.
- **Flake removal:** 120/120 consecutive passes (60 ambient + 60 under 20 CPU spinners, load avg ~124); p99 spread 3.2–24.4µs vs p95 spread 0.2–1.9µs confirms p99 was the unstable statistic.
- **Sweep:** no other worst-of-N timing assertion remains anywhere in `tests/`.
- **Suite health:** full quick suite 8765 passed / 0 failed; ruff check + format clean.

Linear: MOR-1176

🤖 Generated with [Claude Code](https://claude.com/claude-code)
