### PR TITLE
fix(MOR-1258): contain the conditional TX alerts in the rx-tx zone

### DIFF
--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -227,42 +227,78 @@
         onToggleDualWatch={toggleDualWatch}
       />
     {/if}
-    <!--
-      MOR-1069 (finding N1, routed from the MOR-1068 verification). The
-      wrapper used to render on EVERY path as an inert `display: contents`
-      naming shell, which left the single/default path no longer
-      element-identical to its pre-cockpit shape. It is now rendered ONLY in
-      the dual composition, where it is a real, bound zone element the
-      cockpit's responsive rules can place — an inert wrapper cannot be a
-      grid/flex item, so "leave it inert" was not an option once the zone had
-      to move between arrangements. The single/default path (sdr-test / LCD /
-      mobile) renders the surface bare again, and that element shape is
-      re-pinned in `__tests__/semantic-rx-tx-wiring.component.test.ts`.
+  {/if}
+  <!--
+    MOR-1069 (finding N1, routed from the MOR-1068 verification). The
+    wrapper used to render on EVERY path as an inert `display: contents`
+    naming shell, which left the single/default path no longer
+    element-identical to its pre-cockpit shape. It is now rendered ONLY in
+    the dual composition, where it is a real, bound zone element the
+    cockpit's responsive rules can place — an inert wrapper cannot be a
+    grid/flex item, so "leave it inert" was not an option once the zone had
+    to move between arrangements. The single/default path (sdr-test / LCD /
+    mobile) renders the surface bare again, and that element shape is
+    re-pinned in `__tests__/semantic-rx-tx-wiring.component.test.ts`.
 
-      The snippet is deliberate: it keeps exactly ONE `<RxTxSurface>` tag in
-      this file, so single TX authority stays a property of the SOURCE rather
-      than of which branch happens to be taken. Pinned as such by
-      `presentation/layouts/__tests__/cockpit-responsive-composition.test.ts`.
-    -->
-    {#snippet rxTxSurface()}
+    The snippet is deliberate: it keeps exactly ONE `<RxTxSurface>` tag in
+    this file, so single TX authority stays a property of the SOURCE rather
+    than of which branch happens to be taken. Pinned as such by
+    `presentation/layouts/__tests__/cockpit-responsive-composition.test.ts`.
+    MOR-1258 moves the invocation below out from under the outer
+    `{#if view}` (the rx-tx zone and the TX-adjacent alerts it now carries
+    must exist even while `view` is still null — see the alerts comment
+    below), so the view-model gate now lives on the snippet itself.
+  -->
+  {#snippet rxTxSurface()}
+    {#if view}
       <RxTxSurface {view} tx={txState} onRequestKey={requestKey} onRequestUnkey={requestUnkey} />
-    {/snippet}
-    {#if strips === 'dual'}
-      <div class="rx-tx-zone" data-zone-id="rx-tx">{@render rxTxSurface()}</div>
-    {:else}
-      {@render rxTxSurface()}
     {/if}
-    <!--
-      MOR-1265. STRUCTURAL gate: the surface mounts only when the view model
-      actually carries the group, so a radio the MOR-1244 evidence gate
-      declined renders the pre-1265 element shape exactly (pinned in
-      `__tests__/semantic-tx-aux-wiring.component.test.ts`). Bare in BOTH
-      compositions and with no `data-zone-id`: `'txAux'` is merely declarable
-      by a manifest after this slice; no manifest declares a txAux zone yet,
-      and binding one here would put a zone id in the DOM that no layout
-      asked for (the MOR-1069 lesson).
-    -->
-    {#if view.txAux}
+  {/snippet}
+
+  <!--
+    MOR-1258 (owner decision, 2026-08-04, gate item (b)). The three
+    conditional TX-adjacent alerts — `tx-fault-reset` and the two
+    ModInputTxWarning buttons ("Set LAN" / dismiss) — are formal members of
+    the rx-tx zone: they render beside RxTxSurface (inside its bound zone
+    element in the dual composition) rather than in a new `alerts` zone or
+    as a pinned outside-by-design exception. Grouping them in one snippet
+    keeps ONE place that decides where they render, mirroring `rxTxSurface`
+    above.
+
+    MOR-617 network-voice-TX preflight. It ships inside TxPanel, which this
+    layout suppresses (`hideTxPanel`) — but this layout can now key network
+    voice TX, and the controller's `start-audio` effect IS that path. Without
+    the banner the operator keys with a mis-routed MOD input, no warning and
+    no one-click "Set LAN" fix: the exact shape of the "web voice TX = noise"
+    bug. Self-gating on `deriveModInputTxGuardProps().visible`, so the
+    trigger conditions are byte-identical to the panel's, and — same as
+    before MOR-1258 — NOT gated on the view model: it must warn even before
+    capabilities load.
+  -->
+  {#snippet txAdjacentAlerts()}
+    <ModInputTxWarning />
+    {#if txState.phase === 'failed'}
+      <button
+        type="button" class="tx-fault-reset" data-testid="tx-fault-reset" onclick={clearFault}
+      >Clear TX fault</button>
+    {/if}
+  {/snippet}
+
+  <!--
+    MOR-1265. STRUCTURAL gate: the surface mounts only when the view model
+    actually carries the group, so a radio the MOR-1244 evidence gate
+    declined renders the pre-1265 element shape exactly (pinned in
+    `__tests__/semantic-tx-aux-wiring.component.test.ts`). Bare in BOTH
+    compositions and with no `data-zone-id`: `'txAux'` is merely declarable
+    by a manifest after this slice; no manifest declares a txAux zone yet,
+    and binding one here would put a zone id in the DOM that no layout
+    asked for (the MOR-1069 lesson). `view?.txAux` (rather than the caller
+    nesting this under `{#if view}`) keeps the same "never renders while
+    view is null" behavior now that the surrounding structure changed
+    around it (MOR-1258).
+  -->
+  {#snippet txAuxSurface()}
+    {#if view?.txAux}
       <TxAuxSurface
         {view} tx={txState}
         onToggle={(field) => TX_AUX_TOGGLE_INTENT[field]()}
@@ -270,23 +306,31 @@
         onAtuTune={requestAtuTune}
       />
     {/if}
-  {/if}
+  {/snippet}
 
-  <!--
-    MOR-617 network-voice-TX preflight. It ships inside TxPanel, which this
-    layout suppresses (`hideTxPanel`) — but this layout can now key network
-    voice TX, and the controller's `start-audio` effect IS that path. Without
-    the banner the operator keys with a mis-routed MOD input, no warning and no
-    one-click "Set LAN" fix: the exact shape of the "web voice TX = noise" bug.
-    Self-gating on `deriveModInputTxGuardProps().visible`, so the trigger
-    conditions are byte-identical to the panel's.
-  -->
-  <ModInputTxWarning />
-
-  {#if txState.phase === 'failed'}
-    <button
-      type="button" class="tx-fault-reset" data-testid="tx-fault-reset" onclick={clearFault}
-    >Clear TX fault</button>
+  {#if strips === 'dual'}
+    <!--
+      MOR-1258: the zone now carries RxTxSurface AND the two TX-adjacent
+      alerts that used to sit at the bottom of this component, unzoned.
+      TxAuxSurface stays OUTSIDE — it declares no zone (see above) — so it
+      renders after the zone rather than between RxTxSurface and the alerts,
+      which is the one DOM-order change this ticket makes: the alerts move
+      up to sit beside RxTxSurface instead of after TxAuxSurface.
+    -->
+    <div class="rx-tx-zone" data-zone-id="rx-tx">
+      {@render rxTxSurface()}
+      {@render txAdjacentAlerts()}
+    </div>
+    {@render txAuxSurface()}
+  {:else}
+    <!--
+      Single/default path (sdr-test / LCD / mobile): no bound zone exists
+      here (MOR-1069), so containment is not possible — the alerts keep
+      their pre-MOR-1258 position and order, unchanged.
+    -->
+    {@render rxTxSurface()}
+    {@render txAuxSurface()}
+    {@render txAdjacentAlerts()}
   {/if}
 </div>
 
@@ -320,8 +364,14 @@
   }
   /* MOR-1069: no `display: contents` any more — the zone only exists in the
      dual composition now, and it must be a real box there so the cockpit can
-     place it. It carries no presentation of its own; the surface inside owns
-     that. */
+     place it. MOR-1258: the zone now stacks RxTxSurface with the two
+     TX-adjacent alerts it gained, so it owns this minimal layout — the
+     alerts and RxTxSurface still each own their own internal presentation. */
+  .rx-tx-zone {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
 
   .channel-strip[data-strip-active='true'] {
     border-left: 2px solid var(--v2-accent-cyan, #00d4ff);

--- a/frontend/src/components-v2/wiring/__tests__/semantic-rx-tx-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rx-tx-wiring.component.test.ts
@@ -141,10 +141,10 @@ const liveCaps = (): Capabilities => ({
 let target: HTMLDivElement;
 let component: ReturnType<typeof mount> | null = null;
 
-function render(): void {
+function render(props: { strips?: 'single' | 'dual' } = {}): void {
   target = document.createElement('div');
   document.body.appendChild(target);
-  component = mount(SemanticRadioSurfaces, { target });
+  component = mount(SemanticRadioSurfaces, { target, props });
   flushSync();
 }
 
@@ -512,5 +512,54 @@ describe('the migrated layout keeps the MOR-617 network-voice-TX preflight', () 
     render();
     expect(q('[data-testid="rx-tx-surface"]')).toBeNull();
     expect(q('[data-testid="mod-input-tx-warning"]')).not.toBeNull();
+  });
+});
+
+describe('MOR-1258 — the three TX-adjacent alerts join the rx-tx zone in the dual composition', () => {
+  // The owner ruling (2026-08-04, gate item (b)): `tx-fault-reset` and the
+  // two ModInputTxWarning buttons render inside the rx-tx zone's bound
+  // element when `strips="dual"` — the only composition with a bound zone at
+  // all (MOR-1069). Direct containment checks at the wiring level, one layer
+  // below the full cockpit shell mount in
+  // `skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts`.
+  it('contains tx-fault-reset inside the rx-tx zone while a fault is latched', () => {
+    render({ strips: 'dual' });
+    push({ phase: 'failed', fault: 'audio-failed' });
+
+    const zone = q('.rx-tx-zone')!;
+    expect(zone).not.toBeNull();
+    expect(zone.contains(q('[data-testid="tx-fault-reset"]'))).toBe(true);
+  });
+
+  it('contains both ModInputTxWarning buttons inside the rx-tx zone', () => {
+    h.modInputGuard = { visible: true, sourceLabel: 'MIC' };
+    render({ strips: 'dual' });
+
+    const zone = q('.rx-tx-zone')!;
+    expect(zone.contains(q('[data-testid="mod-input-set-lan"]'))).toBe(true);
+    expect(zone.contains(q('[data-testid="mod-input-dismiss"]'))).toBe(true);
+  });
+
+  // The single/default path has no bound zone at all (MOR-1069) — the
+  // ticket's explicit, honest carve-out (no containment is possible there).
+  // The alerts keep their pre-MOR-1258 bare placement, unchanged.
+  it('leaves the alerts bare on the single/default path — there is no zone to contain them in', () => {
+    render();
+    push({ phase: 'failed', fault: 'audio-failed' });
+    expect(target.querySelectorAll('[data-zone-id]')).toHaveLength(0);
+    expect(q('.rx-tx-zone')).toBeNull();
+    expect(q('[data-testid="tx-fault-reset"]')).not.toBeNull();
+  });
+
+  // MOR-617's invariant survives the containment move even in the dual
+  // composition: the warning still is not gated on the view model.
+  it('still shows the MOD-input warning before capabilities load, in the dual composition too', () => {
+    h.caps = null;
+    h.modInputGuard = { visible: true, sourceLabel: 'MIC' };
+    render({ strips: 'dual' });
+    expect(q('[data-testid="rx-tx-surface"]')).toBeNull();
+    const zone = q('.rx-tx-zone')!;
+    expect(zone).not.toBeNull();
+    expect(zone.contains(q('[data-testid="mod-input-tx-warning"]'))).toBe(true);
   });
 });

--- a/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
+++ b/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
@@ -769,6 +769,45 @@ describe('MOR-1069 — focus order is DOM order, and the RX/TX zone comes last',
     // not stranded between two channel strips.
     expect(sequence.at(-1)).toBe(declared.indexOf('rx-tx'));
   });
+
+  // MOR-1258. `tx-fault-reset` and the two ModInputTxWarning buttons only
+  // exist in the DOM while their own conditional trigger is active (a
+  // latched TX fault; a visible MOD-input guard). The base-case test above
+  // never enters either state, so before MOR-1258 these three controls could
+  // sit anywhere at all — including outside every declared zone — without
+  // this assertion ever seeing them (the MOR-1069 verification finding this
+  // ticket exists to close). Driving each conditional state in turn is what
+  // makes the assertion actually SEE them.
+  it.each([
+    ['a TX fault is latched', { phase: 'failed', fault: 'audio-failed' } as Partial<Snapshot>, false],
+    ['the MOD-input guard is visible', {} as Partial<Snapshot>, true],
+    ['both conditional alerts are active at once', { phase: 'failed', fault: 'audio-failed' } as Partial<Snapshot>, true],
+  ] as const)('still ends in rx-tx with no control outside a declared zone — %s', (
+    _label, snapshotOver, modInputVisible,
+  ) => {
+    h.state = mainSubState('MAIN');
+    h.caps = mainSubCaps();
+    h.modInputGuard = modInputVisible
+      ? { visible: true, sourceLabel: 'MIC' }
+      : { visible: false, sourceLabel: null };
+    render();
+    push(snapshotOver);
+
+    // Sanity: the conditional control(s) this case drives are actually present
+    // — otherwise the assertions below would pass vacuously.
+    if ('phase' in snapshotOver) expect(q('[data-testid="tx-fault-reset"]')).not.toBeNull();
+    if (modInputVisible) expect(q('[data-testid="mod-input-tx-warning"]')).not.toBeNull();
+
+    const declared = dualReceiverCockpitLayout.zones.map((z) => z.id);
+    const sequence = qa<HTMLElement>('button, input, select, a[href], [tabindex]')
+      .map((el) => el.closest('[data-zone-id]') as HTMLElement | null)
+      .map((zone) => declared.indexOf(zone?.dataset.zoneId ?? ''));
+
+    expect(sequence.length).toBeGreaterThan(0);
+    expect(sequence).not.toContain(-1);
+    expect(sequence).toEqual([...sequence].sort((a, b) => a - b));
+    expect(sequence.at(-1)).toBe(declared.indexOf('rx-tx'));
+  });
 });
 
 describe('MOR-1069 (N1) — rx-tx is a real bound zone element in the cockpit', () => {
@@ -790,6 +829,77 @@ describe('MOR-1069 (N1) — rx-tx is a real bound zone element in the cockpit', 
     // The zone IS the surface's box, not a sibling marker next to it.
     expect(q('[data-testid="rx-tx-surface"]')!.parentElement).toBe(zone);
     expect(zone.querySelectorAll('[data-testid="rx-tx-key"]')).toHaveLength(1);
+  });
+});
+
+// MOR-1258 (owner decision, 2026-08-04, gate item (b)): `tx-fault-reset` and
+// the two ModInputTxWarning buttons are formal rx-tx zone members. Each
+// assertion is a direct containment check against the zone ELEMENT itself
+// (`.contains` / `.closest`), independent of the focus-order sequence above —
+// a mutant that re-homes any one of the three as a sibling of `.rx-tx-zone`
+// fails here even if it still happened to land last in tab order.
+describe('MOR-1258 — the three TX-adjacent alerts are formal rx-tx zone members', () => {
+  it('contains tx-fault-reset inside the rx-tx zone while a fault is latched, and nowhere before it', () => {
+    h.state = mainSubState('MAIN');
+    h.caps = mainSubCaps();
+    render();
+    expect(q('[data-testid="tx-fault-reset"]')).toBeNull();
+
+    push({ phase: 'failed', fault: 'audio-failed' });
+
+    const zone = q('[data-zone-id="rx-tx"]')!;
+    const reset = q('[data-testid="tx-fault-reset"]')!;
+    expect(zone.contains(reset)).toBe(true);
+    expect(reset.closest('[data-zone-id]')).toBe(zone);
+  });
+
+  it('contains both ModInputTxWarning buttons inside the rx-tx zone while the guard is visible', () => {
+    h.state = mainSubState('MAIN');
+    h.caps = mainSubCaps();
+    h.modInputGuard = { visible: true, sourceLabel: 'MIC' };
+    render();
+
+    const zone = q('[data-zone-id="rx-tx"]')!;
+    const setLan = q('[data-testid="mod-input-set-lan"]')!;
+    const dismiss = q('[data-testid="mod-input-dismiss"]')!;
+    expect(zone.contains(setLan)).toBe(true);
+    expect(zone.contains(dismiss)).toBe(true);
+    expect(setLan.closest('[data-zone-id]')).toBe(zone);
+    expect(dismiss.closest('[data-zone-id]')).toBe(zone);
+  });
+
+  it('contains all three alerts inside the SAME zone box that owns RxTxSurface, active simultaneously', () => {
+    h.state = mainSubState('MAIN');
+    h.caps = mainSubCaps();
+    h.modInputGuard = { visible: true, sourceLabel: 'MIC' };
+    render();
+    push({ phase: 'failed', fault: 'audio-failed' });
+
+    const zone = q('[data-zone-id="rx-tx"]')!;
+    expect(q('[data-testid="rx-tx-surface"]')!.parentElement).toBe(zone);
+    for (const testid of ['tx-fault-reset', 'mod-input-set-lan', 'mod-input-dismiss']) {
+      const el = q(`[data-testid="${testid}"]`);
+      expect(el).not.toBeNull();
+      expect(zone.contains(el)).toBe(true);
+    }
+  });
+
+  // The alert's own behavior is untouched by the containment move: the
+  // fault-reset handler still fires from its new DOM parent exactly as it
+  // did from the old one. (The ModInputTxWarning buttons' own handler
+  // wiring is unchanged — pinned in
+  // `components-v2/wiring/__tests__/semantic-rx-tx-wiring.component.test.ts`
+  // and `components-v2/panels/__tests__/ModInputTxWarning.test.ts` — moving
+  // its DOM parent does not touch the component's own click handlers.)
+  it('still reaches the fault-reset handler from inside the zone', () => {
+    h.state = mainSubState('MAIN');
+    h.caps = mainSubCaps();
+    render();
+    push({ phase: 'failed', fault: 'audio-failed' });
+
+    q<HTMLButtonElement>('[data-testid="tx-fault-reset"]')!.click();
+    flushSync();
+    expect(h.resetFault).toHaveBeenCalledTimes(1);
   });
 });
 


### PR DESCRIPTION
Closes MOR-1258 (owner decision, cockpit gate item (b) from the MOR-1069 verification).

## What

The three conditional TX-adjacent alerts (`tx-fault-reset`, two `ModInputTxWarning` buttons) render inside the rx-tx zone's bound element in the dual composition, and the containment/focus-order tests now exercise the conditional states so they can never silently escape again. Handlers untouched; **17 net production LOC** (frozen formula; the raw diff counts comment lines), 1 production file.

## Provenance

- Independent adversarial verification (opus — the verifier whose MOR-1069 finding created this ticket): **PASS, 5/5 mutations killed, zero survivors**. Own probes: all three alerts inside the SAME bound element that owns RxTxSurface in fault-only, guard-only, and both-at-once states; zero zone-less controls; zone order unchanged; rx-tx-surface/key counts still exactly 1.
- Single-path ruling: **ACCEPT, letter and spirit** — the single path renders zero `data-zone-id` elements and asserts no containment (nothing is false there), and containing it would re-break the MOR-1069 N1 element identity and bind a zone id no manifest on that path declares. Follow-up note recorded for the 1070 gate: if that path gains bound zones, re-home the alerts.
- Behavior identity: only 3 files change (ModInputTxWarning.svelte and the guard adapter NOT among them); the MOR-617 pre-capabilities warning preserved (a view-gating mutant dies on three tests); single path element-identical to base modulo indentation whitespace; txAux unaffected (116/116 its tests; a mutant pulling it into the zone dies on the MOR-1265 pin).
- Verifier followed the hardened backup discipline (per-file backups only, no tree-wide checkout — the MOR-1265 lesson).

Suite 3576/3576 twice + stashed baseline (the one flaky file pre-exists); lint/check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)