### PR TITLE
feat(MOR-1282): BarGauge peak-hold channel - one ballistics implementation (pre-cutover binding)

### DIFF
--- a/frontend/src/components-v2/meters/BarGauge.svelte
+++ b/frontend/src/components-v2/meters/BarGauge.svelte
@@ -1,8 +1,20 @@
+<script module lang="ts">
+  /** MOR-1282: shared decay window so MetersDockPanel's own peak-hold (which
+   *  already channels through `updatePeakHold`/`peakHoldDisplay`, see
+   *  meter-utils.ts) and this gauge's peak marker never drift apart. */
+  export const PEAK_DECAY_MS = 1500;
+</script>
+
 <script lang="ts">
-  import { onMount } from 'svelte';
-  import { createSmoother } from '$lib/utils/smoothing.svelte';
+  import { onMount, untrack } from 'svelte';
+  import {
+    createSmoother,
+    prefersReducedMotion,
+    onReducedMotionChange,
+  } from '$lib/utils/smoothing.svelte';
   import { DEFAULT_ZONES, valueToSegments, getSegmentZone, dimColor } from './bar-gauge-utils';
   import type { Zone } from './bar-gauge-utils';
+  import { updatePeakHold, peakHoldDisplay, type PeakHoldState } from '../panels/meter-utils';
 
   interface Props {
     value: number;         // 0–1 normalized
@@ -10,9 +22,12 @@
     displayValue: string;  // '35W' | '1.2' | '-8'
     zones?: readonly Zone[];
     compact?: boolean;
+    showPeak?: boolean;    // MOR-1282: optional peak-hold marker
   }
 
-  let { value, label, displayValue, zones = DEFAULT_ZONES, compact = false }: Props = $props();
+  let {
+    value, label, displayValue, zones = DEFAULT_ZONES, compact = false, showPeak = false,
+  }: Props = $props();
 
   // ── Segment geometry ────────────────────────────────────────────────────────
   const SEG_COUNT = 10;
@@ -47,6 +62,57 @@
     return () => smoother.stop();
   });
 
+  // ── Peak-hold marker (MOR-1282) ─────────────────────────────────────────────
+  // Reuses `updatePeakHold`/`peakHoldDisplay` — the single MOR-1252 semantics
+  // implementation MetersDockPanel already channels through — so this gauge
+  // never disagrees with the dock about hold/decay/reduced-motion behaviour.
+  // MetersSurface stays loop-free (R9): all ballistics live here.
+  let peakState = $state<PeakHoldState | undefined>(undefined);
+  let peakNow = $state(Date.now());
+
+  // Latches on every live sample. Reads `peakState` (to compare against the
+  // new sample) as well as writing it, so the read must be untracked —
+  // otherwise `resetPeak()`'s write below would re-trigger this same effect
+  // and immediately re-latch from the still-live `value` (mirrors the dock's
+  // own `untrack(() => stepAllPeaks())` pattern for the identical hazard).
+  $effect(() => {
+    if (!showPeak) return;
+    const v = value;
+    const t = Date.now();
+    untrack(() => {
+      peakState = updatePeakHold(peakState, v, t, PEAK_DECAY_MS);
+      peakNow = t;
+    });
+  });
+
+  // Drives the decay display forward. No ticking (and no rAF) while reduced
+  // motion is preferred — the marker is a static hold instead (MOR-1249/1252).
+  $effect(() => {
+    if (!showPeak) return;
+    let intervalId: ReturnType<typeof setInterval> | null = null;
+    const start = () => { intervalId ??= setInterval(() => { peakNow = Date.now(); }, 100); };
+    const stop = () => { if (intervalId) { clearInterval(intervalId); intervalId = null; } };
+
+    if (!prefersReducedMotion()) start();
+    const unsubscribe = onReducedMotionChange((reduced) => {
+      if (reduced) stop(); else start();
+    });
+
+    return () => { stop(); unsubscribe(); };
+  });
+
+  let peakPct = $derived.by(() => {
+    if (!showPeak || peakState === undefined) return undefined;
+    const level = prefersReducedMotion()
+      ? peakState.latchedPeak
+      : peakHoldDisplay(peakState, value, peakNow, PEAK_DECAY_MS);
+    return Math.max(0, Math.min(100, level * 100));
+  });
+
+  function resetPeak() {
+    if (showPeak) peakState = undefined;
+  }
+
   // ── Reactive display values ─────────────────────────────────────────────────
   let fullSegs = $derived(Math.floor(smoother.value));
   let fracSeg  = $derived(smoother.value - Math.floor(smoother.value));
@@ -57,6 +123,8 @@
   width="100%"
   height="auto"
   preserveAspectRatio="xMidYMid meet"
+  role="group"
+  ondblclick={resetPeak}
 >
   <!-- Container background -->
   <rect
@@ -117,6 +185,17 @@
       />
     {/if}
   {/each}
+
+  <!-- Peak-hold marker (MOR-1282) -->
+  {#if showPeak && peakPct !== undefined}
+    <rect
+      x={BAR_X + (peakPct / 100) * BAR_WIDTH - 1}
+      y={TRACK_Y}
+      width="2" height={TRACK_H}
+      fill="var(--v2-accent-yellow, #f2cf4a)"
+      data-testid="bar-gauge-peak-marker"
+    />
+  {/if}
 
   <!-- Display value -->
   <text

--- a/frontend/src/components-v2/meters/BarGauge.svelte
+++ b/frontend/src/components-v2/meters/BarGauge.svelte
@@ -1,10 +1,3 @@
-<script module lang="ts">
-  /** MOR-1282: shared decay window so MetersDockPanel's own peak-hold (which
-   *  already channels through `updatePeakHold`/`peakHoldDisplay`, see
-   *  meter-utils.ts) and this gauge's peak marker never drift apart. */
-  export const PEAK_DECAY_MS = 1500;
-</script>
-
 <script lang="ts">
   import { onMount, untrack } from 'svelte';
   import {
@@ -14,7 +7,7 @@
   } from '$lib/utils/smoothing.svelte';
   import { DEFAULT_ZONES, valueToSegments, getSegmentZone, dimColor } from './bar-gauge-utils';
   import type { Zone } from './bar-gauge-utils';
-  import { updatePeakHold, peakHoldDisplay, type PeakHoldState } from '../panels/meter-utils';
+  import { updatePeakHold, peakHoldDisplay, PEAK_DECAY_MS, type PeakHoldState } from '../panels/meter-utils';
 
   interface Props {
     value: number;         // 0–1 normalized

--- a/frontend/src/components-v2/meters/__tests__/BarGauge.peakhold.svelte.test.ts
+++ b/frontend/src/components-v2/meters/__tests__/BarGauge.peakhold.svelte.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount, unmount, flushSync } from 'svelte';
+import BarGauge from '../BarGauge.svelte';
+
+// MOR-1282: BarGauge's optional peak-hold marker channel. Reuses
+// meter-utils::updatePeakHold/peakHoldDisplay — the single MOR-1252 semantics
+// implementation MetersDockPanel already channels through (see
+// MetersDockPanel.peakhold.svelte.test.ts) — so the marker here and the
+// dock's own held Po/SWR/ALC/Id readouts can never disagree about hold/decay
+// timing. These tests drive the 100 ms decay ticker with fake timers, mirroring
+// the dock's own test convention.
+
+let components: ReturnType<typeof mount>[] = [];
+let roots: HTMLElement[] = [];
+
+beforeEach(() => {
+  components = [];
+  roots = [];
+  vi.useFakeTimers();
+  vi.setSystemTime(0);
+});
+
+afterEach(() => {
+  components.forEach((c) => unmount(c));
+  roots.forEach((r) => r.remove());
+  components = [];
+  roots = [];
+  vi.useRealTimers();
+});
+
+function mountReactive(props: Record<string, unknown>) {
+  const state = $state(props);
+  const t = document.createElement('div');
+  document.body.appendChild(t);
+  roots.push(t);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const component = mount(BarGauge as any, { target: t, props: state });
+  flushSync();
+  components.push(component);
+  return { t, state, component };
+}
+
+// Asserting on NodeList length (not `querySelector(...) + toBeNull()`) sidesteps
+// a Svelte dev-mode "rune used outside .svelte" red herring vitest's
+// failure-message pretty-printer trips when it inspects a live mounted node —
+// the same convention `LinearSMeter.reduced-motion.svelte.test.ts` documents.
+function markerCount(t: HTMLElement): number {
+  return t.querySelectorAll('[data-testid="bar-gauge-peak-marker"]').length;
+}
+
+function markerX(t: HTMLElement): number | null {
+  const el = t.querySelector('[data-testid="bar-gauge-peak-marker"]');
+  const x = el?.getAttribute('x');
+  return x === null || x === undefined ? null : parseFloat(x);
+}
+
+describe('BarGauge peak-hold marker (MOR-1282)', () => {
+  it('renders no marker when showPeak is not set', () => {
+    const { t } = mountReactive({ value: 0.8, label: 'Po', displayValue: '80W' });
+    expect(markerCount(t)).toBe(0);
+  });
+
+  it('renders a marker at the latched peak once showPeak is set', () => {
+    const { t } = mountReactive({ value: 0.8, label: 'Po', displayValue: '80W', showPeak: true });
+    vi.advanceTimersByTime(100);
+    flushSync();
+    expect(markerX(t)).not.toBeNull();
+  });
+
+  it('holds the marker near the prior peak through a drop, then decays back', () => {
+    const { t, state } = mountReactive({
+      value: 1.0, label: 'Po', displayValue: '100W', showPeak: true,
+    });
+    vi.advanceTimersByTime(100);
+    flushSync();
+    const peakX = markerX(t) as number;
+    expect(peakX).not.toBeNull();
+
+    // Drop the live value; shortly after, the marker must still sit well
+    // above the live trough (~44 + 0.05*210 ≈ 55), proving it is held near
+    // the peak rather than tracking the drop instantaneously.
+    state.value = 0.05;
+    vi.advanceTimersByTime(100);
+    flushSync();
+    const heldX = markerX(t) as number;
+    expect(heldX).toBeGreaterThan(150);
+
+    // Advance past the full decay window — the marker must settle near the
+    // live trough, not the stale peak.
+    vi.advanceTimersByTime(1600);
+    flushSync();
+    const settledX = markerX(t) as number;
+    expect(settledX).toBeLessThan(70);
+    expect(settledX).toBeLessThan(peakX);
+  });
+
+  it('double-click resets the held peak', () => {
+    const { t } = mountReactive({
+      value: 1.0, label: 'Po', displayValue: '100W', showPeak: true,
+    });
+    vi.advanceTimersByTime(100);
+    flushSync();
+    expect(markerCount(t)).toBe(1);
+
+    t.querySelector('svg')!.dispatchEvent(new Event('dblclick', { bubbles: true }));
+    flushSync();
+    expect(markerCount(t)).toBe(0);
+  });
+});

--- a/frontend/src/components-v2/meters/__tests__/BarGauge.reduced-motion.svelte.test.ts
+++ b/frontend/src/components-v2/meters/__tests__/BarGauge.reduced-motion.svelte.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount, unmount, flushSync } from 'svelte';
+import BarGauge from '../BarGauge.svelte';
+
+// MOR-1282: BarGauge's peak marker must honor `prefers-reduced-motion` the
+// same way MetersDockPanel and LinearSMeter's own peak-hold loops already do
+// (MOR-1233/1249/1252): no decay interval scheduled while reduced motion is
+// preferred, the marker becomes a STATIC hold (frozen at the latched peak,
+// not decaying/gliding), and it re-seats INSTANTLY on the next live sample
+// once the hold window elapses — never on a timer. The MatchMediaMock +
+// mockReducedMotion() helper is duplicated from the sibling *.reduced-motion
+// test files (established per-file convention in this codebase, no shared
+// test util) — test-only code, not production LOC.
+
+interface MatchMediaMock {
+  mql: MediaQueryList;
+  setMatches: (matches: boolean) => void;
+  listenerCount: () => number;
+}
+
+function createMatchMediaMock(initialMatches: boolean): MatchMediaMock {
+  let matches = initialMatches;
+  const listeners = new Set<() => void>();
+  const mql = {
+    get matches() { return matches; },
+    addEventListener: (_type: string, fn: () => void) => { listeners.add(fn); },
+    removeEventListener: (_type: string, fn: () => void) => { listeners.delete(fn); },
+  } as unknown as MediaQueryList;
+  return {
+    mql,
+    setMatches: (next: boolean) => {
+      matches = next;
+      listeners.forEach((fn) => fn());
+    },
+    listenerCount: () => listeners.size,
+  };
+}
+
+function mockReducedMotion(matches: boolean) {
+  const original = window.matchMedia;
+  const { mql, setMatches, listenerCount } = createMatchMediaMock(matches);
+  window.matchMedia = vi.fn().mockReturnValue(mql) as unknown as typeof window.matchMedia;
+  return {
+    setMatches,
+    listenerCount,
+    restore: () => { window.matchMedia = original; },
+  };
+}
+
+let components: ReturnType<typeof mount>[] = [];
+let roots: HTMLElement[] = [];
+let setIntervalSpy: ReturnType<typeof vi.spyOn>;
+let clearIntervalSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  components = [];
+  roots = [];
+  vi.useFakeTimers();
+  vi.setSystemTime(0);
+  setIntervalSpy = vi.spyOn(window, 'setInterval');
+  clearIntervalSpy = vi.spyOn(window, 'clearInterval');
+});
+
+afterEach(() => {
+  components.forEach((c) => unmount(c));
+  roots.forEach((r) => r.remove());
+  components = [];
+  roots = [];
+  vi.useRealTimers();
+});
+
+function netActiveIntervals(): number {
+  return setIntervalSpy.mock.calls.length - clearIntervalSpy.mock.calls.length;
+}
+
+function mountReactive(props: Record<string, unknown>) {
+  const state = $state(props);
+  const t = document.createElement('div');
+  document.body.appendChild(t);
+  roots.push(t);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const component = mount(BarGauge as any, { target: t, props: state });
+  flushSync();
+  components.push(component);
+  return { t, state, component };
+}
+
+function markerX(t: HTMLElement): number | null {
+  const el = t.querySelector('[data-testid="bar-gauge-peak-marker"]');
+  const x = el?.getAttribute('x');
+  return x === null || x === undefined ? null : parseFloat(x);
+}
+
+describe('BarGauge — prefers-reduced-motion peak marker (MOR-1282, mirrors MOR-1249/1252)', () => {
+  it('schedules no decay interval when reduced motion is preferred at mount', () => {
+    const { restore } = mockReducedMotion(true);
+    try {
+      mountReactive({ value: 1.0, label: 'Po', displayValue: '100W', showPeak: true });
+      expect(netActiveIntervals()).toBe(0);
+    } finally {
+      restore();
+    }
+  });
+
+  it('schedules the decay interval when reduced motion is NOT preferred (baseline)', () => {
+    const { restore } = mockReducedMotion(false);
+    try {
+      mountReactive({ value: 1.0, label: 'Po', displayValue: '100W', showPeak: true });
+      expect(netActiveIntervals()).toBe(1);
+    } finally {
+      restore();
+    }
+  });
+
+  it('holds the marker statically under reduced motion — a further drop does not move it', () => {
+    const { restore } = mockReducedMotion(true);
+    try {
+      const { t, state } = mountReactive({
+        value: 1.0, label: 'Po', displayValue: '100W', showPeak: true,
+      });
+      const held = markerX(t);
+      expect(held).not.toBeNull();
+
+      state.value = 0.05;
+      flushSync();
+      expect(markerX(t)).toBe(held); // unchanged — static hold, no glide
+
+      // No timer ever fires the reset — the hold is event-driven, not ticked.
+      vi.advanceTimersByTime(2000);
+      expect(netActiveIntervals()).toBe(0);
+      expect(markerX(t)).toBe(held);
+    } finally {
+      restore();
+    }
+  });
+
+  it('resets the held peak instantly once a fresh sample arrives past the hold window', () => {
+    const { restore } = mockReducedMotion(true);
+    try {
+      const { t, state } = mountReactive({
+        value: 1.0, label: 'Po', displayValue: '100W', showPeak: true,
+      });
+      const held = markerX(t);
+
+      vi.advanceTimersByTime(2000); // past the 1500ms decay window
+      state.value = 0.2; // the next genuine sample after expiry
+      flushSync();
+      expect(markerX(t)).not.toBe(held);
+    } finally {
+      restore();
+    }
+  });
+
+  it('stops the live decay interval when reduced motion turns ON mid-session (F1)', () => {
+    const { setMatches, restore } = mockReducedMotion(false);
+    try {
+      mountReactive({ value: 1.0, label: 'Po', displayValue: '100W', showPeak: true });
+      expect(netActiveIntervals()).toBe(1);
+
+      setMatches(true);
+      expect(netActiveIntervals()).toBe(0);
+    } finally {
+      restore();
+    }
+  });
+
+  it('resumes the live decay interval when reduced motion turns OFF mid-session (F2)', () => {
+    const { setMatches, restore } = mockReducedMotion(true);
+    try {
+      mountReactive({ value: 1.0, label: 'Po', displayValue: '100W', showPeak: true });
+      expect(netActiveIntervals()).toBe(0);
+
+      setMatches(false);
+      expect(netActiveIntervals()).toBe(1);
+    } finally {
+      restore();
+    }
+  });
+
+  it('detaches the reduced-motion listener and clears the interval on unmount — no leak', () => {
+    const { listenerCount, restore } = mockReducedMotion(false);
+    try {
+      const { component } = mountReactive({
+        value: 1.0, label: 'Po', displayValue: '100W', showPeak: true,
+      });
+      expect(listenerCount()).toBeGreaterThan(0);
+      expect(netActiveIntervals()).toBe(1);
+
+      unmount(component);
+      components = components.filter((c) => c !== component);
+      expect(listenerCount()).toBe(0);
+      expect(netActiveIntervals()).toBe(0);
+    } finally {
+      restore();
+    }
+  });
+});

--- a/frontend/src/components-v2/panels/MetersDockPanel.svelte
+++ b/frontend/src/components-v2/panels/MetersDockPanel.svelte
@@ -15,6 +15,7 @@
     isAlcFault,
     isSwrFault,
     normalizePower,
+    PEAK_DECAY_MS,
     peakHoldDisplay,
     sLevel,
     swrLevel,
@@ -85,8 +86,9 @@
   // value, so the digits and the fill stay consistent. On RX the raw values are
   // 0, so the held peak naturally decays to 0 within the window (no stale TX
   // peak bleed). Vd (steady supply rail), COMP (not requested) and S (the RX
-  // indicator) keep instantaneous display.
-  const PEAK_DECAY_MS = 1500;
+  // indicator) keep instantaneous display. `PEAK_DECAY_MS` is the shared
+  // decay window (MOR-1282) imported from `./meter-utils` above — BarGauge
+  // imports the same binding so the window can never drift between surfaces.
 
   // Peak-hold state for Po/SWR/ALC/Id, latched on the RAW meter value. Stores
   // the latched peak + timestamp only; the decayed value is recomputed per

--- a/frontend/src/components-v2/panels/meter-utils.ts
+++ b/frontend/src/components-v2/panels/meter-utils.ts
@@ -349,6 +349,17 @@ export interface PeakHoldState {
   latchedAt: number;
 }
 
+/**
+ * Shared peak-hold decay window (MOR-1282), in milliseconds.
+ *
+ * Both `BarGauge` and `MetersDockPanel` import this single constant instead
+ * of each declaring their own literal — a raw sample must decay identically
+ * regardless of which surface is rendering it. Do not re-declare a local
+ * `PEAK_DECAY_MS` in either consumer; that would silently reintroduce the
+ * drift this constant exists to close.
+ */
+export const PEAK_DECAY_MS = 1500;
+
 export function updatePeakHold(
   state: PeakHoldState | undefined,
   current: number,

--- a/frontend/src/semantic/MetersSurface.svelte
+++ b/frontend/src/semantic/MetersSurface.svelte
@@ -44,20 +44,23 @@
   import { renderSlot } from './design-language-renderers';
 
   type BarKey = Exclude<keyof MetersViewModel, 'rfState' | 'signal'>;
-  type Scale = readonly [BarKey, string, (raw: number) => number, (raw: number) => string];
+  type Scale = readonly [BarKey, string, (raw: number) => number, (raw: number) => string, boolean];
 
-  /** `[field, label, level, format]` for the six bar meters, in the shipped
-   *  dock's priority order. The level/format pairs are `meter-utils`' own
-   *  calibrated functions — the same ones `MetersDockPanel` uses — so the two
-   *  can never disagree about what a raw sample means. `signal` is absent
-   *  because it has its own component (`LinearSMeter`, below). */
+  /** `[field, label, level, format, showPeak]` for the six bar meters, in the
+   *  shipped dock's priority order. The level/format pairs are
+   *  `meter-utils`' own calibrated functions — the same ones `MetersDockPanel`
+   *  uses — so the two can never disagree about what a raw sample means.
+   *  `showPeak` (MOR-1282) mirrors the dock's own `PeakKey` set (Po/SWR/ALC/
+   *  Id) — Vd (a continuous supply rail) and COMP were never peak-held there
+   *  either. `signal` is absent because it has its own component
+   *  (`LinearSMeter`, below). */
   export const METER_BARS = [
-    ['power', 'Po', normalizePower, formatPowerWatts],
-    ['swr', 'SWR', swrLevel, formatSwr],
-    ['alc', 'ALC', alcLevel, formatAlc],
-    ['drainCurrent', 'Id', idLevel, formatAmps],
-    ['drainVoltage', 'Vd', vdLevel, formatVolts],
-    ['compression', 'COMP', compLevel, formatCompDb],
+    ['power', 'Po', normalizePower, formatPowerWatts, true],
+    ['swr', 'SWR', swrLevel, formatSwr, true],
+    ['alc', 'ALC', alcLevel, formatAlc, true],
+    ['drainCurrent', 'Id', idLevel, formatAmps, true],
+    ['drainVoltage', 'Vd', vdLevel, formatVolts, false],
+    ['compression', 'COMP', compLevel, formatCompDb, false],
   ] as const satisfies readonly Scale[];
 
   /** Level 1 — does this radio HAVE the meter at all. */
@@ -131,7 +134,7 @@
       </div>
     {/if}
 
-    {#each METER_BARS as [field, label, level, format] (field)}
+    {#each METER_BARS as [field, label, level, format, showPeak] (field)}
       {#if present(meters[field]) && (field !== 'compression' || compressorOn)}
         <div
           class="meter-tile" data-meter-tile data-meter={field} data-testid={`meter-${field}`}
@@ -141,7 +144,7 @@
           {#if observed(meters[field])}
             <BarGauge
               value={level(rawOf(meters[field]))} {label}
-              displayValue={format(rawOf(meters[field]))} compact
+              displayValue={format(rawOf(meters[field]))} compact {showPeak}
             />
           {:else}
             <span class="meter-unknown">{label} ?</span>

--- a/frontend/src/semantic/__tests__/MetersSurface.test.ts
+++ b/frontend/src/semantic/__tests__/MetersSurface.test.ts
@@ -461,3 +461,50 @@ describe('the meter table matches the shipped dock', () => {
       .toEqual(['Po', 'SWR', 'ALC', 'Id', 'Vd', 'COMP']);
   });
 });
+
+// ── 9. Peak-hold channel (MOR-1282) — the surface passes it through ────────
+
+describe('BarGauge peak channel (MOR-1282)', () => {
+  // MUTATION KILLED: enabling (or dropping) the peak flag on the wrong
+  // meters. Matches the dock's own peak-held set exactly (MetersDockPanel's
+  // `PeakKey`) — Vd (continuous supply rail) and COMP were never peak-held
+  // there either, so the surface must not invent peak-hold for them.
+  it('enables the peak marker on exactly the meters the dock peak-holds (Po/SWR/ALC/Id)', () => {
+    const withPeak = METER_BARS.filter(([, , , , showPeak]) => showPeak).map(([field]) => field);
+    expect(withPeak).toEqual(['power', 'swr', 'alc', 'drainCurrent']);
+  });
+
+  // MUTATION KILLED: `showPeak` not reaching `<BarGauge>` (freezing it to
+  // its `false` default) — the marker would never render regardless of the
+  // flag table above. This mounts the REAL BarGauge (no stub), so the
+  // marker's presence proves the prop actually threads through.
+  it('renders a peak marker on a peak-tracked meter and none on Vd/COMP', () => {
+    withSurface(base('transmitting'), (s) => {
+      expect(s.tile('power')!.querySelector('[data-testid="bar-gauge-peak-marker"]')).not.toBeNull();
+      expect(s.tile('swr')!.querySelector('[data-testid="bar-gauge-peak-marker"]')).not.toBeNull();
+      expect(s.tile('drainVoltage')!.querySelector('[data-testid="bar-gauge-peak-marker"]')).toBeNull();
+      expect(s.tile('compression')!.querySelector('[data-testid="bar-gauge-peak-marker"]')).toBeNull();
+    });
+  });
+});
+
+// ── 10. Same channel as the dock (MOR-1282) — no independent reimplementation ─
+
+describe('MetersSurface and MetersDockPanel are on the same peak-hold channel', () => {
+  // MUTATION KILLED: either side reimplementing the hold/decay math instead
+  // of calling the shared `meter-utils` functions. `MetersSurface` itself may
+  // never import them (block 7 above); `BarGauge` (which it delegates every
+  // gauge to) and `MetersDockPanel` must both import the SAME functions from
+  // the SAME module, so a raw sample can never decay differently depending on
+  // which surface is rendering it.
+  it('both BarGauge and MetersDockPanel import updatePeakHold/peakHoldDisplay from the shared meter-utils module', () => {
+    const barGaugeSource = readFileSync('src/components-v2/meters/BarGauge.svelte', 'utf8');
+    const dockSource = readFileSync('src/components-v2/panels/MetersDockPanel.svelte', 'utf8');
+    expect(barGaugeSource).toMatch(/updatePeakHold/);
+    expect(barGaugeSource).toMatch(/peakHoldDisplay/);
+    expect(barGaugeSource).toMatch(/from '\.\.\/panels\/meter-utils'/);
+    expect(dockSource).toMatch(/updatePeakHold/);
+    expect(dockSource).toMatch(/peakHoldDisplay/);
+    expect(dockSource).toMatch(/from '\.\/meter-utils'/);
+  });
+});

--- a/frontend/src/semantic/__tests__/MetersSurface.test.ts
+++ b/frontend/src/semantic/__tests__/MetersSurface.test.ts
@@ -507,4 +507,17 @@ describe('MetersSurface and MetersDockPanel are on the same peak-hold channel', 
     expect(dockSource).toMatch(/peakHoldDisplay/);
     expect(dockSource).toMatch(/from '\.\/meter-utils'/);
   });
+
+  // MUTATION KILLED (F1): either consumer re-declaring a local `PEAK_DECAY_MS`
+  // literal instead of importing the shared one from `meter-utils` — the
+  // exact duplicated-window drift the verifier proved was previously pinned
+  // by NOTHING. Both must import the SAME binding; neither may shadow it.
+  it('both BarGauge and MetersDockPanel import the shared PEAK_DECAY_MS instead of declaring their own', () => {
+    const barGaugeSource = readFileSync('src/components-v2/meters/BarGauge.svelte', 'utf8');
+    const dockSource = readFileSync('src/components-v2/panels/MetersDockPanel.svelte', 'utf8');
+    expect(barGaugeSource).toMatch(/import\s*\{[^}]*PEAK_DECAY_MS[^}]*\}\s*from\s*'\.\.\/panels\/meter-utils'/);
+    expect(dockSource).toMatch(/import\s*\{[^}]*PEAK_DECAY_MS[^}]*\}\s*from\s*'\.\/meter-utils'/);
+    expect(barGaugeSource).not.toMatch(/const\s+PEAK_DECAY_MS\s*=/);
+    expect(dockSource).not.toMatch(/const\s+PEAK_DECAY_MS\s*=/);
+  });
 });


### PR DESCRIPTION
## Summary

MOR-1282 (binding pre-cutover follow-up of vocabulary slice 2B): optional peak-hold marker channel in BarGauge reusing meter-utils::updatePeakHold - the single MOR-1252 semantics implementation (1000/1500ms static hold, owner-decided). The meters surface passes it through for Po/SWR/ALC/Id (the dock's exact PeakKey set); MetersDockPanel stays on the same shared channel (verified 0 behavioral diff - it already called the shared functions); PEAK_DECAY_MS moves to meter-utils.ts as the single source of truth with a cross-file parity pin.

Production LOC 52 (verifier-measured, frozen formula). 4-file guardrail EXPLICITLY WAIVED by coordinator: the 4th file is meter-utils.ts receiving the shared constant - the architecturally-preferred variant that REDUCES LOC and removes the drift-inviting second literal.

## Review provenance

Verified by the fixtures/evidence opus anchor (session 8) - the same anchor that owns the MOR-1087 reduced-motion assertions. Live-instrumented in a real page: under reduce - 4 peak markers, rafCount=0, zero 100ms intervals; under no-preference - rafCount=91, exactly four 100ms intervals (one per gauge). setInterval-never-rAF is real, not claimed. Initial PASS with one required fix (F1: false 'shared' comment + dead export + unpinned constant drift - same class as 1087's F-A), fixed and delta-confirmed: drift mutants die at the new single home, dock ballistics 15/15 identical, harness zero capture-level movement, suite 5773/5773 zero failures fresh-localstorage. Adjudications: 0-diff dock correct (rewriting it would drag RAW-domain digit-holding into the 0-1 domain - a forbidden behavior change); LinearSMeter correctly out of scope (MOR-1374, raised to Medium as pre-cutover candidate).

Follow-ups: MOR-1374 (LinearSMeter second implementation), MOR-1375 (mouse-only peak reset, companion to MOR-1350).

On merge the MOR-1262 vocabulary program's last open item closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)