### PR TITLE
feat(MOR-1265): TxAuxSurface - TX-adjacent operator controls (vocabulary slice 1B)

### DIFF
--- a/frontend/src/components-v2/layout/__tests__/MobileRadioLayout.component.svelte.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/MobileRadioLayout.component.svelte.test.ts
@@ -103,6 +103,10 @@ vi.mock('../../wiring/command-bus', () => {
       onMainFreqChange: n, onSubFreqChange: n, onVfoSwap: n, onVfoEqual: n, onReceiverSelect: n,
       onMainVfoClick: onMainVfoClickSpy, onSubVfoClick: onSubVfoClickSpy,
     }),
+    // MOR-1265 — the semantic wiring now also composes the txAux intents.
+    makeVoxHandlers: () => ({
+      onVoxToggle: n, onVoxGainChange: n, onAntiVoxGainChange: n, onVoxDelayChange: n,
+    }),
     makeMeterHandlers: () => ({ onMeterSourceChange: n }), makeKeyboardHandlers: () => ({ dispatch: n }),
     makeModeHandlers: () => ({ onModeChange: n, onDataModeChange: n }),
     makeFilterHandlers: () => ({ onFilterChange: n, onFilterWidthChange: n }),

--- a/frontend/src/components-v2/layout/__tests__/semantic-mobile-migration.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-mobile-migration.component.test.ts
@@ -129,6 +129,10 @@ vi.mock('../../wiring/command-bus', () => {
       onMainVfoClick: n, onSubVfoClick: n, onSplitToggle: n, onSwap: n, onEqual: n,
       onVfoSelect: n, onDualWatchToggle: n,
     }),
+    // MOR-1265 — the semantic wiring now also composes the txAux intents.
+    makeVoxHandlers: () => ({
+      onVoxToggle: n, onVoxGainChange: n, onAntiVoxGainChange: n, onVoxDelayChange: n,
+    }),
     makeMeterHandlers: () => ({ onMeterSourceChange: n }), makeKeyboardHandlers: () => ({ dispatch: n }),
     makeModeHandlers: () => ({ onModeChange: n, onDataModeChange: n }),
     makeFilterHandlers: () => ({ onFilterChange: n, onFilterWidthChange: n }),

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -28,9 +28,13 @@
   import { getAppTxController } from '$lib/runtime/tx-controller/app-host';
   import type { RadioViewModel } from '../../semantic/radio-view-model';
   import RxTxSurface from '../../semantic/RxTxSurface.svelte';
+  import TxAuxSurface, {
+    type TxAuxLevelField, type TxAuxToggleField,
+  } from '../../semantic/TxAuxSurface.svelte';
+  import { keyBlockedReasons } from '../../semantic/rx-tx-surface';
   import VfoSurface, { type VfoSelection } from '../../semantic/VfoSurface.svelte';
   import ModInputTxWarning from '../panels/ModInputTxWarning.svelte';
-  import { makeVfoHandlers } from './command-bus';
+  import { makeTxHandlers, makeVfoHandlers, makeVoxHandlers } from './command-bus';
   import {
     forReceiver, receiversOf, isActiveStrip, isOperationalStrip,
   } from './dual-receiver-strips';
@@ -57,6 +61,25 @@
   let { strips = 'single' }: Props = $props();
 
   const vfo = makeVfoHandlers();
+  /**
+   * MOR-1265. The two v2 handler factories already carry every txAux intent
+   * (`makeVoxHandlers` owns gain/anti-VOX/delay, `makeTxHandlers` the rest);
+   * composing them keeps ONE command vocabulary rather than a v3 fork of it.
+   * The two maps below exist so the pure surface can stay field-addressed —
+   * agreement with the shipped command-bus names is pinned in
+   * `__tests__/tx-aux-command-bus.test.ts` against the REAL module.
+   */
+  const txAuxIntents = { ...makeVoxHandlers(), ...makeTxHandlers() };
+  const TX_AUX_TOGGLE_INTENT: Record<TxAuxToggleField, () => void> = {
+    atu: txAuxIntents.onAtuToggle, vox: txAuxIntents.onVoxToggle,
+    compressor: txAuxIntents.onCompToggle, monitor: txAuxIntents.onMonToggle,
+  };
+  const TX_AUX_LEVEL_INTENT: Record<TxAuxLevelField, (value: number) => void> = {
+    rfPower: txAuxIntents.onRfPowerChange, micGain: txAuxIntents.onMicGainChange,
+    driveGain: txAuxIntents.onDriveGainChange, voxGain: txAuxIntents.onVoxGainChange,
+    antiVoxGain: txAuxIntents.onAntiVoxGainChange, voxDelay: txAuxIntents.onVoxDelayChange,
+    compressorLevel: txAuxIntents.onCompLevelChange, monitorLevel: txAuxIntents.onMonLevelChange,
+  };
   const tx = getAppTxController();
   const sourceId = `semantic-rx-tx-${++surfaceSeq}`;
   let leaseSeq = 0;
@@ -103,6 +126,23 @@
    *  the layout chrome the operator has no UI exit from a fault. */
   function clearFault(): void {
     tx.resetFault();
+  }
+
+  /**
+   * ATU TUNE emits a CARRIER — a transmit-causing action (MOR-1262 §2 slice 1
+   * safety note i). Routing decision, recorded on MOR-1265: the *gate* is the
+   * App-owned TX authority — the shared `keyBlockedReasons` predicate on the
+   * LIVE snapshot, exactly what blocks the key intent — while the *carrier*
+   * stays radio-owned (the ATU's own tune cycle, started by the backend
+   * command). No TX lease is taken, so this never becomes a second key path
+   * (safety note iii); it can only be more restrictive than keying, never
+   * less. The snapshot is read HERE rather than from `txState` because the
+   * transmitter can start between the last render and the click — the same
+   * live-read discipline `requestUnkey` uses for the guard.
+   */
+  function requestAtuTune(): void {
+    if (!view || keyBlockedReasons(view, tx.snapshot()).length > 0) return;
+    txAuxIntents.onAtuTune();
   }
 
   function selectVfo(target: VfoSelection): void {
@@ -211,6 +251,24 @@
       <div class="rx-tx-zone" data-zone-id="rx-tx">{@render rxTxSurface()}</div>
     {:else}
       {@render rxTxSurface()}
+    {/if}
+    <!--
+      MOR-1265. STRUCTURAL gate: the surface mounts only when the view model
+      actually carries the group, so a radio the MOR-1244 evidence gate
+      declined renders the pre-1265 element shape exactly (pinned in
+      `__tests__/semantic-tx-aux-wiring.component.test.ts`). Bare in BOTH
+      compositions and with no `data-zone-id`: `'txAux'` is merely declarable
+      by a manifest after this slice; no manifest declares a txAux zone yet,
+      and binding one here would put a zone id in the DOM that no layout
+      asked for (the MOR-1069 lesson).
+    -->
+    {#if view.txAux}
+      <TxAuxSurface
+        {view} tx={txState}
+        onToggle={(field) => TX_AUX_TOGGLE_INTENT[field]()}
+        onLevelChange={(field, value) => TX_AUX_LEVEL_INTENT[field](value)}
+        onAtuTune={requestAtuTune}
+      />
     {/if}
   {/if}
 

--- a/frontend/src/components-v2/wiring/__tests__/semantic-rx-tx-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rx-tx-wiring.component.test.ts
@@ -43,6 +43,10 @@ const h = vi.hoisted(() => ({
   unsubscribeCalls: 0,
   /** `listeners.size` sampled at the instant each `release` re-enters. */
   listenersAtRelease: [] as number[],
+  /** MOR-1265: stand-in for every txAux intent. These fixtures declare no
+   *  txAux capability and carry no txAux state, so the MOR-1244 evidence gate
+   *  omits the group and none of these is ever reachable here. */
+  txAuxNoop: vi.fn(),
 }));
 
 vi.mock('$lib/runtime', () => ({
@@ -81,6 +85,17 @@ vi.mock('../command-bus', () => ({
     onVfoSelect: h.selectVfo,
     onSplitToggle: h.splitToggle,
     onDualWatchToggle: h.dualWatchToggle,
+  }),
+  // MOR-1265 — the wiring now also composes the txAux intent vocabulary.
+  makeVoxHandlers: () => ({
+    onVoxToggle: h.txAuxNoop, onVoxGainChange: h.txAuxNoop,
+    onAntiVoxGainChange: h.txAuxNoop, onVoxDelayChange: h.txAuxNoop,
+  }),
+  makeTxHandlers: () => ({
+    onRfPowerChange: h.txAuxNoop, onMicGainChange: h.txAuxNoop, onAtuToggle: h.txAuxNoop,
+    onAtuTune: h.txAuxNoop, onVoxToggle: h.txAuxNoop, onCompToggle: h.txAuxNoop,
+    onCompLevelChange: h.txAuxNoop, onMonToggle: h.txAuxNoop,
+    onMonLevelChange: h.txAuxNoop, onDriveGainChange: h.txAuxNoop,
   }),
 }));
 

--- a/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
@@ -1,0 +1,358 @@
+/**
+ * MOR-1265 — the semantic TX-auxiliary surface wired into `SemanticRadioSurfaces`.
+ *
+ * SAFETY-CRITICAL, for two independent reasons:
+ *   (a) ATU **TUNE** emits a carrier. The wiring is the last gate before the
+ *       command leaves the browser, and it must consult the LIVE App TX
+ *       authority snapshot — not the one the last render happened to see.
+ *   (b) The default path must stay byte-identical. `SemanticRadioSurfaces`
+ *       mounts on sdr-test, both LCD layouts, mobile and the cockpit; a view
+ *       model with no `txAux` group (every radio the MOR-1244 evidence gate
+ *       declines) must render exactly the element shape it renders today.
+ *
+ * The controller here is a spy; the surfaces are the real ones.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { ServerState } from '$lib/types/state';
+
+type Snapshot = {
+  phase: string; intent: string | null; guard: { leaseId: string } | null;
+  radioTx: string; txRisk: string; mayOwnKey: boolean; fault: string | null;
+};
+
+const h = vi.hoisted(() => ({
+  state: null as unknown,
+  caps: null as unknown,
+  snapshot: null as unknown,
+  listeners: new Set<(next: unknown) => void>(),
+  start: vi.fn(),
+  release: vi.fn(),
+  atuToggle: vi.fn(),
+  atuTune: vi.fn(),
+  voxToggle: vi.fn(),
+  compToggle: vi.fn(),
+  monToggle: vi.fn(),
+  rfPower: vi.fn(),
+  micGain: vi.fn(),
+  driveGain: vi.fn(),
+  voxGain: vi.fn(),
+  antiVoxGain: vi.fn(),
+  voxDelay: vi.fn(),
+  compLevel: vi.fn(),
+  monLevel: vi.fn(),
+  noop: vi.fn(),
+}));
+
+vi.mock('$lib/runtime', () => ({
+  runtime: { get state() { return h.state; }, get caps() { return h.caps; } },
+}));
+vi.mock('$lib/runtime/tx-controller/app-host', () => ({
+  getAppTxController: () => ({
+    snapshot: () => h.snapshot,
+    subscribe: (listener: (next: unknown) => void) => {
+      h.listeners.add(listener);
+      return () => { h.listeners.delete(listener); };
+    },
+    start: h.start,
+    setIntent: vi.fn(),
+    release: h.release,
+    resetFault: vi.fn(),
+  }),
+}));
+vi.mock('$lib/runtime/adapters/mod-input-tx-guard.svelte', () => ({
+  deriveModInputTxGuardProps: () => ({ visible: false, sourceLabel: null }),
+  getModInputTxGuardHandlers: () => ({ onSetLan: vi.fn(), onDismiss: vi.fn() }),
+}));
+// The names below are the REAL `makeTxHandlers`/`makeVoxHandlers` surface —
+// agreement with the shipped module is proven separately, against the real
+// module, in `tx-aux-command-bus.test.ts`.
+vi.mock('../command-bus', () => ({
+  makeVfoHandlers: () => ({
+    onVfoSelect: h.noop, onSplitToggle: h.noop, onDualWatchToggle: h.noop,
+  }),
+  makeVoxHandlers: () => ({
+    onVoxToggle: h.voxToggle, onVoxGainChange: h.voxGain,
+    onAntiVoxGainChange: h.antiVoxGain, onVoxDelayChange: h.voxDelay,
+  }),
+  makeTxHandlers: () => ({
+    onRfPowerChange: h.rfPower, onMicGainChange: h.micGain, onAtuToggle: h.atuToggle,
+    onAtuTune: h.atuTune, onVoxToggle: h.voxToggle, onCompToggle: h.compToggle,
+    onCompLevelChange: h.compLevel, onMonToggle: h.monToggle,
+    onMonLevelChange: h.monLevel, onDriveGainChange: h.driveGain,
+  }),
+}));
+
+import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';
+
+const IDLE: Snapshot = {
+  phase: 'idle', intent: null, guard: null, radioTx: 'off', txRisk: 'none',
+  mayOwnKey: false, fault: null,
+};
+
+const fresh = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' };
+const slot = (freqHz: number) => ({ freqHz, mode: 'USB', filterNum: 1, dataMode: 0 });
+
+/** Every txAux raw field the MOR-1244 adapter reads, all observed fresh. */
+const TX_AUX_STATE = {
+  tunerStatus: 0, voxOn: false, voxGain: 50, antiVoxGain: 30, voxDelay: 10,
+  compressorOn: false, compressorLevel: 40, monitorOn: false, monitorGain: 60,
+  powerLevel: 0.8, micGain: 128, driveGain: 128,
+} as const;
+const TX_AUX_PATHS = [
+  'tunerStatus', 'voxOn', 'voxGain', 'antiVoxGain', 'voxDelay', 'compressorOn',
+  'compressorLevel', 'monitorOn', 'monitorGain', 'powerLevel', 'micGain', 'driveGain',
+];
+
+function liveState(withTxAux: boolean): ServerState {
+  const paths = ['active', 'split', 'dualWatch', 'txTarget'];
+  for (const rx of ['main', 'sub']) {
+    paths.push(`${rx}.freqHz`, `${rx}.mode`, `${rx}.filter`, `${rx}.activeSlot`);
+    for (const v of ['vfoA', 'vfoB']) {
+      paths.push(`${rx}.${v}.freqHz`, `${rx}.${v}.mode`, `${rx}.${v}.filterNum`);
+    }
+  }
+  if (withTxAux) paths.push(...TX_AUX_PATHS);
+  const receiver = (hz: number) => ({
+    ...slot(hz), vfoA: slot(hz), vfoB: slot(hz + 50000), activeSlot: 'A', filter: 1,
+  });
+  return {
+    active: 'MAIN', split: false, dualWatch: false, ptt: false,
+    txTarget: { status: 'known', receiver: 'MAIN', slot: 'A', frequencyHz: 14250000 },
+    main: receiver(14250000), sub: receiver(14300000),
+    ...(withTxAux ? TX_AUX_STATE : {}),
+    fieldStatus: Object.fromEntries(paths.map((p) => [p, fresh])),
+  } as unknown as ServerState;
+}
+
+const liveCaps = (withTxAux: boolean): Capabilities => ({
+  model: 'fixture', scope: false, audio: true, tx: true,
+  capabilities: withTxAux
+    ? ['audio', 'tx', 'dual_rx', 'vox', 'compressor', 'monitor', 'tuner', 'drive_gain']
+    : ['audio', 'tx', 'dual_rx'],
+  receivers: 2, vfoScheme: 'main_sub', freqRanges: [], modes: [], filters: [],
+  audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
+  webrtc: { available: false, enabled: false },
+  txBands: [{ start: 14000000, end: 14350000, name: '20m' }],
+  scopeSource: null, audioFftAvailable: false,
+} as unknown as Capabilities);
+
+let target: HTMLDivElement;
+let component: ReturnType<typeof mount> | null = null;
+
+function render(props: { strips?: 'single' | 'dual' } = {}): void {
+  target = document.createElement('div');
+  document.body.appendChild(target);
+  component = mount(SemanticRadioSurfaces, { target, props });
+  flushSync();
+}
+
+function push(next: Partial<Snapshot>): void {
+  h.snapshot = { ...(h.snapshot as Snapshot), ...next };
+  for (const listener of h.listeners) listener(h.snapshot);
+  flushSync();
+}
+
+const q = <T extends HTMLElement>(sel: string) => target.querySelector(sel) as T | null;
+
+beforeEach(() => {
+  h.state = liveState(true);
+  h.caps = liveCaps(true);
+  h.snapshot = { ...IDLE };
+  h.listeners.clear();
+  for (const value of Object.values(h)) {
+    if (typeof value === 'function' && 'mockReset' in value) (value as ReturnType<typeof vi.fn>).mockReset();
+  }
+});
+
+afterEach(() => {
+  if (component) unmount(component);
+  component = null;
+  document.body.innerHTML = '';
+});
+
+// ── 1. The structural gate: absent group ⇒ no surface, no element drift ────
+
+describe('the txAux surface mounts only when the view model carries the group', () => {
+  /**
+   * The element shape of the default (single) path, as a LITERAL. Every entry
+   * is `tagName[data-testid]`, depth-first over `.semantic-surfaces`.
+   *
+   * MUTATION KILLED: mounting `TxAuxSurface` unconditionally (dropping the
+   * `{#if view.txAux}` structural gate), or wrapping it in a zone shell that
+   * every path renders — either changes this sequence for a radio whose
+   * MOR-1244 evidence gate declined the group, i.e. for the byte-identical
+   * default path this slice promised not to touch.
+   */
+  const DEFAULT_PATH_TESTIDS = [
+    'vfo-surface', 'vfo-active-receiver', 'vfo-list',
+    'rx-tx-surface', 'rx-tx-state', 'rx-tx-rf-mark', 'rx-tx-rf-label',
+    'rx-tx-target', 'rx-tx-key', 'rx-tx-unkey', 'rx-tx-blocked',
+  ];
+
+  const testids = () => [...target.querySelectorAll<HTMLElement>('[data-testid]')]
+    .map((el) => el.dataset.testid!)
+    .filter((id) => id !== 'semantic-radio-surfaces');
+  /** Every element under the root, in document order — the identity probe
+   *  proper: a mount that renders nothing still cannot slip past this. */
+  const outline = () => [...q('[data-testid="semantic-radio-surfaces"]')!.querySelectorAll('*')]
+    .map((el) => el.tagName.toLowerCase()).join(' ');
+  const DEFAULT_PATH_OUTLINE = 'div p div div span span span span span div span span span button '
+    + 'div span span span button div span span span button div button button '
+    + 'section p span span span span p div button button ul';
+
+  it.each(['single', 'dual'] as const)('renders no txAux surface at all without the group (%s)', (strips) => {
+    h.state = liveState(false);
+    h.caps = liveCaps(false);
+    render({ strips });
+    expect(q('[data-testid="tx-aux-surface"]')).toBeNull();
+    expect(q('[data-testid="tx-aux-atu-tune"]')).toBeNull();
+    expect(target.innerHTML).not.toContain('tx-aux');
+  });
+
+  it('leaves the default path element sequence exactly as it is today', () => {
+    h.state = liveState(false);
+    h.caps = liveCaps(false);
+    render();
+    expect(testids()).toEqual(DEFAULT_PATH_TESTIDS);
+    expect(outline()).toBe(DEFAULT_PATH_OUTLINE);
+  });
+
+  it.each(['single', 'dual'] as const)('mounts the txAux surface when the group is present (%s)', (strips) => {
+    render({ strips });
+    expect(q('[data-testid="tx-aux-surface"]')).not.toBeNull();
+    expect(target.querySelectorAll('[data-testid="tx-aux-surface"]')).toHaveLength(1);
+  });
+
+  // MUTATION KILLED: giving the txAux surface a `data-zone-id` here. Zone
+  // declarability comes from `SEMANTIC_SURFACE_NAMES`; no manifest declares a
+  // txAux zone in this slice, so binding one would put a zone id in the DOM
+  // that no layout manifest ever declared (the MOR-1069 lesson).
+  it('binds no zone id to the txAux surface in either composition', () => {
+    render({ strips: 'dual' });
+    const zones = [...target.querySelectorAll<HTMLElement>('[data-zone-id]')]
+      .map((el) => el.dataset.zoneId);
+    expect(zones).toEqual(['primary-vfo', 'secondary-vfo', 'global', 'rx-tx']);
+    expect(q('[data-testid="tx-aux-surface"]')!.closest('[data-zone-id]')).toBeNull();
+  });
+});
+
+// ── 2. Still exactly ONE key path (safety note iii) ────────────────────────
+
+describe('the txAux surface does not become a second key path', () => {
+  // MUTATION KILLED: a TxAuxSurface variant that renders a key control, or a
+  // wiring change that mounts a second RxTxSurface alongside it.
+  it('keeps exactly one key/unkey authority in the composed tree', () => {
+    render();
+    expect(target.querySelectorAll('[data-testid="rx-tx-surface"]')).toHaveLength(1);
+    expect(target.querySelectorAll('[data-testid="rx-tx-key"]')).toHaveLength(1);
+    expect(target.querySelectorAll('[data-testid="rx-tx-unkey"]')).toHaveLength(1);
+  });
+
+  it('never starts or releases a TX lease from a txAux intent', () => {
+    render();
+    q<HTMLButtonElement>('[data-testid="tx-aux-atu-tune"]')!.click();
+    q<HTMLButtonElement>('[data-testid="tx-aux-vox"]')!.click();
+    flushSync();
+    expect(h.atuTune).toHaveBeenCalledOnce();
+    expect(h.start).not.toHaveBeenCalled();
+    expect(h.release).not.toHaveBeenCalled();
+  });
+});
+
+// ── 3. ATU TUNE routes through the App-owned TX authority ──────────────────
+
+const BLOCKING: readonly (readonly [string, Partial<Snapshot>])[] = [
+  ['a fault is latched', { fault: 'on-timeout' }],
+  ['a lease is in progress', { phase: 'key-confirm-pending' }],
+  ['this browser may own the key', { mayOwnKey: true }],
+  ['the radio is already transmitting', { radioTx: 'on' }],
+  ['the RF state is unknown', { radioTx: 'unknown' }],
+  ['TX risk is uncertain', { txRisk: 'uncertain' }],
+];
+
+describe('ATU TUNE is gated by the live App TX authority', () => {
+  it('dispatches the tune command when nothing blocks a key intent', () => {
+    render();
+    const tune = q<HTMLButtonElement>('[data-testid="tx-aux-atu-tune"]')!;
+    expect(tune.disabled).toBe(false);
+    tune.click();
+    flushSync();
+    expect(h.atuTune).toHaveBeenCalledOnce();
+  });
+
+  it.each(BLOCKING)('disables and refuses TUNE while %s', (_label, over) => {
+    render();
+    push(over);
+    const tune = q<HTMLButtonElement>('[data-testid="tx-aux-atu-tune"]')!;
+    expect(tune.disabled).toBe(true);
+    tune.disabled = false; // a restyled / programmatically enabled control
+    tune.click();
+    flushSync();
+    expect(h.atuTune).not.toHaveBeenCalled();
+  });
+
+  // MUTATION KILLED: guarding on the snapshot captured at render time instead
+  // of reading the authority NOW. The transmitter can start between the last
+  // render and the click; a stale snapshot would let TUNE fire into it. Same
+  // discipline as `requestUnkey` reading the live guard.
+  it('refuses a tune against an authority state the render never saw', () => {
+    render();
+    const tune = q<HTMLButtonElement>('[data-testid="tx-aux-atu-tune"]')!;
+    // Mutate the authority WITHOUT notifying subscribers: no re-render runs.
+    h.snapshot = { ...(h.snapshot as Snapshot), radioTx: 'on' };
+    expect(tune.disabled).toBe(false);
+    tune.click();
+    flushSync();
+    expect(h.atuTune).not.toHaveBeenCalled();
+  });
+
+  // MUTATION KILLED: gating the ordinary (non-transmitting) ATU on/off toggle
+  // on TX authority too. It sets a tuner mode, it does not emit a carrier —
+  // over-gating would strand the operator with an ATU they cannot turn off.
+  it('leaves the non-transmitting ATU toggle usable while TUNE is blocked', () => {
+    render();
+    push({ radioTx: 'on' });
+    expect(q<HTMLButtonElement>('[data-testid="tx-aux-atu-tune"]')!.disabled).toBe(true);
+    const atu = q<HTMLButtonElement>('[data-testid="tx-aux-atu"]')!;
+    expect(atu.disabled).toBe(false);
+    atu.click();
+    flushSync();
+    expect(h.atuToggle).toHaveBeenCalledOnce();
+  });
+});
+
+// ── 4. Intents reach the mapped command-bus handler ────────────────────────
+
+describe('every txAux intent reaches its own command-bus handler', () => {
+  it.each([
+    ['atu', () => h.atuToggle], ['vox', () => h.voxToggle],
+    ['compressor', () => h.compToggle], ['monitor', () => h.monToggle],
+  ] as const)('routes the "%s" toggle', (field, spy) => {
+    render();
+    q<HTMLButtonElement>(`[data-testid="tx-aux-${field}"]`)!.click();
+    flushSync();
+    expect(spy()).toHaveBeenCalledOnce();
+  });
+
+  // MUTATION KILLED: a transposed or duplicated entry in the level intent
+  // map — e.g. mic gain wired to the drive-gain command. Each case asserts
+  // its own spy fired AND that it is the only one that did.
+  it.each([
+    ['rfPower', 0.5, () => h.rfPower], ['micGain', 200, () => h.micGain],
+    ['driveGain', 100, () => h.driveGain], ['voxGain', 77, () => h.voxGain],
+    ['antiVoxGain', 12, () => h.antiVoxGain], ['voxDelay', 5, () => h.voxDelay],
+    ['compressorLevel', 33, () => h.compLevel], ['monitorLevel', 99, () => h.monLevel],
+  ] as const)('routes the "%s" level with its raw value', (field, value, spy) => {
+    render();
+    const input = q<HTMLInputElement>(`[data-testid="tx-aux-${field}"] input`)!;
+    input.value = String(value);
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    expect(spy()).toHaveBeenCalledExactlyOnceWith(value);
+    const others = [h.rfPower, h.micGain, h.driveGain, h.voxGain, h.antiVoxGain,
+      h.voxDelay, h.compLevel, h.monLevel].filter((s) => s !== spy());
+    for (const other of others) expect(other).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components-v2/wiring/__tests__/tx-aux-command-bus.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/tx-aux-command-bus.test.ts
@@ -1,0 +1,86 @@
+/**
+ * MOR-1265 — the txAux intent maps agree with the REAL command bus.
+ *
+ * `SemanticRadioSurfaces` addresses the v2 handlers by name
+ * (`txAuxIntents.onAtuTune`, …). Its own component test mocks `../command-bus`,
+ * so a renamed or deleted handler there would be invisible to it: the mock
+ * would keep answering. This file closes that gap by loading the real module
+ * (`dsp-nr-level.test.ts`'s established mocking recipe) and asserting, for
+ * every name the wiring source actually references, that it exists and emits
+ * the exact command the radio expects.
+ *
+ * The safety-critical one is `onAtuTune`: it must send the ATU tune-start
+ * command and nothing else. A silent rename would leave the gated TUNE
+ * button wired to `undefined` — or, worse, to a neighbouring TX command.
+ */
+import { readFileSync } from 'node:fs';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('$lib/transport/ws-client', () => ({ sendCommand: vi.fn() }));
+vi.mock('$lib/stores/radio.svelte', () => ({
+  getActiveReceiver: vi.fn(() => null),
+  getRadioState: vi.fn(() => ({ active: 'MAIN' })),
+  patchActiveReceiver: vi.fn(),
+  patchRadioState: vi.fn(),
+  patchReceiver: vi.fn(),
+}));
+vi.mock('$lib/audio/audio-manager', () => ({
+  audioManager: {
+    setAudioConfig: vi.fn(), startRx: vi.fn(), stopRx: vi.fn(),
+    setRxVolume: vi.fn(), rxEnabled: false,
+  },
+}));
+
+import { sendCommand } from '$lib/transport/ws-client';
+import { makeTxHandlers, makeVoxHandlers } from '../command-bus';
+
+/** The composed object the wiring builds — same spread, same precedence. */
+const intents = (): Record<string, (...args: never[]) => void> =>
+  ({ ...makeVoxHandlers(), ...makeTxHandlers() }) as unknown as Record<string, (...args: never[]) => void>;
+
+const wiringSource = readFileSync('src/components-v2/wiring/SemanticRadioSurfaces.svelte', 'utf8');
+/** Every `txAuxIntents.onXxx` the wiring references, read off the real file. */
+const REFERENCED = [...new Set(
+  [...wiringSource.matchAll(/txAuxIntents\.(on[A-Za-z]+)/g)].map((m) => m[1]),
+)].sort();
+
+beforeEach(() => { vi.mocked(sendCommand).mockClear(); });
+
+describe('the wiring only names handlers the real command bus provides', () => {
+  // Kills: a rename/removal in command-bus.ts that the mocked component test
+  // cannot see, and a typo in either intent map.
+  it('references at least the thirteen txAux intents', () => {
+    expect(REFERENCED).toHaveLength(13);
+  });
+
+  it.each(REFERENCED)('"%s" exists on the composed handlers and is callable', (name) => {
+    expect(typeof intents()[name]).toBe('function');
+  });
+});
+
+describe('each txAux intent emits the command the radio expects', () => {
+  // SAFETY: the transmit-causing one. `value: 2` is "start tuning" — the same
+  // encoding `tunerStatus` is read back with (MOR-1244 `atu` mapping).
+  it('onAtuTune starts an ATU tune cycle, and sends nothing else', () => {
+    intents().onAtuTune();
+    expect(sendCommand).toHaveBeenCalledExactlyOnceWith('set_tuner_status', { value: 2 });
+  });
+
+  it.each([
+    ['onAtuToggle', [], 'set_tuner_status', { value: 1 }],
+    ['onVoxToggle', [], 'set_vox', { on: true }],
+    ['onCompToggle', [], 'set_compressor', { on: true }],
+    ['onMonToggle', [], 'set_monitor', { on: true }],
+    ['onRfPowerChange', [0.5], 'set_rf_power', { level: 0.5 }],
+    ['onMicGainChange', [200], 'set_mic_gain', { level: 200 }],
+    ['onDriveGainChange', [100], 'set_drive_gain', { level: 100 }],
+    ['onVoxGainChange', [77], 'set_vox_gain', { level: 77 }],
+    ['onAntiVoxGainChange', [12], 'set_anti_vox_gain', { level: 12 }],
+    ['onVoxDelayChange', [5], 'set_vox_delay', { level: 5 }],
+    ['onCompLevelChange', [33], 'set_compressor_level', { level: 33 }],
+    ['onMonLevelChange', [99], 'set_monitor_gain', { level: 99 }],
+  ] as const)('%s sends %s', (name, args, command, params) => {
+    (intents()[name] as (...a: readonly number[]) => void)(...args);
+    expect(sendCommand).toHaveBeenCalledExactlyOnceWith(command, params);
+  });
+});

--- a/frontend/src/presentation/layouts/__tests__/tx-aux-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/tx-aux-declarability.test.ts
@@ -1,0 +1,57 @@
+/**
+ * MOR-1265 — `txAux` is DECLARABLE, and nothing declares it yet.
+ *
+ * Slice 1B adds the name to `SEMANTIC_SURFACE_NAMES` so a manifest CAN mount
+ * the surface later; it deliberately does not touch any manifest. Both halves
+ * need pinning, in both directions:
+ *   - drop the name and a future manifest's zone stops validating (the whole
+ *     point of this slice's contract change);
+ *   - quietly add a `txAux` zone to a shipped manifest and the DOM grows a
+ *     zone id no layout review ever saw. That is out of scope here and is
+ *     what the second test refuses.
+ */
+import { describe, it, expect } from 'vitest';
+import { SEMANTIC_SURFACE_NAMES, validateLayoutManifest } from '../contract';
+import { validLayoutManifest } from './fixtures';
+import {
+  desktopV2Layout, dualReceiverCockpitLayout, lcdCockpitLayout, lcdScopeLayout, mobileLayout,
+  sdrTestLayout,
+} from '../declarations';
+
+describe('txAux is a declarable semantic surface', () => {
+  // Kills: reverting the SEMANTIC_SURFACE_NAMES addition.
+  it('is in the declarable set alongside vfo and rxTx', () => {
+    expect([...SEMANTIC_SURFACE_NAMES]).toEqual(['vfo', 'rxTx', 'txAux']);
+  });
+
+  // Kills: adding the name to the type but not to the runtime allow-list the
+  // zone validator checks — the manifest would still be rejected.
+  it('accepts a manifest zone that declares it', () => {
+    const manifest = validLayoutManifest({
+      zones: [{ id: 'main', surfaces: ['vfo', 'rxTx', 'txAux'] }],
+      requiredSemanticSurfaces: ['vfo', 'rxTx'],
+    });
+    expect(() => validateLayoutManifest(manifest)).not.toThrow();
+  });
+
+  it('still rejects a zone naming a surface that does not exist', () => {
+    const manifest = validLayoutManifest({
+      zones: [{ id: 'main', surfaces: ['txAuxLegacy'] as unknown as readonly ['vfo'] }],
+    });
+    expect(() => validateLayoutManifest(manifest)).toThrow(/subset of/);
+  });
+});
+
+describe('no shipped manifest declares a txAux zone in this slice', () => {
+  // Kills: slipping a txAux zone into an existing layout here. Declarability
+  // is the whole scope of MOR-1265; placing the surface in a real layout is a
+  // later, separately reviewed slice.
+  it.each([
+    ['sdr-test', sdrTestLayout], ['dual-receiver-cockpit', dualReceiverCockpitLayout],
+    ['lcd-cockpit', lcdCockpitLayout], ['lcd-scope', lcdScopeLayout],
+    ['mobile', mobileLayout], ['desktop-v2', desktopV2Layout],
+  ])('%s declares no txAux zone and does not require the surface', (_id, manifest) => {
+    for (const zone of manifest.zones) expect(zone.surfaces).not.toContain('txAux');
+    expect(manifest.requiredSemanticSurfaces).not.toContain('txAux');
+  });
+});

--- a/frontend/src/presentation/layouts/contract.ts
+++ b/frontend/src/presentation/layouts/contract.ts
@@ -12,8 +12,10 @@
 import type { Component } from 'svelte';
 import { isValidLanguageId as isValidProductId } from '../languages/contract';
 
-/** Semantic surfaces a layout may mount (MOR-1062/1065 reference vertical). */
-export const SEMANTIC_SURFACE_NAMES = ['vfo', 'rxTx'] as const;
+/** Semantic surfaces a layout may mount (MOR-1062/1065 reference vertical;
+ *  `txAux` added by MOR-1265). Adding a name makes it DECLARABLE — it does
+ *  not mount anything, and no manifest declares a `txAux` zone yet. */
+export const SEMANTIC_SURFACE_NAMES = ['vfo', 'rxTx', 'txAux'] as const;
 export type SemanticSurfaceName = (typeof SEMANTIC_SURFACE_NAMES)[number];
 
 /**

--- a/frontend/src/semantic/TxAuxSurface.svelte
+++ b/frontend/src/semantic/TxAuxSurface.svelte
@@ -1,0 +1,167 @@
+<!--
+  Semantic TX-auxiliary surface (MOR-1265, vocabulary slice 1B).
+
+  Presentation only. It renders the MOR-1244 `txAux` fact group — ATU, VOX
+  (+gain/anti-VOX/delay), COMP (+level), MON (+level), RF power, mic gain,
+  drive gain — and emits control intents as callbacks. It holds no state and
+  consults no controller (v3 ADR invariant 11).
+
+  SAFETY. Two rules govern this file and nothing may relax them:
+
+  (1) ATU **TUNE** emits a carrier: it is a transmit-causing action. It is
+      gated by `keyBlockedReasons` — the SAME predicate, imported from the
+      same module, applied to the SAME App-owned TX authority snapshot that
+      gates `RxTxSurface`'s key button. A local copy could drift and disagree;
+      the shared import cannot. The gate is enforced twice, on the widget
+      (`disabled`) and inside the handler.
+  (2) This surface is NOT a second key path. Exactly one `<RxTxSurface>`
+      remains the key/unkey authority (MOR-1262 §2 slice 1 safety note iii).
+      Nothing here takes a TX lease, keys, or unkeys: the TUNE carrier is the
+      radio's own ATU cycle, started by a backend command, and this surface
+      only decides whether the operator may ask for it.
+
+  Two-level availability (MOR-977/1256): `structural: false` renders NOTHING —
+  "this radio has no VOX" is a different claim from "VOX is unreadable right
+  now", which renders present-and-disabled with a reason. A control is usable
+  only when it is also actually observed; every intent below is computed from
+  the current value, so acting on an `unknown` reading would arm a guess.
+-->
+<script module lang="ts">
+  import type { TxAuxField } from './radio-view-model';
+
+  /** On/off controls, `[field, label]`. ATU's reading is a three-state enum,
+   *  the rest are booleans; `pressedOf` normalises both to one aria state. */
+  export const TX_AUX_TOGGLES = [
+    ['atu', 'ATU'], ['vox', 'VOX'], ['compressor', 'COMP'], ['monitor', 'MON'],
+  ] as const;
+  /** `[field, label, min, max, step]` in RAW wire units — the MOR-1244
+   *  contract applies no normalisation, so these are exactly the ranges
+   *  `TxPanel`/`VoxPanel` have always used (RF power 0..1, VOX delay 0..20,
+   *  everything else 0..255). Rescaling here would silently move a level. */
+  export const TX_AUX_LEVELS = [
+    ['rfPower', 'RF power', 0, 1, 0.01],
+    ['micGain', 'Mic gain', 0, 255, 1],
+    ['driveGain', 'Drive gain', 0, 255, 1],
+    ['voxGain', 'VOX gain', 0, 255, 1],
+    ['antiVoxGain', 'Anti-VOX', 0, 255, 1],
+    ['voxDelay', 'VOX delay', 0, 20, 1],
+    ['compressorLevel', 'COMP level', 0, 255, 1],
+    ['monitorLevel', 'MON level', 0, 255, 1],
+  ] as const;
+  export type TxAuxToggleField = (typeof TX_AUX_TOGGLES)[number][0];
+  export type TxAuxLevelField = (typeof TX_AUX_LEVELS)[number][0];
+
+  /** Usable ⇔ the radio HAS it, it is readable NOW, and it has been observed. */
+  const usable = (f: TxAuxField<unknown>): boolean =>
+    f.availability.structural && f.availability.operational && f.reading.status === 'known';
+  /** The MOR-977 `DisabledReasonCode` a present-but-unusable control carries. */
+  const reasonOf = (f: TxAuxField<unknown>): 'field-not-observed' | undefined =>
+    usable(f) ? undefined : 'field-not-observed';
+  const textOf = (f: TxAuxField<unknown>): string =>
+    f.reading.status !== 'known' ? '?'
+      : typeof f.reading.value === 'boolean' ? (f.reading.value ? 'on' : 'off')
+        : String(f.reading.value);
+  const pressedOf = (f: TxAuxField<unknown>): boolean | undefined =>
+    f.reading.status === 'known' ? f.reading.value !== false && f.reading.value !== 'off' : undefined;
+  const numberOf = (f: TxAuxField<number>, fallback: number): number =>
+    f.reading.status === 'known' ? f.reading.value : fallback;
+
+  /** Per-instance DOM id, so several mounted surfaces keep distinct aria targets. */
+  let sequence = 0;
+</script>
+
+<script lang="ts">
+  import type { RadioViewModel } from './radio-view-model';
+  import { BLOCKED_LABEL, keyBlockedReasons, type TxAuthoritySnapshot } from './rx-tx-surface';
+
+  interface Props {
+    view: RadioViewModel;
+    tx: TxAuthoritySnapshot;
+    onToggle?: (field: TxAuxToggleField) => void;
+    onLevelChange?: (field: TxAuxLevelField, value: number) => void;
+    onAtuTune?: () => void;
+  }
+  let { view, tx, onToggle, onLevelChange, onAtuTune }: Props = $props();
+
+  const blockedId = `tx-aux-blocked-${++sequence}`;
+  let txAux = $derived(view.txAux);
+  let tuneBlocked = $derived(keyBlockedReasons(view, tx));
+
+  function toggle(field: TxAuxToggleField): void {
+    if (txAux && usable(txAux[field])) onToggle?.(field);
+  }
+  function level(field: TxAuxLevelField, value: number): void {
+    if (txAux && usable(txAux[field])) onLevelChange?.(field, value);
+  }
+  /** The handler half of the TUNE gate. `disabled` alone is not enough: a
+   *  design language may restyle this control, and a programmatic click must
+   *  not start a carrier the key intent would have been refused. */
+  function requestTune(): void {
+    if (txAux && usable(txAux.atu) && tuneBlocked.length === 0) onAtuTune?.();
+  }
+</script>
+
+{#if txAux}
+  <section class="tx-aux-surface" data-testid="tx-aux-surface" aria-label="Transmit auxiliary controls">
+    <div class="tx-aux-row">
+      {#each TX_AUX_TOGGLES as [field, label] (field)}
+        {#if txAux[field].availability.structural}
+          <button
+            type="button" class="tx-aux-toggle"
+            data-testid={`tx-aux-${field}`} data-field={field}
+            data-disabled-reason={reasonOf(txAux[field])}
+            aria-pressed={pressedOf(txAux[field])}
+            disabled={!usable(txAux[field])}
+            onclick={() => toggle(field)}
+          >{label}: {textOf(txAux[field])}</button>
+        {/if}
+      {/each}
+      {#if txAux.atu.availability.structural}
+        <!-- Transmit-causing. See the file header, rule (1). -->
+        <button
+          type="button" class="tx-aux-tune"
+          data-testid="tx-aux-atu-tune" aria-describedby={blockedId}
+          disabled={tuneBlocked.length > 0 || !usable(txAux.atu)}
+          onclick={requestTune}
+        >TUNE</button>
+      {/if}
+    </div>
+
+    {#each TX_AUX_LEVELS as [field, label, min, max, step] (field)}
+      {#if txAux[field].availability.structural}
+        <label
+          class="tx-aux-level" data-testid={`tx-aux-${field}`} data-field={field}
+          data-disabled-reason={reasonOf(txAux[field])}
+        >
+          <span class="tx-aux-name">{label}</span>
+          <input
+            type="range" {min} {max} {step}
+            value={numberOf(txAux[field], min)}
+            disabled={!usable(txAux[field])}
+            oninput={(event) => level(field, event.currentTarget.valueAsNumber)}
+          />
+          <output>{textOf(txAux[field])}</output>
+        </label>
+      {/if}
+    {/each}
+
+    {#if txAux.atu.availability.structural}
+      <ul class="tx-aux-blocked" id={blockedId} data-testid="tx-aux-tune-blocked">
+        {#each tuneBlocked as code (code)}<li data-reason={code}>{BLOCKED_LABEL[code]}</li>{/each}
+      </ul>
+    {/if}
+  </section>
+{/if}
+
+<style>
+  /* Structure only — a design language owns colour and must never become the
+     sole state channel (MOR-977, forced-colors). */
+  .tx-aux-surface { display: flex; flex-direction: column; gap: 0.25rem; }
+  .tx-aux-row { display: flex; flex-wrap: wrap; gap: 0.5rem; }
+  .tx-aux-level { display: flex; align-items: baseline; gap: 0.5rem; }
+  .tx-aux-name { min-width: 8ch; }
+  .tx-aux-blocked { margin: 0; padding-inline-start: 1.2em; }
+  .tx-aux-blocked:empty { display: none; }
+  .tx-aux-toggle[aria-pressed='true'] { font-weight: 700; }
+  .tx-aux-toggle:disabled, .tx-aux-tune:disabled { cursor: not-allowed; }
+</style>

--- a/frontend/src/semantic/__tests__/TxAuxSurface.test.ts
+++ b/frontend/src/semantic/__tests__/TxAuxSurface.test.ts
@@ -1,0 +1,377 @@
+/**
+ * MOR-1265 — the semantic TX-auxiliary surface (vocabulary slice 1B).
+ *
+ * SAFETY-CRITICAL. This surface carries ATU **TUNE**, which emits a carrier:
+ * it is a transmit-causing action, not a settings control. Every test below
+ * names the mutation it kills, because the failure modes are operational:
+ *   (a) TUNE reachable while the App TX authority would refuse a key intent
+ *       (MOR-1262 §2 slice 1 safety note i);
+ *   (b) VOX armed on a field this radio never reported (safety note ii);
+ *   (c) this surface growing a key/unkey control and becoming a SECOND TX
+ *       authority (safety note iii) — exactly one `<RxTxSurface>` keys.
+ *
+ * The TUNE gate is the SHARED `keyBlockedReasons` predicate from
+ * `rx-tx-surface.ts` — the same function, on the same authority snapshot, that
+ * gates `RxTxSurface`'s key button. Not a copy: a copy could disagree.
+ */
+import { readFileSync } from 'node:fs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import TxAuxSurface, {
+  TX_AUX_LEVELS, TX_AUX_TOGGLES,
+  type TxAuxLevelField, type TxAuxToggleField,
+} from '../TxAuxSurface.svelte';
+import { topologyFixtures, withTxAux } from '../fixtures/topologies';
+import type { Availability, RadioViewModel, TxAuxViewModel } from '../radio-view-model';
+import { keyBlockedReasons, type TxAuthoritySnapshot } from '../rx-tx-surface';
+
+const IDLE_RX: TxAuthoritySnapshot = {
+  phase: 'idle', intent: null, radioTx: 'off', txRisk: 'none', mayOwnKey: false, fault: null,
+};
+const snap = (over: Partial<TxAuthoritySnapshot> = {}): TxAuthoritySnapshot => ({ ...IDLE_RX, ...over });
+
+/** `1/single` is the fixture whose permit is 'allowed' AND txTarget known. */
+const base = (): RadioViewModel => withTxAux(topologyFixtures['1/single']);
+
+type AnyField = keyof TxAuxViewModel;
+const ALL_FIELDS: readonly AnyField[] = [
+  ...TX_AUX_TOGGLES.map(([f]) => f), ...TX_AUX_LEVELS.map(([f]) => f),
+] as readonly AnyField[];
+
+/** Re-shape ONE txAux field of an otherwise fully-available fixture. */
+function withField(
+  view: RadioViewModel, field: AnyField,
+  over: { availability?: Availability; unknown?: boolean },
+): RadioViewModel {
+  const txAux = view.txAux!;
+  const current = txAux[field];
+  return {
+    ...view,
+    txAux: {
+      ...txAux,
+      [field]: {
+        reading: over.unknown ? { status: 'unknown' } : current.reading,
+        availability: over.availability ?? current.availability,
+      },
+    } as TxAuxViewModel,
+  };
+}
+
+let target: HTMLDivElement;
+beforeEach(() => { target = document.createElement('div'); document.body.appendChild(target); });
+afterEach(() => { target.remove(); });
+
+type Handlers = {
+  onToggle?: (field: TxAuxToggleField) => void;
+  onLevelChange?: (field: TxAuxLevelField, value: number) => void;
+  onAtuTune?: () => void;
+};
+
+function render(view: RadioViewModel, tx: TxAuthoritySnapshot, handlers: Handlers = {}) {
+  const component = mount(TxAuxSurface, { target, props: { view, tx, ...handlers } });
+  flushSync();
+  const q = <T extends HTMLElement>(sel: string) => target.querySelector(sel) as T | null;
+  return {
+    dispose: () => unmount(component),
+    root: () => q('[data-testid="tx-aux-surface"]'),
+    control: (field: string) => q<HTMLElement>(`[data-testid="tx-aux-${field}"]`),
+    input: (field: string) => q<HTMLInputElement>(`[data-testid="tx-aux-${field}"] input`),
+    tune: () => q<HTMLButtonElement>('[data-testid="tx-aux-atu-tune"]'),
+    tuneReasons: () => [...target.querySelectorAll('[data-testid="tx-aux-tune-blocked"] [data-reason]')]
+      .map((el) => el.getAttribute('data-reason')),
+  };
+}
+
+function withSurface(
+  view: RadioViewModel, tx: TxAuthoritySnapshot,
+  fn: (s: ReturnType<typeof render>) => void, handlers: Handlers = {},
+): void {
+  const s = render(view, tx, handlers);
+  try { fn(s); } finally { s.dispose(); }
+}
+
+/** `disabled` for a <button>, or for the <input> a level control wraps. */
+function isDisabled(s: ReturnType<typeof render>, field: string): boolean {
+  const el = s.control(field)!;
+  if (el instanceof HTMLButtonElement) return el.disabled;
+  return s.input(field)!.disabled;
+}
+
+// ── 1. Structural gating: absent, never a disabled promise ─────────────────
+
+describe('structural availability decides whether a control EXISTS', () => {
+  // MUTATION KILLED: rendering a structurally-absent control as merely
+  // disabled. "This radio has no VOX" and "VOX is unreadable right now" are
+  // different claims, and the MOR-977/1256 doctrine renders them differently.
+  it.each(ALL_FIELDS)('renders no control at all for a structurally absent "%s"', (field) => {
+    const view = withField(base(), field, {
+      availability: { structural: false, operational: false },
+    });
+    withSurface(view, snap(), (s) => {
+      expect(s.control(field)).toBeNull();
+      expect(s.root()).not.toBeNull();
+    });
+  });
+
+  it.each(ALL_FIELDS)('renders an enabled control for a fully available "%s"', (field) => {
+    withSurface(base(), snap(), (s) => {
+      expect(s.control(field)).not.toBeNull();
+      expect(isDisabled(s, field)).toBe(false);
+    });
+  });
+
+  // MUTATION KILLED: dropping the whole-group guard. The surface must refuse
+  // to render for a view model with no txAux facts rather than invent twelve
+  // all-unknown controls (the MOR-1244 N3 fail-closed polarity).
+  it('renders nothing for a view model carrying no txAux group', () => {
+    const view = { ...topologyFixtures['1/single'] };
+    withSurface(view as RadioViewModel, snap(), (s) => {
+      expect(s.root()).toBeNull();
+      expect(target.querySelectorAll('button')).toHaveLength(0);
+    });
+  });
+});
+
+// ── 2. Operational gating: present, disabled, with a reason ────────────────
+
+describe('operational availability decides whether a control is USABLE', () => {
+  // MUTATION KILLED: collapsing the two levels into one, so an operationally
+  // degraded control either vanishes (losing the structural claim) or stays
+  // live (acting on a value the radio never confirmed).
+  it.each(ALL_FIELDS)('keeps "%s" present but disabled when only operationally unavailable', (field) => {
+    const view = withField(base(), field, {
+      availability: { structural: true, operational: false },
+    });
+    withSurface(view, snap(), (s) => {
+      expect(s.control(field)).not.toBeNull();
+      expect(isDisabled(s, field)).toBe(true);
+      expect(s.control(field)!.dataset.disabledReason).toBe('field-not-observed');
+    });
+  });
+
+  // MUTATION KILLED: enabling a control whose reading is `unknown`. Every
+  // toggle computes its next value from the CURRENT one, so acting on an
+  // unobserved field flips it to a guess — fail closed instead.
+  it.each(ALL_FIELDS)('never enables "%s" on an unobserved reading', (field) => {
+    const view = withField(base(), field, { unknown: true });
+    withSurface(view, snap(), (s) => {
+      expect(s.control(field)).not.toBeNull();
+      expect(isDisabled(s, field)).toBe(true);
+      expect(s.control(field)!.dataset.disabledReason).toBe('field-not-observed');
+    });
+  });
+
+  it('shows no disabled reason on a control that is actually usable', () => {
+    withSurface(base(), snap(), (s) => {
+      for (const field of ALL_FIELDS) {
+        expect(s.control(field)!.dataset.disabledReason).toBeUndefined();
+      }
+    });
+  });
+});
+
+// ── 3. VOX — safety note (ii), arming voice keying ─────────────────────────
+
+describe('VOX arming obeys the two-level gate (safety note ii)', () => {
+  it('is ABSENT on a radio without the VOX capability', () => {
+    const view = withField(base(), 'vox', { availability: { structural: false, operational: false } });
+    withSurface(view, snap(), (s) => expect(s.control('vox')).toBeNull());
+  });
+
+  it('is present-and-disabled while structurally present but unreadable', () => {
+    const view = withField(base(), 'vox', { availability: { structural: true, operational: false } });
+    withSurface(view, snap(), (s) => {
+      expect(s.control('vox')!.dataset.disabledReason).toBe('field-not-observed');
+      expect(isDisabled(s, 'vox')).toBe(true);
+    });
+  });
+
+  // MUTATION KILLED: arming VOX from a click on an unobserved field. A VOX
+  // toggle computes `!current`; with `current` unknown the "on" it sends is a
+  // coin flip that arms voice keying.
+  it('emits no intent when clicked on an unobserved reading', () => {
+    const onToggle = vi.fn();
+    const view = withField(base(), 'vox', { unknown: true });
+    withSurface(view, snap(), (s) => {
+      (s.control('vox') as HTMLButtonElement).click();
+      flushSync();
+      expect(onToggle).not.toHaveBeenCalled();
+    }, { onToggle });
+  });
+
+  it('emits the toggle intent for its own field when usable', () => {
+    const onToggle = vi.fn();
+    withSurface(base(), snap(), (s) => {
+      (s.control('vox') as HTMLButtonElement).click();
+      flushSync();
+      expect(onToggle).toHaveBeenCalledExactlyOnceWith('vox');
+    }, { onToggle });
+  });
+
+  // MUTATION KILLED: sharing one disabled state across vox/voxGain/
+  // antiVoxGain/voxDelay (the MOR-1244 handoff note: they share a structural
+  // capability but each carries its OWN operational gate).
+  it('does not collapse voxGain/antiVoxGain/voxDelay into the vox toggle state', () => {
+    const view = withField(base(), 'voxGain', { availability: { structural: true, operational: false } });
+    withSurface(view, snap(), (s) => {
+      expect(isDisabled(s, 'voxGain')).toBe(true);
+      expect(isDisabled(s, 'vox')).toBe(false);
+      expect(isDisabled(s, 'antiVoxGain')).toBe(false);
+      expect(isDisabled(s, 'voxDelay')).toBe(false);
+    });
+  });
+});
+
+// ── 4. ATU TUNE — safety note (i), a transmit-causing action ───────────────
+
+/** Every way the App TX authority (or the permit) refuses a key intent. */
+const BLOCKING: readonly (readonly [string, Partial<TxAuthoritySnapshot>])[] = [
+  ['a fault is latched', { fault: 'on-timeout' }],
+  ['a lease is in progress', { phase: 'key-confirm-pending' }],
+  ['this browser may own the key', { mayOwnKey: true }],
+  ['the radio is already transmitting', { radioTx: 'on' }],
+  ['the RF state is unknown', { radioTx: 'unknown' }],
+  ['TX risk is uncertain', { txRisk: 'uncertain' }],
+  ['TX risk is confirmed-on', { txRisk: 'confirmed-on' }],
+];
+
+describe('ATU TUNE is gated by the App TX authority, exactly like the key intent', () => {
+  it('offers TUNE when the authority is idle and the permit allows', () => {
+    withSurface(base(), snap(), (s) => {
+      expect(s.tune()).not.toBeNull();
+      expect(s.tune()!.disabled).toBe(false);
+      expect(s.tuneReasons()).toEqual([]);
+    });
+  });
+
+  // MUTATION KILLED: gating TUNE on anything weaker than the key intent's own
+  // predicate (or on nothing at all). Asserted against the SHARED
+  // `keyBlockedReasons` so the two can never drift apart.
+  it.each(BLOCKING)('disables TUNE while %s', (_label, over) => {
+    const view = base();
+    const tx = snap(over);
+    expect(keyBlockedReasons(view, tx).length).toBeGreaterThan(0);
+    withSurface(view, tx, (s) => {
+      expect(s.tune()!.disabled).toBe(true);
+      expect(s.tuneReasons()).toEqual([...keyBlockedReasons(view, tx)]);
+    });
+  });
+
+  // The view-model half of the same predicate: an unknown TX target or a
+  // denied/unknown permit blocks TUNE just as it blocks the key.
+  it.each(['1/ab', '2/ab_shared'] as const)('disables TUNE on %s, whose permit is not allowed', (id) => {
+    const view = withTxAux(topologyFixtures[id]);
+    withSurface(view, snap(), (s) => {
+      expect(s.tune()!.disabled).toBe(true);
+      expect(s.tuneReasons()).toEqual([...keyBlockedReasons(view, snap())]);
+    });
+  });
+
+  // MUTATION KILLED: relying on `disabled` alone. A programmatic click (or a
+  // design language that restyles the control into a live element) must not
+  // reach the radio either — widget-disabled AND handler-guarded.
+  it.each(BLOCKING)('emits no TUNE intent from a forced click while %s', (_label, over) => {
+    const onAtuTune = vi.fn();
+    withSurface(base(), snap(over), (s) => {
+      const tune = s.tune()!;
+      tune.disabled = false; // simulate a restyled / programmatically enabled control
+      tune.click();
+      flushSync();
+      expect(onAtuTune).not.toHaveBeenCalled();
+    }, { onAtuTune });
+  });
+
+  it('emits the TUNE intent when the authority and the permit both allow', () => {
+    const onAtuTune = vi.fn();
+    withSurface(base(), snap(), (s) => {
+      s.tune()!.click();
+      flushSync();
+      expect(onAtuTune).toHaveBeenCalledOnce();
+    }, { onAtuTune });
+  });
+
+  // MUTATION KILLED: offering TUNE on a radio with no tuner, or on one whose
+  // tuner status was never observed — a carrier fired from a guessed state.
+  it('renders no TUNE control at all without a structurally present ATU', () => {
+    const view = withField(base(), 'atu', { availability: { structural: false, operational: false } });
+    withSurface(view, snap(), (s) => expect(s.tune()).toBeNull());
+  });
+
+  it('disables TUNE while the ATU status itself is unobserved', () => {
+    const view = withField(base(), 'atu', { unknown: true });
+    withSurface(view, snap(), (s) => expect(s.tune()!.disabled).toBe(true));
+  });
+});
+
+// ── 5. Exactly one key path — safety note (iii) ────────────────────────────
+
+describe('this surface is never a second key path (safety note iii)', () => {
+  /** Same stripper the presentation-zone source pins use — the assertions
+   *  below are about CODE, and the file's own header comment necessarily
+   *  names `RxTxSurface` while explaining why it must not appear in it. */
+  const withoutComments = (source: string): string => source
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/^\s*\/\/.*$/gm, '');
+  const source = withoutComments(readFileSync('src/semantic/TxAuxSurface.svelte', 'utf8'));
+
+  // MUTATION KILLED: a TxAuxSurface variant that renders a key/unkey control.
+  // This is the named test the 1B brief requires such a variant to fail.
+  it('renders no key or unkey control', () => {
+    withSurface(base(), snap(), () => {
+      expect(target.querySelector('[data-testid="rx-tx-key"]')).toBeNull();
+      expect(target.querySelector('[data-testid="rx-tx-unkey"]')).toBeNull();
+      for (const el of target.querySelectorAll<HTMLElement>('[data-testid]')) {
+        expect(el.dataset.testid?.startsWith('rx-tx')).toBe(false);
+      }
+      for (const el of target.querySelectorAll<HTMLElement>('button')) {
+        expect(el.textContent?.toLowerCase()).not.toMatch(/\bun?key\b/);
+      }
+    });
+  });
+
+  // MUTATION KILLED: importing the TX controller, mounting RxTxSurface, or
+  // accepting a key intent here — any of which would make this a second
+  // authority that could disagree with the one in `RxTxSurface`.
+  it('holds no key intent, no controller import and no RxTxSurface mount', () => {
+    expect(source).not.toMatch(/RxTxSurface/);
+    expect(source).not.toMatch(/tx-controller/);
+    expect(source).not.toMatch(/onRequestKey|onRequestUnkey|requestKey|requestUnkey/);
+    expect(source).not.toMatch(/\btx\.(start|release|setIntent|resetFault)\b/);
+  });
+
+  // MUTATION KILLED: re-deriving the block predicate locally. A second copy
+  // could disagree with the key button's; the shared import cannot.
+  it('imports the block predicate from the shared rx-tx vocabulary', () => {
+    expect(source).toMatch(/import\s*\{[^}]*keyBlockedReasons[^}]*\}\s*from\s*'\.\/rx-tx-surface'/);
+  });
+});
+
+// ── 6. Level intents carry the field and the raw value ─────────────────────
+
+describe('level intents reach the caller with the field and the raw value', () => {
+  it.each(TX_AUX_LEVELS)('emits (%s, value) on input', (field, _label, min, max, step) => {
+    const onLevelChange = vi.fn();
+    withSurface(base(), snap(), (s) => {
+      const input = s.input(field)!;
+      expect(input.min).toBe(String(min));
+      expect(input.max).toBe(String(max));
+      expect(input.step).toBe(String(step));
+      input.value = String(min);
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      flushSync();
+      expect(onLevelChange).toHaveBeenCalledExactlyOnceWith(field, min);
+    }, { onLevelChange });
+  });
+
+  // MUTATION KILLED: normalising or rescaling a level on the way out. The
+  // MOR-1244 contract carries RAW wire values (v2 units); rescaling here
+  // would silently halve someone's RF power.
+  it('passes the raw reading straight into the control value', () => {
+    withSurface(base(), snap(), (s) => {
+      expect(s.input('rfPower')!.valueAsNumber).toBe(0.8);
+      expect(s.input('micGain')!.valueAsNumber).toBe(128);
+      expect(s.input('voxDelay')!.valueAsNumber).toBe(20);
+    });
+  });
+});

--- a/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
+++ b/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
@@ -30,6 +30,9 @@ const h = vi.hoisted(() => ({
   splitToggle: vi.fn(),
   dualWatchToggle: vi.fn(),
   modInputGuard: { visible: false, sourceLabel: null } as { visible: boolean; sourceLabel: string | null },
+  /** MOR-1265: stand-in for every txAux intent. This fixture declares no
+   *  txAux capability, so the MOR-1244 evidence gate omits the group. */
+  txAuxNoop: vi.fn(),
 }));
 
 vi.mock('$lib/runtime', () => ({
@@ -60,6 +63,17 @@ vi.mock('../../../components-v2/wiring/command-bus', () => ({
     onVfoSelect: h.selectVfo,
     onSplitToggle: h.splitToggle,
     onDualWatchToggle: h.dualWatchToggle,
+  }),
+  // MOR-1265 — the wiring now also composes the txAux intent vocabulary.
+  makeVoxHandlers: () => ({
+    onVoxToggle: h.txAuxNoop, onVoxGainChange: h.txAuxNoop,
+    onAntiVoxGainChange: h.txAuxNoop, onVoxDelayChange: h.txAuxNoop,
+  }),
+  makeTxHandlers: () => ({
+    onRfPowerChange: h.txAuxNoop, onMicGainChange: h.txAuxNoop, onAtuToggle: h.txAuxNoop,
+    onAtuTune: h.txAuxNoop, onVoxToggle: h.txAuxNoop, onCompToggle: h.txAuxNoop,
+    onCompLevelChange: h.txAuxNoop, onMonToggle: h.txAuxNoop,
+    onMonLevelChange: h.txAuxNoop, onDriveGainChange: h.txAuxNoop,
   }),
 }));
 


### PR DESCRIPTION
Closes MOR-1265 — vocabulary slice 1B (surface half of MOR-1244's txAux facts; MOR-1262 program).

## What

`semantic/TxAuxSurface.svelte` + structural-gated mount + intent wiring + the `'txAux'` vocabulary name. **140 net production LOC**, 3 production files, +152 tests. **TUNE routing: App-owned gate, radio-owned carrier** — the surface shares the exact `keyBlockedReasons` predicate with the key button, re-checked against the live authority snapshot at dispatch; no TX lease is taken.

## Provenance

- Independent adversarial verification (opus — the single-TX-authority verifier across the cockpit series): **PASS on the code**. TUNE ruling: **ACCEPT — gate-without-lease is strictly more restrictive than keying**: the shared predicate blocks on `phase !== 'idle'`, `mayOwnKey`, AND `radioTx === 'on'` (covering the radio transmitting for ANY reason incl. a physical mic PTT — which a lease-based check would miss), fail-closed on `radioTx === 'unknown'`. Proven empirically: authority snapshot mutated WITHOUT notifying subscribers (widget stays enabled) → in six independent blocking states the intent fired ZERO times; the idle control fired once. A carrier cannot collide with voice TX.
- No second key path: mutation-pinned (a TxAuxSurface variant rendering key/unkey dies; no second sourceId/lease anywhere; RxTxSurface count pins hold in both modes).
- 8 verifier mutations: 7 killed; the T4 survivor adjudicated by measurement as inert redundancy (absent-group DOM differs by one 7-byte comment anchor — the wiring gate is shadowed by the surface's load-bearing guard; MOR-1251 class).
- Incident disclosed: the verifier's A/B step destroyed four uncommitted mock-only test edits via a tree-wide git checkout (its own process error, honestly self-reported). The builder re-applied the hunks exactly (numstat-identical, additions only), re-established the A/B in a disposable detached worktree: BEFORE 3413/3413 vs AFTER 3565/3565 (+152 exact, zero failures both sides), production files sha256-identical throughout. Verifier-brief fix for the remaining slices recorded (scratch-worktree baselines, never tree-wide checkout).
- Recorded accepted window: the authority cannot see an in-flight TUNE carrier (closed by the radio's RF truth; unfixable by a lease).

lint clean; check 4373 files / 0 errors; build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)