### PR TITLE
fix(MOR-1271): repair the fixture-harness command-bus stub for the txAux vocabulary

### DIFF
--- a/frontend/fixtures/stubs/command-bus.ts
+++ b/frontend/fixtures/stubs/command-bus.ts
@@ -1,12 +1,34 @@
 /**
  * MOR-1070 stub for `components-v2/wiring/command-bus`.
  *
- * Only `makeVfoHandlers` is reachable from the cockpit's tree. Stubbed so a
- * capture run opens no WebSocket and constructs no AudioContext (the real
- * module pulls in `$lib/transport/ws-client` and `$lib/audio/audio-manager` at
- * module scope) — the harness must be deterministic and offline.
+ * Stubbed so a capture run opens no WebSocket and constructs no AudioContext
+ * (the real module pulls in `$lib/transport/ws-client` and
+ * `$lib/audio/audio-manager` at module scope) — the harness must be
+ * deterministic and offline.
+ *
+ * MOR-1271: this stub went stale. `SemanticRadioSurfaces.svelte` gained a
+ * `txAuxIntents` bundle in the MOR-1244/MOR-1265 vocabulary slices and now
+ * imports `makeTxHandlers` and `makeVoxHandlers` alongside `makeVfoHandlers`;
+ * the stub exported only the last of the three. A stub that omits a named
+ * export fails at MODULE RESOLUTION rather than at call time, so the harness
+ * could not build its own entry and NO fixture loaded at all — the whole
+ * MOR-1070 verification surface was dark, not merely degraded.
+ *
+ * The rule this file therefore has to keep: mirror every factory the
+ * cockpit's tree imports, not only the ones a given fixture exercises. Every
+ * handler records rather than commands — the harness asserts that an intent
+ * reached the bus, and must never reach a radio.
  */
 import { record } from '../harness-state';
+
+/** Records `<channel>.<handler>` with the call's arguments, for a list of handler names. */
+function recorders<K extends string>(
+  channel: string, names: readonly K[],
+): Record<K, (...args: unknown[]) => void> {
+  return Object.fromEntries(
+    names.map((name) => [name, (...args: unknown[]) => record(`${channel}.${name}`, args)]),
+  ) as Record<K, (...args: unknown[]) => void>;
+}
 
 export function makeVfoHandlers() {
   return {
@@ -14,4 +36,17 @@ export function makeVfoHandlers() {
     onSplitToggle: (...args: unknown[]): void => record('vfo.split', args),
     onDualWatchToggle: (...args: unknown[]): void => record('vfo.dualWatch', args),
   };
+}
+
+export function makeVoxHandlers() {
+  return recorders('vox', [
+    'onVoxToggle', 'onVoxGainChange', 'onAntiVoxGainChange', 'onVoxDelayChange',
+  ] as const);
+}
+
+export function makeTxHandlers() {
+  return recorders('tx', [
+    'onRfPowerChange', 'onMicGainChange', 'onAtuToggle', 'onAtuTune', 'onVoxToggle',
+    'onCompToggle', 'onCompLevelChange', 'onMonToggle', 'onMonLevelChange', 'onDriveGainChange',
+  ] as const);
 }


### PR DESCRIPTION
## Summary
The MOR-1070 browser fixture harness (`frontend/fixtures/`, #2203) stopped loading ANY fixture on main: its command-bus stub predates the txAux vocabulary slices (MOR-1244 #2199, MOR-1265 #2200) — `SemanticRadioSurfaces.svelte:37` imports `makeTxHandlers`/`makeVoxHandlers`, the stub exported only `makeVfoHandlers`. One file, +39/−4: adds the missing factories (recorders covering the 13 txAux intents).

Minimal repair only — the drift guard (so the stub can't silently lag the command vocabulary again) stays tracked in MOR-1271.

## Review provenance
Break and repair independently confirmed by the opus design-language-domain verifier during the MOR-1073 verification; extraction to this standalone branch delta-verified: exactly one file, content semantically identical to the reviewed repair, stub name union character-for-character equal to the 13 `txAuxIntents.onXxx` the wiring references, zero studioline leakage, harness spot-boot green (topology-2-main-sub 24/24, tx-phase-tx 24/24; the single tx-phase-fault zone-less-control-count failure is pre-existing at base).

Linear: MOR-1271 (partial — repair; guard remains)

🤖 Generated with [Claude Code](https://claude.com/claude-code)