### PR TITLE
feat(MOR-1304): modeFilter/filterPassband surface (4B) - canon-compliant zoned mount

### DIFF
--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -31,6 +31,7 @@
     compositionSurfaces, useSurfacePlan, zoneShowsSurface,
   } from '../../presentation/workspace/resolution';
   import { LAN_MOD_INPUT_SOURCE } from '$lib/radio/mod-input';
+  import FilterSurface from '../../semantic/FilterSurface.svelte';
   import MetersSurface from '../../semantic/MetersSurface.svelte';
   import type { RadioViewModel } from '../../semantic/radio-view-model';
   import RxAudioSurface from '../../semantic/RxAudioSurface.svelte';
@@ -42,7 +43,7 @@
   import VfoSurface, { type VfoSelection } from '../../semantic/VfoSurface.svelte';
   import ModInputTxWarning from '../panels/ModInputTxWarning.svelte';
   import {
-    makeAudioRoutingHandlers, makeModeHandlers, makeRxAudioHandlers,
+    makeAudioRoutingHandlers, makeFilterHandlers, makeModeHandlers, makeRxAudioHandlers,
     makeTxHandlers, makeVfoHandlers, makeVoxHandlers,
   } from './command-bus';
   import {
@@ -167,6 +168,14 @@
   const rxAudioIntents = makeRxAudioHandlers();
   const routingIntents = makeAudioRoutingHandlers();
   const setModInputLan = () => makeModeHandlers().onModInputChange(LAN_MOD_INPUT_SOURCE);
+  /**
+   * MOR-1304. `makeModeHandlers` owns mode/dataMode intents, `makeFilterHandlers`
+   * the rest — the SAME v2 command vocabulary `FilterPanel` already dispatches
+   * through, composed once here rather than forked for the semantic surface.
+   * Unlike `txAuxIntents` above, `FilterSurface`'s props already match these
+   * names 1:1, so no per-field `Record` indirection is needed.
+   */
+  const filterIntents = { ...makeModeHandlers(), ...makeFilterHandlers() };
   const tx = getAppTxController();
   const sourceId = `semantic-rx-tx-${++surfaceSeq}`;
   let leaseSeq = 0;
@@ -551,6 +560,40 @@
     {/if}
   {/snippet}
 
+  <!--
+    MOR-1304 (vocabulary slice 4B). Same structural gate as `metersSurface`
+    above: the surface mounts only when the view model carries EITHER of the
+    two fact groups it renders (`view.modeFilter` from MOR-1280, `view.
+    filterPassband` from MOR-1284) — a radio the evidence gate declined on
+    both renders the pre-1304 element shape exactly.
+
+    UNLIKE `txAuxSurface`/`metersSurface` (and like `rxAudioSurface` above) it
+    is rendered in the SINGLE composition ONLY (fix round, verify-MOR-1304 F1).
+    `FilterSurface` renders up to 14 focusable controls (mode/filter/shape
+    buttons, width and passband-level sliders) and no manifest declares a
+    `filter` zone, so mounting it bare in the dual cockpit would put every one
+    of those controls outside every declared zone and after the `rx-tx` zone
+    that MOR-1069 requires to end the tab order — exactly the shape the
+    MOR-1279/MOR-1336 zone-mount ruling forbids for any control-bearing
+    surface. `'filter'` became DECLARABLE with this slice, so the cockpit
+    gains the surface the moment a rework slice's manifest declares a zone for
+    it — a layout decision, separately reviewed, exactly as rxAudio left it.
+  -->
+  {#snippet filterSurface()}
+    {#if view?.modeFilter || view?.filterPassband}
+      <FilterSurface
+        {view}
+        onModeChange={filterIntents.onModeChange}
+        onFilterChange={filterIntents.onFilterChange}
+        onFilterWidthChange={filterIntents.onFilterWidthChange}
+        onFilterShapeChange={filterIntents.onFilterShapeChange}
+        onIfShiftChange={filterIntents.onIfShiftChange}
+        onPbtInnerChange={filterIntents.onPbtInnerChange}
+        onPbtOuterChange={filterIntents.onPbtOuterChange}
+      />
+    {/if}
+  {/snippet}
+
   {#if strips === 'dual'}
     <!--
       MOR-1258: the zone now carries RxTxSurface AND the two TX-adjacent
@@ -594,6 +637,7 @@
     {@render zoned('txAux', view?.txAux !== undefined, txAuxSurface)}
     {@render zoned('meters', view?.meters !== undefined, metersSurface)}
     {@render zoned('rxAudio', view?.rxAudio !== undefined, rxAudioSurface)}
+    {@render zoned('filter', view?.modeFilter !== undefined || view?.filterPassband !== undefined, filterSurface)}
     {@render txAdjacentAlerts()}
   {/if}
 </div>

--- a/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
@@ -81,7 +81,16 @@ vi.mock('../command-bus', () => ({
   // MOR-1279 slice 3B: the RX-audio intent vocabulary.
   makeRxAudioHandlers: () => ({ onMonitorModeChange: h.noop, onAfLevelChange: h.noop }),
   makeAudioRoutingHandlers: () => ({ onFocusChange: h.noop, onSplitStereoChange: h.noop }),
-  makeModeHandlers: () => ({ onModInputChange: h.noop }),
+  // MOR-1304 — the wiring now also composes the modeFilter/filterPassband
+  // intent vocabulary; `makeModeHandlers` is composed at both call sites
+  // (rxAudio's MOD-input remedy and filterIntents), so the stub carries both.
+  makeModeHandlers: () => ({
+    onModInputChange: h.noop, onModeChange: h.noop, onDataModeChange: h.noop,
+  }),
+  makeFilterHandlers: () => ({
+    onFilterChange: h.noop, onFilterWidthChange: h.noop, onFilterShapeChange: h.noop,
+    onIfShiftChange: h.noop, onPbtInnerChange: h.noop, onPbtOuterChange: h.noop,
+  }),
 }));
 
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';

--- a/frontend/src/components-v2/wiring/__tests__/semantic-rx-tx-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rx-tx-wiring.component.test.ts
@@ -105,7 +105,16 @@ vi.mock('../command-bus', () => ({
   // MOR-1279 slice 3B: the RX-audio intent vocabulary.
   makeRxAudioHandlers: () => ({ onMonitorModeChange: h.txAuxNoop, onAfLevelChange: h.txAuxNoop }),
   makeAudioRoutingHandlers: () => ({ onFocusChange: h.txAuxNoop, onSplitStereoChange: h.txAuxNoop }),
-  makeModeHandlers: () => ({ onModInputChange: h.txAuxNoop }),
+  // MOR-1304 — the wiring now also composes the modeFilter/filterPassband
+  // intent vocabulary; `makeModeHandlers` is composed at both call sites
+  // (rxAudio's MOD-input remedy and filterIntents), so the stub carries both.
+  makeModeHandlers: () => ({
+    onModInputChange: h.txAuxNoop, onModeChange: h.txAuxNoop, onDataModeChange: h.txAuxNoop,
+  }),
+  makeFilterHandlers: () => ({
+    onFilterChange: h.txAuxNoop, onFilterWidthChange: h.txAuxNoop, onFilterShapeChange: h.txAuxNoop,
+    onIfShiftChange: h.txAuxNoop, onPbtInnerChange: h.txAuxNoop, onPbtOuterChange: h.txAuxNoop,
+  }),
 }));
 
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';

--- a/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
@@ -640,6 +640,59 @@ describe('MOR-1336 — a declared zone renders nothing for a radio without the g
   });
 });
 
+/**
+ * MOR-1304 fix round (verify-MOR-1304 F1) — the zone-mount ruling applied to
+ * `filter`, the MOR-1279 rxAudio shape.
+ *
+ * `FilterSurface` renders up to 14 focusable controls (mode/filter/shape
+ * choice buttons, the width slider, three passband-level sliders) and no
+ * shipped manifest declares a `filter` zone (`filter-declarability.test.ts`).
+ * The cockpit's MOR-1069 invariant requires every focusable control to sit
+ * inside a zone the active layout's manifest actually declares, with `rx-tx`
+ * last in the tab order — a control-bearing surface mounted bare in the DUAL
+ * composition breaks both clauses the moment the fixture's caps carry real
+ * modes/filters (every real radio does). `caps.modes`/`caps.filters` are
+ * empty in this file's own `liveCaps`, which is why this describe supplies
+ * its OWN caps override — a fixture that cannot see the group is not
+ * evidence the surface behaves, it is the bug this pin exists to catch (the
+ * verify report's Probe P1/P2, reproduced here rather than trusted from afar).
+ */
+describe('MOR-1304 fix round — filter never mounts bare in the dual composition', () => {
+  const withFilterCaps = (caps: Capabilities): Capabilities => ({
+    ...caps, modes: ['USB', 'CW', 'FM'], filters: [1, 2, 3],
+  } as unknown as Capabilities);
+
+  it('renders NO filter surface in the dual composition, zoned or unzoned', () => {
+    h.state = liveState(false);
+    h.caps = withFilterCaps(liveCaps(false));
+    render({ strips: 'dual' });
+
+    expect(q('[data-testid="filter-surface"]')).toBeNull();
+    expect(target.innerHTML).not.toContain('filter-surface');
+  });
+
+  it('leaves the cockpit with no focusable control outside a declared zone', () => {
+    h.state = liveState(false);
+    h.caps = withFilterCaps(liveCaps(false));
+    render({ strips: 'dual' });
+
+    const outside = [...target.querySelectorAll<HTMLElement>('button, input, select, [tabindex]')]
+      .filter((node) => node.closest('[data-zone-id]') === null);
+    expect(outside).toEqual([]);
+  });
+
+  // Control: the SAME caps, in the single composition, DO mount the surface —
+  // proves the dual absence above is the zone-mount gate, not the fixture
+  // simply being unable to produce a `modeFilter` group at all.
+  it('mounts the filter surface in the single composition with the same caps', () => {
+    h.state = liveState(false);
+    h.caps = withFilterCaps(liveCaps(false));
+    render({ strips: 'single' });
+
+    expect(q('[data-testid="filter-surface"]')).not.toBeNull();
+  });
+});
+
 // ── MOR-1341 (S5) — desktop-v2's OWN real `meters` zone actually binds ──────
 //
 // The generic-mechanism describe above proves the MECHANISM against a

--- a/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
@@ -93,7 +93,16 @@ vi.mock('../command-bus', () => ({
   // MOR-1279 slice 3B: the RX-audio intent vocabulary.
   makeRxAudioHandlers: () => ({ onMonitorModeChange: h.noop, onAfLevelChange: h.noop }),
   makeAudioRoutingHandlers: () => ({ onFocusChange: h.noop, onSplitStereoChange: h.noop }),
-  makeModeHandlers: () => ({ onModInputChange: h.noop }),
+  // MOR-1304 — the wiring now also composes the modeFilter/filterPassband
+  // intent vocabulary; `makeModeHandlers` is composed at both call sites
+  // (rxAudio's MOD-input remedy and filterIntents), so the stub carries both.
+  makeModeHandlers: () => ({
+    onModInputChange: h.noop, onModeChange: h.noop, onDataModeChange: h.noop,
+  }),
+  makeFilterHandlers: () => ({
+    onFilterChange: h.noop, onFilterWidthChange: h.noop, onFilterShapeChange: h.noop,
+    onIfShiftChange: h.noop, onPbtInnerChange: h.noop, onPbtOuterChange: h.noop,
+  }),
 }));
 
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';

--- a/frontend/src/presentation/layouts/__tests__/filter-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/filter-declarability.test.ts
@@ -1,16 +1,14 @@
 /**
- * MOR-1279 — `rxAudio` is DECLARABLE, and nothing declares it yet.
+ * MOR-1304 — `filter` is DECLARABLE, and nothing declares it yet.
  *
- * Slice 3B adds the name to `SEMANTIC_SURFACE_NAMES` so a manifest CAN mount
- * the surface later; it deliberately does not touch any manifest, and it adds
- * no design-language renderer slot (that set was frozen by MOR-1072 — adding
- * one would be a language-contract change this slice must not make).
- *
- * Same three pins as `tx-aux-declarability.test.ts` / `meters-declarability.test.ts`:
+ * Slice 4B adds the name to `SEMANTIC_SURFACE_NAMES` so a manifest CAN mount
+ * the surface later; it deliberately does not touch any manifest, and it does
+ * not add a renderer slot. The three pins mirror `meters-declarability.test.ts`
+ * / `tx-aux-declarability.test.ts` / `rx-audio-declarability.test.ts`:
  *   - drop the name and a future manifest's zone stops validating;
- *   - quietly add an `rxAudio` zone to a shipped manifest and the DOM grows a
+ *   - quietly add a `filter` zone to a shipped manifest and the DOM grows a
  *     zone id no layout review ever saw;
- *   - the renderer slot set stays exactly what MOR-1072 froze.
+ *   - the renderer slot stays exactly the set MOR-1072 froze.
  */
 import { describe, it, expect } from 'vitest';
 import { SEMANTIC_SURFACE_NAMES, validateLayoutManifest } from '../contract';
@@ -21,9 +19,9 @@ import {
   sdrTestLayout,
 } from '../declarations';
 
-describe('rxAudio is a declarable semantic surface', () => {
+describe('filter is a declarable semantic surface', () => {
   // Kills: reverting the SEMANTIC_SURFACE_NAMES addition.
-  it('is in the declarable set alongside vfo, rxTx, txAux and meters', () => {
+  it('is in the declarable set alongside vfo, rxTx, txAux, meters and rxAudio', () => {
     expect([...SEMANTIC_SURFACE_NAMES]).toEqual(['vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter']);
   });
 
@@ -31,7 +29,7 @@ describe('rxAudio is a declarable semantic surface', () => {
   // zone validator checks — the manifest would still be rejected.
   it('accepts a manifest zone that declares it', () => {
     const manifest = validLayoutManifest({
-      zones: [{ id: 'main', surfaces: ['vfo', 'rxTx', 'rxAudio'] }],
+      zones: [{ id: 'main', surfaces: ['vfo', 'rxTx', 'filter'] }],
       requiredSemanticSurfaces: ['vfo', 'rxTx'],
     });
     expect(() => validateLayoutManifest(manifest)).not.toThrow();
@@ -39,29 +37,29 @@ describe('rxAudio is a declarable semantic surface', () => {
 
   it('still rejects a zone naming a surface that does not exist', () => {
     const manifest = validLayoutManifest({
-      zones: [{ id: 'main', surfaces: ['audioPanel'] as unknown as readonly ['vfo'] }],
+      zones: [{ id: 'main', surfaces: ['filterPanel'] as unknown as readonly ['vfo'] }],
     });
     expect(() => validateLayoutManifest(manifest)).toThrow(/subset of/);
   });
 });
 
-describe('no shipped manifest declares an rxAudio zone in this slice', () => {
-  // Kills: slipping an rxAudio zone into an existing layout here. Declarability
+describe('no shipped manifest declares a filter zone in this slice', () => {
+  // Kills: slipping a filter zone into an existing layout here. Declarability
   // is the whole scope of the contract touch; placing the surface in a real
   // layout is a later, separately reviewed slice.
   it.each([
     ['sdr-test', sdrTestLayout], ['dual-receiver-cockpit', dualReceiverCockpitLayout],
     ['lcd-cockpit', lcdCockpitLayout], ['lcd-scope', lcdScopeLayout],
     ['mobile', mobileLayout], ['desktop-v2', desktopV2Layout],
-  ])('%s declares no rxAudio zone and does not require the surface', (_id, manifest) => {
-    for (const zone of manifest.zones) expect(zone.surfaces).not.toContain('rxAudio');
-    expect(manifest.requiredSemanticSurfaces).not.toContain('rxAudio');
+  ])('%s declares no filter zone and does not require the surface', (_id, manifest) => {
+    for (const zone of manifest.zones) expect(zone.surfaces).not.toContain('filter');
+    expect(manifest.requiredSemanticSurfaces).not.toContain('filter');
   });
 });
 
-describe('the design-language renderer slot set is untouched', () => {
-  // Kills: adding a renderer slot for this surface. RX audio has no gauge
-  // grammar a language must describe; the slot set stays frozen.
+describe('the design-language renderer slot set is untouched (risk R2)', () => {
+  // Kills: adding a renderer slot for this surface — a design language draws
+  // filter facts through existing panel machinery, not a new renderer slot.
   it('still carries exactly the three MOR-1072 slots', () => {
     expect([...RENDERER_SLOT_NAMES]).toEqual(['meters', 'frequencyDisplay', 'stateFeedback']);
   });

--- a/frontend/src/presentation/layouts/__tests__/meters-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/meters-declarability.test.ts
@@ -26,7 +26,7 @@ import {
 describe('meters is a declarable semantic surface', () => {
   // Kills: reverting the SEMANTIC_SURFACE_NAMES addition.
   it('is in the declarable set alongside vfo, rxTx and txAux', () => {
-    expect([...SEMANTIC_SURFACE_NAMES]).toEqual(['vfo', 'rxTx', 'txAux', 'meters', 'rxAudio']);
+    expect([...SEMANTIC_SURFACE_NAMES]).toEqual(['vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter']);
   });
 
   // Kills: adding the name to the type but not to the runtime allow-list the

--- a/frontend/src/presentation/layouts/__tests__/tx-aux-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/tx-aux-declarability.test.ts
@@ -25,9 +25,10 @@ import {
 
 describe('txAux is a declarable semantic surface', () => {
   // Kills: reverting the SEMANTIC_SURFACE_NAMES addition. MOR-1273 appended
-  // `meters`; `txAux` must stay present and in place.
+  // `meters`, MOR-1304 appended `filter`; `txAux` must stay present and in
+  // place.
   it('is in the declarable set alongside vfo and rxTx', () => {
-    expect([...SEMANTIC_SURFACE_NAMES]).toEqual(['vfo', 'rxTx', 'txAux', 'meters', 'rxAudio']);
+    expect([...SEMANTIC_SURFACE_NAMES]).toEqual(['vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter']);
   });
 
   // Kills: adding the name to the type but not to the runtime allow-list the

--- a/frontend/src/presentation/layouts/contract.ts
+++ b/frontend/src/presentation/layouts/contract.ts
@@ -13,13 +13,15 @@ import type { Component } from 'svelte';
 import { isValidLanguageId as isValidProductId } from '../languages/contract';
 
 /** Semantic surfaces a layout may mount (MOR-1062/1065 reference vertical;
- *  `txAux` added by MOR-1265, `meters` by MOR-1273). Adding a name makes it
- *  DECLARABLE — it does not mount anything, and no manifest declares a
- *  `txAux` or `meters` zone yet. Distinct from the design-language renderer
- *  slot of the same name (`languages/contract.ts`'s `RENDERER_SLOT_NAMES`):
- *  that one says how a language DRAWS a meter, this one says which layout
- *  zone may HOST the surface. */
-export const SEMANTIC_SURFACE_NAMES = ['vfo', 'rxTx', 'txAux', 'meters', 'rxAudio'] as const;
+ *  `txAux` added by MOR-1265, `meters` by MOR-1273, `rxAudio` by MOR-1279,
+ *  `filter` by MOR-1304). Adding a name makes it DECLARABLE — it does not
+ *  mount anything by itself, and no manifest declares a `meters`, `rxAudio`
+ *  or `filter` zone yet (the cockpit declares only `txAux`, as `tx-aux` —
+ *  MOR-1336). Distinct from the design-language renderer slot of the same
+ *  name (`languages/contract.ts`'s `RENDERER_SLOT_NAMES`): that one says how
+ *  a language DRAWS a meter, this one says which layout zone may HOST the
+ *  surface. */
+export const SEMANTIC_SURFACE_NAMES = ['vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter'] as const;
 export type SemanticSurfaceName = (typeof SEMANTIC_SURFACE_NAMES)[number];
 
 /**

--- a/frontend/src/semantic/FilterSurface.svelte
+++ b/frontend/src/semantic/FilterSurface.svelte
@@ -1,0 +1,204 @@
+<!--
+  Semantic mode/filter surface (MOR-1304, vocabulary slice 4B).
+
+  Presentation only. Renders BOTH the MOR-1280 `modeFilter` group (mode,
+  filter selection, filter width) and the MOR-1284 `filterPassband` group
+  (filter shape, IF-shift, PBT inner/outer, DATA submode) — the same two
+  groups the v2 `FilterPanel` reads together (`panel-props.ts`'s
+  `deriveFilterProps`). A surface consuming only one half would be half-built.
+
+  Doctrine, same as `TxAuxSurface`/`MetersSurface`:
+  (1) Facts only — every value and every min/max bound is READ from the
+      adapter-produced view model, never re-derived. `resolveFilterModeConfig`
+      and `pbtRawToHz` stay behind the adapter (MOR-1284/1280 rulings); this
+      file imports neither.
+  (2) Two-level availability per field (MOR-977): `structural: false` renders
+      nothing; a present-but-unobserved field renders disabled, with reason
+      `field-not-observed`, never a guessed value or a fabricated selection
+      (a control never claims a choice is active unless its OWN reading says
+      so — an unknown `filterShape` on a radio that HAS filters shows neither
+      button pressed, matching v2's fail-open default nowhere).
+  (3) `filterWidthMin`/`filterWidthMax` are read through their OWN field —
+      each one carries its OWN operational flag (the adapter gates them on
+      `modeObserved`, `filterWidth` on its own `widthObserved`); this file
+      never substitutes one field's gate for another's.
+-->
+<script module lang="ts">
+  import type { TxAuxField } from './radio-view-model';
+
+  /** Fixed filter-shape choice set (SHARP/SOFT) — same two options
+   *  `FilterPanel`'s shape buttons offer, `[value, label]`. */
+  export const FILTER_SHAPES = [[0, 'SHARP'], [1, 'SOFT']] as const;
+  /** `[field, label, min, max, step]` in RAW Hz, same ranges `FilterPanel`'s
+   *  IF-shift/PBT sliders have always used. */
+  export const FILTER_PASSBAND_LEVELS = [
+    ['ifShift', 'IF shift', -1200, 1200, 25],
+    ['pbtInner', 'PBT inner', -1200, 1200, 25],
+    ['pbtOuter', 'PBT outer', -1200, 1200, 25],
+  ] as const;
+  export type FilterPassbandLevelField = (typeof FILTER_PASSBAND_LEVELS)[number][0];
+
+  /** Usable ⇔ the radio HAS it, it is readable NOW, and it has been observed.
+   *  `ModeFilterField`/`FilterPassbandField` are both declared as aliases of
+   *  `TxAuxField` (same field shape per fact family), so one set of helpers
+   *  serves every field in both groups — no per-group re-derivation. */
+  const usable = (f: TxAuxField<unknown>): boolean =>
+    f.availability.structural && f.availability.operational && f.reading.status === 'known';
+  const reasonOf = (f: TxAuxField<unknown>): 'field-not-observed' | undefined =>
+    usable(f) ? undefined : 'field-not-observed';
+  const textOf = (f: TxAuxField<unknown>): string =>
+    f.reading.status === 'known' ? String(f.reading.value) : '?';
+  const numberOf = (f: TxAuxField<number>, fallback: number): number =>
+    f.reading.status === 'known' ? f.reading.value : fallback;
+  /** Never fabricates a selection: `usable` alone cannot narrow `reading` for
+   *  the `===` comparison below, so the known-check is repeated explicitly. */
+  const isSelected = (f: TxAuxField<unknown>, value: unknown): boolean =>
+    usable(f) && f.reading.status === 'known' && f.reading.value === value;
+</script>
+
+<script lang="ts">
+  import type { RadioViewModel } from './radio-view-model';
+
+  interface Props {
+    view: RadioViewModel;
+    onModeChange?: (mode: string) => void;
+    onFilterChange?: (filter: number) => void;
+    onFilterWidthChange?: (width: number) => void;
+    onFilterShapeChange?: (shape: number) => void;
+    onIfShiftChange?: (value: number) => void;
+    onPbtInnerChange?: (value: number) => void;
+    onPbtOuterChange?: (value: number) => void;
+  }
+  let {
+    view, onModeChange, onFilterChange, onFilterWidthChange,
+    onFilterShapeChange, onIfShiftChange, onPbtInnerChange, onPbtOuterChange,
+  }: Props = $props();
+
+  let modeFilter = $derived(view.modeFilter);
+  let filterPassband = $derived(view.filterPassband);
+
+  function selectMode(mode: string): void {
+    if (modeFilter && usable(modeFilter.currentMode)) onModeChange?.(mode);
+  }
+  function selectFilter(filter: number): void {
+    if (modeFilter && usable(modeFilter.currentFilter)) onFilterChange?.(filter);
+  }
+  function changeWidth(value: number): void {
+    if (modeFilter && usable(modeFilter.filterWidth)) onFilterWidthChange?.(value);
+  }
+  function selectShape(shape: number): void {
+    if (filterPassband && usable(filterPassband.filterShape)) onFilterShapeChange?.(shape);
+  }
+  /** One guarded entry point for all three passband sliders — each still
+   *  reads and disables on its OWN field's availability (see the file
+   *  header, rule 3), this only routes the already-checked value onward. */
+  function changePassband(field: FilterPassbandLevelField, value: number): void {
+    if (!filterPassband || !usable(filterPassband[field])) return;
+    if (field === 'ifShift') onIfShiftChange?.(value);
+    else if (field === 'pbtInner') onPbtInnerChange?.(value);
+    else onPbtOuterChange?.(value);
+  }
+</script>
+
+{#if modeFilter || filterPassband}
+  <section class="filter-surface" data-testid="filter-surface" aria-label="Mode and filter controls">
+    {#if modeFilter}
+      {#if modeFilter.currentMode.availability.structural}
+        <div
+          class="filter-choice-group" data-testid="filter-mode"
+          data-disabled-reason={reasonOf(modeFilter.currentMode)}
+        >
+          {#each modeFilter.modeChoices as choice (choice)}
+            <button
+              type="button" class="filter-choice" data-testid={`filter-mode-${choice}`}
+              aria-pressed={isSelected(modeFilter.currentMode, choice)}
+              disabled={!usable(modeFilter.currentMode)}
+              onclick={() => selectMode(choice)}
+            >{choice}</button>
+          {/each}
+        </div>
+      {/if}
+      {#if modeFilter.currentFilter.availability.structural}
+        <div
+          class="filter-choice-group" data-testid="filter-select"
+          data-disabled-reason={reasonOf(modeFilter.currentFilter)}
+        >
+          {#each modeFilter.filterChoices as choice, index (choice)}
+            <button
+              type="button" class="filter-choice" data-testid={`filter-select-${index + 1}`}
+              aria-pressed={isSelected(modeFilter.currentFilter, index + 1)}
+              disabled={!usable(modeFilter.currentFilter)}
+              onclick={() => selectFilter(index + 1)}
+            >{choice}</button>
+          {/each}
+        </div>
+      {/if}
+      {#if modeFilter.filterWidth.availability.structural}
+        <label class="filter-level" data-testid="filter-width" data-disabled-reason={reasonOf(modeFilter.filterWidth)}>
+          <span class="filter-level-name">Width</span>
+          <input
+            type="range"
+            min={numberOf(modeFilter.filterWidthMin, 50)} max={numberOf(modeFilter.filterWidthMax, 9999)} step={50}
+            value={numberOf(modeFilter.filterWidth, 0)}
+            disabled={!usable(modeFilter.filterWidth)}
+            oninput={(event) => changeWidth(event.currentTarget.valueAsNumber)}
+          />
+          <output>{textOf(modeFilter.filterWidth)}</output>
+        </label>
+      {/if}
+    {/if}
+
+    {#if filterPassband}
+      {#if filterPassband.filterShape.availability.structural}
+        <div
+          class="filter-choice-group" data-testid="filter-shape"
+          data-disabled-reason={reasonOf(filterPassband.filterShape)}
+        >
+          {#each FILTER_SHAPES as [value, label] (value)}
+            <button
+              type="button" class="filter-choice" data-testid={`filter-shape-${value}`}
+              aria-pressed={isSelected(filterPassband.filterShape, value)}
+              disabled={!usable(filterPassband.filterShape)}
+              onclick={() => selectShape(value)}
+            >{label}</button>
+          {/each}
+        </div>
+      {/if}
+      {#each FILTER_PASSBAND_LEVELS as [field, label, min, max, step] (field)}
+        {#if filterPassband[field].availability.structural}
+          <label
+            class="filter-level" data-testid={`filter-${field}`}
+            data-disabled-reason={reasonOf(filterPassband[field])}
+          >
+            <span class="filter-level-name">{label}</span>
+            <input
+              type="range" {min} {max} {step}
+              value={numberOf(filterPassband[field], min)}
+              disabled={!usable(filterPassband[field])}
+              oninput={(event) => changePassband(field, event.currentTarget.valueAsNumber)}
+            />
+            <output>{textOf(filterPassband[field])}</output>
+          </label>
+        {/if}
+      {/each}
+      {#if filterPassband.dataMode.availability.structural}
+        <div
+          class="filter-readout" data-testid="filter-data-mode"
+          data-disabled-reason={reasonOf(filterPassband.dataMode)}
+        >
+          <span class="filter-level-name">DATA</span><output>{textOf(filterPassband.dataMode)}</output>
+        </div>
+      {/if}
+    {/if}
+  </section>
+{/if}
+
+<style>
+  /* Structure only — a design language owns colour (MOR-977, forced-colors). */
+  .filter-surface { display: flex; flex-direction: column; gap: 0.25rem; }
+  .filter-choice-group { display: flex; flex-wrap: wrap; gap: 0.5rem; }
+  .filter-level, .filter-readout { display: flex; align-items: baseline; gap: 0.5rem; }
+  .filter-level-name { min-width: 8ch; }
+  .filter-choice[aria-pressed='true'] { font-weight: 700; }
+  .filter-choice:disabled { cursor: not-allowed; }
+</style>

--- a/frontend/src/semantic/__tests__/FilterSurface.test.ts
+++ b/frontend/src/semantic/__tests__/FilterSurface.test.ts
@@ -240,16 +240,57 @@ describe('choice fields emit the caller intent only when usable', () => {
     });
   });
 
-  // MUTATION KILLED: emitting a choice intent from an unobserved reading —
-  // clicking would arm a guess rather than a confirmed selection.
-  it('emits nothing when a choice is clicked on an unobserved reading', () => {
+  /**
+   * MOR-1304 fix round (verify-MOR-1304 F3) — `HTMLElement.click()` is a
+   * no-op on a `disabled` button in jsdom (and in every real browser): the
+   * click-activation steps never run, so the handler's OWN guard
+   * (`usable(...)` in `selectMode`/`selectFilter`/`selectShape`) is never
+   * actually exercised — `disabled` alone would satisfy an assertion that
+   * `onXChange` was never called, even with the guard deleted. Dispatching
+   * the `MouseEvent` directly bypasses that suppression and reaches the
+   * `onclick` handler regardless of `disabled`, so these tests can tell
+   * "the button is disabled" apart from "the guard inside the handler holds"
+   * — MF3/MF12/MF13 in the verify report, each SURVIVED under `.click()`.
+   */
+  function forceClick(button: HTMLButtonElement): void {
+    button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  }
+
+  // MUTATION KILLED (MF3): `selectMode`'s `usable(modeFilter.currentMode)`
+  // guard dropped — clicking would arm a guess rather than a confirmed
+  // selection.
+  it('emits nothing when the mode is clicked on an unobserved reading', () => {
     const onModeChange = vi.fn();
     const view = withModeFilterField(base(), 'currentMode', { unknown: true });
     withSurface(view, (s) => {
-      s.button('filter-mode', 'LSB')!.click();
+      forceClick(s.button('filter-mode', 'LSB')!);
       flushSync();
       expect(onModeChange).not.toHaveBeenCalled();
     }, { onModeChange });
+  });
+
+  // MUTATION KILLED (MF12): `selectFilter`'s `usable(modeFilter.currentFilter)`
+  // guard dropped.
+  it('emits nothing when a filter is clicked on an unobserved reading', () => {
+    const onFilterChange = vi.fn();
+    const view = withModeFilterField(base(), 'currentFilter', { unknown: true });
+    withSurface(view, (s) => {
+      forceClick(s.button('filter-select', 2)!);
+      flushSync();
+      expect(onFilterChange).not.toHaveBeenCalled();
+    }, { onFilterChange });
+  });
+
+  // MUTATION KILLED (MF13): `selectShape`'s `usable(filterPassband.filterShape)`
+  // guard dropped.
+  it('emits nothing when a shape is clicked on an unobserved reading', () => {
+    const onFilterShapeChange = vi.fn();
+    const view = withPassbandField(base(), 'filterShape', { unknown: true });
+    withSurface(view, (s) => {
+      forceClick(s.button('filter-shape', 1)!);
+      flushSync();
+      expect(onFilterShapeChange).not.toHaveBeenCalled();
+    }, { onFilterShapeChange });
   });
 });
 
@@ -264,6 +305,24 @@ describe('level fields emit the raw value, unrescaled', () => {
       input.dispatchEvent(new Event('input', { bubbles: true }));
       flushSync();
       expect(onFilterWidthChange).toHaveBeenCalledExactlyOnceWith(2800);
+    }, { onFilterWidthChange });
+  });
+
+  // MUTATION KILLED (MF9, verify-MOR-1304 F3): `changeWidth`'s
+  // `usable(modeFilter.filterWidth)` guard dropped. No prior test exercised
+  // this — the slider's `disabled` attribute was never in question here, so
+  // an `input` event dispatched directly (never suppressed for a disabled
+  // range input the way `.click()` is for a disabled button) reaches the
+  // handler and proves the guard itself, not merely the DOM attribute.
+  it('emits nothing when the width slider is moved on an unobserved reading', () => {
+    const onFilterWidthChange = vi.fn();
+    const view = withModeFilterField(base(), 'filterWidth', { unknown: true });
+    withSurface(view, (s) => {
+      const input = s.input('filter-width')!;
+      input.value = '2800';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      flushSync();
+      expect(onFilterWidthChange).not.toHaveBeenCalled();
     }, { onFilterWidthChange });
   });
 
@@ -291,6 +350,11 @@ describe('level fields emit the raw value, unrescaled', () => {
     const view = withPassbandField(base(), 'ifShift', { unknown: true });
     withSurface(view, (s) => {
       const input = s.input('filter-ifShift')!;
+      // MUTATION KILLED (MF1b): `numberOf(filterPassband[field], min)`'s
+      // fallback swapped for a non-min literal (e.g. 999) — an unread thumb
+      // is free to claim any position unless the fallback itself is pinned,
+      // BEFORE the dispatched input below overwrites it.
+      expect(input.value).toBe('-1200');
       input.value = '100';
       input.dispatchEvent(new Event('input', { bubbles: true }));
       flushSync();
@@ -324,6 +388,14 @@ describe('filterWidth and its bounds carry independent availability', () => {
       // Bounds are still their own known values — used for min/max regardless.
       expect(s.input('filter-width')!.min).toBe('50');
       expect(s.input('filter-width')!.max).toBe('3600');
+      // MUTATION KILLED (MF1): `numberOf(modeFilter.filterWidth, 0)`'s
+      // fallback swapped for a non-zero literal — an unread thumb is free to
+      // claim any position unless the fallback itself is pinned. The DOM
+      // clamps the fallback `0` to the slider's own `min` (`50`, this view's
+      // known `filterWidthMin`), which is itself the honest rendered
+      // position and still distinguishes the fallback from a fabricated
+      // literal like `777` (which sits inside [50, 3600] and would NOT clamp).
+      expect(s.input('filter-width')!.value).toBe('50');
     });
   });
 

--- a/frontend/src/semantic/__tests__/FilterSurface.test.ts
+++ b/frontend/src/semantic/__tests__/FilterSurface.test.ts
@@ -1,0 +1,402 @@
+/**
+ * MOR-1304 — the semantic mode/filter surface (vocabulary slice 4B).
+ *
+ * Covers BOTH fact groups the surface renders: `modeFilter` (MOR-1280 —
+ * mode, filter selection, filter width) and `filterPassband` (MOR-1284 —
+ * filter shape, IF-shift, PBT inner/outer, DATA submode). Every test names
+ * the doctrine it pins: two-level availability (MOR-977), no fabricated
+ * selection on an unobserved reading, and the F2-style independence between
+ * `filterWidth` and its own `filterWidthMin`/`filterWidthMax` bounds.
+ */
+import { readFileSync } from 'node:fs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import FilterSurface, {
+  FILTER_PASSBAND_LEVELS, FILTER_SHAPES, type FilterPassbandLevelField,
+} from '../FilterSurface.svelte';
+import { topologyFixtures, withFilterPassband, withModeFilter } from '../fixtures/topologies';
+import type {
+  Availability, FilterPassbandViewModel, ModeFilterViewModel, RadioViewModel,
+} from '../radio-view-model';
+
+const base = (): RadioViewModel =>
+  withFilterPassband(withModeFilter(topologyFixtures['1/single']));
+
+type ModeFilterKey = keyof ModeFilterViewModel;
+type FilterPassbandKey = keyof FilterPassbandViewModel;
+
+function withModeFilterField(
+  view: RadioViewModel, field: ModeFilterKey,
+  over: { availability?: Availability; unknown?: boolean },
+): RadioViewModel {
+  const group = view.modeFilter!;
+  const current = group[field] as { reading: unknown; availability: Availability };
+  return {
+    ...view,
+    modeFilter: {
+      ...group,
+      [field]: {
+        reading: over.unknown ? { status: 'unknown' } : current.reading,
+        availability: over.availability ?? current.availability,
+      },
+    } as ModeFilterViewModel,
+  };
+}
+
+function withPassbandField(
+  view: RadioViewModel, field: FilterPassbandKey,
+  over: { availability?: Availability; unknown?: boolean },
+): RadioViewModel {
+  const group = view.filterPassband!;
+  const current = group[field] as { reading: unknown; availability: Availability };
+  return {
+    ...view,
+    filterPassband: {
+      ...group,
+      [field]: {
+        reading: over.unknown ? { status: 'unknown' } : current.reading,
+        availability: over.availability ?? current.availability,
+      },
+    } as FilterPassbandViewModel,
+  };
+}
+
+let target: HTMLDivElement;
+beforeEach(() => { target = document.createElement('div'); document.body.appendChild(target); });
+afterEach(() => { target.remove(); });
+
+type Handlers = {
+  onModeChange?: (mode: string) => void;
+  onFilterChange?: (filter: number) => void;
+  onFilterWidthChange?: (width: number) => void;
+  onFilterShapeChange?: (shape: number) => void;
+  onIfShiftChange?: (value: number) => void;
+  onPbtInnerChange?: (value: number) => void;
+  onPbtOuterChange?: (value: number) => void;
+};
+
+function render(view: RadioViewModel, handlers: Handlers = {}) {
+  const component = mount(FilterSurface, { target, props: { view, ...handlers } });
+  flushSync();
+  const q = <T extends HTMLElement>(sel: string) => target.querySelector(sel) as T | null;
+  return {
+    dispose: () => unmount(component),
+    root: () => q('[data-testid="filter-surface"]'),
+    group: (testId: string) => q<HTMLElement>(`[data-testid="${testId}"]`),
+    button: (testId: string, value: string | number) => q<HTMLButtonElement>(
+      `[data-testid="${testId}-${value}"]`,
+    ),
+    input: (testId: string) => q<HTMLInputElement>(`[data-testid="${testId}"] input`),
+    output: (testId: string) => q<HTMLElement>(`[data-testid="${testId}"] output`),
+  };
+}
+
+function withSurface(
+  view: RadioViewModel, fn: (s: ReturnType<typeof render>) => void, handlers: Handlers = {},
+): void {
+  const s = render(view, handlers);
+  try { fn(s); } finally { s.dispose(); }
+}
+
+// ── 1. Whole-group gating ───────────────────────────────────────────────────
+
+describe('whole-group gating', () => {
+  it('renders nothing for a view model carrying neither group', () => {
+    withSurface(topologyFixtures['1/single'], (s) => {
+      expect(s.root()).toBeNull();
+    });
+  });
+
+  it('renders only the modeFilter controls when filterPassband is absent', () => {
+    withSurface(withModeFilter(topologyFixtures['1/single']), (s) => {
+      expect(s.root()).not.toBeNull();
+      expect(s.group('filter-mode')).not.toBeNull();
+      expect(s.group('filter-shape')).toBeNull();
+      expect(s.group('filter-data-mode')).toBeNull();
+    });
+  });
+
+  it('renders only the filterPassband controls when modeFilter is absent', () => {
+    withSurface(withFilterPassband(topologyFixtures['1/single']), (s) => {
+      expect(s.root()).not.toBeNull();
+      expect(s.group('filter-shape')).not.toBeNull();
+      expect(s.group('filter-mode')).toBeNull();
+    });
+  });
+});
+
+// ── 2. Structural gating: absent, never a disabled promise ──────────────────
+
+describe('structural availability decides whether a control EXISTS', () => {
+  const ABSENT: Availability = { structural: false, operational: false };
+
+  it('renders no mode control when currentMode is structurally absent', () => {
+    const view = withModeFilterField(base(), 'currentMode', { availability: ABSENT });
+    withSurface(view, (s) => expect(s.group('filter-mode')).toBeNull());
+  });
+
+  it('renders no filter-width control when filterWidth is structurally absent', () => {
+    const view = withModeFilterField(base(), 'filterWidth', { availability: ABSENT });
+    withSurface(view, (s) => expect(s.group('filter-width')).toBeNull());
+  });
+
+  it('renders no shape control when filterShape is structurally absent', () => {
+    const view = withPassbandField(base(), 'filterShape', { availability: ABSENT });
+    withSurface(view, (s) => expect(s.group('filter-shape')).toBeNull());
+  });
+
+  it('renders no dataMode readout when dataMode is structurally absent', () => {
+    const view = withPassbandField(base(), 'dataMode', { availability: ABSENT });
+    withSurface(view, (s) => expect(s.group('filter-data-mode')).toBeNull());
+  });
+
+  it.each(FILTER_PASSBAND_LEVELS)('renders no "%s" control when structurally absent', (field) => {
+    const view = withPassbandField(base(), field, { availability: ABSENT });
+    withSurface(view, (s) => expect(s.group(`filter-${field}`)).toBeNull());
+  });
+});
+
+// ── 3. Operational gating: present, disabled, with a reason ─────────────────
+
+describe('operational availability decides whether a control is USABLE', () => {
+  const PRESENT_UNREADABLE: Availability = { structural: true, operational: false };
+
+  it('keeps the width slider present but disabled when unreadable', () => {
+    const view = withModeFilterField(base(), 'filterWidth', { availability: PRESENT_UNREADABLE });
+    withSurface(view, (s) => {
+      expect(s.input('filter-width')!.disabled).toBe(true);
+      expect(s.group('filter-width')!.dataset.disabledReason).toBe('field-not-observed');
+    });
+  });
+
+  it('never enables the width slider on an unobserved reading', () => {
+    const view = withModeFilterField(base(), 'filterWidth', { unknown: true });
+    withSurface(view, (s) => {
+      expect(s.input('filter-width')!.disabled).toBe(true);
+      expect(s.output('filter-width')!.textContent).toBe('?');
+    });
+  });
+
+  it.each(FILTER_PASSBAND_LEVELS)('keeps "%s" present but disabled when unreadable', (field) => {
+    const view = withPassbandField(base(), field, { availability: PRESENT_UNREADABLE });
+    withSurface(view, (s) => {
+      expect(s.input(`filter-${field}`)!.disabled).toBe(true);
+      expect(s.group(`filter-${field}`)!.dataset.disabledReason).toBe('field-not-observed');
+    });
+  });
+
+  it('disables mode buttons and marks none pressed on an unobserved reading', () => {
+    const view = withModeFilterField(base(), 'currentMode', { unknown: true });
+    withSurface(view, (s) => {
+      for (const choice of view.modeFilter!.modeChoices) {
+        const button = s.button('filter-mode', choice)!;
+        expect(button.disabled).toBe(true);
+        expect(button.getAttribute('aria-pressed')).toBe('false');
+      }
+    });
+  });
+});
+
+// ── 4. Choice-field emission: mode, filter selection, shape ─────────────────
+
+describe('choice fields emit the caller intent only when usable', () => {
+  it('emits onModeChange with the clicked choice', () => {
+    const onModeChange = vi.fn();
+    withSurface(base(), (s) => {
+      s.button('filter-mode', 'LSB')!.click();
+      flushSync();
+      expect(onModeChange).toHaveBeenCalledExactlyOnceWith('LSB');
+    }, { onModeChange });
+  });
+
+  it('marks the current mode pressed and no other', () => {
+    withSurface(base(), (s) => {
+      expect(s.button('filter-mode', 'USB')!.getAttribute('aria-pressed')).toBe('true');
+      expect(s.button('filter-mode', 'LSB')!.getAttribute('aria-pressed')).toBe('false');
+    });
+  });
+
+  it('emits onFilterChange with the 1-based filter index', () => {
+    const onFilterChange = vi.fn();
+    withSurface(base(), (s) => {
+      s.button('filter-select', 2)!.click();
+      flushSync();
+      expect(onFilterChange).toHaveBeenCalledExactlyOnceWith(2);
+    }, { onFilterChange });
+  });
+
+  it('emits onFilterShapeChange with the clicked shape value', () => {
+    const onFilterShapeChange = vi.fn();
+    withSurface(base(), (s) => {
+      s.button('filter-shape', 1)!.click();
+      flushSync();
+      expect(onFilterShapeChange).toHaveBeenCalledExactlyOnceWith(1);
+    }, { onFilterShapeChange });
+  });
+
+  it.each(FILTER_SHAPES)('renders a "%s" button labelled "%s"', (value, label) => {
+    withSurface(base(), (s) => {
+      expect(s.button('filter-shape', value)!.textContent).toBe(label);
+    });
+  });
+
+  // MUTATION KILLED: emitting a choice intent from an unobserved reading —
+  // clicking would arm a guess rather than a confirmed selection.
+  it('emits nothing when a choice is clicked on an unobserved reading', () => {
+    const onModeChange = vi.fn();
+    const view = withModeFilterField(base(), 'currentMode', { unknown: true });
+    withSurface(view, (s) => {
+      s.button('filter-mode', 'LSB')!.click();
+      flushSync();
+      expect(onModeChange).not.toHaveBeenCalled();
+    }, { onModeChange });
+  });
+});
+
+// ── 5. Level-field emission: width, IF-shift, PBT inner/outer ───────────────
+
+describe('level fields emit the raw value, unrescaled', () => {
+  it('emits onFilterWidthChange with the raw slider value', () => {
+    const onFilterWidthChange = vi.fn();
+    withSurface(base(), (s) => {
+      const input = s.input('filter-width')!;
+      input.value = '2800';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      flushSync();
+      expect(onFilterWidthChange).toHaveBeenCalledExactlyOnceWith(2800);
+    }, { onFilterWidthChange });
+  });
+
+  const passbandHandlers: Record<FilterPassbandLevelField, keyof Handlers> = {
+    ifShift: 'onIfShiftChange', pbtInner: 'onPbtInnerChange', pbtOuter: 'onPbtOuterChange',
+  };
+
+  it.each(FILTER_PASSBAND_LEVELS)('emits (%s) via its own handler with min/max/step', (field, _label, min, max, step) => {
+    const spy = vi.fn();
+    withSurface(base(), (s) => {
+      const input = s.input(`filter-${field}`)!;
+      expect(input.min).toBe(String(min));
+      expect(input.max).toBe(String(max));
+      expect(input.step).toBe(String(step));
+      input.value = String(max);
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      flushSync();
+      expect(spy).toHaveBeenCalledExactlyOnceWith(max);
+    }, { [passbandHandlers[field]]: spy });
+  });
+
+  // MUTATION KILLED: emitting a level intent from an unobserved reading.
+  it('emits nothing from an unobserved passband level', () => {
+    const onIfShiftChange = vi.fn();
+    const view = withPassbandField(base(), 'ifShift', { unknown: true });
+    withSurface(view, (s) => {
+      const input = s.input('filter-ifShift')!;
+      input.value = '100';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      flushSync();
+      expect(onIfShiftChange).not.toHaveBeenCalled();
+    }, { onIfShiftChange });
+  });
+});
+
+// ── 6. filterWidth bounds read their OWN field, independently (F2-style) ────
+
+describe('filterWidth and its bounds carry independent availability', () => {
+  // MUTATION KILLED: gating the width slider on filterWidthMin/Max's
+  // availability instead of filterWidth's own — a shared "modeObserved" stand-
+  // in for the whole group, exactly the fabrication the MOR-1280 F2 fix bans.
+  it('keeps the width slider enabled when only the BOUNDS are unobserved', () => {
+    let view = withModeFilterField(base(), 'filterWidthMin', {
+      availability: { structural: true, operational: false },
+    });
+    view = withModeFilterField(view, 'filterWidthMax', {
+      availability: { structural: true, operational: false },
+    });
+    withSurface(view, (s) => {
+      expect(s.input('filter-width')!.disabled).toBe(false);
+    });
+  });
+
+  it('disables the width slider when filterWidth itself is unobserved, bounds untouched', () => {
+    const view = withModeFilterField(base(), 'filterWidth', { unknown: true });
+    withSurface(view, (s) => {
+      expect(s.input('filter-width')!.disabled).toBe(true);
+      // Bounds are still their own known values — used for min/max regardless.
+      expect(s.input('filter-width')!.min).toBe('50');
+      expect(s.input('filter-width')!.max).toBe('3600');
+    });
+  });
+
+  it('falls back to a sane default range when the bounds are unobserved', () => {
+    let view = withModeFilterField(base(), 'filterWidthMin', { unknown: true });
+    view = withModeFilterField(view, 'filterWidthMax', { unknown: true });
+    withSurface(view, (s) => {
+      expect(s.input('filter-width')!.min).toBe('50');
+      expect(s.input('filter-width')!.max).toBe('9999');
+    });
+  });
+});
+
+// ── 7. filterShape unknown-but-structural is accepted, honest (carry-fwd 4) ─
+
+describe('filterShape renders honest unknown rather than a fabricated default', () => {
+  it('marks neither SHARP nor SOFT pressed while unobserved', () => {
+    const view = withPassbandField(base(), 'filterShape', { unknown: true });
+    withSurface(view, (s) => {
+      for (const [value] of FILTER_SHAPES) {
+        expect(s.button('filter-shape', value)!.getAttribute('aria-pressed')).toBe('false');
+        expect(s.button('filter-shape', value)!.disabled).toBe(true);
+      }
+    });
+  });
+});
+
+// ── 8. dataMode is an honest readout, never a control ───────────────────────
+
+describe('dataMode renders as a readout', () => {
+  it('shows the known value', () => {
+    withSurface(base(), (s) => {
+      expect(s.output('filter-data-mode')!.textContent).toBe('0');
+    });
+  });
+
+  it('shows "?" honestly when unobserved, never a fabricated default', () => {
+    const view = withPassbandField(base(), 'dataMode', { unknown: true });
+    withSurface(view, (s) => {
+      expect(s.output('filter-data-mode')!.textContent).toBe('?');
+    });
+  });
+
+  it('carries no button or input — it is read-only', () => {
+    withSurface(base(), (s) => {
+      const readout = s.group('filter-data-mode')!;
+      expect(readout.querySelector('button')).toBeNull();
+      expect(readout.querySelector('input')).toBeNull();
+    });
+  });
+});
+
+// ── 9. No re-derivation — facts only (carry-forwards 1 and 5) ───────────────
+
+describe('the surface never re-derives what the adapter already computed', () => {
+  /** Strip comments first — the file's own header PROSE necessarily names
+   *  the functions it must not import, while explaining why. Same stripper
+   *  `TxAuxSurface.test.ts` uses for its analogous source-text pin. */
+  const withoutComments = (text: string): string => text
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/^\s*\/\/.*$/gm, '');
+  const source = withoutComments(readFileSync('src/semantic/FilterSurface.svelte', 'utf8'));
+
+  it('imports neither resolveFilterModeConfig nor a PBT/IF-shift formula', () => {
+    expect(source).not.toMatch(/resolveFilterModeConfig/);
+    expect(source).not.toMatch(/pbtRawToHz/);
+    expect(source).not.toMatch(/deriveIfShift/);
+  });
+
+  it('holds no runtime, transport, audio, or store import', () => {
+    expect(source).not.toMatch(/\$lib\/transport/);
+    expect(source).not.toMatch(/audio-manager/);
+    expect(source).not.toMatch(/\$lib\/runtime/);
+  });
+});

--- a/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
+++ b/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
@@ -82,7 +82,18 @@ vi.mock('../../../components-v2/wiring/command-bus', () => ({
   // MOR-1279 slice 3B: the RX-audio intent vocabulary.
   makeRxAudioHandlers: () => ({ onMonitorModeChange: h.txAuxNoop, onAfLevelChange: h.txAuxNoop }),
   makeAudioRoutingHandlers: () => ({ onFocusChange: h.txAuxNoop, onSplitStereoChange: h.txAuxNoop }),
-  makeModeHandlers: () => ({ onModInputChange: h.txAuxNoop }),
+  // MOR-1304 — the wiring now also composes the modeFilter/filterPassband
+  // intent vocabulary; `makeModeHandlers` is composed at both call sites
+  // (rxAudio's MOD-input remedy and filterIntents), so the stub carries both.
+  // The default fixture (`mainSubCaps()`) declares no filter capability, so
+  // the MOR-1280/1284 evidence gate omits both groups by default.
+  makeModeHandlers: () => ({
+    onModInputChange: h.txAuxNoop, onModeChange: h.txAuxNoop, onDataModeChange: h.txAuxNoop,
+  }),
+  makeFilterHandlers: () => ({
+    onFilterChange: h.txAuxNoop, onFilterWidthChange: h.txAuxNoop, onFilterShapeChange: h.txAuxNoop,
+    onIfShiftChange: h.txAuxNoop, onPbtInnerChange: h.txAuxNoop, onPbtOuterChange: h.txAuxNoop,
+  }),
 }));
 
 import DualReceiverCockpit from '../DualReceiverCockpit.svelte';


### PR DESCRIPTION
## Summary

4B: FilterSurface over the modeFilter + filterPassband facts. Mounted via zoned('filter', ...) in the SINGLE composition only per the mounting canon (MOR-1304 ruling); dual-composition absence pinned with the surface's own caps override (real modes/filters) plus a control test that forecloses fixture-vacuity by construction.

Production LOC 173 (verifier-measured, frozen formula; cap 200).

## Review provenance

Verified by the vocabulary-domain opus anchor (session 8). Initial verify BLOCKED on four findings; all fixed in a prescribed fix round and delta-confirmed:
- F1: dual bare mount removed (was a MOR-1069 violation masked by vacuous fixture caps — the finding that produced the mounting canon now recorded on MOR-1304). Both restoration shapes re-caught by the anchor's own hands, including the canon-critical zoned-dual-mount case.
- F2: slider thumb fallbacks pinned; the '50' clamp deviation adjudicated in the fixer's favor (pins what the operator sees).
- F3: handler guards pinned via direct dispatchEvent (the .click()-on-disabled vacuity class removed); MF3/MF9/MF12/MF13 all die.
- F4: rebased onto main; contract literal [...,'rxAudio','filter'] consistent across four declarability literals.
Final gates by the anchor: 260 files / 5246 tests, 0 failures (fresh localstorage); lint/boundaries/i18n/check clean.

Non-blocking residual: N1 filter-row aria-pressed off-by-one (one assertion, next touch of that file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)