### PR TITLE
feat(MOR-1061): enforce v3 package boundary zones ahead of the code

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,13 +1,21 @@
 /**
- * ESLint flat config — frontend architecture guardrails (v2 layering only).
+ * ESLint flat config — frontend architecture guardrails.
  *
- * Enforces import boundaries defined in ADR 2026-04-12:
- *   - Presentational components (panels, layout, skins, semantic, primitives)
- *     must NOT import runtime/transport modules directly (alias or relative).
- *   - Only wiring/ (adapter layer) and lib/ internals may import these.
- *   - lib/runtime/** must NOT import from components-v2/ (no circular deps).
+ * Enforces import boundaries from ADR 2026-04-12 and the v3 composition ADR
+ * (2026-07-25, MOR-1061). MOR-1061 additions:
+ *   - semantic/ must not import skins/ (skins depend on semantic, not vice
+ *     versa) or the runtime barrel/frontend-runtime (aggregates transport,
+ *     audioManager, stores — April ADR's "runtime/" ban, review cycle 1 F1).
+ *   - presentation/ (layouts, design languages) must not import transport,
+ *     commands, stores/raw-capabilities, or the runtime barrel.
+ *   - presentation/workspace/ additionally must not reference component
+ *     module paths (stable IDs only).
+ *   - primitives/ may import only themes/Svelte/types (April ADR, F3).
+ *   - lib/runtime/** must not import from components-v2/, presentation/, or
+ *     semantic/ (ADR invariant 1, F2; adapters keep full runtime access).
  *
  * @see docs/plans/2026-04-12-target-frontend-architecture.md
+ * @see docs/plans/2026-07-25-ui-composition-architecture-v3.md
  */
 
 import tsParser from '@typescript-eslint/parser';
@@ -40,6 +48,65 @@ const FORBIDDEN_RUNTIME_IMPORTS = {
         'Presentation components must not import audioManager directly (relative paths included). ' +
         'Use callback props from the adapter/wiring layer instead. ' +
         'See ADR 2026-04-12.',
+    },
+  ],
+};
+
+/**
+ * Runtime-internals lockdown (MOR-1061 review cycles 1-2, F1/C1-A/C1-B).
+ * The barrel, frontend-runtime, system-controller, scope-controller, and
+ * tx-controller/app-host (the sole TX authority — v3 ADR invariant 11) all
+ * aggregate transport/audioManager/stores or own exclusive state behind one
+ * import, so banning only the individual specifiers (transport, stores,
+ * audioManager) is bypassable through them. NOT applied to lib/runtime/**
+ * itself — adapters/props keep full access (see "lib/runtime isolation"
+ * below).
+ *
+ * The relative-path form uses `regex`, not `group`: ESLint's gitignore-style
+ * `group` glob matches a bare final segment as a DIRECTORY prefix, so
+ * `**\/lib/runtime` also matched `lib/runtime/adapters/*` and
+ * `lib/runtime/props/*` — the exact paths this ban must NOT touch (cycle-1
+ * finding C1-A). `regex` with a `$`-anchored alternation avoids that; `!`
+ * negation on `group` does not fix it.
+ */
+const RUNTIME_INTERNALS_MSG =
+  'Must not import runtime internals directly (barrel, frontend-runtime, controllers, or the ' +
+  'TX-authority app-host) — alias or relative. Consume adapters/view models instead. ' +
+  'See v3 ADR invariants 5, 6, 11.';
+const FORBIDDEN_RUNTIME_BARREL = {
+  paths: [
+    { name: '$lib/runtime', message: RUNTIME_INTERNALS_MSG },
+    { name: '$lib/runtime/index', message: RUNTIME_INTERNALS_MSG },
+    { name: '$lib/runtime/frontend-runtime', message: RUNTIME_INTERNALS_MSG },
+    { name: '$lib/runtime/system-controller', message: RUNTIME_INTERNALS_MSG },
+    { name: '$lib/runtime/scope-controller.svelte', message: RUNTIME_INTERNALS_MSG },
+    { name: '$lib/runtime/tx-controller/app-host', message: RUNTIME_INTERNALS_MSG },
+  ],
+  patterns: [
+    {
+      regex:
+        '(^|/)lib/runtime(/index|/frontend-runtime|/system-controller|' +
+        '/scope-controller\\.svelte|/tx-controller/app-host)?$',
+      message: RUNTIME_INTERNALS_MSG,
+    },
+  ],
+};
+
+/**
+ * Semantic-specific lockdown (MOR-1061). Semantic UI depends on adapter
+ * view models and primitives, never on a concrete skin — skins depend on
+ * semantic, not the reverse. See v3 ADR invariant 3.
+ */
+const FORBIDDEN_SEMANTIC_IMPORTS = {
+  paths: [...FORBIDDEN_RUNTIME_IMPORTS.paths, ...FORBIDDEN_RUNTIME_BARREL.paths],
+  patterns: [
+    ...FORBIDDEN_RUNTIME_IMPORTS.patterns,
+    ...FORBIDDEN_RUNTIME_BARREL.patterns,
+    {
+      group: ['$lib/skins/*', '**/skins/**'],
+      message:
+        'Semantic UI must not import skins/manufacturer modules — skins depend on ' +
+        'semantic, never the reverse. See v3 ADR.',
     },
   ],
 };
@@ -84,6 +151,81 @@ const FORBIDDEN_PANEL_IMPORTS = {
         'Presentation components must not import audioManager directly. ' +
         'Use callback props from the adapter/wiring layer instead. ' +
         'See ADR 2026-04-12.',
+    },
+  ],
+};
+
+/** Shared: no direct command-module calls — consume bound adapter callbacks instead. */
+const FORBIDDEN_COMMANDS_PATTERN = {
+  group: ['$lib/runtime/commands/*', '**/lib/runtime/commands/*', '**/wiring/command-bus'],
+  message:
+    'Must not call command modules directly — consume bound callbacks from ' +
+    'adapters/view models instead. See v3 ADR.',
+};
+
+/**
+ * Presentation lockdown — layouts and design languages (MOR-1061). No
+ * transport, stores (incl. raw capabilities), audioManager, runtime
+ * internals (F1/C1-A/C1-B), or direct command calls — consume bound
+ * callbacks from adapters/view models instead. See "Target ownership" in
+ * the v3 ADR for what lives under presentation/ (layouts, design
+ * languages, themes, workspace).
+ */
+const FORBIDDEN_PRESENTATION_IMPORTS = {
+  paths: [...FORBIDDEN_PANEL_IMPORTS.paths, ...FORBIDDEN_RUNTIME_BARREL.paths],
+  patterns: [
+    ...FORBIDDEN_PANEL_IMPORTS.patterns,
+    ...FORBIDDEN_RUNTIME_BARREL.patterns,
+    FORBIDDEN_COMMANDS_PATTERN,
+  ],
+};
+
+/**
+ * Primitives lockdown (MOR-1061 review cycle 1 F3; cycle 2 minor 1 adds the
+ * commands/semantic/components-v2 bans to match the row this zone cites).
+ * April ADR: primitives are shared visual atoms and may import only
+ * "Themes, Svelte, types" — forbidden from runtime, adapters, transport,
+ * audio, stores. Also forbidden from commands (same reasoning as
+ * presentation) and from semantic/components-v2, which depend on
+ * primitives, never the reverse.
+ */
+const FORBIDDEN_PRIMITIVES_IMPORTS = {
+  paths: [...FORBIDDEN_PANEL_IMPORTS.paths, ...FORBIDDEN_RUNTIME_BARREL.paths],
+  patterns: [
+    ...FORBIDDEN_PANEL_IMPORTS.patterns,
+    ...FORBIDDEN_RUNTIME_BARREL.patterns,
+    FORBIDDEN_COMMANDS_PATTERN,
+    {
+      group: ['$lib/runtime/adapters/*', '**/lib/runtime/adapters/**'],
+      message:
+        'Primitives are shared visual atoms — no adapters, runtime, transport, audio, or ' +
+        'stores. Only themes, Svelte, and types. See ADR 2026-04-12 ("Primitives" row).',
+    },
+    {
+      group: ['**/semantic/**', '**/components-v2/**'],
+      message:
+        'Primitives must not import semantic/ or components-v2/ — both depend on ' +
+        'primitives, never the reverse. See ADR 2026-04-12 ("Primitives" row).',
+    },
+  ],
+};
+
+/**
+ * Workspace lockdown (MOR-1061). Workspace preferences "reference stable
+ * IDs, never component module paths" (v3 ADR invariant 6) — ID-to-component
+ * resolution belongs to the layout/skin registry, not persisted workspace
+ * data. Inherits the full presentation ban since workspace lives under
+ * presentation/.
+ */
+const FORBIDDEN_WORKSPACE_IMPORTS = {
+  paths: FORBIDDEN_PRESENTATION_IMPORTS.paths,
+  patterns: [
+    ...FORBIDDEN_PRESENTATION_IMPORTS.patterns,
+    {
+      group: ['**/skins/**', '**/semantic/**', '**/primitives/**', '**/components-v2/**'],
+      message:
+        'Workspace must reference stable layout/design-language IDs, never component ' +
+        'module paths. See v3 ADR.',
     },
   ],
 };
@@ -152,13 +294,56 @@ export default [
       'src/components-v2/meters/**/*.svelte',
       'src/components-v2/vfo/**/*.svelte',
       'src/components-v2/controls/**/*.svelte',
-      // Future layers:
-      'src/semantic/**/*.svelte',
+      // semantic and primitives get their own stricter blocks below (MOR-1061):
       'src/skins/**/*.svelte',
-      'src/primitives/**/*.svelte',
     ],
     rules: {
       'no-restricted-imports': ['error', FORBIDDEN_RUNTIME_IMPORTS],
+    },
+  },
+
+  // ── Import boundary: semantic (MOR-1061; F1 adds the runtime-barrel ban) ──
+  // No skins/manufacturer modules (skins depend on semantic, never reverse).
+  {
+    files: ['src/semantic/**/*.svelte', 'src/semantic/**/*.ts'],
+    rules: {
+      'no-restricted-imports': ['error', FORBIDDEN_SEMANTIC_IMPORTS],
+    },
+  },
+
+  // ── Import boundary: primitives (MOR-1061 review cycle 1, F3) ──
+  // Shared visual atoms — themes/Svelte/types only. See ADR 2026-04-12.
+  {
+    files: ['src/primitives/**/*.svelte', 'src/primitives/**/*.ts'],
+    rules: {
+      'no-restricted-imports': ['error', FORBIDDEN_PRIMITIVES_IMPORTS],
+    },
+  },
+
+  // ── Import boundary: presentation — layouts, design languages (MOR-1061) ──
+  // No transport, stores/capabilities, audioManager, runtime barrel/
+  // frontend-runtime (F1), or direct command calls.
+  {
+    files: ['src/presentation/**/*.svelte', 'src/presentation/**/*.ts'],
+    rules: {
+      'no-restricted-imports': ['error', FORBIDDEN_PRESENTATION_IMPORTS],
+    },
+  },
+
+  // ── Import boundary: workspace (MOR-1061; cycle 2 minor 2 adds .svelte
+  // and the plural workspaces/ variant — cycle-0 finding F5) ──
+  // Adds a module-path ban on top of the presentation ban above. Ordered
+  // after the presentation block so this fully-merged rule wins for the
+  // overlapping file set (flat config replaces, not merges, per rule key).
+  {
+    files: [
+      'src/presentation/workspace/**/*.ts',
+      'src/presentation/workspace/**/*.svelte',
+      'src/presentation/workspaces/**/*.ts',
+      'src/presentation/workspaces/**/*.svelte',
+    ],
+    rules: {
+      'no-restricted-imports': ['error', FORBIDDEN_WORKSPACE_IMPORTS],
     },
   },
 
@@ -178,8 +363,9 @@ export default [
   },
 
   // ── Import boundary: lib/runtime isolation ──
-  // lib/runtime must NOT import from components-v2 to prevent circular dependencies.
-  // See ADR 2026-04-12 and issue #1005.
+  // lib/runtime must NOT import from components-v2 (circular deps, ADR
+  // 2026-04-12, issue #1005) or from presentation/semantic (v3 ADR
+  // invariant 1, MOR-1061 review cycle 1 F2).
   {
     files: [
       'src/lib/runtime/**/*.ts',
@@ -197,6 +383,12 @@ export default [
                 'lib/runtime must not import from components-v2. ' +
                 'Use lib/runtime/props/ or lib/runtime/commands/ instead. ' +
                 'See ADR 2026-04-12.',
+            },
+            {
+              group: ['**/presentation/**', '**/presentation', '**/semantic/**', '**/semantic'],
+              message:
+                'lib/runtime must not import from presentation/ or semantic/. ' +
+                'See v3 ADR invariant 1 (MOR-1061 F2).',
             },
           ],
         },

--- a/frontend/src/__tests__/architecture-boundaries.test.ts
+++ b/frontend/src/__tests__/architecture-boundaries.test.ts
@@ -1,0 +1,361 @@
+/**
+ * Architecture boundary tests (MOR-1061).
+ *
+ * Proves the eslint.config.js import-boundary rules for the v3 package
+ * split — semantic/, presentation/, presentation/workspace/, and
+ * lib/runtime/adapters/ — actually reject forbidden imports and accept
+ * legal ones. Lints virtual fixture files (the paths need not exist on
+ * disk) through the real flat config, so a rule regression here fails the
+ * same way `npm run lint` would.
+ *
+ * See docs/plans/2026-07-25-ui-composition-architecture-v3.md
+ * ("Dependency and product invariants", "Target ownership") and
+ * docs/plans/2026-04-12-target-frontend-architecture.md.
+ */
+import { describe, it, expect } from 'vitest';
+import { ESLint } from 'eslint';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const FRONTEND_ROOT = path.resolve(fileURLToPath(import.meta.url), '../../..');
+
+async function restrictedImportHits(code: string, filePath: string): Promise<number> {
+  const eslint = new ESLint({ cwd: FRONTEND_ROOT });
+  const [result] = await eslint.lintText(code, { filePath });
+  return result.messages.filter((m) => m.ruleId === 'no-restricted-imports').length;
+}
+
+describe('v3 package boundaries (MOR-1061)', () => {
+  it('rejects semantic importing skins', async () => {
+    const hits = await restrictedImportHits(
+      `import LcdSkin from '../skins/amber-lcd/LcdSkin.svelte';`,
+      'src/semantic/VfoDisplay.ts',
+    );
+    expect(hits).toBeGreaterThan(0);
+  });
+
+  it('allows semantic importing primitives', async () => {
+    const hits = await restrictedImportHits(
+      `import Button from '../primitives/SegmentedButton.svelte';`,
+      'src/semantic/VfoDisplay.ts',
+    );
+    expect(hits).toBe(0);
+  });
+
+  it('rejects presentation (layouts/design languages) importing transport', async () => {
+    const hits = await restrictedImportHits(
+      `import { sendCommand } from '$lib/transport/ws-client';`,
+      'src/presentation/layouts/SpectrumFirst.ts',
+    );
+    expect(hits).toBeGreaterThan(0);
+  });
+
+  it('rejects presentation importing commands', async () => {
+    const hits = await restrictedImportHits(
+      `import { makeVfoHandlers } from '$lib/runtime/commands/panel-commands';`,
+      'src/presentation/layouts/SpectrumFirst.ts',
+    );
+    expect(hits).toBeGreaterThan(0);
+  });
+
+  it('rejects presentation importing the raw capabilities store', async () => {
+    const hits = await restrictedImportHits(
+      `import { getCapabilities } from '$lib/stores/capabilities.svelte';`,
+      'src/presentation/languages/RigplaneModern.ts',
+    );
+    expect(hits).toBeGreaterThan(0);
+  });
+
+  it('rejects workspace importing a skin module path', async () => {
+    const hits = await restrictedImportHits(
+      `import LcdSkin from '../../skins/amber-lcd/LcdSkin.svelte';`,
+      'src/presentation/workspace/preferences.ts',
+    );
+    expect(hits).toBeGreaterThan(0);
+  });
+
+  it('workspace still inherits the presentation transport ban', async () => {
+    const hits = await restrictedImportHits(
+      `import { sendCommand } from '$lib/transport/ws-client';`,
+      'src/presentation/workspace/preferences.ts',
+    );
+    expect(hits).toBeGreaterThan(0);
+  });
+
+  it('allows adapters to consume runtime and the capabilities store', async () => {
+    const hits = await restrictedImportHits(
+      `import { runtime } from '../frontend-runtime';\n` +
+        `import { getCapabilities } from '$lib/stores/capabilities.svelte';`,
+      'src/lib/runtime/adapters/vfo-adapter.ts',
+    );
+    expect(hits).toBe(0);
+  });
+
+  it('rejects adapters importing components-v2 (pre-existing isolation rule, still live)', async () => {
+    const hits = await restrictedImportHits(
+      `import VfoPanel from '../../../components-v2/panels/VfoPanel.svelte';`,
+      'src/lib/runtime/adapters/vfo-adapter.ts',
+    );
+    expect(hits).toBeGreaterThan(0);
+  });
+
+  // ── Review cycle 1, F1: runtime-barrel bypass ──────────────────────────
+  // $lib/runtime and $lib/runtime/frontend-runtime aggregate transport,
+  // audioManager, and stores behind one import; banning only the individual
+  // specifiers left this open. Cover alias, barrel (index), and relative
+  // forms, and re-confirm adapters keep full access after the tightened ban.
+
+  it('rejects semantic importing the runtime barrel (alias)', async () => {
+    const hits = await restrictedImportHits(
+      `import { runtime } from '$lib/runtime';`,
+      'src/semantic/VfoDisplay.ts',
+    );
+    expect(hits).toBeGreaterThan(0);
+  });
+
+  it('rejects semantic importing frontend-runtime directly (alias)', async () => {
+    const hits = await restrictedImportHits(
+      `import { runtime } from '$lib/runtime/frontend-runtime';`,
+      'src/semantic/VfoDisplay.ts',
+    );
+    expect(hits).toBeGreaterThan(0);
+  });
+
+  it('rejects presentation importing the runtime barrel (relative)', async () => {
+    const hits = await restrictedImportHits(
+      `import { runtime } from '../../lib/runtime';`,
+      'src/presentation/layouts/SpectrumFirst.ts',
+    );
+    expect(hits).toBeGreaterThan(0);
+  });
+
+  it('rejects presentation importing frontend-runtime directly (relative)', async () => {
+    const hits = await restrictedImportHits(
+      `import { runtime } from '../../lib/runtime/frontend-runtime';`,
+      'src/presentation/layouts/SpectrumFirst.ts',
+    );
+    expect(hits).toBeGreaterThan(0);
+  });
+
+  it('still allows adapters to import frontend-runtime (alias) after the F1 tightening', async () => {
+    const hits = await restrictedImportHits(
+      `import { runtime } from '$lib/runtime/frontend-runtime';`,
+      'src/lib/runtime/adapters/vfo-adapter.ts',
+    );
+    expect(hits).toBe(0);
+  });
+
+  // ── Review cycle 1, F2: runtime -> presentation/semantic (reverse) ─────
+  // ADR invariant 1: "Runtime imports no adapters or presentation."
+
+  it('rejects lib/runtime importing presentation', async () => {
+    const hits = await restrictedImportHits(
+      `import { SpectrumFirst } from '../../presentation/layouts/SpectrumFirst';`,
+      'src/lib/runtime/frontend-runtime.ts',
+    );
+    expect(hits).toBeGreaterThan(0);
+  });
+
+  it('rejects lib/runtime importing semantic', async () => {
+    const hits = await restrictedImportHits(
+      `import VfoDisplay from '../../semantic/VfoDisplay.svelte';`,
+      'src/lib/runtime/frontend-runtime.ts',
+    );
+    expect(hits).toBeGreaterThan(0);
+  });
+
+  it('still allows lib/runtime to import its own adapters (legal neighbor, no false positive on "presentation-capabilities")', async () => {
+    const hits = await restrictedImportHits(
+      `import { derivePresentationCapabilities } from './adapters/presentation-capabilities';`,
+      'src/lib/runtime/frontend-runtime.ts',
+    );
+    expect(hits).toBe(0);
+  });
+
+  // ── Review cycle 1, F3: primitives had no dedicated zone ────────────────
+  // April ADR: primitives may import only themes/Svelte/types; forbidden
+  // from runtime, adapters, transport, audio, stores.
+
+  it('rejects primitives importing transport', async () => {
+    const hits = await restrictedImportHits(
+      `import { sendCommand } from '$lib/transport/ws-client';`,
+      'src/primitives/Knob.ts',
+    );
+    expect(hits).toBeGreaterThan(0);
+  });
+
+  it('rejects primitives importing stores', async () => {
+    const hits = await restrictedImportHits(
+      `import { getCapabilities } from '$lib/stores/capabilities.svelte';`,
+      'src/primitives/Knob.ts',
+    );
+    expect(hits).toBeGreaterThan(0);
+  });
+
+  it('rejects primitives importing the runtime barrel', async () => {
+    const hits = await restrictedImportHits(
+      `import { runtime } from '$lib/runtime';`,
+      'src/primitives/Knob.ts',
+    );
+    expect(hits).toBeGreaterThan(0);
+  });
+
+  it('rejects primitives importing adapters', async () => {
+    const hits = await restrictedImportHits(
+      `import { toVfoProps } from '$lib/runtime/adapters/vfo-adapter';`,
+      'src/primitives/Knob.ts',
+    );
+    expect(hits).toBeGreaterThan(0);
+  });
+
+  it('allows primitives importing themes and sibling primitives', async () => {
+    const hits = await restrictedImportHits(
+      `import '../themes/tokens.css';\nimport Icon from './Icon.svelte';`,
+      'src/primitives/Knob.ts',
+    );
+    expect(hits).toBe(0);
+  });
+
+  // ── Review cycle 2, C1-A: group-as-directory false positive ────────────
+  // The gitignore-style `group` glob for the runtime-barrel ban matched a
+  // bare final segment as a DIRECTORY prefix, so it also caught the
+  // sanctioned lib/runtime/adapters/* and lib/runtime/props/* paths. Fixed
+  // by switching the relative-path ban to a `$`-anchored `regex`. Pin both
+  // the fix (sanctioned paths pass) and that the ban itself still holds.
+
+  it('allows presentation to import lib/runtime/adapters/* (the C1-A sanctioned path)', async () => {
+    const hits = await restrictedImportHits(
+      `import { toVfoProps } from '../../lib/runtime/adapters/vfo-adapter';`,
+      'src/presentation/layouts/SpectrumFirst.ts',
+    );
+    expect(hits).toBe(0);
+  });
+
+  it('allows presentation to import lib/runtime/props/*', async () => {
+    const hits = await restrictedImportHits(
+      `import type { VfoProps } from '../../lib/runtime/props/vfo-props';`,
+      'src/presentation/layouts/SpectrumFirst.ts',
+    );
+    expect(hits).toBe(0);
+  });
+
+  it('allows semantic to import lib/runtime/adapters/*', async () => {
+    const hits = await restrictedImportHits(
+      `import { toVfoProps } from '../lib/runtime/adapters/vfo-adapter';`,
+      'src/semantic/VfoDisplay.ts',
+    );
+    expect(hits).toBe(0);
+  });
+
+  it('allows semantic to import lib/runtime/props/*', async () => {
+    const hits = await restrictedImportHits(
+      `import type { VfoProps } from '../lib/runtime/props/vfo-props';`,
+      'src/semantic/VfoDisplay.ts',
+    );
+    expect(hits).toBe(0);
+  });
+
+  // ── Review cycle 2, C1-B: ADR INV-6 was only partially encoded ─────────
+  // system-controller, scope-controller, and the TX-authority
+  // tx-controller/app-host (INV-11) were still reachable from
+  // presentation/semantic despite the F1 barrel ban.
+
+  it('rejects semantic importing system-controller directly', async () => {
+    const hits = await restrictedImportHits(
+      `import { systemController } from '$lib/runtime/system-controller';`,
+      'src/semantic/VfoDisplay.ts',
+    );
+    expect(hits).toBeGreaterThan(0);
+  });
+
+  it('rejects semantic importing scope-controller directly', async () => {
+    const hits = await restrictedImportHits(
+      `import { scopeController } from '$lib/runtime/scope-controller.svelte';`,
+      'src/semantic/VfoDisplay.ts',
+    );
+    expect(hits).toBeGreaterThan(0);
+  });
+
+  it('rejects presentation importing tx-controller/app-host (alias) — the TX authority', async () => {
+    const hits = await restrictedImportHits(
+      `import { getAppTxController } from '$lib/runtime/tx-controller/app-host';`,
+      'src/presentation/layouts/SpectrumFirst.ts',
+    );
+    expect(hits).toBeGreaterThan(0);
+  });
+
+  it('rejects presentation importing tx-controller/app-host (relative)', async () => {
+    const hits = await restrictedImportHits(
+      `import { getAppTxController } from '../../lib/runtime/tx-controller/app-host';`,
+      'src/presentation/layouts/SpectrumFirst.ts',
+    );
+    expect(hits).toBeGreaterThan(0);
+  });
+
+  it('still allows adapters to import tx-controller/app-host after C1-B', async () => {
+    const hits = await restrictedImportHits(
+      `import { getAppTxController } from '$lib/runtime/tx-controller/app-host';`,
+      'src/lib/runtime/adapters/vfo-adapter.ts',
+    );
+    expect(hits).toBe(0);
+  });
+
+  // ── Review cycle 2, minor 3: pin the $lib/runtime/index ban ────────────
+  // Mutation testing (verifier's M4) showed this entry was banned but had
+  // no dedicated assertion — removing it left the suite green.
+
+  it('rejects semantic importing $lib/runtime/index specifically', async () => {
+    const hits = await restrictedImportHits(
+      `import { runtime } from '$lib/runtime/index';`,
+      'src/semantic/VfoDisplay.ts',
+    );
+    expect(hits).toBeGreaterThan(0);
+  });
+
+  // ── Review cycle 2, minor 1: primitives commands/semantic/components-v2 ─
+
+  it('rejects primitives importing commands', async () => {
+    const hits = await restrictedImportHits(
+      `import { makeVfoHandlers } from '$lib/runtime/commands/panel-commands';`,
+      'src/primitives/Knob.ts',
+    );
+    expect(hits).toBeGreaterThan(0);
+  });
+
+  it('rejects primitives importing semantic', async () => {
+    const hits = await restrictedImportHits(
+      `import VfoDisplay from '../semantic/VfoDisplay.svelte';`,
+      'src/primitives/Knob.ts',
+    );
+    expect(hits).toBeGreaterThan(0);
+  });
+
+  it('rejects primitives importing components-v2', async () => {
+    const hits = await restrictedImportHits(
+      `import VfoPanel from '../components-v2/panels/VfoPanel.svelte';`,
+      'src/primitives/Knob.ts',
+    );
+    expect(hits).toBeGreaterThan(0);
+  });
+
+  // ── Review cycle 2, minor 2: workspace .svelte + plural workspaces/ ─────
+
+  it('rejects a workspace .svelte file importing transport', async () => {
+    // .svelte fixtures need a <script> block — svelte-eslint-parser only
+    // treats code inside it as a Program with ImportDeclaration nodes;
+    // a bare top-level import is parsed as template text, not JS.
+    const hits = await restrictedImportHits(
+      `<script lang="ts">\n  import { sendCommand } from '$lib/transport/ws-client';\n</script>`,
+      'src/presentation/workspace/WorkspaceSwitcher.svelte',
+    );
+    expect(hits).toBeGreaterThan(0);
+  });
+
+  it('rejects the plural workspaces/ path variant importing a skin module path', async () => {
+    const hits = await restrictedImportHits(
+      `import LcdSkin from '../../skins/amber-lcd/LcdSkin.svelte';`,
+      'src/presentation/workspaces/preferences.ts',
+    );
+    expect(hits).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

Mechanically enforce the v3 semantic/primitives/presentation/adapter/runtime package boundaries ahead of the code that MOR-1062+ will create, in the repo's established `no-restricted-imports` style:

- `frontend/eslint.config.js` (+192 net): zones for `presentation/**`, `semantic/**`, `presentation/workspace/**` (incl. `.svelte` and plural `workspaces/`), and `src/primitives/**` per the v3 ADR matrix (`docs/plans/2026-07-25-ui-composition-architecture-v3.md`). The runtime barrel (`$lib/runtime`, `/index`, `/frontend-runtime`) and the runtime controllers (`system-controller`, `scope-controller.svelte`, `tx-controller/app-host` — TX authority, INV-11) are blocked from the v3 zones via `$`-anchored regex entries, while the sanctioned consumption path (`lib/runtime/adapters/*`, `props/*`) stays legal. Reverse direction (INV-6/INV-1): `lib/runtime` cannot import `presentation/**`/`semantic/**`.
- `frontend/src/__tests__/architecture-boundaries.test.ts` (37 assertions): every forbidden edge paired with a legal-neighbor proof, linting virtual fixtures through the REAL flat config (`ESLint#lintText`), plus explicit pins for `presentation → lib/runtime/adapters/*` (passes) and `presentation → tx-controller/app-host` (fails).

No target directories exist yet, so `npm run lint` is clean before and after — the rules are the fence MOR-1062+ builds inside.

## Independent verification (adversarial, two cycles at cap)

- Cycle 0 found the runtime-barrel bypass (aggregating transport/audio/stores yet legal from the v3 zones) and unencoded reverse/primitives edges; cycle 1 found the naive fix blocking the sanctioned adapters path (directory-glob semantics) and the partial INV-6 encoding; cycle 2 verified all fixes: 19/19 aggregator forms blocked, 7/7 sanctioned paths allowed, 5/5 controller-ban probes correct, all through real `npm run lint` on planted fixtures with proven cleanup.
- Mutation probes: zone deletion, glob narrowing, and index-pin removal each kill a named assertion.
- Suites: 37/37 architecture, lint 0, svelte-check 0/0, ruff clean; full frontend failure set identical to the main baseline (known localStorage env flake), +37 new passes.
- Report-only residuals (recorded in the review artifact and a follow-up ticket): denylist not exhaustive for three latent runtime modules; inherent specifier-form evasions; one narrow primitives→themes false positive to resolve when the primitives dir materializes.

Linear: MOR-1061

🤖 Generated with [Claude Code](https://claude.com/claude-code)
