### PR TITLE
feat(MOR-1065): live adapter mapping runtime state to the RadioViewModel (slice a)

### DIFF
--- a/frontend/src/lib/i18n/__tests__/pseudo-locale.smoke.test.ts
+++ b/frontend/src/lib/i18n/__tests__/pseudo-locale.smoke.test.ts
@@ -63,6 +63,11 @@ beforeEach(() => {
 
 afterEach(() => {
   localStorage.clear();
+  // The i18n store is a module singleton and the fast pool runs with
+  // ``isolate: false`` (issue #771), so a pseudo-locale left set here leaks
+  // into every later fast-pool file — any test asserting on real English text
+  // then sees ``⟦…⟧`` instead. Hand the locale back on the way out.
+  _resetLocale();
 });
 
 describe('pseudo-locale smoke (representative UI keys)', () => {

--- a/frontend/src/lib/runtime/adapters/__tests__/radio-view-model-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/radio-view-model-adapter.test.ts
@@ -1,0 +1,290 @@
+/**
+ * MOR-1065 — the live adapter behind the semantic VFO / RX-TX surfaces.
+ *
+ * The failure mode this file exists to kill is FABRICATION: an adapter that
+ * fills an unobserved receiver with 'MAIN', an unobserved A/B slot with 'A',
+ * or an unobserved split with `false` looks perfectly healthy on screen and
+ * lies about the radio. Every "unknown" assertion below names the mutation
+ * it kills.
+ *
+ * The contract itself (`semantic/radio-view-model`) cannot be imported by
+ * `lib/runtime/**` production code (eslint invariant 1) — test files are
+ * exempt, so this is also where the emitted shape is proven to be a real,
+ * validator-clean `RadioViewModel`.
+ */
+import { describe, expect, it } from 'vitest';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { FieldStatus, ServerState } from '$lib/types/state';
+import {
+  validateRadioViewModel, type RadioViewModel,
+} from '../../../../semantic/radio-view-model';
+import { topologyFixtures } from '../../../../semantic/fixtures/topologies';
+import { toRadioViewModel } from '../radio-view-model-adapter';
+
+const DUAL = ['scope', 'audio', 'tx', 'dual_rx'];
+const SINGLE = ['scope', 'audio', 'tx'];
+
+function caps(overrides: Partial<Capabilities> = {}): Capabilities {
+  return {
+    model: 'fixture', scope: true, audio: true, tx: true, capabilities: DUAL,
+    receivers: 2, vfoScheme: 'main_sub', freqRanges: [], modes: [], filters: [],
+    audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
+    webrtc: { available: false, enabled: false },
+    txBands: [{ start: 14000000, end: 14350000, name: '20m' }],
+    scopeSource: 'hardware', audioFftAvailable: true, ...overrides,
+  } as Capabilities;
+}
+
+/** One representative capability set per canonical topology fixture. */
+const TOPOLOGY_CAPS: Record<string, Capabilities> = {
+  '1/single': caps({ vfoScheme: 'single', receivers: 1, capabilities: SINGLE }),
+  '1/ab': caps({ vfoScheme: 'ab', receivers: 1, capabilities: SINGLE }),
+  '2/ab_shared': caps({ vfoScheme: 'ab_shared', receivers: 2 }),
+  '2/main_sub': caps({ vfoScheme: 'main_sub', receivers: 2 }),
+};
+
+const fresh: FieldStatus = {
+  storePath: 'x', observed: true, freshness: 'fresh', availability: 'available',
+};
+const stale: FieldStatus = {
+  storePath: 'x', observed: true, freshness: 'stale', availability: 'stale',
+};
+
+const slot = (freqHz: number, mode = 'USB') => ({
+  freqHz, mode, filterNum: 1, dataMode: 0,
+});
+const receiver = (freqHz: number) => ({
+  ...slot(freqHz), vfoA: slot(freqHz), vfoB: slot(freqHz + 50000), activeSlot: 'A',
+  filter: 1, att: 0, preamp: 0, nb: false, nr: false, afLevel: 1, rfGain: 1,
+  squelch: 0, sMeter: 0,
+});
+
+/** A fully observed state: every field this adapter reads is fresh+available. */
+function observedState(overrides: Partial<ServerState> = {}): ServerState {
+  const paths = [
+    'active', 'split', 'dualWatch', 'txTarget', 'main.freqHz', 'main.mode', 'main.filter',
+    'sub.freqHz', 'sub.mode', 'sub.filter', 'main.activeSlot', 'sub.activeSlot',
+  ];
+  for (const key of ['main', 'sub'] as const) {
+    for (const vfo of ['vfoA', 'vfoB']) {
+      paths.push(`${key}.${vfo}.freqHz`, `${key}.${vfo}.mode`, `${key}.${vfo}.filterNum`);
+    }
+  }
+  return {
+    active: 'MAIN', split: false, dualWatch: false, ptt: false,
+    txTarget: { status: 'known', receiver: 'MAIN', slot: 'A', frequencyHz: 14250000 },
+    main: receiver(14250000), sub: receiver(14300000),
+    scopeControls: { receiver: 0, dual: false } as ServerState['scopeControls'],
+    fieldStatus: Object.fromEntries(paths.map((p) => [p, fresh])),
+    ...overrides,
+  } as ServerState;
+}
+
+/** Nothing has ever been observed: the payload exists, field status does not. */
+const unobservedState = (): ServerState => ({
+  ...observedState(), fieldStatus: {},
+} as ServerState);
+
+function model(state: ServerState | null, capabilities: Capabilities | null): RadioViewModel {
+  const view = toRadioViewModel(state, capabilities);
+  expect(view).not.toBeNull();
+  // The single most important assertion in this file: the adapter's output is
+  // a real view model by the contract's OWN validator, cross-field invariants
+  // included (no 'allowed' permit under an unknown target, no orphan
+  // isTxTarget). `lib/runtime` cannot import this type — the test can.
+  return validateRadioViewModel(view);
+}
+
+describe('topology is derived from real capabilities', () => {
+  it.each(Object.keys(TOPOLOGY_CAPS))('%s is reachable and validator-clean', (id) => {
+    const view = model(observedState(), TOPOLOGY_CAPS[id]);
+    expect(view.topologyId).toBe(id);
+    expect(view.vfoScheme).toBe(topologyFixtures[id as keyof typeof topologyFixtures].vfoScheme);
+  });
+
+  it('emits the structural VFO positions each scheme implies', () => {
+    const shape = (id: string) => model(observedState(), TOPOLOGY_CAPS[id]).vfos
+      .map((v) => `${v.receiver}:${v.slot.kind === 'slotted' ? v.slot.id : v.slot.kind}`);
+    expect(shape('1/single')).toEqual(['MAIN:unslotted']);
+    expect(shape('1/ab')).toEqual(['MAIN:A', 'MAIN:B']);
+    expect(shape('2/ab_shared')).toEqual(['MAIN:unslotted', 'SUB:unslotted']);
+    expect(shape('2/main_sub')).toEqual(['MAIN:A', 'MAIN:B', 'SUB:A', 'SUB:B']);
+  });
+
+  it('renders nothing rather than guessing when capabilities are absent or contradictory', () => {
+    expect(toRadioViewModel(observedState(), null)).toBeNull();
+    // receivers=2 under a single-receiver scheme is `invalid-topology`; a
+    // guessed topology here would silently mis-address every TX decision.
+    expect(toRadioViewModel(observedState(), caps({ vfoScheme: 'ab', receivers: 2 }))).toBeNull();
+  });
+});
+
+describe('unobserved facts survive as the explicit unknown branch', () => {
+  // MUTATION KILLED: `activeReceiver: { status: 'known', receiver: state.active ?? 'MAIN' }`
+  // — the classic "default to MAIN" that MOR-988 §3.2 forbids.
+  it('never fabricates an active receiver, and marks no VFO active', () => {
+    const view = model(unobservedState(), TOPOLOGY_CAPS['2/main_sub']);
+    expect(view.activeReceiver).toEqual({ status: 'unknown' });
+    expect(view.vfos.some((v) => v.isActive)).toBe(false);
+    expect(view.disabledReasons).toContainEqual({
+      field: 'activeReceiver', code: 'field-not-observed',
+    });
+  });
+
+  // MUTATION KILLED: `split: { status: 'known', value: state.split ?? false }`.
+  it.each(['split', 'dualWatch'] as const)('never fabricates %s as off', (field) => {
+    expect(model(unobservedState(), TOPOLOGY_CAPS['2/main_sub'])[field])
+      .toEqual({ status: 'unknown' });
+  });
+
+  // MUTATION KILLED: enumerating `['A', 'B']` for a slotted scheme whose slot
+  // view was never sent — one fabricated 'A' position and the operator reads a
+  // slot identity the radio never reported.
+  it('degrades an unobserved A/B slot view to slot.kind "unknown", not to "A"', () => {
+    const view = model(observedState({
+      main: { ...receiver(14250000), vfoA: undefined, vfoB: undefined },
+    } as Partial<ServerState>), TOPOLOGY_CAPS['1/ab']);
+    expect(view.vfos).toHaveLength(1);
+    expect(view.vfos[0].slot).toEqual({ kind: 'unknown' });
+    expect(view.vfos.some((v) => v.slot.kind === 'slotted')).toBe(false);
+  });
+
+  // MUTATION KILLED: reading `<rx>.activeSlot` ungated. The backend DEFAULTS
+  // that field (`state_schema.py`: `activeSlot: str = "A"`), so an ungated
+  // read highlights MAIN A as active on evidence the radio never provided —
+  // a fabricated fact on an operator display, in a file whose header promises
+  // every radio fact is field-status gated.
+  it('marks no slot active when <rx>.activeSlot was never observed', () => {
+    const base = observedState();
+    const fieldStatus = { ...base.fieldStatus } as Record<string, unknown>;
+    delete fieldStatus['main.activeSlot'];
+    delete fieldStatus['sub.activeSlot'];
+    const view = model(
+      { ...base, fieldStatus } as unknown as ServerState, TOPOLOGY_CAPS['2/main_sub'],
+    );
+
+    expect(view.vfos.filter((v) => v.isActive)).toEqual([]);
+    // The slot IDENTITIES stay structurally known (the slot view WAS observed);
+    // only "which one is active" is unknown. The two must not collapse.
+    expect(view.vfos.map((v) => v.slot.kind))
+      .toEqual(['slotted', 'slotted', 'slotted', 'slotted']);
+  });
+
+  it('marks the observed slot active once activeSlot IS reported', () => {
+    const view = model(observedState(), TOPOLOGY_CAPS['2/main_sub']);
+    expect(view.vfos.filter((v) => v.isActive).map((v) => v.label)).toEqual(['MAIN A']);
+  });
+
+  // MUTATION KILLED: reading `state.txTarget` without the freshness gate — a
+  // stale target keys the wrong VFO.
+  it('reports a stale TX target as unknown/stale and blocks the permit', () => {
+    const view = model(observedState({
+      fieldStatus: { ...observedState().fieldStatus, txTarget: stale },
+    }), TOPOLOGY_CAPS['2/main_sub']);
+    expect(view.txTarget).toEqual({ status: 'unknown', reason: 'stale' });
+    expect(view.txPermit.status).not.toBe('allowed');
+    expect(view.vfos.some((v) => v.isTxTarget)).toBe(false);
+  });
+
+  // MUTATION KILLED: `frequencyHz: rx.freqHz ?? 14074000` (the legacy
+  // `toVfoProps` default) — a plausible-looking frequency for an unread radio.
+  it('nulls unobserved frequency / mode / filter instead of defaulting them', () => {
+    const view = model(unobservedState(), TOPOLOGY_CAPS['1/single']);
+    expect(view.vfos[0]).toMatchObject({ frequencyHz: null, mode: null, filter: null });
+  });
+
+  it('keeps observed readings when the field status backs them', () => {
+    const view = model(observedState(), TOPOLOGY_CAPS['2/main_sub']);
+    expect(view.vfos[0]).toMatchObject({
+      receiver: 'MAIN', frequencyHz: 14250000, mode: 'USB', filter: 'FIL1',
+      isActive: true, isTxTarget: true,
+    });
+  });
+});
+
+describe('TX identity and permit fail closed', () => {
+  it('marks exactly the VFO a known target names', () => {
+    const view = model(observedState(), TOPOLOGY_CAPS['2/main_sub']);
+    expect(view.vfos.filter((v) => v.isTxTarget).map((v) => v.label)).toEqual(['MAIN A']);
+    expect(view.txPermit).toEqual({ status: 'allowed', band: '20m' });
+  });
+
+  // MUTATION KILLED: keeping a target whose slot contradicts the scheme (a
+  // slot-less target under `main_sub`) instead of collapsing it to unknown.
+  it('collapses a target that contradicts the capability scheme', () => {
+    const view = model(observedState({
+      txTarget: { status: 'known', receiver: 'MAIN', slot: null, frequencyHz: 14250000 },
+    }), TOPOLOGY_CAPS['2/main_sub']);
+    expect(view.txTarget).toEqual({ status: 'unknown', reason: 'contradiction' });
+    expect(view.txPermit.status).toBe('unknown');
+  });
+
+  it('denies an out-of-band target rather than leaving the permit open', () => {
+    const view = model(observedState({
+      txTarget: { status: 'known', receiver: 'MAIN', slot: 'A', frequencyHz: 1000 },
+    }), TOPOLOGY_CAPS['2/main_sub']);
+    expect(view.txPermit).toEqual({ status: 'denied', reason: 'outside-configured-ranges' });
+    expect(view.disabledReasons).toContainEqual({ field: 'txPermit', code: 'out-of-band' });
+  });
+
+  it('reports unconfigured TX ranges as unknown, never as allowed', () => {
+    const view = model(observedState(), caps({ txBands: null }));
+    expect(view.txPermit).toEqual({ status: 'unknown', reason: 'ranges-unconfigured' });
+  });
+});
+
+describe('scope availability separates structural from operational', () => {
+  it('holds the hardware scope structurally present but not operational without controls', () => {
+    const view = model(observedState({ scopeControls: undefined }), TOPOLOGY_CAPS['2/main_sub']);
+    expect(view.scope.hardwareScope).toEqual({ structural: true, operational: false });
+    expect(view.disabledReasons).toContainEqual({
+      field: 'scope.hardwareScope', code: 'field-not-observed',
+    });
+  });
+
+  it('reports an absent audio FFT as capability-unavailable', () => {
+    const view = model(observedState(), caps({ audioFftAvailable: false }));
+    expect(view.scope.audioFftScope).toEqual({ structural: false, operational: false });
+    expect(view.disabledReasons).toContainEqual({
+      field: 'scope.audioFftScope', code: 'capability-unavailable',
+    });
+  });
+});
+
+describe('the emitted model carries only contract data', () => {
+  it('survives a JSON round-trip unchanged — no functions, classes or live objects', () => {
+    for (const id of Object.keys(TOPOLOGY_CAPS)) {
+      const view = model(observedState(), TOPOLOGY_CAPS[id]);
+      expect(JSON.parse(JSON.stringify(view))).toEqual(view);
+    }
+  });
+
+  // MUTATION KILLED: passing the capability object (or a component/module
+  // path) through onto the view model so a surface can "just read caps" —
+  // exactly the manufacturer/runtime leak the contract exists to prevent.
+  it('leaks no capability object and no module path', () => {
+    const view = model(observedState(), TOPOLOGY_CAPS['2/main_sub']);
+    const strings: string[] = [];
+    const walk = (value: unknown, path: string): void => {
+      expect(typeof value).not.toBe('function');
+      if (typeof value === 'string') strings.push(value);
+      if (value && typeof value === 'object') {
+        for (const [key, child] of Object.entries(value)) walk(child, `${path}.${key}`);
+      }
+    };
+    walk(view, '$');
+    for (const value of strings) {
+      // `topologyId` is legitimately `<count>/<scheme>`, so bare '/' is not the
+      // tell — module-ish segments and file extensions are.
+      expect(value).not.toMatch(
+        /\.svelte|\.ts$|\$lib|node_modules|(^|\/)(src|lib|skins|semantic|components-v2)(\/|$)/,
+      );
+    }
+    expect(Object.keys(view)).not.toContain('capabilities');
+    // The validator rejects extra keys, so this is belt-and-braces on shape.
+    expect(Object.keys(view).sort()).toEqual([
+      'activeReceiver', 'disabledReasons', 'dualWatch', 'scope', 'split',
+      'topologyId', 'txPermit', 'txTarget', 'vfoScheme', 'vfos',
+    ]);
+  });
+});

--- a/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
@@ -1,0 +1,208 @@
+/**
+ * Radio view-model adapter — the live seam behind the semantic VFO and RX/TX
+ * surfaces (MOR-1065).
+ *
+ * Maps REAL runtime state + capabilities onto the MOR-1062 radio semantic
+ * view-model shape. Unknown-preservation is the whole job: an unobserved
+ * active receiver, A/B slot, split, dual-watch or TX target must reach the
+ * surfaces as the contract's explicit `unknown` branch — never as a
+ * fabricated `'MAIN'` / `'A'` / `false` (MOR-988 §3.2, §4, §11.3). Every
+ * radio fact below is gated on the backend's own field status, so an old or
+ * partially-observed server degrades to `unknown`/disabled rather than to a
+ * guessed default.
+ *
+ * The contract type is imported TYPE-ONLY. eslint invariant 1 (MOR-1061 F2)
+ * bans `lib/runtime/** -> semantic/**`, but the v3 ADR's own dependency
+ * diagram puts the view model on the ADAPTER side of that seam, so the
+ * adapters zone carries a narrow, recorded `allowTypeImports` exception (see
+ * `eslint.config.js`; MOR-1065 review ruling 2). Value imports from
+ * `semantic/` stay blocked — pinned by `architecture-boundaries.test.ts`.
+ * Annotating the return type here is what makes contract drift a compile
+ * error at the PRODUCER (and, because the returned object literal is checked
+ * against the annotation, an extra field is an error too);
+ * `__tests__/radio-view-model-adapter.test.ts` additionally runs every
+ * emitted model through the real `validateRadioViewModel`.
+ */
+import type { Capabilities } from '$lib/types/capabilities';
+import type { ServerState } from '$lib/types/state';
+import type { RadioViewModel } from '../../../semantic/radio-view-model';
+import {
+  derivePresentationCapabilities, type ReceiverId, type VfoSlotId,
+} from './presentation-capabilities';
+import { deriveTxCapabilities } from './tx-capabilities';
+
+type Slot = { kind: 'slotted'; id: VfoSlotId } | { kind: 'unslotted' } | { kind: 'unknown' };
+type Fact = { status: 'known'; value: boolean } | { status: 'unknown' };
+type Reason = {
+  field: string;
+  code: 'capability-unavailable' | 'field-not-observed' | 'tx-target-unknown' | 'out-of-band';
+};
+type Readable = {
+  freqHz?: number; mode?: string; filter?: number | null; filterNum?: number | null;
+};
+type Position = { slot: Slot; base: string; filterKey: 'filter' | 'filterNum'; src: Readable | null };
+
+const RECEIVER_KEY = { MAIN: 'main', SUB: 'sub' } as const;
+const SLOT_KEY = { A: 'vfoA', B: 'vfoB' } as const;
+
+/** Observed + fresh + available — the same three-part gate the TX authority uses. */
+function seen(state: ServerState | null, path: string): boolean {
+  const status = state?.fieldStatus?.[path];
+  return status?.observed === true && status.freshness === 'fresh'
+    && status.availability === 'available';
+}
+
+function boolFact(state: ServerState | null, path: string, value: unknown): Fact {
+  return seen(state, path) && typeof value === 'boolean'
+    ? { status: 'known', value }
+    : { status: 'unknown' };
+}
+
+/** Per-position readings; each degrades to `null` on its own, unobserved field. */
+function readings(
+  state: ServerState | null, base: string, filterKey: 'filter' | 'filterNum', src: Readable | null,
+): { frequencyHz: number | null; mode: string | null; filter: string | null } {
+  const hz = src?.freqHz;
+  const mode = src?.mode;
+  const filter = filterKey === 'filter' ? src?.filter : src?.filterNum;
+  return {
+    frequencyHz: seen(state, `${base}freqHz`) && typeof hz === 'number' && Number.isFinite(hz)
+      ? hz : null,
+    mode: seen(state, `${base}mode`) && typeof mode === 'string' && mode !== '' ? mode : null,
+    filter: seen(state, `${base}${filterKey}`) && typeof filter === 'number'
+      ? `FIL${filter}` : null,
+  };
+}
+
+const sameSlot = (a: Slot, b: Slot): boolean =>
+  a.kind === 'slotted' && b.kind === 'slotted' ? a.id === b.id : a.kind === b.kind;
+
+/**
+ * `null` when there is nothing safe to render at all: capabilities have not
+ * loaded, or they describe a topology that contradicts itself
+ * (`derivePresentationCapabilities` diagnoses that, and a contradictory
+ * topology must not be guessed into one of the four canonical shapes).
+ */
+export function toRadioViewModel(
+  state: ServerState | null, caps: Capabilities | null,
+): RadioViewModel | null {
+  if (!caps) return null;
+  const presentation = derivePresentationCapabilities(caps);
+  const topology = presentation.topology;
+  if (!topology) return null;
+
+  const activeReceiver: { status: 'known'; receiver: ReceiverId } | { status: 'unknown' } =
+    seen(state, 'active') && (state?.active === 'MAIN' || state?.active === 'SUB')
+      ? { status: 'known', receiver: state.active }
+      : { status: 'unknown' };
+
+  // TX identity and permit come from the SAME derivation the App TX authority
+  // uses (`deriveTxCapabilities`), so the surfaces cannot disagree with the
+  // controller about what the radio would key.
+  const observedTarget = seen(state, 'txTarget') && state
+    ? state.txTarget
+    : {
+      status: 'unknown' as const,
+      reason: state?.fieldStatus?.txTarget?.availability === 'stale'
+        ? 'stale' as const : 'not-observed' as const,
+    };
+  const facts = deriveTxCapabilities(caps, {
+    txTarget: observedTarget, modInputSource: { status: 'unknown' },
+  });
+  const target = facts.txTarget;
+  const txTarget = target.status === 'known'
+    ? {
+      status: 'known' as const, receiver: target.receiver, frequencyHz: target.frequencyHz,
+      slot: (target.slot === null
+        ? { kind: 'unslotted' } : { kind: 'slotted', id: target.slot }) as Slot,
+    }
+    : { status: 'unknown' as const, reason: target.reason };
+  const txPermit = facts.frequencyPermit;
+
+  const vfos = topology.structuralReceivers.flatMap((receiver) => {
+    const key = RECEIVER_KEY[receiver];
+    const rx = state?.[key] ?? null;
+    const slots = topology.slots[receiver] ?? null;
+    // Gated like every other fact — and it MUST be: the backend defaults
+    // `activeSlot` to "A" (`state_schema.py`), so an ungated read marks
+    // MAIN A active on evidence the radio never provided.
+    const activeSlot = seen(state, `${key}.activeSlot`)
+      && (rx?.activeSlot === 'A' || rx?.activeSlot === 'B') ? rx.activeSlot : null;
+    const positions: Position[] = slots === null
+      ? [{ slot: { kind: 'unslotted' }, base: `${key}.`, filterKey: 'filter', src: rx }]
+      : slots.every((id) => rx?.[SLOT_KEY[id]] != null)
+        ? slots.map((id) => ({
+          slot: { kind: 'slotted', id }, base: `${key}.${SLOT_KEY[id]}.`,
+          filterKey: 'filterNum', src: rx?.[SLOT_KEY[id]] ?? null,
+        }))
+        // A slotted scheme whose slot view was never observed: ONE position of
+        // unknown slot identity. Synthesising 'A' here is exactly the
+        // fabrication MOR-988 §3.2 forbids.
+        : [{ slot: { kind: 'unknown' }, base: `${key}.`, filterKey: 'filter', src: rx }];
+    return positions.map(({ slot, base, filterKey, src }) => ({
+      receiver,
+      slot,
+      label: slot.kind === 'slotted' ? `${receiver} ${slot.id}` : receiver,
+      ...readings(state, base, filterKey, src),
+      isActive: activeReceiver.status === 'known' && activeReceiver.receiver === receiver
+        && (slot.kind !== 'slotted' || slot.id === activeSlot),
+      isTxTarget: txTarget.status === 'known' && txTarget.receiver === receiver
+        && sameSlot(txTarget.slot, slot),
+    }));
+  });
+
+  const split = boolFact(state, 'split', state?.split);
+  const dualWatch = boolFact(state, 'dualWatch', state?.dualWatch);
+  // Structural = the model has it. Operational = usable right now: the
+  // hardware scope needs an observed scope-control block, the audio FFT needs
+  // a live state payload for the stream it rides on.
+  const hardwareScope = {
+    structural: presentation.scope.hardwareScopeAvailable,
+    operational: presentation.scope.hardwareScopeAvailable && state?.scopeControls != null,
+  };
+  const audioFftScope = {
+    structural: presentation.scope.audioFftAvailable,
+    operational: presentation.scope.audioFftAvailable && state !== null,
+  };
+
+  const disabledReasons: Reason[] = [];
+  if (activeReceiver.status === 'unknown') {
+    disabledReasons.push({ field: 'activeReceiver', code: 'field-not-observed' });
+  }
+  if (split.status === 'unknown') disabledReasons.push({ field: 'split', code: 'field-not-observed' });
+  if (dualWatch.status === 'unknown') {
+    disabledReasons.push({ field: 'dualWatch', code: 'field-not-observed' });
+  }
+  if (txTarget.status === 'unknown') {
+    disabledReasons.push({
+      field: 'txTarget',
+      code: txTarget.reason === 'unsupported' ? 'capability-unavailable' : 'field-not-observed',
+    });
+  }
+  if (txPermit.status === 'denied') disabledReasons.push({ field: 'txPermit', code: 'out-of-band' });
+  if (txPermit.status === 'unknown') {
+    disabledReasons.push({
+      field: 'txPermit',
+      code: txPermit.reason === 'ranges-unconfigured' ? 'capability-unavailable' : 'tx-target-unknown',
+    });
+  }
+  for (const [field, availability] of [
+    ['scope.hardwareScope', hardwareScope], ['scope.audioFftScope', audioFftScope],
+  ] as const) {
+    if (!availability.structural) disabledReasons.push({ field, code: 'capability-unavailable' });
+    else if (!availability.operational) disabledReasons.push({ field, code: 'field-not-observed' });
+  }
+
+  return {
+    topologyId: `${topology.structuralCount}/${topology.scheme}`,
+    vfoScheme: topology.scheme,
+    activeReceiver,
+    vfos,
+    split,
+    dualWatch,
+    txTarget,
+    txPermit,
+    scope: { hardwareScope, audioFftScope },
+    disabledReasons,
+  };
+}


### PR DESCRIPTION
## Summary

Slice **a** of the independently reviewed MOR-1065 desktop migration (manifest a0 → a → b → c):

- `lib/runtime/adapters/radio-view-model-adapter.ts` (new, +208 raw): maps real runtime state/capabilities → validator-clean `RadioViewModel`. All facts gated on backend `fieldStatus` — unobserved facts reach the explicit unknown branches (incl. `activeSlot`, which the backend defaults to "A": review finding F3, fixed and pinned — an unobserved slot never renders active). TX target+permit reuse `deriveTxCapabilities` (the same source the TX authority uses). Return type annotated as `RadioViewModel` via the slice-a0 type-only exception — drift and excess fields fail at compile time (probed: an extra field in the returned literal is a tsc error).
- Its test suite + a one-line pre-existing test-isolation fix (`pseudo-locale.smoke.test.ts` never restored the locale; reproduced on unmodified main; no assertion relaxed).

## Independent verification (within the full MOR-1065 review, two cycles)

- Unknown-preservation mutations: 6/6 killed (3 builder + 3 reviewer-fresh, each re-run `-t` to confirm the named test dies), incl. fabricate-'MAIN', fabricate-slot-'A', and the F3 activeSlot gate (ungate → 1 named test fails; reviewer's MAIN-A probe now yields no active VFO with slot identities staying `slotted`).
- All four topologies reachable from real capability sets (executed, not assumed); no capability objects/module paths in emitted models; validator-clean outputs for representative states.
- Suites at the full-tree state: adapter suite green, 126/126 new+boundaries, full frontend 2940/2941 (sole failure adjudicated environmental — Node shared-localStorage race, 13/13 standalone), lint/boundaries/svelte-check/i18n/ruff clean.

Linear: MOR-1065 (slice a of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)