### PR TITLE
feat(MOR-1067): build the compiled dual-receiver cockpit shell from semantic zones

### DIFF
--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -30,6 +30,19 @@
   import VfoSurface, { type VfoSelection } from '../../semantic/VfoSurface.svelte';
   import ModInputTxWarning from '../panels/ModInputTxWarning.svelte';
   import { makeVfoHandlers } from './command-bus';
+  import { forReceiver, receiversOf, isActiveStrip } from './dual-receiver-strips';
+
+  /**
+   * `'single'` (default) is the exact pre-MOR-1067 markup — sdr-test's
+   * behavior is untouched. `'dual'` is the dual-receiver-cockpit's per-
+   * receiver channel strips (MOR-1067): still ONE shared RxTxSurface and
+   * ONE TX lease below — ONLY the VFO half splits, so there is still exactly
+   * one authoritative key/unkey action surface regardless of `strips`.
+   */
+  interface Props {
+    strips?: 'single' | 'dual';
+  }
+  let { strips = 'single' }: Props = $props();
 
   const vfo = makeVfoHandlers();
   const tx = getAppTxController();
@@ -90,12 +103,46 @@
 
 <div class="semantic-surfaces" data-testid="semantic-radio-surfaces">
   {#if view}
-    <VfoSurface
-      viewModel={view}
-      onSelectVfo={selectVfo}
-      onToggleSplit={vfo.onSplitToggle}
-      onToggleDualWatch={toggleDualWatch}
-    />
+    {#if strips === 'dual'}
+      <div class="channel-strips" data-testid="channel-strips">
+        {#each receiversOf(view) as receiverId, index (receiverId)}
+          <div
+            class="channel-strip"
+            data-testid={`channel-strip-${receiverId}`}
+            data-strip-receiver={receiverId}
+            data-strip-active={isActiveStrip(view, receiverId)}
+          >
+            <!--
+              `selectionPoolSize`: the slice below holds this receiver's VFOs
+              only, but the operator can still choose across the WHOLE radio —
+              without the pool the MOR-977 gate reads a 1-VFO slice as
+              "structurally nothing to choose" and an `ab_shared` cockpit
+              silently loses its only receiver-selection control.
+              `showRadioWideFacts`: split / dual-watch / active-receiver are
+              radio-wide, so exactly ONE strip renders them — the FIRST, a
+              position that depends on no observed fact, so the switches never
+              move when the active receiver changes. (Their eventual home is
+              the cockpit's global zone, once a semantic surface backs it.)
+            -->
+            <VfoSurface
+              viewModel={forReceiver(view, receiverId)}
+              selectionPoolSize={view.vfos.length}
+              showRadioWideFacts={index === 0}
+              onSelectVfo={selectVfo}
+              onToggleSplit={vfo.onSplitToggle}
+              onToggleDualWatch={toggleDualWatch}
+            />
+          </div>
+        {/each}
+      </div>
+    {:else}
+      <VfoSurface
+        viewModel={view}
+        onSelectVfo={selectVfo}
+        onToggleSplit={vfo.onSplitToggle}
+        onToggleDualWatch={toggleDualWatch}
+      />
+    {/if}
     <RxTxSurface {view} tx={txState} onRequestKey={requestKey} onRequestUnkey={requestUnkey} />
   {/if}
 
@@ -137,5 +184,16 @@
     color: var(--v2-accent-red, #ef4444);
     font: inherit;
     cursor: pointer;
+  }
+  /* MOR-1067: two borderless channel strips sharing one optical left margin —
+     the RxTxSurface below stays a single shared block, outside this grid. */
+  .channel-strips {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
+    gap: 8px;
+  }
+  .channel-strip[data-strip-active='true'] {
+    border-left: 2px solid var(--v2-accent-cyan, #00d4ff);
+    padding-left: 6px;
   }
 </style>

--- a/frontend/src/components-v2/wiring/__tests__/dual-receiver-strips.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/dual-receiver-strips.test.ts
@@ -1,0 +1,71 @@
+/**
+ * MOR-1067 — pure per-receiver slicing, driven directly by the REAL MOR-1062
+ * topology fixtures (no mocking). Each test's doc line names the mutation it
+ * exists to kill.
+ */
+import { describe, it, expect } from 'vitest';
+import { forReceiver, isActiveStrip, receiversOf } from '../dual-receiver-strips';
+import { topologyFixtures } from '../../../semantic/fixtures/topologies';
+import type { RadioViewModel } from '../../../semantic/radio-view-model';
+
+const dualAbShared = topologyFixtures['2/ab_shared'];
+const dualMainSub = topologyFixtures['2/main_sub'];
+const singleReceiver = topologyFixtures['1/single'];
+
+describe('receiversOf', () => {
+  it('finds both receivers in an unslotted dual (ab_shared) fixture', () => {
+    expect(receiversOf(dualAbShared)).toEqual(['MAIN', 'SUB']);
+  });
+
+  it('finds both receivers in a slotted dual (main_sub) fixture, de-duplicated', () => {
+    expect(receiversOf(dualMainSub)).toEqual(['MAIN', 'SUB']);
+  });
+
+  // Kills: hardcoding ['MAIN', 'SUB'] instead of reading view.vfos — a
+  // single-receiver topology would then falsely report a SUB strip.
+  it('never fabricates a second receiver for a single-receiver fixture', () => {
+    expect(receiversOf(singleReceiver)).toEqual(['MAIN']);
+  });
+
+  it('reports no receivers for an empty vfos array', () => {
+    expect(receiversOf({ ...dualMainSub, vfos: [] })).toEqual([]);
+  });
+});
+
+describe('forReceiver', () => {
+  it('keeps only the requested receiver\'s VFOs, in original order', () => {
+    const sub = forReceiver(dualMainSub, 'SUB');
+    expect(sub.vfos.map((v) => v.label)).toEqual(['S-A', 'S-B']);
+    expect(sub.vfos.every((v) => v.receiver === 'SUB')).toBe(true);
+  });
+
+  it('an unslotted dual fixture yields exactly one VFO per strip', () => {
+    expect(forReceiver(dualAbShared, 'MAIN').vfos).toHaveLength(1);
+    expect(forReceiver(dualAbShared, 'SUB').vfos).toHaveLength(1);
+  });
+
+  // Kills: the slice also touching shared/global facts (activeReceiver,
+  // split, dualWatch, txTarget, txPermit, scope, disabledReasons) instead of
+  // passing them through verbatim — those are radio-wide, not per-receiver.
+  it('leaves every field other than vfos byte-identical to the source', () => {
+    const sliced = forReceiver(dualMainSub, 'MAIN');
+    const { vfos: _vfos, ...sourceRest } = dualMainSub;
+    const { vfos: _slicedVfos, ...slicedRest } = sliced;
+    expect(slicedRest).toEqual(sourceRest);
+  });
+});
+
+describe('isActiveStrip', () => {
+  it('is true only for the positively-observed active receiver', () => {
+    expect(isActiveStrip(dualAbShared, 'SUB')).toBe(true);
+    expect(isActiveStrip(dualAbShared, 'MAIN')).toBe(false);
+  });
+
+  // The explicit mutation this ticket names: a shell/strip that defaults to
+  // "strip one is active" when activeReceiver was never observed.
+  it('marks NEITHER strip active when activeReceiver is unknown — no fabricated default', () => {
+    const unknownActive: RadioViewModel = { ...dualMainSub, activeReceiver: { status: 'unknown' } };
+    expect(isActiveStrip(unknownActive, 'MAIN')).toBe(false);
+    expect(isActiveStrip(unknownActive, 'SUB')).toBe(false);
+  });
+});

--- a/frontend/src/components-v2/wiring/__tests__/semantic-rx-tx-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rx-tx-wiring.component.test.ts
@@ -177,6 +177,18 @@ describe('the surfaces render from the live adapter output', () => {
     expect(q('[data-testid="rx-tx-target"]')?.dataset.target).toBe('known');
   });
 
+  // MUTATION KILLED: flipping the `strips` default from 'single' to 'dual'
+  // (MOR-1067 review cycle 1, F4). The default is what every existing consumer
+  // gets — RadioLayout.svelte mounts this with no `strips` prop — so a flipped
+  // default silently re-composes sdr-test/desktop into per-receiver channel
+  // strips. Nothing else in the suite distinguishes the two modes: this file's
+  // fixtures render the same inner surface either way.
+  it('defaults to the single unsliced surface — no channel-strip wrapper at all', () => {
+    render();
+    expect(q('[data-testid="channel-strips"]')).toBeNull();
+    expect(target.querySelectorAll('[data-testid="vfo-surface"]')).toHaveLength(1);
+  });
+
   it('renders no surfaces at all rather than guessing when capabilities are absent', () => {
     h.caps = null;
     render();

--- a/frontend/src/components-v2/wiring/dual-receiver-strips.ts
+++ b/frontend/src/components-v2/wiring/dual-receiver-strips.ts
@@ -1,0 +1,28 @@
+/**
+ * Pure per-receiver `RadioViewModel` slicing for the dual-receiver-cockpit's
+ * two channel strips (MOR-1067). Carries none of the TX-lease weight
+ * `SemanticRadioSurfaces.svelte` owns — filtering only, never touched by or
+ * touching TX state, so this is not a second TX code path. `receiversOf`
+ * never fabricates a receiver absent from `view.vfos` (MOR-988 §3.2): a
+ * single-receiver view model yields exactly one strip, an empty one yields
+ * none. `isActiveStrip` is true only on a POSITIVELY observed match — an
+ * `unknown` activeReceiver marks every strip inactive, never a guessed one.
+ */
+import type { ReceiverId, RadioViewModel } from '../../semantic/radio-view-model';
+
+export function receiversOf(view: RadioViewModel): readonly ReceiverId[] {
+  const seen: ReceiverId[] = [];
+  for (const vfo of view.vfos) {
+    if (!seen.includes(vfo.receiver)) seen.push(vfo.receiver);
+  }
+  return seen;
+}
+
+/** Every fact except `vfos` stays the shared/global value, unchanged. */
+export function forReceiver(view: RadioViewModel, receiver: ReceiverId): RadioViewModel {
+  return { ...view, vfos: view.vfos.filter((vfo) => vfo.receiver === receiver) };
+}
+
+export function isActiveStrip(view: RadioViewModel, receiver: ReceiverId): boolean {
+  return view.activeReceiver.status === 'known' && view.activeReceiver.receiver === receiver;
+}

--- a/frontend/src/presentation/layouts/__tests__/dual-receiver-cockpit.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/dual-receiver-cockpit.test.ts
@@ -1,0 +1,71 @@
+/**
+ * MOR-1067 — the dual-receiver-cockpit manifest, exercised through the REAL
+ * registry (not a fixture stand-in): registration shape, topology gating
+ * (single-receiver topologies must fall back, never mount the cockpit), and
+ * the MOR-1160 chrome-fluid sizing axis. Each test's doc line names the
+ * mutation it exists to kill.
+ */
+import { describe, it, expect } from 'vitest';
+import { fitsViewport, getLayout, resolveLayoutForTopology, resolveLayoutForViewport } from '../contract';
+// The manifest comes through the BARREL, never from '../dual-receiver-cockpit'
+// directly. A direct import would fire `registerLayout` from inside this test
+// file and mask a `declarations.ts` that no longer wires the cockpit into the
+// app at all — and under the fast pool's `isolate: false` it would leak that
+// registration into sibling test files too (the MOR-1092 lesson). Importing
+// the barrel also registers 'sdr-test', this manifest's fallbackLayoutId
+// target, which the fallback tests below need.
+import { dualReceiverCockpitLayout } from '../declarations';
+
+describe('the dual-receiver-cockpit real registration', () => {
+  it('registers with the id the DL handshake test already pins (MOR-977 §4.4)', () => {
+    expect(getLayout('dual-receiver-cockpit')).toBe(dualReceiverCockpitLayout);
+  });
+
+  it('declares primary/secondary VFO zones and one shared RX/TX zone', () => {
+    expect(dualReceiverCockpitLayout.zones).toEqual([
+      { id: 'primary-vfo', surfaces: ['vfo'] },
+      { id: 'secondary-vfo', surfaces: ['vfo'] },
+      { id: 'rx-tx', surfaces: ['rxTx'] },
+    ]);
+    expect(dualReceiverCockpitLayout.requiredSemanticSurfaces).toEqual(['vfo', 'rxTx']);
+  });
+
+  it('has a compiled Svelte loader', async () => {
+    expect(typeof dualReceiverCockpitLayout.loader).toBe('function');
+  });
+});
+
+describe('topology gating (manifest topology classes + fallback resolution)', () => {
+  // Kills: compatibleTopologies including a single-receiver class, or the
+  // manifest omitting a safe fallback — either way a single-receiver radio
+  // would end up mounting a shell with an empty/fabricated second strip.
+  it.each(['1/single', '1/ab'] as const)(
+    'does NOT mount for single-receiver topology "%s" — falls back to sdr-test instead',
+    (topology) => {
+      const resolved = resolveLayoutForTopology('dual-receiver-cockpit', topology);
+      expect(resolved?.id).not.toBe('dual-receiver-cockpit');
+      expect(resolved?.id).toBe('sdr-test');
+    },
+  );
+
+  it.each(['2/ab_shared', '2/main_sub'] as const)(
+    'mounts for its declared dual-receiver topology "%s"',
+    (topology) => {
+      expect(resolveLayoutForTopology('dual-receiver-cockpit', topology)?.id).toBe('dual-receiver-cockpit');
+    },
+  );
+});
+
+describe('MOR-1160 sizing axis: chrome stays fluid', () => {
+  // This shell composes only VFO/RX-TX status text today — no fixed-native
+  // instrument glass — so it must fit any viewport, unlike a fixed-native
+  // layout that fails below minScale.
+  it('fits an arbitrarily small viewport (fluid never gates on viewport)', () => {
+    expect(fitsViewport(dualReceiverCockpitLayout, { width: 1, height: 1 })).toBe(true);
+  });
+
+  it('resolveLayoutForViewport returns the cockpit itself, never a fallback, at any size', () => {
+    expect(resolveLayoutForViewport('dual-receiver-cockpit', { width: 1, height: 1 })?.id)
+      .toBe('dual-receiver-cockpit');
+  });
+});

--- a/frontend/src/presentation/layouts/__tests__/registry.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/registry.test.ts
@@ -22,6 +22,22 @@ describe('the sdr-test real registration proof', () => {
   });
 });
 
+describe('the dual-receiver-cockpit registration barrel proof (MOR-1067)', () => {
+  // Kills: declarations.ts dropping the dual-receiver-cockpit line — the only
+  // thing that wires that manifest into the app-wide registration barrel.
+  // This file deliberately imports ONLY '../declarations' (never
+  // '../dual-receiver-cockpit'), so the layout can be found here if and only
+  // if the barrel itself pulls the manifest module in. Without this, deleting
+  // the line leaves the whole suite green while the app silently loses the
+  // layout — the surviving mutant review cycle 1 found (F3).
+  it('registers dual-receiver-cockpit through the barrel, not through a test-file import', () => {
+    const cockpit = getLayout('dual-receiver-cockpit');
+    expect(cockpit).toBeDefined();
+    expect(cockpit?.id).toBe('dual-receiver-cockpit');
+    expect(typeof cockpit?.loader).toBe('function');
+  });
+});
+
 describe('count-agnostic registration', () => {
   // Kills: a registry that hardcodes a family count instead of accepting
   // any manifest that passes validation.

--- a/frontend/src/presentation/layouts/declarations.ts
+++ b/frontend/src/presentation/layouts/declarations.ts
@@ -7,6 +7,11 @@
  * migrate the remaining skins the same way, purely additively.
  */
 import { registerLayout, type LayoutManifest } from './contract';
+// MOR-1067 registration — see that file. Re-exported rather than imported for
+// its side effect alone: this barrel is the ONLY thing that wires the cockpit
+// into the app, and a named re-export gives every test a real binding to
+// assert against, so dropping this line cannot pass unnoticed.
+export { dualReceiverCockpitLayout } from './dual-receiver-cockpit';
 
 export const sdrTestLayout: LayoutManifest = {
   schemaVersion: 1,

--- a/frontend/src/presentation/layouts/dual-receiver-cockpit.ts
+++ b/frontend/src/presentation/layouts/dual-receiver-cockpit.ts
@@ -1,0 +1,35 @@
+/**
+ * MOR-1067 — the dual-receiver-cockpit reference layout: two per-receiver
+ * VFO channel strips sharing one shared RX/TX status+action surface
+ * ("studioline's natural home", MOR-977 §4.4). A standalone manifest file
+ * — `declarations.ts` carries only the one registration import — so this
+ * and MOR-1092's LCD entrypoints never touch the same lines.
+ *
+ * `compatibleTopologies` deliberately excludes the two single-receiver
+ * classes: a single-receiver radio has nothing to put in a second strip, so
+ * this layout must not mount for one — `fallbackLayoutId` sends it to the
+ * already-registered, all-topology `sdr-test` layout instead (MOR-976
+ * "degrades safely" acceptance). `sizing: fluid` encodes the MOR-1160
+ * chrome-fluid half of the sizing axis: this shell composes only VFO/RX-TX
+ * status text today (no fixed-native instrument glass yet), so it always
+ * fits, at any viewport.
+ */
+import { registerLayout, type LayoutManifest } from './contract';
+
+export const dualReceiverCockpitLayout: LayoutManifest = {
+  schemaVersion: 1,
+  id: 'dual-receiver-cockpit',
+  displayName: 'Dual Receiver Cockpit',
+  loader: () => import('../../skins/dual-receiver-cockpit/DualReceiverCockpit.svelte'),
+  zones: [
+    { id: 'primary-vfo', surfaces: ['vfo'] },
+    { id: 'secondary-vfo', surfaces: ['vfo'] },
+    { id: 'rx-tx', surfaces: ['rxTx'] },
+  ],
+  compatibleTopologies: ['2/ab_shared', '2/main_sub'],
+  requiredSemanticSurfaces: ['vfo', 'rxTx'],
+  sizing: { mode: 'fluid', responsiveBreakpoints: [] },
+  fallbackLayoutId: 'sdr-test',
+};
+
+registerLayout(dualReceiverCockpitLayout);

--- a/frontend/src/semantic/VfoSurface.svelte
+++ b/frontend/src/semantic/VfoSurface.svelte
@@ -13,6 +13,13 @@
   'unknown'`) — never fabricate an A/B id. Split/dual-watch toggles are
   always structurally present but DISABLED while unobserved, rendered as
   an explicit tri-state — never defaulted to "off".
+
+  Two optional props exist only for callers that mount ONE SURFACE PER
+  RECEIVER over a sliced view model (MOR-1067's dual-receiver cockpit);
+  both default to the unsliced behaviour byte-for-byte. `selectionPoolSize`
+  keeps the "structurally nothing to choose" gate reading the whole radio
+  rather than the slice, and `showRadioWideFacts` lets such a caller render
+  the radio-wide split/dual-watch/active-receiver facts exactly once.
 -->
 <script module lang="ts">
   import type { ReceiverId, VfoSlot } from './radio-view-model';
@@ -32,9 +39,35 @@
     onSelectVfo?: (target: VfoSelection) => void;
     onToggleSplit?: () => void;
     onToggleDualWatch?: () => void;
+    /**
+     * MOR-1067: how many VFOs the operator can choose BETWEEN across the WHOLE
+     * radio. Defaults to `viewModel.vfos.length` — for an unsliced view model
+     * those are the same number, so the default path is unchanged. A
+     * dual-receiver channel strip passes the whole model's count: its slice
+     * holds one VFO, but the radio still has something to choose, and the
+     * MOR-977 structural gate must not read a per-receiver SLICE as "there is
+     * structurally nothing to choose" and render the control ABSENT.
+     */
+    selectionPoolSize?: number;
+    /**
+     * MOR-1067: split / dual-watch / active-receiver are radio-WIDE facts, not
+     * per-receiver ones. A cockpit that mounts one surface per receiver must
+     * render them exactly once — two `role="switch"` controls for one radio
+     * fact is duplicated radio behaviour in the presentation and a duplicated
+     * `aria-checked` pair for assistive tech. Defaults to `true`: the single
+     * unsliced surface renders them exactly as before.
+     */
+    showRadioWideFacts?: boolean;
   }
 
-  let { viewModel, onSelectVfo, onToggleSplit, onToggleDualWatch }: Props = $props();
+  let {
+    viewModel,
+    onSelectVfo,
+    onToggleSplit,
+    onToggleDualWatch,
+    selectionPoolSize,
+    showRadioWideFacts = true,
+  }: Props = $props();
 
   function slotKey(slot: VfoSlot): string {
     return slot.kind === 'slotted' ? slot.id : slot.kind;
@@ -52,7 +85,7 @@
   }
 
   function isSelectable(vfo: VfoViewModel): boolean {
-    return viewModel.vfos.length > 1 && !vfo.isActive;
+    return (selectionPoolSize ?? viewModel.vfos.length) > 1 && !vfo.isActive;
   }
 
   function selectVfo(vfo: VfoViewModel): void {
@@ -82,17 +115,19 @@
 </script>
 
 <div class="vfo-surface" role="group" aria-label={t('core.vfo.groupLabel')} data-testid="vfo-surface">
-  <p
-    class="active-receiver"
-    data-testid="vfo-active-receiver"
-    data-active-receiver={viewModel.activeReceiver.status === 'known'
-      ? viewModel.activeReceiver.receiver
-      : 'unknown'}
-  >
-    {viewModel.activeReceiver.status === 'known'
-      ? t('core.vfo.activeReceiver.known', { receiver: viewModel.activeReceiver.receiver })
-      : t('core.vfo.activeReceiver.unknown')}
-  </p>
+  {#if showRadioWideFacts}
+    <p
+      class="active-receiver"
+      data-testid="vfo-active-receiver"
+      data-active-receiver={viewModel.activeReceiver.status === 'known'
+        ? viewModel.activeReceiver.receiver
+        : 'unknown'}
+    >
+      {viewModel.activeReceiver.status === 'known'
+        ? t('core.vfo.activeReceiver.known', { receiver: viewModel.activeReceiver.receiver })
+        : t('core.vfo.activeReceiver.unknown')}
+    </p>
+  {/if}
 
   <div class="vfo-list" data-testid="vfo-list">
     {#each viewModel.vfos as vfo, i (vfo.receiver + ':' + i)}
@@ -131,32 +166,34 @@
     {/each}
   </div>
 
-  <div class="fact-toggles">
-    <button
-      type="button"
-      class="fact-toggle"
-      data-vfo-split
-      role="switch"
-      aria-checked={triState(viewModel.split)}
-      aria-label={t('core.vfo.split.label')}
-      disabled={viewModel.split.status === 'unknown'}
-      onclick={toggleSplit}
-    >
-      {t('core.vfo.split.label')}: {stateWord(viewModel.split)}
-    </button>
-    <button
-      type="button"
-      class="fact-toggle"
-      data-vfo-dual-watch
-      role="switch"
-      aria-checked={triState(viewModel.dualWatch)}
-      aria-label={t('core.vfo.dualWatch.label')}
-      disabled={viewModel.dualWatch.status === 'unknown'}
-      onclick={toggleDualWatch}
-    >
-      {t('core.vfo.dualWatch.label')}: {stateWord(viewModel.dualWatch)}
-    </button>
-  </div>
+  {#if showRadioWideFacts}
+    <div class="fact-toggles">
+      <button
+        type="button"
+        class="fact-toggle"
+        data-vfo-split
+        role="switch"
+        aria-checked={triState(viewModel.split)}
+        aria-label={t('core.vfo.split.label')}
+        disabled={viewModel.split.status === 'unknown'}
+        onclick={toggleSplit}
+      >
+        {t('core.vfo.split.label')}: {stateWord(viewModel.split)}
+      </button>
+      <button
+        type="button"
+        class="fact-toggle"
+        data-vfo-dual-watch
+        role="switch"
+        aria-checked={triState(viewModel.dualWatch)}
+        aria-label={t('core.vfo.dualWatch.label')}
+        disabled={viewModel.dualWatch.status === 'unknown'}
+        onclick={toggleDualWatch}
+      >
+        {t('core.vfo.dualWatch.label')}: {stateWord(viewModel.dualWatch)}
+      </button>
+    </div>
+  {/if}
 </div>
 
 <style>

--- a/frontend/src/skins/dual-receiver-cockpit/DualReceiverCockpit.svelte
+++ b/frontend/src/skins/dual-receiver-cockpit/DualReceiverCockpit.svelte
@@ -1,0 +1,45 @@
+<!--
+  Dual Receiver Cockpit (MOR-1067) — the `dual-receiver-cockpit` manifest's
+  compiled shell. Static composition only: places the primary/secondary VFO
+  channel strips and the shared RX/TX status+action surface via
+  SemanticRadioSurfaces' `strips="dual"` composition (MOR-1065 wiring,
+  reused unmodified — its lease-safe TX internals live in exactly one file,
+  components-v2/wiring/SemanticRadioSurfaces.svelte). No manufacturer
+  conditionals, no runtime/store/command import here.
+
+  Scope, controls, and global are placed as inert structural zones. MOR-1062/
+  1065 ship only the vfo/rxTx semantic surfaces — nothing here may claim
+  those regions are live. Same two-level gating as the surfaces themselves
+  (MOR-977): present so the shell composes every named region, disabled
+  because no real surface backs them yet — never falsely active.
+-->
+<script lang="ts">
+  import SemanticRadioSurfaces from '../../components-v2/wiring/SemanticRadioSurfaces.svelte';
+</script>
+
+<div class="dual-receiver-cockpit" data-testid="dual-receiver-cockpit">
+  <div class="cockpit-receivers" data-testid="cockpit-zone-receivers">
+    <SemanticRadioSurfaces strips="dual" />
+  </div>
+
+  {#each ['scope', 'controls', 'global'] as zone (zone)}
+    <div
+      class="cockpit-inert-zone"
+      data-testid={`cockpit-zone-${zone}`}
+      data-zone-active="false"
+      aria-disabled="true"
+    ></div>
+  {/each}
+</div>
+
+<style>
+  .dual-receiver-cockpit {
+    display: grid;
+    grid-template-rows: 1fr auto auto auto;
+    gap: 8px;
+    height: 100%;
+  }
+  .cockpit-inert-zone {
+    min-height: 0;
+  }
+</style>

--- a/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
+++ b/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
@@ -1,0 +1,313 @@
+/**
+ * MOR-1067 — the compiled dual-receiver-cockpit SHELL, mounted end to end
+ * against the REAL adapter and REAL semantic surfaces (only the runtime
+ * singleton and the TX authority are mocked, same pattern as
+ * `components-v2/wiring/__tests__/semantic-rx-tx-wiring.component.test.ts`).
+ *
+ * Covers the ticket's discriminating requirements: per-receiver VFO strips
+ * driven by the dual-receiver topologies, single-receiver exclusion (proved
+ * separately at the registry in `presentation/layouts/__tests__/
+ * dual-receiver-cockpit.test.ts`), exactly one TX authority surface, the
+ * scope/controls/global zones staying inert, and no shell-level fabrication
+ * of an active strip. Each test's doc line names the mutation it kills.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { ServerState } from '$lib/types/state';
+
+const h = vi.hoisted(() => ({
+  state: null as unknown,
+  caps: null as unknown,
+  snapshot: null as unknown,
+  listeners: new Set<(next: unknown) => void>(),
+  start: vi.fn(),
+  release: vi.fn(),
+  setIntent: vi.fn(),
+  resetFault: vi.fn(),
+  selectVfo: vi.fn(),
+  splitToggle: vi.fn(),
+  dualWatchToggle: vi.fn(),
+  modInputGuard: { visible: false, sourceLabel: null } as { visible: boolean; sourceLabel: string | null },
+}));
+
+vi.mock('$lib/runtime', () => ({
+  runtime: {
+    get state() { return h.state; },
+    get caps() { return h.caps; },
+  },
+}));
+vi.mock('$lib/runtime/tx-controller/app-host', () => ({
+  getAppTxController: () => ({
+    snapshot: () => h.snapshot,
+    subscribe: (listener: (next: unknown) => void) => {
+      h.listeners.add(listener);
+      return () => h.listeners.delete(listener);
+    },
+    start: h.start,
+    setIntent: h.setIntent,
+    release: h.release,
+    resetFault: h.resetFault,
+  }),
+}));
+vi.mock('$lib/runtime/adapters/mod-input-tx-guard.svelte', () => ({
+  deriveModInputTxGuardProps: () => h.modInputGuard,
+  getModInputTxGuardHandlers: () => ({ onSetLan: vi.fn(), onDismiss: vi.fn() }),
+}));
+vi.mock('../../../components-v2/wiring/command-bus', () => ({
+  makeVfoHandlers: () => ({
+    onVfoSelect: h.selectVfo,
+    onSplitToggle: h.splitToggle,
+    onDualWatchToggle: h.dualWatchToggle,
+  }),
+}));
+
+import DualReceiverCockpit from '../DualReceiverCockpit.svelte';
+
+type Snapshot = {
+  phase: string; intent: string | null; guard: { leaseId: string } | null;
+  radioTx: string; txRisk: string; mayOwnKey: boolean; fault: string | null;
+};
+const IDLE: Snapshot = {
+  phase: 'idle', intent: null, guard: null, radioTx: 'off', txRisk: 'none',
+  mayOwnKey: false, fault: null,
+};
+const fresh = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' };
+
+/** 2/main_sub: MAIN and SUB each carry A/B slots (4 vfo tiles total). */
+function mainSubState(active: 'MAIN' | 'SUB' = 'MAIN'): ServerState {
+  const paths = ['active', 'split', 'dualWatch', 'txTarget'];
+  for (const rx of ['main', 'sub']) {
+    paths.push(`${rx}.activeSlot`);
+    for (const v of ['vfoA', 'vfoB']) paths.push(`${rx}.${v}.freqHz`, `${rx}.${v}.mode`, `${rx}.${v}.filterNum`);
+  }
+  const slot = (hz: number) => ({ freqHz: hz, mode: 'USB', filterNum: 1 });
+  const receiver = (hz: number) => ({ vfoA: slot(hz), vfoB: slot(hz + 30000), activeSlot: 'A' });
+  return {
+    active, split: true, dualWatch: true, ptt: false,
+    txTarget: { status: 'known', receiver: 'MAIN', slot: 'A', frequencyHz: 14250000 },
+    main: receiver(14250000), sub: receiver(21295000),
+    fieldStatus: Object.fromEntries(paths.map((p) => [p, fresh])),
+  } as unknown as ServerState;
+}
+const mainSubCaps = (): Capabilities => ({
+  model: 'fixture', scope: false, audio: true, tx: true,
+  capabilities: ['audio', 'tx', 'dual_rx'], receivers: 2, vfoScheme: 'main_sub',
+  freqRanges: [], modes: [], filters: [],
+  audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
+  webrtc: { available: false, enabled: false },
+  txBands: [{ start: 14000000, end: 14350000, name: '20m' }],
+  scopeSource: null, audioFftAvailable: false,
+} as unknown as Capabilities);
+
+/** 2/ab_shared: MAIN and SUB are each a single unslotted VFO (2 vfo tiles total). */
+function abSharedState(): ServerState {
+  const paths = ['active', 'split', 'dualWatch', 'txTarget', 'main.freqHz', 'main.mode', 'main.filter',
+    'sub.freqHz', 'sub.mode', 'sub.filter'];
+  const receiver = (hz: number) => ({ freqHz: hz, mode: 'CW', filter: 1 });
+  return {
+    active: 'SUB', split: false, dualWatch: true, ptt: false,
+    txTarget: { status: 'known', receiver: 'SUB', slot: null, frequencyHz: 3573000 },
+    main: receiver(3573000), sub: receiver(3573000),
+    fieldStatus: Object.fromEntries(paths.map((p) => [p, fresh])),
+  } as unknown as ServerState;
+}
+/** Same shape as `mainSubState`, minus the 'active' fieldStatus entry — activeReceiver stays unknown. */
+function mainSubStateUnknownActive(): ServerState {
+  const state = mainSubState();
+  const { active: _dropped, ...fieldStatus } = state.fieldStatus as Record<string, unknown>;
+  return { ...state, fieldStatus } as unknown as ServerState;
+}
+const abSharedCaps = (): Capabilities => ({
+  ...mainSubCaps(), vfoScheme: 'ab_shared',
+} as unknown as Capabilities);
+
+let target: HTMLDivElement;
+let component: ReturnType<typeof mount> | null = null;
+
+function render(): void {
+  target = document.createElement('div');
+  document.body.appendChild(target);
+  component = mount(DualReceiverCockpit, { target });
+  flushSync();
+}
+
+const q = <T extends HTMLElement>(sel: string) => target.querySelector(sel) as T | null;
+const qa = <T extends HTMLElement>(sel: string) => [...target.querySelectorAll<T>(sel)];
+
+beforeEach(() => {
+  h.snapshot = { ...IDLE };
+  h.listeners.clear();
+  h.start.mockReset();
+  h.release.mockReset();
+  h.setIntent.mockReset();
+  h.resetFault.mockReset();
+  h.selectVfo = vi.fn();
+  h.splitToggle = vi.fn();
+  h.dualWatchToggle = vi.fn();
+  h.modInputGuard = { visible: false, sourceLabel: null };
+});
+
+afterEach(() => {
+  if (component) unmount(component);
+  component = null;
+  document.body.innerHTML = '';
+});
+
+describe('per-receiver VFO strips, driven by the dual-receiver topologies', () => {
+  it('2/main_sub: renders one strip per receiver, each holding only that receiver\'s tiles', () => {
+    h.state = mainSubState('MAIN');
+    h.caps = mainSubCaps();
+    render();
+
+    expect(qa('[data-testid^="channel-strip-"]')).toHaveLength(2);
+    const mainStrip = q('[data-testid="channel-strip-MAIN"]')!;
+    const subStrip = q('[data-testid="channel-strip-SUB"]')!;
+    expect(mainStrip.querySelectorAll('[data-vfo-tile]')).toHaveLength(2);
+    expect(subStrip.querySelectorAll('[data-vfo-tile]')).toHaveLength(2);
+    // Kills: strips sharing one unfiltered vfo list instead of splitting.
+    expect([...mainStrip.querySelectorAll('[data-vfo-tile]')].every(
+      (el) => (el as HTMLElement).dataset.vfoReceiver === 'MAIN',
+    )).toBe(true);
+    expect([...subStrip.querySelectorAll('[data-vfo-tile]')].every(
+      (el) => (el as HTMLElement).dataset.vfoReceiver === 'SUB',
+    )).toBe(true);
+  });
+
+  it('2/ab_shared: renders one strip per receiver with exactly one tile each', () => {
+    h.state = abSharedState();
+    h.caps = abSharedCaps();
+    render();
+
+    expect(qa('[data-testid^="channel-strip-"]')).toHaveLength(2);
+    expect(q('[data-testid="channel-strip-MAIN"]')!.querySelectorAll('[data-vfo-tile]')).toHaveLength(1);
+    expect(q('[data-testid="channel-strip-SUB"]')!.querySelectorAll('[data-vfo-tile]')).toHaveLength(1);
+  });
+
+  // Review cycle 1, F1. `2/ab_shared` gives each receiver exactly ONE
+  // unslotted VFO, so a strip that gates selection on its own slice sees
+  // `vfos.length === 1` and renders the control ABSENT — the operator loses
+  // every way to change the active receiver, on a topology this layout
+  // declares itself compatible with. The gate must read the whole radio.
+  it('2/ab_shared: offers exactly one control, and it selects the NON-active receiver', () => {
+    h.state = abSharedState();          // SUB is the active receiver
+    h.caps = abSharedCaps();
+    render();
+
+    const selects = qa<HTMLButtonElement>('[data-vfo-select]');
+    expect(selects).toHaveLength(1);
+    // Present, enabled, and living in the strip the operator would switch TO.
+    expect(selects[0].disabled).toBe(false);
+    expect(q('[data-testid="channel-strip-MAIN"]')!.contains(selects[0])).toBe(true);
+
+    selects[0].click();
+    flushSync();
+    expect(h.selectVfo).toHaveBeenCalledTimes(1);
+    expect(h.selectVfo).toHaveBeenCalledWith('MAIN', null);
+  });
+
+  it('marks the positively-observed active receiver\'s strip, and only that one', () => {
+    h.state = mainSubState('SUB');
+    h.caps = mainSubCaps();
+    render();
+
+    expect(q('[data-testid="channel-strip-SUB"]')!.dataset.stripActive).toBe('true');
+    expect(q('[data-testid="channel-strip-MAIN"]')!.dataset.stripActive).toBe('false');
+  });
+
+  // The mutation this ticket names explicitly: a shell that fabricates an
+  // active strip when activeReceiver was never observed.
+  it('fabricates NO active strip when activeReceiver is unknown', () => {
+    h.state = mainSubStateUnknownActive();
+    h.caps = mainSubCaps();
+    render();
+
+    expect(q('[data-testid="channel-strip-MAIN"]')!.dataset.stripActive).toBe('false');
+    expect(q('[data-testid="channel-strip-SUB"]')!.dataset.stripActive).toBe('false');
+  });
+});
+
+describe('radio-wide facts render once per cockpit, never once per strip', () => {
+  // Review cycle 1, F2. split / dualWatch / activeReceiver are radio-WIDE
+  // facts that `forReceiver` (correctly) passes through to every slice, so a
+  // naive strip-per-receiver mount renders each of them TWICE: two
+  // independent-looking `role="switch"` controls for one radio fact — a
+  // duplicated aria-checked pair for assistive tech, and exactly the
+  // "duplicated radio behavior" MOR-976 rules out. The shell got the TX half
+  // of the one-control-per-radio-wide-authority rule right; this is the
+  // split/dual-watch half.
+  it.each([
+    ['2/main_sub', () => mainSubState('MAIN'), mainSubCaps],
+    ['2/ab_shared', abSharedState, abSharedCaps],
+  ] as const)('%s: exactly one split switch, one dual-watch switch, one active-receiver line', (
+    _topology, makeState, makeCaps,
+  ) => {
+    h.state = makeState();
+    h.caps = makeCaps();
+    render();
+
+    expect(qa('[data-testid^="channel-strip-"]')).toHaveLength(2);
+    expect(qa('[data-vfo-split]')).toHaveLength(1);
+    expect(qa('[data-vfo-dual-watch]')).toHaveLength(1);
+    expect(qa('[data-testid="vfo-active-receiver"]')).toHaveLength(1);
+  });
+
+  // Rendering the radio-wide row once must not cost the operator the control:
+  // the surviving switch still reaches the same radio-wide handler.
+  it('the single surviving dual-watch switch still reaches the radio-wide handler', () => {
+    h.state = mainSubState('MAIN');
+    h.caps = mainSubCaps();
+    render();
+
+    const dualWatch = q<HTMLButtonElement>('[data-vfo-dual-watch]')!;
+    expect(dualWatch.disabled).toBe(false);
+    dualWatch.click();
+    flushSync();
+    expect(h.dualWatchToggle).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('exactly one authoritative TX action surface across both strips', () => {
+  it('renders a single shared RX/TX surface and a single key button', () => {
+    h.state = mainSubState('MAIN');
+    h.caps = mainSubCaps();
+    render();
+
+    expect(qa('[data-testid="rx-tx-surface"]')).toHaveLength(1);
+    expect(qa('[data-testid="rx-tx-key"]')).toHaveLength(1);
+  });
+
+  it('unkey stays ungated and reaches the same App TX authority the sdr-test wiring uses', () => {
+    h.state = mainSubState('MAIN');
+    h.caps = mainSubCaps();
+    render();
+    push({ phase: 'failed', fault: 'audio-failed', guard: { leaseId: 'x' }, mayOwnKey: true });
+
+    const unkey = q<HTMLButtonElement>('[data-testid="rx-tx-unkey"]')!;
+    expect(unkey.disabled).toBe(false);
+    unkey.click();
+    flushSync();
+    expect(h.release).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('scope/controls/global zones — placed, never falsely active', () => {
+  it('all three are present and structurally disabled', () => {
+    h.state = mainSubState('MAIN');
+    h.caps = mainSubCaps();
+    render();
+
+    for (const zone of ['scope', 'controls', 'global']) {
+      const el = q(`[data-testid="cockpit-zone-${zone}"]`)!;
+      expect(el).not.toBeNull();
+      expect(el.getAttribute('aria-disabled')).toBe('true');
+      expect(el.dataset.zoneActive).toBe('false');
+    }
+  });
+});
+
+function push(next: Partial<Snapshot>): void {
+  h.snapshot = { ...(h.snapshot as Snapshot), ...next };
+  for (const listener of h.listeners) listener(h.snapshot);
+  flushSync();
+}


### PR DESCRIPTION
Closes MOR-1067.

## What

The reference `dual-receiver-cockpit` layout: manifest v1 (zones `primary-vfo`/`secondary-vfo`/`rx-tx`, topologies `2/ab_shared` + `2/main_sub`, fallback `sdr-test`) registered through the real MOR-1066 registry via the declarations barrel re-export idiom; `DualReceiverCockpit.svelte` shell rendering two VFO strips and ONE shared `RxTxSurface`; pure `dual-receiver-strips.ts` slicing (fail-closed on unknown `activeReceiver`); `SemanticRadioSurfaces` gains `strips?: 'single'|'dual'` with a byte-identical default path; `VfoSurface` gains `selectionPoolSize` + `showRadioWideFacts` whose defaults reproduce pre-change behavior exactly.

**108 net production LOC** (frozen formula, guard ≤200). 31 tests across 3 new + 2 pinned suites.

## Provenance

- Independent adversarial verification (opus), round 1: **BLOCKED** — 3 major (ab_shared receiver-selection control vanished in dual mode; split/dual-watch/active-receiver duplicated per strip; the `declarations.ts` registration line was a surviving mutant), 5 minor.
- Fix cycle 1: `selectionPoolSize` hint prop (whole-radio gate, not the slice), radio-wide facts rendered once per cockpit, declarations-only registration pin routed through the barrel (vitest `isolate:false`-proof), `strips`-default pin.
- Re-verification by the same verifier with its OWN mutants: **PASS**. Single-TX authority mutation-killed (RxTxSurface into the `{#each}` → named test fails); default path proven element-identical across 9 view-model shapes incl. 0/1-VFO edges; `declarations.ts` auto-merges cleanly vs `origin/main` (3-way verified).
- Deferred with tickets/comments: slicer purity lint (MOR-1248), zone-id↔DOM binding + SkinId reachability + radio-wide row placement → MOR-1068.

Local full-suite failing-file set identical to baseline (10 files, environmental Node-26 `localStorage`; CI is the gate). lint / check / i18n:check / build all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)