### PR TITLE
feat(MOR-1305): DspSurface (5B) - canon-compliant zoned mount

### DIFF
--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -31,6 +31,9 @@
     compositionSurfaces, useSurfacePlan, zoneShowsSurface,
   } from '../../presentation/workspace/resolution';
   import { LAN_MOD_INPUT_SOURCE } from '$lib/radio/mod-input';
+  import DspSurface, {
+    type DspLevelField, type DspToggleField,
+  } from '../../semantic/DspSurface.svelte';
   import FilterSurface from '../../semantic/FilterSurface.svelte';
   import MetersSurface from '../../semantic/MetersSurface.svelte';
   import type { RadioViewModel } from '../../semantic/radio-view-model';
@@ -43,8 +46,8 @@
   import VfoSurface, { type VfoSelection } from '../../semantic/VfoSurface.svelte';
   import ModInputTxWarning from '../panels/ModInputTxWarning.svelte';
   import {
-    makeAudioRoutingHandlers, makeFilterHandlers, makeModeHandlers, makeRxAudioHandlers,
-    makeTxHandlers, makeVfoHandlers, makeVoxHandlers,
+    makeAgcHandlers, makeAudioRoutingHandlers, makeDspHandlers, makeFilterHandlers,
+    makeModeHandlers, makeRxAudioHandlers, makeTxHandlers, makeVfoHandlers, makeVoxHandlers,
   } from './command-bus';
   import {
     forReceiver, receiversOf, isActiveStrip, isOperationalStrip,
@@ -176,6 +179,36 @@
    * names 1:1, so no per-field `Record` indirection is needed.
    */
   const filterIntents = { ...makeModeHandlers(), ...makeFilterHandlers() };
+  /**
+   * MOR-1305. `makeDspHandlers`/`makeAgcHandlers` already carry every dsp
+   * intent; the two maps below keep the pure surface field-addressed, same
+   * precedent as `TX_AUX_*_INTENT` above — agreement with the shipped
+   * command-bus names is exercised against the REAL module in the component
+   * test, not re-asserted here.
+   */
+  const dspIntents = makeDspHandlers();
+  const DSP_TOGGLE_INTENT: Record<DspToggleField, (next: boolean) => void> = {
+    nrActive: (next) => dspIntents.onNrModeChange(next ? 1 : 0),
+    nbActive: (next) => dspIntents.onNbToggle(next),
+  };
+  const DSP_LEVEL_INTENT: Record<DspLevelField, (value: number) => void> = {
+    nrLevel: dspIntents.onNrLevelChange, nbLevel: dspIntents.onNbLevelChange,
+    nbDepth: dspIntents.onNbDepthChange, nbWidth: dspIntents.onNbWidthChange,
+    notchFreq: dspIntents.onNotchFreqChange, manualNotchWidth: dspIntents.onManualNotchWidthChange,
+    agcTimeConstant: dspIntents.onAgcTimeChange,
+  };
+  const agcIntents = makeAgcHandlers();
+  /**
+   * `agcLabels`/`nbLevelMax`/`nbLevelPercent` are pure caps-echo display
+   * metadata, NOT `dsp` facts (MOR-1290/MOR-1305 carry-forward 1) — read
+   * straight off `runtime.caps` here, at the one seam that already holds it
+   * for the `toRadioViewModel` call below, verbatim `toDspProps`'s own
+   * fallbacks (`lib/runtime/props/panel-props.ts`).
+   */
+  let agcLabels = $derived(runtime.caps?.agcLabels ?? { '1': 'FAST', '2': 'MID', '3': 'SLOW' });
+  let nbLevelRange = $derived(runtime.caps?.controls?.nb_level ?? null);
+  let nbLevelMax = $derived(nbLevelRange?.raw_max ?? 10);
+  let nbLevelPercent = $derived(nbLevelRange !== null);
   const tx = getAppTxController();
   const sourceId = `semantic-rx-tx-${++surfaceSeq}`;
   let leaseSeq = 0;
@@ -594,6 +627,38 @@
     {/if}
   {/snippet}
 
+  <!--
+    MOR-1305 (vocabulary slice 5B). Same structural gate and same reasoning as
+    `rxAudioSurface` above: the surface mounts only when the view model
+    actually carries the MOR-1290 `dsp` group, so a radio the evidence gate
+    declined renders the pre-1305 element shape exactly.
+
+    Like `rxAudioSurface` and UNLIKE `txAuxSurface`/`metersSurface`, it is
+    rendered in the SINGLE composition ONLY (MOR-1304/MOR-1305 zone-mount
+    ruling). `DspSurface` renders up to 8 range inputs and 7 buttons — it is
+    control-bearing, and the cockpit's MOR-1069 rule forbids mounting any
+    control-bearing surface bare in the dual composition: every focusable
+    control must live inside a declared zone, with rx-tx last in the tab
+    order. `'dsp'` became DECLARABLE with this slice, so the cockpit gains the
+    surface the moment its manifest declares a zone for it — a layout
+    decision, separately reviewed, exactly as rxAudio left it.
+
+    `agcLabels`/`nbLevelMax`/`nbLevelPercent` are the caps-echo metadata
+    carry-forward (1) requires stay OUT of the view model — read at this seam,
+    from `runtime.caps`, and handed down as plain props.
+  -->
+  {#snippet dspSurface()}
+    {#if view?.dsp}
+      <DspSurface
+        {view} {agcLabels} {nbLevelMax} {nbLevelPercent}
+        onToggle={(field, next) => DSP_TOGGLE_INTENT[field](next)}
+        onLevelChange={(field, value) => DSP_LEVEL_INTENT[field](value)}
+        onNotchModeChange={dspIntents.onNotchModeChange}
+        onAgcModeChange={agcIntents.onAgcModeChange}
+      />
+    {/if}
+  {/snippet}
+
   {#if strips === 'dual'}
     <!--
       MOR-1258: the zone now carries RxTxSurface AND the two TX-adjacent
@@ -638,6 +703,7 @@
     {@render zoned('meters', view?.meters !== undefined, metersSurface)}
     {@render zoned('rxAudio', view?.rxAudio !== undefined, rxAudioSurface)}
     {@render zoned('filter', view?.modeFilter !== undefined || view?.filterPassband !== undefined, filterSurface)}
+    {@render zoned('dsp', view?.dsp !== undefined, dspSurface)}
     {@render txAdjacentAlerts()}
   {/if}
 </div>

--- a/frontend/src/components-v2/wiring/__tests__/semantic-dsp-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-dsp-wiring.component.test.ts
@@ -1,0 +1,273 @@
+/**
+ * MOR-1305 — the semantic DSP surface wired into `SemanticRadioSurfaces`.
+ *
+ * The unit tests in `semantic/__tests__/DspSurface.test.ts` prove what the
+ * surface does with a view model and plain handler props. This file proves
+ * the thing only the composed tree can prove:
+ *   (a) the structural gate and default-path byte-identity, same discipline
+ *       as MOR-1265/MOR-1273's own wiring tests;
+ *   (b) every dsp intent reaches its OWN command-bus handler (no transposed
+ *       field, matching `tx-aux-command-bus.test.ts`'s discipline);
+ *   (c) `agcLabels`/`nbLevelMax`/`nbLevelPercent` are read off `runtime.caps`
+ *       at THIS seam and handed down as plain props — carry-forward (1).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { ServerState } from '$lib/types/state';
+
+type Snapshot = {
+  phase: string; intent: string | null; guard: { leaseId: string } | null;
+  radioTx: string; txRisk: string; mayOwnKey: boolean; fault: string | null;
+};
+
+const h = vi.hoisted(() => ({
+  state: null as unknown,
+  caps: null as unknown,
+  snapshot: null as unknown,
+  listeners: new Set<(next: unknown) => void>(),
+  start: vi.fn(),
+  release: vi.fn(),
+  noop: vi.fn(),
+  nrMode: vi.fn(),
+  nrLevel: vi.fn(),
+  nbToggle: vi.fn(),
+  nbLevel: vi.fn(),
+  nbDepth: vi.fn(),
+  nbWidth: vi.fn(),
+  notchMode: vi.fn(),
+  notchFreq: vi.fn(),
+  manualNotchWidth: vi.fn(),
+  agcTime: vi.fn(),
+  agcMode: vi.fn(),
+}));
+
+vi.mock('$lib/runtime', () => ({
+  runtime: { get state() { return h.state; }, get caps() { return h.caps; } },
+}));
+vi.mock('$lib/runtime/tx-controller/app-host', () => ({
+  getAppTxController: () => ({
+    snapshot: () => h.snapshot,
+    subscribe: (listener: (next: unknown) => void) => {
+      h.listeners.add(listener);
+      return () => { h.listeners.delete(listener); };
+    },
+    start: h.start,
+    setIntent: vi.fn(),
+    release: h.release,
+    resetFault: vi.fn(),
+  }),
+}));
+vi.mock('$lib/runtime/adapters/mod-input-tx-guard.svelte', () => ({
+  deriveModInputTxGuardProps: () => ({ visible: false, sourceLabel: null }),
+  getModInputTxGuardHandlers: () => ({ onSetLan: vi.fn(), onDismiss: vi.fn() }),
+}));
+// The names below are the REAL `makeDspHandlers`/`makeAgcHandlers` surface —
+// agreement with the shipped module is proven separately, against the real
+// module, in `command-bus.test.ts`.
+vi.mock('../command-bus', () => ({
+  makeVfoHandlers: () => ({
+    onVfoSelect: h.noop, onSplitToggle: h.noop, onDualWatchToggle: h.noop,
+  }),
+  makeVoxHandlers: () => ({
+    onVoxToggle: h.noop, onVoxGainChange: h.noop,
+    onAntiVoxGainChange: h.noop, onVoxDelayChange: h.noop,
+  }),
+  makeTxHandlers: () => ({
+    onRfPowerChange: h.noop, onMicGainChange: h.noop, onAtuToggle: h.noop,
+    onAtuTune: h.noop, onVoxToggle: h.noop, onCompToggle: h.noop,
+    onCompLevelChange: h.noop, onMonToggle: h.noop,
+    onMonLevelChange: h.noop, onDriveGainChange: h.noop,
+  }),
+  makeDspHandlers: () => ({
+    onNrModeChange: h.nrMode, onNrLevelChange: h.nrLevel, onNbToggle: h.nbToggle,
+    onNbLevelChange: h.nbLevel, onNbDepthChange: h.nbDepth, onNbWidthChange: h.nbWidth,
+    onNotchModeChange: h.notchMode, onNotchFreqChange: h.notchFreq,
+    onManualNotchWidthChange: h.manualNotchWidth, onAgcTimeChange: h.agcTime,
+  }),
+  makeAgcHandlers: () => ({ onAgcModeChange: h.agcMode }),
+}));
+
+import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';
+
+const IDLE: Snapshot = {
+  phase: 'idle', intent: null, guard: null, radioTx: 'off', txRisk: 'none',
+  mayOwnKey: false, fault: null,
+};
+
+const fresh = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' };
+const slot = (freqHz: number) => ({ freqHz, mode: 'USB', filterNum: 1, dataMode: 0 });
+
+/** Every raw dsp field the MOR-1290 adapter reads, all observed fresh. */
+const DSP_STATE = {
+  nr: true, nrLevel: 128, nb: false, nbLevel: 64, nbDepth: 4, nbWidth: 2,
+  autoNotch: false, manualNotch: false, notchFilter: 0, manualNotchWidth: 1,
+  agc: 2, agcTimeConstant: 3,
+} as const;
+const DSP_PATHS = [
+  'main.nr', 'main.nrLevel', 'main.nb', 'main.nbLevel', 'main.autoNotch',
+  'main.manualNotch', 'main.manualNotchWidth', 'main.agc', 'main.agcTimeConstant',
+  'nbDepth', 'nbWidth', 'notchFilter',
+];
+
+function liveState(withDsp: boolean): ServerState {
+  const paths = ['active', 'split', 'dualWatch', 'txTarget'];
+  for (const rx of ['main', 'sub']) {
+    paths.push(`${rx}.freqHz`, `${rx}.mode`, `${rx}.filter`, `${rx}.activeSlot`);
+    for (const v of ['vfoA', 'vfoB']) {
+      paths.push(`${rx}.${v}.freqHz`, `${rx}.${v}.mode`, `${rx}.${v}.filterNum`);
+    }
+  }
+  if (withDsp) paths.push(...DSP_PATHS);
+  const receiver = (hz: number) => ({
+    ...slot(hz), vfoA: slot(hz), vfoB: slot(hz + 50000), activeSlot: 'A', filter: 1,
+    ...(withDsp ? { nr: DSP_STATE.nr, nrLevel: DSP_STATE.nrLevel, nb: DSP_STATE.nb,
+      nbLevel: DSP_STATE.nbLevel, autoNotch: DSP_STATE.autoNotch, manualNotch: DSP_STATE.manualNotch,
+      manualNotchWidth: DSP_STATE.manualNotchWidth, agc: DSP_STATE.agc,
+      agcTimeConstant: DSP_STATE.agcTimeConstant } : {}),
+  });
+  return {
+    active: 'MAIN', split: false, dualWatch: false, ptt: false,
+    txTarget: { status: 'known', receiver: 'MAIN', slot: 'A', frequencyHz: 14250000 },
+    main: receiver(14250000), sub: receiver(14300000),
+    ...(withDsp ? { nbDepth: DSP_STATE.nbDepth, nbWidth: DSP_STATE.nbWidth, notchFilter: DSP_STATE.notchFilter } : {}),
+    fieldStatus: Object.fromEntries(paths.map((p) => [p, fresh])),
+  } as unknown as ServerState;
+}
+
+const liveCaps = (withDsp: boolean): Capabilities => ({
+  model: 'fixture', scope: false, audio: true, tx: true,
+  capabilities: withDsp ? ['audio', 'tx', 'dual_rx', 'nr', 'nb', 'notch', 'agc'] : ['audio', 'tx', 'dual_rx'],
+  receivers: 2, vfoScheme: 'main_sub', freqRanges: [], modes: [], filters: [],
+  audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
+  webrtc: { available: false, enabled: false },
+  txBands: [{ start: 14000000, end: 14350000, name: '20m' }],
+  scopeSource: null, audioFftAvailable: false,
+  agcModes: [1, 2, 3], agcLabels: { '1': 'FAST', '2': 'MID', '3': 'SLOW' },
+  ...(withDsp ? { controls: {
+    nb_level: { raw_min: 0, raw_max: 200, display_min: 0, display_max: 100 },
+    nb_depth: { raw_min: 0, raw_max: 9, display_min: 1, display_max: 10 },
+  } } : {}),
+} as unknown as Capabilities);
+
+let target: HTMLDivElement;
+let component: ReturnType<typeof mount> | null = null;
+
+function render(props: { strips?: 'single' | 'dual' } = {}): void {
+  target = document.createElement('div');
+  document.body.appendChild(target);
+  component = mount(SemanticRadioSurfaces, { target, props });
+  flushSync();
+}
+
+const q = <T extends HTMLElement>(sel: string) => target.querySelector(sel) as T | null;
+
+beforeEach(() => {
+  h.state = liveState(true);
+  h.caps = liveCaps(true);
+  h.snapshot = { ...IDLE };
+  h.listeners.clear();
+  for (const value of Object.values(h)) {
+    if (typeof value === 'function' && 'mockReset' in value) (value as ReturnType<typeof vi.fn>).mockReset();
+  }
+});
+
+afterEach(() => {
+  if (component) unmount(component);
+  component = null;
+  document.body.innerHTML = '';
+});
+
+describe('the dsp surface mounts only when the view model carries the group', () => {
+  const DEFAULT_PATH_TESTIDS = [
+    'vfo-surface', 'vfo-active-receiver', 'vfo-list',
+    'rx-tx-surface', 'rx-tx-state', 'rx-tx-rf-mark', 'rx-tx-rf-label',
+    'rx-tx-target', 'rx-tx-key', 'rx-tx-unkey', 'rx-tx-blocked',
+  ];
+  const testids = () => [...target.querySelectorAll<HTMLElement>('[data-testid]')]
+    .map((el) => el.dataset.testid!)
+    .filter((id) => id !== 'semantic-radio-surfaces');
+
+  it.each(['single', 'dual'] as const)('renders no dsp surface at all without the group (%s)', (strips) => {
+    h.state = liveState(false);
+    h.caps = liveCaps(false);
+    render({ strips });
+    expect(q('[data-testid="dsp-surface"]')).toBeNull();
+    expect(target.innerHTML).not.toContain('dsp-surface');
+  });
+
+  it('leaves the default path element sequence exactly as it is today', () => {
+    h.state = liveState(false);
+    h.caps = liveCaps(false);
+    render();
+    expect(testids()).toEqual(DEFAULT_PATH_TESTIDS);
+  });
+
+  it.each(['single', 'dual'] as const)('mounts the dsp surface when the group is present (%s)', (strips) => {
+    render({ strips });
+    expect(target.querySelectorAll('[data-testid="dsp-surface"]')).toHaveLength(1);
+  });
+
+  it('binds no zone id to the dsp surface in either composition', () => {
+    render({ strips: 'dual' });
+    const zones = [...target.querySelectorAll<HTMLElement>('[data-zone-id]')]
+      .map((el) => el.dataset.zoneId);
+    expect(zones).toEqual(['primary-vfo', 'secondary-vfo', 'global', 'rx-tx']);
+    expect(q('[data-testid="dsp-surface"]')!.closest('[data-zone-id]')).toBeNull();
+  });
+});
+
+describe('every dsp intent reaches its own command-bus handler', () => {
+  it.each([
+    ['nrActive', () => h.nrMode], ['nbActive', () => h.nbToggle],
+  ] as const)('routes the "%s" toggle', (field, spy) => {
+    render();
+    q<HTMLButtonElement>(`[data-testid="dsp-${field}"]`)!.click();
+    flushSync();
+    expect(spy()).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    ['nrLevel', 5, () => h.nrLevel], ['nbLevel', 30, () => h.nbLevel],
+    ['nbDepth', 3, () => h.nbDepth], ['nbWidth', 100, () => h.nbWidth],
+    ['notchFreq', 1200, () => h.notchFreq], ['manualNotchWidth', 2, () => h.manualNotchWidth],
+    ['agcTimeConstant', 4, () => h.agcTime],
+  ] as const)('routes the "%s" level with its raw value', (field, value, spy) => {
+    render();
+    const input = q<HTMLInputElement>(`[data-testid="dsp-${field}"] input`)!;
+    input.value = String(value);
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    expect(spy()).toHaveBeenCalledExactlyOnceWith(value);
+  });
+
+  it('routes notchMode as its own three-way callback, not the level/toggle map', () => {
+    render();
+    q<HTMLButtonElement>('[data-testid="dsp-notchMode-auto"]')!.click();
+    flushSync();
+    expect(h.notchMode).toHaveBeenCalledExactlyOnceWith('auto');
+  });
+
+  it('routes agcMode as its own callback, not the level/toggle map', () => {
+    render();
+    q<HTMLButtonElement>('[data-testid="dsp-agcMode-1"]')!.click();
+    flushSync();
+    expect(h.agcMode).toHaveBeenCalledExactlyOnceWith(1);
+  });
+});
+
+describe('carry-forward (1): caps-echo display metadata is read at this seam', () => {
+  it('passes agcLabels/nbLevelMax/nbLevelPercent from runtime.caps down as props', () => {
+    render();
+    expect(q('[data-testid="dsp-agcMode-1"]')!.textContent).toBe('FAST');
+    const input = q<HTMLInputElement>('[data-testid="dsp-nbLevel"] input')!;
+    expect(input.max).toBe('200');
+  });
+
+  it('falls back to the toDspProps defaults when caps carries no nb_level range', () => {
+    h.caps = { ...liveCaps(true), controls: undefined } as unknown as Capabilities;
+    render();
+    const input = q<HTMLInputElement>('[data-testid="dsp-nbLevel"] input')!;
+    expect(input.max).toBe('10');
+  });
+});

--- a/frontend/src/components-v2/wiring/__tests__/semantic-dsp-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-dsp-wiring.component.test.ts
@@ -43,7 +43,15 @@ const h = vi.hoisted(() => ({
 }));
 
 vi.mock('$lib/runtime', () => ({
-  runtime: { get state() { return h.state; }, get caps() { return h.caps; } },
+  runtime: {
+    get state() { return h.state; },
+    get caps() { return h.caps; },
+    // MOR-1279 slice 3B: the wiring now also hands the adapter an App-owned
+    // RX-audio snapshot (the FOURTH argument). Muted with no browser stream
+    // keeps every fixture below off the rxAudio path — this file tests dsp.
+    get audio() { return { muted: true, rxEnabled: false, volume: 0 }; },
+    get connectionAudio() { return false; },
+  },
 }));
 vi.mock('$lib/runtime/tx-controller/app-host', () => ({
   getAppTxController: () => ({
@@ -79,6 +87,12 @@ vi.mock('../command-bus', () => ({
     onCompLevelChange: h.noop, onMonToggle: h.noop,
     onMonLevelChange: h.noop, onDriveGainChange: h.noop,
   }),
+  // MOR-1279 slice 3B: the RX-audio intent vocabulary. This fixture declares
+  // no rxAudio capability, so none of these is reachable — same stand-in role
+  // as `makeVfoHandlers`/`makeTxHandlers` above.
+  makeRxAudioHandlers: () => ({ onMonitorModeChange: h.noop, onAfLevelChange: h.noop }),
+  makeAudioRoutingHandlers: () => ({ onFocusChange: h.noop, onSplitStereoChange: h.noop }),
+  makeModeHandlers: () => ({ onModInputChange: h.noop }),
   makeDspHandlers: () => ({
     onNrModeChange: h.nrMode, onNrLevelChange: h.nrLevel, onNbToggle: h.nbToggle,
     onNbLevelChange: h.nbLevel, onNbDepthChange: h.nbDepth, onNbWidthChange: h.nbWidth,
@@ -179,10 +193,22 @@ afterEach(() => {
 });
 
 describe('the dsp surface mounts only when the view model carries the group', () => {
+  /**
+   * The default/single-composition element sequence with NO dsp group —
+   * i.e. "today" minus this slice. `liveCaps(false)` still declares the
+   * `audio` capability, so `vfo-ops`/`vfo-split-digest` (unrelated VFO
+   * ops row) and the full `rxAudio` surface (MOR-1279) are both present —
+   * this list pins the CURRENT baseline, not a dsp-slice invention.
+   */
   const DEFAULT_PATH_TESTIDS = [
-    'vfo-surface', 'vfo-active-receiver', 'vfo-list',
+    'vfo-surface', 'vfo-active-receiver', 'vfo-list', 'vfo-ops', 'vfo-split-digest',
     'rx-tx-surface', 'rx-tx-state', 'rx-tx-rf-mark', 'rx-tx-rf-label',
     'rx-tx-target', 'rx-tx-key', 'rx-tx-unkey', 'rx-tx-blocked',
+    'rx-audio-surface', 'rx-audio-monitor', 'rx-audio-monitor-local',
+    'rx-audio-monitor-live', 'rx-audio-monitor-mute', 'rx-audio-af', 'rx-audio-af-value',
+    'rx-audio-focus', 'rx-audio-focus-main', 'rx-audio-focus-sub', 'rx-audio-focus-both',
+    'rx-audio-focus-value', 'rx-audio-split', 'rx-audio-split-on', 'rx-audio-split-off',
+    'rx-audio-split-value',
   ];
   const testids = () => [...target.querySelectorAll<HTMLElement>('[data-testid]')]
     .map((el) => el.dataset.testid!)
@@ -203,17 +229,43 @@ describe('the dsp surface mounts only when the view model carries the group', ()
     expect(testids()).toEqual(DEFAULT_PATH_TESTIDS);
   });
 
-  it.each(['single', 'dual'] as const)('mounts the dsp surface when the group is present (%s)', (strips) => {
-    render({ strips });
+  it('mounts the dsp surface when the group is present (single)', () => {
+    render({ strips: 'single' });
     expect(target.querySelectorAll('[data-testid="dsp-surface"]')).toHaveLength(1);
   });
 
-  it('binds no zone id to the dsp surface in either composition', () => {
+  it('renders it bare in the single composition, outside every zone', () => {
+    render({ strips: 'single' });
+    const surface = q('[data-testid="dsp-surface"]')!;
+    expect(surface).not.toBeNull();
+    expect(surface.closest('[data-zone-id]')).toBeNull();
+  });
+
+  /**
+   * MOR-1304/MOR-1305 zone-mount ruling (inverted from the pre-fix-round
+   * shape, which blessed a bare dual mount). `DspSurface` renders up to 8
+   * range inputs and 7 buttons — it is control-bearing, and the cockpit's
+   * MOR-1069 rule forbids mounting any control-bearing surface bare in the
+   * dual composition: every focusable control must live inside a declared
+   * zone, with rx-tx last in the tab order. No manifest declares a `dsp`
+   * zone, so the dual composition renders NO dsp surface at all — same
+   * precedent as `rxAudioSurface`
+   * (`semantic-rx-audio-wiring.component.test.ts`). The view model here DOES
+   * carry the `dsp` group (see `beforeEach`) — a fixture that cannot see the
+   * surface would repeat the bug this fix closes rather than proving its
+   * absence.
+   */
+  it('renders NO dsp surface in the dual composition, zoned or unzoned', () => {
     render({ strips: 'dual' });
-    const zones = [...target.querySelectorAll<HTMLElement>('[data-zone-id]')]
-      .map((el) => el.dataset.zoneId);
-    expect(zones).toEqual(['primary-vfo', 'secondary-vfo', 'global', 'rx-tx']);
-    expect(q('[data-testid="dsp-surface"]')!.closest('[data-zone-id]')).toBeNull();
+    expect(q('[data-testid="dsp-surface"]')).toBeNull();
+    expect(target.innerHTML).not.toContain('dsp-surface');
+  });
+
+  it('leaves the cockpit with no focusable control outside a declared zone', () => {
+    render({ strips: 'dual' });
+    const outside = [...target.querySelectorAll<HTMLElement>('button, input, select, [tabindex]')]
+      .filter((node) => node.closest('[data-zone-id]') === null);
+    expect(outside).toEqual([]);
   });
 });
 

--- a/frontend/src/components-v2/wiring/__tests__/semantic-dsp-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-dsp-wiring.component.test.ts
@@ -92,7 +92,18 @@ vi.mock('../command-bus', () => ({
   // as `makeVfoHandlers`/`makeTxHandlers` above.
   makeRxAudioHandlers: () => ({ onMonitorModeChange: h.noop, onAfLevelChange: h.noop }),
   makeAudioRoutingHandlers: () => ({ onFocusChange: h.noop, onSplitStereoChange: h.noop }),
-  makeModeHandlers: () => ({ onModInputChange: h.noop }),
+  // MOR-1304 — the wiring now also composes the modeFilter/filterPassband
+  // intent vocabulary; `makeModeHandlers` is composed at both call sites
+  // (rxAudio's MOD-input remedy and filterIntents), so the stub carries both.
+  // This fixture declares no filter capability, so none of these is
+  // reachable — same stand-in role as `makeVfoHandlers`/`makeTxHandlers` above.
+  makeModeHandlers: () => ({
+    onModInputChange: h.noop, onModeChange: h.noop, onDataModeChange: h.noop,
+  }),
+  makeFilterHandlers: () => ({
+    onFilterChange: h.noop, onFilterWidthChange: h.noop, onFilterShapeChange: h.noop,
+    onIfShiftChange: h.noop, onPbtInnerChange: h.noop, onPbtOuterChange: h.noop,
+  }),
   makeDspHandlers: () => ({
     onNrModeChange: h.nrMode, onNrLevelChange: h.nrLevel, onNbToggle: h.nbToggle,
     onNbLevelChange: h.nbLevel, onNbDepthChange: h.nbDepth, onNbWidthChange: h.nbWidth,

--- a/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
@@ -91,6 +91,15 @@ vi.mock('../command-bus', () => ({
     onFilterChange: h.noop, onFilterWidthChange: h.noop, onFilterShapeChange: h.noop,
     onIfShiftChange: h.noop, onPbtInnerChange: h.noop, onPbtOuterChange: h.noop,
   }),
+  // MOR-1305 — the wiring now also composes the dsp intent vocabulary. This
+  // fixture declares no dsp capability or state, so none of these is reachable.
+  makeDspHandlers: () => ({
+    onNrModeChange: h.noop, onNrLevelChange: h.noop, onNbToggle: h.noop,
+    onNbLevelChange: h.noop, onNbDepthChange: h.noop, onNbWidthChange: h.noop,
+    onNotchModeChange: h.noop, onNotchFreqChange: h.noop,
+    onManualNotchWidthChange: h.noop, onAgcTimeChange: h.noop,
+  }),
+  makeAgcHandlers: () => ({ onAgcModeChange: h.noop }),
 }));
 
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';

--- a/frontend/src/components-v2/wiring/__tests__/semantic-rx-tx-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rx-tx-wiring.component.test.ts
@@ -47,6 +47,9 @@ const h = vi.hoisted(() => ({
    *  txAux capability and carry no txAux state, so the MOR-1244 evidence gate
    *  omits the group and none of these is ever reachable here. */
   txAuxNoop: vi.fn(),
+  /** MOR-1305: same stand-in role for every dsp intent — no dsp capability
+   *  or state here either, so the group is absent and these are unreachable. */
+  dspNoop: vi.fn(),
 }));
 
 vi.mock('$lib/runtime', () => ({
@@ -115,6 +118,14 @@ vi.mock('../command-bus', () => ({
     onFilterChange: h.txAuxNoop, onFilterWidthChange: h.txAuxNoop, onFilterShapeChange: h.txAuxNoop,
     onIfShiftChange: h.txAuxNoop, onPbtInnerChange: h.txAuxNoop, onPbtOuterChange: h.txAuxNoop,
   }),
+  // MOR-1305 — the wiring now also composes the dsp intent vocabulary.
+  makeDspHandlers: () => ({
+    onNrModeChange: h.dspNoop, onNrLevelChange: h.dspNoop, onNbToggle: h.dspNoop,
+    onNbLevelChange: h.dspNoop, onNbDepthChange: h.dspNoop, onNbWidthChange: h.dspNoop,
+    onNotchModeChange: h.dspNoop, onNotchFreqChange: h.dspNoop,
+    onManualNotchWidthChange: h.dspNoop, onAgcTimeChange: h.dspNoop,
+  }),
+  makeAgcHandlers: () => ({ onAgcModeChange: h.dspNoop }),
 }));
 
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';

--- a/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
@@ -103,6 +103,15 @@ vi.mock('../command-bus', () => ({
     onFilterChange: h.noop, onFilterWidthChange: h.noop, onFilterShapeChange: h.noop,
     onIfShiftChange: h.noop, onPbtInnerChange: h.noop, onPbtOuterChange: h.noop,
   }),
+  // MOR-1305 — the wiring now also composes the dsp intent vocabulary. This
+  // fixture declares no dsp capability or state, so none of these is reachable.
+  makeDspHandlers: () => ({
+    onNrModeChange: h.noop, onNrLevelChange: h.noop, onNbToggle: h.noop,
+    onNbLevelChange: h.noop, onNbDepthChange: h.noop, onNbWidthChange: h.noop,
+    onNotchModeChange: h.noop, onNotchFreqChange: h.noop,
+    onManualNotchWidthChange: h.noop, onAgcTimeChange: h.noop,
+  }),
+  makeAgcHandlers: () => ({ onAgcModeChange: h.noop }),
 }));
 
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';

--- a/frontend/src/presentation/layouts/__tests__/dsp-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/dsp-declarability.test.ts
@@ -1,0 +1,52 @@
+/**
+ * MOR-1305 — `dsp` is DECLARABLE, and nothing declares it yet.
+ *
+ * Slice 5B adds the name to `SEMANTIC_SURFACE_NAMES` so a manifest CAN mount
+ * the surface later; it deliberately does not touch any manifest. Mirrors
+ * `tx-aux-declarability.test.ts`/`meters-declarability.test.ts`.
+ */
+import { describe, it, expect } from 'vitest';
+import { SEMANTIC_SURFACE_NAMES, validateLayoutManifest } from '../contract';
+import { validLayoutManifest } from './fixtures';
+import {
+  desktopV2Layout, dualReceiverCockpitLayout, lcdCockpitLayout, lcdScopeLayout, mobileLayout,
+  sdrTestLayout,
+} from '../declarations';
+
+describe('dsp is a declarable semantic surface', () => {
+  // Kills: reverting the SEMANTIC_SURFACE_NAMES addition, or reordering the
+  // existing names — other B-slices append their own name concurrently at
+  // this same line, so an accidental reorder here is the merge conflict this
+  // slice must not create.
+  it('is in the declarable set alongside vfo, rxTx, txAux, meters and rxAudio', () => {
+    expect([...SEMANTIC_SURFACE_NAMES]).toEqual([
+      'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp',
+    ]);
+  });
+
+  it('accepts a manifest zone that declares it', () => {
+    const manifest = validLayoutManifest({
+      zones: [{ id: 'main', surfaces: ['vfo', 'rxTx', 'dsp'] }],
+      requiredSemanticSurfaces: ['vfo', 'rxTx'],
+    });
+    expect(() => validateLayoutManifest(manifest)).not.toThrow();
+  });
+
+  it('still rejects a zone naming a surface that does not exist', () => {
+    const manifest = validLayoutManifest({
+      zones: [{ id: 'main', surfaces: ['dspLegacy'] as unknown as readonly ['vfo'] }],
+    });
+    expect(() => validateLayoutManifest(manifest)).toThrow(/subset of/);
+  });
+});
+
+describe('no shipped manifest declares a dsp zone in this slice', () => {
+  it.each([
+    ['sdr-test', sdrTestLayout], ['dual-receiver-cockpit', dualReceiverCockpitLayout],
+    ['lcd-cockpit', lcdCockpitLayout], ['lcd-scope', lcdScopeLayout],
+    ['mobile', mobileLayout], ['desktop-v2', desktopV2Layout],
+  ])('%s declares no dsp zone and does not require the surface', (_id, manifest) => {
+    for (const zone of manifest.zones) expect(zone.surfaces).not.toContain('dsp');
+    expect(manifest.requiredSemanticSurfaces).not.toContain('dsp');
+  });
+});

--- a/frontend/src/presentation/layouts/__tests__/filter-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/filter-declarability.test.ts
@@ -22,7 +22,9 @@ import {
 describe('filter is a declarable semantic surface', () => {
   // Kills: reverting the SEMANTIC_SURFACE_NAMES addition.
   it('is in the declarable set alongside vfo, rxTx, txAux, meters and rxAudio', () => {
-    expect([...SEMANTIC_SURFACE_NAMES]).toEqual(['vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter']);
+    expect([...SEMANTIC_SURFACE_NAMES]).toEqual([
+      'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp',
+    ]);
   });
 
   // Kills: adding the name to the type but not to the runtime allow-list the

--- a/frontend/src/presentation/layouts/__tests__/meters-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/meters-declarability.test.ts
@@ -24,9 +24,12 @@ import {
 } from '../declarations';
 
 describe('meters is a declarable semantic surface', () => {
-  // Kills: reverting the SEMANTIC_SURFACE_NAMES addition.
+  // Kills: reverting the SEMANTIC_SURFACE_NAMES addition. MOR-1305 appended
+  // `dsp`; `meters` must stay present and in place.
   it('is in the declarable set alongside vfo, rxTx and txAux', () => {
-    expect([...SEMANTIC_SURFACE_NAMES]).toEqual(['vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter']);
+    expect([...SEMANTIC_SURFACE_NAMES]).toEqual([
+      'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp',
+    ]);
   });
 
   // Kills: adding the name to the type but not to the runtime allow-list the

--- a/frontend/src/presentation/layouts/__tests__/rx-audio-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/rx-audio-declarability.test.ts
@@ -24,7 +24,9 @@ import {
 describe('rxAudio is a declarable semantic surface', () => {
   // Kills: reverting the SEMANTIC_SURFACE_NAMES addition.
   it('is in the declarable set alongside vfo, rxTx, txAux and meters', () => {
-    expect([...SEMANTIC_SURFACE_NAMES]).toEqual(['vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter']);
+    expect([...SEMANTIC_SURFACE_NAMES]).toEqual([
+      'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp',
+    ]);
   });
 
   // Kills: adding the name to the type but not to the runtime allow-list the

--- a/frontend/src/presentation/layouts/__tests__/tx-aux-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/tx-aux-declarability.test.ts
@@ -25,10 +25,12 @@ import {
 
 describe('txAux is a declarable semantic surface', () => {
   // Kills: reverting the SEMANTIC_SURFACE_NAMES addition. MOR-1273 appended
-  // `meters`, MOR-1304 appended `filter`; `txAux` must stay present and in
-  // place.
+  // `meters`, MOR-1304 appended `filter`, MOR-1305 appended `dsp`; `txAux`
+  // must stay present and in place.
   it('is in the declarable set alongside vfo and rxTx', () => {
-    expect([...SEMANTIC_SURFACE_NAMES]).toEqual(['vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter']);
+    expect([...SEMANTIC_SURFACE_NAMES]).toEqual([
+      'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp',
+    ]);
   });
 
   // Kills: adding the name to the type but not to the runtime allow-list the

--- a/frontend/src/presentation/layouts/contract.ts
+++ b/frontend/src/presentation/layouts/contract.ts
@@ -14,14 +14,14 @@ import { isValidLanguageId as isValidProductId } from '../languages/contract';
 
 /** Semantic surfaces a layout may mount (MOR-1062/1065 reference vertical;
  *  `txAux` added by MOR-1265, `meters` by MOR-1273, `rxAudio` by MOR-1279,
- *  `filter` by MOR-1304). Adding a name makes it DECLARABLE — it does not
- *  mount anything by itself, and no manifest declares a `meters`, `rxAudio`
- *  or `filter` zone yet (the cockpit declares only `txAux`, as `tx-aux` —
- *  MOR-1336). Distinct from the design-language renderer slot of the same
- *  name (`languages/contract.ts`'s `RENDERER_SLOT_NAMES`): that one says how
- *  a language DRAWS a meter, this one says which layout zone may HOST the
- *  surface. */
-export const SEMANTIC_SURFACE_NAMES = ['vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter'] as const;
+ *  `filter` by MOR-1304, `dsp` by MOR-1305). Adding a name makes it
+ *  DECLARABLE — it does not mount anything by itself, and no manifest
+ *  declares a `meters`, `rxAudio`, `filter` or `dsp` zone yet (the cockpit
+ *  declares only `txAux`, as `tx-aux` — MOR-1336). Distinct from the
+ *  design-language renderer slot of the same name (`languages/contract.ts`'s
+ *  `RENDERER_SLOT_NAMES`): that one says how a language DRAWS a meter, this
+ *  one says which layout zone may HOST the surface. */
+export const SEMANTIC_SURFACE_NAMES = ['vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp'] as const;
 export type SemanticSurfaceName = (typeof SEMANTIC_SURFACE_NAMES)[number];
 
 /**

--- a/frontend/src/semantic/DspSurface.svelte
+++ b/frontend/src/semantic/DspSurface.svelte
@@ -1,0 +1,195 @@
+<!--
+  Semantic DSP surface (MOR-1305, vocabulary slice 5B).
+
+  Presentation only. It renders the MOR-1290 `dsp` fact group — NR
+  (active/level), NB (active/level/depth/width), notch (mode/freq/manual
+  width), AGC (mode/choice set/time constant) — and emits control intents as
+  callbacks. It holds no state and consults no controller (v3 ADR invariant
+  11), the same discipline `TxAuxSurface` (MOR-1265) established.
+
+  CARRY-FORWARDS (binding, from the MOR-1290 fact-layer decisions this
+  surface must not relax):
+
+  (1) `agcLabels`/`nbLevelMax`/`nbLevelPercent` are NOT facts — pure
+      caps-echo display metadata (a slider ceiling and a percent-vs-raw
+      display choice, `lib/runtime/props/panel-props.ts`'s own `toDspProps`
+      precedent). They arrive as plain props, read directly off `caps` at the
+      wiring seam (`SemanticRadioSurfaces.svelte`, which already holds
+      `runtime.caps` for the view-model adapter call) — never folded into
+      `DspViewModel`, and never re-derived here from a capabilities import
+      this file is not allowed to hold.
+  (2) `agcTimeConstant` may be `structural: true` with no real control on a
+      radio that borrows the `agc` capability tag optimistically. That is an
+      accepted fact-layer optimism, not something this surface special-cases
+      — a present-but-never-observed field renders exactly like any other
+      unobserved present field, honestly disabled.
+  (3) Every reading here is rendered exactly as the fact group states it. No
+      range-fallback plumbing, no re-derivation of `controlRangeFromCaps` —
+      `nrLevel`/`nbDepth` already arrive display-scaled from the adapter.
+  (4) `unknown` renders as `?`, never as a v2 fabricated default (0 dB, OFF,
+      WIDE) — same fail-closed-presentation doctrine as `TxAuxSurface`.
+
+  Two-level availability (MOR-977/1256): `structural: false` renders NOTHING;
+  a present-but-unusable control stays visible and disabled rather than
+  guessing a value.
+-->
+<script module lang="ts">
+  import type { DspField } from './radio-view-model';
+  import { buildAgcOptions } from '../components-v2/panels/agc-utils';
+  import { NOTCH_WIDTH_LABELS, formatAgcTime } from '../components-v2/panels/dsp-panel-logic';
+  import { rawToPercentDisplay } from '../components-v2/controls/value-control/value-control-core';
+
+  /** On/off controls, `[field, label]`. */
+  export const DSP_TOGGLES = [['nrActive', 'NR'], ['nbActive', 'NB']] as const;
+  /** `[field, label, min, max, step, format?]` — `nrLevel`/`nbDepth` are
+   *  ALREADY the adapter's display-scaled values (carry-forward 3); the rest
+   *  are raw wire ranges, verbatim `DspPanel.svelte`'s own slider bounds.
+   *  `nbLevel` is excluded — its ceiling is the caps-echoed `nbLevelMax` prop,
+   *  not a static bound, and is rendered separately below. */
+  export const DSP_LEVELS = [
+    ['nrLevel', 'NR level', 0, 15, 1],
+    ['nbDepth', 'NB depth', 1, 10, 1],
+    ['nbWidth', 'NB width', 0, 255, 1],
+    ['notchFreq', 'Notch freq', 0, 3000, 1],
+    ['manualNotchWidth', 'Notch width', 0, 2, 1, (v: number) => NOTCH_WIDTH_LABELS[v] ?? String(v)],
+    ['agcTimeConstant', 'AGC time', 0, 9, 1, formatAgcTime],
+  ] as const;
+  export type DspToggleField = (typeof DSP_TOGGLES)[number][0];
+  export type DspLevelField = (typeof DSP_LEVELS)[number][0] | 'nbLevel';
+  const NOTCH_MODES = ['off', 'auto', 'manual'] as const;
+
+  /** Usable ⇔ the radio HAS it, it is readable NOW, and it has been observed. */
+  const usable = (f: DspField<unknown>): boolean =>
+    f.availability.structural && f.availability.operational && f.reading.status === 'known';
+  const reasonOf = (f: DspField<unknown>): 'field-not-observed' | undefined =>
+    usable(f) ? undefined : 'field-not-observed';
+  const numberOf = (f: DspField<number>, fallback: number): number =>
+    f.reading.status === 'known' ? f.reading.value : fallback;
+  const fmt = (f: DspField<unknown>, format?: (v: number) => string): string => {
+    if (f.reading.status !== 'known') return '?';
+    const v = f.reading.value;
+    return typeof v === 'boolean' ? (v ? 'on' : 'off') : format ? format(v as number) : String(v);
+  };
+  const pressedOf = (f: DspField<unknown>): boolean | undefined =>
+    f.reading.status === 'known' ? f.reading.value !== false : undefined;
+</script>
+
+<script lang="ts">
+  import type { RadioViewModel } from './radio-view-model';
+
+  interface Props {
+    view: RadioViewModel;
+    agcLabels?: Record<string, string>;
+    nbLevelMax?: number;
+    nbLevelPercent?: boolean;
+    onToggle?: (field: DspToggleField, next: boolean) => void;
+    onLevelChange?: (field: DspLevelField, value: number) => void;
+    onNotchModeChange?: (mode: 'off' | 'auto' | 'manual') => void;
+    onAgcModeChange?: (mode: number) => void;
+  }
+  let {
+    view, agcLabels = {}, nbLevelMax = 255, nbLevelPercent = false,
+    onToggle, onLevelChange, onNotchModeChange, onAgcModeChange,
+  }: Props = $props();
+
+  /** Absent group ⇒ this surface renders nothing (S0 optional-group doctrine). */
+  let dsp = $derived(view.dsp);
+  let agcOptions = $derived(dsp ? buildAgcOptions([...dsp.agcModes], agcLabels) : []);
+  let nbLevelFormat = $derived(
+    nbLevelPercent ? (v: number) => rawToPercentDisplay(v, 0, nbLevelMax) : undefined,
+  );
+
+  function toggle(field: DspToggleField): void {
+    const f = dsp?.[field];
+    if (f && usable(f) && f.reading.status === 'known') onToggle?.(field, !f.reading.value);
+  }
+  function level(field: DspLevelField, value: number): void {
+    if (dsp && usable(dsp[field])) onLevelChange?.(field, value);
+  }
+  function notch(mode: (typeof NOTCH_MODES)[number]): void {
+    if (dsp && usable(dsp.notchMode)) onNotchModeChange?.(mode);
+  }
+  function agc(mode: number): void {
+    if (dsp && usable(dsp.agcMode)) onAgcModeChange?.(mode);
+  }
+</script>
+
+{#if dsp}
+  <section class="dsp-surface" data-testid="dsp-surface" aria-label="DSP controls">
+    <div class="dsp-row">
+      {#each DSP_TOGGLES as [field, label] (field)}
+        {#if dsp[field].availability.structural}
+          <button
+            type="button" class="dsp-toggle" data-testid={`dsp-${field}`} data-field={field}
+            data-disabled-reason={reasonOf(dsp[field])} aria-pressed={pressedOf(dsp[field])}
+            disabled={!usable(dsp[field])} onclick={() => toggle(field)}
+          >{label}: {fmt(dsp[field])}</button>
+        {/if}
+      {/each}
+    </div>
+
+    {#each DSP_LEVELS as [field, label, min, max, step, format] (field)}
+      {#if dsp[field].availability.structural}
+        <label
+          class="dsp-level" data-testid={`dsp-${field}`} data-field={field}
+          data-disabled-reason={reasonOf(dsp[field])}
+        >
+          <span class="dsp-name">{label}</span>
+          <input
+            type="range" {min} {max} {step} value={numberOf(dsp[field], min)}
+            disabled={!usable(dsp[field])}
+            oninput={(event) => level(field, event.currentTarget.valueAsNumber)}
+          />
+          <output>{fmt(dsp[field], format)}</output>
+        </label>
+      {/if}
+    {/each}
+
+    {#if dsp.nbLevel.availability.structural}
+      <label class="dsp-level" data-testid="dsp-nbLevel" data-field="nbLevel" data-disabled-reason={reasonOf(dsp.nbLevel)}>
+        <span class="dsp-name">NB level</span>
+        <input
+          type="range" min={0} max={nbLevelMax} step={1} value={numberOf(dsp.nbLevel, 0)}
+          disabled={!usable(dsp.nbLevel)}
+          oninput={(event) => level('nbLevel', event.currentTarget.valueAsNumber)}
+        />
+        <output>{fmt(dsp.nbLevel, nbLevelFormat)}</output>
+      </label>
+    {/if}
+
+    {#if dsp.notchMode.availability.structural}
+      <div class="dsp-row" data-testid="dsp-notchMode" data-disabled-reason={reasonOf(dsp.notchMode)}>
+        {#each NOTCH_MODES as mode (mode)}
+          <button
+            type="button" class="dsp-choice" data-testid={`dsp-notchMode-${mode}`}
+            aria-pressed={dsp.notchMode.reading.status === 'known' && dsp.notchMode.reading.value === mode}
+            disabled={!usable(dsp.notchMode)} onclick={() => notch(mode)}
+          >{mode}</button>
+        {/each}
+      </div>
+    {/if}
+
+    {#if dsp.agcMode.availability.structural}
+      <div class="dsp-row" data-testid="dsp-agcMode" data-disabled-reason={reasonOf(dsp.agcMode)}>
+        {#each agcOptions as option (option.value)}
+          <button
+            type="button" class="dsp-choice" data-testid={`dsp-agcMode-${option.value}`}
+            aria-pressed={dsp.agcMode.reading.status === 'known' && dsp.agcMode.reading.value === option.value}
+            disabled={!usable(dsp.agcMode)} onclick={() => agc(option.value)}
+          >{option.label}</button>
+        {/each}
+      </div>
+    {/if}
+  </section>
+{/if}
+
+<style>
+  /* Structure only — a design language owns colour and must never become the
+     sole state channel (MOR-977, forced-colors). */
+  .dsp-surface { display: flex; flex-direction: column; gap: 0.25rem; }
+  .dsp-row { display: flex; flex-wrap: wrap; gap: 0.5rem; }
+  .dsp-level { display: flex; align-items: baseline; gap: 0.5rem; }
+  .dsp-name { min-width: 8ch; }
+  .dsp-toggle[aria-pressed='true'], .dsp-choice[aria-pressed='true'] { font-weight: 700; }
+  .dsp-toggle:disabled, .dsp-choice:disabled { cursor: not-allowed; }
+</style>

--- a/frontend/src/semantic/__tests__/DspSurface.test.ts
+++ b/frontend/src/semantic/__tests__/DspSurface.test.ts
@@ -1,0 +1,339 @@
+/**
+ * MOR-1305 — the semantic DSP surface (vocabulary slice 5B).
+ *
+ * Carry-forward pins from the MOR-1290 fact-layer decisions this surface must
+ * not relax (see `DspSurface.svelte`'s header for the full statement):
+ *  (1) `agcLabels`/`nbLevelMax`/`nbLevelPercent` arrive as plain props, never
+ *      read off a capabilities import inside this file — block 5.
+ *  (2) a structurally-present, never-observed `agcTimeConstant` renders like
+ *      any other unobserved present field — no special-casing — block 2.
+ *  (3) every reading renders exactly as the fact group states it — no local
+ *      rescale of `nrLevel`/`nbDepth` — block 6.
+ *  (4) `unknown` renders as `?`, never a v2 fabricated default — block 2.
+ */
+import { readFileSync } from 'node:fs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import DspSurface, { DSP_LEVELS, DSP_TOGGLES, type DspLevelField, type DspToggleField } from '../DspSurface.svelte';
+import { topologyFixtures, withDsp } from '../fixtures/topologies';
+import type { Availability, DspViewModel, RadioViewModel } from '../radio-view-model';
+
+/** `1/single` + a fully-observed dsp group (nrActive true, nbActive false —
+ *  both toggles exercised at least once by the base fixture). */
+const base = (): RadioViewModel => withDsp(topologyFixtures['1/single']);
+
+type AnyField = keyof DspViewModel;
+const NUMERIC_FIELDS: readonly AnyField[] = [
+  ...DSP_TOGGLES.map(([f]) => f), ...DSP_LEVELS.map(([f]) => f), 'nbLevel',
+] as readonly AnyField[];
+
+/** Re-shape ONE dsp field of an otherwise fully-available fixture. */
+function withField(
+  view: RadioViewModel, field: AnyField,
+  over: { availability?: Availability; unknown?: boolean },
+): RadioViewModel {
+  const dsp = view.dsp!;
+  const current = dsp[field] as { reading: unknown; availability: Availability };
+  return {
+    ...view,
+    dsp: {
+      ...dsp,
+      [field]: {
+        reading: over.unknown ? { status: 'unknown' } : current.reading,
+        availability: over.availability ?? current.availability,
+      },
+    } as DspViewModel,
+  };
+}
+
+let target: HTMLDivElement;
+beforeEach(() => { target = document.createElement('div'); document.body.appendChild(target); });
+afterEach(() => { target.remove(); });
+
+type Handlers = {
+  onToggle?: (field: DspToggleField, next: boolean) => void;
+  onLevelChange?: (field: DspLevelField, value: number) => void;
+  onNotchModeChange?: (mode: 'off' | 'auto' | 'manual') => void;
+  onAgcModeChange?: (mode: number) => void;
+};
+type Props = Handlers & { agcLabels?: Record<string, string>; nbLevelMax?: number; nbLevelPercent?: boolean };
+
+function render(view: RadioViewModel, props: Props = {}) {
+  const component = mount(DspSurface, { target, props: { view, ...props } });
+  flushSync();
+  const q = <T extends HTMLElement>(sel: string) => target.querySelector(sel) as T | null;
+  return {
+    dispose: () => unmount(component),
+    root: () => q('[data-testid="dsp-surface"]'),
+    control: (field: string) => q<HTMLElement>(`[data-testid="dsp-${field}"]`),
+    input: (field: string) => q<HTMLInputElement>(`[data-testid="dsp-${field}"] input`),
+    notchButton: (mode: string) => q<HTMLButtonElement>(`[data-testid="dsp-notchMode-${mode}"]`),
+    agcButton: (mode: number) => q<HTMLButtonElement>(`[data-testid="dsp-agcMode-${mode}"]`),
+  };
+}
+
+function withSurface(view: RadioViewModel, fn: (s: ReturnType<typeof render>) => void, props: Props = {}): void {
+  const s = render(view, props);
+  try { fn(s); } finally { s.dispose(); }
+}
+
+/** `disabled` for a <button>, or for the <input> a level control wraps. */
+function isDisabled(s: ReturnType<typeof render>, field: string): boolean {
+  const el = s.control(field)!;
+  if (el instanceof HTMLButtonElement) return el.disabled;
+  return s.input(field)!.disabled;
+}
+
+// ── 1. Structural gating: absent, never a disabled promise ─────────────────
+
+describe('structural availability decides whether a control EXISTS', () => {
+  it.each(NUMERIC_FIELDS)('renders no control at all for a structurally absent "%s"', (field) => {
+    const view = withField(base(), field, { availability: { structural: false, operational: false } });
+    withSurface(view, (s) => {
+      expect(s.control(field)).toBeNull();
+      expect(s.root()).not.toBeNull();
+    });
+  });
+
+  it.each(NUMERIC_FIELDS)('renders an enabled control for a fully available "%s"', (field) => {
+    withSurface(base(), (s) => {
+      expect(s.control(field)).not.toBeNull();
+      expect(isDisabled(s, field)).toBe(false);
+    });
+  });
+
+  it('renders nothing for a view model carrying no dsp group', () => {
+    const view = { ...topologyFixtures['1/single'] };
+    withSurface(view as RadioViewModel, (s) => {
+      expect(s.root()).toBeNull();
+      expect(target.querySelectorAll('button, input')).toHaveLength(0);
+    });
+  });
+
+  it('renders no notchMode/agcMode control when structurally absent', () => {
+    const view = withField(withField(base(), 'notchMode', {
+      availability: { structural: false, operational: false },
+    }), 'agcMode', { availability: { structural: false, operational: false } });
+    withSurface(view, (s) => {
+      expect(s.notchButton('off')).toBeNull();
+      expect(s.agcButton(1)).toBeNull();
+    });
+  });
+});
+
+// ── 2. Operational gating + unknown-honesty (carry-forwards 2 and 4) ───────
+
+describe('operational availability decides whether a control is USABLE', () => {
+  it.each(NUMERIC_FIELDS)('keeps "%s" present but disabled when only operationally unavailable', (field) => {
+    const view = withField(base(), field, { availability: { structural: true, operational: false } });
+    withSurface(view, (s) => {
+      expect(s.control(field)).not.toBeNull();
+      expect(isDisabled(s, field)).toBe(true);
+      expect(s.control(field)!.dataset.disabledReason).toBe('field-not-observed');
+    });
+  });
+
+  // Carry-forward (4): an unobserved reading renders '?', never a v2 default
+  // (0 dB, OFF, WIDE) — and never enables the control either.
+  it.each(NUMERIC_FIELDS)('renders "?" and disables "%s" on an unobserved reading', (field) => {
+    const view = withField(base(), field, { unknown: true });
+    withSurface(view, (s) => {
+      expect(isDisabled(s, field)).toBe(true);
+      const text = s.control(field)!.textContent ?? '';
+      expect(text).toContain('?');
+    });
+  });
+
+  // Carry-forward (2): `agcTimeConstant` structurally present but never
+  // observed renders exactly like any other honest present-unobserved field —
+  // no special-casing for the borrowed-capability optimism.
+  it('renders agcTimeConstant present-and-disabled, not hidden, when unobserved', () => {
+    const view = withField(base(), 'agcTimeConstant', { unknown: true });
+    withSurface(view, (s) => {
+      expect(s.control('agcTimeConstant')).not.toBeNull();
+      expect(isDisabled(s, 'agcTimeConstant')).toBe(true);
+    });
+  });
+
+  it('disables notchMode/agcMode buttons on an unobserved reading', () => {
+    const view = withField(withField(base(), 'notchMode', { unknown: true }), 'agcMode', { unknown: true });
+    withSurface(view, (s) => {
+      expect(s.notchButton('off')!.disabled).toBe(true);
+      expect(s.agcButton(1)!.disabled).toBe(true);
+    });
+  });
+});
+
+// ── 3. Toggle intents: nrActive/nbActive compute their own next value ──────
+
+describe('toggle intents compute the next boolean from the current reading', () => {
+  it('emits (field, next) flipping the current value', () => {
+    const onToggle = vi.fn();
+    // base(): nrActive known(true), nbActive known(false).
+    withSurface(base(), (s) => {
+      s.control('nrActive')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      flushSync();
+      expect(onToggle).toHaveBeenCalledExactlyOnceWith('nrActive', false);
+      s.control('nbActive')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      flushSync();
+      expect(onToggle).toHaveBeenNthCalledWith(2, 'nbActive', true);
+    }, { onToggle });
+  });
+
+  // MUTATION KILLED: toggling from an unobserved reading — the next value
+  // would be a coin flip presented as a confirmed command.
+  it('emits nothing when the reading is unobserved', () => {
+    const onToggle = vi.fn();
+    const view = withField(base(), 'nrActive', { unknown: true });
+    withSurface(view, (s) => {
+      s.control('nrActive')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      flushSync();
+      expect(onToggle).not.toHaveBeenCalled();
+    }, { onToggle });
+  });
+});
+
+// ── 4. Level intents carry the field and the raw value ─────────────────────
+
+describe('level intents reach the caller with the field and the raw value', () => {
+  it.each(DSP_LEVELS)('emits (%s, value) on input with the declared range', (field, _label, min, max, step, _fmt?) => {
+    const onLevelChange = vi.fn();
+    withSurface(base(), (s) => {
+      const input = s.input(field)!;
+      expect(input.min).toBe(String(min));
+      expect(input.max).toBe(String(max));
+      expect(input.step).toBe(String(step));
+      input.value = String(min);
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      flushSync();
+      expect(onLevelChange).toHaveBeenCalledExactlyOnceWith(field, min);
+    }, { onLevelChange });
+  });
+
+  it('passes reading values through unrescaled (carry-forward 3)', () => {
+    // withDsp(): nrLevel 8, nbDepth 5 — the adapter's own display-scaled
+    // values; this surface must show them verbatim, never re-derive a scale.
+    withSurface(base(), (s) => {
+      expect(s.input('nrLevel')!.valueAsNumber).toBe(8);
+      expect(s.input('nbDepth')!.valueAsNumber).toBe(5);
+    });
+  });
+});
+
+// ── 5. Range-parameterisation: nbLevel takes its ceiling from caps-echo props ─
+
+describe('nbLevel is range-parameterised by the caps-echoed nbLevelMax/nbLevelPercent props', () => {
+  it('uses the default 0..255 raw range when no props are supplied', () => {
+    withSurface(base(), (s) => {
+      expect(s.input('nbLevel')!.max).toBe('255');
+      expect(s.input('nbLevel')!.valueAsNumber).toBe(64); // withDsp() fixture value
+      expect(s.control('nbLevel')!.textContent).toContain('64');
+    });
+  });
+
+  it('uses a caller-supplied ceiling (FTX-1-shaped: native 0..10, raw display)', () => {
+    withSurface(base(), (s) => {
+      expect(s.input('nbLevel')!.max).toBe('10');
+      // Raw pass-through display (carry-forward 3): the fixture's raw
+      // reading (64) renders verbatim, regardless of the ceiling prop.
+      expect(s.control('nbLevel')!.textContent).toContain('64');
+    }, { nbLevelMax: 10, nbLevelPercent: false });
+  });
+
+  it('renders a percent display when nbLevelPercent is true', () => {
+    withSurface(base(), (s) => {
+      // 64 / 255 rounds to 25%.
+      expect(s.control('nbLevel')!.textContent).toContain('25%');
+    }, { nbLevelMax: 255, nbLevelPercent: true });
+  });
+
+  it('emits the raw nbLevel value unrescaled regardless of display mode', () => {
+    const onLevelChange = vi.fn();
+    withSurface(base(), (s) => {
+      const input = s.input('nbLevel')!;
+      input.value = '5';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      flushSync();
+      expect(onLevelChange).toHaveBeenCalledExactlyOnceWith('nbLevel', 5);
+    }, { onLevelChange, nbLevelMax: 10, nbLevelPercent: false });
+  });
+});
+
+// ── 6. notchMode: a three-way choice, not a boolean toggle ──────────────────
+
+describe('notchMode renders as a three-way choice', () => {
+  it('marks the current value pressed and the others not', () => {
+    // withDsp(): notchMode 'off'.
+    withSurface(base(), (s) => {
+      expect(s.notchButton('off')!.getAttribute('aria-pressed')).toBe('true');
+      expect(s.notchButton('auto')!.getAttribute('aria-pressed')).toBe('false');
+      expect(s.notchButton('manual')!.getAttribute('aria-pressed')).toBe('false');
+    });
+  });
+
+  it('emits the clicked mode verbatim', () => {
+    const onNotchModeChange = vi.fn();
+    withSurface(base(), (s) => {
+      s.notchButton('manual')!.click();
+      flushSync();
+      expect(onNotchModeChange).toHaveBeenCalledExactlyOnceWith('manual');
+    }, { onNotchModeChange });
+  });
+
+  it('emits nothing when clicked on an unobserved reading', () => {
+    const onNotchModeChange = vi.fn();
+    const view = withField(base(), 'notchMode', { unknown: true });
+    withSurface(view, (s) => {
+      s.notchButton('auto')!.click();
+      flushSync();
+      expect(onNotchModeChange).not.toHaveBeenCalled();
+    }, { onNotchModeChange });
+  });
+});
+
+// ── 7. agcMode: dynamic choice set from the fact group + caps-echoed labels ──
+
+describe('agcMode renders the capability-derived choice set with caps-echoed labels', () => {
+  it('renders one button per agcModes entry plus OFF, labelled from agcLabels', () => {
+    // withDsp(): agcModes [1, 2, 3], agcMode known(2).
+    withSurface(base(), (s) => {
+      expect(s.agcButton(0)!.textContent).toBe('OFF');
+      expect(s.agcButton(1)!.textContent).toBe('FAST');
+      expect(s.agcButton(2)!.textContent).toBe('MID');
+      expect(s.agcButton(3)!.textContent).toBe('SLOW');
+      expect(s.agcButton(2)!.getAttribute('aria-pressed')).toBe('true');
+      expect(s.agcButton(1)!.getAttribute('aria-pressed')).toBe('false');
+    }, { agcLabels: { '1': 'FAST', '2': 'MID', '3': 'SLOW' } });
+  });
+
+  it('falls back to the raw ordinal when no label is supplied', () => {
+    withSurface(base(), (s) => {
+      expect(s.agcButton(1)!.textContent).toBe('1');
+    }, { agcLabels: {} });
+  });
+
+  it('emits the clicked mode verbatim', () => {
+    const onAgcModeChange = vi.fn();
+    withSurface(base(), (s) => {
+      s.agcButton(1)!.click();
+      flushSync();
+      expect(onAgcModeChange).toHaveBeenCalledExactlyOnceWith(1);
+    }, { onAgcModeChange });
+  });
+});
+
+// ── 8. Presentation-only: no store, transport or command import ────────────
+
+describe('this surface stays presentation-only', () => {
+  const withoutComments = (source: string): string => source
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/^\s*\/\/.*$/gm, '');
+  const source = withoutComments(readFileSync('src/semantic/DspSurface.svelte', 'utf8'));
+
+  it('imports no transport, store or command-bus module', () => {
+    expect(source).not.toMatch(/\$lib\/transport/);
+    expect(source).not.toMatch(/\$lib\/stores/);
+    expect(source).not.toMatch(/command-bus/);
+  });
+});

--- a/frontend/src/semantic/__tests__/DspSurface.test.ts
+++ b/frontend/src/semantic/__tests__/DspSurface.test.ts
@@ -26,6 +26,14 @@ type AnyField = keyof DspViewModel;
 const NUMERIC_FIELDS: readonly AnyField[] = [
   ...DSP_TOGGLES.map(([f]) => f), ...DSP_LEVELS.map(([f]) => f), 'nbLevel',
 ] as readonly AnyField[];
+/** The thumb position an unread level control MUST claim (MOR-1304/1305 F2)
+ *  — `numberOf`'s own fallback, verbatim, so a fallback-value mutation is
+ *  pinned rather than left free to claim any position. `nbLevel` falls back
+ *  to `0` (its own literal in `DspSurface.svelte`), not its declared min. */
+const LEVEL_FALLBACK: Partial<Record<AnyField, number>> = {
+  ...Object.fromEntries(DSP_LEVELS.map(([f, , min]) => [f, min])),
+  nbLevel: 0,
+};
 
 /** Re-shape ONE dsp field of an otherwise fully-available fixture. */
 function withField(
@@ -141,8 +149,29 @@ describe('operational availability decides whether a control is USABLE', () => {
       expect(isDisabled(s, field)).toBe(true);
       const text = s.control(field)!.textContent ?? '';
       expect(text).toContain('?');
+      // MOR-1304/1305 F2: the rendered slider THUMB of an unread level is not
+      // free to claim any position — it must sit at the field's declared
+      // fallback (`numberOf`'s own default), never a mutated stand-in value.
+      const input = s.input(field);
+      if (input) expect(input.value).toBe(String(LEVEL_FALLBACK[field]));
     });
   });
+
+  // MOR-1304/1305 N1/MD7: `pressedOf` must return `undefined` — never `false`
+  // — for an unobserved toggle reading, so Svelte OMITS `aria-pressed`
+  // entirely. `aria-pressed="false"` is not the absence of a claim, it is the
+  // claim "this control is OFF" about a reading the radio never reported —
+  // carry-forward 4's exact prohibition, applied to the attribute as well as
+  // the visible text.
+  it.each(DSP_TOGGLES.map(([f]) => f))(
+    'never fabricates aria-pressed=false for an unobserved toggle "%s"',
+    (field) => {
+      const view = withField(base(), field, { unknown: true });
+      withSurface(view, (s) => {
+        expect(s.control(field)!.getAttribute('aria-pressed')).toBeNull();
+      });
+    },
+  );
 
   // Carry-forward (2): `agcTimeConstant` structurally present but never
   // observed renders exactly like any other honest present-unobserved field —
@@ -218,6 +247,28 @@ describe('level intents reach the caller with the field and the raw value', () =
       expect(s.input('nbDepth')!.valueAsNumber).toBe(5);
     });
   });
+
+  /**
+   * MOR-1304/1305 F3: the `level()` handler guard must reject an unusable
+   * field on its OWN, independently of the `disabled` attribute. A plain
+   * `.click()`/native interaction never reaches a disabled control's handler
+   * at all, which would let this test pass even if the in-component guard
+   * were deleted — so the input event is dispatched directly, the same
+   * bypass a determined operator's assistive tech or a stray event listener
+   * could still trigger.
+   */
+  it('emits nothing when the level reading is unobserved, even bypassing disabled', () => {
+    const onLevelChange = vi.fn();
+    const view = withField(base(), 'nrLevel', { unknown: true });
+    withSurface(view, (s) => {
+      const input = s.input('nrLevel')!;
+      expect(input.disabled).toBe(true);
+      input.value = '9';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      flushSync();
+      expect(onLevelChange).not.toHaveBeenCalled();
+    }, { onLevelChange });
+  });
 });
 
 // ── 5. Range-parameterisation: nbLevel takes its ceiling from caps-echo props ─
@@ -280,11 +331,20 @@ describe('notchMode renders as a three-way choice', () => {
     }, { onNotchModeChange });
   });
 
-  it('emits nothing when clicked on an unobserved reading', () => {
+  /**
+   * MOR-1304/1305 F3: `.click()` on a disabled button never reaches its
+   * `onclick` handler at all — a no-op that would pass this assertion even
+   * with the `notch()` guard deleted. Dispatching the click event directly
+   * proves the GUARD rejects it, not merely that `disabled` suppressed the
+   * interaction.
+   */
+  it('emits nothing when clicked on an unobserved reading, even bypassing disabled', () => {
     const onNotchModeChange = vi.fn();
     const view = withField(base(), 'notchMode', { unknown: true });
     withSurface(view, (s) => {
-      s.notchButton('auto')!.click();
+      const btn = s.notchButton('auto')!;
+      expect(btn.disabled).toBe(true);
+      btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
       flushSync();
       expect(onNotchModeChange).not.toHaveBeenCalled();
     }, { onNotchModeChange });
@@ -318,6 +378,23 @@ describe('agcMode renders the capability-derived choice set with caps-echoed lab
       s.agcButton(1)!.click();
       flushSync();
       expect(onAgcModeChange).toHaveBeenCalledExactlyOnceWith(1);
+    }, { onAgcModeChange });
+  });
+
+  /**
+   * MOR-1304/1305 F3: same bypass discipline as notchMode's guard test — the
+   * event is dispatched directly so a deleted `agc()` guard is what this
+   * assertion catches, not merely `disabled` suppressing a plain `.click()`.
+   */
+  it('emits nothing when clicked on an unobserved reading, even bypassing disabled', () => {
+    const onAgcModeChange = vi.fn();
+    const view = withField(base(), 'agcMode', { unknown: true });
+    withSurface(view, (s) => {
+      const btn = s.agcButton(1)!;
+      expect(btn.disabled).toBe(true);
+      btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      flushSync();
+      expect(onAgcModeChange).not.toHaveBeenCalled();
     }, { onAgcModeChange });
   });
 });

--- a/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
+++ b/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
@@ -33,6 +33,9 @@ const h = vi.hoisted(() => ({
   /** MOR-1265: stand-in for every txAux intent. This fixture declares no
    *  txAux capability, so the MOR-1244 evidence gate omits the group. */
   txAuxNoop: vi.fn(),
+  /** MOR-1305: same stand-in role for every dsp intent — no dsp capability
+   *  or state here either, so the group is absent and these are unreachable. */
+  dspNoop: vi.fn(),
 }));
 
 vi.mock('$lib/runtime', () => ({
@@ -94,6 +97,14 @@ vi.mock('../../../components-v2/wiring/command-bus', () => ({
     onFilterChange: h.txAuxNoop, onFilterWidthChange: h.txAuxNoop, onFilterShapeChange: h.txAuxNoop,
     onIfShiftChange: h.txAuxNoop, onPbtInnerChange: h.txAuxNoop, onPbtOuterChange: h.txAuxNoop,
   }),
+  // MOR-1305 — the wiring now also composes the dsp intent vocabulary.
+  makeDspHandlers: () => ({
+    onNrModeChange: h.dspNoop, onNrLevelChange: h.dspNoop, onNbToggle: h.dspNoop,
+    onNbLevelChange: h.dspNoop, onNbDepthChange: h.dspNoop, onNbWidthChange: h.dspNoop,
+    onNotchModeChange: h.dspNoop, onNotchFreqChange: h.dspNoop,
+    onManualNotchWidthChange: h.dspNoop, onAgcTimeChange: h.dspNoop,
+  }),
+  makeAgcHandlers: () => ({ onAgcModeChange: h.dspNoop }),
 }));
 
 import DualReceiverCockpit from '../DualReceiverCockpit.svelte';


### PR DESCRIPTION
## Summary

5B: DspSurface over the dsp facts (nr/nb/notch/agc). Mounted via zoned('dsp', ...) in the SINGLE composition only per the mounting canon; dual-composition absence pinned non-vacuously (view model carries the dsp group). Caps-echo separation genuinely pinned (hardcoded-ceiling mutant dies); aria-pressed pinned as attribute OMISSION on unknown toggle reading.

Production LOC 169 (verifier-measured, frozen formula; cap 200).

## Review provenance

Verified by the vocabulary-domain opus anchor (session 8). Initial verify BLOCKED (same F1-F4 classes as 4B plus the dual-blessing wiring test); prescribed fix round applied and delta-confirmed:
- F1: dual bare mount removed; blessing pins INVERTED into absence pin + no-focusable-outside-zone pin. Both restoration shapes re-caught by the anchor, including the canon-critical zoned-dual-mount case (the generic mechanism does not rescue an undeclared zone).
- F2/F3/MD7: all previously-surviving mutants die (MD1 x6, MD1b, MD3, MD4, MD5, MD7 x2); .click()-on-disabled vacuity removed (the old notch guard test was a false pass).
- Rebased over 4B (#2250): literals ['vfo','rxTx','txAux','meters','rxAudio','filter','dsp'] across all declarability tests + contract.ts; a third silent-merge casualty (dsp wiring mock lacking makeFilterHandlers) caught and fixed.
Final gates: 5352/5352, lint/boundaries/i18n/check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)