### PR TITLE
feat(MOR-1063): semantic VFO surface on the view-model contract

### DIFF
--- a/frontend/src/lib/i18n/locales/en-US.json
+++ b/frontend/src/lib/i18n/locales/en-US.json
@@ -168,6 +168,17 @@
   "core.modePanel.modInputLabel": "MOD IN",
   "core.modePanel.modInputAria": "Modulation input source",
 
+  "core.vfo.groupLabel": "VFOs",
+  "core.vfo.activeReceiver.known": "Active receiver: {receiver}",
+  "core.vfo.activeReceiver.unknown": "Active receiver: unknown",
+  "core.vfo.selectAction": "Select {label}",
+  "core.vfo.txTarget.label": "TX target",
+  "core.vfo.split.label": "Split",
+  "core.vfo.dualWatch.label": "Dual watch",
+  "core.vfo.state.on": "on",
+  "core.vfo.state.off": "off",
+  "core.vfo.state.unknown": "unknown",
+
   "core.txGuard.modInputNotLan": "MOD input is {source}, not LAN — your voice from the web will not be transmitted (TX).",
   "core.txGuard.setLan": "Set LAN",
   "core.txGuard.dismiss": "Dismiss MOD input warning",

--- a/frontend/src/lib/i18n/locales/ja-JP.json
+++ b/frontend/src/lib/i18n/locales/ja-JP.json
@@ -168,6 +168,17 @@
   "core.modePanel.modInputLabel": "MOD IN",
   "core.modePanel.modInputAria": "変調入力ソース",
 
+  "core.vfo.groupLabel": "VFO",
+  "core.vfo.activeReceiver.known": "アクティブな受信機: {receiver}",
+  "core.vfo.activeReceiver.unknown": "アクティブな受信機: 不明",
+  "core.vfo.selectAction": "{label} を選択",
+  "core.vfo.txTarget.label": "TX 対象",
+  "core.vfo.split.label": "スプリット",
+  "core.vfo.dualWatch.label": "デュアルウォッチ",
+  "core.vfo.state.on": "オン",
+  "core.vfo.state.off": "オフ",
+  "core.vfo.state.unknown": "不明",
+
   "core.txGuard.modInputNotLan": "MOD 入力が {source} のため LAN 経由の音声は送信 (TX) されません。",
   "core.txGuard.setLan": "LAN に設定",
   "core.txGuard.dismiss": "MOD 入力の警告を閉じる",

--- a/frontend/src/lib/i18n/locales/ru-RU.json
+++ b/frontend/src/lib/i18n/locales/ru-RU.json
@@ -168,6 +168,17 @@
   "core.modePanel.modInputLabel": "MOD IN",
   "core.modePanel.modInputAria": "Источник входной модуляции",
 
+  "core.vfo.groupLabel": "VFO",
+  "core.vfo.activeReceiver.known": "Активный приёмник: {receiver}",
+  "core.vfo.activeReceiver.unknown": "Активный приёмник: неизвестно",
+  "core.vfo.selectAction": "Выбрать {label}",
+  "core.vfo.txTarget.label": "Цель TX",
+  "core.vfo.split.label": "Сплит",
+  "core.vfo.dualWatch.label": "Двойной приём",
+  "core.vfo.state.on": "включено",
+  "core.vfo.state.off": "выключено",
+  "core.vfo.state.unknown": "неизвестно",
+
   "core.txGuard.modInputNotLan": "Вход MOD установлен в {source}, а не LAN — голос из веб-интерфейса не уйдёт в эфир (TX).",
   "core.txGuard.setLan": "Включить LAN",
   "core.txGuard.dismiss": "Скрыть предупреждение о входе MOD",

--- a/frontend/src/semantic/VfoSurface.svelte
+++ b/frontend/src/semantic/VfoSurface.svelte
@@ -1,0 +1,174 @@
+<!--
+  VfoSurface — pure semantic rendering of the VFO facts on `RadioViewModel`
+  (MOR-1062 contract): frequency, receiver/slot identity, mode/filter,
+  active state, per-VFO TX-target marker, and the orthogonal split/dual-watch
+  facts. Emits selection/toggle INTENTS via callback props; no store,
+  transport, capability, skin, or manufacturer knowledge (v3 ADR, MOR-1063).
+  txTarget/txPermit (reasoned TX confirmation) and any TX action belong to
+  the sibling RX/TX surface, not here.
+
+  Two-level gating (MOR-977): a selection control is ABSENT when there is
+  structurally nothing to choose (single-VFO topology, or already active)
+  and DISABLED when the slot identity is unobserved (`slot.kind ===
+  'unknown'`) — never fabricate an A/B id. Split/dual-watch toggles are
+  always structurally present but DISABLED while unobserved, rendered as
+  an explicit tri-state — never defaulted to "off".
+-->
+<script module lang="ts">
+  import type { ReceiverId, VfoSlot } from './radio-view-model';
+
+  export interface VfoSelection {
+    receiver: ReceiverId;
+    slot: VfoSlot;
+  }
+</script>
+
+<script lang="ts">
+  import { t } from '$lib/i18n';
+  import type { BooleanFact, RadioViewModel, VfoViewModel } from './radio-view-model';
+
+  interface Props {
+    viewModel: RadioViewModel;
+    onSelectVfo?: (target: VfoSelection) => void;
+    onToggleSplit?: () => void;
+    onToggleDualWatch?: () => void;
+  }
+
+  let { viewModel, onSelectVfo, onToggleSplit, onToggleDualWatch }: Props = $props();
+
+  function slotKey(slot: VfoSlot): string {
+    return slot.kind === 'slotted' ? slot.id : slot.kind;
+  }
+
+  function roleLabel(vfo: VfoViewModel): string {
+    const { slot } = vfo;
+    if (slot.kind === 'slotted') return `${vfo.receiver} ${slot.id}`;
+    if (slot.kind === 'unknown') return `${vfo.receiver} (${t('core.vfo.state.unknown')})`;
+    return vfo.receiver;
+  }
+
+  function formatFrequency(hz: number | null): string {
+    return hz === null ? '—' : `${(hz / 1_000_000).toFixed(6)} MHz`;
+  }
+
+  function isSelectable(vfo: VfoViewModel): boolean {
+    return viewModel.vfos.length > 1 && !vfo.isActive;
+  }
+
+  function selectVfo(vfo: VfoViewModel): void {
+    if (!isSelectable(vfo) || vfo.slot.kind === 'unknown') return;
+    onSelectVfo?.({ receiver: vfo.receiver, slot: vfo.slot });
+  }
+
+  function triState(fact: BooleanFact): 'true' | 'false' | 'mixed' {
+    if (fact.status === 'unknown') return 'mixed';
+    return fact.value ? 'true' : 'false';
+  }
+
+  function stateWord(fact: BooleanFact): string {
+    if (fact.status === 'unknown') return t('core.vfo.state.unknown');
+    return t(fact.value ? 'core.vfo.state.on' : 'core.vfo.state.off');
+  }
+
+  function toggleSplit(): void {
+    if (viewModel.split.status !== 'known') return;
+    onToggleSplit?.();
+  }
+
+  function toggleDualWatch(): void {
+    if (viewModel.dualWatch.status !== 'known') return;
+    onToggleDualWatch?.();
+  }
+</script>
+
+<div class="vfo-surface" role="group" aria-label={t('core.vfo.groupLabel')} data-testid="vfo-surface">
+  <p
+    class="active-receiver"
+    data-testid="vfo-active-receiver"
+    data-active-receiver={viewModel.activeReceiver.status === 'known'
+      ? viewModel.activeReceiver.receiver
+      : 'unknown'}
+  >
+    {viewModel.activeReceiver.status === 'known'
+      ? t('core.vfo.activeReceiver.known', { receiver: viewModel.activeReceiver.receiver })
+      : t('core.vfo.activeReceiver.unknown')}
+  </p>
+
+  <div class="vfo-list" data-testid="vfo-list">
+    {#each viewModel.vfos as vfo, i (vfo.receiver + ':' + i)}
+      {@const selectable = isSelectable(vfo)}
+      {@const disabled = selectable && vfo.slot.kind === 'unknown'}
+      <div
+        class="vfo-tile"
+        class:is-active={vfo.isActive}
+        data-vfo-tile
+        data-vfo-receiver={vfo.receiver}
+        data-vfo-slot={slotKey(vfo.slot)}
+        data-vfo-active={vfo.isActive}
+        data-vfo-tx-target={vfo.isTxTarget}
+      >
+        <span class="vfo-role">{roleLabel(vfo)}</span>
+        <span class="vfo-freq">{formatFrequency(vfo.frequencyHz)}</span>
+        <span class="vfo-mode">{vfo.mode ?? '—'}{vfo.filter ? ` / ${vfo.filter}` : ''}</span>
+        {#if vfo.isTxTarget}
+          <span class="vfo-badge" data-vfo-tx-badge>{t('core.vfo.txTarget.label')}</span>
+        {/if}
+        {#if selectable}
+          <button
+            type="button"
+            class="vfo-select"
+            data-vfo-select
+            disabled={disabled}
+            aria-label={t('core.vfo.selectAction', { label: vfo.label })}
+            onclick={() => selectVfo(vfo)}
+          >
+            {vfo.label}
+          </button>
+        {:else}
+          <span class="vfo-label" data-vfo-label>{vfo.label}</span>
+        {/if}
+      </div>
+    {/each}
+  </div>
+
+  <div class="fact-toggles">
+    <button
+      type="button"
+      class="fact-toggle"
+      data-vfo-split
+      role="switch"
+      aria-checked={triState(viewModel.split)}
+      aria-label={t('core.vfo.split.label')}
+      disabled={viewModel.split.status === 'unknown'}
+      onclick={toggleSplit}
+    >
+      {t('core.vfo.split.label')}: {stateWord(viewModel.split)}
+    </button>
+    <button
+      type="button"
+      class="fact-toggle"
+      data-vfo-dual-watch
+      role="switch"
+      aria-checked={triState(viewModel.dualWatch)}
+      aria-label={t('core.vfo.dualWatch.label')}
+      disabled={viewModel.dualWatch.status === 'unknown'}
+      onclick={toggleDualWatch}
+    >
+      {t('core.vfo.dualWatch.label')}: {stateWord(viewModel.dualWatch)}
+    </button>
+  </div>
+</div>
+
+<style>
+  /* Semantic-neutral layout only — existing --v2-* theme tokens, sensible fallbacks. */
+  .vfo-surface { display: flex; flex-direction: column; gap: 8px; font-family: 'Roboto Mono', monospace; color: var(--v2-text-primary, #e8e8e8); }
+  .active-receiver { margin: 0; font-size: 11px; color: var(--v2-text-subdued, rgba(255, 255, 255, 0.55)); }
+  .vfo-list { display: flex; flex-wrap: wrap; gap: 6px; }
+  .vfo-tile { display: flex; align-items: center; gap: 6px; padding: 4px 8px; border: 1px solid var(--v2-border-panel, rgba(255, 255, 255, 0.12)); border-radius: 4px; background: var(--v2-bg-panel, rgba(255, 255, 255, 0.03)); }
+  .vfo-tile.is-active { border-color: var(--v2-accent-cyan, #00d4ff); }
+  .vfo-role { font-weight: 700; color: var(--v2-text-secondary, rgba(255, 255, 255, 0.8)); }
+  .vfo-badge { padding: 1px 4px; border-radius: 3px; font-size: 10px; color: var(--v2-accent-red, #ff2020); border: 1px solid var(--v2-accent-red, #ff2020); }
+  .vfo-select, .fact-toggle { border: 1px solid var(--v2-border-panel, rgba(255, 255, 255, 0.12)); border-radius: 4px; background: transparent; color: inherit; cursor: pointer; padding: 3px 6px; }
+  .vfo-select:disabled, .fact-toggle:disabled { color: var(--v2-text-disabled, rgba(255, 255, 255, 0.3)); cursor: not-allowed; }
+  .fact-toggles { display: flex; gap: 6px; }
+</style>

--- a/frontend/src/semantic/__tests__/VfoSurface.test.ts
+++ b/frontend/src/semantic/__tests__/VfoSurface.test.ts
@@ -1,0 +1,392 @@
+/**
+ * Tests for the semantic VFO surface (MOR-1063), built on the MOR-1062
+ * `RadioViewModel` contract and its four topology fixtures.
+ *
+ * Discriminating-test goals (see ticket acceptance evidence):
+ *   - render VFO facts faithfully per fixture, across all four topologies;
+ *   - the four topologies must render structurally differently — a test
+ *     that would pass on identical renders is tautological, so we assert a
+ *     rendered-DOM signature is pairwise distinct, mirroring
+ *     `topology-fixtures.test.ts`'s own non-vacuous-distinctness guard;
+ *   - unknown facts (ActiveRx, VFO slot, split/dualWatch) must render as an
+ *     explicit "unknown" state, never silently defaulted;
+ *   - selection/toggle intents fire with the right payload, and never fire
+ *     while the control is disabled (mutation-kill coverage);
+ *   - accessible names and disabled/absent gating per the MOR-977 two-level
+ *     doctrine (structural = absent, operational = disabled);
+ *   - i18n coverage: no unresolved catalog key leaks into rendered text.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount, unmount, flushSync } from 'svelte';
+import type { ComponentProps } from 'svelte';
+import VfoSurface from '../VfoSurface.svelte';
+import { validateRadioViewModel, type RadioViewModel, type VfoSlot } from '../radio-view-model';
+import { topologyFixtures, withAudioOnlyScope, type TopologyFixtureId } from '../fixtures/topologies';
+
+const ids: readonly TopologyFixtureId[] = ['1/single', '1/ab', '2/ab_shared', '2/main_sub'];
+
+let components: ReturnType<typeof mount>[] = [];
+
+function mountSurface(props: ComponentProps<typeof VfoSurface>): HTMLElement {
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+  const component = mount(VfoSurface, { target, props });
+  flushSync();
+  components.push(component);
+  return target;
+}
+
+beforeEach(() => {
+  components = [];
+});
+
+afterEach(() => {
+  components.forEach((c) => unmount(c));
+  while (document.body.firstChild) document.body.removeChild(document.body.firstChild);
+});
+
+function expectedSlotKey(slot: VfoSlot): string {
+  return slot.kind === 'slotted' ? slot.id : slot.kind;
+}
+function expectedFreq(hz: number | null): string {
+  return hz === null ? '—' : `${(hz / 1_000_000).toFixed(6)} MHz`;
+}
+
+/** Normalized rendered-DOM summary — only VFO-surface-owned facts. */
+function renderSignature(target: HTMLElement): string {
+  const tiles = Array.from(target.querySelectorAll<HTMLElement>('[data-vfo-tile]')).map((el) => ({
+    receiver: el.dataset.vfoReceiver,
+    slot: el.dataset.vfoSlot,
+    active: el.dataset.vfoActive,
+    txTarget: el.dataset.vfoTxTarget,
+    freq: el.querySelector('.vfo-freq')?.textContent,
+    mode: el.querySelector('.vfo-mode')?.textContent,
+  }));
+  return JSON.stringify({
+    tiles,
+    activeReceiver: target.querySelector('[data-testid="vfo-active-receiver"]')?.getAttribute('data-active-receiver'),
+    split: target.querySelector('[data-vfo-split]')?.getAttribute('aria-checked'),
+    dualWatch: target.querySelector('[data-vfo-dual-watch]')?.getAttribute('aria-checked'),
+  });
+}
+
+// ── Faithful rendering per fixture ──────────────────────────────────────────
+
+describe.each(ids)('topology %s', (id) => {
+  it('renders every VFO fact faithfully', () => {
+    const model = topologyFixtures[id];
+    const target = mountSurface({ viewModel: model });
+    const tiles = target.querySelectorAll<HTMLElement>('[data-vfo-tile]');
+    expect(tiles.length).toBe(model.vfos.length);
+
+    model.vfos.forEach((vfo, i) => {
+      const tile = tiles[i];
+      expect(tile.dataset.vfoReceiver).toBe(vfo.receiver);
+      expect(tile.dataset.vfoSlot).toBe(expectedSlotKey(vfo.slot));
+      expect(tile.dataset.vfoActive).toBe(String(vfo.isActive));
+      expect(tile.dataset.vfoTxTarget).toBe(String(vfo.isTxTarget));
+      expect(tile.querySelector('.vfo-freq')?.textContent).toBe(expectedFreq(vfo.frequencyHz));
+      expect(tile.querySelector('.vfo-mode')?.textContent).toContain(vfo.mode ?? '—');
+      if (vfo.filter) expect(tile.querySelector('.vfo-mode')?.textContent).toContain(vfo.filter);
+      expect(tile.querySelector('[data-vfo-tx-badge]') !== null).toBe(vfo.isTxTarget);
+      const shownLabel =
+        tile.querySelector('[data-vfo-select]')?.textContent?.trim() ??
+        tile.querySelector('[data-vfo-label]')?.textContent?.trim();
+      expect(shownLabel).toBe(vfo.label);
+    });
+  });
+
+  it('never leaks an unresolved i18n catalog key', () => {
+    const target = mountSurface({ viewModel: topologyFixtures[id] });
+    expect(target.textContent).not.toMatch(/\[missing:/);
+  });
+});
+
+// ── Non-vacuous structural distinctness across topologies (V2-style) ───────
+
+it('renders four structurally different DOM signatures across the four topologies', () => {
+  const signatures = ids.map((id) => renderSignature(mountSurface({ viewModel: topologyFixtures[id] })));
+  expect(new Set(signatures).size).toBe(ids.length);
+});
+
+// ── S1: audio-only scope is orthogonal to the VFO surface ──────────────────
+
+it.each(ids)('withAudioOnlyScope on %s changes nothing this surface renders (scope is out of scope)', (id) => {
+  const base = renderSignature(mountSurface({ viewModel: topologyFixtures[id] }));
+  const variant = renderSignature(mountSurface({ viewModel: withAudioOnlyScope(topologyFixtures[id]) }));
+  expect(variant).toBe(base);
+});
+
+// ── Roles: receiver + slot identity text ────────────────────────────────────
+
+it('shows a distinct role per VFO across single/dual and slotted/unslotted schemes', () => {
+  const single = mountSurface({ viewModel: topologyFixtures['1/single'] });
+  expect(single.querySelector('.vfo-role')?.textContent).toBe('MAIN');
+
+  const ab = mountSurface({ viewModel: topologyFixtures['1/ab'] });
+  const abRoles = Array.from(ab.querySelectorAll('.vfo-role')).map((e) => e.textContent);
+  expect(abRoles).toEqual(['MAIN A', 'MAIN B']);
+
+  const mainSub = mountSurface({ viewModel: topologyFixtures['2/main_sub'] });
+  const roles = Array.from(mainSub.querySelectorAll('.vfo-role')).map((e) => e.textContent);
+  expect(roles).toEqual(['MAIN A', 'MAIN B', 'SUB A', 'SUB B']);
+});
+
+// ── UNCERTAINTY IS VISIBLE ───────────────────────────────────────────────────
+
+describe('uncertainty is rendered explicitly, never defaulted', () => {
+  it('unknown activeReceiver renders an explicit "unknown" state, never MAIN', () => {
+    const model: RadioViewModel = validateRadioViewModel({
+      ...topologyFixtures['1/single'],
+      activeReceiver: { status: 'unknown' },
+    });
+    const target = mountSurface({ viewModel: model });
+    const el = target.querySelector('[data-testid="vfo-active-receiver"]');
+    expect(el?.getAttribute('data-active-receiver')).toBe('unknown');
+    expect(el?.getAttribute('data-active-receiver')).not.toBe('MAIN');
+    expect(el?.textContent).toContain('unknown');
+  });
+
+  it('unknown VFO slot renders an explicit "unknown" state, never defaults to A', () => {
+    const base = topologyFixtures['1/ab'];
+    const model: RadioViewModel = validateRadioViewModel({
+      ...base,
+      vfos: [base.vfos[0], { ...base.vfos[1], slot: { kind: 'unknown' } }],
+    });
+    const target = mountSurface({ viewModel: model });
+    const tiles = target.querySelectorAll<HTMLElement>('[data-vfo-tile]');
+    expect(tiles[1].dataset.vfoSlot).toBe('unknown');
+    expect(tiles[1].dataset.vfoSlot).not.toBe('A');
+    expect(tiles[1].querySelector('.vfo-role')?.textContent).toContain('unknown');
+  });
+
+  it('R2: two VFOs on the SAME receiver with BOTH slots unobserved render without crashing, ' +
+    'each with its own explicit unknown-slot presentation', () => {
+    // MOR-988 §3.2/§4: missing/stale slot projects as unknown per VFO,
+    // independently — the contract validator accepts two same-receiver VFOs
+    // that are each separately unobserved; the surface must never fabricate
+    // a shared/synthesized slot id to disambiguate them, and must not use a
+    // key derived from slot identity (which would collide here).
+    const base = topologyFixtures['1/ab'];
+    const model: RadioViewModel = validateRadioViewModel({
+      ...base,
+      vfos: [
+        { ...base.vfos[0], slot: { kind: 'unknown' } },
+        { ...base.vfos[1], slot: { kind: 'unknown' } },
+      ],
+    });
+    let target!: HTMLElement;
+    expect(() => {
+      target = mountSurface({ viewModel: model });
+    }).not.toThrow();
+    const tiles = target.querySelectorAll<HTMLElement>('[data-vfo-tile]');
+    expect(tiles.length).toBe(2);
+    tiles.forEach((tile) => {
+      expect(tile.dataset.vfoSlot).toBe('unknown');
+      expect(tile.dataset.vfoSlot).not.toBe('A');
+      expect(tile.querySelector('.vfo-role')?.textContent).toContain('unknown');
+    });
+  });
+
+  it('unknown dualWatch renders an explicit "unknown" tri-state, never "off"', () => {
+    // 1/ab fixture carries dualWatch: { status: 'unknown' } verbatim.
+    const target = mountSurface({ viewModel: topologyFixtures['1/ab'] });
+    const toggle = target.querySelector<HTMLButtonElement>('[data-vfo-dual-watch]')!;
+    expect(toggle.getAttribute('aria-checked')).toBe('mixed');
+    expect(toggle.textContent).toContain('unknown');
+    expect(toggle.textContent).not.toContain('off');
+  });
+
+  it('unknown split renders an explicit "unknown" tri-state', () => {
+    const base = topologyFixtures['1/ab'];
+    const model: RadioViewModel = validateRadioViewModel({ ...base, split: { status: 'unknown' } });
+    const target = mountSurface({ viewModel: model });
+    const toggle = target.querySelector<HTMLButtonElement>('[data-vfo-split]')!;
+    expect(toggle.getAttribute('aria-checked')).toBe('mixed');
+    expect(toggle.textContent).toContain('unknown');
+    // R1 (review cycle 1): pin the disabled attribute itself, not just the
+    // aria-checked/text-content facts above — mutation M14 deleted
+    // `disabled={viewModel.split.status === 'unknown'}` and every other
+    // assertion in this file still passed (dualWatch's equivalent was
+    // pinned; split's was not).
+    expect(toggle.disabled).toBe(true);
+  });
+
+  it('null frequency renders as an explicit placeholder, not 0 or blank', () => {
+    const base = topologyFixtures['1/single'];
+    const model: RadioViewModel = validateRadioViewModel({
+      ...base,
+      vfos: [{ ...base.vfos[0], frequencyHz: null }],
+    });
+    const target = mountSurface({ viewModel: model });
+    expect(target.querySelector('.vfo-freq')?.textContent).toBe('—');
+  });
+});
+
+// ── Selection intents: payload correctness + disabled/absent gating ────────
+
+describe('VFO selection intent', () => {
+  it('clicking a selectable inactive VFO emits onSelectVfo with the exact receiver+slot payload', () => {
+    const onSelectVfo = vi.fn();
+    const target = mountSurface({ viewModel: topologyFixtures['2/main_sub'], onSelectVfo });
+    target.querySelector<HTMLButtonElement>('[data-vfo-receiver="MAIN"][data-vfo-slot="B"] [data-vfo-select]')!.click();
+    expect(onSelectVfo).toHaveBeenCalledOnce();
+    expect(onSelectVfo).toHaveBeenCalledWith({ receiver: 'MAIN', slot: { kind: 'slotted', id: 'B' } });
+  });
+
+  it('the active VFO renders no select control at all (nothing to choose)', () => {
+    const target = mountSurface({ viewModel: topologyFixtures['2/main_sub'] });
+    const activeTile = target.querySelector<HTMLElement>('[data-vfo-active="true"]')!;
+    expect(activeTile.querySelector('[data-vfo-select]')).toBeNull();
+  });
+
+  it('a single-VFO topology renders no select control — structurally nothing to choose', () => {
+    const target = mountSurface({ viewModel: topologyFixtures['1/single'] });
+    expect(target.querySelector('[data-vfo-select]')).toBeNull();
+  });
+
+  it('a lone inactive VFO (structural edge case) still renders no select control', () => {
+    // Independent of `isActive`: with only one VFO in the model there is
+    // nothing else to select between, regardless of its active flag.
+    const base = topologyFixtures['1/single'];
+    const model: RadioViewModel = validateRadioViewModel({
+      ...base,
+      vfos: [{ ...base.vfos[0], isActive: false }],
+    });
+    const target = mountSurface({ viewModel: model });
+    expect(target.querySelector('[data-vfo-select]')).toBeNull();
+  });
+
+  it('a VFO with an unobserved slot renders its select control disabled', () => {
+    const base = topologyFixtures['1/ab'];
+    const model: RadioViewModel = validateRadioViewModel({
+      ...base,
+      vfos: [base.vfos[0], { ...base.vfos[1], slot: { kind: 'unknown' } }],
+    });
+    const target = mountSurface({ viewModel: model });
+    const button = target.querySelectorAll<HTMLButtonElement>('[data-vfo-select]')[0];
+    expect(button.disabled).toBe(true);
+  });
+
+  it('MUTATION KILL: clicking a disabled (unknown-slot) select control never emits the intent, ' +
+    'even if the native disabled gate is bypassed', () => {
+    const onSelectVfo = vi.fn();
+    const base = topologyFixtures['1/ab'];
+    const model: RadioViewModel = validateRadioViewModel({
+      ...base,
+      vfos: [base.vfos[0], { ...base.vfos[1], slot: { kind: 'unknown' } }],
+    });
+    const target = mountSurface({ viewModel: model, onSelectVfo });
+    const button = target.querySelectorAll<HTMLButtonElement>('[data-vfo-select]')[0];
+    // A native `disabled` button already refuses to dispatch `click` in jsdom
+    // and real browsers alike. Force it enabled first so this test proves
+    // the component's OWN handler guard — not just DOM disabled semantics —
+    // refuses to fabricate an A/B id and emit the intent.
+    button.disabled = false;
+    button.click();
+    expect(onSelectVfo).not.toHaveBeenCalled();
+  });
+});
+
+// ── Split / dual-watch toggle intents ───────────────────────────────────────
+
+describe('split / dual-watch toggle intents', () => {
+  it('clicking a known split toggle emits onToggleSplit', () => {
+    const onToggleSplit = vi.fn();
+    const target = mountSurface({ viewModel: topologyFixtures['1/single'], onToggleSplit });
+    target.querySelector<HTMLButtonElement>('[data-vfo-split]')!.click();
+    expect(onToggleSplit).toHaveBeenCalledOnce();
+  });
+
+  it('clicking a known dualWatch toggle emits onToggleDualWatch', () => {
+    const onToggleDualWatch = vi.fn();
+    const target = mountSurface({ viewModel: topologyFixtures['2/main_sub'], onToggleDualWatch });
+    target.querySelector<HTMLButtonElement>('[data-vfo-dual-watch]')!.click();
+    expect(onToggleDualWatch).toHaveBeenCalledOnce();
+  });
+
+  it('MUTATION KILL: clicking a disabled (unknown) dualWatch toggle never emits the intent, ' +
+    'even if the native disabled gate is bypassed', () => {
+    const onToggleDualWatch = vi.fn();
+    // 1/ab carries dualWatch: unknown verbatim.
+    const target = mountSurface({ viewModel: topologyFixtures['1/ab'], onToggleDualWatch });
+    const toggle = target.querySelector<HTMLButtonElement>('[data-vfo-dual-watch]')!;
+    toggle.disabled = false;
+    toggle.click();
+    expect(onToggleDualWatch).not.toHaveBeenCalled();
+  });
+
+  it('MUTATION KILL: clicking a disabled (unknown) split toggle never emits the intent, ' +
+    'even if the native disabled gate is bypassed', () => {
+    const onToggleSplit = vi.fn();
+    const base = topologyFixtures['1/ab'];
+    const model: RadioViewModel = validateRadioViewModel({ ...base, split: { status: 'unknown' } });
+    const target = mountSurface({ viewModel: model, onToggleSplit });
+    const toggle = target.querySelector<HTMLButtonElement>('[data-vfo-split]')!;
+    toggle.disabled = false;
+    toggle.click();
+    expect(onToggleSplit).not.toHaveBeenCalled();
+  });
+
+  it('both split and dualWatch can be independently true at once (2/main_sub)', () => {
+    const target = mountSurface({ viewModel: topologyFixtures['2/main_sub'] });
+    expect(target.querySelector('[data-vfo-split]')?.getAttribute('aria-checked')).toBe('true');
+    expect(target.querySelector('[data-vfo-dual-watch]')?.getAttribute('aria-checked')).toBe('true');
+  });
+});
+
+// ── Accessibility basics ─────────────────────────────────────────────────────
+
+describe('accessibility basics', () => {
+  it('the surface exposes an accessible group name', () => {
+    const target = mountSurface({ viewModel: topologyFixtures['2/main_sub'] });
+    const region = target.querySelector('[data-testid="vfo-surface"]');
+    expect(region?.getAttribute('role')).toBe('group');
+    expect(region?.getAttribute('aria-label')?.length).toBeGreaterThan(0);
+  });
+
+  it('every enabled select control has a non-empty accessible name', () => {
+    const target = mountSurface({ viewModel: topologyFixtures['2/main_sub'] });
+    const buttons = target.querySelectorAll<HTMLButtonElement>('[data-vfo-select]');
+    expect(buttons.length).toBeGreaterThan(0);
+    buttons.forEach((b) => expect(b.getAttribute('aria-label')?.length).toBeGreaterThan(0));
+  });
+
+  it('split/dualWatch toggles have accessible names and role="switch"', () => {
+    const target = mountSurface({ viewModel: topologyFixtures['2/main_sub'] });
+    for (const sel of ['[data-vfo-split]', '[data-vfo-dual-watch]']) {
+      const btn = target.querySelector<HTMLButtonElement>(sel)!;
+      expect(btn.getAttribute('role')).toBe('switch');
+      expect(btn.getAttribute('aria-label')?.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('disabled controls are excluded from the tab order (native disabled semantics)', () => {
+    const base = topologyFixtures['1/ab'];
+    const model: RadioViewModel = validateRadioViewModel({
+      ...base,
+      vfos: [base.vfos[0], { ...base.vfos[1], slot: { kind: 'unknown' } }],
+    });
+    const target = mountSurface({ viewModel: model });
+    const disabledSelect = target.querySelectorAll<HTMLButtonElement>('[data-vfo-select]')[0];
+    const disabledDualWatch = target.querySelector<HTMLButtonElement>('[data-vfo-dual-watch]')!;
+    expect(disabledSelect.disabled).toBe(true);
+    expect(disabledDualWatch.disabled).toBe(true);
+    // jsdom mirrors the browser: a disabled element cannot become activeElement.
+    disabledSelect.focus();
+    expect(document.activeElement).not.toBe(disabledSelect);
+  });
+
+  it('focus order follows DOM order: enabled buttons appear in source-array order', () => {
+    const target = mountSurface({ viewModel: topologyFixtures['2/main_sub'] });
+    const focusable = Array.from(target.querySelectorAll<HTMLButtonElement>('button:not([disabled])'));
+    // MAIN A is active (no select button); expect MAIN B, SUB A, SUB B selects,
+    // then the split and dualWatch toggles, in that DOM order.
+    const order = focusable.map(
+      (el) => el.dataset.vfoSelect !== undefined
+        ? `select:${el.closest('[data-vfo-tile]')?.getAttribute('data-vfo-receiver')}:${el.closest('[data-vfo-tile]')?.getAttribute('data-vfo-slot')}`
+        : el.hasAttribute('data-vfo-split') ? 'split' : 'dualWatch',
+    );
+    expect(order).toEqual(['select:MAIN:B', 'select:SUB:A', 'select:SUB:B', 'split', 'dualWatch']);
+  });
+});

--- a/frontend/src/semantic/radio-view-model.ts
+++ b/frontend/src/semantic/radio-view-model.ts
@@ -46,7 +46,11 @@ export type BooleanFact =
 /**
  * Structural = the radio model supports this. Operational = usable right
  * now, given live capability AND field-observed state. MOR-977 two-level
- * gating: a control that fails either half is absent, not merely disabled.
+ * gating: a control that fails the STRUCTURAL half is absent (nothing to
+ * render); a control that fails only the OPERATIONAL half stays present but
+ * disabled, degrading to an explicit unknown/disabled state rather than a
+ * guessed default — MOR-988 §11.3: "Old v1 servers lacking additive fields
+ * degrade to `unknown`/disabled in v3, not guessed behavior."
  */
 export interface Availability {
   structural: boolean;


### PR DESCRIPTION
## Summary

The semantic VFO surface on the MOR-1062 view-model contract — `frontend/src/semantic/VfoSurface.svelte` (pure presentational, 174 lines) + tests + full i18n:

- Consumes ONLY the VFO-owned slice of `RadioViewModel` (frequency, receiver/slot identity, mode/filter, active state, `isTxTarget` marker, `split`/`dualWatch`); never touches `txTarget`/`txPermit`/`scope` (RX/TX-surface territory) nor any store/transport/runtime/skin import.
- Emits three semantic intents via callback props: `onSelectVfo`, `onToggleSplit`, `onToggleDualWatch`. Two-level gating (absent vs disabled) per the MOR-977 record, with markup `disabled` plus an independent JS guard — all three gated controls two-level pinned.
- Uncertainty is visible, never defaulted: unknown `ActiveRx`/slot/split/dualWatch each render an explicit unknown state (MOR-988 doctrine).
- `{#each}` keying by `receiver+':'+index` — survives the contract-legal state of two same-receiver VFOs with unobserved slots (renders both with explicit unknown-slot presentation; regression-pinned; the slot-derived key crashed with `each_key_duplicate`).
- i18n: 10 `core.vfo.*` keys in en-US, ja-JP, ru-RU — catalog parity preserved at 176/0/0.
- One sanctioned comment-only correction in `radio-view-model.ts` (wording aligned to MOR-988 §11.3 verbatim; mechanically comment-only).

## Independent verification (one cycle)

- Cycle 0 findings all fixed and re-verified by mutation: the each-key production defect (crash reproduced, fixed, regression guard proven failure-capable); the unpinned split `disabled` (M14 now fails exactly one test); the first-ever locale-parity break (restored; translations spot-checked as real, register-matched — not transliteration padding).
- Index-key ruling SOUND: reorder probes (reverse + within-receiver swap) — rendered facts track the model, post-reorder clicks emit the correct new identity, no stateful-DOM mismatch (component has no bind/transition/animate/$state); residual a11y nit recorded for MOR-1087.
- Topology distinctness non-vacuous (forced fixture collapse fails the assertion; all 6 pairs differ on ≥4 topology facts); purity/lint/boundaries 37/37; 18 mutations run in cycle 0 with all uncertainty-defaulting variants killed.
- Suites: 36/36 surface tests; 125/125 semantic+boundaries; lint/check/i18n:check clean; full frontend failing set a strict subset of baseline.

Linear: MOR-1063 (with MOR-1064 unblocks MOR-1065)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
