### PR TITLE
fix(MOR-1014): close rigctld listener first, shield TX lease handback on shutdown

### DIFF
--- a/src/rigplane/rigctld/server.py
+++ b/src/rigplane/rigctld/server.py
@@ -204,19 +204,46 @@ class RigctldServer:
         until the max key-down watchdog expires, blocking every other client
         meanwhile.
 
-        Probed rather than called outright, and never allowed to raise, for the
-        same reason ``_handler_execute_call`` probes ``session_id``:
-        ``_rig_handler`` is an injected ``Any``, and a handler that predates
-        this hook must keep working. Failure here cannot be reported to a
-        socket that is already gone, and must not skip the rest of teardown.
+        Probed rather than called outright, and never allowed to raise an
+        ordinary exception, for the same reason ``_handler_execute_call``
+        probes ``session_id``: ``_rig_handler`` is an injected ``Any``, and a
+        handler that predates this hook must keep working. Failure here cannot
+        be reported to a socket that is already gone, and must not skip the
+        rest of teardown.
+
+        Cancellation is the one thing it does not absorb twice: the handback
+        survives the cancellation ``stop()`` sends, and a second one ends it.
+        Nothing recovers from that by itself — the lease stays held with its
+        release obligation unsettled (``RELEASE_REQUIRED``) and no watchdog
+        re-arms behind it, so it is a condition for the uncertain-shutdown
+        diagnostics to surface (MOR-1015), not one that times itself out. The
+        caller's teardown is written to close the socket either way.
         """
         release = getattr(self._rig_handler, "release_session_tx", None)
         if release is None:
             return
         try:
             result = release(session_id)
-            if inspect.isawaitable(result):
-                await result
+            if not inspect.isawaitable(result):
+                return
+            handback = asyncio.ensure_future(result)
+            try:
+                await asyncio.shield(handback)
+            except asyncio.CancelledError:
+                # Shutdown reached this session mid-handback. Every other step
+                # of a teardown can be abandoned; this one cannot, and nothing
+                # downstream would clean up after it. An abandoned handback
+                # leaves the lease held with its release obligation unsettled
+                # (``RELEASE_REQUIRED``, an unfinished WRITE_OFF) and no
+                # watchdog behind it: ``_begin_release`` clears
+                # ``watchdog_deadline``, and ``tick`` arms the max key-down
+                # branch only while no release is pending. That state does not
+                # time itself out — it is for the uncertain-shutdown
+                # diagnostics to surface (MOR-1015). The release is in flight
+                # anyway and ``stop()`` gathers this task, so the wait is
+                # bounded by the handback itself. Swallowed rather than
+                # re-raised so the socket close below still runs (MOR-1014).
+                await handback
         except Exception:
             logger.warning(
                 "session %s: managed TX release failed", session_id, exc_info=True
@@ -696,10 +723,17 @@ class RigctldServer:
             await self._poller.stop()
             self._poller = None
 
-        if self._server is not None:
-            self._server.close()
-            await self._server.wait_closed()
-            self._server = None
+        # Listener down, then the live sessions, then the wait. The order is
+        # the release guarantee, not tidiness (MOR-1014): since 3.12
+        # ``wait_closed()`` returns only once every accepted connection has
+        # gone (gh-79033), so awaiting it before cancelling would park here for
+        # the whole ``client_timeout`` — 300s by default — behind one idle
+        # WSJT-X socket, and the managed TX lease that session holds is handed
+        # back by the cancellation queued below. Shutdown must not leave a
+        # transmitter keyed while it waits on a client that has nothing to say.
+        listener, self._server = self._server, None
+        if listener is not None:
+            listener.close()
         self._server_was_running = False
 
         tasks = list(self._client_tasks)
@@ -707,6 +741,11 @@ class RigctldServer:
             task.cancel()
         if tasks:
             await asyncio.gather(*tasks, return_exceptions=True)
+
+        if listener is not None:
+            # Prompt now: every handler has run its teardown and dropped its
+            # transport, so nothing is left for this to wait on.
+            await listener.wait_closed()
 
         logger.info("rigctld stopped")
 
@@ -1017,13 +1056,19 @@ class RigctldServer:
             )
         finally:
             self._rate_windows.pop(client_id, None)
-            await self._release_session_tx(session_id)
             try:
-                writer.close()
-                await writer.wait_closed()
-            except OSError:
-                pass
-            logger.info("client #%d disconnected", client_id)
+                await self._release_session_tx(session_id)
+            finally:
+                # Unconditional, and nested so no failure above can skip it:
+                # since 3.12 the listener's ``wait_closed()`` returns only once
+                # every accepted connection has gone, so a socket abandoned
+                # here would leave ``stop()`` waiting on it forever (MOR-1014).
+                try:
+                    writer.close()
+                    await writer.wait_closed()
+                except (OSError, asyncio.CancelledError):
+                    pass
+                logger.info("client #%d disconnected", client_id)
 
     # ------------------------------------------------------------------
     # Line reader

--- a/tests/test_rigctld_managed_tx.py
+++ b/tests/test_rigctld_managed_tx.py
@@ -30,7 +30,10 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import socket
+import struct
 from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import asynccontextmanager
 
 import pytest
 
@@ -80,8 +83,10 @@ class _Radio:
 class _Managed:
     """A managed rig plus the two views the assertions need: wire and policy."""
 
-    def __init__(self, runtime: ManagedRadioRuntime, wire: list[str]) -> None:
-        self.runtime, self.wire = runtime, wire
+    def __init__(
+        self, runtime: ManagedRadioRuntime, wire: list[str], provider: _Provider
+    ) -> None:
+        self.runtime, self.wire, self.provider = runtime, wire, provider
         self.radio = _Radio(runtime)
         self.handler = RigctldHandler(self.radio, RigctldConfig())  # type: ignore[arg-type]
 
@@ -103,12 +108,17 @@ async def managed() -> AsyncIterator[_MakeManaged]:
     """
     runtimes: list[ManagedRadioRuntime] = []
 
-    async def _make(*, keyed_by: TxOwner | None = None) -> _Managed:
+    async def _make(
+        *,
+        keyed_by: TxOwner | None = None,
+        provider_factory: Callable[[list[str]], _Provider] = _Provider,
+    ) -> _Managed:
         wire: list[str] = []
+        provider = provider_factory(wire)
         runtime = ManagedRadioRuntime(
             "rigctld-test",
             service_factory=managed_tx_effect_service,
-            provider_lifecycle=_Provider(wire),
+            provider_lifecycle=provider,
         )
         runtimes.append(runtime)
         await runtime.replace_provider(ready=True)
@@ -116,7 +126,7 @@ async def managed() -> AsyncIterator[_MakeManaged]:
         if keyed_by is not None:
             assert (await runtime.request_on(keyed_by)).outcome is TxOutcome.ACCEPTED
         wire.clear()
-        return _Managed(runtime, wire)
+        return _Managed(runtime, wire, provider)
 
     yield _make
 
@@ -354,3 +364,406 @@ async def test_a_dropped_connection_hands_the_lease_to_the_next_client(
             await writer.wait_closed()
         tcp.close()
         await tcp.wait_closed()
+
+
+# ---------------------------------------------------------------------------
+# Session loss: every way a connection can end
+# ---------------------------------------------------------------------------
+
+
+class _Gated(_Provider):
+    """A provider whose first write in one direction parks until released.
+
+    The only way to hold a rigctld session inside an in-flight PTT write long
+    enough to cancel it. One direction at a time: gating the key asks what a
+    cancelled key may still do afterwards, gating the unkey asks whether the
+    teardown handback survives being cancelled, and each leaves the other
+    direction free to reach the wire so the answer is readable there.
+    """
+
+    def __init__(self, log: list[str], *, direction: bool) -> None:
+        super().__init__(log)
+        self.direction = direction
+        self.reached = asyncio.Event()
+        self.gate = asyncio.Event()
+
+    async def _write_managed_ptt(self, generation: int, on: bool) -> None:
+        if on is self.direction and not self.reached.is_set():
+            self.reached.set()
+            await self.gate.wait()
+        await super()._write_managed_ptt(generation, on)
+
+
+def _count_releases(handler: RigctldHandler) -> list[str]:
+    """Record every teardown release the server drives, in order.
+
+    The count is half the claim — ``[]`` is a stranded lease and two entries is
+    a second release path nobody audited — and the session id in it is the
+    other half: a per-request id here could never match the lease that was
+    taken, so the rig would stay keyed with the count still reading 1.
+    """
+    log: list[str] = []
+    real = handler.release_session_tx
+
+    async def _counting(session_id: str) -> None:
+        log.append(session_id)
+        await real(session_id)
+
+    handler.release_session_tx = _counting  # type: ignore[method-assign]
+    return log
+
+
+@asynccontextmanager
+async def _serving(
+    rig: _Managed, **overrides: object
+) -> AsyncIterator[tuple[RigctldServer, int]]:
+    """A real listener over the real accept path, on an ephemeral port.
+
+    ``_accept_client`` rather than ``_handle_client`` because the cancellation
+    and shutdown cases are about the task registry it fills: ``stop()`` has
+    nothing to cancel if the connection was never registered there.
+    """
+    server = RigctldServer(
+        rig.radio,  # type: ignore[arg-type]
+        RigctldConfig(**overrides),  # type: ignore[arg-type]
+        _protocol=rigctld_protocol,
+        _handler=rig.handler,
+    )
+    tcp = await asyncio.start_server(
+        server._accept_client,  # noqa: SLF001
+        host="127.0.0.1",
+        port=0,
+    )
+    # Handing the listener over is what puts ``stop()``'s own shutdown ordering
+    # under test rather than a listener the test closes itself.
+    server._server = tcp  # noqa: SLF001
+    try:
+        yield server, int(tcp.sockets[0].getsockname()[1])
+    finally:
+        await asyncio.wait_for(server.stop(), timeout=_SHUTDOWN_BUDGET)
+
+
+async def _keyed_client(port: int) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+    """Connect, key, and prove the lease is this connection's before losing it."""
+    reader, writer = await asyncio.open_connection("127.0.0.1", port)
+    writer.write(b"T 1\n")
+    await writer.drain()
+    assert await reader.readline() == b"RPRT 0\n"
+    return reader, writer
+
+
+# Well clear of a real teardown, nowhere near ``client_timeout``: the point of
+# the bound is that shutdown must never be paid for out of the idle clock.
+_SHUTDOWN_BUDGET = 10.0
+_IDLE_CLOCK = 0.25
+
+
+@pytest.mark.parametrize(
+    "loss", ["eof", "quit", "reset", "idle_timeout", "cancellation", "shutdown"]
+)
+async def test_every_way_a_session_ends_hands_the_lease_back_exactly_once(
+    managed: _MakeManaged, loss: str
+) -> None:
+    """One release per lost session, on every path out of the session loop.
+
+    Six ways a WSJT-X connection ends and one guarantee: the lease goes back
+    once, under the id it was taken with. The paths are not variations on a
+    theme — EOF and ``q`` leave the loop, a reset and a cancellation unwind it,
+    the idle clock breaks it, and shutdown reaches in from outside — and only
+    the ``finally`` covers all six. Anything narrower strands a transmitter on
+    the paths it misses; anything that fires twice is a release path nobody
+    audited, and the second one carries a spent lease.
+    """
+    rig = await managed()
+    releases = _count_releases(rig.handler)
+
+    async with _serving(
+        rig,
+        client_timeout=_IDLE_CLOCK if loss == "idle_timeout" else 300.0,
+    ) as (server, port):
+        reader, writer = await _keyed_client(port)
+        assert rig.owner == _MINE
+        rig.wire.clear()
+
+        try:
+            if loss == "eof":
+                writer.close()
+                await writer.wait_closed()
+            elif loss == "quit":
+                writer.write(b"q\n")
+                await writer.drain()
+            elif loss == "reset":
+                # SO_LINGER 0 makes close() send an RST, so the server unwinds
+                # through ``ConnectionResetError`` instead of a clean EOF.
+                writer.get_extra_info("socket").setsockopt(
+                    socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("ii", 1, 0)
+                )
+                writer.close()
+            elif loss == "idle_timeout":
+                pass  # the server's own idle clock ends it
+            elif loss == "cancellation":
+                for task in list(server._client_tasks):  # noqa: SLF001
+                    task.cancel()
+            else:
+                # Bounded because the failure mode is a hang, not a wrong
+                # value: a stop() that waits the listener out before retiring
+                # its sessions blocks for the whole idle clock, with the rig
+                # still keyed for every second of it.
+                await asyncio.wait_for(server.stop(), timeout=_SHUTDOWN_BUDGET)
+
+            await _settle(lambda: rig.owner is None, what=f"the {loss} handback")
+        finally:
+            writer.close()
+
+    assert releases == [_SESSION]
+    assert rig.wire == _UNKEY_WIRE
+    assert rig.radio.legacy_writes == []
+
+
+async def test_a_cancelled_key_cannot_reach_the_rig_once_the_session_is_gone(
+    managed: _MakeManaged,
+) -> None:
+    """A key cancelled mid-flight must not land behind its own release.
+
+    The ordering is the whole claim. The session's ``finally`` releases the
+    lease, so any part of the cancelled ``PTT ON`` still able to run afterwards
+    keys a rig that has no owner left to unkey it — the lease is spent, the
+    watchdog retired with it, and nothing in the product is watching. Detaching
+    the command from the connection that raised it (spawning it, shielding it
+    so the socket loop stays responsive) is exactly how that happens, and it is
+    what this rules out: the last thing on the wire has to be the unkey.
+    """
+    rig = await managed(provider_factory=lambda wire: _Gated(wire, direction=True))
+    gate = rig.provider
+    assert isinstance(gate, _Gated)
+
+    async with _serving(rig) as (server, port):
+        _reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        try:
+            writer.write(b"T 1\n")
+            await writer.drain()
+            await _settle(gate.reached.is_set, what="the key reaching the wire")
+
+            for task in list(server._client_tasks):  # noqa: SLF001
+                task.cancel()
+            gate.gate.set()  # anything still holding the key may proceed now
+
+            await _settle(lambda: rig.owner is None, what="the handback")
+            # Give a detached key every chance to land before reading the wire.
+            for _ in range(20):
+                await asyncio.sleep(0.005)
+        finally:
+            writer.close()
+
+    assert rig.wire[-2:] == _UNKEY_WIRE
+    assert "ptt(on)" not in rig.wire[rig.wire.index("ptt(off)") :]
+    assert rig.runtime.tx_snapshot.phase is not TxPhase.KEYED
+    assert rig.radio.legacy_writes == []
+
+
+async def test_shutdown_cannot_walk_away_from_a_handback_it_interrupted(
+    managed: _MakeManaged,
+) -> None:
+    """``stop()`` may cancel a session; it may not cancel the lease coming back.
+
+    The window is small and entirely real — the intermittent one the parametrised
+    case above hits by luck: a session is already inside its teardown release
+    when shutdown cancels it. Every other step of a teardown may be abandoned
+    there; this one may not. Dropping it leaves the lease standing with the
+    server gone and no client left able to unkey, and nothing behind it: the
+    release obligation stays unsettled at ``RELEASE_REQUIRED`` and no watchdog
+    re-arms, because beginning a release clears the max key-down deadline. It
+    also leaves the socket unclosed, which since 3.12 is on its own enough to
+    make ``stop()`` wait for a connection that will never come back.
+    """
+    rig = await managed(provider_factory=lambda wire: _Gated(wire, direction=False))
+    gate = rig.provider
+    assert isinstance(gate, _Gated)
+    releases = _count_releases(rig.handler)
+
+    async with _serving(rig) as (server, port):
+        _reader, writer = await _keyed_client(port)
+        assert rig.owner == _MINE
+        rig.wire.clear()
+
+        writer.close()  # EOF: the session drops into its teardown release
+        await _settle(gate.reached.is_set, what="the handback reaching the wire")
+
+        stopping = asyncio.ensure_future(server.stop())
+        await asyncio.sleep(0)  # far enough for stop() to cancel the session
+        gate.gate.set()  # whatever survived the cancellation may finish now
+        await asyncio.wait_for(stopping, timeout=_SHUTDOWN_BUDGET)
+
+    assert releases == [_SESSION]
+    assert rig.owner is None
+    assert rig.wire == _UNKEY_WIRE
+    assert rig.radio.legacy_writes == []
+
+
+async def test_a_teardown_cancelled_twice_still_lets_go_of_the_connection(
+    managed: _MakeManaged,
+) -> None:
+    """The handback survives one cancellation by design, not two — the socket must.
+
+    A hard shutdown does not cancel politely once, and the second cancellation
+    does end the handback: awaiting the shielded task makes it this session's
+    ``_fut_waiter`` again, so the lease that was on its way back stays held —
+    stuck at ``RELEASE_REQUIRED`` with an unfinished WRITE_OFF and no watchdog
+    to fall back on, since beginning a release clears the max key-down deadline
+    and ``tick`` re-arms it only while no release is pending. That is the
+    honest boundary, it belongs to the uncertain-shutdown surface (MOR-1015),
+    and it is not what this pins. What the second cancellation may not do is
+    take the accepted
+    connection down with it: since 3.12 an unclosed one keeps the listener's
+    ``wait_closed()`` waiting for a client that is already gone, so the cost of
+    skipping that close is not a logged warning but a ``stop()`` that never
+    returns — and a rigctld that will not stop is a rigctld nobody can take off
+    the air.
+    """
+    rig = await managed(provider_factory=lambda wire: _Gated(wire, direction=False))
+    gate = rig.provider
+    assert isinstance(gate, _Gated)
+    releases = _count_releases(rig.handler)
+
+    async with _serving(rig) as (server, port):
+        _reader, writer = await _keyed_client(port)
+        assert rig.owner == _MINE
+        rig.wire.clear()
+
+        writer.close()  # EOF: the session drops into its teardown release
+        await _settle(gate.reached.is_set, what="the handback reaching the wire")
+
+        sessions = list(server._client_tasks)  # noqa: SLF001
+        for _ in range(200):
+            if all(task.done() for task in sessions):
+                break
+            for task in sessions:
+                task.cancel()
+            await asyncio.sleep(0.001)
+        assert all(task.done() for task in sessions), "the session never ended"
+
+        gate.gate.set()  # nothing is parked on it now; belt and braces
+        await asyncio.wait_for(server.stop(), timeout=_SHUTDOWN_BUDGET)
+
+    assert releases == [_SESSION]  # attempted once, from the one path there is
+    assert rig.radio.legacy_writes == []
+
+
+async def test_teardown_shuts_the_door_before_it_starts_retiring_sessions(
+    managed: _MakeManaged,
+) -> None:
+    """A server that has begun shutting down may not accept another client.
+
+    The other half of ``stop()``'s ordering, and the half that is invisible if
+    you only watch the sessions that already exist: the listener has to close
+    *before* the cancellations go out, not after. Cancelling first leaves the
+    door open for the whole cancel-and-gather window — which is exactly as long
+    as the slowest handback — and a WSJT-X arriving in it is accepted into a
+    server that is going away. Its session was never in the set that got
+    cancelled, so it can key a rig nothing will ever unkey, and its socket then
+    holds ``wait_closed()`` open behind it. Refusing the connection is the only
+    answer that leaves no such session.
+    """
+    rig = await managed(provider_factory=lambda wire: _Gated(wire, direction=False))
+    gate = rig.provider
+    assert isinstance(gate, _Gated)
+
+    async with _serving(rig) as (server, port):
+        _reader, writer = await _keyed_client(port)
+        assert rig.owner == _MINE
+
+        # Park the departing session inside its handback: that is what holds
+        # the cancel-and-gather window open long enough for a client to race in.
+        writer.close()
+        await _settle(gate.reached.is_set, what="the handback reaching the wire")
+
+        stopping = asyncio.ensure_future(server.stop())
+        await asyncio.sleep(0)  # stop() runs to its first await, sessions parked
+
+        with pytest.raises(OSError):  # ConnectionRefusedError, if it is refused
+            latecomer = await asyncio.wait_for(
+                asyncio.open_connection("127.0.0.1", port), timeout=2.0
+            )
+            latecomer[1].close()  # only reached when the door was left open
+
+        gate.gate.set()
+        await asyncio.wait_for(stopping, timeout=_SHUTDOWN_BUDGET)
+
+    assert rig.owner is None
+    assert rig.radio.legacy_writes == []
+
+
+# ---------------------------------------------------------------------------
+# Lease qualification and the shared target
+# ---------------------------------------------------------------------------
+
+
+async def test_a_spent_sessions_unkey_cannot_de_key_the_newer_owner(
+    managed: _MakeManaged,
+) -> None:
+    """An OFF carrying a spent lease is not a licence over the current one.
+
+    The dangerous shape is same-source, not foreign-source: two rigctld
+    sessions on one server look alike everywhere except the connection id, so
+    anything that qualifies an unkey by *source* rather than by the whole
+    identity would let a departing WSJT-X take the live one's transmission
+    down. Both of the spent session's routes are tried — a late ``T 0`` on the
+    wire and the teardown release its socket drives — and the same session
+    unkeying its own lease still works, so this is qualification and not a
+    blanket refusal.
+    """
+    older, newer = "rigctld-client-1", "rigctld-client-2"
+    rig = await managed()
+    await rig.handler.execute(_ptt("1"), session_id=older)
+    await rig.handler.execute(_ptt("0"), session_id=older)  # lease spent
+    assert (await rig.handler.execute(_ptt("1"), session_id=newer)).error is (
+        HamlibError.OK
+    )
+    assert rig.owner == TxOwner(TxSource.RIGCTLD, newer)
+    rig.wire.clear()
+
+    late = await rig.handler.execute(_ptt("0"), session_id=older)
+    await rig.handler.release_session_tx(older)
+
+    # ``RPRT 0`` because WSJT-X reads a nonzero RPRT mid-sequence as a hard
+    # rig-control failure; nothing written because the lease is not this one's.
+    assert late.error is HamlibError.OK
+    assert rig.owner == TxOwner(TxSource.RIGCTLD, newer)
+    assert rig.runtime.tx_snapshot.phase is TxPhase.KEYED
+    assert rig.wire == []
+    assert rig.radio.legacy_writes == []
+
+    assert (await rig.handler.execute(_ptt("0"), session_id=newer)).error is (
+        HamlibError.OK
+    )
+    assert rig.owner is None
+    assert rig.wire == _UNKEY_WIRE
+
+
+async def test_a_wsjtx_session_contends_for_the_same_target_as_the_web(
+    managed: _MakeManaged,
+) -> None:
+    """One rig, one target, one lease — rigctld included.
+
+    A private supervisor for rigctld would pass every test that only ever looks
+    at rigctld: keys accepted, leases released, teardown clean. It would also
+    let WSJT-X and the web hold the rig at once. So the claim has to be made
+    from the other side of the boundary — while rigctld holds the lease the web
+    ingress must be refused by the very supervisor rigctld keyed through, and
+    must become able to key the moment rigctld gives it back.
+    """
+    rig = await managed()
+    assert (await rig.handler.execute(_ptt("1"), session_id=_SESSION)).error is (
+        HamlibError.OK
+    )
+
+    contended = await rig.runtime.request_on(_OTHER)
+
+    assert contended.outcome is not TxOutcome.ACCEPTED
+    assert rig.owner == _MINE
+
+    assert (await rig.handler.execute(_ptt("0"), session_id=_SESSION)).error is (
+        HamlibError.OK
+    )
+    assert (await rig.runtime.request_on(_OTHER)).outcome is TxOutcome.ACCEPTED
+    assert rig.owner == _OTHER


### PR DESCRIPTION
## Summary

MOR-1014's ManagedTxApi routing for rigctld sessions was already on main (#2148). Driving the ticket's unpinned acceptance paths surfaced two real shutdown-path defects in `src/rigplane/rigctld/server.py`, both fixed here:

- **D1 — shutdown order:** `stop()` awaited `Server.wait_closed()` *before* cancelling client tasks. On Python 3.12+ `wait_closed()` waits for accepted-connection handlers, so a single idle WSJT-X socket parked shutdown for the full `client_timeout` (300 s default) **with the rig keyed and the lease unreleased**. Reordered to close-listener → cancel → gather → wait. Measured `stop()` with one idle client: 0.0025 s (was a 300 s park). 3.11 does not exhibit D1 — the per-PR quick gate is structurally blind to it (policy ticket MOR-1234); this PR merges with `[full-ci]`.
- **D2 — cancelled teardown skipping the lease handback:** a `CancelledError` inside the handback skipped both the lease release and `writer.close()`, after which `stop()` hung on the abandoned transport. Fixed with a shielded handback plus a nested `finally` guaranteeing socket close. Independent review also proved the *single*-cancel variant of this wedge was reachable from ordinary shutdown pre-fix and is clean post-fix.

Net: `server.py` +55/−17 (~13 net executable + honest doctrine comments), `tests/test_rigctld_managed_tx.py` +12 test cases (+~400 LOC), `handler.py` untouched, facade untouched.

## Independent verification (adversarial, two cycles)

- Defects proven real per-interpreter: 3.11 `wait_closed` returns 0.000 s / 3.12–3.13 block with a live handler; pre-fix code fails the new tests deterministically on 3.13; D2's lease half fails on 3.11 too.
- Shield adjudication: double-cancel ends the handback (documented honestly — lease stays `RELEASE_REQUIRED`, **no watchdog re-arms**, surfaced via the uncertain-shutdown diagnostics path, MOR-1015); no stale-release against a newer owner (owner captured at bind, full `TxOwner` match); every path closes the writer; exactly-once release preserved (asserted as `== [_SESSION]`).
- Mutation battery (PYTHONDONTWRITEBYTECODE=1): 7 builder mutations + 6 reviewer mutations; all load-bearing ones killed, incl. the close-listener-first ordering pinned by `test_teardown_shuts_the_door_before_it_starts_retiring_sessions` (cycle-1 addition; swap-order → exactly that test fails). Survivors adjudicated benign in the review artifact.
- Acceptance mapped test-by-test: EOF/reset/timeout/cancellation/shutdown release exactly once; cancellation cannot replay ON; stale-session OFF cannot de-key a newer owner; shared target namespace ruled sufficient (`web/radio_poller.py:1345` and `rigctld/handler.py:1459` bind the same `bind_managed_tx`, one supervisor per radio).
- Suites: focused rigctld 474 passed (incl. 3.11 run); full quick suite green except one pre-existing flake in an untouched file (green 3/3 in isolation); ruff/format/lint-imports/mypy all at baseline.

Linear: MOR-1014 (gates MOR-987 → MOR-1102 release chain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
