### PR TITLE
feat(MOR-1064): semantic RX/TX status/action surface on App TX authority

### DIFF
--- a/frontend/src/semantic/RxTxSurface.svelte
+++ b/frontend/src/semantic/RxTxSurface.svelte
@@ -1,0 +1,100 @@
+<!--
+  Semantic RX/TX status and action surface (MOR-1064).
+
+  Presentation only. It receives the MOR-1062 `RadioViewModel` and a snapshot
+  of the App-owned TX authority as props, and emits TX intents as callbacks.
+  It holds no TX state, keys nothing, and consults no controller — v3 ADR
+  invariant 11. The authoritative global TX lamp stays in `AppGlobalHost`
+  (MOR-1059); this surface is polite status, not a second alert.
+
+  Colour is not a state channel here: every RF state carries distinct text and
+  a distinct shape so it survives forced-colors (MOR-977). A design language
+  may restyle any of this; it may not change which facts appear.
+-->
+<script lang="ts">
+  import type { RadioViewModel } from './radio-view-model';
+  import {
+    BLOCKED_LABEL, RF_LABEL, RF_MARK, SESSION_LABEL, keyBlockedReasons, nextSurfaceId,
+    rfState, txDisabledReasons, txOrigin, txSessionState, type TxAuthoritySnapshot,
+  } from './rx-tx-surface';
+
+  interface Props {
+    view: RadioViewModel;
+    tx: TxAuthoritySnapshot;
+    onRequestKey?: () => void;
+    onRequestUnkey?: () => void;
+  }
+  let { view, tx, onRequestKey, onRequestUnkey }: Props = $props();
+
+  const blockedId = nextSurfaceId();
+  let rf = $derived(rfState(tx));
+  let session = $derived(txSessionState(tx));
+  let blocked = $derived(keyBlockedReasons(view, tx));
+  let viewBlocked = $derived(txDisabledReasons(view));
+  let pressed = $derived(tx.mayOwnKey || (tx.phase !== 'idle' && tx.phase !== 'failed'));
+  let known = $derived(view.txTarget.status === 'known');
+  let receiver = $derived(view.txTarget.status === 'known' ? view.txTarget.receiver : undefined);
+  let slot = $derived(view.txTarget.status === 'known'
+    ? (view.txTarget.slot.kind === 'slotted' ? view.txTarget.slot.id : view.txTarget.slot.kind)
+    : undefined);
+  let frequencyHz = $derived(view.txTarget.status === 'known' ? view.txTarget.frequencyHz : null);
+  let reason = $derived(view.txTarget.status === 'unknown' ? view.txTarget.reason : undefined);
+</script>
+
+<section class="rx-tx-surface" data-testid="rx-tx-surface" aria-label="Transmitter status and control">
+  <p
+    class="rx-tx-state" role="status" data-testid="rx-tx-state"
+    data-rf={rf} data-session={session} data-origin={txOrigin(tx)} data-intent={tx.intent ?? undefined}
+  >
+    <span class="rx-tx-mark" data-testid="rx-tx-rf-mark" aria-hidden="true">{RF_MARK[rf]}</span>
+    <span class="rx-tx-label" data-testid="rx-tx-rf-label">{RF_LABEL[rf]}</span>
+    <span class="rx-tx-session">{SESSION_LABEL[session]}</span>
+    {#if tx.intent}<span class="rx-tx-intent">· {tx.intent}</span>{/if}
+    <span class="rx-tx-origin">· {txOrigin(tx)}</span>
+  </p>
+
+  {#if tx.fault}
+    <p class="rx-tx-fault" data-testid="rx-tx-fault" data-fault={tx.fault}>TX fault: {tx.fault}</p>
+  {/if}
+
+  {#if known}
+    <p data-testid="rx-tx-target" data-target="known" data-receiver={receiver} data-slot={slot}>
+      TX target: {receiver} {slot} · {frequencyHz ?? '—'} Hz
+    </p>
+  {:else}
+    <p data-testid="rx-tx-target" data-target="unknown" data-reason={reason}>
+      TX target unknown ({reason})
+    </p>
+  {/if}
+
+  <div class="rx-tx-actions">
+    <button
+      type="button" class="rx-tx-key" data-testid="rx-tx-key"
+      disabled={blocked.length > 0} aria-pressed={pressed} aria-describedby={blockedId}
+      onclick={() => onRequestKey?.()}
+    >Key transmitter</button>
+    <!-- Never gated: no `disabled`, no `{#if}`, no guard in the handler. -->
+    <button
+      type="button" class="rx-tx-unkey" data-testid="rx-tx-unkey"
+      onclick={() => onRequestUnkey?.()}
+    >Unkey transmitter</button>
+  </div>
+
+  <ul class="rx-tx-blocked" id={blockedId} data-testid="rx-tx-blocked">
+    {#each blocked as code (code)}<li data-reason={code}>{BLOCKED_LABEL[code]}</li>{/each}
+    {#each viewBlocked as item (item.field + item.code)}
+      <li data-reason={item.code} data-field={item.field}>{item.field}: {item.code}</li>
+    {/each}
+  </ul>
+</section>
+
+<style>
+  /* Structure only — a design language owns colour and must never become the sole state channel. */
+  .rx-tx-surface { display: flex; flex-direction: column; gap: 0.25rem; }
+  .rx-tx-state { display: flex; align-items: baseline; gap: 0.4ch; margin: 0; }
+  .rx-tx-label { font-weight: 700; letter-spacing: 0.08em; }
+  .rx-tx-fault { margin: 0; font-weight: 700; }
+  .rx-tx-actions { display: flex; gap: 0.5rem; }
+  .rx-tx-blocked { margin: 0; padding-inline-start: 1.2em; }
+  .rx-tx-blocked:empty { display: none; }
+</style>

--- a/frontend/src/semantic/__tests__/rx-tx-authority-parity.test.ts
+++ b/frontend/src/semantic/__tests__/rx-tx-authority-parity.test.ts
@@ -1,0 +1,148 @@
+/**
+ * MOR-1064 — parity between the semantic RX/TX surface and the real App TX
+ * authority.
+ *
+ * The component tests exercise hand-written snapshots; this file proves those
+ * snapshots are not fiction. Every state below is produced by the ACTUAL TX
+ * reducer (`lib/runtime/tx-controller/model`), so the surface's vocabulary is
+ * pinned to states the authority can really reach — not to a convenient
+ * subset. Production code never imports the reducer (ADR invariant 11, and
+ * the semantic eslint zone forbids the app-host); only this test does.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  initialTxState, transition,
+  type Eligibility, type PttMarker, type PttObservation, type TxFault, type TxState,
+} from '$lib/runtime/tx-controller/model';
+import {
+  keyBlockedReasons, rfState, txOrigin, txSessionState,
+  type TxAuthoritySnapshot,
+} from '../rx-tx-surface';
+import { topologyFixtures } from '../fixtures/topologies';
+
+const marker = (seq: number, authorityEpoch = 1): PttMarker => ({
+  authorityEpoch, pttObservationSeq: seq, pttLastObservedMonotonic: seq,
+});
+const target = { receiver: 'MAIN', slot: 'A', frequencyHz: 14_195_000 } as const;
+const eligible: Eligibility = {
+  catPtt: true, browserTxAudio: true, controlLive: true, permit: 'allowed', target,
+};
+const ptt = (value: boolean, seq: number): PttObservation => ({
+  value, observed: true, fresh: true, source: 'radio-readback', marker: marker(seq),
+});
+const authority = (state: TxState, value: boolean, seq: number): TxState =>
+  transition(state, { type: 'authority', epoch: 1, ptt: ptt(value, seq), eligibility: eligible, offCommandId: 'off' }).state;
+
+const fresh = () => initialTxState(1, marker(1));
+const started = (): TxState => transition(fresh(), {
+  type: 'start', sourceId: 'semantic', leaseId: 'lease', intent: 'momentary', eligibility: eligible, ptt: ptt(false, 2),
+}).state;
+const dispatched = (): TxState => {
+  const begun = started();
+  return transition(begun, { type: 'audio-ready', guard: begun.guard!, commandId: 'on' }).state;
+};
+const confirmPending = (): TxState => {
+  const on = dispatched();
+  return transition(on, { type: 'on-sent', guard: on.guard!, commandId: 'on', barrier: marker(2) }).state;
+};
+const keyed = (): TxState => authority(confirmPending(), true, 3);
+const releasing = (): TxState => {
+  const live = keyed();
+  return transition(live, { type: 'release', guard: live.guard!, commandId: 'off' }).state;
+};
+const notEligible = (): TxState => transition(fresh(), {
+  type: 'start', sourceId: 'semantic', leaseId: 'lease', intent: 'momentary',
+  eligibility: { ...eligible, permit: 'denied' }, ptt: ptt(false, 2),
+}).state;
+const externalTx = (): TxState => authority(fresh(), true, 5);
+const observedRx = (): TxState => authority(fresh(), false, 5);
+
+/**
+ * Structural parity, checked by the compiler (`npm run check` type-checks
+ * tests): if the reducer ever renames a field the surface reads, or widens a
+ * union member the surface switches on, this assignment stops compiling.
+ * Kill-mutation: rename `txRisk` to `risk` in `TxAuthoritySnapshot` — the
+ * surface would silently read `undefined` and render RX forever.
+ */
+const asSnapshot = (state: TxState): TxAuthoritySnapshot => state;
+
+const REAL_STATES: readonly (readonly [string, () => TxState])[] = [
+  ['fresh (no PTT observed yet)', fresh],
+  ['observed RX', observedRx],
+  ['audio start pending', started],
+  ['ON dispatched, unconfirmed', dispatched],
+  ['key confirmation pending', confirmPending],
+  ['keyed', keyed],
+  ['releasing', releasing],
+  ['not eligible', notEligible],
+  ['external TX', externalTx],
+];
+
+describe('surface vocabulary against real reducer states', () => {
+  it.each(REAL_STATES)('%s is a structurally complete authority snapshot', (_name, build) => {
+    const snapshot = asSnapshot(build());
+    for (const key of ['phase', 'intent', 'radioTx', 'txRisk', 'mayOwnKey', 'fault'] as const) {
+      expect(snapshot).toHaveProperty(key);
+    }
+  });
+
+  it.each([
+    ['fresh (no PTT observed yet)', fresh, 'unknown', 'idle'],
+    ['observed RX', observedRx, 'receiving', 'idle'],
+    ['audio start pending', started, 'receiving', 'pending'],
+    ['ON dispatched, unconfirmed', dispatched, 'uncertain', 'pending'],
+    ['key confirmation pending', confirmPending, 'uncertain', 'pending'],
+    ['keyed', keyed, 'transmitting', 'keyed'],
+    ['releasing', releasing, 'transmitting', 'releasing'],
+    // A rejected start never observed the radio, so its RF state stays unknown
+    // rather than collapsing to RX — the fail-closed direction.
+    ['not eligible', notEligible, 'unknown', 'failed'],
+    ['external TX', externalTx, 'transmitting', 'idle'],
+  ] as const)('%s reads as rf=%s session=%s', (_name, build, rf, session) => {
+    const state = asSnapshot(build());
+    expect(rfState(state)).toBe(rf);
+    expect(txSessionState(state)).toBe(session);
+  });
+
+  it('never reads RX while the authority says the browser may own the key', () => {
+    // The reducer guarantees mayOwnKey => txRisk in {uncertain, confirmed-on}.
+    // This is the single most important safety property of the surface:
+    // kill-mutation — reorder `rfState` so the radioTx check wins over txRisk,
+    // and every unconfirmed key-down (radioTx still 'off') renders as RX.
+    const owning = REAL_STATES.map(([, build]) => build()).filter((s) => s.mayOwnKey);
+    expect(owning.length).toBeGreaterThan(0);
+    for (const state of owning) {
+      expect(state.txRisk === 'uncertain' || state.txRisk === 'confirmed-on').toBe(true);
+      expect(rfState(asSnapshot(state))).not.toBe('receiving');
+      expect(txOrigin(asSnapshot(state))).toBe('local');
+    }
+  });
+
+  it('blocks keying in every non-idle real state, even on a fully permitted view model', () => {
+    const permitted = topologyFixtures['1/single'];
+    expect(keyBlockedReasons(permitted, asSnapshot(observedRx()))).toEqual([]);
+    for (const [name, build] of REAL_STATES) {
+      if (name === 'observed RX') continue;
+      expect(keyBlockedReasons(permitted, asSnapshot(build())).length).toBeGreaterThan(0);
+    }
+  });
+
+  it('classifies every fault the reducer can raise as a fault, none as idle', () => {
+    // Enumerated against the reducer's own union: the `satisfies` clause fails
+    // to compile if `TxFault` gains a member this list does not cover.
+    const faults = [
+      'not-eligible', 'audio-failed', 'audio-timeout', 'ptt-on-rejected',
+      'on-command-failed', 'on-timeout', 'release-not-confirmed', 'backend-dekeyed',
+    ] as const satisfies readonly Exclude<TxFault, null>[];
+    type MissingFault = Exclude<Exclude<TxFault, null>, (typeof faults)[number]>;
+    const everyFaultCovered: [MissingFault] extends [never] ? true : false = true;
+    expect(everyFaultCovered).toBe(true);
+    for (const fault of faults) {
+      const state: TxAuthoritySnapshot = {
+        phase: 'failed', intent: null, radioTx: 'off', txRisk: 'none', mayOwnKey: false, fault,
+      };
+      expect(txSessionState(state)).toBe('failed');
+      expect(keyBlockedReasons(topologyFixtures['1/single'], state)).toContain('tx-fault');
+    }
+  });
+});

--- a/frontend/src/semantic/__tests__/rx-tx-surface.component.test.ts
+++ b/frontend/src/semantic/__tests__/rx-tx-surface.component.test.ts
@@ -1,0 +1,428 @@
+/**
+ * MOR-1064 — the semantic RX/TX status and action surface.
+ *
+ * SAFETY-CRITICAL. Every test below names the mutation it kills, because a
+ * surface that merely "looks right" is worthless here: the failure modes are
+ * (a) showing RX while the browser may own the key, (b) offering a key action
+ * the authority would refuse, and (c) gating the *unkey* path.
+ *
+ * ADR invariant 11: TX authority lives in the App-owned TX controller. This
+ * surface is NOT a second authority — it renders the authority snapshot and
+ * emits intents. It never derives TX truth from the radio view model, and it
+ * never keys anything itself. See `AppGlobalHost.svelte` (MOR-1059) for the
+ * authoritative global lamp, which this surface must not duplicate.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import RxTxSurface from '../RxTxSurface.svelte';
+import { topologyFixtures, withAudioOnlyScope, type TopologyFixtureId } from '../fixtures/topologies';
+import type { RadioViewModel } from '../radio-view-model';
+import type { TxAuthoritySnapshot } from '../rx-tx-surface';
+
+const IDS: readonly TopologyFixtureId[] = ['1/single', '1/ab', '2/ab_shared', '2/main_sub'];
+/** The only fixture whose permit is 'allowed' AND whose txTarget is known. */
+const PERMITTED: TopologyFixtureId[] = ['1/single', '2/main_sub'];
+
+const IDLE_RX: TxAuthoritySnapshot = {
+  phase: 'idle', intent: null, radioTx: 'off', txRisk: 'none', mayOwnKey: false, fault: null,
+};
+const snap = (over: Partial<TxAuthoritySnapshot> = {}): TxAuthoritySnapshot => ({ ...IDLE_RX, ...over });
+
+let target: HTMLDivElement;
+beforeEach(() => { target = document.createElement('div'); document.body.appendChild(target); });
+afterEach(() => { target.remove(); });
+
+type Handlers = { onRequestKey?: () => void; onRequestUnkey?: () => void };
+function render(view: RadioViewModel, tx: TxAuthoritySnapshot, handlers: Handlers = {}) {
+  const component = mount(RxTxSurface, { target, props: { view, tx, ...handlers } });
+  flushSync();
+  const q = (sel: string) => target.querySelector(sel);
+  return {
+    dispose: () => unmount(component),
+    state: () => q('[data-testid="rx-tx-state"]') as HTMLElement,
+    key: () => q('[data-testid="rx-tx-key"]') as HTMLButtonElement,
+    unkey: () => q('[data-testid="rx-tx-unkey"]') as HTMLButtonElement,
+    reasons: () => [...target.querySelectorAll('[data-testid="rx-tx-blocked"] [data-reason]')]
+      .map((el) => el.getAttribute('data-reason')),
+    root: () => q('[data-testid="rx-tx-surface"]') as HTMLElement,
+  };
+}
+function withSurface(
+  view: RadioViewModel, tx: TxAuthoritySnapshot,
+  fn: (s: ReturnType<typeof render>) => void, handlers: Handlers = {},
+): void {
+  const s = render(view, tx, handlers);
+  try { fn(s); } finally { s.dispose(); }
+}
+
+// ── 1. TX state display mirrors the AUTHORITY snapshot, and only it ─────────
+
+describe('RX/TX status mirrors the App TX authority snapshot', () => {
+  it.each(IDS)('%s: an idle authority with an observed OFF radio reads RX', (id) => {
+    withSurface(topologyFixtures[id], IDLE_RX, (s) => {
+      expect(s.state().dataset.rf).toBe('receiving');
+      expect(s.state().textContent).toContain('RX');
+    });
+  });
+
+  it.each(IDS)('%s: txRisk "uncertain" NEVER renders as RX-idle (fail closed)', (id) => {
+    // Kill-mutation: `if (txRisk === 'uncertain') return 'uncertain'` -> deleted,
+    // so an unconfirmed key-down falls through to 'receiving'. radioTx is still
+    // 'off' here (no readback yet) — exactly the state that tempts a naive
+    // implementation into showing RX while the key may be down.
+    withSurface(topologyFixtures[id], snap({ txRisk: 'uncertain', mayOwnKey: true, phase: 'key-confirm-pending' }), (s) => {
+      expect(s.state().dataset.rf).toBe('uncertain');
+      expect(s.state().dataset.rf).not.toBe('receiving');
+      expect(s.state().textContent).not.toContain('RX');
+    });
+  });
+
+  it.each(IDS)('%s: confirmed-on and radioTx=on both read TX', (id) => {
+    for (const over of [{ txRisk: 'confirmed-on' as const }, { radioTx: 'on' as const }]) {
+      withSurface(topologyFixtures[id], snap(over), (s) => {
+        expect(s.state().dataset.rf).toBe('transmitting');
+        expect(s.state().textContent).toContain('TX');
+      });
+    }
+  });
+
+  it.each(IDS)('%s: an unknown radioTx (control loss / not yet observed) is never RX', (id) => {
+    // Kill-mutation: `return 'receiving'` as the unconditional fallback.
+    // Connection loss rebases the authority epoch and resets radioTx to
+    // 'unknown'; claiming RX there is a lie about the RF state.
+    withSurface(topologyFixtures[id], snap({ radioTx: 'unknown' }), (s) => {
+      expect(s.state().dataset.rf).toBe('unknown');
+      expect(s.state().textContent).not.toContain('RX');
+    });
+  });
+
+  it('is a pure function of the authority: same snapshot + different view models render the same RF state', () => {
+    // Kill-mutation: rewire the display to `view.txTarget`/`view.txPermit`.
+    // These four view models disagree on target/permit/topology; the RF state
+    // must not move, because none of that is RF truth.
+    const rendered = IDS.map((id) => {
+      let rf = '';
+      withSurface(topologyFixtures[id], snap({ radioTx: 'on' }), (s) => { rf = s.state().dataset.rf ?? ''; });
+      return rf;
+    });
+    expect(new Set(rendered)).toEqual(new Set(['transmitting']));
+  });
+
+  it('is a pure function of the authority: same view model + different snapshots render different RF states', () => {
+    // The non-vacuity half of the test above: proves the display is wired to
+    // *something* that moves, not hard-coded.
+    const view = topologyFixtures['1/single'];
+    const seen = ([IDLE_RX, snap({ radioTx: 'on' }), snap({ txRisk: 'uncertain' }), snap({ radioTx: 'unknown' })]).map((tx) => {
+      let rf = '';
+      withSurface(view, tx, (s) => { rf = s.state().dataset.rf ?? ''; });
+      return rf;
+    });
+    expect(seen).toEqual(['receiving', 'transmitting', 'uncertain', 'unknown']);
+  });
+
+  it.each([
+    ['audio-start-pending', 'pending'], ['key-confirm-pending', 'pending'],
+    ['active', 'keyed'], ['releasing', 'releasing'], ['failed', 'failed'], ['idle', 'idle'],
+  ] as const)('session phase %s renders as %s', (phase, session) => {
+    withSurface(topologyFixtures['1/single'], snap({ phase }), (s) => {
+      expect(s.state().dataset.session).toBe(session);
+    });
+  });
+
+  it('an unrecognised phase falls back to "pending", never to "idle"', () => {
+    // Kill-mutation: `?? 'idle'` as the lookup fallback. A phase this surface
+    // has not been taught about must read as "something is happening", not as
+    // "nothing is happening".
+    const bogus = { ...IDLE_RX, phase: 'brand-new-phase' as TxAuthoritySnapshot['phase'] };
+    withSurface(topologyFixtures['1/single'], bogus, (s) => {
+      expect(s.state().dataset.session).toBe('pending');
+      expect(s.state().dataset.session).not.toBe('idle');
+    });
+  });
+
+  it.each(['momentary', 'latched'] as const)('surfaces a %s (held/latched) intent', (intent) => {
+    withSurface(topologyFixtures['1/single'], snap({ phase: 'active', intent, mayOwnKey: true, radioTx: 'on' }), (s) => {
+      expect(s.state().dataset.intent).toBe(intent);
+      expect(s.state().textContent?.toLowerCase()).toContain(intent);
+    });
+  });
+
+  it('distinguishes external TX from locally-owned TX', () => {
+    withSurface(topologyFixtures['1/single'], snap({ radioTx: 'on' }), (s) => {
+      expect(s.state().dataset.origin).toBe('external');
+    });
+    withSurface(topologyFixtures['1/single'], snap({ radioTx: 'on', mayOwnKey: true, phase: 'active' }), (s) => {
+      expect(s.state().dataset.origin).toBe('local');
+    });
+  });
+
+  it('never labels TX "external" while the browser may own the key', () => {
+    // Kill-mutation: `origin = mayOwnKey ? 'local' : 'external'` narrowed to
+    // `phase === 'idle' ? 'external' : 'local'` (or vice versa). Telling the
+    // operator "not you" while a lease is live is the dangerous direction.
+    for (const tx of [
+      snap({ mayOwnKey: true, txRisk: 'uncertain' }),
+      snap({ phase: 'releasing', mayOwnKey: true, txRisk: 'confirmed-on', radioTx: 'on' }),
+      snap({ phase: 'audio-start-pending' }),
+      snap({ phase: 'failed', fault: 'on-timeout' }),
+    ]) {
+      withSurface(topologyFixtures['1/single'], tx, (s) => {
+        expect(s.state().dataset.origin).toBe('local');
+      });
+    }
+  });
+});
+
+// ── 4. No duplicate authority: this surface displays, it does not indicate ──
+
+describe('fault display without a second authority', () => {
+  it('displays the authority fault verbatim', () => {
+    withSurface(topologyFixtures['1/single'], snap({ phase: 'failed', fault: 'release-not-confirmed' }), (s) => {
+      const fault = target.querySelector('[data-testid="rx-tx-fault"]') as HTMLElement;
+      expect(fault).not.toBeNull();
+      expect(fault.dataset.fault).toBe('release-not-confirmed');
+      expect(fault.textContent).toContain('release-not-confirmed');
+    });
+  });
+
+  it('shows no fault region when the authority reports none', () => {
+    withSurface(topologyFixtures['1/single'], IDLE_RX, () => {
+      expect(target.querySelector('[data-testid="rx-tx-fault"]')).toBeNull();
+    });
+  });
+
+  it('does not claim the assertive/alert channel owned by the global TX lamp (MOR-1059)', () => {
+    // Kill-mutation: copy AppGlobalHost's `aria-live="assertive"` / `role="alert"`
+    // onto this surface. Two assertive announcers for one fact double-speak over
+    // each other and make the authoritative lamp ambiguous. This surface is
+    // polite status; the App-root lamp stays the alert.
+    withSurface(topologyFixtures['1/single'], snap({ radioTx: 'on', phase: 'failed', fault: 'backend-dekeyed' }), (s) => {
+      const root = s.root();
+      expect(root.querySelector('[aria-live="assertive"]')).toBeNull();
+      expect(root.querySelector('[role="alert"]')).toBeNull();
+      expect(root.querySelector('[role="status"]')).not.toBeNull();
+    });
+  });
+});
+
+// ── 2. TX action intents ────────────────────────────────────────────────────
+
+describe('key intent gating', () => {
+  it.each(PERMITTED)('%s: emits exactly one key intent when permit is allowed and the authority is idle/RX', (id) => {
+    const onRequestKey = vi.fn();
+    withSurface(topologyFixtures[id], IDLE_RX, (s) => {
+      expect(s.key().disabled).toBe(false);
+      s.key().click();
+      flushSync();
+      expect(onRequestKey).toHaveBeenCalledTimes(1);
+    }, { onRequestKey });
+  });
+
+  it.each([
+    ['1/ab', 'tx-permit-unknown'],
+    ['2/ab_shared', 'tx-permit-denied'],
+  ] as const)('%s: a non-allowed permit disables keying and names the reason (%s)', (id, reason) => {
+    // Kill-mutation: `permit.status !== 'denied'` as the gate (treats the
+    // tri-state 'unknown' as permission). The contract validator already
+    // rejects permit='allowed' + unknown target; the surface must independently
+    // treat 'unknown' as NOT allowed.
+    const onRequestKey = vi.fn();
+    withSurface(topologyFixtures[id], IDLE_RX, (s) => {
+      expect(s.key().disabled).toBe(true);
+      expect(s.reasons()).toContain(reason);
+      s.key().click();
+      flushSync();
+      expect(onRequestKey).not.toHaveBeenCalled();
+    }, { onRequestKey });
+  });
+
+  it.each(IDS)('%s: audio-only scope does not change the key gate (scope is not a TX fact)', (id) => {
+    const base = topologyFixtures[id];
+    let plain = false;
+    let audioOnly = false;
+    withSurface(base, IDLE_RX, (s) => { plain = s.key().disabled; });
+    withSurface(withAudioOnlyScope(base), IDLE_RX, (s) => { audioOnly = s.key().disabled; });
+    expect(audioOnly).toBe(plain);
+  });
+
+  it.each([
+    ['external TX in progress', snap({ radioTx: 'on' }), 'radio-transmitting'],
+    ['RF state unknown', snap({ radioTx: 'unknown' }), 'rf-state-unknown'],
+    ['a lease already pending', snap({ phase: 'audio-start-pending' }), 'tx-busy'],
+    ['a key already owned', snap({ phase: 'active', mayOwnKey: true, txRisk: 'confirmed-on', radioTx: 'on' }), 'tx-busy'],
+    ['a release in flight', snap({ phase: 'releasing', mayOwnKey: true, txRisk: 'uncertain' }), 'tx-busy'],
+    ['an unresolved fault', snap({ phase: 'failed', fault: 'not-eligible' }), 'tx-fault'],
+  ] as const)('%s: the authority forbids keying even with an allowed permit', (_name, tx, reason) => {
+    // Kill-mutation: gate on `view.txPermit` alone. The permit says the
+    // FREQUENCY is legal; only the authority knows whether the transmitter is
+    // free. Both must agree before a key intent may leave this surface.
+    const onRequestKey = vi.fn();
+    withSurface(topologyFixtures['1/single'], tx, (s) => {
+      expect(s.key().disabled).toBe(true);
+      expect(s.reasons()).toContain(reason);
+      s.key().click();
+      flushSync();
+      expect(onRequestKey).not.toHaveBeenCalled();
+    }, { onRequestKey });
+  });
+
+  it('surfaces the view model disabled reasons that concern TX', () => {
+    withSurface(topologyFixtures['1/ab'], IDLE_RX, (s) => {
+      expect(s.reasons()).toContain('field-not-observed');
+    });
+    // ...and does not import unrelated scope reasons into the TX gate.
+    withSurface(topologyFixtures['2/main_sub'], IDLE_RX, (s) => {
+      expect(s.reasons()).not.toContain('capability-unavailable');
+    });
+  });
+});
+
+describe('unkey intent is never gated (fail-safe direction)', () => {
+  const EVERY_STATE: TxAuthoritySnapshot[] = [
+    IDLE_RX,
+    snap({ radioTx: 'unknown' }),
+    snap({ radioTx: 'on' }),
+    snap({ phase: 'audio-start-pending' }),
+    snap({ phase: 'key-confirm-pending', mayOwnKey: true, txRisk: 'uncertain' }),
+    snap({ phase: 'active', mayOwnKey: true, txRisk: 'confirmed-on', radioTx: 'on', intent: 'latched' }),
+    snap({ phase: 'releasing', mayOwnKey: true, txRisk: 'confirmed-on' }),
+    snap({ phase: 'failed', fault: 'on-command-failed' }),
+  ];
+
+  it('stays enabled and emits for every topology × every authority state', () => {
+    // Kill-mutation: add ANY condition to the unkey path — `disabled={...}`,
+    // `{#if}` around the button, or an early return in the handler. Stopping
+    // transmission must never require the surface to agree that TX is happening;
+    // the whole point of the uncertain/unknown states is that it may not know.
+    for (const id of IDS) {
+      for (const tx of EVERY_STATE) {
+        const onRequestUnkey = vi.fn();
+        withSurface(topologyFixtures[id], tx, (s) => {
+          expect(s.unkey()).not.toBeNull();
+          expect(s.unkey().disabled).toBe(false);
+          expect(s.unkey().hasAttribute('aria-disabled')).toBe(false);
+          s.unkey().click();
+          flushSync();
+          expect(onRequestUnkey).toHaveBeenCalledTimes(1);
+        }, { onRequestUnkey });
+      }
+    }
+  });
+
+  it('emits unkey even when a denied permit blocks keying', () => {
+    const onRequestKey = vi.fn();
+    const onRequestUnkey = vi.fn();
+    withSurface(topologyFixtures['2/ab_shared'], snap({ phase: 'active', mayOwnKey: true, radioTx: 'on' }), (s) => {
+      expect(s.key().disabled).toBe(true);
+      s.unkey().click();
+      flushSync();
+      expect(onRequestUnkey).toHaveBeenCalledTimes(1);
+      expect(onRequestKey).not.toHaveBeenCalled();
+    }, { onRequestKey, onRequestUnkey });
+  });
+});
+
+// ── 3. txTarget unknown ⇒ target-unknown state, never a guess ───────────────
+
+describe('unknown TX target', () => {
+  it('renders an explicit target-unknown state with its reason and disables keying', () => {
+    // Kill-mutation: fall back to the active VFO / vfos[0] as the target.
+    // MOR-988 §3.2: missing observation never synthesizes a target.
+    withSurface(topologyFixtures['1/ab'], IDLE_RX, (s) => {
+      const t = target.querySelector('[data-testid="rx-tx-target"]') as HTMLElement;
+      expect(t.dataset.target).toBe('unknown');
+      expect(t.dataset.reason).toBe('not-observed');
+      expect(s.key().disabled).toBe(true);
+      expect(s.reasons()).toContain('tx-target-unknown');
+    });
+  });
+
+  it('does not name any receiver, slot or frequency when the target is unknown', () => {
+    const view = topologyFixtures['1/ab'];
+    withSurface(view, IDLE_RX, () => {
+      const t = target.querySelector('[data-testid="rx-tx-target"]') as HTMLElement;
+      const text = t.textContent ?? '';
+      for (const vfo of view.vfos) {
+        expect(text).not.toContain(String(vfo.frequencyHz));
+        expect(text).not.toContain(vfo.label);
+      }
+      expect(t.dataset.receiver).toBeUndefined();
+    });
+  });
+
+  it.each(PERMITTED)('%s: names the known target exactly as the view model reports it', (id) => {
+    const view = topologyFixtures[id];
+    const known = view.txTarget;
+    if (known.status !== 'known') throw new Error('fixture precondition');
+    withSurface(view, IDLE_RX, () => {
+      const t = target.querySelector('[data-testid="rx-tx-target"]') as HTMLElement;
+      expect(t.dataset.target).toBe('known');
+      expect(t.dataset.receiver).toBe(known.receiver);
+      expect(t.dataset.slot).toBe(known.slot.kind === 'slotted' ? known.slot.id : known.slot.kind);
+    });
+  });
+});
+
+// ── 5. Accessibility ───────────────────────────────────────────────────────
+
+describe('accessibility', () => {
+  it('gives both actions unambiguous accessible names', () => {
+    withSurface(topologyFixtures['1/single'], IDLE_RX, (s) => {
+      expect((s.key().getAttribute('aria-label') ?? s.key().textContent ?? '').toLowerCase()).toContain('key');
+      const unkeyName = (s.unkey().getAttribute('aria-label') ?? s.unkey().textContent ?? '').toLowerCase();
+      expect(unkeyName).toContain('unkey');
+      // The two names must not be confusable by prefix alone.
+      expect(unkeyName).not.toBe((s.key().getAttribute('aria-label') ?? s.key().textContent ?? '').toLowerCase());
+    });
+  });
+
+  it('reports the key action pressed state from the authority', () => {
+    withSurface(topologyFixtures['1/single'], IDLE_RX, (s) => {
+      expect(s.key().getAttribute('aria-pressed')).toBe('false');
+    });
+    for (const tx of [
+      snap({ phase: 'key-confirm-pending', mayOwnKey: true, txRisk: 'uncertain' }),
+      snap({ phase: 'active', mayOwnKey: true, txRisk: 'confirmed-on', radioTx: 'on' }),
+      snap({ phase: 'releasing', mayOwnKey: true, txRisk: 'confirmed-on' }),
+    ]) {
+      withSurface(topologyFixtures['1/single'], tx, (s) => {
+        expect(s.key().getAttribute('aria-pressed')).toBe('true');
+      });
+    }
+  });
+
+  it('keeps the unkey action focusable in every state (it must never be reached only by mouse)', () => {
+    withSurface(topologyFixtures['1/single'], snap({ phase: 'active', mayOwnKey: true, radioTx: 'on' }), (s) => {
+      s.unkey().focus();
+      expect(document.activeElement).toBe(s.unkey());
+    });
+  });
+
+  it('encodes RX/TX structurally, not by colour or class alone (forced-colors survival, MOR-977)', () => {
+    // Kill-mutation: drop the text/shape and keep only `data-rf` + a CSS class.
+    // Under forced-colors the class-driven colour is overridden and the states
+    // become visually identical. Each state must carry distinct TEXT and a
+    // distinct SHAPE glyph.
+    const texts = new Map<string, string>();
+    const marks = new Map<string, string>();
+    for (const tx of [IDLE_RX, snap({ radioTx: 'on' }), snap({ txRisk: 'uncertain' }), snap({ radioTx: 'unknown' })]) {
+      withSurface(topologyFixtures['1/single'], tx, (s) => {
+        const rf = s.state().dataset.rf ?? '';
+        texts.set(rf, (s.state().querySelector('[data-testid="rx-tx-rf-label"]')?.textContent ?? '').trim());
+        marks.set(rf, (s.state().querySelector('[data-testid="rx-tx-rf-mark"]')?.textContent ?? '').trim());
+      });
+    }
+    expect(texts.size).toBe(4);
+    expect(new Set(texts.values()).size).toBe(4);
+    expect(new Set(marks.values()).size).toBe(4);
+    for (const value of [...texts.values(), ...marks.values()]) expect(value).not.toBe('');
+  });
+
+  it('associates the blocked reasons with the key action for screen readers', () => {
+    withSurface(topologyFixtures['1/ab'], IDLE_RX, (s) => {
+      const describedBy = s.key().getAttribute('aria-describedby');
+      expect(describedBy).toBeTruthy();
+      expect(target.querySelector(`#${describedBy}`)).not.toBeNull();
+    });
+  });
+});

--- a/frontend/src/semantic/rx-tx-surface.ts
+++ b/frontend/src/semantic/rx-tx-surface.ts
@@ -1,0 +1,99 @@
+/**
+ * MOR-1064 — the semantic RX/TX status and action vocabulary.
+ *
+ * Pure. It maps (a) the MOR-1062 `RadioViewModel` and (b) a snapshot of the
+ * App-owned TX authority onto the words the operator reads and the gate the key
+ * action obeys. It never computes TX truth, never keys anything, and never
+ * imports the TX controller: v3 ADR invariant 11 keeps TX authority in
+ * `lib/runtime/tx-controller` (App-root host, MOR-1059); this module renders
+ * that authority's conclusions rather than becoming a second one.
+ *
+ * Every mapping fails CLOSED: an unrecognised phase reads as "keying in
+ * progress", an unobserved RF state reads as "unknown" rather than RX, and any
+ * doubt blocks the key intent. Only the unkey intent is ungated — stopping
+ * transmission must never depend on this surface agreeing that it is happening.
+ */
+import type { DisabledReason, RadioViewModel } from './radio-view-model';
+
+/**
+ * The subset of the App TX controller's `TxState` this surface reads, with
+ * identical field names and union members so a real snapshot is assignable
+ * without adaptation (pinned against the real reducer in
+ * `__tests__/rx-tx-authority-parity.test.ts`). `fault` stays `string | null`
+ * deliberately: a fault code this surface has never heard of must still show.
+ */
+export interface TxAuthoritySnapshot {
+  phase: 'idle' | 'audio-start-pending' | 'key-confirm-pending' | 'active' | 'releasing' | 'failed';
+  intent: 'momentary' | 'latched' | null;
+  radioTx: 'off' | 'on' | 'unknown';
+  txRisk: 'none' | 'uncertain' | 'confirmed-on';
+  mayOwnKey: boolean;
+  fault: string | null;
+}
+
+export type RfState = 'receiving' | 'transmitting' | 'uncertain' | 'unknown';
+export type TxSessionState = 'idle' | 'pending' | 'keyed' | 'releasing' | 'failed';
+export type TxOrigin = 'local' | 'external';
+export type KeyBlockedReason =
+  | 'tx-target-unknown' | 'tx-permit-denied' | 'tx-permit-unknown'
+  | 'tx-fault' | 'tx-busy' | 'radio-transmitting' | 'rf-state-unknown';
+
+/** Text AND shape — never colour alone, so the state survives forced-colors (MOR-977). */
+export const RF_LABEL: Record<RfState, string> = { receiving: 'RX', transmitting: 'TX', uncertain: 'TX?', unknown: 'RF ?' };
+export const RF_MARK: Record<RfState, string> = { receiving: '▼', transmitting: '▲', uncertain: '△', unknown: '◇' };
+export const SESSION_LABEL: Record<TxSessionState, string> = { idle: 'ready', pending: 'keying', keyed: 'key down', releasing: 'releasing', failed: 'fault' };
+export const BLOCKED_LABEL: Record<KeyBlockedReason, string> = {
+  'tx-target-unknown': 'TX target not observed',
+  'tx-permit-denied': 'frequency outside the configured TX ranges',
+  'tx-permit-unknown': 'TX permit unknown',
+  'tx-fault': 'unresolved TX fault',
+  'tx-busy': 'a TX lease is already in progress',
+  'radio-transmitting': 'the radio is already transmitting',
+  'rf-state-unknown': 'RF state unknown',
+};
+
+const SESSION_BY_PHASE: Record<TxAuthoritySnapshot['phase'], TxSessionState> = {
+  idle: 'idle', 'audio-start-pending': 'pending', 'key-confirm-pending': 'pending', active: 'keyed', releasing: 'releasing', failed: 'failed',
+};
+
+/** 'receiving' requires a positively observed OFF and zero TX risk; anything else is doubt. */
+export function rfState(tx: TxAuthoritySnapshot): RfState {
+  if (tx.radioTx === 'on' || tx.txRisk === 'confirmed-on') return 'transmitting';
+  if (tx.txRisk === 'uncertain') return 'uncertain';
+  return tx.radioTx === 'off' && tx.txRisk === 'none' ? 'receiving' : 'unknown';
+}
+
+/** An unrecognised phase reads as 'pending' — never as 'idle' ("nothing is happening"). */
+export const txSessionState = (tx: TxAuthoritySnapshot): TxSessionState =>
+  SESSION_BY_PHASE[tx.phase] ?? 'pending';
+
+/** 'external' only when the authority is provably uninvolved — "not you" is the dangerous claim. */
+export const txOrigin = (tx: TxAuthoritySnapshot): TxOrigin =>
+  tx.mayOwnKey || tx.phase !== 'idle' ? 'local' : 'external';
+
+/**
+ * Both halves must agree before a key intent may leave this surface: the
+ * permit says the FREQUENCY is legal, the authority says the TRANSMITTER is
+ * free. A 'unknown' permit is not a permit.
+ */
+export function keyBlockedReasons(
+  view: RadioViewModel, tx: TxAuthoritySnapshot,
+): readonly KeyBlockedReason[] {
+  const reasons: KeyBlockedReason[] = [];
+  if (view.txTarget.status !== 'known') reasons.push('tx-target-unknown');
+  if (view.txPermit.status === 'denied') reasons.push('tx-permit-denied');
+  if (view.txPermit.status === 'unknown') reasons.push('tx-permit-unknown');
+  if (tx.fault !== null) reasons.push('tx-fault');
+  if (tx.phase !== 'idle' || tx.mayOwnKey || tx.txRisk !== 'none') reasons.push('tx-busy');
+  if (tx.radioTx === 'on') reasons.push('radio-transmitting');
+  if (tx.radioTx === 'unknown') reasons.push('rf-state-unknown');
+  return reasons;
+}
+
+/** The view model's own disabled reasons that concern TX — scope/VFO reasons are not TX gates. */
+export const txDisabledReasons = (view: RadioViewModel): readonly DisabledReason[] =>
+  view.disabledReasons.filter((reason) => reason.field.startsWith('tx'));
+
+let sequence = 0;
+/** Per-instance DOM id, so several mounted surfaces keep distinct aria targets. */
+export const nextSurfaceId = (): string => `rx-tx-${++sequence}`;


### PR DESCRIPTION
## Summary

The semantic RX/TX status/action surface on App TX authority — 4 new files under `frontend/src/semantic/`:

- `rx-tx-surface.ts` (99) + `RxTxSurface.svelte` (100) = 199 net production LOC. Pure component: props `{ view: RadioViewModel, tx: TxAuthoritySnapshot, onRequestKey?, onRequestUnkey? }`; `TxAuthoritySnapshot` is a name-for-name structural subset of the App TX controller's `TxState` (`phase`/`intent`/`radioTx`/`txRisk`/`mayOwnKey`/`fault`) — a real `snapshot()` is assignable with no adapter. Zero controller/transport/store imports; wiring is a later slice (MOR-1065).
- **Safety shape:** every mapping fails closed — `'receiving'` requires an observed OFF *and* zero `txRisk`; an unrecognized phase reads `pending`, never `idle`; keying requires permit `'allowed'` AND a non-vetoing authority; **unkey is completely ungated** (no `disabled`, no `{#if}`, no handler guard — the fail-safe direction). Fault and target-unknown are displayed, never re-adjudicated; `role="status"` only — `AppGlobalHost` keeps the sole assertive lamp.
- A11y: accessible name + pressed state on the key action; RX/TX distinction carried by text/shape, not color alone (per the MOR-977 record).

## Independent verification

- **Subset/drift ruling closes:** structural assignability compile-enforced (`npm run check` includes the parity test); all 18 omitted `TxState` fields ruled individually (correlation/timer bookkeeping upstream of the rendered facts; `pendingOff`/`localAudio`/`modRestorePending` provably co-occur with non-idle phase or non-none risk — no fail-open vector); drift is LOUD: renaming `radioTx` → 10 errors incl. the pin; widening `TxPhase`/`TxFault` → exactly one error repo-wide each, at the pin/exhaustiveness check.
- **Mutations 21/21 killed** (18 behavioral + 3 drift), incl. three independent unkey-gating shapes, permit-unknown-as-allowed, authority-veto-ignored, view-model-only rewire, guessed target, assertive-channel grab, both a11y channels.
- **No second authority:** the only `view`×`tx` combination is a monotone-restrictive keying gate; status channel is `role="status"` vs the global host's `assertive`/`alert`.
- **Suites:** semantic 131 passed (58+21 new); full frontend A/B same-session — failure set identical (known env flakes), +79 passing; lint/lint:boundaries/check clean.
- Residuals recorded: fault-recovery intent deliberately absent (wiring requirement recorded on MOR-1065); target row is view-model-sourced (cross-check vs `leaseTarget` noted for the wiring slice); cosmetic `data-origin` nit.

Linear: MOR-1064 (with MOR-1063 unblocks MOR-1065 and the entrypoint migrations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
