### PR TITLE
test(MOR-1351): fixture caps hardening - MOR-1069 assertions bite for cap-gated surfaces

### DIFF
--- a/frontend/fixtures/catalog.ts
+++ b/frontend/fixtures/catalog.ts
@@ -190,10 +190,44 @@ function withMeters(state: ServerState): ServerState {
   } as unknown as ServerState;
 }
 
+/**
+ * MOR-1351: was an inert placeholder (`modes: [], filters: []`, three
+ * capability tags) — no semantic surface `SemanticRadioSurfaces.svelte`
+ * actually mounts (`vfo`/`rxTx`/`txAux`/`meters`/`rxAudio`, verified against
+ * its own imports) consumes `modes`/`filters`, or any of the DSP tags added
+ * below, so the vacuous shape proved nothing about those gates being
+ * honestly absent versus never exercised. Hardened to a REAL radio's shape —
+ * IC-7610 (`rigs/ic7610.toml`), the only dual-receiver profile in the tree
+ * and already this fixture's implied topology (`receivers: 2, vfoScheme:
+ * 'main_sub'`) — modes/filters/tags verbatim from that profile, with three
+ * exclusions:
+ *
+ *  - `scope`: `caps.scope` stays `false` (the MOR-1085 `audio-only-scope`
+ *    contrast fixture depends on it), and `presentation-capabilities.ts`'s
+ *    `agreed()` raises `scope-capability-contradiction` the moment the tag
+ *    and the boolean disagree.
+ *  - `tuner`/`vox`/`compressor`/`monitor`/`drive_gain` (the `deriveTxAux`
+ *    evidence tags): this harness (`fixtures/main.ts`) mounts
+ *    `DualReceiverCockpit` with NO `SurfacePlan` context, so
+ *    `SemanticRadioSurfaces.svelte`'s `zoneOwning()` is unconditionally
+ *    `null` and `TxAuxSurface` would render its controls ZONE-LESS rather
+ *    than inside `tx-aux` — flipping every fixture's pinned
+ *    `zonelessControls: 0` for a reason unrelated to this ticket. Left
+ *    exactly as before (absent), so `deriveTxAux` keeps emitting no group.
+ */
 const baseCaps = (): Capabilities => ({
   model: 'fixture', scope: false, audio: true, tx: true,
-  capabilities: ['audio', 'tx', 'dual_rx'], receivers: 2, vfoScheme: 'main_sub',
-  freqRanges: [], modes: [], filters: [],
+  capabilities: [
+    'audio', 'tx', 'dual_rx', 'dual_watch', 'lan_dual_rx_audio_routing',
+    'af_level', 'rf_gain', 'squelch', 'attenuator', 'preamp', 'digisel', 'ip_plus',
+    'antenna', 'rx_antenna', 'nb', 'nr', 'notch', 'apf', 'twin_peak', 'pbt',
+    'filter_width', 'filter_shape', 'split', 'ssb_tx_bw', 'cw', 'break_in', 'rit', 'xit',
+    'meters', 'data_mode', 'mod_input_routing', 'agc', 'power_control', 'dial_lock',
+    'scan', 'bsr', 'main_sub_tracking', 'tuning_step', 'band_edge', 'xfc', 'system_settings',
+  ],
+  receivers: 2, vfoScheme: 'main_sub',
+  freqRanges: [], modes: ['USB', 'LSB', 'CW', 'CW-R', 'AM', 'FM', 'RTTY', 'RTTY-R', 'PSK', 'PSK-R'],
+  filters: ['FIL1', 'FIL2', 'FIL3'],
   audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
   webrtc: { available: false, enabled: false },
   txBands: [{ start: 14000000, end: 14350000, name: '20m' }],

--- a/frontend/fixtures/catalog.ts
+++ b/frontend/fixtures/catalog.ts
@@ -191,32 +191,38 @@ function withMeters(state: ServerState): ServerState {
 }
 
 /**
- * MOR-1351: was an inert placeholder (`modes: [], filters: []`, three
- * capability tags) — no semantic surface `SemanticRadioSurfaces.svelte`
- * actually mounts (`vfo`/`rxTx`/`txAux`/`meters`/`rxAudio`, verified against
- * its own imports) consumes `modes`/`filters`, or any of the DSP tags added
- * below, so the vacuous shape proved nothing about those gates being
- * honestly absent versus never exercised. Hardened to a REAL radio's shape —
- * IC-7610 (`rigs/ic7610.toml`), the only dual-receiver profile in the tree
- * and already this fixture's implied topology (`receivers: 2, vfoScheme:
- * 'main_sub'`) — modes/filters/tags verbatim from that profile, with three
- * exclusions:
+ * MOR-1351: hardened to a REAL radio's shape — IC-7610 (`rigs/ic7610.toml`),
+ * the only dual-receiver profile in the tree and already this fixture's
+ * implied topology (`receivers: 2, vfoScheme: 'main_sub'`) — modes/filters/
+ * tags verbatim from that profile, with one exclusion:
  *
- *  - `scope`: `caps.scope` stays `false` (the MOR-1085 `audio-only-scope`
- *    contrast fixture depends on it), and `presentation-capabilities.ts`'s
- *    `agreed()` raises `scope-capability-contradiction` the moment the tag
- *    and the boolean disagree.
  *  - `tuner`/`vox`/`compressor`/`monitor`/`drive_gain` (the `deriveTxAux`
- *    evidence tags): this harness (`fixtures/main.ts`) mounts
- *    `DualReceiverCockpit` with NO `SurfacePlan` context, so
- *    `SemanticRadioSurfaces.svelte`'s `zoneOwning()` is unconditionally
- *    `null` and `TxAuxSurface` would render its controls ZONE-LESS rather
- *    than inside `tx-aux` — flipping every fixture's pinned
- *    `zonelessControls: 0` for a reason unrelated to this ticket. Left
- *    exactly as before (absent), so `deriveTxAux` keeps emitting no group.
+ *    evidence tags): this harness (`fixtures/main.ts`) supplies NO resolved
+ *    `SurfacePlan`, so `SemanticRadioSurfaces.svelte`'s `zoneOwning()` is
+ *    unconditionally `null` and `TxAuxSurface` would render its controls
+ *    ZONE-LESS rather than inside `tx-aux` — flipping every fixture's pinned
+ *    `zonelessControls: 0` for a reason unrelated to this ticket. Confirmed
+ *    by measurement: adding `tuner` alone (`deriveTxAux`'s cheapest evidence
+ *    tag — `hasTuner` alone satisfies `hasEvidence`) flips 36/60 captures to
+ *    `zone-less-control-count: 4` (the ATU button, ATU-tune button, and two
+ *    disabled inputs, landing `NO-ZONE`). All five tags stay OUT here, unlike
+ *    the cockpit vitest fixture where `render(defaultPlan())` supplies a real
+ *    plan and `tuner` (pre-existing since MOR-1336/S4) lands inside `tx-aux`
+ *    correctly. Follow-up ticket N1 will wire the plan and lift this
+ *    exclusion together.
+ *
+ * `scope` is now `true` with a `'scope'` tag (matching the cockpit vitest
+ * fixture): `presentation-capabilities.ts`'s `agreed()` requires the boolean
+ * and the tag to agree, so leaving the tag off while flipping the boolean
+ * would itself raise `scope-capability-contradiction`. The MOR-1085
+ * `audio-only-scope` contrast fixture below now states its own `scope: false`
+ * condition explicitly instead of inheriting it (see `audioOnlyScopeCaps`).
+ * This flips `topology-2-main-sub`'s `expect.scopeFacts.hardwareScope` from
+ * `structural: false` to `structural: true` — `operational` stays `false`
+ * because no fixture state carries `scopeControls`.
  */
 const baseCaps = (): Capabilities => ({
-  model: 'fixture', scope: false, audio: true, tx: true,
+  model: 'fixture', scope: true, audio: true, tx: true,
   capabilities: [
     'audio', 'tx', 'dual_rx', 'dual_watch', 'lan_dual_rx_audio_routing',
     'af_level', 'rf_gain', 'squelch', 'attenuator', 'preamp', 'digisel', 'ip_plus',
@@ -224,10 +230,19 @@ const baseCaps = (): Capabilities => ({
     'filter_width', 'filter_shape', 'split', 'ssb_tx_bw', 'cw', 'break_in', 'rit', 'xit',
     'meters', 'data_mode', 'mod_input_routing', 'agc', 'power_control', 'dial_lock',
     'scan', 'bsr', 'main_sub_tracking', 'tuning_step', 'band_edge', 'xfc', 'system_settings',
+    'scope',
   ],
   receivers: 2, vfoScheme: 'main_sub',
-  freqRanges: [], modes: ['USB', 'LSB', 'CW', 'CW-R', 'AM', 'FM', 'RTTY', 'RTTY-R', 'PSK', 'PSK-R'],
+  freqRanges: [{ start: 1800000, end: 54000000, label: 'HF+6m', bands: [
+    { name: '20m', start: 14000000, end: 14350000, default: 14195000 },
+    { name: '40m', start: 7000000, end: 7300000, default: 7100000 },
+  ] }],
+  modes: ['USB', 'LSB', 'CW', 'CW-R', 'AM', 'FM', 'RTTY', 'RTTY-R', 'PSK', 'PSK-R'],
   filters: ['FIL1', 'FIL2', 'FIL3'],
+  antennas: 2,
+  attValues: [0, 3, 6, 9, 12, 15, 18, 21, 24, 27, 30, 33, 36, 39, 42, 45],
+  preValues: [0, 1, 2],
+  agcModes: [1, 2, 3], agcLabels: { '1': 'FAST', '2': 'MID', '3': 'SLOW' },
   audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
   webrtc: { available: false, enabled: false },
   txBands: [{ start: 14000000, end: 14350000, name: '20m' }],
@@ -238,24 +253,27 @@ const mainSubCaps = baseCaps;
 const abSharedCaps = (): Capabilities =>
   ({ ...baseCaps(), vfoScheme: 'ab_shared' } as unknown as Capabilities);
 const singleCaps = (): Capabilities => ({
-  ...baseCaps(), receivers: 1, vfoScheme: 'single', capabilities: ['audio', 'tx'],
+  ...baseCaps(), receivers: 1, vfoScheme: 'single', scope: false, capabilities: ['audio', 'tx'],
 } as unknown as Capabilities);
 const abCaps = (): Capabilities => ({
-  ...baseCaps(), receivers: 1, vfoScheme: 'ab', capabilities: ['audio', 'tx'],
+  ...baseCaps(), receivers: 1, vfoScheme: 'ab', scope: false, capabilities: ['audio', 'tx'],
 } as unknown as Capabilities);
 /** The ticket's orthogonal condition: scope=false + audioFft=true. */
-const audioOnlyScopeCaps = (): Capabilities =>
-  ({ ...baseCaps(), audioFftAvailable: true } as unknown as Capabilities);
+const audioOnlyScopeCaps = (): Capabilities => ({
+  ...baseCaps(), scope: false,
+  capabilities: baseCaps().capabilities.filter((t) => t !== 'scope'),
+  audioFftAvailable: true,
+} as unknown as Capabilities);
 /** Structurally dual, no `dual_rx` tag → `dual-rx-unavailable` (MOR-1256). */
 const dualRxUnavailableCaps = (): Capabilities =>
-  ({ ...baseCaps(), capabilities: ['audio', 'tx'] } as unknown as Capabilities);
+  ({ ...baseCaps(), scope: false, capabilities: ['audio', 'tx'] } as unknown as Capabilities);
 /**
  * MOR-1085 — the `ab_shared` analogue of `dualRxUnavailableCaps`: structurally
  * dual (`vfoScheme: 'ab_shared'`, `receivers: 2`), no `dual_rx` tag, so the
  * SAME MOR-1256 two-level gate applies on the other dual topology.
  */
 const abSharedDualRxUnavailableCaps = (): Capabilities =>
-  ({ ...abSharedCaps(), capabilities: ['audio', 'tx'] } as unknown as Capabilities);
+  ({ ...abSharedCaps(), scope: false, capabilities: ['audio', 'tx'] } as unknown as Capabilities);
 
 const tx = (over: Partial<TxSnapshot>): TxSnapshot => ({ ...IDLE_TX, ...over });
 
@@ -480,17 +498,21 @@ const CORE_FIXTURES: readonly Fixture[] = [
     what: '2/main_sub — the reference dual state: 4 tiles across 2 strips, MAIN A active.',
     state: () => withMeters(mainSubState('MAIN')), caps: mainSubCaps, tx: tx({}),
     // MOR-1085 checklist item 5 contrast pair (with `audio-only-scope` below):
-    // baseCaps has NO scope tag and `audioFftAvailable: false`, so both scope
-    // sources read fully unavailable — computed straight from the real
-    // adapter, not asserted by fiat (see `scope-facts-honest` in
-    // assertions.ts). `rxAudioSurfacePresent: false` pins the cockpit's OWN
-    // half of the contrast: the dual composition never mounts
+    // MOR-1351 gave baseCaps a `scope` tag AND `scope: true` (they must
+    // agree, `presentation-capabilities.ts`'s `agreed()`), so hardwareScope
+    // is now structurally available; `audioFftAvailable` stays `false`, so
+    // audioFftScope stays fully unavailable — computed straight from the
+    // real adapter, not asserted by fiat (see `scope-facts-honest` in
+    // assertions.ts). No fixture state carries `scopeControls`, so
+    // hardwareScope stays operationally unavailable even though it is now
+    // structurally available. `rxAudioSurfacePresent: false` pins the
+    // cockpit's OWN half of the contrast: the dual composition never mounts
     // `RxAudioSurface` regardless of any audio capability (structural, not
     // capability-gated) — see the `--reference` twin below for the layout
     // that DOES mount it.
     expect: mainSubExpect({
       scopeFacts: {
-        hardwareScope: { structural: false, operational: false },
+        hardwareScope: { structural: true, operational: false },
         audioFftScope: { structural: false, operational: false },
       },
       rxAudioSurfacePresent: false,
@@ -500,9 +522,11 @@ const CORE_FIXTURES: readonly Fixture[] = [
     id: 'audio-only-scope',
     what: 'scope=false + audioFft=true on 2/main_sub — the cockpit must claim nothing either way.',
     state: () => mainSubState('MAIN'), caps: audioOnlyScopeCaps, tx: tx({}),
-    // `audioOnlyScopeCaps` sets ONLY `audioFftAvailable: true` on top of
-    // baseCaps — `hardwareScope` is untouched (still fully unavailable) and
-    // `audioFftScope.operational` follows `state !== null`, true here.
+    // `audioOnlyScopeCaps` explicitly restates `scope: false` (and drops the
+    // `scope` tag) on top of baseCaps, then sets `audioFftAvailable: true` —
+    // `hardwareScope` stays fully unavailable (structural comes from the
+    // explicit override, not an inherited default) and `audioFftScope.
+    // operational` follows `state !== null`, true here.
     expect: mainSubExpect({
       scopeFacts: {
         hardwareScope: { structural: false, operational: false },

--- a/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
+++ b/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
@@ -127,13 +127,17 @@ function mainSubState(active: 'MAIN' | 'SUB' = 'MAIN'): ServerState {
  * carry enough TX-aux evidence for the MOR-1244 gate to emit the group —
  * otherwise the surface self-gates away, the zone has nothing to hold, and the
  * F6 "every declared zone renders" invariant fails for the right reason but the
- * wrong cause. `tuner` is the cheapest honest evidence (`deriveTxAux` accepts a
- * capability tag OR a raw value); `vox`/`compressor`/`monitor`/`drive_gain`
- * stay OUT deliberately — this harness never supplies a resolved `SurfacePlan`
- * (see `render()` below), so `zoneOwning` is unconditionally null and any
- * ADDITIONAL txAux evidence tag would render its control zone-less rather
- * than inside `tx-aux`, changing the zone-containment shape these tests pin
- * rather than deepening it.
+ * wrong cause. `tuner` was the cheapest honest evidence (`deriveTxAux` accepts
+ * a capability tag OR a raw value) when this fixture carried only one tag; as
+ * of MOR-1351 all five `deriveTxAux` evidence tags
+ * (`tuner`/`vox`/`compressor`/`monitor`/`drive_gain`) are present. This DOES
+ * land the controls inside the declared `tx-aux` zone rather than zone-less —
+ * unlike the browser fixture catalog (`fixtures/catalog.ts`), this harness's
+ * `render()` (below) DOES accept and resolve a real `SurfacePlan`
+ * (`render(defaultPlan())`, used by every MOR-1069 assertion in this file), so
+ * `zoneOwning()` is NOT unconditionally null here — the earlier claim that it
+ * was (pre-MOR-1351) was wrong for this file; that reasoning only holds for
+ * `fixtures/catalog.ts`'s browser harness, which has no plan context at all.
  *
  * MOR-1351: `modes`/`filters` and the rest of the capability tags were an
  * inert placeholder (`[]` / four tags) — the view-model groups those tags
@@ -147,13 +151,16 @@ function mainSubState(active: 'MAIN' | 'SUB' = 'MAIN'): ServerState {
  * (`rigs/ic7610.toml`), the only
  * dual-receiver profile in the tree and already this fixture's implied
  * topology (`receivers: 2`, `vfoScheme: 'main_sub'`) — modes/filters/tags
- * verbatim from that profile, MINUS `scope` (would flip the deliberate
- * `scope: false` into a `scope-capability-contradiction` diagnostic —
- * `presentation-capabilities.ts`'s `agreed()`) and minus the four txAux tags
- * held out above.
+ * verbatim from that profile, WITH `scope` now included: `caps.scope: true`
+ * AND the `'scope'` tag together (`presentation-capabilities.ts`'s `agreed()`
+ * requires the boolean and the tag to agree — the resolution is to flip BOTH
+ * to true, not to drop the tag while leaving the boolean disagreeing). The
+ * MOR-1085 `audio-only-scope` contrast fixture (`audioOnlyScopeCaps` below)
+ * now states its own `scope: false` condition explicitly instead of
+ * inheriting an unstated default.
  */
 const mainSubCaps = (): Capabilities => ({
-  model: 'fixture', scope: false, audio: true, tx: true,
+  model: 'fixture', scope: true, audio: true, tx: true,
   capabilities: [
     'audio', 'tx', 'dual_rx', 'tuner', 'dual_watch', 'lan_dual_rx_audio_routing',
     'af_level', 'rf_gain', 'squelch', 'attenuator', 'preamp', 'digisel', 'ip_plus',
@@ -161,10 +168,19 @@ const mainSubCaps = (): Capabilities => ({
     'filter_width', 'filter_shape', 'split', 'ssb_tx_bw', 'cw', 'break_in', 'rit', 'xit',
     'meters', 'data_mode', 'mod_input_routing', 'agc', 'power_control', 'dial_lock',
     'scan', 'bsr', 'main_sub_tracking', 'tuning_step', 'band_edge', 'xfc', 'system_settings',
+    'scope', 'vox', 'compressor', 'monitor', 'drive_gain',
   ],
   receivers: 2, vfoScheme: 'main_sub',
-  freqRanges: [], modes: ['USB', 'LSB', 'CW', 'CW-R', 'AM', 'FM', 'RTTY', 'RTTY-R', 'PSK', 'PSK-R'],
+  freqRanges: [{ start: 1800000, end: 54000000, label: 'HF+6m', bands: [
+    { name: '20m', start: 14000000, end: 14350000, default: 14195000 },
+    { name: '40m', start: 7000000, end: 7300000, default: 7100000 },
+  ] }],
+  modes: ['USB', 'LSB', 'CW', 'CW-R', 'AM', 'FM', 'RTTY', 'RTTY-R', 'PSK', 'PSK-R'],
   filters: ['FIL1', 'FIL2', 'FIL3'],
+  antennas: 2,
+  attValues: [0, 3, 6, 9, 12, 15, 18, 21, 24, 27, 30, 33, 36, 39, 42, 45],
+  preValues: [0, 1, 2],
+  agcModes: [1, 2, 3], agcLabels: { '1': 'FAST', '2': 'MID', '3': 'SLOW' },
   audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
   webrtc: { available: false, enabled: false },
   txBands: [{ start: 14000000, end: 14350000, name: '20m' }],
@@ -213,12 +229,14 @@ function singleReceiverState(): ServerState {
 }
 /** 1/single caps: no `dual_rx` tag, or the topology derivation contradicts itself. */
 const singleReceiverCaps = (): Capabilities => ({
-  ...mainSubCaps(), receivers: 1, vfoScheme: 'single', capabilities: ['audio', 'tx'],
+  ...mainSubCaps(), receivers: 1, vfoScheme: 'single', scope: false, capabilities: ['audio', 'tx'],
 } as unknown as Capabilities);
 
 /** The ticket's operational audio-scope condition: scope=false + audioFft=true. */
 const audioOnlyScopeCaps = (): Capabilities => ({
-  ...mainSubCaps(), audioFftAvailable: true,
+  ...mainSubCaps(), scope: false,
+  capabilities: mainSubCaps().capabilities.filter((t) => t !== 'scope'),
+  audioFftAvailable: true,
 } as unknown as Capabilities);
 
 /**
@@ -231,7 +249,7 @@ const audioOnlyScopeCaps = (): Capabilities => ({
  * independent of what state.sub happens to report.
  */
 const dualRxUnavailableCaps = (): Capabilities => ({
-  ...mainSubCaps(), capabilities: ['audio', 'tx'],
+  ...mainSubCaps(), scope: false, capabilities: ['audio', 'tx'],
 } as unknown as Capabilities);
 
 let target: HTMLDivElement;

--- a/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
+++ b/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
@@ -128,12 +128,43 @@ function mainSubState(active: 'MAIN' | 'SUB' = 'MAIN'): ServerState {
  * otherwise the surface self-gates away, the zone has nothing to hold, and the
  * F6 "every declared zone renders" invariant fails for the right reason but the
  * wrong cause. `tuner` is the cheapest honest evidence (`deriveTxAux` accepts a
- * capability tag OR a raw value); everything else stays as it was.
+ * capability tag OR a raw value); `vox`/`compressor`/`monitor`/`drive_gain`
+ * stay OUT deliberately — this harness never supplies a resolved `SurfacePlan`
+ * (see `render()` below), so `zoneOwning` is unconditionally null and any
+ * ADDITIONAL txAux evidence tag would render its control zone-less rather
+ * than inside `tx-aux`, changing the zone-containment shape these tests pin
+ * rather than deepening it.
+ *
+ * MOR-1351: `modes`/`filters` and the rest of the capability tags were an
+ * inert placeholder (`[]` / four tags) — the view-model groups those tags
+ * gate (`deriveModeFilter`/`deriveFilterPassband`/`deriveAgc`/
+ * `deriveRfFrontEnd`/`deriveRitXit`/`deriveCwKeyer`, all in
+ * `radio-view-model-adapter.ts`) are none of them consumed by
+ * `SemanticRadioSurfaces.svelte` (verified against its own imports: it
+ * renders only `vfo`/`rxTx`/`txAux`/`meters`/`rxAudio`), so a vacuous caps
+ * object here proved nothing about those gates being honestly absent versus
+ * simply never exercised. Hardened to a REAL radio's shape — IC-7610
+ * (`rigs/ic7610.toml`), the only
+ * dual-receiver profile in the tree and already this fixture's implied
+ * topology (`receivers: 2`, `vfoScheme: 'main_sub'`) — modes/filters/tags
+ * verbatim from that profile, MINUS `scope` (would flip the deliberate
+ * `scope: false` into a `scope-capability-contradiction` diagnostic —
+ * `presentation-capabilities.ts`'s `agreed()`) and minus the four txAux tags
+ * held out above.
  */
 const mainSubCaps = (): Capabilities => ({
   model: 'fixture', scope: false, audio: true, tx: true,
-  capabilities: ['audio', 'tx', 'dual_rx', 'tuner'], receivers: 2, vfoScheme: 'main_sub',
-  freqRanges: [], modes: [], filters: [],
+  capabilities: [
+    'audio', 'tx', 'dual_rx', 'tuner', 'dual_watch', 'lan_dual_rx_audio_routing',
+    'af_level', 'rf_gain', 'squelch', 'attenuator', 'preamp', 'digisel', 'ip_plus',
+    'antenna', 'rx_antenna', 'nb', 'nr', 'notch', 'apf', 'twin_peak', 'pbt',
+    'filter_width', 'filter_shape', 'split', 'ssb_tx_bw', 'cw', 'break_in', 'rit', 'xit',
+    'meters', 'data_mode', 'mod_input_routing', 'agc', 'power_control', 'dial_lock',
+    'scan', 'bsr', 'main_sub_tracking', 'tuning_step', 'band_edge', 'xfc', 'system_settings',
+  ],
+  receivers: 2, vfoScheme: 'main_sub',
+  freqRanges: [], modes: ['USB', 'LSB', 'CW', 'CW-R', 'AM', 'FM', 'RTTY', 'RTTY-R', 'PSK', 'PSK-R'],
+  filters: ['FIL1', 'FIL2', 'FIL3'],
   audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
   webrtc: { available: false, enabled: false },
   txBands: [{ start: 14000000, end: 14350000, name: '20m' }],


### PR DESCRIPTION
## Summary

The dual-receiver cockpit fixture and the browser-harness catalog declared vacuous caps (modes: [], filters: [], 3 tags), making every cap-gated semantic surface INVISIBLE to the four MOR-1069 invariant assertions - the blindness that let the 4B bare-dual-mount violation report green (mounting canon on MOR-1304). This PR gives both fixtures IC-7610's real profile: 41 capability tags + the non-tag gate fields (freqRanges, antennas, attValues/preValues, agcModes/agcLabels), scope enabled with explicit audio-only overrides, txAux tags in the cockpit test (plan exists there), catalog exclusion tracked as MOR-1355.

Test-only, 0 production LOC.

## Proof

Bite: one zone-less control gated on view?.band / view?.scopeControls / view?.antenna each turns MOR-1069 red (4-5 failures); all invisible with the old caps. Clean state: cockpit 43/43; harness 60/60 valid, 1797/1797 assertions, zero ok-flips (one disclosed detail change on 20 captures: scope-facts-honest); full suite 5352/5352 on a rebase-preview against current main.

## Review provenance

Prescribed by the vocabulary-domain opus anchor #1 (as the highest-leverage fix from the 4B/5B verifications); built by sonnet; completed after a first fixer attempt introduced a regression ('tuner' tag breaking 36/60 captures - caught by running, reverted); adjudicated and delta-confirmed by opus anchor #2 with every claim reproduced by hand, including the F-DELTA self-contradiction fix (6 explicit scope: false pins) pre-verified at every gate. Unplanned validation: the harness now renders 4B/5B surfaces (21->54 controls on reference captures) with all a11y assertions holding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)