### PR TITLE
feat(MOR-1059): host global feedback/power/health/TX indication in App root

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte';
   import { initBatteryMonitor } from './lib/utils/battery';
   import RadioLayoutV2 from './components-v2/layout/RadioLayout.svelte';
+  import AppGlobalHost from './AppGlobalHost.svelte';
   import LocalExtensionsHost from './lib/local-extensions/LocalExtensionsHost.svelte';
   import { initMediaSession, destroyMediaSession } from './lib/media/media-session';
   import { runtime } from './lib/runtime/frontend-runtime';
@@ -155,6 +156,10 @@
 {/if}
 
 {#if demoMode !== 'control-buttons' && !backendError}
+  <!-- Global feedback / power-health / authoritative TX indication live here,
+       as siblings of the presentation, so switching layout or skin never
+       recreates or duplicates them (MOR-1059). -->
+  <AppGlobalHost />
   <LocalExtensionsHost />
 {/if}
 

--- a/frontend/src/AppGlobalHost.svelte
+++ b/frontend/src/AppGlobalHost.svelte
@@ -1,0 +1,187 @@
+<!--
+  App-global status host (MOR-1059).
+
+  Owns the operator's global surfaces — feedback (toasts), power/health, and
+  the authoritative TX/fault indication — at the App composition root, above
+  the presentation boundary. Layouts and skins must not host these: a
+  presentation swap replaces the layout subtree, and a global surface mounted
+  inside it would be recreated, drop its subscription, or duplicate itself.
+
+  See docs/plans/2026-07-25-ui-composition-architecture-v3.md
+  ("render safety/status overlays outside the selected layout").
+-->
+<script lang="ts">
+  import { onDestroy } from 'svelte';
+  import Toast from './components/shared/Toast.svelte';
+  import { runtime } from '$lib/runtime';
+  import { getAppTxController } from '$lib/runtime/tx-controller/app-host';
+  import { t } from '$lib/i18n';
+
+  // The App-owned TX controller (MOR-1008/MOR-982) is the ONLY legitimate
+  // source for this lamp. Radio-state PTT is a command/readback echo that can
+  // read RX while the key is still down, so it is never consulted here.
+  const tx = getAppTxController();
+  let txState = $state.raw(tx.snapshot());
+  const stopWatchingTx = tx.subscribe((next) => { txState = next; });
+  onDestroy(() => stopWatchingTx());
+
+  // Fail closed: 'uncertain' means the browser may own the key without a
+  // confirmed readback, and must still be shown as a transmitting radio.
+  let txIndication = $derived(
+    txState.radioTx === 'on' || txState.txRisk === 'confirmed-on'
+      ? 'on'
+      : txState.txRisk === 'uncertain'
+        ? 'uncertain'
+        : null,
+  );
+
+  async function handlePowerOn(): Promise<void> {
+    try {
+      await runtime.system.powerOn();
+    } catch (err) {
+      alert(t('core.overlay.poweredOff.failedPowerOn', { detail: String(err) }));
+    }
+  }
+</script>
+
+<div class="app-global-host" data-testid="app-global-host">
+  <Toast />
+
+  {#if txIndication}
+    <div class="global-tx" data-testid="global-tx-indication" data-tx={txIndication} aria-live="assertive">
+      <span class="global-tx-lamp" aria-hidden="true"></span>
+      <span>{txIndication === 'on' ? 'TX' : 'TX?'}</span>
+    </div>
+  {/if}
+
+  {#if txState.fault}
+    <div class="global-tx-fault" role="alert" data-testid="global-tx-fault" data-fault={txState.fault}>
+      TX FAULT: {txState.fault}
+    </div>
+  {/if}
+
+  {#if runtime.radioPowerOn === false}
+    <div
+      class="power-off-overlay"
+      role="dialog"
+      aria-modal="true"
+      data-testid="global-power-off"
+      aria-label={t('core.overlay.poweredOff.label')}
+    >
+      <div class="power-off-content">
+        <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M18.36 6.64a9 9 0 1 1-12.73 0" />
+          <line x1="12" y1="2" x2="12" y2="12" />
+        </svg>
+        <span class="power-off-label">{t('core.overlay.poweredOff.label')}</span>
+        <button class="power-on-btn" onclick={handlePowerOn}>
+          {t('core.overlay.poweredOff.powerOnButton')}
+        </button>
+      </div>
+    </div>
+  {/if}
+</div>
+
+<style>
+  /* The wrapper is a grouping node only — it must not participate in any
+     layout's box model, and must not create a containing block that would
+     break `position: fixed` on its children. */
+  .app-global-host {
+    display: contents;
+  }
+
+  .global-tx,
+  .global-tx-fault {
+    position: fixed;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 10001;
+    pointer-events: none;
+    font-family: var(--font-mono, 'Roboto Mono', monospace);
+    font-weight: 700;
+    letter-spacing: 0.12em;
+  }
+
+  .global-tx {
+    top: 0;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 3px 12px;
+    border: 1px solid var(--v2-accent-red, #ef4444);
+    border-top: none;
+    border-radius: 0 0 6px 6px;
+    font-size: 12px;
+    color: var(--v2-accent-red, #ef4444);
+    background: rgba(0, 0, 0, 0.72);
+  }
+
+  .global-tx[data-tx='uncertain'] {
+    border-color: var(--warning, #f59e0b);
+    color: var(--warning, #f59e0b);
+  }
+
+  .global-tx-lamp {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: currentColor;
+    box-shadow: 0 0 6px currentColor;
+  }
+
+  .global-tx-fault {
+    top: 28px;
+    padding: 3px 12px;
+    border-radius: 4px;
+    font-size: 11px;
+    color: #fff;
+    background: var(--danger, #b91c1c);
+  }
+
+  .power-off-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 9000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.85);
+    backdrop-filter: blur(6px);
+  }
+
+  .power-off-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+    color: var(--v2-text-dim, #888);
+  }
+
+  .power-off-label {
+    font-family: var(--font-mono, 'Roboto Mono', monospace);
+    font-size: 16px;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    color: var(--v2-text-primary, #fff);
+  }
+
+  .power-on-btn {
+    margin-top: 8px;
+    padding: 10px 24px;
+    font-family: var(--font-mono, 'Roboto Mono', monospace);
+    font-size: 14px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    color: #fff;
+    background: rgba(40, 160, 40, 0.25);
+    border: 1.5px solid rgba(40, 160, 40, 0.6);
+    border-radius: 6px;
+    cursor: pointer;
+    transition: background 0.15s, border-color 0.15s;
+  }
+
+  .power-on-btn:hover {
+    background: rgba(40, 160, 40, 0.4);
+    border-color: rgba(40, 160, 40, 0.8);
+  }
+</style>

--- a/frontend/src/__tests__/LayoutStub.svelte
+++ b/frontend/src/__tests__/LayoutStub.svelte
@@ -1,0 +1,13 @@
+<!--
+  Test fixture (MOR-1059). Stands in for the selected presentation in
+  App-level composition tests. `{#key skinId}` makes every skin change a
+  genuine subtree destroy/recreate, so a test can tell "the presentation was
+  replaced" apart from "a prop changed".
+-->
+<script lang="ts">
+  let { skinId = 'desktop-v2' }: { skinId?: string } = $props();
+</script>
+
+{#key skinId}
+  <div class="layout-stub" data-skin={skinId}></div>
+{/key}

--- a/frontend/src/__tests__/app-global-host.component.test.ts
+++ b/frontend/src/__tests__/app-global-host.component.test.ts
@@ -1,0 +1,331 @@
+/**
+ * MOR-1059 — the App-global feedback / power-health / authoritative-TX host.
+ *
+ * These tests pin the composition contract, not the styling:
+ *   1. the host renders its surfaces with no layout mounted at all;
+ *   2. it survives presentation replacement (one instance, one global
+ *      feedback subscription, no lost fault/TX feedback);
+ *   3. TX indication reads the App-owned TX controller and nothing else;
+ *   4. layouts no longer own the moved surfaces;
+ *   5. teardown unsubscribes exactly once and stays inert afterwards.
+ */
+import { readFileSync } from 'node:fs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+
+type TxSnapshot = {
+  radioTx: 'on' | 'off' | 'unknown';
+  txRisk: 'none' | 'uncertain' | 'confirmed-on';
+  fault: string | null;
+};
+
+const h = vi.hoisted(() => ({
+  tx: { radioTx: 'unknown', txRisk: 'none', fault: null } as TxSnapshot,
+  txListeners: new Set<(s: TxSnapshot) => void>(),
+  stopWatchingTx: vi.fn(),
+  onMessage: vi.fn(),
+  offMessage: vi.fn(),
+  powerOn: vi.fn(),
+  radioPowerOn: null as boolean | null,
+  ptt: false,
+  notifyRuntime: () => {},
+  runtime: undefined as unknown,
+  provide: vi.fn(),
+  registerBarrier: vi.fn(),
+  bootstrap: vi.fn(),
+  initBattery: vi.fn(),
+  resolveSkin: vi.fn(),
+}));
+
+vi.mock('$lib/runtime', async () => {
+  const { createSubscriber } = await import('svelte/reactivity');
+  let update = () => {};
+  const subscribe = createSubscriber((notify) => { update = notify; return () => {}; });
+  h.notifyRuntime = () => update();
+  h.runtime = {
+    // `ptt` is deliberately readable here: it is the non-authoritative echo
+    // the TX indication must NOT be wired to.
+    get state() { subscribe(); return { stateRevision: 1, freshnessRevision: 1, observationSeq: 1, ptt: h.ptt }; },
+    get caps() { subscribe(); return { tx: true, capabilities: ['tx'] }; },
+    get radioPowerOn() { subscribe(); return h.radioPowerOn; },
+    get system() { return { powerOn: h.powerOn }; },
+    bootstrap: h.bootstrap,
+    setPollingMultiplier: vi.fn(),
+  };
+  return { runtime: h.runtime };
+});
+vi.mock('../lib/runtime/frontend-runtime', async () => {
+  const mod = await import('$lib/runtime');
+  return { runtime: mod.runtime };
+});
+vi.mock('../lib/transport/ws-client', () => ({ onMessage: h.onMessage }));
+vi.mock('$lib/i18n', () => ({
+  t: (key: string) => key,
+  messageFromReasonCode: (code: string) => code,
+}));
+vi.mock('$lib/runtime/tx-controller/app-host', () => ({
+  provideAppTxControllerHost: h.provide,
+  getAppTxController: () => ({
+    snapshot: () => h.tx,
+    subscribe: (listener: (s: TxSnapshot) => void) => {
+      h.txListeners.add(listener);
+      return h.stopWatchingTx;
+    },
+  }),
+}));
+vi.mock('$lib/runtime/system-controller', () => ({
+  systemController: { registerPreDisconnectBarrier: h.registerBarrier },
+}));
+vi.mock('$lib/stores/capabilities.svelte', () => ({ hasAnyScope: () => false }));
+vi.mock('$lib/stores/layout.svelte', () => ({ getLayoutMode: () => 'standard' }));
+vi.mock('../skins/registry', () => ({ resolveSkinId: h.resolveSkin }));
+vi.mock('../lib/utils/battery', () => ({ initBatteryMonitor: h.initBattery }));
+vi.mock('../lib/media/media-session', () => ({ initMediaSession: vi.fn(), destroyMediaSession: vi.fn() }));
+vi.mock('../components-v2/layout/RadioLayout.svelte', async () => {
+  const stub = await import('./LayoutStub.svelte');
+  return { default: stub.default };
+});
+vi.mock('../lib/local-extensions/LocalExtensionsHost.svelte', async () => {
+  const stub = await import('./LayoutStub.svelte');
+  return { default: stub.default };
+});
+
+import App from '../App.svelte';
+import AppGlobalHost from '../AppGlobalHost.svelte';
+
+const settle = async () => { await Promise.resolve(); await Promise.resolve(); };
+
+/** Push a new authoritative TX snapshot through the controller subscription. */
+function emitTx(next: Partial<TxSnapshot>): void {
+  h.tx = { ...h.tx, ...next };
+  for (const listener of h.txListeners) listener(h.tx);
+  flushSync();
+}
+
+function mountAt(component: typeof App | typeof AppGlobalHost) {
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+  const instance = mount(component, { target });
+  flushSync();
+  return instance;
+}
+
+const hostEl = () => document.querySelector('[data-testid="app-global-host"]');
+const txEl = () => document.querySelector('[data-testid="global-tx-indication"]');
+const faultEl = () => document.querySelector('[data-testid="global-tx-fault"]');
+const powerEl = () => document.querySelector('[data-testid="global-power-off"]');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.tx = { radioTx: 'unknown', txRisk: 'none', fault: null };
+  h.txListeners.clear();
+  h.radioPowerOn = null;
+  h.ptt = false;
+  document.body.innerHTML = '';
+  Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1200 });
+  Object.defineProperty(window, 'innerHeight', { configurable: true, value: 800 });
+  h.onMessage.mockReturnValue(h.offMessage);
+  h.bootstrap.mockResolvedValue(vi.fn());
+  h.initBattery.mockResolvedValue(vi.fn());
+  h.resolveSkin.mockImplementation(({ isMobile }: { isMobile: boolean }) => (isMobile ? 'mobile' : 'desktop-v2'));
+  h.provide.mockReturnValue({ refreshAuthority: vi.fn(), release: vi.fn(), dispose: vi.fn() });
+});
+
+describe('AppGlobalHost — standalone, with no layout mounted', () => {
+  it('renders global feedback, power/health and TX surfaces without any presentation', () => {
+    h.tx = { radioTx: 'on', txRisk: 'confirmed-on', fault: 'backend-dekeyed' };
+    h.radioPowerOn = false;
+    const instance = mountAt(AppGlobalHost);
+
+    // No layout is mounted at all in this test — nothing but the host.
+    expect(document.querySelector('.layout-stub')).toBeNull();
+    expect(document.querySelector('.toast-container')).not.toBeNull();
+    expect(h.onMessage).toHaveBeenCalledTimes(1);
+    expect(powerEl()).not.toBeNull();
+    expect(txEl()?.getAttribute('data-tx')).toBe('on');
+    expect(faultEl()?.getAttribute('data-fault')).toBe('backend-dekeyed');
+
+    unmount(instance);
+  });
+
+  it('offers the power-on action from the host, not from a layout status bar', async () => {
+    h.radioPowerOn = false;
+    h.powerOn.mockResolvedValue(undefined);
+    const instance = mountAt(AppGlobalHost);
+
+    powerEl()?.querySelector<HTMLButtonElement>('.power-on-btn')?.click();
+    await settle();
+    expect(h.powerOn).toHaveBeenCalledTimes(1);
+
+    unmount(instance);
+  });
+
+  it('hides the power overlay while power is on or unknown', () => {
+    const instance = mountAt(AppGlobalHost);
+    expect(powerEl()).toBeNull();          // unknown — fail-quiet, no false alarm
+    h.radioPowerOn = true;
+    h.notifyRuntime();
+    flushSync();
+    expect(powerEl()).toBeNull();
+    h.radioPowerOn = false;
+    h.notifyRuntime();
+    flushSync();
+    expect(powerEl()).not.toBeNull();
+    unmount(instance);
+  });
+});
+
+describe('AppGlobalHost — authoritative TX source', () => {
+  // MUTATION KILLED: rewiring `data-tx` to the command echo
+  // (`runtime.state.ptt`) or to any layout-local derivation. The echo says
+  // "not transmitting" here while the App-owned controller says the key is
+  // down; the operator lamp must follow the controller.
+  it('shows TX from the controller even when the state echo claims RX', () => {
+    h.ptt = false;
+    h.tx = { radioTx: 'on', txRisk: 'none', fault: null };
+    const instance = mountAt(AppGlobalHost);
+    expect(txEl()?.getAttribute('data-tx')).toBe('on');
+    unmount(instance);
+  });
+
+  // MUTATION KILLED: the inverse rewire — an echo that claims TX while the
+  // controller is idle must not light the authoritative lamp.
+  it('stays dark when the state echo claims TX but the controller is idle', () => {
+    h.ptt = true;
+    h.tx = { radioTx: 'off', txRisk: 'none', fault: null };
+    const instance = mountAt(AppGlobalHost);
+    expect(txEl()).toBeNull();
+    unmount(instance);
+  });
+
+  // MUTATION KILLED: collapsing the indication to `radioTx === 'on'` only.
+  // `txRisk: 'uncertain'` means the browser may own the key without a
+  // confirmed readback — the lamp must fail closed, not stay dark.
+  it('fails closed while TX risk is uncertain', () => {
+    h.tx = { radioTx: 'unknown', txRisk: 'uncertain', fault: null };
+    const instance = mountAt(AppGlobalHost);
+    expect(txEl()?.getAttribute('data-tx')).toBe('uncertain');
+    unmount(instance);
+  });
+
+  // MUTATION KILLED: reading `snapshot()` once at init and never
+  // subscribing — later authoritative transitions would never reach the lamp.
+  it('tracks live controller transitions through the subscription', () => {
+    const instance = mountAt(AppGlobalHost);
+    expect(txEl()).toBeNull();
+    emitTx({ txRisk: 'uncertain' });
+    expect(txEl()?.getAttribute('data-tx')).toBe('uncertain');
+    emitTx({ radioTx: 'on', txRisk: 'confirmed-on' });
+    expect(txEl()?.getAttribute('data-tx')).toBe('on');
+    emitTx({ radioTx: 'off', txRisk: 'none', fault: 'release-not-confirmed' });
+    expect(txEl()).toBeNull();
+    expect(faultEl()?.getAttribute('data-fault')).toBe('release-not-confirmed');
+    unmount(instance);
+  });
+});
+
+describe('App composition — one host above the presentation boundary', () => {
+  it('hosts the global surfaces outside the layout subtree', async () => {
+    const instance = mountAt(App);
+    await settle();
+    flushSync();
+
+    const layout = document.querySelector('.layout-stub');
+    expect(layout).not.toBeNull();
+    expect(hostEl()).not.toBeNull();
+    // MUTATION KILLED: mounting the host inside the layout again.
+    expect(layout!.contains(hostEl())).toBe(false);
+    expect(document.querySelectorAll('.toast-container')).toHaveLength(1);
+    expect(h.onMessage).toHaveBeenCalledTimes(1);
+
+    unmount(instance);
+  });
+
+  it('survives repeated presentation replacement without remount or resubscription', async () => {
+    h.tx = { radioTx: 'on', txRisk: 'confirmed-on', fault: 'on-timeout' };
+    const instance = mountAt(App);
+    await settle();
+    flushSync();
+
+    const hostBefore = hostEl();
+    const layoutBefore = document.querySelector('.layout-stub');
+    expect(layoutBefore?.getAttribute('data-skin')).toBe('desktop-v2');
+
+    const resize = (width: number) => {
+      Object.defineProperty(window, 'innerWidth', { configurable: true, value: width });
+      window.dispatchEvent(new Event('resize'));
+      flushSync();
+    };
+
+    // A -> B -> A. Each hop genuinely destroys and recreates the layout.
+    resize(390);
+    const layoutMobile = document.querySelector('.layout-stub');
+    expect(layoutMobile?.getAttribute('data-skin')).toBe('mobile');
+    expect(layoutMobile).not.toBe(layoutBefore);
+    resize(1200);
+    const layoutBack = document.querySelector('.layout-stub');
+    expect(layoutBack?.getAttribute('data-skin')).toBe('desktop-v2');
+    expect(layoutBack).not.toBe(layoutMobile);
+
+    // The host is untouched by all of it: same node, same single
+    // subscription, same pending authoritative TX/fault feedback.
+    expect(hostEl()).toBe(hostBefore);
+    expect(document.querySelectorAll('.toast-container')).toHaveLength(1);
+    expect(h.onMessage).toHaveBeenCalledTimes(1);
+    expect(h.offMessage).not.toHaveBeenCalled();
+    expect(txEl()?.getAttribute('data-tx')).toBe('on');
+    expect(faultEl()?.getAttribute('data-fault')).toBe('on-timeout');
+
+    unmount(instance);
+  });
+
+  it('releases the host exactly once on App teardown and stays inert afterwards', async () => {
+    const instance = mountAt(App);
+    await settle();
+    flushSync();
+    expect(h.txListeners.size).toBe(1);
+
+    unmount(instance);
+
+    expect(h.stopWatchingTx).toHaveBeenCalledTimes(1);
+    expect(h.offMessage).toHaveBeenCalledTimes(1);
+    expect(hostEl()).toBeNull();
+
+    // A late controller emission after teardown must not resurrect any DOM.
+    h.tx = { radioTx: 'on', txRisk: 'confirmed-on', fault: 'backend-dekeyed' };
+    for (const listener of h.txListeners) listener(h.tx);
+    flushSync();
+    expect(txEl()).toBeNull();
+    expect(faultEl()).toBeNull();
+  });
+});
+
+describe('Layouts no longer own the App-global surfaces', () => {
+  const read = (rel: string) => readFileSync(new URL(rel, import.meta.url), 'utf8');
+
+  // MUTATION KILLED: re-introducing a layout-local Toast or power overlay,
+  // which is how two disagreeing global surfaces get on screen at once.
+  it.each([
+    ['../components-v2/layout/RadioLayout.svelte'],
+    ['../components-v2/layout/LcdLayout.svelte'],
+    ['../components-v2/layout/MobileRadioLayout.svelte'],
+  ])('%s hosts no Toast and no power-off overlay', (rel) => {
+    const source = read(rel);
+    expect(source).not.toMatch(/shared\/Toast\.svelte/);
+    expect(source).not.toMatch(/<Toast\b/);
+    expect(source).not.toMatch(/power-off-overlay/);
+  });
+
+  it('keeps the App composition root as the only mount point for the host', () => {
+    // A mount is an import plus an element; a prose reference is neither.
+    const mountsHost = (source: string) =>
+      /import\s+AppGlobalHost\b/.test(source) && /<AppGlobalHost\b/.test(source);
+    expect(mountsHost(read('../App.svelte'))).toBe(true);
+    const hostMounts = [
+      '../components-v2/layout/RadioLayout.svelte',
+      '../components-v2/layout/LcdLayout.svelte',
+      '../components-v2/layout/MobileRadioLayout.svelte',
+    ].filter((rel) => mountsHost(read(rel)));
+    expect(hostMounts).toEqual([]);
+  });
+});

--- a/frontend/src/components-v2/layout/LcdLayout.svelte
+++ b/frontend/src/components-v2/layout/LcdLayout.svelte
@@ -28,8 +28,6 @@
   import KeyboardHandler from './KeyboardHandler.svelte';
   import StatusBar from './StatusBar.svelte';
   import { makeKeyboardHandlers } from '../wiring/command-bus';
-  import Toast from '../../components/shared/Toast.svelte';
-  import { t } from '$lib/i18n';
 
   // Twin-skin variant selector (#887). Default preserves today's behavior.
   // `scope` currently falls through to cockpit until C-PR1 (#895) delivers
@@ -44,14 +42,6 @@
   let activeMode = $derived(radioState?.active === 'SUB' ? radioState?.sub?.mode : radioState?.main?.mode);
 
   const keyboardHandlers = makeKeyboardHandlers();
-
-  async function handlePowerOn() {
-    try {
-      await runtime.system.powerOn();
-    } catch (err) {
-      alert(t('core.overlay.poweredOff.failedPowerOn', { detail: String(err) }));
-    }
-  }
 
   $effect(() => {
     if (activeMode) {
@@ -98,27 +88,8 @@
 
 </div>
 
-<!-- Toast notifications — rendered in fixed position overlay -->
-<Toast />
-
-{#if runtime.radioPowerOn === false}
-  <div class="power-off-overlay" aria-label={t('core.overlay.poweredOff.label')}>
-    <div class="power-off-content">
-      <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-        <path d="M18.36 6.64a9 9 0 1 1-12.73 0" />
-        <line x1="12" y1="2" x2="12" y2="12" />
-      </svg>
-      <span class="power-off-label">{t('core.overlay.poweredOff.label')}</span>
-      <button class="power-on-btn" onclick={handlePowerOn}>
-        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <path d="M18.36 6.64a9 9 0 1 1-12.73 0" />
-          <line x1="12" y1="2" x2="12" y2="12" />
-        </svg>
-        {t('core.overlay.poweredOff.powerOnButton')}
-      </button>
-    </div>
-  </div>
-{/if}
+<!-- Global feedback / power-health / TX indication are hosted by
+     AppGlobalHost at the App composition root (MOR-1059). -->
 
 <style>
   .lcd-layout {
@@ -216,51 +187,4 @@
     border-radius: 4px;
   }
 
-  .power-off-overlay {
-    position: fixed;
-    inset: 0;
-    z-index: 9999;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: rgba(0, 0, 0, 0.85);
-    backdrop-filter: blur(8px);
-  }
-
-  .power-off-content {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 12px;
-    color: var(--v2-text-dim);
-  }
-
-  .power-off-label {
-    font-family: 'Roboto Mono', monospace;
-    font-size: 16px;
-    font-weight: 700;
-    letter-spacing: 0.1em;
-  }
-
-  .power-on-btn {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    margin-top: 8px;
-    padding: 10px 24px;
-    font-family: 'Roboto Mono', monospace;
-    font-size: 14px;
-    font-weight: 700;
-    letter-spacing: 0.08em;
-    color: #fff;
-    background: rgba(40, 160, 40, 0.25);
-    border: 1.5px solid rgba(40, 160, 40, 0.6);
-    border-radius: 6px;
-    cursor: pointer;
-    transition: background 0.15s, border-color 0.15s;
-  }
-  .power-on-btn:hover {
-    background: rgba(40, 160, 40, 0.4);
-    border-color: rgba(40, 160, 40, 0.8);
-  }
 </style>

--- a/frontend/src/components-v2/layout/MobileRadioLayout.svelte
+++ b/frontend/src/components-v2/layout/MobileRadioLayout.svelte
@@ -64,7 +64,6 @@
   import { getAppTxController } from '$lib/runtime/tx-controller/app-host';
   import { createPttGesture, type PttGesture } from '../wiring/tx-ptt-gesture';
   import { onMount, onDestroy } from 'svelte';
-  import Toast from '../../components/shared/Toast.svelte';
 
   // ── State — via runtime ──
   let radioState = $derived(runtime.state);
@@ -894,8 +893,8 @@
 </div>
 {/if}
 
-<!-- Toast notifications — rendered in fixed position overlay -->
-<Toast />
+<!-- Global feedback / power-health / TX indication are hosted by
+     AppGlobalHost at the App composition root (MOR-1059). -->
 
 <!-- MOR-617: floating MOD-input TX warning — keying happens via the FAB or
      the landscape strip, so the banner must be visible outside the TX

--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -53,7 +53,6 @@
   import RitXitPanel from '../panels/RitXitPanel.svelte';
   import CwPanel from '../panels/CwPanel.svelte';
   import { HardwareButton } from '$lib/Button';
-  import Toast from '../../components/shared/Toast.svelte';
 
   let { skinId = 'desktop-v2' }: { skinId?: SkinId } = $props();
 
@@ -292,21 +291,8 @@
 </div>
 {/if}
 
-<!-- Toast notifications — rendered in fixed position overlay -->
-<Toast />
-
-{#if runtime.radioPowerOn === false}
-  <div class="power-off-overlay" role="dialog" aria-modal="true" aria-label={t('core.overlay.poweredOff.label')}>
-    <div class="power-off-content">
-      <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-        <path d="M18.36 6.64a9 9 0 1 1-12.73 0" />
-        <line x1="12" y1="2" x2="12" y2="12" />
-      </svg>
-      <span class="power-off-label">{t('core.overlay.poweredOff.label')}</span>
-      <span class="power-off-hint">{t('core.overlay.poweredOff.hint')}</span>
-    </div>
-  </div>
-{/if}
+<!-- Global feedback / power-health / TX indication are hosted by
+     AppGlobalHost at the App composition root (MOR-1059). -->
 
 <!-- ═══ SETTINGS MODAL (outside power-off block so it works when radio is on) ═══ -->
 {#if settingsOpen}
@@ -537,52 +523,6 @@
   }
 
   /* Mobile layout is now in MobileRadioLayout.svelte */
-
-  /* Power-off overlay */
-  .power-off-overlay {
-    position: fixed;
-    inset: 28px 0 0 0; /* below status bar */
-    z-index: 1000;
-    background: rgba(0, 0, 0, 0.85);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    backdrop-filter: blur(4px);
-  }
-
-  .power-off-content {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 16px;
-    color: var(--v2-accent-red, #ef4444);
-    animation: pulse-dim 2s ease-in-out infinite;
-  }
-
-  .power-off-label {
-    font-size: 24px;
-    font-weight: 700;
-    letter-spacing: 0.1em;
-    text-transform: uppercase;
-    color: var(--v2-text-primary, #fff);
-  }
-
-  .power-off-hint {
-    font-size: 13px;
-    color: var(--v2-text-dim, #888);
-    letter-spacing: 0.02em;
-  }
-
-  @keyframes pulse-dim {
-    0%, 100% { opacity: 0.6; }
-    50% { opacity: 1; }
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .power-off-content {
-      animation: none;
-    }
-  }
 
   /* ── Settings Modal ── */
   .settings-backdrop {

--- a/frontend/src/lib/runtime/tx-controller/__tests__/app-lifecycle.component.test.ts
+++ b/frontend/src/lib/runtime/tx-controller/__tests__/app-lifecycle.component.test.ts
@@ -49,6 +49,12 @@ vi.mock('../../../../lib/runtime/frontend-runtime', async () => {
 vi.mock('$lib/runtime/system-controller', () => ({ systemController: { registerPreDisconnectBarrier: h.registerBarrier } }));
 vi.mock('$lib/i18n', () => ({ t: (key: string) => key }));
 vi.mock('../app-host', () => ({ provideAppTxControllerHost: h.provide }));
+// The App-global status host (MOR-1059) is stubbed here: these tests own the
+// TX controller lifecycle, and the host has its own focused suite.
+vi.mock('../../../../AppGlobalHost.svelte', async () => {
+  const stub = await import('../../../../components-v2/layout/__tests__/SpectrumPanelStub.svelte');
+  return { default: stub.default };
+});
 import App from '../../../../App.svelte';
 const settle = async () => { await Promise.resolve(); await Promise.resolve(); };
 function mountApp() {


### PR DESCRIPTION
## Summary

New `frontend/src/AppGlobalHost.svelte` hosts the global operator surfaces at the App composition root, as a sibling of the presentation — no layout/skin owns them anymore:

- **Toast**: was rendered by RadioLayout + LcdLayout + MobileRadioLayout → one instance. (The old placement sat outside the skin branch, so LCD actually ran two toasts and mobile two — fixed by construction.)
- **Power-off overlay**: was RadioLayout + LcdLayout (two disagreeing overlays on LCD) → one unified overlay now carrying the Power-ON button (same `runtime.system.powerOn()` path); mobile gains a power-on affordance it previously lacked.
- **Authoritative TX/fault lamp (new)**: none existed above the presentation boundary. Reads *only* `getAppTxController()` (MOR-1008) — `radioTx`/`txRisk`/`fault`; `runtime.state.ptt` is never read; renders fail-closed on `txRisk: 'uncertain'`.

+55 net production LOC (187 new − 137 removed from three layouts + 5 App wiring) across 5 production files; only existing-test edit is a 6-line AppGlobalHost stub (no assertion weakened).

## Independent verification

- Authoritative source proven: zero reads of `state.ptt`/echo/transport in the host; field literals verified against the real `model.ts`; the controller reducer guarantees `mayOwnKey ⇒ txRisk ∈ {uncertain, confirmed-on}`, so no keyed state can render dark.
- Mutation probes 4/4 killed: lamp rewired to `runtime.state.ptt`; `uncertain` rendered dark; fault channel removed; Toast removed — each fails named tests. Worktree sha256-verified residue-free afterwards.
- Coverage matrix both directions: single entrypoint chain (`index.html` → `main.ts` → App), all five skins route through it; mount predicate is exact parity with the old layout gate — every entrypoint keeps toasts/overlay, none duplicates them.
- Presentation-swap survival pinned by test, not assumption: A→B→A with `{#key}`-forced destroys — layout node identity changes, host node identity does not; `onMessage` subscribed once; pending TX/fault indication survives the swap.
- Suites vs a reviewer-reconstructed HEAD baseline: identical failure set (the two known pre-existing flakes, MOR-1230), +14 new passes, zero new failures; check/lint/lint:boundaries/i18n:check/ruff clean.
- Non-blocking findings ticketed: powered-off overlay occludes desktop status-bar controls + orphaned `poweredOff.hint` key (follow-up ticket); MetersDockPanel non-authoritative `txActive` was already MOR-1235 (characterized: suppresses SWR/ALC fault flags during the readback window, never lights a false global TX).

Linear: MOR-1059 (child of MOR-973)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
