### PR TITLE
docs(MOR-1278): standardize [data-design-language] as the canonical DL activation attribute

### DIFF
--- a/docs/plans/2026-07-25-ui-composition-architecture-v3.md
+++ b/docs/plans/2026-07-25-ui-composition-architecture-v3.md
@@ -102,6 +102,19 @@ product-owned identifiers such as `studioline`, `fieldline`,
 `contest-console`, or `classic-instrument`. Public manufacturer naming requires
 separate brand/legal review.
 
+MOR-1278 (owner decision, 2026-08-04): `[data-design-language]` is the
+canonical — and only — activation mechanism for a design language. Its value
+equals the language's registered id (`DesignLanguageManifest.id`,
+`presentation/languages/contract.ts`), and it is placed on the
+semantic-vertical root — the document root that scopes the whole semantic
+radio UI (the MOR-1070 fixture harness sets it on
+`document.documentElement`; `studioline`'s stylesheet keys every rule off it,
+see `presentation/languages/studioline/studioline.css`). No competing
+activation path — a CSS class, a component prop, a Svelte context — may be
+introduced, by `studioline`, by `fieldline` (MOR-1074), or by the renderer
+wiring that consumes it (MOR-1275). Routing this attribute into the app shell
+remains cutover work (MOR-1048/MOR-1263) and stays out of scope here.
+
 ### Theme
 
 CSS token values such as colors, fonts, spacing, shadows, and contrast. A theme

--- a/frontend/src/presentation/languages/contract.ts
+++ b/frontend/src/presentation/languages/contract.ts
@@ -107,6 +107,22 @@ export function isRendererViewModel(value: unknown): value is RendererViewModel 
 }
 
 export interface DesignLanguageManifest {
+  /**
+   * The language's stable id (naming policy: `isValidLanguageId`).
+   *
+   * MOR-1278 (owner decision, 2026-08-04): `[data-design-language]` is the
+   * canonical — and only — design-language activation mechanism. Its DOM
+   * value MUST equal this registered `id`, and it is placed on the
+   * semantic-vertical root: the document root that scopes the whole
+   * semantic radio UI vertical (`document.documentElement` — see the
+   * MOR-1070 fixture harness, `fixtures/main.ts`, and `studioline`'s own
+   * stylesheet, which keys every rule off this same attribute). No
+   * alternative activation path — a CSS class, a component prop, a Svelte
+   * context — may be introduced, by `studioline`, by `fieldline`
+   * (MOR-1074), or by the renderer wiring that consumes it (MOR-1275): the
+   * whole design-language CSS half assumes a single attribute selector it
+   * can scope every rule under.
+   */
   readonly id: string;
   readonly displayName: string;
   readonly tokens: DesignLanguageTokens;

--- a/frontend/src/presentation/languages/studioline/__tests__/activation-attribute.test.ts
+++ b/frontend/src/presentation/languages/studioline/__tests__/activation-attribute.test.ts
@@ -1,0 +1,68 @@
+/**
+ * MOR-1278 — activation-attribute pin.
+ *
+ * `[data-design-language]` is the canonical — and only — sanctioned
+ * design-language activation mechanism (doctrine: `../../contract.ts` on
+ * `DesignLanguageManifest.id`, and
+ * `docs/plans/2026-07-25-ui-composition-architecture-v3.md` under "Design
+ * language"). This test parses `studioline.css` with the same flat
+ * selector/rule idiom `stylesheet.test.ts` already uses (no new parser) and
+ * fails if ANY rule that styles studioline surfaces is not scoped under
+ * `[data-design-language='studioline']` — a `.studioline-*` class, a
+ * `[data-theme='studioline']` attribute, or any other competing activation
+ * selector would silently start working the moment a host introduced it,
+ * without ever touching the attribute this contract requires.
+ */
+import { readFileSync } from 'node:fs';
+import { describe, it, expect } from 'vitest';
+
+const source = readFileSync('src/presentation/languages/studioline/studioline.css', 'utf8');
+// Same comment-stripping idiom as stylesheet.test.ts — pins are about
+// selectors, not the prose describing them.
+const css = source.replace(/\/\*[\s\S]*?\*\//g, '');
+
+const ACTIVATION_ATTRIBUTE = "[data-design-language='studioline']";
+
+/** Every comma-separated selector in the sheet, one entry per rule (flat CSS, no at-rules — same assumption stylesheet.test.ts's parser makes). */
+function selectors(sheet: string): string[] {
+  const out: string[] = [];
+  for (const [, selectorList] of sheet.matchAll(/([^{}]+)\{[^{}]*\}/g)) {
+    for (const selector of selectorList.split(',')) {
+      const trimmed = selector.trim();
+      if (trimmed) out.push(trimmed);
+    }
+  }
+  return out;
+}
+
+const SELECTORS = selectors(css);
+
+describe('MOR-1278 — the sheet has selectors worth pinning', () => {
+  it('found more than a handful of rules', () => {
+    expect(SELECTORS.length).toBeGreaterThan(20);
+  });
+});
+
+describe('MOR-1278 — every studioline rule is scoped under [data-design-language]; nothing else may activate it', () => {
+  it('every selector opens with the sanctioned activation attribute', () => {
+    const unscoped = SELECTORS.filter((s) => !s.startsWith(ACTIVATION_ATTRIBUTE));
+    expect(unscoped).toEqual([]);
+  });
+
+  it('no selector\'s root compound is a competing mechanism (class, alternate attribute, :root, bare element)', () => {
+    // A competing activation mechanism would show up as a selector whose
+    // FIRST compound (before the first combinator/space) is not the
+    // sanctioned attribute — e.g. `.studioline-foo …`, `[data-theme=
+    // 'studioline'] …`, or `:root …`.
+    const rootCompounds = SELECTORS.map((s) => s.split(/\s+/)[0]);
+    const competing = rootCompounds.filter((c) => !c.startsWith(ACTIVATION_ATTRIBUTE));
+    expect(competing).toEqual([]);
+  });
+
+  it('no bare `.studioline-*` class selector exists anywhere in the sheet', () => {
+    // Catches a competing class-based activation selector even if it were
+    // added mid-selector (e.g. combined with the attribute rather than
+    // replacing it) rather than only at the selector root.
+    expect(css).not.toMatch(/\.studioline-/);
+  });
+});


### PR DESCRIPTION
## Summary
Owner decision 2026-08-04 (session-6 batch): `[data-design-language]` is THE canonical activation mechanism for product-owned design languages — standardized before fieldline (MOR-1074) copies it and before renderer wiring (MOR-1275) consumes it.

- Doctrine recorded in the two homes the MOR-1261 precedent established: JSDoc on `DesignLanguageManifest.id` (**+16 lines, all comment — 0 production LOC**) and the v3 plan doc's *Design language* section. All four elements: attribute name, value = registered language id, placement = semantic-vertical root, exclusivity (no class/prop/context alternative).
- New pin test `activation-attribute.test.ts`: every `studioline.css` rule must open with `[data-design-language='studioline']`; competing activation selectors fail the suite.

## Review provenance
Sonnet builder → independent opus DL-domain verifier: **PASS**. Diff surface exactly 3 files; `declarations.ts`/`studioline.css` byte-untouched (CSS SHA identical to the #2208 review record). 4/4 pin mutations killed (rogue class, wrong attribute, unscoped rule, verifier's own mid-selector probe). Doctrine complete and consistent in both homes. Failing-file set identical to baseline; lint/boundaries/check clean. Recorded carry-forward: the pin is studioline-scoped — the MOR-1074 verification must confirm fieldline ships its own copy or the test is generalized (glob-based). Low notes: doctrine equates semantic-vertical root with document root (true until cutover); CSS-only pin (no prop/context write exists in src/ today — verified).

Linear: MOR-1278

🤖 Generated with [Claude Code](https://claude.com/claude-code)