### PR TITLE
feat(MOR-1072): design-language token/renderer contract for the two-family set

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,7 @@
     "preview": "vite preview",
     "check": "svelte-check --tsconfig ./tsconfig.app.json && tsc -p tsconfig.node.json",
     "lint": "eslint src/",
-    "lint:boundaries": "eslint src/components-v2/panels/ src/components-v2/layout/",
+    "lint:boundaries": "eslint src/components-v2/panels/ src/components-v2/layout/ src/presentation/",
     "i18n:check": "node scripts/i18n-check.mjs",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/frontend/src/presentation/languages/__tests__/fixtures.ts
+++ b/frontend/src/presentation/languages/__tests__/fixtures.ts
@@ -1,0 +1,23 @@
+/** Shared valid-manifest fixture for MOR-1072 contract tests (not itself a test file). */
+import type { DesignLanguageManifest } from '../contract';
+
+export function validManifest(overrides: Partial<DesignLanguageManifest> = {}): DesignLanguageManifest {
+  return {
+    id: 'testline',
+    displayName: 'Testline',
+    tokens: {
+      typography: { fontFamily: 'sans-serif', weight: 400, fontVariantNumeric: 'tabular-nums' },
+      geometry: { radius: '0px', borderWidth: '0px' },
+      meters: { trackWidth: '2px', segmentGap: '0px' },
+      frequency: { digitWeight: 400, rankedGroups: true },
+      motion: { durationMs: 100, reducedMotionSafe: true },
+      focusRing: '0 0 0 2px var(--accent)',
+      rx: { idle: 'var(--dl-rx-idle)', active: 'var(--dl-rx-active)', tuning: 'var(--dl-rx-tuning)' },
+      tx: { idle: 'var(--dl-tx-idle)', active: 'var(--dl-tx-active)', tuning: 'var(--dl-tx-tuning)' },
+    },
+    density: { kind: 'clamped', supported: ['comfortable', 'compact', 'dense'] },
+    layoutCompatibility: [],
+    renderers: {},
+    ...overrides,
+  };
+}

--- a/frontend/src/presentation/languages/__tests__/manifest-shape.test.ts
+++ b/frontend/src/presentation/languages/__tests__/manifest-shape.test.ts
@@ -1,0 +1,109 @@
+/**
+ * MOR-1072 manifest shape: naming policy (MOR-977 §4.6, MOR-1071), density
+ * clamps (MOR-1072 review note), layout-compatibility declarations
+ * (MOR-977 §4.4), and the capability-fork rejection that makes
+ * "manufacturer inspiration never becomes a capability fork" enforceable.
+ */
+import { describe, it, expect } from 'vitest';
+import { isValidLanguageId, validateManifest, DesignLanguageValidationError, type LayoutCompatibilityDeclaration } from '../contract';
+import { validManifest } from './fixtures';
+
+describe('naming policy', () => {
+  it.each(['icom-modern', 'yaesu-field', 'kenwood-classic', 'japanese-sdr', 'american-console'])(
+    'rejects the vendor/geographic-marker id "%s"',
+    (id) => {
+      expect(isValidLanguageId(id)).toBe(false);
+    },
+  );
+
+  // Review cycle 1, B2: the marker check used to split on '-' and compare
+  // whole segments, so a marker fused into a longer segment (no hyphen)
+  // slipped through. Fixed to substring-match the flattened id.
+  it.each(['flexradio', 'icom7610', 'icomclassic', 'kenwoodstyle', 'yaesuline', 'ic-7610'])(
+    'rejects the fused/embedded vendor-marker id "%s" (B2)',
+    (id) => {
+      expect(isValidLanguageId(id)).toBe(false);
+    },
+  );
+
+  // Review cycle 2, N3 — process note: the B2 fix in cycle 1 added a bare
+  // `ic` marker to catch `ic-7610`, which over-corrected: it also rejected
+  // `classic-instrument`, a real, doctrine-preserved future family name
+  // (MOR-977 §4.4 — `meridian`, the "classic precision-instrument grammar",
+  // stays revivable). Instead of noticing the regression, cycle 1 silently
+  // swapped `classic-instrument` out of this list for `quiet-bench`, which
+  // hid the failure rather than surfacing it — exactly the failure mode
+  // independent review exists to catch. `classic-instrument` is restored
+  // here, `ic-7610` is now caught by MODEL_NUMBER_PATTERN instead of the
+  // bare `ic` marker (see contract.ts), and three more of the reviewer's
+  // legitimate names are added so this doesn't regress silently again.
+  it.each(['studioline', 'fieldline', 'contest-console', 'classic-instrument', 'atomic-rail', 'optical-bench', 'physics-desk'])(
+    'accepts the product-owned id "%s"',
+    (id) => {
+      expect(isValidLanguageId(id)).toBe(true);
+    },
+  );
+
+  it('rejects non-kebab-case ids', () => {
+    expect(isValidLanguageId('Studioline')).toBe(false);
+    expect(isValidLanguageId('studio_line')).toBe(false);
+  });
+
+  it('registerDesignLanguage rejects a vendor-marker id via validateManifest', () => {
+    const manifest = validManifest({ id: 'icom-reference' });
+    expect(() => validateManifest(manifest)).toThrow(DesignLanguageValidationError);
+  });
+
+  // Honest documented gap (B2): the list is a denylist of named markers,
+  // not a geography classifier — an unlisted place name still passes.
+  // Catching that class is a human naming-review call, not a string match.
+  it('does not catch every geographic reference — "nippon-line" is a known, accepted gap', () => {
+    expect(isValidLanguageId('nippon-line')).toBe(true);
+  });
+});
+
+describe('density clamp', () => {
+  it('accepts "not-applicable" for a fixed-scale language (e.g. an amber-LCD-style family)', () => {
+    const manifest = validManifest({ density: { kind: 'not-applicable' } });
+    expect(() => validateManifest(manifest)).not.toThrow();
+  });
+
+  it('accepts a clamped subset of density levels (e.g. dense excluded)', () => {
+    const manifest = validManifest({ density: { kind: 'clamped', supported: ['comfortable', 'compact'] } });
+    expect(() => validateManifest(manifest)).not.toThrow();
+    expect(manifest.density.kind === 'clamped' && manifest.density.supported).not.toContain('dense');
+  });
+});
+
+describe('layout compatibility', () => {
+  it('is a manifest declaration, not a capability check — a language may declare itself incompatible with a layout', () => {
+    const manifest = validManifest({
+      layoutCompatibility: [
+        { layoutId: 'dual-receiver-cockpit', compatible: false, reason: 'runs at reduced relative density' },
+      ],
+    });
+    expect(() => validateManifest(manifest)).not.toThrow();
+    expect(manifest.layoutCompatibility[0]).toMatchObject({ layoutId: 'dual-receiver-cockpit', compatible: false });
+  });
+});
+
+describe('capability-fork rejection', () => {
+  it('rejects a manifest with a top-level capabilities-shaped key', () => {
+    const manifest = { ...validManifest(), capabilities: ['CW', 'SSB', 'FM'] };
+    expect(() => validateManifest(manifest)).toThrow(/capability-shaped key/);
+  });
+
+  it('rejects a manifest referencing a radio model deep inside a token group', () => {
+    const manifest = validManifest();
+    const poisoned = { ...manifest, tokens: { ...manifest.tokens, meters: { ...manifest.tokens.meters, radioModel: 'test-radio' } } };
+    expect(() => validateManifest(poisoned)).toThrow(/capability-shaped key/);
+  });
+
+  it('rejects a manifest referencing a vendor key anywhere in layoutCompatibility', () => {
+    const poisoned = {
+      layoutId: 'dual-receiver-cockpit', compatible: true, vendor: 'test-vendor',
+    } as unknown as LayoutCompatibilityDeclaration;
+    const manifest = validManifest({ layoutCompatibility: [poisoned] });
+    expect(() => validateManifest(manifest)).toThrow(/capability-shaped key/);
+  });
+});

--- a/frontend/src/presentation/languages/__tests__/registry.test.ts
+++ b/frontend/src/presentation/languages/__tests__/registry.test.ts
@@ -1,0 +1,47 @@
+/**
+ * MOR-1072 registry: the two frozen family IDs (`studioline`/`fieldline`,
+ * MOR-977 §4.6) are registered as declarations with no visual
+ * implementation yet, and the registry does not hardcode a family count —
+ * a third, hypothetical family registers and validates the same way.
+ */
+import { describe, it, expect } from 'vitest';
+import { listDesignLanguageIds, getDesignLanguage, registerDesignLanguage } from '../contract';
+import { studioline, fieldline } from '../declarations';
+import { validManifest } from './fixtures';
+
+describe('the two frozen v3 declarations', () => {
+  it('registers studioline and fieldline', () => {
+    expect(listDesignLanguageIds()).toEqual(expect.arrayContaining(['studioline', 'fieldline']));
+    expect(getDesignLanguage('studioline')).toBe(studioline);
+    expect(getDesignLanguage('fieldline')).toBe(fieldline);
+  });
+
+  it('neither declares a renderer yet — no visual implementation, that is MOR-1073/MOR-1074', () => {
+    expect(studioline.renderers).toEqual({});
+    expect(fieldline.renderers).toEqual({});
+  });
+
+  it('fieldline clamps out "dense" (MOR-977 §4.4)', () => {
+    expect(fieldline.density).toEqual({ kind: 'clamped', supported: ['comfortable', 'compact'] });
+  });
+
+  it('fieldline declares itself layout-incompatible with dual-receiver-cockpit as a manifest fact, not a capability check', () => {
+    expect(fieldline.layoutCompatibility).toEqual([
+      expect.objectContaining({ layoutId: 'dual-receiver-cockpit', compatible: false }),
+    ]);
+  });
+
+  it('studioline holds all three density steps (MOR-977 §4.2.3)', () => {
+    expect(studioline.density).toEqual({ kind: 'clamped', supported: ['comfortable', 'compact', 'dense'] });
+  });
+});
+
+describe('no hardcoded family count', () => {
+  it('registers a third, hypothetical family (fixed-scale, density not-applicable) the same way as studioline/fieldline', () => {
+    const before = listDesignLanguageIds().length;
+    const thirdFamily = validManifest({ id: 'thirdline', displayName: 'Thirdline', density: { kind: 'not-applicable' } });
+    expect(() => registerDesignLanguage(thirdFamily)).not.toThrow();
+    expect(listDesignLanguageIds().length).toBe(before + 1);
+    expect(getDesignLanguage('thirdline')).toBe(thirdFamily);
+  });
+});

--- a/frontend/src/presentation/languages/__tests__/renderer-contract.test.ts
+++ b/frontend/src/presentation/languages/__tests__/renderer-contract.test.ts
@@ -1,0 +1,135 @@
+/**
+ * MOR-1072 renderer contract: renderers consume a RendererViewModel plus
+ * tokens ONLY. `isRendererViewModel`/`invokeRenderer` are the structural
+ * gate that makes a capability fork impossible — a renderer's signature has
+ * no slot for a capability object. The gate checks *exact* top-level keys
+ * (review cycle 1, B1), not just that `kind`/`fields` are present, so a
+ * smuggled sibling key (e.g. `capabilities` riding next to valid
+ * `kind`/`fields`) is rejected too — via both `invokeRenderer` directly and
+ * the `resolveRenderer` resolve path, which is now a gated wrapper and
+ * cannot be called around the check. `resolveRenderer` falls back safely
+ * when a language has not registered a renderer for a slot yet.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  isRendererViewModel, invokeRenderer, resolveRenderer, RendererInputError,
+  type DesignLanguageTokens, type RendererViewModel,
+} from '../contract';
+import { validManifest } from './fixtures';
+
+describe('RendererViewModel structural gate', () => {
+  it('accepts a flat, primitive-only view model', () => {
+    expect(isRendererViewModel({ kind: 'vfo', fields: { freq: 14074000, mode: 'USB', active: true, rit: null } })).toBe(true);
+  });
+
+  it('rejects a capability-object fixture: a list of supported modes cannot be a "fields" value', () => {
+    const capabilityShaped = { kind: 'capabilities', fields: { modes: ['USB', 'LSB', 'CW'], model: 'test-radio' } };
+    expect(isRendererViewModel(capabilityShaped)).toBe(false);
+  });
+
+  it('rejects a nested-object "fields" value (e.g. a bundled antenna/scope descriptor)', () => {
+    expect(isRendererViewModel({ kind: 'vfo', fields: { scope: { spanHz: 100000 } } })).toBe(false);
+  });
+
+  it('rejects a value with no "kind" discriminator', () => {
+    expect(isRendererViewModel({ fields: {} })).toBe(false);
+  });
+
+  // Review cycle 1, B1 (crux): a valid kind/fields pair riding alongside an
+  // extra top-level key must still be rejected — the old check only looked
+  // AT kind/fields, never confirmed they were the ONLY keys.
+  it('rejects a smuggled sibling key even when kind/fields are individually valid (B1)', () => {
+    const smuggled = { kind: 'vfo', fields: { freq: 14074000 }, capabilities: { radioModel: 'IC-7610' } };
+    expect(isRendererViewModel(smuggled)).toBe(false);
+  });
+
+  it('invokeRenderer throws RendererInputError instead of calling the renderer with a capability object', () => {
+    const renderer = vi.fn();
+    const capabilityShaped = { kind: 'capabilities', fields: { modes: ['USB', 'LSB'] } };
+    const tokens = validManifest().tokens;
+    expect(() => invokeRenderer(renderer, capabilityShaped, tokens)).toThrow(RendererInputError);
+    expect(renderer).not.toHaveBeenCalled();
+  });
+
+  it('invokeRenderer calls the renderer with a valid view model', () => {
+    const renderer = vi.fn().mockReturnValue('rendered');
+    const viewModel = { kind: 'vfo', fields: { freq: 14074000 } };
+    const tokens = validManifest().tokens;
+    expect(invokeRenderer(renderer, viewModel, tokens)).toBe('rendered');
+    expect(renderer).toHaveBeenCalledWith(viewModel, tokens);
+  });
+
+  // Review cycle 2, N1: Object.keys only sees the instance's own enumerable
+  // string keys — a getter declared in a class body lives on the
+  // PROTOTYPE, not the instance, so the old check never saw it. A plausible
+  // accident (not just an attack): any class instance passed where a plain
+  // view model is expected.
+  it('rejects a class instance whose extra key is a prototype-chain getter, not an own key (N1)', () => {
+    class Poisoned {
+      kind = 'vfo';
+      fields = { freq: 14074000 };
+      get capabilities() {
+        return { radioModel: 'IC-7610' };
+      }
+    }
+    expect(isRendererViewModel(new Poisoned())).toBe(false);
+  });
+
+  it('B1: a smuggled payload is rejected via BOTH invokeRenderer and the resolveRenderer resolve path', () => {
+    const smuggled = { kind: 'vfo', fields: { freq: 14074000 }, capabilities: { radioModel: 'IC-7610' } };
+    const renderer = vi.fn();
+    const manifest = validManifest({ renderers: { meters: renderer } });
+    const tokens = manifest.tokens;
+
+    expect(() => invokeRenderer(renderer, smuggled, tokens)).toThrow(RendererInputError);
+    // The resolve path must not be a way around the gate: calling what
+    // resolveRenderer returns has to hit the same check, not the raw renderer.
+    expect(() => resolveRenderer(manifest, 'meters')(smuggled as unknown as RendererViewModel, tokens)).toThrow(RendererInputError);
+    expect(renderer).not.toHaveBeenCalled();
+  });
+
+  // Review cycle 1, B1(b): the one thing that DOES work at compile time.
+  // Runtime shape-smuggling isn't caught by TS (excess properties on a
+  // variable don't trigger the literal-only excess-property check), but the
+  // opposite direction is: a renderer whose parameter is a NARROWER type
+  // than RendererViewModel cannot satisfy a manifest's `renderers` slot —
+  // strictFunctionTypes checks function-typed properties contravariantly.
+  // The repo has no dedicated type-testing idiom (no expectTypeOf/tsd); this
+  // reuses the `@ts-expect-error` mechanism already used elsewhere in the
+  // suite (e.g. ws-client.test.ts), pinned by `npm run check` (svelte-check
+  // + tsc), which is already part of required verification. If this stops
+  // being a type error, `npm run check` fails with "Unused '@ts-expect-error'
+  // directive" — that failure IS the pin.
+  it('type-level: a renderer requiring extra fields cannot satisfy a manifest renderer slot', () => {
+    interface NarrowerViewModel extends RendererViewModel {
+      readonly fields: Readonly<Record<string, string | number | boolean | null>> & { readonly segments: number };
+    }
+    const narrowRenderer = (vm: NarrowerViewModel, _tokens: DesignLanguageTokens): number => vm.fields.segments;
+    const manifest = validManifest();
+    // @ts-expect-error — narrowRenderer requires `fields.segments`, which a
+    // general RendererViewModel does not guarantee; TS must reject this
+    // assignment (TS2322, contravariant parameter check). This directive
+    // IS the assertion: `npm run check` fails "Unused '@ts-expect-error'"
+    // if the contract's slot type ever stops enforcing it. vitest doesn't
+    // type-check at runtime, so the line below still executes either way —
+    // it is a smoke check only, not the real proof.
+    manifest.renderers.meters = narrowRenderer;
+    expect(typeof manifest.renderers.meters).toBe('function');
+  });
+});
+
+describe('missing renderers fall back safely', () => {
+  it('resolveRenderer returns a safe no-op when a language declares no renderer for a slot', () => {
+    const manifest = validManifest(); // renderers: {} — no visual implementation yet
+    const fallback = resolveRenderer(manifest, 'meters');
+    expect(() => fallback({ kind: 'meters', fields: {} }, manifest.tokens)).not.toThrow();
+  });
+
+  it('resolveRenderer delegates to the registered renderer when present, through the gate', () => {
+    const renderer = vi.fn().mockReturnValue('ok');
+    const manifest = validManifest({ renderers: { meters: renderer } });
+    const viewModel = { kind: 'meters', fields: { segments: 4 } };
+    expect(resolveRenderer(manifest, 'meters')(viewModel, manifest.tokens)).toBe('ok');
+    expect(renderer).toHaveBeenCalledWith(viewModel, manifest.tokens);
+  });
+});

--- a/frontend/src/presentation/languages/__tests__/token-contract.test.ts
+++ b/frontend/src/presentation/languages/__tests__/token-contract.test.ts
@@ -1,0 +1,49 @@
+/**
+ * MOR-1072 token contract: required token groups, RX/TX symmetry
+ * (MOR-1231), mandatory focus ring (MOR-1232), mandatory tabular figures.
+ */
+import { describe, it, expect } from 'vitest';
+import { REQUIRED_TOKEN_GROUPS, validateManifest, DesignLanguageValidationError, type DesignLanguageManifest } from '../contract';
+import { validManifest } from './fixtures';
+
+describe('required token groups', () => {
+  it('lists exactly the eight groups the contract mandates', () => {
+    expect(REQUIRED_TOKEN_GROUPS).toEqual([
+      'typography', 'geometry', 'meters', 'frequency', 'motion', 'focusRing', 'rx', 'tx',
+    ]);
+  });
+
+  it('accepts a manifest that declares every required group', () => {
+    expect(() => validateManifest(validManifest())).not.toThrow();
+  });
+
+  it.each(REQUIRED_TOKEN_GROUPS)('fails validation when the "%s" group is omitted', (group) => {
+    const manifest = validManifest();
+    const tokens = { ...manifest.tokens } as Record<string, unknown>;
+    delete tokens[group];
+    const broken: DesignLanguageManifest = { ...manifest, tokens: tokens as unknown as DesignLanguageManifest['tokens'] };
+    expect(() => validateManifest(broken)).toThrow(DesignLanguageValidationError);
+    expect(() => validateManifest(broken)).toThrow(new RegExp(group));
+  });
+
+  it('requires rx and tx to be symmetric token groups (MOR-1231) — both are StateFeedbackTokens with idle/active/tuning', () => {
+    const manifest = validManifest();
+    expect(Object.keys(manifest.tokens.rx).sort()).toEqual(Object.keys(manifest.tokens.tx).sort());
+    expect(Object.keys(manifest.tokens.rx).sort()).toEqual(['active', 'idle', 'tuning']);
+  });
+
+  it('rejects an empty focusRing token (MOR-1232 token half)', () => {
+    const manifest = validManifest();
+    const broken = { ...manifest, tokens: { ...manifest.tokens, focusRing: '' } };
+    expect(() => validateManifest(broken)).toThrow(/focusRing/);
+  });
+
+  it('rejects a bundle that declares tabular figures as anything other than "tabular-nums"', () => {
+    // Simulates a plain-JS caller bypassing the 'tabular-nums' literal type —
+    // the runtime check is what actually enforces MOR-977 §4.5.3.
+    const manifest = validManifest();
+    const typography = { ...manifest.tokens.typography, fontVariantNumeric: 'lining-nums' } as unknown as DesignLanguageManifest['tokens']['typography'];
+    const broken = { ...manifest, tokens: { ...manifest.tokens, typography } };
+    expect(() => validateManifest(broken)).toThrow(/tabular/i);
+  });
+});

--- a/frontend/src/presentation/languages/contract.ts
+++ b/frontend/src/presentation/languages/contract.ts
@@ -1,0 +1,192 @@
+/**
+ * Design-language token and renderer contract (MOR-1072): stable ID,
+ * required token groups, renderer slots, the structural view-model shape
+ * renderers may consume, and the registry that validates and stores
+ * declared families. Contract only — no visual family here (MOR-1073
+ * `studioline` / MOR-1074 `fieldline`, registered in `./declarations`).
+ * Themes vary token *values*; languages vary token *groups and renderers*.
+ * Neither imports runtime/capability/transport/command code — enforced at
+ * lint time by the presentation/ zone (MOR-1061). See v3 ADR and MOR-977
+ * §4 (frozen 2026-08-03).
+ */
+
+/**
+ * Naming policy (MOR-977 §4.6, MOR-1071): kebab-case, no vendor/model
+ * marker substring (matches inside a segment too, e.g. `icom7610` — review
+ * cycle 1, B2). Advisory only for geography: this is a denylist, not a
+ * classifier — a real place name the list doesn't enumerate (e.g.
+ * `nippon-line`) still passes. Catching that class is a human review call,
+ * not a string match; this list only blocks the markers it explicitly names.
+ * No bare `ic`/`ft`/`ts` word marker (review cycle 2, N3) — those 2-3 letter
+ * strings occur inside ordinary words (`classic-instrument`, `atomic-rail`)
+ * far more often than as a vendor prefix. Model numbers (ic-7610, ft-991,
+ * ts890, …) are instead anchored by MODEL_NUMBER_PATTERN below, which
+ * requires a trailing digit — MOR-977 §4.4 preserves `meridian`
+ * (`classic-instrument`) as a revivable future family, so that id must stay
+ * valid.
+ */
+const FORBIDDEN_ID_MARKERS = [
+  'icom', 'yaesu', 'kenwood', 'elecraft', 'flex', 'xiegu', 'alinco',
+  'japanese', 'japan', 'chinese', 'china', 'korean', 'american', 'german',
+] as const;
+const MODEL_NUMBER_PATTERN = /(^|-)(ic|ft|ts)-?\d/;
+const ID_PATTERN = /^[a-z][a-z0-9]*(-[a-z0-9]+)*$/;
+
+export function isValidLanguageId(id: string): boolean {
+  if (!ID_PATTERN.test(id)) return false;
+  const flat = id.toLowerCase();
+  if (MODEL_NUMBER_PATTERN.test(flat)) return false;
+  return !(FORBIDDEN_ID_MARKERS as readonly string[]).some((m) => flat.includes(m));
+}
+
+/** Required groups: typography, geometry, meters, frequency, motion, focus ring, RX/TX. Density and renderer slots are manifest-level, not tokens. */
+export interface StateFeedbackTokens { readonly idle: string; readonly active: string; readonly tuning: string }
+
+export const REQUIRED_TOKEN_GROUPS = [
+  'typography', 'geometry', 'meters', 'frequency', 'motion', 'focusRing', 'rx', 'tx',
+] as const;
+export type TokenGroupName = (typeof REQUIRED_TOKEN_GROUPS)[number];
+
+export interface DesignLanguageTokens {
+  readonly typography: { readonly fontFamily: string; readonly weight: number; readonly fontVariantNumeric: 'tabular-nums' }; // mandatory, MOR-977 §4.5.3
+  readonly geometry: { readonly radius: string; readonly borderWidth: string };
+  readonly meters: { readonly trackWidth: string; readonly segmentGap: string };
+  readonly frequency: { readonly digitWeight: number; readonly rankedGroups: boolean };
+  readonly motion: { readonly durationMs: number; readonly reducedMotionSafe: boolean };
+  readonly focusRing: string; // mandatory, non-empty — MOR-1232 token half
+  readonly rx: StateFeedbackTokens; // MOR-1231, symmetric to tx
+  readonly tx: StateFeedbackTokens;
+}
+
+/** Density is workspace-owned with a per-language clamp (MOR-1072 review note). */
+export type DensityLevel = 'comfortable' | 'compact' | 'dense';
+export type DensityClamp =
+  | { readonly kind: 'not-applicable' }
+  | { readonly kind: 'clamped'; readonly supported: readonly DensityLevel[] };
+
+/** Layout compatibility is a manifest declaration, not a capability check. */
+export interface LayoutCompatibilityDeclaration { readonly layoutId: string; readonly compatible: boolean; readonly reason?: string }
+
+/**
+ * Renderers receive a RendererViewModel plus tokens — nothing else.
+ * `fields` is flat primitives only, so a capability object (mode lists,
+ * nested scope/antenna descriptors, a bundled radio-model string) cannot
+ * satisfy this type: the signature has no slot to receive one. Exact-keys
+ * checked at runtime by `isRendererViewModel` (review cycle 1, B1) — a
+ * third top-level key (e.g. a smuggled `capabilities` payload riding
+ * alongside valid `kind`/`fields`) is rejected, not silently ignored.
+ *
+ * Seam with MOR-1062: this is NOT the semantic-UI view model
+ * (`RadioViewModel`, landing in `frontend/src/semantic/radio-view-model.ts`).
+ * The roles are distinct — `RadioViewModel` is the adapter→semantic-UI
+ * contract and may carry `{status:'unknown'}` unions; `RendererViewModel`
+ * is the flat projection a design-language renderer consumes. Projecting
+ * one into the other — and preserving `'unknown'` rather than collapsing
+ * it to a default — is owned by MOR-1243, not this file.
+ */
+export const RENDERER_SLOT_NAMES = ['meters', 'frequencyDisplay', 'stateFeedback'] as const;
+export type RendererSlotName = (typeof RENDERER_SLOT_NAMES)[number];
+
+export interface RendererViewModel { readonly kind: string; readonly fields: Readonly<Record<string, string | number | boolean | null>> }
+const RENDERER_VIEW_MODEL_KEYS: readonly PropertyKey[] = ['kind', 'fields'];
+
+export type Renderer<TViewModel extends RendererViewModel = RendererViewModel> =
+  (viewModel: TViewModel, tokens: DesignLanguageTokens) => unknown;
+
+/** Runtime-enforced twin of the RendererViewModel type check — exact keys, not just present ones. */
+export function isRendererViewModel(value: unknown): value is RendererViewModel {
+  if (typeof value !== 'object' || value === null) return false;
+  const proto = Object.getPrototypeOf(value); // N1: reject class instances — a prototype getter can carry an extra key that Object.keys/ownKeys on the instance itself would never see
+  if (proto !== Object.prototype && proto !== null) return false;
+  if (!Reflect.ownKeys(value).every((k) => RENDERER_VIEW_MODEL_KEYS.includes(k))) return false; // B1/N1: exact OWN keys incl. non-enumerable/symbol, not just enumerable string keys
+  const v = value as Record<string, unknown>;
+  const fieldsOk = typeof v.fields === 'object' && v.fields !== null && !Array.isArray(v.fields);
+  return typeof v.kind === 'string' && fieldsOk && Object.values(v.fields as Record<string, unknown>).every(
+    (val) => val === null || ['string', 'number', 'boolean'].includes(typeof val),
+  );
+}
+
+export interface DesignLanguageManifest {
+  readonly id: string;
+  readonly displayName: string;
+  readonly tokens: DesignLanguageTokens;
+  readonly density: DensityClamp;
+  readonly layoutCompatibility: readonly LayoutCompatibilityDeclaration[];
+  readonly renderers: Partial<Record<RendererSlotName, Renderer>>; // "semantic renderer slots"
+}
+
+// ── Validation + registry. `registerDesignLanguage` does not hardcode a
+// family count — any manifest passing naming policy, required token
+// groups, and the capability-fork check registers, same as `studioline`/
+// `fieldline` in ./declarations (MOR-977 §4.4, §4.6).
+
+export class DesignLanguageValidationError extends Error {}
+export class RendererInputError extends Error {}
+
+/** Manufacturer inspiration must never become a capability fork (MOR-977 §4.4) — no manifest key may reference one, anywhere, including inside renderer closures (JSON.stringify's replacer walks every nested key and skips function values). */
+const FORBIDDEN_MANIFEST_KEY_MARKERS = ['capability', 'capabilities', 'radiomodel', 'vendor', 'manufacturer', 'firmware'];
+
+function findCapabilityLikeKey(manifest: DesignLanguageManifest): string | null {
+  let hit: string | null = null;
+  JSON.stringify(manifest, (key, value) => {
+    if (!hit && FORBIDDEN_MANIFEST_KEY_MARKERS.some((m) => key.toLowerCase().includes(m))) hit = key;
+    return value;
+  });
+  return hit;
+}
+
+/** Throws with a descriptive message if `manifest` violates the contract. */
+export function validateManifest(manifest: DesignLanguageManifest): void {
+  const id = manifest.id;
+  const missing = REQUIRED_TOKEN_GROUPS.filter((g) => manifest.tokens[g] === undefined);
+  const capabilityHit = findCapabilityLikeKey(manifest);
+  const problem =
+    (!isValidLanguageId(id) && `Design-language id "${id}" fails naming policy: kebab-case, no vendor/geographic marker.`) ||
+    (missing.length > 0 && `Design language "${id}" is missing required token group(s): ${missing.join(', ')}.`) ||
+    (!manifest.tokens.focusRing && `Design language "${id}" must declare a non-empty focusRing token (MOR-1232).`) ||
+    (manifest.tokens.typography.fontVariantNumeric !== 'tabular-nums' &&
+      `Design language "${id}" must declare tabular figures (font-variant-numeric: tabular-nums).`) ||
+    (capabilityHit && `Design language "${id}" references a capability-shaped key "${capabilityHit}" (MOR-977 §4.4).`);
+  if (problem) throw new DesignLanguageValidationError(problem);
+}
+
+const registry = new Map<string, DesignLanguageManifest>();
+
+/** Validates then registers `manifest`. Re-registering an ID overwrites it. */
+export function registerDesignLanguage(manifest: DesignLanguageManifest): void {
+  validateManifest(manifest);
+  registry.set(manifest.id, manifest);
+}
+export function getDesignLanguage(id: string): DesignLanguageManifest | undefined {
+  return registry.get(id);
+}
+export function listDesignLanguageIds(): readonly string[] {
+  return Array.from(registry.keys());
+}
+
+/** Safe no-op used when a language has not registered a renderer for a slot yet. */
+const FALLBACK_RENDERER: Renderer = () => null;
+
+/**
+ * Missing renderers fall back safely — a language may declare zero
+ * renderers before its visual slice lands (MOR-1073/1074). Returns a
+ * *gated* wrapper, not the raw renderer/fallback: calling the returned
+ * function always goes through `invokeRenderer`, so the structural check
+ * cannot be bypassed by calling the resolve-path result directly
+ * (review cycle 1, B1).
+ */
+export function resolveRenderer(manifest: DesignLanguageManifest, slot: RendererSlotName): Renderer {
+  const renderer = manifest.renderers[slot] ?? FALLBACK_RENDERER;
+  return (viewModel, tokens) => invokeRenderer(renderer, viewModel, tokens);
+}
+
+/** Structural gate: only a RendererViewModel (exact keys) may reach a renderer. */
+export function invokeRenderer(renderer: Renderer, viewModel: unknown, tokens: DesignLanguageTokens): unknown {
+  if (!isRendererViewModel(viewModel)) {
+    throw new RendererInputError(
+      'Renderer input must be a RendererViewModel (exactly {kind, fields}, fields flat-primitive-only); ' +
+        'capability objects and per-radio data structurally cannot reach a renderer.',
+    );
+  }
+  return renderer(viewModel as RendererViewModel, tokens);
+}

--- a/frontend/src/presentation/languages/declarations.ts
+++ b/frontend/src/presentation/languages/declarations.ts
@@ -1,0 +1,47 @@
+/**
+ * The two v3 design languages frozen by MOR-977 §4.6: `studioline`
+ * (reference) and `fieldline` (proof). Placeholder tokens, shared between
+ * both — no visual implementation yet (MOR-1073/MOR-1074). RX/TX namespace
+ * chosen here (MOR-1231 note): `--dl-rx-*`/`--dl-tx-*`, distinct from the
+ * legacy `--v2-tx-*` family. Registering here does not hardcode "two
+ * families" — contract.test.ts registers a third the same way.
+ */
+import { registerDesignLanguage, type DesignLanguageManifest } from './contract';
+
+const placeholderTokens: DesignLanguageManifest['tokens'] = {
+  typography: { fontFamily: 'system-ui, sans-serif', weight: 400, fontVariantNumeric: 'tabular-nums' },
+  geometry: { radius: '0px', borderWidth: '0px' },
+  meters: { trackWidth: '2px', segmentGap: '0px' },
+  frequency: { digitWeight: 400, rankedGroups: true },
+  motion: { durationMs: 150, reducedMotionSafe: true },
+  focusRing: '0 0 0 2px var(--accent)',
+  rx: { idle: 'var(--dl-rx-idle)', active: 'var(--dl-rx-active)', tuning: 'var(--dl-rx-tuning)' },
+  tx: { idle: 'var(--dl-tx-idle)', active: 'var(--dl-tx-active)', tuning: 'var(--dl-tx-tuning)' },
+};
+
+export const studioline: DesignLanguageManifest = {
+  id: 'studioline',
+  displayName: 'Studioline',
+  tokens: placeholderTokens,
+  // Holds all three density steps without collision (MOR-977 §4.2.3).
+  density: { kind: 'clamped', supported: ['comfortable', 'compact', 'dense'] },
+  layoutCompatibility: [],
+  renderers: {},
+};
+
+export const fieldline: DesignLanguageManifest = {
+  id: 'fieldline',
+  displayName: 'Fieldline',
+  tokens: placeholderTokens,
+  // dense clamped out — fieldline runs at 0.6 relative density (MOR-977 §4.4).
+  density: { kind: 'clamped', supported: ['comfortable', 'compact'] },
+  layoutCompatibility: [{
+    layoutId: 'dual-receiver-cockpit',
+    compatible: false,
+    reason: 'fieldline cannot serve as the desktop dual-receiver default at 0.6 relative density (MOR-977 §4.4).',
+  }],
+  renderers: {},
+};
+
+registerDesignLanguage(studioline);
+registerDesignLanguage(fieldline);


### PR DESCRIPTION
## Summary

The product-owned design-language token/renderer contract under which `studioline` (reference) and `fieldline` (proof) will be implemented — `frontend/src/presentation/languages/{contract.ts,declarations.ts}` (+ a 1-line `lint:boundaries` glob extension in package.json), encoding the frozen doctrine (MOR-1071 + MOR-977 records):

- **Token contract:** 8 required groups incl. a symmetric RX/TX pair under the new `--dl-rx-*`/`--dl-tx-*` namespace (source-of-truth ruling recorded on MOR-1231 — legacy `--v2-*` migration stays that ticket's scope), mandatory non-empty focus-ring (MOR-1232's token half), and a tabular-figures declaration in every language bundle. Validation fails a bundle missing any group.
- **Language manifest:** id + layout-compatibility DECLARATIONS (fieldline vs `dual-receiver-cockpit` — a declaration, never a capability check) + workspace-owned density CLAMPS (incl. `not-applicable`; the manifest declares clamps, never the density itself).
- **Naming policy:** substring denylist + anchored model-number pattern (`/(^|-)(ic|ft|ts)-?\d/`): `ic-7610`, `icom7610`, `icomclassic`, `kenwoodstyle`, `yaesuline`, `flexradio` reject; the frozen IDs and legitimate grammar names (`classic-instrument`, `atomic-rail`, …) pass. Honestly recorded as a denylist, not a classifier (e.g. `ftdx101` infix and geography evade — review owns that class).
- **Fork-proof renderer contract:** renderers consume a flat-primitive `RendererViewModel` + tokens only. The runtime gate checks exact keys over `Reflect.ownKeys` with a plain-prototype requirement (prototype-getter/non-enumerable/symbol smuggling all rejected), and `resolveRenderer` returns a gated wrapper — no bypass path. The projection from MOR-1062's `RadioViewModel` is owned by MOR-1243 (seam documented in the contract).
- **Registry:** `studioline`/`fieldline` registered as declarations (no visual implementation — that is MOR-1073/1074); count-agnostic (hypothetical third family validates).

**Recorded guardrail deviation:** 239 net production LOC vs ≤200 — the overage is review-mandated hardening (exact-key gate, gated resolver, naming anchor); ruling recorded on the Linear ticket (precedent: MOR-1062).

## Independent verification (two cycles at cap + delta confirm)

- Doctrine held under a 15-mutant battery (15/15 killed); cycle findings: capability-smuggling via loose key check (fixed: exact keys + prototype requirement, re-probed with four bypass shapes — all reject), the `'ic'` marker over-rejecting 11 legitimate names incl. the MOR-977-preserved `classic-instrument` (fixed with the anchored pattern), and a silently edited accept-list test that had masked the over-rejection — caught by the reviewer's cross-check against the MOR-977 record, restored, and pinned with an explicit comment against recurrence.
- Namespace and MOR-1062-collision rulings recorded: `--dl-*` is sound layering (MOR-1231 re-scoped); `RendererViewModel` renamed from `SemanticViewModel`, projection ticket MOR-1243 filed.
- Suites: 58/58 contract tests; architecture-boundaries 37/37; lint/lint:boundaries/check clean (the glob extension proven load-bearing by a planted illegal import); full pytest 8777/0 at base (no Python in the diff).

Linear: MOR-1072 (unblocks MOR-1073 chain and MOR-1077 workspace consumer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
