### PR TITLE
feat(MOR-1280): modeFilter fact group (vocabulary slice 4A)

### DIFF
--- a/frontend/src/lib/runtime/adapters/__tests__/mode-filter-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mode-filter-adapter.test.ts
@@ -1,0 +1,294 @@
+/**
+ * MOR-1262 decomposition slice 4A (MOR-1280) — `modeFilter` fact-group
+ * adapter derivation.
+ *
+ * Companion to `radio-view-model-adapter.test.ts` (MOR-1065), which this
+ * file does NOT modify. That file's `TOPOLOGY_CAPS` fixtures all declare
+ * `modes: [], filters: []` and its "carries only contract data" test hard-
+ * codes the exact key list a view model may have — under a naive "emit
+ * whenever a receiver exists" gate (mode/filter are REQUIRED fields on
+ * `ReceiverStatePublic`, so they are never actually absent), `modeFilter`
+ * would appear on every model that file builds. `deriveModeFilter`'s
+ * evidence gate requires a non-empty capability-declared choice set instead
+ * — this file separately pins that a radio with real modes/filters DOES get
+ * the group, and that the empty-choice-set baseline still gets none.
+ */
+import { describe, expect, it } from 'vitest';
+import type { Capabilities, FilterModeConfig } from '$lib/types/capabilities';
+import type { FieldStatus, ServerState } from '$lib/types/state';
+import { validateRadioViewModel, type RadioViewModel } from '../../../../semantic/radio-view-model';
+import { toRadioViewModel } from '../radio-view-model-adapter';
+import { resolveFilterModeConfig } from '$lib/runtime/props/panel-props';
+
+function caps(overrides: Partial<Capabilities> = {}): Capabilities {
+  return {
+    model: 'fixture', scope: true, audio: true, tx: true, capabilities: ['scope', 'audio', 'tx'],
+    receivers: 1, vfoScheme: 'single', freqRanges: [], modes: [], filters: [],
+    audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
+    webrtc: { available: false, enabled: false },
+    txBands: [], scopeSource: 'hardware', audioFftAvailable: false, ...overrides,
+  } as Capabilities;
+}
+
+const fresh: FieldStatus = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' };
+const stale: FieldStatus = { storePath: 'x', observed: true, freshness: 'stale', availability: 'stale' };
+
+/** The exact shape `radio-view-model-adapter.test.ts`'s own baseline uses. */
+function bareState(overrides: Partial<ServerState> = {}): ServerState {
+  return {
+    active: 'MAIN', split: false, dualWatch: false, ptt: false,
+    txTarget: { status: 'known', receiver: 'MAIN', slot: null, frequencyHz: 14195000 },
+    main: {
+      freqHz: 14195000, mode: 'USB', filter: 1, dataMode: 0, att: 0, preamp: 0,
+      nb: false, nr: false, afLevel: 1, rfGain: 1, squelch: 0, sMeter: 0,
+    },
+    sub: {
+      freqHz: 7100000, mode: 'LSB', filter: 2, dataMode: 0, att: 0, preamp: 0,
+      nb: false, nr: false, afLevel: 1, rfGain: 1, squelch: 0, sMeter: 0,
+    },
+    fieldStatus: {
+      active: fresh, split: fresh, dualWatch: fresh, txTarget: fresh,
+      'main.freqHz': fresh, 'main.mode': fresh, 'main.filter': fresh,
+    },
+    ...overrides,
+  } as ServerState;
+}
+
+function model(state: ServerState | null, capabilities: Capabilities | null): RadioViewModel {
+  const view = toRadioViewModel(state, capabilities);
+  expect(view).not.toBeNull();
+  return validateRadioViewModel(view);
+}
+
+describe('modeFilter evidence gate (MOR-1280, N3)', () => {
+  it('emits no modeFilter when capabilities are absent', () => {
+    expect(toRadioViewModel(bareState(), null)).toBeNull();
+  });
+
+  // The exact scenario `radio-view-model-adapter.test.ts`'s fixtures hit:
+  // a receiver always carries `mode`/`filter` (required fields), no choice
+  // sets declared. Regression pin — this must stay group-absent.
+  it('emits no modeFilter for empty modes AND empty filters, even with a fully-populated receiver (regression pin)', () => {
+    const view = model(bareState(), caps());
+    expect(view.modeFilter).toBeUndefined();
+    expect(Object.keys(view)).not.toContain('modeFilter');
+  });
+
+  it('emits modeFilter once modes alone are declared', () => {
+    const view = model(bareState(), caps({ modes: ['USB', 'LSB'] }));
+    expect(view.modeFilter).toBeDefined();
+  });
+
+  it('emits modeFilter once filters alone are declared', () => {
+    const view = model(bareState(), caps({ filters: ['FIL1', 'FIL2'] }));
+    expect(view.modeFilter).toBeDefined();
+  });
+
+  it('never emits modeFilter with no capabilities object at all', () => {
+    expect(toRadioViewModel(bareState(), null)).toBeNull();
+  });
+});
+
+describe('modeFilter per-field derivation (MOR-1280)', () => {
+  const fullCaps = caps({ modes: ['USB', 'LSB', 'CW'], filters: ['FIL1', 'FIL2', 'FIL3'] });
+
+  it('reports the capability-declared choice sets verbatim', () => {
+    const view = model(bareState(), fullCaps);
+    expect(view.modeFilter!.modeChoices).toEqual(['USB', 'LSB', 'CW']);
+    expect(view.modeFilter!.filterChoices).toEqual(['FIL1', 'FIL2', 'FIL3']);
+  });
+
+  it('reports known current mode/filter/width readings for the active (MAIN) receiver', () => {
+    const view = model(bareState({
+      main: { freqHz: 14195000, mode: 'USB', filter: 2, dataMode: 0, filterWidth: 2400, att: 0, preamp: 0, nb: false, nr: false, afLevel: 1, rfGain: 1, squelch: 0, sMeter: 0 },
+      fieldStatus: { ...bareState().fieldStatus, 'main.filterWidth': fresh },
+    }), fullCaps);
+    expect(view.modeFilter!.currentMode.reading).toEqual({ status: 'known', value: 'USB' });
+    expect(view.modeFilter!.currentFilter.reading).toEqual({ status: 'known', value: 2 });
+    expect(view.modeFilter!.filterWidth.reading).toEqual({ status: 'known', value: 2400 });
+  });
+
+  it('follows the SUB receiver once it is the active one', () => {
+    const view = model(bareState({
+      active: 'SUB',
+      fieldStatus: { ...bareState().fieldStatus, 'sub.mode': fresh, 'sub.filter': fresh },
+    }), fullCaps);
+    expect(view.modeFilter!.currentMode.reading).toEqual({ status: 'known', value: 'LSB' });
+    expect(view.modeFilter!.currentFilter.reading).toEqual({ status: 'known', value: 2 });
+  });
+
+  it('marks currentMode structurally absent when no modes are declared, even with filters present', () => {
+    const view = model(bareState(), caps({ filters: ['FIL1'] }));
+    expect(view.modeFilter!.currentMode.availability.structural).toBe(false);
+    expect(view.modeFilter!.currentMode.reading).toEqual({ status: 'unknown' });
+    expect(view.modeFilter!.currentFilter.availability.structural).toBe(true);
+  });
+
+  it('marks currentFilter/filterWidth structurally absent when no filters are declared, even with modes present', () => {
+    const view = model(bareState(), caps({ modes: ['USB'] }));
+    expect(view.modeFilter!.currentFilter.availability.structural).toBe(false);
+    expect(view.modeFilter!.filterWidth.availability.structural).toBe(false);
+    expect(view.modeFilter!.currentMode.availability.structural).toBe(true);
+  });
+
+  it('degrades a stale mode field to unknown while keeping structural availability true', () => {
+    const view = model(bareState({
+      fieldStatus: { ...bareState().fieldStatus, 'main.mode': stale },
+    }), fullCaps);
+    expect(view.modeFilter!.currentMode).toEqual({
+      reading: { status: 'unknown' }, availability: { structural: true, operational: false },
+    });
+  });
+
+  it('resolves filterWidthMin/Max from the mode-keyed filterConfig table when one matches', () => {
+    const filterConfig: Record<string, FilterModeConfig> = {
+      USB: { defaults: [2400], fixed: false, minHz: 50, maxHz: 3600 },
+    };
+    const view = model(
+      bareState({ main: { ...bareState().main, mode: 'USB' } }),
+      caps({ ...fullCaps, filterConfig, filterWidthMin: 10, filterWidthMax: 9999 }),
+    );
+    expect(view.modeFilter!.filterWidthMin.reading).toEqual({ status: 'known', value: 50 });
+    expect(view.modeFilter!.filterWidthMax.reading).toEqual({ status: 'known', value: 3600 });
+  });
+
+  it('falls back to the capability-level filterWidthMin/Max when no per-mode config matches', () => {
+    const view = model(
+      bareState({ main: { ...bareState().main, mode: 'FM' } }),
+      caps({ ...fullCaps, modes: ['FM'], filterWidthMin: 10, filterWidthMax: 9999 }),
+    );
+    expect(view.modeFilter!.filterWidthMin.reading).toEqual({ status: 'known', value: 10 });
+    expect(view.modeFilter!.filterWidthMax.reading).toEqual({ status: 'known', value: 9999 });
+  });
+
+  it('degrades a malformed raw value (wrong JS type) to unknown rather than throwing or coercing', () => {
+    const view = model(bareState({
+      main: { ...bareState().main, filter: 'wide' as unknown as number },
+    }), fullCaps);
+    expect(view.modeFilter!.currentFilter.reading).toEqual({ status: 'unknown' });
+  });
+
+  it('emits a validator-clean model carrying the modeFilter group (round-trip proof)', () => {
+    const view = model(bareState(), fullCaps);
+    expect(JSON.parse(JSON.stringify(view))).toEqual(view);
+  });
+});
+
+/**
+ * SAFETY CONSTRAINT (verify round 1, F1). The doc comment on `deriveModeFilter`
+ * claims `filterWidthMin`/`filterWidthMax` read the shipped
+ * `resolveFilterModeConfig`'s own fallback chain rather than re-deriving it —
+ * same doctrine as `rxAudio.modInputReadiness` reading `deriveTxCapabilities`
+ * verbatim (`rx-audio.test.ts`'s readiness matrix) and `meters.rfState` reading
+ * the real reducer (`meters.test.ts`'s 9-combo pin). Before this block, no test
+ * actually drove a DATA-mode receiver or the CW-R/RTTY-R/SSB fallback branches
+ * — two independent regressions (dropping `dataMode` from the resolver call;
+ * forking a hand-rolled `caps.filterConfig[mode]` lookup that skips the whole
+ * fallback chain) passed the entire suite untouched. This matrix drives the
+ * REAL `resolveFilterModeConfig` across every branch of that chain and asserts
+ * the adapter's bounds equal its own `minHz ?? table[0] ?? caps.filterWidthMin`
+ * / `maxHz ?? table[last] ?? caps.filterWidthMax` — drift in either direction
+ * (dropped argument, forked lookup) reddens this file.
+ */
+describe('filterWidthMin/Max parity with the real resolveFilterModeConfig (MOR-1280, F1)', () => {
+  const filterConfig: Record<string, FilterModeConfig> = {
+    'USB-D': { defaults: [1500], fixed: false, minHz: 200, maxHz: 2800 },
+    SSB: { defaults: [2400], fixed: false, minHz: 50, maxHz: 3000 },
+    CW: { defaults: [500], fixed: false, minHz: 50, maxHz: 1200 },
+    RTTY: { defaults: [300], fixed: false, minHz: 50, maxHz: 900 },
+  };
+  const parityCaps = caps({
+    modes: ['USB', 'LSB', 'CW', 'CW-R', 'RTTY', 'RTTY-R', 'FM'],
+    filters: ['FIL1'],
+    filterConfig,
+    filterWidthMin: 10,
+    filterWidthMax: 9999,
+  });
+
+  // Each row exercises a distinct branch of `resolveFilterModeConfig`'s
+  // candidate chain — direct hit, `-D` data-mode suffix, the USB/LSB→SSB
+  // alias (voice AND data), the CW-R→CW and RTTY-R→RTTY voice fallbacks, and
+  // an unmapped mode that falls all the way through to the capability-level
+  // bounds. `dataMode` is the exact argument mutation D1 dropped.
+  const MATRIX: ReadonlyArray<{ name: string; mode: string; dataMode: number }> = [
+    { name: 'USB, voice (dataMode 0) — falls through to the SSB alias', mode: 'USB', dataMode: 0 },
+    { name: 'USB, data (dataMode 1) — direct USB-D hit, distinct from the voice table', mode: 'USB', dataMode: 1 },
+    { name: 'LSB, voice — falls through to the SSB alias', mode: 'LSB', dataMode: 0 },
+    { name: 'LSB, data — SSB-D absent, falls through to SSB (not USB-D)', mode: 'LSB', dataMode: 1 },
+    { name: 'CW — direct hit', mode: 'CW', dataMode: 0 },
+    { name: 'CW-R — falls back to the CW table', mode: 'CW-R', dataMode: 0 },
+    { name: 'RTTY — direct hit', mode: 'RTTY', dataMode: 0 },
+    { name: 'RTTY-R — falls back to the RTTY table', mode: 'RTTY-R', dataMode: 0 },
+    { name: 'FM — unmapped, falls through to the capability-level bounds', mode: 'FM', dataMode: 0 },
+  ];
+
+  it.each(MATRIX)('$name', ({ mode, dataMode }) => {
+    // The independent, real-resolver-derived expectation — NOT a copy of the
+    // adapter's own formula's inputs, the adapter's OUTPUT is compared
+    // against what the shipped resolver itself says for this mode/dataMode.
+    const expected = resolveFilterModeConfig(parityCaps, mode, dataMode);
+    const expectedMin = expected?.minHz ?? expected?.table?.[0] ?? parityCaps.filterWidthMin;
+    const expectedMax = expected?.maxHz
+      ?? (expected?.table?.length ? expected.table[expected.table.length - 1] : undefined)
+      ?? parityCaps.filterWidthMax;
+
+    const view = model(bareState({ main: { ...bareState().main, mode, dataMode } }), parityCaps);
+
+    expect(view.modeFilter!.filterWidthMin.reading).toEqual({ status: 'known', value: expectedMin });
+    expect(view.modeFilter!.filterWidthMax.reading).toEqual({ status: 'known', value: expectedMax });
+  });
+
+  it('the matrix actually exercises a direct hit, a -D hit, an alias fallback and a full fall-through (no silent coverage gap)', () => {
+    const resolved = MATRIX.map(({ mode, dataMode }) => resolveFilterModeConfig(parityCaps, mode, dataMode));
+    expect(resolved.some((c) => c === filterConfig.CW)).toBe(true); // direct hit
+    expect(resolved.some((c) => c === filterConfig['USB-D'])).toBe(true); // -D hit
+    expect(resolved.some((c) => c === filterConfig.SSB)).toBe(true); // alias fallback
+    expect(resolved.some((c) => c === null)).toBe(true); // full fall-through (FM)
+  });
+});
+
+/**
+ * SAFETY CONSTRAINT (verify round 1, F2). `filterWidthMin`/`filterWidthMax`
+ * are VALUES OF (caps, mode) — never of `filterWidth` — so their operational
+ * gate must be `modeObserved`, not `widthObserved`. Before the fix these two
+ * probes were the demonstrated fabrication/false-negative pair.
+ */
+describe('filterWidthMin/Max observation gate (MOR-1280, F2)', () => {
+  // filterWidthMin/Max set at the capability level (not just via a per-mode
+  // filterConfig) so "the bounds ARE derivable" is unambiguous in the second
+  // probe below — the whole point is that a mode-independent fallback is
+  // still knowable the instant the mode is observed, with no filterConfig at all.
+  const fullCaps = caps({
+    modes: ['USB', 'LSB', 'CW'], filters: ['FIL1', 'FIL2', 'FIL3'],
+    filterWidthMin: 50, filterWidthMax: 9999,
+  });
+
+  it('mode UNOBSERVED, filterWidth observed — bounds must NOT fabricate the mode-derived table', () => {
+    const view = model(bareState({
+      fieldStatus: {
+        ...bareState().fieldStatus, 'main.mode': stale, 'main.filterWidth': fresh,
+      },
+    }), fullCaps);
+    expect(view.modeFilter!.currentMode.reading).toEqual({ status: 'unknown' });
+    // The bounds derive from the SAME unobserved mode as currentMode — they
+    // must degrade with it, not publish a confidently-wrong table.
+    expect(view.modeFilter!.filterWidthMin).toEqual({
+      reading: { status: 'unknown' }, availability: { structural: true, operational: false },
+    });
+    expect(view.modeFilter!.filterWidthMax).toEqual({
+      reading: { status: 'unknown' }, availability: { structural: true, operational: false },
+    });
+  });
+
+  it('mode OBSERVED, filterWidth UNOBSERVED — bounds ARE derivable and must read known', () => {
+    const view = model(bareState({
+      main: { ...bareState().main, mode: 'USB', filterWidth: undefined },
+      fieldStatus: { ...bareState().fieldStatus, 'main.mode': fresh },
+    }), fullCaps);
+    expect(view.modeFilter!.currentMode.reading).toEqual({ status: 'known', value: 'USB' });
+    // filterWidth itself may legitimately still be unknown — it is gated on
+    // its OWN observation, unaffected by this fix.
+    expect(view.modeFilter!.filterWidthMin.reading.status).toBe('known');
+    expect(view.modeFilter!.filterWidthMax.reading.status).toBe('known');
+  });
+});

--- a/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
@@ -28,11 +28,12 @@ import type { ServerState } from '$lib/types/state';
 import type {
   RadioViewModel, TxAuxField, TxAuxViewModel, AtuStatus,
   MeterField, MeterRfState, MetersViewModel,
-  AudioFocus, MonitorMode, RxAudioViewModel,
+  AudioFocus, MonitorMode, RxAudioViewModel, ModeFilterViewModel,
 } from '../../../semantic/radio-view-model';
 import type { TxAuthoritySnapshot } from '../../../semantic/rx-tx-surface';
 import { isFieldAvailable } from '$lib/state/field-status';
 import { modInputStateKey } from '$lib/radio/mod-input';
+import { resolveFilterModeConfig } from '$lib/runtime/props/panel-props';
 import {
   derivePresentationCapabilities, type ReceiverId, type VfoSlotId,
 } from './presentation-capabilities';
@@ -257,6 +258,67 @@ function deriveMeters(
     // same reason), so it is structurally gated but never relevance-gated.
     drainVoltage: meterField(vdMeter !== undefined, topFieldAvailable(state, 'vdMeter'), vdMeter, true),
     drainCurrent: txMeter(idMeter, 'idMeter'),
+  };
+}
+
+/**
+ * Mode/filter facts (MOR-1262 decomposition slice 4A, MOR-1280): current
+ * mode, capability-derived mode choice set, current filter selection,
+ * capability-derived filter choice set, filter width and its min/max bounds.
+ *
+ * Evidence gate (N3): unlike `deriveTxAux`'s optional per-control fields,
+ * `ReceiverStatePublic.mode`/`.filter` are REQUIRED fields — always present
+ * once any receiver exists — so "a raw field was observed" carries no
+ * evidence here (it would fire for every radio ever built). The only honest
+ * signal is the capability-declared choice set: no declared modes AND no
+ * declared filters is NO group, never an all-unknowns placeholder (pinned
+ * against `radio-view-model-adapter.test.ts`'s own `modes: [], filters: []`
+ * baseline fixtures, which must keep emitting no `modeFilter`).
+ *
+ * `resolveFilterModeConfig` moves BEHIND this adapter (the decomposition's
+ * explicit instruction for this slice): `filterWidthMin`/`filterWidthMax`
+ * read the shipped resolver's own per-mode table lookup — the same function
+ * `toFilterProps`/`toScopeControlsProps` call directly today — rather than
+ * re-deriving a width table here. v2's own call sites are untouched; this is
+ * an additional consumer, not a migration (that is slice 4B).
+ */
+function deriveModeFilter(
+  state: ServerState | null, caps: Capabilities | null,
+): ModeFilterViewModel | undefined {
+  if (!caps) return undefined;
+  const modeChoices = caps.modes ?? [];
+  const filterChoices = caps.filters ?? [];
+  if (modeChoices.length === 0 && filterChoices.length === 0) return undefined;
+  const onSub = state?.active === 'SUB';
+  const rx = onSub ? state?.sub : state?.main;
+  const base = onSub ? 'sub.' : 'main.';
+  const hasModes = modeChoices.length > 0;
+  const hasFilters = filterChoices.length > 0;
+  const modeObserved = topFieldAvailable(state, `${base}mode`);
+  const filterObserved = topFieldAvailable(state, `${base}filter`);
+  const widthObserved = topFieldAvailable(state, `${base}filterWidth`);
+  // The active mode-keyed filter config, resolved by the ONE shipped
+  // derivation (`resolveFilterModeConfig`) — see the doc comment above.
+  const filterConfig = resolveFilterModeConfig(caps, rx?.mode, rx?.dataMode);
+  const widthMin = filterConfig?.minHz ?? filterConfig?.table?.[0] ?? caps.filterWidthMin;
+  const widthMax = filterConfig?.maxHz
+    ?? (filterConfig?.table?.length ? filterConfig.table[filterConfig.table.length - 1] : undefined)
+    ?? caps.filterWidthMax;
+  return {
+    currentMode: txAuxField(hasModes, modeObserved, rx?.mode),
+    modeChoices,
+    currentFilter: txAuxField(hasFilters, filterObserved, numOrUndef(rx?.filter ?? undefined)),
+    filterChoices,
+    filterWidth: txAuxField(hasFilters, widthObserved, numOrUndef(rx?.filterWidth ?? undefined)),
+    // F2 fix (verify round 1): the bounds' VALUE comes from
+    // `resolveFilterModeConfig(caps, rx?.mode, rx?.dataMode)` — caps + MODE,
+    // never from `filterWidth` — so their operational gate must be
+    // `modeObserved`, not `widthObserved`. Gating on `widthObserved`
+    // published mode-derived bounds as confirmed while `currentMode` itself
+    // read unknown (fabrication), and withheld derivable bounds whenever a
+    // width readback simply hadn't arrived yet (false negative).
+    filterWidthMin: txAuxField(hasFilters, modeObserved, numOrUndef(widthMin)),
+    filterWidthMax: txAuxField(hasFilters, modeObserved, numOrUndef(widthMax)),
   };
 }
 
@@ -489,6 +551,7 @@ export function toRadioViewModel(
   const txAux = deriveTxAux(state, caps);
   const meters = deriveMeters(state, caps, tx);
   const rxAudio = deriveRxAudio(state, caps, facts, modInputSource, rxAudioSnapshot);
+  const modeFilter = deriveModeFilter(state, caps);
 
   return {
     topologyId: `${topology.structuralCount}/${topology.scheme}`,
@@ -504,5 +567,6 @@ export function toRadioViewModel(
     ...(txAux !== undefined ? { txAux } : {}),
     ...(meters !== undefined ? { meters } : {}),
     ...(rxAudio !== undefined ? { rxAudio } : {}),
+    ...(modeFilter !== undefined ? { modeFilter } : {}),
   };
 }

--- a/frontend/src/semantic/__tests__/mode-filter.test.ts
+++ b/frontend/src/semantic/__tests__/mode-filter.test.ts
@@ -1,0 +1,171 @@
+/**
+ * MOR-1262 decomposition slice 4A (MOR-1280) — `modeFilter` optional fact
+ * group (validator half).
+ *
+ * Facts only: current mode, capability-derived mode choice set, current
+ * filter selection, capability-derived filter choice set, filter width and
+ * its min/max bounds. See `radio-view-model.ts`'s `ModeFilterViewModel`/
+ * `validateModeFilter` for the shape and `radio-view-model-adapter.ts`'s
+ * `deriveModeFilter` for the live derivation (covered by the companion
+ * adapter test file).
+ *
+ * Mirrors the companion families' (`tx-aux.test.ts`, `rx-audio.test.ts`)
+ * kill-tests for this family:
+ *  1. a modeFilter-absent model validates and round-trips byte-identically
+ *  2. `"modeFilter": null` / `{}` throw (absent ≠ malformed)
+ *  3. a malformed inner field throws with a precise `$.modeFilter....` path
+ *  5. an unknown extra key inside modeFilter (or a field) throws
+ * (Kill-test 4, the adapter's evidence gate, lives in the adapter test file.)
+ *
+ * Additionally pins the one shape this family has that the others don't:
+ * `modeChoices`/`filterChoices` are plain string arrays, not
+ * `ModeFilterField`-wrapped — a malformed entry must reject with an
+ * indexed path (`$.modeFilter.modeChoices[N]`), and the arrays themselves
+ * must reject a non-array value.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  validateRadioViewModel, type ModeFilterField, type ModeFilterViewModel,
+} from '../radio-view-model';
+import { topologyFixtures, withModeFilter } from '../fixtures/topologies';
+
+const AVAIL = { structural: true, operational: true } as const;
+const base = topologyFixtures['1/single'];
+
+describe('modeFilter (MOR-1262 slice 4A)', () => {
+  // ── Kill-test 1: absence is byte-identical, not a new default shape ──────
+  it('validates a modeFilter-absent model and never adds the key', () => {
+    expect(Object.keys(base)).not.toContain('modeFilter');
+    const validated = validateRadioViewModel(base);
+    expect(Object.keys(validated)).not.toContain('modeFilter');
+    expect(validated.modeFilter).toBeUndefined();
+    expect(JSON.parse(JSON.stringify(validated))).toEqual(JSON.parse(JSON.stringify(base)));
+  });
+
+  it('validates a fully-populated modeFilter group and returns it unchanged', () => {
+    const withMf = withModeFilter(base);
+    expect(validateRadioViewModel(withMf).modeFilter).toEqual(withMf.modeFilter);
+  });
+
+  // ── Kill-test 2: null / {} are not absent ────────────────────────────────
+  it('rejects an explicit modeFilter: null', () => {
+    expect(() => validateRadioViewModel({ ...base, modeFilter: null })).toThrow(TypeError);
+  });
+
+  it('rejects an explicit modeFilter: {} — present, not absent, must satisfy its own shape', () => {
+    expect(() => validateRadioViewModel({ ...base, modeFilter: {} })).toThrow(TypeError);
+  });
+
+  // ── Kill-test 3: malformed inner field, precise path ─────────────────────
+  it('rejects a non-string currentMode reading value with a precise error path', () => {
+    const withMf = withModeFilter(base);
+    const malformed = {
+      ...withMf,
+      modeFilter: {
+        ...withMf.modeFilter,
+        currentMode: { reading: { status: 'known', value: 7 }, availability: AVAIL },
+      },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.modeFilter\.currentMode\.reading\.value/);
+  });
+
+  it('rejects a non-numeric filterWidth reading value with a precise error path', () => {
+    const withMf = withModeFilter(base);
+    const malformed = {
+      ...withMf,
+      modeFilter: {
+        ...withMf.modeFilter,
+        filterWidth: { reading: { status: 'known', value: 'wide' }, availability: AVAIL },
+      },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.modeFilter\.filterWidth\.reading\.value/);
+  });
+
+  it('rejects a non-array modeChoices value', () => {
+    const withMf = withModeFilter(base);
+    const malformed = { ...withMf, modeFilter: { ...withMf.modeFilter, modeChoices: 'USB' } };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.modeFilter\.modeChoices/);
+  });
+
+  it('rejects a non-string entry inside filterChoices with an indexed path', () => {
+    const withMf = withModeFilter(base);
+    const malformed = {
+      ...withMf, modeFilter: { ...withMf.modeFilter, filterChoices: ['FIL1', 2, 'FIL3'] },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.modeFilter\.filterChoices\[1\]/);
+  });
+
+  it('rejects a non-boolean field inside a modeFilter field Availability', () => {
+    const withMf = withModeFilter(base);
+    const malformed = {
+      ...withMf,
+      modeFilter: {
+        ...withMf.modeFilter,
+        currentFilter: { reading: { status: 'unknown' }, availability: { structural: 'yes', operational: true } },
+      },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(TypeError);
+  });
+
+  it('accepts an unknown reading distinct from a known one, independently per field', () => {
+    const withMf = withModeFilter(base);
+    const partial = {
+      ...withMf,
+      modeFilter: {
+        ...withMf.modeFilter,
+        filterWidthMax: { reading: { status: 'unknown' }, availability: { structural: true, operational: false } },
+      },
+    };
+    const validated = validateRadioViewModel(partial);
+    expect(validated.modeFilter?.filterWidthMax).toEqual({
+      reading: { status: 'unknown' }, availability: { structural: true, operational: false },
+    });
+    // The rest of the group is untouched by the one field's degrade.
+    expect(validated.modeFilter?.filterWidth.reading).toEqual({ status: 'known', value: 2400 });
+  });
+
+  // ── Kill-test 5: no speculative keys (N4) ─────────────────────────────────
+  it('rejects an unknown extra key inside modeFilter', () => {
+    const withMf = withModeFilter(base);
+    const malformed = { ...withMf, modeFilter: { ...withMf.modeFilter, bogus: 1 } };
+    expect(() => validateRadioViewModel(malformed)).toThrow(TypeError);
+  });
+
+  it('rejects an unknown extra key inside a single modeFilter field', () => {
+    const withMf = withModeFilter(base);
+    const malformed = {
+      ...withMf,
+      modeFilter: {
+        ...withMf.modeFilter,
+        currentFilter: { reading: { status: 'known', value: 1 }, availability: AVAIL, extra: true },
+      },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(TypeError);
+  });
+
+  it('rejects a reading that carries a value key while unknown', () => {
+    const withMf = withModeFilter(base);
+    const malformed = {
+      ...withMf,
+      modeFilter: {
+        ...withMf.modeFilter,
+        filterWidthMin: { reading: { status: 'unknown', value: 50 }, availability: AVAIL },
+      },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(TypeError);
+  });
+
+  it('every field of a fully-populated group round-trips its own value', () => {
+    const withMf = withModeFilter(base);
+    const validated = validateRadioViewModel(withMf).modeFilter as ModeFilterViewModel;
+    const knownValue = <T>(f: ModeFilterField<T>): T | undefined =>
+      f.reading.status === 'known' ? f.reading.value : undefined;
+    expect(knownValue(validated.currentMode)).toBe('USB');
+    expect(validated.modeChoices).toEqual(['USB', 'LSB', 'CW', 'RTTY', 'FM']);
+    expect(knownValue(validated.currentFilter)).toBe(1);
+    expect(validated.filterChoices).toEqual(['FIL1', 'FIL2', 'FIL3']);
+    expect(knownValue(validated.filterWidth)).toBe(2400);
+    expect(knownValue(validated.filterWidthMin)).toBe(50);
+    expect(knownValue(validated.filterWidthMax)).toBe(3600);
+  });
+});

--- a/frontend/src/semantic/__tests__/optional-group-allow-list.test.ts
+++ b/frontend/src/semantic/__tests__/optional-group-allow-list.test.ts
@@ -40,9 +40,9 @@ const REQUIRED_KEYS = [
   'txTarget', 'txPermit', 'scope', 'disabledReasons',
 ] as const;
 
-/** MOR-1244: txAux. MOR-1262 slice 2A: meters. Slice 3A: rxAudio. Add your key
- *  here when your family's slice lands. */
-const EXPECTED_OPTIONAL_GROUP_KEYS = ['txAux', 'meters', 'rxAudio'] as const;
+/** MOR-1244: txAux. MOR-1262 slice 2A: meters. Slice 3A: rxAudio. Slice 4A:
+ *  modeFilter. Add your key here when your family's slice lands. */
+const EXPECTED_OPTIONAL_GROUP_KEYS = ['txAux', 'meters', 'rxAudio', 'modeFilter'] as const;
 
 function extractTopLevelAllowList(): string[] {
   // `.toString()` on a Vite/esbuild-transformed function returns the SSR-

--- a/frontend/src/semantic/fixtures/topologies.ts
+++ b/frontend/src/semantic/fixtures/topologies.ts
@@ -15,6 +15,7 @@
  */
 import type {
   Availability, MeterField, MeterRfState, MetersViewModel,
+  ModeFilterField, ModeFilterViewModel,
   ModInputReadiness, RadioViewModel, RxAudioField, RxAudioViewModel,
   TxAuxField, TxAuxViewModel,
 } from '../radio-view-model';
@@ -238,4 +239,24 @@ export function withRxAudio(
     modInputReadiness: readiness,
   };
   return { ...fixture, rxAudio };
+}
+
+/**
+ * Applies a fully-observed `modeFilter` group (MOR-1262 slice 4A) to any
+ * topology fixture — capability-derived choice sets plus a known current
+ * selection, same composable-axis story as `withTxAux`/`withMeters` above.
+ */
+export function withModeFilter(fixture: RadioViewModel): RadioViewModel {
+  const avail: Availability = { structural: true, operational: true };
+  const known = <T>(value: T): ModeFilterField<T> => ({ reading: { status: 'known', value }, availability: avail });
+  const modeFilter: ModeFilterViewModel = {
+    currentMode: known('USB'),
+    modeChoices: ['USB', 'LSB', 'CW', 'RTTY', 'FM'],
+    currentFilter: known(1),
+    filterChoices: ['FIL1', 'FIL2', 'FIL3'],
+    filterWidth: known(2400),
+    filterWidthMin: known(50),
+    filterWidthMax: known(3600),
+  };
+  return { ...fixture, modeFilter };
 }

--- a/frontend/src/semantic/radio-view-model.ts
+++ b/frontend/src/semantic/radio-view-model.ts
@@ -233,6 +233,42 @@ export interface RxAudioViewModel {
   modInputReadiness: ModInputReadiness;
 }
 
+/**
+ * A single mode/filter fact (MOR-1262 decomposition slice 4A, MOR-1280).
+ * Shape-identical to `TxAuxField`, declared as an alias for the same reason
+ * `RxAudioField` is: one field shape per fact family, no near-duplicate.
+ */
+export type ModeFilterField<T> = TxAuxField<T>;
+
+/**
+ * Mode/filter facts (MOR-1262 decomposition slice 4A). Facts only — no
+ * command emission; choosing a mode or dragging the filter-width control
+ * stays with the surface (slice 4B).
+ *
+ * `modeChoices`/`filterChoices` are the capability-derived choice sets
+ * (`Capabilities.modes` / `.filters`, verbatim) — plain lists, not
+ * `ModeFilterField`-wrapped, because a choice set is a structural fact about
+ * the radio MODEL, not a live reading that can itself go stale. The current
+ * selection and the width bounds ARE readings, and degrade to `unknown`
+ * rather than to `toFilterProps`'s fabricated defaults ('USB', 2400 Hz,
+ * 50..9999 Hz) — see `radio-view-model-adapter.ts`'s `deriveModeFilter`.
+ *
+ * `filterWidthMin`/`filterWidthMax` are the ONE remaining consumer of
+ * `resolveFilterModeConfig`'s per-mode table lookup that this slice adds;
+ * the X6200 CAT-audit lesson (filter-width codecs are radio-specific) is why
+ * this group never re-derives that table itself — it reads the shipped
+ * resolver's own output, like `modInputReadiness` reads `deriveTxCapabilities`.
+ */
+export interface ModeFilterViewModel {
+  currentMode: ModeFilterField<string>;
+  modeChoices: readonly string[];
+  currentFilter: ModeFilterField<number>;
+  filterChoices: readonly string[];
+  filterWidth: ModeFilterField<number>;
+  filterWidthMin: ModeFilterField<number>;
+  filterWidthMax: ModeFilterField<number>;
+}
+
 export interface RadioViewModel {
   topologyId: string;
   vfoScheme: VfoScheme;
@@ -258,6 +294,10 @@ export interface RadioViewModel {
    *  not supplied, or this radio has no RX-audio chain to describe — see
    *  `radio-view-model-adapter.ts`'s `deriveRxAudio`. */
   readonly rxAudio?: RxAudioViewModel;
+  /** Absent (MOR-1264 optional group) ⇒ this radio declares no modes and no
+   *  filters and nothing mode/filter-shaped was ever observed — see
+   *  `radio-view-model-adapter.ts`'s `deriveModeFilter`. */
+  readonly modeFilter?: ModeFilterViewModel;
 }
 
 const RECEIVER_IDS: readonly ReceiverId[] = ['MAIN', 'SUB'];
@@ -569,6 +609,32 @@ function validateRxAudio(value: unknown, path: string): RxAudioViewModel {
   };
 }
 
+/** A capability-derived choice set: plain strings, no field-shape wrapper —
+ *  see `ModeFilterViewModel`'s doc comment for why. */
+function strArray(value: unknown, path: string): string[] {
+  if (!Array.isArray(value)) invalid(path, 'an array of strings');
+  return value.map((item, i) => str(item, `${path}[${i}]`));
+}
+
+/** N4 again: exactly the seven facts the adapter reads, no speculative keys.
+ *  See `radio-view-model-adapter.ts::deriveModeFilter`. */
+function validateModeFilter(value: unknown, path: string): ModeFilterViewModel {
+  const v = record(value, path);
+  exactKeys(v, [
+    'currentMode', 'modeChoices', 'currentFilter', 'filterChoices',
+    'filterWidth', 'filterWidthMin', 'filterWidthMax',
+  ], path);
+  return {
+    currentMode: validateTxAuxField(v.currentMode, `${path}.currentMode`, str),
+    modeChoices: strArray(v.modeChoices, `${path}.modeChoices`),
+    currentFilter: validateTxAuxField(v.currentFilter, `${path}.currentFilter`, num),
+    filterChoices: strArray(v.filterChoices, `${path}.filterChoices`),
+    filterWidth: validateTxAuxField(v.filterWidth, `${path}.filterWidth`, num),
+    filterWidthMin: validateTxAuxField(v.filterWidthMin, `${path}.filterWidthMin`, num),
+    filterWidthMax: validateTxAuxField(v.filterWidthMax, `${path}.filterWidthMax`, num),
+  };
+}
+
 /** Runtime validator (repo idiom: throws TypeError with a `$.path`, see `validateCapabilities`).
  *  Also enforces two cross-field invariants (review cycle 1, V1): `txPermit`
  *  cannot be 'allowed' while `txTarget` is unknown (no fail-open), and
@@ -577,7 +643,7 @@ export function validateRadioViewModel(value: unknown): RadioViewModel {
   const v = record(value, '$');
   exactKeys(v, [
     'topologyId', 'vfoScheme', 'activeReceiver', 'vfos', 'split', 'dualWatch',
-    'txTarget', 'txPermit', 'scope', 'disabledReasons', 'txAux', 'meters', 'rxAudio',
+    'txTarget', 'txPermit', 'scope', 'disabledReasons', 'txAux', 'meters', 'rxAudio', 'modeFilter',
   ], '$');
   if (!Array.isArray(v.vfos)) invalid('$.vfos', 'an array');
   if (!Array.isArray(v.disabledReasons)) invalid('$.disabledReasons', 'an array');
@@ -608,6 +674,7 @@ export function validateRadioViewModel(value: unknown): RadioViewModel {
   const txAux = optionalGroup(v.txAux, '$.txAux', validateTxAux);
   const meters = optionalGroup(v.meters, '$.meters', validateMeters);
   const rxAudio = optionalGroup(v.rxAudio, '$.rxAudio', validateRxAudio);
+  const modeFilter = optionalGroup(v.modeFilter, '$.modeFilter', validateModeFilter);
 
   return {
     topologyId: str(v.topologyId, '$.topologyId'),
@@ -626,5 +693,6 @@ export function validateRadioViewModel(value: unknown): RadioViewModel {
     ...(txAux !== undefined ? { txAux } : {}),
     ...(meters !== undefined ? { meters } : {}),
     ...(rxAudio !== undefined ? { rxAudio } : {}),
+    ...(modeFilter !== undefined ? { modeFilter } : {}),
   };
 }


### PR DESCRIPTION
## Summary
Vocabulary slice 4A of the MOR-1262 program. Optional `modeFilter` group via the S0 seam, following the 1A/2A/3A pattern: `currentMode`/`modeChoices`, `currentFilter`/`filterChoices`, `filterWidth`/`filterWidthMin`/`filterWidthMax` — exactKeys at all levels, null/`{}` pinned, one shared field validator. Choice sets are capability-derived; the evidence gate is capability-based — `mode`/`filter` are REQUIRED state fields, so raw presence carries no evidence signal (verifier-adjudicated sound, majority precedent).

`resolveFilterModeConfig` moves behind the adapter (`deriveModeFilter`): the fact group consumes the real shipped derivation; all v2 call sites (`panel-props.ts`, `state-adapter.ts`, `SpectrumPanel.svelte`, `filter-controls.ts`) byte-identical. Net production LOC **132** (verifier re-measured; ≤200).

## Review provenance
Sonnet builder → independent opus vocabulary-domain verifier (5th ticket in domain). Round 1 **BLOCKED**: (F1) the resolver-parity claim was unpinned — a naive `caps.filterConfig[mode]` lookup and a dropped `dataMode` both survived 29/29 because the width tests only covered points where naive and real agree; (F2) `filterWidthMin/Max` gated on `widthObserved` fabricated the CW table under an unobserved mode. Both fixes verifier-pre-validated; delta round **PASS**: D1 killed (1 failed), D2 killed (6 failed, counts matching prediction), honesty probes clean both directions, production delta = exactly the one F2 gate hunk. Contract mutations 4/4 killed; zero literal width tables; A-queue clean; fail-set identical to baseline; merged-onto-main apply clean. Rulings: evidence gate SOUND; decomposition gap found → **MOR-1284** (4A′ filter passband facts: IF-shift/PBT/filterShape, blocks 4B); duplicate `resolveFilterModeConfig` definitions → **MOR-1285**.

Linear: MOR-1280

🤖 Generated with [Claude Code](https://claude.com/claude-code)