### PR TITLE
feat(MOR-1308): ritXit + scan surface (8B) - one offset, two gates, wire-space resume codes

### DIFF
--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -42,6 +42,7 @@
   import RfFrontEndSurface, {
     type RfFrontEndLevelField, type RfFrontEndToggleField,
   } from '../../semantic/RfFrontEndSurface.svelte';
+  import RitXitScanSurface from '../../semantic/RitXitScanSurface.svelte';
   import RxAudioSurface from '../../semantic/RxAudioSurface.svelte';
   import RxTxSurface from '../../semantic/RxTxSurface.svelte';
   import TxAuxSurface, {
@@ -53,7 +54,8 @@
   import {
     makeAgcHandlers, makeAntennaHandlers, makeAudioRoutingHandlers, makeBandHandlers,
     makeDspHandlers, makeFilterHandlers, makeModeHandlers, makeRfFrontEndHandlers,
-    makeRxAudioHandlers, makeTxHandlers, makeVfoHandlers, makeVoxHandlers,
+    makeRitXitHandlers, makeRxAudioHandlers, makeScanHandlers, makeTxHandlers,
+    makeVfoHandlers, makeVoxHandlers,
   } from './command-bus';
   import {
     forReceiver, receiversOf, isActiveStrip, isOperationalStrip,
@@ -243,6 +245,15 @@
   const RF_FRONT_END_TOGGLE_INTENT: Record<RfFrontEndToggleField, (next: boolean) => void> = {
     digiSel: rfFrontEndIntents.onDigiSelToggle, ipPlus: rfFrontEndIntents.onIpPlusToggle,
   };
+  /**
+   * MOR-1308 (vocabulary slice 8B). The shipped RIT/XIT and scan command
+   * vocabularies, composed unmodified — the O1 "one register, two gates"
+   * behavior lives entirely in `makeRitXitHandlers()` already (both offset
+   * handlers write `ritFreq` via the same `set_rit_frequency` command); this
+   * wiring adds no re-derivation, only 1:1 plumbing.
+   */
+  const ritXitIntents = makeRitXitHandlers();
+  const scanIntents = makeScanHandlers();
   const tx = getAppTxController();
   const sourceId = `semantic-rx-tx-${++surfaceSeq}`;
   let leaseSeq = 0;
@@ -805,6 +816,33 @@
     {/if}
   {/snippet}
 
+  <!--
+    MOR-1308 (vocabulary slice 8B). Same reasoning as `rxAudioSurface` above:
+    the second semantic surface carrying interactive controls no manifest
+    declares a zone for, so — per the MOR-1304 mounting canon — it mounts in
+    the SINGLE composition only, and its dual-composition absence is pinned in
+    `__tests__/semantic-ritxit-scan-wiring.component.test.ts` with a view
+    model that actually carries the `ritXit`/`scan` groups (a fixture that
+    cannot see the surface would repeat the bug that canon exists to catch).
+    `'ritXitScan'` becomes DECLARABLE with this slice; no manifest declares a
+    zone for it yet.
+  -->
+  {#snippet ritXitScanSurface()}
+    {#if view?.ritXit || view?.scan}
+      <RitXitScanSurface
+        {view}
+        onRitToggle={ritXitIntents.onRitToggle}
+        onXitToggle={ritXitIntents.onXitToggle}
+        onRitOffsetChange={ritXitIntents.onRitOffsetChange}
+        onXitOffsetChange={ritXitIntents.onXitOffsetChange}
+        onClear={ritXitIntents.onClear}
+        onScanStart={(type) => scanIntents.onScanStart(type)}
+        onScanStop={scanIntents.onScanStop}
+        onResumeModeChange={(mode) => scanIntents.onResumeChange(mode)}
+      />
+    {/if}
+  {/snippet}
+
   {#if strips === 'dual'}
     <!--
       MOR-1258: the zone now carries RxTxSurface AND the two TX-adjacent
@@ -853,6 +891,9 @@
     {@render zoned('rfFrontEnd', view?.rfFrontEnd !== undefined, rfFrontEndSurface)}
     {@render zoned('band', view?.band !== undefined, bandSurface)}
     {@render zoned('antenna', view?.antenna !== undefined, antennaSurface)}
+    {@render zoned(
+      'ritXitScan', view?.ritXit !== undefined || view?.scan !== undefined, ritXitScanSurface,
+    )}
     {@render txAdjacentAlerts()}
   {/if}
 </div>

--- a/frontend/src/components-v2/wiring/__tests__/semantic-dsp-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-dsp-wiring.component.test.ts
@@ -127,6 +127,17 @@ vi.mock('../command-bus', () => ({
   // vocabulary unconditionally. This fixture declares no antenna capability,
   // so none of these is reachable — same stand-in role as `makeBandHandlers`.
   makeAntennaHandlers: () => ({ onSelectAnt1: h.noop, onSelectAnt2: h.noop, onToggleRxAnt: h.noop }),
+  // MOR-1308 — the wiring now also composes the RIT/XIT and scan intent
+  // vocabularies. This fixture declares no rit/xit capability or scan
+  // evidence, so none of these is reachable — same stand-in role as
+  // `makeVfoHandlers`/`makeTxHandlers` above.
+  makeRitXitHandlers: () => ({
+    onRitToggle: h.noop, onXitToggle: h.noop, onRitOffsetChange: h.noop,
+    onXitOffsetChange: h.noop, onClear: h.noop,
+  }),
+  makeScanHandlers: () => ({
+    onScanStart: h.noop, onScanStop: h.noop, onDfSpanChange: h.noop, onResumeChange: h.noop,
+  }),
 }));
 
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';

--- a/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
@@ -109,6 +109,14 @@ vi.mock('../command-bus', () => ({
   makeBandHandlers: () => ({ onBandSelect: h.noop }),
   // MOR-1309 slice 8C: the antenna intent vocabulary.
   makeAntennaHandlers: () => ({ onSelectAnt1: h.noop, onSelectAnt2: h.noop, onToggleRxAnt: h.noop }),
+  // MOR-1308 slice 8B: the RIT/XIT and scan intent vocabularies.
+  makeRitXitHandlers: () => ({
+    onRitToggle: h.noop, onXitToggle: h.noop, onRitOffsetChange: h.noop,
+    onXitOffsetChange: h.noop, onClear: h.noop,
+  }),
+  makeScanHandlers: () => ({
+    onScanStart: h.noop, onScanStop: h.noop, onDfSpanChange: h.noop, onResumeChange: h.noop,
+  }),
 }));
 
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';

--- a/frontend/src/components-v2/wiring/__tests__/semantic-rf-front-end-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rf-front-end-wiring.component.test.ts
@@ -128,6 +128,17 @@ vi.mock('../command-bus', () => ({
   // assertions ever run. This fixture declares no antenna capability, so
   // none of these is reachable — same stand-in role as `makeBandHandlers`.
   makeAntennaHandlers: () => ({ onSelectAnt1: h.noop, onSelectAnt2: h.noop, onToggleRxAnt: h.noop }),
+  // MOR-1308 — the wiring's module scope also composes the RIT/XIT and scan
+  // intent vocabularies unconditionally; without stubs here the wiring's
+  // `makeRitXitHandlers()`/`makeScanHandlers()` calls throw before this
+  // file's own RF-front-end assertions ever run.
+  makeRitXitHandlers: () => ({
+    onRitToggle: h.noop, onXitToggle: h.noop, onRitOffsetChange: h.noop,
+    onXitOffsetChange: h.noop, onClear: h.noop,
+  }),
+  makeScanHandlers: () => ({
+    onScanStart: h.noop, onScanStop: h.noop, onDfSpanChange: h.noop, onResumeChange: h.noop,
+  }),
 }));
 
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';

--- a/frontend/src/components-v2/wiring/__tests__/semantic-ritxit-scan-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-ritxit-scan-wiring.component.test.ts
@@ -1,0 +1,283 @@
+/**
+ * MOR-1308 — the semantic RIT/XIT + scan surface wired into
+ * `SemanticRadioSurfaces`.
+ *
+ * `semantic/__tests__/RitXitScanSurface.test.ts` proves what the pure surface
+ * does with a view model. This file proves what only the composed tree can
+ * prove, using the REAL adapter and the REAL command bus (only the
+ * runtime/transport/TX-authority SEAMS are spied), mirroring
+ * `semantic-rx-audio-wiring.component.test.ts`:
+ *
+ *   (a) O1 end to end: editing the offset through the RIT-leading state and
+ *       through the XIT-leading state both reach the wire as the SAME
+ *       `set_rit_frequency` command — proving `makeRitXitHandlers()`'s two
+ *       offset handlers converge, not merely asserting it about a stub.
+ *   (b) MOUNTING CANON (MOR-1304 ruling). This is a control-bearing surface
+ *       with no manifest-declared zone, so per the canon's option (i) it
+ *       mounts in the SINGLE composition only, bare, and renders NOTHING in
+ *       the DUAL composition — pinned here with a view model that actually
+ *       CARRIES the `ritXit`/`scan` groups (a fixture that cannot see the
+ *       surface would repeat the exact vacuous-green bug the canon exists to
+ *       catch, per the rxAudio precedent).
+ *   (c) The default path (no rit/xit capability, no scan evidence) stays
+ *       byte-identical.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { ServerState } from '$lib/types/state';
+
+type Snapshot = {
+  phase: string; intent: string | null; guard: { leaseId: string } | null;
+  radioTx: string; txRisk: string; mayOwnKey: boolean; fault: string | null;
+};
+
+const h = vi.hoisted(() => ({
+  state: null as unknown,
+  caps: null as unknown,
+  snapshot: null as unknown,
+  audio: { muted: true, rxEnabled: false, volume: 0 },
+  audioConnected: false,
+  guardVisible: false,
+  listeners: new Set<(next: unknown) => void>(),
+}));
+
+vi.mock('$lib/transport/ws-client', () => ({ sendCommand: vi.fn() }));
+vi.mock('$lib/runtime', () => ({
+  runtime: {
+    get state() { return h.state; },
+    get caps() { return h.caps; },
+    get audio() { return h.audio; },
+    get connectionAudio() { return h.audioConnected; },
+  },
+}));
+vi.mock('$lib/runtime/tx-controller/app-host', () => ({
+  getAppTxController: () => ({
+    snapshot: () => h.snapshot,
+    subscribe: (listener: (next: unknown) => void) => {
+      h.listeners.add(listener);
+      return () => { h.listeners.delete(listener); };
+    },
+    start: vi.fn(), setIntent: vi.fn(), release: vi.fn(), resetFault: vi.fn(),
+  }),
+}));
+vi.mock('$lib/runtime/adapters/mod-input-tx-guard.svelte', () => ({
+  deriveModInputTxGuardProps: () => ({ visible: h.guardVisible, sourceLabel: 'MIC' }),
+  getModInputTxGuardHandlers: () => ({ onSetLan: vi.fn(), onDismiss: vi.fn() }),
+}));
+
+import { sendCommand } from '$lib/transport/ws-client';
+// UNMOCKED real store: `makeRitXitHandlers().onRitToggle`/`onXitToggle` read
+// `getRadioState()?.ritOn`/`.ritTx` to decide which way to flip. Seeding it to
+// agree with `h.state` (below) keeps the toggle direction deterministic and
+// independent of whatever a prior test in this file left behind.
+import { resetRadioState, setRadioState } from '$lib/stores/radio.svelte';
+import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';
+
+const IDLE: Snapshot = {
+  phase: 'idle', intent: null, guard: null, radioTx: 'off', txRisk: 'none',
+  mayOwnKey: false, fault: null,
+};
+const fresh = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' };
+const slot = (freqHz: number) => ({ freqHz, mode: 'USB', filterNum: 1, dataMode: 0 });
+
+/** A radio that has observed RIT ON at +250 Hz, is idle-scanning PROG with a
+ *  masked resume of 1, and knows its active receiver — every field this
+ *  surface can render is present so its structural gates all pass. */
+function liveState(over: Partial<ServerState> = {}): ServerState {
+  const paths = [
+    'active', 'split', 'dualWatch', 'txTarget', 'ritOn', 'ritTx', 'ritFreq',
+    'scanning', 'scanType', 'scanResumeMode',
+  ];
+  for (const rx of ['main', 'sub']) {
+    paths.push(`${rx}.freqHz`, `${rx}.mode`, `${rx}.filter`, `${rx}.activeSlot`);
+    for (const v of ['vfoA', 'vfoB']) paths.push(`${rx}.${v}.freqHz`, `${rx}.${v}.mode`, `${rx}.${v}.filterNum`);
+  }
+  const receiver = (hz: number) => ({
+    ...slot(hz), vfoA: slot(hz), vfoB: slot(hz + 50000), activeSlot: 'A', filter: 1,
+  });
+  return {
+    active: 'MAIN', split: false, dualWatch: false, ptt: false,
+    ritOn: true, ritTx: false, ritFreq: 250, scanning: false, scanType: 0x01, scanResumeMode: 1,
+    txTarget: { status: 'known', receiver: 'MAIN', slot: 'A', frequencyHz: 14250000 },
+    main: receiver(14250000), sub: receiver(14300000),
+    ...over,
+    fieldStatus: Object.fromEntries(paths.map((p) => [p, fresh])),
+  } as unknown as ServerState;
+}
+
+const liveCaps = (tags: readonly string[]): Capabilities => ({
+  model: 'fixture', scope: false, audio: false, tx: true,
+  capabilities: tags, receivers: 2, vfoScheme: 'main_sub', freqRanges: [], modes: [], filters: [],
+  audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
+  webrtc: { available: false, enabled: false },
+  txBands: [{ start: 14000000, end: 14350000, name: '20m' }],
+  scopeSource: null, audioFftAvailable: false,
+} as unknown as Capabilities);
+
+/** `rit`/`xit` capability tags are what makes the ritXit group present;
+ *  scan needs no tag at all — its raw fields above are the whole gate. */
+const RIT_XIT_TAGS = ['tx', 'rit', 'xit'] as const;
+const SILENT_TAGS = ['tx'] as const;
+
+let target: HTMLDivElement;
+let component: ReturnType<typeof mount> | null = null;
+
+function render(props: { strips?: 'single' | 'dual' } = {}): void {
+  target = document.createElement('div');
+  document.body.appendChild(target);
+  component = mount(SemanticRadioSurfaces, { target, props });
+  flushSync();
+}
+
+const q = <T extends HTMLElement>(sel: string) => target.querySelector(sel) as T | null;
+const el = (id: string) => q<HTMLElement>(`[data-testid="${id}"]`);
+/** Keeps the mocked view-model state AND the real command-bus store
+ *  (`getRadioState()`) in agreement — `onRitToggle`/`onXitToggle` read the
+ *  latter directly. */
+function useState(state: ServerState): void {
+  h.state = state;
+  setRadioState(state);
+}
+
+beforeEach(() => {
+  resetRadioState();
+  useState(liveState());
+  h.caps = liveCaps(RIT_XIT_TAGS);
+  h.snapshot = { ...IDLE };
+  h.audio = { muted: true, rxEnabled: false, volume: 0 };
+  h.audioConnected = false;
+  h.guardVisible = false;
+  h.listeners.clear();
+  vi.mocked(sendCommand).mockClear();
+});
+
+afterEach(() => {
+  if (component) unmount(component);
+  component = null;
+  document.body.innerHTML = '';
+});
+
+/* ── (a) O1 end to end: both offset paths converge on the wire ────── */
+
+describe('O1: editing via either gate reaches the wire as the identical command', () => {
+  it('RIT-leading: sends set_rit_frequency with the edited value', () => {
+    render();
+    const input = q<HTMLInputElement>('[data-testid="ritxit-offset"] input')!;
+    input.value = '300';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    expect(sendCommand).toHaveBeenCalledExactlyOnceWith('set_rit_frequency', { freq: 300 });
+  });
+
+  it('XIT-leading: sends the SAME set_rit_frequency command, not a different one', () => {
+    useState(liveState({ ritOn: false, ritTx: true } as Partial<ServerState>));
+    render();
+    const input = q<HTMLInputElement>('[data-testid="ritxit-offset"] input')!;
+    input.value = '-300';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    expect(sendCommand).toHaveBeenCalledExactlyOnceWith('set_rit_frequency', { freq: -300 });
+  });
+
+  it('never shows two divergent offset values', () => {
+    render();
+    expect(target.querySelectorAll('[data-testid="ritxit-offset"]').length).toBe(1);
+  });
+
+  it('composes the shipped RIT/XIT and scan command factories', async () => {
+    const real = await import('../command-bus');
+    for (const name of ['onRitToggle', 'onXitToggle', 'onRitOffsetChange', 'onXitOffsetChange', 'onClear']) {
+      expect(typeof (real.makeRitXitHandlers() as Record<string, unknown>)[name]).toBe('function');
+    }
+    for (const name of ['onScanStart', 'onScanStop', 'onResumeChange']) {
+      expect(typeof (real.makeScanHandlers() as Record<string, unknown>)[name]).toBe('function');
+    }
+  });
+});
+
+/* ── intents reach the real bus ────────────────────────────────────── */
+
+describe('the surface intents reach the shipped command vocabulary', () => {
+  it('toggling RIT sends set_rit_status', () => {
+    render();
+    el('ritxit-rit-toggle')!.click();
+    flushSync();
+    expect(sendCommand).toHaveBeenCalledExactlyOnceWith('set_rit_status', { on: false });
+  });
+
+  it('toggling XIT sends set_rit_tx_status', () => {
+    render();
+    el('ritxit-xit-toggle')!.click();
+    flushSync();
+    expect(sendCommand).toHaveBeenCalledExactlyOnceWith('set_rit_tx_status', { on: true });
+  });
+
+  it('Clear sends set_rit_frequency with freq 0', () => {
+    render();
+    el('ritxit-clear')!.click();
+    flushSync();
+    expect(sendCommand).toHaveBeenCalledExactlyOnceWith('set_rit_frequency', { freq: 0 });
+  });
+
+  it('starting a scan sends scan_start with the last-observed type', () => {
+    useState(liveState({ scanning: false, scanType: 0x22 } as Partial<ServerState>));
+    render();
+    el('scan-toggle')!.click();
+    flushSync();
+    expect(sendCommand).toHaveBeenCalledExactlyOnceWith('scan_start', { type: 0x22 });
+  });
+
+  it('stopping a scan sends scan_stop', () => {
+    useState(liveState({ scanning: true } as Partial<ServerState>));
+    render();
+    el('scan-toggle')!.click();
+    flushSync();
+    expect(sendCommand).toHaveBeenCalledExactlyOnceWith('scan_stop', {});
+  });
+
+  it('cycling resume mode sends scan_set_resume with the advanced mask', () => {
+    render();
+    el('scan-resume-cycle')!.click();
+    flushSync();
+    expect(sendCommand).toHaveBeenCalledExactlyOnceWith('scan_set_resume', { mode: 2 });
+  });
+});
+
+/* ── (b) MOUNTING CANON: single bare, dual absent ──────────────────── */
+
+describe('the surface mounts only in the single composition, never in dual', () => {
+  it('renders no ritXit/scan surface for a radio with no evidence at all', () => {
+    h.caps = liveCaps(SILENT_TAGS);
+    useState(liveState({ ritOn: undefined, ritTx: undefined, ritFreq: undefined,
+      scanning: undefined, scanType: undefined, scanResumeMode: undefined } as Partial<ServerState>));
+    render();
+    expect(el('ritxit-scan-surface')).toBeNull();
+  });
+
+  it('renders it bare in the single composition, outside every zone', () => {
+    render();
+    const surface = el('ritxit-scan-surface')!;
+    expect(surface).not.toBeNull();
+    expect(surface.closest('[data-zone-id]')).toBeNull();
+  });
+
+  /**
+   * MOUNTING CANON (MOR-1304 ruling). The view model here DOES carry both
+   * groups — proven by the single-composition assertion above using the
+   * identical fixture — so this is not the vacuous "the fixture can't see it
+   * anyway" green the canon calls out; the absence below is the real thing.
+   */
+  it('renders NO ritXit/scan surface in the dual composition, zoned or unzoned', () => {
+    render({ strips: 'dual' });
+    expect(el('ritxit-scan-surface')).toBeNull();
+    expect(target.innerHTML).not.toContain('ritxit-scan-surface');
+  });
+
+  it('leaves the cockpit composition with no focusable control outside a declared zone', () => {
+    render({ strips: 'dual' });
+    const outside = [...target.querySelectorAll<HTMLElement>('button, input, select, [tabindex]')]
+      .filter((node) => node.closest('[data-zone-id]') === null);
+    expect(outside).toEqual([]);
+  });
+});

--- a/frontend/src/components-v2/wiring/__tests__/semantic-ritxit-scan-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-ritxit-scan-wiring.component.test.ts
@@ -240,7 +240,7 @@ describe('the surface intents reach the shipped command vocabulary', () => {
     render();
     el('scan-resume-cycle')!.click();
     flushSync();
-    expect(sendCommand).toHaveBeenCalledExactlyOnceWith('scan_set_resume', { mode: 2 });
+    expect(sendCommand).toHaveBeenCalledExactlyOnceWith('scan_set_resume', { mode: 0xD2 });
   });
 });
 

--- a/frontend/src/components-v2/wiring/__tests__/semantic-rx-tx-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rx-tx-wiring.component.test.ts
@@ -135,6 +135,15 @@ vi.mock('../command-bus', () => ({
   makeBandHandlers: () => ({ onBandSelect: h.txAuxNoop }),
   // MOR-1309 slice 8C: the antenna intent vocabulary.
   makeAntennaHandlers: () => ({ onSelectAnt1: h.txAuxNoop, onSelectAnt2: h.txAuxNoop, onToggleRxAnt: h.txAuxNoop }),
+  // MOR-1308 slice 8B: the RIT/XIT and scan intent vocabularies.
+  makeRitXitHandlers: () => ({
+    onRitToggle: h.txAuxNoop, onXitToggle: h.txAuxNoop, onRitOffsetChange: h.txAuxNoop,
+    onXitOffsetChange: h.txAuxNoop, onClear: h.txAuxNoop,
+  }),
+  makeScanHandlers: () => ({
+    onScanStart: h.txAuxNoop, onScanStop: h.txAuxNoop, onDfSpanChange: h.txAuxNoop,
+    onResumeChange: h.txAuxNoop,
+  }),
 }));
 
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';

--- a/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
@@ -124,6 +124,14 @@ vi.mock('../command-bus', () => ({
   makeBandHandlers: () => ({ onBandSelect: h.noop }),
   // MOR-1309 slice 8C: the antenna intent vocabulary.
   makeAntennaHandlers: () => ({ onSelectAnt1: h.noop, onSelectAnt2: h.noop, onToggleRxAnt: h.noop }),
+  // MOR-1308 slice 8B: the RIT/XIT and scan intent vocabularies.
+  makeRitXitHandlers: () => ({
+    onRitToggle: h.noop, onXitToggle: h.noop, onRitOffsetChange: h.noop,
+    onXitOffsetChange: h.noop, onClear: h.noop,
+  }),
+  makeScanHandlers: () => ({
+    onScanStart: h.noop, onScanStop: h.noop, onDfSpanChange: h.noop, onResumeChange: h.noop,
+  }),
 }));
 
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';

--- a/frontend/src/presentation/layouts/__tests__/antenna-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/antenna-declarability.test.ts
@@ -32,7 +32,8 @@ describe('antenna is a declarable semantic surface', () => {
   it('is in the declarable set alongside vfo, rxTx, txAux, meters and rxAudio', () => {
     expect([...SEMANTIC_SURFACE_NAMES])
       .toEqual([
-        'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band', 'antenna',
+        'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band',
+        'antenna', 'ritXitScan',
       ]);
   });
 

--- a/frontend/src/presentation/layouts/__tests__/band-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/band-declarability.test.ts
@@ -27,7 +27,10 @@ describe('band is a declarable semantic surface', () => {
   // appended `rfFrontEnd`; `band` must land last, after all of them.
   it('is in the declarable set alongside vfo, rxTx, txAux, meters, rxAudio, filter, dsp and rfFrontEnd', () => {
     expect([...SEMANTIC_SURFACE_NAMES])
-      .toEqual(['vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band', 'antenna']);
+      .toEqual([
+        'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band',
+        'antenna', 'ritXitScan',
+      ]);
   });
 
   // Kills: adding the name to the type but not to the runtime allow-list the

--- a/frontend/src/presentation/layouts/__tests__/dsp-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/dsp-declarability.test.ts
@@ -20,7 +20,8 @@ describe('dsp is a declarable semantic surface', () => {
   // slice must not create.
   it('is in the declarable set alongside vfo, rxTx, txAux, meters and rxAudio', () => {
     expect([...SEMANTIC_SURFACE_NAMES]).toEqual([
-      'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band', 'antenna',
+      'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band',
+      'antenna', 'ritXitScan',
     ]);
   });
 

--- a/frontend/src/presentation/layouts/__tests__/filter-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/filter-declarability.test.ts
@@ -23,7 +23,8 @@ describe('filter is a declarable semantic surface', () => {
   // Kills: reverting the SEMANTIC_SURFACE_NAMES addition.
   it('is in the declarable set alongside vfo, rxTx, txAux, meters and rxAudio', () => {
     expect([...SEMANTIC_SURFACE_NAMES]).toEqual([
-      'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band', 'antenna',
+      'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band',
+      'antenna', 'ritXitScan',
     ]);
   });
 

--- a/frontend/src/presentation/layouts/__tests__/meters-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/meters-declarability.test.ts
@@ -29,7 +29,8 @@ describe('meters is a declarable semantic surface', () => {
   // place.
   it('is in the declarable set alongside vfo, rxTx and txAux', () => {
     expect([...SEMANTIC_SURFACE_NAMES]).toEqual([
-      'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band', 'antenna',
+      'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band',
+      'antenna', 'ritXitScan',
     ]);
   });
 

--- a/frontend/src/presentation/layouts/__tests__/rf-front-end-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/rf-front-end-declarability.test.ts
@@ -27,7 +27,10 @@ describe('rfFrontEnd is a declarable semantic surface', () => {
   // `band`; `rfFrontEnd` must stay present and in place.
   it('is in the declarable set alongside vfo, rxTx, txAux, meters and rxAudio', () => {
     expect([...SEMANTIC_SURFACE_NAMES])
-      .toEqual(['vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band', 'antenna']);
+      .toEqual([
+        'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band',
+        'antenna', 'ritXitScan',
+      ]);
   });
 
   // Kills: adding the name to the type but not to the runtime allow-list the

--- a/frontend/src/presentation/layouts/__tests__/ritxit-scan-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/ritxit-scan-declarability.test.ts
@@ -1,15 +1,16 @@
 /**
- * MOR-1279 — `rxAudio` is DECLARABLE, and nothing declares it yet.
+ * MOR-1308 — `ritXitScan` is DECLARABLE, and nothing declares it yet.
  *
- * Slice 3B adds the name to `SEMANTIC_SURFACE_NAMES` so a manifest CAN mount
+ * Slice 8B adds the name to `SEMANTIC_SURFACE_NAMES` so a manifest CAN mount
  * the surface later; it deliberately does not touch any manifest, and it adds
  * no design-language renderer slot (that set was frozen by MOR-1072 — adding
  * one would be a language-contract change this slice must not make).
  *
- * Same three pins as `tx-aux-declarability.test.ts` / `meters-declarability.test.ts`:
+ * Same three pins as `tx-aux-declarability.test.ts` / `meters-declarability
+ * .test.ts` / `rx-audio-declarability.test.ts`:
  *   - drop the name and a future manifest's zone stops validating;
- *   - quietly add an `rxAudio` zone to a shipped manifest and the DOM grows a
- *     zone id no layout review ever saw;
+ *   - quietly add a `ritXitScan` zone to a shipped manifest and the DOM
+ *     grows a zone id no layout review ever saw;
  *   - the renderer slot set stays exactly what MOR-1072 froze.
  */
 import { describe, it, expect } from 'vitest';
@@ -21,9 +22,9 @@ import {
   sdrTestLayout,
 } from '../declarations';
 
-describe('rxAudio is a declarable semantic surface', () => {
+describe('ritXitScan is a declarable semantic surface', () => {
   // Kills: reverting the SEMANTIC_SURFACE_NAMES addition.
-  it('is in the declarable set alongside vfo, rxTx, txAux and meters', () => {
+  it('is in the declarable set alongside vfo, rxTx, txAux, meters and rxAudio', () => {
     expect([...SEMANTIC_SURFACE_NAMES]).toEqual([
       'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band',
       'antenna', 'ritXitScan',
@@ -34,7 +35,7 @@ describe('rxAudio is a declarable semantic surface', () => {
   // zone validator checks — the manifest would still be rejected.
   it('accepts a manifest zone that declares it', () => {
     const manifest = validLayoutManifest({
-      zones: [{ id: 'main', surfaces: ['vfo', 'rxTx', 'rxAudio'] }],
+      zones: [{ id: 'main', surfaces: ['vfo', 'rxTx', 'ritXitScan'] }],
       requiredSemanticSurfaces: ['vfo', 'rxTx'],
     });
     expect(() => validateLayoutManifest(manifest)).not.toThrow();
@@ -42,29 +43,29 @@ describe('rxAudio is a declarable semantic surface', () => {
 
   it('still rejects a zone naming a surface that does not exist', () => {
     const manifest = validLayoutManifest({
-      zones: [{ id: 'main', surfaces: ['audioPanel'] as unknown as readonly ['vfo'] }],
+      zones: [{ id: 'main', surfaces: ['ritXitPanel'] as unknown as readonly ['vfo'] }],
     });
     expect(() => validateLayoutManifest(manifest)).toThrow(/subset of/);
   });
 });
 
-describe('no shipped manifest declares an rxAudio zone in this slice', () => {
-  // Kills: slipping an rxAudio zone into an existing layout here. Declarability
-  // is the whole scope of the contract touch; placing the surface in a real
-  // layout is a later, separately reviewed slice.
+describe('no shipped manifest declares a ritXitScan zone in this slice', () => {
+  // Kills: slipping a ritXitScan zone into an existing layout here.
+  // Declarability is the whole scope of the contract touch; placing the
+  // surface in a real layout is a later, separately reviewed slice.
   it.each([
     ['sdr-test', sdrTestLayout], ['dual-receiver-cockpit', dualReceiverCockpitLayout],
     ['lcd-cockpit', lcdCockpitLayout], ['lcd-scope', lcdScopeLayout],
     ['mobile', mobileLayout], ['desktop-v2', desktopV2Layout],
-  ])('%s declares no rxAudio zone and does not require the surface', (_id, manifest) => {
-    for (const zone of manifest.zones) expect(zone.surfaces).not.toContain('rxAudio');
-    expect(manifest.requiredSemanticSurfaces).not.toContain('rxAudio');
+  ])('%s declares no ritXitScan zone and does not require the surface', (_id, manifest) => {
+    for (const zone of manifest.zones) expect(zone.surfaces).not.toContain('ritXitScan');
+    expect(manifest.requiredSemanticSurfaces).not.toContain('ritXitScan');
   });
 });
 
 describe('the design-language renderer slot set is untouched', () => {
-  // Kills: adding a renderer slot for this surface. RX audio has no gauge
-  // grammar a language must describe; the slot set stays frozen.
+  // Kills: adding a renderer slot for this surface. RIT/XIT and scan have no
+  // gauge grammar a language must describe; the slot set stays frozen.
   it('still carries exactly the three MOR-1072 slots', () => {
     expect([...RENDERER_SLOT_NAMES]).toEqual(['meters', 'frequencyDisplay', 'stateFeedback']);
   });

--- a/frontend/src/presentation/layouts/__tests__/tx-aux-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/tx-aux-declarability.test.ts
@@ -29,7 +29,8 @@ describe('txAux is a declarable semantic surface', () => {
   // appended `rfFrontEnd`; `txAux` must stay present and in place.
   it('is in the declarable set alongside vfo and rxTx', () => {
     expect([...SEMANTIC_SURFACE_NAMES]).toEqual([
-      'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band', 'antenna',
+      'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band',
+      'antenna', 'ritXitScan',
     ]);
   });
 

--- a/frontend/src/presentation/layouts/contract.ts
+++ b/frontend/src/presentation/layouts/contract.ts
@@ -15,16 +15,16 @@ import { isValidLanguageId as isValidProductId } from '../languages/contract';
 /** Semantic surfaces a layout may mount (MOR-1062/1065 reference vertical;
  *  `txAux` added by MOR-1265, `meters` by MOR-1273, `rxAudio` by MOR-1279,
  *  `filter` by MOR-1304, `dsp` by MOR-1305, `rfFrontEnd` by MOR-1306, `band`
- *  by MOR-1307, `antenna` by MOR-1309). Adding a name makes it DECLARABLE —
- *  it does not mount anything by itself, and no manifest declares a
- *  `meters`, `rxAudio`, `filter`, `dsp`, `rfFrontEnd`, `band` or `antenna`
- *  zone yet (the cockpit declares only `txAux`, as `tx-aux` — MOR-1336).
- *  Distinct from the design-language renderer slot of the same name
- *  (`languages/contract.ts`'s `RENDERER_SLOT_NAMES`): that one says how a
- *  language DRAWS a meter, this one says which layout zone may HOST the
- *  surface. */
+ *  by MOR-1307, `antenna` by MOR-1309, `ritXitScan` by MOR-1308). Adding a
+ *  name makes it DECLARABLE — it does not mount anything by itself, and no
+ *  manifest declares a `meters`, `rxAudio`, `filter`, `dsp`, `rfFrontEnd`,
+ *  `band`, `antenna` or `ritXitScan` zone yet (the cockpit declares only
+ *  `txAux`, as `tx-aux` — MOR-1336). Distinct from the design-language
+ *  renderer slot of the same name (`languages/contract.ts`'s
+ *  `RENDERER_SLOT_NAMES`): that one says how a language DRAWS a meter, this
+ *  one says which layout zone may HOST the surface. */
 export const SEMANTIC_SURFACE_NAMES = [
-  'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band', 'antenna',
+  'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band', 'antenna', 'ritXitScan',
 ] as const;
 export type SemanticSurfaceName = (typeof SEMANTIC_SURFACE_NAMES)[number];
 

--- a/frontend/src/semantic/RitXitScanSurface.svelte
+++ b/frontend/src/semantic/RitXitScanSurface.svelte
@@ -1,0 +1,174 @@
+<!--
+  Semantic RIT/XIT + scan surface (MOR-1308, vocabulary slice 8B).
+
+  Presentation only. Renders the MOR-1295 (slice 8A) `ritXit` and `scan` fact
+  groups and emits control intents as callbacks. Holds no state, consults no
+  controller, keys nothing (v3 ADR invariant 11 — same discipline as every
+  other semantic surface in this directory).
+
+  O1 (MOR-1295 verify report, binding on this ticket). `ritOffset`/`xitOffset`
+  are TWO CONTRACT FIELDS backed by ONE raw register (`ritFreq`), mirroring
+  v2's `RitXitPanel`. Showing them as independently-editable would misrepresent
+  the radio, so this surface renders exactly ONE offset control, visible under
+  EITHER capability gate, and picks which underlying command it calls
+  (`onRitOffsetChange` / `onXitOffsetChange`) the same way v2's own
+  `handleOffsetChange` does — `xitActive && !ritActive` selects XIT, otherwise
+  RIT. Both callbacks are wired 1:1 to the shipped `makeRitXitHandlers()`,
+  whose two offset handlers both write `ritFreq` via the identical
+  `set_rit_frequency` command — proven end to end, not merely asserted, in
+  `__tests__/semantic-ritxit-scan-wiring.component.test.ts`.
+
+  O2. The -9999..9999 Hz / 50 Hz-step slider bounds are UI convenience
+  (`RitXitPanel`'s own `ValueControl` bounds), not a radio fact — the X6200
+  no-UI-tables lesson kept them out of the 8A contract, so this surface
+  supplies them itself, unchanged from v2.
+
+  WRONG-VFO GUARD (S3b lesson, MOR-1322 verify report). RIT/XIT offsets
+  target whichever receiver the radio currently has ACTIVE, and neither
+  `set_rit_frequency` nor the toggle commands carry a receiver parameter —
+  there is no way to address "the other" VFO even if this surface wanted to.
+  v2 never gates on this (fail-open); this surface fails CLOSED instead, per
+  the B-wave criterion: every RIT/XIT control disables itself while
+  `view.activeReceiver` is unobserved, because an edit this surface cannot
+  honestly attribute to a receiver is an edit it must refuse to dispatch.
+  `scan`'s commands carry no such per-receiver ambiguity in v2 to diverge
+  from, so this gate applies to `ritXit` only.
+
+  `scan` HAS NO CAPABILITY TAG anywhere (MOR-1295 ruling): evidence is
+  per-field "ever reported", so a partial reporter surfaces exactly the
+  fields it has reported, no more — expected, not a bug. Scan TYPE and
+  RESUME-MODE label tables are UI-only in v2 and are deliberately not
+  reproduced here (out of scope, not backed by any 8A fact): scan is
+  restarted with the last OBSERVED type, never a fabricated default, and
+  resume mode is cycled by its raw masked value.
+-->
+<script module lang="ts">
+  import type { RitXitField, ScanField } from './radio-view-model';
+
+  export const UNKNOWN_TEXT = '—';
+  /** O2 — v2's own `RitXitPanel` bounds, verbatim. */
+  export const OFFSET_MIN = -9999;
+  export const OFFSET_MAX = 9999;
+  export const OFFSET_STEP = 50;
+
+  export const usable = (f: RitXitField<unknown> | ScanField<unknown>): boolean =>
+    f.availability.structural && f.availability.operational && f.reading.status === 'known';
+  export const textOf = (f: RitXitField<unknown> | ScanField<unknown>): string =>
+    f.reading.status === 'known' ? String(f.reading.value) : UNKNOWN_TEXT;
+  const isOn = (f: RitXitField<boolean>): boolean => f.reading.status === 'known' && f.reading.value === true;
+</script>
+
+<script lang="ts">
+  import type { RadioViewModel } from './radio-view-model';
+
+  interface Props {
+    view: RadioViewModel;
+    onRitToggle?: () => void;
+    onXitToggle?: () => void;
+    onRitOffsetChange?: (hz: number) => void;
+    onXitOffsetChange?: (hz: number) => void;
+    onClear?: () => void;
+    onScanStart?: (type: number) => void;
+    onScanStop?: () => void;
+    onResumeModeChange?: (mode: number) => void;
+  }
+  let {
+    view, onRitToggle, onXitToggle, onRitOffsetChange, onXitOffsetChange, onClear,
+    onScanStart, onScanStop, onResumeModeChange,
+  }: Props = $props();
+
+  let rx = $derived(view.ritXit);
+  let sc = $derived(view.scan);
+  /** v2's `handleOffsetChange` selection, verbatim (O1). Decides only WHICH
+   *  command fires — never what is displayed, since both facts read the
+   *  identical register. */
+  let xitLeads = $derived(rx !== undefined && isOn(rx.xitActive) && !isOn(rx.ritActive));
+  /** Wrong-VFO guard (S3b) — see file header. */
+  let activeKnown = $derived(view.activeReceiver.status === 'known');
+  let scanningOn = $derived(sc !== undefined && usable(sc.scanning)
+    && sc.scanning.reading.status === 'known' && sc.scanning.reading.value === true);
+
+  function toggleRit(): void { if (activeKnown) onRitToggle?.(); }
+  function toggleXit(): void { if (activeKnown) onXitToggle?.(); }
+  function changeOffset(hz: number): void {
+    const offset = rx && (xitLeads ? rx.xitOffset : rx.ritOffset);
+    if (!activeKnown || !offset || !usable(offset)) return;
+    if (xitLeads) onXitOffsetChange?.(hz); else onRitOffsetChange?.(hz);
+  }
+  function clear(): void { if (activeKnown) onClear?.(); }
+  function toggleScan(): void {
+    if (!sc || !usable(sc.scanning)) return;
+    if (scanningOn) { onScanStop?.(); return; }
+    if (usable(sc.scanType) && sc.scanType.reading.status === 'known') onScanStart?.(sc.scanType.reading.value);
+  }
+  function cycleResume(): void {
+    if (!sc || !usable(sc.scanResumeMode) || sc.scanResumeMode.reading.status !== 'known') return;
+    onResumeModeChange?.((sc.scanResumeMode.reading.value + 1) % 4);
+  }
+</script>
+
+{#if rx || sc}
+  <section class="ritxit-scan-surface" data-testid="ritxit-scan-surface" aria-label="RIT, XIT and scan">
+    {#if rx}
+      {@const offset = xitLeads ? rx.xitOffset : rx.ritOffset}
+      <div class="row" data-testid="ritxit" data-active-vfo-known={activeKnown}>
+        {#if rx.ritActive.availability.structural}
+          <button
+            type="button" data-testid="ritxit-rit-toggle" aria-pressed={isOn(rx.ritActive)}
+            disabled={!activeKnown} onclick={toggleRit}
+          >RIT</button>
+        {/if}
+        {#if rx.xitActive.availability.structural}
+          <button
+            type="button" data-testid="ritxit-xit-toggle" aria-pressed={isOn(rx.xitActive)}
+            disabled={!activeKnown} onclick={toggleXit}
+          >XIT</button>
+        {/if}
+        <label class="offset" data-testid="ritxit-offset" data-observed={usable(offset)}>
+          <span>Offset</span>
+          <input
+            type="range" min={OFFSET_MIN} max={OFFSET_MAX} step={OFFSET_STEP}
+            value={offset.reading.status === 'known' ? offset.reading.value : 0}
+            disabled={!activeKnown || !usable(offset)}
+            oninput={(event) => changeOffset(event.currentTarget.valueAsNumber)}
+          />
+          <output data-testid="ritxit-offset-value">{textOf(offset)}</output>
+        </label>
+        <button type="button" data-testid="ritxit-clear" disabled={!activeKnown} onclick={clear}>CLEAR</button>
+      </div>
+    {/if}
+
+    {#if sc}
+      <div class="row" data-testid="scan">
+        {#if sc.scanning.availability.structural}
+          <span data-testid="scan-status" data-observed={usable(sc.scanning)}>{textOf(sc.scanning)}</span>
+          <button
+            type="button" data-testid="scan-toggle" aria-pressed={scanningOn}
+            disabled={!usable(sc.scanning) || (!scanningOn && !usable(sc.scanType))}
+            onclick={toggleScan}
+          >{scanningOn ? 'STOP' : 'START'}</button>
+        {/if}
+        {#if sc.scanType.availability.structural}
+          <output data-testid="scan-type-value">{textOf(sc.scanType)}</output>
+        {/if}
+        {#if sc.scanResumeMode.availability.structural}
+          <output data-testid="scan-resume-value">{textOf(sc.scanResumeMode)}</output>
+          <button
+            type="button" data-testid="scan-resume-cycle" disabled={!usable(sc.scanResumeMode)}
+            onclick={cycleResume}
+          >RESUME ▶</button>
+        {/if}
+      </div>
+    {/if}
+  </section>
+{/if}
+
+<style>
+  /* Structure only — a design language owns colour (MOR-977, forced-colors). */
+  .ritxit-scan-surface { display: flex; flex-direction: column; gap: 0.25rem; }
+  .row { display: flex; flex-wrap: wrap; align-items: baseline; gap: 0.5rem; margin: 0; }
+  .offset { display: flex; align-items: baseline; gap: 0.5rem; }
+  [aria-pressed='true'] { font-weight: 700; }
+  [data-observed='false'] { font-style: italic; }
+  button:disabled, input:disabled { cursor: not-allowed; }
+</style>

--- a/frontend/src/semantic/RitXitScanSurface.svelte
+++ b/frontend/src/semantic/RitXitScanSurface.svelte
@@ -56,6 +56,13 @@
   export const textOf = (f: RitXitField<unknown> | ScanField<unknown>): string =>
     f.reading.status === 'known' ? String(f.reading.value) : UNKNOWN_TEXT;
   const isOn = (f: RitXitField<boolean>): boolean => f.reading.status === 'known' && f.reading.value === true;
+  /** F2 (fix round, verify-MOR-1308). `TxAuxSurface.svelte`'s `pressedOf`,
+   *  verbatim shape: `boolean | undefined` so `aria-pressed` is OMITTED —
+   *  never `"false"` — when the reading is unknown. Claiming "off" for a
+   *  field this surface has never observed is the same fabrication the
+   *  B-wave criterion forbids for the underlying dispatch below. */
+  const pressedOf = (f: RitXitField<boolean> | ScanField<boolean>): boolean | undefined =>
+    f.reading.status === 'known' ? f.reading.value : undefined;
 </script>
 
 <script lang="ts">
@@ -88,13 +95,23 @@
   let scanningOn = $derived(sc !== undefined && usable(sc.scanning)
     && sc.scanning.reading.status === 'known' && sc.scanning.reading.value === true);
 
-  function toggleRit(): void { if (activeKnown) onRitToggle?.(); }
-  function toggleXit(): void { if (activeKnown) onXitToggle?.(); }
+  // F2 (fix round, verify-MOR-1308): gated on the field's OWN observation,
+  // not just the wrong-VFO guard — mirrors `TxAuxSurface.svelte`'s `toggle`.
+  // Firing over an unobserved reading arms a guess at the command bus
+  // (`makeRitXitHandlers().onRitToggle`'s `?? false` optimism), exactly the
+  // re-loosening the B-wave criterion forbids.
+  function toggleRit(): void { if (rx && activeKnown && usable(rx.ritActive)) onRitToggle?.(); }
+  function toggleXit(): void { if (rx && activeKnown && usable(rx.xitActive)) onXitToggle?.(); }
   function changeOffset(hz: number): void {
     const offset = rx && (xitLeads ? rx.xitOffset : rx.ritOffset);
     if (!activeKnown || !offset || !usable(offset)) return;
     if (xitLeads) onXitOffsetChange?.(hz); else onRitOffsetChange?.(hz);
   }
+  // CLEAR is correctly LEFT UNGATED on field observation (F2 fix round):
+  // `onClear` writes `freq: 0` absolutely, not a read-modify-write of the
+  // current offset, so it is honest even while the offset is unobserved —
+  // unlike the toggles, it never reads a guessed value to decide what to
+  // send. Still gated on `activeKnown` (S3b — no receiver to attribute it to).
   function clear(): void { if (activeKnown) onClear?.(); }
   function toggleScan(): void {
     if (!sc || !usable(sc.scanning)) return;
@@ -118,14 +135,14 @@
       <div class="row" data-testid="ritxit" data-active-vfo-known={activeKnown}>
         {#if rx.ritActive.availability.structural}
           <button
-            type="button" data-testid="ritxit-rit-toggle" aria-pressed={isOn(rx.ritActive)}
-            disabled={!activeKnown} onclick={toggleRit}
+            type="button" data-testid="ritxit-rit-toggle" aria-pressed={pressedOf(rx.ritActive)}
+            disabled={!activeKnown || !usable(rx.ritActive)} onclick={toggleRit}
           >RIT</button>
         {/if}
         {#if rx.xitActive.availability.structural}
           <button
-            type="button" data-testid="ritxit-xit-toggle" aria-pressed={isOn(rx.xitActive)}
-            disabled={!activeKnown} onclick={toggleXit}
+            type="button" data-testid="ritxit-xit-toggle" aria-pressed={pressedOf(rx.xitActive)}
+            disabled={!activeKnown || !usable(rx.xitActive)} onclick={toggleXit}
           >XIT</button>
         {/if}
         <label class="offset" data-testid="ritxit-offset" data-observed={usable(offset)}>
@@ -147,7 +164,7 @@
         {#if sc.scanning.availability.structural}
           <span data-testid="scan-status" data-observed={usable(sc.scanning)}>{textOf(sc.scanning)}</span>
           <button
-            type="button" data-testid="scan-toggle" aria-pressed={scanningOn}
+            type="button" data-testid="scan-toggle" aria-pressed={pressedOf(sc.scanning)}
             disabled={!usable(sc.scanning) || (!scanningOn && !usable(sc.scanType))}
             onclick={toggleScan}
           >{scanningOn ? 'STOP' : 'START'}</button>

--- a/frontend/src/semantic/RitXitScanSurface.svelte
+++ b/frontend/src/semantic/RitXitScanSurface.svelte
@@ -103,7 +103,11 @@
   }
   function cycleResume(): void {
     if (!sc || !usable(sc.scanResumeMode) || sc.scanResumeMode.reading.status !== 'known') return;
-    onResumeModeChange?.((sc.scanResumeMode.reading.value + 1) % 4);
+    // F1 (fix round, verify-MOR-1308): the fact is the `& 0x0F` masked value
+    // (8A), but the wire wants the full CI-V byte — the backend validates
+    // `scan_set_resume: mode must be 0xD0-0xD3` (control.py:2283-2289). Same
+    // split `ScanPanel.svelte` makes between `rm.value` and `rm.value & 0x0F`.
+    onResumeModeChange?.(0xD0 | ((sc.scanResumeMode.reading.value + 1) % 4));
   }
 </script>
 

--- a/frontend/src/semantic/__tests__/RitXitScanSurface.test.ts
+++ b/frontend/src/semantic/__tests__/RitXitScanSurface.test.ts
@@ -355,21 +355,38 @@ describe('scan resume mode: a single honest cycle over the raw masked value', ()
     r.dispose();
   });
 
-  it('advances the masked resume value by one', () => {
+  it('advances the masked resume value by one, encoded as the full CI-V byte', () => {
     const onResumeModeChange = vi.fn();
     const r = render(withSc({ scanResumeMode: knownScan(1) }), { onResumeModeChange });
     r.el('scan-resume-cycle')!.click();
     flushSync();
-    expect(onResumeModeChange).toHaveBeenCalledExactlyOnceWith(2);
+    expect(onResumeModeChange).toHaveBeenCalledExactlyOnceWith(0xD2);
     r.dispose();
   });
 
-  it('wraps from the last value back to 0', () => {
+  it('wraps from the last masked value back to 0xD0', () => {
     const onResumeModeChange = vi.fn();
     const r = render(withSc({ scanResumeMode: knownScan(3) }), { onResumeModeChange });
     r.el('scan-resume-cycle')!.click();
     flushSync();
-    expect(onResumeModeChange).toHaveBeenCalledExactlyOnceWith(0);
+    expect(onResumeModeChange).toHaveBeenCalledExactlyOnceWith(0xD0);
+    r.dispose();
+  });
+
+  // F1 (fix round) — the backend validator is `if resume_mode not in
+  // range(0xD0, 0xD4): raise ValueError(...)` (control.py:2283-2289). Every
+  // one of the four masked cycle positions must dispatch a value inside that
+  // accepted range — the assertion whose absence let the masked-only bug ship.
+  it.each([
+    [0, 0xD1], [1, 0xD2], [2, 0xD3], [3, 0xD0],
+  ])('dispatches an accepted-range value (0xD0..0xD3) from masked %i', (masked, expected) => {
+    const onResumeModeChange = vi.fn();
+    const r = render(withSc({ scanResumeMode: knownScan(masked) }), { onResumeModeChange });
+    r.el('scan-resume-cycle')!.click();
+    flushSync();
+    expect(onResumeModeChange).toHaveBeenCalledExactlyOnceWith(expected);
+    expect(expected).toBeGreaterThanOrEqual(0xD0);
+    expect(expected).toBeLessThanOrEqual(0xD3);
     r.dispose();
   });
 });

--- a/frontend/src/semantic/__tests__/RitXitScanSurface.test.ts
+++ b/frontend/src/semantic/__tests__/RitXitScanSurface.test.ts
@@ -119,6 +119,33 @@ describe('unread facts render honestly, never fabricated', () => {
     expect(r.el('ritxit-offset')!.dataset.observed).toBe('false');
     r.dispose();
   });
+
+  // F3 (fix round, verify-MOR-1308 M6/M7): activeReceiver stays KNOWN here —
+  // isolates the offset's OWN observation gate from the S3b wrong-VFO guard.
+  // Both halves of "refuse an edit to an unobserved offset" pinned
+  // independently: the `disabled` attribute (M7) and the in-handler guard,
+  // bypassed via a direct dispatch (M6).
+  it('disables the offset slider while the offset itself is unread (activeReceiver known)', () => {
+    const r = render(withRx({ ritOffset: unread<number>(), xitOffset: unread<number>() }));
+    expect(r.input()!.disabled).toBe(true);
+    r.dispose();
+  });
+
+  it('refuses an offset edit dispatched directly at the input while the offset is unread, bypassing disabled', () => {
+    const onRitOffsetChange = vi.fn();
+    const onXitOffsetChange = vi.fn();
+    const r = render(
+      withRx({ ritOffset: unread<number>(), xitOffset: unread<number>() }),
+      { onRitOffsetChange, onXitOffsetChange },
+    );
+    const input = r.input()!;
+    input.value = '300';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    expect(onRitOffsetChange).not.toHaveBeenCalled();
+    expect(onXitOffsetChange).not.toHaveBeenCalled();
+    r.dispose();
+  });
 });
 
 describe('S3b wrong-VFO guard: every RIT/XIT control fails closed while activeReceiver is unknown', () => {
@@ -403,6 +430,23 @@ describe('scan start/stop: guarded on a KNOWN scanning state, start also on a kn
     r.el('scan-toggle')!.click();
     flushSync();
     expect(onScanStart).toHaveBeenCalledExactlyOnceWith(0x22);
+    r.dispose();
+  });
+
+  // F3 (fix round, verify-MOR-1308 M10): `scanning` is KNOWN idle here (the
+  // button IS disabled in this state, since `!scanningOn && !usable(scanType)`
+  // — so the attribute alone would satisfy a naive assertion). The bypass
+  // dispatch is the only way to prove the handler itself never falls through
+  // to a fabricated `type: 0`, unlike the sibling test above which only
+  // covers the `scanning`-unobserved early-return path.
+  it('never fabricates type 0 via a bypassed click while idle and scanType is unobserved', () => {
+    const onScanStart = vi.fn();
+    const r = render(
+      withSc({ scanning: knownScan(false), scanType: unreadScan<number>(OFF_AVAIL) }), { onScanStart },
+    );
+    bypassClick(r.el('scan-toggle')!);
+    flushSync();
+    expect(onScanStart).not.toHaveBeenCalled();
     r.dispose();
   });
 

--- a/frontend/src/semantic/__tests__/RitXitScanSurface.test.ts
+++ b/frontend/src/semantic/__tests__/RitXitScanSurface.test.ts
@@ -1,0 +1,375 @@
+/**
+ * MOR-1308 — the semantic RIT/XIT + scan surface (vocabulary slice 8B).
+ *
+ * Every test names the mutation/carry-forward it pins:
+ *   O1 — `ritOffset`/`xitOffset` are ONE register under TWO capability gates:
+ *        exactly one offset control renders, and editing it routes through
+ *        whichever underlying command v2's own `xitActive && !ritActive`
+ *        selection names — never both, never neither.
+ *   S3b (wrong-VFO guard) — every RIT/XIT control disables itself, AND
+ *        independently refuses to dispatch, while `activeReceiver` is
+ *        unobserved. `disabled` and the in-handler guard are pinned
+ *        SEPARATELY per the MOR-1304 F3 lesson: `.click()` on a disabled
+ *        button is a jsdom no-op regardless of the guard, so guard tests
+ *        dispatch the event directly instead.
+ *   `scan` per-field partial-reporter gate — a radio that has only ever
+ *        reported `scanning` surfaces exactly that field, no more.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import RitXitScanSurface, { OFFSET_MAX, OFFSET_MIN, OFFSET_STEP, UNKNOWN_TEXT } from '../RitXitScanSurface.svelte';
+import { topologyFixtures, withRitXit, withScan } from '../fixtures/topologies';
+import type {
+  Availability, RadioViewModel, RitXitField, RitXitViewModel, ScanField, ScanViewModel,
+} from '../radio-view-model';
+
+const ON: Availability = { structural: true, operational: true };
+
+const base = (): RadioViewModel => withScan(withRitXit(topologyFixtures['1/single']));
+const withRx = (over: Partial<RitXitViewModel>): RadioViewModel => {
+  const view = base();
+  return { ...view, ritXit: { ...view.ritXit!, ...over } };
+};
+const withSc = (over: Partial<ScanViewModel>): RadioViewModel => {
+  const view = base();
+  return { ...view, scan: { ...view.scan!, ...over } };
+};
+const unread = <T>(availability: Availability = ON): RitXitField<T> =>
+  ({ reading: { status: 'unknown' }, availability });
+const known = <T>(value: T, availability: Availability = ON): RitXitField<T> =>
+  ({ reading: { status: 'known', value }, availability });
+const unknownActive: RadioViewModel = { ...base(), activeReceiver: { status: 'unknown' } };
+
+let target: HTMLDivElement;
+beforeEach(() => { target = document.createElement('div'); document.body.appendChild(target); });
+afterEach(() => { target.remove(); });
+
+type Handlers = {
+  onRitToggle?: () => void;
+  onXitToggle?: () => void;
+  onRitOffsetChange?: (hz: number) => void;
+  onXitOffsetChange?: (hz: number) => void;
+  onClear?: () => void;
+  onScanStart?: (type: number) => void;
+  onScanStop?: () => void;
+  onResumeModeChange?: (mode: number) => void;
+};
+
+function render(view: RadioViewModel, handlers: Handlers = {}) {
+  const component = mount(RitXitScanSurface, { target, props: { view, ...handlers } });
+  flushSync();
+  const q = <T extends HTMLElement>(sel: string) => target.querySelector(sel) as T | null;
+  return {
+    dispose: () => unmount(component),
+    root: () => q('[data-testid="ritxit-scan-surface"]'),
+    el: (id: string) => q<HTMLElement>(`[data-testid="${id}"]`),
+    text: (id: string) => q<HTMLElement>(`[data-testid="${id}"]`)?.textContent?.trim(),
+    input: () => q<HTMLInputElement>('[data-testid="ritxit-offset"] input'),
+    all: (id: string) => target.querySelectorAll(`[data-testid="${id}"]`),
+  };
+}
+/** MOR-1304 F3 recipe: bypasses jsdom's disabled-button `.click()` no-op. */
+const bypassClick = (el: HTMLElement) => el.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+describe('structural presence: absent groups render nothing extra', () => {
+  it('renders nothing when neither ritXit nor scan is present', () => {
+    const r = render(topologyFixtures['1/single']);
+    expect(r.root()).toBeNull();
+    r.dispose();
+  });
+
+  it('renders only the ritXit row when scan is absent', () => {
+    const r = render(withRitXit(topologyFixtures['1/single']));
+    expect(r.el('ritxit')).not.toBeNull();
+    expect(r.el('scan')).toBeNull();
+    r.dispose();
+  });
+
+  it('renders only the scan row when ritXit is absent', () => {
+    const r = render(withScan(topologyFixtures['1/single']));
+    expect(r.el('scan')).not.toBeNull();
+    expect(r.el('ritxit')).toBeNull();
+    r.dispose();
+  });
+
+  it('shows only RIT when the radio has no XIT capability, offset stays present', () => {
+    const r = render(withRx({ xitActive: unread<boolean>(OFF_AVAIL) }));
+    expect(r.el('ritxit-rit-toggle')).not.toBeNull();
+    expect(r.el('ritxit-xit-toggle')).toBeNull();
+    expect(r.el('ritxit-offset')).not.toBeNull();
+    r.dispose();
+  });
+
+  it('shows only XIT when the radio has no RIT capability, offset stays present', () => {
+    const r = render(withRx({ ritActive: unread<boolean>(OFF_AVAIL) }));
+    expect(r.el('ritxit-xit-toggle')).not.toBeNull();
+    expect(r.el('ritxit-rit-toggle')).toBeNull();
+    expect(r.el('ritxit-offset')).not.toBeNull();
+    r.dispose();
+  });
+});
+
+const OFF_AVAIL: Availability = { structural: false, operational: false };
+
+describe('unread facts render honestly, never fabricated', () => {
+  it('shows an unread offset as unknown text with the slider at 0, not a guessed position', () => {
+    const r = render(withRx({ ritOffset: unread<number>(), xitOffset: unread<number>() }));
+    expect(r.text('ritxit-offset-value')).toBe(UNKNOWN_TEXT);
+    expect(r.input()!.valueAsNumber).toBe(0);
+    expect(r.el('ritxit-offset')!.dataset.observed).toBe('false');
+    r.dispose();
+  });
+});
+
+describe('S3b wrong-VFO guard: every RIT/XIT control fails closed while activeReceiver is unknown', () => {
+  it('disables the RIT toggle', () => {
+    const r = render({ ...withRitXit(topologyFixtures['1/single']), activeReceiver: { status: 'unknown' } });
+    expect(r.el('ritxit-rit-toggle')!.hasAttribute('disabled')).toBe(true);
+    r.dispose();
+  });
+
+  it('refuses to toggle RIT even when the click bypasses the disabled attribute', () => {
+    const onRitToggle = vi.fn();
+    const r = render(
+      { ...withRitXit(topologyFixtures['1/single']), activeReceiver: { status: 'unknown' } }, { onRitToggle },
+    );
+    bypassClick(r.el('ritxit-rit-toggle')!);
+    flushSync();
+    expect(onRitToggle).not.toHaveBeenCalled();
+    r.dispose();
+  });
+
+  it('disables the XIT toggle', () => {
+    const r = render({ ...withRitXit(topologyFixtures['1/single']), activeReceiver: { status: 'unknown' } });
+    expect(r.el('ritxit-xit-toggle')!.hasAttribute('disabled')).toBe(true);
+    r.dispose();
+  });
+
+  it('refuses to toggle XIT even when the click bypasses the disabled attribute', () => {
+    const onXitToggle = vi.fn();
+    const r = render(
+      { ...withRitXit(topologyFixtures['1/single']), activeReceiver: { status: 'unknown' } }, { onXitToggle },
+    );
+    bypassClick(r.el('ritxit-xit-toggle')!);
+    flushSync();
+    expect(onXitToggle).not.toHaveBeenCalled();
+    r.dispose();
+  });
+
+  it('disables the offset slider', () => {
+    const r = render(unknownActive);
+    expect(r.input()!.disabled).toBe(true);
+    r.dispose();
+  });
+
+  it('refuses an offset edit dispatched directly at the input, bypassing disabled', () => {
+    const onRitOffsetChange = vi.fn();
+    const onXitOffsetChange = vi.fn();
+    const r = render(unknownActive, { onRitOffsetChange, onXitOffsetChange });
+    const input = r.input()!;
+    input.value = '500';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    expect(onRitOffsetChange).not.toHaveBeenCalled();
+    expect(onXitOffsetChange).not.toHaveBeenCalled();
+    r.dispose();
+  });
+
+  it('disables Clear', () => {
+    const r = render(unknownActive);
+    expect(r.el('ritxit-clear')!.hasAttribute('disabled')).toBe(true);
+    r.dispose();
+  });
+
+  it('refuses to Clear even when the click bypasses the disabled attribute', () => {
+    const onClear = vi.fn();
+    const r = render(unknownActive, { onClear });
+    bypassClick(r.el('ritxit-clear')!);
+    flushSync();
+    expect(onClear).not.toHaveBeenCalled();
+    r.dispose();
+  });
+
+  it('re-enables every RIT/XIT control once activeReceiver is known', () => {
+    const r = render(base());
+    for (const id of ['ritxit-rit-toggle', 'ritxit-clear']) expect(r.el(id)!.hasAttribute('disabled')).toBe(false);
+    expect(r.input()!.disabled).toBe(false);
+    r.dispose();
+  });
+});
+
+describe('O1: one offset register under two capability gates', () => {
+  it('renders exactly one offset control, never two', () => {
+    const r = render(withRx({ ritActive: known(true), xitActive: known(false) }));
+    expect(r.all('ritxit-offset').length).toBe(1);
+    r.dispose();
+  });
+
+  it('routes an edit to onRitOffsetChange when RIT leads (v2 formula: xitActive && !ritActive)', () => {
+    const onRitOffsetChange = vi.fn();
+    const onXitOffsetChange = vi.fn();
+    const r = render(
+      withRx({ ritActive: known(true), xitActive: known(false) }), { onRitOffsetChange, onXitOffsetChange },
+    );
+    const input = r.input()!;
+    input.value = '300';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    expect(onRitOffsetChange).toHaveBeenCalledExactlyOnceWith(300);
+    expect(onXitOffsetChange).not.toHaveBeenCalled();
+    r.dispose();
+  });
+
+  it('routes an edit to onXitOffsetChange when XIT leads (xitActive && !ritActive)', () => {
+    const onRitOffsetChange = vi.fn();
+    const onXitOffsetChange = vi.fn();
+    const r = render(
+      withRx({ ritActive: known(false), xitActive: known(true) }), { onRitOffsetChange, onXitOffsetChange },
+    );
+    const input = r.input()!;
+    input.value = '-300';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    expect(onXitOffsetChange).toHaveBeenCalledExactlyOnceWith(-300);
+    expect(onRitOffsetChange).not.toHaveBeenCalled();
+    r.dispose();
+  });
+
+  it('falls back to onRitOffsetChange when neither is active, mirroring v2 exactly', () => {
+    const onRitOffsetChange = vi.fn();
+    const onXitOffsetChange = vi.fn();
+    const r = render(
+      withRx({ ritActive: known(false), xitActive: known(false) }), { onRitOffsetChange, onXitOffsetChange },
+    );
+    const input = r.input()!;
+    input.value = '0';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    expect(onRitOffsetChange).toHaveBeenCalledExactlyOnceWith(0);
+    expect(onXitOffsetChange).not.toHaveBeenCalled();
+    r.dispose();
+  });
+
+  it('shows the identical displayed value regardless of which side leads (same register)', () => {
+    const rLead = render(withRx({ ritActive: known(true), xitActive: known(false), ritOffset: known(250), xitOffset: known(250) }));
+    const ritText = rLead.text('ritxit-offset-value');
+    rLead.dispose();
+    const xLead = render(withRx({ ritActive: known(false), xitActive: known(true), ritOffset: known(250), xitOffset: known(250) }));
+    expect(xLead.text('ritxit-offset-value')).toBe(ritText);
+    xLead.dispose();
+  });
+
+  it('exposes v2\'s own -9999..9999 Hz / 50 Hz-step bounds (O2)', () => {
+    const r = render(base());
+    const input = r.input()!;
+    expect(Number(input.min)).toBe(OFFSET_MIN);
+    expect(Number(input.max)).toBe(OFFSET_MAX);
+    expect(Number(input.step)).toBe(OFFSET_STEP);
+    r.dispose();
+  });
+});
+
+describe('scan: per-field ever-reported gate (partial reporter, no capability tag)', () => {
+  it('surfaces only scanning when scanType/scanResumeMode were never reported', () => {
+    const r = render(withSc({
+      scanType: unreadScan<number>(OFF_AVAIL), scanResumeMode: unreadScan<number>(OFF_AVAIL),
+    }));
+    expect(r.el('scan-status')).not.toBeNull();
+    expect(r.el('scan-type-value')).toBeNull();
+    expect(r.el('scan-resume-value')).toBeNull();
+    r.dispose();
+  });
+
+  it('surfaces every field once all three have been reported', () => {
+    const r = render(base());
+    expect(r.el('scan-status')).not.toBeNull();
+    expect(r.el('scan-type-value')).not.toBeNull();
+    expect(r.el('scan-resume-value')).not.toBeNull();
+    r.dispose();
+  });
+});
+
+function unreadScan<T>(availability: Availability = ON): ScanField<T> {
+  return { reading: { status: 'unknown' }, availability };
+}
+function knownScan<T>(value: T, availability: Availability = ON): ScanField<T> {
+  return { reading: { status: 'known', value }, availability };
+}
+
+describe('scan start/stop: guarded on a KNOWN scanning state, start also on a known type', () => {
+  it('disables the toggle while scanning itself is unobserved', () => {
+    const r = render(withSc({ scanning: unreadScan<boolean>() }));
+    expect(r.el('scan-toggle')!.hasAttribute('disabled')).toBe(true);
+    r.dispose();
+  });
+
+  it('refuses to dispatch either start or stop when the click bypasses disabled', () => {
+    const onScanStart = vi.fn();
+    const onScanStop = vi.fn();
+    const r = render(withSc({ scanning: unreadScan<boolean>() }), { onScanStart, onScanStop });
+    bypassClick(r.el('scan-toggle')!);
+    flushSync();
+    expect(onScanStart).not.toHaveBeenCalled();
+    expect(onScanStop).not.toHaveBeenCalled();
+    r.dispose();
+  });
+
+  it('disables start while idle and scanType has never been reported (no type to resume)', () => {
+    const r = render(withSc({ scanning: knownScan(false), scanType: unreadScan<number>(OFF_AVAIL) }));
+    expect(r.el('scan-toggle')!.hasAttribute('disabled')).toBe(true);
+    r.dispose();
+  });
+
+  it('starts the last-observed scan type, never a fabricated one', () => {
+    const onScanStart = vi.fn();
+    const r = render(withSc({ scanning: knownScan(false), scanType: knownScan(0x22) }), { onScanStart });
+    r.el('scan-toggle')!.click();
+    flushSync();
+    expect(onScanStart).toHaveBeenCalledExactlyOnceWith(0x22);
+    r.dispose();
+  });
+
+  it('stops an active scan regardless of scanType observation', () => {
+    const onScanStop = vi.fn();
+    const r = render(withSc({ scanning: knownScan(true), scanType: unreadScan<number>(OFF_AVAIL) }), { onScanStop });
+    r.el('scan-toggle')!.click();
+    flushSync();
+    expect(onScanStop).toHaveBeenCalledExactlyOnceWith();
+    r.dispose();
+  });
+});
+
+describe('scan resume mode: a single honest cycle over the raw masked value', () => {
+  it('disables the cycle control while resumeMode is unobserved', () => {
+    const r = render(withSc({ scanResumeMode: unreadScan<number>() }));
+    expect(r.el('scan-resume-cycle')!.hasAttribute('disabled')).toBe(true);
+    r.dispose();
+  });
+
+  it('refuses to dispatch when the click bypasses disabled', () => {
+    const onResumeModeChange = vi.fn();
+    const r = render(withSc({ scanResumeMode: unreadScan<number>() }), { onResumeModeChange });
+    bypassClick(r.el('scan-resume-cycle')!);
+    flushSync();
+    expect(onResumeModeChange).not.toHaveBeenCalled();
+    r.dispose();
+  });
+
+  it('advances the masked resume value by one', () => {
+    const onResumeModeChange = vi.fn();
+    const r = render(withSc({ scanResumeMode: knownScan(1) }), { onResumeModeChange });
+    r.el('scan-resume-cycle')!.click();
+    flushSync();
+    expect(onResumeModeChange).toHaveBeenCalledExactlyOnceWith(2);
+    r.dispose();
+  });
+
+  it('wraps from the last value back to 0', () => {
+    const onResumeModeChange = vi.fn();
+    const r = render(withSc({ scanResumeMode: knownScan(3) }), { onResumeModeChange });
+    r.el('scan-resume-cycle')!.click();
+    flushSync();
+    expect(onResumeModeChange).toHaveBeenCalledExactlyOnceWith(0);
+    r.dispose();
+  });
+});

--- a/frontend/src/semantic/__tests__/RitXitScanSurface.test.ts
+++ b/frontend/src/semantic/__tests__/RitXitScanSurface.test.ts
@@ -198,6 +198,83 @@ describe('S3b wrong-VFO guard: every RIT/XIT control fails closed while activeRe
   });
 });
 
+describe('F2 (fix round): RIT/XIT toggles fail closed on their OWN unobserved reading', () => {
+  // activeReceiver stays KNOWN throughout this block — isolates the field's
+  // own observation gate from the S3b wrong-VFO guard above.
+  it('disables the RIT toggle while ritActive itself is unread', () => {
+    const r = render(withRx({ ritActive: unread<boolean>() }));
+    expect(r.el('ritxit-rit-toggle')!.hasAttribute('disabled')).toBe(true);
+    r.dispose();
+  });
+
+  it('refuses to toggle RIT even when the click bypasses disabled, while ritActive is unread', () => {
+    const onRitToggle = vi.fn();
+    const r = render(withRx({ ritActive: unread<boolean>() }), { onRitToggle });
+    bypassClick(r.el('ritxit-rit-toggle')!);
+    flushSync();
+    expect(onRitToggle).not.toHaveBeenCalled();
+    r.dispose();
+  });
+
+  it('omits aria-pressed — never "false" — for an unread RIT reading', () => {
+    const r = render(withRx({ ritActive: unread<boolean>() }));
+    expect(r.el('ritxit-rit-toggle')!.hasAttribute('aria-pressed')).toBe(false);
+    r.dispose();
+  });
+
+  it('disables the XIT toggle while xitActive itself is unread', () => {
+    const r = render(withRx({ xitActive: unread<boolean>() }));
+    expect(r.el('ritxit-xit-toggle')!.hasAttribute('disabled')).toBe(true);
+    r.dispose();
+  });
+
+  it('refuses to toggle XIT even when the click bypasses disabled, while xitActive is unread', () => {
+    const onXitToggle = vi.fn();
+    const r = render(withRx({ xitActive: unread<boolean>() }), { onXitToggle });
+    bypassClick(r.el('ritxit-xit-toggle')!);
+    flushSync();
+    expect(onXitToggle).not.toHaveBeenCalled();
+    r.dispose();
+  });
+
+  it('omits aria-pressed — never "false" — for an unread XIT reading', () => {
+    const r = render(withRx({ xitActive: unread<boolean>() }));
+    expect(r.el('ritxit-xit-toggle')!.hasAttribute('aria-pressed')).toBe(false);
+    r.dispose();
+  });
+
+  it('shows aria-pressed once the reading is known, RIT on / XIT off', () => {
+    const r = render(withRx({ ritActive: known(true), xitActive: known(false) }));
+    expect(r.el('ritxit-rit-toggle')!.getAttribute('aria-pressed')).toBe('true');
+    expect(r.el('ritxit-xit-toggle')!.getAttribute('aria-pressed')).toBe('false');
+    r.dispose();
+  });
+
+  it('CLEAR stays ungated by field observation — writes freq:0 absolutely, not a read-modify-write', () => {
+    const onClear = vi.fn();
+    const r = render(withRx({ ritActive: unread<boolean>(), xitActive: unread<boolean>() }), { onClear });
+    expect(r.el('ritxit-clear')!.hasAttribute('disabled')).toBe(false);
+    r.el('ritxit-clear')!.click();
+    flushSync();
+    expect(onClear).toHaveBeenCalledExactlyOnceWith();
+    r.dispose();
+  });
+});
+
+describe('F2 (fix round): scan-toggle aria-pressed is honest about an unobserved scanning reading', () => {
+  it('omits aria-pressed — never "false" — while scanning itself is unread', () => {
+    const r = render(withSc({ scanning: unreadScan<boolean>() }));
+    expect(r.el('scan-toggle')!.hasAttribute('aria-pressed')).toBe(false);
+    r.dispose();
+  });
+
+  it('shows aria-pressed="false" once scanning is known idle', () => {
+    const r = render(withSc({ scanning: knownScan(false) }));
+    expect(r.el('scan-toggle')!.getAttribute('aria-pressed')).toBe('false');
+    r.dispose();
+  });
+});
+
 describe('O1: one offset register under two capability gates', () => {
   it('renders exactly one offset control, never two', () => {
     const r = render(withRx({ ritActive: known(true), xitActive: known(false) }));

--- a/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
+++ b/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
@@ -114,6 +114,18 @@ vi.mock('../../../components-v2/wiring/command-bus', () => ({
   makeBandHandlers: () => ({ onBandSelect: h.txAuxNoop }),
   // MOR-1309 slice 8C: the antenna intent vocabulary.
   makeAntennaHandlers: () => ({ onSelectAnt1: h.txAuxNoop, onSelectAnt2: h.txAuxNoop, onToggleRxAnt: h.txAuxNoop }),
+  // MOR-1308 slice 8B: the RIT/XIT and scan intent vocabularies. MOR-1351
+  // hardened `mainSubCaps()` to carry `rit`/`xit` tags, so this group IS
+  // reachable through the default fixture below — these stubs are exercised,
+  // not merely composition-time stand-ins.
+  makeRitXitHandlers: () => ({
+    onRitToggle: h.txAuxNoop, onXitToggle: h.txAuxNoop, onRitOffsetChange: h.txAuxNoop,
+    onXitOffsetChange: h.txAuxNoop, onClear: h.txAuxNoop,
+  }),
+  makeScanHandlers: () => ({
+    onScanStart: h.txAuxNoop, onScanStop: h.txAuxNoop, onDfSpanChange: h.txAuxNoop,
+    onResumeChange: h.txAuxNoop,
+  }),
 }));
 
 import DualReceiverCockpit from '../DualReceiverCockpit.svelte';


### PR DESCRIPTION
## Summary

8B: RitXitScanSurface over the 8A ritXit + scan facts (MOR-1295). One rendered offset control under two capability gates (ritOffset/xitOffset are one raw register - divergence is unrepresentable by construction); slider bounds are explicit UI convenience (-9999..9999 / 50 Hz); scan uses per-field raw-presence gating (partial reporters surface exactly what they reported).

Production LOC 138 (verifier-measured, frozen formula; cap 200).

## Review provenance

Verified by the vocabulary-domain opus anchor #2 (session 8). Initial verify BLOCKED on three findings, all fixed and delta-confirmed against the anchor's own measurements:
- F1 (functional): resume-mode cycling dispatched masked 0..3 values the backend rejects (range 0xD0-0xD3) while the optimistic patch faked success in the UI - now dispatches wire-space 0xD0|mask, all four cycle positions re-measured in-range, regression pin added.
- F2 (honesty): RIT/XIT/scan toggles fired over unobserved readings with fabricated aria-pressed=false - now gate on their own field observation (TxAuxSurface pressedOf shape), attribute omitted on unknown; re-measured in the real browser (harness inventory now shows [disabled]); CLEAR deliberately ungated (absolute write).
- F3 (coverage): M6/M7/M10 survivors pinned.
Full re-battery 13/13 killed; canon (i) with non-vacuous absence pin + control test, both dual restorations caught; O1 ruled structurally stronger than claimed; wrong-VFO ruling recorded (no ritXit/scan command carries a receiver - the fail-closed activeReceiver gate is the only honest protection). Gates 5551/5551 at delta; post-rebase 5603/5603. Harness exercised-and-passing post-1351.

Follow-ups ticketed: MOR-1358 (shared pressedOf), MOR-1359 (XIT-only latent binding). Owner-note pending: scan type/resume render as raw integers vs v2 labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)