### PR TITLE
feat(MOR-1341): meters zone ownership — MetersDockPanel retires on desktop-v2 (rework S5)

### DIFF
--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -111,6 +111,16 @@
   // earns this line a second term — not a subset manifest landing.
   let semanticRxTx = $derived(semanticDeck);
 
+  // MOR-1341 (v3-rework S5) — same per-zone rule as `semanticRxTx` above,
+  // applied to the bottom dock: the legacy `<MetersDockPanel>` retires the
+  // moment a declared zone mounts the `meters` surface, and survives
+  // untouched for any layout that declares no such zone. Unlike `vfo`/`rxTx`
+  // this area carries no R9 stranded-transmitter hazard (a meter is a
+  // readout, never a key/unkey affordance), so there is no asymmetric
+  // "follow the deck, not the zone" rule to restate here — `declared` is the
+  // whole answer.
+  let semanticMeters = $derived(declared.has('meters'));
+
   // Reactive state + capabilities — via runtime
   let radioState = $derived(runtime.state);
   let caps = $derived(runtime.caps);
@@ -328,19 +338,21 @@
     </div>
   </section>
 
-  <section class="bottom-dock">
-    <MetersDockPanel
-      sValue={radioState?.active === 'SUB' ? radioState?.sub?.sMeter : radioState?.main?.sMeter}
-      powerMeter={radioState?.powerMeter}
-      swrMeter={radioState?.swrMeter}
-      alcMeter={radioState?.alcMeter}
-      idMeter={radioState?.idMeter}
-      vdMeter={radioState?.vdMeter}
-      compMeter={radioState?.compMeter}
-      compressorOn={radioState?.compressorOn}
-      txActive={meterTxActive}
-    />
-  </section>
+  {#if !semanticMeters}
+    <section class="bottom-dock">
+      <MetersDockPanel
+        sValue={radioState?.active === 'SUB' ? radioState?.sub?.sMeter : radioState?.main?.sMeter}
+        powerMeter={radioState?.powerMeter}
+        swrMeter={radioState?.swrMeter}
+        alcMeter={radioState?.alcMeter}
+        idMeter={radioState?.idMeter}
+        vdMeter={radioState?.vdMeter}
+        compMeter={radioState?.compMeter}
+        compressorOn={radioState?.compressorOn}
+        txActive={meterTxActive}
+      />
+    </section>
+  {/if}
 </div>
 {/if}
 

--- a/frontend/src/components-v2/layout/__tests__/RadioLayout.isolated.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/RadioLayout.isolated.test.ts
@@ -435,8 +435,12 @@ describe('RadioLayout structure', () => {
     expect(t.querySelector('.spectrum-panel-stub')).not.toBeNull();
   });
 
-  it('renders .bottom-dock', () => {
-    const t = mountLayout();
+  // MOR-1341: `desktop-v2` (the default here) now declares a `meters` zone
+  // and retires `.bottom-dock` — see the suppression matrix in
+  // `semantic-desktop-migration.component.test.ts`. `sdr-test` declares no
+  // such zone, so it stays the layout that proves the dock still exists.
+  it('renders .bottom-dock for a layout that declares no meters zone', () => {
+    const t = mountLayout('sdr-test');
     expect(t.querySelector('.bottom-dock')).not.toBeNull();
   });
 
@@ -482,9 +486,13 @@ describe('App presentation selection', () => {
   });
 });
 
+// MOR-1341: `desktop-v2` (this file's `mountLayout()` default) now suppresses
+// `.bottom-dock` via its `meters` zone declaration. `sdr-test` declares none,
+// so it stays the layout that exercises the dock's OWN behaviour — same move
+// as `VfoHeader dual receiver` below, which tests the legacy deck the same way.
 describe('Bottom dock MetersDockPanel', () => {
   it('renders the unified meters dock panel inside .bottom-dock', () => {
-    const t = mountLayout();
+    const t = mountLayout('sdr-test');
     const dock = t.querySelector('.bottom-dock');
     expect(dock).not.toBeNull();
     expect(dock?.querySelector('[data-testid="meters-dock-panel"]')).not.toBeNull();
@@ -503,7 +511,7 @@ describe('meters dock TX chrome follows the App TX authority (MOR-1235)', () => 
   it('shows TX when the authority is keyed while radioState.ptt reads false', () => {
     rt.state = { active: 'MAIN', ptt: false, main: { sMeter: 120 } };
     txAuthority.current = { ...txAuthority.idle, radioTx: 'on', txRisk: 'confirmed-on' };
-    const t = mountLayout();
+    const t = mountLayout('sdr-test');
     expect(txTag(t)?.getAttribute('data-active')).toBe('true');
     expect(txTag(t)?.textContent).toBe('TX');
   });
@@ -511,7 +519,7 @@ describe('meters dock TX chrome follows the App TX authority (MOR-1235)', () => 
   it('shows RX when the authority is idle while radioState.ptt reads true', () => {
     rt.state = { active: 'MAIN', ptt: true, main: { sMeter: 120 } };
     txAuthority.current = { ...txAuthority.idle, radioTx: 'off', txRisk: 'none' };
-    const t = mountLayout();
+    const t = mountLayout('sdr-test');
     expect(txTag(t)?.getAttribute('data-active')).toBe('false');
     expect(txTag(t)?.textContent).toBe('RX');
   });
@@ -519,7 +527,7 @@ describe('meters dock TX chrome follows the App TX authority (MOR-1235)', () => 
   it('fails closed: an uncertain authority shows TX even with ptt false', () => {
     rt.state = { active: 'MAIN', ptt: false, main: { sMeter: 120 } };
     txAuthority.current = { ...txAuthority.idle, radioTx: 'off', txRisk: 'uncertain' };
-    const t = mountLayout();
+    const t = mountLayout('sdr-test');
     expect(txTag(t)?.getAttribute('data-active')).toBe('true');
   });
 });
@@ -589,9 +597,9 @@ describe('RadioLayout with radioState', () => {
     expect(t.querySelector('.radio-layout')).not.toBeNull();
   });
 
-  it('renders MetersDockPanel in the bottom dock', () => {
+  it('renders MetersDockPanel in the bottom dock for a layout with no meters zone', () => {
     radio.current = sampleState as any;
-    const t = mountLayout();
+    const t = mountLayout('sdr-test');
     expect(t.querySelector('.bottom-dock [data-testid="meters-dock-panel"]')).not.toBeNull();
   });
 });

--- a/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
@@ -336,6 +336,22 @@ describe('desktop-v2 resolves through the v3 path (MOR-1313)', () => {
     expect(t.querySelector('[data-testid="tx-strip"]')).toBeNull();
   });
 
+  // MOR-1341 (S5) — the bottom dock joins the matrix. `desktop-v2` now
+  // declares a `meters` zone too, so `<MetersDockPanel>` retires the moment
+  // the view model actually carries the group. Proven with a state that
+  // reports a real meter reading, not the bare `liveState()` fixture every
+  // other test in this describe uses — that fixture reports NO meter fields
+  // at all, so it would pass this assertion vacuously (both the dock and the
+  // semantic surface self-gate away) and prove nothing about suppression.
+  it('drops the legacy meters dock in favour of the semantic meters surface', () => {
+    const state = liveState() as { main: Record<string, unknown> };
+    h.state = { ...state, main: { ...state.main, sMeter: 120 } };
+    const t = render('desktop-v2');
+    expect(t.querySelector('.bottom-dock')).toBeNull();
+    expect(t.querySelector('[data-testid="meters-dock-panel"]')).toBeNull();
+    expect(t.querySelector('[data-testid="meters-surface"]')).not.toBeNull();
+  });
+
   // R9, asserted BEHAVIORALLY rather than by import absence: whatever the zone
   // shape, the screen carries exactly ONE key/unkey authority. Counting both
   // the semantic surface and the legacy panel in one query is what makes a
@@ -351,13 +367,15 @@ describe('desktop-v2 resolves through the v3 path (MOR-1313)', () => {
 
   // The rest of the shell is chrome, not a zone: nothing about suppression
   // may reach it. Same claim the sdr-test block above makes, restated for the
-  // family that actually ships to every Icom radio.
+  // family that actually ships to every Icom radio. `.bottom-dock` is
+  // deliberately NOT asserted here any more (MOR-1341): it is now itself a
+  // suppressed twin, not part of "the rest" — its own matrix entry is the
+  // dedicated test above.
   it('leaves the rest of the layout intact', () => {
     const t = render('desktop-v2');
     expect(t.querySelector('.content-left .left-sidebar')).not.toBeNull();
     expect(t.querySelector('.content-right .right-sidebar')).not.toBeNull();
     expect(t.querySelector('.center-column .spectrum-slot')).not.toBeNull();
-    expect(t.querySelector('.bottom-dock [data-testid="meters-dock-panel"]')).not.toBeNull();
     expect(t.querySelector('[data-panel-id="rx-audio"]')).not.toBeNull();
     expect(t.querySelector('[data-panel-id="memory"]')).not.toBeNull();
   });

--- a/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
@@ -100,7 +100,7 @@ import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';
 // MOR-1082: the REAL manifests, through the app-wide registration barrel, and
 // the REAL resolution seam — the plans below are what App would hand down.
 import {
-  dualReceiverCockpitLayout, sdrTestLayout,
+  desktopV2Layout, dualReceiverCockpitLayout, sdrTestLayout,
 } from '../../../presentation/layouts/declarations';
 import { readWorkspace } from '../../../presentation/workspace/contract';
 import {
@@ -613,5 +613,44 @@ describe('MOR-1336 — a declared zone renders nothing for a radio without the g
     expect(q('[data-testid="tx-aux-surface"]')).toBeNull();
     expect(q('[data-zone-id="tx-aux"]')).toBeNull();
     expect(target.innerHTML).not.toContain('tx-aux');
+  });
+
+  // MOR-1341 (S5): the same pin, for `meters` against `desktop-v2`'s own real
+  // plan (the manifest that actually declares the zone in production, unlike
+  // the synthetic plan the generic-mechanism describe above uses). `liveState`
+  // reports no meter fields, so `deriveMeters` emits no group at all.
+  it('mounts no meters zone element for a radio without the group, even though desktop-v2 declares one', () => {
+    h.state = liveState(false);
+    h.caps = liveCaps(false);
+    const plan = resolveSurfacePlan(desktopV2Layout, readWorkspace({ version: 1 }).workspace);
+    render({ strips: 'single' }, plan);
+
+    expect(q('[data-testid="meters-surface"]')).toBeNull();
+    expect(q('[data-zone-id="meters"]')).toBeNull();
+    expect(target.innerHTML).not.toContain('data-zone-id="meters"');
+  });
+});
+
+// ── MOR-1341 (S5) — desktop-v2's OWN real `meters` zone actually binds ──────
+//
+// The generic-mechanism describe above proves the MECHANISM against a
+// synthetic id no manifest ships; this proves the SHIPPED zone — the one
+// `desktop-v2` actually declares (`presentation/layouts/desktop-declarations
+// .ts`) and the one `RadioLayout.svelte` reads to retire the legacy dock.
+describe('MOR-1341 — desktop-v2 mounts a real meters zone when the group is present', () => {
+  it('binds [data-zone-id="meters"] around the meters surface, alone in its zone', () => {
+    const base = liveState(false) as unknown as { main: Record<string, unknown> };
+    h.state = { ...base, main: { ...base.main, sMeter: 120 } };
+    h.caps = liveCaps(false);
+    const plan = resolveSurfacePlan(desktopV2Layout, readWorkspace({ version: 1 }).workspace);
+    render({ strips: 'single' }, plan);
+
+    const zone = q('[data-zone-id="meters"]');
+    expect(zone).not.toBeNull();
+    expect(zone!.classList.contains('surface-zone')).toBe(true);
+    expect(q('[data-testid="meters-surface"]')!.parentElement).toBe(zone);
+    // R9 sanity: a readout-only zone adds no key/unkey affordance.
+    expect(zone!.querySelector('[data-testid="rx-tx-key"]')).toBeNull();
+    expect(zone!.querySelector('[data-testid="rx-tx-unkey"]')).toBeNull();
   });
 });

--- a/frontend/src/presentation/layouts/__tests__/desktop-v2-registration.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/desktop-v2-registration.test.ts
@@ -55,12 +55,14 @@ describe('the desktop-v2 entrypoint is registered in the real registry', () => {
 describe('declared zones now drive the DOM (MOR-1263 step 2, MOR-1313)', () => {
   // Kills: declaring a surface this manifest does not name, or dropping
   // either one — the pair per-zone suppression consumes.
-  it('declares receiver-deck:[vfo], rx-tx:[rxTx] and tx-aux:[txAux]', () => {
+  it('declares receiver-deck:[vfo], rx-tx:[rxTx], tx-aux:[txAux] and meters:[meters]', () => {
     expect(desktopV2Layout.zones).toEqual([
       { id: 'receiver-deck', surfaces: ['vfo'] },
       { id: 'rx-tx', surfaces: ['rxTx'] },
       // MOR-1336 (S4): txAux became zone-owned. Declared, deliberately not required.
       { id: 'tx-aux', surfaces: ['txAux'] },
+      // MOR-1341 (S5): meters became zone-owned too, retiring the legacy dock.
+      { id: 'meters', surfaces: ['meters'] },
     ]);
     expect([...desktopV2Layout.requiredSemanticSurfaces].sort()).toEqual(['rxTx', 'vfo']);
   });
@@ -80,8 +82,9 @@ describe('declared zones now drive the DOM (MOR-1263 step 2, MOR-1313)', () => {
   // set, or reading only the first zone) — desktop-v2 is the manifest that
   // splits the pair ACROSS two zones, so it is the one that proves the walk
   // is per-zone rather than per-manifest-first-zone.
-  it('its two zones flatten to the surfaces the shell suppresses legacy twins for', () => {
-    expect([...declaredSurfaces(getLayout('desktop-v2'))].sort()).toEqual(['rxTx', 'txAux', 'vfo']);
+  it('its zones flatten to the surfaces the shell suppresses legacy twins for', () => {
+    expect([...declaredSurfaces(getLayout('desktop-v2'))].sort())
+      .toEqual(['meters', 'rxTx', 'txAux', 'vfo']);
   });
 });
 

--- a/frontend/src/presentation/layouts/__tests__/meters-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/meters-declarability.test.ts
@@ -1,17 +1,18 @@
 /**
- * MOR-1273 — `meters` is DECLARABLE, and nothing declares it yet.
+ * MOR-1273 — `meters` is DECLARABLE. MOR-1341 (S5) declares it for real.
  *
- * Slice 2B adds the name to `SEMANTIC_SURFACE_NAMES` so a manifest CAN mount
- * the surface later; it deliberately does not touch any manifest, and it does
- * not add a renderer slot — a design language draws a meter through the
- * `'meters'` slot `RENDERER_SLOT_NAMES` has carried since MOR-1072 (risk R2:
- * adding a slot would be a language-contract change this slice must not make).
+ * Slice 2B added the name to `SEMANTIC_SURFACE_NAMES` so a manifest CAN mount
+ * the surface later; it deliberately did not touch any manifest, and it added
+ * no renderer slot — a design language draws a meter through the `'meters'`
+ * slot `RENDERER_SLOT_NAMES` has carried since MOR-1072 (risk R2: adding a
+ * slot would be a language-contract change this slice must not make).
  *
- * The three pins mirror `tx-aux-declarability.test.ts`:
- *   - drop the name and a future manifest's zone stops validating;
- *   - quietly add a `meters` zone to a shipped manifest and the DOM grows a
- *     zone id no layout review ever saw;
- *   - the renderer slot stays exactly the set MOR-1072 froze.
+ * MOR-1341 flips the second half, on `desktop-v2` ONLY: the cockpit already
+ * renders no `MetersDockPanel` twin to retire (`meters` group availability is
+ * not manifest-gated at all; adding the zone there is a separately-scoped,
+ * fixture-cost decision left for its own ticket), so this slice's suppression
+ * payoff is desktop-v2-shaped. The inventory below is a LITERAL of who
+ * declares it, mirroring `tx-aux-declarability.test.ts`'s post-S4 shape.
  */
 import { describe, it, expect } from 'vitest';
 import { SEMANTIC_SURFACE_NAMES, validateLayoutManifest } from '../contract';
@@ -46,16 +47,40 @@ describe('meters is a declarable semantic surface', () => {
   });
 });
 
-describe('no shipped manifest declares a meters zone in this slice', () => {
-  // Kills: slipping a meters zone into an existing layout here. Declarability
-  // is the whole scope of the contract touch; placing the surface in a real
-  // layout is a later, separately reviewed slice.
-  it.each([
+describe('exactly the reviewed manifests declare a meters zone (MOR-1341)', () => {
+  /** The literal — extend by hand, with a layout review, never silently. */
+  const DECLARES_METERS = ['desktop-v2'];
+
+  const ALL = [
     ['sdr-test', sdrTestLayout], ['dual-receiver-cockpit', dualReceiverCockpitLayout],
     ['lcd-cockpit', lcdCockpitLayout], ['lcd-scope', lcdScopeLayout],
     ['mobile', mobileLayout], ['desktop-v2', desktopV2Layout],
-  ])('%s declares no meters zone and does not require the surface', (_id, manifest) => {
-    for (const zone of manifest.zones) expect(zone.surfaces).not.toContain('meters');
+  ] as const;
+
+  // Kills BOTH directions: a family losing the zone S5 gave it, and a family
+  // gaining one without review.
+  it('the declaring set is exactly the reviewed literal', () => {
+    const declaring = ALL
+      .filter(([, m]) => m.zones.some((z) => z.surfaces.includes('meters')))
+      .map(([id]) => id)
+      .sort();
+    expect(declaring).toEqual([...DECLARES_METERS].sort());
+  });
+
+  // Kills: declaring the zone under a drifted id — the wiring binds whatever
+  // the plan's key is, so the id IS the contract with the layout's arrangement.
+  it.each(DECLARES_METERS)('%s declares it under the stable `meters` id, alone in its zone', (id) => {
+    const manifest = ALL.find(([name]) => name === id)![1];
+    const zone = manifest.zones.find((z) => z.surfaces.includes('meters'))!;
+    expect(zone.id).toBe('meters');
+    expect(zone.surfaces).toEqual(['meters']);
+  });
+
+  // Kills: making meters REQUIRED. A radio reporting no meter fields at all
+  // must still resolve this layout; the surface self-gates on `view.meters`,
+  // and a required surface no zone could fill would be a resolution failure
+  // rather than an honest absence.
+  it.each(ALL)('%s does not require the meters surface', (_id, manifest) => {
     expect(manifest.requiredSemanticSurfaces).not.toContain('meters');
   });
 });

--- a/frontend/src/presentation/layouts/desktop-declarations.ts
+++ b/frontend/src/presentation/layouts/desktop-declarations.ts
@@ -40,6 +40,12 @@ const DESKTOP_V2_ZONES = [
   // `required` — a radio whose MOR-1244 evidence gate declined the group must
   // still resolve this layout, and the surface self-gates on `view.txAux`.
   { id: 'tx-aux', surfaces: ['txAux'] },
+  // MOR-1341 (S5): meters becomes zone-OWNED here too, and RadioLayout.svelte
+  // retires the legacy `<MetersDockPanel>` the moment this zone is declared
+  // (mirroring `hideTxPanel`'s `tx-aux` precedent). Not `required` — a radio
+  // reporting no meter fields at all must still resolve this layout, and the
+  // surface self-gates on `view.meters`.
+  { id: 'meters', surfaces: ['meters'] },
 ] as const;
 
 export const desktopV2Layout: LayoutManifest = {

--- a/frontend/src/presentation/workspace/__tests__/preferences-adoption.test.ts
+++ b/frontend/src/presentation/workspace/__tests__/preferences-adoption.test.ts
@@ -263,8 +263,10 @@ describe('MOR-1082 — the single-composition order comes from the same plan', (
   it('flattens the plan in zone-declaration order, deduped', () => {
     expect(compositionSurfaces(plan(sdrTestLayout), FALLBACK)).toEqual(['vfo', 'rxTx']);
     // desktop-v2 spreads the same two surfaces over two zones, plus its own
-    // MOR-1336 (S4) tx-aux zone — flattening never drops a third zone.
-    expect(compositionSurfaces(plan(desktopV2Layout), FALLBACK)).toEqual(['vfo', 'rxTx', 'txAux']);
+    // MOR-1336 (S4) tx-aux zone and MOR-1341 (S5) meters zone — flattening
+    // never drops a fourth zone.
+    expect(compositionSurfaces(plan(desktopV2Layout), FALLBACK))
+      .toEqual(['vfo', 'rxTx', 'txAux', 'meters']);
     expect(compositionSurfaces(plan(sdrTestLayout, { zoneOrder: { main: ['rxTx', 'vfo'] } }), FALLBACK))
       .toEqual(['rxTx', 'vfo']);
   });

--- a/frontend/src/presentation/workspace/contract.ts
+++ b/frontend/src/presentation/workspace/contract.ts
@@ -49,7 +49,7 @@ export const WORKSPACE_THEME_IDS = [
 export type WorkspaceThemeId = (typeof WORKSPACE_THEME_IDS)[number];
 
 /** Every zone id declared by a registered layout manifest (decisions 5 and 6). */
-export const WORKSPACE_ZONE_IDS = ['main', 'receiver-deck', 'rx-tx', 'primary-vfo', 'secondary-vfo', 'global', 'portrait-deck', 'control-column', 'tx-aux'] as const;
+export const WORKSPACE_ZONE_IDS = ['main', 'receiver-deck', 'rx-tx', 'primary-vfo', 'secondary-vfo', 'global', 'portrait-deck', 'control-column', 'tx-aux', 'meters'] as const;
 export type WorkspaceZoneId = (typeof WORKSPACE_ZONE_IDS)[number];
 
 /** Decision 7: command-bus intent names (`set_compressor`), never module paths. */


### PR DESCRIPTION
## Summary
- desktop-v2 declares a `meters` zone; `RadioLayout` suppresses the legacy bottom dock when the manifest declares it (`semanticMeters`, mirroring the S2 suppression doctrine). `'meters'` joins `WORKSPACE_ZONE_IDS`. 4 strict net production LOC.
- Split-authority design verifier-ruled fail-safe: the manifest governs the LEGACY side (plan-driven suppression would resurrect the dock — the S2 hazard), the surface plan governs only the semantic wrapper, which degrades to a bare mount on workspace subtraction — the readout can never disappear (probe P1: subtracted plan → dock 0, surface 1 bare, zone 0).
- Also fixes the pre-existing desktop-v2 double render (dock + semantic surface both showing at base).
- Dock-parity lacks recorded, not absorbed: peak-hold (MOR-1282), SWR/ALC fault border (MOR-1345), no-fields "?" placeholder (verifier N1). Cockpit deliberately untouched (meters has no capability gate; its fixtures need data, not a tag). sdr-test's pre-existing double render tracked as MOR-1346.

## Review provenance
Independent opus verifier PASS (rework domain anchor, session-7): asymmetry ruling labeled and approved (the hypothesised "no meters anywhere" state does not occur — probed with a real subtracting workspace); empty-promise signal confirmed exact (`deriveMeters` returns undefined without observed fields — the group's real presence predicate); mutants MM1 (suppression dropped → double meters) 1 RED, MM2 (declaration removed) 8 RED/7 files, MM3 (WORKSPACE_ZONE_IDS dropped) 1 RED via the dynamic registry-sync pin; cockpit path bit-for-bit unchanged; parity table honest (calibration/redline correctly absent — shared meter-utils); binding LOC +4 exact; suite 5159 green, lint/boundaries/check/i18n:check/build clean. Landing delta: merge of origin/main (#2245 fixtures content), no conflicts.

## Linear
MOR-1341 (parent program MOR-1263).

🤖 Generated with [Claude Code](https://claude.com/claude-code)