### PR TITLE
feat(MOR-1307): band surface (7B, safety-adjacent) - live-permit-only TX readout

### DIFF
--- a/frontend/fixtures/stubs/command-bus.ts
+++ b/frontend/fixtures/stubs/command-bus.ts
@@ -52,11 +52,19 @@ function recorders<K extends string>(
   ) as Record<K, (...args: unknown[]) => void>;
 }
 
+/** MOR-1307: `onMainFreqChange`/`onSubFreqChange` are the per-receiver
+ *  `set_freq` path the semantic wiring routes BOTH digit tuning (MOR-1322)
+ *  and the band surface's frequency entry / no-BSR band fallback through.
+ *  Missing here they were not a resolution failure — the names are read off
+ *  the returned object, not the module — but the first captured gesture that
+ *  reached one would have thrown inside the harness instead of recording. */
 export function makeVfoHandlers() {
   return {
     onVfoSelect: (...args: unknown[]): void => record('vfo.select', args),
     onSplitToggle: (...args: unknown[]): void => record('vfo.split', args),
     onDualWatchToggle: (...args: unknown[]): void => record('vfo.dualWatch', args),
+    onMainFreqChange: (...args: unknown[]): void => record('vfo.mainFreq', args),
+    onSubFreqChange: (...args: unknown[]): void => record('vfo.subFreq', args),
   };
 }
 
@@ -158,6 +166,8 @@ export function makePresetHandlers() {
   return recorders('preset', ['onPresetSelect', 'onFreqPreset'] as const);
 }
 
+/** MOR-1307: reached by the fixture-mounted tree from this slice on — the
+ *  band surface's BSR path calls `onBandSelect`. Name set unchanged. */
 export function makeBandHandlers() {
   return recorders('band', ['onBandSelect'] as const);
 }

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -31,6 +31,7 @@
     compositionSurfaces, useSurfacePlan, zoneShowsSurface,
   } from '../../presentation/workspace/resolution';
   import { LAN_MOD_INPUT_SOURCE } from '$lib/radio/mod-input';
+  import BandSurface from '../../semantic/BandSurface.svelte';
   import DspSurface, {
     type DspLevelField, type DspToggleField,
   } from '../../semantic/DspSurface.svelte';
@@ -49,9 +50,9 @@
   import VfoSurface, { type VfoSelection } from '../../semantic/VfoSurface.svelte';
   import ModInputTxWarning from '../panels/ModInputTxWarning.svelte';
   import {
-    makeAgcHandlers, makeAudioRoutingHandlers, makeDspHandlers, makeFilterHandlers,
-    makeModeHandlers, makeRfFrontEndHandlers, makeRxAudioHandlers, makeTxHandlers,
-    makeVfoHandlers, makeVoxHandlers,
+    makeAgcHandlers, makeAudioRoutingHandlers, makeBandHandlers, makeDspHandlers,
+    makeFilterHandlers, makeModeHandlers, makeRfFrontEndHandlers, makeRxAudioHandlers,
+    makeTxHandlers, makeVfoHandlers, makeVoxHandlers,
   } from './command-bus';
   import {
     forReceiver, receiversOf, isActiveStrip, isOperationalStrip,
@@ -143,6 +144,8 @@
   }
 
   const vfo = makeVfoHandlers();
+  /** MOR-1307: the shipped band vocabulary, composed rather than forked. */
+  const band = makeBandHandlers();
   /**
    * MOR-1265. The two v2 handler factories already carry every txAux intent
    * (`makeVoxHandlers` owns gain/anti-VOX/delay, `makeTxHandlers` the rest);
@@ -332,6 +335,36 @@
   function tuneFrequency(receiver: 'MAIN' | 'SUB', frequencyHz: number): void {
     if (receiver === 'SUB') vfo.onSubFreqChange(frequencyHz);
     else vfo.onMainFreqChange(frequencyHz);
+  }
+
+  /**
+   * MOR-1307 (vocabulary slice 7B) — band select and frequency entry, both
+   * routed through the SHIPPED command vocabulary and both gated on a KNOWN
+   * active receiver.
+   *
+   * The gate is the MOR-1322 B1 wrong-VFO dispatch class: `set_freq` /
+   * `set_band` write the ACTIVE receiver's VFO, and the `band` facts are
+   * themselves derived from the active receiver — so with `activeReceiver`
+   * unobserved there is no honest target and neither intent may leave. The
+   * surface disables the controls on the same condition; this is the second,
+   * independent mechanism.
+   *
+   * A band WITHOUT a band-stacking register falls back to a plain frequency
+   * set, and that fallback goes through `tuneFrequency` — the SAME per-receiver
+   * path the VFO tuning uses — rather than `makeBandHandlers`' own fallback,
+   * which hardcodes `receiver: 0` and would tune MAIN while SUB is active.
+   * The BSR path stays the shipped handler untouched.
+   */
+  function selectBand(name: string, defaultHz: number, bsrCode: number | null): void {
+    const active = view?.activeReceiver;
+    if (active?.status !== 'known') return;
+    if (bsrCode !== null) band.onBandSelect(name, defaultHz, bsrCode);
+    else tuneFrequency(active.receiver, defaultHz);
+  }
+  function enterFrequency(frequencyHz: number): void {
+    const active = view?.activeReceiver;
+    if (active?.status !== 'known') return;
+    tuneFrequency(active.receiver, frequencyHz);
   }
 
   function selectVfo(target: VfoSelection): void {
@@ -705,6 +738,30 @@
     {/if}
   {/snippet}
 
+  <!--
+    MOR-1307 (vocabulary slice 7B). Same structural gate as the surfaces above,
+    and the SAME single-composition-only mounting as `rxAudioSurface`, for the
+    same MOR-1069 reason: this surface is control-bearing (band buttons, a
+    frequency entry field and its Set button) and no manifest declares a `band`
+    zone, so a dual mount would put focusable controls outside every declared
+    zone and break the cockpit's "tab order ends in rx-tx" invariant. `zoned()`
+    does not grant that permission by itself — `zoneOwning()` answers `null` for
+    an undeclared surface and the mount renders BARE, which is the violating
+    shape. `'band'` becomes DECLARABLE with this slice; the cockpit gains the
+    surface the moment a rework slice declares a zone for it, and the dual
+    absence is pinned by name in
+    `__tests__/semantic-band-wiring.component.test.ts`.
+
+    It takes NO authority snapshot: the TX permit it renders is already decided
+    inside `view.band` by the one shipped derivation, and this component has no
+    second one to offer.
+  -->
+  {#snippet bandSurface()}
+    {#if view?.band}
+      <BandSurface {view} onSelectBand={selectBand} onEnterFrequency={enterFrequency} />
+    {/if}
+  {/snippet}
+
   {#if strips === 'dual'}
     <!--
       MOR-1258: the zone now carries RxTxSurface AND the two TX-adjacent
@@ -751,6 +808,7 @@
     {@render zoned('filter', view?.modeFilter !== undefined || view?.filterPassband !== undefined, filterSurface)}
     {@render zoned('dsp', view?.dsp !== undefined, dspSurface)}
     {@render zoned('rfFrontEnd', view?.rfFrontEnd !== undefined, rfFrontEndSurface)}
+    {@render zoned('band', view?.band !== undefined, bandSurface)}
     {@render txAdjacentAlerts()}
   {/if}
 </div>

--- a/frontend/src/components-v2/wiring/__tests__/semantic-band-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-band-wiring.component.test.ts
@@ -348,3 +348,30 @@ describe('the rendered TX permit is the LIVE-frequency answer (7B carry-forward 
     expect(el('tx-value')!.textContent!.trim()).toBe('allowed');
   });
 });
+
+/* ── the caveat, end to end through the real adapter's two-permit split
+   (fix-round F1) ────────────────────────────────────────────────────── */
+
+describe('a split TX target surfaces the caveat, end to end (fix-round F1)', () => {
+  /**
+   * THE F1 REGRESSION PIN, end to end. MAIN (the ACTIVE receiver) sits at
+   * 14.250 — inside the 20m TX segment, so `band.currentBandTx` (scoped to
+   * the active receiver) reads `allowed`. But the TX TARGET is SUB, split to
+   * 7.250 — inside the 40m band-plan band but OUTSIDE the 40m TX segment
+   * (7.000-7.200) — so the authoritative `view.txPermit` (`tx-capabilities.ts`,
+   * keyed off `txTarget.frequencyHz`) reads `denied`. A surface that shows
+   * only `band.currentBandTx` renders an unqualified "TX HERE: allowed"
+   * while the radio would refuse to key. The caveat must be visible.
+   */
+  it('shows TX HERE: allowed but a denied TX-target caveat under split', () => {
+    h.state = liveState({
+      split: true,
+      sub: { ...slot(7250000), vfoA: slot(7250000), activeSlot: 'A', filter: 1 },
+      txTarget: { status: 'known', receiver: 'SUB', slot: 'A', frequencyHz: 7250000 },
+    } as unknown as Partial<ServerState>);
+    render();
+    expect(el('tx-value')!.textContent!.trim()).toBe('allowed');
+    expect(el('tx-caveat')).not.toBeNull();
+    expect(el('tx-caveat')!.textContent).toContain('denied');
+  });
+});

--- a/frontend/src/components-v2/wiring/__tests__/semantic-band-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-band-wiring.component.test.ts
@@ -1,0 +1,350 @@
+/**
+ * MOR-1307 — the semantic band surface wired into `SemanticRadioSurfaces`.
+ *
+ * `semantic/__tests__/BandSurface.test.ts` proves what the surface does with a
+ * view model. This file proves what only the composed tree can prove, using the
+ * REAL command bus, the REAL adapter and the REAL surface — only the transport
+ * and runtime SEAMS are spied:
+ *
+ *   (a) THE MOUNTING CANON. The surface is control-bearing (band buttons, a
+ *       frequency field, a Set button) and no manifest declares a `band` zone,
+ *       so it must NOT appear in the dual composition — and the pin renders the
+ *       dual composition with caps that DO emit the group, because a fixture
+ *       that cannot see the surface is the bug, not the proof (MOR-1304 §1).
+ *   (b) THE WRONG-VFO CLASS (MOR-1322 B1). Every intent this surface can fire
+ *       lands on the ACTIVE receiver. The no-BSR band fallback in particular
+ *       must NOT take `makeBandHandlers`' own `receiver: 0` path while SUB is
+ *       active.
+ *   (c) The intents are the SHIPPED command vocabulary, not a v3 fork.
+ *   (d) The wiring's own active-receiver guard is independent of the surface's.
+ *   (e) The structural gate: a radio with no declared frequency range renders
+ *       the pre-1307 element shape exactly.
+ *
+ * Isolated pool by name (`*.component.test.ts`), per the MOR-1272 doctrine.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { ServerState } from '$lib/types/state';
+
+type Snapshot = {
+  phase: string; intent: string | null; guard: { leaseId: string } | null;
+  radioTx: string; txRisk: string; mayOwnKey: boolean; fault: string | null;
+};
+
+const h = vi.hoisted(() => ({
+  state: null as unknown,
+  caps: null as unknown,
+  snapshot: null as unknown,
+  audio: { muted: false, rxEnabled: true, volume: 42 },
+  audioConnected: true,
+  rxEnabled: true,
+  listeners: new Set<(next: unknown) => void>(),
+}));
+
+vi.mock('$lib/transport/ws-client', () => ({ sendCommand: vi.fn() }));
+vi.mock('$lib/audio/audio-manager', () => ({
+  audioManager: {
+    get rxEnabled() { return h.rxEnabled; },
+    startRx: vi.fn(), stopRx: vi.fn(), setRxVolume: vi.fn(), setAudioConfig: vi.fn(),
+  },
+}));
+vi.mock('$lib/runtime/frontend-runtime', () => ({
+  runtime: {
+    get state() { return h.state; },
+    get caps() { return h.caps; },
+    get audio() { return h.audio; },
+    get connectionAudio() { return h.audioConnected; },
+    get rxEnabled() { return h.rxEnabled; },
+    setVolume: vi.fn(), setMuted: vi.fn(), setRxLive: vi.fn(), setRxVolume: vi.fn(),
+  },
+}));
+vi.mock('$lib/runtime', async () => ({
+  runtime: (await import('$lib/runtime/frontend-runtime')).runtime,
+}));
+vi.mock('$lib/runtime/tx-controller/app-host', () => ({
+  getAppTxController: () => ({
+    snapshot: () => h.snapshot,
+    subscribe: (listener: (next: unknown) => void) => {
+      h.listeners.add(listener);
+      return () => { h.listeners.delete(listener); };
+    },
+    start: vi.fn(), setIntent: vi.fn(), release: vi.fn(), resetFault: vi.fn(),
+  }),
+}));
+vi.mock('$lib/runtime/adapters/mod-input-tx-guard.svelte', () => ({
+  deriveModInputTxGuardProps: () => ({ visible: false, sourceLabel: 'MIC' }),
+  getModInputTxGuardHandlers: () => ({ onSetLan: vi.fn(), onDismiss: vi.fn() }),
+}));
+
+import { sendCommand } from '$lib/transport/ws-client';
+import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';
+import { makeBandHandlers, makeVfoHandlers } from '../command-bus';
+
+const IDLE: Snapshot = {
+  phase: 'idle', intent: null, guard: null, radioTx: 'off', txRisk: 'none',
+  mayOwnKey: false, fault: null,
+};
+const fresh = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' };
+const slot = (freqHz: number) => ({ freqHz, mode: 'USB', filterNum: 1, dataMode: 0 });
+
+/** MAIN sits at 14.250 (inside the 20m TX segment), SUB at 7.100 (inside 40m). */
+function liveState(over: Partial<ServerState> = {}): ServerState {
+  const paths = ['active', 'split', 'dualWatch', 'txTarget', 'dataOffModInput'];
+  for (const rx of ['main', 'sub']) {
+    paths.push(`${rx}.freqHz`, `${rx}.mode`, `${rx}.filter`, `${rx}.activeSlot`);
+    for (const v of ['vfoA', 'vfoB']) {
+      paths.push(`${rx}.${v}.freqHz`, `${rx}.${v}.mode`, `${rx}.${v}.filterNum`);
+    }
+  }
+  const receiver = (hz: number) => ({
+    ...slot(hz), vfoA: slot(hz), vfoB: slot(hz + 50000), activeSlot: 'A', filter: 1,
+  });
+  return {
+    active: 'MAIN', split: false, dualWatch: false, ptt: false, dataOffModInput: 5,
+    txTarget: { status: 'known', receiver: 'MAIN', slot: 'A', frequencyHz: 14250000 },
+    main: receiver(14250000), sub: receiver(7100000),
+    ...over,
+    fieldStatus: Object.fromEntries(paths.map((p) => [p, fresh])),
+  } as unknown as ServerState;
+}
+
+/** `freqRanges` is the band group's WHOLE evidence gate — the cockpit
+ *  fixture's `freqRanges: []` is exactly the blindness MOR-1304 §1 recorded,
+ *  so this fixture declares a real plan and the dual-absence pin is real. */
+const BAND_PLAN = [{
+  start: 30000, end: 60000000,
+  bands: [
+    { name: '40m', start: 7000000, end: 7300000, default: 7100000, bsrCode: 2 },
+    { name: '20m', start: 14000000, end: 14350000, default: 14195000, bsrCode: 5 },
+    // No BSR — the `set_freq` fallback path, i.e. the wrong-VFO hazard.
+    { name: 'MW', start: 520000, end: 1710000, default: 1000000 },
+  ],
+}];
+
+const liveCaps = (freqRanges: unknown[]): Capabilities => ({
+  model: 'fixture', scope: false, audio: true, tx: true,
+  capabilities: ['audio', 'tx', 'dual_rx'], audioTxRequiredModInputSource: 5,
+  receivers: 2, vfoScheme: 'main_sub', freqRanges, modes: [], filters: [],
+  audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
+  webrtc: { available: false, enabled: false },
+  txBands: [
+    { start: 7000000, end: 7200000, name: '40m' },
+    { start: 14000000, end: 14350000, name: '20m' },
+  ],
+  scopeSource: null, audioFftAvailable: false,
+} as unknown as Capabilities);
+
+let target: HTMLDivElement;
+let component: ReturnType<typeof mount> | null = null;
+
+function render(props: { strips?: 'single' | 'dual' } = {}): void {
+  target = document.createElement('div');
+  document.body.appendChild(target);
+  component = mount(SemanticRadioSurfaces, { target, props });
+  flushSync();
+}
+
+const q = <T extends HTMLElement>(sel: string) => target.querySelector(sel) as T | null;
+const el = (id: string) => q<HTMLElement>(`[data-testid="band-${id}"]`);
+const btn = (id: string) => q<HTMLButtonElement>(`[data-testid="band-${id}"]`);
+const setFreqCalls = () => vi.mocked(sendCommand).mock.calls.filter(([n]) => n === 'set_freq');
+
+function typeFrequency(value: string): void {
+  const input = q<HTMLInputElement>('[data-testid="band-entry-input"]')!;
+  input.value = value;
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+  flushSync();
+}
+
+beforeEach(() => {
+  h.state = liveState();
+  h.caps = liveCaps(BAND_PLAN);
+  h.snapshot = { ...IDLE };
+  h.listeners.clear();
+  vi.mocked(sendCommand).mockClear();
+});
+
+afterEach(() => {
+  if (component) unmount(component);
+  component = null;
+  document.body.innerHTML = '';
+});
+
+/* ── (a) THE MOUNTING CANON ─────────────────────────────────────── */
+
+describe('the band surface obeys the zone-mount canon (MOR-1069 / MOR-1304)', () => {
+  it('renders it bare in the single composition, outside every zone', () => {
+    render();
+    expect(el('surface')).not.toBeNull();
+    expect(el('surface')!.closest('[data-zone-id]')).toBeNull();
+  });
+
+  /**
+   * THE DUAL-ABSENCE PIN. MUTATION KILLED: mounting this surface in the dual
+   * composition — bare, or through `zoned()`, which renders bare anyway while
+   * no manifest declares a `band` zone (`zoneOwning()` answers `null`). The
+   * view model here DOES carry the band group (asserted below via the single
+   * composition), so this is not the vacuous green MOR-1304 §1 warned about.
+   */
+  it('renders NO band surface in the dual composition, zoned or unzoned', () => {
+    render({ strips: 'dual' });
+    expect(el('surface')).toBeNull();
+    expect(target.innerHTML).not.toContain('band-surface');
+    expect(target.innerHTML).not.toContain('band-entry');
+  });
+
+  it('proves the same view model DOES carry the band group, so the pin is not vacuous', () => {
+    render();
+    expect(el('surface')).not.toBeNull();
+    expect(el('choice-20m')).not.toBeNull();
+  });
+
+  it('leaves the cockpit with no focusable control outside a declared zone', () => {
+    render({ strips: 'dual' });
+    const outside = [...target.querySelectorAll<HTMLElement>('button, input, select, [tabindex]')]
+      .filter((node) => node.closest('[data-zone-id]') === null);
+    expect(outside).toEqual([]);
+  });
+});
+
+/* ── (e) the structural gate ────────────────────────────────────── */
+
+describe('the surface mounts only when the view model carries the group', () => {
+  it('renders no band surface for a radio that declares no frequency range', () => {
+    h.caps = liveCaps([]);
+    render();
+    expect(el('surface')).toBeNull();
+  });
+});
+
+/* ── (b) the wrong-VFO dispatch class ───────────────────────────── */
+
+describe('every band intent lands on the ACTIVE receiver (MOR-1322 B1 class)', () => {
+  // MUTATION KILLED: the no-BSR fallback left to `makeBandHandlers`, whose own
+  // `else` branch sends `set_freq {receiver: 0}` — MAIN — regardless of which
+  // receiver is active. With SUB active that tunes the wrong VFO.
+  it('routes a no-BSR band pick to the SUB receiver while SUB is active', () => {
+    h.state = liveState({ active: 'SUB' } as Partial<ServerState>);
+    render();
+    btn('choice-MW')!.click();
+    flushSync();
+    expect(setFreqCalls()).toEqual([['set_freq', { freq: 1000000, receiver: 1 }]]);
+  });
+
+  it('routes the same pick to MAIN while MAIN is active', () => {
+    render();
+    btn('choice-MW')!.click();
+    flushSync();
+    expect(setFreqCalls()).toEqual([['set_freq', { freq: 1000000, receiver: 0 }]]);
+  });
+
+  // MUTATION KILLED: forking the BSR path instead of using the shipped handler.
+  it('routes a band WITH a stacking register to the shipped set_band command', () => {
+    render();
+    btn('choice-20m')!.click();
+    flushSync();
+    expect(sendCommand).toHaveBeenCalledExactlyOnceWith('set_band', { band: 5 });
+  });
+
+  it('routes a typed frequency to the active receiver', () => {
+    h.state = liveState({ active: 'SUB' } as Partial<ServerState>);
+    render();
+    typeFrequency('7150000');
+    btn('entry-set')!.click();
+    flushSync();
+    expect(setFreqCalls()).toEqual([['set_freq', { freq: 7150000, receiver: 1 }]]);
+  });
+});
+
+/* ── (d) the wiring's own guard, independent of the surface's ───── */
+
+describe('the wiring refuses a receiver-scoped write with no known active receiver', () => {
+  /** `active` unobserved ⇒ `activeReceiver` is `{status:'unknown'}`. The band
+   *  group still derives (its gate is `freqRanges`), so the surface renders. */
+  const unobservedActive = () => {
+    const state = liveState() as unknown as Record<string, unknown>;
+    const status = { ...(state.fieldStatus as Record<string, unknown>) };
+    delete status.active;
+    h.state = { ...state, active: undefined, fieldStatus: status } as unknown as ServerState;
+  };
+
+  // MUTATION KILLED: dropping the wiring-side guard. The surface's `disabled`
+  // is bypassed here, so only the wiring guard (and the surface's own handler
+  // guard, pinned separately in the surface test) can stop the dispatch.
+  it('sends nothing when a band pick is fired past the disabled attribute', () => {
+    unobservedActive();
+    render();
+    expect(el('surface')).not.toBeNull();
+    expect(btn('choice-20m')!.disabled).toBe(true);
+    btn('choice-20m')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    flushSync();
+    expect(sendCommand).not.toHaveBeenCalled();
+  });
+
+  it('sends nothing when a typed frequency is fired past the disabled attribute', () => {
+    unobservedActive();
+    render();
+    btn('entry-set')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    flushSync();
+    expect(sendCommand).not.toHaveBeenCalled();
+  });
+});
+
+/* ── (c) the shipped vocabulary, and no TX authority ────────────── */
+
+describe('the band surface composes the shipped command vocabulary', () => {
+  it('composes the shipped band and VFO factories', () => {
+    for (const [factory, names] of [
+      [makeBandHandlers, ['onBandSelect']],
+      [makeVfoHandlers, ['onMainFreqChange', 'onSubFreqChange']],
+    ] as const) {
+      const handlers = factory() as Record<string, unknown>;
+      for (const name of names) expect(typeof handlers[name]).toBe('function');
+    }
+  });
+
+  // MUTATION KILLED: the surface taking a TX-authority snapshot or growing a
+  // key path. The permit it renders is a FACT, already decided by the adapter.
+  it('never changes with the App TX authority or the raw transmit bit', () => {
+    render();
+    const before = el('surface')!.outerHTML;
+    h.snapshot = { ...IDLE, phase: 'transmitting', radioTx: 'on', mayOwnKey: true };
+    for (const listener of h.listeners) listener(h.snapshot);
+    h.state = liveState({ ptt: true } as Partial<ServerState>);
+    flushSync();
+    expect(el('surface')!.outerHTML).toBe(before);
+  });
+
+  it('mounts and renders the surface without sending a single command', () => {
+    render();
+    expect(el('surface')).not.toBeNull();
+    expect(sendCommand).not.toHaveBeenCalled();
+  });
+});
+
+/* ── the live permit, end to end through the real adapter ───────── */
+
+describe('the rendered TX permit is the LIVE-frequency answer (7B carry-forward 1/F3)', () => {
+  /**
+   * THE FAIL-OPEN REGRESSION PIN, end to end. MAIN sits at 7.250 MHz: inside
+   * the 40m band-plan band (7.000–7.300) but OUTSIDE the 40m TX segment
+   * (7.000–7.200). The band's DEFAULT frequency (7.100) is inside that segment,
+   * so a surface reading `defaultHzTxPermit` would tell the operator "allowed"
+   * at a frequency where transmission is not permitted.
+   */
+  it('reads denied at a live frequency outside a narrower TX segment', () => {
+    h.state = liveState({ main: { ...slot(7250000), vfoA: slot(7250000), activeSlot: 'A' } } as
+      unknown as Partial<ServerState>);
+    render();
+    expect(el('current-value')!.textContent!.trim()).toBe('40m');
+    expect(el('choice-permit-40m')!.textContent).toContain('allowed');
+    expect(el('tx-value')!.textContent!.trim()).toBe('denied');
+  });
+
+  it('reads allowed once the live frequency is inside the segment', () => {
+    render();
+    expect(el('current-value')!.textContent!.trim()).toBe('20m');
+    expect(el('tx-value')!.textContent!.trim()).toBe('allowed');
+  });
+});

--- a/frontend/src/components-v2/wiring/__tests__/semantic-dsp-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-dsp-wiring.component.test.ts
@@ -119,6 +119,10 @@ vi.mock('../command-bus', () => ({
     onAttChange: h.noop, onPreChange: h.noop, onRfGainChange: h.noop,
     onSquelchChange: h.noop, onDigiSelToggle: h.noop, onIpPlusToggle: h.noop,
   }),
+  // MOR-1307 slice 7B: the band-select intent the band surface composes.
+  // This fixture declares no band capability, so it is never reachable —
+  // same stand-in role as `makeVfoHandlers`/`makeTxHandlers` above.
+  makeBandHandlers: () => ({ onBandSelect: h.noop }),
 }));
 
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';

--- a/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
@@ -105,6 +105,8 @@ vi.mock('../command-bus', () => ({
     onAttChange: h.noop, onPreChange: h.noop, onRfGainChange: h.noop,
     onSquelchChange: h.noop, onDigiSelToggle: h.noop, onIpPlusToggle: h.noop,
   }),
+  // MOR-1307 slice 7B: the band-select intent the band surface composes.
+  makeBandHandlers: () => ({ onBandSelect: h.noop }),
 }));
 
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';

--- a/frontend/src/components-v2/wiring/__tests__/semantic-rf-front-end-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rf-front-end-wiring.component.test.ts
@@ -118,6 +118,10 @@ vi.mock('../command-bus', () => ({
     onAttChange: h.att, onPreChange: h.pre, onRfGainChange: h.rfGain,
     onSquelchChange: h.squelch, onDigiSelToggle: h.digiSel, onIpPlusToggle: h.ipPlus,
   }),
+  // MOR-1307 slice 7B: the band-select intent the band surface composes.
+  // This fixture declares no band capability, so it is never reachable —
+  // same stand-in role as the noop handlers above.
+  makeBandHandlers: () => ({ onBandSelect: h.noop }),
 }));
 
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';

--- a/frontend/src/components-v2/wiring/__tests__/semantic-rx-tx-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rx-tx-wiring.component.test.ts
@@ -131,6 +131,8 @@ vi.mock('../command-bus', () => ({
     onAttChange: h.txAuxNoop, onPreChange: h.txAuxNoop, onRfGainChange: h.txAuxNoop,
     onSquelchChange: h.txAuxNoop, onDigiSelToggle: h.txAuxNoop, onIpPlusToggle: h.txAuxNoop,
   }),
+  // MOR-1307 slice 7B: the band-select intent the band surface composes.
+  makeBandHandlers: () => ({ onBandSelect: h.txAuxNoop }),
 }));
 
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';

--- a/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
@@ -120,6 +120,8 @@ vi.mock('../command-bus', () => ({
     onAttChange: h.noop, onPreChange: h.noop, onRfGainChange: h.noop,
     onSquelchChange: h.noop, onDigiSelToggle: h.noop, onIpPlusToggle: h.noop,
   }),
+  // MOR-1307 slice 7B: the band-select intent the band surface composes.
+  makeBandHandlers: () => ({ onBandSelect: h.noop }),
 }));
 
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';

--- a/frontend/src/presentation/layouts/__tests__/band-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/band-declarability.test.ts
@@ -1,0 +1,72 @@
+/**
+ * MOR-1307 — `band` is DECLARABLE, and nothing declares it yet.
+ *
+ * Slice 7B adds the name to `SEMANTIC_SURFACE_NAMES` so a manifest CAN mount
+ * the surface later; it deliberately does not touch any manifest, and it adds
+ * no design-language renderer slot (that set was frozen by MOR-1072).
+ *
+ * Same three pins as `tx-aux-`/`meters-`/`rx-audio-declarability.test.ts`, with
+ * one extra weight here: `band` is a CONTROL-BEARING surface, so "no shipped
+ * manifest declares a band zone" is also what makes the single-composition-only
+ * mount legal under the MOR-1069 cockpit invariant (see the dual-absence pin in
+ * `components-v2/wiring/__tests__/semantic-band-wiring.component.test.ts`). If
+ * a manifest ever gains the zone, that pin must be revisited in the same PR.
+ */
+import { describe, it, expect } from 'vitest';
+import { SEMANTIC_SURFACE_NAMES, validateLayoutManifest } from '../contract';
+import { RENDERER_SLOT_NAMES } from '../../languages/contract';
+import { validLayoutManifest } from './fixtures';
+import {
+  desktopV2Layout, dualReceiverCockpitLayout, lcdCockpitLayout, lcdScopeLayout, mobileLayout,
+  sdrTestLayout,
+} from '../declarations';
+
+describe('band is a declarable semantic surface', () => {
+  // Kills: reverting the SEMANTIC_SURFACE_NAMES addition. MOR-1273 appended
+  // `meters`, MOR-1304 appended `filter`, MOR-1305 appended `dsp`, MOR-1306
+  // appended `rfFrontEnd`; `band` must land last, after all of them.
+  it('is in the declarable set alongside vfo, rxTx, txAux, meters, rxAudio, filter, dsp and rfFrontEnd', () => {
+    expect([...SEMANTIC_SURFACE_NAMES])
+      .toEqual(['vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band']);
+  });
+
+  // Kills: adding the name to the type but not to the runtime allow-list the
+  // zone validator checks — the manifest would still be rejected.
+  it('accepts a manifest zone that declares it', () => {
+    const manifest = validLayoutManifest({
+      zones: [{ id: 'main', surfaces: ['vfo', 'rxTx', 'band'] }],
+      requiredSemanticSurfaces: ['vfo', 'rxTx'],
+    });
+    expect(() => validateLayoutManifest(manifest)).not.toThrow();
+  });
+
+  it('still rejects a zone naming a surface that does not exist', () => {
+    const manifest = validLayoutManifest({
+      zones: [{ id: 'main', surfaces: ['bandSelector'] as unknown as readonly ['vfo'] }],
+    });
+    expect(() => validateLayoutManifest(manifest)).toThrow(/subset of/);
+  });
+});
+
+describe('no shipped manifest declares a band zone in this slice', () => {
+  // Kills: slipping a band zone into an existing layout here. For the cockpit
+  // this is load-bearing, not cosmetic: a declared zone would move the surface
+  // into the dual composition and change what the MOR-1069 tab-order assertion
+  // has to say.
+  it.each([
+    ['sdr-test', sdrTestLayout], ['dual-receiver-cockpit', dualReceiverCockpitLayout],
+    ['lcd-cockpit', lcdCockpitLayout], ['lcd-scope', lcdScopeLayout],
+    ['mobile', mobileLayout], ['desktop-v2', desktopV2Layout],
+  ])('%s declares no band zone and does not require the surface', (_id, manifest) => {
+    for (const zone of manifest.zones) expect(zone.surfaces).not.toContain('band');
+    expect(manifest.requiredSemanticSurfaces).not.toContain('band');
+  });
+});
+
+describe('the design-language renderer slot set is untouched', () => {
+  // Kills: adding a renderer slot for this surface. A band picker has no gauge
+  // grammar a language must describe; the slot set stays frozen.
+  it('still carries exactly the three MOR-1072 slots', () => {
+    expect([...RENDERER_SLOT_NAMES]).toEqual(['meters', 'frequencyDisplay', 'stateFeedback']);
+  });
+});

--- a/frontend/src/presentation/layouts/__tests__/dsp-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/dsp-declarability.test.ts
@@ -20,7 +20,7 @@ describe('dsp is a declarable semantic surface', () => {
   // slice must not create.
   it('is in the declarable set alongside vfo, rxTx, txAux, meters and rxAudio', () => {
     expect([...SEMANTIC_SURFACE_NAMES]).toEqual([
-      'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd',
+      'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band',
     ]);
   });
 

--- a/frontend/src/presentation/layouts/__tests__/filter-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/filter-declarability.test.ts
@@ -23,7 +23,7 @@ describe('filter is a declarable semantic surface', () => {
   // Kills: reverting the SEMANTIC_SURFACE_NAMES addition.
   it('is in the declarable set alongside vfo, rxTx, txAux, meters and rxAudio', () => {
     expect([...SEMANTIC_SURFACE_NAMES]).toEqual([
-      'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd',
+      'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band',
     ]);
   });
 

--- a/frontend/src/presentation/layouts/__tests__/meters-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/meters-declarability.test.ts
@@ -29,7 +29,7 @@ describe('meters is a declarable semantic surface', () => {
   // place.
   it('is in the declarable set alongside vfo, rxTx and txAux', () => {
     expect([...SEMANTIC_SURFACE_NAMES]).toEqual([
-      'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd',
+      'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band',
     ]);
   });
 

--- a/frontend/src/presentation/layouts/__tests__/rf-front-end-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/rf-front-end-declarability.test.ts
@@ -23,10 +23,11 @@ import {
 } from '../declarations';
 
 describe('rfFrontEnd is a declarable semantic surface', () => {
-  // Kills: reverting the SEMANTIC_SURFACE_NAMES addition.
+  // Kills: reverting the SEMANTIC_SURFACE_NAMES addition. MOR-1307 appended
+  // `band`; `rfFrontEnd` must stay present and in place.
   it('is in the declarable set alongside vfo, rxTx, txAux, meters and rxAudio', () => {
     expect([...SEMANTIC_SURFACE_NAMES])
-      .toEqual(['vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd']);
+      .toEqual(['vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band']);
   });
 
   // Kills: adding the name to the type but not to the runtime allow-list the

--- a/frontend/src/presentation/layouts/__tests__/rx-audio-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/rx-audio-declarability.test.ts
@@ -25,7 +25,7 @@ describe('rxAudio is a declarable semantic surface', () => {
   // Kills: reverting the SEMANTIC_SURFACE_NAMES addition.
   it('is in the declarable set alongside vfo, rxTx, txAux and meters', () => {
     expect([...SEMANTIC_SURFACE_NAMES]).toEqual([
-      'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd',
+      'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band',
     ]);
   });
 

--- a/frontend/src/presentation/layouts/__tests__/tx-aux-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/tx-aux-declarability.test.ts
@@ -29,7 +29,7 @@ describe('txAux is a declarable semantic surface', () => {
   // appended `rfFrontEnd`; `txAux` must stay present and in place.
   it('is in the declarable set alongside vfo and rxTx', () => {
     expect([...SEMANTIC_SURFACE_NAMES]).toEqual([
-      'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd',
+      'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band',
     ]);
   });
 

--- a/frontend/src/presentation/layouts/contract.ts
+++ b/frontend/src/presentation/layouts/contract.ts
@@ -14,16 +14,16 @@ import { isValidLanguageId as isValidProductId } from '../languages/contract';
 
 /** Semantic surfaces a layout may mount (MOR-1062/1065 reference vertical;
  *  `txAux` added by MOR-1265, `meters` by MOR-1273, `rxAudio` by MOR-1279,
- *  `filter` by MOR-1304, `dsp` by MOR-1305, `rfFrontEnd` by MOR-1306). Adding
- *  a name makes it DECLARABLE — it does not mount anything by itself, and no
- *  manifest declares a `meters`, `rxAudio`, `filter`, `dsp` or `rfFrontEnd`
- *  zone yet (the cockpit declares only `txAux`, as `tx-aux` — MOR-1336).
- *  Distinct from the design-language renderer slot of the same name
- *  (`languages/contract.ts`'s `RENDERER_SLOT_NAMES`): that one says how a
- *  language DRAWS a meter, this one says which layout zone may HOST the
- *  surface. */
+ *  `filter` by MOR-1304, `dsp` by MOR-1305, `rfFrontEnd` by MOR-1306, `band`
+ *  by MOR-1307). Adding a name makes it DECLARABLE — it does not mount
+ *  anything by itself, and no manifest declares a `meters`, `rxAudio`,
+ *  `filter`, `dsp`, `rfFrontEnd` or `band` zone yet (the cockpit declares
+ *  only `txAux`, as `tx-aux` — MOR-1336). Distinct from the design-language
+ *  renderer slot of the same name (`languages/contract.ts`'s
+ *  `RENDERER_SLOT_NAMES`): that one says how a language DRAWS a meter, this
+ *  one says which layout zone may HOST the surface. */
 export const SEMANTIC_SURFACE_NAMES = [
-  'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd',
+  'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band',
 ] as const;
 export type SemanticSurfaceName = (typeof SEMANTIC_SURFACE_NAMES)[number];
 

--- a/frontend/src/semantic/BandSurface.svelte
+++ b/frontend/src/semantic/BandSurface.svelte
@@ -1,0 +1,213 @@
+<!--
+  Semantic band + frequency-entry surface (MOR-1307, vocabulary slice 7B).
+
+  Presentation only. It renders the MOR-1294 `band` fact group — the current
+  band, the capability-derived band choice set, the live TX permit and the
+  tuning envelope — and emits intents as callbacks. It holds no state beyond
+  the operator's own unsubmitted keystrokes, consults no controller and owns
+  no command path.
+
+  SAFETY-ADJACENT. This surface renders TX-PERMISSION information: a fail-open
+  bug here tells an operator "you may transmit" where transmission is not
+  permitted. Five rules govern this file and nothing may relax them:
+
+  (1) THE BAND-SCOPED TX ANSWER IS `band.currentBandTx`, AND NOTHING ELSE.
+      That fact is the LIVE-frequency permit (MOR-1294 verify F1: the adapter
+      evaluates `getFrequencyPermit(observedFreqHz, caps.txBands)`), already
+      collapsed fail-closed. This file re-derives nothing: it holds no band
+      plan, no `txBands`, no permit function, and its whole import list is the
+      fact contract.
+
+  (2) `BandChoice.defaultHzTxPermit` IS A POINT SAMPLE, AND IS LABELLED AS
+      ONE. It answers "may I key at THIS band's default frequency", never "may
+      I key anywhere in this band" — `txBands` segments are routinely narrower
+      than a band-plan band, so presenting it band-wide is the exact fail-open
+      misread the MOR-1294 rename exists to prevent (7B carry-forward F3).
+      Every rendering of it names the frequency it was sampled at, and it is
+      never used for the band-scoped answer in rule (1).
+
+  (3) THE DENIAL SIGNAL IS THE FIELD VALUE ITSELF. By design the `band` group
+      contributes NO `disabledReasons` entry (MOR-1294 build report §4) — a
+      parallel entry would be a second representation of the same fact. So the
+      denial is read off `currentBandTx` directly, and `disabledReasons` /
+      top-level `txPermit` are consulted only for the richer EXPLANATION the
+      binary collapse cannot carry (carry-forward 2). An empty
+      `disabledReasons` never softens a denial.
+
+  (4) A RECEIVER-SCOPED WRITE NEEDS A KNOWN ACTIVE RECEIVER. Band select and
+      frequency entry both land on `set_freq`/`set_band`, which write the
+      ACTIVE receiver's VFO (the MOR-1322 B1 wrong-VFO dispatch class). While
+      `activeReceiver` is unobserved there is no honest target, so both
+      controls are inert — disabled in the markup AND refused in the handler,
+      two mechanisms on the same condition so neither can be the only one.
+
+  (5) UNKNOWN TUNING BOUNDS FAIL CLOSED. `tuneMinHz`/`tuneMaxHz` are the
+      frequency-entry constraint (MOR-1294 §5 ruling). `null` means the radio
+      declared no range — entry is then DISABLED with a stated reason, never
+      accepted unvalidated against v2's fabricated `0 … 999 MHz` default.
+
+  Two-level availability (MOR-977/1256): `structural: false` renders NOTHING;
+  `structural: true, operational: false` renders present-and-unobserved. An
+  unread fact renders `UNKNOWN_TEXT`, never a fabricated 14.074 MHz.
+-->
+<script module lang="ts">
+  import type {
+    BandChoice, BandField, DisabledReasonCode, RadioViewModel,
+  } from './radio-view-model';
+
+  /** The ONE rendering of "not measured". Never a band name, never a number. */
+  export const UNKNOWN_TEXT = '—';
+
+  /** The `disabledReasons` codes that can EXPLAIN a TX denial, in the order
+   *  they are preferred. Rule (3): explanation only — the denial itself is
+   *  `currentBandTx`, so an empty list changes the words, never the verdict. */
+  export const TX_REASON_CODES: readonly DisabledReasonCode[] = [
+    'out-of-band', 'tx-target-unknown', 'capability-unavailable',
+  ];
+  export const REASON_LABEL: Record<string, string> = {
+    'out-of-band': 'live frequency is outside the configured TX ranges',
+    'tx-target-unknown': 'TX target frequency was never observed',
+    'capability-unavailable': 'TX ranges are not configured',
+  };
+  /** The denial's words when no code explains it: `txPermit` says the TX
+   *  TARGET may key, so what is missing is the band-scoped resolution itself
+   *  (unobserved live frequency, or a frequency in no band of the plan). */
+  export const UNRESOLVED_REASON = 'current band could not be resolved';
+
+  export const usable = (f: BandField<unknown>): boolean =>
+    f.availability.structural && f.availability.operational && f.reading.status === 'known';
+  export const textOf = (f: BandField<unknown>): string =>
+    f.reading.status === 'known' ? String(f.reading.value) : UNKNOWN_TEXT;
+  export const isCurrent = (f: BandField<string>, name: string): boolean =>
+    f.reading.status === 'known' && f.reading.value === name;
+
+  /** Display only, never parsed back — the entry field works in whole Hz so a
+   *  boundary comparison can never lose a digit to a decimal round-trip. */
+  export const mhz = (hz: number): string => `${(hz / 1e6).toFixed(3)} MHz`;
+  /** Rule (2): the permit is spelled WITH the frequency it was sampled at, so
+   *  the label cannot be read as a claim about the whole band. */
+  export const defaultPermitLabel = (choice: BandChoice): string =>
+    `TX at ${mhz(choice.defaultHz)}: ${choice.defaultHzTxPermit.status}`;
+
+  /** Rule (3): consulted ONLY once `currentBandTx` already said `denied`. */
+  export function txDeniedReason(view: RadioViewModel): string {
+    const hit = TX_REASON_CODES.find((c) => view.disabledReasons.some((r) => r.code === c));
+    if (hit !== undefined) return REASON_LABEL[hit];
+    return view.txPermit.status === 'allowed' ? UNRESOLVED_REASON : UNKNOWN_TEXT;
+  }
+</script>
+
+<script lang="ts">
+  interface Props {
+    view: RadioViewModel;
+    onSelectBand?: (name: string, defaultHz: number, bsrCode: number | null) => void;
+    onEnterFrequency?: (frequencyHz: number) => void;
+  }
+  let { view, onSelectBand, onEnterFrequency }: Props = $props();
+
+  /** Absent group ⇒ this surface renders nothing (S0 optional-group doctrine). */
+  let band = $derived(view.band);
+  /** Rule (4). */
+  let receiverKnown = $derived(view.activeReceiver.status === 'known');
+  /** Rule (5). */
+  let boundsKnown = $derived(
+    band !== undefined && band.tuneMinHz !== null && band.tuneMaxHz !== null,
+  );
+  /** The operator's raw keystrokes, kept as typed: an empty or malformed entry
+   *  must stay refusable rather than coerce to 0 Hz. */
+  let entryText = $state('');
+  let typedHz = $derived(entryText.trim() === '' ? Number.NaN : Number(entryText));
+  let inRange = $derived(
+    Number.isFinite(typedHz) && band?.tuneMinHz != null && band?.tuneMaxHz != null
+      && typedHz >= band.tuneMinHz && typedHz <= band.tuneMaxHz,
+  );
+  let entryReady = $derived(receiverKnown && boundsKnown && inRange);
+
+  function selectBand(choice: BandChoice): void {
+    if (!receiverKnown) return;
+    onSelectBand?.(choice.name, choice.defaultHz, choice.bsrCode);
+  }
+  function commitFrequency(): void {
+    if (!entryReady) return;
+    onEnterFrequency?.(typedHz);
+  }
+</script>
+
+{#if band}
+  <section
+    class="band-surface" data-testid="band-surface" aria-label="Band and frequency entry"
+    data-tx-permit-status={view.txPermit.status}
+  >
+    {#if band.currentBand.availability.structural}
+      <p class="band-row" data-testid="band-current" data-observed={usable(band.currentBand)}>
+        <span class="band-name">BAND</span>
+        <output data-testid="band-current-value">{textOf(band.currentBand)}</output>
+      </p>
+    {/if}
+
+    <!-- Rule (1). The live fact, verbatim; `defaultHzTxPermit` is not in scope
+         anywhere in this block. -->
+    <p class="band-row" data-testid="band-tx" data-tx={band.currentBandTx}>
+      <span class="band-name">TX HERE</span>
+      <output data-testid="band-tx-value">{band.currentBandTx}</output>
+      {#if band.currentBandTx === 'denied'}
+        <span data-testid="band-tx-reason">{txDeniedReason(view)}</span>
+      {/if}
+    </p>
+
+    {#if band.bandChoices.length > 0}
+      <div class="band-row" role="group" aria-label="Band select" data-testid="band-choices">
+        {#each band.bandChoices as choice (choice.name)}
+          <!-- NOT gated on the permit: picking a band is a TUNING action and a
+               band with no TX allocation stays perfectly receivable. The permit
+               is a label here (rule 2), never a tuning gate. -->
+          <button
+            type="button" class="band-choice" data-testid={`band-choice-${choice.name}`}
+            data-default-permit={choice.defaultHzTxPermit.status}
+            aria-pressed={isCurrent(band.currentBand, choice.name)}
+            disabled={!receiverKnown}
+            onclick={() => selectBand(choice)}
+          >{choice.name}
+            <small data-testid={`band-choice-permit-${choice.name}`}
+            >{defaultPermitLabel(choice)}</small></button>
+        {/each}
+      </div>
+    {/if}
+
+    <label class="band-row" data-testid="band-entry" data-bounds={boundsKnown}>
+      <span class="band-name">FREQ</span>
+      <input
+        type="number" data-testid="band-entry-input" step="1"
+        min={band.tuneMinHz ?? undefined} max={band.tuneMaxHz ?? undefined}
+        value={entryText} disabled={!receiverKnown || !boundsKnown}
+        oninput={(event) => { entryText = event.currentTarget.value; }}
+      />
+      <span data-testid="band-entry-range">{boundsKnown && band.tuneMinHz !== null
+        && band.tuneMaxHz !== null
+        ? `${mhz(band.tuneMinHz)} … ${mhz(band.tuneMaxHz)}`
+        : UNKNOWN_TEXT}</span>
+      <button
+        type="button" data-testid="band-entry-set" disabled={!entryReady}
+        onclick={commitFrequency}
+      >Set</button>
+      {#if !boundsKnown || !receiverKnown}
+        <span data-testid="band-entry-reason">{boundsKnown
+          ? 'active receiver not observed — no honest tuning target'
+          : 'tuning limits unknown — entry cannot be validated'}</span>
+      {/if}
+    </label>
+  </section>
+{/if}
+
+<style>
+  /* Structure only — a design language owns colour and must never become the
+     sole state channel (MOR-977, forced-colors). Nothing here animates. */
+  .band-surface { display: flex; flex-direction: column; gap: 0.25rem; }
+  .band-row { display: flex; flex-wrap: wrap; align-items: baseline; gap: 0.5rem; margin: 0; }
+  .band-name { min-width: 7ch; }
+  .band-choice[aria-pressed='true'] { font-weight: 700; }
+  /* Second channel beside `data-observed`/`data-tx`, never the only one: the
+     rendered word itself is the primary one and survives forced-colors. */
+  [data-observed='false'] { font-style: italic; }
+  button:disabled, input:disabled { cursor: not-allowed; }
+</style>

--- a/frontend/src/semantic/BandSurface.svelte
+++ b/frontend/src/semantic/BandSurface.svelte
@@ -89,9 +89,20 @@
   export const defaultPermitLabel = (choice: BandChoice): string =>
     `TX at ${mhz(choice.defaultHz)}: ${choice.defaultHzTxPermit.status}`;
 
-  /** Rule (3): consulted ONLY once `currentBandTx` already said `denied`. */
+  /** Rule (3): consulted ONLY once `currentBandTx` already said `denied` (or,
+   *  from the fix-round F1 caveat, once the authoritative `txPermit` itself is
+   *  not `allowed`) — and only over TX-SCOPED entries. `capability-unavailable`
+   *  is ALSO emitted for `scope.hardwareScope`, `scope.audioFftScope` and each
+   *  non-operational `receiver.<id>` (radio-view-model-adapter.ts:1171-1187),
+   *  none of which explain a TX denial. The adapter records a `field:
+   *  'txPermit'` entry for EVERY non-allowed permit
+   *  (radio-view-model-adapter.ts:1164-1170), so filtering on that field is
+   *  the whole fix — a code match alone would misattribute an unrelated
+   *  capability gap as a TX-configuration fault (fix-round F2). */
   export function txDeniedReason(view: RadioViewModel): string {
-    const hit = TX_REASON_CODES.find((c) => view.disabledReasons.some((r) => r.code === c));
+    const hit = TX_REASON_CODES.find(
+      (c) => view.disabledReasons.some((r) => r.code === c && r.field === 'txPermit'),
+    );
     if (hit !== undefined) return REASON_LABEL[hit];
     return view.txPermit.status === 'allowed' ? UNRESOLVED_REASON : UNKNOWN_TEXT;
   }
@@ -152,6 +163,15 @@
       <output data-testid="band-tx-value">{band.currentBandTx}</output>
       {#if band.currentBandTx === 'denied'}
         <span data-testid="band-tx-reason">{txDeniedReason(view)}</span>
+      {:else if view.txPermit.status !== 'allowed'}
+        <!-- Fix-round F1: `band.currentBandTx` answers "may I key at the
+             ACTIVE RECEIVER's frequency" — it can say `allowed` while the
+             authoritative TX-TARGET permit (`view.txPermit`, the one 9A's
+             break-in gate and `keyBlockedReasons` both key off) disagrees,
+             e.g. under split, or while the TX target is simply unobserved.
+             That disagreement must never live only in `data-tx-permit-status`
+             — a data attribute is invisible to an operator. -->
+        <span data-testid="band-tx-caveat">TX target {view.txPermit.status}: {txDeniedReason(view)}</span>
       {/if}
     </p>
 

--- a/frontend/src/semantic/__tests__/BandSurface.test.ts
+++ b/frontend/src/semantic/__tests__/BandSurface.test.ts
@@ -195,6 +195,57 @@ describe('currentBandTx is the live-frequency answer (carry-forwards 1 + 2)', ()
   });
 });
 
+/* ── fix-round F1: the band answer can disagree with the authoritative
+   TX-target permit, and that disagreement must be VISIBLE, not just a
+   `data-` attribute ────────────────────────────────────────────────── */
+
+describe('the TX-target permit caveat (fix-round F1)', () => {
+  // THE F1 REGRESSION PIN. `band.currentBandTx` answers for the ACTIVE
+  // RECEIVER's frequency; `view.txPermit` is the authoritative TX-TARGET
+  // permit and can disagree (e.g. under split). Before the fix this
+  // disagreement was visible only in `data-tx-permit-status` — an operator
+  // reading the text saw an unqualified "TX HERE: allowed".
+  it('renders a visible caveat when the band answer is allowed but the TX-target permit is denied', () => {
+    const view = withB({ currentBand: knownBand('20m'), currentBandTx: 'allowed' });
+    const r = render({
+      ...view,
+      txPermit: DENIED,
+      disabledReasons: [{ field: 'txPermit', code: 'out-of-band' }] as readonly DisabledReason[],
+    });
+    expect(r.text('tx-value')).toBe('allowed');
+    expect(r.el('tx-caveat')).not.toBeNull();
+    expect(r.text('tx-caveat')).toContain(REASON_LABEL['out-of-band']);
+    r.dispose();
+  });
+
+  // Same disagreement, `unknown` case — the far more common shape: an
+  // unobserved TX target. Every other TX-adjacent surface in the program
+  // treats `unknown` as fail-closed (MOR-1296 O2); this surface must not be
+  // the one place that prints an unqualified "allowed".
+  it('renders a visible caveat when the band answer is allowed but the TX-target permit is unknown', () => {
+    const view = withB({ currentBand: knownBand('20m'), currentBandTx: 'allowed' });
+    const r = render({
+      ...view,
+      txPermit: { status: 'unknown', reason: 'tx-target-unknown' },
+      disabledReasons: [{ field: 'txPermit', code: 'tx-target-unknown' }] as readonly DisabledReason[],
+    });
+    expect(r.text('tx-value')).toBe('allowed');
+    expect(r.el('tx-caveat')).not.toBeNull();
+    expect(r.text('tx-caveat')).toContain(REASON_LABEL['tx-target-unknown']);
+    r.dispose();
+  });
+
+  // Negative guard: when both permits agree on `allowed`, no caveat appears
+  // — the caveat is the DISAGREEMENT signal, not a permanent fixture.
+  it('renders no caveat when both the band answer and the TX-target permit are allowed', () => {
+    const view = withB({ currentBand: knownBand('20m'), currentBandTx: 'allowed' });
+    const r = render({ ...view, txPermit: ALLOWED, disabledReasons: [] });
+    expect(r.text('tx-value')).toBe('allowed');
+    expect(r.el('tx-caveat')).toBeNull();
+    r.dispose();
+  });
+});
+
 /* ── (c) no band-scoped disabledReason exists, by design ────────── */
 
 describe('the denial signal is the field value itself (carry-forward 3)', () => {
@@ -211,7 +262,25 @@ describe('the denial signal is the field value itself (carry-forward 3)', () => 
 
   it('never looks for a band-scoped reason code', () => {
     expect(CODE).not.toContain("'band.");
-    expect(CODE).not.toContain('field ===');
+  });
+
+  // THE F2 REGRESSION PIN. `capability-unavailable` is NOT TX-exclusive — the
+  // adapter also emits it for `scope.hardwareScope`/`scope.audioFftScope` and
+  // each non-operational `receiver.<id>`. A denial explanation that matches
+  // on CODE ALONE (ignoring `field`) renders this scope-capability gap as a
+  // TX-configuration statement, which is false: `txPermit` here is allowed,
+  // so the real cause is that the band itself could not be resolved.
+  it('ignores a non-TX reason that happens to carry a TX code', () => {
+    const view = withB({ currentBand: knownBand('20m'), currentBandTx: 'denied' });
+    const r = render({
+      ...view,
+      txPermit: ALLOWED,
+      disabledReasons: [
+        { field: 'scope.audioFftScope', code: 'capability-unavailable' },
+      ] as readonly DisabledReason[],
+    });
+    expect(r.text('tx-reason')).toBe(UNRESOLVED_REASON);
+    r.dispose();
   });
 });
 

--- a/frontend/src/semantic/__tests__/BandSurface.test.ts
+++ b/frontend/src/semantic/__tests__/BandSurface.test.ts
@@ -1,0 +1,451 @@
+/**
+ * MOR-1307 — the semantic band + frequency-entry surface (vocabulary slice 7B).
+ *
+ * SAFETY-ADJACENT. This surface renders TX-PERMISSION information, so every
+ * test below names the mutation it kills:
+ *   (a) the band-scoped TX answer sourced from anything but the LIVE fact
+ *       `band.currentBandTx` — re-inheriting `defaultHzTxPermit` is the exact
+ *       fail-open defect MOR-1294's F1 round removed one layer down, and 7B's
+ *       carry-forward F3 forbids reintroducing it here;
+ *   (b) a point-sample permit presented as band-wide permission;
+ *   (c) a denial softened because `disabledReasons` carries no band entry (by
+ *       design it never does — the denial IS the field value);
+ *   (d) frequency entry accepted outside `tuneMinHz`/`tuneMaxHz`, or accepted
+ *       at all while those bounds are unknown;
+ *   (e) a receiver-scoped write dispatched while the active receiver is
+ *       unobserved (the MOR-1322 B1 wrong-VFO class).
+ *
+ * Fast-pool-safe by construction (MOR-1272): no `vi.mock`, no `vi.stubGlobal`,
+ * no global spy. The composed-tree pins live in the isolated-pool wiring file
+ * `components-v2/wiring/__tests__/semantic-band-wiring.component.test.ts`.
+ */
+import { readFileSync } from 'node:fs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import BandSurface, {
+  REASON_LABEL, UNKNOWN_TEXT, UNRESOLVED_REASON, defaultPermitLabel, mhz,
+} from '../BandSurface.svelte';
+import { topologyFixtures, withBand } from '../fixtures/topologies';
+import type { FrequencyPermit } from '$lib/utils/tx-permit';
+import type {
+  BandChoice, BandViewModel, DisabledReason, RadioViewModel,
+} from '../radio-view-model';
+
+const SOURCE = readFileSync('src/semantic/BandSurface.svelte', 'utf8');
+/** Comments stripped, so the file's own doctrine prose can never be what a
+ *  source-scanning test matches. */
+const CODE = SOURCE
+  .replace(/<!--[\s\S]*?-->/g, '')
+  .replace(/\/\*[\s\S]*?\*\//g, '')
+  .replace(/^\s*\/\/.*$/gm, '');
+
+const ALLOWED: FrequencyPermit = { status: 'allowed', band: '20m' };
+const DENIED: FrequencyPermit = { status: 'denied', reason: 'outside-configured-ranges' };
+const AVAIL = { structural: true, operational: true } as const;
+
+const base = (): RadioViewModel => withBand(topologyFixtures['1/single']);
+
+/** Re-shape the band group of an otherwise fully-observed fixture. */
+function withB(over: Partial<BandViewModel>, view: RadioViewModel = base()): RadioViewModel {
+  return { ...view, band: { ...(view.band as BandViewModel), ...over } };
+}
+const knownBand = (name: string) =>
+  ({ reading: { status: 'known' as const, value: name }, availability: AVAIL });
+const unreadBand = () => ({ reading: { status: 'unknown' as const }, availability: AVAIL });
+
+let target: HTMLDivElement;
+beforeEach(() => { target = document.createElement('div'); document.body.appendChild(target); });
+afterEach(() => { target.remove(); });
+
+type Handlers = {
+  onSelectBand?: (name: string, defaultHz: number, bsrCode: number | null) => void;
+  onEnterFrequency?: (frequencyHz: number) => void;
+};
+
+function render(view: RadioViewModel, handlers: Handlers = {}) {
+  const component = mount(BandSurface, { target, props: { view, ...handlers } });
+  flushSync();
+  const q = <T extends HTMLElement>(sel: string) => target.querySelector(sel) as T | null;
+  return {
+    dispose: () => unmount(component),
+    root: () => q('[data-testid="band-surface"]'),
+    el: (id: string) => q<HTMLElement>(`[data-testid="band-${id}"]`),
+    btn: (id: string) => q<HTMLButtonElement>(`[data-testid="band-${id}"]`),
+    input: () => q<HTMLInputElement>('[data-testid="band-entry-input"]'),
+    text: (id: string) => q<HTMLElement>(`[data-testid="band-${id}"]`)?.textContent?.trim(),
+  };
+}
+
+/** The MOR-1304 F3 recipe: a real `.click()` is swallowed by `disabled`, so a
+ *  handler guard can only be pinned on its OWN by bypassing the attribute. */
+function bypassClick(node: HTMLElement): void {
+  node.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  flushSync();
+}
+function typeFrequency(input: HTMLInputElement, value: string): void {
+  input.value = value;
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+  flushSync();
+}
+
+/* ── purity: no second permit derivation can even be reachable ──── */
+
+describe('the band surface derives nothing (7B carry-forward 1)', () => {
+  // Kills: importing the permit function, the band plan, capabilities or the
+  // command bus — any of which would let a second permit derivation exist.
+  it('imports nothing but the fact contract', () => {
+    const specifiers = [...CODE.matchAll(/from\s+'([^']+)'/g)].map((m) => m[1]);
+    expect(specifiers.length).toBeGreaterThan(0);
+    expect([...new Set(specifiers)]).toEqual(['./radio-view-model']);
+  });
+
+  it('never mentions the permit derivation, the band plan or a capability read', () => {
+    for (const forbidden of [
+      'getFrequencyPermit', 'getTxPermit', 'txBands', 'freqRanges', 'flattenBands',
+      'findActiveBand', 'capabilities', 'hasCap', '$lib/', 'sendCommand',
+    ]) {
+      expect(CODE).not.toContain(forbidden);
+    }
+  });
+
+  it('declares no lifecycle hook and no effect', () => {
+    for (const forbidden of ['onMount', 'onDestroy', '$effect', 'import(']) {
+      expect(CODE).not.toContain(forbidden);
+    }
+  });
+
+  it('takes exactly one state prop — the view model — plus intent callbacks', () => {
+    const props = CODE.slice(CODE.indexOf('interface Props'), CODE.indexOf('}: Props'));
+    expect([...props.matchAll(/^\s{4}(\w+)[?]?:/gm)].map((m) => m[1]))
+      .toEqual(['view', 'onSelectBand', 'onEnterFrequency']);
+  });
+
+  it('renders nothing at all when the radio declares no band plan', () => {
+    const { band: _drop, ...noBand } = base();
+    const r = render(noBand as RadioViewModel);
+    expect(r.root()).toBeNull();
+    r.dispose();
+  });
+});
+
+/* ── (a) the band-scoped TX answer is the LIVE fact ─────────────── */
+
+describe('currentBandTx is the live-frequency answer (carry-forwards 1 + 2)', () => {
+  // THE F1/F3 REGRESSION PIN. The current band's own default-frequency permit
+  // says `allowed`; the live fact says `denied` (a txBands segment narrower
+  // than the plan band — 14.300 MHz against a 14.000–14.150 allocation). A
+  // surface that sourced the answer from `defaultHzTxPermit` renders
+  // "allowed" here and this test dies.
+  it('renders denied while the current band default-frequency permit reads allowed', () => {
+    const view = withB({ currentBand: knownBand('20m'), currentBandTx: 'denied' });
+    const current = (view.band as BandViewModel).bandChoices
+      .find((c) => c.name === '20m') as BandChoice;
+    expect(current.defaultHzTxPermit.status).toBe('allowed');
+    const r = render(view);
+    expect(r.text('tx-value')).toBe('denied');
+    expect(r.el('tx')!.dataset.tx).toBe('denied');
+    r.dispose();
+  });
+
+  // Kills: collapsing the branch the other way (allowed rendered as denied).
+  it('renders allowed when the live fact allows, on the same choice set', () => {
+    const r = render(withB({ currentBand: knownBand('20m'), currentBandTx: 'allowed' }));
+    expect(r.text('tx-value')).toBe('allowed');
+    expect(r.el('tx')!.dataset.tx).toBe('allowed');
+    r.dispose();
+  });
+
+  // Kills: dropping the whole TX readout while the band itself is unknown —
+  // "no answer" must never be how a denial is presented.
+  it('still states the denial while the current band is unreadable', () => {
+    const r = render(withB({ currentBand: unreadBand(), currentBandTx: 'denied' }));
+    expect(r.text('current-value')).toBe(UNKNOWN_TEXT);
+    expect(r.text('tx-value')).toBe('denied');
+    r.dispose();
+  });
+
+  // Carry-forward 2: the tri-state nuance the binary collapse cannot carry is
+  // taken from the TOP-LEVEL txPermit + disabledReasons, not re-derived.
+  it.each([
+    ['out-of-band', REASON_LABEL['out-of-band']],
+    ['tx-target-unknown', REASON_LABEL['tx-target-unknown']],
+    ['capability-unavailable', REASON_LABEL['capability-unavailable']],
+  ])('explains a denial with the recorded %s reason', (code, label) => {
+    const view = withB({ currentBandTx: 'denied' });
+    const r = render({
+      ...view,
+      txPermit: DENIED,
+      disabledReasons: [{ field: 'txPermit', code }] as readonly DisabledReason[],
+    });
+    expect(r.text('tx-reason')).toBe(label);
+    r.dispose();
+  });
+
+  it('annotates the top-level tri-state without collapsing it', () => {
+    const view = withB({ currentBandTx: 'denied' });
+    const r = render({ ...view, txPermit: { status: 'unknown', reason: 'ranges-unconfigured' } });
+    expect(r.root()!.dataset.txPermitStatus).toBe('unknown');
+    r.dispose();
+  });
+
+  it('offers no reason line at all while TX is allowed', () => {
+    const r = render(withB({ currentBandTx: 'allowed' }));
+    expect(r.el('tx-reason')).toBeNull();
+    r.dispose();
+  });
+});
+
+/* ── (c) no band-scoped disabledReason exists, by design ────────── */
+
+describe('the denial signal is the field value itself (carry-forward 3)', () => {
+  // Kills: gating the denial readout on a `band.*` disabledReasons entry. No
+  // such entry is ever emitted (MOR-1294 §4), so a surface that waited for one
+  // would silently present a denied band as unremarkable.
+  it('states a denial with an EMPTY disabledReasons list', () => {
+    const view = withB({ currentBand: knownBand('20m'), currentBandTx: 'denied' });
+    const r = render({ ...view, txPermit: ALLOWED, disabledReasons: [] });
+    expect(r.text('tx-value')).toBe('denied');
+    expect(r.text('tx-reason')).toBe(UNRESOLVED_REASON);
+    r.dispose();
+  });
+
+  it('never looks for a band-scoped reason code', () => {
+    expect(CODE).not.toContain("'band.");
+    expect(CODE).not.toContain('field ===');
+  });
+});
+
+/* ── (b) the point sample is labelled as one ────────────────────── */
+
+describe('defaultHzTxPermit is never presented as band-wide permission (carry-forward 1/F3)', () => {
+  // Kills: labelling the choice "TX allowed" with no frequency — the misread
+  // the MOR-1294 rename exists to prevent.
+  it('names the sampled frequency in every choice permit label', () => {
+    const view = base();
+    const r = render(view);
+    for (const choice of (view.band as BandViewModel).bandChoices) {
+      const label = r.text(`choice-permit-${choice.name}`)!;
+      expect(label).toContain(mhz(choice.defaultHz));
+      expect(label).toBe(defaultPermitLabel(choice));
+      expect(label).toContain(choice.defaultHzTxPermit.status);
+    }
+    r.dispose();
+  });
+
+  // Kills: reusing the point sample as the band-scoped answer. The MW choice
+  // is denied at its default while the live answer is allowed — the two are
+  // rendered by two different elements and must not agree by construction.
+  it('keeps the choice permits independent of the live TX answer', () => {
+    const r = render(withB({ currentBand: knownBand('20m'), currentBandTx: 'allowed' }));
+    expect(r.el('choice-MW')!.dataset.defaultPermit).toBe('denied');
+    expect(r.el('choice-20m')!.dataset.defaultPermit).toBe('allowed');
+    expect(r.text('tx-value')).toBe('allowed');
+    r.dispose();
+  });
+
+  // Kills: disabling a band whose default frequency has no TX permit. Picking
+  // a band is a TUNING action; a receive-only band stays perfectly selectable.
+  it('leaves a TX-denied band selectable, because tuning is not transmitting', () => {
+    const onSelectBand = vi.fn();
+    const r = render(base(), { onSelectBand });
+    expect(r.btn('choice-MW')!.disabled).toBe(false);
+    r.btn('choice-MW')!.click();
+    flushSync();
+    expect(onSelectBand).toHaveBeenCalledExactlyOnceWith('MW', 1000000, null);
+    r.dispose();
+  });
+
+  it('marks the current band pressed and no other', () => {
+    const r = render(withB({ currentBand: knownBand('40m') }));
+    expect(r.el('choice-40m')!.getAttribute('aria-pressed')).toBe('true');
+    expect(r.el('choice-20m')!.getAttribute('aria-pressed')).toBe('false');
+    r.dispose();
+  });
+
+  it('presses nothing while the current band is unread', () => {
+    const r = render(withB({ currentBand: unreadBand() }));
+    for (const name of ['40m', '20m', 'MW']) {
+      expect(r.el(`choice-${name}`)!.getAttribute('aria-pressed')).toBe('false');
+    }
+    r.dispose();
+  });
+});
+
+/* ── (d) frequency entry validates against the envelope ─────────── */
+
+describe('frequency entry validates against tuneMinHz/tuneMaxHz (carry-forward 5)', () => {
+  const BOUNDS = { tuneMinHz: 30000, tuneMaxHz: 60000000 } as const;
+
+  it.each([
+    ['one hertz below the minimum', 29999, false],
+    ['exactly the minimum', 30000, true],
+    ['exactly the maximum', 60000000, true],
+    ['one hertz above the maximum', 60000001, false],
+  ])('%s is accepted=%s', (_label, hz, accepted) => {
+    const onEnterFrequency = vi.fn();
+    const r = render(withB(BOUNDS), { onEnterFrequency });
+    typeFrequency(r.input()!, String(hz));
+    expect(r.btn('entry-set')!.disabled).toBe(!accepted);
+    r.btn('entry-set')!.click();
+    flushSync();
+    if (accepted) expect(onEnterFrequency).toHaveBeenCalledExactlyOnceWith(hz);
+    else expect(onEnterFrequency).not.toHaveBeenCalled();
+    r.dispose();
+  });
+
+  // Kills: dropping the handler-side range check. `disabled` alone satisfies a
+  // `.click()`-based assertion, so the guard is bypassed here on its own.
+  it.each([29999, 60000001])('refuses %i even when the disabled attribute is bypassed', (hz) => {
+    const onEnterFrequency = vi.fn();
+    const r = render(withB(BOUNDS), { onEnterFrequency });
+    typeFrequency(r.input()!, String(hz));
+    bypassClick(r.btn('entry-set')!);
+    expect(onEnterFrequency).not.toHaveBeenCalled();
+    r.dispose();
+  });
+
+  it('publishes the envelope as the input min/max as well', () => {
+    const r = render(withB(BOUNDS));
+    expect(r.input()!.getAttribute('min')).toBe('30000');
+    expect(r.input()!.getAttribute('max')).toBe('60000000');
+    expect(r.text('entry-range')).toBe(`${mhz(30000)} … ${mhz(60000000)}`);
+    r.dispose();
+  });
+
+  // Kills: coercing an empty or malformed entry to 0 Hz and dispatching it.
+  it.each(['', '   ', 'abc'])('never dispatches the malformed entry %o', (typed) => {
+    const onEnterFrequency = vi.fn();
+    const r = render(withB(BOUNDS), { onEnterFrequency });
+    typeFrequency(r.input()!, typed);
+    expect(r.btn('entry-set')!.disabled).toBe(true);
+    bypassClick(r.btn('entry-set')!);
+    expect(onEnterFrequency).not.toHaveBeenCalled();
+    r.dispose();
+  });
+});
+
+describe('unknown tuning bounds fail closed (carry-forward 5, rule 5)', () => {
+  const NO_BOUNDS = { tuneMinHz: null, tuneMaxHz: null } as const;
+
+  // Kills: substituting `frequency-tuning.ts`'s fabricated 0 … 999 MHz, or
+  // accepting the entry unvalidated when the radio declared no range.
+  it('disables the entry field and the Set button, and says why', () => {
+    const r = render(withB(NO_BOUNDS));
+    expect(r.input()!.disabled).toBe(true);
+    expect(r.btn('entry-set')!.disabled).toBe(true);
+    expect(r.el('entry')!.dataset.bounds).toBe('false');
+    expect(r.text('entry-reason')).toContain('tuning limits unknown');
+    expect(r.text('entry-range')).toBe(UNKNOWN_TEXT);
+    r.dispose();
+  });
+
+  it('refuses the dispatch with the disabled attribute bypassed', () => {
+    const onEnterFrequency = vi.fn();
+    const r = render(withB(NO_BOUNDS), { onEnterFrequency });
+    typeFrequency(r.input()!, '14250000');
+    bypassClick(r.btn('entry-set')!);
+    expect(onEnterFrequency).not.toHaveBeenCalled();
+    r.dispose();
+  });
+
+  it.each([
+    [{ tuneMinHz: null, tuneMaxHz: 60000000 }],
+    [{ tuneMinHz: 30000, tuneMaxHz: null }],
+  ])('fails closed on a half-declared envelope %o', (bounds) => {
+    const onEnterFrequency = vi.fn();
+    const r = render(withB(bounds), { onEnterFrequency });
+    expect(r.input()!.disabled).toBe(true);
+    typeFrequency(r.input()!, '14250000');
+    bypassClick(r.btn('entry-set')!);
+    expect(onEnterFrequency).not.toHaveBeenCalled();
+    r.dispose();
+  });
+});
+
+/* ── (e) the wrong-VFO dispatch class ───────────────────────────── */
+
+describe('a receiver-scoped write needs a known active receiver (MOR-1322 B1 class)', () => {
+  const unknownRx = (view: RadioViewModel): RadioViewModel =>
+    ({ ...view, activeReceiver: { status: 'unknown' } });
+
+  // Kills: dropping the markup gate.
+  it('disables every band choice and the entry while the active receiver is unobserved', () => {
+    const r = render(unknownRx(withB({ tuneMinHz: 30000, tuneMaxHz: 60000000 })));
+    for (const name of ['40m', '20m', 'MW']) expect(r.btn(`choice-${name}`)!.disabled).toBe(true);
+    expect(r.input()!.disabled).toBe(true);
+    expect(r.btn('entry-set')!.disabled).toBe(true);
+    expect(r.text('entry-reason')).toContain('active receiver not observed');
+    r.dispose();
+  });
+
+  // Kills: dropping the band-select handler guard — independently of the
+  // attribute, which a `.click()` assertion alone would have satisfied.
+  it('refuses a band select with the disabled attribute bypassed', () => {
+    const onSelectBand = vi.fn();
+    const r = render(unknownRx(base()), { onSelectBand });
+    bypassClick(r.btn('choice-20m')!);
+    expect(onSelectBand).not.toHaveBeenCalled();
+    r.dispose();
+  });
+
+  // Kills: dropping the frequency-entry handler guard.
+  it('refuses a frequency entry with the disabled attribute bypassed', () => {
+    const onEnterFrequency = vi.fn();
+    const r = render(unknownRx(withB({ tuneMinHz: 30000, tuneMaxHz: 60000000 })),
+      { onEnterFrequency });
+    typeFrequency(r.input()!, '14250000');
+    bypassClick(r.btn('entry-set')!);
+    expect(onEnterFrequency).not.toHaveBeenCalled();
+    r.dispose();
+  });
+
+  it('dispatches normally once the active receiver is observed', () => {
+    const onSelectBand = vi.fn();
+    const r = render(base(), { onSelectBand });
+    expect(r.btn('choice-20m')!.disabled).toBe(false);
+    r.btn('choice-20m')!.click();
+    flushSync();
+    expect(onSelectBand).toHaveBeenCalledExactlyOnceWith('20m', 14195000, 5);
+    r.dispose();
+  });
+});
+
+/* ── honest unknown, and the F2 standing convention ─────────────── */
+
+describe('unknown is rendered as unknown (and F2 gets no local workaround)', () => {
+  it('renders an unread current band as the unknown text, marked unobserved', () => {
+    const r = render(withB({ currentBand: unreadBand() }));
+    expect(r.text('current-value')).toBe(UNKNOWN_TEXT);
+    expect(r.el('current')!.dataset.observed).toBe('false');
+    r.dispose();
+  });
+
+  it('renders nothing for a structurally-absent current band', () => {
+    const r = render(withB({
+      currentBand: { reading: { status: 'unknown' }, availability: { structural: false, operational: false } },
+    }));
+    expect(r.el('current')).toBeNull();
+    expect(r.el('tx')).not.toBeNull();
+    r.dispose();
+  });
+
+  // Carry-forward 4 (F2): the permissive `topFieldAvailable` default for
+  // `main.freqHz` is a standing repo convention, deliberately not special-cased
+  // here. Kills: adding a local re-gate that second-guesses the fact.
+  it('takes the availability flags at face value, with no local freshness workaround', () => {
+    for (const forbidden of ['fieldStatus', 'topFieldAvailable', 'freqObserved', 'freshness']) {
+      expect(CODE).not.toContain(forbidden);
+    }
+    const r = render(withB({ currentBand: knownBand('20m'), currentBandTx: 'allowed' }));
+    expect(r.el('current')!.dataset.observed).toBe('true');
+    expect(r.text('current-value')).toBe('20m');
+    r.dispose();
+  });
+
+  it('renders no choice row at all for an empty band plan', () => {
+    const r = render(withB({ bandChoices: [] }));
+    expect(r.el('choices')).toBeNull();
+    expect(r.el('tx')).not.toBeNull();
+    r.dispose();
+  });
+});

--- a/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
+++ b/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
@@ -110,6 +110,8 @@ vi.mock('../../../components-v2/wiring/command-bus', () => ({
     onAttChange: h.txAuxNoop, onPreChange: h.txAuxNoop, onRfGainChange: h.txAuxNoop,
     onSquelchChange: h.txAuxNoop, onDigiSelToggle: h.txAuxNoop, onIpPlusToggle: h.txAuxNoop,
   }),
+  // MOR-1307 slice 7B: the band-select intent the band surface composes.
+  makeBandHandlers: () => ({ onBandSelect: h.txAuxNoop }),
 }));
 
 import DualReceiverCockpit from '../DualReceiverCockpit.svelte';


### PR DESCRIPTION
## Summary

7B: BandSurface over the band facts (MOR-1294, 7A). SAFETY-ADJACENT: renders per-band TX permission. currentBandTx comes ONLY from the live-frequency fact; defaultHzTxPermit is presented strictly as a point-sample naming its frequency; out-of-band stays denied, never fail-open. The authoritative view.txPermit gates the visible headline: under SPLIT or an unobserved TX target the surface renders an explicit caveat ('TX target denied/unknown: ...') instead of a bare 'allowed'.

Production LOC 145 (verifier-measured, frozen formula; cap 200).

## Review provenance

Verified by the vocabulary-domain opus anchor #2 (session 8). Initial verify BLOCKED on two findings both discovered by adversarial probing (F1 split-hazard headline, F2 denial-reason misattribution to scope/receiver entries); prescribed fixes applied and delta-confirmed against the anchor's own original measurements (P2/P4 probes now render the caveat; R1/R2 misattribution exactly inverted; forbidding assertion deleted). Mutation battery: M1 (defaultHz fail-open regression class) kills 12, M2 (permit flip) kills 53, F2-regression mutant kills, 3 new caveat-branch mutants all die; canon dual restorations die after three rebases. Canon: FULL PASS, best-pinned mount of the wave (control-test recipe). Harness post-1351: 60/60, 1797/1797, zero ok-flips - 16 reference captures gain four band controls, all a11y assertions hold ('exercised and passing').

Follow-ups ticketed: MOR-1356 (deriveBand seen()-gate, 7A layer), MOR-1357 (input hardening). Wrong-VFO ruling recorded: no band command carries a receiver parameter; the fail-closed activeReceiver gate is the only honest protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)