### PR TITLE
fix(MOR-1168): guard bootstrap catch effects after App unmount

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -104,6 +104,7 @@
         backendError = null;
       } catch (err) {
         console.error('init error:', err);
+        if (!mounted) return;
         backendError = t('core.app.backendError', { detail: String(err) });
         if (retryCount < MAX_RETRIES) {
           const delay = RETRY_DELAYS[Math.min(retryCount, RETRY_DELAYS.length - 1)];

--- a/frontend/src/lib/runtime/tx-controller/__tests__/app-lifecycle.component.test.ts
+++ b/frontend/src/lib/runtime/tx-controller/__tests__/app-lifecycle.component.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
 const h = vi.hoisted(() => ({
   order: [] as string[],
@@ -157,5 +157,84 @@ describe('App TX lifecycle', () => {
     await settle();
     expect(h.host!.refreshAuthority).not.toHaveBeenCalled();
     expect(h.bootstrapCleanup).toHaveBeenCalledOnce();
+  });
+});
+
+// MOR-1168 — a deferred runtime.bootstrap() rejection must not drive
+// backendError/retry effects or arm a reload timer once App has unmounted.
+// jsdom's `location.reload` is non-configurable, so these assert on the
+// global setTimeout/clearTimeout calls (the retry-timer arm/clear) instead
+// of ever letting the real reload callback run.
+describe('App bootstrap rejection lifecycle (MOR-1168)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function pendingReject() {
+    let rejectBootstrap!: (err: unknown) => void;
+    h.bootstrap.mockImplementationOnce(
+      () => new Promise((_resolve, reject) => { rejectBootstrap = reject; }),
+    );
+    return () => rejectBootstrap;
+  }
+
+  it('makes a rejection that arrives after unmount inert: no retry timer armed', async () => {
+    const getReject = pendingReject();
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+    const component = mountApp();
+    await settle();
+    unmount(component);
+    expect(h.host!.dispose).toHaveBeenCalledOnce();
+    setTimeoutSpy.mockClear();
+
+    getReject()(new Error('late failure after unmount'));
+    await settle();
+    flushSync();
+
+    // Removing the `!mounted` guard in the catch handler would arm a
+    // retry setTimeout (and eventually call location.reload()) here.
+    expect(setTimeoutSpy).not.toHaveBeenCalled();
+  });
+
+  it('preserves bounded retry/error behavior for a rejection while still mounted', async () => {
+    const getReject = pendingReject();
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+    const component = mountApp();
+    await settle();
+    setTimeoutSpy.mockClear();
+
+    getReject()(new Error('mounted failure'));
+    await settle();
+    flushSync();
+
+    expect(document.body.textContent).toContain('core.app.backendError');
+    expect(document.querySelector('.retry-indicator')).not.toBeNull();
+    // A mounted rejection still arms the bounded reload-retry timer.
+    expect(setTimeoutSpy).toHaveBeenCalledTimes(1);
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 3000);
+    unmount(component);
+  });
+
+  it('clears an already-armed retry timer exactly once when unmount races the pending reload', async () => {
+    const getReject = pendingReject();
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
+    const component = mountApp();
+    await settle();
+    setTimeoutSpy.mockClear();
+
+    getReject()(new Error('mounted failure, then unmount before retry fires'));
+    await settle();
+    flushSync();
+    expect(setTimeoutSpy).toHaveBeenCalledTimes(1);
+    const armedTimer = setTimeoutSpy.mock.results[0]!.value;
+    clearTimeoutSpy.mockClear();
+
+    unmount(component);
+
+    // Pre-existing cleanup (untouched by this fix) must still clear an
+    // already-armed retry timer exactly once when unmount races it.
+    expect(clearTimeoutSpy).toHaveBeenCalledOnce();
+    expect(clearTimeoutSpy).toHaveBeenCalledWith(armedTimer);
   });
 });


### PR DESCRIPTION
## Summary

- `frontend/src/App.svelte`: add `if (!mounted) return;` at the top of the bootstrap `catch` handler (+1 net production LOC), guarding all failure-path state writes (`backendError`, `retrying`, `retryAttempt`, `retryDelaySec`, `retryCount`) and the `setTimeout(() => location.reload(), ...)` arm against a bootstrap rejection that arrives after the App unmounted. Mirrors the existing success-path guard from MOR-1159.
- `frontend/src/lib/runtime/tx-controller/__tests__/app-lifecycle.component.test.ts`: 3 new component tests mounting the real `App.svelte` lifecycle (late rejection after unmount → no effects and no armed reload timer; mounted rejection still surfaces the error and retry path; unmount clears a pending retry timer).

## Independent verification

- Late-continuation enumeration over the full bootstrap/mount/unmount flow closes at 13 entries: success path guarded (MOR-1159), catch path guarded (this fix), no `finally`, single production caller of `runtime.bootstrap()`, retry timer cannot fire post-unmount (`mounted = false` and `clearTimeout` share one synchronous teardown closure).
- Mutation probes: removing the guard kills test 1; deleting the pre-existing `clearTimeout` kills test 3; breaking the mounted retry path kills test 2.
- Gates: focused suites 5/5 and 12 files/140 tests, `check` 0/0, `lint`, `lint:boundaries`, `ruff check` all clean. Full `npm test` failure set is test-for-test identical to a same-session main baseline at `ac6ca47a` (known localStorage env flake; `comm -3` empty); the only delta is the 3 new passing tests.
- Pre-existing issues observed (NOT this diff, tickets filed separately): unguarded `initBatteryMonitor` late continuation leaks listeners after unmount; `audio-fft-demand.test.ts` sits on its 5 s timeout boundary on main.

Linear: MOR-1168

🤖 Generated with [Claude Code](https://claude.com/claude-code)
