### PR TITLE
chore: allow-list selection-adoption.test.ts in the rebrand grep gate

### DIFF
--- a/.github/scripts/check-rebrand-allowlist.sh
+++ b/.github/scripts/check-rebrand-allowlist.sh
@@ -91,6 +91,10 @@ ALLOWLIST=(
     # to classify and read them correctly. Read-only — the module never writes
     # or renames these keys, it only routes them.
     'frontend/src/presentation/workspace/legacy-readers.ts'
+    # MOR-1080/MOR-1081: workspace adoption tests assert the legacy-key
+    # routing behavior (reconciliation, retain-outside, sentinel names) and
+    # must therefore spell the historical key names verbatim. Test-only.
+    'frontend/src/presentation/workspace/__tests__/selection-adoption.test.ts'
 )
 
 # Collect all files matching brand pattern.


### PR DESCRIPTION
Fix-forward for the grep-gate red on main introduced by #2227 (stage a of MOR-1080): `selection-adoption.test.ts` asserts the legacy-key routing behavior (reconciliation, retain-outside) and must spell historical key names verbatim — the gate's own case-2 instruction (same class as the MOR-1078 legacy-readers entry). One file, allow-list + comment; local gate run exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)