### PR TITLE
feat(MOR-1065): adapters zone exception - type-only semantic contract imports (slice a0)

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -396,6 +396,60 @@ export default [
     },
   },
 
+  // ── Narrow exception: adapters may reference the view-model CONTRACT ──
+  // MOR-1065 review ruling 2. The v3 ADR's dependency diagram is
+  // `runtime -> adapters/view models -> semantic radio UI`, i.e. the view
+  // model belongs to the ADAPTER side of the seam, but MOR-1062 physically
+  // placed `RadioViewModel` under `src/semantic/`. The base
+  // `no-restricted-imports` rule has no `allowTypeImports`, so the block
+  // above blocks type-only references too and an adapter cannot annotate the
+  // contract it produces. This zone swaps in the typescript-eslint variant so
+  // a TYPE-only import is permitted and a VALUE import stays an error — the
+  // producer-side compile-time link, without a runtime dependency on
+  // presentation. Pinned by `__tests__/architecture-boundaries.test.ts`.
+  //
+  // `ignores` is REQUIRED: without it this `files` glob also captures
+  // `adapters/**/__tests__/**`, and the "tests may import anything" block
+  // below only disables the BASE rule — the typescript-eslint rule would stay
+  // live and reject the adapter tests' legitimate value imports of
+  // `validateRadioViewModel` and the topology fixtures.
+  {
+    files: ['src/lib/runtime/adapters/**/*.ts'],
+    ignores: ['src/lib/runtime/adapters/**/__tests__/**'],
+    plugins: { '@typescript-eslint': tsPlugin },
+    rules: {
+      'no-restricted-imports': 'off',
+      '@typescript-eslint/no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['**/components-v2/**', '**/components-v2'],
+              message:
+                'lib/runtime must not import from components-v2. ' +
+                'Use lib/runtime/props/ or lib/runtime/commands/ instead. ' +
+                'See ADR 2026-04-12.',
+            },
+            {
+              group: ['**/presentation/**', '**/presentation'],
+              message:
+                'lib/runtime must not import from presentation/. ' +
+                'See v3 ADR invariant 1 (MOR-1061 F2).',
+            },
+            {
+              group: ['**/semantic/**', '**/semantic'],
+              allowTypeImports: true,
+              message:
+                'Adapters may import the view-model CONTRACT type-only (v3 ADR: adapters ' +
+                'emit view models). No value imports from semantic/ — a runtime dependency ' +
+                'on presentation is still invariant-1 forbidden.',
+            },
+          ],
+        },
+      ],
+    },
+  },
+
   // ── Tests may import anything (mocking is legitimate) ──
   {
     files: ['src/**/__tests__/**', 'src/**/*.test.ts'],

--- a/frontend/src/__tests__/architecture-boundaries.test.ts
+++ b/frontend/src/__tests__/architecture-boundaries.test.ts
@@ -19,10 +19,21 @@ import path from 'node:path';
 
 const FRONTEND_ROOT = path.resolve(fileURLToPath(import.meta.url), '../../..');
 
+/**
+ * Counts import-boundary violations under EITHER rule id. The adapters zone
+ * (MOR-1065 ruling 2) swaps the base rule for `@typescript-eslint/
+ * no-restricted-imports` so it can express `allowTypeImports`; a filter on the
+ * base id alone would silently score every adapter-zone ban as "0 hits" and
+ * turn the pre-existing adapter assertions below into vacuous passes.
+ */
+const RESTRICTED_IMPORT_RULES = new Set([
+  'no-restricted-imports', '@typescript-eslint/no-restricted-imports',
+]);
+
 async function restrictedImportHits(code: string, filePath: string): Promise<number> {
   const eslint = new ESLint({ cwd: FRONTEND_ROOT });
   const [result] = await eslint.lintText(code, { filePath });
-  return result.messages.filter((m) => m.ruleId === 'no-restricted-imports').length;
+  return result.messages.filter((m) => RESTRICTED_IMPORT_RULES.has(m.ruleId ?? '')).length;
 }
 
 describe('v3 package boundaries (MOR-1061)', () => {
@@ -355,6 +366,73 @@ describe('v3 package boundaries (MOR-1061)', () => {
     const hits = await restrictedImportHits(
       `import LcdSkin from '../../skins/amber-lcd/LcdSkin.svelte';`,
       'src/presentation/workspaces/preferences.ts',
+    );
+    expect(hits).toBeGreaterThan(0);
+  });
+
+  // ── MOR-1065 ruling 2: the adapters' type-only contract exception ───────
+  // The v3 ADR puts the view model on the adapter side of the seam, but
+  // MOR-1062 placed `RadioViewModel` under src/semantic/. Adapters may name
+  // that contract; they may not depend on presentation at runtime. The whole
+  // value of the exception is the asymmetry, so pin both halves.
+
+  it('allows adapters a TYPE-ONLY import of the view-model contract', async () => {
+    const hits = await restrictedImportHits(
+      `import type { RadioViewModel } from '../../../semantic/radio-view-model';\n`
+        + `export type X = RadioViewModel;`,
+      'src/lib/runtime/adapters/radio-view-model-adapter.ts',
+    );
+    expect(hits).toBe(0);
+  });
+
+  it('still rejects adapters VALUE-importing from semantic/', async () => {
+    const hits = await restrictedImportHits(
+      `import { validateRadioViewModel } from '../../../semantic/radio-view-model';`,
+      'src/lib/runtime/adapters/radio-view-model-adapter.ts',
+    );
+    expect(hits).toBeGreaterThan(0);
+  });
+
+  it('still rejects adapters importing a semantic component', async () => {
+    const hits = await restrictedImportHits(
+      `import VfoSurface from '../../../semantic/VfoSurface.svelte';`,
+      'src/lib/runtime/adapters/radio-view-model-adapter.ts',
+    );
+    expect(hits).toBeGreaterThan(0);
+  });
+
+  it('confines the exception to adapters — other lib/runtime files still cannot name semantic', async () => {
+    const hits = await restrictedImportHits(
+      `import type { RadioViewModel } from '../../semantic/radio-view-model';\n`
+        + `export type X = RadioViewModel;`,
+      'src/lib/runtime/frontend-runtime.ts',
+    );
+    expect(hits).toBeGreaterThan(0);
+  });
+
+  it('leaves the adapters zone\'s own __tests__ free to import anything', async () => {
+    // The `ignores:` line on the adapters block is what makes this pass: the
+    // "tests may import anything" block only disables the BASE rule, so
+    // without it the typescript-eslint rule would still reject this.
+    const hits = await restrictedImportHits(
+      `import { validateRadioViewModel } from '../../../../semantic/radio-view-model';`,
+      'src/lib/runtime/adapters/__tests__/radio-view-model-adapter.test.ts',
+    );
+    expect(hits).toBe(0);
+  });
+
+  it('keeps the components-v2 ban live inside the adapters zone', async () => {
+    const hits = await restrictedImportHits(
+      `import VfoPanel from '../../../components-v2/panels/VfoPanel.svelte';`,
+      'src/lib/runtime/adapters/radio-view-model-adapter.ts',
+    );
+    expect(hits).toBeGreaterThan(0);
+  });
+
+  it('keeps the presentation ban live inside the adapters zone', async () => {
+    const hits = await restrictedImportHits(
+      `import { SpectrumFirst } from '../../../presentation/layouts/SpectrumFirst';`,
+      'src/lib/runtime/adapters/radio-view-model-adapter.ts',
     );
     expect(hits).toBeGreaterThan(0);
   });


### PR DESCRIPTION
## Summary

Slice **a0** of the independently reviewed MOR-1065 desktop migration (landing per the review's 4-slice manifest: a0 → a → b → c, each under the 200-LOC guard):

- `frontend/eslint.config.js` (+54): a narrow, recorded zone exception — `lib/runtime/adapters/**` may import **types only** from `semantic/**` (`@typescript-eslint/no-restricted-imports` with `allowTypeImports`; base rule off for that block; `__tests__` ignored). Rationale (review Ruling 2): the v3 ADR's own text says adapters consume runtime/capabilities and EMIT VIEW MODELS — the adapter must name the contract type or the compile-time link is lost.
- `architecture-boundaries.test.ts` (+78): the helper now counts both rule ids (without this the pre-existing adapter assertions would have gone vacuous — verified by reverting the helper alone: 5 tests redden) + 7 new fixtures proving the exception is exactly type-wide: value imports of semantic still FAIL lint, type imports pass, drop-allowTypeImports and drop-ignores mutations each kill a test.

## Independent verification

Reviewed within the full MOR-1065 verification (two cycles): the reviewer prescribed this exact config shape and proved it in-tree before adoption (lint 0, boundaries green, svelte-check 0, value-import still blocked), including the `ignores: ['**/__tests__/**']` trap. Review artifact: session scratchpad `wave4/mor-1065-review.md`.

Linear: MOR-1065 (slice a0 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)