### PR TITLE
test(MOR-1318): update fixture assertions for the post-MOR-1258 zone lifecycle

### DIFF
--- a/frontend/fixtures/assertions.ts
+++ b/frontend/fixtures/assertions.ts
@@ -9,6 +9,7 @@
  * manifest — the picture is evidence of the assertions, never a substitute.
  */
 import type { Expectation } from './catalog';
+import { harness } from './harness-state';
 
 export interface AssertionResult {
   name: string;
@@ -97,14 +98,28 @@ export function runAssertions(
     'disabled selects match :disabled (attribute, not styling)');
 
   // ── single TX authority (the layout's hardest invariant) ────────────────
+  // MOR-1258 moved the `.rx-tx-zone` div's render site out from under the
+  // `{#if view}` gate, so the zone can (and, pre-capabilities, does) exist
+  // with zero mounted surfaces — `caps-unloaded` is exactly that state. The
+  // upper bound ("never more than one TX authority") holds unconditionally;
+  // the lower bound ("exactly one, no fewer") only holds once a view model
+  // can exist at all. `harness.caps` — the same value `toRadioViewModel`
+  // gates on (`if (!caps) return null`) — is read directly here instead of
+  // going through `expected`, so this is the real page state driving the
+  // render, not a fixture-id special-case.
   const surfaces = qa('[data-testid="rx-tx-surface"]');
   const keys = qa<HTMLButtonElement>('[data-testid="rx-tx-key"]');
   const unkeys = qa<HTMLButtonElement>('[data-testid="rx-tx-unkey"]');
-  const txExpected = expected.zones.includes('rx-tx') ? 1 : 0;
+  const zoneDeclared = expected.zones.includes('rx-tx');
+  const capsLoaded = harness.caps !== null;
+  const txMax = zoneDeclared ? 1 : 0;
+  const txMin = zoneDeclared && capsLoaded ? 1 : 0;
   check('single-tx-authority-surface',
-    surfaces.length === txExpected && keys.length === txExpected
-      && unkeys.length === txExpected,
-    `${surfaces.length} surfaces / ${keys.length} key / ${unkeys.length} unkey`);
+    surfaces.length <= txMax && keys.length <= txMax && unkeys.length <= txMax
+      && surfaces.length >= txMin && keys.length >= txMin && unkeys.length >= txMin,
+    `${surfaces.length} surfaces / ${keys.length} key / ${unkeys.length} unkey · `
+    + `expected ${txMin === txMax ? txMin : `${txMin}-${txMax}`} `
+    + `(zone declared=${zoneDeclared}, caps loaded=${capsLoaded})`);
   check('unkey-is-never-gated', unkeys.every((b) => !b.disabled),
     'no unkey control carries `disabled`');
   if (keys.length === 1) {
@@ -151,8 +166,19 @@ export function runAssertions(
     'scope + controls: aria-disabled, empty, claiming no manifest zone');
 
   // ── nothing is hidden (MOR-1069 policy 2 — only decidable in a browser) ─
+  // A declared zone with no children (MOR-1258's `.rx-tx-zone`, rendered
+  // before capabilities load, is the only real case today) is not "hidden" —
+  // there is nothing inside it to hide. `visible()` measures laid-out box
+  // size, which is legitimately 0x0 for an empty flex container; that is a
+  // true and honest reading of "empty", not a bug this assertion should
+  // flag. A zone that DOES have content must still lay out visibly.
+  const isEmptyZone = (el: HTMLElement): boolean =>
+    el.hasAttribute('data-zone-id')
+    && el.childElementCount === 0
+    && (el.textContent ?? '').trim() === '';
   const hideable = [...qa<HTMLElement>('[data-zone-id]'), ...controls(),
-    ...qa<HTMLElement>('[data-testid^="channel-strip-"]')];
+    ...qa<HTMLElement>('[data-testid^="channel-strip-"]')]
+    .filter((el) => !isEmptyZone(el));
   const hidden = hideable.filter((el) => !visible(el));
   check('nothing-hidden', hidden.length === 0,
     hidden.length === 0


### PR DESCRIPTION
## Summary
- `single-tx-authority-surface` splits into an unconditional upper bound (≤1 mounted RxTxSurface when the rx-tx zone is declared) and a caps-gated lower bound (=1 once capabilities load) reading `harness.caps` — the same signal `toRadioViewModel` gates on — instead of deriving surface counts from catalog `expected.zones` (the pre-MOR-1258 assumption).
- `nothing-hidden` exempts declared zone containers with zero element descendants (the zone div legitimately exists empty pre-capabilities since MOR-1258); real hidden controls still fail.
- Fixture matrix: 31/31 captures, **0 invalid** for the first time (baseline: 1 invalid). Unblocks MOR-1085.

## Review provenance
Independent opus verifier PASS (fixtures/evidence anchor, session-7): both root causes from its own MOR-1281-round analysis confirmed removed (no expected.zones truth-derivation; no fixture-id special-cases by grep); the caps signal proven identical to the production gate (`main.ts:66` → same object → `if (!caps) return null`), with the asymmetry vs the topology gate strictly fail-safe; child-predicate sabotaged with a planted zero-size focusable button in the empty zone (fails correctly, incl. display:none variant); both bounds proven to bite via live DOM mutations with zero worktree edits (sha256-matched exit); matrix diff = exactly one outcome change + enriched detail strings on all 31 (evidence enrichment, recorded for MOR-1085). Non-blocking caveat recorded: emptied-but-populated zones are caught by content assertions, so "new declared zone needs its own content assertion" joins the MOR-1085 checklist. 1 file, 0 production LOC; lint/boundaries/check clean.

## Linear
MOR-1318.

🤖 Generated with [Claude Code](https://claude.com/claude-code)