### PR TITLE
feat(MOR-1301): scopeDisplay facts group (12A) - A-queue complete

### DIFF
--- a/frontend/src/lib/runtime/adapters/__tests__/scope-display-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/scope-display-adapter.test.ts
@@ -1,0 +1,162 @@
+/**
+ * MOR-1262 decomposition slice 12A (MOR-1301, the FINAL A-slice of the
+ * vocabulary program) — `scopeDisplay` fact-group adapter derivation.
+ *
+ * Companion to `scope-controls-adapter.test.ts` (11A/11A′) and
+ * `rx-audio-adapter.test.ts` (3A), neither of which this file modifies.
+ * `scopeDisplay` is a SEPARATE optional group — see `radio-view-model.ts`'s
+ * `ScopeDisplayViewModel` doc comment.
+ *
+ * PARITY — `lib/runtime` may not import `components-v2` (ADR 2026-04-12), so
+ * `classifyScopeHealth` cannot call the shipped status-bar's
+ * `deriveScopeIndicatorState` directly; this file imports it anyway (tests
+ * are exempt from that boundary, `eslint.config.js`'s own carve-out) purely
+ * to PIN agreement across a discriminating-combo matrix, the same
+ * "agree with the real projector, don't assume it" discipline
+ * `rx-audio-adapter.test.ts` uses for `projectModInputSource`. No `vi.mock`,
+ * no global store mutation — `deriveScopeIndicatorState` is a pure function
+ * of its two explicit arguments, so this file needs no isolated pool.
+ */
+import { describe, expect, it } from 'vitest';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { FieldStatus, ServerState } from '$lib/types/state';
+import { validateRadioViewModel, type RadioViewModel } from '../../../../semantic/radio-view-model';
+import { toRadioViewModel, type ScopeDisplaySnapshot } from '../radio-view-model-adapter';
+import { deriveScopeIndicatorState } from '../../../../components-v2/layout/StatusBar.svelte';
+
+function caps(overrides: Partial<Capabilities> = {}): Capabilities {
+  return {
+    model: 'fixture', scope: true, audio: true, tx: true, capabilities: ['scope', 'audio', 'tx'],
+    receivers: 1, vfoScheme: 'single', freqRanges: [], modes: [], filters: [],
+    audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
+    webrtc: { available: false, enabled: false },
+    txBands: [], scopeSource: 'hardware', audioFftAvailable: false, ...overrides,
+  } as Capabilities;
+}
+
+const fresh: FieldStatus = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' };
+
+function bareState(overrides: Partial<ServerState> = {}): ServerState {
+  return {
+    active: 'MAIN', split: false, dualWatch: false, ptt: false,
+    txTarget: { status: 'unknown', reason: 'not-observed' },
+    main: {
+      freqHz: 14195000, mode: 'USB', filter: 1, dataMode: 0, att: 0, preamp: 0,
+      nb: false, nr: false, afLevel: 1, rfGain: 1, squelch: 0, sMeter: 0,
+    },
+    fieldStatus: { active: fresh, split: fresh, dualWatch: fresh },
+    ...overrides,
+  } as ServerState;
+}
+
+const SNAP: ScopeDisplaySnapshot = {
+  source: 'hardware', available: true, resourceSelected: true, demand: 1,
+  lifecycle: 'streaming', transport: 'connected', frameSeen: true, isPoweredOff: false,
+};
+
+function model(
+  state: ServerState | null, capabilities: Capabilities | null,
+  snapshot?: ScopeDisplaySnapshot | null,
+): RadioViewModel {
+  const view = toRadioViewModel(state, capabilities, null, null, snapshot);
+  expect(view).not.toBeNull();
+  return validateRadioViewModel(view);
+}
+
+describe('scopeDisplay evidence gate (MOR-1301)', () => {
+  it('emits no scopeDisplay without the App-owned snapshot — runtime status is not this layer\'s to guess', () => {
+    for (const snapshot of [undefined, null]) {
+      const view = model(bareState(), caps(), snapshot);
+      expect(view.scopeDisplay).toBeUndefined();
+      expect(Object.keys(view)).not.toContain('scopeDisplay');
+    }
+  });
+
+  it('emits no scopeDisplay for a radio with neither scope nor an audio-FFT source', () => {
+    const view = model(bareState(), caps({ scope: false, capabilities: ['audio', 'tx'], scopeSource: undefined }), SNAP);
+    expect(view.scopeDisplay).toBeUndefined();
+  });
+
+  it('emits scopeDisplay once the scope capability alone is declared', () => {
+    const view = model(bareState(), caps(), SNAP);
+    expect(view.scopeDisplay).toBeDefined();
+    expect(Object.keys(view.scopeDisplay!).sort()).toEqual(['health', 'source']);
+  });
+
+  it('emits scopeDisplay for an audio-FFT-only radio (no hardware scope at all)', () => {
+    const audioOnly = caps({ scope: false, capabilities: ['audio', 'tx'], scopeSource: 'audio_fft' });
+    const view = model(bareState(), audioOnly, { ...SNAP, source: 'audio_fft' });
+    expect(view.scopeDisplay).toBeDefined();
+  });
+});
+
+describe('scopeDisplay per-field derivation (MOR-1301)', () => {
+  it('reports the known source straight from the snapshot', () => {
+    const view = model(bareState(), caps(), { ...SNAP, source: 'audio_fft' });
+    expect(view.scopeDisplay!.source.reading).toEqual({ status: 'known', value: 'audio_fft' });
+    expect(view.scopeDisplay!.source.availability).toEqual({ structural: true, operational: true });
+  });
+
+  it('reports source unknown, but still structurally present, before any source resolves', () => {
+    const view = model(bareState(), caps(), { ...SNAP, source: null });
+    expect(view.scopeDisplay!.source.reading).toEqual({ status: 'unknown' });
+    expect(view.scopeDisplay!.source.availability).toEqual({ structural: true, operational: false });
+  });
+
+  it('reports a known health reading for a fully live snapshot', () => {
+    const view = model(bareState(), caps(), SNAP);
+    expect(view.scopeDisplay!.health.reading).toEqual({ status: 'known', value: 'connected' });
+  });
+
+  it('emits a validator-clean model carrying the scopeDisplay group (round-trip proof)', () => {
+    const view = model(bareState(), caps(), SNAP);
+    expect(JSON.parse(JSON.stringify(view))).toEqual(view);
+  });
+});
+
+/**
+ * PARITY MATRIX — every branch of `deriveScopeIndicatorState`
+ * (`StatusBar.svelte`), each isolated by flipping exactly the input that
+ * branch decides on, run through BOTH `classifyScopeHealth` (indirectly, via
+ * the adapter) and the real shipped function. Disagreement here is the
+ * reimplementation drift this whole discipline exists to catch.
+ */
+describe('scopeDisplay health classification agrees with the real status-bar indicator (MOR-1301 parity)', () => {
+  const live: ScopeDisplaySnapshot = SNAP;
+
+  const CASES: Array<[string, ScopeDisplaySnapshot]> = [
+    ['radio powered off overrides everything', { ...live, isPoweredOff: true }],
+    ['no source selected', { ...live, source: null }],
+    ['source not available', { ...live, available: false }],
+    ['resource not selected', { ...live, resourceSelected: false }],
+    ['zero demand', { ...live, demand: 0 }],
+    ['lifecycle failed', { ...live, lifecycle: 'failed' }],
+    ['lifecycle starting', { ...live, lifecycle: 'starting' }],
+    ['transport connecting', { ...live, lifecycle: 'inactive', transport: 'connecting' }],
+    ['transport reconnecting', { ...live, lifecycle: 'inactive', transport: 'reconnecting' }],
+    ['transport disconnected', { ...live, lifecycle: 'inactive', transport: 'disconnected' }],
+    ['connected but no frame seen yet', { ...live, frameSeen: false }],
+    ['connected, frame seen, streaming', live],
+    ['connected, frame seen, lifecycle not streaming (fallback)', { ...live, lifecycle: 'inactive' }],
+    ['audio_fft source, otherwise identical to the live case', { ...live, source: 'audio_fft' }],
+  ];
+
+  it.each(CASES)('%s', (_label, snapshot) => {
+    const view = model(bareState(), caps(), snapshot);
+    const expected = deriveScopeIndicatorState(snapshot, snapshot.isPoweredOff);
+    expect(view.scopeDisplay!.health.reading).toEqual({ status: 'known', value: expected });
+  });
+});
+
+describe('scopeDisplay determinism in (caps, snapshot) (MOR-1301)', () => {
+  it('is stable across repeated derivations of the same inputs', () => {
+    expect(model(bareState(), caps(), SNAP).scopeDisplay).toEqual(model(bareState(), caps(), SNAP).scopeDisplay);
+  });
+
+  it('changes with the snapshot, and with caps, independently', () => {
+    const withHealthDiff = model(bareState(), caps(), { ...SNAP, frameSeen: false });
+    expect(withHealthDiff.scopeDisplay!.health).not.toEqual(model(bareState(), caps(), SNAP).scopeDisplay!.health);
+    const noScope = caps({ scope: false, capabilities: ['audio', 'tx'], scopeSource: undefined });
+    expect(model(bareState(), noScope, SNAP).scopeDisplay).toBeUndefined();
+  });
+});

--- a/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
@@ -32,6 +32,7 @@ import type {
   FilterPassbandViewModel, DspViewModel, RfFrontEndViewModel,
   BandChoice, BandViewModel, RitXitViewModel, AntennaViewModel, ScanViewModel,
   BreakInMode, CwKeyerViewModel, ScopeControlsViewModel,
+  ScopeDisplayViewModel, ScopeSourceKind, ScopeHealthState,
 } from '../../../semantic/radio-view-model';
 import type { TxAuthoritySnapshot } from '../../../semantic/rx-tx-surface';
 import { isFieldAvailable } from '$lib/state/field-status';
@@ -966,6 +967,95 @@ function deriveScopeControls(
 }
 
 /**
+ * The App-owned scope-display snapshot the `scopeDisplay` facts are read
+ * against (MOR-1262 slice 12A, MOR-1301). Like `RxAudioSnapshot`, this is an
+ * INPUT: `defaultScopeStatus` lives on the `FrontendRuntime` singleton
+ * (`lib/runtime/frontend-runtime.ts`), not on `ServerState`/`Capabilities`,
+ * so a fact derivation may not reach for it directly (MOR-988 §3.2
+ * determinism) — the caller reads its own already-live
+ * `runtime.defaultScopeStatus` plus the radio-power state it already tracks
+ * and hands the values in. Field names mirror `DefaultScopeStatus` verbatim
+ * (`source`/`available`/`resourceSelected`/`demand`/`lifecycle`/`transport`/
+ * `frameSeen`) so a caller can spread `runtime.defaultScopeStatus` in
+ * directly; `isPoweredOff` is the one addition, the status bar's own
+ * override input to the same classification (see `classifyScopeHealth`).
+ */
+export interface ScopeDisplaySnapshot {
+  source: ScopeSourceKind | null;
+  available: boolean;
+  resourceSelected: boolean;
+  demand: number;
+  lifecycle: 'inactive' | 'starting' | 'streaming' | 'failed';
+  transport: 'disconnected' | 'connecting' | 'connected' | 'reconnecting';
+  frameSeen: boolean;
+  isPoweredOff: boolean;
+}
+
+/**
+ * Mirrors `hasAnyScope()` (`$lib/stores/capabilities.svelte.ts`) — the real
+ * gate the status bar's scope indicator uses to decide whether to render at
+ * all — re-driven on THIS function's own `caps` argument rather than that
+ * store singleton, which a fact derivation may not read (determinism, N2).
+ * A one-line boolean; agreement with the store function is a direct
+ * expression match, not something worth a live-store parity test (which
+ * would need `setCapabilities`/`afterEach` cleanup under the fast pool,
+ * MOR-1272 — avoided here because it is avoidable).
+ */
+function hasAnyScopeCap(caps: Capabilities | null): boolean {
+  return caps?.scope === true || caps?.scopeSource === 'audio_fft';
+}
+
+/**
+ * Byte-identical to `deriveScopeIndicatorState` (`components-v2/layout/
+ * StatusBar.svelte`) — the shipped status-bar scope indicator's own state
+ * machine, reproduced here because `lib/runtime` may not import
+ * `components-v2` (ADR 2026-04-12, `eslint.config.js`'s `FORBIDDEN` import
+ * boundary), so the real function cannot be called from this file. Parity
+ * with the real function, across a full discriminating-combo matrix, is
+ * pinned in `__tests__/scope-display-adapter.test.ts` rather than assumed —
+ * the same "agree with the real projector" discipline `projectModInputSource`
+ * above uses for the same reason (that one duplicates `app-authority.ts`'s
+ * `projectInputs`, blocked by the same boundary).
+ */
+function classifyScopeHealth(s: ScopeDisplaySnapshot): ScopeHealthState {
+  if (s.isPoweredOff) return 'disconnected';
+  if (s.source === null || !s.available || !s.resourceSelected || s.demand === 0) return 'inactive';
+  if (s.lifecycle === 'failed') return 'failed';
+  if (s.lifecycle === 'starting') return 'starting';
+  if (s.transport === 'connecting') return 'connecting';
+  if (s.transport === 'reconnecting') return 'reconnecting';
+  if (s.transport === 'disconnected') return 'disconnected';
+  if (!s.frameSeen) return 'waiting';
+  return s.lifecycle === 'streaming' ? 'connected' : 'inactive';
+}
+
+/**
+ * Scope-display facts (MOR-1262 decomposition slice 12A, MOR-1301 — the
+ * FINAL A-slice of the vocabulary program). See `ScopeDisplayViewModel`'s
+ * doc comment for the group-shape rationale (why scope tuning and scope
+ * pixels are both deliberately absent).
+ *
+ * Evidence gate: NO snapshot ⇒ NO group (same `deriveRxAudio` discipline —
+ * `defaultScopeStatus` is App-owned, not this layer's to guess), AND
+ * `hasAnyScopeCap(caps)` ⇒ NO group otherwise (a radio with neither a
+ * hardware scope nor an audio-FFT source has no indicator to state a fact
+ * about, mirroring the real status bar rendering nothing at all).
+ *
+ * Both leaves share the one structural gate: unlike `scopeControls`'s
+ * per-leaf capability split, there is exactly one v2 reader here (the status
+ * bar's single indicator), so there is exactly one gate.
+ */
+function deriveScopeDisplay(
+  caps: Capabilities | null, snapshot: ScopeDisplaySnapshot | null | undefined,
+): ScopeDisplayViewModel | undefined {
+  if (!snapshot || !hasAnyScopeCap(caps)) return undefined;
+  return {
+    source: txAuxField(true, snapshot.source !== null, snapshot.source ?? undefined),
+    health: txAuxField(true, true, classifyScopeHealth(snapshot)),
+  };
+}
+
+/**
  * The App-owned RX-audio snapshot the `rxAudio` facts are read against
  * (MOR-1262 slice 3A). It is an INPUT, deliberately: audio lifetime belongs to
  * the App (MOR-1058) and building a view model must never open, start or probe
@@ -1065,6 +1155,7 @@ export function toRadioViewModel(
   state: ServerState | null, caps: Capabilities | null,
   tx?: MetersTxAuthority | null,
   rxAudioSnapshot?: RxAudioSnapshot | null,
+  scopeDisplaySnapshot?: ScopeDisplaySnapshot | null,
 ): RadioViewModel | null {
   if (!caps) return null;
   const presentation = derivePresentationCapabilities(caps);
@@ -1204,6 +1295,7 @@ export function toRadioViewModel(
   const scan = deriveScan(state);
   const cwKeyer = deriveCwKeyer(state, caps);
   const scopeControls = deriveScopeControls(state, caps);
+  const scopeDisplay = deriveScopeDisplay(caps, scopeDisplaySnapshot);
   const rfFrontEndMutex = deriveRfFrontEndMutex(rfFrontEnd);
   if (rfFrontEndMutex) disabledReasons.push(rfFrontEndMutex);
   disabledReasons.push(...deriveCwKeyerReasons(cwKeyer, modeFilter, txPermit));
@@ -1232,5 +1324,6 @@ export function toRadioViewModel(
     ...(scan !== undefined ? { scan } : {}),
     ...(cwKeyer !== undefined ? { cwKeyer } : {}),
     ...(scopeControls !== undefined ? { scopeControls } : {}),
+    ...(scopeDisplay !== undefined ? { scopeDisplay } : {}),
   };
 }

--- a/frontend/src/semantic/__tests__/optional-group-allow-list.test.ts
+++ b/frontend/src/semantic/__tests__/optional-group-allow-list.test.ts
@@ -43,10 +43,11 @@ const REQUIRED_KEYS = [
 /** MOR-1244: txAux. MOR-1262 slice 2A: meters. Slice 3A: rxAudio. Slice 4A:
  *  modeFilter. Slice 4A′: filterPassband. Slice 5A: dsp. Slice 6A: rfFrontEnd.
  *  Slice 7A: band. Slice 8A: ritXit, antenna, scan. Slice 9A: cwKeyer. Slice
- *  11A: scopeControls. Add your key here when your family's slice lands. */
+ *  11A: scopeControls. Slice 12A (MOR-1301, final A-slice): scopeDisplay.
+ *  Add your key here when your family's slice lands. */
 const EXPECTED_OPTIONAL_GROUP_KEYS = [
   'txAux', 'meters', 'rxAudio', 'modeFilter', 'filterPassband', 'dsp', 'rfFrontEnd', 'band',
-  'ritXit', 'antenna', 'scan', 'cwKeyer', 'scopeControls',
+  'ritXit', 'antenna', 'scan', 'cwKeyer', 'scopeControls', 'scopeDisplay',
 ] as const;
 
 function extractTopLevelAllowList(): string[] {

--- a/frontend/src/semantic/__tests__/scope-display.test.ts
+++ b/frontend/src/semantic/__tests__/scope-display.test.ts
@@ -1,0 +1,99 @@
+/**
+ * MOR-1262 decomposition slice 12A (MOR-1301, the FINAL A-slice of the
+ * vocabulary program) — `scopeDisplay` optional fact group (validator half).
+ *
+ * Facts: which scope SOURCE is currently live (hardware CI-V frames vs the
+ * browser audio FFT) and how HEALTHY that source's connection is — never
+ * scope tuning (`scopeControls`, slice 11A/11A′, unchanged by this file) and
+ * never scope pixels/overlays. See `radio-view-model.ts`'s
+ * `ScopeDisplayViewModel` doc comment for the full rationale, and
+ * `radio-view-model-adapter.ts`'s `deriveScopeDisplay` for the live
+ * derivation (covered by the companion `scope-display-adapter.test.ts`).
+ *
+ * Mirrors the companion families' (`scope-controls.test.ts`, `scan.test.ts`)
+ * kill-tests: absent-group round-trip, exactKeys rejection of `null`/`{}`,
+ * an extra-key rejection, and one precise-error-path rejection per leaf.
+ */
+import { describe, expect, it } from 'vitest';
+import { validateRadioViewModel, type ScopeDisplayField } from '../radio-view-model';
+import { topologyFixtures, withScopeDisplay } from '../fixtures/topologies';
+
+const AVAIL = { structural: true, operational: true } as const;
+const base = topologyFixtures['1/single'];
+
+describe('scopeDisplay (MOR-1262 slice 12A)', () => {
+  it('validates a scopeDisplay-absent model and never adds the key', () => {
+    expect(Object.keys(base)).not.toContain('scopeDisplay');
+    const validated = validateRadioViewModel(base);
+    expect(Object.keys(validated)).not.toContain('scopeDisplay');
+    expect(validated.scopeDisplay).toBeUndefined();
+    expect(JSON.parse(JSON.stringify(validated))).toEqual(JSON.parse(JSON.stringify(base)));
+  });
+
+  it('validates a fully-populated scopeDisplay group and returns it unchanged', () => {
+    const withSd = withScopeDisplay(base);
+    expect(validateRadioViewModel(withSd).scopeDisplay).toEqual(withSd.scopeDisplay);
+  });
+
+  it('rejects an explicit scopeDisplay: null', () => {
+    expect(() => validateRadioViewModel({ ...base, scopeDisplay: null })).toThrow(TypeError);
+  });
+
+  it('rejects an explicit scopeDisplay: {} — present, not absent, must satisfy its own shape', () => {
+    expect(() => validateRadioViewModel({ ...base, scopeDisplay: {} })).toThrow(TypeError);
+  });
+
+  it('rejects an extra key on the group (closed shape, exactly the two facts)', () => {
+    const withSd = withScopeDisplay(base);
+    const extra: ScopeDisplayField<number> = { reading: { status: 'known', value: 0 }, availability: AVAIL };
+    const malformed = { ...withSd, scopeDisplay: { ...withSd.scopeDisplay, bogus: extra } };
+    expect(() => validateRadioViewModel(malformed)).toThrow(TypeError);
+  });
+
+  it('rejects an invalid source reading value with a precise error path', () => {
+    const withSd = withScopeDisplay(base);
+    const malformed = {
+      ...withSd,
+      scopeDisplay: {
+        ...withSd.scopeDisplay, source: { reading: { status: 'known', value: 'usb' }, availability: AVAIL },
+      },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.scopeDisplay\.source\.reading\.value/);
+  });
+
+  it('rejects an invalid health reading value with a precise error path', () => {
+    const withSd = withScopeDisplay(base);
+    const malformed = {
+      ...withSd,
+      scopeDisplay: {
+        ...withSd.scopeDisplay, health: { reading: { status: 'known', value: 'green' }, availability: AVAIL },
+      },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.scopeDisplay\.health\.reading\.value/);
+  });
+
+  it('accepts a structurally-absent field (present group, source not yet resolved)', () => {
+    const withSd = withScopeDisplay(base);
+    const off = { structural: false, operational: false } as const;
+    const model = {
+      ...withSd,
+      scopeDisplay: { ...withSd.scopeDisplay, source: { reading: { status: 'unknown' }, availability: off } },
+    };
+    expect(validateRadioViewModel(model).scopeDisplay!.source.availability.structural).toBe(false);
+  });
+
+  it('accepts every declared ScopeHealthState value', () => {
+    const states = [
+      'inactive', 'starting', 'connecting', 'waiting',
+      'reconnecting', 'failed', 'disconnected', 'connected',
+    ] as const;
+    for (const health of states) {
+      const withSd = withScopeDisplay(base);
+      const model = {
+        ...withSd,
+        scopeDisplay: { ...withSd.scopeDisplay, health: { reading: { status: 'known', value: health }, availability: AVAIL } },
+      };
+      expect(validateRadioViewModel(model).scopeDisplay!.health.reading).toEqual({ status: 'known', value: health });
+    }
+  });
+});

--- a/frontend/src/semantic/fixtures/topologies.ts
+++ b/frontend/src/semantic/fixtures/topologies.ts
@@ -23,6 +23,7 @@ import type {
   RitXitField, RitXitViewModel, RxAudioField, RxAudioViewModel,
   ScanField, ScanViewModel,
   ScopeControlsField, ScopeControlsViewModel,
+  ScopeDisplayField, ScopeDisplayViewModel,
   TxAuxField, TxAuxViewModel,
 } from '../radio-view-model';
 
@@ -483,4 +484,21 @@ export function withScopeControls(fixture: RadioViewModel): RadioViewModel {
     receiver: known(0),
   };
   return { ...fixture, scopeControls };
+}
+
+/**
+ * Applies a fully-observed `scopeDisplay` group (MOR-1262 slice 12A/
+ * MOR-1301, the FINAL A-slice) to any topology fixture — same
+ * composable-axis story as `withScopeControls` above.
+ */
+export function withScopeDisplay(fixture: RadioViewModel): RadioViewModel {
+  const avail: Availability = { structural: true, operational: true };
+  const known = <T>(value: T): ScopeDisplayField<T> => (
+    { reading: { status: 'known', value }, availability: avail }
+  );
+  const scopeDisplay: ScopeDisplayViewModel = {
+    source: known('hardware'),
+    health: known('connected'),
+  };
+  return { ...fixture, scopeDisplay };
 }

--- a/frontend/src/semantic/radio-view-model.ts
+++ b/frontend/src/semantic/radio-view-model.ts
@@ -818,6 +818,63 @@ export interface ScopeControlsViewModel {
   receiver: ScopeControlsField<number>;
 }
 
+/**
+ * A single scope-display fact (MOR-1262 decomposition slice 12A, MOR-1301 —
+ * the LAST A-slice of the vocabulary program). Shape-identical to
+ * `TxAuxField`, declared as an alias for the same reason
+ * `ScopeControlsField`/`CwKeyerField`/etc. are.
+ */
+export type ScopeDisplayField<T> = TxAuxField<T>;
+
+/** Which scope channel the frontend currently treats as "the" scope
+ *  (`ScopeSource` in `lib/runtime/scope-controller.svelte.ts`) — hardware
+ *  CI-V scope frames vs the browser-side audio FFT. */
+export type ScopeSourceKind = 'hardware' | 'audio_fft';
+
+/** The v2 status-bar scope indicator's own state machine
+ *  (`ScopeIndicatorState` in `components-v2/layout/StatusBar.svelte`),
+ *  reproduced verbatim as the closed set of values this fact may take —
+ *  never a UI-only label, an ordinal, or a raw transport/lifecycle string. */
+export type ScopeHealthState =
+  | 'inactive' | 'starting' | 'connecting' | 'waiting'
+  | 'reconnecting' | 'failed' | 'disconnected' | 'connected';
+
+/**
+ * Scope-display facts (MOR-1262 decomposition slice 12A/MOR-1301, the FINAL
+ * A-slice of the vocabulary program): WHICH scope source is currently live
+ * and HOW HEALTHY it is — never scope TUNING (MODE/EDGE/HOLD/REF are
+ * `scopeControls`, slice 11A/11A′, and are not duplicated here per that
+ * slice's binding boundary ruling) and never the scope's PIXELS (live
+ * hardware/audio-FFT frames stay a wholly App-owned resource demand, same
+ * doctrine `ScopeAvailabilityViewModel`'s doc comment already states for
+ * `scope.hardwareScope`/`scope.audioFftScope` — this group is downstream of
+ * those two structural/operational booleans, not a replacement for them).
+ * Band-plan, DX-spot and EiBi overlays are explicitly out of scope too.
+ *
+ * PARITY: `source` mirrors `runtime.defaultScopeStatus.source`
+ * (`lib/runtime/frontend-runtime.ts`) and `health` reproduces the exact
+ * state machine the shipped status-bar scope indicator already computes
+ * from that same status object (`deriveScopeIndicatorState`,
+ * `StatusBar.svelte`) — pinned against the real function in
+ * `__tests__/scope-display-adapter.test.ts` rather than assumed, the same
+ * "agree with the real projector" discipline `deriveRxAudio`'s
+ * `modInputSource` uses. `demand`/`frameSeen`/`lifecycle`/`transport` are
+ * consumed ONLY as inputs to that one classification, never exposed as
+ * their own leaves — they are exactly the "subscription state"/"frame
+ * data" this slice's ticket forbids restating as facts.
+ *
+ * INPUT, not a store read: like `rxAudio` (slice 3A), `defaultScopeStatus`
+ * lives on the `FrontendRuntime` singleton, not on `ServerState`/
+ * `Capabilities` — a fact derivation may not read it directly (MOR-988 §3.2
+ * determinism), so the caller supplies a plain snapshot
+ * (`ScopeDisplaySnapshot`, `radio-view-model-adapter.ts`) and NO snapshot
+ * means NO group, same as `rxAudio`.
+ */
+export interface ScopeDisplayViewModel {
+  source: ScopeDisplayField<ScopeSourceKind>;
+  health: ScopeDisplayField<ScopeHealthState>;
+}
+
 export interface RadioViewModel {
   topologyId: string;
   vfoScheme: VfoScheme;
@@ -884,6 +941,10 @@ export interface RadioViewModel {
    *  capability, so v2 renders no spectrum toolbar at all — see
    *  `radio-view-model-adapter.ts`'s `deriveScopeControls`. */
   readonly scopeControls?: ScopeControlsViewModel;
+  /** Absent (MOR-1264 optional group) ⇒ this radio declares no `scope`
+   *  capability and no audio-FFT scope source — see
+   *  `radio-view-model-adapter.ts`'s `deriveScopeDisplay`. */
+  readonly scopeDisplay?: ScopeDisplayViewModel;
 }
 
 const RECEIVER_IDS: readonly ReceiverId[] = ['MAIN', 'SUB'];
@@ -1406,6 +1467,21 @@ function validateScopeControls(value: unknown, path: string): ScopeControlsViewM
   };
 }
 
+const SCOPE_SOURCES: readonly ScopeSourceKind[] = ['hardware', 'audio_fft'];
+const SCOPE_HEALTH_STATES: readonly ScopeHealthState[] = [
+  'inactive', 'starting', 'connecting', 'waiting',
+  'reconnecting', 'failed', 'disconnected', 'connected',
+];
+
+function validateScopeDisplay(value: unknown, path: string): ScopeDisplayViewModel {
+  const v = record(value, path);
+  exactKeys(v, ['source', 'health'], path);
+  return {
+    source: validateTxAuxField(v.source, `${path}.source`, (val, p) => oneOf(val, SCOPE_SOURCES, p)),
+    health: validateTxAuxField(v.health, `${path}.health`, (val, p) => oneOf(val, SCOPE_HEALTH_STATES, p)),
+  };
+}
+
 /** Runtime validator (repo idiom: throws TypeError with a `$.path`, see `validateCapabilities`).
  *  Also enforces two cross-field invariants (review cycle 1, V1): `txPermit`
  *  cannot be 'allowed' while `txTarget` is unknown (no fail-open), and
@@ -1416,7 +1492,7 @@ export function validateRadioViewModel(value: unknown): RadioViewModel {
     'topologyId', 'vfoScheme', 'activeReceiver', 'vfos', 'split', 'dualWatch',
     'txTarget', 'txPermit', 'scope', 'disabledReasons', 'txAux', 'meters', 'rxAudio', 'modeFilter',
     'filterPassband', 'dsp', 'rfFrontEnd', 'band', 'ritXit', 'antenna', 'scan', 'cwKeyer',
-    'scopeControls',
+    'scopeControls', 'scopeDisplay',
   ], '$');
   if (!Array.isArray(v.vfos)) invalid('$.vfos', 'an array');
   if (!Array.isArray(v.disabledReasons)) invalid('$.disabledReasons', 'an array');
@@ -1457,6 +1533,7 @@ export function validateRadioViewModel(value: unknown): RadioViewModel {
   const scan = optionalGroup(v.scan, '$.scan', validateScan);
   const cwKeyer = optionalGroup(v.cwKeyer, '$.cwKeyer', validateCwKeyer);
   const scopeControls = optionalGroup(v.scopeControls, '$.scopeControls', validateScopeControls);
+  const scopeDisplay = optionalGroup(v.scopeDisplay, '$.scopeDisplay', validateScopeDisplay);
 
   const disabledReasons = v.disabledReasons.map((r, i) => validateDisabledReason(r, `$.disabledReasons[${i}]`));
   // SAFETY, MOR-1296 — the fail-closed half of "no second permit", enforced
@@ -1499,5 +1576,6 @@ export function validateRadioViewModel(value: unknown): RadioViewModel {
     ...(scan !== undefined ? { scan } : {}),
     ...(cwKeyer !== undefined ? { cwKeyer } : {}),
     ...(scopeControls !== undefined ? { scopeControls } : {}),
+    ...(scopeDisplay !== undefined ? { scopeDisplay } : {}),
   };
 }


### PR DESCRIPTION
## Summary

12A: scopeDisplay facts group added to RadioViewModel — the LAST A-queue slice; on merge the A-queue (MOR-1262 dictionary) is COMPLETE.

- deriveScopeIndicatorState with 14-case parity matrix running the real derivation as oracle.
- Production LOC 62 (verifier-measured, frozen formula; guard <=200).
- Group unreachable in production until 12B wires the snapshot (intentional A/B split, same as rxAudio precedent).

## Review provenance

Verified by the independent vocabulary-domain opus anchor (session 8): 12/12 mutation probes killed (incl. branch-order swap and a reconnecting->connecting near-miss); applies cleanly onto main 37147cee with zero conflicts; full suite on main+patch = 5160 tests with the single failure also failing on plain main (pre-existing).

Verifier notes routed to follow-up tickets (not blocking): unguarded literal-union widening direction (one-line type-only import hardening); hardwareScopeConnected residual when source === 'audio_fft' (real input to the 12B SpectrumPanel port).

🤖 Generated with [Claude Code](https://claude.com/claude-code)