### PR TITLE
fix(MOR-1233): honor prefers-reduced-motion in rAF meter ballistics + token-layer contrast strategy

### DIFF
--- a/frontend/src/components-v2/meters/LinearSMeter.svelte
+++ b/frontend/src/components-v2/meters/LinearSMeter.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { createSmoother } from '$lib/utils/smoothing.svelte';
+  import { createSmoother, prefersReducedMotion, onReducedMotionChange } from '$lib/utils/smoothing.svelte';
   import {
     calibratedToSegments,
     calibratedToSUnit,
@@ -158,7 +158,9 @@
 
   $effect(() => {
     const current = smoother.value;
-    if (current >= peakSegs) {
+    // MOR-1233: under reduced motion there is no hold-then-decay animation —
+    // the indicator tracks the bar directly, so it never lags behind.
+    if (prefersReducedMotion() || current >= peakSegs) {
       // New peak — capture it
       peakSegs = current;
       peakTime = performance.now();
@@ -182,8 +184,28 @@
 
       peakFrameId = requestAnimationFrame(tickPeak);
     };
-    peakFrameId = requestAnimationFrame(tickPeak);
-    return () => { if (peakFrameId) cancelAnimationFrame(peakFrameId); };
+
+    // MOR-1233: the hold/decay ballistics above are exactly the animation
+    // prefers-reduced-motion asks us to skip — don't schedule the loop while
+    // the preference is active. Fix cycle 1: react to it changing mid-
+    // session too (start/stop alone only decide once, at mount).
+    if (!prefersReducedMotion()) peakFrameId = requestAnimationFrame(tickPeak);
+
+    const unsubscribe = onReducedMotionChange((reduced) => {
+      if (reduced) {
+        if (peakFrameId) {
+          cancelAnimationFrame(peakFrameId);
+          peakFrameId = 0;
+        }
+      } else if (!peakFrameId) {
+        peakFrameId = requestAnimationFrame(tickPeak);
+      }
+    });
+
+    return () => {
+      if (peakFrameId) cancelAnimationFrame(peakFrameId);
+      unsubscribe();
+    };
   });
 
   // Peak X position for the vertical indicator line

--- a/frontend/src/components-v2/meters/__tests__/LinearSMeter.reduced-motion.svelte.test.ts
+++ b/frontend/src/components-v2/meters/__tests__/LinearSMeter.reduced-motion.svelte.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount, unmount, flushSync } from 'svelte';
+import type { ComponentProps } from 'svelte';
+import LinearSMeter from '../LinearSMeter.svelte';
+
+// MOR-1233: LinearSMeter runs two independent requestAnimationFrame loops —
+// the ballistics smoother (via createSmoother) and its own peak-hold
+// hold-then-decay loop — neither of which previously checked
+// `prefers-reduced-motion`. These tests pin the fix: under reduced motion,
+// mounting the meter must not schedule any animation frame, and the peak
+// indicator must track the bar directly (no stale hold) rather than
+// lingering after a value drop.
+//
+// requestAnimationFrame is mocked to a no-op (never actually fires) so these
+// tests assert on *scheduling* deterministically, without a real ~16ms timer
+// callback bleeding into a later test after its component is unmounted.
+//
+// Peak-line presence is asserted via querySelectorAll(...).length rather
+// than querySelector(...) + toBeNull(): comparing a live DOM Element with
+// toBeNull() drives vitest's failure-message pretty-printer through the
+// element's own properties, which on a Svelte-mounted node trips Svelte's
+// dev-mode "rune used outside .svelte" guard as a red herring unrelated to
+// this fix. Asserting on the NodeList length sidesteps that entirely.
+//
+// Fix cycle 1 (verifier F1/F2): mounting under a *fixed* preference was
+// proven, but the decision was latched at mount — a runtime OS flip in
+// either direction left the peak-hold loop (like the ballistics loop in
+// smoothing.svelte.ts) either frozen forever or gliding forever. The mock
+// below gets working addEventListener/removeEventListener + a setMatches()
+// trigger so these tests can simulate a live flip.
+
+interface MatchMediaMock {
+  mql: MediaQueryList;
+  setMatches: (matches: boolean) => void;
+  listenerCount: () => number;
+}
+
+function createMatchMediaMock(initialMatches: boolean): MatchMediaMock {
+  let matches = initialMatches;
+  const listeners = new Set<() => void>();
+  const mql = {
+    get matches() { return matches; },
+    addEventListener: (_type: string, fn: () => void) => { listeners.add(fn); },
+    removeEventListener: (_type: string, fn: () => void) => { listeners.delete(fn); },
+  } as unknown as MediaQueryList;
+  return {
+    mql,
+    setMatches: (next: boolean) => {
+      matches = next;
+      listeners.forEach((fn) => fn());
+    },
+    listenerCount: () => listeners.size,
+  };
+}
+
+function mockReducedMotion(matches: boolean) {
+  const original = window.matchMedia;
+  const { mql, setMatches, listenerCount } = createMatchMediaMock(matches);
+  window.matchMedia = vi.fn().mockReturnValue(mql) as unknown as typeof window.matchMedia;
+  return {
+    setMatches,
+    listenerCount,
+    restore: () => { window.matchMedia = original; },
+  };
+}
+
+let rafSpy: ReturnType<typeof vi.spyOn>;
+let cafSpy: ReturnType<typeof vi.spyOn>;
+
+let components: ReturnType<typeof mount>[] = [];
+let roots: HTMLElement[] = [];
+
+function mountReactive(props: ComponentProps<typeof LinearSMeter>) {
+  const state = $state(props);
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+  roots.push(target);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const component = mount(LinearSMeter as any, { target, props: state });
+  flushSync();
+  components.push(component);
+  return { target, state, component };
+}
+
+beforeEach(() => {
+  // Never let a real frame fire — tests only care whether scheduling was
+  // attempted, not about animating an actual frame forward. The fake id
+  // must be non-zero: production code treats a falsy frameId (its initial
+  // value) as "nothing scheduled" — an id of 0 would make a real scheduled
+  // frame indistinguishable from none, silently defeating the
+  // cancelAnimationFrame assertions below.
+  rafSpy = vi.spyOn(window, 'requestAnimationFrame').mockImplementation(() => 1);
+  cafSpy = vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  components.forEach((component) => unmount(component));
+  roots.forEach((root) => root.remove());
+  components = [];
+  roots = [];
+  vi.restoreAllMocks();
+});
+
+function peakLineCount(target: HTMLElement): number {
+  return target.querySelectorAll('line[stroke-width="2"]').length;
+}
+
+describe('LinearSMeter — prefers-reduced-motion (MOR-1233)', () => {
+  it('schedules no animation frame on mount when reduced motion is preferred', () => {
+    const { restore } = mockReducedMotion(true);
+    try {
+      mountReactive({ value: 20 });
+      expect(rafSpy).not.toHaveBeenCalled();
+    } finally {
+      restore();
+    }
+  });
+
+  it('still schedules animation frames on mount when reduced motion is NOT preferred (baseline)', () => {
+    const { restore } = mockReducedMotion(false);
+    try {
+      mountReactive({ value: 20 });
+      // Ballistics smoother + peak-hold decay loop each schedule a frame.
+      expect(rafSpy).toHaveBeenCalled();
+    } finally {
+      restore();
+    }
+  });
+
+  it('does not leave a stale peak indicator after a value drop when reduced motion is preferred', () => {
+    const { restore } = mockReducedMotion(true);
+    try {
+      const { target, state } = mountReactive({ value: 20 });
+      flushSync();
+      // Even at a high value, no held peak line should linger: the peak
+      // tracks the (instantly-snapped) bar value directly under reduced
+      // motion, so peakSegs === smoother.value at all times.
+      expect(peakLineCount(target)).toBe(0);
+
+      state.value = 0;
+      flushSync();
+      expect(peakLineCount(target)).toBe(0);
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe('LinearSMeter — runtime prefers-reduced-motion flips (MOR-1233 fix cycle 1, F1/F2)', () => {
+  it('KILL F1: stops both live loops when reduced motion turns ON mid-session', () => {
+    const { setMatches, restore } = mockReducedMotion(false);
+    try {
+      mountReactive({ value: 20 });
+      flushSync();
+      rafSpy.mockClear();
+
+      // OS preference flips to "reduce" while both loops (ballistics +
+      // peak-hold) are already scheduled.
+      setMatches(true);
+
+      // Both loops must be torn down independently — exactly one
+      // cancelAnimationFrame per loop (2 total). toHaveBeenCalled() alone
+      // is satisfied by either loop cancelling on its own, so a mutant that
+      // severs just one loop's cancel branch (verifier N6/N8) would survive
+      // undetected; toHaveBeenCalledTimes(2) requires both.
+      expect(cafSpy).toHaveBeenCalledTimes(2);
+      expect(rafSpy).not.toHaveBeenCalled();
+    } finally {
+      restore();
+    }
+  });
+
+  it('KILL F2: resumes both loops when reduced motion turns OFF mid-session', () => {
+    const { setMatches, restore } = mockReducedMotion(true);
+    try {
+      mountReactive({ value: 20 });
+      flushSync();
+      expect(rafSpy).not.toHaveBeenCalled(); // nothing scheduled at mount
+
+      // OS preference clears while mounted — both loops must (re)start
+      // independently: exactly one requestAnimationFrame per loop (2
+      // total). toHaveBeenCalled() alone would still pass if only one loop
+      // resumed (verifier N6/N8); toHaveBeenCalledTimes(2) requires both.
+      setMatches(false);
+
+      expect(rafSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      restore();
+    }
+  });
+
+  it('detaches both reduced-motion change listeners on unmount — no leak', () => {
+    const { listenerCount, restore } = mockReducedMotion(false);
+    try {
+      const { component } = mountReactive({ value: 20 });
+      flushSync();
+      // Ballistics smoother + peak-hold each register their own listener.
+      expect(listenerCount()).toBeGreaterThanOrEqual(2);
+
+      unmount(component);
+      components = components.filter((c) => c !== component);
+      expect(listenerCount()).toBe(0);
+    } finally {
+      restore();
+    }
+  });
+});

--- a/frontend/src/components-v2/theme/__tests__/tokens-contrast.test.ts
+++ b/frontend/src/components-v2/theme/__tests__/tokens-contrast.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// MOR-1233: nothing in the frontend responded to the OS-level
+// `prefers-contrast` / `forced-colors` accessibility signals before this —
+// only a manually-selectable "High Contrast" theme existed (see
+// ../themes/high-contrast.css), which a user has to opt into explicitly.
+// This pins the minimal automatic token-layer strategy: the v2 token root
+// (this file, not styles/tokens.css which owns --focus-ring / MOR-1232)
+// gains `@media (prefers-contrast: more)` and `@media (forced-colors:
+// active)` blocks that bump border/text separation, scoped to
+// `:root:not([data-theme])` so an explicit manual theme choice always wins
+// over the automatic OS signal.
+
+const source = readFileSync(
+  resolve(process.cwd(), 'src/components-v2/theme/tokens.css'),
+  'utf8',
+);
+
+describe('components-v2/theme/tokens.css — prefers-contrast / forced-colors (MOR-1233)', () => {
+  it('defines an automatic prefers-contrast: more block', () => {
+    expect(source).toMatch(/@media\s*\(prefers-contrast:\s*more\)/);
+  });
+
+  it('defines an automatic forced-colors: active block', () => {
+    expect(source).toMatch(/@media\s*\(forced-colors:\s*active\)/);
+  });
+
+  it('scopes both blocks to :root:not([data-theme]) so an explicit theme choice wins', () => {
+    const contrastBlock = source.match(
+      /@media\s*\(prefers-contrast:\s*more\)\s*\{([\s\S]*?)\n\}/,
+    );
+    const forcedColorsBlock = source.match(
+      /@media\s*\(forced-colors:\s*active\)\s*\{([\s\S]*?)\n\}/,
+    );
+    expect(contrastBlock).not.toBeNull();
+    expect(forcedColorsBlock).not.toBeNull();
+    expect(contrastBlock![1]).toMatch(/:root:not\(\[data-theme\]\)/);
+    expect(forcedColorsBlock![1]).toMatch(/:root:not\(\[data-theme\]\)/);
+  });
+
+  it('bumps border tokens under both blocks (the concrete accessibility win)', () => {
+    const contrastBlock = source.match(
+      /@media\s*\(prefers-contrast:\s*more\)\s*\{[\s\S]*?\n\}/,
+    )![0];
+    const forcedColorsBlock = source.match(
+      /@media\s*\(forced-colors:\s*active\)\s*\{[\s\S]*?\n\}/,
+    )![0];
+    expect(contrastBlock).toMatch(/--v2-border:/);
+    expect(forcedColorsBlock).toMatch(/--v2-border:/);
+  });
+
+  it('does not declare --focus-ring (owned by MOR-1232 in styles/tokens.css)', () => {
+    // Matches an actual custom-property *declaration*, not a prose mention
+    // of the name in a comment (this file's MOR-1233 block references it).
+    expect(source).not.toMatch(/--focus-ring\s*:/);
+  });
+});

--- a/frontend/src/components-v2/theme/tokens.css
+++ b/frontend/src/components-v2/theme/tokens.css
@@ -283,3 +283,35 @@
   --v2-vfo-font-weight: 700;
   --v2-vfo-font-style: normal;
 }
+
+/* ── MOR-1233: prefers-contrast / forced-colors — minimal automatic strategy ──
+ * A manually-selectable "High Contrast" theme already exists (see
+ * themes/high-contrast.css) but nothing responds to the OS-level signal
+ * automatically. This is intentionally minimal, not a full palette swap:
+ * bump border/text separation under `prefers-contrast: more`, and re-anchor
+ * border tokens to system colors under `forced-colors: active` (e.g.
+ * Windows High Contrast Mode) so panel/track outlines stay visible.
+ * `:not([data-theme])` so an explicit manual theme choice always wins over
+ * the automatic OS signal. SVG fill/stroke (meters, scope) is not
+ * auto-adjusted by forced-colors and is out of scope here — see the build
+ * report for MOR-1233 for a follow-up note. Does not touch --focus-ring
+ * (styles/tokens.css, MOR-1232).
+ */
+@media (prefers-contrast: more) {
+  :root:not([data-theme]) {
+    --v2-border: #7a95b5;
+    --v2-border-subtle: #5f7a9a;
+    --v2-border-panel: #7a95b5;
+    --v2-text-dim: #a8bcd0;
+    --v2-text-muted: #9db2c8;
+  }
+}
+
+@media (forced-colors: active) {
+  :root:not([data-theme]) {
+    --v2-border: CanvasText;
+    --v2-border-subtle: CanvasText;
+    --v2-border-panel: CanvasText;
+    --v2-bg-panel: Canvas;
+  }
+}

--- a/frontend/src/lib/utils/__tests__/smoothing.svelte.test.ts
+++ b/frontend/src/lib/utils/__tests__/smoothing.svelte.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { createSmoother } from '../smoothing.svelte';
+
+// MOR-1233: the rAF ballistics loop in createSmoother previously ran
+// unconditionally, ignoring `prefers-reduced-motion`. These tests pin the
+// fix: under reduced motion the value must snap directly to target instead
+// of animating, and no requestAnimationFrame loop may be scheduled at all.
+//
+// Fix cycle 1 (verifier F1/F2): the reduced-motion decision must not be
+// latched at mount. A `MediaQueryList` mock with working
+// addEventListener/removeEventListener + a `setMatches()` trigger lets these
+// tests simulate the OS flipping the preference *while a smoother is live*,
+// in both directions, and prove the change listener is detached on stop()
+// (no leak).
+
+interface MatchMediaMock {
+  mql: MediaQueryList;
+  setMatches: (matches: boolean) => void;
+  listenerCount: () => number;
+}
+
+function createMatchMediaMock(initialMatches: boolean): MatchMediaMock {
+  let matches = initialMatches;
+  const listeners = new Set<() => void>();
+  const mql = {
+    get matches() { return matches; },
+    addEventListener: (_type: string, fn: () => void) => { listeners.add(fn); },
+    removeEventListener: (_type: string, fn: () => void) => { listeners.delete(fn); },
+  } as unknown as MediaQueryList;
+  return {
+    mql,
+    setMatches: (next: boolean) => {
+      matches = next;
+      listeners.forEach((fn) => fn());
+    },
+    listenerCount: () => listeners.size,
+  };
+}
+
+function mockReducedMotion(matches: boolean) {
+  const original = window.matchMedia;
+  const { mql, setMatches, listenerCount } = createMatchMediaMock(matches);
+  window.matchMedia = vi.fn().mockReturnValue(mql) as unknown as typeof window.matchMedia;
+  return {
+    setMatches,
+    listenerCount,
+    restore: () => { window.matchMedia = original; },
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('createSmoother — prefers-reduced-motion (MOR-1233)', () => {
+  it('snaps value directly to target on update() when reduced motion is preferred', () => {
+    const { restore } = mockReducedMotion(true);
+    try {
+      const smoother = createSmoother(0.12, 0.32, 0);
+      expect(smoother.value).toBe(0);
+
+      smoother.update(42);
+
+      // No rAF tick has run — under reduced motion the snap happens inline.
+      expect(smoother.value).toBe(42);
+    } finally {
+      restore();
+    }
+  });
+
+  it('does not schedule requestAnimationFrame from start() when reduced motion is preferred', () => {
+    const { restore } = mockReducedMotion(true);
+    const rafSpy = vi.spyOn(window, 'requestAnimationFrame');
+    try {
+      const smoother = createSmoother(0.12, 0.32, 0);
+      smoother.update(10);
+      smoother.start();
+
+      expect(rafSpy).not.toHaveBeenCalled();
+      expect(smoother.value).toBe(10);
+
+      smoother.stop();
+    } finally {
+      restore();
+    }
+  });
+
+  it('still schedules requestAnimationFrame from start() when reduced motion is NOT preferred (baseline)', () => {
+    const { restore } = mockReducedMotion(false);
+    const rafSpy = vi.spyOn(window, 'requestAnimationFrame');
+    try {
+      const smoother = createSmoother(0.12, 0.32, 0);
+      smoother.update(10);
+      smoother.start();
+
+      expect(rafSpy).toHaveBeenCalled();
+      // Ballistics haven't converged yet — a real animation is in flight.
+      expect(smoother.value).toBe(0);
+
+      smoother.stop();
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe('createSmoother — runtime prefers-reduced-motion flips (MOR-1233 fix cycle 1, F1/F2)', () => {
+  it('KILL F1: stops the live rAF loop and snaps to target when reduced motion turns ON mid-session', () => {
+    const { setMatches, restore } = mockReducedMotion(false);
+    const rafSpy = vi.spyOn(window, 'requestAnimationFrame').mockImplementation(() => 1);
+    const cafSpy = vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {});
+    try {
+      const smoother = createSmoother(0.12, 0.32, 0);
+      smoother.update(50);
+      smoother.start();
+      expect(rafSpy).toHaveBeenCalledTimes(1);
+
+      // OS preference flips to "reduce" while the loop is already live.
+      setMatches(true);
+
+      expect(smoother.value).toBe(50); // snapped immediately
+      expect(cafSpy).toHaveBeenCalled(); // the live loop was stopped
+
+      rafSpy.mockClear();
+      smoother.update(80); // further updates keep snapping, no new frame
+      expect(smoother.value).toBe(80);
+      expect(rafSpy).not.toHaveBeenCalled();
+
+      smoother.stop();
+    } finally {
+      restore();
+    }
+  });
+
+  it('KILL F2: resumes the rAF loop and stops instant-snapping when reduced motion turns OFF mid-session', () => {
+    const { setMatches, restore } = mockReducedMotion(true);
+    const rafSpy = vi.spyOn(window, 'requestAnimationFrame').mockImplementation(() => 1);
+    try {
+      const smoother = createSmoother(0.12, 0.32, 0);
+      smoother.update(50);
+      smoother.start();
+      expect(smoother.value).toBe(50); // snapped at mount (reduce was ON)
+      expect(rafSpy).not.toHaveBeenCalled(); // no loop yet
+
+      // OS preference clears while mounted.
+      setMatches(false);
+      expect(rafSpy).toHaveBeenCalledTimes(1); // the loop resumed
+
+      rafSpy.mockClear();
+      smoother.update(90);
+      // A currently-snapped meter must animate again, not instant-snap: the
+      // value stays at the pre-flip 50 (the mocked rAF never actually fires
+      // the tick callback here), proving update() no longer force-snaps.
+      expect(smoother.value).toBe(50);
+
+      smoother.stop();
+    } finally {
+      restore();
+    }
+  });
+
+  it('detaches the reduced-motion change listener on stop() — no leak', () => {
+    const { listenerCount, restore } = mockReducedMotion(false);
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation(() => 1);
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {});
+    try {
+      const smoother = createSmoother(0.12, 0.32, 0);
+      smoother.update(10);
+      smoother.start();
+      expect(listenerCount()).toBeGreaterThan(0);
+
+      smoother.stop();
+      expect(listenerCount()).toBe(0);
+    } finally {
+      restore();
+    }
+  });
+});

--- a/frontend/src/lib/utils/smoothing.svelte.ts
+++ b/frontend/src/lib/utils/smoothing.svelte.ts
@@ -1,32 +1,92 @@
 /**
+ * MOR-1233: live (uncached) prefers-reduced-motion check. Shared by the
+ * ballistics loop below and by rAF-driven peak-hold consumers (e.g.
+ * LinearSMeter) so both respect the same signal without duplicating the
+ * matchMedia guard.
+ */
+export function prefersReducedMotion(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  );
+}
+
+/**
+ * MOR-1233 fix cycle 1 (verifier F1/F2): the preference can change while a
+ * loop is already live — reading it once at mount is not enough. Subscribes
+ * to the OS `change` event and returns an unsubscribe function; callers MUST
+ * invoke it on teardown (no leak). No-op subscription when matchMedia is
+ * unavailable.
+ */
+export function onReducedMotionChange(callback: (reduced: boolean) => void): () => void {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return () => {};
+  }
+  const mql = window.matchMedia('(prefers-reduced-motion: reduce)');
+  const handler = () => callback(mql.matches);
+  mql.addEventListener('change', handler);
+  return () => mql.removeEventListener('change', handler);
+}
+
+/**
  * Exponential smoothing for meter values.
  * React useSmoothedValue → Svelte $state + rAF loop.
+ *
+ * MOR-1233: under `prefers-reduced-motion`, ballistics are disabled — the
+ * value snaps directly to target instead of animating, and no rAF loop is
+ * scheduled. Fix cycle 1: the loop also reacts to the preference changing
+ * mid-session in both directions (start()/stop() alone only decide at
+ * mount).
  */
 export function createSmoother(attack = 0.12, release = 0.32, initialValue = 0) {
   let current = $state(initialValue);
   let target = 0;
   let frameId = 0;
   let lastTime = 0;
+  let unsubscribe: (() => void) | null = null;
 
   function update(newTarget: number) {
     target = newTarget;
+    if (prefersReducedMotion()) {
+      current = newTarget;
+    }
+  }
+
+  function tick(now: number) {
+    const dt = Math.min(0.05, (now - lastTime) / 1000);
+    lastTime = now;
+
+    const tau = target >= current ? attack : release;
+    const alpha = 1 - Math.exp(-dt / tau);
+    current += (target - current) * alpha;
+
+    frameId = requestAnimationFrame(tick);
+  }
+
+  function loop() {
+    lastTime = performance.now();
+    frameId = requestAnimationFrame(tick);
   }
 
   function start() {
-    lastTime = performance.now();
+    if (prefersReducedMotion()) {
+      current = target;
+    } else {
+      loop();
+    }
 
-    const tick = (now: number) => {
-      const dt = Math.min(0.05, (now - lastTime) / 1000);
-      lastTime = now;
-
-      const tau = target >= current ? attack : release;
-      const alpha = 1 - Math.exp(-dt / tau);
-      current += (target - current) * alpha;
-
-      frameId = requestAnimationFrame(tick);
-    };
-
-    frameId = requestAnimationFrame(tick);
+    unsubscribe = onReducedMotionChange((reduced) => {
+      if (reduced) {
+        if (frameId) {
+          cancelAnimationFrame(frameId);
+          frameId = 0;
+        }
+        current = target;
+      } else if (!frameId) {
+        loop();
+      }
+    });
   }
 
   function stop() {
@@ -34,6 +94,8 @@ export function createSmoother(attack = 0.12, release = 0.32, initialValue = 0) 
       cancelAnimationFrame(frameId);
       frameId = 0;
     }
+    unsubscribe?.();
+    unsubscribe = null;
   }
 
   return {


### PR DESCRIPTION
Closes MOR-1233 (formal blocker of the MOR-1087 a11y evidence gate).

## What

Both rAF-driven motion sources — the shared ballistics loop in `smoothing.svelte.ts` and `LinearSMeter`'s independent peak-hold loop — now honor `prefers-reduced-motion`: values snap (still update — no frozen meters) and no animation frame is scheduled. A shared `onReducedMotionChange()` subscription reacts to runtime OS preference flips in both directions (reduce ON → live loops stop, pending frame cancelled, values snap; reduce OFF → smoothing resumes). `tokens.css` gains a minimal `prefers-contrast` / `forced-colors` token-layer strategy scoped to never override an explicit manual theme choice.

**70 net production LOC** (frozen formula, guard ≤200), 3 production files, 15 tests.

## Provenance

- Independent adversarial verification (opus), round 1: **BLOCKED** — the reduced-motion decision was latched at mount: an OS preference flip mid-session froze every smoothed meter permanently (or left loops scheduling frames forever on the mirror flip).
- Fix cycle 1: bidirectional matchMedia subscription; re-verified by the same verifier with its own harness (double-flip on→off→on→off, flip-while-frame-pending cancels the exact pending id, listener counts return to 0, jsdom matchMedia absence fails safe): **PASS**. 7/9 of the verifier's own mutants killed; the 2 survivors (per-loop assertion blindness) were killed in a test-only pin round with production files proven sha256-identical.
- Scope ruling: MetersDockPanel's `setInterval` peak-hold, SVG forced-colors, and the dead `--focus-ring` token are out of this ticket's wording — filed as MOR-1249 (High, blocks MOR-1087), MOR-1250, and covered by MOR-1232 respectively; smoothing hardening trio filed as MOR-1251; peak-indicator design decision as MOR-1252.
- Cross-checked conflict-free in both directions against the concurrent MOR-1232 `tokens.css` edit (no landing-order dependency).

Local full-suite failing-file set identical to baseline (10 files, environmental Node-26 `localStorage`; CI is the gate). lint / svelte-check / tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)