### PR TITLE
feat(MOR-1093): complete SDR-test migration to semantic/layout boundaries

### DIFF
--- a/frontend/src/__tests__/architecture-boundaries.test.ts
+++ b/frontend/src/__tests__/architecture-boundaries.test.ts
@@ -436,4 +436,53 @@ describe('v3 package boundaries (MOR-1061)', () => {
     );
     expect(hits).toBeGreaterThan(0);
   });
+
+  // ── MOR-1093: the sdr-test entrypoint's own import boundary ────────────
+  // `src/skins/**/*.svelte` (and components-v2/layout/**) carry the looser
+  // FORBIDDEN_RUNTIME_IMPORTS ban (transport + audioManager only — unlike
+  // the presentation/ zone above, capabilities and commands are legal here)
+  // since MOR-1061, but nothing in this file had ever run that rule through
+  // the real config for the sdr-test path. SdrTestSkin.svelte is a pure
+  // RadioLayout delegate with no other import; these pin the rule that keeps
+  // it that way, and confirm the capabilities import SdrVfoScreen.svelte
+  // gained under MOR-1093 (replacing a hardcoded manufacturer-specific
+  // fallback table) stays inside the boundary this zone actually enforces.
+
+  // .svelte fixtures need a <script> block (see the workspace .svelte test
+  // above) — svelte-eslint-parser only treats code inside it as a Program
+  // with ImportDeclaration nodes; a bare top-level import is parsed as
+  // template text, not JS, and would silently score every case below as
+  // "0 hits" regardless of which import it names.
+
+  it('rejects the sdr-test entrypoint importing transport', async () => {
+    const hits = await restrictedImportHits(
+      `<script lang="ts">\n  import { sendCommand } from '$lib/transport/ws-client';\n</script>`,
+      'src/skins/sdr-test/SdrTestSkin.svelte',
+    );
+    expect(hits).toBeGreaterThan(0);
+  });
+
+  it('rejects the sdr-test entrypoint importing audioManager (relative)', async () => {
+    const hits = await restrictedImportHits(
+      `<script lang="ts">\n  import { audioManager } from '../../lib/audio/audio-manager';\n</script>`,
+      'src/skins/sdr-test/SdrTestSkin.svelte',
+    );
+    expect(hits).toBeGreaterThan(0);
+  });
+
+  it('allows the sdr-test entrypoint to import RadioLayout (its actual import)', async () => {
+    const hits = await restrictedImportHits(
+      `<script lang="ts">\n  import RadioLayout from '../../components-v2/layout/RadioLayout.svelte';\n</script>`,
+      'src/skins/sdr-test/SdrTestSkin.svelte',
+    );
+    expect(hits).toBe(0);
+  });
+
+  it('allows the sdr-test diagnostic renderer to import capabilities (unlike the presentation/ zone)', async () => {
+    const hits = await restrictedImportHits(
+      `<script lang="ts">\n  import { getAgcLabels, getAttValues } from '$lib/stores/capabilities.svelte';\n</script>`,
+      'src/skins/sdr-test/SdrVfoScreen.svelte',
+    );
+    expect(hits).toBe(0);
+  });
 });

--- a/frontend/src/presentation/layouts/__tests__/sdr-registration.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/sdr-registration.test.ts
@@ -1,0 +1,124 @@
+/**
+ * MOR-1093 — the sdr-test presentation entrypoint, registered as a v1 layout
+ * manifest (MOR-1066) and resolved through the REAL registry, not a fixture
+ * registry and not a stub loader.
+ *
+ * `registry.test.ts` already pins the bare registration fact ("the sdr-test
+ * real registration proof") as MOR-1066's acceptance evidence. This file is
+ * the entrypoint's OWN focused suite, mirroring the shape
+ * `lcd-registration.test.ts` (MOR-1092) uses for its family: topology
+ * honesty across all four canonical classes, the sizing axis, and — because
+ * sdr-test has no sibling to fall back to — that it declares none. Every
+ * claim is read back out of the shared registry rather than off the
+ * exported object, so a manifest that is written but never registered fails
+ * here. Each test's doc line names the mutation it exists to kill.
+ */
+import { readFileSync } from 'node:fs';
+import { describe, it, expect } from 'vitest';
+import {
+  getLayout, resolveLayoutForTopology, resolveLayoutForViewport,
+  TOPOLOGY_CLASSES,
+} from '../contract';
+// Deliberately through the shared aggregation entry, not `../declarations`'
+// module-scope side effect alone: importing the named export pins that
+// `declarations.ts` really registers `sdrTestLayout` (nothing else does),
+// and keeps this fast-pool file on the SAME module entry point as
+// `registry.test.ts` — under `isolate: false` a second entry into a module
+// that registers at import time is how a split module graph (and a phantom
+// "layout not registered") happens. See vite.config.ts #771.
+import { sdrTestLayout } from '../declarations';
+
+describe('the sdr-test entrypoint is registered in the real registry', () => {
+  // Kills: declarations.ts defining the manifest but never calling
+  // registerLayout — the resolution below would then read undefined.
+  it('registers "sdr-test" under its stable entrypoint id', () => {
+    expect(getLayout('sdr-test')).toBe(sdrTestLayout);
+    expect(sdrTestLayout.id).toBe('sdr-test');
+  });
+
+  // Kills: a manifest id that drifts from the SkinId SdrTestSkin.svelte
+  // actually passes to RadioLayout. The manifest is only an entrypoint
+  // declaration if the two agree.
+  it('shares its id with the skin registry loader SdrTestSkin.svelte resolves under', () => {
+    const registrySource = readFileSync('src/skins/registry.ts', 'utf8');
+    expect(registrySource).toMatch(/'sdr-test':\s*\(\)\s*=>\s*import\(['"]\.\/sdr-test\/SdrTestSkin\.svelte['"]\)/);
+    const skinSource = readFileSync('src/skins/sdr-test/SdrTestSkin.svelte', 'utf8');
+    expect(skinSource).toMatch(/skinId=["']sdr-test["']/);
+  });
+
+  // Kills: a manifest that declares no compiled loader at all. That the
+  // loader reaches the REAL entrypoint — and renders the semantic surfaces
+  // in place of the legacy VFO/TX block — is proved by mounting it in
+  // `components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts`
+  // (MOR-1065); this file runs outside the DOM environment that whole tree
+  // needs.
+  it('declares a compiled loader', () => {
+    expect(typeof sdrTestLayout.loader).toBe('function');
+  });
+});
+
+describe('declared semantic zones (what the migrated entrypoint actually mounts)', () => {
+  // Kills: declaring a surface the layout does not mount, or dropping rxTx
+  // (which would let sdr-test keep the legacy sidebar TX panel as its only
+  // TX owner).
+  it('mounts vfo + rxTx in one zone', () => {
+    expect(sdrTestLayout.zones).toEqual([{ id: 'main', surfaces: ['vfo', 'rxTx'] }]);
+    expect([...sdrTestLayout.requiredSemanticSurfaces].sort()).toEqual(['rxTx', 'vfo']);
+  });
+});
+
+describe('topology honesty', () => {
+  // Kills: under-declaring the topology set. RadioLayout renders the deck
+  // unconditionally and SemanticRadioSurfaces itself branches on the live
+  // topology fixture (`semantic-desktop-migration.component.test.ts` proves
+  // all four render safely), so every canonical class resolves to sdr-test
+  // itself, never to a fallback.
+  it('resolves itself on all four canonical topologies', () => {
+    for (const topology of TOPOLOGY_CLASSES) {
+      expect(resolveLayoutForTopology('sdr-test', topology)?.id).toBe('sdr-test');
+    }
+  });
+});
+
+describe('MOR-1160 sizing axis — sdr-test stays fluid', () => {
+  // Kills: silently switching sdr-test onto the fixed-native stage the LCD
+  // family owns — sdr-test is a reflowing desktop layout, not a native-scaled
+  // instrument glass.
+  it('declares fluid sizing with no breakpoints', () => {
+    expect(sdrTestLayout.sizing).toEqual({ mode: 'fluid', responsiveBreakpoints: [] });
+  });
+
+  it('resolves on both a desktop and an iPhone-class portrait viewport — fluid never gates', () => {
+    expect(resolveLayoutForViewport('sdr-test', { width: 1440, height: 900 })?.id).toBe('sdr-test');
+    expect(resolveLayoutForViewport('sdr-test', { width: 390, height: 844 })?.id).toBe('sdr-test');
+  });
+});
+
+describe('no fallback family', () => {
+  // Kills: adding a fallbackLayoutId that was never part of sdr-test's
+  // migration — sdr-test is not part of the LCD family and has nothing to
+  // fall back to yet.
+  it('declares no fallback', () => {
+    expect(sdrTestLayout.fallbackLayoutId).toBeNull();
+  });
+});
+
+describe('IC-specific fallback policy is out of the layout (MOR-1093)', () => {
+  // Kills: reintroducing a hardcoded manufacturer-specific label/value table
+  // (e.g. an IC-7610 attenuator-dB or AGC-label array) into the sdr-test
+  // folder instead of sourcing it from capabilities. This scans the actual
+  // files rather than asserting behavior, because the component this policy
+  // lived in (SdrVfoScreen.svelte) is not currently mounted by any test —
+  // see semantic-desktop-migration.component.test.ts for the proof that it
+  // does not render at all.
+  it('SdrVfoScreen carries no local manufacturer-specific value table', () => {
+    const source = readFileSync('src/skins/sdr-test/SdrVfoScreen.svelte', 'utf8');
+    expect(source).not.toMatch(/const ATT_DB/);
+    expect(source).not.toMatch(/const AGC_LABELS/);
+    expect(source).not.toMatch(/IC-7610 ATT levels/);
+    expect(source).not.toMatch(/IC-7610 AGC:/);
+    // The two labels it used to hardcode are now capability-sourced.
+    expect(source).toMatch(/getAttValues\(\)/);
+    expect(source).toMatch(/getAgcLabels\(\)/);
+  });
+});

--- a/frontend/src/skins/sdr-test/SdrTestSkin.svelte
+++ b/frontend/src/skins/sdr-test/SdrTestSkin.svelte
@@ -1,11 +1,16 @@
 <!--
-  SDR Test Skin — prototype desktop skin that swaps the twin-VFO + bridge
-  block for an IC-7610-inspired "SDR screen" design (see SdrVfoScreen).
-  Everything else (sidebars, spectrum, meters dock, status bar) is inherited
-  from the standard desktop layout.
+  SDR Test Skin — the MOR-1065 migrated reference vertical. Delegates to
+  RadioLayout, which branches on skinId === 'sdr-test' and mounts the
+  semantic VFO/RX-TX surfaces (SemanticRadioSurfaces, MOR-1063/1064) in
+  place of the legacy twin-VFO block and sidebar TX panel. Everything else
+  (sidebars, spectrum, meters dock, status bar) is inherited from the
+  standard desktop layout.
 
-  Delegates to RadioLayout, which branches on skinId === 'sdr-test' and
-  swaps VfoHeader for SdrVfoScreen in the top slot.
+  Registered as the 'sdr-test' v1 layout manifest under this same id
+  (MOR-1066, presentation/layouts/declarations.ts) — see
+  presentation/layouts/__tests__/sdr-registration.test.ts. The pre-migration
+  SdrVfoScreen prototype is no longer mounted here; RadioLayout stopped
+  swapping it in once the semantic surfaces landed.
 -->
 <script lang="ts">
   import RadioLayout from '../../components-v2/layout/RadioLayout.svelte';

--- a/frontend/src/skins/sdr-test/SdrVfoScreen.svelte
+++ b/frontend/src/skins/sdr-test/SdrVfoScreen.svelte
@@ -1,10 +1,17 @@
 <!--
   SdrVfoScreen — IC-7610-style dual VFO + central bridge, LCD/"SDR screen" look.
 
-  Drop-in visual replacement for VfoHeader in the sdr-test skin. Consumes the
-  same VfoStateProps as VfoHeader so it plugs directly into the existing
-  runtime wiring (state-adapter + command-bus). Visual design ported from
-  Claude Design handoff "VFO SDR Screen" (2026-04-20).
+  Not currently mounted: MOR-1065 replaced this top slot with
+  SemanticRadioSurfaces (see SdrTestSkin.svelte), so RadioLayout no longer
+  swaps VfoHeader for this component. Kept as the pre-migration prototype
+  reference pending the MOR-1099 legacy-wrapper retirement; MOR-1093 removed
+  the one piece of live policy it carried (below) since a dead file should
+  not also be the sdr-test folder's only source of manufacturer-specific
+  capability fallback values.
+
+  Consumes the same VfoStateProps as VfoHeader so it plugs directly into the
+  existing runtime wiring (state-adapter + command-bus). Visual design ported
+  from Claude Design handoff "VFO SDR Screen" (2026-04-20).
 
   Wired live: freq, mode, filter, active receiver, TX/RX, split, dual-watch,
   sValue, band label, SPLIT/A⇄B/A=B/M/S/SPEAK callbacks.
@@ -15,6 +22,7 @@
   import { formatFrequency } from '../../components-v2/display/frequency-format';
   import type { VfoStateProps } from '../../components-v2/layout/layout-utils';
   import { calibratedToRaw, calibratedToSUnit, getScaleMaxRaw, getS9Raw } from '../../components-v2/meters/smeter-scale';
+  import { getAgcLabels, getAttValues } from '$lib/stores/capabilities.svelte';
   import { HardwareButton } from '$lib/Button';
 
   /**
@@ -80,11 +88,12 @@
     if (hz >= 1000) return `${(hz / 1000).toFixed(hz % 1000 === 0 ? 0 : 1)}k`;
     return String(hz);
   }
-  // IC-7610 ATT levels (dB): 0 / 12 / 18 / 24
-  const ATT_DB = [0, 12, 18, 24];
+  // Attenuator dB steps are radio-model-specific — sourced from capabilities
+  // (MOR-1093; was a hardcoded IC-7610 guess that had drifted from the real
+  // values, see capabilities.ts's own `attValues` doc comment).
   function attLabel(rx: Record<string, unknown> | null | undefined): string {
     const a = num(rx, 'att');
-    const db = ATT_DB[a] ?? a;
+    const db = getAttValues()[a] ?? a;
     return db > 0 ? `ATT ${db}dB` : 'ATT';
   }
   function preampLabel(rx: Record<string, unknown> | null | undefined): string {
@@ -105,11 +114,13 @@
     const sign = khz > 0 ? '+' : khz < 0 ? '' : '+';
     return `${sign}${khz.toFixed(2)} kHz`;
   }
-  // IC-7610 AGC: 1=FAST, 2=MID, 3=SLOW (per capabilities.agcLabels default)
-  const AGC_LABELS: Record<number, string> = { 1: 'FAST', 2: 'MID', 3: 'SLOW' };
+  // AGC mode labels are radio-model-specific — sourced from capabilities
+  // (MOR-1093), the same generic fallback (`{1:'FAST',2:'MID',3:'SLOW'}`)
+  // `state-adapter.ts`'s `toAgcProps` already uses for the desktop AgcPanel.
   function agcLabel(rx: Record<string, unknown> | null | undefined): string {
     const m = num(rx, 'agc');
-    return AGC_LABELS[m] ? `AGC ${AGC_LABELS[m]}` : 'AGC';
+    const label = getAgcLabels()[String(m)];
+    return label ? `AGC ${label}` : 'AGC';
   }
   // rfGain is the backend-normalized 0.0..1.0 float (CI-V raw 0-255 is divided
   // by 255 at the source — see runtime/_civ_rx.py). Convert to 0..100 for


### PR DESCRIPTION
## Summary

The last SDR-test delta after MOR-1065/1066/1086 (+16 net LOC, 2 production files):

- `SdrVfoScreen.svelte` (unreachable prototype — repo-wide grep: zero consumers) carried hardcoded IC-7610 ATT/AGC tables — exactly the manufacturer policy this ticket targets, and the values had DRIFTED (real IC-7610 ladder per `rigs/ic7610.toml`: 16 × 3 dB steps, not `[0,12,18,24]`). Both tables now consume the existing capability-store getters (`getAttValues()`/`getAgcLabels()` — the same source `state-adapter.ts` uses), with a mutation-verified regression pin against reintroducing hardcoded tables. (`rm` of the dead file was classifier-blocked; the acceptance's "moves to the adapter" branch was taken — final deletion rides MOR-1099.)
- 4 new architecture-boundary tests close a real gap: the `src/skins/**` eslint zone had never been exercised (reviewer-verified discriminating).
- Stale doc comment in `SdrTestSkin.svelte` fixed.

## Independent verification

- All 8 acceptance criteria adjudicated per-citation against merged main (delegate entrypoint, manifest registration, semantic surfaces, MOR-1086 identity sweeps explicitly pinning sdr-test).
- Language-ID wording RULED not-yet-applicable: the manifest schema has no design-language field (its exact-key validator would reject one); languages are placeholder-token declarations with zero non-test consumers; consistent with the MOR-1092 precedent.
- Dead-file and drift claims independently reproduced (drift worse than the builder stated; `capabilities.ts`'s own doc comment is stale — filed MOR-1246).
- Suites: 57/57 targeted; full frontend failure set matched against an independent same-base baseline (known localStorage env class only); lint/boundaries/i18n/svelte-check/tsc/ruff clean.

Linear: MOR-1093 (with MOR-1094 closes MOR-973)

🤖 Generated with [Claude Code](https://claude.com/claude-code)