### PR TITLE
feat(MOR-1244): txAux fact group (vocabulary slice 1A)

### DIFF
--- a/frontend/src/lib/runtime/adapters/__tests__/tx-aux-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/tx-aux-adapter.test.ts
@@ -1,0 +1,181 @@
+/**
+ * MOR-1244 — `txAux` fact-group adapter derivation.
+ *
+ * Companion to `radio-view-model-adapter.test.ts` (MOR-1065), which this
+ * file does NOT modify. That file's fixtures all declare `caps.tx: true`
+ * with no txAux-specific capability tag and no txAux field ever set on
+ * `state` — under a naive "emit whenever hasTx" gate, `txAux` would have
+ * appeared on every model that file builds, changing its hard-coded
+ * "carries only contract data" exact-key-list assertion. `deriveTxAux`'s
+ * evidence gate (N3, "capability/observed fields") requires MORE than
+ * generic TX capability — see the doc comment on `deriveTxAux` — so that
+ * file's fixtures correctly still emit no txAux, and this file separately
+ * pins that a radio with real txAux evidence DOES get the group.
+ */
+import { describe, expect, it } from 'vitest';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { FieldStatus, ServerState } from '$lib/types/state';
+import { validateRadioViewModel, type RadioViewModel } from '../../../../semantic/radio-view-model';
+import { toRadioViewModel } from '../radio-view-model-adapter';
+
+function caps(overrides: Partial<Capabilities> = {}): Capabilities {
+  return {
+    model: 'fixture', scope: true, audio: true, tx: true, capabilities: ['scope', 'audio', 'tx'],
+    receivers: 1, vfoScheme: 'single', freqRanges: [], modes: [], filters: [],
+    audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
+    webrtc: { available: false, enabled: false },
+    txBands: [{ start: 14000000, end: 14350000, name: '20m' }],
+    scopeSource: 'hardware', audioFftAvailable: false, ...overrides,
+  } as Capabilities;
+}
+
+const fresh: FieldStatus = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' };
+const stale: FieldStatus = { storePath: 'x', observed: true, freshness: 'stale', availability: 'stale' };
+
+/** No txAux field ever set, no txAux field status entry — the exact shape
+ *  `radio-view-model-adapter.test.ts`'s own `observedState()` uses. */
+function bareState(overrides: Partial<ServerState> = {}): ServerState {
+  return {
+    active: 'MAIN', split: false, dualWatch: false, ptt: false,
+    txTarget: { status: 'known', receiver: 'MAIN', slot: null, frequencyHz: 14195000 },
+    main: {
+      freqHz: 14195000, mode: 'USB', filter: 1, dataMode: 0, att: 0, preamp: 0,
+      nb: false, nr: false, afLevel: 1, rfGain: 1, squelch: 0, sMeter: 0,
+    },
+    fieldStatus: {
+      active: fresh, split: fresh, dualWatch: fresh, txTarget: fresh,
+      'main.freqHz': fresh, 'main.mode': fresh, 'main.filter': fresh,
+    },
+    ...overrides,
+  } as ServerState;
+}
+
+function model(state: ServerState | null, capabilities: Capabilities | null): RadioViewModel {
+  const view = toRadioViewModel(state, capabilities);
+  expect(view).not.toBeNull();
+  return validateRadioViewModel(view);
+}
+
+describe('txAux evidence gate (MOR-1244, N3)', () => {
+  // Kill-test 4: sever the gate (see the build report's mutation-kill
+  // protocol) and this is the test that goes red.
+  it('emits no txAux when capabilities are absent', () => {
+    expect(toRadioViewModel(bareState(), null)).toBeNull();
+  });
+
+  it('emits no txAux for a non-TX radio, even with a vox tag present', () => {
+    const view = model(bareState(), caps({ tx: false, capabilities: ['scope', 'audio', 'vox'] }));
+    expect(view.txAux).toBeUndefined();
+  });
+
+  // The exact scenario `radio-view-model-adapter.test.ts`'s fixtures hit:
+  // tx:true, no txAux-specific capability tag, no txAux field ever set.
+  it('emits no txAux for a TX radio with zero txAux-specific evidence (regression pin)', () => {
+    const view = model(bareState(), caps());
+    expect(view.txAux).toBeUndefined();
+    expect(Object.keys(view)).not.toContain('txAux');
+  });
+
+  it('emits txAux once a single sub-capability tag is present, even with no field observed', () => {
+    const view = model(bareState(), caps({ capabilities: ['scope', 'audio', 'tx', 'vox'] }));
+    expect(view.txAux).toBeDefined();
+  });
+
+  it('emits txAux once a single txAux field is actually observed, even with no sub-capability tag', () => {
+    const view = model(bareState({
+      powerLevel: 0.75,
+      fieldStatus: { ...bareState().fieldStatus, powerLevel: fresh },
+    }), caps());
+    expect(view.txAux).toBeDefined();
+  });
+
+  it('never emits txAux for a receive-only radio (tx capability absent, nothing observed)', () => {
+    const view = model(bareState(), caps({ tx: false, capabilities: ['scope', 'audio'] }));
+    expect(view.txAux).toBeUndefined();
+  });
+});
+
+describe('txAux per-field derivation (MOR-1244)', () => {
+  const fullCaps = caps({ capabilities: ['scope', 'audio', 'tx', 'vox', 'compressor', 'monitor', 'tuner', 'drive_gain'] });
+
+  it('reports known readings for observed, fresh, capability-backed fields', () => {
+    const view = model(bareState({
+      tunerStatus: 2, voxOn: true, voxGain: 40, antiVoxGain: 25, voxDelay: 15,
+      compressorOn: true, compressorLevel: 60, monitorOn: true, monitorGain: 90,
+      powerLevel: 0.9, micGain: 200, driveGain: 210,
+      fieldStatus: {
+        ...bareState().fieldStatus,
+        tunerStatus: fresh, voxOn: fresh, voxGain: fresh, antiVoxGain: fresh, voxDelay: fresh,
+        compressorOn: fresh, compressorLevel: fresh, monitorOn: fresh, monitorGain: fresh,
+        powerLevel: fresh, micGain: fresh, driveGain: fresh,
+      },
+    }), fullCaps);
+    const txAux = view.txAux!;
+    expect(txAux.atu).toEqual({ reading: { status: 'known', value: 'tuning' }, availability: { structural: true, operational: true } });
+    expect(txAux.vox).toEqual({ reading: { status: 'known', value: true }, availability: { structural: true, operational: true } });
+    expect(txAux.voxGain.reading).toEqual({ status: 'known', value: 40 });
+    expect(txAux.antiVoxGain.reading).toEqual({ status: 'known', value: 25 });
+    expect(txAux.voxDelay.reading).toEqual({ status: 'known', value: 15 });
+    expect(txAux.compressor.reading).toEqual({ status: 'known', value: true });
+    expect(txAux.compressorLevel.reading).toEqual({ status: 'known', value: 60 });
+    expect(txAux.monitor.reading).toEqual({ status: 'known', value: true });
+    expect(txAux.monitorLevel.reading).toEqual({ status: 'known', value: 90 });
+    expect(txAux.rfPower.reading).toEqual({ status: 'known', value: 0.9 });
+    expect(txAux.micGain.reading).toEqual({ status: 'known', value: 200 });
+    expect(txAux.driveGain.reading).toEqual({ status: 'known', value: 210 });
+  });
+
+  it.each([[0, 'off'], [1, 'on'], [2, 'tuning']] as const)('maps tunerStatus %d to atu %s', (raw, expected) => {
+    const view = model(bareState({
+      tunerStatus: raw, fieldStatus: { ...bareState().fieldStatus, tunerStatus: fresh },
+    }), fullCaps);
+    expect(view.txAux!.atu.reading).toEqual({ status: 'known', value: expected });
+  });
+
+  it('degrades a stale field to unknown while keeping structural availability true', () => {
+    const view = model(bareState({
+      powerLevel: 0.9, fieldStatus: { ...bareState().fieldStatus, powerLevel: stale },
+    }), fullCaps);
+    expect(view.txAux!.rfPower).toEqual({
+      reading: { status: 'unknown' }, availability: { structural: true, operational: false },
+    });
+  });
+
+  it('marks a control structurally absent when its capability tag is missing, never known', () => {
+    const view = model(bareState({
+      voxOn: true, fieldStatus: { ...bareState().fieldStatus, voxOn: fresh },
+    }), caps({ capabilities: ['scope', 'audio', 'tx', 'compressor'] }));
+    // vox capability absent — must never surface a "known" reading even
+    // though the (irrelevant) field status looks fresh and a value exists.
+    expect(view.txAux!.vox).toEqual({
+      reading: { status: 'unknown' }, availability: { structural: false, operational: false },
+    });
+  });
+
+  it('always marks rfPower and micGain structurally available on any TX radio, no sub-capability required', () => {
+    const view = model(bareState(), caps({ capabilities: ['scope', 'audio', 'tx', 'vox'] }));
+    expect(view.txAux!.rfPower.availability.structural).toBe(true);
+    expect(view.txAux!.micGain.availability.structural).toBe(true);
+    // But vox is the only reason the group exists here — compressor/monitor/
+    // tuner/driveGain stay structurally absent.
+    expect(view.txAux!.compressor.availability.structural).toBe(false);
+    expect(view.txAux!.monitor.availability.structural).toBe(false);
+    expect(view.txAux!.atu.availability.structural).toBe(false);
+    expect(view.txAux!.driveGain.availability.structural).toBe(false);
+  });
+
+  it('degrades a malformed raw value (wrong JS type) to unknown rather than throwing or coercing', () => {
+    const view = model(bareState({
+      compressorLevel: 'ten' as unknown as number,
+      fieldStatus: { ...bareState().fieldStatus, compressorLevel: fresh },
+    }), fullCaps);
+    expect(view.txAux!.compressorLevel.reading).toEqual({ status: 'unknown' });
+  });
+
+  it('emits a validator-clean model carrying the txAux group (round-trip proof)', () => {
+    const view = model(bareState({
+      voxOn: true, voxGain: 10, fieldStatus: { ...bareState().fieldStatus, voxOn: fresh, voxGain: fresh },
+    }), fullCaps);
+    expect(JSON.parse(JSON.stringify(view))).toEqual(view);
+  });
+});

--- a/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
@@ -25,7 +25,8 @@
  */
 import type { Capabilities } from '$lib/types/capabilities';
 import type { ServerState } from '$lib/types/state';
-import type { RadioViewModel } from '../../../semantic/radio-view-model';
+import type { RadioViewModel, TxAuxField, TxAuxViewModel, AtuStatus } from '../../../semantic/radio-view-model';
+import { isFieldAvailable } from '$lib/state/field-status';
 import {
   derivePresentationCapabilities, type ReceiverId, type VfoSlotId,
 } from './presentation-capabilities';
@@ -76,6 +77,91 @@ function readings(
 
 const sameSlot = (a: Slot, b: Slot): boolean =>
   a.kind === 'slotted' && b.kind === 'slotted' ? a.id === b.id : a.kind === b.kind;
+
+function hasCap(caps: Capabilities | null, name: string): boolean {
+  return caps?.capabilities?.includes(name) ?? false;
+}
+
+/**
+ * MOR-1244: the SAME field-status gate `toTxProps`/`toVoxProps` use for these
+ * exact controls (`$lib/runtime/props/panel-props.ts`,
+ * `components-v2/wiring/state-adapter.ts`) — deliberately the looser
+ * "not proven missing/stale" gate (`isFieldAvailable`, defaults to available
+ * absent an explicit field-status entry), not this file's own stricter
+ * `seen()` three-part gate used for VFO/TX-target identity. `txAux` controls
+ * are legacy top-level fields with the same v2 availability story as the
+ * panel they came from; giving them a stricter gate here would silently
+ * disable controls v2 has always shown.
+ */
+function topFieldAvailable(state: ServerState | null, field: string): boolean {
+  return isFieldAvailable(state, field);
+}
+
+/** `fieldFresh` is the raw `topFieldAvailable` read; a structurally-absent
+ *  control must never report a "known" reading even if the (irrelevant)
+ *  field happens to look fresh — so the reading gates on BOTH, same as
+ *  `availability.operational`. */
+function txAuxField<T>(structural: boolean, fieldFresh: boolean, value: T | undefined): TxAuxField<T> {
+  const operational = structural && fieldFresh;
+  return {
+    reading: operational && value !== undefined ? { status: 'known', value } : { status: 'unknown' },
+    availability: { structural, operational },
+  };
+}
+const numOrUndef = (v: unknown): number | undefined => (typeof v === 'number' && Number.isFinite(v) ? v : undefined);
+const boolOrUndef = (v: unknown): boolean | undefined => (typeof v === 'boolean' ? v : undefined);
+const atuStatus = (v: unknown): AtuStatus | undefined =>
+  v === 0 ? 'off' : v === 1 ? 'on' : v === 2 ? 'tuning' : undefined;
+
+/**
+ * N3: emits the group ONLY on positive evidence — "capability/observed
+ * fields", verbatim. `caps.tx` alone is NOT sufficient: a radio can declare
+ * generic TX capability (e.g. for the RX/TX authority, MOR-1064) without
+ * this adapter having ANY reason to believe a single one of the twelve
+ * txAux controls exists — no sub-capability tag AND no field ever observed.
+ * Emitting a group there would be exactly the all-unknowns placeholder N3
+ * forbids. So the gate is a real OR: at least one txAux-specific capability
+ * tag (`vox`/`compressor`/`monitor`/`tuner`/`drive_gain` — confirmed against
+ * both `toTxProps` and `AmberCockpit.svelte`'s
+ * `hasCap('vox' | 'compressor' | 'tuner')` usage) OR at least one of the
+ * twelve raw state fields actually present (any live radio that has ever
+ * reported ptt/power/mic-gain telemetry clears this — RF power and mic gain
+ * carry no separate capability tag in v2 either, they are core TX facts).
+ * Once evidence exists, `hasCap(caps, 'tx')` remains required too — it is
+ * `toTxProps`'s own `hasTx` gate for the panel as a whole.
+ */
+function deriveTxAux(state: ServerState | null, caps: Capabilities | null): TxAuxViewModel | undefined {
+  if (!hasCap(caps, 'tx')) return undefined;
+  const hasTuner = hasCap(caps, 'tuner');
+  const hasVox = hasCap(caps, 'vox');
+  const hasCompressor = hasCap(caps, 'compressor');
+  const hasMonitor = hasCap(caps, 'monitor');
+  const hasDriveGain = hasCap(caps, 'drive_gain');
+  const rawValues = [
+    state?.tunerStatus, state?.voxOn, state?.voxGain, state?.antiVoxGain, state?.voxDelay,
+    state?.compressorOn, state?.compressorLevel, state?.monitorOn, state?.monitorGain,
+    state?.powerLevel, state?.micGain, state?.driveGain,
+  ];
+  const hasEvidence = hasTuner || hasVox || hasCompressor || hasMonitor || hasDriveGain
+    || rawValues.some((v) => v !== undefined);
+  if (!hasEvidence) return undefined;
+  return {
+    atu: txAuxField(hasTuner, topFieldAvailable(state, 'tunerStatus'), atuStatus(state?.tunerStatus)),
+    vox: txAuxField(hasVox, topFieldAvailable(state, 'voxOn'), boolOrUndef(state?.voxOn)),
+    voxGain: txAuxField(hasVox, topFieldAvailable(state, 'voxGain'), numOrUndef(state?.voxGain)),
+    antiVoxGain: txAuxField(hasVox, topFieldAvailable(state, 'antiVoxGain'), numOrUndef(state?.antiVoxGain)),
+    voxDelay: txAuxField(hasVox, topFieldAvailable(state, 'voxDelay'), numOrUndef(state?.voxDelay)),
+    compressor: txAuxField(hasCompressor, topFieldAvailable(state, 'compressorOn'), boolOrUndef(state?.compressorOn)),
+    compressorLevel: txAuxField(
+      hasCompressor, topFieldAvailable(state, 'compressorLevel'), numOrUndef(state?.compressorLevel),
+    ),
+    monitor: txAuxField(hasMonitor, topFieldAvailable(state, 'monitorOn'), boolOrUndef(state?.monitorOn)),
+    monitorLevel: txAuxField(hasMonitor, topFieldAvailable(state, 'monitorGain'), numOrUndef(state?.monitorGain)),
+    rfPower: txAuxField(true, topFieldAvailable(state, 'powerLevel'), numOrUndef(state?.powerLevel)),
+    micGain: txAuxField(true, topFieldAvailable(state, 'micGain'), numOrUndef(state?.micGain)),
+    driveGain: txAuxField(hasDriveGain, topFieldAvailable(state, 'driveGain'), numOrUndef(state?.driveGain)),
+  };
+}
 
 /**
  * `null` when there is nothing safe to render at all: capabilities have not
@@ -204,6 +290,13 @@ export function toRadioViewModel(
     }
   }
 
+  // Conditional spread, not a plain `txAux: deriveTxAux(...)` property: an
+  // object literal assigning a key to `undefined` still shows up in
+  // `Object.keys()`, which would make "no TX capability" indistinguishable
+  // from "has the group" to any consumer that inventories keys — same
+  // reasoning as the validator's own omission below `validateRadioViewModel`.
+  const txAux = deriveTxAux(state, caps);
+
   return {
     topologyId: `${topology.structuralCount}/${topology.scheme}`,
     vfoScheme: topology.scheme,
@@ -215,5 +308,6 @@ export function toRadioViewModel(
     txPermit,
     scope: { hardwareScope, audioFftScope },
     disabledReasons,
+    ...(txAux !== undefined ? { txAux } : {}),
   };
 }

--- a/frontend/src/semantic/__tests__/optional-group-allow-list.test.ts
+++ b/frontend/src/semantic/__tests__/optional-group-allow-list.test.ts
@@ -1,0 +1,92 @@
+/**
+ * MOR-1244 pin round (`mor-1244-verify.md` §8, finding N1) — the top-level
+ * allow-list must agree with the read set.
+ *
+ * `validateRadioViewModel`'s `exactKeys` allow-list is a plain string-array
+ * literal; nothing before this pin proved that every key in it is actually
+ * read/validated. The verifier's V2 mutant demonstrated the gap: adding a
+ * stray key (`'txAuxLegacy'`) to the allow-list, with NO corresponding
+ * validator or read, passed all 322 targeted tests untouched — a garbage
+ * value under that key validated cleanly, because nothing ever looked at
+ * it. Reproduced below (see the build report's "Pin round" section for the
+ * mutate/kill/restore/sha256 proof).
+ *
+ * This file derives the REAL allow-list straight from the shipped
+ * function's own source (`Function.prototype.toString()` + a narrow regex
+ * on the one `exactKeys(v, [...], '$')` call `validateRadioViewModel`
+ * makes) rather than hand-duplicating it — a hand-duplicated copy is
+ * exactly the kind of thing that silently drifts and stops catching
+ * anything. Two independent checks:
+ *
+ *  1. the derived list matches a maintained "expected" set exactly — this
+ *     alone kills a stray-key mutant like the verifier's, regardless of
+ *     whether the stray key happens to be read;
+ *  2. EVERY non-required key in the *derived* list — whatever it is, no
+ *     per-family list to keep in sync for this half — throws when given a
+ *     garbage (non-object) value. This is the "declared but unread" catch:
+ *     a future family that updates check #1's expected set but forgets to
+ *     wire its validator fails check #2 automatically, with no edits here.
+ *
+ * Recipe for each of the 12 remaining MOR-1262 family slices: add your
+ * group's key to `EXPECTED_OPTIONAL_GROUP_KEYS` below. Nothing else in this
+ * file needs to change.
+ */
+import { describe, expect, it } from 'vitest';
+import { validateRadioViewModel } from '../radio-view-model';
+import { topologyFixtures } from '../fixtures/topologies';
+
+const REQUIRED_KEYS = [
+  'topologyId', 'vfoScheme', 'activeReceiver', 'vfos', 'split', 'dualWatch',
+  'txTarget', 'txPermit', 'scope', 'disabledReasons',
+] as const;
+
+/** MOR-1244: txAux. Add your key here when your family's slice lands. */
+const EXPECTED_OPTIONAL_GROUP_KEYS = ['txAux'] as const;
+
+function extractTopLevelAllowList(): string[] {
+  // `.toString()` on a Vite/esbuild-transformed function returns the SSR-
+  // transformed body: the call becomes `(0,__vite_ssr_import_N__.exactKeys)
+  // (v, [...], "$")` (module-wrapped, double-quoted, pretty-printed one
+  // entry per line) rather than the literal source text — the regex allows
+  // for the wrapper prefix, either quote style, and embedded newlines.
+  const source = validateRadioViewModel.toString();
+  const match = source.match(/exactKeys[^(]*\(v,\s*\[([\s\S]*?)\]\s*,\s*["']\$["']\)/);
+  if (!match) {
+    throw new Error(
+      'optional-group-allow-list pin: could not locate the top-level '
+      + "exactKeys(v, [...], '$') allow-list in validateRadioViewModel's "
+      + 'source — has its call shape changed? Update the regex above.',
+    );
+  }
+  return match[1]
+    .split(',')
+    .map((entry) => entry.trim().replace(/^['"]|['"]$/g, ''))
+    .filter((entry) => entry.length > 0);
+}
+
+const base = topologyFixtures['1/single'];
+
+describe('validateRadioViewModel top-level allow-list agrees with the read set (MOR-1244 pin, N1)', () => {
+  it('the shipped allow-list contains exactly the required keys plus the declared optional groups', () => {
+    const allowList = extractTopLevelAllowList();
+    expect(new Set(allowList)).toEqual(new Set([...REQUIRED_KEYS, ...EXPECTED_OPTIONAL_GROUP_KEYS]));
+  });
+
+  // Derived from the REAL source, not from EXPECTED_OPTIONAL_GROUP_KEYS — if
+  // a stray key is added to the shipped allow-list, it appears here too,
+  // and the it.each below automatically exercises it.
+  const declaredOptionalKeys = extractTopLevelAllowList()
+    .filter((key) => !(REQUIRED_KEYS as readonly string[]).includes(key));
+
+  it('at least one declared optional key was found by the source-derivation harness (sanity on the harness itself)', () => {
+    expect(declaredOptionalKeys.length).toBeGreaterThan(0);
+  });
+
+  it.each(declaredOptionalKeys)(
+    'a garbage (non-object) value under the declared optional key "%s" throws — proves it is read, not merely allow-listed',
+    (key) => {
+      const model = { ...base, [key]: 'garbage-not-an-object' };
+      expect(() => validateRadioViewModel(model)).toThrow(TypeError);
+    },
+  );
+});

--- a/frontend/src/semantic/__tests__/tx-aux.test.ts
+++ b/frontend/src/semantic/__tests__/tx-aux.test.ts
@@ -1,0 +1,177 @@
+/**
+ * MOR-1244 — `txAux` optional fact group (validator half).
+ *
+ * Slice 1A of the MOR-1262 decomposition: facts only for ATU/TUNE, VOX
+ * (+gain/anti-vox/delay), COMP (+level), MON (+level), RF power, mic gain,
+ * drive gain. See `radio-view-model.ts`'s `TxAuxViewModel`/`validateTxAux`
+ * for the shape and `radio-view-model-adapter.ts`'s `deriveTxAux` for the
+ * live derivation (covered by the companion adapter test file).
+ *
+ * This file pins the ticket's five kill-tests:
+ *  1. a txAux-absent model validates and round-trips byte-identically
+ *  2. `"txAux": null` throws (the S0/MOR-1264 absent-vs-malformed pin
+ *     extends to a real group, not just the synthetic one)
+ *  3. a malformed inner field throws with a precise `$.txAux....` path
+ *  5. an unknown extra key inside txAux throws
+ * (Kill-test 4, the adapter's evidence gate, lives in the adapter test file
+ * next to the code it mutates.)
+ */
+import { describe, expect, it } from 'vitest';
+import { validateRadioViewModel, type TxAuxField, type TxAuxViewModel } from '../radio-view-model';
+import { topologyFixtures, withTxAux } from '../fixtures/topologies';
+
+const AVAIL = { structural: true, operational: true } as const;
+const base = topologyFixtures['1/single'];
+
+describe('txAux (MOR-1244)', () => {
+  // ── Kill-test 1: absence is byte-identical, not a new default shape ──────
+  it('validates a txAux-absent model and never adds the key — structurally unavailable, not all-unknown', () => {
+    expect(Object.keys(base)).not.toContain('txAux');
+    const validated = validateRadioViewModel(base);
+    expect(Object.keys(validated)).not.toContain('txAux');
+    expect(validated.txAux).toBeUndefined();
+    expect(JSON.parse(JSON.stringify(validated))).toEqual(JSON.parse(JSON.stringify(base)));
+  });
+
+  it('validates a fully-populated txAux group and returns it unchanged', () => {
+    const withAux = withTxAux(base);
+    const validated = validateRadioViewModel(withAux);
+    expect(validated.txAux).toEqual(withAux.txAux);
+  });
+
+  // ── Kill-test 2: null is not absent (JSON has no undefined) ──────────────
+  it('rejects an explicit txAux: null', () => {
+    expect(() => validateRadioViewModel({ ...base, txAux: null })).toThrow(TypeError);
+  });
+
+  it('rejects an explicit txAux: {} — present, not absent, must satisfy its own shape', () => {
+    expect(() => validateRadioViewModel({ ...base, txAux: {} })).toThrow(TypeError);
+  });
+
+  // ── Kill-test 3: malformed inner field, precise path ──────────────────────
+  it('rejects a non-numeric voxGain reading value with a precise error path', () => {
+    const withAux = withTxAux(base);
+    const malformed = {
+      ...withAux,
+      txAux: {
+        ...withAux.txAux,
+        voxGain: { reading: { status: 'known', value: 'loud' }, availability: AVAIL },
+      },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.txAux\.voxGain\.reading\.value/);
+  });
+
+  it('rejects a non-boolean vox reading value with a precise error path', () => {
+    const withAux = withTxAux(base);
+    const malformed = {
+      ...withAux,
+      txAux: { ...withAux.txAux, vox: { reading: { status: 'known', value: 'yes' }, availability: AVAIL } },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.txAux\.vox\.reading\.value/);
+  });
+
+  it('rejects an atu reading value outside off/on/tuning', () => {
+    const withAux = withTxAux(base);
+    const malformed = {
+      ...withAux,
+      txAux: { ...withAux.txAux, atu: { reading: { status: 'known', value: 'tuned' }, availability: AVAIL } },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.txAux\.atu\.reading\.value/);
+  });
+
+  it('accepts each atu status (off, on, tuning)', () => {
+    const withAux = withTxAux(base);
+    for (const value of ['off', 'on', 'tuning'] as const) {
+      const model = {
+        ...withAux,
+        txAux: { ...withAux.txAux, atu: { reading: { status: 'known', value }, availability: AVAIL } },
+      };
+      expect(validateRadioViewModel(model).txAux?.atu.reading).toEqual({ status: 'known', value });
+    }
+  });
+
+  it('rejects a non-boolean field inside a txAux field Availability', () => {
+    const withAux = withTxAux(base);
+    const malformed = {
+      ...withAux,
+      txAux: {
+        ...withAux.txAux,
+        monitor: { reading: { status: 'unknown' }, availability: { structural: 'yes', operational: true } },
+      },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(TypeError);
+  });
+
+  it('rejects a reading with neither known nor unknown status', () => {
+    const withAux = withTxAux(base);
+    const malformed = {
+      ...withAux,
+      txAux: { ...withAux.txAux, compressor: { reading: { status: 'stale' }, availability: AVAIL } },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(TypeError);
+  });
+
+  it('accepts an unknown reading distinct from a known one, independently per field', () => {
+    const withAux = withTxAux(base);
+    const partial = {
+      ...withAux,
+      txAux: {
+        ...withAux.txAux,
+        driveGain: { reading: { status: 'unknown' }, availability: { structural: true, operational: false } },
+      },
+    };
+    const validated = validateRadioViewModel(partial);
+    expect(validated.txAux?.driveGain).toEqual({
+      reading: { status: 'unknown' }, availability: { structural: true, operational: false },
+    });
+    // The rest of the group is untouched by the one field's degrade.
+    expect(validated.txAux?.rfPower.reading).toEqual({ status: 'known', value: 0.8 });
+  });
+
+  // ── Kill-test 5: no speculative keys (N4) ─────────────────────────────────
+  it('rejects an unknown extra key inside txAux', () => {
+    const withAux = withTxAux(base);
+    const malformed = { ...withAux, txAux: { ...withAux.txAux, bogus: 1 } };
+    expect(() => validateRadioViewModel(malformed)).toThrow(TypeError);
+  });
+
+  it('rejects an unknown extra key inside a single txAux field', () => {
+    const withAux = withTxAux(base);
+    const malformed = {
+      ...withAux,
+      txAux: {
+        ...withAux.txAux,
+        micGain: { reading: { status: 'known', value: 128 }, availability: AVAIL, extra: true },
+      },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(TypeError);
+  });
+
+  it('rejects a reading that carries a value key while unknown', () => {
+    const withAux = withTxAux(base);
+    const malformed = {
+      ...withAux,
+      txAux: { ...withAux.txAux, monitorLevel: { reading: { status: 'unknown', value: 1 }, availability: AVAIL } },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(TypeError);
+  });
+
+  it('every field of a fully-populated group round-trips its own value', () => {
+    const withAux = withTxAux(base);
+    const validated = validateRadioViewModel(withAux).txAux as TxAuxViewModel;
+    const knownValue = <T>(f: TxAuxField<T>): T | undefined =>
+      f.reading.status === 'known' ? f.reading.value : undefined;
+    expect(knownValue(validated.atu)).toBe('off');
+    expect(knownValue(validated.vox)).toBe(false);
+    expect(knownValue(validated.voxGain)).toBe(50);
+    expect(knownValue(validated.antiVoxGain)).toBe(30);
+    expect(knownValue(validated.voxDelay)).toBe(20);
+    expect(knownValue(validated.compressor)).toBe(false);
+    expect(knownValue(validated.compressorLevel)).toBe(10);
+    expect(knownValue(validated.monitor)).toBe(false);
+    expect(knownValue(validated.monitorLevel)).toBe(128);
+    expect(knownValue(validated.rfPower)).toBe(0.8);
+    expect(knownValue(validated.micGain)).toBe(128);
+    expect(knownValue(validated.driveGain)).toBe(128);
+  });
+});

--- a/frontend/src/semantic/fixtures/topologies.ts
+++ b/frontend/src/semantic/fixtures/topologies.ts
@@ -13,7 +13,7 @@
  * matrix ("4 topology pairs + audio-only scope"), not a property of any one
  * topology, so it can be applied to any of the four fixtures below.
  */
-import type { RadioViewModel } from '../radio-view-model';
+import type { Availability, RadioViewModel, TxAuxField, TxAuxViewModel } from '../radio-view-model';
 
 const singleReceiver: RadioViewModel = {
   topologyId: '1/single',
@@ -152,4 +152,33 @@ export function withAudioOnlyScope(fixture: RadioViewModel): RadioViewModel {
       audioFftScope: { structural: true, operational: true },
     },
   };
+}
+
+/**
+ * Applies a fully-capable `txAux` group (MOR-1244) to any topology fixture —
+ * every control structurally present and operationally observed. Composable
+ * the same way `withAudioOnlyScope` is: TX-adjacent capability is an axis
+ * orthogonal to VFO topology, not a property of any one scheme, and "only
+ * where the radio genuinely has the capability" (governing scope) is left to
+ * the caller — this fixture models a radio that has all of them, it does not
+ * force txAux onto the four base topologies.
+ */
+export function withTxAux(fixture: RadioViewModel): RadioViewModel {
+  const avail: Availability = { structural: true, operational: true };
+  const known = <T>(value: T): TxAuxField<T> => ({ reading: { status: 'known', value }, availability: avail });
+  const txAux: TxAuxViewModel = {
+    atu: known('off'),
+    vox: known(false),
+    voxGain: known(50),
+    antiVoxGain: known(30),
+    voxDelay: known(20),
+    compressor: known(false),
+    compressorLevel: known(10),
+    monitor: known(false),
+    monitorLevel: known(128),
+    rfPower: known(0.8),
+    micGain: known(128),
+    driveGain: known(128),
+  };
+  return { ...fixture, txAux };
 }

--- a/frontend/src/semantic/radio-view-model.ts
+++ b/frontend/src/semantic/radio-view-model.ts
@@ -89,6 +89,44 @@ export interface DisabledReason {
   code: DisabledReasonCode;
 }
 
+/**
+ * A single TX-adjacent fact (MOR-1244): a value that is either known (with
+ * its type-checked reading) or unknown, paired with the MOR-977 two-level
+ * `Availability` — structural (does this radio model have the control at
+ * all) and operational (is it currently readable). The two are independent:
+ * `structural: false` means nothing to render; `structural: true,
+ * operational: false` means present-but-disabled, degrading to `unknown`
+ * rather than a guessed value, same doctrine as every other fact here.
+ */
+export type TxAuxReading<T> = { status: 'known'; value: T } | { status: 'unknown' };
+export interface TxAuxField<T> {
+  reading: TxAuxReading<T>;
+  availability: Availability;
+}
+export type AtuStatus = 'off' | 'on' | 'tuning';
+
+/**
+ * TX-adjacent facts (MOR-1244, MOR-1262 decomposition slice 1A): ATU/TUNE,
+ * VOX (+gain/anti-vox/delay), COMP (+level), MON (+level), RF power, mic
+ * gain, drive gain. Facts only — no action/dispatch. ATU TUNE is a
+ * transmit-causing action; this contract carries only its honestly-gated
+ * *state*, never a control to trigger it (MOR-1262 §2 slice 1 safety note i).
+ */
+export interface TxAuxViewModel {
+  atu: TxAuxField<AtuStatus>;
+  vox: TxAuxField<boolean>;
+  voxGain: TxAuxField<number>;
+  antiVoxGain: TxAuxField<number>;
+  voxDelay: TxAuxField<number>;
+  compressor: TxAuxField<boolean>;
+  compressorLevel: TxAuxField<number>;
+  monitor: TxAuxField<boolean>;
+  monitorLevel: TxAuxField<number>;
+  rfPower: TxAuxField<number>;
+  micGain: TxAuxField<number>;
+  driveGain: TxAuxField<number>;
+}
+
 export interface RadioViewModel {
   topologyId: string;
   vfoScheme: VfoScheme;
@@ -102,6 +140,10 @@ export interface RadioViewModel {
   txPermit: FrequencyPermit;
   scope: ScopeAvailabilityViewModel;
   disabledReasons: readonly DisabledReason[];
+  /** Absent (MOR-1264 optional group) ⇒ structurally unavailable: this radio
+   *  model has no TX-adjacent controls at all. Never emitted as a placeholder
+   *  of all-unknowns — see `radio-view-model-adapter.ts`'s evidence gate. */
+  readonly txAux?: TxAuxViewModel;
 }
 
 const RECEIVER_IDS: readonly ReceiverId[] = ['MAIN', 'SUB'];
@@ -128,6 +170,10 @@ function nullableNumber(value: unknown, path: string): number | null {
 function nullableString(value: unknown, path: string): string | null {
   if (value !== null && typeof value !== 'string') invalid(path, 'a string or null');
   return value as string | null;
+}
+function num(value: unknown, path: string): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) invalid(path, 'a finite number');
+  return value;
 }
 
 /**
@@ -270,6 +316,52 @@ function validateDisabledReason(value: unknown, path: string): DisabledReason {
   return { field: str(v.field, `${path}.field`), code: oneOf(v.code, DISABLED_REASON_CODES, `${path}.code`) };
 }
 
+const ATU_STATUSES: readonly AtuStatus[] = ['off', 'on', 'tuning'];
+
+function validateTxAuxField<T>(
+  value: unknown, path: string, validateValue: (v: unknown, p: string) => T,
+): TxAuxField<T> {
+  const v = record(value, path);
+  exactKeys(v, ['reading', 'availability'], path);
+  const r = record(v.reading, `${path}.reading`);
+  let reading: TxAuxReading<T>;
+  if (r.status === 'known') {
+    exactKeys(r, ['status', 'value'], `${path}.reading`);
+    reading = { status: 'known', value: validateValue(r.value, `${path}.reading.value`) };
+  } else if (r.status === 'unknown') {
+    exactKeys(r, ['status'], `${path}.reading`);
+    reading = { status: 'unknown' };
+  } else {
+    invalid(`${path}.reading.status`, "'known' | 'unknown'");
+  }
+  return { reading, availability: validateAvailability(v.availability, `${path}.availability`) };
+}
+
+/** N4: this `exactKeys` list is exactly the 12 fields the adapter reads —
+ *  no speculative keys. See `radio-view-model-adapter.ts::deriveTxAux`. */
+function validateTxAux(value: unknown, path: string): TxAuxViewModel {
+  const v = record(value, path);
+  exactKeys(v, [
+    'atu', 'vox', 'voxGain', 'antiVoxGain', 'voxDelay',
+    'compressor', 'compressorLevel', 'monitor', 'monitorLevel',
+    'rfPower', 'micGain', 'driveGain',
+  ], path);
+  return {
+    atu: validateTxAuxField(v.atu, `${path}.atu`, (val, p) => oneOf(val, ATU_STATUSES, p)),
+    vox: validateTxAuxField(v.vox, `${path}.vox`, bool),
+    voxGain: validateTxAuxField(v.voxGain, `${path}.voxGain`, num),
+    antiVoxGain: validateTxAuxField(v.antiVoxGain, `${path}.antiVoxGain`, num),
+    voxDelay: validateTxAuxField(v.voxDelay, `${path}.voxDelay`, num),
+    compressor: validateTxAuxField(v.compressor, `${path}.compressor`, bool),
+    compressorLevel: validateTxAuxField(v.compressorLevel, `${path}.compressorLevel`, num),
+    monitor: validateTxAuxField(v.monitor, `${path}.monitor`, bool),
+    monitorLevel: validateTxAuxField(v.monitorLevel, `${path}.monitorLevel`, num),
+    rfPower: validateTxAuxField(v.rfPower, `${path}.rfPower`, num),
+    micGain: validateTxAuxField(v.micGain, `${path}.micGain`, num),
+    driveGain: validateTxAuxField(v.driveGain, `${path}.driveGain`, num),
+  };
+}
+
 /** Runtime validator (repo idiom: throws TypeError with a `$.path`, see `validateCapabilities`).
  *  Also enforces two cross-field invariants (review cycle 1, V1): `txPermit`
  *  cannot be 'allowed' while `txTarget` is unknown (no fail-open), and
@@ -278,7 +370,7 @@ export function validateRadioViewModel(value: unknown): RadioViewModel {
   const v = record(value, '$');
   exactKeys(v, [
     'topologyId', 'vfoScheme', 'activeReceiver', 'vfos', 'split', 'dualWatch',
-    'txTarget', 'txPermit', 'scope', 'disabledReasons',
+    'txTarget', 'txPermit', 'scope', 'disabledReasons', 'txAux',
   ], '$');
   if (!Array.isArray(v.vfos)) invalid('$.vfos', 'an array');
   if (!Array.isArray(v.disabledReasons)) invalid('$.disabledReasons', 'an array');
@@ -300,6 +392,14 @@ export function validateRadioViewModel(value: unknown): RadioViewModel {
     }
   });
 
+  // Conditional spread, not `txAux: optionalGroup(...)` directly: an absent
+  // group must OMIT the key, not merely set it to `undefined` — a plain
+  // property assignment still shows up in `Object.keys()`, which would make
+  // "structurally unavailable" indistinguishable from "present" to any
+  // consumer that inventories keys (see the adapter test's exact-key-list
+  // assertion this was verified against).
+  const txAux = optionalGroup(v.txAux, '$.txAux', validateTxAux);
+
   return {
     topologyId: str(v.topologyId, '$.topologyId'),
     vfoScheme: oneOf(v.vfoScheme, VFO_SCHEMES, '$.vfoScheme'),
@@ -314,5 +414,6 @@ export function validateRadioViewModel(value: unknown): RadioViewModel {
       audioFftScope: validateAvailability(scope.audioFftScope, '$.scope.audioFftScope'),
     },
     disabledReasons: v.disabledReasons.map((r, i) => validateDisabledReason(r, `$.disabledReasons[${i}]`)),
+    ...(txAux !== undefined ? { txAux } : {}),
   };
 }


### PR DESCRIPTION
Closes MOR-1244 (re-scoped to slice 1A of the MOR-1262 vocabulary program — the facts half; the TxAuxSurface is MOR-1265/1B). First real consumer of the MOR-1264 optional-group mechanism; head of the serialized A-queue.

## What

Optional `txAux` fact group: 12 TX-adjacent operator facts (ATU/TUNE with v2-faithful 0/1/2 status, VOX family, COMP, MON, RF power, mic/drive gain), each `{value|unknown, Availability}` distinguishing structural absence from operational unavailability. Adapter derivation gated on positive evidence; composable fixture helper. **139 net production LOC**, 3 production files, 33 tests.

## Provenance

- Independent adversarial verification (opus — the S0/contract verifier): **PASS**, 4 findings (1 minor + 3 observations). Evidence-gate ruling: **ACCEPTED ADDITION, not a deviation** — the ticket's "topFieldAvailable exactly as toTxProps" governs the per-field gate, satisfied verbatim (byte-identical copy of v2's function); the group-emission gate is a NEW obligation S0's optionality created, N3-faithful (emitting on bare `tx:true` would fabricate a twelve-field all-unknowns family). No under-emission: the verifier ran the adapter against the real `rigs/*.toml` capability tags — IC-7610 declares all five sub-tags, X6200/FTX-1 declare vox/compressor/tuner, so every real radio gets its group at startup with fields honestly `structural: true, operational: false` until observed; X6200/FTX-1 correctly report `monitor` structurally absent.
- All four spot-checked v2 provenance citations verified against real `panel-props.ts` lines; conditional-spread omission ruled stronger than S0's own reference; the 4 canonical fixtures and the protected adapter key-list test proven untouched by git.
- Pin round (test-only, production sha-identical): the verifier's V2 mutant (stray allow-list key with no read — the compounding N4 drift with 12 families queued) now dies on a source-derived pin; 1B handoff notes restate the no-second-key-path and ATU-TUNE-emits-a-carrier constraints.

Failing-file set identical to baseline (environmental Node-26 `localStorage`; CI is the gate); lint/check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)