### PR TITLE
feat(MOR-1273): meters semantic surface (vocabulary slice 2B)

### DIFF
--- a/frontend/fixtures/catalog.ts
+++ b/frontend/fixtures/catalog.ts
@@ -100,6 +100,37 @@ function abState(): ServerState {
   } as unknown as ServerState;
 }
 
+/**
+ * MOR-1273 — raw meter samples overlaid on a fixture state so the browser can
+ * see the semantic meters surface. FIXTURE CODE ONLY: no production module
+ * changes, and no capability is added, so
+ *
+ *   - the cockpit gains no new focusable control (the meters surface is a
+ *     readout — R9), and every existing behavior assertion, focus order and
+ *     zone-less-control count is therefore untouched;
+ *   - `compressorOn` is deliberately NOT set and `compressor` stays out of the
+ *     capability list, so the MOR-1244 `txAux` group is still absent. That is
+ *     the browser proof of the COMP gate: a fully-present compression METER
+ *     with the compressor fact unavailable renders NO COMP tile.
+ *
+ * Fixtures WITHOUT this overlay carry no `meters` group at all and so render
+ * no meters surface — the self-gating half, provable in the same capture run.
+ */
+const METER_PATHS = ['powerMeter', 'swrMeter', 'alcMeter', 'compMeter',
+  'vdMeter', 'idMeter', 'main.sMeter', 'sub.sMeter'];
+
+function withMeters(state: ServerState): ServerState {
+  const s = state as unknown as Record<string, unknown>;
+  const rx = (v: unknown, sMeter: number) =>
+    (v === undefined ? v : { ...(v as Record<string, unknown>), sMeter });
+  return {
+    ...s,
+    powerMeter: 120, swrMeter: 30, alcMeter: 40, compMeter: 20, vdMeter: 200, idMeter: 90,
+    main: rx(s.main, -12), sub: rx(s.sub, -30),
+    fieldStatus: { ...(s.fieldStatus as FieldStatusMap), ...statuses(METER_PATHS) },
+  } as unknown as ServerState;
+}
+
 const baseCaps = (): Capabilities => ({
   model: 'fixture', scope: false, audio: true, tx: true,
   capabilities: ['audio', 'tx', 'dual_rx'], receivers: 2, vfoScheme: 'main_sub',
@@ -183,7 +214,7 @@ export const FIXTURES: readonly Fixture[] = [
   {
     id: 'topology-1-single',
     what: '1/single — one receiver, one unslotted VFO; the cockpit degrades to one strip.',
-    state: singleState, caps: singleCaps, tx: tx({}),
+    state: () => withMeters(singleState()), caps: singleCaps, tx: tx({}),
     expect: {
       zones: SINGLE_ZONES, strips: 1, stripReceivers: ['MAIN'],
       stripOperational: [true], stripActive: [true],
@@ -222,7 +253,7 @@ export const FIXTURES: readonly Fixture[] = [
   {
     id: 'topology-2-main-sub',
     what: '2/main_sub — the reference dual state: 4 tiles across 2 strips, MAIN A active.',
-    state: () => mainSubState('MAIN'), caps: mainSubCaps, tx: tx({}),
+    state: () => withMeters(mainSubState('MAIN')), caps: mainSubCaps, tx: tx({}),
     expect: mainSubExpect(),
   },
   {
@@ -248,13 +279,13 @@ export const FIXTURES: readonly Fixture[] = [
   {
     id: 'tx-phase-rx',
     what: 'TX idle — RF receiving, session ready, key enabled, unkey ungated.',
-    state: () => mainSubState('MAIN'), caps: mainSubCaps, tx: tx({}),
+    state: () => withMeters(mainSubState('MAIN')), caps: mainSubCaps, tx: tx({}),
     expect: mainSubExpect(),
   },
   {
     id: 'tx-phase-pending',
     what: 'TX keying in progress — RF uncertain, session pending, key blocked, unkey still live.',
-    state: () => mainSubState('MAIN'), caps: mainSubCaps,
+    state: () => withMeters(mainSubState('MAIN')), caps: mainSubCaps,
     tx: tx({
       phase: 'key-confirm-pending', intent: 'latched', guard: { leaseId: 'L1' },
       radioTx: 'off', txRisk: 'uncertain', mayOwnKey: true,
@@ -264,7 +295,7 @@ export const FIXTURES: readonly Fixture[] = [
   {
     id: 'tx-phase-tx',
     what: 'transmitting — RF TX, session key down, key blocked, unkey the only way out.',
-    state: () => mainSubState('MAIN'), caps: mainSubCaps,
+    state: () => withMeters(mainSubState('MAIN')), caps: mainSubCaps,
     tx: tx({
       phase: 'active', intent: 'latched', guard: { leaseId: 'L1' },
       radioTx: 'on', txRisk: 'confirmed-on', mayOwnKey: true,
@@ -274,7 +305,7 @@ export const FIXTURES: readonly Fixture[] = [
   {
     id: 'tx-phase-fault',
     what: 'TX fault — session fault, fault line shown, the App-owned fault reset affordance renders.',
-    state: () => mainSubState('MAIN'), caps: mainSubCaps,
+    state: () => withMeters(mainSubState('MAIN')), caps: mainSubCaps,
     tx: tx({ phase: 'failed', radioTx: 'unknown', txRisk: 'uncertain', fault: 'audio-failed' }),
     expect: mainSubExpect({
       keyDisabled: true, rfLabel: 'TX?', sessionLabel: 'fault',

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -26,6 +26,7 @@
   import { runtime } from '$lib/runtime';
   import { toRadioViewModel } from '$lib/runtime/adapters/radio-view-model-adapter';
   import { getAppTxController } from '$lib/runtime/tx-controller/app-host';
+  import MetersSurface from '../../semantic/MetersSurface.svelte';
   import type { RadioViewModel } from '../../semantic/radio-view-model';
   import RxTxSurface from '../../semantic/RxTxSurface.svelte';
   import TxAuxSurface, {
@@ -311,6 +312,27 @@
     {/if}
   {/snippet}
 
+  <!--
+    MOR-1273 (vocabulary slice 2B). Same structural gate, same reasoning as
+    `txAuxSurface` above: the surface mounts only when the view model actually
+    carries the MOR-1269 `meters` group, so a radio that reports no meters —
+    or one for which no App TX authority was supplied, and therefore no honest
+    TX relevance could be stated — renders the pre-1273 element shape exactly.
+    Bare and unzoned in BOTH compositions: `'meters'` becomes declarable by a
+    manifest with this slice, but no manifest declares a meters zone, and the
+    zone schema stays config-free (risk R3).
+
+    It takes NO authority snapshot and no intent callbacks. That is the R9
+    boundary made structural: the meters are a readout, their TX truth is
+    already decided inside `view.meters` by the App-owned authority the
+    adapter was handed, and this component has nothing else to give them.
+  -->
+  {#snippet metersSurface()}
+    {#if view?.meters}
+      <MetersSurface {view} />
+    {/if}
+  {/snippet}
+
   {#if strips === 'dual'}
     <!--
       MOR-1258: the zone now carries RxTxSurface AND the two TX-adjacent
@@ -325,6 +347,7 @@
       {@render txAdjacentAlerts()}
     </div>
     {@render txAuxSurface()}
+    {@render metersSurface()}
   {:else}
     <!--
       Single/default path (sdr-test / LCD / mobile): no bound zone exists
@@ -333,6 +356,7 @@
     -->
     {@render rxTxSurface()}
     {@render txAuxSurface()}
+    {@render metersSurface()}
     {@render txAdjacentAlerts()}
   {/if}
 </div>

--- a/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
@@ -1,0 +1,316 @@
+/**
+ * MOR-1273 — the semantic meters surface wired into `SemanticRadioSurfaces`.
+ *
+ * The unit tests in `semantic/__tests__/MetersSurface.test.ts` prove what the
+ * surface does with a view model. This file proves the thing only the composed
+ * tree can prove: WHERE the meters' TX truth comes from.
+ *
+ *   (a) MOR-1235 must stay fixed. The whole chain here is real — the shipped
+ *       `radio-view-model-adapter`, the real `meters` evidence gate, the real
+ *       surface — and only the runtime/authority seams are spies. So the two
+ *       decisive experiments are possible: move the raw transmit wire bit and
+ *       nothing about the meters may change; move the App TX authority and
+ *       everything must.
+ *   (b) The default path must stay byte-identical. `SemanticRadioSurfaces`
+ *       mounts on sdr-test, both LCD layouts, mobile and the cockpit; a radio
+ *       that reports no meters at all must render exactly the element shape it
+ *       renders today.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { ServerState } from '$lib/types/state';
+
+type Snapshot = {
+  phase: string; intent: string | null; guard: { leaseId: string } | null;
+  radioTx: string; txRisk: string; mayOwnKey: boolean; fault: string | null;
+};
+
+const h = vi.hoisted(() => ({
+  state: null as unknown,
+  caps: null as unknown,
+  snapshot: null as unknown,
+  listeners: new Set<(next: unknown) => void>(),
+  start: vi.fn(),
+  release: vi.fn(),
+  noop: vi.fn(),
+}));
+
+vi.mock('$lib/runtime', () => ({
+  runtime: { get state() { return h.state; }, get caps() { return h.caps; } },
+}));
+vi.mock('$lib/runtime/tx-controller/app-host', () => ({
+  getAppTxController: () => ({
+    snapshot: () => h.snapshot,
+    subscribe: (listener: (next: unknown) => void) => {
+      h.listeners.add(listener);
+      return () => { h.listeners.delete(listener); };
+    },
+    start: h.start,
+    setIntent: vi.fn(),
+    release: h.release,
+    resetFault: vi.fn(),
+  }),
+}));
+vi.mock('$lib/runtime/adapters/mod-input-tx-guard.svelte', () => ({
+  deriveModInputTxGuardProps: () => ({ visible: false, sourceLabel: null }),
+  getModInputTxGuardHandlers: () => ({ onSetLan: vi.fn(), onDismiss: vi.fn() }),
+}));
+vi.mock('../command-bus', () => ({
+  makeVfoHandlers: () => ({
+    onVfoSelect: h.noop, onSplitToggle: h.noop, onDualWatchToggle: h.noop,
+  }),
+  makeVoxHandlers: () => ({
+    onVoxToggle: h.noop, onVoxGainChange: h.noop,
+    onAntiVoxGainChange: h.noop, onVoxDelayChange: h.noop,
+  }),
+  makeTxHandlers: () => ({
+    onRfPowerChange: h.noop, onMicGainChange: h.noop, onAtuToggle: h.noop,
+    onAtuTune: h.noop, onVoxToggle: h.noop, onCompToggle: h.noop,
+    onCompLevelChange: h.noop, onMonToggle: h.noop,
+    onMonLevelChange: h.noop, onDriveGainChange: h.noop,
+  }),
+}));
+
+import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';
+
+const IDLE: Snapshot = {
+  phase: 'idle', intent: null, guard: null, radioTx: 'off', txRisk: 'none',
+  mayOwnKey: false, fault: null,
+};
+
+const fresh = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' };
+const slot = (freqHz: number) => ({ freqHz, mode: 'USB', filterNum: 1, dataMode: 0 });
+
+/** Every raw meter the MOR-1269 adapter reads, all observed fresh. The
+ *  compressor is ON so the txAux-gated COMP tile is reachable. */
+const METER_STATE = {
+  powerMeter: 120, swrMeter: 30, alcMeter: 40, compMeter: 20,
+  vdMeter: 200, idMeter: 90, compressorOn: true, compressorLevel: 40,
+} as const;
+const METER_PATHS = [
+  'powerMeter', 'swrMeter', 'alcMeter', 'compMeter', 'vdMeter', 'idMeter',
+  'main.sMeter', 'sub.sMeter', 'compressorOn', 'compressorLevel',
+];
+
+function liveState(withMeters: boolean, over: Partial<ServerState> = {}): ServerState {
+  const paths = ['active', 'split', 'dualWatch', 'txTarget'];
+  for (const rx of ['main', 'sub']) {
+    paths.push(`${rx}.freqHz`, `${rx}.mode`, `${rx}.filter`, `${rx}.activeSlot`);
+    for (const v of ['vfoA', 'vfoB']) {
+      paths.push(`${rx}.${v}.freqHz`, `${rx}.${v}.mode`, `${rx}.${v}.filterNum`);
+    }
+  }
+  if (withMeters) paths.push(...METER_PATHS);
+  const receiver = (hz: number) => ({
+    ...slot(hz), vfoA: slot(hz), vfoB: slot(hz + 50000), activeSlot: 'A', filter: 1,
+    ...(withMeters ? { sMeter: -12 } : {}),
+  });
+  return {
+    active: 'MAIN', split: false, dualWatch: false, ptt: false,
+    txTarget: { status: 'known', receiver: 'MAIN', slot: 'A', frequencyHz: 14250000 },
+    main: receiver(14250000), sub: receiver(14300000),
+    ...(withMeters ? METER_STATE : {}),
+    ...over,
+    fieldStatus: Object.fromEntries(paths.map((p) => [p, fresh])),
+  } as unknown as ServerState;
+}
+
+const liveCaps = (withMeters: boolean): Capabilities => ({
+  model: 'fixture', scope: false, audio: true, tx: true,
+  capabilities: withMeters
+    ? ['audio', 'tx', 'dual_rx', 'compressor']
+    : ['audio', 'tx', 'dual_rx'],
+  receivers: 2, vfoScheme: 'main_sub', freqRanges: [], modes: [], filters: [],
+  audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
+  webrtc: { available: false, enabled: false },
+  txBands: [{ start: 14000000, end: 14350000, name: '20m' }],
+  scopeSource: null, audioFftAvailable: false,
+} as unknown as Capabilities);
+
+let target: HTMLDivElement;
+let component: ReturnType<typeof mount> | null = null;
+
+function render(props: { strips?: 'single' | 'dual' } = {}): void {
+  target = document.createElement('div');
+  document.body.appendChild(target);
+  component = mount(SemanticRadioSurfaces, { target, props });
+  flushSync();
+}
+
+function push(next: Partial<Snapshot>): void {
+  h.snapshot = { ...(h.snapshot as Snapshot), ...next };
+  for (const listener of h.listeners) listener(h.snapshot);
+  flushSync();
+}
+
+const q = <T extends HTMLElement>(sel: string) => target.querySelector(sel) as T | null;
+const rfState = (): string | undefined => q('[data-testid="meters-surface"]')!.dataset.rfState;
+/** `data-meter -> data-relevant` for every rendered tile. */
+const relevance = (): Record<string, string> => Object.fromEntries(
+  [...target.querySelectorAll<HTMLElement>('[data-meter-tile]')]
+    .map((el) => [el.dataset.meter!, el.dataset.relevant!]),
+);
+
+beforeEach(() => {
+  h.state = liveState(true);
+  h.caps = liveCaps(true);
+  h.snapshot = { ...IDLE };
+  h.listeners.clear();
+  h.start.mockReset();
+  h.release.mockReset();
+  h.noop.mockReset();
+});
+
+afterEach(() => {
+  if (component) unmount(component);
+  component = null;
+  document.body.innerHTML = '';
+});
+
+// ── 1. The structural gate: absent group ⇒ no surface, no element drift ────
+
+describe('the meters surface mounts only when the view model carries the group', () => {
+  /**
+   * The element shape of the default (single) path, as a LITERAL — the same
+   * probe MOR-1265 introduced, re-pinned here.
+   *
+   * MUTATION KILLED: mounting `MetersSurface` unconditionally (dropping the
+   * `{#if view.meters}` structural gate), or wrapping it in a shell every path
+   * renders — either changes this sequence for a radio whose MOR-1269 evidence
+   * gate declined the group.
+   */
+  const DEFAULT_PATH_TESTIDS = [
+    'vfo-surface', 'vfo-active-receiver', 'vfo-list',
+    'rx-tx-surface', 'rx-tx-state', 'rx-tx-rf-mark', 'rx-tx-rf-label',
+    'rx-tx-target', 'rx-tx-key', 'rx-tx-unkey', 'rx-tx-blocked',
+  ];
+  const testids = () => [...target.querySelectorAll<HTMLElement>('[data-testid]')]
+    .map((el) => el.dataset.testid!)
+    .filter((id) => id !== 'semantic-radio-surfaces');
+
+  it.each(['single', 'dual'] as const)('renders no meters surface at all without the group (%s)', (strips) => {
+    h.state = liveState(false);
+    h.caps = liveCaps(false);
+    render({ strips });
+    expect(q('[data-testid="meters-surface"]')).toBeNull();
+    expect(target.innerHTML).not.toContain('data-meter-tile');
+  });
+
+  it('leaves the default path element sequence exactly as it is today', () => {
+    h.state = liveState(false);
+    h.caps = liveCaps(false);
+    render();
+    expect(testids()).toEqual(DEFAULT_PATH_TESTIDS);
+  });
+
+  it.each(['single', 'dual'] as const)('mounts the meters surface when the group is present (%s)', (strips) => {
+    render({ strips });
+    expect(target.querySelectorAll('[data-testid="meters-surface"]')).toHaveLength(1);
+    expect(Object.keys(relevance())).toContain('power');
+  });
+
+  // MUTATION KILLED: giving the meters surface a `data-zone-id`. `meters` is
+  // declarable after this slice, but no manifest declares a meters zone — and
+  // the zone schema stays config-free (risk R3).
+  it('binds no zone id to the meters surface in either composition', () => {
+    render({ strips: 'dual' });
+    const zones = [...target.querySelectorAll<HTMLElement>('[data-zone-id]')]
+      .map((el) => el.dataset.zoneId);
+    expect(zones).toEqual(['primary-vfo', 'secondary-vfo', 'global', 'rx-tx']);
+    expect(q('[data-testid="meters-surface"]')!.closest('[data-zone-id]')).toBeNull();
+  });
+});
+
+// ── 2. Carry-forward (1): TX truth comes from the App authority, not ptt ──
+
+describe('meter TX relevance follows the App TX authority and nothing else', () => {
+  // MUTATION KILLED: reading the raw transmit wire bit anywhere on this path
+  // (`state.ptt`) — the MOR-1235 disagreement. The bit is flipped to `true`
+  // here while the App authority stays idle; the meters must not notice.
+  it('ignores the raw transmit wire bit entirely', () => {
+    render();
+    const before = { rf: rfState(), tiles: relevance() };
+    h.state = liveState(true, { ptt: true } as Partial<ServerState>);
+    push({});
+    expect(rfState()).toBe(before.rf);
+    expect(rfState()).toBe('receiving');
+    expect(relevance()).toEqual(before.tiles);
+  });
+
+  // MUTATION KILLED: any second derivation — a surface that computed relevance
+  // itself would not move when the ONLY thing that changed is the authority.
+  it('flips every TX-gated meter when the App authority says the radio is transmitting', () => {
+    render();
+    expect(rfState()).toBe('receiving');
+    const rx = relevance();
+    expect(rx.signal).toBe('true');
+    expect(rx.power).toBe('false');
+
+    push({ radioTx: 'on', txRisk: 'confirmed-on', phase: 'active', mayOwnKey: true });
+    expect(rfState()).toBe('transmitting');
+    const tx = relevance();
+    expect(tx.signal).toBe('false');
+    for (const field of ['power', 'swr', 'alc', 'drainCurrent', 'compression']) {
+      expect(tx[field]).toBe('true');
+    }
+    // Vd is the station supply rail, relevant in every RF state.
+    expect(tx.drainVoltage).toBe('true');
+  });
+
+  // MUTATION KILLED: collapsing 'uncertain' onto 'receiving' — the boolean
+  // `txActive` shape the shipped v2 dock uses, and the reason MOR-1235 could
+  // hide. An uncertain transmitter must not read as RX.
+  it('renders an uncertain transmitter as uncertain, never as receiving', () => {
+    render();
+    push({ txRisk: 'uncertain' });
+    expect(rfState()).toBe('uncertain');
+    expect(relevance().power).toBe('true');
+  });
+});
+
+// ── 3. Carry-forward (4): the cold-start unknown window ──────────────────
+
+describe('the cold-start window renders fail-closed', () => {
+  // MUTATION KILLED: defaulting an unknown authority to 'receiving' (RX
+  // styling on a radio that may be keyed), or suppressing the surface until
+  // the authority speaks (a flash of nothing, then a reflow).
+  it('renders the surface with rfState unknown before the authority has spoken', () => {
+    h.snapshot = { ...IDLE, radioTx: 'unknown' };
+    render();
+    expect(q('[data-testid="meters-surface"]')).not.toBeNull();
+    expect(rfState()).toBe('unknown');
+    expect(Object.keys(relevance()).length).toBeGreaterThan(0);
+  });
+
+  // The adapter emits NO meters group without a TX authority snapshot, so the
+  // "no honest relevance can be stated" case is absence, not a guess.
+  it('never renders RX styling while the RF state is unknown', () => {
+    h.snapshot = { ...IDLE, radioTx: 'unknown' };
+    render();
+    expect(target.innerHTML).not.toContain('data-rf-state="receiving"');
+  });
+});
+
+// ── 4. R9: the meters surface is a readout, never an action path ─────────
+
+describe('the meters surface adds no control and no TX path', () => {
+  it('keeps exactly one key/unkey authority in the composed tree', () => {
+    render();
+    expect(target.querySelectorAll('[data-testid="rx-tx-surface"]')).toHaveLength(1);
+    expect(target.querySelectorAll('[data-testid="rx-tx-key"]')).toHaveLength(1);
+    expect(target.querySelectorAll('[data-testid="rx-tx-unkey"]')).toHaveLength(1);
+  });
+
+  // MUTATION KILLED: a meters surface that grew a peak-reset / source-select
+  // control. Zero controls also keeps the cockpit's focus order and its
+  // zone-less-control count exactly as MOR-1069/1070 pinned them.
+  it('contributes no focusable control to the composition', () => {
+    render({ strips: 'dual' });
+    const surface = q('[data-testid="meters-surface"]')!;
+    expect(surface.querySelectorAll('button, input, select, a[href], [tabindex]'))
+      .toHaveLength(0);
+    expect(h.start).not.toHaveBeenCalled();
+    expect(h.release).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/presentation/layouts/__tests__/meters-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/meters-declarability.test.ts
@@ -1,0 +1,69 @@
+/**
+ * MOR-1273 — `meters` is DECLARABLE, and nothing declares it yet.
+ *
+ * Slice 2B adds the name to `SEMANTIC_SURFACE_NAMES` so a manifest CAN mount
+ * the surface later; it deliberately does not touch any manifest, and it does
+ * not add a renderer slot — a design language draws a meter through the
+ * `'meters'` slot `RENDERER_SLOT_NAMES` has carried since MOR-1072 (risk R2:
+ * adding a slot would be a language-contract change this slice must not make).
+ *
+ * The three pins mirror `tx-aux-declarability.test.ts`:
+ *   - drop the name and a future manifest's zone stops validating;
+ *   - quietly add a `meters` zone to a shipped manifest and the DOM grows a
+ *     zone id no layout review ever saw;
+ *   - the renderer slot stays exactly the set MOR-1072 froze.
+ */
+import { describe, it, expect } from 'vitest';
+import { SEMANTIC_SURFACE_NAMES, validateLayoutManifest } from '../contract';
+import { RENDERER_SLOT_NAMES } from '../../languages/contract';
+import { validLayoutManifest } from './fixtures';
+import {
+  desktopV2Layout, dualReceiverCockpitLayout, lcdCockpitLayout, lcdScopeLayout, mobileLayout,
+  sdrTestLayout,
+} from '../declarations';
+
+describe('meters is a declarable semantic surface', () => {
+  // Kills: reverting the SEMANTIC_SURFACE_NAMES addition.
+  it('is in the declarable set alongside vfo, rxTx and txAux', () => {
+    expect([...SEMANTIC_SURFACE_NAMES]).toEqual(['vfo', 'rxTx', 'txAux', 'meters']);
+  });
+
+  // Kills: adding the name to the type but not to the runtime allow-list the
+  // zone validator checks — the manifest would still be rejected.
+  it('accepts a manifest zone that declares it', () => {
+    const manifest = validLayoutManifest({
+      zones: [{ id: 'main', surfaces: ['vfo', 'rxTx', 'meters'] }],
+      requiredSemanticSurfaces: ['vfo', 'rxTx'],
+    });
+    expect(() => validateLayoutManifest(manifest)).not.toThrow();
+  });
+
+  it('still rejects a zone naming a surface that does not exist', () => {
+    const manifest = validLayoutManifest({
+      zones: [{ id: 'main', surfaces: ['meterDock'] as unknown as readonly ['vfo'] }],
+    });
+    expect(() => validateLayoutManifest(manifest)).toThrow(/subset of/);
+  });
+});
+
+describe('no shipped manifest declares a meters zone in this slice', () => {
+  // Kills: slipping a meters zone into an existing layout here. Declarability
+  // is the whole scope of the contract touch; placing the surface in a real
+  // layout is a later, separately reviewed slice.
+  it.each([
+    ['sdr-test', sdrTestLayout], ['dual-receiver-cockpit', dualReceiverCockpitLayout],
+    ['lcd-cockpit', lcdCockpitLayout], ['lcd-scope', lcdScopeLayout],
+    ['mobile', mobileLayout], ['desktop-v2', desktopV2Layout],
+  ])('%s declares no meters zone and does not require the surface', (_id, manifest) => {
+    for (const zone of manifest.zones) expect(zone.surfaces).not.toContain('meters');
+    expect(manifest.requiredSemanticSurfaces).not.toContain('meters');
+  });
+});
+
+describe('the design-language renderer slot set is untouched (risk R2)', () => {
+  // Kills: adding a renderer slot for this surface. `'meters'` already exists;
+  // a language that draws meters goes through it and through `projection.ts`.
+  it('still carries exactly the three MOR-1072 slots, meters among them', () => {
+    expect([...RENDERER_SLOT_NAMES]).toEqual(['meters', 'frequencyDisplay', 'stateFeedback']);
+  });
+});

--- a/frontend/src/presentation/layouts/__tests__/tx-aux-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/tx-aux-declarability.test.ts
@@ -19,9 +19,10 @@ import {
 } from '../declarations';
 
 describe('txAux is a declarable semantic surface', () => {
-  // Kills: reverting the SEMANTIC_SURFACE_NAMES addition.
+  // Kills: reverting the SEMANTIC_SURFACE_NAMES addition. MOR-1273 appended
+  // `meters`; `txAux` must stay present and in place.
   it('is in the declarable set alongside vfo and rxTx', () => {
-    expect([...SEMANTIC_SURFACE_NAMES]).toEqual(['vfo', 'rxTx', 'txAux']);
+    expect([...SEMANTIC_SURFACE_NAMES]).toEqual(['vfo', 'rxTx', 'txAux', 'meters']);
   });
 
   // Kills: adding the name to the type but not to the runtime allow-list the

--- a/frontend/src/presentation/layouts/contract.ts
+++ b/frontend/src/presentation/layouts/contract.ts
@@ -13,9 +13,13 @@ import type { Component } from 'svelte';
 import { isValidLanguageId as isValidProductId } from '../languages/contract';
 
 /** Semantic surfaces a layout may mount (MOR-1062/1065 reference vertical;
- *  `txAux` added by MOR-1265). Adding a name makes it DECLARABLE — it does
- *  not mount anything, and no manifest declares a `txAux` zone yet. */
-export const SEMANTIC_SURFACE_NAMES = ['vfo', 'rxTx', 'txAux'] as const;
+ *  `txAux` added by MOR-1265, `meters` by MOR-1273). Adding a name makes it
+ *  DECLARABLE — it does not mount anything, and no manifest declares a
+ *  `txAux` or `meters` zone yet. Distinct from the design-language renderer
+ *  slot of the same name (`languages/contract.ts`'s `RENDERER_SLOT_NAMES`):
+ *  that one says how a language DRAWS a meter, this one says which layout
+ *  zone may HOST the surface. */
+export const SEMANTIC_SURFACE_NAMES = ['vfo', 'rxTx', 'txAux', 'meters'] as const;
 export type SemanticSurfaceName = (typeof SEMANTIC_SURFACE_NAMES)[number];
 
 /**

--- a/frontend/src/semantic/MetersSurface.svelte
+++ b/frontend/src/semantic/MetersSurface.svelte
@@ -1,0 +1,152 @@
+<!--
+  Semantic meters surface (MOR-1273, vocabulary slice 2B).
+
+  Presentation only. It renders the MOR-1269 `meters` fact group — S / Po /
+  SWR / ALC / COMP / Vd / Id — as SVG gauges. It holds no state, consults no
+  controller and emits no intent (v3 ADR invariant 11): a meter is a readout,
+  never an action surface.
+
+  SAFETY (R9). Three rules govern this file:
+
+  (1) TX truth arrives ALREADY DECIDED. `meters.rfState` and each field's
+      `relevant` flag come from the App-owned TX authority via the adapter's
+      evidence gate; this surface displays that conclusion and computes no
+      second one. Deriving relevance from the raw transmit wire bit is the
+      open disagreement MOR-1235 reported and MOR-1269 closed — the single
+      `view` prop below is the whole reason it cannot come back here.
+  (2) The RF word and its mark are the SHARED `RF_LABEL` / `RF_MARK` maps that
+      spell the RX/TX surface's own state, imported rather than copied. A copy
+      could drift and tell the operator "RX" beside a key button reading "TX".
+      They are text AND shape, so the state survives forced-colors (MOR-977).
+  (3) An unobserved meter renders as an explicit `?`, never as a gauge at
+      zero. "0 W into the antenna" and "not measured" are different claims.
+
+  Two-level availability (MOR-977/1256): `structural: false` renders NOTHING —
+  "this radio has no SWR meter" is a different claim from "the SWR meter is
+  unreadable right now", which renders present-but-unobserved. An irrelevant
+  meter is DIMMED rather than hidden, so the dock geometry does not reflow
+  under the operator at the moment they key up (MOR-485).
+
+  BALLISTICS ARE NOT HERE. Smoothing and peak-hold — and, with them, the
+  `prefers-reduced-motion` behaviour of MOR-1233/1249/1252 — belong to the
+  shipped SVG components this file composes (`LinearSMeter`, `BarGauge`), both
+  driving `$lib/utils/smoothing.svelte`'s `createSmoother`, which snaps to
+  target instead of animating under `reduce`. A loop here would be a second,
+  unaudited one. This surface's own styles carry structure only: no colour, no
+  transition, so a reduced-motion cockpit page stays provably still.
+-->
+<script module lang="ts">
+  import type { MeterField, MetersViewModel } from './radio-view-model';
+  import {
+    alcLevel, compLevel, formatAlc, formatAmps, formatCompDb, formatPowerWatts,
+    formatSwr, formatVolts, idLevel, normalizePower, swrLevel, vdLevel,
+  } from '../components-v2/panels/meter-utils';
+
+  type BarKey = Exclude<keyof MetersViewModel, 'rfState' | 'signal'>;
+  type Scale = readonly [BarKey, string, (raw: number) => number, (raw: number) => string];
+
+  /** `[field, label, level, format]` for the six bar meters, in the shipped
+   *  dock's priority order. The level/format pairs are `meter-utils`' own
+   *  calibrated functions — the same ones `MetersDockPanel` uses — so the two
+   *  can never disagree about what a raw sample means. `signal` is absent
+   *  because it has its own component (`LinearSMeter`, below). */
+  export const METER_BARS = [
+    ['power', 'Po', normalizePower, formatPowerWatts],
+    ['swr', 'SWR', swrLevel, formatSwr],
+    ['alc', 'ALC', alcLevel, formatAlc],
+    ['drainCurrent', 'Id', idLevel, formatAmps],
+    ['drainVoltage', 'Vd', vdLevel, formatVolts],
+    ['compression', 'COMP', compLevel, formatCompDb],
+  ] as const satisfies readonly Scale[];
+
+  /** Level 1 — does this radio HAVE the meter at all. */
+  const present = (f: MeterField): boolean => f.availability.structural;
+  /** Level 2 — is it readable now AND actually read. */
+  const observed = (f: MeterField): boolean =>
+    f.availability.operational && f.reading.status === 'known';
+  const rawOf = (f: MeterField): number => (f.reading.status === 'known' ? f.reading.value : 0);
+</script>
+
+<script lang="ts">
+  import BarGauge from '../components-v2/meters/BarGauge.svelte';
+  import LinearSMeter from '../components-v2/meters/LinearSMeter.svelte';
+  import type { RadioViewModel } from './radio-view-model';
+  import { RF_LABEL, RF_MARK } from './rx-tx-surface';
+
+  interface Props { view: RadioViewModel }
+  let { view }: Props = $props();
+
+  /** Absent group ⇒ this surface renders nothing (S0 optional-group doctrine,
+   *  risk R3): a radio that reports no meters gets no empty dock, and no zone
+   *  schema had to learn about it. */
+  let meters = $derived(view.meters);
+
+  /** The COMP gate is the MOR-1244 `txAux.compressor` FACT, deliberately NOT
+   *  `meters.compression.availability`: a radio can keep reporting a
+   *  compression meter while the compressor is switched off, and that reading
+   *  measures nothing. Fail-closed — an unobserved compressor, or a radio with
+   *  no txAux group at all, never opens the gate. */
+  let compressorOn = $derived(
+    view.txAux?.compressor.reading.status === 'known'
+      && view.txAux.compressor.reading.value === true,
+  );
+</script>
+
+{#if meters}
+  <section
+    class="meters-surface" data-testid="meters-surface"
+    data-rf-state={meters.rfState} aria-label="Station meters"
+  >
+    <p class="meters-rf" data-testid="meters-rf">
+      <span data-testid="meters-rf-mark">{RF_MARK[meters.rfState]}</span>
+      <span data-testid="meters-rf-label">{RF_LABEL[meters.rfState]}</span>
+    </p>
+
+    {#if present(meters.signal)}
+      <div
+        class="meter-tile" data-meter-tile data-meter="signal" data-testid="meter-signal"
+        data-relevant={meters.signal.relevant} data-observed={observed(meters.signal)}
+        role="group" aria-label="S meter"
+      >
+        {#if observed(meters.signal)}
+          <LinearSMeter value={rawOf(meters.signal)} label="S" compact />
+        {:else}
+          <span class="meter-unknown">S ?</span>
+        {/if}
+      </div>
+    {/if}
+
+    {#each METER_BARS as [field, label, level, format] (field)}
+      {#if present(meters[field]) && (field !== 'compression' || compressorOn)}
+        <div
+          class="meter-tile" data-meter-tile data-meter={field} data-testid={`meter-${field}`}
+          data-relevant={meters[field].relevant} data-observed={observed(meters[field])}
+          role="group" aria-label={`${label} meter`}
+        >
+          {#if observed(meters[field])}
+            <BarGauge
+              value={level(rawOf(meters[field]))} {label}
+              displayValue={format(rawOf(meters[field]))} compact
+            />
+          {:else}
+            <span class="meter-unknown">{label} ?</span>
+          {/if}
+        </div>
+      {/if}
+    {/each}
+  </section>
+{/if}
+
+<style>
+  /* Structure only — a design language owns the palette and must never become
+     the sole state channel (MOR-977). Nothing here moves: the gauges own their
+     own ballistics and honour reduced motion themselves. */
+  .meters-surface { display: flex; flex-direction: column; gap: 0.25rem; }
+  .meters-rf { display: flex; align-items: baseline; gap: 0.4ch; margin: 0; font-weight: 700; }
+  .meter-tile { display: block; }
+  /* Dim, never hide: an irrelevant meter keeps its box so the dock cannot
+     reflow across an RX/TX transition. Opacity survives forced-colors, and it
+     is a second channel beside `data-relevant`, never the only one. */
+  .meter-tile[data-relevant='false'] { opacity: 0.4; }
+  .meter-unknown { font-weight: 700; }
+</style>

--- a/frontend/src/semantic/__tests__/MetersSurface.test.ts
+++ b/frontend/src/semantic/__tests__/MetersSurface.test.ts
@@ -1,0 +1,463 @@
+/**
+ * MOR-1273 — the semantic meters surface (vocabulary slice 2B).
+ *
+ * SAFETY-ADJACENT. The meters are the operator's only continuous read of what
+ * the transmitter is actually doing, so every test below names the mutation it
+ * kills. The four BINDING carry-forwards from the slice-2A verification each
+ * get their own discriminating test:
+ *
+ *  (1) MOR-1235 must not come back. TX relevance reaches this surface through
+ *      the fact layer (`meters.rfState` / `meters.<field>.relevant`) and
+ *      NOWHERE else — this component has no access to `radioState.ptt`, no TX
+ *      authority prop, and no second derivation. See `describe` block 5.
+ *  (2) The COMP tile is gated on the MOR-1244 `txAux.compressor` FACT, not on
+ *      `meters.compression.availability` — a radio can report a compression
+ *      meter while the compressor is off, and a COMP reading with the
+ *      compressor off is meaningless. Block 4.
+ *  (3) `relevant` is CONSUMED, never recomputed. Block 3 feeds deliberately
+ *      self-inconsistent facts (an rfState that disagrees with `relevant`) so
+ *      any re-derivation from `rfState` shows up as a red test.
+ *  (4) The cold-start `unknown` window renders sanely and fail-closed: no
+ *      flicker to RX styling while the authority has not spoken. Block 6.
+ *
+ * Presentation-only (v3 ADR invariant 11 / R9): this surface renders no
+ * control of any kind and decides no TX state. Block 1.
+ */
+import { readFileSync } from 'node:fs';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import MetersSurface, { METER_BARS } from '../MetersSurface.svelte';
+import { topologyFixtures, withMeters, withTxAux } from '../fixtures/topologies';
+import type {
+  Availability, MeterField, MeterRfState, MetersViewModel, RadioViewModel,
+} from '../radio-view-model';
+import { RF_LABEL, RF_MARK } from '../rx-tx-surface';
+
+/** Source scans below run over the CODE, with comments stripped — the same
+ *  instrument (and the same reason) as `TxAuxSurface.test.ts`: a behavioural
+ *  test cannot prove the ABSENCE of an input the component could reach for. */
+const SOURCE = readFileSync('src/semantic/MetersSurface.svelte', 'utf8')
+  .replace(/<!--[\s\S]*?-->/g, '')
+  .replace(/\/\*[\s\S]*?\*\//g, '')
+  .replace(/^\s*\/\/.*$/gm, '');
+
+const AVAIL: Availability = { structural: true, operational: true };
+const RF_STATES: readonly MeterRfState[] = ['receiving', 'transmitting', 'uncertain', 'unknown'];
+
+/** Every meter field this surface can render, S first. */
+type MeterKey = Exclude<keyof MetersViewModel, 'rfState'>;
+const BAR_KEYS = METER_BARS.map(([field]) => field);
+const ALL_KEYS: readonly MeterKey[] = ['signal', ...BAR_KEYS] as readonly MeterKey[];
+
+/** `1/single` + a fully-observed meters group + a fully-observed txAux group,
+ *  with the compressor ON so the COMP tile is reachable by default. */
+function base(rfState: MeterRfState = 'receiving'): RadioViewModel {
+  const view = withMeters(withTxAux(topologyFixtures['1/single']), rfState);
+  return compressor(view, true);
+}
+
+/** Re-shape ONE meter field of an otherwise fully-available fixture. */
+function withField(
+  view: RadioViewModel, field: MeterKey,
+  over: { availability?: Availability; unknown?: boolean; relevant?: boolean },
+): RadioViewModel {
+  const meters = view.meters!;
+  const current: MeterField = meters[field];
+  return {
+    ...view,
+    meters: {
+      ...meters,
+      [field]: {
+        reading: over.unknown ? { status: 'unknown' } : current.reading,
+        availability: over.availability ?? current.availability,
+        relevant: over.relevant ?? current.relevant,
+      } satisfies MeterField,
+    } as MetersViewModel,
+  };
+}
+
+/** Sets the MOR-1244 `txAux.compressor` fact, or drops the whole group. */
+function compressor(view: RadioViewModel, value: boolean | 'unknown' | 'no-group'): RadioViewModel {
+  if (value === 'no-group') {
+    const { txAux: _dropped, ...rest } = view;
+    return rest as RadioViewModel;
+  }
+  return {
+    ...view,
+    txAux: {
+      ...view.txAux!,
+      compressor: {
+        reading: value === 'unknown' ? { status: 'unknown' } : { status: 'known', value },
+        availability: AVAIL,
+      },
+    },
+  };
+}
+
+let target: HTMLDivElement;
+beforeEach(() => { target = document.createElement('div'); document.body.appendChild(target); });
+afterEach(() => { target.remove(); });
+
+function render(view: RadioViewModel) {
+  const component = mount(MetersSurface, { target, props: { view } });
+  flushSync();
+  const q = <T extends HTMLElement>(sel: string) => target.querySelector(sel) as T | null;
+  return {
+    dispose: () => unmount(component),
+    root: () => q('[data-testid="meters-surface"]'),
+    tile: (field: string) => q<HTMLElement>(`[data-testid="meter-${field}"]`),
+    tiles: () => [...target.querySelectorAll<HTMLElement>('[data-meter-tile]')]
+      .map((el) => el.dataset.meter!),
+    rfLabel: () => q('[data-testid="meters-rf-label"]')?.textContent?.trim() ?? null,
+    rfMark: () => q('[data-testid="meters-rf-mark"]')?.textContent?.trim() ?? null,
+  };
+}
+
+function withSurface(view: RadioViewModel, fn: (s: ReturnType<typeof render>) => void): void {
+  const s = render(view);
+  try { fn(s); } finally { s.dispose(); }
+}
+
+// ── 1. Display only (R9) + optional-group self-gating (risk R3) ────────────
+
+describe('the meters surface is display-only and self-gates on group presence', () => {
+  // MUTATION KILLED: rendering a placeholder / empty dock for a radio the
+  // MOR-1269 evidence gate declined. Absent group means absent surface — the
+  // S0 optional-group doctrine, same as TxAuxSurface's structural mount gate.
+  it('renders NOTHING at all when the view model carries no meters group', () => {
+    const bare = topologyFixtures['1/single'];
+    expect(bare.meters).toBeUndefined();
+    withSurface(bare, (s) => {
+      expect(s.root()).toBeNull();
+      expect(target.innerHTML).not.toContain('meter');
+    });
+  });
+
+  it('renders the surface when the group is present', () => {
+    withSurface(base(), (s) => {
+      expect(s.root()).not.toBeNull();
+      expect(target.querySelectorAll('[data-testid="meters-surface"]')).toHaveLength(1);
+    });
+  });
+
+  // MUTATION KILLED: growing a reset/peak-clear/source-select control. R9 —
+  // this surface displays; it never becomes an action surface, and it can
+  // never become a TX path.
+  it('renders no interactive control of any kind', () => {
+    withSurface(base('transmitting'), () => {
+      expect(target.querySelectorAll(
+        'button, input, select, textarea, a[href], [tabindex], [role="button"], [role="switch"]',
+      )).toHaveLength(0);
+    });
+  });
+
+  // MUTATION KILLED: adding a `data-zone-id` here. `meters` is declarable as a
+  // semantic surface after this slice, but no manifest declares a meters zone
+  // — binding one would put a zone id in the DOM no layout asked for
+  // (the MOR-1069 lesson, carried forward from MOR-1265).
+  it('binds no zone id', () => {
+    withSurface(base(), () => {
+      expect(target.querySelectorAll('[data-zone-id]')).toHaveLength(0);
+    });
+  });
+});
+
+// ── 2. Two-level availability (MOR-977/1256) ──────────────────────────────
+
+describe('structural availability decides whether a meter EXISTS', () => {
+  // MUTATION KILLED: rendering a structurally-absent meter as an empty or
+  // dimmed tile. "This radio has no SWR meter" and "the SWR meter is
+  // unreadable right now" are different claims and render differently.
+  it.each(ALL_KEYS)('renders no tile at all for a structurally absent "%s"', (field) => {
+    const view = withField(base(), field, {
+      availability: { structural: false, operational: false },
+    });
+    withSurface(view, (s) => {
+      expect(s.tile(field)).toBeNull();
+      expect(s.tiles()).not.toContain(field);
+    });
+  });
+
+  it('renders every structurally present meter of a fully-observed radio', () => {
+    withSurface(base(), (s) => {
+      expect(s.tiles()).toEqual([...ALL_KEYS]);
+    });
+  });
+
+  // MUTATION KILLED: hiding an unobserved meter (a reflow on every dropout) or
+  // — far worse — drawing its gauge at zero, which reads as "0 W into the
+  // antenna" when the truth is "not measured".
+  it.each(ALL_KEYS)('keeps an operationally-unavailable "%s" PRESENT and marked unobserved', (field) => {
+    const view = withField(base(), field, {
+      availability: { structural: true, operational: false },
+    });
+    withSurface(view, (s) => {
+      const tile = s.tile(field)!;
+      expect(tile).not.toBeNull();
+      expect(tile.dataset.observed).toBe('false');
+      expect(tile.querySelector('svg')).toBeNull();
+      expect(tile.textContent).toContain('?');
+    });
+  });
+
+  it.each(ALL_KEYS)('never draws a gauge for an unobserved "%s" reading', (field) => {
+    withSurface(withField(base(), field, { unknown: true }), (s) => {
+      const tile = s.tile(field)!;
+      expect(tile.dataset.observed).toBe('false');
+      expect(tile.querySelector('svg')).toBeNull();
+    });
+  });
+
+  it('draws an SVG gauge for every observed meter', () => {
+    withSurface(base('transmitting'), (s) => {
+      for (const field of ALL_KEYS) {
+        expect(s.tile(field)!.querySelector('svg')).not.toBeNull();
+      }
+    });
+  });
+});
+
+// ── 3. Carry-forward (3): `relevant` is CONSUMED, never re-derived ─────────
+
+describe('relevance is read from the facts, not recomputed', () => {
+  /**
+   * The discriminating fixtures: `rfState` and `relevant` are made to
+   * DISAGREE. Any surface that recomputes relevance from `rfState` (the
+   * obvious "TX meters matter on TX" shortcut) produces the opposite answer
+   * on every row below; a surface that reads the fact produces `relevant`.
+   */
+  it.each([
+    ['receiving', 'power', true],
+    ['receiving', 'swr', true],
+    ['transmitting', 'signal', true],
+    ['transmitting', 'power', false],
+    ['unknown', 'drainVoltage', true],
+    ['uncertain', 'alc', false],
+  ] as const)('rfState=%s: renders "%s" with the fact\'s own relevant=%s', (rf, field, relevant) => {
+    const view = withField(base(rf), field, { relevant });
+    withSurface(view, (s) => {
+      expect(s.tile(field)!.dataset.relevant).toBe(String(relevant));
+    });
+  });
+
+  // MUTATION KILLED: `relevant = rfState !== 'receiving'` (or any variant of
+  // it) computed in the surface. Every TX-gated meter is marked NOT relevant
+  // here even though the radio is transmitting, because that is what the fact
+  // layer said — the surface has no standing to overrule it.
+  it('marks every meter irrelevant while transmitting when the facts say so', () => {
+    let view = base('transmitting');
+    for (const field of ALL_KEYS) view = withField(view, field, { relevant: false });
+    withSurface(view, (s) => {
+      for (const field of ALL_KEYS) {
+        expect(s.tile(field)!.dataset.relevant).toBe('false');
+      }
+    });
+  });
+
+  // MUTATION KILLED: hiding irrelevant meters. Dimming keeps the dock's
+  // geometry stable across an RX<->TX transition (MOR-485); hiding reflows the
+  // layout under the operator's eyes at the exact moment they key up.
+  it('dims rather than hides an irrelevant meter', () => {
+    const view = withField(base(), 'power', { relevant: false });
+    withSurface(view, (s) => {
+      expect(s.tile('power')).not.toBeNull();
+      expect(s.tile('power')!.dataset.relevant).toBe('false');
+    });
+  });
+});
+
+// ── 4. Carry-forward (2): the COMP tile is gated on txAux.compressor ───────
+
+describe('the COMP tile is gated on the txAux compressor fact', () => {
+  /** The compression METER is fully present and observed in every case here —
+   *  so anything that gates on `meters.compression.availability` renders the
+   *  tile in all four, and only the txAux-gated surface passes. */
+  it('renders COMP when the compressor fact says it is ON', () => {
+    withSurface(compressor(base(), true), (s) => {
+      expect(s.tile('compression')).not.toBeNull();
+    });
+  });
+
+  // MUTATION KILLED: `if (meters.compression.availability.structural)` — the
+  // gate slice 2A explicitly refused. A COMP reading with the compressor off
+  // is not a measurement of anything.
+  it('renders no COMP tile when the compressor fact says it is OFF', () => {
+    const view = compressor(base(), false);
+    expect(view.meters!.compression.availability).toEqual(AVAIL);
+    withSurface(view, (s) => {
+      expect(s.tile('compression')).toBeNull();
+      expect(s.tiles()).not.toContain('compression');
+    });
+  });
+
+  // MUTATION KILLED: treating an unobserved compressor as "probably on".
+  // Fail-closed: an unknown fact never enables a tile.
+  it('renders no COMP tile when the compressor fact is unobserved', () => {
+    withSurface(compressor(base(), 'unknown'), (s) => {
+      expect(s.tile('compression')).toBeNull();
+    });
+  });
+
+  // MUTATION KILLED: `view.txAux?.compressor... ?? true` — a radio with no
+  // txAux group at all (the MOR-1244 evidence gate declined it) has never
+  // told us the compressor is on.
+  it('renders no COMP tile when the radio reports no txAux group at all', () => {
+    const view = compressor(base(), 'no-group');
+    expect(view.txAux).toBeUndefined();
+    withSurface(view, (s) => {
+      expect(s.tile('compression')).toBeNull();
+      expect(s.root()).not.toBeNull();
+    });
+  });
+
+  // The gate is one-directional: txAux says WHETHER, the meter fact says WHAT.
+  it('still respects the meter fact once the compressor gate opens', () => {
+    const view = withField(compressor(base(), true), 'compression', {
+      availability: { structural: false, operational: false },
+    });
+    withSurface(view, (s) => {
+      expect(s.tile('compression')).toBeNull();
+    });
+  });
+});
+
+// ── 5. Carry-forward (1): MOR-1235 stays fixed — no second TX derivation ──
+
+describe('TX truth reaches this surface only through the fact layer (R9)', () => {
+  // MUTATION KILLED: reintroducing a `ptt` read — the exact disagreement
+  // MOR-1235 reported and MOR-1269 fixed one layer down. A source scan is the
+  // right instrument: a behavioural test cannot prove the ABSENCE of an input
+  // the component could reach for.
+  it('never mentions ptt, and takes no radio-state or TX-authority prop', () => {
+    expect(SOURCE).not.toMatch(/\bptt\b/i);
+    expect(SOURCE).not.toMatch(/TxAuthoritySnapshot/);
+    expect(SOURCE).not.toMatch(/radioState/);
+    // `view` is the ONE prop. A second one would be a second TX input.
+    expect(SOURCE).toMatch(/interface Props\s*\{\s*view:\s*RadioViewModel;?\s*\}/);
+  });
+
+  // MUTATION KILLED: computing an RF state locally (e.g. from txPermit, or
+  // from a `tx` snapshot). The rendered RF word is `meters.rfState` mapped
+  // through the SHARED `RF_LABEL`, so it cannot disagree with RxTxSurface.
+  it.each(RF_STATES)('renders the shared RF label/mark for rfState=%s', (state) => {
+    withSurface(base(state), (s) => {
+      expect(s.root()!.dataset.rfState).toBe(state);
+      expect(s.rfLabel()).toBe(RF_LABEL[state]);
+      expect(s.rfMark()).toBe(RF_MARK[state]);
+    });
+  });
+
+  // MUTATION KILLED: forking RF_LABEL/RF_MARK into a local copy that could
+  // drift from the key button's wording.
+  it('imports the RF vocabulary from rx-tx-surface rather than copying it', () => {
+    expect(SOURCE).toMatch(/import\s*\{[^}]*RF_LABEL[^}]*\}\s*from\s*'\.\/rx-tx-surface'/);
+    expect(SOURCE).not.toMatch(/RF_LABEL\s*(:|=)\s*\{/);
+  });
+});
+
+// ── 6. Carry-forward (4): the cold-start `unknown` window ─────────────────
+
+describe('the cold-start unknown window renders fail-closed', () => {
+  /** `withMeters(..., 'unknown')` marks every TX-gated meter relevant (the
+   *  adapter's own fail-closed choice: unknown is treated as "may be on"),
+   *  and the S meter NOT relevant. What matters here is that the surface
+   *  renders the unknown state as unknown — never as RX. */
+  it('never presents an unknown RF state as receiving', () => {
+    withSurface(base('unknown'), (s) => {
+      expect(s.root()!.dataset.rfState).toBe('unknown');
+      expect(s.rfLabel()).not.toBe(RF_LABEL.receiving);
+      expect(s.rfMark()).not.toBe(RF_MARK.receiving);
+      expect(target.innerHTML).not.toContain('data-rf-state="receiving"');
+    });
+  });
+
+  // MUTATION KILLED: a boolean `txActive`-shaped attribute (the shipped v2
+  // dock's shape, and the reason MOR-1235 was invisible) — it collapses
+  // 'uncertain' and 'unknown' onto 'receiving'. Four states in, four out.
+  it('keeps all four RF states distinguishable in the DOM', () => {
+    const seen = RF_STATES.map((state) => {
+      const s = render(base(state));
+      const shown = `${s.root()!.dataset.rfState}|${s.rfMark()}|${s.rfLabel()}`;
+      s.dispose();
+      return shown;
+    });
+    expect(new Set(seen).size).toBe(RF_STATES.length);
+  });
+
+  // MUTATION KILLED: rendering the surface only once the authority is known
+  // (a flash of nothing), or blanking the readings. The group's presence is
+  // the only mount condition; every structurally present meter still renders.
+  it('renders every meter tile while the RF state is still unknown', () => {
+    withSurface(base('unknown'), (s) => {
+      expect(s.tiles()).toEqual([...ALL_KEYS]);
+    });
+  });
+});
+
+// ── 7. Motion / forced-colors carry-overs (MOR-1249 / 1252 / 1250) ────────
+
+describe('motion and forced-colors mechanisms are reused, not forked', () => {
+  // MUTATION KILLED: a local rAF/interval ballistics loop. Smoothing and
+  // peak-hold — including their `prefers-reduced-motion` behaviour — belong to
+  // the reused SVG meter components (LinearSMeter / BarGauge, both driving
+  // `$lib/utils/smoothing.svelte`'s `createSmoother`, which snaps instead of
+  // animating under reduce). A copy here would be a second, unaudited loop.
+  it('schedules no animation loop of its own', () => {
+    expect(SOURCE).not.toMatch(/requestAnimationFrame|setInterval|setTimeout/);
+    expect(SOURCE).not.toMatch(/createSmoother|updatePeakHold|peakHoldDisplay/);
+  });
+
+  it('delegates every gauge to the shipped SVG meter components', () => {
+    expect(SOURCE).toMatch(/import BarGauge from '\.\.\/components-v2\/meters\/BarGauge\.svelte'/);
+    expect(SOURCE).toMatch(/import LinearSMeter from '\.\.\/components-v2\/meters\/LinearSMeter\.svelte'/);
+  });
+
+  // MUTATION KILLED: a CSS transition/animation on the relevance dim — under
+  // `prefers-reduced-motion` the cockpit's harness assertion requires that
+  // NOTHING inside it animates, and a surface that transitions its own opacity
+  // would break that page-level guarantee.
+  it('declares no transition or animation in its own styles', () => {
+    const styles = SOURCE.slice(SOURCE.indexOf('<style>'));
+    expect(styles).not.toMatch(/transition|animation|@keyframes/);
+  });
+
+  // MUTATION KILLED: encoding relevance/unknown by colour alone. Under
+  // forced-colors the palette is overridden, so state must survive as TEXT
+  // and ATTRIBUTES (MOR-977/1250) — the RF word, the '?' placeholder and the
+  // data attributes all do.
+  it('encodes state as text and attributes, never colour alone', () => {
+    const view = withField(base('transmitting'), 'swr', { unknown: true });
+    withSurface(view, (s) => {
+      expect(s.tile('swr')!.textContent).toContain('?');
+      expect(s.tile('swr')!.dataset.observed).toBe('false');
+      expect(s.rfLabel()).toBe(RF_LABEL.transmitting);
+    });
+    // The surface's own stylesheet carries structure, not a palette.
+    const styles = SOURCE.slice(SOURCE.indexOf('<style>'));
+    expect(styles).not.toMatch(/#[0-9a-f]{3,8}\b|\brgb\(|\bhsl\(/i);
+  });
+});
+
+// ── 8. The meter table is the shipped one, not a re-derivation ────────────
+
+describe('the meter table matches the shipped dock', () => {
+  // MUTATION KILLED: inventing a new scale/formatter here. Every bar reads its
+  // level and its number from `components-v2/panels/meter-utils` — the same
+  // calibrated functions MetersDockPanel uses — so the two never disagree
+  // about what 0.6 on the SWR meter means.
+  it('covers exactly the seven meters the fact group carries', () => {
+    expect([...ALL_KEYS].sort()).toEqual(
+      Object.keys(withMeters(topologyFixtures['1/single']).meters!)
+        .filter((k) => k !== 'rfState').sort(),
+    );
+  });
+
+  it('reads its levels and formatters from the shipped meter-utils', () => {
+    expect(SOURCE).toMatch(/from '\.\.\/components-v2\/panels\/meter-utils'/);
+  });
+
+  it('labels each bar with the dock\'s own short name', () => {
+    expect(METER_BARS.map(([, label]) => label))
+      .toEqual(['Po', 'SWR', 'ALC', 'Id', 'Vd', 'COMP']);
+  });
+});


### PR DESCRIPTION
## Summary
Vocabulary slice 2B of the MOR-1262 program (SAFETY-ADJACENT): `MetersSurface.svelte` over the 2A meters facts (#2206). Self-gates on group presence (R3, config-free), uses the existing 'meters' renderer slot only (R2 — `RENDERER_SLOT_NAMES` untouched), zero controls, all smoothing/peak ballistics delegated to the reused SVG components (a local ballistics loop is pinned red). `SEMANTIC_SURFACE_NAMES` gains 'meters' per the 1B precedent. Net production LOC **180** (verifier re-measured; ≤200); fixture catalog gains a `withMeters()` overlay (+37/−6, fixture-side).

Binding 2A carry-forwards, each with discriminating tests: TX relevance from `meters.rfState` only — never `radioState.ptt`; COMP tile gates on `txAux.compressor`, not `meters.compression.availability`; `relevant` consumed, never re-derived; cold-start `unknown` renders fail-closed with all four RF states distinguishable.

**Peak-hold note (verifier ruling):** `BarGauge` has no peak channel, so bar peak-hold markers are deferred to a follow-up — NOT a regression today (`MetersDockPanel` stays mounted and untouched), but the follow-up is a binding pre-cutover condition (ticket filed, labeled v3-prereq).

## Review provenance
Opus builder → independent opus vocabulary-domain verifier (fresh eyes, 4th ticket in domain): **PASS**. Kills: complete MOR-1235 reintroduction (real ptt prop + wiring + both relevance channels) — 15 tests; COMP re-gate — 3; local relevance re-derivation — 6; unknown→receiving — 5; ballistics pins — local rAF loop / setInterval / CSS transition / colour literal all red; self-gate removal red. Zero contract/adapter/allow-list edits; test-merge onto current main (3666dd13) clean with the full check green. Harness pre-existing failures independently reproduced at baaaf480 (= MOR-1281); zero new focusable controls proven by assertion-identical A/B; a11y roles/labels match the dock precedent. Low findings: audio-fft-demand pool flake → MOR-1272 inventory; decorative RF mark aria-hidden → follow-up ticket.

Linear: MOR-1273

🤖 Generated with [Claude Code](https://claude.com/claude-code)