### PR TITLE
feat(MOR-1292): rfFrontEnd fact group (vocabulary slice 6A)

### DIFF
--- a/frontend/src/lib/runtime/adapters/__tests__/rf-front-end-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/rf-front-end-adapter.test.ts
@@ -1,0 +1,247 @@
+/**
+ * MOR-1262 decomposition slice 6A (MOR-1292) — `rfFrontEnd` fact-group
+ * adapter derivation.
+ *
+ * Companion to `dsp-adapter.test.ts` (MOR-1290), which this file does NOT
+ * modify. `rfFrontEnd` is a SEPARATE optional group — see
+ * `radio-view-model.ts`'s `RfFrontEndViewModel` doc comment.
+ *
+ * Unlike `dsp`'s `nrLevel`/`nbDepth`, none of this group's four facts
+ * (preamp/attenuator/rfGain/squelch) consume a capabilities-STORE-backed
+ * scale conversion — they are plain pass-through readings (see
+ * `deriveRfFrontEnd`'s doc comment) — so this file never calls the real
+ * `setCapabilities` and does not need the isolated pool (MOR-1272; contrast
+ * `dsp-adapter.test.ts`'s own file-level doc comment on that point).
+ */
+import { describe, expect, it } from 'vitest';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { FieldStatus, ServerState } from '$lib/types/state';
+import { validateRadioViewModel, type RadioViewModel } from '../../../../semantic/radio-view-model';
+import { toRadioViewModel } from '../radio-view-model-adapter';
+
+function caps(overrides: Partial<Capabilities> = {}): Capabilities {
+  return {
+    model: 'fixture', scope: true, audio: true, tx: true, capabilities: ['scope', 'audio', 'tx'],
+    receivers: 1, vfoScheme: 'single', freqRanges: [], modes: [], filters: [],
+    audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
+    webrtc: { available: false, enabled: false },
+    txBands: [], scopeSource: 'hardware', audioFftAvailable: false, ...overrides,
+  } as Capabilities;
+}
+
+const fresh: FieldStatus = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' };
+const stale: FieldStatus = { storePath: 'x', observed: true, freshness: 'stale', availability: 'stale' };
+
+/** The exact shape `dsp-adapter.test.ts`'s own baseline uses. */
+function bareState(overrides: Partial<ServerState> = {}): ServerState {
+  return {
+    active: 'MAIN', split: false, dualWatch: false, ptt: false,
+    txTarget: { status: 'known', receiver: 'MAIN', slot: null, frequencyHz: 14195000 },
+    main: {
+      freqHz: 14195000, mode: 'USB', filter: 1, dataMode: 0, att: 0, preamp: 0,
+      nb: false, nr: false, afLevel: 1, rfGain: 1, squelch: 0, sMeter: 0,
+    },
+    sub: {
+      freqHz: 7100000, mode: 'LSB', filter: 2, dataMode: 0, att: 0, preamp: 0,
+      nb: false, nr: false, afLevel: 1, rfGain: 1, squelch: 0, sMeter: 0,
+    },
+    fieldStatus: {
+      active: fresh, split: fresh, dualWatch: fresh, txTarget: fresh,
+      'main.freqHz': fresh, 'main.mode': fresh, 'main.filter': fresh,
+    },
+    ...overrides,
+  } as ServerState;
+}
+
+function model(state: ServerState | null, capabilities: Capabilities | null): RadioViewModel {
+  const view = toRadioViewModel(state, capabilities);
+  expect(view).not.toBeNull();
+  return validateRadioViewModel(view);
+}
+
+describe('rfFrontEnd evidence gate (MOR-1292, N3)', () => {
+  it('emits no rfFrontEnd when capabilities are absent', () => {
+    expect(toRadioViewModel(bareState(), null)).toBeNull();
+  });
+
+  it('emits no rfFrontEnd for a baseline radio with no preamp/attenuator/rf_gain/squelch capability (regression pin)', () => {
+    const view = model(bareState(), caps());
+    expect(view.rfFrontEnd).toBeUndefined();
+    expect(Object.keys(view)).not.toContain('rfFrontEnd');
+  });
+
+  it('emits rfFrontEnd once the preamp capability alone is declared', () => {
+    const view = model(bareState(), caps({ capabilities: ['preamp'] }));
+    expect(view.rfFrontEnd).toBeDefined();
+  });
+
+  it('emits rfFrontEnd once the attenuator capability alone is declared', () => {
+    const view = model(bareState(), caps({ capabilities: ['attenuator'] }));
+    expect(view.rfFrontEnd).toBeDefined();
+  });
+
+  it('emits rfFrontEnd once the rf_gain capability alone is declared', () => {
+    const view = model(bareState(), caps({ capabilities: ['rf_gain'] }));
+    expect(view.rfFrontEnd).toBeDefined();
+  });
+
+  it('emits rfFrontEnd once the squelch capability alone is declared', () => {
+    const view = model(bareState(), caps({ capabilities: ['squelch'] }));
+    expect(view.rfFrontEnd).toBeDefined();
+  });
+});
+
+describe('rfFrontEnd per-field structural gates (MOR-1292)', () => {
+  it('preamp is structurally absent without the preamp capability, even with squelch present', () => {
+    const view = model(bareState(), caps({ capabilities: ['squelch'] }));
+    expect(view.rfFrontEnd!.preamp.availability.structural).toBe(false);
+    expect(view.rfFrontEnd!.squelch.availability.structural).toBe(true);
+  });
+
+  it('attenuator is structurally absent without the attenuator capability, even with preamp present', () => {
+    const view = model(bareState(), caps({ capabilities: ['preamp'] }));
+    expect(view.rfFrontEnd!.attenuator.availability.structural).toBe(false);
+  });
+
+  it('rfGain is structurally absent without the rf_gain capability, even with attenuator present', () => {
+    const view = model(bareState(), caps({ capabilities: ['attenuator'] }));
+    expect(view.rfFrontEnd!.rfGain.availability.structural).toBe(false);
+  });
+
+  it('squelch is structurally absent without the squelch capability, even with rf_gain present', () => {
+    const view = model(bareState(), caps({ capabilities: ['rf_gain'] }));
+    expect(view.rfFrontEnd!.squelch.availability.structural).toBe(false);
+  });
+
+  it('follows the SUB receiver once it is the active one', () => {
+    const view = model(bareState({
+      active: 'SUB',
+      sub: { ...bareState().sub, preamp: 2 },
+      fieldStatus: { ...bareState().fieldStatus, 'sub.preamp': fresh },
+    }), caps({ capabilities: ['preamp'] }));
+    expect(view.rfFrontEnd!.preamp.reading).toEqual({ status: 'known', value: 2 });
+  });
+});
+
+describe('rfFrontEnd per-field derivation (MOR-1292)', () => {
+  const fullCaps = caps({
+    capabilities: ['preamp', 'attenuator', 'rf_gain', 'squelch'],
+    preValues: [0, 1, 2], attValues: [0, 6, 12, 18],
+  });
+
+  it('reports known readings for observed, fresh, capability-backed fields', () => {
+    const view = model(bareState({
+      main: { ...bareState().main, preamp: 2, att: 12, rfGain: 0.8, squelch: 0.25 },
+      fieldStatus: {
+        ...bareState().fieldStatus,
+        'main.preamp': fresh, 'main.att': fresh, 'main.rfGain': fresh, 'main.squelch': fresh,
+      },
+    }), fullCaps);
+    const rfFrontEnd = view.rfFrontEnd!;
+    expect(rfFrontEnd.preamp).toEqual(
+      { reading: { status: 'known', value: 2 }, availability: { structural: true, operational: true } },
+    );
+    expect(rfFrontEnd.attenuator.reading).toEqual({ status: 'known', value: 12 });
+    expect(rfFrontEnd.rfGain.reading).toEqual({ status: 'known', value: 0.8 });
+    expect(rfFrontEnd.squelch.reading).toEqual({ status: 'known', value: 0.25 });
+  });
+
+  // Verifier finding (MOR-1292 re-verify): the single-field version of this
+  // pin (`att` only) let mutant G1 (loosening the `rfGain` freshness gate)
+  // survive — 35/35 green. One row per field closes that: each of the four
+  // controls has its OWN `topFieldAvailable(...)` call site in `deriveRfFrontEnd`,
+  // and only a table covering all four proves every one of them is wired to
+  // the strict gate, not just `att`'s.
+  const STALE_FIELDS: ReadonlyArray<readonly [
+    rawField: 'preamp' | 'att' | 'rfGain' | 'squelch',
+    viewField: 'preamp' | 'attenuator' | 'rfGain' | 'squelch',
+    value: number,
+  ]> = [
+    ['preamp', 'preamp', 2],
+    ['att', 'attenuator', 18],
+    ['rfGain', 'rfGain', 0.5],
+    ['squelch', 'squelch', 0.5],
+  ];
+
+  it.each(STALE_FIELDS)(
+    'degrades a stale %s field to unknown while keeping structural availability true',
+    (rawField, viewField, value) => {
+      const main = { ...bareState().main, [rawField]: value } as unknown as ServerState['main'];
+      const view = model(bareState({
+        main,
+        fieldStatus: { ...bareState().fieldStatus, [`main.${rawField}`]: stale },
+      }), fullCaps);
+      expect(view.rfFrontEnd![viewField]).toEqual({
+        reading: { status: 'unknown' }, availability: { structural: true, operational: false },
+      });
+    },
+  );
+
+  it('marks a control structurally absent when its capability tag is missing, never known', () => {
+    const view = model(bareState({
+      main: { ...bareState().main, preamp: 2 },
+      fieldStatus: { ...bareState().fieldStatus, 'main.preamp': fresh },
+    }), caps({ capabilities: ['squelch'] }));
+    // preamp capability absent — must never surface a "known" reading even
+    // though the (irrelevant) field status looks fresh and a value exists.
+    expect(view.rfFrontEnd!.preamp).toEqual({
+      reading: { status: 'unknown' }, availability: { structural: false, operational: false },
+    });
+  });
+
+  it('degrades a malformed raw value (wrong JS type) to unknown rather than throwing or coercing', () => {
+    const view = model(bareState({
+      main: { ...bareState().main, rfGain: 'high' as unknown as number },
+      fieldStatus: { ...bareState().fieldStatus, 'main.rfGain': fresh },
+    }), fullCaps);
+    expect(view.rfFrontEnd!.rfGain.reading).toEqual({ status: 'unknown' });
+  });
+
+  it('emits a validator-clean model carrying the rfFrontEnd group (round-trip proof)', () => {
+    const view = model(bareState({
+      main: { ...bareState().main, preamp: 1, att: 6 },
+      fieldStatus: { ...bareState().fieldStatus, 'main.preamp': fresh, 'main.att': fresh },
+    }), fullCaps);
+    expect(JSON.parse(JSON.stringify(view))).toEqual(view);
+  });
+});
+
+describe('preValues/attValues choice sets (MOR-1292)', () => {
+  it('reports the capability-declared choice sets verbatim', () => {
+    const view = model(bareState(), caps({ capabilities: ['preamp', 'attenuator'], preValues: [0, 1, 2], attValues: [0, 20] }));
+    expect(view.rfFrontEnd!.preValues).toEqual([0, 1, 2]);
+    expect(view.rfFrontEnd!.attValues).toEqual([0, 20]);
+  });
+
+  it('defaults to an empty array — never the shipped panel\'s [0,1,2]/[0,6,12,18] fallback — when caps declares none', () => {
+    const view = model(bareState(), caps({ capabilities: ['preamp', 'attenuator'] }));
+    expect(view.rfFrontEnd!.preValues).toEqual([]);
+    expect(view.rfFrontEnd!.attValues).toEqual([]);
+  });
+});
+
+/**
+ * HONESTY GATE (MOR-1292, mirroring the DSP F2/mutant-H3 lesson,
+ * `dsp-adapter.test.ts`). Each of the four numeric fields is read via
+ * `numOrUndef(raw)` with no `?? 0` — pin that a mutant seeding one WOULD be
+ * caught: the field absent from the receiver object entirely, no
+ * `fieldStatus` entry either, so the ONLY thing standing between an honest
+ * `unknown` and a fabricated `{status: 'known', value: 0}` is `numOrUndef`
+ * gating on the raw value itself.
+ */
+describe('rfFrontEnd honesty gate — absent raw values never fabricate (MOR-1292, mutant H3 lineage)', () => {
+  const allCaps = caps({ capabilities: ['preamp', 'attenuator', 'rf_gain', 'squelch'] });
+  const RECEIVER_SCOPED_FIELDS = ['preamp', 'att', 'rfGain', 'squelch'] as const;
+  const VIEW_FIELD_NAME = { preamp: 'preamp', att: 'attenuator', rfGain: 'rfGain', squelch: 'squelch' } as const;
+
+  it.each(RECEIVER_SCOPED_FIELDS)(
+    '%s: absent from the receiver object (no fieldStatus entry) reads unknown, not {known, 0}',
+    (field) => {
+      const main = { ...bareState().main } as Record<string, unknown>;
+      delete main[field];
+      const view = model(bareState({ main: main as unknown as ServerState['main'] }), allCaps);
+      const viewField = VIEW_FIELD_NAME[field];
+      expect(view.rfFrontEnd![viewField].reading).toEqual({ status: 'unknown' });
+    },
+  );
+});

--- a/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
@@ -29,7 +29,7 @@ import type {
   RadioViewModel, TxAuxField, TxAuxViewModel, AtuStatus,
   MeterField, MeterRfState, MetersViewModel,
   AudioFocus, MonitorMode, RxAudioViewModel, ModeFilterViewModel,
-  FilterPassbandViewModel, DspViewModel,
+  FilterPassbandViewModel, DspViewModel, RfFrontEndViewModel,
 } from '../../../semantic/radio-view-model';
 import type { TxAuthoritySnapshot } from '../../../semantic/rx-tx-surface';
 import { isFieldAvailable } from '$lib/state/field-status';
@@ -502,6 +502,63 @@ function deriveDsp(
 }
 
 /**
+ * RF front-end facts (MOR-1262 decomposition slice 6A, MOR-1292): preamp,
+ * attenuator, RF gain, squelch. A separate group from `dsp` — family
+ * enumeration is explicit and CLOSED (NR/NB/notch/AGC are family 5,
+ * `deriveDsp` above; never duplicated here).
+ *
+ * Evidence gate (N3), purely caps-driven, same shape as `deriveDsp`'s own
+ * gate (no raw-state fallback): `hasCap(caps, 'preamp'|'attenuator'|
+ * 'rf_gain'|'squelch')`, copied verbatim from the shipped `toRfFrontEndProps`
+ * (`lib/runtime/props/panel-props.ts`)'s own `showPre`/`showAtt`/
+ * `showRfGain`/`showSquelch` gates. The group itself emits only when at
+ * least one of the four is declared.
+ *
+ * `preamp`/`attenuator`/`rfGain`/`squelch` are read straight off the active
+ * receiver with NO scale conversion (see `RfFrontEndViewModel`'s doc comment
+ * for why there is no "real function" to consume for these four, unlike
+ * `dsp`'s `nrLevel`/`nbDepth`) — `numOrUndef(rx?.preamp)` etc., never a
+ * `?? 0` stand-in, so an unobserved control never reports a fabricated
+ * reading.
+ *
+ * The field-freshness gate is this file's own `topFieldAvailable`
+ * (`isFieldAvailable`, the same "operational" discipline `deriveTxAux`/
+ * `deriveDsp` use), NOT the shipped panel's looser `activeFieldShown` (which
+ * treats a stale field as still "shown" for UX continuity, `panel-props.ts`).
+ * A fact-layer reading must degrade a stale field to `unknown` — the
+ * looser gate is presentation policy, not a fact.
+ *
+ * `preValues`/`attValues` are the capability-derived choice sets
+ * (`Capabilities.preValues`/`.attValues`, verbatim) — see
+ * `RfFrontEndViewModel`'s doc comment. Deliberately `?? []`, never the
+ * shipped panel's `[0, 1, 2]`/`[0, 6, 12, 18]` IC-7610-shaped UI-convenience
+ * fallback (X6200 lesson: no radio-specific tables in the fact layer).
+ */
+function deriveRfFrontEnd(
+  state: ServerState | null, caps: Capabilities | null,
+): RfFrontEndViewModel | undefined {
+  if (!caps) return undefined;
+  const hasPreCap = hasCap(caps, 'preamp');
+  const hasAttCap = hasCap(caps, 'attenuator');
+  const hasRfGainCap = hasCap(caps, 'rf_gain');
+  const hasSquelchCap = hasCap(caps, 'squelch');
+  if (!hasPreCap && !hasAttCap && !hasRfGainCap && !hasSquelchCap) return undefined;
+
+  const onSub = state?.active === 'SUB';
+  const rx = onSub ? state?.sub : state?.main;
+  const base = onSub ? 'sub.' : 'main.';
+
+  return {
+    preamp: txAuxField(hasPreCap, topFieldAvailable(state, `${base}preamp`), numOrUndef(rx?.preamp)),
+    preValues: caps.preValues ?? [],
+    attenuator: txAuxField(hasAttCap, topFieldAvailable(state, `${base}att`), numOrUndef(rx?.att)),
+    attValues: caps.attValues ?? [],
+    rfGain: txAuxField(hasRfGainCap, topFieldAvailable(state, `${base}rfGain`), numOrUndef(rx?.rfGain)),
+    squelch: txAuxField(hasSquelchCap, topFieldAvailable(state, `${base}squelch`), numOrUndef(rx?.squelch)),
+  };
+}
+
+/**
  * The App-owned RX-audio snapshot the `rxAudio` facts are read against
  * (MOR-1262 slice 3A). It is an INPUT, deliberately: audio lifetime belongs to
  * the App (MOR-1058) and building a view model must never open, start or probe
@@ -733,6 +790,7 @@ export function toRadioViewModel(
   const modeFilter = deriveModeFilter(state, caps);
   const filterPassband = deriveFilterPassband(state, caps);
   const dsp = deriveDsp(state, caps);
+  const rfFrontEnd = deriveRfFrontEnd(state, caps);
 
   return {
     topologyId: `${topology.structuralCount}/${topology.scheme}`,
@@ -751,5 +809,6 @@ export function toRadioViewModel(
     ...(modeFilter !== undefined ? { modeFilter } : {}),
     ...(filterPassband !== undefined ? { filterPassband } : {}),
     ...(dsp !== undefined ? { dsp } : {}),
+    ...(rfFrontEnd !== undefined ? { rfFrontEnd } : {}),
   };
 }

--- a/frontend/src/semantic/__tests__/optional-group-allow-list.test.ts
+++ b/frontend/src/semantic/__tests__/optional-group-allow-list.test.ts
@@ -41,10 +41,10 @@ const REQUIRED_KEYS = [
 ] as const;
 
 /** MOR-1244: txAux. MOR-1262 slice 2A: meters. Slice 3A: rxAudio. Slice 4A:
- *  modeFilter. Slice 4A′: filterPassband. Slice 5A: dsp. Add your key here
- *  when your family's slice lands. */
+ *  modeFilter. Slice 4A′: filterPassband. Slice 5A: dsp. Slice 6A: rfFrontEnd.
+ *  Add your key here when your family's slice lands. */
 const EXPECTED_OPTIONAL_GROUP_KEYS = [
-  'txAux', 'meters', 'rxAudio', 'modeFilter', 'filterPassband', 'dsp',
+  'txAux', 'meters', 'rxAudio', 'modeFilter', 'filterPassband', 'dsp', 'rfFrontEnd',
 ] as const;
 
 function extractTopLevelAllowList(): string[] {

--- a/frontend/src/semantic/__tests__/rf-front-end.test.ts
+++ b/frontend/src/semantic/__tests__/rf-front-end.test.ts
@@ -1,0 +1,150 @@
+/**
+ * MOR-1262 decomposition slice 6A (MOR-1292) — `rfFrontEnd` optional fact
+ * group (validator half).
+ *
+ * Facts only: preamp, attenuator, RF gain, squelch (+ the `preValues`/
+ * `attValues` capability-derived choice sets). A SEPARATE group from `dsp`
+ * (MOR-1290, slice 5A) — see `radio-view-model.ts`'s `RfFrontEndViewModel`
+ * doc comment for the group-shape rationale, and
+ * `radio-view-model-adapter.ts`'s `deriveRfFrontEnd` for the live derivation
+ * (covered by the companion adapter test file).
+ *
+ * Mirrors the companion families' (`tx-aux.test.ts`, `dsp.test.ts`)
+ * kill-tests for this family:
+ *  1. an rfFrontEnd-absent model validates and round-trips byte-identically
+ *  2. `"rfFrontEnd": null` / `{}` throw (absent ≠ malformed)
+ *  3. a malformed inner field throws with a precise `$.rfFrontEnd....` path
+ *  5. an unknown extra key inside rfFrontEnd (or a field) throws
+ * (Kill-test 4, the adapter's evidence gate, lives in the adapter test file.)
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  validateRadioViewModel, type RfFrontEndField, type RfFrontEndViewModel,
+} from '../radio-view-model';
+import { topologyFixtures, withRfFrontEnd } from '../fixtures/topologies';
+
+const AVAIL = { structural: true, operational: true } as const;
+const base = topologyFixtures['1/single'];
+
+describe('rfFrontEnd (MOR-1262 slice 6A)', () => {
+  // ── Kill-test 1: absence is byte-identical, not a new default shape ──────
+  it('validates an rfFrontEnd-absent model and never adds the key', () => {
+    expect(Object.keys(base)).not.toContain('rfFrontEnd');
+    const validated = validateRadioViewModel(base);
+    expect(Object.keys(validated)).not.toContain('rfFrontEnd');
+    expect(validated.rfFrontEnd).toBeUndefined();
+    expect(JSON.parse(JSON.stringify(validated))).toEqual(JSON.parse(JSON.stringify(base)));
+  });
+
+  it('validates a fully-populated rfFrontEnd group and returns it unchanged', () => {
+    const withR = withRfFrontEnd(base);
+    expect(validateRadioViewModel(withR).rfFrontEnd).toEqual(withR.rfFrontEnd);
+  });
+
+  // ── Kill-test 2: null / {} are not absent ────────────────────────────────
+  it('rejects an explicit rfFrontEnd: null', () => {
+    expect(() => validateRadioViewModel({ ...base, rfFrontEnd: null })).toThrow(TypeError);
+  });
+
+  it('rejects an explicit rfFrontEnd: {} — present, not absent, must satisfy its own shape', () => {
+    expect(() => validateRadioViewModel({ ...base, rfFrontEnd: {} })).toThrow(TypeError);
+  });
+
+  // ── Kill-test 3: malformed inner field, precise path ─────────────────────
+  it('rejects a non-numeric preamp reading value with a precise error path', () => {
+    const withR = withRfFrontEnd(base);
+    const malformed = {
+      ...withR,
+      rfFrontEnd: {
+        ...withR.rfFrontEnd,
+        preamp: { reading: { status: 'known', value: 'high' }, availability: AVAIL },
+      },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.rfFrontEnd\.preamp\.reading\.value/);
+  });
+
+  it('rejects a non-array preValues', () => {
+    const withR = withRfFrontEnd(base);
+    const malformed = { ...withR, rfFrontEnd: { ...withR.rfFrontEnd, preValues: 'P1' } };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.rfFrontEnd\.preValues/);
+  });
+
+  it('rejects a non-array attValues', () => {
+    const withR = withRfFrontEnd(base);
+    const malformed = { ...withR, rfFrontEnd: { ...withR.rfFrontEnd, attValues: '6dB' } };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.rfFrontEnd\.attValues/);
+  });
+
+  it('rejects a non-boolean field inside an rfFrontEnd field Availability', () => {
+    const withR = withRfFrontEnd(base);
+    const malformed = {
+      ...withR,
+      rfFrontEnd: {
+        ...withR.rfFrontEnd,
+        squelch: { reading: { status: 'unknown' }, availability: { structural: 'yes', operational: true } },
+      },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(TypeError);
+  });
+
+  it('accepts an unknown reading distinct from a known one, independently per field', () => {
+    const withR = withRfFrontEnd(base);
+    const partial = {
+      ...withR,
+      rfFrontEnd: {
+        ...withR.rfFrontEnd,
+        rfGain: { reading: { status: 'unknown' }, availability: { structural: true, operational: false } },
+      },
+    };
+    const validated = validateRadioViewModel(partial);
+    expect(validated.rfFrontEnd?.rfGain).toEqual({
+      reading: { status: 'unknown' }, availability: { structural: true, operational: false },
+    });
+    // The rest of the group is untouched by the one field's degrade.
+    expect(validated.rfFrontEnd?.preamp.reading).toEqual({ status: 'known', value: 1 });
+  });
+
+  // ── Kill-test 5: no speculative keys (N4) ─────────────────────────────────
+  it('rejects an unknown extra key inside rfFrontEnd', () => {
+    const withR = withRfFrontEnd(base);
+    const malformed = { ...withR, rfFrontEnd: { ...withR.rfFrontEnd, bogus: 1 } };
+    expect(() => validateRadioViewModel(malformed)).toThrow(TypeError);
+  });
+
+  it('rejects an unknown extra key inside a single rfFrontEnd field', () => {
+    const withR = withRfFrontEnd(base);
+    const malformed = {
+      ...withR,
+      rfFrontEnd: {
+        ...withR.rfFrontEnd,
+        attenuator: { reading: { status: 'known', value: 6 }, availability: AVAIL, extra: true },
+      },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(TypeError);
+  });
+
+  it('rejects a reading that carries a value key while unknown', () => {
+    const withR = withRfFrontEnd(base);
+    const malformed = {
+      ...withR,
+      rfFrontEnd: {
+        ...withR.rfFrontEnd,
+        squelch: { reading: { status: 'unknown', value: 0 }, availability: AVAIL },
+      },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(TypeError);
+  });
+
+  it('every field of a fully-populated group round-trips its own value', () => {
+    const withR = withRfFrontEnd(base);
+    const validated = validateRadioViewModel(withR).rfFrontEnd as RfFrontEndViewModel;
+    const knownValue = <T>(f: RfFrontEndField<T>): T | undefined =>
+      f.reading.status === 'known' ? f.reading.value : undefined;
+    expect(knownValue(validated.preamp)).toBe(1);
+    expect(validated.preValues).toEqual([0, 1, 2]);
+    expect(knownValue(validated.attenuator)).toBe(6);
+    expect(validated.attValues).toEqual([0, 6, 12, 18]);
+    expect(knownValue(validated.rfGain)).toBe(1);
+    expect(knownValue(validated.squelch)).toBe(0);
+  });
+});

--- a/frontend/src/semantic/fixtures/topologies.ts
+++ b/frontend/src/semantic/fixtures/topologies.ts
@@ -17,7 +17,7 @@ import type {
   Availability, DspField, DspViewModel, FilterPassbandField, FilterPassbandViewModel,
   MeterField, MeterRfState, MetersViewModel,
   ModeFilterField, ModeFilterViewModel,
-  ModInputReadiness, RadioViewModel, RxAudioField, RxAudioViewModel,
+  ModInputReadiness, RadioViewModel, RfFrontEndField, RfFrontEndViewModel, RxAudioField, RxAudioViewModel,
   TxAuxField, TxAuxViewModel,
 } from '../radio-view-model';
 
@@ -306,4 +306,25 @@ export function withDsp(fixture: RadioViewModel): RadioViewModel {
     agcTimeConstant: known(0),
   };
   return { ...fixture, dsp };
+}
+
+/**
+ * Applies a fully-observed `rfFrontEnd` group (MOR-1262 slice 6A, MOR-1292)
+ * to any topology fixture — a SEPARATE group from `dsp` above (see
+ * `RfFrontEndViewModel`'s doc comment for why), same composable-axis story
+ * as `withTxAux`/`withMeters`/`withRxAudio`/`withFilterPassband`/`withDsp`.
+ */
+export function withRfFrontEnd(fixture: RadioViewModel): RadioViewModel {
+  const avail: Availability = { structural: true, operational: true };
+  const known = <T>(value: T): RfFrontEndField<T> =>
+    ({ reading: { status: 'known', value }, availability: avail });
+  const rfFrontEnd: RfFrontEndViewModel = {
+    preamp: known(1),
+    preValues: [0, 1, 2],
+    attenuator: known(6),
+    attValues: [0, 6, 12, 18],
+    rfGain: known(1),
+    squelch: known(0),
+  };
+  return { ...fixture, rfFrontEnd };
 }

--- a/frontend/src/semantic/radio-view-model.ts
+++ b/frontend/src/semantic/radio-view-model.ts
@@ -358,6 +358,53 @@ export interface DspViewModel {
   agcTimeConstant: DspField<number>;
 }
 
+/**
+ * A single RF-front-end fact (MOR-1262 decomposition slice 6A, MOR-1292).
+ * Shape-identical to `TxAuxField`, declared as an alias for the same reason
+ * `DspField`/`FilterPassbandField`/`ModeFilterField`/`RxAudioField` are: one
+ * field shape per fact family.
+ */
+export type RfFrontEndField<T> = TxAuxField<T>;
+
+/**
+ * RF front-end facts (MOR-1262 decomposition slice 6A, MOR-1292): preamp,
+ * attenuator, RF gain, squelch. Facts only — no command emission, same
+ * doctrine as `dsp`/`modeFilter`/`filterPassband`. Family enumeration is
+ * explicit and CLOSED: NR/NB/notch/AGC are family 5 (`dsp`, MOR-1290) — this
+ * group never duplicates them; DIGI-SEL/IP+ are the shipped `RfFrontEndProps`
+ * panel's OWN remaining controls but are not part of this slice's four named
+ * facts and are deliberately left uncovered here (ticket scope, not an
+ * oversight — see the build report).
+ *
+ * `preamp`/`attenuator`/`rfGain`/`squelch` are plain pass-through readings:
+ * unlike `dsp`'s `nrLevel`/`nbDepth`, the shipped `toRfFrontEndProps`
+ * (`lib/runtime/props/panel-props.ts`) reads `rx.preamp`/`rx.att`/
+ * `rx.rfGain`/`rx.squelch` verbatim, with no raw<->display scale conversion
+ * — the server already reports these as display-ready values (dB steps,
+ * preamp-level ordinal, 0-1 gain fractions). There is no separate "real
+ * function" to consume for the VALUE; the parity surface here is the
+ * CAPABILITY gate and the choice sets below, both copied verbatim from
+ * `toRfFrontEndProps`.
+ *
+ * `preValues`/`attValues` are the capability-derived preamp-level and
+ * attenuator-dB choice sets (`Capabilities.preValues`/`.attValues`,
+ * verbatim) — plain lists, not field-wrapped, same reasoning as `dsp`'s
+ * `agcModes`: a choice set is a structural fact about the radio MODEL, not a
+ * live reading that can itself go stale. Per the X6200 lesson, these are
+ * read from the `caps` ARGUMENT only — never a radio-specific fallback table
+ * (the shipped panel's own `[0, 6, 12, 18]`/`[0, 1, 2]` UI-convenience
+ * defaults are presentation, not a fact — see `radio-view-model-adapter.ts`'s
+ * `deriveRfFrontEnd`).
+ */
+export interface RfFrontEndViewModel {
+  preamp: RfFrontEndField<number>;
+  preValues: readonly number[];
+  attenuator: RfFrontEndField<number>;
+  attValues: readonly number[];
+  rfGain: RfFrontEndField<number>;
+  squelch: RfFrontEndField<number>;
+}
+
 export interface RadioViewModel {
   topologyId: string;
   vfoScheme: VfoScheme;
@@ -395,6 +442,10 @@ export interface RadioViewModel {
    *  notch and no AGC capability — see `radio-view-model-adapter.ts`'s
    *  `deriveDsp`. */
   readonly dsp?: DspViewModel;
+  /** Absent (MOR-1264 optional group) ⇒ this radio declares no preamp, no
+   *  attenuator, no RF-gain and no squelch capability — see
+   *  `radio-view-model-adapter.ts`'s `deriveRfFrontEnd`. */
+  readonly rfFrontEnd?: RfFrontEndViewModel;
 }
 
 const RECEIVER_IDS: readonly ReceiverId[] = ['MAIN', 'SUB'];
@@ -778,6 +829,21 @@ function validateDsp(value: unknown, path: string): DspViewModel {
   };
 }
 
+/** N4 again: exactly the six facts the adapter reads, no speculative keys.
+ *  See `radio-view-model-adapter.ts::deriveRfFrontEnd`. */
+function validateRfFrontEnd(value: unknown, path: string): RfFrontEndViewModel {
+  const v = record(value, path);
+  exactKeys(v, ['preamp', 'preValues', 'attenuator', 'attValues', 'rfGain', 'squelch'], path);
+  return {
+    preamp: validateTxAuxField(v.preamp, `${path}.preamp`, num),
+    preValues: numArray(v.preValues, `${path}.preValues`),
+    attenuator: validateTxAuxField(v.attenuator, `${path}.attenuator`, num),
+    attValues: numArray(v.attValues, `${path}.attValues`),
+    rfGain: validateTxAuxField(v.rfGain, `${path}.rfGain`, num),
+    squelch: validateTxAuxField(v.squelch, `${path}.squelch`, num),
+  };
+}
+
 /** Runtime validator (repo idiom: throws TypeError with a `$.path`, see `validateCapabilities`).
  *  Also enforces two cross-field invariants (review cycle 1, V1): `txPermit`
  *  cannot be 'allowed' while `txTarget` is unknown (no fail-open), and
@@ -787,7 +853,7 @@ export function validateRadioViewModel(value: unknown): RadioViewModel {
   exactKeys(v, [
     'topologyId', 'vfoScheme', 'activeReceiver', 'vfos', 'split', 'dualWatch',
     'txTarget', 'txPermit', 'scope', 'disabledReasons', 'txAux', 'meters', 'rxAudio', 'modeFilter',
-    'filterPassband', 'dsp',
+    'filterPassband', 'dsp', 'rfFrontEnd',
   ], '$');
   if (!Array.isArray(v.vfos)) invalid('$.vfos', 'an array');
   if (!Array.isArray(v.disabledReasons)) invalid('$.disabledReasons', 'an array');
@@ -821,6 +887,7 @@ export function validateRadioViewModel(value: unknown): RadioViewModel {
   const modeFilter = optionalGroup(v.modeFilter, '$.modeFilter', validateModeFilter);
   const filterPassband = optionalGroup(v.filterPassband, '$.filterPassband', validateFilterPassband);
   const dsp = optionalGroup(v.dsp, '$.dsp', validateDsp);
+  const rfFrontEnd = optionalGroup(v.rfFrontEnd, '$.rfFrontEnd', validateRfFrontEnd);
 
   return {
     topologyId: str(v.topologyId, '$.topologyId'),
@@ -842,5 +909,6 @@ export function validateRadioViewModel(value: unknown): RadioViewModel {
     ...(modeFilter !== undefined ? { modeFilter } : {}),
     ...(filterPassband !== undefined ? { filterPassband } : {}),
     ...(dsp !== undefined ? { dsp } : {}),
+    ...(rfFrontEnd !== undefined ? { rfFrontEnd } : {}),
   };
 }


### PR DESCRIPTION
## Summary
Vocabulary slice 6A: optional `rfFrontEnd` group via the S0 seam — preamp, attenuator, rfGain, squelch + capability-derived `preValues`/`attValues` choice sets. First family in the program that is deterministic **by construction**: the four fields are verbatim pass-throughs of what `toRfFrontEndProps` reads (verifier-confirmed independently: no conversion exists for this family; `CONTROL_DEFAULTS` holds only nr/nb), so no range-param treatment needed and no store path exists. Choice sets never replicate the panel's IC-7610-shaped UI fallback (mutation-pinned). Absent-raw honesty table-driven across all four fields; stale-freshness gates pinned per field (it.each). Net production LOC **47** strict / 127 raw (verifier re-measured; well under the ~80 target).

**Freshness-gate ruling:** facts use the strict `topFieldAvailable` convention (uniform across all six prior families — it is what `operational` means); the v2 panel's looser `activeFieldShown` is NOT replicated. 6B carry-forward: the surface presents staleness explicitly via `structural:true/operational:false`, never re-loosens the fact.

**Decomposition gap found:** DIGI-SEL/IP+ appear nowhere in the decomposition, yet share the panel and have capability tags — and without a DIGI-SEL fact, 6B cannot reproduce the shipped PREAMP/DIGI-SEL mutex (MOR-479) without raw-state reads. Filed as MOR-1293 (blocks 6B).

## Review provenance
Sonnet builder → independent opus vocabulary-domain verifier (11th ticket in domain): **PASS** + one required test addition. Parity claim verified against source (not the report); X1 fallback-replication mutant killed; H3a–d absent-raw mutants each die on their own table row; contract mutations killed (drop-from-exactKeys 27, bypass, smuggle); A-queue clean; zero store/global mutation in tests (no isolated-pool entry needed — merge onto current main is CLEAN, no vite.config hunk). Round-1 gap: the stale-freshness pin covered att only (G1 rfGain-loosen survived) — closed by the it.each conversion, G1 re-red with checksum-verified restore (test-only round per the delta discipline). Fail-set identical to baseline; lint/boundaries/check clean.

Linear: MOR-1292

🤖 Generated with [Claude Code](https://claude.com/claude-code)