### PR TITLE
feat(MOR-1068): adapt the dual-receiver cockpit across all four topology pairs

### DIFF
--- a/frontend/src/__tests__/presentation-switch-resources.component.test.ts
+++ b/frontend/src/__tests__/presentation-switch-resources.component.test.ts
@@ -175,6 +175,9 @@ import { presentationResources, runtime } from '../lib/runtime/frontend-runtime'
  */
 const SKIN_PLAN: Record<SkinId, readonly AppResource[]> = {
   'desktop-v2': ['hardware-scope', 'audio-fft'],
+  // MOR-1068: the cockpit mounts the VFO/RX-TX surfaces only — no scope
+  // panel of either kind — so it demands nothing and bridges nothing.
+  'dual-receiver-cockpit': [],
   'lcd-cockpit': ['audio-fft'],
   'lcd-scope': ['audio-fft'],
   'mobile': ['hardware-scope'],
@@ -183,6 +186,7 @@ const SKIN_PLAN: Record<SkinId, readonly AppResource[]> = {
 
 const WIDTH_FOR: Record<SkinId, number> = {
   'desktop-v2': 1200,
+  'dual-receiver-cockpit': 1500,
   'lcd-cockpit': 1000,
   'lcd-scope': 900,
   'sdr-test': 1400,

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -22,6 +22,7 @@
 
 <script lang="ts">
   import { onDestroy } from 'svelte';
+  import { t } from '$lib/i18n';
   import { runtime } from '$lib/runtime';
   import { toRadioViewModel } from '$lib/runtime/adapters/radio-view-model-adapter';
   import { getAppTxController } from '$lib/runtime/tx-controller/app-host';
@@ -38,6 +39,15 @@
    * receiver channel strips (MOR-1067): still ONE shared RxTxSurface and
    * ONE TX lease below — ONLY the VFO half splits, so there is still exactly
    * one authoritative key/unkey action surface regardless of `strips`.
+   *
+   * MOR-1068: in `'dual'` the composed blocks carry `data-zone-id` values
+   * drawn from the `dual-receiver-cockpit` layout manifest's declared zones
+   * (`presentation/layouts/dual-receiver-cockpit.ts`). The manifest is the
+   * authority and is NOT imported here — importing it would close a cycle
+   * (manifest -> loader -> skin -> wiring) and let a wiring change register a
+   * layout. The two descriptions are held together by a test that reads the
+   * ids out of the real registry and requires exactly these in the rendered
+   * tree (MOR-1067 verification F6).
    */
   interface Props {
     strips?: 'single' | 'dual';
@@ -106,9 +116,16 @@
     {#if strips === 'dual'}
       <div class="channel-strips" data-testid="channel-strips">
         {#each receiversOf(view) as receiverId, index (receiverId)}
+          <!--
+            `data-zone-id`: `ReceiverId` is `'MAIN' | 'SUB'`, so the index is
+            total over the manifest's two per-receiver zones. A degraded
+            single-receiver view model renders `primary-vfo` and NO
+            `secondary-vfo` — an absent zone, never an empty promise.
+          -->
           <div
             class="channel-strip"
             data-testid={`channel-strip-${receiverId}`}
+            data-zone-id={index === 0 ? 'primary-vfo' : 'secondary-vfo'}
             data-strip-receiver={receiverId}
             data-strip-active={isActiveStrip(view, receiverId)}
           >
@@ -118,22 +135,40 @@
               without the pool the MOR-977 gate reads a 1-VFO slice as
               "structurally nothing to choose" and an `ab_shared` cockpit
               silently loses its only receiver-selection control.
-              `showRadioWideFacts`: split / dual-watch / active-receiver are
-              radio-wide, so exactly ONE strip renders them — the FIRST, a
-              position that depends on no observed fact, so the switches never
-              move when the active receiver changes. (Their eventual home is
-              the cockpit's global zone, once a semantic surface backs it.)
+              `showRadioWideFacts={false}`: split / dual-watch / active-receiver
+              are radio-wide and now live in the global zone below (MOR-1068);
+              a strip owns nothing but its own receiver.
+              `groupLabel`: without it all three mounted surfaces share one
+              generic accessible name and assistive tech cannot tell the
+              strips apart.
             -->
             <VfoSurface
               viewModel={forReceiver(view, receiverId)}
               selectionPoolSize={view.vfos.length}
-              showRadioWideFacts={index === 0}
+              showRadioWideFacts={false}
+              groupLabel={t('core.vfo.receiverGroupLabel', { receiver: receiverId })}
               onSelectVfo={selectVfo}
-              onToggleSplit={vfo.onSplitToggle}
-              onToggleDualWatch={toggleDualWatch}
             />
           </div>
         {/each}
+      </div>
+      <!--
+        The radio-wide row, rendered ONCE and outside every strip. It used to
+        ride in the first strip's column, which put "Active receiver: SUB"
+        inside the column without the active border (MOR-1067 verification
+        #4). Binding it to the ACTIVE strip instead is proven worse — a
+        verifier mutant made split/dual-watch vanish whenever `activeReceiver`
+        was unobserved. It is not `aria-disabled`: it holds live switches that
+        already gate themselves on their own observed facts (F7).
+      -->
+      <div class="cockpit-global-row" data-testid="cockpit-zone-global" data-zone-id="global">
+        <VfoSurface
+          viewModel={view}
+          showVfoList={false}
+          groupLabel={t('core.vfo.radioWideGroupLabel')}
+          onToggleSplit={vfo.onSplitToggle}
+          onToggleDualWatch={toggleDualWatch}
+        />
       </div>
     {:else}
       <VfoSurface
@@ -143,7 +178,11 @@
         onToggleDualWatch={toggleDualWatch}
       />
     {/if}
-    <RxTxSurface {view} tx={txState} onRequestKey={requestKey} onRequestUnkey={requestUnkey} />
+    <!-- `display: contents` — a naming wrapper only, so the single-strip
+         layout is unchanged and the shared TX surface stays one flex item. -->
+    <div class="rx-tx-zone" data-zone-id={strips === 'dual' ? 'rx-tx' : null}>
+      <RxTxSurface {view} tx={txState} onRequestKey={requestKey} onRequestUnkey={requestUnkey} />
+    </div>
   {/if}
 
   <!--
@@ -191,6 +230,9 @@
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
     gap: 8px;
+  }
+  .rx-tx-zone {
+    display: contents;
   }
   .channel-strip[data-strip-active='true'] {
     border-left: 2px solid var(--v2-accent-cyan, #00d4ff);

--- a/frontend/src/lib/i18n/locales/en-US.json
+++ b/frontend/src/lib/i18n/locales/en-US.json
@@ -170,6 +170,8 @@
   "core.modePanel.modInputAria": "Modulation input source",
 
   "core.vfo.groupLabel": "VFOs",
+  "core.vfo.receiverGroupLabel": "Receiver {receiver}",
+  "core.vfo.radioWideGroupLabel": "Radio-wide controls",
   "core.vfo.activeReceiver.known": "Active receiver: {receiver}",
   "core.vfo.activeReceiver.unknown": "Active receiver: unknown",
   "core.vfo.selectAction": "Select {label}",

--- a/frontend/src/lib/i18n/locales/ja-JP.json
+++ b/frontend/src/lib/i18n/locales/ja-JP.json
@@ -170,6 +170,8 @@
   "core.modePanel.modInputAria": "変調入力ソース",
 
   "core.vfo.groupLabel": "VFO",
+  "core.vfo.receiverGroupLabel": "受信機 {receiver}",
+  "core.vfo.radioWideGroupLabel": "無線機全体の操作",
   "core.vfo.activeReceiver.known": "アクティブな受信機: {receiver}",
   "core.vfo.activeReceiver.unknown": "アクティブな受信機: 不明",
   "core.vfo.selectAction": "{label} を選択",

--- a/frontend/src/lib/i18n/locales/ru-RU.json
+++ b/frontend/src/lib/i18n/locales/ru-RU.json
@@ -170,6 +170,8 @@
   "core.modePanel.modInputAria": "Источник входной модуляции",
 
   "core.vfo.groupLabel": "VFO",
+  "core.vfo.receiverGroupLabel": "Приёмник {receiver}",
+  "core.vfo.radioWideGroupLabel": "Общие органы управления",
   "core.vfo.activeReceiver.known": "Активный приёмник: {receiver}",
   "core.vfo.activeReceiver.unknown": "Активный приёмник: неизвестно",
   "core.vfo.selectAction": "Выбрать {label}",

--- a/frontend/src/presentation/layouts/__tests__/cockpit-topology-adaptation.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/cockpit-topology-adaptation.test.ts
@@ -1,0 +1,137 @@
+/**
+ * MOR-1068 — the dual-receiver cockpit's ADAPTATION POLICY across all four
+ * canonical topology pairs, resolved through the REAL registry (MOR-1066),
+ * plus the two gaps the MOR-1067 adversarial verification handed to this
+ * ticket: F8 (SkinId reachability) and the fixture-level survival of
+ * `scope=false + audioFft=true` as operational audio-scope availability.
+ *
+ * The DOM half of the policy (what the shell actually renders, and the F6
+ * manifest-zone <-> DOM binding) lives in
+ * `skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts`
+ * — that tree needs the isolated jsdom pool; this file is pure.
+ *
+ * Each test's doc line names the mutation it exists to kill.
+ */
+import { readFileSync } from 'node:fs';
+import { describe, it, expect } from 'vitest';
+import {
+  getLayout, resolveLayoutForTopology, supportsTopology,
+  TOPOLOGY_CLASSES, type LayoutManifest, type TopologyClass,
+} from '../contract';
+// Barrel-only import, never '../dual-receiver-cockpit' — a direct manifest
+// import would fire `registerLayout` from this test file, masking a
+// `declarations.ts` that no longer wires the cockpit into the app, and under
+// the fast pool's `isolate: false` it would leak that registration into
+// sibling files (the MOR-1092 lesson, restated on MOR-1067).
+import {
+  dualReceiverCockpitLayout, lcdCockpitLayout, lcdScopeLayout, mobileLayout, sdrTestLayout,
+} from '../declarations';
+import { forReceiver, receiversOf } from '../../../components-v2/wiring/dual-receiver-strips';
+import { topologyFixtures, withAudioOnlyScope } from '../../../semantic/fixtures/topologies';
+
+/**
+ * The frozen policy table. Column 3 is what `compatibleTopologies` must say;
+ * column 2 is what a consumer asking for the cockpit ACTUALLY gets. The two
+ * single-receiver pairs degrade by resolution (one validated hop to the
+ * all-topology `sdr-test`), never by mounting a cockpit whose second strip
+ * has nothing to put in it.
+ */
+const POLICY: readonly (readonly [TopologyClass, string, boolean])[] = [
+  ['1/single', 'sdr-test', false],
+  ['1/ab', 'sdr-test', false],
+  ['2/ab_shared', 'dual-receiver-cockpit', true],
+  ['2/main_sub', 'dual-receiver-cockpit', true],
+];
+
+const FIXTURE_IDS = ['1/single', '1/ab', '2/ab_shared', '2/main_sub'] as const;
+
+describe('the four-pair adaptation policy, through the real registry', () => {
+  // Kills: widening compatibleTopologies to a single-receiver pair (the
+  // cockpit would then mount with an empty second strip), or narrowing it
+  // away from a dual pair (a real dual-receiver radio would silently lose
+  // the layout built for it — the MOR-1067 F1 mirror: live presenting as
+  // absent).
+  it.each(POLICY)('%s resolves to "%s" (declared-compatible: %s)', (topology, expectedId, mounts) => {
+    expect(supportsTopology(dualReceiverCockpitLayout, topology)).toBe(mounts);
+    expect(resolveLayoutForTopology('dual-receiver-cockpit', topology)?.id).toBe(expectedId);
+  });
+
+  // Kills: dropping `fallbackLayoutId`, or pointing it at a layout that does
+  // not itself cover the refused pairs — resolution would return undefined
+  // and a single-receiver radio would get NO layout at all.
+  it('leaves no canonical topology unresolvable', () => {
+    for (const topology of TOPOLOGY_CLASSES) {
+      expect(resolveLayoutForTopology('dual-receiver-cockpit', topology)).toBeDefined();
+    }
+  });
+
+  // Kills: a fallback that is decoration rather than policy. Whatever the
+  // cockpit refuses, the declared fallback must actually support.
+  it('the declared fallback covers exactly the pairs the cockpit refuses', () => {
+    const refused = TOPOLOGY_CLASSES.filter((t) => !supportsTopology(dualReceiverCockpitLayout, t));
+    expect(refused).toEqual(['1/single', '1/ab']);
+    expect(dualReceiverCockpitLayout.fallbackLayoutId).toBe('sdr-test');
+    for (const topology of refused) expect(supportsTopology(sdrTestLayout, topology)).toBe(true);
+  });
+});
+
+describe('degrade honesty: the strip slicing never invents a receiver', () => {
+  // Kills: hardcoding two strips. Read against all four approved fixtures,
+  // so a cockpit mounted on a degraded (single-receiver) view model gets one
+  // strip and no fabricated SUB — "no impossible receiver/VFO labels".
+  it.each(FIXTURE_IDS)('%s: yields exactly the receivers the fixture observes', (id) => {
+    const view = topologyFixtures[id];
+    const expectedCount = Number(id.split('/')[0]);
+    const receivers = receiversOf(view);
+    expect(receivers).toHaveLength(expectedCount);
+    expect(receivers.every((rx) => view.vfos.some((v) => v.receiver === rx))).toBe(true);
+    expect(expectedCount === 1 ? receivers : []).not.toContain('SUB');
+  });
+});
+
+describe('audio-only scope survives the cockpit slicing (scope=false + audioFft=true)', () => {
+  // Kills: `forReceiver` touching anything but `vfos` — the exact MOR-1067
+  // F1 mirror at fixture level. An operational audio-FFT scope must reach
+  // every strip's view model intact, never flattened to "no scope".
+  it.each(FIXTURE_IDS)('%s: every per-receiver slice keeps operational audio-FFT scope', (id) => {
+    const view = withAudioOnlyScope(topologyFixtures[id]);
+    for (const receiver of receiversOf(view)) {
+      expect(forReceiver(view, receiver).scope).toEqual({
+        hardwareScope: { structural: false, operational: false },
+        audioFftScope: { structural: true, operational: true },
+      });
+    }
+  });
+});
+
+// MOR-1067 verification F8: `skins/registry.ts` had no `dual-receiver-cockpit`
+// SkinId and no loader, so the cockpit was the only registered layout manifest
+// the App could not load. `lcd-registration.test.ts` pins the same rule for
+// `lcd-*` ids only; this generalizes it to every real manifest. Read as TEXT,
+// not imported: `skins/registry.ts` pulls in the layout preference store,
+// which touches `localStorage` at module scope.
+describe('F8 — every registered layout manifest names a loadable skin', () => {
+  const REAL_LAYOUTS: readonly LayoutManifest[] = [
+    sdrTestLayout, dualReceiverCockpitLayout, lcdCockpitLayout, lcdScopeLayout, mobileLayout,
+  ];
+  const source = readFileSync('src/skins/registry.ts', 'utf8');
+  const loadersStart = source.indexOf('const SKIN_LOADERS');
+  const loaderIds = [...source.slice(loadersStart, source.indexOf('};', loadersStart))
+    .matchAll(/'([a-z0-9-]+)':/g)].map((m) => m[1]);
+  const unionStart = source.indexOf('export type SkinId');
+  const skinIdUnion = source.slice(unionStart, source.indexOf(';', unionStart));
+
+  it.each(REAL_LAYOUTS.map((m) => [m.id, m] as const))(
+    '"%s" is registered and reachable as a SkinId with a loader', (id, manifest) => {
+      expect(getLayout(id)).toBe(manifest);
+      expect(skinIdUnion).toContain(`'${id}'`);
+      expect(loaderIds).toContain(id);
+    },
+  );
+
+  // Kills: closing F8 by deleting the manifest instead of adding the skin.
+  it('names the dual-receiver cockpit specifically (the F8 gap)', () => {
+    expect(loaderIds).toContain('dual-receiver-cockpit');
+    expect(skinIdUnion).toContain("'dual-receiver-cockpit'");
+  });
+});

--- a/frontend/src/presentation/layouts/__tests__/dual-receiver-cockpit.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/dual-receiver-cockpit.test.ts
@@ -21,10 +21,15 @@ describe('the dual-receiver-cockpit real registration', () => {
     expect(getLayout('dual-receiver-cockpit')).toBe(dualReceiverCockpitLayout);
   });
 
-  it('declares primary/secondary VFO zones and one shared RX/TX zone', () => {
+  // MOR-1068 added `global`: the radio-wide half of the `vfo` surface (split
+  // / dual-watch / active receiver) moved out of the first strip into its own
+  // zone. Declaration order is rendered order — the end-to-end binding is
+  // pinned in the shell's component test (MOR-1067 verification F6).
+  it('declares primary/secondary VFO zones, the global row, and one shared RX/TX zone', () => {
     expect(dualReceiverCockpitLayout.zones).toEqual([
       { id: 'primary-vfo', surfaces: ['vfo'] },
       { id: 'secondary-vfo', surfaces: ['vfo'] },
+      { id: 'global', surfaces: ['vfo'] },
       { id: 'rx-tx', surfaces: ['rxTx'] },
     ]);
     expect(dualReceiverCockpitLayout.requiredSemanticSurfaces).toEqual(['vfo', 'rxTx']);

--- a/frontend/src/presentation/layouts/dual-receiver-cockpit.ts
+++ b/frontend/src/presentation/layouts/dual-receiver-cockpit.ts
@@ -5,14 +5,28 @@
  * — `declarations.ts` carries only the one registration import — so this
  * and MOR-1092's LCD entrypoints never touch the same lines.
  *
- * `compatibleTopologies` deliberately excludes the two single-receiver
- * classes: a single-receiver radio has nothing to put in a second strip, so
- * this layout must not mount for one — `fallbackLayoutId` sends it to the
- * already-registered, all-topology `sdr-test` layout instead (MOR-976
- * "degrades safely" acceptance). `stageSizing: fluid` encodes the MOR-1160
- * chrome-fluid half of the sizing axis: this shell composes only VFO/RX-TX
- * status text today (no fixed-native instrument glass yet), so it always
- * fits, at any viewport.
+ * MOR-1068 — the frozen adaptation policy across the four canonical pairs
+ * (pinned in `__tests__/cockpit-topology-adaptation.test.ts`):
+ *
+ *   1/single, 1/ab  FALL BACK. `compatibleTopologies` excludes them, so
+ *                   `resolveLayoutForTopology` takes the one validated hop to
+ *                   the all-topology `sdr-test` (MOR-976 "degrades safely").
+ *                   A single-receiver radio has nothing to put in a second
+ *                   strip, and an empty column is a claim about the radio.
+ *   2/ab_shared     MOUNTS. One unslotted VFO per receiver; `selectionPoolSize`
+ *                   keeps the receiver-selection control present even though
+ *                   each per-receiver slice holds a single VFO.
+ *   2/main_sub      MOUNTS. Slotted A/B per receiver, two tiles per strip.
+ *
+ * DEGRADE is the third arm and belongs to the shell, not the declaration: a
+ * declared-compatible topology whose second receiver was never observed
+ * renders ONE strip and no `secondary-vfo` zone. Nothing fabricates a SUB
+ * (`receiversOf` reads `view.vfos`), the radio-wide row still renders exactly
+ * once, and the single TX authority is untouched in every arm.
+ *
+ * `stageSizing: fluid` encodes the MOR-1160 chrome-fluid half of the sizing
+ * axis: this shell composes only VFO/RX-TX status text today (no fixed-native
+ * instrument glass yet), so it always fits, at any viewport.
  */
 import { registerLayout, type LayoutManifest } from './contract';
 
@@ -21,9 +35,19 @@ export const dualReceiverCockpitLayout: LayoutManifest = {
   id: 'dual-receiver-cockpit',
   displayName: 'Dual Receiver Cockpit',
   loader: () => import('../../skins/dual-receiver-cockpit/DualReceiverCockpit.svelte'),
+  // Declaration order IS rendered order, pinned end to end against the
+  // mounted shell (MOR-1067 verification F6 — before this, not one id was
+  // shared with the DOM and nothing asserted the correspondence). `global`
+  // mounts the `vfo` surface's radio-wide half (split / dual-watch / active
+  // receiver), which belongs to no receiver's column. The shell's remaining
+  // `scope`/`controls` placeholders are deliberately NOT declared: a
+  // `LayoutZone` must mount at least one semantic surface and MOR-1062/1065
+  // ship none for them, so declaring them would claim a mount that cannot
+  // happen.
   zones: [
     { id: 'primary-vfo', surfaces: ['vfo'] },
     { id: 'secondary-vfo', surfaces: ['vfo'] },
+    { id: 'global', surfaces: ['vfo'] },
     { id: 'rx-tx', surfaces: ['rxTx'] },
   ],
   compatibleTopologies: ['2/ab_shared', '2/main_sub'],

--- a/frontend/src/semantic/VfoSurface.svelte
+++ b/frontend/src/semantic/VfoSurface.svelte
@@ -58,6 +58,22 @@
      * unsliced surface renders them exactly as before.
      */
     showRadioWideFacts?: boolean;
+    /**
+     * MOR-1068: the mirror of `showRadioWideFacts`. `false` renders the
+     * radio-wide half ALONE, so a layout can place that row outside the
+     * per-receiver strips (the dual-receiver cockpit's global zone) without
+     * repeating the VFO tiles the strips already show. Defaults to `true`:
+     * every unsliced caller renders exactly as before.
+     */
+    showVfoList?: boolean;
+    /**
+     * MOR-1068: accessible name for this surface's group. A cockpit mounts
+     * three of these at once (one per receiver strip + the radio-wide row);
+     * with one shared generic name assistive tech sees three identical
+     * groups and cannot tell which receiver it is in. Defaults to the
+     * generic catalog label, so single-surface callers are unchanged.
+     */
+    groupLabel?: string;
   }
 
   let {
@@ -67,6 +83,8 @@
     onToggleDualWatch,
     selectionPoolSize,
     showRadioWideFacts = true,
+    showVfoList = true,
+    groupLabel,
   }: Props = $props();
 
   function slotKey(slot: VfoSlot): string {
@@ -114,7 +132,7 @@
   }
 </script>
 
-<div class="vfo-surface" role="group" aria-label={t('core.vfo.groupLabel')} data-testid="vfo-surface">
+<div class="vfo-surface" role="group" aria-label={groupLabel ?? t('core.vfo.groupLabel')} data-testid="vfo-surface">
   {#if showRadioWideFacts}
     <p
       class="active-receiver"
@@ -129,6 +147,7 @@
     </p>
   {/if}
 
+  {#if showVfoList}
   <div class="vfo-list" data-testid="vfo-list">
     {#each viewModel.vfos as vfo, i (vfo.receiver + ':' + i)}
       {@const selectable = isSelectable(vfo)}
@@ -165,6 +184,7 @@
       </div>
     {/each}
   </div>
+  {/if}
 
   {#if showRadioWideFacts}
     <div class="fact-toggles">

--- a/frontend/src/semantic/__tests__/VfoSurface.test.ts
+++ b/frontend/src/semantic/__tests__/VfoSurface.test.ts
@@ -390,3 +390,84 @@ describe('accessibility basics', () => {
     expect(order).toEqual(['select:MAIN:B', 'select:SUB:A', 'select:SUB:B', 'split', 'dualWatch']);
   });
 });
+
+// ── MOR-1068: the three composition props a per-receiver cockpit needs ───────
+// `selectionPoolSize` and `showRadioWideFacts` shipped with MOR-1067;
+// `showVfoList` and `groupLabel` land with the radio-wide row's move out of
+// the strips. Every default path below must stay byte-identical for the
+// unsliced callers (sdr-test / LCD / mobile).
+
+describe('selectionPoolSize (MOR-1067) — the ?? vs || distinction', () => {
+  // MOR-1067 verification, gap (c): `??` -> `||` in the fallback survived
+  // mutation because every existing caller passes a positive pool. An
+  // EXPLICIT pool of 0 is the only value that separates them: `??` keeps 0
+  // (nothing to choose -> control ABSENT), `||` treats 0 as "unset" and
+  // silently falls back to the slice's own length, resurrecting the control.
+  it('an explicit pool size of 0 means "nothing to choose", not "unset"', () => {
+    const target = mountSurface({
+      viewModel: topologyFixtures['2/main_sub'],
+      selectionPoolSize: 0,
+    });
+    expect(target.querySelectorAll('[data-vfo-select]')).toHaveLength(0);
+    // Same model with no pool override still offers the controls, so the
+    // assertion above cannot pass for the trivial reason.
+    const unsliced = mountSurface({ viewModel: topologyFixtures['2/main_sub'] });
+    expect(unsliced.querySelectorAll('[data-vfo-select]').length).toBeGreaterThan(0);
+  });
+
+  it('a pool larger than the slice keeps the control present (MOR-1067 F1)', () => {
+    const sliced: RadioViewModel = {
+      ...topologyFixtures['2/ab_shared'],
+      vfos: topologyFixtures['2/ab_shared'].vfos.filter((v) => v.receiver === 'MAIN'),
+    };
+    expect(mountSurface({ viewModel: sliced }).querySelectorAll('[data-vfo-select]')).toHaveLength(0);
+    expect(
+      mountSurface({ viewModel: sliced, selectionPoolSize: 2 }).querySelectorAll('[data-vfo-select]'),
+    ).toHaveLength(1);
+  });
+});
+
+describe('showVfoList (MOR-1068) — the radio-wide half, placeable on its own', () => {
+  // Kills: ignoring the prop (the cockpit's global row would duplicate every
+  // VFO tile already rendered in the strips), or letting it also suppress the
+  // radio-wide facts (the row would render nothing at all).
+  it('false renders the radio-wide facts with no VFO list', () => {
+    const target = mountSurface({ viewModel: topologyFixtures['2/main_sub'], showVfoList: false });
+    expect(target.querySelectorAll('[data-vfo-tile]')).toHaveLength(0);
+    expect(target.querySelector('[data-testid="vfo-list"]')).toBeNull();
+    expect(target.querySelectorAll('[data-vfo-split]')).toHaveLength(1);
+    expect(target.querySelectorAll('[data-vfo-dual-watch]')).toHaveLength(1);
+    expect(target.querySelectorAll('[data-testid="vfo-active-receiver"]')).toHaveLength(1);
+  });
+
+  // Kills: defaulting the new prop to false — every unsliced caller would
+  // lose its VFO tiles.
+  it('defaults to true: the unsliced surface is unchanged', () => {
+    const target = mountSurface({ viewModel: topologyFixtures['2/main_sub'] });
+    expect(target.querySelectorAll('[data-vfo-tile]')).toHaveLength(4);
+    expect(target.querySelector('[data-testid="vfo-list"]')).not.toBeNull();
+  });
+});
+
+describe('groupLabel (MOR-1068) — distinct accessible names per mounted surface', () => {
+  // Kills: ignoring the prop. A cockpit mounts three of these surfaces at
+  // once (MAIN strip, SUB strip, radio-wide row); with one shared generic
+  // name assistive tech sees three identical groups and cannot tell which
+  // receiver it is in.
+  it('overrides the group accessible name when supplied', () => {
+    const target = mountSurface({
+      viewModel: topologyFixtures['2/main_sub'], groupLabel: 'Receiver SUB',
+    });
+    expect(target.querySelector('[data-testid="vfo-surface"]')?.getAttribute('aria-label'))
+      .toBe('Receiver SUB');
+  });
+
+  it('falls back to the generic catalog label when absent', () => {
+    const target = mountSurface({ viewModel: topologyFixtures['2/main_sub'] });
+    const label = target.querySelector('[data-testid="vfo-surface"]')?.getAttribute('aria-label');
+    expect(label).toBeTruthy();
+    expect(label).not.toBe('Receiver SUB');
+    // i18n coverage: never an unresolved catalog key.
+    expect(label).not.toContain('core.vfo.');
+  });
+});

--- a/frontend/src/skins/dual-receiver-cockpit/DualReceiverCockpit.svelte
+++ b/frontend/src/skins/dual-receiver-cockpit/DualReceiverCockpit.svelte
@@ -7,22 +7,32 @@
   components-v2/wiring/SemanticRadioSurfaces.svelte). No manufacturer
   conditionals, no runtime/store/command import here.
 
-  Scope, controls, and global are placed as inert structural zones. MOR-1062/
-  1065 ship only the vfo/rxTx semantic surfaces — nothing here may claim
-  those regions are live. Same two-level gating as the surfaces themselves
-  (MOR-977): present so the shell composes every named region, disabled
-  because no real surface backs them yet — never falsely active.
+  MOR-1068: the manifest's four declared zones — `primary-vfo`,
+  `secondary-vfo`, `global`, `rx-tx` — are realized by that one `strips="dual"`
+  composition, in declaration order, each tagged with its `data-zone-id`. They
+  cannot be split across separate mounts here: a second SemanticRadioSurfaces
+  would be a second TX lease source, and single TX authority is the layout's
+  hardest invariant.
+
+  Scope and controls remain inert structural zones. MOR-1062/1065 ship only
+  the vfo/rxTx semantic surfaces — nothing here may claim those regions are
+  live, and they declare no manifest zone for the same reason. Same two-level
+  gating as the surfaces themselves (MOR-977): present so the shell composes
+  every named region, disabled because no real surface backs them yet — never
+  falsely active. `global` left this list when the radio-wide row moved in:
+  a zone holding live switches gates at the widget, not with a container
+  marker (MOR-1067 verification F7).
 -->
 <script lang="ts">
   import SemanticRadioSurfaces from '../../components-v2/wiring/SemanticRadioSurfaces.svelte';
 </script>
 
 <div class="dual-receiver-cockpit" data-testid="dual-receiver-cockpit">
-  <div class="cockpit-receivers" data-testid="cockpit-zone-receivers">
+  <div class="cockpit-surfaces" data-testid="cockpit-surfaces">
     <SemanticRadioSurfaces strips="dual" />
   </div>
 
-  {#each ['scope', 'controls', 'global'] as zone (zone)}
+  {#each ['scope', 'controls'] as zone (zone)}
     <div
       class="cockpit-inert-zone"
       data-testid={`cockpit-zone-${zone}`}
@@ -35,7 +45,7 @@
 <style>
   .dual-receiver-cockpit {
     display: grid;
-    grid-template-rows: 1fr auto auto auto;
+    grid-template-rows: 1fr auto auto;
     gap: 8px;
     height: 100%;
   }

--- a/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
+++ b/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
@@ -63,6 +63,11 @@ vi.mock('../../../components-v2/wiring/command-bus', () => ({
 }));
 
 import DualReceiverCockpit from '../DualReceiverCockpit.svelte';
+// MOR-1068 F6: the manifest's declared zone ids, read through the app-wide
+// registration barrel (never '../../../presentation/layouts/
+// dual-receiver-cockpit' directly), so the DOM assertions below are checked
+// against what the app actually registers rather than a local copy.
+import { dualReceiverCockpitLayout } from '../../../presentation/layouts/declarations';
 
 type Snapshot = {
   phase: string; intent: string | null; guard: { leaseId: string } | null;
@@ -120,6 +125,34 @@ function mainSubStateUnknownActive(): ServerState {
 }
 const abSharedCaps = (): Capabilities => ({
   ...mainSubCaps(), vfoScheme: 'ab_shared',
+} as unknown as Capabilities);
+
+/**
+ * MOR-1068 degrade case: 1/single — ONE receiver, one unslotted VFO. The
+ * manifest refuses this topology, so resolution sends it to sdr-test
+ * (`presentation/layouts/__tests__/cockpit-topology-adaptation.test.ts`); the
+ * shell must nonetheless degrade honestly if it is mounted over a
+ * single-receiver view model — one strip, no fabricated SUB, and no
+ * `secondary-vfo` zone standing empty.
+ */
+function singleReceiverState(): ServerState {
+  const paths = ['active', 'split', 'dualWatch', 'txTarget',
+    'main.freqHz', 'main.mode', 'main.filter'];
+  return {
+    active: 'MAIN', split: false, dualWatch: false, ptt: false,
+    txTarget: { status: 'known', receiver: 'MAIN', slot: null, frequencyHz: 14195000 },
+    main: { freqHz: 14195000, mode: 'USB', filter: 1 },
+    fieldStatus: Object.fromEntries(paths.map((p) => [p, fresh])),
+  } as unknown as ServerState;
+}
+/** 1/single caps: no `dual_rx` tag, or the topology derivation contradicts itself. */
+const singleReceiverCaps = (): Capabilities => ({
+  ...mainSubCaps(), receivers: 1, vfoScheme: 'single', capabilities: ['audio', 'tx'],
+} as unknown as Capabilities);
+
+/** The ticket's operational audio-scope condition: scope=false + audioFft=true. */
+const audioOnlyScopeCaps = (): Capabilities => ({
+  ...mainSubCaps(), audioFftAvailable: true,
 } as unknown as Capabilities);
 
 let target: HTMLDivElement;
@@ -291,18 +324,235 @@ describe('exactly one authoritative TX action surface across both strips', () =>
   });
 });
 
-describe('scope/controls/global zones — placed, never falsely active', () => {
-  it('all three are present and structurally disabled', () => {
+describe('scope/controls zones — placed, never falsely active', () => {
+  // MOR-1068: `global` left this list — it now carries the real radio-wide
+  // row (see below), and MOR-1067's F7 note is explicit that `aria-disabled`
+  // may only stand while a zone is honest-by-emptiness. A zone holding live
+  // switches must gate at the widget, which the switches already do.
+  it('both are present, structurally disabled, and hold nothing interactive', () => {
     h.state = mainSubState('MAIN');
     h.caps = mainSubCaps();
     render();
 
-    for (const zone of ['scope', 'controls', 'global']) {
+    for (const zone of ['scope', 'controls']) {
       const el = q(`[data-testid="cockpit-zone-${zone}"]`)!;
       expect(el).not.toBeNull();
       expect(el.getAttribute('aria-disabled')).toBe('true');
       expect(el.dataset.zoneActive).toBe('false');
+      // "Unsupported surfaces never appear enabled": empty, so there is no
+      // widget for the marker to lie about.
+      expect(el.querySelectorAll('button, [role="switch"], input')).toHaveLength(0);
     }
+  });
+
+  // Kills: keeping `aria-disabled` on the global zone after real content
+  // landed in it — MOR-1067 F7. An `aria-disabled` container wrapping enabled
+  // switches is precisely the MOR-557 bug class inverted: a live control
+  // presenting as dead.
+  it('the global zone is NOT marked disabled once it carries the live row', () => {
+    h.state = mainSubState('MAIN');
+    h.caps = mainSubCaps();
+    render();
+
+    const global = q('[data-zone-id="global"]')!;
+    expect(global).not.toBeNull();
+    expect(global.getAttribute('aria-disabled')).toBeNull();
+    expect(global.dataset.zoneActive).not.toBe('false');
+  });
+});
+
+// MOR-1067 verification F6: the manifest declared `primary-vfo` /
+// `secondary-vfo` / `rx-tx` while the shell's DOM shared not one id with it,
+// and nothing asserted the correspondence. These tests read the zone ids out
+// of the REGISTERED manifest and require the rendered tree to expose exactly
+// those, in declaration order — the two descriptions can no longer drift.
+describe('F6 — manifest zone ids are bound to the rendered structure', () => {
+  const declaredZoneIds = (): readonly string[] => dualReceiverCockpitLayout.zones.map((z) => z.id);
+
+  it.each([
+    ['2/main_sub', () => mainSubState('MAIN'), mainSubCaps],
+    ['2/ab_shared', abSharedState, abSharedCaps],
+  ] as const)('%s: renders every declared zone, once, in declaration order', (
+    _topology, makeState, makeCaps,
+  ) => {
+    h.state = makeState();
+    h.caps = makeCaps();
+    render();
+
+    expect(qa('[data-zone-id]').map((el) => el.dataset.zoneId)).toEqual([...declaredZoneIds()]);
+  });
+
+  // Kills: a zone id invented in the DOM that no manifest zone declares (the
+  // drift direction that made the shell's five ad-hoc ids invisible to the
+  // registry). The inert placeholders are deliberately NOT manifest zones:
+  // `LayoutZone` requires at least one semantic surface and MOR-1062/1065
+  // ship none for scope/controls.
+  it('no rendered zone id is undeclared, and the placeholders claim none', () => {
+    h.state = mainSubState('MAIN');
+    h.caps = mainSubCaps();
+    render();
+
+    for (const el of qa('[data-zone-id]')) {
+      expect(declaredZoneIds()).toContain(el.dataset.zoneId);
+    }
+    for (const zone of ['scope', 'controls']) {
+      expect(q(`[data-testid="cockpit-zone-${zone}"]`)!.hasAttribute('data-zone-id')).toBe(false);
+    }
+  });
+
+  // Kills: binding zone ids to a fixed strip count. `primary-vfo` is the
+  // FIRST rendered strip whatever the topology; `secondary-vfo` exists only
+  // when a second receiver was actually observed.
+  it.each([
+    ['2/main_sub', () => mainSubState('MAIN'), mainSubCaps, 'MAIN', 'SUB'],
+    ['2/ab_shared', abSharedState, abSharedCaps, 'MAIN', 'SUB'],
+  ] as const)('%s: primary-vfo is the first strip, secondary-vfo the second', (
+    _topology, makeState, makeCaps, primary, secondary,
+  ) => {
+    h.state = makeState();
+    h.caps = makeCaps();
+    render();
+
+    expect(q('[data-zone-id="primary-vfo"]')!.dataset.stripReceiver).toBe(primary);
+    expect(q('[data-zone-id="secondary-vfo"]')!.dataset.stripReceiver).toBe(secondary);
+    // #5(b): strip ORDER, pinned. Kills a reversed/receiver-sorted render.
+    expect(qa('[data-testid^="channel-strip-"]').map((el) => el.dataset.stripReceiver))
+      .toEqual([primary, secondary]);
+  });
+});
+
+describe('degrading to a single-receiver view model', () => {
+  // "One compiled layout safely degrades across all pairs; no impossible
+  // receiver/VFO labels." Kills: a shell that renders a second, empty strip
+  // (or a fabricated SUB label) when only one receiver was observed.
+  it('renders one strip, no SUB anywhere, and no secondary-vfo zone', () => {
+    h.state = singleReceiverState();
+    h.caps = singleReceiverCaps();
+    render();
+
+    expect(qa('[data-testid^="channel-strip-"]')).toHaveLength(1);
+    expect(q('[data-zone-id="primary-vfo"]')!.dataset.stripReceiver).toBe('MAIN');
+    expect(q('[data-zone-id="secondary-vfo"]')).toBeNull();
+    expect(q('[data-testid="channel-strip-SUB"]')).toBeNull();
+    expect(target.textContent).not.toContain('SUB');
+  });
+
+  // Kills: degrading by dropping the radio-wide row or the TX authority with
+  // the second strip. Single TX authority is non-negotiable in EVERY topology.
+  it('keeps exactly one radio-wide row and exactly one TX action surface', () => {
+    h.state = singleReceiverState();
+    h.caps = singleReceiverCaps();
+    render();
+
+    expect(qa('[data-zone-id="global"]')).toHaveLength(1);
+    expect(qa('[data-vfo-split]')).toHaveLength(1);
+    expect(qa('[data-vfo-dual-watch]')).toHaveLength(1);
+    expect(qa('[data-testid="rx-tx-surface"]')).toHaveLength(1);
+    expect(qa('[data-testid="rx-tx-key"]')).toHaveLength(1);
+  });
+
+  // The declared zone set is a superset here, and that is the honest reading:
+  // a zone is rendered when its content exists, never as an empty promise.
+  it('renders a strict, declared subset of the manifest zones', () => {
+    h.state = singleReceiverState();
+    h.caps = singleReceiverCaps();
+    render();
+
+    const rendered = qa('[data-zone-id]').map((el) => el.dataset.zoneId);
+    expect(rendered).toEqual(['primary-vfo', 'global', 'rx-tx']);
+    for (const id of rendered) {
+      expect(dualReceiverCockpitLayout.zones.map((z) => z.id)).toContain(id);
+    }
+  });
+});
+
+describe('the radio-wide row lives in the cockpit\'s global zone', () => {
+  // MOR-1067 verification #4: the row used to sit inside the FIRST strip, so
+  // with SUB active "Active receiver: SUB" rendered in the column WITHOUT the
+  // active border. It is radio-wide, so it belongs to no receiver's column.
+  // #5(a): its PRESENCE is pinned here — deleting split/dual-watch fails.
+  it.each([
+    ['2/main_sub', () => mainSubState('SUB'), mainSubCaps],
+    ['2/ab_shared', abSharedState, abSharedCaps],
+  ] as const)('%s: split, dual-watch and active-receiver render once, outside every strip', (
+    _topology, makeState, makeCaps,
+  ) => {
+    h.state = makeState();
+    h.caps = makeCaps();
+    render();
+
+    const global = q('[data-zone-id="global"]')!;
+    for (const sel of ['[data-vfo-split]', '[data-vfo-dual-watch]', '[data-testid="vfo-active-receiver"]']) {
+      expect(qa(sel)).toHaveLength(1);
+      expect(global.contains(q(sel)!)).toBe(true);
+      // Kills: reintroducing the row inside a strip (the MOR-1067 placement).
+      expect(qa('[data-testid^="channel-strip-"]').some((s) => s.contains(q(sel)!))).toBe(false);
+    }
+    // The global row is facts only — the VFO tiles stay in the strips.
+    expect(global.querySelectorAll('[data-vfo-tile]')).toHaveLength(0);
+  });
+
+  // Kills: moving the row at the cost of its wiring — the switches must still
+  // reach the radio-wide handlers from their new home.
+  it('the relocated switches still reach the radio-wide handlers', () => {
+    h.state = mainSubState('SUB');
+    h.caps = mainSubCaps();
+    render();
+
+    q<HTMLButtonElement>('[data-vfo-split]')!.click();
+    q<HTMLButtonElement>('[data-vfo-dual-watch]')!.click();
+    flushSync();
+    expect(h.splitToggle).toHaveBeenCalledTimes(1);
+    expect(h.dualWatchToggle).toHaveBeenCalledTimes(1);
+  });
+
+  // #5(b): strip accessible NAMING. Three groups mount at once (two strips +
+  // the radio-wide row); with one shared generic name assistive tech cannot
+  // tell MAIN from SUB, and the ticket's "no impossible receiver/VFO labels"
+  // has no a11y half at all.
+  it('names each mounted surface distinctly for assistive tech', () => {
+    h.state = mainSubState('MAIN');
+    h.caps = mainSubCaps();
+    render();
+
+    const names = qa('[data-testid="vfo-surface"]').map((el) => el.getAttribute('aria-label'));
+    expect(names).toHaveLength(3);
+    expect(new Set(names).size).toBe(3);
+    expect(names.every((n) => (n?.length ?? 0) > 0)).toBe(true);
+    expect(names.every((n) => !n?.includes('core.vfo.'))).toBe(true);
+    const named = (receiver: string) =>
+      q(`[data-testid="channel-strip-${receiver}"] [data-testid="vfo-surface"]`)!
+        .getAttribute('aria-label');
+    expect(named('MAIN')).toContain('MAIN');
+    expect(named('SUB')).toContain('SUB');
+  });
+});
+
+describe('operational audio-scope availability (scope=false + audioFft=true)', () => {
+  // The ticket's fifth, orthogonal condition. The cockpit mounts no scope
+  // surface, so the honest behaviour is to make NO claim either way: the
+  // rendered tree must be identical with and without a live audio-FFT scope,
+  // and the inert scope placeholder must not turn into an "unavailable"
+  // verdict about a capability that IS available. Kills: gating any strip,
+  // switch or TX control on scope state.
+  /** The RX/TX surface's aria-describedby carries a per-instance counter. */
+  const markup = (): string => target.innerHTML.replace(/rx-tx-\d+/g, 'rx-tx-N');
+
+  it('changes nothing in the cockpit, and denies nothing about the radio', () => {
+    h.state = mainSubState('MAIN');
+    h.caps = mainSubCaps();
+    render();
+    const withoutAudioFft = markup();
+
+    if (component) unmount(component);
+    document.body.innerHTML = '';
+    h.state = mainSubState('MAIN');
+    h.caps = audioOnlyScopeCaps();
+    render();
+
+    expect(markup()).toBe(withoutAudioFft);
+    expect(qa('[data-testid="rx-tx-key"]')).toHaveLength(1);
+    expect(q('[data-testid="cockpit-zone-scope"]')!.textContent).toBe('');
   });
 });
 

--- a/frontend/src/skins/registry.ts
+++ b/frontend/src/skins/registry.ts
@@ -15,7 +15,8 @@ import {
   type LayoutMode,
 } from '$lib/stores/layout.svelte';
 
-export type SkinId = 'desktop-v2' | 'lcd-cockpit' | 'lcd-scope' | 'mobile' | 'sdr-test';
+export type SkinId =
+  | 'desktop-v2' | 'dual-receiver-cockpit' | 'lcd-cockpit' | 'lcd-scope' | 'mobile' | 'sdr-test';
 
 /**
  * Persisted skin IDs include the legacy `amber-lcd` alias, which routes to
@@ -65,6 +66,12 @@ export function resolveSkinId(ctx: SkinResolutionContext): SkinId {
  */
 const SKIN_LOADERS: Record<SkinId, () => Promise<{ default: Component }>> = {
   'desktop-v2': () => import('./desktop-v2/DesktopSkin.svelte'),
+  // MOR-1068 (F8): the cockpit's layout manifest registers under this exact
+  // id, so it needs the matching loadable SkinId — it was the only registered
+  // manifest the App had no way to load. `resolveSkinId` does not yet return
+  // it (that needs a `LayoutMode` preference and a picker affordance, tracked
+  // separately); the entry here is what makes the id addressable at all.
+  'dual-receiver-cockpit': () => import('./dual-receiver-cockpit/DualReceiverCockpit.svelte'),
   'lcd-cockpit': () => import('./lcd-cockpit/LcdCockpitSkin.svelte'),
   'lcd-scope': () => import('./lcd-scope/LcdScopeSkin.svelte'),
   'mobile': () => import('./mobile/MobileSkin.svelte'),
@@ -108,6 +115,11 @@ export async function loadSkin(id: SkinId): Promise<Component> {
  */
 const SKIN_RESOURCE_PLAN: Record<SkinId, readonly AppResource[]> = {
   'desktop-v2': ['hardware-scope', 'audio-fft'],
+  // Empty by construction: the cockpit mounts the VFO/RX-TX surfaces only —
+  // no SpectrumPanel, no AudioSpectrumPanel. Membership only permits
+  // bridging, so naming a resource this tree cannot consume would be a
+  // presentation manufacturing a live service (v3 ADR invariant 12).
+  'dual-receiver-cockpit': [],
   'lcd-cockpit': ['audio-fft'],
   'lcd-scope': ['audio-fft'],
   'mobile': ['hardware-scope'],


### PR DESCRIPTION
Closes MOR-1068.

## What

The four-pair topology contract for the reference cockpit: `1/single`/`1/ab` fall back to `sdr-test` through the real registry (one validated hop); `2/ab_shared`/`2/main_sub` mount; a single-receiver capability set renders one strip with the `secondary-vfo` zone absent. Structural-vs-observed doctrine holds: strips derive from `structuralReceivers` (pure capability function), so a dual radio whose SUB is not yet observed renders TWO strips with the SUB tile unknown-slotted and its selection control present-but-disabled (MOR-977 third option) — no transient false structural negative. Plus the inherited MOR-1067 obligations: F6 zone-id ↔ DOM binding (`data-zone-id`, order-checked), F8 SkinId/loader/resource-plan + the manifest-reachability rule generalized beyond lcd-*, the radio-wide row moved into a live `global` manifest zone, and the four test-gap pins.

**31 net production LOC** (frozen formula, guard ≤200), +40 tests (3153→3193).

## Provenance

- Independent adversarial verification (opus — the same verifier that BLOCKED and then passed MOR-1067, fully independent of this builder): **PASS**, all eight claims held under its own probes run before reading the build report. 12 mutations killed, zero survivors — 7 of the builder's re-run independently plus 5 of the verifier's own design (fabricated strips, swapped zone order, scope-gated global row, SkinId union drop, cockpit resource-plan claim).
- Degrade ruling: ABSENT is correct and the startup-window concern does not arise (probed directly with dual caps + undefined sub state → two strips, SUB present + disabled).
- Non-blocking findings routed: inert `.rx-tx-zone` wrapper (layout preserved via display:contents) → MOR-1069; `dual-rx-unavailable` rendering an enabled SUB strip is a pre-existing MOR-1062 adapter gap (`operationalReceivers` has zero consumers) → filed separately.
- VfoSurface default path re-proven byte-identical across all 9 view-model shapes; audio-scope invariance across four capability variants; the deferred App-level preference routing leaves no dead SkinId (build emits the cockpit chunk; lazy import resolves).

Local full-suite failing-file set identical to baseline (10 files, environmental Node-26 `localStorage`; CI is the gate); lint/check/i18n/build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)