### PR TITLE
feat(MOR-1295): ritXit, antenna, and scan fact groups (vocabulary slice 8A)

### DIFF
--- a/frontend/src/lib/runtime/adapters/__tests__/antenna-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/antenna-adapter.test.ts
@@ -1,0 +1,212 @@
+/**
+ * MOR-1262 decomposition slice 8A (MOR-1295) — `antenna` fact-group adapter
+ * derivation.
+ *
+ * Companion to `rit-xit-adapter.test.ts`/`rf-front-end-adapter.test.ts`,
+ * which this file does NOT modify. `antenna` is a SEPARATE optional group —
+ * see `radio-view-model.ts`'s `AntennaViewModel` doc comment.
+ *
+ * PARITY — the parity pin below calls the REAL `toAntennaProps`
+ * (`lib/runtime/props/panel-props.ts`), never a reimplementation.
+ *
+ * Neither `txAntenna`/`rxAntenna1`/`rxAntenna2` nor `caps.antennas`/
+ * `rx_antenna` consume a capabilities-STORE-backed helper, so this file
+ * never calls the real `setCapabilities` and does not need the isolated
+ * pool (MOR-1272).
+ */
+import { describe, expect, it } from 'vitest';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { FieldStatus, ServerState } from '$lib/types/state';
+import { validateRadioViewModel, type RadioViewModel } from '../../../../semantic/radio-view-model';
+import { toRadioViewModel } from '../radio-view-model-adapter';
+import { toAntennaProps } from '../../props/panel-props';
+
+function caps(overrides: Partial<Capabilities> = {}): Capabilities {
+  return {
+    model: 'fixture', scope: true, audio: true, tx: true, capabilities: ['scope', 'audio', 'tx'],
+    receivers: 1, vfoScheme: 'single', freqRanges: [], modes: [], filters: [],
+    audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
+    webrtc: { available: false, enabled: false },
+    txBands: [], scopeSource: 'hardware', audioFftAvailable: false, ...overrides,
+  } as Capabilities;
+}
+
+const fresh: FieldStatus = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' };
+const stale: FieldStatus = { storePath: 'x', observed: true, freshness: 'stale', availability: 'stale' };
+
+function bareState(overrides: Partial<ServerState> = {}): ServerState {
+  return {
+    active: 'MAIN', split: false, dualWatch: false, ptt: false,
+    txTarget: { status: 'known', receiver: 'MAIN', slot: null, frequencyHz: 14195000 },
+    main: {
+      freqHz: 14195000, mode: 'USB', filter: 1, dataMode: 0, att: 0, preamp: 0,
+      nb: false, nr: false, afLevel: 1, rfGain: 1, squelch: 0, sMeter: 0,
+    },
+    sub: {
+      freqHz: 7100000, mode: 'LSB', filter: 2, dataMode: 0, att: 0, preamp: 0,
+      nb: false, nr: false, afLevel: 1, rfGain: 1, squelch: 0, sMeter: 0,
+    },
+    fieldStatus: {
+      active: fresh, split: fresh, dualWatch: fresh, txTarget: fresh,
+      'main.freqHz': fresh, 'main.mode': fresh, 'main.filter': fresh,
+    },
+    ...overrides,
+  } as ServerState;
+}
+
+function model(state: ServerState | null, capabilities: Capabilities | null): RadioViewModel {
+  const view = toRadioViewModel(state, capabilities);
+  expect(view).not.toBeNull();
+  return validateRadioViewModel(view);
+}
+
+describe('antenna evidence gate (MOR-1295, N3)', () => {
+  it('emits no antenna when capabilities are absent', () => {
+    expect(toRadioViewModel(bareState(), null)).toBeNull();
+  });
+
+  it('emits no antenna for a baseline radio with no declared antenna port count (regression pin)', () => {
+    const view = model(bareState(), caps());
+    expect(view.antenna).toBeUndefined();
+    expect(Object.keys(view)).not.toContain('antenna');
+  });
+
+  it('emits no antenna for a radio explicitly declaring exactly one port — nothing to select', () => {
+    const view = model(bareState(), caps({ antennas: 1 }));
+    expect(view.antenna).toBeUndefined();
+  });
+
+  it('emits no antenna for the rx_antenna capability ALONE, without a multi-port declaration — matches the nested v2 gate', () => {
+    const view = model(bareState(), caps({ capabilities: ['rx_antenna'] }));
+    expect(view.antenna).toBeUndefined();
+  });
+
+  it('emits antenna once antennas > 1 is declared', () => {
+    const view = model(bareState(), caps({ antennas: 2 }));
+    expect(view.antenna).toBeDefined();
+    expect(view.antenna!.antennaCount).toBe(2);
+  });
+});
+
+describe('antenna per-field structural gates (MOR-1295)', () => {
+  it('rxAnt is structurally absent without the rx_antenna capability, even though txAntenna is present', () => {
+    const view = model(bareState(), caps({ antennas: 2 }));
+    expect(view.antenna!.rxAnt.availability.structural).toBe(false);
+    expect(view.antenna!.txAntenna.availability.structural).toBe(true);
+  });
+
+  it('rxAnt is structurally present once rx_antenna is declared alongside a multi-port radio', () => {
+    const view = model(bareState(), caps({ antennas: 2, capabilities: ['rx_antenna'] }));
+    expect(view.antenna!.rxAnt.availability.structural).toBe(true);
+  });
+});
+
+describe('antenna per-field derivation (MOR-1295)', () => {
+  const fullCaps = caps({ antennas: 2, capabilities: ['rx_antenna'] });
+
+  it('reports known readings for observed, fresh fields — parity with the real toAntennaProps', () => {
+    const state = bareState({
+      txAntenna: 1, rxAntenna1: true,
+      fieldStatus: { ...bareState().fieldStatus, txAntenna: fresh, rxAntenna1: fresh },
+    });
+    const real = toAntennaProps(state, fullCaps);
+    const view = model(state, fullCaps);
+    expect(view.antenna!.txAntenna.reading).toEqual({ status: 'known', value: real.txAntenna });
+    expect(view.antenna!.rxAnt.reading).toEqual({ status: 'known', value: real.rxAnt });
+  });
+
+  it('reads rxAntenna2 (not rxAntenna1) once txAntenna selects port 2 — parity with the real toAntennaProps', () => {
+    const state = bareState({
+      txAntenna: 2, rxAntenna1: true, rxAntenna2: false,
+      fieldStatus: { ...bareState().fieldStatus, txAntenna: fresh, rxAntenna2: fresh },
+    });
+    const real = toAntennaProps(state, fullCaps);
+    const view = model(state, fullCaps);
+    expect(real.rxAnt).toBe(false);
+    expect(view.antenna!.rxAnt.reading).toEqual({ status: 'known', value: false });
+  });
+
+  it('degrades a stale txAntenna field to unknown while keeping structural availability true', () => {
+    const state = bareState({
+      txAntenna: 1, fieldStatus: { ...bareState().fieldStatus, txAntenna: stale },
+    });
+    const view = model(state, fullCaps);
+    expect(view.antenna!.txAntenna).toEqual({
+      reading: { status: 'unknown' }, availability: { structural: true, operational: false },
+    });
+  });
+
+  it('marks rxAnt structurally absent when the rx_antenna capability is missing, never known', () => {
+    const state = bareState({
+      txAntenna: 1, rxAntenna1: true,
+      fieldStatus: { ...bareState().fieldStatus, txAntenna: fresh, rxAntenna1: fresh },
+    });
+    const view = model(state, caps({ antennas: 2 }));
+    expect(view.antenna!.rxAnt).toEqual({
+      reading: { status: 'unknown' }, availability: { structural: false, operational: false },
+    });
+  });
+
+  it('degrades a malformed raw txAntenna (wrong JS type) to unknown rather than coercing', () => {
+    const state = bareState({
+      txAntenna: '1' as unknown as number,
+      fieldStatus: { ...bareState().fieldStatus, txAntenna: fresh },
+    });
+    const view = model(state, fullCaps);
+    expect(view.antenna!.txAntenna.reading).toEqual({ status: 'unknown' });
+  });
+
+  it('emits a validator-clean model carrying the antenna group (round-trip proof)', () => {
+    const state = bareState({
+      txAntenna: 1, rxAntenna1: true,
+      fieldStatus: { ...bareState().fieldStatus, txAntenna: fresh, rxAntenna1: fresh },
+    });
+    const view = model(state, fullCaps);
+    expect(JSON.parse(JSON.stringify(view))).toEqual(view);
+  });
+});
+
+/**
+ * HONESTY — "never derive from a half-observed pair" (the 4A′/5A lesson,
+ * applied here to `rxAnt`'s two-field dependency on `txAntenna`). An
+ * unobserved `txAntenna` must never silently resolve to port 1's reading —
+ * that is exactly the fabricated-default this contract exists to forbid.
+ */
+describe('antenna rxAnt fails closed on an unobserved txAntenna (half-observed-pair lesson)', () => {
+  const fullCaps = caps({ antennas: 2, capabilities: ['rx_antenna'] });
+
+  it('rxAnt reads unknown when txAntenna was never reported, even though rxAntenna1 is fresh and true', () => {
+    const state = bareState({
+      rxAntenna1: true, fieldStatus: { ...bareState().fieldStatus, rxAntenna1: fresh },
+    });
+    const view = model(state, fullCaps);
+    expect(view.antenna!.txAntenna.reading).toEqual({ status: 'unknown' });
+    expect(view.antenna!.rxAnt.reading).toEqual({ status: 'unknown' });
+  });
+
+  it('rxAnt reads unknown when txAntenna is stale, even though rxAntenna1 is fresh', () => {
+    const state = bareState({
+      txAntenna: 1, rxAntenna1: true,
+      fieldStatus: { ...bareState().fieldStatus, txAntenna: stale, rxAntenna1: fresh },
+    });
+    const view = model(state, fullCaps);
+    expect(view.antenna!.rxAnt.reading).toEqual({ status: 'unknown' });
+  });
+
+  it('rxAnt reads unknown when txAntenna selects port 2 but rxAntenna2 was never reported (port-2 half-observed variant)', () => {
+    const state = bareState({
+      txAntenna: 2, rxAntenna1: true,
+      fieldStatus: { ...bareState().fieldStatus, txAntenna: fresh, rxAntenna1: fresh },
+    });
+    const view = model(state, fullCaps);
+    expect(view.antenna!.rxAnt.reading).toEqual({ status: 'unknown' });
+  });
+});
+
+/** HONESTY GATE — absent raw values never fabricate. */
+describe('antenna honesty gate — absent raw values never fabricate', () => {
+  it('txAntenna with nothing reported at all reads unknown, not {known, 1}', () => {
+    const view = model(bareState(), caps({ antennas: 2 }));
+    expect(view.antenna!.txAntenna.reading).toEqual({ status: 'unknown' });
+  });
+});

--- a/frontend/src/lib/runtime/adapters/__tests__/rit-xit-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/rit-xit-adapter.test.ts
@@ -1,0 +1,188 @@
+/**
+ * MOR-1262 decomposition slice 8A (MOR-1295) — `ritXit` fact-group adapter
+ * derivation.
+ *
+ * Companion to `rf-front-end-adapter.test.ts`/`band-adapter.test.ts`, which
+ * this file does NOT modify. `ritXit` is a SEPARATE optional group — see
+ * `radio-view-model.ts`'s `RitXitViewModel` doc comment.
+ *
+ * PARITY — the parity pin below calls the REAL `toRitXitProps`
+ * (`lib/runtime/props/panel-props.ts`), never a reimplementation, so
+ * agreement is against the shipped derivation itself.
+ *
+ * Neither `ritOn`/`ritFreq`/`ritTx` nor the `rit`/`xit` capability tags
+ * consume a capabilities-STORE-backed helper, so this file never calls the
+ * real `setCapabilities` and does not need the isolated pool (MOR-1272).
+ */
+import { describe, expect, it } from 'vitest';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { FieldStatus, ServerState } from '$lib/types/state';
+import { validateRadioViewModel, type RadioViewModel } from '../../../../semantic/radio-view-model';
+import { toRadioViewModel } from '../radio-view-model-adapter';
+import { toRitXitProps } from '../../props/panel-props';
+
+function caps(overrides: Partial<Capabilities> = {}): Capabilities {
+  return {
+    model: 'fixture', scope: true, audio: true, tx: true, capabilities: ['scope', 'audio', 'tx'],
+    receivers: 1, vfoScheme: 'single', freqRanges: [], modes: [], filters: [],
+    audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
+    webrtc: { available: false, enabled: false },
+    txBands: [], scopeSource: 'hardware', audioFftAvailable: false, ...overrides,
+  } as Capabilities;
+}
+
+const fresh: FieldStatus = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' };
+const stale: FieldStatus = { storePath: 'x', observed: true, freshness: 'stale', availability: 'stale' };
+
+function bareState(overrides: Partial<ServerState> = {}): ServerState {
+  return {
+    active: 'MAIN', split: false, dualWatch: false, ptt: false,
+    txTarget: { status: 'known', receiver: 'MAIN', slot: null, frequencyHz: 14195000 },
+    main: {
+      freqHz: 14195000, mode: 'USB', filter: 1, dataMode: 0, att: 0, preamp: 0,
+      nb: false, nr: false, afLevel: 1, rfGain: 1, squelch: 0, sMeter: 0,
+    },
+    sub: {
+      freqHz: 7100000, mode: 'LSB', filter: 2, dataMode: 0, att: 0, preamp: 0,
+      nb: false, nr: false, afLevel: 1, rfGain: 1, squelch: 0, sMeter: 0,
+    },
+    fieldStatus: {
+      active: fresh, split: fresh, dualWatch: fresh, txTarget: fresh,
+      'main.freqHz': fresh, 'main.mode': fresh, 'main.filter': fresh,
+    },
+    ...overrides,
+  } as ServerState;
+}
+
+function model(state: ServerState | null, capabilities: Capabilities | null): RadioViewModel {
+  const view = toRadioViewModel(state, capabilities);
+  expect(view).not.toBeNull();
+  return validateRadioViewModel(view);
+}
+
+describe('ritXit evidence gate (MOR-1295, N3)', () => {
+  it('emits no ritXit when capabilities are absent', () => {
+    expect(toRadioViewModel(bareState(), null)).toBeNull();
+  });
+
+  it('emits no ritXit for a baseline radio with neither rit nor xit capability (regression pin)', () => {
+    const view = model(bareState(), caps());
+    expect(view.ritXit).toBeUndefined();
+    expect(Object.keys(view)).not.toContain('ritXit');
+  });
+
+  it('emits ritXit once the rit capability alone is declared', () => {
+    const view = model(bareState(), caps({ capabilities: ['rit'] }));
+    expect(view.ritXit).toBeDefined();
+  });
+
+  it('emits ritXit once the xit capability alone is declared', () => {
+    const view = model(bareState(), caps({ capabilities: ['xit'] }));
+    expect(view.ritXit).toBeDefined();
+  });
+});
+
+describe('ritXit per-field structural gates (MOR-1295)', () => {
+  it('rit* fields are structurally absent without the rit capability, even with xit present', () => {
+    const view = model(bareState(), caps({ capabilities: ['xit'] }));
+    expect(view.ritXit!.ritActive.availability.structural).toBe(false);
+    expect(view.ritXit!.ritOffset.availability.structural).toBe(false);
+    expect(view.ritXit!.xitActive.availability.structural).toBe(true);
+  });
+
+  it('xit* fields are structurally absent without the xit capability, even with rit present', () => {
+    const view = model(bareState(), caps({ capabilities: ['rit'] }));
+    expect(view.ritXit!.xitActive.availability.structural).toBe(false);
+    expect(view.ritXit!.xitOffset.availability.structural).toBe(false);
+    expect(view.ritXit!.ritActive.availability.structural).toBe(true);
+  });
+});
+
+describe('ritXit per-field derivation (MOR-1295)', () => {
+  const fullCaps = caps({ capabilities: ['rit', 'xit'] });
+
+  it('reports known readings for observed, fresh, capability-backed fields — parity with the real toRitXitProps', () => {
+    const state = bareState({
+      ritOn: true, ritTx: false, ritFreq: 250,
+      fieldStatus: { ...bareState().fieldStatus, ritOn: fresh, ritTx: fresh, ritFreq: fresh },
+    });
+    const real = toRitXitProps(state, fullCaps);
+    const view = model(state, fullCaps);
+    const ritXit = view.ritXit!;
+    expect(ritXit.ritActive.reading).toEqual({ status: 'known', value: real.ritActive });
+    expect(ritXit.ritOffset.reading).toEqual({ status: 'known', value: real.ritOffset });
+    expect(ritXit.xitActive.reading).toEqual({ status: 'known', value: real.xitActive });
+    expect(ritXit.xitOffset.reading).toEqual({ status: 'known', value: real.xitOffset });
+  });
+
+  it('ritOffset and xitOffset read the SAME shared register, in parity with the real derivation', () => {
+    const state = bareState({ ritFreq: -400, fieldStatus: { ...bareState().fieldStatus, ritFreq: fresh } });
+    const view = model(state, fullCaps);
+    expect(view.ritXit!.ritOffset.reading).toEqual({ status: 'known', value: -400 });
+    expect(view.ritXit!.xitOffset.reading).toEqual({ status: 'known', value: -400 });
+  });
+
+  const STALE_FIELDS: ReadonlyArray<readonly [rawField: 'ritOn' | 'ritTx' | 'ritFreq', viewField: 'ritActive' | 'xitActive' | 'ritOffset' | 'xitOffset']> = [
+    ['ritOn', 'ritActive'],
+    ['ritTx', 'xitActive'],
+    ['ritFreq', 'ritOffset'],
+  ];
+
+  it.each(STALE_FIELDS)(
+    'degrades a stale %s field to unknown while keeping structural availability true',
+    (rawField, viewField) => {
+      const state = bareState({
+        [rawField]: rawField === 'ritFreq' ? 500 : true,
+        fieldStatus: { ...bareState().fieldStatus, [rawField]: stale },
+      });
+      const view = model(state, fullCaps);
+      expect(view.ritXit![viewField]).toEqual({
+        reading: { status: 'unknown' }, availability: { structural: true, operational: false },
+      });
+    },
+  );
+
+  it('marks ritActive structurally absent when the rit capability is missing, never known', () => {
+    const state = bareState({ ritOn: true, fieldStatus: { ...bareState().fieldStatus, ritOn: fresh } });
+    const view = model(state, caps({ capabilities: ['xit'] }));
+    expect(view.ritXit!.ritActive).toEqual({
+      reading: { status: 'unknown' }, availability: { structural: false, operational: false },
+    });
+  });
+
+  it('degrades a malformed raw ritFreq (wrong JS type) to unknown rather than coercing', () => {
+    const state = bareState({
+      ritFreq: '250' as unknown as number,
+      fieldStatus: { ...bareState().fieldStatus, ritFreq: fresh },
+    });
+    const view = model(state, fullCaps);
+    expect(view.ritXit!.ritOffset.reading).toEqual({ status: 'unknown' });
+  });
+
+  it('emits a validator-clean model carrying the ritXit group (round-trip proof)', () => {
+    const state = bareState({
+      ritOn: true, ritFreq: 100, fieldStatus: { ...bareState().fieldStatus, ritOn: fresh, ritFreq: fresh },
+    });
+    const view = model(state, fullCaps);
+    expect(JSON.parse(JSON.stringify(view))).toEqual(view);
+  });
+});
+
+/**
+ * HONESTY GATE — absent raw values never fabricate a `{known, false}`/
+ * `{known, 0}` default, mirroring `deriveTxAux`'s own H3-lineage pins.
+ */
+describe('ritXit honesty gate — absent raw values never fabricate', () => {
+  const fullCaps = caps({ capabilities: ['rit', 'xit'] });
+
+  it('ritOffset/xitOffset with no ritFreq reported at all read unknown, not {known, 0}', () => {
+    const view = model(bareState(), fullCaps);
+    expect(view.ritXit!.ritOffset.reading).toEqual({ status: 'unknown' });
+    expect(view.ritXit!.xitOffset.reading).toEqual({ status: 'unknown' });
+  });
+
+  it('ritActive with no ritOn reported at all reads unknown, not {known, false}', () => {
+    const view = model(bareState(), fullCaps);
+    expect(view.ritXit!.ritActive.reading).toEqual({ status: 'unknown' });
+  });
+});

--- a/frontend/src/lib/runtime/adapters/__tests__/scan-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/scan-adapter.test.ts
@@ -1,0 +1,177 @@
+/**
+ * MOR-1262 decomposition slice 8A (MOR-1295) — `scan` fact-group adapter
+ * derivation.
+ *
+ * Companion to `rit-xit-adapter.test.ts`/`antenna-adapter.test.ts`, which
+ * this file does NOT modify. `scan` is a SEPARATE optional group — see
+ * `radio-view-model.ts`'s `ScanViewModel` doc comment.
+ *
+ * PARITY — the parity pin below calls the REAL `toScanProps`
+ * (`lib/runtime/props/panel-props.ts`), never a reimplementation, so the
+ * `& 0x0F` resume-mode mask is proven consumed, not re-derived.
+ *
+ * No `scan` capability tag exists anywhere in v2, so this group's evidence
+ * gate is state-only (mirrors `deriveMeters`); this file never calls the
+ * real `setCapabilities` and does not need the isolated pool (MOR-1272).
+ */
+import { describe, expect, it } from 'vitest';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { FieldStatus, ServerState } from '$lib/types/state';
+import { validateRadioViewModel, type RadioViewModel } from '../../../../semantic/radio-view-model';
+import { toRadioViewModel } from '../radio-view-model-adapter';
+import { toScanProps } from '../../props/panel-props';
+
+function caps(overrides: Partial<Capabilities> = {}): Capabilities {
+  return {
+    model: 'fixture', scope: true, audio: true, tx: true, capabilities: ['scope', 'audio', 'tx'],
+    receivers: 1, vfoScheme: 'single', freqRanges: [], modes: [], filters: [],
+    audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
+    webrtc: { available: false, enabled: false },
+    txBands: [], scopeSource: 'hardware', audioFftAvailable: false, ...overrides,
+  } as Capabilities;
+}
+
+const fresh: FieldStatus = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' };
+const stale: FieldStatus = { storePath: 'x', observed: true, freshness: 'stale', availability: 'stale' };
+
+function bareState(overrides: Partial<ServerState> = {}): ServerState {
+  return {
+    active: 'MAIN', split: false, dualWatch: false, ptt: false,
+    txTarget: { status: 'known', receiver: 'MAIN', slot: null, frequencyHz: 14195000 },
+    main: {
+      freqHz: 14195000, mode: 'USB', filter: 1, dataMode: 0, att: 0, preamp: 0,
+      nb: false, nr: false, afLevel: 1, rfGain: 1, squelch: 0, sMeter: 0,
+    },
+    sub: {
+      freqHz: 7100000, mode: 'LSB', filter: 2, dataMode: 0, att: 0, preamp: 0,
+      nb: false, nr: false, afLevel: 1, rfGain: 1, squelch: 0, sMeter: 0,
+    },
+    fieldStatus: {
+      active: fresh, split: fresh, dualWatch: fresh, txTarget: fresh,
+      'main.freqHz': fresh, 'main.mode': fresh, 'main.filter': fresh,
+    },
+    ...overrides,
+  } as ServerState;
+}
+
+function model(state: ServerState | null, capabilities: Capabilities | null): RadioViewModel {
+  const view = toRadioViewModel(state, capabilities);
+  expect(view).not.toBeNull();
+  return validateRadioViewModel(view);
+}
+
+describe('scan evidence gate (MOR-1295, N3)', () => {
+  it('emits no scan when capabilities are absent', () => {
+    expect(toRadioViewModel(bareState(), null)).toBeNull();
+  });
+
+  it('emits no scan for a baseline radio that has never reported any scan field (regression pin)', () => {
+    const view = model(bareState(), caps());
+    expect(view.scan).toBeUndefined();
+    expect(Object.keys(view)).not.toContain('scan');
+  });
+
+  it('emits scan once scanning alone has ever been reported', () => {
+    const view = model(bareState({ scanning: false }), caps());
+    expect(view.scan).toBeDefined();
+  });
+
+  it('emits scan once scanType alone has ever been reported', () => {
+    const view = model(bareState({ scanType: 0x01 }), caps());
+    expect(view.scan).toBeDefined();
+  });
+
+  it('emits scan once scanResumeMode alone has ever been reported', () => {
+    const view = model(bareState({ scanResumeMode: 0 }), caps());
+    expect(view.scan).toBeDefined();
+  });
+});
+
+describe('scan per-field structural gates (MOR-1295, mirrors deriveMeters\' "!== undefined" discipline)', () => {
+  it('scanType is structurally absent when never reported, even though scanning is present', () => {
+    const view = model(bareState({ scanning: true }), caps());
+    expect(view.scan!.scanning.availability.structural).toBe(true);
+    expect(view.scan!.scanType.availability.structural).toBe(false);
+  });
+
+  it('scanResumeMode is structurally present once it has ever been reported, independent of the others', () => {
+    const view = model(bareState({ scanResumeMode: 0xd1 }), caps());
+    expect(view.scan!.scanResumeMode.availability.structural).toBe(true);
+    expect(view.scan!.scanning.availability.structural).toBe(false);
+  });
+});
+
+describe('scan per-field derivation (MOR-1295)', () => {
+  it('reports known readings for observed, fresh fields — parity with the real toScanProps', () => {
+    const state = bareState({
+      scanning: true, scanType: 0x22, scanResumeMode: 0xd2,
+      fieldStatus: { ...bareState().fieldStatus, scanning: fresh, scanType: fresh, scanResumeMode: fresh },
+    });
+    const real = toScanProps(state);
+    const view = model(state, caps());
+    expect(view.scan!.scanning.reading).toEqual({ status: 'known', value: real.scanning });
+    expect(view.scan!.scanType.reading).toEqual({ status: 'known', value: real.scanType });
+    expect(view.scan!.scanResumeMode.reading).toEqual({ status: 'known', value: real.scanResumeMode });
+  });
+
+  it('applies the shipped 0x0F resume-mode mask verbatim — parity with the real toScanProps', () => {
+    // 0xD2 (10s resume) carries bits outside the low nibble; the mask must
+    // survive through this contract exactly as `toScanProps` applies it.
+    const state = bareState({
+      scanResumeMode: 0xd2, fieldStatus: { ...bareState().fieldStatus, scanResumeMode: fresh },
+    });
+    const real = toScanProps(state);
+    const view = model(state, caps());
+    expect(real.scanResumeMode).toBe(0x02);
+    expect(view.scan!.scanResumeMode.reading).toEqual({ status: 'known', value: 0x02 });
+  });
+
+  const STALE_FIELDS: ReadonlyArray<readonly [rawField: 'scanning' | 'scanType' | 'scanResumeMode', value: boolean | number]> = [
+    ['scanning', true],
+    ['scanType', 0x01],
+    ['scanResumeMode', 0xd0],
+  ];
+
+  it.each(STALE_FIELDS)(
+    'degrades a stale %s field to unknown while keeping structural availability true',
+    (rawField, value) => {
+      const state = bareState({
+        [rawField]: value, fieldStatus: { ...bareState().fieldStatus, [rawField]: stale },
+      });
+      const view = model(state, caps());
+      expect(view.scan![rawField]).toEqual({
+        reading: { status: 'unknown' }, availability: { structural: true, operational: false },
+      });
+    },
+  );
+
+  it('degrades a malformed raw scanType (wrong JS type) to unknown rather than coercing', () => {
+    const state = bareState({
+      scanType: 'PROG' as unknown as number,
+      fieldStatus: { ...bareState().fieldStatus, scanType: fresh },
+    });
+    const view = model(state, caps());
+    expect(view.scan!.scanType.reading).toEqual({ status: 'unknown' });
+  });
+
+  it('emits a validator-clean model carrying the scan group (round-trip proof)', () => {
+    const state = bareState({
+      scanning: true, scanType: 0x01, fieldStatus: { ...bareState().fieldStatus, scanning: fresh, scanType: fresh },
+    });
+    const view = model(state, caps());
+    expect(JSON.parse(JSON.stringify(view))).toEqual(view);
+  });
+});
+
+/** HONESTY GATE — absent raw values never fabricate. */
+describe('scan honesty gate — absent raw values never fabricate', () => {
+  it('scanning read via the group triggered by scanType alone still reads unknown, not {known, false}', () => {
+    const view = model(bareState({ scanType: 0x01 }), caps());
+    expect(view.scan!.scanning.reading).toEqual({ status: 'unknown' });
+  });
+
+  it('scanResumeMode read via the group triggered by scanning alone still reads unknown, not {known, 0}', () => {
+    const view = model(bareState({ scanning: false }), caps());
+    expect(view.scan!.scanResumeMode.reading).toEqual({ status: 'unknown' });
+  });
+});

--- a/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
@@ -30,7 +30,7 @@ import type {
   MeterField, MeterRfState, MetersViewModel,
   AudioFocus, MonitorMode, RxAudioViewModel, ModeFilterViewModel,
   FilterPassbandViewModel, DspViewModel, RfFrontEndViewModel,
-  BandChoice, BandViewModel,
+  BandChoice, BandViewModel, RitXitViewModel, AntennaViewModel, ScanViewModel,
 } from '../../../semantic/radio-view-model';
 import type { TxAuthoritySnapshot } from '../../../semantic/rx-tx-surface';
 import { isFieldAvailable } from '$lib/state/field-status';
@@ -729,6 +729,92 @@ function deriveBand(
 }
 
 /**
+ * RIT/XIT facts (MOR-1262 decomposition slice 8A, MOR-1295): the RIT/XIT
+ * enables and their shared frequency offset. A separate group from `txAux`
+ * — RIT/XIT is not a TX-adjacent control (it offsets the RX/TX pair without
+ * transmitting), and family enumeration stays explicit and closed.
+ *
+ * Evidence gate (N3), purely caps-driven: `hasCap(caps, 'rit'|'xit')` — the
+ * shipped `RitXitPanel`'s own `shouldShowPanel(hasRit, hasXit)` gate,
+ * verbatim, no raw-field fallback (same shape as `deriveBand`'s
+ * `freqRanges`-only gate).
+ *
+ * `ritOffset`/`xitOffset` deliberately read the SAME raw field
+ * (`state.ritFreq`) and the SAME freshness signal — see `RitXitViewModel`'s
+ * doc comment for why duplicating, not deriving one from the other, is the
+ * parity-correct shape.
+ */
+function deriveRitXit(state: ServerState | null, caps: Capabilities | null): RitXitViewModel | undefined {
+  const hasRitCap = hasCap(caps, 'rit');
+  const hasXitCap = hasCap(caps, 'xit');
+  if (!hasRitCap && !hasXitCap) return undefined;
+  const offsetObserved = topFieldAvailable(state, 'ritFreq');
+  const offsetRaw = numOrUndef(state?.ritFreq);
+  return {
+    ritActive: txAuxField(hasRitCap, topFieldAvailable(state, 'ritOn'), boolOrUndef(state?.ritOn)),
+    ritOffset: txAuxField(hasRitCap, offsetObserved, offsetRaw),
+    xitActive: txAuxField(hasXitCap, topFieldAvailable(state, 'ritTx'), boolOrUndef(state?.ritTx)),
+    xitOffset: txAuxField(hasXitCap, offsetObserved, offsetRaw),
+  };
+}
+
+/**
+ * Antenna facts (MOR-1262 decomposition slice 8A, MOR-1295): selected TX
+ * antenna port, the port-dependent RX-antenna override, and the declared
+ * port count. See `AntennaViewModel`'s doc comment for why ATU/tuner state
+ * is deliberately absent (family 1, `txAux.atu`) and why `antennaCount` is
+ * this group's whole evidence gate.
+ *
+ * `rxAnt` selects `rxAntenna1`/`rxAntenna2` by the RAW `txAntenna` reading —
+ * `toAntennaProps`'s own `txAntenna === 2 ? rxAntenna2 : rxAntenna1` — and,
+ * per the "never derive from a half-observed pair" lesson (4A′/5A), is
+ * operational only when `txAntenna` ITSELF was honestly observed; an
+ * unobserved port never silently resolves to port 1's reading.
+ */
+function deriveAntenna(state: ServerState | null, caps: Capabilities | null): AntennaViewModel | undefined {
+  const antennaCount = caps?.antennas ?? 0;
+  if (antennaCount <= 1) return undefined;
+  const hasRxAntennaCap = hasCap(caps, 'rx_antenna');
+  const txAntennaObserved = topFieldAvailable(state, 'txAntenna');
+  const txAntennaRaw = numOrUndef(state?.txAntenna);
+  const rxAntennaRaw = txAntennaRaw === 2 ? state?.rxAntenna2 : state?.rxAntenna1;
+  const rxAntennaObserved = txAntennaObserved && txAntennaRaw !== undefined
+    && topFieldAvailable(state, txAntennaRaw === 2 ? 'rxAntenna2' : 'rxAntenna1');
+  return {
+    txAntenna: txAuxField(true, txAntennaObserved, txAntennaRaw),
+    rxAnt: txAuxField(hasRxAntennaCap, rxAntennaObserved, boolOrUndef(rxAntennaRaw)),
+    antennaCount,
+  };
+}
+
+/**
+ * Scan facts (MOR-1262 decomposition slice 8A, MOR-1295): scanning, scan
+ * type, and the masked resume mode. No capability tag exists for `scan`
+ * anywhere in v2 (the shipped `ScanPanel` renders unconditionally), so —
+ * like `deriveMeters` — evidence is per-field "was this ever reported",
+ * not a capability check; see `ScanViewModel`'s doc comment.
+ */
+function deriveScan(state: ServerState | null): ScanViewModel | undefined {
+  const raw = [state?.scanning, state?.scanType, state?.scanResumeMode];
+  if (!raw.some((v) => v !== undefined)) return undefined;
+  const resumeRaw = numOrUndef(state?.scanResumeMode);
+  return {
+    scanning: txAuxField(
+      state?.scanning !== undefined, topFieldAvailable(state, 'scanning'), boolOrUndef(state?.scanning),
+    ),
+    scanType: txAuxField(
+      state?.scanType !== undefined, topFieldAvailable(state, 'scanType'), numOrUndef(state?.scanType),
+    ),
+    // The shipped `& 0x0F` mask (`toScanProps`), applied verbatim — the raw
+    // field carries a direction bit this contract does not interpret.
+    scanResumeMode: txAuxField(
+      state?.scanResumeMode !== undefined, topFieldAvailable(state, 'scanResumeMode'),
+      resumeRaw !== undefined ? (resumeRaw & 0x0f) : undefined,
+    ),
+  };
+}
+
+/**
  * The App-owned RX-audio snapshot the `rxAudio` facts are read against
  * (MOR-1262 slice 3A). It is an INPUT, deliberately: audio lifetime belongs to
  * the App (MOR-1058) and building a view model must never open, start or probe
@@ -962,6 +1048,9 @@ export function toRadioViewModel(
   const dsp = deriveDsp(state, caps);
   const rfFrontEnd = deriveRfFrontEnd(state, caps);
   const band = deriveBand(state, caps);
+  const ritXit = deriveRitXit(state, caps);
+  const antenna = deriveAntenna(state, caps);
+  const scan = deriveScan(state);
   const rfFrontEndMutex = deriveRfFrontEndMutex(rfFrontEnd);
   if (rfFrontEndMutex) disabledReasons.push(rfFrontEndMutex);
 
@@ -984,5 +1073,8 @@ export function toRadioViewModel(
     ...(dsp !== undefined ? { dsp } : {}),
     ...(rfFrontEnd !== undefined ? { rfFrontEnd } : {}),
     ...(band !== undefined ? { band } : {}),
+    ...(ritXit !== undefined ? { ritXit } : {}),
+    ...(antenna !== undefined ? { antenna } : {}),
+    ...(scan !== undefined ? { scan } : {}),
   };
 }

--- a/frontend/src/semantic/__tests__/antenna.test.ts
+++ b/frontend/src/semantic/__tests__/antenna.test.ts
@@ -1,0 +1,122 @@
+/**
+ * MOR-1262 decomposition slice 8A (MOR-1295) — `antenna` optional fact group
+ * (validator half).
+ *
+ * Facts only: selected TX antenna port, the port-dependent RX-antenna
+ * override, and the declared port count. ATU/tuner state is DELIBERATELY
+ * absent (family 1's `txAux.atu`, MOR-1244) — see `radio-view-model.ts`'s
+ * `AntennaViewModel` doc comment. `radio-view-model-adapter.ts`'s
+ * `deriveAntenna` covers the live derivation (companion
+ * `antenna-adapter.test.ts`).
+ *
+ * Mirrors the companion families' kill-tests:
+ *  1. an antenna-absent model validates and round-trips byte-identically
+ *  2. `"antenna": null` / `{}` throw (absent ≠ malformed)
+ *  3. a malformed inner field throws with a precise `$.antenna....` path
+ *  5. an unknown extra key inside antenna (or a field) throws
+ * (Kill-test 4, the adapter's evidence gate, lives in the adapter test file.)
+ */
+import { describe, expect, it } from 'vitest';
+import { validateRadioViewModel, type AntennaField, type AntennaViewModel } from '../radio-view-model';
+import { topologyFixtures, withAntenna } from '../fixtures/topologies';
+
+const AVAIL = { structural: true, operational: true } as const;
+const base = topologyFixtures['1/single'];
+
+describe('antenna (MOR-1262 slice 8A)', () => {
+  it('validates an antenna-absent model and never adds the key', () => {
+    expect(Object.keys(base)).not.toContain('antenna');
+    const validated = validateRadioViewModel(base);
+    expect(Object.keys(validated)).not.toContain('antenna');
+    expect(validated.antenna).toBeUndefined();
+    expect(JSON.parse(JSON.stringify(validated))).toEqual(JSON.parse(JSON.stringify(base)));
+  });
+
+  it('validates a fully-populated antenna group and returns it unchanged', () => {
+    const withA = withAntenna(base);
+    expect(validateRadioViewModel(withA).antenna).toEqual(withA.antenna);
+  });
+
+  it('rejects an explicit antenna: null', () => {
+    expect(() => validateRadioViewModel({ ...base, antenna: null })).toThrow(TypeError);
+  });
+
+  it('rejects an explicit antenna: {} — present, not absent, must satisfy its own shape', () => {
+    expect(() => validateRadioViewModel({ ...base, antenna: {} })).toThrow(TypeError);
+  });
+
+  it('rejects a non-numeric txAntenna reading value with a precise error path', () => {
+    const withA = withAntenna(base);
+    const malformed = {
+      ...withA,
+      antenna: { ...withA.antenna, txAntenna: { reading: { status: 'known', value: 'ANT1' }, availability: AVAIL } },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.antenna\.txAntenna\.reading\.value/);
+  });
+
+  it('rejects a non-boolean rxAnt reading value with a precise error path', () => {
+    const withA = withAntenna(base);
+    const malformed = {
+      ...withA,
+      antenna: { ...withA.antenna, rxAnt: { reading: { status: 'known', value: 1 }, availability: AVAIL } },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.antenna\.rxAnt\.reading\.value/);
+  });
+
+  it('rejects a non-numeric antennaCount', () => {
+    const withA = withAntenna(base);
+    expect(() => validateRadioViewModel({ ...withA, antenna: { ...withA.antenna, antennaCount: '2' } }))
+      .toThrow(/\$\.antenna\.antennaCount/);
+  });
+
+  it('accepts an unknown rxAnt reading independent of a known txAntenna reading', () => {
+    const withA = withAntenna(base);
+    const partial = {
+      ...withA,
+      antenna: { ...withA.antenna, rxAnt: { reading: { status: 'unknown' }, availability: { structural: false, operational: false } } },
+    };
+    const validated = validateRadioViewModel(partial);
+    expect(validated.antenna?.rxAnt).toEqual({
+      reading: { status: 'unknown' }, availability: { structural: false, operational: false },
+    });
+    expect(validated.antenna?.txAntenna.reading).toEqual({ status: 'known', value: 1 });
+  });
+
+  it('rejects an unknown extra key inside antenna', () => {
+    const withA = withAntenna(base);
+    expect(() => validateRadioViewModel({ ...base, antenna: { ...withA.antenna, bogus: 1 } })).toThrow(TypeError);
+  });
+
+  it('rejects an unknown extra key inside a single antenna field', () => {
+    const withA = withAntenna(base);
+    const malformed = {
+      ...withA,
+      antenna: { ...withA.antenna, txAntenna: { reading: { status: 'known', value: 1 }, availability: AVAIL, extra: true } },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(TypeError);
+  });
+
+  it('rejects a reading that carries a value key while unknown', () => {
+    const withA = withAntenna(base);
+    const malformed = {
+      ...withA,
+      antenna: { ...withA.antenna, rxAnt: { reading: { status: 'unknown', value: false }, availability: AVAIL } },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(TypeError);
+  });
+
+  it('rejects an antenna group missing a key (no partial 8A shape survives)', () => {
+    const withA = withAntenna(base);
+    const { antennaCount: _antennaCount, ...withoutCount } = withA.antenna as AntennaViewModel;
+    expect(() => validateRadioViewModel({ ...withA, antenna: withoutCount })).toThrow(TypeError);
+  });
+
+  it('every field of a fully-populated group round-trips its own value', () => {
+    const validated = validateRadioViewModel(withAntenna(base)).antenna as AntennaViewModel;
+    const knownValue = <T>(f: AntennaField<T>): T | undefined =>
+      f.reading.status === 'known' ? f.reading.value : undefined;
+    expect(knownValue(validated.txAntenna)).toBe(1);
+    expect(knownValue(validated.rxAnt)).toBe(false);
+    expect(validated.antennaCount).toBe(2);
+  });
+});

--- a/frontend/src/semantic/__tests__/optional-group-allow-list.test.ts
+++ b/frontend/src/semantic/__tests__/optional-group-allow-list.test.ts
@@ -42,9 +42,11 @@ const REQUIRED_KEYS = [
 
 /** MOR-1244: txAux. MOR-1262 slice 2A: meters. Slice 3A: rxAudio. Slice 4A:
  *  modeFilter. Slice 4A′: filterPassband. Slice 5A: dsp. Slice 6A: rfFrontEnd.
- *  Slice 7A: band. Add your key here when your family's slice lands. */
+ *  Slice 7A: band. Slice 8A: ritXit, antenna, scan. Add your key here when
+ *  your family's slice lands. */
 const EXPECTED_OPTIONAL_GROUP_KEYS = [
   'txAux', 'meters', 'rxAudio', 'modeFilter', 'filterPassband', 'dsp', 'rfFrontEnd', 'band',
+  'ritXit', 'antenna', 'scan',
 ] as const;
 
 function extractTopLevelAllowList(): string[] {

--- a/frontend/src/semantic/__tests__/rit-xit.test.ts
+++ b/frontend/src/semantic/__tests__/rit-xit.test.ts
@@ -1,0 +1,129 @@
+/**
+ * MOR-1262 decomposition slice 8A (MOR-1295) — `ritXit` optional fact group
+ * (validator half).
+ *
+ * Facts only: RIT/XIT enables and their shared frequency offset. A separate
+ * group from `txAux` — RIT/XIT is not TX-adjacent (it offsets RX/TX without
+ * keying), and family enumeration is explicit and CLOSED. See
+ * `radio-view-model.ts`'s `RitXitViewModel` doc comment for the group-shape
+ * rationale, and `radio-view-model-adapter.ts`'s `deriveRitXit` for the live
+ * derivation (covered by the companion `rit-xit-adapter.test.ts`).
+ *
+ * Mirrors the companion families' (`rf-front-end.test.ts`, `dsp.test.ts`)
+ * kill-tests for this family:
+ *  1. a ritXit-absent model validates and round-trips byte-identically
+ *  2. `"ritXit": null` / `{}` throw (absent ≠ malformed)
+ *  3. a malformed inner field throws with a precise `$.ritXit....` path
+ *  5. an unknown extra key inside ritXit (or a field) throws
+ * (Kill-test 4, the adapter's evidence gate, lives in the adapter test file.)
+ */
+import { describe, expect, it } from 'vitest';
+import { validateRadioViewModel, type RitXitField, type RitXitViewModel } from '../radio-view-model';
+import { topologyFixtures, withRitXit } from '../fixtures/topologies';
+
+const AVAIL = { structural: true, operational: true } as const;
+const base = topologyFixtures['1/single'];
+
+describe('ritXit (MOR-1262 slice 8A)', () => {
+  it('validates a ritXit-absent model and never adds the key', () => {
+    expect(Object.keys(base)).not.toContain('ritXit');
+    const validated = validateRadioViewModel(base);
+    expect(Object.keys(validated)).not.toContain('ritXit');
+    expect(validated.ritXit).toBeUndefined();
+    expect(JSON.parse(JSON.stringify(validated))).toEqual(JSON.parse(JSON.stringify(base)));
+  });
+
+  it('validates a fully-populated ritXit group and returns it unchanged', () => {
+    const withR = withRitXit(base);
+    expect(validateRadioViewModel(withR).ritXit).toEqual(withR.ritXit);
+  });
+
+  it('rejects an explicit ritXit: null', () => {
+    expect(() => validateRadioViewModel({ ...base, ritXit: null })).toThrow(TypeError);
+  });
+
+  it('rejects an explicit ritXit: {} — present, not absent, must satisfy its own shape', () => {
+    expect(() => validateRadioViewModel({ ...base, ritXit: {} })).toThrow(TypeError);
+  });
+
+  it('rejects a non-numeric ritOffset reading value with a precise error path', () => {
+    const withR = withRitXit(base);
+    const malformed = {
+      ...withR,
+      ritXit: { ...withR.ritXit, ritOffset: { reading: { status: 'known', value: '250' }, availability: AVAIL } },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.ritXit\.ritOffset\.reading\.value/);
+  });
+
+  it('rejects a non-boolean xitActive reading value with a precise error path', () => {
+    const withR = withRitXit(base);
+    const malformed = {
+      ...withR,
+      ritXit: { ...withR.ritXit, xitActive: { reading: { status: 'known', value: 1 }, availability: AVAIL } },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.ritXit\.xitActive\.reading\.value/);
+  });
+
+  it('accepts an unknown reading distinct from a known one, independently per field', () => {
+    const withR = withRitXit(base);
+    const partial = {
+      ...withR,
+      ritXit: { ...withR.ritXit, xitActive: { reading: { status: 'unknown' }, availability: { structural: false, operational: false } } },
+    };
+    const validated = validateRadioViewModel(partial);
+    expect(validated.ritXit?.xitActive).toEqual({
+      reading: { status: 'unknown' }, availability: { structural: false, operational: false },
+    });
+    expect(validated.ritXit?.ritActive.reading).toEqual({ status: 'known', value: true });
+  });
+
+  it('accepts ritOffset and xitOffset carrying independently-different values', () => {
+    const withR = withRitXit(base);
+    const model = {
+      ...withR,
+      ritXit: { ...withR.ritXit, xitOffset: { reading: { status: 'known', value: -300 }, availability: AVAIL } },
+    };
+    const validated = validateRadioViewModel(model);
+    expect(validated.ritXit?.ritOffset.reading).toEqual({ status: 'known', value: 250 });
+    expect(validated.ritXit?.xitOffset.reading).toEqual({ status: 'known', value: -300 });
+  });
+
+  it('rejects an unknown extra key inside ritXit', () => {
+    const withR = withRitXit(base);
+    expect(() => validateRadioViewModel({ ...base, ritXit: { ...withR.ritXit, bogus: 1 } })).toThrow(TypeError);
+  });
+
+  it('rejects an unknown extra key inside a single ritXit field', () => {
+    const withR = withRitXit(base);
+    const malformed = {
+      ...withR,
+      ritXit: { ...withR.ritXit, ritActive: { reading: { status: 'known', value: true }, availability: AVAIL, extra: true } },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(TypeError);
+  });
+
+  it('rejects a reading that carries a value key while unknown', () => {
+    const withR = withRitXit(base);
+    const malformed = {
+      ...withR,
+      ritXit: { ...withR.ritXit, ritActive: { reading: { status: 'unknown', value: true }, availability: AVAIL } },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(TypeError);
+  });
+
+  it('rejects a ritXit group missing a key (no partial 8A shape survives)', () => {
+    const withR = withRitXit(base);
+    const { xitOffset: _xitOffset, ...withoutXitOffset } = withR.ritXit as RitXitViewModel;
+    expect(() => validateRadioViewModel({ ...withR, ritXit: withoutXitOffset })).toThrow(TypeError);
+  });
+
+  it('every field of a fully-populated group round-trips its own value', () => {
+    const validated = validateRadioViewModel(withRitXit(base)).ritXit as RitXitViewModel;
+    const knownValue = <T>(f: RitXitField<T>): T | undefined =>
+      f.reading.status === 'known' ? f.reading.value : undefined;
+    expect(knownValue(validated.ritActive)).toBe(true);
+    expect(knownValue(validated.ritOffset)).toBe(250);
+    expect(knownValue(validated.xitActive)).toBe(false);
+    expect(knownValue(validated.xitOffset)).toBe(250);
+  });
+});

--- a/frontend/src/semantic/__tests__/scan.test.ts
+++ b/frontend/src/semantic/__tests__/scan.test.ts
@@ -1,0 +1,115 @@
+/**
+ * MOR-1262 decomposition slice 8A (MOR-1295) — `scan` optional fact group
+ * (validator half).
+ *
+ * Facts only: scanning, scan type, and the masked resume mode. No
+ * `scan` capability tag exists anywhere in v2 — see `radio-view-model.ts`'s
+ * `ScanViewModel` doc comment, and `radio-view-model-adapter.ts`'s
+ * `deriveScan` for the per-field "was this ever reported" evidence gate
+ * (companion `scan-adapter.test.ts`).
+ *
+ * Mirrors the companion families' kill-tests:
+ *  1. a scan-absent model validates and round-trips byte-identically
+ *  2. `"scan": null` / `{}` throw (absent ≠ malformed)
+ *  3. a malformed inner field throws with a precise `$.scan....` path
+ *  5. an unknown extra key inside scan (or a field) throws
+ * (Kill-test 4, the adapter's evidence gate, lives in the adapter test file.)
+ */
+import { describe, expect, it } from 'vitest';
+import { validateRadioViewModel, type ScanField, type ScanViewModel } from '../radio-view-model';
+import { topologyFixtures, withScan } from '../fixtures/topologies';
+
+const AVAIL = { structural: true, operational: true } as const;
+const base = topologyFixtures['1/single'];
+
+describe('scan (MOR-1262 slice 8A)', () => {
+  it('validates a scan-absent model and never adds the key', () => {
+    expect(Object.keys(base)).not.toContain('scan');
+    const validated = validateRadioViewModel(base);
+    expect(Object.keys(validated)).not.toContain('scan');
+    expect(validated.scan).toBeUndefined();
+    expect(JSON.parse(JSON.stringify(validated))).toEqual(JSON.parse(JSON.stringify(base)));
+  });
+
+  it('validates a fully-populated scan group and returns it unchanged', () => {
+    const withS = withScan(base);
+    expect(validateRadioViewModel(withS).scan).toEqual(withS.scan);
+  });
+
+  it('rejects an explicit scan: null', () => {
+    expect(() => validateRadioViewModel({ ...base, scan: null })).toThrow(TypeError);
+  });
+
+  it('rejects an explicit scan: {} — present, not absent, must satisfy its own shape', () => {
+    expect(() => validateRadioViewModel({ ...base, scan: {} })).toThrow(TypeError);
+  });
+
+  it('rejects a non-boolean scanning reading value with a precise error path', () => {
+    const withS = withScan(base);
+    const malformed = {
+      ...withS,
+      scan: { ...withS.scan, scanning: { reading: { status: 'known', value: 1 }, availability: AVAIL } },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.scan\.scanning\.reading\.value/);
+  });
+
+  it('rejects a non-numeric scanType reading value with a precise error path', () => {
+    const withS = withScan(base);
+    const malformed = {
+      ...withS,
+      scan: { ...withS.scan, scanType: { reading: { status: 'known', value: 'PROG' }, availability: AVAIL } },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.scan\.scanType\.reading\.value/);
+  });
+
+  it('accepts an unknown scanResumeMode reading independent of a known scanning reading', () => {
+    const withS = withScan(base);
+    const partial = {
+      ...withS,
+      scan: { ...withS.scan, scanResumeMode: { reading: { status: 'unknown' }, availability: { structural: false, operational: false } } },
+    };
+    const validated = validateRadioViewModel(partial);
+    expect(validated.scan?.scanResumeMode).toEqual({
+      reading: { status: 'unknown' }, availability: { structural: false, operational: false },
+    });
+    expect(validated.scan?.scanning.reading).toEqual({ status: 'known', value: false });
+  });
+
+  it('rejects an unknown extra key inside scan', () => {
+    const withS = withScan(base);
+    expect(() => validateRadioViewModel({ ...base, scan: { ...withS.scan, bogus: 1 } })).toThrow(TypeError);
+  });
+
+  it('rejects an unknown extra key inside a single scan field', () => {
+    const withS = withScan(base);
+    const malformed = {
+      ...withS,
+      scan: { ...withS.scan, scanType: { reading: { status: 'known', value: 1 }, availability: AVAIL, extra: true } },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(TypeError);
+  });
+
+  it('rejects a reading that carries a value key while unknown', () => {
+    const withS = withScan(base);
+    const malformed = {
+      ...withS,
+      scan: { ...withS.scan, scanning: { reading: { status: 'unknown', value: true }, availability: AVAIL } },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(TypeError);
+  });
+
+  it('rejects a scan group missing a key (no partial 8A shape survives)', () => {
+    const withS = withScan(base);
+    const { scanResumeMode: _scanResumeMode, ...withoutResume } = withS.scan as ScanViewModel;
+    expect(() => validateRadioViewModel({ ...withS, scan: withoutResume })).toThrow(TypeError);
+  });
+
+  it('every field of a fully-populated group round-trips its own value', () => {
+    const validated = validateRadioViewModel(withScan(base)).scan as ScanViewModel;
+    const knownValue = <T>(f: ScanField<T>): T | undefined =>
+      f.reading.status === 'known' ? f.reading.value : undefined;
+    expect(knownValue(validated.scanning)).toBe(false);
+    expect(knownValue(validated.scanType)).toBe(0x01);
+    expect(knownValue(validated.scanResumeMode)).toBe(0);
+  });
+});

--- a/frontend/src/semantic/fixtures/topologies.ts
+++ b/frontend/src/semantic/fixtures/topologies.ts
@@ -14,11 +14,14 @@
  * topology, so it can be applied to any of the four fixtures below.
  */
 import type {
+  AntennaField, AntennaViewModel,
   Availability, BandField, BandViewModel,
   DspField, DspViewModel, FilterPassbandField, FilterPassbandViewModel,
   MeterField, MeterRfState, MetersViewModel,
   ModeFilterField, ModeFilterViewModel,
-  ModInputReadiness, RadioViewModel, RfFrontEndField, RfFrontEndViewModel, RxAudioField, RxAudioViewModel,
+  ModInputReadiness, RadioViewModel, RfFrontEndField, RfFrontEndViewModel,
+  RitXitField, RitXitViewModel, RxAudioField, RxAudioViewModel,
+  ScanField, ScanViewModel,
   TxAuxField, TxAuxViewModel,
 } from '../radio-view-model';
 
@@ -377,4 +380,53 @@ export function withBand(
     tuneMaxHz: 60000000,
   };
   return { ...fixture, band };
+}
+
+/**
+ * Applies a fully-observed `ritXit` group (MOR-1262 slice 8A, MOR-1295) to
+ * any topology fixture — same composable-axis story as `withBand`/
+ * `withRfFrontEnd` above.
+ */
+export function withRitXit(fixture: RadioViewModel): RadioViewModel {
+  const avail: Availability = { structural: true, operational: true };
+  const known = <T>(value: T): RitXitField<T> => ({ reading: { status: 'known', value }, availability: avail });
+  const ritXit: RitXitViewModel = {
+    ritActive: known(true),
+    ritOffset: known(250),
+    xitActive: known(false),
+    xitOffset: known(250),
+  };
+  return { ...fixture, ritXit };
+}
+
+/**
+ * Applies a fully-observed `antenna` group (MOR-1262 slice 8A, MOR-1295) to
+ * any topology fixture — same composable-axis story as `withBand`/
+ * `withRfFrontEnd` above.
+ */
+export function withAntenna(fixture: RadioViewModel): RadioViewModel {
+  const avail: Availability = { structural: true, operational: true };
+  const known = <T>(value: T): AntennaField<T> => ({ reading: { status: 'known', value }, availability: avail });
+  const antenna: AntennaViewModel = {
+    txAntenna: known(1),
+    rxAnt: known(false),
+    antennaCount: 2,
+  };
+  return { ...fixture, antenna };
+}
+
+/**
+ * Applies a fully-observed `scan` group (MOR-1262 slice 8A, MOR-1295) to any
+ * topology fixture — same composable-axis story as `withBand`/
+ * `withRfFrontEnd` above.
+ */
+export function withScan(fixture: RadioViewModel): RadioViewModel {
+  const avail: Availability = { structural: true, operational: true };
+  const known = <T>(value: T): ScanField<T> => ({ reading: { status: 'known', value }, availability: avail });
+  const scan: ScanViewModel = {
+    scanning: known(false),
+    scanType: known(0x01),
+    scanResumeMode: known(0),
+  };
+  return { ...fixture, scan };
 }

--- a/frontend/src/semantic/radio-view-model.ts
+++ b/frontend/src/semantic/radio-view-model.ts
@@ -544,6 +544,107 @@ export interface BandViewModel {
   tuneMaxHz: number | null;
 }
 
+/**
+ * A single RIT/XIT fact (MOR-1262 decomposition slice 8A, MOR-1295).
+ * Shape-identical to `TxAuxField`, declared as an alias for the same reason
+ * `BandField`/`RfFrontEndField`/`DspField`/`ModeFilterField`/`RxAudioField`
+ * are: one field shape per fact family.
+ */
+export type RitXitField<T> = TxAuxField<T>;
+
+/**
+ * RIT/XIT facts (MOR-1262 decomposition slice 8A, MOR-1295): the RIT/XIT
+ * enables and their frequency offset. Facts only — no command emission;
+ * toggling RIT/XIT or dragging the offset stays with a future surface slice.
+ *
+ * `ritOffset`/`xitOffset` are DELIBERATELY two separate fields reading the
+ * SAME underlying register (`ServerStatePublic.ritFreq` — one CI-V RIT/XIT
+ * offset, shared), verbatim the shipped `toRitXitProps`
+ * (`lib/runtime/props/panel-props.ts`): `ritOffset: state?.ritFreq`,
+ * `xitOffset: state?.ritFreq`. This is not a duplicate-in-error; it is
+ * parity with the one existing derivation, which the shipped `RitXitPanel`
+ * itself resolves by displaying whichever is currently active
+ * (`xitActive && !ritActive ? xitOffset : ritOffset`). A future surface
+ * consuming this group makes that same choice from two honestly-identical
+ * readings, not from a field this contract already collapsed for it.
+ */
+export interface RitXitViewModel {
+  ritActive: RitXitField<boolean>;
+  ritOffset: RitXitField<number>;
+  xitActive: RitXitField<boolean>;
+  xitOffset: RitXitField<number>;
+}
+
+/**
+ * A single antenna fact (MOR-1262 decomposition slice 8A, MOR-1295).
+ * Shape-identical to `TxAuxField`, declared as an alias for the same reason
+ * `RitXitField`/`BandField`/`RfFrontEndField`/`DspField` are.
+ */
+export type AntennaField<T> = TxAuxField<T>;
+
+/**
+ * Antenna facts (MOR-1262 decomposition slice 8A, MOR-1295): the selected TX
+ * antenna port, whether the (port-dependent) RX-antenna override is active,
+ * and the capability-declared port count. ATU/tuner state is DELIBERATELY
+ * absent here — it is family 1's `txAux.atu` (MOR-1244) already, and family
+ * enumeration is explicit and CLOSED (same discipline `dsp`/`rfFrontEnd` use
+ * for their own neighbors) — this group never duplicates it.
+ *
+ * `antennaCount` is a plain number, not an `AntennaField`-wrapped reading,
+ * for the same reason `RfFrontEndViewModel.preValues` isn't: a port count is
+ * a structural fact about the radio MODEL (from `caps.antennas`), not a live
+ * reading that can itself go stale — see `radio-view-model-adapter.ts`'s
+ * `deriveAntenna` for why it is also this group's WHOLE evidence gate (the
+ * shipped `AntennaPanel`/`MobileRadioLayout` show nothing at all when
+ * `antennaCount <= 1`, and RX-ANT only nested inside that same condition —
+ * one v2 gate, not two).
+ *
+ * `rxAnt` reads the RX-antenna override for whichever port `txAntenna`
+ * currently names (`ServerStatePublic.rxAntenna1`/`.rxAntenna2`) — the
+ * shipped `toAntennaProps`'s own `txAntenna === 2 ? rxAntenna2 : rxAntenna1`
+ * selection. Per the 4A′/5A "never derive from a half-observed pair" lesson,
+ * it degrades to `unknown` whenever `txAntenna` itself is unobserved — an
+ * honest reading of a port this contract cannot honestly name is not
+ * possible, and silently falling back to port 1 is exactly the fabrication
+ * this contract exists to forbid.
+ */
+export interface AntennaViewModel {
+  txAntenna: AntennaField<number>;
+  rxAnt: AntennaField<boolean>;
+  antennaCount: number;
+}
+
+/**
+ * A single scan fact (MOR-1262 decomposition slice 8A, MOR-1295).
+ * Shape-identical to `TxAuxField`, declared as an alias for the same reason
+ * `AntennaField`/`RitXitField`/`BandField`/`RfFrontEndField` are.
+ */
+export type ScanField<T> = TxAuxField<T>;
+
+/**
+ * Scan facts (MOR-1262 decomposition slice 8A, MOR-1295): whether a scan is
+ * running, its type, and its resume mode. Facts only — the shipped scan-type
+ * / ΔF-span / resume-mode LABEL tables (`ScanPanel.svelte`'s `scanTypes`/
+ * `dfSpans`/`resumeModes` constants) are UI convenience, not radio facts, and
+ * are deliberately absent (X6200 lesson: no UI-only tables in the fact
+ * layer).
+ *
+ * There is no `scan` capability tag anywhere in v2 — the shipped `ScanPanel`
+ * renders unconditionally — so, like `MetersViewModel`, evidence is
+ * per-field "was this ever reported" (`radio-view-model-adapter.ts`'s
+ * `deriveScan`), not a capability check.
+ *
+ * `scanResumeMode` carries the shipped `& 0x0F` mask applied verbatim
+ * (`toScanProps`'s own `(state?.scanResumeMode ?? 0) & 0x0f`) — the raw field
+ * carries a direction bit this contract does not interpret, so the mask is
+ * consumed, not re-derived.
+ */
+export interface ScanViewModel {
+  scanning: ScanField<boolean>;
+  scanType: ScanField<number>;
+  scanResumeMode: ScanField<number>;
+}
+
 export interface RadioViewModel {
   topologyId: string;
   vfoScheme: VfoScheme;
@@ -590,6 +691,18 @@ export interface RadioViewModel {
    *  range at all, so there is no band plan and no tuning envelope to state
    *  — see `radio-view-model-adapter.ts`'s `deriveBand`. */
   readonly band?: BandViewModel;
+  /** Absent (MOR-1264 optional group) ⇒ this radio declares neither `rit`
+   *  nor `xit` capability — see `radio-view-model-adapter.ts`'s
+   *  `deriveRitXit`. */
+  readonly ritXit?: RitXitViewModel;
+  /** Absent (MOR-1264 optional group) ⇒ this radio declares one antenna
+   *  port or fewer, so there is no port to select — see
+   *  `radio-view-model-adapter.ts`'s `deriveAntenna`. */
+  readonly antenna?: AntennaViewModel;
+  /** Absent (MOR-1264 optional group) ⇒ this radio has never reported
+   *  scanning/scanType/scanResumeMode — see `radio-view-model-adapter.ts`'s
+   *  `deriveScan`. */
+  readonly scan?: ScanViewModel;
 }
 
 const RECEIVER_IDS: readonly ReceiverId[] = ['MAIN', 'SUB'];
@@ -1037,6 +1150,43 @@ function validateBand(value: unknown, path: string): BandViewModel {
   };
 }
 
+/** Exactly the four facts the adapter reads. See
+ *  `radio-view-model-adapter.ts::deriveRitXit`. */
+function validateRitXit(value: unknown, path: string): RitXitViewModel {
+  const v = record(value, path);
+  exactKeys(v, ['ritActive', 'ritOffset', 'xitActive', 'xitOffset'], path);
+  return {
+    ritActive: validateTxAuxField(v.ritActive, `${path}.ritActive`, bool),
+    ritOffset: validateTxAuxField(v.ritOffset, `${path}.ritOffset`, num),
+    xitActive: validateTxAuxField(v.xitActive, `${path}.xitActive`, bool),
+    xitOffset: validateTxAuxField(v.xitOffset, `${path}.xitOffset`, num),
+  };
+}
+
+/** Exactly the three facts the adapter reads. See
+ *  `radio-view-model-adapter.ts::deriveAntenna`. */
+function validateAntenna(value: unknown, path: string): AntennaViewModel {
+  const v = record(value, path);
+  exactKeys(v, ['txAntenna', 'rxAnt', 'antennaCount'], path);
+  return {
+    txAntenna: validateTxAuxField(v.txAntenna, `${path}.txAntenna`, num),
+    rxAnt: validateTxAuxField(v.rxAnt, `${path}.rxAnt`, bool),
+    antennaCount: num(v.antennaCount, `${path}.antennaCount`),
+  };
+}
+
+/** Exactly the three facts the adapter reads. See
+ *  `radio-view-model-adapter.ts::deriveScan`. */
+function validateScan(value: unknown, path: string): ScanViewModel {
+  const v = record(value, path);
+  exactKeys(v, ['scanning', 'scanType', 'scanResumeMode'], path);
+  return {
+    scanning: validateTxAuxField(v.scanning, `${path}.scanning`, bool),
+    scanType: validateTxAuxField(v.scanType, `${path}.scanType`, num),
+    scanResumeMode: validateTxAuxField(v.scanResumeMode, `${path}.scanResumeMode`, num),
+  };
+}
+
 /** Runtime validator (repo idiom: throws TypeError with a `$.path`, see `validateCapabilities`).
  *  Also enforces two cross-field invariants (review cycle 1, V1): `txPermit`
  *  cannot be 'allowed' while `txTarget` is unknown (no fail-open), and
@@ -1046,7 +1196,7 @@ export function validateRadioViewModel(value: unknown): RadioViewModel {
   exactKeys(v, [
     'topologyId', 'vfoScheme', 'activeReceiver', 'vfos', 'split', 'dualWatch',
     'txTarget', 'txPermit', 'scope', 'disabledReasons', 'txAux', 'meters', 'rxAudio', 'modeFilter',
-    'filterPassband', 'dsp', 'rfFrontEnd', 'band',
+    'filterPassband', 'dsp', 'rfFrontEnd', 'band', 'ritXit', 'antenna', 'scan',
   ], '$');
   if (!Array.isArray(v.vfos)) invalid('$.vfos', 'an array');
   if (!Array.isArray(v.disabledReasons)) invalid('$.disabledReasons', 'an array');
@@ -1082,6 +1232,9 @@ export function validateRadioViewModel(value: unknown): RadioViewModel {
   const dsp = optionalGroup(v.dsp, '$.dsp', validateDsp);
   const rfFrontEnd = optionalGroup(v.rfFrontEnd, '$.rfFrontEnd', validateRfFrontEnd);
   const band = optionalGroup(v.band, '$.band', validateBand);
+  const ritXit = optionalGroup(v.ritXit, '$.ritXit', validateRitXit);
+  const antenna = optionalGroup(v.antenna, '$.antenna', validateAntenna);
+  const scan = optionalGroup(v.scan, '$.scan', validateScan);
 
   return {
     topologyId: str(v.topologyId, '$.topologyId'),
@@ -1105,5 +1258,8 @@ export function validateRadioViewModel(value: unknown): RadioViewModel {
     ...(dsp !== undefined ? { dsp } : {}),
     ...(rfFrontEnd !== undefined ? { rfFrontEnd } : {}),
     ...(band !== undefined ? { band } : {}),
+    ...(ritXit !== undefined ? { ritXit } : {}),
+    ...(antenna !== undefined ? { antenna } : {}),
+    ...(scan !== undefined ? { scan } : {}),
   };
 }


### PR DESCRIPTION
## Summary
Vocabulary slice 8A: three separate optional groups (the 4A′ separate-group precedent — each family has its own evidence story). `ritXit`: enables + shared offset (verifier observation O1 recorded: one register under two gates — the 8B surface must not present the offsets as independently editable). `antenna`: TX port + RX-ant override + port count, mirroring v2's single `antennaCount>1` display gate (verified at source) — and **failing closed where v2 fails open**: no port-1 fallback under an unobserved `txAntenna`. `scan`: scanning/type/masked resume-mode with a per-field ever-reported gate — verifier-ruled SOUND (no scan capability tag exists anywhere by construction; raw-presence is the established fallback). ATU deliberately not duplicated (verifier-ruled: the tuner is exactly one global fact, `txAux.atu`; no per-antenna tuner exists in v2 — 8C carry-forward recorded: unknown tuner ⇒ not-ready, fail-closed). Net production LOC **107** strict / 248 raw (verifier re-measured; ≤200).

## Review provenance
Sonnet builder → independent opus vocabulary-domain verifier (16th ticket in domain): **PASS, no findings requiring action** — third clean slice. Parity verified at source for all three groups (no scaling conversions exist — the range-param class is N/A by construction); mutants killed: enable-swap, inverted port mapping (3), dropped 0x0f mask (2), restored port-1 fallback (3), seeded absent offset (2), both gate mutations, contract mutations ×3 (7/7/6). Determinism sweep clean (no store paths). Fail-set identical to baseline (+90 passing); lint/boundaries/check clean; merge clean.

Linear: MOR-1295

🤖 Generated with [Claude Code](https://claude.com/claude-code)