### PR TITLE
docs(MOR-1268): mark IC-7610 retired (2026-08-04) — env claims, test docstring, cat-audit banner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # CLAUDE.md — Control Plane
 
 **rigplane** v2.0.0 — Python 3.11+ asyncio library + Web UI for Icom transceivers over LAN/USB.
-IC-7610 at `192.168.55.40`, CI-V `0x98`. Context: `docs/PROJECT.md`.
+Live bench: **IC-7300, FTX-1, X6200**. *(IC-7610 retired 2026-08-04.)* Context: `docs/PROJECT.md`.
 
 ---
 

--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -115,7 +115,7 @@ Each UDP packet has a fixed-format header (see `packettypes.h` in wfview):
 - [x] Dual-port architecture (control port 50001 + CI-V port 50002)
 - [x] Keep-alive loop (ping + retransmit)
 - [x] Graceful disconnect
-- [x] Test: connect to IC-7610 at 192.168.55.40
+- [x] Test: connect over LAN (historical IC-7610 at 192.168.55.40; hardware retired 2026-08-04)
 
 **Result:** `radio.connect()` / `radio.disconnect()` work. ✅
 
@@ -430,10 +430,8 @@ IC-7610 parity matrix (issue #139, 2026-03-06): 134 implemented, 0 partial, 0 mi
 
 ## Test Equipment
 
-- **Icom IC-7610** at `192.168.55.40`
-- LAN ports: 50001 (control), 50002 (CI-V), 50003 (audio)
-- USB path: CI-V serial device + exported RX/TX audio devices
-- Local development host on the same LAN (IP redacted)
+- **Live bench:** Icom IC-7300, FTX-1, X6200 (LAN/USB ports per model docs)
+- **Retired:** Icom IC-7610 *(was at 192.168.55.40; hardware destroyed 2026-08-04; CAT audit frozen in `docs/validation/cat-audits/ic7610.md`)*
 
 ## License Notes
 

--- a/docs/validation/cat-audits/ic7610.md
+++ b/docs/validation/cat-audits/ic7610.md
@@ -3,7 +3,7 @@
 **Manual:** Icom IC-7610 **CI-V Reference Guide** rev **1a** (2021 printing) — full command table (cmds `00`–`27`, `1A 05 00xx` menu) + command formats. Source: `docs/validation/cat-audits/manuals/ic7610.txt` (extracted from the official Icom Japan PDF `IC-7610_ENG_CI-V_1a.pdf`, retrieved via the radiomanual.info mirror — Icom's own download endpoint serves an HTML/JS shell to `curl`, not the PDF; the mirror's bytes are the official document).
 **Driver:** `src/rigplane/runtime/radio.py` (IcomRadio + mixins) · scope in `src/rigplane/runtime/_scope_runtime.py` · dual-RX in `src/rigplane/runtime/_dual_rx_runtime.py`. Backend assembly `src/rigplane/backends/icom7610/`.
 **Profile:** `rigs/ic7610.toml`. **Validation:** `src/rigplane/validation/registry/*`.
-**Live run:** `/tmp/ic7610.live.json` — 70 checks: **59 pass · 3 fail** (`scope_dual.set`, `scope_vbw.set`, `scope_rbw.set`) · 8 manual_required. (core 2.9.0, mode=hardware, tx_allowed, LAN `192.168.55.40:50001`.)
+**Live run** *(hardware retired 2026-08-04—figures frozen for historical reference):* `/tmp/ic7610.live.json` — 70 checks: **59 pass · 3 fail** (`scope_dual.set`, `scope_vbw.set`, `scope_rbw.set`) · 8 manual_required. (core 2.9.0, mode=hardware, tx_allowed, LAN `192.168.55.40:50001`.)
 
 Protocol: Icom CI-V, `FE FE 98 E0 … FD` framing (transceiver addr `0x98`). `@9` in the manual = "**Command 29 supported**" → dual-RX targeting via the `0x29 <00|01>` prefix; the profile's `[cmd29]` block routes 26 commands this way. Set-then-read round-trips (RMVR) are the harness's strongest signal; many implemented controls only get a `*.presence` check because no RMVR is registered.
 

--- a/tests/hardware/test_ic7610_audio_pipeline.py
+++ b/tests/hardware/test_ic7610_audio_pipeline.py
@@ -2,6 +2,10 @@
 
 These tests transmit RF/audio when explicitly enabled. They are skipped by
 default and require a controlled station setup such as a dummy load.
+
+**Note:** No IC-7610 hardware is available for testing as of 2026-08-04 (hardware retired).
+Tests remain in place for historical reference and are gated by the RIGPLANE_HW_IC7610_AUDIO
+environment variable if future testing becomes possible.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
Executes §7 items 4–6 of the IC-7610 loss impact audit (owner decision Q5=A: freeze historical evidence in place with a dated banner — nothing deleted or retracted). Docs-only, 4 files, 0 production LOC:

- **CLAUDE.md** — live-environment header now names IC-7300/FTX-1/X6200 as the live bench
- **docs/PROJECT.md** — owned-hardware claims corrected; IC-7610 moved to *Retired* with destruction date
- **tests/hardware/test_ic7610_audio_pipeline.py** — module docstring retirement note; test kept, still env-gated by `RIGPLANE_HW_IC7610_AUDIO`
- **docs/validation/cat-audits/ic7610.md** — dated "hardware retired 2026-08-04" banner on the *Live run* line (59/3/8 figures frozen as historical)

## Review provenance
Built by a haiku builder from the audit's verbatim §7 spec; independently verified by an opus verifier (fresh eyes): **PASS**, all 6 checks, zero production LOC confirmed, historical figures survive verbatim, test parses + stays gated (pytest 1 skipped, ruff clean), parity-matrix test over PROJECT.md still green (5 passed). 4 non-blocking findings: F1 (optional re-nest of retired sub-bullets — info duplicated elsewhere), F2/F3 (pre-existing stale PROJECT.md claims at :223/:413 — follow-up ticket filed separately), F4 (info).

Linear: MOR-1268

🤖 Generated with [Claude Code](https://claude.com/claude-code)