### PR TITLE
feat(MOR-1293): DIGI-SEL and IP+ facts with the PREAMP mutex via disabledReasons

### DIFF
--- a/frontend/src/lib/runtime/adapters/__tests__/rf-front-end-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/rf-front-end-adapter.test.ts
@@ -1,23 +1,26 @@
 /**
  * MOR-1262 decomposition slice 6A (MOR-1292) — `rfFrontEnd` fact-group
- * adapter derivation.
+ * adapter derivation. Extended by slice 6A′ (MOR-1293) with `digiSel`/
+ * `ipPlus` and the PREAMP/DIGI-SEL hardware mutex (MOR-479).
  *
  * Companion to `dsp-adapter.test.ts` (MOR-1290), which this file does NOT
  * modify. `rfFrontEnd` is a SEPARATE optional group — see
  * `radio-view-model.ts`'s `RfFrontEndViewModel` doc comment.
  *
- * Unlike `dsp`'s `nrLevel`/`nbDepth`, none of this group's four facts
- * (preamp/attenuator/rfGain/squelch) consume a capabilities-STORE-backed
- * scale conversion — they are plain pass-through readings (see
- * `deriveRfFrontEnd`'s doc comment) — so this file never calls the real
- * `setCapabilities` and does not need the isolated pool (MOR-1272; contrast
- * `dsp-adapter.test.ts`'s own file-level doc comment on that point).
+ * Unlike `dsp`'s `nrLevel`/`nbDepth`, none of this group's six facts
+ * (preamp/attenuator/rfGain/squelch/digiSel/ipPlus) consume a
+ * capabilities-STORE-backed scale conversion — they are plain pass-through
+ * readings (see `deriveRfFrontEnd`'s doc comment) — so this file never calls
+ * the real `setCapabilities` and does not need the isolated pool (MOR-1272;
+ * contrast `dsp-adapter.test.ts`'s own file-level doc comment on that
+ * point).
  */
 import { describe, expect, it } from 'vitest';
 import type { Capabilities } from '$lib/types/capabilities';
 import type { FieldStatus, ServerState } from '$lib/types/state';
 import { validateRadioViewModel, type RadioViewModel } from '../../../../semantic/radio-view-model';
 import { toRadioViewModel } from '../radio-view-model-adapter';
+import { toRfFrontEndProps } from '../../props/panel-props';
 
 function caps(overrides: Partial<Capabilities> = {}): Capabilities {
   return {
@@ -244,4 +247,225 @@ describe('rfFrontEnd honesty gate — absent raw values never fabricate (MOR-129
       expect(view.rfFrontEnd![viewField].reading).toEqual({ status: 'unknown' });
     },
   );
+});
+
+/**
+ * MOR-1293 (slice 6A′) — `digiSel`/`ipPlus`, the two family-11 facts the
+ * MOR-1292 re-verify found enumerated nowhere in the decomposition despite
+ * belonging to the same panel/adapter as `preamp`/`attenuator`/`rfGain`/
+ * `squelch`. Same evidence-gate, structural-gate, freshness and honesty
+ * disciplines as the original four — mirrored here rather than folded into
+ * the existing tables above so the MOR-1292 test file stays untouched
+ * (A-queue: this slice extends, never edits, prior-family assertions).
+ */
+describe('rfFrontEnd evidence gate — digiSel/ipPlus (MOR-1293, N3)', () => {
+  it('emits rfFrontEnd once the digisel capability alone is declared', () => {
+    const view = model(bareState(), caps({ capabilities: ['digisel'] }));
+    expect(view.rfFrontEnd).toBeDefined();
+  });
+
+  it('emits rfFrontEnd once the ip_plus capability alone is declared', () => {
+    const view = model(bareState(), caps({ capabilities: ['ip_plus'] }));
+    expect(view.rfFrontEnd).toBeDefined();
+  });
+});
+
+describe('rfFrontEnd per-field structural gates — digiSel/ipPlus (MOR-1293)', () => {
+  it('digiSel is structurally absent without the digisel capability, even with preamp present', () => {
+    const view = model(bareState(), caps({ capabilities: ['preamp'] }));
+    expect(view.rfFrontEnd!.digiSel.availability.structural).toBe(false);
+    expect(view.rfFrontEnd!.preamp.availability.structural).toBe(true);
+  });
+
+  it('ipPlus is structurally absent without the ip_plus capability, even with digisel present', () => {
+    const view = model(bareState(), caps({ capabilities: ['digisel'] }));
+    expect(view.rfFrontEnd!.ipPlus.availability.structural).toBe(false);
+    expect(view.rfFrontEnd!.digiSel.availability.structural).toBe(true);
+  });
+});
+
+describe('rfFrontEnd per-field derivation — digiSel/ipPlus (MOR-1293)', () => {
+  const boolCaps = caps({ capabilities: ['digisel', 'ip_plus'] });
+
+  it('reports known boolean readings for observed, fresh, capability-backed fields', () => {
+    const view = model(bareState({
+      main: { ...bareState().main, digisel: true, ipplus: false },
+      fieldStatus: { ...bareState().fieldStatus, 'main.digisel': fresh, 'main.ipplus': fresh },
+    }), boolCaps);
+    expect(view.rfFrontEnd!.digiSel).toEqual(
+      { reading: { status: 'known', value: true }, availability: { structural: true, operational: true } },
+    );
+    expect(view.rfFrontEnd!.ipPlus.reading).toEqual({ status: 'known', value: false });
+  });
+
+  // Same STALE_FIELDS lesson as the base four (MOR-1292 re-verify F1): one
+  // row per field proves each has its OWN `topFieldAvailable` call, not a
+  // shared one that only one mutation-tested field happens to exercise.
+  const STALE_BOOL_FIELDS: ReadonlyArray<readonly [
+    rawField: 'digisel' | 'ipplus', viewField: 'digiSel' | 'ipPlus',
+  ]> = [
+    ['digisel', 'digiSel'],
+    ['ipplus', 'ipPlus'],
+  ];
+
+  it.each(STALE_BOOL_FIELDS)(
+    'degrades a stale %s field to unknown while keeping structural availability true',
+    (rawField, viewField) => {
+      const main = { ...bareState().main, [rawField]: true } as unknown as ServerState['main'];
+      const view = model(bareState({
+        main,
+        fieldStatus: { ...bareState().fieldStatus, [`main.${rawField}`]: stale },
+      }), boolCaps);
+      expect(view.rfFrontEnd![viewField]).toEqual({
+        reading: { status: 'unknown' }, availability: { structural: true, operational: false },
+      });
+    },
+  );
+
+  it('marks digiSel structurally absent when its capability tag is missing, never known', () => {
+    const view = model(bareState({
+      main: { ...bareState().main, digisel: true },
+      fieldStatus: { ...bareState().fieldStatus, 'main.digisel': fresh },
+    }), caps({ capabilities: ['squelch'] }));
+    expect(view.rfFrontEnd!.digiSel).toEqual({
+      reading: { status: 'unknown' }, availability: { structural: false, operational: false },
+    });
+  });
+
+  it('degrades a malformed raw value (wrong JS type) to unknown rather than throwing or coercing', () => {
+    const view = model(bareState({
+      main: { ...bareState().main, digisel: 'on' as unknown as boolean },
+      fieldStatus: { ...bareState().fieldStatus, 'main.digisel': fresh },
+    }), boolCaps);
+    expect(view.rfFrontEnd!.digiSel.reading).toEqual({ status: 'unknown' });
+  });
+});
+
+describe(
+  'rfFrontEnd honesty gate — digiSel/ipPlus absent raw values never fabricate (MOR-1293, mutant H3 lineage)',
+  () => {
+    const allCaps = caps({ capabilities: ['digisel', 'ip_plus'] });
+    const RECEIVER_SCOPED_BOOL_FIELDS = ['digisel', 'ipplus'] as const;
+    const VIEW_FIELD_NAME = { digisel: 'digiSel', ipplus: 'ipPlus' } as const;
+
+    it.each(RECEIVER_SCOPED_BOOL_FIELDS)(
+      '%s: absent from the receiver object (no fieldStatus entry) reads unknown, not {known, false}',
+      (field) => {
+        const main = { ...bareState().main } as Record<string, unknown>;
+        delete main[field];
+        const view = model(bareState({ main: main as unknown as ServerState['main'] }), allCaps);
+        const viewField = VIEW_FIELD_NAME[field];
+        expect(view.rfFrontEnd![viewField].reading).toEqual({ status: 'unknown' });
+      },
+    );
+  },
+);
+
+/**
+ * THE MUTEX (MOR-479, MOR-1293) — `deriveRfFrontEndMutex`. The shipped
+ * `toRfFrontEndProps` (`panel-props.ts`) computes `preDisabled = rx?.digisel
+ * ?? false` and disables the PRE control when it's true. This contract
+ * expresses the same disable as a `disabledReasons` entry
+ * (`{field: 'rfFrontEnd.preamp', code: 'mutually-exclusive-control'}`),
+ * derived from the group's OWN `digiSel` fact rather than a second raw read.
+ *
+ * The parity pins below call the REAL `toRfFrontEndProps` (never a
+ * reimplementation) so the known-value agreement is against the shipped
+ * function itself, not an assumption about it — "consume, never re-derive"
+ * per the MOR-1292 re-verify's gap-ticket wording. The `unknown` pin is the
+ * one place this contract is REQUIRED to diverge from that real function's
+ * own `?? false` (fail-closed, not the panel's fail-open) — asserted
+ * explicitly rather than merely implied by the on/off pins.
+ */
+describe('rfFrontEnd PREAMP/DIGI-SEL mutex (MOR-479, MOR-1293)', () => {
+  const mutexCaps = caps({ capabilities: ['preamp', 'digisel'] });
+
+  function preampMutexReason(view: RadioViewModel) {
+    return view.disabledReasons.find(
+      (r) => r.field === 'rfFrontEnd.preamp' && r.code === 'mutually-exclusive-control',
+    );
+  }
+
+  it('DIGI-SEL on: the real toRfFrontEndProps disables PRE, and this contract agrees', () => {
+    const state = bareState({
+      main: { ...bareState().main, digisel: true, preamp: 1 },
+      fieldStatus: { ...bareState().fieldStatus, 'main.digisel': fresh, 'main.preamp': fresh },
+    });
+    expect(toRfFrontEndProps(state, mutexCaps).preDisabled).toBe(true);
+
+    const view = model(state, mutexCaps);
+    expect(preampMutexReason(view)).toEqual({ field: 'rfFrontEnd.preamp', code: 'mutually-exclusive-control' });
+  });
+
+  it('DIGI-SEL off: the real toRfFrontEndProps leaves PRE enabled, and this contract agrees', () => {
+    const state = bareState({
+      main: { ...bareState().main, digisel: false, preamp: 1 },
+      fieldStatus: { ...bareState().fieldStatus, 'main.digisel': fresh, 'main.preamp': fresh },
+    });
+    expect(toRfFrontEndProps(state, mutexCaps).preDisabled).toBe(false);
+
+    const view = model(state, mutexCaps);
+    expect(preampMutexReason(view)).toBeUndefined();
+  });
+
+  it(
+    'DIGI-SEL unknown (never observed): FAILS CLOSED — disables PRE — deliberately diverging from ' +
+    'the real toRfFrontEndProps, which would fail OPEN',
+    () => {
+      const state = bareState({
+        main: { ...bareState().main, preamp: 1 },
+        // No 'main.digisel' fieldStatus entry AND no fieldStatus for the group
+        // parent either — an honestly never-observed control.
+        fieldStatus: { ...bareState().fieldStatus, 'main.preamp': fresh },
+      });
+      // The shipped panel's own naive `rx?.digisel ?? false` reads this as
+      // "off" — PRE stays enabled. This is the exact fabricated-default this
+      // contract exists to refuse to repeat.
+      expect(toRfFrontEndProps(state, mutexCaps).preDisabled).toBe(false);
+
+      const view = model(state, mutexCaps);
+      expect(preampMutexReason(view)).toEqual({ field: 'rfFrontEnd.preamp', code: 'mutually-exclusive-control' });
+      expect(view.rfFrontEnd!.digiSel.reading).toEqual({ status: 'unknown' });
+    },
+  );
+
+  it('DIGI-SEL stale: FAILS CLOSED the same way as never-observed', () => {
+    const state = bareState({
+      main: { ...bareState().main, digisel: false, preamp: 1 },
+      fieldStatus: { ...bareState().fieldStatus, 'main.digisel': stale, 'main.preamp': fresh },
+    });
+    const view = model(state, mutexCaps);
+    expect(view.rfFrontEnd!.digiSel.reading).toEqual({ status: 'unknown' });
+    expect(preampMutexReason(view)).toEqual({ field: 'rfFrontEnd.preamp', code: 'mutually-exclusive-control' });
+  });
+
+  it('no digisel capability at all: no mutex entry regardless of raw digisel value', () => {
+    const state = bareState({
+      main: { ...bareState().main, digisel: true, preamp: 1 },
+      fieldStatus: { ...bareState().fieldStatus, 'main.digisel': fresh, 'main.preamp': fresh },
+    });
+    const view = model(state, caps({ capabilities: ['preamp'] }));
+    expect(view.rfFrontEnd!.digiSel.availability.structural).toBe(false);
+    expect(preampMutexReason(view)).toBeUndefined();
+  });
+
+  it('no preamp capability at all: no mutex entry regardless of DIGI-SEL state', () => {
+    const state = bareState({
+      main: { ...bareState().main, digisel: true },
+      fieldStatus: { ...bareState().fieldStatus, 'main.digisel': fresh },
+    });
+    const view = model(state, caps({ capabilities: ['digisel'] }));
+    expect(view.rfFrontEnd!.preamp.availability.structural).toBe(false);
+    expect(preampMutexReason(view)).toBeUndefined();
+  });
+
+  it('follows the SUB receiver once it is the active one', () => {
+    const state = bareState({
+      active: 'SUB',
+      sub: { ...bareState().sub, digisel: true, preamp: 2 },
+      fieldStatus: { ...bareState().fieldStatus, 'sub.digisel': fresh, 'sub.preamp': fresh },
+    });
+    const view = model(state, mutexCaps);
+    expect(preampMutexReason(view)).toEqual({ field: 'rfFrontEnd.preamp', code: 'mutually-exclusive-control' });
+  });
 });

--- a/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
@@ -50,7 +50,8 @@ type Slot = { kind: 'slotted'; id: VfoSlotId } | { kind: 'unslotted' } | { kind:
 type Fact = { status: 'known'; value: boolean } | { status: 'unknown' };
 type Reason = {
   field: string;
-  code: 'capability-unavailable' | 'field-not-observed' | 'tx-target-unknown' | 'out-of-band';
+  code: 'capability-unavailable' | 'field-not-observed' | 'tx-target-unknown' | 'out-of-band'
+    | 'mutually-exclusive-control';
 };
 type Readable = {
   freqHz?: number; mode?: string; filter?: number | null; filterNum?: number | null;
@@ -502,37 +503,52 @@ function deriveDsp(
 }
 
 /**
- * RF front-end facts (MOR-1262 decomposition slice 6A, MOR-1292): preamp,
- * attenuator, RF gain, squelch. A separate group from `dsp` — family
- * enumeration is explicit and CLOSED (NR/NB/notch/AGC are family 5,
- * `deriveDsp` above; never duplicated here).
+ * RF front-end facts (MOR-1262 decomposition slice 6A, MOR-1292; extended by
+ * slice 6A′, MOR-1293 with `digiSel`/`ipPlus` — the family-11 enumeration
+ * gap the 6A re-verify flagged): preamp, attenuator, RF gain, squelch,
+ * DIGI-SEL, IP+. A separate group from `dsp` — family enumeration is
+ * explicit and CLOSED (NR/NB/notch/AGC are family 5, `deriveDsp` above;
+ * never duplicated here).
  *
  * Evidence gate (N3), purely caps-driven, same shape as `deriveDsp`'s own
  * gate (no raw-state fallback): `hasCap(caps, 'preamp'|'attenuator'|
- * 'rf_gain'|'squelch')`, copied verbatim from the shipped `toRfFrontEndProps`
- * (`lib/runtime/props/panel-props.ts`)'s own `showPre`/`showAtt`/
- * `showRfGain`/`showSquelch` gates. The group itself emits only when at
- * least one of the four is declared.
+ * 'rf_gain'|'squelch'|'digisel'|'ip_plus')`, copied verbatim from the shipped
+ * `toRfFrontEndProps` (`lib/runtime/props/panel-props.ts`)'s own
+ * `showPre`/`showAtt`/`showRfGain`/`showSquelch`/`showDigiSel`/`showIpPlus`
+ * gates. The group itself emits only when at least one of the six is
+ * declared.
  *
- * `preamp`/`attenuator`/`rfGain`/`squelch` are read straight off the active
- * receiver with NO scale conversion (see `RfFrontEndViewModel`'s doc comment
- * for why there is no "real function" to consume for these four, unlike
- * `dsp`'s `nrLevel`/`nbDepth`) — `numOrUndef(rx?.preamp)` etc., never a
- * `?? 0` stand-in, so an unobserved control never reports a fabricated
+ * `preamp`/`attenuator`/`rfGain`/`squelch`/`digiSel`/`ipPlus` are read
+ * straight off the active receiver with NO scale conversion (see
+ * `RfFrontEndViewModel`'s doc comment for why there is no "real function" to
+ * consume for these six, unlike `dsp`'s `nrLevel`/`nbDepth`) —
+ * `numOrUndef(rx?.preamp)`/`boolOrUndef(rx?.digisel)` etc., never a `?? 0`/
+ * `?? false` stand-in, so an unobserved control never reports a fabricated
  * reading.
  *
  * The field-freshness gate is this file's own `topFieldAvailable`
  * (`isFieldAvailable`, the same "operational" discipline `deriveTxAux`/
  * `deriveDsp` use), NOT the shipped panel's looser `activeFieldShown` (which
- * treats a stale field as still "shown" for UX continuity, `panel-props.ts`).
- * A fact-layer reading must degrade a stale field to `unknown` — the
- * looser gate is presentation policy, not a fact.
+ * treats a stale field as still "shown" for UX continuity, `panel-props.ts`)
+ * — for `preamp`/`attenuator`/`rfGain`/`squelch`, that is a deliberate
+ * deviation (a fact-layer reading must degrade a stale field to `unknown`;
+ * the looser gate is presentation policy, not a fact). `digiSel`/`ipPlus`
+ * carry NO such deviation: the shipped panel already gates them on the
+ * STRICT `activeFieldAvailable` (`panel-props.ts`'s own `digiSelAvailable`/
+ * `ipPlusAvailable`), which calls the exact same `isFieldAvailable` this
+ * file's `topFieldAvailable` does — so this file's gate is parity-exact for
+ * these two, not a deviation, per the MOR-1292 re-verify's finding.
  *
  * `preValues`/`attValues` are the capability-derived choice sets
  * (`Capabilities.preValues`/`.attValues`, verbatim) — see
  * `RfFrontEndViewModel`'s doc comment. Deliberately `?? []`, never the
  * shipped panel's `[0, 1, 2]`/`[0, 6, 12, 18]` IC-7610-shaped UI-convenience
  * fallback (X6200 lesson: no radio-specific tables in the fact layer).
+ *
+ * THE MUTEX is NOT derived here — it lives in `toRadioViewModel`, below,
+ * where it reads THIS function's own `digiSel` field back rather than
+ * re-reading `rx?.digisel` a second time (one raw read per fact, same
+ * discipline as every other field here).
  */
 function deriveRfFrontEnd(
   state: ServerState | null, caps: Capabilities | null,
@@ -542,7 +558,11 @@ function deriveRfFrontEnd(
   const hasAttCap = hasCap(caps, 'attenuator');
   const hasRfGainCap = hasCap(caps, 'rf_gain');
   const hasSquelchCap = hasCap(caps, 'squelch');
-  if (!hasPreCap && !hasAttCap && !hasRfGainCap && !hasSquelchCap) return undefined;
+  const hasDigiSelCap = hasCap(caps, 'digisel');
+  const hasIpPlusCap = hasCap(caps, 'ip_plus');
+  if (!hasPreCap && !hasAttCap && !hasRfGainCap && !hasSquelchCap && !hasDigiSelCap && !hasIpPlusCap) {
+    return undefined;
+  }
 
   const onSub = state?.active === 'SUB';
   const rx = onSub ? state?.sub : state?.main;
@@ -555,7 +575,37 @@ function deriveRfFrontEnd(
     attValues: caps.attValues ?? [],
     rfGain: txAuxField(hasRfGainCap, topFieldAvailable(state, `${base}rfGain`), numOrUndef(rx?.rfGain)),
     squelch: txAuxField(hasSquelchCap, topFieldAvailable(state, `${base}squelch`), numOrUndef(rx?.squelch)),
+    digiSel: txAuxField(hasDigiSelCap, topFieldAvailable(state, `${base}digisel`), boolOrUndef(rx?.digisel)),
+    ipPlus: txAuxField(hasIpPlusCap, topFieldAvailable(state, `${base}ipplus`), boolOrUndef(rx?.ipplus)),
   };
+}
+
+/**
+ * THE MUTEX (MOR-479, MOR-1293): the shipped `toRfFrontEndProps` disables the
+ * PRE control while DIGI-SEL is ON — `const preDisabled = rx?.digisel ??
+ * false` (`panel-props.ts`) — because the IC-7610 silently ignores a PREAMP
+ * set in that state. Expressed here as a `disabledReasons` entry rather than
+ * a bespoke field (the gap-ticket ruling, MOR-1292 re-verify §5), and
+ * consumes THIS group's own `digiSel` fact rather than re-deriving the raw
+ * `rx?.digisel ?? false` read a second time — the fact already carries the
+ * two-level availability the raw read has no way to express.
+ *
+ * FAIL-CLOSED (the discriminating deviation from v2's own naive read): the
+ * shipped `rx?.digisel ?? false` treats an UNOBSERVED digisel as "off", so a
+ * radio that has never reported DIGI-SEL would silently show PREAMP enabled.
+ * This function does the opposite for an `unknown` reading — mutex ACTIVE,
+ * same as `on` — because "we don't know DIGI-SEL is off" is not evidence
+ * that it's safe to optimistically enable PREAMP; it is exactly the class of
+ * fabricated-default this whole contract exists to forbid (MOR-988 §3.2).
+ * Gated on `preamp.availability.structural` — a radio with no preamp
+ * capability at all gets no `rfFrontEnd.preamp` disable entry, mutex or not.
+ */
+function deriveRfFrontEndMutex(rfFrontEnd: RfFrontEndViewModel | undefined): Reason | null {
+  if (!rfFrontEnd) return null;
+  const { preamp, digiSel } = rfFrontEnd;
+  if (!preamp.availability.structural || !digiSel.availability.structural) return null;
+  const mutexActive = digiSel.reading.status === 'unknown' || digiSel.reading.value === true;
+  return mutexActive ? { field: 'rfFrontEnd.preamp', code: 'mutually-exclusive-control' } : null;
 }
 
 /**
@@ -791,6 +841,8 @@ export function toRadioViewModel(
   const filterPassband = deriveFilterPassband(state, caps);
   const dsp = deriveDsp(state, caps);
   const rfFrontEnd = deriveRfFrontEnd(state, caps);
+  const rfFrontEndMutex = deriveRfFrontEndMutex(rfFrontEnd);
+  if (rfFrontEndMutex) disabledReasons.push(rfFrontEndMutex);
 
   return {
     topologyId: `${topology.structuralCount}/${topology.scheme}`,

--- a/frontend/src/semantic/__tests__/rf-front-end.test.ts
+++ b/frontend/src/semantic/__tests__/rf-front-end.test.ts
@@ -1,11 +1,15 @@
 /**
  * MOR-1262 decomposition slice 6A (MOR-1292) — `rfFrontEnd` optional fact
- * group (validator half).
+ * group (validator half). Extended by slice 6A′ (MOR-1293) with `digiSel`/
+ * `ipPlus` and the `'mutually-exclusive-control'` `DisabledReasonCode` for
+ * the PREAMP/DIGI-SEL hardware mutex (MOR-479) — the derivation lives in
+ * `radio-view-model-adapter.ts`'s `deriveRfFrontEndMutex`, covered by
+ * `rf-front-end-adapter.test.ts`; this file only pins the SHAPE.
  *
- * Facts only: preamp, attenuator, RF gain, squelch (+ the `preValues`/
- * `attValues` capability-derived choice sets). A SEPARATE group from `dsp`
- * (MOR-1290, slice 5A) — see `radio-view-model.ts`'s `RfFrontEndViewModel`
- * doc comment for the group-shape rationale, and
+ * Facts only: preamp, attenuator, RF gain, squelch, DIGI-SEL, IP+ (+ the
+ * `preValues`/`attValues` capability-derived choice sets). A SEPARATE group
+ * from `dsp` (MOR-1290, slice 5A) — see `radio-view-model.ts`'s
+ * `RfFrontEndViewModel` doc comment for the group-shape rationale, and
  * `radio-view-model-adapter.ts`'s `deriveRfFrontEnd` for the live derivation
  * (covered by the companion adapter test file).
  *
@@ -146,5 +150,63 @@ describe('rfFrontEnd (MOR-1262 slice 6A)', () => {
     expect(validated.attValues).toEqual([0, 6, 12, 18]);
     expect(knownValue(validated.rfGain)).toBe(1);
     expect(knownValue(validated.squelch)).toBe(0);
+    expect(knownValue(validated.digiSel)).toBe(false);
+    expect(knownValue(validated.ipPlus)).toBe(false);
+  });
+
+  // ── MOR-1293 (slice 6A′): digiSel/ipPlus shape + the mutex reason code ───
+  it('rejects a non-boolean digiSel reading value with a precise error path', () => {
+    const withR = withRfFrontEnd(base);
+    const malformed = {
+      ...withR,
+      rfFrontEnd: {
+        ...withR.rfFrontEnd,
+        digiSel: { reading: { status: 'known', value: 'on' }, availability: AVAIL },
+      },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.rfFrontEnd\.digiSel\.reading\.value/);
+  });
+
+  it('rejects a non-boolean ipPlus reading value with a precise error path', () => {
+    const withR = withRfFrontEnd(base);
+    const malformed = {
+      ...withR,
+      rfFrontEnd: {
+        ...withR.rfFrontEnd,
+        ipPlus: { reading: { status: 'known', value: 1 }, availability: AVAIL },
+      },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.rfFrontEnd\.ipPlus\.reading\.value/);
+  });
+
+  it('rejects an rfFrontEnd group missing digiSel/ipPlus (N4 — no partial 6A shape survives)', () => {
+    const withR = withRfFrontEnd(base);
+    const { digiSel: _digiSel, ...withoutDigiSel } = withR.rfFrontEnd as RfFrontEndViewModel;
+    const malformed = { ...withR, rfFrontEnd: withoutDigiSel };
+    expect(() => validateRadioViewModel(malformed)).toThrow(TypeError);
+  });
+
+  it('accepts the rfFrontEnd.preamp disabledReasons entry the DIGI-SEL mutex derives (MOR-479, MOR-1293)', () => {
+    const withR = withRfFrontEnd(base);
+    const withMutex = {
+      ...withR,
+      disabledReasons: [
+        ...withR.disabledReasons,
+        { field: 'rfFrontEnd.preamp', code: 'mutually-exclusive-control' },
+      ],
+    };
+    const validated = validateRadioViewModel(withMutex);
+    expect(validated.disabledReasons).toContainEqual(
+      { field: 'rfFrontEnd.preamp', code: 'mutually-exclusive-control' },
+    );
+  });
+
+  it('rejects a disabledReasons entry with an unrecognized code (mutex code is NOT a wildcard)', () => {
+    const withR = withRfFrontEnd(base);
+    const malformed = {
+      ...withR,
+      disabledReasons: [...withR.disabledReasons, { field: 'rfFrontEnd.preamp', code: 'digisel-is-on' }],
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(TypeError);
   });
 });

--- a/frontend/src/semantic/fixtures/topologies.ts
+++ b/frontend/src/semantic/fixtures/topologies.ts
@@ -309,10 +309,14 @@ export function withDsp(fixture: RadioViewModel): RadioViewModel {
 }
 
 /**
- * Applies a fully-observed `rfFrontEnd` group (MOR-1262 slice 6A, MOR-1292)
- * to any topology fixture — a SEPARATE group from `dsp` above (see
- * `RfFrontEndViewModel`'s doc comment for why), same composable-axis story
- * as `withTxAux`/`withMeters`/`withRxAudio`/`withFilterPassband`/`withDsp`.
+ * Applies a fully-observed `rfFrontEnd` group (MOR-1262 slice 6A, MOR-1292;
+ * extended with `digiSel`/`ipPlus` by slice 6A′, MOR-1293) to any topology
+ * fixture — a SEPARATE group from `dsp` above (see `RfFrontEndViewModel`'s
+ * doc comment for why), same composable-axis story as
+ * `withTxAux`/`withMeters`/`withRxAudio`/`withFilterPassband`/`withDsp`.
+ * DIGI-SEL defaults to `known(false)` — mutex OFF, PRE not disabled by it —
+ * so this fixture stays a "nothing disabled" baseline; the mutex-ON/-unknown
+ * cases are exercised by the adapter's own dedicated tests, not this fixture.
  */
 export function withRfFrontEnd(fixture: RadioViewModel): RadioViewModel {
   const avail: Availability = { structural: true, operational: true };
@@ -325,6 +329,8 @@ export function withRfFrontEnd(fixture: RadioViewModel): RadioViewModel {
     attValues: [0, 6, 12, 18],
     rfGain: known(1),
     squelch: known(0),
+    digiSel: known(false),
+    ipPlus: known(false),
   };
   return { ...fixture, rfFrontEnd };
 }

--- a/frontend/src/semantic/radio-view-model.ts
+++ b/frontend/src/semantic/radio-view-model.ts
@@ -82,7 +82,13 @@ export type DisabledReasonCode =
   | 'capability-unavailable'
   | 'field-not-observed'
   | 'tx-target-unknown'
-  | 'out-of-band';
+  | 'out-of-band'
+  /** MOR-1293: a hardware mutex with another control's CURRENT state
+   *  disables this one (e.g. PREAMP while DIGI-SEL is on/unknown, MOR-479).
+   *  Distinct from `capability-unavailable` (the control doesn't exist) and
+   *  `field-not-observed` (this control's OWN reading is unobserved) —
+   *  here the control itself is fine, a PEER control's state disables it. */
+  | 'mutually-exclusive-control';
 
 export interface DisabledReason {
   field: string;
@@ -367,24 +373,31 @@ export interface DspViewModel {
 export type RfFrontEndField<T> = TxAuxField<T>;
 
 /**
- * RF front-end facts (MOR-1262 decomposition slice 6A, MOR-1292): preamp,
- * attenuator, RF gain, squelch. Facts only — no command emission, same
- * doctrine as `dsp`/`modeFilter`/`filterPassband`. Family enumeration is
- * explicit and CLOSED: NR/NB/notch/AGC are family 5 (`dsp`, MOR-1290) — this
- * group never duplicates them; DIGI-SEL/IP+ are the shipped `RfFrontEndProps`
- * panel's OWN remaining controls but are not part of this slice's four named
- * facts and are deliberately left uncovered here (ticket scope, not an
- * oversight — see the build report).
+ * RF front-end facts (MOR-1262 decomposition slice 6A, MOR-1292; extended by
+ * slice 6A′, MOR-1293): preamp, attenuator, RF gain, squelch, DIGI-SEL, IP+.
+ * Facts only — no command emission, same doctrine as
+ * `dsp`/`modeFilter`/`filterPassband`. Family enumeration is explicit and
+ * CLOSED: NR/NB/notch/AGC are family 5 (`dsp`, MOR-1290) — this group never
+ * duplicates them.
  *
- * `preamp`/`attenuator`/`rfGain`/`squelch` are plain pass-through readings:
- * unlike `dsp`'s `nrLevel`/`nbDepth`, the shipped `toRfFrontEndProps`
- * (`lib/runtime/props/panel-props.ts`) reads `rx.preamp`/`rx.att`/
- * `rx.rfGain`/`rx.squelch` verbatim, with no raw<->display scale conversion
- * — the server already reports these as display-ready values (dB steps,
- * preamp-level ordinal, 0-1 gain fractions). There is no separate "real
- * function" to consume for the VALUE; the parity surface here is the
- * CAPABILITY gate and the choice sets below, both copied verbatim from
- * `toRfFrontEndProps`.
+ * `digiSel`/`ipPlus` were deliberately left out of 6A (MOR-1292 review
+ * ruling — enumeration gap identical in kind to the filterShape/IF-shift/PBT
+ * one from MOR-1284) because they are the shipped `RfFrontEndProps` panel's
+ * OWN remaining controls, sourced from the same `toRfFrontEndProps`. This
+ * slice (MOR-1293) closes the gap: EXTENDING this group rather than adding a
+ * sibling, because they share the same panel, the same `rf-frontend-utils`
+ * neighborhood, and the same per-field shape as the original four — a
+ * sibling group would just be this one split for no reason.
+ *
+ * `preamp`/`attenuator`/`rfGain`/`squelch`/`digiSel`/`ipPlus` are plain
+ * pass-through readings: unlike `dsp`'s `nrLevel`/`nbDepth`, the shipped
+ * `toRfFrontEndProps` (`lib/runtime/props/panel-props.ts`) reads
+ * `rx.preamp`/`rx.att`/`rx.rfGain`/`rx.squelch`/`rx.digisel`/`rx.ipplus`
+ * verbatim, with no raw<->display scale conversion — the server already
+ * reports these as display-ready values (dB steps, preamp-level ordinal,
+ * 0-1 gain fractions, booleans). There is no separate "real function" to
+ * consume for the VALUE; the parity surface here is the CAPABILITY gate and
+ * the choice sets below, both copied verbatim from `toRfFrontEndProps`.
  *
  * `preValues`/`attValues` are the capability-derived preamp-level and
  * attenuator-dB choice sets (`Capabilities.preValues`/`.attValues`,
@@ -395,6 +408,21 @@ export type RfFrontEndField<T> = TxAuxField<T>;
  * (the shipped panel's own `[0, 6, 12, 18]`/`[0, 1, 2]` UI-convenience
  * defaults are presentation, not a fact — see `radio-view-model-adapter.ts`'s
  * `deriveRfFrontEnd`).
+ *
+ * THE MUTEX (MOR-479, MOR-1293): the shipped panel derives an IC-7610
+ * hardware mutex from `digiSel` — the radio silently ignores a PREAMP set
+ * while DIGI-SEL is ON, so `toRfFrontEndProps` disables the PRE control
+ * rather than let it light optimistically. This contract does NOT add a
+ * bespoke boolean for that (no `preDisabled` field here) — it expresses the
+ * mutex through the existing `RadioViewModel.disabledReasons` home, exactly
+ * like every other cross-field disable in this contract (`scope.*`,
+ * `receiver.*`), with `field: 'rfFrontEnd.preamp'` and the new
+ * `'mutually-exclusive-control'` code. See
+ * `radio-view-model-adapter.ts`'s `deriveRfFrontEnd` for the derivation,
+ * which reads the mutex condition off THIS group's own `digiSel` fact —
+ * never off raw state again — so a stale/unobserved DIGI-SEL reading FAILS
+ * CLOSED (the reason is present, disabling PRE) rather than silently
+ * re-enabling the control the way a naive `rawDigisel ?? false` would.
  */
 export interface RfFrontEndViewModel {
   preamp: RfFrontEndField<number>;
@@ -403,6 +431,8 @@ export interface RfFrontEndViewModel {
   attValues: readonly number[];
   rfGain: RfFrontEndField<number>;
   squelch: RfFrontEndField<number>;
+  digiSel: RfFrontEndField<boolean>;
+  ipPlus: RfFrontEndField<boolean>;
 }
 
 export interface RadioViewModel {
@@ -443,7 +473,8 @@ export interface RadioViewModel {
    *  `deriveDsp`. */
   readonly dsp?: DspViewModel;
   /** Absent (MOR-1264 optional group) ⇒ this radio declares no preamp, no
-   *  attenuator, no RF-gain and no squelch capability — see
+   *  attenuator, no RF-gain, no squelch, no DIGI-SEL and no IP+ capability
+   *  (MOR-1293 added the latter two) — see
    *  `radio-view-model-adapter.ts`'s `deriveRfFrontEnd`. */
   readonly rfFrontEnd?: RfFrontEndViewModel;
 }
@@ -453,6 +484,7 @@ const SLOT_IDS: readonly VfoSlotId[] = ['A', 'B'];
 const VFO_SCHEMES: readonly VfoScheme[] = ['single', 'ab', 'ab_shared', 'main_sub'];
 const DISABLED_REASON_CODES: readonly DisabledReasonCode[] = [
   'capability-unavailable', 'field-not-observed', 'tx-target-unknown', 'out-of-band',
+  'mutually-exclusive-control',
 ];
 
 function oneOf<T>(value: unknown, allowed: readonly T[], path: string): T {
@@ -829,11 +861,14 @@ function validateDsp(value: unknown, path: string): DspViewModel {
   };
 }
 
-/** N4 again: exactly the six facts the adapter reads, no speculative keys.
+/** N4 again: exactly the eight facts the adapter reads (MOR-1293 added
+ *  `digiSel`/`ipPlus` to 6A's original six), no speculative keys.
  *  See `radio-view-model-adapter.ts::deriveRfFrontEnd`. */
 function validateRfFrontEnd(value: unknown, path: string): RfFrontEndViewModel {
   const v = record(value, path);
-  exactKeys(v, ['preamp', 'preValues', 'attenuator', 'attValues', 'rfGain', 'squelch'], path);
+  exactKeys(v, [
+    'preamp', 'preValues', 'attenuator', 'attValues', 'rfGain', 'squelch', 'digiSel', 'ipPlus',
+  ], path);
   return {
     preamp: validateTxAuxField(v.preamp, `${path}.preamp`, num),
     preValues: numArray(v.preValues, `${path}.preValues`),
@@ -841,6 +876,8 @@ function validateRfFrontEnd(value: unknown, path: string): RfFrontEndViewModel {
     attValues: numArray(v.attValues, `${path}.attValues`),
     rfGain: validateTxAuxField(v.rfGain, `${path}.rfGain`, num),
     squelch: validateTxAuxField(v.squelch, `${path}.squelch`, num),
+    digiSel: validateTxAuxField(v.digiSel, `${path}.digiSel`, bool),
+    ipPlus: validateTxAuxField(v.ipPlus, `${path}.ipPlus`, bool),
   };
 }
 


### PR DESCRIPTION
## Summary
Closes the family-11 omission found by the 6A verification: `digiSel`/`ipPlus` facts extend the `rfFrontEnd` group, and the IC-7610 PREAMP/DIGI-SEL mutex (MOR-479) is expressed through the contract's `disabledReasons` home with a new generic `'mutually-exclusive-control'` code (in both the type union and the validator's runtime array) — so the 6B surface reproduces the shipped disable without raw-state reads. Derived from the group's OWN digiSel fact, never a second raw read (grep-verified single read; a second read would also lose active-receiver keying — bonus discriminator pinned).

**FAIL-CLOSED by design (safety):** unknown/stale DIGI-SEL disables PREAMP where v2's `rx?.digisel ?? false` fails open — the divergence is documented at the code site and pinned so a future "match v2 exactly" refactor goes red with an explanation attached. No over-blocking: observed `false` ⇒ no reason emitted. Net production LOC **24** strict / 89 raw (verifier re-measured; 2 files).

## Review provenance
Sonnet builder → independent opus vocabulary-domain verifier (13th ticket in domain, and the author of this ticket's scoping): **PASS, no findings requiring action** — first slice of the program with a clean first-round verdict. All 4 fail-closed cases probed against the REAL `toRfFrontEndProps`; mutations killed: revert-to-fail-open (2), second-raw-read (3, incl. the SUB-receiver discriminator), reason-code dropped from the validator array (5), absent-raw seeding (3). Capability gating degenerate probed; A-queue clean; fail-set identical to baseline (+23 passing); lint/boundaries/check clean; merge onto main clean (no vite.config hunk). 6B carry-forwards recorded (render the reason; never re-loosen).

Linear: MOR-1293

🤖 Generated with [Claude Code](https://claude.com/claude-code)