### PR TITLE
feat(MOR-1264): optional fact groups on the frozen RadioViewModel (vocabulary slice S0)

### DIFF
--- a/frontend/src/semantic/__tests__/optional-fact-groups.test.ts
+++ b/frontend/src/semantic/__tests__/optional-fact-groups.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { optionalGroup } from '../radio-view-model';
+import { record, exactKeys, str } from '../validator-primitives';
+
+/**
+ * MOR-1264 slice 0: validator support for optional fact groups. No group is
+ * actually added to `RadioViewModel` in this slice (`txAux` is MOR-1244) —
+ * this harness exercises the mechanism in isolation, using a synthetic,
+ * test-only group built from the same primitives
+ * (`record`/`exactKeys`/`str` from `validator-primitives.ts`, `optionalGroup`
+ * from `radio-view-model.ts`) a real group validator will use. See
+ * `radio-view-model.ts`'s `optionalGroup` doc comment for the exact one-liner
+ * a future slice writes.
+ */
+interface SyntheticGroupViewModel {
+  widget: string;
+}
+
+function validateSyntheticGroup(value: unknown, path: string): SyntheticGroupViewModel {
+  const v = record(value, path);
+  exactKeys(v, ['widget'], path);
+  return { widget: str(v.widget, `${path}.widget`) };
+}
+
+interface SyntheticModel {
+  required: string;
+  group?: SyntheticGroupViewModel;
+}
+
+function validateSyntheticModel(value: unknown): SyntheticModel {
+  const v = record(value, '$');
+  exactKeys(v, ['required', 'group'], '$');
+  return {
+    required: str(v.required, '$.required'),
+    group: optionalGroup(v.group, '$.group', validateSyntheticGroup),
+  };
+}
+
+describe('optional fact groups (MOR-1264 mechanism)', () => {
+  it('still throws on an unknown extra top-level key — the exactKeys discipline is not weakened', () => {
+    expect(() => validateSyntheticModel({ required: 'x', bogus: 1 })).toThrow(TypeError);
+  });
+
+  it('passes validation when the optional group is entirely absent — the family is structurally unavailable', () => {
+    const model = validateSyntheticModel({ required: 'x' });
+    expect(model).toEqual({ required: 'x', group: undefined });
+    expect(() => validateSyntheticModel({ required: 'x' })).not.toThrow();
+  });
+
+  it('throws with a precise error path when a present optional group is malformed', () => {
+    expect(() => validateSyntheticModel({ required: 'x', group: { widget: 42 } }))
+      .toThrow(/\$\.group\.widget/);
+  });
+
+  // ── N1 (adversarial verification, mor-1264-verify.md §7): pin the
+  // absent-vs-malformed boundary. `optionalGroup` treats ONLY `undefined` as
+  // absent — JSON has no `undefined`, so a backend emitting `"txAux": null`
+  // must be rejected as malformed, not silently degraded to "structurally
+  // unavailable". These two cases already throw in shipped code; without a
+  // pin, a future `=== undefined` → `== null` slip (or an "empty object
+  // means absent" slip) would go undetected because every existing test
+  // uses either a fully-omitted key or a non-empty malformed value.
+  it('rejects an explicit null optional group — null is not absent (JSON has no undefined)', () => {
+    expect(() => validateSyntheticModel({ required: 'x', group: null })).toThrow(TypeError);
+  });
+
+  it('rejects an explicit empty-object optional group — {} is present, not absent, and must satisfy the group\'s own shape checks', () => {
+    expect(() => validateSyntheticModel({ required: 'x', group: {} })).toThrow(TypeError);
+  });
+});

--- a/frontend/src/semantic/radio-view-model.ts
+++ b/frontend/src/semantic/radio-view-model.ts
@@ -17,6 +17,7 @@
  */
 import type { VfoScheme } from '$lib/types/capabilities';
 import type { FrequencyPermit } from '$lib/utils/tx-permit';
+import { invalid, record, exactKeys, str } from './validator-primitives';
 
 export type ReceiverId = 'MAIN' | 'SUB';
 export type VfoSlotId = 'A' | 'B';
@@ -110,27 +111,12 @@ const DISABLED_REASON_CODES: readonly DisabledReasonCode[] = [
   'capability-unavailable', 'field-not-observed', 'tx-target-unknown', 'out-of-band',
 ];
 
-function invalid(path: string, expected: string): never {
-  throw new TypeError(`Invalid radio view model at ${path}: expected ${expected}`);
-}
-function record(value: unknown, path: string): Record<string, unknown> {
-  if (typeof value !== 'object' || value === null || Array.isArray(value)) invalid(path, 'an object');
-  return value as Record<string, unknown>;
-}
-function exactKeys(value: Record<string, unknown>, keys: readonly string[], path: string): void {
-  const extra = Object.keys(value).filter((k) => !keys.includes(k));
-  if (extra.length > 0) invalid(path, `only [${keys.join(', ')}] (found extra: ${extra.join(', ')})`);
-}
 function oneOf<T>(value: unknown, allowed: readonly T[], path: string): T {
   if (!allowed.includes(value as T)) invalid(path, allowed.join(' | '));
   return value as T;
 }
 function bool(value: unknown, path: string): boolean {
   if (typeof value !== 'boolean') invalid(path, 'a boolean');
-  return value;
-}
-function str(value: unknown, path: string): string {
-  if (typeof value !== 'string') invalid(path, 'a string');
   return value;
 }
 function nullableNumber(value: unknown, path: string): number | null {
@@ -142,6 +128,32 @@ function nullableNumber(value: unknown, path: string): number | null {
 function nullableString(value: unknown, path: string): string | null {
   if (value !== null && typeof value !== 'string') invalid(path, 'a string or null');
   return value as string | null;
+}
+
+/**
+ * Declares a fact group as optional (MOR-1264, decision (b) of the MOR-1262
+ * decomposition's slice 0): present ⇒ validated strictly by `validate` (the
+ * group runs its own `exactKeys`/shape checks, unchanged); absent (`value`
+ * is `undefined`) ⇒ the field stays `undefined` on the returned model and
+ * the family is structurally unavailable — the MOR-988 §11.3 degrade-to-
+ * unknown doctrine applied at the group level, not a new relaxation.
+ *
+ * A group is optional *only* because its key is listed in the containing
+ * `exactKeys(...)` allow-list alongside the required keys — `exactKeys`
+ * itself is untouched, so a key absent from that list is still rejected as
+ * an extra. This is what keeps "optional" bounded rather than "anything
+ * goes". A future slice declares and reads its group with one line each,
+ * e.g. (MOR-1244, `txAux`) — `validateTxAux` built from the same
+ * `record`/`exactKeys`/`str` imported from `./validator-primitives`:
+ *   exactKeys(v, [...requiredKeys, 'txAux'], '$');
+ *   txAux: optionalGroup(v.txAux, '$.txAux', validateTxAux),
+ */
+export function optionalGroup<T>(
+  value: unknown,
+  path: string,
+  validate: (value: unknown, path: string) => T,
+): T | undefined {
+  return value === undefined ? undefined : validate(value, path);
 }
 
 function validateVfoSlot(value: unknown, path: string): VfoSlot {

--- a/frontend/src/semantic/validator-primitives.ts
+++ b/frontend/src/semantic/validator-primitives.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared validator primitives for the semantic contract layer.
+ *
+ * MOR-1264 export-seam narrowing: the adversarial-verification ruling on
+ * slice S0's mutation report (§3/N2) found `record`/`exactKeys`/`str`
+ * exported raw from `radio-view-model.ts`, justified only by that slice's
+ * test harness. Moved here — a named seam, not an incidental one — before
+ * the remaining MOR-1262 vocabulary families copy the shape. Every future
+ * per-family group validator (MOR-1244's `validateTxAux`, …) imports these
+ * the same way `radio-view-model.ts`'s own group validators
+ * (`validateVfoSlot`, `validateActiveRx`, …) do. `radio-view-model.ts`'s own
+ * public surface goes back to types + `validateRadioViewModel` +
+ * `optionalGroup`.
+ *
+ * Bodies are byte-identical to their pre-move originals — only their file
+ * (and therefore their exposure) changed.
+ */
+export function invalid(path: string, expected: string): never {
+  throw new TypeError(`Invalid radio view model at ${path}: expected ${expected}`);
+}
+export function record(value: unknown, path: string): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) invalid(path, 'an object');
+  return value as Record<string, unknown>;
+}
+export function exactKeys(value: Record<string, unknown>, keys: readonly string[], path: string): void {
+  const extra = Object.keys(value).filter((k) => !keys.includes(k));
+  if (extra.length > 0) invalid(path, `only [${keys.join(', ')}] (found extra: ${extra.join(', ')})`);
+}
+export function str(value: unknown, path: string): string {
+  if (typeof value !== 'string') invalid(path, 'a string');
+  return value;
+}


### PR DESCRIPTION
Closes MOR-1264 — contract slice S0 of the MOR-1262 vocabulary program (unblocks the entire 23-slice A/B queue).

## What

The optional-fact-group mechanism: a group key may be optional (`readonly txAux?: ...` pattern); absent ⇒ the family is structurally unavailable (the MOR-988 §11.3 degrade-to-unknown doctrine at group level); present ⇒ validated strictly with group-level exactKeys; explicit `null` and present-but-empty `{}` both throw. Validator primitives relocated byte-identical into `semantic/validator-primitives.ts` — the final seam shape the 13 vocabulary families copy. **8 net production LOC** (frozen formula; the relocation lines are byte-identical moves, not new logic). No real group added (txAux is MOR-1244).

## Provenance

- Independent adversarial verification (opus — the verifier that measured the exactKeys discipline at MOR-1256): **PASS**. Every evasion of its own design fails correctly (unknown extra key alongside a valid group; null/number/string/boolean/array as the group; extra key inside a group; missing required key; typo of a required name). Its MOR-1256-era contract pins still bite; mutating exactKeys itself kills 5 tests incl. the MOR-988-era anti-smuggling pins.
- Delta 1 (two surviving mutants pinned: null-as-absent and {}-as-absent — the likeliest 3-line-helper slip, and JSON has no undefined; export seam narrowed to the prescribed validator-primitives module) CONFIRMED by the same verifier: relocation proven byte-identical function-by-function, V1/V2 mutants die on named pins, exactKeys probes throw with identical paths post-move.
- Standing design notes for slice 1 (recorded in the verify report): declared-but-unread drift; the shared allow-list literal as the A-queue merge point.

semantic/ isolation 182/182; failing-file set identical to baseline (environmental Node-26 `localStorage`; CI is the gate); lint/check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)