### PR TITLE
feat(MOR-1062): radio semantic view-model contract + four topology fixtures

### DIFF
--- a/frontend/src/semantic/__tests__/radio-view-model.test.ts
+++ b/frontend/src/semantic/__tests__/radio-view-model.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it } from 'vitest';
+import { validateRadioViewModel, type RadioViewModel } from '../radio-view-model';
+
+function valid(): RadioViewModel {
+  return {
+    topologyId: '1/single',
+    vfoScheme: 'single',
+    activeReceiver: { status: 'known', receiver: 'MAIN' },
+    vfos: [{
+      receiver: 'MAIN', slot: { kind: 'unslotted' }, label: 'MAIN', frequencyHz: 14195000,
+      mode: 'USB', filter: 'WIDE', isActive: true, isTxTarget: true,
+    }],
+    split: { status: 'known', value: false },
+    dualWatch: { status: 'known', value: false },
+    txTarget: { status: 'known', receiver: 'MAIN', slot: { kind: 'unslotted' }, frequencyHz: 14195000 },
+    txPermit: { status: 'allowed', band: '20m' },
+    scope: {
+      hardwareScope: { structural: true, operational: true },
+      audioFftScope: { structural: false, operational: false },
+    },
+    disabledReasons: [],
+  };
+}
+
+describe('validateRadioViewModel', () => {
+  it('accepts a well-formed view model and round-trips it unchanged', () => {
+    const model = valid();
+    expect(validateRadioViewModel(model)).toEqual(model);
+  });
+
+  it('accepts an unknown txTarget with its reason preserved', () => {
+    const model = {
+      ...valid(),
+      vfos: [{ ...valid().vfos[0], isTxTarget: false }],
+      txTarget: { status: 'unknown', reason: 'stale' },
+      txPermit: { status: 'unknown', reason: 'tx-target-unknown' },
+    };
+    expect(validateRadioViewModel(model).txTarget).toEqual({ status: 'unknown', reason: 'stale' });
+  });
+
+  it('accepts a denied and an unknown txPermit distinctly', () => {
+    const denied = validateRadioViewModel({
+      ...valid(), txPermit: { status: 'denied', reason: 'outside-configured-ranges' },
+    });
+    const unknown = validateRadioViewModel({
+      ...valid(),
+      vfos: [{ ...valid().vfos[0], isTxTarget: false }],
+      txTarget: { status: 'unknown', reason: 'not-observed' },
+      txPermit: { status: 'unknown', reason: 'ranges-unconfigured' },
+    });
+    expect(denied.txPermit.status).toBe('denied');
+    expect(unknown.txPermit.status).toBe('unknown');
+    expect(denied.txPermit).not.toEqual(unknown.txPermit);
+  });
+
+  // ── B1 (review cycle 1): ActiveRx, MOR-988 §3.2 verbatim ─────────────────
+  it('accepts an unknown activeReceiver — never fabricates MAIN', () => {
+    expect(validateRadioViewModel({ ...valid(), activeReceiver: { status: 'unknown' } }).activeReceiver)
+      .toEqual({ status: 'unknown' });
+  });
+
+  it('rejects an activeReceiver with neither known nor unknown status', () => {
+    expect(() => validateRadioViewModel({ ...valid(), activeReceiver: { status: 'stale' } })).toThrow(TypeError);
+  });
+
+  // ── B2 (review cycle 1): split/dualWatch are independent BooleanFacts ────
+  it('accepts split and dualWatch true at the same time (the combination the old enum could not represent)', () => {
+    const model = validateRadioViewModel({
+      ...valid(), split: { status: 'known', value: true }, dualWatch: { status: 'known', value: true },
+    });
+    expect(model.split).toEqual({ status: 'known', value: true });
+    expect(model.dualWatch).toEqual({ status: 'known', value: true });
+  });
+
+  it('accepts split known while dualWatch is unknown, independently', () => {
+    const model = validateRadioViewModel({
+      ...valid(), split: { status: 'known', value: true }, dualWatch: { status: 'unknown' },
+    });
+    expect(model.split).toEqual({ status: 'known', value: true });
+    expect(model.dualWatch).toEqual({ status: 'unknown' });
+  });
+
+  it('rejects a BooleanFact with a non-boolean value', () => {
+    expect(() => validateRadioViewModel({ ...valid(), split: { status: 'known', value: 'yes' } })).toThrow(TypeError);
+  });
+
+  // ── B3 (review cycle 1): VfoSlot — slotted/unslotted/unknown ─────────────
+  it('accepts a slotted VFO slot with an A/B id', () => {
+    const model = validateRadioViewModel({
+      ...valid(),
+      vfos: [{ ...valid().vfos[0], slot: { kind: 'slotted', id: 'B' } }],
+      txTarget: { status: 'known', receiver: 'MAIN', slot: { kind: 'slotted', id: 'B' }, frequencyHz: 14195000 },
+    });
+    expect(model.vfos[0].slot).toEqual({ kind: 'slotted', id: 'B' });
+  });
+
+  it('accepts an unknown VFO slot distinct from unslotted (never conflates "no A/B" with "not observed")', () => {
+    const model = validateRadioViewModel({
+      ...valid(), vfos: [{ ...valid().vfos[0], slot: { kind: 'unknown' }, isTxTarget: false }],
+    });
+    expect(model.vfos[0].slot).toEqual({ kind: 'unknown' });
+    expect(model.vfos[0].slot).not.toEqual({ kind: 'unslotted' });
+  });
+
+  it('rejects a slotted VFO slot carrying an extra key', () => {
+    expect(() => validateRadioViewModel({
+      ...valid(), vfos: [{ ...valid().vfos[0], slot: { kind: 'slotted', id: 'A', extra: 1 } }],
+    })).toThrow(TypeError);
+  });
+
+  it('rejects a VFO slot with an unrecognized kind', () => {
+    expect(() => validateRadioViewModel({
+      ...valid(), vfos: [{ ...valid().vfos[0], slot: { kind: 'bogus' } }],
+    })).toThrow(TypeError);
+  });
+
+  // ── V1a (review cycle 1): fail-open cross-field check ────────────────────
+  // Every per-field check alone accepts this object — only the cross-field
+  // guard rejects it. Removing that guard would make this test fail (a
+  // mutation-kill proof, since no mutation tool is wired into this repo).
+  //
+  // C1 (review cycle 2): the fixture below deliberately clears isTxTarget so
+  // this object violates ONLY the fail-open invariant — nothing else about it
+  // is invalid. If the V1a check were deleted, every remaining per-field and
+  // V1b check would accept this object and validateRadioViewModel would
+  // return normally, so this specific test — not some other guard — is what
+  // would go red.
+  it('rejects txPermit "allowed" while txTarget is unknown (fail-open) — isolated from the V1b guard', () => {
+    const smuggled = {
+      ...valid(),
+      vfos: [{ ...valid().vfos[0], isTxTarget: false }],
+      txTarget: { status: 'unknown', reason: 'not-observed' },
+      txPermit: { status: 'allowed', band: '20m' },
+    };
+    expect(() => validateRadioViewModel(smuggled)).toThrow(TypeError);
+  });
+
+  it('still accepts txPermit "allowed" when txTarget is known (the V1a guard must not over-block the legal case)', () => {
+    expect(() => validateRadioViewModel(valid())).not.toThrow();
+  });
+
+  // ── V1b (review cycle 1): isTxTarget must match the known txTarget ───────
+  it('rejects isTxTarget=true on a VFO whose receiver does not match a known txTarget', () => {
+    const smuggled = {
+      ...valid(),
+      txTarget: { status: 'known', receiver: 'MAIN', slot: { kind: 'unslotted' }, frequencyHz: 14195000 },
+      vfos: [{ ...valid().vfos[0], receiver: 'SUB', isTxTarget: true }],
+    };
+    expect(() => validateRadioViewModel(smuggled)).toThrow(TypeError);
+  });
+
+  it('rejects isTxTarget=true on any VFO when txTarget is unknown', () => {
+    const smuggled = {
+      ...valid(),
+      txTarget: { status: 'unknown', reason: 'not-observed' },
+      txPermit: { status: 'unknown', reason: 'tx-target-unknown' },
+      vfos: [{ ...valid().vfos[0], isTxTarget: true }],
+    };
+    expect(() => validateRadioViewModel(smuggled)).toThrow(TypeError);
+  });
+
+  it('rejects isTxTarget=true on the matching receiver but the wrong slot', () => {
+    const smuggled = {
+      ...valid(),
+      vfoScheme: 'ab' as const,
+      txTarget: { status: 'known', receiver: 'MAIN', slot: { kind: 'slotted', id: 'A' }, frequencyHz: 14195000 },
+      vfos: [{ ...valid().vfos[0], slot: { kind: 'slotted' as const, id: 'B' as const }, isTxTarget: true }],
+    };
+    expect(() => validateRadioViewModel(smuggled)).toThrow(TypeError);
+  });
+
+  it('accepts isTxTarget=true only on the VFO whose receiver AND slot both match', () => {
+    const legal = {
+      ...valid(),
+      vfoScheme: 'ab' as const,
+      txTarget: { status: 'known', receiver: 'MAIN', slot: { kind: 'slotted', id: 'A' }, frequencyHz: 14195000 },
+      vfos: [
+        { ...valid().vfos[0], slot: { kind: 'slotted' as const, id: 'A' as const }, isTxTarget: true },
+        { ...valid().vfos[0], slot: { kind: 'slotted' as const, id: 'B' as const }, isTxTarget: false },
+      ],
+    };
+    expect(() => validateRadioViewModel(legal)).not.toThrow();
+  });
+
+  // ── Rejects a fixture that smuggles a raw capability object or module path ──
+  it('rejects a top-level raw capabilities array smuggled onto the model', () => {
+    const smuggled = { ...valid(), capabilities: ['scope', 'audio', 'tx'] };
+    expect(() => validateRadioViewModel(smuggled)).toThrow(TypeError);
+  });
+
+  it('rejects a module path smuggled onto the model', () => {
+    const smuggled = { ...valid(), modulePath: '$lib/runtime/frontend-runtime' };
+    expect(() => validateRadioViewModel(smuggled)).toThrow(TypeError);
+  });
+
+  it('rejects a raw capability object smuggled into scope', () => {
+    const smuggled = {
+      ...valid(),
+      scope: { ...valid().scope, raw: { scope: true, audioFftAvailable: true } },
+    };
+    expect(() => validateRadioViewModel(smuggled)).toThrow(TypeError);
+  });
+
+  it('rejects an unexpected key inside a VFO entry', () => {
+    const smuggled = { ...valid(), vfos: [{ ...valid().vfos[0], capabilityTags: ['tx'] }] };
+    expect(() => validateRadioViewModel(smuggled)).toThrow(TypeError);
+  });
+
+  // ── Structural rejection per field ──────────────────────────────────────
+  it('rejects a non-object', () => {
+    expect(() => validateRadioViewModel(null)).toThrow(TypeError);
+    expect(() => validateRadioViewModel('1/single')).toThrow(TypeError);
+  });
+
+  it('rejects an invalid vfoScheme', () => {
+    expect(() => validateRadioViewModel({ ...valid(), vfoScheme: 'quad' })).toThrow(TypeError);
+  });
+
+  it('rejects a txTarget with neither known nor unknown status', () => {
+    expect(() => validateRadioViewModel({ ...valid(), txTarget: { status: 'stale' } })).toThrow(TypeError);
+  });
+
+  it('rejects a txPermit reason that does not belong to its status', () => {
+    // 'tx-target-unknown' is a valid reason for 'unknown', not 'denied'.
+    expect(() => validateRadioViewModel({
+      ...valid(), txPermit: { status: 'denied', reason: 'tx-target-unknown' },
+    })).toThrow(TypeError);
+  });
+
+  it('rejects a non-boolean Availability field', () => {
+    expect(() => validateRadioViewModel({
+      ...valid(),
+      scope: { ...valid().scope, hardwareScope: { structural: 'yes', operational: true } },
+    })).toThrow(TypeError);
+  });
+
+  it('rejects a disabledReasons entry with an unknown code', () => {
+    expect(() => validateRadioViewModel({
+      ...valid(), disabledReasons: [{ field: 'txTarget', code: 'operator-error' }],
+    })).toThrow(TypeError);
+  });
+});

--- a/frontend/src/semantic/__tests__/topology-fixtures.test.ts
+++ b/frontend/src/semantic/__tests__/topology-fixtures.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from 'vitest';
+import { validateRadioViewModel } from '../radio-view-model';
+import { topologyFixtures, withAudioOnlyScope, type TopologyFixtureId } from '../fixtures/topologies';
+
+const ids: readonly TopologyFixtureId[] = ['1/single', '1/ab', '2/ab_shared', '2/main_sub'];
+
+/**
+ * Structural signature "modulo pure identifiers" (review cycle 1, V2; review
+ * cycle 2, V2 de-vacuization). A naive full JSON diff is vacuous two ways:
+ * fixtures that were structurally identical copies differing only in
+ * cosmetic `label` text, OR only in `topologyId` (a free-form name that
+ * duplicates `vfoScheme`/receiver-count information already present
+ * elsewhere in the object), would both still count as "distinct". Strip
+ * both identifier fields before comparing so the test can only pass because
+ * the topology/state axes themselves differ, never because of naming.
+ */
+const IDENTIFIER_KEYS = new Set(['label', 'topologyId']);
+function stripIdentifiers(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stripIdentifiers);
+  if (value !== null && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      if (IDENTIFIER_KEYS.has(k)) continue;
+      out[k] = stripIdentifiers(v);
+    }
+    return out;
+  }
+  return value;
+}
+const signature = (id: TopologyFixtureId) => JSON.stringify(stripIdentifiers(topologyFixtures[id]));
+
+describe('topology fixtures (MOR-1062)', () => {
+  it.each(ids)('%s is a valid RadioViewModel', (id) => {
+    expect(() => validateRadioViewModel(topologyFixtures[id])).not.toThrow();
+  });
+
+  it('carries the topologyId that matches its own key', () => {
+    for (const id of ids) expect(topologyFixtures[id].topologyId).toBe(id);
+  });
+
+  it('covers all four backend VFO schemes exactly once', () => {
+    const schemes = ids.map((id) => topologyFixtures[id].vfoScheme).sort();
+    expect(schemes).toEqual(['ab', 'ab_shared', 'main_sub', 'single']);
+  });
+
+  it('assigns single-receiver topologies exactly one receiver and dual-receiver topologies exactly two', () => {
+    const receiverSetSize = (id: TopologyFixtureId) =>
+      new Set(topologyFixtures[id].vfos.map((v) => v.receiver)).size;
+    expect(receiverSetSize('1/single')).toBe(1);
+    expect(receiverSetSize('1/ab')).toBe(1);
+    expect(receiverSetSize('2/ab_shared')).toBe(2);
+    expect(receiverSetSize('2/main_sub')).toBe(2);
+  });
+
+  it('exercises all three tri-state txPermit branches across the set (never just two)', () => {
+    const statuses = new Set(ids.map((id) => topologyFixtures[id].txPermit.status));
+    expect(statuses).toEqual(new Set(['allowed', 'unknown', 'denied']));
+  });
+
+  // ── V2 (review cycle 1 + 2): non-vacuous distinctness ─────────────────────
+  it('fails if two fixtures collapse to the same structural signature modulo pure identifiers', () => {
+    const signatures = ids.map(signature);
+    expect(new Set(signatures).size).toBe(ids.length);
+  });
+
+  it('proves the signature is label-blind: two label-only-differing structures DO collapse to one signature', () => {
+    // Meta-test on the guard above: if this failed, "modulo labels" would be a
+    // no-op and the previous test would be exactly as vacuous as a raw JSON diff.
+    const base = topologyFixtures['1/single'];
+    const a = { ...base, vfos: base.vfos.map((v) => ({ ...v, label: 'X' })) };
+    const b = { ...base, vfos: base.vfos.map((v) => ({ ...v, label: 'Y' })) };
+    expect(JSON.stringify(stripIdentifiers(a))).toBe(JSON.stringify(stripIdentifiers(b)));
+  });
+
+  it('proves the signature is also topologyId-blind (review cycle 2, V2 de-vacuization): ' +
+    'two topologyId-only-differing structures DO collapse to one signature', () => {
+    // Before this fix, `topologyId` survived the strip, so two fixtures with
+    // identical structure but different topologyId would still (correctly)
+    // report as "distinct" for the WRONG reason — the id, not the structure.
+    // That made the outer test pass even if a real structural duplication
+    // ever crept in, as long as the fixture's key/id stayed unique.
+    const base = topologyFixtures['1/single'];
+    const a = { ...base, topologyId: 'x/one' };
+    const b = { ...base, topologyId: 'x/two' };
+    expect(JSON.stringify(stripIdentifiers(a))).toBe(JSON.stringify(stripIdentifiers(b)));
+  });
+
+  // ── S1 (review cycle 1): audio-only scope is a composable fifth condition ─
+  it.each(ids)('withAudioOnlyScope composes onto %s: scope flips, every other fact is untouched', (id) => {
+    const base = topologyFixtures[id];
+    const variant = withAudioOnlyScope(base);
+    expect(() => validateRadioViewModel(variant)).not.toThrow();
+    expect(variant.scope).toEqual({
+      hardwareScope: { structural: false, operational: false },
+      audioFftScope: { structural: true, operational: true },
+    });
+    expect({ ...variant, scope: base.scope }).toEqual(base);
+  });
+
+  // ── Null/unknown preservation (ticket acceptance evidence) ───────────────
+  it('preserves an unknown txTarget with its reason, distinct from a known one', () => {
+    expect(topologyFixtures['1/ab'].txTarget).toEqual({ status: 'unknown', reason: 'not-observed' });
+    expect(topologyFixtures['2/ab_shared'].txTarget).toEqual({
+      status: 'known', receiver: 'SUB', slot: { kind: 'unslotted' }, frequencyHz: 3573000,
+    });
+  });
+
+  it('keeps "no A/B slot" (unslotted) distinct from "slot not observed" (unknown) — B3', () => {
+    // ab_shared has no A/B concept at all: every VFO is structurally unslotted,
+    // never a placeholder for an unobserved slot.
+    for (const vfo of topologyFixtures['2/ab_shared'].vfos) expect(vfo.slot).toEqual({ kind: 'unslotted' });
+    // ab/main_sub are slotted schemes: every VFO carries a real observed id.
+    for (const vfo of topologyFixtures['1/ab'].vfos) expect(vfo.slot.kind).toBe('slotted');
+    for (const vfo of topologyFixtures['2/main_sub'].vfos) expect(vfo.slot.kind).toBe('slotted');
+  });
+
+  it('preserves activeReceiver as an explicit known fact, never a bare string (B1)', () => {
+    for (const id of ids) expect(topologyFixtures[id].activeReceiver.status).toBe('known');
+  });
+
+  // ── B2: split and dualWatch are independent — the set proves all three
+  // representable relationships (both false, one unknown, both true) ───────
+  it('represents split and dualWatch orthogonally across the set, including both true at once', () => {
+    expect(topologyFixtures['1/single'].split).toEqual({ status: 'known', value: false });
+    expect(topologyFixtures['1/single'].dualWatch).toEqual({ status: 'known', value: false });
+    expect(topologyFixtures['1/ab'].split).toEqual({ status: 'known', value: true });
+    expect(topologyFixtures['1/ab'].dualWatch).toEqual({ status: 'unknown' });
+    expect(topologyFixtures['2/main_sub'].split).toEqual({ status: 'known', value: true });
+    expect(topologyFixtures['2/main_sub'].dualWatch).toEqual({ status: 'known', value: true });
+  });
+
+  // ── TX truthfulness: confirmed/uncertain must never collapse to a boolean ─
+  it('kills a mutation collapsing tx permit "unknown" into "denied"', () => {
+    const permit = topologyFixtures['1/ab'].txPermit;
+    expect(permit).toEqual({ status: 'unknown', reason: 'tx-target-unknown' });
+    expect(permit.status).not.toBe('denied');
+    expect(permit.status).not.toBe('allowed');
+  });
+
+  it('kills a mutation collapsing tx permit "unknown" into "allowed" (the fail-open direction)', () => {
+    expect(topologyFixtures['1/ab'].txPermit.status).not.toBe('allowed');
+  });
+
+  it('kills a mutation dropping the denied reason on 2/ab_shared', () => {
+    expect(topologyFixtures['2/ab_shared'].txPermit).toEqual({
+      status: 'denied', reason: 'outside-configured-ranges',
+    });
+  });
+
+  // ── Capability-gated controls never smuggle raw capability data ─────────
+  it('never smuggles a raw capabilities array or module path into a fixture', () => {
+    // The contract's own `disabledReasons[].code` legitimately contains the word
+    // "capability" (e.g. 'capability-unavailable'); this asserts against the raw
+    // wire field `"capabilities":[...]` and module-path-shaped strings, not the word.
+    for (const id of ids) {
+      const json = JSON.stringify(topologyFixtures[id]);
+      expect(json).not.toMatch(/"capabilities"\s*:/);
+      expect(json).not.toMatch(/\$lib\//);
+      expect(json).not.toMatch(/\.svelte/);
+      expect(json).not.toMatch(/skins\//);
+    }
+  });
+
+  it('gates hardware scope structurally and operationally, independently of audio FFT scope', () => {
+    // 2/main_sub: hardware scope fully available; audio FFT structurally present
+    // but not currently operational — the two-level gate must stay independent.
+    const scope = topologyFixtures['2/main_sub'].scope;
+    expect(scope.hardwareScope).toEqual({ structural: true, operational: true });
+    expect(scope.audioFftScope).toEqual({ structural: true, operational: false });
+  });
+});

--- a/frontend/src/semantic/fixtures/topologies.ts
+++ b/frontend/src/semantic/fixtures/topologies.ts
@@ -1,0 +1,155 @@
+/**
+ * The four canonical topology fixtures (MOR-1062).
+ *
+ * Each is a complete, valid `RadioViewModel` instance for one of the
+ * backend's four VFO schemes (`single | ab | ab_shared | main_sub`, see
+ * `$lib/types/capabilities::VfoScheme`), paired with the structural receiver
+ * count that scheme implies. MOR-1085's browser fixture matrix consumes
+ * these by `topologyId`. Test assets — excluded from the MOR-1062 200-LOC
+ * production guard (see the ticket's "Size guard" note).
+ *
+ * `withAudioOnlyScope` (review cycle 1, S1) is a composable scope-variant
+ * helper: audio-only scope is a fifth, orthogonal condition in MOR-1085's
+ * matrix ("4 topology pairs + audio-only scope"), not a property of any one
+ * topology, so it can be applied to any of the four fixtures below.
+ */
+import type { RadioViewModel } from '../radio-view-model';
+
+const singleReceiver: RadioViewModel = {
+  topologyId: '1/single',
+  vfoScheme: 'single',
+  activeReceiver: { status: 'known', receiver: 'MAIN' },
+  vfos: [
+    {
+      receiver: 'MAIN', slot: { kind: 'unslotted' }, label: 'MAIN', frequencyHz: 14195000,
+      mode: 'USB', filter: 'WIDE', isActive: true, isTxTarget: true,
+    },
+  ],
+  split: { status: 'known', value: false },
+  dualWatch: { status: 'known', value: false },
+  txTarget: {
+    status: 'known', receiver: 'MAIN', slot: { kind: 'unslotted' }, frequencyHz: 14195000,
+  },
+  txPermit: { status: 'allowed', band: '20m' },
+  scope: {
+    hardwareScope: { structural: true, operational: true },
+    audioFftScope: { structural: false, operational: false },
+  },
+  disabledReasons: [],
+};
+
+const singleAb: RadioViewModel = {
+  topologyId: '1/ab',
+  vfoScheme: 'ab',
+  activeReceiver: { status: 'known', receiver: 'MAIN' },
+  vfos: [
+    {
+      receiver: 'MAIN', slot: { kind: 'slotted', id: 'A' }, label: 'VFO A', frequencyHz: 7100000,
+      mode: 'LSB', filter: 'NARROW', isActive: true, isTxTarget: false,
+    },
+    {
+      receiver: 'MAIN', slot: { kind: 'slotted', id: 'B' }, label: 'VFO B', frequencyHz: 7150000,
+      mode: 'LSB', filter: 'NARROW', isActive: false, isTxTarget: false,
+    },
+  ],
+  // dualWatch deliberately unknown: this fixture models an early/partial
+  // observation window, same story as its unobserved txTarget below.
+  split: { status: 'known', value: true },
+  dualWatch: { status: 'unknown' },
+  txTarget: { status: 'unknown', reason: 'not-observed' },
+  txPermit: { status: 'unknown', reason: 'tx-target-unknown' },
+  scope: {
+    hardwareScope: { structural: false, operational: false },
+    audioFftScope: { structural: false, operational: false },
+  },
+  disabledReasons: [{ field: 'txTarget', code: 'field-not-observed' }],
+};
+
+const dualAbShared: RadioViewModel = {
+  topologyId: '2/ab_shared',
+  vfoScheme: 'ab_shared',
+  activeReceiver: { status: 'known', receiver: 'SUB' },
+  vfos: [
+    {
+      receiver: 'MAIN', slot: { kind: 'unslotted' }, label: 'MAIN', frequencyHz: 3573000,
+      mode: 'CW', filter: 'NARROW', isActive: false, isTxTarget: false,
+    },
+    {
+      receiver: 'SUB', slot: { kind: 'unslotted' }, label: 'SUB', frequencyHz: 3573000,
+      mode: 'CW', filter: 'NARROW', isActive: true, isTxTarget: true,
+    },
+  ],
+  split: { status: 'known', value: false },
+  dualWatch: { status: 'known', value: true },
+  txTarget: {
+    status: 'known', receiver: 'SUB', slot: { kind: 'unslotted' }, frequencyHz: 3573000,
+  },
+  txPermit: { status: 'denied', reason: 'outside-configured-ranges' },
+  scope: {
+    hardwareScope: { structural: true, operational: false },
+    audioFftScope: { structural: false, operational: false },
+  },
+  disabledReasons: [{ field: 'scope.hardwareScope', code: 'field-not-observed' }],
+};
+
+const dualMainSub: RadioViewModel = {
+  topologyId: '2/main_sub',
+  vfoScheme: 'main_sub',
+  activeReceiver: { status: 'known', receiver: 'MAIN' },
+  vfos: [
+    {
+      receiver: 'MAIN', slot: { kind: 'slotted', id: 'A' }, label: 'M-A', frequencyHz: 14250000,
+      mode: 'USB', filter: 'WIDE', isActive: true, isTxTarget: true,
+    },
+    {
+      receiver: 'MAIN', slot: { kind: 'slotted', id: 'B' }, label: 'M-B', frequencyHz: 14280000,
+      mode: 'USB', filter: 'WIDE', isActive: false, isTxTarget: false,
+    },
+    {
+      receiver: 'SUB', slot: { kind: 'slotted', id: 'A' }, label: 'S-A', frequencyHz: 21295000,
+      mode: 'USB', filter: 'WIDE', isActive: false, isTxTarget: false,
+    },
+    {
+      receiver: 'SUB', slot: { kind: 'slotted', id: 'B' }, label: 'S-B', frequencyHz: 21330000,
+      mode: 'USB', filter: 'WIDE', isActive: false, isTxTarget: false,
+    },
+  ],
+  // Both true at once, proving the orthogonal split/dualWatch representation
+  // (review cycle 1, B2) actually admits the combination the old enum couldn't.
+  split: { status: 'known', value: true },
+  dualWatch: { status: 'known', value: true },
+  txTarget: {
+    status: 'known', receiver: 'MAIN', slot: { kind: 'slotted', id: 'A' }, frequencyHz: 14250000,
+  },
+  txPermit: { status: 'allowed', band: '20m' },
+  scope: {
+    hardwareScope: { structural: true, operational: true },
+    audioFftScope: { structural: true, operational: false },
+  },
+  disabledReasons: [{ field: 'scope.audioFftScope', code: 'capability-unavailable' }],
+};
+
+export const topologyFixtures = {
+  '1/single': singleReceiver,
+  '1/ab': singleAb,
+  '2/ab_shared': dualAbShared,
+  '2/main_sub': dualMainSub,
+} as const satisfies Record<string, RadioViewModel>;
+
+export type TopologyFixtureId = keyof typeof topologyFixtures;
+
+/**
+ * Applies the "audio-only scope" condition (hardware scope absent, audio FFT
+ * present and live) to any topology fixture, leaving every other fact
+ * untouched. MOR-1085's browser matrix composes this onto whichever of the
+ * four canonical topologies it needs — it is not baked into one fixture.
+ */
+export function withAudioOnlyScope(fixture: RadioViewModel): RadioViewModel {
+  return {
+    ...fixture,
+    scope: {
+      hardwareScope: { structural: false, operational: false },
+      audioFftScope: { structural: true, operational: true },
+    },
+  };
+}

--- a/frontend/src/semantic/radio-view-model.ts
+++ b/frontend/src/semantic/radio-view-model.ts
@@ -1,0 +1,302 @@
+/**
+ * Radio semantic view-model contract (MOR-1062).
+ *
+ * The seam between adapters (which consume runtime state and capabilities —
+ * see `lib/runtime/adapters/*`) and semantic UI (which renders only this
+ * shape and nothing else — no transport, store, or manufacturer knowledge).
+ * A design language may change how a fact looks; it may never change which
+ * facts exist. See docs/plans/2026-07-25-ui-composition-architecture-v3.md
+ * and the MOR-977 shared semantic skeleton (Linear comment, 2026-08-03).
+ *
+ * `ActiveRx` and the scheme-conditioned slot/target shapes below mirror the
+ * exact identity types frozen by the MOR-988 "Accepted capability and
+ * presentation semantics" decision (§3.2, §4) — this contract reuses that
+ * vocabulary rather than reinventing it. Every "unknown"/"denied" branch is
+ * intentional and must survive round-tripping — collapsing it into a
+ * boolean or a default is the failure mode this contract exists to prevent.
+ */
+import type { VfoScheme } from '$lib/types/capabilities';
+import type { FrequencyPermit } from '$lib/utils/tx-permit';
+
+export type ReceiverId = 'MAIN' | 'SUB';
+export type VfoSlotId = 'A' | 'B';
+
+/**
+ * Whether a VFO/target position has an addressable A/B slot at all, distinct
+ * from whether that slot was actually observed. `unslotted` = the scheme has
+ * no A/B concept here (`single`, `ab_shared`); `unknown` = a slotted scheme
+ * (`ab`, `main_sub`) whose slot could not be observed — MOR-988 §3.2/§4:
+ * missing/stale never synthesizes `A`.
+ */
+export type VfoSlot =
+  | { kind: 'slotted'; id: VfoSlotId }
+  | { kind: 'unslotted' }
+  | { kind: 'unknown' };
+
+/** MOR-988 §3.2 `ActiveRx`, verbatim: an adapter with no observation must never fabricate 'MAIN'. */
+export type ActiveRx =
+  | { status: 'known'; receiver: ReceiverId }
+  | { status: 'unknown' };
+
+/** A boolean radio fact (`split`, `dualWatch`) that can itself be unobserved. */
+export type BooleanFact =
+  | { status: 'known'; value: boolean }
+  | { status: 'unknown' };
+
+/**
+ * Structural = the radio model supports this. Operational = usable right
+ * now, given live capability AND field-observed state. MOR-977 two-level
+ * gating: a control that fails either half is absent, not merely disabled.
+ */
+export interface Availability {
+  structural: boolean;
+  operational: boolean;
+}
+
+export interface VfoViewModel {
+  receiver: ReceiverId;
+  slot: VfoSlot;
+  label: string;
+  frequencyHz: number | null;
+  mode: string | null;
+  filter: string | null;
+  isActive: boolean;
+  isTxTarget: boolean;
+}
+
+export type TxTargetViewModel =
+  | { status: 'known'; receiver: ReceiverId; slot: VfoSlot; frequencyHz: number | null }
+  | { status: 'unknown'; reason: 'not-observed' | 'stale' | 'unsupported' | 'contradiction' };
+
+export interface ScopeAvailabilityViewModel {
+  hardwareScope: Availability;
+  audioFftScope: Availability;
+}
+
+export type DisabledReasonCode =
+  | 'capability-unavailable'
+  | 'field-not-observed'
+  | 'tx-target-unknown'
+  | 'out-of-band';
+
+export interface DisabledReason {
+  field: string;
+  code: DisabledReasonCode;
+}
+
+export interface RadioViewModel {
+  topologyId: string;
+  vfoScheme: VfoScheme;
+  activeReceiver: ActiveRx;
+  vfos: readonly VfoViewModel[];
+  /** Orthogonal wire booleans (state.ts `split`/`dualWatch`; independent CI-V
+   *  commands) — both may be true, false, or unobserved independently. */
+  split: BooleanFact;
+  dualWatch: BooleanFact;
+  txTarget: TxTargetViewModel;
+  txPermit: FrequencyPermit;
+  scope: ScopeAvailabilityViewModel;
+  disabledReasons: readonly DisabledReason[];
+}
+
+const RECEIVER_IDS: readonly ReceiverId[] = ['MAIN', 'SUB'];
+const SLOT_IDS: readonly VfoSlotId[] = ['A', 'B'];
+const VFO_SCHEMES: readonly VfoScheme[] = ['single', 'ab', 'ab_shared', 'main_sub'];
+const DISABLED_REASON_CODES: readonly DisabledReasonCode[] = [
+  'capability-unavailable', 'field-not-observed', 'tx-target-unknown', 'out-of-band',
+];
+
+function invalid(path: string, expected: string): never {
+  throw new TypeError(`Invalid radio view model at ${path}: expected ${expected}`);
+}
+function record(value: unknown, path: string): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) invalid(path, 'an object');
+  return value as Record<string, unknown>;
+}
+function exactKeys(value: Record<string, unknown>, keys: readonly string[], path: string): void {
+  const extra = Object.keys(value).filter((k) => !keys.includes(k));
+  if (extra.length > 0) invalid(path, `only [${keys.join(', ')}] (found extra: ${extra.join(', ')})`);
+}
+function oneOf<T>(value: unknown, allowed: readonly T[], path: string): T {
+  if (!allowed.includes(value as T)) invalid(path, allowed.join(' | '));
+  return value as T;
+}
+function bool(value: unknown, path: string): boolean {
+  if (typeof value !== 'boolean') invalid(path, 'a boolean');
+  return value;
+}
+function str(value: unknown, path: string): string {
+  if (typeof value !== 'string') invalid(path, 'a string');
+  return value;
+}
+function nullableNumber(value: unknown, path: string): number | null {
+  if (value !== null && (typeof value !== 'number' || !Number.isFinite(value))) {
+    invalid(path, 'a finite number or null');
+  }
+  return value as number | null;
+}
+function nullableString(value: unknown, path: string): string | null {
+  if (value !== null && typeof value !== 'string') invalid(path, 'a string or null');
+  return value as string | null;
+}
+
+function validateVfoSlot(value: unknown, path: string): VfoSlot {
+  const v = record(value, path);
+  if (v.kind === 'slotted') {
+    exactKeys(v, ['kind', 'id'], path);
+    return { kind: 'slotted', id: oneOf(v.id, SLOT_IDS, `${path}.id`) };
+  }
+  if (v.kind === 'unslotted') {
+    exactKeys(v, ['kind'], path);
+    return { kind: 'unslotted' };
+  }
+  if (v.kind === 'unknown') {
+    exactKeys(v, ['kind'], path);
+    return { kind: 'unknown' };
+  }
+  invalid(`${path}.kind`, `'slotted' | 'unslotted' | 'unknown'`);
+}
+function slotEqual(a: VfoSlot, b: VfoSlot): boolean {
+  return a.kind === 'slotted' && b.kind === 'slotted' ? a.id === b.id : a.kind === b.kind;
+}
+
+function validateActiveRx(value: unknown, path: string): ActiveRx {
+  const v = record(value, path);
+  if (v.status === 'known') {
+    exactKeys(v, ['status', 'receiver'], path);
+    return { status: 'known', receiver: oneOf(v.receiver, RECEIVER_IDS, `${path}.receiver`) };
+  }
+  if (v.status === 'unknown') {
+    exactKeys(v, ['status'], path);
+    return { status: 'unknown' };
+  }
+  invalid(`${path}.status`, `'known' | 'unknown'`);
+}
+
+function validateBooleanFact(value: unknown, path: string): BooleanFact {
+  const v = record(value, path);
+  if (v.status === 'known') {
+    exactKeys(v, ['status', 'value'], path);
+    return { status: 'known', value: bool(v.value, `${path}.value`) };
+  }
+  if (v.status === 'unknown') {
+    exactKeys(v, ['status'], path);
+    return { status: 'unknown' };
+  }
+  invalid(`${path}.status`, `'known' | 'unknown'`);
+}
+
+function validateAvailability(value: unknown, path: string): Availability {
+  const v = record(value, path);
+  exactKeys(v, ['structural', 'operational'], path);
+  return { structural: bool(v.structural, `${path}.structural`), operational: bool(v.operational, `${path}.operational`) };
+}
+
+function validateVfo(value: unknown, path: string): VfoViewModel {
+  const v = record(value, path);
+  exactKeys(v, ['receiver', 'slot', 'label', 'frequencyHz', 'mode', 'filter', 'isActive', 'isTxTarget'], path);
+  return {
+    receiver: oneOf(v.receiver, RECEIVER_IDS, `${path}.receiver`),
+    slot: validateVfoSlot(v.slot, `${path}.slot`),
+    label: str(v.label, `${path}.label`),
+    frequencyHz: nullableNumber(v.frequencyHz, `${path}.frequencyHz`),
+    mode: nullableString(v.mode, `${path}.mode`),
+    filter: nullableString(v.filter, `${path}.filter`),
+    isActive: bool(v.isActive, `${path}.isActive`),
+    isTxTarget: bool(v.isTxTarget, `${path}.isTxTarget`),
+  };
+}
+
+function validateTxTarget(value: unknown, path: string): TxTargetViewModel {
+  const v = record(value, path);
+  if (v.status === 'known') {
+    exactKeys(v, ['status', 'receiver', 'slot', 'frequencyHz'], path);
+    return {
+      status: 'known',
+      receiver: oneOf(v.receiver, RECEIVER_IDS, `${path}.receiver`),
+      slot: validateVfoSlot(v.slot, `${path}.slot`),
+      frequencyHz: nullableNumber(v.frequencyHz, `${path}.frequencyHz`),
+    };
+  }
+  if (v.status === 'unknown') {
+    exactKeys(v, ['status', 'reason'], path);
+    return {
+      status: 'unknown',
+      reason: oneOf(v.reason, ['not-observed', 'stale', 'unsupported', 'contradiction'] as const, `${path}.reason`),
+    };
+  }
+  invalid(`${path}.status`, `'known' | 'unknown'`);
+}
+
+function validateTxPermit(value: unknown, path: string): FrequencyPermit {
+  const v = record(value, path);
+  if (v.status === 'allowed') {
+    exactKeys(v, ['status', 'band'], path);
+    return { status: 'allowed', band: nullableString(v.band, `${path}.band`) };
+  }
+  if (v.status === 'denied') {
+    exactKeys(v, ['status', 'reason'], path);
+    return { status: 'denied', reason: oneOf(v.reason, ['outside-configured-ranges'] as const, `${path}.reason`) };
+  }
+  if (v.status === 'unknown') {
+    exactKeys(v, ['status', 'reason'], path);
+    return {
+      status: 'unknown',
+      reason: oneOf(v.reason, ['ranges-unconfigured', 'tx-target-unknown'] as const, `${path}.reason`),
+    };
+  }
+  invalid(`${path}.status`, `'allowed' | 'denied' | 'unknown'`);
+}
+
+function validateDisabledReason(value: unknown, path: string): DisabledReason {
+  const v = record(value, path);
+  exactKeys(v, ['field', 'code'], path);
+  return { field: str(v.field, `${path}.field`), code: oneOf(v.code, DISABLED_REASON_CODES, `${path}.code`) };
+}
+
+/** Runtime validator (repo idiom: throws TypeError with a `$.path`, see `validateCapabilities`).
+ *  Also enforces two cross-field invariants (review cycle 1, V1): `txPermit`
+ *  cannot be 'allowed' while `txTarget` is unknown (no fail-open), and
+ *  `isTxTarget` can be true only on the VFO a known `txTarget` names. */
+export function validateRadioViewModel(value: unknown): RadioViewModel {
+  const v = record(value, '$');
+  exactKeys(v, [
+    'topologyId', 'vfoScheme', 'activeReceiver', 'vfos', 'split', 'dualWatch',
+    'txTarget', 'txPermit', 'scope', 'disabledReasons',
+  ], '$');
+  if (!Array.isArray(v.vfos)) invalid('$.vfos', 'an array');
+  if (!Array.isArray(v.disabledReasons)) invalid('$.disabledReasons', 'an array');
+  const scope = record(v.scope, '$.scope');
+  exactKeys(scope, ['hardwareScope', 'audioFftScope'], '$.scope');
+
+  const vfos = v.vfos.map((vfo, i) => validateVfo(vfo, `$.vfos[${i}]`));
+  const txTarget = validateTxTarget(v.txTarget, '$.txTarget');
+  const txPermit = validateTxPermit(v.txPermit, '$.txPermit');
+
+  if (txPermit.status === 'allowed' && txTarget.status === 'unknown') {
+    invalid('$.txPermit', "'allowed' only when txTarget is known (fail-open otherwise)");
+  }
+  vfos.forEach((vfo, i) => {
+    const matches = txTarget.status === 'known'
+      && vfo.receiver === txTarget.receiver && slotEqual(vfo.slot, txTarget.slot);
+    if (vfo.isTxTarget && !matches) {
+      invalid(`$.vfos[${i}].isTxTarget`, 'true only on the VFO matching a known txTarget');
+    }
+  });
+
+  return {
+    topologyId: str(v.topologyId, '$.topologyId'),
+    vfoScheme: oneOf(v.vfoScheme, VFO_SCHEMES, '$.vfoScheme'),
+    activeReceiver: validateActiveRx(v.activeReceiver, '$.activeReceiver'),
+    vfos,
+    split: validateBooleanFact(v.split, '$.split'),
+    dualWatch: validateBooleanFact(v.dualWatch, '$.dualWatch'),
+    txTarget,
+    txPermit,
+    scope: {
+      hardwareScope: validateAvailability(scope.hardwareScope, '$.scope.hardwareScope'),
+      audioFftScope: validateAvailability(scope.audioFftScope, '$.scope.audioFftScope'),
+    },
+    disabledReasons: v.disabledReasons.map((r, i) => validateDisabledReason(r, `$.disabledReasons[${i}]`)),
+  };
+}


### PR DESCRIPTION
## Summary

The v3 semantic view-model contract — the shape every surface, layout, and design language consumes — plus its validator and the four canonical topology fixtures. New files only, under `frontend/src/semantic/`:

- `radio-view-model.ts`: `RadioViewModel` — `topologyId`, `vfoScheme`, `activeReceiver` as the MOR-988 §3.2 `ActiveRx` union (`known|unknown` — an adapter with no observation never fabricates `MAIN`), `vfos[]` (receiver/slot/label/freq/mode/filter/isActive/isTxTarget) with slots as an explicit tri-state (`slotted|unslotted|unknown` — unobserved never masquerades as slot-less), **independent** `split` and `dualWatch` `BooleanFact`s (the two orthogonal wire booleans; DUALWATCH+SPLIT co-occur in today's UI), `txTarget` (known/unknown), `txPermit` (reused `FrequencyPermit` tri-state), `scope` (`hardwareScope`/`audioFftScope`, each `{structural, operational}` — gating hides and gates twice per the MOR-977 record), `disabledReasons[]`. Two type-only imports; zero transport/store/runtime knowledge (MOR-1061 zones green).
- Runtime validator incl. cross-field coherence: rejects the fail-open `txPermit: allowed` + `txTarget: unknown` combination and `isTxTarget` inconsistent with `txTarget`.
- `fixtures/topologies.ts`: `1/single`, `1/ab`, `2/ab_shared`, `2/main_sub` — pairwise structurally distinct (proven by an identifier-blind structural-signature test), covering all `txPermit` branches, split/dual-watch combinations, and scope combos — plus `withAudioOnlyScope(fixture)` so the MOR-1085 browser matrix can request the audio-only-scope condition on ANY topology.

`txRisk` is deliberately NOT here — it lives in the App-owned `TxState` (ADR invariant 11); reviewer-confirmed that MOR-1063/1064 consume this contract without breaking changes.

**Recorded guardrail deviation:** 240 net production LOC vs the ≤200 guard — the +40 is entirely review-mandated correctness (union shapes + coherence checks); reviewer ruling ACCEPT-OVER-CAP, deviation recorded on the Linear ticket.

## Independent verification (two cycles)

- Cycle 0 BLOCKED on three would-be breaking changes, each grounded in the frozen MOR-988 semantics (`ActiveRx` union missing; split enum collapsing two orthogonal booleans; slot null overload) — all fixed and re-verified verbatim against MOR-988.
- Downstream walk: MOR-1063/1064/1085 needs met without future type changes; both builder judgment calls (scope = spectrum-scope axis; txRisk deferral) ruled sound.
- Validator mutations killed (incl. cycle-2 pins: the fail-open guard now has an isolated fixture — guard removal fails exactly one test; the structural-signature test is identifier-blind — collapsing two fixtures fails it).
- Suites: semantic 52/52; architecture-boundaries 37/37; lint/lint:boundaries/check clean; full frontend suite zero new failures vs baseline (known flakes only); ruff clean.

Linear: MOR-1062 (unblocks MOR-1063, MOR-1064, MOR-1085)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
