### PR TITLE
feat(MOR-1060): lazy presentation loading with stale-resolution cancellation

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1,16 +1,16 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
+  import { onMount, tick, type Component } from 'svelte';
   import { initBatteryMonitor } from './lib/utils/battery';
-  import RadioLayoutV2 from './components-v2/layout/RadioLayout.svelte';
   import AppGlobalHost from './AppGlobalHost.svelte';
   import LocalExtensionsHost from './lib/local-extensions/LocalExtensionsHost.svelte';
   import { initMediaSession, destroyMediaSession } from './lib/media/media-session';
-  import { runtime } from './lib/runtime/frontend-runtime';
+  import { presentationResources, runtime } from './lib/runtime/frontend-runtime';
+  import type { ResourceLease } from '$lib/runtime/resource-demand';
   import { systemController } from '$lib/runtime/system-controller';
   import { provideAppTxControllerHost } from '$lib/runtime/tx-controller/app-host';
   import { hasAnyScope } from './lib/stores/capabilities.svelte';
   import { getLayoutMode } from './lib/stores/layout.svelte';
-  import { resolveSkinId, type SkinId } from './skins/registry';
+  import { loadSkin, presentationResourcePlan, resolveSkinId, type SkinId } from './skins/registry';
   import { t } from '$lib/i18n';
   import './app.css';
 
@@ -37,6 +37,87 @@
     isMobile,
     hasAnyScope: hasAnyScope(),
   }));
+
+  // ── Lazy presentation loading (MOR-1060) ──
+  //
+  // App is the sole owner of presentation selection, loading and commit. Each
+  // request takes a fresh loader generation — including A → B → A — so exactly
+  // one resolution can commit: any completion whose generation is no longer
+  // current is discarded without mounting, without writing state and without
+  // touching the resources of the presentation that is actually on screen.
+  //
+  // The committed presentation stays mounted for the whole time the next
+  // loader is in flight, so a switch never blanks the operator's screen and
+  // never replays bootstrap, transport, audio or TX ownership — all of which
+  // live above this seam (MOR-973, MOR-1008, MOR-1059).
+  let presentation = $state<{ id: SkinId; component: Component } | null>(null);
+  let presentationFailed = $state(false);
+  let Presentation = $derived(presentation?.component ?? null);
+  let loaderGeneration = 0;
+  /** Cleared by App teardown; a resolution that lands afterwards is inert. */
+  let presentationActive = true;
+
+  $effect(() => {
+    const requested = skinId;
+    if (demoMode === 'control-buttons') return;
+    void requestPresentation(requested);
+  });
+
+  async function requestPresentation(id: SkinId): Promise<void> {
+    const generation = ++loaderGeneration;
+    let loaded: Component;
+    try {
+      loaded = await loadSkin(id);
+    } catch (err) {
+      // A stale or post-teardown failure is inert: only the newest request
+      // owns the error surface (same guard doctrine as the bootstrap catch).
+      if (!presentationActive || generation !== loaderGeneration) return;
+      console.error(`[rigplane] presentation "${id}" failed to load:`, err);
+      // Last-known-good survives a failed switch; only an initial load has
+      // nothing to keep, and then the surface is inert — no retry, no
+      // runtime teardown.
+      presentationFailed = presentation === null;
+      return;
+    }
+    if (!presentationActive || generation !== loaderGeneration) return;
+
+    // Hold the incoming presentation's demand BEFORE the swap so destroying
+    // the outgoing subtree can never drop a live resource to zero and bounce
+    // it (MOR-973). Released only after the commit has flushed, by which time
+    // the new subtree owns its own leases.
+    const bridge = acquireSwapBridge(id);
+    try {
+      presentationFailed = false;
+      presentation = { id, component: loaded };
+      await tick();
+    } finally {
+      releaseSwapBridge(bridge);
+    }
+  }
+
+  /**
+   * Bridge leases for the incoming presentation's planned resources, limited
+   * to those already demanded: a presentation choice must not manufacture a
+   * live service (v3 ADR invariant 12).
+   */
+  function acquireSwapBridge(id: SkinId): ResourceLease[] {
+    const leases: ResourceLease[] = [];
+    for (const resource of presentationResourcePlan(id)) {
+      try {
+        if (presentationResources.snapshot(resource).demand <= 0) continue;
+        // Every acquisition returns its own distinct lease object, so a
+        // release can only ever cancel the binding it created.
+        leases.push(presentationResources.acquire(resource, `App:${id}`));
+      } catch {
+        // The App resource session is torn down — there is nothing to bridge.
+      }
+    }
+    return leases;
+  }
+
+  function releaseSwapBridge(leases: ResourceLease[]): void {
+    while (leases.length > 0) presentationResources.release(leases.pop()!);
+  }
 
   const txHost = provideAppTxControllerHost({
     registerPreDisconnectBarrier: (barrier) =>
@@ -70,7 +151,10 @@
 
   onMount(() => {
     if (demoMode === 'control-buttons') {
-      return () => txHost.dispose();
+      return () => {
+        presentationActive = false;
+        txHost.dispose();
+      };
     }
 
     // Stale-bookmark notice: ?ui=v1 is no longer supported (v0.20+). Emit once per session.
@@ -123,6 +207,7 @@
 
     return () => {
       mounted = false;
+      presentationActive = false;
       txAuthorityReady = false;
       txHost.dispose();
       destroyMediaSession();
@@ -151,8 +236,18 @@
       {/if}
     </div>
   </div>
-{:else}
-  <RadioLayoutV2 {skinId} />
+{:else if Presentation}
+  <Presentation />
+{:else if presentationFailed}
+  <!-- Initial presentation load failed: an inert App-owned surface. No retry
+       and no runtime teardown — control transport, audio and TX authority all
+       live above this boundary and stay up. -->
+  <div class="error-overlay" role="alert" aria-live="assertive">
+    <div class="error-box">
+      <div class="error-icon">⚠</div>
+      <p class="error-msg" data-testid="presentation-load-error">{t('core.app.presentationError')}</p>
+    </div>
+  </div>
 {/if}
 
 {#if demoMode !== 'control-buttons' && !backendError}

--- a/frontend/src/__tests__/app-global-host.component.test.ts
+++ b/frontend/src/__tests__/app-global-host.component.test.ts
@@ -35,6 +35,7 @@ const h = vi.hoisted(() => ({
   bootstrap: vi.fn(),
   initBattery: vi.fn(),
   resolveSkin: vi.fn(),
+  loadSkin: vi.fn(),
 }));
 
 vi.mock('$lib/runtime', async () => {
@@ -56,7 +57,17 @@ vi.mock('$lib/runtime', async () => {
 });
 vi.mock('../lib/runtime/frontend-runtime', async () => {
   const mod = await import('$lib/runtime');
-  return { runtime: mod.runtime };
+  return {
+    runtime: mod.runtime,
+    // MOR-1060: App bridges presentation resource demand across a swap. The
+    // demand model has its own suite; here it only has to exist and stay
+    // inert (nothing is demanded, so nothing is bridged).
+    presentationResources: {
+      snapshot: () => ({ demand: 0 }),
+      acquire: () => ({}),
+      release: () => true,
+    },
+  };
 });
 vi.mock('../lib/transport/ws-client', () => ({ onMessage: h.onMessage }));
 vi.mock('$lib/i18n', () => ({
@@ -78,7 +89,11 @@ vi.mock('$lib/runtime/system-controller', () => ({
 }));
 vi.mock('$lib/stores/capabilities.svelte', () => ({ hasAnyScope: () => false }));
 vi.mock('$lib/stores/layout.svelte', () => ({ getLayoutMode: () => 'standard' }));
-vi.mock('../skins/registry', () => ({ resolveSkinId: h.resolveSkin }));
+vi.mock('../skins/registry', () => ({
+  resolveSkinId: h.resolveSkin,
+  loadSkin: h.loadSkin,
+  presentationResourcePlan: () => [],
+}));
 vi.mock('../lib/utils/battery', () => ({ initBatteryMonitor: h.initBattery }));
 vi.mock('../lib/media/media-session', () => ({ initMediaSession: vi.fn(), destroyMediaSession: vi.fn() }));
 vi.mock('../components-v2/layout/RadioLayout.svelte', async () => {
@@ -92,8 +107,25 @@ vi.mock('../lib/local-extensions/LocalExtensionsHost.svelte', async () => {
 
 import App from '../App.svelte';
 import AppGlobalHost from '../AppGlobalHost.svelte';
+import LayoutStub from './LayoutStub.svelte';
 
 const settle = async () => { await Promise.resolve(); await Promise.resolve(); };
+
+/**
+ * MOR-1060: the presentation reaches App through the lazy loader, so each
+ * skin id gets its own component identity wrapping the shared stub — a swap
+ * is still a genuine destroy/recreate of the presentation subtree.
+ */
+type ClientComponent = (anchor: unknown, props: Record<string, unknown>) => void;
+const presentationStubs = new Map<string, ClientComponent>();
+function presentationStub(skinId: string): ClientComponent {
+  let stub = presentationStubs.get(skinId);
+  if (!stub) {
+    stub = (anchor, props) => (LayoutStub as unknown as ClientComponent)(anchor, { ...props, skinId });
+    presentationStubs.set(skinId, stub);
+  }
+  return stub;
+}
 
 /** Push a new authoritative TX snapshot through the controller subscription. */
 function emitTx(next: Partial<TxSnapshot>): void {
@@ -128,6 +160,7 @@ beforeEach(() => {
   h.bootstrap.mockResolvedValue(vi.fn());
   h.initBattery.mockResolvedValue(vi.fn());
   h.resolveSkin.mockImplementation(({ isMobile }: { isMobile: boolean }) => (isMobile ? 'mobile' : 'desktop-v2'));
+  h.loadSkin.mockImplementation(async (skinId: string) => presentationStub(skinId));
   h.provide.mockReturnValue({ refreshAuthority: vi.fn(), release: vi.fn(), dispose: vi.fn() });
 });
 
@@ -251,18 +284,23 @@ describe('App composition — one host above the presentation boundary', () => {
     const layoutBefore = document.querySelector('.layout-stub');
     expect(layoutBefore?.getAttribute('data-skin')).toBe('desktop-v2');
 
-    const resize = (width: number) => {
+    // MOR-1060 made the swap asynchronous (the next presentation is loaded
+    // lazily), so each hop settles the loader before asserting. The
+    // assertions themselves are unchanged.
+    const resize = async (width: number) => {
       Object.defineProperty(window, 'innerWidth', { configurable: true, value: width });
       window.dispatchEvent(new Event('resize'));
+      flushSync();
+      await settle();
       flushSync();
     };
 
     // A -> B -> A. Each hop genuinely destroys and recreates the layout.
-    resize(390);
+    await resize(390);
     const layoutMobile = document.querySelector('.layout-stub');
     expect(layoutMobile?.getAttribute('data-skin')).toBe('mobile');
     expect(layoutMobile).not.toBe(layoutBefore);
-    resize(1200);
+    await resize(1200);
     const layoutBack = document.querySelector('.layout-stub');
     expect(layoutBack?.getAttribute('data-skin')).toBe('desktop-v2');
     expect(layoutBack).not.toBe(layoutMobile);

--- a/frontend/src/__tests__/lazy-presentation.component.test.ts
+++ b/frontend/src/__tests__/lazy-presentation.component.test.ts
@@ -1,0 +1,631 @@
+/**
+ * MOR-1060 — lazy presentation loading with stale-resolution cancellation.
+ *
+ * These tests pin the composition-root contract, not any skin's markup:
+ *   1. only the selected presentation's module is ever loaded;
+ *   2. the committed presentation stays mounted while the next one resolves,
+ *      and a stale resolution never mounts and never writes state;
+ *   3. A -> B -> A leaves exactly one instance of the latest request, with
+ *      every bridge lease a distinct object released exactly once;
+ *   4. a switch keeps bootstrap, TX authority and the App-global host
+ *      identical — nothing above the presentation boundary is replayed;
+ *   5. loader failure keeps last-known-good; an initial failure yields an
+ *      inert App-owned surface; a late failure after teardown is inert.
+ */
+import { readFileSync } from 'node:fs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, tick, unmount } from 'svelte';
+import type { SkinId } from '../skins/registry';
+
+type Pending = { id: SkinId; resolve: (component: unknown) => void; reject: (err: unknown) => void };
+type LeaseEvent = { op: 'acquire' | 'release'; resource: string; consumer: string; mounted: string | null };
+
+const h = vi.hoisted(() => ({
+  pending: [] as Pending[],
+  loadSkin: vi.fn(),
+  resolveSkinId: vi.fn(),
+  plan: vi.fn(),
+  demand: new Map<string, number>(),
+  leaseEvents: [] as LeaseEvent[],
+  issuedLeases: [] as object[],
+  releasedLeases: [] as object[],
+  resourcesEnded: false,
+  bootstrap: vi.fn(),
+  bootstrapCleanup: vi.fn(),
+  initBattery: vi.fn(),
+  provide: vi.fn(),
+  registerBarrier: vi.fn(),
+  txHost: undefined as { refreshAuthority: ReturnType<typeof vi.fn>; dispose: ReturnType<typeof vi.fn> } | undefined,
+}));
+
+// The presentation subtree under test is the *loader result*, so the skin
+// registry is fully faked: `loadSkin` hands back a deferred promise per call
+// and the test decides when — and whether — each one resolves.
+vi.mock('../skins/registry', () => ({
+  resolveSkinId: h.resolveSkinId,
+  loadSkin: h.loadSkin,
+  presentationResourcePlan: h.plan,
+}));
+
+vi.mock('../lib/runtime/frontend-runtime', () => ({
+  runtime: {
+    get state() { return { stateRevision: 1, freshnessRevision: 1, observationSeq: 1, ptt: false }; },
+    get caps() { return { tx: true, capabilities: ['tx'] }; },
+    bootstrap: h.bootstrap,
+    setPollingMultiplier: vi.fn(),
+  },
+  presentationResources: {
+    snapshot: (resource: string) => ({ demand: h.demand.get(resource) ?? 0 }),
+    acquire: (resource: string, consumer: string) => {
+      if (h.resourcesEnded) throw new Error('resource demand session is torn down');
+      h.leaseEvents.push({ op: 'acquire', resource, consumer, mounted: mountedSkin() });
+      h.demand.set(resource, (h.demand.get(resource) ?? 0) + 1);
+      // A distinct, frozen object per acquisition — never a reused handle.
+      const lease = Object.freeze({ resource, consumer });
+      h.issuedLeases.push(lease);
+      return lease;
+    },
+    release: (lease: { resource: string; consumer: string }) => {
+      h.leaseEvents.push({ op: 'release', resource: lease.resource, consumer: lease.consumer, mounted: mountedSkin() });
+      h.demand.set(lease.resource, (h.demand.get(lease.resource) ?? 0) - 1);
+      h.releasedLeases.push(lease);
+      return true;
+    },
+  },
+}));
+
+vi.mock('$lib/runtime/system-controller', () => ({
+  systemController: { registerPreDisconnectBarrier: h.registerBarrier },
+}));
+vi.mock('$lib/runtime/tx-controller/app-host', () => ({ provideAppTxControllerHost: h.provide }));
+vi.mock('$lib/i18n', () => ({ t: (key: string) => key }));
+vi.mock('$lib/stores/capabilities.svelte', () => ({ hasAnyScope: () => false }));
+vi.mock('$lib/stores/layout.svelte', () => ({ getLayoutMode: () => 'standard' }));
+vi.mock('../lib/utils/battery', () => ({ initBatteryMonitor: h.initBattery }));
+vi.mock('../lib/media/media-session', () => ({ initMediaSession: vi.fn(), destroyMediaSession: vi.fn() }));
+// The App-global host and local-extensions host have their own suites; here
+// they only need a stable, identifiable node so a switch can be shown not to
+// disturb them.
+vi.mock('../AppGlobalHost.svelte', async () => {
+  const stub = await import('../components-v2/layout/__tests__/SpectrumPanelStub.svelte');
+  return { default: stub.default };
+});
+vi.mock('../lib/local-extensions/LocalExtensionsHost.svelte', async () => {
+  const stub = await import('../components-v2/layout/__tests__/SpectrumPanelStub.svelte');
+  return { default: stub.default };
+});
+
+import App from '../App.svelte';
+import LayoutStub from './LayoutStub.svelte';
+
+/**
+ * A distinct presentation component per tag. Delegating to the compiled
+ * `LayoutStub` keeps real Svelte mount/destroy semantics (so "one instance"
+ * and "never mounted" are DOM facts), while the wrapper gives each tag its
+ * own component identity — exactly what the commit path switches on.
+ *
+ * The tag is usually the skin id, but any string works: a test that has to
+ * tell two resolutions of the SAME skin apart tags one of them separately
+ * and reads the winner back off `data-skin`.
+ */
+type ClientComponent = (anchor: unknown, props: Record<string, unknown>) => void;
+const stubFor = new Map<string, ClientComponent>();
+function presentationStub(id: string): ClientComponent {
+  let stub = stubFor.get(id);
+  if (!stub) {
+    stub = (anchor, props) => (LayoutStub as unknown as ClientComponent)(anchor, { ...props, skinId: id });
+    stubFor.set(id, stub);
+  }
+  return stub;
+}
+
+const mountedSkin = (): string | null =>
+  document.querySelector('.layout-stub')?.getAttribute('data-skin') ?? null;
+const mountedCount = () => document.querySelectorAll('.layout-stub').length;
+const globalHost = () => document.querySelector('.spectrum-panel-stub');
+const errorSurface = () => document.querySelector('[data-testid="presentation-load-error"]');
+
+/** Drain the microtask queue past App's post-commit `await tick()`. */
+async function settle(): Promise<void> {
+  for (let i = 0; i < 4; i++) await Promise.resolve();
+  await tick();
+  flushSync();
+}
+
+function mountApp() {
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+  const instance = mount(App, { target });
+  flushSync();
+  return instance;
+}
+
+/** Change the viewport so `resolveSkinId` returns the other skin. */
+function selectSkin(id: SkinId): void {
+  Object.defineProperty(window, 'innerWidth', { configurable: true, value: id === 'mobile' ? 390 : 1200 });
+  window.dispatchEvent(new Event('resize'));
+  flushSync();
+}
+
+/**
+ * Resolve the oldest still-pending load for `id`. `as` overrides which stub
+ * that resolution hands back, so two pending requests for the same skin can
+ * be told apart in the DOM.
+ */
+function completeLoad(id: SkinId, as: string = id): void {
+  const index = h.pending.findIndex((entry) => entry.id === id);
+  if (index < 0) throw new Error(`no pending load for ${id}`);
+  h.pending.splice(index, 1)[0].resolve(presentationStub(as));
+}
+
+function failLoad(id: SkinId, message = 'chunk load failed'): void {
+  const index = h.pending.findIndex((entry) => entry.id === id);
+  if (index < 0) throw new Error(`no pending load for ${id}`);
+  h.pending.splice(index, 1)[0].reject(new Error(message));
+}
+
+const requestedSkins = () => h.loadSkin.mock.calls.map((call) => call[0] as SkinId);
+
+let consoleError: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.pending.length = 0;
+  h.leaseEvents.length = 0;
+  h.issuedLeases.length = 0;
+  h.releasedLeases.length = 0;
+  h.demand.clear();
+  h.resourcesEnded = false;
+  document.body.innerHTML = '';
+  Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1200 });
+  Object.defineProperty(window, 'innerHeight', { configurable: true, value: 800 });
+  h.bootstrap.mockResolvedValue(h.bootstrapCleanup);
+  h.initBattery.mockResolvedValue(vi.fn());
+  h.resolveSkinId.mockImplementation(({ isMobile }: { isMobile: boolean }) => (isMobile ? 'mobile' : 'desktop-v2'));
+  h.loadSkin.mockImplementation(
+    (id: SkinId) => new Promise((resolve, reject) => { h.pending.push({ id, resolve, reject }); }),
+  );
+  h.plan.mockImplementation((id: SkinId) => (id === 'mobile' ? ['hardware-scope'] : ['hardware-scope', 'audio-fft']));
+  h.provide.mockImplementation(() => {
+    h.txHost = { refreshAuthority: vi.fn(), dispose: vi.fn() };
+    return { ...h.txHost, release: vi.fn() };
+  });
+  consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+describe('lazy presentation loading', () => {
+  // MUTATION KILLED: re-introducing a static `import RadioLayout from ...`
+  // (or eagerly pre-loading every entrypoint) — the app would ship and
+  // execute every presentation module regardless of the resolved skin.
+  it('requests only the selected presentation entrypoint', async () => {
+    const instance = mountApp();
+    await settle();
+
+    expect(requestedSkins()).toEqual(['desktop-v2']);
+    completeLoad('desktop-v2');
+    await settle();
+    expect(mountedSkin()).toBe('desktop-v2');
+    // Still exactly one module requested after the commit.
+    expect(requestedSkins()).toEqual(['desktop-v2']);
+
+    unmount(instance);
+  });
+
+  it('keeps App.svelte free of static presentation entrypoint imports', () => {
+    const source = readFileSync('src/App.svelte', 'utf8');
+    // A static import of a layout or skin entrypoint defeats code splitting
+    // no matter what the loader does at runtime.
+    expect(source).not.toMatch(/import\s+\w+\s+from\s+['"][^'"]*components-v2\/layout\/[^'"]*\.svelte['"]/);
+    expect(source).not.toMatch(/import\s+\w+\s+from\s+['"][^'"]*skins\/[^'"]*\.svelte['"]/);
+  });
+});
+
+describe('stale-resolution cancellation', () => {
+  // MUTATION KILLED: dropping the generation check before commit. Without it
+  // the late mobile resolution mounts on top of (or instead of) the desktop
+  // presentation the newest request selected — a stale mount, and with the
+  // naive form a second live instance.
+  it('discards a superseded loader completion without mounting it', async () => {
+    const instance = mountApp();
+    await settle();
+    completeLoad('desktop-v2');
+    await settle();
+    expect(mountedSkin()).toBe('desktop-v2');
+
+    selectSkin('mobile');                 // request 2 — in flight
+    await settle();
+    // The committed presentation stays mounted while the next one resolves.
+    expect(mountedSkin()).toBe('desktop-v2');
+    expect(mountedCount()).toBe(1);
+
+    selectSkin('desktop-v2');             // request 3 — supersedes request 2
+    await settle();
+
+    completeLoad('mobile');               // request 2 lands late
+    await settle();
+
+    expect(mountedSkin()).toBe('desktop-v2');
+    expect(mountedCount()).toBe(1);
+    // The stale completion touched no resources at all.
+    expect(h.leaseEvents.filter((e) => e.consumer === 'App:mobile')).toEqual([]);
+
+    unmount(instance);
+  });
+
+  // MUTATION KILLED: committing on any resolution instead of the newest one.
+  // Here the newest request (desktop) resolves FIRST and the superseded one
+  // (mobile) resolves after — order of arrival must not decide the winner.
+  it('mounts the latest request even when an older one resolves after it', async () => {
+    const instance = mountApp();
+    await settle();
+    completeLoad('desktop-v2');
+    await settle();
+
+    selectSkin('mobile');                 // request 2
+    await settle();
+    selectSkin('desktop-v2');             // request 3 wins
+    await settle();
+
+    completeLoad('desktop-v2');
+    await settle();
+    expect(mountedSkin()).toBe('desktop-v2');
+
+    completeLoad('mobile');
+    await settle();
+    expect(mountedSkin()).toBe('desktop-v2');
+    expect(mountedCount()).toBe(1);
+
+    unmount(instance);
+  });
+
+  // MUTATION KILLED: gating the commit on the SKIN ID rather than on the
+  // loader generation (`if (id !== skinId) return`). Three requests are in
+  // flight as [A, B, A]; the first and the last select the same skin, so an
+  // id comparison cannot tell them apart and the long-superseded first
+  // resolution commits. Only the generation distinguishes them — which is
+  // why the gate must compare generations, not ids.
+  it('discards a stale resolution whose skin id equals the newest request', async () => {
+    h.demand.set('hardware-scope', 1);   // so a real commit would bridge
+    const instance = mountApp();          // request 1: desktop-v2
+    await settle();
+    selectSkin('mobile');                 // request 2: mobile
+    await settle();
+    selectSkin('desktop-v2');             // request 3: desktop-v2 — same id as #1
+    await settle();
+    expect(requestedSkins()).toEqual(['desktop-v2', 'mobile', 'desktop-v2']);
+    expect(h.pending).toHaveLength(3);
+
+    // Resolve request 1, tagged so a commit would be visible in the DOM.
+    completeLoad('desktop-v2', 'desktop-v2#stale');
+    await settle();
+
+    expect(mountedCount()).toBe(0);
+    expect(mountedSkin()).toBeNull();
+    // A discarded resolution touches no resources either.
+    expect(h.leaseEvents).toEqual([]);
+
+    completeLoad('desktop-v2');           // request 3 — the current one
+    await settle();
+
+    expect(mountedSkin()).toBe('desktop-v2');
+    expect(mountedCount()).toBe(1);
+
+    unmount(instance);
+  });
+
+  // MUTATION KILLED: not taking a fresh generation for a request that
+  // returns to the currently committed skin (A -> B -> A). If A's request
+  // reused the committed generation, B's in-flight completion would still
+  // look current and would mount.
+  it('takes a fresh loader generation for the A -> B -> A return leg', async () => {
+    const instance = mountApp();
+    await settle();
+    completeLoad('desktop-v2');
+    await settle();
+
+    selectSkin('mobile');
+    await settle();
+    selectSkin('desktop-v2');
+    await settle();
+
+    expect(requestedSkins()).toEqual(['desktop-v2', 'mobile', 'desktop-v2']);
+
+    completeLoad('mobile');               // stale — must not mount
+    completeLoad('desktop-v2');           // current
+    await settle();
+
+    expect(mountedSkin()).toBe('desktop-v2');
+    expect(mountedCount()).toBe(1);
+
+    unmount(instance);
+  });
+});
+
+describe('resource-demand continuity across a swap', () => {
+  // MUTATION KILLED: releasing the bridge before the commit, or acquiring it
+  // after the commit. Either ordering lets demand pass through zero while the
+  // outgoing subtree is destroyed, which stops and restarts a live stream —
+  // exactly the reconnect MOR-973 forbids.
+  it('acquires the incoming demand before the commit and releases it after', async () => {
+    h.demand.set('hardware-scope', 1);    // a live scope, owned by the desktop subtree
+    const instance = mountApp();
+    await settle();
+    completeLoad('desktop-v2');
+    await settle();
+    h.leaseEvents.length = 0;
+
+    selectSkin('mobile');
+    await settle();
+    completeLoad('mobile');
+    await settle();
+
+    const bridge = h.leaseEvents.filter((event) => event.consumer === 'App:mobile');
+    expect(bridge.map((event) => event.op)).toEqual(['acquire', 'release']);
+    expect(bridge[0].resource).toBe('hardware-scope');
+    // The acquire happened while the OLD presentation was still on screen and
+    // the release only after the NEW one had been committed and flushed.
+    expect(bridge[0].mounted).toBe('desktop-v2');
+    expect(bridge[1].mounted).toBe('mobile');
+
+    unmount(instance);
+  });
+
+  // MUTATION KILLED: bridging every planned resource unconditionally. That
+  // would START the audio FFT for a presentation nobody has asked it from —
+  // a presentation choice manufacturing a live service (v3 ADR invariant 12).
+  it('bridges only resources that are already demanded', async () => {
+    // A live hardware scope, and an audio FFT nobody has asked for. The
+    // incoming desktop presentation plans BOTH.
+    h.demand.set('hardware-scope', 1);
+    h.demand.set('audio-fft', 0);
+    const instance = mountApp();
+    await settle();
+    completeLoad('desktop-v2');
+    await settle();
+    selectSkin('mobile');
+    await settle();
+    completeLoad('mobile');
+    await settle();
+    h.leaseEvents.length = 0;
+
+    selectSkin('desktop-v2');
+    await settle();
+    completeLoad('desktop-v2');
+    await settle();
+
+    expect(h.plan).toHaveBeenCalledWith('desktop-v2');
+    expect(h.leaseEvents.map((event) => event.resource)).toEqual(['hardware-scope', 'hardware-scope']);
+    expect(h.demand.get('audio-fft')).toBe(0);
+
+    unmount(instance);
+  });
+
+  // MUTATION KILLED: caching/reusing one lease object across switches. A
+  // reused handle leaks a binding (the second release cancels the first
+  // acquisition's lease, leaving the newer one held forever).
+  it('issues a distinct lease per acquisition and releases each exactly once', async () => {
+    h.demand.set('hardware-scope', 1);
+    const instance = mountApp();
+    await settle();
+    completeLoad('desktop-v2');
+    await settle();
+
+    for (const id of ['mobile', 'desktop-v2', 'mobile'] as const) {
+      selectSkin(id);
+      await settle();
+      completeLoad(id);
+      await settle();
+    }
+
+    expect(h.issuedLeases.length).toBeGreaterThan(0);
+    expect(new Set(h.issuedLeases).size).toBe(h.issuedLeases.length);
+    // stop-count == start-count: nothing outstanding, nothing double-released.
+    expect(h.releasedLeases).toEqual(h.issuedLeases);
+    expect(new Set(h.releasedLeases).size).toBe(h.releasedLeases.length);
+    expect(h.demand.get('hardware-scope')).toBe(1);
+
+    unmount(instance);
+  });
+
+  // MUTATION KILLED: letting an acquire on a torn-down resource session throw
+  // out of the commit path — the presentation would never mount.
+  it('commits the presentation even when the resource session is torn down', async () => {
+    h.demand.set('hardware-scope', 1);
+    const instance = mountApp();
+    await settle();
+    completeLoad('desktop-v2');
+    await settle();
+
+    h.resourcesEnded = true;
+    selectSkin('mobile');
+    await settle();
+    completeLoad('mobile');
+    await settle();
+
+    expect(mountedSkin()).toBe('mobile');
+    expect(mountedCount()).toBe(1);
+
+    unmount(instance);
+  });
+});
+
+describe('identity preserved across a presentation switch', () => {
+  // MUTATION KILLED: driving the switch through anything that re-runs the
+  // App script — re-bootstrapping the control transport, re-providing the TX
+  // controller, or remounting the App-global host (MOR-1059 swap survival).
+  it('never replays bootstrap, TX authority or the App-global host', async () => {
+    const instance = mountApp();
+    await settle();
+    completeLoad('desktop-v2');
+    await settle();
+
+    const hostBefore = globalHost();
+    expect(hostBefore).not.toBeNull();
+    expect(h.bootstrap).toHaveBeenCalledTimes(1);
+    expect(h.provide).toHaveBeenCalledTimes(1);
+
+    for (const id of ['mobile', 'desktop-v2'] as const) {
+      selectSkin(id);
+      await settle();
+      completeLoad(id);
+      await settle();
+    }
+
+    expect(mountedSkin()).toBe('desktop-v2');
+    expect(h.bootstrap).toHaveBeenCalledTimes(1);
+    expect(h.provide).toHaveBeenCalledTimes(1);
+    expect(h.bootstrapCleanup).not.toHaveBeenCalled();
+    expect(h.txHost!.dispose).not.toHaveBeenCalled();
+    // Same DOM node — the host was never destroyed and recreated.
+    expect(globalHost()).toBe(hostBefore);
+    expect(document.querySelectorAll('.spectrum-panel-stub')).toHaveLength(2);
+
+    unmount(instance);
+  });
+
+  // MUTATION KILLED: bootstrapping or tearing down per presentation instead
+  // of per App instance.
+  it('bootstraps and tears down exactly once per App instance', async () => {
+    const first = mountApp();
+    await settle();
+    completeLoad('desktop-v2');
+    await settle();
+    selectSkin('mobile');
+    await settle();
+    completeLoad('mobile');
+    await settle();
+
+    expect(h.bootstrap).toHaveBeenCalledTimes(1);
+    unmount(first);
+    expect(h.bootstrapCleanup).toHaveBeenCalledTimes(1);
+
+    // The viewport is still narrow, so the fresh instance resolves to mobile
+    // and loads it from scratch — no presentation state survived the remount.
+    const second = mountApp();
+    await settle();
+    expect(h.bootstrap).toHaveBeenCalledTimes(2);
+    completeLoad('mobile');
+    await settle();
+    expect(mountedSkin()).toBe('mobile');
+    expect(mountedCount()).toBe(1);
+
+    unmount(second);
+    expect(h.bootstrapCleanup).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('presentation loader failure', () => {
+  // MUTATION KILLED: clearing the committed presentation (or tearing the
+  // runtime down) when a switch fails to load. The operator would lose the
+  // working screen because an unrelated chunk 404'd.
+  it('keeps the last-known-good presentation when a switch fails', async () => {
+    const instance = mountApp();
+    await settle();
+    completeLoad('desktop-v2');
+    await settle();
+
+    selectSkin('mobile');
+    await settle();
+    failLoad('mobile');
+    await settle();
+
+    expect(mountedSkin()).toBe('desktop-v2');
+    expect(mountedCount()).toBe(1);
+    expect(errorSurface()).toBeNull();
+    // Nothing above the presentation boundary was disturbed.
+    expect(h.bootstrapCleanup).not.toHaveBeenCalled();
+    expect(globalHost()).not.toBeNull();
+
+    unmount(instance);
+  });
+
+  // MUTATION KILLED: an initial failure that renders nothing at all, or one
+  // that arms the bootstrap retry/reload path — the surface must be inert.
+  it('shows an inert App-owned surface when the initial load fails', async () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+    const instance = mountApp();
+    await settle();
+    setTimeoutSpy.mockClear();
+
+    failLoad('desktop-v2');
+    await settle();
+
+    expect(errorSurface()).not.toBeNull();
+    expect(mountedCount()).toBe(0);
+    expect(setTimeoutSpy).not.toHaveBeenCalled();
+    expect(h.bootstrapCleanup).not.toHaveBeenCalled();
+    // The App-global surfaces stay up: the radio is still connected.
+    expect(globalHost()).not.toBeNull();
+
+    setTimeoutSpy.mockRestore();
+    unmount(instance);
+  });
+
+  // MUTATION KILLED: dropping the `presentationActive` guard in the catch. A
+  // rejection arriving after unmount would still run the whole handler —
+  // logging and writing component state for an App that no longer exists.
+  it('makes a rejection that lands after teardown inert', async () => {
+    const instance = mountApp();
+    await settle();
+    unmount(instance);
+    consoleError.mockClear();
+
+    expect(() => failLoad('desktop-v2')).not.toThrow();
+    await settle();
+
+    expect(consoleError).not.toHaveBeenCalled();
+    expect(errorSurface()).toBeNull();
+    expect(mountedCount()).toBe(0);
+    expect(document.body.textContent).not.toContain('core.app.presentationError');
+  });
+
+  // MUTATION KILLED: letting a superseded rejection claim the error surface
+  // and blank a presentation that loaded fine.
+  it('makes a superseded rejection inert', async () => {
+    const instance = mountApp();
+    await settle();
+
+    selectSkin('mobile');                 // supersedes the initial request
+    await settle();
+    consoleError.mockClear();
+    failLoad('desktop-v2');               // stale rejection
+    await settle();
+
+    expect(consoleError).not.toHaveBeenCalled();
+    expect(errorSurface()).toBeNull();
+    completeLoad('mobile');
+    await settle();
+    expect(mountedSkin()).toBe('mobile');
+
+    unmount(instance);
+  });
+
+  // PINS: an initial failure is recoverable — a later successful switch
+  // replaces the error surface with a live presentation.
+  //
+  // No mutation claim here, honestly. The surface is gated behind "nothing
+  // committed" (`{:else if presentationFailed}` sits after `{:else if
+  // Presentation}`), so mutating the `presentationFailed = false` write on
+  // the commit path — dropping it, or latching the flag true — is an
+  // EQUIVALENT MUTANT: the template branch already hides the surface the
+  // moment a presentation exists. The assignment stays as defence in depth
+  // against a future template that renders the two independently; this test
+  // pins the observable recovery, not that one statement.
+  it('clears the initial error surface once a presentation finally commits', async () => {
+    const instance = mountApp();
+    await settle();
+    failLoad('desktop-v2');
+    await settle();
+    expect(errorSurface()).not.toBeNull();
+
+    selectSkin('mobile');
+    await settle();
+    completeLoad('mobile');
+    await settle();
+
+    expect(errorSurface()).toBeNull();
+    expect(mountedSkin()).toBe('mobile');
+
+    unmount(instance);
+  });
+});

--- a/frontend/src/components-v2/layout/__tests__/RadioLayout.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/RadioLayout.test.ts
@@ -18,7 +18,11 @@ vi.mock('$lib/stores/layout.svelte', () => ({
   setLayoutMode: vi.fn(),
 }));
 
-vi.mock('../../../skins/registry', () => ({
+// Only the resolver is faked; `loadSkin` stays real so the App-mount test
+// below still exercises the actual lazy entrypoint → RadioLayout path
+// (MOR-1060).
+vi.mock('../../../skins/registry', async (importOriginal) => ({
+  ...await importOriginal<typeof import('../../../skins/registry')>(),
   resolveSkinId: vi.fn(() => 'desktop-v2'),
 }));
 
@@ -412,7 +416,7 @@ describe('RadioLayout structure', () => {
 });
 
 describe('App presentation selection', () => {
-  it('owns the resolver inputs and passes the resolved skinId to RadioLayout', () => {
+  it('owns the resolver inputs and passes the resolved skinId to RadioLayout', async () => {
     vi.mocked(resolveSkinId).mockReturnValue('sdr-test');
 
     const t = document.createElement('div');
@@ -420,6 +424,12 @@ describe('App presentation selection', () => {
     const component = mount(App, { target: t });
     flushSync();
     components.push(component);
+    // MOR-1060: the presentation is loaded lazily (a real dynamic import of
+    // the sdr-test entrypoint), so wait for the commit before asserting.
+    await vi.waitFor(() => {
+      flushSync();
+      expect(t.querySelector('.radio-layout.sdr-test')).not.toBeNull();
+    });
 
     expect(resolveSkinId).toHaveBeenLastCalledWith({
       capabilities: { scope: true },

--- a/frontend/src/lib/i18n/locales/en-US.json
+++ b/frontend/src/lib/i18n/locales/en-US.json
@@ -13,6 +13,7 @@
   "core.app.backendError": "Backend error: {detail}",
   "core.app.serverUnreachable": "Server unreachable after multiple attempts. Check connection and reload manually.",
   "core.app.retryIndicator": "Retry {attempt}/{max}, next attempt in {seconds}s…",
+  "core.app.presentationError": "This layout failed to load. The radio connection is unaffected — reload the page to try again.",
 
   "core.statusbar.connection.connected": "Connected",
   "core.statusbar.connection.notConnected": "Not Connected",

--- a/frontend/src/lib/i18n/locales/ja-JP.json
+++ b/frontend/src/lib/i18n/locales/ja-JP.json
@@ -13,6 +13,7 @@
   "core.app.backendError": "サーバーエラー: {detail}",
   "core.app.serverUnreachable": "何度試してもサーバーに接続できません。接続を確認して手動で再読み込みしてください。",
   "core.app.retryIndicator": "再試行 {attempt}/{max}、次の試行まで {seconds} 秒…",
+  "core.app.presentationError": "このレイアウトを読み込めませんでした。無線機との接続には影響ありません。ページを再読み込みして再試行してください。",
 
   "core.statusbar.connection.connected": "接続済み",
   "core.statusbar.connection.notConnected": "未接続",

--- a/frontend/src/lib/i18n/locales/ru-RU.json
+++ b/frontend/src/lib/i18n/locales/ru-RU.json
@@ -13,6 +13,7 @@
   "core.app.backendError": "Ошибка сервера: {detail}",
   "core.app.serverUnreachable": "Сервер недоступен после нескольких попыток. Проверьте соединение и перезагрузите страницу вручную.",
   "core.app.retryIndicator": "Попытка {attempt}/{max}, следующая через {seconds} с…",
+  "core.app.presentationError": "Не удалось загрузить эту раскладку. Связь с трансивером не затронута — перезагрузите страницу, чтобы повторить попытку.",
 
   "core.statusbar.connection.connected": "Подключено",
   "core.statusbar.connection.notConnected": "Не подключено",

--- a/frontend/src/lib/runtime/__tests__/frontend-runtime.test.ts
+++ b/frontend/src/lib/runtime/__tests__/frontend-runtime.test.ts
@@ -331,6 +331,42 @@ describe('FrontendRuntime.bootstrap()', () => {
     teardown.mockRestore();
   });
 
+  // MOR-1060 — the App remount seam. A second App instance must get a live
+  // runtime, not the cached cleanup of an instance that already tore down.
+  it('re-bootstraps after cleanup so a remounted App gets a live runtime', async () => {
+    const teardown = vi.spyOn(presentationResources, 'teardown')
+      .mockImplementation(async () => {});
+    const rt = await freshRuntime();
+    const internals = rt as unknown as { _ended: boolean };
+
+    const cleanup = await rt.bootstrap();
+    await cleanup();
+    expect(internals._ended).toBe(true);
+
+    const second = await rt.bootstrap();
+
+    expect(fetchCapabilities).toHaveBeenCalledTimes(2);
+    expect(connect).toHaveBeenCalledTimes(2);
+    expect(sendRaw).toHaveBeenCalledTimes(2);
+    expect(second).not.toBe(cleanup);
+    // The facades are re-armed, not latched closed by the previous teardown.
+    expect(internals._ended).toBe(false);
+    const lease = rt.acquireHardwareScope('remount-probe');
+    presentationResources.release(lease);
+
+    // MUTATION KILLED: clearing the cache from a cleanup body that can run
+    // more than once. Re-invoking the first instance's cleanup must stay a
+    // no-op and must not drop the SECOND instance's registration — otherwise
+    // a third bootstrap silently re-runs the transport chain on a live
+    // runtime.
+    await cleanup();
+    expect(fetchCapabilities).toHaveBeenCalledTimes(2);
+    expect(await rt.bootstrap()).toBe(second);
+
+    await second();
+    teardown.mockRestore();
+  });
+
   it('propagates fetchCapabilities error and allows retry', async () => {
     const rt = await freshRuntime();
     const error = new Error('network failure');

--- a/frontend/src/lib/runtime/frontend-runtime.ts
+++ b/frontend/src/lib/runtime/frontend-runtime.ts
@@ -254,6 +254,11 @@ class FrontendRuntime {
    * can be set before this async function starts.
    */
   private async _doBootstrap(): Promise<() => void> {
+    // A new App instance re-arms the runtime: `_ended` is latched by the
+    // previous instance's cleanup and would otherwise fail every facade
+    // (`acquireHardwareScope`, `subscribeDx`, `setRxLive`) closed forever.
+    this._ended = false;
+
     // Remove legacy pre-authority-gate restore records without consulting
     // cached state or issuing any radio command.
     clearLegacyPendingModInputRestore();
@@ -295,6 +300,12 @@ class FrontendRuntime {
     let cleanupInFlight: Promise<void> | undefined;
     const cleanup = () => cleanupInFlight ??= (async () => {
       this._ended = true;
+      // Drop the cached registration so a later `bootstrap()` (a remounted
+      // App) re-runs the chain instead of being handed a cleanup that has
+      // already run. Safe to do unconditionally: `cleanupInFlight` latches
+      // this body to exactly one execution, which happens before any newer
+      // registration can exist.
+      this._bootstrapCleanup = null;
       this._rxAudioLease = null;
       this._dxSubscribers.clear();
       const unsubscribeDx = this._dxControlUnsubscribe;

--- a/frontend/src/lib/runtime/tx-controller/__tests__/app-lifecycle.component.test.ts
+++ b/frontend/src/lib/runtime/tx-controller/__tests__/app-lifecycle.component.test.ts
@@ -32,7 +32,13 @@ vi.mock('../../../../lib/local-extensions/LocalExtensionsHost.svelte', async () 
 });
 vi.mock('$lib/stores/capabilities.svelte', () => ({ hasAnyScope: () => false }));
 vi.mock('$lib/stores/layout.svelte', () => ({ getLayoutMode: () => 'standard' }));
-vi.mock('../../../../skins/registry', () => ({ resolveSkinId: h.resolveSkin }));
+// MOR-1060: App loads the presentation lazily; serve the same stub through
+// the loader so the mounted tree is unchanged for these TX lifecycle tests.
+vi.mock('../../../../skins/registry', () => ({
+  resolveSkinId: h.resolveSkin,
+  loadSkin: async () => (await import('../../../../components-v2/layout/__tests__/SpectrumPanelStub.svelte')).default,
+  presentationResourcePlan: () => [],
+}));
 vi.mock('../../../../lib/utils/battery', () => ({ initBatteryMonitor: h.initBattery }));
 vi.mock('../../../../lib/media/media-session', () => ({ initMediaSession: h.initMedia, destroyMediaSession: h.destroyMedia }));
 vi.mock('../../../../lib/runtime/frontend-runtime', async () => {
@@ -40,11 +46,19 @@ vi.mock('../../../../lib/runtime/frontend-runtime', async () => {
   let update = () => {};
   const subscribe = createSubscriber((notify) => { update = notify; return () => {}; });
   h.notifyRuntime = () => update();
-  return { runtime: {
-    get state() { subscribe(); return h.radio; },
-    get caps() { subscribe(); return h.caps; },
-    bootstrap: h.bootstrap, setPollingMultiplier: vi.fn(),
-  } };
+  return {
+    runtime: {
+      get state() { subscribe(); return h.radio; },
+      get caps() { subscribe(); return h.caps; },
+      bootstrap: h.bootstrap, setPollingMultiplier: vi.fn(),
+    },
+    // MOR-1060 swap-bridge surface; inert here (nothing is demanded).
+    presentationResources: {
+      snapshot: () => ({ demand: 0 }),
+      acquire: () => ({}),
+      release: () => true,
+    },
+  };
 });
 vi.mock('$lib/runtime/system-controller', () => ({ systemController: { registerPreDisconnectBarrier: h.registerBarrier } }));
 vi.mock('$lib/i18n', () => ({ t: (key: string) => key }));

--- a/frontend/src/lib/runtime/tx-controller/__tests__/integration-page-lifecycle.test.ts
+++ b/frontend/src/lib/runtime/tx-controller/__tests__/integration-page-lifecycle.test.ts
@@ -114,7 +114,14 @@ vi.mock('../../../../lib/local-extensions/LocalExtensionsHost.svelte', async () 
   return { default: stub.default };
 });
 vi.mock('$lib/stores/layout.svelte', () => ({ getLayoutMode: () => 'standard' }));
-vi.mock('../../../../skins/registry', () => ({ resolveSkinId: () => 'desktop-v2' }));
+// MOR-1060: App now loads the presentation lazily through the registry, so
+// the probe is served by `loadSkin` rather than by the RadioLayout module
+// substitution above. Same tree, same captured controller.
+vi.mock('../../../../skins/registry', () => ({
+  resolveSkinId: () => 'desktop-v2',
+  loadSkin: async () => (await import('./support/TxControllerProbe.svelte')).default,
+  presentationResourcePlan: () => [],
+}));
 vi.mock('../../../../lib/utils/battery', () => ({ initBatteryMonitor: h.initBattery }));
 vi.mock('../../../../lib/media/media-session', () => ({
   initMediaSession: h.initMedia,
@@ -140,6 +147,11 @@ vi.mock('../../../../lib/runtime/frontend-runtime', async () => {
       },
       bootstrap: h.bootstrap,
       setPollingMultiplier: vi.fn(),
+    },
+    presentationResources: {
+      snapshot: () => ({ demand: 0 }),
+      acquire: () => ({}),
+      release: () => true,
     },
   };
 });
@@ -223,6 +235,12 @@ async function mountConnectedApp(): Promise<{
   mountedComponent = component;
   flushSync();
   await settle(); // let onMount's runtime.bootstrap() resolve → txAuthorityReady = true
+  // …and the lazy presentation loader commit + flush, which is what mounts
+  // the probe that captures the controller (MOR-1060).
+  await vi.waitFor(() => {
+    flushSync();
+    if (!capturedController()) throw new Error('presentation not committed yet');
+  });
 
   connection.setRadioReady(true);
   wsClient.connect('ws://test/api/v1/ws');

--- a/frontend/src/skins/__tests__/registry.test.ts
+++ b/frontend/src/skins/__tests__/registry.test.ts
@@ -23,7 +23,7 @@ vi.mock('../lcd-scope/LcdScopeSkin.svelte', () => lazyImports.scope());
 vi.mock('../mobile/MobileSkin.svelte', () => lazyImports.mobile());
 vi.mock('../sdr-test/SdrTestSkin.svelte', () => lazyImports.sdr());
 
-import { loadSkin, resolvePersistedSkinId, resolveSkinId } from '../registry';
+import { loadSkin, presentationResourcePlan, resolvePersistedSkinId, resolveSkinId } from '../registry';
 
 const resolve = (overrides: Partial<Parameters<typeof resolveSkinId>[0]> = {}) =>
   resolveSkinId({
@@ -80,5 +80,32 @@ describe('skin registry', () => {
   ] as const)('lazily loads the %s entrypoint', async (skinId: SkinId, entrypoint, lazyImport) => {
     await expect(loadSkin(skinId)).resolves.toBe(entrypoint);
     expect(lazyImport).toHaveBeenCalledTimes(1);
+  });
+});
+
+// MOR-1060 — the private per-presentation resource plan. It exists so the
+// composition root can bridge demand across a swap; it is read off the actual
+// component trees, not invented per skin.
+describe('presentation resource plan', () => {
+  const everySkin = ['desktop-v2', 'lcd-cockpit', 'lcd-scope', 'mobile', 'sdr-test'] as const;
+
+  it.each([
+    ['desktop-v2', ['audio-fft', 'hardware-scope']],
+    ['sdr-test', ['audio-fft', 'hardware-scope']],
+    ['lcd-cockpit', ['audio-fft']],
+    ['lcd-scope', ['audio-fft']],
+    // The mobile layout mounts SpectrumPanel but no audio-FFT surface.
+    ['mobile', ['hardware-scope']],
+  ] as const)('names the resources the %s tree can demand', (skinId: SkinId, resources) => {
+    expect([...presentationResourcePlan(skinId)].sort()).toEqual([...resources]);
+  });
+
+  // MUTATION KILLED: adding `rx-audio` to any plan. Its lease belongs to the
+  // runtime (`setRxLive`), not to a presentation subtree — bridging it would
+  // hand a second owner to a resource that already survives a swap.
+  it('never claims rx-audio for a presentation', () => {
+    for (const skinId of everySkin) {
+      expect(presentationResourcePlan(skinId)).not.toContain('rx-audio');
+    }
   });
 });

--- a/frontend/src/skins/registry.ts
+++ b/frontend/src/skins/registry.ts
@@ -9,6 +9,7 @@
 
 import type { Component } from 'svelte';
 import type { Capabilities } from '$lib/types/capabilities';
+import type { AppResource } from '$lib/runtime/resource-demand';
 import {
   normalizeLayoutMode,
   type LayoutMode,
@@ -82,4 +83,37 @@ export function resolvePersistedSkinId(id: PersistedSkinId): SkinId {
 
 export async function loadSkin(id: SkinId): Promise<Component> {
   return (await SKIN_LOADERS[id]()).default;
+}
+
+/**
+ * Which App-session resources a presentation's subtree can demand (MOR-1060).
+ *
+ * This is a private composition-root detail, NOT a public workspace or
+ * design-language API: it exists so `App.svelte` can hold demand across a
+ * presentation swap and stop the outgoing subtree's release from bouncing a
+ * stream the incoming subtree is about to ask for again.
+ *
+ * Read off the actual component trees:
+ * - `hardware-scope` — `SpectrumPanel`, mounted by the desktop/sdr-test and
+ *   mobile layouts; the LCD layouts have none.
+ * - `audio-fft` — `AudioSpectrumPanel` (right sidebar, desktop/sdr-test/LCD)
+ *   and `AmberCockpit` / `AmberScope` (LCD); the mobile layout has none.
+ *
+ * `rx-audio` is deliberately absent: its lease is held by the runtime
+ * (`setRxLive`), not by a presentation subtree, so it already survives a swap.
+ *
+ * Membership here only permits bridging — `App.svelte` bridges a resource
+ * solely while it is already demanded, so a presentation choice can never
+ * manufacture a live service (v3 ADR invariant 12).
+ */
+const SKIN_RESOURCE_PLAN: Record<SkinId, readonly AppResource[]> = {
+  'desktop-v2': ['hardware-scope', 'audio-fft'],
+  'lcd-cockpit': ['audio-fft'],
+  'lcd-scope': ['audio-fft'],
+  'mobile': ['hardware-scope'],
+  'sdr-test': ['hardware-scope', 'audio-fft'],
+};
+
+export function presentationResourcePlan(id: SkinId): readonly AppResource[] {
+  return SKIN_RESOURCE_PLAN[id] ?? [];
 }


### PR DESCRIPTION
## Summary

Activate lazy presentation loading with stale-resolution cancellation (`App.svelte` + the skin registry's previously-dead `loadSkin()`; static `RadioLayoutV2` import removed):

- Every presentation request takes a fresh **loader generation**; only the newest resolution commits — a stale resolution never mounts, never writes state, never touches resources, even in the A→B→A shape where the stale resolution's skin id equals the final target (generation compared, never skin id — pinned by test).
- The committed presentation stays mounted while the next resolves; resolution failure keeps last-known-good rendered and surfaces the established error path; unmount during an in-flight resolution is inert (MOR-1168 doctrine).
- **Handle discipline** (the ResourceDemand identity traps): a per-skin private resource plan drives the swap bridge — leases acquired before commit, released in a `finally` after the commit flush; each acquire yields its own frozen lease (never reused/cached); only `demand > 0` resources are bridged. Measured swap ordering: bridge-acquire → old-release → new-acquire → bridge-release, min demand 1 (no torn window, no reconnect).
- Entry bundle 609 → 233 kB.

+143 net production LOC across 3 code files + 3 locale keys. Four existing suites had registry mocks extended and awaits added for the now-async swap — no assertion weakened (MOR-1059 swap-survival assertions byte-identical; `RadioLayout.test.ts` strengthened to the real `loadSkin`).

## Independent verification

- All five adversarial race questions closed with file:line evidence: stale-A-commit impossible (generation gate, probed with 3 pending [A,B,A] → `mountedCount()===0`); same-skin re-request cannot double-mount/double-acquire (same component ref, same DOM node, zero lease events); failure-mid-swap releases exactly the acquired set with last-known-good retained; unmount inert; no torn window against the real host.
- Existing-suite edits adjudicated hunk-by-hunk: no assertion weakened.
- The simplified identity guard's unreachability argument verified (`cleanupInFlight` latches the synchronous prefix; two cleanup closures cannot coexist).
- Identity pinned against real singletons: `connect`/`sendRaw`/`fetchCapabilities` ×1 each across A→B→A; `startRx` never.
- Mutations: 16 run, 14 killed + the reviewer's M3 (commit gate by skin id instead of generation) pinned post-review with a dedicated test (kill proof: 5 failed incl. the new test under M3; production byte-identical, sha256-verified); M12/M13 adjudicated equivalent mutants and the test comment corrected to say so honestly.
- Suites: 2637 passed / 2 known pre-existing flakes (green in isolation, MOR-1230); lint/lint:boundaries/check/i18n:check/ruff clean.
- Pre-existing issues routed to tickets: MOR-1242 (double resolver fetch on first paint, now visible), MOR-1122 (resource-host session reset on remount — not production-reachable).

Linear: MOR-1060 (unblocks MOR-1086 identity proofs and the MOR-1092/1093/1094 entrypoint migrations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
