### PR TITLE
feat(MOR-1321): receiver-deck mechanical parity for desktop-v2 (rework S3a)

### DIFF
--- a/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
@@ -478,3 +478,42 @@ describe('exactly one key authority on a partially declaring manifest (R9)', () 
     expect(render(skinId).querySelectorAll(KEY_AUTHORITIES).length).toBe(1);
   });
 });
+
+/**
+ * MOR-1321 (S3a) — receiver-deck parity for the VFO ops.
+ *
+ * MOR-1313 put desktop-v2 on the v3 path and, with it, retired the legacy
+ * `VfoOps` bridge from the deck: A=B, A↔B and the two composite quick triggers
+ * left the flagship skin (A=B/A↔B survived only in the settings modal, which
+ * the owner declined as parity). These assert the semantic deck carries them
+ * again — end-to-end through the real RadioLayout mount, not just in the
+ * surface's own unit tests.
+ */
+describe('the semantic receiver deck carries the VFO ops again (MOR-1321)', () => {
+  const OPS = ['equalize', 'swap', 'quick-split', 'quick-dual-watch'] as const;
+
+  // MUTATION KILLED: the ops landing in the surface but never being wired at
+  // the desktop mount site — every VfoSurface unit test would still pass.
+  it.each(['desktop-v2', 'sdr-test'] as const)('%s renders all four ops inside the deck', (skinId) => {
+    const deck = render(skinId).querySelector('.receiver-deck')!;
+    for (const op of OPS) expect(deck.querySelector(`[data-vfo-${op}]`), op).not.toBeNull();
+    expect(deck.querySelector('[data-testid="vfo-split-digest"]')).not.toBeNull();
+  });
+
+  // The structural gate survives the trip through the real adapter: a
+  // single-VFO radio has nothing to swap against, so the deck shows no ops.
+  // Kills a wiring that renders them unconditionally at the mount site.
+  it('a single-VFO topology renders no ops in the deck', () => {
+    h.caps = capsFor('1/single');
+    const deck = render('desktop-v2').querySelector('.receiver-deck')!;
+    for (const op of OPS) expect(deck.querySelector(`[data-vfo-${op}]`), op).toBeNull();
+    expect(deck.querySelector('[data-testid="vfo-split-digest"]')).toBeNull();
+  });
+
+  // R9 restated at the deck level: adding four buttons to the deck must not
+  // add a second key authority. Same probe shape as the MOR-1313 matrix.
+  it('adds no key authority to the deck', () => {
+    const t = render('desktop-v2');
+    expect(t.querySelectorAll('[data-testid="rx-tx-surface"], .tx-panel').length).toBe(1);
+  });
+});

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -297,12 +297,23 @@
       -->
       {#if zoneShows('global', 'vfo')}
         <div class="cockpit-global-row" data-testid="cockpit-zone-global" data-zone-id="global">
+          <!--
+            MOR-1321: the VFO ops ride with the radio-wide facts, so in the dual
+            composition they land HERE — once, in the global row — and not in the
+            per-receiver strips above, which set `showRadioWideFacts={false}`.
+            Same placement rule split/dual-watch already follow, for the same
+            reason: one radio-wide action must not appear once per receiver.
+          -->
           <VfoSurface
             viewModel={view}
             showVfoList={false}
             groupLabel={t('core.vfo.radioWideGroupLabel')}
             onToggleSplit={vfo.onSplitToggle}
             onToggleDualWatch={toggleDualWatch}
+            onEqualizeVfos={vfo.onEqual}
+            onSwapVfos={vfo.onSwap}
+            onQuickSplit={vfo.onQuickSplit}
+            onQuickDualWatch={vfo.onQuickDw}
           />
         </div>
       {/if}
@@ -324,6 +335,10 @@
         onSelectVfo={selectVfo}
         onToggleSplit={vfo.onSplitToggle}
         onToggleDualWatch={toggleDualWatch}
+        onEqualizeVfos={vfo.onEqual}
+        onSwapVfos={vfo.onSwap}
+        onQuickSplit={vfo.onQuickSplit}
+        onQuickDualWatch={vfo.onQuickDw}
       />
     {/if}
   {/snippet}

--- a/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
@@ -194,6 +194,12 @@ describe('the meters surface mounts only when the view model carries the group',
    */
   const DEFAULT_PATH_TESTIDS = [
     'vfo-surface', 'vfo-active-receiver', 'vfo-list',
+    // MOR-1321 (S3a): the VFO ops row and the split RX/TX digest are part of
+    // the vfo surface's radio-wide half now, so they belong to the default
+    // path's element shape. This fixture's radio is dual-receiver, so the
+    // structural gate (more than one VFO) legitimately opens; the single-VFO
+    // absence is pinned in `semantic/__tests__/VfoSurface.test.ts`.
+    'vfo-ops', 'vfo-split-digest',
     'rx-tx-surface', 'rx-tx-state', 'rx-tx-rf-mark', 'rx-tx-rf-label',
     'rx-tx-target', 'rx-tx-key', 'rx-tx-unkey', 'rx-tx-blocked',
     // MOR-1279 slice 3B: this fixture's radio DOES have an audio chain

--- a/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
@@ -219,6 +219,12 @@ describe('the txAux surface mounts only when the view model carries the group', 
    */
   const DEFAULT_PATH_TESTIDS = [
     'vfo-surface', 'vfo-active-receiver', 'vfo-list',
+    // MOR-1321 (S3a): the VFO ops row and the split RX/TX digest are part of
+    // the vfo surface's radio-wide half now, so they belong to the default
+    // path's element shape. This fixture's radio is dual-receiver, so the
+    // structural gate (more than one VFO) legitimately opens; the single-VFO
+    // absence is pinned in `semantic/__tests__/VfoSurface.test.ts`.
+    'vfo-ops', 'vfo-split-digest',
     'rx-tx-surface', 'rx-tx-state', 'rx-tx-rf-mark', 'rx-tx-rf-label',
     'rx-tx-target', 'rx-tx-key', 'rx-tx-unkey', 'rx-tx-blocked',
     // MOR-1279 slice 3B: this fixture's radio DOES have an audio chain
@@ -243,6 +249,10 @@ describe('the txAux surface mounts only when the view model carries the group', 
     .map((el) => el.tagName.toLowerCase()).join(' ');
   const DEFAULT_PATH_OUTLINE = 'div p div div span span span span span div span span span button '
     + 'div span span span button div span span span button div button button '
+    // MOR-1321 (S3a): the ops row (four action buttons) and the split RX/TX
+    // digest (a `p` carrying an RX and a TX span), both part of the vfo
+    // surface's radio-wide half, immediately after the split/dualWatch toggles.
+    + 'div button button button button p span span '
     + 'section p span span span span p div button button ul'
     // MOR-1279 slice 3B: the rxAudio surface, mounted because this fixture's
     // radio has an audio chain. See the testid literal above.

--- a/frontend/src/components-v2/wiring/__tests__/vfo-ops-command-bus.isolated.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/vfo-ops-command-bus.isolated.test.ts
@@ -1,0 +1,115 @@
+/**
+ * MOR-1321 (S3a) — the VFO-ops intents agree with the REAL command bus.
+ *
+ * `SemanticRadioSurfaces` binds the four new `VfoSurface` props by name
+ * (`onEqualizeVfos={vfo.onEqual}`, …). Its own component test mocks
+ * `../command-bus`, so a renamed or deleted handler there would be invisible:
+ * the mock would keep answering. This file closes that gap the same way
+ * `tx-aux-command-bus.isolated.test.ts` does — load the real module, read the
+ * names off the real wiring source, and assert each one exists AND emits the
+ * command the radio expects.
+ *
+ * The pair that matters most is `onQuickSplit` / `onQuickDw`: they are the
+ * BACKEND composite triggers (epic #774, equalize-then-toggle-on, atomic). A
+ * silent rename would leave the deck's quick buttons wired to `undefined` —
+ * or, worse, to a neighbouring VFO command that moves a frequency the
+ * operator did not ask to move.
+ *
+ * Each test's doc line names the mutation it exists to kill.
+ */
+import { readFileSync } from 'node:fs';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('$lib/transport/ws-client', () => ({ sendCommand: vi.fn() }));
+vi.mock('$lib/stores/radio.svelte', () => ({
+  getActiveReceiver: vi.fn(() => null),
+  getRadioState: vi.fn(() => ({ active: 'MAIN' })),
+  patchActiveReceiver: vi.fn(),
+  patchRadioState: vi.fn(),
+  patchReceiver: vi.fn(),
+}));
+vi.mock('$lib/audio/audio-manager', () => ({
+  audioManager: {
+    setAudioConfig: vi.fn(), startRx: vi.fn(), stopRx: vi.fn(),
+    setRxVolume: vi.fn(), rxEnabled: false,
+  },
+}));
+
+import { sendCommand } from '$lib/transport/ws-client';
+import { makeVfoHandlers } from '../command-bus';
+
+const wiringSource = readFileSync('src/components-v2/wiring/SemanticRadioSurfaces.svelte', 'utf8');
+
+/**
+ * The four MOR-1321 surface props, and the command each one must ultimately
+ * reach. Read as pairs so a cross-wiring (swap bound to equalize) fails on the
+ * COMMAND, not merely on "something was called".
+ */
+const OPS = [
+  { prop: 'onEqualizeVfos', handler: 'onEqual', command: 'vfo_equalize' },
+  { prop: 'onSwapVfos', handler: 'onSwap', command: 'vfo_swap' },
+  { prop: 'onQuickSplit', handler: 'onQuickSplit', command: 'quick_split' },
+  { prop: 'onQuickDualWatch', handler: 'onQuickDw', command: 'quick_dualwatch' },
+] as const;
+
+beforeEach(() => { vi.mocked(sendCommand).mockClear(); });
+
+describe('the wiring binds every VFO op to a handler the real command bus provides', () => {
+  // Kills: a prop bound to `vfo.onQuickDW` (or any other typo) — Svelte would
+  // pass `undefined` silently and the button would do nothing at runtime.
+  it.each(OPS)('$prop is bound to vfo.$handler in the real wiring source', ({ prop, handler }) => {
+    expect(wiringSource).toContain(`${prop}={vfo.${handler}}`);
+  });
+
+  // Kills: a rename/removal in command-bus.ts that the mocked component test
+  // cannot see.
+  it.each(OPS)('vfo.$handler exists and is callable', ({ handler }) => {
+    expect(typeof (makeVfoHandlers() as Record<string, unknown>)[handler]).toBe('function');
+  });
+
+  // Kills: cross-wiring. Each handler must emit ITS command and no other —
+  // "quick split fired something" is not the claim; "quick split fired
+  // quick_split" is.
+  it.each(OPS)('vfo.$handler emits $command', ({ handler, command }) => {
+    (makeVfoHandlers() as unknown as Record<string, () => void>)[handler]();
+    const sent = vi.mocked(sendCommand).mock.calls.map((c) => c[0]);
+    expect(sent).toContain(command);
+    // No sibling op's command rode along.
+    for (const other of OPS) {
+      if (other.command !== command) expect(sent).not.toContain(other.command);
+    }
+  });
+
+  // R9. None of the four may touch a key path: the transmitter is keyed only
+  // through the App TX controller, never from a VFO action.
+  it('no VFO op emits a TX key/unkey command', () => {
+    for (const { handler } of OPS) {
+      (makeVfoHandlers() as unknown as Record<string, () => void>)[handler]();
+    }
+    const sent = vi.mocked(sendCommand).mock.calls.map((c) => String(c[0]));
+    for (const forbidden of ['set_ptt', 'ptt', 'start_tx', 'stop_tx', 'tx']) {
+      expect(sent, forbidden).not.toContain(forbidden);
+    }
+  });
+});
+
+describe('placement — the ops ride with the radio-wide facts', () => {
+  // Kills: binding the ops onto the per-receiver strip surface, which would
+  // render one equalize button PER RECEIVER in the dual-receiver cockpit. The
+  // strip mount is the one that sets `showRadioWideFacts={false}`; the two
+  // legitimate mounts are the cockpit's global row and the single composition.
+  it.each(OPS)('$prop is bound exactly twice — the global row and the single composition', ({ prop }) => {
+    const occurrences = wiringSource.split(`${prop}={vfo.`).length - 1;
+    expect(occurrences).toBe(2);
+  });
+
+  // The strip mount stays op-free — asserted on the strip's own markup block
+  // rather than on a global count, so this cannot pass by miscounting above.
+  it('the per-receiver strip mount binds no ops', () => {
+    const stripBlock = wiringSource.slice(
+      wiringSource.indexOf('showRadioWideFacts={false}') - 400,
+      wiringSource.indexOf('showRadioWideFacts={false}') + 400,
+    );
+    for (const { prop } of OPS) expect(stripBlock, prop).not.toContain(prop);
+  });
+});

--- a/frontend/src/lib/i18n/locales/en-US.json
+++ b/frontend/src/lib/i18n/locales/en-US.json
@@ -201,6 +201,12 @@
   "core.vfo.state.on": "on",
   "core.vfo.state.off": "off",
   "core.vfo.state.unknown": "unknown",
+  "core.vfo.ops.equalize": "Equalize VFOs",
+  "core.vfo.ops.swap": "Swap VFOs",
+  "core.vfo.ops.quickSplit": "Quick split",
+  "core.vfo.ops.quickDualWatch": "Quick dual watch",
+  "core.vfo.splitDigest.rx": "RX {frequency}",
+  "core.vfo.splitDigest.tx": "TX {frequency}",
 
   "core.txGuard.modInputNotLan": "MOD input is {source}, not LAN — your voice from the web will not be transmitted (TX).",
   "core.txGuard.setLan": "Set LAN",

--- a/frontend/src/lib/i18n/locales/ja-JP.json
+++ b/frontend/src/lib/i18n/locales/ja-JP.json
@@ -181,6 +181,12 @@
   "core.vfo.state.on": "オン",
   "core.vfo.state.off": "オフ",
   "core.vfo.state.unknown": "不明",
+  "core.vfo.ops.equalize": "VFO を等しくする",
+  "core.vfo.ops.swap": "VFO を入れ替え",
+  "core.vfo.ops.quickSplit": "クイックスプリット",
+  "core.vfo.ops.quickDualWatch": "クイックデュアルウォッチ",
+  "core.vfo.splitDigest.rx": "RX {frequency}",
+  "core.vfo.splitDigest.tx": "TX {frequency}",
 
   "core.txGuard.modInputNotLan": "MOD 入力が {source} のため LAN 経由の音声は送信 (TX) されません。",
   "core.txGuard.setLan": "LAN に設定",

--- a/frontend/src/lib/i18n/locales/ru-RU.json
+++ b/frontend/src/lib/i18n/locales/ru-RU.json
@@ -181,6 +181,12 @@
   "core.vfo.state.on": "включено",
   "core.vfo.state.off": "выключено",
   "core.vfo.state.unknown": "неизвестно",
+  "core.vfo.ops.equalize": "Уравнять VFO",
+  "core.vfo.ops.swap": "Поменять VFO местами",
+  "core.vfo.ops.quickSplit": "Быстрый сплит",
+  "core.vfo.ops.quickDualWatch": "Быстрый двойной приём",
+  "core.vfo.splitDigest.rx": "RX {frequency}",
+  "core.vfo.splitDigest.tx": "TX {frequency}",
 
   "core.txGuard.modInputNotLan": "Вход MOD установлен в {source}, а не LAN — голос из веб-интерфейса не уйдёт в эфир (TX).",
   "core.txGuard.setLan": "Включить LAN",

--- a/frontend/src/semantic/VfoSurface.svelte
+++ b/frontend/src/semantic/VfoSurface.svelte
@@ -88,6 +88,23 @@
      * and an operationally-fine dual strip — is unchanged.
      */
     disabled?: boolean;
+    /**
+     * MOR-1321 (v3-rework slice S3a) — the VFO-scoped ACTIONS the legacy
+     * `VfoOps` bridge carried and the semantic deck lost at MOR-1313: equalize
+     * (copy one VFO onto the other), swap, and the two composite "quick"
+     * triggers the backend performs atomically as equalize-then-toggle-on
+     * (`quick_split` / `quick_dualwatch`, epic #774).
+     *
+     * INTENTS, like every other callback here: this surface names what the
+     * operator asked for and knows nothing about how it is sent. None is a TX
+     * path — the quick triggers move receive/transmit FREQUENCY assignment and
+     * never key the transmitter (R9: the sole key/unkey authority is the
+     * sibling RX/TX surface).
+     */
+    onEqualizeVfos?: () => void;
+    onSwapVfos?: () => void;
+    onQuickSplit?: () => void;
+    onQuickDualWatch?: () => void;
   }
 
   let {
@@ -100,7 +117,22 @@
     showVfoList = true,
     groupLabel,
     disabled = false,
+    onEqualizeVfos,
+    onSwapVfos,
+    onQuickSplit,
+    onQuickDualWatch,
   }: Props = $props();
+
+  /**
+   * MOR-1321 — the STRUCTURAL half of the MOR-977 gate for everything below,
+   * and the same pool `isSelectable` reads: with one VFO there is nothing to
+   * equalize onto, swap with, or split against, so the ops row and the RX/TX
+   * digest are ABSENT rather than present-and-inert. `selectionPoolSize` keeps
+   * a per-receiver slice reading the whole radio (MOR-1067), exactly as it does
+   * for tile selection.
+   */
+  let vfoPool = $derived(selectionPoolSize ?? viewModel.vfos.length);
+  let hasVfoPair = $derived(vfoPool > 1);
 
   function slotKey(slot: VfoSlot): string {
     return slot.kind === 'slotted' ? slot.id : slot.kind;
@@ -130,7 +162,7 @@
   }
 
   function isSelectable(vfo: VfoViewModel): boolean {
-    return (selectionPoolSize ?? viewModel.vfos.length) > 1 && !vfo.isActive;
+    return hasVfoPair && !vfo.isActive;
   }
 
   function selectVfo(vfo: VfoViewModel): void {
@@ -157,6 +189,42 @@
     if (viewModel.dualWatch.status !== 'known') return;
     onToggleDualWatch?.();
   }
+
+  /**
+   * MOR-1321 — the OPERATIONAL half of the gate, and it applies to the quick
+   * triggers only. `quick_split` / `quick_dualwatch` end with the corresponding
+   * fact turned ON, so firing one while that fact is unobserved would ask the
+   * radio to reach a state this surface cannot see it reach — the same reason
+   * `toggleSplit`/`toggleDualWatch` above refuse, and the same `disabled`
+   * attribute, not a parallel mechanism.
+   *
+   * Equalize and swap deliberately have NO such guard: neither reads a fact,
+   * both are meaningful whatever split/dual-watch report, and gating them on an
+   * unrelated unknown would invent a dependency the radio does not have.
+   */
+  function quickSplit(): void {
+    if (viewModel.split.status !== 'known') return;
+    onQuickSplit?.();
+  }
+
+  function quickDualWatch(): void {
+    if (viewModel.dualWatch.status !== 'known') return;
+    onQuickDualWatch?.();
+  }
+
+  /**
+   * MOR-1321 row 20 — the legacy bridge's `RX <freq> TX <freq>` digest, restated
+   * on facts. RX is the ACTIVE VFO (what the operator is listening to); TX comes
+   * from the radio-wide `txTarget`, which carries its OWN frequency and is the
+   * same derivation the App TX authority uses — so the digest can never disagree
+   * with the per-tile TX-target badge. Either side reads `null` — rendered `—`
+   * by `formatFrequency` — when its fact is unobserved; neither is ever defaulted
+   * to the other's value, which is precisely what a split digest must not do.
+   */
+  let rxFrequencyHz = $derived(viewModel.vfos.find((vfo) => vfo.isActive)?.frequencyHz ?? null);
+  let txFrequencyHz = $derived(
+    viewModel.txTarget.status === 'known' ? viewModel.txTarget.frequencyHz : null,
+  );
 </script>
 
 <div class="vfo-surface" role="group" aria-label={groupLabel ?? t('core.vfo.groupLabel')} data-testid="vfo-surface">
@@ -241,6 +309,46 @@
         {t('core.vfo.dualWatch.label')}: {stateWord(viewModel.dualWatch)}
       </button>
     </div>
+
+    <!--
+      MOR-1321. Actions, not facts — so no `role="switch"` and no `aria-checked`:
+      each button DOES a thing once, it does not report a state. The two quick
+      triggers carry the same `disabled` gate their fact toggles above carry.
+      Button text is the accessible name; no `aria-label` duplicates it.
+    -->
+    {#if hasVfoPair}
+      <div class="vfo-ops" data-testid="vfo-ops">
+        <button type="button" class="vfo-op" data-vfo-equalize onclick={() => onEqualizeVfos?.()}>
+          {t('core.vfo.ops.equalize')}
+        </button>
+        <button type="button" class="vfo-op" data-vfo-swap onclick={() => onSwapVfos?.()}>
+          {t('core.vfo.ops.swap')}
+        </button>
+        <button
+          type="button" class="vfo-op" data-vfo-quick-split
+          disabled={viewModel.split.status === 'unknown'}
+          onclick={quickSplit}
+        >
+          {t('core.vfo.ops.quickSplit')}
+        </button>
+        <button
+          type="button" class="vfo-op" data-vfo-quick-dual-watch
+          disabled={viewModel.dualWatch.status === 'unknown'}
+          onclick={quickDualWatch}
+        >
+          {t('core.vfo.ops.quickDualWatch')}
+        </button>
+      </div>
+
+      <!--
+        `data-split-active` carries the split fact's TRI-STATE, so "unknown" is
+        stated rather than collapsed into the legacy bridge's binary dimming.
+      -->
+      <p class="split-digest" data-testid="vfo-split-digest" data-split-active={triState(viewModel.split)}>
+        <span data-split-rx>{t('core.vfo.splitDigest.rx', { frequency: formatFrequency(rxFrequencyHz) })}</span>
+        <span data-split-tx>{t('core.vfo.splitDigest.tx', { frequency: formatFrequency(txFrequencyHz) })}</span>
+      </p>
+    {/if}
   {/if}
 </div>
 
@@ -253,7 +361,9 @@
   .vfo-tile.is-active { border-color: var(--v2-accent-cyan, #00d4ff); }
   .vfo-role { font-weight: 700; color: var(--v2-text-secondary, rgba(255, 255, 255, 0.8)); }
   .vfo-badge { padding: 1px 4px; border-radius: 3px; font-size: 10px; color: var(--v2-accent-red, #ff2020); border: 1px solid var(--v2-accent-red, #ff2020); }
-  .vfo-select, .fact-toggle { border: 1px solid var(--v2-border-panel, rgba(255, 255, 255, 0.12)); border-radius: 4px; background: transparent; color: inherit; cursor: pointer; padding: 3px 6px; }
-  .vfo-select:disabled, .fact-toggle:disabled { color: var(--v2-text-disabled, rgba(255, 255, 255, 0.3)); cursor: not-allowed; }
-  .fact-toggles { display: flex; gap: 6px; }
+  .vfo-select, .fact-toggle, .vfo-op { border: 1px solid var(--v2-border-panel, rgba(255, 255, 255, 0.12)); border-radius: 4px; background: transparent; color: inherit; cursor: pointer; padding: 3px 6px; }
+  .vfo-select:disabled, .fact-toggle:disabled, .vfo-op:disabled { color: var(--v2-text-disabled, rgba(255, 255, 255, 0.3)); cursor: not-allowed; }
+  .fact-toggles, .vfo-ops { display: flex; gap: 6px; flex-wrap: wrap; }
+  .split-digest { display: flex; gap: 8px; margin: 0; font-size: 11px; color: var(--v2-text-subdued, rgba(255, 255, 255, 0.55)); }
+  .split-digest[data-split-active='false'] { opacity: 0.64; }
 </style>

--- a/frontend/src/semantic/__tests__/VfoSurface.test.ts
+++ b/frontend/src/semantic/__tests__/VfoSurface.test.ts
@@ -381,13 +381,22 @@ describe('accessibility basics', () => {
     const target = mountSurface({ viewModel: topologyFixtures['2/main_sub'] });
     const focusable = Array.from(target.querySelectorAll<HTMLButtonElement>('button:not([disabled])'));
     // MAIN A is active (no select button); expect MAIN B, SUB A, SUB B selects,
-    // then the split and dualWatch toggles, in that DOM order.
+    // then the split and dualWatch toggles, then MOR-1321's four ops — facts
+    // before actions, in that DOM order. The classifier NAMES each op rather
+    // than letting an unrecognised button fall through to 'dualWatch', which is
+    // what made this test read four phantom dualWatch entries when the ops row
+    // first landed.
+    const OPS = ['equalize', 'swap', 'quick-split', 'quick-dual-watch'];
     const order = focusable.map(
       (el) => el.dataset.vfoSelect !== undefined
         ? `select:${el.closest('[data-vfo-tile]')?.getAttribute('data-vfo-receiver')}:${el.closest('[data-vfo-tile]')?.getAttribute('data-vfo-slot')}`
-        : el.hasAttribute('data-vfo-split') ? 'split' : 'dualWatch',
+        : el.hasAttribute('data-vfo-split') ? 'split'
+          : el.hasAttribute('data-vfo-dual-watch') ? 'dualWatch'
+            : OPS.find((op) => el.hasAttribute(`data-vfo-${op}`)) ?? 'UNCLASSIFIED',
     );
-    expect(order).toEqual(['select:MAIN:B', 'select:SUB:A', 'select:SUB:B', 'split', 'dualWatch']);
+    expect(order).toEqual([
+      'select:MAIN:B', 'select:SUB:A', 'select:SUB:B', 'split', 'dualWatch', ...OPS,
+    ]);
   });
 });
 
@@ -513,5 +522,255 @@ describe('groupLabel (MOR-1068) — distinct accessible names per mounted surfac
     expect(label).not.toBe('Receiver SUB');
     // i18n coverage: never an unresolved catalog key.
     expect(label).not.toContain('core.vfo.');
+  });
+});
+
+// ── MOR-1321 (S3a): the VFO ops row and the split RX/TX digest ──────────────
+//
+// Receiver-deck parity for the four VFO-scoped ACTIONS the legacy `VfoOps`
+// bridge carried (A=B, A↔B, Quick Split, Quick DW) and the `RX … TX …` digest
+// that sat under them, restated on facts. Every test's doc line names the
+// mutation it exists to kill.
+
+describe('VFO ops (MOR-1321) — structural gating', () => {
+  // Kills: rendering the ops row unconditionally. With one VFO there is nothing
+  // to equalize onto, swap with, or split against — MOR-977 says ABSENT, not
+  // present-and-inert.
+  it('is absent when there is structurally nothing to swap against', () => {
+    const target = mountSurface({ viewModel: topologyFixtures['1/single'] });
+    expect(target.querySelector('[data-testid="vfo-ops"]')).toBeNull();
+    expect(target.querySelector('[data-testid="vfo-split-digest"]')).toBeNull();
+  });
+
+  // The non-vacuous half: the same assertions must NOT hold for a multi-VFO
+  // radio, or "absent" above would be passing for the trivial reason.
+  it.each(['1/ab', '2/ab_shared', '2/main_sub'] as const)(
+    'renders all four ops on the %s topology', (id) => {
+      const target = mountSurface({ viewModel: topologyFixtures[id] });
+      expect(target.querySelector('[data-testid="vfo-ops"]')).not.toBeNull();
+      for (const op of ['equalize', 'swap', 'quick-split', 'quick-dual-watch']) {
+        expect(target.querySelector(`[data-vfo-${op}]`), op).not.toBeNull();
+      }
+    },
+  );
+
+  // Kills: reading `viewModel.vfos.length` directly instead of the pool. A
+  // per-receiver cockpit strip holds ONE vfo but the radio still has a pair —
+  // the same MOR-1067 distinction tile selection already makes.
+  it('follows selectionPoolSize, not the slice length', () => {
+    const sliced: RadioViewModel = {
+      ...topologyFixtures['2/ab_shared'],
+      vfos: topologyFixtures['2/ab_shared'].vfos.filter((v) => v.receiver === 'MAIN'),
+    };
+    expect(mountSurface({ viewModel: sliced }).querySelector('[data-testid="vfo-ops"]')).toBeNull();
+    expect(
+      mountSurface({ viewModel: sliced, selectionPoolSize: 2 }).querySelector('[data-testid="vfo-ops"]'),
+    ).not.toBeNull();
+  });
+
+  // Kills: emitting the ops from a per-receiver strip. They are radio-wide
+  // actions; one per receiver would fire equalize twice from one screen.
+  it('rides with the radio-wide facts, so a per-receiver strip renders none', () => {
+    const target = mountSurface({
+      viewModel: topologyFixtures['2/main_sub'], showRadioWideFacts: false,
+    });
+    expect(target.querySelector('[data-testid="vfo-ops"]')).toBeNull();
+    expect(target.querySelector('[data-testid="vfo-split-digest"]')).toBeNull();
+  });
+});
+
+describe('VFO ops (MOR-1321) — intents', () => {
+  it.each([
+    ['equalize', 'onEqualizeVfos'], ['swap', 'onSwapVfos'],
+    ['quick-split', 'onQuickSplit'], ['quick-dual-watch', 'onQuickDualWatch'],
+  ] as const)('%s emits exactly its own intent, once', (op, prop) => {
+    const spies = {
+      onEqualizeVfos: vi.fn(), onSwapVfos: vi.fn(),
+      onQuickSplit: vi.fn(), onQuickDualWatch: vi.fn(),
+    };
+    const target = mountSurface({ viewModel: topologyFixtures['2/main_sub'], ...spies });
+    target.querySelector<HTMLButtonElement>(`[data-vfo-${op}]`)!.click();
+    flushSync();
+    // Exactly one intent fired, and it was this button's — a cross-wired
+    // handler (swap firing equalize) passes a "was called" assertion alone.
+    for (const [name, spy] of Object.entries(spies)) {
+      expect(spy.mock.calls.length, name).toBe(name === prop ? 1 : 0);
+    }
+  });
+
+  // R9. The ops surface must not grow a key path: none of these four intents
+  // is a TX action, and the surface carries no key/unkey affordance at all.
+  it('R9: the ops row emits no TX intent and mounts no key affordance', () => {
+    const target = mountSurface({ viewModel: topologyFixtures['2/main_sub'] });
+    expect(target.querySelector('[data-testid="rx-tx-surface"]')).toBeNull();
+    const ops = target.querySelector<HTMLElement>('[data-testid="vfo-ops"]')!;
+    expect(ops.querySelectorAll('button')).toHaveLength(4);
+    // Actions, not facts: no switch semantics on any of them.
+    expect(ops.querySelectorAll('[role="switch"]')).toHaveLength(0);
+  });
+});
+
+describe('VFO ops (MOR-1321) — unknown honesty on the quick triggers', () => {
+  const base = topologyFixtures['2/main_sub'];
+
+  // Kills: dropping the `disabled` gate on quick-split. The composite trigger
+  // ends with SPLIT ON — firing it while split is unobserved asks for a state
+  // this surface cannot see reached. Same gate its fact toggle carries.
+  it('quick split is disabled, and inert, while split is unknown', () => {
+    const model = validateRadioViewModel({ ...base, split: { status: 'unknown' } });
+    const onQuickSplit = vi.fn();
+    const target = mountSurface({ viewModel: model, onQuickSplit });
+    const button = target.querySelector<HTMLButtonElement>('[data-vfo-quick-split]')!;
+    expect(button.disabled).toBe(true);
+    // MUTATION KILL: the handler's own guard, independent of the attribute —
+    // deleting either one alone must fail here.
+    button.click();
+    flushSync();
+    expect(onQuickSplit).not.toHaveBeenCalled();
+  });
+
+  it('quick dual watch is disabled, and inert, while dualWatch is unknown', () => {
+    const model = validateRadioViewModel({ ...base, dualWatch: { status: 'unknown' } });
+    const onQuickDualWatch = vi.fn();
+    const target = mountSurface({ viewModel: model, onQuickDualWatch });
+    const button = target.querySelector<HTMLButtonElement>('[data-vfo-quick-dual-watch]')!;
+    expect(button.disabled).toBe(true);
+    button.click();
+    flushSync();
+    expect(onQuickDualWatch).not.toHaveBeenCalled();
+  });
+
+  /**
+   * MOR-1321 fix round (verifier B2) — the DISCRIMINATING half of the two tests
+   * above, and the house pattern this file already applies twice to
+   * `toggleSplit` / `toggleDualWatch` ("even if the native disabled gate is
+   * bypassed").
+   *
+   * A native `disabled` button refuses to dispatch `click` in jsdom and in real
+   * browsers alike, so the click assertions above are satisfied by the ATTRIBUTE
+   * alone and prove nothing about the component's own guard: an independent
+   * verifier's mutant, which deleted the guard line and kept the attribute,
+   * survived all 5075 tests. Forcing the button enabled first separates the two
+   * mechanisms, so deleting EITHER one alone now fails.
+   */
+  it.each([
+    ['quick-split', 'split', 'onQuickSplit'],
+    ['quick-dual-watch', 'dualWatch', 'onQuickDualWatch'],
+  ] as const)(
+    'MUTATION KILL: %s never emits its intent while %s is unknown, ' +
+    'even if the native disabled gate is bypassed',
+    (op, fact, prop) => {
+      const spy = vi.fn();
+      const model = validateRadioViewModel({ ...base, [fact]: { status: 'unknown' } });
+      const target = mountSurface({ viewModel: model, [prop]: spy });
+      const button = target.querySelector<HTMLButtonElement>(`[data-vfo-${op}]`)!;
+      button.disabled = false;
+      button.click();
+      flushSync();
+      expect(spy).not.toHaveBeenCalled();
+    },
+  );
+
+  // The non-vacuous companion: with the fact KNOWN, the same click DOES emit —
+  // so the two assertions above cannot be passing merely because the button was
+  // never wired to anything.
+  it.each([
+    ['quick-split', 'onQuickSplit'],
+    ['quick-dual-watch', 'onQuickDualWatch'],
+  ] as const)('%s emits normally once its fact is known', (op, prop) => {
+    const spy = vi.fn();
+    const target = mountSurface({ viewModel: base, [prop]: spy });
+    target.querySelector<HTMLButtonElement>(`[data-vfo-${op}]`)!.click();
+    flushSync();
+    expect(spy).toHaveBeenCalledOnce();
+  });
+
+  // Kills: gating equalize/swap on an unrelated unknown. Neither reads split or
+  // dual-watch, so an unobserved fact must not make them inert — that would
+  // invent a dependency the radio does not have.
+  it('equalize and swap stay live while both toggle facts are unknown', () => {
+    const model = validateRadioViewModel({
+      ...base, split: { status: 'unknown' }, dualWatch: { status: 'unknown' },
+    });
+    const onEqualizeVfos = vi.fn();
+    const onSwapVfos = vi.fn();
+    const target = mountSurface({ viewModel: model, onEqualizeVfos, onSwapVfos });
+    for (const op of ['equalize', 'swap'] as const) {
+      const button = target.querySelector<HTMLButtonElement>(`[data-vfo-${op}]`)!;
+      expect(button.disabled, op).toBe(false);
+      button.click();
+    }
+    flushSync();
+    expect(onEqualizeVfos).toHaveBeenCalledTimes(1);
+    expect(onSwapVfos).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('split RX/TX digest (MOR-1321)', () => {
+  // Kills: reading TX off the active VFO (or RX off the TX target) — the two
+  // sides would then agree by construction and the digest could never show the
+  // split it exists to show.
+  it('reads RX from the active VFO and TX from the radio-wide txTarget', () => {
+    const model = topologyFixtures['2/main_sub'];
+    const active = model.vfos.find((v) => v.isActive)!;
+    const target = mountSurface({ viewModel: model });
+    const digest = target.querySelector<HTMLElement>('[data-testid="vfo-split-digest"]')!;
+    expect(digest.querySelector('[data-split-rx]')!.textContent)
+      .toContain(expectedFreq(active.frequencyHz));
+    expect(model.txTarget.status).toBe('known');
+    if (model.txTarget.status === 'known') {
+      expect(digest.querySelector('[data-split-tx]')!.textContent)
+        .toContain(expectedFreq(model.txTarget.frequencyHz));
+    }
+  });
+
+  // Unknown honesty, TX side: an unobserved txTarget must render the
+  // placeholder — never fall back to the active VFO's frequency, which would
+  // tell the operator he is transmitting on a frequency nobody observed.
+  it('renders the placeholder for TX while txTarget is unknown', () => {
+    const base = topologyFixtures['2/main_sub'];
+    const model = validateRadioViewModel({
+      ...base,
+      txTarget: { status: 'unknown', reason: 'not-observed' },
+      // The validator refuses `txPermit: 'allowed'` while the target is
+      // unknown (fail-open is not permitted), and refuses `isTxTarget` on a
+      // tile no known target names — so an honest unknown-TX model has to
+      // carry all three, which is exactly the state the radio reports.
+      txPermit: { status: 'unknown', reason: 'tx-target-unknown' },
+      vfos: base.vfos.map((v) => ({ ...v, isTxTarget: false })),
+      disabledReasons: [{ field: 'txTarget', code: 'field-not-observed' }],
+    });
+    const digest = mountSurface({ viewModel: model })
+      .querySelector<HTMLElement>('[data-testid="vfo-split-digest"]')!;
+    expect(digest.querySelector('[data-split-tx]')!.textContent).toContain('—');
+    // ...and RX is still stated, so the placeholder is TX-specific rather than
+    // the whole digest going blank.
+    expect(digest.querySelector('[data-split-rx]')!.textContent).not.toContain('—');
+  });
+
+  // Kills: collapsing the split fact to a boolean for the dimming hook, which
+  // is what the legacy bridge did (`class:inactive={!splitActive}`) and what
+  // this surface must not do.
+  it.each([
+    [{ status: 'known', value: true } as const, 'true'],
+    [{ status: 'known', value: false } as const, 'false'],
+    [{ status: 'unknown' } as const, 'mixed'],
+  ])('carries the split fact as a tri-state (%j)', (split, expected) => {
+    const model = validateRadioViewModel({ ...topologyFixtures['2/main_sub'], split });
+    const digest = mountSurface({ viewModel: model })
+      .querySelector<HTMLElement>('[data-testid="vfo-split-digest"]')!;
+    expect(digest.getAttribute('data-split-active')).toBe(expected);
+  });
+});
+
+describe('MOR-1321 i18n', () => {
+  // Kills: a missing catalog key silently rendering its own dotted name.
+  it('no unresolved catalog key leaks into the ops row or the digest', () => {
+    const target = mountSurface({ viewModel: topologyFixtures['2/main_sub'] });
+    for (const sel of ['vfo-ops', 'vfo-split-digest']) {
+      const text = target.querySelector<HTMLElement>(`[data-testid="${sel}"]`)!.textContent ?? '';
+      expect(text, sel).not.toMatch(/core\.vfo\./);
+      expect(text.trim().length, sel).toBeGreaterThan(0);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Restores the five mechanical VfoHeader affordances lost when S2 (#2236) suppressed the legacy header on desktop-v2: A=B, A↔B, Quick Split, Quick DW, SPLIT RX/TX digest (~78 strict LOC incl. locale keys ×3, per the new binding LOC precedent that locale lines count).
- All five drive the identical legacy command-bus handlers (verifier-checked side-by-side against the header at c2cffb74~1); radio-wide placement (cockpit per-receiver strips render none); operational gating only on the two quick triggers, each pinned independently of the `disabled` attribute in both directions.
- Digest TX follows `txTarget` (the App TX authority derivation — probed under forced divergence); two accepted behavior deltas recorded on the ticket: RX side reads the ACTIVE VFO (improvement over the legacy non-TX-receiver derivation), digest renders on any VFO pair incl. 1/ab.
- Phase-0 parity inventory (28 rows) produced the S3a/S3b split + spin-offs: MOR-1322 (digit tuning, owner-ruled out-of-language), MOR-1323/1324/1325 (vocabulary gaps), MOR-1326 (a11y SPEAK).

## Review provenance
Independent opus verifier (rework domain anchor, session-7): round 1 BLOCKED — B1 ru-RU glossary-token violation (i18n:check red; gate had been omitted from the builder's table) + B2 quick triggers' handler guard not pinned independently (verifier mutant MA survived 5075 tests). Fix round: locale values corrected (i18n:check exit 0), house bypass-pattern tests added; verifier re-applied its own MA both ways (MA-1/MA-2/MA-both/MB all RED, restoration sha-verified). Delta-confirmation: CONFIRMED → PASS; production delta = locale values only, VfoSurface byte-identical; strict LOC +78; R9 probes clean (exactly one key authority, zero TX commands from all five handlers). Landing delta: merge of origin/main (#2237/#2238), no conflicts; post-merge targeted + stub-parity guard 127/127.

## Linear
MOR-1321 (parent program MOR-1263).

🤖 Generated with [Claude Code](https://claude.com/claude-code)