### PR TITLE
feat(MOR-1364): single suppression channel for desktop-v2 legacy twins (rework S6-pre)

### DIFF
--- a/frontend/src/components-v2/layout/LeftSidebar.svelte
+++ b/frontend/src/components-v2/layout/LeftSidebar.svelte
@@ -16,11 +16,33 @@
   import MemoryPanel from '../panels/MemoryPanel.svelte';
   import CollapsiblePanel from '../controls/CollapsiblePanel.svelte';
   import { createDragReorder } from '$lib/drag-reorder.svelte';
+  import type { SemanticSurfaceName } from '../../presentation/layouts/contract';
 
   /** MOR-1065: mirrors RightSidebar. The TX panel is not in this sidebar's
    *  defaults, but a cross-sidebar drag can move it here, so the semantic
-   *  layout's TX suppression has to hold on both sides. */
-  let { hideTxPanel = false }: { hideTxPanel?: boolean } = $props();
+   *  layout's TX suppression has to hold on both sides.
+   *
+   *  MOR-1364 (v3-rework S6-pre) — `declared` is the ONE legacy-twin
+   *  suppression channel: the ACTIVE layout manifest's declared-surface set
+   *  (`declaredSurfaces(getLayout(skinId))`, derived once in RadioLayout).
+   *  Every panel below whose semantic twin is mounted by a declared zone
+   *  retires; a surface no zone declares keeps its legacy panel untouched, so
+   *  the default empty set is a full no-op. Deliberately the MANIFEST and
+   *  never the resolved SurfacePlan (S5 ruling): a workspace SUBTRACTION must
+   *  cost the operator the zone, never resurrect the legacy panel through the
+   *  back door.
+   *
+   *  Safe ONLY because MOR-1336's `zoned()` degrades to a BARE render for an
+   *  unzoned surface (S5-N3) — a future change making `zoned` withhold its
+   *  body instead would turn each suppression below into a readout-losing bug.
+   *
+   *  `hideTxPanel` stays a SEPARATE boolean and is deliberately NOT folded
+   *  into this set (R9, MOR-1313): it follows the semantic DECK, not
+   *  `declared.has('rxTx')`. Do not "tidy" the two into one prop. */
+  let {
+    hideTxPanel = false,
+    declared = new Set<SemanticSurfaceName>(),
+  }: { hideTxPanel?: boolean; declared?: ReadonlySet<SemanticSurfaceName> } = $props();
 
   // Reactive state + capabilities — via runtime
   let caps = $derived(runtime.caps);
@@ -34,7 +56,7 @@
 </script>
 
 <aside class="left-sidebar" class:cross-drop-target={drag.isDropTarget}>
-  {#if drag.order.includes('rf-front-end')}
+  {#if drag.order.includes('rf-front-end') && !declared.has('rfFrontEnd')}
     <CollapsiblePanel title="RF FRONT END" panelId="rf-front-end" dataPanel="rf-frontend"
       draggable={true} onDragStart={drag.handleDragStart}
       style={drag.dragStyle('rf-front-end')}>
@@ -42,7 +64,7 @@
     </CollapsiblePanel>
   {/if}
 
-  {#if drag.order.includes('mode')}
+  {#if drag.order.includes('mode') && !declared.has('filter')}
     <CollapsiblePanel title="MODE" panelId="mode"
       draggable={true} onDragStart={drag.handleDragStart}
       style={drag.dragStyle('mode')}>
@@ -50,7 +72,7 @@
     </CollapsiblePanel>
   {/if}
 
-  {#if drag.order.includes('filter')}
+  {#if drag.order.includes('filter') && !declared.has('filter')}
     <CollapsiblePanel title="FILTER" panelId="filter"
       draggable={true} onDragStart={drag.handleDragStart}
       style={drag.dragStyle('filter')}>
@@ -58,7 +80,7 @@
     </CollapsiblePanel>
   {/if}
 
-  {#if drag.order.includes('agc')}
+  {#if drag.order.includes('agc') && !declared.has('dsp')}
     <CollapsiblePanel title="AGC" panelId="agc"
       draggable={true} onDragStart={drag.handleDragStart}
       style={drag.dragStyle('agc')}>
@@ -66,7 +88,7 @@
     </CollapsiblePanel>
   {/if}
 
-  {#if drag.order.includes('rit-xit')}
+  {#if drag.order.includes('rit-xit') && !declared.has('ritXitScan')}
     <CollapsiblePanel title="RIT / XIT" panelId="rit-xit"
       draggable={true} onDragStart={drag.handleDragStart}
       style={drag.dragStyle('rit-xit')}>
@@ -74,6 +96,12 @@
     </CollapsiblePanel>
   {/if}
 
+  <!-- MOR-1364: the BAND twin is deliberately NOT on this channel. `BandSelector`
+       hosts three tabs (HAM / LW-MW / SWL) and 17 broadcast presets; only the HAM
+       half is duplicated by `BandSurface`, and the broadcast presets are
+       deliberately NOT facts (`semantic/radio-view-model.ts:494-496`) and have no
+       other production host. Gating on `declared.has('band')` would orphan them.
+       Joins the channel in S8, after the component split (`hamBands` prop). -->
   {#if drag.order.includes('band')}
     <CollapsiblePanel title="BAND" panelId="band"
       draggable={true} onDragStart={drag.handleDragStart}
@@ -82,7 +110,7 @@
     </CollapsiblePanel>
   {/if}
 
-  {#if drag.order.includes('antenna') && (caps?.antennas ?? 1) > 1}
+  {#if drag.order.includes('antenna') && (caps?.antennas ?? 1) > 1 && !declared.has('antenna')}
     <CollapsiblePanel title="ANTENNA" panelId="antenna" dataPanel="antenna"
       draggable={true} onDragStart={drag.handleDragStart}
       style={drag.dragStyle('antenna')}>
@@ -90,7 +118,7 @@
     </CollapsiblePanel>
   {/if}
 
-  {#if drag.order.includes('scan')}
+  {#if drag.order.includes('scan') && !declared.has('ritXitScan')}
     <CollapsiblePanel title="SCAN" panelId="scan"
       draggable={true} onDragStart={drag.handleDragStart}
       style={drag.dragStyle('scan')}>
@@ -98,13 +126,13 @@
     </CollapsiblePanel>
   {/if}
 
-  {#if drag.order.includes('rx-audio')}
+  {#if drag.order.includes('rx-audio') && !declared.has('rxAudio')}
     <CollapsiblePanel title="RX AUDIO" panelId="rx-audio" draggable onDragStart={drag.handleDragStart} style={drag.dragStyle('rx-audio')}>
       <RxAudioPanel />
     </CollapsiblePanel>
   {/if}
 
-  {#if drag.order.includes('dsp')}
+  {#if drag.order.includes('dsp') && !declared.has('dsp')}
     <CollapsiblePanel title="DSP" panelId="dsp" draggable onDragStart={drag.handleDragStart} style={drag.dragStyle('dsp')}>
       <DspPanel />
     </CollapsiblePanel>
@@ -116,7 +144,7 @@
     </CollapsiblePanel>
   {/if}
 
-  {#if drag.order.includes('cw') && hasCapability('cw')}
+  {#if drag.order.includes('cw') && hasCapability('cw') && !declared.has('cwKeyer')}
     <CollapsiblePanel title="CW" panelId="cw" draggable onDragStart={drag.handleDragStart} style={drag.dragStyle('cw')}>
       <CwPanel />
     </CollapsiblePanel>

--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -446,11 +446,11 @@
                HAM tab is duplicated by `BandSurface`, while the LW/MW + SWL tabs
                and their 17 broadcast presets are deliberately not facts and have
                no other host. It joins the channel in S8, after `BandSelector` is
-               split. When BOTH children of this section are eventually gated,
-               gate the whole `<CollapsiblePanel>` instead — a suppressed section
-               must not ship as a titled empty shell with a live localStorage
-               collapse entry (the RightSidebar `hideTxPanel` precedent, and the
-               shape every other section below already uses). -->
+               split. This panel is the ONE section that must never be wrapped as
+               a whole: row 10 (the LW/MW + SWL tabs) is permanent, so the panel
+               can never be empty, and S8 retires the HAM half by passing
+               `hamBands={!declared.has('band')}` — a prop change, not a mount
+               gate (S10 §4a/§7). -->
           <BandSelector />
         </CollapsiblePanel>
 

--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -121,6 +121,33 @@
   // whole answer.
   let semanticMeters = $derived(declared.has('meters'));
 
+  // MOR-1364 (v3-rework S6-pre) — the ONE legacy-twin suppression channel.
+  //
+  // `declared` above is already the whole answer for every remaining legacy
+  // twin, so nothing new is derived here: the set itself is handed to
+  // `LeftSidebar`, `RightSidebar` and `StatusBar` (which each gate their own
+  // panels on `!declared.has('<surface>')`), and the settings modal below —
+  // this shell's own third copy of six of those panels — gates in place.
+  // Landed INERT: no manifest declares any of `filter`/`rfFrontEnd`/`band`/
+  // `antenna`/`ritXitScan`/`rxAudio`/`dsp`/`cwKeyer` yet, so every predicate
+  // is `false` and the rendered tree is unchanged until S6a/S7/S8/S9 declare
+  // the zones. The ONE exception is the modal's SPLIT/A↔B/A=B row, which
+  // gates on the ALREADY-TRUE `semanticDeck` (S10 §4 — a real, deliberate
+  // change, not inert plumbing).
+  //
+  // Same two rules as `semanticRxTx`/`semanticMeters`, restated because this
+  // channel now carries them to three more files:
+  //   - the MANIFEST decides, never the resolved SurfacePlan (S5 ruling) —
+  //     a workspace subtraction must cost the operator the zone, never
+  //     resurrect the legacy twin through the back door;
+  //   - it is safe ONLY because MOR-1336's `zoned()` degrades to a BARE
+  //     render for an unzoned surface (S5-N3). That guarantee lives in
+  //     `SemanticRadioSurfaces.svelte`; a change making `zoned` withhold its
+  //     body instead would turn every suppression on this channel into a
+  //     readout-losing bug.
+  // AGC pairs with `dsp`, not a zone of its own: `DspSurface` owns the AGC
+  // leaf (5A/MOR-1290), so `<AgcPanel>` retires on `declared.has('dsp')`.
+
   // Reactive state + capabilities — via runtime
   let radioState = $derived(runtime.state);
   let caps = $derived(runtime.caps);
@@ -281,7 +308,7 @@
   now that a second family resolves into it (MOR-1313).
 -->
 <div class="radio-layout" class:sdr-test={skinId === 'sdr-test'} class:semantic-deck={semanticDeck}>
-  <StatusBar onSettings={() => (settingsOpen = true)} />
+  <StatusBar onSettings={() => (settingsOpen = true)} {declared} />
   <KeyboardHandler config={keyboardConfig} onAction={keyboardHandlers.dispatch} />
 
   <section class="receiver-deck" bind:this={receiverDeckElement} style={receiverDeckStyle}>
@@ -317,7 +344,7 @@
 
   <section class="content-row">
     <div class="content-left">
-      <LeftSidebar hideTxPanel={semanticRxTx} />
+      <LeftSidebar hideTxPanel={semanticRxTx} {declared} />
     </div>
 
     <main class="content-center center-column">
@@ -334,7 +361,7 @@
     </main>
 
     <div class="content-right">
-      <RightSidebar hideTxPanel={semanticRxTx} />
+      <RightSidebar hideTxPanel={semanticRxTx} {declared} />
     </div>
   </section>
 
@@ -380,56 +407,88 @@
         </CollapsiblePanel>
 
         <CollapsiblePanel title="VFO / BAND" panelId="desktop-vfo-ops">
-          <div class="settings-vfo-ops-row">
-            <HardwareButton
-              active={vfoOps.splitActive}
-              indicator="edge-left"
-              color={vfoOps.splitActive ? 'yellow' : 'gray'}
-              onclick={vfoHandlers.onSplitToggle}
-            >
-              SPLIT
-            </HardwareButton>
-            <HardwareButton
-              indicator="edge-left"
-              color="cyan"
-              onclick={vfoHandlers.onSwap}
-            >
-              A↔B
-            </HardwareButton>
-            <HardwareButton
-              indicator="edge-left"
-              color="cyan"
-              onclick={vfoHandlers.onEqual}
-            >
-              A=B
-            </HardwareButton>
-          </div>
+          <!-- S10 §4, the NAMED EXCEPTION to this slice's inertness: unlike
+               every other predicate on this channel, `semanticDeck` is
+               ALREADY true on desktop-v2 (MOR-1313 declared `receiver-deck`),
+               so this row disappears the day S6-pre merges. Deliberate: the
+               semantic `VfoSurface` has owned equivalent — and translated —
+               split/swap/equalize controls since MOR-1321, and only the
+               modal's third copy was never gated. Gated on `semanticDeck`,
+               NOT on `semanticRxTx`: this is VFO-ops routing, not a
+               key/unkey affordance, so it is not an R9 site (S10 §6). -->
+          {#if !semanticDeck}
+            <div class="settings-vfo-ops-row">
+              <HardwareButton
+                active={vfoOps.splitActive}
+                indicator="edge-left"
+                color={vfoOps.splitActive ? 'yellow' : 'gray'}
+                onclick={vfoHandlers.onSplitToggle}
+              >
+                SPLIT
+              </HardwareButton>
+              <HardwareButton
+                indicator="edge-left"
+                color="cyan"
+                onclick={vfoHandlers.onSwap}
+              >
+                A↔B
+              </HardwareButton>
+              <HardwareButton
+                indicator="edge-left"
+                color="cyan"
+                onclick={vfoHandlers.onEqual}
+              >
+                A=B
+              </HardwareButton>
+            </div>
+          {/if}
+          <!-- The BAND half of this section stays UNGATED this slice: only the
+               HAM tab is duplicated by `BandSurface`, while the LW/MW + SWL tabs
+               and their 17 broadcast presets are deliberately not facts and have
+               no other host. It joins the channel in S8, after `BandSelector` is
+               split. When BOTH children of this section are eventually gated,
+               gate the whole `<CollapsiblePanel>` instead — a suppressed section
+               must not ship as a titled empty shell with a live localStorage
+               collapse entry (the RightSidebar `hideTxPanel` precedent, and the
+               shape every other section below already uses). -->
           <BandSelector />
         </CollapsiblePanel>
 
-        <CollapsiblePanel title="DSP" panelId="desktop-dsp">
-          <DspPanel />
-        </CollapsiblePanel>
+        {#if !declared.has('dsp')}
+          <CollapsiblePanel title="DSP" panelId="desktop-dsp">
+            <DspPanel />
+          </CollapsiblePanel>
+        {/if}
 
-        <CollapsiblePanel title="AGC" panelId="desktop-agc">
-          <AgcPanel />
-        </CollapsiblePanel>
+        <!-- Same predicate as DSP above, on purpose (S10 row 2): AGC is a
+             leaf of `DspSurface`, not a surface of its own. -->
+        {#if !declared.has('dsp')}
+          <CollapsiblePanel title="AGC" panelId="desktop-agc">
+            <AgcPanel />
+          </CollapsiblePanel>
+        {/if}
 
-        <CollapsiblePanel title="RF FRONT END" panelId="desktop-rf">
-          <RfFrontEnd />
-        </CollapsiblePanel>
+        {#if !declared.has('rfFrontEnd')}
+          <CollapsiblePanel title="RF FRONT END" panelId="desktop-rf">
+            <RfFrontEnd />
+          </CollapsiblePanel>
+        {/if}
 
-        <CollapsiblePanel title="RIT / XIT" panelId="desktop-rit">
-          <RitXitPanel />
-        </CollapsiblePanel>
+        {#if !declared.has('ritXitScan')}
+          <CollapsiblePanel title="RIT / XIT" panelId="desktop-rit">
+            <RitXitPanel />
+          </CollapsiblePanel>
+        {/if}
 
-        <CollapsiblePanel
-          title="CW"
-          panelId="desktop-cw"
-          autoCollapseWhen={activeMode !== 'CW' && activeMode !== 'CW-R'}
-        >
-          <CwPanel />
-        </CollapsiblePanel>
+        {#if !declared.has('cwKeyer')}
+          <CollapsiblePanel
+            title="CW"
+            panelId="desktop-cw"
+            autoCollapseWhen={activeMode !== 'CW' && activeMode !== 'CW-R'}
+          >
+            <CwPanel />
+          </CollapsiblePanel>
+        {/if}
       </div>
     </div>
   </div>

--- a/frontend/src/components-v2/layout/RightSidebar.svelte
+++ b/frontend/src/components-v2/layout/RightSidebar.svelte
@@ -8,6 +8,7 @@
   import AudioSpectrumPanel from '../panels/audio-scope/AudioSpectrumPanel.svelte';
   import CollapsiblePanel from '../controls/CollapsiblePanel.svelte';
   import { createDragReorder } from '$lib/drag-reorder.svelte';
+  import type { SemanticSurfaceName } from '../../presentation/layouts/contract';
 
   type RightSidebarMode = 'all' | 'rx' | 'tx';
 
@@ -17,9 +18,17 @@
      *  surface suppresses the legacy TX panel, so no layout ships two PTT
      *  affordances at once. Scoped to the TX panel — CW is unaffected. */
     hideTxPanel?: boolean;
+    /** MOR-1364 (v3-rework S6-pre) — the same manifest-driven suppression
+     *  channel LeftSidebar carries, and it MUST be wired on both sides:
+     *  `rx-audio`, `dsp` and `cw` live in both sidebars and a cross-sidebar
+     *  drag moves them freely, so a one-sided suppression would leave the
+     *  retired twin reachable. See LeftSidebar for the full doctrine (manifest
+     *  not plan; safe only while `zoned()` degrades to bare; `hideTxPanel`
+     *  stays separate for R9). */
+    declared?: ReadonlySet<SemanticSurfaceName>;
   }
 
-  let { mode = 'all', hideTxPanel = false }: Props = $props();
+  let { mode = 'all', hideTxPanel = false, declared = new Set<SemanticSurfaceName>() }: Props = $props();
 
   let showRx = $derived(mode === 'all' || mode === 'rx');
   let showTx = $derived(mode === 'all' || mode === 'tx');
@@ -33,7 +42,7 @@
 </script>
 
 <aside class="right-sidebar" class:cross-drop-target={drag.isDropTarget}>
-  {#if showRx && drag.order.includes('rx-audio')}
+  {#if showRx && drag.order.includes('rx-audio') && !declared.has('rxAudio')}
     <CollapsiblePanel title="RX AUDIO" panelId="rx-audio" draggable onDragStart={drag.handleDragStart} style={drag.dragStyle('rx-audio')}>
       <RxAudioPanel />
     </CollapsiblePanel>
@@ -45,7 +54,7 @@
     </CollapsiblePanel>
   {/if}
 
-  {#if showRx && drag.order.includes('dsp')}
+  {#if showRx && drag.order.includes('dsp') && !declared.has('dsp')}
     <CollapsiblePanel title="DSP" panelId="dsp" draggable onDragStart={drag.handleDragStart} style={drag.dragStyle('dsp')}>
       <DspPanel />
     </CollapsiblePanel>
@@ -57,7 +66,7 @@
     </CollapsiblePanel>
   {/if}
 
-  {#if showTx && drag.order.includes('cw') && hasCapability('cw')}
+  {#if showTx && drag.order.includes('cw') && hasCapability('cw') && !declared.has('cwKeyer')}
     <CollapsiblePanel title="CW" panelId="cw" draggable onDragStart={drag.handleDragStart} style={drag.dragStyle('cw')}>
       <CwPanel />
     </CollapsiblePanel>

--- a/frontend/src/components-v2/layout/StatusBar.svelte
+++ b/frontend/src/components-v2/layout/StatusBar.svelte
@@ -71,11 +71,22 @@
   import { getFrequency } from '$lib/stores/radio.svelte';
   import { hasAnyScope, hasAudio, hasSpectrum } from '$lib/stores/capabilities.svelte';
   import { getLayoutMode, setLayoutMode, type CanonicalLayoutMode, type LayoutMode } from '$lib/stores/layout.svelte';
+  import type { SemanticSurfaceName } from '../../presentation/layouts/contract';
 
   interface Props {
     onSettings?: () => void;
+    /** MOR-1364 (v3-rework S6-pre) — the manifest-driven legacy-twin
+     *  suppression channel, reaching the status bar for its one twin: the
+     *  scope indicator, whose semantic replacement is `ScopeDisplaySurface`
+     *  (MOR-1312). Same doctrine as the sidebars': the MANIFEST decides, never
+     *  the resolved SurfacePlan (S5 ruling), and it is safe only because
+     *  MOR-1336's `zoned()` degrades to a bare render for an unzoned surface
+     *  (S5-N3). Default empty set ⇒ no-op, so mobile/LCD and every caller that
+     *  omits the prop keep the indicator. Note the OTHER four indicators
+     *  (radio/control/audio/http) have no semantic twin and are never gated. */
+    declared?: ReadonlySet<SemanticSurfaceName>;
   }
-  let { onSettings }: Props = $props();
+  let { onSettings, declared = new Set<SemanticSurfaceName>() }: Props = $props();
 
   // Canonicalize legacy 'lcd' to 'lcd-cockpit' for UI binding — the persisted
   // value may still be 'lcd' (from pre-#889 installs), but the dropdown only
@@ -257,7 +268,7 @@
       <span class="indicator-dot"></span>
       <Cable size={12} color="currentColor" strokeWidth={2.5} />
     </span>
-    {#if hasAnyScope()}
+    {#if hasAnyScope() && !declared.has('scopeDisplay')}
       <span class="indicator" role="status" title={t('core.statusbar.indicator.scope', { state: scopeState })} style="--indicator-color: {stateColor(scopeState)}">
         <span class="indicator-dot"></span>
         <Activity size={12} color="currentColor" strokeWidth={2.5} />

--- a/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
@@ -137,7 +137,7 @@ vi.mock('$lib/stores/capabilities.svelte', () => ({
 }));
 
 import RadioLayout from '../RadioLayout.svelte';
-import { hasCapability } from '$lib/stores/capabilities.svelte';
+import { hasAnyScope, hasCapability } from '$lib/stores/capabilities.svelte';
 import { topologyFixtures, type TopologyFixtureId } from '../../../semantic/fixtures/topologies';
 import { registerLayout, type LayoutManifest } from '../../../presentation/layouts/contract';
 // Barrel, for the same reason `skins/dual-receiver-cockpit/__tests__/
@@ -544,5 +544,215 @@ describe('the semantic receiver deck carries the VFO ops again (MOR-1321)', () =
   it('adds no key authority to the deck', () => {
     const t = render('desktop-v2');
     expect(t.querySelectorAll('[data-testid="rx-tx-surface"], .tx-panel').length).toBe(1);
+  });
+});
+
+/**
+ * MOR-1364 (v3-rework S6-pre) — the ONE manifest-driven legacy-twin
+ * suppression channel, landed INERT.
+ *
+ * S2/MOR-1313 built this rule for `vfo`/`rxTx` and S5/MOR-1341 for `meters`;
+ * this slice generalises it to every remaining legacy twin the zone slices
+ * S6a/S7/S8/S9 will retire — the sidebar panels, the settings modal's third
+ * copy of five of them, and the status bar's scope indicator — by handing the
+ * same `declaredSurfaces(manifest)` set `RadioLayout` already derives down to
+ * `LeftSidebar`, `RightSidebar` and `StatusBar`.
+ *
+ * Nothing renders differently today (no manifest declares any of these zones),
+ * which is the whole point: the risky plumbing lands once, independently
+ * pinned, and each zone slice after it is a two-file manifest edit. The ONE
+ * exception is the settings modal's SPLIT/A↔B/A=B row, which gates on the
+ * already-true `semanticDeck` — a real, deliberate change, pinned by its own
+ * named test below rather than folded into the inertness claim.
+ *
+ * The probes are `desktop-v2`'s REAL manifest plus exactly ONE zone — the
+ * literal shape S6a/S7/S8/S9 will land — so a row that fails here is a
+ * statement about the channel and not about a hand-built fixture.
+ */
+describe('the legacy-twin suppression channel (MOR-1364, S6-pre)', () => {
+  /** Every panel id either sidebar can host. Without these the pins would pass
+   *  vacuously for the boring reason that the drag order never offered the
+   *  panel — `rx-audio`/`dsp`/`cw` are exactly the cross-sidebar ones a drag
+   *  can move to the other side, so both sidebars are stocked with all of
+   *  them. */
+  const LEFT_ALL = ['rf-front-end', 'mode', 'filter', 'agc', 'rit-xit', 'band',
+    'antenna', 'scan', 'rx-audio', 'dsp', 'tx', 'cw', 'memory'];
+  const RIGHT_ALL = ['rx-audio', 'audio-scope', 'dsp', 'tx', 'cw', 'memory'];
+
+  /** surface → the zone id its rework slice will declare on `desktop-v2`. */
+  const ZONES = [
+    ['filter', 'filter'], ['rfFrontEnd', 'rf-front-end'], ['dsp', 'dsp'],
+    ['ritXitScan', 'rit-xit-scan'], ['antenna', 'antenna'], ['rxAudio', 'rx-audio'],
+    ['cwKeyer', 'cw-keyer'], ['scopeDisplay', 'scope-display'], ['band', 'band'],
+  ] as const;
+  type CoveredSurface = (typeof ZONES)[number][0];
+
+  const ZONE_PROBE = Object.fromEntries(ZONES.map(([surface, zoneId]) => {
+    const id = `${zoneId}-zone-probe` as SkinId;
+    registerLayout(probeManifest(
+      id,
+      [...desktopV2Layout.zones, { id: zoneId, surfaces: [surface] }],
+      desktopV2Layout.requiredSemanticSurfaces,
+    ));
+    return [surface, id];
+  })) as Record<CoveredSurface, SkinId>;
+
+  /**
+   * One row per legacy twin the channel covers: which surface's zone retires
+   * it, and where it lives. `dsp` owns FIVE rows because `DspSurface` covers
+   * the AGC leaf too (5A/MOR-1290) — a `dsp` zone that retired `DspPanel` and
+   * left `AgcPanel` standing would ship a half-double, in two hosts.
+   */
+  const TWINS = [
+    ['filter', 'left sidebar MODE', '.left-sidebar [data-panel-id="mode"]'],
+    ['filter', 'left sidebar FILTER', '.left-sidebar [data-panel-id="filter"]'],
+    ['rfFrontEnd', 'left sidebar RF FRONT END', '.left-sidebar [data-panel-id="rf-front-end"]'],
+    ['rfFrontEnd', 'settings modal RF FRONT END', '[data-panel-id="desktop-rf"]'],
+    ['dsp', 'left sidebar AGC', '.left-sidebar [data-panel-id="agc"]'],
+    ['dsp', 'left sidebar DSP', '.left-sidebar [data-panel-id="dsp"]'],
+    ['dsp', 'right sidebar DSP', '.right-sidebar [data-panel-id="dsp"]'],
+    ['dsp', 'settings modal DSP', '[data-panel-id="desktop-dsp"]'],
+    ['dsp', 'settings modal AGC', '[data-panel-id="desktop-agc"]'],
+    ['ritXitScan', 'left sidebar RIT / XIT', '.left-sidebar [data-panel-id="rit-xit"]'],
+    ['ritXitScan', 'left sidebar SCAN', '.left-sidebar [data-panel-id="scan"]'],
+    ['ritXitScan', 'settings modal RIT / XIT', '[data-panel-id="desktop-rit"]'],
+    ['antenna', 'left sidebar ANTENNA', '.left-sidebar [data-panel-id="antenna"]'],
+    ['rxAudio', 'left sidebar RX AUDIO', '.left-sidebar [data-panel-id="rx-audio"]'],
+    ['rxAudio', 'right sidebar RX AUDIO', '.right-sidebar [data-panel-id="rx-audio"]'],
+    ['cwKeyer', 'left sidebar CW', '.left-sidebar [data-panel-id="cw"]'],
+    ['cwKeyer', 'right sidebar CW', '.right-sidebar [data-panel-id="cw"]'],
+    ['cwKeyer', 'settings modal CW', '[data-panel-id="desktop-cw"]'],
+    ['scopeDisplay', 'status bar scope indicator', '.status-indicators [title^="Scope WebSocket"]'],
+  ] as const satisfies readonly (readonly [CoveredSurface, string, string])[];
+
+  /**
+   * The BAND twin is deliberately NOT on the channel (S10 verifier ruling):
+   * `BandSelector` hosts the LW/MW + SWL tabs and 17 broadcast presets that
+   * are deliberately not facts and have no other production host, so gating it
+   * on `declared.has('band')` would orphan them. It joins in S8, after the
+   * component split. Pinned so that deferral is a decision someone has to
+   * revisit rather than an omission nobody notices.
+   */
+  const BAND_TWINS = [
+    ['left sidebar BAND', '.left-sidebar [data-panel-id="band"]'],
+    ['settings modal BAND', '[data-panel-id="desktop-vfo-ops"] .band-tabs'],
+  ] as const;
+
+  /** Opens the settings modal too — the third host, and the only one that is
+   *  not on screen by default. */
+  function renderAll(skinId: SkinId): HTMLElement {
+    const target = render(skinId);
+    (target.querySelector('.settings-btn') as HTMLElement | null)?.click();
+    flushSync();
+    return target;
+  }
+
+  beforeEach(() => {
+    // A radio that actually emits every gated family: two antennas (the
+    // ANTENNA panel self-gates on the count), CW, and a scope.
+    h.caps = { ...(capsFor('2/main_sub') as object), antennas: 2 } as Capabilities;
+    vi.mocked(hasCapability).mockImplementation((tag: string) => tag === 'cw');
+    vi.mocked(hasAnyScope).mockReturnValue(true);
+    localStorage.setItem('rigplane:panel-order', JSON.stringify(LEFT_ALL));
+    localStorage.setItem('rigplane:right-panel-order', JSON.stringify(RIGHT_ALL));
+  });
+
+  afterEach(() => {
+    vi.mocked(hasAnyScope).mockReturnValue(false);
+    localStorage.clear();
+  });
+
+  // INERTNESS, half one: every covered twin is on screen TODAY. Without this
+  // the suppression pins below would be satisfied by a twin that never
+  // rendered in the first place.
+  it.each(TWINS)('[%s] %s renders on desktop-v2, no zone declaring it', (_surface, _host, selector) => {
+    expect(renderAll('desktop-v2').querySelector(selector)).not.toBeNull();
+  });
+
+  // INERTNESS, half two, stated as an inventory rather than per-row: the exact
+  // set of panels desktop-v2 renders is unchanged by this slice. Measured
+  // against `origin/main` with the identical fixture before the channel
+  // landed — see the build report's element-stream diff (2049/2049 nodes
+  // identical on the undeclared layout; on desktop-v2 exactly one 11-node
+  // hunk, the SPLIT row below).
+  it('renders exactly the panel inventory it rendered before the channel existed', () => {
+    const ids = [...renderAll('desktop-v2').querySelectorAll('[data-panel-id]')]
+      .map((el) => el.getAttribute('data-panel-id'))
+      .sort();
+    expect(ids).toEqual([
+      'agc', 'antenna', 'band', 'cw', 'cw',
+      'desktop-agc', 'desktop-cw', 'desktop-dsp', 'desktop-language', 'desktop-rf',
+      'desktop-rit', 'desktop-vfo-ops', 'desktop-workspace',
+      'dsp', 'dsp', 'filter', 'memory', 'memory', 'mode', 'rf-front-end',
+      'rit-xit', 'rx-audio', 'rx-audio', 'scan',
+    ]);
+  });
+
+  // THE CHANNEL ITSELF, both directions in one assertion per surface: a
+  // declared zone retires every twin of ITS OWN family, in every host, and
+  // touches no sibling family's twin. A `dsp`-only suppression that leaves
+  // `AgcPanel`, or a one-sided suppression that leaves the right sidebar's
+  // `rx-audio`/`dsp`/`cw` reachable by a cross-sidebar drag, dies here.
+  it.each(ZONES.filter(([s]) => s !== 'band').map(([s]) => s))(
+    'declaring the %s zone retires that family\'s twins in every host, and no sibling\'s',
+    (surface) => {
+      const t = renderAll(ZONE_PROBE[surface]);
+      for (const [twinSurface, host, selector] of TWINS) {
+        if (twinSurface === surface) {
+          expect(t.querySelector(selector), `${host} must be suppressed`).toBeNull();
+        } else {
+          expect(t.querySelector(selector), `${host} must survive`).not.toBeNull();
+        }
+      }
+    },
+  );
+
+  // The deferral, pinned: declaring `band` today must suppress NOTHING. When
+  // S8 splits `BandSelector` and wires the predicate, this test is the one it
+  // has to come back and change — deliberately, not by accident.
+  it('declaring the band zone suppresses nothing yet (BandSelector split deferred to S8)', () => {
+    const t = renderAll(ZONE_PROBE.band);
+    for (const [host, selector] of BAND_TWINS) {
+      expect(t.querySelector(selector), `${host} must survive`).not.toBeNull();
+    }
+    for (const [, host, selector] of TWINS) {
+      expect(t.querySelector(selector), `${host} must survive`).not.toBeNull();
+    }
+  });
+
+  // R9, restated over the new quadrants: none of the nine probes may change
+  // the number of elements that can key or unkey the transmitter. The channel
+  // deliberately does NOT carry `rxTx` — `hideTxPanel` still follows the
+  // semantic DECK (MOR-1313) and must stay a separate prop.
+  it.each(ZONES.map(([s]) => s))('leaves exactly one key authority with the %s zone declared', (surface) => {
+    expect(renderAll(ZONE_PROBE[surface]).querySelectorAll(KEY_AUTHORITIES).length).toBe(1);
+  });
+
+  /**
+   * THE NAMED EXCEPTION (S10 §4) — the one thing this slice changes on screen.
+   *
+   * `semanticDeck` is ALREADY true on desktop-v2 (MOR-1313 declared
+   * `receiver-deck`), and `VfoSurface` has carried translated split/swap/
+   * equalize controls since MOR-1321; only the settings modal's third copy of
+   * that row was never gated. Gating it removes three hardcoded, untranslated
+   * strings from the flagship skin the day this merges.
+   *
+   * The false branch cannot be `sdr-test` — it declares `vfo` too, as do all
+   * five registered manifests — so it is taken from the `rxTx`-only probe and
+   * the unregistered-layout fallback, the only two `semanticDeck === false`
+   * configurations this shell can reach.
+   *
+   * The row is VFO-ops routing, NOT a key/unkey affordance (S10 §6), so it
+   * gates on `semanticDeck` and never on `semanticRxTx`; the R9 counts above
+   * cover both probes.
+   */
+  it('NAMED EXCEPTION: retires the settings-modal SPLIT/A↔B/A=B row where the semantic deck owns it', () => {
+    expect(renderAll('desktop-v2').querySelector('.settings-vfo-ops-row')).toBeNull();
+    expect(renderAll(RX_TX_ONLY).querySelector('.settings-vfo-ops-row')).not.toBeNull();
+    expect(renderAll('no-such-layout' as SkinId).querySelector('.settings-vfo-ops-row')).not.toBeNull();
+    // ...and the semantic replacement really is on screen where the row went.
+    expect(renderAll('desktop-v2').querySelector('.receiver-deck [data-vfo-split]')).not.toBeNull();
+    // The BAND half of the same modal section is untouched by this exception.
+    expect(renderAll('desktop-v2').querySelector('[data-panel-id="desktop-vfo-ops"] .band-tabs')).not.toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

S6-pre (MOR-1263 tail): ONE suppression channel for the legacy twins the zone slices will retire. A declared?: ReadonlySet<SemanticSurfaceName> prop (default empty = no-op) flows from RadioLayout's existing declaredSurfaces(getLayout(skinId)) into LeftSidebar/RightSidebar/StatusBar and the settings modal: 19 twins across 4 hosts gated, incl. the AGC->dsp pairing and both-sidebar rx-audio/dsp/cw twins. INERT on main today except the S10-ruled named exception (the settings-modal SPLIT/A-B row retires where the semantic deck owns it - it was already double-presented). Band twin deliberately EXCLUDED and pinned ('declaring the band zone suppresses nothing yet') - BandSelector splits in S8 per the S10 row-10 ruling.

Production LOC 20 (verifier-measured, frozen formula). 4-file guardrail EXPLICITLY WAIVED by coordinator (the alternative is every zone slice touching 4-5 files re-deriving the same wiring).

## Review provenance

Verified by the rework-domain opus anchor #3 (session 8): PASS with one comment-only correction (applied - the desktop-vfo-ops comment now matches S10 row 10: that panel can never be fully gated, S8 must NOT gate its mount). Twin coverage verified COMPLETE by the anchor's independent enumeration (13+6 sidebar panels, 5 indicators, 8 modal sections - every ungated one has a recorded reason). Inertness re-proved by the anchor's own element-stream capture: undeclared layout 1171->1171 identical; desktop-v2 and sdr-test each exactly one 11-node hunk (the named SPLIT exception). Mutants re-killed incl. MM8 dying on the UNEDITED MOR-1313 R9 quadrant test; semanticRxTx byte-identical to main; S5 asymmetry intact; no singleOrder branches. Gates 5797/5797 fresh localstorage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)