### PR TITLE
feat(MOR-1336): txAux zone ownership via a generic zone mount (rework S4)

### DIFF
--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -21,7 +21,7 @@
 </script>
 
 <script lang="ts">
-  import { onDestroy } from 'svelte';
+  import { onDestroy, type Snippet } from 'svelte';
   import { t } from '$lib/i18n';
   import { runtime } from '$lib/runtime';
   import { toRadioViewModel } from '$lib/runtime/adapters/radio-view-model-adapter';
@@ -90,6 +90,38 @@
   let singleOrder = $derived(compositionSurfaces(surfacePlan(), SINGLE_COMPOSITION));
   function zoneShows(zoneId: string, surface: SemanticSurfaceName): boolean {
     return zoneShowsSurface(surfacePlan(), zoneId, surface);
+  }
+  /**
+   * MOR-1336 (v3-rework S4) — the DECLARED zone that mounts `surface`, or
+   * `null` when no zone does.
+   *
+   * This is the whole zone-ownership mechanism, and it is GENERIC: any
+   * `SEMANTIC_SURFACE_NAMES` member a layout declares mounts through the one
+   * `zoned` path below, so the next declarable surface needs no new code and
+   * `txAux` is not a third hardcoded special case beside `vfo`/`rxTx`.
+   *
+   * It reads the SURFACE PLAN, never a manifest — this file stays manifest-blind
+   * (the MOR-1068 cycle). That works because `resolveSurfacePlan` keys its map
+   * by `manifest.zones`, so the plan's KEY SET is exactly the active layout's
+   * declared-zone set. App already computes it; this only consults it.
+   *
+   * `null` → the caller renders BARE, byte-identical to the pre-S4 DOM. That is
+   * MOR-1069 enforced by construction: a zone element exists only where a
+   * layout actually declared one, never as an empty promise.
+   *
+   * LIMITATION, recorded rather than hidden: the plan is POST-subtraction, so
+   * "no zone declares this" and "a zone declared it and the workspace hid it"
+   * are indistinguishable here, and both render bare. That matches today
+   * exactly (these surfaces consult no plan at all before this slice), so no
+   * force-show is introduced and nothing regresses — but the workspace still
+   * cannot hide a zoned optional surface. Fixing that needs `SurfacePlan` to
+   * carry declaration and visibility separately (own ticket).
+   */
+  function zoneOwning(surface: SemanticSurfaceName): string | null {
+    const plan = surfacePlan();
+    if (plan === null) return null;
+    for (const [zoneId, surfaces] of plan) if (surfaces.includes(surface)) return zoneId;
+    return null;
   }
   /** The dual composition's per-receiver strips, after the workspace. Filtering
    *  the `{#each}` SOURCE rather than wrapping its body keeps ONE place that
@@ -425,6 +457,34 @@
     view is null" behavior now that the surrounding structure changed
     around it (MOR-1258).
   -->
+  <!--
+    MOR-1336 — the ONE zone-aware mount path, applied uniformly to every
+    optional surface that used to render bare. Declared → a real zone element
+    the layout's arrangement can place; undeclared → bare, exactly as before.
+
+    Deliberately NOT applied to `vfo`/`rxTx`: those carry per-receiver slicing,
+    the `showVfoList`/`showRadioWideFacts` split and the R6 TX-adjacent alerts,
+    none of which a uniform wrapper can express. Genericity is applied where it
+    is honest; the two bespoke arrangements stay bespoke and are documented as
+    such rather than forced through this path.
+
+    `present` is the surface's OWN structural gate, hoisted to the wrap
+    decision. Without it a declared zone would render as an empty `<div>` for a
+    radio whose view model carries no such group — an "empty promise" zone,
+    exactly what MOR-1069 forbids. The snippet bodies keep their own `{#if}`
+    as well: one decides whether the zone exists, the other whether the surface
+    does, and they must agree.
+  -->
+  {#snippet zoned(surface: SemanticSurfaceName, present: boolean, body: Snippet)}
+    {#if present}
+      {@const zoneId = zoneOwning(surface)}
+      {#if zoneId === null}{@render body()}
+      {:else}
+        <div class="surface-zone" data-zone-id={zoneId}>{@render body()}</div>
+      {/if}
+    {/if}
+  {/snippet}
+
   {#snippet txAuxSurface()}
     {#if view?.txAux}
       <TxAuxSurface
@@ -512,8 +572,8 @@
       {#if zoneShows('rx-tx', 'rxTx')}{@render rxTxSurface()}{/if}
       {@render txAdjacentAlerts()}
     </div>
-    {@render txAuxSurface()}
-    {@render metersSurface()}
+    {@render zoned('txAux', view?.txAux !== undefined, txAuxSurface)}
+    {@render zoned('meters', view?.meters !== undefined, metersSurface)}
   {:else}
     <!--
       Single/default path (sdr-test / LCD / mobile): no bound zone exists
@@ -531,9 +591,9 @@
       {#if surface === 'vfo'}{@render vfoSurface()}
       {:else if surface === 'rxTx'}{@render rxTxSurface()}{/if}
     {/each}
-    {@render txAuxSurface()}
-    {@render metersSurface()}
-    {@render rxAudioSurface()}
+    {@render zoned('txAux', view?.txAux !== undefined, txAuxSurface)}
+    {@render zoned('meters', view?.meters !== undefined, metersSurface)}
+    {@render zoned('rxAudio', view?.rxAudio !== undefined, rxAudioSurface)}
     {@render txAdjacentAlerts()}
   {/if}
 </div>
@@ -572,6 +632,14 @@
      TX-adjacent alerts it gained, so it owns this minimal layout — the
      alerts and RxTxSurface still each own their own internal presentation. */
   .rx-tx-zone {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  /* MOR-1336: a declared zone must be a real box the arrangement can place —
+     the MOR-1069 lesson that an inert `display: contents` wrapper cannot be a
+     grid/flex item. Layout only; the surface owns its own presentation. */
+  .surface-zone {
     display: flex;
     flex-direction: column;
     gap: 8px;

--- a/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
@@ -291,11 +291,20 @@ describe('the txAux surface mounts only when the view model carries the group', 
     expect(target.querySelectorAll('[data-testid="tx-aux-surface"]')).toHaveLength(1);
   });
 
-  // MUTATION KILLED: giving the txAux surface a `data-zone-id` here. Zone
-  // declarability comes from `SEMANTIC_SURFACE_NAMES`; no manifest declares a
-  // txAux zone in this slice, so binding one would put a zone id in the DOM
-  // that no layout manifest ever declared (the MOR-1069 lesson).
-  it('binds no zone id to the txAux surface in either composition', () => {
+  // MOR-1336 (S4) UPDATE: the cockpit manifest DOES declare a `tx-aux` zone
+  // now (`presentation/layouts/dual-receiver-cockpit.ts`) — what this pin
+  // still proves is the STANDALONE-mount path: with no resolved plan handed
+  // down through context (`render`'s default here), `zoneOwning` reads no
+  // plan and returns `null` for every surface, so the mount stays bare
+  // regardless of what any manifest declares (`useSurfacePlan()`'s documented
+  // fallback). The zoned case — a plan actually supplied — is pinned
+  // separately in `MOR-1336 — the zone-mount mechanism generalizes beyond
+  // txAux` below and in `DualReceiverCockpit.component.test.ts`'s F6 suite.
+  // MUTATION KILLED: giving the txAux surface a `data-zone-id` here anyway,
+  // i.e. ignoring the plan and binding a zone id unconditionally (the
+  // MOR-1069 lesson: a zone element must exist only where BOTH a layout
+  // declared one AND a plan actually resolved it).
+  it('binds no zone id to the txAux surface in either composition, absent a resolved plan', () => {
     render({ strips: 'dual' });
     const zones = [...target.querySelectorAll<HTMLElement>('[data-zone-id]')]
       .map((el) => el.dataset.zoneId);
@@ -324,6 +333,25 @@ describe('the txAux surface does not become a second key path', () => {
     expect(h.atuTune).toHaveBeenCalledOnce();
     expect(h.start).not.toHaveBeenCalled();
     expect(h.release).not.toHaveBeenCalled();
+  });
+
+  // MOR-1336 (S4) restated (R9): the invariant above holds vacuously once
+  // txAux is ALWAYS unzoned — no plan was ever supplied, so `zoneOwning`
+  // always returned null. Restated against a RESOLVED plan that actually
+  // zones txAux (the cockpit's own), so "no second key authority" is proven
+  // for the zoned surface, not merely the bare one.
+  it('still keeps exactly one key/unkey authority once a resolved plan actually zones txAux', () => {
+    const plan = resolveSurfacePlan(dualReceiverCockpitLayout, readWorkspace({ version: 1 }).workspace);
+    render({ strips: 'dual' }, plan);
+
+    const zone = q('[data-zone-id="tx-aux"]');
+    expect(zone).not.toBeNull(); // sanity: the zone this pin restates for actually exists
+    expect(target.querySelectorAll('[data-testid="rx-tx-surface"]')).toHaveLength(1);
+    expect(target.querySelectorAll('[data-testid="rx-tx-key"]')).toHaveLength(1);
+    expect(target.querySelectorAll('[data-testid="rx-tx-unkey"]')).toHaveLength(1);
+    // ...and none of them live inside the tx-aux zone itself.
+    expect(zone!.querySelector('[data-testid="rx-tx-key"]')).toBeNull();
+    expect(zone!.querySelector('[data-testid="rx-tx-unkey"]')).toBeNull();
   });
 });
 
@@ -514,5 +542,76 @@ describe('MOR-1082 — the semantic vertical consults the resolved surface plan'
     document.body.innerHTML = '';
     render({ strips: 'single' });
     expect(surfaceOrder()).toEqual(['vfo-surface', 'rx-tx-surface']);
+  });
+});
+
+// ── MOR-1336 (S4) — the zone-mount mechanism is generic, not txAux-shaped ───
+//
+// `zoneOwning`/`zoned` in `SemanticRadioSurfaces` is written ONCE and applied
+// uniformly to every optional surface (txAux, meters, and — single
+// composition only — rxAudio). Every pin above proves it exclusively against
+// txAux, which is also the one real manifest happens to declare a zone for —
+// a wiring change that special-cased `if (surface === 'txAux')` would pass
+// every one of them just as well. These pins exercise the SAME mechanism
+// against `meters`, a structurally unrelated surface, through a SYNTHETIC
+// plan no shipped manifest declares, so it is the mechanism's own generality
+// under test, not any layout's arrangement.
+describe('MOR-1336 — the zone-mount mechanism generalizes beyond txAux', () => {
+  /**
+   * Enough raw state for `deriveMeters` (`radio-view-model-adapter.ts`) to
+   * emit the `meters` group: the TX authority and `state` are already
+   * supplied by every fixture here, so one observed raw meter field is the
+   * only thing missing — `deriveMeters` emits the group the moment any of
+   * its seven raw fields is defined, `caps.tx` untouched.
+   */
+  function withMeterReading(state: ServerState): ServerState {
+    return {
+      ...state,
+      powerMeter: 50,
+      fieldStatus: { ...(state.fieldStatus as Record<string, unknown>), powerMeter: fresh },
+    } as unknown as ServerState;
+  }
+
+  it('mounts a real zone element for meters when a plan declares one, under an id no shipped manifest uses', () => {
+    h.state = withMeterReading(liveState(false));
+    h.caps = liveCaps(false);
+    // MUTATION KILLED: a mechanism secretly keyed on the literal 'tx-aux' id
+    // or on `SEMANTIC_SURFACE_NAMES` order rather than the plan's own keys.
+    const plan: SurfacePlan = new Map([['synthetic-meters-zone', ['meters']]]);
+    render({ strips: 'dual' }, plan);
+
+    const zone = q('[data-zone-id="synthetic-meters-zone"]');
+    expect(zone).not.toBeNull();
+    expect(zone!.classList.contains('surface-zone')).toBe(true);
+    expect(q('[data-testid="meters-surface"]')!.parentElement).toBe(zone);
+  });
+
+  it('renders the identical meters content bare when no plan declares a zone for it', () => {
+    h.state = withMeterReading(liveState(false));
+    h.caps = liveCaps(false);
+    render({ strips: 'dual' }); // no plan at all — the pre-S4 / standalone-mount path
+
+    const surface = q('[data-testid="meters-surface"]');
+    expect(surface).not.toBeNull();
+    expect(surface!.closest('.surface-zone')).toBeNull();
+    expect(surface!.closest('[data-zone-id]')).toBeNull();
+  });
+});
+
+// ── MOR-1336 (S4) — a declared zone is never an empty promise ───────────────
+describe('MOR-1336 — a declared zone renders nothing for a radio without the group', () => {
+  // MUTATION KILLED: wrapping the zone unconditionally on `zoneId !== null`
+  // rather than gating on the surface's own `present` argument first — the
+  // exact regression the `zoned` snippet's `present` parameter exists to
+  // prevent (see the handover note on `SemanticRadioSurfaces.svelte`).
+  it('mounts no tx-aux zone element for a radio without the group, even though the cockpit declares one', () => {
+    h.state = liveState(false);
+    h.caps = liveCaps(false);
+    const plan = resolveSurfacePlan(dualReceiverCockpitLayout, readWorkspace({ version: 1 }).workspace);
+    render({ strips: 'dual' }, plan);
+
+    expect(q('[data-testid="tx-aux-surface"]')).toBeNull();
+    expect(q('[data-zone-id="tx-aux"]')).toBeNull();
+    expect(target.innerHTML).not.toContain('tx-aux');
   });
 });

--- a/frontend/src/presentation/layouts/__tests__/desktop-v2-registration.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/desktop-v2-registration.test.ts
@@ -55,10 +55,12 @@ describe('the desktop-v2 entrypoint is registered in the real registry', () => {
 describe('declared zones now drive the DOM (MOR-1263 step 2, MOR-1313)', () => {
   // Kills: declaring a surface this manifest does not name, or dropping
   // either one — the pair per-zone suppression consumes.
-  it('declares receiver-deck:[vfo] and rx-tx:[rxTx]', () => {
+  it('declares receiver-deck:[vfo], rx-tx:[rxTx] and tx-aux:[txAux]', () => {
     expect(desktopV2Layout.zones).toEqual([
       { id: 'receiver-deck', surfaces: ['vfo'] },
       { id: 'rx-tx', surfaces: ['rxTx'] },
+      // MOR-1336 (S4): txAux became zone-owned. Declared, deliberately not required.
+      { id: 'tx-aux', surfaces: ['txAux'] },
     ]);
     expect([...desktopV2Layout.requiredSemanticSurfaces].sort()).toEqual(['rxTx', 'vfo']);
   });
@@ -79,7 +81,7 @@ describe('declared zones now drive the DOM (MOR-1263 step 2, MOR-1313)', () => {
   // splits the pair ACROSS two zones, so it is the one that proves the walk
   // is per-zone rather than per-manifest-first-zone.
   it('its two zones flatten to the surfaces the shell suppresses legacy twins for', () => {
-    expect([...declaredSurfaces(getLayout('desktop-v2'))].sort()).toEqual(['rxTx', 'vfo']);
+    expect([...declaredSurfaces(getLayout('desktop-v2'))].sort()).toEqual(['rxTx', 'txAux', 'vfo']);
   });
 });
 

--- a/frontend/src/presentation/layouts/__tests__/dual-receiver-cockpit.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/dual-receiver-cockpit.test.ts
@@ -31,6 +31,8 @@ describe('the dual-receiver-cockpit real registration', () => {
       { id: 'secondary-vfo', surfaces: ['vfo'] },
       { id: 'global', surfaces: ['vfo'] },
       { id: 'rx-tx', surfaces: ['rxTx'] },
+      // MOR-1336 (S4): the cockpit's txAux controls gain a zone of their own.
+      { id: 'tx-aux', surfaces: ['txAux'] },
     ]);
     expect(dualReceiverCockpitLayout.requiredSemanticSurfaces).toEqual(['vfo', 'rxTx']);
   });

--- a/frontend/src/presentation/layouts/__tests__/tx-aux-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/tx-aux-declarability.test.ts
@@ -1,5 +1,5 @@
 /**
- * MOR-1265 — `txAux` is DECLARABLE, and nothing declares it yet.
+ * MOR-1265 — `txAux` is DECLARABLE. MOR-1336 (S4) declares it for real.
  *
  * Slice 1B adds the name to `SEMANTIC_SURFACE_NAMES` so a manifest CAN mount
  * the surface later; it deliberately does not touch any manifest. Both halves
@@ -7,8 +7,13 @@
  *   - drop the name and a future manifest's zone stops validating (the whole
  *     point of this slice's contract change);
  *   - quietly add a `txAux` zone to a shipped manifest and the DOM grows a
- *     zone id no layout review ever saw. That is out of scope here and is
- *     what the second test refuses.
+ *     zone id no layout review ever saw.
+ *
+ * MOR-1336 flipped the second half: `desktop-v2` and `dual-receiver-cockpit`
+ * now DO declare a `tx-aux` zone, and the surface mounts through it. The
+ * inventory below is a LITERAL of who declares it, so a third family gaining
+ * the zone without review still fails here — the guard's direction changed, its
+ * job did not.
  */
 import { describe, it, expect } from 'vitest';
 import { SEMANTIC_SURFACE_NAMES, validateLayoutManifest } from '../contract';
@@ -43,16 +48,40 @@ describe('txAux is a declarable semantic surface', () => {
   });
 });
 
-describe('no shipped manifest declares a txAux zone in this slice', () => {
-  // Kills: slipping a txAux zone into an existing layout here. Declarability
-  // is the whole scope of MOR-1265; placing the surface in a real layout is a
-  // later, separately reviewed slice.
-  it.each([
+describe('exactly the reviewed manifests declare a txAux zone (MOR-1336)', () => {
+  /** The literal — extend by hand, with a layout review, never silently. */
+  const DECLARES_TX_AUX = ['desktop-v2', 'dual-receiver-cockpit'];
+
+  const ALL = [
     ['sdr-test', sdrTestLayout], ['dual-receiver-cockpit', dualReceiverCockpitLayout],
     ['lcd-cockpit', lcdCockpitLayout], ['lcd-scope', lcdScopeLayout],
     ['mobile', mobileLayout], ['desktop-v2', desktopV2Layout],
-  ])('%s declares no txAux zone and does not require the surface', (_id, manifest) => {
-    for (const zone of manifest.zones) expect(zone.surfaces).not.toContain('txAux');
+  ] as const;
+
+  // Kills BOTH directions: a family losing the zone S4 gave it, and a family
+  // gaining one without review.
+  it('the declaring set is exactly the reviewed literal', () => {
+    const declaring = ALL
+      .filter(([, m]) => m.zones.some((z) => z.surfaces.includes('txAux')))
+      .map(([id]) => id)
+      .sort();
+    expect(declaring).toEqual([...DECLARES_TX_AUX].sort());
+  });
+
+  // Kills: declaring the zone under a drifted id — the wiring binds whatever
+  // the plan's key is, so the id IS the contract with the layout's arrangement.
+  it.each(DECLARES_TX_AUX)('%s declares it under the stable `tx-aux` id, alone in its zone', (id) => {
+    const manifest = ALL.find(([name]) => name === id)![1];
+    const zone = manifest.zones.find((z) => z.surfaces.includes('txAux'))!;
+    expect(zone.id).toBe('tx-aux');
+    expect(zone.surfaces).toEqual(['txAux']);
+  });
+
+  // Kills: making txAux REQUIRED. A radio whose MOR-1244 evidence gate declined
+  // the group must still resolve these layouts; the surface self-gates on
+  // `view.txAux`, and a required surface no zone could fill would be a
+  // resolution failure rather than an honest absence.
+  it.each(ALL)('%s does not require the txAux surface', (_id, manifest) => {
     expect(manifest.requiredSemanticSurfaces).not.toContain('txAux');
   });
 });

--- a/frontend/src/presentation/layouts/desktop-declarations.ts
+++ b/frontend/src/presentation/layouts/desktop-declarations.ts
@@ -36,6 +36,10 @@ import { registerLayout, type LayoutManifest } from './contract';
 const DESKTOP_V2_ZONES = [
   { id: 'receiver-deck', surfaces: ['vfo'] },
   { id: 'rx-tx', surfaces: ['rxTx'] },
+  // MOR-1336 (S4): txAux becomes zone-OWNED here. Declared but deliberately not
+  // `required` — a radio whose MOR-1244 evidence gate declined the group must
+  // still resolve this layout, and the surface self-gates on `view.txAux`.
+  { id: 'tx-aux', surfaces: ['txAux'] },
 ] as const;
 
 export const desktopV2Layout: LayoutManifest = {

--- a/frontend/src/presentation/layouts/dual-receiver-cockpit.ts
+++ b/frontend/src/presentation/layouts/dual-receiver-cockpit.ts
@@ -77,6 +77,10 @@ export const dualReceiverCockpitLayout: LayoutManifest = {
     { id: 'secondary-vfo', surfaces: ['vfo'] },
     { id: 'global', surfaces: ['vfo'] },
     { id: 'rx-tx', surfaces: ['rxTx'] },
+    // MOR-1336 (S4): the cockpit declares it too, so the MOR-1069 invariant has a
+    // live txAux zone to bite on in the DUAL composition — where the surface's
+    // three focusable controls previously sat outside every zone.
+    { id: 'tx-aux', surfaces: ['txAux'] },
   ],
   compatibleTopologies: ['2/ab_shared', '2/main_sub'],
   requiredSemanticSurfaces: ['vfo', 'rxTx'],

--- a/frontend/src/presentation/workspace/__tests__/preferences-adoption.test.ts
+++ b/frontend/src/presentation/workspace/__tests__/preferences-adoption.test.ts
@@ -130,6 +130,8 @@ describe('MOR-1082 — the surface plan starts from what the manifest declares',
   it('is the manifest, verbatim, for a workspace that expresses no preference', () => {
     expect([...plan(dualReceiverCockpitLayout)]).toEqual([
       ['primary-vfo', ['vfo']], ['secondary-vfo', ['vfo']], ['global', ['vfo']], ['rx-tx', ['rxTx']],
+      // MOR-1336 (S4): the cockpit now declares a tx-aux zone too.
+      ['tx-aux', ['txAux']],
     ]);
     expect([...plan(sdrTestLayout)]).toEqual([['main', ['vfo', 'rxTx']]]);
   });
@@ -241,6 +243,8 @@ describe('MOR-1082 — the surface plan starts from what the manifest declares',
     );
     expect([...resolveSurfacePlan(dualReceiverCockpitLayout, read.workspace)]).toEqual([
       ['primary-vfo', ['vfo']], ['secondary-vfo', ['vfo']], ['global', ['vfo']], ['rx-tx', ['rxTx']],
+      // MOR-1336 (S4): the cockpit now declares a tx-aux zone too.
+      ['tx-aux', ['txAux']],
     ]);
   });
 });
@@ -258,8 +262,9 @@ describe('MOR-1082 — the single-composition order comes from the same plan', (
 
   it('flattens the plan in zone-declaration order, deduped', () => {
     expect(compositionSurfaces(plan(sdrTestLayout), FALLBACK)).toEqual(['vfo', 'rxTx']);
-    // desktop-v2 spreads the same two surfaces over two zones.
-    expect(compositionSurfaces(plan(desktopV2Layout), FALLBACK)).toEqual(['vfo', 'rxTx']);
+    // desktop-v2 spreads the same two surfaces over two zones, plus its own
+    // MOR-1336 (S4) tx-aux zone — flattening never drops a third zone.
+    expect(compositionSurfaces(plan(desktopV2Layout), FALLBACK)).toEqual(['vfo', 'rxTx', 'txAux']);
     expect(compositionSurfaces(plan(sdrTestLayout, { zoneOrder: { main: ['rxTx', 'vfo'] } }), FALLBACK))
       .toEqual(['rxTx', 'vfo']);
   });

--- a/frontend/src/presentation/workspace/contract.ts
+++ b/frontend/src/presentation/workspace/contract.ts
@@ -49,7 +49,7 @@ export const WORKSPACE_THEME_IDS = [
 export type WorkspaceThemeId = (typeof WORKSPACE_THEME_IDS)[number];
 
 /** Every zone id declared by a registered layout manifest (decisions 5 and 6). */
-export const WORKSPACE_ZONE_IDS = ['main', 'receiver-deck', 'rx-tx', 'primary-vfo', 'secondary-vfo', 'global', 'portrait-deck', 'control-column'] as const;
+export const WORKSPACE_ZONE_IDS = ['main', 'receiver-deck', 'rx-tx', 'primary-vfo', 'secondary-vfo', 'global', 'portrait-deck', 'control-column', 'tx-aux'] as const;
 export type WorkspaceZoneId = (typeof WORKSPACE_ZONE_IDS)[number];
 
 /** Decision 7: command-bus intent names (`set_compressor`), never module paths. */

--- a/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
+++ b/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
@@ -91,6 +91,10 @@ import DualReceiverCockpit from '../DualReceiverCockpit.svelte';
 // dual-receiver-cockpit' directly), so the DOM assertions below are checked
 // against what the app actually registers rather than a local copy.
 import { dualReceiverCockpitLayout } from '../../../presentation/layouts/declarations';
+import { readWorkspace } from '../../../presentation/workspace/contract';
+import {
+  resolveSurfacePlan, SURFACE_PLAN_CONTEXT_KEY, type SurfacePlan,
+} from '../../../presentation/workspace/resolution';
 
 type Snapshot = {
   phase: string; intent: string | null; guard: { leaseId: string } | null;
@@ -118,9 +122,17 @@ function mainSubState(active: 'MAIN' | 'SUB' = 'MAIN'): ServerState {
     fieldStatus: Object.fromEntries(paths.map((p) => [p, fresh])),
   } as unknown as ServerState;
 }
+/**
+ * MOR-1336 (S4): the cockpit declares a `tx-aux` zone now, so this fixture must
+ * carry enough TX-aux evidence for the MOR-1244 gate to emit the group —
+ * otherwise the surface self-gates away, the zone has nothing to hold, and the
+ * F6 "every declared zone renders" invariant fails for the right reason but the
+ * wrong cause. `tuner` is the cheapest honest evidence (`deriveTxAux` accepts a
+ * capability tag OR a raw value); everything else stays as it was.
+ */
 const mainSubCaps = (): Capabilities => ({
   model: 'fixture', scope: false, audio: true, tx: true,
-  capabilities: ['audio', 'tx', 'dual_rx'], receivers: 2, vfoScheme: 'main_sub',
+  capabilities: ['audio', 'tx', 'dual_rx', 'tuner'], receivers: 2, vfoScheme: 'main_sub',
   freqRanges: [], modes: [], filters: [],
   audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
   webrtc: { available: false, enabled: false },
@@ -194,11 +206,30 @@ const dualRxUnavailableCaps = (): Capabilities => ({
 let target: HTMLDivElement;
 let component: ReturnType<typeof mount> | null = null;
 
-function render(): void {
+/**
+ * `plan` mirrors what App actually hands down through context (MOR-1082) —
+ * omitted, this is the pre-1082/standalone mount `useSurfacePlan()` documents
+ * ("Absent by design ... every consumer renders its declared composition
+ * unchanged"), which is what every pre-existing test below still exercises.
+ * The MOR-1336 (S4) generic zone-mount mechanism reads the SAME plan
+ * (`zoneOwning` in `SemanticRadioSurfaces`), so proving the cockpit's new
+ * `tx-aux` zone actually binds — rather than merely being declared — needs a
+ * resolved plan supplied, exactly as it is supplied in production.
+ */
+function render(plan?: SurfacePlan): void {
   target = document.createElement('div');
   document.body.appendChild(target);
-  component = mount(DualReceiverCockpit, { target });
+  const context = plan === undefined
+    ? undefined
+    : new Map<unknown, unknown>([[SURFACE_PLAN_CONTEXT_KEY, () => plan]]);
+  component = mount(DualReceiverCockpit, { target, context });
   flushSync();
+}
+
+/** The plan App resolves for the cockpit when the operator expressed no
+ *  visibleSurfaces/zoneOrder preference — i.e. every declared zone, verbatim. */
+function defaultPlan(): SurfacePlan {
+  return resolveSurfacePlan(dualReceiverCockpitLayout, readWorkspace({ version: 1 }).workspace);
 }
 
 const q = <T extends HTMLElement>(sel: string) => target.querySelector(sel) as T | null;
@@ -486,6 +517,14 @@ describe('scope/controls zones — placed, never falsely active', () => {
 describe('F6 — manifest zone ids are bound to the rendered structure', () => {
   const declaredZoneIds = (): readonly string[] => dualReceiverCockpitLayout.zones.map((z) => z.id);
 
+  // MOR-1336 (S4): `tx-aux` joined the declared set, and it is the FIRST zone
+  // here whose existence in the DOM is plan-gated rather than hardcoded
+  // (`vfo`/`rxTx` stay bespoke and render their box unconditionally) — so
+  // proving the correspondence now needs the SAME resolved plan App actually
+  // hands down, or the new zone's box would never appear regardless of what
+  // the manifest declares (`useSurfacePlan()`'s documented standalone-mount
+  // fallback). Both fixtures already carry `tuner` (MOR-1336 fixture note
+  // above), so `view.txAux` is present and the zone is not an empty promise.
   it.each([
     ['2/main_sub', () => mainSubState('MAIN'), mainSubCaps],
     ['2/ab_shared', abSharedState, abSharedCaps],
@@ -494,7 +533,7 @@ describe('F6 — manifest zone ids are bound to the rendered structure', () => {
   ) => {
     h.state = makeState();
     h.caps = makeCaps();
-    render();
+    render(defaultPlan());
 
     expect(qa('[data-zone-id]').map((el) => el.dataset.zoneId)).toEqual([...declaredZoneIds()]);
   });
@@ -652,8 +691,16 @@ describe('operational audio-scope availability (scope=false + audioFft=true)', (
   // and the inert scope placeholder must not turn into an "unavailable"
   // verdict about a capability that IS available. Kills: gating any strip,
   // switch or TX control on scope state.
-  /** The RX/TX surface's aria-describedby carries a per-instance counter. */
-  const markup = (): string => target.innerHTML.replace(/rx-tx-\d+/g, 'rx-tx-N');
+  /**
+   * The RX/TX surface's aria-describedby carries a per-instance counter.
+   * MOR-1336 (S4): `mainSubCaps` now carries `tuner`, so the txAux surface
+   * also mounts here and its own blocked-list id (`TxAuxSurface`'s module
+   * counter) is exactly as per-instance — this test unmounts and remounts
+   * within itself, so the second mount's id is never the first's.
+   */
+  const markup = (): string => target.innerHTML
+    .replace(/rx-tx-\d+/g, 'rx-tx-N')
+    .replace(/tx-aux-blocked-\d+/g, 'tx-aux-blocked-N');
 
   it('changes nothing in the cockpit, and denies nothing about the radio', () => {
     h.state = mainSubState('MAIN');
@@ -751,17 +798,25 @@ describe('MOR-1069 — a viewport or orientation change recomposes nothing at ru
   });
 });
 
-describe('MOR-1069 — focus order is DOM order, and the RX/TX zone comes last', () => {
+describe('MOR-1069 — focus order is DOM order, and the LAST declared zone comes last', () => {
   // "Keyboard and touch order remain logical." The CSS side (no `order`, no
   // reversed flow) is pinned textually; this is the DOM side that the CSS
   // must keep agreeing with. Kills: emitting the radio-wide row or the RX/TX
   // zone before the strips, or interleaving the strips' controls — either
   // would make the tab sequence disagree with the reading order in BOTH
   // arrangements at once.
-  it('every control appears in declared zone order, ending in rx-tx', () => {
+  //
+  // MOR-1336 (S4) flips the premise this test pinned: `tx-aux` is now the
+  // LAST declared zone (after `rx-tx`), and its controls are real, focusable
+  // members of it once a resolved plan is supplied (see `defaultPlan()` /
+  // the F6 comment above) — both fixtures carry `tuner`, so the surface
+  // mounts. The tab sequence must still never go backwards, and now ends in
+  // `tx-aux`, not `rx-tx`: the key/unkey control sits SECOND-TO-LAST, ahead
+  // of the txAux row, which is exactly where the manifest places the zone.
+  it('every control appears in declared zone order, ending in tx-aux', () => {
     h.state = mainSubState('MAIN');
     h.caps = mainSubCaps();
-    render();
+    render(defaultPlan());
 
     const declared = dualReceiverCockpitLayout.zones.map((z) => z.id);
     const sequence = qa<HTMLElement>('button, input, select, a[href], [tabindex]')
@@ -773,9 +828,10 @@ describe('MOR-1069 — focus order is DOM order, and the RX/TX zone comes last',
     expect(sequence).not.toContain(-1);
     // ...and the sequence never goes backwards through the declared order.
     expect(sequence).toEqual([...sequence].sort((a, b) => a - b));
-    // The operator's key/unkey control is the last thing in the tab sequence,
-    // not stranded between two channel strips.
-    expect(sequence.at(-1)).toBe(declared.indexOf('rx-tx'));
+    // MOR-1336: tx-aux is now the last declared zone, and its controls are
+    // the last thing in the tab sequence — the key/unkey control precedes it.
+    expect(sequence.at(-1)).toBe(declared.indexOf('tx-aux'));
+    expect(declared.indexOf('tx-aux')).toBeGreaterThan(declared.indexOf('rx-tx'));
   });
 
   // MOR-1258. `tx-fault-reset` and the two ModInputTxWarning buttons only
@@ -786,11 +842,15 @@ describe('MOR-1069 — focus order is DOM order, and the RX/TX zone comes last',
   // this assertion ever seeing them (the MOR-1069 verification finding this
   // ticket exists to close). Driving each conditional state in turn is what
   // makes the assertion actually SEE them.
+  //
+  // MOR-1336: these three alerts are rx-tx zone members (R6, pinned formally
+  // below), not tx-aux members, so the sequence still ends in tx-aux even
+  // while they are present — they land just BEFORE it, never after.
   it.each([
     ['a TX fault is latched', { phase: 'failed', fault: 'audio-failed' } as Partial<Snapshot>, false],
     ['the MOD-input guard is visible', {} as Partial<Snapshot>, true],
     ['both conditional alerts are active at once', { phase: 'failed', fault: 'audio-failed' } as Partial<Snapshot>, true],
-  ] as const)('still ends in rx-tx with no control outside a declared zone — %s', (
+  ] as const)('still ends in tx-aux with no control outside a declared zone — %s', (
     _label, snapshotOver, modInputVisible,
   ) => {
     h.state = mainSubState('MAIN');
@@ -798,7 +858,7 @@ describe('MOR-1069 — focus order is DOM order, and the RX/TX zone comes last',
     h.modInputGuard = modInputVisible
       ? { visible: true, sourceLabel: 'MIC' }
       : { visible: false, sourceLabel: null };
-    render();
+    render(defaultPlan());
     push(snapshotOver);
 
     // Sanity: the conditional control(s) this case drives are actually present
@@ -814,7 +874,7 @@ describe('MOR-1069 — focus order is DOM order, and the RX/TX zone comes last',
     expect(sequence.length).toBeGreaterThan(0);
     expect(sequence).not.toContain(-1);
     expect(sequence).toEqual([...sequence].sort((a, b) => a - b));
-    expect(sequence.at(-1)).toBe(declared.indexOf('rx-tx'));
+    expect(sequence.at(-1)).toBe(declared.indexOf('tx-aux'));
   });
 });
 
@@ -908,6 +968,30 @@ describe('MOR-1258 — the three TX-adjacent alerts are formal rx-tx zone member
     q<HTMLButtonElement>('[data-testid="tx-fault-reset"]')!.click();
     flushSync();
     expect(h.resetFault).toHaveBeenCalledTimes(1);
+  });
+
+  // MOR-1336 (S4) restated (R6): the four tests above never supply a resolved
+  // plan, so the new tx-aux zone never actually mounts alongside them — R6
+  // holds, but only because there was nowhere for the alerts to have moved
+  // TO. Restated with `defaultPlan()`, so the tx-aux zone is a real sibling
+  // element and containment inside rx-tx — never tx-aux — is proven against
+  // it, not merely against its absence.
+  it('keeps all three TX-adjacent alerts inside rx-tx, never tx-aux, once the tx-aux zone actually mounts', () => {
+    h.state = mainSubState('MAIN');
+    h.caps = mainSubCaps();
+    h.modInputGuard = { visible: true, sourceLabel: 'MIC' };
+    render(defaultPlan());
+    push({ phase: 'failed', fault: 'audio-failed' });
+
+    const rxTxZone = q('[data-zone-id="rx-tx"]')!;
+    const txAuxZone = q('[data-zone-id="tx-aux"]');
+    expect(txAuxZone).not.toBeNull(); // sanity: the zone this pin restates for actually exists
+    for (const testid of ['tx-fault-reset', 'mod-input-set-lan', 'mod-input-dismiss']) {
+      const el = q(`[data-testid="${testid}"]`);
+      expect(el).not.toBeNull();
+      expect(rxTxZone.contains(el)).toBe(true);
+      expect(txAuxZone!.contains(el)).toBe(false);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- Zone-awareness moves into `SemanticRadioSurfaces` via the surface plan: `zoneOwning(surface)` + one `zoned` snippet serve txAux/meters/rxAudio generically (vfo/rxTx stay bespoke, documented) — the next declarable surface needs no code. The snippet takes `present`, so a declared zone never renders an empty container (MOR-1069 "empty promise").
- desktop-v2 and the dual-receiver cockpit declare `tx-aux` zones; legacy TxPanel suppression is unchanged from S2 (verified sweep: no txAux legacy twin remains on any surface). Partially resolves MOR-1317 — declaring txAux is no longer a silent no-op, and the cockpit fixture now declares tuner caps so the MOR-1069 invariant genuinely bites (sequence ends in tx-aux).
- `'tx-aux'` joins `WORKSPACE_ZONE_IDS` — a production-literal gap exposed by the contract control test (pure allow-list widening; verifier-checked: no stored workspace can contain it, downgrade degrades to `repaired`, no version bump required).

## Review provenance
Independent opus verifier PASS (rework domain anchor, session-7). Design adjudicated CONSISTENT with its own S2 manifest-over-plan ruling: here the plan gates the SEMANTIC wrapper only (workspace subtraction removes the wrapper, never resurrects a twin — probe V1: subtracted plan → surface bare, zone 0, legacy 0, key authorities 1). Mutants: MZ1 lookup hardcoded → 1 RED (genericity genuinely pinned via the synthetic-meters-zone test), MZ2 `present` dropped → 2 RED, MZ3 double-mount → 4 RED; directional probes all clean. R9/R6 probed with the zone mounted. The two-builder seam audited: the Snippet typing fix was a second-builder correction of a first-builder defect, disclosed, NOT smuggled (origin/main has 0 svelte-check errors, the handed-over diff had 2). Binding LOC +22 (matches the Phase-0 estimate exactly). Gates: 5154/5154 green, lint/boundaries/check/i18n:check/build clean. Notes N1–N4 filed as follow-up tickets. Landing delta: merge of origin/main (#2243), no conflicts.

## Linear
MOR-1336 (parent program MOR-1263). Related: MOR-1317 (partially resolved), MOR-1337 (declaration-vs-visibility, pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)