### PR TITLE
feat(MOR-1330): scope-settings facts (11A") - four popover leaves on scopeControls

### DIFF
--- a/frontend/src/lib/runtime/adapters/__tests__/scope-controls-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/scope-controls-adapter.test.ts
@@ -126,41 +126,34 @@ describe('scopeControls per-field structural gates (MOR-1298/MOR-1299/MOR-1330, 
 describe('scopeControls per-field derivation (MOR-1298/MOR-1299/MOR-1330)', () => {
   const fullCaps = scopeCaps(['scope', 'dual_rx']);
 
-  it('reports known readings for observed, fresh fields — parity with isFieldAvailable, the same predicate the real toolbar uses', () => {
+  const ALL_TWELVE = [
+    'mode', 'edge', 'span', 'speed', 'hold', 'refDb', 'dual', 'receiver',
+    'duringTx', 'centerType', 'vbwNarrow', 'rbw',
+  ] as const;
+
+  const CASE_A = {
+    mode: 1, edge: 2, span: 5, speed: 3, refDb: -5, receiver: 0,
+    centerType: 4, rbw: 6, hold: false, dual: false, duringTx: true, vbwNarrow: true,
+  };
+  const CASE_B = { ...CASE_A, dual: true, duringTx: false };
+
+  it.each([['A', CASE_A], ['B', CASE_B]])('case %s: every leaf reports its OWN raw value', (_label, sc) => {
     const state = bareState({
       scopeControls: {
-        receiver: 1, dual: true, mode: 1, span: 5, edge: 2, hold: true, refDb: -5, speed: 2,
-        duringTx: true, centerType: 2, vbwNarrow: true, rbw: 1,
+        ...sc,
         fixedEdge: { rangeIndex: 0, edge: 0, startHz: 0, endHz: 0 },
       },
       fieldStatus: {
         ...bareState().fieldStatus,
-        'scopeControls.mode': fresh, 'scopeControls.edge': fresh,
-        'scopeControls.span': fresh, 'scopeControls.speed': fresh,
-        'scopeControls.hold': fresh, 'scopeControls.refDb': fresh,
-        'scopeControls.dual': fresh, 'scopeControls.receiver': fresh,
-        'scopeControls.duringTx': fresh, 'scopeControls.centerType': fresh,
-        'scopeControls.vbwNarrow': fresh, 'scopeControls.rbw': fresh,
+        ...Object.fromEntries(ALL_TWELVE.map(leaf => [`scopeControls.${leaf}`, fresh])),
       },
     } as Partial<ServerState>);
-    const sc = model(state, fullCaps).scopeControls!;
-    expect(sc.mode.reading).toEqual({ status: 'known', value: 1 });
-    expect(sc.edge.reading).toEqual({ status: 'known', value: 2 });
-    expect(sc.span.reading).toEqual({ status: 'known', value: 5 });
-    expect(sc.speed.reading).toEqual({ status: 'known', value: 2 });
-    expect(sc.hold.reading).toEqual({ status: 'known', value: true });
-    expect(sc.refDb.reading).toEqual({ status: 'known', value: -5 });
-    expect(sc.dual.reading).toEqual({ status: 'known', value: true });
-    expect(sc.receiver.reading).toEqual({ status: 'known', value: 1 });
-    expect(sc.duringTx.reading).toEqual({ status: 'known', value: true });
-    expect(sc.centerType.reading).toEqual({ status: 'known', value: 2 });
-    expect(sc.vbwNarrow.reading).toEqual({ status: 'known', value: true });
-    expect(sc.rbw.reading).toEqual({ status: 'known', value: 1 });
-    for (const leaf of [
-      'mode', 'edge', 'span', 'speed', 'hold', 'refDb', 'dual', 'receiver',
-      'duringTx', 'centerType', 'vbwNarrow', 'rbw',
-    ] as const) {
-      expect(sc[leaf].availability.operational).toBe(isFieldAvailable(state, `scopeControls.${leaf}`));
+    const view = model(state, fullCaps);
+    for (const leaf of ALL_TWELVE) {
+      expect(view.scopeControls![leaf].reading).toEqual({ status: 'known', value: sc[leaf] });
+    }
+    for (const leaf of ALL_TWELVE) {
+      expect(view.scopeControls![leaf].availability.operational).toBe(isFieldAvailable(state, `scopeControls.${leaf}`));
     }
   });
 

--- a/frontend/src/lib/runtime/adapters/__tests__/scope-controls-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/scope-controls-adapter.test.ts
@@ -1,21 +1,24 @@
 /**
  * MOR-1262 decomposition slice 11A (MOR-1298), extended by slice 11A′
- * (MOR-1299) — `scopeControls` fact-group adapter derivation.
+ * (MOR-1299) and slice 11A″ (MOR-1330) — `scopeControls` fact-group adapter
+ * derivation.
  *
  * Companion to `cw-keyer-adapter.test.ts`/`scan-adapter.test.ts`, which this
  * file does NOT modify. `scopeControls` is a SEPARATE optional group — see
  * `radio-view-model.ts`'s `ScopeControlsViewModel` doc comment.
  *
  * PARITY — this group has no extractable pure `toXProps` function to call
- * (the real derivation is inline in `SpectrumToolbar.svelte`'s `$derived`
- * blocks), so the pins below call the SAME `isFieldAvailable` predicate the
- * toolbar calls for its own `scopeModeAvailable`/`scopeEdgeAvailable`/
- * `scopeSpanAvailable`/`scopeSpeedAvailable`/`scopeHoldAvailable`/
- * `scopeRefAvailable`/`scopeDualAvailable`/`scopeReceiverAvailable`
- * booleans, rather than reimplementing it. The toolbar's
- * `scopeControls?.span ?? 3` (etc.) fallbacks are pinned as fabrication this
- * contract deliberately diverges from — see the honesty-gate describe
- * block.
+ * (the real derivation is inline in `SpectrumToolbar.svelte`'s/
+ * `ScopeSettingsPopover.svelte`'s `$derived` blocks), so the pins below call
+ * the SAME `isFieldAvailable` predicate those components call for their own
+ * `scopeModeAvailable`/`scopeEdgeAvailable`/`scopeSpanAvailable`/
+ * `scopeSpeedAvailable`/`scopeHoldAvailable`/`scopeRefAvailable`/
+ * `scopeDualAvailable`/`scopeReceiverAvailable` booleans (toolbar) and its
+ * own `scopeControls?.<leaf>` reads (popover), rather than reimplementing
+ * it. The toolbar's `scopeControls?.span ?? 3` (etc.) fallbacks and the
+ * popover's `?.vbwNarrow ?? false` / `?.duringTx ?? false` fallbacks are
+ * pinned as fabrication this contract deliberately diverges from — see the
+ * honesty-gate describe block.
  */
 import { describe, expect, it } from 'vitest';
 import type { Capabilities } from '$lib/types/capabilities';
@@ -77,21 +80,30 @@ describe('scopeControls evidence gate (MOR-1298, N3)', () => {
     const view = model(bareState(), scopeCaps());
     expect(view.scopeControls).toBeDefined();
     expect(Object.keys(view.scopeControls!).sort()).toEqual(
-      ['dual', 'edge', 'hold', 'mode', 'receiver', 'refDb', 'span', 'speed'],
+      ['centerType', 'dual', 'duringTx', 'edge', 'hold', 'mode', 'rbw', 'receiver', 'refDb', 'span',
+        'speed', 'vbwNarrow'],
     );
   });
 });
 
-describe('scopeControls per-field structural gates (MOR-1298/MOR-1299, X6200 lesson)', () => {
-  it('mode/edge/span/speed/hold/refDb stay structurally present on a scope-only, single-RX radio (IC-7300/IC-9700 shape)', () => {
-    const view = model(bareState(), scopeCaps(['scope']));
-    expect(view.scopeControls!.mode.availability.structural).toBe(true);
-    expect(view.scopeControls!.edge.availability.structural).toBe(true);
-    expect(view.scopeControls!.span.availability.structural).toBe(true);
-    expect(view.scopeControls!.speed.availability.structural).toBe(true);
-    expect(view.scopeControls!.hold.availability.structural).toBe(true);
-    expect(view.scopeControls!.refDb.availability.structural).toBe(true);
-  });
+describe('scopeControls per-field structural gates (MOR-1298/MOR-1299/MOR-1330, X6200 lesson)', () => {
+  it(
+    'mode/edge/span/speed/hold/refDb/duringTx/centerType/vbwNarrow/rbw stay structurally present on a '
+    + 'scope-only, single-RX radio (IC-7300/IC-9700 shape)',
+    () => {
+      const view = model(bareState(), scopeCaps(['scope']));
+      expect(view.scopeControls!.mode.availability.structural).toBe(true);
+      expect(view.scopeControls!.edge.availability.structural).toBe(true);
+      expect(view.scopeControls!.span.availability.structural).toBe(true);
+      expect(view.scopeControls!.speed.availability.structural).toBe(true);
+      expect(view.scopeControls!.hold.availability.structural).toBe(true);
+      expect(view.scopeControls!.refDb.availability.structural).toBe(true);
+      expect(view.scopeControls!.duringTx.availability.structural).toBe(true);
+      expect(view.scopeControls!.centerType.availability.structural).toBe(true);
+      expect(view.scopeControls!.vbwNarrow.availability.structural).toBe(true);
+      expect(view.scopeControls!.rbw.availability.structural).toBe(true);
+    },
+  );
 
   it('dual/receiver are structurally absent without dual_rx — no radio-specific table, just the cap tag', () => {
     const view = model(bareState(), scopeCaps(['scope']));
@@ -111,14 +123,14 @@ describe('scopeControls per-field structural gates (MOR-1298/MOR-1299, X6200 les
   });
 });
 
-describe('scopeControls per-field derivation (MOR-1298/MOR-1299)', () => {
+describe('scopeControls per-field derivation (MOR-1298/MOR-1299/MOR-1330)', () => {
   const fullCaps = scopeCaps(['scope', 'dual_rx']);
 
   it('reports known readings for observed, fresh fields — parity with isFieldAvailable, the same predicate the real toolbar uses', () => {
     const state = bareState({
       scopeControls: {
         receiver: 1, dual: true, mode: 1, span: 5, edge: 2, hold: true, refDb: -5, speed: 2,
-        duringTx: false, centerType: 0, vbwNarrow: false, rbw: 0,
+        duringTx: true, centerType: 2, vbwNarrow: true, rbw: 1,
         fixedEdge: { rangeIndex: 0, edge: 0, startHz: 0, endHz: 0 },
       },
       fieldStatus: {
@@ -127,6 +139,8 @@ describe('scopeControls per-field derivation (MOR-1298/MOR-1299)', () => {
         'scopeControls.span': fresh, 'scopeControls.speed': fresh,
         'scopeControls.hold': fresh, 'scopeControls.refDb': fresh,
         'scopeControls.dual': fresh, 'scopeControls.receiver': fresh,
+        'scopeControls.duringTx': fresh, 'scopeControls.centerType': fresh,
+        'scopeControls.vbwNarrow': fresh, 'scopeControls.rbw': fresh,
       },
     } as Partial<ServerState>);
     const sc = model(state, fullCaps).scopeControls!;
@@ -138,12 +152,22 @@ describe('scopeControls per-field derivation (MOR-1298/MOR-1299)', () => {
     expect(sc.refDb.reading).toEqual({ status: 'known', value: -5 });
     expect(sc.dual.reading).toEqual({ status: 'known', value: true });
     expect(sc.receiver.reading).toEqual({ status: 'known', value: 1 });
-    for (const leaf of ['mode', 'edge', 'span', 'speed', 'hold', 'refDb', 'dual', 'receiver'] as const) {
+    expect(sc.duringTx.reading).toEqual({ status: 'known', value: true });
+    expect(sc.centerType.reading).toEqual({ status: 'known', value: 2 });
+    expect(sc.vbwNarrow.reading).toEqual({ status: 'known', value: true });
+    expect(sc.rbw.reading).toEqual({ status: 'known', value: 1 });
+    for (const leaf of [
+      'mode', 'edge', 'span', 'speed', 'hold', 'refDb', 'dual', 'receiver',
+      'duringTx', 'centerType', 'vbwNarrow', 'rbw',
+    ] as const) {
       expect(sc[leaf].availability.operational).toBe(isFieldAvailable(state, `scopeControls.${leaf}`));
     }
   });
 
-  const STALE_FIELDS = ['mode', 'edge', 'span', 'speed', 'hold', 'refDb', 'dual', 'receiver'] as const;
+  const STALE_FIELDS = [
+    'mode', 'edge', 'span', 'speed', 'hold', 'refDb', 'dual', 'receiver',
+    'duringTx', 'centerType', 'vbwNarrow', 'rbw',
+  ] as const;
 
   it.each(STALE_FIELDS)(
     'degrades a stale scopeControls.%s to unknown while keeping structural availability true',
@@ -208,14 +232,19 @@ describe('scopeControls per-field derivation (MOR-1298/MOR-1299)', () => {
  * HONESTY / FAIL-CLOSED GATE — absent raw values never fabricate the
  * SpectrumToolbar's own `?? 3` / `?? 1` / `?? false` / `?? 0` defaults
  * (`SpectrumToolbar.svelte` lines around its `SPAN_LABELS[scopeControls?.
- * span ?? 3]`-style reads).
+ * span ?? 3]`-style reads), nor the popover's own `?? false` defaults
+ * (`ScopeSettingsPopover.svelte`'s `vbwNarrow ?? false` / `duringTx ??
+ * false` reads; `centerType`/`rbw` use bare `=== val` comparisons with no
+ * default at all, same "row stays unlit" story as `mode`/`edge`).
  */
-describe('scopeControls honesty gate — absent raw values never fabricate (MOR-1298/MOR-1299)', () => {
+describe('scopeControls honesty gate — absent raw values never fabricate (MOR-1298/MOR-1299/MOR-1330)', () => {
   const fullCaps = scopeCaps(['scope', 'dual_rx']);
 
   const NO_TOOLBAR_DEFAULT_CASES = [
     ['mode', 0],
     ['edge', 1],
+    ['centerType', 0],
+    ['rbw', 0],
   ] as const;
 
   const TOOLBAR_DEFAULT_CASES = [
@@ -225,6 +254,8 @@ describe('scopeControls honesty gate — absent raw values never fabricate (MOR-
     ['refDb', 0],
     ['dual', false],
     ['receiver', 0],
+    ['duringTx', false],
+    ['vbwNarrow', false],
   ] as const;
 
   it.each(NO_TOOLBAR_DEFAULT_CASES)(

--- a/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
@@ -924,10 +924,12 @@ function deriveCwKeyerReasons(
 
 /**
  * Scope-control facts (MOR-1262 decomposition slice 11A/MOR-1298, extended
- * by slice 11A′/MOR-1299 with mode/edge/hold/refDb). See
- * `ScopeControlsViewModel`'s doc comment for the field set, the parity
- * story against `SpectrumToolbar.svelte`'s own `scopeControls?.<leaf> ??
- * <default>` reads, and the doubly-applied X6200 capability-gating lesson.
+ * by slice 11A′/MOR-1299 with mode/edge/hold/refDb, and slice 11A″/MOR-1330
+ * with duringTx/centerType/vbwNarrow/rbw). See `ScopeControlsViewModel`'s
+ * doc comment for the field set (including why `fixedEdge` is excluded),
+ * the parity story against `SpectrumToolbar.svelte`'s/
+ * `ScopeSettingsPopover.svelte`'s own `scopeControls?.<leaf> ?? <default>`
+ * reads, and the doubly-applied X6200 capability-gating lesson.
  *
  * Evidence gate (N3): `hasCap(caps, 'scope')`, the same single gate the
  * shipped toolbar uses to render at all (`{#if hasCapability('scope')}`,
@@ -936,13 +938,13 @@ function deriveCwKeyerReasons(
  * scope-adjacent state that reports independently of the `scope` capability
  * the way TX telemetry does.
  *
- * `mode`/`edge`/`span`/`speed`/`hold`/`refDb` are structurally available
- * whenever the group is (every scope-bearing single-RX radio supports them
- * — the backend spec declares all six as read-only ingress leaves with no
- * additional capability distinction); `dual`/`receiver` additionally
- * require `hasCap(caps, 'dual_rx')` — the only generic tag available to
- * gate "does dual-scope / receiver-select make sense here" without a
- * radio-specific table.
+ * `mode`/`edge`/`span`/`speed`/`hold`/`refDb`/`duringTx`/`centerType`/
+ * `vbwNarrow`/`rbw` are structurally available whenever the group is (every
+ * scope-bearing single-RX radio supports them — the backend spec declares
+ * all ten as read-only ingress leaves with no additional capability
+ * distinction); `dual`/`receiver` additionally require `hasCap(caps,
+ * 'dual_rx')` — the only generic tag available to gate "does dual-scope /
+ * receiver-select make sense here" without a radio-specific table.
  */
 function deriveScopeControls(
   state: ServerState | null, caps: Capabilities | null,
@@ -963,6 +965,16 @@ function deriveScopeControls(
     receiver: txAuxField(
       hasReceiverSelect, topFieldAvailable(state, 'scopeControls.receiver'), numOrUndef(sc?.receiver),
     ),
+    duringTx: txAuxField(
+      true, topFieldAvailable(state, 'scopeControls.duringTx'), boolOrUndef(sc?.duringTx),
+    ),
+    centerType: txAuxField(
+      true, topFieldAvailable(state, 'scopeControls.centerType'), numOrUndef(sc?.centerType),
+    ),
+    vbwNarrow: txAuxField(
+      true, topFieldAvailable(state, 'scopeControls.vbwNarrow'), boolOrUndef(sc?.vbwNarrow),
+    ),
+    rbw: txAuxField(true, topFieldAvailable(state, 'scopeControls.rbw'), numOrUndef(sc?.rbw)),
   };
 }
 

--- a/frontend/src/semantic/__tests__/scope-controls.test.ts
+++ b/frontend/src/semantic/__tests__/scope-controls.test.ts
@@ -1,13 +1,15 @@
 /**
  * MOR-1262 decomposition slice 11A (MOR-1298), extended by slice 11A′
- * (MOR-1299) — `scopeControls` optional fact group (validator half).
+ * (MOR-1299) and slice 11A″ (MOR-1330) — `scopeControls` optional fact
+ * group (validator half).
  *
- * Facts: scope mode, fixed-edge preset, span preset index, sweep speed,
- * hold on/off, reference level, dual-scope on/off, scope receiver
- * (MAIN/SUB) — all eight `scopeControls.*` leaves the backend gives
- * field-status entries for. See `radio-view-model.ts`'s
- * `ScopeControlsViewModel` doc comment for the group-shape rationale (why
- * live scope frame data is still deliberately absent), and
+ * Facts: scope mode, fixed-edge preset index, span preset index, sweep
+ * speed, hold on/off, reference level, dual-scope on/off, scope receiver
+ * (MAIN/SUB), plus the four `ScopeSettingsPopover.svelte` scalar leaves —
+ * during-TX, center-type, VBW-narrow, RBW — twelve `scopeControls.*` leaves
+ * total. `fixedEdge` (a composite, not a scalar) is deliberately excluded —
+ * see `radio-view-model.ts`'s `ScopeControlsViewModel` doc comment for the
+ * group-shape rationale and the exclusion's justification, and
  * `radio-view-model-adapter.ts`'s `deriveScopeControls` for the live
  * derivation (covered by the companion `scope-controls-adapter.test.ts`).
  *
@@ -44,7 +46,7 @@ describe('scopeControls (MOR-1262 slice 11A)', () => {
     expect(() => validateRadioViewModel({ ...base, scopeControls: {} })).toThrow(TypeError);
   });
 
-  it('rejects an extra key on the group (closed shape, exactly the eight facts)', () => {
+  it('rejects an extra key on the group (closed shape, exactly the twelve facts)', () => {
     const withSc = withScopeControls(base);
     const extra: ScopeControlsField<number> = { reading: { status: 'known', value: 0 }, availability: AVAIL };
     const malformed = { ...withSc, scopeControls: { ...withSc.scopeControls, bogus: extra } };
@@ -123,6 +125,42 @@ describe('scopeControls (MOR-1262 slice 11A)', () => {
       },
     };
     expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.scopeControls\.receiver\.reading\.value/);
+  });
+
+  it('rejects a non-boolean duringTx reading value with a precise error path', () => {
+    const withSc = withScopeControls(base);
+    const malformed = {
+      ...withSc,
+      scopeControls: { ...withSc.scopeControls, duringTx: { reading: { status: 'known', value: 1 }, availability: AVAIL } },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.scopeControls\.duringTx\.reading\.value/);
+  });
+
+  it('rejects a non-numeric centerType reading value with a precise error path', () => {
+    const withSc = withScopeControls(base);
+    const malformed = {
+      ...withSc,
+      scopeControls: { ...withSc.scopeControls, centerType: { reading: { status: 'known', value: 'Filter' }, availability: AVAIL } },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.scopeControls\.centerType\.reading\.value/);
+  });
+
+  it('rejects a non-boolean vbwNarrow reading value with a precise error path', () => {
+    const withSc = withScopeControls(base);
+    const malformed = {
+      ...withSc,
+      scopeControls: { ...withSc.scopeControls, vbwNarrow: { reading: { status: 'known', value: 0 }, availability: AVAIL } },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.scopeControls\.vbwNarrow\.reading\.value/);
+  });
+
+  it('rejects a non-numeric rbw reading value with a precise error path', () => {
+    const withSc = withScopeControls(base);
+    const malformed = {
+      ...withSc,
+      scopeControls: { ...withSc.scopeControls, rbw: { reading: { status: 'known', value: true }, availability: AVAIL } },
+    };
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.scopeControls\.rbw\.reading\.value/);
   });
 
   it('accepts a structurally-absent field (present group, one control this radio lacks)', () => {

--- a/frontend/src/semantic/fixtures/topologies.ts
+++ b/frontend/src/semantic/fixtures/topologies.ts
@@ -465,8 +465,10 @@ export function withScan(fixture: RadioViewModel): RadioViewModel {
 
 /**
  * Applies a fully-observed `scopeControls` group (MOR-1262 slice 11A/
- * MOR-1298, extended by slice 11A′/MOR-1299) to any topology fixture — same
- * composable-axis story as `withScan`/`withCwKeyer` above.
+ * MOR-1298, extended by slice 11A′/MOR-1299 and slice 11A″/MOR-1330) to any
+ * topology fixture — same composable-axis story as `withScan`/`withCwKeyer`
+ * above. `fixedEdge` is deliberately excluded from the group — see
+ * `ScopeControlsViewModel`'s doc comment.
  */
 export function withScopeControls(fixture: RadioViewModel): RadioViewModel {
   const avail: Availability = { structural: true, operational: true };
@@ -482,6 +484,10 @@ export function withScopeControls(fixture: RadioViewModel): RadioViewModel {
     refDb: known(0),
     dual: known(false),
     receiver: known(0),
+    duringTx: known(false),
+    centerType: known(0),
+    vbwNarrow: known(false),
+    rbw: known(0),
   };
   return { ...fixture, scopeControls };
 }

--- a/frontend/src/semantic/fixtures/topologies.ts
+++ b/frontend/src/semantic/fixtures/topologies.ts
@@ -476,18 +476,18 @@ export function withScopeControls(fixture: RadioViewModel): RadioViewModel {
     { reading: { status: 'known', value }, availability: avail }
   );
   const scopeControls: ScopeControlsViewModel = {
-    mode: known(0),
-    edge: known(1),
+    mode: known(1),
+    edge: known(2),
     span: known(3),
-    speed: known(1),
+    speed: known(4),
     hold: known(false),
-    refDb: known(0),
+    refDb: known(-5),
     dual: known(false),
     receiver: known(0),
     duringTx: known(false),
-    centerType: known(0),
+    centerType: known(5),
     vbwNarrow: known(false),
-    rbw: known(0),
+    rbw: known(6),
   };
   return { ...fixture, scopeControls };
 }

--- a/frontend/src/semantic/radio-view-model.ts
+++ b/frontend/src/semantic/radio-view-model.ts
@@ -735,62 +735,85 @@ export type ScopeControlsField<T> = TxAuxField<T>;
 
 /**
  * Scope-control facts (MOR-1262 decomposition slice 11A/MOR-1298, extended
- * by slice 11A′/MOR-1299): the eight operator-navigated facts off the
- * shipped spectrum toolbar's own `scopeControls` block
- * (`components/spectrum/SpectrumToolbar.svelte`) — SPAN preset index, sweep
- * SPEED, DUAL-scope on/off, which RECEIVER (MAIN=0/SUB=1) feeds the scope
- * (11A), plus scope MODE (CTR/FIX/S-C/S-F), EDGE, HOLD and REF level (11A′).
- * The design doc that named this toolbar
- * (`docs/plans/2026-04-18-spectrum-controls.md`) calls the MAIN/SUB selector
- * the "scope-source selector" and proposes labelling it "SCOPE SRC" — the
- * decomposition ticket's "receiver/source" pair names this ONE wire field
- * (`ScopeControlsPublic.receiver`), not two.
+ * by slice 11A′/MOR-1299 and slice 11A″/MOR-1330): the twelve
+ * operator-navigated facts off the shipped spectrum toolbar's own
+ * `scopeControls` block (`components/spectrum/SpectrumToolbar.svelte`) —
+ * SPAN preset index, sweep SPEED, DUAL-scope on/off, which RECEIVER
+ * (MAIN=0/SUB=1) feeds the scope (11A), scope MODE (CTR/FIX/S-C/S-F), EDGE,
+ * HOLD and REF level (11A′), plus the four `ScopeSettingsPopover.svelte`
+ * leaves — CENTER TYPE, VBW NARROW, RBW and DURING-TX (11A″). The design doc
+ * that named this toolbar (`docs/plans/2026-04-18-spectrum-controls.md`)
+ * calls the MAIN/SUB selector the "scope-source selector" and proposes
+ * labelling it "SCOPE SRC" — the decomposition ticket's "receiver/source"
+ * pair names this ONE wire field (`ScopeControlsPublic.receiver`), not two.
  *
- * FACTS ONLY, and now the COMPLETE set of the eight `scopeControls.*` leaves
- * the backend gives field-status entries for (`runtime_helpers.py`'s
- * `_SCOPE_CONTROL_PUBLIC_FIELDS`) — MODE/EDGE/HOLD/REF were a recorded
- * enumeration gap in 11A (they matched `SpectrumToolbar.svelte`'s own
- * `scopeModeAvailable`/`scopeEdgeAvailable`/`scopeHoldAvailable`/
- * `scopeRefAvailable` booleans but were left out of the first slice; MOR-1299
- * closes the gap, same group, same `scope` gate, same namespace — not a
- * separate "display" family). Live scope FRAMES/WATERFALL DATA remain a
- * wholly different, App-owned resource demand (12A) and are never carried
- * here — this group states facts about the scope's CONTROLS, never its
- * pixels.
+ * FACTS ONLY, and now the COMPLETE set of the twelve `scopeControls.*`
+ * SCALAR leaves the backend gives field-status entries for
+ * (`runtime_helpers.py`'s `_SCOPE_CONTROL_PUBLIC_FIELDS`) — MODE/EDGE/HOLD/
+ * REF were a recorded enumeration gap in 11A (11A′ closed it);
+ * duringTx/centerType/vbwNarrow/rbw were the four scalar leaves
+ * `ScopeSettingsPopover.svelte` reads (`scopeControls?.centerType`/
+ * `?.vbwNarrow`/`?.rbw`/`?.duringTx`) with no registered fact-layer home
+ * until now (11A″ closes that gap too). Same group, same `scope` gate, same
+ * namespace — not a separate "popover" or "display" family. Live scope
+ * FRAMES/WATERFALL DATA remain a wholly different, App-owned resource
+ * demand (12A) and are never carried here — this group states facts about
+ * the scope's CONTROLS, never its pixels.
+ *
+ * EXCLUDED — `fixedEdge`: the backend spec registers a fifth
+ * ScopeSettingsPopover-adjacent leaf, `scopeControls.fixedEdge`
+ * (MOR-1302), but it is deliberately left out of this group. It is a
+ * COMPOSITE — `FixedEdgePublic{rangeIndex, edge, startHz, endHz}`, not a
+ * scalar `int` as the original ticket guessed (MOR-1302's correction) — so
+ * adding it here would need a bespoke nested-object validator, not a
+ * drop-in `ScopeControlsField<number>`/`<boolean>`. And nothing reads it:
+ * `ScopeSettingsPopover.svelte` has no Fixed-Edge control section (verified
+ * by grep — only `centerType`/`vbwNarrow`/`rbw`/`duringTx` are read), nor
+ * does any other v2 component. A composite validator with zero consumers is
+ * exactly the speculative surface "no speculative keys" forbids. If a
+ * future surface reads `fixedEdge`, give it its own ticket.
  *
  * PARITY: values mirror the same `scopeControls.<leaf>` register the toolbar
- * reads (`radio.current?.scopeControls`), and availability reuses the exact
- * same `isFieldAvailable(state, 'scopeControls.<leaf>')` predicate the
- * toolbar calls for its own `scope{Mode,Edge,Span,Speed,Hold,Ref,Dual,
- * Receiver}Available` booleans — not a reimplementation. Where this contract
- * DIVERGES from v2: the toolbar's `scopeControls?.span ?? 3` / `?? 1` /
- * `?? false` / `?? 0` fallbacks (and the analogous `?.mode` / `?.edge`
- * / `?.hold ?? false` / `?.refDb ?? 0` reads) fabricate a value on an
- * unobserved field; here an absent raw reads `unknown`, never those
+ * and popover read (`radio.current?.scopeControls`), and availability
+ * reuses the exact same `isFieldAvailable(state, 'scopeControls.<leaf>')`
+ * predicate the toolbar calls for its own `scope{Mode,Edge,Span,Speed,Hold,
+ * Ref,Dual,Receiver}Available` booleans — not a reimplementation. Where
+ * this contract DIVERGES from v2: the toolbar's `scopeControls?.span ?? 3`
+ * / `?? 1` / `?? false` / `?? 0` fallbacks (and the analogous `?.mode` /
+ * `?.edge` / `?.hold ?? false` / `?.refDb ?? 0` reads) fabricate a value on
+ * an unobserved field; here an absent raw reads `unknown`, never those
  * defaults. When `mode` is absent, the entire row is hidden rather than
  * fabricating CTR. EDGE's applicability is UI-only, gated on the current MODE
  * value (`isEdgeApplicable` in `spectrum-toolbar-logic.ts` shows EDGE only
  * in FIX/S-F modes) — that is a rendering decision, not a fact-availability
  * distinction, so `edge`'s structural gate here mirrors `span`/`speed`/
- * `mode`/`hold`/`refDb`, not a mode-conditional gate.
+ * `mode`/`hold`/`refDb`, not a mode-conditional gate. The popover itself
+ * only fabricates on two of its four leaves — `vbwNarrow ?? false` and
+ * `duringTx ?? false` pick a concrete default, while `centerType`/`rbw` use
+ * bare `=== val` comparisons against `undefined` (no button lights up, but
+ * no specific value is asserted either) — this contract still reports
+ * `unknown` for all four when the raw field is unobserved, same honesty
+ * story either way.
  *
  * STRUCTURAL gate, doubly per the X6200 lesson (scope command support
  * varies per radio — IC-7300/IC-9700 lack the `27 12`/`27 13` receiver-select
  * commands even though `scope` is declared, and dual-scope operation is
  * IC-7610-only in practice per MOR-664): `span`/`speed`/`mode`/`edge`/
- * `hold`/`refDb` are structurally available under `hasCap('scope')` alone
- * (every scope-bearing single-RX radio supports them — the backend spec
- * (`state_pipeline_contracts.py`) declares all six as read-only ingress
- * leaves with no additional capability distinction), while `dual`/`receiver`
- * ADDITIONALLY require `hasCap('dual_rx')` — the only generic capability tag
- * this contract may use, per "no radio-specific tables in the frontend".
- * This is a real strengthening beyond the shipped toolbar, which gates
- * DUAL/MAIN-SUB on field-availability alone; where `dual_rx` still
- * over-declares for a specific radio (e.g. IC-9700, whose VHF/UHF `dual_rx`
- * is unrelated to scope receiver-select), the OPERATIONAL half degrades
- * honestly because the backend never observes that leaf for that radio —
- * same structural/operational split `hardwareScope`/`audioFftScope` already
- * use.
+ * `hold`/`refDb`/`duringTx`/`centerType`/`vbwNarrow`/`rbw` are structurally
+ * available under `hasCap('scope')` alone (every scope-bearing single-RX
+ * radio supports them — the backend spec (`state_pipeline_contracts.py`)
+ * declares all ten as read-only ingress leaves with no additional
+ * capability distinction; the four popover leaves get no `dual_rx`
+ * sub-gate, matching MOR-1302's `family DISPLAY` registration), while
+ * `dual`/`receiver` ADDITIONALLY require `hasCap('dual_rx')` — the only
+ * generic capability tag this contract may use, per "no radio-specific
+ * tables in the frontend". This is a real strengthening beyond the shipped
+ * toolbar, which gates DUAL/MAIN-SUB on field-availability alone; where
+ * `dual_rx` still over-declares for a specific radio (e.g. IC-9700, whose
+ * VHF/UHF `dual_rx` is unrelated to scope receiver-select), the OPERATIONAL
+ * half degrades honestly because the backend never observes that leaf for
+ * that radio — same structural/operational split `hardwareScope`/
+ * `audioFftScope` already use.
  */
 export interface ScopeControlsViewModel {
   /** Scope mode ordinal: 0=CTR, 1=FIX, 2=S-C (scroll-center), 3=S-F
@@ -816,6 +839,21 @@ export interface ScopeControlsViewModel {
   dual: ScopeControlsField<boolean>;
   /** 0=MAIN, 1=SUB. */
   receiver: ScopeControlsField<number>;
+  /** Whether the scope keeps sweeping while transmitting. Popover's
+   *  `duringTx ?? false` read fabricates a default on absence; here an
+   *  absent raw reads `unknown`. */
+  duringTx: ScopeControlsField<boolean>;
+  /** Sweep-center reference ordinal: 0=Filter, 1=Carrier, 2=Abs.Freq
+   *  (`CENTER_TYPE_LABELS` in `ScopeSettingsPopover.svelte` maps the
+   *  ordinal to a display label; that table is UI convenience, not a fact,
+   *  and is deliberately absent here). */
+  centerType: ScopeControlsField<number>;
+  /** Video-bandwidth-narrow toggle. Popover's `vbwNarrow ?? false` read
+   *  fabricates a default on absence; here an absent raw reads `unknown`. */
+  vbwNarrow: ScopeControlsField<boolean>;
+  /** Resolution-bandwidth ordinal: 0=Wide, 1=Mid, 2=Narrow (`RBW_LABELS` in
+   *  `ScopeSettingsPopover.svelte` maps the ordinal to a display label). */
+  rbw: ScopeControlsField<number>;
 }
 
 /**
@@ -1449,12 +1487,18 @@ function validateCwKeyer(value: unknown, path: string): CwKeyerViewModel {
   };
 }
 
-/** Exactly the eight facts the adapter reads (11A's four plus 11A′'s
- *  mode/edge/hold/refDb). See
- *  `radio-view-model-adapter.ts::deriveScopeControls`. */
+/** Exactly the twelve facts the adapter reads (11A's four, plus 11A′'s
+ *  mode/edge/hold/refDb, plus 11A″'s duringTx/centerType/vbwNarrow/rbw).
+ *  `fixedEdge` is deliberately excluded — see `ScopeControlsViewModel`'s
+ *  doc comment. See `radio-view-model-adapter.ts::deriveScopeControls`. */
 function validateScopeControls(value: unknown, path: string): ScopeControlsViewModel {
   const v = record(value, path);
-  exactKeys(v, ['mode', 'edge', 'span', 'speed', 'hold', 'refDb', 'dual', 'receiver'], path);
+  exactKeys(
+    v,
+    ['mode', 'edge', 'span', 'speed', 'hold', 'refDb', 'dual', 'receiver',
+      'duringTx', 'centerType', 'vbwNarrow', 'rbw'],
+    path,
+  );
   return {
     mode: validateTxAuxField(v.mode, `${path}.mode`, num),
     edge: validateTxAuxField(v.edge, `${path}.edge`, num),
@@ -1464,6 +1508,10 @@ function validateScopeControls(value: unknown, path: string): ScopeControlsViewM
     refDb: validateTxAuxField(v.refDb, `${path}.refDb`, num),
     dual: validateTxAuxField(v.dual, `${path}.dual`, bool),
     receiver: validateTxAuxField(v.receiver, `${path}.receiver`, num),
+    duringTx: validateTxAuxField(v.duringTx, `${path}.duringTx`, bool),
+    centerType: validateTxAuxField(v.centerType, `${path}.centerType`, num),
+    vbwNarrow: validateTxAuxField(v.vbwNarrow, `${path}.vbwNarrow`, bool),
+    rbw: validateTxAuxField(v.rbw, `${path}.rbw`, num),
   };
 }
 


### PR DESCRIPTION
## Summary

11A": duringTx (bool), centerType (number), vbwNarrow (bool), rbw (number) added to the scopeControls fact group per the exact 11A' pattern (MOR-1299). exactKeys 8->12; absent-raw honesty; staleness tables pin the production-realistic shape (backend ships dataclass defaults, honesty rests on field-status). fixedEdge excluded by design (composite FixedEdgePublic per MOR-1302, zero consumers) - deferral ledger MOR-1354.

Production LOC 23 (verifier-measured, frozen formula).

## Review provenance

Verified by the vocabulary-domain opus anchor (session 8): pattern parity vs 11A' exact item-by-item; enumeration-gap check clean (12 scalars + fixedEdge = the full _SCOPE_CONTROL_PUBLIC_FIELDS set; tree-wide consumer sweep 100% mapped); MOR-1352 chain ruled closed for all four keys (producer 0x1B/0x1C/0x1D/0x1F -> FieldPath -> field-status -> adapter path verified end-to-end). Initial BLOCK (fixture value collisions let 5 raw-key-swap mutants survive) fixed and delta-confirmed: all 5 mutants re-killed by the anchor's own hands, full suite 5206/5206 with fresh localstorage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)