### PR TITLE
feat(MOR-1310): cwKeyer surface (9B, safety-critical) - break-in fail-closed, no key path

### DIFF
--- a/frontend/src/components-v2/layout/__tests__/MobileRadioLayout.component.svelte.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/MobileRadioLayout.component.svelte.test.ts
@@ -122,7 +122,12 @@ vi.mock('../../wiring/command-bus', () => {
     makeAgcHandlers: () => ({ onAgcModeChange: n }),
     makeRitXitHandlers: () => ({ onRitToggle: n, onRitClear: n, onXitToggle: n, onXitClear: n }),
     makeDspHandlers: () => ({ onNrToggle: n, onNbToggle: n, onNotchToggle: n }),
-    makeCwPanelHandlers: () => ({ onSpeedChange: n }),
+    // MOR-1310 slice 9B added the semantic CW surface's setting intents here.
+    makeCwPanelHandlers: () => ({
+      onSpeedChange: n, onKeySpeedChange: n, onCwPitchChange: n,
+      onBreakInDelayChange: n, onBreakInModeChange: n, onApfChange: n,
+      onTwinPeakToggle: n, onReversePaddleToggle: n,
+    }),
     makeAntennaHandlers: () => ({ onAntennaSelect: n }),
     makeScanHandlers: () => ({ onScanStart: n, onScanStop: n, onDfSpanChange: n, onResumeChange: n }),
   };

--- a/frontend/src/components-v2/layout/__tests__/semantic-mobile-migration.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-mobile-migration.component.test.ts
@@ -148,7 +148,12 @@ vi.mock('../../wiring/command-bus', () => {
     makeAgcHandlers: () => ({ onAgcModeChange: n }),
     makeRitXitHandlers: () => ({ onRitToggle: n, onRitClear: n, onXitToggle: n, onXitClear: n }),
     makeDspHandlers: () => ({ onNrToggle: n, onNbToggle: n, onNotchToggle: n, onNrModeChange: n, onNotchModeChange: n }),
-    makeCwPanelHandlers: () => ({ onSpeedChange: n }),
+    // MOR-1310 slice 9B added the semantic CW surface's setting intents here.
+    makeCwPanelHandlers: () => ({
+      onSpeedChange: n, onKeySpeedChange: n, onCwPitchChange: n,
+      onBreakInDelayChange: n, onBreakInModeChange: n, onApfChange: n,
+      onTwinPeakToggle: n, onReversePaddleToggle: n,
+    }),
     makeAntennaHandlers: () => ({ onAntennaSelect: n }),
     makeScanHandlers: () => ({ onScanStart: n, onScanStop: n, onDfSpanChange: n, onResumeChange: n }),
   };

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -51,11 +51,12 @@
   import { keyBlockedReasons } from '../../semantic/rx-tx-surface';
   import VfoSurface, { type VfoSelection } from '../../semantic/VfoSurface.svelte';
   import ModInputTxWarning from '../panels/ModInputTxWarning.svelte';
+  import CwKeyerSurface, { type CwLevelField } from '../../semantic/CwKeyerSurface.svelte';
   import {
     makeAgcHandlers, makeAntennaHandlers, makeAudioRoutingHandlers, makeBandHandlers,
-    makeDspHandlers, makeFilterHandlers, makeModeHandlers, makeRfFrontEndHandlers,
-    makeRitXitHandlers, makeRxAudioHandlers, makeScanHandlers, makeTxHandlers,
-    makeVfoHandlers, makeVoxHandlers,
+    makeCwPanelHandlers, makeDspHandlers, makeFilterHandlers, makeModeHandlers,
+    makeRfFrontEndHandlers, makeRitXitHandlers, makeRxAudioHandlers, makeScanHandlers,
+    makeTxHandlers, makeVfoHandlers, makeVoxHandlers,
   } from './command-bus';
   import {
     forReceiver, receiversOf, isActiveStrip, isOperationalStrip,
@@ -254,6 +255,18 @@
    */
   const ritXitIntents = makeRitXitHandlers();
   const scanIntents = makeScanHandlers();
+  /**
+   * MOR-1310 (slice 9B). The CW intent vocabulary, composed from the SHIPPED
+   * `makeCwPanelHandlers` rather than forked. `onAutoTune` is deliberately NOT
+   * wired: `cw_auto_tune` is a transmit-causing action and the surface offers no
+   * control for it (MOR-1244 ATU-TUNE precedent). Nothing here keys — exactly
+   * one `<RxTxSurface>` stays the key/unkey authority (decomposition R9).
+   */
+  const cwIntents = makeCwPanelHandlers();
+  const CW_LEVEL_INTENT: Record<CwLevelField, (value: number) => void> = {
+    keyerSpeed: cwIntents.onKeySpeedChange, pitchHz: cwIntents.onCwPitchChange,
+    breakInDelay: cwIntents.onBreakInDelayChange,
+  };
   const tx = getAppTxController();
   const sourceId = `semantic-rx-tx-${++surfaceSeq}`;
   let leaseSeq = 0;
@@ -843,6 +856,37 @@
     {/if}
   {/snippet}
 
+  <!--
+    MOR-1310 (vocabulary slice 9B) — SAFETY-CRITICAL. Same structural gate as
+    the surfaces above, and the SAME single-composition-only mounting as
+    `rxAudioSurface`: this surface is control-bearing, no manifest declares a
+    `cwKeyer` zone, and the MOR-1069 cockpit rule is that every focusable
+    control lives inside a declared zone with rx-tx last in the tab order.
+    Mounted bare in the dual composition it would break both clauses; folded
+    into the rx-tx zone it would put a keyer slider between the operator and
+    the unkey button. `'cwKeyer'` became DECLARABLE with this slice, so the
+    cockpit gains the surface the moment a manifest declares a zone — a layout
+    decision, separately reviewed, exactly as rxAudio left it. Its absence from
+    the dual composition is pinned by name in
+    `__tests__/semantic-cw-keyer-wiring.component.test.ts`.
+
+    It takes NO authority snapshot and no key intent: break-in is a SETTING,
+    gated inside the surface on the model's one `txPermit`, and the key/unkey
+    authority stays the single `<RxTxSurface>` above (decomposition R9).
+  -->
+  {#snippet cwKeyerSurface()}
+    {#if view?.cwKeyer}
+      <CwKeyerSurface
+        {view}
+        onBreakInMode={(mode) => cwIntents.onBreakInModeChange(mode)}
+        onLevelChange={(field, value) => CW_LEVEL_INTENT[field](value)}
+        onApfOn={(on) => cwIntents.onApfChange(on ? 1 : 0)}
+        onTwinPeakToggle={() => cwIntents.onTwinPeakToggle()}
+        onReversePaddleToggle={() => cwIntents.onReversePaddleToggle()}
+      />
+    {/if}
+  {/snippet}
+
   {#if strips === 'dual'}
     <!--
       MOR-1258: the zone now carries RxTxSurface AND the two TX-adjacent
@@ -894,6 +938,7 @@
     {@render zoned(
       'ritXitScan', view?.ritXit !== undefined || view?.scan !== undefined, ritXitScanSurface,
     )}
+    {@render zoned('cwKeyer', view?.cwKeyer !== undefined, cwKeyerSurface)}
     {@render txAdjacentAlerts()}
   {/if}
 </div>

--- a/frontend/src/components-v2/wiring/__tests__/semantic-cw-keyer-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-cw-keyer-wiring.component.test.ts
@@ -1,0 +1,405 @@
+/**
+ * MOR-1310 — the semantic CW-keyer surface wired into `SemanticRadioSurfaces`.
+ *
+ * SAFETY-CRITICAL. `semantic/__tests__/CwKeyerSurface.test.ts` proves what the
+ * surface does with a view model. This file proves the things only the composed
+ * tree can prove, and it uses the REAL command bus, the REAL adapter and the
+ * REAL surface — only the transport/runtime/authority SEAMS are spied:
+ *
+ *   (a) NO KEY PATH. With everything ARMED — break-in structurally available,
+ *       `txPermit` `allowed`, every control enabled — exercising EVERY control
+ *       on the surface must produce only the legal SETTING commands and ZERO
+ *       commands of the key/unkey class (`ptt`, `cw_auto_tune`,
+ *       `set_tuner_status`). Exactly one `<RxTxSurface>` remains the key/unkey
+ *       authority (MOR-1262 decomposition R9), and it is untouched here.
+ *   (b) The break-in gate survives the real adapter: a radio whose TX target is
+ *       unobserved (permit `unknown`) reaches the surface with the control
+ *       disabled and the recorded reason rendered — the deliberate fail-closed
+ *       over-disable of MOR-1296 O2.
+ *   (c) NO SECOND PERMIT: the whole composed tree resolves break-in from the
+ *       ONE `txPermit`; moving the radio out of band flips the gate with no
+ *       band-plan lookup anywhere in the CW path.
+ *   (d) Receiver-scoped intents (APF, TPF) target the ACTIVE VFO — the facts
+ *       and the commands must name the same receiver.
+ *   (e) MOUNTING: the surface is control-bearing and no manifest declares a
+ *       `cwKeyer` zone, so it renders in the SINGLE composition only. The dual
+ *       composition must not grow it — asserted with a view model that DOES
+ *       carry the group, because a fixture that cannot see the surface would
+ *       reproduce the very hole the MOR-1304 ruling was written about.
+ *
+ * Isolated pool by name (`*.component.test.ts`), per the MOR-1272 doctrine.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { ServerState } from '$lib/types/state';
+
+type Snapshot = {
+  phase: string; intent: string | null; guard: { leaseId: string } | null;
+  radioTx: string; txRisk: string; mayOwnKey: boolean; fault: string | null;
+};
+
+const h = vi.hoisted(() => ({
+  state: null as unknown,
+  caps: null as unknown,
+  snapshot: null as unknown,
+  audio: { muted: false, rxEnabled: true, volume: 42 },
+  audioConnected: true,
+  rxEnabled: true,
+  listeners: new Set<(next: unknown) => void>(),
+  txStart: vi.fn(),
+  txRelease: vi.fn(),
+}));
+
+vi.mock('$lib/transport/ws-client', () => ({ sendCommand: vi.fn() }));
+vi.mock('$lib/audio/audio-manager', () => ({
+  audioManager: {
+    get rxEnabled() { return h.rxEnabled; },
+    startRx: vi.fn(), stopRx: vi.fn(), setRxVolume: vi.fn(), setAudioConfig: vi.fn(),
+  },
+}));
+vi.mock('$lib/runtime/frontend-runtime', () => ({
+  runtime: {
+    get state() { return h.state; },
+    get caps() { return h.caps; },
+    get audio() { return h.audio; },
+    get connectionAudio() { return h.audioConnected; },
+    get rxEnabled() { return h.rxEnabled; },
+    setVolume: vi.fn(), setMuted: vi.fn(), setRxLive: vi.fn(), setRxVolume: vi.fn(),
+  },
+}));
+vi.mock('$lib/runtime', async () => ({
+  runtime: (await import('$lib/runtime/frontend-runtime')).runtime,
+}));
+vi.mock('$lib/runtime/tx-controller/app-host', () => ({
+  getAppTxController: () => ({
+    snapshot: () => h.snapshot,
+    subscribe: (listener: (next: unknown) => void) => {
+      h.listeners.add(listener);
+      return () => { h.listeners.delete(listener); };
+    },
+    start: h.txStart, setIntent: vi.fn(), release: h.txRelease, resetFault: vi.fn(),
+  }),
+}));
+vi.mock('$lib/runtime/adapters/mod-input-tx-guard.svelte', () => ({
+  deriveModInputTxGuardProps: () => ({ visible: false, sourceLabel: 'LAN' }),
+  getModInputTxGuardHandlers: () => ({ onSetLan: vi.fn(), onDismiss: vi.fn() }),
+}));
+
+import { sendCommand } from '$lib/transport/ws-client';
+import { resetRadioState, setRadioState } from '$lib/stores/radio.svelte';
+import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';
+
+/**
+ * The command names that KEY or cause a carrier. Not one of these may leave
+ * this surface, in any state, through any control. `set_tuner_status` is here
+ * because value 2 starts an ATU tune cycle (the MOR-1244 carrier), and
+ * `cw_auto_tune` is `CwPanel`'s own transmit-causing button.
+ */
+const KEY_CLASS_COMMANDS = ['ptt', 'cw_auto_tune', 'set_tuner_status'] as const;
+
+const IDLE: Snapshot = {
+  phase: 'idle', intent: null, guard: null, radioTx: 'off', txRisk: 'none',
+  mayOwnKey: false, fault: null,
+};
+const fresh = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' };
+const slot = (freqHz: number, mode: string) => ({ freqHz, mode, filterNum: 1, dataMode: 0 });
+
+/**
+ * Every CW fact observed, on both receivers, with a TX target inside 20m.
+ * `mode` is a parameter because the APF/TPF mutex consumes
+ * `modeFilter.currentMode`: APF is live only in CW/CW-R, TPF only in
+ * RTTY/RTTY-R, and the two can therefore never be enabled at once (MOR-1296
+ * O1 — the reason this "CW" group is not uniformly CW).
+ */
+function liveState(over: Partial<ServerState> = {}, mode = 'CW'): ServerState {
+  const paths = [
+    'active', 'split', 'dualWatch', 'txTarget', 'breakIn', 'breakInDelay', 'keySpeed',
+    'cwPitch', 'dashRatio',
+  ];
+  for (const rx of ['main', 'sub']) {
+    paths.push(
+      `${rx}.freqHz`, `${rx}.mode`, `${rx}.filter`, `${rx}.activeSlot`,
+      `${rx}.apfTypeLevel`, `${rx}.twinPeakFilter`,
+    );
+    for (const v of ['vfoA', 'vfoB']) {
+      paths.push(`${rx}.${v}.freqHz`, `${rx}.${v}.mode`, `${rx}.${v}.filterNum`);
+    }
+  }
+  const receiver = (hz: number, apfTypeLevel: number) => ({
+    ...slot(hz, mode), vfoA: slot(hz, mode), vfoB: slot(hz + 50000, mode), activeSlot: 'A',
+    filter: 1, apfTypeLevel, twinPeakFilter: false,
+  });
+  return {
+    active: 'MAIN', split: false, dualWatch: false, ptt: false,
+    breakIn: 1, breakInDelay: 64, keySpeed: 24, cwPitch: 600, dashRatio: 0,
+    txTarget: { status: 'known', receiver: 'MAIN', slot: 'A', frequencyHz: 14250000 },
+    main: receiver(14250000, 0), sub: receiver(14300000, 2),
+    ...over,
+    fieldStatus: Object.fromEntries(paths.map((p) => [p, fresh])),
+  } as unknown as ServerState;
+}
+
+const liveCaps = (tags: readonly string[]): Capabilities => ({
+  model: 'fixture', scope: false, audio: false, tx: true,
+  capabilities: tags, receivers: 2, vfoScheme: 'main_sub', freqRanges: [],
+  // A radio that declares no modes is not a radio that exists, and the
+  // APF/TPF mutex reads `modeFilter.currentMode` — an empty `modes` list makes
+  // the mode fact absent and BOTH controls fail closed, hiding this slice's
+  // behaviour behind a fixture hole (the MOR-1304 N2 lesson).
+  modes: ['CW', 'CW-R', 'RTTY', 'USB'], filters: [1, 2, 3],
+  audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
+  webrtc: { available: false, enabled: false },
+  txBands: [{ start: 14000000, end: 14350000, name: '20m' }],
+  scopeSource: null, audioFftAvailable: false,
+} as unknown as Capabilities);
+
+/** A full CW radio: keyer, break-in, APF and the twin-peak filter. */
+const CW_TAGS = ['tx', 'cw', 'break_in', 'apf', 'twin_peak'] as const;
+/** No `cw` tag ⇒ the MOR-1296 evidence gate declines and no group is emitted. */
+const NO_CW_TAGS = ['tx'] as const;
+
+let target: HTMLDivElement;
+let component: ReturnType<typeof mount> | null = null;
+
+function render(props: { strips?: 'single' | 'dual' } = {}): void {
+  target = document.createElement('div');
+  document.body.appendChild(target);
+  component = mount(SemanticRadioSurfaces, { target, props });
+  flushSync();
+}
+
+const q = <T extends HTMLElement>(sel: string) => target.querySelector(sel) as T | null;
+const el = (id: string) => q<HTMLElement>(`[data-testid="cw-keyer-${id}"]`);
+const press = (node: HTMLElement) => node.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+const commands = () => vi.mocked(sendCommand).mock.calls.map(([name]) => name);
+
+/**
+ * The runtime seam and the radio STORE are two views of one state in
+ * production (`FrontendRuntime` wraps the store the command bus reads). The
+ * mocks split them, so this helper sets BOTH from one object — otherwise the
+ * receiver-scoping pins below would compare a fact from one source against a
+ * command param from the other and prove nothing about production.
+ */
+function useState(state: ServerState): void {
+  h.state = state;
+  // Reset first: `setRadioState` ignores a state whose revision has not
+  // advanced, and these fixtures carry no revision counter at all.
+  resetRadioState();
+  setRadioState(state);
+}
+
+beforeEach(() => {
+  useState(liveState());
+  h.caps = liveCaps(CW_TAGS);
+  h.snapshot = { ...IDLE };
+  h.listeners.clear();
+  vi.mocked(sendCommand).mockClear();
+  h.txStart.mockClear();
+  h.txRelease.mockClear();
+});
+
+afterEach(() => {
+  if (component) unmount(component);
+  component = null;
+  document.body.innerHTML = '';
+});
+
+/* ── (a) THE NO-KEY-PATH PIN ───────────────────────────────────── */
+
+describe('the CW surface never becomes a second key path (decomposition R9)', () => {
+  // MUTATION KILLED: any module in the closure keying at import time.
+  it('mounts the armed tree and sends no command at all', () => {
+    render();
+    expect(el('surface')).not.toBeNull();
+    expect(el('break-in-full')!.hasAttribute('disabled')).toBe(false);
+    expect(sendCommand).not.toHaveBeenCalled();
+    expect(h.txStart).not.toHaveBeenCalled();
+  });
+
+  /**
+   * THE PIN. Everything armed (break-in structurally available, permit
+   * `allowed`, every fact observed), EVERY control on the surface interacted
+   * with — including the ones the APF/TPF mutex disables, driven past
+   * `disabled` with a real bubbling click — and the bus must see only the
+   * legal setting commands.
+   *
+   * Run in both mutex halves because APF (CW/CW-R) and TPF (RTTY/RTTY-R) can
+   * never be live at once, so one render cannot exercise both live.
+   *
+   * MUTATION KILLED: wiring a key intent onto ANY control here (`cmd('ptt')`,
+   * `tx.start(...)`, `onAutoTune`, an ATU tune). Sliders are driven to their
+   * maximum, so even a "key at full scale" mutant is exercised.
+   */
+  it.each([
+    ['CW', ['set_apf', 'set_apf'], 'cw-keyer-twin-peak-toggle'],
+    ['RTTY', ['set_twin_peak'], 'cw-keyer-apf-off'],
+  ] as const)('in %s mode sends only SETTING commands with every control exercised', (
+    mode, filterCommands, mutexedTestId,
+  ) => {
+    useState(liveState({}, mode));
+    render();
+    const surface = el('surface')!;
+    // The mutexed control really is disabled — otherwise the sweep below would
+    // be exercising a live control and this pin would prove less than it says.
+    expect(surface.querySelector(`[data-testid="${mutexedTestId}"]`)!.hasAttribute('disabled'))
+      .toBe(true);
+
+    const controls = [...surface.querySelectorAll<HTMLElement>('button, input, select, [tabindex]')];
+    expect(controls.length).toBeGreaterThan(0);
+    for (const control of controls) {
+      if (control instanceof HTMLInputElement) {
+        control.value = control.max;
+        control.dispatchEvent(new Event('input', { bubbles: true }));
+      } else press(control);
+    }
+    flushSync();
+
+    expect(commands()).toEqual([
+      'set_break_in', 'set_break_in', 'set_break_in',
+      'set_key_speed', 'set_cw_pitch', 'set_break_in_delay',
+      'set_dash_ratio', ...filterCommands,
+    ]);
+    for (const forbidden of KEY_CLASS_COMMANDS) expect(commands()).not.toContain(forbidden);
+    // The App TX authority is never asked for a lease either — the ONE
+    // `<RxTxSurface>` above is untouched by everything this surface does.
+    expect(h.txStart).not.toHaveBeenCalled();
+    expect(h.txRelease).not.toHaveBeenCalled();
+  });
+
+  // MUTATION KILLED: the surface reacting to the transmit bit or the App TX
+  // authority at all. Nothing here is TX truth.
+  it('never changes with the App TX authority or the raw transmit bit', () => {
+    render();
+    const before = el('surface')!.outerHTML;
+    h.snapshot = { ...IDLE, phase: 'active', radioTx: 'on', mayOwnKey: true };
+    for (const listener of h.listeners) listener(h.snapshot);
+    h.state = liveState({ ptt: true } as Partial<ServerState>);
+    flushSync();
+    expect(el('surface')!.outerHTML).toBe(before);
+  });
+});
+
+/* ── (b)(c) the break-in gate through the real adapter ─────────── */
+
+describe('break-in is gated on the ONE txPermit, end to end', () => {
+  it.each([
+    ['an unobserved TX target', { txTarget: { status: 'unknown', reason: 'not-observed' } }, 'tx-target-unknown'],
+    ['an out-of-band TX target', { txTarget: { status: 'known', receiver: 'MAIN', slot: 'A', frequencyHz: 7100000 } }, 'out-of-band'],
+  ] as const)('disables every break-in choice under %s', (_label, over, code) => {
+    useState(liveState(over as Partial<ServerState>));
+    render();
+    for (const choice of ['off', 'semi', 'full']) {
+      expect(el(`break-in-${choice}`)!.hasAttribute('disabled')).toBe(true);
+    }
+    expect(el('break-in')!.dataset.permitted).toBe('false');
+    expect(el('break-in-blocked')!.dataset.reason).toBe(code);
+    expect(el('break-in-blocked')!.textContent).toContain('TX not permitted');
+  });
+
+  /**
+   * MUTATION KILLED: a second permit derivation, or the `unknown` case being
+   * "fixed" to fail open. The handler is driven past `disabled` with a real
+   * bubbling click, so this cannot pass on the attribute alone.
+   */
+  it.each([
+    ['unknown', { txTarget: { status: 'unknown', reason: 'not-observed' } }],
+    ['denied', { txTarget: { status: 'known', receiver: 'MAIN', slot: 'A', frequencyHz: 7100000 } }],
+  ] as const)('sends no set_break_in under a %s permit, even bypassing disabled', (_l, over) => {
+    useState(liveState(over as Partial<ServerState>));
+    render();
+    for (const choice of ['off', 'semi', 'full']) press(el(`break-in-${choice}`)!);
+    flushSync();
+    expect(commands()).not.toContain('set_break_in');
+  });
+
+  // MUTATION KILLED: a permit read from the band plan / `defaultHz` rather than
+  // the live TX target. Only the target frequency moves between these two
+  // renders; the band table and every CW fact are identical.
+  it('flips the gate on the LIVE TX-target frequency alone', () => {
+    render();
+    expect(el('break-in-full')!.hasAttribute('disabled')).toBe(false);
+    unmount(component!);
+    component = null;
+    useState(liveState({
+      txTarget: { status: 'known', receiver: 'MAIN', slot: 'A', frequencyHz: 14400000 },
+    } as unknown as Partial<ServerState>));
+    render();
+    expect(el('break-in-full')!.hasAttribute('disabled')).toBe(true);
+    expect(el('break-in-blocked')!.dataset.reason).toBe('out-of-band');
+  });
+
+  it('sends set_break_in with the absolute wire mode when permitted', () => {
+    render();
+    press(el('break-in-full')!);
+    flushSync();
+    expect(sendCommand).toHaveBeenCalledExactlyOnceWith('set_break_in', { mode: 2 });
+  });
+});
+
+/* ── (d) receiver-scoped intents follow the ACTIVE VFO ─────────── */
+
+describe('APF and TPF are receiver-scoped and follow the active VFO', () => {
+  // MUTATION KILLED: facts read from one receiver while the command targets
+  // the other. SUB's apfTypeLevel is 2, MAIN's is 0, so the rendered ordinal
+  // and the command's `receiver` param must move together.
+  it('reads SUB facts and commands SUB when SUB is active', () => {
+    useState(liveState({ active: 'SUB' } as Partial<ServerState>));
+    render();
+    expect(el('apf-value')!.textContent!.trim()).toBe('2');
+    press(el('apf-off')!);
+    flushSync();
+    expect(sendCommand).toHaveBeenCalledWith('set_apf', { mode: 0, receiver: 1 });
+  });
+
+  it('reads MAIN facts and commands MAIN when MAIN is active', () => {
+    render();
+    expect(el('apf-value')!.textContent!.trim()).toBe('0');
+    press(el('apf-on')!);
+    flushSync();
+    expect(sendCommand).toHaveBeenCalledWith('set_apf', { mode: 1, receiver: 0 });
+  });
+});
+
+/* ── (e) MOUNTING — single composition only, dual absence pinned ── */
+
+describe('the surface mounts only where a declared zone can hold it', () => {
+  // MUTATION KILLED: mounting `CwKeyerSurface` unconditionally — a radio with
+  // no CW keyer would gain a panel it never asked for.
+  it('renders no CW surface for a radio with no keyer', () => {
+    h.caps = liveCaps(NO_CW_TAGS);
+    render();
+    expect(el('surface')).toBeNull();
+  });
+
+  it('renders it bare in the single composition, outside every zone', () => {
+    render();
+    expect(el('surface')).not.toBeNull();
+    expect(el('surface')!.closest('[data-zone-id]')).toBeNull();
+  });
+
+  /**
+   * MUTATION KILLED: mounting this surface bare in the cockpit (the MOR-1304
+   * ruling). It is control-bearing and no manifest declares a `cwKeyer` zone,
+   * so MOR-1069's cockpit rule — every focusable control inside a declared
+   * zone, tab order ending in rx-tx — would break on both clauses; folding it
+   * into the rx-tx zone would put break-in choices between the operator and
+   * the unkey button.
+   *
+   * The caps here DO emit the group (proved by the single-composition test
+   * above, same `h.caps`), so this pin cannot pass vacuously the way a
+   * cockpit fixture with `modes: [], filters: []` does.
+   */
+  it('renders NO CW-keyer surface in the dual composition, zoned or unzoned', () => {
+    render({ strips: 'dual' });
+    expect(el('surface')).toBeNull();
+    expect(target.innerHTML).not.toContain('cw-keyer');
+  });
+
+  it('leaves the cockpit with no focusable control outside a declared zone', () => {
+    render({ strips: 'dual' });
+    const outside = [...target.querySelectorAll<HTMLElement>('button, input, select, [tabindex]')]
+      .filter((node) => node.closest('[data-zone-id]') === null);
+    expect(outside).toEqual([]);
+  });
+});

--- a/frontend/src/components-v2/wiring/__tests__/semantic-dsp-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-dsp-wiring.component.test.ts
@@ -138,6 +138,14 @@ vi.mock('../command-bus', () => ({
   makeScanHandlers: () => ({
     onScanStart: h.noop, onScanStop: h.noop, onDfSpanChange: h.noop, onResumeChange: h.noop,
   }),
+  // MOR-1310 slice 9B: the wiring now also composes the CW keyer intent
+  // vocabulary unconditionally. This fixture declares no cwKeyer capability,
+  // so none of these is reachable — same stand-in role as `makeRitXitHandlers`.
+  makeCwPanelHandlers: () => ({
+    onKeySpeedChange: h.noop, onCwPitchChange: h.noop, onBreakInDelayChange: h.noop,
+    onBreakInModeChange: h.noop, onApfChange: h.noop, onTwinPeakToggle: h.noop,
+    onReversePaddleToggle: h.noop,
+  }),
 }));
 
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';

--- a/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
@@ -80,6 +80,12 @@ vi.mock('../command-bus', () => ({
   }),
   // MOR-1279 slice 3B: the RX-audio intent vocabulary.
   makeRxAudioHandlers: () => ({ onMonitorModeChange: h.noop, onAfLevelChange: h.noop }),
+  // MOR-1310 slice 9B: the semantic CW-keyer surface's setting intents.
+  makeCwPanelHandlers: () => ({
+    onKeySpeedChange: h.noop, onCwPitchChange: h.noop, onBreakInDelayChange: h.noop,
+    onBreakInModeChange: h.noop, onApfChange: h.noop, onTwinPeakToggle: h.noop,
+    onReversePaddleToggle: h.noop,
+  }),
   makeAudioRoutingHandlers: () => ({ onFocusChange: h.noop, onSplitStereoChange: h.noop }),
   // MOR-1304 — the wiring now also composes the modeFilter/filterPassband
   // intent vocabulary; `makeModeHandlers` is composed at both call sites

--- a/frontend/src/components-v2/wiring/__tests__/semantic-rf-front-end-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rf-front-end-wiring.component.test.ts
@@ -139,6 +139,16 @@ vi.mock('../command-bus', () => ({
   makeScanHandlers: () => ({
     onScanStart: h.noop, onScanStop: h.noop, onDfSpanChange: h.noop, onResumeChange: h.noop,
   }),
+  // MOR-1310 slice 9B — the wiring's module scope also composes the CW keyer
+  // intent vocabulary unconditionally; without a stub here the wiring's
+  // `makeCwPanelHandlers()` call throws before this file's own RF-front-end
+  // assertions ever run. This fixture declares no cwKeyer capability, so
+  // none of these is reachable — same stand-in role as `makeRitXitHandlers`.
+  makeCwPanelHandlers: () => ({
+    onKeySpeedChange: h.noop, onCwPitchChange: h.noop, onBreakInDelayChange: h.noop,
+    onBreakInModeChange: h.noop, onApfChange: h.noop, onTwinPeakToggle: h.noop,
+    onReversePaddleToggle: h.noop,
+  }),
 }));
 
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';

--- a/frontend/src/components-v2/wiring/__tests__/semantic-rx-tx-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rx-tx-wiring.component.test.ts
@@ -107,6 +107,12 @@ vi.mock('../command-bus', () => ({
   }),
   // MOR-1279 slice 3B: the RX-audio intent vocabulary.
   makeRxAudioHandlers: () => ({ onMonitorModeChange: h.txAuxNoop, onAfLevelChange: h.txAuxNoop }),
+  // MOR-1310 slice 9B: the semantic CW-keyer surface's setting intents.
+  makeCwPanelHandlers: () => ({
+    onKeySpeedChange: h.txAuxNoop, onCwPitchChange: h.txAuxNoop, onBreakInDelayChange: h.txAuxNoop,
+    onBreakInModeChange: h.txAuxNoop, onApfChange: h.txAuxNoop, onTwinPeakToggle: h.txAuxNoop,
+    onReversePaddleToggle: h.txAuxNoop,
+  }),
   makeAudioRoutingHandlers: () => ({ onFocusChange: h.txAuxNoop, onSplitStereoChange: h.txAuxNoop }),
   // MOR-1304 — the wiring now also composes the modeFilter/filterPassband
   // intent vocabulary; `makeModeHandlers` is composed at both call sites

--- a/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
@@ -92,6 +92,12 @@ vi.mock('../command-bus', () => ({
   }),
   // MOR-1279 slice 3B: the RX-audio intent vocabulary.
   makeRxAudioHandlers: () => ({ onMonitorModeChange: h.noop, onAfLevelChange: h.noop }),
+  // MOR-1310 slice 9B: the semantic CW-keyer surface's setting intents.
+  makeCwPanelHandlers: () => ({
+    onKeySpeedChange: h.noop, onCwPitchChange: h.noop, onBreakInDelayChange: h.noop,
+    onBreakInModeChange: h.noop, onApfChange: h.noop, onTwinPeakToggle: h.noop,
+    onReversePaddleToggle: h.noop,
+  }),
   makeAudioRoutingHandlers: () => ({ onFocusChange: h.noop, onSplitStereoChange: h.noop }),
   // MOR-1304 — the wiring now also composes the modeFilter/filterPassband
   // intent vocabulary; `makeModeHandlers` is composed at both call sites

--- a/frontend/src/presentation/layouts/__tests__/antenna-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/antenna-declarability.test.ts
@@ -33,7 +33,7 @@ describe('antenna is a declarable semantic surface', () => {
     expect([...SEMANTIC_SURFACE_NAMES])
       .toEqual([
         'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band',
-        'antenna', 'ritXitScan',
+        'antenna', 'ritXitScan', 'cwKeyer',
       ]);
   });
 

--- a/frontend/src/presentation/layouts/__tests__/band-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/band-declarability.test.ts
@@ -29,7 +29,7 @@ describe('band is a declarable semantic surface', () => {
     expect([...SEMANTIC_SURFACE_NAMES])
       .toEqual([
         'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band',
-        'antenna', 'ritXitScan',
+        'antenna', 'ritXitScan', 'cwKeyer',
       ]);
   });
 

--- a/frontend/src/presentation/layouts/__tests__/cw-keyer-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/cw-keyer-declarability.test.ts
@@ -1,16 +1,17 @@
 /**
- * MOR-1308 — `ritXitScan` is DECLARABLE, and nothing declares it yet.
+ * MOR-1310 — `cwKeyer` is DECLARABLE, and nothing declares it yet.
  *
- * Slice 8B adds the name to `SEMANTIC_SURFACE_NAMES` so a manifest CAN mount
+ * Slice 9B adds the name to `SEMANTIC_SURFACE_NAMES` so a manifest CAN mount
  * the surface later; it deliberately does not touch any manifest, and it adds
- * no design-language renderer slot (that set was frozen by MOR-1072 — adding
- * one would be a language-contract change this slice must not make).
+ * no design-language renderer slot (that set was frozen by MOR-1072).
  *
- * Same three pins as `tx-aux-declarability.test.ts` / `meters-declarability
- * .test.ts` / `rx-audio-declarability.test.ts`:
+ * Same three pins as `rx-audio-declarability.test.ts` /
+ * `tx-aux-declarability.test.ts` / `meters-declarability.test.ts`:
  *   - drop the name and a future manifest's zone stops validating;
- *   - quietly add a `ritXitScan` zone to a shipped manifest and the DOM
- *     grows a zone id no layout review ever saw;
+ *   - quietly add a `cwKeyer` zone to a shipped manifest and the DOM grows a
+ *     zone id no layout review ever saw — which for THIS surface would also
+ *     mount break-in controls into the cockpit's tab order without the
+ *     MOR-1069 sequence assertion ever being updated;
  *   - the renderer slot set stays exactly what MOR-1072 froze.
  */
 import { describe, it, expect } from 'vitest';
@@ -22,9 +23,9 @@ import {
   sdrTestLayout,
 } from '../declarations';
 
-describe('ritXitScan is a declarable semantic surface', () => {
+describe('cwKeyer is a declarable semantic surface', () => {
   // Kills: reverting the SEMANTIC_SURFACE_NAMES addition.
-  it('is in the declarable set alongside vfo, rxTx, txAux, meters and rxAudio', () => {
+  it('is in the declarable set, appended last', () => {
     expect([...SEMANTIC_SURFACE_NAMES]).toEqual([
       'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band',
       'antenna', 'ritXitScan', 'cwKeyer',
@@ -35,7 +36,7 @@ describe('ritXitScan is a declarable semantic surface', () => {
   // zone validator checks — the manifest would still be rejected.
   it('accepts a manifest zone that declares it', () => {
     const manifest = validLayoutManifest({
-      zones: [{ id: 'main', surfaces: ['vfo', 'rxTx', 'ritXitScan'] }],
+      zones: [{ id: 'main', surfaces: ['vfo', 'rxTx', 'cwKeyer'] }],
       requiredSemanticSurfaces: ['vfo', 'rxTx'],
     });
     expect(() => validateLayoutManifest(manifest)).not.toThrow();
@@ -43,29 +44,30 @@ describe('ritXitScan is a declarable semantic surface', () => {
 
   it('still rejects a zone naming a surface that does not exist', () => {
     const manifest = validLayoutManifest({
-      zones: [{ id: 'main', surfaces: ['ritXitPanel'] as unknown as readonly ['vfo'] }],
+      zones: [{ id: 'main', surfaces: ['cwPanel'] as unknown as readonly ['vfo'] }],
     });
     expect(() => validateLayoutManifest(manifest)).toThrow(/subset of/);
   });
 });
 
-describe('no shipped manifest declares a ritXitScan zone in this slice', () => {
-  // Kills: slipping a ritXitScan zone into an existing layout here.
-  // Declarability is the whole scope of the contract touch; placing the
-  // surface in a real layout is a later, separately reviewed slice.
+describe('no shipped manifest declares a cwKeyer zone in this slice', () => {
+  // Kills: slipping a cwKeyer zone into an existing layout here. SAFETY-
+  // relevant: the dual-receiver cockpit's MOR-1069 tab-order assertion is
+  // written against the zones it declares today, so declaring one here would
+  // put break-in controls in the cockpit with no updated sequence pin.
   it.each([
     ['sdr-test', sdrTestLayout], ['dual-receiver-cockpit', dualReceiverCockpitLayout],
     ['lcd-cockpit', lcdCockpitLayout], ['lcd-scope', lcdScopeLayout],
     ['mobile', mobileLayout], ['desktop-v2', desktopV2Layout],
-  ])('%s declares no ritXitScan zone and does not require the surface', (_id, manifest) => {
-    for (const zone of manifest.zones) expect(zone.surfaces).not.toContain('ritXitScan');
-    expect(manifest.requiredSemanticSurfaces).not.toContain('ritXitScan');
+  ])('%s declares no cwKeyer zone and does not require the surface', (_id, manifest) => {
+    for (const zone of manifest.zones) expect(zone.surfaces).not.toContain('cwKeyer');
+    expect(manifest.requiredSemanticSurfaces).not.toContain('cwKeyer');
   });
 });
 
 describe('the design-language renderer slot set is untouched', () => {
-  // Kills: adding a renderer slot for this surface. RIT/XIT and scan have no
-  // gauge grammar a language must describe; the slot set stays frozen.
+  // Kills: adding a renderer slot for this surface. A CW keyer has no gauge
+  // grammar a language must describe; the slot set stays frozen.
   it('still carries exactly the three MOR-1072 slots', () => {
     expect([...RENDERER_SLOT_NAMES]).toEqual(['meters', 'frequencyDisplay', 'stateFeedback']);
   });

--- a/frontend/src/presentation/layouts/__tests__/dsp-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/dsp-declarability.test.ts
@@ -21,7 +21,7 @@ describe('dsp is a declarable semantic surface', () => {
   it('is in the declarable set alongside vfo, rxTx, txAux, meters and rxAudio', () => {
     expect([...SEMANTIC_SURFACE_NAMES]).toEqual([
       'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band',
-      'antenna', 'ritXitScan',
+      'antenna', 'ritXitScan', 'cwKeyer',
     ]);
   });
 

--- a/frontend/src/presentation/layouts/__tests__/filter-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/filter-declarability.test.ts
@@ -24,7 +24,7 @@ describe('filter is a declarable semantic surface', () => {
   it('is in the declarable set alongside vfo, rxTx, txAux, meters and rxAudio', () => {
     expect([...SEMANTIC_SURFACE_NAMES]).toEqual([
       'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band',
-      'antenna', 'ritXitScan',
+      'antenna', 'ritXitScan', 'cwKeyer',
     ]);
   });
 

--- a/frontend/src/presentation/layouts/__tests__/meters-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/meters-declarability.test.ts
@@ -30,7 +30,7 @@ describe('meters is a declarable semantic surface', () => {
   it('is in the declarable set alongside vfo, rxTx and txAux', () => {
     expect([...SEMANTIC_SURFACE_NAMES]).toEqual([
       'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band',
-      'antenna', 'ritXitScan',
+      'antenna', 'ritXitScan', 'cwKeyer',
     ]);
   });
 

--- a/frontend/src/presentation/layouts/__tests__/rf-front-end-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/rf-front-end-declarability.test.ts
@@ -29,7 +29,7 @@ describe('rfFrontEnd is a declarable semantic surface', () => {
     expect([...SEMANTIC_SURFACE_NAMES])
       .toEqual([
         'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band',
-        'antenna', 'ritXitScan',
+        'antenna', 'ritXitScan', 'cwKeyer',
       ]);
   });
 

--- a/frontend/src/presentation/layouts/__tests__/rx-audio-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/rx-audio-declarability.test.ts
@@ -26,7 +26,7 @@ describe('rxAudio is a declarable semantic surface', () => {
   it('is in the declarable set alongside vfo, rxTx, txAux and meters', () => {
     expect([...SEMANTIC_SURFACE_NAMES]).toEqual([
       'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band',
-      'antenna', 'ritXitScan',
+      'antenna', 'ritXitScan', 'cwKeyer',
     ]);
   });
 

--- a/frontend/src/presentation/layouts/__tests__/tx-aux-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/tx-aux-declarability.test.ts
@@ -30,7 +30,7 @@ describe('txAux is a declarable semantic surface', () => {
   it('is in the declarable set alongside vfo and rxTx', () => {
     expect([...SEMANTIC_SURFACE_NAMES]).toEqual([
       'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band',
-      'antenna', 'ritXitScan',
+      'antenna', 'ritXitScan', 'cwKeyer',
     ]);
   });
 

--- a/frontend/src/presentation/layouts/contract.ts
+++ b/frontend/src/presentation/layouts/contract.ts
@@ -15,16 +15,18 @@ import { isValidLanguageId as isValidProductId } from '../languages/contract';
 /** Semantic surfaces a layout may mount (MOR-1062/1065 reference vertical;
  *  `txAux` added by MOR-1265, `meters` by MOR-1273, `rxAudio` by MOR-1279,
  *  `filter` by MOR-1304, `dsp` by MOR-1305, `rfFrontEnd` by MOR-1306, `band`
- *  by MOR-1307, `antenna` by MOR-1309, `ritXitScan` by MOR-1308). Adding a
- *  name makes it DECLARABLE — it does not mount anything by itself, and no
- *  manifest declares a `meters`, `rxAudio`, `filter`, `dsp`, `rfFrontEnd`,
- *  `band`, `antenna` or `ritXitScan` zone yet (the cockpit declares only
- *  `txAux`, as `tx-aux` — MOR-1336). Distinct from the design-language
- *  renderer slot of the same name (`languages/contract.ts`'s
- *  `RENDERER_SLOT_NAMES`): that one says how a language DRAWS a meter, this
- *  one says which layout zone may HOST the surface. */
+ *  by MOR-1307, `antenna` by MOR-1309, `ritXitScan` by MOR-1308, `cwKeyer` by
+ *  MOR-1310). Adding a name makes it DECLARABLE — it does not mount anything
+ *  by itself, and no manifest declares a `meters`, `rxAudio`, `filter`,
+ *  `dsp`, `rfFrontEnd`, `band`, `antenna`, `ritXitScan` or `cwKeyer` zone yet
+ *  (the cockpit declares only `txAux`, as `tx-aux` — MOR-1336). Distinct
+ *  from the design-language renderer slot of the same name
+ *  (`languages/contract.ts`'s `RENDERER_SLOT_NAMES`): that one says how a
+ *  language DRAWS a meter, this one says which layout zone may HOST the
+ *  surface. */
 export const SEMANTIC_SURFACE_NAMES = [
   'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band', 'antenna', 'ritXitScan',
+  'cwKeyer',
 ] as const;
 export type SemanticSurfaceName = (typeof SEMANTIC_SURFACE_NAMES)[number];
 

--- a/frontend/src/semantic/CwKeyerSurface.svelte
+++ b/frontend/src/semantic/CwKeyerSurface.svelte
@@ -1,0 +1,282 @@
+<!--
+  Semantic CW-keyer surface (MOR-1310, vocabulary slice 9B) — SAFETY-CRITICAL.
+
+  Presentation only. It renders the MOR-1296 `cwKeyer` fact group — break-in
+  posture (+delay), keyer speed, CW pitch, reverse paddle, APF and the twin-peak
+  filter — and emits control intents as callbacks. It holds no state, consults
+  no controller and owns no TX authority (v3 ADR invariant 11).
+
+  SAFETY. Five rules govern this file and nothing may relax them:
+
+  (1) NOT A KEY PATH. Break-in KEYS THE TRANSMITTER, but this surface never
+      keys it: exactly one `<RxTxSurface>` remains the key/unkey authority
+      (MOR-1262 decomposition R9). Every intent below is a SETTING intent
+      (`set_break_in`, `set_cw_pitch`, …); nothing here takes a TX lease, sends
+      a PTT command or asks for a carrier. `CwPanel.svelte`'s AUTO TUNE button
+      (`cw_auto_tune`) is deliberately ABSENT for the same reason ATU TUNE is
+      absent from the facts (MOR-1244 precedent): state may be carried, a
+      transmit-causing control may not. Pinned behaviourally, not asserted.
+
+  (2) BREAK-IN OBEYS THE ONE PERMIT, FAIL-CLOSED. Arming break-in is gated on
+      `view.txPermit` — the model's SINGLE authoritative live-TX-target permit,
+      the same one `deriveTxCapabilities` gives the App TX authority. It is
+      READ, never re-derived: no `getFrequencyPermit` call, no band-plan
+      lookup, no second permit. Anything other than a positively `'allowed'`
+      permit — denied, ranges-unconfigured, tx-target-unknown — disables every
+      break-in choice, `unknown` INCLUDED. That over-disable is deliberate
+      (MOR-1296 O2) and must never be "fixed" back to v2's optimism.
+
+      Including "break-in OFF". Unlike RxTxSurface's unkey — which is never
+      gated because it STOPS transmission — `set_break_in 0` is an ordinary
+      setting command, not an emergency stop: this UI holds no key line, and
+      the operator's emergency exit stays the ungated unkey action.
+
+  (3) THE REASON IS RENDERED, NOT SWALLOWED. `validateRadioViewModel` refuses a
+      model that carries a structurally-available `breakIn` under a non-allowed
+      permit with no recorded `disabledReasons` entry, so the explanation always
+      exists — this surface reads it (`out-of-band` / `capability-unavailable` /
+      `tx-target-unknown`) rather than re-deriving it or leaving the operator a
+      dead control with no cause.
+
+  (4) THIS GROUP IS NOT UNIFORMLY "CW". `twinPeak` is an RTTY control living in
+      the CW family for v2 reasons (MOR-1296 O1), and its
+      `mutually-exclusive-control` reason is rendered with RTTY named — as is
+      APF's with CW named. Presenting the block as plain "CW" would leave the
+      operator a permanently-disabled control with no explanation.
+
+  (5) UNKNOWN IS RENDERED AS UNKNOWN. `formatBreakIn` in v2 falls back to 'OFF'
+      for an unrecognised mode; slice 9A degrades it to `unknown` instead,
+      because an unreadable break-in state must never present as "the key is
+      safe". `breakInPosture` therefore groups `unknown` WITH `armed`, never
+      with `off`.
+-->
+<script module lang="ts">
+  import type { BreakInMode, CwKeyerField, DisabledReasonCode } from './radio-view-model';
+
+  /** Break-in as THREE ABSOLUTE choices, `[label, wire mode]`. Absolute, not a
+   *  toggle: a toggle computed from an unread reading arms a guess, and here
+   *  the guess would be about the transmitter. The wire ints are v2's own
+   *  (`cw-panel-logic.ts`'s `BREAK_IN_LABELS`), consumed not reinvented. */
+  export const BREAK_IN_CHOICES = [['off', 0], ['semi', 1], ['full', 2]] as const;
+  /** APF as two ABSOLUTE choices over its ordinal, `[label, on]`. */
+  export const APF_CHOICES = [['off', false], ['on', true]] as const;
+  /** `[field, label, min, max, step, unit]` in the RAW wire units `CwPanel`
+   *  has always used — rescaling here would silently move a setting. */
+  export const CW_LEVELS = [
+    ['keyerSpeed', 'Keyer speed', 6, 48, 1, 'WPM'],
+    ['pitchHz', 'CW pitch', 300, 900, 5, 'Hz'],
+    ['breakInDelay', 'Break-in delay', 0, 255, 1, ''],
+  ] as const;
+  export type CwLevelField = (typeof CW_LEVELS)[number][0];
+  /** The ONE rendering of "not measured". Never 'OFF', never 0. */
+  export const UNKNOWN_TEXT = '—';
+  /** Break-in as the operator must read it. `unknown` is NOT 'off' (rule 5). */
+  export type BreakInPosture = 'off' | 'armed' | 'unknown';
+  export const POSTURE_LABEL: Record<BreakInPosture, string> = {
+    off: 'break-in off — the key does not transmit',
+    armed: 'break-in ARMED — the key transmits',
+    unknown: 'break-in state unknown — assume the key transmits',
+  };
+  /** Why break-in is blocked, in the permit's own vocabulary (rule 3). */
+  export const BREAK_IN_BLOCKED_LABEL: Partial<Record<DisabledReasonCode, string>> = {
+    'out-of-band': 'TX not permitted: frequency outside the configured TX ranges',
+    'capability-unavailable': 'TX not permitted: TX ranges are not configured',
+    'tx-target-unknown': 'TX not permitted: the TX target is not observed',
+  };
+  /** Rule 4 — the mutex reason, per field, with the OTHER mode named. The
+   *  `mutually-exclusive-control` code is generic by design (MOR-1293), so the
+   *  words have to come from here. */
+  export const MUTEX_LABEL = {
+    apf: 'audio peak filter works only in CW / CW-R',
+    twinPeak: 'twin-peak filter is an RTTY control — works only in RTTY / RTTY-R',
+  } as const;
+
+  /** Usable ⇔ the radio HAS it, it is readable NOW, and it was actually read. */
+  export const usable = (f: CwKeyerField<unknown>): boolean =>
+    f.availability.structural && f.availability.operational && f.reading.status === 'known';
+  /** Honest text: an unread fact reads as unknown, never as a v2 default. */
+  export const textOf = (f: CwKeyerField<unknown>): string =>
+    f.reading.status !== 'known' ? UNKNOWN_TEXT
+      : typeof f.reading.value === 'boolean' ? (f.reading.value ? 'on' : 'off')
+        : String(f.reading.value);
+  /** Rule 5: only a positively-read `'off'` is `'off'`. */
+  export const breakInPosture = (f: CwKeyerField<BreakInMode>): BreakInPosture =>
+    f.reading.status !== 'known' ? 'unknown' : f.reading.value === 'off' ? 'off' : 'armed';
+</script>
+
+<script lang="ts">
+  import type { RadioViewModel } from './radio-view-model';
+
+  interface Props {
+    view: RadioViewModel;
+    onBreakInMode?: (mode: number) => void;
+    onLevelChange?: (field: CwLevelField, value: number) => void;
+    onApfOn?: (on: boolean) => void;
+    onTwinPeakToggle?: () => void;
+    onReversePaddleToggle?: () => void;
+  }
+  let {
+    view, onBreakInMode, onLevelChange, onApfOn, onTwinPeakToggle, onReversePaddleToggle,
+  }: Props = $props();
+
+  /** Absent group ⇒ this surface renders nothing (S0 optional-group doctrine). */
+  let cw = $derived(view.cwKeyer);
+  /** Rule 2. The model's ONE permit, READ. No second derivation exists here —
+   *  `getFrequencyPermit`, `txBands` and `band` are not imported at all. */
+  let permitAllowed = $derived(view.txPermit.status === 'allowed');
+  /** Rule 3. Guaranteed present by the validator whenever break-in is blocked. */
+  let breakInReason = $derived(
+    view.disabledReasons.find((r) => r.field === 'cwKeyer.breakIn')?.code,
+  );
+  const mutexed = (field: 'apf' | 'twinPeak'): boolean =>
+    view.disabledReasons.some((r) => r.field === `cwKeyer.${field}`);
+
+  /** The handler half of every gate. `disabled` alone is not enough: a design
+   *  language may restyle these controls, and a programmatic click must not
+   *  set what the widget refused. */
+  function setBreakIn(mode: number): void {
+    if (cw && usable(cw.breakIn) && permitAllowed) onBreakInMode?.(mode);
+  }
+  function setLevel(field: CwLevelField, value: number): void {
+    if (cw && usable(cw[field])) onLevelChange?.(field, value);
+  }
+  function setApf(on: boolean): void {
+    if (cw && usable(cw.apf) && !mutexed('apf')) onApfOn?.(on);
+  }
+  function toggleTwinPeak(): void {
+    if (cw && usable(cw.twinPeak) && !mutexed('twinPeak')) onTwinPeakToggle?.();
+  }
+  function toggleReversePaddle(): void {
+    if (cw && usable(cw.reversePaddle)) onReversePaddleToggle?.();
+  }
+</script>
+
+{#if cw}
+  <!-- Rule 4: named for what it actually holds, not "CW". -->
+  <section
+    class="cw-keyer-surface" data-testid="cw-keyer-surface"
+    aria-label="CW keyer and audio peak filters"
+  >
+    {#if cw.breakIn.availability.structural}
+      <div
+        class="cw-keyer-row" role="radiogroup" aria-label="Break-in"
+        data-testid="cw-keyer-break-in"
+        data-posture={breakInPosture(cw.breakIn)}
+        data-permitted={permitAllowed}
+      >
+        {#each BREAK_IN_CHOICES as [label, mode] (mode)}
+          <button
+            type="button" role="radio" class="cw-keyer-choice"
+            data-testid={`cw-keyer-break-in-${label}`}
+            aria-checked={cw.breakIn.reading.status === 'known'
+              && cw.breakIn.reading.value === label}
+            disabled={!usable(cw.breakIn) || !permitAllowed}
+            onclick={() => setBreakIn(mode)}
+          >{label}</button>
+        {/each}
+        <!-- Rule 5: the posture is TEXT, so it survives forced-colors and so
+             "armed but not permitted" reads differently from "off and not
+             permitted" — the operator's radio can still key from its own
+             paddle while this UI refuses to change the setting. -->
+        <output data-testid="cw-keyer-posture">{POSTURE_LABEL[breakInPosture(cw.breakIn)]}</output>
+        {#if !permitAllowed && breakInReason}
+          <output data-testid="cw-keyer-break-in-blocked" data-reason={breakInReason}
+          >{BREAK_IN_BLOCKED_LABEL[breakInReason]}</output>
+        {/if}
+      </div>
+    {/if}
+
+    {#each CW_LEVELS as [field, label, min, max, step, unit] (field)}
+      {@const f = cw[field]}
+      {#if f.availability.structural}
+        <label class="cw-keyer-level" data-testid={`cw-keyer-${field}`} data-observed={usable(f)}>
+          <span class="cw-keyer-name">{label}</span>
+          <input
+            type="range" {min} {max} {step}
+            value={f.reading.status === 'known' ? f.reading.value : min}
+            disabled={!usable(f)}
+            oninput={(event) => setLevel(field, event.currentTarget.valueAsNumber)}
+          />
+          <output data-testid={`cw-keyer-${field}-value`}>{textOf(f)} {unit}</output>
+        </label>
+      {/if}
+    {/each}
+
+    {#if cw.reversePaddle.availability.structural}
+      <button
+        type="button" class="cw-keyer-toggle" data-testid="cw-keyer-reverse-paddle"
+        aria-pressed={cw.reversePaddle.reading.status === 'known'
+          ? cw.reversePaddle.reading.value : undefined}
+        disabled={!usable(cw.reversePaddle)}
+        onclick={toggleReversePaddle}
+      >Reverse paddle: {textOf(cw.reversePaddle)}</button>
+    {/if}
+
+    {#if cw.apf.availability.structural}
+      <!-- `apf` is an ORDINAL (0 = off, >0 = a filter type this contract does
+           not enumerate). The two choices below are ABSOLUTE on/off over that
+           ordinal and the ordinal itself is shown verbatim; "which type" would
+           need an `apfOn`/`apfType` fact that slice 9A deliberately did not
+           promote (MOR-1296 open question 2) — flagged, not guessed. -->
+      <div
+        class="cw-keyer-row" role="radiogroup" aria-label="Audio peak filter"
+        data-testid="cw-keyer-apf" data-observed={usable(cw.apf)}
+      >
+        {#each APF_CHOICES as [label, on] (label)}
+          <button
+            type="button" role="radio" class="cw-keyer-choice"
+            data-testid={`cw-keyer-apf-${label}`}
+            aria-checked={cw.apf.reading.status === 'known'
+              && (cw.apf.reading.value > 0) === on}
+            disabled={!usable(cw.apf) || mutexed('apf')}
+            onclick={() => setApf(on)}
+          >APF {label}</button>
+        {/each}
+        <output data-testid="cw-keyer-apf-value">{textOf(cw.apf)}</output>
+        {#if mutexed('apf')}
+          <output data-testid="cw-keyer-apf-mutex" data-reason="mutually-exclusive-control"
+          >{MUTEX_LABEL.apf}</output>
+        {/if}
+      </div>
+    {/if}
+
+    {#if cw.twinPeak.availability.structural}
+      <div class="cw-keyer-row" data-testid="cw-keyer-twin-peak" data-observed={usable(cw.twinPeak)}>
+        <button
+          type="button" class="cw-keyer-toggle" data-testid="cw-keyer-twin-peak-toggle"
+          aria-pressed={cw.twinPeak.reading.status === 'known' ? cw.twinPeak.reading.value : undefined}
+          disabled={!usable(cw.twinPeak) || mutexed('twinPeak')}
+          onclick={toggleTwinPeak}
+        >TPF: {textOf(cw.twinPeak)}</button>
+        {#if mutexed('twinPeak')}
+          <!-- Rule 4: RTTY is named, so a permanently-disabled control in a
+               block the operator reads as "CW" is never unexplained. -->
+          <output data-testid="cw-keyer-twin-peak-mutex" data-reason="mutually-exclusive-control"
+          >{MUTEX_LABEL.twinPeak}</output>
+        {/if}
+      </div>
+    {/if}
+
+    {#if view.txAux}
+      <!-- Sidetone level IS `txAux.monitorLevel` (MOR-1296 §4): read there,
+           never duplicated as a second fact and never given a second control —
+           the one control lives in `TxAuxSurface`. Readout only. -->
+      <p class="cw-keyer-row" data-testid="cw-keyer-sidetone" data-observed={usable(view.txAux.monitorLevel)}>
+        Sidetone level: {textOf(view.txAux.monitorLevel)}
+      </p>
+    {/if}
+  </section>
+{/if}
+
+<style>
+  /* Structure only — a design language owns colour and must never become the
+     sole state channel (MOR-977, forced-colors). Nothing here animates. */
+  .cw-keyer-surface { display: flex; flex-direction: column; gap: 0.25rem; }
+  .cw-keyer-row { display: flex; flex-wrap: wrap; align-items: baseline; gap: 0.5rem; margin: 0; }
+  .cw-keyer-level { display: flex; align-items: baseline; gap: 0.5rem; }
+  .cw-keyer-name { min-width: 12ch; }
+  .cw-keyer-choice[aria-checked='true'], .cw-keyer-toggle[aria-pressed='true'] { font-weight: 700; }
+  /* Second channel beside the unknown TEXT, never the only one. */
+  [data-observed='false'] { font-style: italic; }
+  button:disabled, input:disabled { cursor: not-allowed; }
+</style>

--- a/frontend/src/semantic/__tests__/CwKeyerSurface.test.ts
+++ b/frontend/src/semantic/__tests__/CwKeyerSurface.test.ts
@@ -1,0 +1,566 @@
+/**
+ * MOR-1310 — the semantic CW-keyer surface (vocabulary slice 9B).
+ *
+ * SAFETY-CRITICAL. Break-in KEYS THE TRANSMITTER, so every test below names
+ * the mutation it kills:
+ *   (a) the surface becoming a second key path — it must emit SETTING intents
+ *       only, and never a key/unkey or a transmit-causing action
+ *       (`cw_auto_tune`), exactly one `<RxTxSurface>` stays the authority
+ *       (MOR-1262 decomposition R9);
+ *   (b) break-in enabled under a permit that is not positively `'allowed'` —
+ *       `denied` AND `unknown`, each pinned independently, on the widget AND
+ *       in the handler (a `.click()` on a disabled button is a no-op, so the
+ *       `disabled` assertion alone is vacuous — MOR-1304 F3);
+ *   (c) a second permit derivation appearing in the CW path (MOR-1296 §2);
+ *   (d) the `twinPeak` mutex rendered without naming RTTY, leaving the
+ *       operator a permanently-disabled control in a block they read as "CW"
+ *       (MOR-1296 O1);
+ *   (e) an unread break-in state presented as "off" — v2's `formatBreakIn`
+ *       falls back to 'OFF' and slice 9A degraded it to `unknown` precisely so
+ *       an unreadable keyer never reads as "the key is safe".
+ *
+ * Fast-pool-safe by construction (MOR-1272): no `vi.mock`, no `vi.stubGlobal`,
+ * no global spy. The command-bus / no-key-path behavioural pins against the
+ * REAL module live in `components-v2/wiring/__tests__/
+ * semantic-cw-keyer-wiring.component.test.ts`.
+ */
+import { readFileSync } from 'node:fs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import CwKeyerSurface, {
+  APF_CHOICES, BREAK_IN_BLOCKED_LABEL, BREAK_IN_CHOICES, CW_LEVELS, MUTEX_LABEL, POSTURE_LABEL,
+  UNKNOWN_TEXT, breakInPosture, type CwLevelField,
+} from '../CwKeyerSurface.svelte';
+import { topologyFixtures, withCwKeyer, withTxAux } from '../fixtures/topologies';
+import type {
+  Availability, BreakInMode, CwKeyerField, CwKeyerViewModel, DisabledReason, RadioViewModel,
+} from '../radio-view-model';
+
+const SOURCE = readFileSync('src/semantic/CwKeyerSurface.svelte', 'utf8');
+/** Comments stripped, so the file's own doctrine prose can never be what a
+ *  source-scanning test matches. */
+const CODE = SOURCE
+  .replace(/<!--[\s\S]*?-->/g, '')
+  .replace(/\/\*[\s\S]*?\*\//g, '')
+  .replace(/^\s*\/\/.*$/gm, '');
+
+const ON: Availability = { structural: true, operational: true };
+const OFF: Availability = { structural: false, operational: false };
+const DEGRADED: Availability = { structural: true, operational: false };
+
+/** `1/single` carries an `allowed` permit — the only fixture whose break-in is
+ *  legitimately live, which is what most of the non-permit tests need. */
+const base = (): RadioViewModel => withCwKeyer(topologyFixtures['1/single']);
+const withCw = (
+  over: Partial<CwKeyerViewModel>, view: RadioViewModel = base(),
+): RadioViewModel => ({ ...view, cwKeyer: { ...view.cwKeyer!, ...over } });
+const unread = <T>(availability: Availability = ON): CwKeyerField<T> =>
+  ({ reading: { status: 'unknown' }, availability });
+const known = <T>(value: T, availability: Availability = ON): CwKeyerField<T> =>
+  ({ reading: { status: 'known', value }, availability });
+const withReasons = (view: RadioViewModel, ...extra: DisabledReason[]): RadioViewModel =>
+  ({ ...view, disabledReasons: [...view.disabledReasons, ...extra] });
+
+let target: HTMLDivElement;
+beforeEach(() => { target = document.createElement('div'); document.body.appendChild(target); });
+afterEach(() => { target.remove(); });
+
+type Handlers = {
+  onBreakInMode?: (mode: number) => void;
+  onLevelChange?: (field: CwLevelField, value: number) => void;
+  onApfOn?: (on: boolean) => void;
+  onTwinPeakToggle?: () => void;
+  onReversePaddleToggle?: () => void;
+};
+
+function render(view: RadioViewModel, handlers: Handlers = {}) {
+  const component = mount(CwKeyerSurface, { target, props: { view, ...handlers } });
+  flushSync();
+  const q = <T extends HTMLElement>(sel: string) => target.querySelector(sel) as T | null;
+  return {
+    dispose: () => unmount(component),
+    root: () => q('[data-testid="cw-keyer-surface"]'),
+    el: (id: string) => q<HTMLElement>(`[data-testid="cw-keyer-${id}"]`),
+    input: (id: string) => q<HTMLInputElement>(`[data-testid="cw-keyer-${id}"] input`),
+    text: (id: string) => q<HTMLElement>(`[data-testid="cw-keyer-${id}"]`)?.textContent?.trim(),
+    /** Every focusable control the surface renders, whatever its state. */
+    controls: () => [...target.querySelectorAll<HTMLElement>('button, input, select, [tabindex]')],
+  };
+}
+
+/** A real click, not `.click()`: `.click()` is a no-op on a disabled button, so
+ *  it can never tell a `disabled` attribute apart from a handler guard. */
+const press = (el: HTMLElement) => el.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+const slide = (el: HTMLInputElement, value: number) => {
+  el.value = String(value);
+  el.dispatchEvent(new Event('input', { bubbles: true }));
+};
+
+/* ── (a) the surface is not a key path ────────────────────────── */
+
+describe('the CW-keyer surface is NOT a key path (decomposition R9)', () => {
+  /** The whole static import closure of the file, allow-listed. Kills: adding
+   *  ANY import that could reach the TX controller, the transport or the
+   *  permit utility — including through a relative specifier. */
+  it('imports nothing but the fact contract', () => {
+    const specifiers = [...CODE.matchAll(/from\s+'([^']+)'/g)].map((m) => m[1]);
+    expect(specifiers.length).toBeGreaterThan(0);
+    expect([...new Set(specifiers)]).toEqual(['./radio-view-model']);
+  });
+
+  // Kills: `onMount(() => …)` and every relative of it, plus a dynamic import
+  // used to smuggle in the controller.
+  it('declares no lifecycle hook and no effect', () => {
+    for (const forbidden of ['onMount', 'onDestroy', '$effect', 'import(']) {
+      expect(CODE).not.toContain(forbidden);
+    }
+  });
+
+  // Kills: (a) a key path, (c) a second permit derivation. Neither the key
+  // vocabulary nor the permit machinery may appear anywhere in this file.
+  it('never mentions keying, PTT, the TX controller or a permit derivation', () => {
+    for (const forbidden of [
+      'ptt', 'Ptt', 'PTT', 'requestKey', 'onRequestKey', 'onRequestUnkey', 'tx-controller',
+      'TxAuthoritySnapshot', 'keyBlockedReasons', 'getFrequencyPermit', 'txBands', 'auto_tune',
+      'onAutoTune', 'AutoTune', 'sendCommand', '$lib/transport', '$lib/utils/tx-permit',
+    ]) {
+      expect(CODE).not.toContain(forbidden);
+    }
+  });
+
+  // Kills: the surface growing an authority prop or a key intent. The props
+  // list is the structural statement that this cannot key.
+  it('takes exactly one state prop — the view model — plus SETTING intents', () => {
+    const props = CODE.slice(CODE.indexOf('interface Props'), CODE.indexOf('}: Props'));
+    expect([...props.matchAll(/^\s{4}(\w+)[?]?:/gm)].map((m) => m[1])).toEqual([
+      'view', 'onBreakInMode', 'onLevelChange', 'onApfOn', 'onTwinPeakToggle',
+      'onReversePaddleToggle',
+    ]);
+  });
+
+  // Kills: adding an AUTO TUNE affordance. `cw_auto_tune` is transmit-causing;
+  // the MOR-1244 ATU-TUNE precedent is state carried, control never.
+  it('renders no AUTO TUNE control', () => {
+    const r = render(base());
+    expect(r.root()!.textContent!.toUpperCase()).not.toContain('TUNE');
+    r.dispose();
+  });
+
+  // Kills: rendering an empty CW panel for a radio with no keyer.
+  it('renders NOTHING at all when the view model carries no cwKeyer group', () => {
+    const view = { ...base() };
+    delete (view as { cwKeyer?: unknown }).cwKeyer;
+    const r = render(view);
+    expect(r.root()).toBeNull();
+    expect(target.textContent).toBe('');
+    r.dispose();
+  });
+
+  /**
+   * The FULLY-ARMED sweep: break-in structurally available, permit `allowed`,
+   * every fact observed, every control enabled — then every control on the
+   * surface is interacted with. Only the five declared SETTING intents may
+   * fire, and each carries a setting payload. Kills: wiring a key intent onto
+   * any control (it would have to arrive as a sixth channel, or as a call on a
+   * handler this surface is not allowed to have).
+   */
+  it('emits ONLY setting intents when every control is exercised fully armed', () => {
+    const seen: string[] = [];
+    const r = render(withCw({ breakIn: known<BreakInMode>('full') }, withTxAux(base())), {
+      onBreakInMode: (m) => seen.push(`breakIn:${m}`),
+      onLevelChange: (f, v) => seen.push(`level:${f}:${v}`),
+      onApfOn: (on) => seen.push(`apf:${on}`),
+      onTwinPeakToggle: () => seen.push('twinPeak'),
+      onReversePaddleToggle: () => seen.push('reversePaddle'),
+    });
+    const controls = r.controls();
+    expect(controls.length).toBeGreaterThan(0);
+    for (const control of controls) {
+      if (control instanceof HTMLInputElement) slide(control, Number(control.max));
+      else press(control);
+    }
+    flushSync();
+    expect(seen).toEqual([
+      'breakIn:0', 'breakIn:1', 'breakIn:2',
+      'level:keyerSpeed:48', 'level:pitchHz:900', 'level:breakInDelay:255',
+      'reversePaddle', 'apf:false', 'apf:true', 'twinPeak',
+    ]);
+    r.dispose();
+  });
+});
+
+/* ── (b) the break-in permit gate, fail-closed ─────────────────── */
+
+describe('break-in obeys the ONE txPermit and fails closed', () => {
+  it('enables the break-in choices under a positively allowed permit', () => {
+    const r = render(base());
+    for (const [label] of BREAK_IN_CHOICES) {
+      expect(r.el(`break-in-${label}`)!.hasAttribute('disabled')).toBe(false);
+    }
+    expect(r.el('break-in')!.dataset.permitted).toBe('true');
+    expect(r.el('break-in-blocked')).toBeNull();
+    r.dispose();
+  });
+
+  // Kills: enabling break-in under a DENIED permit. `2/ab_shared`'s permit is
+  // `denied`; `withCwKeyer` records the matching reason, as the validator
+  // requires.
+  it.each(BREAK_IN_CHOICES)('disables the %s choice under a denied permit', (label) => {
+    const r = render(withCwKeyer(topologyFixtures['2/ab_shared']));
+    expect(r.el(`break-in-${label}`)!.hasAttribute('disabled')).toBe(true);
+    r.dispose();
+  });
+
+  /**
+   * Kills: enabling break-in under an UNKNOWN permit — the deliberate
+   * over-disable of MOR-1296 O2, and the single most likely "fix" a future
+   * reader would apply. Pinned INDEPENDENTLY of the denied case: `unknown` is
+   * not `denied`, and a `status === 'denied'` gate would pass the test above
+   * while failing this one.
+   */
+  it.each(BREAK_IN_CHOICES)('disables the %s choice under an UNKNOWN permit', (label) => {
+    const r = render(withCwKeyer(topologyFixtures['1/ab']));
+    expect(r.el(`break-in-${label}`)!.hasAttribute('disabled')).toBe(true);
+    r.dispose();
+  });
+
+  /**
+   * The handler half, for BOTH non-allowed permits, dispatched as a real
+   * bubbling click rather than `.click()`. Kills: dropping the `permitAllowed`
+   * conjunct from `setBreakIn` — which the `disabled` assertions above cannot
+   * see, because jsdom fires nothing on a disabled button (MOR-1304 F3).
+   */
+  it.each([
+    ['denied', '2/ab_shared'], ['unknown', '1/ab'],
+  ] as const)('emits no break-in intent under a %s permit, even bypassing disabled', (_s, key) => {
+    const onBreakInMode = vi.fn();
+    const r = render(withCwKeyer(topologyFixtures[key]), { onBreakInMode });
+    for (const [label] of BREAK_IN_CHOICES) press(r.el(`break-in-${label}`)!);
+    flushSync();
+    expect(onBreakInMode).not.toHaveBeenCalled();
+    r.dispose();
+  });
+
+  // Kills: swallowing the recorded reason and leaving a dead control with no
+  // cause. The validator guarantees the entry exists (MOR-1296 §3), so the
+  // surface only has to render it — and it must render the RIGHT one.
+  it.each([
+    ['2/ab_shared', 'out-of-band'], ['1/ab', 'tx-target-unknown'],
+  ] as const)('renders the recorded reason for %s', (key, code) => {
+    const view = withCwKeyer(topologyFixtures[key]);
+    const r = render({
+      ...view,
+      disabledReasons: view.disabledReasons.map(
+        (reason) => (reason.field === 'cwKeyer.breakIn' ? { field: reason.field, code } : reason),
+      ),
+    });
+    const blocked = r.el('break-in-blocked')!;
+    expect(blocked).not.toBeNull();
+    expect(blocked.dataset.reason).toBe(code);
+    expect(blocked.textContent!.trim()).toBe(BREAK_IN_BLOCKED_LABEL[code]);
+    r.dispose();
+  });
+
+  // Kills: a label map that drifts from the three codes the adapter can emit
+  // for this field (`deriveCwKeyerReasons`).
+  it('has a label for each of the three codes the CW break-in gate can record', () => {
+    expect(Object.keys(BREAK_IN_BLOCKED_LABEL).sort())
+      .toEqual(['capability-unavailable', 'out-of-band', 'tx-target-unknown']);
+  });
+
+  // Kills: a radio with no break-in capability growing the control anyway.
+  it('renders no break-in block at all when break-in is structurally absent', () => {
+    const r = render(withCw({ breakIn: unread<BreakInMode>(OFF) }));
+    expect(r.el('break-in')).toBeNull();
+    r.dispose();
+  });
+
+  // Kills: acting on an unread break-in reading even while the permit allows.
+  it('disables and refuses break-in while its own reading is unobserved', () => {
+    const onBreakInMode = vi.fn();
+    const r = render(withCw({ breakIn: unread<BreakInMode>(DEGRADED) }), { onBreakInMode });
+    for (const [label] of BREAK_IN_CHOICES) {
+      expect(r.el(`break-in-${label}`)!.hasAttribute('disabled')).toBe(true);
+      press(r.el(`break-in-${label}`)!);
+    }
+    flushSync();
+    expect(onBreakInMode).not.toHaveBeenCalled();
+    r.dispose();
+  });
+
+  it.each(BREAK_IN_CHOICES)('emits the absolute %s intent when permitted', (label, mode) => {
+    const onBreakInMode = vi.fn();
+    const r = render(base(), { onBreakInMode });
+    press(r.el(`break-in-${label}`)!);
+    flushSync();
+    expect(onBreakInMode).toHaveBeenCalledExactlyOnceWith(mode);
+    r.dispose();
+  });
+
+  it.each(BREAK_IN_CHOICES)('checks exactly the observed break-in mode %s', (label) => {
+    const r = render(withCw({ breakIn: known<BreakInMode>(label) }));
+    for (const [other] of BREAK_IN_CHOICES) {
+      expect(r.el(`break-in-${other}`)!.getAttribute('aria-checked')).toBe(String(other === label));
+    }
+    r.dispose();
+  });
+});
+
+/* ── (e) armed-vs-off is a rendered distinction, unknown fails closed ── */
+
+describe('break-in POSTURE distinguishes armed from off, and unknown from both', () => {
+  // The explicit MOR-1296 open-question-5 decision, made here: "armed but not
+  // permitted" reads differently from "off and not permitted", because the
+  // radio's own paddle can still key an armed keyer while this UI refuses to
+  // change the setting.
+  it.each([
+    ['off', 'off'], ['semi', 'armed'], ['full', 'armed'],
+  ] as const)('reads a %s break-in as posture %s', (value, posture) => {
+    expect(breakInPosture(known<BreakInMode>(value))).toBe(posture);
+    const r = render(withCw({ breakIn: known<BreakInMode>(value) }));
+    expect(r.el('break-in')!.dataset.posture).toBe(posture);
+    expect(r.text('posture')).toBe(POSTURE_LABEL[posture]);
+    r.dispose();
+  });
+
+  // Kills: v2's `formatBreakIn` fallback to 'OFF'. An unreadable keyer must
+  // never present as "the key is safe".
+  it('reads an UNOBSERVED break-in as unknown, never as off', () => {
+    expect(breakInPosture(unread<BreakInMode>(DEGRADED))).toBe('unknown');
+    const r = render(withCw({ breakIn: unread<BreakInMode>(DEGRADED) }));
+    expect(r.el('break-in')!.dataset.posture).toBe('unknown');
+    expect(r.text('posture')).toBe(POSTURE_LABEL.unknown);
+    expect(r.text('posture')).not.toContain('off');
+    r.dispose();
+  });
+
+  // Kills: a posture whose only channel is an attribute (forced-colors,
+  // MOR-977), and a wording that does not say what the key will DO.
+  it.each(['off', 'armed', 'unknown'] as const)('says in TEXT what %s means for the key', (p) => {
+    expect(POSTURE_LABEL[p]).toMatch(/key/);
+  });
+
+  // The two "not permitted" states are visibly different, which is the whole
+  // point of the decision above.
+  it('renders armed-and-not-permitted differently from off-and-not-permitted', () => {
+    const denied = withCwKeyer(topologyFixtures['2/ab_shared']);
+    const armed = render(withCw({ breakIn: known<BreakInMode>('semi') }, denied));
+    const armedText = armed.el('break-in')!.textContent;
+    armed.dispose();
+    const idle = render(withCw({ breakIn: known<BreakInMode>('off') }, denied));
+    expect(idle.el('break-in')!.textContent).not.toBe(armedText);
+    expect(armedText).toContain('ARMED');
+    idle.dispose();
+  });
+});
+
+/* ── (d) the group is not uniformly "CW" ──────────────────────── */
+
+describe('the mutex reasons are rendered with the other mode NAMED (MOR-1296 O1)', () => {
+  // Kills: labelling the block "CW". `twinPeak` is an RTTY control living here
+  // for v2-family reasons; a block called "CW" makes it inexplicable.
+  it('does not present the group as uniformly CW', () => {
+    const r = render(base());
+    expect(r.root()!.getAttribute('aria-label')).toBe('CW keyer and audio peak filters');
+    r.dispose();
+  });
+
+  // Kills: rendering the generic `mutually-exclusive-control` code with no
+  // words, leaving a permanently-disabled TPF button unexplained.
+  it('disables TPF and names RTTY when the mutex reason is recorded', () => {
+    const onTwinPeakToggle = vi.fn();
+    const r = render(
+      withReasons(base(), { field: 'cwKeyer.twinPeak', code: 'mutually-exclusive-control' }),
+      { onTwinPeakToggle },
+    );
+    const button = r.el('twin-peak-toggle')!;
+    expect(button.hasAttribute('disabled')).toBe(true);
+    expect(r.text('twin-peak-mutex')).toBe(MUTEX_LABEL.twinPeak);
+    expect(r.text('twin-peak-mutex')).toContain('RTTY');
+    press(button);
+    flushSync();
+    expect(onTwinPeakToggle).not.toHaveBeenCalled();
+    r.dispose();
+  });
+
+  // Same for APF, whose mutex names CW/CW-R.
+  it('disables APF and names CW when the mutex reason is recorded', () => {
+    const onApfOn = vi.fn();
+    const r = render(
+      withReasons(base(), { field: 'cwKeyer.apf', code: 'mutually-exclusive-control' }),
+      { onApfOn },
+    );
+    for (const [label] of APF_CHOICES) {
+      expect(r.el(`apf-${label}`)!.hasAttribute('disabled')).toBe(true);
+      press(r.el(`apf-${label}`)!);
+    }
+    flushSync();
+    expect(onApfOn).not.toHaveBeenCalled();
+    expect(r.text('apf-mutex')).toBe(MUTEX_LABEL.apf);
+    expect(r.text('apf-mutex')).toContain('CW');
+    r.dispose();
+  });
+
+  // Kills: a mutex lookup that matches the WRONG field — the entries are
+  // dotted paths (MOR-1293 O1) and APF's must not disable TPF or vice versa.
+  it('keeps the other control live when only one mutex reason is recorded', () => {
+    const r = render(
+      withReasons(base(), { field: 'cwKeyer.apf', code: 'mutually-exclusive-control' }),
+    );
+    expect(r.el('twin-peak-toggle')!.hasAttribute('disabled')).toBe(false);
+    expect(r.el('twin-peak-mutex')).toBeNull();
+    r.dispose();
+  });
+
+  it('shows no mutex explanation while neither reason is recorded', () => {
+    const r = render(base());
+    expect(r.el('apf-mutex')).toBeNull();
+    expect(r.el('twin-peak-mutex')).toBeNull();
+    r.dispose();
+  });
+});
+
+/* ── facts render honestly ─────────────────────────────────────── */
+
+describe('every unread fact renders honestly, never as a v2 default', () => {
+  it.each(CW_LEVELS)('renders the %s fact verbatim on its raw wire scale', (field, _l, min, max) => {
+    const r = render(withCw({ [field]: known(max) } as Partial<CwKeyerViewModel>));
+    expect(r.input(field)!.valueAsNumber).toBe(max);
+    expect([r.input(field)!.min, r.input(field)!.max]).toEqual([String(min), String(max)]);
+    r.dispose();
+  });
+
+  // Kills: an unread level rendering as a number, and a thumb free to claim
+  // any position (the MOR-1279 F1 / MOR-1304 F2 precedent).
+  it.each(CW_LEVELS)('renders an unread %s as unknown and parks the thumb at min', (field, _l, min) => {
+    const onLevelChange = vi.fn();
+    const r = render(
+      withCw({ [field]: unread<number>() } as Partial<CwKeyerViewModel>), { onLevelChange },
+    );
+    expect(r.text(`${field}-value`)).toContain(UNKNOWN_TEXT);
+    expect(r.el(field)!.dataset.observed).toBe('false');
+    expect(r.input(field)!.disabled).toBe(true);
+    expect(r.input(field)!.valueAsNumber).toBe(min);
+    slide(r.input(field)!, min + 1);
+    flushSync();
+    expect(onLevelChange).not.toHaveBeenCalled();
+    r.dispose();
+  });
+
+  it.each(CW_LEVELS)('emits the %s intent verbatim when observed', (field, _l, _min, max) => {
+    const onLevelChange = vi.fn();
+    const r = render(base(), { onLevelChange });
+    slide(r.input(field)!, max);
+    flushSync();
+    expect(onLevelChange).toHaveBeenCalledExactlyOnceWith(field, max);
+    r.dispose();
+  });
+
+  it.each(CW_LEVELS)('renders no %s block when it is structurally absent', (field) => {
+    const r = render(withCw({ [field]: unread(OFF) } as Partial<CwKeyerViewModel>));
+    expect(r.el(field)).toBeNull();
+    r.dispose();
+  });
+
+  // Kills: `?? 0` on the APF ordinal, and a hardcoded APF domain. The contract
+  // states an ordinal; the surface shows it verbatim and offers absolute
+  // on/off over it (an `apfOn`/`apfType` fact is a deferred 9A question).
+  it('renders the APF ordinal verbatim and checks on for any non-zero type', () => {
+    for (const [value, expected] of [[0, 'off'], [1, 'on'], [3, 'on']] as const) {
+      const r = render(withCw({ apf: known(value) }));
+      expect(r.text('apf-value')).toBe(String(value));
+      for (const [label] of APF_CHOICES) {
+        expect(r.el(`apf-${label}`)!.getAttribute('aria-checked')).toBe(String(label === expected));
+      }
+      r.dispose();
+    }
+  });
+
+  it('renders an unread APF ordinal as unknown with nothing checked', () => {
+    const r = render(withCw({ apf: unread<number>(DEGRADED) }));
+    expect(r.text('apf-value')).toBe(UNKNOWN_TEXT);
+    for (const [label] of APF_CHOICES) {
+      expect(r.el(`apf-${label}`)!.getAttribute('aria-checked')).toBe('false');
+    }
+    r.dispose();
+  });
+
+  it.each(APF_CHOICES)('emits the absolute APF %s intent', (label, on) => {
+    const onApfOn = vi.fn();
+    const r = render(base(), { onApfOn });
+    press(r.el(`apf-${label}`)!);
+    flushSync();
+    expect(onApfOn).toHaveBeenCalledExactlyOnceWith(on);
+    r.dispose();
+  });
+
+  it.each([
+    ['apf', 'apf'], ['twinPeak', 'twin-peak'], ['reversePaddle', 'reverse-paddle'],
+  ] as const)('renders no %s block when it is structurally absent', (field, id) => {
+    const r = render(withCw({ [field]: unread(OFF) } as Partial<CwKeyerViewModel>));
+    expect(r.el(id)).toBeNull();
+    r.dispose();
+  });
+
+  it.each([
+    ['twinPeak', 'twin-peak-toggle', 'onTwinPeakToggle'],
+    ['reversePaddle', 'reverse-paddle', 'onReversePaddleToggle'],
+  ] as const)('disables and refuses %s while unobserved', (field, id, handler) => {
+    const spy = vi.fn();
+    const r = render(
+      withCw({ [field]: unread<boolean>(DEGRADED) } as Partial<CwKeyerViewModel>),
+      { [handler]: spy },
+    );
+    expect(r.el(id)!.hasAttribute('disabled')).toBe(true);
+    expect(r.el(id)!.hasAttribute('aria-pressed')).toBe(false);
+    press(r.el(id)!);
+    flushSync();
+    expect(spy).not.toHaveBeenCalled();
+    r.dispose();
+  });
+
+  it('emits the reverse-paddle intent when observed', () => {
+    const onReversePaddleToggle = vi.fn();
+    const r = render(base(), { onReversePaddleToggle });
+    press(r.el('reverse-paddle')!);
+    flushSync();
+    expect(onReversePaddleToggle).toHaveBeenCalledTimes(1);
+    r.dispose();
+  });
+
+  // Kills: an unknown state that is only a colour or an attribute (MOR-977).
+  it('keeps every unknown distinguishable as TEXT', () => {
+    const r = render(withCw({
+      keyerSpeed: unread<number>(), pitchHz: unread<number>(), apf: unread<number>(),
+    }));
+    expect(r.root()!.textContent).toContain(UNKNOWN_TEXT);
+    r.dispose();
+  });
+});
+
+/* ── sidetone level is READ from txAux, never duplicated ───────── */
+
+describe('sidetone level is txAux.monitorLevel — read there, not duplicated (MOR-1296 §4)', () => {
+  // Kills: a second sidetone CONTROL, or a `cwKeyer.sidetoneLevel` fact. The
+  // readout carries no input and no intent; the one control lives in
+  // `TxAuxSurface`.
+  it('shows the txAux monitor level as a READOUT with no control of its own', () => {
+    const r = render(withTxAux(base()));
+    expect(r.text('sidetone')).toBe('Sidetone level: 128');
+    expect(r.el('sidetone')!.querySelector('input, button')).toBeNull();
+    r.dispose();
+  });
+
+  it('shows no sidetone readout at all when the model carries no txAux group', () => {
+    const r = render(base());
+    expect(r.el('sidetone')).toBeNull();
+    r.dispose();
+  });
+
+  // Kills: reintroducing the fact into the CW group.
+  it('the cwKeyer group states no sidetone level of its own', () => {
+    expect(Object.keys(base().cwKeyer!).sort()).toEqual([
+      'apf', 'breakIn', 'breakInDelay', 'keyerSpeed', 'pitchHz', 'reversePaddle', 'twinPeak',
+    ]);
+  });
+});

--- a/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
+++ b/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
@@ -84,6 +84,12 @@ vi.mock('../../../components-v2/wiring/command-bus', () => ({
   }),
   // MOR-1279 slice 3B: the RX-audio intent vocabulary.
   makeRxAudioHandlers: () => ({ onMonitorModeChange: h.txAuxNoop, onAfLevelChange: h.txAuxNoop }),
+  // MOR-1310 slice 9B: the semantic CW-keyer surface's setting intents.
+  makeCwPanelHandlers: () => ({
+    onKeySpeedChange: h.txAuxNoop, onCwPitchChange: h.txAuxNoop, onBreakInDelayChange: h.txAuxNoop,
+    onBreakInModeChange: h.txAuxNoop, onApfChange: h.txAuxNoop, onTwinPeakToggle: h.txAuxNoop,
+    onReversePaddleToggle: h.txAuxNoop,
+  }),
   makeAudioRoutingHandlers: () => ({ onFocusChange: h.txAuxNoop, onSplitStereoChange: h.txAuxNoop }),
   // MOR-1304 — the wiring now also composes the modeFilter/filterPassband
   // intent vocabulary; `makeModeHandlers` is composed at both call sites


### PR DESCRIPTION
## Summary

9B: CwKeyerSurface over the cwKeyer facts (MOR-1296) - the SAFETY-CRITICAL slice: break-in keys the transmitter. Break-in controls are disabled with the recorded reason whenever txPermit is not positively allowed, INCLUDING unknown; the surface is provably not a key path (exactly one RxTxSurface keeps key/unkey authority); no second permit derivation exists or can be added silently (exact-equality import allow-list + comment-stripped token scan); AUTO TUNE stays state-only per the MOR-1244 ATU-TUNE precedent; twinPeak renders its generic RTTY-only mutex reason; sidetone read at txAux.monitorLevel. Unknown break-in reading inherits the ARMED posture as a distinct labeled state - the paddle is wired to the radio, not to this UI.

Production LOC 195 (verifier-measured, frozen formula; cap 200). Rider recorded: 5 lines of headroom - future fixes must not reclaim margin by deleting safety commentary.

## Review provenance

Verified by the vocabulary-domain opus anchor #2 (session 8): PASS with ZERO required code fixes - best-defended slice of the wave. The anchor's extended no-key-path sweep (keyboard/pointer lifecycles, form submit, mid-drag bursts, rapid double-dispatch across 19 controls x 2 mutex modes) found key-class commands = none by regex, txStart/txRelease = 0; two wiring-layer mutants prove the pin bites outside the surface file. No-second-permit verified structurally: permits re-derived from band.currentBandTx and defaultHzTxPermit both die 10 tests each. 6(c) unknown-inherits-armed adjudicated CORRECT (consequence-asymmetric, epistemically honest via distinct data-posture; posture readout deliberately not permit-gated). 15/15 mutation battery. Post-1351: harness exercises the surface - 7 new controls, every one [disabled] under an unobserved TX target (fail-closed doctrine visible in a real browser). Post-verify rebase mechanical (12-name literal across 11 sites, mock sweep, snippet-region hand-reconstruction); no-key-path pin green untouched 66/66; suite 5695/5695.

Follow-up ticketed: MOR-1362 (thumb pin + total label map). cwSpot/apfOn correctly deferred (fact-side tickets when wanted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)