### PR TITLE
fix(MOR-1249): honor prefers-reduced-motion in MetersDockPanel interval peak decay

### DIFF
--- a/frontend/src/components-v2/panels/MetersDockPanel.svelte
+++ b/frontend/src/components-v2/panels/MetersDockPanel.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount, untrack } from 'svelte';
-  import { createSmoother } from '$lib/utils/smoothing.svelte';
+  import { createSmoother, onReducedMotionChange, prefersReducedMotion } from '$lib/utils/smoothing.svelte';
   import {
     alcLevel,
     compLevel,
@@ -124,10 +124,75 @@
   // A 100ms interval drives both the decay and the latch from fresh
   // prop samples. Driving everything off a timer (not a reactive $effect)
   // avoids the read-then-write cycle on `peaks` that Svelte 5 flags.
+  //
+  // MOR-1249: mirrors the MOR-1233 fix already shipped for LinearSMeter's
+  // own rAF peak-hold loop — under `prefers-reduced-motion` there is no
+  // hold-then-decay animation, so the interval is not scheduled at all (no
+  // ticks) and any already-latched peak is cleared. With `peaks[key]`
+  // undefined, `heldRaw()` (peakHoldDisplay with state=undefined) falls
+  // through to the live raw sample every render, so the NUMBER and the bar
+  // FILL track raw input with zero glide — matching "snap, never freeze".
+  //
+  // Clearing the latch also stops the peak MARKER from rendering while
+  // reduced, because its render gate is `peaks[tile.key] !== undefined`
+  // (latch existence) — unlike LinearSMeter's `showPeak = peakSegs -
+  // smoother.value > 0.3` (a value comparison). That means the marker's
+  // disappearance here is a deliberate choice, mirroring the removal
+  // MOR-1233 already shipped for LinearSMeter, not an unavoidable
+  // consequence of the snap fix itself — a gate keyed on `tile.fillPct`
+  // instead of latch existence could keep the marker visible at the live
+  // position with the identical zero-glide motion profile. Provisional
+  // pending the MOR-1252 owner decision (which now explicitly names
+  // MetersDockPanel alongside LinearSMeter) on whether peak indicators
+  // should render at all, or hold statically, under reduced motion.
+  //
+  // Reacts to the OS preference flipping mid-session in both directions
+  // (fix cycle 1 precedent: deciding once at mount is not enough).
   $effect(() => {
-    untrack(() => stepAllPeaks());
-    const id = setInterval(() => untrack(() => stepAllPeaks()), 100);
-    return () => clearInterval(id);
+    let intervalId: ReturnType<typeof setInterval> | null = null;
+
+    function startTicking() {
+      if (intervalId) return;
+      intervalId = setInterval(() => untrack(() => stepAllPeaks()), 100);
+    }
+
+    function stopTicking() {
+      if (intervalId) {
+        clearInterval(intervalId);
+        intervalId = null;
+      }
+    }
+
+    function snapPeaks() {
+      untrack(() => {
+        if (peaks.po !== undefined) peaks.po = undefined;
+        if (peaks.swr !== undefined) peaks.swr = undefined;
+        if (peaks.alc !== undefined) peaks.alc = undefined;
+        if (peaks.id !== undefined) peaks.id = undefined;
+      });
+    }
+
+    if (prefersReducedMotion()) {
+      snapPeaks();
+    } else {
+      untrack(() => stepAllPeaks());
+      startTicking();
+    }
+
+    const unsubscribe = onReducedMotionChange((reduced) => {
+      if (reduced) {
+        stopTicking();
+        snapPeaks();
+      } else if (!intervalId) {
+        untrack(() => stepAllPeaks());
+        startTicking();
+      }
+    });
+
+    return () => {
+      stopTicking();
+      unsubscribe();
+    };
   });
 
   function resetPeak(key: PeakKey) {

--- a/frontend/src/components-v2/panels/__tests__/MetersDockPanel.reduced-motion.svelte.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/MetersDockPanel.reduced-motion.svelte.test.ts
@@ -1,0 +1,276 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount, unmount, flushSync } from 'svelte';
+import MetersDockPanel from '../MetersDockPanel.svelte';
+
+// MOR-1249: MetersDockPanel's setInterval-driven peak-hold decay (the
+// Po/SWR/ALC/Id peak markers, PEAK_DECAY_MS) previously ran unconditionally,
+// ignoring `prefers-reduced-motion`. After MOR-1233 snapped the bar-fill
+// smoother, this left the panel internally inconsistent: the bar snapped
+// while the peak marker glided. These tests pin the fix, mirroring the
+// MOR-1233 precedent already shipped for LinearSMeter's own rAF peak-hold
+// loop: under reduced motion the decay interval is not scheduled at all (no
+// ticks), any already-latched peak snaps to the live raw value (never
+// freezes at a stale position), and the preference is honored on RUNTIME
+// flips in both directions.
+//
+// The MatchMediaMock + mockReducedMotion() helper is duplicated from
+// smoothing.svelte.test.ts / LinearSMeter.reduced-motion.svelte.test.ts,
+// matching the established per-file convention in this codebase (no shared
+// test util) — this is test-only code, not production LOC.
+
+vi.mock('$lib/stores/capabilities.svelte', () => ({
+  hasTx: vi.fn(() => true),
+}));
+vi.mock('$lib/runtime/adapters/capabilities-adapter', () => ({
+  getMeterCalibration: vi.fn(() => null),
+  getMeterRedline: vi.fn(() => null),
+}));
+
+interface MatchMediaMock {
+  mql: MediaQueryList;
+  setMatches: (matches: boolean) => void;
+  listenerCount: () => number;
+}
+
+function createMatchMediaMock(initialMatches: boolean): MatchMediaMock {
+  let matches = initialMatches;
+  const listeners = new Set<() => void>();
+  const mql = {
+    get matches() { return matches; },
+    addEventListener: (_type: string, fn: () => void) => { listeners.add(fn); },
+    removeEventListener: (_type: string, fn: () => void) => { listeners.delete(fn); },
+  } as unknown as MediaQueryList;
+  return {
+    mql,
+    setMatches: (next: boolean) => {
+      matches = next;
+      listeners.forEach((fn) => fn());
+    },
+    listenerCount: () => listeners.size,
+  };
+}
+
+function mockReducedMotion(matches: boolean) {
+  const original = window.matchMedia;
+  const { mql, setMatches, listenerCount } = createMatchMediaMock(matches);
+  window.matchMedia = vi.fn().mockReturnValue(mql) as unknown as typeof window.matchMedia;
+  return {
+    setMatches,
+    listenerCount,
+    restore: () => { window.matchMedia = original; },
+  };
+}
+
+let components: ReturnType<typeof mount>[] = [];
+let roots: HTMLElement[] = [];
+let setIntervalSpy: ReturnType<typeof vi.spyOn>;
+let clearIntervalSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  components = [];
+  roots = [];
+  vi.useFakeTimers();
+  // Anchor wall-clock time; stepAllPeaks() reads Date.now() for latch/decay.
+  vi.setSystemTime(0);
+  // Vitest's fake timers also fake requestAnimationFrame, and the panel's
+  // (MOR-1233-covered, unrelated) per-tile bar-fill smoother schedules an
+  // rAF frame of its own on mount whenever reduced motion is off — which
+  // would pollute a global `vi.getTimerCount()` read. Spying directly on
+  // setInterval/clearInterval (call-through, so fake-timer scheduling still
+  // works) isolates the assertions to the ONE thing this fix owns: the
+  // peak-decay interval's lifecycle.
+  setIntervalSpy = vi.spyOn(window, 'setInterval');
+  clearIntervalSpy = vi.spyOn(window, 'clearInterval');
+});
+
+afterEach(() => {
+  components.forEach((c) => unmount(c));
+  roots.forEach((r) => r.remove());
+  components = [];
+  roots = [];
+  vi.useRealTimers();
+});
+
+// Net live intervals created by MetersDockPanel's own code: every
+// setInterval call in this component is paired 1:1 with a guarded
+// clearInterval call (see startTicking/stopTicking), so this difference is
+// exactly 0 or 1 — never more, per the interval-lifecycle requirement.
+function netActiveIntervals(): number {
+  return setIntervalSpy.mock.calls.length - clearIntervalSpy.mock.calls.length;
+}
+
+// A $state props proxy so prop mutations re-render the mounted component.
+function mountReactive(props: Record<string, unknown>) {
+  const state = $state(props);
+  const t = document.createElement('div');
+  document.body.appendChild(t);
+  roots.push(t);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const component = mount(MetersDockPanel as any, { target: t, props: state });
+  flushSync();
+  components.push(component);
+  return { t, state, component };
+}
+
+function poNumber(t: HTMLElement): number {
+  return parseInt(t.querySelector('[data-meter="po"] .tile-value')?.textContent ?? '0', 10);
+}
+
+function peakMarkerCount(t: HTMLElement): number {
+  return t.querySelectorAll('[data-testid="peak-marker"]').length;
+}
+
+describe('MetersDockPanel — prefers-reduced-motion (MOR-1249)', () => {
+  it('schedules no decay interval when reduced motion is preferred at mount', () => {
+    const { restore } = mockReducedMotion(true);
+    try {
+      mountReactive({ powerMeter: 212, txActive: true });
+      expect(setIntervalSpy).not.toHaveBeenCalled();
+      expect(netActiveIntervals()).toBe(0);
+    } finally {
+      restore();
+    }
+  });
+
+  it('still schedules the decay interval when reduced motion is NOT preferred (baseline)', () => {
+    const { restore } = mockReducedMotion(false);
+    try {
+      mountReactive({ powerMeter: 212, txActive: true });
+      expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+      expect(netActiveIntervals()).toBe(1);
+    } finally {
+      restore();
+    }
+  });
+
+  it('snaps the Po NUMBER directly to the live raw sample when reduced motion is preferred (no glide)', () => {
+    const { restore } = mockReducedMotion(true);
+    try {
+      // raw 212 -> 100W; raw 5 -> ~2W (see MetersDockPanel.peakhold test).
+      const { t, state } = mountReactive({ powerMeter: 212, txActive: true });
+      expect(poNumber(t)).toBe(100);
+
+      // A drop must be reflected IMMEDIATELY (no held peak decaying toward
+      // it over PEAK_DECAY_MS) — proving there is no gliding animation, and
+      // proving it without advancing any timers (none are scheduled).
+      state.powerMeter = 5;
+      flushSync();
+      expect(poNumber(t)).toBeLessThan(10);
+    } finally {
+      restore();
+    }
+  });
+
+  // Removal semantics — provisional pending MOR-1252: the marker is gated
+  // on latch existence (`peaks[tile.key] !== undefined`), not on a value
+  // comparison, so its disappearance here is a deliberate implementation
+  // choice (mirroring LinearSMeter's shipped removal), not an unavoidable
+  // consequence of the snap fix. This test pins the CURRENT behavior; it
+  // is expected to change if MOR-1252 rules for a static/visible hold
+  // instead of removal.
+  it('renders no peak marker under reduced motion (removal semantics — provisional pending MOR-1252)', () => {
+    const { restore } = mockReducedMotion(true);
+    try {
+      const { t } = mountReactive({ powerMeter: 212, txActive: true });
+      expect(peakMarkerCount(t)).toBe(0);
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe('MetersDockPanel — runtime prefers-reduced-motion flips (MOR-1249, mirrors MOR-1233 F1/F2)', () => {
+  it('KILL F1: stops the live decay interval and snaps the peak to current when reduced motion turns ON mid-session', () => {
+    const { setMatches, restore } = mockReducedMotion(false);
+    try {
+      const { t, state } = mountReactive({ powerMeter: 212, txActive: true });
+      // Latch a peak, then let it partially decay so the marker is live.
+      vi.advanceTimersByTime(100);
+      flushSync();
+      expect(poNumber(t)).toBe(100);
+      expect(netActiveIntervals()).toBe(1);
+
+      // OS preference flips to "reduce" while the decay interval is live.
+      setMatches(true);
+      expect(netActiveIntervals()).toBe(0); // the interval was torn down
+
+      // Drop the raw signal; without any timer advancing, the number must
+      // reflect the live trough immediately — proving the held peak was
+      // cleared (snapped), not merely paused mid-decay (frozen).
+      state.powerMeter = 5;
+      flushSync();
+      expect(poNumber(t)).toBeLessThan(10);
+
+      // Further time passing schedules nothing new.
+      vi.advanceTimersByTime(5000);
+      expect(netActiveIntervals()).toBe(0);
+    } finally {
+      restore();
+    }
+  });
+
+  it('KILL F2: resumes the live decay interval and peak-hold behavior when reduced motion turns OFF mid-session', () => {
+    const { setMatches, restore } = mockReducedMotion(true);
+    try {
+      const { t, state } = mountReactive({ powerMeter: 212, txActive: true });
+      expect(poNumber(t)).toBe(100); // snapped at mount (reduce was ON)
+      expect(netActiveIntervals()).toBe(0); // no interval yet
+
+      // OS preference clears while mounted — the interval must resume and
+      // a fresh peak must latch (re-seated from the current live value).
+      setMatches(false);
+      expect(netActiveIntervals()).toBe(1);
+
+      // Drop the raw signal shortly after the flip and advance one tick:
+      // with peak-hold active again, the NUMBER must hold near the peak
+      // rather than tracking the trough instantaneously.
+      state.powerMeter = 5;
+      vi.advanceTimersByTime(100);
+      flushSync();
+      expect(poNumber(t)).toBeGreaterThan(70);
+    } finally {
+      restore();
+    }
+  });
+
+  it('multiple flips leave exactly one or zero intervals scheduled, never more', () => {
+    const { setMatches, restore } = mockReducedMotion(false);
+    try {
+      mountReactive({ powerMeter: 212, txActive: true });
+      expect(netActiveIntervals()).toBe(1);
+
+      setMatches(true);
+      expect(netActiveIntervals()).toBe(0);
+      setMatches(true); // redundant flip — must stay idempotent
+      expect(netActiveIntervals()).toBe(0);
+
+      setMatches(false);
+      expect(netActiveIntervals()).toBe(1);
+      setMatches(false); // redundant flip — must not create a second interval
+      expect(netActiveIntervals()).toBe(1);
+
+      setMatches(true);
+      expect(netActiveIntervals()).toBe(0);
+      setMatches(false);
+      expect(netActiveIntervals()).toBe(1);
+    } finally {
+      restore();
+    }
+  });
+
+  it('detaches the reduced-motion change listener and clears the interval on unmount — no leak', () => {
+    const { listenerCount, restore } = mockReducedMotion(false);
+    try {
+      const { component } = mountReactive({ powerMeter: 212, txActive: true });
+      expect(listenerCount()).toBeGreaterThan(0);
+      expect(netActiveIntervals()).toBe(1);
+
+      unmount(component);
+      components = components.filter((c) => c !== component);
+      expect(listenerCount()).toBe(0);
+      expect(netActiveIntervals()).toBe(0);
+    } finally {
+      restore();
+    }
+  });
+});


### PR DESCRIPTION
Closes MOR-1249 (formal blocker of the MOR-1087 a11y evidence gate — the last live motion source in the meters dock under reduced motion).

## What

`MetersDockPanel.svelte`'s `setInterval`-driven peak decay now honors `prefers-reduced-motion`, mirroring the merged MOR-1233 semantics: no interval while reduced, latched peaks snap to the live raw value (never freeze), both-direction runtime flips via the shared `onReducedMotionChange()` helper (`smoothing.svelte.ts` sha-identical to main — reused, not touched). **35 net production LOC** (frozen formula), 1 production file, 8 tests.

## Provenance

- Independent adversarial verification (opus — the same verifier that established and verified the MOR-1233 semantics): **PASS**, 5 findings (1 MEDIUM, 4 LOW), none blocking. Its own probes: snap-never-freeze end-to-end through the DOM (flip ON mid-interval + 10s fake time → live value, not a frozen peak); the original MOR-1233 freeze scenario adapted to the interval passes; interval count across a double flip is [1,0,1,0,1]; unmount-under-reduce + post-unmount flips leak nothing; MOR-1233's merged tests undisturbed.
- MEDIUM (G1) corrected in place pre-merge (comment/test-label only, diff proven comment-only): the marker's disappearance under reduce is a deliberate visibility choice (marker gates on latch existence, not value comparison — proven), provisional pending the MOR-1252 owner decision, which has been widened to name this panel.

Local full-suite failing-file set identical to baseline (10 files, environmental Node-26 `localStorage`; CI is the gate); lint/check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)