### PR TITLE
feat(MOR-1298): scopeControls fact group (vocabulary slice 11A)

### DIFF
--- a/frontend/src/lib/runtime/adapters/__tests__/radio-view-model-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/radio-view-model-adapter.test.ts
@@ -321,7 +321,7 @@ describe('the emitted model carries only contract data', () => {
     expect(Object.keys(view)).not.toContain('capabilities');
     // The validator rejects extra keys, so this is belt-and-braces on shape.
     expect(Object.keys(view).sort()).toEqual([
-      'activeReceiver', 'disabledReasons', 'dualWatch', 'scope', 'split',
+      'activeReceiver', 'disabledReasons', 'dualWatch', 'scope', 'scopeControls', 'split',
       'topologyId', 'txPermit', 'txTarget', 'vfoScheme', 'vfos',
     ]);
   });

--- a/frontend/src/lib/runtime/adapters/__tests__/scope-controls-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/scope-controls-adapter.test.ts
@@ -1,0 +1,259 @@
+/**
+ * MOR-1262 decomposition slice 11A (MOR-1298) — `scopeControls` fact-group
+ * adapter derivation.
+ *
+ * Companion to `cw-keyer-adapter.test.ts`/`scan-adapter.test.ts`, which this
+ * file does NOT modify. `scopeControls` is a SEPARATE optional group — see
+ * `radio-view-model.ts`'s `ScopeControlsViewModel` doc comment.
+ *
+ * PARITY — this group has no extractable pure `toXProps` function to call
+ * (the real derivation is inline in `SpectrumToolbar.svelte`'s `$derived`
+ * blocks), so the pins below call the SAME `isFieldAvailable` predicate the
+ * toolbar calls for its own `scopeSpanAvailable`/`scopeSpeedAvailable`/
+ * `scopeDualAvailable`/`scopeReceiverAvailable` booleans, rather than
+ * reimplementing it. The toolbar's `scopeControls?.span ?? 3` (etc.)
+ * fallbacks are pinned as fabrication this contract deliberately diverges
+ * from — see the honesty-gate describe block.
+ */
+import { describe, expect, it } from 'vitest';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { FieldStatus, ServerState } from '$lib/types/state';
+import { isFieldAvailable } from '$lib/state/field-status';
+import { validateRadioViewModel, type RadioViewModel } from '../../../../semantic/radio-view-model';
+import { toRadioViewModel } from '../radio-view-model-adapter';
+
+function caps(overrides: Partial<Capabilities> = {}): Capabilities {
+  return {
+    model: 'fixture', scope: true, audio: true, tx: true, capabilities: ['scope', 'audio', 'tx'],
+    receivers: 1, vfoScheme: 'single', freqRanges: [], modes: [], filters: [],
+    audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
+    webrtc: { available: false, enabled: false },
+    txBands: [], scopeSource: 'hardware', audioFftAvailable: false, ...overrides,
+  } as Capabilities;
+}
+
+/** Scope-bearing, single-RX by default (mirrors IC-7300/IC-9700: `scope`
+ *  without `dual_rx`). Pass `['scope', 'dual_rx']` for the IC-7610 case. */
+function scopeCaps(tags: readonly string[] = ['scope']): Capabilities {
+  return caps({ capabilities: [...tags] });
+}
+
+const fresh: FieldStatus = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' };
+const stale: FieldStatus = { storePath: 'x', observed: true, freshness: 'stale', availability: 'stale' };
+
+function bareState(overrides: Partial<ServerState> = {}): ServerState {
+  return {
+    active: 'MAIN', split: false, dualWatch: false, ptt: false,
+    txTarget: { status: 'unknown', reason: 'not-observed' },
+    main: {
+      freqHz: 14195000, mode: 'USB', filter: 1, dataMode: 0, att: 0, preamp: 0,
+      nb: false, nr: false, afLevel: 1, rfGain: 1, squelch: 0, sMeter: 0,
+    },
+    fieldStatus: { active: fresh, split: fresh, dualWatch: fresh },
+    ...overrides,
+  } as ServerState;
+}
+
+function model(state: ServerState | null, capabilities: Capabilities | null): RadioViewModel {
+  const view = toRadioViewModel(state, capabilities);
+  expect(view).not.toBeNull();
+  return validateRadioViewModel(view);
+}
+
+describe('scopeControls evidence gate (MOR-1298, N3)', () => {
+  it('emits no scopeControls when capabilities are absent', () => {
+    expect(toRadioViewModel(bareState(), null)).toBeNull();
+  });
+
+  it('emits no scopeControls for a radio without the scope capability (regression pin)', () => {
+    const view = model(bareState(), caps({ capabilities: ['audio', 'tx'] }));
+    expect(view.scopeControls).toBeUndefined();
+    expect(Object.keys(view)).not.toContain('scopeControls');
+  });
+
+  it('emits scopeControls once the scope capability alone is declared', () => {
+    const view = model(bareState(), scopeCaps());
+    expect(view.scopeControls).toBeDefined();
+    expect(Object.keys(view.scopeControls!).sort()).toEqual(['dual', 'receiver', 'span', 'speed']);
+  });
+});
+
+describe('scopeControls per-field structural gates (MOR-1298, X6200 lesson)', () => {
+  it('span/speed stay structurally present on a scope-only, single-RX radio (IC-7300/IC-9700 shape)', () => {
+    const view = model(bareState(), scopeCaps(['scope']));
+    expect(view.scopeControls!.span.availability.structural).toBe(true);
+    expect(view.scopeControls!.speed.availability.structural).toBe(true);
+  });
+
+  it('dual/receiver are structurally absent without dual_rx — no radio-specific table, just the cap tag', () => {
+    const view = model(bareState(), scopeCaps(['scope']));
+    expect(view.scopeControls!.dual.availability.structural).toBe(false);
+    expect(view.scopeControls!.receiver.availability.structural).toBe(false);
+  });
+
+  it('dual/receiver become structurally present once dual_rx is declared alongside scope (IC-7610 shape)', () => {
+    const view = model(bareState(), scopeCaps(['scope', 'dual_rx']));
+    expect(view.scopeControls!.dual.availability.structural).toBe(true);
+    expect(view.scopeControls!.receiver.availability.structural).toBe(true);
+  });
+
+  it('no scopeControls-derived structural availability at all when the scope capability itself is missing', () => {
+    const view = model(bareState(), caps({ capabilities: ['audio', 'tx', 'dual_rx'] }));
+    expect(view.scopeControls).toBeUndefined();
+  });
+});
+
+describe('scopeControls per-field derivation (MOR-1298)', () => {
+  const fullCaps = scopeCaps(['scope', 'dual_rx']);
+
+  it('reports known readings for observed, fresh fields — parity with isFieldAvailable, the same predicate the real toolbar uses', () => {
+    const state = bareState({
+      scopeControls: {
+        receiver: 1, dual: true, mode: 0, span: 5, edge: 0, hold: false, refDb: 0, speed: 2,
+        duringTx: false, centerType: 0, vbwNarrow: false, rbw: 0,
+        fixedEdge: { rangeIndex: 0, edge: 0, startHz: 0, endHz: 0 },
+      },
+      fieldStatus: {
+        ...bareState().fieldStatus,
+        'scopeControls.span': fresh, 'scopeControls.speed': fresh,
+        'scopeControls.dual': fresh, 'scopeControls.receiver': fresh,
+      },
+    } as Partial<ServerState>);
+    const sc = model(state, fullCaps).scopeControls!;
+    expect(sc.span.reading).toEqual({ status: 'known', value: 5 });
+    expect(sc.speed.reading).toEqual({ status: 'known', value: 2 });
+    expect(sc.dual.reading).toEqual({ status: 'known', value: true });
+    expect(sc.receiver.reading).toEqual({ status: 'known', value: 1 });
+    for (const leaf of ['span', 'speed', 'dual', 'receiver'] as const) {
+      expect(sc[leaf].availability.operational).toBe(isFieldAvailable(state, `scopeControls.${leaf}`));
+    }
+  });
+
+  const STALE_FIELDS = ['span', 'speed', 'dual', 'receiver'] as const;
+
+  it.each(STALE_FIELDS)(
+    'degrades a stale scopeControls.%s to unknown while keeping structural availability true',
+    (leaf) => {
+      const state = bareState({
+        scopeControls: {
+          receiver: 1, dual: true, mode: 0, span: 4, edge: 0, hold: false, refDb: 0, speed: 1,
+          duringTx: false, centerType: 0, vbwNarrow: false, rbw: 0,
+          fixedEdge: { rangeIndex: 0, edge: 0, startHz: 0, endHz: 0 },
+        },
+        fieldStatus: { ...bareState().fieldStatus, [`scopeControls.${leaf}`]: stale },
+      } as Partial<ServerState>);
+      const field = model(state, fullCaps).scopeControls![leaf];
+      expect(field.reading).toEqual({ status: 'unknown' });
+      expect(field.availability).toEqual({ structural: true, operational: false });
+    },
+  );
+
+  it('marks dual/receiver structurally absent (never known) when dual_rx is missing, even with fresh raw data', () => {
+    const state = bareState({
+      scopeControls: {
+        receiver: 1, dual: true, mode: 0, span: 3, edge: 0, hold: false, refDb: 0, speed: 1,
+        duringTx: false, centerType: 0, vbwNarrow: false, rbw: 0,
+        fixedEdge: { rangeIndex: 0, edge: 0, startHz: 0, endHz: 0 },
+      },
+      fieldStatus: {
+        ...bareState().fieldStatus, 'scopeControls.dual': fresh, 'scopeControls.receiver': fresh,
+      },
+    } as Partial<ServerState>);
+    const sc = model(state, scopeCaps(['scope'])).scopeControls!;
+    expect(sc.dual).toEqual({ reading: { status: 'unknown' }, availability: { structural: false, operational: false } });
+    expect(sc.receiver).toEqual({ reading: { status: 'unknown' }, availability: { structural: false, operational: false } });
+  });
+
+  it('degrades a malformed raw span (wrong JS type) to unknown rather than coercing', () => {
+    const state = bareState({
+      scopeControls: {
+        receiver: 0, dual: false, mode: 0, span: '5' as unknown as number, edge: 0, hold: false,
+        refDb: 0, speed: 1, duringTx: false, centerType: 0, vbwNarrow: false, rbw: 0,
+        fixedEdge: { rangeIndex: 0, edge: 0, startHz: 0, endHz: 0 },
+      },
+      fieldStatus: { ...bareState().fieldStatus, 'scopeControls.span': fresh },
+    } as Partial<ServerState>);
+    expect(model(state, fullCaps).scopeControls!.span.reading).toEqual({ status: 'unknown' });
+  });
+
+  it('emits a validator-clean model carrying the scopeControls group (round-trip proof)', () => {
+    const state = bareState({
+      scopeControls: {
+        receiver: 0, dual: false, mode: 0, span: 3, edge: 0, hold: false, refDb: 0, speed: 1,
+        duringTx: false, centerType: 0, vbwNarrow: false, rbw: 0,
+        fixedEdge: { rangeIndex: 0, edge: 0, startHz: 0, endHz: 0 },
+      },
+      fieldStatus: { ...bareState().fieldStatus, 'scopeControls.span': fresh, 'scopeControls.speed': fresh },
+    } as Partial<ServerState>);
+    const view = model(state, fullCaps);
+    expect(JSON.parse(JSON.stringify(view))).toEqual(view);
+  });
+});
+
+/**
+ * HONESTY / FAIL-CLOSED GATE — absent raw values never fabricate the
+ * SpectrumToolbar's own `?? 3` / `?? 1` / `?? false` / `?? 0` defaults
+ * (`SpectrumToolbar.svelte` lines around its `SPAN_LABELS[scopeControls?.
+ * span ?? 3]`-style reads).
+ */
+describe('scopeControls honesty gate — absent raw values never fabricate (MOR-1298)', () => {
+  const fullCaps = scopeCaps(['scope', 'dual_rx']);
+
+  const ABSENT_CASES = [
+    ['span', 3],
+    ['speed', 1],
+    ['dual', false],
+    ['receiver', 0],
+  ] as const;
+
+  it.each(ABSENT_CASES)(
+    '%s with nothing reported at all reads unknown, not the toolbar\'s fabricated %s default',
+    (viewField) => {
+      expect(model(bareState(), fullCaps).scopeControls![viewField].reading).toEqual({ status: 'unknown' });
+    },
+  );
+
+  it('emits no false "available" reading before scope is ever enabled (no scopeControls block observed at all)', () => {
+    const state = bareState();
+    expect(state.scopeControls).toBeUndefined();
+    const sc = model(state, fullCaps).scopeControls!;
+    expect(sc.span.reading.status).toBe('unknown');
+    expect(sc.dual.reading.status).toBe('unknown');
+  });
+});
+
+/**
+ * DETERMINISM — a fact-layer value is a pure function of `(state, caps)`.
+ * Both directions: same inputs ⇒ same output, and a changed input ⇒ changed
+ * output (so the first half cannot pass by returning a constant).
+ */
+describe('scopeControls determinism in (state, caps) (MOR-1298)', () => {
+  const fullCaps = scopeCaps(['scope', 'dual_rx']);
+
+  it('is stable across repeated derivations of the same inputs', () => {
+    const state = bareState({
+      scopeControls: {
+        receiver: 1, dual: true, mode: 0, span: 6, edge: 0, hold: false, refDb: 0, speed: 0,
+        duringTx: false, centerType: 0, vbwNarrow: false, rbw: 0,
+        fixedEdge: { rangeIndex: 0, edge: 0, startHz: 0, endHz: 0 },
+      },
+      fieldStatus: { ...bareState().fieldStatus, 'scopeControls.span': fresh },
+    } as Partial<ServerState>);
+    expect(model(state, fullCaps).scopeControls).toEqual(model(state, fullCaps).scopeControls);
+  });
+
+  it('changes with state, and with caps, independently', () => {
+    const withSpan = (span: number) => bareState({
+      scopeControls: {
+        receiver: 0, dual: false, mode: 0, span, edge: 0, hold: false, refDb: 0, speed: 1,
+        duringTx: false, centerType: 0, vbwNarrow: false, rbw: 0,
+        fixedEdge: { rangeIndex: 0, edge: 0, startHz: 0, endHz: 0 },
+      },
+      fieldStatus: { ...bareState().fieldStatus, 'scopeControls.span': fresh },
+    } as Partial<ServerState>);
+    expect(model(withSpan(2), fullCaps).scopeControls!.span.reading)
+      .not.toEqual(model(withSpan(6), fullCaps).scopeControls!.span.reading);
+    expect(model(withSpan(2), fullCaps).scopeControls!.dual.availability)
+      .not.toEqual(model(withSpan(2), scopeCaps(['scope'])).scopeControls!.dual.availability);
+  });
+});

--- a/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
@@ -31,7 +31,7 @@ import type {
   AudioFocus, MonitorMode, RxAudioViewModel, ModeFilterViewModel,
   FilterPassbandViewModel, DspViewModel, RfFrontEndViewModel,
   BandChoice, BandViewModel, RitXitViewModel, AntennaViewModel, ScanViewModel,
-  BreakInMode, CwKeyerViewModel,
+  BreakInMode, CwKeyerViewModel, ScopeControlsViewModel,
 } from '../../../semantic/radio-view-model';
 import type { TxAuthoritySnapshot } from '../../../semantic/rx-tx-surface';
 import { isFieldAvailable } from '$lib/state/field-status';
@@ -922,6 +922,43 @@ function deriveCwKeyerReasons(
 }
 
 /**
+ * Scope-control facts (MOR-1262 decomposition slice 11A, MOR-1298). See
+ * `ScopeControlsViewModel`'s doc comment for the field set, the parity
+ * story against `SpectrumToolbar.svelte`'s own `scopeControls?.<leaf> ??
+ * <default>` reads, and the doubly-applied X6200 capability-gating lesson.
+ *
+ * Evidence gate (N3): `hasCap(caps, 'scope')`, the same single gate the
+ * shipped toolbar uses to render at all (`{#if hasCapability('scope')}`,
+ * three call sites in `SpectrumToolbar.svelte`) — one v2 gate, not a
+ * per-field OR-of-evidence like `deriveTxAux`, because there is no
+ * scope-adjacent state that reports independently of the `scope` capability
+ * the way TX telemetry does.
+ *
+ * `span`/`speed` are structurally available whenever the group is (every
+ * scope-bearing single-RX radio supports them); `dual`/`receiver`
+ * additionally require `hasCap(caps, 'dual_rx')` — the only generic tag
+ * available to gate "does dual-scope / receiver-select make sense here"
+ * without a radio-specific table.
+ */
+function deriveScopeControls(
+  state: ServerState | null, caps: Capabilities | null,
+): ScopeControlsViewModel | undefined {
+  if (!hasCap(caps, 'scope')) return undefined;
+  const hasReceiverSelect = hasCap(caps, 'dual_rx');
+  const sc = state?.scopeControls;
+  return {
+    span: txAuxField(true, topFieldAvailable(state, 'scopeControls.span'), numOrUndef(sc?.span)),
+    speed: txAuxField(true, topFieldAvailable(state, 'scopeControls.speed'), numOrUndef(sc?.speed)),
+    dual: txAuxField(
+      hasReceiverSelect, topFieldAvailable(state, 'scopeControls.dual'), boolOrUndef(sc?.dual),
+    ),
+    receiver: txAuxField(
+      hasReceiverSelect, topFieldAvailable(state, 'scopeControls.receiver'), numOrUndef(sc?.receiver),
+    ),
+  };
+}
+
+/**
  * The App-owned RX-audio snapshot the `rxAudio` facts are read against
  * (MOR-1262 slice 3A). It is an INPUT, deliberately: audio lifetime belongs to
  * the App (MOR-1058) and building a view model must never open, start or probe
@@ -1159,6 +1196,7 @@ export function toRadioViewModel(
   const antenna = deriveAntenna(state, caps);
   const scan = deriveScan(state);
   const cwKeyer = deriveCwKeyer(state, caps);
+  const scopeControls = deriveScopeControls(state, caps);
   const rfFrontEndMutex = deriveRfFrontEndMutex(rfFrontEnd);
   if (rfFrontEndMutex) disabledReasons.push(rfFrontEndMutex);
   disabledReasons.push(...deriveCwKeyerReasons(cwKeyer, modeFilter, txPermit));
@@ -1186,5 +1224,6 @@ export function toRadioViewModel(
     ...(antenna !== undefined ? { antenna } : {}),
     ...(scan !== undefined ? { scan } : {}),
     ...(cwKeyer !== undefined ? { cwKeyer } : {}),
+    ...(scopeControls !== undefined ? { scopeControls } : {}),
   };
 }

--- a/frontend/src/semantic/__tests__/optional-group-allow-list.test.ts
+++ b/frontend/src/semantic/__tests__/optional-group-allow-list.test.ts
@@ -42,11 +42,11 @@ const REQUIRED_KEYS = [
 
 /** MOR-1244: txAux. MOR-1262 slice 2A: meters. Slice 3A: rxAudio. Slice 4A:
  *  modeFilter. Slice 4A′: filterPassband. Slice 5A: dsp. Slice 6A: rfFrontEnd.
- *  Slice 7A: band. Slice 8A: ritXit, antenna, scan. Slice 9A: cwKeyer. Add
- *  your key here when your family's slice lands. */
+ *  Slice 7A: band. Slice 8A: ritXit, antenna, scan. Slice 9A: cwKeyer. Slice
+ *  11A: scopeControls. Add your key here when your family's slice lands. */
 const EXPECTED_OPTIONAL_GROUP_KEYS = [
   'txAux', 'meters', 'rxAudio', 'modeFilter', 'filterPassband', 'dsp', 'rfFrontEnd', 'band',
-  'ritXit', 'antenna', 'scan', 'cwKeyer',
+  'ritXit', 'antenna', 'scan', 'cwKeyer', 'scopeControls',
 ] as const;
 
 function extractTopLevelAllowList(): string[] {

--- a/frontend/src/semantic/__tests__/scope-controls.test.ts
+++ b/frontend/src/semantic/__tests__/scope-controls.test.ts
@@ -1,0 +1,99 @@
+/**
+ * MOR-1262 decomposition slice 11A (MOR-1298) — `scopeControls` optional
+ * fact group (validator half).
+ *
+ * Facts only: span preset index, sweep speed, dual-scope on/off, scope
+ * receiver (MAIN/SUB). See `radio-view-model.ts`'s `ScopeControlsViewModel`
+ * doc comment for the group-shape rationale (why MODE/EDGE/HOLD/REF and
+ * frame data are deliberately absent), and `radio-view-model-adapter.ts`'s
+ * `deriveScopeControls` for the live derivation (covered by the companion
+ * `scope-controls-adapter.test.ts`).
+ *
+ * Mirrors the companion families' (`scan.test.ts`, `cw-keyer.test.ts`)
+ * kill-tests: absent-group round-trip, exactKeys rejection of `null`/`{}`,
+ * and one precise-error-path rejection per field type.
+ */
+import { describe, expect, it } from 'vitest';
+import { validateRadioViewModel, type ScopeControlsField } from '../radio-view-model';
+import { topologyFixtures, withScopeControls } from '../fixtures/topologies';
+
+const AVAIL = { structural: true, operational: true } as const;
+const base = topologyFixtures['1/single'];
+
+describe('scopeControls (MOR-1262 slice 11A)', () => {
+  it('validates a scopeControls-absent model and never adds the key', () => {
+    expect(Object.keys(base)).not.toContain('scopeControls');
+    const validated = validateRadioViewModel(base);
+    expect(Object.keys(validated)).not.toContain('scopeControls');
+    expect(validated.scopeControls).toBeUndefined();
+    expect(JSON.parse(JSON.stringify(validated))).toEqual(JSON.parse(JSON.stringify(base)));
+  });
+
+  it('validates a fully-populated scopeControls group and returns it unchanged', () => {
+    const withSc = withScopeControls(base);
+    expect(validateRadioViewModel(withSc).scopeControls).toEqual(withSc.scopeControls);
+  });
+
+  it('rejects an explicit scopeControls: null', () => {
+    expect(() => validateRadioViewModel({ ...base, scopeControls: null })).toThrow(TypeError);
+  });
+
+  it('rejects an explicit scopeControls: {} — present, not absent, must satisfy its own shape', () => {
+    expect(() => validateRadioViewModel({ ...base, scopeControls: {} })).toThrow(TypeError);
+  });
+
+  it('rejects an extra key on the group (closed shape, exactly the four facts)', () => {
+    const withSc = withScopeControls(base);
+    const extra: ScopeControlsField<number> = { reading: { status: 'known', value: 0 }, availability: AVAIL };
+    const malformed = { ...withSc, scopeControls: { ...withSc.scopeControls, mode: extra } };
+    expect(() => validateRadioViewModel(malformed)).toThrow(TypeError);
+  });
+
+  it('rejects a non-numeric span reading value with a precise error path', () => {
+    const withSc = withScopeControls(base);
+    const malformed = {
+      ...withSc,
+      scopeControls: { ...withSc.scopeControls, span: { reading: { status: 'known', value: '3' }, availability: AVAIL } },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.scopeControls\.span\.reading\.value/);
+  });
+
+  it('rejects a non-numeric speed reading value with a precise error path', () => {
+    const withSc = withScopeControls(base);
+    const malformed = {
+      ...withSc,
+      scopeControls: { ...withSc.scopeControls, speed: { reading: { status: 'known', value: true }, availability: AVAIL } },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.scopeControls\.speed\.reading\.value/);
+  });
+
+  it('rejects a non-boolean dual reading value with a precise error path', () => {
+    const withSc = withScopeControls(base);
+    const malformed = {
+      ...withSc,
+      scopeControls: { ...withSc.scopeControls, dual: { reading: { status: 'known', value: 1 }, availability: AVAIL } },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.scopeControls\.dual\.reading\.value/);
+  });
+
+  it('rejects a non-numeric receiver reading value with a precise error path', () => {
+    const withSc = withScopeControls(base);
+    const malformed = {
+      ...withSc,
+      scopeControls: {
+        ...withSc.scopeControls, receiver: { reading: { status: 'known', value: 'SUB' }, availability: AVAIL },
+      },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.scopeControls\.receiver\.reading\.value/);
+  });
+
+  it('accepts a structurally-absent field (present group, one control this radio lacks)', () => {
+    const withSc = withScopeControls(base);
+    const off = { structural: false, operational: false } as const;
+    const model = {
+      ...withSc,
+      scopeControls: { ...withSc.scopeControls, dual: { reading: { status: 'unknown' }, availability: off } },
+    };
+    expect(validateRadioViewModel(model).scopeControls!.dual.availability.structural).toBe(false);
+  });
+});

--- a/frontend/src/semantic/fixtures/topologies.ts
+++ b/frontend/src/semantic/fixtures/topologies.ts
@@ -22,6 +22,7 @@ import type {
   ModInputReadiness, RadioViewModel, RfFrontEndField, RfFrontEndViewModel,
   RitXitField, RitXitViewModel, RxAudioField, RxAudioViewModel,
   ScanField, ScanViewModel,
+  ScopeControlsField, ScopeControlsViewModel,
   TxAuxField, TxAuxViewModel,
 } from '../radio-view-model';
 
@@ -459,4 +460,23 @@ export function withScan(fixture: RadioViewModel): RadioViewModel {
     scanResumeMode: known(0),
   };
   return { ...fixture, scan };
+}
+
+/**
+ * Applies a fully-observed `scopeControls` group (MOR-1262 slice 11A,
+ * MOR-1298) to any topology fixture — same composable-axis story as
+ * `withScan`/`withCwKeyer` above.
+ */
+export function withScopeControls(fixture: RadioViewModel): RadioViewModel {
+  const avail: Availability = { structural: true, operational: true };
+  const known = <T>(value: T): ScopeControlsField<T> => (
+    { reading: { status: 'known', value }, availability: avail }
+  );
+  const scopeControls: ScopeControlsViewModel = {
+    span: known(3),
+    speed: known(1),
+    dual: known(false),
+    receiver: known(0),
+  };
+  return { ...fixture, scopeControls };
 }

--- a/frontend/src/semantic/radio-view-model.ts
+++ b/frontend/src/semantic/radio-view-model.ts
@@ -726,6 +726,71 @@ export interface CwKeyerViewModel {
   twinPeak: CwKeyerField<boolean>;
 }
 
+/**
+ * A single scope-control fact (MOR-1262 decomposition slice 11A, MOR-1298).
+ * Shape-identical to `TxAuxField`, declared as an alias for the same reason
+ * `CwKeyerField`/`ScanField`/`AntennaField` are.
+ */
+export type ScopeControlsField<T> = TxAuxField<T>;
+
+/**
+ * Scope-control facts (MOR-1262 decomposition slice 11A, MOR-1298): the four
+ * operator-navigated facts off the shipped spectrum toolbar's own
+ * `scopeControls` block (`components/spectrum/SpectrumToolbar.svelte`) — SPAN
+ * preset index, sweep SPEED, DUAL-scope on/off, and which RECEIVER (MAIN=0/
+ * SUB=1) feeds the scope. The design doc that named this toolbar
+ * (`docs/plans/2026-04-18-spectrum-controls.md`) calls the MAIN/SUB selector
+ * the "scope-source selector" and proposes labelling it "SCOPE SRC" — the
+ * decomposition ticket's "receiver/source" pair names this ONE wire field
+ * (`ScopeControlsPublic.receiver`), not two.
+ *
+ * FACTS ONLY, and a DELIBERATELY NARROW slice of the eight
+ * `scopeControls.*` leaves the backend gives field-status entries for
+ * (`runtime_helpers.py`'s `_SCOPE_CONTROL_PUBLIC_FIELDS`): scope MODE
+ * (CTR/FIX/S-C/S-F), EDGE, HOLD and REF level are cosmetic/display-tuning
+ * facts that belong to the display slice (12), matching
+ * `SpectrumToolbar.svelte`'s own `scopeModeAvailable`/`scopeEdgeAvailable`/
+ * `scopeHoldAvailable`/`scopeRefAvailable` booleans staying separate from the
+ * four this group reads. Live scope FRAMES/WATERFALL DATA are a wholly
+ * different, App-owned resource demand (12A) and are never carried here —
+ * this group states facts about the scope's CONTROLS, never its pixels.
+ *
+ * PARITY: values mirror the same `scopeControls.<leaf>` register the toolbar
+ * reads (`radio.current?.scopeControls`), and availability reuses the exact
+ * same `isFieldAvailable(state, 'scopeControls.<leaf>')` predicate the
+ * toolbar calls for its own `scope{Span,Speed,Dual,Receiver}Available`
+ * booleans — not a reimplementation. Where this contract DIVERGES from v2:
+ * the toolbar's `scopeControls?.span ?? 3` / `?? 1` / `?? false` / `?? 0`
+ * fallbacks fabricate a value on an unobserved field; here an absent raw
+ * reads `unknown`, never those defaults.
+ *
+ * STRUCTURAL gate, doubly per the X6200 lesson (scope command support
+ * varies per radio — IC-7300/IC-9700 lack the `27 12`/`27 13` receiver-select
+ * commands even though `scope` is declared, and dual-scope operation is
+ * IC-7610-only in practice per MOR-664): `span`/`speed` are structurally
+ * available under `hasCap('scope')` alone (every scope-bearing single-RX
+ * radio supports them), while `dual`/`receiver` ADDITIONALLY require
+ * `hasCap('dual_rx')` — the only generic capability tag this contract may
+ * use, per "no radio-specific tables in the frontend". This is a real
+ * strengthening beyond the shipped toolbar, which gates DUAL/MAIN-SUB on
+ * field-availability alone; where `dual_rx` still over-declares for a
+ * specific radio (e.g. IC-9700, whose VHF/UHF `dual_rx` is unrelated to
+ * scope receiver-select), the OPERATIONAL half degrades honestly because the
+ * backend never observes that leaf for that radio — same structural/
+ * operational split `hardwareScope`/`audioFftScope` already use.
+ */
+export interface ScopeControlsViewModel {
+  /** Span preset index 0..7 (`SPAN_LABELS` in `spectrum-toolbar-logic.ts`
+   *  maps the ordinal to a display string; that table is UI convenience,
+   *  not a fact, and is deliberately absent here). */
+  span: ScopeControlsField<number>;
+  /** Sweep-speed ordinal 0=FST/1=MID/2=SLO. */
+  speed: ScopeControlsField<number>;
+  dual: ScopeControlsField<boolean>;
+  /** 0=MAIN, 1=SUB. */
+  receiver: ScopeControlsField<number>;
+}
+
 export interface RadioViewModel {
   topologyId: string;
   vfoScheme: VfoScheme;
@@ -788,6 +853,10 @@ export interface RadioViewModel {
    *  capability, so v2 renders no CW panel at all — see
    *  `radio-view-model-adapter.ts`'s `deriveCwKeyer`. */
   readonly cwKeyer?: CwKeyerViewModel;
+  /** Absent (MOR-1264 optional group) ⇒ this radio declares no `scope`
+   *  capability, so v2 renders no spectrum toolbar at all — see
+   *  `radio-view-model-adapter.ts`'s `deriveScopeControls`. */
+  readonly scopeControls?: ScopeControlsViewModel;
 }
 
 const RECEIVER_IDS: readonly ReceiverId[] = ['MAIN', 'SUB'];
@@ -1292,6 +1361,19 @@ function validateCwKeyer(value: unknown, path: string): CwKeyerViewModel {
   };
 }
 
+/** Exactly the four facts the adapter reads. See
+ *  `radio-view-model-adapter.ts::deriveScopeControls`. */
+function validateScopeControls(value: unknown, path: string): ScopeControlsViewModel {
+  const v = record(value, path);
+  exactKeys(v, ['span', 'speed', 'dual', 'receiver'], path);
+  return {
+    span: validateTxAuxField(v.span, `${path}.span`, num),
+    speed: validateTxAuxField(v.speed, `${path}.speed`, num),
+    dual: validateTxAuxField(v.dual, `${path}.dual`, bool),
+    receiver: validateTxAuxField(v.receiver, `${path}.receiver`, num),
+  };
+}
+
 /** Runtime validator (repo idiom: throws TypeError with a `$.path`, see `validateCapabilities`).
  *  Also enforces two cross-field invariants (review cycle 1, V1): `txPermit`
  *  cannot be 'allowed' while `txTarget` is unknown (no fail-open), and
@@ -1302,6 +1384,7 @@ export function validateRadioViewModel(value: unknown): RadioViewModel {
     'topologyId', 'vfoScheme', 'activeReceiver', 'vfos', 'split', 'dualWatch',
     'txTarget', 'txPermit', 'scope', 'disabledReasons', 'txAux', 'meters', 'rxAudio', 'modeFilter',
     'filterPassband', 'dsp', 'rfFrontEnd', 'band', 'ritXit', 'antenna', 'scan', 'cwKeyer',
+    'scopeControls',
   ], '$');
   if (!Array.isArray(v.vfos)) invalid('$.vfos', 'an array');
   if (!Array.isArray(v.disabledReasons)) invalid('$.disabledReasons', 'an array');
@@ -1341,6 +1424,7 @@ export function validateRadioViewModel(value: unknown): RadioViewModel {
   const antenna = optionalGroup(v.antenna, '$.antenna', validateAntenna);
   const scan = optionalGroup(v.scan, '$.scan', validateScan);
   const cwKeyer = optionalGroup(v.cwKeyer, '$.cwKeyer', validateCwKeyer);
+  const scopeControls = optionalGroup(v.scopeControls, '$.scopeControls', validateScopeControls);
 
   const disabledReasons = v.disabledReasons.map((r, i) => validateDisabledReason(r, `$.disabledReasons[${i}]`));
   // SAFETY, MOR-1296 — the fail-closed half of "no second permit", enforced
@@ -1382,5 +1466,6 @@ export function validateRadioViewModel(value: unknown): RadioViewModel {
     ...(antenna !== undefined ? { antenna } : {}),
     ...(scan !== undefined ? { scan } : {}),
     ...(cwKeyer !== undefined ? { cwKeyer } : {}),
+    ...(scopeControls !== undefined ? { scopeControls } : {}),
   };
 }


### PR DESCRIPTION
## Summary
Vocabulary slice 11A: optional `scopeControls` group — span, speed, dual, receiver (the exact four the decomposition's family row enumerates; "receiver/source" is one wire leaf, the MAIN/SUB scope-source selector). Gated on `scope` group-wide + `dual_rx` for dual/receiver (IC-7300-shaped degenerate probed: group present, those two structural:false). Verifier-traced end-to-end as genuinely StateStore-fed (the per-leaf 0x27 pipeline that MOR-557 mandated — `runtime_helpers.py` cites it by name), not a legacy mirror. Absent raw stays unknown, never the toolbar's fabricated defaults. Net production LOC **40** strict / 124 raw (verifier re-measured; ≤200). Frames/waterfall stay an App-owned resource demand (12A).

**Enumeration gap found (third of the program):** the toolbar declares EIGHT scopeControls leaves; MODE/EDGE/HOLD/REF are named nowhere in the decomposition yet are live pipeline-fed — filed as MOR-1299 (11A′, blocks 11B; the surface must not reach into raw state to fill the toolbar).

## Review provenance
Sonnet builder → independent opus vocabulary-domain verifier (19th ticket in domain): **PASS, no findings requiring action**. The builder's mid-build main-checkout incident was cleared four ways (shared checkout clean, all symbols in-tree, state field pre-existing, standalone typecheck). 11/12 boundary ruled correct at source + decomposition row. H1 fabricated-default mutant killed 3; C1 exactKeys killed 26; capability-gate probes direct. Fail-set identical to baseline (+33 passing); lint/boundaries/check clean; merge clean.

Linear: MOR-1298

🤖 Generated with [Claude Code](https://claude.com/claude-code)