### PR TITLE
feat(MOR-1094): migrate the mobile shell to App-owned behavior and manifests

### DIFF
--- a/frontend/src/components-v2/layout/MobileRadioLayout.svelte
+++ b/frontend/src/components-v2/layout/MobileRadioLayout.svelte
@@ -33,6 +33,7 @@
   import CwPanel from '../panels/CwPanel.svelte';
   import DockMeterPanel from '../panels/DockMeterPanel.svelte';
   import KeyboardHandler from './KeyboardHandler.svelte';
+  import SemanticRadioSurfaces from '../wiring/SemanticRadioSurfaces.svelte';
   import MobileChipBar from './mobile-chip-bar.svelte';
   import EssentialsPanel from '../panels/EssentialsPanel.svelte';
   import PttFab from '../controls/PttFab.svelte';
@@ -639,6 +640,17 @@
         <AmberLcdDisplay />
       </section>
     {/if}
+
+    <!-- MOR-1094: the portrait deck's VFO facts and RX/TX status/action are
+         owned by the semantic surfaces (MOR-1063/1064), wired exactly once by
+         the shared SemanticRadioSurfaces — no new TX path, and no change to
+         the press-and-hold PTT below, which keeps its own gesture recognizer
+         and its own per-surface sourceId on the App TX controller. Mounted
+         outside the chip panels on purpose: a chip tap destroys and recreates
+         its panel, and this subtree is a TX lease source. -->
+    <section class="m-semantic-deck">
+      <SemanticRadioSurfaces />
+    </section>
 
     <!-- Chip-scroll IA nav (#839) -->
     <MobileChipBar
@@ -1321,6 +1333,16 @@
 
   .m-content::-webkit-scrollbar {
     display: none;
+  }
+
+  /* ── Semantic deck (MOR-1094) ── */
+  /* The surfaces declare `height: 100%`, which inside the scrolling
+     `.m-content` would resolve to the full viewport. An auto-height wrapper
+     resolves that percentage to `auto` and keeps the deck the size of its
+     content, above the chip bar. Same slot idiom as the LCD control column. */
+  .m-semantic-deck {
+    padding: 6px 8px;
+    border-bottom: 1px solid var(--v2-border-darker, #222);
   }
 
   /* ── Spectrum ── */

--- a/frontend/src/components-v2/layout/__tests__/semantic-mobile-migration.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-mobile-migration.component.test.ts
@@ -1,0 +1,612 @@
+/**
+ * MOR-1094 — the mobile presentation shell migrated to App-owned behavior and
+ * a v1 layout manifest, mirroring the MOR-1092 LCD slice.
+ *
+ * SAFETY-ADJACENT. The mobile shell carries the operator's press-and-hold PTT,
+ * and this slice adds a SECOND TX source to it (the semantic RX/TX surface,
+ * which keys LATCHED). So four things must hold at once:
+ *   1. the semantic VFO / RX-TX surfaces are mounted in the portrait deck via
+ *      the unchanged `SemanticRadioSurfaces` wiring — no new TX code path;
+ *   2. the press-and-hold path is still the MOR-1011/1012 gesture recognizer
+ *      feeding the App TX controller under its own per-surface `sourceId`,
+ *      byte-identical to before — pinned by identity, not by shape;
+ *   3. the two sources cannot disturb each other: the semantic surface's
+ *      fail-closed teardown release (which fires on every rotation, because
+ *      the portrait deck is destroyed) must be INERT against a lease the PTT
+ *      gesture owns, and vice versa;
+ *   4. the App-global Toast / power overlay / TX lamp stay singular and global
+ *      (MOR-1059), and the skin wrapper owns no resolution or runtime.
+ *
+ * The controller behind `getAppTxController` is the REAL `TxController` over
+ * stub dependencies, not a double: claim 3 is a property of the production
+ * state machine's owner check, and a recording spy would pass it vacuously.
+ *
+ * Each test's doc line names the mutation it exists to kill.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { mount, unmount, flushSync } from 'svelte';
+import { TxController } from '$lib/runtime/tx-controller/controller';
+import type { TxControllerDependencies } from '$lib/runtime/tx-controller/controller';
+
+// -- Child components the shell mounts that are irrelevant here -------------
+vi.mock('../../../components/spectrum/SpectrumPanel.svelte', async () => {
+  const stub = await import('./SpectrumPanelStub.svelte');
+  return { default: stub.default };
+});
+vi.mock('../panels/lcd/AmberLcdDisplay.svelte', () => ({ default: function S() { return {}; } }));
+vi.mock('../display/FrequencyDisplay.svelte', () => ({ default: function S() { return {}; } }));
+vi.mock('../meters/LinearSMeter.svelte', () => ({ default: function S() { return {}; } }));
+vi.mock('../controls/CollapsiblePanel.svelte', () => ({ default: function S() { return {}; } }));
+vi.mock('../controls/BottomSheet.svelte', () => ({ default: function S() { return {}; } }));
+vi.mock('../controls/BandSelector.svelte', () => ({ default: function S() { return {}; } }));
+vi.mock('../panels/FilterPanel.svelte', () => ({ default: function S() { return {}; } }));
+vi.mock('../panels/RxAudioPanel.svelte', () => ({ default: function S() { return {}; } }));
+vi.mock('../panels/TxPanel.svelte', () => ({ default: function S() { return {}; } }));
+vi.mock('../panels/DspPanel.svelte', () => ({ default: function S() { return {}; } }));
+vi.mock('../panels/AgcPanel.svelte', () => ({ default: function S() { return {}; } }));
+vi.mock('../panels/RfFrontEnd.svelte', () => ({ default: function S() { return {}; } }));
+vi.mock('../panels/RitXitPanel.svelte', () => ({ default: function S() { return {}; } }));
+vi.mock('../panels/AntennaPanel.svelte', () => ({ default: function S() { return {}; } }));
+vi.mock('../panels/ScanPanel.svelte', () => ({ default: function S() { return {}; } }));
+vi.mock('../panels/CwPanel.svelte', () => ({ default: function S() { return {}; } }));
+vi.mock('../panels/DockMeterPanel.svelte', () => ({ default: function S() { return {}; } }));
+vi.mock('../panels/EssentialsPanel.svelte', () => ({ default: function S() { return {}; } }));
+vi.mock('./KeyboardHandler.svelte', () => ({ default: function S() { return {}; } }));
+vi.mock('$lib/Button', () => ({ HardwareButton: function S() { return {}; } }));
+vi.mock('lucide-svelte', () => {
+  const S = function () { return {}; };
+  return { Settings: S, ChevronLeft: S, ChevronRight: S, ChevronsLeft: S, ChevronsRight: S, Mic: S, MicOff: S, Sliders: S, Radio: S };
+});
+vi.mock('../controls/value-control', () => ({
+  ValueControl: function S() { return {}; },
+  normalizedPercentDisplay: (v: number) => `${Math.round(v * 100)}%`,
+}));
+vi.mock('./vfo-layout-tokens', () => ({
+  resolveVfoLayoutProfile: vi.fn(() => 'standard'),
+  vfoLayoutStyleVars: vi.fn(() => ''),
+}));
+
+// The MOR-617 banner's adapter reads persisted state; keep this suite hermetic
+// (and free of the localStorage-shaped environment noise) by stubbing it flat.
+vi.mock('$lib/runtime/adapters/mod-input-tx-guard.svelte', () => ({
+  deriveModInputTxGuardProps: vi.fn(() => ({ visible: false, sourceLabel: null })),
+  getModInputTxGuardHandlers: vi.fn(() => ({ onSetLan: vi.fn(), onDismiss: vi.fn() })),
+}));
+
+// A real, fully-populated view model so the semantic surfaces actually RENDER.
+// Without it `SemanticRadioSurfaces` short-circuits on `{#if view}` and every
+// assertion below about the surfaces would pass for the wrong reason.
+vi.mock('$lib/runtime/adapters/radio-view-model-adapter', async () => {
+  const { topologyFixtures } = await import('../../../semantic/fixtures/topologies');
+  // `1/single` matches the mocked capabilities below (no dual receiver) and is
+  // the fixture whose TX target is observed and whose permit is allowed — so
+  // the RX/TX surface's key action is reachable rather than blocked.
+  return { toRadioViewModel: vi.fn(() => topologyFixtures['1/single']) };
+});
+
+// -- Store mocks (kept in step with MobileRadioLayout.component.svelte.test.ts) --
+vi.mock('$lib/stores/radio.svelte', () => ({
+  radio: { current: null as { active?: 'MAIN' | 'SUB' } | null },
+  getActiveReceiver: vi.fn(), getRadioState: vi.fn(), patchActiveReceiver: vi.fn(),
+  patchRadioState: vi.fn(), patchReceiver: vi.fn(),
+}));
+vi.mock('$lib/stores/connection.svelte', () => ({
+  getConnectionStatus: vi.fn(() => ({ connected: false })),
+  getRadioPowerOn: vi.fn(() => null),
+}));
+vi.mock('$lib/stores/audio.svelte', () => ({
+  getAudioState: vi.fn(() => ({ volume: 50, muted: false, rxEnabled: false, txEnabled: false, micEnabled: false, bridgeRunning: false })),
+}));
+vi.mock('$lib/audio/audio-manager', () => ({
+  audioManager: { start: vi.fn(), stop: vi.fn(), setVolume: vi.fn(), toggleMute: vi.fn() },
+}));
+vi.mock('$lib/utils/tx-permit', () => ({ getTxPermit: vi.fn(() => 'allowed') }));
+vi.mock('$lib/stores/tuning.svelte', () => ({ applyModeDefault: vi.fn() }));
+vi.mock('$lib/stores/capabilities.svelte', () => ({
+  hasTx: vi.fn(() => true), hasDualReceiver: vi.fn(() => false), hasAnyScope: vi.fn(() => false),
+  hasSpectrum: vi.fn(() => true), getCapabilities: vi.fn(() => ({ freqRanges: [], modes: [], filters: [] })),
+  getKeyboardConfig: vi.fn(() => null), setCapabilities: vi.fn(), hasCapability: vi.fn(() => false),
+  vfoLabel: vi.fn((s: string) => s === 'A' ? 'MAIN' : 'SUB'),
+  receiverLabel: vi.fn((id: 'MAIN' | 'SUB') => id), isAudioFftScope: vi.fn(() => false),
+  hasAudioFft: vi.fn(() => false), getScopeSource: vi.fn(() => null), hasAudio: vi.fn(() => false),
+  getSmeterCalibration: vi.fn(() => null), getSmeterRedline: vi.fn(() => null),
+  getMeterCalibration: vi.fn(() => null), getMeterRedline: vi.fn(() => null),
+  getControlRange: vi.fn(() => ({ min: 0, max: 255 })),
+  getSupportedModes: vi.fn(() => ['USB', 'LSB', 'CW', 'AM', 'FM']),
+  getSupportedFilters: vi.fn(() => ['FIL1', 'FIL2', 'FIL3']),
+  getAttValues: vi.fn(() => [0, 10, 20]), getAttLabels: vi.fn(() => ({ 0: '0dB', 10: '10dB', 20: '20dB' })),
+  getPreValues: vi.fn(() => [0, 1, 2]), getPreLabels: vi.fn(() => ({ 0: 'OFF', 1: 'PRE1', 2: 'PRE2' })),
+  getAgcModes: vi.fn(() => [0, 1, 2, 3]),
+  getAgcLabels: vi.fn(() => ({ 0: 'OFF', 1: 'FAST', 2: 'MID', 3: 'SLOW' })),
+  getVfoScheme: vi.fn(() => 'ab'), getAntennaCount: vi.fn(() => 1),
+}));
+vi.mock('../../wiring/command-bus', () => {
+  const n = vi.fn();
+  return {
+    makeVfoHandlers: () => ({
+      onMainFreqChange: n, onSubFreqChange: n, onVfoSwap: n, onVfoEqual: n, onReceiverSelect: n,
+      onMainVfoClick: n, onSubVfoClick: n, onSplitToggle: n, onSwap: n, onEqual: n,
+      onVfoSelect: n, onDualWatchToggle: n,
+    }),
+    makeMeterHandlers: () => ({ onMeterSourceChange: n }), makeKeyboardHandlers: () => ({ dispatch: n }),
+    makeModeHandlers: () => ({ onModeChange: n, onDataModeChange: n }),
+    makeFilterHandlers: () => ({ onFilterChange: n, onFilterWidthChange: n }),
+    makeBandHandlers: () => ({ onBandSelect: n }), makePresetHandlers: () => ({ onPresetSelect: n }),
+    makeRxAudioHandlers: () => ({ onAfLevelChange: n, onMonitorModeChange: n }),
+    makeTxHandlers: () => ({ onPttChange: n, onPowerChange: n, onTuneStart: n, onAtuToggle: n, onRfPowerChange: n, onMicGainChange: n, onAtuTune: n, onVoxToggle: n, onCompToggle: n, onCompLevelChange: n, onMonToggle: n, onMonLevelChange: n, onDriveGainChange: n }),
+    makeRfFrontEndHandlers: () => ({ onAttChange: n, onPreChange: n, onRfGainChange: n }),
+    makeAgcHandlers: () => ({ onAgcModeChange: n }),
+    makeRitXitHandlers: () => ({ onRitToggle: n, onRitClear: n, onXitToggle: n, onXitClear: n }),
+    makeDspHandlers: () => ({ onNrToggle: n, onNbToggle: n, onNotchToggle: n, onNrModeChange: n, onNotchModeChange: n }),
+    makeCwPanelHandlers: () => ({ onSpeedChange: n }),
+    makeAntennaHandlers: () => ({ onAntennaSelect: n }),
+    makeScanHandlers: () => ({ onScanStart: n, onScanStop: n, onDfSpanChange: n, onResumeChange: n }),
+  };
+});
+vi.mock('../../wiring/state-adapter', () => {
+  const vfo = { freq: 14074000, mode: 'USB', filter: 'FIL1', sValue: 0, badges: {}, receiver: 'main', isActive: true };
+  return {
+    toVfoProps: vi.fn(() => vfo), toVfoOpsProps: vi.fn(() => ({ split: false, dualWatch: false })),
+    toMeterProps: vi.fn(() => ({ signal: 0, rfPower: 0, swr: 0, alc: 0, txActive: false, meterSource: 'S' })),
+    toModeProps: vi.fn(() => ({ currentMode: 'USB', modes: ['USB', 'LSB', 'CW', 'AM', 'FM'], dataMode: 0 })),
+    toFilterProps: vi.fn(() => ({ currentFilter: 1, filterLabels: ['FIL1', 'FIL2', 'FIL3'] })),
+    toBandSelectorProps: vi.fn(() => ({ currentFreq: 14074000 })),
+    toRxAudioProps: vi.fn(() => ({ afLevel: 0.5, monitorMode: 'local' })),
+    toTxProps: vi.fn(() => ({ rfPower: 0.5, txActive: false, atuActive: false, atuTuning: false })),
+    toRfFrontEndProps: vi.fn(() => ({ att: 0, preamp: 0, rfGain: 1 })),
+    toAgcProps: vi.fn(() => ({ agcMode: 3 })),
+    toRitXitProps: vi.fn(() => ({ ritOn: false, ritOffset: 0, xitOn: false, xitOffset: 0 })),
+    toDspProps: vi.fn(() => ({ nr: false, nb: false, notch: false })), toCwProps: vi.fn(() => ({ speed: 20 })),
+    toAntennaProps: vi.fn(() => ({ selected: 1 })),
+    toScanProps: vi.fn(() => ({ scanning: false, scanType: 'off', scanResumeMode: 'time' })),
+  };
+});
+
+const txHost = vi.hoisted(() => ({ current: undefined as unknown as TxHostFacade }));
+vi.mock('$lib/runtime/tx-controller/app-host', () => ({
+  getAppTxController: () => txHost.current,
+}));
+
+import MobileRadioLayout from '../MobileRadioLayout.svelte';
+import mobileLayoutSource from '../MobileRadioLayout.svelte?raw';
+import mobileSkinSource from '../../../skins/mobile/MobileSkin.svelte?raw';
+import { hasTx } from '$lib/stores/capabilities.svelte';
+
+// ---------------------------------------------------------------------------
+// Real-controller harness
+//
+// Copied from MobileRadioLayout.component.svelte.test.ts (itself copied from
+// TxPanel.test.ts). Duplicated rather than shared because the suites live in
+// different pools and a shared helper module would pin the controller in the
+// ``isolate: false`` cache for siblings that mock it — see vite.config.ts /
+// #771. Keep the copies in step.
+// ---------------------------------------------------------------------------
+type TxEvent = Parameters<TxController['dispatch']>[0];
+type StartEvent = Extract<TxEvent, { type: 'start' }>;
+type Eligibility = StartEvent['eligibility'];
+type Observation = StartEvent['ptt'];
+type Intent = StartEvent['intent'];
+type Guard = Extract<TxEvent, { type: 'intent' }>['guard'];
+type Command = Parameters<TxControllerDependencies['sendPtt']>[0];
+type Report = Parameters<TxControllerDependencies['sendPtt']>[3];
+type TxHostFacade = ReturnType<typeof createTxHarness>['facade'];
+
+const marker = (seq: number) => ({
+  authorityEpoch: 1, pttObservationSeq: seq, pttLastObservedMonotonic: seq,
+});
+const allowed: Eligibility = {
+  catPtt: true, browserTxAudio: true, controlLive: true, permit: 'allowed',
+  target: { receiver: 'MAIN', slot: 'A', frequencyHz: 14_074_000 },
+};
+const observe = (value: boolean, seq: number): Observation =>
+  ({ value, observed: true, fresh: true, source: 'radio-readback', marker: marker(seq) });
+
+function deepFreeze<T>(value: T): T {
+  if (value === null || typeof value !== 'object') return value;
+  const copy = Object.fromEntries(Object.entries(value as Record<string, unknown>)
+    .map(([key, child]) => [key, deepFreeze(child)]));
+  return Object.freeze(copy) as unknown as T;
+}
+
+function createTxHarness() {
+  const sends: Array<{ command: Command; report: Report }> = [];
+  /** Every `start` the App controller is asked for, with its source identity. */
+  const starts: Array<{ sourceId: string; leaseId: string; intent: Intent }> = [];
+  /** Every `release` request, whether or not the model honours it. */
+  const releases: Array<{ sourceId: string }> = [];
+  const audio: { next: Promise<string | null> } = { next: Promise.resolve(null) };
+  const eligibility = { current: allowed };
+  let id = 0;
+  let seq = 0;
+  const dependencies: TxControllerDependencies = {
+    startAudio: vi.fn(() => audio.next),
+    sendPtt: vi.fn((command, _commandId, _correlation, report) => { sends.push({ command, report }); }),
+    stopLocalAudio: vi.fn(),
+    restoreMod: vi.fn(),
+    commandId: vi.fn((command) => `${command}-${++id}`),
+    schedule: vi.fn((callback, delay) => setTimeout(callback, delay)),
+    cancel: vi.fn((handle) => clearTimeout(handle as ReturnType<typeof setTimeout>)),
+    timeoutMs: { 'audio-start': 60_000, 'on-confirmation': 60_000, 'off-confirmation': 60_000 },
+  };
+  const controller = new TxController(1, marker(0), dependencies);
+  const facade = {
+    snapshot: () => deepFreeze(controller.snapshot()),
+    subscribe: (listener: (state: unknown) => void) =>
+      controller.subscribe((state) => listener(deepFreeze(state))),
+    start: (sourceId: string, leaseId: string, intent: Intent) => {
+      starts.push({ sourceId, leaseId, intent });
+      return controller.dispatch({
+        type: 'start', sourceId, leaseId, intent,
+        eligibility: eligibility.current, ptt: observe(false, ++seq),
+      });
+    },
+    setIntent: (sourceId: string, guard: Guard, intent: Intent) =>
+      controller.dispatch({ type: 'intent', sourceId, guard: { ...guard }, intent }),
+    release: (sourceId: string, guard: Guard) => {
+      releases.push({ sourceId });
+      return controller.dispatch({
+        type: 'release', sourceId, guard: { ...guard }, commandId: dependencies.commandId('off'),
+      });
+    },
+    resetFault: () => controller.dispatch({ type: 'reset-fault' }),
+  };
+  return {
+    controller, dependencies, sends, starts, releases, facade, audio, eligibility,
+    /** Feed an authoritative PTT readback (what the App host does on session
+     *  updates). Without one the controller reports `radioTx: 'unknown'` and
+     *  the semantic surface correctly refuses to offer its key action. */
+    authority: (value: boolean) => controller.dispatch({
+      type: 'authority', epoch: 1, ptt: observe(value, ++seq),
+      eligibility: eligibility.current, offCommandId: dependencies.commandId('off'),
+    }),
+    confirm: (command: Command) => {
+      const send = [...sends].reverse().find((item) => item.command === command);
+      expect(send).toBeDefined();
+      send!.report({ outcome: 'sent', eventEpoch: 1, barrier: marker(++seq) });
+    },
+  };
+}
+
+let tx: ReturnType<typeof createTxHarness>;
+let components: ReturnType<typeof mount>[] = [];
+
+const HOLD_MS = 50;
+const GESTURE_WINDOW_MS = 300;
+
+function setViewport(landscape: boolean) {
+  Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: landscape ? 844 : 390 });
+  Object.defineProperty(window, 'innerHeight', { writable: true, configurable: true, value: landscape ? 390 : 844 });
+}
+
+function mountMobile(): HTMLElement {
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+  components.push(mount(MobileRadioLayout, { target }));
+  flushSync();
+  return target;
+}
+
+function rotate(landscape: boolean) {
+  setViewport(landscape);
+  window.dispatchEvent(new Event('resize'));
+  flushSync();
+}
+
+function pointer(el: Element, type: string, init: PointerEventInit = {}) {
+  el.dispatchEvent(new PointerEvent(type, { bubbles: true, clientX: 0, clientY: 0, pointerId: 1, ...init }));
+  flushSync();
+}
+
+const fabEl = (t: HTMLElement) => t.querySelector<HTMLButtonElement>('.ptt-fab')!;
+const flushAudio = async () => { await Promise.resolve(); await Promise.resolve(); flushSync(); };
+
+/** A completed FAB press: PttFab only calls onDown() past its 50 ms guard. */
+function fabPress(t: HTMLElement) {
+  pointer(fabEl(t), 'pointerdown');
+  vi.advanceTimersByTime(HOLD_MS);
+  flushSync();
+}
+
+/** Press and hold the FAB until the radio has acknowledged the ON command. */
+async function hold(t: HTMLElement) {
+  fabPress(t);
+  await flushAudio();
+  tx.confirm('on');
+  flushSync();
+}
+
+/** Count of `off` commands the controller has actually emitted. */
+const offs = () => tx.sends.filter((s) => s.command === 'off').length;
+
+/**
+ * Key through the semantic RX/TX surface. An authoritative readback comes
+ * first because the surface refuses its own key action while the RF state is
+ * unobserved (`rf-state-unknown`) — asserting the button is live keeps a
+ * silently-disabled button from making these tests pass vacuously.
+ */
+function semanticKey(t: HTMLElement) {
+  tx.authority(false);
+  flushSync();
+  const key = t.querySelector<HTMLButtonElement>('[data-testid="rx-tx-key"]')!;
+  expect(key.disabled).toBe(false);
+  key.click();
+  flushSync();
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  components = [];
+  setViewport(false);
+  tx = createTxHarness();
+  txHost.current = tx.facade;
+  vi.mocked(hasTx).mockReturnValue(true);
+});
+
+afterEach(() => {
+  components.forEach((c) => {
+    try { unmount(c); } catch { /* already unmounted by a test */ }
+  });
+  document.body.innerHTML = '';
+  vi.useRealTimers();
+});
+
+// ---------------------------------------------------------------------------
+// 1. Semantic surface adoption
+// ---------------------------------------------------------------------------
+describe('semantic VFO / RX-TX adoption in the mobile shell', () => {
+  // Kills: the migration never landing — the shell keeping only its legacy
+  // header facts and the FAB as its sole TX truth.
+  it('mounts the semantic surfaces in the portrait deck', () => {
+    const t = mountMobile();
+    expect(t.querySelectorAll('[data-testid="semantic-radio-surfaces"]')).toHaveLength(1);
+    expect(t.querySelectorAll('[data-testid="rx-tx-surface"]')).toHaveLength(1);
+  });
+
+  // Kills: mounting the surfaces inside a chip panel. Chip panels are
+  // destroyed and recreated on every chip tap, and this subtree holds a TX
+  // lease source — churning it would churn a TX identity (MOR-1086 doctrine).
+  it('mounts them in the scrollable deck, not inside a chip panel', () => {
+    const t = mountMobile();
+    const surfaces = t.querySelector('[data-testid="semantic-radio-surfaces"]')!;
+    expect(t.querySelector('.m-content')!.contains(surfaces)).toBe(true);
+    expect(surfaces.closest('.m-section')).toBeNull();
+  });
+
+  // Kills: adding a second copy of the wiring (one per orientation, or one
+  // per chip). Exactly one instance may exist — each is a distinct TX source.
+  it('never mounts a second copy, in either orientation', () => {
+    const t = mountMobile();
+    rotate(true);
+    expect(t.querySelectorAll('[data-testid="semantic-radio-surfaces"]')).toHaveLength(0);
+    rotate(false);
+    expect(t.querySelectorAll('[data-testid="semantic-radio-surfaces"]')).toHaveLength(1);
+  });
+
+  // Kills: hand-rolling a mobile-local copy of the surfaces instead of reusing
+  // the shared wiring the LCD and desktop slices mount (MOR-1065).
+  it('reuses the shared SemanticRadioSurfaces wiring, unchanged', () => {
+    expect(mobileLayoutSource).toContain('SemanticRadioSurfaces');
+    expect(mobileLayoutSource).toContain("from '../wiring/SemanticRadioSurfaces.svelte'");
+    // No mobile-local RX/TX or VFO surface reimplementation.
+    expect(mobileLayoutSource).not.toContain('RxTxSurface');
+    expect(mobileLayoutSource).not.toContain('VfoSurface');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. The press-and-hold PTT path is UNCHANGED — identity, not shape
+// ---------------------------------------------------------------------------
+describe('mobile press-and-hold PTT identity (MOR-1011/1012, unchanged)', () => {
+  // THE pin. Kills: rewiring the FAB to anything other than the per-surface
+  // gesture recognizer — to the semantic surface's latched `requestKey`, to a
+  // shared sourceId, to a raw command, or to a re-derived id. All of those
+  // change the (sourceId, intent) pair the App controller is asked to start.
+  it('keys through the gesture recognizer under its own momentary mobile source', async () => {
+    const t = mountMobile();
+    await hold(t);
+
+    expect(tx.starts).toHaveLength(1);
+    expect(tx.starts[0].sourceId).toMatch(/^mobile-ptt-portrait-\d+$/);
+    expect(tx.starts[0].intent).toBe('momentary');
+    // The lease id is derived from that same source identity, per-lease.
+    expect(tx.starts[0].leaseId).toBe(`${tx.starts[0].sourceId}-1`);
+    // The App controller — not a local machine — owns the resulting key.
+    expect(tx.controller.snapshot().sourceId).toBe(tx.starts[0].sourceId);
+    expect(tx.controller.snapshot().phase).toBe('key-confirm-pending');
+  });
+
+  // Kills: the semantic surface silently becoming the press-and-hold owner.
+  // It keys LATCHED under its own id; if the FAB were rewired through it, the
+  // press above would produce a `semantic-rx-tx-*` latched start instead.
+  it('gives the semantic RX/TX key a different source and a different intent', () => {
+    const t = mountMobile();
+    semanticKey(t);
+
+    expect(tx.starts).toHaveLength(1);
+    expect(tx.starts[0].sourceId).toMatch(/^semantic-rx-tx-\d+$/);
+    expect(tx.starts[0].intent).toBe('latched');
+    expect(tx.starts[0].sourceId).not.toMatch(/^mobile-ptt/);
+  });
+
+  // Kills: reintroducing a local TX machine, raw PTT commands or bespoke
+  // timers alongside the App controller (the MOR-1012 acceptance evidence,
+  // re-asserted here because this slice edits the same file).
+  it('still routes every mobile TX path through the App controller alone', () => {
+    expect(mobileLayoutSource).toContain('getAppTxController');
+    expect(mobileLayoutSource).toContain('createPttGesture');
+    // Deliberately NOT asserting on 'ptt_on'/'ptt_off' as bare substrings —
+    // the retirement note in the layout's own comments names them.
+    for (const retired of [
+      'tx-adapter', 'getTxAudioControl', 'systemHandlers', 'engageTx', 'disengageTx',
+      'pttSafetyTimer', 'PTT_SAFETY_TIMEOUT_MS', 'txStartToken', 'lastPttDown',
+      'sendCommand',
+    ]) {
+      expect(mobileLayoutSource).not.toContain(retired);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. The two TX sources cannot disturb each other
+// ---------------------------------------------------------------------------
+describe('two TX sources on one mobile shell', () => {
+  // THE new-risk pin for this slice. The semantic subtree is destroyed on
+  // every rotation, and its fail-closed teardown blind-releases the LIVE
+  // guard. Kills: giving it the gesture's sourceId (or dropping the sourceId
+  // argument), which would let a rotation-time teardown dekey — or double-off
+  // — a lease the operator is holding on the FAB.
+  it('the semantic teardown cannot dekey a lease the PTT gesture owns', async () => {
+    const t = mountMobile();
+    await hold(t);
+    const owner = tx.controller.snapshot().sourceId;
+    expect(owner).toMatch(/^mobile-ptt-portrait-\d+$/);
+
+    rotate(true); // destroys BOTH the portrait recognizer and the semantic deck
+
+    // The semantic surface did ask to release — with its own identity.
+    const semanticReleases = tx.releases.filter((r) => /^semantic-rx-tx-/.test(r.sourceId));
+    expect(semanticReleases.length).toBeGreaterThan(0);
+    // ...and it was inert: the single ptt_off is the recognizer's own
+    // documented rotation release (docs/guide/web-ui.md — rotating while
+    // keyed or latched releases TX rather than stranding it), not a second.
+    expect(offs()).toBe(1);
+    expect(tx.releases.filter((r) => r.sourceId === owner)).toHaveLength(1);
+    expect(tx.controller.snapshot().phase).toBe('releasing');
+  });
+
+  // The mirror image. Kills: the gesture recognizer releasing on a guard it
+  // does not own — a latched semantic key must survive an unrelated FAB tap.
+  it('the PTT gesture cannot dekey a lease the semantic surface owns', () => {
+    const t = mountMobile();
+    semanticKey(t);
+    const owner = tx.controller.snapshot().sourceId;
+    expect(owner).toMatch(/^semantic-rx-tx-\d+$/);
+
+    fabPress(t);
+    pointer(fabEl(t), 'pointerup');
+    vi.advanceTimersByTime(GESTURE_WINDOW_MS * 2);
+    flushSync();
+
+    expect(offs()).toBe(0);
+    expect(tx.controller.snapshot().sourceId).toBe(owner);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Orientation preserves App-owned authority and resources
+// ---------------------------------------------------------------------------
+describe('orientation change preserves App authority (MOR-1086 doctrine)', () => {
+  // Kills: the shell re-deriving, re-creating or re-hosting TX authority per
+  // orientation. A rotation is an intra-layout surface swap; the App-owned
+  // controller object must be the IDENTICAL instance on the other side.
+  it('keeps the identical App TX controller object across a rotation', () => {
+    const t = mountMobile();
+    const before = txHost.current;
+    rotate(true);
+    rotate(false);
+    expect(txHost.current).toBe(before);
+    expect(txHost.current).toBe(tx.facade);
+    // And the shell is still LIVE on it: a post-rotation key still lands.
+    semanticKey(t);
+    expect(tx.controller.snapshot().sourceId).toMatch(/^semantic-rx-tx-\d+$/);
+  });
+
+  // Kills: the semantic subtree taking its own App resource demand. It is
+  // destroyed and rebuilt on every rotation, so any demand it held would
+  // bounce the mobile hardware-scope stream (the MOR-1092 mutation, applied
+  // to mobile). Demand belongs to SpectrumPanel via the skin resource plan.
+  it('leaves App resource demand entirely outside the semantic subtree', () => {
+    const wiringSource = readFileSync('src/components-v2/wiring/SemanticRadioSurfaces.svelte', 'utf8');
+    for (const source of [mobileLayoutSource, wiringSource]) {
+      expect(source).not.toContain('presentationResources');
+      expect(source).not.toContain('resource-demand');
+    }
+    // The plan still names hardware-scope for mobile, owned by SpectrumPanel.
+    const registrySource = readFileSync('src/skins/registry.ts', 'utf8');
+    expect(registrySource).toContain("'mobile': ['hardware-scope']");
+  });
+
+  // Kills: silently flipping the recorded rotation behaviour. The guide says
+  // rotating while keyed or latched RELEASES TX rather than stranding it;
+  // this asserts the direction the code actually implements, both ways.
+  it('still releases TX on rotation, in the direction the guide records', async () => {
+    const guide = readFileSync('../docs/guide/web-ui.md', 'utf8');
+    expect(guide).toContain('rotating the device while keyed or latched releases TX');
+
+    const t = mountMobile();
+    await hold(t);
+    rotate(true);
+    expect(offs()).toBe(1);
+    expect(tx.controller.snapshot().phase).toBe('releasing');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Global-host singletons stay global (MOR-1059)
+// ---------------------------------------------------------------------------
+describe('the App-global host stays singular on mobile (MOR-1059)', () => {
+  // Kills: the migration reintroducing a layout-hosted Toast, power overlay
+  // or TX lamp — the duplicates MOR-1059 pulled up to the composition root.
+  it.each([['portrait', false], ['landscape', true]] as const)(
+    'hosts no Toast, power overlay or global TX lamp in %s', (_label, landscape) => {
+      setViewport(landscape);
+      const t = mountMobile();
+      for (const selector of [
+        '.toast-container',
+        '[data-testid="app-global-host"]',
+        '[data-testid="global-power-off"]',
+        '[data-testid="global-tx-indication"]',
+        '[data-testid="global-tx-fault"]',
+      ]) {
+        expect(t.querySelectorAll(selector)).toHaveLength(0);
+      }
+    });
+
+  // Source-level backstop, matching the app-global-host suite's idiom.
+  it('imports neither the Toast nor the global host itself', () => {
+    expect(mobileLayoutSource).not.toMatch(/shared\/Toast\.svelte/);
+    expect(mobileLayoutSource).not.toMatch(/<Toast\b/);
+    expect(mobileLayoutSource).not.toContain('power-off-overlay');
+    expect(mobileLayoutSource).not.toMatch(/<AppGlobalHost\b/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. The skin wrapper owns no resolution and no runtime
+// ---------------------------------------------------------------------------
+describe('the mobile skin wrapper is a pure delegator', () => {
+  // Kills: the wrapper re-deriving which skin/layout to show. Selection,
+  // loading and commit belong to App.svelte over skins/registry.ts; a wrapper
+  // that resolves again can disagree with the presentation App committed.
+  it('owns no resolver: it selects nothing and loads nothing', () => {
+    for (const owned of [
+      'resolveSkinId', 'loadSkin', 'resolvePersistedSkinId', 'normalizeLayoutMode',
+      'presentationResourcePlan', 'getLayout', 'resolveLayoutForViewport',
+    ]) {
+      expect(mobileSkinSource).not.toContain(owned);
+    }
+  });
+
+  // Kills: the wrapper reaching past the presentation boundary. eslint's
+  // no-restricted-imports covers src/skins/**; this pins the same boundary
+  // from the test side so a config drift cannot silently open it.
+  it('owns no runtime: no transport, command, capability or TX-authority import', () => {
+    for (const forbidden of [
+      '$lib/transport', 'audio-manager', '$lib/stores/capabilities',
+      'tx-controller/app-host', 'sendCommand', 'wiring/command-bus',
+    ]) {
+      expect(mobileSkinSource).not.toContain(forbidden);
+    }
+    // What it DOES do: delegate, and nothing else.
+    expect(mobileSkinSource).toContain('MobileRadioLayout');
+  });
+
+  // Kills: a manifest that reaches for live state. Manifests are declarations
+  // — the presentation/ zone bans runtime, transport and capability imports.
+  it('keeps the mobile manifest a declaration over the layout contract alone', () => {
+    const manifest = readFileSync('src/presentation/layouts/mobile-declarations.ts', 'utf8');
+    const imports = [...manifest.matchAll(/from '([^']+)'/g)].map((m) => m[1]);
+    expect(imports).toEqual(['./contract']);
+  });
+});

--- a/frontend/src/presentation/layouts/__tests__/mobile-registration.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/mobile-registration.test.ts
@@ -1,0 +1,161 @@
+/**
+ * MOR-1094 — the mobile presentation entrypoint as a v1 layout manifest
+ * (schema, validator and registry: `../contract`, MOR-1066), mirroring the
+ * MOR-1092 LCD registration proof.
+ *
+ * What this file is for: the manifest is the only place the mobile entrypoint
+ * declares its identity, the semantic zone it mounts, the topologies it
+ * survives, and its MOR-1160 sizing assignment. Mobile is the FLUID side of
+ * that axis — the counterpart to the LCD's fixed-native stage — and it is the
+ * one layout a portrait phone can always resolve, which is what makes it the
+ * only viable destination for a fixed-native layout's fallback hop off that
+ * viewport. Every claim below is read back out of the shared registry rather
+ * than off the exported object, so a manifest that is written but never
+ * registered fails here. Each test's doc line names the mutation it kills.
+ */
+import { readFileSync } from 'node:fs';
+import { describe, it, expect } from 'vitest';
+import {
+  getLayout, registerLayout, resolveLayoutForTopology, resolveLayoutForViewport,
+  fitsViewport, TOPOLOGY_CLASSES, type LayoutManifest,
+} from '../contract';
+// Deliberately through the shared aggregation entry, not `../mobile-declarations`
+// directly: it pins that `declarations.ts` really pulls the mobile family in
+// (nothing else does), and it keeps this fast-pool file on the SAME module
+// entry point as `registry.test.ts` / `lcd-registration.test.ts` — under
+// `isolate: false` a second entry into a module that registers at import time
+// is how a split module graph (and a phantom "layout not registered") happens.
+import { mobileLayout, lcdCockpitLayout, lcdScopeLayout } from '../declarations';
+
+/** iPhone-class portrait — the viewport the LCD family fails arithmetically. */
+const PORTRAIT_MOBILE = { width: 390, height: 844 };
+/** The same handset rotated: what `isLandscape` in MobileRadioLayout sees. */
+const LANDSCAPE_MOBILE = { width: 844, height: 390 };
+
+describe('the mobile entrypoint is registered in the real registry', () => {
+  // Kills: mobile-declarations.ts defining the manifest but never calling
+  // registerLayout — every resolution below would then read undefined.
+  it('registers "mobile" under its stable entrypoint id', () => {
+    expect(getLayout('mobile')).toBe(mobileLayout);
+    expect(mobileLayout.id).toBe('mobile');
+  });
+
+  // Kills: a manifest id that drifts from the SkinId the App actually loads.
+  // The manifest is only an entrypoint declaration if the two agree — a
+  // "mobile-v2" or "phone" manifest would register cleanly and address nothing.
+  it('uses the same id the skin registry loads the mobile entrypoint under', () => {
+    const source = readFileSync('src/skins/registry.ts', 'utf8');
+    const start = source.indexOf('const SKIN_LOADERS');
+    const loaders = source.slice(start, source.indexOf('};', start));
+    expect(loaders).toContain("'mobile':");
+    // And it is the id `resolveSkinId` hands back for a mobile viewport.
+    expect(source).toContain("if (ctx.isMobile) return 'mobile';");
+  });
+
+  // Kills: a manifest that declares no compiled loader at all. That the
+  // loader reaches the REAL entrypoint — and renders the migrated mobile
+  // shell — is proved by mounting it in
+  // `components-v2/layout/__tests__/semantic-mobile-migration.component.test.ts`;
+  // this file runs outside the DOM environment that whole tree needs.
+  it('declares a compiled loader', () => {
+    expect(typeof mobileLayout.loader).toBe('function');
+  });
+});
+
+describe('declared semantic zone (what the migrated mobile shell mounts)', () => {
+  // Kills: declaring a surface the layout does not mount, or dropping rxTx
+  // (which would leave the PTT FAB as mobile's only RX/TX truth).
+  it('mounts vfo + rxTx in one portrait deck zone', () => {
+    expect(mobileLayout.zones).toEqual([{ id: 'portrait-deck', surfaces: ['vfo', 'rxTx'] }]);
+    expect([...mobileLayout.requiredSemanticSurfaces].sort()).toEqual(['rxTx', 'vfo']);
+  });
+});
+
+describe('topology honesty', () => {
+  // Kills: under-declaring the topology set. The mobile shell renders VFO A
+  // unconditionally and gates the MAIN/SUB receiver selector and the SUB
+  // readout on `hasDualReceiver`, so every canonical class resolves to the
+  // layout itself, never to a fallback.
+  it.each(TOPOLOGY_CLASSES)('resolves itself on the %s topology', (topology) => {
+    expect(resolveLayoutForTopology('mobile', topology)?.id).toBe('mobile');
+  });
+});
+
+describe('MOR-1160 sizing axis — mobile is the fluid side', () => {
+  // Kills: declaring mobile `fixed-native`. Mobile chrome reflows; it is not
+  // an instrument stage scaled as one letterboxed block, and a native stage
+  // here would make the phone shell fail its own minScale gate.
+  it('declares fluid sizing with the one breakpoint the layout implements', () => {
+    expect(mobileLayout.sizing).toEqual({ mode: 'fluid', responsiveBreakpoints: [500] });
+  });
+
+  // Kills: flipping mobile to a mode with a viewport gate. `fluid` always
+  // fits (contract: breakpoints are reflow hints, not a hard gate in v1), and
+  // that is precisely why mobile is resolvable where the LCD stage is not.
+  it.each([
+    ['portrait phone', PORTRAIT_MOBILE],
+    ['landscape phone', LANDSCAPE_MOBILE],
+    ['desktop', { width: 1440, height: 900 }],
+  ])('resolves itself on a %s viewport', (_label, viewport) => {
+    expect(fitsViewport(mobileLayout, viewport)).toBe(true);
+    expect(resolveLayoutForViewport('mobile', viewport)?.id).toBe('mobile');
+  });
+
+  // Kills: giving mobile a fallback it does not need. Mobile is the terminal
+  // destination — it fits every viewport, so a hop off it is unreachable code
+  // and a hop TO somewhere else would hide a real resolution failure.
+  it('declares no fallback, because it never fails a viewport', () => {
+    expect(mobileLayout.fallbackLayoutId).toBeNull();
+  });
+});
+
+describe('portrait-mobile exclusion of fixed-native layouts, and the hop off it', () => {
+  // The exclusion case this fallback machinery exists for, asserted read-only
+  // against the LCD family (MOR-1092 owns those manifests). An iPhone-class
+  // 390x844 achieves min(390/1280, 844/540) ~= 0.30 against minScale 0.5.
+  it.each([
+    ['lcd-cockpit', lcdCockpitLayout],
+    ['lcd-scope', lcdScopeLayout],
+  ])('excludes fixed-native "%s" from portrait mobile while mobile fits', (_id, manifest) => {
+    expect(fitsViewport(manifest, PORTRAIT_MOBILE)).toBe(false);
+    expect(fitsViewport(mobileLayout, PORTRAIT_MOBILE)).toBe(true);
+  });
+
+  // The LCD family names only its own sibling, which shares the same native
+  // stage — so it correctly dead-ends at `undefined` rather than handing back
+  // a layout that fails the same gate (MOR-1066 review cycle 1, F1). Pinned
+  // here so registering a fluid `mobile` alongside it cannot be mistaken for
+  // having silently changed LCD resolution.
+  it('leaves the LCD family unresolvable on portrait mobile (no LCD fallback rewiring)', () => {
+    expect(resolveLayoutForViewport('lcd-scope', PORTRAIT_MOBILE)).toBeUndefined();
+    expect(resolveLayoutForViewport('lcd-cockpit', PORTRAIT_MOBILE)).toBeUndefined();
+  });
+
+  // Kills: the registration that looks right but cannot actually terminate a
+  // hop — a `mobile` manifest that itself failed the viewport, or a validator
+  // that returned the fallback WITHOUT re-applying the criterion. Registering
+  // a probe is the count-agnostic idiom `registry.test.ts` already uses.
+  it('is a viable fallback destination: a fixed-native layout hops to it off portrait mobile', () => {
+    const probe: LayoutManifest = {
+      schemaVersion: 1,
+      id: 'mobile-hop-probe',
+      displayName: 'Mobile Hop Probe',
+      loader: mobileLayout.loader,
+      zones: [{ id: 'main', surfaces: ['vfo', 'rxTx'] }],
+      compatibleTopologies: ['1/single'],
+      requiredSemanticSurfaces: ['vfo', 'rxTx'],
+      sizing: { mode: 'fixed-native', nativeW: 1280, nativeH: 540, minScale: 0.5 },
+      fallbackLayoutId: 'mobile',
+    };
+    registerLayout(probe);
+
+    // Fails its own gate on the phone, and the ONE validated hop lands on
+    // mobile — which passes the same criterion it was fetched to satisfy.
+    expect(fitsViewport(probe, PORTRAIT_MOBILE)).toBe(false);
+    expect(resolveLayoutForViewport('mobile-hop-probe', PORTRAIT_MOBILE)?.id).toBe('mobile');
+    // On a viewport it fits, the probe still resolves to itself — the hop is
+    // a fallback, not an unconditional redirect to mobile.
+    expect(resolveLayoutForViewport('mobile-hop-probe', { width: 1440, height: 900 })?.id)
+      .toBe('mobile-hop-probe');
+  });
+});

--- a/frontend/src/presentation/layouts/declarations.ts
+++ b/frontend/src/presentation/layouts/declarations.ts
@@ -23,3 +23,4 @@ export const sdrTestLayout: LayoutManifest = {
 registerLayout(sdrTestLayout);
 
 export { lcdCockpitLayout, lcdScopeLayout } from './lcd-declarations';
+export { mobileLayout } from './mobile-declarations';

--- a/frontend/src/presentation/layouts/mobile-declarations.ts
+++ b/frontend/src/presentation/layouts/mobile-declarations.ts
@@ -1,0 +1,63 @@
+/**
+ * MOR-1094 — the mobile presentation entrypoint as a v1 layout manifest
+ * (schema, validator and registry: `./contract`, MOR-1066).
+ *
+ * Kept in its own file so `./declarations.ts` carries one aggregation line per
+ * family, alongside `./lcd-declarations.ts` (MOR-1092).
+ *
+ * A manifest is a DECLARATION, never behaviour. `loader` names the existing
+ * skin entrypoint with no change to it, and `sizing` records the assignment
+ * MOR-1160 froze without implementing it — the shared ScaledStage primitive
+ * owns measurement and the transform (MOR-1160 constraint 1), never a layout.
+ * In particular this manifest does NOT take over the shell's own orientation
+ * handling: `isLandscape` still drives which PTT surface is mounted, and that
+ * is live safety behaviour, not a sizing declaration.
+ */
+import { registerLayout, type LayoutManifest } from './contract';
+
+/**
+ * MOR-1160, fluid side. Mobile chrome reflows; it is not an instrument stage
+ * scaled as one letterboxed block, so it declares no native size and no
+ * `minScale` — and therefore always fits (`fitsViewport`: breakpoints are
+ * reflow hints, not a hard gate in v1). That is what makes mobile the only
+ * viable destination for a fixed-native layout's one validated fallback hop
+ * off a portrait phone, where the LCD stage fails arithmetically.
+ *
+ * The single breakpoint is the one reflow the shell actually implements:
+ * `MobileRadioLayout` switches to its spectrum-dominant landscape arrangement
+ * when the viewport is wider than it is tall AND under 500px of HEIGHT. It is
+ * recorded here as the honest threshold the layout uses, not as a width.
+ */
+const MOBILE_FLUID_SIZING = { mode: 'fluid', responsiveBreakpoints: [500] } as const;
+
+/**
+ * One zone: the portrait scroll deck, where `SemanticRadioSurfaces` owns the
+ * VFO facts and the RX/TX status/action. The landscape arrangement is a
+ * fullscreen spectrum with a compact control strip and mounts no semantic
+ * zone in this slice — the manifest has no orientation axis, so that is
+ * recorded here rather than declared.
+ *
+ * The press-and-hold PTT affordances (the portrait FAB, the landscape strip)
+ * are NOT part of this zone: they stay wired to the App TX controller through
+ * the MOR-1011/1012 gesture recognizer, unchanged by this migration.
+ */
+const MOBILE_ZONES = [{ id: 'portrait-deck', surfaces: ['vfo', 'rxTx'] }] as const;
+
+export const mobileLayout: LayoutManifest = {
+  schemaVersion: 1,
+  id: 'mobile',
+  displayName: 'Mobile',
+  loader: () => import('../../skins/mobile/MobileSkin.svelte'),
+  zones: MOBILE_ZONES,
+  // All four canonical classes: the shell renders VFO A unconditionally and
+  // gates the MAIN/SUB selector and the SUB readout on `hasDualReceiver`, so
+  // single- and dual-receiver topologies are both structurally supported.
+  compatibleTopologies: ['1/single', '1/ab', '2/ab_shared', '2/main_sub'],
+  requiredSemanticSurfaces: ['vfo', 'rxTx'],
+  sizing: MOBILE_FLUID_SIZING,
+  // Terminal by construction: a fluid layout never fails a viewport, so a hop
+  // off mobile would be unreachable and would only mask a real failure.
+  fallbackLayoutId: null,
+};
+
+registerLayout(mobileLayout);


### PR DESCRIPTION
## Summary

The last MOR-973 blocker: the mobile presentation shell moves onto layout manifest v1 with App-owned behavior. 3 production files, +86/0/86 net:

- `mobile` manifest (fluid sizing per MOR-1160, all four topologies — verified rendering all four fixtures without degradation, portrait-deck zone, no fallback target); one line in `declarations.ts`.
- The portrait deck mounts the UNCHANGED shared `SemanticRadioSurfaces` (sha-identical file); the fixed MOD-input overlay stays (portrait double-banner recorded as MOR-1245 — fails safe).
- **PTT path byte-untouched** (`tx-ptt-gesture.ts`, `PttFab`, controller files all sha-identical to main): FAB = momentary with its own sourceId; semantic key = latched with its own; `isLandscape` still selects WHICH PTT surface mounts — exactly one per orientation.

## Independent verification

- Cross-source inertness proven by the reviewer's own direct probes on the real `TxController`: FAB-keyed → semantic unkey click ⇒ 0 `off`, owner unchanged; semantic-latched → full FAB cycle ⇒ 0 `off`; rotation while keyed ⇒ exactly one `off` (still one after 240 s and rotate-back).
- Portrait exclusion: 17/17 + six reviewer-written adversarial cases — fixed-native→fixed-native at 390×844 rejected, two-hop chains dead-end, self-ref/dangling rejected, a FITTING fixed-native fallback still honored (no MOR-1066 F1 pass-through class).
- Mutations: builder's set (shared sourceId → 2 fail; fixed-native flip → 5 fail; chip-panel move → 1 fail) reproduced exactly + two reviewer mutations (FAB intent→latched; second landscape copy) killed.
- Rotation behavior asserted TOGETHER with the guide string (docs/guide/web-ui.md:656) — both true.
- Suites: 35 new; reviewer's 570/570 regression set ×2; full frontend failing set byte-identical to baseline (+35 passes); lint/boundaries/check/i18n/ruff/lint-imports clean.

Linear: MOR-1094 (closes the MOR-973 blocker set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)