### PR TITLE
refactor(MOR-1247): scope layout-manifest sizing to the instrument stage (sizing -> stageSizing)

### DIFF
--- a/docs/plans/2026-07-25-ui-composition-architecture-v3.md
+++ b/docs/plans/2026-07-25-ui-composition-architecture-v3.md
@@ -178,6 +178,25 @@ Resolution order:
 6. provide semantic view models and product services;
 7. render safety/status overlays outside the selected layout.
 
+### Stage sizing (MOR-1160)
+
+[MOR-1160](https://linear.app/morozsm/issue/MOR-1160/decision-freeze-the-surface-sizing-model-fluid-vs-fixed-native-uniform)
+(frozen 2026-07-29) fixes the surface sizing model: a layout's instrument
+stage is either `fluid` (reflows on declared breakpoints) or `fixed-native`
+(scaled as one uniform, letterboxed block by `min(w/nativeW, h/nativeH)`,
+falling back below `minScale`). Chrome — nav, control columns, sidebars,
+anything that is not the instrument glass — is fluid by doctrine and is
+never swept into the stage's fixed scale (constraint 2). It renders as a
+sibling of the future `ScaledStage` primitive, which will own mechanical
+enforcement of this split (constraint 1).
+
+A layout manifest's sizing field is scoped to this instrument-stage axis, not
+the whole layout —
+[MOR-1247](https://linear.app/morozsm/issue/MOR-1247/scope-layout-manifest-sizing-to-the-instrument-stage-rename-sizing)
+renamed it `stageSizing` to say so and froze it declaration-only (an
+architecture test flags any direct textual read outside
+`presentation/layouts/`) until `ScaledStage` exists to enforce it.
+
 ## Dependency and product invariants
 
 1. Runtime imports no adapters or presentation.

--- a/frontend/src/presentation/layouts/__tests__/fixtures.ts
+++ b/frontend/src/presentation/layouts/__tests__/fixtures.ts
@@ -11,7 +11,7 @@ export function validLayoutManifest(overrides: Partial<LayoutManifest> = {}): La
     zones: [{ id: 'main', surfaces: ['vfo', 'rxTx'] }],
     compatibleTopologies: ['1/single'],
     requiredSemanticSurfaces: ['vfo', 'rxTx'],
-    sizing: { mode: 'fluid', responsiveBreakpoints: [] },
+    stageSizing: { mode: 'fluid', responsiveBreakpoints: [] },
     fallbackLayoutId: null,
     ...overrides,
   };

--- a/frontend/src/presentation/layouts/__tests__/lcd-registration.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/lcd-registration.test.ts
@@ -87,7 +87,7 @@ describe('MOR-1160 sizing axis — the LCD is the fixed-native archetype', () =>
   // Kills: leaving the LCD on `fluid`, or drifting off the native stage size
   // MOR-1160 froze for the incoming LCD directions (1280x540).
   it.each(LCD_LAYOUTS)('"%s" declares the frozen fixed-native stage', (_id, manifest) => {
-    expect(manifest.sizing).toEqual({
+    expect(manifest.stageSizing).toEqual({
       mode: 'fixed-native', nativeW: 1280, nativeH: 540, minScale: 0.5,
     });
   });

--- a/frontend/src/presentation/layouts/__tests__/manifest-shape.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/manifest-shape.test.ts
@@ -88,12 +88,12 @@ describe('compatible topology classes', () => {
 
 describe('sizing (MOR-1160)', () => {
   it('accepts fluid sizing with breakpoints', () => {
-    const manifest = validLayoutManifest({ sizing: { mode: 'fluid', responsiveBreakpoints: [600, 900] } });
+    const manifest = validLayoutManifest({ stageSizing: { mode: 'fluid', responsiveBreakpoints: [600, 900] } });
     expect(() => validateLayoutManifest(manifest)).not.toThrow();
   });
 
   it('accepts fixed-native sizing with a positive minScale', () => {
-    const manifest = validLayoutManifest({ sizing: { mode: 'fixed-native', nativeW: 1280, nativeH: 540, minScale: 0.5 } });
+    const manifest = validLayoutManifest({ stageSizing: { mode: 'fixed-native', nativeW: 1280, nativeH: 540, minScale: 0.5 } });
     expect(() => validateLayoutManifest(manifest)).not.toThrow();
   });
 
@@ -103,11 +103,11 @@ describe('sizing (MOR-1160)', () => {
     const poisoned = {
       mode: 'fixed-native', nativeW: 1280, nativeH: 540, minScale: 0.5, responsiveBreakpoints: [600],
     } as unknown as SizingPolicy;
-    expect(() => validateLayoutManifest(validLayoutManifest({ sizing: poisoned }))).toThrow(/mutually exclusive/);
+    expect(() => validateLayoutManifest(validLayoutManifest({ stageSizing: poisoned }))).toThrow(/mutually exclusive/);
   });
 
   it('rejects a non-positive minScale', () => {
-    const manifest = validLayoutManifest({ sizing: { mode: 'fixed-native', nativeW: 1280, nativeH: 540, minScale: 0 } });
+    const manifest = validLayoutManifest({ stageSizing: { mode: 'fixed-native', nativeW: 1280, nativeH: 540, minScale: 0 } });
     expect(() => validateLayoutManifest(manifest)).toThrow(/positive finite/);
   });
 });
@@ -181,7 +181,7 @@ describe('exact-key discipline pins (MOR-1072 N1 lesson, review cycle 1 F2)', ()
       zones = [{ id: 'main', surfaces: ['vfo', 'rxTx'] as const }];
       compatibleTopologies = ['1/single'] as const;
       requiredSemanticSurfaces = ['vfo', 'rxTx'] as const;
-      sizing = { mode: 'fluid' as const, responsiveBreakpoints: [] as number[] };
+      stageSizing = { mode: 'fluid' as const, responsiveBreakpoints: [] as number[] };
       fallbackLayoutId = null;
       // Prototype getter: an own-keys/Object.keys walk of the instance never
       // sees this — only the explicit prototype check catches it.

--- a/frontend/src/presentation/layouts/__tests__/mobile-registration.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/mobile-registration.test.ts
@@ -86,7 +86,7 @@ describe('MOR-1160 sizing axis — mobile is the fluid side', () => {
   // an instrument stage scaled as one letterboxed block, and a native stage
   // here would make the phone shell fail its own minScale gate.
   it('declares fluid sizing with the one breakpoint the layout implements', () => {
-    expect(mobileLayout.sizing).toEqual({ mode: 'fluid', responsiveBreakpoints: [500] });
+    expect(mobileLayout.stageSizing).toEqual({ mode: 'fluid', responsiveBreakpoints: [500] });
   });
 
   // Kills: flipping mobile to a mode with a viewport gate. `fluid` always
@@ -144,7 +144,7 @@ describe('portrait-mobile exclusion of fixed-native layouts, and the hop off it'
       zones: [{ id: 'main', surfaces: ['vfo', 'rxTx'] }],
       compatibleTopologies: ['1/single'],
       requiredSemanticSurfaces: ['vfo', 'rxTx'],
-      sizing: { mode: 'fixed-native', nativeW: 1280, nativeH: 540, minScale: 0.5 },
+      stageSizing: { mode: 'fixed-native', nativeW: 1280, nativeH: 540, minScale: 0.5 },
       fallbackLayoutId: 'mobile',
     };
     registerLayout(probe);

--- a/frontend/src/presentation/layouts/__tests__/registry.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/registry.test.ts
@@ -130,11 +130,11 @@ describe('fallback re-validation (review cycle 1, F1)', () => {
   // portrait-mobile exclusion for the fallback layout itself.
   it('a fixed-native fallback that itself fails minScale resolves to undefined, not the fallback', () => {
     registerLayout(validLayoutManifest({
-      id: 'f1-vp-fallback', sizing: { mode: 'fixed-native', nativeW: 1280, nativeH: 540, minScale: 0.5 },
+      id: 'f1-vp-fallback', stageSizing: { mode: 'fixed-native', nativeW: 1280, nativeH: 540, minScale: 0.5 },
     }));
     registerLayout(validLayoutManifest({
       id: 'f1-vp-primary',
-      sizing: { mode: 'fixed-native', nativeW: 1280, nativeH: 540, minScale: 0.5 },
+      stageSizing: { mode: 'fixed-native', nativeW: 1280, nativeH: 540, minScale: 0.5 },
       fallbackLayoutId: 'f1-vp-fallback',
     }));
     // Same tiny viewport fails minScale for both primary and fallback.
@@ -146,7 +146,7 @@ describe('fallback re-validation (review cycle 1, F1)', () => {
 describe('viewport resolution (MOR-1160 sizing)', () => {
   it('a fixed-native layout resolves when the achievable scale meets minScale', () => {
     registerLayout(validLayoutManifest({
-      id: 'fixed-fit-test', sizing: { mode: 'fixed-native', nativeW: 1280, nativeH: 540, minScale: 0.5 },
+      id: 'fixed-fit-test', stageSizing: { mode: 'fixed-native', nativeW: 1280, nativeH: 540, minScale: 0.5 },
     }));
     expect(resolveLayoutForViewport('fixed-fit-test', { width: 1280, height: 540 })?.id).toBe('fixed-fit-test');
   });
@@ -155,11 +155,11 @@ describe('viewport resolution (MOR-1160 sizing)', () => {
   // minScale for a fixed-native layout (the MOR-1066 comment's explicit ask).
   it('falls back below minScale — portrait mobile is excluded arithmetically, no special-cased branch', () => {
     registerLayout(validLayoutManifest({
-      id: 'fixed-portrait-fallback', sizing: { mode: 'fluid', responsiveBreakpoints: [] },
+      id: 'fixed-portrait-fallback', stageSizing: { mode: 'fluid', responsiveBreakpoints: [] },
     }));
     registerLayout(validLayoutManifest({
       id: 'fixed-portrait-primary',
-      sizing: { mode: 'fixed-native', nativeW: 1280, nativeH: 540, minScale: 0.5 },
+      stageSizing: { mode: 'fixed-native', nativeW: 1280, nativeH: 540, minScale: 0.5 },
       fallbackLayoutId: 'fixed-portrait-fallback',
     }));
     // iPhone-class portrait viewport: min(390/1280, 844/540) ≈ 0.30 < 0.5.
@@ -169,7 +169,7 @@ describe('viewport resolution (MOR-1160 sizing)', () => {
 
   it('a fluid layout always fits — breakpoints are reflow hints, not a hard gate', () => {
     registerLayout(validLayoutManifest({
-      id: 'fluid-always-fits', sizing: { mode: 'fluid', responsiveBreakpoints: [600] },
+      id: 'fluid-always-fits', stageSizing: { mode: 'fluid', responsiveBreakpoints: [600] },
     }));
     expect(resolveLayoutForViewport('fluid-always-fits', { width: 100, height: 100 })?.id).toBe('fluid-always-fits');
   });

--- a/frontend/src/presentation/layouts/__tests__/sdr-registration.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/sdr-registration.test.ts
@@ -85,7 +85,7 @@ describe('MOR-1160 sizing axis — sdr-test stays fluid', () => {
   // family owns — sdr-test is a reflowing desktop layout, not a native-scaled
   // instrument glass.
   it('declares fluid sizing with no breakpoints', () => {
-    expect(sdrTestLayout.sizing).toEqual({ mode: 'fluid', responsiveBreakpoints: [] });
+    expect(sdrTestLayout.stageSizing).toEqual({ mode: 'fluid', responsiveBreakpoints: [] });
   });
 
   it('resolves on both a desktop and an iPhone-class portrait viewport — fluid never gates', () => {

--- a/frontend/src/presentation/layouts/__tests__/stage-sizing-boundary.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/stage-sizing-boundary.test.ts
@@ -1,0 +1,54 @@
+/**
+ * MOR-1247 guard: `stageSizing` (the manifest field) and `fitsViewport` (the
+ * function that reads it) are frozen declaration-only until the ScaledStage
+ * primitive (MOR-1160 constraint 1) exists to mechanically enforce the
+ * policy.
+ *
+ * This is a TEXTUAL TRIPWIRE, not a security boundary — it catches a file
+ * outside this directory whose source contains the literal identifier
+ * `stageSizing` or `fitsViewport`, which is what an ordinary import/read
+ * looks like. Known, accepted evasions: computed-key access (building the
+ * property/import name from concatenated substrings so the literal
+ * identifier never appears contiguously in source), and an aliased
+ * re-export from inside `layouts/` (e.g. `export { fitsViewport as
+ * checkFit } from './contract'` here, consumed externally as `checkFit` —
+ * the external file's source never contains the literal name either). Both
+ * take deliberate effort to construct; this scan's job is to catch the
+ * ordinary case, not to withstand someone trying to route around it.
+ *
+ * This is NOT expressible as an eslint import-boundary rule (the
+ * `../../../__tests__/architecture-boundaries.test.ts` pattern): both names
+ * are legitimate exports of `../contract` that other files in THIS directory
+ * use freely, and eslint's `no-restricted-imports` bans a module specifier,
+ * not a named read from an otherwise-legal import. Proof that the scan
+ * catches an ordinary violation (temporary violation -> red -> reverted ->
+ * green, sha256-verified) is recorded in the MOR-1247 build report, not
+ * committed here.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+
+const SRC_ROOT = 'src';
+const LAYOUTS_DIR = path.join(SRC_ROOT, 'presentation', 'layouts') + path.sep;
+const SOURCE_EXTENSIONS = new Set(['.ts', '.svelte']);
+const GUARDED_NAMES = [/\bstageSizing\b/, /\bfitsViewport\b/];
+
+function collectSourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...collectSourceFiles(full));
+    else if (SOURCE_EXTENSIONS.has(path.extname(entry.name))) out.push(full);
+  }
+  return out;
+}
+
+describe('stageSizing/fitsViewport stay declaration-only outside layouts/ (MOR-1247)', () => {
+  it('no file outside presentation/layouts/ names stageSizing or fitsViewport', () => {
+    const offenders = collectSourceFiles(SRC_ROOT)
+      .filter((file) => !file.startsWith(LAYOUTS_DIR))
+      .filter((file) => GUARDED_NAMES.some((re) => re.test(readFileSync(file, 'utf8'))));
+    expect(offenders).toEqual([]);
+  });
+});

--- a/frontend/src/presentation/layouts/contract.ts
+++ b/frontend/src/presentation/layouts/contract.ts
@@ -3,7 +3,7 @@
  * (MOR-1066) — the other side of the design-language handshake in
  * `../languages/contract.ts` (`./compatibility.ts` composes the two).
  * Declares identity, zones mounting semantic surfaces, compatible radio
- * topologies, the MOR-1160 sizing axis, and a safe fallback — never
+ * topologies, the MOR-1160 stage-sizing axis, and a safe fallback — never
  * executable radio behavior, capability objects, or component module paths
  * (v3 ADR "Composition contract"; MOR-988/983 doctrine). Lint-enforced
  * presentation/ zone (MOR-1061) bans runtime/capability/transport/command
@@ -36,7 +36,8 @@ export interface LayoutZone {
  * `min(w/nativeW, h/nativeH)`, letterboxed, falling back below `minScale`.
  * Structurally exclusive at the type level (`FixedNativeSizing` has no
  * `responsiveBreakpoints` slot); the runtime validator enforces the same
- * exclusion against untyped input.
+ * exclusion against untyped input. See `LayoutManifest.stageSizing` below for
+ * what this policy is scoped to.
  */
 export interface FluidSizing {
   readonly mode: 'fluid';
@@ -58,13 +59,23 @@ export interface LayoutManifest {
   readonly zones: readonly LayoutZone[];
   readonly compatibleTopologies: readonly TopologyClass[];
   readonly requiredSemanticSurfaces: readonly SemanticSurfaceName[];
-  readonly sizing: SizingPolicy;
+  /**
+   * The INSTRUMENT STAGE's sizing policy (MOR-1160/1247) — not the whole
+   * layout. Chrome (nav, control columns, sidebars — anything that is not
+   * the instrument glass) is fluid by doctrine and renders as a sibling of
+   * the future `ScaledStage` primitive, which owns the stage's mechanical
+   * enforcement of this policy (MOR-1160 constraint 1); until that primitive
+   * exists this field stays declaration-only (guard test: `__tests__/
+   * stage-sizing-boundary.test.ts`). A `fixed-native` value here does NOT
+   * mean the whole layout is fixed-native — only its instrument stage is.
+   */
+  readonly stageSizing: SizingPolicy;
   readonly fallbackLayoutId: string | null;
 }
 
 const TOP_LEVEL_KEYS: readonly PropertyKey[] = [
   'schemaVersion', 'id', 'displayName', 'loader', 'zones',
-  'compatibleTopologies', 'requiredSemanticSurfaces', 'sizing', 'fallbackLayoutId',
+  'compatibleTopologies', 'requiredSemanticSurfaces', 'stageSizing', 'fallbackLayoutId',
 ];
 
 export class LayoutValidationError extends Error {}
@@ -117,22 +128,22 @@ function validateSizing(id: string, sizing: SizingPolicy): string | null {
     if (!hasExactPlainKeys(sizing, ['mode', 'responsiveBreakpoints'])
       || !Array.isArray(sizing.responsiveBreakpoints)
       || !sizing.responsiveBreakpoints.every((b) => typeof b === 'number')) {
-      return `Layout "${id}" fluid sizing must declare only mode/responsiveBreakpoints (number array).`;
+      return `Layout "${id}" fluid stageSizing must declare only mode/responsiveBreakpoints (number array).`;
     }
     return null;
   }
   if (sizing.mode === 'fixed-native') {
     if (!hasExactPlainKeys(sizing, ['mode', 'nativeW', 'nativeH', 'minScale'])) {
-      return `Layout "${id}" fixed-native sizing must declare only mode/nativeW/nativeH/minScale — ` +
+      return `Layout "${id}" fixed-native stageSizing must declare only mode/nativeW/nativeH/minScale — ` +
         'no responsiveBreakpoints (MOR-1160: the two are mutually exclusive).';
     }
     const { nativeW, nativeH, minScale } = sizing;
     if (![nativeW, nativeH, minScale].every((n) => typeof n === 'number' && Number.isFinite(n) && n > 0)) {
-      return `Layout "${id}" fixed-native sizing requires positive finite nativeW/nativeH/minScale.`;
+      return `Layout "${id}" fixed-native stageSizing requires positive finite nativeW/nativeH/minScale.`;
     }
     return null;
   }
-  return `Layout "${id}" sizing.mode must be 'fluid' | 'fixed-native'.`;
+  return `Layout "${id}" stageSizing.mode must be 'fluid' | 'fixed-native'.`;
 }
 
 function validateZones(id: string, zones: readonly LayoutZone[]): string | null {
@@ -181,7 +192,7 @@ export function validateLayoutManifest(manifest: LayoutManifest): void {
       `Layout "${id}" must declare at least one required semantic surface.`) ||
     (manifest.requiredSemanticSurfaces.some((s) => !manifest.zones.some((z) => z.surfaces.includes(s))) &&
       `Layout "${id}" requires a semantic surface that no zone mounts.`) ||
-    validateSizing(id, manifest.sizing) ||
+    validateSizing(id, manifest.stageSizing) ||
     (manifest.fallbackLayoutId !== null && !isValidProductId(manifest.fallbackLayoutId) &&
       `Layout "${id}" fallbackLayoutId "${manifest.fallbackLayoutId}" fails naming policy.`);
   if (problem) throw new LayoutValidationError(problem);
@@ -250,8 +261,8 @@ export interface Viewport { readonly width: number; readonly height: number }
  *  mobile viewport fails this arithmetically (small height vs. a wide
  *  native design), with no separate mobile-detection branch. */
 export function fitsViewport(manifest: LayoutManifest, viewport: Viewport): boolean {
-  if (manifest.sizing.mode === 'fluid') return true;
-  const { nativeW, nativeH, minScale } = manifest.sizing;
+  if (manifest.stageSizing.mode === 'fluid') return true;
+  const { nativeW, nativeH, minScale } = manifest.stageSizing;
   return Math.min(viewport.width / nativeW, viewport.height / nativeH) >= minScale;
 }
 

--- a/frontend/src/presentation/layouts/declarations.ts
+++ b/frontend/src/presentation/layouts/declarations.ts
@@ -21,7 +21,7 @@ export const sdrTestLayout: LayoutManifest = {
   zones: [{ id: 'main', surfaces: ['vfo', 'rxTx'] }],
   compatibleTopologies: ['1/single', '1/ab', '2/ab_shared', '2/main_sub'],
   requiredSemanticSurfaces: ['vfo', 'rxTx'],
-  sizing: { mode: 'fluid', responsiveBreakpoints: [] },
+  stageSizing: { mode: 'fluid', responsiveBreakpoints: [] },
   fallbackLayoutId: null,
 };
 

--- a/frontend/src/presentation/layouts/dual-receiver-cockpit.ts
+++ b/frontend/src/presentation/layouts/dual-receiver-cockpit.ts
@@ -9,7 +9,7 @@
  * classes: a single-receiver radio has nothing to put in a second strip, so
  * this layout must not mount for one — `fallbackLayoutId` sends it to the
  * already-registered, all-topology `sdr-test` layout instead (MOR-976
- * "degrades safely" acceptance). `sizing: fluid` encodes the MOR-1160
+ * "degrades safely" acceptance). `stageSizing: fluid` encodes the MOR-1160
  * chrome-fluid half of the sizing axis: this shell composes only VFO/RX-TX
  * status text today (no fixed-native instrument glass yet), so it always
  * fits, at any viewport.
@@ -28,7 +28,7 @@ export const dualReceiverCockpitLayout: LayoutManifest = {
   ],
   compatibleTopologies: ['2/ab_shared', '2/main_sub'],
   requiredSemanticSurfaces: ['vfo', 'rxTx'],
-  sizing: { mode: 'fluid', responsiveBreakpoints: [] },
+  stageSizing: { mode: 'fluid', responsiveBreakpoints: [] },
   fallbackLayoutId: 'sdr-test',
 };
 

--- a/frontend/src/presentation/layouts/lcd-declarations.ts
+++ b/frontend/src/presentation/layouts/lcd-declarations.ts
@@ -7,7 +7,7 @@
  * without three tickets editing the same declaration block.
  *
  * A manifest is a DECLARATION, never behaviour. `loader` names the existing
- * skin entrypoint with no change to it; `sizing` records the assignment
+ * skin entrypoint with no change to it; `stageSizing` records the assignment
  * MOR-1160 froze without implementing it — the shared ScaledStage primitive
  * owns measurement and the transform (MOR-1160 constraint 1), never a layout.
  */
@@ -30,6 +30,10 @@ const LCD_NATIVE_STAGE = {
  * hand control column, where `SemanticRadioSurfaces` now owns the VFO facts
  * and the RX/TX action. The amber glass itself declares no zone: it stays
  * legacy presentation for this slice and is redesigned by MOR-1162.
+ *
+ * `control-column` is CHROME, not the instrument stage: MOR-1162 is what
+ * declares the glass. It sits outside `stageSizing` below (MOR-1160/1247) —
+ * chrome stays fluid by doctrine regardless of this manifest's stage mode.
  */
 const LCD_ZONES = [{ id: 'control-column', surfaces: ['vfo', 'rxTx'] }] as const;
 
@@ -49,7 +53,7 @@ export const lcdCockpitLayout: LayoutManifest = {
   zones: LCD_ZONES,
   compatibleTopologies: LCD_TOPOLOGIES,
   requiredSemanticSurfaces: ['vfo', 'rxTx'],
-  sizing: LCD_NATIVE_STAGE,
+  stageSizing: LCD_NATIVE_STAGE,
   // The family's universal variant — nothing left to fall back to.
   fallbackLayoutId: null,
 };
@@ -69,7 +73,7 @@ export const lcdScopeLayout: LayoutManifest = {
   zones: LCD_ZONES,
   compatibleTopologies: LCD_TOPOLOGIES,
   requiredSemanticSurfaces: ['vfo', 'rxTx'],
-  sizing: LCD_NATIVE_STAGE,
+  stageSizing: LCD_NATIVE_STAGE,
   fallbackLayoutId: 'lcd-cockpit',
 };
 

--- a/frontend/src/presentation/layouts/mobile-declarations.ts
+++ b/frontend/src/presentation/layouts/mobile-declarations.ts
@@ -6,9 +6,10 @@
  * family, alongside `./lcd-declarations.ts` (MOR-1092).
  *
  * A manifest is a DECLARATION, never behaviour. `loader` names the existing
- * skin entrypoint with no change to it, and `sizing` records the assignment
- * MOR-1160 froze without implementing it — the shared ScaledStage primitive
- * owns measurement and the transform (MOR-1160 constraint 1), never a layout.
+ * skin entrypoint with no change to it, and `stageSizing` records the
+ * assignment MOR-1160 froze without implementing it — the shared ScaledStage
+ * primitive owns measurement and the transform (MOR-1160 constraint 1), never
+ * a layout.
  * In particular this manifest does NOT take over the shell's own orientation
  * handling: `isLandscape` still drives which PTT surface is mounted, and that
  * is live safety behaviour, not a sizing declaration.
@@ -54,7 +55,7 @@ export const mobileLayout: LayoutManifest = {
   // single- and dual-receiver topologies are both structurally supported.
   compatibleTopologies: ['1/single', '1/ab', '2/ab_shared', '2/main_sub'],
   requiredSemanticSurfaces: ['vfo', 'rxTx'],
-  sizing: MOBILE_FLUID_SIZING,
+  stageSizing: MOBILE_FLUID_SIZING,
   // Terminal by construction: a fluid layout never fails a viewport, so a hop
   // off mobile would be unreachable and would only mask a real failure.
   fallbackLayoutId: null,


### PR DESCRIPTION
Closes MOR-1247. Implements the owner decision (option b+d of the sizing-sweep brief, recorded on MOR-1247/MOR-1160): one `stageSizing` policy per manifest, scoped to the layout's instrument stage; chrome is fluid by doctrine as a sibling of the future ScaledStage; a declaration-only guard test freezes the field until ScaledStage lands.

## What

- Identifier rename `sizing` → `stageSizing` across `presentation/layouts/contract.ts` and all five registered manifests (sdr-test, lcd-cockpit, lcd-scope, mobile, dual-receiver-cockpit) — **0 net production LOC** (+14/−14 incl. validator error strings), zero manifest value changes.
- Docstring + LCD `control-column` chrome note + MOR-1160 sizing-model subsection in the v3 plan doc (previously unrecorded there).
- Architecture guard test: no module outside `presentation/layouts/` reads `stageSizing`/`fitsViewport` (an honest textual tripwire — known evasions documented in the test).

## Provenance

- Independent adversarial verification (opus): **PASS** — rename-only proven stronger than asked (comment-stripped, identifier-reverted head is byte-identical to base for all five production files); guard bite proven with the verifier's own .ts/.svelte/type-only violations; full-suite failing-FILE set identical to an untouched-main baseline.
- Delta 1 (validator error strings, guard docstring honesty, plan-doc constraint numbering) applied and CONFIRMED by the same verifier: the four error strings are the only production change since the PASS; kill-proofs unaffected.

lint clean, check 4350/0/0, build OK, layouts suite 8 files/107 tests green. Local full-suite failing-file set identical to baseline (environmental Node-26 `localStorage`; CI is the gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)