### PR TITLE
feat(MOR-1080): workspace settings panel — selection UI (stage a of 3)

### DIFF
--- a/frontend/src/components-v2/controls/WorkspaceSettingsPanel.svelte
+++ b/frontend/src/components-v2/controls/WorkspaceSettingsPanel.svelte
@@ -1,0 +1,103 @@
+<script lang="ts">
+  /**
+   * MOR-1080a — workspace selection UI: layout / design language / theme.
+   *
+   * Enumerates ONLY the ids the workspace validator itself pins
+   * (`WORKSPACE_LAYOUT_IDS` / `WORKSPACE_DESIGN_LANGUAGE_IDS` /
+   * `WORKSPACE_THEME_IDS` from `contract.ts`, the MOR-1077 precedent) — never
+   * a hand-rolled list, so a selectable id can never drift from what the
+   * store accepts. Theme writes route through `theme-switcher.ts` (not the
+   * store directly) so the DOM `data-theme` attribute stays in sync, exactly
+   * like the existing `ThemePicker`.
+   *
+   * The discard/repair notice and recoverable reset land in the follow-up
+   * MOR-1080c; import/export is the sibling `WorkspaceImportExport.svelte`
+   * landing in MOR-1080b — both split out to keep this file inside the
+   * frozen strict-LOC guardrail (owner ruling on MOR-1080's F1 finding).
+   */
+  import { getWorkspace, setDesignLanguage, setLayout } from '../../presentation/workspace/store.svelte';
+  import {
+    WORKSPACE_DESIGN_LANGUAGE_IDS, WORKSPACE_LAYOUT_IDS, WORKSPACE_THEME_IDS,
+    type WorkspaceDesignLanguageId, type WorkspaceLayoutId, type WorkspaceThemeId,
+  } from '../../presentation/workspace/contract';
+  import { getAvailableThemes, setThemeUserChoice } from '../theme/theme-switcher';
+  import { t } from '$lib/i18n';
+
+  const workspace = $derived(getWorkspace());
+  const themeNames = new Map(getAvailableThemes().map((th) => [th.id, th.name]));
+
+  function humanize(id: string): string {
+    return id.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+  }
+
+  function handleLayoutChange(ev: Event): void {
+    setLayout((ev.currentTarget as HTMLSelectElement).value as WorkspaceLayoutId);
+  }
+  function handleLanguageChange(ev: Event): void {
+    setDesignLanguage((ev.currentTarget as HTMLSelectElement).value as WorkspaceDesignLanguageId);
+  }
+  function handleThemeChange(ev: Event): void {
+    setThemeUserChoice((ev.currentTarget as HTMLSelectElement).value as WorkspaceThemeId);
+  }
+</script>
+
+<div class="ws-panel" data-testid="workspace-settings-panel">
+  <label class="ws-row">
+    <span>{t('core.settings.workspace.layoutLabel')}</span>
+    <select data-testid="workspace-layout-select" value={workspace.layout} onchange={handleLayoutChange}>
+      {#each WORKSPACE_LAYOUT_IDS as id (id)}
+        <option value={id}>{humanize(id)}</option>
+      {/each}
+    </select>
+  </label>
+
+  <label class="ws-row">
+    <span>{t('core.settings.workspace.designLanguageLabel')}</span>
+    <select data-testid="workspace-language-select" value={workspace.designLanguage} onchange={handleLanguageChange}>
+      {#each WORKSPACE_DESIGN_LANGUAGE_IDS as id (id)}
+        <option value={id}>{humanize(id)}</option>
+      {/each}
+    </select>
+  </label>
+
+  <label class="ws-row">
+    <span>{t('core.settings.workspace.themeLabel')}</span>
+    <select data-testid="workspace-theme-select" value={workspace.theme} onchange={handleThemeChange}>
+      {#each WORKSPACE_THEME_IDS as id (id)}
+        <option value={id}>{themeNames.get(id) ?? humanize(id)}</option>
+      {/each}
+    </select>
+  </label>
+</div>
+
+<style>
+  .ws-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 8px 4px;
+    font-family: 'Roboto Mono', monospace;
+  }
+  .ws-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    font-size: 11px;
+    color: var(--v2-text-secondary, #aaa);
+  }
+  .ws-row select {
+    min-width: 180px;
+    padding: 5px 8px;
+    background: var(--v2-bg-input, #1a1a2e);
+    border: 1px solid var(--v2-border, #2a2a3e);
+    border-radius: 3px;
+    color: var(--v2-text-primary, #fff);
+    font-family: inherit;
+    font-size: 12px;
+  }
+  .ws-row select:focus-visible {
+    outline: var(--v2-focus-ring);
+    outline-offset: 2px;
+  }
+</style>

--- a/frontend/src/components-v2/controls/__tests__/WorkspaceSettingsPanel.test.ts
+++ b/frontend/src/components-v2/controls/__tests__/WorkspaceSettingsPanel.test.ts
@@ -1,0 +1,130 @@
+/**
+ * MOR-1080a — the workspace selection surface: layout / design language /
+ * theme pickers enumerate only the ids the workspace validator itself pins.
+ * The discard/repair notice and recoverable reset are pinned in the follow-up
+ * MOR-1080c's extension of this file; import/export gets its own test file
+ * in MOR-1080b.
+ *
+ * Storage is injected (`initWorkspaceStore(fake)`), no module is
+ * `vi.mock`-ed, and no global is stubbed, so this file stays in the fast
+ * pool per the MOR-1272 doctrine (see `store.test.ts`).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mount, unmount, flushSync, tick } from 'svelte';
+import WorkspaceSettingsPanel from '../WorkspaceSettingsPanel.svelte';
+import { getWorkspace, initWorkspaceStore, setDesignLanguage, setLayout, setTheme } from '../../../presentation/workspace/store.svelte';
+import { WORKSPACE_DESIGN_LANGUAGE_IDS, WORKSPACE_LAYOUT_IDS, WORKSPACE_THEME_IDS } from '../../../presentation/workspace/contract';
+import enUS from '$lib/i18n/locales/en-US.json' with { type: 'json' };
+
+class FakeStorage {
+  readonly map = new Map<string, string>();
+  getItem(key: string): string | null {
+    return this.map.has(key) ? this.map.get(key)! : null;
+  }
+  setItem(key: string, value: string): void {
+    this.map.set(key, value);
+  }
+}
+
+let storage: FakeStorage;
+
+function setup() {
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+  const component = mount(WorkspaceSettingsPanel, { target });
+  flushSync();
+  return { target, component };
+}
+
+beforeEach(() => {
+  storage = new FakeStorage();
+  initWorkspaceStore(storage);
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  delete document.documentElement.dataset.theme;
+});
+
+describe('WorkspaceSettingsPanel (MOR-1080a)', () => {
+  it('enumerates exactly the registered layout ids, in order', () => {
+    const { target, component } = setup();
+    const sel = target.querySelector('[data-testid="workspace-layout-select"]') as HTMLSelectElement;
+    expect(Array.from(sel.options).map((o) => o.value)).toEqual([...WORKSPACE_LAYOUT_IDS]);
+    unmount(component);
+  });
+
+  it('enumerates exactly the registered design-language ids, in order', () => {
+    const { target, component } = setup();
+    const sel = target.querySelector('[data-testid="workspace-language-select"]') as HTMLSelectElement;
+    expect(Array.from(sel.options).map((o) => o.value)).toEqual([...WORKSPACE_DESIGN_LANGUAGE_IDS]);
+    unmount(component);
+  });
+
+  it('enumerates exactly the registered theme ids, in order', () => {
+    const { target, component } = setup();
+    const sel = target.querySelector('[data-testid="workspace-theme-select"]') as HTMLSelectElement;
+    expect(Array.from(sel.options).map((o) => o.value)).toEqual([...WORKSPACE_THEME_IDS]);
+    unmount(component);
+  });
+
+  it('reflects the current workspace values in each select', () => {
+    setLayout('lcd-scope');
+    setDesignLanguage('fieldline');
+    setTheme('nord', true);
+
+    const { target, component } = setup();
+
+    expect((target.querySelector('[data-testid="workspace-layout-select"]') as HTMLSelectElement).value).toBe('lcd-scope');
+    expect((target.querySelector('[data-testid="workspace-language-select"]') as HTMLSelectElement).value).toBe('fieldline');
+    expect((target.querySelector('[data-testid="workspace-theme-select"]') as HTMLSelectElement).value).toBe('nord');
+    unmount(component);
+  });
+
+  it('every select is wrapped in a <label> with visible text', () => {
+    const { target, component } = setup();
+    for (const testid of ['workspace-layout-select', 'workspace-language-select', 'workspace-theme-select']) {
+      const sel = target.querySelector(`[data-testid="${testid}"]`) as HTMLSelectElement;
+      const label = sel.closest('label');
+      expect(label, `${testid} must be inside a <label>`).not.toBeNull();
+      expect(label!.textContent?.trim().length).toBeGreaterThan(0);
+    }
+    unmount(component);
+  });
+
+  it('changing the layout select writes through the store', async () => {
+    const { target, component } = setup();
+    const sel = target.querySelector('[data-testid="workspace-layout-select"]') as HTMLSelectElement;
+
+    sel.value = 'standard';
+    sel.dispatchEvent(new Event('change', { bubbles: true }));
+    flushSync();
+    await tick();
+
+    expect(getWorkspace().layout).toBe('standard');
+    unmount(component);
+  });
+
+  it('changing the theme select writes through the store AND applies the DOM attribute', async () => {
+    const { target, component } = setup();
+    const sel = target.querySelector('[data-testid="workspace-theme-select"]') as HTMLSelectElement;
+
+    sel.value = 'crt-green';
+    sel.dispatchEvent(new Event('change', { bubbles: true }));
+    flushSync();
+    await tick();
+
+    expect(getWorkspace().theme).toBe('crt-green');
+    expect(document.documentElement.dataset.theme).toBe('crt-green');
+    unmount(component);
+  });
+
+  it('catalog source ships every key the component reads', () => {
+    const required = [
+      'core.settings.workspace.layoutLabel', 'core.settings.workspace.designLanguageLabel',
+      'core.settings.workspace.themeLabel',
+    ];
+    const catalog = enUS as Record<string, unknown>;
+    for (const key of required) expect(catalog[key], `en-US missing ${key}`).toBeTypeOf('string');
+  });
+});

--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -48,6 +48,7 @@
   import CollapsiblePanel from '../controls/CollapsiblePanel.svelte';
   import BandSelector from '../controls/BandSelector.svelte';
   import LanguageSelector from '../controls/LanguageSelector.svelte';
+  import WorkspaceSettingsPanel from '../controls/WorkspaceSettingsPanel.svelte';
   import DspPanel from '../panels/DspPanel.svelte';
   import AgcPanel from '../panels/AgcPanel.svelte';
   import RfFrontEnd from '../panels/RfFrontEnd.svelte';
@@ -306,6 +307,10 @@
       <div class="settings-content">
         <CollapsiblePanel title="LANGUAGE" panelId="desktop-language">
           <LanguageSelector />
+        </CollapsiblePanel>
+
+        <CollapsiblePanel title="WORKSPACE" panelId="desktop-workspace">
+          <WorkspaceSettingsPanel />
         </CollapsiblePanel>
 
         <CollapsiblePanel title="VFO / BAND" panelId="desktop-vfo-ops">

--- a/frontend/src/lib/i18n/locales/en-US.json
+++ b/frontend/src/lib/i18n/locales/en-US.json
@@ -73,6 +73,11 @@
   "core.settings.language.srHint": "Selecting a language updates the UI immediately and is saved on this device.",
   "core.settings.language.devLocaleSuffix": "developer pseudo-locale",
 
+  "core.settings.workspace.title": "Workspace",
+  "core.settings.workspace.layoutLabel": "Layout",
+  "core.settings.workspace.designLanguageLabel": "Design language",
+  "core.settings.workspace.themeLabel": "Theme",
+
   "core.overlay.poweredOff.label": "Radio is powered off",
   "core.overlay.poweredOff.hint": "Use the ON button in the status bar to power up",
   "core.overlay.poweredOff.powerOnButton": "Power ON",


### PR DESCRIPTION
## Summary
Stage a of the owner-approved three-way landing of MOR-1080 (the verified whole measured 346 strict LOC vs the frozen ≤200 — split along the ticket's own sanctioned seam; each stage ≤200, concatenation byte-identical to the verified tree). This stage: `WorkspaceSettingsPanel.svelte` with layout/language/theme selects enumerating ONLY validator-pinned registered ids, wired into RadioLayout's existing Core Settings modal as a WORKSPACE panel (no new modal system). All mutation flows through the store's typed setters — no raw localStorage (one-writer scan holds). Strict LOC **84**.

## Review provenance
Opus verifier PASS on the complete tree (17th domain ticket): registered-ids-only confirmed against the validator's pinned literals; one-writer intact; a11y native controls + shared focus ring + existing modal pattern. The split is mechanical: final-stage tree diffed file-by-file against the verified tree + the verifier-prescribed F2 test — byte-empty. Stages: a (this) → c notice/reset → b import/export. Full reports in session scratchpad (wave-workspace/mor-1080-*.md).

Linear: MOR-1080 (stays open until stage b lands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)