### PR TITLE
feat(MOR-1312): scopeDisplay surface (12B) - vocabulary COMPLETE

### DIFF
--- a/frontend/fixtures/stubs/runtime.ts
+++ b/frontend/fixtures/stubs/runtime.ts
@@ -13,9 +13,25 @@ import { harness } from '../harness-state';
  * (`$lib/stores/audio.svelte.ts`'s initial `audioState`) rather than reading
  * from `harness` — there is nothing yet for a fixture to set.
  */
+/**
+ * MOR-1312 (slice 12B): `SemanticRadioSurfaces` gained a
+ * `runtime.defaultScopeStatus` / `runtime.scope.hardwareScopeConnected` /
+ * `runtime.radioPowerOn` read (`scopeDisplaySnapshot`) — the same class of
+ * gap MOR-1320 fixed for `runtime.audio` above. No fixture varies
+ * scope-runtime state (`fixtures/catalog.ts` has no such override), so these
+ * are fixed, honest "never observed" defaults, not reads from `harness`.
+ */
+const DEFAULT_SCOPE_STATUS = {
+  source: null, available: false, resourceSelected: false, demand: 0,
+  lifecycle: 'inactive' as const, transport: 'disconnected' as const, frameSeen: false,
+};
+
 export const runtime = {
   get state() { return harness.state; },
   get caps() { return harness.caps; },
   get audio() { return { rxEnabled: false, volume: 50, muted: false }; },
   get connectionAudio() { return false; },
+  get defaultScopeStatus() { return DEFAULT_SCOPE_STATUS; },
+  get radioPowerOn() { return null; },
+  get scope() { return { hardwareScopeConnected: false }; },
 };

--- a/frontend/src/__tests__/app-global-host.component.test.ts
+++ b/frontend/src/__tests__/app-global-host.component.test.ts
@@ -50,6 +50,16 @@ vi.mock('$lib/runtime', async () => {
     get caps() { subscribe(); return { tx: true, capabilities: ['tx'] }; },
     get radioPowerOn() { subscribe(); return h.radioPowerOn; },
     get system() { return { powerOn: h.powerOn }; },
+    // MOR-1312 slice 12B (rebase fix): `SemanticRadioSurfaces`'s scope-display
+    // snapshot (the FIFTH adapter argument) reads these two directly; this
+    // fixture declares no scope capability.
+    get defaultScopeStatus() {
+      return {
+        source: null, available: false, resourceSelected: false, demand: 0,
+        lifecycle: 'inactive', transport: 'disconnected', frameSeen: false,
+      };
+    },
+    get scope() { return { hardwareScopeConnected: false }; },
     bootstrap: h.bootstrap,
     setPollingMultiplier: vi.fn(),
   };

--- a/frontend/src/components-v2/layout/__tests__/RadioLayout.isolated.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/RadioLayout.isolated.test.ts
@@ -43,6 +43,14 @@ vi.mock('../../../lib/runtime/frontend-runtime', () => ({
     radioPowerOn: null,
     connection: { status: 'disconnected', radioPowerOn: null },
     audio: { rxEnabled: false, txEnabled: false, volume: 50, muted: false },
+    connectionAudio: false,
+    // MOR-1312 slice 12B: see the `$lib/runtime` mock below for why these
+    // are fixed, honest "never observed" defaults.
+    defaultScopeStatus: {
+      source: null, available: false, resourceSelected: false, demand: 0,
+      lifecycle: 'inactive', transport: 'disconnected', frameSeen: false,
+    },
+    scope: { hardwareScopeConnected: false },
     bootstrap: vi.fn(async () => vi.fn()),
     setPollingMultiplier: vi.fn(),
     send: vi.fn(),
@@ -62,6 +70,17 @@ vi.mock('$lib/runtime', () => ({
     radioPowerOn: null,
     connection: { status: 'disconnected', radioPowerOn: null },
     audio: { rxEnabled: false, txEnabled: false, volume: 50, muted: false },
+    connectionAudio: false,
+    // MOR-1312 slice 12B: `SemanticRadioSurfaces` now also reads
+    // `runtime.defaultScopeStatus` / `runtime.scope.hardwareScopeConnected`
+    // for the scope-display snapshot (the FIFTH adapter argument). `caps` is
+    // `null` here, so `toRadioViewModel` returns `null` regardless — these
+    // are fixed, honest "never observed" defaults, not exercised behavior.
+    defaultScopeStatus: {
+      source: null, available: false, resourceSelected: false, demand: 0,
+      lifecycle: 'inactive', transport: 'disconnected', frameSeen: false,
+    },
+    scope: { hardwareScopeConnected: false },
     send: vi.fn(),
   },
 }));

--- a/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
@@ -33,6 +33,17 @@ const h = vi.hoisted(() => {
       radioPowerOn: null,
       connection: { status: 'disconnected', radioPowerOn: null },
       audio: { rxEnabled: false, txEnabled: false, volume: 50, muted: false },
+      connectionAudio: false,
+      // MOR-1312 slice 12B: `SemanticRadioSurfaces` now also reads
+      // `runtime.defaultScopeStatus` / `runtime.scope.hardwareScopeConnected`
+      // for the scope-display snapshot (the FIFTH adapter argument). No
+      // fixture here declares a scope capability, so this stays on its
+      // pre-1312 path regardless of these fixed defaults.
+      defaultScopeStatus: {
+        source: null, available: false, resourceSelected: false, demand: 0,
+        lifecycle: 'inactive', transport: 'disconnected', frameSeen: false,
+      },
+      scope: { hardwareScopeConnected: false },
       bootstrap: async () => () => {},
       setPollingMultiplier: () => {},
       send: () => {},

--- a/frontend/src/components-v2/layout/__tests__/semantic-lcd-migration.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-lcd-migration.component.test.ts
@@ -68,6 +68,9 @@ const h = vi.hoisted(() => {
     scope: {
       registerPresentationDriver: vi.fn(),
       subscribe: vi.fn(() => () => {}),
+      // MOR-1312 slice 12B: `SemanticRadioSurfaces`'s scope-display snapshot
+      // reads `runtime.scope.hardwareScopeConnected` directly.
+      hardwareScopeConnected: false,
     },
     /**
      * The runtime facade is REACTIVE, not a plain getter box: the MOR-557
@@ -93,6 +96,13 @@ const h = vi.hoisted(() => {
           radioPowerOn: null,
           connection: { status: 'disconnected', radioPowerOn: null },
           audio: { rxEnabled: false, txEnabled: false, volume: 50, muted: false },
+          connectionAudio: false,
+          // MOR-1312 slice 12B: the scope-display snapshot (the FIFTH
+          // adapter argument) — no fixture here declares a scope capability.
+          defaultScopeStatus: {
+            source: null, available: false, resourceSelected: false, demand: 0,
+            lifecycle: 'inactive', transport: 'disconnected', frameSeen: false,
+          },
           bootstrap: async () => () => {},
           setPollingMultiplier: () => {},
           send: () => {},

--- a/frontend/src/components-v2/layout/__tests__/top-row-visual-regression.isolated.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/top-row-visual-regression.isolated.test.ts
@@ -37,6 +37,14 @@ vi.mock('$lib/runtime', () => ({
     radioPowerOn: null,
     connection: { status: 'disconnected', radioPowerOn: null },
     audio: { rxEnabled: false, txEnabled: false, volume: 50, muted: false },
+    // MOR-1312 slice 12B (rebase fix): `SemanticRadioSurfaces`'s scope-display
+    // snapshot (the FIFTH adapter argument) reads these two directly; this
+    // fixture declares no scope capability.
+    defaultScopeStatus: {
+      source: null, available: false, resourceSelected: false, demand: 0,
+      lifecycle: 'inactive', transport: 'disconnected', frameSeen: false,
+    },
+    scope: { hardwareScopeConnected: false },
     send: vi.fn(),
   },
 }));

--- a/frontend/src/components-v2/panels/lcd/__tests__/lcd-availability.isolated.test.ts
+++ b/frontend/src/components-v2/panels/lcd/__tests__/lcd-availability.isolated.test.ts
@@ -30,7 +30,16 @@ vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
 
 vi.mock('$lib/runtime', () => ({
   runtime: {
-    scope: { subscribe: vi.fn(() => vi.fn()) },
+    // MOR-1312 slice 12B (rebase fix): `SemanticRadioSurfaces`'s scope-display
+    // snapshot reads `runtime.scope.hardwareScopeConnected` directly; this
+    // fixture's own `scope` store shape (`subscribe`) is unrelated but shares
+    // the same key. `AmberScope` here does not mount `SemanticRadioSurfaces`,
+    // so this is defensive rather than a live hazard.
+    scope: { subscribe: vi.fn(() => vi.fn()), hardwareScopeConnected: false },
+    defaultScopeStatus: {
+      source: null, available: false, resourceSelected: false, demand: 0,
+      lifecycle: 'inactive', transport: 'disconnected', frameSeen: false,
+    },
   },
 }));
 

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -45,6 +45,7 @@
   import RitXitScanSurface from '../../semantic/RitXitScanSurface.svelte';
   import RxAudioSurface from '../../semantic/RxAudioSurface.svelte';
   import RxTxSurface from '../../semantic/RxTxSurface.svelte';
+  import ScopeDisplaySurface from '../../semantic/ScopeDisplaySurface.svelte';
   import TxAuxSurface, {
     type TxAuxLevelField, type TxAuxToggleField,
   } from '../../semantic/TxAuxSurface.svelte';
@@ -316,14 +317,38 @@
     routing: null,
   });
 
+  /**
+   * MOR-1312 (slice 12B) — the App-owned scope-display snapshot the
+   * `scopeDisplay` facts are read against (MOR-1301's FIFTH adapter
+   * argument). Every member is state this layer already holds — nothing
+   * here opens, starts or probes the scope resource (MOR-972 P0); scope
+   * lifetime stays App-owned (MOR-1058), same discipline `rxAudioSnapshot`
+   * above uses for audio.
+   *
+   * `...runtime.defaultScopeStatus` spreads `source`/`available`/
+   * `resourceSelected`/`demand`/`lifecycle`/`transport`/`frameSeen` verbatim
+   * — the field-name mirroring `ScopeDisplaySnapshot`'s own doc comment
+   * documents. `isPoweredOff` is the status bar's own override input
+   * (`StatusBar.svelte`'s `isPoweredOff`), read from the SAME
+   * `runtime.radioPowerOn` getter rather than re-derived. `hardwareConnected`
+   * is the MOR-1312 addition (MOR-1352 finding) — `runtime.scope`'s own
+   * hardware-transport flag, independent of `source`.
+   */
+  let scopeDisplaySnapshot = $derived({
+    ...runtime.defaultScopeStatus,
+    isPoweredOff: runtime.radioPowerOn === false,
+    hardwareConnected: runtime.scope.hardwareScopeConnected,
+  });
+
   // Belt-and-braces contract pin. The adapter now annotates its own return
   // type (MOR-1065 ruling 2), so this is the second of two compile-time links.
   // MOR-1262 slice 2A: the live authority snapshot is the THIRD argument — the
   // meter facts read their TX relevance from it and never from `state.ptt`
   // (invariant R9). Without it the adapter emits no `meters` group at all.
   // MOR-1279 slice 3B: the RX-audio snapshot is the FOURTH.
+  // MOR-1312 slice 12B: the scope-display snapshot is the FIFTH.
   let view: RadioViewModel | null = $derived(
-    toRadioViewModel(runtime.state, runtime.caps, txState, rxAudioSnapshot),
+    toRadioViewModel(runtime.state, runtime.caps, txState, rxAudioSnapshot, scopeDisplaySnapshot),
   );
 
   // Bound once per instance, never per render — see `surfaceSeq` above.
@@ -887,6 +912,30 @@
     {/if}
   {/snippet}
 
+  <!--
+    MOR-1312 (vocabulary slice 12B — the LAST vocabulary slice). Same
+    structural gate and same reasoning as `txAuxSurface`/`metersSurface`
+    above: the surface mounts only when the view model actually carries the
+    MOR-1301 `scopeDisplay` group, so a radio with neither a hardware scope
+    nor an audio-FFT source renders the pre-1312 element shape exactly.
+    Bare and unzoned in BOTH compositions, the `meters`/`txAux` shape, NOT
+    `rxAudio`'s single-only shape: `ScopeDisplaySurface` renders zero
+    focusable elements (pinned in `__tests__/ScopeDisplaySurface.test.ts` and
+    re-pinned below at the composed-tree level), so it carries none of the
+    MOR-1069 tab-order risk a control-bearing surface would. `'scopeDisplay'`
+    becomes DECLARABLE with this slice, so a manifest gains the surface the
+    moment it declares a zone for it — a layout decision, separately
+    reviewed, exactly as txAux/meters/rxAudio left it.
+
+    It takes NO intent callbacks: a source/health/hardware readout has no
+    action to offer (v3 ADR invariant 11).
+  -->
+  {#snippet scopeDisplaySurface()}
+    {#if view?.scopeDisplay}
+      <ScopeDisplaySurface {view} />
+    {/if}
+  {/snippet}
+
   {#if strips === 'dual'}
     <!--
       MOR-1258: the zone now carries RxTxSurface AND the two TX-adjacent
@@ -910,6 +959,7 @@
     </div>
     {@render zoned('txAux', view?.txAux !== undefined, txAuxSurface)}
     {@render zoned('meters', view?.meters !== undefined, metersSurface)}
+    {@render zoned('scopeDisplay', view?.scopeDisplay !== undefined, scopeDisplaySurface)}
   {:else}
     <!--
       Single/default path (sdr-test / LCD / mobile): no bound zone exists
@@ -939,6 +989,7 @@
       'ritXitScan', view?.ritXit !== undefined || view?.scan !== undefined, ritXitScanSurface,
     )}
     {@render zoned('cwKeyer', view?.cwKeyer !== undefined, cwKeyerSurface)}
+    {@render zoned('scopeDisplay', view?.scopeDisplay !== undefined, scopeDisplaySurface)}
     {@render txAdjacentAlerts()}
   {/if}
 </div>

--- a/frontend/src/components-v2/wiring/__tests__/semantic-antenna-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-antenna-wiring.component.test.ts
@@ -55,6 +55,16 @@ vi.mock('$lib/runtime/frontend-runtime', () => ({
     get connectionAudio() { return h.audioConnected; },
     get rxEnabled() { return true; },
     setVolume: vi.fn(), setMuted: vi.fn(), setRxLive: vi.fn(), setRxVolume: vi.fn(),
+    // MOR-1312 slice 12B (rebase fix): the wiring now also hands the adapter
+    // a scope-display snapshot (the FIFTH argument). This file tests
+    // antenna, so this stays on its pre-1312 path regardless of these values.
+    get defaultScopeStatus() {
+      return {
+        source: null, available: false, resourceSelected: false, demand: 0,
+        lifecycle: 'inactive', transport: 'disconnected', frameSeen: false,
+      };
+    },
+    get scope() { return { hardwareScopeConnected: false }; },
   },
 }));
 vi.mock('$lib/runtime', async () => ({

--- a/frontend/src/components-v2/wiring/__tests__/semantic-band-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-band-wiring.component.test.ts
@@ -57,6 +57,16 @@ vi.mock('$lib/runtime/frontend-runtime', () => ({
     get connectionAudio() { return h.audioConnected; },
     get rxEnabled() { return h.rxEnabled; },
     setVolume: vi.fn(), setMuted: vi.fn(), setRxLive: vi.fn(), setRxVolume: vi.fn(),
+    // MOR-1312 slice 12B (rebase fix): the wiring now also hands the adapter
+    // a scope-display snapshot (the FIFTH argument). This file tests band, so
+    // this stays on its pre-1312 path regardless of these values.
+    get defaultScopeStatus() {
+      return {
+        source: null, available: false, resourceSelected: false, demand: 0,
+        lifecycle: 'inactive', transport: 'disconnected', frameSeen: false,
+      };
+    },
+    get scope() { return { hardwareScopeConnected: false }; },
   },
 }));
 vi.mock('$lib/runtime', async () => ({

--- a/frontend/src/components-v2/wiring/__tests__/semantic-cw-keyer-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-cw-keyer-wiring.component.test.ts
@@ -66,6 +66,16 @@ vi.mock('$lib/runtime/frontend-runtime', () => ({
     get connectionAudio() { return h.audioConnected; },
     get rxEnabled() { return h.rxEnabled; },
     setVolume: vi.fn(), setMuted: vi.fn(), setRxLive: vi.fn(), setRxVolume: vi.fn(),
+    // MOR-1312 slice 12B (rebase fix): the wiring now also hands the adapter
+    // a scope-display snapshot (the FIFTH argument). This file tests
+    // cwKeyer, so this stays on its pre-1312 path regardless of these values.
+    get defaultScopeStatus() {
+      return {
+        source: null, available: false, resourceSelected: false, demand: 0,
+        lifecycle: 'inactive', transport: 'disconnected', frameSeen: false,
+      };
+    },
+    get scope() { return { hardwareScopeConnected: false }; },
   },
 }));
 vi.mock('$lib/runtime', async () => ({

--- a/frontend/src/components-v2/wiring/__tests__/semantic-dsp-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-dsp-wiring.component.test.ts
@@ -51,6 +51,16 @@ vi.mock('$lib/runtime', () => ({
     // keeps every fixture below off the rxAudio path — this file tests dsp.
     get audio() { return { muted: true, rxEnabled: false, volume: 0 }; },
     get connectionAudio() { return false; },
+    // MOR-1312 slice 12B (rebase fix): the wiring now also hands the adapter
+    // a scope-display snapshot (the FIFTH argument). This file tests dsp, so
+    // this stays on its pre-1312 path regardless of these values.
+    get defaultScopeStatus() {
+      return {
+        source: null, available: false, resourceSelected: false, demand: 0,
+        lifecycle: 'inactive', transport: 'disconnected', frameSeen: false,
+      };
+    },
+    get scope() { return { hardwareScopeConnected: false }; },
   },
 }));
 vi.mock('$lib/runtime/tx-controller/app-host', () => ({

--- a/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
@@ -45,6 +45,18 @@ vi.mock('$lib/runtime', () => ({
     // browser stream keeps every fixture below on its pre-1279 path.
     get audio() { return { muted: true, rxEnabled: false, volume: 0 }; },
     get connectionAudio() { return false; },
+    // MOR-1312 slice 12B: the wiring now also hands the adapter a
+    // scope-display snapshot (the FIFTH argument). Every fixture below
+    // declares no scope capability, so this stays on its pre-1312 path
+    // regardless of these values.
+    get defaultScopeStatus() {
+      return {
+        source: null, available: false, resourceSelected: false, demand: 0,
+        lifecycle: 'inactive', transport: 'disconnected', frameSeen: false,
+      };
+    },
+    get radioPowerOn() { return null; },
+    get scope() { return { hardwareScopeConnected: false }; },
   },
 }));
 vi.mock('$lib/runtime/tx-controller/app-host', () => ({

--- a/frontend/src/components-v2/wiring/__tests__/semantic-rf-front-end-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rf-front-end-wiring.component.test.ts
@@ -63,6 +63,17 @@ vi.mock('$lib/runtime', () => ({
     get caps() { return h.caps; },
     get audio() { return { muted: true, rxEnabled: false, volume: 0 }; },
     get connectionAudio() { return false; },
+    // MOR-1312 slice 12B (rebase fix): the wiring now also hands the adapter
+    // a scope-display snapshot (the FIFTH argument). This file tests
+    // rfFrontEnd, so this stays on its pre-1312 path regardless of these
+    // values.
+    get defaultScopeStatus() {
+      return {
+        source: null, available: false, resourceSelected: false, demand: 0,
+        lifecycle: 'inactive', transport: 'disconnected', frameSeen: false,
+      };
+    },
+    get scope() { return { hardwareScopeConnected: false }; },
   },
 }));
 vi.mock('$lib/runtime/tx-controller/app-host', () => ({

--- a/frontend/src/components-v2/wiring/__tests__/semantic-ritxit-scan-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-ritxit-scan-wiring.component.test.ts
@@ -49,6 +49,17 @@ vi.mock('$lib/runtime', () => ({
     get caps() { return h.caps; },
     get audio() { return h.audio; },
     get connectionAudio() { return h.audioConnected; },
+    // MOR-1312 slice 12B (rebase fix): the wiring now also hands the adapter
+    // a scope-display snapshot (the FIFTH argument). This file tests
+    // ritXit/scan, so this stays on its pre-1312 path regardless of these
+    // values.
+    get defaultScopeStatus() {
+      return {
+        source: null, available: false, resourceSelected: false, demand: 0,
+        lifecycle: 'inactive', transport: 'disconnected', frameSeen: false,
+      };
+    },
+    get scope() { return { hardwareScopeConnected: false }; },
   },
 }));
 vi.mock('$lib/runtime/tx-controller/app-host', () => ({

--- a/frontend/src/components-v2/wiring/__tests__/semantic-rx-audio-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rx-audio-wiring.component.test.ts
@@ -67,6 +67,17 @@ vi.mock('$lib/runtime/frontend-runtime', () => ({
     get rxEnabled() { return h.rxEnabled; },
     setVolume: h.setVolume, setMuted: h.setMuted,
     setRxLive: h.setRxLive, setRxVolume: h.setRxVolume,
+    // MOR-1312 slice 12B: the wiring now also hands the adapter a
+    // scope-display snapshot (the FIFTH argument). This fixture declares no
+    // scope capability, so this stays on its pre-1312 path regardless.
+    get defaultScopeStatus() {
+      return {
+        source: null, available: false, resourceSelected: false, demand: 0,
+        lifecycle: 'inactive', transport: 'disconnected', frameSeen: false,
+      };
+    },
+    get radioPowerOn() { return null; },
+    get scope() { return { hardwareScopeConnected: false }; },
   },
 }));
 vi.mock('$lib/runtime', async () => ({

--- a/frontend/src/components-v2/wiring/__tests__/semantic-rx-tx-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rx-tx-wiring.component.test.ts
@@ -61,6 +61,18 @@ vi.mock('$lib/runtime', () => ({
     // browser stream keeps every fixture below on its pre-1279 path.
     get audio() { return { muted: true, rxEnabled: false, volume: 0 }; },
     get connectionAudio() { return false; },
+    // MOR-1312 slice 12B: the wiring now also hands the adapter a
+    // scope-display snapshot (the FIFTH argument). Every fixture below
+    // declares no scope capability, so this stays on its pre-1312 path
+    // regardless of these values.
+    get defaultScopeStatus() {
+      return {
+        source: null, available: false, resourceSelected: false, demand: 0,
+        lifecycle: 'inactive', transport: 'disconnected', frameSeen: false,
+      };
+    },
+    get radioPowerOn() { return null; },
+    get scope() { return { hardwareScopeConnected: false }; },
   },
 }));
 vi.mock('$lib/runtime/tx-controller/app-host', () => ({

--- a/frontend/src/components-v2/wiring/__tests__/semantic-scope-display-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-scope-display-wiring.component.test.ts
@@ -1,0 +1,378 @@
+/**
+ * MOR-1312 — the semantic scope-display surface wired into
+ * `SemanticRadioSurfaces` (vocabulary slice 12B, the LAST vocabulary slice).
+ *
+ * The unit tests in `semantic/__tests__/ScopeDisplaySurface.test.ts` prove
+ * what the surface does with a view model. This file proves the thing only
+ * the composed tree can prove: WHERE the `scopeDisplaySnapshot` comes from,
+ * and that the reachability gap 12A left (N3 in the 12A verify report — the
+ * group was production-unreachable until this slice wired the snapshot) is
+ * actually closed.
+ *
+ *   (a) The snapshot is built from `runtime.defaultScopeStatus` +
+ *       `runtime.radioPowerOn` + `runtime.scope.hardwareScopeConnected` —
+ *       never guessed, never read from `state`.
+ *   (b) `hardwareConnected` (MOR-1352 finding) moves independently of
+ *       `defaultScopeStatus` — the composed-tree analogue of the adapter-level
+ *       probe in `scope-display-adapter.test.ts`.
+ *   (c) Unlike `rxAudio` (control-bearing, single-composition-only), this
+ *       surface is PURE READOUT and mounts BARE in BOTH compositions, the
+ *       `meters`/`txAux` shape — proved by mounting it in `dual` too.
+ *   (d) The default path must stay byte-identical: a radio that declares no
+ *       scope capability renders exactly the pre-1312 element shape.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { ServerState } from '$lib/types/state';
+
+type Snapshot = {
+  phase: string; intent: string | null; guard: { leaseId: string } | null;
+  radioTx: string; txRisk: string; mayOwnKey: boolean; fault: string | null;
+};
+type ScopeStatus = {
+  source: 'hardware' | 'audio_fft' | null;
+  available: boolean; resourceSelected: boolean; demand: number;
+  lifecycle: 'inactive' | 'starting' | 'streaming' | 'failed';
+  transport: 'disconnected' | 'connecting' | 'connected' | 'reconnecting';
+  frameSeen: boolean;
+};
+
+const OFF_SCOPE_STATUS: ScopeStatus = {
+  source: null, available: false, resourceSelected: false, demand: 0,
+  lifecycle: 'inactive', transport: 'disconnected', frameSeen: false,
+};
+const LIVE_SCOPE_STATUS: ScopeStatus = {
+  source: 'hardware', available: true, resourceSelected: true, demand: 1,
+  lifecycle: 'streaming', transport: 'connected', frameSeen: true,
+};
+
+const h = vi.hoisted(() => ({
+  state: null as unknown,
+  caps: null as unknown,
+  snapshot: null as unknown,
+  listeners: new Set<(next: unknown) => void>(),
+  start: vi.fn(),
+  release: vi.fn(),
+  noop: vi.fn(),
+  scopeStatus: {
+    source: null, available: false, resourceSelected: false, demand: 0,
+    lifecycle: 'inactive', transport: 'disconnected', frameSeen: false,
+  } as ScopeStatus,
+  radioPowerOn: null as boolean | null,
+  hardwareScopeConnected: false,
+}));
+
+vi.mock('$lib/runtime', () => ({
+  runtime: {
+    get state() { return h.state; },
+    get caps() { return h.caps; },
+    get audio() { return { muted: true, rxEnabled: false, volume: 0 }; },
+    get connectionAudio() { return false; },
+    // MOR-1312 slice 12B: the wiring's `scopeDisplaySnapshot` (the FIFTH
+    // adapter argument) is built from these three reads.
+    get defaultScopeStatus() { return h.scopeStatus; },
+    get radioPowerOn() { return h.radioPowerOn; },
+    get scope() { return { hardwareScopeConnected: h.hardwareScopeConnected }; },
+  },
+}));
+vi.mock('$lib/runtime/tx-controller/app-host', () => ({
+  getAppTxController: () => ({
+    snapshot: () => h.snapshot,
+    subscribe: (listener: (next: unknown) => void) => {
+      h.listeners.add(listener);
+      return () => { h.listeners.delete(listener); };
+    },
+    start: h.start,
+    setIntent: vi.fn(),
+    release: h.release,
+    resetFault: vi.fn(),
+  }),
+}));
+vi.mock('$lib/runtime/adapters/mod-input-tx-guard.svelte', () => ({
+  deriveModInputTxGuardProps: () => ({ visible: false, sourceLabel: null }),
+  getModInputTxGuardHandlers: () => ({ onSetLan: vi.fn(), onDismiss: vi.fn() }),
+}));
+vi.mock('../command-bus', () => ({
+  makeVfoHandlers: () => ({
+    onVfoSelect: h.noop, onSplitToggle: h.noop, onDualWatchToggle: h.noop,
+  }),
+  makeVoxHandlers: () => ({
+    onVoxToggle: h.noop, onVoxGainChange: h.noop,
+    onAntiVoxGainChange: h.noop, onVoxDelayChange: h.noop,
+  }),
+  makeTxHandlers: () => ({
+    onRfPowerChange: h.noop, onMicGainChange: h.noop, onAtuToggle: h.noop,
+    onAtuTune: h.noop, onVoxToggle: h.noop, onCompToggle: h.noop,
+    onCompLevelChange: h.noop, onMonToggle: h.noop,
+    onMonLevelChange: h.noop, onDriveGainChange: h.noop,
+  }),
+  makeRxAudioHandlers: () => ({ onMonitorModeChange: h.noop, onAfLevelChange: h.noop }),
+  makeAudioRoutingHandlers: () => ({ onFocusChange: h.noop, onSplitStereoChange: h.noop }),
+  makeModeHandlers: () => ({
+    onModInputChange: h.noop, onModeChange: h.noop, onDataModeChange: h.noop,
+  }),
+  // MOR-1312 slice 12B (rebase fix): `SemanticRadioSurfaces` now calls every
+  // one of these factories unconditionally at init — this file's own mock
+  // predates 4B-9B and only needs each module-scope call not to throw; none
+  // of these are reachable through the scopeDisplay-only fixtures below.
+  makeFilterHandlers: () => ({
+    onFilterChange: h.noop, onFilterWidthChange: h.noop, onFilterShapeChange: h.noop,
+    onIfShiftChange: h.noop, onPbtInnerChange: h.noop, onPbtOuterChange: h.noop,
+  }),
+  makeDspHandlers: () => ({
+    onNrModeChange: h.noop, onNrLevelChange: h.noop, onNbToggle: h.noop,
+    onNbLevelChange: h.noop, onNbDepthChange: h.noop, onNbWidthChange: h.noop,
+    onNotchModeChange: h.noop, onNotchFreqChange: h.noop,
+    onManualNotchWidthChange: h.noop, onAgcTimeChange: h.noop,
+  }),
+  makeAgcHandlers: () => ({ onAgcModeChange: h.noop }),
+  makeRfFrontEndHandlers: () => ({
+    onAttChange: h.noop, onPreChange: h.noop, onRfGainChange: h.noop,
+    onSquelchChange: h.noop, onDigiSelToggle: h.noop, onIpPlusToggle: h.noop,
+  }),
+  makeBandHandlers: () => ({ onBandSelect: h.noop }),
+  makeAntennaHandlers: () => ({ onSelectAnt1: h.noop, onSelectAnt2: h.noop, onToggleRxAnt: h.noop }),
+  makeRitXitHandlers: () => ({
+    onRitToggle: h.noop, onXitToggle: h.noop, onRitOffsetChange: h.noop,
+    onXitOffsetChange: h.noop, onClear: h.noop,
+  }),
+  makeScanHandlers: () => ({
+    onScanStart: h.noop, onScanStop: h.noop, onDfSpanChange: h.noop, onResumeChange: h.noop,
+  }),
+  makeCwPanelHandlers: () => ({
+    onKeySpeedChange: h.noop, onCwPitchChange: h.noop, onBreakInDelayChange: h.noop,
+    onBreakInModeChange: h.noop, onApfChange: h.noop, onTwinPeakToggle: h.noop,
+    onReversePaddleToggle: h.noop,
+  }),
+}));
+
+import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';
+
+const IDLE: Snapshot = {
+  phase: 'idle', intent: null, guard: null, radioTx: 'off', txRisk: 'none',
+  mayOwnKey: false, fault: null,
+};
+
+const fresh = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' };
+const slot = (freqHz: number) => ({ freqHz, mode: 'USB', filterNum: 1, dataMode: 0 });
+
+function liveState(): ServerState {
+  const paths = ['active', 'split', 'dualWatch', 'txTarget'];
+  for (const rx of ['main', 'sub']) {
+    paths.push(`${rx}.freqHz`, `${rx}.mode`, `${rx}.filter`, `${rx}.activeSlot`);
+    for (const v of ['vfoA', 'vfoB']) {
+      paths.push(`${rx}.${v}.freqHz`, `${rx}.${v}.mode`, `${rx}.${v}.filterNum`);
+    }
+  }
+  const receiver = (hz: number) => ({
+    ...slot(hz), vfoA: slot(hz), vfoB: slot(hz + 50000), activeSlot: 'A', filter: 1,
+  });
+  return {
+    active: 'MAIN', split: false, dualWatch: false, ptt: false,
+    txTarget: { status: 'known', receiver: 'MAIN', slot: 'A', frequencyHz: 14250000 },
+    main: receiver(14250000), sub: receiver(14300000),
+    fieldStatus: Object.fromEntries(paths.map((p) => [p, fresh])),
+  } as unknown as ServerState;
+}
+
+/** `withScope=false` mirrors `semantic-meters-wiring`'s `liveCaps(false)` —
+ *  the exact fixture the default-path element-shape literal is pinned
+ *  against, so that literal stays valid as a cross-file invariant. */
+const liveCaps = (withScope: boolean): Capabilities => ({
+  model: 'fixture', scope: withScope, audio: true, tx: true,
+  capabilities: ['audio', 'tx', 'dual_rx'],
+  receivers: 2, vfoScheme: 'main_sub', freqRanges: [], modes: [], filters: [],
+  audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
+  webrtc: { available: false, enabled: false },
+  txBands: [{ start: 14000000, end: 14350000, name: '20m' }],
+  scopeSource: withScope ? 'hardware' : null, audioFftAvailable: false,
+} as unknown as Capabilities);
+
+let target: HTMLDivElement;
+let component: ReturnType<typeof mount> | null = null;
+
+function render(props: { strips?: 'single' | 'dual' } = {}): void {
+  target = document.createElement('div');
+  document.body.appendChild(target);
+  component = mount(SemanticRadioSurfaces, { target, props });
+  flushSync();
+}
+
+const q = <T extends HTMLElement>(sel: string) => target.querySelector(sel) as T | null;
+
+beforeEach(() => {
+  h.state = liveState();
+  h.caps = liveCaps(false);
+  h.snapshot = { ...IDLE };
+  h.listeners.clear();
+  h.start.mockReset();
+  h.release.mockReset();
+  h.noop.mockReset();
+  h.scopeStatus = { ...OFF_SCOPE_STATUS };
+  h.radioPowerOn = null;
+  h.hardwareScopeConnected = false;
+});
+
+afterEach(() => {
+  if (component) unmount(component);
+  component = null;
+  document.body.innerHTML = '';
+});
+
+// ── 1. The structural gate: absent group ⇒ no surface, no element drift ────
+
+describe('the scope-display surface mounts only when the view model carries the group', () => {
+  /** Same literal `semantic-meters-wiring`'s DEFAULT_PATH_TESTIDS pins,
+   *  against the SAME `scope:false`/`dual_rx`-only fixture, so a scope-caps
+   *  radio's default path is provably unaffected by this slice. */
+  const DEFAULT_PATH_TESTIDS = [
+    'vfo-surface', 'vfo-active-receiver', 'vfo-list',
+    'vfo-ops', 'vfo-split-digest',
+    'rx-tx-surface', 'rx-tx-state', 'rx-tx-rf-mark', 'rx-tx-rf-label',
+    'rx-tx-target', 'rx-tx-key', 'rx-tx-unkey', 'rx-tx-blocked',
+    'rx-audio-surface', 'rx-audio-monitor',
+    'rx-audio-monitor-local', 'rx-audio-monitor-live', 'rx-audio-monitor-mute',
+    'rx-audio-af', 'rx-audio-af-value',
+    'rx-audio-focus', 'rx-audio-focus-main', 'rx-audio-focus-sub', 'rx-audio-focus-both',
+    'rx-audio-focus-value',
+    'rx-audio-split', 'rx-audio-split-on', 'rx-audio-split-off', 'rx-audio-split-value',
+  ];
+  const testids = () => [...target.querySelectorAll<HTMLElement>('[data-testid]')]
+    .map((el) => el.dataset.testid!)
+    .filter((id) => id !== 'semantic-radio-surfaces');
+
+  it.each(['single', 'dual'] as const)(
+    'renders no scope-display surface at all without the scope capability (%s)',
+    (strips) => {
+      render({ strips });
+      expect(q('[data-testid="scope-display-surface"]')).toBeNull();
+    },
+  );
+
+  it('leaves the default path element sequence exactly as it is today', () => {
+    render();
+    expect(testids()).toEqual(DEFAULT_PATH_TESTIDS);
+  });
+
+  // MUTATION PROBE — source-selection rendering (2 of 2 required by the
+  // ticket, integration half of the unit-level probe in
+  // ScopeDisplaySurface.test.ts): a radio WITH the scope capability, wired
+  // through the REAL adapter, must actually mount the surface.
+  it.each(['single', 'dual'] as const)(
+    'mounts the scope-display surface when the scope capability is declared (%s)',
+    (strips) => {
+      h.caps = liveCaps(true);
+      h.scopeStatus = { ...LIVE_SCOPE_STATUS };
+      render({ strips });
+      expect(target.querySelectorAll('[data-testid="scope-display-surface"]')).toHaveLength(1);
+      expect(q('[data-testid="scope-display-source"]')!.textContent).toContain('hardware');
+    },
+  );
+
+  // Same shape as `meters`/`txAux`: declarable, but no manifest declares a
+  // `scopeDisplay` zone in this slice — the surface renders bare in BOTH
+  // compositions, unlike `rxAudio`'s single-only mount.
+  it('binds no zone id to the scope-display surface in either composition', () => {
+    h.caps = liveCaps(true);
+    h.scopeStatus = { ...LIVE_SCOPE_STATUS };
+    render({ strips: 'dual' });
+    const zones = [...target.querySelectorAll<HTMLElement>('[data-zone-id]')]
+      .map((el) => el.dataset.zoneId);
+    expect(zones).toEqual(['primary-vfo', 'secondary-vfo', 'global', 'rx-tx']);
+    expect(q('[data-testid="scope-display-surface"]')!.closest('[data-zone-id]')).toBeNull();
+  });
+
+  it('mounts in the dual composition too — pure readout, not the rxAudio single-only shape', () => {
+    h.caps = liveCaps(true);
+    h.scopeStatus = { ...LIVE_SCOPE_STATUS };
+    render({ strips: 'dual' });
+    expect(q('[data-testid="scope-display-surface"]')).not.toBeNull();
+  });
+});
+
+// ── 2. The snapshot is built from the runtime facade, never from `state` ──
+
+describe('the scope-display snapshot comes from runtime.defaultScopeStatus / radioPowerOn / scope', () => {
+  it('reflects a live snapshot honestly', () => {
+    h.caps = liveCaps(true);
+    h.scopeStatus = { ...LIVE_SCOPE_STATUS };
+    render();
+    expect(q('[data-testid="scope-display-health"]')!.textContent).toContain('connected');
+  });
+
+  // MOR-1352 finding, wiring-level proof (carry-forward from the 12A
+  // verify): `hardwareConnected` must move independently of
+  // `defaultScopeStatus` — it comes from a SEPARATE runtime read
+  // (`runtime.scope.hardwareScopeConnected`), never derived from `health`.
+  it('renders hardwareConnected independently of health/source (MOR-1352)', () => {
+    h.caps = liveCaps(true);
+    // Selected source is audio_fft and fully healthy...
+    h.scopeStatus = { ...LIVE_SCOPE_STATUS, source: 'audio_fft' };
+    // ...while the hardware channel is explicitly reported down.
+    h.hardwareScopeConnected = false;
+    render();
+    expect(q('[data-testid="scope-display-source"]')!.textContent).toContain('audio_fft');
+    expect(q('[data-testid="scope-display-health"]')!.textContent).toContain('connected');
+    expect(q('[data-testid="scope-display-hardware"]')!.textContent).toContain('off');
+  });
+
+  it('renders hardwareConnected "on" when the hardware channel is up, independent of source', () => {
+    h.caps = liveCaps(true);
+    h.scopeStatus = { ...LIVE_SCOPE_STATUS, source: 'audio_fft' };
+    h.hardwareScopeConnected = true;
+    render();
+    expect(q('[data-testid="scope-display-hardware"]')!.textContent).toContain('on');
+  });
+
+  // `isPoweredOff` — the status bar's own override input — must reach the
+  // group through `runtime.radioPowerOn`, overriding an otherwise-live
+  // snapshot exactly as `classifyScopeHealth` requires.
+  it('forces health to disconnected when the radio is powered off, even with a live snapshot', () => {
+    h.caps = liveCaps(true);
+    h.scopeStatus = { ...LIVE_SCOPE_STATUS };
+    h.radioPowerOn = false;
+    render();
+    expect(q('[data-testid="scope-display-health"]')!.textContent).toContain('disconnected');
+  });
+
+  it('never reads scope facts off `state` — only the runtime facade', () => {
+    h.caps = liveCaps(true);
+    h.scopeStatus = { ...LIVE_SCOPE_STATUS };
+    // A raw `state.scopeControls`-shaped value has no bearing on this group.
+    h.state = { ...liveState(), scopeControls: { mode: 99 } } as unknown as ServerState;
+    render();
+    expect(q('[data-testid="scope-display-surface"]')).not.toBeNull();
+    expect(q('[data-testid="scope-display-source"]')!.textContent).toContain('hardware');
+  });
+});
+
+// ── 3. R9: the scope-display surface is a readout, never an action path ───
+
+describe('the scope-display surface adds no control and no TX path', () => {
+  it('keeps exactly one key/unkey authority in the composed tree', () => {
+    h.caps = liveCaps(true);
+    h.scopeStatus = { ...LIVE_SCOPE_STATUS };
+    render();
+    expect(target.querySelectorAll('[data-testid="rx-tx-surface"]')).toHaveLength(1);
+    expect(target.querySelectorAll('[data-testid="rx-tx-key"]')).toHaveLength(1);
+    expect(target.querySelectorAll('[data-testid="rx-tx-unkey"]')).toHaveLength(1);
+  });
+
+  // MUTATION PROBE (required by the ticket, integration half of the
+  // unit-level probe): the composed tree's ONLY new focusable elements after
+  // this slice must be zero, in EITHER composition.
+  it.each(['single', 'dual'] as const)(
+    'contributes no focusable control to the composition (%s)',
+    (strips) => {
+      h.caps = liveCaps(true);
+      h.scopeStatus = { ...LIVE_SCOPE_STATUS };
+      render({ strips });
+      const surface = q('[data-testid="scope-display-surface"]')!;
+      expect(surface.querySelectorAll('button, input, select, a[href], [tabindex]'))
+        .toHaveLength(0);
+      expect(h.start).not.toHaveBeenCalled();
+      expect(h.release).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
@@ -54,6 +54,18 @@ vi.mock('$lib/runtime', () => ({
     // browser stream keeps every fixture below on its pre-1279 path.
     get audio() { return { muted: true, rxEnabled: false, volume: 0 }; },
     get connectionAudio() { return false; },
+    // MOR-1312 slice 12B: the wiring now also hands the adapter a
+    // scope-display snapshot (the FIFTH argument). Every fixture below
+    // declares no scope capability, so this stays on its pre-1312 path
+    // regardless of these values.
+    get defaultScopeStatus() {
+      return {
+        source: null, available: false, resourceSelected: false, demand: 0,
+        lifecycle: 'inactive', transport: 'disconnected', frameSeen: false,
+      };
+    },
+    get radioPowerOn() { return null; },
+    get scope() { return { hardwareScopeConnected: false }; },
   },
 }));
 vi.mock('$lib/runtime/tx-controller/app-host', () => ({

--- a/frontend/src/lib/runtime/adapters/__tests__/scope-display-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/scope-display-adapter.test.ts
@@ -1,6 +1,8 @@
 /**
  * MOR-1262 decomposition slice 12A (MOR-1301, the FINAL A-slice of the
  * vocabulary program) — `scopeDisplay` fact-group adapter derivation.
+ * Extended by slice 12B (MOR-1312, the LAST vocabulary slice) for the
+ * `hardwareConnected` leaf — see the `hardwareConnected` describe block below.
  *
  * Companion to `scope-controls-adapter.test.ts` (11A/11A′) and
  * `rx-audio-adapter.test.ts` (3A), neither of which this file modifies.
@@ -16,6 +18,9 @@
  * `rx-audio-adapter.test.ts` uses for `projectModInputSource`. No `vi.mock`,
  * no global store mutation — `deriveScopeIndicatorState` is a pure function
  * of its two explicit arguments, so this file needs no isolated pool.
+ * `hardwareConnected` is deliberately EXCLUDED from this parity discipline —
+ * `deriveScopeIndicatorState` takes no such input, by design (see the
+ * CORRECTION note on `ScopeDisplayViewModel`).
  */
 import { describe, expect, it } from 'vitest';
 import type { Capabilities } from '$lib/types/capabilities';
@@ -52,6 +57,7 @@ function bareState(overrides: Partial<ServerState> = {}): ServerState {
 const SNAP: ScopeDisplaySnapshot = {
   source: 'hardware', available: true, resourceSelected: true, demand: 1,
   lifecycle: 'streaming', transport: 'connected', frameSeen: true, isPoweredOff: false,
+  hardwareConnected: true,
 };
 
 function model(
@@ -80,7 +86,9 @@ describe('scopeDisplay evidence gate (MOR-1301)', () => {
   it('emits scopeDisplay once the scope capability alone is declared', () => {
     const view = model(bareState(), caps(), SNAP);
     expect(view.scopeDisplay).toBeDefined();
-    expect(Object.keys(view.scopeDisplay!).sort()).toEqual(['health', 'source']);
+    // MOR-1312 (12B): `hardwareConnected` joins the group's three facts.
+    expect(Object.keys(view.scopeDisplay!).sort())
+      .toEqual(['hardwareConnected', 'health', 'source']);
   });
 
   it('emits scopeDisplay for an audio-FFT-only radio (no hardware scope at all)', () => {
@@ -111,6 +119,54 @@ describe('scopeDisplay per-field derivation (MOR-1301)', () => {
   it('emits a validator-clean model carrying the scopeDisplay group (round-trip proof)', () => {
     const view = model(bareState(), caps(), SNAP);
     expect(JSON.parse(JSON.stringify(view))).toEqual(view);
+  });
+});
+
+/**
+ * MOR-1312 (12B) — `hardwareConnected`. The MOR-1352 finding: `health` alone
+ * does not tell the operator whether the HARDWARE channel is connected when
+ * `source === 'audio_fft'` — this leaf reads the flag straight off the
+ * snapshot, never through `classifyScopeHealth`.
+ */
+describe('scopeDisplay hardwareConnected (MOR-1312, MOR-1352 finding)', () => {
+  it('reads true straight from the snapshot', () => {
+    const view = model(bareState(), caps(), { ...SNAP, hardwareConnected: true });
+    expect(view.scopeDisplay!.hardwareConnected.reading).toEqual({ status: 'known', value: true });
+    expect(view.scopeDisplay!.hardwareConnected.availability).toEqual({ structural: true, operational: true });
+  });
+
+  it('reads false straight from the snapshot', () => {
+    const view = model(bareState(), caps(), { ...SNAP, hardwareConnected: false });
+    expect(view.scopeDisplay!.hardwareConnected.reading).toEqual({ status: 'known', value: false });
+  });
+
+  // MUTATION KILLED: computing `hardwareConnected` from `health`/`transport`
+  // instead of reading the snapshot's own dedicated field — this is the exact
+  // residual `health` cannot cover when `source === 'audio_fft'` (MOR-1352):
+  // the two are made to DISAGREE here, and the leaf must still report the
+  // snapshot's own truth, not a derivation from the other two.
+  it('disagrees with health/transport when the snapshot says so — proving it is not re-derived from them', () => {
+    const view = model(bareState(), caps(), {
+      ...SNAP,
+      source: 'audio_fft',
+      // The selected (audio) channel is fully healthy...
+      lifecycle: 'streaming', transport: 'connected', frameSeen: true,
+      // ...while the hardware channel is explicitly down.
+      hardwareConnected: false,
+    });
+    expect(view.scopeDisplay!.health.reading).toEqual({ status: 'known', value: 'connected' });
+    expect(view.scopeDisplay!.hardwareConnected.reading).toEqual({ status: 'known', value: false });
+  });
+
+  // The audio_fft case is the one MOR-1352 named — hardware may be live even
+  // though the selected/rendered source is audio_fft, and `health` alone
+  // cannot say so.
+  it('stays independent of source selection: audio_fft selected, hardware still connected', () => {
+    const view = model(bareState(), caps(), {
+      ...SNAP, source: 'audio_fft', hardwareConnected: true,
+    });
+    expect(view.scopeDisplay!.source.reading).toEqual({ status: 'known', value: 'audio_fft' });
+    expect(view.scopeDisplay!.hardwareConnected.reading).toEqual({ status: 'known', value: true });
   });
 });
 

--- a/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
@@ -50,6 +50,17 @@ import {
 import {
   deriveTxCapabilities, type ModInputSource, type TxCapabilityFacts,
 } from './tx-capabilities';
+// MOR-1312 (12A verify N1): the REAL type, not a hand-copied literal union —
+// `ScopeDisplaySnapshot.lifecycle` below now widens automatically if
+// `ResourceHealth` ever gains a value upstream, instead of silently staying
+// narrower than the runtime status it mirrors. `ConnectionState` (the sibling
+// type N1 also names) stays a hand-copied literal deliberately: it lives in
+// `$lib/transport/ws-client`, and this file's own purity guard
+// (`__tests__/rx-audio-purity.isolated.test.ts` pin 3 / SAFETY CONSTRAINT 1)
+// asserts NO import from `$lib/transport/*` anywhere in this adapter, type-only
+// or not — that guard is more binding than N1's suggestion, so `.transport`
+// keeps its inline union and only `.lifecycle` gets the real type.
+import type { ResourceHealth } from '$lib/runtime/resource-demand';
 
 type Slot = { kind: 'slotted'; id: VfoSlotId } | { kind: 'unslotted' } | { kind: 'unknown' };
 type Fact = { status: 'known'; value: boolean } | { status: 'unknown' };
@@ -991,16 +1002,25 @@ function deriveScopeControls(
  * `frameSeen`) so a caller can spread `runtime.defaultScopeStatus` in
  * directly; `isPoweredOff` is the one addition, the status bar's own
  * override input to the same classification (see `classifyScopeHealth`).
+ *
+ * `hardwareConnected` (MOR-1312, slice 12B) is a SECOND addition: mirrors
+ * `runtime.scope.hardwareScopeConnected` verbatim, the hardware channel's own
+ * transport regardless of `source` — NOT an input to `classifyScopeHealth`
+ * (see `ScopeDisplayViewModel`'s CORRECTION note for why it stays a separate
+ * leaf instead).
  */
 export interface ScopeDisplaySnapshot {
   source: ScopeSourceKind | null;
   available: boolean;
   resourceSelected: boolean;
   demand: number;
-  lifecycle: 'inactive' | 'starting' | 'streaming' | 'failed';
+  lifecycle: ResourceHealth;
+  // `ConnectionState`'s own literal union, hand-copied rather than imported —
+  // see the import comment above (this file's transport-purity guard).
   transport: 'disconnected' | 'connecting' | 'connected' | 'reconnecting';
   frameSeen: boolean;
   isPoweredOff: boolean;
+  hardwareConnected: boolean;
 }
 
 /**
@@ -1064,6 +1084,9 @@ function deriveScopeDisplay(
   return {
     source: txAuxField(true, snapshot.source !== null, snapshot.source ?? undefined),
     health: txAuxField(true, true, classifyScopeHealth(snapshot)),
+    // MOR-1312 (12B): read straight from the snapshot, never through
+    // `classifyScopeHealth` — see `ScopeDisplayViewModel`'s CORRECTION note.
+    hardwareConnected: txAuxField(true, true, snapshot.hardwareConnected),
   };
 }
 

--- a/frontend/src/presentation/layouts/__tests__/antenna-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/antenna-declarability.test.ts
@@ -33,7 +33,7 @@ describe('antenna is a declarable semantic surface', () => {
     expect([...SEMANTIC_SURFACE_NAMES])
       .toEqual([
         'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band',
-        'antenna', 'ritXitScan', 'cwKeyer',
+        'antenna', 'ritXitScan', 'cwKeyer', 'scopeDisplay',
       ]);
   });
 

--- a/frontend/src/presentation/layouts/__tests__/band-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/band-declarability.test.ts
@@ -29,7 +29,7 @@ describe('band is a declarable semantic surface', () => {
     expect([...SEMANTIC_SURFACE_NAMES])
       .toEqual([
         'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band',
-        'antenna', 'ritXitScan', 'cwKeyer',
+        'antenna', 'ritXitScan', 'cwKeyer', 'scopeDisplay',
       ]);
   });
 

--- a/frontend/src/presentation/layouts/__tests__/dsp-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/dsp-declarability.test.ts
@@ -21,7 +21,7 @@ describe('dsp is a declarable semantic surface', () => {
   it('is in the declarable set alongside vfo, rxTx, txAux, meters and rxAudio', () => {
     expect([...SEMANTIC_SURFACE_NAMES]).toEqual([
       'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band',
-      'antenna', 'ritXitScan', 'cwKeyer',
+      'antenna', 'ritXitScan', 'cwKeyer', 'scopeDisplay',
     ]);
   });
 

--- a/frontend/src/presentation/layouts/__tests__/filter-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/filter-declarability.test.ts
@@ -24,7 +24,7 @@ describe('filter is a declarable semantic surface', () => {
   it('is in the declarable set alongside vfo, rxTx, txAux, meters and rxAudio', () => {
     expect([...SEMANTIC_SURFACE_NAMES]).toEqual([
       'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band',
-      'antenna', 'ritXitScan', 'cwKeyer',
+      'antenna', 'ritXitScan', 'cwKeyer', 'scopeDisplay',
     ]);
   });
 

--- a/frontend/src/presentation/layouts/__tests__/meters-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/meters-declarability.test.ts
@@ -30,7 +30,7 @@ describe('meters is a declarable semantic surface', () => {
   it('is in the declarable set alongside vfo, rxTx and txAux', () => {
     expect([...SEMANTIC_SURFACE_NAMES]).toEqual([
       'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band',
-      'antenna', 'ritXitScan', 'cwKeyer',
+      'antenna', 'ritXitScan', 'cwKeyer', 'scopeDisplay',
     ]);
   });
 

--- a/frontend/src/presentation/layouts/__tests__/rf-front-end-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/rf-front-end-declarability.test.ts
@@ -29,7 +29,7 @@ describe('rfFrontEnd is a declarable semantic surface', () => {
     expect([...SEMANTIC_SURFACE_NAMES])
       .toEqual([
         'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band',
-        'antenna', 'ritXitScan', 'cwKeyer',
+        'antenna', 'ritXitScan', 'cwKeyer', 'scopeDisplay',
       ]);
   });
 

--- a/frontend/src/presentation/layouts/__tests__/ritxit-scan-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/ritxit-scan-declarability.test.ts
@@ -27,7 +27,7 @@ describe('ritXitScan is a declarable semantic surface', () => {
   it('is in the declarable set alongside vfo, rxTx, txAux, meters and rxAudio', () => {
     expect([...SEMANTIC_SURFACE_NAMES]).toEqual([
       'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band',
-      'antenna', 'ritXitScan', 'cwKeyer',
+      'antenna', 'ritXitScan', 'cwKeyer', 'scopeDisplay',
     ]);
   });
 

--- a/frontend/src/presentation/layouts/__tests__/rx-audio-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/rx-audio-declarability.test.ts
@@ -26,7 +26,7 @@ describe('rxAudio is a declarable semantic surface', () => {
   it('is in the declarable set alongside vfo, rxTx, txAux and meters', () => {
     expect([...SEMANTIC_SURFACE_NAMES]).toEqual([
       'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band',
-      'antenna', 'ritXitScan', 'cwKeyer',
+      'antenna', 'ritXitScan', 'cwKeyer', 'scopeDisplay',
     ]);
   });
 

--- a/frontend/src/presentation/layouts/__tests__/scope-display-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/scope-display-declarability.test.ts
@@ -1,17 +1,16 @@
 /**
- * MOR-1310 — `cwKeyer` is DECLARABLE, and nothing declares it yet.
+ * MOR-1312 — `scopeDisplay` is DECLARABLE, and nothing declares it yet.
  *
- * Slice 9B adds the name to `SEMANTIC_SURFACE_NAMES` so a manifest CAN mount
+ * Slice 12B adds the name to `SEMANTIC_SURFACE_NAMES` so a manifest CAN mount
  * the surface later; it deliberately does not touch any manifest, and it adds
- * no design-language renderer slot (that set was frozen by MOR-1072).
+ * no design-language renderer slot (that set was frozen by MOR-1072 — adding
+ * one would be a language-contract change this slice must not make).
  *
- * Same three pins as `rx-audio-declarability.test.ts` /
- * `tx-aux-declarability.test.ts` / `meters-declarability.test.ts`:
+ * Same three pins as `tx-aux-declarability.test.ts` / `meters-declarability.test.ts`
+ * / `rx-audio-declarability.test.ts`:
  *   - drop the name and a future manifest's zone stops validating;
- *   - quietly add a `cwKeyer` zone to a shipped manifest and the DOM grows a
- *     zone id no layout review ever saw — which for THIS surface would also
- *     mount break-in controls into the cockpit's tab order without the
- *     MOR-1069 sequence assertion ever being updated;
+ *   - quietly add a `scopeDisplay` zone to a shipped manifest and the DOM
+ *     grows a zone id no layout review ever saw;
  *   - the renderer slot set stays exactly what MOR-1072 froze.
  */
 import { describe, it, expect } from 'vitest';
@@ -23,9 +22,9 @@ import {
   sdrTestLayout,
 } from '../declarations';
 
-describe('cwKeyer is a declarable semantic surface', () => {
+describe('scopeDisplay is a declarable semantic surface', () => {
   // Kills: reverting the SEMANTIC_SURFACE_NAMES addition.
-  it('is in the declarable set, appended last', () => {
+  it('is in the declarable set alongside vfo, rxTx, txAux, meters and rxAudio', () => {
     expect([...SEMANTIC_SURFACE_NAMES]).toEqual([
       'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band',
       'antenna', 'ritXitScan', 'cwKeyer', 'scopeDisplay',
@@ -36,7 +35,7 @@ describe('cwKeyer is a declarable semantic surface', () => {
   // zone validator checks — the manifest would still be rejected.
   it('accepts a manifest zone that declares it', () => {
     const manifest = validLayoutManifest({
-      zones: [{ id: 'main', surfaces: ['vfo', 'rxTx', 'cwKeyer'] }],
+      zones: [{ id: 'main', surfaces: ['vfo', 'rxTx', 'scopeDisplay'] }],
       requiredSemanticSurfaces: ['vfo', 'rxTx'],
     });
     expect(() => validateLayoutManifest(manifest)).not.toThrow();
@@ -44,30 +43,30 @@ describe('cwKeyer is a declarable semantic surface', () => {
 
   it('still rejects a zone naming a surface that does not exist', () => {
     const manifest = validLayoutManifest({
-      zones: [{ id: 'main', surfaces: ['cwPanel'] as unknown as readonly ['vfo'] }],
+      zones: [{ id: 'main', surfaces: ['scopeStatus'] as unknown as readonly ['vfo'] }],
     });
     expect(() => validateLayoutManifest(manifest)).toThrow(/subset of/);
   });
 });
 
-describe('no shipped manifest declares a cwKeyer zone in this slice', () => {
-  // Kills: slipping a cwKeyer zone into an existing layout here. SAFETY-
-  // relevant: the dual-receiver cockpit's MOR-1069 tab-order assertion is
-  // written against the zones it declares today, so declaring one here would
-  // put break-in controls in the cockpit with no updated sequence pin.
+describe('no shipped manifest declares a scopeDisplay zone in this slice', () => {
+  // Kills: slipping a scopeDisplay zone into an existing layout here.
+  // Declarability is the whole scope of the contract touch; placing the
+  // surface in a real layout is a later, separately reviewed slice (the
+  // same discipline `rxAudio`'s MOR-1279 established).
   it.each([
     ['sdr-test', sdrTestLayout], ['dual-receiver-cockpit', dualReceiverCockpitLayout],
     ['lcd-cockpit', lcdCockpitLayout], ['lcd-scope', lcdScopeLayout],
     ['mobile', mobileLayout], ['desktop-v2', desktopV2Layout],
-  ])('%s declares no cwKeyer zone and does not require the surface', (_id, manifest) => {
-    for (const zone of manifest.zones) expect(zone.surfaces).not.toContain('cwKeyer');
-    expect(manifest.requiredSemanticSurfaces).not.toContain('cwKeyer');
+  ])('%s declares no scopeDisplay zone and does not require the surface', (_id, manifest) => {
+    for (const zone of manifest.zones) expect(zone.surfaces).not.toContain('scopeDisplay');
+    expect(manifest.requiredSemanticSurfaces).not.toContain('scopeDisplay');
   });
 });
 
 describe('the design-language renderer slot set is untouched', () => {
-  // Kills: adding a renderer slot for this surface. A CW keyer has no gauge
-  // grammar a language must describe; the slot set stays frozen.
+  // Kills: adding a renderer slot for this surface. A source/health readout
+  // has no gauge grammar a language must describe; the slot set stays frozen.
   it('still carries exactly the three MOR-1072 slots', () => {
     expect([...RENDERER_SLOT_NAMES]).toEqual(['meters', 'frequencyDisplay', 'stateFeedback']);
   });

--- a/frontend/src/presentation/layouts/__tests__/tx-aux-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/tx-aux-declarability.test.ts
@@ -30,7 +30,7 @@ describe('txAux is a declarable semantic surface', () => {
   it('is in the declarable set alongside vfo and rxTx', () => {
     expect([...SEMANTIC_SURFACE_NAMES]).toEqual([
       'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band',
-      'antenna', 'ritXitScan', 'cwKeyer',
+      'antenna', 'ritXitScan', 'cwKeyer', 'scopeDisplay',
     ]);
   });
 

--- a/frontend/src/presentation/layouts/contract.ts
+++ b/frontend/src/presentation/layouts/contract.ts
@@ -16,17 +16,17 @@ import { isValidLanguageId as isValidProductId } from '../languages/contract';
  *  `txAux` added by MOR-1265, `meters` by MOR-1273, `rxAudio` by MOR-1279,
  *  `filter` by MOR-1304, `dsp` by MOR-1305, `rfFrontEnd` by MOR-1306, `band`
  *  by MOR-1307, `antenna` by MOR-1309, `ritXitScan` by MOR-1308, `cwKeyer` by
- *  MOR-1310). Adding a name makes it DECLARABLE — it does not mount anything
- *  by itself, and no manifest declares a `meters`, `rxAudio`, `filter`,
- *  `dsp`, `rfFrontEnd`, `band`, `antenna`, `ritXitScan` or `cwKeyer` zone yet
- *  (the cockpit declares only `txAux`, as `tx-aux` — MOR-1336). Distinct
- *  from the design-language renderer slot of the same name
- *  (`languages/contract.ts`'s `RENDERER_SLOT_NAMES`): that one says how a
- *  language DRAWS a meter, this one says which layout zone may HOST the
- *  surface. */
+ *  MOR-1310, `scopeDisplay` by MOR-1312 — the LAST vocabulary slice). Adding
+ *  a name makes it DECLARABLE — it does not mount anything by itself, and no
+ *  manifest declares a `meters`, `rxAudio`, `filter`, `dsp`, `rfFrontEnd`,
+ *  `band`, `antenna`, `ritXitScan`, `cwKeyer` or `scopeDisplay` zone yet (the
+ *  cockpit declares only `txAux`, as `tx-aux` — MOR-1336). Distinct from the
+ *  design-language renderer slot of the same name (`languages/contract.ts`'s
+ *  `RENDERER_SLOT_NAMES`): that one says how a language DRAWS a meter, this
+ *  one says which layout zone may HOST the surface. */
 export const SEMANTIC_SURFACE_NAMES = [
   'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band', 'antenna', 'ritXitScan',
-  'cwKeyer',
+  'cwKeyer', 'scopeDisplay',
 ] as const;
 export type SemanticSurfaceName = (typeof SEMANTIC_SURFACE_NAMES)[number];
 

--- a/frontend/src/semantic/ScopeDisplaySurface.svelte
+++ b/frontend/src/semantic/ScopeDisplaySurface.svelte
@@ -1,0 +1,107 @@
+<!--
+  Semantic scope-display surface (MOR-1312, vocabulary slice 12B — the LAST
+  slice of the vocabulary program).
+
+  Presentation only. It renders the MOR-1301/MOR-1312 `scopeDisplay` fact
+  group — WHICH scope source is currently live and HOW HEALTHY it is, plus
+  the hardware channel's own connectivity — and emits NO intent (v3 ADR
+  invariant 11): this is a pure readout, never an action surface.
+
+  SCOPE (boundary ruling, 11A verify, carried forward by 12A/12B):
+  (1) NEVER scope TUNING. MODE/EDGE/HOLD/REF/etc. are `scopeControls`
+      (slice 11A/11A′) and are not duplicated here.
+  (2) NEVER the scope's PIXELS. Live hardware/audio-FFT frames stay a wholly
+      App-owned resource demand (MOR-1161 + `ScaledStage` territory) — this
+      file renders three short facts, not a canvas.
+  (3) NEVER band-plan/DX/EiBi overlays. Explicitly out of scope per the
+      ticket.
+
+  ZERO FOCUSABLE ELEMENTS, BY CONSTRUCTION (MOR-1069 mounting canon). A
+  source/health readout has no action to offer, so this surface renders no
+  `button`/`input`/`select`/`a[href]`/`[tabindex]` — pinned in
+  `__tests__/ScopeDisplaySurface.test.ts` and re-pinned at the composed-tree
+  level in `semantic-scope-display-wiring.component.test.ts`, so a future
+  control addition trips both. That property is what lets `SemanticRadioSurfaces`
+  mount this surface bare in BOTH compositions (the `meters`/`txAux` shape,
+  not the control-bearing `rxAudio` single-only shape).
+
+  `hardwareConnected` (MOR-1312 addition, MOR-1352 finding) is genuinely NOT
+  redundant with `health` when `source === 'audio_fft'` — see
+  `radio-view-model.ts`'s `ScopeDisplayViewModel` doc comment.
+-->
+<script module lang="ts">
+  import type { ScopeDisplayField, ScopeHealthState } from './radio-view-model';
+
+  /** The ONE rendering of "not observed". Never a fabricated default. */
+  export const UNKNOWN_TEXT = '—';
+
+  /** Three-tone classification for `health`, mirroring `indicatorTone`
+   *  (`components-v2/layout/StatusBar.svelte`) — reproduced, not imported,
+   *  because `semantic/` may not import `components-v2/*` (the same ADR
+   *  boundary reason `classifyScopeHealth` reproduces
+   *  `deriveScopeIndicatorState` instead of calling it). */
+  export type HealthTone = 'green' | 'yellow' | 'red' | 'neutral';
+  export function healthTone(state: ScopeHealthState): HealthTone {
+    switch (state) {
+      case 'connected': return 'green';
+      case 'connecting':
+      case 'starting':
+      case 'waiting':
+      case 'reconnecting': return 'yellow';
+      case 'disconnected':
+      case 'failed': return 'red';
+      default: return 'neutral';
+    }
+  }
+
+  const usable = (f: ScopeDisplayField<unknown>): boolean =>
+    f.availability.structural && f.availability.operational && f.reading.status === 'known';
+  const textOf = (f: ScopeDisplayField<unknown>): string =>
+    f.reading.status === 'known' ? String(f.reading.value) : UNKNOWN_TEXT;
+  /** `on`/`off`/unknown for a boolean field — narrows `reading.status` inline
+   *  so the value read is never a stale/impossible union member. */
+  const onOff = (f: ScopeDisplayField<boolean>): string =>
+    f.reading.status === 'known' ? (f.reading.value ? 'on' : 'off') : UNKNOWN_TEXT;
+</script>
+
+<script lang="ts">
+  import type { RadioViewModel } from './radio-view-model';
+
+  interface Props { view: RadioViewModel }
+  let { view }: Props = $props();
+
+  /** Absent group ⇒ this surface renders nothing (S0 optional-group
+   *  doctrine): a radio the MOR-1301 evidence gate declined gets no empty
+   *  indicator and no zone had to learn about it. */
+  let sd = $derived(view.scopeDisplay);
+</script>
+
+{#if sd}
+  <section
+    class="scope-display-surface" data-testid="scope-display-surface" role="status"
+    aria-label="Scope status"
+  >
+    <span
+      class="scope-display-field" data-testid="scope-display-source"
+      data-observed={usable(sd.source)}
+    >SRC {textOf(sd.source)}</span>
+    <span
+      class="scope-display-field" data-testid="scope-display-health"
+      data-observed={usable(sd.health)}
+      data-tone={sd.health.reading.status === 'known' ? healthTone(sd.health.reading.value) : 'neutral'}
+    >{textOf(sd.health)}</span>
+    <span
+      class="scope-display-field" data-testid="scope-display-hardware"
+      data-observed={usable(sd.hardwareConnected)}
+    >HW {onOff(sd.hardwareConnected)}</span>
+  </section>
+{/if}
+
+<style>
+  /* Structure only — a design language owns colour and must never become the
+     sole state channel (MOR-977, forced-colors). Nothing here animates. */
+  .scope-display-surface { display: flex; align-items: baseline; gap: 0.5rem; }
+  /* Second channel beside `data-observed`, never the only one: the unknown
+     text itself is the primary one and survives forced-colors. */
+  [data-observed='false'] { font-style: italic; }
+</style>

--- a/frontend/src/semantic/__tests__/ScopeDisplaySurface.test.ts
+++ b/frontend/src/semantic/__tests__/ScopeDisplaySurface.test.ts
@@ -1,0 +1,263 @@
+/**
+ * MOR-1312 — the semantic scope-display surface (vocabulary slice 12B, the
+ * LAST slice of the vocabulary program).
+ *
+ * Presentation-only (v3 ADR invariant 11 / R9): this surface renders no
+ * control of any kind. Block 1 pins that with a source scan for
+ * `button`/`input`/`onclick`-shaped syntax AND a rendered-DOM query, so a
+ * behavioural mutation (adding a control) and a source-level one (adding a
+ * handler prop) both die — the same double instrument
+ * `MetersSurface.test.ts` block 1/5 uses.
+ *
+ * Two carry-forward mutation probes this file exists to satisfy:
+ *   (1) flip the `health`-state -> tone/text branch mapping and a test dies
+ *       (block 3, `healthTone` exhaustive-mapping tests).
+ *   (2) flip source-selection rendering and a test dies (block 2, the
+ *       hardware/audio_fft rendering + unknown-source tests).
+ */
+import { readFileSync } from 'node:fs';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import ScopeDisplaySurface, { healthTone, UNKNOWN_TEXT } from '../ScopeDisplaySurface.svelte';
+import { topologyFixtures, withScopeDisplay } from '../fixtures/topologies';
+import type {
+  Availability, ScopeDisplayField, ScopeHealthState, ScopeDisplayViewModel, RadioViewModel,
+} from '../radio-view-model';
+
+const SOURCE = readFileSync('src/semantic/ScopeDisplaySurface.svelte', 'utf8')
+  .replace(/<!--[\s\S]*?-->/g, '')
+  .replace(/\/\*[\s\S]*?\*\//g, '')
+  .replace(/^\s*\/\/.*$/gm, '');
+
+const AVAIL: Availability = { structural: true, operational: true };
+const UNOBSERVED: Availability = { structural: true, operational: false };
+const ABSENT: Availability = { structural: false, operational: false };
+
+/** Re-shape ONE leaf of an otherwise fully-observed `scopeDisplay` group. */
+function withField(
+  view: RadioViewModel, field: keyof ScopeDisplayViewModel,
+  over: { availability?: Availability; unknown?: boolean; value?: unknown },
+): RadioViewModel {
+  const sd = view.scopeDisplay!;
+  const current: ScopeDisplayField<unknown> = sd[field];
+  return {
+    ...view,
+    scopeDisplay: {
+      ...sd,
+      [field]: {
+        reading: over.unknown
+          ? { status: 'unknown' }
+          : over.value !== undefined ? { status: 'known', value: over.value } : current.reading,
+        availability: over.availability ?? current.availability,
+      } satisfies ScopeDisplayField<unknown>,
+    } as ScopeDisplayViewModel,
+  };
+}
+
+let target: HTMLDivElement;
+beforeEach(() => { target = document.createElement('div'); document.body.appendChild(target); });
+afterEach(() => { target.remove(); });
+
+function render(view: RadioViewModel) {
+  const component = mount(ScopeDisplaySurface, { target, props: { view } });
+  flushSync();
+  const q = <T extends HTMLElement>(sel: string) => target.querySelector(sel) as T | null;
+  return {
+    dispose: () => unmount(component),
+    root: () => q('[data-testid="scope-display-surface"]'),
+    source: () => q('[data-testid="scope-display-source"]'),
+    health: () => q('[data-testid="scope-display-health"]'),
+    hardware: () => q('[data-testid="scope-display-hardware"]'),
+  };
+}
+
+function withSurface(view: RadioViewModel, fn: (s: ReturnType<typeof render>) => void): void {
+  const s = render(view);
+  try { fn(s); } finally { s.dispose(); }
+}
+
+const base = () => withScopeDisplay(topologyFixtures['1/single']);
+
+// ── 1. Display only (R9) + optional-group self-gating (risk R3) ────────────
+
+describe('the scope-display surface is display-only and self-gates on group presence', () => {
+  it('renders NOTHING at all when the view model carries no scopeDisplay group', () => {
+    const bare = topologyFixtures['1/single'];
+    expect(bare.scopeDisplay).toBeUndefined();
+    withSurface(bare, (s) => {
+      expect(s.root()).toBeNull();
+      expect(target.innerHTML).not.toContain('scope-display');
+    });
+  });
+
+  it('renders the surface when the group is present', () => {
+    withSurface(base(), (s) => {
+      expect(s.root()).not.toBeNull();
+      expect(target.querySelectorAll('[data-testid="scope-display-surface"]')).toHaveLength(1);
+    });
+  });
+
+  // MUTATION PROBE (1 of 2 required by the ticket): grows a button/input of
+  // any kind. Zero focusable elements is what lets `SemanticRadioSurfaces`
+  // mount this surface bare in BOTH compositions (the `meters` shape, not
+  // `rxAudio`'s single-only shape) — see `ScopeDisplaySurface.svelte`'s doc
+  // comment and `semantic-scope-display-wiring.component.test.ts`.
+  it('contributes no focusable control of any kind', () => {
+    withSurface(base(), () => {
+      expect(target.querySelectorAll(
+        'button, input, select, textarea, a[href], [tabindex], [role="button"], [role="switch"]',
+      )).toHaveLength(0);
+    });
+  });
+
+  // Source-level companion to the behavioural probe above: proves the
+  // ABSENCE of a handler prop, which a rendered-DOM query alone cannot.
+  it('takes no intent callback prop and has exactly one prop', () => {
+    expect(SOURCE).toMatch(/interface Props\s*\{\s*view:\s*RadioViewModel\s*\}/);
+    expect(SOURCE).not.toMatch(/on[A-Z]\w*\?:/);
+  });
+
+  it('binds no zone id of its own', () => {
+    withSurface(base(), () => {
+      expect(target.querySelectorAll('[data-zone-id]')).toHaveLength(0);
+    });
+  });
+});
+
+// ── 2. MUTATION PROBE (2 of 2): source-selection rendering ─────────────────
+
+describe('source rendering reflects the fact, never a default', () => {
+  it('renders the known hardware source', () => {
+    withSurface(withField(base(), 'source', { value: 'hardware' }), (s) => {
+      expect(s.source()!.textContent).toContain('hardware');
+      expect(s.source()!.dataset.observed).toBe('true');
+    });
+  });
+
+  // The discriminating case: hardware and audio_fft must render DIFFERENT
+  // text. A mutation that hardcodes 'hardware' or drops the source read
+  // entirely produces the SAME text for both and this test dies.
+  it('renders the known audio_fft source, distinctly from hardware', () => {
+    withSurface(withField(base(), 'source', { value: 'audio_fft' }), (s) => {
+      expect(s.source()!.textContent).toContain('audio_fft');
+      expect(s.source()!.textContent).not.toContain('hardware');
+    });
+  });
+
+  it('renders unknown, never a fabricated source, before any source resolves', () => {
+    withSurface(withField(base(), 'source', { unknown: true, availability: UNOBSERVED }), (s) => {
+      expect(s.source()!.textContent).toContain(UNKNOWN_TEXT);
+      expect(s.source()!.dataset.observed).toBe('false');
+      expect(s.source()!.textContent).not.toMatch(/hardware|audio_fft/);
+    });
+  });
+});
+
+// ── 3. MUTATION PROBE (1 of 2): the health-state branch mapping ────────────
+
+describe('healthTone maps every ScopeHealthState to its own tone (exhaustive)', () => {
+  const EXPECTED: Record<ScopeHealthState, string> = {
+    connected: 'green',
+    connecting: 'yellow', starting: 'yellow', waiting: 'yellow', reconnecting: 'yellow',
+    disconnected: 'red', failed: 'red',
+    inactive: 'neutral',
+  };
+
+  it.each(Object.entries(EXPECTED) as Array<[ScopeHealthState, string]>)(
+    'health=%s -> tone=%s',
+    (state, tone) => {
+      expect(healthTone(state)).toBe(tone);
+    },
+  );
+
+  // MUTATION KILLED: swapping any two branches (e.g. 'failed' -> yellow, or
+  // 'connected' -> neutral) — every state maps to exactly the tone above, and
+  // no two adjacent branches collapse onto each other by accident.
+  it('keeps green/red/neutral each reachable by exactly the states above', () => {
+    const byTone = new Map<string, ScopeHealthState[]>();
+    for (const [state, tone] of Object.entries(EXPECTED)) {
+      byTone.set(tone, [...(byTone.get(tone) ?? []), state as ScopeHealthState]);
+    }
+    expect(byTone.get('green')).toEqual(['connected']);
+    expect(byTone.get('red')!.sort()).toEqual(['disconnected', 'failed']);
+    expect(byTone.get('neutral')).toEqual(['inactive']);
+  });
+
+  it.each(Object.entries(EXPECTED) as Array<[ScopeHealthState, string]>)(
+    'renders data-tone=%s for the rendered health field',
+    (state, tone) => {
+      withSurface(withField(base(), 'health', { value: state }), (s) => {
+        expect(s.health()!.dataset.tone).toBe(tone);
+        expect(s.health()!.textContent).toContain(state);
+      });
+    },
+  );
+});
+
+// ── 4. hardwareConnected (MOR-1312, MOR-1352 finding) ───────────────────────
+
+describe('hardwareConnected renders independent of source/health', () => {
+  it('renders "on" when the hardware channel is connected', () => {
+    withSurface(withField(base(), 'hardwareConnected', { value: true }), (s) => {
+      expect(s.hardware()!.textContent).toContain('on');
+      expect(s.hardware()!.textContent).not.toContain('off');
+    });
+  });
+
+  it('renders "off" when the hardware channel is not connected', () => {
+    withSurface(withField(base(), 'hardwareConnected', { value: false }), (s) => {
+      expect(s.hardware()!.textContent).toContain('off');
+    });
+  });
+
+  it('renders unknown, never a guessed boolean, when unobserved', () => {
+    withSurface(
+      withField(base(), 'hardwareConnected', { unknown: true, availability: UNOBSERVED }),
+      (s) => {
+        expect(s.hardware()!.textContent).toContain(UNKNOWN_TEXT);
+        expect(s.hardware()!.dataset.observed).toBe('false');
+      },
+    );
+  });
+
+  // The MOR-1352 case itself: audio_fft selected AND healthy, hardware still
+  // reported separately as connected. Proves the leaf is not derived from
+  // `health`/`source` — see the adapter-level probe of the same name.
+  it('stays true while source=audio_fft and health=connected', () => {
+    let view = withField(base(), 'source', { value: 'audio_fft' });
+    view = withField(view, 'health', { value: 'connected' });
+    view = withField(view, 'hardwareConnected', { value: true });
+    withSurface(view, (s) => {
+      expect(s.source()!.textContent).toContain('audio_fft');
+      expect(s.hardware()!.textContent).toContain('on');
+    });
+  });
+});
+
+// ── 5. Two-level availability (MOR-977/1256) ──────────────────────────────
+
+describe('structural availability never renders as a guessed value', () => {
+  it('keeps an operationally-unavailable field PRESENT and marked unobserved', () => {
+    withSurface(withField(base(), 'source', { unknown: true, availability: UNOBSERVED }), (s) => {
+      expect(s.source()).not.toBeNull();
+      expect(s.source()!.dataset.observed).toBe('false');
+    });
+  });
+
+  // Every leaf the 12A/12B adapter emits is structurally present whenever the
+  // group itself is present (`deriveScopeDisplay` always passes `structural:
+  // true`) — this is a closed-shape sanity check, not a live adapter test.
+  it('never encodes state by colour alone in its own stylesheet', () => {
+    const styles = SOURCE.slice(SOURCE.indexOf('<style>'));
+    expect(styles).not.toMatch(/#[0-9a-f]{3,8}\b|\brgb\(|\bhsl\(/i);
+  });
+
+  it('does not gate its own render on structural absence (no case exercises it live)', () => {
+    // Documents intent: `ABSENT` is unreachable from the real adapter today
+    // (both leaves are always structural:true), but the surface's `usable()`
+    // helper still degrades correctly if that ever changes.
+    withSurface(withField(base(), 'source', { availability: ABSENT, unknown: true }), (s) => {
+      expect(s.source()!.dataset.observed).toBe('false');
+    });
+  });
+});

--- a/frontend/src/semantic/__tests__/scope-display.test.ts
+++ b/frontend/src/semantic/__tests__/scope-display.test.ts
@@ -1,9 +1,12 @@
 /**
  * MOR-1262 decomposition slice 12A (MOR-1301, the FINAL A-slice of the
  * vocabulary program) — `scopeDisplay` optional fact group (validator half).
+ * Extended by slice 12B (MOR-1312, the LAST vocabulary slice) with the
+ * `hardwareConnected` leaf (MOR-1352 finding).
  *
  * Facts: which scope SOURCE is currently live (hardware CI-V frames vs the
- * browser audio FFT) and how HEALTHY that source's connection is — never
+ * browser audio FFT), how HEALTHY that source's connection is, and whether
+ * the HARDWARE channel is connected independent of that selection — never
  * scope tuning (`scopeControls`, slice 11A/11A′, unchanged by this file) and
  * never scope pixels/overlays. See `radio-view-model.ts`'s
  * `ScopeDisplayViewModel` doc comment for the full rationale, and
@@ -43,7 +46,7 @@ describe('scopeDisplay (MOR-1262 slice 12A)', () => {
     expect(() => validateRadioViewModel({ ...base, scopeDisplay: {} })).toThrow(TypeError);
   });
 
-  it('rejects an extra key on the group (closed shape, exactly the two facts)', () => {
+  it('rejects an extra key on the group (closed shape, exactly the three facts)', () => {
     const withSd = withScopeDisplay(base);
     const extra: ScopeDisplayField<number> = { reading: { status: 'known', value: 0 }, availability: AVAIL };
     const malformed = { ...withSd, scopeDisplay: { ...withSd.scopeDisplay, bogus: extra } };
@@ -94,6 +97,35 @@ describe('scopeDisplay (MOR-1262 slice 12A)', () => {
         scopeDisplay: { ...withSd.scopeDisplay, health: { reading: { status: 'known', value: health }, availability: AVAIL } },
       };
       expect(validateRadioViewModel(model).scopeDisplay!.health.reading).toEqual({ status: 'known', value: health });
+    }
+  });
+
+  // MOR-1312 (12B) — `hardwareConnected` leaf.
+  it('rejects an invalid hardwareConnected reading value with a precise error path', () => {
+    const withSd = withScopeDisplay(base);
+    const malformed = {
+      ...withSd,
+      scopeDisplay: {
+        ...withSd.scopeDisplay,
+        hardwareConnected: { reading: { status: 'known', value: 'yes' }, availability: AVAIL },
+      },
+    };
+    expect(() => validateRadioViewModel(malformed))
+      .toThrow(/\$\.scopeDisplay\.hardwareConnected\.reading\.value/);
+  });
+
+  it('accepts both boolean values for hardwareConnected', () => {
+    for (const value of [true, false]) {
+      const withSd = withScopeDisplay(base);
+      const model = {
+        ...withSd,
+        scopeDisplay: {
+          ...withSd.scopeDisplay,
+          hardwareConnected: { reading: { status: 'known', value }, availability: AVAIL },
+        },
+      };
+      expect(validateRadioViewModel(model).scopeDisplay!.hardwareConnected.reading)
+        .toEqual({ status: 'known', value });
     }
   });
 });

--- a/frontend/src/semantic/fixtures/topologies.ts
+++ b/frontend/src/semantic/fixtures/topologies.ts
@@ -493,9 +493,12 @@ export function withScopeControls(fixture: RadioViewModel): RadioViewModel {
 }
 
 /**
- * Applies a fully-observed `scopeDisplay` group (MOR-1262 slice 12A/
- * MOR-1301, the FINAL A-slice) to any topology fixture — same
- * composable-axis story as `withScopeControls` above.
+ * Applies a fully-observed `scopeDisplay` group (MOR-1262 slice 12A/12B,
+ * MOR-1301/MOR-1312) to any topology fixture — same composable-axis story as
+ * `withScopeControls` above. `hardwareConnected` (12B) defaults to matching
+ * `source`/`health` (hardware, connected) — the case where the leaf is
+ * redundant with `health`; callers exercising the `audio_fft` residual
+ * (MOR-1352) override it explicitly.
  */
 export function withScopeDisplay(fixture: RadioViewModel): RadioViewModel {
   const avail: Availability = { structural: true, operational: true };
@@ -505,6 +508,7 @@ export function withScopeDisplay(fixture: RadioViewModel): RadioViewModel {
   const scopeDisplay: ScopeDisplayViewModel = {
     source: known('hardware'),
     health: known('connected'),
+    hardwareConnected: known(true),
   };
   return { ...fixture, scopeDisplay };
 }

--- a/frontend/src/semantic/radio-view-model.ts
+++ b/frontend/src/semantic/radio-view-model.ts
@@ -907,10 +907,25 @@ export type ScopeHealthState =
  * determinism), so the caller supplies a plain snapshot
  * (`ScopeDisplaySnapshot`, `radio-view-model-adapter.ts`) and NO snapshot
  * means NO group, same as `rxAudio`.
+ *
+ * CORRECTION (MOR-1312, slice 12B, MOR-1352): the 12A enumeration called
+ * `runtime.scope.hardwareScopeConnected` (`ScopeController`,
+ * `components/spectrum/SpectrumPanel.svelte`) "fully subsumed by `source` +
+ * `health`". That is false when `source === 'audio_fft'`: `health` then
+ * classifies the SELECTED (audio) channel, and says nothing about whether
+ * the hardware channel is ALSO connected. `hardwareConnected` below closes
+ * that gap as its own leaf rather than folding the input into
+ * `classifyScopeHealth` — that function is pinned byte-identical to the
+ * shipped `deriveScopeIndicatorState`, which does not take this input, so
+ * folding it in would break the parity slice 12A established.
  */
 export interface ScopeDisplayViewModel {
   source: ScopeDisplayField<ScopeSourceKind>;
   health: ScopeDisplayField<ScopeHealthState>;
+  /** Mirrors `runtime.scope.hardwareScopeConnected` verbatim — independent
+   *  of `source`, tracking the hardware channel's own transport regardless
+   *  of which source is currently selected. See the CORRECTION note above. */
+  hardwareConnected: ScopeDisplayField<boolean>;
 }
 
 export interface RadioViewModel {
@@ -1523,10 +1538,11 @@ const SCOPE_HEALTH_STATES: readonly ScopeHealthState[] = [
 
 function validateScopeDisplay(value: unknown, path: string): ScopeDisplayViewModel {
   const v = record(value, path);
-  exactKeys(v, ['source', 'health'], path);
+  exactKeys(v, ['source', 'health', 'hardwareConnected'], path);
   return {
     source: validateTxAuxField(v.source, `${path}.source`, (val, p) => oneOf(val, SCOPE_SOURCES, p)),
     health: validateTxAuxField(v.health, `${path}.health`, (val, p) => oneOf(val, SCOPE_HEALTH_STATES, p)),
+    hardwareConnected: validateTxAuxField(v.hardwareConnected, `${path}.hardwareConnected`, bool),
   };
 }
 

--- a/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
+++ b/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
@@ -46,6 +46,17 @@ vi.mock('$lib/runtime', () => ({
     // RX-audio snapshot (the FOURTH argument).
     get audio() { return { muted: true, rxEnabled: false, volume: 0 }; },
     get connectionAudio() { return false; },
+    // MOR-1312 slice 12B: the wiring now also hands the adapter a
+    // scope-display snapshot (the FIFTH argument). This fixture declares no
+    // scope capability, so this stays on its pre-1312 path regardless.
+    get defaultScopeStatus() {
+      return {
+        source: null, available: false, resourceSelected: false, demand: 0,
+        lifecycle: 'inactive', transport: 'disconnected', frameSeen: false,
+      };
+    },
+    get radioPowerOn() { return null; },
+    get scope() { return { hardwareScopeConnected: false }; },
   },
 }));
 vi.mock('$lib/runtime/tx-controller/app-host', () => ({
@@ -286,6 +297,14 @@ const audioOnlyScopeCaps = (): Capabilities => ({
   ...mainSubCaps(), scope: false,
   capabilities: mainSubCaps().capabilities.filter((t) => t !== 'scope'),
   audioFftAvailable: true,
+  // MOR-1312 slice 12B (rebase fix): `hasAnyScopeCap` (the scopeDisplay
+  // facts gate, radio-view-model-adapter.ts) reads `scopeSource`, not
+  // `audioFftAvailable` — this fixture predates 12B and only set the latter.
+  // Naming the audio-FFT source here keeps `hasAnyScopeCap` true across both
+  // caps variants in this describe block, matching this fixture's own intent
+  // (scope=false but audio-FFT IS an available scope source) and preserving
+  // the "changes nothing in the cockpit" invariant the test proves.
+  scopeSource: 'audio_fft',
 } as unknown as Capabilities);
 
 /**


### PR DESCRIPTION
## Summary

12B: ScopeDisplaySurface over the scopeDisplay facts (MOR-1301, 12A) - THE FINAL VOCABULARY SLICE. Pure readout (zero focusable elements): live source + source-qualified health + hardware connectivity; frames stay an App-owned resource demand; no scope tuning (that is scopeControls); overlays out of scope. Mounts bare in BOTH compositions (the canon's permitted pure-readout case) with the zero-focusable property PINNED at two levels so a future control addition trips the canon.

MOR-1352 resolved in-slice: hardwareConnected is its own leaf read straight from the snapshot (never through classifyScopeHealth - preserves the 12A byte-parity pin); the audio_fft case verified at source; 12A doc comment carries an explicit CORRECTION block. The scopeDisplaySnapshot wiring makes the group production-reachable (the A/B split completes).

Production LOC 73 (verifier-measured, frozen formula - the builder's '200' was raw --stat). GUARDRAIL WAIVER (explicit, per MOR-1312 verify recommendation): 5 production files vs the 3-file limit - files 4/5 are the facts-layer MOR-1352 resolution the coordinator directed in-slice, 5 counted lines total.

## Review provenance

Verified by the vocabulary-domain opus anchor #2 (session 8): PASS with zero required code fixes. Pure-readout claim proven by reading every branch + button-injection probe (slice pins die AND post-1351 cockpit goes 4-red); ConnectionState type-only-import skip adjudicated SOUND and FORCED (binding transport-purity guards match the specifier; residual fails loud at compile time); 13 pre-existing runtime-mock crash fixes spot-checked as inert insertions; 6/7 mutants killed, 7th proven unreachable (classifyScopeHealth total). Harness: the group EMITS post-1351 and the surface is invisible to the control inventory BY CONSTRUCTION (zero focusable) - 60/60, 1797/1797.

Rebase: 12-name final literal across 12 sites; 9 runtime-mock fixes (18 sites swept); snippet-boundary hand-reconstruction; suite 281/281 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)