### PR TITLE
feat(MOR-1074): fieldline — a second product-owned design language with unchanged behavior

### DIFF
--- a/frontend/fixtures/main.ts
+++ b/frontend/fixtures/main.ts
@@ -39,20 +39,25 @@ if ((params.get('theme') ?? 'v2') === 'v2') {
   await import('../src/components-v2/theme/index');
 }
 
-// MOR-1073: design languages are scoped to `[data-design-language]` and have
+// MOR-1073/MOR-1074: design languages are scoped to `[data-design-language]`,
+// which is their ONLY activation mechanism (owner decision Q2) — and they have
 // no activation path in the app yet (routing one in is cutover work,
-// MOR-1048/MOR-1263). This param is the only opt-in, so the harness can
-// capture the language over the same fixtures the unstyled baselines use.
+// MOR-1048/MOR-1263). This param is the only opt-in, so the harness can capture
+// each language over the same fixtures the unstyled baselines use.
+const LANGUAGE_STYLESHEETS: Record<string, () => Promise<unknown>> = {
+  studioline: () => import('../src/presentation/languages/studioline/studioline.css'),
+  fieldline: () => import('../src/presentation/languages/fieldline/fieldline.css'),
+};
 const language = params.get('language');
-if (language === 'studioline') {
-  await import('../src/presentation/languages/studioline/studioline.css');
+if (language) {
+  const load = LANGUAGE_STYLESHEETS[language];
+  if (!load) throw new Error(`MOR-1074 harness: unknown design language "${language}"`);
+  await load();
   document.documentElement.dataset.designLanguage = language;
   // Light is an explicit opt-in, never an OS-preference flip: the app's own
   // light/dark is a manual `[data-theme]` choice, so language and surface have
   // to be switched by the same deliberate act.
   if (params.get('mode') === 'light') document.documentElement.dataset.languageMode = 'light';
-} else if (language) {
-  throw new Error(`MOR-1073 harness: unknown design language "${language}"`);
 }
 
 harness.state = fixture.state();

--- a/frontend/src/presentation/languages/__tests__/registry.test.ts
+++ b/frontend/src/presentation/languages/__tests__/registry.test.ts
@@ -2,9 +2,11 @@
  * MOR-1072 registry: the two frozen family IDs (`studioline`/`fieldline`,
  * MOR-977 §4.6) are registered as declarations, and the registry does not
  * hardcode a family count — a third, hypothetical family registers and
- * validates the same way. MOR-1073 gave studioline its renderers; fieldline
- * is still renderer-less, which keeps the "zero renderers declared" fallback
- * path under test with a real declaration rather than only a fixture.
+ * validates the same way. MOR-1073 gave studioline its renderers and MOR-1074
+ * gave fieldline its own, so BOTH declared families now fill every slot — the
+ * "zero renderers declared" fallback path is exercised by the shared fixture
+ * (`validManifest`) and by `renderer-contract.test.ts`, which is where it
+ * belongs now that no real family is renderer-less.
  */
 import { describe, it, expect } from 'vitest';
 import {
@@ -20,9 +22,19 @@ describe('the two frozen v3 declarations', () => {
     expect(getDesignLanguage('fieldline')).toBe(fieldline);
   });
 
-  it('studioline declares every renderer slot (MOR-1073); fieldline none yet (MOR-1074)', () => {
+  it('both declared families fill every renderer slot (MOR-1073, MOR-1074)', () => {
     expect(Object.keys(studioline.renderers).sort()).toEqual([...RENDERER_SLOT_NAMES].sort());
-    expect(fieldline.renderers).toEqual({});
+    expect(Object.keys(fieldline.renderers).sort()).toEqual([...RENDERER_SLOT_NAMES].sort());
+  });
+
+  // The inventory row that makes "second language" mean something: the two
+  // families occupy the same slots with DIFFERENT implementations, so no slot
+  // is silently shared and no family is a re-export of the other.
+  it('no renderer instance is shared between the two families', () => {
+    for (const slot of RENDERER_SLOT_NAMES) {
+      expect(fieldline.renderers[slot]).toBeDefined();
+      expect(fieldline.renderers[slot]).not.toBe(studioline.renderers[slot]);
+    }
   });
 
   it('fieldline clamps out "dense" (MOR-977 §4.4)', () => {

--- a/frontend/src/presentation/languages/declarations.ts
+++ b/frontend/src/presentation/languages/declarations.ts
@@ -6,32 +6,25 @@
  * contract.test.ts registers a third the same way.
  *
  * MOR-1073 landed studioline's real token set and its three renderers
- * (`./studioline`). `fieldline` still carries the placeholder bundle below
- * until MOR-1074 gives it a grammar of its own.
+ * (`./studioline`); MOR-1074 does the same for `fieldline` (`./fieldline`),
+ * which retires the shared placeholder bundle that used to stand in for it.
+ * Both families now supply their own contrast-proven ring tone, so nothing
+ * here inherits `var(--accent)` — which carries no such guarantee — any more.
+ * The contract's `var(--accent)` default is deliberately left untouched.
+ *
+ * The two bundles are imported under family-qualified aliases because they
+ * export the same three renderer names: that symmetry IS the proof — the
+ * second language plugs into identical slots with no contract change.
  */
 import { registerDesignLanguage, type DesignLanguageManifest } from './contract';
-import { renderFrequency } from './studioline/frequency-renderer';
-import { renderMeter } from './studioline/meters-renderer';
-import { renderStateFeedback } from './studioline/state-feedback-renderer';
+import { renderFrequency as studiolineFrequency } from './studioline/frequency-renderer';
+import { renderMeter as studiolineMeter } from './studioline/meters-renderer';
+import { renderStateFeedback as studiolineStateFeedback } from './studioline/state-feedback-renderer';
 import { STUDIOLINE_TOKENS } from './studioline/tokens';
-
-const placeholderTokens: DesignLanguageManifest['tokens'] = {
-  typography: { fontFamily: 'system-ui, sans-serif', weight: 400, fontVariantNumeric: 'tabular-nums' },
-  geometry: { radius: '0px', borderWidth: '0px' },
-  meters: { trackWidth: '2px', segmentGap: '0px' },
-  frequency: { digitWeight: 400, rankedGroups: true },
-  motion: { durationMs: 150, reducedMotionSafe: true },
-  // Outline shorthand, not a box-shadow spread list (MOR-1232 D5): consumers
-  // assign this straight to `outline`, where `0 0 0 2px …` is silently
-  // invalid and the ring never appears. The `var(--accent)` COLOUR is
-  // untouched here on purpose — it carries no contrast guarantee (it fails
-  // 3:1 on a light skin), and whether that is fixed per language or in the
-  // contract is an open owner question, not this slice's call. `studioline`
-  // pins and proves its own ring colour instead (see ./studioline/tokens.ts).
-  focusRing: '2px solid var(--accent)',
-  rx: { idle: 'var(--dl-rx-idle)', active: 'var(--dl-rx-active)', tuning: 'var(--dl-rx-tuning)' },
-  tx: { idle: 'var(--dl-tx-idle)', active: 'var(--dl-tx-active)', tuning: 'var(--dl-tx-tuning)' },
-};
+import { renderFrequency as fieldlineFrequency } from './fieldline/frequency-renderer';
+import { renderMeter as fieldlineMeter } from './fieldline/meters-renderer';
+import { renderStateFeedback as fieldlineStateFeedback } from './fieldline/state-feedback-renderer';
+import { FIELDLINE_TOKENS } from './fieldline/tokens';
 
 export const studioline: DesignLanguageManifest = {
   id: 'studioline',
@@ -44,16 +37,16 @@ export const studioline: DesignLanguageManifest = {
   // (MOR-977 §4.2.2), so the reference language says so as a manifest fact.
   layoutCompatibility: [{ layoutId: 'dual-receiver-cockpit', compatible: true }],
   renderers: {
-    frequencyDisplay: renderFrequency,
-    meters: renderMeter,
-    stateFeedback: renderStateFeedback,
+    frequencyDisplay: studiolineFrequency,
+    meters: studiolineMeter,
+    stateFeedback: studiolineStateFeedback,
   },
 };
 
 export const fieldline: DesignLanguageManifest = {
   id: 'fieldline',
   displayName: 'Fieldline',
-  tokens: placeholderTokens,
+  tokens: FIELDLINE_TOKENS,
   // dense clamped out — fieldline runs at 0.6 relative density (MOR-977 §4.4).
   density: { kind: 'clamped', supported: ['comfortable', 'compact'] },
   layoutCompatibility: [{
@@ -61,7 +54,11 @@ export const fieldline: DesignLanguageManifest = {
     compatible: false,
     reason: 'fieldline cannot serve as the desktop dual-receiver default at 0.6 relative density (MOR-977 §4.4).',
   }],
-  renderers: {},
+  renderers: {
+    frequencyDisplay: fieldlineFrequency,
+    meters: fieldlineMeter,
+    stateFeedback: fieldlineStateFeedback,
+  },
 };
 
 registerDesignLanguage(studioline);

--- a/frontend/src/presentation/languages/fieldline/__tests__/frequency-renderer.test.ts
+++ b/frontend/src/presentation/languages/fieldline/__tests__/frequency-renderer.test.ts
@@ -1,0 +1,189 @@
+/**
+ * MOR-1074 — the `fieldline` VFO renderer slice, over the same four canonical
+ * topology fixtures studioline's twin file uses (MOR-1062
+ * `semantic/fixtures/topologies`). Running BOTH languages over one fixture set
+ * is what makes "unchanged behavior, different language" checkable rather than
+ * asserted: the digits agree, the presentation does not.
+ *
+ * The renderer is a pure projection of ONE frequency fact onto MOR-977 §2.2's
+ * grammar: equal-weight slab digit cells, no group de-emphasis, gaps rather
+ * than separator characters, leading MHz zeros shifted off exactly as
+ * `splitFrequencyToDigits()` shifts them, and cell inversion as the tuning
+ * affordance. It is driven through `invokeRenderer` on purpose — the structural
+ * gate is what makes a capability fork impossible, so a second language must be
+ * shown to survive it too.
+ */
+import { describe, it, expect } from 'vitest';
+import { invokeRenderer, RendererInputError } from '../../contract';
+import { topologyFixtures } from '../../../../semantic/fixtures/topologies';
+import { renderFrequency as renderStudioline } from '../../studioline/frequency-renderer';
+import { STUDIOLINE_TOKENS } from '../../studioline/tokens';
+import { FIELDLINE_TOKENS } from '../tokens';
+import {
+  DIGIT_SIZE_PX, GROUP_GAP_PX, renderFrequency, type FieldlineFrequency,
+} from '../frequency-renderer';
+
+const render = (
+  fields: Record<string, string | number | boolean | null>,
+): FieldlineFrequency => renderFrequency({ kind: 'frequency', fields }, FIELDLINE_TOKENS);
+
+const groupText = (r: FieldlineFrequency, group: 'mhz' | 'khz' | 'hz'): string =>
+  r.digits.filter((d) => d.group === group).map((d) => d.char).join('');
+
+/** Every VFO the four topology fixtures declare — the real acceptance surface. */
+const topologyVfos = Object.entries(topologyFixtures).flatMap(([id, model]) =>
+  model.vfos.map((vfo) => [id, vfo.label, vfo.frequencyHz] as const));
+
+describe('four topology fixtures render under the fieldline grammar', () => {
+  it.each(topologyVfos)('%s / %s renders equal-weight digit cells', (_topology, _label, hz) => {
+    const r = render({ frequencyHz: hz });
+    expect(r.unknown).toBe(false);
+    expect(r.digits.length).toBeGreaterThanOrEqual(7);
+    expect(groupText(r, 'khz')).toHaveLength(3);
+    expect(groupText(r, 'hz')).toHaveLength(3);
+    // The axis: nothing is demoted. One size, one weight, for every cell.
+    expect(new Set(r.digits.map(() => `${r.fontSizePx}/${r.fontWeight}`)).size).toBe(1);
+  });
+
+  it.each(topologyVfos)('%s / %s keeps the digits and the value in agreement', (_topology, _label, hz) => {
+    expect(Number(render({ frequencyHz: hz }).digits.map((d) => d.char).join(''))).toBe(hz);
+  });
+
+  it('renders each fixture at its declared active frequency', () => {
+    expect(groupText(render({ frequencyHz: topologyFixtures['1/single'].vfos[0].frequencyHz }), 'mhz')).toBe('14');
+    expect(groupText(render({ frequencyHz: topologyFixtures['1/ab'].vfos[0].frequencyHz }), 'mhz')).toBe('7');
+    expect(groupText(render({ frequencyHz: topologyFixtures['2/ab_shared'].vfos[0].frequencyHz }), 'mhz')).toBe('3');
+    expect(groupText(render({ frequencyHz: topologyFixtures['2/main_sub'].vfos[0].frequencyHz }), 'mhz')).toBe('14');
+  });
+});
+
+describe('the digits are IDENTICAL to studioline; only the presentation differs', () => {
+  // This is the acceptance core in one assertion pair: same facts, same digit
+  // semantics, materially different grammar — with no runtime, adapter or
+  // vocabulary change in between.
+  it.each(topologyVfos)('%s / %s draws the same glyph run as studioline', (_topology, _label, hz) => {
+    const mine = render({ frequencyHz: hz }).digits.map((d) => d.char).join('');
+    const theirs = renderStudioline({ kind: 'frequency', fields: { frequencyHz: hz } }, STUDIOLINE_TOKENS)
+      .groups.map((g) => g.text).join('');
+    expect(mine).toBe(theirs);
+  });
+
+  it('ranks nothing, where studioline demotes the Hz group in size and tone', () => {
+    const mine = render({ frequencyHz: 14_250_000 });
+    const theirs = renderStudioline({ kind: 'frequency', fields: { frequencyHz: 14_250_000 } }, STUDIOLINE_TOKENS);
+    expect(FIELDLINE_TOKENS.frequency.rankedGroups).toBe(false);
+    expect(new Set(theirs.groups.map((g) => g.fontSizePx)).size).toBe(2);
+    expect(mine.fontSizePx).toBe(DIGIT_SIZE_PX);
+    // Size and weight are declared ONCE for the whole readout, so there is no
+    // per-cell field a future edit could quietly demote a group with.
+    for (const cell of mine.digits) {
+      expect(Object.keys(cell).sort()).toEqual(['char', 'group', 'inverted', 'multiplier', 'startsGroup']);
+    }
+  });
+
+  it('emits NO separator character at all — the 6px gap is the grouping mark', () => {
+    const r = render({ frequencyHz: 14_250_000 });
+    expect(r.separator).toBe('');
+    expect(r.groupGapPx).toBe(GROUP_GAP_PX);
+    expect(r.text).toBe('14250000');
+    expect(r.text).not.toMatch(/[\s.,]/);
+    // Three gap anchors: one per group, the first of which needs no gap drawn.
+    expect(r.digits.filter((d) => d.startsGroup)).toHaveLength(3);
+  });
+
+  it('is left-aligned slab type: mono face, 700, tabular, tight tracking', () => {
+    const r = render({ frequencyHz: 14_250_000 });
+    expect(r.align).toBe('start');
+    expect(r.style.fontFamily).toBe(FIELDLINE_TOKENS.typography.fontFamily);
+    expect(r.style.fontFamily).toMatch(/mono/i);
+    expect(r.style.fontWeight).toBe(String(FIELDLINE_TOKENS.frequency.digitWeight));
+    expect(r.style.fontVariantNumeric).toBe('tabular-nums');
+  });
+});
+
+describe('leading MHz zeros shift off, matching splitFrequencyToDigits()', () => {
+  it.each([
+    [14_250_000, '14'],
+    [7_100_000, '7'],
+    [3_573_000, '3'],
+    [144_300_000, '144'],
+    [500_000, '0'], // sub-MHz: the group never empties — one digit always remains
+  ])('%i MHz group renders as "%s"', (hz, expected) => {
+    expect(groupText(render({ frequencyHz: hz }), 'mhz')).toBe(expected);
+  });
+
+  it('does NOT strip zeros from the kHz or Hz groups — only the MHz group shifts', () => {
+    const r = render({ frequencyHz: 14_000_000 });
+    expect(groupText(r, 'khz')).toBe('000');
+    expect(groupText(r, 'hz')).toBe('000');
+  });
+
+  it('shifts rather than ghosts: a dropped zero leaves no cell behind', () => {
+    expect(render({ frequencyHz: 7_100_000 }).digits).toHaveLength(7);
+    expect(render({ frequencyHz: 144_300_000 }).digits).toHaveLength(9);
+  });
+});
+
+describe('an unobserved frequency stays unobserved', () => {
+  it('renders a null frequency as an explicit unknown, never as 0 Hz', () => {
+    const r = render({ frequencyHz: null });
+    expect(r.unknown).toBe(true);
+    expect(r.digits).toEqual([]);
+    expect(r.text).toBe('—');
+    expect(r.text).not.toMatch(/0/);
+  });
+
+  it('renders a missing frequency field the same way — absence is not zero', () => {
+    expect(render({}).unknown).toBe(true);
+  });
+});
+
+describe('tuning affordance: the cell inverts, it is not underlined', () => {
+  it('inverts exactly the tuned cell, by multiplier', () => {
+    const r = render({ frequencyHz: 14_250_000, tuningMultiplier: 1000 });
+    const inverted = r.digits.filter((d) => d.inverted);
+    expect(inverted).toHaveLength(1);
+    expect(inverted[0]).toMatchObject({ multiplier: 1000, group: 'khz', char: '0' });
+  });
+
+  it('inverts a cell in the MHz group after the leading-zero shift', () => {
+    const r = render({ frequencyHz: 7_100_000, tuningMultiplier: 1_000_000 });
+    expect(r.digits.filter((d) => d.inverted)).toEqual([
+      { char: '7', multiplier: 1_000_000, group: 'mhz', inverted: true, startsGroup: true },
+    ]);
+  });
+
+  it('inverts nothing when nothing is being tuned', () => {
+    expect(render({ frequencyHz: 14_250_000 }).digits.some((d) => d.inverted)).toBe(false);
+  });
+
+  it('drops an inversion whose multiplier is not on the readout', () => {
+    expect(render({ frequencyHz: 14_250_000, tuningMultiplier: 5 }).digits.some((d) => d.inverted)).toBe(false);
+    expect(render({ frequencyHz: 14_250_000, tuningMultiplier: 1_000_000_000 }).digits.some((d) => d.inverted))
+      .toBe(false);
+  });
+
+  it('a shifted-off leading zero cannot be tuned — there is no cell to invert', () => {
+    // 7 MHz: the 10^8 digit is shifted off, so asking for it inverts nothing.
+    expect(render({ frequencyHz: 7_100_000, tuningMultiplier: 100_000_000 }).digits.some((d) => d.inverted))
+      .toBe(false);
+  });
+});
+
+describe('the renderer survives the MOR-1072 structural gate', () => {
+  it('renders through invokeRenderer', () => {
+    const viewModel = { kind: 'frequency', fields: { frequencyHz: 14_250_000 } };
+    expect(invokeRenderer(renderFrequency, viewModel, FIELDLINE_TOKENS)).toMatchObject({ unknown: false });
+  });
+
+  it('cannot be reached with a capability-shaped payload', () => {
+    const smuggled = { kind: 'frequency', fields: { frequencyHz: 14_250_000 }, capabilities: { modes: ['USB'] } };
+    expect(() => invokeRenderer(renderFrequency, smuggled, FIELDLINE_TOKENS)).toThrow(RendererInputError);
+  });
+
+  it('ignores any field it does not name — an extra field cannot alter the render', () => {
+    const plain = render({ frequencyHz: 14_250_000 });
+    const noisy = render({ frequencyHz: 14_250_000, radioModel: 'test-radio', ptt: true });
+    expect(noisy).toEqual(plain);
+  });
+});

--- a/frontend/src/presentation/languages/fieldline/__tests__/meters-renderer.test.ts
+++ b/frontend/src/presentation/languages/fieldline/__tests__/meters-renderer.test.ts
@@ -1,0 +1,94 @@
+/**
+ * MOR-1074 — the `fieldline` meter form: 12 discrete segments, which is what
+ * distinguishes it from `studioline`'s continuous bar rail and `meridian`'s
+ * needle (MOR-977 §3.1). The pin that matters most is the same one studioline's
+ * twin file ends on: an unobserved reading must render as unknown, not as a
+ * ladder sitting dark, which reads as "no signal" — a different fact.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderMeter as renderStudioline } from '../../studioline/meters-renderer';
+import { STUDIOLINE_TOKENS } from '../../studioline/tokens';
+import { FIELDLINE_TOKENS } from '../tokens';
+import { FIELDLINE_SCALE_TICKS, FIELDLINE_SEGMENT_COUNT, renderMeter } from '../meters-renderer';
+
+const render = (fields: Record<string, number | null>) =>
+  renderMeter({ kind: 'meter', fields }, FIELDLINE_TOKENS);
+
+describe('the meter is a discrete segment ladder', () => {
+  it('always renders the same 12 blocks, whatever the reading', () => {
+    for (const value of [null, 0, 4, 9, 15, 99]) {
+      expect(render({ value }).segments).toHaveLength(FIELDLINE_SEGMENT_COUNT);
+    }
+  });
+
+  it('takes its block geometry from the token set, gap included', () => {
+    const m = render({ value: 5 });
+    expect(m.trackWidth).toBe(FIELDLINE_TOKENS.meters.trackWidth);
+    expect(m.segmentGap).toBe(FIELDLINE_TOKENS.meters.segmentGap);
+    expect(Number.parseFloat(m.segmentGap)).toBeGreaterThan(0);
+  });
+
+  it('quantises the reading to a countable number of lit blocks', () => {
+    expect(render({ value: 15, max: 15 }).litCount).toBe(12);
+    expect(render({ value: 7.5, max: 15 }).litCount).toBe(6);
+    expect(render({ value: 0, max: 15 }).litCount).toBe(0);
+    // The lit flags and the count never disagree.
+    const m = render({ value: 7.5, max: 15 });
+    expect(m.segments.filter((s) => s.lit)).toHaveLength(m.litCount!);
+  });
+
+  it('clamps an over-range reading to the ladder rather than overflowing it', () => {
+    expect(render({ value: 40, max: 15 }).litCount).toBe(12);
+    expect(render({ value: -3, max: 15 }).litCount).toBe(0);
+  });
+
+  it('zones at S9: blocks below the crossover are RX-toned, above it are not', () => {
+    const m = render({ value: 12, max: 15, s9: 9 });
+    expect(m.crossoverIndex).toBe(7);
+    expect(m.segments.slice(0, 7).every((s) => s.zone === 'normal' && s.tone === FIELDLINE_TOKENS.rx.active)).toBe(true);
+    expect(m.segments.slice(7).every((s) => s.zone === 'over' && s.tone === FIELDLINE_TOKENS.tx.tuning)).toBe(true);
+  });
+
+  it('holds the peak as ONE segment, never as a second fill', () => {
+    const m = render({ value: 4, peak: 12, max: 15 });
+    const held = m.segments.filter((s) => s.peakHold);
+    expect(held).toHaveLength(1);
+    expect(held[0].index).toBe(9);
+    expect(render({ value: 4 }).segments.some((s) => s.peakHold)).toBe(false);
+  });
+
+  it('renders the scale as marks at the zone boundaries only', () => {
+    expect(render({ value: 4 }).scaleTicks).toEqual(FIELDLINE_SCALE_TICKS);
+  });
+
+  it('renders an unobserved reading as unknown, never as a dark ladder at zero', () => {
+    const m = render({ value: null });
+    expect(m.unknown).toBe(true);
+    expect(m.litCount).toBeNull();
+    expect(m.segments.every((s) => !s.lit)).toBe(true);
+    // A genuine zero is a DIFFERENT fact and says so.
+    expect(render({ value: 0 })).toMatchObject({ unknown: false, litCount: 0 });
+  });
+});
+
+describe('the meter form is structurally different from studioline, not recoloured', () => {
+  it('quantises where studioline is continuous, at the same reading', () => {
+    const mine = render({ value: 7.5, max: 15 });
+    const theirs = renderStudioline({ kind: 'meter', fields: { value: 7.5, max: 15 } }, STUDIOLINE_TOKENS);
+    expect(theirs.fill).toBe(0.5); // a fraction of one track
+    expect(mine.litCount).toBe(6); // a count of blocks
+    expect(mine).not.toHaveProperty('fill');
+    expect(theirs).not.toHaveProperty('segments');
+  });
+
+  it('holds peak as a whole segment where studioline holds a 1px tick', () => {
+    const theirs = renderStudioline({ kind: 'meter', fields: { value: 4, peak: 12, max: 15 } }, STUDIOLINE_TOKENS);
+    expect(theirs.peakWidthPx).toBe(1);
+    expect(render({ value: 4, peak: 12, max: 15 }).segments.filter((s) => s.peakHold)).toHaveLength(1);
+  });
+
+  it('agrees with studioline on the UNKNOWN reading — the one fact both must not soften', () => {
+    expect(render({ value: null }).unknown).toBe(true);
+    expect(renderStudioline({ kind: 'meter', fields: { value: null } }, STUDIOLINE_TOKENS).unknown).toBe(true);
+  });
+});

--- a/frontend/src/presentation/languages/fieldline/__tests__/state-feedback-renderer.test.ts
+++ b/frontend/src/presentation/languages/fieldline/__tests__/state-feedback-renderer.test.ts
@@ -1,0 +1,233 @@
+/**
+ * MOR-1074 — the `fieldline` TX renderer slice: the flooding left rail, the
+ * full-width band and the action slab (MOR-977 §2.2 "takeover").
+ *
+ * SAFETY INVARIANT R9 is the spine of this file, exactly as it is of
+ * studioline's twin. The renderer DISPLAYS TX state; it never decides it. Every
+ * input below is produced by the real MOR-1064 vocabulary
+ * (`rfState`/`txSessionState` over a `TxAuthoritySnapshot`) rather than by
+ * hand-written strings, so a renderer that quietly grew a second opinion — or
+ * started reading a raw `ptt` — fails here rather than in a shack. A second
+ * design language is exactly where that regression would be cheapest to
+ * introduce and most expensive to notice, which is why the pins are duplicated
+ * rather than assumed to be inherited.
+ */
+import { describe, it, expect } from 'vitest';
+import { invokeRenderer, RendererInputError } from '../../contract';
+import {
+  rfState, txSessionState, type TxAuthoritySnapshot,
+} from '../../../../semantic/rx-tx-surface';
+import { renderStateFeedback as renderStudioline } from '../../studioline/state-feedback-renderer';
+import { STUDIOLINE_TOKENS } from '../../studioline/tokens';
+import { FIELDLINE_KNOCKOUT, FIELDLINE_PALETTE, FIELDLINE_TOKENS } from '../tokens';
+import { renderStateFeedback, type FieldlineStateFeedback } from '../state-feedback-renderer';
+
+const authority = (over: Partial<TxAuthoritySnapshot> = {}): TxAuthoritySnapshot => ({
+  phase: 'idle', intent: null, radioTx: 'off', txRisk: 'none', mayOwnKey: false, fault: null, ...over,
+});
+
+/** Exactly the projection a consumer performs: App-authority conclusions in, flat primitives out. */
+const fields = (tx: TxAuthoritySnapshot, extra: Record<string, string | number | boolean | null> = {}) => ({
+  rf: rfState(tx), session: txSessionState(tx), fault: tx.fault, keyBlocked: false, ...extra,
+});
+const fromAuthority = (
+  tx: TxAuthoritySnapshot, extra: Record<string, string | number | boolean | null> = {},
+): FieldlineStateFeedback =>
+  renderStateFeedback({ kind: 'state-feedback', fields: fields(tx, extra) }, FIELDLINE_TOKENS);
+
+const RX = authority();
+const PENDING = authority({ phase: 'key-confirm-pending', intent: 'latched', mayOwnKey: true, txRisk: 'uncertain' });
+const TX = authority({ phase: 'active', intent: 'latched', radioTx: 'on', txRisk: 'confirmed-on', mayOwnKey: true });
+const RELEASING = authority({ phase: 'releasing', radioTx: 'on', txRisk: 'confirmed-on', mayOwnKey: true });
+const FAULT = authority({ phase: 'failed', radioTx: 'unknown', txRisk: 'uncertain', fault: 'audio-failed' });
+const UNKNOWN_RF = authority({ radioTx: 'unknown' });
+const ALL = [RX, PENDING, TX, RELEASING, FAULT, UNKNOWN_RF];
+
+describe('the LEFT rail is the always-visible TX carrier (MOR-977 §2.2)', () => {
+  it.each([
+    ['RX', RX], ['pending', PENDING], ['TX', TX], ['releasing', RELEASING], ['fault', FAULT], ['rf-unknown', UNKNOWN_RF],
+  ])('%s renders a full-bleed rail on the inline start edge', (_name, tx) => {
+    expect(fromAuthority(tx).rail).toMatchObject({ fullBleed: true, edge: 'inline-start' });
+  });
+
+  it('RX is the quiet 8px baseline', () => {
+    const { rail, band, meterScaleLabel, numeralTone } = fromAuthority(RX);
+    expect(rail).toMatchObject({ widthPx: 8, tone: FIELDLINE_TOKENS.rx.idle });
+    expect(band).toMatchObject({ treatment: 'absent', text: null, textTone: null });
+    expect(meterScaleLabel).toBe('S');
+    expect(numeralTone).toBe('primary');
+  });
+
+  it('pending floods to 16px and outlines the band, before any RF is out', () => {
+    const { rail, band, meterScaleLabel } = fromAuthority(PENDING);
+    expect(rail).toMatchObject({ widthPx: 16, tone: FIELDLINE_TOKENS.tx.tuning });
+    expect(band).toMatchObject({ treatment: 'outlined', text: 'KEYING' });
+    expect(meterScaleLabel).toBe('S');
+  });
+
+  it('TX takes over: 24px rail, a FILLED "ON AIR" band, meter re-zoned to power', () => {
+    const { rail, band, meterScaleLabel, numeralTone } = fromAuthority(TX);
+    expect(rail).toMatchObject({ widthPx: 24, tone: FIELDLINE_TOKENS.tx.active });
+    expect(band).toMatchObject({ treatment: 'filled', text: 'ON AIR', textTone: FIELDLINE_KNOCKOUT });
+    expect(meterScaleLabel).toBe('PO');
+    expect(numeralTone).toBe('tx-target');
+  });
+
+  it('releasing steps back to 16px without pretending RX has resumed', () => {
+    const { rail, band, meterScaleLabel } = fromAuthority(RELEASING);
+    expect(rail.widthPx).toBe(16);
+    expect(band.text).toBe('UNKEYING');
+    expect(meterScaleLabel).toBe('PO');
+  });
+
+  it('a fault puts its code IN the band — an unheard-of code still shows', () => {
+    const f = fromAuthority(FAULT);
+    expect(f.rail).toMatchObject({ widthPx: 24, tone: FIELDLINE_TOKENS.tx.active });
+    expect(f.band).toMatchObject({ treatment: 'filled', text: 'TX FAULT: audio-failed', textTone: FIELDLINE_KNOCKOUT });
+    expect(fromAuthority(authority({ phase: 'failed', fault: 'no-such-code-4711' })).band.text)
+      .toBe('TX FAULT: no-such-code-4711');
+  });
+
+  it('unknown RF is a THIRD thing — never collapsed into RX (MOR-977 §1.2.1)', () => {
+    const unknown = fromAuthority(UNKNOWN_RF);
+    expect(unknown.rail).toMatchObject({ widthPx: 16, tone: FIELDLINE_TOKENS.tx.tuning });
+    expect(unknown.band.text).toBe('TX?');
+    expect(unknown.rail).not.toEqual(fromAuthority(RX).rail);
+  });
+});
+
+describe('state survives forced-colors and colour-vision deficiency', () => {
+  it('no two states are distinguished by colour alone', () => {
+    const colourless = ALL.map((tx) => {
+      const s = fromAuthority(tx);
+      return `${s.rail.widthPx}/${s.band.treatment}/${s.band.text ?? 'RX'}`;
+    });
+    expect(new Set(colourless).size).toBe(ALL.length);
+  });
+
+  it('uses only the declared 8/16/24px rail floods', () => {
+    for (const tx of ALL) expect([8, 16, 24]).toContain(fromAuthority(tx).rail.widthPx);
+  });
+
+  it('every band treatment is one of the three declared forms', () => {
+    for (const tx of ALL) expect(['absent', 'outlined', 'filled']).toContain(fromAuthority(tx).band.treatment);
+  });
+});
+
+describe('the action slab gets an intentional treatment, not a UA default (N2)', () => {
+  it.each([
+    ['idle', RX, 'idle'], ['pending', PENDING, 'pending'],
+    ['keyed', TX, 'keyed'], ['fault', FAULT, 'fault'],
+  ])('%s renders the "%s" slab treatment', (_name, tx, treatment) => {
+    expect(fromAuthority(tx).slab.treatment).toBe(treatment);
+  });
+
+  it('is a full-width 48px slab — gloves, in daylight, possibly one-handed', () => {
+    expect(fromAuthority(RX).slab).toMatchObject({ fullWidth: true, minHeightPx: 48 });
+    expect(FIELDLINE_TOKENS.geometry.radius).toBe('0px');
+  });
+
+  it('carries state in edge GEOMETRY as well as fill, so colour is never the only channel', () => {
+    const geometry = (tx: TxAuthoritySnapshot, extra = {}): string => {
+      const { slab } = fromAuthority(tx, extra);
+      return `${slab.edgeStyle}/${slab.filled ? 'solid' : 'empty'}`;
+    };
+    const treatments = {
+      idle: geometry(RX), pending: geometry(PENDING), keyed: geometry(TX),
+      fault: geometry(FAULT), blocked: geometry(RX, { keyBlocked: true }),
+    };
+    expect(treatments).toEqual({
+      idle: 'solid/empty', pending: 'solid/empty', keyed: 'solid/solid',
+      fault: 'dashed/empty', blocked: 'dotted/empty',
+    });
+    // idle and pending share an edge/fill pair in the DESCRIPTOR; the hatch that
+    // separates them is a stylesheet concern, pinned in `stylesheet.test.ts`.
+    expect(new Set(Object.values(treatments)).size).toBe(4);
+  });
+
+  it('fills solid with a knocked-out BLACK label while keyed, and stays outlined otherwise', () => {
+    expect(fromAuthority(TX).slab).toMatchObject({
+      fill: FIELDLINE_TOKENS.tx.active, filled: true, tone: FIELDLINE_KNOCKOUT,
+    });
+    expect(fromAuthority(RX).slab.filled).toBe(false);
+  });
+
+  it('a blocked slab is rendered inert-but-PRESENT, never absent (MOR-977 §1.2.3)', () => {
+    const blocked = renderStateFeedback({
+      kind: 'state-feedback',
+      fields: { rf: 'receiving', session: 'idle', fault: null, keyBlocked: true },
+    }, FIELDLINE_TOKENS);
+    expect(blocked.slab).toMatchObject({ treatment: 'blocked', present: true, filled: false });
+    expect(blocked.slab.tone).toBe(FIELDLINE_PALETTE.inert);
+  });
+
+  it('every treatment is present — no state hides the control', () => {
+    for (const tx of ALL) expect(fromAuthority(tx).slab.present).toBe(true);
+  });
+
+  it('carries the mandatory focus ring rather than re-suppressing it (MOR-977 §1.2.5)', () => {
+    expect(fromAuthority(RX).slab.focusRing).toBe(FIELDLINE_TOKENS.focusRing);
+    expect(fromAuthority(RX).slab.focusRing).not.toMatch(/none/);
+  });
+});
+
+describe('R9 — TX truth comes from App authority, never from the renderer', () => {
+  it('a raw ptt field cannot move the rail: authority says RX, so it renders RX', () => {
+    const withPtt = fromAuthority(RX, { ptt: true, radioStatePtt: true });
+    expect(withPtt).toEqual(fromAuthority(RX));
+    expect(withPtt.band.text).toBeNull();
+  });
+
+  it('a raw ptt field cannot clear a TX rail either', () => {
+    expect(fromAuthority(TX, { ptt: false }).rail).toEqual(fromAuthority(TX).rail);
+  });
+
+  it('an unrecognised state fails CLOSED — doubt, never a quiet RX rail', () => {
+    const bogus = renderStateFeedback({
+      kind: 'state-feedback',
+      fields: { rf: 'who-knows', session: 'brand-new-phase', fault: null, keyBlocked: false },
+    }, FIELDLINE_TOKENS);
+    expect(bogus.rail.widthPx).toBe(16);
+    expect(bogus.band.text).toBe('TX?');
+    expect(bogus.slab.treatment).not.toBe('idle');
+  });
+
+  it('is reachable only through the structural gate', () => {
+    const smuggled = { kind: 'state-feedback', fields: { rf: 'receiving' }, capabilities: { tx: true } };
+    expect(() => invokeRenderer(renderStateFeedback, smuggled, FIELDLINE_TOKENS)).toThrow(RendererInputError);
+  });
+});
+
+describe('the two languages agree on the FACTS and disagree on the grammar', () => {
+  // The acceptance core again, on the safety-critical surface: identical
+  // authority in, identical conclusions out, materially different carriers.
+  it.each([
+    ['RX', RX], ['pending', PENDING], ['TX', TX], ['releasing', RELEASING], ['fault', FAULT], ['rf-unknown', UNKNOWN_RF],
+  ])('%s: both languages agree on meter scale and numeral tone', (_name, tx) => {
+    const mine = fromAuthority(tx);
+    const theirs = renderStudioline({ kind: 'state-feedback', fields: fields(tx) }, STUDIOLINE_TOKENS);
+    expect(mine.meterScaleLabel).toBe(theirs.meterScaleLabel);
+    expect(mine.numeralTone).toBe(theirs.numeralTone);
+  });
+
+  it('the TX CARRIER is a different element in each language', () => {
+    const theirs = renderStudioline({ kind: 'state-feedback', fields: fields(TX) }, STUDIOLINE_TOKENS);
+    expect(theirs.rail).toMatchObject({ thicknessPx: 3 }); // a TOP rail, measured in thickness
+    expect(fromAuthority(TX).rail).toMatchObject({ edge: 'inline-start', widthPx: 24 });
+    expect(theirs.rail).not.toHaveProperty('edge');
+  });
+
+  it('takeover vs quiet: fieldline adds a band studioline has no equivalent of', () => {
+    const theirs = renderStudioline({ kind: 'state-feedback', fields: fields(TX) }, STUDIOLINE_TOKENS);
+    expect(theirs.rail.label).toBe('TX'); // a label ON the rail
+    expect(fromAuthority(TX).band).toMatchObject({ treatment: 'filled', text: 'ON AIR' });
+    expect(theirs).not.toHaveProperty('band');
+  });
+
+  it('slab vs pill: the same control, opposite geometry', () => {
+    const theirs = renderStudioline({ kind: 'state-feedback', fields: fields(RX) }, STUDIOLINE_TOKENS);
+    expect(theirs.key.radius).toBe('999px');
+    expect(fromAuthority(RX).slab).toMatchObject({ fullWidth: true, minHeightPx: 48 });
+    expect(fromAuthority(RX).slab).not.toHaveProperty('radius');
+  });
+});

--- a/frontend/src/presentation/languages/fieldline/__tests__/stylesheet.test.ts
+++ b/frontend/src/presentation/languages/fieldline/__tests__/stylesheet.test.ts
@@ -1,0 +1,271 @@
+/**
+ * MOR-1074 — cascade pins for the `fieldline` stylesheet.
+ *
+ * WHY THESE RESOLVE THE CASCADE BY HAND. Same reason as studioline's twin
+ * file: three of fieldline's state channels are decided by the CASCADE, not by
+ * any single declaration — the fault rail beats the RF-doubt rail only because
+ * it comes later at equal specificity, the fault BAND beats the doubt band the
+ * same way, and the keyed slab beats the `:disabled` treatment only because it
+ * scores higher. None of that is observable from the renderer unit tests, and
+ * none of it is observable in jsdom either: jsdom's `getComputedStyle` resolves
+ * no `:has()` and substitutes no custom property, so it reports an empty border
+ * width and a literal `var(...)` colour. The studioline review cycle proved the
+ * gap the expensive way — the ordering bug was reintroduced and every unit and
+ * in-page assertion stayed green while the fault rail rendered amber.
+ *
+ * So this file parses the sheet and ranks the matching rules the way a browser
+ * would — (specificity, source order) — and asserts the WINNER. That catches
+ * both mutation classes: moving a rule earlier, and weakening its selector.
+ */
+import { readFileSync } from 'node:fs';
+import { describe, it, expect } from 'vitest';
+import { FIELDLINE_PALETTE } from '../tokens';
+
+const source = readFileSync('src/presentation/languages/fieldline/fieldline.css', 'utf8');
+// Comments name the very constructs several tests below forbid, so they are
+// stripped first: the pins are about DECLARATIONS, not about prose.
+const css = source.replace(/\/\*[\s\S]*?\*\//g, '');
+
+interface Rule {
+  selector: string;
+  declarations: Record<string, string>;
+  order: number;
+  specificity: number;
+}
+
+/**
+ * `(classes + attributes + pseudo-classes) * 100 + elements` — the b and c
+ * columns of the CSS specificity tuple. No rule here uses an id, so the a
+ * column is constant and omitted. `:has()` contributes its argument, exactly as
+ * the spec says.
+ */
+function specificity(selector: string): number {
+  const b = (selector.match(/\[[^\]]*]|\.[\w-]+|:(?!has\b)[\w-]+/g) ?? []).length;
+  return b * 100;
+}
+
+function parseRules(sheet: string): Rule[] {
+  const rules: Rule[] = [];
+  for (const [, selectorList, body] of sheet.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+    const declarations: Record<string, string> = {};
+    for (const declaration of body.split(';')) {
+      const colon = declaration.indexOf(':');
+      if (colon > 0) declarations[declaration.slice(0, colon).trim()] = declaration.slice(colon + 1).trim();
+    }
+    // A comma-separated list is N rules that happen to share a body.
+    for (const selector of selectorList.split(',')) {
+      const trimmed = selector.trim();
+      if (trimmed) rules.push({ selector: trimmed, declarations, order: rules.length, specificity: specificity(trimmed) });
+    }
+  }
+  return rules;
+}
+
+const RULES = parseRules(css);
+const STATE_SCOPED = /:has\(\[data-(?:session|rf)=/;
+
+interface SurfaceState {
+  session: string;
+  rf: string;
+  keyDisabled?: boolean;
+}
+
+type Target = 'surface' | 'band' | 'slab';
+
+/** Does `selector` match this state, for the given target element? */
+function matches(selector: string, state: SurfaceState, target: Target): boolean {
+  const wantsSlab = selector.includes('.rx-tx-key');
+  const wantsBand = selector.includes('.rx-tx-state');
+  const wants: Target = wantsSlab ? 'slab' : wantsBand ? 'band' : 'surface';
+  if (wants !== target) return false;
+  if (wants === 'surface' && !selector.includes('.rx-tx-surface')) return false;
+  if (selector.includes(':disabled') && !state.keyDisabled) return false;
+  for (const [, attribute, value] of selector.matchAll(/:has\(\[data-(session|rf)='([^']+)']\)/g)) {
+    if ((attribute === 'session' ? state.session : state.rf) !== value) return false;
+  }
+  // A rule scoped to a state attribute this selector never names still applies.
+  return true;
+}
+
+/** The declaration a browser would use: highest specificity, then latest. */
+function winner(property: string, state: SurfaceState, target: Target = 'surface'): string | undefined {
+  const candidates = RULES
+    .filter((r) => r.declarations[property] !== undefined && matches(r.selector, state, target))
+    .sort((a, b) => a.specificity - b.specificity || a.order - b.order);
+  return candidates.at(-1)?.declarations[property];
+}
+
+const RX = { session: 'idle', rf: 'receiving' };
+const PENDING = { session: 'pending', rf: 'uncertain', keyDisabled: true };
+const KEYED = { session: 'keyed', rf: 'transmitting', keyDisabled: true };
+const RELEASING = { session: 'releasing', rf: 'transmitting', keyDisabled: true };
+// The crux state: a failed session almost always reports RF doubt as well, so
+// the fault rule and the doubt rule both match and one of them has to win.
+const FAULT = { session: 'failed', rf: 'uncertain', keyDisabled: true };
+const RF_UNKNOWN = { session: 'idle', rf: 'unknown' };
+const BLOCKED = { session: 'idle', rf: 'receiving', keyDisabled: true };
+
+describe('the sheet parses into something worth asserting against', () => {
+  it('found the rail, band and slab rules it is about to rank', () => {
+    expect(RULES.length).toBeGreaterThan(20);
+    expect(RULES.filter((r) => STATE_SCOPED.test(r.selector))).not.toHaveLength(0);
+  });
+});
+
+describe('F1 — the fault rail WINS over the RF-doubt rail, it does not merely exist', () => {
+  it('renders a fault red, not the amber of the doubt rail it overlaps with', () => {
+    expect(winner('border-inline-start', FAULT)).toBe('24px solid var(--dl-fieldline-tx-active)');
+    expect(winner('border-inline-start', FAULT)).not.toContain('tx-tuning');
+  });
+
+  it('still leaves RF doubt amber when the session has NOT failed', () => {
+    expect(winner('border-inline-start', RF_UNKNOWN)).toBe('16px solid var(--dl-fieldline-tx-tuning)');
+    expect(winner('border-inline-start', { session: 'idle', rf: 'uncertain' }))
+      .toBe('16px solid var(--dl-fieldline-tx-tuning)');
+  });
+
+  it('the two rules really do collide — the pin above is not vacuous', () => {
+    const colliding = RULES.filter(
+      (r) => r.declarations['border-inline-start'] && matches(r.selector, FAULT, 'surface'));
+    expect(colliding.length).toBeGreaterThanOrEqual(2);
+    expect(colliding.map((r) => r.declarations['border-inline-start']))
+      .toContain('16px solid var(--dl-fieldline-tx-tuning)');
+  });
+
+  it('every rail flood is one of the declared 8/16/24px widths', () => {
+    for (const state of [PENDING, KEYED, RELEASING, FAULT, RF_UNKNOWN]) {
+      expect(winner('border-inline-start', state))
+        .toMatch(/^(?:16|24)px solid var\(--dl-fieldline-tx-\w+\)$/);
+    }
+    // The RX baseline is the token'd 8px rail, on the RX tone.
+    expect(winner('border-inline-start', RX))
+      .toBe('var(--dl-fieldline-rail) solid var(--dl-fieldline-rx-idle)');
+  });
+
+  it('the carrier is the INLINE-START edge — a top rail would be studioline', () => {
+    expect(css).not.toMatch(/border-top:/);
+    expect(css).toMatch(/border-inline-start:/);
+  });
+});
+
+describe('F2 — the TX slab carries state in GEOMETRY, not only in colour (N2)', () => {
+  /** The two non-colour channels: edge style and whether the slab is filled. */
+  function geometry(state: SurfaceState): string {
+    // `border: var(--dl-fieldline-border) solid currentcolor` on the base rule
+    // is the shorthand that seeds the edge, so an absent `border-style`
+    // override means `solid`.
+    const style = winner('border-style', state, 'slab')
+      ?? winner('border', state, 'slab')?.split(/\s+/)[1]
+      ?? 'solid';
+    const background = winner('background', state, 'slab') ?? 'none';
+    const fill = background === 'none' ? 'empty'
+      : background.includes('gradient') ? 'hatched' : 'solid';
+    return `${style}/${fill}`;
+  }
+
+  it('gives each treatment its own edge+fill pair, so colour is never the only channel', () => {
+    const treatments = {
+      idle: geometry(RX), pending: geometry(PENDING), keyed: geometry(KEYED),
+      fault: geometry(FAULT), blocked: geometry(BLOCKED),
+    };
+    expect(treatments).toEqual({
+      idle: 'solid/empty',
+      pending: 'solid/hatched',
+      keyed: 'solid/solid',
+      fault: 'dashed/empty',
+      blocked: 'dotted/empty',
+    });
+    // The property that actually matters: all five are mutually distinguishable.
+    expect(new Set(Object.values(treatments)).size).toBe(5);
+  });
+
+  it('keyed outranks the inert treatment on SPECIFICITY, not on rule order', () => {
+    expect(geometry(KEYED)).toBe('solid/solid');
+    expect(geometry(RELEASING)).toBe('solid/solid');
+    const keyed = RULES.find((r) => r.selector.includes("session='keyed'") && r.selector.includes('.rx-tx-key'))!;
+    const inert = RULES.find((r) => r.selector.includes(':disabled') && r.selector.includes('.rx-tx-key'))!;
+    expect(keyed.specificity).toBeGreaterThan(inert.specificity);
+  });
+
+  it('the slab is square and full-width in every state — no pill anywhere', () => {
+    expect(winner('border-radius', RX, 'slab')).toBe('0');
+    expect(winner('border-radius', FAULT, 'slab')).toBe('0');
+    expect(winner('width', RX, 'slab')).toBe('100%');
+    expect(winner('min-height', RX, 'slab')).toBe('48px');
+    expect(css).not.toMatch(/border-radius:\s*999px/);
+  });
+});
+
+describe('F3 — the band takes over, and a fault band beats the doubt band', () => {
+  it('floods solid with knocked-out black text while keyed', () => {
+    expect(winner('background', KEYED, 'band')).toBe('var(--dl-fieldline-tx-active)');
+    expect(winner('color', KEYED, 'band')).toBe('var(--dl-fieldline-knockout)');
+  });
+
+  it('a fault band is filled red, not the outlined amber of the doubt band', () => {
+    expect(winner('background', FAULT, 'band')).toBe('var(--dl-fieldline-tx-active)');
+    expect(winner('border-color', FAULT, 'band')).toBe('var(--dl-fieldline-tx-active)');
+    expect(winner('color', FAULT, 'band')).toBe('var(--dl-fieldline-knockout)');
+  });
+
+  it('doubt and pending stay OUTLINED — an unfilled band is a different reading', () => {
+    for (const state of [PENDING, RF_UNKNOWN]) {
+      expect(winner('border-color', state, 'band')).toBe('var(--dl-fieldline-tx-tuning)');
+      expect(winner('background', state, 'band')).toBe('none');
+    }
+  });
+
+  it('RX shows no band at all: a transparent edge and no fill', () => {
+    expect(winner('border', RX, 'band')).toBe('var(--dl-fieldline-border) solid transparent');
+    expect(winner('background', RX, 'band')).toBe('none');
+  });
+});
+
+describe('the CSS half honours the same constraints as the token half', () => {
+  it('is activated ONLY by the design-language attribute (owner decision Q2)', () => {
+    // Every rule in the sheet is rooted at the attribute — no class, prop or
+    // context can switch this language on.
+    for (const rule of RULES) {
+      expect(rule.selector).toMatch(/^\[data-design-language='fieldline']\[data-design-language]/);
+    }
+  });
+
+  it('never flips polarity on prefers-color-scheme — daylight is an explicit opt-in', () => {
+    expect(css).not.toMatch(/prefers-color-scheme/);
+    expect(css).toMatch(/\[data-language-mode='light']/);
+  });
+
+  it('adds and removes nothing — a language may not become a capability fork', () => {
+    expect(css).not.toMatch(/display:\s*none/);
+    expect(css).not.toMatch(/visibility:\s*hidden/);
+    expect(css).not.toMatch(/content:\s*'/);
+  });
+
+  it('never re-suppresses the focus ring, and applies it as `outline` (MOR-977 §1.2.5)', () => {
+    expect(css).not.toMatch(/outline:\s*none/);
+    expect(css).toMatch(/outline:\s*3px solid var\(--dl-fieldline-focus\)/);
+  });
+
+  it('wins on specificity rather than on `!important`', () => {
+    expect(css).not.toMatch(/!important/);
+  });
+
+  it('declares no motion at all, which is why it needs no reduced-motion block', () => {
+    expect(css).not.toMatch(/transition/);
+    expect(css).not.toMatch(/animation/);
+    expect(css).not.toMatch(/@keyframes/);
+  });
+
+  it('is flat by construction: no shadow, no inset, no radial or linear wash', () => {
+    expect(css).not.toMatch(/box-shadow/);
+    // The one gradient is the pending HATCH, which is a pattern, not a wash.
+    const gradients = css.match(/[\w-]*gradient\(/g) ?? [];
+    expect(gradients).toEqual(['repeating-linear-gradient(']);
+  });
+
+  it('declares every palette entry it references as a custom property', () => {
+    for (const hex of Object.values(FIELDLINE_PALETTE)) {
+      expect(css.toLowerCase()).toContain(hex.toLowerCase());
+    }
+  });
+});

--- a/frontend/src/presentation/languages/fieldline/__tests__/tokens.test.ts
+++ b/frontend/src/presentation/languages/fieldline/__tests__/tokens.test.ts
@@ -1,0 +1,179 @@
+/**
+ * MOR-1074 — the `fieldline` token slice.
+ *
+ * Same two things are pinned here as in studioline's twin file, because the
+ * point of a SECOND language is that the same obligations bind it:
+ *
+ *  1. FOCUS-RING SYNTAX (MOR-1232 D5) — the ring is stored as one opaque
+ *     string and applied to `outline`, where a box-shadow-shaped literal is
+ *     silently invalid and the ring simply never appears.
+ *
+ *  2. CONTRAST AS ARITHMETIC, NOT OPINION (owner decision Q1, 2026-08-04).
+ *     fieldline supplies its own placeholder/ring tone and every state tone
+ *     clears 3:1 against BOTH its surfaces — computed here, not eyeballed.
+ *     Label TEXT is held to 4.5:1 against its own ground in BOTH modes, which
+ *     is the bar studioline missed in light mode (finding MOR-1277).
+ *
+ * The third group is what makes this file worth having at all: the token set
+ * must be the OPPOSITE of studioline on every axis a token can express, or the
+ * "second language" claim is decoration. Those assertions compare the two
+ * declared bundles directly rather than restating fieldline's numbers.
+ */
+import { describe, it, expect } from 'vitest';
+import { validateManifest, REQUIRED_TOKEN_GROUPS } from '../../contract';
+import { studioline, fieldline } from '../../declarations';
+import { STUDIOLINE_TOKENS } from '../../studioline/tokens';
+import {
+  FIELDLINE_KNOCKOUT, FIELDLINE_LABEL_TONES, FIELDLINE_PALETTE, FIELDLINE_SURFACES, FIELDLINE_TOKENS,
+} from '../tokens';
+
+/** WCAG relative luminance / contrast ratio, on `#rrggbb` only. */
+function luminance(hex: string): number {
+  const n = Number.parseInt(hex.slice(1), 16);
+  const channel = (c: number): number => {
+    const s = c / 255;
+    return s <= 0.04045 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * channel((n >> 16) & 255) + 0.7152 * channel((n >> 8) & 255) + 0.0722 * channel(n & 255);
+}
+function contrast(a: string, b: string): number {
+  const [x, y] = [luminance(a), luminance(b)];
+  return (Math.max(x, y) + 0.05) / (Math.min(x, y) + 0.05);
+}
+
+/** `<width> <style> <color>` — the shorthand form `outline` actually accepts. */
+const OUTLINE_SHORTHAND = /^\d+(?:\.\d+)?px\s+(?:solid|dashed|dotted|double)\s+\S.*$/;
+const fallbackHex = (token: string): string => {
+  const hit = /#[0-9a-fA-F]{6}/.exec(token);
+  expect(hit, `expected a literal #rrggbb fallback in "${token}"`).not.toBeNull();
+  return hit![0];
+};
+
+describe('fieldline contrast regime (owner decision Q1; MOR-977 §3.2)', () => {
+  const surfaces = Object.entries(FIELDLINE_SURFACES);
+
+  it('declares both grounds it must survive on — dark shack and daylight', () => {
+    expect(Object.keys(FIELDLINE_SURFACES).sort()).toEqual(['dark', 'light']);
+    // Daylight is the hard case: pure white, not studioline's warm off-white.
+    expect(FIELDLINE_SURFACES.light).toBe('#FFFFFF');
+  });
+
+  it('declares its OWN ring tone rather than inheriting var(--accent)', () => {
+    expect(fieldline.tokens.focusRing).toMatch(OUTLINE_SHORTHAND);
+    expect(fieldline.tokens.focusRing).not.toMatch(/--accent/);
+    expect(fieldline.tokens.focusRing).not.toMatch(/^0 0 0 /);
+  });
+
+  it.each(surfaces)('the focus ring clears 3:1 on the %s surface', (_mode, surface) => {
+    expect(contrast(fallbackHex(fieldline.tokens.focusRing), surface)).toBeGreaterThanOrEqual(3);
+  });
+
+  it.each(
+    surfaces.flatMap(([mode, surface]) =>
+      Object.entries(FIELDLINE_PALETTE).map(([t, hex]) => [t, mode, hex, surface] as const)),
+  )('state tone "%s" clears 3:1 on the %s surface', (_tone, _mode, hex, surface) => {
+    expect(contrast(hex, surface)).toBeGreaterThanOrEqual(3);
+  });
+
+  // The declared margin, not just the floor: flat sunlight-safe fills have no
+  // gradient or glow to fall back on, so the whole palette is held higher.
+  it.each(surfaces)('every tone in fact clears 3.9:1 on the %s surface', (_mode, surface) => {
+    for (const hex of Object.values(FIELDLINE_PALETTE)) {
+      expect(contrast(hex, surface)).toBeGreaterThanOrEqual(3.9);
+    }
+  });
+
+  // MOR-1277 is the finding this pin exists to avoid repeating: 3:1 is the
+  // NON-TEXT floor, and a label is text.
+  it.each(Object.entries(FIELDLINE_LABEL_TONES))(
+    'label text and muted label text clear 4.5:1 on their own %s ground', (mode, tones) => {
+      const surface = FIELDLINE_SURFACES[mode as keyof typeof FIELDLINE_SURFACES];
+      expect(contrast(tones.text, surface)).toBeGreaterThanOrEqual(4.5);
+      expect(contrast(tones.muted, surface)).toBeGreaterThanOrEqual(4.5);
+    },
+  );
+
+  it('knocked-out black label text clears 4.5:1 on the filled TX slab, in both modes', () => {
+    // One value for both modes, so one assertion covers both (MOR-977 §2.2).
+    expect(contrast(FIELDLINE_KNOCKOUT, FIELDLINE_PALETTE.txActive)).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it('every rx/tx token resolves to a palette entry with a literal fallback', () => {
+    const stateTokens = [...Object.values(FIELDLINE_TOKENS.rx), ...Object.values(FIELDLINE_TOKENS.tx)];
+    expect(stateTokens).toHaveLength(6);
+    for (const token of stateTokens) {
+      expect(Object.values(FIELDLINE_PALETTE)).toContain(fallbackHex(token));
+    }
+  });
+});
+
+describe('fieldline token set implements the MOR-977 §2.2 grammar', () => {
+  it('validates against the MOR-1072 contract', () => {
+    expect(() => validateManifest(fieldline)).not.toThrow();
+    expect(REQUIRED_TOKEN_GROUPS.every((g) => fieldline.tokens[g] !== undefined)).toBe(true);
+  });
+
+  it('is the manifest fieldline registers — not a copy', () => {
+    expect(fieldline.tokens).toBe(FIELDLINE_TOKENS);
+  });
+
+  it('numerals are monospace slab digits at 700, and still declare tabular figures', () => {
+    expect(FIELDLINE_TOKENS.typography.weight).toBe(700);
+    expect(FIELDLINE_TOKENS.typography.fontFamily).toMatch(/mono/i);
+    expect(FIELDLINE_TOKENS.typography.fontVariantNumeric).toBe('tabular-nums');
+  });
+
+  it('is hard-edged: zero radius with a 3px opaque border', () => {
+    expect(FIELDLINE_TOKENS.geometry.radius).toBe('0px');
+    expect(FIELDLINE_TOKENS.geometry.borderWidth).toBe('3px');
+  });
+
+  it('the meter is discrete segments with a real gap, not a continuous rail', () => {
+    expect(FIELDLINE_TOKENS.meters.segmentGap).toBe('3px');
+    expect(Number.parseFloat(FIELDLINE_TOKENS.meters.segmentGap)).toBeGreaterThan(0);
+  });
+
+  it('frequency groups are NOT ranked — the Hz digits carry the numeral weight too', () => {
+    expect(FIELDLINE_TOKENS.frequency.rankedGroups).toBe(false);
+    expect(FIELDLINE_TOKENS.frequency.digitWeight).toBe(FIELDLINE_TOKENS.typography.weight);
+  });
+
+  it('declares zero motion, so the grammar is intact under the reduced-motion clamp', () => {
+    expect(FIELDLINE_TOKENS.motion.durationMs).toBe(0);
+    expect(FIELDLINE_TOKENS.motion.reducedMotionSafe).toBe(true);
+  });
+
+  it('clamps out "dense" and declares the cockpit incompatible (MOR-977 §4.4)', () => {
+    expect(fieldline.density).toEqual({ kind: 'clamped', supported: ['comfortable', 'compact'] });
+    expect(fieldline.layoutCompatibility).toContainEqual(
+      expect.objectContaining({ layoutId: 'dual-receiver-cockpit', compatible: false }),
+    );
+  });
+});
+
+describe('fieldline is a materially different language, not a recolour of studioline', () => {
+  // The MOR-977 §4.3.1 claim, asserted rather than asserted-in-prose: the two
+  // bundles disagree on every axis a TOKEN can express. Colour is deliberately
+  // absent from this list — a language that differed only in colour would pass
+  // a colour comparison and still be a reskin.
+  it.each([
+    ['numeral weight', (t: typeof FIELDLINE_TOKENS) => t.typography.weight],
+    ['numeral face is monospace', (t: typeof FIELDLINE_TOKENS) => /mono/i.test(t.typography.fontFamily)],
+    ['border weight', (t: typeof FIELDLINE_TOKENS) => t.geometry.borderWidth],
+    ['meter segment gap', (t: typeof FIELDLINE_TOKENS) => t.meters.segmentGap],
+    ['meter track width', (t: typeof FIELDLINE_TOKENS) => t.meters.trackWidth],
+    ['frequency group ranking', (t: typeof FIELDLINE_TOKENS) => t.frequency.rankedGroups],
+    ['digit weight', (t: typeof FIELDLINE_TOKENS) => t.frequency.digitWeight],
+    ['focus-ring width', (t: typeof FIELDLINE_TOKENS) => t.focusRing.split(' ')[0]],
+  ])('differs from studioline on %s', (_axis, read) => {
+    expect(read(FIELDLINE_TOKENS)).not.toEqual(read(STUDIOLINE_TOKENS));
+  });
+
+  it('shares the contract, not the bundle: both satisfy every required token group', () => {
+    expect(fieldline.tokens).not.toBe(studioline.tokens);
+    for (const group of REQUIRED_TOKEN_GROUPS) {
+      expect(fieldline.tokens[group]).toBeDefined();
+      expect(studioline.tokens[group]).toBeDefined();
+    }
+  });
+});

--- a/frontend/src/presentation/languages/fieldline/fieldline.css
+++ b/frontend/src/presentation/languages/fieldline/fieldline.css
@@ -1,0 +1,329 @@
+/*
+  `fieldline` design language — the CSS half of the MOR-1074 token slice.
+  Its arithmetic half is `./tokens.ts`; every colour below is one of the palette
+  entries proven there to clear 3:1 (in fact 3.9:1) against BOTH fieldline
+  surfaces, with label text held to 4.5:1 on its own ground.
+
+  ACTIVATION. `[data-design-language='fieldline']` is the ONLY activation
+  mechanism — no class, no prop, no context (owner decision Q2, 2026-08-04).
+  Loading this file therefore changes nothing until a host sets that attribute.
+  Routing a language into the shell is cutover work (MOR-1048/MOR-1263); the
+  only opt-in today is the MOR-1070 fixture harness (`?language=fieldline`).
+
+  WHAT IT MAY STYLE. Colour, type, spacing and geometry on the semantic
+  surfaces. Never which facts appear, never whether a control is available: no
+  rule here uses `display: none`, `visibility`, or `content` to add or remove a
+  fact, and none keys off a capability.
+
+  SPECIFICITY. The root selector repeats the attribute
+  (`[data-design-language='fieldline'][data-design-language]`) purely to score
+  (0,3,0), for the same reason studioline does: Svelte compiles a component's
+  own rules to `.vfo-surface.s-<hash>` — also (0,2,0) — and injects them after
+  this file, so a single-attribute root would TIE and lose on order. Deliberate
+  one-step raise, not an escalation ladder; nothing here uses `!important`.
+
+  WHAT IS DELIBERATELY ABSENT. Anything the semantic components already declare
+  is not restated: `.rx-tx-surface` and `.rx-tx-state` are already flex, and
+  `.rx-tx-state`/`.rx-tx-fault` already zero their margins. A language restyles;
+  it does not re-declare a layout it agrees with.
+
+  R9. The TX-adjacent rules key off `[data-session]` / `[data-rf]`, which
+  RxTxSurface derives from the App-owned TX authority snapshot — never from
+  `radioState.ptt`. CSS displays that authority's conclusion; it cannot form one.
+
+  NO MOTION AT ALL. This file declares no transition, animation or keyframes,
+  and that is a grammar property rather than an omission: every fieldline state
+  change is a discrete colour/size step, so the language is fully intact under
+  `prefers-reduced-motion` without needing a reduce block (MOR-977 §3.2).
+*/
+
+[data-design-language='fieldline'][data-design-language] {
+  --dl-fieldline-focus: #0a6ed1;
+  --dl-fieldline-rx-idle: #6e7a85;
+  --dl-fieldline-rx-active: #008a5c;
+  --dl-fieldline-rx-tuning: #0a6ed1;
+  --dl-fieldline-tx-idle: #8a6a2e;
+  --dl-fieldline-tx-active: #e03a2f;
+  --dl-fieldline-tx-tuning: #b25a00;
+  --dl-fieldline-inert: #6f7a85;
+
+  --dl-fieldline-surface: #0a0a0a;
+  --dl-fieldline-text: #f2f5f7;
+  --dl-fieldline-muted: #c2cbd2;
+  /* Knocked-out label text on a filled slab or band: black in BOTH modes. */
+  --dl-fieldline-knockout: #0a0a0a;
+  /* 8px rhythm throughout — no micro/macro split, because this grammar ranks
+     by block size and border weight rather than by negative space. */
+  --dl-fieldline-gap: 8px;
+  --dl-fieldline-border: 3px;
+  --dl-fieldline-rail: 8px;
+  --dl-fieldline-font: ui-monospace, 'SF Mono', Menlo, 'DejaVu Sans Mono', 'Roboto Mono', monospace;
+
+  /* `app.css` paints `body { background-color: var(--bg) }`, so a background
+     declared only here would be covered by the body box. Re-pointing `--bg` is
+     what actually makes the language own its surface. */
+  --bg: var(--dl-fieldline-surface);
+
+  background: var(--dl-fieldline-surface);
+  color: var(--dl-fieldline-text);
+  font-family: var(--dl-fieldline-font);
+  font-variant-numeric: tabular-nums;
+}
+
+/* Restated rather than inherited, for the mirror of studioline's reason: the
+   shared wiring block (`.semantic-surfaces`) pins its own family above these,
+   so an `inherit` here would resolve to whatever that block chose. */
+[data-design-language='fieldline'][data-design-language] .semantic-surfaces,
+[data-design-language='fieldline'][data-design-language] .channel-strip {
+  font-family: var(--dl-fieldline-font);
+}
+
+/* DAYLIGHT MODE — not "light mode". Black on white, borders held at full
+   strength, state fills at maximum saturation. This is the grammar's BEST
+   condition, the one no other family is usable in, not a compromise
+   (MOR-977 §5).
+
+   EXPLICIT OPT-IN, not `prefers-color-scheme`: this app's light/dark is a
+   MANUAL `[data-theme]` choice and nothing in it responds to the OS signal, so
+   a language that flipped its own text to black on an OS preference would put
+   black text on the app's still-dark surface. */
+[data-design-language='fieldline'][data-design-language][data-language-mode='light'] {
+  --dl-fieldline-surface: #ffffff;
+  --dl-fieldline-text: #000000;
+  --dl-fieldline-muted: #3a4249;
+}
+
+/* High contrast pushes both label tones to the rail; the numeral weight is
+   already 700 and has nowhere useful to go, so unlike studioline — which must
+   bump 200 → 600 — this bundle changes colour only. */
+[data-design-language='fieldline'][data-design-language][data-theme='high-contrast'],
+[data-design-language='fieldline'][data-design-language] [data-theme='high-contrast'] {
+  --dl-fieldline-text: #ffffff;
+  --dl-fieldline-muted: #ffffff;
+}
+
+/* ── One focus contract, never re-suppressed (MOR-977 §1.2.5) ───────────── */
+[data-design-language='fieldline'][data-design-language] :focus-visible {
+  /* Outline shorthand matching the token literal exactly (MOR-1232 D5). 3px
+     and hugging the edge: thick borders give the ring room, so it reads as an
+     inversion of the block rather than as a halo standing off it — the
+     opposite placement to studioline's 3px offset (MOR-977 §3.2). */
+  outline: 3px solid var(--dl-fieldline-focus);
+  outline-offset: 0;
+}
+
+/* ── Stacked blocks: hard edges, 8px rhythm, nothing soft ───────────────── */
+[data-design-language='fieldline'][data-design-language] .vfo-surface,
+[data-design-language='fieldline'][data-design-language] .vfo-list,
+[data-design-language='fieldline'][data-design-language] .rx-tx-surface {
+  gap: var(--dl-fieldline-gap);
+  font-family: var(--dl-fieldline-font);
+  color: var(--dl-fieldline-text);
+}
+[data-design-language='fieldline'][data-design-language] .vfo-tile {
+  border: var(--dl-fieldline-border) solid var(--dl-fieldline-rx-idle);
+  border-radius: 0;
+  background: none;
+  padding: var(--dl-fieldline-gap);
+  gap: var(--dl-fieldline-gap);
+}
+/* Identity is carried by a flooded left rail on the block itself — the same
+   carrier the TX surface uses, so one silhouette cue covers both. */
+[data-design-language='fieldline'][data-design-language] .vfo-tile.is-active {
+  border-inline-start: var(--dl-fieldline-rail) solid var(--dl-fieldline-rx-active);
+}
+[data-design-language='fieldline'][data-design-language] .vfo-freq {
+  font-size: 34px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+/* Labels are bordered CHIPS at 800, not micro-labels that recede: this grammar
+   has no light weights anywhere and ranks nothing by subtlety. */
+[data-design-language='fieldline'][data-design-language] .active-receiver,
+[data-design-language='fieldline'][data-design-language] .vfo-role,
+[data-design-language='fieldline'][data-design-language] .vfo-mode,
+[data-design-language='fieldline'][data-design-language] .vfo-badge,
+[data-design-language='fieldline'][data-design-language] .rx-tx-session,
+[data-design-language='fieldline'][data-design-language] .rx-tx-origin {
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--dl-fieldline-muted);
+  border: 2px solid currentcolor;
+  border-radius: 0;
+  padding: 2px 6px;
+}
+/* The TX-target marker keeps the chip and changes only its tone — the border
+   follows via `currentcolor`. */
+[data-design-language='fieldline'][data-design-language] .vfo-badge {
+  color: var(--dl-fieldline-tx-active);
+}
+
+/* ── Controls: one hard-edged 48px block, whatever the control ───────────
+   Above the 44px `--tap-target` floor because this grammar assumes gloves,
+   daylight and possibly one hand. `currentcolor` borders let each group set
+   only its tone below. */
+[data-design-language='fieldline'][data-design-language] .vfo-select,
+[data-design-language='fieldline'][data-design-language] .fact-toggle,
+[data-design-language='fieldline'][data-design-language] .rx-tx-key,
+[data-design-language='fieldline'][data-design-language] .rx-tx-unkey {
+  border: var(--dl-fieldline-border) solid currentcolor;
+  /* Zero radius everywhere — this grammar allows no pill anywhere at all. */
+  border-radius: 0;
+  background: none;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 12px var(--dl-fieldline-gap);
+  min-height: 48px;
+  cursor: pointer;
+}
+[data-design-language='fieldline'][data-design-language] .vfo-select,
+[data-design-language='fieldline'][data-design-language] .fact-toggle {
+  color: var(--dl-fieldline-muted);
+}
+/* Disabled must stay legible: it is a fact about the radio, not a dimming. */
+[data-design-language='fieldline'][data-design-language] .vfo-select:disabled,
+[data-design-language='fieldline'][data-design-language] .fact-toggle:disabled {
+  color: var(--dl-fieldline-inert);
+  border-style: dotted;
+}
+
+/* ── The TX carrier: a flooding LEFT rail (MOR-977 §2.2) ─────────────────
+   Width AND colour, so the state survives forced-colors: 8px baseline, 16px
+   for doubt, 24px for RF that is actually out. The left edge is the one
+   element that never scrolls out of a stacked layout. */
+[data-design-language='fieldline'][data-design-language] .rx-tx-surface {
+  padding-inline-start: var(--dl-fieldline-gap);
+  border-inline-start: var(--dl-fieldline-rail) solid var(--dl-fieldline-rx-idle);
+}
+[data-design-language='fieldline'][data-design-language] .rx-tx-surface:has([data-session='pending']) {
+  border-inline-start: 16px solid var(--dl-fieldline-tx-tuning);
+}
+[data-design-language='fieldline'][data-design-language] .rx-tx-surface:has([data-session='keyed']) {
+  border-inline-start: 24px solid var(--dl-fieldline-tx-active);
+}
+[data-design-language='fieldline'][data-design-language] .rx-tx-surface:has([data-session='releasing']) {
+  border-inline-start: 16px solid var(--dl-fieldline-tx-active);
+}
+/* Unknown RF is a THIRD thing, never RX (MOR-977 §1.2.1). */
+[data-design-language='fieldline'][data-design-language] .rx-tx-surface:has([data-rf='unknown']),
+[data-design-language='fieldline'][data-design-language] .rx-tx-surface:has([data-rf='uncertain']) {
+  border-inline-start: 16px solid var(--dl-fieldline-tx-tuning);
+}
+/* A fault outranks RF doubt and must stay LAST: a failed session almost always
+   reports `rf=uncertain` too, and at equal specificity the later rule wins — so
+   ordering, not specificity, is what keeps a fault rail red instead of amber. */
+[data-design-language='fieldline'][data-design-language] .rx-tx-surface:has([data-session='failed']) {
+  border-inline-start: 24px solid var(--dl-fieldline-tx-active);
+}
+
+/* ── The band: a full-width strip above the reading, not a micro-label ──── */
+[data-design-language='fieldline'][data-design-language] .rx-tx-state {
+  padding: var(--dl-fieldline-gap);
+  /* A transparent edge at full width reserves the band's box in every state,
+     so appearing is a colour step and never a reflow. */
+  border: var(--dl-fieldline-border) solid transparent;
+  background: none;
+  color: var(--dl-fieldline-text);
+}
+[data-design-language='fieldline'][data-design-language] .rx-tx-surface:has([data-session='pending']) .rx-tx-state,
+[data-design-language='fieldline'][data-design-language] .rx-tx-surface:has([data-rf='unknown']) .rx-tx-state,
+[data-design-language='fieldline'][data-design-language] .rx-tx-surface:has([data-rf='uncertain']) .rx-tx-state {
+  border-color: var(--dl-fieldline-tx-tuning);
+}
+/* KEYED floods the band solid with the label knocked out in black — the
+   takeover the grammar is named for. */
+[data-design-language='fieldline'][data-design-language] .rx-tx-surface:has([data-session='keyed']) .rx-tx-state {
+  border-color: var(--dl-fieldline-tx-active);
+  background: var(--dl-fieldline-tx-active);
+  color: var(--dl-fieldline-knockout);
+}
+/* FAULT floods it the same way and stays LAST, same ordering argument as the
+   rail: a failed session reports RF doubt too, and the amber outline above
+   must not be what the operator sees. */
+[data-design-language='fieldline'][data-design-language] .rx-tx-surface:has([data-session='failed']) .rx-tx-state {
+  border-color: var(--dl-fieldline-tx-active);
+  background: var(--dl-fieldline-tx-active);
+  color: var(--dl-fieldline-knockout);
+}
+[data-design-language='fieldline'][data-design-language] .rx-tx-label {
+  font-size: 22px;
+  font-weight: 800;
+}
+[data-design-language='fieldline'][data-design-language] .rx-tx-fault {
+  font-size: 12px;
+  text-transform: uppercase;
+  color: var(--dl-fieldline-knockout);
+  background: var(--dl-fieldline-tx-active);
+  padding: var(--dl-fieldline-gap);
+}
+[data-design-language='fieldline'][data-design-language] .rx-tx-blocked {
+  color: var(--dl-fieldline-muted);
+}
+
+/* ── The action slab: full-width, hard-edged (MOR-977 §2.2) ───────────────
+   Border style and fill carry the state without colour, so the five treatments
+   stay distinct under forced-colors and colour-vision deficiency:
+     idle     solid edge, no fill
+     pending  solid edge, hatched fill
+     keyed    solid edge, solid fill (label knocked out in black)
+     fault    dashed edge, no fill
+     blocked  dotted edge, no fill
+   The state itself always comes from `[data-session]`, i.e. from the App TX
+   authority — never from a raw PTT reading (R9). */
+[data-design-language='fieldline'][data-design-language] .rx-tx-actions {
+  flex-direction: column;
+  gap: var(--dl-fieldline-gap);
+}
+[data-design-language='fieldline'][data-design-language] .rx-tx-key,
+[data-design-language='fieldline'][data-design-language] .rx-tx-unkey {
+  width: 100%;
+  color: var(--dl-fieldline-tx-idle);
+}
+/* IDLE — outlined and quiet: keying is deliberate, not the default gesture. */
+[data-design-language='fieldline'][data-design-language] .rx-tx-surface:has([data-session='idle']) .rx-tx-key {
+  color: var(--dl-fieldline-rx-tuning);
+}
+/* PENDING — the request is out but no RF is; hatched, so it can never be
+   mistaken for the keyed fill. Coarse 8px hatching, not studioline's 5px: this
+   has to read through sunlight and a glove. */
+[data-design-language='fieldline'][data-design-language] .rx-tx-surface:has([data-session='pending']) .rx-tx-key {
+  color: var(--dl-fieldline-tx-tuning);
+  border-style: solid;
+  background: repeating-linear-gradient(
+    -45deg, transparent 0 8px, color-mix(in srgb, var(--dl-fieldline-tx-tuning) 45%, transparent) 8px 16px
+  );
+}
+/* KEYED — solid fill with a knocked-out BLACK label: the loudest thing on
+   screen. The slab is also `disabled` here, and the inert treatment below must
+   NOT bleed through, so these selectors outrank it and the border style is
+   restated rather than left to cascade order. */
+[data-design-language='fieldline'][data-design-language] .rx-tx-surface:has([data-session='keyed']) .rx-tx-key,
+[data-design-language='fieldline'][data-design-language] .rx-tx-surface:has([data-session='releasing']) .rx-tx-key {
+  background: var(--dl-fieldline-tx-active);
+  border-color: var(--dl-fieldline-tx-active);
+  border-style: solid;
+  color: var(--dl-fieldline-knockout);
+}
+/* FAULT — dashed, so the state reads without colour. */
+[data-design-language='fieldline'][data-design-language] .rx-tx-surface:has([data-session='failed']) .rx-tx-key {
+  color: var(--dl-fieldline-tx-active);
+  border-style: dashed;
+}
+/* Fail-closed permit renders as DENIAL, not absence — inert but present, and
+   still legible (MOR-977 §1.2.3). A hidden PTT reads as "no TX capability",
+   which is a different fact. */
+[data-design-language='fieldline'][data-design-language] .rx-tx-key:disabled {
+  color: var(--dl-fieldline-inert);
+  border-style: dotted;
+  background: none;
+  cursor: not-allowed;
+}
+/* Unkey is never gated, and is the heaviest control on the surface. */
+[data-design-language='fieldline'][data-design-language] .rx-tx-unkey {
+  color: var(--dl-fieldline-text);
+}

--- a/frontend/src/presentation/languages/fieldline/frequency-renderer.ts
+++ b/frontend/src/presentation/languages/fieldline/frequency-renderer.ts
@@ -1,0 +1,106 @@
+/**
+ * `fieldline` frequency renderer (MOR-1074, VFO slice) — MOR-977 §2.2's
+ * "slab digits, left-aligned, no group de-emphasis".
+ *
+ * Pure projection of one frequency fact. It reads exactly two named fields and
+ * nothing else, so an extra field on the view model — a smuggled capability
+ * payload, a raw `ptt` — cannot reach the output. Digit semantics are identical
+ * to `splitFrequencyToDigits()` and to studioline's: nine digits, leading MHz
+ * zeros shifted off but never below one digit, grouped 10^8..10^6 / 10^5..10^3 /
+ * 10^2..10^0. Only the PRESENTATION of those digits differs.
+ *
+ * Where studioline emits three groups at two type sizes with an underline
+ * descriptor, this emits one flat list of equal-weight DIGIT CELLS: in the field
+ * the Hz digits are read as often as the kHz ones, so nothing is demoted, the
+ * grouping mark is a gap rather than any character, and the tuning affordance
+ * inverts a whole cell to a filled block with a knocked-out glyph — visible at
+ * arm's length, which an underline is not.
+ */
+import type { DesignLanguageTokens, RendererViewModel } from '../contract';
+
+/** The grouping mark IS the gap — fieldline emits no separator character at all. */
+export const GROUP_GAP_PX = 6;
+export const DIGIT_SIZE_PX = 46;
+/** Slab digits are set slightly tight; a mono face already advances uniformly. */
+export const DIGIT_TRACKING = '-0.01em';
+const UNKNOWN_TEXT = '—';
+const GROUP_NAMES = ['mhz', 'khz', 'hz'] as const;
+
+export type FrequencyGroupName = (typeof GROUP_NAMES)[number];
+
+export interface FieldlineDigit {
+  readonly char: string;
+  /** The place value this cell tunes — the same handle studioline's underline uses. */
+  readonly multiplier: number;
+  readonly group: FrequencyGroupName;
+  /** True for the tuned cell: solid fill, glyph knocked out (MOR-977 §2.2). */
+  readonly inverted: boolean;
+  /** First cell of a group, i.e. the cell a 6px gap is placed before. */
+  readonly startsGroup: boolean;
+}
+
+export interface FieldlineFrequency {
+  readonly kind: 'fieldline-frequency';
+  readonly digits: readonly FieldlineDigit[];
+  readonly groupGapPx: number;
+  /** One size for every cell: the axis on which this grammar refuses to rank. */
+  readonly fontSizePx: number;
+  readonly fontWeight: number;
+  /** Empty on purpose — geometry carries the grouping, not a glyph. */
+  readonly separator: '';
+  readonly align: 'start';
+  readonly text: string;
+  readonly unknown: boolean;
+  readonly style: Readonly<Record<string, string>>;
+}
+
+const finiteNumber = (fields: RendererViewModel['fields'], key: string): number | null => {
+  const value = fields[key];
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+};
+
+/** How many of the three MHz digits shift off — capped at 2 so the group never empties. */
+const mhzShift = (digits: string): number =>
+  Math.min(3 - digits.slice(0, 3).replace(/^0+/, '').length, 2);
+
+/** The one multiplier that may invert a cell, or null when nothing is tuned. */
+function tunedMultiplier(raw: number | null): number | null {
+  if (raw === null || raw <= 0) return null;
+  const exponent = Math.log10(raw);
+  return Number.isInteger(exponent) && exponent <= 8 ? raw : null;
+}
+
+export function renderFrequency(
+  viewModel: RendererViewModel, tokens: DesignLanguageTokens,
+): FieldlineFrequency {
+  const style = {
+    fontFamily: tokens.typography.fontFamily,
+    fontWeight: String(tokens.frequency.digitWeight),
+    fontVariantNumeric: tokens.typography.fontVariantNumeric,
+    letterSpacing: DIGIT_TRACKING,
+  };
+  const base = {
+    kind: 'fieldline-frequency', groupGapPx: GROUP_GAP_PX, fontSizePx: DIGIT_SIZE_PX,
+    fontWeight: tokens.frequency.digitWeight, separator: '', align: 'start', style,
+  } as const;
+
+  const hz = finiteNumber(viewModel.fields, 'frequencyHz');
+  if (hz === null) return { ...base, digits: [], text: UNKNOWN_TEXT, unknown: true };
+
+  const digits = String(Math.max(0, Math.floor(hz))).padStart(9, '0');
+  const shift = mhzShift(digits);
+  const tuned = tunedMultiplier(finiteNumber(viewModel.fields, 'tuningMultiplier'));
+  const cells = [...digits].flatMap((char, index): FieldlineDigit[] => {
+    if (index < shift) return []; // a leading MHz zero is shifted off, not ghosted
+    const multiplier = 10 ** (8 - index);
+    return [{
+      char,
+      multiplier,
+      group: GROUP_NAMES[Math.floor(index / 3)],
+      inverted: multiplier === tuned,
+      startsGroup: index % 3 === 0 || index === shift,
+    }];
+  });
+
+  return { ...base, digits: cells, text: cells.map((c) => c.char).join(''), unknown: false };
+}

--- a/frontend/src/presentation/languages/fieldline/meters-renderer.ts
+++ b/frontend/src/presentation/languages/fieldline/meters-renderer.ts
@@ -1,0 +1,94 @@
+/**
+ * `fieldline` meter renderer (MOR-1074, VFO slice) — MOR-977 §2.2's "discrete
+ * segments": 12 chunky blocks separated by the token's gap, zoned by colour at
+ * the S9 and redline boundaries, with peak-hold as a SINGLE segment held at
+ * full brightness rather than a hairline tick.
+ *
+ * Pure geometry, expressed as a fixed segment count so the consumer owns the
+ * pixel width. Ballistics are NOT here: smoothing is a per-grammar tuning
+ * applied at the smoother (MOR-977 §1.1), not a renderer behaviour — fieldline
+ * is the fastest and least smoothed of the three, and that lives with the
+ * smoother, not with this descriptor.
+ *
+ * The contrast with studioline is structural, not cosmetic: a continuous rail
+ * carries a fractional fill and a sub-pixel peak; a segment ladder quantises
+ * both, so a reading is legible as a COUNT at arm's length with gloves on.
+ */
+import type { DesignLanguageTokens, RendererViewModel } from '../contract';
+
+/** Few enough to count at a glance, coarse enough to read in sunlight. */
+export const FIELDLINE_SEGMENT_COUNT = 12;
+/** Scale marks live under the ladder, at the two zone boundaries only. */
+export const FIELDLINE_SCALE_TICKS = [9, 15] as const;
+
+export type SegmentZone = 'normal' | 'over';
+
+export interface FieldlineSegment {
+  readonly index: number;
+  readonly zone: SegmentZone;
+  readonly lit: boolean;
+  readonly tone: string;
+  /** Peak-hold: one segment held at full brightness, never a second fill. */
+  readonly peakHold: boolean;
+}
+
+export interface FieldlineMeter {
+  readonly kind: 'fieldline-meter';
+  readonly trackWidth: string;
+  readonly segmentGap: string;
+  readonly segments: readonly FieldlineSegment[];
+  /** How many segments the reading lights; `null` when unobserved — never 0. */
+  readonly litCount: number | null;
+  /** Index of the first `over` segment: the S9 boundary, quantised. */
+  readonly crossoverIndex: number;
+  readonly scaleTicks: readonly number[];
+  readonly unknown: boolean;
+}
+
+const clampFraction = (value: number, max: number): number => Math.min(1, Math.max(0, value / max));
+
+const finiteNumber = (fields: RendererViewModel['fields'], key: string): number | null => {
+  const value = fields[key];
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+};
+
+/** Segments are lit by quantised fraction; only a true zero lights nothing. */
+const segmentsFor = (value: number, max: number): number =>
+  Math.ceil(clampFraction(value, max) * FIELDLINE_SEGMENT_COUNT);
+
+export function renderMeter(
+  viewModel: RendererViewModel, tokens: DesignLanguageTokens,
+): FieldlineMeter {
+  const max = finiteNumber(viewModel.fields, 'max') ?? 15;
+  const s9 = finiteNumber(viewModel.fields, 's9') ?? 9;
+  const value = finiteNumber(viewModel.fields, 'value');
+  const peak = finiteNumber(viewModel.fields, 'peak');
+
+  const crossoverIndex = Math.round(clampFraction(s9, max) * FIELDLINE_SEGMENT_COUNT);
+  const litCount = value === null ? null : segmentsFor(value, max);
+  // A held peak below the live reading is already lit; it only earns its own
+  // segment when it sits above, which is the whole point of holding it.
+  const peakIndex = peak === null ? null : Math.max(0, segmentsFor(peak, max) - 1);
+
+  const segments = Array.from({ length: FIELDLINE_SEGMENT_COUNT }, (_, index): FieldlineSegment => {
+    const zone: SegmentZone = index >= crossoverIndex ? 'over' : 'normal';
+    return {
+      index,
+      zone,
+      lit: litCount !== null && index < litCount,
+      tone: zone === 'over' ? tokens.tx.tuning : tokens.rx.active,
+      peakHold: peakIndex !== null && index === peakIndex,
+    };
+  });
+
+  return {
+    kind: 'fieldline-meter',
+    trackWidth: tokens.meters.trackWidth,
+    segmentGap: tokens.meters.segmentGap,
+    segments,
+    litCount,
+    crossoverIndex,
+    scaleTicks: FIELDLINE_SCALE_TICKS,
+    unknown: value === null,
+  };
+}

--- a/frontend/src/presentation/languages/fieldline/state-feedback-renderer.ts
+++ b/frontend/src/presentation/languages/fieldline/state-feedback-renderer.ts
@@ -1,0 +1,151 @@
+/**
+ * `fieldline` TX renderer (MOR-1074, TX slice) — MOR-977 §2.2's "takeover"
+ * state feedback: a left rail that floods, a full-width band above the
+ * frequency, and an action slab that inverts to a solid fill with knocked-out
+ * black text.
+ *
+ * SAFETY INVARIANT R9. This renderer DISPLAYS the App TX authority's
+ * conclusions; it never forms its own. The only fields it reads are `rf` and
+ * `session` — the outputs of `semantic/rx-tx-surface`'s `rfState()` /
+ * `txSessionState()`, themselves derived from the App-owned
+ * `TxAuthoritySnapshot` — plus `fault` and `keyBlocked`. It never reads a raw
+ * `ptt`, and because it names every field it consumes, one cannot be smuggled
+ * in. Unrecognised values fail CLOSED to the doubt rail, never to the quiet RX
+ * one: "nothing is happening" is the dangerous claim.
+ *
+ * Colour is never the sole channel. Every state carries a distinct rail WIDTH,
+ * a distinct band TREATMENT (absent / outlined / filled) and a distinct text
+ * label, so the state survives forced-colors and colour-vision deficiency.
+ * The carrier is the LEFT RAIL rather than studioline's top rail: it is the one
+ * element that never scrolls out of a stacked layout (MOR-977 §2.2).
+ */
+import type { DesignLanguageTokens, RendererViewModel } from '../contract';
+import { FIELDLINE_KNOCKOUT, FIELDLINE_PALETTE } from './tokens';
+
+export type KeyTreatment = 'idle' | 'pending' | 'keyed' | 'fault' | 'blocked';
+export type BandTreatment = 'absent' | 'outlined' | 'filled';
+
+export interface FieldlineRail {
+  /** 8px baseline, flooding to 16 and 24 — width IS the non-colour channel. */
+  readonly widthPx: 8 | 16 | 24;
+  readonly tone: string;
+  /** Non-negotiable: the rail runs the full height and cannot be cropped away. */
+  readonly edge: 'inline-start';
+  readonly fullBleed: true;
+}
+
+export interface FieldlineBand {
+  readonly treatment: BandTreatment;
+  readonly text: string | null;
+  readonly tone: string;
+  /** Knocked-out black on a filled band; the label tone otherwise. */
+  readonly textTone: string | null;
+}
+
+export interface FieldlineSlab {
+  readonly treatment: KeyTreatment;
+  /** Denied/unknown permit renders inert-but-present — a hidden PTT reads as "no TX capability". */
+  readonly present: true;
+  readonly filled: boolean;
+  readonly fill: string;
+  readonly tone: string;
+  readonly edgeStyle: 'solid' | 'dashed' | 'dotted';
+  /** Full-width bottom slab, above the 44px floor: gloves, one-handed (MOR-977 §2.2). */
+  readonly fullWidth: true;
+  readonly minHeightPx: 48;
+  readonly focusRing: string;
+}
+
+export interface FieldlineStateFeedback {
+  readonly kind: 'fieldline-state-feedback';
+  readonly rail: FieldlineRail;
+  readonly band: FieldlineBand;
+  readonly numeralTone: 'primary' | 'tx-target';
+  readonly meterScaleLabel: 'S' | 'PO';
+  readonly slab: FieldlineSlab;
+}
+
+interface RailState {
+  width: 8 | 16 | 24;
+  band: BandTreatment;
+  label: string | null;
+  keyed: boolean;
+}
+
+/** Rail flood + band per session state. `absent` band is the RX baseline — the only silent state. */
+const SESSION_RAIL: Record<string, RailState> = {
+  idle: { width: 8, band: 'absent', label: null, keyed: false },
+  pending: { width: 16, band: 'outlined', label: 'KEYING', keyed: false },
+  keyed: { width: 24, band: 'filled', label: 'ON AIR', keyed: true },
+  releasing: { width: 16, band: 'outlined', label: 'UNKEYING', keyed: true },
+  failed: { width: 24, band: 'filled', label: 'TX FAULT', keyed: false },
+};
+
+/** The fail-closed rail: doubt about RF outranks a tidy silhouette. */
+const DOUBT_RAIL: RailState = { width: 16, band: 'outlined', label: 'TX?', keyed: false };
+
+const SLAB_EDGE: Record<KeyTreatment, FieldlineSlab['edgeStyle']> = {
+  idle: 'solid', pending: 'solid', keyed: 'solid', fault: 'dashed', blocked: 'dotted',
+};
+const KEY_TREATMENT: Record<string, KeyTreatment> = {
+  idle: 'idle', pending: 'pending', keyed: 'keyed', releasing: 'keyed', failed: 'fault',
+};
+
+const stringField = (fields: RendererViewModel['fields'], key: string): string => {
+  const value = fields[key];
+  return typeof value === 'string' ? value : '';
+};
+
+export function renderStateFeedback(
+  viewModel: RendererViewModel, tokens: DesignLanguageTokens,
+): FieldlineStateFeedback {
+  const rf = stringField(viewModel.fields, 'rf');
+  const session = stringField(viewModel.fields, 'session');
+  const fault = stringField(viewModel.fields, 'fault');
+  const blocked = viewModel.fields.keyBlocked === true;
+
+  const known = SESSION_RAIL[session];
+  // An unrecognised session, or an idle session the authority cannot vouch for
+  // as genuinely receiving, both land on the doubt rail.
+  const state = known && (session !== 'idle' || rf === 'receiving') ? known : DOUBT_RAIL;
+  const failed = session === 'failed';
+
+  const tone = state.label === null ? tokens.rx.idle
+    : state.keyed || failed ? tokens.tx.active
+      : tokens.tx.tuning;
+  // Treatment follows the RESOLVED state, not the raw session: a slab that
+  // still looks idle under a doubt rail is the contradiction R9 exists to
+  // prevent.
+  const treatment: KeyTreatment = blocked ? 'blocked'
+    : state === DOUBT_RAIL ? 'pending'
+      : (KEY_TREATMENT[session] ?? 'pending');
+
+  return {
+    kind: 'fieldline-state-feedback',
+    rail: { widthPx: state.width, tone, edge: 'inline-start', fullBleed: true },
+    band: {
+      treatment: state.band,
+      // The fault code rides IN the band rather than in a separate micro-label:
+      // takeover means the operator does not have to look anywhere else.
+      text: failed && fault ? `TX FAULT: ${fault}` : state.label,
+      tone,
+      textTone: state.band === 'absent' ? null
+        : state.band === 'filled' ? FIELDLINE_KNOCKOUT : tone,
+    },
+    numeralTone: state.keyed ? 'tx-target' : 'primary',
+    // The meter re-zones with the transmitter, not with the request to key.
+    meterScaleLabel: state.keyed ? 'PO' : 'S',
+    slab: {
+      treatment,
+      present: true,
+      filled: treatment === 'keyed',
+      fill: treatment === 'keyed' ? tokens.tx.active : 'transparent',
+      tone: treatment === 'blocked' ? FIELDLINE_PALETTE.inert
+        : treatment === 'keyed' ? FIELDLINE_KNOCKOUT : tone,
+      edgeStyle: SLAB_EDGE[treatment],
+      fullWidth: true,
+      minHeightPx: 48,
+      focusRing: tokens.focusRing,
+    },
+  };
+}

--- a/frontend/src/presentation/languages/fieldline/tokens.ts
+++ b/frontend/src/presentation/languages/fieldline/tokens.ts
@@ -1,0 +1,110 @@
+/**
+ * `fieldline` token set (MOR-1074) — the independent PROOF family selected by
+ * MOR-977 §4.1: a rugged field console for a deployed portable station operated
+ * with gloves on, in daylight, possibly one-handed. Values here implement
+ * §2.2's seven axes; the CSS half of the same slice is `./fieldline.css`.
+ *
+ * Its whole reason to exist is that it differs from `studioline` on ALL SEVEN
+ * acceptance axes at once (§4.3.1) while consuming the identical contract — so
+ * the token set is deliberately the opposite value on every axis a token can
+ * express: mono 700 against proportional 200, a 3px opaque border against no
+ * border, a 3px segment gap against a continuous rail, and `rankedGroups: false`
+ * against `true`. Nothing else about the contract changes.
+ *
+ * Contract instance only. This file declares no renderer, imports no runtime,
+ * store, transport or capability code, and knows nothing about any radio.
+ *
+ * COLOUR IS ARITHMETIC HERE, exactly as in studioline's slice: every tone below
+ * clears 3:1 against BOTH surfaces in `FIELDLINE_SURFACES`, computed in
+ * `__tests__/tokens.test.ts` rather than asserted by eye. fieldline supplies its
+ * own ring tone rather than inheriting the shared placeholder's `var(--accent)`,
+ * which carries no such guarantee (owner decision Q1, 2026-08-04).
+ */
+import type { DesignLanguageTokens } from '../contract';
+
+/**
+ * The two grounds the language must hold on (MOR-977 §5). For fieldline the
+ * second one is not "light mode", it is DAYLIGHT MODE — pure black on pure
+ * white, the grammar's best condition rather than a compromise — so the pair is
+ * harder than studioline's warm off-white and near-black.
+ */
+export const FIELDLINE_SURFACES = { dark: '#0A0A0A', light: '#FFFFFF' } as const;
+
+/**
+ * One mid-luminance palette serves both surfaces: a state channel cannot afford
+ * a per-mode fork. Every entry clears 3.9:1 on BOTH grounds — a wider margin
+ * than the 3:1 floor, because flat fills give this grammar no gradient or glow
+ * to fall back on when the sun is on the screen.
+ */
+export const FIELDLINE_PALETTE = {
+  focus: '#0A6ED1',
+  rxIdle: '#6E7A85',
+  rxActive: '#008A5C',
+  rxTuning: '#0A6ED1',
+  txIdle: '#8A6A2E',
+  txActive: '#E03A2F',
+  txTuning: '#B25A00',
+  inert: '#6F7A85',
+} as const;
+
+/**
+ * Knocked-out label text on a filled slab or band. Black in BOTH modes, unlike
+ * studioline's mode-dependent knockout to its own surface — §2.2's "solid red
+ * with knocked-out black text" is a fixed treatment, and pinning it to one
+ * value is what lets a single arithmetic assertion cover both modes. Clears
+ * 4.5:1 on `txActive`, which is why that red is lighter than studioline's.
+ */
+export const FIELDLINE_KNOCKOUT = '#0A0A0A';
+
+/**
+ * Label TEXT is per-mode, unlike the state channel above. A single tone cannot
+ * be 4.5:1 against both black and white at once (the two required luminance
+ * bands do not overlap), and taking the 3:1 non-text floor for label text is
+ * what produced finding MOR-1277 against studioline. So text forks by mode and
+ * each half is asserted at 4.5:1 against its OWN ground.
+ */
+export const FIELDLINE_LABEL_TONES = {
+  dark: { text: '#F2F5F7', muted: '#C2CBD2' },
+  light: { text: '#000000', muted: '#3A4249' },
+} as const;
+
+/** `var()` with the literal fallback, so a bundle mounted without the CSS still renders the proven colour. */
+const tone = (name: string, fallback: string): string => `var(--dl-fieldline-${name}, ${fallback})`;
+
+export const FIELDLINE_TOKENS: DesignLanguageTokens = {
+  // Monospace 700 slab digits, never a proportional face: the chunky uniform
+  // numeral IS the silhouette. `tabular-nums` stays mandatory even on a mono
+  // face, because the contract requires the declaration rather than the
+  // happy accident of a family that already advances uniformly.
+  typography: {
+    fontFamily: 'ui-monospace, "SF Mono", Menlo, "DejaVu Sans Mono", "Roboto Mono", monospace',
+    weight: 700,
+    fontVariantNumeric: 'tabular-nums',
+  },
+  // Hard-edged blocks: zero radius, 3px opaque borders. No inset, no glow, no
+  // gradient anywhere — gradients wash out in sunlight (MOR-977 §2.2).
+  geometry: { radius: '0px', borderWidth: '3px' },
+  // Discrete segments: a non-zero gap is precisely what makes this a segment
+  // form rather than the continuous rail `studioline` owns.
+  meters: { trackWidth: '18px', segmentGap: '3px' },
+  // `false` is the axis: all nine digits at one size and one weight, because in
+  // the field the Hz digits are read as often as the kHz ones (MOR-977 §2.2).
+  frequency: { digitWeight: 700, rankedGroups: false },
+  // Zero, not merely "safe": every fieldline state change is a discrete step,
+  // so the grammar is fully intact under the global reduced-motion clamp.
+  motion: { durationMs: 0, reducedMotionSafe: true },
+  // Outline shorthand, not a box-shadow spread list (MOR-1232 D5). 3px, one
+  // step above studioline's 2px: thick borders give the ring room, so it can be
+  // heavier without competing with the block edge (MOR-977 §3.2).
+  focusRing: `3px solid ${tone('focus', FIELDLINE_PALETTE.focus)}`,
+  rx: {
+    idle: tone('rx-idle', FIELDLINE_PALETTE.rxIdle),
+    active: tone('rx-active', FIELDLINE_PALETTE.rxActive),
+    tuning: tone('rx-tuning', FIELDLINE_PALETTE.rxTuning),
+  },
+  tx: {
+    idle: tone('tx-idle', FIELDLINE_PALETTE.txIdle),
+    active: tone('tx-active', FIELDLINE_PALETTE.txActive),
+    tuning: tone('tx-tuning', FIELDLINE_PALETTE.txTuning),
+  },
+};

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -74,6 +74,16 @@ export default defineConfig({
             // elsewhere in the suite reshuffles the fast pool and flips it red
             // with no production change. Isolation makes it order-independent.
             'src/components-v2/wiring/__tests__/rx-audio-authority.test.ts',
+            // MOR-1074, same class again: it declares module-scope
+            // ``vi.mock('$lib/transport/...')`` and asserts exact lease counts
+            // through the canonical audio authority, so whether its hoisted
+            // mock wins depends on which sibling loaded the real transport
+            // module first. Reproduced on a PRISTINE baaaf480 checkout by
+            // adding five test files that merely import
+            // `semantic/rx-tx-surface` + `presentation/languages/*` and assert
+            // nothing else: red in 4 of 6 runs with zero production change.
+            // Isolation makes it a function of its own subject again.
+            'src/components-v2/panels/lcd/__tests__/audio-fft-demand.test.ts',
             // MOR-1262 slice 2A, same class: it spies on the GLOBAL
             // `requestAnimationFrame` and asserts exact call counts, while
             // sibling component tests (MetersDockPanel's `tick`/`tickPeak`
@@ -181,6 +191,7 @@ export default defineConfig({
           environment: 'jsdom',
           include: [
             'src/components-v2/wiring/__tests__/rx-audio-authority.test.ts',
+            'src/components-v2/panels/lcd/__tests__/audio-fft-demand.test.ts',
             'src/lib/utils/__tests__/smoothing.svelte.test.ts',
             'src/components-v2/wiring/__tests__/keyboard-wiring.test.ts',
             'src/components-v2/wiring/__tests__/vfo-wiring.test.ts',


### PR DESCRIPTION
## Summary
Proves the second product-owned design language from the MOR-977 exploration: **fieldline**, a field console — hard-edged stacked blocks, flooding left rail (8/16/24px + a band studioline has no equivalent of), full-width 48px action slab, mono-700 slab digits, 12 discrete meter segments, zero motion, daylight mode as a first-class condition. Slices (net production LOC, verifier re-measured): tokens 40 · stylesheet **exactly 200 (zero headroom)** · frequency 68 · meters 59 · state-feedback 101 · declarations −2.

**Material difference beyond colour:** 12 axes, 8 mechanically asserted against studioline's bundle (weight/family, rankedGroups, digit grouping, selection treatment, rail geometry + side, segments vs continuous, key slab vs pill, motion). Side-by-side captures in the session archive.

**Unchanged behavior (acceptance core):** the only touched existing test file is the registry/inventory table; accessible-name count+signature, focus order, and `data-rf`/`data-session`/readout proven identical across studioline / fieldline / no-language live in the harness. Failing-file set identical to baseline (+162 passing tests).

**Owner decisions honoured:** per-language accessible ring/placeholder `#0A6ED1` (palette min 3.93:1 both grounds; TX-fill knockout 4.54:1); label TEXT tones are per-mode at 10.2–21:1 — every text tone ≥4.5:1 in its own mode (verifier-ruled compliant with the MOR-1277 lesson; a single tone mathematically cannot clear 4.5:1 on both grounds). Activation via `[data-design-language='fieldline']` only, with fieldline's own pin test (MOR-1278 carry-forward discharged).

**vite.config note (+2 non-comment LOC):** fieldline's test files enter the isolated pool. Necessity evidence: on a pristine baaaf480, five filler tests that merely import `semantic/rx-tx-surface` and assert `1===1` flip an unrelated LCD test red 4/6 runs; identical fillers importing nothing — 0/8 (isolate:false hazard, MOR-1272 inventory). The verifier could not reproduce locally post-fix (documented low-core-CI class) and ruled the hunk stays with its triggering PR.

**Caveat:** like studioline, fieldline's renderer half awaits the language-agnostic wiring (MOR-1275) — captures prove the stylesheet half.

## Review provenance
Opus builder → independent opus DL-domain verifier (fresh eyes): **PASS, no blocking findings**. 19/19 mutants killed (R9 ptt-carrier, fault/doubt/blocked collapses, F1 rail order, F2 edge collapses, F3 band order/fill); contrast recomputed from first principles, every figure matches; activation-pin mutants 3/3 killed; unchanged-behavior proven live; merge-forward test-applied clean; LOC re-measured incl. the at-boundary stylesheet (200, not 201). Post-review this branch merged current main (2B #2211, disjoint files) — languages+semantic 767/767 green on the merged tree. Nits routed: activation-pin generalization + blocked-beats-keyed (both languages) + stale test names → MOR-1275/hygiene.

Linear: MOR-1074

🤖 Generated with [Claude Code](https://claude.com/claude-code)