### PR TITLE
feat(MOR-1299): scopeControls MODE/EDGE/HOLD/REF leaves (vocabulary slice 11A')

### DIFF
--- a/frontend/src/lib/runtime/adapters/__tests__/scope-controls-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/scope-controls-adapter.test.ts
@@ -1,6 +1,6 @@
 /**
- * MOR-1262 decomposition slice 11A (MOR-1298) — `scopeControls` fact-group
- * adapter derivation.
+ * MOR-1262 decomposition slice 11A (MOR-1298), extended by slice 11A′
+ * (MOR-1299) — `scopeControls` fact-group adapter derivation.
  *
  * Companion to `cw-keyer-adapter.test.ts`/`scan-adapter.test.ts`, which this
  * file does NOT modify. `scopeControls` is a SEPARATE optional group — see
@@ -9,11 +9,13 @@
  * PARITY — this group has no extractable pure `toXProps` function to call
  * (the real derivation is inline in `SpectrumToolbar.svelte`'s `$derived`
  * blocks), so the pins below call the SAME `isFieldAvailable` predicate the
- * toolbar calls for its own `scopeSpanAvailable`/`scopeSpeedAvailable`/
- * `scopeDualAvailable`/`scopeReceiverAvailable` booleans, rather than
- * reimplementing it. The toolbar's `scopeControls?.span ?? 3` (etc.)
- * fallbacks are pinned as fabrication this contract deliberately diverges
- * from — see the honesty-gate describe block.
+ * toolbar calls for its own `scopeModeAvailable`/`scopeEdgeAvailable`/
+ * `scopeSpanAvailable`/`scopeSpeedAvailable`/`scopeHoldAvailable`/
+ * `scopeRefAvailable`/`scopeDualAvailable`/`scopeReceiverAvailable`
+ * booleans, rather than reimplementing it. The toolbar's
+ * `scopeControls?.span ?? 3` (etc.) fallbacks are pinned as fabrication this
+ * contract deliberately diverges from — see the honesty-gate describe
+ * block.
  */
 import { describe, expect, it } from 'vitest';
 import type { Capabilities } from '$lib/types/capabilities';
@@ -74,15 +76,21 @@ describe('scopeControls evidence gate (MOR-1298, N3)', () => {
   it('emits scopeControls once the scope capability alone is declared', () => {
     const view = model(bareState(), scopeCaps());
     expect(view.scopeControls).toBeDefined();
-    expect(Object.keys(view.scopeControls!).sort()).toEqual(['dual', 'receiver', 'span', 'speed']);
+    expect(Object.keys(view.scopeControls!).sort()).toEqual(
+      ['dual', 'edge', 'hold', 'mode', 'receiver', 'refDb', 'span', 'speed'],
+    );
   });
 });
 
-describe('scopeControls per-field structural gates (MOR-1298, X6200 lesson)', () => {
-  it('span/speed stay structurally present on a scope-only, single-RX radio (IC-7300/IC-9700 shape)', () => {
+describe('scopeControls per-field structural gates (MOR-1298/MOR-1299, X6200 lesson)', () => {
+  it('mode/edge/span/speed/hold/refDb stay structurally present on a scope-only, single-RX radio (IC-7300/IC-9700 shape)', () => {
     const view = model(bareState(), scopeCaps(['scope']));
+    expect(view.scopeControls!.mode.availability.structural).toBe(true);
+    expect(view.scopeControls!.edge.availability.structural).toBe(true);
     expect(view.scopeControls!.span.availability.structural).toBe(true);
     expect(view.scopeControls!.speed.availability.structural).toBe(true);
+    expect(view.scopeControls!.hold.availability.structural).toBe(true);
+    expect(view.scopeControls!.refDb.availability.structural).toBe(true);
   });
 
   it('dual/receiver are structurally absent without dual_rx — no radio-specific table, just the cap tag', () => {
@@ -103,33 +111,39 @@ describe('scopeControls per-field structural gates (MOR-1298, X6200 lesson)', ()
   });
 });
 
-describe('scopeControls per-field derivation (MOR-1298)', () => {
+describe('scopeControls per-field derivation (MOR-1298/MOR-1299)', () => {
   const fullCaps = scopeCaps(['scope', 'dual_rx']);
 
   it('reports known readings for observed, fresh fields — parity with isFieldAvailable, the same predicate the real toolbar uses', () => {
     const state = bareState({
       scopeControls: {
-        receiver: 1, dual: true, mode: 0, span: 5, edge: 0, hold: false, refDb: 0, speed: 2,
+        receiver: 1, dual: true, mode: 1, span: 5, edge: 2, hold: true, refDb: -5, speed: 2,
         duringTx: false, centerType: 0, vbwNarrow: false, rbw: 0,
         fixedEdge: { rangeIndex: 0, edge: 0, startHz: 0, endHz: 0 },
       },
       fieldStatus: {
         ...bareState().fieldStatus,
+        'scopeControls.mode': fresh, 'scopeControls.edge': fresh,
         'scopeControls.span': fresh, 'scopeControls.speed': fresh,
+        'scopeControls.hold': fresh, 'scopeControls.refDb': fresh,
         'scopeControls.dual': fresh, 'scopeControls.receiver': fresh,
       },
     } as Partial<ServerState>);
     const sc = model(state, fullCaps).scopeControls!;
+    expect(sc.mode.reading).toEqual({ status: 'known', value: 1 });
+    expect(sc.edge.reading).toEqual({ status: 'known', value: 2 });
     expect(sc.span.reading).toEqual({ status: 'known', value: 5 });
     expect(sc.speed.reading).toEqual({ status: 'known', value: 2 });
+    expect(sc.hold.reading).toEqual({ status: 'known', value: true });
+    expect(sc.refDb.reading).toEqual({ status: 'known', value: -5 });
     expect(sc.dual.reading).toEqual({ status: 'known', value: true });
     expect(sc.receiver.reading).toEqual({ status: 'known', value: 1 });
-    for (const leaf of ['span', 'speed', 'dual', 'receiver'] as const) {
+    for (const leaf of ['mode', 'edge', 'span', 'speed', 'hold', 'refDb', 'dual', 'receiver'] as const) {
       expect(sc[leaf].availability.operational).toBe(isFieldAvailable(state, `scopeControls.${leaf}`));
     }
   });
 
-  const STALE_FIELDS = ['span', 'speed', 'dual', 'receiver'] as const;
+  const STALE_FIELDS = ['mode', 'edge', 'span', 'speed', 'hold', 'refDb', 'dual', 'receiver'] as const;
 
   it.each(STALE_FIELDS)(
     'degrades a stale scopeControls.%s to unknown while keeping structural availability true',
@@ -196,17 +210,31 @@ describe('scopeControls per-field derivation (MOR-1298)', () => {
  * (`SpectrumToolbar.svelte` lines around its `SPAN_LABELS[scopeControls?.
  * span ?? 3]`-style reads).
  */
-describe('scopeControls honesty gate — absent raw values never fabricate (MOR-1298)', () => {
+describe('scopeControls honesty gate — absent raw values never fabricate (MOR-1298/MOR-1299)', () => {
   const fullCaps = scopeCaps(['scope', 'dual_rx']);
 
-  const ABSENT_CASES = [
+  const NO_TOOLBAR_DEFAULT_CASES = [
+    ['mode', 0],
+    ['edge', 1],
+  ] as const;
+
+  const TOOLBAR_DEFAULT_CASES = [
     ['span', 3],
     ['speed', 1],
+    ['hold', false],
+    ['refDb', 0],
     ['dual', false],
     ['receiver', 0],
   ] as const;
 
-  it.each(ABSENT_CASES)(
+  it.each(NO_TOOLBAR_DEFAULT_CASES)(
+    '%s with nothing reported at all reads unknown, no toolbar default at all — the row is hidden',
+    (viewField) => {
+      expect(model(bareState(), fullCaps).scopeControls![viewField].reading).toEqual({ status: 'unknown' });
+    },
+  );
+
+  it.each(TOOLBAR_DEFAULT_CASES)(
     '%s with nothing reported at all reads unknown, not the toolbar\'s fabricated %s default',
     (viewField) => {
       expect(model(bareState(), fullCaps).scopeControls![viewField].reading).toEqual({ status: 'unknown' });

--- a/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
@@ -922,7 +922,8 @@ function deriveCwKeyerReasons(
 }
 
 /**
- * Scope-control facts (MOR-1262 decomposition slice 11A, MOR-1298). See
+ * Scope-control facts (MOR-1262 decomposition slice 11A/MOR-1298, extended
+ * by slice 11A′/MOR-1299 with mode/edge/hold/refDb). See
  * `ScopeControlsViewModel`'s doc comment for the field set, the parity
  * story against `SpectrumToolbar.svelte`'s own `scopeControls?.<leaf> ??
  * <default>` reads, and the doubly-applied X6200 capability-gating lesson.
@@ -934,11 +935,13 @@ function deriveCwKeyerReasons(
  * scope-adjacent state that reports independently of the `scope` capability
  * the way TX telemetry does.
  *
- * `span`/`speed` are structurally available whenever the group is (every
- * scope-bearing single-RX radio supports them); `dual`/`receiver`
- * additionally require `hasCap(caps, 'dual_rx')` — the only generic tag
- * available to gate "does dual-scope / receiver-select make sense here"
- * without a radio-specific table.
+ * `mode`/`edge`/`span`/`speed`/`hold`/`refDb` are structurally available
+ * whenever the group is (every scope-bearing single-RX radio supports them
+ * — the backend spec declares all six as read-only ingress leaves with no
+ * additional capability distinction); `dual`/`receiver` additionally
+ * require `hasCap(caps, 'dual_rx')` — the only generic tag available to
+ * gate "does dual-scope / receiver-select make sense here" without a
+ * radio-specific table.
  */
 function deriveScopeControls(
   state: ServerState | null, caps: Capabilities | null,
@@ -947,8 +950,12 @@ function deriveScopeControls(
   const hasReceiverSelect = hasCap(caps, 'dual_rx');
   const sc = state?.scopeControls;
   return {
+    mode: txAuxField(true, topFieldAvailable(state, 'scopeControls.mode'), numOrUndef(sc?.mode)),
+    edge: txAuxField(true, topFieldAvailable(state, 'scopeControls.edge'), numOrUndef(sc?.edge)),
     span: txAuxField(true, topFieldAvailable(state, 'scopeControls.span'), numOrUndef(sc?.span)),
     speed: txAuxField(true, topFieldAvailable(state, 'scopeControls.speed'), numOrUndef(sc?.speed)),
+    hold: txAuxField(true, topFieldAvailable(state, 'scopeControls.hold'), boolOrUndef(sc?.hold)),
+    refDb: txAuxField(true, topFieldAvailable(state, 'scopeControls.refDb'), numOrUndef(sc?.refDb)),
     dual: txAuxField(
       hasReceiverSelect, topFieldAvailable(state, 'scopeControls.dual'), boolOrUndef(sc?.dual),
     ),

--- a/frontend/src/semantic/__tests__/scope-controls.test.ts
+++ b/frontend/src/semantic/__tests__/scope-controls.test.ts
@@ -1,13 +1,15 @@
 /**
- * MOR-1262 decomposition slice 11A (MOR-1298) — `scopeControls` optional
- * fact group (validator half).
+ * MOR-1262 decomposition slice 11A (MOR-1298), extended by slice 11A′
+ * (MOR-1299) — `scopeControls` optional fact group (validator half).
  *
- * Facts only: span preset index, sweep speed, dual-scope on/off, scope
- * receiver (MAIN/SUB). See `radio-view-model.ts`'s `ScopeControlsViewModel`
- * doc comment for the group-shape rationale (why MODE/EDGE/HOLD/REF and
- * frame data are deliberately absent), and `radio-view-model-adapter.ts`'s
- * `deriveScopeControls` for the live derivation (covered by the companion
- * `scope-controls-adapter.test.ts`).
+ * Facts: scope mode, fixed-edge preset, span preset index, sweep speed,
+ * hold on/off, reference level, dual-scope on/off, scope receiver
+ * (MAIN/SUB) — all eight `scopeControls.*` leaves the backend gives
+ * field-status entries for. See `radio-view-model.ts`'s
+ * `ScopeControlsViewModel` doc comment for the group-shape rationale (why
+ * live scope frame data is still deliberately absent), and
+ * `radio-view-model-adapter.ts`'s `deriveScopeControls` for the live
+ * derivation (covered by the companion `scope-controls-adapter.test.ts`).
  *
  * Mirrors the companion families' (`scan.test.ts`, `cw-keyer.test.ts`)
  * kill-tests: absent-group round-trip, exactKeys rejection of `null`/`{}`,
@@ -42,11 +44,47 @@ describe('scopeControls (MOR-1262 slice 11A)', () => {
     expect(() => validateRadioViewModel({ ...base, scopeControls: {} })).toThrow(TypeError);
   });
 
-  it('rejects an extra key on the group (closed shape, exactly the four facts)', () => {
+  it('rejects an extra key on the group (closed shape, exactly the eight facts)', () => {
     const withSc = withScopeControls(base);
     const extra: ScopeControlsField<number> = { reading: { status: 'known', value: 0 }, availability: AVAIL };
-    const malformed = { ...withSc, scopeControls: { ...withSc.scopeControls, mode: extra } };
+    const malformed = { ...withSc, scopeControls: { ...withSc.scopeControls, bogus: extra } };
     expect(() => validateRadioViewModel(malformed)).toThrow(TypeError);
+  });
+
+  it('rejects a non-numeric mode reading value with a precise error path', () => {
+    const withSc = withScopeControls(base);
+    const malformed = {
+      ...withSc,
+      scopeControls: { ...withSc.scopeControls, mode: { reading: { status: 'known', value: 'CTR' }, availability: AVAIL } },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.scopeControls\.mode\.reading\.value/);
+  });
+
+  it('rejects a non-numeric edge reading value with a precise error path', () => {
+    const withSc = withScopeControls(base);
+    const malformed = {
+      ...withSc,
+      scopeControls: { ...withSc.scopeControls, edge: { reading: { status: 'known', value: false }, availability: AVAIL } },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.scopeControls\.edge\.reading\.value/);
+  });
+
+  it('rejects a non-boolean hold reading value with a precise error path', () => {
+    const withSc = withScopeControls(base);
+    const malformed = {
+      ...withSc,
+      scopeControls: { ...withSc.scopeControls, hold: { reading: { status: 'known', value: 1 }, availability: AVAIL } },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.scopeControls\.hold\.reading\.value/);
+  });
+
+  it('rejects a non-numeric refDb reading value with a precise error path', () => {
+    const withSc = withScopeControls(base);
+    const malformed = {
+      ...withSc,
+      scopeControls: { ...withSc.scopeControls, refDb: { reading: { status: 'known', value: '0' }, availability: AVAIL } },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.scopeControls\.refDb\.reading\.value/);
   });
 
   it('rejects a non-numeric span reading value with a precise error path', () => {

--- a/frontend/src/semantic/fixtures/topologies.ts
+++ b/frontend/src/semantic/fixtures/topologies.ts
@@ -463,9 +463,9 @@ export function withScan(fixture: RadioViewModel): RadioViewModel {
 }
 
 /**
- * Applies a fully-observed `scopeControls` group (MOR-1262 slice 11A,
- * MOR-1298) to any topology fixture — same composable-axis story as
- * `withScan`/`withCwKeyer` above.
+ * Applies a fully-observed `scopeControls` group (MOR-1262 slice 11A/
+ * MOR-1298, extended by slice 11A′/MOR-1299) to any topology fixture — same
+ * composable-axis story as `withScan`/`withCwKeyer` above.
  */
 export function withScopeControls(fixture: RadioViewModel): RadioViewModel {
   const avail: Availability = { structural: true, operational: true };
@@ -473,8 +473,12 @@ export function withScopeControls(fixture: RadioViewModel): RadioViewModel {
     { reading: { status: 'known', value }, availability: avail }
   );
   const scopeControls: ScopeControlsViewModel = {
+    mode: known(0),
+    edge: known(1),
     span: known(3),
     speed: known(1),
+    hold: known(false),
+    refDb: known(0),
     dual: known(false),
     receiver: known(0),
   };

--- a/frontend/src/semantic/radio-view-model.ts
+++ b/frontend/src/semantic/radio-view-model.ts
@@ -734,58 +734,85 @@ export interface CwKeyerViewModel {
 export type ScopeControlsField<T> = TxAuxField<T>;
 
 /**
- * Scope-control facts (MOR-1262 decomposition slice 11A, MOR-1298): the four
- * operator-navigated facts off the shipped spectrum toolbar's own
- * `scopeControls` block (`components/spectrum/SpectrumToolbar.svelte`) — SPAN
- * preset index, sweep SPEED, DUAL-scope on/off, and which RECEIVER (MAIN=0/
- * SUB=1) feeds the scope. The design doc that named this toolbar
+ * Scope-control facts (MOR-1262 decomposition slice 11A/MOR-1298, extended
+ * by slice 11A′/MOR-1299): the eight operator-navigated facts off the
+ * shipped spectrum toolbar's own `scopeControls` block
+ * (`components/spectrum/SpectrumToolbar.svelte`) — SPAN preset index, sweep
+ * SPEED, DUAL-scope on/off, which RECEIVER (MAIN=0/SUB=1) feeds the scope
+ * (11A), plus scope MODE (CTR/FIX/S-C/S-F), EDGE, HOLD and REF level (11A′).
+ * The design doc that named this toolbar
  * (`docs/plans/2026-04-18-spectrum-controls.md`) calls the MAIN/SUB selector
  * the "scope-source selector" and proposes labelling it "SCOPE SRC" — the
  * decomposition ticket's "receiver/source" pair names this ONE wire field
  * (`ScopeControlsPublic.receiver`), not two.
  *
- * FACTS ONLY, and a DELIBERATELY NARROW slice of the eight
- * `scopeControls.*` leaves the backend gives field-status entries for
- * (`runtime_helpers.py`'s `_SCOPE_CONTROL_PUBLIC_FIELDS`): scope MODE
- * (CTR/FIX/S-C/S-F), EDGE, HOLD and REF level are cosmetic/display-tuning
- * facts that belong to the display slice (12), matching
- * `SpectrumToolbar.svelte`'s own `scopeModeAvailable`/`scopeEdgeAvailable`/
- * `scopeHoldAvailable`/`scopeRefAvailable` booleans staying separate from the
- * four this group reads. Live scope FRAMES/WATERFALL DATA are a wholly
- * different, App-owned resource demand (12A) and are never carried here —
- * this group states facts about the scope's CONTROLS, never its pixels.
+ * FACTS ONLY, and now the COMPLETE set of the eight `scopeControls.*` leaves
+ * the backend gives field-status entries for (`runtime_helpers.py`'s
+ * `_SCOPE_CONTROL_PUBLIC_FIELDS`) — MODE/EDGE/HOLD/REF were a recorded
+ * enumeration gap in 11A (they matched `SpectrumToolbar.svelte`'s own
+ * `scopeModeAvailable`/`scopeEdgeAvailable`/`scopeHoldAvailable`/
+ * `scopeRefAvailable` booleans but were left out of the first slice; MOR-1299
+ * closes the gap, same group, same `scope` gate, same namespace — not a
+ * separate "display" family). Live scope FRAMES/WATERFALL DATA remain a
+ * wholly different, App-owned resource demand (12A) and are never carried
+ * here — this group states facts about the scope's CONTROLS, never its
+ * pixels.
  *
  * PARITY: values mirror the same `scopeControls.<leaf>` register the toolbar
  * reads (`radio.current?.scopeControls`), and availability reuses the exact
  * same `isFieldAvailable(state, 'scopeControls.<leaf>')` predicate the
- * toolbar calls for its own `scope{Span,Speed,Dual,Receiver}Available`
- * booleans — not a reimplementation. Where this contract DIVERGES from v2:
- * the toolbar's `scopeControls?.span ?? 3` / `?? 1` / `?? false` / `?? 0`
- * fallbacks fabricate a value on an unobserved field; here an absent raw
- * reads `unknown`, never those defaults.
+ * toolbar calls for its own `scope{Mode,Edge,Span,Speed,Hold,Ref,Dual,
+ * Receiver}Available` booleans — not a reimplementation. Where this contract
+ * DIVERGES from v2: the toolbar's `scopeControls?.span ?? 3` / `?? 1` /
+ * `?? false` / `?? 0` fallbacks (and the analogous `?.mode` / `?.edge`
+ * / `?.hold ?? false` / `?.refDb ?? 0` reads) fabricate a value on an
+ * unobserved field; here an absent raw reads `unknown`, never those
+ * defaults. When `mode` is absent, the entire row is hidden rather than
+ * fabricating CTR. EDGE's applicability is UI-only, gated on the current MODE
+ * value (`isEdgeApplicable` in `spectrum-toolbar-logic.ts` shows EDGE only
+ * in FIX/S-F modes) — that is a rendering decision, not a fact-availability
+ * distinction, so `edge`'s structural gate here mirrors `span`/`speed`/
+ * `mode`/`hold`/`refDb`, not a mode-conditional gate.
  *
  * STRUCTURAL gate, doubly per the X6200 lesson (scope command support
  * varies per radio — IC-7300/IC-9700 lack the `27 12`/`27 13` receiver-select
  * commands even though `scope` is declared, and dual-scope operation is
- * IC-7610-only in practice per MOR-664): `span`/`speed` are structurally
- * available under `hasCap('scope')` alone (every scope-bearing single-RX
- * radio supports them), while `dual`/`receiver` ADDITIONALLY require
- * `hasCap('dual_rx')` — the only generic capability tag this contract may
- * use, per "no radio-specific tables in the frontend". This is a real
- * strengthening beyond the shipped toolbar, which gates DUAL/MAIN-SUB on
- * field-availability alone; where `dual_rx` still over-declares for a
- * specific radio (e.g. IC-9700, whose VHF/UHF `dual_rx` is unrelated to
- * scope receiver-select), the OPERATIONAL half degrades honestly because the
- * backend never observes that leaf for that radio — same structural/
- * operational split `hardwareScope`/`audioFftScope` already use.
+ * IC-7610-only in practice per MOR-664): `span`/`speed`/`mode`/`edge`/
+ * `hold`/`refDb` are structurally available under `hasCap('scope')` alone
+ * (every scope-bearing single-RX radio supports them — the backend spec
+ * (`state_pipeline_contracts.py`) declares all six as read-only ingress
+ * leaves with no additional capability distinction), while `dual`/`receiver`
+ * ADDITIONALLY require `hasCap('dual_rx')` — the only generic capability tag
+ * this contract may use, per "no radio-specific tables in the frontend".
+ * This is a real strengthening beyond the shipped toolbar, which gates
+ * DUAL/MAIN-SUB on field-availability alone; where `dual_rx` still
+ * over-declares for a specific radio (e.g. IC-9700, whose VHF/UHF `dual_rx`
+ * is unrelated to scope receiver-select), the OPERATIONAL half degrades
+ * honestly because the backend never observes that leaf for that radio —
+ * same structural/operational split `hardwareScope`/`audioFftScope` already
+ * use.
  */
 export interface ScopeControlsViewModel {
+  /** Scope mode ordinal: 0=CTR, 1=FIX, 2=S-C (scroll-center), 3=S-F
+   *  (scroll-fixed) — `MODE_BUTTONS` in `spectrum-toolbar-logic.ts` maps the
+   *  ordinal to a display label; that table is UI convenience, not a fact,
+   *  and is deliberately absent here. */
+  mode: ScopeControlsField<number>;
+  /** Fixed-edge preset index 1..4. Applicable only in FIX/S-F modes per the
+   *  toolbar's `isEdgeApplicable`, but that is a rendering decision — this
+   *  fact is structurally available whenever the group is, same as `mode`. */
+  edge: ScopeControlsField<number>;
   /** Span preset index 0..7 (`SPAN_LABELS` in `spectrum-toolbar-logic.ts`
    *  maps the ordinal to a display string; that table is UI convenience,
    *  not a fact, and is deliberately absent here). */
   span: ScopeControlsField<number>;
   /** Sweep-speed ordinal 0=FST/1=MID/2=SLO. */
   speed: ScopeControlsField<number>;
+  hold: ScopeControlsField<boolean>;
+  /** Reference level in dB, clamped [-30, 10] by the toolbar's `clampRef`
+   *  (that clamp is a UI editing convenience, not a fact constraint — the
+   *  raw value here is whatever the radio reports). */
+  refDb: ScopeControlsField<number>;
   dual: ScopeControlsField<boolean>;
   /** 0=MAIN, 1=SUB. */
   receiver: ScopeControlsField<number>;
@@ -1361,14 +1388,19 @@ function validateCwKeyer(value: unknown, path: string): CwKeyerViewModel {
   };
 }
 
-/** Exactly the four facts the adapter reads. See
+/** Exactly the eight facts the adapter reads (11A's four plus 11A′'s
+ *  mode/edge/hold/refDb). See
  *  `radio-view-model-adapter.ts::deriveScopeControls`. */
 function validateScopeControls(value: unknown, path: string): ScopeControlsViewModel {
   const v = record(value, path);
-  exactKeys(v, ['span', 'speed', 'dual', 'receiver'], path);
+  exactKeys(v, ['mode', 'edge', 'span', 'speed', 'hold', 'refDb', 'dual', 'receiver'], path);
   return {
+    mode: validateTxAuxField(v.mode, `${path}.mode`, num),
+    edge: validateTxAuxField(v.edge, `${path}.edge`, num),
     span: validateTxAuxField(v.span, `${path}.span`, num),
     speed: validateTxAuxField(v.speed, `${path}.speed`, num),
+    hold: validateTxAuxField(v.hold, `${path}.hold`, bool),
+    refDb: validateTxAuxField(v.refDb, `${path}.refDb`, num),
     dual: validateTxAuxField(v.dual, `${path}.dual`, bool),
     receiver: validateTxAuxField(v.receiver, `${path}.receiver`, num),
   };


### PR DESCRIPTION
## Summary
- Closes the 11A enumeration gap (MOR-1299): mode/edge/hold/refDb join the `scopeControls` fact group under the same `scope` gate — no `dual_rx` sub-gate (only dual/receiver carry that, per the X6200 lesson).
- EDGE's mode-conditional visibility (`isEdgeApplicable`, modes FIX/S-F) stays a UI rendering decision, mirroring the SPAN precedent from 11A — documented in the group doc comment.
- Corrects the stale 11A doc comment that assigned these four leaves to slice 12 (scopeDisplay) — verified against the MOR-1262 decomposition and the 11A verify ruling.
- exactKeys closes over all 8 leaves; per-leaf malformed-type rejections, absent-raw honesty (status 'unknown', never the toolbar's fabricated defaults), stale-degradation and structural-gate tables extended to all 8.

## Review provenance
Independent opus verifier PASS (session-7): parity verified at source against `state_pipeline_contracts.py:1247-1251`, `ScopeControlsPublic`, and the real toolbar predicates; binding strict LOC = 12 (≤200 guardrail); mutation battery 15/16 killed with printed applied-proofs (the 1 survivor is a program-wide exactKeys-widening limit filed separately); both rulings (doc correction, EDGE gating) affirmed; full suite fail-set identical to pristine-HEAD baseline; lint/boundaries/check clean; vite.config untouched. Verifier's F1 doc-comment nit fixed in place per prescription (comment/test-title only, 59/59 targeted tests re-run).

## Linear
MOR-1299.

🤖 Generated with [Claude Code](https://claude.com/claude-code)