### PR TITLE
feat(MOR-1296): cwKeyer fact group (vocabulary slice 9A)

### DIFF
--- a/frontend/src/lib/runtime/adapters/__tests__/cw-keyer-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/cw-keyer-adapter.test.ts
@@ -1,0 +1,435 @@
+/**
+ * MOR-1262 decomposition slice 9A (MOR-1296) — `cwKeyer` fact-group adapter
+ * derivation. SAFETY-CRITICAL: break-in keys the transmitter.
+ *
+ * Companion to `rit-xit-adapter.test.ts`/`scan-adapter.test.ts`, which this
+ * file does NOT modify. `cwKeyer` is a SEPARATE optional group — see
+ * `radio-view-model.ts`'s `CwKeyerViewModel` doc comment. The no-key-path
+ * proof lives in `cw-keyer-purity.test.ts`.
+ *
+ * PARITY — the pins below call the REAL `toCwProps`
+ * (`lib/runtime/props/panel-props.ts`) and the REAL `isBreakInActive`
+ * (`components-v2/panels/cw-panel-logic.ts`), never a reimplementation, so
+ * agreement is against the shipped derivations themselves. Where this adapter
+ * deliberately DIVERGES from v2 it is because v2 fabricates a default
+ * (600 Hz / 12 WPM / OFF / not-reversed) on an unobserved field, and those
+ * divergences are pinned as such rather than papered over.
+ *
+ * Neither the CW state fields nor the `cw`/`break_in`/`apf`/`twin_peak`
+ * capability tags consume a capabilities-STORE-backed helper, so this file
+ * never calls the real `setCapabilities` and does not need the isolated pool
+ * (MOR-1272).
+ */
+import { describe, expect, it } from 'vitest';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { FieldStatus, ServerState } from '$lib/types/state';
+import { validateRadioViewModel, type RadioViewModel } from '../../../../semantic/radio-view-model';
+import { toRadioViewModel } from '../radio-view-model-adapter';
+import { toCwProps } from '../../props/panel-props';
+import { isBreakInActive } from '../../../../components-v2/panels/cw-panel-logic';
+
+function caps(overrides: Partial<Capabilities> = {}): Capabilities {
+  return {
+    model: 'fixture', scope: true, audio: true, tx: true, capabilities: ['scope', 'audio', 'tx'],
+    receivers: 1, vfoScheme: 'single', freqRanges: [], modes: [], filters: [],
+    audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
+    webrtc: { available: false, enabled: false },
+    txBands: [], scopeSource: 'hardware', audioFftAvailable: false, ...overrides,
+  } as Capabilities;
+}
+
+/** A radio whose TX permit is positively `allowed`: 14.195 MHz inside a
+ *  declared 20 m TX band, with an observed TX target. Break-in is only
+ *  UNGATED under such a permit, so every non-safety pin below uses it. */
+function cwCaps(tags: readonly string[] = ['cw', 'break_in', 'apf', 'twin_peak']): Capabilities {
+  return caps({
+    capabilities: ['tx', ...tags],
+    txBands: [{ name: '20m', start: 14000000, end: 14350000 }],
+  });
+}
+
+const fresh: FieldStatus = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' };
+const stale: FieldStatus = { storePath: 'x', observed: true, freshness: 'stale', availability: 'stale' };
+
+function bareState(overrides: Partial<ServerState> = {}): ServerState {
+  return {
+    active: 'MAIN', split: false, dualWatch: false, ptt: false,
+    txTarget: { status: 'known', receiver: 'MAIN', slot: null, frequencyHz: 14195000 },
+    main: {
+      freqHz: 14195000, mode: 'CW', filter: 1, dataMode: 0, att: 0, preamp: 0,
+      nb: false, nr: false, afLevel: 1, rfGain: 1, squelch: 0, sMeter: 0,
+    },
+    sub: {
+      freqHz: 7100000, mode: 'LSB', filter: 2, dataMode: 0, att: 0, preamp: 0,
+      nb: false, nr: false, afLevel: 1, rfGain: 1, squelch: 0, sMeter: 0,
+    },
+    fieldStatus: {
+      active: fresh, split: fresh, dualWatch: fresh, txTarget: fresh,
+      'main.freqHz': fresh, 'main.mode': fresh, 'main.filter': fresh,
+    },
+    ...overrides,
+  } as ServerState;
+}
+
+function model(state: ServerState | null, capabilities: Capabilities | null): RadioViewModel {
+  const view = toRadioViewModel(state, capabilities);
+  expect(view).not.toBeNull();
+  return validateRadioViewModel(view);
+}
+
+const reasonFields = (view: RadioViewModel) => view.disabledReasons.map((r) => r.field);
+
+describe('cwKeyer evidence gate (MOR-1296, N3)', () => {
+  it('emits no cwKeyer when capabilities are absent', () => {
+    expect(toRadioViewModel(bareState(), null)).toBeNull();
+  });
+
+  it('emits no cwKeyer for a baseline radio with no cw capability (regression pin)', () => {
+    const view = model(bareState(), caps());
+    expect(view.cwKeyer).toBeUndefined();
+    expect(Object.keys(view)).not.toContain('cwKeyer');
+  });
+
+  it('emits no cwKeyer for a radio declaring break_in/apf/twin_peak but NOT cw — v2 renders nothing there', () => {
+    const view = model(bareState(), cwCaps(['break_in', 'apf', 'twin_peak']));
+    expect(view.cwKeyer).toBeUndefined();
+  });
+
+  it('emits cwKeyer once the cw capability alone is declared', () => {
+    const view = model(bareState(), cwCaps(['cw']));
+    expect(view.cwKeyer).toBeDefined();
+  });
+
+  it('emits no cwKeyer-derived disabled reason when the group is absent', () => {
+    const view = model(bareState(), caps());
+    expect(reasonFields(view).filter((f) => f.startsWith('cwKeyer.'))).toEqual([]);
+  });
+});
+
+describe('cwKeyer per-field structural gates (MOR-1296)', () => {
+  it('break-in fields are structurally absent without the break_in capability', () => {
+    const view = model(bareState(), cwCaps(['cw']));
+    expect(view.cwKeyer!.breakIn.availability.structural).toBe(false);
+    expect(view.cwKeyer!.breakInDelay.availability.structural).toBe(false);
+    // The cw-tagged fields stay structurally present — one gate per control.
+    expect(view.cwKeyer!.keyerSpeed.availability.structural).toBe(true);
+    expect(view.cwKeyer!.pitchHz.availability.structural).toBe(true);
+    expect(view.cwKeyer!.reversePaddle.availability.structural).toBe(true);
+  });
+
+  it('apf is structurally absent without the apf capability, twinPeak without twin_peak', () => {
+    const view = model(bareState(), cwCaps(['cw', 'twin_peak']));
+    expect(view.cwKeyer!.apf.availability.structural).toBe(false);
+    expect(view.cwKeyer!.twinPeak.availability.structural).toBe(true);
+  });
+});
+
+describe('cwKeyer per-field derivation (MOR-1296)', () => {
+  const fullCaps = cwCaps();
+
+  it('reports known readings for observed, fresh, capability-backed fields — parity with the real toCwProps', () => {
+    const state = bareState({
+      breakIn: 2, breakInDelay: 128, keySpeed: 24, cwPitch: 700, dashRatio: -1,
+      main: { ...bareState().main, apfTypeLevel: 1, twinPeakFilter: true },
+      fieldStatus: {
+        ...bareState().fieldStatus,
+        breakIn: fresh, breakInDelay: fresh, keySpeed: fresh, cwPitch: fresh, dashRatio: fresh,
+        'main.apfTypeLevel': fresh, 'main.twinPeakFilter': fresh,
+      },
+    } as Partial<ServerState>);
+    const real = toCwProps(state, fullCaps);
+    const cw = model(state, fullCaps).cwKeyer!;
+    expect(cw.breakInDelay.reading).toEqual({ status: 'known', value: real.breakInDelay });
+    expect(cw.keyerSpeed.reading).toEqual({ status: 'known', value: real.keySpeed });
+    expect(cw.pitchHz.reading).toEqual({ status: 'known', value: real.cwPitch });
+    expect(cw.reversePaddle.reading).toEqual({ status: 'known', value: real.reversePaddle });
+    expect(cw.apf.reading).toEqual({ status: 'known', value: real.apfMode });
+    expect(cw.twinPeak.reading).toEqual({ status: 'known', value: real.twinPeak });
+    // `wpm` and `sidetonePitch` are v2 duplicates of the same two registers —
+    // one fact each here, in agreement with both shipped props.
+    expect(cw.keyerSpeed.reading).toEqual({ status: 'known', value: real.wpm });
+    expect(cw.pitchHz.reading).toEqual({ status: 'known', value: real.sidetonePitch });
+  });
+
+  const BREAK_IN_CASES = [[0, 'off'], [1, 'semi'], [2, 'full']] as const;
+
+  it.each(BREAK_IN_CASES)(
+    'decodes the raw break-in int %i to %s, agreeing with the real isBreakInActive predicate',
+    (raw, mode) => {
+      const state = bareState({
+        breakIn: raw, fieldStatus: { ...bareState().fieldStatus, breakIn: fresh },
+      } as Partial<ServerState>);
+      const cw = model(state, fullCaps).cwKeyer!;
+      expect(cw.breakIn.reading).toEqual({ status: 'known', value: mode });
+      expect(cw.breakIn.reading.status === 'known' && cw.breakIn.reading.value !== 'off')
+        .toBe(isBreakInActive(toCwProps(state, fullCaps).breakIn));
+    },
+  );
+
+  it('reads apf/twinPeak off the ACTIVE receiver, not always MAIN — value AND field-status path', () => {
+    // MAIN's own entries are STALE on purpose: without them a MAIN-path
+    // field-status lookup would find no entry and default to available, so a
+    // receiver-path bug would still read SUB's values and stay invisible.
+    const state = bareState({
+      active: 'SUB',
+      main: { ...bareState().main, apfTypeLevel: 1, twinPeakFilter: true },
+      sub: { ...bareState().sub, apfTypeLevel: 3, twinPeakFilter: false },
+      fieldStatus: {
+        ...bareState().fieldStatus,
+        active: fresh, 'sub.apfTypeLevel': fresh, 'sub.twinPeakFilter': fresh,
+        'main.apfTypeLevel': stale, 'main.twinPeakFilter': stale,
+      },
+    } as Partial<ServerState>);
+    const cw = model(state, cwCaps()).cwKeyer!;
+    expect(cw.apf.reading).toEqual({ status: 'known', value: 3 });
+    expect(cw.twinPeak.reading).toEqual({ status: 'known', value: false });
+    expect(cw.apf.availability.operational).toBe(true);
+  });
+
+  const STALE_FIELDS = [
+    ['breakIn', 'breakIn', 1],
+    ['breakInDelay', 'breakInDelay', 100],
+    ['keySpeed', 'keyerSpeed', 30],
+    ['cwPitch', 'pitchHz', 750],
+    ['dashRatio', 'reversePaddle', -1],
+  ] as const;
+
+  it.each(STALE_FIELDS)(
+    'degrades a stale %s field to unknown while keeping structural availability true',
+    (rawField, viewField, rawValue) => {
+      const state = bareState({
+        [rawField]: rawValue, fieldStatus: { ...bareState().fieldStatus, [rawField]: stale },
+      } as Partial<ServerState>);
+      expect(model(state, fullCaps).cwKeyer![viewField]).toEqual({
+        reading: { status: 'unknown' }, availability: { structural: true, operational: false },
+      });
+    },
+  );
+
+  it('marks breakIn structurally absent when the break_in capability is missing, never known', () => {
+    const state = bareState({
+      breakIn: 2, fieldStatus: { ...bareState().fieldStatus, breakIn: fresh },
+    } as Partial<ServerState>);
+    expect(model(state, cwCaps(['cw'])).cwKeyer!.breakIn).toEqual({
+      reading: { status: 'unknown' }, availability: { structural: false, operational: false },
+    });
+  });
+
+  it('degrades a malformed raw cwPitch (wrong JS type) to unknown rather than coercing', () => {
+    const state = bareState({
+      cwPitch: '700' as unknown as number, fieldStatus: { ...bareState().fieldStatus, cwPitch: fresh },
+    } as Partial<ServerState>);
+    expect(model(state, fullCaps).cwKeyer!.pitchHz.reading).toEqual({ status: 'unknown' });
+  });
+
+  it('emits a validator-clean model carrying the cwKeyer group (round-trip proof)', () => {
+    const state = bareState({
+      breakIn: 1, keySpeed: 20, fieldStatus: { ...bareState().fieldStatus, breakIn: fresh, keySpeed: fresh },
+    } as Partial<ServerState>);
+    const view = model(state, fullCaps);
+    expect(JSON.parse(JSON.stringify(view))).toEqual(view);
+  });
+});
+
+/**
+ * HONESTY / FAIL-CLOSED GATE — absent raw values never fabricate v2's
+ * defaults, and an unrecognised break-in encoding never decodes to `off`.
+ */
+describe('cwKeyer honesty gate — absent raw values never fabricate (MOR-1296)', () => {
+  const fullCaps = cwCaps();
+
+  const ABSENT_CASES = [
+    ['breakIn', 'off'],
+    ['breakInDelay', 0],
+    ['keyerSpeed', 12],
+    ['pitchHz', 600],
+    ['reversePaddle', false],
+    ['apf', 0],
+    ['twinPeak', false],
+  ] as const;
+
+  it.each(ABSENT_CASES)(
+    '%s with nothing reported at all reads unknown, not v2\'s fabricated %s',
+    (viewField) => {
+      expect(model(bareState(), fullCaps).cwKeyer![viewField].reading).toEqual({ status: 'unknown' });
+    },
+  );
+
+  it("v2's own toCwProps DOES fabricate those defaults — the divergence is real, not vacuous", () => {
+    const real = toCwProps(bareState(), fullCaps);
+    expect(real.breakIn).toBe(0);
+    expect(real.keySpeed).toBe(12);
+    expect(real.cwPitch).toBe(600);
+    expect(real.reversePaddle).toBe(false);
+  });
+
+  it('an unrecognised break-in int reads unknown, where the real formatBreakIn falls back to OFF', () => {
+    const state = bareState({
+      breakIn: 7, fieldStatus: { ...bareState().fieldStatus, breakIn: fresh },
+    } as Partial<ServerState>);
+    expect(model(state, cwCaps()).cwKeyer!.breakIn.reading).toEqual({ status: 'unknown' });
+  });
+});
+
+/**
+ * THE APF/TPF MUTEX (MOR-479 lineage, MOR-1293 precedent) — expressed as
+ * `disabledReasons` with the generic `'mutually-exclusive-control'` code,
+ * never as bespoke `apfDisabled`/`tpfDisabled` booleans, and fail-closed on
+ * an unknown mode.
+ */
+describe('cwKeyer APF/TPF mode mutex (MOR-1296)', () => {
+  const stateInMode = (mode: string): ServerState => bareState({
+    main: { ...bareState().main, mode },
+    fieldStatus: { ...bareState().fieldStatus, 'main.mode': fresh },
+  } as Partial<ServerState>);
+
+  /** The mutex reads `modeFilter.currentMode`, which needs a declared mode
+   *  set to exist at all — hence the `modes` override here and its absence
+   *  in the "modeFilter group absent" pin below. */
+  function viewFor(mode: string, tags?: readonly string[]): RadioViewModel {
+    const capabilities = { ...cwCaps(tags), modes: ['USB', 'CW', 'CW-R', 'RTTY', 'RTTY-R'] } as Capabilities;
+    return model(stateInMode(mode), capabilities);
+  }
+
+  it('carries no bespoke apfDisabled/tpfDisabled key on the group', () => {
+    expect(Object.keys(viewFor('CW').cwKeyer!).sort()).toEqual([
+      'apf', 'breakIn', 'breakInDelay', 'keyerSpeed', 'pitchHz', 'reversePaddle', 'twinPeak',
+    ]);
+  });
+
+  it.each(['CW', 'CW-R'])('leaves APF enabled in %s, and disables TPF there — parity with toCwProps', (mode) => {
+    const view = viewFor(mode);
+    const real = toCwProps(stateInMode(mode), cwCaps());
+    expect(real.apfDisabled).toBe(false);
+    expect(real.tpfDisabled).toBe(true);
+    expect(reasonFields(view)).not.toContain('cwKeyer.apf');
+    expect(view.disabledReasons).toContainEqual({ field: 'cwKeyer.twinPeak', code: 'mutually-exclusive-control' });
+  });
+
+  it.each(['RTTY', 'RTTY-R'])('leaves TPF enabled in %s and disables APF there', (mode) => {
+    const view = viewFor(mode);
+    expect(reasonFields(view)).not.toContain('cwKeyer.twinPeak');
+    expect(view.disabledReasons).toContainEqual({ field: 'cwKeyer.apf', code: 'mutually-exclusive-control' });
+  });
+
+  it('disables BOTH in an unrelated mode', () => {
+    const fields = reasonFields(viewFor('USB'));
+    expect(fields).toContain('cwKeyer.apf');
+    expect(fields).toContain('cwKeyer.twinPeak');
+  });
+
+  it('FAILS CLOSED on an unobserved mode: both disabled, no fabricated USB/CW guess', () => {
+    const state = bareState({
+      fieldStatus: { ...bareState().fieldStatus, 'main.mode': stale },
+    } as Partial<ServerState>);
+    const capabilities = { ...cwCaps(), modes: ['USB', 'CW'] } as Capabilities;
+    const view = model(state, capabilities);
+    expect(view.modeFilter!.currentMode.reading).toEqual({ status: 'unknown' });
+    expect(reasonFields(view)).toContain('cwKeyer.apf');
+    expect(reasonFields(view)).toContain('cwKeyer.twinPeak');
+  });
+
+  it('FAILS CLOSED when the modeFilter group is absent entirely — no mode fact, no enablement', () => {
+    const view = model(stateInMode('CW'), cwCaps());
+    expect(view.modeFilter).toBeUndefined();
+    expect(reasonFields(view)).toContain('cwKeyer.apf');
+    expect(reasonFields(view)).toContain('cwKeyer.twinPeak');
+  });
+
+  it('emits no mutex reason for a control the radio does not have', () => {
+    const view = viewFor('USB', ['cw']);
+    expect(reasonFields(view)).not.toContain('cwKeyer.apf');
+    expect(reasonFields(view)).not.toContain('cwKeyer.twinPeak');
+  });
+});
+
+/**
+ * SAFETY CONSTRAINT 2 — the break-in TX gate consumes the model's ONE
+ * `txPermit`. There is no second permit and no `state.ptt` read (R9).
+ */
+describe('cwKeyer break-in TX gate (MOR-1296)', () => {
+  const inBand = cwCaps();
+
+  it('leaves break-in ungated under a positively allowed txPermit', () => {
+    const view = model(bareState(), inBand);
+    expect(view.txPermit.status).toBe('allowed');
+    expect(reasonFields(view)).not.toContain('cwKeyer.breakIn');
+  });
+
+  it('disables break-in out of band, with the same out-of-band code the model-level permit uses', () => {
+    const state = bareState({
+      main: { ...bareState().main, freqHz: 14400000 },
+      txTarget: { status: 'known', receiver: 'MAIN', slot: null, frequencyHz: 14400000 },
+    } as Partial<ServerState>);
+    const view = model(state, inBand);
+    expect(view.txPermit.status).toBe('denied');
+    expect(view.disabledReasons).toContainEqual({ field: 'cwKeyer.breakIn', code: 'out-of-band' });
+  });
+
+  it('disables break-in when the TX target is unobserved (fail-closed, not fail-open)', () => {
+    const state = bareState({
+      txTarget: { status: 'unknown', reason: 'not-observed' },
+      fieldStatus: { ...bareState().fieldStatus, txTarget: stale },
+    } as Partial<ServerState>);
+    const view = model(state, inBand);
+    expect(view.txPermit.status).toBe('unknown');
+    expect(view.disabledReasons).toContainEqual({ field: 'cwKeyer.breakIn', code: 'tx-target-unknown' });
+  });
+
+  it('disables break-in when the radio declares no TX ranges at all', () => {
+    const unconfigured = caps({
+      capabilities: ['tx', 'cw', 'break_in'], txBands: null,
+    } as unknown as Partial<Capabilities>);
+    const view = model(bareState(), unconfigured);
+    expect(view.txPermit).toEqual({ status: 'unknown', reason: 'ranges-unconfigured' });
+    expect(view.disabledReasons)
+      .toContainEqual({ field: 'cwKeyer.breakIn', code: 'capability-unavailable' });
+  });
+
+  it('emits no break-in gate for a radio without the break_in capability — nothing to key with', () => {
+    const state = bareState({
+      main: { ...bareState().main, freqHz: 14400000 },
+      txTarget: { status: 'known', receiver: 'MAIN', slot: null, frequencyHz: 14400000 },
+    } as Partial<ServerState>);
+    const view = model(state, cwCaps(['cw']));
+    expect(view.txPermit.status).toBe('denied');
+    expect(reasonFields(view)).not.toContain('cwKeyer.breakIn');
+  });
+
+  it('gates on the permit even while the radio reports ptt=false and break-in reads off (R9)', () => {
+    const state = bareState({
+      ptt: false, breakIn: 0,
+      main: { ...bareState().main, freqHz: 14400000 },
+      txTarget: { status: 'known', receiver: 'MAIN', slot: null, frequencyHz: 14400000 },
+      fieldStatus: { ...bareState().fieldStatus, breakIn: fresh },
+    } as Partial<ServerState>);
+    const view = model(state, inBand);
+    expect(view.cwKeyer!.breakIn.reading).toEqual({ status: 'known', value: 'off' });
+    expect(reasonFields(view)).toContain('cwKeyer.breakIn');
+  });
+});
+
+/**
+ * DETERMINISM — a fact-layer value is a pure function of `(state, caps)`.
+ * Both directions: same inputs ⇒ same output, and a changed input ⇒ changed
+ * output (so the first half cannot pass by returning a constant).
+ */
+describe('cwKeyer determinism in (state, caps) (MOR-1296)', () => {
+  it('is stable across repeated derivations of the same inputs', () => {
+    const state = bareState({
+      breakIn: 1, keySpeed: 18, cwPitch: 650,
+      fieldStatus: { ...bareState().fieldStatus, breakIn: fresh, keySpeed: fresh, cwPitch: fresh },
+    } as Partial<ServerState>);
+    expect(model(state, cwCaps()).cwKeyer).toEqual(model(state, cwCaps()).cwKeyer);
+  });
+
+  it('changes with state, and with caps, independently', () => {
+    const withState = (speed: number) => bareState({
+      keySpeed: speed, fieldStatus: { ...bareState().fieldStatus, keySpeed: fresh },
+    } as Partial<ServerState>);
+    expect(model(withState(18), cwCaps()).cwKeyer!.keyerSpeed.reading)
+      .not.toEqual(model(withState(30), cwCaps()).cwKeyer!.keyerSpeed.reading);
+    expect(model(withState(18), cwCaps()).cwKeyer!.apf.availability)
+      .not.toEqual(model(withState(18), cwCaps(['cw'])).cwKeyer!.apf.availability);
+  });
+});

--- a/frontend/src/lib/runtime/adapters/__tests__/cw-keyer-purity.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/cw-keyer-purity.test.ts
@@ -1,0 +1,173 @@
+/**
+ * MOR-1262 decomposition slice 9A (MOR-1296) — SAFETY CONSTRAINT 1:
+ * THE CW SURFACE MUST NOT BECOME A KEY PATH.
+ *
+ * Break-in keys the transmitter. The `cwKeyer` fact group is therefore a PURE
+ * READ-MODEL: deriving, validating or serializing it must emit no command, do
+ * no transport I/O, and mutate no radio store — there must exist no code path
+ * from "build the view model" to "the radio transmits". The three-pin
+ * discipline is MOR-1274's (slice 3A), applied to the CW command seam instead
+ * of the audio one, and deliberately non-interchangeable:
+ *
+ *  1. LOAD-TIME — spy call counts snapshotted at module-import time, BEFORE
+ *     any `mockClear()`. Covers the whole transitive import closure of the
+ *     adapter and the contract, and is the only pin that would see a side
+ *     effect fired at import rather than at derive.
+ *  2. BEHAVIOURAL — a full derive + validate + serialize round trip over a
+ *     state whose break-in is ARMED (`full`/QSK) and whose TX permit is
+ *     ALLOWED — the most dangerous input this family has — must leave the
+ *     control transport at zero calls. A model with no `cwKeyer` group would
+ *     make "zero calls" vacuous, so the pin asserts the group was produced.
+ *  3. STRUCTURAL — the adapter's own source text imports no transport and no
+ *     command module, and contains none of the CW command verbs the shipped
+ *     handlers send (`set_break_in`, `cw_auto_tune`, …). SOURCE-LOCAL and
+ *     NON-TRANSITIVE by construction; pins 1 and 2 are the closure-wide ones.
+ *
+ * Pool: `isolated` (MOR-1272). Module-scope `vi.mock` is exactly the
+ * shared-state shape that is order-dependent under the fast pool's
+ * `isolate: false` — a sibling that imports the real transport first would
+ * pin it in the module cache and turn the hoisted mock into a no-op.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+vi.mock('$lib/transport/ws-client', () => ({
+  sendCommand: vi.fn(), connectWs: vi.fn(), disconnectWs: vi.fn(),
+}));
+
+import { sendCommand } from '$lib/transport/ws-client';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { FieldStatus, ServerState } from '$lib/types/state';
+import { validateRadioViewModel } from '../../../../semantic/radio-view-model';
+import { toRadioViewModel } from '../radio-view-model-adapter';
+
+/** PIN 1 — the load-time snapshot, read at module scope so it runs after the
+ *  imports above have fully evaluated the adapter's and the contract's entire
+ *  transitive closure and BEFORE `beforeEach` erases the evidence. */
+const loadTimeCommandCalls = vi.mocked(sendCommand).mock.calls.length;
+
+const fresh: FieldStatus = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' };
+
+/** The most dangerous input this family has: full break-in (QSK — the key
+ *  transmits immediately), on an in-band frequency with an observed TX
+ *  target, so the model-level permit is positively `allowed` and nothing
+ *  gates the affordance. */
+const caps = {
+  model: 'fixture', scope: false, audio: false, tx: true,
+  capabilities: ['tx', 'cw', 'break_in', 'apf', 'twin_peak'],
+  receivers: 1, vfoScheme: 'single', freqRanges: [], modes: ['CW'], filters: [],
+  audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
+  webrtc: { available: false, enabled: false },
+  txBands: [{ name: '20m', start: 14000000, end: 14350000 }],
+  scopeSource: 'hardware', audioFftAvailable: false,
+} as unknown as Capabilities;
+
+const state = {
+  active: 'MAIN', split: false, dualWatch: false, ptt: false,
+  txTarget: { status: 'known', receiver: 'MAIN', slot: null, frequencyHz: 14030000 },
+  main: {
+    freqHz: 14030000, mode: 'CW', filter: 1, dataMode: 0, afLevel: 1, rfGain: 1,
+    squelch: 0, sMeter: 0, apfTypeLevel: 1, twinPeakFilter: false,
+  },
+  breakIn: 2, breakInDelay: 0, keySpeed: 32, cwPitch: 600, dashRatio: 0,
+  fieldStatus: {
+    active: fresh, txTarget: fresh, 'main.freqHz': fresh, 'main.mode': fresh,
+    breakIn: fresh, breakInDelay: fresh, keySpeed: fresh, cwPitch: fresh, dashRatio: fresh,
+    'main.apfTypeLevel': fresh, 'main.twinPeakFilter': fresh,
+  },
+} as unknown as ServerState;
+
+/** Comments are stripped before the structural assertions: the adapter
+ *  DOCUMENTS this prohibition in prose (and names `cw_auto_tune` while doing
+ *  so), and a naive text search would match the doctrine instead of the code. */
+function code(path: string): string {
+  return readFileSync(path, 'utf8')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
+const adapterSource = code('src/lib/runtime/adapters/radio-view-model-adapter.ts');
+const contractSource = code('src/semantic/radio-view-model.ts');
+
+describe('cwKeyer fact construction is not a key path (MOR-1296, safety constraint 1)', () => {
+  beforeEach(() => {
+    vi.mocked(sendCommand).mockClear();
+  });
+
+  // ── Pin 1: load-time, closure-wide ───────────────────────────────────────
+  it('importing the adapter and contract sends no command at module-load time', () => {
+    expect(loadTimeCommandCalls).toBe(0);
+  });
+
+  // ── Pin 2: behavioural, closure-wide ─────────────────────────────────────
+  it('derives, validates and serializes an ARMED break-in model with zero commands sent', () => {
+    const view = validateRadioViewModel(toRadioViewModel(state, caps));
+    // The group really was produced, under a permit that does not gate it —
+    // otherwise "zero calls" would prove nothing.
+    expect(view.cwKeyer).toBeDefined();
+    expect(view.cwKeyer!.breakIn.reading).toEqual({ status: 'known', value: 'full' });
+    expect(view.txPermit.status).toBe('allowed');
+    expect(view.disabledReasons.map((r) => r.field)).not.toContain('cwKeyer.breakIn');
+    JSON.stringify(view);
+
+    expect(sendCommand).not.toHaveBeenCalled();
+  });
+
+  it('repeated derivation stays side-effect free and stable', () => {
+    const first = toRadioViewModel(state, caps);
+    const second = toRadioViewModel(state, caps);
+    expect(second).toEqual(first);
+    expect(sendCommand).not.toHaveBeenCalled();
+  });
+
+  it('sends nothing even when the derivation runs against a TX-permitted, mode-matched CW state', () => {
+    const view = validateRadioViewModel(toRadioViewModel(state, caps));
+    expect(view.modeFilter!.currentMode.reading).toEqual({ status: 'known', value: 'CW' });
+    // APF is in its permitted mode, so nothing disables it — the "enabled"
+    // branch of the mutex is exercised here, not just the disabled one.
+    expect(view.disabledReasons.map((r) => r.field)).not.toContain('cwKeyer.apf');
+    expect(sendCommand).not.toHaveBeenCalled();
+  });
+
+  // ── Pin 3: structural, source-local ──────────────────────────────────────
+  it('the adapter imports no transport and no command module', () => {
+    expect(adapterSource).not.toMatch(/from\s+'\$lib\/transport\//);
+    expect(adapterSource).not.toMatch(/from\s+'[^']*commands\//);
+    expect(adapterSource).not.toMatch(/from\s+'[^']*components-v2\//);
+    expect(adapterSource).not.toMatch(/\bsendCommand\b/);
+  });
+
+  it('the adapter contains none of the CW command verbs the shipped handlers send', () => {
+    for (const verb of [
+      'set_break_in', 'set_break_in_delay', 'cw_auto_tune', 'set_key_speed',
+      'set_cw_pitch', 'set_apf', 'set_twin_peak', 'set_keyer_type', 'set_dash_ratio', 'set_ptt',
+    ]) {
+      expect(adapterSource).not.toContain(verb);
+    }
+  });
+
+  it('the contract carries no command vocabulary and no transport import', () => {
+    expect(contractSource).not.toMatch(/from\s+'\$lib\/transport\//);
+    expect(contractSource).not.toMatch(/from\s+'\$lib\/runtime\//);
+    expect(contractSource).not.toContain('set_break_in');
+    expect(contractSource).not.toContain('cw_auto_tune');
+  });
+
+  /**
+   * SAFETY CONSTRAINT 2 — NO SECOND PERMIT, structurally. The CW derivation
+   * must consume the model's single `txPermit`, so `getFrequencyPermit` (the
+   * one shipped permit derivation) must appear in this file exactly where
+   * MOR-1294's band family already calls it, and nowhere in the CW path.
+   */
+  it('the CW derivation contains no permit re-derivation of its own', () => {
+    const cwSection = adapterSource.slice(
+      adapterSource.indexOf('function deriveCwKeyer('),
+      adapterSource.indexOf('export interface RxAudioSnapshot'),
+    );
+    expect(cwSection.length).toBeGreaterThan(0);
+    expect(cwSection).not.toContain('getFrequencyPermit');
+    expect(cwSection).not.toContain('txBands');
+    // R9: TX truth comes from the authority-derived permit, never `state.ptt`.
+    expect(cwSection).not.toMatch(/\bptt\b/);
+  });
+});

--- a/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
@@ -31,12 +31,13 @@ import type {
   AudioFocus, MonitorMode, RxAudioViewModel, ModeFilterViewModel,
   FilterPassbandViewModel, DspViewModel, RfFrontEndViewModel,
   BandChoice, BandViewModel, RitXitViewModel, AntennaViewModel, ScanViewModel,
+  BreakInMode, CwKeyerViewModel,
 } from '../../../semantic/radio-view-model';
 import type { TxAuthoritySnapshot } from '../../../semantic/rx-tx-surface';
 import { isFieldAvailable } from '$lib/state/field-status';
 import { modInputStateKey } from '$lib/radio/mod-input';
 import { flattenBands, findActiveBand } from '$lib/radio/band-plan';
-import { getFrequencyPermit, type TxPermit } from '$lib/utils/tx-permit';
+import { getFrequencyPermit, type FrequencyPermit, type TxPermit } from '$lib/utils/tx-permit';
 import { resolveFilterModeConfig } from '$lib/runtime/props/panel-props';
 import {
   deriveIfShift, pbtRangeFromCaps, pbtRawToHz,
@@ -814,6 +815,112 @@ function deriveScan(state: ServerState | null): ScanViewModel | undefined {
   };
 }
 
+/** The v2 wire encoding (`BREAK_IN_LABELS`, `components-v2/panels/
+ *  cw-panel-logic.ts`), decoded ONCE here. Unlike v2's `formatBreakIn`, an
+ *  unrecognised int returns `undefined` (⇒ `unknown` reading) instead of
+ *  falling back to OFF — an unreadable break-in state must never present as
+ *  "the key is safe". Same shape as `atuStatus` above. */
+const breakInMode = (v: unknown): BreakInMode | undefined =>
+  v === 0 ? 'off' : v === 1 ? 'semi' : v === 2 ? 'full' : undefined;
+
+/**
+ * CW-keyer facts (MOR-1262 decomposition slice 9A, MOR-1296) — SAFETY-CRITICAL.
+ * See `CwKeyerViewModel`'s doc comment for the group shape, the closed family
+ * enumeration (sidetone LEVEL is `txAux.monitorLevel`, current MODE is
+ * `modeFilter.currentMode`, keyer TYPE has no state field at all) and the
+ * "no second permit" rule. This function emits READINGS ONLY; every disable —
+ * the APF/TPF mode mutex and the break-in TX gate alike — is produced by
+ * `deriveCwKeyerReasons` below, which consumes facts, never raw state.
+ *
+ * Evidence gate (N3): `hasCap(caps, 'cw')`, the shipped panel's own single
+ * gate (`LeftSidebar.svelte`/`RightSidebar.svelte` render the CW panel only
+ * under `hasCapability('cw')`, and `CwPanel.svelte` wraps its whole body in
+ * `{#if showCw}`), copied rather than replaced. One v2 gate, not four: a radio
+ * declaring `twin_peak` but not `cw` shows nothing in v2 and gets no group
+ * here either. The per-control `break_in`/`apf`/`twin_peak` tags are
+ * `toCwProps`'s own sub-gates and become per-field STRUCTURAL availability,
+ * exactly as `deriveRitXit` treats `rit`/`xit`.
+ *
+ * `reversePaddle` consumes `toCwProps`'s own `(state?.dashRatio ?? 0) < 0`
+ * predicate — but over an HONEST input: v2's `?? 0` makes an unreported dash
+ * ratio read as "not reversed", where an unobserved field here yields
+ * `unknown`. Same deviation-from-v2-fabrication story as `pitchHz`/
+ * `keyerSpeed`, which never fall back to v2's 600 Hz / 12 WPM.
+ */
+function deriveCwKeyer(state: ServerState | null, caps: Capabilities | null): CwKeyerViewModel | undefined {
+  if (!hasCap(caps, 'cw')) return undefined;
+  const hasBreakInCap = hasCap(caps, 'break_in');
+  const hasApfCap = hasCap(caps, 'apf');
+  const hasTwinPeakCap = hasCap(caps, 'twin_peak');
+  const onSub = state?.active === 'SUB';
+  const rx = onSub ? state?.sub : state?.main;
+  const base = onSub ? 'sub.' : 'main.';
+  const dashRatio = numOrUndef(state?.dashRatio);
+  return {
+    breakIn: txAuxField(hasBreakInCap, topFieldAvailable(state, 'breakIn'), breakInMode(state?.breakIn)),
+    breakInDelay: txAuxField(
+      hasBreakInCap, topFieldAvailable(state, 'breakInDelay'), numOrUndef(state?.breakInDelay),
+    ),
+    keyerSpeed: txAuxField(true, topFieldAvailable(state, 'keySpeed'), numOrUndef(state?.keySpeed)),
+    pitchHz: txAuxField(true, topFieldAvailable(state, 'cwPitch'), numOrUndef(state?.cwPitch)),
+    reversePaddle: txAuxField(
+      true, topFieldAvailable(state, 'dashRatio'), dashRatio === undefined ? undefined : dashRatio < 0,
+    ),
+    apf: txAuxField(hasApfCap, topFieldAvailable(state, `${base}apfTypeLevel`), numOrUndef(rx?.apfTypeLevel)),
+    twinPeak: txAuxField(
+      hasTwinPeakCap, topFieldAvailable(state, `${base}twinPeakFilter`), boolOrUndef(rx?.twinPeakFilter),
+    ),
+  };
+}
+
+/**
+ * Every CW-keyer disable, in one place, derived from FACTS only (MOR-1296).
+ *
+ * THE APF/TPF MUTEX (MOR-479 lineage, MOR-1293 precedent): `toCwProps`
+ * disables APF outside CW/CW-R and TPF outside RTTY/RTTY-R — its own comment
+ * calls this a mirror of the MOR-479 preamp mutex — so it is expressed the
+ * way the DIGI-SEL/PREAMP mutex is: `disabledReasons` entries with the generic
+ * `'mutually-exclusive-control'` code, never bespoke `apfDisabled`/
+ * `tpfDisabled` booleans. The mode comes from THIS model's own
+ * `modeFilter.currentMode` fact, never a second `rx?.mode` read, and an
+ * `unknown` (or structurally-absent) mode leaves BOTH controls disabled —
+ * fail-closed, matching what v2's `?? 'USB'` fallback happens to produce
+ * while resting on a fabricated value this contract refuses to invent.
+ *
+ * THE BREAK-IN TX GATE (safety constraint 2, "no second permit"): break-in
+ * keys the transmitter, so its affordance is gated on the model's ONE
+ * `txPermit` — the value already computed by `deriveTxCapabilities` and
+ * passed in here, NOT a second `getFrequencyPermit` call and NOT `state.ptt`
+ * (invariant R9). The reason CODES mirror the model-level `txPermit` entries
+ * `toRadioViewModel` already emits, so there is one vocabulary for one
+ * permit. Anything other than a positively `'allowed'` permit — denied,
+ * ranges-unconfigured, tx-target-unknown — disables break-in; that
+ * fail-closed pairing is additionally enforced by `validateRadioViewModel`.
+ */
+function deriveCwKeyerReasons(
+  cwKeyer: CwKeyerViewModel | undefined, modeFilter: ModeFilterViewModel | undefined,
+  txPermit: FrequencyPermit,
+): Reason[] {
+  if (!cwKeyer) return [];
+  const modeReading = modeFilter?.currentMode.reading;
+  const mode = modeReading?.status === 'known' ? modeReading.value : undefined;
+  const reasons: Reason[] = [];
+  if (cwKeyer.apf.availability.structural && mode !== 'CW' && mode !== 'CW-R') {
+    reasons.push({ field: 'cwKeyer.apf', code: 'mutually-exclusive-control' });
+  }
+  if (cwKeyer.twinPeak.availability.structural && mode !== 'RTTY' && mode !== 'RTTY-R') {
+    reasons.push({ field: 'cwKeyer.twinPeak', code: 'mutually-exclusive-control' });
+  }
+  if (cwKeyer.breakIn.availability.structural && txPermit.status !== 'allowed') {
+    reasons.push({
+      field: 'cwKeyer.breakIn',
+      code: txPermit.status === 'denied' ? 'out-of-band'
+        : txPermit.reason === 'ranges-unconfigured' ? 'capability-unavailable' : 'tx-target-unknown',
+    });
+  }
+  return reasons;
+}
+
 /**
  * The App-owned RX-audio snapshot the `rxAudio` facts are read against
  * (MOR-1262 slice 3A). It is an INPUT, deliberately: audio lifetime belongs to
@@ -1051,8 +1158,10 @@ export function toRadioViewModel(
   const ritXit = deriveRitXit(state, caps);
   const antenna = deriveAntenna(state, caps);
   const scan = deriveScan(state);
+  const cwKeyer = deriveCwKeyer(state, caps);
   const rfFrontEndMutex = deriveRfFrontEndMutex(rfFrontEnd);
   if (rfFrontEndMutex) disabledReasons.push(rfFrontEndMutex);
+  disabledReasons.push(...deriveCwKeyerReasons(cwKeyer, modeFilter, txPermit));
 
   return {
     topologyId: `${topology.structuralCount}/${topology.scheme}`,
@@ -1076,5 +1185,6 @@ export function toRadioViewModel(
     ...(ritXit !== undefined ? { ritXit } : {}),
     ...(antenna !== undefined ? { antenna } : {}),
     ...(scan !== undefined ? { scan } : {}),
+    ...(cwKeyer !== undefined ? { cwKeyer } : {}),
   };
 }

--- a/frontend/src/semantic/__tests__/cw-keyer.test.ts
+++ b/frontend/src/semantic/__tests__/cw-keyer.test.ts
@@ -1,0 +1,222 @@
+/**
+ * MOR-1262 decomposition slice 9A (MOR-1296) — `cwKeyer` optional fact group
+ * (validator half). SAFETY-CRITICAL: break-in keys the transmitter.
+ *
+ * Facts only: break-in mode/delay, keyer speed, pitch, reverse paddle, APF,
+ * TPF. See `radio-view-model.ts`'s `CwKeyerViewModel` doc comment for the
+ * group-shape rationale (and for the three shipped `CwProps` fields
+ * deliberately absent from it), and `radio-view-model-adapter.ts`'s
+ * `deriveCwKeyer`/`deriveCwKeyerReasons` for the live derivation (covered by
+ * the companion `cw-keyer-adapter.test.ts` and `cw-keyer-purity.test.ts`).
+ *
+ * Mirrors the companion families' (`rit-xit.test.ts`, `scan.test.ts`)
+ * kill-tests, plus one this family alone carries: the fail-closed cross-field
+ * invariant tying a structurally-available `breakIn` to a `txPermit` that is
+ * not `'allowed'` (safety constraint 2/3, same shape as MOR-1294's band pin).
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  validateRadioViewModel, type CwKeyerField, type CwKeyerViewModel,
+} from '../radio-view-model';
+import { topologyFixtures, withCwKeyer } from '../fixtures/topologies';
+
+const AVAIL = { structural: true, operational: true } as const;
+const OFF = { structural: false, operational: false } as const;
+const base = topologyFixtures['1/single'];
+
+describe('cwKeyer (MOR-1262 slice 9A)', () => {
+  it('validates a cwKeyer-absent model and never adds the key', () => {
+    expect(Object.keys(base)).not.toContain('cwKeyer');
+    const validated = validateRadioViewModel(base);
+    expect(Object.keys(validated)).not.toContain('cwKeyer');
+    expect(validated.cwKeyer).toBeUndefined();
+    expect(JSON.parse(JSON.stringify(validated))).toEqual(JSON.parse(JSON.stringify(base)));
+  });
+
+  it('validates a fully-populated cwKeyer group and returns it unchanged', () => {
+    const withC = withCwKeyer(base);
+    expect(validateRadioViewModel(withC).cwKeyer).toEqual(withC.cwKeyer);
+  });
+
+  it('rejects an explicit cwKeyer: null', () => {
+    expect(() => validateRadioViewModel({ ...base, cwKeyer: null })).toThrow(TypeError);
+  });
+
+  it('rejects an explicit cwKeyer: {} — present, not absent, must satisfy its own shape', () => {
+    expect(() => validateRadioViewModel({ ...base, cwKeyer: {} })).toThrow(TypeError);
+  });
+
+  it('rejects a non-numeric keyerSpeed reading value with a precise error path', () => {
+    const withC = withCwKeyer(base);
+    const malformed = {
+      ...withC,
+      cwKeyer: { ...withC.cwKeyer, keyerSpeed: { reading: { status: 'known', value: '24' }, availability: AVAIL } },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.cwKeyer\.keyerSpeed\.reading\.value/);
+  });
+
+  it('rejects a non-boolean twinPeak reading value with a precise error path', () => {
+    const withC = withCwKeyer(base);
+    const malformed = {
+      ...withC,
+      cwKeyer: { ...withC.cwKeyer, twinPeak: { reading: { status: 'known', value: 1 }, availability: AVAIL } },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.cwKeyer\.twinPeak\.reading\.value/);
+  });
+
+  it('rejects the RAW v2 int encoding for breakIn — the contract carries the tri-state, not 0/1/2', () => {
+    const withC = withCwKeyer(base);
+    const malformed = {
+      ...withC,
+      cwKeyer: { ...withC.cwKeyer, breakIn: { reading: { status: 'known', value: 1 }, availability: AVAIL } },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.cwKeyer\.breakIn\.reading\.value/);
+  });
+
+  it('rejects a breakIn mode outside the closed union (no silent extra keyer mode)', () => {
+    const withC = withCwKeyer(base);
+    const malformed = {
+      ...withC,
+      cwKeyer: { ...withC.cwKeyer, breakIn: { reading: { status: 'known', value: 'qsk' }, availability: AVAIL } },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.cwKeyer\.breakIn\.reading\.value/);
+  });
+
+  it.each(['off', 'semi', 'full'] as const)('accepts the %s break-in mode', (mode) => {
+    const withC = withCwKeyer(base);
+    const model = {
+      ...withC,
+      cwKeyer: { ...withC.cwKeyer, breakIn: { reading: { status: 'known', value: mode }, availability: AVAIL } },
+    };
+    expect(validateRadioViewModel(model).cwKeyer?.breakIn.reading).toEqual({ status: 'known', value: mode });
+  });
+
+  it('accepts an unknown reading distinct from a known one, independently per field', () => {
+    const withC = withCwKeyer(base);
+    const partial = {
+      ...withC,
+      cwKeyer: { ...withC.cwKeyer, apf: { reading: { status: 'unknown' }, availability: OFF } },
+    };
+    const validated = validateRadioViewModel(partial);
+    expect(validated.cwKeyer?.apf).toEqual({ reading: { status: 'unknown' }, availability: OFF });
+    expect(validated.cwKeyer?.pitchHz.reading).toEqual({ status: 'known', value: 600 });
+  });
+
+  it('rejects an unknown extra key inside cwKeyer', () => {
+    const withC = withCwKeyer(base);
+    expect(() => validateRadioViewModel({ ...base, cwKeyer: { ...withC.cwKeyer, bogus: 1 } })).toThrow(TypeError);
+  });
+
+  it('rejects an unknown extra key inside a single cwKeyer field', () => {
+    const withC = withCwKeyer(base);
+    const malformed = {
+      ...withC,
+      cwKeyer: {
+        ...withC.cwKeyer,
+        reversePaddle: { reading: { status: 'known', value: false }, availability: AVAIL, extra: true },
+      },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(TypeError);
+  });
+
+  it('rejects a reading that carries a value key while unknown', () => {
+    const withC = withCwKeyer(base);
+    const malformed = {
+      ...withC,
+      cwKeyer: { ...withC.cwKeyer, breakIn: { reading: { status: 'unknown', value: 'full' }, availability: AVAIL } },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(TypeError);
+  });
+
+  it('rejects a cwKeyer group missing a key (no partial 9A shape survives)', () => {
+    const withC = withCwKeyer(base);
+    const { apf: _apf, ...withoutApf } = withC.cwKeyer as CwKeyerViewModel;
+    expect(() => validateRadioViewModel({ ...withC, cwKeyer: withoutApf })).toThrow(TypeError);
+  });
+
+  it('every field of a fully-populated group round-trips its own value', () => {
+    const validated = validateRadioViewModel(withCwKeyer(base)).cwKeyer as CwKeyerViewModel;
+    const knownValue = <T>(f: CwKeyerField<T>): T | undefined =>
+      f.reading.status === 'known' ? f.reading.value : undefined;
+    expect(knownValue(validated.breakIn)).toBe('semi');
+    expect(knownValue(validated.breakInDelay)).toBe(64);
+    expect(knownValue(validated.keyerSpeed)).toBe(24);
+    expect(knownValue(validated.pitchHz)).toBe(600);
+    expect(knownValue(validated.reversePaddle)).toBe(false);
+    expect(knownValue(validated.apf)).toBe(0);
+    expect(knownValue(validated.twinPeak)).toBe(false);
+  });
+});
+
+/**
+ * SAFETY CONSTRAINTS 2 + 3, enforced structurally by the contract itself: a
+ * producer cannot ship a usable break-in fact while dropping the record that
+ * TX is not permitted. This is the CW analogue of MOR-1294's band invariant,
+ * and it is what makes "no second permit" checkable — the only permit in play
+ * is the model's own `txPermit`.
+ */
+describe('cwKeyer break-in / txPermit fail-closed invariant (MOR-1296)', () => {
+  const armed = withCwKeyer(base);
+
+  it.each([
+    ['denied', { status: 'denied', reason: 'outside-configured-ranges' }],
+    ['unknown (ranges unconfigured)', { status: 'unknown', reason: 'ranges-unconfigured' }],
+    ['unknown (tx target unknown)', { status: 'unknown', reason: 'tx-target-unknown' }],
+  ] as const)(
+    'rejects a structurally-available breakIn under a %s txPermit with no cwKeyer.breakIn disabled reason',
+    (_label, txPermit) => {
+      const model = {
+        ...armed,
+        txTarget: { status: 'unknown', reason: 'not-observed' },
+        txPermit,
+        vfos: armed.vfos.map((vfo) => ({ ...vfo, isTxTarget: false })),
+        disabledReasons: [],
+      };
+      expect(() => validateRadioViewModel(model)).toThrow(/cwKeyer\.breakIn/);
+    },
+  );
+
+  it('accepts the same model once the disabled reason is recorded', () => {
+    const model = {
+      ...armed,
+      txTarget: { status: 'unknown', reason: 'not-observed' },
+      txPermit: { status: 'unknown', reason: 'tx-target-unknown' },
+      vfos: armed.vfos.map((vfo) => ({ ...vfo, isTxTarget: false })),
+      disabledReasons: [{ field: 'cwKeyer.breakIn', code: 'tx-target-unknown' }],
+    };
+    expect(validateRadioViewModel(model).cwKeyer?.breakIn.reading).toEqual({ status: 'known', value: 'semi' });
+  });
+
+  it('needs no reason when txPermit is positively allowed', () => {
+    expect(base.txPermit.status).toBe('allowed');
+    expect(() => validateRadioViewModel(armed)).not.toThrow();
+    expect(armed.disabledReasons).toEqual([]);
+  });
+
+  it('needs no reason when break-in is structurally absent — nothing to key with', () => {
+    const model = {
+      ...armed,
+      txTarget: { status: 'unknown', reason: 'not-observed' },
+      txPermit: { status: 'unknown', reason: 'tx-target-unknown' },
+      vfos: armed.vfos.map((vfo) => ({ ...vfo, isTxTarget: false })),
+      disabledReasons: [],
+      cwKeyer: { ...armed.cwKeyer, breakIn: { reading: { status: 'unknown' }, availability: OFF } },
+    };
+    expect(() => validateRadioViewModel(model)).not.toThrow();
+  });
+
+  it('an UNKNOWN break-in reading is still gated — unobserved is not evidence the key is safe', () => {
+    const model = {
+      ...armed,
+      txTarget: { status: 'unknown', reason: 'not-observed' },
+      txPermit: { status: 'unknown', reason: 'tx-target-unknown' },
+      vfos: armed.vfos.map((vfo) => ({ ...vfo, isTxTarget: false })),
+      disabledReasons: [],
+      cwKeyer: {
+        ...armed.cwKeyer,
+        breakIn: { reading: { status: 'unknown' }, availability: { structural: true, operational: false } },
+      },
+    };
+    expect(() => validateRadioViewModel(model)).toThrow(/cwKeyer\.breakIn/);
+  });
+});

--- a/frontend/src/semantic/__tests__/optional-group-allow-list.test.ts
+++ b/frontend/src/semantic/__tests__/optional-group-allow-list.test.ts
@@ -42,11 +42,11 @@ const REQUIRED_KEYS = [
 
 /** MOR-1244: txAux. MOR-1262 slice 2A: meters. Slice 3A: rxAudio. Slice 4A:
  *  modeFilter. Slice 4A′: filterPassband. Slice 5A: dsp. Slice 6A: rfFrontEnd.
- *  Slice 7A: band. Slice 8A: ritXit, antenna, scan. Add your key here when
- *  your family's slice lands. */
+ *  Slice 7A: band. Slice 8A: ritXit, antenna, scan. Slice 9A: cwKeyer. Add
+ *  your key here when your family's slice lands. */
 const EXPECTED_OPTIONAL_GROUP_KEYS = [
   'txAux', 'meters', 'rxAudio', 'modeFilter', 'filterPassband', 'dsp', 'rfFrontEnd', 'band',
-  'ritXit', 'antenna', 'scan',
+  'ritXit', 'antenna', 'scan', 'cwKeyer',
 ] as const;
 
 function extractTopLevelAllowList(): string[] {

--- a/frontend/src/semantic/fixtures/topologies.ts
+++ b/frontend/src/semantic/fixtures/topologies.ts
@@ -15,7 +15,7 @@
  */
 import type {
   AntennaField, AntennaViewModel,
-  Availability, BandField, BandViewModel,
+  Availability, BandField, BandViewModel, CwKeyerField, CwKeyerViewModel,
   DspField, DspViewModel, FilterPassbandField, FilterPassbandViewModel,
   MeterField, MeterRfState, MetersViewModel,
   ModeFilterField, ModeFilterViewModel,
@@ -420,6 +420,36 @@ export function withAntenna(fixture: RadioViewModel): RadioViewModel {
  * topology fixture — same composable-axis story as `withBand`/
  * `withRfFrontEnd` above.
  */
+/**
+ * Applies a fully-observed `cwKeyer` group (MOR-1262 slice 9A, MOR-1296) to
+ * any topology fixture — same composable-axis story as `withScan`/`withBand`
+ * above, with one SAFETY-CRITICAL difference it cannot opt out of: break-in
+ * keys the transmitter, and `validateRadioViewModel` rejects a model carrying
+ * a structurally-available `breakIn` under a non-`'allowed'` `txPermit`
+ * unless the matching `disabledReasons` entry is present. So this helper adds
+ * that entry for exactly the fixtures that need it (`1/ab`, whose txPermit is
+ * unknown), rather than quietly weakening the invariant to keep a fixture
+ * valid. `breakIn` is `'semi'`, not `'off'`: a fixture whose keyer is idle
+ * would make every fail-closed consumer path unobservable.
+ */
+export function withCwKeyer(fixture: RadioViewModel): RadioViewModel {
+  const avail: Availability = { structural: true, operational: true };
+  const known = <T>(value: T): CwKeyerField<T> => ({ reading: { status: 'known', value }, availability: avail });
+  const cwKeyer: CwKeyerViewModel = {
+    breakIn: known('semi'),
+    breakInDelay: known(64),
+    keyerSpeed: known(24),
+    pitchHz: known(600),
+    reversePaddle: known(false),
+    apf: known(0),
+    twinPeak: known(false),
+  };
+  const disabledReasons = fixture.txPermit.status === 'allowed'
+    ? fixture.disabledReasons
+    : [...fixture.disabledReasons, { field: 'cwKeyer.breakIn', code: 'tx-target-unknown' as const }];
+  return { ...fixture, cwKeyer, disabledReasons };
+}
+
 export function withScan(fixture: RadioViewModel): RadioViewModel {
   const avail: Availability = { structural: true, operational: true };
   const known = <T>(value: T): ScanField<T> => ({ reading: { status: 'known', value }, availability: avail });

--- a/frontend/src/semantic/radio-view-model.ts
+++ b/frontend/src/semantic/radio-view-model.ts
@@ -645,6 +645,87 @@ export interface ScanViewModel {
   scanResumeMode: ScanField<number>;
 }
 
+/**
+ * A single CW-keyer fact (MOR-1262 decomposition slice 9A, MOR-1296).
+ * Shape-identical to `TxAuxField`, declared as an alias for the same reason
+ * `ScanField`/`AntennaField`/`RitXitField`/`BandField` are.
+ */
+export type CwKeyerField<T> = TxAuxField<T>;
+
+/**
+ * Break-in state as a THREE-VALUED fact, never a boolean and never an int.
+ * `off` = the key does not transmit; `semi` = keying transmits with a
+ * hang-time (the delay fact below applies); `full` = QSK, the key transmits
+ * immediately. The shipped v2 wire encoding is an int (`ServerStatePublic.
+ * breakIn`, 0/1/2 — `components-v2/panels/cw-panel-logic.ts`'s
+ * `BREAK_IN_LABELS`), decoded ONCE in `radio-view-model-adapter.ts`'s
+ * `breakInMode`; an int this contract does not recognise decodes to the
+ * field's `unknown` reading, where v2's `formatBreakIn` falls back to 'OFF'.
+ * That difference is deliberate and is the whole point of the type: an
+ * unreadable break-in state must never present as "the key is safe".
+ */
+export type BreakInMode = 'off' | 'semi' | 'full';
+
+/**
+ * CW-keyer facts (MOR-1262 decomposition slice 9A, MOR-1296) — SAFETY-CRITICAL.
+ *
+ * FACTS ONLY, and here that phrase carries more weight than in any previous
+ * family: break-in KEYS THE TRANSMITTER. This group carries the READ state of
+ * the keyer and nothing else — no toggle, no action, no command vocabulary,
+ * not even a label table. `CwPanel.svelte`'s AUTO TUNE button (`cw_auto_tune`,
+ * a transmit-causing action) has no representation here at all, the same way
+ * `txAux` carries ATU *state* but never an ATU TUNE control (MOR-1244).
+ * Constructing, validating or serializing this group must not be able to key
+ * the radio; that is pinned by `__tests__/cw-keyer-purity.test.ts`, not merely
+ * asserted here.
+ *
+ * NO SECOND PERMIT. This group states no TX permission of its own. "May
+ * arming break-in cause the transmitter to key" is answered by the model's
+ * ONE existing `RadioViewModel.txPermit` (produced by `deriveTxCapabilities`,
+ * the same derivation the App TX authority uses — safety invariant R9: TX
+ * truth never comes from `radioState.ptt`), surfaced for this family through
+ * the existing `disabledReasons` home with `field: 'cwKeyer.breakIn'` — the
+ * MOR-1293 ruling that a cross-field disable is a `disabledReasons` entry, not
+ * a bespoke boolean, applied to the safety-critical case. A second permit
+ * field here — or any re-derivation of `getFrequencyPermit` in the CW path —
+ * is the forbidden defect, and `validateRadioViewModel` enforces the
+ * fail-closed half structurally: a model that carries a structurally-available
+ * `breakIn` while `txPermit` is anything other than `'allowed'` is REJECTED
+ * unless it also records that disabled reason.
+ *
+ * THE APF/TPF MUTEX (MOR-479 lineage, MOR-1293 precedent). `toCwProps`
+ * (`lib/runtime/props/panel-props.ts`) disables APF outside CW/CW-R and TPF
+ * outside RTTY/RTTY-R, in its own words "mirrors the MOR-479 preamp mutex".
+ * Same treatment as the DIGI-SEL/PREAMP mutex: no bespoke `apfDisabled`/
+ * `tpfDisabled` booleans here, one `disabledReasons` entry each with the
+ * generic `'mutually-exclusive-control'` code, and FAIL-CLOSED on an unknown
+ * mode (see `radio-view-model-adapter.ts`'s `deriveCwKeyerReasons`).
+ *
+ * Family enumeration is explicit and CLOSED. Three facts the shipped
+ * `CwProps` exposes are deliberately ABSENT because they belong to families
+ * this slice must not duplicate or fabricate:
+ *  - `sidetoneLevel` IS `txAux.monitorLevel` (`state.monitorGain`, family 1);
+ *  - `currentMode` IS `modeFilter.currentMode` (family 4) — the mutex above
+ *    READS that fact rather than re-reading `rx.mode` a second time;
+ *  - `keyerType` has no state field at all in v2 (`toCwProps` hard-codes 0
+ *    while `set_keyer_type` is write-only), so there is no fact to state and
+ *    a placeholder would be exactly the fabrication this contract forbids.
+ * `pitchHz` covers `cwPitch` and `sidetonePitch` together: both shipped props
+ * read the one `state.cwPitch` register, so this is one fact, not two.
+ */
+export interface CwKeyerViewModel {
+  breakIn: CwKeyerField<BreakInMode>;
+  breakInDelay: CwKeyerField<number>;
+  /** Keyer speed in WPM (`state.keySpeed`); `unknown`, never v2's 12. */
+  keyerSpeed: CwKeyerField<number>;
+  /** CW pitch / sidetone pitch in Hz (`state.cwPitch`); `unknown`, never 600. */
+  pitchHz: CwKeyerField<number>;
+  reversePaddle: CwKeyerField<boolean>;
+  /** Audio peak filter type/level ordinal (`rx.apfTypeLevel`, 0 = off). */
+  apf: CwKeyerField<number>;
+  twinPeak: CwKeyerField<boolean>;
+}
+
 export interface RadioViewModel {
   topologyId: string;
   vfoScheme: VfoScheme;
@@ -703,6 +784,10 @@ export interface RadioViewModel {
    *  scanning/scanType/scanResumeMode — see `radio-view-model-adapter.ts`'s
    *  `deriveScan`. */
   readonly scan?: ScanViewModel;
+  /** Absent (MOR-1264 optional group) ⇒ this radio declares no `cw`
+   *  capability, so v2 renders no CW panel at all — see
+   *  `radio-view-model-adapter.ts`'s `deriveCwKeyer`. */
+  readonly cwKeyer?: CwKeyerViewModel;
 }
 
 const RECEIVER_IDS: readonly ReceiverId[] = ['MAIN', 'SUB'];
@@ -1187,6 +1272,26 @@ function validateScan(value: unknown, path: string): ScanViewModel {
   };
 }
 
+const BREAK_IN_MODES: readonly BreakInMode[] = ['off', 'semi', 'full'];
+
+/** Exactly the seven facts the adapter reads. See
+ *  `radio-view-model-adapter.ts::deriveCwKeyer`. */
+function validateCwKeyer(value: unknown, path: string): CwKeyerViewModel {
+  const v = record(value, path);
+  exactKeys(v, [
+    'breakIn', 'breakInDelay', 'keyerSpeed', 'pitchHz', 'reversePaddle', 'apf', 'twinPeak',
+  ], path);
+  return {
+    breakIn: validateTxAuxField(v.breakIn, `${path}.breakIn`, (val, p) => oneOf(val, BREAK_IN_MODES, p)),
+    breakInDelay: validateTxAuxField(v.breakInDelay, `${path}.breakInDelay`, num),
+    keyerSpeed: validateTxAuxField(v.keyerSpeed, `${path}.keyerSpeed`, num),
+    pitchHz: validateTxAuxField(v.pitchHz, `${path}.pitchHz`, num),
+    reversePaddle: validateTxAuxField(v.reversePaddle, `${path}.reversePaddle`, bool),
+    apf: validateTxAuxField(v.apf, `${path}.apf`, num),
+    twinPeak: validateTxAuxField(v.twinPeak, `${path}.twinPeak`, bool),
+  };
+}
+
 /** Runtime validator (repo idiom: throws TypeError with a `$.path`, see `validateCapabilities`).
  *  Also enforces two cross-field invariants (review cycle 1, V1): `txPermit`
  *  cannot be 'allowed' while `txTarget` is unknown (no fail-open), and
@@ -1196,7 +1301,7 @@ export function validateRadioViewModel(value: unknown): RadioViewModel {
   exactKeys(v, [
     'topologyId', 'vfoScheme', 'activeReceiver', 'vfos', 'split', 'dualWatch',
     'txTarget', 'txPermit', 'scope', 'disabledReasons', 'txAux', 'meters', 'rxAudio', 'modeFilter',
-    'filterPassband', 'dsp', 'rfFrontEnd', 'band', 'ritXit', 'antenna', 'scan',
+    'filterPassband', 'dsp', 'rfFrontEnd', 'band', 'ritXit', 'antenna', 'scan', 'cwKeyer',
   ], '$');
   if (!Array.isArray(v.vfos)) invalid('$.vfos', 'an array');
   if (!Array.isArray(v.disabledReasons)) invalid('$.disabledReasons', 'an array');
@@ -1235,6 +1340,21 @@ export function validateRadioViewModel(value: unknown): RadioViewModel {
   const ritXit = optionalGroup(v.ritXit, '$.ritXit', validateRitXit);
   const antenna = optionalGroup(v.antenna, '$.antenna', validateAntenna);
   const scan = optionalGroup(v.scan, '$.scan', validateScan);
+  const cwKeyer = optionalGroup(v.cwKeyer, '$.cwKeyer', validateCwKeyer);
+
+  const disabledReasons = v.disabledReasons.map((r, i) => validateDisabledReason(r, `$.disabledReasons[${i}]`));
+  // SAFETY, MOR-1296 — the fail-closed half of "no second permit", enforced
+  // structurally rather than left to the adapter. Break-in keys the
+  // transmitter, so a model that presents a structurally-available break-in
+  // fact while the model's ONE `txPermit` is anything other than 'allowed'
+  // must ALSO record that the affordance is disabled. Same shape as the
+  // `band` invariant above (MOR-1294): a producer cannot ship the permissive
+  // half of a TX-adjacent pair while silently dropping the restrictive half.
+  if (cwKeyer !== undefined && cwKeyer.breakIn.availability.structural
+    && txPermit.status !== 'allowed'
+    && !disabledReasons.some((r) => r.field === 'cwKeyer.breakIn')) {
+    invalid('$.disabledReasons', "a 'cwKeyer.breakIn' entry whenever txPermit is not 'allowed' (fail-open otherwise)");
+  }
 
   return {
     topologyId: str(v.topologyId, '$.topologyId'),
@@ -1249,7 +1369,7 @@ export function validateRadioViewModel(value: unknown): RadioViewModel {
       hardwareScope: validateAvailability(scope.hardwareScope, '$.scope.hardwareScope'),
       audioFftScope: validateAvailability(scope.audioFftScope, '$.scope.audioFftScope'),
     },
-    disabledReasons: v.disabledReasons.map((r, i) => validateDisabledReason(r, `$.disabledReasons[${i}]`)),
+    disabledReasons,
     ...(txAux !== undefined ? { txAux } : {}),
     ...(meters !== undefined ? { meters } : {}),
     ...(rxAudio !== undefined ? { rxAudio } : {}),
@@ -1261,5 +1381,6 @@ export function validateRadioViewModel(value: unknown): RadioViewModel {
     ...(ritXit !== undefined ? { ritXit } : {}),
     ...(antenna !== undefined ? { antenna } : {}),
     ...(scan !== undefined ? { scan } : {}),
+    ...(cwKeyer !== undefined ? { cwKeyer } : {}),
   };
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -96,6 +96,11 @@ export default defineConfig({
             // both shared-state shapes that are order-dependent under
             // ``isolate: false``. See MOR-1272.
             'src/lib/runtime/adapters/__tests__/rx-audio-purity.test.ts',
+            // MOR-1262 slice 9A: same shape as the 3A entry above — module-scope
+            // ``vi.mock`` of ws-client, whose hoisted mock must be authoritative
+            // for the "the CW fact group is not a key path" pins to mean
+            // anything (SAFETY: break-in keys the transmitter). See MOR-1272.
+            'src/lib/runtime/adapters/__tests__/cw-keyer-purity.test.ts',
             // MOR-1262 slice 4A′: calls the REAL ``setCapabilities``
             // (``$lib/stores/capabilities.svelte``, no ``vi.mock``) to install
             // a non-default PBT control range for the filter-passband parity
@@ -224,6 +229,7 @@ export default defineConfig({
             'src/components-v2/panels/lcd/__tests__/audio-fft-demand.test.ts',
             'src/lib/utils/__tests__/smoothing.svelte.test.ts',
             'src/lib/runtime/adapters/__tests__/rx-audio-purity.test.ts',
+            'src/lib/runtime/adapters/__tests__/cw-keyer-purity.test.ts',
             'src/lib/runtime/adapters/__tests__/filter-passband-adapter.test.ts',
             'src/lib/runtime/adapters/__tests__/dsp-adapter.test.ts',
             'src/presentation/workspace/__tests__/purity.test.ts',


### PR DESCRIPTION
## Summary
Vocabulary slice 9A (SAFETY-CRITICAL — break-in keys the transmitter): optional `cwKeyer` group — `breakIn` tri-state, `breakInDelay`, `keyerSpeed`, `pitchHz`, `reversePaddle`, `apf` (ordinal — v2's type/level would be lost in a boolean), `twinPeak` — gated on v2's single `hasCap('cw')` (verified at all three v2 gate sites). Net production LOC **90** strict / 231 raw (verifier re-measured; ≤200).

**Safety properties, each adversarially pinned:** the facts create NO key path — purity battery pins zero command emission at load AND behaviourally over an ARMED full-QSK, permit-allowed model (the verifier's own armed-corner injection — a command reachable only when breakIn='full' ∧ permit allowed — was killed by the behavioural pins, not just the verb scan); NO second permit derivation (the permit arrives as the model's existing live-frequency `txPermit` fact; a re-derivation mutation dies); unknown break-in never reads 'off' (v2's OFF fallback divergence documented + pinned, 1293 pattern); unknown/absent mode disables APF and TPF; and the validator REJECTS a structurally-available break-in under a non-allowed permit with no recorded reason (mirrors 7A's band invariant — a producer cannot ship that state).

Single-home absences (verifier-ruled sound, 8A ATU precedent): sidetone = `txAux.monitorLevel`; mode = `modeFilter.currentMode` (the APF/TPF mutex CONSUMES that fact, never re-reads rx.mode); `keyerType` verified absent from ServerStatePublic (write-only in v2 — a placeholder would fabricate); AUTO TUNE is a transmit-causing action, not a fact. 9B carry-forwards recorded: TPF is RTTY-only inside the CW group (render its reason); break-in disabled on unknown permit is deliberate over-disable (render, don't fix).

## Review provenance
Opus builder → independent opus vocabulary-domain verifier (18th ticket in domain): **PASS, no findings requiring action** — builder's own battery 11/11 plus the verifier's K1 armed-corner injection (killed 5, behaviourally), K2 permit re-derivation (killed 3), F1 off-fallback (killed 2), V1 validator-invariant deletion (killed 4), C1 exactKeys (killed 59). Determinism sweep clean; A-queue clean; fail-set identical to baseline (+79 passing); lint/boundaries/check clean; merge clean.

Linear: MOR-1296

🤖 Generated with [Claude Code](https://claude.com/claude-code)