### PR TITLE
feat(MOR-1309): antenna surface (8C, safety-adjacent) - under-power switching gated fail-closed

### DIFF
--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -31,6 +31,7 @@
     compositionSurfaces, useSurfacePlan, zoneShowsSurface,
   } from '../../presentation/workspace/resolution';
   import { LAN_MOD_INPUT_SOURCE } from '$lib/radio/mod-input';
+  import AntennaSurface from '../../semantic/AntennaSurface.svelte';
   import BandSurface from '../../semantic/BandSurface.svelte';
   import DspSurface, {
     type DspLevelField, type DspToggleField,
@@ -50,9 +51,9 @@
   import VfoSurface, { type VfoSelection } from '../../semantic/VfoSurface.svelte';
   import ModInputTxWarning from '../panels/ModInputTxWarning.svelte';
   import {
-    makeAgcHandlers, makeAudioRoutingHandlers, makeBandHandlers, makeDspHandlers,
-    makeFilterHandlers, makeModeHandlers, makeRfFrontEndHandlers, makeRxAudioHandlers,
-    makeTxHandlers, makeVfoHandlers, makeVoxHandlers,
+    makeAgcHandlers, makeAntennaHandlers, makeAudioRoutingHandlers, makeBandHandlers,
+    makeDspHandlers, makeFilterHandlers, makeModeHandlers, makeRfFrontEndHandlers,
+    makeRxAudioHandlers, makeTxHandlers, makeVfoHandlers, makeVoxHandlers,
   } from './command-bus';
   import {
     forReceiver, receiversOf, isActiveStrip, isOperationalStrip,
@@ -177,6 +178,18 @@
    */
   const rxAudioIntents = makeRxAudioHandlers();
   const routingIntents = makeAudioRoutingHandlers();
+  /**
+   * MOR-1309. The antenna intent vocabulary, composed from the SHIPPED command
+   * bus rather than forked — `set_antenna_1`/`set_antenna_2`/the two RX-ANT
+   * commands are exactly what `AntennaPanel` fires today. The port map exists
+   * so the pure surface can stay PORT-addressed while the bus stays
+   * command-addressed; a port the bus cannot name is unreachable by
+   * construction rather than by a silent no-op.
+   */
+  const antennaIntents = makeAntennaHandlers();
+  const ANTENNA_PORT_INTENT: Record<number, () => void> = {
+    1: antennaIntents.onSelectAnt1, 2: antennaIntents.onSelectAnt2,
+  };
   const setModInputLan = () => makeModeHandlers().onModInputChange(LAN_MOD_INPUT_SOURCE);
   /**
    * MOR-1304. `makeModeHandlers` owns mode/dataMode intents, `makeFilterHandlers`
@@ -679,6 +692,36 @@
   {/snippet}
 
   <!--
+    MOR-1309 (vocabulary slice 8C, SAFETY-ADJACENT). Same structural gate as
+    the surfaces above, and the SAME single-composition-only rule `rxAudio`
+    carries: this surface renders focusable controls and no manifest declares
+    an `antenna` zone, so mounting it in the dual composition would put
+    controls outside every declared zone — the MOR-1069 invariant the cockpit
+    enforces, and `zoned()` does NOT grant that permission on its own
+    (`zoneOwning()` returns null for an undeclared surface and renders bare,
+    which IS the violating shape). Its absence from the dual composition is
+    pinned by name in `__tests__/semantic-antenna-wiring.component.test.ts`.
+    `'antenna'` became DECLARABLE with this slice, so a layout gains the
+    surface the moment its manifest declares a zone — a layout decision,
+    separately reviewed, exactly as txAux/meters/rxAudio left it.
+
+    It DOES take the App-owned TX authority snapshot: unlike `rxAudio`,
+    switching a TX antenna under power is a hazard, and the surface gates on
+    the SHARED `keyBlockedReasons` predicate applied to this snapshot. It
+    still takes no lease and keys nothing — exactly one `<RxTxSurface>`
+    remains the key/unkey authority (R9).
+  -->
+  {#snippet antennaSurface()}
+    {#if view?.antenna}
+      <AntennaSurface
+        {view} tx={txState}
+        onSelectPort={(port) => ANTENNA_PORT_INTENT[port]?.()}
+        onToggleRxAnt={antennaIntents.onToggleRxAnt}
+      />
+    {/if}
+  {/snippet}
+
+  <!--
     MOR-1305 (vocabulary slice 5B). Same structural gate and same reasoning as
     `rxAudioSurface` above: the surface mounts only when the view model
     actually carries the MOR-1290 `dsp` group, so a radio the evidence gate
@@ -809,6 +852,7 @@
     {@render zoned('dsp', view?.dsp !== undefined, dspSurface)}
     {@render zoned('rfFrontEnd', view?.rfFrontEnd !== undefined, rfFrontEndSurface)}
     {@render zoned('band', view?.band !== undefined, bandSurface)}
+    {@render zoned('antenna', view?.antenna !== undefined, antennaSurface)}
     {@render txAdjacentAlerts()}
   {/if}
 </div>

--- a/frontend/src/components-v2/wiring/__tests__/semantic-antenna-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-antenna-wiring.component.test.ts
@@ -1,0 +1,305 @@
+/**
+ * MOR-1309 — the semantic antenna surface wired into `SemanticRadioSurfaces`.
+ *
+ * `semantic/__tests__/AntennaSurface.test.ts` proves what the surface does with
+ * a view model. This file proves what only the composed tree can prove, using
+ * the REAL command bus, the REAL adapter and the REAL surface — only the
+ * transport/runtime/authority SEAMS are spied:
+ *
+ *   (a) MOUNTING CANON (MOR-1304 ruling). The surface is control-bearing and
+ *       no manifest declares an `antenna` zone, so it must NOT appear in the
+ *       DUAL composition — bare OR through `zoned()`, which renders bare for an
+ *       undeclared surface and is therefore not permission. The pin below
+ *       renders `strips="dual"` with a view model that DOES carry the antenna
+ *       group; a fixture that cannot see the surface would make it vacuous.
+ *   (b) SAFETY, end to end: while the App-owned TX authority reports the
+ *       transmitter keyed — or its RF state unknown — a forced click on a port
+ *       reaches NO command. The gate is pinned at the transport seam, past both
+ *       the disabled attribute and the surface's own handler.
+ *   (c) The port intents route to the SHIPPED antenna commands, not a v3 fork.
+ *   (d) The structural gate: a single-port radio renders the pre-1309 shape.
+ *
+ * Isolated pool by name (`*.component.test.ts`), per the MOR-1272 doctrine.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { ServerState } from '$lib/types/state';
+
+type Snapshot = {
+  phase: string; intent: string | null; guard: { leaseId: string } | null;
+  radioTx: string; txRisk: string; mayOwnKey: boolean; fault: string | null;
+};
+
+const h = vi.hoisted(() => ({
+  state: null as unknown,
+  caps: null as unknown,
+  snapshot: null as unknown,
+  audio: { muted: false, rxEnabled: true, volume: 42 },
+  audioConnected: true,
+  listeners: new Set<(next: unknown) => void>(),
+}));
+
+vi.mock('$lib/transport/ws-client', () => ({ sendCommand: vi.fn() }));
+vi.mock('$lib/audio/audio-manager', () => ({
+  audioManager: {
+    get rxEnabled() { return true; },
+    startRx: vi.fn(), stopRx: vi.fn(), setRxVolume: vi.fn(), setAudioConfig: vi.fn(),
+  },
+}));
+vi.mock('$lib/runtime/frontend-runtime', () => ({
+  runtime: {
+    get state() { return h.state; },
+    get caps() { return h.caps; },
+    get audio() { return h.audio; },
+    get connectionAudio() { return h.audioConnected; },
+    get rxEnabled() { return true; },
+    setVolume: vi.fn(), setMuted: vi.fn(), setRxLive: vi.fn(), setRxVolume: vi.fn(),
+  },
+}));
+vi.mock('$lib/runtime', async () => ({
+  runtime: (await import('$lib/runtime/frontend-runtime')).runtime,
+}));
+vi.mock('$lib/runtime/tx-controller/app-host', () => ({
+  getAppTxController: () => ({
+    snapshot: () => h.snapshot,
+    subscribe: (listener: (next: unknown) => void) => {
+      h.listeners.add(listener);
+      return () => { h.listeners.delete(listener); };
+    },
+    start: vi.fn(), setIntent: vi.fn(), release: vi.fn(), resetFault: vi.fn(),
+  }),
+}));
+vi.mock('$lib/runtime/adapters/mod-input-tx-guard.svelte', () => ({
+  deriveModInputTxGuardProps: () => ({ visible: false, sourceLabel: 'MIC' }),
+  getModInputTxGuardHandlers: () => ({ onSetLan: vi.fn(), onDismiss: vi.fn() }),
+}));
+
+import { sendCommand } from '$lib/transport/ws-client';
+import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';
+import { makeAntennaHandlers } from '../command-bus';
+
+const RECEIVING: Snapshot = {
+  phase: 'idle', intent: null, guard: null, radioTx: 'off', txRisk: 'none',
+  mayOwnKey: false, fault: null,
+};
+const TRANSMITTING: Snapshot = {
+  ...RECEIVING, phase: 'active', intent: 'latched', guard: { leaseId: 'x' },
+  radioTx: 'on', txRisk: 'confirmed-on', mayOwnKey: true,
+};
+const RF_UNKNOWN: Snapshot = { ...RECEIVING, radioTx: 'unknown' };
+
+const fresh = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' };
+const slot = (freqHz: number) => ({ freqHz, mode: 'USB', filterNum: 1, dataMode: 0 });
+
+function liveState(over: Partial<ServerState> = {}): ServerState {
+  const paths = [
+    'active', 'split', 'dualWatch', 'txTarget', 'txAntenna', 'rxAntenna1', 'rxAntenna2',
+    'tunerStatus',
+  ];
+  for (const rx of ['main', 'sub']) {
+    paths.push(`${rx}.freqHz`, `${rx}.mode`, `${rx}.filter`, `${rx}.activeSlot`);
+    for (const v of ['vfoA', 'vfoB']) {
+      paths.push(`${rx}.${v}.freqHz`, `${rx}.${v}.mode`, `${rx}.${v}.filterNum`);
+    }
+  }
+  const receiver = (hz: number) => ({
+    ...slot(hz), vfoA: slot(hz), vfoB: slot(hz + 50000), activeSlot: 'A', filter: 1,
+  });
+  return {
+    active: 'MAIN', split: false, dualWatch: false, ptt: false,
+    txAntenna: 1, rxAntenna1: false, rxAntenna2: false, tunerStatus: 0,
+    txTarget: { status: 'known', receiver: 'MAIN', slot: 'A', frequencyHz: 14250000 },
+    main: receiver(14250000), sub: receiver(14300000),
+    ...over,
+    fieldStatus: Object.fromEntries(paths.map((p) => [p, fresh])),
+  } as unknown as ServerState;
+}
+
+const liveCaps = (antennas: number, tags: readonly string[]): Capabilities => ({
+  model: 'fixture', scope: false, audio: false, tx: true,
+  capabilities: tags, antennas,
+  receivers: 2, vfoScheme: 'main_sub', freqRanges: [], modes: [], filters: [],
+  audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
+  webrtc: { available: false, enabled: false },
+  txBands: [{ start: 14000000, end: 14350000, name: '20m' }],
+  scopeSource: null, audioFftAvailable: false,
+} as unknown as Capabilities);
+
+const ANTENNA_TAGS = ['tx', 'dual_rx', 'rx_antenna', 'tuner'] as const;
+
+let target: HTMLDivElement;
+let component: ReturnType<typeof mount> | null = null;
+
+function render(props: { strips?: 'single' | 'dual' } = {}): void {
+  target = document.createElement('div');
+  document.body.appendChild(target);
+  component = mount(SemanticRadioSurfaces, { target, props });
+  flushSync();
+}
+
+const q = <T extends HTMLElement>(sel: string) => target.querySelector(sel) as T | null;
+const el = (id: string) => q<HTMLElement>(`[data-testid="antenna-${id}"]`);
+const btn = (id: string) => q<HTMLButtonElement>(`[data-testid="antenna-${id}"]`);
+/** Past the `disabled` attribute, so a handler/command guard is proven alone. */
+function forceClick(node: HTMLElement): void {
+  node.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  flushSync();
+}
+
+beforeEach(() => {
+  h.state = liveState();
+  h.caps = liveCaps(2, ANTENNA_TAGS);
+  h.snapshot = { ...RECEIVING };
+  h.listeners.clear();
+  vi.mocked(sendCommand).mockClear();
+});
+
+afterEach(() => {
+  if (component) unmount(component);
+  component = null;
+  document.body.innerHTML = '';
+});
+
+/* ── (a) the mounting canon ────────────────────────────────────── */
+
+describe('the antenna surface never mounts in the dual composition (MOR-1304 canon)', () => {
+  /**
+   * MUTATION KILLED: mounting this surface in the cockpit, bare or through
+   * `zoned()`. It renders focusable controls and no manifest declares an
+   * `antenna` zone, so `zoneOwning()` returns null and `zoned` renders BARE —
+   * outside every declared zone, breaking the MOR-1069 invariant that every
+   * focusable control sits inside a declared zone with rx-tx last in the tab
+   * order. The view model here DOES carry the group (asserted below), so this
+   * pin cannot pass because the fixture is blind — the failure mode that made
+   * `DualReceiverCockpit.component.test.ts` non-discriminating.
+   */
+  it('renders NO antenna surface in the dual composition, zoned or unzoned', () => {
+    render({ strips: 'single' });
+    expect(el('surface')).not.toBeNull();
+    unmount(component!);
+    component = null;
+    document.body.innerHTML = '';
+
+    render({ strips: 'dual' });
+    expect(el('surface')).toBeNull();
+    expect(target.innerHTML).not.toContain('antenna');
+  });
+
+  /**
+   * The same claim stated as a DIFFERENCE, which is what MOR-1069 actually
+   * cares about: carrying the antenna group must not add one focusable control
+   * to the cockpit. Asserting "nothing outside a zone" outright would fail for
+   * reasons this slice does not own (a standalone mount resolves no surface
+   * plan, so every optional surface renders bare here) and would therefore be
+   * a broken pin rather than a strict one.
+   */
+  it('adds no focusable control to the cockpit compared with a single-port radio', () => {
+    const controls = () => [...target
+      .querySelectorAll<HTMLElement>('button, input, select, [tabindex]')]
+      .map((node) => node.dataset.testid ?? node.tagName);
+
+    h.caps = liveCaps(1, ANTENNA_TAGS);
+    render({ strips: 'dual' });
+    const withoutGroup = controls();
+    unmount(component!);
+    component = null;
+    document.body.innerHTML = '';
+
+    h.caps = liveCaps(2, ANTENNA_TAGS);
+    render({ strips: 'dual' });
+    expect(controls()).toEqual(withoutGroup);
+  });
+
+  it('renders it bare in the single composition, outside every zone', () => {
+    render();
+    expect(el('surface')!.closest('[data-zone-id]')).toBeNull();
+  });
+});
+
+/* ── (d) the structural gate ───────────────────────────────────── */
+
+describe('the surface mounts only when the view model carries the group', () => {
+  // MUTATION KILLED: mounting unconditionally — a single-port radio would gain
+  // an antenna panel with nothing to switch between.
+  it('renders no antenna surface for a radio declaring one TX port', () => {
+    h.caps = liveCaps(1, ANTENNA_TAGS);
+    render();
+    expect(el('surface')).toBeNull();
+  });
+
+  it('omits RX-ANT for a multi-port radio that does not declare the capability', () => {
+    h.caps = liveCaps(2, ['tx', 'tuner']);
+    render();
+    expect(el('surface')).not.toBeNull();
+    expect(el('rx-toggle')).toBeNull();
+  });
+});
+
+/* ── (c) the shipped command vocabulary ────────────────────────── */
+
+describe('the antenna intents reach the shipped command vocabulary', () => {
+  it('composes the shipped antenna handler factory', () => {
+    const handlers = makeAntennaHandlers() as Record<string, unknown>;
+    for (const name of ['onSelectAnt1', 'onSelectAnt2', 'onToggleRxAnt']) {
+      expect(typeof handlers[name]).toBe('function');
+    }
+  });
+
+  it('routes a port pick to the shipped set_antenna command for that port', () => {
+    render();
+    btn('port-2')!.click();
+    flushSync();
+    expect(sendCommand).toHaveBeenCalledExactlyOnceWith('set_antenna_2', { on: false });
+  });
+
+  it('routes an RX-ANT toggle to the shipped RX-antenna command', () => {
+    render();
+    btn('rx-toggle')!.click();
+    flushSync();
+    expect(sendCommand).toHaveBeenCalledExactlyOnceWith('set_rx_antenna_ant1', { on: true });
+  });
+});
+
+/* ── (b) the under-power gate, pinned at the transport seam ────── */
+
+describe('no antenna command leaves the tree while the transmitter is not idle', () => {
+  // MUTATION KILLED (end to end, past `disabled` AND past the surface handler):
+  // inverting or dropping the under-power gate. This is the whole point of the
+  // slice — a relay switched under power damages the radio.
+  it.each([['transmitting', TRANSMITTING], ['RF-state unknown', RF_UNKNOWN]] as const)(
+    'sends nothing on a forced port click while %s', (_label, snapshot) => {
+      h.snapshot = { ...snapshot };
+      render();
+      forceClick(btn('port-2')!);
+      forceClick(btn('rx-toggle')!);
+      expect(sendCommand).not.toHaveBeenCalled();
+      expect(btn('port-2')!.disabled).toBe(true);
+    },
+  );
+
+  // MUTATION KILLED: letting an UNOBSERVED tunerStatus fall through to "idle"
+  // (MOR-1295 §3). The ATU fact is `txAux.atu` — this pin proves the LIVE
+  // adapter path produces the not-ready state, not just a hand-built fixture.
+  it('sends nothing while the live tunerStatus was never observed', () => {
+    h.state = liveState({ tunerStatus: undefined } as Partial<ServerState>);
+    render();
+    expect(el('blocked')!.textContent).toContain('ATU');
+    forceClick(btn('port-2')!);
+    expect(sendCommand).not.toHaveBeenCalled();
+  });
+
+  // The gate must open again — a surface that can never switch is not a gate.
+  it('sends the command once the authority reports a positively receiving radio', () => {
+    h.snapshot = { ...TRANSMITTING };
+    render();
+    forceClick(btn('port-2')!);
+    expect(sendCommand).not.toHaveBeenCalled();
+    h.snapshot = { ...RECEIVING };
+    for (const listener of h.listeners) listener(h.snapshot);
+    flushSync();
+    btn('port-2')!.click();
+    flushSync();
+    expect(sendCommand).toHaveBeenCalledExactlyOnceWith('set_antenna_2', { on: false });
+  });
+});

--- a/frontend/src/components-v2/wiring/__tests__/semantic-dsp-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-dsp-wiring.component.test.ts
@@ -123,6 +123,10 @@ vi.mock('../command-bus', () => ({
   // This fixture declares no band capability, so it is never reachable —
   // same stand-in role as `makeVfoHandlers`/`makeTxHandlers` above.
   makeBandHandlers: () => ({ onBandSelect: h.noop }),
+  // MOR-1309 slice 8C: the wiring now also composes the antenna intent
+  // vocabulary unconditionally. This fixture declares no antenna capability,
+  // so none of these is reachable — same stand-in role as `makeBandHandlers`.
+  makeAntennaHandlers: () => ({ onSelectAnt1: h.noop, onSelectAnt2: h.noop, onToggleRxAnt: h.noop }),
 }));
 
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';

--- a/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
@@ -107,6 +107,8 @@ vi.mock('../command-bus', () => ({
   }),
   // MOR-1307 slice 7B: the band-select intent the band surface composes.
   makeBandHandlers: () => ({ onBandSelect: h.noop }),
+  // MOR-1309 slice 8C: the antenna intent vocabulary.
+  makeAntennaHandlers: () => ({ onSelectAnt1: h.noop, onSelectAnt2: h.noop, onToggleRxAnt: h.noop }),
 }));
 
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';

--- a/frontend/src/components-v2/wiring/__tests__/semantic-rf-front-end-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rf-front-end-wiring.component.test.ts
@@ -122,6 +122,12 @@ vi.mock('../command-bus', () => ({
   // This fixture declares no band capability, so it is never reachable —
   // same stand-in role as the noop handlers above.
   makeBandHandlers: () => ({ onBandSelect: h.noop }),
+  // MOR-1309 slice 8C: the wiring's module scope also composes the antenna
+  // intent vocabulary unconditionally; without a stub here the wiring's
+  // `makeAntennaHandlers()` call throws before this file's own RF-front-end
+  // assertions ever run. This fixture declares no antenna capability, so
+  // none of these is reachable — same stand-in role as `makeBandHandlers`.
+  makeAntennaHandlers: () => ({ onSelectAnt1: h.noop, onSelectAnt2: h.noop, onToggleRxAnt: h.noop }),
 }));
 
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';

--- a/frontend/src/components-v2/wiring/__tests__/semantic-rx-tx-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rx-tx-wiring.component.test.ts
@@ -133,6 +133,8 @@ vi.mock('../command-bus', () => ({
   }),
   // MOR-1307 slice 7B: the band-select intent the band surface composes.
   makeBandHandlers: () => ({ onBandSelect: h.txAuxNoop }),
+  // MOR-1309 slice 8C: the antenna intent vocabulary.
+  makeAntennaHandlers: () => ({ onSelectAnt1: h.txAuxNoop, onSelectAnt2: h.txAuxNoop, onToggleRxAnt: h.txAuxNoop }),
 }));
 
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';

--- a/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
@@ -122,6 +122,8 @@ vi.mock('../command-bus', () => ({
   }),
   // MOR-1307 slice 7B: the band-select intent the band surface composes.
   makeBandHandlers: () => ({ onBandSelect: h.noop }),
+  // MOR-1309 slice 8C: the antenna intent vocabulary.
+  makeAntennaHandlers: () => ({ onSelectAnt1: h.noop, onSelectAnt2: h.noop, onToggleRxAnt: h.noop }),
 }));
 
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';

--- a/frontend/src/presentation/layouts/__tests__/antenna-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/antenna-declarability.test.ts
@@ -1,16 +1,21 @@
 /**
- * MOR-1306 — `rfFrontEnd` is DECLARABLE, and nothing declares it yet.
+ * MOR-1309 — `antenna` is DECLARABLE, and nothing declares it yet.
  *
- * Slice 6B adds the name to `SEMANTIC_SURFACE_NAMES` so a manifest CAN mount
+ * Slice 8C adds the name to `SEMANTIC_SURFACE_NAMES` so a manifest CAN mount
  * the surface later; it deliberately does not touch any manifest, and it adds
  * no design-language renderer slot (that set was frozen by MOR-1072 — adding
  * one would be a language-contract change this slice must not make).
  *
- * Same three pins as `tx-aux-declarability.test.ts` / `meters-declarability.test.ts`
- * / `rx-audio-declarability.test.ts`:
+ * The "nothing declares it yet" half is load-bearing HERE in a way it was not
+ * for `meters`: the antenna surface is control-bearing, and it is mounted in
+ * the SINGLE composition only (MOR-1304 mounting canon, option (i)). A zone
+ * declared in a dual-mounting manifest without the matching composition work
+ * would put focusable controls outside the cockpit's declared zones.
+ *
+ * Same three pins as `rx-audio-declarability.test.ts` / `tx-aux-declarability.test.ts`:
  *   - drop the name and a future manifest's zone stops validating;
- *   - quietly add an `rfFrontEnd` zone to a shipped manifest and the DOM
- *     grows a zone id no layout review ever saw;
+ *   - quietly add an `antenna` zone to a shipped manifest and the DOM grows a
+ *     zone id no layout review ever saw;
  *   - the renderer slot set stays exactly what MOR-1072 froze.
  */
 import { describe, it, expect } from 'vitest';
@@ -22,19 +27,20 @@ import {
   sdrTestLayout,
 } from '../declarations';
 
-describe('rfFrontEnd is a declarable semantic surface', () => {
-  // Kills: reverting the SEMANTIC_SURFACE_NAMES addition. MOR-1307 appended
-  // `band`; `rfFrontEnd` must stay present and in place.
+describe('antenna is a declarable semantic surface', () => {
+  // Kills: reverting the SEMANTIC_SURFACE_NAMES addition.
   it('is in the declarable set alongside vfo, rxTx, txAux, meters and rxAudio', () => {
     expect([...SEMANTIC_SURFACE_NAMES])
-      .toEqual(['vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band', 'antenna']);
+      .toEqual([
+        'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band', 'antenna',
+      ]);
   });
 
   // Kills: adding the name to the type but not to the runtime allow-list the
   // zone validator checks — the manifest would still be rejected.
   it('accepts a manifest zone that declares it', () => {
     const manifest = validLayoutManifest({
-      zones: [{ id: 'main', surfaces: ['vfo', 'rxTx', 'rfFrontEnd'] }],
+      zones: [{ id: 'main', surfaces: ['vfo', 'rxTx', 'antenna'] }],
       requiredSemanticSurfaces: ['vfo', 'rxTx'],
     });
     expect(() => validateLayoutManifest(manifest)).not.toThrow();
@@ -42,31 +48,30 @@ describe('rfFrontEnd is a declarable semantic surface', () => {
 
   it('still rejects a zone naming a surface that does not exist', () => {
     const manifest = validLayoutManifest({
-      zones: [{ id: 'main', surfaces: ['rfFrontEndPanel'] as unknown as readonly ['vfo'] }],
+      zones: [{ id: 'main', surfaces: ['antennaPanel'] as unknown as readonly ['vfo'] }],
     });
     expect(() => validateLayoutManifest(manifest)).toThrow(/subset of/);
   });
 });
 
-describe('no shipped manifest declares an rfFrontEnd zone in this slice', () => {
-  // Kills: slipping an rfFrontEnd zone into an existing layout here.
-  // Declarability is the whole scope of the contract touch; placing the
-  // surface in a real layout (including the dual-receiver-cockpit — see the
-  // MOR-1069 mount canon in `RfFrontEndSurface.svelte`) is a later, separately
-  // reviewed rework slice.
+describe('no shipped manifest declares an antenna zone in this slice', () => {
+  // Kills: slipping an antenna zone into an existing layout here. Declarability
+  // is the whole scope of the contract touch; placing a control-bearing surface
+  // in a real layout is a later, separately reviewed slice that must also do
+  // the dual-composition mount work the canon requires.
   it.each([
     ['sdr-test', sdrTestLayout], ['dual-receiver-cockpit', dualReceiverCockpitLayout],
     ['lcd-cockpit', lcdCockpitLayout], ['lcd-scope', lcdScopeLayout],
     ['mobile', mobileLayout], ['desktop-v2', desktopV2Layout],
-  ])('%s declares no rfFrontEnd zone and does not require the surface', (_id, manifest) => {
-    for (const zone of manifest.zones) expect(zone.surfaces).not.toContain('rfFrontEnd');
-    expect(manifest.requiredSemanticSurfaces).not.toContain('rfFrontEnd');
+  ])('%s declares no antenna zone and does not require the surface', (_id, manifest) => {
+    for (const zone of manifest.zones) expect(zone.surfaces).not.toContain('antenna');
+    expect(manifest.requiredSemanticSurfaces).not.toContain('antenna');
   });
 });
 
 describe('the design-language renderer slot set is untouched', () => {
-  // Kills: adding a renderer slot for this surface. RF front end has no gauge
-  // grammar a language must describe; the slot set stays frozen.
+  // Kills: adding a renderer slot for this surface. An antenna selector has no
+  // gauge grammar a language must describe; the slot set stays frozen.
   it('still carries exactly the three MOR-1072 slots', () => {
     expect([...RENDERER_SLOT_NAMES]).toEqual(['meters', 'frequencyDisplay', 'stateFeedback']);
   });

--- a/frontend/src/presentation/layouts/__tests__/band-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/band-declarability.test.ts
@@ -27,7 +27,7 @@ describe('band is a declarable semantic surface', () => {
   // appended `rfFrontEnd`; `band` must land last, after all of them.
   it('is in the declarable set alongside vfo, rxTx, txAux, meters, rxAudio, filter, dsp and rfFrontEnd', () => {
     expect([...SEMANTIC_SURFACE_NAMES])
-      .toEqual(['vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band']);
+      .toEqual(['vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band', 'antenna']);
   });
 
   // Kills: adding the name to the type but not to the runtime allow-list the

--- a/frontend/src/presentation/layouts/__tests__/dsp-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/dsp-declarability.test.ts
@@ -20,7 +20,7 @@ describe('dsp is a declarable semantic surface', () => {
   // slice must not create.
   it('is in the declarable set alongside vfo, rxTx, txAux, meters and rxAudio', () => {
     expect([...SEMANTIC_SURFACE_NAMES]).toEqual([
-      'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band',
+      'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band', 'antenna',
     ]);
   });
 

--- a/frontend/src/presentation/layouts/__tests__/filter-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/filter-declarability.test.ts
@@ -23,7 +23,7 @@ describe('filter is a declarable semantic surface', () => {
   // Kills: reverting the SEMANTIC_SURFACE_NAMES addition.
   it('is in the declarable set alongside vfo, rxTx, txAux, meters and rxAudio', () => {
     expect([...SEMANTIC_SURFACE_NAMES]).toEqual([
-      'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band',
+      'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band', 'antenna',
     ]);
   });
 

--- a/frontend/src/presentation/layouts/__tests__/meters-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/meters-declarability.test.ts
@@ -29,7 +29,7 @@ describe('meters is a declarable semantic surface', () => {
   // place.
   it('is in the declarable set alongside vfo, rxTx and txAux', () => {
     expect([...SEMANTIC_SURFACE_NAMES]).toEqual([
-      'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band',
+      'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band', 'antenna',
     ]);
   });
 

--- a/frontend/src/presentation/layouts/__tests__/rx-audio-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/rx-audio-declarability.test.ts
@@ -25,7 +25,7 @@ describe('rxAudio is a declarable semantic surface', () => {
   // Kills: reverting the SEMANTIC_SURFACE_NAMES addition.
   it('is in the declarable set alongside vfo, rxTx, txAux and meters', () => {
     expect([...SEMANTIC_SURFACE_NAMES]).toEqual([
-      'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band',
+      'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band', 'antenna',
     ]);
   });
 

--- a/frontend/src/presentation/layouts/__tests__/tx-aux-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/tx-aux-declarability.test.ts
@@ -29,7 +29,7 @@ describe('txAux is a declarable semantic surface', () => {
   // appended `rfFrontEnd`; `txAux` must stay present and in place.
   it('is in the declarable set alongside vfo and rxTx', () => {
     expect([...SEMANTIC_SURFACE_NAMES]).toEqual([
-      'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band',
+      'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band', 'antenna',
     ]);
   });
 

--- a/frontend/src/presentation/layouts/contract.ts
+++ b/frontend/src/presentation/layouts/contract.ts
@@ -15,15 +15,16 @@ import { isValidLanguageId as isValidProductId } from '../languages/contract';
 /** Semantic surfaces a layout may mount (MOR-1062/1065 reference vertical;
  *  `txAux` added by MOR-1265, `meters` by MOR-1273, `rxAudio` by MOR-1279,
  *  `filter` by MOR-1304, `dsp` by MOR-1305, `rfFrontEnd` by MOR-1306, `band`
- *  by MOR-1307). Adding a name makes it DECLARABLE — it does not mount
- *  anything by itself, and no manifest declares a `meters`, `rxAudio`,
- *  `filter`, `dsp`, `rfFrontEnd` or `band` zone yet (the cockpit declares
- *  only `txAux`, as `tx-aux` — MOR-1336). Distinct from the design-language
- *  renderer slot of the same name (`languages/contract.ts`'s
- *  `RENDERER_SLOT_NAMES`): that one says how a language DRAWS a meter, this
- *  one says which layout zone may HOST the surface. */
+ *  by MOR-1307, `antenna` by MOR-1309). Adding a name makes it DECLARABLE —
+ *  it does not mount anything by itself, and no manifest declares a
+ *  `meters`, `rxAudio`, `filter`, `dsp`, `rfFrontEnd`, `band` or `antenna`
+ *  zone yet (the cockpit declares only `txAux`, as `tx-aux` — MOR-1336).
+ *  Distinct from the design-language renderer slot of the same name
+ *  (`languages/contract.ts`'s `RENDERER_SLOT_NAMES`): that one says how a
+ *  language DRAWS a meter, this one says which layout zone may HOST the
+ *  surface. */
 export const SEMANTIC_SURFACE_NAMES = [
-  'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band',
+  'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band', 'antenna',
 ] as const;
 export type SemanticSurfaceName = (typeof SEMANTIC_SURFACE_NAMES)[number];
 

--- a/frontend/src/semantic/AntennaSurface.svelte
+++ b/frontend/src/semantic/AntennaSurface.svelte
@@ -1,0 +1,206 @@
+<!--
+  Semantic antenna surface (MOR-1309, vocabulary slice 8C). SAFETY-ADJACENT.
+
+  Presentation only. It renders the MOR-1295 `antenna` fact group — the
+  selected TX port, the port-dependent RX-antenna override and the declared
+  port count — and emits control intents as callbacks. It holds no state,
+  consults no controller and takes no TX lease (v3 ADR invariant 11).
+
+  SAFETY. Four rules govern this file and nothing may relax them:
+
+  (1) AN ANTENNA MUST NOT SWITCH UNDER POWER. Throwing a TX antenna relay
+      while RF is present arcs the contacts and can destroy the PA, the relay
+      or whatever is on the other end of the feedline. The gate is
+      `antennaSwitchBlocks` below, enforced TWICE — on every control
+      (`disabled`) and again inside every handler, because a design language
+      may restyle these controls and a programmatic click must not switch a
+      relay the disabled attribute would have refused.
+
+  (2) UNKNOWN TX STATE IS TREATED AS KEYED. The RF half of the gate is the
+      SHARED `keyBlockedReasons` predicate, applied to the SAME App-owned TX
+      authority snapshot that gates `RxTxSurface`'s key button and
+      `TxAuxSurface`'s TUNE, filtered to the three reasons that mean "the
+      transmitter is not provably idle" (`tx-busy`, `radio-transmitting`,
+      `rf-state-unknown`). A local re-derivation could drift and disagree; the
+      shared import cannot, and this surface never computes TX truth itself
+      (R9). `radioTx: 'unknown'` therefore blocks exactly as hard as
+      `radioTx: 'on'`.
+
+  (3) AN UNREAD TUNER IS TREATED AS RUNNING (MOR-1295 §3 / MOR-1293
+      precedent). ATU state is family 1's `txAux.atu` — it is deliberately NOT
+      duplicated into the `antenna` group — and an ATU mid-cycle is emitting a
+      carrier. `tunerIdle` therefore requires a POSITIVELY observed, non-
+      `tuning` reading; an unobserved or stale `tunerStatus` is not-ready, and
+      this surface never infers "tuner idle, safe to switch".
+      A radio that declares NO tuner (`atu.availability.structural === false`,
+      or no `txAux` group at all — `deriveTxAux` only omits the group when the
+      radio declares no `tx` capability or reported nothing at all) is a
+      DIFFERENT claim from an unread one: there is no tuner that could be
+      running, so it is not a block. Conflating the two would permanently
+      disable antenna switching on every ATU-less radio — broken, not safe.
+
+  (4) NO FABRICATED PORT 1. The shipped v2 `toAntennaProps` defaults
+      `txAntenna = state?.txAntenna ?? 1`, so v2 silently claims port 1 and
+      then reports port 1's RX-ANT; slice 8A refused that and this surface
+      preserves the divergence (the same deliberate, documented pattern
+      6B/PRE and 9B/break-in carry). An unread port renders `UNKNOWN_TEXT`
+      with NO port marked selected — never ANT 1.
+
+  Two-level availability (MOR-977/1256): `structural: false` renders NOTHING —
+  "this radio has no RX-ANT" is a different claim from "RX-ANT is unreadable
+  right now", which renders present-and-disabled with a reason.
+-->
+<script module lang="ts">
+  import type { AntennaField, RadioViewModel } from './radio-view-model';
+  import {
+    BLOCKED_LABEL, keyBlockedReasons, type KeyBlockedReason, type TxAuthoritySnapshot,
+  } from './rx-tx-surface';
+
+  /** The TX ports the shipped command vocabulary can actually reach
+   *  (`set_antenna_1` / `set_antenna_2`) — and exactly what the shipped
+   *  `AntennaPanel` renders. `antennaCount` is this group's EVIDENCE GATE
+   *  (`> 1`), not a port enumerator: inventing a button for a port no command
+   *  can address would be a dead control (the "no speculative keys" rule), so
+   *  the count is published as `data-antenna-count` instead. Every shipped
+   *  profile declares 1 or 2. */
+  export const ANTENNA_PORTS = [1, 2] as const;
+  /** The ONE rendering of "not measured". Never `1`, never `off`. */
+  export const UNKNOWN_TEXT = '—';
+
+  /** The `keyBlockedReasons` subset that means "the transmitter is not
+   *  provably idle". The permit/target/fault reasons are deliberately NOT
+   *  here: an out-of-band frequency makes keying illegal, not antenna
+   *  switching dangerous, and gating on it would be theatre rather than
+   *  safety. */
+  const RF_MUST_BE_IDLE: readonly KeyBlockedReason[] = [
+    'tx-busy', 'radio-transmitting', 'rf-state-unknown',
+  ];
+  export type AntennaSwitchBlock = KeyBlockedReason | 'tuner-not-ready';
+  /** Each label names the CONSEQUENCE, not just the state — an operator who
+   *  sees a disabled antenna button must be told why it is disabled. */
+  export const ANTENNA_BLOCKED_LABEL: Record<AntennaSwitchBlock, string> = {
+    ...BLOCKED_LABEL,
+    'tx-busy': 'a TX lease is in progress — an antenna must not switch under power',
+    'radio-transmitting': 'the radio is transmitting — an antenna must not switch under power',
+    'rf-state-unknown': 'RF state unknown — an unconfirmed transmitter is treated as keyed',
+    'tuner-not-ready': 'ATU not confirmed idle — an unread tuner is treated as running',
+  };
+
+  /** Usable ⇔ the radio HAS it, it is readable NOW, and it was actually read. */
+  export const usable = (f: AntennaField<unknown>): boolean =>
+    f.availability.structural && f.availability.operational && f.reading.status === 'known';
+  /** Honest text: an unread fact reads as unknown, never as a default. */
+  export const textOf = (f: AntennaField<unknown>): string =>
+    f.reading.status !== 'known' ? UNKNOWN_TEXT
+      : typeof f.reading.value === 'boolean' ? (f.reading.value ? 'on' : 'off')
+        : String(f.reading.value);
+  /** Rule (4): `undefined` for an unread fact. There is no `?? 1` here and
+   *  there must never be one. */
+  export const valueOf = <T>(f: AntennaField<T>): T | undefined =>
+    f.reading.status === 'known' ? f.reading.value : undefined;
+
+  /** Rule (3). `true` only for a radio with no ATU at all, or a positively
+   *  observed ATU that is not mid-cycle. */
+  export function tunerIdle(view: RadioViewModel): boolean {
+    const atu = view.txAux?.atu;
+    if (atu === undefined || !atu.availability.structural) return true;
+    return usable(atu) && atu.reading.status === 'known' && atu.reading.value !== 'tuning';
+  }
+
+  /** Rules (1)–(3) as one ordered list of reasons; empty ⇔ switching is safe. */
+  export function antennaSwitchBlocks(
+    view: RadioViewModel, tx: TxAuthoritySnapshot,
+  ): readonly AntennaSwitchBlock[] {
+    const blocks: AntennaSwitchBlock[] = keyBlockedReasons(view, tx)
+      .filter((reason) => RF_MUST_BE_IDLE.includes(reason));
+    if (!tunerIdle(view)) blocks.push('tuner-not-ready');
+    return blocks;
+  }
+
+  /** Per-instance DOM id, so several mounted surfaces keep distinct aria targets. */
+  let sequence = 0;
+</script>
+
+<script lang="ts">
+  interface Props {
+    view: RadioViewModel;
+    tx: TxAuthoritySnapshot;
+    onSelectPort?: (port: number) => void;
+    onToggleRxAnt?: () => void;
+  }
+  let { view, tx, onSelectPort, onToggleRxAnt }: Props = $props();
+
+  const blockedId = `antenna-blocked-${++sequence}`;
+  /** Absent group ⇒ this surface renders nothing (S0 optional-group doctrine):
+   *  a single-port radio gets no empty panel and no zone had to learn about it. */
+  let ant = $derived(view.antenna);
+  let blocked = $derived(antennaSwitchBlocks(view, tx));
+  /** Rule (4). */
+  let currentPort = $derived(ant ? valueOf(ant.txAntenna) : undefined);
+
+  /** The handler half of rule (1). The port choice is ABSOLUTE, so it does not
+   *  need the current reading and is deliberately NOT gated on it — a radio
+   *  that never reported its port must still be able to select one; that is a
+   *  readability gap, not a hazard. The hazard gate is `blocked`. */
+  function selectPort(port: number): void {
+    if (ant && blocked.length === 0) onSelectPort?.(port);
+  }
+  /** RX-ANT is a RELATIVE toggle computed from the current value, so it needs
+   *  an observed reading as well — and `rxAnt`'s own `operational` flag
+   *  already carries "the TX port it belongs to was observed" (MOR-1295). */
+  function toggleRxAnt(): void {
+    if (ant && blocked.length === 0 && usable(ant.rxAnt)) onToggleRxAnt?.();
+  }
+</script>
+
+{#if ant}
+  <section
+    class="antenna-surface" data-testid="antenna-surface" aria-label="Antenna selection"
+    data-antenna-count={ant.antennaCount} data-switch-blocked={blocked.length > 0}
+  >
+    <div
+      class="antenna-row" role="radiogroup" aria-label="Transmit antenna"
+      data-testid="antenna-ports" data-observed={usable(ant.txAntenna)}
+    >
+      {#each ANTENNA_PORTS as port (port)}
+        <button
+          type="button" role="radio" class="antenna-choice"
+          data-testid={`antenna-port-${port}`} data-port={port}
+          aria-checked={currentPort === port} aria-describedby={blockedId}
+          disabled={blocked.length > 0}
+          onclick={() => selectPort(port)}
+        >ANT {port}</button>
+      {/each}
+      <output data-testid="antenna-port-value">{textOf(ant.txAntenna)}</output>
+    </div>
+
+    {#if ant.rxAnt.availability.structural}
+      <div class="antenna-row" data-testid="antenna-rx" data-observed={usable(ant.rxAnt)}>
+        <button
+          type="button" class="antenna-choice" data-testid="antenna-rx-toggle"
+          aria-pressed={valueOf(ant.rxAnt)} aria-describedby={blockedId}
+          disabled={blocked.length > 0 || !usable(ant.rxAnt)}
+          onclick={toggleRxAnt}
+        >RX-ANT: {textOf(ant.rxAnt)}</button>
+      </div>
+    {/if}
+
+    <ul class="antenna-blocked" id={blockedId} data-testid="antenna-blocked">
+      {#each blocked as code (code)}<li data-reason={code}>{ANTENNA_BLOCKED_LABEL[code]}</li>{/each}
+    </ul>
+  </section>
+{/if}
+
+<style>
+  /* Structure only — a design language owns colour and must never become the
+     sole state channel (MOR-977, forced-colors). Nothing here animates. */
+  .antenna-surface { display: flex; flex-direction: column; gap: 0.25rem; }
+  .antenna-row { display: flex; flex-wrap: wrap; align-items: baseline; gap: 0.5rem; }
+  .antenna-choice[aria-checked='true'], .antenna-choice[aria-pressed='true'] { font-weight: 700; }
+  .antenna-blocked { margin: 0; padding-inline-start: 1.2em; }
+  .antenna-blocked:empty { display: none; }
+  /* Second channel beside `data-observed`, never the only one: the unknown
+     text itself is the primary one and survives forced-colors. */
+  [data-observed='false'] { font-style: italic; }
+  button:disabled { cursor: not-allowed; }
+</style>

--- a/frontend/src/semantic/__tests__/AntennaSurface.test.ts
+++ b/frontend/src/semantic/__tests__/AntennaSurface.test.ts
@@ -1,0 +1,391 @@
+/**
+ * MOR-1309 — the semantic antenna surface (vocabulary slice 8C).
+ *
+ * SAFETY-ADJACENT. Every test below names the mutation it kills, because the
+ * failure modes are physical:
+ *   (a) an antenna relay thrown under power — the transmitter is keyed, may be
+ *       keyed, or its state was never observed;
+ *   (b) an ATU mid-cycle treated as idle because its reading was never taken
+ *       (MOR-1295 §3 / the MOR-1293 DIGI-SEL precedent: unknown ⇒ not-ready);
+ *   (c) the shipped v2 `?? 1` port fabrication reintroduced at this layer,
+ *       which makes the surface claim ANT 1 for a port nobody read;
+ *   (d) a gate enforced only on `disabled` — a design language may restyle the
+ *       control, and a programmatic click must not switch a relay.
+ *
+ * Every gate is pinned TWICE and INDEPENDENTLY: once on the attribute, once by
+ * invoking the handler directly (`dispatchEvent`, not `.click()` — the latter
+ * is a no-op on a disabled button and would make the handler pin vacuous).
+ *
+ * Fast-pool-safe by construction (MOR-1272): no `vi.mock`, no `vi.stubGlobal`,
+ * no global spy. The composed-tree pins live in the isolated-pool wiring file
+ * `components-v2/wiring/__tests__/semantic-antenna-wiring.component.test.ts`.
+ */
+import { readFileSync } from 'node:fs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import AntennaSurface, {
+  ANTENNA_BLOCKED_LABEL, ANTENNA_PORTS, UNKNOWN_TEXT, antennaSwitchBlocks, tunerIdle,
+} from '../AntennaSurface.svelte';
+import { topologyFixtures, withAntenna, withTxAux } from '../fixtures/topologies';
+import type { TxAuthoritySnapshot } from '../rx-tx-surface';
+import type {
+  AntennaField, AntennaViewModel, Availability, AtuStatus, RadioViewModel, TxAuxField,
+} from '../radio-view-model';
+
+const SOURCE = readFileSync('src/semantic/AntennaSurface.svelte', 'utf8');
+/** Comments stripped, so the file's own doctrine prose can never be what a
+ *  source-scanning test matches. */
+const CODE = SOURCE
+  .replace(/<!--[\s\S]*?-->/g, '')
+  .replace(/\/\*[\s\S]*?\*\//g, '')
+  .replace(/^\s*\/\/.*$/gm, '');
+
+const ON: Availability = { structural: true, operational: true };
+const OFF: Availability = { structural: false, operational: false };
+const DEGRADED: Availability = { structural: true, operational: false };
+
+/** The ONLY snapshot in which switching is permitted: the transmitter is
+ *  positively observed OFF, no lease, no risk. */
+const RECEIVING: TxAuthoritySnapshot = {
+  phase: 'idle', intent: null, radioTx: 'off', txRisk: 'none', mayOwnKey: false, fault: null,
+};
+const TRANSMITTING: TxAuthoritySnapshot = {
+  ...RECEIVING, phase: 'active', intent: 'latched', radioTx: 'on', txRisk: 'confirmed-on',
+  mayOwnKey: true,
+};
+/** The fail-closed case: nobody keyed anything here, the RF state simply was
+ *  never confirmed. It must gate exactly as hard as TRANSMITTING. */
+const RF_UNKNOWN: TxAuthoritySnapshot = { ...RECEIVING, radioTx: 'unknown' };
+
+/** A fully-observed antenna group on a radio whose ATU is observed and idle. */
+const base = (): RadioViewModel => withTxAux(withAntenna(topologyFixtures['1/single']));
+const withAnt = (over: Partial<AntennaViewModel>): RadioViewModel => {
+  const view = base();
+  return { ...view, antenna: { ...view.antenna!, ...over } };
+};
+/** Re-shape ONLY the ATU fact — the carry-forward-1 axis. */
+const withAtu = (atu: TxAuxField<AtuStatus>): RadioViewModel => {
+  const view = base();
+  return { ...view, txAux: { ...view.txAux!, atu } };
+};
+const unread = <T>(availability: Availability = ON): AntennaField<T> =>
+  ({ reading: { status: 'unknown' }, availability });
+const known = <T>(value: T, availability: Availability = ON): AntennaField<T> =>
+  ({ reading: { status: 'known', value }, availability });
+
+let target: HTMLDivElement;
+beforeEach(() => { target = document.createElement('div'); document.body.appendChild(target); });
+afterEach(() => { target.remove(); });
+
+type Handlers = { onSelectPort?: (port: number) => void; onToggleRxAnt?: () => void };
+
+function render(view: RadioViewModel, tx: TxAuthoritySnapshot, handlers: Handlers = {}) {
+  const component = mount(AntennaSurface, { target, props: { view, tx, ...handlers } });
+  flushSync();
+  const q = <T extends HTMLElement>(sel: string) => target.querySelector(sel) as T | null;
+  return {
+    dispose: () => unmount(component),
+    root: () => q('[data-testid="antenna-surface"]'),
+    el: (id: string) => q<HTMLElement>(`[data-testid="antenna-${id}"]`),
+    btn: (id: string) => q<HTMLButtonElement>(`[data-testid="antenna-${id}"]`),
+    text: (id: string) => q<HTMLElement>(`[data-testid="antenna-${id}"]`)?.textContent?.trim(),
+    reasons: () => [...target.querySelectorAll('[data-testid="antenna-blocked"] li')]
+      .map((li) => li.getAttribute('data-reason')),
+  };
+}
+
+/** The bypass pattern: a REAL click event, dispatched past the `disabled`
+ *  attribute, so the handler guard is proven on its own. `.click()` is a
+ *  documented no-op on a disabled button and would pass with no guard at all. */
+function forceClick(node: HTMLElement): void {
+  node.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  flushSync();
+}
+
+/* ── the surface stays presentation-only ───────────────────────── */
+
+describe('the antenna surface owns no state and no TX authority (R9)', () => {
+  // Kills: importing the runtime, the command bus, transport or the capability
+  // store — the layering the semantic vertical exists to remove.
+  it('imports nothing but the fact contract and the shared RX/TX vocabulary', () => {
+    const specifiers = [...CODE.matchAll(/from\s+'([^']+)'/g)].map((m) => m[1]);
+    expect(specifiers.length).toBeGreaterThan(0);
+    expect([...new Set(specifiers)].sort()).toEqual(['./radio-view-model', './rx-tx-surface']);
+  });
+
+  // Kills: a lifecycle hook, an effect, or a dynamic import that could reach a
+  // command path from a presentation file.
+  it('declares no lifecycle hook and no effect', () => {
+    for (const forbidden of ['onMount', 'onDestroy', '$effect', 'import(']) {
+      expect(CODE).not.toContain(forbidden);
+    }
+  });
+
+  // Kills: this surface becoming a second key path or a second TX authority.
+  it('never keys, leases or re-derives TX truth', () => {
+    // `lease` is deliberately absent from this list: it appears in a REASON
+    // STRING ("a TX lease is in progress"), which is the surface reporting the
+    // authority's conclusion — the opposite of taking one.
+    for (const forbidden of [
+      'requestKey', 'tx.start', 'tx.release', 'resetFault', 'sendCommand',
+      'capabilities', 'hasCap', '$lib/transport', '$lib/stores',
+    ]) {
+      expect(CODE).not.toContain(forbidden);
+    }
+  });
+
+  // Kills: the surface growing a live-state prop beyond the view model and the
+  // App-owned authority snapshot.
+  it('takes exactly two state props — the view model and the TX snapshot', () => {
+    const props = CODE.slice(CODE.indexOf('interface Props'), CODE.indexOf('}: Props'));
+    expect([...props.matchAll(/^\s{4}(\w+)[?]?:/gm)].map((m) => m[1]))
+      .toEqual(['view', 'tx', 'onSelectPort', 'onToggleRxAnt']);
+  });
+});
+
+/* ── carry-forward 4: the evidence gate ────────────────────────── */
+
+describe('the group-level evidence gate is the whole mount condition (CF4)', () => {
+  // Kills: mounting the surface unconditionally — a single-port radio would
+  // gain an antenna panel it has no antennas to fill.
+  it('renders nothing at all when the view model carries no antenna group', () => {
+    const view = topologyFixtures['1/single'];
+    expect(view.antenna).toBeUndefined();
+    const r = render(view, RECEIVING);
+    expect(r.root()).toBeNull();
+    expect(target.innerHTML).not.toContain('antenna');
+    r.dispose();
+  });
+
+  // Kills: gating RX-ANT on the group gate instead of on its own structural
+  // flag — CF4's "independent, finer-grained field gate".
+  it('omits RX-ANT entirely when the radio does not declare it, keeping the ports', () => {
+    const r = render(withAnt({ rxAnt: unread<boolean>(OFF) }), RECEIVING);
+    expect(r.el('rx')).toBeNull();
+    expect(r.btn('port-1')).not.toBeNull();
+    r.dispose();
+  });
+
+  it('renders RX-ANT present-and-disabled when it is declared but unread', () => {
+    const r = render(withAnt({ rxAnt: unread<boolean>(DEGRADED) }), RECEIVING);
+    expect(r.el('rx')).not.toBeNull();
+    expect(r.el('rx')!.dataset.observed).toBe('false');
+    expect(r.btn('rx-toggle')!.disabled).toBe(true);
+    r.dispose();
+  });
+
+  it('publishes the declared port count rather than inventing a button per port', () => {
+    const r = render(withAnt({ antennaCount: 4 }), RECEIVING);
+    expect(r.root()!.dataset.antennaCount).toBe('4');
+    expect(target.querySelectorAll('[role="radio"]').length).toBe(ANTENNA_PORTS.length);
+    r.dispose();
+  });
+});
+
+/* ── carry-forward 3: no fabricated port 1 ─────────────────────── */
+
+describe('an unread TX port renders as unknown, never as ANT 1 (CF3)', () => {
+  // MUTATION KILLED: restoring v2's `state?.txAntenna ?? 1` at this layer.
+  // `toAntennaProps` does exactly that today, which makes v2 claim port 1 —
+  // and then report port 1's RX-ANT — for a radio that reported neither.
+  it('marks NO port selected while the port itself is unobserved', () => {
+    const r = render(withAnt({ txAntenna: unread<number>(DEGRADED) }), RECEIVING);
+    for (const port of ANTENNA_PORTS) {
+      expect(r.btn(`port-${port}`)!.getAttribute('aria-checked')).toBe('false');
+    }
+    r.dispose();
+  });
+
+  // MUTATION KILLED: the same fabrication in the readout instead of the
+  // pressed state — "ANT 1" printed for a port nobody read.
+  it('prints the unknown marker for the port readout, not a port number', () => {
+    const r = render(withAnt({ txAntenna: unread<number>(DEGRADED) }), RECEIVING);
+    expect(r.text('port-value')).toBe(UNKNOWN_TEXT);
+    expect(r.el('ports')!.dataset.observed).toBe('false');
+    r.dispose();
+  });
+
+  it('marks exactly the observed port selected when the port IS read', () => {
+    const r = render(withAnt({ txAntenna: known(2) }), RECEIVING);
+    expect(r.btn('port-2')!.getAttribute('aria-checked')).toBe('true');
+    expect(r.btn('port-1')!.getAttribute('aria-checked')).toBe('false');
+    expect(r.text('port-value')).toBe('2');
+    r.dispose();
+  });
+
+  // MUTATION KILLED: rendering an unread RX-ANT as `off` — the second half of
+  // the same v2 fabrication (v2 reports port 1's RX-ANT for an unread port).
+  it('renders an unread RX-ANT as unknown rather than off', () => {
+    const r = render(withAnt({ rxAnt: unread<boolean>(DEGRADED) }), RECEIVING);
+    expect(r.text('rx-toggle')).toContain(UNKNOWN_TEXT);
+    expect(r.btn('rx-toggle')!.getAttribute('aria-pressed')).toBeNull();
+    r.dispose();
+  });
+});
+
+/* ── the under-power gate: attribute AND handler, independently ── */
+
+describe('antenna switching is gated while the transmitter is not provably idle', () => {
+  // MUTATION KILLED: inverting or dropping the under-power gate condition on
+  // the widget — the operator can throw a TX relay mid-transmission.
+  it.each([['transmitting', TRANSMITTING], ['RF-state unknown', RF_UNKNOWN]] as const)(
+    'disables every port button while %s', (_label, tx) => {
+      const r = render(base(), tx);
+      for (const port of ANTENNA_PORTS) expect(r.btn(`port-${port}`)!.disabled).toBe(true);
+      expect(r.btn('rx-toggle')!.disabled).toBe(true);
+      expect(r.root()!.dataset.switchBlocked).toBe('true');
+      r.dispose();
+    },
+  );
+
+  // MUTATION KILLED (INDEPENDENTLY of `disabled`): dropping the guard inside
+  // `selectPort`. Dispatched as a real event past the disabled attribute, so
+  // the assertion cannot be satisfied by the attribute alone.
+  it.each([['transmitting', TRANSMITTING], ['RF-state unknown', RF_UNKNOWN]] as const)(
+    'refuses a forced port click while %s, in the handler', (_label, tx) => {
+      const onSelectPort = vi.fn();
+      const r = render(base(), tx, { onSelectPort });
+      forceClick(r.btn('port-2')!);
+      expect(onSelectPort).not.toHaveBeenCalled();
+      r.dispose();
+    },
+  );
+
+  it.each([['transmitting', TRANSMITTING], ['RF-state unknown', RF_UNKNOWN]] as const)(
+    'refuses a forced RX-ANT click while %s, in the handler', (_label, tx) => {
+      const onToggleRxAnt = vi.fn();
+      const r = render(base(), tx, { onToggleRxAnt });
+      forceClick(r.btn('rx-toggle')!);
+      expect(onToggleRxAnt).not.toHaveBeenCalled();
+      r.dispose();
+    },
+  );
+
+  // MUTATION KILLED: a gate that blocks silently. An operator facing a dead
+  // control with no explanation reaches for the radio's front panel instead.
+  it('states a reason naming the consequence for every blocked state', () => {
+    for (const [tx, code] of [
+      [TRANSMITTING, 'radio-transmitting'], [RF_UNKNOWN, 'rf-state-unknown'],
+    ] as const) {
+      const r = render(base(), tx);
+      expect(r.reasons()).toContain(code);
+      expect(r.el('blocked')!.textContent).toContain(ANTENNA_BLOCKED_LABEL[code]);
+      expect(r.btn('port-1')!.getAttribute('aria-describedby'))
+        .toBe(r.el('blocked')!.getAttribute('id'));
+      r.dispose();
+    }
+  });
+
+  // MUTATION KILLED: a gate that never opens. Switching MUST work on a radio
+  // that is positively receiving, or the surface is useless and the operator
+  // routes around it.
+  it('permits switching, in the widget and the handler, while positively receiving', () => {
+    const onSelectPort = vi.fn();
+    const onToggleRxAnt = vi.fn();
+    const r = render(base(), RECEIVING, { onSelectPort, onToggleRxAnt });
+    expect(r.btn('port-2')!.disabled).toBe(false);
+    expect(r.reasons()).toEqual([]);
+    expect(r.root()!.dataset.switchBlocked).toBe('false');
+    r.btn('port-2')!.click();
+    flushSync();
+    r.btn('rx-toggle')!.click();
+    flushSync();
+    expect(onSelectPort).toHaveBeenCalledExactlyOnceWith(2);
+    expect(onToggleRxAnt).toHaveBeenCalledOnce();
+    r.dispose();
+  });
+
+  // The gate is the SHARED predicate on the SHARED snapshot, filtered to the
+  // three reasons that mean "the transmitter is not provably idle". Kills:
+  // widening it to the whole `keyBlockedReasons` list — an out-of-band
+  // frequency makes KEYING illegal, it does not make a relay hot, and blocking
+  // on it would be theatre that trains operators to distrust the gate.
+  it('does not block on a permit or target reason alone', () => {
+    const view = withTxAux(withAntenna(topologyFixtures['1/ab']));
+    expect(view.txPermit.status).toBe('unknown');
+    expect(antennaSwitchBlocks(view, RECEIVING)).toEqual([]);
+  });
+
+  // Kills: a local re-derivation of TX truth drifting from the shared one.
+  it('shares the transmitter-busy vocabulary with the key gate', () => {
+    expect(CODE).toContain('keyBlockedReasons');
+    expect(antennaSwitchBlocks(base(), TRANSMITTING)).toContain('radio-transmitting');
+    expect(antennaSwitchBlocks(base(), { ...RECEIVING, phase: 'key-confirm-pending' }))
+      .toContain('tx-busy');
+  });
+});
+
+/* ── carry-forwards 1 + 2: the ATU lives in txAux, and unknown is busy ── */
+
+describe('ATU readiness comes from txAux.atu and fails closed (CF1, CF2)', () => {
+  // CF2, confirmed as an acceptance criterion: `txAux.atu` (slice 1A) is the
+  // ONLY tuner signal and was deliberately NOT duplicated into `antenna`.
+  // Kills: a second ATU fact appearing on the antenna group and this surface
+  // quietly preferring it.
+  it('reads no tuner fact from the antenna group, which carries none', () => {
+    expect(Object.keys(base().antenna!).sort()).toEqual(['antennaCount', 'rxAnt', 'txAntenna']);
+    expect(CODE).toContain('view.txAux?.atu');
+    expect(CODE).not.toMatch(/antenna[^\n]*\.(atu|tuner)/);
+  });
+
+  // MUTATION KILLED: letting an unknown tuner fall through to "idle". This is
+  // the MOR-1295 §3 ruling verbatim — 8C must not infer "tuner idle, safe to
+  // switch" from an unobserved `tunerStatus`.
+  it.each([
+    ['unobserved', { reading: { status: 'unknown' }, availability: ON }],
+    ['stale', { reading: { status: 'unknown' }, availability: DEGRADED }],
+  ] as const)('treats a %s tuner reading as not-ready', (_label, atu) => {
+    const view = withAtu(atu as TxAuxField<AtuStatus>);
+    expect(tunerIdle(view)).toBe(false);
+    const r = render(view, RECEIVING);
+    expect(r.btn('port-1')!.disabled).toBe(true);
+    expect(r.reasons()).toContain('tuner-not-ready');
+    r.dispose();
+  });
+
+  // MUTATION KILLED (INDEPENDENTLY of `disabled`): dropping the guard inside
+  // the handler while the tuner is unread.
+  it('refuses a forced port click while the tuner reading is unknown', () => {
+    const onSelectPort = vi.fn();
+    const r = render(withAtu({ reading: { status: 'unknown' }, availability: ON }), RECEIVING,
+      { onSelectPort });
+    forceClick(r.btn('port-1')!);
+    expect(onSelectPort).not.toHaveBeenCalled();
+    r.dispose();
+  });
+
+  // MUTATION KILLED: treating a running ATU as idle. An ATU mid-cycle IS
+  // emitting a carrier — this is the under-power case the ticket names.
+  it('treats a tuner that is actively tuning as not-ready', () => {
+    const view = withAtu(known<AtuStatus>('tuning') as TxAuxField<AtuStatus>);
+    expect(tunerIdle(view)).toBe(false);
+    const r = render(view, RECEIVING);
+    expect(r.btn('port-1')!.disabled).toBe(true);
+    r.dispose();
+  });
+
+  it.each(['off', 'on'] as const)('treats an observed, idle ATU (%s) as ready', (value) => {
+    const view = withAtu(known<AtuStatus>(value) as TxAuxField<AtuStatus>);
+    expect(tunerIdle(view)).toBe(true);
+    const r = render(view, RECEIVING);
+    expect(r.btn('port-1')!.disabled).toBe(false);
+    r.dispose();
+  });
+
+  /**
+   * The distinction the 6B/PRE precedent turns on: "this radio has no ATU" is
+   * a STRUCTURAL claim, not an unread reading. Collapsing the two would
+   * permanently disable antenna switching on every ATU-less multi-port radio —
+   * broken, not fail-closed. Kills: a `tunerIdle` that returns false for a
+   * structurally-absent ATU, and one that returns true for an unread one.
+   */
+  it('does not block on a radio that declares no ATU at all', () => {
+    const noTuner = withAtu({ reading: { status: 'unknown' }, availability: OFF });
+    expect(tunerIdle(noTuner)).toBe(true);
+    const { txAux: _dropped, ...noTxAux } = base();
+    expect(tunerIdle(noTxAux as RadioViewModel)).toBe(true);
+    const r = render(noTxAux as RadioViewModel, RECEIVING);
+    expect(r.btn('port-1')!.disabled).toBe(false);
+    r.dispose();
+  });
+});

--- a/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
+++ b/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
@@ -112,6 +112,8 @@ vi.mock('../../../components-v2/wiring/command-bus', () => ({
   }),
   // MOR-1307 slice 7B: the band-select intent the band surface composes.
   makeBandHandlers: () => ({ onBandSelect: h.txAuxNoop }),
+  // MOR-1309 slice 8C: the antenna intent vocabulary.
+  makeAntennaHandlers: () => ({ onSelectAnt1: h.txAuxNoop, onSelectAnt2: h.txAuxNoop, onToggleRxAnt: h.txAuxNoop }),
 }));
 
 import DualReceiverCockpit from '../DualReceiverCockpit.svelte';


### PR DESCRIPTION
## Summary

8C: AntennaSurface over the 8A antenna facts (MOR-1295). SAFETY-ADJACENT: TX antenna switching under power is operationally gated - while TX is active OR TX state is unknown OR the declared tuner is unread/mid-cycle, switching is disabled with a reason; unknown gates exactly as hard as active. No fabricated port-1 default (v2's ?? 1 refused); no second TX authority (RF half reads the shared keyBlockedReasons).

Production LOC 119 (verifier-measured, frozen formula; cap 200).

## Review provenance

Verified by the vocabulary-domain opus anchor #2 (session 8): PASS with ZERO required code fixes - first such slice in the wave. ATU interpretive call ('no ATU declared = not a block' vs 'unread ATU = block') adjudicated SOUND via an 8-combination adapter matrix: hasEvidence and atu.structural share the hasTuner source, so a declared tuner can never vanish into no-group, and the reverse-ruling mutant dies. 13/13 mutation battery (incl. allow-list drops, aria-pressed collapse, tuning-no-longer-blocks); under-power gate measured at the sendCommand seam by the anchor's own forced clicks (unknown TX = 0 commands). Canon FULL PASS; the differential second pin adjudicated correct over the flat zone assertion. Post-1351 harness: antenna ports now exercised - 60/60, 1797/1797 ('exercised and passing').

Follow-ups ticketed: MOR-1360 (facts-layer tunerStatus-vs-tag evidence inconsistency), MOR-1361 (allow-list exhaustiveness guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)