### PR TITLE
feat(MOR-1274): rxAudio fact group (vocabulary slice 3A)

### DIFF
--- a/frontend/src/lib/runtime/adapters/__tests__/rx-audio-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/rx-audio-adapter.test.ts
@@ -1,0 +1,328 @@
+/**
+ * MOR-1262 decomposition slice 3A (MOR-1274) — `rxAudio` fact-group adapter
+ * derivation.
+ *
+ * Companion to `radio-view-model-adapter.test.ts` (MOR-1065),
+ * `tx-aux-adapter.test.ts` (1A) and `meters-adapter.test.ts` (2A), none of
+ * which this file modifies. Those files never pass an RX-audio snapshot, so
+ * `deriveRxAudio` declines to emit for them and their exact-key-list
+ * assertions stand unchanged.
+ *
+ * Three safety blocks:
+ *  1. MOD-input readiness IS `deriveTxCapabilities`'s conclusion, and the
+ *     source projection IS the App TX authority's — both pinned against the
+ *     shipped originals, not against a hand-copied expectation.
+ *  2. TX truth (R9): the whole group is invariant to `radioState.ptt`.
+ *  3. Honest degradation: the group never fabricates the shipped panel's
+ *     0.5 AF / 'both' focus defaults.
+ * (Purity — no transport/audio-manager/AudioContext contact — is pinned
+ * separately in `rx-audio-purity.test.ts`, which needs the isolated pool.)
+ */
+import { describe, expect, it } from 'vitest';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { FieldStatus, ServerState } from '$lib/types/state';
+import { validateRadioViewModel, type RadioViewModel } from '../../../../semantic/radio-view-model';
+import { toRadioViewModel, type RxAudioSnapshot } from '../radio-view-model-adapter';
+import { deriveTxCapabilities } from '../tx-capabilities';
+import { createAppAuthorityProjector } from '../../tx-controller/app-authority';
+import { toRxAudioProps } from '../../props/panel-props';
+
+const fresh: FieldStatus = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' };
+const stale: FieldStatus = { storePath: 'x', observed: true, freshness: 'stale', availability: 'stale' };
+const missing: FieldStatus = { storePath: 'x', observed: false, freshness: 'fresh', availability: 'missing' };
+
+function caps(overrides: Partial<Capabilities> = {}): Capabilities {
+  return {
+    model: 'fixture', scope: false, audio: true, tx: true,
+    capabilities: ['audio', 'tx', 'mod_input_routing', 'af_level'],
+    receivers: 1, vfoScheme: 'single', freqRanges: [], modes: [], filters: [],
+    audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
+    webrtc: { available: false, enabled: false },
+    txBands: [{ start: 14000000, end: 14350000, name: '20m' }],
+    scopeSource: 'hardware', audioFftAvailable: false,
+    audioTxRequiredModInputSource: 5, ...overrides,
+  } as Capabilities;
+}
+
+/** The App-owned snapshot: live browser RX at 42 %, audio link up, routing restored. */
+const SNAP: RxAudioSnapshot = {
+  muted: false, rxEnabled: true, volume: 42, connected: true,
+  routing: { focus: 'both', splitStereo: false },
+};
+
+function audioState(overrides: Partial<ServerState> = {}): ServerState {
+  return {
+    active: 'MAIN', split: false, dualWatch: false, ptt: false,
+    txTarget: { status: 'known', receiver: 'MAIN', slot: null, frequencyHz: 14195000 },
+    main: {
+      freqHz: 14195000, mode: 'USB', filter: 1, dataMode: 0, att: 0, preamp: 0,
+      nb: false, nr: false, afLevel: 0.31, rfGain: 1, squelch: 0, sMeter: 120,
+    },
+    dataOffModInput: 5,
+    fieldStatus: {
+      active: fresh, split: fresh, dualWatch: fresh, txTarget: fresh,
+      'main.freqHz': fresh, 'main.mode': fresh, 'main.filter': fresh,
+      'main.afLevel': fresh, dataOffModInput: fresh,
+    },
+    ...overrides,
+  } as unknown as ServerState;
+}
+
+function model(
+  state: ServerState | null, capabilities: Capabilities | null,
+  snapshot?: RxAudioSnapshot | null,
+): RadioViewModel {
+  const view = toRadioViewModel(state, capabilities, null, snapshot);
+  expect(view).not.toBeNull();
+  return validateRadioViewModel(view);
+}
+
+describe('rxAudio group gate (MOR-1262 slice 3A, kill-test 4)', () => {
+  it('emits NO group without the App-owned audio snapshot — audio lifetime is not this layer\'s', () => {
+    for (const snapshot of [undefined, null]) {
+      const view = model(audioState(), caps(), snapshot);
+      expect(view.rxAudio).toBeUndefined();
+      expect(Object.keys(view)).not.toContain('rxAudio');
+    }
+  });
+
+  it('emits no group for a radio with no AF, no live audio, no dual RX and no MOD routing', () => {
+    const bare = caps({ audio: false, capabilities: ['tx'] });
+    expect(model(audioState(), bare, SNAP).rxAudio).toBeUndefined();
+  });
+
+  it('emits the group once a single piece of evidence exists (MOD-input routing alone)', () => {
+    const routingOnly = caps({ audio: false, capabilities: ['tx', 'mod_input_routing'] });
+    const rxAudio = model(audioState(), routingOnly, SNAP).rxAudio!;
+    expect(rxAudio.modInputSource.reading).toEqual({ status: 'known', value: 5 });
+    expect(rxAudio.liveAudio).toEqual({ structural: false, operational: false });
+  });
+
+  it('emits no model at all when capabilities are absent', () => {
+    expect(toRadioViewModel(audioState(), null, null, SNAP)).toBeNull();
+  });
+
+  it('leaves the pre-3A families untouched when rxAudio is present', () => {
+    const view = model(audioState(), caps(), SNAP);
+    expect(view.topologyId).toBe('1/single');
+    expect(view.meters).toBeUndefined();
+    expect(view.txAux).toBeUndefined();
+    expect(view.txPermit).toEqual({ status: 'allowed', band: '20m' });
+    expect(JSON.parse(JSON.stringify(view))).toEqual(view);
+  });
+});
+
+/**
+ * SAFETY CONSTRAINT 2. The readiness fact is the shipped `deriveTxCapabilities`
+ * conclusion and the source projection is the App TX authority's own — both
+ * asserted against the REAL functions, so re-deriving either with new logic in
+ * the adapter goes red instead of quietly disagreeing with the TX guard.
+ */
+describe('MOD-input readiness mirrors the shipped derivation (web-voice-TX guard)', () => {
+  const SOURCES = [0, 1, 2, 3, 4, 5];
+
+  it.each(SOURCES)('agrees with deriveTxCapabilities for an observed source %i', (source) => {
+    const state = audioState({ dataOffModInput: source });
+    const expected = deriveTxCapabilities(caps(), {
+      txTarget: { status: 'known', receiver: 'MAIN', slot: null, frequencyHz: 14195000 },
+      modInputSource: { status: 'known', source },
+    }).modInputReadiness;
+    expect(model(state, caps(), SNAP).rxAudio!.modInputReadiness).toEqual(expected);
+  });
+
+  it('reports the recorded failure as a mismatch carrying the offending source', () => {
+    // DATA OFF MOD = MIC while the web UI streams over LAN: the exact
+    // "web voice TX = noise/squeal" configuration.
+    const rxAudio = model(audioState({ dataOffModInput: 0 }), caps(), SNAP).rxAudio!;
+    expect(rxAudio.modInputReadiness).toEqual({ status: 'mismatch', source: 0 });
+    expect(rxAudio.modInputSource.reading).toEqual({ status: 'known', value: 0 });
+  });
+
+  it('follows the active receiver\'s DATA group, not always DATA OFF', () => {
+    const onData1 = audioState({
+      main: { ...audioState().main, dataMode: 1 } as ServerState['main'],
+      data1ModInput: 0,
+      fieldStatus: { ...audioState().fieldStatus, data1ModInput: fresh },
+    });
+    expect(model(onData1, caps(), SNAP).rxAudio!.modInputReadiness)
+      .toEqual({ status: 'mismatch', source: 0 });
+  });
+
+  it.each([
+    ['unobserved', missing],
+    ['stale', stale],
+  ])('degrades a %s source to unknown readiness — never assumed ready', (_label, status) => {
+    const state = audioState({
+      fieldStatus: { ...audioState().fieldStatus, dataOffModInput: status },
+    });
+    const rxAudio = model(state, caps(), SNAP).rxAudio!;
+    expect(rxAudio.modInputReadiness).toEqual({ status: 'unknown' });
+    expect(rxAudio.modInputSource.reading).toEqual({ status: 'unknown' });
+    expect(rxAudio.modInputSource.availability).toEqual({ structural: true, operational: false });
+  });
+
+  it('marks the source structurally absent on a radio without MOD-input routing', () => {
+    const noRouting = caps({ capabilities: ['audio', 'tx', 'af_level'] });
+    const rxAudio = model(audioState(), noRouting, SNAP).rxAudio!;
+    expect(rxAudio.modInputSource.availability).toEqual({ structural: false, operational: false });
+    expect(rxAudio.modInputReadiness).toEqual({ status: 'not-applicable' });
+  });
+
+  it.each([
+    ['LAN', 5], ['MIC', 0], ['USB', 3],
+  ])('projects the %s source exactly as the App TX authority does', (_label, source) => {
+    const state = audioState({ dataOffModInput: source });
+    const project = createAppAuthorityProjector();
+    const authority = project(state, caps(), { state: 'connected', epoch: 0 });
+    const reading = model(state, caps(), SNAP).rxAudio!.modInputSource.reading;
+    expect(authority.modInputSource.status).toBe('known');
+    expect(reading).toEqual({
+      status: 'known',
+      value: (authority.modInputSource as { status: 'known'; source: number }).source,
+    });
+    expect(model(state, caps(), SNAP).rxAudio!.modInputReadiness)
+      .toEqual(authority.facts!.modInputReadiness);
+  });
+
+  it('projects an unobserved source as unknown, exactly as the App TX authority does', () => {
+    const state = audioState({
+      fieldStatus: { ...audioState().fieldStatus, dataOffModInput: missing },
+    });
+    const project = createAppAuthorityProjector();
+    const authority = project(state, caps(), { state: 'connected', epoch: 0 });
+    expect(authority.modInputSource).toEqual({ status: 'unknown' });
+    expect(model(state, caps(), SNAP).rxAudio!.modInputSource.reading).toEqual({ status: 'unknown' });
+  });
+});
+
+/** SAFETY CONSTRAINT 3 (R9). Nothing in this family may read `radioState.ptt`. */
+describe('rxAudio carries no ptt-derived TX truth (R9)', () => {
+  it('is byte-identical with ptt true and ptt false', () => {
+    const keyedDown = model(audioState({ ptt: true }), caps(), SNAP).rxAudio;
+    const keyedUp = model(audioState({ ptt: false }), caps(), SNAP).rxAudio;
+    expect(keyedDown).toEqual(keyedUp);
+  });
+
+  it('is byte-identical whether or not a TX authority snapshot is supplied', () => {
+    const withAuthority = toRadioViewModel(
+      audioState(), caps(), { radioTx: 'on', txRisk: 'confirmed-on' }, SNAP,
+    );
+    const withoutAuthority = toRadioViewModel(audioState(), caps(), null, SNAP);
+    expect(withAuthority?.rxAudio).toEqual(withoutAuthority?.rxAudio);
+  });
+});
+
+describe('rxAudio degrades honestly rather than to the shipped panel defaults', () => {
+  it('reports the browser volume as AF while monitoring live', () => {
+    const rxAudio = model(audioState(), caps(), SNAP).rxAudio!;
+    expect(rxAudio.monitorMode).toBe('live');
+    expect(rxAudio.afLevel.reading).toEqual({ status: 'known', value: 0.42 });
+  });
+
+  it('reports the radio AF level while monitoring locally', () => {
+    const local: RxAudioSnapshot = { ...SNAP, rxEnabled: false };
+    const rxAudio = model(audioState(), caps(), local).rxAudio!;
+    expect(rxAudio.monitorMode).toBe('local');
+    expect(rxAudio.afLevel.reading).toEqual({ status: 'known', value: 0.31 });
+  });
+
+  it('reports AF unknown when the radio field is unobserved — where the panel substitutes 0.5', () => {
+    const local: RxAudioSnapshot = { ...SNAP, rxEnabled: false };
+    const state = audioState({
+      main: { ...audioState().main, afLevel: undefined } as unknown as ServerState['main'],
+      fieldStatus: { ...audioState().fieldStatus, 'main.afLevel': missing },
+    });
+    const rxAudio = model(state, caps(), local).rxAudio!;
+    expect(rxAudio.afLevel.reading).toEqual({ status: 'unknown' });
+    expect(rxAudio.afLevel.availability).toEqual({ structural: true, operational: false });
+    // The discriminating half: the shipped panel prop fabricates a mid-scale
+    // default from exactly this state. The contract must NOT.
+    expect(toRxAudioProps(state, caps(), { muted: false, rxEnabled: false, volume: 42 }, true).afLevel)
+      .toBe(0.5);
+  });
+
+  it.each([
+    ['absent', undefined],
+    ['malformed', 'loud'],
+  ])('reports AF unknown for a %s value the field status claims is available — never 0.5', (_label, value) => {
+    // The discriminating half of the pair above: here the gate says
+    // "available", so ONLY the value check stands between the contract and the
+    // panel's `?? 0.5` fabrication.
+    const local: RxAudioSnapshot = { ...SNAP, rxEnabled: false };
+    const state = audioState({
+      main: { ...audioState().main, afLevel: value } as unknown as ServerState['main'],
+    });
+    const rxAudio = model(state, caps(), local).rxAudio!;
+    expect(rxAudio.afLevel.reading).toEqual({ status: 'unknown' });
+    expect(rxAudio.afLevel.availability).toEqual({ structural: true, operational: true });
+  });
+
+  it('reports routing unknown when the App never restored the prefs — not \'both\'/false', () => {
+    const dualRx = caps({ capabilities: [...caps().capabilities, 'dual_rx'] });
+    const noRouting: RxAudioSnapshot = { ...SNAP, routing: null };
+    const rxAudio = model(audioState(), dualRx, noRouting).rxAudio!;
+    expect(rxAudio.routingFocus.reading).toEqual({ status: 'unknown' });
+    expect(rxAudio.routingSplit.reading).toEqual({ status: 'unknown' });
+    expect(rxAudio.routingFocus.availability).toEqual({ structural: true, operational: false });
+  });
+
+  it('marks routing structurally absent on a single-receiver radio', () => {
+    const rxAudio = model(audioState(), caps(), SNAP).rxAudio!;
+    expect(rxAudio.routingFocus.availability).toEqual({ structural: false, operational: false });
+    expect(rxAudio.routingSplit.reading).toEqual({ status: 'unknown' });
+  });
+
+  it('reports the restored routing prefs on a dual-receiver radio', () => {
+    const dualRx = caps({ capabilities: [...caps().capabilities, 'dual_rx'] });
+    const snapshot: RxAudioSnapshot = { ...SNAP, routing: { focus: 'sub', splitStereo: true } };
+    const rxAudio = model(audioState(), dualRx, snapshot).rxAudio!;
+    expect(rxAudio.routingFocus.reading).toEqual({ status: 'known', value: 'sub' });
+    expect(rxAudio.routingSplit.reading).toEqual({ status: 'known', value: true });
+  });
+
+  it('reports the audio link as structurally present but not operational when the WS is down', () => {
+    const offline: RxAudioSnapshot = { ...SNAP, connected: false };
+    expect(model(audioState(), caps(), offline).rxAudio!.liveAudio)
+      .toEqual({ structural: true, operational: false });
+  });
+
+  it('follows the active receiver for the AF field status', () => {
+    const local: RxAudioSnapshot = { ...SNAP, rxEnabled: false };
+    const onSub = audioState({
+      active: 'SUB',
+      sub: {
+        freqHz: 7100000, mode: 'LSB', filter: 1, dataMode: 0, afLevel: 0.77, sMeter: 60,
+      } as unknown as ServerState['sub'],
+    });
+    expect(model(onSub, caps(), local).rxAudio!.afLevel.reading)
+      .toEqual({ status: 'known', value: 0.77 });
+    const staleSub = audioState({
+      ...onSub,
+      fieldStatus: { ...audioState().fieldStatus, 'sub.afLevel': stale },
+    });
+    expect(model(staleSub, caps(), local).rxAudio!.afLevel.reading).toEqual({ status: 'unknown' });
+  });
+});
+
+/**
+ * Monitor-mode parity with the shipped `toRxAudioProps`: the contract adopts
+ * the panel's vocabulary, it does not invent a second one.
+ */
+describe('monitor mode agrees with the shipped RxAudioProps derivation', () => {
+  const MATRIX = [false, true].flatMap((muted) => [false, true].flatMap(
+    (rxEnabled) => [false, true].map((hasAudio) => ({ muted, rxEnabled, hasAudio })),
+  ));
+
+  it.each(MATRIX)('muted=$muted rxEnabled=$rxEnabled audio=$hasAudio', ({ muted, rxEnabled, hasAudio }) => {
+    const capabilities = hasAudio
+      ? caps()
+      : caps({ audio: false, capabilities: ['tx', 'mod_input_routing', 'af_level'] });
+    const snapshot: RxAudioSnapshot = { ...SNAP, muted, rxEnabled };
+    const state = audioState();
+    const expected = toRxAudioProps(state, capabilities, { muted, rxEnabled, volume: 42 }, true);
+    const rxAudio = model(state, capabilities, snapshot).rxAudio!;
+    expect(rxAudio.monitorMode).toBe(expected.monitorMode);
+    expect(rxAudio.liveAudio.structural).toBe(expected.hasLiveAudio);
+    expect(rxAudio.afLevel.availability.structural).toBe(expected.hasAfLevel);
+  });
+});

--- a/frontend/src/lib/runtime/adapters/__tests__/rx-audio-purity.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/rx-audio-purity.test.ts
@@ -1,0 +1,195 @@
+/**
+ * MOR-1262 decomposition slice 3A (MOR-1274) — SAFETY CONSTRAINT 1.
+ *
+ * The `rxAudio` fact group is a PURE READ-MODEL. Constructing or serializing
+ * it must never open, start, probe or configure the audio path: audio lifetime
+ * is App-owned (MOR-1058) and "opens transport on mount" is the recorded
+ * MOR-972 P0 finding this family must not reintroduce. The snapshot is an
+ * INPUT precisely so the read-model has nothing to reach for.
+ *
+ * Three pins with DIFFERENT, deliberately stated coverage — they are not
+ * interchangeable, and no one of them is sufficient (MOR-1274 verification F1):
+ *  1. LOAD-TIME — spy call counts snapshotted at module-import time, BEFORE any
+ *     `mockClear()`. Covers the whole transitive import closure of the adapter
+ *     and the contract, and it is the only pin that sees a side effect fired at
+ *     import rather than at derive. This is the MOR-972 P0 shape ("opens
+ *     transport on mount"), and it is reachable without editing this slice at
+ *     all — any of the five transitive modules could acquire it later.
+ *  2. BEHAVIOURAL — the audio manager, the control transport, `AudioContext`
+ *     and `localStorage` are all spied; a full derive + validate + serialize
+ *     round trip must leave every one of them at zero calls. Covers derive-time
+ *     contact anywhere in the closure, including lazy getters; blind to
+ *     anything that already happened at import (hence pin 1).
+ *  3. STRUCTURAL — the adapter's and contract's own source text import none of
+ *     those modules. This pin is SOURCE-LOCAL and NON-TRANSITIVE: it reads two
+ *     files and matches `$lib/...` specifiers, so a relative-path import or a
+ *     dependency-of-a-dependency slips past it. It is a fast, precise guard on
+ *     the two files this slice owns, not a closure-wide proof (pins 1 and 2 are).
+ *
+ * Pool: `isolated` (MOR-1272). Module-scope `vi.mock` plus `vi.stubGlobal` on
+ * `AudioContext`/`localStorage` are exactly the shared-state shapes that are
+ * order-dependent under the fast pool's `isolate: false`.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+vi.mock('$lib/audio/audio-manager', () => ({
+  audioManager: {
+    rxEnabled: false,
+    startRx: vi.fn(), stopRx: vi.fn(), startTx: vi.fn(), stopTx: vi.fn(),
+    setRxVolume: vi.fn(), setAudioConfig: vi.fn(),
+  },
+}));
+
+vi.mock('$lib/transport/ws-client', () => ({
+  sendCommand: vi.fn(), connectWs: vi.fn(), disconnectWs: vi.fn(),
+}));
+
+import { audioManager } from '$lib/audio/audio-manager';
+import { sendCommand } from '$lib/transport/ws-client';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { FieldStatus, ServerState } from '$lib/types/state';
+import { validateRadioViewModel } from '../../../../semantic/radio-view-model';
+import { toRadioViewModel, type RxAudioSnapshot } from '../radio-view-model-adapter';
+
+/**
+ * PIN 1 — the load-time snapshot. Read at module scope, so it runs after the
+ * imports above have fully evaluated the adapter's and the contract's entire
+ * transitive closure, and BEFORE `beforeEach`'s `mockClear()` erases the
+ * evidence. Anything in that closure that touches a seam at import time is
+ * recorded here and nowhere else.
+ */
+const loadTimeCalls = [
+  audioManager.startRx, audioManager.stopRx, audioManager.setRxVolume,
+  audioManager.setAudioConfig, sendCommand,
+].map((spy) => vi.mocked(spy).mock.calls.length);
+
+/** Comments are stripped before the structural assertions below: both files
+ *  DOCUMENT this prohibition in prose ("never opens `audio-manager`…"), and a
+ *  naive text search would match the doctrine instead of the code. */
+function code(path: string): string {
+  return readFileSync(path, 'utf8')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
+const adapterSource = code('src/lib/runtime/adapters/radio-view-model-adapter.ts');
+const contractSource = code('src/semantic/radio-view-model.ts');
+
+const fresh: FieldStatus = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' };
+
+const caps = {
+  model: 'fixture', scope: false, audio: true, tx: true,
+  capabilities: ['audio', 'tx', 'mod_input_routing', 'af_level', 'dual_rx'],
+  receivers: 1, vfoScheme: 'single', freqRanges: [], modes: [], filters: [],
+  audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
+  webrtc: { available: false, enabled: false },
+  txBands: [], scopeSource: 'hardware', audioFftAvailable: false,
+  audioTxRequiredModInputSource: 5,
+} as unknown as Capabilities;
+
+const state = {
+  active: 'MAIN', split: false, dualWatch: false, ptt: false,
+  txTarget: { status: 'unknown', reason: 'not-observed' },
+  main: {
+    freqHz: 14195000, mode: 'USB', filter: 1, dataMode: 0, afLevel: 0.31, sMeter: 120,
+  },
+  dataOffModInput: 0,
+  fieldStatus: { active: fresh, dataOffModInput: fresh, 'main.afLevel': fresh },
+} as unknown as ServerState;
+
+const snapshot: RxAudioSnapshot = {
+  muted: false, rxEnabled: true, volume: 42, connected: true,
+  routing: { focus: 'sub', splitStereo: true },
+};
+
+const audioContextCtor = vi.fn();
+class SpyAudioContext {
+  constructor(...args: unknown[]) { audioContextCtor(...args); }
+}
+const storage = {
+  getItem: vi.fn(() => null), setItem: vi.fn(), removeItem: vi.fn(), clear: vi.fn(),
+  key: vi.fn(() => null), length: 0,
+};
+
+describe('rxAudio fact construction never touches the audio path (MOR-1058 / MOR-972 P0)', () => {
+  beforeEach(() => {
+    vi.stubGlobal('AudioContext', SpyAudioContext);
+    vi.stubGlobal('webkitAudioContext', SpyAudioContext);
+    vi.stubGlobal('localStorage', storage);
+    audioContextCtor.mockClear();
+    for (const spy of [
+      audioManager.startRx, audioManager.stopRx, audioManager.startTx, audioManager.stopTx,
+      audioManager.setRxVolume, audioManager.setAudioConfig,
+      sendCommand, storage.getItem, storage.setItem,
+    ]) {
+      vi.mocked(spy).mockClear();
+    }
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  // ── Pin 1: load-time, closure-wide ───────────────────────────────────────
+  it('importing the adapter and contract calls no audio or transport seam', () => {
+    expect(loadTimeCalls).toEqual([0, 0, 0, 0, 0]);
+  });
+
+  it('derives, validates and serializes the group with zero audio-manager calls', () => {
+    const view = validateRadioViewModel(toRadioViewModel(state, caps, null, snapshot));
+    // The group really was produced — otherwise "zero calls" proves nothing.
+    expect(view.rxAudio).toBeDefined();
+    expect(view.rxAudio!.monitorMode).toBe('live');
+    JSON.stringify(view);
+
+    expect(audioManager.startRx).not.toHaveBeenCalled();
+    expect(audioManager.stopRx).not.toHaveBeenCalled();
+    expect(audioManager.startTx).not.toHaveBeenCalled();
+    expect(audioManager.stopTx).not.toHaveBeenCalled();
+    expect(audioManager.setRxVolume).not.toHaveBeenCalled();
+    expect(audioManager.setAudioConfig).not.toHaveBeenCalled();
+  });
+
+  it('sends no control command while building the group', () => {
+    validateRadioViewModel(toRadioViewModel(state, caps, null, snapshot));
+    expect(sendCommand).not.toHaveBeenCalled();
+  });
+
+  it('constructs no AudioContext, in either vendor spelling', () => {
+    validateRadioViewModel(toRadioViewModel(state, caps, null, snapshot));
+    expect(audioContextCtor).not.toHaveBeenCalled();
+  });
+
+  it('reads no browser storage — routing prefs arrive through the snapshot, not localStorage', () => {
+    const view = validateRadioViewModel(toRadioViewModel(state, caps, null, snapshot));
+    expect(view.rxAudio!.routingFocus.reading).toEqual({ status: 'known', value: 'sub' });
+    expect(storage.getItem).not.toHaveBeenCalled();
+    expect(storage.setItem).not.toHaveBeenCalled();
+  });
+
+  it('repeated derivation is side-effect free and stable', () => {
+    const first = toRadioViewModel(state, caps, null, snapshot);
+    const second = toRadioViewModel(state, caps, null, snapshot);
+    expect(second).toEqual(first);
+    expect(audioContextCtor).not.toHaveBeenCalled();
+    expect(sendCommand).not.toHaveBeenCalled();
+    expect(audioManager.startRx).not.toHaveBeenCalled();
+  });
+
+  // ── Structural pin: the handles are not even importable from here ────────
+  it('the adapter imports no audio or transport module', () => {
+    expect(adapterSource).not.toMatch(/from\s+'\$lib\/audio\//);
+    expect(adapterSource).not.toMatch(/from\s+'\$lib\/transport\//);
+    expect(adapterSource).not.toMatch(/\baudioManager\b/);
+    expect(adapterSource).not.toMatch(/\bAudioContext\b/);
+    expect(adapterSource).not.toMatch(/\blocalStorage\b/);
+  });
+
+  it('the contract imports no audio, transport or adapter module', () => {
+    expect(contractSource).not.toMatch(/from\s+'\$lib\/audio\//);
+    expect(contractSource).not.toMatch(/from\s+'\$lib\/transport\//);
+    expect(contractSource).not.toMatch(/from\s+'\$lib\/runtime\//);
+    expect(contractSource).not.toMatch(/\bAudioContext\b/);
+  });
+});

--- a/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
@@ -28,13 +28,17 @@ import type { ServerState } from '$lib/types/state';
 import type {
   RadioViewModel, TxAuxField, TxAuxViewModel, AtuStatus,
   MeterField, MeterRfState, MetersViewModel,
+  AudioFocus, MonitorMode, RxAudioViewModel,
 } from '../../../semantic/radio-view-model';
 import type { TxAuthoritySnapshot } from '../../../semantic/rx-tx-surface';
 import { isFieldAvailable } from '$lib/state/field-status';
+import { modInputStateKey } from '$lib/radio/mod-input';
 import {
   derivePresentationCapabilities, type ReceiverId, type VfoSlotId,
 } from './presentation-capabilities';
-import { deriveTxCapabilities } from './tx-capabilities';
+import {
+  deriveTxCapabilities, type ModInputSource, type TxCapabilityFacts,
+} from './tx-capabilities';
 
 type Slot = { kind: 'slotted'; id: VfoSlotId } | { kind: 'unslotted' } | { kind: 'unknown' };
 type Fact = { status: 'known'; value: boolean } | { status: 'unknown' };
@@ -257,6 +261,96 @@ function deriveMeters(
 }
 
 /**
+ * The App-owned RX-audio snapshot the `rxAudio` facts are read against
+ * (MOR-1262 slice 3A). It is an INPUT, deliberately: audio lifetime belongs to
+ * the App (MOR-1058) and building a view model must never open, start or probe
+ * the audio path (MOR-972 P0). Nothing in this file imports `audio-manager`,
+ * `ws-client` or `AudioContext`; the caller reads its own already-live state
+ * (`runtime.audio`, `runtime.connectionAudio`, the routing prefs
+ * `AudioRoutingControl` restores) and hands the values in. Pinned by
+ * `__tests__/rx-audio-purity.test.ts`.
+ */
+export interface RxAudioSnapshot {
+  /** `AudioUiState` (`lib/runtime/props/panel-props.ts`), verbatim. */
+  muted: boolean;
+  rxEnabled: boolean;
+  /** 0..100 browser RX volume. */
+  volume: number;
+  /** Audio-WS link health (`runtime.connectionAudio`). */
+  connected: boolean;
+  /** Browser-side routing prefs; absent/null ⇒ never restored, so the routing
+   *  facts read `unknown` rather than the control's own 'both'/false defaults. */
+  routing?: { focus: AudioFocus; splitStereo: boolean } | null;
+}
+
+/**
+ * Projects the active DATA group's MOD-input source exactly as the App TX
+ * authority does (`tx-controller/app-authority.ts::projectInputs`): the same
+ * three-part `seen()` gate and the same `Number.isSafeInteger` value check.
+ * Agreement with the real projector is pinned in
+ * `__tests__/rx-audio-adapter.test.ts` rather than assumed.
+ */
+function projectModInputSource(state: ServerState | null): ModInputSource {
+  const rx = state?.active === 'SUB' ? state.sub : state?.main;
+  const key = modInputStateKey(rx?.dataMode ?? 0);
+  const source = state?.[key];
+  return seen(state, key) && typeof source === 'number' && Number.isSafeInteger(source)
+    ? { status: 'known', source }
+    : { status: 'unknown' };
+}
+
+/**
+ * RX audio-chain facts. Same positive-evidence discipline as `deriveTxAux`
+ * (N3) and `deriveMeters`: NO App snapshot ⇒ NO group (there is no honest
+ * monitor mode to state, and guessing one from a store this layer does not own
+ * is the MOR-972 failure), and a radio with no AF control, no live audio, no
+ * dual-RX routing and no MOD-input routing gets no all-unknowns placeholder.
+ *
+ * SAFETY: `modInputReadiness` is `deriveTxCapabilities`'s own conclusion,
+ * passed straight through. It is NOT re-derived here — the "web voice TX =
+ * noise" guard has exactly one derivation in this codebase and this contract
+ * exposes it, the same way the meters group exposes the TX authority's.
+ */
+function deriveRxAudio(
+  state: ServerState | null, caps: Capabilities | null, facts: TxCapabilityFacts,
+  modInputSource: ModInputSource, audio: RxAudioSnapshot | null | undefined,
+): RxAudioViewModel | undefined {
+  if (!audio) return undefined;
+  const hasLiveAudio = hasCap(caps, 'audio');
+  // `toRxAudioProps`'s own gate: the radio's AF control, or the browser stream.
+  const hasAfLevel = hasCap(caps, 'af_level') || hasLiveAudio;
+  const hasDualRx = hasCap(caps, 'dual_rx');
+  const hasModInput = facts.modInputRoutingAvailable;
+  if (!hasAfLevel && !hasLiveAudio && !hasDualRx && !hasModInput) return undefined;
+  // Byte-identical to `toRxAudioProps`'s monitor-mode derivation; parity across
+  // the whole matrix is pinned in `__tests__/rx-audio-adapter.test.ts`.
+  const monitorMode: MonitorMode = audio.muted
+    ? 'mute'
+    : audio.rxEnabled && hasLiveAudio ? 'live' : 'local';
+  const onSub = state?.active === 'SUB';
+  const rx = onSub ? state?.sub : state?.main;
+  const afObserved = state !== null && topFieldAvailable(state, onSub ? 'sub.afLevel' : 'main.afLevel');
+  // In `live` mode AF is the browser volume the App already owns, so it is
+  // known by construction; otherwise it is the radio's own gated field — and
+  // `unknown` when unobserved, where the shipped panel substitutes 0.5.
+  const live = monitorMode === 'live';
+  const afLevel = live ? numOrUndef(audio.volume / 100) : (afObserved ? numOrUndef(rx?.afLevel) : undefined);
+  const routing = audio.routing ?? null;
+  const source = modInputSource.status === 'known' ? modInputSource.source : undefined;
+  return {
+    monitorMode,
+    liveAudio: { structural: hasLiveAudio, operational: hasLiveAudio && audio.connected },
+    // `txAuxField` is the shared `{reading, availability}` builder — `RxAudioField`
+    // IS `TxAuxField` (see the contract's alias), so there is one builder, not a fork.
+    afLevel: txAuxField(hasAfLevel, live || afObserved, afLevel),
+    routingFocus: txAuxField(hasDualRx, routing !== null, routing?.focus),
+    routingSplit: txAuxField(hasDualRx, routing !== null, routing?.splitStereo),
+    modInputSource: txAuxField(hasModInput, source !== undefined, source),
+    modInputReadiness: facts.modInputReadiness,
+  };
+}
+
+/**
  * `null` when there is nothing safe to render at all: capabilities have not
  * loaded, or they describe a topology that contradicts itself
  * (`derivePresentationCapabilities` diagnoses that, and a contradictory
@@ -265,6 +359,7 @@ function deriveMeters(
 export function toRadioViewModel(
   state: ServerState | null, caps: Capabilities | null,
   tx?: MetersTxAuthority | null,
+  rxAudioSnapshot?: RxAudioSnapshot | null,
 ): RadioViewModel | null {
   if (!caps) return null;
   const presentation = derivePresentationCapabilities(caps);
@@ -286,9 +381,11 @@ export function toRadioViewModel(
       reason: state?.fieldStatus?.txTarget?.availability === 'stale'
         ? 'stale' as const : 'not-observed' as const,
     };
-  const facts = deriveTxCapabilities(caps, {
-    txTarget: observedTarget, modInputSource: { status: 'unknown' },
-  });
+  // MOR-1274: the REAL projected MOD-input source, not a stub — it is the sole
+  // input to `modInputReadiness`, the "web voice TX = noise" guard the rxAudio
+  // group exposes. No other fact this call returns depends on it.
+  const modInputSource = projectModInputSource(state);
+  const facts = deriveTxCapabilities(caps, { txTarget: observedTarget, modInputSource });
   const target = facts.txTarget;
   const txTarget = target.status === 'known'
     ? {
@@ -391,6 +488,7 @@ export function toRadioViewModel(
   // reasoning as the validator's own omission below `validateRadioViewModel`.
   const txAux = deriveTxAux(state, caps);
   const meters = deriveMeters(state, caps, tx);
+  const rxAudio = deriveRxAudio(state, caps, facts, modInputSource, rxAudioSnapshot);
 
   return {
     topologyId: `${topology.structuralCount}/${topology.scheme}`,
@@ -405,5 +503,6 @@ export function toRadioViewModel(
     disabledReasons,
     ...(txAux !== undefined ? { txAux } : {}),
     ...(meters !== undefined ? { meters } : {}),
+    ...(rxAudio !== undefined ? { rxAudio } : {}),
   };
 }

--- a/frontend/src/semantic/__tests__/optional-group-allow-list.test.ts
+++ b/frontend/src/semantic/__tests__/optional-group-allow-list.test.ts
@@ -40,9 +40,9 @@ const REQUIRED_KEYS = [
   'txTarget', 'txPermit', 'scope', 'disabledReasons',
 ] as const;
 
-/** MOR-1244: txAux. MOR-1262 slice 2A: meters. Add your key here when your
- *  family's slice lands. */
-const EXPECTED_OPTIONAL_GROUP_KEYS = ['txAux', 'meters'] as const;
+/** MOR-1244: txAux. MOR-1262 slice 2A: meters. Slice 3A: rxAudio. Add your key
+ *  here when your family's slice lands. */
+const EXPECTED_OPTIONAL_GROUP_KEYS = ['txAux', 'meters', 'rxAudio'] as const;
 
 function extractTopLevelAllowList(): string[] {
   // `.toString()` on a Vite/esbuild-transformed function returns the SSR-

--- a/frontend/src/semantic/__tests__/rx-audio.test.ts
+++ b/frontend/src/semantic/__tests__/rx-audio.test.ts
@@ -1,0 +1,256 @@
+/**
+ * MOR-1262 decomposition slice 3A (MOR-1274) — `rxAudio` optional fact group,
+ * validator half, plus the SAFETY-CRITICAL MOD-input readiness parity pin.
+ *
+ * Companion to `tx-aux.test.ts` (1A) and `meters.test.ts` (2A), whose kill
+ * tests this file mirrors for the RX-audio family:
+ *  1. an rxAudio-absent model validates and round-trips byte-identically
+ *  2. `"rxAudio": null` / `{}` throw (absent ≠ malformed — JSON has no undefined)
+ *  3. a malformed inner field throws with a precise `$.rxAudio....` path
+ *  5. an unknown extra key inside rxAudio (or a field) throws
+ * (Kill-test 4, the adapter's evidence + snapshot gate, lives in
+ * `lib/runtime/adapters/__tests__/rx-audio-adapter.test.ts`.)
+ *
+ * The last describe block is the safety-critical one: the contract's
+ * `ModInputReadiness` is a copy of `tx-capabilities.ts`'s own union (a contract
+ * must not depend on an adapter), so it is pinned member-for-member against the
+ * original AND value-for-value against the real `deriveTxCapabilities` across
+ * the readiness matrix. Drift is a red test, never a silent fork — this is the
+ * recorded "web voice TX = noise/squeal" guard.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  validateRadioViewModel, type ModInputReadiness, type RxAudioViewModel,
+} from '../radio-view-model';
+import { topologyFixtures, withRxAudio } from '../fixtures/topologies';
+import {
+  deriveTxCapabilities, type ModInputReadiness as AdapterModInputReadiness,
+  type ModInputSource,
+} from '$lib/runtime/adapters/tx-capabilities';
+import type { Capabilities } from '$lib/types/capabilities';
+
+const AVAIL = { structural: true, operational: true } as const;
+const base = topologyFixtures['1/single'];
+const READINESS_STATUSES = ['not-applicable', 'ready', 'mismatch', 'unknown'] as const;
+
+describe('rxAudio (MOR-1262 slice 3A)', () => {
+  // ── Kill-test 1: absence is byte-identical, not a new default shape ──────
+  it('validates an rxAudio-absent model and never adds the key', () => {
+    expect(Object.keys(base)).not.toContain('rxAudio');
+    const validated = validateRadioViewModel(base);
+    expect(Object.keys(validated)).not.toContain('rxAudio');
+    expect(validated.rxAudio).toBeUndefined();
+    expect(JSON.parse(JSON.stringify(validated))).toEqual(JSON.parse(JSON.stringify(base)));
+  });
+
+  it('validates a fully-populated rxAudio group and returns it unchanged', () => {
+    const withRx = withRxAudio(base);
+    expect(validateRadioViewModel(withRx).rxAudio).toEqual(withRx.rxAudio);
+  });
+
+  // ── Kill-test 2: null / {} are not absent ────────────────────────────────
+  it('rejects an explicit rxAudio: null', () => {
+    expect(() => validateRadioViewModel({ ...base, rxAudio: null })).toThrow(TypeError);
+  });
+
+  it('rejects an explicit rxAudio: {} — present, not absent, must satisfy its own shape', () => {
+    expect(() => validateRadioViewModel({ ...base, rxAudio: {} })).toThrow(TypeError);
+  });
+
+  // ── Kill-test 3: malformed inner field, precise path ─────────────────────
+  it('rejects a monitor mode outside the shipped vocabulary', () => {
+    const withRx = withRxAudio(base);
+    const malformed = { ...withRx, rxAudio: { ...withRx.rxAudio, monitorMode: 'headphones' } };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.rxAudio\.monitorMode/);
+  });
+
+  it('rejects a non-numeric afLevel reading value with a precise error path', () => {
+    const withRx = withRxAudio(base);
+    const malformed = {
+      ...withRx,
+      rxAudio: {
+        ...withRx.rxAudio,
+        afLevel: { reading: { status: 'known', value: 'loud' }, availability: AVAIL },
+      },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.rxAudio\.afLevel\.reading\.value/);
+  });
+
+  it('rejects a routing focus outside the dual-RX vocabulary', () => {
+    const withRx = withRxAudio(base);
+    const malformed = {
+      ...withRx,
+      rxAudio: {
+        ...withRx.rxAudio,
+        routingFocus: { reading: { status: 'known', value: 'left' }, availability: AVAIL },
+      },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.rxAudio\.routingFocus\.reading\.value/);
+  });
+
+  it('rejects a readiness status outside the guard vocabulary', () => {
+    const withRx = withRxAudio(base);
+    const malformed = {
+      ...withRx, rxAudio: { ...withRx.rxAudio, modInputReadiness: { status: 'probably-fine' } },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.rxAudio\.modInputReadiness\.status/);
+  });
+
+  it('rejects a mismatch readiness with no source — the offending source is the whole point', () => {
+    const withRx = withRxAudio(base);
+    const malformed = {
+      ...withRx, rxAudio: { ...withRx.rxAudio, modInputReadiness: { status: 'mismatch' } },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(TypeError);
+  });
+
+  it('rejects a not-applicable readiness that smuggles a source in', () => {
+    const withRx = withRxAudio(base);
+    const malformed = {
+      ...withRx,
+      rxAudio: { ...withRx.rxAudio, modInputReadiness: { status: 'not-applicable', source: 5 } },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(TypeError);
+  });
+
+  it('rejects a non-boolean field inside liveAudio availability', () => {
+    const withRx = withRxAudio(base);
+    const malformed = {
+      ...withRx,
+      rxAudio: { ...withRx.rxAudio, liveAudio: { structural: 'yes', operational: true } },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.rxAudio\.liveAudio\.structural/);
+  });
+
+  it('accepts an unknown reading independently per fact, without degrading the rest', () => {
+    const withRx = withRxAudio(base);
+    const partial = {
+      ...withRx,
+      rxAudio: {
+        ...withRx.rxAudio,
+        routingFocus: { reading: { status: 'unknown' }, availability: { structural: true, operational: false } },
+      },
+    };
+    const validated = validateRadioViewModel(partial);
+    expect(validated.rxAudio?.routingFocus).toEqual({
+      reading: { status: 'unknown' }, availability: { structural: true, operational: false },
+    });
+    expect(validated.rxAudio?.afLevel.reading).toEqual({ status: 'known', value: 0.42 });
+  });
+
+  // ── Kill-test 5: no speculative keys ─────────────────────────────────────
+  it('rejects an unknown extra key inside rxAudio', () => {
+    const withRx = withRxAudio(base);
+    expect(() => validateRadioViewModel({ ...withRx, rxAudio: { ...withRx.rxAudio, squelch: 1 } }))
+      .toThrow(TypeError);
+  });
+
+  it('rejects an unknown extra key inside a single rxAudio field', () => {
+    const withRx = withRxAudio(base);
+    const malformed = {
+      ...withRx,
+      rxAudio: {
+        ...withRx.rxAudio,
+        afLevel: { reading: { status: 'known', value: 0.5 }, availability: AVAIL, relevant: true },
+      },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(TypeError);
+  });
+
+  it('rejects a reading that carries a value key while unknown', () => {
+    const withRx = withRxAudio(base);
+    const malformed = {
+      ...withRx,
+      rxAudio: {
+        ...withRx.rxAudio,
+        modInputSource: { reading: { status: 'unknown', value: 5 }, availability: AVAIL },
+      },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(TypeError);
+  });
+
+  it.each(READINESS_STATUSES)('accepts the readiness status %s', (status) => {
+    const readiness = (status === 'ready' || status === 'mismatch'
+      ? { status, source: 0 } : { status }) as ModInputReadiness;
+    const validated = validateRadioViewModel(withRxAudio(base, readiness));
+    expect(validated.rxAudio?.modInputReadiness).toEqual(readiness);
+  });
+
+  it('every fact of a fully-populated group round-trips its own value', () => {
+    const rxAudio = validateRadioViewModel(withRxAudio(base)).rxAudio as RxAudioViewModel;
+    expect(rxAudio.monitorMode).toBe('live');
+    expect(rxAudio.afLevel.reading).toEqual({ status: 'known', value: 0.42 });
+    expect(rxAudio.routingFocus.reading).toEqual({ status: 'known', value: 'both' });
+    expect(rxAudio.routingSplit.reading).toEqual({ status: 'known', value: false });
+    expect(rxAudio.modInputSource.reading).toEqual({ status: 'known', value: 5 });
+    expect(rxAudio.modInputReadiness).toEqual({ status: 'ready', source: 5 });
+  });
+});
+
+/**
+ * SAFETY CONSTRAINT 2. The contract carries a copy of the adapter's
+ * `ModInputReadiness`; these tests prove the copy is not a fork, and that the
+ * shipped `deriveTxCapabilities` derivation is the ONE source of readiness.
+ */
+describe('MOD-input readiness is the tx-capabilities derivation, verbatim (web-voice-TX guard)', () => {
+  it('the contract union has exactly the members tx-capabilities declares', () => {
+    // EXHAUSTIVE both ways at compile time, same technique as the meters
+    // `RfState` pin (MOR-1269 finding F3): `Record<K, …>` demands a key per
+    // member, so widening EITHER union breaks `npm run check`.
+    const adapterToContract: Record<AdapterModInputReadiness['status'], ModInputReadiness['status']> = {
+      'not-applicable': 'not-applicable', ready: 'ready', mismatch: 'mismatch', unknown: 'unknown',
+    };
+    const contractToAdapter: Record<ModInputReadiness['status'], AdapterModInputReadiness['status']> =
+      adapterToContract;
+    expect(new Set(READINESS_STATUSES)).toEqual(new Set(Object.keys(contractToAdapter)));
+    expect(Object.entries(contractToAdapter).every(([key, value]) => key === value)).toBe(true);
+  });
+
+  function caps(overrides: Partial<Capabilities> = {}): Capabilities {
+    return {
+      model: 'fixture', scope: false, audio: true, tx: true,
+      capabilities: ['audio', 'tx', 'mod_input_routing'],
+      receivers: 1, vfoScheme: 'single', freqRanges: [], modes: [], filters: [],
+      audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
+      webrtc: { available: false, enabled: false },
+      txBands: [], scopeSource: 'hardware', audioFftAvailable: false,
+      audioTxRequiredModInputSource: 5, ...overrides,
+    } as unknown as Capabilities;
+  }
+
+  // The full readiness matrix: routing capability × required-source config ×
+  // observed source. Each row states the fact the group must carry.
+  const MATRIX: ReadonlyArray<{
+    name: string; caps: Capabilities; source: ModInputSource;
+  }> = [
+    { name: 'LAN observed, LAN required → ready', caps: caps(), source: { status: 'known', source: 5 } },
+    { name: 'MIC observed, LAN required → mismatch (the noise failure)', caps: caps(), source: { status: 'known', source: 0 } },
+    { name: 'USB observed, LAN required → mismatch', caps: caps(), source: { status: 'known', source: 3 } },
+    { name: 'source unread → unknown, never assumed ready', caps: caps(), source: { status: 'unknown' } },
+    {
+      name: 'no required source configured → not-applicable',
+      caps: caps({ audioTxRequiredModInputSource: null }), source: { status: 'known', source: 0 },
+    },
+    {
+      name: 'radio without mod_input_routing → not-applicable',
+      caps: caps({ capabilities: ['audio', 'tx'] }), source: { status: 'known', source: 0 },
+    },
+  ];
+
+  it.each(MATRIX)('$name', ({ caps: capabilities, source }) => {
+    const derived = deriveTxCapabilities(capabilities, {
+      txTarget: { status: 'unknown', reason: 'not-observed' }, modInputSource: source,
+    }).modInputReadiness;
+    // The contract accepts exactly what the shipped derivation produces —
+    // no adaptation, no re-derivation, no widening.
+    const validated = validateRadioViewModel(withRxAudio(base, derived));
+    expect(validated.rxAudio?.modInputReadiness).toEqual(derived);
+  });
+
+  it('the matrix actually exercises every readiness status (no silent coverage gap)', () => {
+    const statuses = MATRIX.map(({ caps: capabilities, source }) => deriveTxCapabilities(capabilities, {
+      txTarget: { status: 'unknown', reason: 'not-observed' }, modInputSource: source,
+    }).modInputReadiness.status);
+    expect(new Set(statuses)).toEqual(new Set(READINESS_STATUSES));
+  });
+});

--- a/frontend/src/semantic/fixtures/topologies.ts
+++ b/frontend/src/semantic/fixtures/topologies.ts
@@ -15,7 +15,8 @@
  */
 import type {
   Availability, MeterField, MeterRfState, MetersViewModel,
-  RadioViewModel, TxAuxField, TxAuxViewModel,
+  ModInputReadiness, RadioViewModel, RxAudioField, RxAudioViewModel,
+  TxAuxField, TxAuxViewModel,
 } from '../radio-view-model';
 
 const singleReceiver: RadioViewModel = {
@@ -212,4 +213,29 @@ export function withMeters(
     drainCurrent: field(80, tx),
   };
   return { ...fixture, meters };
+}
+
+/**
+ * Applies a fully-observed `rxAudio` group (MOR-1262 slice 3A) to any topology
+ * fixture. `readiness` is a PARAMETER for the same reason `withMeters`'s
+ * `rfState` is: MOD-input readiness is the safety-critical axis, and a fixture
+ * that hard-coded `ready` would make the "web voice TX = noise" mismatch
+ * unobservable in every consumer that composes this helper.
+ */
+export function withRxAudio(
+  fixture: RadioViewModel,
+  readiness: ModInputReadiness = { status: 'ready', source: 5 },
+): RadioViewModel {
+  const avail: Availability = { structural: true, operational: true };
+  const known = <T>(value: T): RxAudioField<T> => ({ reading: { status: 'known', value }, availability: avail });
+  const rxAudio: RxAudioViewModel = {
+    monitorMode: 'live',
+    liveAudio: avail,
+    afLevel: known(0.42),
+    routingFocus: known('both'),
+    routingSplit: known(false),
+    modInputSource: known(readiness.status === 'ready' || readiness.status === 'mismatch' ? readiness.source : 5),
+    modInputReadiness: readiness,
+  };
+  return { ...fixture, rxAudio };
 }

--- a/frontend/src/semantic/radio-view-model.ts
+++ b/frontend/src/semantic/radio-view-model.ts
@@ -172,6 +172,67 @@ export interface MetersViewModel {
   drainCurrent: MeterField;
 }
 
+/**
+ * A single RX-audio fact (MOR-1262 decomposition slice 3A, MOR-1274). Shape-
+ * identical to `TxAuxField` — `{reading, availability}`, no third member —
+ * so it is declared as an alias rather than a near-duplicate: one field shape
+ * for every non-meter fact family, and slice 1A's declaration is left
+ * untouched. The validator is shared for the same reason.
+ */
+export type RxAudioReading<T> = TxAuxReading<T>;
+export type RxAudioField<T> = TxAuxField<T>;
+
+/** What the operator is listening to, verbatim the shipped `RxAudioProps`
+ *  vocabulary (`lib/runtime/props/panel-props.ts::toRxAudioProps`): `local` =
+ *  the rig's own speaker, `live` = the browser RX stream, `mute` = silenced. */
+export type MonitorMode = 'local' | 'live' | 'mute';
+
+/** Dual-receiver audio routing focus, verbatim `AudioRoutingControl.svelte`. */
+export type AudioFocus = 'main' | 'sub' | 'both';
+
+/**
+ * MOD-input readiness — the recorded "web voice TX = noise/squeal" guard.
+ * Member-for-member `lib/runtime/adapters/tx-capabilities.ts`'s own
+ * `ModInputReadiness`, declared again here for the same reason `MeterRfState`
+ * is (a contract must not depend on an adapter); the adapter EXPOSES
+ * `deriveTxCapabilities(...).modInputReadiness` rather than re-deriving it,
+ * and both the union and the derivation are pinned in `__tests__/rx-audio.test.ts`.
+ * `mismatch` is the failure the whole family exists to make visible: the rig
+ * is modulating from MIC/ACC/USB while the web UI streams audio over LAN.
+ */
+export type ModInputReadiness =
+  | { status: 'not-applicable' }
+  | { status: 'ready'; source: number }
+  | { status: 'mismatch'; source: number }
+  | { status: 'unknown' };
+
+/**
+ * RX audio-chain facts (MOR-1262 decomposition slice 3A). Facts only — no
+ * transport, no AudioContext, no lifetime: audio lifetime is App-owned
+ * (MOR-1058, MOR-972 P0) and this group is a pure read-model over a snapshot
+ * the App hands in. Constructing or serializing it must never start a stream.
+ *
+ * `monitorMode` and `liveAudio` come from that App-owned snapshot (the same
+ * relationship `meters.rfState` has to the TX authority); `afLevel` /
+ * `routingFocus` / `routingSplit` / `modInputSource` are two-level-gated facts
+ * that degrade to `unknown` rather than to the shipped panel's fabricated
+ * defaults (0.5 AF, 'both' focus).
+ */
+export interface RxAudioViewModel {
+  monitorMode: MonitorMode;
+  /** Structural = the radio streams audio at all; operational = the audio WS
+   *  is up. Without it a surface cannot honestly offer the `live` mode. */
+  liveAudio: Availability;
+  /** 0..1. In `live` mode the browser volume; otherwise the radio's AF level —
+   *  and `unknown` when that field was never observed, never 0.5. */
+  afLevel: RxAudioField<number>;
+  routingFocus: RxAudioField<AudioFocus>;
+  routingSplit: RxAudioField<boolean>;
+  /** The active DATA group's MOD-input source enum (`$lib/radio/mod-input`). */
+  modInputSource: RxAudioField<number>;
+  modInputReadiness: ModInputReadiness;
+}
+
 export interface RadioViewModel {
   topologyId: string;
   vfoScheme: VfoScheme;
@@ -193,6 +254,10 @@ export interface RadioViewModel {
    *  or the App TX authority was not supplied so no honest TX-relevance could
    *  be stated — see `radio-view-model-adapter.ts`'s `deriveMeters`. */
   readonly meters?: MetersViewModel;
+  /** Absent (MOR-1264 optional group) ⇒ the App-owned RX-audio snapshot was
+   *  not supplied, or this radio has no RX-audio chain to describe — see
+   *  `radio-view-model-adapter.ts`'s `deriveRxAudio`. */
+  readonly rxAudio?: RxAudioViewModel;
 }
 
 const RECEIVER_IDS: readonly ReceiverId[] = ['MAIN', 'SUB'];
@@ -454,6 +519,56 @@ function validateTxAux(value: unknown, path: string): TxAuxViewModel {
   };
 }
 
+const MONITOR_MODES: readonly MonitorMode[] = ['local', 'live', 'mute'];
+const AUDIO_FOCUSES: readonly AudioFocus[] = ['main', 'sub', 'both'];
+
+/** The `source` carried by `ready`/`mismatch` is the offending/confirmed
+ *  MOD-input enum value; a bare status must NOT carry one (that would make
+ *  "not applicable" indistinguishable from a read). */
+function validateModInputReadiness(value: unknown, path: string): ModInputReadiness {
+  const v = record(value, path);
+  if (v.status === 'ready') {
+    exactKeys(v, ['status', 'source'], path);
+    return { status: 'ready', source: num(v.source, `${path}.source`) };
+  }
+  if (v.status === 'mismatch') {
+    exactKeys(v, ['status', 'source'], path);
+    return { status: 'mismatch', source: num(v.source, `${path}.source`) };
+  }
+  if (v.status === 'not-applicable') {
+    exactKeys(v, ['status'], path);
+    return { status: 'not-applicable' };
+  }
+  if (v.status === 'unknown') {
+    exactKeys(v, ['status'], path);
+    return { status: 'unknown' };
+  }
+  invalid(`${path}.status`, "'not-applicable' | 'ready' | 'mismatch' | 'unknown'");
+}
+
+/** N4 again: exactly the seven facts the adapter reads, no speculative keys.
+ *  The per-field validator is `validateTxAuxField` — `RxAudioField` IS
+ *  `TxAuxField`, so sharing it is the alias's whole point, not a shortcut.
+ *  See `radio-view-model-adapter.ts::deriveRxAudio`. */
+function validateRxAudio(value: unknown, path: string): RxAudioViewModel {
+  const v = record(value, path);
+  exactKeys(v, [
+    'monitorMode', 'liveAudio', 'afLevel', 'routingFocus', 'routingSplit',
+    'modInputSource', 'modInputReadiness',
+  ], path);
+  return {
+    monitorMode: oneOf(v.monitorMode, MONITOR_MODES, `${path}.monitorMode`),
+    liveAudio: validateAvailability(v.liveAudio, `${path}.liveAudio`),
+    afLevel: validateTxAuxField(v.afLevel, `${path}.afLevel`, num),
+    routingFocus: validateTxAuxField(
+      v.routingFocus, `${path}.routingFocus`, (val, p) => oneOf(val, AUDIO_FOCUSES, p),
+    ),
+    routingSplit: validateTxAuxField(v.routingSplit, `${path}.routingSplit`, bool),
+    modInputSource: validateTxAuxField(v.modInputSource, `${path}.modInputSource`, num),
+    modInputReadiness: validateModInputReadiness(v.modInputReadiness, `${path}.modInputReadiness`),
+  };
+}
+
 /** Runtime validator (repo idiom: throws TypeError with a `$.path`, see `validateCapabilities`).
  *  Also enforces two cross-field invariants (review cycle 1, V1): `txPermit`
  *  cannot be 'allowed' while `txTarget` is unknown (no fail-open), and
@@ -462,7 +577,7 @@ export function validateRadioViewModel(value: unknown): RadioViewModel {
   const v = record(value, '$');
   exactKeys(v, [
     'topologyId', 'vfoScheme', 'activeReceiver', 'vfos', 'split', 'dualWatch',
-    'txTarget', 'txPermit', 'scope', 'disabledReasons', 'txAux', 'meters',
+    'txTarget', 'txPermit', 'scope', 'disabledReasons', 'txAux', 'meters', 'rxAudio',
   ], '$');
   if (!Array.isArray(v.vfos)) invalid('$.vfos', 'an array');
   if (!Array.isArray(v.disabledReasons)) invalid('$.disabledReasons', 'an array');
@@ -492,6 +607,7 @@ export function validateRadioViewModel(value: unknown): RadioViewModel {
   // assertion this was verified against).
   const txAux = optionalGroup(v.txAux, '$.txAux', validateTxAux);
   const meters = optionalGroup(v.meters, '$.meters', validateMeters);
+  const rxAudio = optionalGroup(v.rxAudio, '$.rxAudio', validateRxAudio);
 
   return {
     topologyId: str(v.topologyId, '$.topologyId'),
@@ -509,5 +625,6 @@ export function validateRadioViewModel(value: unknown): RadioViewModel {
     disabledReasons: v.disabledReasons.map((r, i) => validateDisabledReason(r, `$.disabledReasons[${i}]`)),
     ...(txAux !== undefined ? { txAux } : {}),
     ...(meters !== undefined ? { meters } : {}),
+    ...(rxAudio !== undefined ? { rxAudio } : {}),
   };
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -81,6 +81,11 @@ export default defineConfig({
             // then counts. Under ``isolate: false`` that makes it a function of
             // worker assignment rather than of its own subject.
             'src/lib/utils/__tests__/smoothing.svelte.test.ts',
+            // MOR-1262 slice 3A: module-scope ``vi.mock`` of audio-manager and
+            // ws-client PLUS ``vi.stubGlobal`` on AudioContext / localStorage —
+            // both shared-state shapes that are order-dependent under
+            // ``isolate: false``. See MOR-1272.
+            'src/lib/runtime/adapters/__tests__/rx-audio-purity.test.ts',
             'src/components-v2/wiring/__tests__/keyboard-wiring.test.ts',
             'src/components-v2/wiring/__tests__/vfo-wiring.test.ts',
             'src/components-v2/wiring/__tests__/dsp-nr-level.test.ts',
@@ -182,6 +187,7 @@ export default defineConfig({
           include: [
             'src/components-v2/wiring/__tests__/rx-audio-authority.test.ts',
             'src/lib/utils/__tests__/smoothing.svelte.test.ts',
+            'src/lib/runtime/adapters/__tests__/rx-audio-purity.test.ts',
             'src/components-v2/wiring/__tests__/keyboard-wiring.test.ts',
             'src/components-v2/wiring/__tests__/vfo-wiring.test.ts',
             'src/components-v2/wiring/__tests__/dsp-nr-level.test.ts',


### PR DESCRIPTION
## Summary
Vocabulary slice 3A of the MOR-1262 program (SAFETY-CRITICAL). Optional `rxAudio` fact group via the S0 seam, mirroring 1A/2A: `monitorMode` (local/live/mute), `liveAudio`, `afLevel`, `routingFocus`, `routingSplit`, `modInputSource`, `modInputReadiness` — 7 keys, exactKeys both levels, null/`{}` pinned; `RxAudioField<T>` aliases 1A's `TxAuxField<T>` (one builder, one validator; drift cannot be silent — exactKeys reddens both).

**Safety, each mutation-pinned:** (1) purity — fact derive/validate/serialize can NEVER touch audio transport (audio lifetime is App-owned, MOR-1058/MOR-972 P0): structural pin + behavioural spies + a closure-wide module-LOAD-time snapshot; (2) MOD-input readiness is a pass-through of `deriveTxCapabilities`, never re-derived (the "web voice TX = noise" guard survives; `ModInputTxWarning` byte-untouched); (3) R9 — group byte-identical under ptt flips and authority presence/absence.

Nothing wires the group yet (3B is a separate ticket) — zero shipped-behaviour change. Net production LOC **112** (independently re-measured; ≤200).

## Review provenance
Opus builder → independent opus vocabulary-domain verifier (fresh eyes, own transitive-import-closure proof + 6 injection probes). Round 1 **BLOCKED**: the purity pin was blind to module-load-time transport touches (probes P4/P5 — exactly the MOR-972 P0 shape); verifier pre-validated an 8-line loadTimeCalls fix. Builder applied it; delta round **PASS**: production sha256-identical, all 6 probes now killed, header claims corrected to actual coverage. Other kills across rounds: readiness bless-mismatch 9, local re-derive 9, seen()-gate drop 3, exactKeys drop 55, optionalGroup bypass, R9 monitorMode-from-ptt. Rulings: TxAuxField alias accepted; `liveAudio` ruled in-scope (surface would otherwise re-derive from capabilities — eslint-forbidden for panels); degrade-to-unknown discriminating test ruled honest. Failing-file set identical to baseline; lint/boundaries/check clean. Five 3B carry-forwards recorded in the verify report.

Linear: MOR-1274

🤖 Generated with [Claude Code](https://claude.com/claude-code)