### PR TITLE
feat(MOR-1082): adopt density, surface visibility, zone order, and pinned commands from the workspace

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -17,7 +17,16 @@
   // does. Imported here too so the activation effect below cannot depend on a
   // lazily-loaded skin having pulled the barrel in first.
   import './presentation/languages/declarations';
+  import { getLayout } from './presentation/layouts/contract';
+  // MOR-1082, the layout half of the same idiom: a side-effect import that
+  // populates the LAYOUT registry, so `getLayout(skinId)` below can resolve
+  // the active layout's declared zones. Manifests stay declarations — the
+  // surface plan reads `zones` and `requiredSemanticSurfaces`, nothing else.
+  import './presentation/layouts/declarations';
   import { designLanguageActivation } from './presentation/workspace/activation';
+  import {
+    densityActivation, provideSurfacePlan, resolveSurfacePlan,
+  } from './presentation/workspace/resolution';
   import { getWorkspace, initWorkspaceStore } from './presentation/workspace/store.svelte';
   import { loadSkin, presentationResourcePlan, resolveSkinId, type SkinId } from './skins/registry';
   import { t } from '$lib/i18n';
@@ -64,12 +73,33 @@
   // activation path. `designLanguageActivation` gates on the language's own
   // manifest, which is what keeps the shipped v2 skins unchanged until the
   // cutover (MOR-1048/MOR-1263) declares them compatible.
+  //
+  // MOR-1082 rides the SAME effect and the same gate rather than adding a
+  // second one: `[data-density]` carries the resolved density (the workspace
+  // override clamped by the ACTIVE language's own DensityClamp) on the same
+  // semantic-vertical root, so the two attributes can never disagree about
+  // which language is in force. No stylesheet consumes it yet — density
+  // rules arrive with the cutover — and it is absent entirely wherever the
+  // language is not active, so no shipped v2 skin sees a new attribute.
   $effect(() => {
-    const activated = designLanguageActivation(
-      getDesignLanguage(getWorkspace().designLanguage), skinId,
-    );
+    const language = getDesignLanguage(getWorkspace().designLanguage);
+    const activated = designLanguageActivation(language, skinId);
     if (activated === null) delete document.documentElement.dataset.designLanguage;
     else document.documentElement.dataset.designLanguage = activated;
+    const density = densityActivation(language, skinId, getWorkspace().density);
+    if (density === null) delete document.documentElement.dataset.density;
+    else document.documentElement.dataset.density = density;
+  });
+
+  // MOR-1082 — the workspace's per-zone `visibleSurfaces`/`zoneOrder`, resolved
+  // against the ACTIVE layout manifest and handed down as a getter. App is the
+  // only place that can do this: the semantic wiring must not import a layout
+  // manifest (that closes the manifest → loader → skin → wiring cycle the
+  // MOR-1068 wiring documents), and this is where the layout id already lives.
+  // A getter, so a consumer's `$derived` re-runs when either input changes.
+  provideSurfacePlan(() => {
+    const manifest = getLayout(skinId);
+    return manifest === undefined ? null : resolveSurfacePlan(manifest, getWorkspace());
   });
 
   // ── Lazy presentation loading (MOR-1060) ──

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -26,6 +26,10 @@
   import { runtime } from '$lib/runtime';
   import { toRadioViewModel } from '$lib/runtime/adapters/radio-view-model-adapter';
   import { getAppTxController } from '$lib/runtime/tx-controller/app-host';
+  import type { SemanticSurfaceName } from '../../presentation/layouts/contract';
+  import {
+    compositionSurfaces, useSurfacePlan, zoneShowsSurface,
+  } from '../../presentation/workspace/resolution';
   import MetersSurface from '../../semantic/MetersSurface.svelte';
   import type { RadioViewModel } from '../../semantic/radio-view-model';
   import RxTxSurface from '../../semantic/RxTxSurface.svelte';
@@ -60,6 +64,38 @@
     strips?: 'single' | 'dual';
   }
   let { strips = 'single' }: Props = $props();
+
+  /**
+   * MOR-1082 — the workspace's per-zone `visibleSurfaces`/`zoneOrder`, resolved
+   * by the composition root (App) against the ACTIVE layout manifest and read
+   * here through a context getter. The manifest itself is deliberately still
+   * NOT imported (see `strips` below): App owns the lookup, this file owns only
+   * the consultation.
+   *
+   * It can ONLY subtract. `zoneShows` answers "unchanged" whenever there is no
+   * plan (a standalone mount) or the active layout declares no such zone, the
+   * plan can never contain a surface the manifest did not declare, and the
+   * self-gates below (`view`, `view?.txAux`, `view?.meters`) are untouched — so
+   * "the workspace says visible" can never mount a surface whose view-model
+   * group is absent. `singleOrder` likewise falls back to the composed order,
+   * so the vertical can never resolve to a screen with no RX/TX surface.
+   */
+  const surfacePlan = useSurfacePlan();
+  const SINGLE_COMPOSITION: readonly SemanticSurfaceName[] = ['vfo', 'rxTx'];
+  let singleOrder = $derived(compositionSurfaces(surfacePlan(), SINGLE_COMPOSITION));
+  function zoneShows(zoneId: string, surface: SemanticSurfaceName): boolean {
+    return zoneShowsSurface(surfacePlan(), zoneId, surface);
+  }
+  /** The dual composition's per-receiver strips, after the workspace. Filtering
+   *  the `{#each}` SOURCE rather than wrapping its body keeps ONE place that
+   *  decides a strip's zone id — the id the DOM carries is the id consulted. */
+  function visibleStrips(model: RadioViewModel) {
+    return receiversOf(model)
+      .map((receiverId, index) => ({
+        receiverId, zoneId: index === 0 ? 'primary-vfo' : 'secondary-vfo',
+      }))
+      .filter(({ zoneId }) => zoneShows(zoneId, 'vfo'));
+  }
 
   const vfo = makeVfoHandlers();
   /**
@@ -161,7 +197,7 @@
   {#if view}
     {#if strips === 'dual'}
       <div class="channel-strips" data-testid="channel-strips">
-        {#each receiversOf(view) as receiverId, index (receiverId)}
+        {#each visibleStrips(view) as { receiverId, zoneId } (receiverId)}
           <!--
             `data-zone-id`: `ReceiverId` is `'MAIN' | 'SUB'`, so the index is
             total over the manifest's two per-receiver zones. A degraded
@@ -171,7 +207,7 @@
           <div
             class="channel-strip"
             data-testid={`channel-strip-${receiverId}`}
-            data-zone-id={index === 0 ? 'primary-vfo' : 'secondary-vfo'}
+            data-zone-id={zoneId}
             data-strip-receiver={receiverId}
             data-strip-active={isActiveStrip(view, receiverId)}
             data-strip-operational={isOperationalStrip(view, receiverId)}
@@ -214,16 +250,30 @@
         was unobserved. It is not `aria-disabled`: it holds live switches that
         already gate themselves on their own observed facts (F7).
       -->
-      <div class="cockpit-global-row" data-testid="cockpit-zone-global" data-zone-id="global">
-        <VfoSurface
-          viewModel={view}
-          showVfoList={false}
-          groupLabel={t('core.vfo.radioWideGroupLabel')}
-          onToggleSplit={vfo.onSplitToggle}
-          onToggleDualWatch={toggleDualWatch}
-        />
-      </div>
-    {:else}
+      {#if zoneShows('global', 'vfo')}
+        <div class="cockpit-global-row" data-testid="cockpit-zone-global" data-zone-id="global">
+          <VfoSurface
+            viewModel={view}
+            showVfoList={false}
+            groupLabel={t('core.vfo.radioWideGroupLabel')}
+            onToggleSplit={vfo.onSplitToggle}
+            onToggleDualWatch={toggleDualWatch}
+          />
+        </div>
+      {/if}
+    {/if}
+  {/if}
+
+  <!--
+    MOR-1082: the single composition's VFO half, moved into a snippet for the
+    same reason `rxTxSurface` is one — so the two surfaces the layout's single
+    zone mounts can be rendered in the ORDER that zone resolves to, from one
+    place, with exactly one `<VfoSurface>` tag per composition. Its render
+    site below is where the default path's VFO already was, so an unresolved
+    or default plan reproduces today's element sequence exactly.
+  -->
+  {#snippet vfoSurface()}
+    {#if view}
       <VfoSurface
         viewModel={view}
         onSelectVfo={selectVfo}
@@ -231,7 +281,7 @@
         onToggleDualWatch={toggleDualWatch}
       />
     {/if}
-  {/if}
+  {/snippet}
   <!--
     MOR-1069 (finding N1, routed from the MOR-1068 verification). The
     wrapper used to render on EVERY path as an inert `display: contents`
@@ -342,8 +392,16 @@
       which is the one DOM-order change this ticket makes: the alerts move
       up to sit beside RxTxSurface instead of after TxAuxSurface.
     -->
+    <!--
+      MOR-1082: only the SURFACE is workspace-gated. The TX-adjacent alerts
+      stay unconditional — they are not a semantic surface, and the MOD-input
+      preflight in particular must warn regardless of any presentation
+      preference. In every shipped layout `rxTx` is `requiredSemanticSurfaces`
+      and exactly one zone mounts it, so the plan refuses to hide it anyway;
+      the gate is here so the rule is enforced where it is read, not assumed.
+    -->
     <div class="rx-tx-zone" data-zone-id="rx-tx">
-      {@render rxTxSurface()}
+      {#if zoneShows('rx-tx', 'rxTx')}{@render rxTxSurface()}{/if}
       {@render txAdjacentAlerts()}
     </div>
     {@render txAuxSurface()}
@@ -353,8 +411,18 @@
       Single/default path (sdr-test / LCD / mobile): no bound zone exists
       here (MOR-1069), so containment is not possible — the alerts keep
       their pre-MOR-1258 position and order, unchanged.
+
+      MOR-1082: the layout's single zone mounts both `vfo` and `rxTx`
+      (sdr-test `main`, LCD `control-column`, mobile `portrait-deck`), so this
+      is where a per-zone reorder actually lands. `singleOrder` is the plan
+      flattened in zone-declaration order and falls back to the composed order
+      whenever no plan is resolved — an unresolved plan renders exactly the
+      sequence this path renders today.
     -->
-    {@render rxTxSurface()}
+    {#each singleOrder as surface (surface)}
+      {#if surface === 'vfo'}{@render vfoSurface()}
+      {:else if surface === 'rxTx'}{@render rxTxSurface()}{/if}
+    {/each}
     {@render txAuxSurface()}
     {@render metersSurface()}
     {@render txAdjacentAlerts()}

--- a/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
@@ -85,6 +85,15 @@ vi.mock('../command-bus', () => ({
 }));
 
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';
+// MOR-1082: the REAL manifests, through the app-wide registration barrel, and
+// the REAL resolution seam — the plans below are what App would hand down.
+import {
+  dualReceiverCockpitLayout, sdrTestLayout,
+} from '../../../presentation/layouts/declarations';
+import { readWorkspace } from '../../../presentation/workspace/contract';
+import {
+  resolveSurfacePlan, SURFACE_PLAN_CONTEXT_KEY, type SurfacePlan,
+} from '../../../presentation/workspace/resolution';
 
 const IDLE: Snapshot = {
   phase: 'idle', intent: null, guard: null, radioTx: 'off', txRisk: 'none',
@@ -141,10 +150,21 @@ const liveCaps = (withTxAux: boolean): Capabilities => ({
 let target: HTMLDivElement;
 let component: ReturnType<typeof mount> | null = null;
 
-function render(props: { strips?: 'single' | 'dual' } = {}): void {
+/**
+ * MOR-1082: `plan` is what the composition root (App) resolves and hands down
+ * through context. Omitting it is the pre-1082 mount — no plan, everything the
+ * composition declares — which every suite above therefore still exercises.
+ */
+function render(
+  props: { strips?: 'single' | 'dual' } = {},
+  plan?: SurfacePlan,
+): void {
   target = document.createElement('div');
   document.body.appendChild(target);
-  component = mount(SemanticRadioSurfaces, { target, props });
+  const context = plan === undefined
+    ? undefined
+    : new Map<unknown, unknown>([[SURFACE_PLAN_CONTEXT_KEY, () => plan]]);
+  component = mount(SemanticRadioSurfaces, { target, props, context });
   flushSync();
 }
 
@@ -354,5 +374,99 @@ describe('every txAux intent reaches its own command-bus handler', () => {
     const others = [h.rfPower, h.micGain, h.driveGain, h.voxGain, h.antiVoxGain,
       h.voxDelay, h.compLevel, h.monLevel].filter((s) => s !== spy());
     for (const other of others) expect(other).not.toHaveBeenCalled();
+  });
+});
+
+// ── MOR-1082: the workspace's per-zone visibility/order, consulted HERE ─────
+//
+// The plans below are built by the real `resolveSurfacePlan` from a real,
+// validated workspace against the real registered manifests, so these probes
+// fail if either the manifest or the resolution rules drift — not just if this
+// component's wiring does.
+
+describe('MOR-1082 — the semantic vertical consults the resolved surface plan', () => {
+  /** What App resolves for `layout` given a stored workspace `fields`. */
+  function planFor(layout: typeof sdrTestLayout, fields: Record<string, unknown>): SurfacePlan {
+    return resolveSurfacePlan(layout, readWorkspace({ version: 1, ...fields }).workspace);
+  }
+
+  const stripIds = () => [...target.querySelectorAll<HTMLElement>('[data-testid^="channel-strip-"]')]
+    .map((el) => el.dataset.testid!);
+  /** `vfo-surface` / `rx-tx-surface`, in document order — the order probe. */
+  const surfaceOrder = () => [...target.querySelectorAll<HTMLElement>(
+    '[data-testid="vfo-surface"], [data-testid="rx-tx-surface"]',
+  )].map((el) => el.dataset.testid!);
+
+  it('hides a strip the operator switched off, and only that strip', () => {
+    // MUTATION KILLED: ignoring `visibleSurfaces` in the dual composition —
+    // the SUB strip would still mount. Also kills gating the wrong zone: the
+    // MAIN strip, the global row and the RX/TX surface must all survive.
+    render({ strips: 'dual' }, planFor(dualReceiverCockpitLayout, {
+      visibleSurfaces: { 'secondary-vfo': [] },
+    }));
+
+    expect(stripIds()).toEqual(['channel-strip-MAIN']);
+    expect(q('[data-testid="cockpit-zone-global"]')).not.toBeNull();
+    expect(q('[data-testid="rx-tx-surface"]')).not.toBeNull();
+    expect(q('[data-testid="rx-tx-key"]')).not.toBeNull();
+  });
+
+  it('renders every declared zone when the operator expressed nothing', () => {
+    render({ strips: 'dual' }, planFor(dualReceiverCockpitLayout, {}));
+
+    expect(stripIds()).toEqual(['channel-strip-MAIN', 'channel-strip-SUB']);
+    expect(q('[data-testid="cockpit-zone-global"]')).not.toBeNull();
+  });
+
+  it('refuses to hide the RX/TX surface — the only unkey affordance', () => {
+    // `rxTx` is `requiredSemanticSurfaces` and exactly one zone mounts it, so
+    // the plan restores it. MUTATION KILLED: dropping the required-coverage
+    // arm of `resolveSurfacePlan`, which would leave a keyed operator with no
+    // way to stop transmitting.
+    render({ strips: 'dual' }, planFor(dualReceiverCockpitLayout, {
+      visibleSurfaces: { 'rx-tx': [] },
+    }));
+
+    expect(q('[data-testid="rx-tx-surface"]')).not.toBeNull();
+    expect(q('[data-testid="rx-tx-unkey"]')).not.toBeNull();
+  });
+
+  it('cannot force-show a surface whose view-model group is absent', () => {
+    // The S0 self-gate outranks the workspace. This radio's MOR-1244 evidence
+    // gate declined `txAux`; a workspace that names it everywhere it could be
+    // named still mounts nothing. MUTATION KILLED: rendering a surface because
+    // the plan lists it, rather than because the view model carries it.
+    h.state = liveState(false);
+    h.caps = liveCaps(false);
+    render({ strips: 'dual' }, planFor(dualReceiverCockpitLayout, {
+      visibleSurfaces: { 'rx-tx': ['rxTx', 'txAux'], 'primary-vfo': ['vfo', 'txAux'] },
+      zoneOrder: { 'rx-tx': ['txAux', 'rxTx'] },
+    }));
+
+    expect(q('[data-testid="tx-aux-surface"]')).toBeNull();
+    expect(target.innerHTML).not.toContain('tx-aux');
+    // …and the surface that IS declared there is still exactly where it was.
+    expect(q('.rx-tx-zone [data-testid="rx-tx-surface"]')).not.toBeNull();
+  });
+
+  it('reorders the single composition from the zone that mounts both surfaces', () => {
+    // sdr-test's `main` zone declares ['vfo', 'rxTx']; the operator flipped it.
+    // MUTATION KILLED: ignoring `zoneOrder` in the single composition, or
+    // hard-coding the VFO-before-RX/TX sequence.
+    render({ strips: 'single' }, planFor(sdrTestLayout, {
+      zoneOrder: { main: ['rxTx', 'vfo'] },
+    }));
+
+    expect(surfaceOrder()).toEqual(['rx-tx-surface', 'vfo-surface']);
+  });
+
+  it('keeps the default sequence with a plan that expresses nothing, and with none at all', () => {
+    render({ strips: 'single' }, planFor(sdrTestLayout, {}));
+    expect(surfaceOrder()).toEqual(['vfo-surface', 'rx-tx-surface']);
+
+    if (component) unmount(component);
+    document.body.innerHTML = '';
+    render({ strips: 'single' });
+    expect(surfaceOrder()).toEqual(['vfo-surface', 'rx-tx-surface']);
   });
 });

--- a/frontend/src/presentation/workspace/__tests__/preferences-adoption.test.ts
+++ b/frontend/src/presentation/workspace/__tests__/preferences-adoption.test.ts
@@ -1,0 +1,363 @@
+/**
+ * MOR-1082 — the adoption pins for the workspace's own COARSE fields:
+ * `density`, `visibleSurfaces`, `zoneOrder` and `pinnedCommands`.
+ *
+ * Scope, per the MOR-1289 owner decision (which post-dates the ticket text):
+ * the fine-grained legacy panel keys (`rigplane:panel-collapsed`,
+ * `panel-order`, `right-panel-order`, `lcd-*`, `vfo-theme`) have NO v1 home
+ * and stay RETAIN-OUTSIDE with their current owners — nothing here migrates
+ * them, derives them, or writes them. What is adopted is the four fields the
+ * MOR-1076 freeze already put in the v1 contract and MOR-1079 already gave
+ * setters.
+ *
+ * Everything below runs against the REAL registered manifests (through the
+ * `declarations` barrels, never a local copy of a manifest), so a manifest
+ * edit that breaks an adoption invariant fails HERE rather than at the
+ * cutover.
+ *
+ * Pool: `fast`. No `vi.mock`, no `vi.stubGlobal`, no `vi.resetModules()` —
+ * the resolution seam is pure and the store takes its storage as an argument,
+ * so none of the order-dependent shapes that force the workspace purity
+ * suites into the isolated pool (MOR-1272) appear here. `afterEach` returns
+ * the shared store state to defaults for sibling files under `isolate: false`.
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import type { DensityLevel, DesignLanguageManifest } from '../../languages/contract';
+import type { LayoutManifest, SemanticSurfaceName } from '../../layouts/contract';
+import { fieldline, studioline } from '../../languages/declarations';
+import {
+  desktopV2Layout, dualReceiverCockpitLayout, lcdCockpitLayout, mobileLayout, sdrTestLayout,
+} from '../../layouts/declarations';
+import { DEFAULT_WORKSPACE, readWorkspace, type WorkspaceV1 } from '../contract';
+import { classifyLegacyKey } from '../legacy-readers';
+import {
+  compositionSurfaces, densityActivation, resolveSurfacePlan,
+} from '../resolution';
+import {
+  getWorkspace, initWorkspaceStore, setDensity, setPinnedCommands,
+} from '../store.svelte';
+
+/** A validated workspace carrying `fields` — the ONLY way one is built here:
+ *  the resolution seam consumes an already-validated object and must not
+ *  re-validate (that is the store's job, MOR-1077/1079). */
+function workspace(fields: Record<string, unknown>): WorkspaceV1 {
+  return readWorkspace({ version: 1, ...fields }).workspace;
+}
+
+function plan(manifest: LayoutManifest, fields: Record<string, unknown> = {}) {
+  return resolveSurfacePlan(manifest, workspace(fields));
+}
+
+afterEach(() => {
+  initWorkspaceStore(null);
+});
+
+// ── 1. Density: DL default + workspace override, clamped by the ACTIVE
+//       language at RESOLUTION time (MOR-1076 decision 4, hybrid arm) ───────
+
+describe('MOR-1082 — density resolves against the ACTIVE design language', () => {
+  it('honours the operator override where the language supports it', () => {
+    expect(densityActivation(studioline, 'dual-receiver-cockpit', 'dense')).toBe('dense');
+    expect(densityActivation(studioline, 'dual-receiver-cockpit', 'compact')).toBe('compact');
+  });
+
+  it('is inert wherever the language itself is not active (no cutover here)', () => {
+    // Same gate as `[data-design-language]` (MOR-1081/MOR-1278): density can
+    // never activate on a layout the language has not declared, so every
+    // shipped v2 skin keeps its current, density-free presentation.
+    for (const layoutId of ['desktop-v2', 'lcd-cockpit', 'lcd-scope', 'mobile', 'sdr-test']) {
+      expect(densityActivation(studioline, layoutId, 'dense')).toBeNull();
+    }
+    expect(densityActivation(fieldline, 'dual-receiver-cockpit', 'compact')).toBeNull();
+    expect(densityActivation(undefined, 'dual-receiver-cockpit', 'compact')).toBeNull();
+  });
+
+  /**
+   * The pin the ticket names: FIELDLINE HAS NO `dense`. The clamp applied is
+   * the ACTIVE language's own `DensityClamp`, read live off its manifest —
+   * not the `WORKSPACE_DENSITY_CLAMP` mirror, and not the clamp of whatever
+   * language the workspace happens to have stored.
+   *
+   * `fieldline` declares `dual-receiver-cockpit` INCOMPATIBLE, so it is never
+   * active on any registered layout today and the clamp cannot be exercised
+   * through it directly. This borrows its real, frozen clamp onto a manifest
+   * that IS active somewhere — a language with fieldline's density policy.
+   */
+  const activeFieldline: DesignLanguageManifest = {
+    ...fieldline,
+    layoutCompatibility: [{ layoutId: 'dual-receiver-cockpit', compatible: true }],
+  };
+
+  it('clamps an out-of-clamp override down to the active language default', () => {
+    expect(fieldline.density).toEqual({ kind: 'clamped', supported: ['comfortable', 'compact'] });
+    expect(densityActivation(activeFieldline, 'dual-receiver-cockpit', 'dense')).toBe('comfortable');
+    expect(densityActivation(activeFieldline, 'dual-receiver-cockpit', 'compact')).toBe('compact');
+  });
+
+  it('clamps against the ACTIVE language even when the stored one allows the value', () => {
+    // The workspace stores `studioline` + `dense`; the language actually
+    // ACTIVE on screen is a fieldline-clamped one. Kills: resolving the clamp
+    // from `workspace.designLanguage` (or from the pinned mirror) instead of
+    // from the manifest handed in.
+    const stored = workspace({ designLanguage: 'studioline', density: 'dense' });
+    expect(stored.density).toBe('dense');
+    expect(densityActivation(activeFieldline, 'dual-receiver-cockpit', stored.density)).toBe('comfortable');
+  });
+
+  it('passes an override straight through for a language that declares no clamp', () => {
+    const free: DesignLanguageManifest = {
+      ...studioline,
+      density: { kind: 'not-applicable' },
+    };
+    expect(densityActivation(free, 'dual-receiver-cockpit', 'dense')).toBe('dense');
+  });
+
+  it('refuses an out-of-clamp density at the STORE too, so nothing unclamped persists', () => {
+    initWorkspaceStore(null);
+    setDensity('dense');
+    expect(getWorkspace().density).toBe('dense'); // studioline is stored → allowed
+    expect(DEFAULT_WORKSPACE.density).toBe('comfortable');
+    // …and a fieldline workspace cannot even hold `dense` (MOR-1077 pickDensity).
+    expect(workspace({ designLanguage: 'fieldline', density: 'dense' }).density).toBe('comfortable');
+  });
+});
+
+// ── 2. visibleSurfaces / zoneOrder: the workspace may only FURTHER hide and
+//       reorder WITHIN a zone the active layout already declares ────────────
+
+describe('MOR-1082 — the surface plan starts from what the manifest declares', () => {
+  it('is the manifest, verbatim, for a workspace that expresses no preference', () => {
+    expect([...plan(dualReceiverCockpitLayout)]).toEqual([
+      ['primary-vfo', ['vfo']], ['secondary-vfo', ['vfo']], ['global', ['vfo']], ['rx-tx', ['rxTx']],
+    ]);
+    expect([...plan(sdrTestLayout)]).toEqual([['main', ['vfo', 'rxTx']]]);
+  });
+
+  it('applies ONE contract to every layout family — mobile does not fork', () => {
+    // Kills: a mobile-specific preference path. The same function, the same
+    // workspace object, and every registered family answers in its own zone
+    // vocabulary with no special case.
+    for (const manifest of [mobileLayout, lcdCockpitLayout, desktopV2Layout]) {
+      expect([...plan(manifest).keys()]).toEqual(manifest.zones.map((zone) => zone.id));
+      for (const zone of manifest.zones) {
+        expect(plan(manifest).get(zone.id)).toEqual([...zone.surfaces]);
+      }
+    }
+    // The same preference, expressed once, lands identically on mobile and on
+    // the LCD — including the REFUSAL: both mount their required surfaces in a
+    // single zone, so hiding one there is refused in exactly the same way.
+    expect(plan(mobileLayout, { zoneOrder: { 'portrait-deck': ['rxTx'] } }).get('portrait-deck'))
+      .toEqual(['rxTx', 'vfo']);
+    expect(plan(lcdCockpitLayout, { zoneOrder: { 'control-column': ['rxTx'] } }).get('control-column'))
+      .toEqual(['rxTx', 'vfo']);
+    expect(plan(mobileLayout, { visibleSurfaces: { 'portrait-deck': ['rxTx'] } }).get('portrait-deck'))
+      .toEqual(['vfo', 'rxTx']);
+    expect(plan(lcdCockpitLayout, { visibleSurfaces: { 'control-column': ['rxTx'] } }).get('control-column'))
+      .toEqual(['vfo', 'rxTx']);
+  });
+
+  it('hides a surface the operator switched off in that zone', () => {
+    const hidden = plan(dualReceiverCockpitLayout, { visibleSurfaces: { 'secondary-vfo': [] } });
+    expect(hidden.get('secondary-vfo')).toEqual([]);
+    // …and touches no other zone: `vfo` is still mounted where it was.
+    expect(hidden.get('primary-vfo')).toEqual(['vfo']);
+    expect(hidden.get('global')).toEqual(['vfo']);
+  });
+
+  it('cannot FORCE-SHOW a surface into a zone that does not declare it', () => {
+    // The manifest is the ceiling. Kills: treating `visibleSurfaces` as the
+    // list of what to render rather than as an allow-list over the declared
+    // set — which would mount `vfo` in the RX/TX zone on the operator's say-so.
+    const forced = plan(dualReceiverCockpitLayout, {
+      visibleSurfaces: { 'rx-tx': ['vfo', 'rxTx'] },
+    });
+    expect(forced.get('rx-tx')).toEqual(['rxTx']);
+  });
+
+  it('cannot move a surface ACROSS zones through the plan either', () => {
+    // The contract already refuses a duplicate across zones on READ; the
+    // adoption must not open a second door. `txAux` is a real surface id that
+    // no shipped zone declares, so naming it is the purest cross-zone probe.
+    const moved = plan(sdrTestLayout, {
+      visibleSurfaces: { main: ['vfo', 'rxTx', 'txAux'] },
+      zoneOrder: { main: ['txAux', 'rxTx', 'vfo'] },
+    });
+    expect(moved.get('main')).toEqual(['rxTx', 'vfo']);
+    expect(moved.get('main')).not.toContain('txAux');
+  });
+
+  it('reorders within a zone, and normalizes a partial or padded order', () => {
+    expect(plan(sdrTestLayout, { zoneOrder: { main: ['rxTx', 'vfo'] } }).get('main'))
+      .toEqual(['rxTx', 'vfo']);
+    // Partial: what the operator named leads, the rest follows in DECLARED order.
+    expect(plan(sdrTestLayout, { zoneOrder: { main: ['rxTx'] } }).get('main'))
+      .toEqual(['rxTx', 'vfo']);
+    // An order naming nothing the zone declares is inert, never destructive.
+    expect(plan(sdrTestLayout, { zoneOrder: { main: ['meters'] } }).get('main'))
+      .toEqual(['vfo', 'rxTx']);
+  });
+
+  it('refuses a hide that would leave a REQUIRED surface mounted by no zone', () => {
+    // `requiredSemanticSurfaces` is the layout's own invariant — the validator
+    // already refuses a manifest whose zones do not mount one. A persisted
+    // preference may not break what a manifest may not declare. For `rxTx`
+    // this is also the TX-safety arm: the RX/TX surface carries the ONLY
+    // unkey affordance, and exactly one zone in every shipped layout mounts it.
+    const stripped = plan(dualReceiverCockpitLayout, { visibleSurfaces: { 'rx-tx': [] } });
+    expect(stripped.get('rx-tx')).toEqual(['rxTx']);
+
+    // Same rule, the vfo arm: hiding it in ONE of the three zones that mount
+    // it is honoured, because two still do.
+    const partial = plan(dualReceiverCockpitLayout, { visibleSurfaces: { 'secondary-vfo': [] } });
+    expect(partial.get('secondary-vfo')).toEqual([]);
+
+    // …but hiding it in ALL of them is refused, in every one.
+    const total = plan(dualReceiverCockpitLayout, {
+      visibleSurfaces: { 'primary-vfo': [], 'secondary-vfo': [], global: [] },
+    });
+    expect(total.get('primary-vfo')).toEqual(['vfo']);
+    expect(total.get('secondary-vfo')).toEqual(['vfo']);
+    expect(total.get('global')).toEqual(['vfo']);
+    // The rx-tx zone was never touched by that write.
+    expect(total.get('rx-tx')).toEqual(['rxTx']);
+  });
+
+  it('never re-validates: an invalid zone or id is already gone before it arrives', () => {
+    // MOR-1082 acceptance "invalid order/size is normalized" is the STORE's
+    // behaviour (MOR-1077), and the plan must not duplicate it. Proof that the
+    // validation happened upstream: the invalid names are absent from the
+    // validated object the plan is handed, and rejections were reported.
+    const read = readWorkspace({
+      version: 1,
+      visibleSurfaces: { 'not-a-zone': ['vfo'], 'rx-tx': ['not-a-surface', 'rxTx'] },
+      zoneOrder: 'not-an-object',
+    });
+    expect(read.outcome).toBe('repaired');
+    expect(read.workspace.visibleSurfaces).toEqual({ 'rx-tx': ['rxTx'] });
+    expect(read.workspace.zoneOrder).toEqual({});
+    expect(read.rejections.map((r) => r.reason)).toEqual(
+      expect.arrayContaining(['unknown-id', 'malformed']),
+    );
+    expect([...resolveSurfacePlan(dualReceiverCockpitLayout, read.workspace)]).toEqual([
+      ['primary-vfo', ['vfo']], ['secondary-vfo', ['vfo']], ['global', ['vfo']], ['rx-tx', ['rxTx']],
+    ]);
+  });
+});
+
+// ── 3. The single composition's view of the plan ───────────────────────────
+
+describe('MOR-1082 — the single-composition order comes from the same plan', () => {
+  const FALLBACK: readonly SemanticSurfaceName[] = ['vfo', 'rxTx'];
+
+  it('falls back to the composed order when no plan is resolved', () => {
+    // No App ancestor (a standalone component mount), or a layout id that
+    // resolves to no manifest: the vertical renders exactly as it does today.
+    expect(compositionSurfaces(null, FALLBACK)).toEqual(['vfo', 'rxTx']);
+  });
+
+  it('flattens the plan in zone-declaration order, deduped', () => {
+    expect(compositionSurfaces(plan(sdrTestLayout), FALLBACK)).toEqual(['vfo', 'rxTx']);
+    // desktop-v2 spreads the same two surfaces over two zones.
+    expect(compositionSurfaces(plan(desktopV2Layout), FALLBACK)).toEqual(['vfo', 'rxTx']);
+    expect(compositionSurfaces(plan(sdrTestLayout, { zoneOrder: { main: ['rxTx', 'vfo'] } }), FALLBACK))
+      .toEqual(['rxTx', 'vfo']);
+  });
+
+  it('never composes to nothing — an empty plan yields the fallback', () => {
+    // Belt and braces for the unkey path: whatever a future manifest or a
+    // stored preference does, the single composition cannot resolve to a
+    // vertical with no surfaces at all.
+    expect(compositionSurfaces(new Map(), FALLBACK)).toEqual(['vfo', 'rxTx']);
+  });
+});
+
+// ── 4. pinnedCommands: the store field is authoritative and validated, and
+//       nothing else is wired to it yet (MOR-1076 decision 7) ──────────────
+
+describe('MOR-1082 — pinnedCommands are validated command-bus intent names', () => {
+  it('keeps intent names, drops malformed entries and duplicates', () => {
+    initWorkspaceStore(null);
+    setPinnedCommands(['set_compressor', 'set_compressor', 'Set Monitor', './panel.svelte', 'atu_tune']);
+    expect(getWorkspace().pinnedCommands).toEqual(['set_compressor', 'atu_tune']);
+  });
+
+  it('refuses a forbidden class outright rather than persisting it', () => {
+    initWorkspaceStore(null);
+    setPinnedCommands(['tx_power', 'ptt_on', 'session_token', 'set_filter']);
+    expect(getWorkspace().pinnedCommands).toEqual(['set_filter']);
+  });
+
+  it('is consumed by no production module yet — adoption is the field, not a UI', () => {
+    // States the stance as a FACT instead of a claim: if a panel starts
+    // reading pinned commands, this pin fails and the decision gets revisited
+    // deliberately rather than by accident.
+    const offenders = productionSources('src')
+      .filter((path) => !path.startsWith('src/presentation/workspace/'))
+      .filter((path) => stripComments(readFileSync(path, 'utf8')).includes('pinnedCommands'));
+    expect(offenders).toEqual([]);
+  });
+});
+
+// ── 5. The legacy stance, re-affirmed for the fine-grained panel keys ──────
+
+describe('MOR-1082 — the retain-outside panel keys keep their owners', () => {
+  /** MOR-1289: 0/13 surface-id overlap with the v1 schema — no v1 home, so
+   *  they are neither migrated nor derived. This pin is the other direction
+   *  from MOR-1081's F2 scan: those keys must NOT appear in the workspace. */
+  const RETAINED_OUTSIDE = [
+    'rigplane:panel-collapsed', 'rigplane:panel-order', 'rigplane:right-panel-order',
+    'rigplane:vfo-theme',
+  ];
+
+  it('routes every one of them retain-outside, and nowhere else in the workspace', () => {
+    for (const key of RETAINED_OUTSIDE) expect(classifyLegacyKey(key)).toBe('retain-outside');
+    // `legacy-readers.ts` is the getItem-only routing table (MOR-1078) and the
+    // one legitimate place a retained key is NAMED. Anywhere else in the
+    // workspace zone would mean adoption started reaching for them.
+    const offenders = productionSources('src/presentation/workspace')
+      .filter((path) => path !== 'src/presentation/workspace/legacy-readers.ts')
+      .filter((path) => RETAINED_OUTSIDE.some((key) => stripComments(readFileSync(path, 'utf8')).includes(key)));
+    expect(offenders).toEqual([]);
+  });
+
+  it('the resolution seam touches no storage of its own', () => {
+    const source = stripComments(readFileSync('src/presentation/workspace/resolution.ts', 'utf8'));
+    for (const banned of ['localStorage', 'sessionStorage', 'document', 'window']) {
+      expect(source).not.toContain(banned);
+    }
+  });
+});
+
+function productionSources(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = `${dir}/${entry.name}`;
+    if (entry.isDirectory()) {
+      if (entry.name !== '__tests__') productionSources(path, out);
+    } else if (/\.(ts|svelte)$/.test(entry.name) && !entry.name.endsWith('.test.ts')) {
+      out.push(path);
+    }
+  }
+  return out;
+}
+
+/** Prose about a prohibition must not read as a violation of it. */
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
+/** Guards the two scans above against silently scanning nothing. */
+describe('the source scans still see the tree', () => {
+  it('finds production sources under both roots', () => {
+    expect(productionSources('src').length).toBeGreaterThan(200);
+    expect(productionSources('src/presentation/workspace').length).toBeGreaterThan(3);
+  });
+});
+
+/** Type-only: `DensityLevel` is referenced so a rename cannot silently pass. */
+const DENSITY_LEVELS: readonly DensityLevel[] = ['comfortable', 'compact', 'dense'];
+describe('the density id space is the language contract\'s', () => {
+  it('covers every level the pinned clamps can name', () => {
+    expect(DENSITY_LEVELS).toContain(DEFAULT_WORKSPACE.density);
+  });
+});

--- a/frontend/src/presentation/workspace/resolution.ts
+++ b/frontend/src/presentation/workspace/resolution.ts
@@ -1,0 +1,172 @@
+/**
+ * MOR-1082 — the workspace → PRESENTATION resolution seam.
+ *
+ * The sibling of `activation.ts` (MOR-1081) for the workspace's remaining
+ * coarse fields: `density`, `visibleSurfaces` and `zoneOrder`. Same shape,
+ * same reasons — one place that decides what a validated preference MEANS on
+ * screen, taking the manifests the caller already resolved, so the workspace
+ * zone never imports a registry, a component or a store.
+ *
+ * Pure: no storage, no DOM, no registry lookup. The only non-type import
+ * beyond `activation.ts` is Svelte's context pair, which is how the
+ * composition root hands the resolved plan to the semantic vertical without
+ * the vertical importing a layout manifest (that would close the
+ * manifest → loader → skin → wiring cycle the MOR-1068 wiring documents).
+ *
+ * WHAT THE WORKSPACE MAY DO, AND WHAT IT MAY NOT.
+ *
+ *   MAY   further hide a surface inside a zone that already declares it;
+ *         reorder the surfaces inside one zone.
+ *   MAY NOT  force-show — the manifest's `zone.surfaces` is the ceiling, so
+ *         an id the zone does not declare is ignored rather than mounted;
+ *         move a surface across zones (the v1 contract already refuses a
+ *         duplicate across zones on read, and this must not open a second
+ *         door); strip a `requiredSemanticSurfaces` entry from every zone —
+ *         a persisted preference may not break the invariant a manifest is
+ *         not allowed to declare its way out of, and for `rxTx` that
+ *         invariant is also the only unkey affordance on screen.
+ *
+ * Self-gating is untouched (S0 doctrine): a surface whose view-model group is
+ * absent still does not render, whatever the workspace says. The plan can
+ * only take a surface away from the vertical, never give it one.
+ */
+import { getContext, setContext } from 'svelte';
+import type { DensityLevel, DesignLanguageManifest } from '../languages/contract';
+import type { LayoutManifest, LayoutZone, SemanticSurfaceName } from '../layouts/contract';
+import { designLanguageActivation } from './activation';
+import type { WorkspaceV1 } from './contract';
+
+/**
+ * The density that is actually in force, or `null` for "no density active".
+ *
+ * Hybrid, per the MOR-1076 freeze: the language's own default unless the
+ * operator overrode it, and the override is honoured only INSIDE the ACTIVE
+ * language's `DensityClamp` — read live off the manifest handed in, never off
+ * `workspace.designLanguage` and never off the pinned `WORKSPACE_DENSITY_CLAMP`
+ * mirror. `fieldline` has no `dense`, so a workspace carrying `dense` resolves
+ * to `comfortable` wherever fieldline is the language on screen.
+ *
+ * Gated by `designLanguageActivation`, so density can never activate on a
+ * layout the language has not declared: every shipped v2 skin keeps exactly
+ * the density-free presentation it has today until the cutover
+ * (MOR-1048/MOR-1263).
+ */
+export function densityActivation(
+  manifest: DesignLanguageManifest | undefined,
+  layoutId: string,
+  override: DensityLevel,
+): DensityLevel | null {
+  if (manifest === undefined || designLanguageActivation(manifest, layoutId) === null) return null;
+  const clamp = manifest.density;
+  if (clamp.kind === 'not-applicable') return override;
+  if (clamp.supported.includes(override)) return override;
+  return clamp.supported[0] ?? null;
+}
+
+/** Zone id → the ordered surfaces that may mount there, after the workspace. */
+export type SurfacePlan = ReadonlyMap<string, readonly SemanticSurfaceName[]>;
+
+/** `WorkspaceV1`'s zone maps are keyed by the `WorkspaceZoneId` union while a
+ *  manifest zone id is an open `string`; this is the one place the two id
+ *  spaces meet. A miss is `undefined` = "the operator expressed nothing". */
+function forZone(
+  map: WorkspaceV1['visibleSurfaces'],
+  id: string,
+): readonly SemanticSurfaceName[] | undefined {
+  return (map as unknown as Record<string, readonly SemanticSurfaceName[] | undefined>)[id];
+}
+
+const NOTHING_FORCED: ReadonlySet<SemanticSurfaceName> = new Set();
+
+function resolveZone(
+  zone: LayoutZone,
+  workspace: WorkspaceV1,
+  forced: ReadonlySet<SemanticSurfaceName>,
+): SemanticSurfaceName[] {
+  const allowed = forZone(workspace.visibleSurfaces, zone.id);
+  // Intersection with the declared set, in declared order: this single
+  // expression is what makes force-show and cross-zone structurally
+  // impossible — nothing outside `zone.surfaces` can survive it.
+  const kept = allowed === undefined
+    ? [...zone.surfaces]
+    : zone.surfaces.filter((surface) => allowed.includes(surface) || forced.has(surface));
+  const sequence = forZone(workspace.zoneOrder, zone.id);
+  if (sequence === undefined) return kept;
+  // A partial order leads; whatever it did not name keeps its DECLARED
+  // relative position behind it, so an incomplete write is normalized rather
+  // than treated as a hide.
+  const rank = (surface: SemanticSurfaceName): number => {
+    const named = sequence.indexOf(surface);
+    return named === -1 ? sequence.length + zone.surfaces.indexOf(surface) : named;
+  };
+  return kept.sort((a, b) => rank(a) - rank(b));
+}
+
+/**
+ * The active layout's zones, resolved against an ALREADY VALIDATED workspace.
+ * Validation is the store's boundary (MOR-1077/1079) and is deliberately not
+ * repeated here: an unknown zone or surface id never reaches this function.
+ */
+export function resolveSurfacePlan(manifest: LayoutManifest, workspace: WorkspaceV1): SurfacePlan {
+  const build = (forced: ReadonlySet<SemanticSurfaceName>): SemanticSurfaceName[][] =>
+    manifest.zones.map((zone) => resolveZone(zone, workspace, forced));
+  const first = build(NOTHING_FORCED);
+  const mounted = new Set(first.flat());
+  const uncovered = manifest.requiredSemanticSurfaces.filter((surface) => !mounted.has(surface));
+  const resolved = uncovered.length === 0 ? first : build(new Set(uncovered));
+  return new Map(manifest.zones.map((zone, index) => [zone.id, resolved[index]]));
+}
+
+/**
+ * The plan as ONE ordered region — what the wiring's single composition
+ * renders, since it mounts everything the layout declares without binding a
+ * zone element (MOR-1069). Falls back whenever there is no plan to read (a
+ * standalone mount with no composition root above it) or when the plan would
+ * compose to nothing at all: the vertical must never resolve to a screen with
+ * no surfaces, least of all no RX/TX surface.
+ */
+export function compositionSurfaces(
+  plan: SurfacePlan | null,
+  fallback: readonly SemanticSurfaceName[],
+): readonly SemanticSurfaceName[] {
+  if (plan === null) return fallback;
+  const composed: SemanticSurfaceName[] = [];
+  for (const surfaces of plan.values()) {
+    for (const surface of surfaces) if (!composed.includes(surface)) composed.push(surface);
+  }
+  return composed.length === 0 ? fallback : composed;
+}
+
+/**
+ * The composition root's channel to the semantic vertical. A Svelte context
+ * rather than a module singleton so nothing leaks between mounts, and a
+ * GETTER rather than a value so the consumer's `$derived` re-runs when the
+ * workspace or the resolved layout changes.
+ *
+ * Absent by design in a standalone component mount: `useSurfacePlan()` then
+ * yields `null` and every consumer renders its declared composition
+ * unchanged. Exported key so a test (or the MOR-1070 fixture harness) can
+ * supply a plan through `mount`'s `context` option.
+ */
+export const SURFACE_PLAN_CONTEXT_KEY = Symbol('WorkspaceSurfacePlan');
+export type SurfacePlanSource = () => SurfacePlan | null;
+const NO_PLAN: SurfacePlanSource = () => null;
+
+export function provideSurfacePlan(source: SurfacePlanSource): void {
+  setContext(SURFACE_PLAN_CONTEXT_KEY, source);
+}
+
+export function useSurfacePlan(): SurfacePlanSource {
+  return getContext<SurfacePlanSource | undefined>(SURFACE_PLAN_CONTEXT_KEY) ?? NO_PLAN;
+}
+
+/** Is `surface` still mounted in `zoneId`? "No plan" and "the active layout
+ *  declares no such zone" both mean UNCHANGED — this can only ever hide. */
+export function zoneShowsSurface(
+  plan: SurfacePlan | null,
+  zoneId: string,
+  surface: SemanticSurfaceName,
+): boolean {
+  const zone = plan?.get(zoneId);
+  return zone === undefined || zone.includes(surface);
+}


### PR DESCRIPTION
## Summary
Second adoption ticket (post-freeze scope per MOR-1289: fine-grained legacy panel keys stay retain-outside — untouched). New `resolution.ts` (sibling of 1081's `activation.ts`): `densityActivation()` clamps the workspace override by the **active** language's `DensityClamp` and App writes `[data-density]` in the SAME $effect as `[data-design-language]` (desync impossible); `resolveSurfacePlan()` resolves per-zone visibility/order against the layout manifest and `SemanticRadioSurfaces` consults it in both compositions — mobile mounts the same wiring (verifier-proven: the mobile pin fires under both mutations). **Zero visual delta today, proven:** the activation gate returns null on every shipped v2 skin, so `[data-density]` is absent everywhere until cutover.

**Safety property:** preferences can only NARROW what a manifest declares — force-show impossible, cross-zone impossible, and a hide that would leave a `requiredSemanticSurfaces` entry (the only unkey affordance) unmounted is neutralised at EVERY resolve. Verifier-ruled a faithful extension of the pre-existing manifest-level invariant (layouts contract validates the same coverage; 1082 touches that file 0 lines) — self-healing beats write-time refusal: a stale already-bad workspace still renders the required surface (boot-with-bad-workspace probed). `pinnedCommands`: validated store field only, zero production LOC, static-scan proven unconsumed. Net production LOC **132** strict / 270 raw (verifier re-measured; ≤200).

## Review provenance
Opus builder → independent opus contracts-domain verifier (15th ticket in domain): **PASS, no blocking findings**. Probes against the real desktop-v2 manifest: hide-rxTx-everywhere and hide-everything both keep required surfaces mounted with the documented fallback; force-show-all renders only what zones declare; reversed zoneOrder lands in all three single-composition skins. M1 (drop coverage rebuild) killed 3 incl. the unkey-affordance test; M2 (bypass manifest ceiling) killed 3. Density clamp proven against the ACTIVE language (stored dense + fieldline ⇒ clamped; studioline ⇒ honored). App's layouts/declarations import ruled NOT new dirtiness (same composition-root idiom as 1081's languages import); stageSizing freeze intact (0 lines). Observations: O1 (legitimate hide path has no production instance until cutover — flagged there), O3 (report wording: refusal is resolution-time). Fail-set identical to baseline (+30 passing); lint/boundaries/check clean; merge clean.

Linear: MOR-1082

🤖 Generated with [Claude Code](https://claude.com/claude-code)