### PR TITLE
feat(MOR-1266): register a desktop-v2 layout manifest (v2-rework slice S1)

### DIFF
--- a/frontend/src/presentation/layouts/__tests__/cockpit-topology-adaptation.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/cockpit-topology-adaptation.test.ts
@@ -24,7 +24,8 @@ import {
 // the fast pool's `isolate: false` it would leak that registration into
 // sibling files (the MOR-1092 lesson, restated on MOR-1067).
 import {
-  dualReceiverCockpitLayout, lcdCockpitLayout, lcdScopeLayout, mobileLayout, sdrTestLayout,
+  desktopV2Layout, dualReceiverCockpitLayout, lcdCockpitLayout, lcdScopeLayout, mobileLayout,
+  sdrTestLayout,
 } from '../declarations';
 import { forReceiver, receiversOf } from '../../../components-v2/wiring/dual-receiver-strips';
 import { topologyFixtures, withAudioOnlyScope } from '../../../semantic/fixtures/topologies';
@@ -111,8 +112,12 @@ describe('audio-only scope survives the cockpit slicing (scope=false + audioFft=
 // not imported: `skins/registry.ts` pulls in the layout preference store,
 // which touches `localStorage` at module scope.
 describe('F8 — every registered layout manifest names a loadable skin', () => {
+  // MOR-1266 adds desktop-v2 to the generalized set — the rule this ticket's
+  // acceptance criteria requires to stay green for every newly registered
+  // manifest, not just the ones that existed when F8 was written.
   const REAL_LAYOUTS: readonly LayoutManifest[] = [
     sdrTestLayout, dualReceiverCockpitLayout, lcdCockpitLayout, lcdScopeLayout, mobileLayout,
+    desktopV2Layout,
   ];
   const source = readFileSync('src/skins/registry.ts', 'utf8');
   const loadersStart = source.indexOf('const SKIN_LOADERS');

--- a/frontend/src/presentation/layouts/__tests__/desktop-v2-registration.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/desktop-v2-registration.test.ts
@@ -1,0 +1,141 @@
+/**
+ * MOR-1266 — the `desktop-v2` presentation entrypoint's v1 layout manifest,
+ * registered and resolved through the REAL registry (MOR-1066), mirroring
+ * the shape `lcd-registration.test.ts` (MOR-1092) and
+ * `mobile-registration.test.ts` (MOR-1094) use for their families.
+ *
+ * Every claim below is read back out of the shared registry rather than off
+ * the exported object, so a manifest that is written but never registered
+ * fails here. Each test's doc line names the mutation it exists to kill.
+ */
+import { existsSync, readFileSync } from 'node:fs';
+import { describe, it, expect } from 'vitest';
+import {
+  getLayout, resolveLayoutForTopology, resolveLayoutForViewport,
+  TOPOLOGY_CLASSES,
+} from '../contract';
+// Barrel-only, never '../desktop-declarations' directly — the M7 lesson
+// (registry.test.ts's "dual-receiver-cockpit registration barrel proof",
+// restated on every family since): a direct manifest import fires
+// `registerLayout` from THIS file, masking a `declarations.ts` that no
+// longer wires desktop-v2 into the app, and under the fast pool's
+// `isolate: false` it would leak the registration into sibling files.
+import { desktopV2Layout } from '../declarations';
+
+/** iPhone-class portrait — the viewport the LCD family fails arithmetically. */
+const PORTRAIT_MOBILE = { width: 390, height: 844 };
+
+describe('the desktop-v2 entrypoint is registered in the real registry', () => {
+  // Kills: desktop-declarations.ts defining the manifest but never calling
+  // registerLayout — every resolution below would then read undefined.
+  it('registers "desktop-v2" under its stable entrypoint id', () => {
+    expect(getLayout('desktop-v2')).toBe(desktopV2Layout);
+    expect(desktopV2Layout.id).toBe('desktop-v2');
+  });
+
+  // Kills: a manifest id that drifts from the SkinId the App actually loads,
+  // or from the id `resolveSkinId` hands back for the standard/auto
+  // preference. The manifest is only an entrypoint declaration if all three
+  // agree.
+  it('uses the same id the skin registry loads the desktop-v2 entrypoint under', () => {
+    const source = readFileSync('src/skins/registry.ts', 'utf8');
+    const start = source.indexOf('const SKIN_LOADERS');
+    const loaders = source.slice(start, source.indexOf('};', start));
+    expect(loaders).toContain("'desktop-v2':");
+    expect(source).toContain("if (layoutPreference === 'standard') return 'desktop-v2';");
+    expect(source).toContain('return ctx.hasAnyScope ? \'desktop-v2\' : \'lcd-cockpit\';');
+  });
+
+  // Kills: a manifest that declares no compiled loader at all.
+  it('declares a compiled loader', () => {
+    expect(typeof desktopV2Layout.loader).toBe('function');
+  });
+});
+
+describe('declared zones are a forward declaration, not a DOM claim (MOR-1263 step 1 vs step 2)', () => {
+  // Kills: declaring a surface this manifest does not name, or dropping
+  // either one — the pair the future DOM binding (MOR-1263 step 2) must
+  // still satisfy.
+  it('declares receiver-deck:[vfo] and rx-tx:[rxTx]', () => {
+    expect(desktopV2Layout.zones).toEqual([
+      { id: 'receiver-deck', surfaces: ['vfo'] },
+      { id: 'rx-tx', surfaces: ['rxTx'] },
+    ]);
+    expect([...desktopV2Layout.requiredSemanticSurfaces].sort()).toEqual(['rxTx', 'vfo']);
+  });
+
+  // Kills: silently flipping RadioLayout.svelte's semanticSurfaces gate to
+  // also cover 'desktop-v2' as part of "registering the manifest" — the
+  // ticket's explicit boundary is that the legacy resolution path stays the
+  // live one until a later slice. This reads the actual gate expression, not
+  // a mounted assertion (no DOM tree needed here).
+  it('RadioLayout.svelte does not (yet) gate semanticSurfaces on desktop-v2', () => {
+    const source = readFileSync('src/components-v2/layout/RadioLayout.svelte', 'utf8');
+    expect(source).toContain("let semanticSurfaces = $derived(skinId === 'sdr-test');");
+  });
+});
+
+describe('loader identity — pins the real desktop-v2 entrypoint (verify.md N1)', () => {
+  // Kills: repointing the manifest's OWN `loader` closure at a different,
+  // real, loadable skin (e.g. `SdrTestSkin.svelte`) — the adversarial
+  // verification's surviving mutant (V3). `typeof loader === 'function'`
+  // above and the `skins/registry.ts` reachability check earlier both stay
+  // green under that mutation, because neither ties THIS manifest's loader
+  // to the file it actually names. Read as TEXT — the same idiom as every
+  // other module-specifier pin in this suite — because invoking the loader
+  // would pull in RadioLayout.svelte's full import graph, including
+  // `lib/stores/layout.svelte.ts`'s module-scope `localStorage` read, which
+  // throws outside a DOM environment (why F8 reads `skins/registry.ts` as
+  // text instead of importing it).
+  it('the manifest loader names DesktopSkin.svelte, not a sibling skin entrypoint', () => {
+    const source = readFileSync('src/presentation/layouts/desktop-declarations.ts', 'utf8');
+    const match = source.match(/loader:\s*\(\)\s*=>\s*import\(['"]([^'"]+)['"]\)/);
+    expect(match?.[1]).toBe('../../skins/desktop-v2/DesktopSkin.svelte');
+  });
+
+  // Belt-and-braces: the specifier must resolve to a real file too — guards
+  // against a typo'd path that would only fail at runtime, in the browser,
+  // never in this suite.
+  it('the loader specifier resolves to a real file on disk', () => {
+    expect(existsSync('src/skins/desktop-v2/DesktopSkin.svelte')).toBe(true);
+  });
+});
+
+describe('topology honesty', () => {
+  // Kills: under-declaring the topology set. VfoHeader renders VfoOps
+  // (A/B swap/equal) unconditionally and branches DualVfoDisplay vs a
+  // single-receiver VfoPanel on hasDualReceiver(), so every canonical class
+  // resolves to desktop-v2 itself, never to a fallback (it declares none).
+  it.each(TOPOLOGY_CLASSES)('resolves itself on the %s topology', (topology) => {
+    expect(resolveLayoutForTopology('desktop-v2', topology)?.id).toBe('desktop-v2');
+  });
+});
+
+describe('MOR-1160 sizing axis — desktop-v2 stays fluid, mirroring sdr-test', () => {
+  // Kills: silently switching desktop-v2 onto the fixed-native stage the LCD
+  // family owns, or recording a breakpoint set that disagrees with
+  // sdr-test's declaration for the identical shared RadioLayout stylesheet.
+  it('declares fluid sizing with no breakpoints', () => {
+    expect(desktopV2Layout.stageSizing).toEqual({ mode: 'fluid', responsiveBreakpoints: [] });
+  });
+
+  // Kills: fitsViewport gating a fluid layout on a breakpoint instead of
+  // always fitting (contract: breakpoints are reflow hints, not a hard gate
+  // in v1).
+  it.each([
+    ['desktop', { width: 1440, height: 900 }],
+    ['portrait phone', PORTRAIT_MOBILE],
+  ])('resolves itself on a %s viewport', (_label, viewport) => {
+    expect(resolveLayoutForViewport('desktop-v2', viewport)?.id).toBe('desktop-v2');
+  });
+});
+
+describe('no fallback family', () => {
+  // Kills: adding a fallbackLayoutId that has nothing to do — desktop-v2
+  // supports every canonical topology and fluid sizing never fails a
+  // viewport, so any hop off it would be unreachable and would only mask a
+  // real resolution failure.
+  it('declares no fallback', () => {
+    expect(desktopV2Layout.fallbackLayoutId).toBeNull();
+  });
+});

--- a/frontend/src/presentation/layouts/__tests__/forward-declaration-inventory.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/forward-declaration-inventory.test.ts
@@ -1,0 +1,102 @@
+/**
+ * MOR-1266 pin round (verify.md §1(d)/N2 disposition) — makes the
+ * DOM-backed-vs-forward-declared split explicit and asserted, not just a file
+ * comment on `desktop-declarations.ts`. Every registered manifest's zones
+ * name either (a) a REAL mount some skin unconditionally renders today, or
+ * (b) a target the DOM does not reach yet — today that is `desktop-v2` only
+ * (MOR-1263 §3 "manifest first"; see `desktop-v2-registration.test.ts`).
+ *
+ * This file reads each skin's OWN source as TEXT, never imports it — the
+ * same reason `cockpit-topology-adaptation.test.ts`'s F8 rule and every
+ * other module-specifier pin in this suite do: several of these skins
+ * transitively import `lib/stores/layout.svelte.ts`, whose module-scope
+ * `localStorage` read throws outside a DOM environment.
+ *
+ * The expected forward-declared set below is a LITERAL, not a derived count:
+ * a new manifest that lands still forward-declared must be added to it by
+ * hand (silently landing an undeclared one fails `ALL_MANIFESTS`'s DOM_BACKED
+ * lookup below), and `desktop-v2` gaining a real mount must remove it by hand
+ * (its DOM-backing proof flips to `true`, so the computed set stops matching
+ * the literal and the test fails until the literal is edited down to `[]`).
+ * Each test's doc line names the mutation it exists to kill.
+ */
+import { readFileSync } from 'node:fs';
+import { describe, it, expect } from 'vitest';
+import type { LayoutManifest } from '../contract';
+// Barrel-only — the M7 lesson, restated on every family in this directory:
+// importing a manifest module directly fires `registerLayout` from this file
+// and, under the fast pool's `isolate: false`, leaks the registration into
+// sibling files.
+import {
+  desktopV2Layout, dualReceiverCockpitLayout, lcdCockpitLayout, lcdScopeLayout, mobileLayout,
+  sdrTestLayout,
+} from '../declarations';
+
+/** Every manifest currently registered by the barrel (mirrors F8's `REAL_LAYOUTS`). */
+const ALL_MANIFESTS: readonly LayoutManifest[] = [
+  sdrTestLayout, dualReceiverCockpitLayout, lcdCockpitLayout, lcdScopeLayout, mobileLayout,
+  desktopV2Layout,
+];
+
+/** The set this whole file exists to keep honest — see the header comment. */
+const EXPECTED_FORWARD_DECLARED: readonly string[] = ['desktop-v2'];
+
+const radioLayoutSource = readFileSync('src/components-v2/layout/RadioLayout.svelte', 'utf8');
+const lcdLayoutSource = readFileSync('src/components-v2/layout/LcdLayout.svelte', 'utf8');
+const mobileLayoutSource = readFileSync('src/components-v2/layout/MobileRadioLayout.svelte', 'utf8');
+const cockpitShellSource = readFileSync('src/skins/dual-receiver-cockpit/DualReceiverCockpit.svelte', 'utf8');
+
+/** `sdr-test` and `desktop-v2` share this one conditional gate. */
+const semanticGateExpr = radioLayoutSource.match(/let semanticSurfaces = \$derived\(([^;]*)\);/)?.[1] ?? '';
+
+/**
+ * Per-manifest DOM-backing proof, read off the ACTUAL skin source — never a
+ * hardcoded boolean. `sdr-test` and `desktop-v2` are decided by whether their
+ * id appears inside RadioLayout.svelte's single `semanticSurfaces` gate
+ * expression; the other four each mount `SemanticRadioSurfaces` outright in
+ * their own dedicated shell (verified unconditional — not wrapped in any
+ * `{#if}` — by direct reading, MOR-1266 pin round).
+ */
+const DOM_BACKED: Readonly<Record<string, () => boolean>> = {
+  'sdr-test': () => semanticGateExpr.includes("'sdr-test'"),
+  'desktop-v2': () => semanticGateExpr.includes("'desktop-v2'"),
+  'lcd-cockpit': () => /<SemanticRadioSurfaces\s*\/>/.test(lcdLayoutSource),
+  'lcd-scope': () => /<SemanticRadioSurfaces\s*\/>/.test(lcdLayoutSource),
+  'mobile': () => /<SemanticRadioSurfaces\s*\/>/.test(mobileLayoutSource),
+  'dual-receiver-cockpit': () => /<SemanticRadioSurfaces strips="dual"\s*\/>/.test(cockpitShellSource),
+};
+
+describe('forward-declared vs DOM-backed manifest inventory (verify.md N2)', () => {
+  // Kills: a new manifest landing without a corresponding DOM_BACKED prober
+  // above — it would otherwise be silently absent from the inventory instead
+  // of failing loudly here.
+  it('every registered manifest has an asserted DOM-backing proof', () => {
+    for (const m of ALL_MANIFESTS) {
+      expect(Object.hasOwn(DOM_BACKED, m.id), `no DOM-backing proof registered for "${m.id}"`).toBe(true);
+    }
+  });
+
+  // The actual inventory. Kills BOTH directions of drift: (a) a new
+  // forward-declared manifest landing without this literal being extended to
+  // name it, and (b) desktop-v2 gaining a real mount (RadioLayout's gate
+  // widening — already independently pinned RED by
+  // `desktop-v2-registration.test.ts`'s own copy of this mutation — or
+  // DesktopSkin.svelte switching entrypoints) without this literal shrinking
+  // back to `[]`. Either drift flips the computed set against the literal.
+  it(`the forward-declared set is exactly ${JSON.stringify(EXPECTED_FORWARD_DECLARED)}`, () => {
+    const forwardDeclared = ALL_MANIFESTS
+      .filter((m) => !DOM_BACKED[m.id]())
+      .map((m) => m.id)
+      .sort();
+    expect(forwardDeclared).toEqual([...EXPECTED_FORWARD_DECLARED].sort());
+  });
+
+  // The negative case the positive assertion alone would not distinguish
+  // from "everything is forward-declared" — kills DOM_BACKED probers that
+  // always return false regardless of what they read.
+  it('sdr-test, both LCD variants, mobile and the cockpit are DOM-backed today', () => {
+    for (const id of ['sdr-test', 'lcd-cockpit', 'lcd-scope', 'mobile', 'dual-receiver-cockpit']) {
+      expect(DOM_BACKED[id](), `${id} should be DOM-backed`).toBe(true);
+    }
+  });
+});

--- a/frontend/src/presentation/layouts/declarations.ts
+++ b/frontend/src/presentation/layouts/declarations.ts
@@ -29,3 +29,9 @@ registerLayout(sdrTestLayout);
 
 export { lcdCockpitLayout, lcdScopeLayout } from './lcd-declarations';
 export { mobileLayout } from './mobile-declarations';
+// MOR-1266 registration — see that file. Re-exported for the same reason as
+// dualReceiverCockpitLayout above: this barrel is the ONLY thing that wires
+// desktop-v2's manifest into the app, and a named re-export gives every test
+// a real binding to assert against (the M7 lesson — a bare side-effect
+// import would let this line be dropped without any test noticing).
+export { desktopV2Layout } from './desktop-declarations';

--- a/frontend/src/presentation/layouts/desktop-declarations.ts
+++ b/frontend/src/presentation/layouts/desktop-declarations.ts
@@ -1,0 +1,86 @@
+/**
+ * MOR-1266 (v3-rework slice S1, MOR-1263 §3 item 1) — the `desktop-v2`
+ * presentation entrypoint's v1 layout manifest (schema, validator and
+ * registry: `./contract`, MOR-1066), following the MOR-1092/94/67
+ * declaration idiom.
+ *
+ * MANIFEST FIRST, NOT DOM FIRST (MOR-1263 decomposition §3, item 1 vs item
+ * 2). Every existing family's zones bind something a real DOM tree already
+ * mounts: `sdr-test` renders `<SemanticRadioSurfaces />` in place of the
+ * legacy VFO/TX block (`sdr-registration.test.ts`), and LCD/mobile/cockpit
+ * each own their entrypoint outright. `desktop-v2` is different: it shares
+ * `components-v2/layout/RadioLayout.svelte`'s "else" branch with `sdr-test`,
+ * gated by `let semanticSurfaces = $derived(skinId === 'sdr-test')` — for
+ * `skinId === 'desktop-v2'` that is `false`, so TODAY it still mounts the
+ * legacy `<VfoHeader>` in `.receiver-deck` and the sidebars' legacy
+ * `<TxPanel>` (`hideTxPanel={semanticSurfaces}` is `false` here), pinned by
+ * the pre-existing `RadioLayout.test.ts` ("renders .vfo-header inside
+ * .receiver-deck", default `skinId: 'desktop-v2'`). Registering this
+ * manifest does not change that — `validateLayoutManifest` only requires
+ * internal self-consistency (every `requiredSemanticSurfaces` entry covered
+ * by some zone); it "does not require the layout to be fully semantic"
+ * (MOR-1263 decomposition §3). Actually wiring `RadioLayout`'s
+ * `semanticSurfaces` flag to mount these zones for `desktop-v2` for real is
+ * MOR-1263 step 2, a later slice — this ticket registers the manifest half
+ * only, deliberately ahead of the DOM, per the programme's "manifest first"
+ * ordering argument.
+ */
+import { registerLayout, type LayoutManifest } from './contract';
+
+/**
+ * `receiver-deck` names the real DOM section (`RadioLayout.svelte`'s
+ * `<section class="receiver-deck">`) that will host the `vfo` surface once
+ * MOR-1263 step 2 lands; `rx-tx` names the future replacement for the
+ * sidebars' legacy `<TxPanel>`. Both are forward-declared zone ids, not yet
+ * bound to a `data-zone-id` in the DOM — unlike the dual-receiver-cockpit's
+ * `rx-tx` zone, which IS bound today (`SemanticRadioSurfaces.svelte`,
+ * `strips="dual"`).
+ */
+const DESKTOP_V2_ZONES = [
+  { id: 'receiver-deck', surfaces: ['vfo'] },
+  { id: 'rx-tx', surfaces: ['rxTx'] },
+] as const;
+
+export const desktopV2Layout: LayoutManifest = {
+  schemaVersion: 1,
+  id: 'desktop-v2',
+  displayName: 'Desktop',
+  loader: () => import('../../skins/desktop-v2/DesktopSkin.svelte'),
+  zones: DESKTOP_V2_ZONES,
+  /**
+   * All four canonical classes. `VfoHeader` branches on `hasDualReceiver()`
+   * (`components-v2/layout/VfoHeader.svelte`) between `DualVfoDisplay` (2
+   * receivers) and a single-receiver `VfoPanel`, with `VfoOps` — the A/B
+   * swap/equal controls — always mounted regardless, and TX is
+   * receiver-count-agnostic. This is the flagship, already-shipped v2 skin
+   * every real Icom radio uses today (`resolveSkinId`'s default `auto`
+   * destination when any scope is available) — read off `VfoHeader.svelte`,
+   * not assumed.
+   */
+  compatibleTopologies: ['1/single', '1/ab', '2/ab_shared', '2/main_sub'],
+  requiredSemanticSurfaces: ['vfo', 'rxTx'],
+  /**
+   * Fluid, no recorded breakpoints — mirroring `sdr-test`'s declaration for
+   * the SAME shared `RadioLayout.svelte` `.content-row`/`.radio-layout`
+   * rules (both skins fall into the same non-`sdr-test`-scoped "else"
+   * branch). The stylesheet does implement two shared reflows (`max-width:
+   * 1200px`, `max-width: 1024px`) — the MOR-1261 chrome-breakpoints doctrine
+   * would allow recording them declaratively while no instrument stage
+   * exists — but they are not specific to `desktop-v2`: `sdr-test`'s
+   * manifest already declares `[]` against the identical rules, and
+   * recording a different set here for the one physical stylesheet would
+   * just disagree with that sibling declaration rather than describe a real
+   * difference. Left `[]`, consistent with `sdr-test`.
+   */
+  stageSizing: { mode: 'fluid', responsiveBreakpoints: [] },
+  /**
+   * No fallback: terminal by construction, same reasoning as `mobile` and
+   * `lcd-cockpit`. `compatibleTopologies` above covers all four canonical
+   * classes (no topology ever fails), and `fluid` sizing always fits a
+   * viewport (`fitsViewport`) — so a fallback hop would be unreachable and
+   * would only mask a real failure, never resolve one.
+   */
+  fallbackLayoutId: null,
+};
+
+registerLayout(desktopV2Layout);


### PR DESCRIPTION
Closes MOR-1266 — slice S1 of the MOR-1263 desktop-v2 rework program (manifest-first, per the decomposition; explicitly unblocked ahead of the vocabulary program).

## What

A `desktop-v2` v1 layout manifest registered through the real registry: fluid `stageSizing`, `receiver-deck:[vfo]` + `rx-tx:[rxTx]` zones, all four topology classes (verified from `VfoHeader`/`VfoOps` source, not assumed), barrel re-export idiom. **18 net production LOC**, 2 production files.

**Honest forward declaration:** desktop-v2 does NOT mount SemanticRadioSurfaces today (`RadioLayout.svelte`'s gate is sdr-test-only) — the manifest is a deliberate forward declaration of the target DOM, documented in-file and triple-pinned: the RadioLayout gate cannot be silently widened; an asserted forward-declared inventory (exactly `['desktop-v2']`) must shrink as the wiring slice lands; the loader identity is pinned (a wrong-but-real entrypoint dies).

## Provenance

- Independent adversarial verification (opus — the presentation/layouts domain verifier across MOR-1067/1068/1069/1247/1264): **PASS**, 4 findings none blocking. The forward-declaration ruled honest with measured evidence: all five other registered manifests bind a real semantic mount (desktop-v2 is the first that does not); the v1 schema admits no weaker truthful state (empty requiredSemanticSurfaces rejected); nothing can act on the declaration (zones/requiredSemanticSurfaces read only inside the validator; loader returns the real legacy tree) — the failure mode is misleading a reader, not rendering a lie, materially weaker than the MOR-1067 F6 class.
- `compatibleTopologies` re-verified from source by the verifier (`VfoHeader.svelte` branching; `VfoOps` mounted unconditionally, self-gating dual-only controls). Noted: the list means renders-coherently per structural class; the dual DISPLAY branches on the operational tag.
- Pin round (test-only, production sha-identical): the verifier's V3 loader-swap mutant and both directions of the inventory pin proven killed. The V3 gap is program-wide (lcd/mobile share the shape) — follow-up ticket queued for a table-driven loader-identity pin across all manifests.
- 8/9 verifier mutations killed at review (the 1 survivor was V3, now pinned); resolveSkinId byte-identical, git-verified.

Failing-file set identical to baseline (environmental Node-26 `localStorage`; CI is the gate); lint/check/build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)