### PR TITLE
feat(MOR-1081): migrate layout, design-language, and theme selection to workspace ownership

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -11,9 +11,23 @@
   import { hasAnyScope } from './lib/stores/capabilities.svelte';
   import { getLayoutMode } from './lib/stores/layout.svelte';
   import { readQaCockpitLayoutOverride } from './lib/stores/qa-cockpit-override';
+  import { getDesignLanguage } from './presentation/languages/contract';
+  // Side-effect import: populates the design-language registry the lookup
+  // above resolves against, exactly as `semantic/design-language-renderers.ts`
+  // does. Imported here too so the activation effect below cannot depend on a
+  // lazily-loaded skin having pulled the barrel in first.
+  import './presentation/languages/declarations';
+  import { designLanguageActivation } from './presentation/workspace/activation';
+  import { getWorkspace, initWorkspaceStore } from './presentation/workspace/store.svelte';
   import { loadSkin, presentationResourcePlan, resolveSkinId, type SkinId } from './skins/registry';
   import { t } from '$lib/i18n';
   import './app.css';
+
+  // MOR-1081: the workspace store owns layout, design-language and theme
+  // selection. Initialised here — the composition root, and the first thing
+  // in it — so it is loaded before the first selection read below
+  // (`getLayoutMode()`) and before any skin, theme or surface mounts.
+  initWorkspaceStore();
 
   let backendError = $state<string | null>(null);
   let retrying = $state(false);
@@ -42,6 +56,21 @@
     isMobile,
     hasAnyScope: hasAnyScope(),
   }));
+
+  // MOR-1081: the workspace's `designLanguage` is the ONLY source the
+  // `[data-design-language]` activation attribute (MOR-1278) is written from,
+  // and this is its only writer — the MOR-1275 renderer wiring and the
+  // language stylesheets both read that same attribute, so there is no second
+  // activation path. `designLanguageActivation` gates on the language's own
+  // manifest, which is what keeps the shipped v2 skins unchanged until the
+  // cutover (MOR-1048/MOR-1263) declares them compatible.
+  $effect(() => {
+    const activated = designLanguageActivation(
+      getDesignLanguage(getWorkspace().designLanguage), skinId,
+    );
+    if (activated === null) delete document.documentElement.dataset.designLanguage;
+    else document.documentElement.dataset.designLanguage = activated;
+  });
 
   // ── Lazy presentation loading (MOR-1060) ──
   //

--- a/frontend/src/components-v2/theme/theme-switcher.ts
+++ b/frontend/src/components-v2/theme/theme-switcher.ts
@@ -1,3 +1,26 @@
+/**
+ * Theme selection — since MOR-1081 the theme ID lives in the single workspace
+ * store (`presentation/workspace/store.svelte.ts`); this module keeps the
+ * catalogue and applies the choice to the DOM.
+ *
+ * SINGLE WRITER. `rigplane:theme` and `rigplane:theme-user-choice` are no
+ * longer read or written here. MOR-1079's migration folded them into
+ * `WorkspaceV1.theme` (user-choice first, applied-theme second) and MOR-1076's
+ * rollback window only requires that older builds can still READ them — so
+ * they stay frozen at their migration-time value, never rewritten and never
+ * deleted, and the workspace object is the sole write target.
+ *
+ * `rigplane:vfo-theme` is deliberately untouched: MOR-1078 routed it
+ * `retain-outside` (a per-VFO override with no field in the frozen v1 schema),
+ * so its current owner is still this module.
+ */
+import type { WorkspaceThemeId } from '../../presentation/workspace/contract';
+import {
+  getWorkspace,
+  isThemeExplicit,
+  setTheme as setWorkspaceTheme,
+} from '../../presentation/workspace/store.svelte';
+
 export interface ThemeInfo {
   id: string;
   name: string;
@@ -5,8 +28,6 @@ export interface ThemeInfo {
   preview: string[]; // 5 colors for swatch
 }
 
-const STORAGE_KEY = 'rigplane:theme';
-const USER_CHOICE_KEY = 'rigplane:theme-user-choice';
 const VFO_STORAGE_KEY = 'rigplane:vfo-theme';
 
 const THEMES: ThemeInfo[] = [
@@ -148,51 +169,61 @@ export function getAvailableThemes(): ThemeInfo[] {
 }
 
 export function getTheme(): string {
-  if (typeof window === 'undefined') {
-    return 'default';
-  }
-  try {
-    return localStorage.getItem(STORAGE_KEY) || 'default';
-  } catch {
-    return 'default';
-  }
+  return getWorkspace().theme;
 }
 
 /**
  * True if the user has explicitly chosen a theme via the picker UI.
  * False when no user preference exists yet — lets skins pick a sensible
- * default without stomping an explicit user choice. Note: the applied-theme
- * key (STORAGE_KEY) may be written by framework startup code and is not a
- * reliable indicator of user intent — hence the separate USER_CHOICE_KEY.
+ * default without stomping an explicit user choice.
+ *
+ * MOR-1081 keeps v2's semantics exactly (KEY PRESENCE, any value — including
+ * an explicit `default`) while retiring the second key: the store latches, at
+ * load, whether the stored object carried a `theme` field at all, and
+ * `setThemeUserChoice` below is what makes it carry one. The applied-theme
+ * value alone could not answer this, which is precisely why v2 kept two keys.
  */
 export function hasExplicitTheme(): boolean {
-  if (typeof window === 'undefined') {
-    return false;
-  }
-  try {
-    return localStorage.getItem(USER_CHOICE_KEY) !== null;
-  } catch {
-    return false;
-  }
+  return isThemeExplicit();
 }
 
+/**
+ * Apply `id` to the DOM and record it as the current theme.
+ *
+ * NOT an explicit choice: this is the path a skin mount takes when it
+ * re-applies the theme already in effect, so it must not turn "never chose"
+ * into "chose" — see `setThemeUserChoice` for the operator's own pick.
+ */
 export function setTheme(id: string): void {
-  if (typeof window === 'undefined') {
-    return;
-  }
+  applyTheme(id, false);
+}
 
+/**
+ * Called by the theme picker UI when a user explicitly selects a theme.
+ * Applies the theme and records that the choice came from the user so
+ * skin auto-defaults (e.g. amber-lcd → lcd-warm) do not override it on
+ * subsequent loads — including when the user picks `default` itself.
+ */
+export function setThemeUserChoice(id: string): void {
+  applyTheme(id, true);
+}
+
+function applyTheme(id: string, explicit: boolean): void {
   // Validate theme ID
   if (!THEMES.some((theme) => theme.id === id)) {
     console.warn(`Unknown theme ID: ${id}`);
     return;
   }
 
-  // Store preference (applied-theme key; may be written at startup even
-  // without explicit user intent — see setThemeUserChoice for explicit).
-  try {
-    localStorage.setItem(STORAGE_KEY, id);
-  } catch (err) {
-    console.warn('Failed to save theme preference:', err);
+  // An explicit pick always goes through — it is what latches explicitness and
+  // makes the field persist, even when the value is unchanged. A non-explicit
+  // re-apply of the theme already selected writes nothing.
+  if (explicit || getWorkspace().theme !== id) {
+    setWorkspaceTheme(id as WorkspaceThemeId, explicit);
+  }
+
+  if (typeof document === 'undefined') {
+    return;
   }
 
   // Apply to DOM
@@ -200,24 +231,6 @@ export function setTheme(id: string): void {
     delete document.documentElement.dataset.theme;
   } else {
     document.documentElement.dataset.theme = id;
-  }
-}
-
-/**
- * Called by the theme picker UI when a user explicitly selects a theme.
- * Applies the theme and records that the choice came from the user so
- * skin auto-defaults (e.g. amber-lcd → lcd-warm) do not override it on
- * subsequent loads.
- */
-export function setThemeUserChoice(id: string): void {
-  setTheme(id);
-  if (typeof window === 'undefined') {
-    return;
-  }
-  try {
-    localStorage.setItem(USER_CHOICE_KEY, id);
-  } catch (err) {
-    console.warn('Failed to save user theme choice:', err);
   }
 }
 

--- a/frontend/src/lib/stores/__tests__/layout.test.ts
+++ b/frontend/src/lib/stores/__tests__/layout.test.ts
@@ -1,18 +1,47 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+/**
+ * MOR-1081 rewrote this store into a façade over the single workspace store,
+ * so the persistence assertions moved with it: the layout selection is read
+ * from and written to `rigplane:workspace`, never to `rigplane-layout` or
+ * `rigplane-skin`. The pure `normalizeLayoutMode` contract (MOR-1042 aliases,
+ * MOR-1257's QA-only exclusion) is unchanged and still pinned here.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const LAYOUT_KEY = 'rigplane-layout';
 const LEGACY_SKIN_KEY = 'rigplane-skin';
+const WORKSPACE_KEY = 'rigplane:workspace';
+const MIGRATED_KEY = 'rigplane:workspace-migrated:v1';
 
-async function loadStore() {
-  vi.resetModules();
-  return import('../layout.svelte');
+function fakeStorage(seed: Record<string, string> = {}) {
+  const data = new Map(Object.entries(seed));
+  return {
+    data,
+    storage: {
+      getItem: (k: string) => data.get(k) ?? null,
+      setItem: (k: string, v: string) => { data.set(k, v); },
+    },
+  };
 }
 
-describe('layout preference normalization', () => {
-  beforeEach(() => {
-    localStorage.clear();
-  });
+async function loadStore(seed: Record<string, string> = {}) {
+  vi.resetModules();
+  const store = await import('../layout.svelte');
+  const workspace = await import('../../../presentation/workspace/store.svelte');
+  const backing = fakeStorage(seed);
+  workspace.initWorkspaceStore(backing.storage);
+  return { ...store, ...backing };
+}
 
+/** The layout id as it is actually stored, not as the store reports it. */
+function persistedLayout(data: Map<string, string>): unknown {
+  return JSON.parse(data.get(WORKSPACE_KEY) ?? '{}').layout;
+}
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('layout preference normalization', () => {
   it.each([
     ['lcd', 'lcd-cockpit'],
     ['amber-lcd', 'lcd-cockpit'],
@@ -31,30 +60,43 @@ describe('layout preference normalization', () => {
     expect(normalizeLayoutMode(input)).toBe(expected);
   });
 
-  it('restores the primary layout preference before the legacy skin fallback', async () => {
-    localStorage.setItem(LAYOUT_KEY, 'lcd-scope');
-    localStorage.setItem(LEGACY_SKIN_KEY, 'amber-lcd');
-
-    const { getLayoutMode } = await loadStore();
+  it('restores the layout preference from the workspace object', async () => {
+    const { getLayoutMode } = await loadStore({
+      [WORKSPACE_KEY]: JSON.stringify({ version: 1, layout: 'lcd-scope' }),
+      [MIGRATED_KEY]: '1',
+      [LAYOUT_KEY]: 'standard',
+    });
 
     expect(getLayoutMode()).toBe('lcd-scope');
   });
 
-  it('restores a migrated legacy skin when no layout preference exists', async () => {
-    localStorage.setItem(LEGACY_SKIN_KEY, 'amber-lcd');
-
-    const { getLayoutMode } = await loadStore();
+  it('folds a legacy layout key in on the one-time migration, aliases included', async () => {
+    const { getLayoutMode } = await loadStore({ [LAYOUT_KEY]: 'amber-lcd' });
 
     expect(getLayoutMode()).toBe('lcd-cockpit');
   });
 
-  it('persists canonical values for legacy callers', async () => {
-    const { getLayoutMode, setLayoutMode } = await loadStore();
+  // MOR-1078 routed `rigplane-skin` to `retire` (dead write path), so adoption
+  // deliberately drops the pre-#889 fallback rather than migrating it. Kill-test:
+  // adding the key back to the migrate set would make this resolve to lcd-cockpit.
+  it('does not resurrect the retired rigplane-skin fallback', async () => {
+    const { getLayoutMode } = await loadStore({ [LEGACY_SKIN_KEY]: 'amber-lcd' });
+
+    expect(getLayoutMode()).toBe('auto');
+  });
+
+  it('persists canonical values to the workspace, never to the legacy key', async () => {
+    const { getLayoutMode, setLayoutMode, data } = await loadStore({
+      [WORKSPACE_KEY]: JSON.stringify({ version: 1 }),
+      [MIGRATED_KEY]: '1',
+      [LAYOUT_KEY]: 'auto',
+    });
 
     setLayoutMode('lcd');
 
     expect(getLayoutMode()).toBe('lcd-cockpit');
-    expect(localStorage.getItem(LAYOUT_KEY)).toBe('lcd-cockpit');
+    expect(persistedLayout(data)).toBe('lcd-cockpit');
+    expect(data.get(LAYOUT_KEY)).toBe('auto');
   });
 
   it('preserves the visible cycle and no-scope fallback using canonical values', async () => {
@@ -78,18 +120,21 @@ describe('layout preference normalization', () => {
   // `CanonicalLayoutMode` exclusion (or adding the value to
   // `CANONICAL_LAYOUT_MODES`) would make this normalize to itself instead of
   // falling through to 'auto', and it would then survive setLayoutMode /
-  // localStorage like any other forced preference.
+  // the workspace like any other forced preference.
   it('does not let the QA-only dual-receiver-cockpit value normalize to itself', async () => {
     const { normalizeLayoutMode } = await loadStore();
     expect(normalizeLayoutMode('dual-receiver-cockpit')).toBe('auto');
   });
 
   it('does not let setLayoutMode persist the QA-only dual-receiver-cockpit value', async () => {
-    const { getLayoutMode, setLayoutMode } = await loadStore();
+    const { getLayoutMode, setLayoutMode, data } = await loadStore({
+      [WORKSPACE_KEY]: JSON.stringify({ version: 1 }),
+      [MIGRATED_KEY]: '1',
+    });
 
     setLayoutMode('dual-receiver-cockpit');
 
     expect(getLayoutMode()).toBe('auto');
-    expect(localStorage.getItem(LAYOUT_KEY)).toBe('auto');
+    expect(persistedLayout(data)).toBe('auto');
   });
 });

--- a/frontend/src/lib/stores/layout.svelte.ts
+++ b/frontend/src/lib/stores/layout.svelte.ts
@@ -1,5 +1,8 @@
 /**
- * Layout preference store.
+ * Layout preference — since MOR-1081 a thin façade over the single workspace
+ * store (`presentation/workspace/store.svelte.ts`), which owns the selection,
+ * its validation and its persistence.
+ *
  * 'auto'        = standard layout when any scope available (HW or audio FFT), LCD otherwise
  * 'lcd'         = legacy alias for 'lcd-cockpit'
  * 'lcd-cockpit' = force LCD cockpit (TS-990S-style dual-cockpit)
@@ -10,15 +13,26 @@
  *                 `lib/stores/qa-cockpit-override.ts`) — deliberately NOT a
  *                 CanonicalLayoutMode, so normalizeLayoutMode below falls it
  *                 through to 'auto'. It can therefore never be persisted via
- *                 setLayoutMode/localStorage and never appears in the
+ *                 setLayoutMode/the workspace and never appears in the
  *                 StatusBar skin selector.
  *
- * Raw persisted aliases are normalized here before presentation policy reads
- * the preference.
+ * SINGLE WRITER (MOR-1081). This module no longer reads or writes
+ * `rigplane-layout` / `rigplane-skin`. The legacy keys are neither written nor
+ * deleted: MOR-1079's repository froze them at their migration-time value so
+ * an older build can still READ them during the rollback window, while the
+ * workspace object is the only thing this build writes. Reconciliation is
+ * therefore "the workspace wins, once migrated" by construction — the legacy
+ * keys are simply off the selection path.
+ *
+ * `normalizeLayoutMode` stays here, pure and unchanged: MOR-1042's canonical
+ * alias behavior is the contract several callers (skins/registry.ts,
+ * StatusBar) depend on, and the workspace validator applies the same alias
+ * table on its own read path.
  */
-
-const STORAGE_KEY = 'rigplane-layout';
-const LEGACY_SKIN_STORAGE_KEY = 'rigplane-skin';
+import {
+  getWorkspace,
+  setLayout as setWorkspaceLayout,
+} from '../../presentation/workspace/store.svelte';
 
 export type LayoutMode =
   | 'auto' | 'lcd' | 'lcd-cockpit' | 'lcd-scope' | 'standard' | 'sdr-test'
@@ -54,31 +68,20 @@ export function normalizeLayoutMode(value: unknown): CanonicalLayoutMode {
   return 'auto';
 }
 
-let mode = $state<CanonicalLayoutMode>(loadMode());
-
-function loadMode(): CanonicalLayoutMode {
-  if (typeof window === 'undefined') return 'auto';
-  const saved = localStorage.getItem(STORAGE_KEY)
-    ?? localStorage.getItem(LEGACY_SKIN_STORAGE_KEY);
-  return normalizeLayoutMode(saved);
-}
-
+/** Reactive: the workspace store's `$state` is the backing cell. */
 export function getLayoutMode(): LayoutMode {
-  return mode;
+  return getWorkspace().layout;
 }
 
 export function setLayoutMode(m: LayoutMode): void {
-  mode = normalizeLayoutMode(m);
-  if (typeof window !== 'undefined') {
-    localStorage.setItem(STORAGE_KEY, mode);
-  }
+  setWorkspaceLayout(normalizeLayoutMode(m));
 }
 
 export function cycleLayoutMode(hasAnyScope: boolean): void {
   if (hasAnyScope) {
     // auto → LCD cockpit → standard → auto
     const order: CanonicalLayoutMode[] = ['auto', 'lcd-cockpit', 'standard'];
-    const idx = order.indexOf(mode);
+    const idx = order.indexOf(normalizeLayoutMode(getLayoutMode()));
     setLayoutMode(order[(idx + 1) % order.length]);
   } else {
     // No scope at all: always LCD, no toggle needed

--- a/frontend/src/presentation/workspace/__tests__/selection-adoption.test.ts
+++ b/frontend/src/presentation/workspace/__tests__/selection-adoption.test.ts
@@ -1,0 +1,502 @@
+/**
+ * MOR-1081 — the adoption integration test: layout, design-language and theme
+ * selection now come from ONE workspace field set.
+ *
+ * It drives the real façades the app uses (`lib/stores/layout.svelte`,
+ * `components-v2/theme/theme-switcher`, `skins/registry`) against a recording
+ * fake storage, so every assertion about "who writes what" is about the actual
+ * call the shipped code makes, not about a mock of it.
+ *
+ * Pool: `fast`. Deliberately no `vi.resetModules()` / `vi.stubGlobal` — the
+ * store takes its storage as an argument, so the order-dependent shapes that
+ * force the workspace purity suites into the isolated pool (MOR-1272) are not
+ * needed here. `afterEach` re-inits the shared module state back to defaults
+ * so nothing leaks to a sibling file under `isolate: false`.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { DEFAULT_WORKSPACE } from '../contract';
+import { designLanguageActivation } from '../activation';
+import { WORKSPACE_MIGRATION_SENTINEL_KEY, WORKSPACE_STORAGE_KEY } from '../repository';
+import { getWorkspace, initWorkspaceStore, setDesignLanguage } from '../store.svelte';
+import {
+  cycleLayoutMode, getLayoutMode, setLayoutMode,
+} from '../../../lib/stores/layout.svelte';
+import { readQaCockpitLayoutOverride } from '../../../lib/stores/qa-cockpit-override';
+import {
+  getTheme, hasExplicitTheme, setTheme, setThemeUserChoice,
+} from '../../../components-v2/theme/theme-switcher';
+import { resolveSkinId } from '../../../skins/registry';
+import { fieldline, studioline } from '../../languages/declarations';
+
+const LEGACY_LAYOUT_KEY = 'rigplane-layout';
+const LEGACY_SKIN_KEY = 'rigplane-skin';
+const LEGACY_THEME_KEY = 'rigplane:theme';
+const LEGACY_THEME_USER_CHOICE_KEY = `${LEGACY_THEME_KEY}-user-choice`;
+
+interface Recorder {
+  readonly data: Map<string, string>;
+  readonly writes: string[];
+  readonly storage: Storage;
+}
+
+/** A full `Storage` whose `removeItem`/`clear` throw: deleting a legacy key in
+ *  the rollback window is a failure, not a tolerated write. */
+function recorder(seed: Record<string, string> = {}): Recorder {
+  const data = new Map(Object.entries(seed));
+  const writes: string[] = [];
+  const storage = {
+    getItem: (k: string) => data.get(k) ?? null,
+    setItem: (k: string, v: string) => { writes.push(k); data.set(k, v); },
+    removeItem: (k: string) => { throw new Error(`legacy-window violation: removeItem(${k})`); },
+    clear: () => { throw new Error('legacy-window violation: clear()'); },
+    key: (i: number) => [...data.keys()][i] ?? null,
+    get length() { return data.size; },
+  } as unknown as Storage;
+  return { data, writes, storage };
+}
+
+function workspaceJson(fields: Record<string, unknown>): string {
+  return JSON.stringify({ version: 1, ...fields });
+}
+
+/** Every key written that is not the one workspace key or its migration sentinel. */
+function foreignWrites(rec: Recorder): string[] {
+  return rec.writes.filter(
+    (k) => k !== WORKSPACE_STORAGE_KEY && k !== WORKSPACE_MIGRATION_SENTINEL_KEY,
+  );
+}
+
+beforeEach(() => {
+  document.documentElement.removeAttribute('data-theme');
+});
+
+afterEach(() => {
+  // Return the shared module-level `$state` to defaults for sibling files.
+  initWorkspaceStore(null);
+  document.documentElement.removeAttribute('data-theme');
+});
+
+describe('MOR-1081 — one workspace field set owns the selection', () => {
+  it('reconciles a disagreeing legacy key by letting the migrated workspace win', () => {
+    // The 1079 migration already ran (sentinel present) and the workspace says
+    // lcd-scope; `rigplane-layout` still holds the pre-migration value, and an
+    // older build during the rollback window could even have moved it on.
+    const rec = recorder({
+      [WORKSPACE_STORAGE_KEY]: workspaceJson({ layout: 'lcd-scope', theme: 'nord' }),
+      [WORKSPACE_MIGRATION_SENTINEL_KEY]: '1',
+      [LEGACY_LAYOUT_KEY]: 'standard',
+      [LEGACY_SKIN_KEY]: 'amber-lcd',
+      [LEGACY_THEME_KEY]: 'dracula',
+    });
+
+    initWorkspaceStore(rec.storage);
+
+    expect(getLayoutMode()).toBe('lcd-scope');
+    expect(getTheme()).toBe('nord');
+    // …and the legacy values are still there, untouched, for an older build.
+    expect(rec.data.get(LEGACY_LAYOUT_KEY)).toBe('standard');
+    expect(rec.data.get(LEGACY_THEME_KEY)).toBe('dracula');
+  });
+
+  it('migrates the legacy keys once when no workspace object exists yet', () => {
+    const rec = recorder({ [LEGACY_LAYOUT_KEY]: 'lcd', [LEGACY_THEME_USER_CHOICE_KEY]: 'nord' });
+
+    initWorkspaceStore(rec.storage);
+
+    // MOR-1042 alias canonicalization survives the migration read path.
+    expect(getLayoutMode()).toBe('lcd-cockpit');
+    expect(getTheme()).toBe('nord');
+  });
+
+  it('canonicalizes MOR-1042 aliases stored in the workspace object itself', () => {
+    const rec = recorder({
+      [WORKSPACE_STORAGE_KEY]: workspaceJson({ layout: 'amber-lcd' }),
+      [WORKSPACE_MIGRATION_SENTINEL_KEY]: '1',
+    });
+
+    initWorkspaceStore(rec.storage);
+
+    expect(getLayoutMode()).toBe('lcd-cockpit');
+  });
+
+  it('writes ONLY the workspace key when layout or theme is selected', () => {
+    const rec = recorder({
+      [WORKSPACE_STORAGE_KEY]: workspaceJson({}),
+      [WORKSPACE_MIGRATION_SENTINEL_KEY]: '1',
+      [LEGACY_LAYOUT_KEY]: 'auto',
+      [LEGACY_THEME_KEY]: 'default',
+    });
+    initWorkspaceStore(rec.storage);
+    rec.writes.length = 0;
+
+    setLayoutMode('lcd-scope');
+    setThemeUserChoice('nord');
+    cycleLayoutMode(true);
+
+    expect(foreignWrites(rec)).toEqual([]);
+    expect(rec.writes.every((k) => k === WORKSPACE_STORAGE_KEY)).toBe(true);
+    // The legacy keys keep their pre-adoption bytes: readable, never rewritten,
+    // never deleted (the fake throws on removeItem/clear).
+    expect(rec.data.get(LEGACY_LAYOUT_KEY)).toBe('auto');
+    expect(rec.data.get(LEGACY_THEME_KEY)).toBe('default');
+    expect(rec.data.get(LEGACY_THEME_USER_CHOICE_KEY)).toBeUndefined();
+  });
+
+  it('preserves the chosen presentation across a reload', () => {
+    const rec = recorder({
+      [WORKSPACE_STORAGE_KEY]: workspaceJson({}),
+      [WORKSPACE_MIGRATION_SENTINEL_KEY]: '1',
+    });
+    initWorkspaceStore(rec.storage);
+
+    setLayoutMode('lcd-scope');
+    setThemeUserChoice('gruvbox-dark');
+    setDesignLanguage('fieldline');
+
+    // Reload: a fresh init against the same bytes.
+    initWorkspaceStore(rec.storage);
+
+    expect(getLayoutMode()).toBe('lcd-scope');
+    expect(getTheme()).toBe('gruvbox-dark');
+    expect(getWorkspace().designLanguage).toBe('fieldline');
+  });
+
+  it('keeps selection working in-memory when writes are blocked (forward-read-only)', () => {
+    // A newer object this build cannot fully represent: the store latches
+    // "not writable", but the operator can still change presentation now.
+    const rec = recorder({
+      [WORKSPACE_STORAGE_KEY]: JSON.stringify({ version: 2, layout: 'lcd-scope', theme: 'v2-only-theme' }),
+      [WORKSPACE_MIGRATION_SENTINEL_KEY]: '1',
+    });
+    initWorkspaceStore(rec.storage);
+    rec.writes.length = 0;
+
+    setLayoutMode('standard');
+
+    expect(getLayoutMode()).toBe('standard');
+    expect(rec.writes).toEqual([]);
+  });
+});
+
+describe('MOR-1081 — capabilities cannot mutate the persisted preference', () => {
+  it('resolves `auto` against the rig at resolution time and leaves `auto` persisted', () => {
+    const rec = recorder({
+      [WORKSPACE_STORAGE_KEY]: workspaceJson({ layout: 'auto' }),
+      [WORKSPACE_MIGRATION_SENTINEL_KEY]: '1',
+    });
+    initWorkspaceStore(rec.storage);
+    rec.writes.length = 0;
+
+    const withScope = resolveSkinId({
+      capabilities: null, layoutPreference: getLayoutMode(), isMobile: false, hasAnyScope: true,
+    });
+    const withoutScope = resolveSkinId({
+      capabilities: null, layoutPreference: getLayoutMode(), isMobile: false, hasAnyScope: false,
+    });
+
+    expect(withScope).toBe('desktop-v2');
+    expect(withoutScope).toBe('lcd-cockpit');
+    // The resolved skin is never written back over the preference.
+    expect(getWorkspace().layout).toBe('auto');
+    expect(rec.writes).toEqual([]);
+    expect(JSON.parse(rec.data.get(WORKSPACE_STORAGE_KEY)!).layout).toBe('auto');
+  });
+
+  it('does not let a mobile viewport overwrite the persisted preference', () => {
+    const rec = recorder({
+      [WORKSPACE_STORAGE_KEY]: workspaceJson({ layout: 'standard' }),
+      [WORKSPACE_MIGRATION_SENTINEL_KEY]: '1',
+    });
+    initWorkspaceStore(rec.storage);
+    rec.writes.length = 0;
+
+    expect(resolveSkinId({
+      capabilities: null, layoutPreference: getLayoutMode(), isMobile: true, hasAnyScope: true,
+    })).toBe('mobile');
+    expect(getWorkspace().layout).toBe('standard');
+    expect(rec.writes).toEqual([]);
+  });
+});
+
+describe('MOR-1257 — the ?layout= QA override survives adoption byte-exactly', () => {
+  it('is desktop-only, non-persistable, and never writes the workspace', () => {
+    const rec = recorder({
+      [WORKSPACE_STORAGE_KEY]: workspaceJson({ layout: 'standard' }),
+      [WORKSPACE_MIGRATION_SENTINEL_KEY]: '1',
+    });
+    initWorkspaceStore(rec.storage);
+    rec.writes.length = 0;
+
+    const override = readQaCockpitLayoutOverride('?layout=dual-receiver-cockpit');
+    expect(override).toBe('dual-receiver-cockpit');
+
+    // App's own expression: the override wins for RESOLUTION only.
+    expect(resolveSkinId({
+      capabilities: null,
+      layoutPreference: override ?? getLayoutMode(),
+      isMobile: false,
+      hasAnyScope: true,
+    })).toBe('dual-receiver-cockpit');
+
+    // …and mobile still wins under 640px.
+    expect(resolveSkinId({
+      capabilities: null,
+      layoutPreference: override ?? getLayoutMode(),
+      isMobile: true,
+      hasAnyScope: true,
+    })).toBe('mobile');
+
+    // Nothing was persisted, and the stored preference is untouched.
+    expect(rec.writes).toEqual([]);
+    expect(getWorkspace().layout).toBe('standard');
+  });
+
+  it('cannot enter the workspace even if something tries to select it', () => {
+    const rec = recorder({
+      [WORKSPACE_STORAGE_KEY]: workspaceJson({ layout: 'standard' }),
+      [WORKSPACE_MIGRATION_SENTINEL_KEY]: '1',
+    });
+    initWorkspaceStore(rec.storage);
+
+    setLayoutMode('dual-receiver-cockpit');
+
+    expect(getWorkspace().layout).toBe('auto');
+    expect(JSON.parse(rec.data.get(WORKSPACE_STORAGE_KEY)!).layout).toBe('auto');
+  });
+});
+
+describe('MOR-1278 — the workspace is the only source [data-design-language] is written from', () => {
+  it('activates the selected language where its own manifest declares the layout', () => {
+    expect(designLanguageActivation(studioline, 'dual-receiver-cockpit')).toBe('studioline');
+  });
+
+  it('stays inert for a layout the language has not declared (no cutover here)', () => {
+    for (const layoutId of ['desktop-v2', 'lcd-cockpit', 'lcd-scope', 'mobile', 'sdr-test']) {
+      expect(designLanguageActivation(studioline, layoutId)).toBeNull();
+    }
+  });
+
+  it('honours an explicit incompatible declaration', () => {
+    expect(designLanguageActivation(fieldline, 'dual-receiver-cockpit')).toBeNull();
+  });
+
+  it('is inert when the selected id resolves to no registered manifest', () => {
+    expect(designLanguageActivation(undefined, 'dual-receiver-cockpit')).toBeNull();
+  });
+});
+
+describe('MOR-1081 — theme selection reads and writes the workspace only', () => {
+  it('applies the selection to the DOM and reports explicitness off the workspace', () => {
+    const rec = recorder({
+      [WORKSPACE_STORAGE_KEY]: workspaceJson({}),
+      [WORKSPACE_MIGRATION_SENTINEL_KEY]: '1',
+    });
+    initWorkspaceStore(rec.storage);
+
+    expect(hasExplicitTheme()).toBe(false);
+    setThemeUserChoice('tokyo-night');
+
+    expect(getTheme()).toBe('tokyo-night');
+    expect(hasExplicitTheme()).toBe(true);
+    expect(document.documentElement.dataset.theme).toBe('tokyo-night');
+    expect(foreignWrites(rec)).toEqual([]);
+  });
+
+  it('does not persist a re-apply of the theme already selected', () => {
+    const rec = recorder({
+      [WORKSPACE_STORAGE_KEY]: workspaceJson({ theme: 'nord' }),
+      [WORKSPACE_MIGRATION_SENTINEL_KEY]: '1',
+    });
+    initWorkspaceStore(rec.storage);
+    rec.writes.length = 0;
+
+    // What a skin mount does: re-apply the stored theme to the DOM.
+    setTheme(getTheme());
+
+    expect(document.documentElement.dataset.theme).toBe('nord');
+    expect(rec.writes).toEqual([]);
+  });
+
+  it('rejects an unknown theme id without touching the workspace', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const rec = recorder({
+      [WORKSPACE_STORAGE_KEY]: workspaceJson({ theme: 'nord' }),
+      [WORKSPACE_MIGRATION_SENTINEL_KEY]: '1',
+    });
+    initWorkspaceStore(rec.storage);
+    rec.writes.length = 0;
+
+    setTheme('not-a-theme');
+
+    expect(getTheme()).toBe('nord');
+    expect(rec.writes).toEqual([]);
+    warn.mockRestore();
+  });
+
+  it('falls back to the schema default with no storage at all', () => {
+    initWorkspaceStore(null);
+    expect(getTheme()).toBe(DEFAULT_WORKSPACE.theme);
+    expect(getLayoutMode()).toBe(DEFAULT_WORKSPACE.layout);
+  });
+});
+
+/**
+ * MOR-1081 F1 — the explicitness latch, pinned at the consumer.
+ *
+ * `hasExplicitTheme()` has exactly one consumer, `LcdLayout.svelte:6-14`, and
+ * the regression it guards is invisible at the store: an operator who picks
+ * *Default Dark* (a real, first-in-list, selectable theme) must keep it, and
+ * must not be silently given `lcd-warm` instead. `lcdLayoutBoot()` below is
+ * that component's own two lines, so these probes fail if the semantics drift
+ * even when every store-level assertion still passes.
+ */
+function lcdLayoutBoot(): string {
+  if (hasExplicitTheme()) setTheme(getTheme());
+  else document.documentElement.dataset.theme = 'lcd-warm';
+  // `setTheme('default')` deletes the attribute — absence IS Default Dark.
+  return document.documentElement.dataset.theme ?? 'default';
+}
+
+describe('MOR-1081 F1 — an explicit Default Dark survives reload and the amber-lcd default', () => {
+  it('fresh install: picking Default Dark in the UI keeps it across a reload', () => {
+    const rec = recorder();
+    initWorkspaceStore(rec.storage); // first boot, nothing chosen
+
+    expect(hasExplicitTheme()).toBe(false);
+    setThemeUserChoice('default');
+    expect(hasExplicitTheme()).toBe(true);
+
+    initWorkspaceStore(rec.storage); // reload
+
+    expect(getTheme()).toBe('default');
+    expect(hasExplicitTheme()).toBe(true);
+    expect(lcdLayoutBoot()).toBe('default');
+  });
+
+  it('migrated operator: legacy theme-user-choice=default keeps Default Dark', () => {
+    const rec = recorder({ [LEGACY_THEME_USER_CHOICE_KEY]: 'default' });
+    initWorkspaceStore(rec.storage); // one-time migration
+
+    expect(getTheme()).toBe('default');
+    expect(hasExplicitTheme()).toBe(true);
+    expect(lcdLayoutBoot()).toBe('default');
+
+    initWorkspaceStore(rec.storage); // reload
+
+    expect(hasExplicitTheme()).toBe(true);
+    expect(lcdLayoutBoot()).toBe('default');
+  });
+
+  it('control: Nord is unchanged, before and after a reload', () => {
+    const rec = recorder();
+    initWorkspaceStore(rec.storage);
+
+    setThemeUserChoice('nord');
+    expect(lcdLayoutBoot()).toBe('nord');
+
+    initWorkspaceStore(rec.storage);
+
+    expect(getTheme()).toBe('nord');
+    expect(hasExplicitTheme()).toBe(true);
+    expect(lcdLayoutBoot()).toBe('nord');
+  });
+
+  // The other half of the same invariant, and the reason the latch alone is not
+  // enough: once the first boot has written the workspace object, a never-chosen
+  // theme must STILL read as "never chosen", or every fresh install would lose
+  // the amber-lcd warm default on its second boot.
+  it('never-chose: the amber-lcd default still applies after the first boot writes', () => {
+    const rec = recorder();
+    initWorkspaceStore(rec.storage);
+    expect(lcdLayoutBoot()).toBe('lcd-warm');
+
+    // The migration write happened; the theme field must not be in it.
+    expect(rec.data.has(WORKSPACE_STORAGE_KEY)).toBe(true);
+    expect('theme' in JSON.parse(rec.data.get(WORKSPACE_STORAGE_KEY)!)).toBe(false);
+
+    initWorkspaceStore(rec.storage); // reload
+
+    expect(hasExplicitTheme()).toBe(false);
+    expect(lcdLayoutBoot()).toBe('lcd-warm');
+  });
+
+  it('a host re-applying the current theme does not turn "never chose" into "chose"', () => {
+    const rec = recorder();
+    initWorkspaceStore(rec.storage);
+
+    setTheme(getTheme()); // what RadioLayout/LcdLayout do on mount
+
+    expect(hasExplicitTheme()).toBe(false);
+  });
+
+  it('keeps a non-default value persisted even when it was never explicitly chosen', () => {
+    const rec = recorder();
+    initWorkspaceStore(rec.storage);
+
+    setTheme('nord'); // non-explicit, but carries real information
+
+    initWorkspaceStore(rec.storage);
+    expect(getTheme()).toBe('nord');
+  });
+});
+
+/**
+ * MOR-1081 F2 — "no duplicate writes" as a static pin.
+ *
+ * The behavioural pins above only see writes routed through the injected fake
+ * storage, so a rogue direct `localStorage.setItem('rigplane-layout', …)`
+ * escapes them entirely. This scan closes that hole: no production module may
+ * so much as NAME a legacy selection key, which also kills the const-indirection
+ * variant of the same mutation.
+ */
+describe('MOR-1081 F2 — no production module names a legacy selection key', () => {
+  /** `rigplane:theme` is a prefix of `rigplane:theme-user-choice`, so both are covered. */
+  const LEGACY_SELECTION_KEYS = ['rigplane-layout', 'rigplane-skin', 'rigplane:theme'];
+
+  /**
+   * `rigplane:vfo-theme` is deliberately NOT in the list: MOR-1078 routed it
+   * `retain-outside` (a per-VFO override with no field in the frozen v1
+   * schema), so `theme-switcher.ts` is still its legitimate owner and writer.
+   * It also does not contain any banned substring, so it needs no exemption
+   * beyond this comment.
+   */
+  const ALLOWED: readonly string[] = [
+    // The `getItem`-only routing table + migration reader (MOR-1078). Reads only.
+    'src/presentation/workspace/legacy-readers.ts',
+    // The v1.x → v2.x key RENAME (`icom-lan-*` → `rigplane-*`), which runs
+    // before the workspace exists and is what makes the legacy keys readable
+    // for the one-time migration. Not a selection write.
+    'src/lib/migrate-legacy-storage.ts',
+  ];
+
+  function productionSources(dir: string, out: string[] = []): string[] {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const path = `${dir}/${entry.name}`;
+      if (entry.isDirectory()) {
+        if (entry.name !== '__tests__') productionSources(path, out);
+      } else if (/\.(ts|svelte)$/.test(entry.name) && !entry.name.endsWith('.test.ts')) {
+        out.push(path);
+      }
+    }
+    return out;
+  }
+
+  /** Comments are prose about the retired keys — only real code counts. */
+  function stripComments(source: string): string {
+    return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+  }
+
+  it.each(LEGACY_SELECTION_KEYS)('no production file references %s', (key) => {
+    const offenders = productionSources('src')
+      .filter((path) => !ALLOWED.includes(path))
+      .filter((path) => stripComments(readFileSync(path, 'utf8')).includes(key));
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('the allow-list itself still exists, so a rename cannot silently empty the scan', () => {
+    for (const path of ALLOWED) expect(readFileSync(path, 'utf8').length).toBeGreaterThan(0);
+    expect(productionSources('src').length).toBeGreaterThan(200);
+  });
+});

--- a/frontend/src/presentation/workspace/activation.ts
+++ b/frontend/src/presentation/workspace/activation.ts
@@ -1,0 +1,35 @@
+/**
+ * MOR-1081 — the single route from the workspace's `designLanguage` selection
+ * to the `[data-design-language]` activation attribute.
+ *
+ * MOR-1278 froze that attribute on the semantic-vertical root as the ONE
+ * activation mechanism, and MOR-1275's `renderSlot` wiring reads the very same
+ * attribute. Adoption therefore may not introduce a second switch: this module
+ * only decides WHICH value the one attribute may carry, and the composition
+ * root (`App.svelte`) is the only caller that writes it.
+ *
+ * WHY A GATE AT ALL. The workspace always carries a `designLanguage` (v1 has
+ * no "unset"), but the app shell has not adopted design-language presentation
+ * yet — routing a language into every shipped skin IS the cutover
+ * (MOR-1048/MOR-1263), not this ticket. The gate is the language's OWN frozen
+ * manifest data rather than new policy: a family declares, in
+ * `layoutCompatibility`, which layouts it can serve. Today `studioline`
+ * declares exactly one (`dual-receiver-cockpit`), so the selection activates
+ * there and every v2 skin renders byte-identically to before.
+ *
+ * Pure: takes the manifest the caller already resolved, touches no DOM, no
+ * storage and no registry — the registry-populating `languages/declarations`
+ * barrel is a deliberate non-import here (the workspace zone's module-load
+ * purity pin), so the lookup stays the caller's.
+ */
+import type { DesignLanguageManifest } from '../languages/contract';
+
+/** The value `[data-design-language]` may take, or `null` for "no language active". */
+export function designLanguageActivation(
+  manifest: DesignLanguageManifest | undefined,
+  layoutId: string,
+): string | null {
+  if (manifest === undefined) return null;
+  const declared = manifest.layoutCompatibility.find((entry) => entry.layoutId === layoutId);
+  return declared?.compatible === true ? manifest.id : null;
+}

--- a/frontend/src/presentation/workspace/repository.ts
+++ b/frontend/src/presentation/workspace/repository.ts
@@ -20,10 +20,11 @@
  *    resurrect a legacy layout the operator has since changed.
  */
 import {
-  WORKSPACE_SCHEMA_VERSION, readWorkspace, readWorkspaceJson, serializeWorkspace,
+  DEFAULT_WORKSPACE, WORKSPACE_SCHEMA_VERSION,
+  readWorkspace, readWorkspaceJson, serializeWorkspace,
   type WorkspaceReadResult,
 } from './contract';
-import { readLegacyWorkspaceFromStorage } from './legacy-readers';
+import { buildWorkspaceInput, readLegacyWorkspace, snapshotLegacyStorage } from './legacy-readers';
 
 /** Unversioned on purpose: the schema version lives INSIDE the object, so a
  *  newer build writes its own version to this same key and an older build can
@@ -47,6 +48,20 @@ export interface WorkspaceLoad {
    *  unrepresentable value has been repaired away, a patched result validates
    *  cleanly and would silently overwrite the newer data. */
   readonly writable: boolean;
+  /**
+   * MOR-1081 — explicitness-via-presence. `true` when the loaded INPUT actually
+   * carried a `theme` key, i.e. the operator has a theme of their own; `false`
+   * when it did not, i.e. they never chose and a skin's own default applies.
+   *
+   * It has to be read off the input: `readWorkspace` folds an absent `theme`
+   * to the schema default WITHOUT a rejection, so `'default'` in the validated
+   * result is ambiguous between "explicitly picked Default Dark" and "never
+   * chose" — exactly the conflation v2's separate `rigplane:theme-user-choice`
+   * key existed to prevent. `persistWorkspace` keeps the distinction alive by
+   * omitting the field again when it was never chosen, so the answer survives
+   * a reload with no schema change.
+   */
+  readonly themeChosen: boolean;
 }
 
 const EMPTY_WORKSPACE_JSON = JSON.stringify({ version: WORKSPACE_SCHEMA_VERSION });
@@ -59,15 +74,36 @@ function readKey(storage: WorkspaceStorage, key: string): string | null {
   }
 }
 
+/** Did the stored text carry a `theme` key at all? Never throws. */
+function storedThemeChosen(text: string): boolean {
+  try {
+    const raw: unknown = JSON.parse(text);
+    return typeof raw === 'object' && raw !== null && !Array.isArray(raw) && 'theme' in raw;
+  } catch {
+    return false;
+  }
+}
+
+function load(
+  result: WorkspaceReadResult, source: WorkspaceLoadSource, themeChosen: boolean,
+): WorkspaceLoad {
+  return { result, source, writable: canPersistWorkspace(result), themeChosen };
+}
+
 /** Total: every storage state yields a validated result, nothing throws. */
 export function loadWorkspace(storage: WorkspaceStorage): WorkspaceLoad {
   const stored = readKey(storage, WORKSPACE_STORAGE_KEY);
-  const load = stored !== null
-    ? { result: readWorkspaceJson(stored), source: 'stored' as const }
-    : readKey(storage, WORKSPACE_MIGRATION_SENTINEL_KEY) !== null
-      ? { result: readWorkspaceJson(EMPTY_WORKSPACE_JSON), source: 'absent' as const }
-      : { result: readLegacyWorkspaceFromStorage(storage), source: 'migrated' as const };
-  return { ...load, writable: canPersistWorkspace(load.result) };
+  if (stored !== null) {
+    return load(readWorkspaceJson(stored), 'stored', storedThemeChosen(stored));
+  }
+  if (readKey(storage, WORKSPACE_MIGRATION_SENTINEL_KEY) !== null) {
+    // A cleared key is "back to defaults", never "resurrect a legacy choice".
+    return load(readWorkspaceJson(EMPTY_WORKSPACE_JSON), 'absent', false);
+  }
+  // First run. `buildWorkspaceInput` sets `theme` only when a legacy theme key
+  // existed, so its presence IS the migrated operator's explicitness.
+  const snapshot = snapshotLegacyStorage(storage);
+  return load(readLegacyWorkspace(snapshot), 'migrated', 'theme' in buildWorkspaceInput(snapshot));
 }
 
 /**
@@ -90,11 +126,26 @@ export function canPersistWorkspace(result: WorkspaceReadResult): boolean {
  *  always says "writable", because the unrepresentable value has been repaired
  *  away by then; the real gate is the `blocked` latch in `store.svelte.ts`,
  *  which holds the verdict from the LOAD. */
-export function persistWorkspace(storage: WorkspaceStorage, result: WorkspaceReadResult): boolean {
+export function persistWorkspace(
+  storage: WorkspaceStorage,
+  result: WorkspaceReadResult,
+  themeChosen = true,
+): boolean {
   if (!canPersistWorkspace(result)) return false;
   let payload: string;
   try {
-    payload = JSON.stringify(serializeWorkspace(result));
+    const object = serializeWorkspace(result);
+    // Explicitness-via-presence (MOR-1081). The field is omitted in exactly one
+    // case: it was never chosen AND it carries nothing beyond the schema
+    // default, i.e. it holds no information at all. Writing it anyway would
+    // make the next load indistinguishable from an explicit Default Dark, and
+    // a skin's own default (amber-lcd → lcd-warm) would be silently
+    // unreachable forever. Any non-default value is still persisted, chosen or
+    // not, so nothing can be lost. Omitting is not a schema change:
+    // `readWorkspace` already folds an absent `theme` to the default without a
+    // rejection.
+    if (!themeChosen && object.theme === DEFAULT_WORKSPACE.theme) delete object.theme;
+    payload = JSON.stringify(object);
   } catch {
     return false;
   }

--- a/frontend/src/presentation/workspace/store.svelte.ts
+++ b/frontend/src/presentation/workspace/store.svelte.ts
@@ -56,6 +56,18 @@ let backing: WorkspaceStorage | null = null;
  *  repaired away a patched result validates cleanly, so re-deriving would
  *  re-enable the write and destroy the newer data. */
 let blocked: WorkspaceNotice | null = null;
+/**
+ * MOR-1081 — the theme-explicitness latch, the same shape as `blocked` above:
+ * a verdict taken from the LOAD and then carried for the session.
+ *
+ * `WorkspaceV1.theme` is total — it always resolves to something — so the
+ * validated value cannot say whether the operator ever chose one. v2 answered
+ * that with a second key (`rigplane:theme-user-choice`); adoption answers it
+ * with the PRESENCE of the `theme` field in the stored object, which
+ * `repository.ts` reports on load and preserves on write. Read it through
+ * `isThemeExplicit()`. `$state` so a `$derived` consumer re-runs on a pick.
+ */
+let themeChosen = $state(false);
 
 function defaultStorage(): WorkspaceStorage | null {
   try {
@@ -85,6 +97,7 @@ function noticeFor(result: WorkspaceReadResult): WorkspaceNotice | null {
 export function initWorkspaceStore(storage: WorkspaceStorage | null = defaultStorage()): void {
   backing = storage;
   blocked = null;
+  themeChosen = false;
   if (storage === null) {
     current = INITIAL;
     notice = null;
@@ -94,7 +107,10 @@ export function initWorkspaceStore(storage: WorkspaceStorage | null = defaultSto
   current = load.result;
   notice = noticeFor(load.result);
   blocked = load.writable ? null : notice;
-  if (load.source === 'migrated' && persistWorkspace(storage, load.result)) markWorkspaceMigrated(storage);
+  themeChosen = load.themeChosen;
+  if (load.source === 'migrated' && persistWorkspace(storage, load.result, themeChosen)) {
+    markWorkspaceMigrated(storage);
+  }
 }
 
 export function getWorkspace(): WorkspaceV1 {
@@ -110,6 +126,19 @@ export function dismissWorkspaceNotice(): void {
   notice = null;
 }
 
+/**
+ * MOR-1081 — has the operator a theme of their OWN, as opposed to whatever the
+ * schema default resolved to? The signal a skin needs before it may apply its
+ * own default (amber-lcd → lcd-warm) without stomping a real choice, and the
+ * successor to v2's `rigplane:theme-user-choice` key presence.
+ *
+ * Explicitly picking `default` counts: `setTheme(id, true)` latches it and the
+ * field is then persisted, so Default Dark stays Default Dark across a reload.
+ */
+export function isThemeExplicit(): boolean {
+  return themeChosen;
+}
+
 function update(patch: Readonly<Record<string, unknown>>): void {
   const next = applyWorkspacePatch(current, patch);
   current = next;
@@ -120,7 +149,7 @@ function update(patch: Readonly<Record<string, unknown>>): void {
     notice = blocked;
     return;
   }
-  if (!persistWorkspace(backing, next)) {
+  if (!persistWorkspace(backing, next, themeChosen)) {
     notice = published ?? { kind: 'persist-failed', rejections: next.rejections };
   }
 }
@@ -133,7 +162,14 @@ export function setDesignLanguage(designLanguage: WorkspaceDesignLanguageId): vo
   update({ designLanguage });
 }
 
-export function setTheme(theme: WorkspaceThemeId): void {
+/**
+ * `explicit` = this came from the operator picking a theme, not from a host
+ * re-applying the one already selected. It latches `isThemeExplicit()` and is
+ * what makes the field persist — mirroring v2's `setTheme` /
+ * `setThemeUserChoice` split onto one field plus one latch.
+ */
+export function setTheme(theme: WorkspaceThemeId, explicit = false): void {
+  if (explicit) themeChosen = true;
   update({ theme });
 }
 


### PR DESCRIPTION
## Summary
The first adoption ticket: `initWorkspaceStore()` gains its first caller (App.svelte, before the first selection read); layout/design-language/theme selection is owned by the workspace store. Reconciliation-by-removal (verifier-probed: workspace wins over disagreeing legacy keys; legacy keys byte-untouched after boot + changes); single-writer pinned by a static source-scan over `rigplane-layout`/`rigplane-skin`/`rigplane:theme` (legit `vfo-theme` writer excluded with comment). Net production LOC **+28** strict / 167 raw — and **18 pre-existing baseline test failures fixed** as a side effect of removing the module-scope localStorage read (verifier-attributed honestly: strengthened tests, not weakened).

**Theme explicitness (owner-gated fix):** round-1 verification found a real regression — explicit *Default Dark* was permanently unexpressible (LCD substituted lcd-warm; v2 distinguished via a second key). Owner chose the load-time latch; the landed mechanism adds presence-semantics: `persistWorkspace` omits `theme` only when never-chosen AND still schema-default, so explicit Default Dark materialises in stored bytes and survives reload on BOTH migrated and fresh-install paths (delta-probed through real reloads; never-chose inverse keeps lcd-warm; omitted-field round-trip validates clean).

**Activation gate:** `[data-design-language]` written from one App $effect fed by the workspace, gated on the manifest's own `layoutCompatibility` — studioline declares only dual-receiver-cockpit, so every shipped v2 skin is byte-identical (gate-delete mutation red; ungated routing would effectively be the MOR-1263 cutover). `?layout=` QA override byte-exact per MOR-1257; `'auto'` persists as `'auto'` (capabilities cannot mutate preference — pinned); pre-#889 `rigplane-skin` fallback drop owner-accepted (retire disposition, soft degradation to auto-resolve).

## Review provenance
Opus builder → independent opus contracts-domain verifier (12th+ ticket in domain): round 1 **BLOCKED** (the theme regression — measured live on both paths — plus an unpinned no-duplicate-writes criterion); owner decided the fix; delta round **PASS** with real-reload probes on all four theme trajectories, W1/A1 mutations red, production delta enumerated file-by-file against the round-1 sha record. Info notes routed to MOR-1080 (settings UI): forward-read notice content; legacy applied-theme-only migration reads as explicit (errs toward preserving what the operator sees). Fail-set: zero new failures, 3 baseline files fixed, strict subset. lint/boundaries/check clean.

Linear: MOR-1081

🤖 Generated with [Claude Code](https://claude.com/claude-code)