### PR TITLE
feat(MOR-1069): responsive/mobile composition for the dual-receiver cockpit

### DIFF
--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -178,11 +178,31 @@
         onToggleDualWatch={toggleDualWatch}
       />
     {/if}
-    <!-- `display: contents` — a naming wrapper only, so the single-strip
-         layout is unchanged and the shared TX surface stays one flex item. -->
-    <div class="rx-tx-zone" data-zone-id={strips === 'dual' ? 'rx-tx' : null}>
+    <!--
+      MOR-1069 (finding N1, routed from the MOR-1068 verification). The
+      wrapper used to render on EVERY path as an inert `display: contents`
+      naming shell, which left the single/default path no longer
+      element-identical to its pre-cockpit shape. It is now rendered ONLY in
+      the dual composition, where it is a real, bound zone element the
+      cockpit's responsive rules can place — an inert wrapper cannot be a
+      grid/flex item, so "leave it inert" was not an option once the zone had
+      to move between arrangements. The single/default path (sdr-test / LCD /
+      mobile) renders the surface bare again, and that element shape is
+      re-pinned in `__tests__/semantic-rx-tx-wiring.component.test.ts`.
+
+      The snippet is deliberate: it keeps exactly ONE `<RxTxSurface>` tag in
+      this file, so single TX authority stays a property of the SOURCE rather
+      than of which branch happens to be taken. Pinned as such by
+      `presentation/layouts/__tests__/cockpit-responsive-composition.test.ts`.
+    -->
+    {#snippet rxTxSurface()}
       <RxTxSurface {view} tx={txState} onRequestKey={requestKey} onRequestUnkey={requestUnkey} />
-    </div>
+    {/snippet}
+    {#if strips === 'dual'}
+      <div class="rx-tx-zone" data-zone-id="rx-tx">{@render rxTxSurface()}</div>
+    {:else}
+      {@render rxTxSurface()}
+    {/if}
   {/if}
 
   <!--
@@ -231,9 +251,11 @@
     grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
     gap: 8px;
   }
-  .rx-tx-zone {
-    display: contents;
-  }
+  /* MOR-1069: no `display: contents` any more — the zone only exists in the
+     dual composition now, and it must be a real box there so the cockpit can
+     place it. It carries no presentation of its own; the surface inside owns
+     that. */
+
   .channel-strip[data-strip-active='true'] {
     border-left: 2px solid var(--v2-accent-cyan, #00d4ff);
     padding-left: 6px;

--- a/frontend/src/components-v2/wiring/__tests__/semantic-rx-tx-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rx-tx-wiring.component.test.ts
@@ -189,6 +189,28 @@ describe('the surfaces render from the live adapter output', () => {
     expect(target.querySelectorAll('[data-testid="vfo-surface"]')).toHaveLength(1);
   });
 
+  // MOR-1069, finding N1 (routed from the MOR-1068 verification). MOR-1068
+  // wrapped the RX/TX surface in an inert `display: contents` zone shell on
+  // EVERY path, so the single/default composition — the one sdr-test, the LCD
+  // layouts and MOBILE all mount — stopped being element-identical to its
+  // pre-cockpit shape. Layout was preserved, nothing queried the old position,
+  // and it was accepted as a trade-off; MOR-1069 collapses it back out, and
+  // this is the element-shape expectation re-pinned so it cannot drift back.
+  // MUTATION KILLED: reintroducing an always-on wrapper (or extending the
+  // cockpit's zone binding to the default path, which would put a zone id on
+  // a layout whose manifest never declared one).
+  it('mounts the RX/TX surface bare — no zone wrapper on the default path', () => {
+    render();
+    const root = q('[data-testid="semantic-radio-surfaces"]')!;
+    const surface = q('[data-testid="rx-tx-surface"]')!;
+    expect(surface.parentElement).toBe(root);
+    expect(root.querySelector('.rx-tx-zone')).toBeNull();
+    expect(target.querySelectorAll('[data-zone-id]')).toHaveLength(0);
+    // Still exactly one TX action surface — the branch must not duplicate it.
+    expect(target.querySelectorAll('[data-testid="rx-tx-surface"]')).toHaveLength(1);
+    expect(target.querySelectorAll('[data-testid="rx-tx-key"]')).toHaveLength(1);
+  });
+
   it('renders no surfaces at all rather than guessing when capabilities are absent', () => {
     h.caps = null;
     render();

--- a/frontend/src/presentation/layouts/__tests__/cockpit-responsive-composition.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/cockpit-responsive-composition.test.ts
@@ -1,0 +1,250 @@
+/**
+ * MOR-1069 — the dual-receiver cockpit's RESPONSIVE COMPOSITION policy, held
+ * against the two descriptions that must agree: the manifest's declared
+ * reflow breakpoints and the shell's actual media queries.
+ *
+ * Why source text and not a rendered assertion: jsdom does not evaluate media
+ * queries, so a mounted tree can say nothing about which arrangement a
+ * viewport gets. The established idiom for this in the codebase is a textual
+ * pin over the stylesheet (`components-v2/theme/__tests__/tokens-contrast.
+ * test.ts`, MOR-1233) and over a registry file that cannot be imported
+ * (`cockpit-topology-adaptation.test.ts` F8, MOR-1068). The DOM half of this
+ * ticket — element identity across an orientation change, focus order, the
+ * bound rx-tx zone — is a real mounted test in `skins/dual-receiver-cockpit/
+ * __tests__/DualReceiverCockpit.component.test.ts`.
+ *
+ * This file lives under `presentation/layouts/` deliberately: it is the only
+ * place allowed to name the frozen sizing field (MOR-1247 guard,
+ * `./stage-sizing-boundary.test.ts`), and the breakpoint agreement below has
+ * to read it. It declares only — nothing here consumes it to make a layout
+ * decision.
+ *
+ * Each test's doc line names the mutation it exists to kill.
+ */
+import { readFileSync } from 'node:fs';
+import { describe, it, expect } from 'vitest';
+// Barrel, never '../dual-receiver-cockpit' — a direct manifest import fires
+// `registerLayout` from this file and, under the fast pool's `isolate: false`,
+// leaks that registration into sibling files (the MOR-1092 lesson).
+import { dualReceiverCockpitLayout } from '../declarations';
+
+const SHELL_PATH = 'src/skins/dual-receiver-cockpit/DualReceiverCockpit.svelte';
+const WIRING_PATH = 'src/components-v2/wiring/SemanticRadioSurfaces.svelte';
+
+/** Comments are prose ABOUT the policy and must never satisfy a scan FOR it —
+ *  the shell's header comment names `matchMedia` and `transition` precisely
+ *  because it forbids them. */
+function withoutComments(source: string): string {
+  return source
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/^\s*\/\/.*$/gm, '');
+}
+
+const shellSource = withoutComments(readFileSync(SHELL_PATH, 'utf8'));
+const wiringSource = withoutComments(readFileSync(WIRING_PATH, 'utf8'));
+const shellStyles = shellSource.slice(shellSource.indexOf('<style>'));
+
+interface MediaBlock { readonly query: string; readonly body: string }
+
+/** Brace-matched extraction — a media block contains nested rule braces, so a
+ *  non-greedy regex would stop at the first inner `}`. */
+function mediaBlocks(css: string): MediaBlock[] {
+  const out: MediaBlock[] = [];
+  const opener = /@media([^{]+)\{/g;
+  let match: RegExpExecArray | null;
+  while ((match = opener.exec(css)) !== null) {
+    let depth = 1;
+    let i = opener.lastIndex;
+    while (i < css.length && depth > 0) {
+      if (css[i] === '{') depth += 1;
+      else if (css[i] === '}') depth -= 1;
+      i += 1;
+    }
+    out.push({ query: match[1].trim(), body: css.slice(opener.lastIndex, i - 1) });
+    opener.lastIndex = i;
+  }
+  return out;
+}
+
+function selectorsOf(body: string): string[] {
+  return body
+    .split('}')
+    .map((rule) => rule.split('{')[0].trim())
+    .filter(Boolean)
+    .flatMap((selector) => selector.split(',').map((s) => s.trim()))
+    .filter(Boolean);
+}
+
+const blocks = mediaBlocks(shellStyles);
+const widthBlocks = blocks.filter((b) => /-width:/.test(b.query));
+const find = (predicate: (b: MediaBlock) => boolean): MediaBlock | undefined => blocks.find(predicate);
+
+describe('the declared reflow breakpoints and the shell agree, in both directions', () => {
+  // Kills: leaving the manifest at the pre-MOR-1069 empty breakpoint list
+  // while the shell reflows anyway — a layout that lies about being
+  // responsive, which is the exact drift MOR-1094 avoided by recording
+  // mobile's real threshold instead of a nominal one.
+  it('the manifest declares the two thresholds as fluid reflow breakpoints', () => {
+    expect(dualReceiverCockpitLayout.stageSizing).toEqual({
+      mode: 'fluid',
+      responsiveBreakpoints: [768, 1024],
+    });
+  });
+
+  // Kills: moving a media threshold (or adding a third band) without
+  // re-declaring it, AND declaring a breakpoint the shell never implements.
+  // `max-width: N` is the band BELOW breakpoint N+1, `min-width: N` the band
+  // at breakpoint N — so both spellings normalize onto the same number.
+  it('every media threshold in the shell is a declared breakpoint, and vice versa', () => {
+    const fromCss = new Set<number>();
+    for (const block of widthBlocks) {
+      for (const [, kind, px] of block.query.matchAll(/\((min|max)-width:\s*(\d+)px\)/g)) {
+        fromCss.add(kind === 'min' ? Number(px) : Number(px) + 1);
+      }
+    }
+    const sizing = dualReceiverCockpitLayout.stageSizing;
+    const declared = sizing.mode === 'fluid' ? [...sizing.responsiveBreakpoints] : [];
+    expect([...fromCss].sort((a, b) => a - b)).toEqual(declared.sort((a, b) => a - b));
+  });
+});
+
+describe('portrait-mobile ruling: STACK, not exclude', () => {
+  // The ruling, pinned at the manifest end. A fluid layout has no arithmetic
+  // exclusion from a portrait phone the way a fixed-native one does, and the
+  // two ways to build one back (a viewport consumer of the frozen sizing
+  // field, or a second mobile behavior state machine) are both banned. Kills:
+  // repurposing `fallbackLayoutId` as a viewport escape hatch, which would
+  // also silently break MOR-1068's frozen topology table.
+  it('stays fluid, and keeps a TOPOLOGY fallback rather than a viewport one', () => {
+    expect(dualReceiverCockpitLayout.stageSizing.mode).toBe('fluid');
+    expect(dualReceiverCockpitLayout.fallbackLayoutId).toBe('sdr-test');
+  });
+
+  // Kills: gating the compact stack on portrait, which is what "quietly loses
+  // the portrait-mobile property" looks like in CSS — a phone in LANDSCAPE is
+  // still ~700px wide and still cannot carry two channel strips.
+  it('the compact band stacks to one column in BOTH orientations', () => {
+    const compact = find((b) => /max-width:\s*767px/.test(b.query));
+    expect(compact).toBeDefined();
+    expect(compact!.query).not.toMatch(/orientation/);
+    expect(compact!.body).toMatch(/grid-template-columns:\s*1fr/);
+  });
+
+  // Kills: dropping the orientation axis and stacking the whole tablet band
+  // (a 1024x768 landscape tablet has the width for two strips and would lose
+  // them), or extending the portrait stack up into desktop widths.
+  it('the tablet band stacks in PORTRAIT only', () => {
+    const tabletPortrait = find((b) => /orientation:\s*portrait/.test(b.query));
+    expect(tabletPortrait).toBeDefined();
+    expect(tabletPortrait!.query).toMatch(/min-width:\s*768px/);
+    expect(tabletPortrait!.query).toMatch(/max-width:\s*1023px/);
+    expect(tabletPortrait!.body).toMatch(/grid-template-columns:\s*1fr/);
+  });
+});
+
+describe('nothing is hidden by a breakpoint (the MOR-557 / F1-mirror lens)', () => {
+  // The ticket's "hidden secondary zones do not destroy active runtime
+  // resources" is satisfied here by never hiding one. Kills: answering
+  // "narrow" with `display: none` on a strip, the global row or the RX/TX
+  // zone — a control removed by viewport is capability the operator silently
+  // lost, with no other way to reach it in this layout.
+  it('no media block hides a zone or a control', () => {
+    for (const block of blocks) {
+      expect(block.body).not.toMatch(/display:\s*none/);
+      expect(block.body).not.toMatch(/visibility:\s*hidden/);
+      expect(block.body).not.toMatch(/content-visibility:\s*hidden/);
+    }
+  });
+
+  // Kills: a responsive rule that escapes the cockpit. The shell reaches into
+  // the SHARED wiring's classes with `:global(...)`, and sdr-test / LCD /
+  // mobile mount that same wiring — an unrooted selector would re-compose all
+  // of them from here.
+  it('every responsive selector is rooted at the cockpit', () => {
+    const selectors = blocks.flatMap((b) => selectorsOf(b.body));
+    expect(selectors.length).toBeGreaterThan(0);
+    for (const selector of selectors) {
+      expect(selector).toContain('.dual-receiver-cockpit');
+    }
+  });
+});
+
+describe('DOM order stays focus order at every breakpoint', () => {
+  // "Keyboard and touch order remain logical" has exactly one mechanical
+  // reading in a CSS-only composition: the reflow must never reorder boxes
+  // away from source order, because tab order follows the DOM and touch
+  // follows the pixels. Kills: `order:`, a `-reverse` flow, `dense` packing,
+  // or lifting a zone out of flow to re-place it.
+  it('the shell uses no order-divorcing property anywhere in its styles', () => {
+    expect(shellStyles).not.toMatch(/(?:^|[;{\s])order\s*:/);
+    expect(shellStyles).not.toMatch(/-reverse/);
+    expect(shellStyles).not.toMatch(/grid-auto-flow:[^;]*dense/);
+    expect(shellStyles).not.toMatch(/position:\s*(?:absolute|fixed)/);
+  });
+});
+
+describe('reduced motion: the reflow has no motion to reduce', () => {
+  // Kills: animating the reflow (a transition on grid-template-columns, a
+  // slide between arrangements). The app-wide `prefers-reduced-motion` block
+  // in styles/animations.css only shortens durations — a layout that composes
+  // its arrangement change as motion still moves under it. Declaring none is
+  // the honest floor; if motion is ever wanted here it must arrive inside a
+  // `(prefers-reduced-motion: no-preference)` block, which this scan forces
+  // the author to notice.
+  it('declares no transition, animation or keyframes', () => {
+    expect(shellStyles).not.toMatch(/(?:^|[;{\s])transition\b/);
+    expect(shellStyles).not.toMatch(/(?:^|[;{\s])animation\b/);
+    expect(shellStyles).not.toMatch(/@keyframes/);
+  });
+});
+
+describe('touch targets are keyed off the pointer, never off a width', () => {
+  // MOR-1160's note, made mechanical: cockpit chrome is fluid and never
+  // uniformly scaled precisely because scaled controls fall below the minimum
+  // hit size. Kills: dropping the floor, or re-keying it to a narrow width so
+  // a touch laptop at desktop width gets mouse-sized controls.
+  it('a pointer: coarse block gives every cockpit control a >= 44px hit box', () => {
+    const coarse = find((b) => /pointer:\s*coarse/.test(b.query));
+    expect(coarse).toBeDefined();
+    expect(coarse!.query).not.toMatch(/-width:/);
+    for (const axis of ['min-height', 'min-width']) {
+      const declared = [...coarse!.body.matchAll(new RegExp(`${axis}:\\s*(\\d+)px`, 'g'))]
+        .map((m) => Number(m[1]));
+      expect(declared.length).toBeGreaterThan(0);
+      expect(Math.min(...declared)).toBeGreaterThanOrEqual(44);
+    }
+    expect(coarse!.body).toMatch(/:global\(button\)/);
+    expect(coarse!.body).toMatch(/:global\(\[role='switch'\]\)/);
+  });
+});
+
+describe('no second mobile behavior state machine (the ticket\'s owned-area rule)', () => {
+  // Kills: re-implementing the reflow in JS — a `matchMedia` subscription, a
+  // resize/orientation listener, or width/height state. Beyond duplicating
+  // MobileRadioLayout's machine, a JS-driven recomposition can REMOUNT the
+  // surfaces on rotation, and that is what puts the TX lease identity and
+  // live runtime resources at risk. The mounted counterpart (element identity
+  // survives a rotation) is in the shell's component test.
+  it.each([
+    ['the cockpit shell', () => shellSource],
+    ['the shared wiring', () => wiringSource],
+  ])('%s observes no viewport signal', (_name, read) => {
+    const source = read();
+    expect(source).not.toMatch(/matchMedia/);
+    expect(source).not.toMatch(/orientationchange/);
+    expect(source).not.toMatch(/addEventListener\(\s*['"]resize['"]/);
+    expect(source).not.toMatch(/window\.inner(?:Width|Height)/);
+    expect(source).not.toMatch(/ResizeObserver/);
+  });
+
+  // MOR-1069 (N1) at source level. The rx-tx zone wrapper is now rendered
+  // only in the dual composition, and the branch is a `{#snippet}` render so
+  // there is exactly ONE `<RxTxSurface>` tag in the file. Kills: closing the
+  // branch by duplicating the surface tag — two tags is one edit away from
+  // two mounted key controls, and single TX authority is this layout's
+  // hardest invariant.
+  it('the wiring declares exactly one RxTxSurface tag', () => {
+    expect(wiringSource.match(/<RxTxSurface\b/g)).toHaveLength(1);
+  });
+});

--- a/frontend/src/presentation/layouts/dual-receiver-cockpit.ts
+++ b/frontend/src/presentation/layouts/dual-receiver-cockpit.ts
@@ -27,8 +27,36 @@
  * `stageSizing: fluid` encodes the MOR-1160 chrome-fluid half of the sizing
  * axis: this shell composes only VFO/RX-TX status text today (no fixed-native
  * instrument glass yet), so it always fits, at any viewport.
+ *
+ * MOR-1069 — the PORTRAIT-MOBILE RULING, stated rather than defaulted.
+ *
+ * A `fixed-native` layout is excluded from a portrait phone arithmetically:
+ * the achievable uniform scale drops under `minScale` and resolution takes the
+ * one validated hop to a fluid fallback. A `fluid` layout has no such
+ * exclusion — it fits every viewport by construction — so this cockpit DOES
+ * reach portrait mobile, and it reaches it deliberately. It is not a silent
+ * default: restoring an exclusion would need either a viewport consumer of the
+ * frozen sizing field (banned while the ScaledStage primitive does not exist —
+ * `__tests__/stage-sizing-boundary.test.ts`) or a second mobile behavior state
+ * machine (banned by MOR-1069's owned area). So the ruling is STACK, NOT
+ * EXCLUDE: on a portrait phone the cockpit composes as a single column with
+ * touch-sized controls, and `fallbackLayoutId` stays a TOPOLOGY fallback
+ * (`sdr-test`, MOR-1068's frozen table), never a viewport one.
  */
 import { registerLayout, type LayoutManifest } from './contract';
+
+/**
+ * The two reflow thresholds the shell actually implements, recorded honestly
+ * — the same discipline MOR-1094 applied to the mobile manifest's single
+ * breakpoint. Widths, in px: `<768` compact, `768-1023` tablet, `>=1024`
+ * desktop, matching the app's existing tablet band in
+ * `components-v2/layout/responsive.css`. Declaration only, as the field's
+ * contract requires: the media queries in
+ * `skins/dual-receiver-cockpit/DualReceiverCockpit.svelte` are what reflows,
+ * and `__tests__/cockpit-responsive-composition.test.ts` requires the two
+ * descriptions to name the same numbers in both directions.
+ */
+const COCKPIT_REFLOW_BREAKPOINTS = [768, 1024] as const;
 
 export const dualReceiverCockpitLayout: LayoutManifest = {
   schemaVersion: 1,
@@ -52,7 +80,7 @@ export const dualReceiverCockpitLayout: LayoutManifest = {
   ],
   compatibleTopologies: ['2/ab_shared', '2/main_sub'],
   requiredSemanticSurfaces: ['vfo', 'rxTx'],
-  stageSizing: { mode: 'fluid', responsiveBreakpoints: [] },
+  stageSizing: { mode: 'fluid', responsiveBreakpoints: COCKPIT_REFLOW_BREAKPOINTS },
   fallbackLayoutId: 'sdr-test',
 };
 

--- a/frontend/src/skins/dual-receiver-cockpit/DualReceiverCockpit.svelte
+++ b/frontend/src/skins/dual-receiver-cockpit/DualReceiverCockpit.svelte
@@ -22,6 +22,49 @@
   falsely active. `global` left this list when the radio-wide row moved in:
   a zone holding live switches gates at the widget, not with a container
   marker (MOR-1067 verification F7).
+
+  MOR-1069 — the cockpit's RESPONSIVE COMPOSITION lives in the style block
+  below and nowhere else. Four policies, each pinned (see
+  `presentation/layouts/__tests__/cockpit-responsive-composition.test.ts` and
+  `__tests__/DualReceiverCockpit.component.test.ts`):
+
+  1. PLACEMENT. Desktop-first: the base rules ARE the wide arrangement and
+     each media block only reflows it. Compact (<768px) stacks the channel
+     strips into one column in both orientations; the tablet band
+     (768-1023px) stacks in PORTRAIT only, because there the width is not
+     real. Desktop (>=1024px) and tablet landscape keep the two columns. The
+     thresholds are declared on the manifest as this layout's reflow
+     breakpoints, and a test requires the two descriptions to agree.
+
+  2. NOTHING IS HIDDEN. No breakpoint may `display: none` or
+     `visibility: hidden` any zone or control — the MOR-557 / F1-mirror lens
+     applied to responsiveness: a control removed by viewport is a capability
+     the operator silently lost, and the ticket's "hidden secondary zones do
+     not destroy active runtime resources" cannot be violated by a
+     composition that hides nothing. Stacking is the answer to narrow, not
+     hiding.
+
+  3. DOM ORDER IS FOCUS ORDER. The reflow never uses `order`, a `-reverse`
+     direction, `grid-auto-flow: dense`, or out-of-flow positioning, so the
+     visual sequence and the tab sequence stay the same sequence at every
+     breakpoint and in both orientations ("keyboard and touch order remain
+     logical").
+
+  4. NO MOTION, NO STATE MACHINE. The reflow is instantaneous — this shell
+     declares no transition, animation or keyframes, so there is nothing for
+     `prefers-reduced-motion` to have to switch off (the app-wide reduce
+     block in `styles/animations.css` still covers any descendant). And it is
+     pure CSS: no `matchMedia`, no resize/orientation listener, no width or
+     height state anywhere in the cockpit. The DOM is IDENTICAL across every
+     viewport and orientation, so a portrait/landscape change cannot remount
+     the surfaces, cannot re-key the TX lease identity, and cannot destroy a
+     live runtime resource. That is also what keeps this layout free of the
+     second mobile behavior state machine MOR-1069 rules out.
+
+  Touch targets are enforced on `pointer: coarse` at EVERY band rather than
+  at a width, and this chrome is never uniformly scaled (MOR-1160: scaled
+  controls shrink below the minimum hit size, which is exactly why cockpit
+  chrome stays fluid).
 -->
 <script lang="ts">
   import SemanticRadioSurfaces from '../../components-v2/wiring/SemanticRadioSurfaces.svelte';
@@ -51,5 +94,45 @@
   }
   .cockpit-inert-zone {
     min-height: 0;
+  }
+
+  /* ── MOR-1069 responsive composition ──────────────────────────────────
+     The `:global(...)` halves reach into the shared wiring's composed
+     blocks (`components-v2/wiring/SemanticRadioSurfaces.svelte`) on purpose:
+     the cockpit OWNS its own responsive rules, and rooting every selector at
+     `.dual-receiver-cockpit` keeps them off sdr-test / LCD / mobile, which
+     mount the same wiring in its single composition. The coupling to those
+     class names is not silent — a component test requires every class named
+     below to exist in the mounted tree, so a rename fails loudly here
+     instead of quietly dropping the reflow. */
+
+  /* Compact (<768px), both orientations: one column. A phone on its side is
+     wider than it is tall but still far too narrow for two channel strips,
+     so this band does not consult orientation at all. */
+  @media (max-width: 767px) {
+    .dual-receiver-cockpit :global(.channel-strips) {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  /* Tablet band (768-1023px), PORTRAIT only: same stack — 768px of portrait
+     width split in two leaves neither strip readable. In landscape at the
+     same width the two columns stay, because there the width is real and the
+     height is what is scarce. This is the orientation axis of the policy. */
+  @media (min-width: 768px) and (max-width: 1023px) and (orientation: portrait) {
+    .dual-receiver-cockpit :global(.channel-strips) {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  /* Touch targets, every band and every orientation. Keyed off the pointer,
+     never off a width: a touch laptop at desktop width needs the same hit
+     size a phone does, and a mouse on a narrow window does not. */
+  @media (pointer: coarse) {
+    .dual-receiver-cockpit :global(button),
+    .dual-receiver-cockpit :global([role='switch']) {
+      min-height: 44px;
+      min-width: 44px;
+    }
   }
 </style>

--- a/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
+++ b/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
@@ -11,6 +11,7 @@
  * scope/controls/global zones staying inert, and no shell-level fabrication
  * of an active strip. Each test's doc line names the mutation it kills.
  */
+import { readFileSync } from 'node:fs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
 import type { Capabilities } from '$lib/types/capabilities';
@@ -553,6 +554,155 @@ describe('operational audio-scope availability (scope=false + audioFft=true)', (
     expect(markup()).toBe(withoutAudioFft);
     expect(qa('[data-testid="rx-tx-key"]')).toHaveLength(1);
     expect(q('[data-testid="cockpit-zone-scope"]')!.textContent).toBe('');
+  });
+});
+
+// ── MOR-1069: the mounted half of the responsive-composition policy. The
+// breakpoint/orientation rules themselves are CSS and jsdom does not evaluate
+// media queries, so they are pinned textually in
+// `presentation/layouts/__tests__/cockpit-responsive-composition.test.ts`.
+// What IS observable here — and what the ticket's acceptance evidence is
+// actually about — is that the composition is CSS-only: the same DOM, the
+// same elements and the same TX ownership at every viewport and orientation.
+
+describe('MOR-1069 — a viewport or orientation change recomposes nothing at runtime', () => {
+  /** Drive the signals a JS-based responsive implementation would listen to. */
+  function rotateToPortraitPhone(): void {
+    for (const [axis, value] of [['innerWidth', 390], ['innerHeight', 844]] as const) {
+      Object.defineProperty(window, axis, { value, configurable: true, writable: true });
+    }
+    window.dispatchEvent(new Event('resize'));
+    window.dispatchEvent(new Event('orientationchange'));
+    flushSync();
+  }
+
+  // The ticket's headline evidence: "portrait/landscape replacement preserves
+  // TX/resource ownership" and "hidden secondary zones do not destroy active
+  // runtime resources". Both hold trivially IF the arrangement change never
+  // touches the DOM — so that is what is pinned, by ELEMENT IDENTITY rather
+  // than by markup equality. Kills: re-implementing the reflow as JS state
+  // (a matchMedia subscription, a resize listener, an `{#if isPortrait}`),
+  // which remounts this subtree on rotation, destroys the RxTxSurface that
+  // owns the operator's only unkey control, and re-runs the wiring's
+  // `onDestroy` lease release under a fresh sourceId.
+  it('keeps every zone element, the TX surface and the key control identical across a rotation', () => {
+    h.state = mainSubState('MAIN');
+    h.caps = mainSubCaps();
+    render();
+
+    const zonesBefore = qa('[data-zone-id]');
+    const keyBefore = q('[data-testid="rx-tx-key"]')!;
+    const surfaceBefore = q('[data-testid="rx-tx-surface"]')!;
+    const markupBefore = target.innerHTML;
+    expect(zonesBefore).toHaveLength(4);
+
+    rotateToPortraitPhone();
+
+    const zonesAfter = qa('[data-zone-id]');
+    expect(zonesAfter).toHaveLength(zonesBefore.length);
+    zonesAfter.forEach((el, i) => expect(el).toBe(zonesBefore[i]));
+    expect(q('[data-testid="rx-tx-key"]')).toBe(keyBefore);
+    expect(q('[data-testid="rx-tx-surface"]')).toBe(surfaceBefore);
+    expect(target.innerHTML).toBe(markupBefore);
+  });
+
+  // The TX half, driven from a LIVE lease rather than from idle — idle has no
+  // guard, so a remount's fail-closed `onDestroy` release is a no-op and the
+  // interesting failure hides. Keyed, the same remount drops the operator's
+  // transmission on rotation, or re-keys under a fresh `sourceId` that the
+  // controller will refuse to release from. This is the ticket's "portrait/
+  // landscape replacement preserves TX/resource ownership", stated where it
+  // can actually fail: rotating while keyed is not a lease event.
+  it('rotating while KEYED neither releases nor re-acquires the lease', () => {
+    h.state = mainSubState('MAIN');
+    h.caps = mainSubCaps();
+    render();
+
+    q<HTMLButtonElement>('[data-testid="rx-tx-key"]')!.click();
+    flushSync();
+    expect(h.start).toHaveBeenCalledTimes(1);
+    push({ phase: 'transmitting', intent: 'latched', guard: { leaseId: 'L1' }, mayOwnKey: true });
+    h.start.mockReset();
+    h.release.mockReset();
+
+    rotateToPortraitPhone();
+
+    expect(h.start).not.toHaveBeenCalled();
+    expect(h.release).not.toHaveBeenCalled();
+    // ...and the only way out of transmit is still there, exactly once.
+    expect(qa('[data-testid="rx-tx-surface"]')).toHaveLength(1);
+    expect(qa('[data-testid="rx-tx-unkey"]')).toHaveLength(1);
+  });
+});
+
+describe('MOR-1069 — focus order is DOM order, and the RX/TX zone comes last', () => {
+  // "Keyboard and touch order remain logical." The CSS side (no `order`, no
+  // reversed flow) is pinned textually; this is the DOM side that the CSS
+  // must keep agreeing with. Kills: emitting the radio-wide row or the RX/TX
+  // zone before the strips, or interleaving the strips' controls — either
+  // would make the tab sequence disagree with the reading order in BOTH
+  // arrangements at once.
+  it('every control appears in declared zone order, ending in rx-tx', () => {
+    h.state = mainSubState('MAIN');
+    h.caps = mainSubCaps();
+    render();
+
+    const declared = dualReceiverCockpitLayout.zones.map((z) => z.id);
+    const sequence = qa<HTMLElement>('button, input, select, a[href], [tabindex]')
+      .map((el) => el.closest('[data-zone-id]') as HTMLElement | null)
+      .map((zone) => declared.indexOf(zone?.dataset.zoneId ?? ''));
+
+    expect(sequence.length).toBeGreaterThan(0);
+    // No control sits outside a declared zone...
+    expect(sequence).not.toContain(-1);
+    // ...and the sequence never goes backwards through the declared order.
+    expect(sequence).toEqual([...sequence].sort((a, b) => a - b));
+    // The operator's key/unkey control is the last thing in the tab sequence,
+    // not stranded between two channel strips.
+    expect(sequence.at(-1)).toBe(declared.indexOf('rx-tx'));
+  });
+});
+
+describe('MOR-1069 (N1) — rx-tx is a real bound zone element in the cockpit', () => {
+  // The MOR-1068 verification accepted an inert `display: contents` wrapper on
+  // every path. It cannot stay inert here: a `display: contents` box takes no
+  // part in its parent's layout, so the zone could not be placed by the
+  // responsive rules at all. It is now a real element, rendered only in this
+  // composition. Kills: reverting the wrapper to a phantom, or losing the
+  // zone binding while collapsing it.
+  it('wraps the shared TX surface in a placeable element carrying the zone id', () => {
+    h.state = mainSubState('MAIN');
+    h.caps = mainSubCaps();
+    render();
+
+    const zone = q('[data-zone-id="rx-tx"]')!;
+    expect(zone).not.toBeNull();
+    expect(zone.tagName).toBe('DIV');
+    expect(zone.classList.contains('rx-tx-zone')).toBe(true);
+    // The zone IS the surface's box, not a sibling marker next to it.
+    expect(q('[data-testid="rx-tx-surface"]')!.parentElement).toBe(zone);
+    expect(zone.querySelectorAll('[data-testid="rx-tx-key"]')).toHaveLength(1);
+  });
+});
+
+describe('MOR-1069 — the shell\'s responsive selectors still match the composed tree', () => {
+  // The cockpit owns its responsive rules but the boxes they place are
+  // composed by the SHARED wiring, so the rules reach in with `:global(...)`.
+  // That coupling is one rename away from silently doing nothing — a CSS
+  // selector that matches no element is not an error anywhere. Kills: a class
+  // rename (or a restructure) in SemanticRadioSurfaces that leaves the
+  // cockpit's stacking rules pointing at nothing.
+  it('every :global class named by the cockpit CSS exists in the mounted DOM', () => {
+    h.state = mainSubState('MAIN');
+    h.caps = mainSubCaps();
+    render();
+
+    const source = readFileSync('src/skins/dual-receiver-cockpit/DualReceiverCockpit.svelte', 'utf8');
+    const classes = [...source.matchAll(/:global\(\.([a-z0-9-]+)\)/g)].map((m) => m[1]);
+    expect(classes.length).toBeGreaterThan(0);
+    for (const className of new Set(classes)) {
+      expect(qa(`.${className}`).length).toBeGreaterThan(0);
+    }
   });
 });
 


### PR DESCRIPTION
Closes MOR-1069 — the last execution ticket before the MOR-1070 owner acceptance gate.

## What

CSS-only responsive composition for the dual-receiver cockpit: breakpoints 768/1024 plus an orientation axis (compact stacks in both orientations; tablet stacks in portrait only); nothing is hidden at any breakpoint (pinned by an assertion that no media block contains `display:none`/`visibility:hidden`); DOM order = focus order; `pointer: coarse` ships 44px touch targets covering 100% of cockpit controls. **Portrait-mobile ruling: STACK, not exclude** — adjudicated as the only reading reachable inside the ticket's constraints (`fitsViewport` is unconditionally true for fluid; a viewport consumer of `stageSizing` is blocked by the MOR-1247 guard; a JS mobile state machine is banned by the ticket's owned area; `fallbackLayoutId` not repurposed). The rx-tx wrapper became a real bound zone element in the dual path and was collapsed out of the single path — which now differs from its true pre-cockpit shape by a single whitespace text node, zero element differences.

**20 net production LOC** (frozen formula; the raw diff is larger due to comment/doc lines), 3 files, +19 tests.

## Provenance

- Independent adversarial verification (opus — the verifier of MOR-1067/1068, independent of this builder): **PASS**. 13 mutations killed, zero survivors (9 of the builder's re-derived independently + 4 of the verifier's own, incl. per-side breakpoint-agreement probes and stripping `data-zone-id` from the newly-bound element).
- The builder report's A/B anomaly (fewer failures than baseline) was investigated and explained: an incomplete builder run (arithmetic signature matches one dropped test file); the verifier's own five A/B runs are stable with identical failing test-NAME sets — the code is unaffected.
- Stack-vs-handoff is genuinely latent, not silently decided: `skins/registry.ts` untouched, `resolveSkinId` still routes every mobile viewport to the mobile skin — a real phone cannot reach the cockpit today. Consolidated for the MOR-1070 owner gate together with: conditional-control zone membership (three conditional zone-less controls: `tx-fault-reset` + two `ModInputTxWarning` buttons) and the semantics of `fluid.responsiveBreakpoints` vs the field's instrument-stage scope (precedent set by the merged MOR-1094 mobile manifest).

Failing-file set identical to baseline (10 files, environmental Node-26 `localStorage`; CI is the gate); lint/check/i18n/build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)