### PR TITLE
feat(MOR-1066): layout manifest v1 - schema, validator, registry, DL handshake

### DIFF
--- a/docs/plans/2026-07-25-ui-composition-architecture-v3.md
+++ b/docs/plans/2026-07-25-ui-composition-architecture-v3.md
@@ -98,7 +98,7 @@ Layouts are compiled Svelte compositions, not serialized component trees.
 
 Visual grammar: typography, geometry, control families, meter and frequency
 renderers, state indication, motion, density, and surface treatment. Use
-product-owned identifiers such as `rigplane-modern`, `japanese-sdr`,
+product-owned identifiers such as `studioline`, `fieldline`,
 `contest-console`, or `classic-instrument`. Public manufacturer naming requires
 separate brand/legal review.
 
@@ -161,10 +161,12 @@ persistent browser TX controller, and global overlays. Its selection contains
 stable layout, design-language and theme IDs plus `comfortable`, `compact`, or
 `dense` density.
 
-A layout manifest declares identity, zones, responsive policy, and capability
-requirements; its implementation is a lazy-loaded Svelte component. A design
-language manifest declares compatible renderer families and token bundles.
-Manifests support discovery and validation, never executable radio behavior.
+A layout manifest declares identity, zones, responsive policy, and compatible
+topology classes — a pure, transient derived presentation fact (MOR-988), not
+a capability claim; its implementation is a lazy-loaded Svelte component. A
+design language manifest declares compatible renderer families and token
+bundles. Manifests support discovery and validation, never executable radio
+behavior.
 
 Resolution order:
 

--- a/frontend/src/presentation/layouts/__tests__/compatibility.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/compatibility.test.ts
@@ -1,0 +1,64 @@
+/**
+ * MOR-1066 design-language x layout compatibility handshake. Pure
+ * composition of the two manifests' own declarations — the mutation-kill
+ * test at the bottom proves it structurally via a Proxy trap: touching any
+ * property other than `layout.id` / `language.layoutCompatibility` throws.
+ */
+import { describe, it, expect } from 'vitest';
+import { studioline, fieldline } from '../../languages/declarations';
+import type { DesignLanguageManifest } from '../../languages/contract';
+import { checkLayoutLanguageCompatibility } from '../compatibility';
+import type { LayoutManifest } from '../contract';
+import { validLayoutManifest } from './fixtures';
+
+describe('the frozen v3 handshake pair (MOR-977 §4.4)', () => {
+  it('fieldline x dual-receiver-cockpit is incompatible', () => {
+    const layout = validLayoutManifest({ id: 'dual-receiver-cockpit' });
+    const result = checkLayoutLanguageCompatibility(fieldline, layout);
+    expect(result).toEqual({
+      compatible: false,
+      reason: expect.stringContaining('0.6 relative density'),
+    });
+  });
+
+  it('studioline x dual-receiver-cockpit is compatible (no declaration = compatible)', () => {
+    const layout = validLayoutManifest({ id: 'dual-receiver-cockpit' });
+    expect(checkLayoutLanguageCompatibility(studioline, layout)).toEqual({ compatible: true });
+  });
+
+  // Kills: hardcoding the dual-receiver-cockpit id instead of reading
+  // layout.id — any other layout id must also come back compatible with
+  // studioline, since studioline declares no incompatibilities at all.
+  it('studioline x any other layout id is compatible', () => {
+    const layout = validLayoutManifest({ id: 'sdr-test' });
+    expect(checkLayoutLanguageCompatibility(studioline, layout)).toEqual({ compatible: true });
+  });
+
+  // Kills: fieldline's incompatibility bleeding into an unrelated layout id.
+  it('fieldline x an unrelated layout id is compatible', () => {
+    const layout = validLayoutManifest({ id: 'sdr-test' });
+    expect(checkLayoutLanguageCompatibility(fieldline, layout)).toEqual({ compatible: true });
+  });
+});
+
+describe('structural purity (mutation-kill)', () => {
+  // Kills: the function consulting anything other than layout.id and
+  // language.layoutCompatibility (e.g. a capability check, sizing, tokens).
+  it('touches only layout.id and language.layoutCompatibility — a Proxy trap on any other property throws', () => {
+    const layoutTarget = validLayoutManifest({ id: 'dual-receiver-cockpit' });
+    const layout = new Proxy(layoutTarget, {
+      get(target, prop, receiver) {
+        if (prop !== 'id') throw new Error(`unexpected access to layout.${String(prop)}`);
+        return Reflect.get(target, prop, receiver);
+      },
+    });
+    const language = new Proxy(fieldline, {
+      get(target, prop, receiver) {
+        if (prop !== 'layoutCompatibility') throw new Error(`unexpected access to language.${String(prop)}`);
+        return Reflect.get(target, prop, receiver);
+      },
+    });
+    expect(() => checkLayoutLanguageCompatibility(language as DesignLanguageManifest, layout as LayoutManifest))
+      .not.toThrow();
+  });
+});

--- a/frontend/src/presentation/layouts/__tests__/fixtures.ts
+++ b/frontend/src/presentation/layouts/__tests__/fixtures.ts
@@ -1,0 +1,18 @@
+/** Shared valid-manifest fixture for MOR-1066 contract tests (not itself a test file). */
+import type { Component } from 'svelte';
+import type { LayoutManifest } from '../contract';
+
+export function validLayoutManifest(overrides: Partial<LayoutManifest> = {}): LayoutManifest {
+  return {
+    schemaVersion: 1,
+    id: 'testlayout',
+    displayName: 'Test Layout',
+    loader: () => Promise.resolve({ default: {} as unknown as Component }),
+    zones: [{ id: 'main', surfaces: ['vfo', 'rxTx'] }],
+    compatibleTopologies: ['1/single'],
+    requiredSemanticSurfaces: ['vfo', 'rxTx'],
+    sizing: { mode: 'fluid', responsiveBreakpoints: [] },
+    fallbackLayoutId: null,
+    ...overrides,
+  };
+}

--- a/frontend/src/presentation/layouts/__tests__/manifest-shape.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/manifest-shape.test.ts
@@ -1,0 +1,201 @@
+/**
+ * MOR-1066 manifest shape: naming policy (reused from the MOR-1072 design-
+ * language denylist), declared zones, the v1 schema version, and the
+ * rejection classes the ticket names explicitly — capability-like keys,
+ * module-path-shaped values, unknown top-level keys, vendor/geo-marker IDs.
+ * Each test's doc line names the mutation it exists to kill.
+ */
+import { describe, it, expect } from 'vitest';
+import { isValidLanguageId } from '../../languages/contract';
+import { validateLayoutManifest, LayoutValidationError, type SizingPolicy } from '../contract';
+import { validLayoutManifest } from './fixtures';
+
+describe('naming policy (reused from ../languages/contract.ts, not reimplemented)', () => {
+  // Kills: swapping isValidProductId for a no-op/always-true check.
+  it.each(['icom-modern', 'yaesu-field', 'japanese-sdr', 'american-console', 'ic-7610'])(
+    'rejects the vendor/geographic-marker id "%s"',
+    (id) => {
+      expect(() => validateLayoutManifest(validLayoutManifest({ id }))).toThrow(LayoutValidationError);
+    },
+  );
+
+  it.each(['dual-receiver-cockpit', 'sdr-test', 'classic-instrument', 'spectrum-first'])(
+    'accepts the product-owned id "%s"',
+    (id) => {
+      expect(() => validateLayoutManifest(validLayoutManifest({ id }))).not.toThrow();
+    },
+  );
+
+  // Kills: a validator that checks id shape but not fallbackLayoutId shape.
+  it('rejects a fallbackLayoutId that fails the same naming policy', () => {
+    const manifest = validLayoutManifest({ fallbackLayoutId: 'icom-classic' });
+    expect(() => validateLayoutManifest(manifest)).toThrow(/naming policy/);
+  });
+
+  it('is literally the shared function, not a duplicate', () => {
+    expect(isValidLanguageId('japanese-sdr')).toBe(false);
+  });
+});
+
+describe('versioned (v1) shape', () => {
+  // Kills: dropping the schemaVersion check entirely.
+  it('rejects a manifest with the wrong schemaVersion', () => {
+    const manifest = { ...validLayoutManifest(), schemaVersion: 2 as 1 };
+    expect(() => validateLayoutManifest(manifest)).toThrow(/schemaVersion/);
+  });
+
+  it('accepts schemaVersion 1', () => {
+    expect(() => validateLayoutManifest(validLayoutManifest())).not.toThrow();
+  });
+});
+
+describe('declared zones (v3 ADR: which semantic surfaces appear, and where)', () => {
+  // Kills: accepting an empty zones array (a layout that mounts nothing).
+  it('rejects a manifest with zero zones', () => {
+    expect(() => validateLayoutManifest(validLayoutManifest({ zones: [] }))).toThrow(/zone/);
+  });
+
+  // Kills: not validating zone.surfaces against SEMANTIC_SURFACE_NAMES.
+  it('rejects a zone declaring an unknown semantic surface', () => {
+    const manifest = validLayoutManifest({
+      zones: [{ id: 'main', surfaces: ['vfo', 'meterPanel'] as unknown as readonly ['vfo'] }],
+    });
+    expect(() => validateLayoutManifest(manifest)).toThrow(/subset of/);
+  });
+
+  // Kills: requiredSemanticSurfaces accepted without checking it is
+  // actually mounted by some declared zone (a claimed-but-absent surface).
+  it('rejects a requiredSemanticSurfaces entry no zone mounts', () => {
+    const manifest = validLayoutManifest({
+      zones: [{ id: 'main', surfaces: ['vfo'] }],
+      requiredSemanticSurfaces: ['vfo', 'rxTx'],
+    });
+    expect(() => validateLayoutManifest(manifest)).toThrow(/no zone mounts/);
+  });
+});
+
+describe('compatible topology classes', () => {
+  // Kills: accepting compatibleTopologies outside the four canonical classes.
+  it('rejects an unknown topology class', () => {
+    const manifest = validLayoutManifest({ compatibleTopologies: ['3/whatever'] as unknown as ['1/single'] });
+    expect(() => validateLayoutManifest(manifest)).toThrow(/compatibleTopologies/);
+  });
+
+  it('rejects zero compatible topologies', () => {
+    expect(() => validateLayoutManifest(validLayoutManifest({ compatibleTopologies: [] }))).toThrow(/topology/);
+  });
+});
+
+describe('sizing (MOR-1160)', () => {
+  it('accepts fluid sizing with breakpoints', () => {
+    const manifest = validLayoutManifest({ sizing: { mode: 'fluid', responsiveBreakpoints: [600, 900] } });
+    expect(() => validateLayoutManifest(manifest)).not.toThrow();
+  });
+
+  it('accepts fixed-native sizing with a positive minScale', () => {
+    const manifest = validLayoutManifest({ sizing: { mode: 'fixed-native', nativeW: 1280, nativeH: 540, minScale: 0.5 } });
+    expect(() => validateLayoutManifest(manifest)).not.toThrow();
+  });
+
+  // Kills: dropping the mutual-exclusivity check between fixed-native and
+  // responsiveBreakpoints (MOR-1066 comment, MOR-1160).
+  it('rejects a fixed-native layout that also declares responsiveBreakpoints', () => {
+    const poisoned = {
+      mode: 'fixed-native', nativeW: 1280, nativeH: 540, minScale: 0.5, responsiveBreakpoints: [600],
+    } as unknown as SizingPolicy;
+    expect(() => validateLayoutManifest(validLayoutManifest({ sizing: poisoned }))).toThrow(/mutually exclusive/);
+  });
+
+  it('rejects a non-positive minScale', () => {
+    const manifest = validLayoutManifest({ sizing: { mode: 'fixed-native', nativeW: 1280, nativeH: 540, minScale: 0 } });
+    expect(() => validateLayoutManifest(manifest)).toThrow(/positive finite/);
+  });
+});
+
+describe('capability-fork and module-path rejection', () => {
+  // Kills: findCapabilityLikeKey never wired into validateLayoutManifest.
+  it('rejects a manifest with a top-level capabilities-shaped key', () => {
+    const manifest = { ...validLayoutManifest(), capabilities: ['CW', 'SSB'] };
+    expect(() => validateLayoutManifest(manifest)).toThrow(/capability-shaped key/);
+  });
+
+  it('rejects a vendor key nested inside a zone', () => {
+    const manifest = validLayoutManifest({
+      zones: [{ id: 'main', surfaces: ['vfo'], vendor: 'test-vendor' } as unknown as { id: string; surfaces: ['vfo'] }],
+    });
+    expect(() => validateLayoutManifest(manifest)).toThrow(/capability-shaped key/);
+  });
+
+  // Kills: findModulePathLikeValue never wired in, or its regex loosened
+  // to miss a real relative-import-shaped string. displayName is free text
+  // with no naming-policy check of its own, so this proves the scan (not
+  // the id-shape check) is what catches it.
+  it('rejects a module-path-shaped value riding in a free-text field (displayName)', () => {
+    const manifest = { ...validLayoutManifest(), displayName: './SomeLayout.svelte' };
+    expect(() => validateLayoutManifest(manifest)).toThrow(/module-path-shaped value/);
+  });
+
+  it('does not flag the compiled loader itself — JSON.stringify never sees inside a function', () => {
+    expect(() => validateLayoutManifest(validLayoutManifest())).not.toThrow();
+  });
+
+  // Kills: unknown-top-level-key rejection missing or checking a subset of keys.
+  it('rejects a manifest with an extra unknown top-level key', () => {
+    const manifest = { ...validLayoutManifest(), extraField: 'nope' };
+    expect(() => validateLayoutManifest(manifest)).toThrow(/unknown top-level key/);
+  });
+
+  // Kills: F3 — the module-path scan only recognizing './'/'../' and missing
+  // this codebase's actual alias/bare/absolute forms.
+  it.each([
+    ['the $lib alias', '$lib/skins/foo/Bar.svelte'],
+    ['a bare src/ reference', 'src/skins/foo/Bar.svelte'],
+    ['an absolute path', '/abs/skins/foo/Bar.svelte'],
+  ])('rejects a module-path-shaped value using %s', (_label, value) => {
+    const manifest = { ...validLayoutManifest(), displayName: value };
+    expect(() => validateLayoutManifest(manifest)).toThrow(/module-path-shaped value/);
+  });
+
+  // Kills: F4 — an eagerly-computed derived value (e.g. mountedSurfaces)
+  // reading `manifest.zones` before the capability/module-path scan has had
+  // a chance to short-circuit, turning a doctrine violation into a raw
+  // TypeError instead of the documented LayoutValidationError.
+  it('a capability-shaped key wins over malformed/missing zones — no raw TypeError', () => {
+    const manifest = { ...validLayoutManifest(), capabilities: ['CW'], zones: undefined };
+    expect(() => validateLayoutManifest(manifest as never)).toThrow(/capability-shaped key/);
+  });
+});
+
+describe('exact-key discipline pins (MOR-1072 N1 lesson, review cycle 1 F2)', () => {
+  // Kills: hasExactPlainKeys downgraded to a plain Object.keys check, which
+  // drops the `proto !== Object.prototype` guard — a class instance (or any
+  // object with a non-plain prototype) carries its extra keys on the
+  // prototype chain, invisible to Object.keys/Reflect.ownKeys on the
+  // instance itself, but must still be rejected outright.
+  it('rejects a manifest whose prototype is not plain Object.prototype (class-instance smuggling)', () => {
+    class PoisonedManifest {
+      schemaVersion = 1 as const;
+      id = 'testlayout';
+      displayName = 'Test Layout';
+      loader = () => Promise.resolve({ default: {} as never });
+      zones = [{ id: 'main', surfaces: ['vfo', 'rxTx'] as const }];
+      compatibleTopologies = ['1/single'] as const;
+      requiredSemanticSurfaces = ['vfo', 'rxTx'] as const;
+      sizing = { mode: 'fluid' as const, responsiveBreakpoints: [] as number[] };
+      fallbackLayoutId = null;
+      // Prototype getter: an own-keys/Object.keys walk of the instance never
+      // sees this — only the explicit prototype check catches it.
+      get capabilities(): string[] { return ['CW']; }
+    }
+    expect(() => validateLayoutManifest(new PoisonedManifest() as unknown as never)).toThrow(LayoutValidationError);
+  });
+
+  // Kills: hasExactPlainKeys downgraded to Object.keys, which enumerates
+  // string keys only — a symbol key is invisible to Object.keys but visible
+  // to Reflect.ownKeys, so only the latter catches a smuggled symbol key.
+  it('rejects a manifest with a smuggled symbol key', () => {
+    const manifest: Record<PropertyKey, unknown> = { ...validLayoutManifest() };
+    manifest[Symbol('capabilities')] = ['CW'];
+    expect(() => validateLayoutManifest(manifest as never)).toThrow(/unknown top-level key/);
+  });
+});

--- a/frontend/src/presentation/layouts/__tests__/registry.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/registry.test.ts
@@ -1,0 +1,160 @@
+/**
+ * MOR-1066 compiled registry: count-agnostic registration, lookup by id,
+ * duplicate-ID rejection, missing-loader rejection, the sdr-test real
+ * registration proof, topology fallback resolution, and MOR-1160 viewport
+ * (fixed-native/minScale) fallback resolution. Each test's doc line names
+ * the mutation it exists to kill.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  registerLayout, getLayout, listLayoutIds, resolveLayoutForTopology,
+  resolveLayoutForViewport, LayoutValidationError,
+} from '../contract';
+import { sdrTestLayout } from '../declarations';
+import { validLayoutManifest } from './fixtures';
+
+describe('the sdr-test real registration proof', () => {
+  // Kills: declarations.ts never actually calling registerLayout.
+  it('registers sdr-test, mounting the live vfo + rxTx zones, with no change to SdrTestSkin.svelte behavior', () => {
+    expect(getLayout('sdr-test')).toBe(sdrTestLayout);
+    expect(sdrTestLayout.zones).toEqual([{ id: 'main', surfaces: ['vfo', 'rxTx'] }]);
+    expect(typeof sdrTestLayout.loader).toBe('function');
+  });
+});
+
+describe('count-agnostic registration', () => {
+  // Kills: a registry that hardcodes a family count instead of accepting
+  // any manifest that passes validation.
+  it('registers a hypothetical extra layout the same way as sdr-test', () => {
+    const before = listLayoutIds().length;
+    registerLayout(validLayoutManifest({ id: 'hypothetical-layout' }));
+    expect(listLayoutIds().length).toBe(before + 1);
+    expect(getLayout('hypothetical-layout')?.id).toBe('hypothetical-layout');
+  });
+});
+
+describe('duplicate IDs', () => {
+  // Kills: registerLayout silently overwriting (the design-language
+  // registry's semantics) instead of rejecting a second registration.
+  it('rejects re-registering an already-registered id', () => {
+    registerLayout(validLayoutManifest({ id: 'duplicate-test-layout' }));
+    expect(() => registerLayout(validLayoutManifest({ id: 'duplicate-test-layout' }))).toThrow(LayoutValidationError);
+    expect(() => registerLayout(validLayoutManifest({ id: 'duplicate-test-layout' }))).toThrow(/already registered/);
+  });
+});
+
+describe('missing loaders', () => {
+  // Kills: registerLayout accepting a manifest whose loader isn't a function.
+  it('rejects registration when loader is not a function', () => {
+    const manifest = { ...validLayoutManifest({ id: 'no-loader-layout' }), loader: undefined };
+    expect(() => registerLayout(manifest as never)).toThrow(/compiled Svelte loader/);
+    expect(getLayout('no-loader-layout')).toBeUndefined();
+  });
+});
+
+describe('lookup by id', () => {
+  it('returns undefined for an id that was never registered', () => {
+    expect(getLayout('never-registered-layout-xyz')).toBeUndefined();
+  });
+});
+
+describe('unsupported topology + fallback resolution (single fallback hop)', () => {
+  it('resolves the primary layout when it declares the requested topology', () => {
+    registerLayout(validLayoutManifest({ id: 'topo-primary', compatibleTopologies: ['1/single', '2/main_sub'] }));
+    expect(resolveLayoutForTopology('topo-primary', '2/main_sub')?.id).toBe('topo-primary');
+  });
+
+  // Kills: resolveLayoutForTopology ignoring compatibleTopologies and
+  // always returning the primary manifest.
+  it('falls back to fallbackLayoutId when the primary does not declare the topology', () => {
+    registerLayout(validLayoutManifest({ id: 'topo-fallback-target', compatibleTopologies: ['1/ab'] }));
+    registerLayout(validLayoutManifest({
+      id: 'topo-fallback-primary', compatibleTopologies: ['1/single'], fallbackLayoutId: 'topo-fallback-target',
+    }));
+    expect(resolveLayoutForTopology('topo-fallback-primary', '1/ab')?.id).toBe('topo-fallback-target');
+  });
+
+  it('returns undefined when unsupported and there is no fallback', () => {
+    registerLayout(validLayoutManifest({ id: 'topo-no-fallback', compatibleTopologies: ['1/single'] }));
+    expect(resolveLayoutForTopology('topo-no-fallback', '2/main_sub')).toBeUndefined();
+  });
+});
+
+describe('fallback re-validation (review cycle 1, F1)', () => {
+  // Kills: resolveFallback returning getLayout(fallbackLayoutId) without
+  // re-applying the criterion. Before the fix this returned `f1-self-ref`
+  // itself — a layout that does NOT support the requested topology.
+  it('a self-referential fallback under an unsupported topology resolves to undefined, not itself', () => {
+    registerLayout(validLayoutManifest({
+      id: 'f1-self-ref', compatibleTopologies: ['1/single'], fallbackLayoutId: 'f1-self-ref',
+    }));
+    expect(resolveLayoutForTopology('f1-self-ref', '2/main_sub')).toBeUndefined();
+  });
+
+  // Kills the same bug via a two-hop chain: before the fix, the middle
+  // layout (which itself does not support the topology) was returned
+  // unvalidated because only the primary's support was ever checked.
+  it('a two-hop chain (a -> b -> c) does not return b when only c supports the topology', () => {
+    registerLayout(validLayoutManifest({ id: 'f1-chain-c', compatibleTopologies: ['1/ab'] }));
+    registerLayout(validLayoutManifest({
+      id: 'f1-chain-b', compatibleTopologies: ['1/single'], fallbackLayoutId: 'f1-chain-c',
+    }));
+    registerLayout(validLayoutManifest({
+      id: 'f1-chain-a', compatibleTopologies: ['2/main_sub'], fallbackLayoutId: 'f1-chain-b',
+    }));
+    // v1 takes exactly one hop, so this must NOT silently return b (which
+    // does not support '1/ab') and must NOT chase through to c either.
+    const resolved = resolveLayoutForTopology('f1-chain-a', '1/ab');
+    expect(resolved?.id).not.toBe('f1-chain-b');
+    expect(resolved).toBeUndefined();
+  });
+
+  // Kills: resolveLayoutForViewport returning a fixed-native fallback
+  // without checking IT against minScale too — defeats the MOR-1160
+  // portrait-mobile exclusion for the fallback layout itself.
+  it('a fixed-native fallback that itself fails minScale resolves to undefined, not the fallback', () => {
+    registerLayout(validLayoutManifest({
+      id: 'f1-vp-fallback', sizing: { mode: 'fixed-native', nativeW: 1280, nativeH: 540, minScale: 0.5 },
+    }));
+    registerLayout(validLayoutManifest({
+      id: 'f1-vp-primary',
+      sizing: { mode: 'fixed-native', nativeW: 1280, nativeH: 540, minScale: 0.5 },
+      fallbackLayoutId: 'f1-vp-fallback',
+    }));
+    // Same tiny viewport fails minScale for both primary and fallback.
+    const resolved = resolveLayoutForViewport('f1-vp-primary', { width: 100, height: 100 });
+    expect(resolved).toBeUndefined();
+  });
+});
+
+describe('viewport resolution (MOR-1160 sizing)', () => {
+  it('a fixed-native layout resolves when the achievable scale meets minScale', () => {
+    registerLayout(validLayoutManifest({
+      id: 'fixed-fit-test', sizing: { mode: 'fixed-native', nativeW: 1280, nativeH: 540, minScale: 0.5 },
+    }));
+    expect(resolveLayoutForViewport('fixed-fit-test', { width: 1280, height: 540 })?.id).toBe('fixed-fit-test');
+  });
+
+  // Kills: fitsViewport matching breakpoints instead of comparing scale to
+  // minScale for a fixed-native layout (the MOR-1066 comment's explicit ask).
+  it('falls back below minScale — portrait mobile is excluded arithmetically, no special-cased branch', () => {
+    registerLayout(validLayoutManifest({
+      id: 'fixed-portrait-fallback', sizing: { mode: 'fluid', responsiveBreakpoints: [] },
+    }));
+    registerLayout(validLayoutManifest({
+      id: 'fixed-portrait-primary',
+      sizing: { mode: 'fixed-native', nativeW: 1280, nativeH: 540, minScale: 0.5 },
+      fallbackLayoutId: 'fixed-portrait-fallback',
+    }));
+    // iPhone-class portrait viewport: min(390/1280, 844/540) ≈ 0.30 < 0.5.
+    const resolved = resolveLayoutForViewport('fixed-portrait-primary', { width: 390, height: 844 });
+    expect(resolved?.id).toBe('fixed-portrait-fallback');
+  });
+
+  it('a fluid layout always fits — breakpoints are reflow hints, not a hard gate', () => {
+    registerLayout(validLayoutManifest({
+      id: 'fluid-always-fits', sizing: { mode: 'fluid', responsiveBreakpoints: [600] },
+    }));
+    expect(resolveLayoutForViewport('fluid-always-fits', { width: 100, height: 100 })?.id).toBe('fluid-always-fits');
+  });
+});

--- a/frontend/src/presentation/layouts/compatibility.ts
+++ b/frontend/src/presentation/layouts/compatibility.ts
@@ -1,0 +1,22 @@
+/**
+ * The design-language x layout compatibility handshake (MOR-1066/MOR-1072).
+ * Pure composition of the two manifests' own declarations — no capability
+ * checks, no runtime state, nothing else consulted. Absence of a
+ * declaration means compatible: today only `fieldline` (MOR-977 §4.4)
+ * declares an incompatibility, against `dual-receiver-cockpit`.
+ */
+import type { DesignLanguageManifest } from '../languages/contract';
+import type { LayoutManifest } from './contract';
+
+export type CompatibilityResult =
+  | { readonly compatible: true }
+  | { readonly compatible: false; readonly reason?: string };
+
+export function checkLayoutLanguageCompatibility(
+  language: DesignLanguageManifest,
+  layout: LayoutManifest,
+): CompatibilityResult {
+  const declaration = language.layoutCompatibility.find((d) => d.layoutId === layout.id);
+  if (!declaration || declaration.compatible) return { compatible: true };
+  return { compatible: false, reason: declaration.reason };
+}

--- a/frontend/src/presentation/layouts/contract.ts
+++ b/frontend/src/presentation/layouts/contract.ts
@@ -1,0 +1,266 @@
+/**
+ * Layout manifest v1 schema, runtime validator, and compiled registry
+ * (MOR-1066) — the other side of the design-language handshake in
+ * `../languages/contract.ts` (`./compatibility.ts` composes the two).
+ * Declares identity, zones mounting semantic surfaces, compatible radio
+ * topologies, the MOR-1160 sizing axis, and a safe fallback — never
+ * executable radio behavior, capability objects, or component module paths
+ * (v3 ADR "Composition contract"; MOR-988/983 doctrine). Lint-enforced
+ * presentation/ zone (MOR-1061) bans runtime/capability/transport/command
+ * imports here and in every manifest.
+ */
+import type { Component } from 'svelte';
+import { isValidLanguageId as isValidProductId } from '../languages/contract';
+
+/** Semantic surfaces a layout may mount (MOR-1062/1065 reference vertical). */
+export const SEMANTIC_SURFACE_NAMES = ['vfo', 'rxTx'] as const;
+export type SemanticSurfaceName = (typeof SEMANTIC_SURFACE_NAMES)[number];
+
+/**
+ * The four canonical topology classes from the MOR-1062 fixtures
+ * (`semantic/fixtures/topologies.ts`), `${receiverCount}/${vfoScheme}`.
+ * Mirrored here as a standalone literal union instead of importing the
+ * fixtures module — fixtures are a test asset, not a production dependency.
+ */
+export const TOPOLOGY_CLASSES = ['1/single', '1/ab', '2/ab_shared', '2/main_sub'] as const;
+export type TopologyClass = (typeof TOPOLOGY_CLASSES)[number];
+
+export interface LayoutZone {
+  readonly id: string;
+  readonly surfaces: readonly SemanticSurfaceName[];
+}
+
+/**
+ * Sizing axis (MOR-1160, frozen 2026-07-29): `fluid` reflows on declared
+ * breakpoints; `fixed-native` scales as one block by
+ * `min(w/nativeW, h/nativeH)`, letterboxed, falling back below `minScale`.
+ * Structurally exclusive at the type level (`FixedNativeSizing` has no
+ * `responsiveBreakpoints` slot); the runtime validator enforces the same
+ * exclusion against untyped input.
+ */
+export interface FluidSizing {
+  readonly mode: 'fluid';
+  readonly responsiveBreakpoints: readonly number[];
+}
+export interface FixedNativeSizing {
+  readonly mode: 'fixed-native';
+  readonly nativeW: number;
+  readonly nativeH: number;
+  readonly minScale: number;
+}
+export type SizingPolicy = FluidSizing | FixedNativeSizing;
+
+export interface LayoutManifest {
+  readonly schemaVersion: 1;
+  readonly id: string;
+  readonly displayName: string;
+  readonly loader: () => Promise<{ default: Component }>;
+  readonly zones: readonly LayoutZone[];
+  readonly compatibleTopologies: readonly TopologyClass[];
+  readonly requiredSemanticSurfaces: readonly SemanticSurfaceName[];
+  readonly sizing: SizingPolicy;
+  readonly fallbackLayoutId: string | null;
+}
+
+const TOP_LEVEL_KEYS: readonly PropertyKey[] = [
+  'schemaVersion', 'id', 'displayName', 'loader', 'zones',
+  'compatibleTopologies', 'requiredSemanticSurfaces', 'sizing', 'fallbackLayoutId',
+];
+
+export class LayoutValidationError extends Error {}
+
+/** Exact-OWN-keys discipline (MOR-1072 review precedent; radio-view-model.ts
+ *  idiom): rejects a class-instance prototype leak and any extra own/symbol
+ *  key `Object.keys` would miss. Extras-only, matching `../languages/
+ *  contract.ts` (a TS-typed-author boundary, not a full untyped-JSON check). */
+function hasExactPlainKeys(value: object, keys: readonly PropertyKey[]): boolean {
+  const proto = Object.getPrototypeOf(value);
+  if (proto !== Object.prototype && proto !== null) return false;
+  return Reflect.ownKeys(value).every((k) => keys.includes(k));
+}
+
+function allIn<T>(values: readonly T[], allowed: readonly T[]): boolean {
+  return values.every((v) => allowed.includes(v));
+}
+
+/** JSON.stringify-replacer idiom mirrored from the design-language contract's
+ *  findCapabilityLikeKey: walks every nested key, skips function values — the
+ *  `loader` closure's import specifier is invisible to it, by design. */
+const FORBIDDEN_MANIFEST_KEY_MARKERS = ['capability', 'capabilities', 'radiomodel', 'vendor', 'manufacturer', 'firmware'];
+function findCapabilityLikeKey(manifest: LayoutManifest): string | null {
+  let hit: string | null = null;
+  JSON.stringify(manifest, (key, value) => {
+    if (!hit && FORBIDDEN_MANIFEST_KEY_MARKERS.some((m) => key.toLowerCase().includes(m))) hit = key;
+    return value;
+  });
+  return hit;
+}
+
+/** Same idiom applied to VALUES: rejects a string shaped like a relative
+ *  import (`./`, `../`), the `$lib/` alias, a bare `src/` reference, or an
+ *  absolute path — the forms a real component specifier takes in this
+ *  codebase. Not exhaustive (any string could theoretically resolve as a
+ *  module elsewhere), but the compiled `loader` closure is the only field
+ *  meant to carry one, and the scan never sees inside a function value. */
+const MODULE_PATH_VALUE_PATTERN = /^(\.{1,2}\/|\$lib\/|src\/|\/)/;
+function findModulePathLikeValue(manifest: LayoutManifest): string | null {
+  let hit: string | null = null;
+  JSON.stringify(manifest, (key, value) => {
+    if (!hit && typeof value === 'string' && MODULE_PATH_VALUE_PATTERN.test(value)) hit = key;
+    return value;
+  });
+  return hit;
+}
+
+function validateSizing(id: string, sizing: SizingPolicy): string | null {
+  if (sizing.mode === 'fluid') {
+    if (!hasExactPlainKeys(sizing, ['mode', 'responsiveBreakpoints'])
+      || !Array.isArray(sizing.responsiveBreakpoints)
+      || !sizing.responsiveBreakpoints.every((b) => typeof b === 'number')) {
+      return `Layout "${id}" fluid sizing must declare only mode/responsiveBreakpoints (number array).`;
+    }
+    return null;
+  }
+  if (sizing.mode === 'fixed-native') {
+    if (!hasExactPlainKeys(sizing, ['mode', 'nativeW', 'nativeH', 'minScale'])) {
+      return `Layout "${id}" fixed-native sizing must declare only mode/nativeW/nativeH/minScale — ` +
+        'no responsiveBreakpoints (MOR-1160: the two are mutually exclusive).';
+    }
+    const { nativeW, nativeH, minScale } = sizing;
+    if (![nativeW, nativeH, minScale].every((n) => typeof n === 'number' && Number.isFinite(n) && n > 0)) {
+      return `Layout "${id}" fixed-native sizing requires positive finite nativeW/nativeH/minScale.`;
+    }
+    return null;
+  }
+  return `Layout "${id}" sizing.mode must be 'fluid' | 'fixed-native'.`;
+}
+
+function validateZones(id: string, zones: readonly LayoutZone[]): string | null {
+  for (const zone of zones) {
+    if (typeof zone.id !== 'string' || zone.id.length === 0) {
+      return `Layout "${id}" has a zone with an empty id.`;
+    }
+    if (!Array.isArray(zone.surfaces) || zone.surfaces.length === 0 || !allIn(zone.surfaces, SEMANTIC_SURFACE_NAMES)) {
+      return `Layout "${id}" zone "${zone.id}" must declare a non-empty subset of [${SEMANTIC_SURFACE_NAMES.join(', ')}].`;
+    }
+  }
+  return null;
+}
+
+/** Throws with a descriptive message if `manifest` violates the v1 contract. */
+export function validateLayoutManifest(manifest: LayoutManifest): void {
+  const id = manifest.id;
+  const capabilityHit = findCapabilityLikeKey(manifest);
+  const modulePathHit = findModulePathLikeValue(manifest);
+  // Capability-fork and module-path rejection run FIRST, ahead of every
+  // structural check below: "no capability objects, no module paths in any
+  // manifest" is the doctrine violation (MOR-988/983), not a schema-shape
+  // nicety, so it must not be masked by a more specific structural error
+  // (e.g. an unknown top-level key, or a zone/surface mismatch) that
+  // happens to fire on the same poisoned manifest. This only holds if
+  // nothing below touches `manifest.zones`/etc. EAGERLY — a manifest with a
+  // capability key AND a missing `zones` field must still die on the
+  // capability message, not a raw TypeError from an early, unguarded read.
+  // So every later check that needs derived data (e.g. which surfaces are
+  // mounted) computes it lazily, inline, only once short-circuiting proves
+  // every earlier term was clean.
+  const problem =
+    (capabilityHit && `Layout "${id}" references a capability-shaped key "${capabilityHit}".`) ||
+    (modulePathHit && `Layout "${id}" references a module-path-shaped value at key "${modulePathHit}" — manifests hold stable IDs, not paths.`) ||
+    (!hasExactPlainKeys(manifest, TOP_LEVEL_KEYS) &&
+      `Layout "${id}" has unknown top-level key(s) — only [${TOP_LEVEL_KEYS.join(', ')}] are allowed.`) ||
+    (manifest.schemaVersion !== 1 && `Layout "${id}" schemaVersion must be 1.`) ||
+    (!isValidProductId(id) && `Layout id "${id}" fails naming policy: kebab-case, no vendor/geographic marker.`) ||
+    (typeof manifest.loader !== 'function' && `Layout "${id}" must declare a compiled Svelte loader function.`) ||
+    validateZones(id, manifest.zones) ||
+    (manifest.compatibleTopologies.length === 0 &&
+      `Layout "${id}" must declare at least one compatible topology class.`) ||
+    (!allIn(manifest.compatibleTopologies, TOPOLOGY_CLASSES) &&
+      `Layout "${id}" compatibleTopologies must be a subset of [${TOPOLOGY_CLASSES.join(', ')}].`) ||
+    (manifest.requiredSemanticSurfaces.length === 0 &&
+      `Layout "${id}" must declare at least one required semantic surface.`) ||
+    (manifest.requiredSemanticSurfaces.some((s) => !manifest.zones.some((z) => z.surfaces.includes(s))) &&
+      `Layout "${id}" requires a semantic surface that no zone mounts.`) ||
+    validateSizing(id, manifest.sizing) ||
+    (manifest.fallbackLayoutId !== null && !isValidProductId(manifest.fallbackLayoutId) &&
+      `Layout "${id}" fallbackLayoutId "${manifest.fallbackLayoutId}" fails naming policy.`);
+  if (problem) throw new LayoutValidationError(problem);
+}
+
+// ── Compiled registry. Count-agnostic: any manifest passing validation
+// registers, same as the design-language registry (MOR-1072 precedent).
+
+const registry = new Map<string, LayoutManifest>();
+
+/**
+ * Validates then registers `manifest`. Rejects a duplicate ID — unlike the
+ * design-language registry's overwrite semantics, a silently swapped layout
+ * loader can replace what is already resolved on screen, so MOR-1066 treats
+ * "duplicate IDs" as its own rejection class rather than an overwrite.
+ */
+export function registerLayout(manifest: LayoutManifest): void {
+  validateLayoutManifest(manifest);
+  if (registry.has(manifest.id)) {
+    throw new LayoutValidationError(`Layout id "${manifest.id}" is already registered.`);
+  }
+  registry.set(manifest.id, manifest);
+}
+export function getLayout(id: string): LayoutManifest | undefined {
+  return registry.get(id);
+}
+export function listLayoutIds(): readonly string[] {
+  return Array.from(registry.keys());
+}
+
+/** Resolves `manifest.fallbackLayoutId` and re-applies `criterion` to the
+ *  fallback itself — a fallback that also fails the criterion (or points
+ *  back at `manifest`) is not returned; the caller gets `undefined`, a typed
+ *  "unresolvable" signal, not a layout that silently fails what it was
+ *  fetched to satisfy (review cycle 1, F1: a self-referential or two-hop
+ *  fallback, or a fixed-native fallback that itself fails minScale, used to
+ *  come back unvalidated). v1 takes exactly one hop — it does not chase a
+ *  chain — but that one hop must still pass. */
+function resolveFallback(
+  manifest: LayoutManifest,
+  criterion: (candidate: LayoutManifest) => boolean,
+): LayoutManifest | undefined {
+  if (!manifest.fallbackLayoutId || manifest.fallbackLayoutId === manifest.id) return undefined;
+  const fallback = getLayout(manifest.fallbackLayoutId);
+  return fallback && criterion(fallback) ? fallback : undefined;
+}
+
+export function supportsTopology(manifest: LayoutManifest, topology: TopologyClass): boolean {
+  return manifest.compatibleTopologies.includes(topology);
+}
+
+/** Resolves `id` against `topology`, falling back to `fallbackLayoutId` only
+ *  when the fallback itself also supports `topology`. */
+export function resolveLayoutForTopology(id: string, topology: TopologyClass): LayoutManifest | undefined {
+  const manifest = getLayout(id);
+  if (!manifest) return undefined;
+  if (supportsTopology(manifest, topology)) return manifest;
+  return resolveFallback(manifest, (candidate) => supportsTopology(candidate, topology));
+}
+
+export interface Viewport { readonly width: number; readonly height: number }
+
+/** `fluid` always fits — breakpoints are reflow hints, not a hard gate in
+ *  v1. `fixed-native` compares the achievable uniform scale against
+ *  `minScale` (MOR-1160) instead of matching a breakpoint: a portrait
+ *  mobile viewport fails this arithmetically (small height vs. a wide
+ *  native design), with no separate mobile-detection branch. */
+export function fitsViewport(manifest: LayoutManifest, viewport: Viewport): boolean {
+  if (manifest.sizing.mode === 'fluid') return true;
+  const { nativeW, nativeH, minScale } = manifest.sizing;
+  return Math.min(viewport.width / nativeW, viewport.height / nativeH) >= minScale;
+}
+
+/** Same fallback path as `resolveLayoutForTopology` — falling below
+ *  `minScale` triggers the normal fallback resolution (re-checked against
+ *  the same viewport), not a special case and not an unvalidated return. */
+export function resolveLayoutForViewport(id: string, viewport: Viewport): LayoutManifest | undefined {
+  const manifest = getLayout(id);
+  if (!manifest) return undefined;
+  if (fitsViewport(manifest, viewport)) return manifest;
+  return resolveFallback(manifest, (candidate) => fitsViewport(candidate, viewport));
+}

--- a/frontend/src/presentation/layouts/declarations.ts
+++ b/frontend/src/presentation/layouts/declarations.ts
@@ -1,0 +1,23 @@
+/**
+ * The one real registration proof MOR-1066 acceptance requires: the
+ * existing `sdr-test` skin, which already mounts the two live semantic
+ * zones (MOR-1065 VFO + RX/TX reference vertical), registers as a v1
+ * layout manifest with no change to `skins/sdr-test/SdrTestSkin.svelte` or
+ * `components-v2/wiring/SemanticRadioSurfaces.svelte`. MOR-1092/93/94
+ * migrate the remaining skins the same way, purely additively.
+ */
+import { registerLayout, type LayoutManifest } from './contract';
+
+export const sdrTestLayout: LayoutManifest = {
+  schemaVersion: 1,
+  id: 'sdr-test',
+  displayName: 'SDR Test',
+  loader: () => import('../../skins/sdr-test/SdrTestSkin.svelte'),
+  zones: [{ id: 'main', surfaces: ['vfo', 'rxTx'] }],
+  compatibleTopologies: ['1/single', '1/ab', '2/ab_shared', '2/main_sub'],
+  requiredSemanticSurfaces: ['vfo', 'rxTx'],
+  sizing: { mode: 'fluid', responsiveBreakpoints: [] },
+  fallbackLayoutId: null,
+};
+
+registerLayout(sdrTestLayout);


### PR DESCRIPTION
## Summary

Layout manifest v1 — the contract for the dual-receiver cockpit (MOR-1067+) and the entrypoint migrations (MOR-1092/93/94). `frontend/src/presentation/layouts/{contract,compatibility,declarations}.ts` (191 net production LOC under the epic's frozen counting formula) + tests + two sanctioned ADR doc edits:

- **Schema v1:** id / loader / semantic zones / topology classes (derived presentation fact, never a capability claim — MOR-988) / MOR-1160 sizing axis / fallback.
- **Validator:** exact plain-key discipline (Reflect.ownKeys + plain prototype; prototype-getter and symbol smuggling pinned per the MOR-1072 N1 lesson), capability-like keys rejected at all depths incl. array elements, module-path strings rejected ($lib/, bare src/, absolute — comment honest about non-exhaustiveness), naming policy reused from the languages contract, checks run before any zone access (malformed input hits the scan, not a TypeError), cross-field mount check.
- **Fallback resolution (review F1):** the single permitted hop is re-validated against the same predicate — self-referential and multi-hop chains and minScale-failing viewport fallbacks fail loudly instead of returning unsupported layouts (the exact MOR-1160 portrait-mobile exclusion case); positive controls still resolve.
- **Registry:** count-agnostic, duplicate-ID rejection, topology/viewport fallback; `sdr-test` registered as a REAL proof (loader traced to the actual skin mounting the semantic surfaces; zero skin changes).
- **Design-language handshake:** pure two-declaration composition (fieldline × dual-receiver-cockpit → incompatible; studioline × all → compatible); mutation proves it consults nothing else.
- **ADR edits:** `japanese-sdr` struck (MOR-977 record); manifest wording aligned to topology classes (MOR-988).

## Independent verification (one cycle)

Cycle 0 found the unvalidated fallback return (three probe classes), the unpinned exact-key defense, the module-path scan gaps, and the eager zone read defeating the documented check order — all fixed and re-verified by the reviewer's own probes with per-fix mutation kills and sha-verified restores. Schema↔ADR map ruled exact (no invented fields, no gaps; topology classes correctly substitute for the old capability wording). Suites: 52/52 new, 347/347 presentation+semantic+boundaries, lint/lint:boundaries/svelte-check/ruff clean; full frontend baseline-clean. LOC measured under the frozen epic formula: 191 net ≤ 200.

Known caveat carried (recorded, out of scope): the shared naming denylist's ftdx-class evasions (MOR-1072 file, review-owned class).

Linear: MOR-1066 (unblocks MOR-1067 and MOR-1092/1093/1094)

🤖 Generated with [Claude Code](https://claude.com/claude-code)