### PR TITLE
feat(MOR-1065): wire the semantic VFO surface into the sdr-test layout (slice b)

### DIFF
--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -20,7 +20,7 @@
   import LeftSidebar from './LeftSidebar.svelte';
   import RightSidebar from './RightSidebar.svelte';
   import VfoHeader from './VfoHeader.svelte';
-  import SdrVfoScreen from '../../skins/sdr-test/SdrVfoScreen.svelte';
+  import SemanticRadioSurfaces from '../wiring/SemanticRadioSurfaces.svelte';
   import KeyboardHandler from './KeyboardHandler.svelte';
   import StatusBar from './StatusBar.svelte';
   import MetersDockPanel from '../panels/MetersDockPanel.svelte';
@@ -55,6 +55,13 @@
   import { HardwareButton } from '$lib/Button';
 
   let { skinId = 'desktop-v2' }: { skinId?: SkinId } = $props();
+
+  // MOR-1065: the sdr-test desktop layout is the migrated reference vertical —
+  // its VFO presentation is owned by the semantic surface, so the legacy
+  // twin-VFO block must not also render. desktop-v2 keeps the legacy panels
+  // for the compatibility window (MOR-1099). Slice c additionally passes this
+  // flag to the sidebars as `hideTxPanel`, once they declare that prop.
+  let semanticSurfaces = $derived(skinId === 'sdr-test');
 
   // Reactive state + capabilities — via runtime
   let radioState = $derived(runtime.state);
@@ -199,31 +206,8 @@
   <KeyboardHandler config={keyboardConfig} onAction={keyboardHandlers.dispatch} />
 
   <section class="receiver-deck" bind:this={receiverDeckElement} style={receiverDeckStyle}>
-    {#if skinId === 'sdr-test'}
-      <SdrVfoScreen
-        {mainVfo}
-        {subVfo}
-        splitActive={vfoOps.splitActive}
-        dualWatchActive={vfoOps.dualWatch}
-        txVfo={vfoOps.txVfo}
-        extras={{
-          tunerStatus: (radioState as { tunerStatus?: number } | null)?.tunerStatus,
-          xitActive: (radioState as { ritTx?: boolean } | null)?.ritTx,
-          xitOffset: (radioState as { ritFreq?: number } | null)?.ritFreq,
-          txAntenna: (radioState as { txAntenna?: number } | null)?.txAntenna,
-          main: (radioState as { main?: Record<string, unknown> } | null)?.main ?? null,
-          sub: (radioState as { sub?: Record<string, unknown> } | null)?.sub ?? null,
-        }}
-        onSwap={vfoHandlers.onSwap}
-        onEqual={vfoHandlers.onEqual}
-        onSplitToggle={vfoHandlers.onSplitToggle}
-        onDualWatchToggle={vfoHandlers.onDualWatchToggle}
-        onMainVfoClick={vfoHandlers.onMainVfoClick}
-        onSubVfoClick={vfoHandlers.onSubVfoClick}
-        onMainModeClick={vfoHandlers.onMainModeClick}
-        onSubModeClick={vfoHandlers.onSubModeClick}
-        onSpeak={systemHandlers.onSpeak}
-      />
+    {#if semanticSurfaces}
+      <SemanticRadioSurfaces />
     {:else}
       <VfoHeader
         {mainVfo}

--- a/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
@@ -1,0 +1,258 @@
+/**
+ * MOR-1065 slice b — one current desktop layout migrated to the semantic VFO
+ * surface.
+ *
+ * The migrated layout is `sdr-test`: its VFO presentation is now owned by the
+ * MOR-1063 surface. Two things must hold at once:
+ *   1. the semantic VFO surface renders IN PLACE of the legacy twin-VFO block
+ *      — a layout carrying both would ship two VFO truths;
+ *   2. everything else in that layout (status bar, sidebars — INCLUDING the
+ *      legacy TX panel, which slice c replaces — spectrum, meters dock) is
+ *      untouched, and `desktop-v2` still renders the legacy VFO header for the
+ *      compatibility window (MOR-1099).
+ *
+ * The RX/TX surface, the TX-panel suppression and the CW-survival pin arrive
+ * with slice c, together with the code they pin.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { SkinId } from '../../../skins/registry';
+
+const h = vi.hoisted(() => {
+  const box = { state: null as unknown, caps: null as unknown };
+  return {
+    ...box,
+    runtime: {
+      get state() { return h.state; },
+      get caps() { return h.caps; },
+      connectionStatus: 'disconnected',
+      radioPowerOn: null,
+      connection: { status: 'disconnected', radioPowerOn: null },
+      audio: { rxEnabled: false, txEnabled: false, volume: 50, muted: false },
+      bootstrap: async () => () => {},
+      setPollingMultiplier: () => {},
+      send: () => {},
+    },
+  };
+});
+
+vi.mock('../../../components/spectrum/SpectrumPanel.svelte', async () => {
+  const stub = await import('./SpectrumPanelStub.svelte');
+  return { default: stub.default };
+});
+vi.mock('../../../lib/local-extensions/LocalExtensionsHost.svelte', async () => {
+  const stub = await import('./SpectrumPanelStub.svelte');
+  return { default: stub.default };
+});
+vi.mock('$lib/stores/layout.svelte', () => ({
+  useLcdLayout: vi.fn(() => false),
+  getLayoutMode: vi.fn(() => 'standard'),
+  cycleLayoutMode: vi.fn(),
+  setLayoutMode: vi.fn(),
+}));
+vi.mock('$lib/stores/tuning.svelte', () => ({ applyModeDefault: vi.fn() }));
+vi.mock('$lib/stores/connection.svelte', () => ({
+  getConnectionStatus: vi.fn(() => ({ connected: false })),
+  getRadioPowerOn: vi.fn(() => null),
+  getRadioStatus: vi.fn(() => 'disconnected'),
+  isScopeConnected: vi.fn(() => false),
+  isAudioConnected: vi.fn(() => false),
+  getHttpConnected: vi.fn(() => false),
+  getRigConnected: vi.fn(() => false),
+  getRadioReady: vi.fn(() => false),
+  getRadioHealth: vi.fn(() => null),
+  markScopeFrame: vi.fn(),
+}));
+
+vi.mock('../../../lib/runtime/frontend-runtime', () => ({ runtime: h.runtime }));
+vi.mock('$lib/runtime', () => ({ runtime: h.runtime }));
+
+// MOR-1011: the App TX controller comes from Svelte context that only
+// App.svelte provides; RadioLayout is mounted here without it.
+vi.mock('$lib/runtime/tx-controller/app-host', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('$lib/runtime/tx-controller/app-host')>();
+  const idle = {
+    phase: 'idle', intent: null, guard: null, radioTx: 'off', txRisk: 'none',
+    mayOwnKey: false, fault: null,
+  };
+  return {
+    ...actual,
+    getAppTxController: () => ({
+      snapshot: () => idle,
+      subscribe: () => () => {},
+      start: vi.fn(),
+      setIntent: vi.fn(),
+      release: vi.fn(),
+      resetFault: vi.fn(),
+    }),
+  };
+});
+
+vi.mock('$lib/stores/capabilities.svelte', () => ({
+  hasTx: vi.fn(() => true),
+  hasDualReceiver: vi.fn(() => true),
+  hasAudio: vi.fn(() => false),
+  hasSpectrum: vi.fn(() => true),
+  hasAnyScope: vi.fn(() => false),
+  isAudioFftScope: vi.fn(() => false),
+  hasAudioFft: vi.fn(() => false),
+  getScopeSource: vi.fn(() => null),
+  hasCapability: vi.fn(() => false),
+  vfoLabel: vi.fn((slot: 'A' | 'B') => (slot === 'A' ? 'MAIN' : 'SUB')),
+  receiverLabel: vi.fn((id: 'MAIN' | 'SUB') => id),
+  vfoSlotLabel: vi.fn((slot: 'A' | 'B') => (slot === 'A' ? 'VFO A' : 'VFO B')),
+  getCapabilities: vi.fn(() => ({ freqRanges: [], modes: [], filters: [] })),
+  setCapabilities: vi.fn(),
+  getAgcModes: vi.fn(() => [0, 1, 2, 3]),
+  getAgcLabels: vi.fn(() => ({ 0: 'OFF', 1: 'FAST', 2: 'MID', 3: 'SLOW' })),
+  getSupportedModes: vi.fn(() => ['USB', 'LSB', 'CW', 'AM', 'FM']),
+  getSupportedFilters: vi.fn(() => ['FIL1', 'FIL2', 'FIL3']),
+  getAttValues: vi.fn(() => [0, 10, 20]),
+  getAttLabels: vi.fn(() => ({ 0: '0dB', 10: '10dB', 20: '20dB' })),
+  getPreValues: vi.fn(() => [0, 1, 2]),
+  getPreLabels: vi.fn(() => ({ 0: 'OFF', 1: 'PRE1', 2: 'PRE2' })),
+  getKeyboardConfig: vi.fn(() => null),
+  getVfoScheme: vi.fn(() => 'main_sub'),
+  getAntennaCount: vi.fn(() => 1),
+  getSmeterCalibration: vi.fn(() => null),
+  getSmeterRedline: vi.fn(() => null),
+  getMeterCalibration: vi.fn(() => null),
+  getMeterRedline: vi.fn(() => null),
+  getControlRange: vi.fn(() => ({ min: 0, max: 255 })),
+}));
+
+import RadioLayout from '../RadioLayout.svelte';
+import { hasCapability } from '$lib/stores/capabilities.svelte';
+import { topologyFixtures, type TopologyFixtureId } from '../../../semantic/fixtures/topologies';
+
+const fresh = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' };
+const slot = (freqHz: number) => ({ freqHz, mode: 'USB', filterNum: 1, dataMode: 0 });
+const receiver = (hz: number) => ({
+  ...slot(hz), vfoA: slot(hz), vfoB: slot(hz + 50000), activeSlot: 'A', filter: 1,
+});
+
+function liveState(): unknown {
+  const paths = ['active', 'split', 'dualWatch', 'txTarget'];
+  for (const rx of ['main', 'sub']) {
+    paths.push(`${rx}.freqHz`, `${rx}.mode`, `${rx}.filter`, `${rx}.activeSlot`);
+    for (const v of ['vfoA', 'vfoB']) {
+      paths.push(`${rx}.${v}.freqHz`, `${rx}.${v}.mode`, `${rx}.${v}.filterNum`);
+    }
+  }
+  return {
+    active: 'MAIN', split: false, dualWatch: false, ptt: false,
+    txTarget: { status: 'known', receiver: 'MAIN', slot: 'A', frequencyHz: 14250000 },
+    main: receiver(14250000), sub: receiver(14300000),
+    fieldStatus: Object.fromEntries(paths.map((p) => [p, fresh])),
+  };
+}
+
+/** One representative capability set per canonical topology fixture id. */
+function capsFor(id: TopologyFixtureId): Capabilities {
+  const scheme = topologyFixtures[id].vfoScheme;
+  const dual = scheme === 'ab_shared' || scheme === 'main_sub';
+  return {
+    model: 'fixture', scope: true, audio: true, tx: true,
+    capabilities: dual ? ['scope', 'audio', 'tx', 'dual_rx'] : ['scope', 'audio', 'tx'],
+    receivers: dual ? 2 : 1, vfoScheme: scheme, freqRanges: [], modes: [], filters: [],
+    audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
+    webrtc: { available: false, enabled: false },
+    txBands: [{ start: 14000000, end: 14350000, name: '20m' }],
+    scopeSource: 'hardware', audioFftAvailable: false,
+  } as unknown as Capabilities;
+}
+
+let mounted: ReturnType<typeof mount>[] = [];
+
+function render(skinId: SkinId): HTMLElement {
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+  mounted.push(mount(RadioLayout, { target, props: { skinId } }));
+  flushSync();
+  return target;
+}
+
+beforeEach(() => {
+  mounted = [];
+  h.state = liveState();
+  h.caps = capsFor('2/main_sub');
+  vi.mocked(hasCapability).mockReturnValue(false);
+  Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1440 });
+  Object.defineProperty(window, 'innerHeight', { writable: true, configurable: true, value: 900 });
+});
+
+afterEach(() => {
+  mounted.forEach((c) => unmount(c));
+  document.body.innerHTML = '';
+});
+
+
+describe('the migrated desktop layout owns its VFO through the semantic surface', () => {
+  it('renders the semantic VFO surface inside the receiver deck', () => {
+    const t = render('sdr-test');
+    const deck = t.querySelector('.receiver-deck')!;
+    expect(deck.querySelector('[data-testid="semantic-radio-surfaces"]')).not.toBeNull();
+    expect(deck.querySelector('[data-testid="vfo-surface"]')).not.toBeNull();
+  });
+
+  // MUTATION KILLED: adding the surface alongside the block it replaces. Two
+  // VFO readouts in one layout is exactly the "duplicate presentation
+  // ownership" MOR-1099 exists to retire.
+  it('renders none of the legacy VFO presentation it replaces', () => {
+    const t = render('sdr-test');
+    expect(t.querySelector('.vfo-header')).toBeNull();
+    expect(t.querySelector('.sdr-host')).toBeNull();
+  });
+
+  // The coherent slice-b intermediate: the legacy TX panel is STILL the only
+  // PTT affordance in this layout, so no TX capability is lost between b and c.
+  // Slice c replaces it with the semantic RX/TX surface in the same commit that
+  // introduces `hideTxPanel`.
+  it('leaves the legacy TX panel in place until the RX/TX surface lands', () => {
+    const t = render('sdr-test');
+    expect(t.querySelector('[data-panel-id="tx"]')).not.toBeNull();
+    expect(t.querySelector('[data-testid="rx-tx-surface"]')).toBeNull();
+  });
+
+  it('leaves the rest of the layout intact', () => {
+    const t = render('sdr-test');
+    expect(t.querySelector('.radio-layout.sdr-test')).not.toBeNull();
+    expect(t.querySelector('.content-left .left-sidebar')).not.toBeNull();
+    expect(t.querySelector('.content-right .right-sidebar')).not.toBeNull();
+    expect(t.querySelector('.center-column .spectrum-slot')).not.toBeNull();
+    expect(t.querySelector('.spectrum-panel-stub')).not.toBeNull();
+    expect(t.querySelector('.bottom-dock')).not.toBeNull();
+    expect(t.querySelector('[data-panel-id="rx-audio"]')).not.toBeNull();
+    expect(t.querySelector('[data-panel-id="memory"]')).not.toBeNull();
+  });
+
+  it.each(['1/single', '1/ab', '2/ab_shared', '2/main_sub'] as const)(
+    'renders safely on the %s topology', (id) => {
+      h.caps = capsFor(id);
+      const t = render('sdr-test');
+      const tiles = t.querySelectorAll('[data-vfo-tile]');
+      expect(tiles.length).toBe(topologyFixtures[id].vfos.length);
+      expect(t.querySelector('[data-testid="vfo-surface"]')).not.toBeNull();
+    },
+  );
+
+  it('renders the chrome but no surface when capabilities have not loaded', () => {
+    h.caps = null;
+    const t = render('sdr-test');
+    expect(t.querySelector('.receiver-deck')).not.toBeNull();
+    expect(t.querySelector('[data-testid="vfo-surface"]')).toBeNull();
+  });
+});
+
+describe('the unmigrated desktop layout is unchanged', () => {
+  // MUTATION KILLED: flipping the whole desktop family over in one step. The
+  // compatibility window (MOR-1099) requires desktop-v2 to keep the legacy
+  // panels until the parity programme (MOR-1084) clears them.
+  it('keeps the legacy VFO header and TX panel on desktop-v2', () => {
+    const t = render('desktop-v2');
+    expect(t.querySelector('.receiver-deck .vfo-header')).not.toBeNull();
+    expect(t.querySelector('[data-panel-id="tx"]')).not.toBeNull();
+    expect(t.querySelector('[data-testid="semantic-radio-surfaces"]')).toBeNull();
+  });
+});

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -1,0 +1,60 @@
+<!--
+  Wiring for the semantic VFO surface (MOR-1065, slice b).
+
+  This is the ONLY place the pure VFO surface meets live state: it derives the
+  MOR-1062 view model from the real runtime through
+  `lib/runtime/adapters/radio-view-model-adapter` and turns the surface's
+  callback intents into commands. The surface itself stays presentation-only.
+
+  Slice c adds the RX/TX half to this file: the App-owned TX authority
+  (v3 ADR invariant 11 — `lib/runtime/tx-controller/app-host`, provided once by
+  App.svelte), the RX/TX surface, the fault-recovery affordance, and the
+  MOR-617 preflight. Until then `sdr-test` keeps the legacy TxPanel in the
+  sidebars, so this layout has exactly one PTT affordance and loses no
+  capability. The authoritative global TX lamp stays in AppGlobalHost
+  (MOR-1059) throughout and is never duplicated here.
+-->
+<script lang="ts">
+  import { runtime } from '$lib/runtime';
+  import { toRadioViewModel } from '$lib/runtime/adapters/radio-view-model-adapter';
+  import type { RadioViewModel } from '../../semantic/radio-view-model';
+  import VfoSurface, { type VfoSelection } from '../../semantic/VfoSurface.svelte';
+  import { makeVfoHandlers } from './command-bus';
+
+  const vfo = makeVfoHandlers();
+
+  // Belt-and-braces contract pin. The adapter annotates its own return type
+  // (MOR-1065 ruling 2), so this is the second of two compile-time links.
+  let view: RadioViewModel | null = $derived(toRadioViewModel(runtime.state, runtime.caps));
+
+  function selectVfo(target: VfoSelection): void {
+    vfo.onVfoSelect(target.receiver, target.slot.kind === 'slotted' ? target.slot.id : null);
+  }
+  function toggleDualWatch(): void {
+    if (view?.dualWatch.status === 'known') vfo.onDualWatchToggle(!view.dualWatch.value);
+  }
+</script>
+
+<div class="semantic-surfaces" data-testid="semantic-radio-surfaces">
+  {#if view}
+    <VfoSurface
+      viewModel={view}
+      onSelectVfo={selectVfo}
+      onToggleSplit={vfo.onSplitToggle}
+      onToggleDualWatch={toggleDualWatch}
+    />
+  {/if}
+</div>
+
+<style>
+  /* Layout only — the surfaces own their own presentation. */
+  .semantic-surfaces {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    height: 100%;
+    overflow: auto;
+    font-family: 'Roboto Mono', monospace;
+    color: var(--v2-text-primary, #e8e8e8);
+  }
+</style>

--- a/frontend/src/components-v2/wiring/__tests__/semantic-rx-tx-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rx-tx-wiring.component.test.ts
@@ -1,0 +1,153 @@
+/**
+ * MOR-1065 slice b — the semantic VFO surface wired to live runtime state.
+ *
+ * Slice b owns the VFO half only: the adapter output actually reaching a
+ * mounted surface, and the surface's selection/toggle intents reaching the
+ * command bus with the real slot identity. Every TX assertion — authority
+ * snapshot pass-through, owner identity, ungated unkey, teardown release,
+ * fault recovery, and the MOR-617 preflight — arrives with the TX half in
+ * slice c, together with the code it pins.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { ServerState } from '$lib/types/state';
+
+const h = vi.hoisted(() => ({
+  state: null as unknown,
+  caps: null as unknown,
+  selectVfo: vi.fn(),
+  splitToggle: vi.fn(),
+  dualWatchToggle: vi.fn(),
+}));
+
+vi.mock('$lib/runtime', () => ({
+  runtime: {
+    get state() { return h.state; },
+    get caps() { return h.caps; },
+  },
+}));
+vi.mock('../command-bus', () => ({
+  makeVfoHandlers: () => ({
+    onVfoSelect: h.selectVfo,
+    onSplitToggle: h.splitToggle,
+    onDualWatchToggle: h.dualWatchToggle,
+  }),
+}));
+
+import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';
+
+const fresh = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' };
+const slot = (freqHz: number) => ({ freqHz, mode: 'USB', filterNum: 1, dataMode: 0 });
+
+function liveState(): ServerState {
+  const paths = ['active', 'split', 'dualWatch', 'txTarget'];
+  for (const rx of ['main', 'sub']) {
+    paths.push(`${rx}.freqHz`, `${rx}.mode`, `${rx}.filter`, `${rx}.activeSlot`);
+    for (const v of ['vfoA', 'vfoB']) {
+      paths.push(`${rx}.${v}.freqHz`, `${rx}.${v}.mode`, `${rx}.${v}.filterNum`);
+    }
+  }
+  const receiver = (hz: number) => ({
+    ...slot(hz), vfoA: slot(hz), vfoB: slot(hz + 50000), activeSlot: 'A', filter: 1,
+  });
+  return {
+    active: 'MAIN', split: false, dualWatch: false, ptt: false,
+    txTarget: { status: 'known', receiver: 'MAIN', slot: 'A', frequencyHz: 14250000 },
+    main: receiver(14250000), sub: receiver(14300000),
+    fieldStatus: Object.fromEntries(paths.map((p) => [p, fresh])),
+  } as unknown as ServerState;
+}
+
+const liveCaps = (): Capabilities => ({
+  model: 'fixture', scope: false, audio: true, tx: true,
+  capabilities: ['audio', 'tx', 'dual_rx'], receivers: 2, vfoScheme: 'main_sub',
+  freqRanges: [], modes: [], filters: [],
+  audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
+  webrtc: { available: false, enabled: false },
+  txBands: [{ start: 14000000, end: 14350000, name: '20m' }],
+  scopeSource: null, audioFftAvailable: false,
+} as unknown as Capabilities);
+
+let target: HTMLDivElement;
+let component: ReturnType<typeof mount> | null = null;
+
+function render(): void {
+  target = document.createElement('div');
+  document.body.appendChild(target);
+  component = mount(SemanticRadioSurfaces, { target });
+  flushSync();
+}
+
+const q = <T extends HTMLElement>(sel: string) => target.querySelector(sel) as T | null;
+
+beforeEach(() => {
+  h.state = liveState();
+  h.caps = liveCaps();
+  h.selectVfo = vi.fn();
+  h.splitToggle = vi.fn();
+  h.dualWatchToggle = vi.fn();
+});
+
+afterEach(() => {
+  if (component) unmount(component);
+  component = null;
+  document.body.innerHTML = '';
+});
+
+describe('the VFO surface renders from the live adapter output', () => {
+  it('mounts the semantic VFO surface with the derived view model', () => {
+    render();
+    expect(q('[data-testid="vfo-surface"]')).not.toBeNull();
+    expect(target.querySelectorAll('[data-vfo-tile]')).toHaveLength(4);
+    expect(q('[data-testid="vfo-active-receiver"]')?.dataset.activeReceiver).toBe('MAIN');
+  });
+
+  // MUTATION KILLED: rendering the surface against a fabricated fallback model
+  // when capabilities have not loaded. There is no safe default topology.
+  it('renders no surface at all rather than guessing when capabilities are absent', () => {
+    h.caps = null;
+    render();
+    expect(q('[data-testid="vfo-surface"]')).toBeNull();
+    expect(q('[data-testid="semantic-radio-surfaces"]')).not.toBeNull();
+  });
+
+  it('routes the VFO selection intent to the command bus with the real slot id', () => {
+    render();
+    const buttons = [...target.querySelectorAll<HTMLButtonElement>('[data-vfo-select]')];
+    buttons[0].click();
+    flushSync();
+    expect(h.selectVfo).toHaveBeenCalledWith('MAIN', 'B');
+  });
+
+  it('routes the split toggle straight through to the command bus', () => {
+    render();
+    q<HTMLButtonElement>('[data-vfo-split]')!.click();
+    flushSync();
+    expect(h.splitToggle).toHaveBeenCalledTimes(1);
+  });
+
+  // MUTATION KILLED: sending a blind `true` (or the current value) for
+  // dual-watch instead of its negation — the toggle would latch rather than
+  // toggle.
+  it('sends the negated dual-watch value', () => {
+    render();
+    q<HTMLButtonElement>('[data-vfo-dual-watch]')!.click();
+    flushSync();
+    expect(h.dualWatchToggle).toHaveBeenCalledWith(true);
+  });
+
+  // MUTATION KILLED: dropping the `status === 'known'` guard in
+  // `toggleDualWatch` — an unobserved fact has no defined negation, so the
+  // wiring would command a value it invented. (The surface also disables the
+  // control; this pins the wiring's own half of the two-level gate.)
+  it('commands nothing for an unobserved dual-watch fact', () => {
+    h.state = { ...liveState(), fieldStatus: {} } as unknown as ServerState;
+    render();
+    const toggle = q<HTMLButtonElement>('[data-vfo-dual-watch]')!;
+    expect(toggle.getAttribute('aria-checked')).toBe('mixed');
+    toggle.click();
+    flushSync();
+    expect(h.dualWatchToggle).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components-v2/wiring/__tests__/vfo-wiring.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/vfo-wiring.test.ts
@@ -216,6 +216,48 @@ describe('makeVfoHandlers', () => {
       expect(audioManager.setAudioConfig).toHaveBeenCalledWith({ focus: 'sub' });
     });
   });
+
+  // MOR-1065 — the semantic VFO surface's selection intent.
+  describe('onVfoSelect', () => {
+    beforeEach(() => {
+      vi.mocked(audioManager.setAudioConfig).mockClear();
+      vi.mocked(patchRadioState).mockClear();
+    });
+
+    it('activates the receiver and the addressed A/B slot', () => {
+      vi.mocked(getRadioState).mockReturnValue({ active: 'MAIN' } as any);
+
+      makeVfoHandlers().onVfoSelect('SUB', 'B');
+
+      expect(patchRadioState).toHaveBeenCalledWith({ active: 'SUB' });
+      expect(audioManager.setAudioConfig).toHaveBeenCalledWith({ focus: 'sub' });
+      expect(sendCommand).toHaveBeenCalledWith('set_vfo', { vfo: 'SUB' });
+      expect(sendCommand).toHaveBeenCalledWith('set_vfo', { vfo: 'B' });
+    });
+
+    // MUTATION KILLED: defaulting an unslotted position to `vfo: 'A'` — the
+    // topology has no A/B to address and the radio would be re-slotted behind
+    // the operator's back.
+    it('sends no slot command for an unslotted position', () => {
+      vi.mocked(getRadioState).mockReturnValue({ active: 'MAIN' } as any);
+
+      makeVfoHandlers().onVfoSelect('SUB', null);
+
+      expect(sendCommand).toHaveBeenCalledWith('set_vfo', { vfo: 'SUB' });
+      expect(sendCommand).not.toHaveBeenCalledWith('set_vfo', { vfo: 'A' });
+      expect(sendCommand).toHaveBeenCalledTimes(1);
+    });
+
+    it('switches slot without re-selecting the receiver already in use', () => {
+      vi.mocked(getRadioState).mockReturnValue({ active: 'MAIN' } as any);
+
+      makeVfoHandlers().onVfoSelect('MAIN', 'B');
+
+      expect(patchRadioState).not.toHaveBeenCalled();
+      expect(sendCommand).toHaveBeenCalledTimes(1);
+      expect(sendCommand).toHaveBeenCalledWith('set_vfo', { vfo: 'B' });
+    });
+  });
 });
 
 describe('makeModeHandlers', () => {

--- a/frontend/src/components-v2/wiring/command-bus.ts
+++ b/frontend/src/components-v2/wiring/command-bus.ts
@@ -118,6 +118,15 @@ export function makeVfoHandlers() {
     },
     onMainVfoClick: () => _activateReceiver('MAIN'),
     onSubVfoClick: () => _activateReceiver('SUB'),
+    /** Semantic VFO selection (MOR-1065): activate the receiver, then the A/B
+     *  slot when the topology has one. `set_vfo` carries either identity
+     *  (`command_service._active_receiver_value` / `_active_slot_value`).
+     *  `slot === null` means the position has no addressable slot — never a
+     *  guessed 'A'. */
+    onVfoSelect: (receiver: 'MAIN' | 'SUB', slot: 'A' | 'B' | null) => {
+      if (getRadioState()?.active !== receiver) _activateReceiver(receiver);
+      if (slot !== null) cmd('set_vfo', { vfo: slot });
+    },
     onMainModeClick: () => focusModePanel('MAIN'),
     onSubModeClick: () => focusModePanel('SUB'),
     onMainFreqChange: (freq: number) => {


### PR DESCRIPTION
## Summary

Slice **b** of the independently reviewed MOR-1065 desktop migration (manifest a0 → a → b → c):

- `wiring/SemanticRadioSurfaces.svelte` (new, VFO half): mounts `VfoSurface` on the slice-a adapter's `RadioViewModel`; select/split/dual-watch intents dispatch through `command-bus` (+9). The TX half arrives in slice c.
- `RadioLayout.svelte` (+10/−26): the sdr-test screen mounts the semantic wiring in place of the legacy VFO block. Per review Ruling 1: `sdr-test` is the sanctioned "one current desktop layout" (desktop-v2 stays legacy through the MOR-1099 compatibility window), and the ticket's "preserving current visuals" clause is **re-scoped** — the migrated deck's visuals intentionally change.
- Intermediate coherence: this slice's layout test **positively asserts the legacy TX panel is still present** — the TX migration is slice c's diff, reviewed as such.

## Independent verification (within the full MOR-1065 review)

- The b-state (exactly these file versions against the merged a0+a) was proven green standalone: 368 tests / 13 touched files, svelte-check 4327 files 0 errors, lint + lint:boundaries clean.
- VFO wiring behaviors verified in the full review: intents carry correct identities, adapter unknowns render explicitly, CW path unaffected.
- Slice boundaries per the reviewer's manifest; no production file straddles a/b.

Linear: MOR-1065 (slice b of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)