### PR TITLE
feat(MOR-1302): backend specs + field-status seeding for the 5 scope-settings leaves

### DIFF
--- a/frontend/src/lib/state/__tests__/fixtures/empty-store-field-status.json
+++ b/frontend/src/lib/state/__tests__/fixtures/empty-store-field-status.json
@@ -605,17 +605,35 @@
     "observed": false,
     "storePath": "global.slow_state.scanning"
   },
+  "scopeControls.centerType": {
+    "availability": "missing",
+    "freshness": "unknown",
+    "observed": false,
+    "storePath": "scope_controls.global.display.center_type"
+  },
   "scopeControls.dual": {
     "availability": "missing",
     "freshness": "unknown",
     "observed": false,
     "storePath": "scope_controls.global.display.dual"
   },
+  "scopeControls.duringTx": {
+    "availability": "missing",
+    "freshness": "unknown",
+    "observed": false,
+    "storePath": "scope_controls.global.display.during_tx"
+  },
   "scopeControls.edge": {
     "availability": "missing",
     "freshness": "unknown",
     "observed": false,
     "storePath": "scope_controls.global.display.edge"
+  },
+  "scopeControls.fixedEdge": {
+    "availability": "missing",
+    "freshness": "unknown",
+    "observed": false,
+    "storePath": "scope_controls.global.display.fixed_edge"
   },
   "scopeControls.hold": {
     "availability": "missing",
@@ -628,6 +646,12 @@
     "freshness": "unknown",
     "observed": false,
     "storePath": "scope_controls.global.display.mode"
+  },
+  "scopeControls.rbw": {
+    "availability": "missing",
+    "freshness": "unknown",
+    "observed": false,
+    "storePath": "scope_controls.global.display.rbw"
   },
   "scopeControls.receiver": {
     "availability": "missing",
@@ -652,6 +676,12 @@
     "freshness": "unknown",
     "observed": false,
     "storePath": "scope_controls.global.display.speed"
+  },
+  "scopeControls.vbwNarrow": {
+    "availability": "missing",
+    "freshness": "unknown",
+    "observed": false,
+    "storePath": "scope_controls.global.display.vbw_narrow"
   },
   "split": {
     "availability": "missing",

--- a/src/rigplane/core/state_pipeline_contracts.py
+++ b/src/rigplane/core/state_pipeline_contracts.py
@@ -1250,6 +1250,16 @@ def _global_specs() -> tuple[FieldSpec, ...]:
         spec(FieldPath.scope_control("display", "hold"), "bool"),
         spec(FieldPath.scope_control("display", "ref_db"), "float", unit="db"),
         spec(FieldPath.scope_control("display", "speed"), "int"),
+        # MOR-1302: the five ScopeSettingsPopover leaves on ScopeControlsPublic
+        # that had no registered spec (verified against the 0x27 sub-command
+        # decoders in runtime/_civ_rx.py: 0x1B during_tx, 0x1C center_type,
+        # 0x1D vbw_narrow, 0x1E fixed_edge, 0x1F rbw). Read-only, same as the
+        # eight leaves above -- writes go through the scope command path.
+        spec(FieldPath.scope_control("display", "during_tx"), "bool"),
+        spec(FieldPath.scope_control("display", "center_type"), "int"),
+        spec(FieldPath.scope_control("display", "vbw_narrow"), "bool"),
+        spec(FieldPath.scope_control("display", "rbw"), "int"),
+        spec(FieldPath.scope_control("display", "fixed_edge"), "object"),
     )
 
 

--- a/src/rigplane/web/runtime_helpers.py
+++ b/src/rigplane/web/runtime_helpers.py
@@ -195,6 +195,13 @@ _SCOPE_CONTROL_PUBLIC_FIELDS = {
     "refDb": "ref_db",
     "dual": "dual",
     "receiver": "receiver",
+    # MOR-1302: ScopeSettingsPopover leaves (registered FieldSpecs added in
+    # state_pipeline_contracts.py alongside the eight above).
+    "duringTx": "during_tx",
+    "centerType": "center_type",
+    "vbwNarrow": "vbw_narrow",
+    "rbw": "rbw",
+    "fixedEdge": "fixed_edge",
 }
 # Inverse map: backend scope-control leaf name → public ``scopeControls.``
 # suffix, used to project store snapshot fields back out (MOR-557).
@@ -811,6 +818,31 @@ def _project_tx_target(field: FieldSnapshot) -> dict[str, object]:
     return cast(dict[str, object], target.to_dict())
 
 
+def _project_scope_fixed_edge(value: Any) -> dict[str, int]:
+    """Serialise a ``ScopeFixedEdge``-shaped observation value to a dict.
+
+    MOR-1302: the observation value may be a ``ScopeFixedEdge`` dataclass
+    (the 0x1E parse helper's return type) or a plain mapping (tests); either
+    way ``_camel_case_state`` needs a snake_case dict to recurse into for the
+    nested public ``scopeControls.fixedEdge`` leaf.
+    """
+
+    def _int_field(name: str) -> int:
+        raw = (
+            value.get(name)
+            if isinstance(value, Mapping)
+            else getattr(value, name, None)
+        )
+        return raw if isinstance(raw, int) and not isinstance(raw, bool) else 0
+
+    return {
+        "range_index": _int_field("range_index"),
+        "edge": _int_field("edge"),
+        "start_hz": _int_field("start_hz"),
+        "end_hz": _int_field("end_hz"),
+    }
+
+
 def _canonical_snapshot_fields(snapshot: StateSnapshot) -> tuple[FieldSnapshot, ...]:
     path = FieldPath.global_("tx_state", "tx_target")
     targets = tuple(field for field in snapshot.fields if field.path == path)
@@ -939,7 +971,9 @@ def _apply_snapshot_field(
                 scope_controls["receiver"] = 0
             elif receiver_key == "sub":
                 scope_controls["receiver"] = 1
-        if path.name in _SCOPE_CONTROL_PUBLIC_SUFFIXES:
+        if path.name == "fixed_edge":
+            scope_controls["fixed_edge"] = _project_scope_fixed_edge(value)
+        elif path.name in _SCOPE_CONTROL_PUBLIC_SUFFIXES:
             scope_controls[path.name] = value
 
 

--- a/tests/test_state_pipeline_contracts.py
+++ b/tests/test_state_pipeline_contracts.py
@@ -374,6 +374,32 @@ def test_global_scope_control_display_leaves_registered() -> None:
         assert spec.writable is False
 
 
+def test_scope_settings_popover_leaves_registered() -> None:
+    """MOR-1302: the five ScopeSettingsPopover leaves have canonical FieldSpecs.
+
+    ``duringTx``/``centerType``/``vbwNarrow``/``rbw``/``fixedEdge`` are on the
+    ``ScopeControlsPublic`` wire type and read by ``ScopeSettingsPopover.svelte``
+    but, until now, had no registered spec. Types verified against the 0x27
+    sub-command decoders in ``runtime/_civ_rx.py``: 0x1B during_tx (bool),
+    0x1C center_type (int), 0x1D vbw_narrow (bool), 0x1E fixed_edge
+    (``ScopeFixedEdge`` composite -> ``object``), 0x1F rbw (int).
+    """
+    expected = {
+        "during_tx": "bool",
+        "center_type": "int",
+        "vbw_narrow": "bool",
+        "rbw": "int",
+        "fixed_edge": "object",
+    }
+    for name, value_type in expected.items():
+        path = FieldPath.scope_control("display", name)
+        spec = DEFAULT_FIELD_REGISTRY.require(path)
+        assert spec.path == path
+        assert spec.family is FieldFamily.DISPLAY
+        assert spec.value_type == value_type
+        assert spec.writable is False
+
+
 def test_global_key_speed_registered_as_operator_control_int() -> None:
     """MOR-456: ``global.operator_controls.key_speed`` is a registered int.
 

--- a/tests/test_web_runtime_helpers.py
+++ b/tests/test_web_runtime_helpers.py
@@ -28,6 +28,7 @@ from rigplane.core.state_store import (
     StateStore,
 )
 from rigplane.core.tx_target import KnownTxTarget, TxTarget, UnknownTxTarget
+from rigplane.core.types import ScopeFixedEdge
 from rigplane.radio_state import RadioState
 
 
@@ -808,5 +809,99 @@ def test_observed_scope_control_leaves_survive_frontend_parent_veto() -> None:
     )
     field_status = payload["fieldStatus"]
     for suffix in _SCOPE_TOOLBAR_SUFFIXES:
+        path = f"scopeControls.{suffix}"
+        assert _frontend_availability(field_status, path) == "available", suffix
+
+
+_SCOPE_SETTINGS_POPOVER_SUFFIXES = (
+    "duringTx",
+    "centerType",
+    "vbwNarrow",
+    "rbw",
+    "fixedEdge",
+)
+
+
+def test_public_state_projection_covers_scope_settings_popover_leaves() -> None:
+    """MOR-1302: the five ScopeSettingsPopover leaves must project and seed
+    field status exactly like the eight MOR-557 toolbar leaves."""
+    clock = FreshnessClock(start=10.0)
+    store = StateStore(freshness_clock=clock)
+    fixed_edge = ScopeFixedEdge(
+        range_index=1, edge=0, start_hz=7_000_000, end_hz=7_300_000
+    )
+    leaves: dict[str, Any] = {
+        "during_tx": True,
+        "center_type": 2,
+        "vbw_narrow": True,
+        "rbw": 1,
+        "fixed_edge": fixed_edge,
+    }
+    for name, value in leaves.items():
+        store.apply(
+            _observation(
+                FieldPath.scope_control("display", name), value, at=clock.now()
+            )
+        )
+
+    payload = build_public_state_payload_from_snapshot(
+        store.snapshot(), radio=None, receiver_count=2
+    )
+
+    sc = payload["scopeControls"]
+    assert sc["duringTx"] is True
+    assert sc["centerType"] == 2
+    assert sc["vbwNarrow"] is True
+    assert sc["rbw"] == 1
+    assert sc["fixedEdge"] == {
+        "rangeIndex": 1,
+        "edge": 0,
+        "startHz": 7_000_000,
+        "endHz": 7_300_000,
+    }
+
+    for suffix in _SCOPE_SETTINGS_POPOVER_SUFFIXES:
+        status = payload["fieldStatus"][f"scopeControls.{suffix}"]
+        assert status["observed"] is True, suffix
+        assert status["availability"] == "available", suffix
+
+
+def test_default_field_status_seeds_scope_settings_popover_leaves_missing() -> None:
+    """MOR-1302: the five popover leaves are seeded ``missing`` by default,
+    same as the eight existing scope-control toolbar leaves (MOR-429)."""
+    payload = build_public_state_payload_from_snapshot(
+        StateSnapshot.empty(), radio=None, receiver_count=2
+    )
+    field_status = payload["fieldStatus"]
+    for suffix in _SCOPE_SETTINGS_POPOVER_SUFFIXES:
+        status = field_status[f"scopeControls.{suffix}"]
+        assert status["availability"] == "missing", suffix
+        assert status["observed"] is False, suffix
+
+
+def test_observed_scope_settings_popover_leaves_survive_frontend_parent_veto() -> None:
+    """MOR-1302: observed popover leaves resolve ``available`` through the
+    frontend parent-availability walk, same as the MOR-557 toolbar leaves."""
+    clock = FreshnessClock(start=10.0)
+    store = StateStore(freshness_clock=clock)
+    fixed_edge = ScopeFixedEdge(range_index=0, edge=0, start_hz=0, end_hz=0)
+    leaves: dict[str, Any] = {
+        "during_tx": False,
+        "center_type": 0,
+        "vbw_narrow": False,
+        "rbw": 0,
+        "fixed_edge": fixed_edge,
+    }
+    for name, value in leaves.items():
+        store.apply(
+            _observation(
+                FieldPath.scope_control("display", name), value, at=clock.now()
+            )
+        )
+    payload = build_public_state_payload_from_snapshot(
+        store.snapshot(), radio=None, receiver_count=2
+    )
+    field_status = payload["fieldStatus"]
+    for suffix in _SCOPE_SETTINGS_POPOVER_SUFFIXES:
         path = f"scopeControls.{suffix}"
         assert _frontend_availability(field_status, path) == "available", suffix


### PR DESCRIPTION
## Summary
- Registers the 5 ScopeSettingsPopover-adjacent leaves as read-only `scope_control` FieldSpecs with per-leaf field-status seeding mirroring the 8 existing scopeControls leaves (owner-decided scope, 2026-08-05): duringTx (bool, 0x1B), centerType (int, 0x1C), vbwNarrow (bool, 0x1D), rbw (int, 0x1F), fixedEdge (object, 0x1E — composite `FixedEdgePublic`, correcting the ticket's int guess; `tx_target` precedent) + a fixed-edge projector emitting the exact wire keys.
- Frontend facts deferred to 11A″ (MOR-1330, fixedEdge explicitly excluded — no consumer); the 0x1B–0x1F observations-producer gap found during the build is MOR-1329 (sequenced before/with the 11B popover half).

## Review provenance
Independent opus verifier PASS (backend contracts, session-7): all 5 types confirmed independently against the wire type, the 0x27 sub-decoders, and the dataclasses; projector proven key-identical to the untouched default by executing `RadioState().to_dict()` (no snake/camel trap); seeding parity exact (same loop, all writable=False, real dataclasses in tests); mutant battery 7/9 killed with applied-proofs (2 survivors = unreachable defensive branches, equivalent mutants); producer gap confirmed both ways at `_civ_rx.py:2334-2375`; pytest 8815/0, ruff clean, mypy identical 15-error baseline vs main, lint-imports 5 contracts kept; binding LOC 44 net (2 production files).

## Linear
MOR-1302.

🤖 Generated with [Claude Code](https://claude.com/claude-code)