### PR TITLE
feat(MOR-1078): deterministic legacy workspace readers and migration fixtures

### DIFF
--- a/.github/scripts/check-rebrand-allowlist.sh
+++ b/.github/scripts/check-rebrand-allowlist.sh
@@ -86,6 +86,11 @@ ALLOWLIST=(
     # Release skill documents src/icom_lan/__init__.py shim as DO-NOT-TOUCH
     # (deprecation shim — must not be modified during version bumps).
     '.claude/skills/release/SKILL.md'
+    # MOR-1078: legacy workspace migration layer must name historical
+    # localStorage keys verbatim (e.g. `rigplane:storage-migrated-from-icom-lan`)
+    # to classify and read them correctly. Read-only — the module never writes
+    # or renames these keys, it only routes them.
+    'frontend/src/presentation/workspace/legacy-readers.ts'
 )
 
 # Collect all files matching brand pattern.

--- a/frontend/src/presentation/workspace/__tests__/legacy-readers-purity.test.ts
+++ b/frontend/src/presentation/workspace/__tests__/legacy-readers-purity.test.ts
@@ -1,0 +1,121 @@
+/**
+ * MOR-1078 read-only purity, mirroring the MOR-1077 idiom in
+ * `contract-purity.test.ts` (formerly `purity.test.ts`): a module-LOAD spy
+ * pin (covers the whole transitive closure, catches an import-time side
+ * effect no call-time assertion would see) plus a CALL-time spy pin scoped
+ * to the one storage-touching function, `snapshotLegacyStorage`. Actual
+ * persistence is MOR-1079's boundary — this module must never write or
+ * delete a key, only read the enumerated migrate-key closure.
+ *
+ * Pool: `isolated` (MOR-1272) — `vi.stubGlobal` + `vi.resetModules()` are the
+ * shared-state shapes that are order-dependent under the fast pool's
+ * `isolate: false`; registered in `vite.config.ts` alongside the sibling
+ * `contract-purity.test.ts` entry.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, join, normalize } from 'node:path';
+
+const ENTRY = 'src/presentation/workspace/legacy-readers.ts';
+
+function code(path: string): string {
+  return readFileSync(path, 'utf8').replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
+function relativeImports(path: string): string[] {
+  const source = code(path);
+  return [...source.matchAll(/(?:from|import)\s*['"](\.[^'"]+)['"]/g)]
+    .map((m) => normalize(join(dirname(path), m[1].endsWith('.ts') ? m[1] : `${m[1]}.ts`)));
+}
+
+function closure(entry: string): string[] {
+  const seen = new Set<string>();
+  const queue = [entry];
+  while (queue.length > 0) {
+    const path = queue.shift()!;
+    if (seen.has(path)) continue;
+    seen.add(path);
+    queue.push(...relativeImports(path));
+  }
+  return [...seen];
+}
+
+const storage = { getItem: vi.fn(() => null), setItem: vi.fn(), removeItem: vi.fn(), clear: vi.fn(), key: vi.fn(() => null), length: 0 };
+const fetchSpy = vi.fn();
+const wsCtor = vi.fn();
+class SpyWebSocket { constructor(...args: unknown[]) { wsCtor(...args); } }
+
+describe('legacy workspace readers are read-only (MOR-1078)', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  // ── Pin 1: load-time, closure-wide ─────────────────────────────────────
+  it('importing the module touches no storage, network or socket', async () => {
+    vi.stubGlobal('localStorage', storage);
+    vi.stubGlobal('sessionStorage', storage);
+    vi.stubGlobal('fetch', fetchSpy);
+    vi.stubGlobal('WebSocket', SpyWebSocket);
+    for (const spy of [storage.getItem, storage.setItem, storage.removeItem, fetchSpy, wsCtor]) spy.mockClear();
+
+    vi.resetModules();
+    const module = await import('../legacy-readers');
+
+    expect(module.LEGACY_MIGRATE_KEYS.length).toBeGreaterThan(0);
+    expect(storage.getItem).not.toHaveBeenCalled();
+    expect(storage.setItem).not.toHaveBeenCalled();
+    expect(storage.removeItem).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(wsCtor).not.toHaveBeenCalled();
+  });
+
+  // ── Pin 2: call-time, scoped to the one storage-touching function ──────
+  it('snapshotLegacyStorage / readLegacyWorkspaceFromStorage never write or delete', async () => {
+    const { snapshotLegacyStorage, readLegacyWorkspaceFromStorage, LEGACY_MIGRATE_KEYS } = await import('../legacy-readers');
+    const spySetItem = vi.fn();
+    const spyRemoveItem = vi.fn();
+    const spyClear = vi.fn();
+    const spyStorage = {
+      getItem: vi.fn((key: string) => (key === 'rigplane:theme' ? 'nord' : null)),
+      setItem: spySetItem,
+      removeItem: spyRemoveItem,
+      clear: spyClear,
+    };
+
+    snapshotLegacyStorage(spyStorage);
+    readLegacyWorkspaceFromStorage(spyStorage);
+
+    expect(spySetItem).not.toHaveBeenCalled();
+    expect(spyRemoveItem).not.toHaveBeenCalled();
+    expect(spyClear).not.toHaveBeenCalled();
+    // Enumerated-closure pin: getItem is called for exactly the migrate-key
+    // set, twice each (once per call above) — never a key outside the set.
+    const readKeys = new Set(spyStorage.getItem.mock.calls.map((c) => c[0] as string));
+    expect([...readKeys].sort()).toEqual([...LEGACY_MIGRATE_KEYS].sort());
+  });
+
+  // ── Pin 3: structural, transitive over the enumerated closure ───────────
+  it('the closure is exactly the reader plus the two pure presentation contracts', () => {
+    expect(closure(ENTRY).sort()).toEqual([
+      'src/presentation/languages/contract.ts',
+      'src/presentation/layouts/contract.ts',
+      'src/presentation/workspace/contract.ts',
+      ENTRY,
+    ].sort());
+  });
+
+  it.each(closure(ENTRY))('%s imports no store, transport, audio, skin or component module', (path) => {
+    const source = code(path);
+    expect(source).not.toMatch(/from\s+['"]\$lib\//);
+    expect(source).not.toMatch(/from\s+['"][^'"]*(stores|transport|audio|skins|components-v2|semantic)\//);
+    expect(source).not.toMatch(/\bdeclarations['"]/);
+  });
+
+  it('the reader itself references no browser or runtime global at module scope', () => {
+    const source = code(ENTRY);
+    for (const banned of [/\blocalStorage\b/, /\bsessionStorage\b/, /\bdocument\b/, /\bwindow\b/, /\bfetch\(/, /\bWebSocket\b/, /\bAudioContext\b/]) {
+      expect(source).not.toMatch(banned);
+    }
+  });
+});

--- a/frontend/src/presentation/workspace/__tests__/legacy-readers.test.ts
+++ b/frontend/src/presentation/workspace/__tests__/legacy-readers.test.ts
@@ -1,0 +1,173 @@
+/**
+ * MOR-1078 — legacy workspace reader behaviour: routing-table completeness,
+ * the fixture matrix (full/legacy-alias/partial/corrupt/empty/mixed-
+ * manufacturer snapshots), determinism, and idempotence. Fast pool: no
+ * globals stubbed, no modules mocked (MOR-1272) — the read-only/purity pins
+ * live in `legacy-readers-purity.test.ts` instead.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  LEGACY_KEY_ROUTING, LEGACY_MIGRATE_KEYS, buildWorkspaceInput, classifyLegacyKey,
+  readLegacyWorkspace, readLegacyWorkspaceFromStorage, snapshotLegacyStorage,
+  type LegacyStorageSnapshot,
+} from '../legacy-readers';
+import { DEFAULT_WORKSPACE } from '../contract';
+
+const MANUFACTURER_PREFIXED = /^(icom|yaesu|kenwood|elecraft|xiegu|alinco)[.:-]/i;
+
+function snap(overrides: Record<string, string | null>): LegacyStorageSnapshot {
+  const base: Record<string, string | null> = Object.fromEntries(LEGACY_MIGRATE_KEYS.map((k) => [k, null]));
+  return { ...base, ...overrides };
+}
+
+describe('routing table — all 29 MOR-1076 evidence keys accounted for', () => {
+  it('has no duplicate keys and a disposition for every row', () => {
+    const keys = LEGACY_KEY_ROUTING.map((r) => r.key);
+    expect(new Set(keys).size).toBe(keys.length);
+    expect(keys.length).toBe(29);
+  });
+
+  it('classifies each routed key and returns undefined for an unknown one', () => {
+    for (const route of LEGACY_KEY_ROUTING) expect(classifyLegacyKey(route.key)).toBe(route.disposition);
+    expect(classifyLegacyKey('not-a-real-key')).toBeUndefined();
+  });
+
+  it('the migrate set is exactly the theme + layout sources, all classified migrate', () => {
+    expect([...LEGACY_MIGRATE_KEYS].sort()).toEqual(
+      ['rigplane-layout', 'rigplane:theme', 'rigplane:theme-user-choice'].sort(),
+    );
+    for (const key of LEGACY_MIGRATE_KEYS) expect(classifyLegacyKey(key)).toBe('migrate');
+  });
+
+  it('no manufacturer-prefixed key is ever in the migrate set (carry-forward guarantee)', () => {
+    expect(LEGACY_MIGRATE_KEYS.some((k) => MANUFACTURER_PREFIXED.test(k))).toBe(false);
+    const manufacturerKeys = LEGACY_KEY_ROUTING.filter((r) => MANUFACTURER_PREFIXED.test(r.key));
+    expect(manufacturerKeys.length).toBeGreaterThan(0);
+    for (const route of manufacturerKeys) expect(route.disposition).toBe('retain-outside');
+  });
+
+  it('exactly one key is forbidden and it is the auth token', () => {
+    const forbidden = LEGACY_KEY_ROUTING.filter((r) => r.disposition === 'forbidden');
+    expect(forbidden.map((r) => r.key)).toEqual(['rigplane-auth-token']);
+  });
+});
+
+describe('fixture matrix — deterministic mapping to workspace v1', () => {
+  it('full modern set: explicit user theme choice wins over the applied-theme fallback', () => {
+    const result = readLegacyWorkspace(snap({
+      'rigplane:theme-user-choice': 'dracula', 'rigplane:theme': 'default', 'rigplane-layout': 'lcd-cockpit',
+    }));
+    expect(result.outcome).toBe('ok');
+    expect(result.workspace.theme).toBe('dracula');
+    expect(result.workspace.layout).toBe('lcd-cockpit');
+  });
+
+  it('legacy-alias set: MOR-1042 layout alias normalizes, theme falls back to the applied key', () => {
+    const result = readLegacyWorkspace(snap({ 'rigplane:theme': 'nord', 'rigplane-layout': 'amber-lcd' }));
+    expect(result.outcome).toBe('ok');
+    expect(result.workspace.theme).toBe('nord');
+    expect(result.workspace.layout).toBe('lcd-cockpit');
+  });
+
+  it('partial set: only layout present, theme defaults', () => {
+    const result = readLegacyWorkspace(snap({ 'rigplane-layout': 'sdr-test' }));
+    expect(result.outcome).toBe('ok');
+    expect(result.workspace.layout).toBe('sdr-test');
+    expect(result.workspace.theme).toBe(DEFAULT_WORKSPACE.theme);
+  });
+
+  it('corrupt values: an unrecognized theme/layout id falls back per-field, never throws', () => {
+    const result = readLegacyWorkspace(snap({ 'rigplane:theme': 'not-a-real-theme', 'rigplane-layout': 'not-a-real-layout' }));
+    expect(result.outcome).toBe('repaired');
+    expect(result.workspace).toEqual(DEFAULT_WORKSPACE);
+    expect(result.rejections).toContainEqual({ field: 'theme', reason: 'unknown-id' });
+    expect(result.rejections).toContainEqual({ field: 'layout', reason: 'unknown-id' });
+  });
+
+  it('empty snapshot: every migrate key absent yields the untouched default workspace', () => {
+    const result = readLegacyWorkspace(snap({}));
+    expect(result.outcome).toBe('ok');
+    expect(result.workspace).toEqual(DEFAULT_WORKSPACE);
+    expect(result.rejections).toEqual([]);
+  });
+
+  it('a corrupt/throwing storage degrades to "absent" instead of propagating', () => {
+    const throwing: Pick<Storage, 'getItem'> = {
+      getItem() { throw new Error('sandboxed storage'); },
+    };
+    expect(() => snapshotLegacyStorage(throwing)).not.toThrow();
+    const result = readLegacyWorkspaceFromStorage(throwing);
+    expect(result.outcome).toBe('ok');
+    expect(result.workspace).toEqual(DEFAULT_WORKSPACE);
+  });
+
+  it('mixed manufacturer keys in the snapshot never influence the result or reach the validator', () => {
+    const withExtras = {
+      ...snap({ 'rigplane:theme': 'nord', 'rigplane-layout': 'lcd-scope' }),
+      'icom.audio.focus': 'main',
+      'icom.audio.main_gain_db': '-6',
+    };
+    const result = readLegacyWorkspace(withExtras);
+    expect(result.workspace.theme).toBe('nord');
+    expect(result.workspace.layout).toBe('lcd-scope');
+    expect(result.preserved).toEqual({});
+    expect(result.rejections).toEqual([]);
+    expect(buildWorkspaceInput(withExtras)).not.toHaveProperty('icom.audio.focus');
+    expect(buildWorkspaceInput(withExtras)).not.toHaveProperty('icom.audio.main_gain_db');
+  });
+});
+
+describe('determinism and idempotence', () => {
+  const SNAPSHOT = snap({ 'rigplane:theme-user-choice': 'gruvbox-dark', 'rigplane-layout': 'lcd-scope' });
+
+  it('the same snapshot in yields a byte-stable workspace out, repeatedly', () => {
+    const results = Array.from({ length: 5 }, () => JSON.stringify(readLegacyWorkspace(SNAPSHOT)));
+    expect(new Set(results).size).toBe(1);
+  });
+
+  it('reading twice never mutates the input snapshot', () => {
+    const before = { ...SNAPSHOT };
+    readLegacyWorkspace(SNAPSHOT);
+    readLegacyWorkspace(SNAPSHOT);
+    expect(SNAPSHOT).toEqual(before);
+  });
+
+  it('re-reading an already-migrated state (legacy keys untouched — read-only) is a fixed point', () => {
+    const first = readLegacyWorkspace(SNAPSHOT);
+    // The reader never deletes/writes the legacy keys (MOR-1078 constraint), so a
+    // second boot sees the identical snapshot and must reproduce the identical result.
+    const second = readLegacyWorkspace(SNAPSHOT);
+    expect(second).toEqual(first);
+  });
+
+  it('storage is read through getItem only, exactly the enumerated migrate-key closure', () => {
+    const calls: string[] = [];
+    const storage: Pick<Storage, 'getItem'> = {
+      getItem(key: string) { calls.push(key); return null; },
+    };
+    snapshotLegacyStorage(storage);
+    expect([...calls].sort()).toEqual([...LEGACY_MIGRATE_KEYS].sort());
+  });
+
+  // F1 (MOR-1078 verify report, mutant D1): theme precedence must be fixed by
+  // THEME_SOURCE_KEYS, never by the snapshot object's own key insertion order.
+  // readLegacyWorkspace is a public export MOR-1079 will call with a snapshot
+  // it constructs itself, so this cannot be left to accident.
+  it('resolves the same theme regardless of the snapshot object\'s own key order', () => {
+    const userChoiceFirst = { 'rigplane:theme-user-choice': 'nord', 'rigplane:theme': 'dracula', 'rigplane-layout': null };
+    const appliedThemeFirst = { 'rigplane-layout': null, 'rigplane:theme': 'dracula', 'rigplane:theme-user-choice': 'nord' };
+    // Sanity: the two literals really do have different key insertion order —
+    // otherwise this test would pass for the wrong reason.
+    expect(Object.keys(userChoiceFirst)).not.toEqual(Object.keys(appliedThemeFirst));
+
+    expect(readLegacyWorkspace(userChoiceFirst).workspace.theme).toBe('nord');
+    expect(readLegacyWorkspace(appliedThemeFirst).workspace.theme).toBe('nord');
+  });
+
+  it('two key orders of the same content produce an identical workspace, including under theme conflict', () => {
+    const orderA = { 'rigplane:theme-user-choice': 'nord', 'rigplane:theme': 'dracula', 'rigplane-layout': 'lcd-scope' };
+    const orderB = { 'rigplane-layout': 'lcd-scope', 'rigplane:theme': 'dracula', 'rigplane:theme-user-choice': 'nord' };
+    expect(Object.keys(orderA)).not.toEqual(Object.keys(orderB));
+    expect(readLegacyWorkspace(orderA)).toEqual(readLegacyWorkspace(orderB));
+  });
+});

--- a/frontend/src/presentation/workspace/legacy-readers.ts
+++ b/frontend/src/presentation/workspace/legacy-readers.ts
@@ -1,0 +1,138 @@
+/**
+ * MOR-1078 — deterministic legacy workspace readers. Turns the MOR-1076
+ * evidence inventory (27 keys audited, resolved below to 29 distinct storage
+ * keys once every row is counted) into code: a full key routing table, plus
+ * a pure reader that folds the keys with a genuine home in `WorkspaceV1`
+ * (MOR-1077's `contract.ts`) into that schema's input shape. `readWorkspace`
+ * is the ONLY construction path — this module never bypasses it.
+ *
+ * Read-only by construction, not just by convention: `snapshotLegacyStorage`
+ * is the sole point of storage contact and its parameter type is
+ * `Pick<Storage, 'getItem'>` — a `setItem`/`removeItem`/`clear` call would
+ * not type-check. Actual persistence (writing the migrated object back) is
+ * MOR-1079's boundary.
+ *
+ * Scope note — several evidence-file keys were tentatively marked MIGRATE
+ * before the v1 schema was frozen (`panel-collapsed`, `panel-order`,
+ * `right-panel-order`, `lcd-display-mode`, `lcd-contrast`, `vfo-theme`).
+ * None has a matching field in the frozen schema: `zoneOrder`/
+ * `visibleSurfaces` are keyed by the 4-id `SemanticSurfaceName` enum
+ * (`vfo`/`rxTx`/`txAux`/`meters`), not the ~15-20 fine-grained sidebar panel
+ * ids those keys actually store, and there is no `contrast`/`lcdMode`/
+ * `vfoTheme` field at all. Routing them through the validator would either
+ * invent zone assignments no legacy data provides, or produce 100%
+ * `unknown-id` rejections on every real value — never an actual migration.
+ * Per this ticket's own acceptance language ("maps ... to workspace v1 OR
+ * ITS CORRECT NON-WORKSPACE OWNER"), they route to `retain-outside`: their
+ * current store stays the owner. See the MOR-1078 build report for the full
+ * per-key reasoning and the resulting MIGRATE-set size mismatch.
+ */
+import { readWorkspace, type WorkspaceReadResult } from './contract';
+
+/** Terminal routing outcome for one legacy key, per the MOR-1076 evidence table. */
+export type LegacyKeyDisposition = 'migrate' | 'retain-outside' | 'retire' | 'forbidden';
+
+export interface LegacyKeyRoute {
+  readonly key: string;
+  readonly disposition: LegacyKeyDisposition;
+  readonly note: string;
+}
+
+/** Mirrors `contract.ts`'s own `manufacturer-policy` marker class — used only to
+ *  prove, structurally, that the migrate set below carries no such key. */
+const MANUFACTURER_KEY_PATTERN = /^(icom|yaesu|kenwood|elecraft|xiegu|alinco)[.:-]/i;
+
+/** The full MOR-1076 evidence inventory, one disposition per key. */
+export const LEGACY_KEY_ROUTING: readonly LegacyKeyRoute[] = [
+  { key: 'rigplane:theme', disposition: 'migrate', note: 'canonical theme field (fallback source)' },
+  { key: 'rigplane:theme-user-choice', disposition: 'migrate', note: 'canonical theme field (priority source: explicit user choice)' },
+  { key: 'rigplane:vfo-theme', disposition: 'retain-outside', note: 'per-VFO theme override; no v1 field, owner-gate unresolved' },
+  { key: 'rigplane-layout', disposition: 'migrate', note: 'canonical layout field; MOR-1042 aliases resolved by the validator' },
+  { key: 'rigplane-skin', disposition: 'retire', note: 'dead write path, legacy read-only fallback' },
+  { key: 'rigplane-lcd-display-mode', disposition: 'retain-outside', note: 'clean/vintage/crt/flicker is a distinct axis, no v1 field' },
+  { key: 'rigplane:lcd-contrast', disposition: 'retain-outside', note: 'ambient-light setting, no v1 field' },
+  { key: 'rigplane:panel-collapsed', disposition: 'retain-outside', note: 'panel-id vocabulary, not the 4-id SemanticSurfaceName enum' },
+  { key: 'rigplane:panel-order', disposition: 'retain-outside', note: 'same vocabulary mismatch as panel-collapsed' },
+  { key: 'rigplane:panel-order:known-defaults', disposition: 'retain-outside', note: 'internal bookkeeping, not a user preference' },
+  { key: 'rigplane:right-panel-order', disposition: 'retain-outside', note: 'same vocabulary mismatch as panel-collapsed' },
+  { key: 'rigplane:right-panel-order:known-defaults', disposition: 'retain-outside', note: 'internal bookkeeping, not a user preference' },
+  { key: 'rigplane:memory-channels', disposition: 'retain-outside', note: 'radio data, not a UI/presentation preference' },
+  { key: 'rigplane:install-dismissed', disposition: 'retire', note: 'PWA install nag, unrelated to workspace' },
+  { key: 'rigplane.tuning-step-hz', disposition: 'retain-outside', note: 'operating preference, mirrors to a companion device' },
+  { key: 'rigplane.tuning-step-auto', disposition: 'retain-outside', note: 'same reasoning as tuning-step-hz' },
+  { key: 'rigplane.i18n.locale', disposition: 'retain-outside', note: 'stable cross-app locale contract' },
+  { key: 'rigplane.i18n.proLocale.v1', disposition: 'retain-outside', note: 'cross-app contract jointly owned with Pro' },
+  { key: 'rigplane:local-extension-dock-layout:v1', disposition: 'retain-outside', note: 'local-extension dock surface, not workspace' },
+  { key: 'rigplane:auto-lan-mod-input', disposition: 'retain-outside', note: 'TX-safety-adjacent opt-in, must not enter workspace' },
+  { key: 'rigplane:mod-input-tx-restore:v1', disposition: 'retire', note: 'dead key retained only for migration cleanup' },
+  { key: 'rigplane-auth-token', disposition: 'forbidden', note: 'transport/session ownership' },
+  { key: 'icom.audio.focus', disposition: 'retain-outside', note: 'manufacturer-prefixed but live; global flat key stays with the audio layer' },
+  { key: 'icom.audio.split_stereo', disposition: 'retain-outside', note: 'same as icom.audio.focus' },
+  { key: 'icom.audio.main_gain_db', disposition: 'retain-outside', note: 'same as icom.audio.focus' },
+  { key: 'icom.audio.sub_gain_db', disposition: 'retain-outside', note: 'same as icom.audio.focus' },
+  { key: 'eibi-favourites', disposition: 'retain-outside', note: 'station-data favourite, legacy component tree' },
+  { key: 'rigplane-hidden-layers', disposition: 'retain-outside', note: 'legacy component tree, retire candidate' },
+  { key: 'rigplane:storage-migrated-from-icom-lan', disposition: 'retire', note: 'internal migration sentinel, never workspace-visible' },
+];
+
+const ROUTING_BY_KEY: ReadonlyMap<string, LegacyKeyRoute> = new Map(LEGACY_KEY_ROUTING.map((r) => [r.key, r]));
+
+/** `undefined` = not in the MOR-1076 inventory at all (out of MOR-1078's scope). */
+export function classifyLegacyKey(key: string): LegacyKeyDisposition | undefined {
+  return ROUTING_BY_KEY.get(key)?.disposition;
+}
+
+/** Legacy keys that fold into `WorkspaceV1.theme`, in priority order (index 0 wins). */
+const THEME_SOURCE_KEYS = ['rigplane:theme-user-choice', 'rigplane:theme'] as const;
+const LAYOUT_SOURCE_KEY = 'rigplane-layout';
+
+/** Every key `snapshotLegacyStorage` will ever call `getItem` for — the read-only
+ *  pin's enumerated closure (MOR-1078 constraint: "enumerated-closure pin if feasible"). */
+export const LEGACY_MIGRATE_KEYS: readonly string[] = [...THEME_SOURCE_KEYS, LAYOUT_SOURCE_KEY];
+
+// Structural guarantee, also asserted by a test: the migrate set carries no
+// manufacturer-prefixed key today, so there is nothing to translate at read
+// time — a future addition that violated this would fail loudly at import.
+if (LEGACY_MIGRATE_KEYS.some((k) => MANUFACTURER_KEY_PATTERN.test(k))) {
+  throw new Error('MOR-1078 invariant violated: a manufacturer-prefixed key entered the migrate set');
+}
+
+export type LegacyStorageSnapshot = Readonly<Record<string, string | null>>;
+
+/** The ONLY place this module touches storage. `getItem`-only by type — a write
+ *  call would not compile. Per-key try/catch: a throwing `getItem` (sandboxed
+ *  contexts) degrades to "absent," matching the codebase's `migrate-legacy-
+ *  storage.ts` resilience doctrine rather than blocking boot. */
+export function snapshotLegacyStorage(storage: Pick<Storage, 'getItem'>): LegacyStorageSnapshot {
+  const snapshot: Record<string, string | null> = {};
+  for (const key of LEGACY_MIGRATE_KEYS) {
+    try {
+      snapshot[key] = storage.getItem(key);
+    } catch {
+      snapshot[key] = null;
+    }
+  }
+  return snapshot;
+}
+
+/** Pure: snapshot in, a `WorkspaceV1`-shaped candidate input out. Never touches storage. */
+export function buildWorkspaceInput(snapshot: LegacyStorageSnapshot): Record<string, unknown> {
+  const input: Record<string, unknown> = { version: 1 };
+  const theme = THEME_SOURCE_KEYS.map((k) => snapshot[k]).find((v) => v !== null && v !== undefined);
+  if (theme !== undefined) input.theme = theme;
+  const layout = snapshot[LAYOUT_SOURCE_KEY];
+  if (layout !== null && layout !== undefined) input.layout = layout;
+  return input;
+}
+
+/** Pure: snapshot in, a fully validated `WorkspaceReadResult` out. `readWorkspace`
+ *  (MOR-1077) is the only construction path — never bypassed. */
+export function readLegacyWorkspace(snapshot: LegacyStorageSnapshot): WorkspaceReadResult {
+  return readWorkspace(buildWorkspaceInput(snapshot));
+}
+
+/** Convenience for real callers (MOR-1079): read + validate in one pass, read-only
+ *  by construction (see `snapshotLegacyStorage`). */
+export function readLegacyWorkspaceFromStorage(storage: Pick<Storage, 'getItem'>): WorkspaceReadResult {
+  return readLegacyWorkspace(snapshotLegacyStorage(storage));
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -101,6 +101,10 @@ export default defineConfig({
             // import of the workspace contract — both mutate state the fast
             // pool shares across files. See MOR-1272.
             'src/presentation/workspace/__tests__/purity.test.ts',
+            // MOR-1078, same class again: ``vi.stubGlobal`` on localStorage/
+            // fetch/WebSocket plus ``vi.resetModules()`` around a fresh
+            // dynamic import of the legacy workspace readers. See MOR-1272.
+            'src/presentation/workspace/__tests__/legacy-readers-purity.test.ts',
             'src/components-v2/wiring/__tests__/keyboard-wiring.test.ts',
             'src/components-v2/wiring/__tests__/vfo-wiring.test.ts',
             'src/components-v2/wiring/__tests__/dsp-nr-level.test.ts',
@@ -205,6 +209,7 @@ export default defineConfig({
             'src/lib/utils/__tests__/smoothing.svelte.test.ts',
             'src/lib/runtime/adapters/__tests__/rx-audio-purity.test.ts',
             'src/presentation/workspace/__tests__/purity.test.ts',
+            'src/presentation/workspace/__tests__/legacy-readers-purity.test.ts',
             'src/components-v2/wiring/__tests__/keyboard-wiring.test.ts',
             'src/components-v2/wiring/__tests__/vfo-wiring.test.ts',
             'src/components-v2/wiring/__tests__/dsp-nr-level.test.ts',


### PR DESCRIPTION
## Summary
Read-only migration layer for the workspace chain: `presentation/workspace/legacy-readers.ts` — a 29-key routing table (the full MOR-1076 evidence inventory; verifier recounted key-by-key: no gaps, no extras), `snapshotLegacyStorage` (`getItem`-only by TYPE — a write doesn't compile), and readers funneling exclusively through the MOR-1077 `readWorkspace` (bypass pinned red). Deterministic (key-order independent — pinned incl. the theme-precedence case), idempotent (pinned), never deletes old keys. Net production LOC **77** by the frozen formula (143 raw).

**Scope ruling (verifier-adjudicated):** only 3 keys genuinely migrate into v1 (theme ×2 with user-choice precedence, layout via MOR-1042 alias normalization). Six pre-freeze MIGRATE candidates (panel-collapsed/order ×3, lcd ×2, vfo-theme) have NO home in the frozen v1 vocabulary — real payloads fed through the real `readWorkspace` give **0 kept / 13 rejected / overlap 0 of 13** — and were routed retain-outside per the ticket's own "or its correct non-workspace owner". The reduction is caused by the freeze, not the reader; a coarse derivation was explicitly rejected as invented, lossy product semantics. Owner-decision record: MOR-1289. Manufacturer-prefixed `icom.*` keys never reach the validator raw (load-time guard + pins) — closing the 1077 carry-forward more strongly than a translate step.

## Review provenance
Sonnet builder → independent opus contracts-domain verifier (8th ticket in domain): **PASS**. Routing mutations killed (auth-token→migrate, manufacturer key in read set → load-time guard throws, icom row→migrate); read-only enforced by type + spy (injected setItem killed); bypass killed; non-idempotence killed; closure re-derived (4 modules, pure); contract.ts byte-unchanged (sha-confirmed three ways). Round-1 gap: key-order dependence survived — meaningful (reorder silently flips explicit theme choice) — closed by two prescribed assertions, D1 re-red with sha-verified restore (test-only round per the delta discipline). The 110-vs-108 fail-count discrepancy resolved to the standard 108/10-file env set. lint/boundaries/check clean; merge onto current main clean.

Linear: MOR-1078

🤖 Generated with [Claude Code](https://claude.com/claude-code)