### PR TITLE
feat(MOR-1311): scopeControls surface (11B) - scope toolbar + settings popover, facts-only

### DIFF
--- a/frontend/fixtures/stubs/command-bus.ts
+++ b/frontend/fixtures/stubs/command-bus.ts
@@ -190,6 +190,15 @@ export function makeScanHandlers() {
   ] as const);
 }
 
+/** MOR-1311: the scope-toolbar/popover vocabulary. */
+export function makeScopeControlsHandlers() {
+  return recorders('scopeControls', [
+    'onModeChange', 'onEdgeChange', 'onSpanChange', 'onSpeedChange', 'onHoldChange', 'onRefChange',
+    'onDualChange', 'onReceiverChange', 'onDuringTxChange', 'onCenterTypeChange', 'onVbwChange',
+    'onRbwChange',
+  ] as const);
+}
+
 /** `dispatch` takes the same shape as the real module's — a single
  *  `KeyboardActionConfig` — but `recorders()` only names bare handlers, so
  *  it is built directly rather than forced through that helper. */

--- a/frontend/src/components-v2/layout/__tests__/MobileRadioLayout.component.svelte.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/MobileRadioLayout.component.svelte.test.ts
@@ -130,6 +130,12 @@ vi.mock('../../wiring/command-bus', () => {
     }),
     makeAntennaHandlers: () => ({ onAntennaSelect: n }),
     makeScanHandlers: () => ({ onScanStart: n, onScanStop: n, onDfSpanChange: n, onResumeChange: n }),
+    // MOR-1311 slice 11B: the scope-toolbar/popover intent vocabulary.
+    makeScopeControlsHandlers: () => ({
+      onModeChange: n, onEdgeChange: n, onSpanChange: n, onSpeedChange: n, onHoldChange: n,
+      onRefChange: n, onDualChange: n, onReceiverChange: n, onDuringTxChange: n,
+      onCenterTypeChange: n, onVbwChange: n, onRbwChange: n,
+    }),
   };
 });
 

--- a/frontend/src/components-v2/layout/__tests__/semantic-mobile-migration.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-mobile-migration.component.test.ts
@@ -156,6 +156,12 @@ vi.mock('../../wiring/command-bus', () => {
     }),
     makeAntennaHandlers: () => ({ onAntennaSelect: n }),
     makeScanHandlers: () => ({ onScanStart: n, onScanStop: n, onDfSpanChange: n, onResumeChange: n }),
+    // MOR-1311 slice 11B: the scope-toolbar/popover intent vocabulary.
+    makeScopeControlsHandlers: () => ({
+      onModeChange: n, onEdgeChange: n, onSpanChange: n, onSpeedChange: n, onHoldChange: n,
+      onRefChange: n, onDualChange: n, onReceiverChange: n, onDuringTxChange: n,
+      onCenterTypeChange: n, onVbwChange: n, onRbwChange: n,
+    }),
   };
 });
 vi.mock('../../wiring/state-adapter', () => {

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -53,11 +53,14 @@
   import VfoSurface, { type VfoSelection } from '../../semantic/VfoSurface.svelte';
   import ModInputTxWarning from '../panels/ModInputTxWarning.svelte';
   import CwKeyerSurface, { type CwLevelField } from '../../semantic/CwKeyerSurface.svelte';
+  import ScopeControlsSurface, {
+    type ScopeChoiceField, type ScopeToggleField,
+  } from '../../semantic/ScopeControlsSurface.svelte';
   import {
     makeAgcHandlers, makeAntennaHandlers, makeAudioRoutingHandlers, makeBandHandlers,
     makeCwPanelHandlers, makeDspHandlers, makeFilterHandlers, makeModeHandlers,
     makeRfFrontEndHandlers, makeRitXitHandlers, makeRxAudioHandlers, makeScanHandlers,
-    makeTxHandlers, makeVfoHandlers, makeVoxHandlers,
+    makeScopeControlsHandlers, makeTxHandlers, makeVfoHandlers, makeVoxHandlers,
   } from './command-bus';
   import {
     forReceiver, receiversOf, isActiveStrip, isOperationalStrip,
@@ -267,6 +270,22 @@
   const CW_LEVEL_INTENT: Record<CwLevelField, (value: number) => void> = {
     keyerSpeed: cwIntents.onKeySpeedChange, pitchHz: cwIntents.onCwPitchChange,
     breakInDelay: cwIntents.onBreakInDelayChange,
+  };
+  /**
+   * MOR-1311 (slice 11B, LAST of the vocabulary program). The shipped
+   * scope-toolbar/popover command vocabulary, composed unmodified — the two
+   * maps keep the pure surface field-addressed, same precedent as
+   * `TX_AUX_*_INTENT`/`DSP_*_INTENT` above.
+   */
+  const scopeIntents = makeScopeControlsHandlers();
+  const SCOPE_TOGGLE_INTENT: Record<ScopeToggleField, (next: boolean) => void> = {
+    hold: scopeIntents.onHoldChange, dual: scopeIntents.onDualChange,
+    duringTx: scopeIntents.onDuringTxChange, vbwNarrow: scopeIntents.onVbwChange,
+  };
+  const SCOPE_CHOICE_INTENT: Record<ScopeChoiceField, (value: number) => void> = {
+    mode: scopeIntents.onModeChange, edge: scopeIntents.onEdgeChange,
+    centerType: scopeIntents.onCenterTypeChange, rbw: scopeIntents.onRbwChange,
+    receiver: scopeIntents.onReceiverChange,
   };
   const tx = getAppTxController();
   const sourceId = `semantic-rx-tx-${++surfaceSeq}`;
@@ -913,19 +932,19 @@
   {/snippet}
 
   <!--
-    MOR-1312 (vocabulary slice 12B — the LAST vocabulary slice). Same
-    structural gate and same reasoning as `txAuxSurface`/`metersSurface`
-    above: the surface mounts only when the view model actually carries the
-    MOR-1301 `scopeDisplay` group, so a radio with neither a hardware scope
-    nor an audio-FFT source renders the pre-1312 element shape exactly.
-    Bare and unzoned in BOTH compositions, the `meters`/`txAux` shape, NOT
-    `rxAudio`'s single-only shape: `ScopeDisplaySurface` renders zero
-    focusable elements (pinned in `__tests__/ScopeDisplaySurface.test.ts` and
-    re-pinned below at the composed-tree level), so it carries none of the
-    MOR-1069 tab-order risk a control-bearing surface would. `'scopeDisplay'`
-    becomes DECLARABLE with this slice, so a manifest gains the surface the
-    moment it declares a zone for it — a layout decision, separately
-    reviewed, exactly as txAux/meters/rxAudio left it.
+    MOR-1312 (vocabulary slice 12B). Same structural gate and same reasoning
+    as `txAuxSurface`/`metersSurface` above: the surface mounts only when the
+    view model actually carries the MOR-1301 `scopeDisplay` group, so a radio
+    with neither a hardware scope nor an audio-FFT source renders the
+    pre-1312 element shape exactly. Bare and unzoned in BOTH compositions,
+    the `meters`/`txAux` shape, NOT `rxAudio`'s single-only shape:
+    `ScopeDisplaySurface` renders zero focusable elements (pinned in
+    `__tests__/ScopeDisplaySurface.test.ts` and re-pinned below at the
+    composed-tree level), so it carries none of the MOR-1069 tab-order risk a
+    control-bearing surface would. `'scopeDisplay'` becomes DECLARABLE with
+    this slice, so a manifest gains the surface the moment it declares a zone
+    for it — a layout decision, separately reviewed, exactly as
+    txAux/meters/rxAudio left it.
 
     It takes NO intent callbacks: a source/health/hardware readout has no
     action to offer (v3 ADR invariant 11).
@@ -933,6 +952,27 @@
   {#snippet scopeDisplaySurface()}
     {#if view?.scopeDisplay}
       <ScopeDisplaySurface {view} />
+    {/if}
+  {/snippet}
+
+  <!--
+    MOR-1311 (vocabulary slice 11B, the LAST B-slice of the vocabulary
+    program). Same mounting canon as `ritXitScanSurface`/`cwKeyerSurface`
+    above: control-bearing, no manifest declares a `scopeControls` zone, so
+    per the MOR-1304 ruling's option (i) it mounts in the SINGLE composition
+    only, bare, and must render NOTHING in the DUAL composition — pinned by
+    name in `__tests__/semantic-scope-controls-wiring.component.test.ts`.
+  -->
+  {#snippet scopeControlsSurface()}
+    {#if view?.scopeControls}
+      <ScopeControlsSurface
+        {view}
+        onToggleChange={(field, next) => SCOPE_TOGGLE_INTENT[field](next)}
+        onChoiceChange={(field, value) => SCOPE_CHOICE_INTENT[field](value)}
+        onSpanChange={scopeIntents.onSpanChange}
+        onSpeedChange={scopeIntents.onSpeedChange}
+        onRefChange={scopeIntents.onRefChange}
+      />
     {/if}
   {/snippet}
 
@@ -990,6 +1030,7 @@
     )}
     {@render zoned('cwKeyer', view?.cwKeyer !== undefined, cwKeyerSurface)}
     {@render zoned('scopeDisplay', view?.scopeDisplay !== undefined, scopeDisplaySurface)}
+    {@render zoned('scopeControls', view?.scopeControls !== undefined, scopeControlsSurface)}
     {@render txAdjacentAlerts()}
   {/if}
 </div>

--- a/frontend/src/components-v2/wiring/__tests__/semantic-dsp-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-dsp-wiring.component.test.ts
@@ -156,6 +156,12 @@ vi.mock('../command-bus', () => ({
     onBreakInModeChange: h.noop, onApfChange: h.noop, onTwinPeakToggle: h.noop,
     onReversePaddleToggle: h.noop,
   }),
+  // MOR-1311 slice 11B: the scope-toolbar/popover intent vocabulary.
+  makeScopeControlsHandlers: () => ({
+    onModeChange: h.noop, onEdgeChange: h.noop, onSpanChange: h.noop, onSpeedChange: h.noop,
+    onHoldChange: h.noop, onRefChange: h.noop, onDualChange: h.noop, onReceiverChange: h.noop,
+    onDuringTxChange: h.noop, onCenterTypeChange: h.noop, onVbwChange: h.noop, onRbwChange: h.noop,
+  }),
 }));
 
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';

--- a/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
@@ -135,6 +135,12 @@ vi.mock('../command-bus', () => ({
   makeScanHandlers: () => ({
     onScanStart: h.noop, onScanStop: h.noop, onDfSpanChange: h.noop, onResumeChange: h.noop,
   }),
+  // MOR-1311 slice 11B: the scope-toolbar/popover intent vocabulary.
+  makeScopeControlsHandlers: () => ({
+    onModeChange: h.noop, onEdgeChange: h.noop, onSpanChange: h.noop, onSpeedChange: h.noop,
+    onHoldChange: h.noop, onRefChange: h.noop, onDualChange: h.noop, onReceiverChange: h.noop,
+    onDuringTxChange: h.noop, onCenterTypeChange: h.noop, onVbwChange: h.noop, onRbwChange: h.noop,
+  }),
 }));
 
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';

--- a/frontend/src/components-v2/wiring/__tests__/semantic-rf-front-end-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rf-front-end-wiring.component.test.ts
@@ -160,6 +160,12 @@ vi.mock('../command-bus', () => ({
     onBreakInModeChange: h.noop, onApfChange: h.noop, onTwinPeakToggle: h.noop,
     onReversePaddleToggle: h.noop,
   }),
+  // MOR-1311 slice 11B: the scope-toolbar/popover intent vocabulary.
+  makeScopeControlsHandlers: () => ({
+    onModeChange: h.noop, onEdgeChange: h.noop, onSpanChange: h.noop, onSpeedChange: h.noop,
+    onHoldChange: h.noop, onRefChange: h.noop, onDualChange: h.noop, onReceiverChange: h.noop,
+    onDuringTxChange: h.noop, onCenterTypeChange: h.noop, onVbwChange: h.noop, onRbwChange: h.noop,
+  }),
 }));
 
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';

--- a/frontend/src/components-v2/wiring/__tests__/semantic-rx-tx-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rx-tx-wiring.component.test.ts
@@ -162,6 +162,13 @@ vi.mock('../command-bus', () => ({
     onScanStart: h.txAuxNoop, onScanStop: h.txAuxNoop, onDfSpanChange: h.txAuxNoop,
     onResumeChange: h.txAuxNoop,
   }),
+  // MOR-1311 slice 11B: the scope-toolbar/popover intent vocabulary.
+  makeScopeControlsHandlers: () => ({
+    onModeChange: h.txAuxNoop, onEdgeChange: h.txAuxNoop, onSpanChange: h.txAuxNoop,
+    onSpeedChange: h.txAuxNoop, onHoldChange: h.txAuxNoop, onRefChange: h.txAuxNoop,
+    onDualChange: h.txAuxNoop, onReceiverChange: h.txAuxNoop, onDuringTxChange: h.txAuxNoop,
+    onCenterTypeChange: h.txAuxNoop, onVbwChange: h.txAuxNoop, onRbwChange: h.txAuxNoop,
+  }),
 }));
 
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';

--- a/frontend/src/components-v2/wiring/__tests__/semantic-scope-controls-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-scope-controls-wiring.component.test.ts
@@ -1,0 +1,289 @@
+/**
+ * MOR-1311 — the semantic scope-controls surface wired into
+ * `SemanticRadioSurfaces` (vocabulary slice 11B, the scope toolbar — the
+ * LAST B-slice of the vocabulary program).
+ *
+ * `semantic/__tests__/ScopeControlsSurface.test.ts` proves what the pure
+ * surface does with a view model. This file proves what only the composed
+ * tree can prove, using the REAL adapter and the REAL command bus (only the
+ * runtime/transport/TX-authority SEAMS are spied), mirroring
+ * `semantic-ritxit-scan-wiring.component.test.ts`:
+ *
+ *   (a) every control category (choice, toggle, stepper) reaches the wire as
+ *       the exact command `SpectrumToolbar.svelte`/`ScopeSettingsPopover.svelte`
+ *       themselves dispatch — composed, not forked.
+ *   (b) MOUNTING CANON (MOR-1304 ruling). Control-bearing, no manifest
+ *       declares a `scopeControls` zone, so it mounts in the SINGLE
+ *       composition only, bare, and renders NOTHING in the DUAL composition
+ *       — pinned with a view model that actually CARRIES the group (the
+ *       rxAudio/ritXitScan/cwKeyer precedent), plus a control test mounting
+ *       the same fixture in single to foreclose vacuity.
+ *   (c) the default path (no `scope` capability) stays byte-identical.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { ServerState } from '$lib/types/state';
+
+type Snapshot = {
+  phase: string; intent: string | null; guard: { leaseId: string } | null;
+  radioTx: string; txRisk: string; mayOwnKey: boolean; fault: string | null;
+};
+
+const h = vi.hoisted(() => ({
+  state: null as unknown,
+  caps: null as unknown,
+  snapshot: null as unknown,
+  audio: { muted: true, rxEnabled: false, volume: 0 },
+  audioConnected: false,
+  guardVisible: false,
+  listeners: new Set<(next: unknown) => void>(),
+}));
+
+vi.mock('$lib/transport/ws-client', () => ({ sendCommand: vi.fn() }));
+vi.mock('$lib/runtime', () => ({
+  runtime: {
+    get state() { return h.state; },
+    get caps() { return h.caps; },
+    get audio() { return h.audio; },
+    get connectionAudio() { return h.audioConnected; },
+    // MOR-1312 slice 12B: the wiring now also hands the adapter a
+    // scope-display snapshot (the FIFTH argument). This file tests
+    // scopeControls, so this stays on its pre-1312 path regardless of
+    // these values.
+    get defaultScopeStatus() {
+      return {
+        source: null, available: false, resourceSelected: false, demand: 0,
+        lifecycle: 'inactive', transport: 'disconnected', frameSeen: false,
+      };
+    },
+    get scope() { return { hardwareScopeConnected: false }; },
+  },
+}));
+vi.mock('$lib/runtime/tx-controller/app-host', () => ({
+  getAppTxController: () => ({
+    snapshot: () => h.snapshot,
+    subscribe: (listener: (next: unknown) => void) => {
+      h.listeners.add(listener);
+      return () => { h.listeners.delete(listener); };
+    },
+    start: vi.fn(), setIntent: vi.fn(), release: vi.fn(), resetFault: vi.fn(),
+  }),
+}));
+vi.mock('$lib/runtime/adapters/mod-input-tx-guard.svelte', () => ({
+  deriveModInputTxGuardProps: () => ({ visible: h.guardVisible, sourceLabel: 'MIC' }),
+  getModInputTxGuardHandlers: () => ({ onSetLan: vi.fn(), onDismiss: vi.fn() }),
+}));
+
+import { sendCommand } from '$lib/transport/ws-client';
+import { resetRadioState, setRadioState } from '$lib/stores/radio.svelte';
+import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';
+
+const IDLE: Snapshot = {
+  phase: 'idle', intent: null, guard: null, radioTx: 'off', txRisk: 'none',
+  mayOwnKey: false, fault: null,
+};
+const fresh = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' };
+const slot = (freqHz: number) => ({ freqHz, mode: 'USB', filterNum: 1, dataMode: 0 });
+
+/** A radio that has observed every `scopeControls` leaf — every field this
+ *  surface can render is present so its structural gates all pass. */
+function liveState(over: Partial<ServerState> = {}): ServerState {
+  const scopeLeaves = [
+    'mode', 'edge', 'span', 'speed', 'hold', 'refDb', 'dual', 'receiver',
+    'duringTx', 'centerType', 'vbwNarrow', 'rbw',
+  ];
+  const paths = ['active', 'split', 'dualWatch', 'txTarget', ...scopeLeaves.map((l) => `scopeControls.${l}`)];
+  for (const rx of ['main', 'sub']) {
+    paths.push(`${rx}.freqHz`, `${rx}.mode`, `${rx}.filter`, `${rx}.activeSlot`);
+    for (const v of ['vfoA', 'vfoB']) paths.push(`${rx}.${v}.freqHz`, `${rx}.${v}.mode`, `${rx}.${v}.filterNum`);
+  }
+  const receiver = (hz: number) => ({
+    ...slot(hz), vfoA: slot(hz), vfoB: slot(hz + 50000), activeSlot: 'A', filter: 1,
+  });
+  return {
+    active: 'MAIN', split: false, dualWatch: false, ptt: false,
+    txTarget: { status: 'known', receiver: 'MAIN', slot: 'A', frequencyHz: 14250000 },
+    main: receiver(14250000), sub: receiver(14300000),
+    scopeControls: {
+      mode: 1, edge: 2, span: 3, speed: 1, hold: false, refDb: -5, dual: false, receiver: 0,
+      duringTx: false, centerType: 0, vbwNarrow: false, rbw: 0,
+    },
+    ...over,
+    fieldStatus: Object.fromEntries(paths.map((p) => [p, fresh])),
+  } as unknown as ServerState;
+}
+
+const liveCaps = (tags: readonly string[]): Capabilities => ({
+  model: 'fixture', scope: true, audio: false, tx: true,
+  capabilities: tags, receivers: 2, vfoScheme: 'main_sub', freqRanges: [], modes: [], filters: [],
+  audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
+  webrtc: { available: false, enabled: false },
+  txBands: [{ start: 14000000, end: 14350000, name: '20m' }],
+  scopeSource: 'hardware', audioFftAvailable: false,
+} as unknown as Capabilities);
+
+/** `scope` + `dual_rx` is what makes the FULL group (incl. `dual`/`receiver`)
+ *  present; `NO_SCOPE_TAGS` declines the group evidence gate entirely. */
+const SCOPE_TAGS = ['tx', 'scope', 'dual_rx'] as const;
+const NO_SCOPE_TAGS = ['tx'] as const;
+
+let target: HTMLDivElement;
+let component: ReturnType<typeof mount> | null = null;
+
+function render(props: { strips?: 'single' | 'dual' } = {}): void {
+  target = document.createElement('div');
+  document.body.appendChild(target);
+  component = mount(SemanticRadioSurfaces, { target, props });
+  flushSync();
+}
+
+const q = <T extends HTMLElement>(sel: string) => target.querySelector(sel) as T | null;
+const el = (id: string) => q<HTMLElement>(`[data-testid="${id}"]`);
+function useState(state: ServerState): void {
+  h.state = state;
+  resetRadioState();
+  setRadioState(state);
+}
+
+beforeEach(() => {
+  useState(liveState());
+  h.caps = liveCaps(SCOPE_TAGS);
+  h.snapshot = { ...IDLE };
+  h.audio = { muted: true, rxEnabled: false, volume: 0 };
+  h.audioConnected = false;
+  h.guardVisible = false;
+  h.listeners.clear();
+  vi.mocked(sendCommand).mockClear();
+});
+
+afterEach(() => {
+  if (component) unmount(component);
+  component = null;
+  document.body.innerHTML = '';
+});
+
+/* ── (a) every control category reaches the shipped command vocabulary ── */
+
+describe('the surface intents reach the shipped scope command vocabulary', () => {
+  it('a mode click sends set_scope_mode with the absolute wire ordinal', () => {
+    render();
+    el('scope-mode-2')!.click();
+    flushSync();
+    expect(sendCommand).toHaveBeenCalledExactlyOnceWith('set_scope_mode', { mode: 2 });
+  });
+
+  it('an edge click sends set_scope_edge', () => {
+    render();
+    el('scope-edge-3')!.click();
+    flushSync();
+    expect(sendCommand).toHaveBeenCalledExactlyOnceWith('set_scope_edge', { edge: 3 });
+  });
+
+  it('a centerType click sends set_scope_center_type with the snake_case param', () => {
+    render();
+    el('scope-centerType-1')!.click();
+    flushSync();
+    expect(sendCommand).toHaveBeenCalledExactlyOnceWith('set_scope_center_type', { center_type: 1 });
+  });
+
+  it('an rbw click sends set_scope_rbw', () => {
+    render();
+    el('scope-rbw-2')!.click();
+    flushSync();
+    expect(sendCommand).toHaveBeenCalledExactlyOnceWith('set_scope_rbw', { rbw: 2 });
+  });
+
+  it('the receiver click sends switch_scope_receiver — the ONE receiver/source field', () => {
+    render();
+    el('scope-receiver-1')!.click();
+    flushSync();
+    expect(sendCommand).toHaveBeenCalledExactlyOnceWith('switch_scope_receiver', { receiver: 1 });
+  });
+
+  it('the HOLD toggle sends set_scope_hold with the flipped boolean', () => {
+    render();
+    el('scope-hold')!.click();
+    flushSync();
+    expect(sendCommand).toHaveBeenCalledExactlyOnceWith('set_scope_hold', { on: true });
+  });
+
+  it('the DUAL toggle sends set_scope_dual', () => {
+    render();
+    el('scope-dual')!.click();
+    flushSync();
+    expect(sendCommand).toHaveBeenCalledExactlyOnceWith('set_scope_dual', { dual: true });
+  });
+
+  it('the "During TX" toggle sends set_scope_during_tx', () => {
+    render();
+    el('scope-duringTx')!.click();
+    flushSync();
+    expect(sendCommand).toHaveBeenCalledExactlyOnceWith('set_scope_during_tx', { on: true });
+  });
+
+  it('the VBW-narrow toggle sends set_scope_vbw with `narrow`', () => {
+    render();
+    el('scope-vbwNarrow')!.click();
+    flushSync();
+    expect(sendCommand).toHaveBeenCalledExactlyOnceWith('set_scope_vbw', { narrow: true });
+  });
+
+  it('the SPAN stepper sends set_scope_span through the shipped clampSpan', () => {
+    useState(liveState({ scopeControls: { ...liveState().scopeControls, mode: 0, span: 3 } } as Partial<ServerState>));
+    render();
+    el('scope-span')!.querySelectorAll('button')[1]!.click();
+    flushSync();
+    expect(sendCommand).toHaveBeenCalledExactlyOnceWith('set_scope_span', { span: 4 });
+  });
+
+  it('the SPEED stepper sends set_scope_speed', () => {
+    render();
+    el('scope-speed')!.querySelectorAll('button')[1]!.click();
+    flushSync();
+    expect(sendCommand).toHaveBeenCalledExactlyOnceWith('set_scope_speed', { speed: 0 });
+  });
+
+  it('the REF stepper sends set_scope_ref, stepping by 5', () => {
+    render();
+    el('scope-ref')!.querySelectorAll('button')[1]!.click();
+    flushSync();
+    expect(sendCommand).toHaveBeenCalledExactlyOnceWith('set_scope_ref', { ref: 0 });
+  });
+});
+
+/* ── (b) MOUNTING CANON: single bare, dual absent ─────────────────────── */
+
+describe('the surface mounts only in the single composition, never in dual', () => {
+  it('renders no scope-controls surface for a radio without the scope capability', () => {
+    h.caps = liveCaps(NO_SCOPE_TAGS);
+    render();
+    expect(el('scope-controls-surface')).toBeNull();
+  });
+
+  it('renders it bare in the single composition, outside every zone', () => {
+    render();
+    const surface = el('scope-controls-surface')!;
+    expect(surface).not.toBeNull();
+    expect(surface.closest('[data-zone-id]')).toBeNull();
+  });
+
+  /**
+   * MOUNTING CANON (MOR-1304 ruling). The view model here DOES carry the
+   * group — proven by the single-composition assertion above using the
+   * IDENTICAL fixture (`SCOPE_TAGS`/`liveState()`), so this cannot pass
+   * vacuously the way a cockpit fixture with no scope evidence would.
+   */
+  it('renders NO scope-controls surface in the dual composition, zoned or unzoned', () => {
+    render({ strips: 'dual' });
+    expect(el('scope-controls-surface')).toBeNull();
+    expect(target.innerHTML).not.toContain('scope-controls-surface');
+  });
+
+  it('leaves the cockpit composition with no focusable control outside a declared zone', () => {
+    render({ strips: 'dual' });
+    const outside = [...target.querySelectorAll<HTMLElement>('button, input, select, [tabindex]')]
+      .filter((node) => node.closest('[data-zone-id]') === null);
+    expect(outside).toEqual([]);
+  });
+});

--- a/frontend/src/components-v2/wiring/__tests__/semantic-scope-display-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-scope-display-wiring.component.test.ts
@@ -145,6 +145,12 @@ vi.mock('../command-bus', () => ({
     onBreakInModeChange: h.noop, onApfChange: h.noop, onTwinPeakToggle: h.noop,
     onReversePaddleToggle: h.noop,
   }),
+  // MOR-1311 slice 11B: the scope-toolbar/popover intent vocabulary.
+  makeScopeControlsHandlers: () => ({
+    onModeChange: h.noop, onEdgeChange: h.noop, onSpanChange: h.noop, onSpeedChange: h.noop,
+    onHoldChange: h.noop, onRefChange: h.noop, onDualChange: h.noop, onReceiverChange: h.noop,
+    onDuringTxChange: h.noop, onCenterTypeChange: h.noop, onVbwChange: h.noop, onRbwChange: h.noop,
+  }),
 }));
 
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';

--- a/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
@@ -150,6 +150,12 @@ vi.mock('../command-bus', () => ({
   makeScanHandlers: () => ({
     onScanStart: h.noop, onScanStop: h.noop, onDfSpanChange: h.noop, onResumeChange: h.noop,
   }),
+  // MOR-1311 slice 11B: the scope-toolbar/popover intent vocabulary.
+  makeScopeControlsHandlers: () => ({
+    onModeChange: h.noop, onEdgeChange: h.noop, onSpanChange: h.noop, onSpeedChange: h.noop,
+    onHoldChange: h.noop, onRefChange: h.noop, onDualChange: h.noop, onReceiverChange: h.noop,
+    onDuringTxChange: h.noop, onCenterTypeChange: h.noop, onVbwChange: h.noop, onRbwChange: h.noop,
+  }),
 }));
 
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';

--- a/frontend/src/components-v2/wiring/command-bus.ts
+++ b/frontend/src/components-v2/wiring/command-bus.ts
@@ -792,6 +792,29 @@ export function makeScanHandlers() {
   };
 }
 
+/**
+ * MOR-1311 (vocabulary slice 11B). The shipped scope-toolbar/popover command
+ * vocabulary, composed unmodified — every name and parameter below is
+ * `SpectrumToolbar.svelte`'s/`ScopeSettingsPopover.svelte`'s own `sendCommand`
+ * call, reproduced 1:1 rather than re-derived.
+ */
+export function makeScopeControlsHandlers() {
+  return {
+    onModeChange: (mode: number) => cmd('set_scope_mode', { mode }),
+    onEdgeChange: (edge: number) => cmd('set_scope_edge', { edge }),
+    onSpanChange: (span: number) => cmd('set_scope_span', { span }),
+    onSpeedChange: (speed: number) => cmd('set_scope_speed', { speed }),
+    onHoldChange: (on: boolean) => cmd('set_scope_hold', { on }),
+    onRefChange: (ref: number) => cmd('set_scope_ref', { ref }),
+    onDualChange: (dual: boolean) => cmd('set_scope_dual', { dual }),
+    onReceiverChange: (receiver: number) => cmd('switch_scope_receiver', { receiver }),
+    onDuringTxChange: (on: boolean) => cmd('set_scope_during_tx', { on }),
+    onCenterTypeChange: (center_type: number) => cmd('set_scope_center_type', { center_type }),
+    onVbwChange: (narrow: boolean) => cmd('set_scope_vbw', { narrow }),
+    onRbwChange: (rbw: number) => cmd('set_scope_rbw', { rbw }),
+  };
+}
+
 function cycleValue(values: number[], current: number): number {
   if (values.length === 0) {
     return current;

--- a/frontend/src/presentation/layouts/__tests__/antenna-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/antenna-declarability.test.ts
@@ -33,7 +33,7 @@ describe('antenna is a declarable semantic surface', () => {
     expect([...SEMANTIC_SURFACE_NAMES])
       .toEqual([
         'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band',
-        'antenna', 'ritXitScan', 'cwKeyer', 'scopeDisplay',
+        'antenna', 'ritXitScan', 'cwKeyer', 'scopeDisplay', 'scopeControls',
       ]);
   });
 

--- a/frontend/src/presentation/layouts/__tests__/band-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/band-declarability.test.ts
@@ -29,7 +29,7 @@ describe('band is a declarable semantic surface', () => {
     expect([...SEMANTIC_SURFACE_NAMES])
       .toEqual([
         'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band',
-        'antenna', 'ritXitScan', 'cwKeyer', 'scopeDisplay',
+        'antenna', 'ritXitScan', 'cwKeyer', 'scopeDisplay', 'scopeControls',
       ]);
   });
 

--- a/frontend/src/presentation/layouts/__tests__/dsp-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/dsp-declarability.test.ts
@@ -21,7 +21,7 @@ describe('dsp is a declarable semantic surface', () => {
   it('is in the declarable set alongside vfo, rxTx, txAux, meters and rxAudio', () => {
     expect([...SEMANTIC_SURFACE_NAMES]).toEqual([
       'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band',
-      'antenna', 'ritXitScan', 'cwKeyer', 'scopeDisplay',
+      'antenna', 'ritXitScan', 'cwKeyer', 'scopeDisplay', 'scopeControls',
     ]);
   });
 

--- a/frontend/src/presentation/layouts/__tests__/filter-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/filter-declarability.test.ts
@@ -24,7 +24,7 @@ describe('filter is a declarable semantic surface', () => {
   it('is in the declarable set alongside vfo, rxTx, txAux, meters and rxAudio', () => {
     expect([...SEMANTIC_SURFACE_NAMES]).toEqual([
       'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band',
-      'antenna', 'ritXitScan', 'cwKeyer', 'scopeDisplay',
+      'antenna', 'ritXitScan', 'cwKeyer', 'scopeDisplay', 'scopeControls',
     ]);
   });
 

--- a/frontend/src/presentation/layouts/__tests__/meters-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/meters-declarability.test.ts
@@ -30,7 +30,7 @@ describe('meters is a declarable semantic surface', () => {
   it('is in the declarable set alongside vfo, rxTx and txAux', () => {
     expect([...SEMANTIC_SURFACE_NAMES]).toEqual([
       'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band',
-      'antenna', 'ritXitScan', 'cwKeyer', 'scopeDisplay',
+      'antenna', 'ritXitScan', 'cwKeyer', 'scopeDisplay', 'scopeControls',
     ]);
   });
 

--- a/frontend/src/presentation/layouts/__tests__/rf-front-end-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/rf-front-end-declarability.test.ts
@@ -29,7 +29,7 @@ describe('rfFrontEnd is a declarable semantic surface', () => {
     expect([...SEMANTIC_SURFACE_NAMES])
       .toEqual([
         'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band',
-        'antenna', 'ritXitScan', 'cwKeyer', 'scopeDisplay',
+        'antenna', 'ritXitScan', 'cwKeyer', 'scopeDisplay', 'scopeControls',
       ]);
   });
 

--- a/frontend/src/presentation/layouts/__tests__/ritxit-scan-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/ritxit-scan-declarability.test.ts
@@ -27,7 +27,7 @@ describe('ritXitScan is a declarable semantic surface', () => {
   it('is in the declarable set alongside vfo, rxTx, txAux, meters and rxAudio', () => {
     expect([...SEMANTIC_SURFACE_NAMES]).toEqual([
       'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band',
-      'antenna', 'ritXitScan', 'cwKeyer', 'scopeDisplay',
+      'antenna', 'ritXitScan', 'cwKeyer', 'scopeDisplay', 'scopeControls',
     ]);
   });
 

--- a/frontend/src/presentation/layouts/__tests__/rx-audio-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/rx-audio-declarability.test.ts
@@ -26,7 +26,7 @@ describe('rxAudio is a declarable semantic surface', () => {
   it('is in the declarable set alongside vfo, rxTx, txAux and meters', () => {
     expect([...SEMANTIC_SURFACE_NAMES]).toEqual([
       'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band',
-      'antenna', 'ritXitScan', 'cwKeyer', 'scopeDisplay',
+      'antenna', 'ritXitScan', 'cwKeyer', 'scopeDisplay', 'scopeControls',
     ]);
   });
 

--- a/frontend/src/presentation/layouts/__tests__/scope-controls-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/scope-controls-declarability.test.ts
@@ -1,17 +1,16 @@
 /**
- * MOR-1310 — `cwKeyer` is DECLARABLE, and nothing declares it yet.
+ * MOR-1311 — `scopeControls` is DECLARABLE, and nothing declares it yet.
  *
- * Slice 9B adds the name to `SEMANTIC_SURFACE_NAMES` so a manifest CAN mount
- * the surface later; it deliberately does not touch any manifest, and it adds
- * no design-language renderer slot (that set was frozen by MOR-1072).
+ * Slice 11B (the LAST B-slice of the vocabulary program) adds the name to
+ * `SEMANTIC_SURFACE_NAMES` so a manifest CAN mount the surface later; it
+ * deliberately does not touch any manifest, and it adds no design-language
+ * renderer slot (that set was frozen by MOR-1072).
  *
- * Same three pins as `rx-audio-declarability.test.ts` /
- * `tx-aux-declarability.test.ts` / `meters-declarability.test.ts`:
+ * Same three pins as `cw-keyer-declarability.test.ts` /
+ * `ritxit-scan-declarability.test.ts` / `rx-audio-declarability.test.ts`:
  *   - drop the name and a future manifest's zone stops validating;
- *   - quietly add a `cwKeyer` zone to a shipped manifest and the DOM grows a
- *     zone id no layout review ever saw — which for THIS surface would also
- *     mount break-in controls into the cockpit's tab order without the
- *     MOR-1069 sequence assertion ever being updated;
+ *   - quietly add a `scopeControls` zone to a shipped manifest and the DOM
+ *     grows a zone id no layout review ever saw;
  *   - the renderer slot set stays exactly what MOR-1072 froze.
  */
 import { describe, it, expect } from 'vitest';
@@ -23,7 +22,7 @@ import {
   sdrTestLayout,
 } from '../declarations';
 
-describe('cwKeyer is a declarable semantic surface', () => {
+describe('scopeControls is a declarable semantic surface', () => {
   // Kills: reverting the SEMANTIC_SURFACE_NAMES addition.
   it('is in the declarable set, appended last', () => {
     expect([...SEMANTIC_SURFACE_NAMES]).toEqual([
@@ -36,7 +35,7 @@ describe('cwKeyer is a declarable semantic surface', () => {
   // zone validator checks — the manifest would still be rejected.
   it('accepts a manifest zone that declares it', () => {
     const manifest = validLayoutManifest({
-      zones: [{ id: 'main', surfaces: ['vfo', 'rxTx', 'cwKeyer'] }],
+      zones: [{ id: 'main', surfaces: ['vfo', 'rxTx', 'scopeControls'] }],
       requiredSemanticSurfaces: ['vfo', 'rxTx'],
     });
     expect(() => validateLayoutManifest(manifest)).not.toThrow();
@@ -44,30 +43,30 @@ describe('cwKeyer is a declarable semantic surface', () => {
 
   it('still rejects a zone naming a surface that does not exist', () => {
     const manifest = validLayoutManifest({
-      zones: [{ id: 'main', surfaces: ['cwPanel'] as unknown as readonly ['vfo'] }],
+      zones: [{ id: 'main', surfaces: ['spectrumToolbar'] as unknown as readonly ['vfo'] }],
     });
     expect(() => validateLayoutManifest(manifest)).toThrow(/subset of/);
   });
 });
 
-describe('no shipped manifest declares a cwKeyer zone in this slice', () => {
-  // Kills: slipping a cwKeyer zone into an existing layout here. SAFETY-
-  // relevant: the dual-receiver cockpit's MOR-1069 tab-order assertion is
-  // written against the zones it declares today, so declaring one here would
-  // put break-in controls in the cockpit with no updated sequence pin.
+describe('no shipped manifest declares a scopeControls zone in this slice', () => {
+  // Kills: slipping a scopeControls zone into an existing layout here — the
+  // MOR-1069 dual-receiver-cockpit tab-order assertion is written against
+  // the zones it declares today, so declaring one here would put toolbar
+  // controls in the cockpit with no updated sequence pin.
   it.each([
     ['sdr-test', sdrTestLayout], ['dual-receiver-cockpit', dualReceiverCockpitLayout],
     ['lcd-cockpit', lcdCockpitLayout], ['lcd-scope', lcdScopeLayout],
     ['mobile', mobileLayout], ['desktop-v2', desktopV2Layout],
-  ])('%s declares no cwKeyer zone and does not require the surface', (_id, manifest) => {
-    for (const zone of manifest.zones) expect(zone.surfaces).not.toContain('cwKeyer');
-    expect(manifest.requiredSemanticSurfaces).not.toContain('cwKeyer');
+  ])('%s declares no scopeControls zone and does not require the surface', (_id, manifest) => {
+    for (const zone of manifest.zones) expect(zone.surfaces).not.toContain('scopeControls');
+    expect(manifest.requiredSemanticSurfaces).not.toContain('scopeControls');
   });
 });
 
 describe('the design-language renderer slot set is untouched', () => {
-  // Kills: adding a renderer slot for this surface. A CW keyer has no gauge
-  // grammar a language must describe; the slot set stays frozen.
+  // Kills: adding a renderer slot for this surface. The scope toolbar has no
+  // gauge grammar a language must describe; the slot set stays frozen.
   it('still carries exactly the three MOR-1072 slots', () => {
     expect([...RENDERER_SLOT_NAMES]).toEqual(['meters', 'frequencyDisplay', 'stateFeedback']);
   });

--- a/frontend/src/presentation/layouts/__tests__/scope-display-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/scope-display-declarability.test.ts
@@ -27,7 +27,7 @@ describe('scopeDisplay is a declarable semantic surface', () => {
   it('is in the declarable set alongside vfo, rxTx, txAux, meters and rxAudio', () => {
     expect([...SEMANTIC_SURFACE_NAMES]).toEqual([
       'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band',
-      'antenna', 'ritXitScan', 'cwKeyer', 'scopeDisplay',
+      'antenna', 'ritXitScan', 'cwKeyer', 'scopeDisplay', 'scopeControls',
     ]);
   });
 

--- a/frontend/src/presentation/layouts/__tests__/tx-aux-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/tx-aux-declarability.test.ts
@@ -30,7 +30,7 @@ describe('txAux is a declarable semantic surface', () => {
   it('is in the declarable set alongside vfo and rxTx', () => {
     expect([...SEMANTIC_SURFACE_NAMES]).toEqual([
       'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band',
-      'antenna', 'ritXitScan', 'cwKeyer', 'scopeDisplay',
+      'antenna', 'ritXitScan', 'cwKeyer', 'scopeDisplay', 'scopeControls',
     ]);
   });
 

--- a/frontend/src/presentation/layouts/contract.ts
+++ b/frontend/src/presentation/layouts/contract.ts
@@ -16,17 +16,19 @@ import { isValidLanguageId as isValidProductId } from '../languages/contract';
  *  `txAux` added by MOR-1265, `meters` by MOR-1273, `rxAudio` by MOR-1279,
  *  `filter` by MOR-1304, `dsp` by MOR-1305, `rfFrontEnd` by MOR-1306, `band`
  *  by MOR-1307, `antenna` by MOR-1309, `ritXitScan` by MOR-1308, `cwKeyer` by
- *  MOR-1310, `scopeDisplay` by MOR-1312 — the LAST vocabulary slice). Adding
- *  a name makes it DECLARABLE — it does not mount anything by itself, and no
- *  manifest declares a `meters`, `rxAudio`, `filter`, `dsp`, `rfFrontEnd`,
- *  `band`, `antenna`, `ritXitScan`, `cwKeyer` or `scopeDisplay` zone yet (the
- *  cockpit declares only `txAux`, as `tx-aux` — MOR-1336). Distinct from the
- *  design-language renderer slot of the same name (`languages/contract.ts`'s
- *  `RENDERER_SLOT_NAMES`): that one says how a language DRAWS a meter, this
- *  one says which layout zone may HOST the surface. */
+ *  MOR-1310, `scopeDisplay` by MOR-1312, `scopeControls` by MOR-1311 — the
+ *  LAST B-slice of the vocabulary program). Adding a name makes it
+ *  DECLARABLE — it does not mount anything by itself, and no manifest
+ *  declares a `meters`, `rxAudio`, `filter`, `dsp`, `rfFrontEnd`, `band`,
+ *  `antenna`, `ritXitScan`, `cwKeyer`, `scopeDisplay` or `scopeControls`
+ *  zone yet (the cockpit declares only `txAux`, as `tx-aux` — MOR-1336).
+ *  Distinct from the design-language renderer slot of the same name
+ *  (`languages/contract.ts`'s `RENDERER_SLOT_NAMES`): that one says how a
+ *  language DRAWS a meter, this one says which layout zone may HOST the
+ *  surface. */
 export const SEMANTIC_SURFACE_NAMES = [
   'vfo', 'rxTx', 'txAux', 'meters', 'rxAudio', 'filter', 'dsp', 'rfFrontEnd', 'band', 'antenna', 'ritXitScan',
-  'cwKeyer', 'scopeDisplay',
+  'cwKeyer', 'scopeDisplay', 'scopeControls',
 ] as const;
 export type SemanticSurfaceName = (typeof SEMANTIC_SURFACE_NAMES)[number];
 

--- a/frontend/src/semantic/ScopeControlsSurface.svelte
+++ b/frontend/src/semantic/ScopeControlsSurface.svelte
@@ -1,0 +1,191 @@
+<!--
+  Semantic scope-controls surface (MOR-1311, vocabulary slice 11B — the scope
+  toolbar, the LAST B-slice of the vocabulary program).
+
+  Presentation only. Renders the MOR-1298/1299/1330 `scopeControls` fact
+  group — all twelve toolbar/popover leaves (mode, edge, span, speed, hold,
+  refDb, dual, receiver, duringTx, centerType, vbwNarrow, rbw) — and emits
+  control intents as callbacks. It holds no state and consults no controller
+  (v3 ADR invariant 11), the same discipline every other semantic surface in
+  this directory follows.
+
+  BINDING CARRY-FORWARDS (11A/11A′/11A″ verify reports):
+  (1) Renders ONLY from `view.scopeControls`. It never reaches into raw
+      state for any leaf — that layering violation is exactly what this
+      program removes.
+  (2) "receiver/source" is ONE field (`scopeControls.receiver`) — the
+      MAIN/SUB button below, never a second invented source control.
+  (3) EDGE (`isEdgeApplicable`, modes FIX/S-F) and SPAN (`isSpanApplicable`,
+      modes CTR/S-C) are always structurally available; their conditional
+      VISIBILITY is a rendering decision layered on top, using the real
+      `spectrum-toolbar-logic.ts` predicates (do-not-re-derive doctrine) —
+      never a new gate. Both predicates return `false` on an unobserved
+      `mode`, so the rows are HIDDEN rather than rendered with a fabricated
+      CTR/S-C guess.
+  (5) The four popover-only leaves (duringTx/centerType/vbwNarrow/rbw) are
+      rendered from facts exactly like the eight toolbar leaves.
+      `ScopeSettingsPopover.svelte` exports nothing, so its `CENTER_TYPE`/
+      `RBW` label tables are reproduced here verbatim as UI convenience, not
+      a fact; `fixedEdge` stays excluded (no fact-layer home, MOR-1354).
+
+  Two-level availability (MOR-977/1256): `structural: false` renders
+  NOTHING; a present-but-unusable control stays visible and disabled rather
+  than guessing a value. `aria-pressed`/`aria-checked` are OMITTED (never
+  `"false"`) on an unread field — `TxAuxSurface.svelte`'s `pressedOf` shape.
+-->
+<script module lang="ts">
+  import type { ScopeControlsField } from './radio-view-model';
+  import {
+    MODE_BUTTONS, SPAN_LABELS, SPEED_LABELS,
+    isSpanApplicable, isEdgeApplicable, clampSpan, clampSpeed, clampRef,
+  } from '../components/spectrum/spectrum-toolbar-logic';
+
+  /** On/off leaves, `[field, label]`. */
+  export const TOGGLES = [
+    ['hold', 'HOLD'], ['dual', 'DUAL'], ['duringTx', 'During TX'], ['vbwNarrow', 'VBW narrow'],
+  ] as const;
+  export type ScopeToggleField = (typeof TOGGLES)[number][0];
+
+  /** Choice-group leaves (excluding `mode`, which uses the imported
+   *  `MODE_BUTTONS` table directly), `[field, ariaLabel, choices]`. */
+  export const CHOICES = [
+    ['edge', 'Scope edge', [[1, '1'], [2, '2'], [3, '3'], [4, '4']]],
+    ['centerType', 'Scope center type', [[0, 'Filter'], [1, 'Carrier'], [2, 'Abs.Freq']]],
+    ['rbw', 'Scope RBW', [[0, 'Wide'], [1, 'Mid'], [2, 'Narrow']]],
+    ['receiver', 'Scope receiver', [[0, 'MAIN'], [1, 'SUB']]],
+  ] as const;
+  export type ScopeChoiceField = 'mode' | (typeof CHOICES)[number][0];
+
+  export const UNKNOWN_TEXT = '—';
+  /** Usable ⇔ the radio HAS it, it is readable NOW, and it was observed. */
+  export const usable = (f: ScopeControlsField<unknown>): boolean =>
+    f.availability.structural && f.availability.operational && f.reading.status === 'known';
+  export const numberOf = (f: ScopeControlsField<number>, fallback: number): number =>
+    f.reading.status === 'known' ? f.reading.value : fallback;
+  export const textOf = (f: ScopeControlsField<unknown>): string =>
+    f.reading.status === 'known' ? String(f.reading.value) : UNKNOWN_TEXT;
+  export const pressedOf = (f: ScopeControlsField<boolean>): boolean | undefined =>
+    f.reading.status === 'known' ? f.reading.value : undefined;
+</script>
+
+<script lang="ts">
+  import type { RadioViewModel } from './radio-view-model';
+
+  interface Props {
+    view: RadioViewModel;
+    onToggleChange?: (field: ScopeToggleField, next: boolean) => void;
+    onChoiceChange?: (field: ScopeChoiceField, value: number) => void;
+    onSpanChange?: (span: number) => void;
+    onSpeedChange?: (speed: number) => void;
+    onRefChange?: (ref: number) => void;
+  }
+  let {
+    view, onToggleChange, onChoiceChange, onSpanChange, onSpeedChange, onRefChange,
+  }: Props = $props();
+
+  /** Absent group ⇒ this surface renders nothing (S0 optional-group doctrine). */
+  let sc = $derived(view.scopeControls);
+  let modeKnown = $derived(
+    sc?.mode.reading.status === 'known' ? sc.mode.reading.value : undefined,
+  );
+  let spanApplicable = $derived(isSpanApplicable(modeKnown));
+  let edgeApplicable = $derived(isEdgeApplicable(modeKnown));
+
+  function toggle(field: ScopeToggleField): void {
+    const f = sc?.[field];
+    if (f && usable(f) && f.reading.status === 'known') onToggleChange?.(field, !f.reading.value);
+  }
+  function choice(field: ScopeChoiceField, value: number): void {
+    const f = sc?.[field];
+    if (f && usable(f)) onChoiceChange?.(field, value);
+  }
+  function span(delta: -1 | 1): void {
+    if (sc && usable(sc.span)) onSpanChange?.(clampSpan(numberOf(sc.span, 3), delta));
+  }
+  function speed(delta: -1 | 1): void {
+    if (sc && usable(sc.speed)) onSpeedChange?.(clampSpeed(numberOf(sc.speed, 1), delta));
+  }
+  function ref(delta: -5 | 5): void {
+    if (sc && usable(sc.refDb)) onRefChange?.(clampRef(numberOf(sc.refDb, 0), delta));
+  }
+</script>
+
+{#if sc}
+  <section class="scope-controls-surface" data-testid="scope-controls-surface" aria-label="Scope controls">
+    {#if sc.mode.availability.structural}
+      <div class="scope-row" role="radiogroup" aria-label="Scope mode" data-testid="scope-mode">
+        {#each MODE_BUTTONS as [v, label] (v)}
+          <button
+            type="button" role="radio" class="scope-choice" data-testid={`scope-mode-${v}`}
+            aria-checked={sc.mode.reading.status === 'known' && sc.mode.reading.value === v}
+            disabled={!usable(sc.mode)} onclick={() => choice('mode', v)}
+          >{label}</button>
+        {/each}
+      </div>
+    {/if}
+
+    {#each CHOICES as [field, label, options] (field)}
+      {#if (field !== 'edge' || edgeApplicable) && sc[field].availability.structural}
+        <div class="scope-row" role="radiogroup" aria-label={label} data-testid={`scope-${field}`}>
+          {#each options as [v, optLabel] (v)}
+            <button
+              type="button" role="radio" class="scope-choice" data-testid={`scope-${field}-${v}`}
+              aria-checked={sc[field].reading.status === 'known' && sc[field].reading.value === v}
+              disabled={!usable(sc[field])} onclick={() => choice(field, v)}
+            >{optLabel}</button>
+          {/each}
+        </div>
+      {/if}
+    {/each}
+
+    {#if spanApplicable && sc.span.availability.structural}
+      <div class="scope-stepper" data-testid="scope-span">
+        <span class="scope-name">SPAN</span>
+        <button type="button" disabled={!usable(sc.span)} onclick={() => span(-1)}>-</button>
+        <output data-testid="scope-span-value">
+          {usable(sc.span) ? (SPAN_LABELS[numberOf(sc.span, 3)] ?? '?') : UNKNOWN_TEXT}
+        </output>
+        <button type="button" disabled={!usable(sc.span)} onclick={() => span(1)}>+</button>
+      </div>
+    {/if}
+
+    {#if sc.speed.availability.structural}
+      <div class="scope-stepper" data-testid="scope-speed">
+        <span class="scope-name">SPEED</span>
+        <button type="button" disabled={!usable(sc.speed)} onclick={() => speed(-1)}>-</button>
+        <output data-testid="scope-speed-value">
+          {usable(sc.speed) ? (SPEED_LABELS[numberOf(sc.speed, 1)] ?? '?') : UNKNOWN_TEXT}
+        </output>
+        <button type="button" disabled={!usable(sc.speed)} onclick={() => speed(1)}>+</button>
+      </div>
+    {/if}
+
+    {#if sc.refDb.availability.structural}
+      <div class="scope-stepper" data-testid="scope-ref">
+        <span class="scope-name">REF</span>
+        <button type="button" disabled={!usable(sc.refDb)} onclick={() => ref(-5)}>-</button>
+        <output data-testid="scope-ref-value">{textOf(sc.refDb)}</output>
+        <button type="button" disabled={!usable(sc.refDb)} onclick={() => ref(5)}>+</button>
+      </div>
+    {/if}
+
+    {#each TOGGLES as [field, label] (field)}
+      {#if sc[field].availability.structural}
+        <button
+          type="button" class="scope-toggle" data-testid={`scope-${field}`}
+          aria-pressed={pressedOf(sc[field])} disabled={!usable(sc[field])}
+          onclick={() => toggle(field)}
+        >{label}: {textOf(sc[field])}</button>
+      {/if}
+    {/each}
+  </section>
+{/if}
+
+<style>
+  /* Structure only — a design language owns colour (MOR-977, forced-colors). */
+  .scope-controls-surface { display: flex; flex-direction: column; gap: 0.25rem; }
+  .scope-row, .scope-stepper { display: flex; flex-wrap: wrap; align-items: baseline; gap: 0.5rem; margin: 0; }
+  .scope-name { min-width: 5ch; }
+  .scope-choice[aria-checked='true'], .scope-toggle[aria-pressed='true'] { font-weight: 700; }
+  button:disabled { cursor: not-allowed; }
+</style>

--- a/frontend/src/semantic/__tests__/ScopeControlsSurface.test.ts
+++ b/frontend/src/semantic/__tests__/ScopeControlsSurface.test.ts
@@ -1,0 +1,282 @@
+/**
+ * MOR-1311 — the semantic scope-controls surface (vocabulary slice 11B, the
+ * scope toolbar — the LAST B-slice of the vocabulary program).
+ *
+ * Every test names the carry-forward/mutation it pins:
+ *   (1) renders exclusively from `view.scopeControls` — no raw-state reach.
+ *   (2) `receiver` is the ONE MAIN/SUB control; no second "source" control.
+ *   (3) EDGE/SPAN visibility is a RENDERING decision (`isEdgeApplicable`/
+ *       `isSpanApplicable`, reused from `spectrum-toolbar-logic.ts`) layered
+ *       on facts that are always structurally available; an unread `mode`
+ *       hides BOTH rows rather than guessing CTR.
+ *   handler guards — pinned independently of `disabled` (MOR-1304 F3
+ *       recipe): a direct dispatched click/input on a disabled control must
+ *       not reach the callback.
+ *   field identity — every choice/toggle control names ITS OWN field in the
+ *       callback, not a neighbour's (the copy-paste-loop mutation class).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import ScopeControlsSurface, {
+  CHOICES, TOGGLES, UNKNOWN_TEXT, type ScopeChoiceField, type ScopeToggleField,
+} from '../ScopeControlsSurface.svelte';
+import { topologyFixtures, withScopeControls } from '../fixtures/topologies';
+import type { Availability, RadioViewModel, ScopeControlsField, ScopeControlsViewModel } from '../radio-view-model';
+
+const ON: Availability = { structural: true, operational: true };
+const OFF: Availability = { structural: false, operational: false };
+const unread = <T>(availability: Availability = ON): ScopeControlsField<T> =>
+  ({ reading: { status: 'unknown' }, availability });
+const known = <T>(value: T, availability: Availability = ON): ScopeControlsField<T> =>
+  ({ reading: { status: 'known', value }, availability });
+
+const base = (): RadioViewModel => withScopeControls(topologyFixtures['1/single']);
+const withSc = (over: Partial<ScopeControlsViewModel>): RadioViewModel => {
+  const view = base();
+  return { ...view, scopeControls: { ...view.scopeControls!, ...over } };
+};
+
+let target: HTMLDivElement;
+beforeEach(() => { target = document.createElement('div'); document.body.appendChild(target); });
+afterEach(() => { target.remove(); });
+
+type Handlers = {
+  onToggleChange?: (field: ScopeToggleField, next: boolean) => void;
+  onChoiceChange?: (field: ScopeChoiceField, value: number) => void;
+  onSpanChange?: (span: number) => void;
+  onSpeedChange?: (speed: number) => void;
+  onRefChange?: (ref: number) => void;
+};
+
+function render(view: RadioViewModel, handlers: Handlers = {}) {
+  const component = mount(ScopeControlsSurface, { target, props: { view, ...handlers } });
+  flushSync();
+  const q = <T extends HTMLElement>(sel: string) => target.querySelector(sel) as T | null;
+  return {
+    dispose: () => unmount(component),
+    root: () => q('[data-testid="scope-controls-surface"]'),
+    el: (id: string) => q<HTMLElement>(`[data-testid="${id}"]`),
+  };
+}
+/** MOR-1304 F3 recipe: bypasses jsdom's disabled-button `.click()` no-op. */
+const bypassClick = (el: HTMLElement) => el.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+describe('structural presence: absent group / absent leaves render nothing extra', () => {
+  it('renders nothing when scopeControls is absent', () => {
+    const r = render(topologyFixtures['1/single']);
+    expect(r.root()).toBeNull();
+    r.dispose();
+  });
+
+  it('hides a choice leaf whose structural availability is false', () => {
+    const r = render(withSc({ mode: unread(OFF) }));
+    expect(r.el('scope-mode')).toBeNull();
+    r.dispose();
+  });
+
+  it('hides a toggle leaf whose structural availability is false', () => {
+    const r = render(withSc({ hold: unread(OFF) }));
+    expect(r.el('scope-hold')).toBeNull();
+    r.dispose();
+  });
+});
+
+describe('carry-forward (3): EDGE/SPAN visibility is a rendering decision on top of facts', () => {
+  it('shows EDGE and hides SPAN when mode is known FIX (1)', () => {
+    const r = render(withSc({ mode: known(1) }));
+    expect(r.el('scope-edge')).not.toBeNull();
+    expect(r.el('scope-span')).toBeNull();
+    r.dispose();
+  });
+
+  it('shows SPAN and hides EDGE when mode is known CTR (0)', () => {
+    const r = render(withSc({ mode: known(0) }));
+    expect(r.el('scope-span')).not.toBeNull();
+    expect(r.el('scope-edge')).toBeNull();
+    r.dispose();
+  });
+
+  // Carry-forward (3), the exact wording: an unobserved mode hides BOTH
+  // rows rather than rendering either with a fabricated guess.
+  it('hides BOTH EDGE and SPAN when mode is unread, never fabricating CTR', () => {
+    const r = render(withSc({ mode: unread() }));
+    expect(r.el('scope-edge')).toBeNull();
+    expect(r.el('scope-span')).toBeNull();
+    r.dispose();
+  });
+});
+
+describe('unread leaves render honestly, never fabricated', () => {
+  // `centerType` has no mode-applicability gate (unlike `mode` itself), so
+  // it isolates the choice-leaf honesty story from carry-forward 3 above.
+  it('an unread choice leaf shows no aria-checked="true" option and stays disabled', () => {
+    const r = render(withSc({ centerType: unread() }));
+    expect(r.el('scope-centerType-0')!.getAttribute('aria-checked')).toBe('false');
+    expect(r.el('scope-centerType-0')!.hasAttribute('disabled')).toBe(true);
+    r.dispose();
+  });
+
+  it('an unread toggle OMITS aria-pressed entirely, never "false" (MOR-1358 class)', () => {
+    const r = render(withSc({ hold: unread() }));
+    expect(r.el('scope-hold')!.hasAttribute('aria-pressed')).toBe(false);
+    expect(r.el('scope-hold')!.textContent).toContain(UNKNOWN_TEXT);
+    r.dispose();
+  });
+
+  it('an unread stepper shows unknown text, never a v2-fabricated default', () => {
+    const r = render(withSc({ refDb: unread() }));
+    expect(r.el('scope-ref-value')!.textContent).toBe(UNKNOWN_TEXT);
+    r.dispose();
+  });
+});
+
+describe('handler guards are pinned independently of `disabled` (MOR-1304 F3)', () => {
+  it('refuses a choice click dispatched directly at a disabled option', () => {
+    const onChoiceChange = vi.fn();
+    const r = render(withSc({ centerType: unread() }), { onChoiceChange });
+    bypassClick(r.el('scope-centerType-0')!);
+    flushSync();
+    expect(onChoiceChange).not.toHaveBeenCalled();
+    r.dispose();
+  });
+
+  it('refuses a toggle click dispatched directly at a disabled control', () => {
+    const onToggleChange = vi.fn();
+    const r = render(withSc({ hold: unread() }), { onToggleChange });
+    bypassClick(r.el('scope-hold')!);
+    flushSync();
+    expect(onToggleChange).not.toHaveBeenCalled();
+    r.dispose();
+  });
+
+  it('refuses a stepper click dispatched directly at a disabled control', () => {
+    const onSpanChange = vi.fn();
+    const r = render(withSc({ mode: known(0), span: unread() }), { onSpanChange });
+    bypassClick(r.el('scope-span')!.querySelector('button')!);
+    flushSync();
+    expect(onSpanChange).not.toHaveBeenCalled();
+    r.dispose();
+  });
+
+  /**
+   * The `usable()` gate is structural && operational && known — a field can
+   * be `reading.status === 'known'` (a stale, previously-observed value)
+   * while `operational: false` (unwritable right now). These three pin THAT
+   * half specifically: a guard that checks only `status === 'known'` (a
+   * plausible partial mutation) still passes the tests above but must fail
+   * these, since none of them is unread.
+   */
+  const STALE: Availability = { structural: true, operational: false };
+
+  it('refuses a choice click on a KNOWN but operationally-stale field', () => {
+    const onChoiceChange = vi.fn();
+    const r = render(withSc({ centerType: known(1, STALE) }), { onChoiceChange });
+    bypassClick(r.el('scope-centerType-1')!);
+    flushSync();
+    expect(onChoiceChange).not.toHaveBeenCalled();
+    r.dispose();
+  });
+
+  it('refuses a toggle click on a KNOWN but operationally-stale field', () => {
+    const onToggleChange = vi.fn();
+    const r = render(withSc({ hold: known(true, STALE) }), { onToggleChange });
+    bypassClick(r.el('scope-hold')!);
+    flushSync();
+    expect(onToggleChange).not.toHaveBeenCalled();
+    r.dispose();
+  });
+
+  it('refuses a stepper click on a KNOWN but operationally-stale field', () => {
+    const onSpanChange = vi.fn();
+    const r = render(withSc({ mode: known(0), span: known(3, STALE) }), { onSpanChange });
+    bypassClick(r.el('scope-span')!.querySelector('button')!);
+    flushSync();
+    expect(onSpanChange).not.toHaveBeenCalled();
+    r.dispose();
+  });
+});
+
+/** First option value per `CHOICES` field, precomputed once. */
+const CHOICE_FIRST_VALUE = Object.fromEntries(
+  CHOICES.map(([field, , options]) => [field, options[0][0]]),
+) as Record<(typeof CHOICES)[number][0], number>;
+
+describe('field identity: every control names ITS OWN field, never a neighbour\'s', () => {
+  // MUTATION KILLED: a copy-paste-loop bug that closes over the wrong `field`
+  // — every CHOICES entry is driven and must report its own name.
+  it.each(CHOICES.map(([field]) => field))('choice group "%s" reports its own field', (field) => {
+    const onChoiceChange = vi.fn();
+    const r = render(base(), { onChoiceChange });
+    r.el(`scope-${field}-${CHOICE_FIRST_VALUE[field]}`)!.click();
+    flushSync();
+    expect(onChoiceChange).toHaveBeenCalledExactlyOnceWith(field, CHOICE_FIRST_VALUE[field]);
+    r.dispose();
+  });
+
+  it.each(TOGGLES.map(([field]) => field))('toggle "%s" reports its own field', (field) => {
+    const onToggleChange = vi.fn();
+    const r = render(base(), { onToggleChange });
+    r.el(`scope-${field}`)!.click();
+    flushSync();
+    expect(onToggleChange).toHaveBeenCalledExactlyOnceWith(field, expect.any(Boolean));
+    r.dispose();
+  });
+
+  // `mode` uses the imported MODE_BUTTONS table rather than CHOICES, so it is
+  // exercised separately.
+  it('mode reports "mode" with the clicked button\'s own value', () => {
+    const onChoiceChange = vi.fn();
+    const r = render(base(), { onChoiceChange });
+    r.el('scope-mode-2')!.click();
+    flushSync();
+    expect(onChoiceChange).toHaveBeenCalledExactlyOnceWith('mode', 2);
+    r.dispose();
+  });
+});
+
+describe('steppers compute the next value with the shipped clamp functions', () => {
+  it('SPAN increments through clampSpan, not a re-derived formula', () => {
+    const onSpanChange = vi.fn();
+    const r = render(withSc({ mode: known(0), span: known(3) }), { onSpanChange });
+    r.el('scope-span')!.querySelectorAll('button')[1]!.click();
+    flushSync();
+    expect(onSpanChange).toHaveBeenCalledExactlyOnceWith(4);
+    r.dispose();
+  });
+
+  it('SPEED decrements through clampSpeed (inverted delta, per the shipped function)', () => {
+    const onSpeedChange = vi.fn();
+    const r = render(withSc({ speed: known(1) }), { onSpeedChange });
+    r.el('scope-speed')!.querySelectorAll('button')[0]!.click();
+    flushSync();
+    expect(onSpeedChange).toHaveBeenCalledExactlyOnceWith(2);
+    r.dispose();
+  });
+
+  it('REF steps by 5 through clampRef', () => {
+    const onRefChange = vi.fn();
+    const r = render(withSc({ refDb: known(0) }), { onRefChange });
+    r.el('scope-ref')!.querySelectorAll('button')[1]!.click();
+    flushSync();
+    expect(onRefChange).toHaveBeenCalledExactlyOnceWith(5);
+    r.dispose();
+  });
+});
+
+describe('carry-forward (2): receiver is the ONE MAIN/SUB control', () => {
+  it('renders exactly one scope-receiver control and no separate "source" control', () => {
+    const r = render(base());
+    expect(r.el('scope-receiver')).not.toBeNull();
+    expect(target.querySelectorAll('[data-testid^="scope-source"]').length).toBe(0);
+    r.dispose();
+  });
+
+  it('reports the receiver choice through the same onChoiceChange path as any other choice', () => {
+    const onChoiceChange = vi.fn();
+    const r = render(withSc({ receiver: known(0) }), { onChoiceChange });
+    r.el('scope-receiver-1')!.click();
+    flushSync();
+    expect(onChoiceChange).toHaveBeenCalledExactlyOnceWith('receiver', 1);
+    r.dispose();
+  });
+});

--- a/frontend/src/semantic/__tests__/ScopeControlsSurface.test.ts
+++ b/frontend/src/semantic/__tests__/ScopeControlsSurface.test.ts
@@ -104,6 +104,22 @@ describe('carry-forward (3): EDGE/SPAN visibility is a rendering decision on top
     expect(r.el('scope-span')).toBeNull();
     r.dispose();
   });
+
+  // F2 — mode S-F (3) shows EDGE and hides SPAN
+  it('shows EDGE and hides SPAN when mode is known S-F (3)', () => {
+    const r = render(withSc({ mode: known(3) }));
+    expect(r.el('scope-edge')).not.toBeNull();
+    expect(r.el('scope-span')).toBeNull();
+    r.dispose();
+  });
+
+  // F2 — mode S-C (2) shows SPAN and hides EDGE
+  it('shows SPAN and hides EDGE when mode is known S-C (2)', () => {
+    const r = render(withSc({ mode: known(2) }));
+    expect(r.el('scope-span')).not.toBeNull();
+    expect(r.el('scope-edge')).toBeNull();
+    r.dispose();
+  });
 });
 
 describe('unread leaves render honestly, never fabricated', () => {
@@ -259,6 +275,36 @@ describe('steppers compute the next value with the shipped clamp functions', () 
     r.el('scope-ref')!.querySelectorAll('button')[1]!.click();
     flushSync();
     expect(onRefChange).toHaveBeenCalledExactlyOnceWith(5);
+    r.dispose();
+  });
+
+  // F1 — SPAN at the ceiling stays 7, never 8 (domain 0-7)
+  it('SPAN at the ceiling clamped to 7, never exceeds domain', () => {
+    const onSpanChange = vi.fn();
+    const r = render(withSc({ mode: known(0), span: known(7) }), { onSpanChange });
+    r.el('scope-span')!.querySelectorAll('button')[1]!.click();
+    flushSync();
+    expect(onSpanChange).toHaveBeenCalledExactlyOnceWith(7);
+    r.dispose();
+  });
+
+  // F1 — REF at the ceiling stays 10 (domain -30..10)
+  it('REF at the ceiling clamped to 10, never exceeds domain', () => {
+    const onRefChange = vi.fn();
+    const r = render(withSc({ refDb: known(10) }), { onRefChange });
+    r.el('scope-ref')!.querySelectorAll('button')[1]!.click();
+    flushSync();
+    expect(onRefChange).toHaveBeenCalledExactlyOnceWith(10);
+    r.dispose();
+  });
+
+  // F1 — SPEED at the floor stays 0 (domain 0-2, note clampSpeed's inverted delta)
+  it('SPEED at the floor clamped to 0, never goes below domain', () => {
+    const onSpeedChange = vi.fn();
+    const r = render(withSc({ speed: known(0) }), { onSpeedChange });
+    r.el('scope-speed')!.querySelectorAll('button')[1]!.click();
+    flushSync();
+    expect(onSpeedChange).toHaveBeenCalledExactlyOnceWith(0);
     r.dispose();
   });
 });

--- a/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
+++ b/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
@@ -143,6 +143,13 @@ vi.mock('../../../components-v2/wiring/command-bus', () => ({
     onScanStart: h.txAuxNoop, onScanStop: h.txAuxNoop, onDfSpanChange: h.txAuxNoop,
     onResumeChange: h.txAuxNoop,
   }),
+  // MOR-1311 slice 11B: the scope-toolbar/popover intent vocabulary.
+  makeScopeControlsHandlers: () => ({
+    onModeChange: h.txAuxNoop, onEdgeChange: h.txAuxNoop, onSpanChange: h.txAuxNoop,
+    onSpeedChange: h.txAuxNoop, onHoldChange: h.txAuxNoop, onRefChange: h.txAuxNoop,
+    onDualChange: h.txAuxNoop, onReceiverChange: h.txAuxNoop, onDuringTxChange: h.txAuxNoop,
+    onCenterTypeChange: h.txAuxNoop, onVbwChange: h.txAuxNoop, onRbwChange: h.txAuxNoop,
+  }),
 }));
 
 import DualReceiverCockpit from '../DualReceiverCockpit.svelte';


### PR DESCRIPTION
## Summary

11B: ScopeControlsSurface - the scope toolbar rendered ONLY from the 12-leaf scopeControls fact group (8 toolbar + 4 popover leaves), removing the layering violation the vocabulary program exists to fix (v2's SpectrumToolbar reads the live store directly). EDGE/SPAN visibility reuses the REAL spectrum-toolbar-logic predicates (rendering conditions, not gates; unknown mode hides rows, never fabricates CTR). receiver is the ONE scope-source selector. fixedEdge appears nowhere (MOR-1354 exclusion). New makeScopeControlsHandlers command-bus factory (v2 called sendCommand directly - no prior vocabulary).

Production LOC 178 (verifier-measured, frozen formula; cap 200). 4-file guardrail WAIVED with corrected rationale: makeKeyboardHandlers already emits 5 of the 12 scope commands but as state-reading switch cases, not composable value-taking setters; the alternatives (surface calls sendCommand, or a fifth module) are both worse. Note N2 recorded: five commands now have two emitters.

## Review provenance

Verified by the rework-domain opus anchor #3 (session 8): initial BLOCK on two test-only findings, both prescription-pre-verified and fixed with pasted kill proofs (F1: stepper clamps pinned at domain boundaries - a drifted stepper would emit out-of-domain CI-V parameters like set_scope_span {span: 8}; F2: scope modes 2/3 covered so a hand-copied isEdgeApplicable dies). Canon option (i) killed in both restoration shapes with 5 of 7 failures coming from the post-MOR-1351 cockpit - 11B is the first B-slice the cockpit catches unaided. Facts-only claim verified at source (zero store imports). Harness: 60/60, 1797/1797, zero ok-flips; reference captures 98->118 controls (all [disabled], all NO-ZONE per MOR-1355 residual); dual/cockpit captures move by ZERO.

On merge the MOR-1262 vocabulary B-queue is COMPLETE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)