### PR TITLE
feat(MOR-1290): dsp fact group — NR/NB/notch/AGC (vocabulary slice 5A)

### DIFF
--- a/frontend/src/lib/radio/filter-controls.ts
+++ b/frontend/src/lib/radio/filter-controls.ts
@@ -127,9 +127,75 @@ function controlRange(key: string, fallback: ControlRange): ControlRange {
   return fallback;
 }
 
-/** Convert a raw CI-V wire value to the slider display value for `key`. */
-export function controlRawToDisplay(key: string, raw: number, fallback: ControlRange): number {
-  const { rawMin, rawMax, displayMin, displayMax } = controlRange(key, fallback);
+/** Same shape as the internal (unexported) `ControlRange`, exported under its
+ *  own name (MOR-1290) so `controlRangeFromCaps`'s return type — and the
+ *  optional `range` parameter it feeds `controlRawToDisplay` — can be named
+ *  by callers outside this module, the same reason `PbtRange` (MOR-1284) is
+ *  exported rather than the conversion functions staying un-parameterisable. */
+export type ControlDisplayRange = ControlRange;
+
+/**
+ * Derives a `ControlDisplayRange` explicitly from a `Capabilities` object's
+ * own `controls[key]` entry (MOR-1290, following the `pbtRangeFromCaps`
+ * precedent, MOR-1284 F1) — the same shape `controlRange()` reads from the
+ * capabilities STORE singleton, but sourced from an argument a caller
+ * already has in hand rather than a module-global. Returns `undefined` when
+ * the caps object carries no usable range for `key`, so `controlRawToDisplay`
+ * falls through to its own store-lookup default.
+ */
+export function controlRangeFromCaps(
+  key: string, caps: Capabilities | null | undefined,
+): ControlDisplayRange | undefined {
+  const ctrl = caps?.controls?.[key];
+  if (
+    ctrl &&
+    ctrl.display_min !== undefined &&
+    ctrl.display_max !== undefined &&
+    ctrl.display_max > ctrl.display_min
+  ) {
+    return {
+      rawMin: ctrl.raw_min, rawMax: ctrl.raw_max,
+      displayMin: ctrl.display_min, displayMax: ctrl.display_max,
+    };
+  }
+  return undefined;
+}
+
+/**
+ * `controlRangeFromCaps(key, caps)`, falling back to this module's own
+ * `CONTROL_DEFAULTS[key]` when caps carries no range for `key` at all
+ * (MOR-1290 F1, verify round 1). `controlRangeFromCaps` alone still has one
+ * honest "I don't know" outcome — `undefined` — and a caller that passes
+ * that straight into `controlRawToDisplay`'s optional `range` falls through
+ * to that function's OWN store lookup, making the result a function of
+ * module-global state again for exactly the caps-omits-the-key case. This
+ * wrapper closes that residual: every caller gets a CONCRETE range either
+ * way, so passing its result as `range` never reaches the store — the
+ * conversion becomes a pure function of `(raw, caps)` with no residual
+ * dependency. Only defined for keys with a `CONTROL_DEFAULTS` entry
+ * (`nr_level`, `nb_depth` today); throws for any other key so a typo fails
+ * loudly rather than silently degrading to `undefined` mid-computation.
+ */
+export function controlRangeFromCapsOrDefault(
+  key: string, caps: Capabilities | null | undefined,
+): ControlDisplayRange {
+  const fallback = CONTROL_DEFAULTS[key];
+  if (!fallback) throw new Error(`controlRangeFromCapsOrDefault: no CONTROL_DEFAULTS entry for '${key}'`);
+  return controlRangeFromCaps(key, caps) ?? fallback;
+}
+
+/**
+ * `range`, when supplied (MOR-1290, mirroring `pbtRawToHz`'s own `range`
+ * parameter), is used INSTEAD of the capabilities STORE lookup — pass
+ * `controlRangeFromCaps(key, caps)` from a caller that already holds a
+ * `caps` argument so the conversion is a pure function of that argument
+ * rather than a hidden dependency on module-global store state. Every
+ * EXISTING call site omits `range` and keeps today's store-lookup behavior
+ * unchanged — this parameter is strictly additive. */
+export function controlRawToDisplay(
+  key: string, raw: number, fallback: ControlRange, range?: ControlDisplayRange,
+): number {
+  const { rawMin, rawMax, displayMin, displayMax } = range ?? controlRange(key, fallback);
   const span = rawMax - rawMin;
   if (span <= 0) return displayMin;
   const display = Math.round(((raw - rawMin) / span) * (displayMax - displayMin) + displayMin);
@@ -145,9 +211,10 @@ export function controlDisplayToRaw(key: string, display: number, fallback: Cont
   return Math.max(rawMin, Math.min(rawMax, raw));
 }
 
-/** Convert a raw 0-255 NR wire value to the 0-15 display value. */
-export function nrRawToDisplay(raw: number): number {
-  return controlRawToDisplay('nr_level', raw, CONTROL_DEFAULTS.nr_level);
+/** Convert a raw 0-255 NR wire value to the 0-15 display value. `range`
+ *  (MOR-1290) is strictly additive — see `controlRawToDisplay`. */
+export function nrRawToDisplay(raw: number, range?: ControlDisplayRange): number {
+  return controlRawToDisplay('nr_level', raw, CONTROL_DEFAULTS.nr_level, range);
 }
 
 /** Convert a 0-15 display value to the raw 0-255 NR wire value. */
@@ -155,9 +222,10 @@ export function nrDisplayToRaw(display: number): number {
   return controlDisplayToRaw('nr_level', display, CONTROL_DEFAULTS.nr_level);
 }
 
-/** Convert a raw 0-9 NB-depth wire value to the 1-10 display value. */
-export function nbDepthRawToDisplay(raw: number): number {
-  return controlRawToDisplay('nb_depth', raw, CONTROL_DEFAULTS.nb_depth);
+/** Convert a raw 0-9 NB-depth wire value to the 1-10 display value. `range`
+ *  (MOR-1290) is strictly additive — see `controlRawToDisplay`. */
+export function nbDepthRawToDisplay(raw: number, range?: ControlDisplayRange): number {
+  return controlRawToDisplay('nb_depth', raw, CONTROL_DEFAULTS.nb_depth, range);
 }
 
 /** Convert a 1-10 display value to the raw 0-9 NB-depth wire value. */

--- a/frontend/src/lib/runtime/adapters/__tests__/dsp-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/dsp-adapter.test.ts
@@ -1,0 +1,499 @@
+/**
+ * MOR-1262 decomposition slice 5A (MOR-1290) — `dsp` fact-group adapter
+ * derivation.
+ *
+ * Companion to `filter-passband-adapter.test.ts` (MOR-1284), which this file
+ * does NOT modify. `dsp` is a SEPARATE optional group — see
+ * `radio-view-model.ts`'s `DspViewModel` doc comment.
+ *
+ * Pool: `isolated` (MOR-1272). The parity-pin block below calls the REAL
+ * `setCapabilities` (`$lib/stores/capabilities.svelte`, module-scope global
+ * state, no `vi.mock`) to install non-default NR/NB control ranges, because
+ * `deriveDsp`'s `nrLevel`/`nbDepth` facts consume `$lib/radio/filter-
+ * controls`'s `nrRawToDisplay`/`nbDepthRawToDisplay`, which read their scale
+ * from that STORE rather than from this file's own `caps` parameter. Under
+ * the fast pool's `isolate: false` this mutation would leak into whichever
+ * sibling file's tests share the worker afterward — the same shape
+ * `filter-passband-adapter.test.ts` is isolated for. See `vite.config.ts`.
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import type { Capabilities, ControlRange } from '$lib/types/capabilities';
+import type { FieldStatus, ServerState } from '$lib/types/state';
+import { validateRadioViewModel, type RadioViewModel } from '../../../../semantic/radio-view-model';
+import { toRadioViewModel } from '../radio-view-model-adapter';
+import { nrRawToDisplay, nbDepthRawToDisplay, controlRangeFromCapsOrDefault } from '$lib/radio/filter-controls';
+import { setCapabilities } from '$lib/stores/capabilities.svelte';
+
+function caps(overrides: Partial<Capabilities> = {}): Capabilities {
+  return {
+    model: 'fixture', scope: true, audio: true, tx: true, capabilities: ['scope', 'audio', 'tx'],
+    receivers: 1, vfoScheme: 'single', freqRanges: [], modes: [], filters: [],
+    audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
+    webrtc: { available: false, enabled: false },
+    txBands: [], scopeSource: 'hardware', audioFftAvailable: false, ...overrides,
+  } as Capabilities;
+}
+
+/** No `controls` entry ⇒ `nrRawToDisplay`/`nbDepthRawToDisplay`'s own store
+ *  lookup falls back to their built-in defaults — the neutral baseline every
+ *  test starts from, and what every test restores in `afterEach` so no
+ *  custom range leaks across this file's own tests (never mind siblings —
+ *  isolation handles that half; this handles order-within-file). */
+const NEUTRAL_STORE_CAPS = caps();
+afterEach(() => setCapabilities(NEUTRAL_STORE_CAPS));
+
+const fresh: FieldStatus = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' };
+const stale: FieldStatus = { storePath: 'x', observed: true, freshness: 'stale', availability: 'stale' };
+
+/** The exact shape `filter-passband-adapter.test.ts`'s own baseline uses. */
+function bareState(overrides: Partial<ServerState> = {}): ServerState {
+  return {
+    active: 'MAIN', split: false, dualWatch: false, ptt: false,
+    txTarget: { status: 'known', receiver: 'MAIN', slot: null, frequencyHz: 14195000 },
+    main: {
+      freqHz: 14195000, mode: 'USB', filter: 1, dataMode: 0, att: 0, preamp: 0,
+      nb: false, nr: false, afLevel: 1, rfGain: 1, squelch: 0, sMeter: 0,
+    },
+    sub: {
+      freqHz: 7100000, mode: 'LSB', filter: 2, dataMode: 0, att: 0, preamp: 0,
+      nb: false, nr: false, afLevel: 1, rfGain: 1, squelch: 0, sMeter: 0,
+    },
+    fieldStatus: {
+      active: fresh, split: fresh, dualWatch: fresh, txTarget: fresh,
+      'main.freqHz': fresh, 'main.mode': fresh, 'main.filter': fresh,
+    },
+    ...overrides,
+  } as ServerState;
+}
+
+function model(state: ServerState | null, capabilities: Capabilities | null): RadioViewModel {
+  const view = toRadioViewModel(state, capabilities);
+  expect(view).not.toBeNull();
+  return validateRadioViewModel(view);
+}
+
+describe('dsp evidence gate (MOR-1290, N3)', () => {
+  it('emits no dsp when capabilities are absent', () => {
+    expect(toRadioViewModel(bareState(), null)).toBeNull();
+  });
+
+  it('emits no dsp for a baseline radio with no nr/nb/notch/agc capability or nb_depth control (regression pin)', () => {
+    const view = model(bareState(), caps());
+    expect(view.dsp).toBeUndefined();
+    expect(Object.keys(view)).not.toContain('dsp');
+  });
+
+  it('emits dsp once the nr capability alone is declared', () => {
+    const view = model(bareState(), caps({ capabilities: ['nr'] }));
+    expect(view.dsp).toBeDefined();
+  });
+
+  it('emits dsp once the nb capability alone is declared', () => {
+    const view = model(bareState(), caps({ capabilities: ['nb'] }));
+    expect(view.dsp).toBeDefined();
+  });
+
+  it('emits dsp once the notch capability alone is declared', () => {
+    const view = model(bareState(), caps({ capabilities: ['notch'] }));
+    expect(view.dsp).toBeDefined();
+  });
+
+  it('emits dsp once the agc capability alone is declared', () => {
+    const view = model(bareState(), caps({ capabilities: ['agc'] }));
+    expect(view.dsp).toBeDefined();
+  });
+
+  it('emits dsp once an nb_depth control range alone is declared, with no other capability', () => {
+    const nbDepthRange: ControlRange = { raw_min: 0, raw_max: 9, raw_center: 0, display_min: 1, display_max: 10 };
+    const view = model(bareState(), caps({ controls: { nb_depth: nbDepthRange } }));
+    expect(view.dsp).toBeDefined();
+  });
+
+  it('never emits dsp with no capabilities object at all', () => {
+    expect(toRadioViewModel(bareState(), null)).toBeNull();
+  });
+});
+
+describe('dsp per-field structural gates (MOR-1290)', () => {
+  it('nrActive/nrLevel are structurally absent without the nr capability, even with agc present', () => {
+    const view = model(bareState(), caps({ capabilities: ['agc'] }));
+    expect(view.dsp!.nrActive.availability.structural).toBe(false);
+    expect(view.dsp!.nrLevel.availability.structural).toBe(false);
+    expect(view.dsp!.agcMode.availability.structural).toBe(true);
+  });
+
+  it('nbActive/nbLevel are structurally absent without the nb capability, even with nr present', () => {
+    const view = model(bareState(), caps({ capabilities: ['nr'] }));
+    expect(view.dsp!.nbActive.availability.structural).toBe(false);
+    expect(view.dsp!.nbLevel.availability.structural).toBe(false);
+  });
+
+  it('nbDepth/nbWidth are structurally absent without a declared nb_depth control range, even with nb present', () => {
+    const view = model(bareState(), caps({ capabilities: ['nb'] }));
+    expect(view.dsp!.nbDepth.availability.structural).toBe(false);
+    expect(view.dsp!.nbWidth.availability.structural).toBe(false);
+    expect(view.dsp!.nbActive.availability.structural).toBe(true);
+  });
+
+  it('nbDepth/nbWidth are structurally present once an nb_depth control range is declared, independent of the nb capability', () => {
+    const nbDepthRange: ControlRange = { raw_min: 0, raw_max: 9, raw_center: 0, display_min: 1, display_max: 10 };
+    const view = model(bareState(), caps({ controls: { nb_depth: nbDepthRange } }));
+    expect(view.dsp!.nbDepth.availability.structural).toBe(true);
+    expect(view.dsp!.nbWidth.availability.structural).toBe(true);
+    expect(view.dsp!.nbActive.availability.structural).toBe(false);
+  });
+
+  it('notchMode/notchFreq/manualNotchWidth are structurally absent without the notch capability', () => {
+    const view = model(bareState(), caps({ capabilities: ['agc'] }));
+    expect(view.dsp!.notchMode.availability.structural).toBe(false);
+    expect(view.dsp!.notchFreq.availability.structural).toBe(false);
+    expect(view.dsp!.manualNotchWidth.availability.structural).toBe(false);
+  });
+
+  it('agcMode/agcTimeConstant are structurally absent without the agc capability', () => {
+    const view = model(bareState(), caps({ capabilities: ['nr'] }));
+    expect(view.dsp!.agcMode.availability.structural).toBe(false);
+    expect(view.dsp!.agcTimeConstant.availability.structural).toBe(false);
+  });
+
+  it('follows the SUB receiver once it is the active one', () => {
+    const view = model(bareState({
+      active: 'SUB',
+      sub: { ...bareState().sub, nr: true },
+      fieldStatus: { ...bareState().fieldStatus, 'sub.nr': fresh },
+    }), caps({ capabilities: ['nr'] }));
+    expect(view.dsp!.nrActive.reading).toEqual({ status: 'known', value: true });
+  });
+});
+
+describe('agcModes choice set (MOR-1290)', () => {
+  it('reports the capability-declared choice set verbatim', () => {
+    const view = model(bareState(), caps({ capabilities: ['agc'], agcModes: [1, 2, 3] }));
+    expect(view.dsp!.agcModes).toEqual([1, 2, 3]);
+  });
+
+  it('defaults to an empty array — never a fabricated FAST/MID/SLOW default — when caps declares none', () => {
+    const view = model(bareState(), caps({ capabilities: ['agc'] }));
+    expect(view.dsp!.agcModes).toEqual([]);
+  });
+});
+
+/**
+ * PARITY PIN (MOR-1290, following the 4A′ F1 lesson). `nrLevel`/`nbDepth`
+ * must consume the REAL `$lib/radio/filter-controls` helpers, not a
+ * re-derived formula. The discriminating axis a naive re-implementation
+ * would miss is the SAME one the X6200 CAT audit flagged for filter-width
+ * tables and `filterPassband`'s PBT scale: `nrRawToDisplay`/
+ * `nbDepthRawToDisplay` read their raw<->display scale from the capabilities
+ * STORE's `controls.nr_level`/`controls.nb_depth` (rawMin/rawMax/displayMin/
+ * displayMax), not from a constant. A hand-rolled linear-interpolation
+ * inside the adapter would match every row that leaves the store at its
+ * built-in default and silently diverge the instant a radio profile
+ * declares a non-default control range.
+ *
+ * Each row's "expected" value is computed by calling the SAME shipped
+ * `nrRawToDisplay`/`nbDepthRawToDisplay` this test imports directly — this
+ * is a regression/mutation-kill pin on the ADAPTER's wiring to those
+ * functions, not a re-proof of their own arithmetic.
+ */
+describe('nrLevel/nbDepth parity with the real filter-controls helpers (MOR-1290)', () => {
+  const customNrRange: ControlRange = { raw_min: 0, raw_max: 200, raw_center: 0, display_min: 0, display_max: 20 };
+  const customNbDepthRange: ControlRange = {
+    raw_min: 0, raw_max: 20, raw_center: 0, display_min: 1, display_max: 20,
+  };
+
+  const NR_MATRIX: ReadonlyArray<{ name: string; controls?: Record<string, ControlRange>; raw: number }> = [
+    { name: 'default 0-255/0-15 range, mid value', raw: 128 },
+    { name: 'default range, odd raw value that forces rounding', raw: 191 },
+    {
+      name: 'custom capabilities-store nr_level range (0-200 -> 0-20)',
+      controls: { nr_level: customNrRange }, raw: 100,
+    },
+    {
+      name: 'custom range at its raw extreme (200) — the X6200-lesson discriminator',
+      controls: { nr_level: customNrRange }, raw: 200,
+    },
+  ];
+
+  it.each(NR_MATRIX)('nrLevel: $name', ({ controls, raw }) => {
+    const parityCaps = caps({ capabilities: ['nr'], ...(controls ? { controls } : {}) });
+    setCapabilities(parityCaps);
+    const expectedDisplay = nrRawToDisplay(raw);
+
+    const view = model(bareState({
+      main: { ...bareState().main, nrLevel: raw },
+      fieldStatus: { ...bareState().fieldStatus, 'main.nrLevel': fresh },
+    }), parityCaps);
+
+    expect(view.dsp!.nrLevel.reading).toEqual({ status: 'known', value: expectedDisplay });
+  });
+
+  // `nbDepth`'s STRUCTURAL gate itself requires a declared `nb_depth` control
+  // entry to exist (see `deriveDsp`'s `hasNbDepth`), so every row below
+  // declares one explicitly — including the "IC-7610-shaped" row, which
+  // declares the same bounds `CONTROL_DEFAULTS.nb_depth` uses rather than
+  // omitting `controls.nb_depth` (that would fail the structural gate, not
+  // exercise the store-lookup fallback branch).
+  const ic7610ShapedRange: ControlRange = { raw_min: 0, raw_max: 9, raw_center: 0, display_min: 1, display_max: 10 };
+
+  const NB_MATRIX: ReadonlyArray<{ name: string; range: ControlRange; raw: number }> = [
+    { name: 'declared IC-7610-shaped range (0-9 -> 1-10), mid value', range: ic7610ShapedRange, raw: 5 },
+    { name: 'custom capabilities-store nb_depth range (0-20 -> 1-20)', range: customNbDepthRange, raw: 10 },
+    {
+      name: 'custom range at its raw extreme (20) — the X6200-lesson discriminator',
+      range: customNbDepthRange, raw: 20,
+    },
+  ];
+
+  it.each(NB_MATRIX)('nbDepth: $name', ({ range, raw }) => {
+    const parityCaps = caps({ controls: { nb_depth: range } });
+    setCapabilities(parityCaps);
+    const expectedDisplay = nbDepthRawToDisplay(raw);
+
+    const view = model(bareState({
+      nbDepth: raw,
+      fieldStatus: { ...bareState().fieldStatus, nbDepth: fresh },
+    }), parityCaps);
+
+    expect(view.dsp!.nbDepth.reading).toEqual({ status: 'known', value: expectedDisplay });
+  });
+
+  it('the custom-range rows actually produce a different scale than the default (sanity on the discriminator itself)', () => {
+    setCapabilities(NEUTRAL_STORE_CAPS);
+    const defaultHz = nrRawToDisplay(100);
+    setCapabilities(caps({ controls: { nr_level: customNrRange } }));
+    const customHz = nrRawToDisplay(100);
+    expect(customHz).not.toBe(defaultHz);
+  });
+});
+
+/**
+ * F1 determinism pin (MOR-1290, following `filterPassband`'s MOR-1284 F1
+ * lesson — CLOSED at verify round 1). `nrLevel`/`nbDepth` must be a PURE
+ * function of `(state, caps)` in BOTH branches: when `caps` declares its own
+ * `controls.nr_level`/`nb_depth` range (CASE A) AND when it declares none at
+ * all (CASE B). CASE A was already deterministic pre-fix (an explicit range
+ * always won). CASE B was NOT: `controlRangeFromCaps` alone returns
+ * `undefined` when caps carries no range, and passing that straight through
+ * let `nrRawToDisplay` fall through to ITS OWN capabilities-STORE lookup —
+ * the round-1 verifier's live probe showed `nrLevel` moving 8 / 50 / 8 across
+ * three store states for the SAME `(state, caps)` pair. The fix routes
+ * `deriveDsp` through `controlRangeFromCapsOrDefault` (`$lib/radio/filter-
+ * controls`, MOR-1290 F1), which always returns a CONCRETE range — this
+ * module's own `CONTROL_DEFAULTS` when caps has none — so the store is never
+ * consulted in either branch.
+ *
+ * The round-1 verifier's OWN finding on the prior version of this block: its
+ * expectation was computed via the store-reading `nrRawToDisplay(100)`
+ * no-arg call, so it moved WITH whatever store the test happened to set and
+ * could only prove "the adapter agrees with the store fallback" — never "the
+ * fact is independent of the store". Every expectation below is computed via
+ * `controlRangeFromCapsOrDefault(key, caps)` — a pure function of `caps`
+ * ALONE, with zero store read — so it cannot silently track a store mutation
+ * the way the old computation did.
+ */
+describe('nrLevel/nbDepth are deterministic in (state, caps) — MOR-1290 (F1, verify round 1)', () => {
+  const rangeA: ControlRange = { raw_min: 0, raw_max: 255, raw_center: 0, display_min: 0, display_max: 15 };
+  const rangeB: ControlRange = { raw_min: 0, raw_max: 200, raw_center: 0, display_min: 0, display_max: 20 };
+  // The `caps` argument itself declares NO `controls.nr_level` — this is the
+  // property under test: the STORE varies (A / B / EMPTY) but the
+  // `(state, caps)` ARGUMENTS to `toRadioViewModel` never change.
+  const capsWithNoOwnRange = caps({ capabilities: ['nr'] });
+  const stateWithNr = bareState({
+    main: { ...bareState().main, nrLevel: 100 },
+    fieldStatus: { ...bareState().fieldStatus, 'main.nrLevel': fresh },
+  });
+  // Pure — no `setCapabilities` call anywhere in this expression. This is
+  // THE literal value `deriveDsp` must produce for `(stateWithNr,
+  // capsWithNoOwnRange)`, computed once, outside any store mutation.
+  const pureExpected = nrRawToDisplay(100, controlRangeFromCapsOrDefault('nr_level', capsWithNoOwnRange));
+
+  it.each([
+    ['store shaped like rangeA (0-255 -> 0-15, same shape CONTROL_DEFAULTS uses)', rangeA],
+    ['store shaped like rangeB (0-200 -> 0-20, genuinely different scale)', rangeB],
+  ] as const)(
+    'identical (state, caps-without-range) ⇒ the SAME store-independent literal fact — %s',
+    (_label, storeRange) => {
+      setCapabilities(caps({ controls: { nr_level: storeRange } }));
+      const view = model(stateWithNr, capsWithNoOwnRange);
+      expect(view.dsp!.nrLevel.reading).toEqual({ status: 'known', value: pureExpected });
+    },
+  );
+
+  it('identical (state, caps-without-range) ⇒ the SAME store-independent literal fact — store EMPTY', () => {
+    setCapabilities(caps());
+    const view = model(stateWithNr, capsWithNoOwnRange);
+    expect(view.dsp!.nrLevel.reading).toEqual({ status: 'known', value: pureExpected });
+  });
+
+  it('sanity: rangeA and rangeB really do produce different raw-100 outputs when actually applied (the discriminator the rows above depend on)', () => {
+    const underA = nrRawToDisplay(100, { rawMin: 0, rawMax: 255, displayMin: 0, displayMax: 15 });
+    const underB = nrRawToDisplay(100, { rawMin: 0, rawMax: 200, displayMin: 0, displayMax: 20 });
+    expect(underA).not.toBe(underB);
+  });
+
+  // Mirrors the round-1 verifier's own live probe (raw 128, 0..15 vs 0..100)
+  // as a direct, easy-to-re-run kill-test for a regression of this exact fix.
+  it("reproduces the verifier's own probe: raw 128 reads the SAME literal value under three genuinely different stores, not 8/50/8", () => {
+    const raw = 128;
+    const stateWith128 = bareState({
+      main: { ...bareState().main, nrLevel: raw },
+      fieldStatus: { ...bareState().fieldStatus, 'main.nrLevel': fresh },
+    });
+    const literalExpected = nrRawToDisplay(raw, controlRangeFromCapsOrDefault('nr_level', capsWithNoOwnRange));
+
+    setCapabilities(caps({ controls: { nr_level: { raw_min: 0, raw_max: 255, raw_center: 0, display_min: 0, display_max: 15 } } }));
+    const underDefaultShapedStore = model(stateWith128, capsWithNoOwnRange).dsp!.nrLevel.reading;
+
+    setCapabilities(caps({ controls: { nr_level: { raw_min: 0, raw_max: 100, raw_center: 0, display_min: 0, display_max: 100 } } }));
+    const under0to100Store = model(stateWith128, capsWithNoOwnRange).dsp!.nrLevel.reading;
+
+    setCapabilities(caps());
+    const underEmptyStore = model(stateWith128, capsWithNoOwnRange).dsp!.nrLevel.reading;
+
+    expect(underDefaultShapedStore).toEqual({ status: 'known', value: literalExpected });
+    expect(under0to100Store).toEqual({ status: 'known', value: literalExpected });
+    expect(underEmptyStore).toEqual({ status: 'known', value: literalExpected });
+  });
+
+  it('CASE A — caps-declared range WINS over a conflicting store — the pre-capabilities-landed boot window', () => {
+    setCapabilities(NEUTRAL_STORE_CAPS);
+    const capsWithOwnRange = caps({ capabilities: ['nr'], controls: { nr_level: rangeB } });
+    const view = model(stateWithNr, capsWithOwnRange);
+    const expectedFromCaps = nrRawToDisplay(100, { rawMin: 0, rawMax: 200, displayMin: 0, displayMax: 20 });
+    const expectedFromEmptyStore = nrRawToDisplay(100); // what the OLD store-only code would have said
+    expect(expectedFromCaps).not.toBe(expectedFromEmptyStore);
+    expect(view.dsp!.nrLevel.reading).toEqual({ status: 'known', value: expectedFromCaps });
+  });
+
+  it('CASE A — identical (state, caps) ⇒ identical facts even when the store is left at a THIRD, unrelated range mid-test', () => {
+    const capsOwnRange = caps({ capabilities: ['nr'], controls: { nr_level: rangeB } });
+    setCapabilities(caps({ controls: { nr_level: rangeA } }));
+    const viewUnderStoreA = model(stateWithNr, capsOwnRange);
+    setCapabilities(caps()); // store now EMPTY — still must not move the fact
+    const viewUnderEmptyStore = model(stateWithNr, capsOwnRange);
+    expect(viewUnderStoreA.dsp!.nrLevel.reading).toEqual(viewUnderEmptyStore.dsp!.nrLevel.reading);
+  });
+});
+
+/**
+ * HONESTY GATE (MOR-1290, following the 4A′ F2 lesson). `notchMode`'s
+ * derivation from TWO raw booleans (`autoNotch`/`manualNotch`) must never
+ * fabricate a reading from ONE observed field and the other's silently-
+ * defaulted-to-false value — the same "never emit a known value derived
+ * from an unobserved input" discipline `filterPassband`'s `ifShift` F2 fix
+ * enforces for `pbtInner`/`pbtOuter`.
+ */
+describe('dsp honesty gate — no notchMode derivation from a half-observed input (MOR-1290, F2 lesson)', () => {
+  const notchCaps = caps({ capabilities: ['notch'] });
+
+  it('autoNotch observed, manualNotch UNOBSERVED (stale) — notchMode must NOT derive from a fabricated manualNotch default', () => {
+    const view = model(bareState({
+      main: { ...bareState().main, autoNotch: true, manualNotch: false },
+      fieldStatus: { ...bareState().fieldStatus, 'main.autoNotch': fresh, 'main.manualNotch': stale },
+    }), notchCaps);
+    expect(view.dsp!.notchMode).toEqual({
+      reading: { status: 'unknown' }, availability: { structural: true, operational: false },
+    });
+  });
+
+  it('both autoNotch and manualNotch observed — notchMode derives and reports known', () => {
+    const view = model(bareState({
+      main: { ...bareState().main, autoNotch: false, manualNotch: true },
+      fieldStatus: { ...bareState().fieldStatus, 'main.autoNotch': fresh, 'main.manualNotch': fresh },
+    }), notchCaps);
+    expect(view.dsp!.notchMode.reading).toEqual({ status: 'known', value: 'manual' });
+  });
+
+  it('both false and both observed ⇒ notchMode reports the honest "off", not withheld as unknown', () => {
+    const view = model(bareState({
+      main: { ...bareState().main, autoNotch: false, manualNotch: false },
+      fieldStatus: { ...bareState().fieldStatus, 'main.autoNotch': fresh, 'main.manualNotch': fresh },
+    }), notchCaps);
+    expect(view.dsp!.notchMode.reading).toEqual({ status: 'known', value: 'off' });
+  });
+
+  // MOR-1290 (mirroring MOR-1284 F2's mutant pin): a `?? false` stand-in for
+  // an ABSENT raw value must not seed a fabricated 'off'. `main.manualNotch`
+  // missing from the receiver object entirely, no `fieldStatus` entry for it
+  // either (so the loose `topFieldAvailable` gate defaults it to "available"
+  // were the reading not independently gated on the raw value itself).
+  it('manualNotch ABSENT from the receiver object (not merely unobserved) — notchMode must read unknown, not fabricate "auto"/"off"', () => {
+    const mainWithoutManualNotch = { ...bareState().main, autoNotch: false };
+    delete (mainWithoutManualNotch as { manualNotch?: boolean }).manualNotch;
+    const view = model(bareState({
+      main: mainWithoutManualNotch,
+      fieldStatus: { ...bareState().fieldStatus, 'main.autoNotch': fresh },
+    }), notchCaps);
+    expect(view.dsp!.notchMode.reading).toEqual({ status: 'unknown' });
+  });
+
+  it('with no notch capability, notchMode is structurally absent even when both booleans are observed', () => {
+    const view = model(bareState({
+      main: { ...bareState().main, autoNotch: false, manualNotch: false },
+      fieldStatus: { ...bareState().fieldStatus, 'main.autoNotch': fresh, 'main.manualNotch': fresh },
+    }), caps({ capabilities: ['agc'] }));
+    expect(view.dsp!.notchMode.availability.structural).toBe(false);
+    expect(view.dsp!.notchMode.reading).toEqual({ status: 'unknown' });
+  });
+});
+
+/**
+ * HONESTY GATE (MOR-1290 F2, verify round 1). `notchMode`'s absent-raw pin
+ * above does NOT cover the six plain numeric fields — each is read via
+ * `numOrUndef(raw)` with no `?? 0` today, but nothing pinned that a mutant
+ * seeding one WOULD be caught. The round-1 verifier's mutation H3
+ * (`numOrUndef(rx?.nrLevel) ?? 0`) survived all 51 pre-fix tests, turning an
+ * entirely-absent `nrLevel` into a fabricated `{status:'known', value:0}` —
+ * "NR level is 0" — with nothing to notice. One table-driven case per field,
+ * mirroring `notchMode`'s own "ABSENT from the receiver object (not merely
+ * unobserved), no `fieldStatus` entry either" construction, so the loose
+ * `topFieldAvailable` gate defaults to "available" and the ONLY thing that
+ * can stop a fabricated reading is `numOrUndef` gating on the raw value
+ * itself — exactly what a `?? 0` mutant would defeat.
+ */
+describe('dsp honesty gate — absent raw values on numeric fields never fabricate (MOR-1290 F2, mutant H3)', () => {
+  const allCaps = caps({
+    capabilities: ['nr', 'nb', 'notch', 'agc'],
+    controls: { nb_depth: { raw_min: 0, raw_max: 9, raw_center: 0, display_min: 1, display_max: 10 } },
+  });
+
+  const RECEIVER_SCOPED_FIELDS = ['nrLevel', 'nbLevel', 'manualNotchWidth', 'agcTimeConstant'] as const;
+
+  it.each(RECEIVER_SCOPED_FIELDS)(
+    '%s: absent from the receiver object (no fieldStatus entry) reads unknown, not {known, 0}',
+    (field) => {
+      const main = { ...bareState().main } as Record<string, unknown>;
+      delete main[field];
+      const view = model(bareState({ main: main as unknown as ServerState['main'] }), allCaps);
+      expect(view.dsp![field].reading).toEqual({ status: 'unknown' });
+    },
+  );
+
+  // `nbDepth`/`notchFreq` are TOP-LEVEL `ServerState` fields (not on `main`),
+  // and `bareState()` already omits both by default — no explicit `delete`
+  // needed, the baseline fixture itself is the absent-raw case.
+  const TOP_LEVEL_FIELDS = ['nbDepth', 'notchFreq'] as const;
+
+  it.each(TOP_LEVEL_FIELDS)(
+    '%s: absent from top-level state (no fieldStatus entry) reads unknown, not {known, 0}',
+    (field) => {
+      const view = model(bareState(), allCaps);
+      expect(view.dsp![field].reading).toEqual({ status: 'unknown' });
+    },
+  );
+});
+
+describe('dsp validator round-trip (MOR-1290)', () => {
+  it('emits a validator-clean model carrying the dsp group', () => {
+    const view = model(bareState(), caps({ capabilities: ['nr', 'nb', 'notch', 'agc'] }));
+    expect(JSON.parse(JSON.stringify(view))).toEqual(view);
+  });
+
+  it('degrades a malformed raw value (wrong JS type) to unknown rather than throwing or coercing', () => {
+    const view = model(bareState({
+      main: { ...bareState().main, agc: 'fast' as unknown as number },
+    }), caps({ capabilities: ['agc'] }));
+    expect(view.dsp!.agcMode.reading).toEqual({ status: 'unknown' });
+  });
+});

--- a/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
@@ -29,13 +29,16 @@ import type {
   RadioViewModel, TxAuxField, TxAuxViewModel, AtuStatus,
   MeterField, MeterRfState, MetersViewModel,
   AudioFocus, MonitorMode, RxAudioViewModel, ModeFilterViewModel,
-  FilterPassbandViewModel,
+  FilterPassbandViewModel, DspViewModel,
 } from '../../../semantic/radio-view-model';
 import type { TxAuthoritySnapshot } from '../../../semantic/rx-tx-surface';
 import { isFieldAvailable } from '$lib/state/field-status';
 import { modInputStateKey } from '$lib/radio/mod-input';
 import { resolveFilterModeConfig } from '$lib/runtime/props/panel-props';
-import { deriveIfShift, pbtRangeFromCaps, pbtRawToHz } from '$lib/radio/filter-controls';
+import {
+  deriveIfShift, pbtRangeFromCaps, pbtRawToHz,
+  controlRangeFromCapsOrDefault, nrRawToDisplay, nbDepthRawToDisplay,
+} from '$lib/radio/filter-controls';
 import {
   derivePresentationCapabilities, type ReceiverId, type VfoSlotId,
 } from './presentation-capabilities';
@@ -412,6 +415,93 @@ function deriveFilterPassband(
 }
 
 /**
+ * DSP facts (MOR-1262 decomposition slice 5A, MOR-1290): NR, NB (+ depth/
+ * width), notch (auto/manual), AGC. A separate group from `filterPassband`
+ * — family enumeration is explicit and CLOSED (filter shape / IF-shift / PBT
+ * are family 4, `deriveFilterPassband` above; never duplicated here).
+ *
+ * Evidence gate (N3): each field's structural gate mirrors `toDspProps`'/
+ * `toAgcProps`' OWN gate verbatim — `hasCap(caps, 'nr'|'nb'|'notch'|'agc')`,
+ * or (for `nbDepth`/`nbWidth`) the presence of a `controls.nb_depth` range,
+ * exactly `toDspProps`' own `hasNbDepth`/`hasNbWidth` (`hasNbWidth` borrows
+ * `hasNbDepth`'s signal verbatim, same as that function does). The group
+ * itself emits only when at least one of these signals is positive.
+ */
+function deriveDsp(
+  state: ServerState | null, caps: Capabilities | null,
+): DspViewModel | undefined {
+  if (!caps) return undefined;
+  const hasNrCap = hasCap(caps, 'nr');
+  const hasNbCap = hasCap(caps, 'nb');
+  const hasNotchCap = hasCap(caps, 'notch');
+  const hasAgcCap = hasCap(caps, 'agc');
+  const hasNbDepth = (caps.controls?.nb_depth ?? null) !== null;
+  if (!hasNrCap && !hasNbCap && !hasNotchCap && !hasAgcCap && !hasNbDepth) return undefined;
+
+  const onSub = state?.active === 'SUB';
+  const rx = onSub ? state?.sub : state?.main;
+  const base = onSub ? 'sub.' : 'main.';
+
+  // The ONE shipped display-scale conversions (`nrRawToDisplay`/
+  // `nbDepthRawToDisplay`, `$lib/radio/filter-controls`) — called with the
+  // range explicitly derived from THIS function's own `caps` argument
+  // (`controlRangeFromCapsOrDefault`, mirroring `filterPassband`'s
+  // `pbtRangeFromCaps`, MOR-1284 F1), not the capabilities STORE singleton
+  // they otherwise fall back to. MOR-1290 F1 (verify round 1): the plain
+  // `controlRangeFromCaps` alone still returns `undefined` when `caps`
+  // declares no range for the key, and passing `undefined` as `range` makes
+  // `nrRawToDisplay`/`nbDepthRawToDisplay` fall through to THEIR OWN store
+  // lookup — reintroducing the exact module-global dependency this is meant
+  // to close, for the one case (`caps` omitting the key) that matters most
+  // (a server whose capabilities haven't fully landed yet). The `…OrDefault`
+  // wrapper always returns a CONCRETE range — this module's own
+  // `CONTROL_DEFAULTS`, the same ones `nrRawToDisplay`/`nbDepthRawToDisplay`
+  // fall back to today — so the store is NEVER consulted here, in either
+  // branch: the fact is a pure function of `(state, caps)` unconditionally.
+  // See the determinism pin in `__tests__/dsp-adapter.test.ts`. Computed only
+  // from the field's OWN raw value — never from a `?? 0` stand-in — so an
+  // unobserved nrLevel/nbDepth never silently reports a fabricated reading.
+  const nrLevelRange = controlRangeFromCapsOrDefault('nr_level', caps);
+  const nrLevelRaw = numOrUndef(rx?.nrLevel);
+  const nrLevelValue = nrLevelRaw !== undefined ? nrRawToDisplay(nrLevelRaw, nrLevelRange) : undefined;
+
+  const nbDepthRange = controlRangeFromCapsOrDefault('nb_depth', caps);
+  const nbDepthRaw = numOrUndef(state?.nbDepth);
+  const nbDepthValue = nbDepthRaw !== undefined ? nbDepthRawToDisplay(nbDepthRaw, nbDepthRange) : undefined;
+
+  // `notchMode` is derived from TWO raw booleans (`autoNotch`/`manualNotch`);
+  // same "never derive from a half-observed input" discipline `filterPassband`'s
+  // `ifShift` uses for `pbtInner`/`pbtOuter` (MOR-1284 F2 lesson) — both must
+  // be honestly observed before a definitive 'off'/'auto'/'manual' is reported.
+  const autoNotchObserved = topFieldAvailable(state, `${base}autoNotch`);
+  const manualNotchObserved = topFieldAvailable(state, `${base}manualNotch`);
+  const autoNotchRaw = boolOrUndef(rx?.autoNotch);
+  const manualNotchRaw = boolOrUndef(rx?.manualNotch);
+  const notchModeValue = autoNotchRaw !== undefined && manualNotchRaw !== undefined
+    ? (autoNotchRaw ? 'auto' as const : manualNotchRaw ? 'manual' as const : 'off' as const)
+    : undefined;
+
+  return {
+    nrActive: txAuxField(hasNrCap, topFieldAvailable(state, `${base}nr`), boolOrUndef(rx?.nr)),
+    nrLevel: txAuxField(hasNrCap, topFieldAvailable(state, `${base}nrLevel`), nrLevelValue),
+    nbActive: txAuxField(hasNbCap, topFieldAvailable(state, `${base}nb`), boolOrUndef(rx?.nb)),
+    nbLevel: txAuxField(hasNbCap, topFieldAvailable(state, `${base}nbLevel`), numOrUndef(rx?.nbLevel)),
+    nbDepth: txAuxField(hasNbDepth, topFieldAvailable(state, 'nbDepth'), nbDepthValue),
+    nbWidth: txAuxField(hasNbDepth, topFieldAvailable(state, 'nbWidth'), numOrUndef(state?.nbWidth)),
+    notchMode: txAuxField(hasNotchCap, autoNotchObserved && manualNotchObserved, notchModeValue),
+    notchFreq: txAuxField(hasNotchCap, topFieldAvailable(state, 'notchFilter'), numOrUndef(state?.notchFilter)),
+    manualNotchWidth: txAuxField(
+      hasNotchCap, topFieldAvailable(state, `${base}manualNotchWidth`), numOrUndef(rx?.manualNotchWidth),
+    ),
+    agcMode: txAuxField(hasAgcCap, topFieldAvailable(state, `${base}agc`), numOrUndef(rx?.agc)),
+    agcModes: caps.agcModes ?? [],
+    agcTimeConstant: txAuxField(
+      hasAgcCap, topFieldAvailable(state, `${base}agcTimeConstant`), numOrUndef(rx?.agcTimeConstant),
+    ),
+  };
+}
+
+/**
  * The App-owned RX-audio snapshot the `rxAudio` facts are read against
  * (MOR-1262 slice 3A). It is an INPUT, deliberately: audio lifetime belongs to
  * the App (MOR-1058) and building a view model must never open, start or probe
@@ -642,6 +732,7 @@ export function toRadioViewModel(
   const rxAudio = deriveRxAudio(state, caps, facts, modInputSource, rxAudioSnapshot);
   const modeFilter = deriveModeFilter(state, caps);
   const filterPassband = deriveFilterPassband(state, caps);
+  const dsp = deriveDsp(state, caps);
 
   return {
     topologyId: `${topology.structuralCount}/${topology.scheme}`,
@@ -659,5 +750,6 @@ export function toRadioViewModel(
     ...(rxAudio !== undefined ? { rxAudio } : {}),
     ...(modeFilter !== undefined ? { modeFilter } : {}),
     ...(filterPassband !== undefined ? { filterPassband } : {}),
+    ...(dsp !== undefined ? { dsp } : {}),
   };
 }

--- a/frontend/src/semantic/__tests__/dsp.test.ts
+++ b/frontend/src/semantic/__tests__/dsp.test.ts
@@ -1,0 +1,174 @@
+/**
+ * MOR-1262 decomposition slice 5A (MOR-1290) — `dsp` optional fact group
+ * (validator half).
+ *
+ * Facts only: NR (active + level), NB (active + level + depth + width),
+ * notch (mode + freq + manual width), AGC (mode + choice set + time
+ * constant). A SEPARATE group from `filterPassband` (MOR-1284, slice 4A′) —
+ * see `radio-view-model.ts`'s `DspViewModel` doc comment for the group-shape
+ * rationale, and `radio-view-model-adapter.ts`'s `deriveDsp` for the live
+ * derivation (covered by the companion adapter test file).
+ *
+ * Mirrors the companion families' (`tx-aux.test.ts`, `filter-passband.test.ts`)
+ * kill-tests for this family:
+ *  1. a dsp-absent model validates and round-trips byte-identically
+ *  2. `"dsp": null` / `{}` throw (absent ≠ malformed)
+ *  3. a malformed inner field throws with a precise `$.dsp....` path
+ *  5. an unknown extra key inside dsp (or a field) throws
+ * (Kill-test 4, the adapter's evidence gate, lives in the adapter test file.)
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  validateRadioViewModel, type DspField, type DspViewModel,
+} from '../radio-view-model';
+import { topologyFixtures, withDsp } from '../fixtures/topologies';
+
+const AVAIL = { structural: true, operational: true } as const;
+const base = topologyFixtures['1/single'];
+
+describe('dsp (MOR-1262 slice 5A)', () => {
+  // ── Kill-test 1: absence is byte-identical, not a new default shape ──────
+  it('validates a dsp-absent model and never adds the key', () => {
+    expect(Object.keys(base)).not.toContain('dsp');
+    const validated = validateRadioViewModel(base);
+    expect(Object.keys(validated)).not.toContain('dsp');
+    expect(validated.dsp).toBeUndefined();
+    expect(JSON.parse(JSON.stringify(validated))).toEqual(JSON.parse(JSON.stringify(base)));
+  });
+
+  it('validates a fully-populated dsp group and returns it unchanged', () => {
+    const withD = withDsp(base);
+    expect(validateRadioViewModel(withD).dsp).toEqual(withD.dsp);
+  });
+
+  // ── Kill-test 2: null / {} are not absent ────────────────────────────────
+  it('rejects an explicit dsp: null', () => {
+    expect(() => validateRadioViewModel({ ...base, dsp: null })).toThrow(TypeError);
+  });
+
+  it('rejects an explicit dsp: {} — present, not absent, must satisfy its own shape', () => {
+    expect(() => validateRadioViewModel({ ...base, dsp: {} })).toThrow(TypeError);
+  });
+
+  // ── Kill-test 3: malformed inner field, precise path ─────────────────────
+  it('rejects a non-numeric nrLevel reading value with a precise error path', () => {
+    const withD = withDsp(base);
+    const malformed = {
+      ...withD,
+      dsp: {
+        ...withD.dsp,
+        nrLevel: { reading: { status: 'known', value: 'high' }, availability: AVAIL },
+      },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.dsp\.nrLevel\.reading\.value/);
+  });
+
+  it('rejects a non-boolean nbActive reading value with a precise error path', () => {
+    const withD = withDsp(base);
+    const malformed = {
+      ...withD,
+      dsp: {
+        ...withD.dsp,
+        nbActive: { reading: { status: 'known', value: 1 }, availability: AVAIL },
+      },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.dsp\.nbActive\.reading\.value/);
+  });
+
+  it('rejects a notchMode reading value outside the off/auto/manual union', () => {
+    const withD = withDsp(base);
+    const malformed = {
+      ...withD,
+      dsp: {
+        ...withD.dsp,
+        notchMode: { reading: { status: 'known', value: 'wide' }, availability: AVAIL },
+      },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.dsp\.notchMode\.reading\.value/);
+  });
+
+  it('rejects a non-array agcModes', () => {
+    const withD = withDsp(base);
+    const malformed = { ...withD, dsp: { ...withD.dsp, agcModes: 'FAST' } };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.dsp\.agcModes/);
+  });
+
+  it('rejects a non-boolean field inside a dsp field Availability', () => {
+    const withD = withDsp(base);
+    const malformed = {
+      ...withD,
+      dsp: {
+        ...withD.dsp,
+        agcMode: { reading: { status: 'unknown' }, availability: { structural: 'yes', operational: true } },
+      },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(TypeError);
+  });
+
+  it('accepts an unknown reading distinct from a known one, independently per field', () => {
+    const withD = withDsp(base);
+    const partial = {
+      ...withD,
+      dsp: {
+        ...withD.dsp,
+        nbDepth: { reading: { status: 'unknown' }, availability: { structural: true, operational: false } },
+      },
+    };
+    const validated = validateRadioViewModel(partial);
+    expect(validated.dsp?.nbDepth).toEqual({
+      reading: { status: 'unknown' }, availability: { structural: true, operational: false },
+    });
+    // The rest of the group is untouched by the one field's degrade.
+    expect(validated.dsp?.nrLevel.reading).toEqual({ status: 'known', value: 8 });
+  });
+
+  // ── Kill-test 5: no speculative keys (N4) ─────────────────────────────────
+  it('rejects an unknown extra key inside dsp', () => {
+    const withD = withDsp(base);
+    const malformed = { ...withD, dsp: { ...withD.dsp, bogus: 1 } };
+    expect(() => validateRadioViewModel(malformed)).toThrow(TypeError);
+  });
+
+  it('rejects an unknown extra key inside a single dsp field', () => {
+    const withD = withDsp(base);
+    const malformed = {
+      ...withD,
+      dsp: {
+        ...withD.dsp,
+        agcTimeConstant: { reading: { status: 'known', value: 1 }, availability: AVAIL, extra: true },
+      },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(TypeError);
+  });
+
+  it('rejects a reading that carries a value key while unknown', () => {
+    const withD = withDsp(base);
+    const malformed = {
+      ...withD,
+      dsp: {
+        ...withD.dsp,
+        nbWidth: { reading: { status: 'unknown', value: 0 }, availability: AVAIL },
+      },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(TypeError);
+  });
+
+  it('every field of a fully-populated group round-trips its own value', () => {
+    const withD = withDsp(base);
+    const validated = validateRadioViewModel(withD).dsp as DspViewModel;
+    const knownValue = <T>(f: DspField<T>): T | undefined =>
+      f.reading.status === 'known' ? f.reading.value : undefined;
+    expect(knownValue(validated.nrActive)).toBe(true);
+    expect(knownValue(validated.nrLevel)).toBe(8);
+    expect(knownValue(validated.nbActive)).toBe(false);
+    expect(knownValue(validated.nbLevel)).toBe(64);
+    expect(knownValue(validated.nbDepth)).toBe(5);
+    expect(knownValue(validated.nbWidth)).toBe(2);
+    expect(knownValue(validated.notchMode)).toBe('off');
+    expect(knownValue(validated.notchFreq)).toBe(0);
+    expect(knownValue(validated.manualNotchWidth)).toBe(10);
+    expect(knownValue(validated.agcMode)).toBe(2);
+    expect(validated.agcModes).toEqual([1, 2, 3]);
+    expect(knownValue(validated.agcTimeConstant)).toBe(0);
+  });
+});

--- a/frontend/src/semantic/__tests__/optional-group-allow-list.test.ts
+++ b/frontend/src/semantic/__tests__/optional-group-allow-list.test.ts
@@ -41,10 +41,10 @@ const REQUIRED_KEYS = [
 ] as const;
 
 /** MOR-1244: txAux. MOR-1262 slice 2A: meters. Slice 3A: rxAudio. Slice 4A:
- *  modeFilter. Slice 4A′: filterPassband. Add your key here when your
- *  family's slice lands. */
+ *  modeFilter. Slice 4A′: filterPassband. Slice 5A: dsp. Add your key here
+ *  when your family's slice lands. */
 const EXPECTED_OPTIONAL_GROUP_KEYS = [
-  'txAux', 'meters', 'rxAudio', 'modeFilter', 'filterPassband',
+  'txAux', 'meters', 'rxAudio', 'modeFilter', 'filterPassband', 'dsp',
 ] as const;
 
 function extractTopLevelAllowList(): string[] {

--- a/frontend/src/semantic/fixtures/topologies.ts
+++ b/frontend/src/semantic/fixtures/topologies.ts
@@ -14,7 +14,7 @@
  * topology, so it can be applied to any of the four fixtures below.
  */
 import type {
-  Availability, FilterPassbandField, FilterPassbandViewModel,
+  Availability, DspField, DspViewModel, FilterPassbandField, FilterPassbandViewModel,
   MeterField, MeterRfState, MetersViewModel,
   ModeFilterField, ModeFilterViewModel,
   ModInputReadiness, RadioViewModel, RxAudioField, RxAudioViewModel,
@@ -280,4 +280,30 @@ export function withFilterPassband(fixture: RadioViewModel): RadioViewModel {
     dataMode: known(0),
   };
   return { ...fixture, filterPassband };
+}
+
+/**
+ * Applies a fully-observed `dsp` group (MOR-1262 slice 5A) to any topology
+ * fixture — a SEPARATE group from `withFilterPassband` above (see
+ * `DspViewModel`'s doc comment for why), same composable-axis story as
+ * `withTxAux`/`withMeters`/`withRxAudio`/`withFilterPassband`.
+ */
+export function withDsp(fixture: RadioViewModel): RadioViewModel {
+  const avail: Availability = { structural: true, operational: true };
+  const known = <T>(value: T): DspField<T> => ({ reading: { status: 'known', value }, availability: avail });
+  const dsp: DspViewModel = {
+    nrActive: known(true),
+    nrLevel: known(8),
+    nbActive: known(false),
+    nbLevel: known(64),
+    nbDepth: known(5),
+    nbWidth: known(2),
+    notchMode: known('off'),
+    notchFreq: known(0),
+    manualNotchWidth: known(10),
+    agcMode: known(2),
+    agcModes: [1, 2, 3],
+    agcTimeConstant: known(0),
+  };
+  return { ...fixture, dsp };
 }

--- a/frontend/src/semantic/radio-view-model.ts
+++ b/frontend/src/semantic/radio-view-model.ts
@@ -311,6 +311,53 @@ export interface FilterPassbandViewModel {
   dataMode: FilterPassbandField<number>;
 }
 
+/**
+ * A single DSP fact (MOR-1262 decomposition slice 5A, MOR-1290).
+ * Shape-identical to `TxAuxField`, declared as an alias for the same reason
+ * `FilterPassbandField`/`ModeFilterField`/`RxAudioField` are: one field
+ * shape per fact family.
+ */
+export type DspField<T> = TxAuxField<T>;
+
+/**
+ * DSP facts (MOR-1262 decomposition slice 5A, MOR-1290): noise reduction
+ * (NR), noise blanker (NB, + depth/width), notch (auto/manual), and AGC.
+ * Facts only — no command emission, same doctrine as `modeFilter`/
+ * `filterPassband`. Family enumeration is explicit and CLOSED: filter shape,
+ * IF-shift, and PBT are family 4 (`filterPassband`, MOR-1284) — this group
+ * never duplicates them.
+ *
+ * `nrLevel`/`nbDepth` are the ONE remaining consumers of `$lib/radio/filter-
+ * controls`'s `nrRawToDisplay`/`nbDepthRawToDisplay` — the exact functions
+ * `toDspProps` calls — never a re-derived scale (X6200 lesson: control
+ * scaling is per-radio-model data, `caps.controls.nr_level`/`.nb_depth`).
+ * Like `filterPassband`'s `pbtInner`/`pbtOuter` (MOR-1284 F1), the adapter
+ * passes both an explicit `ControlDisplayRange` derived from THIS request's
+ * own `caps` argument (`controlRangeFromCaps`) rather than letting them fall
+ * back to the capabilities STORE singleton — a fact-layer value must be a
+ * pure function of `(state, caps)`, never of module-global state.
+ *
+ * `agcModes` is the capability-derived AGC choice set (`Capabilities.
+ * agcModes`, verbatim) — a plain list, not `DspField`-wrapped, for the same
+ * reason `ModeFilterViewModel`'s `modeChoices`/`filterChoices` aren't: a
+ * choice set is a structural fact about the radio MODEL, not a live reading
+ * that can itself go stale.
+ */
+export interface DspViewModel {
+  nrActive: DspField<boolean>;
+  nrLevel: DspField<number>;
+  nbActive: DspField<boolean>;
+  nbLevel: DspField<number>;
+  nbDepth: DspField<number>;
+  nbWidth: DspField<number>;
+  notchMode: DspField<'off' | 'auto' | 'manual'>;
+  notchFreq: DspField<number>;
+  manualNotchWidth: DspField<number>;
+  agcMode: DspField<number>;
+  agcModes: readonly number[];
+  agcTimeConstant: DspField<number>;
+}
+
 export interface RadioViewModel {
   topologyId: string;
   vfoScheme: VfoScheme;
@@ -344,6 +391,10 @@ export interface RadioViewModel {
    *  PBT, no IF-shift and no DATA-mode capability — see
    *  `radio-view-model-adapter.ts`'s `deriveFilterPassband`. */
   readonly filterPassband?: FilterPassbandViewModel;
+  /** Absent (MOR-1264 optional group) ⇒ this radio declares no NR, no NB, no
+   *  notch and no AGC capability — see `radio-view-model-adapter.ts`'s
+   *  `deriveDsp`. */
+  readonly dsp?: DspViewModel;
 }
 
 const RECEIVER_IDS: readonly ReceiverId[] = ['MAIN', 'SUB'];
@@ -662,6 +713,12 @@ function strArray(value: unknown, path: string): string[] {
   return value.map((item, i) => str(item, `${path}[${i}]`));
 }
 
+/** Same idea as `strArray`, for `DspViewModel.agcModes` — see its doc comment. */
+function numArray(value: unknown, path: string): number[] {
+  if (!Array.isArray(value)) invalid(path, 'an array of numbers');
+  return value.map((item, i) => num(item, `${path}[${i}]`));
+}
+
 /** N4 again: exactly the seven facts the adapter reads, no speculative keys.
  *  See `radio-view-model-adapter.ts::deriveModeFilter`. */
 function validateModeFilter(value: unknown, path: string): ModeFilterViewModel {
@@ -695,6 +752,32 @@ function validateFilterPassband(value: unknown, path: string): FilterPassbandVie
   };
 }
 
+const NOTCH_MODES = ['off', 'auto', 'manual'] as const;
+
+/** N4 again: exactly the twelve facts the adapter reads, no speculative keys.
+ *  See `radio-view-model-adapter.ts::deriveDsp`. */
+function validateDsp(value: unknown, path: string): DspViewModel {
+  const v = record(value, path);
+  exactKeys(v, [
+    'nrActive', 'nrLevel', 'nbActive', 'nbLevel', 'nbDepth', 'nbWidth',
+    'notchMode', 'notchFreq', 'manualNotchWidth', 'agcMode', 'agcModes', 'agcTimeConstant',
+  ], path);
+  return {
+    nrActive: validateTxAuxField(v.nrActive, `${path}.nrActive`, bool),
+    nrLevel: validateTxAuxField(v.nrLevel, `${path}.nrLevel`, num),
+    nbActive: validateTxAuxField(v.nbActive, `${path}.nbActive`, bool),
+    nbLevel: validateTxAuxField(v.nbLevel, `${path}.nbLevel`, num),
+    nbDepth: validateTxAuxField(v.nbDepth, `${path}.nbDepth`, num),
+    nbWidth: validateTxAuxField(v.nbWidth, `${path}.nbWidth`, num),
+    notchMode: validateTxAuxField(v.notchMode, `${path}.notchMode`, (val, p) => oneOf(val, NOTCH_MODES, p)),
+    notchFreq: validateTxAuxField(v.notchFreq, `${path}.notchFreq`, num),
+    manualNotchWidth: validateTxAuxField(v.manualNotchWidth, `${path}.manualNotchWidth`, num),
+    agcMode: validateTxAuxField(v.agcMode, `${path}.agcMode`, num),
+    agcModes: numArray(v.agcModes, `${path}.agcModes`),
+    agcTimeConstant: validateTxAuxField(v.agcTimeConstant, `${path}.agcTimeConstant`, num),
+  };
+}
+
 /** Runtime validator (repo idiom: throws TypeError with a `$.path`, see `validateCapabilities`).
  *  Also enforces two cross-field invariants (review cycle 1, V1): `txPermit`
  *  cannot be 'allowed' while `txTarget` is unknown (no fail-open), and
@@ -704,7 +787,7 @@ export function validateRadioViewModel(value: unknown): RadioViewModel {
   exactKeys(v, [
     'topologyId', 'vfoScheme', 'activeReceiver', 'vfos', 'split', 'dualWatch',
     'txTarget', 'txPermit', 'scope', 'disabledReasons', 'txAux', 'meters', 'rxAudio', 'modeFilter',
-    'filterPassband',
+    'filterPassband', 'dsp',
   ], '$');
   if (!Array.isArray(v.vfos)) invalid('$.vfos', 'an array');
   if (!Array.isArray(v.disabledReasons)) invalid('$.disabledReasons', 'an array');
@@ -737,6 +820,7 @@ export function validateRadioViewModel(value: unknown): RadioViewModel {
   const rxAudio = optionalGroup(v.rxAudio, '$.rxAudio', validateRxAudio);
   const modeFilter = optionalGroup(v.modeFilter, '$.modeFilter', validateModeFilter);
   const filterPassband = optionalGroup(v.filterPassband, '$.filterPassband', validateFilterPassband);
+  const dsp = optionalGroup(v.dsp, '$.dsp', validateDsp);
 
   return {
     topologyId: str(v.topologyId, '$.topologyId'),
@@ -757,5 +841,6 @@ export function validateRadioViewModel(value: unknown): RadioViewModel {
     ...(rxAudio !== undefined ? { rxAudio } : {}),
     ...(modeFilter !== undefined ? { modeFilter } : {}),
     ...(filterPassband !== undefined ? { filterPassband } : {}),
+    ...(dsp !== undefined ? { dsp } : {}),
   };
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -103,6 +103,10 @@ export default defineConfig({
             // ``mod-input-tx-guard.test.ts`` / ``frontend-runtime.test.ts``
             // below. See MOR-1272.
             'src/lib/runtime/adapters/__tests__/filter-passband-adapter.test.ts',
+            // MOR-1262 slice 5A, same shape as the 4A′ entry above: calls the
+            // REAL ``setCapabilities`` to install non-default NR/NB control
+            // ranges for the dsp parity pin. See MOR-1272.
+            'src/lib/runtime/adapters/__tests__/dsp-adapter.test.ts',
             // MOR-1077, same class: ``vi.stubGlobal`` on localStorage/fetch/
             // WebSocket plus ``vi.resetModules()`` around a fresh dynamic
             // import of the workspace contract — both mutate state the fast
@@ -212,6 +216,7 @@ export default defineConfig({
             'src/lib/utils/__tests__/smoothing.svelte.test.ts',
             'src/lib/runtime/adapters/__tests__/rx-audio-purity.test.ts',
             'src/lib/runtime/adapters/__tests__/filter-passband-adapter.test.ts',
+            'src/lib/runtime/adapters/__tests__/dsp-adapter.test.ts',
             'src/presentation/workspace/__tests__/purity.test.ts',
             'src/components-v2/wiring/__tests__/keyboard-wiring.test.ts',
             'src/components-v2/wiring/__tests__/vfo-wiring.test.ts',


### PR DESCRIPTION
## Summary
Vocabulary slice 5A: optional `dsp` group via the S0 seam — 11 `DspField` readings + `agcModes` choice set (NR active/level, NB active/level/depth/width, notch mode/freq/width, AGC mode/modes/time-constant), range-parameterised from the caps argument. Family closed per the decomposition (passband = family 4, landed as 4A′).

`nrLevel`/`nbDepth` consume the REAL `nrRawToDisplay`/`nbDepthRawToDisplay`; `controlRangeFromCapsOrDefault` makes facts a pure function of `(state, caps)` in BOTH cases: caps-declared range wins over any store state, and a caps-omitted range uses the same `CONTROL_DEFAULTS` constant v2 already falls back to — never the store (verifier-ruled: nothing invented, byte-matches `toDspProps` semantics). Absent raw values stay `unknown` across all six numeric fields (table-driven pin); `notchMode` never derives from a half-observed auto/manual pair. Net production LOC **121** strict / 245 raw (verifier re-measured; ≤200).

## Review provenance
Sonnet builder → independent opus vocabulary-domain verifier (9th ticket in domain): **PASS** + fix round + delta. Round 1 required fixes: (F1) the caps-omits-range case still fell through to the store (8/50/8 across store states) with a test whose expectation itself called the store-reading path; (F2) an absent-`nrLevel` fabrication mutant survived 51/51 (the recurring PA4 class). Delta round: Case B now 8/8/8 deterministic with genuinely store-free expectations + a rangeA≠rangeB discriminator guard; H3 killed; parity mutants (naive re-implementations, dropped range param) all killed; v2 untouched three ways (call-site audit, no-arg path, pre-existing 18/18 filter-controls suite). Contract mutations killed (drop-from-exactKeys 41, bypass, smuggle); A-queue clean; fail-set identical to baseline (the builder's 12/151 baseline anomaly resolved to the documented fast-pool flake class); lint/boundaries/check clean. Carry-forward: the identical caps-omits residual in landed 4A′ → MOR-1291.

Linear: MOR-1290

🤖 Generated with [Claude Code](https://claude.com/claude-code)