### PR TITLE
feat(MOR-1257): interim QA reachability for the cockpit behind a query param

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -10,6 +10,7 @@
   import { provideAppTxControllerHost } from '$lib/runtime/tx-controller/app-host';
   import { hasAnyScope } from './lib/stores/capabilities.svelte';
   import { getLayoutMode } from './lib/stores/layout.svelte';
+  import { readQaCockpitLayoutOverride } from './lib/stores/qa-cockpit-override';
   import { loadSkin, presentationResourcePlan, resolveSkinId, type SkinId } from './skins/registry';
   import { t } from '$lib/i18n';
   import './app.css';
@@ -24,6 +25,10 @@
   const demoMode = typeof window !== 'undefined'
     ? new URLSearchParams(window.location.search).get('demo')
     : null;
+  // MOR-1257: interim QA-only reachability for the dual-receiver cockpit —
+  // resolved once at load, exactly like `demoMode` above. See
+  // `lib/stores/qa-cockpit-override.ts`.
+  const qaCockpitLayoutOverride = readQaCockpitLayoutOverride();
   let windowWidth = $state(typeof window !== 'undefined' ? window.innerWidth : 1200);
   let windowHeight = $state(typeof window !== 'undefined' ? window.innerHeight : 800);
   // Mobile = narrow portrait OR short landscape (touch device rotated)
@@ -33,7 +38,7 @@
   );
   let skinId = $derived<SkinId>(resolveSkinId({
     capabilities: runtime.caps,
-    layoutPreference: getLayoutMode(),
+    layoutPreference: qaCockpitLayoutOverride ?? getLayoutMode(),
     isMobile,
     hasAnyScope: hasAnyScope(),
   }));

--- a/frontend/src/__tests__/lazy-presentation.component.test.ts
+++ b/frontend/src/__tests__/lazy-presentation.component.test.ts
@@ -218,6 +218,21 @@ describe('lazy presentation loading', () => {
     expect(source).not.toMatch(/import\s+\w+\s+from\s+['"][^'"]*components-v2\/layout\/[^'"]*\.svelte['"]/);
     expect(source).not.toMatch(/import\s+\w+\s+from\s+['"][^'"]*skins\/[^'"]*\.svelte['"]/);
   });
+
+  // MOR-1257 — this suite mocks `resolveSkinId` entirely (`h.resolveSkinId`
+  // above only reads `isMobile`), so it cannot observe what `layoutPreference`
+  // App.svelte actually passes through. Source-pinned instead, the same
+  // technique as the static-import check above. Kills: reverting to
+  // `layoutPreference: getLayoutMode()` (dropping the QA override), or
+  // flipping the `??` precedence so the stored preference would win over an
+  // explicit query param.
+  it('wires the QA-only cockpit override ahead of the stored layout preference (MOR-1257)', () => {
+    const source = readFileSync('src/App.svelte', 'utf8');
+    expect(source).toMatch(
+      /import\s*\{\s*readQaCockpitLayoutOverride\s*\}\s*from\s*['"]\.\/lib\/stores\/qa-cockpit-override['"]\s*;/,
+    );
+    expect(source).toMatch(/layoutPreference:\s*qaCockpitLayoutOverride\s*\?\?\s*getLayoutMode\(\)/);
+  });
 });
 
 describe('stale-resolution cancellation', () => {

--- a/frontend/src/components-v2/layout/StatusBar.svelte
+++ b/frontend/src/components-v2/layout/StatusBar.svelte
@@ -70,7 +70,7 @@
   } from '$lib/stores/connection.svelte';
   import { getFrequency } from '$lib/stores/radio.svelte';
   import { hasAnyScope, hasAudio, hasSpectrum } from '$lib/stores/capabilities.svelte';
-  import { getLayoutMode, setLayoutMode, type LayoutMode } from '$lib/stores/layout.svelte';
+  import { getLayoutMode, setLayoutMode, type CanonicalLayoutMode, type LayoutMode } from '$lib/stores/layout.svelte';
 
   interface Props {
     onSettings?: () => void;
@@ -88,7 +88,12 @@
   // Skin-switcher dropdown options. `lcd` is a legacy persisted value that
   // normalizes to `lcd-cockpit` above (kept for backward compat). Twin-skin
   // variants (`lcd-cockpit`, `lcd-scope`) are selectable per #887 / #889.
-  const skinOptions: Array<{ value: LayoutMode; label: string }> = [
+  // Typed `CanonicalLayoutMode`, not the wider `LayoutMode` (MOR-1257 F1):
+  // `CanonicalLayoutMode` excludes the QA-only 'dual-receiver-cockpit' value,
+  // so adding it to this array is a compile error, not just an omission —
+  // restoring the barrier that existed before that value was added to
+  // `LayoutMode`. See lib/stores/qa-cockpit-override.ts.
+  const skinOptions: Array<{ value: CanonicalLayoutMode; label: string }> = [
     { value: 'auto', label: 'AUTO' },
     { value: 'standard', label: 'Standard' },
     { value: 'lcd-cockpit', label: 'LCD Cockpit' },

--- a/frontend/src/components-v2/layout/__tests__/StatusBar.skin-options.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/StatusBar.skin-options.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * MOR-1257 F1 (independent verification) — `skinOptions` is typed
+ * `Array<{ value: CanonicalLayoutMode; ... }>`, which makes adding the
+ * QA-only `'dual-receiver-cockpit'` value here a compile error (`npm run
+ * check`) — the mutant the verifier added survived at the *type* level
+ * (`LayoutMode` widening had turned it into a clean compile) until that
+ * annotation was restored.
+ *
+ * This is a redundant, cheaper-to-run pin for the same invariant: a
+ * source-level check that catches the regression even in a test-only run
+ * that skips `npm run check`. Source-based (not a mounted component test)
+ * because StatusBar.svelte pulls in the full connection/runtime store
+ * surface — importing it for real would need the same heavy mock scaffolding
+ * App.svelte's own tests carry, for a check that doesn't need a live DOM.
+ */
+describe('StatusBar skinOptions (MOR-1257 F1)', () => {
+  it('never lists the QA-only dual-receiver-cockpit value', () => {
+    const source = readFileSync('src/components-v2/layout/StatusBar.svelte', 'utf8');
+    const match = source.match(/const skinOptions[^=]*=\s*\[([\s\S]*?)\n\s*\];/);
+    expect(match, 'expected to find the skinOptions array literal').not.toBeNull();
+    expect(match![1]).not.toMatch(/dual-receiver-cockpit/);
+  });
+
+  it('is typed CanonicalLayoutMode, not the wider LayoutMode', () => {
+    const source = readFileSync('src/components-v2/layout/StatusBar.svelte', 'utf8');
+    expect(source).toMatch(/const skinOptions:\s*Array<\{\s*value:\s*CanonicalLayoutMode;/);
+  });
+});

--- a/frontend/src/lib/stores/__tests__/layout.test.ts
+++ b/frontend/src/lib/stores/__tests__/layout.test.ts
@@ -70,4 +70,26 @@ describe('layout preference normalization', () => {
     cycleLayoutMode(false);
     expect(getLayoutMode()).toBe('lcd-cockpit');
   });
+
+  // MOR-1257: the QA-only dual-receiver-cockpit value must never become a
+  // normal, persisted layout preference — the only legitimate way to reach
+  // it is `readQaCockpitLayoutOverride()` (lib/stores/qa-cockpit-override.ts)
+  // reading the exact query param. Kill-test: dropping the
+  // `CanonicalLayoutMode` exclusion (or adding the value to
+  // `CANONICAL_LAYOUT_MODES`) would make this normalize to itself instead of
+  // falling through to 'auto', and it would then survive setLayoutMode /
+  // localStorage like any other forced preference.
+  it('does not let the QA-only dual-receiver-cockpit value normalize to itself', async () => {
+    const { normalizeLayoutMode } = await loadStore();
+    expect(normalizeLayoutMode('dual-receiver-cockpit')).toBe('auto');
+  });
+
+  it('does not let setLayoutMode persist the QA-only dual-receiver-cockpit value', async () => {
+    const { getLayoutMode, setLayoutMode } = await loadStore();
+
+    setLayoutMode('dual-receiver-cockpit');
+
+    expect(getLayoutMode()).toBe('auto');
+    expect(localStorage.getItem(LAYOUT_KEY)).toBe('auto');
+  });
 });

--- a/frontend/src/lib/stores/__tests__/qa-cockpit-override.test.ts
+++ b/frontend/src/lib/stores/__tests__/qa-cockpit-override.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { readQaCockpitLayoutOverride } from '../qa-cockpit-override';
+
+describe('readQaCockpitLayoutOverride (MOR-1257)', () => {
+  it('returns the cockpit override when the exact query param is present', () => {
+    expect(readQaCockpitLayoutOverride('?layout=dual-receiver-cockpit')).toBe('dual-receiver-cockpit');
+  });
+
+  it('returns null for an empty search string', () => {
+    expect(readQaCockpitLayoutOverride('')).toBeNull();
+  });
+
+  it('returns null when the param is absent entirely', () => {
+    expect(readQaCockpitLayoutOverride('?foo=bar')).toBeNull();
+  });
+
+  // Kill-test: without this exact-value check, any `?layout=...` (e.g. a
+  // persisted-style value a user might guess) would wrongly activate the
+  // QA-only cockpit.
+  it('returns null for any other layout value, including near-misses', () => {
+    for (const value of ['standard', 'lcd-cockpit', 'dual-receiver', 'Dual-Receiver-Cockpit', '']) {
+      expect(readQaCockpitLayoutOverride(`?layout=${value}`)).toBeNull();
+    }
+  });
+
+  it('finds the param alongside unrelated query params, in either position', () => {
+    expect(readQaCockpitLayoutOverride('?ui=v2&layout=dual-receiver-cockpit')).toBe('dual-receiver-cockpit');
+    expect(readQaCockpitLayoutOverride('?layout=dual-receiver-cockpit&demo=1')).toBe('dual-receiver-cockpit');
+  });
+
+  it('accepts a leading-?-less search string, matching URLSearchParams semantics', () => {
+    expect(readQaCockpitLayoutOverride('layout=dual-receiver-cockpit')).toBe('dual-receiver-cockpit');
+  });
+
+  describe('falling back to window.location.search when no argument is given', () => {
+    it('reads the live URL', () => {
+      const originalSearch = window.location.search;
+      window.history.replaceState({}, '', '/?layout=dual-receiver-cockpit');
+      try {
+        expect(readQaCockpitLayoutOverride()).toBe('dual-receiver-cockpit');
+      } finally {
+        window.history.replaceState({}, '', `/${originalSearch}`);
+      }
+    });
+
+    it('returns null for the default (param-less) URL — the default-path pin', () => {
+      const originalSearch = window.location.search;
+      window.history.replaceState({}, '', '/');
+      try {
+        expect(readQaCockpitLayoutOverride()).toBeNull();
+      } finally {
+        window.history.replaceState({}, '', `/${originalSearch}`);
+      }
+    });
+  });
+
+  // MOR-1257 D2 (independent verification, F2 mitigation) — below the same
+  // 640px minimum dimension App.svelte uses to classify the viewport as
+  // mobile, `resolveSkinId`'s mobile short-circuit suppresses the override
+  // with no signal at all. This does not change that precedence (still an
+  // owner-escalated question, not decided here) — it only makes the no-op
+  // self-explaining.
+  describe('mobile-suppression warning (MOR-1257 D2)', () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+    let originalWidth: number;
+    let originalHeight: number;
+
+    beforeEach(() => {
+      warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      originalWidth = window.innerWidth;
+      originalHeight = window.innerHeight;
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+      Object.defineProperty(window, 'innerWidth', { configurable: true, value: originalWidth });
+      Object.defineProperty(window, 'innerHeight', { configurable: true, value: originalHeight });
+    });
+
+    it('warns once when the param matches but the viewport is under 640px', () => {
+      Object.defineProperty(window, 'innerWidth', { configurable: true, value: 390 });
+      Object.defineProperty(window, 'innerHeight', { configurable: true, value: 844 });
+
+      expect(readQaCockpitLayoutOverride('?layout=dual-receiver-cockpit')).toBe('dual-receiver-cockpit');
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toMatch(/dual-receiver-cockpit/);
+      expect(warnSpy.mock.calls[0][0]).toMatch(/640/);
+    });
+
+    it('does not warn when the param matches and the viewport is desktop-sized', () => {
+      Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1280 });
+      Object.defineProperty(window, 'innerHeight', { configurable: true, value: 800 });
+
+      expect(readQaCockpitLayoutOverride('?layout=dual-receiver-cockpit')).toBe('dual-receiver-cockpit');
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not warn when the param is absent, regardless of viewport size', () => {
+      Object.defineProperty(window, 'innerWidth', { configurable: true, value: 390 });
+      Object.defineProperty(window, 'innerHeight', { configurable: true, value: 844 });
+
+      expect(readQaCockpitLayoutOverride('')).toBeNull();
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('treats exactly 640px as desktop-sized (boundary is exclusive)', () => {
+      Object.defineProperty(window, 'innerWidth', { configurable: true, value: 640 });
+      Object.defineProperty(window, 'innerHeight', { configurable: true, value: 640 });
+
+      expect(readQaCockpitLayoutOverride('?layout=dual-receiver-cockpit')).toBe('dual-receiver-cockpit');
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/lib/stores/layout.svelte.ts
+++ b/frontend/src/lib/stores/layout.svelte.ts
@@ -5,6 +5,13 @@
  * 'lcd-cockpit' = force LCD cockpit (TS-990S-style dual-cockpit)
  * 'lcd-scope'   = force LCD scope (IC-7300-style scope-dominant)
  * 'standard'    = force standard layout
+ * 'dual-receiver-cockpit' = QA-ONLY (MOR-1257): reachable solely via the
+ *                 exact `?layout=dual-receiver-cockpit` query param (see
+ *                 `lib/stores/qa-cockpit-override.ts`) — deliberately NOT a
+ *                 CanonicalLayoutMode, so normalizeLayoutMode below falls it
+ *                 through to 'auto'. It can therefore never be persisted via
+ *                 setLayoutMode/localStorage and never appears in the
+ *                 StatusBar skin selector.
  *
  * Raw persisted aliases are normalized here before presentation policy reads
  * the preference.
@@ -13,8 +20,10 @@
 const STORAGE_KEY = 'rigplane-layout';
 const LEGACY_SKIN_STORAGE_KEY = 'rigplane-skin';
 
-export type LayoutMode = 'auto' | 'lcd' | 'lcd-cockpit' | 'lcd-scope' | 'standard' | 'sdr-test';
-export type CanonicalLayoutMode = Exclude<LayoutMode, 'lcd'>;
+export type LayoutMode =
+  | 'auto' | 'lcd' | 'lcd-cockpit' | 'lcd-scope' | 'standard' | 'sdr-test'
+  | 'dual-receiver-cockpit';
+export type CanonicalLayoutMode = Exclude<LayoutMode, 'lcd' | 'dual-receiver-cockpit'>;
 
 const CANONICAL_LAYOUT_MODES = new Set<CanonicalLayoutMode>([
   'auto',

--- a/frontend/src/lib/stores/qa-cockpit-override.ts
+++ b/frontend/src/lib/stores/qa-cockpit-override.ts
@@ -1,0 +1,50 @@
+/**
+ * Interim QA reachability for the dual-receiver cockpit (MOR-1257).
+ *
+ * Staple reachability arrives with the MOR-1081 workspace-owned layout
+ * chain (layout selection migrates there). Until then, the ONLY way to
+ * reach the cockpit skin is the exact `?layout=dual-receiver-cockpit`
+ * query param — it is not a `CanonicalLayoutMode` (see
+ * `lib/stores/layout.svelte.ts`), so it can never be persisted via
+ * `setLayoutMode`/localStorage, and it is deliberately absent from
+ * `components-v2/layout/StatusBar.svelte`'s hardcoded skin-selector
+ * options, so it never appears as a normal layout choice.
+ *
+ * Kept in its own module — not `layout.svelte.ts` or `skins/registry.ts` —
+ * so `App.svelte` importing it cannot be shadowed by the partial
+ * `vi.mock('$lib/stores/layout.svelte', () => ({ getLayoutMode: ... }))` /
+ * `vi.mock('../skins/registry', () => ({ resolveSkinId: ... }))` factories
+ * several component-test suites already use for those two modules (e.g.
+ * `src/__tests__/lazy-presentation.component.test.ts`) — a new named
+ * export added to either would come back `undefined` under those mocks.
+ *
+ * Pure: reads only the given search string (or `window.location.search`
+ * when none is given); touches no store and persists nothing. Safe to call
+ * from tests.
+ *
+ * The param never overrides the mobile short-circuit in `resolveSkinId`
+ * (`skins/registry.ts` checks `ctx.isMobile` first, unconditionally) —
+ * that precedence is unchanged here. Below the same 640px minimum
+ * dimension `App.svelte` uses to classify the viewport as mobile, the
+ * param would otherwise be silently ignored with no signal, which reads
+ * as "the param is broken" rather than "this viewport is mobile" — most
+ * often on an ordinary narrow/short desktop window, not an actual phone.
+ * `console.warn` makes that non-obvious no-op self-explaining.
+ */
+const QA_COCKPIT_QUERY_PARAM = 'layout';
+const QA_COCKPIT_QUERY_VALUE = 'dual-receiver-cockpit';
+const MOBILE_MIN_DIMENSION_PX = 640;
+
+export function readQaCockpitLayoutOverride(search?: string): 'dual-receiver-cockpit' | null {
+  const raw = search ?? (typeof window !== 'undefined' ? window.location.search : '');
+  const matched = new URLSearchParams(raw).get(QA_COCKPIT_QUERY_PARAM) === QA_COCKPIT_QUERY_VALUE;
+  if (matched && typeof window !== 'undefined'
+    && Math.min(window.innerWidth, window.innerHeight) < MOBILE_MIN_DIMENSION_PX) {
+    console.warn(
+      '[rigplane] ?layout=dual-receiver-cockpit is set, but the viewport is under '
+      + `${MOBILE_MIN_DIMENSION_PX}px — the mobile skin takes precedence and the cockpit will `
+      + 'not show. Widen the window to at least 640x640 to view it.',
+    );
+  }
+  return matched ? 'dual-receiver-cockpit' : null;
+}

--- a/frontend/src/skins/__tests__/registry.test.ts
+++ b/frontend/src/skins/__tests__/registry.test.ts
@@ -7,6 +7,7 @@ const entrypoints = vi.hoisted(() => ({
   scope: { name: 'lcd-scope' },
   mobile: { name: 'mobile' },
   sdr: { name: 'sdr-test' },
+  dualReceiverCockpit: { name: 'dual-receiver-cockpit' },
 }));
 
 const lazyImports = vi.hoisted(() => ({
@@ -15,6 +16,7 @@ const lazyImports = vi.hoisted(() => ({
   scope: vi.fn(() => ({ default: entrypoints.scope })),
   mobile: vi.fn(() => ({ default: entrypoints.mobile })),
   sdr: vi.fn(() => ({ default: entrypoints.sdr })),
+  dualReceiverCockpit: vi.fn(() => ({ default: entrypoints.dualReceiverCockpit })),
 }));
 
 vi.mock('../desktop-v2/DesktopSkin.svelte', () => lazyImports.desktop());
@@ -22,6 +24,7 @@ vi.mock('../lcd-cockpit/LcdCockpitSkin.svelte', () => lazyImports.cockpit());
 vi.mock('../lcd-scope/LcdScopeSkin.svelte', () => lazyImports.scope());
 vi.mock('../mobile/MobileSkin.svelte', () => lazyImports.mobile());
 vi.mock('../sdr-test/SdrTestSkin.svelte', () => lazyImports.sdr());
+vi.mock('../dual-receiver-cockpit/DualReceiverCockpit.svelte', () => lazyImports.dualReceiverCockpit());
 
 import { loadSkin, presentationResourcePlan, resolvePersistedSkinId, resolveSkinId } from '../registry';
 
@@ -80,6 +83,54 @@ describe('skin registry', () => {
   ] as const)('lazily loads the %s entrypoint', async (skinId: SkinId, entrypoint, lazyImport) => {
     await expect(loadSkin(skinId)).resolves.toBe(entrypoint);
     expect(lazyImport).toHaveBeenCalledTimes(1);
+  });
+});
+
+// MOR-1257 — interim QA reachability for the dual-receiver cockpit, gated
+// behind the exact `?layout=dual-receiver-cockpit` query param (the URL ->
+// LayoutMode translation itself is `readQaCockpitLayoutOverride`, pinned
+// separately in lib/stores/__tests__/qa-cockpit-override.test.ts). These
+// tests pin resolveSkinId's half of the contract only.
+describe('MOR-1257: QA-only dual-receiver-cockpit reachability', () => {
+  // Kill-test: removing this branch (or mistyping the literal) leaves the
+  // QA-only preference falling through `normalizeLayoutMode` to 'auto',
+  // which resolves to 'desktop-v2' or 'lcd-cockpit' — never the cockpit.
+  it('resolves the QA-only preference to the cockpit skin', () => {
+    expect(resolve({ layoutPreference: 'dual-receiver-cockpit' })).toBe('dual-receiver-cockpit');
+    expect(resolve({ layoutPreference: 'dual-receiver-cockpit', hasAnyScope: true })).toBe('dual-receiver-cockpit');
+  });
+
+  // Default-path pin (ticket acceptance): every OTHER forced preference is
+  // completely unaffected by the new branch — same outcomes as the
+  // unmodified 'resolves forced %s preference to %s' cases above.
+  it('leaves every other forced preference unaffected', () => {
+    expect(resolve({ layoutPreference: 'standard' })).toBe('desktop-v2');
+    expect(resolve({ layoutPreference: 'auto', hasAnyScope: false })).toBe('lcd-cockpit');
+  });
+
+  // Documents the chosen behaviour for the ticket's mobile/QA-override
+  // tension: the mobile short-circuit stays first, so an actual phone
+  // viewport keeps the mobile skin even with the QA param present. QA is
+  // expected to open the URL on a desktop-sized viewport.
+  it('still gives mobile precedence over the QA-only preference', () => {
+    expect(resolve({ isMobile: true, layoutPreference: 'dual-receiver-cockpit', hasAnyScope: true }))
+      .toBe('mobile');
+  });
+
+  // Must run before the lazy-load test below actually triggers the import —
+  // this file has no per-test mock reset, so call order is significant here
+  // (mirrors "does not import a skin entrypoint while the registry is
+  // initialized" above, which runs before every "lazily loads" case).
+  it('does not import the dual-receiver-cockpit entrypoint merely by resolving other preferences', () => {
+    for (const layoutPreference of ['auto', 'standard', 'lcd-cockpit', 'lcd-scope', 'sdr-test'] as const) {
+      resolve({ layoutPreference });
+    }
+    expect(lazyImports.dualReceiverCockpit).not.toHaveBeenCalled();
+  });
+
+  it('lazily loads the dual-receiver-cockpit entrypoint through the real loader', async () => {
+    await expect(loadSkin('dual-receiver-cockpit')).resolves.toBe(entrypoints.dualReceiverCockpit);
+    expect(lazyImports.dualReceiverCockpit).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/frontend/src/skins/dual-receiver-cockpit/DualReceiverCockpit.svelte
+++ b/frontend/src/skins/dual-receiver-cockpit/DualReceiverCockpit.svelte
@@ -67,6 +67,15 @@
   chrome stays fluid).
 -->
 <script lang="ts">
+  // MOR-1257 (N4): the components-v2 theme layer (fonts, base tokens, and
+  // the MOR-1232 focus-ring pair --v2-focus-ring-color/--v2-focus-ring) is
+  // code-split per skin — RadioLayout.svelte and LcdLayout.svelte both pull
+  // it in via this exact side-effect import. This shell composed neither of
+  // those, so a standalone mount never loaded the theme layer and
+  // app.css's `outline: var(--v2-focus-ring, var(--focus-ring))` silently
+  // fell back to the legacy ring (MOR-1070 evidence run finding N4). A pure
+  // CSS side effect, not a runtime/store/command import.
+  import '../../components-v2/theme/index';
   import SemanticRadioSurfaces from '../../components-v2/wiring/SemanticRadioSurfaces.svelte';
 </script>
 

--- a/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
+++ b/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
@@ -800,6 +800,27 @@ describe('MOR-1069 — the shell\'s responsive selectors still match the compose
   });
 });
 
+// MOR-1257 (N4) — MOR-1070 evidence run finding: a standalone mount of this
+// shell never pulled in the code-split components-v2 theme layer
+// (fonts/tokens/themes), so app.css's
+// `outline: var(--v2-focus-ring, var(--focus-ring))` silently fell back to
+// the legacy ring instead of the MOR-1232 --v2-focus-ring pair (pinned in
+// src/__tests__/focus-ring-token-wiring.test.ts). RadioLayout.svelte and
+// LcdLayout.svelte already import the theme layer as a side effect; this
+// shell had no equivalent import.
+describe('MOR-1257 (N4) — the components-v2 theme layer loads with this skin', () => {
+  // Source-based, mirroring this file's own F5 check above (":global class
+  // exists in the mounted DOM") rather than a DOM computed-style assertion —
+  // vitest/jsdom does not reliably apply real CSS cascade from side-effect
+  // `.css` imports, which is why MOR-1232's own wiring pins
+  // (focus-ring-token-wiring.test.ts) read source text too.
+  // Kills: dropping the import, or narrowing it to skip tokens.css.
+  it('imports the v2 theme layer as a side effect, the same way RadioLayout/LcdLayout do', () => {
+    const source = readFileSync('src/skins/dual-receiver-cockpit/DualReceiverCockpit.svelte', 'utf8');
+    expect(source).toMatch(/import\s+['"]\.\.\/\.\.\/components-v2\/theme\/index['"]\s*;/);
+  });
+});
+
 function push(next: Partial<Snapshot>): void {
   h.snapshot = { ...(h.snapshot as Snapshot), ...next };
   for (const listener of h.listeners) listener(h.snapshot);

--- a/frontend/src/skins/registry.ts
+++ b/frontend/src/skins/registry.ts
@@ -37,6 +37,9 @@ export interface SkinResolutionContext {
  *
  * Rules:
  * - Mobile viewport → mobile skin
+ * - QA-only: layoutPreference === 'dual-receiver-cockpit' → dual-receiver-cockpit
+ *   (MOR-1257 — only reachable via the exact `?layout=dual-receiver-cockpit`
+ *   query param; see `lib/stores/qa-cockpit-override.ts`)
  * - User forced 'lcd' or 'lcd-cockpit' → lcd-cockpit
  * - User forced 'lcd-scope' → lcd-scope
  * - User forced 'standard' → desktop-v2
@@ -44,6 +47,13 @@ export interface SkinResolutionContext {
  */
 export function resolveSkinId(ctx: SkinResolutionContext): SkinId {
   if (ctx.isMobile) return 'mobile';
+  // MOR-1257: interim QA reachability. `ctx.layoutPreference` can only be
+  // this value when the caller resolved it from the exact
+  // `?layout=dual-receiver-cockpit` query param — it is deliberately NOT a
+  // `CanonicalLayoutMode` (lib/stores/layout.svelte.ts), so
+  // `normalizeLayoutMode` below would fall it straight through to 'auto'.
+  // Checked here, before normalization, for that reason.
+  if (ctx.layoutPreference === 'dual-receiver-cockpit') return 'dual-receiver-cockpit';
   const layoutPreference = normalizeLayoutMode(ctx.layoutPreference);
   if (layoutPreference === 'sdr-test') return 'sdr-test';
   if (layoutPreference === 'lcd-cockpit') return 'lcd-cockpit';


### PR DESCRIPTION
Closes MOR-1257 (owner gate decision (a); unblocks the owner's live viewing for the MOR-1070 acceptance).

## What

`http://<host>/?layout=dual-receiver-cockpit` mounts the dual-receiver cockpit in-app. A pure override module wired ahead of the stored preference; one `resolveSkinId` branch; the mode is deliberately NOT canonical — it cannot persist (normalized to `auto` on write and read; even a hand-written localStorage entry cannot stick) and cannot appear in the StatusBar selector (array typed `CanonicalLayoutMode` — the compile barrier the verifier's mutant proved load-bearing). Includes the N4 fix: the cockpit skin now imports the code-split theme layer, delivering the MOR-1232 focus ring (verified down to the vite chunk graph — the skin loader preloads the css chunk declaring `--v2-focus-ring-color` with the per-skin overrides). **22 net production LOC** (frozen formula).

## Provenance

- Independent adversarial verification (opus — the MOR-1232/1254 focus-system verifier): **PASS**, 5 findings none blocking, F1 fixed in a delta and CONFIRMED.
- Crux mutants: unconditional-override kills 5 tests incl. the default-path pin and a pre-existing App test; the ticket-mandated cockpit-resolvable-without-param mutant kills 8 tests, 7 of them pre-existing and untouched. Non-persistence airtight by construction.
- F1 (delta, confirmed): adding the cockpit to StatusBar skinOptions was a surviving mutant AND had silently become type-legal — now fails `npm run check` with a real type error plus a named pin. A `console.warn` fires iff the param is genuinely suppressed by the mobile branch (mutant-proven both directions).
- Open owner question (escalated by the verifier, deliberately not decided in code): below 640px mobile always wins and the param no-ops (with the warn) — including ordinary narrow desktop windows. Precedence pinned as-built; owner batch will settle it.
- Verifier also confirmed no duplicate theme injection (all five skin loaders reference the same shared css index) and audited the builder's disclosed shared-stash incident (no residue).

Suite 3345/3345 (--localstorage-file method; the no-flag method flakes a file this diff touches — investigated and reproduced on the unmodified tree); lint/check/build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)