### PR TITLE
feat(MOR-1365): scopeDisplay zone ownership on desktop-v2 (rework S6a)

### DIFF
--- a/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
@@ -579,11 +579,17 @@ describe('the legacy-twin suppression channel (MOR-1364, S6-pre)', () => {
     'antenna', 'scan', 'rx-audio', 'dsp', 'tx', 'cw', 'memory'];
   const RIGHT_ALL = ['rx-audio', 'audio-scope', 'dsp', 'tx', 'cw', 'memory'];
 
-  /** surface → the zone id its rework slice will declare on `desktop-v2`. */
+  /** surface → the zone id its rework slice will declare on `desktop-v2`.
+   *  `scopeDisplay` graduated to a REAL declaration in MOR-1365 (S6a) and left
+   *  this synthetic-probe literal — a probe re-declaring `scope-display` here
+   *  would collide with the real zone `desktopV2Layout.zones` already
+   *  carries. Its suppression is now proved directly against the real
+   *  manifest below (`the legacy-twin suppression channel retires the status
+   *  bar scope indicator on the REAL desktop-v2 manifest (MOR-1365)`). */
   const ZONES = [
     ['filter', 'filter'], ['rfFrontEnd', 'rf-front-end'], ['dsp', 'dsp'],
     ['ritXitScan', 'rit-xit-scan'], ['antenna', 'antenna'], ['rxAudio', 'rx-audio'],
-    ['cwKeyer', 'cw-keyer'], ['scopeDisplay', 'scope-display'], ['band', 'band'],
+    ['cwKeyer', 'cw-keyer'], ['band', 'band'],
   ] as const;
   type CoveredSurface = (typeof ZONES)[number][0];
 
@@ -622,7 +628,6 @@ describe('the legacy-twin suppression channel (MOR-1364, S6-pre)', () => {
     ['cwKeyer', 'left sidebar CW', '.left-sidebar [data-panel-id="cw"]'],
     ['cwKeyer', 'right sidebar CW', '.right-sidebar [data-panel-id="cw"]'],
     ['cwKeyer', 'settings modal CW', '[data-panel-id="desktop-cw"]'],
-    ['scopeDisplay', 'status bar scope indicator', '.status-indicators [title^="Scope WebSocket"]'],
   ] as const satisfies readonly (readonly [CoveredSurface, string, string])[];
 
   /**
@@ -754,5 +759,66 @@ describe('the legacy-twin suppression channel (MOR-1364, S6-pre)', () => {
     expect(renderAll('desktop-v2').querySelector('.receiver-deck [data-vfo-split]')).not.toBeNull();
     // The BAND half of the same modal section is untouched by this exception.
     expect(renderAll('desktop-v2').querySelector('[data-panel-id="desktop-vfo-ops"] .band-tabs')).not.toBeNull();
+  });
+});
+
+/**
+ * MOR-1365 (v3-rework S6a) — `scopeDisplay` GRADUATES from a synthetic probe
+ * (the `ZONE_PROBE` shape above) to a REAL zone `desktopV2Layout` declares.
+ * The status bar's legacy scope indicator retires through the SAME MOR-1364
+ * suppression channel; this describe proves it directly against the real
+ * manifest, not a hand-built one, so a regression here is a statement about
+ * `desktop-declarations.ts` and not about test scaffolding.
+ *
+ * MUTATION PROBE (required by the ticket): dropping the `scope-display` zone
+ * from `DESKTOP_V2_ZONES` turns this file's own
+ * `scope-display-declarability.test.ts` / `desktop-v2-registration.test.ts` /
+ * `preferences-adoption.test.ts` pins red (the S5 MM2 fan-out) AND turns the
+ * first test below red too — five independent pins, not a thin margin.
+ */
+describe('scopeDisplay zone ownership retires the status bar scope indicator (MOR-1365, S6a)', () => {
+  const SCOPE_INDICATOR = '.status-indicators [title^="Scope WebSocket"]';
+
+  beforeEach(() => {
+    h.caps = { ...(capsFor('2/main_sub') as object), antennas: 2 } as Capabilities;
+    vi.mocked(hasAnyScope).mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    vi.mocked(hasAnyScope).mockReturnValue(false);
+  });
+
+  // THE CHANNEL, on the real manifest: the twin that rendered unconditionally
+  // before this slice (proved by the S6-pre `TWINS` inventory prior to
+  // MOR-1365 removing the row — see git history) is gone.
+  it('suppresses the status bar scope indicator on real desktop-v2', () => {
+    expect(render('desktop-v2').querySelector(SCOPE_INDICATOR)).toBeNull();
+  });
+
+  // Mirrors the S6-pre matrix's own inertness half: a layout that declares NO
+  // scope-display zone still shows the legacy indicator — proves the
+  // predicate reads the manifest, not a global flag.
+  it('leaves the indicator on a layout that declares no scope-display zone', () => {
+    expect(render(RX_TX_ONLY).querySelector(SCOPE_INDICATOR)).not.toBeNull();
+  });
+
+  // R9 restated once more: this zone carries no key/unkey authority.
+  it('adds no key authority when the scope-display zone is declared', () => {
+    expect(render('desktop-v2').querySelectorAll(KEY_AUTHORITIES).length).toBe(1);
+  });
+
+  // MOR-1069, verified rather than assumed (ScopeDisplaySurface is a
+  // ZERO-FOCUSABLE pure readout — see its own file header): declaring the
+  // zone contributes NOTHING to desktop-v2's tab sequence. This shell mounts
+  // `RadioLayout` directly (not under `App`), so it never provides a
+  // `SurfacePlan` context and cannot see the `data-zone-id` wrapper itself
+  // (`useSurfacePlan()` falls back to `NO_PLAN`, same as every other test in
+  // this file) — the zone-binding half of MOR-1069 is proved with a real
+  // context in `semantic-scope-display-wiring.component.test.ts` instead.
+  // What THIS harness can and does prove is the surface's own contract.
+  it('contributes no focusable control to desktop-v2 (MOR-1069 sequence unmoved)', () => {
+    const surface = render('desktop-v2').querySelector('[data-testid="scope-display-surface"]');
+    expect(surface).not.toBeNull();
+    expect(surface!.querySelectorAll('button, input, select, a[href], [tabindex]')).toHaveLength(0);
   });
 });

--- a/frontend/src/components-v2/wiring/__tests__/semantic-scope-display-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-scope-display-wiring.component.test.ts
@@ -154,6 +154,18 @@ vi.mock('../command-bus', () => ({
 }));
 
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';
+// MOR-1365 (S6a): the REAL manifests + the REAL resolution seam, mirroring
+// `semantic-tx-aux-wiring.component.test.ts`'s "MOR-1082 — the semantic
+// vertical consults the resolved surface plan" shape — the only way to prove
+// the `scope-display` zone binding and the S5 subtraction asymmetry, since
+// `useSurfacePlan()` falls back to `NO_PLAN` on a standalone mount.
+import {
+  desktopV2Layout, dualReceiverCockpitLayout,
+} from '../../../presentation/layouts/declarations';
+import { readWorkspace } from '../../../presentation/workspace/contract';
+import {
+  resolveSurfacePlan, SURFACE_PLAN_CONTEXT_KEY, type SurfacePlan,
+} from '../../../presentation/workspace/resolution';
 
 const IDLE: Snapshot = {
   phase: 'idle', intent: null, guard: null, radioTx: 'off', txRisk: 'none',
@@ -198,10 +210,13 @@ const liveCaps = (withScope: boolean): Capabilities => ({
 let target: HTMLDivElement;
 let component: ReturnType<typeof mount> | null = null;
 
-function render(props: { strips?: 'single' | 'dual' } = {}): void {
+function render(props: { strips?: 'single' | 'dual' } = {}, plan?: SurfacePlan): void {
   target = document.createElement('div');
   document.body.appendChild(target);
-  component = mount(SemanticRadioSurfaces, { target, props });
+  const context = plan === undefined
+    ? undefined
+    : new Map<unknown, unknown>([[SURFACE_PLAN_CONTEXT_KEY, () => plan]]);
+  component = mount(SemanticRadioSurfaces, { target, props, context });
   flushSync();
 }
 
@@ -381,4 +396,70 @@ describe('the scope-display surface adds no control and no TX path', () => {
       expect(h.release).not.toHaveBeenCalled();
     },
   );
+});
+
+// ── 4. MOR-1365 (S6a) — desktop-v2 REALLY declares the zone; the cockpit ──
+// ── does not, and the plan can only ever cost the wrapper, never the fact ─
+
+/**
+ * `desktopV2Layout` now carries a `scope-display` zone
+ * (`presentation/layouts/desktop-declarations.ts`). This describes the two
+ * things that follow from it, using the REAL manifest + the REAL
+ * `resolveSurfacePlan` seam, exactly as `semantic-tx-aux-wiring.component
+ * .test.ts`'s "MOR-1082 — the semantic vertical consults the resolved
+ * surface plan" section does for `txAux`:
+ *
+ *   (a) the zone binds — `zoneOwning('scopeDisplay')` now answers
+ *       `'scope-display'` against desktop-v2's real plan, so the composed
+ *       tree wraps the surface in `<div data-zone-id="scope-display">`;
+ *   (b) the S5/S6-pre asymmetry: a workspace that SUBTRACTS `scopeDisplay`
+ *       from that zone costs the operator the wrapper `<div>`, never the
+ *       readout — `zoned()` degrades to bare (S5-N3), so "the workspace
+ *       hid it" and "no zone declares it" are indistinguishable and both
+ *       render exactly the pre-1365 element shape. MUTATION PROBE: remove
+ *       the `zoned(...)` mount from `scopeDisplaySurface`'s call site and
+ *       BOTH tests below go red — (a) loses the wrapper, (b) loses the
+ *       surface entirely, proving the wrapper mount is what keeps the
+ *       readout alive when subtracted, not a redundant safety net.
+ *   (c) the dual-receiver cockpit manifest is untouched by this slice, so
+ *       the surface keeps mounting bare there — MOR-1069 unmoved.
+ */
+describe('desktop-v2 declares a REAL scope-display zone; the cockpit does not (MOR-1365)', () => {
+  /** What App resolves for `layout` given a stored workspace `fields`. */
+  function planFor(layout: typeof desktopV2Layout, fields: Record<string, unknown>): SurfacePlan {
+    return resolveSurfacePlan(layout, readWorkspace({ version: 1, ...fields }).workspace);
+  }
+
+  it('binds the scope-display zone id against desktop-v2\'s real plan', () => {
+    h.caps = liveCaps(true);
+    h.scopeStatus = { ...LIVE_SCOPE_STATUS };
+    render({ strips: 'single' }, planFor(desktopV2Layout, {}));
+    expect(q('[data-testid="scope-display-surface"]')!.closest('[data-zone-id="scope-display"]'))
+      .not.toBeNull();
+  });
+
+  // THE ASYMMETRY (S5 shape): a workspace subtraction costs the wrapper, not
+  // the fact. MUTATION PROBE: reading the PLAN instead of the MANIFEST for
+  // suppression anywhere in this channel would make this subtraction able to
+  // resurrect a legacy twin — this test only proves the surface side (the
+  // legacy-twin side is `semantic-desktop-migration.component.test.ts`'s
+  // job), but it is the half that shows the readout itself never disappears.
+  it('degrades to a bare readout — never disappears — when the workspace subtracts scopeDisplay from its zone', () => {
+    h.caps = liveCaps(true);
+    h.scopeStatus = { ...LIVE_SCOPE_STATUS };
+    render({ strips: 'single' }, planFor(desktopV2Layout, {
+      visibleSurfaces: { 'scope-display': [] },
+    }));
+    expect(q('[data-testid="scope-display-surface"]')).not.toBeNull();
+    expect(q('[data-testid="scope-display-source"]')!.textContent).toContain('hardware');
+    expect(q('[data-testid="scope-display-surface"]')!.closest('[data-zone-id]')).toBeNull();
+  });
+
+  it('keeps mounting bare in the dual-receiver cockpit — its manifest is untouched by this slice', () => {
+    h.caps = liveCaps(true);
+    h.scopeStatus = { ...LIVE_SCOPE_STATUS };
+    render({ strips: 'dual' }, planFor(dualReceiverCockpitLayout, {}));
+    expect(q('[data-testid="scope-display-surface"]')).not.toBeNull();
+    expect(q('[data-testid="scope-display-surface"]')!.closest('[data-zone-id]')).toBeNull();
+  });
 });

--- a/frontend/src/presentation/layouts/__tests__/desktop-v2-registration.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/desktop-v2-registration.test.ts
@@ -55,7 +55,7 @@ describe('the desktop-v2 entrypoint is registered in the real registry', () => {
 describe('declared zones now drive the DOM (MOR-1263 step 2, MOR-1313)', () => {
   // Kills: declaring a surface this manifest does not name, or dropping
   // either one — the pair per-zone suppression consumes.
-  it('declares receiver-deck:[vfo], rx-tx:[rxTx], tx-aux:[txAux] and meters:[meters]', () => {
+  it('declares receiver-deck:[vfo], rx-tx:[rxTx], tx-aux:[txAux], meters:[meters] and scope-display:[scopeDisplay]', () => {
     expect(desktopV2Layout.zones).toEqual([
       { id: 'receiver-deck', surfaces: ['vfo'] },
       { id: 'rx-tx', surfaces: ['rxTx'] },
@@ -63,6 +63,9 @@ describe('declared zones now drive the DOM (MOR-1263 step 2, MOR-1313)', () => {
       { id: 'tx-aux', surfaces: ['txAux'] },
       // MOR-1341 (S5): meters became zone-owned too, retiring the legacy dock.
       { id: 'meters', surfaces: ['meters'] },
+      // MOR-1365 (S6a): scopeDisplay became zone-owned too, retiring the
+      // status bar's legacy scope indicator.
+      { id: 'scope-display', surfaces: ['scopeDisplay'] },
     ]);
     expect([...desktopV2Layout.requiredSemanticSurfaces].sort()).toEqual(['rxTx', 'vfo']);
   });
@@ -84,7 +87,7 @@ describe('declared zones now drive the DOM (MOR-1263 step 2, MOR-1313)', () => {
   // is per-zone rather than per-manifest-first-zone.
   it('its zones flatten to the surfaces the shell suppresses legacy twins for', () => {
     expect([...declaredSurfaces(getLayout('desktop-v2'))].sort())
-      .toEqual(['meters', 'rxTx', 'txAux', 'vfo']);
+      .toEqual(['meters', 'rxTx', 'scopeDisplay', 'txAux', 'vfo']);
   });
 });
 

--- a/frontend/src/presentation/layouts/__tests__/scope-display-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/scope-display-declarability.test.ts
@@ -1,15 +1,21 @@
 /**
- * MOR-1312 — `scopeDisplay` is DECLARABLE, and nothing declares it yet.
+ * MOR-1312 — `scopeDisplay` is DECLARABLE. MOR-1365 (S6a) declares it for
+ * real.
  *
- * Slice 12B adds the name to `SEMANTIC_SURFACE_NAMES` so a manifest CAN mount
- * the surface later; it deliberately does not touch any manifest, and it adds
- * no design-language renderer slot (that set was frozen by MOR-1072 — adding
- * one would be a language-contract change this slice must not make).
+ * Slice 12B added the name to `SEMANTIC_SURFACE_NAMES` so a manifest CAN
+ * mount the surface later; it deliberately did not touch any manifest, and it
+ * added no design-language renderer slot (that set was frozen by MOR-1072 —
+ * adding one would be a language-contract change this slice must not make).
+ *
+ * MOR-1365 flips the second half, on `desktop-v2` ONLY: the cockpit manifest
+ * is deliberately untouched (S5 precedent), so `scopeDisplay` keeps mounting
+ * bare there. The inventory below is a LITERAL of who declares it, mirroring
+ * `meters-declarability.test.ts`'s post-S5 shape.
  *
  * Same three pins as `tx-aux-declarability.test.ts` / `meters-declarability.test.ts`
  * / `rx-audio-declarability.test.ts`:
  *   - drop the name and a future manifest's zone stops validating;
- *   - quietly add a `scopeDisplay` zone to a shipped manifest and the DOM
+ *   - quietly add a `scopeDisplay` zone to an unreviewed manifest and the DOM
  *     grows a zone id no layout review ever saw;
  *   - the renderer slot set stays exactly what MOR-1072 froze.
  */
@@ -49,17 +55,43 @@ describe('scopeDisplay is a declarable semantic surface', () => {
   });
 });
 
-describe('no shipped manifest declares a scopeDisplay zone in this slice', () => {
-  // Kills: slipping a scopeDisplay zone into an existing layout here.
-  // Declarability is the whole scope of the contract touch; placing the
-  // surface in a real layout is a later, separately reviewed slice (the
-  // same discipline `rxAudio`'s MOR-1279 established).
-  it.each([
+describe('exactly the reviewed manifests declare a scopeDisplay zone (MOR-1365)', () => {
+  /** The literal — extend by hand, with a layout review, never silently. */
+  const DECLARES_SCOPE_DISPLAY = ['desktop-v2'];
+
+  const ALL = [
     ['sdr-test', sdrTestLayout], ['dual-receiver-cockpit', dualReceiverCockpitLayout],
     ['lcd-cockpit', lcdCockpitLayout], ['lcd-scope', lcdScopeLayout],
     ['mobile', mobileLayout], ['desktop-v2', desktopV2Layout],
-  ])('%s declares no scopeDisplay zone and does not require the surface', (_id, manifest) => {
-    for (const zone of manifest.zones) expect(zone.surfaces).not.toContain('scopeDisplay');
+  ] as const;
+
+  // Kills BOTH directions: a family losing the zone S6a gave it, and a family
+  // gaining one without review.
+  it('the declaring set is exactly the reviewed literal', () => {
+    const declaring = ALL
+      .filter(([, m]) => m.zones.some((z) => z.surfaces.includes('scopeDisplay')))
+      .map(([id]) => id)
+      .sort();
+    expect(declaring).toEqual([...DECLARES_SCOPE_DISPLAY].sort());
+  });
+
+  // Kills: declaring the zone under a drifted id — the wiring binds whatever
+  // the plan's key is, so the id IS the contract with the layout's arrangement.
+  it.each(DECLARES_SCOPE_DISPLAY)(
+    '%s declares it under the stable `scope-display` id, alone in its zone',
+    (id) => {
+      const manifest = ALL.find(([name]) => name === id)![1];
+      const zone = manifest.zones.find((z) => z.surfaces.includes('scopeDisplay'))!;
+      expect(zone.id).toBe('scope-display');
+      expect(zone.surfaces).toEqual(['scopeDisplay']);
+    },
+  );
+
+  // Kills: making scopeDisplay REQUIRED. A radio the MOR-1301 evidence gate
+  // declines must still resolve this layout; the surface self-gates on
+  // `view.scopeDisplay`, and a required surface no zone could fill would be a
+  // resolution failure rather than an honest absence.
+  it.each(ALL)('%s does not require the scopeDisplay surface', (_id, manifest) => {
     expect(manifest.requiredSemanticSurfaces).not.toContain('scopeDisplay');
   });
 });

--- a/frontend/src/presentation/layouts/desktop-declarations.ts
+++ b/frontend/src/presentation/layouts/desktop-declarations.ts
@@ -46,6 +46,15 @@ const DESKTOP_V2_ZONES = [
   // reporting no meter fields at all must still resolve this layout, and the
   // surface self-gates on `view.meters`.
   { id: 'meters', surfaces: ['meters'] },
+  // MOR-1365 (S6a): scopeDisplay becomes zone-OWNED here too, retiring the
+  // status bar's legacy scope indicator via the MOR-1364 suppression channel
+  // (`StatusBar.svelte`'s `!declared.has('scopeDisplay')` guard). Pure
+  // readout, zero focusable elements, so MOR-1069 cannot be disturbed. Not
+  // `required` — a radio the MOR-1301 evidence gate declined must still
+  // resolve this layout, and the surface self-gates on `view.scopeDisplay`.
+  // The dual-receiver cockpit manifest is deliberately untouched;
+  // `scopeDisplay` keeps mounting bare there (12B's own shape).
+  { id: 'scope-display', surfaces: ['scopeDisplay'] },
 ] as const;
 
 export const desktopV2Layout: LayoutManifest = {

--- a/frontend/src/presentation/workspace/__tests__/preferences-adoption.test.ts
+++ b/frontend/src/presentation/workspace/__tests__/preferences-adoption.test.ts
@@ -263,10 +263,10 @@ describe('MOR-1082 — the single-composition order comes from the same plan', (
   it('flattens the plan in zone-declaration order, deduped', () => {
     expect(compositionSurfaces(plan(sdrTestLayout), FALLBACK)).toEqual(['vfo', 'rxTx']);
     // desktop-v2 spreads the same two surfaces over two zones, plus its own
-    // MOR-1336 (S4) tx-aux zone and MOR-1341 (S5) meters zone — flattening
-    // never drops a fourth zone.
+    // MOR-1336 (S4) tx-aux zone, MOR-1341 (S5) meters zone and MOR-1365 (S6a)
+    // scope-display zone — flattening never drops a fifth zone.
     expect(compositionSurfaces(plan(desktopV2Layout), FALLBACK))
-      .toEqual(['vfo', 'rxTx', 'txAux', 'meters']);
+      .toEqual(['vfo', 'rxTx', 'txAux', 'meters', 'scopeDisplay']);
     expect(compositionSurfaces(plan(sdrTestLayout, { zoneOrder: { main: ['rxTx', 'vfo'] } }), FALLBACK))
       .toEqual(['rxTx', 'vfo']);
   });

--- a/frontend/src/presentation/workspace/contract.ts
+++ b/frontend/src/presentation/workspace/contract.ts
@@ -49,7 +49,7 @@ export const WORKSPACE_THEME_IDS = [
 export type WorkspaceThemeId = (typeof WORKSPACE_THEME_IDS)[number];
 
 /** Every zone id declared by a registered layout manifest (decisions 5 and 6). */
-export const WORKSPACE_ZONE_IDS = ['main', 'receiver-deck', 'rx-tx', 'primary-vfo', 'secondary-vfo', 'global', 'portrait-deck', 'control-column', 'tx-aux', 'meters'] as const;
+export const WORKSPACE_ZONE_IDS = ['main', 'receiver-deck', 'rx-tx', 'primary-vfo', 'secondary-vfo', 'global', 'portrait-deck', 'control-column', 'tx-aux', 'meters', 'scope-display'] as const;
 export type WorkspaceZoneId = (typeof WORKSPACE_ZONE_IDS)[number];
 
 /** Decision 7: command-bus intent names (`set_compressor`), never module paths. */


### PR DESCRIPTION
## Summary

S6a (MOR-1263 tail): the scope-display zone declared in the desktop-v2 manifest; the S6-pre channel retires the status-bar legacy scope indicator (the only scopeDisplay twin); the surface plan mounts the semantic wrapper per the S5 asymmetry (degrades to bare on subtraction - readout never disappears).

Production LOC 1 (verifier-measured, frozen formula).

## Review provenance

Verified by the rework-domain opus anchor #3 (session 8): PASS, no required fixes. Zone ownership proved at plan level 4/4 including the pre-S6a stored-workspace migration case (an absent workspace entry keeps the declared set - no blank zones for existing operators); cockpit confirmed NOT owning; MOR-1337 subtraction residual unchanged. Re-kills: 4 mutants incl. both directions of the legacy predicate (margin 2); the anchor's MM-B re-run found 10 red vs the builder's 9 - the two new zone pins are load-bearing. Twin completeness confirmed by source sweep (StatusBar:271 only; SpectrumPanel:48 is an operational gate, correctly not on the channel). N1 ruling: this slice ships the program's FIRST committed zone-ownership assertion (real SurfacePlan context injection) - the recipe is now required for S7/S8/S9. Suite 5864/5865 (the one failure isolated 28/28 twice and attributed to a pre-existing registry flake, reproduced on unmodified main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)