### PR TITLE
docs(MOR-1261): record the chrome-breakpoints doctrine on stageSizing

### DIFF
--- a/docs/plans/2026-07-25-ui-composition-architecture-v3.md
+++ b/docs/plans/2026-07-25-ui-composition-architecture-v3.md
@@ -197,6 +197,17 @@ renamed it `stageSizing` to say so and froze it declaration-only (an
 architecture test flags any direct textual read outside
 `presentation/layouts/`) until `ScaledStage` exists to enforce it.
 
+MOR-1261 (owner decision, 2026-08-04): until a layout's instrument stage
+exists, `stageSizing`'s fluid `responsiveBreakpoints` may ALSO carry CHROME
+reflow thresholds declaratively — legitimizing the mobile manifest's `[500]`
+(MOR-1094) and the cockpit's `[768, 1024]` (MOR-1069) — the cockpit's pair
+pinned by a CSS↔manifest agreement test, mobile's declared value pinned at
+the manifest only. This is an interim carriage: the field's primary
+semantics stay the instrument stage's policy above, the MOR-1247
+declaration-only guard still forbids a runtime read, and a per-zone sizing
+superset may supersede it later. A dedicated `chromeBreakpoints` field was
+considered and rejected for now.
+
 ## Dependency and product invariants
 
 1. Runtime imports no adapters or presentation.

--- a/frontend/src/presentation/layouts/contract.ts
+++ b/frontend/src/presentation/layouts/contract.ts
@@ -70,6 +70,16 @@ export interface LayoutManifest {
    * exists this field stays declaration-only (guard test: `__tests__/
    * stage-sizing-boundary.test.ts`). A `fixed-native` value here does NOT
    * mean the whole layout is fixed-native — only its instrument stage is.
+   *
+   * MOR-1261 (owner decision, 2026-08-04): until a layout has an instrument
+   * stage, this field's fluid `responsiveBreakpoints` may ALSO carry CHROME
+   * reflow thresholds declaratively — legitimizing mobile's `[500]`
+   * (MOR-1094) and the cockpit's `[768, 1024]` (MOR-1069) — the cockpit's
+   * pair pinned by a CSS↔manifest agreement test, mobile's declared value
+   * pinned at the manifest only. Interim carriage only: the field's primary
+   * semantics stay the instrument stage's policy above, runtime still must
+   * not read it (MOR-1247 declaration-only guard unchanged), and a per-zone
+   * superset may supersede this later.
    */
   readonly stageSizing: SizingPolicy;
   readonly fallbackLayoutId: string | null;


### PR DESCRIPTION
Closes MOR-1261 (owner decision, cockpit gate item (c)).

## What

19 doc lines across exactly 2 files: JSDoc on `LayoutManifest.stageSizing` (contract.ts) + a paragraph in the MOR-1160/1247 subsection of the v3 plan doc. Zero production change — the stripped-comment `.ts` diff is empty; the MOR-1247 declaration-only guard, validator, and every manifest value untouched. **0 net production LOC.**

## Provenance

- Independent verification (opus — the layouts/doctrine verifier): **PASS with one required wording correction, applied**. All five elements of the owner decision recorded faithfully (interim chrome carriage; both precedents legitimized; runtime reads still forbidden; primary stage semantics preserved; per-zone superset may supersede) with no invented doctrine.
- The correction (the MOR-1096 overclaim class, caught again): the draft claimed both precedents were "pinned by a CSS↔manifest agreement test" — true only of the cockpit (mutation-proven two-way test from MOR-1069); mobile's `[500]` is asserted as a manifest value only. Wording now states coverage honestly in both places.
- Zero-change proof re-verified post-fix: layouts suite 168/168, lint/check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)