### PR TITLE
test(MOR-1070): browser fixture harness for the dual-receiver cockpit baselines

### DIFF
--- a/frontend/fixtures/assertions.ts
+++ b/frontend/fixtures/assertions.ts
@@ -1,0 +1,281 @@
+/**
+ * MOR-1070 — the behavior assertions that must pass BEFORE a screenshot is
+ * taken. They are the browser half of the invariants MOR-1067/1068/1069/1256
+ * pinned in jsdom, plus the three that only a real engine can decide:
+ * `nothing-hidden` (computed visibility), `strip-columns` (evaluated media
+ * queries) and `touch-targets` (laid-out hit boxes).
+ *
+ * A capture whose assertions did not all pass is recorded as INVALID in the
+ * manifest — the picture is evidence of the assertions, never a substitute.
+ */
+import type { Expectation } from './catalog';
+
+export interface AssertionResult {
+  name: string;
+  ok: boolean;
+  detail: string;
+}
+
+export interface AssertionOptions {
+  /**
+   * Expected arrangement of the two channel strips at this viewport — the
+   * operator-visible truth of MOR-1069's reflow, read off laid-out boxes
+   * rather than off the grid's resolved `grid-template-columns` string (which
+   * `repeat(auto-fit, …)` makes an implementation detail).
+   */
+  arrangement?: 'side-by-side' | 'stacked';
+  /** Require every cockpit control to be >= 44x44 CSS px (pointer: coarse). */
+  touchTargets?: boolean;
+  /** Require every animation/transition inside the cockpit to be switched off. */
+  reducedMotion?: boolean;
+}
+
+const root = (): HTMLElement =>
+  document.querySelector<HTMLElement>('[data-testid="dual-receiver-cockpit"]')!;
+const qa = <T extends HTMLElement>(sel: string): T[] => [...root().querySelectorAll<T>(sel)];
+const q = <T extends HTMLElement>(sel: string): T | null => root().querySelector<T>(sel);
+const eq = (a: unknown, b: unknown): boolean => JSON.stringify(a) === JSON.stringify(b);
+
+function visible(el: HTMLElement): boolean {
+  const cs = getComputedStyle(el);
+  if (cs.display === 'none' || cs.visibility === 'hidden' || cs.visibility === 'collapse') {
+    return false;
+  }
+  if (cs.contentVisibility === 'hidden') return false;
+  const rect = el.getBoundingClientRect();
+  return rect.width > 0 && rect.height > 0;
+}
+
+/** Every focusable control the cockpit renders, in DOM order. */
+const controls = (): HTMLElement[] =>
+  qa<HTMLElement>('button, input, select, a[href], [tabindex]');
+
+export function runAssertions(
+  expected: Expectation, options: AssertionOptions = {},
+): AssertionResult[] {
+  const out: AssertionResult[] = [];
+  const check = (name: string, ok: boolean, detail: string): void => {
+    out.push({ name, ok, detail });
+  };
+
+  // ── structure ───────────────────────────────────────────────────────────
+  const zones = qa('[data-zone-id]').map((el) => el.dataset.zoneId);
+  check('zones-in-declaration-order', eq(zones, [...expected.zones]),
+    `rendered ${JSON.stringify(zones)} · expected ${JSON.stringify(expected.zones)}`);
+
+  const strips = qa<HTMLElement>('[data-testid^="channel-strip-"]');
+  check('strip-count', strips.length === expected.strips,
+    `${strips.length} strips · expected ${expected.strips}`);
+  check('strip-receivers',
+    eq(strips.map((s) => s.dataset.stripReceiver), [...expected.stripReceivers]),
+    JSON.stringify(strips.map((s) => s.dataset.stripReceiver)));
+  check('strip-operational-flags',
+    eq(strips.map((s) => s.dataset.stripOperational === 'true'), [...expected.stripOperational]),
+    JSON.stringify(strips.map((s) => s.dataset.stripOperational)));
+  check('strip-active-flags',
+    eq(strips.map((s) => s.dataset.stripActive === 'true'), [...expected.stripActive]),
+    JSON.stringify(strips.map((s) => s.dataset.stripActive)));
+
+  const tiles = qa('[data-vfo-tile]');
+  check('tile-count', tiles.length === expected.tiles,
+    `${tiles.length} tiles · expected ${expected.tiles}`);
+  check('tiles-belong-to-their-strip',
+    strips.every((s) => [...s.querySelectorAll<HTMLElement>('[data-vfo-tile]')]
+      .every((t) => t.dataset.vfoReceiver === s.dataset.stripReceiver)),
+    'every tile carries its own strip\'s receiver id');
+
+  // ── two-level gating (MOR-977 / MOR-1256) ───────────────────────────────
+  const selects = qa<HTMLButtonElement>('[data-vfo-select]');
+  const enabled = selects.filter((b) => !b.disabled).length;
+  const disabled = selects.length - enabled;
+  check('select-gating',
+    enabled === expected.selectsEnabled && disabled === expected.selectsDisabled,
+    `${enabled} enabled / ${disabled} disabled · expected `
+    + `${expected.selectsEnabled}/${expected.selectsDisabled}`);
+  check('disabled-selects-are-really-inert',
+    selects.filter((b) => b.disabled).every((b) => b.matches(':disabled')),
+    'disabled selects match :disabled (attribute, not styling)');
+
+  // ── single TX authority (the layout's hardest invariant) ────────────────
+  const surfaces = qa('[data-testid="rx-tx-surface"]');
+  const keys = qa<HTMLButtonElement>('[data-testid="rx-tx-key"]');
+  const unkeys = qa<HTMLButtonElement>('[data-testid="rx-tx-unkey"]');
+  const txExpected = expected.zones.includes('rx-tx') ? 1 : 0;
+  check('single-tx-authority-surface',
+    surfaces.length === txExpected && keys.length === txExpected
+      && unkeys.length === txExpected,
+    `${surfaces.length} surfaces / ${keys.length} key / ${unkeys.length} unkey`);
+  check('unkey-is-never-gated', unkeys.every((b) => !b.disabled),
+    'no unkey control carries `disabled`');
+  if (keys.length === 1) {
+    check('key-gate', keys[0].disabled === expected.keyDisabled,
+      `key disabled=${keys[0].disabled} · expected ${expected.keyDisabled}`);
+  }
+
+  // ── radio-wide facts render once, outside every strip (MOR-1068) ────────
+  const global = q('[data-zone-id="global"]');
+  const wide = ['[data-vfo-split]', '[data-vfo-dual-watch]',
+    '[data-testid="vfo-active-receiver"]'];
+  if (expected.zones.includes('global')) {
+    check('radio-wide-row-renders-once',
+      wide.every((sel) => qa(sel).length === 1),
+      wide.map((sel) => `${sel}=${qa(sel).length}`).join(' '));
+    check('radio-wide-row-lives-in-the-global-zone',
+      wide.every((sel) => {
+        const el = q(sel);
+        return el !== null && global !== null && global.contains(el)
+          && !strips.some((s) => s.contains(el));
+      }),
+      'split / dual-watch / active-receiver are inside `global` and inside no strip');
+    check('global-zone-is-not-aria-disabled',
+      global !== null && global.getAttribute('aria-disabled') === null,
+      'a zone holding live switches must not present as dead');
+    const switches = qa<HTMLButtonElement>('[data-vfo-split], [data-vfo-dual-watch]');
+    check('radio-wide-switch-gate',
+      switches.length === 2
+      && switches.every((b) => b.disabled === expected.radioWideSwitchesDisabled),
+      `disabled=${JSON.stringify(switches.map((b) => b.disabled))} · `
+      + `expected all ${expected.radioWideSwitchesDisabled}`);
+  }
+
+  // ── honest placeholders ────────────────────────────────────────────────
+  const inert = ['scope', 'controls']
+    .map((z) => q(`[data-testid="cockpit-zone-${z}"]`));
+  check('placeholder-zones-present-and-inert',
+    inert.every((el) => el !== null
+      && el.getAttribute('aria-disabled') === 'true'
+      && el.dataset.zoneActive === 'false'
+      && el.querySelectorAll('button, [role="switch"], input').length === 0
+      && (el.textContent ?? '') === ''
+      && !el.hasAttribute('data-zone-id')),
+    'scope + controls: aria-disabled, empty, claiming no manifest zone');
+
+  // ── nothing is hidden (MOR-1069 policy 2 — only decidable in a browser) ─
+  const hideable = [...qa<HTMLElement>('[data-zone-id]'), ...controls(),
+    ...qa<HTMLElement>('[data-testid^="channel-strip-"]')];
+  const hidden = hideable.filter((el) => !visible(el));
+  check('nothing-hidden', hidden.length === 0,
+    hidden.length === 0
+      ? `${hideable.length} zones/controls all laid out and visible`
+      : `hidden: ${hidden.map((el) => el.dataset.testid ?? el.tagName).join(', ')}`);
+
+  // ── focus order is DOM order, ending in rx-tx (MOR-1069) ───────────────
+  const declared = [...expected.zones];
+  const seq = controls().map((el) => {
+    const zone = el.closest('[data-zone-id]') as HTMLElement | null;
+    return declared.indexOf(zone?.dataset.zoneId ?? '');
+  });
+  const zoned = seq.filter((i) => i >= 0);
+  check('focus-order-is-zone-order',
+    controls().length === 0
+      || (eq(zoned, [...zoned].sort((a, b) => a - b))
+        && (zoned.length === 0 || zoned[zoned.length - 1] === declared.indexOf('rx-tx'))),
+    `zone indices ${JSON.stringify(seq)} (-1 = outside every declared zone)`);
+  check('zone-less-control-count',
+    seq.filter((i) => i === -1).length === expected.zonelessControls,
+    `${seq.filter((i) => i === -1).length} outside every zone · `
+    + `expected ${expected.zonelessControls}`);
+  check('no-negative-tabindex-and-no-aria-hidden-control',
+    controls().every((el) => Number(el.getAttribute('tabindex') ?? '0') >= 0
+      && el.closest('[aria-hidden="true"]') === null),
+    `${controls().length} focusable controls`);
+
+  // ── TX readout words (text AND shape, never colour alone) ──────────────
+  const rf = q('[data-testid="rx-tx-rf-label"]')?.textContent?.trim() ?? null;
+  const session = q('[data-testid="rx-tx-state"] .rx-tx-session')?.textContent?.trim() ?? null;
+  check('tx-readout', rf === expected.rfLabel && session === expected.sessionLabel,
+    `rf=${JSON.stringify(rf)} session=${JSON.stringify(session)} · `
+    + `expected ${JSON.stringify(expected.rfLabel)}/${JSON.stringify(expected.sessionLabel)}`);
+  check('fault-affordance',
+    (q('[data-testid="tx-fault-reset"]') !== null) === expected.faultResetPresent,
+    `tx-fault-reset present=${q('[data-testid="tx-fault-reset"]') !== null}`);
+  check('mod-input-warning',
+    (q('[data-testid="mod-input-tx-warning"]') !== null) === expected.modInputWarningPresent,
+    `mod-input-tx-warning present=${q('[data-testid="mod-input-tx-warning"]') !== null}`);
+
+  // ── viewport-dependent: the reflow itself ──────────────────────────────
+  if (options.arrangement !== undefined && strips.length === 2) {
+    const [a, b] = strips.map((el) => el.getBoundingClientRect());
+    const actual = b.top >= a.bottom - 1 ? 'stacked'
+      : Math.abs(b.top - a.top) < 1 && b.left > a.left ? 'side-by-side'
+        : 'indeterminate';
+    // `repeat(auto-fit, minmax(0, 1fr))` resolves to the used tracks followed
+    // by ~150 collapsed `0px` ones in Chromium — record only the used prefix.
+    const tracks = getComputedStyle(q('.channel-strips')!).gridTemplateColumns
+      .trim().split(/\s+/).filter((t) => t !== '0px');
+    check('strip-arrangement-at-this-viewport', actual === options.arrangement,
+      `${actual} · expected ${options.arrangement} · used tracks: ${tracks.join(' ')}`
+      + ` (+${
+        getComputedStyle(q('.channel-strips')!).gridTemplateColumns.trim().split(/\s+/).length
+        - tracks.length} collapsed auto-fit tracks)`);
+  }
+  if (options.touchTargets) {
+    const small = qa<HTMLElement>('button, [role="switch"]').filter((el) => {
+      const r = el.getBoundingClientRect();
+      return r.width < 44 || r.height < 44;
+    });
+    check('touch-targets-44px', small.length === 0,
+      small.length === 0
+        ? `${qa('button, [role="switch"]').length} controls all >= 44x44`
+        : `too small: ${small.map((el) => el.textContent?.trim().slice(0, 18)).join(' | ')}`);
+  }
+  if (options.reducedMotion) {
+    const moving = [root(), ...qa<HTMLElement>('*')].filter((el) => {
+      const cs = getComputedStyle(el);
+      const anim = cs.animationName !== 'none'
+        && cs.animationDuration.split(',').some((d) => parseFloat(d) > 0.001);
+      const trans = cs.transitionDuration.split(',').some((d) => parseFloat(d) > 0.001);
+      return anim || trans;
+    });
+    check('reduced-motion-switches-everything-off', moving.length === 0,
+      moving.length === 0
+        ? 'no element inside the cockpit animates or transitions'
+        : `still moving: ${moving.map((el) => el.className).join(' | ')}`);
+  }
+
+  return out;
+}
+
+/**
+ * Resolved paint of the controls that carry the most safety weight, recorded
+ * per capture so a `prefers-contrast` / `forced-colors` variant is provable in
+ * TEXT and not only in pixels.
+ */
+export function styleProbe(): Record<string, Record<string, string>> {
+  const targets: Record<string, string> = {
+    key: '[data-testid="rx-tx-key"]',
+    unkey: '[data-testid="rx-tx-unkey"]',
+    split: '[data-vfo-split]',
+    vfoSelect: '[data-vfo-select]:not(:disabled)',
+    disabledSelect: '[data-vfo-select]:disabled',
+    activeTile: '[data-vfo-tile][data-vfo-active="true"]',
+    inactiveTile: '[data-vfo-tile][data-vfo-active="false"]',
+    activeStrip: '[data-testid^="channel-strip-"][data-strip-active="true"]',
+    inactiveStrip: '[data-testid^="channel-strip-"][data-strip-active="false"]',
+    txBadge: '[data-vfo-tx-badge]',
+  };
+  const out: Record<string, Record<string, string>> = {};
+  for (const [name, sel] of Object.entries(targets)) {
+    const el = q<HTMLElement>(sel);
+    if (!el) continue;
+    const cs = getComputedStyle(el);
+    out[name] = {
+      color: cs.color,
+      backgroundColor: cs.backgroundColor,
+      borderColor: cs.borderTopColor,
+      borderLeftColor: cs.borderLeftColor,
+      outlineColor: cs.outlineColor,
+      forcedColorAdjust: cs.forcedColorAdjust,
+    };
+  }
+  return out;
+}
+
+/** Resolved token values, recorded per capture so a media variant is provable. */
+export function tokenSnapshot(): Record<string, string> {
+  const cs = getComputedStyle(document.documentElement);
+  const names = ['--v2-text-primary', '--v2-text-secondary', '--v2-text-disabled',
+    '--v2-border-panel', '--v2-bg-panel', '--v2-accent-cyan', '--v2-accent-red',
+    '--v2-focus-ring', '--focus-ring', '--bg', '--text', '--accent'];
+  return Object.fromEntries(names.map((n) => [n, cs.getPropertyValue(n).trim()]));
+}

--- a/frontend/fixtures/capture.mjs
+++ b/frontend/fixtures/capture.mjs
@@ -1,0 +1,379 @@
+/**
+ * MOR-1070 — cockpit baseline capture runner.
+ *
+ * Verification-only tooling. Starts the additive fixtures vite config on
+ * 127.0.0.1:5199, drives Playwright's bundled Chromium over the fixture
+ * matrix, runs the fixture's BEHAVIOR ASSERTIONS in the page BEFORE taking any
+ * screenshot, and writes both the PNGs and a manifest that records build
+ * identity, media emulation, every assertion result and the intentional
+ * differences.
+ *
+ *   node fixtures/capture.mjs [--out <dir>] [--only <substring>]
+ *
+ * The server is always closed, including on failure.
+ */
+import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { chromium } from '@playwright/test';
+import { createServer } from 'vite';
+
+const FRONTEND = path.resolve(import.meta.dirname, '..');
+const REPO = path.resolve(FRONTEND, '..');
+const argv = process.argv.slice(2);
+const arg = (name, fallback) => {
+  const i = argv.indexOf(name);
+  return i >= 0 ? argv[i + 1] : fallback;
+};
+const OUT = path.resolve(arg('--out', path.join(FRONTEND, 'fixtures-baselines')));
+const ONLY = arg('--only', null);
+const PORT = 5199;
+
+/* ── viewports ─────────────────────────────────────────────────────────── */
+const VIEWPORTS = {
+  desktop: { width: 1280, height: 800, arrangement: 'side-by-side' },
+  'tablet-portrait': { width: 768, height: 1024, arrangement: 'stacked' },
+  'tablet-landscape': { width: 1024, height: 768, arrangement: 'side-by-side' },
+  'phone-portrait': { width: 375, height: 812, arrangement: 'stacked' },
+  // 812px wide falls in the 768-1023 tablet band, and the band stacks in
+  // PORTRAIT only — so a phone on its side keeps two columns. Captured
+  // deliberately: it is the boundary the MOR-1069 policy actually draws.
+  'phone-landscape': { width: 812, height: 375, arrangement: 'side-by-side' },
+};
+
+/* ── the capture matrix ────────────────────────────────────────────────── */
+/** { name, fixture, viewport, media?, touch?, theme?, focusTabs?, note? } */
+const MATRIX = [
+  // A. the reference dual state across every viewport + orientation
+  ...Object.keys(VIEWPORTS).map((v) => ({
+    name: `dual-main-sub--${v}`, fixture: 'topology-2-main-sub', viewport: v,
+  })),
+  // B. the four topology pairs
+  { name: 'topology-1-single--desktop', fixture: 'topology-1-single', viewport: 'desktop' },
+  { name: 'topology-1-ab--desktop', fixture: 'topology-1-ab', viewport: 'desktop' },
+  { name: 'topology-2-ab-shared--desktop', fixture: 'topology-2-ab-shared', viewport: 'desktop' },
+  {
+    name: 'topology-2-ab-shared--phone-portrait',
+    fixture: 'topology-2-ab-shared', viewport: 'phone-portrait',
+  },
+  // C. the orthogonal audio-only scope condition
+  { name: 'audio-only-scope--desktop', fixture: 'audio-only-scope', viewport: 'desktop' },
+  // D. startup window
+  { name: 'sub-unobserved--desktop', fixture: 'sub-unobserved', viewport: 'desktop' },
+  // E. operational gating (MOR-1256)
+  { name: 'dual-rx-unavailable--desktop', fixture: 'dual-rx-unavailable', viewport: 'desktop' },
+  {
+    name: 'dual-rx-unavailable--phone-portrait',
+    fixture: 'dual-rx-unavailable', viewport: 'phone-portrait',
+  },
+  // F. RX / pending / TX / fault
+  { name: 'tx-phase-rx--desktop', fixture: 'tx-phase-rx', viewport: 'desktop' },
+  { name: 'tx-phase-pending--desktop', fixture: 'tx-phase-pending', viewport: 'desktop' },
+  { name: 'tx-phase-tx--desktop', fixture: 'tx-phase-tx', viewport: 'desktop' },
+  { name: 'tx-phase-fault--desktop', fixture: 'tx-phase-fault', viewport: 'desktop' },
+  { name: 'tx-phase-tx--phone-portrait', fixture: 'tx-phase-tx', viewport: 'phone-portrait' },
+  // G. connection loss, both honest readings
+  {
+    name: 'connection-loss-stale--desktop',
+    fixture: 'connection-loss-stale', viewport: 'desktop',
+  },
+  {
+    name: 'connection-loss-state-null--desktop',
+    fixture: 'connection-loss-state-null', viewport: 'desktop',
+  },
+  {
+    name: 'connection-loss-state-null--phone-portrait',
+    fixture: 'connection-loss-state-null', viewport: 'phone-portrait',
+  },
+  { name: 'caps-unloaded--desktop', fixture: 'caps-unloaded', viewport: 'desktop' },
+  // H. acceptance gate (b): the three conditional zone-less controls
+  { name: 'zoneless-controls--desktop', fixture: 'zoneless-controls', viewport: 'desktop' },
+  // I. media emulation on the reference dual state
+  {
+    name: 'dual-main-sub--desktop--reduced-motion', fixture: 'topology-2-main-sub',
+    viewport: 'desktop', media: { reducedMotion: 'reduce' },
+  },
+  {
+    name: 'dual-main-sub--desktop--contrast-more', fixture: 'topology-2-main-sub',
+    viewport: 'desktop', media: { contrast: 'more' },
+  },
+  {
+    name: 'dual-main-sub--desktop--forced-colors', fixture: 'topology-2-main-sub',
+    viewport: 'desktop', media: { forcedColors: 'active' },
+  },
+  {
+    name: 'dual-main-sub--phone-portrait--reduced-motion', fixture: 'topology-2-main-sub',
+    viewport: 'phone-portrait', media: { reducedMotion: 'reduce' },
+  },
+  // J. keyboard focus — real `:focus-visible`, reached by Tab, not by .focus()
+  {
+    name: 'focus-visible-key-control--desktop', fixture: 'topology-2-main-sub',
+    viewport: 'desktop', focusTabs: 6,
+  },
+  {
+    name: 'focus-visible-first-select--desktop', fixture: 'topology-2-main-sub',
+    viewport: 'desktop', focusTabs: 1,
+  },
+  // K. coarse pointer — the 44px hit-size floor, on laid-out boxes
+  {
+    name: 'touch-targets--phone-portrait', fixture: 'topology-2-main-sub',
+    viewport: 'phone-portrait', touch: true,
+  },
+  // L. the honest un-themed reading (see fixtures/main.ts)
+  {
+    name: 'dual-main-sub--desktop--no-v2-theme', fixture: 'topology-2-main-sub',
+    viewport: 'desktop', theme: 'none',
+  },
+];
+
+/* ── build identity ────────────────────────────────────────────────────── */
+const git = (...args) =>
+  execFileSync('git', ['-C', REPO, ...args], { encoding: 'utf8' }).trim();
+const PRODUCTION_SOURCES = [
+  'frontend/src/skins/dual-receiver-cockpit/DualReceiverCockpit.svelte',
+  'frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte',
+  'frontend/src/components-v2/wiring/dual-receiver-strips.ts',
+  'frontend/src/semantic/VfoSurface.svelte',
+  'frontend/src/semantic/RxTxSurface.svelte',
+  'frontend/src/semantic/rx-tx-surface.ts',
+  'frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts',
+  'frontend/src/lib/runtime/adapters/presentation-capabilities.ts',
+  'frontend/src/presentation/layouts/dual-receiver-cockpit.ts',
+  'frontend/src/app.css',
+  'frontend/src/styles/tokens.css',
+  'frontend/src/styles/animations.css',
+  'frontend/src/components-v2/theme/tokens.css',
+];
+const sha256 = (file) =>
+  createHash('sha256').update(readFileSync(path.join(REPO, file))).digest('hex');
+const buildIdentity = {
+  repo: 'rigplane-core',
+  headSha: git('rev-parse', 'HEAD'),
+  headShaShort: git('rev-parse', '--short=8', 'HEAD'),
+  branch: git('rev-parse', '--abbrev-ref', 'HEAD'),
+  headSubject: git('log', '-1', '--pretty=%s'),
+  worktreeClean: git('status', '--porcelain', '--', 'frontend/src', 'src') === '',
+  node: process.version,
+  playwright: JSON.parse(
+    readFileSync(path.join(FRONTEND, 'node_modules/@playwright/test/package.json'), 'utf8'),
+  ).version,
+  svelte: JSON.parse(
+    readFileSync(path.join(FRONTEND, 'node_modules/svelte/package.json'), 'utf8'),
+  ).version,
+  productionSourceDigests: Object.fromEntries(
+    PRODUCTION_SOURCES.map((f) => [f, sha256(f).slice(0, 16)]),
+  ),
+};
+
+/* ── run ───────────────────────────────────────────────────────────────── */
+mkdirSync(OUT, { recursive: true });
+const server = await createServer({
+  configFile: path.join(FRONTEND, 'vite.fixtures.config.ts'),
+  root: FRONTEND,
+  logLevel: 'warn',
+  server: { port: PORT, strictPort: true, host: '127.0.0.1' },
+});
+await server.listen();
+
+/**
+ * This host has the shared ms-playwright cache populated by a NEWER
+ * playwright than the repo's devDependency, so `chromium.launch()` cannot find
+ * the exact revision it wants. Rather than pull a second browser build down,
+ * fall back to the newest headless shell already installed and record which
+ * binary produced the baselines. Override with MOR1070_CHROMIUM=<path>.
+ */
+async function launchChromium() {
+  try {
+    return { browser: await chromium.launch(), executable: 'playwright-bundled' };
+  } catch (bundledError) {
+    const explicit = process.env.MOR1070_CHROMIUM;
+    const candidates = explicit ? [explicit] : (() => {
+      const cache = path.join(process.env.HOME ?? '', 'Library/Caches/ms-playwright');
+      if (!existsSync(cache)) return [];
+      return readdirSync(cache)
+        .filter((d) => d.startsWith('chromium_headless_shell-') || d.startsWith('chromium-'))
+        .sort((a, b) => Number(b.split('-').pop()) - Number(a.split('-').pop()))
+        // Full builds first: on this host the version-mismatched headless
+        // SHELL launches but fails `Page.captureScreenshot`, which would make
+        // every baseline silently unobtainable.
+        .flatMap((d) => [
+          path.join(cache, d, 'chrome-mac-arm64',
+            'Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing'),
+          path.join(cache, d, 'chrome-mac-arm64', 'Chromium.app/Contents/MacOS/Chromium'),
+          path.join(cache, d, 'chrome-linux', 'chrome'),
+          path.join(cache, d, 'chrome-headless-shell-mac-arm64', 'chrome-headless-shell'),
+          path.join(cache, d, 'chrome-headless-shell-linux', 'chrome-headless-shell'),
+        ]);
+    })();
+    const executablePath = candidates.find((p) => existsSync(p));
+    if (!executablePath) throw bundledError;
+    return {
+      browser: await chromium.launch({ executablePath }),
+      executable: executablePath,
+    };
+  }
+}
+
+const { browser, executable } = await launchChromium();
+buildIdentity.chromium = executable;
+const captures = [];
+let failures = 0;
+
+try {
+  for (const spec of MATRIX) {
+    if (ONLY && !spec.name.includes(ONLY)) continue;
+    const vp = VIEWPORTS[spec.viewport];
+    const context = await browser.newContext({
+      viewport: { width: vp.width, height: vp.height },
+      deviceScaleFactor: 1,
+      hasTouch: Boolean(spec.touch),
+      isMobile: false,
+      colorScheme: 'dark',
+      reducedMotion: spec.media?.reducedMotion,
+      timezoneId: 'UTC',
+      locale: 'en-US',
+    });
+    const page = await context.newPage();
+    const consoleErrors = [];
+    page.on('console', (m) => { if (m.type() === 'error') consoleErrors.push(m.text()); });
+    page.on('pageerror', (e) => consoleErrors.push(`pageerror: ${e.message}`));
+    if (spec.media) await page.emulateMedia(spec.media);
+
+    const theme = spec.theme ?? 'v2';
+    const url = `http://127.0.0.1:${PORT}/fixtures/index.html`
+      + `?fixture=${spec.fixture}&theme=${theme}`;
+    await page.goto(url, { waitUntil: 'load' });
+    await page.waitForSelector('body[data-harness-ready="true"]', { timeout: 15_000 });
+
+    // ── keyboard focus, before assertions so the tab order is recorded too
+    let focusPath = null;
+    let focusedControl = null;
+    if (spec.focusTabs) {
+      focusPath = [];
+      for (let i = 0; i < spec.focusTabs; i += 1) {
+        await page.keyboard.press('Tab');
+        focusPath.push(await page.evaluate(() => {
+          const el = document.activeElement;
+          if (!el || el === document.body) return 'BODY';
+          const zone = el.closest('[data-zone-id]')?.dataset.zoneId ?? 'NO-ZONE';
+          const strip = el.closest('[data-testid^="channel-strip-"]')?.dataset.stripReceiver;
+          const name = el.dataset.testid
+            ?? (el.hasAttribute('data-vfo-select') ? 'vfo-select'
+              : el.hasAttribute('data-vfo-split') ? 'vfo-split'
+                : el.hasAttribute('data-vfo-dual-watch') ? 'vfo-dual-watch'
+                  : el.tagName.toLowerCase());
+          return `${zone}${strip ? `/${strip}` : ''}:${name}`;
+        }));
+      }
+      focusedControl = focusPath[focusPath.length - 1];
+    }
+
+    // ── BEHAVIOR ASSERTIONS FIRST ────────────────────────────────────────
+    const options = {
+      arrangement: vp.arrangement,
+      touchTargets: Boolean(spec.touch),
+      reducedMotion: spec.media?.reducedMotion === 'reduce',
+    };
+    const assertions = await page.evaluate((o) => window.__harness.assert(o), options);
+    const tokens = await page.evaluate(() => window.__harness.tokens());
+    const paint = await page.evaluate(() => window.__harness.paint());
+    const domFocusOrder = await page.evaluate(() => window.__harness.focusOrder());
+    const passed = assertions.every((a) => a.ok) && consoleErrors.length === 0;
+    if (!passed) failures += 1;
+
+    const file = `${spec.name}.png`;
+    await page.screenshot({
+      path: path.join(OUT, file), fullPage: false, animations: 'disabled', caret: 'hide',
+    });
+
+    captures.push({
+      name: spec.name,
+      file,
+      valid: passed,
+      fixture: spec.fixture,
+      what: await page.evaluate(() => window.__harness.what),
+      viewport: { id: spec.viewport, ...vp },
+      media: {
+        reducedMotion: spec.media?.reducedMotion ?? 'no-preference',
+        contrast: spec.media?.contrast ?? 'no-preference',
+        forcedColors: spec.media?.forcedColors ?? 'none',
+        colorScheme: 'dark',
+        pointer: spec.touch ? 'coarse' : 'fine',
+      },
+      themeLayer: theme === 'v2' ? 'components-v2/theme (tokens + themes)' : 'none (fallbacks)',
+      url,
+      assertions,
+      assertionsPassed: assertions.filter((a) => a.ok).length,
+      assertionsTotal: assertions.length,
+      consoleErrors,
+      focusPath,
+      focusedControl,
+      domFocusOrder,
+      tokens,
+      paint,
+    });
+    // eslint-disable-next-line no-console
+    console.log(
+      `${passed ? 'PASS' : 'FAIL'}  ${spec.name}`
+      + `  (${assertions.filter((a) => a.ok).length}/${assertions.length} assertions)`,
+    );
+    if (!passed) {
+      for (const a of assertions.filter((x) => !x.ok)) {
+        // eslint-disable-next-line no-console
+        console.log(`        ✗ ${a.name}: ${a.detail}`);
+      }
+      for (const e of consoleErrors) console.log(`        ✗ console: ${e}`);
+    }
+    await context.close();
+  }
+} finally {
+  await browser.close();
+  await server.close();
+}
+
+const manifest = {
+  ticket: 'MOR-1070',
+  generatedAt: new Date().toISOString(),
+  buildIdentity,
+  harness: {
+    entry: 'frontend/fixtures/index.html + frontend/fixtures/main.ts',
+    config: 'frontend/vite.fixtures.config.ts (additive; vite.config.ts untouched)',
+    stubbedSeams: [
+      '$lib/runtime',
+      '$lib/runtime/tx-controller/app-host',
+      '$lib/runtime/adapters/mod-input-tx-guard.svelte',
+      'components-v2/wiring/command-bus',
+    ],
+    productionFilesChanged: 0,
+  },
+  intentionalDifferences: [
+    'The cockpit is mounted DIRECTLY (fixtures/main.ts) — resolveSkinId() has no '
+    + 'cockpit branch on this commit, so no navigation path can produce these views.',
+    'Four live seams are stubbed (see harness.stubbedSeams); every other module in the '
+    + 'render path — adapter, capability derivation, semantic surfaces, i18n, CSS — is shipped code.',
+    'Screenshots are taken with Playwright `animations: "disabled"` and `caret: "hide"` for '
+    + 'determinism. The cockpit declares no animation of its own; the only transition in the '
+    + 'tree is ModInputTxWarning\'s `.set-lan { transition: all .15s }`.',
+    'deviceScaleFactor is 1 for every capture — baselines are CSS-pixel exact, not Retina.',
+    'colorScheme is `dark` and no `data-theme` is set, so the components-v2 base token layer '
+    + 'applies. The `--no-v2-theme` capture records what the cockpit looks like WITHOUT that '
+    + 'layer, which is what it actually gets when mounted as the only skin (code-splitting: '
+    + 'components-v2/theme/index is imported by RadioLayout/LcdLayout, never by the cockpit).',
+    'The page chrome is a bare 100dvh box — no caption, padding or harness UI is composited '
+    + 'into any baseline.',
+  ],
+  viewports: VIEWPORTS,
+  summary: {
+    captures: captures.length,
+    valid: captures.filter((c) => c.valid).length,
+    invalid: failures,
+    assertionsRun: captures.reduce((n, c) => n + c.assertionsTotal, 0),
+    assertionsPassed: captures.reduce((n, c) => n + c.assertionsPassed, 0),
+  },
+  captures,
+};
+writeFileSync(path.join(OUT, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`);
+// eslint-disable-next-line no-console
+console.log(`\n${captures.length} captures → ${OUT}  (${failures} invalid)`);
+process.exit(failures === 0 ? 0 : 1);

--- a/frontend/fixtures/catalog.ts
+++ b/frontend/fixtures/catalog.ts
@@ -1,0 +1,328 @@
+/**
+ * MOR-1070 — the browser fixture catalog.
+ *
+ * Every state/capability shape below is lifted from the fixtures the merged
+ * component tests already use
+ * (`src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts`),
+ * so a browser capture and the jsdom behavior pins describe the same radio.
+ * The extra entries (`connection-loss-*`, `caps-unloaded`, the four TX phases,
+ * `zoneless-controls`) are the states the ticket's Evidence line names but the
+ * component tests do not enumerate as separate fixtures.
+ *
+ * `expect` is the BEHAVIOR ASSERTION contract for the fixture — it runs in the
+ * page before any screenshot is taken (MOR-1070 acceptance: "behavior
+ * assertions pass before screenshot comparison"). It is intentionally written
+ * as the DERIVED shape (strip/tile/select counts, zone order, operational
+ * flags), never as a copy of the fixture input, so an adapter or wiring
+ * regression breaks the assertion rather than silently re-baselining a picture.
+ */
+import type { Capabilities } from '$lib/types/capabilities';
+import type { ServerState } from '$lib/types/state';
+import { IDLE_TX, type ModGuardProps, type TxSnapshot } from './harness-state';
+
+const fresh = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' };
+const stale = { storePath: 'x', observed: true, freshness: 'stale', availability: 'stale' };
+
+type FieldStatusMap = Record<string, unknown>;
+const statuses = (paths: readonly string[], entry: unknown = fresh): FieldStatusMap =>
+  Object.fromEntries(paths.map((p) => [p, entry]));
+
+const RADIO_WIDE = ['active', 'split', 'dualWatch', 'txTarget'] as const;
+
+/** 2/main_sub: MAIN and SUB each carry A/B slots (4 vfo tiles total). */
+function mainSubState(active: 'MAIN' | 'SUB' = 'MAIN', entry: unknown = fresh): ServerState {
+  const paths: string[] = [...RADIO_WIDE];
+  for (const rx of ['main', 'sub']) {
+    paths.push(`${rx}.activeSlot`);
+    for (const v of ['vfoA', 'vfoB']) {
+      paths.push(`${rx}.${v}.freqHz`, `${rx}.${v}.mode`, `${rx}.${v}.filterNum`);
+    }
+  }
+  const slot = (hz: number) => ({ freqHz: hz, mode: 'USB', filterNum: 1 });
+  const receiver = (hz: number) => ({ vfoA: slot(hz), vfoB: slot(hz + 30000), activeSlot: 'A' });
+  return {
+    active, split: true, dualWatch: true, ptt: false,
+    txTarget: { status: 'known', receiver: 'MAIN', slot: 'A', frequencyHz: 14250000 },
+    main: receiver(14250000), sub: receiver(21295000),
+    fieldStatus: statuses(paths, entry),
+  } as unknown as ServerState;
+}
+
+/** 2/main_sub with SUB never observed at all — the startup window. */
+function mainSubSubUnobserved(): ServerState {
+  const paths: string[] = [...RADIO_WIDE, 'main.activeSlot'];
+  for (const v of ['vfoA', 'vfoB']) {
+    paths.push(`main.${v}.freqHz`, `main.${v}.mode`, `main.${v}.filterNum`);
+  }
+  const base = mainSubState('MAIN') as unknown as Record<string, unknown>;
+  const { sub: _absent, ...rest } = base;
+  return { ...rest, fieldStatus: statuses(paths) } as unknown as ServerState;
+}
+
+/** 2/ab_shared: MAIN and SUB are each a single unslotted VFO (2 vfo tiles). */
+function abSharedState(): ServerState {
+  const paths = [...RADIO_WIDE, 'main.freqHz', 'main.mode', 'main.filter',
+    'sub.freqHz', 'sub.mode', 'sub.filter'];
+  const receiver = (hz: number) => ({ freqHz: hz, mode: 'CW', filter: 1 });
+  return {
+    active: 'SUB', split: false, dualWatch: true, ptt: false,
+    txTarget: { status: 'known', receiver: 'SUB', slot: null, frequencyHz: 14250000 },
+    main: receiver(14250000), sub: receiver(14250000),
+    fieldStatus: statuses(paths),
+  } as unknown as ServerState;
+}
+
+/** 1/single: ONE receiver, one unslotted VFO. */
+function singleState(): ServerState {
+  const paths = [...RADIO_WIDE, 'main.freqHz', 'main.mode', 'main.filter'];
+  return {
+    active: 'MAIN', split: false, dualWatch: false, ptt: false,
+    txTarget: { status: 'known', receiver: 'MAIN', slot: null, frequencyHz: 14195000 },
+    main: { freqHz: 14195000, mode: 'USB', filter: 1 },
+    fieldStatus: statuses(paths),
+  } as unknown as ServerState;
+}
+
+/** 1/ab: ONE receiver carrying A/B slots. */
+function abState(): ServerState {
+  const paths = [...RADIO_WIDE, 'main.activeSlot',
+    'main.vfoA.freqHz', 'main.vfoA.mode', 'main.vfoA.filterNum',
+    'main.vfoB.freqHz', 'main.vfoB.mode', 'main.vfoB.filterNum'];
+  return {
+    active: 'MAIN', split: true, dualWatch: false, ptt: false,
+    txTarget: { status: 'known', receiver: 'MAIN', slot: 'A', frequencyHz: 14195000 },
+    main: {
+      vfoA: { freqHz: 14195000, mode: 'USB', filterNum: 1 },
+      vfoB: { freqHz: 14225000, mode: 'USB', filterNum: 2 },
+      activeSlot: 'A',
+    },
+    fieldStatus: statuses(paths),
+  } as unknown as ServerState;
+}
+
+const baseCaps = (): Capabilities => ({
+  model: 'fixture', scope: false, audio: true, tx: true,
+  capabilities: ['audio', 'tx', 'dual_rx'], receivers: 2, vfoScheme: 'main_sub',
+  freqRanges: [], modes: [], filters: [],
+  audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
+  webrtc: { available: false, enabled: false },
+  txBands: [{ start: 14000000, end: 14350000, name: '20m' }],
+  scopeSource: null, audioFftAvailable: false,
+} as unknown as Capabilities);
+
+const mainSubCaps = baseCaps;
+const abSharedCaps = (): Capabilities =>
+  ({ ...baseCaps(), vfoScheme: 'ab_shared' } as unknown as Capabilities);
+const singleCaps = (): Capabilities => ({
+  ...baseCaps(), receivers: 1, vfoScheme: 'single', capabilities: ['audio', 'tx'],
+} as unknown as Capabilities);
+const abCaps = (): Capabilities => ({
+  ...baseCaps(), receivers: 1, vfoScheme: 'ab', capabilities: ['audio', 'tx'],
+} as unknown as Capabilities);
+/** The ticket's orthogonal condition: scope=false + audioFft=true. */
+const audioOnlyScopeCaps = (): Capabilities =>
+  ({ ...baseCaps(), audioFftAvailable: true } as unknown as Capabilities);
+/** Structurally dual, no `dual_rx` tag → `dual-rx-unavailable` (MOR-1256). */
+const dualRxUnavailableCaps = (): Capabilities =>
+  ({ ...baseCaps(), capabilities: ['audio', 'tx'] } as unknown as Capabilities);
+
+const tx = (over: Partial<TxSnapshot>): TxSnapshot => ({ ...IDLE_TX, ...over });
+
+export interface Expectation {
+  /** Rendered `data-zone-id` values, in DOM order. */
+  zones: readonly string[];
+  strips: number;
+  /** Per-strip receiver ids, in DOM order. */
+  stripReceivers: readonly string[];
+  /** Per-strip `data-strip-operational`, in DOM order. */
+  stripOperational: readonly boolean[];
+  /** Per-strip `data-strip-active`, in DOM order. */
+  stripActive: readonly boolean[];
+  tiles: number;
+  selectsEnabled: number;
+  selectsDisabled: number;
+  /** `[data-vfo-split]` / `[data-vfo-dual-watch]` disabled state. */
+  radioWideSwitchesDisabled: boolean;
+  /** `[data-testid="rx-tx-key"]` disabled state. */
+  keyDisabled: boolean;
+  rfLabel: string | null;
+  sessionLabel: string | null;
+  /** `[data-testid="tx-fault-reset"]` present. */
+  faultResetPresent: boolean;
+  modInputWarningPresent: boolean;
+  /** Controls whose `closest('[data-zone-id]')` is null (acceptance gate (b)). */
+  zonelessControls: number;
+}
+
+export interface Fixture {
+  id: string;
+  /** One line, for the manifest. */
+  what: string;
+  state: () => ServerState | null;
+  caps: () => Capabilities | null;
+  tx: TxSnapshot;
+  modGuard?: ModGuardProps;
+  expect: Expectation;
+}
+
+const DUAL_ZONES = ['primary-vfo', 'secondary-vfo', 'global', 'rx-tx'] as const;
+const SINGLE_ZONES = ['primary-vfo', 'global', 'rx-tx'] as const;
+
+/** Shared shape of every healthy `2/main_sub` fixture — only TX state varies. */
+const mainSubExpect = (over: Partial<Expectation> = {}): Expectation => ({
+  zones: DUAL_ZONES, strips: 2, stripReceivers: ['MAIN', 'SUB'],
+  stripOperational: [true, true], stripActive: [true, false],
+  tiles: 4, selectsEnabled: 3, selectsDisabled: 0,
+  radioWideSwitchesDisabled: false, keyDisabled: false,
+  rfLabel: 'RX', sessionLabel: 'ready',
+  faultResetPresent: false, modInputWarningPresent: false, zonelessControls: 0,
+  ...over,
+});
+
+export const FIXTURES: readonly Fixture[] = [
+  {
+    id: 'topology-1-single',
+    what: '1/single — one receiver, one unslotted VFO; the cockpit degrades to one strip.',
+    state: singleState, caps: singleCaps, tx: tx({}),
+    expect: {
+      zones: SINGLE_ZONES, strips: 1, stripReceivers: ['MAIN'],
+      stripOperational: [true], stripActive: [true],
+      tiles: 1, selectsEnabled: 0, selectsDisabled: 0,
+      radioWideSwitchesDisabled: false, keyDisabled: false,
+      rfLabel: 'RX', sessionLabel: 'ready',
+      faultResetPresent: false, modInputWarningPresent: false, zonelessControls: 0,
+    },
+  },
+  {
+    id: 'topology-1-ab',
+    what: '1/ab — one receiver carrying A/B slots; still one strip, no SUB anywhere.',
+    state: abState, caps: abCaps, tx: tx({}),
+    expect: {
+      zones: SINGLE_ZONES, strips: 1, stripReceivers: ['MAIN'],
+      stripOperational: [true], stripActive: [true],
+      tiles: 2, selectsEnabled: 1, selectsDisabled: 0,
+      radioWideSwitchesDisabled: false, keyDisabled: false,
+      rfLabel: 'RX', sessionLabel: 'ready',
+      faultResetPresent: false, modInputWarningPresent: false, zonelessControls: 0,
+    },
+  },
+  {
+    id: 'topology-2-ab-shared',
+    what: '2/ab_shared — two receivers, one unslotted VFO each; SUB is the active receiver.',
+    state: abSharedState, caps: abSharedCaps, tx: tx({}),
+    expect: {
+      zones: DUAL_ZONES, strips: 2, stripReceivers: ['MAIN', 'SUB'],
+      stripOperational: [true, true], stripActive: [false, true],
+      tiles: 2, selectsEnabled: 1, selectsDisabled: 0,
+      radioWideSwitchesDisabled: false, keyDisabled: false,
+      rfLabel: 'RX', sessionLabel: 'ready',
+      faultResetPresent: false, modInputWarningPresent: false, zonelessControls: 0,
+    },
+  },
+  {
+    id: 'topology-2-main-sub',
+    what: '2/main_sub — the reference dual state: 4 tiles across 2 strips, MAIN A active.',
+    state: () => mainSubState('MAIN'), caps: mainSubCaps, tx: tx({}),
+    expect: mainSubExpect(),
+  },
+  {
+    id: 'audio-only-scope',
+    what: 'scope=false + audioFft=true on 2/main_sub — the cockpit must claim nothing either way.',
+    state: () => mainSubState('MAIN'), caps: audioOnlyScopeCaps, tx: tx({}),
+    expect: mainSubExpect(),
+  },
+  {
+    id: 'sub-unobserved',
+    what: 'startup window: SUB never observed — strip present, one explicit unknown slot, select disabled.',
+    state: mainSubSubUnobserved, caps: mainSubCaps, tx: tx({}),
+    expect: mainSubExpect({ tiles: 3, selectsEnabled: 1, selectsDisabled: 1 }),
+  },
+  {
+    id: 'dual-rx-unavailable',
+    what: 'structural dual, operationally degraded (MOR-1256) — SUB present, its selects really disabled.',
+    state: () => mainSubState('MAIN'), caps: dualRxUnavailableCaps, tx: tx({}),
+    expect: mainSubExpect({
+      stripOperational: [true, false], selectsEnabled: 1, selectsDisabled: 2,
+    }),
+  },
+  {
+    id: 'tx-phase-rx',
+    what: 'TX idle — RF receiving, session ready, key enabled, unkey ungated.',
+    state: () => mainSubState('MAIN'), caps: mainSubCaps, tx: tx({}),
+    expect: mainSubExpect(),
+  },
+  {
+    id: 'tx-phase-pending',
+    what: 'TX keying in progress — RF uncertain, session pending, key blocked, unkey still live.',
+    state: () => mainSubState('MAIN'), caps: mainSubCaps,
+    tx: tx({
+      phase: 'key-confirm-pending', intent: 'latched', guard: { leaseId: 'L1' },
+      radioTx: 'off', txRisk: 'uncertain', mayOwnKey: true,
+    }),
+    expect: mainSubExpect({ keyDisabled: true, rfLabel: 'TX?', sessionLabel: 'keying' }),
+  },
+  {
+    id: 'tx-phase-tx',
+    what: 'transmitting — RF TX, session key down, key blocked, unkey the only way out.',
+    state: () => mainSubState('MAIN'), caps: mainSubCaps,
+    tx: tx({
+      phase: 'active', intent: 'latched', guard: { leaseId: 'L1' },
+      radioTx: 'on', txRisk: 'confirmed-on', mayOwnKey: true,
+    }),
+    expect: mainSubExpect({ keyDisabled: true, rfLabel: 'TX', sessionLabel: 'key down' }),
+  },
+  {
+    id: 'tx-phase-fault',
+    what: 'TX fault — session fault, fault line shown, the App-owned fault reset affordance renders.',
+    state: () => mainSubState('MAIN'), caps: mainSubCaps,
+    tx: tx({ phase: 'failed', radioTx: 'unknown', txRisk: 'uncertain', fault: 'audio-failed' }),
+    expect: mainSubExpect({
+      keyDisabled: true, rfLabel: 'TX?', sessionLabel: 'fault',
+      faultResetPresent: true, zonelessControls: 1,
+    }),
+  },
+  {
+    id: 'connection-loss-stale',
+    what: 'radio link lost, values retained but every field STALE — every fact degrades to unknown.',
+    state: () => mainSubState('MAIN', stale), caps: mainSubCaps, tx: tx({}),
+    expect: mainSubExpect({
+      stripActive: [false, false], selectsEnabled: 4, selectsDisabled: 0,
+      radioWideSwitchesDisabled: true, keyDisabled: true,
+    }),
+  },
+  {
+    id: 'connection-loss-state-null',
+    what: 'reconnect window — capabilities known, no state payload at all; everything present and inert.',
+    state: () => null, caps: mainSubCaps, tx: tx({}),
+    expect: mainSubExpect({
+      stripActive: [false, false], tiles: 2, selectsEnabled: 0, selectsDisabled: 2,
+      radioWideSwitchesDisabled: true, keyDisabled: true,
+    }),
+  },
+  {
+    id: 'caps-unloaded',
+    what: 'no capabilities yet — the shell renders its inert placeholders and claims nothing.',
+    state: () => null, caps: () => null, tx: tx({}),
+    expect: {
+      zones: [], strips: 0, stripReceivers: [], stripOperational: [], stripActive: [],
+      tiles: 0, selectsEnabled: 0, selectsDisabled: 0,
+      radioWideSwitchesDisabled: false, keyDisabled: false,
+      rfLabel: null, sessionLabel: null,
+      faultResetPresent: false, modInputWarningPresent: false, zonelessControls: 0,
+    },
+  },
+  {
+    id: 'zoneless-controls',
+    what: 'acceptance gate (b): the three conditional controls that render OUTSIDE every declared zone.',
+    state: () => mainSubState('MAIN'), caps: mainSubCaps,
+    tx: tx({ phase: 'failed', radioTx: 'unknown', txRisk: 'uncertain', fault: 'audio-failed' }),
+    modGuard: { visible: true, sourceLabel: 'MIC' },
+    expect: mainSubExpect({
+      keyDisabled: true, rfLabel: 'TX?', sessionLabel: 'fault',
+      faultResetPresent: true, modInputWarningPresent: true, zonelessControls: 3,
+    }),
+  },
+];
+
+export const fixtureById = (id: string): Fixture | undefined =>
+  FIXTURES.find((f) => f.id === id);

--- a/frontend/fixtures/harness-state.ts
+++ b/frontend/fixtures/harness-state.ts
@@ -1,0 +1,56 @@
+/**
+ * MOR-1070 — mutable holders the aliased fixture stubs read.
+ *
+ * VERIFICATION-ONLY TOOLING. Nothing under `src/` imports this file; it lives
+ * outside `src/` on purpose so `eslint src/`, `svelte-check --tsconfig
+ * tsconfig.app.json` (include: `src/**`) and `vitest` (include:
+ * `src/ ** /*.test.ts`) all ignore it. The production tree is byte-unchanged.
+ *
+ * The cockpit reaches live state through exactly four seams
+ * (`$lib/runtime`, `$lib/runtime/tx-controller/app-host`,
+ * `$lib/runtime/adapters/mod-input-tx-guard.svelte` and the wiring's
+ * `command-bus`). `vite.fixtures.config.ts` re-points those four at
+ * `fixtures/stubs/*`, which read the holders below. Everything else — the real
+ * view-model adapter, the real presentation-capability derivation, the real
+ * semantic surfaces, the real i18n catalog, the real CSS — is the shipped code.
+ */
+import type { Capabilities } from '$lib/types/capabilities';
+import type { ServerState } from '$lib/types/state';
+
+export interface TxSnapshot {
+  phase: 'idle' | 'audio-start-pending' | 'key-confirm-pending' | 'active' | 'releasing' | 'failed';
+  intent: 'momentary' | 'latched' | null;
+  guard: { leaseId: string } | null;
+  radioTx: 'off' | 'on' | 'unknown';
+  txRisk: 'none' | 'uncertain' | 'confirmed-on';
+  mayOwnKey: boolean;
+  fault: string | null;
+}
+
+export interface ModGuardProps {
+  visible: boolean;
+  sourceLabel: string | null;
+}
+
+export const IDLE_TX: TxSnapshot = {
+  phase: 'idle', intent: null, guard: null,
+  radioTx: 'off', txRisk: 'none', mayOwnKey: false, fault: null,
+};
+
+export interface HarnessCall {
+  fn: string;
+  args: unknown[];
+}
+
+export const harness = {
+  state: null as ServerState | null,
+  caps: null as Capabilities | null,
+  tx: { ...IDLE_TX } as TxSnapshot,
+  modGuard: { visible: false, sourceLabel: null } as ModGuardProps,
+  calls: [] as HarnessCall[],
+  listeners: new Set<(next: TxSnapshot) => void>(),
+};
+
+export function record(fn: string, args: unknown[]): void {
+  harness.calls.push({ fn, args });
+}

--- a/frontend/fixtures/index.html
+++ b/frontend/fixtures/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>MOR-1070 — dual-receiver cockpit fixtures</title>
+    <style>
+      /* The cockpit's grid is `height: 100%`; give it a viewport-sized box and
+         nothing else. No chrome, no caption, no padding — a baseline picture
+         must contain the layout under test and nothing the harness invented. */
+      html, body { margin: 0; height: 100%; }
+      #app { height: 100dvh; }
+    </style>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/frontend/fixtures/main.ts
+++ b/frontend/fixtures/main.ts
@@ -1,0 +1,93 @@
+/**
+ * MOR-1070 — fixture harness entry.
+ *
+ * WHY THIS EXISTS. `skins/registry.ts:resolveSkinId()` has no branch that can
+ * return `'dual-receiver-cockpit'` and `LayoutMode` has no matching value, so
+ * the cockpit is unreachable through app navigation on `cdf0e99d` — no URL
+ * param, no stored preference, no picker. This page therefore mounts the skin
+ * DIRECTLY over fixture props, bypassing navigation entirely, which is also
+ * why it can stay verification-only: routing the cockpit into the app is a
+ * product decision (acceptance-package gate item (a)), not a capture task.
+ *
+ * Query parameters:
+ *   ?fixture=<id>    one of `catalog.ts`'s FIXTURES ids (required)
+ *   &theme=v2|none   load the components-v2 theme layer (default `v2`)
+ *
+ * `theme=none` is not a styling preference — it is the honest reading of what
+ * the cockpit gets today: `components-v2/theme/index` is imported by
+ * `RadioLayout` / `LcdLayout` only, and skins are code-split, so a cockpit
+ * mounted on its own resolves every `--v2-*` token to its in-component
+ * fallback. Both are captured; the difference is named in the manifest.
+ */
+import { flushSync, mount } from 'svelte';
+import '../src/app.css';
+import DualReceiverCockpit from '../src/skins/dual-receiver-cockpit/DualReceiverCockpit.svelte';
+import {
+  runAssertions, styleProbe, tokenSnapshot, type AssertionOptions,
+} from './assertions';
+import { fixtureById } from './catalog';
+import { harness, IDLE_TX } from './harness-state';
+
+const params = new URLSearchParams(window.location.search);
+const id = params.get('fixture') ?? 'topology-2-main-sub';
+const fixture = fixtureById(id);
+if (!fixture) throw new Error(`MOR-1070 harness: unknown fixture id "${id}"`);
+
+if ((params.get('theme') ?? 'v2') === 'v2') {
+  await import('../src/components-v2/theme/index');
+}
+
+harness.state = fixture.state();
+harness.caps = fixture.caps();
+harness.tx = { ...IDLE_TX, ...fixture.tx };
+harness.modGuard = fixture.modGuard ?? { visible: false, sourceLabel: null };
+harness.calls = [];
+
+document.title = `MOR-1070 · ${fixture.id}`;
+mount(DualReceiverCockpit, { target: document.getElementById('app')! });
+flushSync();
+
+declare global {
+  interface Window {
+    __harness: {
+      fixture: string;
+      what: string;
+      assert: (options?: AssertionOptions) => ReturnType<typeof runAssertions>;
+      tokens: () => Record<string, string>;
+      paint: () => Record<string, Record<string, string>>;
+      calls: () => typeof harness.calls;
+      focusOrder: () => string[];
+    };
+  }
+}
+
+window.__harness = {
+  fixture: fixture.id,
+  what: fixture.what,
+  assert: (options: AssertionOptions = {}) => runAssertions(fixture.expect, options),
+  tokens: tokenSnapshot,
+  paint: styleProbe,
+  calls: () => harness.calls,
+  /** A stable identifier per focusable control, in DOM order — the tab sequence. */
+  focusOrder: () => [...document.querySelectorAll<HTMLElement>(
+    '[data-testid="dual-receiver-cockpit"] button, '
+    + '[data-testid="dual-receiver-cockpit"] input, '
+    + '[data-testid="dual-receiver-cockpit"] select, '
+    + '[data-testid="dual-receiver-cockpit"] a[href], '
+    + '[data-testid="dual-receiver-cockpit"] [tabindex]',
+  )].map(describe),
+};
+
+function describe(el: HTMLElement): string {
+  const zone = (el.closest('[data-zone-id]') as HTMLElement | null)?.dataset.zoneId ?? 'NO-ZONE';
+  const strip = (el.closest('[data-testid^="channel-strip-"]') as HTMLElement | null)
+    ?.dataset.stripReceiver;
+  const name = el.dataset.testid
+    ?? (el.hasAttribute('data-vfo-select') ? 'vfo-select'
+      : el.hasAttribute('data-vfo-split') ? 'vfo-split'
+        : el.hasAttribute('data-vfo-dual-watch') ? 'vfo-dual-watch'
+          : el.tagName.toLowerCase());
+  return `${zone}${strip ? `/${strip}` : ''}:${name}${el.matches(':disabled') ? '[disabled]' : ''}`;
+}
+
+document.body.dataset.harnessReady = 'true';

--- a/frontend/fixtures/stubs/app-host.ts
+++ b/frontend/fixtures/stubs/app-host.ts
@@ -1,0 +1,22 @@
+/**
+ * MOR-1070 stub for `$lib/runtime/tx-controller/app-host`.
+ *
+ * Same surface the component tests mock (`snapshot` / `subscribe` / `start` /
+ * `setIntent` / `release` / `resetFault`), so the wiring's real lease identity
+ * discipline runs unmodified — the calls are recorded rather than sent.
+ */
+import { harness, record, type TxSnapshot } from '../harness-state';
+
+export function getAppTxController() {
+  return {
+    snapshot: (): TxSnapshot => harness.tx,
+    subscribe: (listener: (next: TxSnapshot) => void): (() => void) => {
+      harness.listeners.add(listener);
+      return () => { harness.listeners.delete(listener); };
+    },
+    start: (...args: unknown[]): void => record('tx.start', args),
+    setIntent: (...args: unknown[]): void => record('tx.setIntent', args),
+    release: (...args: unknown[]): void => record('tx.release', args),
+    resetFault: (...args: unknown[]): void => record('tx.resetFault', args),
+  };
+}

--- a/frontend/fixtures/stubs/command-bus.ts
+++ b/frontend/fixtures/stubs/command-bus.ts
@@ -1,0 +1,17 @@
+/**
+ * MOR-1070 stub for `components-v2/wiring/command-bus`.
+ *
+ * Only `makeVfoHandlers` is reachable from the cockpit's tree. Stubbed so a
+ * capture run opens no WebSocket and constructs no AudioContext (the real
+ * module pulls in `$lib/transport/ws-client` and `$lib/audio/audio-manager` at
+ * module scope) — the harness must be deterministic and offline.
+ */
+import { record } from '../harness-state';
+
+export function makeVfoHandlers() {
+  return {
+    onVfoSelect: (...args: unknown[]): void => record('vfo.select', args),
+    onSplitToggle: (...args: unknown[]): void => record('vfo.split', args),
+    onDualWatchToggle: (...args: unknown[]): void => record('vfo.dualWatch', args),
+  };
+}

--- a/frontend/fixtures/stubs/mod-input-tx-guard.ts
+++ b/frontend/fixtures/stubs/mod-input-tx-guard.ts
@@ -1,0 +1,20 @@
+/**
+ * MOR-1070 stub for `$lib/runtime/adapters/mod-input-tx-guard.svelte`.
+ *
+ * The real adapter reads the radio/capability stores and the command bus; the
+ * banner it drives is one of the three conditional, zone-less controls named
+ * in the MOR-1070 acceptance package's gate item (b), so the harness needs to
+ * be able to turn it on deliberately (`zoneless-controls` fixture).
+ */
+import { harness, record, type ModGuardProps } from '../harness-state';
+
+export function deriveModInputTxGuardProps(): ModGuardProps {
+  return harness.modGuard;
+}
+
+export function getModInputTxGuardHandlers() {
+  return {
+    onSetLan: (): void => record('modGuard.setLan', []),
+    onDismiss: (): void => record('modGuard.dismiss', []),
+  };
+}

--- a/frontend/fixtures/stubs/runtime.ts
+++ b/frontend/fixtures/stubs/runtime.ts
@@ -1,0 +1,7 @@
+/** MOR-1070 stub for `$lib/runtime` — fixture state/caps, no transport. */
+import { harness } from '../harness-state';
+
+export const runtime = {
+  get state() { return harness.state; },
+  get caps() { return harness.caps; },
+};

--- a/frontend/vite.fixtures.config.ts
+++ b/frontend/vite.fixtures.config.ts
@@ -1,0 +1,70 @@
+/**
+ * MOR-1070 — ADDITIVE vite config for the verification-only cockpit fixture
+ * harness. `vite.config.ts` is untouched: this file is passed explicitly
+ * (`vite --config vite.fixtures.config.ts`) and nothing in the app build,
+ * `npm run dev`, `npm run lint`, `npm run check` or `vitest` reads it.
+ *
+ * It differs from the app config in exactly two ways:
+ *   1. no dev-server proxy — the harness is offline by construction;
+ *   2. the `fixtureStubs` plugin below re-points the FOUR live seams the
+ *      cockpit's tree reaches through at `fixtures/stubs/*`.
+ *
+ * Everything else the capture renders is the shipped code: the real
+ * `radio-view-model-adapter`, the real `derivePresentationCapabilities`, the
+ * real `SemanticRadioSurfaces` / `VfoSurface` / `RxTxSurface`, the real i18n
+ * catalog, the real `app.css` + `components-v2/theme` token layer.
+ *
+ * Stubbing by RESOLVED ABSOLUTE PATH (not by alias on the import specifier) is
+ * deliberate: `SemanticRadioSurfaces` imports `./command-bus` relatively, and
+ * a string alias on `./command-bus` would match any same-named relative import
+ * anywhere in the graph.
+ */
+import path from 'node:path';
+import { defineConfig, type Plugin } from 'vite';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+
+const here = import.meta.dirname;
+
+/** production module (repo-relative) → fixture stub (repo-relative) */
+const STUBS: Readonly<Record<string, string>> = {
+  'src/lib/runtime/index.ts': 'fixtures/stubs/runtime.ts',
+  'src/lib/runtime/tx-controller/app-host.ts': 'fixtures/stubs/app-host.ts',
+  'src/lib/runtime/adapters/mod-input-tx-guard.svelte.ts': 'fixtures/stubs/mod-input-tx-guard.ts',
+  'src/components-v2/wiring/command-bus.ts': 'fixtures/stubs/command-bus.ts',
+};
+
+function fixtureStubs(): Plugin {
+  const table = new Map(Object.entries(STUBS).map(
+    ([from, to]) => [path.resolve(here, from), path.resolve(here, to)],
+  ));
+  const stubPaths = new Set(table.values());
+  return {
+    name: 'mor-1070-fixture-stubs',
+    enforce: 'pre',
+    async resolveId(source, importer, options) {
+      if (source.startsWith('\0') || !importer) return null;
+      // Never re-enter for the stubs themselves.
+      if (stubPaths.has(importer.split('?')[0])) return null;
+      const resolved = await this.resolve(source, importer, { ...options, skipSelf: true });
+      if (!resolved) return null;
+      return table.get(resolved.id.split('?')[0]) ?? null;
+    },
+  };
+}
+
+export default defineConfig({
+  // Root stays the app root so `svelte.config.js`, `public/` and the `../src`
+  // imports resolve exactly as they do in a normal build; the harness is a
+  // second HTML entry at `/fixtures/index.html`, not a second project.
+  plugins: [fixtureStubs(), svelte()],
+  resolve: {
+    alias: { $lib: path.resolve(here, 'src/lib') },
+    conditions: ['svelte', 'browser'],
+  },
+  server: { port: 5199, strictPort: true },
+  build: {
+    outDir: path.resolve(here, 'fixtures-dist'),
+    emptyOutDir: true,
+    rollupOptions: { input: path.resolve(here, 'fixtures/index.html') },
+  },
+});


### PR DESCRIPTION
Closes MOR-1070 — the owner acceptance gate of the MOR-976 reference-cockpit program (with this, all six children of MOR-976 are done).

## What

The browser fixture harness that produced the accepted baselines: `frontend/fixtures/` (catalog of 15 fixture states, in-page assertion library, capture driver, live-seam stubs) + an additive `vite.fixtures.config.ts`. **Zero production LOC** — no tracked production file changes; the harness mounts `DualReceiverCockpit` directly with fixture props. Reusable by design: the catalog IS MOR-1085's matrix seed; the recording TX stub feeds MOR-1088; the manifest carries MOR-1090's build-identity half.

## Acceptance record

- Evidence run: 31 baseline PNGs across the ticket's full Evidence line (4 topology pairs, audio-only scope, 5 viewports incl. both orientations, RX/pending/TX/fault, connection loss, focus-visible, prefers-contrast, forced-colors, reduced motion, MOR-1256 operational gating, SUB-unobserved startup, zone-less controls), with **770/770 in-page behavior assertions passing before captures**. Archived with the manifest and evidence report at `~/Projects/rigplane-archives/mor-1070-baselines/`.
- Owner reviewed key captures AND the live harness (fixture server), and **accepted 2026-08-04 as the structural/behavioral gate**, with the explicit record that the current visuals are the semantic skeleton — the design language (MOR-1073, unblocked by this acceptance) and the vocabulary program (MOR-1262) supply the visual richness next.
- Six browser-only findings from the run were triaged: MOR-1260 filed (non-color signaling); N2 noted to MOR-1073; N4 fixed in MOR-1257; gaps for MOR-1090 recorded (TX phases are fixture snapshots; fonts unbundled; Chromium revision pinning).

Suite/lint/check verified green with the harness present (failing-file set a strict subset of the env baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)