### PR TITLE
feat(MOR-1367): band + antenna + ritXitScan zone ownership on desktop-v2 (rework S8)

### DIFF
--- a/docs/plans/2026-08-06-settings-modal-boundary.md
+++ b/docs/plans/2026-08-06-settings-modal-boundary.md
@@ -110,7 +110,7 @@ render on those skins with §3's predicates evaluated against **their** manifest
 | 7 | `desktop-vfo-ops` → `SPLIT`/`A↔B`/`A=B` row | `VfoSurface`'s own split-toggle/swap/equalize controls (`data-vfo-split`/`data-vfo-swap`/`data-vfo-equalize`, `VfoSurface.svelte`) | **(a)** | `receiver-deck` zone — **already landed** (MOR-1313, v3-rework S1/S2) | `semanticDeck` (existing `RadioLayout.svelte:90` derived value) — **see §4, non-inert exception** |
 | 8 | `desktop-language` (`LanguageSelector`) | — no sidebar twin, no semantic surface | **(b)** | n/a | n/a — never suppressed |
 | 9 | `desktop-workspace` (`WorkspaceSettingsPanel` + `WorkspaceImportExport`) | — no sidebar twin, no semantic surface | **(b)** | n/a | n/a — never suppressed |
-| 10 | `desktop-vfo-ops` → `BandSelector` **LW/MW tab + SWL tab** (17 curated presets, `broadcast-presets.ts`) | — no semantic surface; **deliberately** excluded (`semantic/radio-view-model.ts:494-496`, verbatim: *"UI convenience, not radio facts, … deliberately absent"*) | **(b)** | n/a | n/a — never suppressed, on any manifest; see §4a for the coordinator ruling |
+| 10 | `desktop-vfo-ops` → `BandSelector` **LW/MW tab + SWL tab** (16 curated presets, `broadcast-presets.ts`) | — no semantic surface; **deliberately** excluded (`semantic/radio-view-model.ts:494-496`, verbatim: *"UI convenience, not radio facts, … deliberately absent"*) | **(b)** | n/a | n/a — never suppressed, on any manifest; see §4a for the coordinator ruling |
 
 Every semantic-surface copy the modal hosts appears in exactly one row. No row is category (c): every
 duplicative control in this modal already has either a landed zone (#7) or a zone a named slice is
@@ -143,7 +143,7 @@ possible. Category (b) is exact, not a default.
 iterates `flattenBands(caps.freqRanges)`, the same source `deriveBand`
 (`lib/runtime/adapters/radio-view-model-adapter.ts:668-692`) uses to build `BandSurface`'s
 `band-choices`. The `LW/MW` and `SWL` branches iterate `BROADCAST_LW_MW_BANDS`/`BROADCAST_SW_BANDS`
-from `components-v2/controls/broadcast-presets.ts` — 17 curated presets, each firing
+from `components-v2/controls/broadcast-presets.ts` — 16 curated presets, each firing
 `presetH.onPresetSelect(preset.freq, preset.mode)` (a frequency+mode intent, not a band selection).
 
 The vocabulary comment for `bandChoices` states the exclusion directly
@@ -223,7 +223,7 @@ silently into the "nothing renders differently" inertness claim.** Concretely:
 §3 row 6 originally ruled `BandSelector` as a whole (a): duplicated by `BandSurface`, retiring with
 the `band` zone. That is wrong for two of the component's three tabs — see §3's Row 10 detail. The
 vocabulary (`semantic/radio-view-model.ts:494-496`) *deliberately* excludes the LW/MW and SWL
-broadcast-preset tabs (17 presets, `broadcast-presets.ts`) from `bandChoices`; ruling row 6 as (a) for
+broadcast-preset tabs (16 presets, `broadcast-presets.ts`) from `bandChoices`; ruling row 6 as (a) for
 the whole component would have suppressed those tabs the moment `declared.has('band')` went true on
 `desktop-v2`, and — since `BandSelector.svelte` is the **only** production consumer of
 `BROADCAST_LW_MW_BANDS`/`BROADCAST_SW_BANDS`/`onPresetSelect` — deleted an operator affordance no
@@ -232,7 +232,7 @@ semantic surface replaces, with no remaining host anywhere in `desktop-v2`.
 **Coordinator ruling (recorded here, not left open): option (A) — split the component.**
 `BandSelector` gains a `hamBands?: boolean` prop (default `true`). The suppression predicate for row 6
 becomes *pass `hamBands={!declared.has('band')}`* rather than *omit the component*: the `HAM` tab and
-grid disappear when the `band` zone is declared, the `LW/MW`/`SWL` tabs and their 17 presets survive
+grid disappear when the `band` zone is declared, the `LW/MW`/`SWL` tabs and their 16 presets survive
 unconditionally. This is the only one of the three options considered (§3 Row 10 detail; the
 alternatives were retain-whole, which reopens double-presentation, and accept-the-loss, which deletes
 the affordance) with **zero** operator loss.

--- a/frontend/src/components-v2/controls/BandSelector.svelte
+++ b/frontend/src/components-v2/controls/BandSelector.svelte
@@ -7,6 +7,28 @@
 
   import { deriveBandSelectorProps, getBandHandlers, getPresetHandlers } from '$lib/runtime/adapters/panel-adapters';
 
+  /**
+   * MOR-1367 (v3-rework S8) — the HAM/broadcast split, ruled by
+   * `docs/plans/2026-08-06-settings-modal-boundary.md` §4a (row 6 vs row 10).
+   *
+   * This component is TWO independently-ruled things under one roof. The HAM
+   * tab and its grid iterate `flattenBands(caps.freqRanges)` — the same source
+   * `deriveBand` uses for `BandSurface`'s `band-choices` — so they are a plain
+   * duplicate that retires under `band` zone ownership. The LW/MW and SWL tabs
+   * iterate the sixteen curated `broadcast-presets.ts` entries (6 LW/MW + 10
+   * SW; the S10 doc's "17" counted the interface's own `name:` field), which the
+   * vocabulary excludes BY NAME (`semantic/radio-view-model.ts:494-496`: "UI convenience,
+   * not radio facts, … deliberately absent") and which this component is the
+   * only production consumer of. Suppressing the whole component would delete
+   * that affordance with no remaining host.
+   *
+   * Hence a prop, not a mount gate: hosts pass `hamBands={!declared.has('band')}`
+   * and keep mounting the component unconditionally. `true` by default, so
+   * every caller that does not know about the split (LCD, mobile, tests)
+   * renders exactly the pre-split three-tab component.
+   */
+  let { hamBands = true }: { hamBands?: boolean } = $props();
+
   const bandH = getBandHandlers();
   const presetH = getPresetHandlers();
   let bp = $derived(deriveBandSelectorProps());
@@ -17,6 +39,13 @@
   const onFreqPreset = presetH.onFreqPreset;
 
   let bandMode = $state<'ham' | 'broadcast' | 'lwmw'>('ham');
+
+  // S10 §4a explicitly gates the DEFAULT too, not just the tab: with the HAM
+  // tab gone there would be no control able to leave a `'ham'` selection, so
+  // the component would open on an empty grid and stay there. Derived rather
+  // than baked into `$state`'s initialiser so the fallback also holds if a host
+  // flips the prop after mount.
+  let shownMode = $derived(!hamBands && bandMode === 'ham' ? 'lwmw' : bandMode);
 
   let bands = $derived(flattenBands(getCapabilities()?.freqRanges ?? []));
   let activeBand = $derived(findActiveBand(currentFreq, getCapabilities()?.freqRanges ?? []));
@@ -36,24 +65,26 @@
 </script>
 
 <div class="band-tabs">
+  {#if hamBands}
+    <button
+      class="band-tab"
+      class:active={shownMode === 'ham'}
+      onclick={(e: MouseEvent) => { bandMode = 'ham'; (e.currentTarget as HTMLElement)?.blur(); }}
+    >HAM</button>
+  {/if}
   <button
     class="band-tab"
-    class:active={bandMode === 'ham'}
-    onclick={(e: MouseEvent) => { bandMode = 'ham'; (e.currentTarget as HTMLElement)?.blur(); }}
-  >HAM</button>
-  <button
-    class="band-tab"
-    class:active={bandMode === 'lwmw'}
+    class:active={shownMode === 'lwmw'}
     onclick={(e: MouseEvent) => { bandMode = 'lwmw'; (e.currentTarget as HTMLElement)?.blur(); }}
   >LW/MW</button>
   <button
     class="band-tab"
-    class:active={bandMode === 'broadcast'}
+    class:active={shownMode === 'broadcast'}
     onclick={(e: MouseEvent) => { bandMode = 'broadcast'; (e.currentTarget as HTMLElement)?.blur(); }}
   >SWL</button>
 </div>
 
-{#if bandMode === 'ham'}
+{#if shownMode === 'ham'}
   <div class="grid">
     {#each bands as band (band.name)}
       {@const isActive = activeBand === band.name}
@@ -69,7 +100,7 @@
       </HardwareButton>
     {/each}
   </div>
-{:else if bandMode === 'lwmw'}
+{:else if shownMode === 'lwmw'}
   <div class="grid">
     {#each BROADCAST_LW_MW_BANDS as preset (preset.name)}
       {@const isActive = activeBroadcast === preset.name}

--- a/frontend/src/components-v2/controls/__tests__/BandSelector.isolated.test.ts
+++ b/frontend/src/components-v2/controls/__tests__/BandSelector.isolated.test.ts
@@ -57,11 +57,11 @@ import BandSelector from '../BandSelector.svelte';
 
 let components: ReturnType<typeof mount>[] = [];
 
-function mountPanel(overrides?: Partial<typeof mockProps>) {
+function mountPanel(overrides?: Partial<typeof mockProps>, props?: { hamBands?: boolean }) {
   if (overrides) Object.assign(mockProps, overrides);
   const target = document.createElement('div');
   document.body.appendChild(target);
-  const component = mount(BandSelector, { target });
+  const component = mount(BandSelector, { target, props: props ?? {} });
   flushSync();
   components.push(component);
   return target;
@@ -225,5 +225,78 @@ describe('BandSelector component', () => {
     flushSync();
 
     expect(mockBandHandlers.onBandSelect).toHaveBeenCalledWith('20m', 14_225_000, 5);
+  });
+});
+
+/**
+ * MOR-1367 (v3-rework S8) — the HAM/broadcast split, at the component level.
+ *
+ * `docs/plans/2026-08-06-settings-modal-boundary.md` §4a: this component is two
+ * independently-ruled halves. The HAM tab and grid duplicate `BandSurface` and
+ * retire under `band` zone ownership; the LW/MW + SWL broadcast presets are
+ * excluded from the vocabulary BY NAME (`semantic/radio-view-model.ts:494-496`)
+ * and this component is their only production consumer, so they are permanent
+ * on every manifest. Hence a prop, and hosts that never unmount the component.
+ *
+ * The composed-tree half of this contract (both hosts, the real desktop-v2
+ * manifest) lives in
+ * `components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts`.
+ */
+describe('BandSelector HAM/broadcast split (hamBands prop)', () => {
+  const tabs = (t: HTMLElement) =>
+    [...t.querySelectorAll('.band-tab')].map((el) => el.textContent?.trim());
+  const grid = (t: HTMLElement) =>
+    [...t.querySelectorAll('.grid button')].map((el) => el.textContent?.trim());
+
+  // Kills: making the prop default to `false`, or removing the default. Every
+  // caller that predates the split (mobile, LCD, ControlButtonDemo) passes
+  // nothing and must keep the pre-split three-tab component.
+  it('defaults to the full three-tab component when the prop is omitted', () => {
+    const t = mountPanel();
+    expect(tabs(t)).toEqual(['HAM', 'LW/MW', 'SWL']);
+    expect(grid(t)).toEqual(['160m', '80m', '40m', '20m', '15m', '10m', '6m']);
+  });
+
+  // Kills: gating only the grid and leaving a dead HAM tab, or vice versa.
+  it('drops the HAM tab AND the HAM grid when hamBands is false', () => {
+    const t = mountPanel(undefined, { hamBands: false });
+    expect(tabs(t)).toEqual(['LW/MW', 'SWL']);
+    expect(grid(t)).not.toContain('20m');
+  });
+
+  // Kills: gating the tab/grid but leaving `bandMode`'s `'ham'` initial value
+  // (S10 §4a explicitly requires the DEFAULT to be gated too). Without this the
+  // suppressed component opens on an empty grid with no control able to leave
+  // that state.
+  it('defaults bandMode to LW/MW — never to an unreachable empty HAM grid', () => {
+    const t = mountPanel(undefined, { hamBands: false });
+    expect(grid(t)).toEqual(['LW', 'MW', '120m', '90m', '75m', '60m']);
+    expect(t.querySelector('.band-tab.active')?.textContent?.trim()).toBe('LW/MW');
+  });
+
+  // Kills: taking the broadcast half with the HAM half — the operator-affordance
+  // loss §4a exists to prevent. Sixteen presets, counted: `broadcast-presets.ts`
+  // ships 6 LW/MW + 10 SW. (The S10 doc says "17"; it counted the
+  // `BroadcastPreset` interface's own `name:` field. Measured, not copied.)
+  it('keeps every broadcast preset reachable with the HAM half suppressed', () => {
+    const t = mountPanel(undefined, { hamBands: false });
+    const lwmw = grid(t);
+    (t.querySelectorAll('.band-tab')[1] as HTMLElement).click();
+    flushSync();
+    const swl = grid(t);
+    expect(lwmw).toEqual(['LW', 'MW', '120m', '90m', '75m', '60m']);
+    expect(swl).toEqual(['49m', '41m', '31m', '25m', '22m', '19m', '16m', '15m', '13m', '11m']);
+    expect(lwmw.length + swl.length).toBe(16);
+  });
+
+  // Kills: suppressing the preset intent along with the tab. The presets fire
+  // `onPresetSelect(freq, mode)` — a frequency+mode intent, NOT a band
+  // selection — and that path must survive the split untouched.
+  it('still forwards a broadcast preset intent with the HAM half suppressed', () => {
+    const t = mountPanel(undefined, { hamBands: false });
+    ([...t.querySelectorAll('.grid button')]
+      .find((el) => el.textContent?.trim() === 'MW') as HTMLElement).click();
+    flushSync();
+    expect(mockPresetHandlers.onPresetSelect).toHaveBeenCalledWith(1_000_000, 'AM');
   });
 });

--- a/frontend/src/components-v2/layout/LeftSidebar.svelte
+++ b/frontend/src/components-v2/layout/LeftSidebar.svelte
@@ -96,17 +96,19 @@
     </CollapsiblePanel>
   {/if}
 
-  <!-- MOR-1364: the BAND twin is deliberately NOT on this channel. `BandSelector`
-       hosts three tabs (HAM / LW-MW / SWL) and 17 broadcast presets; only the HAM
-       half is duplicated by `BandSurface`, and the broadcast presets are
-       deliberately NOT facts (`semantic/radio-view-model.ts:494-496`) and have no
-       other production host. Gating on `declared.has('band')` would orphan them.
-       Joins the channel in S8, after the component split (`hamBands` prop). -->
+  <!-- MOR-1367 (S8): the BAND twin joins the channel by PROP, not by mount.
+       `BandSelector` hosts three tabs (HAM / LW-MW / SWL) and 17 broadcast
+       presets; only the HAM half is duplicated by `BandSurface`, and the
+       broadcast presets are deliberately NOT facts
+       (`semantic/radio-view-model.ts:494-496`) and have no other production
+       host. So the panel keeps mounting unconditionally and the component
+       drops only its HAM half (S10 §4a) — a `{#if !declared.has('band')}` here
+       would orphan the presets. -->
   {#if drag.order.includes('band')}
     <CollapsiblePanel title="BAND" panelId="band"
       draggable={true} onDragStart={drag.handleDragStart}
       style={drag.dragStyle('band')}>
-      <BandSelector />
+      <BandSelector hamBands={!declared.has('band')} />
     </CollapsiblePanel>
   {/if}
 

--- a/frontend/src/components-v2/layout/LeftSidebar.svelte
+++ b/frontend/src/components-v2/layout/LeftSidebar.svelte
@@ -97,7 +97,7 @@
   {/if}
 
   <!-- MOR-1367 (S8): the BAND twin joins the channel by PROP, not by mount.
-       `BandSelector` hosts three tabs (HAM / LW-MW / SWL) and 17 broadcast
+       `BandSelector` hosts three tabs (HAM / LW-MW / SWL) and 16 broadcast
        presets; only the HAM half is duplicated by `BandSurface`, and the
        broadcast presets are deliberately NOT facts
        (`semantic/radio-view-model.ts:494-496`) and have no other production

--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -444,7 +444,7 @@
           {/if}
           <!-- MOR-1367 (S8) wires the BAND half, S10 §4a/§7: only the HAM tab
                is duplicated by `BandSurface`, while the LW/MW + SWL tabs and
-               their 17 broadcast presets are deliberately not facts and have no
+               their 16 broadcast presets are deliberately not facts and have no
                other production host. So the split is a PROP, never a mount
                gate. This panel is the ONE section that must never be wrapped as
                a whole: row 10 (the LW/MW + SWL tabs) is permanent, so the panel

--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -442,16 +442,16 @@
               </HardwareButton>
             </div>
           {/if}
-          <!-- The BAND half of this section stays UNGATED this slice: only the
-               HAM tab is duplicated by `BandSurface`, while the LW/MW + SWL tabs
-               and their 17 broadcast presets are deliberately not facts and have
-               no other host. It joins the channel in S8, after `BandSelector` is
-               split. This panel is the ONE section that must never be wrapped as
+          <!-- MOR-1367 (S8) wires the BAND half, S10 §4a/§7: only the HAM tab
+               is duplicated by `BandSurface`, while the LW/MW + SWL tabs and
+               their 17 broadcast presets are deliberately not facts and have no
+               other production host. So the split is a PROP, never a mount
+               gate. This panel is the ONE section that must never be wrapped as
                a whole: row 10 (the LW/MW + SWL tabs) is permanent, so the panel
-               can never be empty, and S8 retires the HAM half by passing
-               `hamBands={!declared.has('band')}` — a prop change, not a mount
-               gate (S10 §4a/§7). -->
-          <BandSelector />
+               can never be empty and an outer `{#if}` here would orphan the
+               presets — the exact operator-affordance loss §4a exists to
+               prevent. -->
+          <BandSelector hamBands={!declared.has('band')} />
         </CollapsiblePanel>
 
         {#if !declared.has('dsp')}

--- a/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
@@ -137,7 +137,7 @@ vi.mock('$lib/stores/capabilities.svelte', () => ({
 }));
 
 import RadioLayout from '../RadioLayout.svelte';
-import { hasAnyScope, hasCapability } from '$lib/stores/capabilities.svelte';
+import { getCapabilities, hasAnyScope, hasCapability } from '$lib/stores/capabilities.svelte';
 import { topologyFixtures, type TopologyFixtureId } from '../../../semantic/fixtures/topologies';
 import { registerLayout, type LayoutManifest } from '../../../presentation/layouts/contract';
 // Barrel, for the same reason `skins/dual-receiver-cockpit/__tests__/
@@ -145,6 +145,10 @@ import { registerLayout, type LayoutManifest } from '../../../presentation/layou
 // derive the probes below from. RadioLayout.svelte already pulls this module in
 // (its side-effect registry import), so this adds no registration of its own.
 import { desktopV2Layout } from '../../../presentation/layouts/declarations';
+// MOR-1367 (S8): the zone-ELEMENT assertions need the resolved plan in context
+// — see `renderWithPlan` in the S8 describe for why `render()` cannot show one.
+import { resolveSurfacePlan, SURFACE_PLAN_CONTEXT_KEY } from '../../../presentation/workspace/resolution';
+import { DEFAULT_WORKSPACE } from '../../../presentation/workspace/contract';
 
 /**
  * MOR-1313 fix round — PARTIALLY DECLARING manifests, the quadrants no shipped
@@ -579,26 +583,18 @@ describe('the legacy-twin suppression channel (MOR-1364, S6-pre)', () => {
     'antenna', 'scan', 'rx-audio', 'dsp', 'tx', 'cw', 'memory'];
   const RIGHT_ALL = ['rx-audio', 'audio-scope', 'dsp', 'tx', 'cw', 'memory'];
 
-  /**
-   * surface → the zone id its rework slice will declare on `desktop-v2`.
-   * `scopeDisplay` graduated to a REAL declaration in MOR-1365 (S6a) and left
-   * this synthetic-probe literal — a probe re-declaring `scope-display` here
-   * would collide with the real zone `desktopV2Layout.zones` already
-   * carries. Its suppression is now proved directly against the real
-   * manifest below (`the legacy-twin suppression channel retires the status
-   * bar scope indicator on the REAL desktop-v2 manifest (MOR-1365)`).
+  /** surface → the zone id its rework slice will declare on `desktop-v2`.
    *
-   * `filter` and `rfFrontEnd` graduated off this synthetic-probe list in
-   * MOR-1366 (S7): `desktopV2Layout` now declares both for real, so spreading
-   * `desktopV2Layout.zones` plus a second `{ id: 'filter', … }` /
-   * `{ id: 'rf-front-end', … }` entry here would duplicate a zone id the real
-   * manifest already owns. Their suppression is asserted directly against the
-   * REAL `desktop-v2` registration below instead of through `ZONE_PROBE`.
-   */
+   *  GRADUATIONS — surfaces whose zone `desktopV2Layout` now really declares
+   *  have LEFT this synthetic-probe literal, because a probe spreading
+   *  `...desktopV2Layout.zones` plus a second entry with the same id would
+   *  declare a duplicate zone id. Each graduate's coverage moved to a describe
+   *  asserting the REAL registration — a strictly stronger statement:
+   *    - `scopeDisplay` graduated in MOR-1365 (S6a);
+   *    - `filter`, `rfFrontEnd` graduated in MOR-1366 (S7);
+   *    - `band`, `antenna`, `ritXitScan` graduated in MOR-1367 (S8). */
   const ZONES = [
-    ['dsp', 'dsp'],
-    ['ritXitScan', 'rit-xit-scan'], ['antenna', 'antenna'], ['rxAudio', 'rx-audio'],
-    ['cwKeyer', 'cw-keyer'], ['band', 'band'],
+    ['dsp', 'dsp'], ['rxAudio', 'rx-audio'], ['cwKeyer', 'cw-keyer'],
   ] as const;
   type CoveredSurface = (typeof ZONES)[number][0];
 
@@ -630,10 +626,9 @@ describe('the legacy-twin suppression channel (MOR-1364, S6-pre)', () => {
     ['dsp', 'right sidebar DSP', '.right-sidebar [data-panel-id="dsp"]'],
     ['dsp', 'settings modal DSP', '[data-panel-id="desktop-dsp"]'],
     ['dsp', 'settings modal AGC', '[data-panel-id="desktop-agc"]'],
-    ['ritXitScan', 'left sidebar RIT / XIT', '.left-sidebar [data-panel-id="rit-xit"]'],
-    ['ritXitScan', 'left sidebar SCAN', '.left-sidebar [data-panel-id="scan"]'],
-    ['ritXitScan', 'settings modal RIT / XIT', '[data-panel-id="desktop-rit"]'],
-    ['antenna', 'left sidebar ANTENNA', '.left-sidebar [data-panel-id="antenna"]'],
+    // MOR-1367 (S8): the three `ritXitScan` rows and the `antenna` row moved to
+    // the zone-ownership describe below — those twins are GONE on desktop-v2
+    // now, so an "it renders today" row here would be false.
     ['rxAudio', 'left sidebar RX AUDIO', '.left-sidebar [data-panel-id="rx-audio"]'],
     ['rxAudio', 'right sidebar RX AUDIO', '.right-sidebar [data-panel-id="rx-audio"]'],
     ['cwKeyer', 'left sidebar CW', '.left-sidebar [data-panel-id="cw"]'],
@@ -642,12 +637,13 @@ describe('the legacy-twin suppression channel (MOR-1364, S6-pre)', () => {
   ] as const satisfies readonly (readonly [CoveredSurface, string, string])[];
 
   /**
-   * The BAND twin is deliberately NOT on the channel (S10 verifier ruling):
-   * `BandSelector` hosts the LW/MW + SWL tabs and 17 broadcast presets that
-   * are deliberately not facts and have no other production host, so gating it
-   * on `declared.has('band')` would orphan them. It joins in S8, after the
-   * component split. Pinned so that deferral is a decision someone has to
-   * revisit rather than an omission nobody notices.
+   * The BAND twin is never MOUNT-gated, on any manifest, ever (S10 rows 6/10,
+   * §4a): `BandSelector` hosts the LW/MW + SWL broadcast tabs that are
+   * deliberately not facts and have no other production host, so unmounting the
+   * component would orphan them. MOR-1367 (S8) retires the HAM half by PROP
+   * instead — the hosts below keep rendering the component either way, which is
+   * exactly what these two rows say. See the split pins in the zone-ownership
+   * describe for the HAM-vs-broadcast half of the statement.
    */
   const BAND_TWINS = [
     ['left sidebar BAND', '.left-sidebar [data-panel-id="band"]'],
@@ -686,24 +682,29 @@ describe('the legacy-twin suppression channel (MOR-1364, S6-pre)', () => {
   });
 
   // INERTNESS, half two, stated as an inventory rather than per-row: the exact
-  // set of panels desktop-v2 renders. This is the pin the N3 carry-forward
-  // warned about — it MUST go red the moment a zone-declaring slice lands,
-  // and the correct fix is deleting the retired ids, never widening the
-  // literal. MOR-1366 (S7) is the first slice to do that: `desktop-rf`
-  // (settings modal RF FRONT END), `filter`, `mode` and `rf-front-end` are
-  // gone from the panel inventory because the `filter`/`rf-front-end` zones
-  // are now REAL on `desktop-v2`, not synthetic probes — see the dedicated
-  // "drops the legacy ... twins" tests below for the non-vacuous proof.
-  it('renders exactly the panel inventory desktop-v2 renders post-S7', () => {
+  // set of panels desktop-v2 renders. S6-pre landed it as "unchanged by the
+  // channel"; every zone slice after it SHRINKS this literal by the ids its
+  // zones retire, and the shrink is the intended signal (S6-pre verify N3 — a
+  // builder who sees this go red must remove ids, never weaken the literal).
+  //
+  // MOR-1366 (S7) removed four: `desktop-rf` (settings modal RF FRONT END),
+  // `filter`, `mode` and `rf-front-end` — the `filter`/`rf-front-end` zones are
+  // now REAL on `desktop-v2`, not synthetic probes.
+  //
+  // MOR-1367 (S8) removes four more: `antenna`, `rit-xit`, `scan` (left
+  // sidebar) and `desktop-rit` (settings modal). `band` STAYS — the band zone
+  // retires only the component's HAM half, by prop, so the panel itself keeps
+  // rendering (S10 §4a).
+  it('renders exactly the panel inventory the declared zones leave standing', () => {
     const ids = [...renderAll('desktop-v2').querySelectorAll('[data-panel-id]')]
       .map((el) => el.getAttribute('data-panel-id'))
       .sort();
     expect(ids).toEqual([
-      'agc', 'antenna', 'band', 'cw', 'cw',
+      'agc', 'band', 'cw', 'cw',
       'desktop-agc', 'desktop-cw', 'desktop-dsp', 'desktop-language',
-      'desktop-rit', 'desktop-vfo-ops', 'desktop-workspace',
+      'desktop-vfo-ops', 'desktop-workspace',
       'dsp', 'dsp', 'memory', 'memory',
-      'rit-xit', 'rx-audio', 'rx-audio', 'scan',
+      'rx-audio', 'rx-audio',
     ]);
   });
 
@@ -712,7 +713,7 @@ describe('the legacy-twin suppression channel (MOR-1364, S6-pre)', () => {
   // touches no sibling family's twin. A `dsp`-only suppression that leaves
   // `AgcPanel`, or a one-sided suppression that leaves the right sidebar's
   // `rx-audio`/`dsp`/`cw` reachable by a cross-sidebar drag, dies here.
-  it.each(ZONES.filter(([s]) => s !== 'band').map(([s]) => s))(
+  it.each(ZONES.map(([s]) => s))(
     'declaring the %s zone retires that family\'s twins in every host, and no sibling\'s',
     (surface) => {
       const t = renderAll(ZONE_PROBE[surface]);
@@ -726,11 +727,15 @@ describe('the legacy-twin suppression channel (MOR-1364, S6-pre)', () => {
     },
   );
 
-  // The deferral, pinned: declaring `band` today must suppress NOTHING. When
-  // S8 splits `BandSelector` and wires the predicate, this test is the one it
-  // has to come back and change — deliberately, not by accident.
-  it('declaring the band zone suppresses nothing yet (BandSelector split deferred to S8)', () => {
-    const t = renderAll(ZONE_PROBE.band);
+  // MOR-1367 (S8) flipped this from the S6-pre deferral pin ("declaring `band`
+  // suppresses nothing yet") to its split-aware successor. The band zone IS
+  // declared on `desktop-v2` now, and the statement that survives is the one
+  // that matters permanently: declaring it never UNMOUNTS either band host.
+  // Which half of the component goes is asserted in the zone-ownership
+  // describe below; here we only pin that neither host disappears, so a future
+  // slice that "simplifies" the prop into an `{#if}` dies on this row.
+  it('the band zone never unmounts a band host — the split is a prop, not a mount gate', () => {
+    const t = renderAll('desktop-v2');
     for (const [host, selector] of BAND_TWINS) {
       expect(t.querySelector(selector), `${host} must survive`).not.toBeNull();
     }
@@ -883,5 +888,251 @@ describe('scopeDisplay zone ownership retires the status bar scope indicator (MO
     const surface = render('desktop-v2').querySelector('[data-testid="scope-display-surface"]');
     expect(surface).not.toBeNull();
     expect(surface!.querySelectorAll('button, input, select, a[href], [tabindex]')).toHaveLength(0);
+  });
+});
+
+/**
+ * MOR-1367 (v3-rework S8) — `band`, `antenna` and `ritXitScan` become
+ * ZONE-OWNED on `desktop-v2`, closing the live double-presentation these three
+ * families have shown on the flagship skin since their B-slices landed (7B/8C/
+ * 8B mounted the surfaces; no manifest declared the zones, so `zoneOwning()`
+ * returned `null` and each rendered BARE inside the receiver deck while the
+ * sidebar and modal twins kept rendering too).
+ *
+ * Everything here is asserted against the REAL `desktop-v2` registration, not a
+ * synthetic probe — the three surfaces graduated off the S6-pre probe apparatus
+ * above because a probe would now declare a duplicate zone id.
+ *
+ * NON-VACUITY is the whole design of this describe (the MOR-1304-verify P1/P5
+ * trap, and the S5/MOR-1341 `drops the legacy meters dock` pattern): the outer
+ * file's default `capsFor('2/main_sub')` reports `freqRanges: []`, `antennas`
+ * undefined and no `rit`/`xit` tag, so all three evidence gates would decline
+ * their groups and every "the surface is present" assertion would pass for the
+ * boring reason that nothing rendered at all. The fixture below makes each
+ * `derive*` gate actually FIRE:
+ *   - `deriveBand`   — non-empty `caps.freqRanges` (adapter:683);
+ *   - `deriveAntenna`— `caps.antennas > 1` (adapter:788);
+ *   - `deriveRitXit` — a `rit`/`xit` capability tag (adapter:761);
+ *   - `deriveScan`   — at least one of scanning/scanType/scanResumeMode in state.
+ *
+ * S-ADJ NOTE: this slice writes NO gate logic. 7B's TX-permission readout, 8C's
+ * under-power antenna gating and 8B's observation gates are untouched, and
+ * their own tests are unedited by this change. What the slice does is remove
+ * the legacy fallbacks, which makes those semantic gates the ONLY ones left —
+ * see the build report's carry-forward section (MOR-1307-N4, MOR-1309-N1,
+ * MOR-1308-N4).
+ */
+describe('band, antenna and ritXitScan are zone-owned on desktop-v2 (MOR-1367, S8)', () => {
+  const LEFT_ALL = ['rf-front-end', 'mode', 'filter', 'agc', 'rit-xit', 'band',
+    'antenna', 'scan', 'rx-audio', 'dsp', 'tx', 'cw', 'memory'];
+  const RIGHT_ALL = ['rx-audio', 'audio-scope', 'dsp', 'tx', 'cw', 'memory'];
+
+  /** Two HAM bands the legacy `BandSelector` grid renders by name — so the
+   *  "HAM half is gone" pin below is about content, not just a tab strip. */
+  const HAM_RANGES = [{
+    start: 1_800_000, end: 30_000_000, label: 'HF',
+    bands: [
+      { name: '40m', start: 7_000_000, end: 7_300_000, default: 7_100_000 },
+      { name: '20m', start: 14_000_000, end: 14_350_000, default: 14_225_000, bsrCode: 5 },
+    ],
+  }];
+  const LW_MW_PRESETS = ['LW', 'MW', '120m', '90m', '75m', '60m'];
+  const SW_PRESETS = ['49m', '41m', '31m', '25m', '22m', '19m', '16m', '15m', '13m', '11m'];
+
+  function renderAll(skinId: SkinId): HTMLElement {
+    const target = render(skinId);
+    (target.querySelector('.settings-btn') as HTMLElement | null)?.click();
+    flushSync();
+    return target;
+  }
+
+  /**
+   * The zone ELEMENT half of ownership needs the resolved plan, which reaches
+   * `SemanticRadioSurfaces` through Svelte context that only `App.svelte`
+   * provides — so `render()` above (a standalone `RadioLayout` mount) leaves
+   * `useSurfacePlan()` at its `NO_PLAN` default and every surface renders bare,
+   * declared or not. `resolution.ts:148` exports the context key for exactly
+   * this: a test may supply a plan through `mount`'s `context` option.
+   *
+   * This is the S5 asymmetry made visible in one file: the LEGACY suppression
+   * reads the MANIFEST (so it works in every mount above), while the ZONE
+   * WRAPPER reads the PLAN (so it needs this).
+   */
+  function renderWithPlan(skinId: SkinId): HTMLElement {
+    const target = document.createElement('div');
+    document.body.appendChild(target);
+    const plan = resolveSurfacePlan(desktopV2Layout, DEFAULT_WORKSPACE);
+    mounted.push(mount(RadioLayout, {
+      target,
+      props: { skinId },
+      context: new Map([[SURFACE_PLAN_CONTEXT_KEY, () => plan]]),
+    }));
+    flushSync();
+    return target;
+  }
+
+  const texts = (root: Element | null, selector: string) =>
+    [...(root?.querySelectorAll(selector) ?? [])].map((el) => el.textContent?.trim());
+
+  beforeEach(() => {
+    h.caps = {
+      ...(capsFor('2/main_sub') as object),
+      antennas: 2,
+      capabilities: ['scope', 'audio', 'tx', 'dual_rx', 'rit', 'xit'],
+      freqRanges: HAM_RANGES,
+    } as Capabilities;
+    h.state = {
+      ...(liveState() as object),
+      scanning: false, scanType: 0x34, scanResumeMode: 1,
+      txAntenna: 1, rxAntenna1: 0, ritOn: false, ritTx: false, ritFreq: 0,
+    };
+    // The legacy `BandSelector` reads its HAM grid from the capabilities STORE,
+    // not from `runtime.caps` — without this the grid is empty and the split
+    // pin would only ever be about the tab strip.
+    vi.mocked(getCapabilities).mockReturnValue(
+      { freqRanges: HAM_RANGES, modes: [], filters: [] } as never,
+    );
+    vi.mocked(hasCapability).mockImplementation((tag: string) => tag === 'cw');
+    vi.mocked(hasAnyScope).mockReturnValue(true);
+    localStorage.setItem('rigplane:panel-order', JSON.stringify(LEFT_ALL));
+    localStorage.setItem('rigplane:right-panel-order', JSON.stringify(RIGHT_ALL));
+  });
+
+  afterEach(() => {
+    vi.mocked(getCapabilities).mockReturnValue({ freqRanges: [], modes: [], filters: [] } as never);
+    vi.mocked(hasAnyScope).mockReturnValue(false);
+    localStorage.clear();
+  });
+
+  // Non-vacuity, stated first and on its own: every one of the three evidence
+  // gates fires under this fixture. If one stops firing, the suppression pins
+  // below would still pass while asserting nothing — this row is what makes
+  // them mean something.
+  it('the fixture actually emits all three groups (non-vacuity)', () => {
+    const t = renderAll('desktop-v2');
+    expect(t.querySelector('[data-testid="band-surface"]')).not.toBeNull();
+    expect(t.querySelector('[data-testid="antenna-surface"]')).not.toBeNull();
+    expect(t.querySelector('[data-testid="ritxit-scan-surface"]')).not.toBeNull();
+  });
+
+  // Each declared zone actually binds a zone element and OWNS its surface —
+  // the difference between "declared" and "still rendering bare inside the
+  // deck", which is the double-presentation defect this slice closes. Run
+  // against the real resolved plan (see `renderWithPlan`), because that is the
+  // read `zoneOwning()` makes.
+  it.each([['band', 'band-surface'], ['antenna', 'antenna-surface'],
+    ['rit-xit-scan', 'ritxit-scan-surface']])(
+    'mounts %s inside its own declared zone element', (zoneId, testid) => {
+      const t = renderWithPlan('desktop-v2');
+      const zone = t.querySelector(`[data-zone-id="${zoneId}"]`);
+      expect(zone, `${zoneId} zone element`).not.toBeNull();
+      expect(zone!.querySelector(`[data-testid="${testid}"]`)).not.toBeNull();
+      // …and it is the ONLY instance — no second, bare mount alongside it.
+      expect(t.querySelectorAll(`[data-testid="${testid}"]`).length).toBe(1);
+    },
+  );
+
+  // The ritXitScan zone retires THREE twins across two hosts. A slice that
+  // gated RIT/XIT and forgot SCAN — they are separate legacy panels sharing one
+  // surface, the same shape as the `dsp`→`agc` pairing — dies here.
+  it('drops the legacy RIT / XIT + SCAN twins (sidebar + modal) for the semantic surface', () => {
+    const t = renderAll('desktop-v2');
+    expect(t.querySelector('.left-sidebar [data-panel-id="rit-xit"]')).toBeNull();
+    expect(t.querySelector('.left-sidebar [data-panel-id="scan"]')).toBeNull();
+    expect(t.querySelector('[data-panel-id="desktop-rit"]')).toBeNull();
+    expect(t.querySelector('[data-testid="ritxit-scan-surface"]')).not.toBeNull();
+  });
+
+  // 8C's own gate (`antennaCount > 1`) and the sidebar panel's identical
+  // self-gate both pass under this fixture, so the twin genuinely WOULD render
+  // without the zone — see the mutation battery.
+  it('drops the legacy ANTENNA twin for the semantic surface', () => {
+    const t = renderAll('desktop-v2');
+    expect(t.querySelector('.left-sidebar [data-panel-id="antenna"]')).toBeNull();
+    expect(t.querySelector('[data-testid="antenna-surface"]')).not.toBeNull();
+  });
+
+  /**
+   * THE SPLIT (S10 §4a, rows 6 and 10) — the one asymmetric retirement in the
+   * wave. `BandSelector` keeps its mount in BOTH hosts; only its HAM tab and
+   * HAM grid go, because `BandSurface` duplicates those and nothing duplicates
+   * the broadcast presets (`semantic/radio-view-model.ts:494-496` excludes them
+   * from the vocabulary BY NAME) and `BandSelector` is their only production
+   * consumer.
+   */
+  it('retires the HAM half of BandSelector in BOTH hosts and keeps the broadcast half', () => {
+    const t = renderAll('desktop-v2');
+    for (const [host, root] of [
+      ['left sidebar', t.querySelector('.left-sidebar [data-panel-id="band"]')],
+      ['settings modal', t.querySelector('[data-panel-id="desktop-vfo-ops"]')],
+    ] as const) {
+      expect(root, `${host} still hosts BandSelector`).not.toBeNull();
+      // The HAM tab is gone; the two broadcast tabs are not.
+      expect(texts(root, '.band-tab'), `${host} tabs`).toEqual(['LW/MW', 'SWL']);
+      // …and so is the HAM grid's content — the default landed on LW/MW, which
+      // is the other half of §4a's instruction ("gate the `bandMode === 'ham'`
+      // DEFAULT too"): without it the component would open on an empty grid.
+      expect(texts(root, '.grid button'), `${host} grid`).toEqual(LW_MW_PRESETS);
+      expect(texts(root, '.grid button')).not.toContain('20m');
+    }
+    // The semantic replacement really is on screen where the HAM grid went.
+    expect(t.querySelector('[data-testid="band-choices"]')).not.toBeNull();
+  });
+
+  // PRESET SURVIVAL. Both broadcast tabs remain reachable and every preset is
+  // still there. Note the count: `broadcast-presets.ts` ships SIXTEEN presets
+  // (6 LW/MW + 10 SW), not the seventeen the S10 doc states — the doc counted
+  // the `BroadcastPreset` interface's own `name:` field. Pinned as the measured
+  // number, with the discrepancy recorded rather than propagated.
+  it('keeps all 16 broadcast presets reachable after the split', () => {
+    const t = renderAll('desktop-v2');
+    const panel = t.querySelector('.left-sidebar [data-panel-id="band"]')!;
+    expect(texts(panel, '.grid button')).toEqual(LW_MW_PRESETS);
+    (texts(panel, '.band-tab').indexOf('SWL') >= 0
+      ? (panel.querySelectorAll('.band-tab')[1] as HTMLElement)
+      : null)?.click();
+    flushSync();
+    expect(texts(panel, '.grid button')).toEqual(SW_PRESETS);
+    expect(LW_MW_PRESETS.length + SW_PRESETS.length).toBe(16);
+  });
+
+  // The un-split direction: a host that does NOT declare `band` renders the
+  // pre-split three-tab component, HAM grid and all. `hamBands` defaults to
+  // `true`, so mobile/LCD and every other caller are untouched by the split.
+  it('an undeclared layout still renders the full three-tab BandSelector', () => {
+    const panel = renderAll('no-such-layout' as SkinId)
+      .querySelector('.left-sidebar [data-panel-id="band"]')!;
+    expect(texts(panel, '.band-tab')).toEqual(['HAM', 'LW/MW', 'SWL']);
+    expect(texts(panel, '.grid button')).toEqual(['40m', '20m']);
+  });
+
+  // §1.5 / MOR-1339: `compositionSurfaces(plan(desktopV2Layout))` grew by three
+  // members, and NO `{#each singleOrder}` branch was added for any of them, so
+  // each surface must render exactly ONCE. This is the double-presentation
+  // CLOSED assertion — the shape most likely to reveal a suppression that
+  // covers only some of the three zones, or a second mount path.
+  it('presents band, antenna and ritXitScan exactly ONCE each on desktop-v2', () => {
+    const t = renderAll('desktop-v2');
+    for (const testid of ['band-surface', 'antenna-surface', 'ritxit-scan-surface']) {
+      expect(t.querySelectorAll(`[data-testid="${testid}"]`).length, testid).toBe(1);
+    }
+    for (const selector of [
+      '.left-sidebar [data-panel-id="rit-xit"]', '.left-sidebar [data-panel-id="scan"]',
+      '[data-panel-id="desktop-rit"]', '.left-sidebar [data-panel-id="antenna"]',
+    ]) {
+      expect(t.querySelectorAll(selector).length, selector).toBe(0);
+    }
+    // The band family's "exactly once" is tab-shaped, not panel-shaped: one
+    // semantic band grid, and zero HAM tabs anywhere on the flagship skin.
+    expect(t.querySelectorAll('[data-testid="band-choices"]').length).toBe(1);
+    expect([...t.querySelectorAll('.band-tab')].filter((b) => b.textContent?.trim() === 'HAM').length)
+      .toBe(0);
+  });
+
+  // R9, over the real manifest rather than a probe: three more declared zones
+  // must not change the number of elements that can key or unkey. `hideTxPanel`
+  // still follows the semantic DECK and stays a separate prop (§1.4).
+  it('leaves exactly one key authority with all three zones declared', () => {
+    expect(renderAll('desktop-v2').querySelectorAll(KEY_AUTHORITIES).length).toBe(1);
   });
 });

--- a/frontend/src/presentation/layouts/__tests__/antenna-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/antenna-declarability.test.ts
@@ -1,22 +1,16 @@
 /**
- * MOR-1309 — `antenna` is DECLARABLE, and nothing declares it yet.
+ * MOR-1309 — `antenna` is DECLARABLE. MOR-1367 (S8) declares it for real.
  *
- * Slice 8C adds the name to `SEMANTIC_SURFACE_NAMES` so a manifest CAN mount
- * the surface later; it deliberately does not touch any manifest, and it adds
- * no design-language renderer slot (that set was frozen by MOR-1072 — adding
- * one would be a language-contract change this slice must not make).
+ * Slice 8C added the name to `SEMANTIC_SURFACE_NAMES` so a manifest COULD mount
+ * the surface later; it deliberately touched no manifest and added no
+ * design-language renderer slot (that set was frozen by MOR-1072).
  *
- * The "nothing declares it yet" half is load-bearing HERE in a way it was not
- * for `meters`: the antenna surface is control-bearing, and it is mounted in
- * the SINGLE composition only (MOR-1304 mounting canon, option (i)). A zone
- * declared in a dual-mounting manifest without the matching composition work
- * would put focusable controls outside the cockpit's declared zones.
- *
- * Same three pins as `rx-audio-declarability.test.ts` / `tx-aux-declarability.test.ts`:
- *   - drop the name and a future manifest's zone stops validating;
- *   - quietly add an `antenna` zone to a shipped manifest and the DOM grows a
- *     zone id no layout review ever saw;
- *   - the renderer slot set stays exactly what MOR-1072 froze.
+ * MOR-1367 flips the second half, on `desktop-v2` ONLY. The "nothing declares
+ * it" half was load-bearing for 8C because the surface is CONTROL-BEARING and is
+ * mounted in the SINGLE composition only (MOR-1304 mounting canon, option (i));
+ * declaring a zone on `desktop-v2` does not put it into the dual composition, so
+ * the cockpit manifest stays untouched and 8C's dual-absence pin stays valid and
+ * unedited. This is canon option (ii), for `desktop-v2` alone.
  */
 import { describe, it, expect } from 'vitest';
 import { SEMANTIC_SURFACE_NAMES, validateLayoutManifest } from '../contract';
@@ -55,17 +49,43 @@ describe('antenna is a declarable semantic surface', () => {
   });
 });
 
-describe('no shipped manifest declares an antenna zone in this slice', () => {
-  // Kills: slipping an antenna zone into an existing layout here. Declarability
-  // is the whole scope of the contract touch; placing a control-bearing surface
-  // in a real layout is a later, separately reviewed slice that must also do
-  // the dual-composition mount work the canon requires.
-  it.each([
+describe('exactly the reviewed manifests declare an antenna zone (MOR-1367)', () => {
+  /** The literal — extend by hand, with a layout review, never silently. */
+  const DECLARES_ANTENNA = ['desktop-v2'];
+
+  const ALL = [
     ['sdr-test', sdrTestLayout], ['dual-receiver-cockpit', dualReceiverCockpitLayout],
     ['lcd-cockpit', lcdCockpitLayout], ['lcd-scope', lcdScopeLayout],
     ['mobile', mobileLayout], ['desktop-v2', desktopV2Layout],
-  ])('%s declares no antenna zone and does not require the surface', (_id, manifest) => {
-    for (const zone of manifest.zones) expect(zone.surfaces).not.toContain('antenna');
+  ] as const;
+
+  // Kills BOTH directions: a family losing the zone S8 gave it, and a family
+  // gaining one without review. For the cockpit that is load-bearing rather
+  // than cosmetic — a declared zone there would move a control-bearing surface
+  // into the dual composition and change what MOR-1069's tab-order assertion
+  // has to say.
+  it('the declaring set is exactly the reviewed literal', () => {
+    const declaring = ALL
+      .filter(([, m]) => m.zones.some((z) => z.surfaces.includes('antenna')))
+      .map(([id]) => id)
+      .sort();
+    expect(declaring).toEqual([...DECLARES_ANTENNA].sort());
+  });
+
+  // Kills: declaring the zone under a drifted id — the wiring binds whatever
+  // the plan's key is, so the id IS the contract with the layout's arrangement.
+  it.each(DECLARES_ANTENNA)('%s declares it under the stable `antenna` id, alone in its zone', (id) => {
+    const manifest = ALL.find(([name]) => name === id)![1];
+    const zone = manifest.zones.find((z) => z.surfaces.includes('antenna'))!;
+    expect(zone.id).toBe('antenna');
+    expect(zone.surfaces).toEqual(['antenna']);
+  });
+
+  // Kills: making antenna REQUIRED. A single-antenna radio reports no antenna
+  // group at all and must still resolve this layout; the surface self-gates on
+  // `view.antenna`, and a required surface no zone could fill would be a
+  // resolution failure rather than an honest absence.
+  it.each(ALL)('%s does not require the antenna surface', (_id, manifest) => {
     expect(manifest.requiredSemanticSurfaces).not.toContain('antenna');
   });
 });

--- a/frontend/src/presentation/layouts/__tests__/band-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/band-declarability.test.ts
@@ -1,16 +1,22 @@
 /**
- * MOR-1307 — `band` is DECLARABLE, and nothing declares it yet.
+ * MOR-1307 — `band` is DECLARABLE. MOR-1367 (S8) declares it for real.
  *
- * Slice 7B adds the name to `SEMANTIC_SURFACE_NAMES` so a manifest CAN mount
- * the surface later; it deliberately does not touch any manifest, and it adds
- * no design-language renderer slot (that set was frozen by MOR-1072).
+ * Slice 7B added the name to `SEMANTIC_SURFACE_NAMES` so a manifest COULD mount
+ * the surface later; it deliberately touched no manifest and added no
+ * design-language renderer slot (that set was frozen by MOR-1072).
  *
- * Same three pins as `tx-aux-`/`meters-`/`rx-audio-declarability.test.ts`, with
- * one extra weight here: `band` is a CONTROL-BEARING surface, so "no shipped
- * manifest declares a band zone" is also what makes the single-composition-only
- * mount legal under the MOR-1069 cockpit invariant (see the dual-absence pin in
- * `components-v2/wiring/__tests__/semantic-band-wiring.component.test.ts`). If
- * a manifest ever gains the zone, that pin must be revisited in the same PR.
+ * MOR-1367 flips the second half, on `desktop-v2` ONLY — the cockpit manifest is
+ * deliberately untouched (S5 precedent), so 7B's single-composition-only mount
+ * and its dual-absence pin in
+ * `components-v2/wiring/__tests__/semantic-band-wiring.component.test.ts` stay
+ * valid and unedited. The inventory below is a LITERAL of who declares it,
+ * mirroring `meters-declarability.test.ts`'s post-S5 shape.
+ *
+ * `band` is the one surface in this slice whose legacy twin does NOT retire
+ * wholesale: `BandSelector` keeps hosting the LW/MW + SWL broadcast tabs and
+ * loses only its HAM half, via `hamBands={!declared.has('band')}` (S10 §4a).
+ * That half of the contract is pinned in
+ * `components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts`.
  */
 import { describe, it, expect } from 'vitest';
 import { SEMANTIC_SURFACE_NAMES, validateLayoutManifest } from '../contract';
@@ -51,17 +57,45 @@ describe('band is a declarable semantic surface', () => {
   });
 });
 
-describe('no shipped manifest declares a band zone in this slice', () => {
-  // Kills: slipping a band zone into an existing layout here. For the cockpit
-  // this is load-bearing, not cosmetic: a declared zone would move the surface
-  // into the dual composition and change what the MOR-1069 tab-order assertion
-  // has to say.
-  it.each([
+describe('exactly the reviewed manifests declare a band zone (MOR-1367)', () => {
+  /** The literal — extend by hand, with a layout review, never silently. */
+  const DECLARES_BAND = ['desktop-v2'];
+
+  const ALL = [
     ['sdr-test', sdrTestLayout], ['dual-receiver-cockpit', dualReceiverCockpitLayout],
     ['lcd-cockpit', lcdCockpitLayout], ['lcd-scope', lcdScopeLayout],
     ['mobile', mobileLayout], ['desktop-v2', desktopV2Layout],
-  ])('%s declares no band zone and does not require the surface', (_id, manifest) => {
-    for (const zone of manifest.zones) expect(zone.surfaces).not.toContain('band');
+  ] as const;
+
+  // Kills BOTH directions: a family losing the zone S8 gave it, and a family
+  // gaining one without review. For the cockpit that is load-bearing rather
+  // than cosmetic — a declared zone there would move a control-bearing surface
+  // into the dual composition and change what MOR-1069's tab-order assertion
+  // has to say.
+  it('the declaring set is exactly the reviewed literal', () => {
+    const declaring = ALL
+      .filter(([, m]) => m.zones.some((z) => z.surfaces.includes('band')))
+      .map(([id]) => id)
+      .sort();
+    expect(declaring).toEqual([...DECLARES_BAND].sort());
+  });
+
+  // Kills: declaring the zone under a drifted id — the suppression binds the
+  // DECLARED set, and `BandSelector`'s `hamBands` prop reads exactly
+  // `declared.has('band')`, so the surface name and the zone id are both
+  // contracts with the shell.
+  it.each(DECLARES_BAND)('%s declares it under the stable `band` id, alone in its zone', (id) => {
+    const manifest = ALL.find(([name]) => name === id)![1];
+    const zone = manifest.zones.find((z) => z.surfaces.includes('band'))!;
+    expect(zone.id).toBe('band');
+    expect(zone.surfaces).toEqual(['band']);
+  });
+
+  // Kills: making band REQUIRED. A radio whose caps carry no frequency ranges
+  // at all must still resolve this layout; the surface self-gates on
+  // `view.band`, and a required surface no zone could fill would be a
+  // resolution failure rather than an honest absence.
+  it.each(ALL)('%s does not require the band surface', (_id, manifest) => {
     expect(manifest.requiredSemanticSurfaces).not.toContain('band');
   });
 });

--- a/frontend/src/presentation/layouts/__tests__/desktop-v2-registration.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/desktop-v2-registration.test.ts
@@ -56,7 +56,8 @@ describe('declared zones now drive the DOM (MOR-1263 step 2, MOR-1313)', () => {
   // Kills: declaring a surface this manifest does not name, or dropping
   // either one — the pair per-zone suppression consumes.
   it('declares receiver-deck:[vfo], rx-tx:[rxTx], tx-aux:[txAux], meters:[meters], '
-    + 'scope-display:[scopeDisplay], filter:[filter] and rf-front-end:[rfFrontEnd]', () => {
+    + 'scope-display:[scopeDisplay], filter:[filter], rf-front-end:[rfFrontEnd], '
+    + 'band:[band], antenna:[antenna] and rit-xit-scan:[ritXitScan]', () => {
     expect(desktopV2Layout.zones).toEqual([
       { id: 'receiver-deck', surfaces: ['vfo'] },
       { id: 'rx-tx', surfaces: ['rxTx'] },
@@ -71,6 +72,12 @@ describe('declared zones now drive the DOM (MOR-1263 step 2, MOR-1313)', () => {
       // double-presentation defect on desktop-v2. Neither required.
       { id: 'filter', surfaces: ['filter'] },
       { id: 'rf-front-end', surfaces: ['rfFrontEnd'] },
+      // MOR-1367 (S8): band, antenna and ritXit/scan. `band` retires only the
+      // HAM half of `BandSelector` (S10 §4a); the other two retire their
+      // sidebar/modal twins outright.
+      { id: 'band', surfaces: ['band'] },
+      { id: 'antenna', surfaces: ['antenna'] },
+      { id: 'rit-xit-scan', surfaces: ['ritXitScan'] },
     ]);
     expect([...desktopV2Layout.requiredSemanticSurfaces].sort()).toEqual(['rxTx', 'vfo']);
   });
@@ -92,7 +99,7 @@ describe('declared zones now drive the DOM (MOR-1263 step 2, MOR-1313)', () => {
   // is per-zone rather than per-manifest-first-zone.
   it('its zones flatten to the surfaces the shell suppresses legacy twins for', () => {
     expect([...declaredSurfaces(getLayout('desktop-v2'))].sort())
-      .toEqual(['filter', 'meters', 'rfFrontEnd', 'rxTx', 'scopeDisplay', 'txAux', 'vfo']);
+      .toEqual(['antenna', 'band', 'filter', 'meters', 'rfFrontEnd', 'ritXitScan', 'rxTx', 'scopeDisplay', 'txAux', 'vfo']);
   });
 });
 

--- a/frontend/src/presentation/layouts/__tests__/ritxit-scan-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/ritxit-scan-declarability.test.ts
@@ -1,17 +1,14 @@
 /**
- * MOR-1308 — `ritXitScan` is DECLARABLE, and nothing declares it yet.
+ * MOR-1308 — `ritXitScan` is DECLARABLE. MOR-1367 (S8) declares it for real.
  *
- * Slice 8B adds the name to `SEMANTIC_SURFACE_NAMES` so a manifest CAN mount
- * the surface later; it deliberately does not touch any manifest, and it adds
- * no design-language renderer slot (that set was frozen by MOR-1072 — adding
- * one would be a language-contract change this slice must not make).
+ * Slice 8B added the name to `SEMANTIC_SURFACE_NAMES` so a manifest COULD mount
+ * the surface later; it deliberately touched no manifest and added no
+ * design-language renderer slot (that set was frozen by MOR-1072).
  *
- * Same three pins as `tx-aux-declarability.test.ts` / `meters-declarability
- * .test.ts` / `rx-audio-declarability.test.ts`:
- *   - drop the name and a future manifest's zone stops validating;
- *   - quietly add a `ritXitScan` zone to a shipped manifest and the DOM
- *     grows a zone id no layout review ever saw;
- *   - the renderer slot set stays exactly what MOR-1072 froze.
+ * MOR-1367 flips the second half, on `desktop-v2` ONLY — the cockpit manifest is
+ * deliberately untouched (S5 precedent), so 8B's single-composition-only mount
+ * and its dual-absence pin stay valid and unedited. This is canon option (ii),
+ * for `desktop-v2` alone.
  */
 import { describe, it, expect } from 'vitest';
 import { SEMANTIC_SURFACE_NAMES, validateLayoutManifest } from '../contract';
@@ -49,16 +46,43 @@ describe('ritXitScan is a declarable semantic surface', () => {
   });
 });
 
-describe('no shipped manifest declares a ritXitScan zone in this slice', () => {
-  // Kills: slipping a ritXitScan zone into an existing layout here.
-  // Declarability is the whole scope of the contract touch; placing the
-  // surface in a real layout is a later, separately reviewed slice.
-  it.each([
+describe('exactly the reviewed manifests declare a ritXitScan zone (MOR-1367)', () => {
+  /** The literal — extend by hand, with a layout review, never silently. */
+  const DECLARES_RITXIT_SCAN = ['desktop-v2'];
+
+  const ALL = [
     ['sdr-test', sdrTestLayout], ['dual-receiver-cockpit', dualReceiverCockpitLayout],
     ['lcd-cockpit', lcdCockpitLayout], ['lcd-scope', lcdScopeLayout],
     ['mobile', mobileLayout], ['desktop-v2', desktopV2Layout],
-  ])('%s declares no ritXitScan zone and does not require the surface', (_id, manifest) => {
-    for (const zone of manifest.zones) expect(zone.surfaces).not.toContain('ritXitScan');
+  ] as const;
+
+  // Kills BOTH directions: a family losing the zone S8 gave it, and a family
+  // gaining one without review. For the cockpit that is load-bearing rather
+  // than cosmetic — a declared zone there would move a control-bearing surface
+  // into the dual composition and change what MOR-1069's tab-order assertion
+  // has to say.
+  it('the declaring set is exactly the reviewed literal', () => {
+    const declaring = ALL
+      .filter(([, m]) => m.zones.some((z) => z.surfaces.includes('ritXitScan')))
+      .map(([id]) => id)
+      .sort();
+    expect(declaring).toEqual([...DECLARES_RITXIT_SCAN].sort());
+  });
+
+  // Kills: declaring the zone under a drifted id — the wiring binds whatever
+  // the plan's key is, so the id IS the contract with the layout's arrangement.
+  it.each(DECLARES_RITXIT_SCAN)('%s declares it under the stable `rit-xit-scan` id, alone in its zone', (id) => {
+    const manifest = ALL.find(([name]) => name === id)![1];
+    const zone = manifest.zones.find((z) => z.surfaces.includes('ritXitScan'))!;
+    expect(zone.id).toBe('rit-xit-scan');
+    expect(zone.surfaces).toEqual(['ritXitScan']);
+  });
+
+  // Kills: making ritXitScan REQUIRED. A radio declaring neither RIT/XIT nor
+  // scan must still resolve this layout; the surface self-gates on
+  // `view.ritXit`/`view.scan`, and a required surface no zone could fill would
+  // be a resolution failure rather than an honest absence.
+  it.each(ALL)('%s does not require the ritXitScan surface', (_id, manifest) => {
     expect(manifest.requiredSemanticSurfaces).not.toContain('ritXitScan');
   });
 });

--- a/frontend/src/presentation/layouts/desktop-declarations.ts
+++ b/frontend/src/presentation/layouts/desktop-declarations.ts
@@ -70,6 +70,24 @@ const DESKTOP_V2_ZONES = [
   // this layout, and each surface self-gates on its own view-model group.
   { id: 'filter', surfaces: ['filter'] },
   { id: 'rf-front-end', surfaces: ['rfFrontEnd'] },
+  // MOR-1367 (S8): band, antenna and ritXit/scan become zone-OWNED here, which
+  // is what activates the S6-pre suppression channel for the RIT / XIT, SCAN
+  // and ANTENNA sidebar panels and the `desktop-rit` modal section — closing
+  // the live double-presentation these three families have shown on the
+  // flagship skin since their B-slices mounted the surfaces (§0.1).
+  //
+  // `band` is the one that is NOT a plain retirement: `BandSelector` hosts the
+  // LW/MW + SWL broadcast tabs (16 presets) that the vocabulary deliberately
+  // excludes from `bandChoices` (`semantic/radio-view-model.ts:494-496`), so
+  // declaring this zone retires the component's HAM half ONLY, through
+  // `hamBands={!declared.has('band')}` — a prop, never a mount gate (S10 §4a).
+  //
+  // None is `required`, for the same reason as `tx-aux`/`meters`: a radio whose
+  // evidence gate declined the group must still resolve this layout, and each
+  // surface self-gates on its own `view.*` leaf.
+  { id: 'band', surfaces: ['band'] },
+  { id: 'antenna', surfaces: ['antenna'] },
+  { id: 'rit-xit-scan', surfaces: ['ritXitScan'] },
 ] as const;
 
 export const desktopV2Layout: LayoutManifest = {

--- a/frontend/src/presentation/workspace/__tests__/preferences-adoption.test.ts
+++ b/frontend/src/presentation/workspace/__tests__/preferences-adoption.test.ts
@@ -264,10 +264,17 @@ describe('MOR-1082 — the single-composition order comes from the same plan', (
     expect(compositionSurfaces(plan(sdrTestLayout), FALLBACK)).toEqual(['vfo', 'rxTx']);
     // desktop-v2 spreads the same two surfaces over two zones, plus its own
     // MOR-1336 (S4) tx-aux zone, MOR-1341 (S5) meters zone, MOR-1365 (S6a)
-    // scope-display zone, and MOR-1366 (S7) filter/rf-front-end zones —
-    // flattening never drops a later zone.
+    // scope-display zone, the MOR-1366 (S7) filter/rf-front-end zones and the
+    // three MOR-1367 (S8) zones — flattening never drops a later zone.
+    //
+    // §1.5 / MOR-1339 discipline: this list GROWS, but `singleOrder`'s `{#each}`
+    // in `SemanticRadioSurfaces.svelte` gains NO branch for any of these
+    // members — each renders exactly once, through `zoned()`. The
+    // "presents … exactly ONCE" pin in
+    // `components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts`
+    // is the counterpart that would catch a double mount.
     expect(compositionSurfaces(plan(desktopV2Layout), FALLBACK))
-      .toEqual(['vfo', 'rxTx', 'txAux', 'meters', 'scopeDisplay', 'filter', 'rfFrontEnd']);
+      .toEqual(['vfo', 'rxTx', 'txAux', 'meters', 'scopeDisplay', 'filter', 'rfFrontEnd', 'band', 'antenna', 'ritXitScan']);
     expect(compositionSurfaces(plan(sdrTestLayout, { zoneOrder: { main: ['rxTx', 'vfo'] } }), FALLBACK))
       .toEqual(['rxTx', 'vfo']);
   });

--- a/frontend/src/presentation/workspace/contract.ts
+++ b/frontend/src/presentation/workspace/contract.ts
@@ -49,7 +49,7 @@ export const WORKSPACE_THEME_IDS = [
 export type WorkspaceThemeId = (typeof WORKSPACE_THEME_IDS)[number];
 
 /** Every zone id declared by a registered layout manifest (decisions 5 and 6). */
-export const WORKSPACE_ZONE_IDS = ['main', 'receiver-deck', 'rx-tx', 'primary-vfo', 'secondary-vfo', 'global', 'portrait-deck', 'control-column', 'tx-aux', 'meters', 'scope-display', 'filter', 'rf-front-end'] as const;
+export const WORKSPACE_ZONE_IDS = ['main', 'receiver-deck', 'rx-tx', 'primary-vfo', 'secondary-vfo', 'global', 'portrait-deck', 'control-column', 'tx-aux', 'meters', 'scope-display', 'filter', 'rf-front-end', 'band', 'antenna', 'rit-xit-scan'] as const;
 export type WorkspaceZoneId = (typeof WORKSPACE_ZONE_IDS)[number];
 
 /** Decision 7: command-bus intent names (`set_compressor`), never module paths. */


### PR DESCRIPTION
## Summary

S8 (MOR-1263 tail, SAFETY-ADJACENT, defect-closing): the band, antenna, and rit-xit-scan zones declared in the desktop-v2 manifest; the S6-pre channel retires the sidebar/modal legacy twins. Includes the S10 row-10 BandSelector split: a hamBands prop (NEVER a mount gate - zero mount sites consult it) retires the HAM grid + the ham default with the band zone, while the LW/MW/SWL broadcast tabs and their 16 presets stay hosted everywhere they were (count corrected from the doc's 17 - a grep artifact counting the interface's own name: field; corrections to the S10 doc and S6-pre comments ride along).

Production LOC 7 (verifier-measured against the slice's own base). 5-file guardrail WAIVED explicitly: 2 standing serialization points + the 3 files the S10 §4a ruling assigns to the split by name.

## Review provenance

Verified by the rework-domain opus anchor #3 (session 8): PASS, no required fixes. The three landed surfaces + their tests byte-identical (gating unchanged - band TX-caveat and antenna under-power suites re-run unedited, 43/43); the derived-fallback split shape ruled sound Svelte 5 (not a warning dodge) and surviving post-mount prop flips; broadcast reachability pinned in BOTH hosts (tabs, 6 LW/MW + 10 SW presets, onPresetSelect firing); N1 zone-binding assertions for all three zones with an only-instance improvement; M10 proves the ham DEFAULT gate is independently pinned. Post-merge mutant re-runs on the fully-merged tree: M1 10/10, M10 6/6. Suite 5894/5894. Landing gate discharged: the deriveBand raw-active concern is tracked as MOR-1356 (pre-cutover path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)