### PR TITLE
fix(MOR-1205): let a fresh authoritative OFF discharge a reconnect-surviving pendingOff

### DIFF
--- a/frontend/src/lib/runtime/tx-controller/__tests__/integration-reconnect-dekey-matrix.test.ts
+++ b/frontend/src/lib/runtime/tx-controller/__tests__/integration-reconnect-dekey-matrix.test.ts
@@ -30,18 +30,18 @@ import { MockWebSocket, instances } from '$lib/transport/__tests__/support/fake-
 //      lease is never reconstructed from an external PTT observation alone.
 //   4. WS loss while a *self-issued* release is already in flight but
 //      unconfirmed — proving the pending release obligation is neither
-//      duplicated nor silently discarded by the reconnect's epoch bump.
+//      duplicated nor silently discarded by the reconnect's epoch bump, and
+//      that it can still converge afterwards.
 //
-// Case 4 was hand-verified against the real code before being written down:
-// once the OFF has already reached the (since-dropped) socket, the model has
-// no path back to a clean "idle" after a session-epoch bump (the bound
-// delivery barrier and the armed timeout are both epoch-stamped at the old
-// epoch, so neither the authoritative-confirm branch nor the off-confirmation
-// timeout can fire against the new one). That's an existing property of
-// model.ts, not something this test suite invents or repairs — the assertion
-// here is deliberately scoped to what the reconnect boundary must never do
-// (invent a duplicate OFF, or drop the still-owed one), not to a full
-// idle convergence this specific interleaving doesn't reach.
+// Case 4's boundary half was hand-verified against the real code before being
+// written down: once the OFF has already reached the (since-dropped) socket,
+// the reconnect must neither invent a duplicate OFF nor drop the still-owed
+// one. Its convergence half is MOR-1205: the bound delivery barrier and the
+// armed off-confirmation timeout are both epoch-stamped at the old epoch, so
+// neither could fire against the new one and the controller used to sit in
+// "releasing" forever. The stale timeout still cannot fire (asserted below);
+// discharge now comes from a fresh authoritative ptt:false observed on the
+// new epoch — evidence, not a timer, and never another command.
 
 const h = vi.hoisted(() => ({
   radio: null as any,
@@ -345,5 +345,25 @@ describe('tx-controller integration reconnect/de-key matrix — real WsChannel +
       }),
     });
     expect(h.restore).not.toHaveBeenCalled(); // never falsely restores MOD without a real confirmation
+
+    // ── The surviving obligation must also be able to DISCHARGE (MOR-1205) ──
+    // The off-confirmation timeout armed before the drop is stamped at the old
+    // epoch, so it can never fire against the new one: advancing well past its
+    // 5s deadline must change nothing — no `release-not-confirmed`, no OFF.
+    vi.advanceTimersByTime(6_000);
+    expect(controller.snapshot()).toMatchObject({ phase: 'releasing', fault: null });
+    expect(countFrames('ptt_off', socket0, socket1)).toBe(1);
+
+    // A fresh authoritative ptt:false on the NEW epoch is the source of truth,
+    // and the controller converges on it: the obligation is discharged without
+    // ever putting another OFF on the wire.
+    confirmAuthority(controller, factory, getSession(), false, 4);
+    expect(controller.snapshot()).toMatchObject({
+      phase: 'idle', fault: null, guard: null, leaseId: null, mayOwnKey: false,
+      pendingOff: null, txRisk: 'none', modRestorePending: false, radioTx: 'off',
+    });
+    expect(countFrames('ptt_off', socket0, socket1)).toBe(1); // still exactly one OFF, ever
+    expect(countFrames('ptt_on', socket0, socket1)).toBe(1);
+    expect(h.restore).toHaveBeenCalledTimes(1); // MOD restored once, on real evidence
   });
 });

--- a/frontend/src/lib/runtime/tx-controller/__tests__/model.test.ts
+++ b/frontend/src/lib/runtime/tx-controller/__tests__/model.test.ts
@@ -277,6 +277,35 @@ describe('TX reducer', () => {
     expect(transition(delivered.state, { type: 'authority', epoch: 2, ptt: ptt(false, 2, 2), eligibility: eligible, offCommandId: 'other' })).toEqual({ state: delivered.state, effects: [] });
     const confirmed = transition(delivered.state, { type: 'authority', epoch: 2, ptt: ptt(false, 3, 2), eligibility: eligible, offCommandId: 'other' }); expect(confirmed.state.phase).toBe('idle'); expect(types(confirmed)).toEqual(['cancel-timers', 'restore-mod']);
   });
+  // MOR-1205: an OFF bound BEFORE a reconnect carries an old-epoch delivery barrier,
+  // and its armed timeout is stamped at the old epoch too. Neither can fire against
+  // the new epoch, so only a fresh authoritative observation on the live epoch can
+  // discharge the surviving obligation — and it must do so without a second OFF.
+  it('discharges a reconnect-stranded OFF only from live-epoch authoritative evidence', () => {
+    const keyed = active(); const released = transition(keyed, { type: 'release', guard: keyed.guard!, commandId: 'off' });
+    const off = released.state.pendingOff!; const delivered = transition(released.state, { type: 'off-sent', ...off, eventEpoch: 1, barrier: marker(4) });
+    expect(delivered.state.pendingOff?.deliveryPttBarrier).toEqual(marker(4)); // bound on the OLD epoch
+    const opened = transition(delivered.state, { type: 'epoch', epoch: 2, baseline: marker(1, 2), offCommandId: 'other' });
+    expect(types(opened)).toEqual([]); expect(opened.state).toMatchObject({ phase: 'releasing', authorityEpoch: 2, epochBaseline: marker(1, 2), pendingOff: delivered.state.pendingOff, mayOwnKey: true, modRestorePending: true });
+    expect(transition(opened.state, timerEvent(delivered.state, 'off-confirmation', 'off'))).toEqual({ state: opened.state, effects: [] }); // old-epoch timeout stays dead
+    const inert: PttObservation[] = [{ ...ptt(false, 2, 2), fresh: false }, { ...ptt(false, 2, 2), observed: false }, { ...ptt(false, 2, 2), source: 'other' }, ptt(false, 5, 1)];
+    for (const observation of inert) expect(transition(opened.state, { type: 'authority', epoch: 2, ptt: observation, eligibility: eligible, offCommandId: 'other' })).toEqual({ state: opened.state, effects: [] });
+    expect(transition(opened.state, { type: 'authority', epoch: 1, ptt: ptt(false, 5, 1), eligibility: eligible, offCommandId: 'other' })).toEqual({ state: opened.state, effects: [] }); // stale epoch, stale evidence
+    const discharged = transition(opened.state, { type: 'authority', epoch: 2, ptt: ptt(false, 2, 2), eligibility: eligible, offCommandId: 'other' });
+    expect(types(discharged)).toEqual(['cancel-timers', 'restore-mod']); // never a second OFF
+    expect(discharged.effects.find((item) => item.type === 'restore-mod')?.barrier).toEqual(marker(1, 2)); // rebased, so the MOD restore is not silently rejected downstream
+    expect(discharged.state).toMatchObject({ phase: 'idle', fault: null, intent: null, leaseId: null, guard: null, cleanupGuard: null, pendingOff: null, mayOwnKey: false, modRestorePending: false, txRisk: 'none', radioTx: 'off', timerRevision: { audio: 0, on: 0, off: 0 } });
+    expect(transition(discharged.state, { type: 'authority', epoch: 2, ptt: ptt(false, 2, 2), eligibility: eligible, offCommandId: 'other' })).toEqual({ state: discharged.state, effects: [] }); // discharged exactly once
+    const later = transition(discharged.state, { type: 'authority', epoch: 2, ptt: ptt(false, 3, 2), eligibility: eligible, offCommandId: 'other' }); // later truth is observed, never re-discharged
+    expect(types(later)).toEqual([]); expect(later.state).toMatchObject({ phase: 'idle', pendingOff: null, mayOwnKey: false, pttMarker: marker(3, 2) });
+    const next = start(discharged.state, { leaseId: 'lease-next', ptt: ptt(false, 3, 2) }); // no residue blocking the next cycle
+    expect(types(next)).toEqual(['start-audio', 'arm-audio-timeout']); expect(next.state).toMatchObject({ phase: 'audio-start-pending', leaseId: 'lease-next', authorityEpoch: 2, pendingOff: null, mayOwnKey: false, fault: null });
+    const errored = transition(opened.state, { type: 'command-result', command: 'off', outcome: 'response-error', barrier: null, ...correlation(delivered.state, 'off'), eventEpoch: 2 });
+    expect(errored.state).toMatchObject({ phase: 'failed', fault: 'release-not-confirmed', pendingOff: opened.state.pendingOff }); // same strand, failed terminal
+    const dischargedFailed = transition(errored.state, { type: 'authority', epoch: 2, ptt: ptt(false, 2, 2), eligibility: eligible, offCommandId: 'other' });
+    expect(types(dischargedFailed)).toEqual(['cancel-timers', 'restore-mod']);
+    expect(dischargedFailed.state).toMatchObject({ phase: 'failed', fault: 'release-not-confirmed', pendingOff: null, mayOwnKey: false, modRestorePending: false, txRisk: 'none' });
+  });
   it('never reconstructs ON intent across reconnect, restore, remount or fault reset', () => {
     const dekeyed = transition(active(), { type: 'authority', epoch: 1, ptt: ptt(false, 4), eligibility: eligible, offCommandId: 'off' }); const reset = transition(dekeyed.state, { type: 'reset-fault' });
     const opened = transition(reset.state, { type: 'epoch', epoch: 2, baseline: marker(1, 2), offCommandId: 'off' }); const restored = transition(opened.state, { type: 'authority', epoch: 2, ptt: ptt(false, 2, 2), eligibility: eligible, offCommandId: 'off' }); const rekeyed = transition(restored.state, { type: 'authority', epoch: 2, ptt: ptt(true, 3, 2), eligibility: eligible, offCommandId: 'off' });

--- a/frontend/src/lib/runtime/tx-controller/model.ts
+++ b/frontend/src/lib/runtime/tx-controller/model.ts
@@ -147,7 +147,13 @@ export function transition(state: TxState, event: TxEvent): TxTransition {
       return { state: next, effects: [effect('cancel-timers', state, undefined, undefined, cleanupGuard), effect('stop-local-audio', state, undefined, undefined, cleanupGuard), effect('restore-mod', state, undefined, state.onConfirmed, cleanupGuard)] };
     }
     if ((state.phase === 'releasing' || state.phase === 'failed') && !event.ptt.value && state.modRestorePending) {
-      const barrier = state.pendingOff ? state.pendingOff.deliveryPttBarrier : state.modBarrier;
+      const bound = state.pendingOff ? state.pendingOff.deliveryPttBarrier : state.modBarrier;
+      // A barrier stamped at a superseded authority epoch can never be crossed by an
+      // observation on the live epoch, so an obligation a reconnect caught mid-flight
+      // would be stranded forever (MOR-1205). Fall back to the current epoch's own
+      // baseline: the authoritative reading past it is the source of truth. Stale
+      // commands and timers stay dead, and discharging issues no further command.
+      const barrier = bound && bound.authorityEpoch < state.authorityEpoch ? state.epochBaseline : bound;
       if (barrier && newer(barrier, event.ptt)) {
         const cleanupGuard = state.cleanupGuard ?? state.guard;
         const discharged = state.phase === 'releasing' ? { ...clearLease(next), phase: 'idle' as const, txRisk: 'none' as const, modRestorePending: false, fault: null } : state.fault === 'release-not-confirmed' ? { ...clearLease(next), phase: 'failed' as const, txRisk: 'none' as const, modRestorePending: false, fault: state.fault } : { ...next, cleanupGuard: null, modRestorePending: false };


### PR DESCRIPTION
## Summary

Closes the single software GAP in the MOR-987 cross-surface TX lifecycle matrix: a browser `pendingOff` that survived a WebSocket reconnect could never discharge — both discharge paths (the bound delivery barrier and the armed off-confirmation timeout) were stamped at the stale pre-reconnect epoch, so the controller never converged to idle (operator saw UNKEYING… forever despite fresh authoritative `ptt:false` observations). Failure direction was SAFE (no replay, no duplicate, no lost obligation) — a convergence failure.

Fix — `frontend/src/lib/runtime/tx-controller/model.ts`, **net +1 production line** (+comments): inside the existing authoritative-OFF discharge branch, a delivery barrier stamped at a superseded epoch is rebased onto `state.epochBaseline`. Everything else stands: discharge still requires a fresh authoritative `ptt:false` on the live epoch; stale commands/timers stay dead; discharge effects remain `['cancel-timers','restore-mod']` — never another `ptt_off`. The rebase also matters downstream: `tx-adapter` rejects epoch-mismatched barriers in both directions, so the stale barrier would have silently voided the MOD restore.

Closing test extends the U5 reconnect case per the MOR-987 evidence spec §7 (fresh authoritative `ptt:false` on the new epoch + timers → `phase:'idle'`, `pendingOff:null`, `txRisk:'none'`, no additional `ptt_off`); pre-existing U5 boundary assertions append-only intact.

## Independent verification

- All six adversarial epoch questions closed with file:line evidence: the rebase is reachable ONLY via a legitimately-surviving `pendingOff` (no cancelled/replaced obligation can reach it; `bound === null` still blocks); multi-reconnect 1→2→3 discharges exactly once (epoch-2 evidence inert, epoch-3 discharges — reviewer's own probe); stale-epoch authoritative OFF still rejected; non-authoritative OFF rejected; no path emits another `ptt_off` and `clearLease` makes further OFF paths unreachable; the MOD-restore claim proven including the inverse (widening the adapter's rejection list keeps 25/25 green).
- Pre-fix reproduction exact (2/102 fail with the ticket's precise stuck state); closing test matches and exceeds the §7 spec (stale 5 s timeout asserted dead first).
- Mutations: builder's 6 all killed; reviewer added 5 → 4 killed, 1 adjudicated a provable equivalent mutant. Next-cycle cleanliness pinned and re-proved with a full second key/release cycle.
- Suites: TX-controller 102/102; lint/boundaries/check/ruff clean; full frontend zero new failures vs a back-to-back baseline (remaining failures are the documented localStorage env break — proven by a 25/25 run with `--localstorage-file`).
- **MOR-987 cell ruling (relayed to the ticket):** S2 × reconnect-after-unconfirmed-release → PROVEN (software evidence): obligation survives, never duplicated, stale timeout stays dead, fresh authoritative OFF on the new epoch discharges to idle with the MOD restore run once and exactly one `ptt_off` on the wire, ever.

Linear: MOR-1205 (unblocks MOR-987)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
