### PR TITLE
feat(MOR-1065): wire the semantic RX/TX surface with lease-safe teardown (slice c)

### DIFF
--- a/frontend/src/components-v2/layout/LeftSidebar.svelte
+++ b/frontend/src/components-v2/layout/LeftSidebar.svelte
@@ -17,6 +17,11 @@
   import CollapsiblePanel from '../controls/CollapsiblePanel.svelte';
   import { createDragReorder } from '$lib/drag-reorder.svelte';
 
+  /** MOR-1065: mirrors RightSidebar. The TX panel is not in this sidebar's
+   *  defaults, but a cross-sidebar drag can move it here, so the semantic
+   *  layout's TX suppression has to hold on both sides. */
+  let { hideTxPanel = false }: { hideTxPanel?: boolean } = $props();
+
   // Reactive state + capabilities — via runtime
   let caps = $derived(runtime.caps);
 
@@ -105,7 +110,7 @@
     </CollapsiblePanel>
   {/if}
 
-  {#if drag.order.includes('tx')}
+  {#if !hideTxPanel && drag.order.includes('tx')}
     <CollapsiblePanel title="TX" panelId="tx" draggable onDragStart={drag.handleDragStart} style={drag.dragStyle('tx')}>
       <TxPanel />
     </CollapsiblePanel>

--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -57,10 +57,9 @@
   let { skinId = 'desktop-v2' }: { skinId?: SkinId } = $props();
 
   // MOR-1065: the sdr-test desktop layout is the migrated reference vertical —
-  // its VFO presentation is owned by the semantic surface, so the legacy
-  // twin-VFO block must not also render. desktop-v2 keeps the legacy panels
-  // for the compatibility window (MOR-1099). Slice c additionally passes this
-  // flag to the sidebars as `hideTxPanel`, once they declare that prop.
+  // its VFO and TX presentation is owned by the semantic surfaces, so the
+  // legacy twin-VFO block and the sidebars' TX panel must not also render.
+  // desktop-v2 keeps the legacy panels for the compatibility window (MOR-1099).
   let semanticSurfaces = $derived(skinId === 'sdr-test');
 
   // Reactive state + capabilities — via runtime
@@ -238,7 +237,7 @@
 
   <section class="content-row">
     <div class="content-left">
-      <LeftSidebar />
+      <LeftSidebar hideTxPanel={semanticSurfaces} />
     </div>
 
     <main class="content-center center-column">
@@ -255,7 +254,7 @@
     </main>
 
     <div class="content-right">
-      <RightSidebar />
+      <RightSidebar hideTxPanel={semanticSurfaces} />
     </div>
   </section>
 

--- a/frontend/src/components-v2/layout/RightSidebar.svelte
+++ b/frontend/src/components-v2/layout/RightSidebar.svelte
@@ -13,9 +13,13 @@
 
   interface Props {
     mode?: RightSidebarMode;
+    /** MOR-1065: a layout whose TX presentation is owned by the semantic RX/TX
+     *  surface suppresses the legacy TX panel, so no layout ships two PTT
+     *  affordances at once. Scoped to the TX panel — CW is unaffected. */
+    hideTxPanel?: boolean;
   }
 
-  let { mode = 'all' }: Props = $props();
+  let { mode = 'all', hideTxPanel = false }: Props = $props();
 
   let showRx = $derived(mode === 'all' || mode === 'rx');
   let showTx = $derived(mode === 'all' || mode === 'tx');
@@ -47,7 +51,7 @@
     </CollapsiblePanel>
   {/if}
 
-  {#if showTx && drag.order.includes('tx')}
+  {#if showTx && !hideTxPanel && drag.order.includes('tx')}
     <CollapsiblePanel title="TX" panelId="tx" draggable onDragStart={drag.handleDragStart} style={drag.dragStyle('tx')}>
       <TxPanel />
     </CollapsiblePanel>

--- a/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
@@ -1,18 +1,14 @@
 /**
- * MOR-1065 slice b — one current desktop layout migrated to the semantic VFO
- * surface.
+ * MOR-1065 — one current desktop layout migrated to the semantic surfaces.
  *
- * The migrated layout is `sdr-test`: its VFO presentation is now owned by the
- * MOR-1063 surface. Two things must hold at once:
- *   1. the semantic VFO surface renders IN PLACE of the legacy twin-VFO block
- *      — a layout carrying both would ship two VFO truths;
- *   2. everything else in that layout (status bar, sidebars — INCLUDING the
- *      legacy TX panel, which slice c replaces — spectrum, meters dock) is
- *      untouched, and `desktop-v2` still renders the legacy VFO header for the
- *      compatibility window (MOR-1099).
- *
- * The RX/TX surface, the TX-panel suppression and the CW-survival pin arrive
- * with slice c, together with the code they pin.
+ * The migrated layout is `sdr-test`: its VFO and TX presentation is now owned
+ * by the MOR-1063 / MOR-1064 surfaces. Two things must hold at once:
+ *   1. the semantic surfaces render IN PLACE of the legacy twin-VFO block and
+ *      the sidebar TX panel — a layout carrying both would ship two PTT
+ *      affordances and two VFO truths;
+ *   2. everything else in that layout (status bar, sidebars, spectrum, meters
+ *      dock) is untouched, and `desktop-v2` still renders the legacy panels
+ *      for the compatibility window (MOR-1099).
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
@@ -187,32 +183,25 @@ afterEach(() => {
   document.body.innerHTML = '';
 });
 
-
-describe('the migrated desktop layout owns its VFO through the semantic surface', () => {
-  it('renders the semantic VFO surface inside the receiver deck', () => {
+describe('the migrated desktop layout owns VFO/TX through the semantic surfaces', () => {
+  it('renders both surfaces inside the receiver deck', () => {
     const t = render('sdr-test');
     const deck = t.querySelector('.receiver-deck')!;
     expect(deck.querySelector('[data-testid="semantic-radio-surfaces"]')).not.toBeNull();
     expect(deck.querySelector('[data-testid="vfo-surface"]')).not.toBeNull();
+    expect(deck.querySelector('[data-testid="rx-tx-surface"]')).not.toBeNull();
   });
 
-  // MUTATION KILLED: adding the surface alongside the block it replaces. Two
-  // VFO readouts in one layout is exactly the "duplicate presentation
-  // ownership" MOR-1099 exists to retire.
-  it('renders none of the legacy VFO presentation it replaces', () => {
+  // MUTATION KILLED: adding the surfaces alongside the panels they replace.
+  // Two PTT affordances and two VFO readouts in one layout is exactly the
+  // "duplicate presentation ownership" MOR-1099 exists to retire.
+  it('renders none of the legacy VFO/TX presentation it replaces', () => {
     const t = render('sdr-test');
     expect(t.querySelector('.vfo-header')).toBeNull();
     expect(t.querySelector('.sdr-host')).toBeNull();
-  });
-
-  // The coherent slice-b intermediate: the legacy TX panel is STILL the only
-  // PTT affordance in this layout, so no TX capability is lost between b and c.
-  // Slice c replaces it with the semantic RX/TX surface in the same commit that
-  // introduces `hideTxPanel`.
-  it('leaves the legacy TX panel in place until the RX/TX surface lands', () => {
-    const t = render('sdr-test');
-    expect(t.querySelector('[data-panel-id="tx"]')).not.toBeNull();
-    expect(t.querySelector('[data-testid="rx-tx-surface"]')).toBeNull();
+    expect(t.querySelector('.tx-panel')).toBeNull();
+    expect(t.querySelector('[data-testid="tx-strip"]')).toBeNull();
+    expect(t.querySelector('[data-panel-id="tx"]')).toBeNull();
   });
 
   it('leaves the rest of the layout intact', () => {
@@ -223,8 +212,20 @@ describe('the migrated desktop layout owns its VFO through the semantic surface'
     expect(t.querySelector('.center-column .spectrum-slot')).not.toBeNull();
     expect(t.querySelector('.spectrum-panel-stub')).not.toBeNull();
     expect(t.querySelector('.bottom-dock')).not.toBeNull();
+    // Non-TX sidebar panels are untouched by the TX suppression.
     expect(t.querySelector('[data-panel-id="rx-audio"]')).not.toBeNull();
     expect(t.querySelector('[data-panel-id="memory"]')).not.toBeNull();
+  });
+
+  // MUTATION KILLED: widening `hideTxPanel` to the sidebar's whole `showTx`
+  // branch, which also guards CW. The suppression is TX-panel-scoped by
+  // construction, but nothing pinned it — `hasCapability` is mocked false
+  // everywhere else in this file, so the CW block never renders to be checked.
+  it('keeps the CW panel, which shares the sidebar\'s TX branch', () => {
+    vi.mocked(hasCapability).mockImplementation((tag: string) => tag === 'cw');
+    const t = render('sdr-test');
+    expect(t.querySelector('[data-panel-id="cw"]')).not.toBeNull();
+    expect(t.querySelector('[data-panel-id="tx"]')).toBeNull();
   });
 
   it.each(['1/single', '1/ab', '2/ab_shared', '2/main_sub'] as const)(
@@ -233,15 +234,16 @@ describe('the migrated desktop layout owns its VFO through the semantic surface'
       const t = render('sdr-test');
       const tiles = t.querySelectorAll('[data-vfo-tile]');
       expect(tiles.length).toBe(topologyFixtures[id].vfos.length);
-      expect(t.querySelector('[data-testid="vfo-surface"]')).not.toBeNull();
+      expect(t.querySelector('[data-testid="rx-tx-surface"]')).not.toBeNull();
     },
   );
 
-  it('renders the chrome but no surface when capabilities have not loaded', () => {
+  it('renders the chrome but no surfaces when capabilities have not loaded', () => {
     h.caps = null;
     const t = render('sdr-test');
     expect(t.querySelector('.receiver-deck')).not.toBeNull();
     expect(t.querySelector('[data-testid="vfo-surface"]')).toBeNull();
+    expect(t.querySelector('[data-testid="rx-tx-surface"]')).toBeNull();
   });
 });
 

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -1,31 +1,84 @@
 <!--
-  Wiring for the semantic VFO surface (MOR-1065, slice b).
+  Wiring for the semantic VFO + RX/TX reference vertical (MOR-1065).
 
-  This is the ONLY place the pure VFO surface meets live state: it derives the
+  This is the ONLY place the two pure surfaces meet live state: it derives the
   MOR-1062 view model from the real runtime through
-  `lib/runtime/adapters/radio-view-model-adapter` and turns the surface's
-  callback intents into commands. The surface itself stays presentation-only.
-
-  Slice c adds the RX/TX half to this file: the App-owned TX authority
-  (v3 ADR invariant 11 — `lib/runtime/tx-controller/app-host`, provided once by
-  App.svelte), the RX/TX surface, the fault-recovery affordance, and the
-  MOR-617 preflight. Until then `sdr-test` keeps the legacy TxPanel in the
-  sidebars, so this layout has exactly one PTT affordance and loses no
-  capability. The authoritative global TX lamp stays in AppGlobalHost
-  (MOR-1059) throughout and is never duplicated here.
+  `lib/runtime/adapters/radio-view-model-adapter`, hands the RX/TX surface a
+  snapshot of the App-owned TX authority (v3 ADR invariant 11 — the controller
+  in `lib/runtime/tx-controller/app-host`, provided once by App.svelte), and
+  turns the surfaces' callback intents into commands. The surfaces themselves
+  stay presentation-only; the authoritative global TX lamp stays in
+  AppGlobalHost (MOR-1059) and is not duplicated here.
 -->
+<script module lang="ts">
+  /**
+   * Per-instance TX lease identity. The App TX controller keys lease ownership
+   * by `sourceId`: an id recomputed per render — or shared with another mounted
+   * source — makes `release()` a silent no-op and can strand a key DOWN. Same
+   * identity discipline as TxPanel (MOR-1011) and the MOR-1221/1226 audits.
+   */
+  let surfaceSeq = 0;
+</script>
+
 <script lang="ts">
+  import { onDestroy } from 'svelte';
   import { runtime } from '$lib/runtime';
   import { toRadioViewModel } from '$lib/runtime/adapters/radio-view-model-adapter';
+  import { getAppTxController } from '$lib/runtime/tx-controller/app-host';
   import type { RadioViewModel } from '../../semantic/radio-view-model';
+  import RxTxSurface from '../../semantic/RxTxSurface.svelte';
   import VfoSurface, { type VfoSelection } from '../../semantic/VfoSurface.svelte';
+  import ModInputTxWarning from '../panels/ModInputTxWarning.svelte';
   import { makeVfoHandlers } from './command-bus';
 
   const vfo = makeVfoHandlers();
+  const tx = getAppTxController();
+  const sourceId = `semantic-rx-tx-${++surfaceSeq}`;
+  let leaseSeq = 0;
 
-  // Belt-and-braces contract pin. The adapter annotates its own return type
-  // (MOR-1065 ruling 2), so this is the second of two compile-time links.
+  let txState = $state.raw(tx.snapshot());
+  const stopWatchingTx = tx.subscribe((next) => { txState = next; });
+
+  onDestroy(() => {
+    // Unsubscribe FIRST: the release below is fail-closed and must run to
+    // completion inside the controller, not bounce back into a component that
+    // is already being destroyed (TxPanel's documented teardown order).
+    stopWatchingTx();
+    // `requestKey` starts a LATCHED lease — it outlives this component. The
+    // App TX controller keeps the lease across a presentation swap (MOR-1060
+    // destroys this subtree on any skinId change), the model refuses a release
+    // from any other sourceId, and `start` is a no-op off-idle: without this,
+    // swapping away while keyed STRANDS the transmitter with no UI exit.
+    // Same fail-safe direction as MobileRadioLayout's recognizer teardown
+    // ("rotating away while keyed or latched drops TX rather than stranding
+    // it") and TxPanel's `ptt.destroy()`. Blind release is safe — the model's
+    // owner check makes it inert when another source holds the lease.
+    const guard = tx.snapshot().guard;
+    if (guard) tx.release(sourceId, guard);
+  });
+
+  // Belt-and-braces contract pin. The adapter now annotates its own return
+  // type (MOR-1065 ruling 2), so this is the second of two compile-time links.
   let view: RadioViewModel | null = $derived(toRadioViewModel(runtime.state, runtime.caps));
+
+  // Bound once per instance, never per render — see `surfaceSeq` above.
+  function requestKey(): void {
+    tx.start(sourceId, `${sourceId}-${++leaseSeq}`, 'latched');
+  }
+  /** NEVER gated. Reads the LIVE authority guard and releases: no phase,
+   *  permit, fault or view-model condition may stand between the operator and
+   *  stopping transmission. */
+  function requestUnkey(): void {
+    const guard = tx.snapshot().guard;
+    if (guard) tx.release(sourceId, guard);
+  }
+  /** App-owned fault recovery (MOR-1065 wiring decision, recorded on the
+   *  ticket). The pure RX/TX surface deliberately has no `resetFault` intent,
+   *  and a `failed` phase blocks the key action — without this affordance in
+   *  the layout chrome the operator has no UI exit from a fault. */
+  function clearFault(): void {
+    tx.resetFault();
+  }
 
   function selectVfo(target: VfoSelection): void {
     vfo.onVfoSelect(target.receiver, target.slot.kind === 'slotted' ? target.slot.id : null);
@@ -43,6 +96,24 @@
       onToggleSplit={vfo.onSplitToggle}
       onToggleDualWatch={toggleDualWatch}
     />
+    <RxTxSurface {view} tx={txState} onRequestKey={requestKey} onRequestUnkey={requestUnkey} />
+  {/if}
+
+  <!--
+    MOR-617 network-voice-TX preflight. It ships inside TxPanel, which this
+    layout suppresses (`hideTxPanel`) — but this layout can now key network
+    voice TX, and the controller's `start-audio` effect IS that path. Without
+    the banner the operator keys with a mis-routed MOD input, no warning and no
+    one-click "Set LAN" fix: the exact shape of the "web voice TX = noise" bug.
+    Self-gating on `deriveModInputTxGuardProps().visible`, so the trigger
+    conditions are byte-identical to the panel's.
+  -->
+  <ModInputTxWarning />
+
+  {#if txState.phase === 'failed'}
+    <button
+      type="button" class="tx-fault-reset" data-testid="tx-fault-reset" onclick={clearFault}
+    >Clear TX fault</button>
   {/if}
 </div>
 
@@ -56,5 +127,15 @@
     overflow: auto;
     font-family: 'Roboto Mono', monospace;
     color: var(--v2-text-primary, #e8e8e8);
+  }
+  .tx-fault-reset {
+    align-self: flex-start;
+    padding: 3px 8px;
+    border: 1px solid var(--v2-accent-red, #ef4444);
+    border-radius: 4px;
+    background: transparent;
+    color: var(--v2-accent-red, #ef4444);
+    font: inherit;
+    cursor: pointer;
   }
 </style>

--- a/frontend/src/components-v2/wiring/__tests__/semantic-rx-tx-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rx-tx-wiring.component.test.ts
@@ -1,24 +1,48 @@
 /**
- * MOR-1065 slice b — the semantic VFO surface wired to live runtime state.
+ * MOR-1065 — the semantic RX/TX surface wired to the REAL App TX authority.
  *
- * Slice b owns the VFO half only: the adapter output actually reaching a
- * mounted surface, and the surface's selection/toggle intents reaching the
- * command bus with the real slot identity. Every TX assertion — authority
- * snapshot pass-through, owner identity, ungated unkey, teardown release,
- * fault recovery, and the MOR-617 preflight — arrives with the TX half in
- * slice c, together with the code it pins.
+ * SAFETY-CRITICAL. This is the first slice where the pure surface's key/unkey
+ * intents reach a controller, so the failure modes are operational, not
+ * cosmetic:
+ *   (a) a lease owner identity that changes between `start` and `release`,
+ *       which makes unkey a silent no-op and strands a key DOWN
+ *       (the MOR-1221/1226 identity discipline);
+ *   (b) any condition inserted in front of the unkey path;
+ *   (c) a `failed` phase with no App-owned way out (the RX/TX surface has no
+ *       `resetFault` intent by design — recorded on the ticket).
+ *
+ * The controller here is a spy that records the exact `sourceId` and guard it
+ * is handed; the surfaces are the real ones.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
 import type { Capabilities } from '$lib/types/capabilities';
 import type { ServerState } from '$lib/types/state';
 
+type Snapshot = {
+  phase: string; intent: string | null; guard: { leaseId: string } | null;
+  radioTx: string; txRisk: string; mayOwnKey: boolean; fault: string | null;
+};
+
 const h = vi.hoisted(() => ({
   state: null as unknown,
   caps: null as unknown,
+  snapshot: null as unknown,
+  listeners: new Set<(next: unknown) => void>(),
+  start: vi.fn(),
+  release: vi.fn(),
+  setIntent: vi.fn(),
+  resetFault: vi.fn(),
   selectVfo: vi.fn(),
   splitToggle: vi.fn(),
   dualWatchToggle: vi.fn(),
+  setLan: vi.fn(),
+  dismissWarning: vi.fn(),
+  modInputGuard: { visible: false, sourceLabel: null } as { visible: boolean; sourceLabel: string | null },
+  subscribeCalls: 0,
+  unsubscribeCalls: 0,
+  /** `listeners.size` sampled at the instant each `release` re-enters. */
+  listenersAtRelease: [] as number[],
 }));
 
 vi.mock('$lib/runtime', () => ({
@@ -26,6 +50,31 @@ vi.mock('$lib/runtime', () => ({
     get state() { return h.state; },
     get caps() { return h.caps; },
   },
+}));
+vi.mock('$lib/runtime/tx-controller/app-host', () => ({
+  getAppTxController: () => ({
+    snapshot: () => h.snapshot,
+    subscribe: (listener: (next: unknown) => void) => {
+      h.subscribeCalls += 1;
+      h.listeners.add(listener);
+      return () => { h.unsubscribeCalls += 1; h.listeners.delete(listener); };
+    },
+    start: h.start,
+    setIntent: h.setIntent,
+    // Sample the live subscription count at the instant release re-enters —
+    // this is what makes the teardown ORDER observable (see the teardown suite).
+    release: (...args: unknown[]) => {
+      h.listenersAtRelease.push(h.listeners.size);
+      return (h.release as (...a: unknown[]) => unknown)(...args);
+    },
+    resetFault: h.resetFault,
+  }),
+}));
+// The MOR-617 preflight's own adapter — stubbed so the test drives the
+// warning's real trigger condition (`visible`) without a live TX guard.
+vi.mock('$lib/runtime/adapters/mod-input-tx-guard.svelte', () => ({
+  deriveModInputTxGuardProps: () => h.modInputGuard,
+  getModInputTxGuardHandlers: () => ({ onSetLan: h.setLan, onDismiss: h.dismissWarning }),
 }));
 vi.mock('../command-bus', () => ({
   makeVfoHandlers: () => ({
@@ -36,6 +85,11 @@ vi.mock('../command-bus', () => ({
 }));
 
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';
+
+const IDLE: Snapshot = {
+  phase: 'idle', intent: null, guard: null, radioTx: 'off', txRisk: 'none',
+  mayOwnKey: false, fault: null,
+};
 
 const fresh = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' };
 const slot = (freqHz: number) => ({ freqHz, mode: 'USB', filterNum: 1, dataMode: 0 });
@@ -79,14 +133,33 @@ function render(): void {
   flushSync();
 }
 
+/** Push a new authority snapshot exactly as the real controller would. */
+function push(next: Partial<Snapshot>): void {
+  h.snapshot = { ...(h.snapshot as Snapshot), ...next };
+  for (const listener of h.listeners) listener(h.snapshot);
+  flushSync();
+}
+
 const q = <T extends HTMLElement>(sel: string) => target.querySelector(sel) as T | null;
 
 beforeEach(() => {
   h.state = liveState();
   h.caps = liveCaps();
+  h.snapshot = { ...IDLE };
+  h.listeners.clear();
+  h.subscribeCalls = 0;
+  h.unsubscribeCalls = 0;
+  h.listenersAtRelease = [];
+  h.start.mockReset();
+  h.release.mockReset();
+  h.setIntent.mockReset();
+  h.resetFault.mockReset();
   h.selectVfo = vi.fn();
   h.splitToggle = vi.fn();
   h.dualWatchToggle = vi.fn();
+  h.setLan = vi.fn();
+  h.dismissWarning = vi.fn();
+  h.modInputGuard = { visible: false, sourceLabel: null };
 });
 
 afterEach(() => {
@@ -95,21 +168,20 @@ afterEach(() => {
   document.body.innerHTML = '';
 });
 
-describe('the VFO surface renders from the live adapter output', () => {
-  it('mounts the semantic VFO surface with the derived view model', () => {
+describe('the surfaces render from the live adapter output', () => {
+  it('mounts both semantic surfaces with the derived view model', () => {
     render();
     expect(q('[data-testid="vfo-surface"]')).not.toBeNull();
+    expect(q('[data-testid="rx-tx-surface"]')).not.toBeNull();
     expect(target.querySelectorAll('[data-vfo-tile]')).toHaveLength(4);
-    expect(q('[data-testid="vfo-active-receiver"]')?.dataset.activeReceiver).toBe('MAIN');
+    expect(q('[data-testid="rx-tx-target"]')?.dataset.target).toBe('known');
   });
 
-  // MUTATION KILLED: rendering the surface against a fabricated fallback model
-  // when capabilities have not loaded. There is no safe default topology.
-  it('renders no surface at all rather than guessing when capabilities are absent', () => {
+  it('renders no surfaces at all rather than guessing when capabilities are absent', () => {
     h.caps = null;
     render();
     expect(q('[data-testid="vfo-surface"]')).toBeNull();
-    expect(q('[data-testid="semantic-radio-surfaces"]')).not.toBeNull();
+    expect(q('[data-testid="rx-tx-surface"]')).toBeNull();
   });
 
   it('routes the VFO selection intent to the command bus with the real slot id', () => {
@@ -119,35 +191,277 @@ describe('the VFO surface renders from the live adapter output', () => {
     flushSync();
     expect(h.selectVfo).toHaveBeenCalledWith('MAIN', 'B');
   });
+});
 
-  it('routes the split toggle straight through to the command bus', () => {
+describe('TX intents reach the App controller under one stable owner identity', () => {
+  // MUTATION KILLED: deriving `sourceId` per render (or per call) instead of
+  // once per instance. `release` would carry an id the controller never
+  // registered, the model's `event.sourceId === state.sourceId` check would
+  // reject it, and the key would stay DOWN with the UI showing "unkeyed".
+  it('releases under the exact sourceId it started with, across re-renders', () => {
     render();
-    q<HTMLButtonElement>('[data-vfo-split]')!.click();
+    q<HTMLButtonElement>('[data-testid="rx-tx-key"]')!.click();
     flushSync();
-    expect(h.splitToggle).toHaveBeenCalledTimes(1);
+    expect(h.start).toHaveBeenCalledTimes(1);
+    const [startSource, leaseId, intent] = h.start.mock.calls[0];
+    expect(intent).toBe('latched');
+    expect(leaseId).toContain(startSource);
+
+    // Everything the component renders from changes underneath it: a new
+    // authority snapshot AND a new radio state. Any per-render binding is
+    // rebuilt here.
+    const guard = { leaseId };
+    push({ phase: 'active', intent: 'latched', guard, radioTx: 'on', txRisk: 'confirmed-on', mayOwnKey: true });
+    h.state = { ...liveState(), split: true };
+    flushSync();
+
+    q<HTMLButtonElement>('[data-testid="rx-tx-unkey"]')!.click();
+    flushSync();
+    expect(h.release).toHaveBeenCalledTimes(1);
+    expect(h.release).toHaveBeenCalledWith(startSource, guard);
   });
 
-  // MUTATION KILLED: sending a blind `true` (or the current value) for
-  // dual-watch instead of its negation — the toggle would latch rather than
-  // toggle.
-  it('sends the negated dual-watch value', () => {
+  // MUTATION KILLED: re-subscribing (or re-reading a cached snapshot) per
+  // render — a leaked subscription per render both grows without bound and
+  // lets a stale listener overwrite the live snapshot.
+  it('subscribes to the authority exactly once and unsubscribes on destroy', () => {
     render();
-    q<HTMLButtonElement>('[data-vfo-dual-watch]')!.click();
+    push({ radioTx: 'unknown' });
+    h.state = { ...liveState(), dualWatch: true };
     flushSync();
-    expect(h.dualWatchToggle).toHaveBeenCalledWith(true);
+    expect(h.subscribeCalls).toBe(1);
+
+    unmount(component!);
+    component = null;
+    expect(h.unsubscribeCalls).toBe(1);
   });
 
-  // MUTATION KILLED: dropping the `status === 'known'` guard in
-  // `toggleDualWatch` — an unobserved fact has no defined negation, so the
-  // wiring would command a value it invented. (The surface also disables the
-  // control; this pins the wiring's own half of the two-level gate.)
-  it('commands nothing for an unobserved dual-watch fact', () => {
-    h.state = { ...liveState(), fieldStatus: {} } as unknown as ServerState;
+  // MUTATION KILLED: two mounted wiring instances sharing one lease id — one
+  // would be able to release the other's lease (the TxPanel precedent).
+  it('gives a second mounted instance a different lease owner', () => {
     render();
-    const toggle = q<HTMLButtonElement>('[data-vfo-dual-watch]')!;
-    expect(toggle.getAttribute('aria-checked')).toBe('mixed');
-    toggle.click();
+    q<HTMLButtonElement>('[data-testid="rx-tx-key"]')!.click();
     flushSync();
-    expect(h.dualWatchToggle).not.toHaveBeenCalled();
+    const first = h.start.mock.calls[0][0];
+
+    const second = document.createElement('div');
+    document.body.appendChild(second);
+    const other = mount(SemanticRadioSurfaces, { target: second });
+    flushSync();
+    (second.querySelector('[data-testid="rx-tx-key"]') as HTMLButtonElement).click();
+    flushSync();
+    expect(h.start.mock.calls[1][0]).not.toBe(first);
+    unmount(other);
+  });
+
+  it('passes the authority snapshot straight through to the surface', () => {
+    render();
+    push({ phase: 'key-confirm-pending', txRisk: 'uncertain', mayOwnKey: true, radioTx: 'off' });
+    expect(q('[data-testid="rx-tx-state"]')?.dataset.rf).toBe('uncertain');
+    expect(h.start).not.toHaveBeenCalled();
+  });
+});
+
+describe('the unkey path is ungated end to end', () => {
+  // MUTATION KILLED: gating unkey on phase/permit/fault or on the view model
+  // agreeing that transmission is happening. Stopping TX must never depend on
+  // this layer's opinion.
+  it.each([
+    ['a fault is latched', { phase: 'failed', fault: 'on-timeout' }],
+    ['the radio reports RX', { radioTx: 'off', txRisk: 'none' }],
+    ['the RF state is unknown', { radioTx: 'unknown' }],
+    ['a release is already in flight', { phase: 'releasing' }],
+  ] as const)('still releases while %s', (_label, over) => {
+    render();
+    const guard = { leaseId: 'lease-x' };
+    push({ ...over, guard, mayOwnKey: true } as Partial<Snapshot>);
+
+    const unkey = q<HTMLButtonElement>('[data-testid="rx-tx-unkey"]')!;
+    expect(unkey.disabled).toBe(false);
+    unkey.click();
+    flushSync();
+    expect(h.release).toHaveBeenCalledWith(expect.any(String), guard);
+  });
+
+  // MUTATION KILLED: caching the guard at render time. A guard captured before
+  // the lease generation bumped is rejected by the controller, so the unkey
+  // silently does nothing.
+  it('releases the guard the authority holds NOW, not the one seen at render', () => {
+    render();
+    push({ phase: 'active', guard: { leaseId: 'gen-1' }, mayOwnKey: true, radioTx: 'on' });
+    // A regeneration the component never re-rendered for.
+    h.snapshot = { ...(h.snapshot as Snapshot), guard: { leaseId: 'gen-2' } };
+
+    q<HTMLButtonElement>('[data-testid="rx-tx-unkey"]')!.click();
+    expect(h.release).toHaveBeenCalledWith(expect.any(String), { leaseId: 'gen-2' });
+  });
+});
+
+describe('a failed phase has an App-owned way out', () => {
+  // MUTATION KILLED: relying on the RX/TX surface for recovery. It has no
+  // `resetFault` intent by design, and `keyBlockedReasons` disables the key
+  // action while `fault !== null` — so without this affordance the operator is
+  // stuck behind a failed phase with no UI exit at all.
+  it('offers a recovery control only while the authority phase is failed', () => {
+    render();
+    expect(q('[data-testid="tx-fault-reset"]')).toBeNull();
+
+    push({ phase: 'failed', fault: 'audio-failed' });
+    expect(q<HTMLButtonElement>('[data-testid="rx-tx-key"]')!.disabled).toBe(true);
+    const reset = q<HTMLButtonElement>('[data-testid="tx-fault-reset"]');
+    expect(reset).not.toBeNull();
+
+    reset!.click();
+    flushSync();
+    expect(h.resetFault).toHaveBeenCalledTimes(1);
+
+    push({ phase: 'idle', fault: null });
+    expect(q('[data-testid="tx-fault-reset"]')).toBeNull();
+  });
+
+  // MUTATION KILLED: an unconditional `tx.resetFault()` at the top of
+  // `requestKey`. The failed-phase variant below CANNOT kill it — the key
+  // button is disabled there, so the click never reaches the handler and the
+  // assertion is vacuous (proven: the mutation left the suite 14/14 green).
+  // This one drives the handler through the ENABLED path, where the mutation
+  // has to show. "No implicit reset" is a deliberate contract: recovery is an
+  // explicit operator action, per the ticket's recorded decision.
+  it('never resets the fault as a side effect of a key request (enabled path)', () => {
+    render();
+    const key = q<HTMLButtonElement>('[data-testid="rx-tx-key"]')!;
+    expect(key.disabled).toBe(false);
+
+    key.click();
+    flushSync();
+
+    expect(h.start).toHaveBeenCalledTimes(1);
+    expect(h.resetFault).not.toHaveBeenCalled();
+  });
+
+  it('leaves the key action disabled in a failed phase, so no reset can leak through it', () => {
+    render();
+    push({ phase: 'failed', fault: 'audio-failed' });
+    q<HTMLButtonElement>('[data-testid="rx-tx-key"]')!.click();
+    flushSync();
+    expect(h.resetFault).not.toHaveBeenCalled();
+    expect(h.start).not.toHaveBeenCalled();
+  });
+});
+
+describe('teardown releases the lease rather than stranding the transmitter', () => {
+  // MUTATION KILLED: `onDestroy(() => stopWatchingTx())` alone. `requestKey`
+  // starts a LATCHED lease that outlives this component; MOR-1060 destroys the
+  // presentation subtree on any skinId change (resize across 640px, a skin
+  // preference change, a capability update). The App TX controller keeps the
+  // lease, `model.ts` refuses a release from any other sourceId, `start` is a
+  // no-op off-idle, and AppGlobalHost exposes no unkey — so without a release
+  // here the key is DOWN with no UI exit anywhere.
+  it('releases the live lease exactly once when the subtree is destroyed', () => {
+    render();
+    q<HTMLButtonElement>('[data-testid="rx-tx-key"]')!.click();
+    flushSync();
+    const [owner, leaseId] = h.start.mock.calls[0];
+    const guard = { leaseId };
+    push({
+      phase: 'active', intent: 'latched', guard, radioTx: 'on',
+      txRisk: 'confirmed-on', mayOwnKey: true,
+    });
+
+    unmount(component!);
+    component = null;
+
+    expect(h.release).toHaveBeenCalledTimes(1);
+    expect(h.release).toHaveBeenCalledWith(owner, guard);
+    expect(h.unsubscribeCalls).toBe(1);
+    // MUTATION KILLED: swapping the teardown order (release BEFORE
+    // unsubscribe). The release is fail-closed and re-enters the controller
+    // synchronously, which re-emits state to every live listener — into a
+    // component Svelte is mid-way through destroying. Sampling the live
+    // subscription count at the instant release re-enters is what makes the
+    // ORDER observable at all: [0] means we were already detached, [1] means
+    // the release can still bounce back into the dying component. Same
+    // documented order as TxPanel's `stopWatchingTx(); ptt.destroy();`.
+    expect(h.listenersAtRelease).toEqual([0]);
+  });
+
+  // MUTATION KILLED: releasing the render-time `txState.guard` instead of the
+  // live snapshot — a lease regenerated after the last render (the model bumps
+  // `generation` on every release/authority churn) would be released under a
+  // stale guard, which `sameGuard` rejects. Same failure as never releasing.
+  it('releases the guard the authority holds at teardown, not the last rendered one', () => {
+    render();
+    q<HTMLButtonElement>('[data-testid="rx-tx-key"]')!.click();
+    flushSync();
+    const [owner] = h.start.mock.calls[0];
+    push({ phase: 'active', guard: { leaseId: 'gen-1' }, mayOwnKey: true, radioTx: 'on' });
+    // A regeneration the component never re-rendered for.
+    h.snapshot = { ...(h.snapshot as Snapshot), guard: { leaseId: 'gen-2' } };
+
+    unmount(component!);
+    component = null;
+
+    expect(h.release).toHaveBeenCalledWith(owner, { leaseId: 'gen-2' });
+  });
+
+  it('issues no release when it holds no lease', () => {
+    render();
+    unmount(component!);
+    component = null;
+    expect(h.release).not.toHaveBeenCalled();
+  });
+
+  // The operator-visible half of F1: after the swap, the incoming subtree is
+  // usable again. Under the un-released mutation the controller is stuck
+  // off-idle and this key request can never take a lease.
+  it('lets a remounted instance key again, under its own owner identity', () => {
+    render();
+    q<HTMLButtonElement>('[data-testid="rx-tx-key"]')!.click();
+    flushSync();
+    const [firstOwner, leaseId] = h.start.mock.calls[0];
+    push({ phase: 'active', intent: 'latched', guard: { leaseId }, mayOwnKey: true, radioTx: 'on' });
+
+    unmount(component!);            // the swap
+    component = null;
+    expect(h.release).toHaveBeenCalledTimes(1);
+
+    h.snapshot = { ...IDLE };       // the release lands; the authority is idle
+    render();                       // the incoming presentation
+    q<HTMLButtonElement>('[data-testid="rx-tx-key"]')!.click();
+    flushSync();
+
+    expect(h.start).toHaveBeenCalledTimes(2);
+    expect(h.start.mock.calls[1][0]).not.toBe(firstOwner);
+  });
+});
+
+describe('the migrated layout keeps the MOR-617 network-voice-TX preflight', () => {
+  // MUTATION KILLED: dropping <ModInputTxWarning /> from the wiring. It ships
+  // inside TxPanel, which this layout suppresses — but this layout can now key
+  // network voice TX (the controller's start-audio effect IS that path), so
+  // without it the operator keys into a mis-routed MOD input with no warning
+  // and no one-click fix.
+  it('shows the warning under the same trigger condition the panel used', () => {
+    h.modInputGuard = { visible: true, sourceLabel: 'MIC' };
+    render();
+    const warning = q('[data-testid="mod-input-tx-warning"]');
+    expect(warning).not.toBeNull();
+    expect(q('[data-testid="mod-input-set-lan"]')).not.toBeNull();
+
+    q<HTMLButtonElement>('[data-testid="mod-input-set-lan"]')!.click();
+    flushSync();
+    expect(h.setLan).toHaveBeenCalledTimes(1);
+  });
+
+  it('stays out of the way when the preflight is satisfied', () => {
+    render();
+    expect(q('[data-testid="mod-input-tx-warning"]')).toBeNull();
+  });
+
+  it('is not gated on the view model — it shows even before capabilities load', () => {
+    h.caps = null;
+    h.modInputGuard = { visible: true, sourceLabel: 'MIC' };
+    render();
+    expect(q('[data-testid="rx-tx-surface"]')).toBeNull();
+    expect(q('[data-testid="mod-input-tx-warning"]')).not.toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Slice **c** (final) of the independently reviewed MOR-1065 desktop migration:

- `SemanticRadioSurfaces.svelte` (+95/−14): the TX half — `RxTxSurface` on the real App TX controller snapshot; one registered `sourceId` per instance; intents drive the controller's key/unkey paths with **unkey ungated end-to-end**; App-owned fault-recovery button only on `phase==='failed'` calling the real `resetFault()` (no implicit reset on key — pinned).
- **Lease-safe teardown (review finding F1, safety):** onDestroy unsubscribes then releases the live guard under the registered owner — a presentation swap while latched can no longer strand the key with no UI exit; the unsubscribe→release ORDER is itself pinned (`listenersAtRelease === [0]` — the order-swap mutation fails it).
- **ModInputTxWarning restored (F2):** the MOR-617 network-voice-TX preflight mounts next to the surface, self-gating on the real `deriveModInputTxGuardProps().visible`, outside `{#if view}`.
- Sidebars suppress the legacy TxPanel **TX-scoped only** (CW survival pinned by mutation).

## Independent verification (two cycles + delta confirm)

- F1 re-proven by the reviewer's own stranding probe: release fires exactly once under the registered owner, remount keys again; the teardown window is clean (`listeners.size === 0` at release re-entry — nothing bounces or re-arms).
- F2 verified on the REAL MOR-617 path (real warning + real guard + real stores): MIC banner, `Set LAN` issues `set_data1_mod_input {source:5}`, clears on readback, renders with `caps===null`.
- F4: unconditional-resetFault mutation now kills; 7 TX-wiring mutations killed incl. gating unkey inside the surface itself.
- Suites at the full-tree state: 126/126 new+boundaries, 303/303 regression (incl. TxPanel + ModInputTxWarning suites), full frontend 2940/2941 — the sole local failure is the adjudicated environmental shared-localStorage race (13/13 standalone); CI gates. Merging with `[full-ci]`.

Linear: MOR-1065 (slice c of 4 — completes the ticket)

🤖 Generated with [Claude Code](https://claude.com/claude-code)