### PR TITLE
feat(MOR-1079): single workspace store and persistence boundary

### DIFF
--- a/frontend/src/presentation/workspace/__tests__/repository.test.ts
+++ b/frontend/src/presentation/workspace/__tests__/repository.test.ts
@@ -1,0 +1,330 @@
+/**
+ * MOR-1079 — the pure persistence layer. Everything here runs against an
+ * injected fake `Storage`; no global is stubbed, so this file stays in the
+ * fast pool (MOR-1272).
+ *
+ * Pins, in ticket order: atomic write / failure fallback, reload, invalid
+ * stored state, migration idempotency, unknown future version — plus the two
+ * carry-forwards this layer owns outright (legacy keys are never written or
+ * deleted; the workspace key has exactly one writer in `src/`).
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import {
+  WORKSPACE_MIGRATION_SENTINEL_KEY, WORKSPACE_STORAGE_KEY, applyWorkspacePatch,
+  canPersistWorkspace, loadWorkspace, markWorkspaceMigrated, persistWorkspace,
+} from '../repository';
+import { LEGACY_KEY_ROUTING } from '../legacy-readers';
+import { DEFAULT_WORKSPACE, serializeWorkspace } from '../contract';
+
+class FakeStorage {
+  readonly map = new Map<string, string>();
+  readonly writes: string[] = [];
+  readonly deletes: string[] = [];
+  throwOnSet = false;
+
+  getItem(key: string): string | null {
+    return this.map.has(key) ? this.map.get(key)! : null;
+  }
+
+  setItem(key: string, value: string): void {
+    if (this.throwOnSet) throw new Error('QuotaExceededError');
+    this.writes.push(key);
+    this.map.set(key, value);
+  }
+
+  removeItem(key: string): void {
+    this.deletes.push(key);
+    this.map.delete(key);
+  }
+
+  clear(): void {
+    this.deletes.push('*');
+    this.map.clear();
+  }
+}
+
+/** Every legacy key the MOR-1076 inventory knows about, given a value. */
+function seedLegacy(storage: FakeStorage): void {
+  for (const route of LEGACY_KEY_ROUTING) storage.map.set(route.key, `legacy:${route.key}`);
+  storage.map.set('rigplane:theme-user-choice', 'nord');
+  storage.map.set('rigplane:theme', 'dracula');
+  storage.map.set('rigplane-layout', 'amber-lcd');
+}
+
+function store(storage: FakeStorage, value: unknown): void {
+  storage.map.set(WORKSPACE_STORAGE_KEY, JSON.stringify(value));
+}
+
+const V1 = { ...DEFAULT_WORKSPACE, theme: 'nord', layout: 'lcd-scope' };
+
+describe('workspace load (MOR-1079)', () => {
+  it('reads validated v1 from the stored key', () => {
+    const storage = new FakeStorage();
+    store(storage, V1);
+
+    const { result, source } = loadWorkspace(storage);
+
+    expect(source).toBe('stored');
+    expect(result.outcome).toBe('ok');
+    expect(result.workspace.theme).toBe('nord');
+    expect(result.workspace.layout).toBe('lcd-scope');
+  });
+
+  it('runs the legacy migration once, through readLegacyWorkspace', () => {
+    const storage = new FakeStorage();
+    seedLegacy(storage);
+
+    const { result, source } = loadWorkspace(storage);
+
+    expect(source).toBe('migrated');
+    // theme-user-choice wins over theme; `amber-lcd` is the MOR-1042 alias.
+    expect(result.workspace.theme).toBe('nord');
+    expect(result.workspace.layout).toBe('lcd-cockpit');
+  });
+
+  it('does NOT re-migrate once the sentinel is set, even with the workspace key cleared', () => {
+    const storage = new FakeStorage();
+    seedLegacy(storage);
+    storage.map.set(WORKSPACE_MIGRATION_SENTINEL_KEY, '1');
+
+    const { result, source } = loadWorkspace(storage);
+
+    expect(source).toBe('absent');
+    expect(result.outcome).toBe('ok');
+    expect(result.workspace).toEqual(DEFAULT_WORKSPACE);
+  });
+
+  it('migration is idempotent: a persisted change survives a second load', () => {
+    const storage = new FakeStorage();
+    seedLegacy(storage);
+
+    const first = loadWorkspace(storage);
+    expect(persistWorkspace(storage, first.result)).toBe(true);
+    expect(markWorkspaceMigrated(storage)).toBe(true);
+    const changed = applyWorkspacePatch(first.result, { theme: 'gruvbox-dark' });
+    persistWorkspace(storage, changed);
+
+    const second = loadWorkspace(storage);
+    expect(second.source).toBe('stored');
+    expect(second.result.workspace.theme).toBe('gruvbox-dark');
+  });
+
+  it.each([
+    ['unparsable JSON', '{{{'],
+    ['a JSON scalar', '"nope"'],
+    ['a JSON array', '[1,2,3]'],
+    ['empty bytes', ''],
+  ])('resets on invalid stored state: %s', (_label, raw) => {
+    const storage = new FakeStorage();
+    storage.map.set(WORKSPACE_STORAGE_KEY, raw);
+
+    const { result } = loadWorkspace(storage);
+
+    expect(result.outcome).toBe('reset');
+    expect(result.workspace).toEqual(DEFAULT_WORKSPACE);
+  });
+
+  it('degrades to defaults when getItem itself throws', () => {
+    const hostile = { getItem() { throw new Error('SecurityError'); }, setItem() {} };
+
+    const { result } = loadWorkspace(hostile);
+
+    // No stored key, no sentinel → the legacy reader path, which is itself
+    // throw-tolerant, so this lands on defaults rather than blocking boot.
+    expect(result.workspace).toEqual(DEFAULT_WORKSPACE);
+  });
+});
+
+describe('workspace unknown future versions (MOR-1079)', () => {
+  it('forward-reads inside the N=2 window and never downgrades on writeback', () => {
+    const storage = new FakeStorage();
+    store(storage, { ...DEFAULT_WORKSPACE, version: 3, theme: 'nord', futureField: { a: 1 } });
+
+    const { result } = loadWorkspace(storage);
+    expect(result.outcome).toBe('forward-read');
+    expect(result.workspace.version).toBe(3);
+    expect(result.preserved).toEqual({ futureField: { a: 1 } });
+
+    const updated = applyWorkspacePatch(result, { density: 'compact' });
+    expect(persistWorkspace(storage, updated)).toBe(true);
+
+    const written = JSON.parse(storage.map.get(WORKSPACE_STORAGE_KEY)!) as Record<string, unknown>;
+    expect(written.version).toBe(3);
+    expect(written.futureField).toEqual({ a: 1 });
+    expect(written.density).toBe('compact');
+  });
+
+  it('refuses to write over a newer object it could not fully represent', () => {
+    const storage = new FakeStorage();
+    store(storage, { ...DEFAULT_WORKSPACE, version: 3, theme: 'v3-only-theme' });
+    const before = storage.map.get(WORKSPACE_STORAGE_KEY)!;
+
+    const { result, writable } = loadWorkspace(storage);
+    expect(result.outcome).toBe('forward-read');
+    expect(result.rejections).toContainEqual({ field: 'theme', reason: 'unknown-id' });
+    expect(canPersistWorkspace(result)).toBe(false);
+    expect(writable).toBe(false);
+
+    expect(persistWorkspace(storage, result)).toBe(false);
+    expect(storage.map.get(WORKSPACE_STORAGE_KEY)).toBe(before);
+  });
+
+  it('the unrepresentable verdict belongs to the LOAD — a patched result looks clean', () => {
+    const storage = new FakeStorage();
+    store(storage, { ...DEFAULT_WORKSPACE, version: 3, theme: 'v3-only-theme' });
+
+    const { result, writable } = loadWorkspace(storage);
+    const patched = applyWorkspacePatch(result, { density: 'compact' });
+
+    // The offending value was already repaired away, so re-deriving the verdict
+    // per update would re-enable the write and destroy the newer theme. This is
+    // exactly why `writable` is latched from the load by the store.
+    expect(canPersistWorkspace(patched)).toBe(true);
+    expect(writable).toBe(false);
+  });
+
+  it('a lossless forward read stays writable', () => {
+    const storage = new FakeStorage();
+    store(storage, { ...DEFAULT_WORKSPACE, version: 2, futureField: 7 });
+
+    const { result, writable } = loadWorkspace(storage);
+
+    expect(result.outcome).toBe('forward-read');
+    expect(writable).toBe(true);
+  });
+
+  it.each([0, 4, 99, 1.5, 'two', null])('discards an unreadable version: %s', (version) => {
+    const storage = new FakeStorage();
+    store(storage, { ...DEFAULT_WORKSPACE, version, theme: 'nord' });
+
+    const { result } = loadWorkspace(storage);
+
+    expect(result.outcome).toBe('version-discarded');
+    expect(result.workspace).toEqual(DEFAULT_WORKSPACE);
+    if (result.outcome === 'version-discarded') expect(result.discardedVersion).toBe(version);
+  });
+});
+
+describe('workspace write is atomic and single-key (MOR-1079)', () => {
+  it('serializes first, then writes exactly one key', () => {
+    const storage = new FakeStorage();
+
+    expect(persistWorkspace(storage, applyWorkspacePatch(loadWorkspace(storage).result, { theme: 'nord' }))).toBe(true);
+
+    expect(storage.writes).toEqual([WORKSPACE_STORAGE_KEY]);
+  });
+
+  it('a throwing setItem leaves the previous stored state byte-identical', () => {
+    const storage = new FakeStorage();
+    store(storage, V1);
+    const before = storage.map.get(WORKSPACE_STORAGE_KEY)!;
+    const { result } = loadWorkspace(storage);
+
+    storage.throwOnSet = true;
+    const next = applyWorkspacePatch(result, { theme: 'crt-green' });
+    expect(persistWorkspace(storage, next)).toBe(false);
+
+    expect(storage.map.get(WORKSPACE_STORAGE_KEY)).toBe(before);
+    // The in-memory result is still a usable, fully validated workspace.
+    expect(next.workspace.theme).toBe('crt-green');
+  });
+
+  it('the migration sentinel is only written after a successful workspace write', () => {
+    const storage = new FakeStorage();
+    seedLegacy(storage);
+    storage.throwOnSet = true;
+
+    const { result, source } = loadWorkspace(storage);
+    expect(source).toBe('migrated');
+    const wrote = persistWorkspace(storage, result);
+    if (wrote) markWorkspaceMigrated(storage);
+
+    expect(wrote).toBe(false);
+    expect(storage.getItem(WORKSPACE_MIGRATION_SENTINEL_KEY)).toBeNull();
+  });
+});
+
+describe('legacy data survives the compatibility window (MOR-1079)', () => {
+  it('migration + updates never delete or rewrite a legacy key', () => {
+    const storage = new FakeStorage();
+    seedLegacy(storage);
+    const legacyBefore = new Map(storage.map);
+
+    const { result } = loadWorkspace(storage);
+    persistWorkspace(storage, result);
+    markWorkspaceMigrated(storage);
+    let state = result;
+    for (const theme of ['nord', 'dracula', 'crt-green'] as const) {
+      state = applyWorkspacePatch(state, { theme });
+      persistWorkspace(storage, state);
+    }
+
+    expect(storage.deletes).toEqual([]);
+    expect(new Set(storage.writes)).toEqual(new Set([WORKSPACE_STORAGE_KEY, WORKSPACE_MIGRATION_SENTINEL_KEY]));
+    for (const [key, value] of legacyBefore) expect(storage.getItem(key)).toBe(value);
+  });
+});
+
+describe('every mutation goes through the validator (MOR-1079)', () => {
+  it('an invalid patch value falls back instead of being stored', () => {
+    const base = loadWorkspace(new FakeStorage()).result;
+
+    const patched = applyWorkspacePatch(base, { theme: 'not-a-theme', layout: 'nonsense' });
+
+    expect(patched.workspace.theme).toBe('default');
+    expect(patched.workspace.layout).toBe('auto');
+    expect(patched.rejections.map((r) => r.field).sort()).toEqual(['layout', 'theme']);
+  });
+
+  it('serializeWorkspace round-trips through readWorkspace unchanged', () => {
+    const base = applyWorkspacePatch(loadWorkspace(new FakeStorage()).result, { theme: 'nord', density: 'compact' });
+    const storage = new FakeStorage();
+    persistWorkspace(storage, base);
+
+    expect(loadWorkspace(storage).result.workspace).toEqual(base.workspace);
+    expect(JSON.parse(storage.map.get(WORKSPACE_STORAGE_KEY)!)).toEqual(serializeWorkspace(base));
+  });
+});
+
+// ── Source-scan gate: exactly one writer of the workspace key ───────────────
+// Textual tripwire in the MOR-1247 `stage-sizing-boundary` idiom, not a
+// security boundary: it catches the ordinary case (a module naming the key or
+// calling setItem with it), not a deliberately obfuscated one.
+const SRC_ROOT = 'src';
+const SOURCE_EXTENSIONS = new Set(['.ts', '.svelte']);
+
+function collectSourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...collectSourceFiles(full));
+    else if (SOURCE_EXTENSIONS.has(path.extname(entry.name))) out.push(full);
+  }
+  return out;
+}
+
+describe('the workspace key has exactly one writer in src/ (MOR-1079)', () => {
+  const production = collectSourceFiles(SRC_ROOT).filter((f) => !f.includes('__tests__') && !f.endsWith('.test.ts'));
+
+  it('no module outside repository.ts names the workspace storage keys', () => {
+    const offenders = production
+      .filter((file) => file !== path.join(SRC_ROOT, 'presentation', 'workspace', 'repository.ts'))
+      .filter((file) => {
+        const source = readFileSync(file, 'utf8');
+        return source.includes(WORKSPACE_STORAGE_KEY) || source.includes(WORKSPACE_MIGRATION_SENTINEL_KEY);
+      });
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('no module outside presentation/workspace/ calls setItem on a workspace key', () => {
+    const zone = path.join(SRC_ROOT, 'presentation', 'workspace') + path.sep;
+    const offenders = production
+      .filter((file) => !file.startsWith(zone))
+      .filter((file) => /setItem\s*\(\s*WORKSPACE_/.test(readFileSync(file, 'utf8')));
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/frontend/src/presentation/workspace/__tests__/store-purity.test.ts
+++ b/frontend/src/presentation/workspace/__tests__/store-purity.test.ts
@@ -1,0 +1,124 @@
+/**
+ * MOR-1079 module-load purity, in the MOR-1077 / MOR-1078 idiom: a load-time
+ * spy pin over the whole transitive closure (catches an import-time side
+ * effect no call-time assertion would see), plus the boundary pin that the
+ * store is the only module in the closure that touches storage at all.
+ *
+ * Unlike its two predecessors this module DOES write — it is the persistence
+ * boundary — so the pin is "not at import, only on an explicit init/action",
+ * not "never".
+ *
+ * Pool: `isolated` (MOR-1272) — `vi.stubGlobal` + `vi.resetModules()` are the
+ * order-dependent shapes under the fast pool's `isolate: false`; registered in
+ * `vite.config.ts` alongside the sibling workspace purity entries.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, join, normalize } from 'node:path';
+
+const ENTRY = 'src/presentation/workspace/store.svelte.ts';
+
+function code(path: string): string {
+  return readFileSync(path, 'utf8').replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
+function relativeImports(path: string): string[] {
+  const source = code(path);
+  return [...source.matchAll(/(?:from|import)\s*['"](\.[^'"]+)['"]/g)]
+    .map((m) => normalize(join(dirname(path), m[1].endsWith('.ts') ? m[1] : `${m[1]}.ts`)));
+}
+
+function closure(entry: string): string[] {
+  const seen = new Set<string>();
+  const queue = [entry];
+  while (queue.length > 0) {
+    const path = queue.shift()!;
+    if (seen.has(path)) continue;
+    seen.add(path);
+    queue.push(...relativeImports(path));
+  }
+  return [...seen];
+}
+
+const storage = { getItem: vi.fn(() => null), setItem: vi.fn(), removeItem: vi.fn(), clear: vi.fn(), key: vi.fn(() => null), length: 0 };
+const fetchSpy = vi.fn();
+const wsCtor = vi.fn();
+class SpyWebSocket { constructor(...args: unknown[]) { wsCtor(...args); } }
+
+function stubAll(): void {
+  vi.stubGlobal('localStorage', storage);
+  vi.stubGlobal('sessionStorage', storage);
+  vi.stubGlobal('fetch', fetchSpy);
+  vi.stubGlobal('WebSocket', SpyWebSocket);
+  for (const spy of [storage.getItem, storage.setItem, storage.removeItem, storage.clear, fetchSpy, wsCtor]) spy.mockClear();
+}
+
+describe('the workspace store is inert until it is initialised (MOR-1079)', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  it('importing the module touches no storage, network or socket', async () => {
+    stubAll();
+    vi.resetModules();
+
+    const module = await import('../store.svelte');
+
+    expect(typeof module.initWorkspaceStore).toBe('function');
+    expect(storage.getItem).not.toHaveBeenCalled();
+    expect(storage.setItem).not.toHaveBeenCalled();
+    expect(storage.removeItem).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(wsCtor).not.toHaveBeenCalled();
+  });
+
+  it('reading state before init still touches no storage', async () => {
+    stubAll();
+    vi.resetModules();
+    const { getWorkspace, getWorkspaceNotice } = await import('../store.svelte');
+
+    expect(getWorkspace().layout).toBe('auto');
+    expect(getWorkspaceNotice()).toBeNull();
+    expect(storage.getItem).not.toHaveBeenCalled();
+    expect(storage.setItem).not.toHaveBeenCalled();
+  });
+
+  it('an explicit init is what reaches the ambient localStorage, and it never deletes', async () => {
+    stubAll();
+    vi.resetModules();
+    const { initWorkspaceStore, setTheme } = await import('../store.svelte');
+
+    initWorkspaceStore();
+    setTheme('nord');
+
+    expect(storage.getItem).toHaveBeenCalled();
+    expect(storage.setItem).toHaveBeenCalled();
+    expect(storage.removeItem).not.toHaveBeenCalled();
+    expect(storage.clear).not.toHaveBeenCalled();
+    // Single-key writes only: the workspace key and its migration sentinel.
+    const keys = new Set(storage.setItem.mock.calls.map((c) => c[0] as string));
+    expect([...keys].sort()).toEqual(['rigplane:workspace', 'rigplane:workspace-migrated:v1']);
+  });
+
+  it('the closure is the store, the repository and the three pure contracts', () => {
+    expect(closure(ENTRY).sort()).toEqual([
+      'src/presentation/languages/contract.ts',
+      'src/presentation/layouts/contract.ts',
+      'src/presentation/workspace/contract.ts',
+      'src/presentation/workspace/legacy-readers.ts',
+      'src/presentation/workspace/repository.ts',
+      ENTRY,
+    ].sort());
+  });
+
+  it.each(closure(ENTRY))('%s imports no store, transport, audio, skin or component module', (path) => {
+    const source = code(path);
+    expect(source).not.toMatch(/from\s+['"]\$lib\//);
+    expect(source).not.toMatch(/from\s+['"][^'"]*(stores|transport|audio|skins|components-v2|semantic)\//);
+  });
+
+  it.each(closure(ENTRY).filter((p) => p !== ENTRY))('%s never names a browser storage global', (path) => {
+    expect(code(path)).not.toMatch(/\b(localStorage|sessionStorage|document|window)\b/);
+  });
+});

--- a/frontend/src/presentation/workspace/__tests__/store.test.ts
+++ b/frontend/src/presentation/workspace/__tests__/store.test.ts
@@ -1,0 +1,305 @@
+/**
+ * MOR-1079 — the Svelte-facing store: semantic actions, the visible-discard
+ * notice signal, and the storage behaviours as observed through the store
+ * rather than the repository.
+ *
+ * Storage is INJECTED (`initWorkspaceStore(fake)`), so no global is stubbed
+ * and this file stays in the fast pool. The module-load purity spy pin lives
+ * in the sibling `store-purity.test.ts`, which is registered in the isolated
+ * pool (MOR-1272).
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  WORKSPACE_MIGRATION_SENTINEL_KEY, WORKSPACE_STORAGE_KEY,
+} from '../repository';
+import { DEFAULT_WORKSPACE } from '../contract';
+import {
+  dismissWorkspaceNotice, getWorkspace, getWorkspaceNotice, initWorkspaceStore,
+  setDensity, setDesignLanguage, setLayout, setPinnedCommands, setTheme,
+  setZoneOrder, setZoneVisibleSurfaces,
+} from '../store.svelte';
+
+class FakeStorage {
+  readonly map = new Map<string, string>();
+  readonly deletes: string[] = [];
+  throwOnSet = false;
+
+  getItem(key: string): string | null {
+    return this.map.has(key) ? this.map.get(key)! : null;
+  }
+
+  setItem(key: string, value: string): void {
+    if (this.throwOnSet) throw new Error('QuotaExceededError');
+    this.map.set(key, value);
+  }
+
+  removeItem(key: string): void {
+    this.deletes.push(key);
+    this.map.delete(key);
+  }
+
+  clear(): void {
+    this.deletes.push('*');
+    this.map.clear();
+  }
+}
+
+function stored(storage: FakeStorage): Record<string, unknown> {
+  return JSON.parse(storage.map.get(WORKSPACE_STORAGE_KEY)!) as Record<string, unknown>;
+}
+
+let storage: FakeStorage;
+
+beforeEach(() => {
+  storage = new FakeStorage();
+});
+
+describe('workspace store boot (MOR-1079)', () => {
+  it('with no storage it stays on defaults and raises no notice', () => {
+    initWorkspaceStore(null);
+
+    expect(getWorkspace()).toEqual(DEFAULT_WORKSPACE);
+    expect(getWorkspaceNotice()).toBeNull();
+  });
+
+  it('migrates legacy keys once and marks the sentinel', () => {
+    storage.map.set('rigplane:theme-user-choice', 'tokyo-night');
+    storage.map.set('rigplane-layout', 'desktop-v2');
+
+    initWorkspaceStore(storage);
+
+    expect(getWorkspace().theme).toBe('tokyo-night');
+    expect(getWorkspace().layout).toBe('standard');
+    expect(storage.getItem(WORKSPACE_MIGRATION_SENTINEL_KEY)).toBe('1');
+    expect(stored(storage).theme).toBe('tokyo-night');
+  });
+
+  it('re-running init does not re-apply the migration over a later change', () => {
+    storage.map.set('rigplane:theme-user-choice', 'tokyo-night');
+    initWorkspaceStore(storage);
+    setTheme('nord');
+
+    initWorkspaceStore(storage);
+
+    expect(getWorkspace().theme).toBe('nord');
+    // The legacy key is untouched — still readable for a rollback.
+    expect(storage.getItem('rigplane:theme-user-choice')).toBe('tokyo-night');
+  });
+
+  it('reloads persisted state across a fresh init', () => {
+    initWorkspaceStore(storage);
+    setTheme('gruvbox-dark');
+    setLayout('lcd-scope');
+    setPinnedCommands(['set_compressor', 'set_compressor', 'toggle_vox']);
+
+    initWorkspaceStore(new FakeStorageFrom(storage));
+
+    expect(getWorkspace().theme).toBe('gruvbox-dark');
+    expect(getWorkspace().layout).toBe('lcd-scope');
+    expect(getWorkspace().pinnedCommands).toEqual(['set_compressor', 'toggle_vox']);
+  });
+
+  /**
+   * The sentinel-ordering pin, at STORE level — it drives the real
+   * `initWorkspaceStore`, because the ordering being pinned is a production
+   * line and a test that re-implements `if (wrote) markWorkspaceMigrated(...)`
+   * in its own body only verifies itself.
+   *
+   * It also needs a SIZE-SENSITIVE quota: a storage that throws on every
+   * `setItem` hides the bug, because the sentinel write fails too. Here the
+   * 1-byte sentinel fits and the larger workspace payload does not, which is
+   * the realistic quota shape. Write the sentinel first and run 2 comes back
+   * `auto`/`default` with the legacy keys still in storage but never read
+   * again — permanent, silent loss of the operator's layout and theme.
+   */
+  it('a failed migration write leaves no sentinel, so the next boot still recovers the legacy data', () => {
+    const quota = new LengthLimitedStorage(8);
+    quota.map.set('rigplane:theme-user-choice', 'nord');
+    quota.map.set('rigplane-layout', 'amber-lcd');
+
+    initWorkspaceStore(quota);
+
+    expect(quota.getItem(WORKSPACE_STORAGE_KEY)).toBeNull();
+    expect(quota.getItem(WORKSPACE_MIGRATION_SENTINEL_KEY)).toBeNull();
+
+    // Same storage, next boot: the migration must run again, not be skipped.
+    quota.limit = Number.MAX_SAFE_INTEGER;
+    initWorkspaceStore(quota);
+
+    expect(getWorkspace().layout).toBe('lcd-cockpit');
+    expect(getWorkspace().theme).toBe('nord');
+    expect(quota.getItem(WORKSPACE_MIGRATION_SENTINEL_KEY)).toBe('1');
+  });
+});
+
+/** A second storage instance holding the same bytes — a page reload, not a mutation. */
+class FakeStorageFrom extends FakeStorage {
+  constructor(source: FakeStorage) {
+    super();
+    for (const [k, v] of source.map) this.map.set(k, v);
+  }
+}
+
+/** Quota that depends on VALUE SIZE, not on the call: the short sentinel gets
+ *  through where the workspace payload does not. */
+class LengthLimitedStorage extends FakeStorage {
+  constructor(public limit: number) {
+    super();
+  }
+
+  override setItem(key: string, value: string): void {
+    if (value.length > this.limit) throw new Error('QuotaExceededError');
+    super.setItem(key, value);
+  }
+}
+
+describe('the discard signal is surfaced, never swallowed (MOR-1079)', () => {
+  it('publishes version-discarded with the offending version', () => {
+    storage.map.set(WORKSPACE_STORAGE_KEY, JSON.stringify({ ...DEFAULT_WORKSPACE, version: 9, theme: 'nord' }));
+
+    initWorkspaceStore(storage);
+
+    expect(getWorkspace()).toEqual(DEFAULT_WORKSPACE);
+    expect(getWorkspaceNotice()).toEqual({
+      kind: 'version-discarded', discardedVersion: 9, rejections: [{ field: 'version', reason: 'malformed' }],
+    });
+  });
+
+  it('does not overwrite the discarded bytes until the operator changes something', () => {
+    const raw = JSON.stringify({ ...DEFAULT_WORKSPACE, version: 9, theme: 'nord' });
+    storage.map.set(WORKSPACE_STORAGE_KEY, raw);
+
+    initWorkspaceStore(storage);
+
+    expect(storage.map.get(WORKSPACE_STORAGE_KEY)).toBe(raw);
+  });
+
+  it('publishes reset for unusable bytes and repaired for a partial recovery', () => {
+    storage.map.set(WORKSPACE_STORAGE_KEY, '{{{');
+    initWorkspaceStore(storage);
+    expect(getWorkspaceNotice()?.kind).toBe('reset');
+
+    const other = new FakeStorage();
+    other.map.set(WORKSPACE_STORAGE_KEY, JSON.stringify({ version: 1, theme: 'no-such-theme' }));
+    initWorkspaceStore(other);
+    expect(getWorkspaceNotice()?.kind).toBe('repaired');
+    expect(getWorkspaceNotice()?.rejections).toContainEqual({ field: 'theme', reason: 'unknown-id' });
+  });
+
+  it('is dismissable and does not come back on a clean update', () => {
+    storage.map.set(WORKSPACE_STORAGE_KEY, '{{{');
+    initWorkspaceStore(storage);
+    dismissWorkspaceNotice();
+
+    setTheme('nord');
+
+    expect(getWorkspaceNotice()).toBeNull();
+    expect(getWorkspace().theme).toBe('nord');
+  });
+
+  it('publishes persist-failed and keeps the in-memory state functional', () => {
+    initWorkspaceStore(storage);
+    setTheme('nord');
+    const before = storage.map.get(WORKSPACE_STORAGE_KEY)!;
+    storage.throwOnSet = true;
+
+    setTheme('crt-green');
+
+    expect(getWorkspaceNotice()?.kind).toBe('persist-failed');
+    expect(getWorkspace().theme).toBe('crt-green');
+    expect(storage.map.get(WORKSPACE_STORAGE_KEY)).toBe(before);
+    // Still usable after the failure.
+    storage.throwOnSet = false;
+    setLayout('sdr-test');
+    expect(getWorkspace().layout).toBe('sdr-test');
+    expect(stored(storage).layout).toBe('sdr-test');
+  });
+});
+
+describe('forward-read objects are never downgraded (MOR-1079)', () => {
+  it('keeps the newer version and its unknown fields across an unrelated update', () => {
+    storage.map.set(WORKSPACE_STORAGE_KEY, JSON.stringify({
+      ...DEFAULT_WORKSPACE, version: 3, theme: 'nord', futurePanelBudget: { rows: 4 },
+    }));
+    initWorkspaceStore(storage);
+
+    setDensity('compact');
+
+    expect(stored(storage).version).toBe(3);
+    expect(stored(storage).futurePanelBudget).toEqual({ rows: 4 });
+    expect(stored(storage).density).toBe('compact');
+    expect(stored(storage).theme).toBe('nord');
+  });
+
+  it('refuses to write at all when the newer object was only partly representable', () => {
+    const raw = JSON.stringify({ ...DEFAULT_WORKSPACE, version: 3, theme: 'v3-only-theme' });
+    storage.map.set(WORKSPACE_STORAGE_KEY, raw);
+    initWorkspaceStore(storage);
+    expect(getWorkspaceNotice()?.kind).toBe('forward-read-only');
+
+    setDensity('compact');
+
+    expect(storage.map.get(WORKSPACE_STORAGE_KEY)).toBe(raw);
+    expect(getWorkspaceNotice()?.kind).toBe('forward-read-only');
+  });
+});
+
+describe('semantic actions go through the validator (MOR-1079)', () => {
+  beforeEach(() => {
+    initWorkspaceStore(storage);
+  });
+
+  it('applies each typed field', () => {
+    setLayout('lcd-cockpit');
+    setDesignLanguage('fieldline');
+    setTheme('lcd-warm');
+    setZoneVisibleSurfaces('rx-tx', ['rxTx']);
+    setZoneOrder('main', ['vfo', 'meters']);
+    setPinnedCommands(['set_compressor']);
+
+    expect(getWorkspace()).toMatchObject({
+      layout: 'lcd-cockpit', designLanguage: 'fieldline', theme: 'lcd-warm',
+      visibleSurfaces: { 'rx-tx': ['rxTx'] }, zoneOrder: { main: ['vfo', 'meters'] },
+      pinnedCommands: ['set_compressor'],
+    });
+    expect(stored(storage).theme).toBe('lcd-warm');
+  });
+
+  it('re-clamps density when the design language changes under it', () => {
+    setDensity('dense');
+    expect(getWorkspace().density).toBe('dense');
+
+    setDesignLanguage('fieldline');
+
+    expect(getWorkspace().density).toBe('comfortable');
+    expect(getWorkspaceNotice()).toEqual({
+      kind: 'repaired', rejections: [{ field: 'density', reason: 'out-of-clamp' }],
+    });
+    expect(stored(storage).density).toBe('comfortable');
+  });
+
+  it('rejects a cross-zone duplicate rather than persisting it', () => {
+    setZoneOrder('main', ['vfo']);
+    setZoneOrder('rx-tx', ['vfo']);
+
+    expect(getWorkspace().zoneOrder).toEqual({ main: ['vfo'], 'rx-tx': [] });
+    expect(getWorkspaceNotice()?.rejections).toContainEqual({ field: 'zoneOrder.rx-tx', reason: 'cross-zone' });
+  });
+
+  it('drops a forbidden pinned command instead of storing it', () => {
+    setPinnedCommands(['set_compressor', 'tx_power_limit']);
+
+    expect(getWorkspace().pinnedCommands).toEqual(['set_compressor']);
+    expect(stored(storage).pinnedCommands).toEqual(['set_compressor']);
+  });
+
+  it('never deletes a legacy key across a long update sequence', () => {
+    storage.map.set('rigplane:theme', 'dracula');
+    storage.map.set('rigplane-layout', 'amber-lcd');
+    for (const theme of ['nord', 'ayu-dark', 'crt-green'] as const) setTheme(theme);
+
+    expect(storage.deletes).toEqual([]);
+    expect(storage.getItem('rigplane:theme')).toBe('dracula');
+    expect(storage.getItem('rigplane-layout')).toBe('amber-lcd');
+  });
+});

--- a/frontend/src/presentation/workspace/repository.ts
+++ b/frontend/src/presentation/workspace/repository.ts
@@ -1,0 +1,126 @@
+/**
+ * MOR-1079 — the workspace persistence boundary, as pure functions.
+ *
+ * Storage contact is confined to this module and every read is routed through
+ * MOR-1077's `readWorkspace` / MOR-1078's `readLegacyWorkspace` — there is no
+ * path here that constructs a `WorkspaceV1` any other way. The Svelte-facing
+ * store (`store.svelte.ts`) owns reactivity and the semantic actions; this
+ * file owns the bytes.
+ *
+ * Three rules the tests pin:
+ *  - ONE key. `persistWorkspace` serializes first and then does a single
+ *    `setItem`, so a throwing storage (quota) leaves the previous stored
+ *    value byte-for-byte intact — there is no partial multi-key write.
+ *  - Legacy keys are NEVER written or deleted. The type is
+ *    `getItem`+`setItem` only, and the migration reads legacy data through
+ *    `readLegacyWorkspaceFromStorage`, whose own parameter type is
+ *    `getItem`-only. The rollback window stays readable.
+ *  - Migration runs ONCE, decided by a versioned sentinel key rather than by
+ *    "is the workspace key empty" — clearing the workspace key must not
+ *    resurrect a legacy layout the operator has since changed.
+ */
+import {
+  WORKSPACE_SCHEMA_VERSION, readWorkspace, readWorkspaceJson, serializeWorkspace,
+  type WorkspaceReadResult,
+} from './contract';
+import { readLegacyWorkspaceFromStorage } from './legacy-readers';
+
+/** Unversioned on purpose: the schema version lives INSIDE the object, so a
+ *  newer build writes its own version to this same key and an older build can
+ *  still forward-read it (contract N=2 window). */
+export const WORKSPACE_STORAGE_KEY = 'rigplane:workspace';
+/** Versioned on purpose: it records WHICH migration generation already ran. */
+export const WORKSPACE_MIGRATION_SENTINEL_KEY = 'rigplane:workspace-migrated:v1';
+
+/** No `removeItem`/`clear`: deleting anything would not type-check. */
+export type WorkspaceStorage = Pick<Storage, 'getItem' | 'setItem'>;
+
+/** `stored` = the workspace key was present. `migrated` = first run, legacy data
+ *  folded in. `absent` = already migrated, nothing stored (a cleared key, not a
+ *  discard — the store must not raise a "settings lost" notice for it). */
+export type WorkspaceLoadSource = 'stored' | 'migrated' | 'absent';
+export interface WorkspaceLoad {
+  readonly result: WorkspaceReadResult;
+  readonly source: WorkspaceLoadSource;
+  /** `false` = a newer stored object this build could not fully represent. The
+   *  verdict belongs to the LOAD and must be latched for the session: once the
+   *  unrepresentable value has been repaired away, a patched result validates
+   *  cleanly and would silently overwrite the newer data. */
+  readonly writable: boolean;
+}
+
+const EMPTY_WORKSPACE_JSON = JSON.stringify({ version: WORKSPACE_SCHEMA_VERSION });
+
+function readKey(storage: WorkspaceStorage, key: string): string | null {
+  try {
+    return storage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+/** Total: every storage state yields a validated result, nothing throws. */
+export function loadWorkspace(storage: WorkspaceStorage): WorkspaceLoad {
+  const stored = readKey(storage, WORKSPACE_STORAGE_KEY);
+  const load = stored !== null
+    ? { result: readWorkspaceJson(stored), source: 'stored' as const }
+    : readKey(storage, WORKSPACE_MIGRATION_SENTINEL_KEY) !== null
+      ? { result: readWorkspaceJson(EMPTY_WORKSPACE_JSON), source: 'absent' as const }
+      : { result: readLegacyWorkspaceFromStorage(storage), source: 'migrated' as const };
+  return { ...load, writable: canPersistWorkspace(load.result) };
+}
+
+/**
+ * Forward-write policy (MOR-1076 N=2). `contract.ts` keeps `version` as read
+ * and preserves unknown top-level fields verbatim, so writing a forward-read
+ * object back is explicitly supported and does NOT downgrade it. What the
+ * contract canNOT preserve is an unknown VALUE in a KNOWN field (a v2 theme
+ * id repairs to `default`), and those rejections are exactly what a lossy
+ * forward read reports. So: write back an un-downgraded forward read when it
+ * was lossless, and refuse to write at all when it was not — an older build
+ * never overwrites newer data it could not fully represent.
+ */
+export function canPersistWorkspace(result: WorkspaceReadResult): boolean {
+  return result.outcome !== 'forward-read' || result.rejections.length === 0;
+}
+
+/** Atomic: serialize fully, then one `setItem`. `false` = nothing was written.
+ *  The `canPersistWorkspace` re-check below is belt-and-braces for a direct
+ *  caller — it is NOT the protection. Re-derived from a PATCHED result it
+ *  always says "writable", because the unrepresentable value has been repaired
+ *  away by then; the real gate is the `blocked` latch in `store.svelte.ts`,
+ *  which holds the verdict from the LOAD. */
+export function persistWorkspace(storage: WorkspaceStorage, result: WorkspaceReadResult): boolean {
+  if (!canPersistWorkspace(result)) return false;
+  let payload: string;
+  try {
+    payload = JSON.stringify(serializeWorkspace(result));
+  } catch {
+    return false;
+  }
+  try {
+    storage.setItem(WORKSPACE_STORAGE_KEY, payload);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Written only AFTER a successful workspace write, so a failed migration retries. */
+export function markWorkspaceMigrated(storage: WorkspaceStorage): boolean {
+  try {
+    storage.setItem(WORKSPACE_MIGRATION_SENTINEL_KEY, String(WORKSPACE_SCHEMA_VERSION));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** The only mutation path: re-validate the whole object, never mutate in place.
+ *  Unknown preserved fields survive because `serializeWorkspace` re-emits them. */
+export function applyWorkspacePatch(
+  current: WorkspaceReadResult,
+  patch: Readonly<Record<string, unknown>>,
+): WorkspaceReadResult {
+  return readWorkspace({ ...serializeWorkspace(current), ...patch });
+}

--- a/frontend/src/presentation/workspace/store.svelte.ts
+++ b/frontend/src/presentation/workspace/store.svelte.ts
@@ -1,0 +1,154 @@
+/**
+ * MOR-1079 — the single workspace store.
+ *
+ * Svelte 5 runes over the pure `repository.ts` layer, in the module-level
+ * `$state` + exported accessors idiom the `lib/stores/*` modules already use.
+ * Module load is PURE (MOR-1077 idiom): storage is touched only by an explicit
+ * `initWorkspaceStore()` call, never at import.
+ *
+ * The notice is the "visible discard" signal the owner asked for: when a
+ * stored object is discarded on version mismatch, or repaired, or could not be
+ * written, that fact is published reactively instead of being swallowed. The
+ * future settings UI (MOR-1080) reads `getWorkspaceNotice()` from a `$derived`
+ * and calls `dismissWorkspaceNotice()`.
+ *
+ * Updates are semantic and typed. There is deliberately no raw-object setter:
+ * every mutation goes through `applyWorkspacePatch`, i.e. through
+ * `readWorkspace`, so an invalid value can never reach state or storage.
+ */
+import { DEFAULT_WORKSPACE, readWorkspace } from './contract';
+import {
+  applyWorkspacePatch, loadWorkspace, markWorkspaceMigrated, persistWorkspace,
+  type WorkspaceStorage,
+} from './repository';
+import type {
+  WorkspaceDesignLanguageId, WorkspaceLayoutId, WorkspaceReadResult, WorkspaceRejection,
+  WorkspaceThemeId, WorkspaceV1, WorkspaceZoneId,
+} from './contract';
+import type { SemanticSurfaceName } from '../layouts/contract';
+import type { DensityLevel } from '../languages/contract';
+
+export type WorkspaceNoticeKind =
+  /** A stored object outside the readable version window was NOT recovered. */
+  | 'version-discarded'
+  /** Stored bytes were unusable (not an object / bad JSON) and reset to defaults. */
+  | 'reset'
+  /** Recovered, but individual fields fell back — the operator lost those. */
+  | 'repaired'
+  /** A newer stored object this build cannot fully represent; writes are refused. */
+  | 'forward-read-only'
+  /** The last write failed (quota, private mode); the previous stored state stands. */
+  | 'persist-failed';
+
+export interface WorkspaceNotice {
+  readonly kind: WorkspaceNoticeKind;
+  readonly discardedVersion?: unknown;
+  readonly rejections: readonly WorkspaceRejection[];
+}
+
+const INITIAL: WorkspaceReadResult = readWorkspace(DEFAULT_WORKSPACE);
+
+let current = $state<WorkspaceReadResult>(INITIAL);
+let notice = $state<WorkspaceNotice | null>(null);
+let backing: WorkspaceStorage | null = null;
+/** Set at init when the load was NOT writable (see `WorkspaceLoad.writable`),
+ *  and never re-derived per update: once the unrepresentable value has been
+ *  repaired away a patched result validates cleanly, so re-deriving would
+ *  re-enable the write and destroy the newer data. */
+let blocked: WorkspaceNotice | null = null;
+
+function defaultStorage(): WorkspaceStorage | null {
+  try {
+    return typeof localStorage === 'undefined' ? null : localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function noticeFor(result: WorkspaceReadResult): WorkspaceNotice | null {
+  if (result.outcome === 'version-discarded') {
+    return { kind: 'version-discarded', discardedVersion: result.discardedVersion, rejections: result.rejections };
+  }
+  if (result.outcome === 'reset') return { kind: 'reset', rejections: result.rejections };
+  if (result.outcome === 'forward-read' && result.rejections.length > 0) {
+    return { kind: 'forward-read-only', rejections: result.rejections };
+  }
+  if (result.rejections.length > 0) return { kind: 'repaired', rejections: result.rejections };
+  return null;
+}
+
+/**
+ * Explicit, idempotent boot step. Migration is decided by the repository's
+ * sentinel, so calling this twice re-reads the stored object and never
+ * re-applies legacy data.
+ */
+export function initWorkspaceStore(storage: WorkspaceStorage | null = defaultStorage()): void {
+  backing = storage;
+  blocked = null;
+  if (storage === null) {
+    current = INITIAL;
+    notice = null;
+    return;
+  }
+  const load = loadWorkspace(storage);
+  current = load.result;
+  notice = noticeFor(load.result);
+  blocked = load.writable ? null : notice;
+  if (load.source === 'migrated' && persistWorkspace(storage, load.result)) markWorkspaceMigrated(storage);
+}
+
+export function getWorkspace(): WorkspaceV1 {
+  return current.workspace;
+}
+
+/** The discard/repair/write-failure signal. Reactive: read it from `$derived`. */
+export function getWorkspaceNotice(): WorkspaceNotice | null {
+  return notice;
+}
+
+export function dismissWorkspaceNotice(): void {
+  notice = null;
+}
+
+function update(patch: Readonly<Record<string, unknown>>): void {
+  const next = applyWorkspacePatch(current, patch);
+  current = next;
+  const published = noticeFor(next);
+  if (published !== null) notice = published;
+  if (backing === null) return;
+  if (blocked !== null) {
+    notice = blocked;
+    return;
+  }
+  if (!persistWorkspace(backing, next)) {
+    notice = published ?? { kind: 'persist-failed', rejections: next.rejections };
+  }
+}
+
+export function setLayout(layout: WorkspaceLayoutId): void {
+  update({ layout });
+}
+
+export function setDesignLanguage(designLanguage: WorkspaceDesignLanguageId): void {
+  update({ designLanguage });
+}
+
+export function setTheme(theme: WorkspaceThemeId): void {
+  update({ theme });
+}
+
+export function setDensity(density: DensityLevel): void {
+  update({ density });
+}
+
+export function setZoneVisibleSurfaces(zone: WorkspaceZoneId, surfaces: readonly SemanticSurfaceName[]): void {
+  update({ visibleSurfaces: { ...current.workspace.visibleSurfaces, [zone]: surfaces } });
+}
+
+export function setZoneOrder(zone: WorkspaceZoneId, surfaces: readonly SemanticSurfaceName[]): void {
+  update({ zoneOrder: { ...current.workspace.zoneOrder, [zone]: surfaces } });
+}
+
+export function setPinnedCommands(pinnedCommands: readonly string[]): void {
+  update({ pinnedCommands });
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -112,6 +112,11 @@ export default defineConfig({
             // fetch/WebSocket plus ``vi.resetModules()`` around a fresh
             // dynamic import of the legacy workspace readers. See MOR-1272.
             'src/presentation/workspace/__tests__/legacy-readers-purity.test.ts',
+            // MOR-1079, same class a third time: ``vi.stubGlobal`` on
+            // localStorage/fetch/WebSocket plus ``vi.resetModules()`` around a
+            // fresh dynamic import of the workspace store, whose module-scope
+            // ``$state`` would otherwise be shared across files. See MOR-1272.
+            'src/presentation/workspace/__tests__/store-purity.test.ts',
             'src/components-v2/wiring/__tests__/keyboard-wiring.test.ts',
             'src/components-v2/wiring/__tests__/vfo-wiring.test.ts',
             'src/components-v2/wiring/__tests__/dsp-nr-level.test.ts',
@@ -218,6 +223,7 @@ export default defineConfig({
             'src/lib/runtime/adapters/__tests__/filter-passband-adapter.test.ts',
             'src/presentation/workspace/__tests__/purity.test.ts',
             'src/presentation/workspace/__tests__/legacy-readers-purity.test.ts',
+            'src/presentation/workspace/__tests__/store-purity.test.ts',
             'src/components-v2/wiring/__tests__/keyboard-wiring.test.ts',
             'src/components-v2/wiring/__tests__/vfo-wiring.test.ts',
             'src/components-v2/wiring/__tests__/dsp-nr-level.test.ts',


### PR DESCRIPTION
## Summary
The workspace chain's persistence layer: `repository.ts` (pure load/persist/sentinel/patch) + `store.svelte.ts` (runes store, 7 typed semantic setters — no raw-object escape hatch). Key `rigplane:workspace` (version lives in the object so newer builds share the key); migration runs ONCE behind a sentinel written only AFTER a successful workspace write — a quota failure leaves no sentinel, so the next boot still recovers legacy data (pinned against a size-sensitive quota fake; a throw-on-every-write fake provably hides this bug class). Net production LOC **168** code (281 raw; verifier re-measured).

**Forward-read hybrid (verifier-adjudicated against the MOR-1076 freeze):** lossless newer-version reads write back un-downgraded (version + `preserved` intact); a LOSSY forward read (unknown VALUE in a KNOWN field — which `preserved` structurally cannot carry) latches at load and refuses all writes for the session with a surfaced `forward-read-only` notice. Ruling: the freeze's N=2 clause is a READ guarantee and is silent on this case; loss asymmetry decides — refusing loses only the older build's new preference (recoverably, with a notice), writing would destroy the newer build's choice unrecoverably. The latch belongs to the LOAD: re-deriving per update self-re-enables writes after repair (the builder caught this in their own first cut; regression-pinned).

Atomic single-key write with quota fallback; legacy keys never deleted (rollback window, `deletes == []` pinned); single-writer source-scan gate covers workspace AND sentinel keys; module-load purity. Nothing calls `initWorkspaceStore` yet — adoption is 1080/1081/1082.

## Review provenance
Opus builder → independent opus contracts-domain verifier (10th ticket in domain): **PASS** + one required fix + delta. Kills: latch removal, write-then-validate reorder, validator bypass (4), module-load storage contact (3), single-writer plants incl. a sentinel-key write from outside the module. Round-1 gap: the sentinel-ordering test re-implemented the guard in its own test body (M3 survived) — replaced with a store-level pin driving the REAL init against `LengthLimitedStorage`; M3 delta-confirmed red with sha-verified restore. Forward-read probes: lossless writeback preserves version+fields; lossy → zero write attempts, stored bytes byte-unchanged. Fail-set identical to baseline; lint/boundaries/check clean. Carry-forwards recorded: MOR-1080 (notice should say what would be lost + operator override), MOR-1081 (dual layout-key ownership + one-time reconciliation).

Linear: MOR-1079

🤖 Generated with [Claude Code](https://claude.com/claude-code)