### PR TITLE
feat(MOR-1329): emit CI-V 0x27 sub 0x1B-0x1F scope-settings observations

### DIFF
--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -2336,11 +2336,13 @@ class CivRuntime:
 
         Mirrors the ``_handle_27`` sub-command dispatch for the leaves the web
         layer publishes as ``scopeControls.*`` (MOR-557): receiver/dual/mode/
-        span/edge/hold/ref_db/speed. Sub 0x00 (waterfall pixel data) never
-        reaches here — ``_route_civ_frame`` short-circuits it — and command
-        echoes are dropped earlier by the ``from_addr`` filter. Malformed
-        payloads raise ``ValueError`` in the parse helpers and are swallowed
-        by ``_apply_state_store_observations``.
+        span/edge/hold/ref_db/speed, plus the five ScopeSettingsPopover leaves
+        registered by MOR-1302 (during_tx/center_type/vbw_narrow/fixed_edge/
+        rbw, MOR-1329). Sub 0x00 (waterfall pixel data) never reaches here —
+        ``_route_civ_frame`` short-circuits it — and command echoes are
+        dropped earlier by the ``from_addr`` filter. Malformed payloads raise
+        ``ValueError`` in the parse helpers and are swallowed by
+        ``_apply_state_store_observations``.
         """
         receiver: int | None = None
         pairs: list[tuple[str, Any]] = []
@@ -2366,6 +2368,19 @@ class CivRuntime:
         elif frame.sub == 0x1A:
             receiver, speed = parse_scope_speed_response(frame)
             pairs.append(("speed", speed))
+        elif frame.sub == 0x1B:
+            pairs.append(("during_tx", parse_scope_during_tx_response(frame)))
+        elif frame.sub == 0x1C:
+            receiver, center_type = parse_scope_center_type_response(frame)
+            pairs.append(("center_type", center_type))
+        elif frame.sub == 0x1D:
+            receiver, vbw_narrow = parse_scope_vbw_response(frame)
+            pairs.append(("vbw_narrow", vbw_narrow))
+        elif frame.sub == 0x1E:
+            pairs.append(("fixed_edge", parse_scope_fixed_edge_response(frame)))
+        elif frame.sub == 0x1F:
+            receiver, rbw = parse_scope_rbw_response(frame)
+            pairs.append(("rbw", rbw))
         if receiver is not None:
             pairs.append(("receiver", receiver))
         return [

--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -59,7 +59,7 @@ from rigplane.radio import IcomRadio
 from rigplane.radio_state import RadioState
 from rigplane.scope import ScopeFrame
 from rigplane.core.state_store import FreshnessState, StateSnapshot
-from rigplane.types import CivFrame, Mode, bcd_encode
+from rigplane.types import CivFrame, Mode, ScopeFixedEdge, bcd_encode
 from rigplane.web.radio_poller import CommandQueue, RadioPoller
 
 # ---------------------------------------------------------------------------
@@ -3322,6 +3322,49 @@ _SCOPE_CONTROL_OBSERVATION_CASES = (
             "scope_controls.global.display.receiver": 0,
         },
     ),
+    # MOR-1329: the five MOR-1302 leaves (during_tx/center_type/vbw_narrow/
+    # fixed_edge/rbw) had a registered field-status spec but no 0x27 decoder
+    # wired to emit an observation for them — this closes that gap.
+    (
+        _make_frame(cmd=0x27, sub=0x1B, data=b"\x01"),
+        {"scope_controls.global.display.during_tx": True},
+    ),
+    (
+        _make_frame(cmd=0x27, sub=0x1C, data=b"\x00\x02"),
+        {
+            "scope_controls.global.display.center_type": 2,
+            "scope_controls.global.display.receiver": 0,
+        },
+    ),
+    (
+        _make_frame(cmd=0x27, sub=0x1D, data=b"\x00\x01"),
+        {
+            "scope_controls.global.display.vbw_narrow": True,
+            "scope_controls.global.display.receiver": 0,
+        },
+    ),
+    (
+        _make_frame(
+            cmd=0x27,
+            sub=0x1E,
+            data=b"\x06\x04" + bcd_encode(14_000_000) + bcd_encode(14_350_000),
+        ),
+        {
+            "scope_controls.global.display.fixed_edge": ScopeFixedEdge(
+                range_index=6,
+                edge=4,
+                start_hz=14_000_000,
+                end_hz=14_350_000,
+            ),
+        },
+    ),
+    (
+        _make_frame(cmd=0x27, sub=0x1F, data=b"\x00\x02"),
+        {
+            "scope_controls.global.display.rbw": 2,
+            "scope_controls.global.display.receiver": 0,
+        },
+    ),
 )
 
 
@@ -3378,8 +3421,18 @@ def test_scope_control_observations_project_public(radio: IcomRadio) -> None:
     assert sc["hold"] is True
     assert sc["refDb"] == -10.5
     assert sc["speed"] == 2
+    # MOR-1329: five new leaves
+    assert sc["duringTx"] is True
+    assert sc["centerType"] == 2
+    assert sc["vbwNarrow"] is True
+    assert sc["fixedEdge"]["rangeIndex"] == 6
+    assert sc["fixedEdge"]["edge"] == 4
+    assert sc["fixedEdge"]["startHz"] == 14_000_000
+    assert sc["fixedEdge"]["endHz"] == 14_350_000
+    assert sc["rbw"] == 2
 
-    suffixes = ("receiver", "dual", "mode", "span", "edge", "hold", "refDb", "speed")
+    suffixes = ("receiver", "dual", "mode", "span", "edge", "hold", "refDb", "speed",
+                "duringTx", "centerType", "vbwNarrow", "fixedEdge", "rbw")
     for suffix in suffixes:
         status = payload["fieldStatus"][f"scopeControls.{suffix}"]
         assert status["observed"] is True, suffix

--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -3431,8 +3431,21 @@ def test_scope_control_observations_project_public(radio: IcomRadio) -> None:
     assert sc["fixedEdge"]["endHz"] == 14_350_000
     assert sc["rbw"] == 2
 
-    suffixes = ("receiver", "dual", "mode", "span", "edge", "hold", "refDb", "speed",
-                "duringTx", "centerType", "vbwNarrow", "fixedEdge", "rbw")
+    suffixes = (
+        "receiver",
+        "dual",
+        "mode",
+        "span",
+        "edge",
+        "hold",
+        "refDb",
+        "speed",
+        "duringTx",
+        "centerType",
+        "vbwNarrow",
+        "fixedEdge",
+        "rbw",
+    )
     for suffix in suffixes:
         status = payload["fieldStatus"][f"scopeControls.{suffix}"]
         assert status["observed"] is True, suffix


### PR DESCRIPTION
## Summary
- Closes the producer gap found during MOR-1302: the five scope-settings field-status entries (duringTx/centerType/vbwNarrow/fixedEdge/rbw) now go observed when the radio reports them — five additive `elif` arms in `_scope_control_observations` mirroring the existing eight byte-for-byte in structure. The scope-control ladder is now exhaustive (13 leaves ↔ 13 subs).
- The `is`-identity observer logic is untouched (civ-ptt-observer-identity trap); the cumulative projection test now drives all 13 subs through to the public payload.

## Review provenance
Independent opus verifier PASS (backend contracts, session-7): all 5 FieldPaths cross-checked by EXECUTING `DEFAULT_FIELD_REGISTRY.require()` against the MOR-1302 registrations; receiver form re-derived from the decoder sources (0x1B proven receiver-free on the wire — a prefixed frame raises); 0x1E proven end-to-end (decoded frame → fixedEdge object in fieldStatus, observed/available/fresh, tx_target special-case does not swallow it); mutant battery 6/6 killed (wrong path segment, dropped receiver, 0x1C↔0x1F swap, dropped elif, wrong-registry, object-as-scalar); the 0x1F receiver-0x00 test accommodation ruled legitimate. Gates: pytest 8820/0, ruff clean, mypy identical baseline, lint-imports 5/0. Binding LOC 15 net (1 production file). Post-review delta: verifier-noted test extension applied (cumulative projection test covers the 5 new leaves; 354/354 in-file). Finding A (0x1E legacy-path edge asymmetry) filed as MOR-1334, non-blocking.

## Linear
MOR-1329. Unblocks (with MOR-1330) the 11B ScopeSettingsPopover half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)