### PR TITLE
feat(MOR-1294): band fact group with live-frequency TX permit (vocabulary slice 7A)

### DIFF
--- a/frontend/src/components-v2/controls/band-utils.ts
+++ b/frontend/src/components-v2/controls/band-utils.ts
@@ -1,44 +1,9 @@
-import type { FreqRange } from '$lib/types/capabilities';
-
-export interface FlatBand {
-  name: string;
-  defaultFreq: number;
-  start: number;
-  end: number;
-  bsrCode?: number;
-}
-
 /**
- * Flatten all bands from all freq ranges into a single ordered array.
- * Ranges and bands within each range appear in the order defined in the config.
+ * Re-export shim (MOR-1294). The implementations moved to
+ * `$lib/radio/band-plan` so the `band` fact group's adapter can consume them
+ * — `lib/runtime/**` may not import from `components-v2/**` (eslint zone),
+ * and a second copy of the band-plan lookup is exactly the forked derivation
+ * the fact layer exists to prevent. Every existing importer of this module
+ * keeps working unchanged; see `band-plan.ts` for the doc comments.
  */
-export function flattenBands(freqRanges: FreqRange[]): FlatBand[] {
-  const result: FlatBand[] = [];
-  for (const range of freqRanges) {
-    for (const band of range.bands ?? []) {
-      result.push({
-        name: band.name,
-        defaultFreq: band.default,
-        start: band.start,
-        end: band.end,
-        bsrCode: band.bsrCode,
-      });
-    }
-  }
-  return result;
-}
-
-/**
- * Find the band name whose [start, end] range contains `freq`.
- * Returns null if no band matches.
- */
-export function findActiveBand(freq: number, freqRanges: FreqRange[]): string | null {
-  for (const range of freqRanges) {
-    for (const band of range.bands ?? []) {
-      if (freq >= band.start && freq <= band.end) {
-        return band.name;
-      }
-    }
-  }
-  return null;
-}
+export { flattenBands, findActiveBand, type FlatBand } from '$lib/radio/band-plan';

--- a/frontend/src/lib/radio/band-plan.ts
+++ b/frontend/src/lib/radio/band-plan.ts
@@ -1,0 +1,61 @@
+/**
+ * Band-plan lookups (MOR-1262 decomposition slice 7A, MOR-1294).
+ *
+ * The bodies below are `components-v2/controls/band-utils.ts` MOVED here
+ * verbatim, not reimplemented: `lib/runtime/**` may not import from
+ * `components-v2/**` (eslint zone, ADR circular-dependency rule), and the
+ * `band` fact group must consume the ONE shipped band-plan derivation rather
+ * than fork a second copy of it — the same "consume, never re-derive"
+ * discipline `filterPassband` follows for `pbtRawToHz` and `dsp` for
+ * `nrRawToDisplay`. `band-utils.ts` is now a re-export shim, so every v2 call
+ * site (`BandSelector.svelte`, `VfoPanel.svelte`, their tests) is untouched.
+ *
+ * Both functions take `freqRanges` as an EXPLICIT parameter and read no
+ * store — a fact-layer value must be a pure function of `(state, caps)`, and
+ * the v2 callers' own `getCapabilities()?.freqRanges ?? []` store read stays
+ * on the v2 side of the seam.
+ */
+import type { FreqRange } from '$lib/types/capabilities';
+
+export interface FlatBand {
+  name: string;
+  defaultFreq: number;
+  start: number;
+  end: number;
+  bsrCode?: number;
+}
+
+/**
+ * Flatten all bands from all freq ranges into a single ordered array.
+ * Ranges and bands within each range appear in the order defined in the config.
+ */
+export function flattenBands(freqRanges: FreqRange[]): FlatBand[] {
+  const result: FlatBand[] = [];
+  for (const range of freqRanges) {
+    for (const band of range.bands ?? []) {
+      result.push({
+        name: band.name,
+        defaultFreq: band.default,
+        start: band.start,
+        end: band.end,
+        bsrCode: band.bsrCode,
+      });
+    }
+  }
+  return result;
+}
+
+/**
+ * Find the band name whose [start, end] range contains `freq`.
+ * Returns null if no band matches.
+ */
+export function findActiveBand(freq: number, freqRanges: FreqRange[]): string | null {
+  for (const range of freqRanges) {
+    for (const band of range.bands ?? []) {
+      if (freq >= band.start && freq <= band.end) {
+        return band.name;
+      }
+    }
+  }
+  return null;
+}

--- a/frontend/src/lib/runtime/adapters/__tests__/band-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/band-adapter.test.ts
@@ -1,0 +1,409 @@
+/**
+ * MOR-1262 decomposition slice 7A (MOR-1294) — `band` fact-group adapter
+ * derivation. SAFETY-ADJACENT.
+ *
+ * Companion to `rf-front-end-adapter.test.ts` (MOR-1292/1293), which this
+ * file does NOT modify. `band` is a SEPARATE optional group — see
+ * `radio-view-model.ts`'s `BandViewModel` doc comment.
+ *
+ * The parity pins below call the REAL `getFrequencyPermit`/`getTxPermit`
+ * (`$lib/utils/tx-permit`) and the REAL `flattenBands`/`findActiveBand`
+ * (`$lib/radio/band-plan`) — never a reimplementation — so agreement is
+ * against the shipped derivations themselves, not an assumption about them.
+ * That is the whole point of the slice's safety constraint: ONE permit
+ * derivation, consumed, never re-derived.
+ *
+ * None of this group's facts consume a capabilities-STORE-backed helper (both
+ * band-plan lookups take `freqRanges` as an explicit parameter), so this file
+ * never calls the real `setCapabilities` and does not need the isolated pool
+ * (MOR-1272) — the determinism pin below asserts that property directly.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import type { Capabilities, FreqRange, TxBand } from '$lib/types/capabilities';
+import type { FieldStatus, ServerState } from '$lib/types/state';
+import { validateRadioViewModel, type RadioViewModel } from '../../../../semantic/radio-view-model';
+import { toRadioViewModel } from '../radio-view-model-adapter';
+import { getFrequencyPermit, getTxPermit } from '$lib/utils/tx-permit';
+import { findActiveBand, flattenBands } from '$lib/radio/band-plan';
+
+const HF_RANGES: FreqRange[] = [
+  {
+    start: 30000, end: 60000000, label: 'HF',
+    bands: [
+      { name: '40m', start: 7000000, end: 7300000, default: 7100000, bsrCode: 2 },
+      { name: '20m', start: 14000000, end: 14350000, default: 14195000, bsrCode: 5 },
+      { name: 'MW', start: 520000, end: 1710000, default: 1000000 },
+    ],
+  },
+];
+const HAM_TX_BANDS: TxBand[] = [
+  { name: '40m', start: 7000000, end: 7300000 },
+  { name: '20m', start: 14000000, end: 14350000 },
+];
+
+function caps(overrides: Partial<Capabilities> = {}): Capabilities {
+  return {
+    model: 'fixture', scope: true, audio: true, tx: true, capabilities: ['scope', 'audio', 'tx'],
+    receivers: 1, vfoScheme: 'single', freqRanges: [], modes: [], filters: [],
+    audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
+    webrtc: { available: false, enabled: false },
+    txBands: [], scopeSource: 'hardware', audioFftAvailable: false, ...overrides,
+  } as Capabilities;
+}
+
+const fresh: FieldStatus = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' };
+const stale: FieldStatus = { storePath: 'x', observed: true, freshness: 'stale', availability: 'stale' };
+
+/** The exact shape `rf-front-end-adapter.test.ts`'s own baseline uses. */
+function bareState(overrides: Partial<ServerState> = {}): ServerState {
+  return {
+    active: 'MAIN', split: false, dualWatch: false, ptt: false,
+    txTarget: { status: 'known', receiver: 'MAIN', slot: null, frequencyHz: 14195000 },
+    main: {
+      freqHz: 14195000, mode: 'USB', filter: 1, dataMode: 0, att: 0, preamp: 0,
+      nb: false, nr: false, afLevel: 1, rfGain: 1, squelch: 0, sMeter: 0,
+    },
+    sub: {
+      freqHz: 7100000, mode: 'LSB', filter: 2, dataMode: 0, att: 0, preamp: 0,
+      nb: false, nr: false, afLevel: 1, rfGain: 1, squelch: 0, sMeter: 0,
+    },
+    fieldStatus: {
+      active: fresh, split: fresh, dualWatch: fresh, txTarget: fresh,
+      'main.freqHz': fresh, 'main.mode': fresh, 'main.filter': fresh,
+    },
+    ...overrides,
+  } as ServerState;
+}
+
+function model(state: ServerState | null, capabilities: Capabilities | null): RadioViewModel {
+  const view = toRadioViewModel(state, capabilities);
+  expect(view).not.toBeNull();
+  return validateRadioViewModel(view);
+}
+
+const hfCaps = caps({ freqRanges: HF_RANGES, txBands: HAM_TX_BANDS });
+
+describe('band evidence gate (MOR-1294, N3)', () => {
+  it('emits no band when capabilities are absent', () => {
+    expect(toRadioViewModel(bareState(), null)).toBeNull();
+  });
+
+  it('emits no band for a radio declaring no freqRanges (regression pin on the baseline fixtures)', () => {
+    const view = model(bareState(), caps());
+    expect(view.band).toBeUndefined();
+    expect(Object.keys(view)).not.toContain('band');
+  });
+
+  it('emits band once a freqRange is declared, even with no named bands in it', () => {
+    const view = model(bareState(), caps({ freqRanges: [{ start: 30000, end: 60000000, label: 'HF' }] }));
+    expect(view.band).toBeDefined();
+    expect(view.band!.bandChoices).toEqual([]);
+    // No band plan ⇒ no current-band concept at all: structurally absent.
+    expect(view.band!.currentBand.availability.structural).toBe(false);
+    expect(view.band!.currentBandTx).toBe('denied');
+  });
+});
+
+describe('band choice set (MOR-1294)', () => {
+  it('is the shipped flattenBands output over the caps argument, verbatim', () => {
+    const view = model(bareState(), hfCaps);
+    expect(view.band!.bandChoices.map((c) => ({ name: c.name, startHz: c.startHz, endHz: c.endHz, defaultHz: c.defaultHz })))
+      .toEqual(flattenBands(HF_RANGES).map((b) => ({
+        name: b.name, startHz: b.start, endHz: b.end, defaultHz: b.defaultFreq,
+      })));
+  });
+
+  it('never invents a band table — a radio with ranges but no bands gets an empty choice set (X6200 lesson)', () => {
+    const view = model(bareState(), caps({ freqRanges: [{ start: 30000, end: 60000000, label: 'HF' }] }));
+    expect(view.band!.bandChoices).toEqual([]);
+  });
+
+  it('reports an absent bsrCode as null, never a fabricated 0 (0 is a real BSR index)', () => {
+    const view = model(bareState(), hfCaps);
+    expect(view.band!.bandChoices.find((c) => c.name === 'MW')!.bsrCode).toBeNull();
+    expect(view.band!.bandChoices.find((c) => c.name === '40m')!.bsrCode).toBe(2);
+  });
+
+  it('omits a band with a non-finite boundary or default rather than emitting a fabricated one', () => {
+    const broken: FreqRange[] = [{
+      start: 30000, end: 60000000, label: 'HF',
+      bands: [
+        { name: '20m', start: 14000000, end: 14350000, default: 14195000 },
+        { name: 'BAD', start: 21000000, end: 21450000, default: Number.NaN },
+      ],
+    }];
+    const view = model(bareState(), caps({ freqRanges: broken, txBands: HAM_TX_BANDS }));
+    expect(view.band!.bandChoices.map((c) => c.name)).toEqual(['20m']);
+  });
+});
+
+/**
+ * SAFETY — THE ONE PERMIT DERIVATION (MOR-1294). Every per-band permit must
+ * deep-equal the REAL `getFrequencyPermit(defaultHz, caps.txBands)`, across
+ * every discriminating combination of the tri-state. A re-derivation (or the
+ * fail-open shortcut of reading permission off the band PLAN instead of
+ * `txBands`) goes red here.
+ */
+describe('per-band TX permit parity with the shipped tri-state (MOR-1294)', () => {
+  const PERMIT_CASES: ReadonlyArray<readonly [label: string, txBands: TxBand[] | null]> = [
+    ['named TX allocations (allowed + denied mix)', HAM_TX_BANDS],
+    ['an unnamed TX allocation (allowed with band: null)', [{ name: '', start: 7000000, end: 7300000 }]],
+    ['an explicit empty list (deny-all)', []],
+    ['unconfigured ranges (null)', null],
+  ];
+
+  it.each(PERMIT_CASES)('agrees with getFrequencyPermit for every band under %s', (_label, txBands) => {
+    const view = model(bareState(), caps({ freqRanges: HF_RANGES, txBands }));
+    for (const choice of view.band!.bandChoices) {
+      expect(choice.defaultHzTxPermit).toEqual(getFrequencyPermit(choice.defaultHz, txBands));
+    }
+  });
+
+  it('covers all three tri-state branches across the fixture matrix (the pin above is discriminating)', () => {
+    const statuses = new Set<string>();
+    for (const [, txBands] of PERMIT_CASES) {
+      const view = model(bareState(), caps({ freqRanges: HF_RANGES, txBands }));
+      view.band!.bandChoices.forEach((c) => statuses.add(c.defaultHzTxPermit.status));
+    }
+    expect(statuses).toEqual(new Set(['allowed', 'denied', 'unknown']));
+  });
+
+  it('denies an out-of-band plan entry even though the band plan itself lists it (never fail-open)', () => {
+    const view = model(bareState(), hfCaps);
+    const mw = view.band!.bandChoices.find((c) => c.name === 'MW')!;
+    expect(mw.defaultHzTxPermit).toEqual({ status: 'denied', reason: 'outside-configured-ranges' });
+  });
+
+  it('reports unknown — never allowed — when TX ranges are unconfigured', () => {
+    const view = model(bareState(), caps({ freqRanges: HF_RANGES, txBands: null }));
+    expect(view.band!.bandChoices.every((c) => c.defaultHzTxPermit.status === 'unknown')).toBe(true);
+    expect(view.band!.currentBandTx).toBe('denied');
+  });
+});
+
+/**
+ * SAFETY — THE LIVE-FREQUENCY PERMIT (MOR-1294 verify F1). `currentBandTx`
+ * must be evaluated at the frequency the operator is ACTUALLY on, never
+ * inherited from `bandChoices[].defaultHzTxPermit`'s point sample at the
+ * band's default.
+ *
+ * The discriminator is the verifier's own: a `txBands` segment NARROWER than
+ * the band-plan band it sits in, with the band's `defaultHz` INSIDE the
+ * segment. The point sample then reads `allowed` while a live frequency
+ * higher up the same band is denied — the fail-open the F1 ruling names, and
+ * a common real shape (WARC segments, regional sub-bands, 60m channels).
+ * Every assertion is against the REAL `getFrequencyPermit`/`getTxPermit`.
+ */
+describe('currentBandTx is the LIVE-frequency permit, not the defaultHz sample (MOR-1294 F1)', () => {
+  /** 20m plan spans 14.000–14.350; the allocation stops at 14.250, and the
+   *  plan's own defaultHz (14.195) sits INSIDE it. */
+  const SEGMENT: TxBand[] = [{ name: '20m-lower', start: 14000000, end: 14250000 }];
+  const segmentCaps = caps({ freqRanges: HF_RANGES, txBands: SEGMENT });
+
+  function at(freqHz: number) {
+    return model(bareState({ main: { ...bareState().main, freqHz } }), segmentCaps);
+  }
+
+  it('sanity: the fixture really produces the narrower-than-band shape (choice count + in-segment sample)', () => {
+    const view = at(14195000);
+    // Guard against the flat-freqRanges shape trap: a degenerate fixture
+    // yields zero choices and fakes a PASS on every row below.
+    expect(view.band!.bandChoices).toHaveLength(3);
+    const twenty = view.band!.bandChoices.find((c) => c.name === '20m')!;
+    expect(twenty.defaultHz).toBe(14195000);
+    expect(twenty.defaultHzTxPermit).toEqual({ status: 'allowed', band: '20m-lower' });
+    expect(twenty.endHz).toBeGreaterThan(SEGMENT[0].end);
+  });
+
+  it('DENIES a live frequency above the segment even though the band sample says allowed (the F1 probe)', () => {
+    const view = at(14300000);
+    expect(view.band!.currentBand.reading).toEqual({ status: 'known', value: '20m' });
+    // The point sample still reads allowed — that is its correct, narrow meaning…
+    expect(view.band!.bandChoices.find((c) => c.name === '20m')!.defaultHzTxPermit.status).toBe('allowed');
+    // …and the live answer must NOT inherit it.
+    expect(getFrequencyPermit(14300000, SEGMENT)).toEqual({ status: 'denied', reason: 'outside-configured-ranges' });
+    expect(view.band!.currentBandTx).toBe('denied');
+  });
+
+  it('ALLOWS a live frequency inside the segment — the pin is not vacuously denying everything', () => {
+    const view = at(14100000);
+    expect(view.band!.currentBandTx).toBe('allowed');
+  });
+
+  it.each([14100000, 14195000, 14250000, 14250001, 14300000, 14349999])(
+    'agrees with the shipped getTxPermit at the LIVE frequency %i (segment-boundary sweep)',
+    (freqHz) => {
+      expect(at(freqHz).band!.currentBandTx).toBe(getTxPermit(freqHz, SEGMENT));
+    },
+  );
+});
+
+/**
+ * SAFETY — FAIL-CLOSED CURRENT-BAND PERMISSION (MOR-1294 constraint 2, the
+ * MOR-1293 DIGI-SEL precedent). `currentBandTx` is 'allowed' only on a
+ * positively known band, with a choice entry, and a positively allowed
+ * LIVE-frequency permit; every unknown input reads 'denied'. Parity against
+ * the shipped `getTxPermit` collapse ("unknown fails closed") is asserted,
+ * not assumed.
+ */
+describe('currentBandTx fails closed (MOR-1294)', () => {
+  it('allows only a known, in-band current band, and agrees with the shipped getTxPermit collapse', () => {
+    const view = model(bareState(), hfCaps);
+    expect(view.band!.currentBand.reading).toEqual({ status: 'known', value: '20m' });
+    expect(view.band!.currentBandTx).toBe('allowed');
+    expect(view.band!.currentBandTx).toBe(getTxPermit(14195000, HAM_TX_BANDS));
+  });
+
+  const CLOSED_CASES: ReadonlyArray<readonly [label: string, state: () => ServerState, capabilities: Capabilities]> = [
+    [
+      'the frequency was never observed',
+      () => {
+        const main = { ...bareState().main } as Record<string, unknown>;
+        delete main.freqHz;
+        const status = { ...bareState().fieldStatus };
+        delete (status as Record<string, unknown>)['main.freqHz'];
+        return bareState({ main: main as unknown as ServerState['main'], fieldStatus: status });
+      },
+      hfCaps,
+    ],
+    [
+      'the frequency reading is stale',
+      () => bareState({ fieldStatus: { ...bareState().fieldStatus, 'main.freqHz': stale } }),
+      hfCaps,
+    ],
+    [
+      'the frequency lies outside every band of the plan',
+      () => bareState({ main: { ...bareState().main, freqHz: 9000000 } }),
+      hfCaps,
+    ],
+    [
+      'the current band is in the plan but outside the TX allocations',
+      () => bareState({ main: { ...bareState().main, freqHz: 1000000 } }),
+      hfCaps,
+    ],
+    [
+      'the TX ranges are unconfigured',
+      () => bareState(),
+      caps({ freqRanges: HF_RANGES, txBands: null }),
+    ],
+    [
+      'the live frequency is outside a TX segment narrower than its band (verify F1)',
+      () => bareState({ main: { ...bareState().main, freqHz: 14300000 } }),
+      caps({ freqRanges: HF_RANGES, txBands: [{ name: '20m-lower', start: 14000000, end: 14250000 }] }),
+    ],
+    [
+      'the plan names the current band but its entry was omitted as malformed',
+      () => bareState({ main: { ...bareState().main, freqHz: 21200000 } }),
+      caps({
+        freqRanges: [{
+          start: 30000, end: 60000000, label: 'HF',
+          bands: [{ name: '15m', start: 21000000, end: 21450000, default: Number.NaN }],
+        }],
+        txBands: [{ name: '15m', start: 21000000, end: 21450000 }],
+      }),
+    ],
+  ];
+
+  it.each(CLOSED_CASES)('reads denied when %s', (_label, makeState, capabilities) => {
+    const view = model(makeState(), capabilities);
+    expect(view.band!.currentBandTx).toBe('denied');
+  });
+
+  it('keeps the current band unknown — never the shipped 14.074 MHz stand-in — when the frequency is unobserved', () => {
+    const main = { ...bareState().main } as Record<string, unknown>;
+    delete main.freqHz;
+    const view = model(bareState({ main: main as unknown as ServerState['main'] }), hfCaps);
+    expect(view.band!.currentBand.reading).toEqual({ status: 'unknown' });
+    expect(view.band!.currentBandTx).toBe('denied');
+  });
+
+  it('degrades a stale frequency to an unknown band while keeping structural availability true', () => {
+    const view = model(bareState({
+      fieldStatus: { ...bareState().fieldStatus, 'main.freqHz': stale },
+    }), hfCaps);
+    expect(view.band!.currentBand).toEqual({
+      reading: { status: 'unknown' }, availability: { structural: true, operational: false },
+    });
+  });
+
+  it('degrades a malformed raw frequency (wrong JS type) to unknown rather than coercing', () => {
+    const view = model(bareState({
+      main: { ...bareState().main, freqHz: '14.195' as unknown as number },
+    }), hfCaps);
+    expect(view.band!.currentBand.reading).toEqual({ status: 'unknown' });
+    expect(view.band!.currentBandTx).toBe('denied');
+  });
+});
+
+describe('band current-band derivation (MOR-1294)', () => {
+  it('is the shipped findActiveBand lookup over the caps argument, verbatim', () => {
+    const view = model(bareState(), hfCaps);
+    expect(view.band!.currentBand.reading).toEqual({
+      status: 'known', value: findActiveBand(14195000, HF_RANGES),
+    });
+  });
+
+  it('follows the SUB receiver once it is the active one', () => {
+    const view = model(bareState({
+      active: 'SUB',
+      fieldStatus: { ...bareState().fieldStatus, 'sub.freqHz': fresh },
+    }), caps({ freqRanges: HF_RANGES, txBands: HAM_TX_BANDS, receivers: 2, vfoScheme: 'ab_shared', capabilities: ['tx', 'dual_rx'] }));
+    expect(view.band!.currentBand.reading).toEqual({ status: 'known', value: '40m' });
+  });
+});
+
+describe('band tuning envelope (MOR-1294)', () => {
+  it('reports the envelope of the declared ranges, never adjustFreqByDigit\'s 0..999 MHz stand-in', () => {
+    const view = model(bareState(), caps({
+      freqRanges: [
+        { start: 1800000, end: 30000000, label: 'HF' },
+        { start: 30000, end: 1700000, label: 'LF/MW' },
+        { start: 50000000, end: 54000000, label: '6m' },
+      ],
+    }));
+    expect(view.band!.tuneMinHz).toBe(30000);
+    expect(view.band!.tuneMaxHz).toBe(54000000);
+  });
+});
+
+/**
+ * DETERMINISM (the 4A/5A binding lesson): every band fact is a pure function
+ * of `(state, caps)`. Both band-plan lookups take `freqRanges` as an EXPLICIT
+ * parameter — unlike `pbtRawToHz`/`nrRawToDisplay`, neither has a
+ * capabilities-STORE fallback to fall through to — so there is no store path
+ * to close here. Pinned two ways: identical arguments produce deep-equal
+ * output, and the band-plan module's own source imports no store.
+ */
+describe('band determinism in (state, caps) (MOR-1294)', () => {
+  it('produces deep-equal output for identical arguments', () => {
+    const state = bareState();
+    expect(model(state, hfCaps).band).toEqual(model(state, hfCaps).band);
+  });
+
+  it('tracks the caps ARGUMENT, not a module-global — a different caps yields different facts', () => {
+    const state = bareState();
+    const denied = model(state, caps({ freqRanges: HF_RANGES, txBands: [] }));
+    expect(model(state, hfCaps).band!.currentBandTx).toBe('allowed');
+    expect(denied.band!.currentBandTx).toBe('denied');
+  });
+
+  it('the shipped band-plan module reads no store', () => {
+    const source = readFileSync(resolve(process.cwd(), 'src/lib/radio/band-plan.ts'), 'utf8');
+    // Import statements only — the module's doc comment names the v2 callers'
+    // own `getCapabilities()` store read, which is exactly what stays on the
+    // far side of this seam.
+    const imports = source.match(/^\s*import\s[\s\S]*?;$/gm) ?? [];
+    expect(imports.length).toBeGreaterThan(0);
+    expect(imports.join('\n')).not.toMatch(/stores|getCapabilities/);
+  });
+});
+
+describe('band round-trip (MOR-1294)', () => {
+  it('emits a validator-clean model carrying the band group', () => {
+    const view = model(bareState(), hfCaps);
+    expect(JSON.parse(JSON.stringify(view))).toEqual(view);
+    expect(view.band).toBeDefined();
+  });
+});

--- a/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
@@ -30,10 +30,13 @@ import type {
   MeterField, MeterRfState, MetersViewModel,
   AudioFocus, MonitorMode, RxAudioViewModel, ModeFilterViewModel,
   FilterPassbandViewModel, DspViewModel, RfFrontEndViewModel,
+  BandChoice, BandViewModel,
 } from '../../../semantic/radio-view-model';
 import type { TxAuthoritySnapshot } from '../../../semantic/rx-tx-surface';
 import { isFieldAvailable } from '$lib/state/field-status';
 import { modInputStateKey } from '$lib/radio/mod-input';
+import { flattenBands, findActiveBand } from '$lib/radio/band-plan';
+import { getFrequencyPermit, type TxPermit } from '$lib/utils/tx-permit';
 import { resolveFilterModeConfig } from '$lib/runtime/props/panel-props';
 import {
   deriveIfShift, pbtRangeFromCaps, pbtRawToHz,
@@ -609,6 +612,123 @@ function deriveRfFrontEndMutex(rfFrontEnd: RfFrontEndViewModel | undefined): Rea
 }
 
 /**
+ * Band facts (MOR-1262 decomposition slice 7A, MOR-1294): current band, the
+ * capability-derived band choice set with its per-band TX permits, and the
+ * tuning envelope frequency entry validates against. A separate group from
+ * `rfFrontEnd` — family enumeration is explicit and CLOSED.
+ *
+ * Evidence gate (N3), purely caps-driven like `deriveRfFrontEnd`'s: no
+ * declared `freqRanges` ⇒ NO group. `freqRanges` is a REQUIRED capability
+ * field (always present, possibly empty), so "was it observed" carries no
+ * evidence here — the same reasoning `deriveModeFilter` applies to
+ * `modes`/`filters`. There is no `band`/`band_select` capability TAG to gate
+ * on: the shipped `BandSelector.svelte` gates purely on `freqRanges` being
+ * non-empty, and that gate is copied rather than replaced.
+ *
+ * `flattenBands`/`findActiveBand` are the ONE shipped band-plan derivation
+ * (`$lib/radio/band-plan`, moved there from `components-v2/controls/band-utils`
+ * by this slice precisely so it could be CONSUMED rather than forked) —
+ * called with `caps.freqRanges` from THIS request's own `caps` argument, not
+ * the capabilities STORE singleton the v2 callers read (`getCapabilities()?.
+ * freqRanges ?? []`). Same discipline as `filterPassband`'s `pbtRangeFromCaps`
+ * (MOR-1284 F1) and `dsp`'s `controlRangeFromCapsOrDefault` (MOR-1290 F1): a
+ * fact-layer value is a pure function of `(state, caps)`, never of
+ * module-global state that can differ from the `caps` already in hand.
+ *
+ * SAFETY (MOR-1294). Every permit here comes from `getFrequencyPermit(hz,
+ * caps.txBands)`, the SAME single derivation `deriveTxCapabilities` calls for
+ * the model's top-level `txPermit`. What differs between the two permit facts
+ * is only the FREQUENCY ARGUMENT, and that difference is the whole point:
+ *  - `bandChoices[].defaultHzTxPermit` samples the band's own `defaultHz` —
+ *    the picker label, "may I key where selecting this band lands me".
+ *  - `currentBandTx` samples the LIVE observed frequency — "may I key right
+ *    now". It is NEVER inherited from the point sample above (verify F1): a
+ *    `txBands` segment narrower than its band-plan band (WARC segments,
+ *    regional sub-bands, 60m channels) makes the inherited answer fail OPEN,
+ *    e.g. live 14.300 MHz reading `allowed` off a 14.000–14.150 allocation
+ *    whose 14.074 default happens to be inside. Same derivation, correct
+ *    argument — not a second derivation.
+ *
+ * Two things this deliberately does NOT do:
+ *  - it never treats a band's presence in the PLAN as permission to key. The
+ *    plan (`freqRanges`) is what the radio can TUNE; `caps.txBands` is where
+ *    it may TRANSMIT, and they routinely differ (a general-coverage receiver
+ *    tunes far outside its TX allocations). Reading permission off the plan
+ *    is the fail-open defect the slice's safety note names.
+ *  - it never states a permit on unknown input. `currentBandTx` is `'allowed'`
+ *    only when the current band is POSITIVELY known, has a choice entry, AND
+ *    the live-frequency permit is POSITIVELY `allowed`; everything else
+ *    collapses to `'denied'` exactly as the shipped `getTxPermit` does
+ *    ("unknown fails closed", `$lib/utils/tx-permit`). An unknown input must
+ *    not enable a TX-adjacent affordance. `validateRadioViewModel` enforces
+ *    the known-band half of that invariant structurally.
+ */
+function deriveBand(
+  state: ServerState | null, caps: Capabilities | null,
+): BandViewModel | undefined {
+  if (!caps) return undefined;
+  const freqRanges = caps.freqRanges ?? [];
+  if (freqRanges.length === 0) return undefined;
+
+  const bandChoices: BandChoice[] = flattenBands(freqRanges)
+    // A band whose boundaries or default frequency are not finite numbers is
+    // OMITTED rather than emitted with a fabricated value: there is no
+    // frequency to tune to and therefore no permit to state. Omission is the
+    // fail-closed outcome — `currentBandTx` finds no entry for such a band
+    // and reads 'denied' even when `findActiveBand` still names it.
+    .filter((band) => [band.start, band.end, band.defaultFreq].every((hz) => numOrUndef(hz) !== undefined))
+    .map((band) => ({
+      name: band.name,
+      startHz: band.start,
+      endHz: band.end,
+      defaultHz: band.defaultFreq,
+      // `?? null` is the contract's own "no BSR index declared", not a
+      // fabricated 0 — index 0 is a real band-stacking register on Icom rigs.
+      bsrCode: numOrUndef(band.bsrCode) ?? null,
+      // POINT SAMPLE at defaultHz — the picker label, never the live answer.
+      defaultHzTxPermit: getFrequencyPermit(band.defaultFreq, caps.txBands),
+    }));
+
+  const onSub = state?.active === 'SUB';
+  const rx = onSub ? state?.sub : state?.main;
+  const freqObserved = topFieldAvailable(state, onSub ? 'sub.freqHz' : 'main.freqHz');
+  const freqHz = numOrUndef(rx?.freqHz);
+  // Never over a `?? 14074000` stand-in, where the shipped `toBandSelectorProps`
+  // fabricates exactly that; an unobserved or plan-less frequency stays unknown.
+  const currentName = freqObserved && freqHz !== undefined
+    ? findActiveBand(freqHz, freqRanges) ?? undefined
+    : undefined;
+  const currentBand = txAuxField(bandChoices.length > 0, freqObserved, currentName);
+  const reading = currentBand.reading;
+  const currentChoice = reading.status === 'known'
+    ? bandChoices.find((band) => band.name === reading.value)
+    : undefined;
+  // THE LIVE-FREQUENCY PERMIT (verify F1). Evaluated at `freqHz`, the
+  // frequency the operator is actually on — never inherited from
+  // `currentChoice.defaultHzTxPermit`, which only samples the band's default.
+  // The `currentChoice`/`reading` conjunction is fail-closed reinforcement,
+  // not the permit itself: a frequency inside `txBands` but outside every
+  // plan band, or inside a band whose entry was dropped as malformed, still
+  // reads 'denied' (and would otherwise break the contract's own
+  // "allowed ⇒ currentBand known" invariant).
+  const liveFreqPermit = freqObserved && freqHz !== undefined
+    ? getFrequencyPermit(freqHz, caps.txBands)
+    : getFrequencyPermit(null, caps.txBands);
+  const currentBandTx: TxPermit = reading.status === 'known' && currentChoice !== undefined
+    && liveFreqPermit.status === 'allowed' ? 'allowed' : 'denied';
+
+  const starts = freqRanges.map((range) => range.start).filter((hz) => Number.isFinite(hz));
+  const ends = freqRanges.map((range) => range.end).filter((hz) => Number.isFinite(hz));
+  return {
+    currentBand,
+    bandChoices,
+    currentBandTx,
+    tuneMinHz: starts.length > 0 ? Math.min(...starts) : null,
+    tuneMaxHz: ends.length > 0 ? Math.max(...ends) : null,
+  };
+}
+
+/**
  * The App-owned RX-audio snapshot the `rxAudio` facts are read against
  * (MOR-1262 slice 3A). It is an INPUT, deliberately: audio lifetime belongs to
  * the App (MOR-1058) and building a view model must never open, start or probe
@@ -841,6 +961,7 @@ export function toRadioViewModel(
   const filterPassband = deriveFilterPassband(state, caps);
   const dsp = deriveDsp(state, caps);
   const rfFrontEnd = deriveRfFrontEnd(state, caps);
+  const band = deriveBand(state, caps);
   const rfFrontEndMutex = deriveRfFrontEndMutex(rfFrontEnd);
   if (rfFrontEndMutex) disabledReasons.push(rfFrontEndMutex);
 
@@ -862,5 +983,6 @@ export function toRadioViewModel(
     ...(filterPassband !== undefined ? { filterPassband } : {}),
     ...(dsp !== undefined ? { dsp } : {}),
     ...(rfFrontEnd !== undefined ? { rfFrontEnd } : {}),
+    ...(band !== undefined ? { band } : {}),
   };
 }

--- a/frontend/src/semantic/__tests__/band.test.ts
+++ b/frontend/src/semantic/__tests__/band.test.ts
@@ -1,0 +1,222 @@
+/**
+ * MOR-1262 decomposition slice 7A (MOR-1294) — `band` optional fact group
+ * (validator half). SAFETY-ADJACENT: the group carries a TX permit per band.
+ *
+ * Facts only: current band, the capability-derived band choice set (each
+ * entry carrying the EXISTING `FrequencyPermit` tri-state), the fail-closed
+ * `currentBandTx` collapse, and the tuning envelope. A SEPARATE group from
+ * `rfFrontEnd` (MOR-1293, slice 6A′) — see `radio-view-model.ts`'s
+ * `BandViewModel` doc comment for the group-shape rationale, and
+ * `radio-view-model-adapter.ts`'s `deriveBand` for the live derivation
+ * (covered by the companion `band-adapter.test.ts`).
+ *
+ * Mirrors the companion families' (`rf-front-end.test.ts`, `dsp.test.ts`)
+ * kill-tests for this family:
+ *  1. a band-absent model validates and round-trips byte-identically
+ *  2. `"band": null` / `{}` throw (absent ≠ malformed)
+ *  3. a malformed inner field throws with a precise `$.band....` path
+ *  5. an unknown extra key inside band (or a choice entry) throws
+ * (Kill-test 4, the adapter's evidence gate, lives in the adapter test file.)
+ * Plus the fail-closed cross-field invariant this family adds: `currentBandTx`
+ * may never read `'allowed'` while `currentBand` is unknown.
+ */
+import { describe, expect, it } from 'vitest';
+import { validateRadioViewModel, type BandViewModel } from '../radio-view-model';
+import { topologyFixtures, withBand } from '../fixtures/topologies';
+
+const AVAIL = { structural: true, operational: true } as const;
+const base = topologyFixtures['1/single'];
+
+describe('band (MOR-1262 slice 7A)', () => {
+  // ── Kill-test 1: absence is byte-identical, not a new default shape ──────
+  it('validates a band-absent model and never adds the key', () => {
+    expect(Object.keys(base)).not.toContain('band');
+    const validated = validateRadioViewModel(base);
+    expect(Object.keys(validated)).not.toContain('band');
+    expect(validated.band).toBeUndefined();
+    expect(JSON.parse(JSON.stringify(validated))).toEqual(JSON.parse(JSON.stringify(base)));
+  });
+
+  it('validates a fully-populated band group and returns it unchanged', () => {
+    const withB = withBand(base);
+    expect(validateRadioViewModel(withB).band).toEqual(withB.band);
+  });
+
+  // ── Kill-test 2: null / {} are not absent ────────────────────────────────
+  it('rejects an explicit band: null', () => {
+    expect(() => validateRadioViewModel({ ...base, band: null })).toThrow(TypeError);
+  });
+
+  it('rejects an explicit band: {} — present, not absent, must satisfy its own shape', () => {
+    expect(() => validateRadioViewModel({ ...base, band: {} })).toThrow(TypeError);
+  });
+
+  // ── Kill-test 3: malformed inner fields, precise paths ───────────────────
+  it('rejects a non-string currentBand reading value with a precise error path', () => {
+    const withB = withBand(base);
+    const malformed = {
+      ...withB,
+      band: {
+        ...withB.band,
+        currentBand: { reading: { status: 'known', value: 20 }, availability: AVAIL },
+      },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.band\.currentBand\.reading\.value/);
+  });
+
+  it('rejects a non-array bandChoices', () => {
+    const withB = withBand(base);
+    const malformed = { ...withB, band: { ...withB.band, bandChoices: '20m' } };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.band\.bandChoices/);
+  });
+
+  it('rejects a non-numeric band-choice boundary with a precise, indexed error path', () => {
+    const withB = withBand(base);
+    const choices = [...(withB.band as BandViewModel).bandChoices];
+    choices[1] = { ...choices[1], endHz: '14.35 MHz' as unknown as number };
+    const malformed = { ...withB, band: { ...withB.band, bandChoices: choices } };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.band\.bandChoices\[1\]\.endHz/);
+  });
+
+  it('rejects a non-numeric tuneMinHz while accepting an explicit null (no declared range)', () => {
+    const withB = withBand(base);
+    expect(() => validateRadioViewModel({ ...withB, band: { ...withB.band, tuneMinHz: '30 kHz' } }))
+      .toThrow(/\$\.band\.tuneMinHz/);
+    const noRange = { ...withB, band: { ...withB.band, tuneMinHz: null, tuneMaxHz: null } };
+    expect(validateRadioViewModel(noRange).band?.tuneMinHz).toBeNull();
+  });
+
+  it('accepts a null bsrCode but rejects a non-numeric one — absence is null, never a fabricated 0', () => {
+    const withB = withBand(base);
+    expect(validateRadioViewModel(withB).band?.bandChoices[2].bsrCode).toBeNull();
+    const choices = [...(withB.band as BandViewModel).bandChoices];
+    choices[0] = { ...choices[0], bsrCode: '2' as unknown as number };
+    expect(() => validateRadioViewModel({ ...withB, band: { ...withB.band, bandChoices: choices } }))
+      .toThrow(/\$\.band\.bandChoices\[0\]\.bsrCode/);
+  });
+
+  // ── The per-band permit IS the existing tri-state (MOR-1294) ─────────────
+  it('validates every branch of the per-band permit tri-state, including its reasons', () => {
+    const withB = withBand(base);
+    const choices = [
+      { ...(withB.band as BandViewModel).bandChoices[0], defaultHzTxPermit: { status: 'allowed', band: '40m' } },
+      {
+        ...(withB.band as BandViewModel).bandChoices[1],
+        defaultHzTxPermit: { status: 'unknown', reason: 'ranges-unconfigured' },
+      },
+      {
+        ...(withB.band as BandViewModel).bandChoices[2],
+        defaultHzTxPermit: { status: 'denied', reason: 'outside-configured-ranges' },
+      },
+    ];
+    const model = validateRadioViewModel({
+      ...withB,
+      band: { ...withB.band, currentBand: { reading: { status: 'unknown' }, availability: AVAIL }, currentBandTx: 'denied', bandChoices: choices },
+    });
+    expect(model.band?.bandChoices.map((c) => c.defaultHzTxPermit.status)).toEqual(['allowed', 'unknown', 'denied']);
+  });
+
+  it('rejects a bespoke per-band permit shape — the band permit is the shared txPermit tri-state, not a boolean', () => {
+    const withB = withBand(base);
+    const choices = [...(withB.band as BandViewModel).bandChoices];
+    choices[0] = { ...choices[0], defaultHzTxPermit: true as unknown as BandViewModel['bandChoices'][0]['defaultHzTxPermit'] };
+    expect(() => validateRadioViewModel({ ...withB, band: { ...withB.band, bandChoices: choices } }))
+      .toThrow(TypeError);
+  });
+
+  it('rejects an unrecognized per-band permit reason (the tri-state reasons are not a wildcard)', () => {
+    const withB = withBand(base);
+    const choices = [...(withB.band as BandViewModel).bandChoices];
+    choices[2] = {
+      ...choices[2],
+      defaultHzTxPermit: { status: 'denied', reason: 'not-a-ham-band' } as unknown as BandViewModel['bandChoices'][0]['defaultHzTxPermit'],
+    };
+    expect(() => validateRadioViewModel({ ...withB, band: { ...withB.band, bandChoices: choices } }))
+      .toThrow(TypeError);
+  });
+
+  // ── FAIL-CLOSED cross-field invariant (MOR-1294 safety constraint 2) ─────
+  it('rejects currentBandTx: allowed while currentBand is unknown — an unknown band must never permit TX', () => {
+    const withB = withBand(base);
+    const failOpen = {
+      ...withB,
+      band: {
+        ...withB.band,
+        currentBand: { reading: { status: 'unknown' }, availability: AVAIL },
+        currentBandTx: 'allowed',
+      },
+    };
+    expect(() => validateRadioViewModel(failOpen)).toThrow(/\$\.band\.currentBandTx/);
+  });
+
+  it('accepts currentBandTx: denied while currentBand is unknown — the fail-closed pairing', () => {
+    const withB = withBand(base, 'denied');
+    const validated = validateRadioViewModel(withB);
+    expect(validated.band?.currentBand.reading).toEqual({ status: 'unknown' });
+    expect(validated.band?.currentBandTx).toBe('denied');
+  });
+
+  it('rejects a currentBandTx outside the shipped binary permit vocabulary', () => {
+    const withB = withBand(base);
+    expect(() => validateRadioViewModel({ ...withB, band: { ...withB.band, currentBandTx: 'unknown' } }))
+      .toThrow(/\$\.band\.currentBandTx/);
+  });
+
+  // ── Kill-test 5: no speculative keys (N4) ────────────────────────────────
+  it('rejects an unknown extra key inside band', () => {
+    const withB = withBand(base);
+    expect(() => validateRadioViewModel({ ...withB, band: { ...withB.band, bogus: 1 } })).toThrow(TypeError);
+  });
+
+  // The verify-F1 rename is enforced, not merely documented: `exactKeys`
+  // rejects the old point-sample-agnostic `txPermit` key outright, so a 7B
+  // consumer cannot reach for a name that reads like a live permit.
+  it('rejects the pre-rename txPermit key on a band choice (the point-sample name is mandatory)', () => {
+    const withB = withBand(base);
+    const choices = (withB.band as BandViewModel).bandChoices.map(
+      ({ defaultHzTxPermit, ...rest }) => ({ ...rest, txPermit: defaultHzTxPermit }),
+    );
+    expect(() => validateRadioViewModel({ ...withB, band: { ...withB.band, bandChoices: choices } }))
+      .toThrow(TypeError);
+  });
+
+  it('rejects an unknown extra key inside a band choice', () => {
+    const withB = withBand(base);
+    const choices = [...(withB.band as BandViewModel).bandChoices];
+    choices[0] = { ...choices[0], label: 'Forty' } as unknown as BandViewModel['bandChoices'][0];
+    expect(() => validateRadioViewModel({ ...withB, band: { ...withB.band, bandChoices: choices } }))
+      .toThrow(TypeError);
+  });
+
+  it('rejects a band group missing a key (no partial 7A shape survives)', () => {
+    const withB = withBand(base);
+    const { tuneMaxHz: _tuneMaxHz, ...withoutMax } = withB.band as BandViewModel;
+    expect(() => validateRadioViewModel({ ...withB, band: withoutMax })).toThrow(TypeError);
+  });
+
+  it('rejects a currentBand reading that carries a value key while unknown', () => {
+    const withB = withBand(base);
+    const malformed = {
+      ...withB,
+      band: {
+        ...withB.band,
+        currentBand: { reading: { status: 'unknown', value: '20m' }, availability: AVAIL },
+        currentBandTx: 'denied',
+      },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(TypeError);
+  });
+
+  it('every field of a fully-populated group round-trips its own value', () => {
+    const validated = validateRadioViewModel(withBand(base)).band as BandViewModel;
+    expect(validated.currentBand.reading).toEqual({ status: 'known', value: '20m' });
+    expect(validated.bandChoices.map((c) => c.name)).toEqual(['40m', '20m', 'MW']);
+    expect(validated.bandChoices[1]).toEqual({
+      name: '20m', startHz: 14000000, endHz: 14350000, defaultHz: 14195000, bsrCode: 5,
+      defaultHzTxPermit: { status: 'allowed', band: '20m' },
+    });
+    expect(validated.currentBandTx).toBe('allowed');
+    expect(validated.tuneMinHz).toBe(30000);
+    expect(validated.tuneMaxHz).toBe(60000000);
+  });
+});

--- a/frontend/src/semantic/__tests__/optional-group-allow-list.test.ts
+++ b/frontend/src/semantic/__tests__/optional-group-allow-list.test.ts
@@ -42,9 +42,9 @@ const REQUIRED_KEYS = [
 
 /** MOR-1244: txAux. MOR-1262 slice 2A: meters. Slice 3A: rxAudio. Slice 4A:
  *  modeFilter. Slice 4A′: filterPassband. Slice 5A: dsp. Slice 6A: rfFrontEnd.
- *  Add your key here when your family's slice lands. */
+ *  Slice 7A: band. Add your key here when your family's slice lands. */
 const EXPECTED_OPTIONAL_GROUP_KEYS = [
-  'txAux', 'meters', 'rxAudio', 'modeFilter', 'filterPassband', 'dsp', 'rfFrontEnd',
+  'txAux', 'meters', 'rxAudio', 'modeFilter', 'filterPassband', 'dsp', 'rfFrontEnd', 'band',
 ] as const;
 
 function extractTopLevelAllowList(): string[] {

--- a/frontend/src/semantic/fixtures/topologies.ts
+++ b/frontend/src/semantic/fixtures/topologies.ts
@@ -14,7 +14,8 @@
  * topology, so it can be applied to any of the four fixtures below.
  */
 import type {
-  Availability, DspField, DspViewModel, FilterPassbandField, FilterPassbandViewModel,
+  Availability, BandField, BandViewModel,
+  DspField, DspViewModel, FilterPassbandField, FilterPassbandViewModel,
   MeterField, MeterRfState, MetersViewModel,
   ModeFilterField, ModeFilterViewModel,
   ModInputReadiness, RadioViewModel, RfFrontEndField, RfFrontEndViewModel, RxAudioField, RxAudioViewModel,
@@ -333,4 +334,47 @@ export function withRfFrontEnd(fixture: RadioViewModel): RadioViewModel {
     ipPlus: known(false),
   };
   return { ...fixture, rfFrontEnd };
+}
+
+/**
+ * Applies a fully-observed `band` group (MOR-1262 slice 7A, MOR-1294) to any
+ * topology fixture — same composable-axis story as `withRfFrontEnd`/`withDsp`
+ * above. `currentBandTx` is a PARAMETER for the same reason `withMeters`'s
+ * `rfState` and `withRxAudio`'s `readiness` are: TX permission is the
+ * safety-critical axis of this family, and a fixture that hard-coded
+ * `'allowed'` would make the fail-closed path unobservable in every consumer
+ * that composes this helper. Passing `'denied'` also switches the current
+ * band to `unknown`, because the contract's own cross-field invariant forbids
+ * an `'allowed'`-on-unknown pairing and this fixture must stay valid in both
+ * directions; the finer per-permit combinations are exercised by the
+ * adapter's own tests, not this fixture.
+ */
+export function withBand(
+  fixture: RadioViewModel, currentBandTx: 'allowed' | 'denied' = 'allowed',
+): RadioViewModel {
+  const avail: Availability = { structural: true, operational: true };
+  const known = <T>(value: T): BandField<T> => ({ reading: { status: 'known', value }, availability: avail });
+  const band: BandViewModel = {
+    currentBand: currentBandTx === 'allowed'
+      ? known('20m')
+      : { reading: { status: 'unknown' }, availability: avail },
+    bandChoices: [
+      {
+        name: '40m', startHz: 7000000, endHz: 7300000, defaultHz: 7100000, bsrCode: 2,
+        defaultHzTxPermit: { status: 'allowed', band: '40m' },
+      },
+      {
+        name: '20m', startHz: 14000000, endHz: 14350000, defaultHz: 14195000, bsrCode: 5,
+        defaultHzTxPermit: { status: 'allowed', band: '20m' },
+      },
+      {
+        name: 'MW', startHz: 520000, endHz: 1710000, defaultHz: 1000000, bsrCode: null,
+        defaultHzTxPermit: { status: 'denied', reason: 'outside-configured-ranges' },
+      },
+    ],
+    currentBandTx,
+    tuneMinHz: 30000,
+    tuneMaxHz: 60000000,
+  };
+  return { ...fixture, band };
 }

--- a/frontend/src/semantic/radio-view-model.ts
+++ b/frontend/src/semantic/radio-view-model.ts
@@ -16,7 +16,7 @@
  * boolean or a default is the failure mode this contract exists to prevent.
  */
 import type { VfoScheme } from '$lib/types/capabilities';
-import type { FrequencyPermit } from '$lib/utils/tx-permit';
+import type { FrequencyPermit, TxPermit } from '$lib/utils/tx-permit';
 import { invalid, record, exactKeys, str } from './validator-primitives';
 
 export type ReceiverId = 'MAIN' | 'SUB';
@@ -435,6 +435,115 @@ export interface RfFrontEndViewModel {
   ipPlus: RfFrontEndField<boolean>;
 }
 
+/**
+ * A single band fact (MOR-1262 decomposition slice 7A, MOR-1294).
+ * Shape-identical to `TxAuxField`, declared as an alias for the same reason
+ * `RfFrontEndField`/`DspField`/`ModeFilterField`/`RxAudioField` are: one
+ * field shape per fact family.
+ */
+export type BandField<T> = TxAuxField<T>;
+
+/**
+ * One selectable band of the radio's own band plan — `$lib/radio/band-plan`'s
+ * `FlatBand` (the shipped `flattenBands` output over `Capabilities.
+ * freqRanges`) plus the band's TX permit.
+ *
+ * SAFETY (MOR-1294): `defaultHzTxPermit` is the EXISTING `FrequencyPermit`
+ * tri-state, produced by the ONE derivation in this codebase
+ * (`getFrequencyPermit`, `$lib/utils/tx-permit` — the same function
+ * `deriveTxCapabilities` calls for the model's top-level `txPermit`). It is
+ * NOT read off the band plan itself: `freqRanges` describes what the radio
+ * can TUNE, `caps.txBands` describes where it may TRANSMIT, and treating a
+ * band's presence in the plan as permission to key is precisely the fail-open
+ * defect this slice forbids. A default outside `txBands` stays `denied`;
+ * `txBands: null` stays `unknown`.
+ *
+ * It is a POINT SAMPLE at `defaultHz`, and the field name says so (MOR-1294
+ * verify F1). It answers only "if I pick this band and land on its default
+ * frequency, may I key THERE" — the picker label. It is NOT a statement about
+ * the whole band: `txBands` segments are routinely NARROWER than a band-plan
+ * band (WARC segments, regional sub-bands, 60m channels), so a band whose
+ * default sits inside a permitted segment reads `allowed` here while the
+ * operator's LIVE frequency elsewhere in the same band is denied.
+ * `BandViewModel.currentBandTx` is the live-frequency answer and is NEVER
+ * derived from this field; a 7B surface must not present this as "you may
+ * transmit anywhere in this band".
+ */
+export interface BandChoice {
+  name: string;
+  startHz: number;
+  endHz: number;
+  defaultHz: number;
+  /** Icom band-stacking-register index; `null` when the plan declares none. */
+  bsrCode: number | null;
+  defaultHzTxPermit: FrequencyPermit;
+}
+
+/**
+ * Band facts (MOR-1262 decomposition slice 7A, MOR-1294): the current band,
+ * the capability-derived band choice set with its per-band TX permits, and
+ * the tuning envelope a frequency-entry surface validates against. Facts only
+ * — no command emission; selecting a band or committing a typed frequency
+ * stays with the surface (slice 7B).
+ *
+ * `bandChoices` is a plain list, not `BandField`-wrapped, for the same reason
+ * `modeFilter`'s `modeChoices` and `dsp`'s `agcModes` aren't: a choice set is
+ * a structural fact about the radio MODEL, not a live reading that can go
+ * stale. Per the X6200 lesson it is read from the `caps` ARGUMENT only, via
+ * the shipped `flattenBands` — never a frontend band table (the shipped
+ * `BandSelector.svelte`'s hard-coded `BROADCAST_SW_BANDS`/`BROADCAST_LW_MW_BANDS`
+ * presets are UI convenience, not radio facts, and are deliberately absent).
+ *
+ * `currentBand` is the shipped `findActiveBand` lookup over that same `caps`
+ * argument, keyed on the ACTIVE receiver's observed frequency — `unknown`
+ * when the frequency was never observed or when no band of the plan contains
+ * it, where the shipped `toBandSelectorProps` substitutes a fabricated
+ * 14.074 MHz.
+ *
+ * `currentBandTx` is the FAIL-CLOSED, LIVE-FREQUENCY answer to "may the
+ * operator key right now" — see its own comment below. It is a different
+ * question from `bandChoices[].defaultHzTxPermit`, which is a point sample at
+ * a band's default frequency, and the two must never be conflated.
+ *
+ * `tuneMinHz`/`tuneMaxHz` are the frequency-entry constraint: the envelope of
+ * the declared `freqRanges` (range bounds, not band bounds — the gaps between
+ * bands are still tunable). `null` when the radio declares no range at all;
+ * never `components-v2/display/frequency-tuning.ts::adjustFreqByDigit`'s
+ * fabricated `0 … 999 MHz` defaults, which is the only bound v2 has (that
+ * function has no production caller that supplies one).
+ */
+export interface BandViewModel {
+  currentBand: BandField<string>;
+  bandChoices: readonly BandChoice[];
+  /**
+   * SAFETY (MOR-1294, corrected by the verify F1 ruling). "May the operator
+   * key RIGHT NOW, at the frequency the radio is actually on."
+   *
+   * Evaluated at the LIVE frequency — `getFrequencyPermit(observedFreqHz,
+   * caps.txBands)`, the same single shipped derivation, just at the correct
+   * argument — and NEVER inherited from `bandChoices[].defaultHzTxPermit`.
+   * Inheriting the point sample is a demonstrated fail-OPEN whenever a
+   * `txBands` segment is narrower than the band-plan band it sits in (live
+   * 14.300 MHz reading `allowed` off a 14.000–14.150 allocation), which is
+   * common, silent, and exactly what "out-of-band must stay denied, never
+   * fail-open" forbids.
+   *
+   * Collapsed fail-closed exactly the way the shipped `getTxPermit` collapses
+   * the tri-state (`$lib/utils/tx-permit`: "unknown fails closed").
+   * `'allowed'` requires ALL of: a POSITIVELY known current band, a choice
+   * entry for it, and a POSITIVELY `allowed` live-frequency permit. An
+   * unobserved/stale/malformed frequency, an out-of-plan frequency, a band
+   * absent from the choice set, an out-of-segment frequency and unconfigured
+   * TX ranges all read `'denied'`. An unknown input must never enable a
+   * TX-adjacent affordance — see `radio-view-model-adapter.ts`'s `deriveBand`,
+   * and the cross-field invariant `validateRadioViewModel` enforces on this
+   * pair.
+   */
+  currentBandTx: TxPermit;
+  tuneMinHz: number | null;
+  tuneMaxHz: number | null;
+}
+
 export interface RadioViewModel {
   topologyId: string;
   vfoScheme: VfoScheme;
@@ -477,6 +586,10 @@ export interface RadioViewModel {
    *  (MOR-1293 added the latter two) — see
    *  `radio-view-model-adapter.ts`'s `deriveRfFrontEnd`. */
   readonly rfFrontEnd?: RfFrontEndViewModel;
+  /** Absent (MOR-1264 optional group) ⇒ this radio declares no frequency
+   *  range at all, so there is no band plan and no tuning envelope to state
+   *  — see `radio-view-model-adapter.ts`'s `deriveBand`. */
+  readonly band?: BandViewModel;
 }
 
 const RECEIVER_IDS: readonly ReceiverId[] = ['MAIN', 'SUB'];
@@ -881,6 +994,49 @@ function validateRfFrontEnd(value: unknown, path: string): RfFrontEndViewModel {
   };
 }
 
+const TX_PERMITS: readonly TxPermit[] = ['allowed', 'denied'];
+
+/** One band-plan entry plus its own default-frequency TX point sample — the
+ *  permit is validated by the SAME `validateTxPermit` the top-level
+ *  `txPermit` uses, because it IS the same tri-state (MOR-1294); a divergent
+ *  per-band permit shape would be the second derivation this slice exists to
+ *  prevent. */
+function validateBandChoice(value: unknown, path: string): BandChoice {
+  const v = record(value, path);
+  exactKeys(v, ['name', 'startHz', 'endHz', 'defaultHz', 'bsrCode', 'defaultHzTxPermit'], path);
+  return {
+    name: str(v.name, `${path}.name`),
+    startHz: num(v.startHz, `${path}.startHz`),
+    endHz: num(v.endHz, `${path}.endHz`),
+    defaultHz: num(v.defaultHz, `${path}.defaultHz`),
+    bsrCode: nullableNumber(v.bsrCode, `${path}.bsrCode`),
+    defaultHzTxPermit: validateTxPermit(v.defaultHzTxPermit, `${path}.defaultHzTxPermit`),
+  };
+}
+
+/** N4 again: exactly the five facts the adapter reads, no speculative keys.
+ *  See `radio-view-model-adapter.ts::deriveBand`. */
+function validateBand(value: unknown, path: string): BandViewModel {
+  const v = record(value, path);
+  exactKeys(v, ['currentBand', 'bandChoices', 'currentBandTx', 'tuneMinHz', 'tuneMaxHz'], path);
+  if (!Array.isArray(v.bandChoices)) invalid(`${path}.bandChoices`, 'an array');
+  const currentBand = validateTxAuxField(v.currentBand, `${path}.currentBand`, str);
+  const currentBandTx = oneOf(v.currentBandTx, TX_PERMITS, `${path}.currentBandTx`);
+  // The fail-closed cross-field invariant (MOR-1294), the same shape as the
+  // model-level "txPermit 'allowed' only when txTarget is known" pin below:
+  // a band the radio could not identify must never carry TX permission.
+  if (currentBandTx === 'allowed' && currentBand.reading.status === 'unknown') {
+    invalid(`${path}.currentBandTx`, "'denied' whenever currentBand is unknown (fail-open otherwise)");
+  }
+  return {
+    currentBand,
+    bandChoices: v.bandChoices.map((b, i) => validateBandChoice(b, `${path}.bandChoices[${i}]`)),
+    currentBandTx,
+    tuneMinHz: nullableNumber(v.tuneMinHz, `${path}.tuneMinHz`),
+    tuneMaxHz: nullableNumber(v.tuneMaxHz, `${path}.tuneMaxHz`),
+  };
+}
+
 /** Runtime validator (repo idiom: throws TypeError with a `$.path`, see `validateCapabilities`).
  *  Also enforces two cross-field invariants (review cycle 1, V1): `txPermit`
  *  cannot be 'allowed' while `txTarget` is unknown (no fail-open), and
@@ -890,7 +1046,7 @@ export function validateRadioViewModel(value: unknown): RadioViewModel {
   exactKeys(v, [
     'topologyId', 'vfoScheme', 'activeReceiver', 'vfos', 'split', 'dualWatch',
     'txTarget', 'txPermit', 'scope', 'disabledReasons', 'txAux', 'meters', 'rxAudio', 'modeFilter',
-    'filterPassband', 'dsp', 'rfFrontEnd',
+    'filterPassband', 'dsp', 'rfFrontEnd', 'band',
   ], '$');
   if (!Array.isArray(v.vfos)) invalid('$.vfos', 'an array');
   if (!Array.isArray(v.disabledReasons)) invalid('$.disabledReasons', 'an array');
@@ -925,6 +1081,7 @@ export function validateRadioViewModel(value: unknown): RadioViewModel {
   const filterPassband = optionalGroup(v.filterPassband, '$.filterPassband', validateFilterPassband);
   const dsp = optionalGroup(v.dsp, '$.dsp', validateDsp);
   const rfFrontEnd = optionalGroup(v.rfFrontEnd, '$.rfFrontEnd', validateRfFrontEnd);
+  const band = optionalGroup(v.band, '$.band', validateBand);
 
   return {
     topologyId: str(v.topologyId, '$.topologyId'),
@@ -947,5 +1104,6 @@ export function validateRadioViewModel(value: unknown): RadioViewModel {
     ...(filterPassband !== undefined ? { filterPassband } : {}),
     ...(dsp !== undefined ? { dsp } : {}),
     ...(rfFrontEnd !== undefined ? { rfFrontEnd } : {}),
+    ...(band !== undefined ? { band } : {}),
   };
 }


### PR DESCRIPTION
## Summary
Vocabulary slice 7A (SAFETY-ADJACENT): optional `band` group — `currentBand`, `bandChoices` (with `defaultHzTxPermit`, named so the point-sample picker label can never be conflated with a live permit), `currentBandTx`, `tuneMinHz`/`tuneMaxHz` (kept: the slice is band + frequency ENTRY; bounds derive from caps with honest null). Evidence gate caps-driven (no freqRanges ⇒ no group). `flattenBands`/`findActiveBand` move byte-verbatim to `lib/radio/band-plan.ts` with a re-export shim (layering: lib/runtime may not import components-v2; forking the lookup is the forbidden defect). Net production LOC **98** strict / 306 raw (verifier re-measured; ≤200).

**Safety:** ONE permit derivation — everything flows from the shipped `getFrequencyPermit`/`getTxPermit`; `currentBandTx` is evaluated at the LIVE frequency gated on `freqObserved`, fail-closed collapse. Round-1 verification demonstrated a real fail-OPEN (the field inherited the band's `defaultHz` point-sample: live 14.300 MHz read `allowed` while `getFrequencyPermit` said `denied` on a lower-half `txBands` segment — the WARC/regional-sub-band shape); fixed and pinned with the exact discriminator + a segment-boundary sweep incl. the off-by-one. Full degenerate matrix (stale/malformed/NaN/out-of-plan/empty/null) reads denied; `allowed ⇒ currentBand known` enforced structurally.

## Review provenance
Opus builder → independent opus vocabulary-domain verifier (14th ticket in domain): round 1 **BLOCKED** on the demonstrated fail-open; delta round **PASS** — F1 probe re-run on the verifier's own half-band fixture (14.300 denied / 14.050 allowed / boundary allowed / stale denied), M-E revert-to-point-sample killed 5, the verifier's own second-derivation mutant killed 8, production delta = the F1 fix + rename only (other files byte-identical to the round-1 record). Rulings: binary `TxPermit` collapse sound (tri-state remains at the top-level `txPermit`); tune bounds kept; file move verbatim-verified with the eslint ban confirmed real. Info: F2 (permissive topFieldAvailable default = repo-wide convention → owner note), F3 (7B renders the live-frequency fact — post-rename hard to misread). Fail-set identical to baseline; lint/boundaries/check clean.

Linear: MOR-1294

🤖 Generated with [Claude Code](https://claude.com/claude-code)