### PR TITLE
feat(MOR-1306): rfFrontEnd surface (6B) - canon-compliant zoned mount

### DIFF
--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -37,6 +37,9 @@
   import FilterSurface from '../../semantic/FilterSurface.svelte';
   import MetersSurface from '../../semantic/MetersSurface.svelte';
   import type { RadioViewModel } from '../../semantic/radio-view-model';
+  import RfFrontEndSurface, {
+    type RfFrontEndLevelField, type RfFrontEndToggleField,
+  } from '../../semantic/RfFrontEndSurface.svelte';
   import RxAudioSurface from '../../semantic/RxAudioSurface.svelte';
   import RxTxSurface from '../../semantic/RxTxSurface.svelte';
   import TxAuxSurface, {
@@ -47,7 +50,8 @@
   import ModInputTxWarning from '../panels/ModInputTxWarning.svelte';
   import {
     makeAgcHandlers, makeAudioRoutingHandlers, makeDspHandlers, makeFilterHandlers,
-    makeModeHandlers, makeRxAudioHandlers, makeTxHandlers, makeVfoHandlers, makeVoxHandlers,
+    makeModeHandlers, makeRfFrontEndHandlers, makeRxAudioHandlers, makeTxHandlers,
+    makeVfoHandlers, makeVoxHandlers,
   } from './command-bus';
   import {
     forReceiver, receiversOf, isActiveStrip, isOperationalStrip,
@@ -209,6 +213,20 @@
   let nbLevelRange = $derived(runtime.caps?.controls?.nb_level ?? null);
   let nbLevelMax = $derived(nbLevelRange?.raw_max ?? 10);
   let nbLevelPercent = $derived(nbLevelRange !== null);
+  /**
+   * MOR-1306. The RF-front-end intent vocabulary, composed from the SHIPPED
+   * command bus rather than forked — same discipline as `rxAudioIntents`
+   * above. `RF_FRONT_END_LEVEL_INTENT` maps the surface's field-addressed
+   * `onLevelChange` onto the two real level handlers, mirroring
+   * `TX_AUX_LEVEL_INTENT`.
+   */
+  const rfFrontEndIntents = makeRfFrontEndHandlers();
+  const RF_FRONT_END_LEVEL_INTENT: Record<RfFrontEndLevelField, (value: number) => void> = {
+    rfGain: rfFrontEndIntents.onRfGainChange, squelch: rfFrontEndIntents.onSquelchChange,
+  };
+  const RF_FRONT_END_TOGGLE_INTENT: Record<RfFrontEndToggleField, (next: boolean) => void> = {
+    digiSel: rfFrontEndIntents.onDigiSelToggle, ipPlus: rfFrontEndIntents.onIpPlusToggle,
+  };
   const tx = getAppTxController();
   const sourceId = `semantic-rx-tx-${++surfaceSeq}`;
   let leaseSeq = 0;
@@ -659,6 +677,34 @@
     {/if}
   {/snippet}
 
+  <!--
+    MOR-1306 (vocabulary slice 6B). Same structural gate and same reasoning as
+    `rxAudioSurface` above: the surface mounts only when the view model
+    actually carries the MOR-1292/MOR-1293 `rfFrontEnd` group, so a radio with
+    no preamp/attenuator/RF-gain/squelch/DIGI-SEL/IP+ capability renders the
+    pre-1306 element shape exactly.
+
+    SINGLE COMPOSITION ONLY — the MOR-1304 mounting canon (`RfFrontEndSurface.
+    svelte`'s file header): this surface carries focusable controls (preamp
+    and attenuator choice buttons, RF-gain/squelch sliders, DIGI-SEL/IP+
+    toggles) and no shipped manifest declares an `rfFrontEnd` zone yet, so a
+    bare dual mount would put controls outside every declared zone — exactly
+    the defect the MOR-1279 rxAudio precedent avoided. `'rfFrontEnd'` became
+    DECLARABLE with this slice; the cockpit gains the surface the moment a
+    rework slice declares a zone for it, same as `rxAudio` left it.
+  -->
+  {#snippet rfFrontEndSurface()}
+    {#if view?.rfFrontEnd}
+      <RfFrontEndSurface
+        {view}
+        onPreampChange={(level) => rfFrontEndIntents.onPreChange(level)}
+        onAttenuatorChange={(db) => rfFrontEndIntents.onAttChange(db)}
+        onLevelChange={(field, value) => RF_FRONT_END_LEVEL_INTENT[field](value)}
+        onToggle={(field, next) => RF_FRONT_END_TOGGLE_INTENT[field](next)}
+      />
+    {/if}
+  {/snippet}
+
   {#if strips === 'dual'}
     <!--
       MOR-1258: the zone now carries RxTxSurface AND the two TX-adjacent
@@ -704,6 +750,7 @@
     {@render zoned('rxAudio', view?.rxAudio !== undefined, rxAudioSurface)}
     {@render zoned('filter', view?.modeFilter !== undefined || view?.filterPassband !== undefined, filterSurface)}
     {@render zoned('dsp', view?.dsp !== undefined, dspSurface)}
+    {@render zoned('rfFrontEnd', view?.rfFrontEnd !== undefined, rfFrontEndSurface)}
     {@render txAdjacentAlerts()}
   {/if}
 </div>

--- a/frontend/src/components-v2/wiring/__tests__/semantic-dsp-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-dsp-wiring.component.test.ts
@@ -111,6 +111,14 @@ vi.mock('../command-bus', () => ({
     onManualNotchWidthChange: h.manualNotchWidth, onAgcTimeChange: h.agcTime,
   }),
   makeAgcHandlers: () => ({ onAgcModeChange: h.agcMode }),
+  // MOR-1306 — the wiring now also composes the RF-front-end intent
+  // vocabulary. This fixture declares no RF-front-end capability, so none of
+  // these is reachable — same stand-in role as `makeVfoHandlers`/
+  // `makeTxHandlers` above.
+  makeRfFrontEndHandlers: () => ({
+    onAttChange: h.noop, onPreChange: h.noop, onRfGainChange: h.noop,
+    onSquelchChange: h.noop, onDigiSelToggle: h.noop, onIpPlusToggle: h.noop,
+  }),
 }));
 
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';

--- a/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
@@ -100,6 +100,11 @@ vi.mock('../command-bus', () => ({
     onManualNotchWidthChange: h.noop, onAgcTimeChange: h.noop,
   }),
   makeAgcHandlers: () => ({ onAgcModeChange: h.noop }),
+  // MOR-1306 slice 6B: the RF-front-end intent vocabulary.
+  makeRfFrontEndHandlers: () => ({
+    onAttChange: h.noop, onPreChange: h.noop, onRfGainChange: h.noop,
+    onSquelchChange: h.noop, onDigiSelToggle: h.noop, onIpPlusToggle: h.noop,
+  }),
 }));
 
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';

--- a/frontend/src/components-v2/wiring/__tests__/semantic-rf-front-end-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rf-front-end-wiring.component.test.ts
@@ -1,0 +1,309 @@
+/**
+ * MOR-1306 — the semantic RF-front-end surface wired into
+ * `SemanticRadioSurfaces`.
+ *
+ * `semantic/__tests__/RfFrontEndSurface.test.ts` proves what the surface does
+ * with a view model. This file proves what only the composed tree can prove:
+ *
+ *   (a) every intent reaches its OWN mapped `makeRfFrontEndHandlers` spy,
+ *       none cross-wired to a neighbor — mirrors
+ *       `semantic-tx-aux-wiring.component.test.ts`'s own "every intent
+ *       reaches its own command-bus handler" section, and `../command-bus` is
+ *       mocked wholesale for the same reason that file mocks it: the real
+ *       `makeRfFrontEndHandlers` reads/writes the LEGACY `$lib/stores/
+ *       radio.svelte` singleton (`getRadioState`/`patchActiveReceiver`), a
+ *       different seam than `runtime.state` — agreement between the real
+ *       module and this file's names is a name/arity fact, already covered
+ *       by `stub-export-parity.test.ts` and TypeScript itself (the real
+ *       factory is imported for its type in the toggle-flip test below);
+ *   (b) THE MOUNTING CANON (MOR-1304 ruling): the surface mounts through
+ *       `zoned(...)` in the SINGLE composition only, and is ABSENT — zoned or
+ *       unzoned — from the DUAL composition, with a view model that actually
+ *       carries the group (a fixture that cannot see the surface is the bug
+ *       being fixed, not a pass). Mirrors
+ *       `semantic-rx-audio-wiring.component.test.ts`'s own pin exactly, per
+ *       the ticket brief's option (i);
+ *   (c) the default path stays byte-identical for a radio with no RF-front-end
+ *       capability at all;
+ *   (d) the FLIPPED-value contract between the surface and the toggle wiring
+ *       (`RfFrontEndSurface.svelte`'s `onToggle`) reaches the real
+ *       `onDigiSelToggle`/`onIpPlusToggle` `(on: boolean)` signature, not the
+ *       argument-less vox/comp/mon shape `TxAuxSurface` composes.
+ *
+ * Isolated pool by name (`*.component.test.ts`), per the MOR-1272 doctrine —
+ * no `vite.config.ts` edit was needed.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { ServerState } from '$lib/types/state';
+
+type Snapshot = {
+  phase: string; intent: string | null; guard: { leaseId: string } | null;
+  radioTx: string; txRisk: string; mayOwnKey: boolean; fault: string | null;
+};
+
+const h = vi.hoisted(() => ({
+  state: null as unknown,
+  caps: null as unknown,
+  snapshot: null as unknown,
+  listeners: new Set<(next: unknown) => void>(),
+  noop: vi.fn(),
+  att: vi.fn(),
+  pre: vi.fn(),
+  rfGain: vi.fn(),
+  squelch: vi.fn(),
+  digiSel: vi.fn(),
+  ipPlus: vi.fn(),
+}));
+
+vi.mock('$lib/runtime', () => ({
+  runtime: {
+    get state() { return h.state; },
+    get caps() { return h.caps; },
+    get audio() { return { muted: true, rxEnabled: false, volume: 0 }; },
+    get connectionAudio() { return false; },
+  },
+}));
+vi.mock('$lib/runtime/tx-controller/app-host', () => ({
+  getAppTxController: () => ({
+    snapshot: () => h.snapshot,
+    subscribe: (listener: (next: unknown) => void) => {
+      h.listeners.add(listener);
+      return () => { h.listeners.delete(listener); };
+    },
+    start: vi.fn(), setIntent: vi.fn(), release: vi.fn(), resetFault: vi.fn(),
+  }),
+}));
+vi.mock('$lib/runtime/adapters/mod-input-tx-guard.svelte', () => ({
+  deriveModInputTxGuardProps: () => ({ visible: false, sourceLabel: null }),
+  getModInputTxGuardHandlers: () => ({ onSetLan: vi.fn(), onDismiss: vi.fn() }),
+}));
+// The real module's names/arities are covered by `stub-export-parity.test.ts`
+// and by TypeScript; this file only proves ROUTING, mirroring
+// `semantic-tx-aux-wiring.component.test.ts`'s own wholesale mock.
+vi.mock('../command-bus', () => ({
+  makeVfoHandlers: () => ({
+    onVfoSelect: h.noop, onSplitToggle: h.noop, onDualWatchToggle: h.noop,
+  }),
+  makeVoxHandlers: () => ({
+    onVoxToggle: h.noop, onVoxGainChange: h.noop, onAntiVoxGainChange: h.noop, onVoxDelayChange: h.noop,
+  }),
+  makeTxHandlers: () => ({
+    onRfPowerChange: h.noop, onMicGainChange: h.noop, onAtuToggle: h.noop, onAtuTune: h.noop,
+    onVoxToggle: h.noop, onCompToggle: h.noop, onCompLevelChange: h.noop, onMonToggle: h.noop,
+    onMonLevelChange: h.noop, onDriveGainChange: h.noop,
+  }),
+  makeRxAudioHandlers: () => ({ onMonitorModeChange: h.noop, onAfLevelChange: h.noop }),
+  makeAudioRoutingHandlers: () => ({ onFocusChange: h.noop, onSplitStereoChange: h.noop }),
+  // MOR-1304/MOR-1305 — the wiring's module scope also composes the
+  // filter/dsp intent vocabularies unconditionally; without stubs here the
+  // wiring's `makeFilterHandlers()`/`makeDspHandlers()`/`makeAgcHandlers()`
+  // calls throw before this file's own RF-front-end assertions ever run.
+  makeModeHandlers: () => ({
+    onModInputChange: h.noop, onModeChange: h.noop, onDataModeChange: h.noop,
+  }),
+  makeFilterHandlers: () => ({
+    onFilterChange: h.noop, onFilterWidthChange: h.noop, onFilterShapeChange: h.noop,
+    onIfShiftChange: h.noop, onPbtInnerChange: h.noop, onPbtOuterChange: h.noop,
+  }),
+  makeDspHandlers: () => ({
+    onNrModeChange: h.noop, onNrLevelChange: h.noop, onNbToggle: h.noop,
+    onNbLevelChange: h.noop, onNbDepthChange: h.noop, onNbWidthChange: h.noop,
+    onNotchModeChange: h.noop, onNotchFreqChange: h.noop,
+    onManualNotchWidthChange: h.noop, onAgcTimeChange: h.noop,
+  }),
+  makeAgcHandlers: () => ({ onAgcModeChange: h.noop }),
+  makeRfFrontEndHandlers: () => ({
+    onAttChange: h.att, onPreChange: h.pre, onRfGainChange: h.rfGain,
+    onSquelchChange: h.squelch, onDigiSelToggle: h.digiSel, onIpPlusToggle: h.ipPlus,
+  }),
+}));
+
+import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';
+
+const IDLE: Snapshot = {
+  phase: 'idle', intent: null, guard: null, radioTx: 'off', txRisk: 'none',
+  mayOwnKey: false, fault: null,
+};
+const fresh = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' };
+const slot = (freqHz: number) => ({ freqHz, mode: 'USB', filterNum: 1, dataMode: 0 });
+
+/** Every rfFrontEnd raw field the MOR-1292/1293 adapter reads, all observed fresh. */
+const RF_FRONT_END_STATE = { preamp: 1, att: 6, rfGain: 0.8, squelch: 0.1, digisel: false, ipplus: false };
+const RF_FRONT_END_PATHS = ['preamp', 'att', 'rfGain', 'squelch', 'digisel', 'ipplus'];
+
+function liveState(withRfFrontEnd: boolean): ServerState {
+  const paths = ['active', 'split', 'dualWatch', 'txTarget'];
+  for (const rx of ['main', 'sub']) {
+    paths.push(`${rx}.freqHz`, `${rx}.mode`, `${rx}.filter`, `${rx}.activeSlot`);
+    if (withRfFrontEnd) paths.push(...RF_FRONT_END_PATHS.map((p) => `${rx}.${p}`));
+    for (const v of ['vfoA', 'vfoB']) {
+      paths.push(`${rx}.${v}.freqHz`, `${rx}.${v}.mode`, `${rx}.${v}.filterNum`);
+    }
+  }
+  const receiver = (hz: number) => ({
+    ...slot(hz), vfoA: slot(hz), vfoB: slot(hz + 50000), activeSlot: 'A', filter: 1,
+    ...(withRfFrontEnd ? RF_FRONT_END_STATE : {}),
+  });
+  return {
+    active: 'MAIN', split: false, dualWatch: false, ptt: false,
+    txTarget: { status: 'known', receiver: 'MAIN', slot: 'A', frequencyHz: 14250000 },
+    main: receiver(14250000), sub: receiver(14300000),
+    fieldStatus: Object.fromEntries(paths.map((p) => [p, fresh])),
+  } as unknown as ServerState;
+}
+
+const liveCaps = (withRfFrontEnd: boolean): Capabilities => ({
+  model: 'fixture', scope: false, audio: true, tx: true,
+  capabilities: withRfFrontEnd
+    ? ['audio', 'tx', 'dual_rx', 'preamp', 'attenuator', 'rf_gain', 'squelch', 'digisel', 'ip_plus']
+    : ['audio', 'tx', 'dual_rx'],
+  preValues: [0, 1, 2], attValues: [0, 6, 12, 18],
+  receivers: 2, vfoScheme: 'main_sub', freqRanges: [], modes: [], filters: [],
+  audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
+  webrtc: { available: false, enabled: false },
+  txBands: [{ start: 14000000, end: 14350000, name: '20m' }],
+  scopeSource: null, audioFftAvailable: false,
+} as unknown as Capabilities);
+
+let target: HTMLDivElement;
+let component: ReturnType<typeof mount> | null = null;
+
+function render(props: { strips?: 'single' | 'dual' } = {}): void {
+  target = document.createElement('div');
+  document.body.appendChild(target);
+  component = mount(SemanticRadioSurfaces, { target, props });
+  flushSync();
+}
+
+const q = <T extends HTMLElement>(sel: string) => target.querySelector(sel) as T | null;
+const el = (id: string) => q<HTMLElement>(`[data-testid="rf-front-end-${id}"]`);
+
+beforeEach(() => {
+  h.state = liveState(true);
+  h.caps = liveCaps(true);
+  h.snapshot = { ...IDLE };
+  h.listeners.clear();
+  for (const value of Object.values(h)) {
+    if (typeof value === 'function' && 'mockReset' in value) (value as ReturnType<typeof vi.fn>).mockReset();
+  }
+});
+
+afterEach(() => {
+  if (component) unmount(component);
+  component = null;
+  document.body.innerHTML = '';
+});
+
+/* ── (a)+(d) each intent reaches its own mapped handler ─────────── */
+
+describe('every rfFrontEnd intent reaches its own command-bus handler, none cross-wired', () => {
+  const ALL = [h.att, h.pre, h.rfGain, h.squelch, h.digiSel, h.ipPlus];
+
+  it('routes the preamp choice to onPreChange, verbatim', () => {
+    render();
+    el('preamp-2')!.click();
+    flushSync();
+    expect(h.pre).toHaveBeenCalledExactlyOnceWith(2);
+    for (const other of ALL.filter((s) => s !== h.pre)) expect(other).not.toHaveBeenCalled();
+  });
+
+  it('routes the attenuator choice to onAttChange, verbatim', () => {
+    render();
+    el('attenuator-18')!.click();
+    flushSync();
+    expect(h.att).toHaveBeenCalledExactlyOnceWith(18);
+    for (const other of ALL.filter((s) => s !== h.att)) expect(other).not.toHaveBeenCalled();
+  });
+
+  it('routes the RF-gain slider to onRfGainChange, verbatim', () => {
+    render();
+    const input = el('rfGain')!.querySelector('input')!;
+    input.value = '0.55';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    expect(h.rfGain).toHaveBeenCalledExactlyOnceWith(0.55);
+    for (const other of ALL.filter((s) => s !== h.rfGain)) expect(other).not.toHaveBeenCalled();
+  });
+
+  it('routes the squelch slider to onSquelchChange, verbatim', () => {
+    render();
+    const input = el('squelch')!.querySelector('input')!;
+    input.value = '0.2';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    expect(h.squelch).toHaveBeenCalledExactlyOnceWith(0.2);
+    for (const other of ALL.filter((s) => s !== h.squelch)) expect(other).not.toHaveBeenCalled();
+  });
+
+  // (d): `onDigiSelToggle`/`onIpPlusToggle` take an explicit `on: boolean` —
+  // the wiring must pass the FLIPPED value the surface computed, not call
+  // with no argument (the vox/comp/mon toggle shape) and not the CURRENT value.
+  it('routes DIGI-SEL to onDigiSelToggle with the FLIPPED boolean', () => {
+    render();
+    el('digiSel')!.click();
+    flushSync();
+    expect(h.digiSel).toHaveBeenCalledExactlyOnceWith(true);
+    for (const other of ALL.filter((s) => s !== h.digiSel)) expect(other).not.toHaveBeenCalled();
+  });
+
+  it('routes IP+ to onIpPlusToggle with the FLIPPED boolean', () => {
+    render();
+    el('ipPlus')!.click();
+    flushSync();
+    expect(h.ipPlus).toHaveBeenCalledExactlyOnceWith(true);
+    for (const other of ALL.filter((s) => s !== h.ipPlus)) expect(other).not.toHaveBeenCalled();
+  });
+});
+
+/* ── (b) THE MOUNTING CANON ──────────────────────────────────────── */
+
+describe('the surface mounts only when the view model carries the group', () => {
+  it('renders no rf-front-end surface for a radio with no RF-front-end capability', () => {
+    h.state = liveState(false);
+    h.caps = liveCaps(false);
+    render();
+    expect(el('surface')).toBeNull();
+    expect(target.innerHTML).not.toContain('rf-front-end');
+  });
+
+  it('renders it bare in the single composition, outside every zone', () => {
+    render();
+    const surface = el('surface')!;
+    expect(surface).not.toBeNull();
+    expect(surface.closest('[data-zone-id]')).toBeNull();
+  });
+
+  /**
+   * MOR-1304 mounting canon, applied per the ticket brief's option (i): a
+   * control-bearing surface with no declared cockpit zone must be ABSENT from
+   * the dual composition, not mounted bare. Caps here positively declare
+   * every rfFrontEnd sub-capability, so this is not the `mainSubCaps()` blind
+   * spot the MOR-1304 verify round documented for 4B — the group genuinely IS
+   * present, and the surface must still not appear.
+   */
+  it('renders NO rf-front-end surface in the dual composition, zoned or unzoned', () => {
+    render({ strips: 'dual' });
+    expect(el('surface')).toBeNull();
+    expect(target.innerHTML).not.toContain('rf-front-end');
+  });
+
+  it('leaves the cockpit with no focusable control outside a declared zone', () => {
+    render({ strips: 'dual' });
+    const outside = [...target.querySelectorAll<HTMLElement>('button, input, select, [tabindex]')]
+      .filter((node) => node.closest('[data-zone-id]') === null);
+    expect(outside).toEqual([]);
+  });
+
+  it('never changes with the App TX authority or the raw transmit bit', () => {
+    render();
+    const before = el('surface')!.outerHTML;
+    h.snapshot = { ...IDLE, phase: 'transmitting', radioTx: 'on', mayOwnKey: true };
+    for (const listener of h.listeners) listener(h.snapshot);
+    h.state = liveState(true);
+    (h.state as unknown as { ptt: boolean }).ptt = true;
+    flushSync();
+    expect(el('surface')!.outerHTML).toBe(before);
+  });
+});

--- a/frontend/src/components-v2/wiring/__tests__/semantic-rx-tx-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rx-tx-wiring.component.test.ts
@@ -126,6 +126,11 @@ vi.mock('../command-bus', () => ({
     onManualNotchWidthChange: h.dspNoop, onAgcTimeChange: h.dspNoop,
   }),
   makeAgcHandlers: () => ({ onAgcModeChange: h.dspNoop }),
+  // MOR-1306 slice 6B: the RF-front-end intent vocabulary.
+  makeRfFrontEndHandlers: () => ({
+    onAttChange: h.txAuxNoop, onPreChange: h.txAuxNoop, onRfGainChange: h.txAuxNoop,
+    onSquelchChange: h.txAuxNoop, onDigiSelToggle: h.txAuxNoop, onIpPlusToggle: h.txAuxNoop,
+  }),
 }));
 
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';

--- a/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
@@ -112,6 +112,14 @@ vi.mock('../command-bus', () => ({
     onManualNotchWidthChange: h.noop, onAgcTimeChange: h.noop,
   }),
   makeAgcHandlers: () => ({ onAgcModeChange: h.noop }),
+  // MOR-1306 slice 6B: the RF-front-end intent vocabulary — routing is pinned
+  // separately in `semantic-rf-front-end-wiring.component.test.ts`; this file
+  // only needs the wiring's module-scope `makeRfFrontEndHandlers()` call not
+  // to throw.
+  makeRfFrontEndHandlers: () => ({
+    onAttChange: h.noop, onPreChange: h.noop, onRfGainChange: h.noop,
+    onSquelchChange: h.noop, onDigiSelToggle: h.noop, onIpPlusToggle: h.noop,
+  }),
 }));
 
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';

--- a/frontend/src/presentation/layouts/__tests__/dsp-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/dsp-declarability.test.ts
@@ -20,7 +20,7 @@ describe('dsp is a declarable semantic surface', () => {
   // slice must not create.
   it('is in the declarable set alongside vfo, rxTx, txAux, meters and rxAudio', () => {
     expect([...SEMANTIC_SURFACE_NAMES]).toEqual([
-      'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp',
+      'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd',
     ]);
   });
 

--- a/frontend/src/presentation/layouts/__tests__/filter-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/filter-declarability.test.ts
@@ -23,7 +23,7 @@ describe('filter is a declarable semantic surface', () => {
   // Kills: reverting the SEMANTIC_SURFACE_NAMES addition.
   it('is in the declarable set alongside vfo, rxTx, txAux, meters and rxAudio', () => {
     expect([...SEMANTIC_SURFACE_NAMES]).toEqual([
-      'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp',
+      'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd',
     ]);
   });
 

--- a/frontend/src/presentation/layouts/__tests__/meters-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/meters-declarability.test.ts
@@ -25,10 +25,11 @@ import {
 
 describe('meters is a declarable semantic surface', () => {
   // Kills: reverting the SEMANTIC_SURFACE_NAMES addition. MOR-1305 appended
-  // `dsp`; `meters` must stay present and in place.
+  // `dsp`, MOR-1306 appended `rfFrontEnd`; `meters` must stay present and in
+  // place.
   it('is in the declarable set alongside vfo, rxTx and txAux', () => {
     expect([...SEMANTIC_SURFACE_NAMES]).toEqual([
-      'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp',
+      'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd',
     ]);
   });
 

--- a/frontend/src/presentation/layouts/__tests__/rf-front-end-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/rf-front-end-declarability.test.ts
@@ -1,15 +1,16 @@
 /**
- * MOR-1279 — `rxAudio` is DECLARABLE, and nothing declares it yet.
+ * MOR-1306 — `rfFrontEnd` is DECLARABLE, and nothing declares it yet.
  *
- * Slice 3B adds the name to `SEMANTIC_SURFACE_NAMES` so a manifest CAN mount
+ * Slice 6B adds the name to `SEMANTIC_SURFACE_NAMES` so a manifest CAN mount
  * the surface later; it deliberately does not touch any manifest, and it adds
  * no design-language renderer slot (that set was frozen by MOR-1072 — adding
  * one would be a language-contract change this slice must not make).
  *
- * Same three pins as `tx-aux-declarability.test.ts` / `meters-declarability.test.ts`:
+ * Same three pins as `tx-aux-declarability.test.ts` / `meters-declarability.test.ts`
+ * / `rx-audio-declarability.test.ts`:
  *   - drop the name and a future manifest's zone stops validating;
- *   - quietly add an `rxAudio` zone to a shipped manifest and the DOM grows a
- *     zone id no layout review ever saw;
+ *   - quietly add an `rfFrontEnd` zone to a shipped manifest and the DOM
+ *     grows a zone id no layout review ever saw;
  *   - the renderer slot set stays exactly what MOR-1072 froze.
  */
 import { describe, it, expect } from 'vitest';
@@ -21,19 +22,18 @@ import {
   sdrTestLayout,
 } from '../declarations';
 
-describe('rxAudio is a declarable semantic surface', () => {
+describe('rfFrontEnd is a declarable semantic surface', () => {
   // Kills: reverting the SEMANTIC_SURFACE_NAMES addition.
-  it('is in the declarable set alongside vfo, rxTx, txAux and meters', () => {
-    expect([...SEMANTIC_SURFACE_NAMES]).toEqual([
-      'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd',
-    ]);
+  it('is in the declarable set alongside vfo, rxTx, txAux, meters and rxAudio', () => {
+    expect([...SEMANTIC_SURFACE_NAMES])
+      .toEqual(['vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd']);
   });
 
   // Kills: adding the name to the type but not to the runtime allow-list the
   // zone validator checks — the manifest would still be rejected.
   it('accepts a manifest zone that declares it', () => {
     const manifest = validLayoutManifest({
-      zones: [{ id: 'main', surfaces: ['vfo', 'rxTx', 'rxAudio'] }],
+      zones: [{ id: 'main', surfaces: ['vfo', 'rxTx', 'rfFrontEnd'] }],
       requiredSemanticSurfaces: ['vfo', 'rxTx'],
     });
     expect(() => validateLayoutManifest(manifest)).not.toThrow();
@@ -41,28 +41,30 @@ describe('rxAudio is a declarable semantic surface', () => {
 
   it('still rejects a zone naming a surface that does not exist', () => {
     const manifest = validLayoutManifest({
-      zones: [{ id: 'main', surfaces: ['audioPanel'] as unknown as readonly ['vfo'] }],
+      zones: [{ id: 'main', surfaces: ['rfFrontEndPanel'] as unknown as readonly ['vfo'] }],
     });
     expect(() => validateLayoutManifest(manifest)).toThrow(/subset of/);
   });
 });
 
-describe('no shipped manifest declares an rxAudio zone in this slice', () => {
-  // Kills: slipping an rxAudio zone into an existing layout here. Declarability
-  // is the whole scope of the contract touch; placing the surface in a real
-  // layout is a later, separately reviewed slice.
+describe('no shipped manifest declares an rfFrontEnd zone in this slice', () => {
+  // Kills: slipping an rfFrontEnd zone into an existing layout here.
+  // Declarability is the whole scope of the contract touch; placing the
+  // surface in a real layout (including the dual-receiver-cockpit — see the
+  // MOR-1069 mount canon in `RfFrontEndSurface.svelte`) is a later, separately
+  // reviewed rework slice.
   it.each([
     ['sdr-test', sdrTestLayout], ['dual-receiver-cockpit', dualReceiverCockpitLayout],
     ['lcd-cockpit', lcdCockpitLayout], ['lcd-scope', lcdScopeLayout],
     ['mobile', mobileLayout], ['desktop-v2', desktopV2Layout],
-  ])('%s declares no rxAudio zone and does not require the surface', (_id, manifest) => {
-    for (const zone of manifest.zones) expect(zone.surfaces).not.toContain('rxAudio');
-    expect(manifest.requiredSemanticSurfaces).not.toContain('rxAudio');
+  ])('%s declares no rfFrontEnd zone and does not require the surface', (_id, manifest) => {
+    for (const zone of manifest.zones) expect(zone.surfaces).not.toContain('rfFrontEnd');
+    expect(manifest.requiredSemanticSurfaces).not.toContain('rfFrontEnd');
   });
 });
 
 describe('the design-language renderer slot set is untouched', () => {
-  // Kills: adding a renderer slot for this surface. RX audio has no gauge
+  // Kills: adding a renderer slot for this surface. RF front end has no gauge
   // grammar a language must describe; the slot set stays frozen.
   it('still carries exactly the three MOR-1072 slots', () => {
     expect([...RENDERER_SLOT_NAMES]).toEqual(['meters', 'frequencyDisplay', 'stateFeedback']);

--- a/frontend/src/presentation/layouts/__tests__/tx-aux-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/tx-aux-declarability.test.ts
@@ -25,11 +25,11 @@ import {
 
 describe('txAux is a declarable semantic surface', () => {
   // Kills: reverting the SEMANTIC_SURFACE_NAMES addition. MOR-1273 appended
-  // `meters`, MOR-1304 appended `filter`, MOR-1305 appended `dsp`; `txAux`
-  // must stay present and in place.
+  // `meters`, MOR-1304 appended `filter`, MOR-1305 appended `dsp`, MOR-1306
+  // appended `rfFrontEnd`; `txAux` must stay present and in place.
   it('is in the declarable set alongside vfo and rxTx', () => {
     expect([...SEMANTIC_SURFACE_NAMES]).toEqual([
-      'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp',
+      'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd',
     ]);
   });
 

--- a/frontend/src/presentation/layouts/contract.ts
+++ b/frontend/src/presentation/layouts/contract.ts
@@ -14,14 +14,17 @@ import { isValidLanguageId as isValidProductId } from '../languages/contract';
 
 /** Semantic surfaces a layout may mount (MOR-1062/1065 reference vertical;
  *  `txAux` added by MOR-1265, `meters` by MOR-1273, `rxAudio` by MOR-1279,
- *  `filter` by MOR-1304, `dsp` by MOR-1305). Adding a name makes it
- *  DECLARABLE — it does not mount anything by itself, and no manifest
- *  declares a `meters`, `rxAudio`, `filter` or `dsp` zone yet (the cockpit
- *  declares only `txAux`, as `tx-aux` — MOR-1336). Distinct from the
- *  design-language renderer slot of the same name (`languages/contract.ts`'s
- *  `RENDERER_SLOT_NAMES`): that one says how a language DRAWS a meter, this
- *  one says which layout zone may HOST the surface. */
-export const SEMANTIC_SURFACE_NAMES = ['vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp'] as const;
+ *  `filter` by MOR-1304, `dsp` by MOR-1305, `rfFrontEnd` by MOR-1306). Adding
+ *  a name makes it DECLARABLE — it does not mount anything by itself, and no
+ *  manifest declares a `meters`, `rxAudio`, `filter`, `dsp` or `rfFrontEnd`
+ *  zone yet (the cockpit declares only `txAux`, as `tx-aux` — MOR-1336).
+ *  Distinct from the design-language renderer slot of the same name
+ *  (`languages/contract.ts`'s `RENDERER_SLOT_NAMES`): that one says how a
+ *  language DRAWS a meter, this one says which layout zone may HOST the
+ *  surface. */
+export const SEMANTIC_SURFACE_NAMES = [
+  'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd',
+] as const;
 export type SemanticSurfaceName = (typeof SEMANTIC_SURFACE_NAMES)[number];
 
 /**

--- a/frontend/src/semantic/RfFrontEndSurface.svelte
+++ b/frontend/src/semantic/RfFrontEndSurface.svelte
@@ -1,0 +1,202 @@
+<!--
+  Semantic RF-front-end surface (MOR-1306, vocabulary slice 6B).
+
+  Presentation only. It renders the MOR-1262 decomposition family 11
+  `rfFrontEnd` fact group (MOR-1292/MOR-1293) — preamp, attenuator, RF gain,
+  squelch, DIGI-SEL, IP+ — and emits control intents as callbacks. It holds
+  no state, consults no controller and issues no command directly (v3 ADR
+  invariant 11), same doctrine as `TxAuxSurface`/`RxAudioSurface`.
+
+  CARRY-FORWARDS (binding, from the MOR-1292/MOR-1293 review rulings — see
+  `radio-view-model.ts`'s `RfFrontEndViewModel` doc comment for the fact-layer
+  half of each):
+
+  (1) FRESHNESS. A stale/unobserved reading renders `UNKNOWN_TEXT`, never the
+      last-known value. This is inherited "for free" from `usable`/`textOf`
+      gating on `reading.status === 'known'` — the same idiom
+      `TxAuxSurface`/`RxAudioSurface` use — as long as nothing here adds a
+      fallback that reads `rf.<field>.reading.value` outside that gate. There
+      is deliberately no "show it anyway, marked stale" branch: the fact
+      layer already collapses a stale reading to `unknown` before this file
+      ever sees it (`radio-view-model-adapter.ts`'s `txAuxField`), so widening
+      here would silently reopen exactly the gate MOR-1292 closed.
+  (2)+(3) THE PREAMP MUTEX. PRE is genuinely disabled while DIGI-SEL is
+      unobserved, by design (MOR-479 hardware mutex, IC-7610). Rendered as a
+      disabled control WITH AN EXPLANATION, read from `view.disabledReasons`
+      matched on the DOTTED path `'rfFrontEnd.preamp'` — never a bespoke
+      `preDisabled` boolean, and never `?? false` (the shipped v2 fallback
+      that would silently re-enable PRE the moment DIGI-SEL goes unobserved).
+      The mutex disables the control on TOP of its own field usability: a
+      positively-known, positively-usable preamp reading is still inert while
+      the mutex entry is present.
+  (4) The explanation is keyed off `DisabledReasonCode`, not off "DIGI-SEL" —
+      `'mutually-exclusive-control'` is deliberately generic (reusable by a
+      future CW APF/TPF mutex, MOR-1293's own note), so `MUTEX_LABEL` names
+      the SHAPE of the conflict, never this radio's specific peer control.
+
+  Two-level availability (MOR-977/1256), same as every sibling surface:
+  `structural: false` renders NOTHING for that field — "this radio has no
+  squelch" is a different claim from "squelch was never observed", which
+  renders present-and-disabled.
+-->
+<script module lang="ts">
+  import type { DisabledReasonCode, RfFrontEndField } from './radio-view-model';
+
+  /** The one rendering of "not read". Never 0, never the last value. */
+  export const UNKNOWN_TEXT = '?';
+
+  /** Usable ⇔ the radio HAS it, it is readable NOW, and it was actually read. */
+  export const usable = (f: RfFrontEndField<unknown>): boolean =>
+    f.availability.structural && f.availability.operational && f.reading.status === 'known';
+  /** Honest text: an unread fact reads as unknown, never as a stale value. */
+  export const textOf = (f: RfFrontEndField<unknown>): string =>
+    f.reading.status === 'known' ? String(f.reading.value) : UNKNOWN_TEXT;
+  const isValue = (f: RfFrontEndField<unknown>, value: unknown): boolean =>
+    f.reading.status === 'known' && f.reading.value === value;
+
+  /** `[field, label, min, max, step]`, RAW wire units (0..1 fractions, no
+   *  rescale) — same discipline as `TxAuxSurface.TX_AUX_LEVELS`. */
+  export const RF_FRONT_END_LEVELS = [
+    ['rfGain', 'RF gain', 0, 1, 0.01],
+    ['squelch', 'Squelch', 0, 1, 0.01],
+  ] as const;
+  /** `[field, label]` on/off controls. */
+  export const RF_FRONT_END_TOGGLES = [
+    ['digiSel', 'DIGI-SEL'], ['ipPlus', 'IP+'],
+  ] as const;
+  export type RfFrontEndLevelField = (typeof RF_FRONT_END_LEVELS)[number][0];
+  export type RfFrontEndToggleField = (typeof RF_FRONT_END_TOGGLES)[number][0];
+
+  /** Carry-forward 4: keyed by the generic CODE, never by a peer-control
+   *  name — the mutex label must read the same whichever control triggers
+   *  it. */
+  export const DISABLED_REASON_LABEL: Partial<Record<DisabledReasonCode, string>> = {
+    'mutually-exclusive-control': 'disabled: another control is active',
+  };
+</script>
+
+<script lang="ts">
+  import type { RadioViewModel } from './radio-view-model';
+
+  interface Props {
+    view: RadioViewModel;
+    onPreampChange?: (level: number) => void;
+    onAttenuatorChange?: (db: number) => void;
+    onLevelChange?: (field: RfFrontEndLevelField, value: number) => void;
+    /** `next` is the FLIPPED value, computed here from the observed reading —
+     *  `makeRfFrontEndHandlers().onDigiSelToggle`/`onIpPlusToggle` take an
+     *  explicit `on: boolean`, unlike the argument-less vox/comp/mon toggles
+     *  `TxAuxSurface` composes, so the surface (which holds the fact) computes
+     *  it rather than the wiring re-reading raw state to derive it. */
+    onToggle?: (field: RfFrontEndToggleField, next: boolean) => void;
+  }
+  let { view, onPreampChange, onAttenuatorChange, onLevelChange, onToggle }: Props = $props();
+
+  let rf = $derived(view.rfFrontEnd);
+  /** Carry-forwards 2/3: matched on the DOTTED field path, never re-derived
+   *  from a raw DIGI-SEL read — the fact layer already decided this. */
+  let preMutex = $derived(
+    view.disabledReasons.find((reason) => reason.field === 'rfFrontEnd.preamp') ?? null,
+  );
+
+  function changePreamp(level: number): void {
+    if (rf && usable(rf.preamp) && preMutex === null) onPreampChange?.(level);
+  }
+  function changeAttenuator(db: number): void {
+    if (rf && usable(rf.attenuator)) onAttenuatorChange?.(db);
+  }
+  function changeLevel(field: RfFrontEndLevelField, value: number): void {
+    if (rf && usable(rf[field])) onLevelChange?.(field, value);
+  }
+  function toggle(field: RfFrontEndToggleField): void {
+    const f = rf?.[field];
+    if (f && usable(f) && f.reading.status === 'known') onToggle?.(field, !f.reading.value);
+  }
+</script>
+
+{#if rf}
+  <section class="rf-front-end-surface" data-testid="rf-front-end-surface" aria-label="RF front end">
+    {#if rf.preamp.availability.structural}
+      <div
+        class="rf-front-end-row" role="radiogroup" aria-label="Preamp"
+        data-testid="rf-front-end-preamp"
+        data-observed={usable(rf.preamp)}
+        data-disabled-reason={preMutex?.code}
+      >
+        {#each rf.preValues as value (value)}
+          <button
+            type="button" role="radio" class="rf-front-end-choice"
+            data-testid={`rf-front-end-preamp-${value}`}
+            aria-checked={isValue(rf.preamp, value)}
+            disabled={!usable(rf.preamp) || preMutex !== null}
+            onclick={() => changePreamp(value)}
+          >{value}</button>
+        {/each}
+        <output data-testid="rf-front-end-preamp-value">{textOf(rf.preamp)}</output>
+        {#if preMutex}
+          <p data-testid="rf-front-end-preamp-mutex-reason">{DISABLED_REASON_LABEL[preMutex.code]}</p>
+        {/if}
+      </div>
+    {/if}
+
+    {#if rf.attenuator.availability.structural}
+      <div
+        class="rf-front-end-row" role="radiogroup" aria-label="Attenuator"
+        data-testid="rf-front-end-attenuator" data-observed={usable(rf.attenuator)}
+      >
+        {#each rf.attValues as value (value)}
+          <button
+            type="button" role="radio" class="rf-front-end-choice"
+            data-testid={`rf-front-end-attenuator-${value}`}
+            aria-checked={isValue(rf.attenuator, value)}
+            disabled={!usable(rf.attenuator)}
+            onclick={() => changeAttenuator(value)}
+          >{value} dB</button>
+        {/each}
+        <output data-testid="rf-front-end-attenuator-value">{textOf(rf.attenuator)}</output>
+      </div>
+    {/if}
+
+    {#each RF_FRONT_END_LEVELS as [field, label, min, max, step] (field)}
+      {#if rf[field].availability.structural}
+        <label
+          class="rf-front-end-level" data-testid={`rf-front-end-${field}`}
+          data-observed={usable(rf[field])}
+        >
+          <span class="rf-front-end-name">{label}</span>
+          <input
+            type="range" {min} {max} {step}
+            value={rf[field].reading.status === 'known' ? rf[field].reading.value : 0}
+            disabled={!usable(rf[field])}
+            oninput={(event) => changeLevel(field, event.currentTarget.valueAsNumber)}
+          />
+          <output>{textOf(rf[field])}</output>
+        </label>
+      {/if}
+    {/each}
+
+    {#each RF_FRONT_END_TOGGLES as [field, label] (field)}
+      {#if rf[field].availability.structural}
+        <button
+          type="button" class="rf-front-end-toggle"
+          data-testid={`rf-front-end-${field}`} data-observed={usable(rf[field])}
+          aria-pressed={rf[field].reading.status === 'known' ? rf[field].reading.value : undefined}
+          disabled={!usable(rf[field])}
+          onclick={() => toggle(field)}
+        >{label}: {textOf(rf[field])}</button>
+      {/if}
+    {/each}
+  </section>
+{/if}
+
+<style>
+  /* Structure only — a design language owns colour and must never become the
+     sole state channel (MOR-977, forced-colors). */
+  .rf-front-end-surface { display: flex; flex-direction: column; gap: 0.25rem; }
+  .rf-front-end-row { display: flex; flex-wrap: wrap; align-items: baseline; gap: 0.5rem; margin: 0; }
+  .rf-front-end-level { display: flex; align-items: baseline; gap: 0.5rem; }
+  .rf-front-end-name { min-width: 6ch; }
+  .rf-front-end-choice[aria-checked='true'] { font-weight: 700; }
+  [data-observed='false'] { font-style: italic; }
+  button:disabled, input:disabled { cursor: not-allowed; }
+</style>

--- a/frontend/src/semantic/__tests__/RfFrontEndSurface.test.ts
+++ b/frontend/src/semantic/__tests__/RfFrontEndSurface.test.ts
@@ -1,0 +1,305 @@
+/**
+ * MOR-1306 — the semantic RF-front-end surface (vocabulary slice 6B).
+ *
+ * Pins the four carry-forward rulings named in `RfFrontEndSurface.svelte`'s
+ * file header:
+ *   (1) freshness — a stale/unread field renders unknown, never a stale value;
+ *   (2)+(3) the PREAMP/DIGI-SEL mutex renders as a disabled control WITH AN
+ *       EXPLANATION, matched on the DOTTED `disabledReasons` field path, and
+ *       disables the control even when the preamp field is otherwise usable;
+ *   (4) the mutex explanation is keyed by the generic `DisabledReasonCode`,
+ *       not by a peer-control name.
+ *
+ * Fast-pool-safe by construction (MOR-1272): no `vi.mock`, no global spy.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import RfFrontEndSurface, {
+  DISABLED_REASON_LABEL, RF_FRONT_END_LEVELS, RF_FRONT_END_TOGGLES, UNKNOWN_TEXT,
+} from '../RfFrontEndSurface.svelte';
+import { topologyFixtures, withRfFrontEnd } from '../fixtures/topologies';
+import type {
+  Availability, DisabledReason, RadioViewModel, RfFrontEndField, RfFrontEndViewModel,
+} from '../radio-view-model';
+
+const ON: Availability = { structural: true, operational: true };
+const OFF: Availability = { structural: false, operational: false };
+const DEGRADED: Availability = { structural: true, operational: false };
+
+const base = (): RadioViewModel => withRfFrontEnd(topologyFixtures['1/single']);
+/** Re-shape the rfFrontEnd group of an otherwise fully-observed fixture. */
+const withRf = (over: Partial<RfFrontEndViewModel>): RadioViewModel => {
+  const view = base();
+  return { ...view, rfFrontEnd: { ...view.rfFrontEnd!, ...over } };
+};
+const withReasons = (reasons: readonly DisabledReason[]): RadioViewModel => ({
+  ...base(), disabledReasons: reasons,
+});
+const unread = <T>(availability: Availability = ON): RfFrontEndField<T> =>
+  ({ reading: { status: 'unknown' }, availability });
+const known = <T>(value: T, availability: Availability = ON): RfFrontEndField<T> =>
+  ({ reading: { status: 'known', value }, availability });
+
+let target: HTMLDivElement;
+
+function render(view: RadioViewModel, handlers: Record<string, unknown> = {}) {
+  target = document.createElement('div');
+  document.body.appendChild(target);
+  const component = mount(RfFrontEndSurface, { target, props: { view, ...handlers } });
+  flushSync();
+  const q = <T extends HTMLElement>(sel: string) => target.querySelector(sel) as T | null;
+  return {
+    dispose: () => { unmount(component); target.remove(); },
+    root: () => q('[data-testid="rf-front-end-surface"]'),
+    el: (id: string) => q<HTMLElement>(`[data-testid="rf-front-end-${id}"]`),
+    text: (id: string) => q<HTMLElement>(`[data-testid="rf-front-end-${id}"]`)?.textContent?.trim(),
+  };
+}
+
+/* ── the surface renders nothing without the group ─────────────── */
+
+describe('the surface self-gates on the rfFrontEnd group', () => {
+  it('renders NOTHING at all when the view model carries no rfFrontEnd group', () => {
+    const view = { ...base() };
+    delete (view as { rfFrontEnd?: unknown }).rfFrontEnd;
+    const r = render(view);
+    expect(r.root()).toBeNull();
+    expect(target.textContent).toBe('');
+    r.dispose();
+  });
+
+  it.each([
+    ['preamp', 'preamp'], ['attenuator', 'attenuator'], ['rfGain', 'rfGain'], ['squelch', 'squelch'],
+    ['digiSel', 'digiSel'], ['ipPlus', 'ipPlus'],
+  ] as const)('renders no %s block at all when it is structurally absent', (field, id) => {
+    const r = render(withRf({ [field]: unread(OFF) } as Partial<RfFrontEndViewModel>));
+    expect(r.el(id)).toBeNull();
+    r.dispose();
+  });
+});
+
+/* ── (1) freshness: unknown is rendered as unknown, never stale-value ──── */
+
+describe('carry-forward 1: a stale/unread reading renders unknown, never its last value', () => {
+  it('renders a DEGRADED preamp as unknown text, not the last-known level', () => {
+    const r = render(withRf({ preamp: unread<number>(DEGRADED) }));
+    expect(r.el('preamp')!.dataset.observed).toBe('false');
+    expect(r.text('preamp-value')).toBe(UNKNOWN_TEXT);
+    r.dispose();
+  });
+
+  it('renders a DEGRADED attenuator as unknown text, not the last-known step', () => {
+    const r = render(withRf({ attenuator: unread<number>(DEGRADED) }));
+    expect(r.el('attenuator')!.dataset.observed).toBe('false');
+    expect(r.text('attenuator-value')).toBe(UNKNOWN_TEXT);
+    r.dispose();
+  });
+
+  it('renders a stale RF-gain reading as "?", never 0.5 or any prior level', () => {
+    const r = render(withRf({ rfGain: unread<number>(DEGRADED) }));
+    expect(r.text('rfGain')).toContain(UNKNOWN_TEXT);
+    r.dispose();
+  });
+
+  it('makes the RF-gain slider inert while the level is unread, and emits nothing', () => {
+    const onLevelChange = vi.fn();
+    const r = render(withRf({ rfGain: unread<number>(DEGRADED) }), { onLevelChange });
+    const input = r.el('rfGain')!.querySelector('input')!;
+    expect(input.disabled).toBe(true);
+    expect(input.valueAsNumber).toBe(0);
+    input.value = '0.7';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    expect(onLevelChange).not.toHaveBeenCalled();
+    r.dispose();
+  });
+
+  it('disables an unread preamp/attenuator choice and emits nothing on click', () => {
+    const onPreampChange = vi.fn();
+    const onAttenuatorChange = vi.fn();
+    const r = render(
+      withRf({ preamp: unread<number>(DEGRADED), attenuator: unread<number>(DEGRADED) }),
+      { onPreampChange, onAttenuatorChange },
+    );
+    const preBtn = r.el('preamp-1')!;
+    const attBtn = r.el('attenuator-6')!;
+    expect(preBtn.hasAttribute('disabled')).toBe(true);
+    expect(attBtn.hasAttribute('disabled')).toBe(true);
+    preBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    attBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    flushSync();
+    expect(onPreampChange).not.toHaveBeenCalled();
+    expect(onAttenuatorChange).not.toHaveBeenCalled();
+    r.dispose();
+  });
+});
+
+/* ── (2)+(3) the PREAMP/DIGI-SEL mutex ──────────────────────────── */
+
+describe('carry-forwards 2+3: the PREAMP mutex disables the control WITH AN EXPLANATION', () => {
+  const MUTEX: DisabledReason = { field: 'rfFrontEnd.preamp', code: 'mutually-exclusive-control' };
+
+  it('disables every preamp choice while the mutex entry is present, even though preamp is usable', () => {
+    const r = render(withReasons([MUTEX]));
+    for (const value of [0, 1, 2]) expect(r.el(`preamp-${value}`)!.hasAttribute('disabled')).toBe(true);
+    r.dispose();
+  });
+
+  it('shows the mutex explanation text, not merely an attribute', () => {
+    const r = render(withReasons([MUTEX]));
+    expect(r.text('preamp-mutex-reason')).toBe(DISABLED_REASON_LABEL['mutually-exclusive-control']);
+    r.dispose();
+  });
+
+  it('carries the reason code as data, matched on the DOTTED field path', () => {
+    const r = render(withReasons([MUTEX]));
+    expect(r.el('preamp')!.dataset.disabledReason).toBe('mutually-exclusive-control');
+    r.dispose();
+  });
+
+  // MUTATION KILLED (the `?? false` bypass, MOR-1293's forbidden shape): the
+  // handler guard must refuse to emit even if `disabled` were somehow bypassed
+  // (a programmatic dispatchEvent, exactly like a restyled design language).
+  it('the handler itself refuses to emit while the mutex is active — independent of `disabled`', () => {
+    const onPreampChange = vi.fn();
+    const r = render(withReasons([MUTEX]), { onPreampChange });
+    r.el('preamp-1')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    flushSync();
+    expect(onPreampChange).not.toHaveBeenCalled();
+    r.dispose();
+  });
+
+  it('leaves preamp enabled and emits normally once the mutex entry is absent', () => {
+    const onPreampChange = vi.fn();
+    const r = render(base(), { onPreampChange });
+    const btn = r.el('preamp-0')!;
+    expect(btn.hasAttribute('disabled')).toBe(false);
+    btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    flushSync();
+    expect(onPreampChange).toHaveBeenCalledExactlyOnceWith(0);
+    expect(r.el('preamp-mutex-reason')).toBeNull();
+    r.dispose();
+  });
+
+  it('never disables the attenuator, RF gain or squelch controls for the preamp mutex', () => {
+    const r = render(withReasons([MUTEX]));
+    expect(r.el('attenuator-6')!.hasAttribute('disabled')).toBe(false);
+    expect(r.el('rfGain')!.querySelector('input')!.disabled).toBe(false);
+    expect(r.el('squelch')!.querySelector('input')!.disabled).toBe(false);
+    r.dispose();
+  });
+});
+
+/* ── (4) the explanation is keyed by the generic code ───────────── */
+
+describe('carry-forward 4: the mutex explanation names the code, never a peer control', () => {
+  it('the label text never mentions DIGI-SEL', () => {
+    const label = DISABLED_REASON_LABEL['mutually-exclusive-control']!;
+    expect(label.toUpperCase()).not.toContain('DIGI-SEL');
+    expect(label.toUpperCase()).not.toContain('DIGISEL');
+  });
+
+  it('is keyed by DisabledReasonCode, not by field name', () => {
+    expect(Object.keys(DISABLED_REASON_LABEL)).toEqual(['mutually-exclusive-control']);
+  });
+});
+
+/* ── choices, levels and toggles render and emit from the facts ────── */
+
+describe('preamp and attenuator render as choice groups from the capability-derived sets', () => {
+  it('checks exactly the observed preamp level', () => {
+    const r = render(withRf({ preamp: known(2) }));
+    for (const value of [0, 1, 2]) {
+      expect(r.el(`preamp-${value}`)!.getAttribute('aria-checked')).toBe(String(value === 2));
+    }
+    expect(r.text('preamp-value')).toBe('2');
+    r.dispose();
+  });
+
+  it('emits the clicked preamp level verbatim', () => {
+    const onPreampChange = vi.fn();
+    const r = render(base(), { onPreampChange });
+    r.el('preamp-2')!.click();
+    flushSync();
+    expect(onPreampChange).toHaveBeenCalledExactlyOnceWith(2);
+    r.dispose();
+  });
+
+  it('checks exactly the observed attenuator step and emits it verbatim', () => {
+    const onAttenuatorChange = vi.fn();
+    const r = render(withRf({ attenuator: known(12) }), { onAttenuatorChange });
+    expect(r.el('attenuator-12')!.getAttribute('aria-checked')).toBe('true');
+    r.el('attenuator-18')!.click();
+    flushSync();
+    expect(onAttenuatorChange).toHaveBeenCalledExactlyOnceWith(18);
+    r.dispose();
+  });
+});
+
+describe('RF gain and squelch render as 0..1 sliders, no rescale', () => {
+  it.each(RF_FRONT_END_LEVELS)('declares the %s slider on the 0..1 scale', (field, _label, min, max) => {
+    const r = render(base());
+    const input = r.el(field)!.querySelector('input')!;
+    expect([input.min, input.max]).toEqual([String(min), String(max)]);
+    r.dispose();
+  });
+
+  it('emits the slider value verbatim, on the way out', () => {
+    const onLevelChange = vi.fn();
+    const r = render(base(), { onLevelChange });
+    const input = r.el('squelch')!.querySelector('input')!;
+    input.value = '0.33';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    expect(onLevelChange).toHaveBeenCalledExactlyOnceWith('squelch', 0.33);
+    r.dispose();
+  });
+
+  // MUTATION KILLED: a guard that only lives in `disabled`.
+  it('the level handler refuses to emit for an unusable field, independent of `disabled`', () => {
+    const onLevelChange = vi.fn();
+    const r = render(withRf({ squelch: unread<number>(DEGRADED) }), { onLevelChange });
+    const input = r.el('squelch')!.querySelector('input')!;
+    input.value = '0.5';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    expect(onLevelChange).not.toHaveBeenCalled();
+    r.dispose();
+  });
+});
+
+describe('DIGI-SEL and IP+ render as toggles and emit the FLIPPED value', () => {
+  it.each(RF_FRONT_END_TOGGLES)('shows the observed %s state as pressed/unpressed', (field) => {
+    const r = render(withRf({ [field]: known(true) } as Partial<RfFrontEndViewModel>));
+    expect(r.el(field)!.getAttribute('aria-pressed')).toBe('true');
+    r.dispose();
+  });
+
+  it('emits the flipped value on click, computed from the observed reading', () => {
+    const onToggle = vi.fn();
+    const r = render(withRf({ digiSel: known(false) }), { onToggle });
+    r.el('digiSel')!.click();
+    flushSync();
+    expect(onToggle).toHaveBeenCalledExactlyOnceWith('digiSel', true);
+    r.dispose();
+  });
+
+  it('flips the other direction too', () => {
+    const onToggle = vi.fn();
+    const r = render(withRf({ ipPlus: known(true) }), { onToggle });
+    r.el('ipPlus')!.click();
+    flushSync();
+    expect(onToggle).toHaveBeenCalledExactlyOnceWith('ipPlus', false);
+    r.dispose();
+  });
+
+  // MUTATION KILLED: a guard that only lives in `disabled`.
+  it('the toggle handler refuses to emit for an unusable field, independent of `disabled`', () => {
+    const onToggle = vi.fn();
+    const r = render(withRf({ digiSel: unread<boolean>(DEGRADED) }), { onToggle });
+    r.el('digiSel')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    flushSync();
+    expect(onToggle).not.toHaveBeenCalled();
+    r.dispose();
+  });
+});

--- a/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
+++ b/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
@@ -105,6 +105,11 @@ vi.mock('../../../components-v2/wiring/command-bus', () => ({
     onManualNotchWidthChange: h.dspNoop, onAgcTimeChange: h.dspNoop,
   }),
   makeAgcHandlers: () => ({ onAgcModeChange: h.dspNoop }),
+  // MOR-1306 slice 6B: the RF-front-end intent vocabulary.
+  makeRfFrontEndHandlers: () => ({
+    onAttChange: h.txAuxNoop, onPreChange: h.txAuxNoop, onRfGainChange: h.txAuxNoop,
+    onSquelchChange: h.txAuxNoop, onDigiSelToggle: h.txAuxNoop, onIpPlusToggle: h.txAuxNoop,
+  }),
 }));
 
 import DualReceiverCockpit from '../DualReceiverCockpit.svelte';


### PR DESCRIPTION
## Summary

6B: RfFrontEndSurface over the rfFrontEnd facts (MOR-1292 preamp/attenuator/RF gain/squelch + MOR-1293 DIGI-SEL/IP+ with PREAMP mutex). Mounted via zoned('rfFrontEnd', ...) in the SINGLE composition only per the mounting canon; dual absence pinned non-vacuously (control-test recipe: same caps assert presence in single).

Production LOC 154 (verifier-measured, frozen formula; cap 200).

Carry-forwards honored: freshness via fact-layer unknown-collapse (stale shows unknown, never last value); PREAMP/DIGI-SEL mutex renders disabled-with-explanation from disabledReasons on the dotted 'rfFrontEnd.preamp' path, independent of usable(); mutex label keyed by the generic DisabledReasonCode (reusable, never DIGI-SEL-specific).

## Review provenance

Verified by the vocabulary-domain opus anchor (session 8): PASS on first verify (no fix round needed) — the canon and fix-round precedents visibly propagated into this build. LOC 154 binding; 7/8 mutants killed incl. R2 (mutex on wrong dotted field, killed 4) and R4 (handler drops mutex half while disabled stays — defence-in-depth pinned via dispatch-past-disabled); both mount-restoration shapes caught incl. the canon-critical zoned-dual. Gates by the anchor: 5212/5212 fresh localstorage, lint/boundaries/i18n/check clean.

Post-verify rebase over #2249-#2251 is mechanical (landing-order literals across contract.ts + 6 declarability tests; cross-slice mock parity casualties fixed); gates re-run green.

Note: fixture-harness re-run scheduled after this and MOR-1351 both land (current no-drift is vacuous - no fixture declares rfFrontEnd caps yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)