### PR TITLE
feat(MOR-1077): workspace v1 schema, validator, defaults, and safe fallback

### DIFF
--- a/frontend/src/presentation/workspace/__tests__/contract.test.ts
+++ b/frontend/src/presentation/workspace/__tests__/contract.test.ts
@@ -1,0 +1,311 @@
+/**
+ * MOR-1077 — workspace v1 schema/validator/defaults/fallback, one describe
+ * block per MOR-1076 decision plus the registry-sync pins that stand in for
+ * the live imports this zone cannot make (see `../contract.ts`'s header).
+ *
+ * Fast pool on purpose: this file stubs no global and mocks no module, so it
+ * is order-independent under `isolate: false` (MOR-1272). The registry
+ * imports below DO fire `registerLayout`/`registerDesignLanguage`, which is
+ * exactly why they live here and not in `purity.test.ts`.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import {
+  DEFAULT_WORKSPACE, WORKSPACE_DENSITY_CLAMP, WORKSPACE_DESIGN_LANGUAGE_IDS, WORKSPACE_LAYOUT_IDS,
+  WORKSPACE_SCHEMA_VERSION, WORKSPACE_THEME_IDS, WORKSPACE_ZONE_IDS, normalizeWorkspaceLayoutId,
+  readWorkspace, readWorkspaceJson, serializeWorkspace, workspaceLayoutManifestId,
+  type WorkspaceForbiddenClass, type WorkspaceV1,
+} from '../contract';
+// Registry-sync sources. Each is imported ONLY to prove the pinned literal
+// still matches the live declaration — never used by production code here.
+import * as layoutDeclarations from '../../layouts/declarations';
+import type { LayoutManifest } from '../../layouts/contract';
+import { fieldline, studioline } from '../../languages/declarations';
+import { getAvailableThemes } from '../../../components-v2/theme/theme-switcher';
+
+/**
+ * The layout id space is synced from SOURCE TEXT, not an import: `lib/stores/
+ * layout.svelte.ts` reads `localStorage` at module scope and throws in a Node
+ * env without one — the same reason `presentation/layouts/__tests__/
+ * loader-identity-inventory.test.ts` reads specifiers as text rather than
+ * importing the modules that hold them.
+ */
+const LAYOUT_STORE_SOURCE = readFileSync('src/lib/stores/layout.svelte.ts', 'utf8');
+function block(marker: string, open: string, close: string): string {
+  const start = LAYOUT_STORE_SOURCE.indexOf(marker);
+  expect(start).toBeGreaterThan(-1);
+  const from = LAYOUT_STORE_SOURCE.indexOf(open, start);
+  return LAYOUT_STORE_SOURCE.slice(from, LAYOUT_STORE_SOURCE.indexOf(close, from));
+}
+const LIVE_CANONICAL_MODES = [...block('CANONICAL_LAYOUT_MODES', '[', ']').matchAll(/'([^']+)'/g)].map((m) => m[1]);
+const LIVE_ALIASES = [...block('LEGACY_LAYOUT_ALIASES', '{', '}').matchAll(/'?([\w-]+)'?:\s*'([^']+)'/g)].map((m) => [m[1], m[2]] as const);
+
+const VALID: WorkspaceV1 = {
+  version: 1,
+  layout: 'lcd-cockpit',
+  designLanguage: 'fieldline',
+  theme: 'nord',
+  density: 'compact',
+  visibleSurfaces: { 'control-column': ['vfo'] },
+  zoneOrder: { 'rx-tx': ['rxTx'] },
+  pinnedCommands: ['set_compressor', 'set_monitor_gain'],
+};
+
+describe('registry sync — the pinned id spaces still match their live owners', () => {
+  it('layout ids are exactly the store\'s CanonicalLayoutMode set', () => {
+    // Kills: a new CanonicalLayoutMode landing in the store without a pin here.
+    expect([...WORKSPACE_LAYOUT_IDS].sort()).toEqual([...LIVE_CANONICAL_MODES].sort());
+    for (const id of WORKSPACE_LAYOUT_IDS) expect(normalizeWorkspaceLayoutId(id)).toBe(id);
+    // The QA-only cockpit id must stay unpersistable (MOR-1257).
+    expect(LIVE_CANONICAL_MODES).not.toContain('dual-receiver-cockpit');
+    expect(normalizeWorkspaceLayoutId('dual-receiver-cockpit')).toBe('auto');
+  });
+
+  it('the MOR-1042 alias table is mirrored exactly', () => {
+    expect(LIVE_ALIASES.length).toBe(4);
+    for (const [alias, canonical] of LIVE_ALIASES) expect(normalizeWorkspaceLayoutId(alias)).toBe(canonical);
+  });
+
+  it('design-language ids and their density clamps match the live manifests', () => {
+    expect([...WORKSPACE_DESIGN_LANGUAGE_IDS]).toEqual([studioline.id, fieldline.id]);
+    for (const manifest of [studioline, fieldline]) {
+      expect(manifest.density.kind).toBe('clamped');
+      const supported = manifest.density.kind === 'clamped' ? manifest.density.supported : [];
+      expect(WORKSPACE_DENSITY_CLAMP[manifest.id as 'studioline']).toEqual(supported);
+    }
+    // fieldline clamps `dense` out at 0.6 relative density (MOR-977 §4.4).
+    expect(WORKSPACE_DENSITY_CLAMP.fieldline).not.toContain('dense');
+  });
+
+  it('theme ids are exactly the switcher\'s 21-id list, in order', () => {
+    expect([...WORKSPACE_THEME_IDS]).toEqual(getAvailableThemes().map((t) => t.id));
+  });
+
+  it('zone ids are exactly the zones every registered layout manifest declares', () => {
+    const manifests = Object.values(layoutDeclarations).filter(
+      (v): v is LayoutManifest => typeof v === 'object' && v !== null && (v as LayoutManifest).schemaVersion === 1,
+    );
+    const live = [...new Set(manifests.flatMap((m) => m.zones.map((z) => z.id)))].sort();
+    expect([...WORKSPACE_ZONE_IDS].sort()).toEqual(live);
+  });
+});
+
+describe('decision 12 — valid v1 round-trips unchanged', () => {
+  it('reads a fully valid object with no rejections and re-serializes identically', () => {
+    const result = readWorkspace(VALID);
+    expect(result.outcome).toBe('ok');
+    expect(result.rejections).toEqual([]);
+    expect(result.workspace).toEqual(VALID);
+    expect(serializeWorkspace(result)).toEqual(VALID);
+    // Second pass over the serialized form is a fixed point.
+    expect(readWorkspace(serializeWorkspace(result)).workspace).toEqual(VALID);
+  });
+
+  it('defaults are themselves a valid, rejection-free workspace', () => {
+    const result = readWorkspace(DEFAULT_WORKSPACE);
+    expect(result.outcome).toBe('ok');
+    expect(result.workspace).toEqual(DEFAULT_WORKSPACE);
+  });
+
+  it('JSON import/export is whole-object and carries the version field', () => {
+    const text = JSON.stringify(serializeWorkspace(readWorkspace(VALID)));
+    expect(JSON.parse(text).version).toBe(WORKSPACE_SCHEMA_VERSION);
+    expect(readWorkspaceJson(text).workspace).toEqual(VALID);
+  });
+});
+
+describe('decision 10 — unknown fields are ignored AND preserved, never erased', () => {
+  it('keeps an unknown top-level field verbatim through a full round trip', () => {
+    const stored = { ...VALID, futureField: { nested: [1, 'two'] }, anotherOne: 'plain' };
+    const result = readWorkspace(stored);
+    expect(result.outcome).toBe('ok');
+    expect(result.preserved).toEqual({ futureField: { nested: [1, 'two'] }, anotherOne: 'plain' });
+    // The known surface is unaffected, and serialization restores the stripped-nothing whole.
+    expect(result.workspace).toEqual(VALID);
+    expect(serializeWorkspace(result)).toEqual(stored);
+  });
+
+  it('an unknown field never leaks into the typed workspace object', () => {
+    const result = readWorkspace({ ...VALID, futureField: 1 });
+    expect(Object.keys(result.workspace).sort()).toEqual(Object.keys(VALID).sort());
+  });
+});
+
+describe('decision 11 + rollback window — version policy', () => {
+  it('discards a version outside the window with a surfaced, discriminated signal', () => {
+    const result = readWorkspace({ ...VALID, version: 99 });
+    expect(result.outcome).toBe('version-discarded');
+    expect(result.outcome === 'version-discarded' && result.discardedVersion).toBe(99);
+    expect(result.workspace).toEqual(DEFAULT_WORKSPACE);
+    // Discard is data loss: nothing from the discarded object may survive.
+    expect(result.preserved).toEqual({});
+    expect(result.rejections).toEqual([{ field: 'version', reason: 'malformed' }]);
+  });
+
+  it.each([undefined, null, '1', 1.5, 0])('discards a non-v1 version marker %p', (version) => {
+    expect(readWorkspace({ ...VALID, version }).outcome).toBe('version-discarded');
+  });
+
+  it.each([2, 3])('N=2 forward-read: version %i is READ, not discarded', (version) => {
+    const stored = { ...VALID, version, brandNewField: 'from-a-newer-app' };
+    const result = readWorkspace(stored);
+    expect(result.outcome).toBe('forward-read');
+    expect(result.workspace.theme).toBe('nord');
+    // The newer version is written back un-downgraded, with its new field intact.
+    expect(result.workspace.version).toBe(version);
+    expect(serializeWorkspace(result)).toEqual(stored);
+  });
+
+  it('version 4 is one past the window and discards', () => {
+    expect(readWorkspace({ ...VALID, version: 4 }).outcome).toBe('version-discarded');
+  });
+});
+
+describe('forbidden classes — one refusal per class, fail-closed', () => {
+  const CASES: readonly (readonly [WorkspaceForbiddenClass, Record<string, unknown>])[] = [
+    ['capabilities', { capabilities: ['audio', 'tx'] }],
+    ['runtime-state', { freqHz: 14195000 }],
+    ['manufacturer-policy', { icomModPolicy: 'lan' }],
+    ['component-module-path', { favouritePanel: '$lib/../components-v2/panels/TxPanel.svelte' }],
+    ['transport-session', { authToken: 'deadbeef' }],
+    ['tx-resource-safety', { txPowerOverride: 100 }],
+  ];
+
+  it.each(CASES)('refuses a %s field with a typed reason and never persists it', (reason, field) => {
+    const key = Object.keys(field)[0];
+    const result = readWorkspace({ ...VALID, ...field });
+    expect(result.rejections).toContainEqual({ field: key, reason });
+    expect(result.preserved).toEqual({});
+    expect(serializeWorkspace(result)).not.toHaveProperty(key);
+    // Refusing one field must not destroy the rest of a valid workspace.
+    expect(result.outcome).toBe('repaired');
+    expect(result.workspace).toEqual(VALID);
+  });
+
+  it('catches a forbidden payload nested inside an otherwise innocuous unknown field', () => {
+    const result = readWorkspace({ ...VALID, uiExtras: { panel: { capabilities: ['tx'] } } });
+    expect(result.rejections).toContainEqual({ field: 'uiExtras', reason: 'capabilities' });
+    expect(result.preserved).toEqual({});
+  });
+
+  it('catches a module path smuggled as a value deep in an unknown field', () => {
+    const result = readWorkspace({ ...VALID, uiExtras: { slots: ['./panels/TxPanel.svelte'] } });
+    expect(result.rejections).toContainEqual({ field: 'uiExtras', reason: 'component-module-path' });
+  });
+
+  it('rejects a pinned command whose intent name is TX-safety shaped', () => {
+    const result = readWorkspace({ ...VALID, pinnedCommands: ['set_compressor', 'tx_inhibit'] });
+    expect(result.workspace.pinnedCommands).toEqual(['set_compressor']);
+    expect(result.rejections).toContainEqual({ field: 'pinnedCommands', reason: 'tx-resource-safety' });
+  });
+
+  it('rejects a pinned command that is a module path rather than an intent name', () => {
+    const result = readWorkspace({ ...VALID, pinnedCommands: ['$lib/runtime/commands/tx'] });
+    expect(result.workspace.pinnedCommands).toEqual([]);
+    expect(result.rejections).toContainEqual({ field: 'pinnedCommands', reason: 'malformed' });
+  });
+});
+
+describe('decision 4 — density is clamped by the ACTIVE design language', () => {
+  it('honours an in-clamp override', () => {
+    expect(readWorkspace({ ...VALID, designLanguage: 'studioline', density: 'dense' }).workspace.density).toBe('dense');
+  });
+
+  it('clamps `dense` out under fieldline and says why', () => {
+    const result = readWorkspace({ ...VALID, designLanguage: 'fieldline', density: 'dense' });
+    expect(result.workspace.density).toBe('comfortable');
+    expect(result.rejections).toContainEqual({ field: 'density', reason: 'out-of-clamp' });
+  });
+
+  it('an unknown density is `unknown-id`, not `out-of-clamp`', () => {
+    expect(readWorkspace({ ...VALID, density: 'spacious' }).rejections)
+      .toContainEqual({ field: 'density', reason: 'unknown-id' });
+  });
+
+  it('the clamp follows the language that was actually accepted, not the one requested', () => {
+    // An invalid language falls back to studioline, whose clamp then admits `dense`.
+    const result = readWorkspace({ ...VALID, designLanguage: 'nope', density: 'dense' });
+    expect(result.workspace.designLanguage).toBe('studioline');
+    expect(result.workspace.density).toBe('dense');
+  });
+});
+
+describe('decision 1 — `auto` is first class and resolution is deferred', () => {
+  it('round-trips `auto` and defers its manifest resolution to resolveSkinId', () => {
+    expect(readWorkspace({ ...VALID, layout: 'auto' }).workspace.layout).toBe('auto');
+    expect(workspaceLayoutManifestId('auto')).toBeNull();
+  });
+
+  it('bridges the two id spaces — `standard` is the `desktop-v2` manifest', () => {
+    expect(workspaceLayoutManifestId('standard')).toBe('desktop-v2');
+    for (const id of WORKSPACE_LAYOUT_IDS) {
+      const manifestId = workspaceLayoutManifestId(id);
+      if (manifestId !== null) expect(typeof manifestId).toBe('string');
+    }
+  });
+
+  it('normalizes a legacy alias on read instead of rejecting it', () => {
+    const result = readWorkspace({ ...VALID, layout: 'amber-lcd' });
+    expect(result.workspace.layout).toBe('lcd-cockpit');
+    expect(result.rejections).toEqual([]);
+  });
+
+  it('falls an unknown layout id back to `auto` with a rejection', () => {
+    const result = readWorkspace({ ...VALID, layout: 'dual-receiver-cockpit' });
+    expect(result.workspace.layout).toBe('auto');
+    expect(result.rejections).toContainEqual({ field: 'layout', reason: 'unknown-id' });
+  });
+});
+
+describe('decisions 5 and 6 — zone constraints', () => {
+  it('drops an unknown zone id and an unknown surface id', () => {
+    const result = readWorkspace({ ...VALID, visibleSurfaces: { 'no-such-zone': ['vfo'], main: ['vfo', 'nope'] } });
+    expect(result.workspace.visibleSurfaces).toEqual({ main: ['vfo'] });
+    expect(result.rejections).toContainEqual({ field: 'visibleSurfaces.no-such-zone', reason: 'unknown-id' });
+    expect(result.rejections).toContainEqual({ field: 'visibleSurfaces.main', reason: 'unknown-id' });
+  });
+
+  it('rejects the same surface claimed by two zones — the cross-zone move shape', () => {
+    const result = readWorkspace({ ...VALID, zoneOrder: { 'primary-vfo': ['vfo'], 'secondary-vfo': ['vfo'] } });
+    expect(result.workspace.zoneOrder).toEqual({ 'primary-vfo': ['vfo'], 'secondary-vfo': [] });
+    expect(result.rejections).toContainEqual({ field: 'zoneOrder.secondary-vfo', reason: 'cross-zone' });
+  });
+
+  it('preserves within-zone order — reordering is the whole point of the field', () => {
+    const result = readWorkspace({ ...VALID, zoneOrder: { main: ['rxTx', 'vfo'] } });
+    expect(result.workspace.zoneOrder.main).toEqual(['rxTx', 'vfo']);
+  });
+
+  it('a malformed zone map degrades to empty rather than throwing', () => {
+    expect(readWorkspace({ ...VALID, visibleSurfaces: ['vfo'] }).workspace.visibleSurfaces).toEqual({});
+    expect(readWorkspace({ ...VALID, zoneOrder: 42 }).workspace.zoneOrder).toEqual({});
+  });
+});
+
+describe('decision 12 — invalid state resets, never throws, never blocks boot', () => {
+  it('invalid-everything (but a readable version) falls back field by field', () => {
+    const result = readWorkspace({
+      version: 1, layout: 7, designLanguage: {}, theme: 'no-such-theme', density: null,
+      visibleSurfaces: 'nope', zoneOrder: null, pinnedCommands: 'set_compressor',
+    });
+    expect(result.outcome).toBe('repaired');
+    expect(result.workspace).toEqual({ ...DEFAULT_WORKSPACE, version: 1 });
+  });
+
+  it.each([null, undefined, 42, 'text', [], true, NaN])('never throws on %p', (input) => {
+    expect(() => readWorkspace(input)).not.toThrow();
+    expect(readWorkspace(input).workspace).toEqual(DEFAULT_WORKSPACE);
+  });
+
+  it('unparseable JSON resets instead of propagating a SyntaxError', () => {
+    expect(() => readWorkspaceJson('{not json')).not.toThrow();
+    expect(readWorkspaceJson('{not json').outcome).toBe('reset');
+    expect(readWorkspaceJson('null').outcome).toBe('reset');
+  });
+
+  it('a prototype-polluting key is treated as an ordinary unknown field, not applied', () => {
+    const result = readWorkspace(JSON.parse('{"version":1,"__proto__":{"polluted":true}}') as unknown);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    expect(result.workspace).toEqual({ ...DEFAULT_WORKSPACE, version: 1 });
+  });
+});

--- a/frontend/src/presentation/workspace/__tests__/purity.test.ts
+++ b/frontend/src/presentation/workspace/__tests__/purity.test.ts
@@ -1,0 +1,126 @@
+/**
+ * MOR-1077 load-time purity. The workspace contract is a PURE module: reading
+ * it must never touch storage, the DOM, transport or audio — persistence is
+ * MOR-1079's boundary, and the 3A lesson (`lib/runtime/adapters/__tests__/
+ * rx-audio-purity.test.ts`) is that a side effect fired at IMPORT is invisible
+ * to every behavioural assertion made afterwards.
+ *
+ * Two pins with different, non-interchangeable coverage:
+ *  1. LOAD-TIME SPY — globals are stubbed, the module registry is reset, and
+ *     the contract is imported fresh. Covers its whole transitive closure and
+ *     is the only pin that sees an effect fired at import rather than at call.
+ *  2. STRUCTURAL CLOSURE — the import graph is walked from the contract's own
+ *     source and every file in it is checked for banned specifiers and banned
+ *     globals. Source-text pins are normally non-transitive; this one is not,
+ *     because it enumerates the closure rather than reading a single file.
+ *
+ * Pool: `isolated` (MOR-1272). `vi.stubGlobal` + `vi.resetModules()` are
+ * exactly the shared-state shapes that are order-dependent under the fast
+ * pool's `isolate: false` — registered in `vite.config.ts`.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, join, normalize } from 'node:path';
+
+const ENTRY = 'src/presentation/workspace/contract.ts';
+
+/** Comments are stripped first: this file's subjects DOCUMENT the prohibition
+ *  in prose ("nothing here reads or writes storage"), and a naive text search
+ *  would match the doctrine instead of the code. */
+function code(path: string): string {
+  return readFileSync(path, 'utf8').replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
+/** Every relative specifier a file imports or re-exports, `.ts`-resolved. */
+function relativeImports(path: string): string[] {
+  const source = code(path);
+  return [...source.matchAll(/(?:from|import)\s*['"](\.[^'"]+)['"]/g)]
+    .map((m) => normalize(join(dirname(path), m[1].endsWith('.ts') ? m[1] : `${m[1]}.ts`)));
+}
+
+/** The contract's full transitive closure of first-party modules. */
+function closure(entry: string): string[] {
+  const seen = new Set<string>();
+  const queue = [entry];
+  while (queue.length > 0) {
+    const path = queue.shift()!;
+    if (seen.has(path)) continue;
+    seen.add(path);
+    queue.push(...relativeImports(path));
+  }
+  return [...seen];
+}
+
+const storage = { getItem: vi.fn(() => null), setItem: vi.fn(), removeItem: vi.fn(), clear: vi.fn(), key: vi.fn(() => null), length: 0 };
+const fetchSpy = vi.fn();
+const wsCtor = vi.fn();
+class SpyWebSocket { constructor(...args: unknown[]) { wsCtor(...args); } }
+
+describe('the workspace contract is pure at load (MOR-1077)', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  // ── Pin 1: load-time, closure-wide ─────────────────────────────────────
+  it('importing the contract touches no storage, network or socket', async () => {
+    vi.stubGlobal('localStorage', storage);
+    vi.stubGlobal('sessionStorage', storage);
+    vi.stubGlobal('fetch', fetchSpy);
+    vi.stubGlobal('WebSocket', SpyWebSocket);
+    for (const spy of [storage.getItem, storage.setItem, storage.removeItem, fetchSpy, wsCtor]) spy.mockClear();
+
+    vi.resetModules();
+    const module = await import('../contract');
+
+    // The module really did evaluate — otherwise "zero calls" proves nothing.
+    expect(module.DEFAULT_WORKSPACE.layout).toBe('auto');
+    expect(storage.getItem).not.toHaveBeenCalled();
+    expect(storage.setItem).not.toHaveBeenCalled();
+    expect(storage.removeItem).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(wsCtor).not.toHaveBeenCalled();
+  });
+
+  it('reading a workspace mutates neither its input nor the shared defaults', async () => {
+    const { readWorkspace, DEFAULT_WORKSPACE } = await import('../contract');
+    const input = { version: 1, layout: 'lcd', pinnedCommands: ['set_compressor'], future: { a: 1 } };
+    const snapshot = structuredClone(input);
+    const first = readWorkspace(input);
+    const second = readWorkspace(input);
+
+    expect(input).toEqual(snapshot);
+    expect(second).toEqual(first);
+    expect(DEFAULT_WORKSPACE.visibleSurfaces).toEqual({});
+    expect(DEFAULT_WORKSPACE.pinnedCommands).toEqual([]);
+  });
+
+  // ── Pin 2: structural, transitive over the enumerated closure ───────────
+  it('the closure is exactly the contract plus the two pure presentation contracts', () => {
+    expect(closure(ENTRY).sort()).toEqual([
+      'src/presentation/languages/contract.ts',
+      'src/presentation/layouts/contract.ts',
+      ENTRY,
+    ].sort());
+  });
+
+  it.each(closure(ENTRY))('%s imports no store, transport, audio, skin or component module', (path) => {
+    const source = code(path);
+    expect(source).not.toMatch(/from\s+['"]\$lib\//);
+    expect(source).not.toMatch(/from\s+['"][^'"]*(stores|transport|audio|skins|components-v2|semantic)\//);
+    expect(source).not.toMatch(/\bdeclarations['"]/);
+  });
+
+  it.each(closure(ENTRY))('%s references no browser or runtime global', (path) => {
+    const source = code(path);
+    for (const banned of [/\blocalStorage\b/, /\bsessionStorage\b/, /\bdocument\b/, /\bwindow\b/, /\bfetch\(/, /\bWebSocket\b/, /\bAudioContext\b/]) {
+      expect(source).not.toMatch(banned);
+    }
+  });
+
+  it('the contract persists no component module path — ids only (v3 ADR invariant 6)', () => {
+    const source = code(ENTRY);
+    expect(source).not.toMatch(/import\s*\(/);
+    expect(source).not.toMatch(/\.svelte['"]/);
+  });
+});

--- a/frontend/src/presentation/workspace/contract.ts
+++ b/frontend/src/presentation/workspace/contract.ts
@@ -1,0 +1,243 @@
+/**
+ * Workspace v1 schema, validator, defaults and safe fallback (MOR-1077) —
+ * the code form of the MOR-1076 owner freeze (2026-08-04). Pure and
+ * store-free: nothing here reads or writes storage, mounts UI, or resolves a
+ * component. Persistence + settings UI are MOR-1079's boundary; adopting
+ * this object as the layout source of truth is MOR-1081's.
+ *
+ * ID sources. `SEMANTIC_SURFACE_NAMES` is imported LIVE from the layout
+ * contract — a pure module. The other id spaces are PINNED literals with a
+ * registry-sync test (`__tests__/contract.test.ts`), because every module
+ * that owns them is unusable from here: `lib/stores/layout.svelte.ts` reads
+ * `localStorage` at module scope and is `$lib/stores/*` (lint-banned in this
+ * zone), the two `declarations.ts` barrels fire `registerLayout`/
+ * `registerDesignLanguage` as import side effects, and
+ * `components-v2/theme/theme-switcher.ts` is banned by the workspace zone
+ * (v3 ADR invariant 6). The sync test imports all three and fails on drift.
+ */
+import { SEMANTIC_SURFACE_NAMES, type SemanticSurfaceName } from '../layouts/contract';
+import type { DensityLevel } from '../languages/contract';
+
+export const WORKSPACE_SCHEMA_VERSION = 1;
+/** MOR-1076: an app up to 2 minors older must still READ a newer object. */
+export const WORKSPACE_FORWARD_READ_WINDOW = 2;
+
+/** Decision 1: `CanonicalLayoutMode` including `auto`, MOR-1042 aliases applied on read. */
+export const WORKSPACE_LAYOUT_IDS = ['auto', 'lcd-cockpit', 'lcd-scope', 'standard', 'sdr-test'] as const;
+export type WorkspaceLayoutId = (typeof WORKSPACE_LAYOUT_IDS)[number];
+const LAYOUT_ALIASES: Readonly<Record<string, WorkspaceLayoutId>> = { lcd: 'lcd-cockpit', 'amber-lcd': 'lcd-cockpit', spectrum: 'standard', 'desktop-v2': 'standard' };
+/** Workspace id space → layout-manifest id space. `auto` is resolved by the existing
+ *  `skins/registry.ts::resolveSkinId()` (it needs live scope facts this module must not
+ *  see), so it maps to null — "defer", not "unknown". */
+const LAYOUT_MANIFEST_ID: Readonly<Record<WorkspaceLayoutId, string | null>> = { auto: null, 'lcd-cockpit': 'lcd-cockpit', 'lcd-scope': 'lcd-scope', standard: 'desktop-v2', 'sdr-test': 'sdr-test' };
+
+/** Decision 2: frozen by MOR-977 §4.6. */
+export const WORKSPACE_DESIGN_LANGUAGE_IDS = ['studioline', 'fieldline'] as const;
+export type WorkspaceDesignLanguageId = (typeof WORKSPACE_DESIGN_LANGUAGE_IDS)[number];
+/** Decision 4: each language's `DensityClamp.supported`; index 0 is that language's default. */
+export const WORKSPACE_DENSITY_CLAMP: Readonly<Record<WorkspaceDesignLanguageId, readonly DensityLevel[]>> = {
+  studioline: ['comfortable', 'compact', 'dense'],
+  fieldline: ['comfortable', 'compact'],
+};
+
+/** Decision 3: the flat 21-id theme list, allow-list validated ON READ. */
+export const WORKSPACE_THEME_IDS = [
+  'default', 'dracula', 'nord', 'catppuccin-mocha', 'solarized-dark', 'gruvbox-dark', 'tokyo-night',
+  'one-dark', 'ayu-dark', 'amoled-black', 'high-contrast', 'solarized-light', 'catppuccin-latte',
+  'nord-light', 'gruvbox-light', 'github-light', 'custom-ic7610', 'nixie-tube', 'lcd-blue', 'lcd-warm', 'crt-green',
+] as const;
+export type WorkspaceThemeId = (typeof WORKSPACE_THEME_IDS)[number];
+
+/** Every zone id declared by a registered layout manifest (decisions 5 and 6). */
+export const WORKSPACE_ZONE_IDS = ['main', 'receiver-deck', 'rx-tx', 'primary-vfo', 'secondary-vfo', 'global', 'portrait-deck', 'control-column'] as const;
+export type WorkspaceZoneId = (typeof WORKSPACE_ZONE_IDS)[number];
+
+/** Decision 7: command-bus intent names (`set_compressor`), never module paths. */
+const PINNED_COMMAND_PATTERN = /^[a-z][a-z0-9]*(_[a-z0-9]+)*$/;
+
+type ZoneSurfaceMap = Readonly<Partial<Record<WorkspaceZoneId, readonly SemanticSurfaceName[]>>>;
+
+export interface WorkspaceV1 {
+  /** Kept as read, so a forward-read object is written back un-downgraded. */
+  readonly version: number;
+  readonly layout: WorkspaceLayoutId;
+  readonly designLanguage: WorkspaceDesignLanguageId;
+  readonly theme: WorkspaceThemeId;
+  readonly density: DensityLevel;
+  /** Decision 5: ids of the surfaces that are VISIBLE in a zone (allow-list). */
+  readonly visibleSurfaces: ZoneSurfaceMap;
+  /** Decision 6: per-zone order. A surface may appear in at most one zone — the shape
+   *  carries no move operation and a duplicate across zones is rejected, so cross-zone
+   *  moves are structurally out of v1. */
+  readonly zoneOrder: ZoneSurfaceMap;
+  readonly pinnedCommands: readonly string[];
+}
+
+export const DEFAULT_WORKSPACE: WorkspaceV1 = {
+  version: WORKSPACE_SCHEMA_VERSION, layout: 'auto', designLanguage: 'studioline', theme: 'default',
+  density: 'comfortable', visibleSurfaces: {}, zoneOrder: {}, pinnedCommands: [],
+};
+
+/** The classes MOR-1076 forbids outright. A hit is refused with this reason, never persisted. */
+export type WorkspaceForbiddenClass =
+  | 'capabilities' | 'runtime-state' | 'manufacturer-policy'
+  | 'component-module-path' | 'transport-session' | 'tx-resource-safety';
+export type WorkspaceRejectionReason = WorkspaceForbiddenClass | 'unknown-id' | 'out-of-clamp' | 'cross-zone' | 'malformed';
+export interface WorkspaceRejection { readonly field: string; readonly reason: WorkspaceRejectionReason }
+
+/** Matched against a lowercased, separator-stripped key (`tx_power` → `txpower`). */
+const FORBIDDEN_KEY_MARKERS: readonly (readonly [WorkspaceForbiddenClass, RegExp])[] = [
+  ['capabilities', /capabilit/],
+  ['transport-session', /transport|session|token|auth|credential|websocket|socket|endpoint/],
+  ['tx-resource-safety', /^tx|ptt|interlock|safety|inhibit|powerlimit|resource|lockout/],
+  ['runtime-state', /^freq|smeter|swr|runtimestate|radiostate|livestate|rawstate/],
+  ['manufacturer-policy', /icom|yaesu|kenwood|elecraft|xiegu|alinco|vendor|manufacturer|radiomodel|firmware/],
+];
+/** The forms a component specifier takes here (mirrors the layout contract's value scan). */
+const MODULE_PATH_VALUE = /^(\.{1,2}\/|\$lib\/|src\/|\/)|\.(svelte|ts|js)$/;
+
+function forbiddenClassOf(key: string): WorkspaceForbiddenClass | null {
+  const k = key.toLowerCase().replace(/[^a-z0-9]/g, '');
+  return FORBIDDEN_KEY_MARKERS.find(([, re]) => re.test(k))?.[0] ?? null;
+}
+
+/** Deep scan of one unknown field's subtree — preserving it verbatim would persist it. */
+function scanForbidden(value: unknown, key: string): WorkspaceForbiddenClass | null {
+  const keyHit = key ? forbiddenClassOf(key) : null;
+  if (keyHit) return keyHit;
+  if (typeof value === 'string') return MODULE_PATH_VALUE.test(value) ? 'component-module-path' : null;
+  if (Array.isArray(value)) return value.map((v) => scanForbidden(v, '')).find(Boolean) ?? null;
+  if (typeof value === 'object' && value !== null) return Object.entries(value).map(([k, v]) => scanForbidden(v, k)).find(Boolean) ?? null;
+  return null;
+}
+
+function pickId<T extends string>(value: unknown, allowed: readonly T[], fallback: T, field: string, out: WorkspaceRejection[]): T {
+  if (typeof value === 'string' && (allowed as readonly string[]).includes(value)) return value as T;
+  if (value !== undefined) out.push({ field, reason: 'unknown-id' });
+  return fallback;
+}
+
+/** MOR-1042 alias normalization; anything unrecognized falls to `auto`, never throws. */
+export function normalizeWorkspaceLayoutId(value: unknown): WorkspaceLayoutId {
+  if (typeof value !== 'string') return 'auto';
+  if (Object.hasOwn(LAYOUT_ALIASES, value)) return LAYOUT_ALIASES[value];
+  return (WORKSPACE_LAYOUT_IDS as readonly string[]).includes(value) ? (value as WorkspaceLayoutId) : 'auto';
+}
+
+/** Layout-manifest id for a workspace layout id; `null` = defer to `resolveSkinId()`. */
+export function workspaceLayoutManifestId(id: WorkspaceLayoutId): string | null {
+  return LAYOUT_MANIFEST_ID[id];
+}
+
+/** Decision 4 resolution point: the override is honoured only inside the ACTIVE language's clamp. */
+function pickDensity(value: unknown, language: WorkspaceDesignLanguageId, out: WorkspaceRejection[]): DensityLevel {
+  const clamp = WORKSPACE_DENSITY_CLAMP[language];
+  if (typeof value === 'string' && (clamp as readonly string[]).includes(value)) return value as DensityLevel;
+  if (value !== undefined) {
+    const known = (WORKSPACE_DENSITY_CLAMP.studioline as readonly string[]).includes(value as string);
+    out.push({ field: 'density', reason: known ? 'out-of-clamp' : 'unknown-id' });
+  }
+  return clamp[0];
+}
+
+function pickZoneMap(value: unknown, field: string, out: WorkspaceRejection[]): ZoneSurfaceMap {
+  const result: Partial<Record<WorkspaceZoneId, readonly SemanticSurfaceName[]>> = {};
+  if (value === undefined) return result;
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) { out.push({ field, reason: 'malformed' }); return result; }
+  const claimed = new Set<string>();
+  for (const [zone, list] of Object.entries(value)) {
+    if (!(WORKSPACE_ZONE_IDS as readonly string[]).includes(zone) || !Array.isArray(list)) { out.push({ field: `${field}.${zone}`, reason: 'unknown-id' }); continue; }
+    const kept: SemanticSurfaceName[] = [];
+    for (const surface of list) {
+      if (typeof surface !== 'string' || !(SEMANTIC_SURFACE_NAMES as readonly string[]).includes(surface)) { out.push({ field: `${field}.${zone}`, reason: 'unknown-id' }); continue; }
+      if (claimed.has(surface)) { out.push({ field: `${field}.${zone}`, reason: 'cross-zone' }); continue; }
+      claimed.add(surface);
+      kept.push(surface as SemanticSurfaceName);
+    }
+    result[zone as WorkspaceZoneId] = kept;
+  }
+  return result;
+}
+
+function pickCommands(value: unknown, out: WorkspaceRejection[]): readonly string[] {
+  if (value === undefined) return [];
+  if (!Array.isArray(value)) { out.push({ field: 'pinnedCommands', reason: 'malformed' }); return []; }
+  const kept: string[] = [];
+  for (const name of value) {
+    if (typeof name !== 'string' || !PINNED_COMMAND_PATTERN.test(name)) { out.push({ field: 'pinnedCommands', reason: 'malformed' }); continue; }
+    const forbidden = forbiddenClassOf(name);
+    if (forbidden) { out.push({ field: 'pinnedCommands', reason: forbidden }); continue; }
+    if (!kept.includes(name)) kept.push(name);
+  }
+  return kept;
+}
+
+/**
+ * `repaired` = read, with per-field fallbacks applied. `forward-read` = a newer object
+ * inside the N=2 window. `version-discarded` / `reset` are the two signals a future store
+ * surfaces to the operator — the stored object was NOT recovered. Never throws, never
+ * blocks boot (the `normalizeLayoutMode` doctrine).
+ */
+export type WorkspaceOutcome = 'ok' | 'repaired' | 'forward-read' | 'version-discarded' | 'reset';
+interface WorkspaceResultBase {
+  readonly workspace: WorkspaceV1;
+  /** Unknown top-level fields, kept verbatim so a round trip cannot strip them. */
+  readonly preserved: Readonly<Record<string, unknown>>;
+  readonly rejections: readonly WorkspaceRejection[];
+}
+export type WorkspaceReadResult =
+  | (WorkspaceResultBase & { readonly outcome: 'ok' | 'repaired' | 'forward-read' })
+  | (WorkspaceResultBase & { readonly outcome: 'version-discarded'; readonly discardedVersion: unknown })
+  | (WorkspaceResultBase & { readonly outcome: 'reset' });
+
+const KNOWN_FIELDS: readonly string[] = ['version', 'layout', 'designLanguage', 'theme', 'density', 'visibleSurfaces', 'zoneOrder', 'pinnedCommands'];
+
+function reset(field: string): WorkspaceReadResult {
+  return { outcome: 'reset', workspace: DEFAULT_WORKSPACE, preserved: {}, rejections: [{ field, reason: 'malformed' }] };
+}
+
+/** Validates arbitrary input into a usable workspace. Total — every input returns a result. */
+export function readWorkspace(input: unknown): WorkspaceReadResult {
+  if (typeof input !== 'object' || input === null || Array.isArray(input)) return reset('');
+  const raw = input as Record<string, unknown>;
+  const version = raw.version;
+  const readable = typeof version === 'number' && Number.isInteger(version)
+    && version >= WORKSPACE_SCHEMA_VERSION && version <= WORKSPACE_SCHEMA_VERSION + WORKSPACE_FORWARD_READ_WINDOW;
+  if (!readable) {
+    return { outcome: 'version-discarded', discardedVersion: version, workspace: DEFAULT_WORKSPACE, preserved: {}, rejections: [{ field: 'version', reason: 'malformed' }] };
+  }
+
+  const rejections: WorkspaceRejection[] = [];
+  const layout = normalizeWorkspaceLayoutId(raw.layout);
+  if (raw.layout !== undefined && raw.layout !== 'auto' && layout === 'auto') rejections.push({ field: 'layout', reason: 'unknown-id' });
+  const designLanguage = pickId(raw.designLanguage, WORKSPACE_DESIGN_LANGUAGE_IDS, 'studioline', 'designLanguage', rejections);
+
+  const preserved: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(raw)) {
+    if (KNOWN_FIELDS.includes(key)) continue;
+    const forbidden = scanForbidden(value, key);
+    if (forbidden) rejections.push({ field: key, reason: forbidden });
+    else preserved[key] = value;
+  }
+
+  const workspace: WorkspaceV1 = {
+    version, layout, designLanguage,
+    theme: pickId(raw.theme, WORKSPACE_THEME_IDS, 'default', 'theme', rejections),
+    density: pickDensity(raw.density, designLanguage, rejections),
+    visibleSurfaces: pickZoneMap(raw.visibleSurfaces, 'visibleSurfaces', rejections),
+    zoneOrder: pickZoneMap(raw.zoneOrder, 'zoneOrder', rejections),
+    pinnedCommands: pickCommands(raw.pinnedCommands, rejections),
+  };
+  const outcome = version > WORKSPACE_SCHEMA_VERSION ? 'forward-read' : rejections.length > 0 ? 'repaired' : 'ok';
+  return { outcome, workspace, preserved, rejections };
+}
+
+/** Whole-object JSON import (decision 9). Malformed text resets, never throws. */
+export function readWorkspaceJson(text: string): WorkspaceReadResult {
+  try { return readWorkspace(JSON.parse(text) as unknown); } catch { return reset(''); }
+}
+
+/** Whole-object export: the validated fields plus every preserved unknown field. */
+export function serializeWorkspace(result: Pick<WorkspaceResultBase, 'workspace' | 'preserved'>): Record<string, unknown> {
+  return { ...result.preserved, ...result.workspace };
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -96,6 +96,11 @@ export default defineConfig({
             // both shared-state shapes that are order-dependent under
             // ``isolate: false``. See MOR-1272.
             'src/lib/runtime/adapters/__tests__/rx-audio-purity.test.ts',
+            // MOR-1077, same class: ``vi.stubGlobal`` on localStorage/fetch/
+            // WebSocket plus ``vi.resetModules()`` around a fresh dynamic
+            // import of the workspace contract — both mutate state the fast
+            // pool shares across files. See MOR-1272.
+            'src/presentation/workspace/__tests__/purity.test.ts',
             'src/components-v2/wiring/__tests__/keyboard-wiring.test.ts',
             'src/components-v2/wiring/__tests__/vfo-wiring.test.ts',
             'src/components-v2/wiring/__tests__/dsp-nr-level.test.ts',
@@ -199,6 +204,7 @@ export default defineConfig({
             'src/components-v2/panels/lcd/__tests__/audio-fft-demand.test.ts',
             'src/lib/utils/__tests__/smoothing.svelte.test.ts',
             'src/lib/runtime/adapters/__tests__/rx-audio-purity.test.ts',
+            'src/presentation/workspace/__tests__/purity.test.ts',
             'src/components-v2/wiring/__tests__/keyboard-wiring.test.ts',
             'src/components-v2/wiring/__tests__/vfo-wiring.test.ts',
             'src/components-v2/wiring/__tests__/dsp-nr-level.test.ts',


### PR DESCRIPTION
## Summary
First implementation ticket of the workspace chain, encoding the owner's MOR-1076 freeze (decided 2026-08-04, full record on the ticket): one new pure module `presentation/workspace/contract.ts` — schema, validator, defaults, fallback. All six owner decisions + the codifiable policies map 1:1 to code (the in-file comments ARE the freeze-to-code map — verifier counselled keeping them). Net production LOC **166** by the frozen formula (243 raw = 166 + 49 comment + 28 blank); effectively 1 production file + 2 test files (+6-line MOR-1272 pool registration in vite.config).

Key behaviors: `'auto'` layout is first-class with deferred resolution; density = DL default + workspace override clamped by the ACTIVE language's DensityClamp; unknown fields ignored-and-preserved (round-trip never strips); version mismatch discards WITH a typed signal for the future store to surface; N=2 minor forward-read never downgrades on writeback; invalid state resets to defaults, never throws, never blocks boot; all six forbidden classes rejected fail-closed with typed reasons — including keys nested in unknown objects, module-path-shaped strings, and `__proto__`.

## Review provenance
Opus builder → independent opus contracts-domain verifier (6th ticket in domain): **PASS, 24/24 mutations killed, zero survivors** (freeze-fidelity per decision: eager-auto, any-string theme, wrong-language clamp + requested-vs-accepted variant, cross-zone move, strip-on-serialize, dropped discard signal, downgrade-on-writeback, throw-on-invalid — all red; 7 forbidden-class smuggling probes all fail-closed; scan weakenings die; purity closure re-derived independently, load-time spy catches what the text scan cannot — the 3A complementarity applied unprompted; all 5 registry pins fail on drift in both directions incl. order). Rulings: registry pins over live imports SOUND (owners dirty at load or lint-banned; the one clean import was used live); density-default-as-index-0 accepted for v1 with a follow-up filed; file count effectively within guardrail. Fail-set identical to baseline; lint/boundaries/check clean. Carry-forward recorded for MOR-1079: legacy `icom*` keys must be translated by migration BEFORE `readWorkspace`, or the manufacturer-policy marker refuses them.

Linear: MOR-1077

🤖 Generated with [Claude Code](https://claude.com/claude-code)