### PR TITLE
fix(MOR-1256): gate the SUB strip on operationalReceivers (present + disabled)

### DIFF
--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -31,7 +31,9 @@
   import VfoSurface, { type VfoSelection } from '../../semantic/VfoSurface.svelte';
   import ModInputTxWarning from '../panels/ModInputTxWarning.svelte';
   import { makeVfoHandlers } from './command-bus';
-  import { forReceiver, receiversOf, isActiveStrip } from './dual-receiver-strips';
+  import {
+    forReceiver, receiversOf, isActiveStrip, isOperationalStrip,
+  } from './dual-receiver-strips';
 
   /**
    * `'single'` (default) is the exact pre-MOR-1067 markup — sdr-test's
@@ -128,6 +130,7 @@
             data-zone-id={index === 0 ? 'primary-vfo' : 'secondary-vfo'}
             data-strip-receiver={receiverId}
             data-strip-active={isActiveStrip(view, receiverId)}
+            data-strip-operational={isOperationalStrip(view, receiverId)}
           >
             <!--
               `selectionPoolSize`: the slice below holds this receiver's VFOs
@@ -141,6 +144,11 @@
               `groupLabel`: without it all three mounted surfaces share one
               generic accessible name and assistive tech cannot tell the
               strips apart.
+              `disabled` (MOR-1256): a structurally-dual, operationally-
+              degraded receiver (`dual-rx-unavailable`) keeps its strip
+              PRESENT but forces its select controls inert — the shared
+              RxTxSurface below is untouched, so single TX authority stays
+              radio-wide regardless of which strip this gates.
             -->
             <VfoSurface
               viewModel={forReceiver(view, receiverId)}
@@ -148,6 +156,7 @@
               showRadioWideFacts={false}
               groupLabel={t('core.vfo.receiverGroupLabel', { receiver: receiverId })}
               onSelectVfo={selectVfo}
+              disabled={!isOperationalStrip(view, receiverId)}
             />
           </div>
         {/each}

--- a/frontend/src/components-v2/wiring/__tests__/dual-receiver-strips.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/dual-receiver-strips.test.ts
@@ -4,13 +4,28 @@
  * exists to kill.
  */
 import { describe, it, expect } from 'vitest';
-import { forReceiver, isActiveStrip, receiversOf } from '../dual-receiver-strips';
+import {
+  forReceiver, isActiveStrip, isOperationalStrip, receiversOf,
+} from '../dual-receiver-strips';
 import { topologyFixtures } from '../../../semantic/fixtures/topologies';
 import type { RadioViewModel } from '../../../semantic/radio-view-model';
 
 const dualAbShared = topologyFixtures['2/ab_shared'];
 const dualMainSub = topologyFixtures['2/main_sub'];
 const singleReceiver = topologyFixtures['1/single'];
+
+// MOR-1256: none of the four canonical topology fixtures models
+// `dual-rx-unavailable` (structurally dual, operationally degraded) — it is
+// a diagnostic condition, not a fifth topology. Built here the same way
+// `withAudioOnlyScope` composes its orthogonal condition onto a fixture:
+// every other fact stays byte-identical to `dualMainSub`.
+const dualRxUnavailable: RadioViewModel = {
+  ...dualMainSub,
+  disabledReasons: [
+    ...dualMainSub.disabledReasons,
+    { field: 'receiver.SUB', code: 'capability-unavailable' },
+  ],
+};
 
 describe('receiversOf', () => {
   it('finds both receivers in an unslotted dual (ab_shared) fixture', () => {
@@ -67,5 +82,33 @@ describe('isActiveStrip', () => {
     const unknownActive: RadioViewModel = { ...dualMainSub, activeReceiver: { status: 'unknown' } };
     expect(isActiveStrip(unknownActive, 'MAIN')).toBe(false);
     expect(isActiveStrip(unknownActive, 'SUB')).toBe(false);
+  });
+});
+
+describe('isOperationalStrip (MOR-1256)', () => {
+  it('is true for both receivers of a fully dual-capable fixture (no receiver disabledReason)', () => {
+    expect(isOperationalStrip(dualMainSub, 'MAIN')).toBe(true);
+    expect(isOperationalStrip(dualMainSub, 'SUB')).toBe(true);
+  });
+
+  // The kill-test this ticket requires: severing the operational feed (no
+  // `receiver.SUB` disabledReason reaching the view model) makes this false
+  // assertion pass instead — i.e. the present+disabled assertion fails.
+  it('is false only for the receiver named in a receiver.<ID> disabledReason', () => {
+    expect(isOperationalStrip(dualRxUnavailable, 'SUB')).toBe(false);
+    expect(isOperationalStrip(dualRxUnavailable, 'MAIN')).toBe(true);
+  });
+
+  // MUTATION KILLED: matching on ANY `receiver.` prefix (or on the presence
+  // of ANY disabledReason) instead of the exact `receiver.<ID>` field — would
+  // wrongly disable MAIN whenever SUB is unavailable, gating the shared
+  // TX-adjacent strip on someone else's diagnostic.
+  it('does not fire on an unrelated disabledReason field', () => {
+    const other: RadioViewModel = {
+      ...dualMainSub,
+      disabledReasons: [{ field: 'scope.hardwareScope', code: 'field-not-observed' }],
+    };
+    expect(isOperationalStrip(other, 'SUB')).toBe(true);
+    expect(isOperationalStrip(other, 'MAIN')).toBe(true);
   });
 });

--- a/frontend/src/components-v2/wiring/dual-receiver-strips.ts
+++ b/frontend/src/components-v2/wiring/dual-receiver-strips.ts
@@ -7,6 +7,10 @@
  * single-receiver view model yields exactly one strip, an empty one yields
  * none. `isActiveStrip` is true only on a POSITIVELY observed match — an
  * `unknown` activeReceiver marks every strip inactive, never a guessed one.
+ * `isOperationalStrip` (MOR-1256) is the structural/operational counterpart:
+ * a receiver stays in `receiversOf`/`vfos` when only STRUCTURALLY present
+ * (MOR-977 — the strip renders), but reads back the adapter's per-receiver
+ * `disabledReasons` entry to say whether it is also usable right now.
  */
 import type { ReceiverId, RadioViewModel } from '../../semantic/radio-view-model';
 
@@ -25,4 +29,14 @@ export function forReceiver(view: RadioViewModel, receiver: ReceiverId): RadioVi
 
 export function isActiveStrip(view: RadioViewModel, receiver: ReceiverId): boolean {
   return view.activeReceiver.status === 'known' && view.activeReceiver.receiver === receiver;
+}
+
+/**
+ * True unless the adapter reported this exact receiver as operationally
+ * unavailable (`radio-view-model-adapter.ts`'s `receiver.<ID>` disabledReason
+ * — the `dual-rx-unavailable` diagnostic). Matches on the FULL field name,
+ * not a prefix: an unrelated receiver's reason must never gate this one.
+ */
+export function isOperationalStrip(view: RadioViewModel, receiver: ReceiverId): boolean {
+  return !view.disabledReasons.some((reason) => reason.field === `receiver.${receiver}`);
 }

--- a/frontend/src/lib/runtime/adapters/__tests__/radio-view-model-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/radio-view-model-adapter.test.ts
@@ -251,6 +251,44 @@ describe('scope availability separates structural from operational', () => {
   });
 });
 
+// MOR-1256: `operationalReceivers` (presentation-capabilities.ts) had zero
+// consumers — a `dual-rx-unavailable` radio (structurally dual, no `dual_rx`
+// tag) kept SUB fully enabled. `vfos` correctly stays derived from
+// `structuralReceivers` (MOR-977: the strip must still be PRESENT); the gap
+// was that nothing fed `operationalReceivers` anywhere, so no CONSUMER ever
+// disabled it. This closes the gap the same way `scope.hardwareScope` /
+// `scope.audioFftScope` already report degraded-but-structural facts: one
+// `disabledReasons` entry per structurally-present, operationally-absent
+// receiver, read back by `dual-receiver-strips.ts`'s `isOperationalStrip`.
+describe('operational receiver availability separates structural from operational (MOR-1256)', () => {
+  const dualRxUnavailableCaps = caps({ capabilities: SINGLE });
+
+  // MUTATION KILLED: dropping the `topology.operationalReceivers` loop
+  // entirely — SUB stays structurally present (correct) but nothing ever
+  // marks it disabled, reproducing the exact bug this ticket exists to fix.
+  it('marks the structurally-present, operationally-unavailable SUB receiver disabled', () => {
+    const view = model(observedState(), dualRxUnavailableCaps);
+    expect(view.topologyId).toBe('2/main_sub');
+    expect(view.vfos.some((v) => v.receiver === 'SUB')).toBe(true);
+    expect(view.disabledReasons).toContainEqual({
+      field: 'receiver.SUB', code: 'capability-unavailable',
+    });
+  });
+
+  // MUTATION KILLED: pushing the reason for every structural receiver
+  // instead of only the ones missing from `operationalReceivers` — MAIN
+  // would falsely disable too.
+  it('never marks MAIN unavailable — only the receiver that failed the capability check', () => {
+    const view = model(observedState(), dualRxUnavailableCaps);
+    expect(view.disabledReasons.some((r) => r.field === 'receiver.MAIN')).toBe(false);
+  });
+
+  it('emits no receiver disabledReason when the radio is fully dual-capable', () => {
+    const view = model(observedState(), TOPOLOGY_CAPS['2/main_sub']);
+    expect(view.disabledReasons.some((r) => r.field.startsWith('receiver.'))).toBe(false);
+  });
+});
+
 describe('the emitted model carries only contract data', () => {
   it('survives a JSON round-trip unchanged — no functions, classes or live objects', () => {
     for (const id of Object.keys(TOPOLOGY_CAPS)) {

--- a/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
@@ -192,6 +192,17 @@ export function toRadioViewModel(
     if (!availability.structural) disabledReasons.push({ field, code: 'capability-unavailable' });
     else if (!availability.operational) disabledReasons.push({ field, code: 'field-not-observed' });
   }
+  // MOR-1256: `operationalReceivers` (presentation-capabilities.ts) had zero
+  // consumers — a `dual-rx-unavailable` radio (structurally dual, no
+  // `dual_rx` tag) kept SUB in `vfos` (correct: MOR-977 renders it PRESENT)
+  // but nothing ever disabled it. One reason per structurally-present,
+  // operationally-absent receiver, same shape as the scope facts above;
+  // `dual-receiver-strips.ts`'s `isOperationalStrip` reads it back.
+  for (const receiverId of topology.structuralReceivers) {
+    if (!topology.operationalReceivers.includes(receiverId)) {
+      disabledReasons.push({ field: `receiver.${receiverId}`, code: 'capability-unavailable' });
+    }
+  }
 
   return {
     topologyId: `${topology.structuralCount}/${topology.scheme}`,

--- a/frontend/src/semantic/VfoSurface.svelte
+++ b/frontend/src/semantic/VfoSurface.svelte
@@ -74,6 +74,19 @@
      * generic catalog label, so single-surface callers are unchanged.
      */
     groupLabel?: string;
+    /**
+     * MOR-1256: forces every select control in this surface's VFO list
+     * disabled, regardless of slot/active state — the strip-level
+     * counterpart to the per-VFO `slot.kind === 'unknown'` gate below (same
+     * `disabled` attribute on the same button; not a parallel mechanism). A
+     * dual-receiver-cockpit strip whose receiver is structurally present but
+     * OPERATIONALLY unavailable (`dual-rx-unavailable`) sets this so its
+     * controls go inert without pretending the receiver does not exist
+     * (MOR-977: absent only when structural, disabled when only operational
+     * fails). Defaults to `false`: every existing caller — single/unsliced,
+     * and an operationally-fine dual strip — is unchanged.
+     */
+    disabled?: boolean;
   }
 
   let {
@@ -85,6 +98,7 @@
     showRadioWideFacts = true,
     showVfoList = true,
     groupLabel,
+    disabled = false,
   }: Props = $props();
 
   function slotKey(slot: VfoSlot): string {
@@ -107,7 +121,7 @@
   }
 
   function selectVfo(vfo: VfoViewModel): void {
-    if (!isSelectable(vfo) || vfo.slot.kind === 'unknown') return;
+    if (!isSelectable(vfo) || vfo.slot.kind === 'unknown' || disabled) return;
     onSelectVfo?.({ receiver: vfo.receiver, slot: vfo.slot });
   }
 
@@ -151,7 +165,7 @@
   <div class="vfo-list" data-testid="vfo-list">
     {#each viewModel.vfos as vfo, i (vfo.receiver + ':' + i)}
       {@const selectable = isSelectable(vfo)}
-      {@const disabled = selectable && vfo.slot.kind === 'unknown'}
+      {@const selectDisabled = selectable && (vfo.slot.kind === 'unknown' || disabled)}
       <div
         class="vfo-tile"
         class:is-active={vfo.isActive}
@@ -172,7 +186,7 @@
             type="button"
             class="vfo-select"
             data-vfo-select
-            disabled={disabled}
+            disabled={selectDisabled}
             aria-label={t('core.vfo.selectAction', { label: vfo.label })}
             onclick={() => selectVfo(vfo)}
           >

--- a/frontend/src/semantic/__tests__/VfoSurface.test.ts
+++ b/frontend/src/semantic/__tests__/VfoSurface.test.ts
@@ -449,6 +449,50 @@ describe('showVfoList (MOR-1068) — the radio-wide half, placeable on its own',
   });
 });
 
+describe('disabled (MOR-1256) — the strip-level operational gate', () => {
+  // Mirrors the existing per-VFO `slot.kind === 'unknown'` disabled-select
+  // mechanism rather than inventing a parallel one: same `disabled`
+  // attribute on the same button, now also forced by this prop. A
+  // dual-receiver-cockpit strip whose receiver is structurally present but
+  // operationally unavailable (`dual-rx-unavailable`) sets this.
+  it('forces every otherwise-selectable control disabled when true', () => {
+    const target = mountSurface({ viewModel: topologyFixtures['2/main_sub'], disabled: true });
+    const buttons = target.querySelectorAll<HTMLButtonElement>('[data-vfo-select]');
+    expect(buttons.length).toBeGreaterThan(0);
+    buttons.forEach((b) => expect(b.disabled).toBe(true));
+  });
+
+  it('MUTATION KILL: clicking a strip-disabled select control never emits the intent, ' +
+    'even if the native disabled gate is bypassed', () => {
+    const onSelectVfo = vi.fn();
+    const target = mountSurface({
+      viewModel: topologyFixtures['2/main_sub'], disabled: true, onSelectVfo,
+    });
+    const button = target.querySelectorAll<HTMLButtonElement>('[data-vfo-select]')[0];
+    button.disabled = false;
+    button.click();
+    expect(onSelectVfo).not.toHaveBeenCalled();
+  });
+
+  // Kills: defaulting the new prop to `true` — every existing caller
+  // (single/unsliced, and an operationally-fine dual strip) would lose its
+  // selection controls.
+  it('defaults to false: the unsliced surface is unchanged', () => {
+    const target = mountSurface({ viewModel: topologyFixtures['2/main_sub'] });
+    const buttons = target.querySelectorAll<HTMLButtonElement>('[data-vfo-select]');
+    expect(buttons.length).toBeGreaterThan(0);
+    buttons.forEach((b) => expect(b.disabled).toBe(false));
+  });
+
+  // The MOR-977 structural half is untouched by this prop: a control that is
+  // structurally ABSENT (nothing to choose) must stay absent, not reappear
+  // as a disabled button.
+  it('does not resurrect a structurally-absent control', () => {
+    const target = mountSurface({ viewModel: topologyFixtures['1/single'], disabled: true });
+    expect(target.querySelector('[data-vfo-select]')).toBeNull();
+  });
+});
+
 describe('groupLabel (MOR-1068) — distinct accessible names per mounted surface', () => {
   // Kills: ignoring the prop. A cockpit mounts three of these surfaces at
   // once (MAIN strip, SUB strip, radio-wide row); with one shared generic

--- a/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
+++ b/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
@@ -156,6 +156,19 @@ const audioOnlyScopeCaps = (): Capabilities => ({
   ...mainSubCaps(), audioFftAvailable: true,
 } as unknown as Capabilities);
 
+/**
+ * MOR-1256: `2/main_sub` structurally (receivers=2, main_sub scheme) but
+ * missing the `dual_rx` tag — `derivePresentationCapabilities` diagnoses
+ * `dual-rx-unavailable` and reports `operationalReceivers: ['MAIN']` while
+ * `structuralReceivers` stays `['MAIN', 'SUB']`. The SUB strip must still
+ * mount (MOR-977: structural ✓ renders present), just disabled (operational
+ * ✗). Reuses `mainSubState` — the diagnostic is purely a capability fact,
+ * independent of what state.sub happens to report.
+ */
+const dualRxUnavailableCaps = (): Capabilities => ({
+  ...mainSubCaps(), capabilities: ['audio', 'tx'],
+} as unknown as Capabilities);
+
 let target: HTMLDivElement;
 let component: ReturnType<typeof mount> | null = null;
 
@@ -258,6 +271,87 @@ describe('per-receiver VFO strips, driven by the dual-receiver topologies', () =
 
     expect(q('[data-testid="channel-strip-MAIN"]')!.dataset.stripActive).toBe('false');
     expect(q('[data-testid="channel-strip-SUB"]')!.dataset.stripActive).toBe('false');
+  });
+});
+
+// MOR-1256 — MOR-1068 verification finding N2: `operationalReceivers` had
+// zero consumers, so a `dual-rx-unavailable` radio (structurally dual,
+// operationally degraded) rendered a fully ENABLED SUB strip. The fix must
+// leave the SUB strip PRESENT (structural doctrine untouched) but its
+// controls genuinely inert, and must not leak into MAIN or the shared TX
+// surface — the MOR-557 lens applied in both directions.
+describe('dual-rx-unavailable: SUB strip present but operationally disabled (MOR-1256)', () => {
+  it('renders the SUB strip present, its select controls really disabled, MAIN fully live', () => {
+    h.state = mainSubState('MAIN');
+    h.caps = dualRxUnavailableCaps();
+    render();
+
+    const subStrip = q('[data-testid="channel-strip-SUB"]')!;
+    expect(subStrip).not.toBeNull();
+    expect(subStrip.dataset.stripOperational).toBe('false');
+    const subSelects = subStrip.querySelectorAll<HTMLButtonElement>('[data-vfo-select]');
+    expect(subSelects.length).toBeGreaterThan(0);
+    subSelects.forEach((b) => expect(b.disabled).toBe(true));
+
+    // Kill-test (2): the disabled-SUB fixture must not affect MAIN liveness.
+    const mainStrip = q('[data-testid="channel-strip-MAIN"]')!;
+    expect(mainStrip.dataset.stripOperational).toBe('true');
+    const mainSelects = mainStrip.querySelectorAll<HTMLButtonElement>('[data-vfo-select]');
+    expect(mainSelects.length).toBeGreaterThan(0);
+    mainSelects.forEach((b) => expect(b.disabled).toBe(false));
+  });
+
+  // Kill-test (2), the TX half: single TX authority is untouched by this
+  // ticket — the shared RxTxSurface must not become per-strip-gated.
+  it('does not touch the shared TX surface — the key control stays live and reaches the authority', () => {
+    h.state = mainSubState('MAIN');
+    h.caps = dualRxUnavailableCaps();
+    render();
+
+    expect(qa('[data-testid="rx-tx-surface"]')).toHaveLength(1);
+    const key = q<HTMLButtonElement>('[data-testid="rx-tx-key"]')!;
+    expect(key.disabled).toBe(false);
+    key.click();
+    flushSync();
+    expect(h.start).toHaveBeenCalledTimes(1);
+  });
+
+  // Pin round (verifier N1): the radio-wide row's immunity to the SUB
+  // per-receiver gate was correct but unpinned. Split/dual-watch are
+  // radio-wide facts (`showRadioWideFacts` only on the global-zone
+  // `VfoSurface`, `disabled` only on the per-receiver strips' `VfoSurface`
+  // instances) — mirrors the TX-authority protection above, which the
+  // original build already pinned; this closes the same gap for the
+  // global row.
+  it('leaves the radio-wide split and dual-watch switches enabled and reaching their handlers, with SUB operationally degraded', () => {
+    h.state = mainSubState('MAIN');
+    h.caps = dualRxUnavailableCaps();
+    render();
+
+    const split = q<HTMLButtonElement>('[data-vfo-split]')!;
+    const dualWatch = q<HTMLButtonElement>('[data-vfo-dual-watch]')!;
+    expect(split.disabled).toBe(false);
+    expect(dualWatch.disabled).toBe(false);
+
+    split.click();
+    dualWatch.click();
+    flushSync();
+    expect(h.splitToggle).toHaveBeenCalledTimes(1);
+    expect(h.dualWatchToggle).toHaveBeenCalledTimes(1);
+  });
+
+  // Regression pin: a fully dual-capable radio (dual_rx present) must render
+  // both strips operational — this ticket's fix must not fire unconditionally.
+  it('a fully dual-capable radio keeps SUB operational', () => {
+    h.state = mainSubState('MAIN');
+    h.caps = mainSubCaps();
+    render();
+
+    const subStrip = q('[data-testid="channel-strip-SUB"]')!;
+    expect(subStrip.dataset.stripOperational).toBe('true');
+    const subSelects = subStrip.querySelectorAll<HTMLButtonElement>('[data-vfo-select]');
+    expect(subSelects.length).toBeGreaterThan(0);
+    subSelects.forEach((b) => expect(b.disabled).toBe(false));
   });
 });
 


### PR DESCRIPTION
Closes MOR-1256 (pre-existing MOR-1062 adapter gap found during MOR-1068 verification; last formal blocker of the MOR-1070 acceptance gate).

## What

The operational level of the MOR-977 two-level gating finally reaches the cockpit: `operationalReceivers` feeds `disabledReasons` (`receiver.<ID>`, code `capability-unavailable` — existing frozen-contract vocabulary, no shape change), the pure slicer exposes `isOperationalStrip`, and a `dual-rx-unavailable` radio now renders its SUB strip present + genuinely disabled (widget-level, handler-guarded) while MAIN, the shared TX surface, and the radio-wide row stay live. **14 net production LOC** (frozen formula), 4 files.

## Provenance

- Independent adversarial verification (opus — the verifier whose MOR-1068 finding N2 this fixes; fourth cockpit verification in its series): **PASS**. Contract discipline measured, not assumed: `validateRadioViewModel`'s exactKeys/oneOf pins (the ones that caught the MOR-988 episode) pass unchanged; `rx-tx-surface.ts` filters `startsWith('tx')` so `receiver.*` cannot reach TX gating by code; a healthy radio's projection is byte-identical; substring traps (`activeReceiver` vs `receiver`) probed and impossible (full-equality matching).
- Compose matrix coherent across all four operational×observed states; inertness proven real (disabled attribute stripped from DOM → intent never reaches `onVfoSelect`, MAIN's live button still does). VfoSurface default path RAW byte-identical across all 9 shapes — the cleanest of the four cockpit tickets.
- 9 verifier mutations: 8 killed; the 1 survivor (global-row immunity unpinned) closed in a test-only pin round with all four production files sha256-proven identical to the verified state.
- 8-vs-10 baseline discrepancy investigated: genuine env variance (worker scheduling), both builder sides internally consistent — the invariant that matters.

Failing-file set identical to baseline (environmental Node-26 `localStorage`; CI is the gate); lint/check/build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)