### PR TITLE
feat(MOR-1269): meters fact group — TX truth from App authority (vocabulary slice 2A)

### DIFF
--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
+  import { onDestroy, onMount } from 'svelte';
   import '../theme/index';
   import { setTheme, getTheme, setVfoTheme, getVfoTheme } from '../theme/theme-switcher';
   
@@ -21,6 +21,7 @@
   import RightSidebar from './RightSidebar.svelte';
   import VfoHeader from './VfoHeader.svelte';
   import SemanticRadioSurfaces from '../wiring/SemanticRadioSurfaces.svelte';
+  import { getAppTxController } from '$lib/runtime/tx-controller/app-host';
   import KeyboardHandler from './KeyboardHandler.svelte';
   import StatusBar from './StatusBar.svelte';
   import MetersDockPanel from '../panels/MetersDockPanel.svelte';
@@ -65,6 +66,21 @@
   // Reactive state + capabilities — via runtime
   let radioState = $derived(runtime.state);
   let caps = $derived(runtime.caps);
+
+  // MOR-1235. The meters dock's TX chrome takes its truth from the App-owned
+  // TX controller — the SAME source as the authoritative global lamp
+  // (MOR-1008/MOR-1059) — and never from `radioState.ptt`, a command/readback
+  // echo that can read RX while the key is still down. The two disagree
+  // exactly in the uncertain/confirming windows the lamp fails closed on, and
+  // a meters panel that says RX there greys out the SWR/ALC fault tiles
+  // mid-transmission. Predicate below is AppGlobalHost's own, verbatim.
+  const txCtl = getAppTxController();
+  let txState = $state.raw(txCtl.snapshot());
+  const stopWatchingTx = txCtl.subscribe((next) => { txState = next; });
+  onDestroy(() => stopWatchingTx());
+  let meterTxActive = $derived(
+    txState.radioTx === 'on' || txState.txRisk === 'confirmed-on' || txState.txRisk === 'uncertain',
+  );
 
   // Scope digest for VfoHeader bridge (issue #832).  Gate on `scope` capability;
   // VfoHeader treats null as "hide the block".
@@ -268,7 +284,7 @@
       vdMeter={radioState?.vdMeter}
       compMeter={radioState?.compMeter}
       compressorOn={radioState?.compressorOn}
-      txActive={radioState?.ptt ?? false}
+      txActive={meterTxActive}
     />
   </section>
 </div>

--- a/frontend/src/components-v2/layout/__tests__/RadioLayout.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/RadioLayout.test.ts
@@ -49,9 +49,14 @@ vi.mock('../../../lib/runtime/frontend-runtime', () => ({
   },
 }));
 
+// MOR-1235: `state` is a live getter over a mutable holder (default `null`,
+// reset per test) so a test can put a REAL `ptt` on the runtime state and
+// prove the meters dock ignores it in favour of the App TX authority.
+const rt = vi.hoisted(() => ({ state: null as unknown }));
+
 vi.mock('$lib/runtime', () => ({
   runtime: {
-    state: null,
+    get state() { return rt.state; },
     caps: null,
     connectionStatus: 'disconnected',
     radioPowerOn: null,
@@ -284,13 +289,22 @@ describe('extractVfoState partial data', () => {
 // only App.svelte provides. RadioLayout is mounted here without that provider,
 // so stub the host lookup — the layout still renders the real panel tree.
 // (Partial mock: the App-mount test below still needs the real provider.)
+// MOR-1235: the snapshot is a MUTABLE holder now — the meters dock reads its
+// TX chrome from this controller, so a test has to be able to key it.
+const txAuthority = vi.hoisted(() => {
+  const idle = {
+    phase: 'idle', intent: null, guard: null, radioTx: 'unknown',
+    txRisk: 'none', mayOwnKey: false, fault: null,
+  };
+  return { idle, current: idle as Record<string, unknown> };
+});
+
 vi.mock('$lib/runtime/tx-controller/app-host', async (importOriginal) => {
   const actual = await importOriginal<typeof import('$lib/runtime/tx-controller/app-host')>();
-  const idle = { phase: 'idle', intent: null, guard: null, radioTx: 'unknown', fault: null };
   return {
     ...actual,
     getAppTxController: () => ({
-      snapshot: () => idle,
+      snapshot: () => txAuthority.current,
       subscribe: () => () => {},
       start: vi.fn(),
       setIntent: vi.fn(),
@@ -349,6 +363,8 @@ function mountLayout(skinId: SkinId = 'desktop-v2') {
 beforeEach(() => {
   components = [];
   radio.current = null;
+  rt.state = null;
+  txAuthority.current = txAuthority.idle;
   vi.mocked(hasDualReceiver).mockReturnValue(false);
   vi.mocked(resolveSkinId).mockReturnValue('desktop-v2');
   // JSDOM defaults to 0x0 — force desktop dimensions so isMobile stays false
@@ -359,6 +375,13 @@ beforeEach(() => {
 afterEach(() => {
   components.forEach((c) => unmount(c));
   document.body.innerHTML = '';
+  // Hygiene WITHIN this file. It runs in the `isolated` pool
+  // (`vite.config.ts`), so these holders cannot leak into another file — but
+  // they are module-level and shared by every `it` here, so a non-null `state`
+  // or a keyed authority left behind by one test would be read by the next one
+  // that does not set its own. Reset on the way OUT as well as the way in.
+  rt.state = null;
+  txAuthority.current = txAuthority.idle;
 });
 
 describe('RadioLayout structure', () => {
@@ -447,6 +470,39 @@ describe('Bottom dock MetersDockPanel', () => {
     const dock = t.querySelector('.bottom-dock');
     expect(dock).not.toBeNull();
     expect(dock?.querySelector('[data-testid="meters-dock-panel"]')).not.toBeNull();
+  });
+});
+
+/**
+ * MOR-1235 — the discriminating pair. The dock's TX chrome must follow the
+ * App TX controller (the same source as the authoritative AppGlobalHost lamp),
+ * NOT `radioState.ptt`. Each case sets the two to OPPOSITE values, so routing
+ * the prop back to `ptt` flips both assertions.
+ */
+describe('meters dock TX chrome follows the App TX authority (MOR-1235)', () => {
+  const txTag = (t: HTMLElement) => t.querySelector('.bottom-dock .dock-tx-state');
+
+  it('shows TX when the authority is keyed while radioState.ptt reads false', () => {
+    rt.state = { active: 'MAIN', ptt: false, main: { sMeter: 120 } };
+    txAuthority.current = { ...txAuthority.idle, radioTx: 'on', txRisk: 'confirmed-on' };
+    const t = mountLayout();
+    expect(txTag(t)?.getAttribute('data-active')).toBe('true');
+    expect(txTag(t)?.textContent).toBe('TX');
+  });
+
+  it('shows RX when the authority is idle while radioState.ptt reads true', () => {
+    rt.state = { active: 'MAIN', ptt: true, main: { sMeter: 120 } };
+    txAuthority.current = { ...txAuthority.idle, radioTx: 'off', txRisk: 'none' };
+    const t = mountLayout();
+    expect(txTag(t)?.getAttribute('data-active')).toBe('false');
+    expect(txTag(t)?.textContent).toBe('RX');
+  });
+
+  it('fails closed: an uncertain authority shows TX even with ptt false', () => {
+    rt.state = { active: 'MAIN', ptt: false, main: { sMeter: 120 } };
+    txAuthority.current = { ...txAuthority.idle, radioTx: 'off', txRisk: 'uncertain' };
+    const t = mountLayout();
+    expect(txTag(t)?.getAttribute('data-active')).toBe('true');
   });
 });
 

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -107,7 +107,10 @@
 
   // Belt-and-braces contract pin. The adapter now annotates its own return
   // type (MOR-1065 ruling 2), so this is the second of two compile-time links.
-  let view: RadioViewModel | null = $derived(toRadioViewModel(runtime.state, runtime.caps));
+  // MOR-1262 slice 2A: the live authority snapshot is the THIRD argument — the
+  // meter facts read their TX relevance from it and never from `state.ptt`
+  // (invariant R9). Without it the adapter emits no `meters` group at all.
+  let view: RadioViewModel | null = $derived(toRadioViewModel(runtime.state, runtime.caps, txState));
 
   // Bound once per instance, never per render — see `surfaceSeq` above.
   function requestKey(): void {

--- a/frontend/src/lib/runtime/adapters/__tests__/meters-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/meters-adapter.test.ts
@@ -1,0 +1,206 @@
+/**
+ * MOR-1262 decomposition slice 2A — `meters` fact-group adapter derivation.
+ *
+ * Companion to `radio-view-model-adapter.test.ts` (MOR-1065) and
+ * `tx-aux-adapter.test.ts` (MOR-1244), neither of which this file modifies.
+ * Those files never pass a TX authority snapshot, so `deriveMeters` declines
+ * to emit for them and their exact-key-list assertions stand unchanged.
+ *
+ * The first describe block is the SAFETY block (invariant R9, MOR-1235): the
+ * discriminating pair proves the group's TX truth comes from the App TX
+ * authority and from nowhere else — sever it and route `state.ptt` back in,
+ * and both halves go red in opposite directions.
+ */
+import { describe, expect, it } from 'vitest';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { FieldStatus, ServerState } from '$lib/types/state';
+import { validateRadioViewModel, type RadioViewModel } from '../../../../semantic/radio-view-model';
+import { toRadioViewModel, type MetersTxAuthority } from '../radio-view-model-adapter';
+
+function caps(overrides: Partial<Capabilities> = {}): Capabilities {
+  return {
+    model: 'fixture', scope: true, audio: true, tx: true, capabilities: ['scope', 'audio', 'tx'],
+    receivers: 1, vfoScheme: 'single', freqRanges: [], modes: [], filters: [],
+    audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
+    webrtc: { available: false, enabled: false },
+    txBands: [{ start: 14000000, end: 14350000, name: '20m' }],
+    scopeSource: 'hardware', audioFftAvailable: false, ...overrides,
+  } as Capabilities;
+}
+
+const fresh: FieldStatus = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' };
+const stale: FieldStatus = { storePath: 'x', observed: true, freshness: 'stale', availability: 'stale' };
+
+/** The RX authority: positively observed OFF with zero TX risk. */
+const RX: MetersTxAuthority = { radioTx: 'off', txRisk: 'none' };
+/** The TX authority: the transmitter is confirmed on. */
+const TX: MetersTxAuthority = { radioTx: 'on', txRisk: 'confirmed-on' };
+
+function meterState(overrides: Partial<ServerState> = {}): ServerState {
+  return {
+    active: 'MAIN', split: false, dualWatch: false, ptt: false,
+    txTarget: { status: 'known', receiver: 'MAIN', slot: null, frequencyHz: 14195000 },
+    main: {
+      freqHz: 14195000, mode: 'USB', filter: 1, dataMode: 0, att: 0, preamp: 0,
+      nb: false, nr: false, afLevel: 1, rfGain: 1, squelch: 0, sMeter: 120,
+    },
+    powerMeter: 0.6, swrMeter: 20, alcMeter: 40, compMeter: 10, vdMeter: 200, idMeter: 80,
+    fieldStatus: {
+      active: fresh, split: fresh, dualWatch: fresh, txTarget: fresh,
+      'main.freqHz': fresh, 'main.mode': fresh, 'main.filter': fresh,
+    },
+    ...overrides,
+  } as ServerState;
+}
+
+function model(
+  state: ServerState | null, capabilities: Capabilities | null, tx?: MetersTxAuthority | null,
+): RadioViewModel {
+  const view = toRadioViewModel(state, capabilities, tx);
+  expect(view).not.toBeNull();
+  return validateRadioViewModel(view);
+}
+
+describe('meters TX truth comes from the App TX authority (R9 / MOR-1235)', () => {
+  // ── The discriminating pair ─────────────────────────────────────────────
+  it('reads TX-active from the authority even while radioState.ptt is stale FALSE', () => {
+    const view = model(meterState({ ptt: false }), caps(), TX);
+    const meters = view.meters!;
+    expect(meters.rfState).toBe('transmitting');
+    expect(meters.power.relevant).toBe(true);
+    expect(meters.swr.relevant).toBe(true);
+    expect(meters.alc.relevant).toBe(true);
+    expect(meters.compression.relevant).toBe(true);
+    expect(meters.drainCurrent.relevant).toBe(true);
+    // ...and the RX meter is the one that steps aside.
+    expect(meters.signal.relevant).toBe(false);
+  });
+
+  it('reads RX from the authority even while radioState.ptt is stale TRUE', () => {
+    const view = model(meterState({ ptt: true }), caps(), RX);
+    const meters = view.meters!;
+    expect(meters.rfState).toBe('receiving');
+    expect(meters.power.relevant).toBe(false);
+    expect(meters.swr.relevant).toBe(false);
+    expect(meters.alc.relevant).toBe(false);
+    expect(meters.compression.relevant).toBe(false);
+    expect(meters.drainCurrent.relevant).toBe(false);
+    expect(meters.signal.relevant).toBe(true);
+  });
+
+  it('fails closed on an uncertain authority: the TX fault meters stay relevant', () => {
+    const view = model(meterState({ ptt: false }), caps(), { radioTx: 'off', txRisk: 'uncertain' });
+    expect(view.meters!.rfState).toBe('uncertain');
+    expect(view.meters!.swr.relevant).toBe(true);
+    expect(view.meters!.alc.relevant).toBe(true);
+    expect(view.meters!.signal.relevant).toBe(false);
+  });
+
+  it('fails closed on an unobserved RF state', () => {
+    const view = model(meterState(), caps(), { radioTx: 'unknown', txRisk: 'none' });
+    expect(view.meters!.rfState).toBe('unknown');
+    expect(view.meters!.power.relevant).toBe(true);
+  });
+
+  it('emits NO meters group without an authority snapshot — never a ptt-derived guess', () => {
+    for (const tx of [undefined, null]) {
+      const view = model(meterState({ ptt: true }), caps(), tx);
+      expect(view.meters).toBeUndefined();
+      expect(Object.keys(view)).not.toContain('meters');
+    }
+  });
+});
+
+describe('meters evidence gate and per-meter derivation (MOR-1262 slice 2A)', () => {
+  it('emits no meters when capabilities are absent', () => {
+    expect(toRadioViewModel(meterState(), null, RX)).toBeNull();
+  });
+
+  it('emits no meters when the radio has reported no meter at all', () => {
+    const bare = meterState({
+      powerMeter: undefined, swrMeter: undefined, alcMeter: undefined,
+      compMeter: undefined, vdMeter: undefined, idMeter: undefined,
+      main: { freqHz: 14195000, mode: 'USB', filter: 1 } as ServerState['main'],
+    });
+    expect(model(bare, caps(), RX).meters).toBeUndefined();
+  });
+
+  it('emits the group once a single meter is reported', () => {
+    const one = meterState({
+      powerMeter: undefined, swrMeter: undefined, alcMeter: undefined,
+      compMeter: undefined, idMeter: undefined,
+      main: { freqHz: 14195000, mode: 'USB', filter: 1 } as ServerState['main'],
+    });
+    expect(model(one, caps(), RX).meters?.drainVoltage.reading).toEqual({ status: 'known', value: 200 });
+  });
+
+  it('reports known readings for every reported meter', () => {
+    const meters = model(meterState(), caps(), TX).meters!;
+    expect(meters.signal.reading).toEqual({ status: 'known', value: 120 });
+    expect(meters.power.reading).toEqual({ status: 'known', value: 0.6 });
+    expect(meters.swr.reading).toEqual({ status: 'known', value: 20 });
+    expect(meters.alc.reading).toEqual({ status: 'known', value: 40 });
+    expect(meters.compression.reading).toEqual({ status: 'known', value: 10 });
+    expect(meters.drainVoltage.reading).toEqual({ status: 'known', value: 200 });
+    expect(meters.drainCurrent.reading).toEqual({ status: 'known', value: 80 });
+  });
+
+  it('marks TX meters structurally absent on a receive-only radio, never known', () => {
+    const meters = model(meterState(), caps({ tx: false, capabilities: ['scope', 'audio'] }), RX).meters!;
+    for (const field of [meters.power, meters.swr, meters.alc, meters.compression, meters.drainCurrent]) {
+      expect(field.availability).toEqual({ structural: false, operational: false });
+      expect(field.reading).toEqual({ status: 'unknown' });
+    }
+    // The S-meter and the supply rail are not TX facts and survive.
+    expect(meters.signal.availability.structural).toBe(true);
+    expect(meters.drainVoltage.availability.structural).toBe(true);
+  });
+
+  it('marks an unreported meter structurally absent rather than zero', () => {
+    const meters = model(meterState({ alcMeter: undefined }), caps(), TX).meters!;
+    expect(meters.alc).toEqual({
+      reading: { status: 'unknown' }, availability: { structural: false, operational: false }, relevant: true,
+    });
+  });
+
+  it('degrades a stale meter to unknown while keeping structural availability', () => {
+    const meters = model(meterState({
+      fieldStatus: { ...meterState().fieldStatus, swrMeter: stale },
+    }), caps(), TX).meters!;
+    expect(meters.swr).toEqual({
+      reading: { status: 'unknown' }, availability: { structural: true, operational: false }, relevant: true,
+    });
+  });
+
+  it('follows the active receiver for the S-meter, with its own field status', () => {
+    const onSub = meterState({
+      active: 'SUB',
+      sub: { freqHz: 7100000, mode: 'LSB', filter: 1, sMeter: 60 } as ServerState['main'],
+    });
+    expect(model(onSub, caps(), RX).meters!.signal.reading).toEqual({ status: 'known', value: 60 });
+    const staleSub = meterState({
+      active: 'SUB',
+      sub: { freqHz: 7100000, mode: 'LSB', filter: 1, sMeter: 60 } as ServerState['main'],
+      fieldStatus: { ...meterState().fieldStatus, 'sub.sMeter': stale },
+    });
+    expect(model(staleSub, caps(), RX).meters!.signal.reading).toEqual({ status: 'unknown' });
+  });
+
+  it('degrades a malformed raw value (wrong JS type) to unknown rather than coercing', () => {
+    const meters = model(meterState({
+      compMeter: 'ten' as unknown as number,
+    }), caps(), TX).meters!;
+    expect(meters.compression.reading).toEqual({ status: 'unknown' });
+  });
+
+  it('emits a validator-clean model carrying the meters group (round-trip proof)', () => {
+    const view = model(meterState(), caps(), TX);
+    expect(JSON.parse(JSON.stringify(view))).toEqual(view);
+  });
+
+  it('leaves the pre-2A families untouched when meters are present', () => {
+    const view = model(meterState(), caps(), TX);
+    expect(view.topologyId).toBe('1/single');
+    expect(view.txAux).toBeUndefined();
+  });
+});

--- a/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
@@ -25,7 +25,11 @@
  */
 import type { Capabilities } from '$lib/types/capabilities';
 import type { ServerState } from '$lib/types/state';
-import type { RadioViewModel, TxAuxField, TxAuxViewModel, AtuStatus } from '../../../semantic/radio-view-model';
+import type {
+  RadioViewModel, TxAuxField, TxAuxViewModel, AtuStatus,
+  MeterField, MeterRfState, MetersViewModel,
+} from '../../../semantic/radio-view-model';
+import type { TxAuthoritySnapshot } from '../../../semantic/rx-tx-surface';
 import { isFieldAvailable } from '$lib/state/field-status';
 import {
   derivePresentationCapabilities, type ReceiverId, type VfoSlotId,
@@ -164,6 +168,95 @@ function deriveTxAux(state: ServerState | null, caps: Capabilities | null): TxAu
 }
 
 /**
+ * The subset of the App TX authority the meter facts read (MOR-1262 slice 2A).
+ * `Pick<>` of the RX/TX surface's own snapshot type — one authority vocabulary
+ * for the whole v3 contract layer, already parity-pinned against the real
+ * reducer in `semantic/__tests__/rx-tx-authority-parity.test.ts`, so the
+ * controller's deep-readonly `snapshot()` is assignable with no adaptation.
+ */
+export type MetersTxAuthority = Pick<TxAuthoritySnapshot, 'radioTx' | 'txRisk'>;
+
+/**
+ * SAFETY INVARIANT R9. TX truth comes from the App TX authority and from
+ * nowhere else — never from `state.ptt`, which is a command/readback echo
+ * that can read RX while the key is still down (the AppGlobalHost lamp's own
+ * reasoning, MOR-1059) and whose use for meter chrome is the open MOR-1235
+ * disagreement this slice closes.
+ *
+ * The body is a byte-identical copy of `rx-tx-surface.ts::rfState` — eslint
+ * invariant 1 permits this file only TYPE imports from `semantic/`, so the
+ * shared predicate cannot be called from here. Agreement with the real
+ * function, across every state the real reducer can reach, is pinned in
+ * `semantic/__tests__/meters.test.ts`; drift there is a red test, not a
+ * silent fork.
+ */
+function meterRfState(tx: MetersTxAuthority): MeterRfState {
+  if (tx.radioTx === 'on' || tx.txRisk === 'confirmed-on') return 'transmitting';
+  if (tx.txRisk === 'uncertain') return 'uncertain';
+  return tx.radioTx === 'off' && tx.txRisk === 'none' ? 'receiving' : 'unknown';
+}
+
+function meterField(structural: boolean, fieldFresh: boolean, raw: unknown, relevant: boolean): MeterField {
+  const operational = structural && fieldFresh;
+  const value = numOrUndef(raw);
+  return {
+    reading: operational && value !== undefined ? { status: 'known', value } : { status: 'unknown' },
+    availability: { structural, operational },
+    relevant,
+  };
+}
+
+/**
+ * Emits the group only on positive evidence, same discipline as `deriveTxAux`
+ * (N3) with two additions:
+ *
+ *  - NO authority snapshot ⇒ NO group. Without the App TX authority there is
+ *    no honest TX relevance to state, and inventing one from `state.ptt` is
+ *    exactly what R9 forbids; a caller that has not wired the controller gets
+ *    a structurally-absent family, not a guess.
+ *  - `raw !== undefined` IS the shipped capability gate for meters. There is
+ *    no per-meter capability tag anywhere in v2 — `MetersDockPanel.svelte`'s
+ *    own doc comment says "capability gating by `!== undefined`" — so that
+ *    gate is copied rather than replaced. TX meters additionally require the
+ *    radio to be able to transmit at all (`caps.tx`, `toMeterProps`'s `hasTx`).
+ *
+ * Relevance fails CLOSED: TX meters read as relevant in every state that is
+ * not a positively observed RX, so an 'uncertain'/'unknown' window keeps the
+ * SWR and ALC fault meters live rather than greying them out mid-transmission.
+ */
+function deriveMeters(
+  state: ServerState | null, caps: Capabilities | null, tx: MetersTxAuthority | null | undefined,
+): MetersViewModel | undefined {
+  if (!tx || !state) return undefined;
+  const rfState = meterRfState(tx);
+  const onTx = rfState !== 'receiving';
+  const hasTx = caps?.tx ?? false;
+  // Mirrors the shipped dock's own active-receiver read (`RadioLayout.svelte`):
+  // the S-meter follows the receiver the operator is listening to.
+  const onSub = state.active === 'SUB';
+  const rx = onSub ? state.sub : state.main;
+  const sPath = onSub ? 'sub.sMeter' : 'main.sMeter';
+  const { powerMeter, swrMeter, alcMeter, compMeter, vdMeter, idMeter } = state;
+  const raws = [rx?.sMeter, powerMeter, swrMeter, alcMeter, compMeter, vdMeter, idMeter];
+  if (!raws.some((v) => v !== undefined)) return undefined;
+  const txMeter = (raw: unknown, path: string): MeterField =>
+    meterField(hasTx && raw !== undefined, topFieldAvailable(state, path), raw, onTx);
+  return {
+    rfState,
+    signal: meterField(rx?.sMeter !== undefined, topFieldAvailable(state, sPath), rx?.sMeter, !onTx),
+    power: txMeter(powerMeter, 'powerMeter'),
+    swr: txMeter(swrMeter, 'swrMeter'),
+    alc: txMeter(alcMeter, 'alcMeter'),
+    compression: txMeter(compMeter, 'compMeter'),
+    // Vd is the station's supply rail, not a TX reading: it is worth showing
+    // in every RF state (the dock keeps it on instantaneous display for the
+    // same reason), so it is structurally gated but never relevance-gated.
+    drainVoltage: meterField(vdMeter !== undefined, topFieldAvailable(state, 'vdMeter'), vdMeter, true),
+    drainCurrent: txMeter(idMeter, 'idMeter'),
+  };
+}
+
+/**
  * `null` when there is nothing safe to render at all: capabilities have not
  * loaded, or they describe a topology that contradicts itself
  * (`derivePresentationCapabilities` diagnoses that, and a contradictory
@@ -171,6 +264,7 @@ function deriveTxAux(state: ServerState | null, caps: Capabilities | null): TxAu
  */
 export function toRadioViewModel(
   state: ServerState | null, caps: Capabilities | null,
+  tx?: MetersTxAuthority | null,
 ): RadioViewModel | null {
   if (!caps) return null;
   const presentation = derivePresentationCapabilities(caps);
@@ -296,6 +390,7 @@ export function toRadioViewModel(
   // from "has the group" to any consumer that inventories keys — same
   // reasoning as the validator's own omission below `validateRadioViewModel`.
   const txAux = deriveTxAux(state, caps);
+  const meters = deriveMeters(state, caps, tx);
 
   return {
     topologyId: `${topology.structuralCount}/${topology.scheme}`,
@@ -309,5 +404,6 @@ export function toRadioViewModel(
     scope: { hardwareScope, audioFftScope },
     disabledReasons,
     ...(txAux !== undefined ? { txAux } : {}),
+    ...(meters !== undefined ? { meters } : {}),
   };
 }

--- a/frontend/src/semantic/__tests__/meters.test.ts
+++ b/frontend/src/semantic/__tests__/meters.test.ts
@@ -1,0 +1,246 @@
+/**
+ * MOR-1262 decomposition slice 2A — `meters` optional fact group (validator
+ * half), plus the R9 authority-parity pin.
+ *
+ * Companion to `__tests__/tx-aux.test.ts` (slice 1A), whose five kill-tests
+ * this file mirrors for the meters family:
+ *  1. a meters-absent model validates and round-trips byte-identically
+ *  2. `"meters": null` throws (absent ≠ malformed — JSON has no undefined)
+ *  3. a malformed inner field throws with a precise `$.meters....` path
+ *  5. an unknown extra key inside meters throws
+ * (Kill-test 4, the adapter's evidence + TX-authority gate, lives in
+ * `lib/runtime/adapters/__tests__/meters-adapter.test.ts` next to the code
+ * it mutates.)
+ *
+ * The last describe block is the safety-critical one: `MeterRfState` and the
+ * adapter's private `meterRfState` are copies of the RX/TX surface's own
+ * `RfState`/`rfState` (the eslint seam forbids the adapter a value import),
+ * so this file pins the copies against the ORIGINALS across every state the
+ * REAL TX reducer can reach. Drift is a red test, never a silent fork.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  validateRadioViewModel, type MeterField, type MeterRfState, type MetersViewModel,
+} from '../radio-view-model';
+import { topologyFixtures, withMeters } from '../fixtures/topologies';
+import { rfState, type RfState, type TxAuthoritySnapshot } from '../rx-tx-surface';
+import { toRadioViewModel } from '$lib/runtime/adapters/radio-view-model-adapter';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { ServerState } from '$lib/types/state';
+
+const AVAIL = { structural: true, operational: true } as const;
+const base = topologyFixtures['1/single'];
+const RF_STATES: readonly MeterRfState[] = ['receiving', 'transmitting', 'uncertain', 'unknown'];
+
+describe('meters (MOR-1262 slice 2A)', () => {
+  // ── Kill-test 1: absence is byte-identical, not a new default shape ──────
+  it('validates a meters-absent model and never adds the key', () => {
+    expect(Object.keys(base)).not.toContain('meters');
+    const validated = validateRadioViewModel(base);
+    expect(Object.keys(validated)).not.toContain('meters');
+    expect(validated.meters).toBeUndefined();
+    expect(JSON.parse(JSON.stringify(validated))).toEqual(JSON.parse(JSON.stringify(base)));
+  });
+
+  it('validates a fully-populated meters group and returns it unchanged', () => {
+    const withM = withMeters(base);
+    expect(validateRadioViewModel(withM).meters).toEqual(withM.meters);
+  });
+
+  // ── Kill-test 2: null / {} are not absent ────────────────────────────────
+  it('rejects an explicit meters: null', () => {
+    expect(() => validateRadioViewModel({ ...base, meters: null })).toThrow(TypeError);
+  });
+
+  it('rejects an explicit meters: {} — present, not absent, must satisfy its own shape', () => {
+    expect(() => validateRadioViewModel({ ...base, meters: {} })).toThrow(TypeError);
+  });
+
+  // ── Kill-test 3: malformed inner field, precise path ─────────────────────
+  it('rejects a non-numeric swr reading value with a precise error path', () => {
+    const withM = withMeters(base);
+    const malformed = {
+      ...withM,
+      meters: {
+        ...withM.meters,
+        swr: { reading: { status: 'known', value: 'high' }, availability: AVAIL, relevant: true },
+      },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.meters\.swr\.reading\.value/);
+  });
+
+  it('rejects a non-boolean relevant with a precise error path', () => {
+    const withM = withMeters(base);
+    const malformed = {
+      ...withM,
+      meters: {
+        ...withM.meters,
+        alc: { reading: { status: 'unknown' }, availability: AVAIL, relevant: 'yes' },
+      },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.meters\.alc\.relevant/);
+  });
+
+  it('rejects an rfState outside the authority vocabulary', () => {
+    const withM = withMeters(base);
+    const malformed = { ...withM, meters: { ...withM.meters, rfState: 'keyed' } };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.meters\.rfState/);
+  });
+
+  it.each(RF_STATES)('accepts the authoritative rfState %s', (state) => {
+    const withM = withMeters(base, state);
+    expect(validateRadioViewModel(withM).meters?.rfState).toBe(state);
+  });
+
+  it('rejects a reading with neither known nor unknown status', () => {
+    const withM = withMeters(base);
+    const malformed = {
+      ...withM,
+      meters: {
+        ...withM.meters,
+        power: { reading: { status: 'stale' }, availability: AVAIL, relevant: true },
+      },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(TypeError);
+  });
+
+  it('rejects a non-boolean field inside a meter Availability', () => {
+    const withM = withMeters(base);
+    const malformed = {
+      ...withM,
+      meters: {
+        ...withM.meters,
+        signal: {
+          reading: { status: 'unknown' },
+          availability: { structural: 'yes', operational: true },
+          relevant: true,
+        },
+      },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(TypeError);
+  });
+
+  it('accepts an unknown reading independently per meter, without degrading the rest', () => {
+    const withM = withMeters(base);
+    const partial = {
+      ...withM,
+      meters: {
+        ...withM.meters,
+        drainCurrent: {
+          reading: { status: 'unknown' },
+          availability: { structural: true, operational: false },
+          relevant: false,
+        },
+      },
+    };
+    const validated = validateRadioViewModel(partial);
+    expect(validated.meters?.drainCurrent).toEqual({
+      reading: { status: 'unknown' },
+      availability: { structural: true, operational: false },
+      relevant: false,
+    });
+    expect(validated.meters?.signal.reading).toEqual({ status: 'known', value: 120 });
+  });
+
+  // ── Kill-test 5: no speculative keys ─────────────────────────────────────
+  it('rejects an unknown extra key inside meters', () => {
+    const withM = withMeters(base);
+    expect(() => validateRadioViewModel({ ...withM, meters: { ...withM.meters, temperature: 1 } }))
+      .toThrow(TypeError);
+  });
+
+  it('rejects an unknown extra key inside a single meter field', () => {
+    const withM = withMeters(base);
+    const malformed = {
+      ...withM,
+      meters: {
+        ...withM.meters,
+        power: { reading: { status: 'known', value: 1 }, availability: AVAIL, relevant: true, peak: 2 },
+      },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(TypeError);
+  });
+
+  it('rejects a reading that carries a value key while unknown', () => {
+    const withM = withMeters(base);
+    const malformed = {
+      ...withM,
+      meters: {
+        ...withM.meters,
+        drainVoltage: { reading: { status: 'unknown', value: 1 }, availability: AVAIL, relevant: true },
+      },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(TypeError);
+  });
+
+  it('every meter of a fully-populated group round-trips its own value', () => {
+    const validated = validateRadioViewModel(withMeters(base)).meters as MetersViewModel;
+    const knownValue = (f: MeterField): number | undefined =>
+      f.reading.status === 'known' ? f.reading.value : undefined;
+    expect(knownValue(validated.signal)).toBe(120);
+    expect(knownValue(validated.power)).toBe(0.6);
+    expect(knownValue(validated.swr)).toBe(20);
+    expect(knownValue(validated.alc)).toBe(40);
+    expect(knownValue(validated.compression)).toBe(10);
+    expect(knownValue(validated.drainVoltage)).toBe(200);
+    expect(knownValue(validated.drainCurrent)).toBe(80);
+  });
+});
+
+/**
+ * R9 parity. The adapter cannot call `rx-tx-surface.rfState` (type-only seam),
+ * so it carries a copy; these tests prove the copy is not a fork, and that
+ * `MeterRfState` is member-for-member the surface's `RfState`.
+ */
+describe('meters RF state is the App TX authority vocabulary, verbatim (R9)', () => {
+  const RADIO_TX = ['off', 'on', 'unknown'] as const;
+  const TX_RISK = ['none', 'uncertain', 'confirmed-on'] as const;
+  const snapshot = (
+    radioTx: (typeof RADIO_TX)[number], txRisk: (typeof TX_RISK)[number],
+  ): TxAuthoritySnapshot => ({
+    phase: 'idle', intent: null, radioTx, txRisk, mayOwnKey: false, fault: null,
+  });
+
+  function caps(): Capabilities {
+    return {
+      model: 'fixture', scope: false, audio: false, tx: true, capabilities: ['tx'],
+      receivers: 1, vfoScheme: 'single', freqRanges: [], modes: [], filters: [],
+      audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
+      webrtc: { available: false, enabled: false },
+      txBands: [], scopeSource: 'hardware', audioFftAvailable: false,
+    } as unknown as Capabilities;
+  }
+  const state = (): ServerState => ({
+    active: 'MAIN', split: false, dualWatch: false, ptt: false,
+    txTarget: { status: 'unknown', reason: 'not-observed' },
+    main: { freqHz: 14195000, mode: 'USB', filter: 1, sMeter: 120 },
+    powerMeter: 0.6, swrMeter: 20, alcMeter: 40, compMeter: 10, vdMeter: 200, idMeter: 80,
+    fieldStatus: {},
+  } as unknown as ServerState);
+
+  it('the contract union has exactly the members the RX/TX surface declares', () => {
+    // EXHAUSTIVE both ways, at compile time. A `satisfies` pair proves only
+    // that one literal is in both unions — widening either side with a new
+    // member still type-checks (verification finding F3). `Record<K, …>`
+    // demands a key per member: a member added to `RfState` leaves `surfaceToMeter`
+    // missing a key, and a member added to `MeterRfState` leaves `meterToSurface`
+    // missing one. Either way `npm run check` fails.
+    const surfaceToMeter: Record<RfState, MeterRfState> = {
+      receiving: 'receiving', transmitting: 'transmitting',
+      uncertain: 'uncertain', unknown: 'unknown',
+    };
+    const meterToSurface: Record<MeterRfState, RfState> = surfaceToMeter;
+    // ...and the runtime list this file drives its cases from is that same set.
+    expect(new Set(RF_STATES)).toEqual(new Set(Object.keys(meterToSurface)));
+    expect(Object.entries(meterToSurface).every(([key, value]) => key === value)).toBe(true);
+  });
+
+  it.each(RADIO_TX.flatMap((radioTx) => TX_RISK.map((txRisk) => [radioTx, txRisk] as const)))(
+    'agrees with the shipped rfState() for radioTx=%s txRisk=%s',
+    (radioTx, txRisk) => {
+      const tx = snapshot(radioTx, txRisk);
+      const view = toRadioViewModel(state(), caps(), tx);
+      expect(view?.meters?.rfState).toBe(rfState(tx));
+    },
+  );
+});

--- a/frontend/src/semantic/__tests__/optional-group-allow-list.test.ts
+++ b/frontend/src/semantic/__tests__/optional-group-allow-list.test.ts
@@ -40,8 +40,9 @@ const REQUIRED_KEYS = [
   'txTarget', 'txPermit', 'scope', 'disabledReasons',
 ] as const;
 
-/** MOR-1244: txAux. Add your key here when your family's slice lands. */
-const EXPECTED_OPTIONAL_GROUP_KEYS = ['txAux'] as const;
+/** MOR-1244: txAux. MOR-1262 slice 2A: meters. Add your key here when your
+ *  family's slice lands. */
+const EXPECTED_OPTIONAL_GROUP_KEYS = ['txAux', 'meters'] as const;
 
 function extractTopLevelAllowList(): string[] {
   // `.toString()` on a Vite/esbuild-transformed function returns the SSR-

--- a/frontend/src/semantic/fixtures/topologies.ts
+++ b/frontend/src/semantic/fixtures/topologies.ts
@@ -13,7 +13,10 @@
  * matrix ("4 topology pairs + audio-only scope"), not a property of any one
  * topology, so it can be applied to any of the four fixtures below.
  */
-import type { Availability, RadioViewModel, TxAuxField, TxAuxViewModel } from '../radio-view-model';
+import type {
+  Availability, MeterField, MeterRfState, MetersViewModel,
+  RadioViewModel, TxAuxField, TxAuxViewModel,
+} from '../radio-view-model';
 
 const singleReceiver: RadioViewModel = {
   topologyId: '1/single',
@@ -181,4 +184,32 @@ export function withTxAux(fixture: RadioViewModel): RadioViewModel {
     driveGain: known(128),
   };
   return { ...fixture, txAux };
+}
+
+/**
+ * Applies a fully-observed `meters` group (MOR-1262 slice 2A) to any topology
+ * fixture, read against the RF state the caller names — meters are an axis
+ * orthogonal to VFO topology, same as `withTxAux` above. `rfState` is a
+ * PARAMETER rather than a constant precisely because TX relevance is the
+ * property under test: a fixture that hard-coded 'receiving' would make the
+ * MOR-1235 disagreement unobservable.
+ */
+export function withMeters(
+  fixture: RadioViewModel, rfState: MeterRfState = 'receiving',
+): RadioViewModel {
+  const avail: Availability = { structural: true, operational: true };
+  const tx = rfState !== 'receiving';
+  const field = (value: number, relevant: boolean): MeterField =>
+    ({ reading: { status: 'known', value }, availability: avail, relevant });
+  const meters: MetersViewModel = {
+    rfState,
+    signal: field(120, !tx),
+    power: field(0.6, tx),
+    swr: field(20, tx),
+    alc: field(40, tx),
+    compression: field(10, tx),
+    drainVoltage: field(200, true),
+    drainCurrent: field(80, tx),
+  };
+  return { ...fixture, meters };
 }

--- a/frontend/src/semantic/radio-view-model.ts
+++ b/frontend/src/semantic/radio-view-model.ts
@@ -127,6 +127,51 @@ export interface TxAuxViewModel {
   driveGain: TxAuxField<number>;
 }
 
+/**
+ * A single meter fact (MOR-1262 decomposition slice 2A): a numeric reading
+ * that is either known or unknown, the MOR-977 two-level `Availability`, and
+ * whether the meter reads meaningfully in the CURRENT RF state.
+ *
+ * `relevant` is the one field of this contract that must NOT be derived from
+ * radio state: TX-gated meters (Po/SWR/ALC/COMP/Id) are relevant exactly when
+ * the App-owned TX authority — the same source as the AppGlobalHost lamp
+ * (MOR-1008/MOR-1059) — says the transmitter may be live. Deriving it from
+ * `radioState.ptt` is the open disagreement MOR-1235 reports, and safety
+ * invariant R9 forbids reintroducing it here: this contract EXPOSES the
+ * authority's conclusion, it never computes one.
+ */
+export type MeterReading = { status: 'known'; value: number } | { status: 'unknown' };
+export interface MeterField {
+  reading: MeterReading;
+  availability: Availability;
+  relevant: boolean;
+}
+
+/**
+ * The authoritative RF state the meters are read against. Member-for-member
+ * the RX/TX surface's own `RfState` (`rx-tx-surface.ts`, MOR-1064) — declared
+ * again here rather than imported because that module already imports this
+ * one, and a contract must not depend on a surface. Agreement is pinned in
+ * `__tests__/meters.test.ts` against the real union and the real reducer.
+ */
+export type MeterRfState = 'receiving' | 'transmitting' | 'uncertain' | 'unknown';
+
+/**
+ * Meter facts (MOR-1262 decomposition slice 2A): S / Po / SWR / ALC / COMP /
+ * Vd / Id — the seven meters the shipped v2 dock renders. Facts only: no
+ * ballistics, no peak-hold, no formatting (those are presentation, slice 2B).
+ */
+export interface MetersViewModel {
+  rfState: MeterRfState;
+  signal: MeterField;
+  power: MeterField;
+  swr: MeterField;
+  alc: MeterField;
+  compression: MeterField;
+  drainVoltage: MeterField;
+  drainCurrent: MeterField;
+}
+
 export interface RadioViewModel {
   topologyId: string;
   vfoScheme: VfoScheme;
@@ -144,6 +189,10 @@ export interface RadioViewModel {
    *  model has no TX-adjacent controls at all. Never emitted as a placeholder
    *  of all-unknowns — see `radio-view-model-adapter.ts`'s evidence gate. */
   readonly txAux?: TxAuxViewModel;
+  /** Absent (MOR-1264 optional group) ⇒ this radio reports no meters at all,
+   *  or the App TX authority was not supplied so no honest TX-relevance could
+   *  be stated — see `radio-view-model-adapter.ts`'s `deriveMeters`. */
+  readonly meters?: MetersViewModel;
 }
 
 const RECEIVER_IDS: readonly ReceiverId[] = ['MAIN', 'SUB'];
@@ -316,6 +365,49 @@ function validateDisabledReason(value: unknown, path: string): DisabledReason {
   return { field: str(v.field, `${path}.field`), code: oneOf(v.code, DISABLED_REASON_CODES, `${path}.code`) };
 }
 
+const METER_RF_STATES: readonly MeterRfState[] = ['receiving', 'transmitting', 'uncertain', 'unknown'];
+
+function validateMeterField(value: unknown, path: string): MeterField {
+  const v = record(value, path);
+  exactKeys(v, ['reading', 'availability', 'relevant'], path);
+  const r = record(v.reading, `${path}.reading`);
+  let reading: MeterReading;
+  if (r.status === 'known') {
+    exactKeys(r, ['status', 'value'], `${path}.reading`);
+    reading = { status: 'known', value: num(r.value, `${path}.reading.value`) };
+  } else if (r.status === 'unknown') {
+    exactKeys(r, ['status'], `${path}.reading`);
+    reading = { status: 'unknown' };
+  } else {
+    invalid(`${path}.reading.status`, "'known' | 'unknown'");
+  }
+  return {
+    reading,
+    availability: validateAvailability(v.availability, `${path}.availability`),
+    relevant: bool(v.relevant, `${path}.relevant`),
+  };
+}
+
+/** This `exactKeys` list is exactly the seven meters the adapter reads plus
+ *  the authoritative `rfState` — no speculative keys (MOR-1244 finding N4).
+ *  See `radio-view-model-adapter.ts::deriveMeters`. */
+function validateMeters(value: unknown, path: string): MetersViewModel {
+  const v = record(value, path);
+  exactKeys(v, [
+    'rfState', 'signal', 'power', 'swr', 'alc', 'compression', 'drainVoltage', 'drainCurrent',
+  ], path);
+  return {
+    rfState: oneOf(v.rfState, METER_RF_STATES, `${path}.rfState`),
+    signal: validateMeterField(v.signal, `${path}.signal`),
+    power: validateMeterField(v.power, `${path}.power`),
+    swr: validateMeterField(v.swr, `${path}.swr`),
+    alc: validateMeterField(v.alc, `${path}.alc`),
+    compression: validateMeterField(v.compression, `${path}.compression`),
+    drainVoltage: validateMeterField(v.drainVoltage, `${path}.drainVoltage`),
+    drainCurrent: validateMeterField(v.drainCurrent, `${path}.drainCurrent`),
+  };
+}
+
 const ATU_STATUSES: readonly AtuStatus[] = ['off', 'on', 'tuning'];
 
 function validateTxAuxField<T>(
@@ -370,7 +462,7 @@ export function validateRadioViewModel(value: unknown): RadioViewModel {
   const v = record(value, '$');
   exactKeys(v, [
     'topologyId', 'vfoScheme', 'activeReceiver', 'vfos', 'split', 'dualWatch',
-    'txTarget', 'txPermit', 'scope', 'disabledReasons', 'txAux',
+    'txTarget', 'txPermit', 'scope', 'disabledReasons', 'txAux', 'meters',
   ], '$');
   if (!Array.isArray(v.vfos)) invalid('$.vfos', 'an array');
   if (!Array.isArray(v.disabledReasons)) invalid('$.disabledReasons', 'an array');
@@ -399,6 +491,7 @@ export function validateRadioViewModel(value: unknown): RadioViewModel {
   // consumer that inventories keys (see the adapter test's exact-key-list
   // assertion this was verified against).
   const txAux = optionalGroup(v.txAux, '$.txAux', validateTxAux);
+  const meters = optionalGroup(v.meters, '$.meters', validateMeters);
 
   return {
     topologyId: str(v.topologyId, '$.topologyId'),
@@ -415,5 +508,6 @@ export function validateRadioViewModel(value: unknown): RadioViewModel {
     },
     disabledReasons: v.disabledReasons.map((r, i) => validateDisabledReason(r, `$.disabledReasons[${i}]`)),
     ...(txAux !== undefined ? { txAux } : {}),
+    ...(meters !== undefined ? { meters } : {}),
   };
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -67,6 +67,20 @@ export default defineConfig({
           environment: 'jsdom',
           include: ['src/**/*.test.ts'],
           exclude: [
+            // MOR-1262 slice 2A: joins the sensitive set. It asserts on
+            // `sendCommand`/`audioManager` call counts through the shared
+            // RX-audio authority, so under ``isolate: false`` it is sensitive
+            // to WHICH siblings share its worker — adding unrelated test files
+            // elsewhere in the suite reshuffles the fast pool and flips it red
+            // with no production change. Isolation makes it order-independent.
+            'src/components-v2/wiring/__tests__/rx-audio-authority.test.ts',
+            // MOR-1262 slice 2A, same class: it spies on the GLOBAL
+            // `requestAnimationFrame` and asserts exact call counts, while
+            // sibling component tests (MetersDockPanel's `tick`/`tickPeak`
+            // smoothers among them) leave live rAF loops running that the spy
+            // then counts. Under ``isolate: false`` that makes it a function of
+            // worker assignment rather than of its own subject.
+            'src/lib/utils/__tests__/smoothing.svelte.test.ts',
             'src/components-v2/wiring/__tests__/keyboard-wiring.test.ts',
             'src/components-v2/wiring/__tests__/vfo-wiring.test.ts',
             'src/components-v2/wiring/__tests__/dsp-nr-level.test.ts',
@@ -166,6 +180,8 @@ export default defineConfig({
           name: 'isolated',
           environment: 'jsdom',
           include: [
+            'src/components-v2/wiring/__tests__/rx-audio-authority.test.ts',
+            'src/lib/utils/__tests__/smoothing.svelte.test.ts',
             'src/components-v2/wiring/__tests__/keyboard-wiring.test.ts',
             'src/components-v2/wiring/__tests__/vfo-wiring.test.ts',
             'src/components-v2/wiring/__tests__/dsp-nr-level.test.ts',


### PR DESCRIPTION
## Summary
Vocabulary slice 2A of the MOR-1262 program (SAFETY-ADJACENT). Optional `meters` fact group on the frozen RadioViewModel via the S0 `optionalGroup` seam, mirroring the MOR-1244 (1A) pattern: `rfState` + 7 `MeterField`s (`signal/power/swr/alc/compression/drainVoltage/drainCurrent`), each `{reading, availability, relevant}`, exactKeys at both levels, null/`{}` pinned.

**Safety (invariant R9):** `rfState` derives only from an optional App TX-authority snapshot (`radioTx`/`txRisk`) passed as a third adapter argument — no snapshot ⇒ no group, never a `ptt` guess; TX relevance fails closed on `uncertain`/`unknown`.

**In-scope MOR-1235 fix:** `RadioLayout` now feeds `MetersDockPanel` `txActive` from the App TX controller (AppGlobalHost's verbatim fail-closed predicate), not `radioState.ptt` — pinned by three discriminating tests (authority keyed + ptt false ⇒ TX; authority idle + ptt true ⇒ RX; uncertain ⇒ fails closed to TX).

**Test infra:** `rx-audio-authority` and `smoothing.svelte` tests moved to the isolated vitest pool — pre-existing fast-pool order-dependence, reproduced at origin/main with zero slice code; systemic ticket MOR-1272.

Net production LOC: **135** (independently re-measured by the verifier; ≤200 guardrail).

## Review provenance
Opus builder → independent opus domain verifier (fresh eyes, own mutants). Round 1 **BLOCKED** (3 findings: pool assignment, wrong leak-diagnosis comment, toothless type-parity pin) → all fixed → delta round **PASS**: production byte-identical to round 1 (sha256), 10 mutations killed across rounds — R9 authority-source flip kills 14 tests, uncertain→receiving 3, fail-closed weakenings 2+2+1, MOR-1235 prop revert kills all 3 discriminating tests, contract mutations 3/3, F3 'keyed' widening breaks `check`. Failing-file set identical to the origin/main baseline (both sets listed in the verify report). Verifier rulings: SemanticRadioSurfaces wiring stays (1A precedent), `relevant` in the fact layer accepted, `compressorOn` gating deferred to 2B with a recorded carry-forward (COMP tile gates on `txAux.compressor`).

Linear: MOR-1269 (+ fixes MOR-1235)

🤖 Generated with [Claude Code](https://claude.com/claude-code)