### PR TITLE
fix(MOR-1252): hold peak indicators statically under prefers-reduced-motion

### DIFF
--- a/frontend/src/components-v2/meters/LinearSMeter.svelte
+++ b/frontend/src/components-v2/meters/LinearSMeter.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
+  import { onMount, untrack } from 'svelte';
   import { createSmoother, prefersReducedMotion, onReducedMotionChange } from '$lib/utils/smoothing.svelte';
   import {
     calibratedToSegments,
@@ -158,10 +158,35 @@
 
   $effect(() => {
     const current = smoother.value;
-    // MOR-1233: under reduced motion there is no hold-then-decay animation —
-    // the indicator tracks the bar directly, so it never lags behind.
-    if (prefersReducedMotion() || current >= peakSegs) {
-      // New peak — capture it
+
+    if (prefersReducedMotion()) {
+      // MOR-1252: static hold under reduced motion — the peak marker
+      // latches at the highest observed value and stays put (no glide)
+      // until either a higher value arrives or the hold window elapses, at
+      // which point it resets INSTANTLY to the current value (a single
+      // jump computed here, not a decay). This effect only re-runs when
+      // `smoother.value` actually changes — MOR-1233 already makes that a
+      // direct snap-to-target under reduce, so no rAF loop or interval is
+      // scheduled to drive this hold/reset.
+      //
+      // J2: the condition/write below both reads and writes peakSegs and
+      // peakTime, so it must run inside untrack() — otherwise the effect
+      // depends on its own writes and self-invalidates (it still converges
+      // today because the re-seat is idempotent and `||` short-circuits,
+      // but that's incidental, not guaranteed; matches the untrack()
+      // pattern MetersDockPanel's own latch-freshness effect already uses).
+      untrack(() => {
+        if (current >= peakSegs || performance.now() - peakTime > PEAK_HOLD_MS) {
+          peakSegs = current;
+          peakTime = performance.now();
+        }
+      });
+      return;
+    }
+
+    if (current >= peakSegs) {
+      // New peak — capture it (the decay-toward-current glide for an
+      // expired hold is handled by the rAF loop below).
       peakSegs = current;
       peakTime = performance.now();
     }

--- a/frontend/src/components-v2/meters/__tests__/LinearSMeter.reduced-motion.svelte.test.ts
+++ b/frontend/src/components-v2/meters/__tests__/LinearSMeter.reduced-motion.svelte.test.ts
@@ -127,19 +127,141 @@ describe('LinearSMeter — prefers-reduced-motion (MOR-1233)', () => {
     }
   });
 
-  it('does not leave a stale peak indicator after a value drop when reduced motion is preferred', () => {
+  // MOR-1252 owner decision (2026-08-04, option b): under reduced motion the
+  // peak indicator is a STATIC HOLD, not a removal — it latches at the
+  // highest observed value and stays visible (motion removed, information
+  // kept) instead of vanishing. This replaces the MOR-1233-era removal pin
+  // above (peakSegs forced to smoother.value on every update, so the gap
+  // that gates `showPeak` was always 0).
+  it('KILL: holds the peak marker statically after a value drop, instead of vanishing (MOR-1252 static hold)', () => {
     const { restore } = mockReducedMotion(true);
     try {
       const { target, state } = mountReactive({ value: 20 });
       flushSync();
-      // Even at a high value, no held peak line should linger: the peak
-      // tracks the (instantly-snapped) bar value directly under reduced
-      // motion, so peakSegs === smoother.value at all times.
+      // At mount the peak is freshly captured at the current value — no gap
+      // yet, so no marker (unchanged from before).
       expect(peakLineCount(target)).toBe(0);
+
+      // A drop must LATCH the prior peak, not erase it: the marker appears
+      // and holds at the old high-water mark rather than tracking the bar
+      // down to 0. A mutant reverting to the old
+      // `peakSegs = smoother.value` behavior collapses the gap to 0 and
+      // this assertion fails.
+      state.value = 0;
+      flushSync();
+      expect(peakLineCount(target)).toBe(1);
+    } finally {
+      restore();
+    }
+  });
+
+  it('KILL: does not move the held peak marker when fed a further-lower value (true static hold, not a slow follow)', () => {
+    const { restore } = mockReducedMotion(true);
+    try {
+      const { target, state } = mountReactive({ value: 20 });
+      flushSync();
 
       state.value = 0;
       flushSync();
-      expect(peakLineCount(target)).toBe(0);
+      const firstLine = target.querySelector('line[stroke-width="2"]');
+      const xAfterFirstDrop = firstLine?.getAttribute('x1');
+      expect(xAfterFirstDrop).toBeTruthy();
+
+      // A further, even-lower value within the same hold window must NOT
+      // move the latch — a mutant that keeps recomputing the peak as some
+      // function of the live value (rather than truly holding it) would
+      // shift the marker here.
+      state.value = -30;
+      flushSync();
+      const secondLine = target.querySelector('line[stroke-width="2"]');
+      expect(secondLine?.getAttribute('x1')).toBe(xAfterFirstDrop);
+    } finally {
+      restore();
+    }
+  });
+
+  it('KILL: resets the held peak instantly (no glide, no scheduled frames) once the hold window elapses', () => {
+    const { restore } = mockReducedMotion(true);
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    try {
+      const { target, state } = mountReactive({ value: 20 });
+      flushSync();
+
+      state.value = 0;
+      flushSync();
+      expect(peakLineCount(target)).toBe(1);
+      rafSpy.mockClear();
+
+      // Advance well past the 1s hold window with NO new sample arriving.
+      // The static-hold design is event-driven (computed on the next real
+      // update), not a ticking reset — nothing should fire on its own, and
+      // no rAF/interval should ever be scheduled under reduced motion.
+      vi.advanceTimersByTime(1500);
+      expect(peakLineCount(target)).toBe(1); // still held — no timer reset it
+      expect(rafSpy).not.toHaveBeenCalled();
+
+      // The next genuine sample after expiry resets in a single synchronous
+      // jump: the marker collapses back onto the live bar immediately
+      // (peakSegs re-seats to the new current value), with no intermediate
+      // decaying frame ever rendered.
+      state.value = -20; // distinct from the previous value, still well below the old peak
+      flushSync();
+      expect(peakLineCount(target)).toBe(0); // reset landed instantly
+      expect(rafSpy).not.toHaveBeenCalled(); // reset was computed, not animated
+    } finally {
+      vi.useRealTimers();
+      restore();
+    }
+  });
+
+  // J2 (verifier finding, MOR-1252 review): the reduce branch reads AND
+  // writes peakSegs/peakTime, so without untrack() it depends on its own
+  // writes and self-invalidates — it only converged incidentally (the
+  // re-seat is idempotent and `||` short-circuits). The verifier's Z5
+  // mutant (a step-glide reset instead of an instant jump) demonstrated
+  // ~140 synchronous effect passes inside a single flush before landing on
+  // the same end state, which is why a *bound* on this effect's pass count
+  // is the cheap regression pin — not just its converged output.
+  //
+  // `performance.now()` is called only from this effect while reduced
+  // motion holds (the smoother's own rAF-driven call site never runs under
+  // reduce, and the non-reduce branch is dead code on this path), so its
+  // call count is a precise, direct proxy for how many times the effect
+  // body actually executed for one external update.
+  //
+  // A drop (current < peakSegs, within the hold window) never writes, so it
+  // cannot discriminate a missing untrack() — measured empirically at
+  // exactly 1 call with or without the wrap, since nothing invalidates a
+  // dependency that was never written. A RISE (current >= peakSegs, the
+  // write-back path) is what discriminates: measured empirically at
+  // exactly 1 call with untrack() correctly scoping the read/write, vs 2
+  // without it (the effect re-runs once more after writing peakSegs to a
+  // genuinely new value, before the idempotent second pass settles) —
+  // proving this effect's dependency set no longer includes its own
+  // writes.
+  it('KILL J2: the reduce-branch peak effect does not self-invalidate on a new-peak write (bounded performance.now() calls)', () => {
+    const { restore } = mockReducedMotion(true);
+    const nowSpy = vi.spyOn(performance, 'now');
+    try {
+      const { state } = mountReactive({ value: 20 });
+      flushSync();
+      nowSpy.mockClear();
+
+      // Drop: no write occurs (current < peakSegs, hold window not
+      // expired) — sanity check that this path stays a single read, not a
+      // kill signal on its own.
+      state.value = 0;
+      flushSync();
+      expect(nowSpy.mock.calls.length).toBe(1);
+
+      // Rise: current >= peakSegs, so this DOES write peakSegs/peakTime —
+      // the actual kill signal. Exactly 1 call proves the effect ran
+      // exactly once; a missing untrack() measures 2 (see comment above).
+      nowSpy.mockClear();
+      state.value = 40;
+      flushSync();
+      expect(nowSpy.mock.calls.length).toBe(1);
     } finally {
       restore();
     }

--- a/frontend/src/components-v2/panels/MetersDockPanel.svelte
+++ b/frontend/src/components-v2/panels/MetersDockPanel.svelte
@@ -65,6 +65,9 @@
     label: string;
     display: string;
     fillPct: number;
+    // MOR-1252: position of the held peak marker, independent of `fillPct`
+    // under reduced motion (see `displayRaw` below). Undefined = no marker.
+    peakFillPct?: number;
     fill: string;
     track: string;
     relevant: boolean;
@@ -121,30 +124,46 @@
     return peakHoldDisplay(peaks[key], liveRaw, now, PEAK_DECAY_MS);
   }
 
+  // MOR-1252: the NUMBER (and, coupled to it, the bar FILL) always render
+  // the raw live sample under reduced motion — never the held/decaying
+  // value — so freezing the peak marker never freezes the readout. Under
+  // full motion this is unchanged: both still derive from the held+decaying
+  // raw value (MOR-498/1249 ballistics stand).
+  function displayRaw(key: PeakKey, liveRaw: number): number {
+    return prefersReducedMotion() ? liveRaw : heldRaw(key, liveRaw);
+  }
+
+  // MOR-1252: fill-% position for the peak MARKER. Under full motion this
+  // matches `fillPct` exactly (the marker rides the held/decaying bar tip,
+  // unchanged from MOR-498/1249). Under reduced motion it instead reflects
+  // the STATIC latch (`peaks[key].latchedPeak`), independent of the live
+  // `raw` driving the number/fill — undefined (no marker) while unlatched.
+  function peakFillPctFor(
+    key: PeakKey,
+    raw: number,
+    levelFn: (raw: number) => number,
+  ): number | undefined {
+    const peakState = peaks[key];
+    if (peakState === undefined) return undefined;
+    return levelFn(prefersReducedMotion() ? peakState.latchedPeak : raw) * 100;
+  }
+
   // A 100ms interval drives both the decay and the latch from fresh
   // prop samples. Driving everything off a timer (not a reactive $effect)
   // avoids the read-then-write cycle on `peaks` that Svelte 5 flags.
   //
-  // MOR-1249: mirrors the MOR-1233 fix already shipped for LinearSMeter's
+  // MOR-1249/MOR-1252: mirrors the MOR-1233 fix shipped for LinearSMeter's
   // own rAF peak-hold loop — under `prefers-reduced-motion` there is no
-  // hold-then-decay animation, so the interval is not scheduled at all (no
-  // ticks) and any already-latched peak is cleared. With `peaks[key]`
-  // undefined, `heldRaw()` (peakHoldDisplay with state=undefined) falls
-  // through to the live raw sample every render, so the NUMBER and the bar
-  // FILL track raw input with zero glide — matching "snap, never freeze".
-  //
-  // Clearing the latch also stops the peak MARKER from rendering while
-  // reduced, because its render gate is `peaks[tile.key] !== undefined`
-  // (latch existence) — unlike LinearSMeter's `showPeak = peakSegs -
-  // smoother.value > 0.3` (a value comparison). That means the marker's
-  // disappearance here is a deliberate choice, mirroring the removal
-  // MOR-1233 already shipped for LinearSMeter, not an unavoidable
-  // consequence of the snap fix itself — a gate keyed on `tile.fillPct`
-  // instead of latch existence could keep the marker visible at the live
-  // position with the identical zero-glide motion profile. Provisional
-  // pending the MOR-1252 owner decision (which now explicitly names
-  // MetersDockPanel alongside LinearSMeter) on whether peak indicators
-  // should render at all, or hold statically, under reduced motion.
+  // hold-then-decay animation, so this interval is not scheduled at all (no
+  // ticks). Unlike the interim MOR-1249 fix, the latch itself is NOT
+  // cleared here: per the MOR-1252 owner decision the peak MARKER is a
+  // static hold (latch at the highest observed value, instant reset on
+  // expiry) while the NUMBER/FILL stay live via `displayRaw` above. The
+  // reduced-motion branch below is kept only for the ticking
+  // interval's own start/stop lifecycle; the latch's static-hold semantics
+  // are owned by the prop-reactive effect further down (no timer needed —
+  // see meter-utils.ts's `updatePeakHold`, which already holds statically
+  // and re-seats instantly on expiry rather than gliding).
   //
   // Reacts to the OS preference flipping mid-session in both directions
   // (fix cycle 1 precedent: deciding once at mount is not enough).
@@ -163,18 +182,7 @@
       }
     }
 
-    function snapPeaks() {
-      untrack(() => {
-        if (peaks.po !== undefined) peaks.po = undefined;
-        if (peaks.swr !== undefined) peaks.swr = undefined;
-        if (peaks.alc !== undefined) peaks.alc = undefined;
-        if (peaks.id !== undefined) peaks.id = undefined;
-      });
-    }
-
-    if (prefersReducedMotion()) {
-      snapPeaks();
-    } else {
+    if (!prefersReducedMotion()) {
       untrack(() => stepAllPeaks());
       startTicking();
     }
@@ -182,7 +190,6 @@
     const unsubscribe = onReducedMotionChange((reduced) => {
       if (reduced) {
         stopTicking();
-        snapPeaks();
       } else if (!intervalId) {
         untrack(() => stepAllPeaks());
         startTicking();
@@ -193,6 +200,29 @@
       stopTicking();
       unsubscribe();
     };
+  });
+
+  // MOR-1252: keeps the static-hold latch fresh under reduced motion. This
+  // is ordinary prop-reactive Svelte tracking — it re-runs only when a raw
+  // meter value actually changes (a genuine data update) — not a scheduled
+  // loop, so it does not reintroduce the animation prefers-reduced-motion
+  // disables. `updatePeakHold` (see meter-utils.ts) already implements
+  // exactly the desired semantics: hold the latch unchanged while within
+  // the decay window, or re-seat it to the current sample (a single jump,
+  // no glide) once the window has elapsed.
+  $effect(() => {
+    const po = powerMeter;
+    const swr = swrMeter;
+    const alc = alcMeter;
+    const id = idMeter;
+    if (!prefersReducedMotion()) return;
+    const t = Date.now();
+    untrack(() => {
+      steppeak('po', po, t);
+      steppeak('swr', swr, t);
+      steppeak('alc', alc, t);
+      steppeak('id', id, t);
+    });
   });
 
   function resetPeak(key: PeakKey) {
@@ -214,24 +244,26 @@
     // 100 ms tick as the held peak decays.
     void now;
     if (powerMeter !== undefined) {
-      const raw = heldRaw('po', powerMeter);
+      const raw = displayRaw('po', powerMeter);
       out.push({
         key: 'po',
         label: 'Po',
         display: formatPowerWatts(raw),
         fillPct: normalizePower(raw) * 100,
+        peakFillPct: peakFillPctFor('po', raw, normalizePower),
         fill: 'var(--v2-meter-power-fill)',
         track: 'var(--v2-meter-power-track)',
         relevant: txActive,
       });
     }
     if (swrMeter !== undefined) {
-      const raw = heldRaw('swr', swrMeter);
+      const raw = displayRaw('swr', swrMeter);
       out.push({
         key: 'swr',
         label: 'SWR',
         display: formatSwr(raw),
         fillPct: swrLevel(raw) * 100,
+        peakFillPct: peakFillPctFor('swr', raw, swrLevel),
         fill: 'var(--v2-meter-swr-fill)',
         track: 'var(--v2-meter-swr-track)',
         relevant: txActive,
@@ -239,12 +271,13 @@
       });
     }
     if (alcMeter !== undefined) {
-      const raw = heldRaw('alc', alcMeter);
+      const raw = displayRaw('alc', alcMeter);
       out.push({
         key: 'alc',
         label: 'ALC',
         display: formatAlc(raw),
         fillPct: alcLevel(raw) * 100,
+        peakFillPct: peakFillPctFor('alc', raw, alcLevel),
         fill: 'var(--v2-meter-alc-fill)',
         track: 'var(--v2-meter-alc-track)',
         relevant: txActive,
@@ -252,12 +285,13 @@
       });
     }
     if (idMeter !== undefined) {
-      const raw = heldRaw('id', idMeter);
+      const raw = displayRaw('id', idMeter);
       out.push({
         key: 'id',
         label: 'Id',
         display: formatAmps(raw),
         fillPct: idLevel(raw) * 100,
+        peakFillPct: peakFillPctFor('id', raw, idLevel),
         fill: 'var(--v2-meter-id-fill)',
         track: 'var(--v2-meter-id-track)',
         relevant: txActive,
@@ -303,10 +337,11 @@
 
   // Issue #938 — per-tile rAF-driven bar smoothing. Smoothers are keyed by
   // tile.key and reused across renders so the bar carries fractional state
-  // between updates. Peak-hold (`peakPct`) and digit text (`tile.display`)
-  // continue to read raw props; only the bar-fill width is smoothed. Each
-  // smoother is seeded with the tile's current fillPct on first creation so
-  // the initial synchronous render matches the raw target (no flash from 0).
+  // between updates. Peak-hold (`peakFillPct`) and digit text
+  // (`tile.display`) continue to read raw props; only the bar-fill width is
+  // smoothed. Each smoother is seeded with the tile's current fillPct on
+  // first creation so the initial synchronous render matches the raw target
+  // (no flash from 0).
   type Smoother = ReturnType<typeof createSmoother>;
   const smoothers = new Map<Tile['key'], Smoother>();
 
@@ -353,12 +388,6 @@
 
   <div class="dock-grid">
     {#each tiles as tile (tile.key)}
-      {@const peakPct =
-        tile.key === 'po' || tile.key === 'swr' || tile.key === 'alc' || tile.key === 'id'
-          ? peaks[tile.key] !== undefined
-            ? tile.fillPct
-            : undefined
-          : undefined}
       {@const displayPct = smoothers.get(tile.key)?.value ?? tile.fillPct}
       <div
         class="dock-tile"
@@ -388,11 +417,11 @@
             style:width={`${Math.max(0, Math.min(100, displayPct))}%`}
             style:background={tile.fill}
           ></div>
-          {#if peakPct !== undefined && tile.relevant}
+          {#if tile.peakFillPct !== undefined && tile.relevant}
             <div
               class="tile-bar-peak"
               data-testid="peak-marker"
-              style:left={`${Math.max(0, Math.min(100, peakPct))}%`}
+              style:left={`${Math.max(0, Math.min(100, tile.peakFillPct))}%`}
             ></div>
           {/if}
         </div>

--- a/frontend/src/components-v2/panels/__tests__/MetersDockPanel.reduced-motion.svelte.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/MetersDockPanel.reduced-motion.svelte.test.ts
@@ -120,6 +120,18 @@ function peakMarkerCount(t: HTMLElement): number {
   return t.querySelectorAll('[data-testid="peak-marker"]').length;
 }
 
+function peakMarkerLeft(t: HTMLElement, meterKey = 'po'): string | null {
+  const el = t.querySelector(
+    `[data-meter="${meterKey}"] [data-testid="peak-marker"]`,
+  ) as HTMLElement | null;
+  return el?.style.left ?? null;
+}
+
+function tileBarFillWidth(t: HTMLElement, meterKey = 'po'): string | null {
+  const el = t.querySelector(`[data-meter="${meterKey}"] .tile-bar-fill`) as HTMLElement | null;
+  return el?.style.width ?? null;
+}
+
 describe('MetersDockPanel — prefers-reduced-motion (MOR-1249)', () => {
   it('schedules no decay interval when reduced motion is preferred at mount', () => {
     const { restore } = mockReducedMotion(true);
@@ -161,18 +173,77 @@ describe('MetersDockPanel — prefers-reduced-motion (MOR-1249)', () => {
     }
   });
 
-  // Removal semantics — provisional pending MOR-1252: the marker is gated
-  // on latch existence (`peaks[tile.key] !== undefined`), not on a value
-  // comparison, so its disappearance here is a deliberate implementation
-  // choice (mirroring LinearSMeter's shipped removal), not an unavoidable
-  // consequence of the snap fix. This test pins the CURRENT behavior; it
-  // is expected to change if MOR-1252 rules for a static/visible hold
-  // instead of removal.
-  it('renders no peak marker under reduced motion (removal semantics — provisional pending MOR-1252)', () => {
+  // MOR-1252 owner decision (2026-08-04, option b): the peak marker is a
+  // STATIC HOLD under reduced motion, not a removal — it latches at the
+  // highest observed value and stays visible while the NUMBER (pinned live
+  // above) keeps tracking the raw sample. This replaces the MOR-1249-era
+  // removal pin (`snapPeaks()` used to clear `peaks[key]` outright, which
+  // gated the marker's render condition to always-false under reduce).
+  it('KILL: renders and holds the peak marker under reduced motion, decoupled from the live NUMBER (MOR-1252 static hold)', () => {
     const { restore } = mockReducedMotion(true);
     try {
-      const { t } = mountReactive({ powerMeter: 212, txActive: true });
-      expect(peakMarkerCount(t)).toBe(0);
+      const { t, state } = mountReactive({ powerMeter: 212, txActive: true });
+      expect(peakMarkerCount(t)).toBe(1);
+
+      // A drop must NOT move or remove the held marker — only the NUMBER
+      // (already pinned live above) reflects the new sample. A mutant that
+      // reverts to clearing `peaks[key]` under reduce (the old removal
+      // fix) makes the marker vanish here.
+      state.powerMeter = 5;
+      flushSync();
+      expect(peakMarkerCount(t)).toBe(1);
+      expect(poNumber(t)).toBeLessThan(10); // number stays live, not frozen
+    } finally {
+      restore();
+    }
+  });
+
+  it('KILL: does not move the held peak marker when fed a further-lower value (true static hold)', () => {
+    const { restore } = mockReducedMotion(true);
+    try {
+      const { t, state } = mountReactive({ powerMeter: 212, txActive: true });
+      const leftAfterMount = peakMarkerLeft(t);
+      expect(leftAfterMount).toBeTruthy();
+
+      state.powerMeter = 5;
+      flushSync();
+      expect(peakMarkerLeft(t)).toBe(leftAfterMount); // unchanged — latch held
+
+      state.powerMeter = 1;
+      flushSync();
+      expect(peakMarkerLeft(t)).toBe(leftAfterMount); // still unchanged
+    } finally {
+      restore();
+    }
+  });
+
+  it('KILL: resets the held peak instantly (no glide) once the hold window elapses, with no interval ever scheduled', () => {
+    const { restore } = mockReducedMotion(true);
+    try {
+      const { t, state } = mountReactive({ powerMeter: 212, txActive: true });
+      const highLeft = peakMarkerLeft(t);
+      expect(highLeft).toBeTruthy();
+
+      state.powerMeter = 5;
+      flushSync();
+      expect(peakMarkerLeft(t)).toBe(highLeft); // held
+
+      // Advance well past PEAK_DECAY_MS (1500ms) with no new sample — the
+      // static-hold design is event-driven (computed on the next real
+      // update), not a ticking reset: nothing should fire on its own.
+      vi.advanceTimersByTime(2000);
+      expect(netActiveIntervals()).toBe(0);
+      expect(peakMarkerLeft(t)).toBe(highLeft); // still held — no timer reset it
+
+      // The next genuine sample after expiry resets in a single synchronous
+      // jump, landing exactly at the fresh sample's own live position (not
+      // decayed/interpolated toward it) — proving the reset is a re-seat,
+      // not a partial glide.
+      state.powerMeter = 3;
+      flushSync();
+      const resetLeft = peakMarkerLeft(t);
+      expect(resetLeft).not.toBe(highLeft);
+      expect(parseFloat(resetLeft ?? '')).toBeCloseTo(parseFloat(tileBarFillWidth(t) ?? ''), 5);
     } finally {
       restore();
     }


### PR DESCRIPTION
Closes MOR-1252 (owner decision recorded on the ticket: option (b) static hold; must precede MOR-1087's evidence capture).

## What

Under `prefers-reduced-motion`, peak indicators now HOLD statically instead of disappearing: LinearSMeter latches at the highest observed value with a single-step (un-animated) re-seat after the hold window; MetersDockPanel holds the MARKER while the numeric readout and fill stay live (a frozen number was explicitly not wanted). No rAF and no interval are scheduled under reduce; the ballistics snap semantics of MOR-1233/1249 stand unchanged. **23 net production LOC** (frozen formula), 2 production files.

## Provenance

- Independent adversarial verification (opus — the verifier that owns this domain's probe harness across MOR-1233/1249/1251): **PASS**, 5 findings, none blocking. Its own DOM probes: marker holds across two drops and latches up on a rise; reset is a genuine single step (5s idle changes nothing, next sample re-seats, zero frames); dock marker pinned at 100% while the number goes 100→2→1; the new prop-reactive effect is genuinely inert (30s of fake time leaves innerHTML byte-identical); both-direction preference flips clean ([1,0,1,0,1] interval sequence, listeners 2→0); four original mutants from the three predecessor tickets still killed; smoothing.svelte.ts byte-identical to base.
- J2 delta (self-invalidating $effect fragility — verifier demonstrated ~140 synchronous passes on a mutant) fixed with `untrack()` per the MetersDockPanel pattern and CONFIRMED: one data update now costs exactly one effect pass; the previously-surviving step-glide mutant now dies on a named pin.
- Open owner question J5 (LinearSMeter 1000ms vs MetersDockPanel 1500ms hold durations) queued for the next owner batch — deliberately NOT changed here.

Failing-file set identical to baseline (environmental Node-26 `localStorage`; CI is the gate); lint/check/boundaries clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)