### PR TITLE
feat(MOR-1366): filter + rfFrontEnd zone ownership on desktop-v2 (rework S7)

### DIFF
--- a/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
@@ -579,15 +579,24 @@ describe('the legacy-twin suppression channel (MOR-1364, S6-pre)', () => {
     'antenna', 'scan', 'rx-audio', 'dsp', 'tx', 'cw', 'memory'];
   const RIGHT_ALL = ['rx-audio', 'audio-scope', 'dsp', 'tx', 'cw', 'memory'];
 
-  /** surface → the zone id its rework slice will declare on `desktop-v2`.
-   *  `scopeDisplay` graduated to a REAL declaration in MOR-1365 (S6a) and left
-   *  this synthetic-probe literal — a probe re-declaring `scope-display` here
-   *  would collide with the real zone `desktopV2Layout.zones` already
-   *  carries. Its suppression is now proved directly against the real
-   *  manifest below (`the legacy-twin suppression channel retires the status
-   *  bar scope indicator on the REAL desktop-v2 manifest (MOR-1365)`). */
+  /**
+   * surface → the zone id its rework slice will declare on `desktop-v2`.
+   * `scopeDisplay` graduated to a REAL declaration in MOR-1365 (S6a) and left
+   * this synthetic-probe literal — a probe re-declaring `scope-display` here
+   * would collide with the real zone `desktopV2Layout.zones` already
+   * carries. Its suppression is now proved directly against the real
+   * manifest below (`the legacy-twin suppression channel retires the status
+   * bar scope indicator on the REAL desktop-v2 manifest (MOR-1365)`).
+   *
+   * `filter` and `rfFrontEnd` graduated off this synthetic-probe list in
+   * MOR-1366 (S7): `desktopV2Layout` now declares both for real, so spreading
+   * `desktopV2Layout.zones` plus a second `{ id: 'filter', … }` /
+   * `{ id: 'rf-front-end', … }` entry here would duplicate a zone id the real
+   * manifest already owns. Their suppression is asserted directly against the
+   * REAL `desktop-v2` registration below instead of through `ZONE_PROBE`.
+   */
   const ZONES = [
-    ['filter', 'filter'], ['rfFrontEnd', 'rf-front-end'], ['dsp', 'dsp'],
+    ['dsp', 'dsp'],
     ['ritXitScan', 'rit-xit-scan'], ['antenna', 'antenna'], ['rxAudio', 'rx-audio'],
     ['cwKeyer', 'cw-keyer'], ['band', 'band'],
   ] as const;
@@ -608,12 +617,14 @@ describe('the legacy-twin suppression channel (MOR-1364, S6-pre)', () => {
    * it, and where it lives. `dsp` owns FIVE rows because `DspSurface` covers
    * the AGC leaf too (5A/MOR-1290) — a `dsp` zone that retired `DspPanel` and
    * left `AgcPanel` standing would ship a half-double, in two hosts.
+   *
+   * `filter` (left sidebar MODE + FILTER) and `rfFrontEnd` (left sidebar RF
+   * FRONT END + settings modal RF FRONT END) are NOT rows here any more
+   * (MOR-1366, S7): the real `desktop-v2` manifest now declares both zones,
+   * so those twins no longer render at all — asserted directly below rather
+   * than through this "no zone declaring it yet" inventory.
    */
   const TWINS = [
-    ['filter', 'left sidebar MODE', '.left-sidebar [data-panel-id="mode"]'],
-    ['filter', 'left sidebar FILTER', '.left-sidebar [data-panel-id="filter"]'],
-    ['rfFrontEnd', 'left sidebar RF FRONT END', '.left-sidebar [data-panel-id="rf-front-end"]'],
-    ['rfFrontEnd', 'settings modal RF FRONT END', '[data-panel-id="desktop-rf"]'],
     ['dsp', 'left sidebar AGC', '.left-sidebar [data-panel-id="agc"]'],
     ['dsp', 'left sidebar DSP', '.left-sidebar [data-panel-id="dsp"]'],
     ['dsp', 'right sidebar DSP', '.right-sidebar [data-panel-id="dsp"]'],
@@ -675,20 +686,23 @@ describe('the legacy-twin suppression channel (MOR-1364, S6-pre)', () => {
   });
 
   // INERTNESS, half two, stated as an inventory rather than per-row: the exact
-  // set of panels desktop-v2 renders is unchanged by this slice. Measured
-  // against `origin/main` with the identical fixture before the channel
-  // landed — see the build report's element-stream diff (2049/2049 nodes
-  // identical on the undeclared layout; on desktop-v2 exactly one 11-node
-  // hunk, the SPLIT row below).
-  it('renders exactly the panel inventory it rendered before the channel existed', () => {
+  // set of panels desktop-v2 renders. This is the pin the N3 carry-forward
+  // warned about — it MUST go red the moment a zone-declaring slice lands,
+  // and the correct fix is deleting the retired ids, never widening the
+  // literal. MOR-1366 (S7) is the first slice to do that: `desktop-rf`
+  // (settings modal RF FRONT END), `filter`, `mode` and `rf-front-end` are
+  // gone from the panel inventory because the `filter`/`rf-front-end` zones
+  // are now REAL on `desktop-v2`, not synthetic probes — see the dedicated
+  // "drops the legacy ... twins" tests below for the non-vacuous proof.
+  it('renders exactly the panel inventory desktop-v2 renders post-S7', () => {
     const ids = [...renderAll('desktop-v2').querySelectorAll('[data-panel-id]')]
       .map((el) => el.getAttribute('data-panel-id'))
       .sort();
     expect(ids).toEqual([
       'agc', 'antenna', 'band', 'cw', 'cw',
-      'desktop-agc', 'desktop-cw', 'desktop-dsp', 'desktop-language', 'desktop-rf',
+      'desktop-agc', 'desktop-cw', 'desktop-dsp', 'desktop-language',
       'desktop-rit', 'desktop-vfo-ops', 'desktop-workspace',
-      'dsp', 'dsp', 'filter', 'memory', 'memory', 'mode', 'rf-front-end',
+      'dsp', 'dsp', 'memory', 'memory',
       'rit-xit', 'rx-audio', 'rx-audio', 'scan',
     ]);
   });
@@ -731,6 +745,55 @@ describe('the legacy-twin suppression channel (MOR-1364, S6-pre)', () => {
   // semantic DECK (MOR-1313) and must stay a separate prop.
   it.each(ZONES.map(([s]) => s))('leaves exactly one key authority with the %s zone declared', (surface) => {
     expect(renderAll(ZONE_PROBE[surface]).querySelectorAll(KEY_AUTHORITIES).length).toBe(1);
+  });
+
+  /**
+   * MOR-1366 (S7) — `filter` and `rfFrontEnd` join the matrix for real.
+   *
+   * Same shape as MOR-1341's meters test above: proven with caps that
+   * actually make the evidence gate fire, not the bare `capsFor()` default
+   * (`modes: [], filters: []`, no rf-front-end capability tag), which would
+   * pass these assertions vacuously (both the legacy twin and the semantic
+   * surface self-gate away) and prove nothing about suppression. This is
+   * also the closing evidence for §0.1 of the rework tail: BEFORE this slice,
+   * `desktop-v2` double-presented both families (bare deck render +
+   * legacy twin); the surface's `data-testid` count pins "exactly ONE".
+   */
+  it('drops the legacy MODE/FILTER twins in favour of the semantic filter surface', () => {
+    h.caps = { ...capsFor('2/main_sub'), modes: ['USB', 'CW', 'FM'], filters: [1, 2, 3] };
+    const t = renderAll('desktop-v2');
+    expect(t.querySelector('.left-sidebar [data-panel-id="mode"]')).toBeNull();
+    expect(t.querySelector('.left-sidebar [data-panel-id="filter"]')).toBeNull();
+    expect(t.querySelectorAll('[data-testid="filter-surface"]').length).toBe(1);
+  });
+
+  it('drops the legacy RF FRONT END twins (sidebar + modal) in favour of the semantic rfFrontEnd surface', () => {
+    h.caps = {
+      ...capsFor('2/main_sub'),
+      capabilities: [...capsFor('2/main_sub').capabilities, 'preamp'],
+    };
+    const t = renderAll('desktop-v2');
+    expect(t.querySelector('.left-sidebar [data-panel-id="rf-front-end"]')).toBeNull();
+    expect(t.querySelector('[data-panel-id="desktop-rf"]')).toBeNull();
+    expect(t.querySelectorAll('[data-testid="rf-front-end-surface"]').length).toBe(1);
+  });
+
+  // DOUBLE-PRESENTATION CLOSED, stated over BOTH families in caps that make
+  // BOTH evidence gates fire at once — the shape most likely to reveal a
+  // suppression that only covers one of the two zones this slice declares.
+  it('presents filter and rfFrontEnd controls exactly ONCE each on desktop-v2', () => {
+    h.caps = {
+      ...capsFor('2/main_sub'),
+      modes: ['USB', 'CW', 'FM'], filters: [1, 2, 3],
+      capabilities: [...capsFor('2/main_sub').capabilities, 'preamp'],
+    };
+    const t = renderAll('desktop-v2');
+    expect(t.querySelectorAll('[data-testid="filter-surface"]').length).toBe(1);
+    expect(t.querySelectorAll('[data-testid="rf-front-end-surface"]').length).toBe(1);
+    expect(t.querySelectorAll('.left-sidebar [data-panel-id="mode"]').length).toBe(0);
+    expect(t.querySelectorAll('.left-sidebar [data-panel-id="filter"]').length).toBe(0);
+    expect(t.querySelectorAll('.left-sidebar [data-panel-id="rf-front-end"]').length).toBe(0);
+    expect(t.querySelectorAll('[data-panel-id="desktop-rf"]').length).toBe(0);
   });
 
   /**

--- a/frontend/src/components-v2/wiring/__tests__/semantic-rf-front-end-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rf-front-end-wiring.component.test.ts
@@ -169,6 +169,14 @@ vi.mock('../command-bus', () => ({
 }));
 
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';
+// MOR-1366 (S7), N1 fold (verify-MOR-1365 ruling item 3): the REAL manifest +
+// the REAL resolution seam, mirroring `semantic-scope-display-wiring
+// .component.test.ts`'s S6a context-injection recipe — the only way to prove
+// the `rf-front-end` zone binding, since `useSurfacePlan()` falls back to
+// `NO_PLAN` on a standalone mount.
+import { desktopV2Layout } from '../../../presentation/layouts/declarations';
+import { readWorkspace } from '../../../presentation/workspace/contract';
+import { resolveSurfacePlan, SURFACE_PLAN_CONTEXT_KEY, type SurfacePlan } from '../../../presentation/workspace/resolution';
 
 const IDLE: Snapshot = {
   phase: 'idle', intent: null, guard: null, radioTx: 'off', txRisk: 'none',
@@ -218,10 +226,13 @@ const liveCaps = (withRfFrontEnd: boolean): Capabilities => ({
 let target: HTMLDivElement;
 let component: ReturnType<typeof mount> | null = null;
 
-function render(props: { strips?: 'single' | 'dual' } = {}): void {
+function render(props: { strips?: 'single' | 'dual' } = {}, plan?: SurfacePlan): void {
   target = document.createElement('div');
   document.body.appendChild(target);
-  component = mount(SemanticRadioSurfaces, { target, props });
+  const context = plan === undefined
+    ? undefined
+    : new Map<unknown, unknown>([[SURFACE_PLAN_CONTEXT_KEY, () => plan]]);
+  component = mount(SemanticRadioSurfaces, { target, props, context });
   flushSync();
 }
 
@@ -353,5 +364,15 @@ describe('the surface mounts only when the view model carries the group', () => 
     (h.state as unknown as { ptt: boolean }).ptt = true;
     flushSync();
     expect(el('surface')!.outerHTML).toBe(before);
+  });
+});
+
+/* ── MOR-1366 (S7), N1 fold — desktop-v2's REAL rf-front-end zone binds ─── */
+
+describe('desktop-v2 declares a REAL rf-front-end zone (MOR-1366, S7)', () => {
+  it('binds the rf-front-end zone id against desktop-v2\'s real plan', () => {
+    const plan = resolveSurfacePlan(desktopV2Layout, readWorkspace({ version: 1 }).workspace);
+    render({ strips: 'single' }, plan);
+    expect(el('surface')!.closest('[data-zone-id="rf-front-end"]')).not.toBeNull();
   });
 });

--- a/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
@@ -744,6 +744,19 @@ describe('MOR-1304 fix round — filter never mounts bare in the dual compositio
 
     expect(q('[data-testid="filter-surface"]')).not.toBeNull();
   });
+
+  // MOR-1366 (S7), N1 fold (verify-MOR-1365 ruling item 3): desktop-v2 now
+  // declares a REAL `filter` zone — mirrors the S6a context-injection recipe
+  // (`semantic-scope-display-wiring.component.test.ts`) and this file's own
+  // `meters` binding pin below.
+  it('binds the filter zone id against desktop-v2\'s real plan', () => {
+    h.state = liveState(false);
+    h.caps = withFilterCaps(liveCaps(false));
+    const plan = resolveSurfacePlan(desktopV2Layout, readWorkspace({ version: 1 }).workspace);
+    render({ strips: 'single' }, plan);
+
+    expect(q('[data-testid="filter-surface"]')!.closest('[data-zone-id="filter"]')).not.toBeNull();
+  });
 });
 
 // ── MOR-1341 (S5) — desktop-v2's OWN real `meters` zone actually binds ──────

--- a/frontend/src/presentation/layouts/__tests__/desktop-v2-registration.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/desktop-v2-registration.test.ts
@@ -55,7 +55,8 @@ describe('the desktop-v2 entrypoint is registered in the real registry', () => {
 describe('declared zones now drive the DOM (MOR-1263 step 2, MOR-1313)', () => {
   // Kills: declaring a surface this manifest does not name, or dropping
   // either one — the pair per-zone suppression consumes.
-  it('declares receiver-deck:[vfo], rx-tx:[rxTx], tx-aux:[txAux], meters:[meters] and scope-display:[scopeDisplay]', () => {
+  it('declares receiver-deck:[vfo], rx-tx:[rxTx], tx-aux:[txAux], meters:[meters], '
+    + 'scope-display:[scopeDisplay], filter:[filter] and rf-front-end:[rfFrontEnd]', () => {
     expect(desktopV2Layout.zones).toEqual([
       { id: 'receiver-deck', surfaces: ['vfo'] },
       { id: 'rx-tx', surfaces: ['rxTx'] },
@@ -66,6 +67,10 @@ describe('declared zones now drive the DOM (MOR-1263 step 2, MOR-1313)', () => {
       // MOR-1365 (S6a): scopeDisplay became zone-owned too, retiring the
       // status bar's legacy scope indicator.
       { id: 'scope-display', surfaces: ['scopeDisplay'] },
+      // MOR-1366 (S7): filter and rfFrontEnd became zone-owned, closing the
+      // double-presentation defect on desktop-v2. Neither required.
+      { id: 'filter', surfaces: ['filter'] },
+      { id: 'rf-front-end', surfaces: ['rfFrontEnd'] },
     ]);
     expect([...desktopV2Layout.requiredSemanticSurfaces].sort()).toEqual(['rxTx', 'vfo']);
   });
@@ -87,7 +92,7 @@ describe('declared zones now drive the DOM (MOR-1263 step 2, MOR-1313)', () => {
   // is per-zone rather than per-manifest-first-zone.
   it('its zones flatten to the surfaces the shell suppresses legacy twins for', () => {
     expect([...declaredSurfaces(getLayout('desktop-v2'))].sort())
-      .toEqual(['meters', 'rxTx', 'scopeDisplay', 'txAux', 'vfo']);
+      .toEqual(['filter', 'meters', 'rfFrontEnd', 'rxTx', 'scopeDisplay', 'txAux', 'vfo']);
   });
 });
 

--- a/frontend/src/presentation/layouts/__tests__/filter-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/filter-declarability.test.ts
@@ -1,14 +1,15 @@
 /**
- * MOR-1304 — `filter` is DECLARABLE, and nothing declares it yet.
+ * MOR-1304 — `filter` is DECLARABLE. MOR-1366 (S7) declares it for real.
  *
- * Slice 4B adds the name to `SEMANTIC_SURFACE_NAMES` so a manifest CAN mount
- * the surface later; it deliberately does not touch any manifest, and it does
- * not add a renderer slot. The three pins mirror `meters-declarability.test.ts`
- * / `tx-aux-declarability.test.ts` / `rx-audio-declarability.test.ts`:
- *   - drop the name and a future manifest's zone stops validating;
- *   - quietly add a `filter` zone to a shipped manifest and the DOM grows a
- *     zone id no layout review ever saw;
- *   - the renderer slot stays exactly the set MOR-1072 froze.
+ * Slice 4B added the name to `SEMANTIC_SURFACE_NAMES` so a manifest CAN mount
+ * the surface later; it deliberately did not touch any manifest, and it added
+ * no renderer slot. MOR-1366 flips the second half, on `desktop-v2` ONLY,
+ * closing the double-presentation defect the rework tail found live on that
+ * skin (FilterSurface already mounted bare in the receiver deck via the
+ * MOR-1304 `zoned(...)` single-composition mount, while `ModePanel`/
+ * `FilterPanel` kept rendering a legacy twin). The inventory below is a
+ * LITERAL of who declares it, mirroring `meters-declarability.test.ts` /
+ * `tx-aux-declarability.test.ts`'s post-rework shape.
  */
 import { describe, it, expect } from 'vitest';
 import { SEMANTIC_SURFACE_NAMES, validateLayoutManifest } from '../contract';
@@ -46,16 +47,41 @@ describe('filter is a declarable semantic surface', () => {
   });
 });
 
-describe('no shipped manifest declares a filter zone in this slice', () => {
-  // Kills: slipping a filter zone into an existing layout here. Declarability
-  // is the whole scope of the contract touch; placing the surface in a real
-  // layout is a later, separately reviewed slice.
-  it.each([
+describe('exactly the reviewed manifests declare a filter zone (MOR-1366)', () => {
+  /** The literal — extend by hand, with a layout review, never silently. */
+  const DECLARES_FILTER = ['desktop-v2'];
+
+  const ALL = [
     ['sdr-test', sdrTestLayout], ['dual-receiver-cockpit', dualReceiverCockpitLayout],
     ['lcd-cockpit', lcdCockpitLayout], ['lcd-scope', lcdScopeLayout],
     ['mobile', mobileLayout], ['desktop-v2', desktopV2Layout],
-  ])('%s declares no filter zone and does not require the surface', (_id, manifest) => {
-    for (const zone of manifest.zones) expect(zone.surfaces).not.toContain('filter');
+  ] as const;
+
+  // Kills BOTH directions: a family losing the zone S7 gave it, and a family
+  // gaining one without review.
+  it('the declaring set is exactly the reviewed literal', () => {
+    const declaring = ALL
+      .filter(([, m]) => m.zones.some((z) => z.surfaces.includes('filter')))
+      .map(([id]) => id)
+      .sort();
+    expect(declaring).toEqual([...DECLARES_FILTER].sort());
+  });
+
+  // Kills: declaring the zone under a drifted id — the wiring binds whatever
+  // the plan's key is, so the id IS the contract with the layout's arrangement.
+  it.each(DECLARES_FILTER)('%s declares it under the stable `filter` id, alone in its zone', (id) => {
+    const manifest = ALL.find(([name]) => name === id)![1];
+    const zone = manifest.zones.find((z) => z.surfaces.includes('filter'))!;
+    expect(zone.id).toBe('filter');
+    expect(zone.surfaces).toEqual(['filter']);
+  });
+
+  // Kills: making filter REQUIRED. A radio whose evidence gate declines both
+  // groups (`caps.modes`/`caps.filters` empty) must still resolve this
+  // layout; the surface self-gates on `view.modeFilter`/`view.filterPassband`,
+  // and a required surface no zone could fill would be a resolution failure
+  // rather than an honest absence.
+  it.each(ALL)('%s does not require the filter surface', (_id, manifest) => {
     expect(manifest.requiredSemanticSurfaces).not.toContain('filter');
   });
 });

--- a/frontend/src/presentation/layouts/__tests__/rf-front-end-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/rf-front-end-declarability.test.ts
@@ -1,17 +1,19 @@
 /**
- * MOR-1306 — `rfFrontEnd` is DECLARABLE, and nothing declares it yet.
+ * MOR-1306 — `rfFrontEnd` is DECLARABLE. MOR-1366 (S7) declares it for real.
  *
- * Slice 6B adds the name to `SEMANTIC_SURFACE_NAMES` so a manifest CAN mount
- * the surface later; it deliberately does not touch any manifest, and it adds
- * no design-language renderer slot (that set was frozen by MOR-1072 — adding
- * one would be a language-contract change this slice must not make).
- *
- * Same three pins as `tx-aux-declarability.test.ts` / `meters-declarability.test.ts`
- * / `rx-audio-declarability.test.ts`:
- *   - drop the name and a future manifest's zone stops validating;
- *   - quietly add an `rfFrontEnd` zone to a shipped manifest and the DOM
- *     grows a zone id no layout review ever saw;
- *   - the renderer slot set stays exactly what MOR-1072 froze.
+ * Slice 6B added the name to `SEMANTIC_SURFACE_NAMES` so a manifest CAN mount
+ * the surface later; it deliberately did not touch any manifest, and it added
+ * no design-language renderer slot (that set was frozen by MOR-1072). MOR-1366
+ * flips the second half, on `desktop-v2` ONLY: closing the double-presentation
+ * defect the rework tail found live on that skin (`RfFrontEndSurface` already
+ * mounted bare in the receiver deck via the MOR-1306 `zoned(...)`
+ * single-composition mount, while `RfFrontEnd` kept rendering a legacy twin in
+ * `LeftSidebar` and the settings modal). The cockpit is deliberately
+ * untouched (S5 precedent) — the MOR-1069 mount canon in `RfFrontEndSurface`
+ * still forbids a dual-composition mount with no cockpit zone declared. The
+ * inventory below is a LITERAL of who declares it, mirroring
+ * `meters-declarability.test.ts` / `tx-aux-declarability.test.ts`'s
+ * post-rework shape.
  */
 import { describe, it, expect } from 'vitest';
 import { SEMANTIC_SURFACE_NAMES, validateLayoutManifest } from '../contract';
@@ -51,18 +53,43 @@ describe('rfFrontEnd is a declarable semantic surface', () => {
   });
 });
 
-describe('no shipped manifest declares an rfFrontEnd zone in this slice', () => {
-  // Kills: slipping an rfFrontEnd zone into an existing layout here.
-  // Declarability is the whole scope of the contract touch; placing the
-  // surface in a real layout (including the dual-receiver-cockpit — see the
-  // MOR-1069 mount canon in `RfFrontEndSurface.svelte`) is a later, separately
-  // reviewed rework slice.
-  it.each([
+describe('exactly the reviewed manifests declare an rfFrontEnd zone (MOR-1366)', () => {
+  /** The literal — extend by hand, with a layout review, never silently. */
+  const DECLARES_RF_FRONT_END = ['desktop-v2'];
+
+  const ALL = [
     ['sdr-test', sdrTestLayout], ['dual-receiver-cockpit', dualReceiverCockpitLayout],
     ['lcd-cockpit', lcdCockpitLayout], ['lcd-scope', lcdScopeLayout],
     ['mobile', mobileLayout], ['desktop-v2', desktopV2Layout],
-  ])('%s declares no rfFrontEnd zone and does not require the surface', (_id, manifest) => {
-    for (const zone of manifest.zones) expect(zone.surfaces).not.toContain('rfFrontEnd');
+  ] as const;
+
+  // Kills BOTH directions: a family losing the zone S7 gave it, and a family
+  // gaining one without review — including the dual-receiver-cockpit, which
+  // the mounting canon (MOR-1304) forbids from mounting a control-bearing
+  // surface bare and this slice deliberately leaves undeclared.
+  it('the declaring set is exactly the reviewed literal', () => {
+    const declaring = ALL
+      .filter(([, m]) => m.zones.some((z) => z.surfaces.includes('rfFrontEnd')))
+      .map(([id]) => id)
+      .sort();
+    expect(declaring).toEqual([...DECLARES_RF_FRONT_END].sort());
+  });
+
+  // Kills: declaring the zone under a drifted id — the wiring binds whatever
+  // the plan's key is, so the id IS the contract with the layout's arrangement.
+  it.each(DECLARES_RF_FRONT_END)('%s declares it under the stable `rf-front-end` id, alone in its zone', (id) => {
+    const manifest = ALL.find(([name]) => name === id)![1];
+    const zone = manifest.zones.find((z) => z.surfaces.includes('rfFrontEnd'))!;
+    expect(zone.id).toBe('rf-front-end');
+    expect(zone.surfaces).toEqual(['rfFrontEnd']);
+  });
+
+  // Kills: making rfFrontEnd REQUIRED. A radio whose evidence gate declines
+  // every group (no preamp/attenuator/rf_gain/squelch/digisel/ip_plus
+  // capability) must still resolve this layout; the surface self-gates on
+  // `view.rfFrontEnd`, and a required surface no zone could fill would be a
+  // resolution failure rather than an honest absence.
+  it.each(ALL)('%s does not require the rfFrontEnd surface', (_id, manifest) => {
     expect(manifest.requiredSemanticSurfaces).not.toContain('rfFrontEnd');
   });
 });

--- a/frontend/src/presentation/layouts/desktop-declarations.ts
+++ b/frontend/src/presentation/layouts/desktop-declarations.ts
@@ -55,6 +55,21 @@ const DESKTOP_V2_ZONES = [
   // The dual-receiver cockpit manifest is deliberately untouched;
   // `scopeDisplay` keeps mounting bare there (12B's own shape).
   { id: 'scope-display', surfaces: ['scopeDisplay'] },
+  // MOR-1366 (S7): filter and rfFrontEnd become zone-OWNED here, closing the
+  // double-presentation defect §0.1 of the rework tail found live on
+  // `desktop-v2` (FilterSurface/RfFrontEndSurface already mounted bare in the
+  // receiver deck via MOR-1304/MOR-1306's `zoned(...)` single-composition
+  // mounts, while `LeftSidebar`'s ModePanel/FilterPanel/RfFrontEnd and the
+  // settings modal's RF FRONT END section kept rendering a legacy third
+  // copy). The MOR-1364 (S6-pre) suppression channel already carries the
+  // `!declared.has('filter')` / `!declared.has('rfFrontEnd')` predicates on
+  // those hosts as no-ops; declaring the zones here is what activates them.
+  // Not `required` on either — a radio whose evidence gate declines both
+  // groups (`caps.modes`/`caps.filters` empty, or none of
+  // preamp/attenuator/rf_gain/squelch/digisel/ip_plus) must still resolve
+  // this layout, and each surface self-gates on its own view-model group.
+  { id: 'filter', surfaces: ['filter'] },
+  { id: 'rf-front-end', surfaces: ['rfFrontEnd'] },
 ] as const;
 
 export const desktopV2Layout: LayoutManifest = {

--- a/frontend/src/presentation/workspace/__tests__/preferences-adoption.test.ts
+++ b/frontend/src/presentation/workspace/__tests__/preferences-adoption.test.ts
@@ -263,10 +263,11 @@ describe('MOR-1082 — the single-composition order comes from the same plan', (
   it('flattens the plan in zone-declaration order, deduped', () => {
     expect(compositionSurfaces(plan(sdrTestLayout), FALLBACK)).toEqual(['vfo', 'rxTx']);
     // desktop-v2 spreads the same two surfaces over two zones, plus its own
-    // MOR-1336 (S4) tx-aux zone, MOR-1341 (S5) meters zone and MOR-1365 (S6a)
-    // scope-display zone — flattening never drops a fifth zone.
+    // MOR-1336 (S4) tx-aux zone, MOR-1341 (S5) meters zone, MOR-1365 (S6a)
+    // scope-display zone, and MOR-1366 (S7) filter/rf-front-end zones —
+    // flattening never drops a later zone.
     expect(compositionSurfaces(plan(desktopV2Layout), FALLBACK))
-      .toEqual(['vfo', 'rxTx', 'txAux', 'meters', 'scopeDisplay']);
+      .toEqual(['vfo', 'rxTx', 'txAux', 'meters', 'scopeDisplay', 'filter', 'rfFrontEnd']);
     expect(compositionSurfaces(plan(sdrTestLayout, { zoneOrder: { main: ['rxTx', 'vfo'] } }), FALLBACK))
       .toEqual(['rxTx', 'vfo']);
   });

--- a/frontend/src/presentation/workspace/contract.ts
+++ b/frontend/src/presentation/workspace/contract.ts
@@ -49,7 +49,7 @@ export const WORKSPACE_THEME_IDS = [
 export type WorkspaceThemeId = (typeof WORKSPACE_THEME_IDS)[number];
 
 /** Every zone id declared by a registered layout manifest (decisions 5 and 6). */
-export const WORKSPACE_ZONE_IDS = ['main', 'receiver-deck', 'rx-tx', 'primary-vfo', 'secondary-vfo', 'global', 'portrait-deck', 'control-column', 'tx-aux', 'meters', 'scope-display'] as const;
+export const WORKSPACE_ZONE_IDS = ['main', 'receiver-deck', 'rx-tx', 'primary-vfo', 'secondary-vfo', 'global', 'portrait-deck', 'control-column', 'tx-aux', 'meters', 'scope-display', 'filter', 'rf-front-end'] as const;
 export type WorkspaceZoneId = (typeof WORKSPACE_ZONE_IDS)[number];
 
 /** Decision 7: command-bus intent names (`set_compressor`), never module paths. */


### PR DESCRIPTION
## Summary

S7 (MOR-1263 tail, DEFECT-CLOSING): the filter and rf-front-end zones declared in the desktop-v2 manifest. The S6-pre channel retires the sidebar/modal legacy twins, and the surfaces' existing zoned() mounts resolve to REAL zones - closing the live double-presentation defect (bare deck render + legacy twin) for both families. Zone ownership asserted directly (the S6a context-injection recipe, per the anchor's N1 ruling).

Production LOC 2 (verifier-measured, frozen formula; contract.ts single-line append nets 0 per the MOR-1304 F4 precedent - blind-spot recorded for the wave).

## Review provenance

Verified by the rework-domain opus anchor #3 (session 8): PASS, no required fixes. Zone ownership proved at plan level by the anchor's own probe - including the pre-S7 stored-workspace migration case (absent workspace entry keeps the declared set; a different branch would have shipped blank zones to every existing operator). Exactly-ONCE double-presentation pins; non-vacuous suppression tests (caps overridden so evidence gates fire - the MOR-1304 vacuity trap deliberately avoided); B-slice dual-absence pins untouched and green; MOR-1069 unmoved correctly (desktop-v2 is the single composition). Harness zero-movement ruled 'acceptable as disclosure, not as evidence' - the browser harness is structurally blind to desktop-v2 (recorded for S12: four zeroes are not four confirmations). Post-S6a collision rebase per the anchor's 5-file map with post-merge mutant re-runs: M1 10 RED (the new N1 ownership assertion itself load-bearing), M3 3 RED. Suite 5881/5881.

🤖 Generated with [Claude Code](https://claude.com/claude-code)