### PR TITLE
test(MOR-1320): revive the fixture harness and guard stub-export parity

### DIFF
--- a/frontend/fixtures/stubs/command-bus.ts
+++ b/frontend/fixtures/stubs/command-bus.ts
@@ -14,10 +14,32 @@
  * could not build its own entry and NO fixture loaded at all — the whole
  * MOR-1070 verification surface was dark, not merely degraded.
  *
- * The rule this file therefore has to keep: mirror every factory the
- * cockpit's tree imports, not only the ones a given fixture exercises. Every
- * handler records rather than commands — the harness asserts that an intent
- * reached the bus, and must never reach a radio.
+ * MOR-1320: second occurrence of the exact same class. The MOR-1279 rxAudio
+ * slice added `makeAudioRoutingHandlers`, `makeModeHandlers` and
+ * `makeRxAudioHandlers` (the last re-exported by the real module from
+ * `$lib/runtime/commands/panel-commands`) to the wiring's import list, and
+ * this stub again omitted all three — dark harness again, silently, until
+ * someone happened to run `capture.mjs` by hand. `stub-export-parity.test.ts`
+ * (`src/components-v2/wiring/__tests__/`) now asserts stub ⊇ real so this
+ * fails CI at commit time instead of at some future capture attempt.
+ *
+ * That guard checks the WHOLE export surface, not just the names the current
+ * wiring tree happens to import — MOR-1271's fix was deliberately minimal
+ * ("the drift guard stays in [this ticket]"), so at the time this guard
+ * landed the stub was still missing thirteen more factories the real module
+ * exports but nothing in the fixture-mounted tree references yet
+ * (`makeAgcHandlers`, `makeAntennaHandlers`, `makeBandHandlers`,
+ * `makeCwPanelHandlers`, `makeDspHandlers`, `makeFilterHandlers`,
+ * `makeKeyboardHandlers`, `makeMeterHandlers`, `makePresetHandlers`,
+ * `makeRfFrontEndHandlers`, `makeRitXitHandlers`, `makeScanHandlers`,
+ * `makeSystemHandlers`). Full parity is the only guard the test can enforce
+ * without also encoding "and here is every place in the tree that imports
+ * this module today" — a list that changes on every future wiring PR.
+ *
+ * The rule this file therefore has to keep: mirror every export the real
+ * module has, not only the ones a given fixture exercises. Every handler
+ * records rather than commands — the harness asserts that an intent reached
+ * the bus, and must never reach a radio.
  */
 import { record } from '../harness-state';
 
@@ -49,4 +71,120 @@ export function makeTxHandlers() {
     'onRfPowerChange', 'onMicGainChange', 'onAtuToggle', 'onAtuTune', 'onVoxToggle',
     'onCompToggle', 'onCompLevelChange', 'onMonToggle', 'onMonLevelChange', 'onDriveGainChange',
   ] as const);
+}
+
+/** MOR-1279: `onModInputChange` is the one `makeModeHandlers` member the
+ *  rxAudio wiring calls directly (the LAN MOD-input remedy); the other two
+ *  are mirrored for the same reason every other unused member here is —
+ *  a stub that omits a name fails at module resolution, not call time. */
+export function makeModeHandlers() {
+  return recorders('mode', ['onModeChange', 'onDataModeChange', 'onModInputChange'] as const);
+}
+
+/** MOR-1279: dual-RX audio routing (focus / stereo split / per-channel gain).
+ *  `restoreFromStorage` is the one member with a real return value in the
+ *  shipped module (it reads `localStorage` and answers the restored config)
+ *  — the harness must never touch `localStorage`, so the stub answers a
+ *  fixed, honest "nothing was stored" shape instead of recording+returning
+ *  undefined, which would crash the first destructure. */
+export function makeAudioRoutingHandlers() {
+  return {
+    ...recorders('audioRouting', [
+      'onFocusChange', 'onSplitStereoChange', 'onChannelGainChange',
+    ] as const),
+    restoreFromStorage: (): {
+      focus: 'main' | 'sub' | 'both'; split_stereo: boolean;
+      main_gain_db: number; sub_gain_db: number;
+    } => {
+      record('audioRouting.restoreFromStorage', []);
+      return { focus: 'both', split_stereo: false, main_gain_db: 0, sub_gain_db: 0 };
+    },
+  };
+}
+
+/** MOR-1279: RX-audio monitor mode + AF level. Re-exported by the real
+ *  module from `$lib/runtime/commands/panel-commands` — stubbed directly
+ *  here instead, since stubbing `command-bus.ts` wholesale means nothing
+ *  reaches that real module through this seam anyway. */
+export function makeRxAudioHandlers() {
+  return recorders('rxAudio', ['onMonitorModeChange', 'onAfLevelChange'] as const);
+}
+
+/* ── MOR-1320: the remaining factories, unreached by the fixture-mounted
+ *  tree today but required for `stub-export-parity.test.ts` — see the file
+ *  header. One name set per real factory, in the real module's own order. */
+
+export function makeRfFrontEndHandlers() {
+  return recorders('rfFrontEnd', [
+    'onAttChange', 'onPreChange', 'onRfGainChange', 'onSquelchChange',
+    'onDigiSelToggle', 'onIpPlusToggle',
+  ] as const);
+}
+
+export function makeFilterHandlers() {
+  return recorders('filter', [
+    'onFilterChange', 'onFilterWidthChange', 'onFilterShapeChange', 'onFilterPresetChange',
+    'onFilterDefaults', 'onIfShiftChange', 'onPbtInnerChange', 'onPbtOuterChange', 'onPbtReset',
+  ] as const);
+}
+
+export function makeAgcHandlers() {
+  return recorders('agc', ['onAgcModeChange'] as const);
+}
+
+export function makeRitXitHandlers() {
+  return recorders('ritXit', [
+    'onRitToggle', 'onXitToggle', 'onRitOffsetChange', 'onXitOffsetChange', 'onClear',
+  ] as const);
+}
+
+export function makeDspHandlers() {
+  return recorders('dsp', [
+    'onNrModeChange', 'onNrLevelChange', 'onNbToggle', 'onNbLevelChange', 'onNotchModeChange',
+    'onNotchFreqChange', 'onNbDepthChange', 'onNbWidthChange', 'onManualNotchWidthChange',
+    'onAgcTimeChange',
+  ] as const);
+}
+
+export function makeCwPanelHandlers() {
+  return recorders('cwPanel', [
+    'onCwPitchChange', 'onKeySpeedChange', 'onBreakInToggle', 'onBreakInModeChange',
+    'onApfChange', 'onTwinPeakToggle', 'onAutoTune', 'onWpmChange', 'onBreakInDelayChange',
+    'onSidetonePitchChange', 'onSidetoneLevelChange', 'onReversePaddleToggle', 'onKeyerTypeChange',
+  ] as const);
+}
+
+export function makePresetHandlers() {
+  return recorders('preset', ['onPresetSelect', 'onFreqPreset'] as const);
+}
+
+export function makeBandHandlers() {
+  return recorders('band', ['onBandSelect'] as const);
+}
+
+export function makeAntennaHandlers() {
+  return recorders('antenna', ['onSelectAnt1', 'onSelectAnt2', 'onToggleRxAnt'] as const);
+}
+
+export function makeMeterHandlers() {
+  return recorders('meter', ['onMeterSourceChange'] as const);
+}
+
+export function makeSystemHandlers() {
+  return recorders('system', ['onDialLock', 'onPowerOff', 'onSpeak'] as const);
+}
+
+export function makeScanHandlers() {
+  return recorders('scan', [
+    'onScanStart', 'onScanStop', 'onDfSpanChange', 'onResumeChange',
+  ] as const);
+}
+
+/** `dispatch` takes the same shape as the real module's — a single
+ *  `KeyboardActionConfig` — but `recorders()` only names bare handlers, so
+ *  it is built directly rather than forced through that helper. */
+export function makeKeyboardHandlers() {
+  return {
+    dispatch: (...args: unknown[]): void => record('keyboard.dispatch', args),
+  };
 }

--- a/frontend/fixtures/stubs/runtime.ts
+++ b/frontend/fixtures/stubs/runtime.ts
@@ -1,7 +1,21 @@
 /** MOR-1070 stub for `$lib/runtime` — fixture state/caps, no transport. */
 import { harness } from '../harness-state';
 
+/**
+ * MOR-1320: `SemanticRadioSurfaces.svelte` gained a `runtime.audio` /
+ * `runtime.connectionAudio` read in the MOR-1279 rxAudio slice
+ * (`rxAudioSnapshot`'s `muted`/`rxEnabled`/`volume`/`connected`) and this stub
+ * had no such fields — a `TypeError: Cannot read properties of undefined
+ * (reading 'muted')` at first render, one seam over from the command-bus
+ * export gaps this ticket also fixes. No fixture varies audio-runtime state
+ * (`fixtures/catalog.ts` has no such override), so the fixed defaults below
+ * mirror the real module's construction-time values
+ * (`$lib/stores/audio.svelte.ts`'s initial `audioState`) rather than reading
+ * from `harness` — there is nothing yet for a fixture to set.
+ */
 export const runtime = {
   get state() { return harness.state; },
   get caps() { return harness.caps; },
+  get audio() { return { rxEnabled: false, volume: 50, muted: false }; },
+  get connectionAudio() { return false; },
 };

--- a/frontend/src/components-v2/wiring/__tests__/stub-export-parity.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/stub-export-parity.test.ts
@@ -1,0 +1,50 @@
+/**
+ * MOR-1320 — the fixture harness's `command-bus` stub must never omit a name
+ * the real module exports.
+ *
+ * `vite.fixtures.config.ts` re-points `components-v2/wiring/command-bus` at
+ * `fixtures/stubs/command-bus.ts` wholesale (see that file's own docstring):
+ * an ES module's named imports are resolved at MODULE RESOLUTION time, so a
+ * stub missing even one export the importing tree names kills the harness
+ * before a single fixture can mount — not a degraded capture, a dark one.
+ * This happened twice on the real module (MOR-1271: `makeTxHandlers` /
+ * `makeVoxHandlers`; MOR-1320: `makeAudioRoutingHandlers` / `makeModeHandlers`
+ * / `makeRxAudioHandlers`, all added by the MOR-1279 rxAudio slice), and both
+ * times the drift was invisible until someone ran `fixtures/capture.mjs` by
+ * hand. This test makes the drift visible at commit time instead.
+ *
+ * Deliberately does not mock or exercise EITHER module — it only imports the
+ * two module namespace objects and compares their key sets. That is
+ * sufficient because the failure mode is entirely name-level (an import that
+ * cannot resolve), not behavioral; the stub's *behavior* (recording rather
+ * than commanding) is covered by `fixtures/harness-state.ts`'s own callers
+ * and by capture.mjs's assertions, not by this file.
+ *
+ * `stub ⊇ real` (not `===`) is the correct direction: the stub is allowed to
+ * carry a name the real module has since retired (harmless — nothing can
+ * import a name that no longer exists), but never allowed to be missing a
+ * name the real module currently exports.
+ */
+import { describe, expect, it } from 'vitest';
+import * as real from '../command-bus';
+// fixtures/ lives outside src/, which is why this guard has to reach the
+// stub by relative path rather than through any configured alias.
+import * as stub from '../../../../fixtures/stubs/command-bus';
+
+const realExports = Object.keys(real).sort();
+const stubExports = new Set(Object.keys(stub));
+
+describe('fixtures/stubs/command-bus.ts stays a superset of the real module', () => {
+  it('exports at least one factory, so this guard cannot pass on an empty real module', () => {
+    expect(realExports.length).toBeGreaterThan(0);
+  });
+
+  it.each(realExports)('exports "%s"', (name) => {
+    expect(stubExports.has(name)).toBe(true);
+  });
+
+  it.each(realExports)('"%s" is a function on both the real module and the stub', (name) => {
+    expect(typeof (real as Record<string, unknown>)[name]).toBe('function');
+    expect(typeof (stub as Record<string, unknown>)[name]).toBe('function');
+  });
+});


### PR DESCRIPTION
## Summary
- Revives the browser fixture harness, dead at main since the 3B landing (0/31 captures failing at module resolution — the second MOR-1271-class break): `fixtures/stubs/command-bus.ts` gains the 16 exports the real command-bus grew past it; `fixtures/stubs/runtime.ts` gains `audio`/`connectionAudio` (the actual 3B drift, found during reproduction).
- Adds a stub-export-parity guard (`stub-export-parity.test.ts`, fast pool, no mocks) pinning stub exports ⊇ real command-bus exports — the next surface slice fails its own PR instead of silently killing the harness.

## Review provenance
Independent opus verifier PASS (fixtures/evidence anchor, session-7): harness re-run independently (31/31 execute, 0 module/page/console errors; residuals are exactly the known MOR-1318 pair); its own bite probe on a DIFFERENT export (makeModeHandlers) with sha256-verified restoration; all 19 stub factories compared dynamically against the real signatures (exact handler-name parity); fast-pool safety proven (only fast-pool file in the command-bus graph); 254 files/5046 tests green, lint/boundaries/check/build clean, 0 production LOC. The build report's MOR-1279-catalog-drift attribution was disproven by the verifier — MOR-1327 canceled with the proof; follow-up MOR-1328 filed (guard extension to returned key sets).

## Linear
MOR-1320.

🤖 Generated with [Claude Code](https://claude.com/claude-code)