### PR TITLE
test(MOR-1355): plan-ful harness topology + txAux tag restoration - no vacuous zonelessControls pins

### DIFF
--- a/frontend/fixtures/assertions.ts
+++ b/frontend/fixtures/assertions.ts
@@ -289,7 +289,7 @@ export function runAssertions(
       ? `${hideable.length} zones/controls all laid out and visible`
       : `hidden: ${hidden.map((el) => el.dataset.testid ?? el.tagName).join(', ')}`);
 
-  // ── focus order is DOM order, ending in rx-tx (MOR-1069) ───────────────
+  // ── focus order is DOM order, ending in the LAST declared zone (MOR-1069) ─
   // MOR-1085: "every control lives inside a declared zone" is the
   // dual-receiver-cockpit's own acceptance gate (MOR-1069/1070 gate item
   // (b)) — it presupposes zones exist to live inside. The reference/single
@@ -297,6 +297,13 @@ export function runAssertions(
   // so EVERY control there is trivially "outside every declared zone"; that
   // is not a regression to police, it is the honest absence of the concept
   // this check verifies. Both checks stay cockpit-only for that reason.
+  // MOR-1355: the terminal zone is `declared[declared.length - 1]`, not a
+  // hardcoded `'rx-tx'` — the same generalisation
+  // `DualReceiverCockpit.component.test.ts`'s MOR-1069 suite already made
+  // ("the LAST declared zone comes last"), needed the moment a resolved
+  // `SurfacePlan` puts real content in the manifest's `tx-aux` zone, which
+  // sits declared (and rendered) AFTER `rx-tx`. A no-op for every fixture
+  // whose declared zones still end in `rx-tx` (every one before this ticket).
   if (zonedComposition) {
     const declared = [...expected.zones];
     const seq = controls().map((el) => {
@@ -307,7 +314,7 @@ export function runAssertions(
     check('focus-order-is-zone-order',
       controls().length === 0
         || (eq(zoned, [...zoned].sort((a, b) => a - b))
-          && (zoned.length === 0 || zoned[zoned.length - 1] === declared.indexOf('rx-tx'))),
+          && (zoned.length === 0 || zoned[zoned.length - 1] === declared.length - 1)),
       `zone indices ${JSON.stringify(seq)} (-1 = outside every declared zone)`);
     check('zone-less-control-count',
       seq.filter((i) => i === -1).length === expected.zonelessControls,

--- a/frontend/fixtures/capture.mjs
+++ b/frontend/fixtures/capture.mjs
@@ -191,6 +191,15 @@ const MATRIX = [
     { name: `tx-phase-tx--desktop--${language}`, fixture: 'tx-phase-tx',
       viewport: 'desktop', language },
   ]),
+  // R. MOR-1355 — the harness's one PLAN-FUL capture: `main.ts` resolves a
+  // real `SurfacePlan` for this fixture (`catalog.ts`'s `planned: true`), so
+  // `tx-aux` is genuinely bound rather than merely declared. Same radio as
+  // section A's `topology-2-main-sub`; the only variable is plan-ful vs
+  // plan-less.
+  {
+    name: 'topology-2-main-sub--planned--desktop', fixture: 'topology-2-main-sub--planned',
+    viewport: 'desktop',
+  },
 ];
 
 /* ── build identity ────────────────────────────────────────────────────── */
@@ -206,6 +215,10 @@ const PRODUCTION_SOURCES = [
   'frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts',
   'frontend/src/lib/runtime/adapters/presentation-capabilities.ts',
   'frontend/src/presentation/layouts/dual-receiver-cockpit.ts',
+  // MOR-1355: the plan-ful capture genuinely exercises these two — the
+  // resolution seam and the default-workspace path `resolveSurfacePlan` reads.
+  'frontend/src/presentation/workspace/resolution.ts',
+  'frontend/src/presentation/workspace/contract.ts',
   'frontend/src/app.css',
   'frontend/src/styles/tokens.css',
   'frontend/src/styles/animations.css',
@@ -526,6 +539,13 @@ const manifest = {
     + 'Tab reachability (covered separately by the focus-order assertions).',
     '`meter-ballistics-honor-reduced-motion` counts `requestAnimationFrame` calls page-wide, not scoped '
     + 'to the meters subtree — correct today (nothing else in the tree calls rAF).',
+    'MOR-1355: exactly ONE capture (`topology-2-main-sub--planned--desktop`) supplies a real resolved '
+    + '`SurfacePlan` (`resolveSurfacePlan(dualReceiverCockpitLayout, …)`, via `catalog.ts`\'s `planned: '
+    + 'true`); every other capture stays plan-less on purpose — those still model the pre-navigation '
+    + 'reference path this harness mounts directly (see the `main.ts` header). Only '
+    + '`dualReceiverCockpitLayout` is ever resolved here; the `--reference` family (desktop-v2/sdr-test '
+    + 'wiring) has no plan-ful twin in this slice — its manifest declares a different zone set and is '
+    + 'separately scoped follow-up work.',
   ],
   viewports: VIEWPORTS,
   summary: {

--- a/frontend/fixtures/catalog.ts
+++ b/frontend/fixtures/catalog.ts
@@ -194,24 +194,28 @@ function withMeters(state: ServerState): ServerState {
  * MOR-1351: hardened to a REAL radio's shape — IC-7610 (`rigs/ic7610.toml`),
  * the only dual-receiver profile in the tree and already this fixture's
  * implied topology (`receivers: 2, vfoScheme: 'main_sub'`) — modes/filters/
- * tags verbatim from that profile, with one exclusion:
+ * tags verbatim from that profile.
  *
- *  - `tuner`/`vox`/`compressor`/`monitor`/`drive_gain` (the `deriveTxAux`
- *    evidence tags): this harness (`fixtures/main.ts`) supplies NO resolved
- *    `SurfacePlan`, so `SemanticRadioSurfaces.svelte`'s `zoneOwning()` is
- *    unconditionally `null` and `TxAuxSurface` would render its controls
- *    ZONE-LESS rather than inside `tx-aux` — flipping every fixture's pinned
- *    `zonelessControls: 0` for a reason unrelated to this ticket. Confirmed
- *    by measurement: adding `tuner` alone (`deriveTxAux`'s cheapest evidence
- *    tag — `hasTuner` alone satisfies `hasEvidence`) flips 36/60 captures to
- *    `zone-less-control-count: 4` (the ATU button, ATU-tune button, and two
- *    disabled inputs, landing `NO-ZONE`). All five tags stay OUT here, unlike
- *    the cockpit vitest fixture where `render(defaultPlan())` supplies a real
- *    plan and `tuner` (pre-existing since MOR-1336/S4) lands inside `tx-aux`
- *    correctly. Follow-up ticket N1 will wire the plan and lift this
- *    exclusion together.
+ * MOR-1355 (N1 follow-up landed): the five `deriveTxAux` evidence tags
+ * (`tuner`/`vox`/`compressor`/`monitor`/`drive_gain`) are now INCLUDED — the
+ * reason they were withheld ("this harness supplies no resolved
+ * `SurfacePlan`, so every fixture would render the group ZONE-LESS") no
+ * longer holds universally: `fixtures/main.ts` can now supply a real
+ * `resolveSurfacePlan(dualReceiverCockpitLayout, …)` plan through Svelte
+ * context, exactly the `DualReceiverCockpit.component.test.ts` recipe. It
+ * still holds PER FIXTURE — only `topology-2-main-sub--planned` below opts
+ * in (`planned: true`); every other fixture stays plan-less on purpose (the
+ * ticket's instruction: the existing zone-less topologies still represent
+ * production's pre-navigation reference path). Measured consequence: with
+ * caps evidence for all five tags and no fixture state observing any of
+ * them, `TxAuxSurface` renders exactly 13 controls, all present-and-disabled
+ * (4 toggles + TUNE + 8 level inputs — see `TX_AUX_TOGGLES`/`TX_AUX_LEVELS`
+ * in `TxAuxSurface.svelte`) — inside `tx-aux` for the one planned fixture,
+ * outside every declared zone (`NO-ZONE`) everywhere else. Every affected
+ * `zonelessControls` pin below carries this count with its own rationale
+ * rather than a blanket default, per the MOR-1355 build report.
  *
- * `scope` is now `true` with a `'scope'` tag (matching the cockpit vitest
+ * `scope` is `true` with a `'scope'` tag (matching the cockpit vitest
  * fixture): `presentation-capabilities.ts`'s `agreed()` requires the boolean
  * and the tag to agree, so leaving the tag off while flipping the boolean
  * would itself raise `scope-capability-contradiction`. The MOR-1085
@@ -224,13 +228,13 @@ function withMeters(state: ServerState): ServerState {
 const baseCaps = (): Capabilities => ({
   model: 'fixture', scope: true, audio: true, tx: true,
   capabilities: [
-    'audio', 'tx', 'dual_rx', 'dual_watch', 'lan_dual_rx_audio_routing',
+    'audio', 'tx', 'dual_rx', 'tuner', 'dual_watch', 'lan_dual_rx_audio_routing',
     'af_level', 'rf_gain', 'squelch', 'attenuator', 'preamp', 'digisel', 'ip_plus',
     'antenna', 'rx_antenna', 'nb', 'nr', 'notch', 'apf', 'twin_peak', 'pbt',
     'filter_width', 'filter_shape', 'split', 'ssb_tx_bw', 'cw', 'break_in', 'rit', 'xit',
     'meters', 'data_mode', 'mod_input_routing', 'agc', 'power_control', 'dial_lock',
     'scan', 'bsr', 'main_sub_tracking', 'tuning_step', 'band_edge', 'xfc', 'system_settings',
-    'scope',
+    'scope', 'vox', 'compressor', 'monitor', 'drive_gain',
   ],
   receivers: 2, vfoScheme: 'main_sub',
   freqRanges: [{ start: 1800000, end: 54000000, label: 'HF+6m', bands: [
@@ -355,11 +359,35 @@ export interface Fixture {
    * id from its cockpit sibling.
    */
   layout?: 'cockpit' | 'reference';
+  /**
+   * MOR-1355. `true` ⇒ `fixtures/main.ts` mounts this fixture with a REAL
+   * resolved `SurfacePlan` (`resolveSurfacePlan(dualReceiverCockpitLayout,
+   * …)`) supplied through Svelte context — the same recipe
+   * `DualReceiverCockpit.component.test.ts`'s `render(defaultPlan())` uses.
+   * Default `false`/absent: the pre-MOR-1355 plan-less mount, unchanged.
+   */
+  planned?: boolean;
   expect: Expectation;
 }
 
 const DUAL_ZONES = ['primary-vfo', 'secondary-vfo', 'global', 'rx-tx'] as const;
 const SINGLE_ZONES = ['primary-vfo', 'global', 'rx-tx'] as const;
+/**
+ * MOR-1355. `dualReceiverCockpitLayout` declares a `tx-aux` zone (MOR-1336/
+ * S4); a `planned` fixture resolves a real plan against it, so `tx-aux`
+ * genuinely comes last in DOM order, after `rx-tx`.
+ */
+const DUAL_ZONES_PLANNED = [...DUAL_ZONES, 'tx-aux'] as const;
+/**
+ * MOR-1355. The exact `TxAuxSurface` control count once `baseCaps` carries
+ * all five `deriveTxAux` evidence tags and no fixture state observes any of
+ * them: 4 toggles (ATU/VOX/COMP/MON) + 1 TUNE button + 8 level inputs
+ * (rfPower/micGain/driveGain/voxGain/antiVoxGain/voxDelay/compressorLevel/
+ * monitorLevel) = 13, every one present-and-disabled
+ * (`TxAuxSurface.svelte`'s `TX_AUX_TOGGLES`/`TX_AUX_LEVELS`). Measured via
+ * `fixtures/capture.mjs`, not assumed — see the MOR-1355 build report.
+ */
+const TX_AUX_ZONELESS_CONTROLS = 13;
 
 /** Shared shape of every healthy `2/main_sub` fixture — only TX state varies. */
 const mainSubExpect = (over: Partial<Expectation> = {}): Expectation => ({
@@ -441,7 +469,11 @@ const CORE_FIXTURES: readonly Fixture[] = [
       tiles: 2, selectsEnabled: 1, selectsDisabled: 0,
       radioWideSwitchesDisabled: false, keyDisabled: false,
       rfLabel: 'RX', sessionLabel: 'ready',
-      faultResetPresent: false, modInputWarningPresent: false, zonelessControls: 0,
+      faultResetPresent: false, modInputWarningPresent: false,
+      // MOR-1355: `abSharedCaps` inherits `baseCaps`'s txAux evidence and this
+      // fixture supplies no plan (`planned` unset), so TxAuxSurface's 13
+      // controls land NO-ZONE.
+      zonelessControls: TX_AUX_ZONELESS_CONTROLS,
     },
   },
   {
@@ -490,7 +522,9 @@ const CORE_FIXTURES: readonly Fixture[] = [
       tiles: 2, selectsEnabled: 1, selectsDisabled: 0,
       radioWideSwitchesDisabled: false, keyDisabled: false,
       rfLabel: 'RX', sessionLabel: 'ready',
-      faultResetPresent: false, modInputWarningPresent: false, zonelessControls: 0,
+      faultResetPresent: false, modInputWarningPresent: false,
+      // MOR-1355: same reasoning as `topology-2-ab-shared` above.
+      zonelessControls: TX_AUX_ZONELESS_CONTROLS,
     },
   },
   {
@@ -516,6 +550,10 @@ const CORE_FIXTURES: readonly Fixture[] = [
         audioFftScope: { structural: false, operational: false },
       },
       rxAudioSurfacePresent: false,
+      // MOR-1355: `mainSubCaps` (= `baseCaps`) now carries txAux evidence and
+      // this fixture supplies no plan — see `topology-2-main-sub--planned`
+      // below for the plan-ful twin where this is honestly 0.
+      zonelessControls: TX_AUX_ZONELESS_CONTROLS,
     }),
   },
   {
@@ -533,13 +571,19 @@ const CORE_FIXTURES: readonly Fixture[] = [
         audioFftScope: { structural: true, operational: true },
       },
       rxAudioSurfacePresent: false,
+      // MOR-1355: `audioOnlyScopeCaps` inherits `baseCaps`'s txAux evidence
+      // and this fixture supplies no plan.
+      zonelessControls: TX_AUX_ZONELESS_CONTROLS,
     }),
   },
   {
     id: 'sub-unobserved',
     what: 'startup window: SUB never observed — strip present, one explicit unknown slot, select disabled.',
     state: mainSubSubUnobserved, caps: mainSubCaps, tx: tx({}),
-    expect: mainSubExpect({ tiles: 3, selectsEnabled: 1, selectsDisabled: 1 }),
+    // MOR-1355: `mainSubCaps` carries txAux evidence, no plan supplied.
+    expect: mainSubExpect({
+      tiles: 3, selectsEnabled: 1, selectsDisabled: 1, zonelessControls: TX_AUX_ZONELESS_CONTROLS,
+    }),
   },
   {
     id: 'dual-rx-unavailable',
@@ -553,7 +597,8 @@ const CORE_FIXTURES: readonly Fixture[] = [
     id: 'tx-phase-rx',
     what: 'TX idle — RF receiving, session ready, key enabled, unkey ungated.',
     state: () => withMeters(mainSubState('MAIN')), caps: mainSubCaps, tx: tx({}),
-    expect: mainSubExpect(),
+    // MOR-1355: `mainSubCaps` carries txAux evidence, no plan supplied.
+    expect: mainSubExpect({ zonelessControls: TX_AUX_ZONELESS_CONTROLS }),
   },
   {
     id: 'tx-phase-pending',
@@ -563,7 +608,11 @@ const CORE_FIXTURES: readonly Fixture[] = [
       phase: 'key-confirm-pending', intent: 'latched', guard: { leaseId: 'L1' },
       radioTx: 'off', txRisk: 'uncertain', mayOwnKey: true,
     }),
-    expect: mainSubExpect({ keyDisabled: true, rfLabel: 'TX?', sessionLabel: 'keying' }),
+    // MOR-1355: `mainSubCaps` carries txAux evidence, no plan supplied.
+    expect: mainSubExpect({
+      keyDisabled: true, rfLabel: 'TX?', sessionLabel: 'keying',
+      zonelessControls: TX_AUX_ZONELESS_CONTROLS,
+    }),
   },
   {
     id: 'tx-phase-tx',
@@ -573,34 +622,46 @@ const CORE_FIXTURES: readonly Fixture[] = [
       phase: 'active', intent: 'latched', guard: { leaseId: 'L1' },
       radioTx: 'on', txRisk: 'confirmed-on', mayOwnKey: true,
     }),
-    expect: mainSubExpect({ keyDisabled: true, rfLabel: 'TX', sessionLabel: 'key down' }),
+    // MOR-1355: `mainSubCaps` carries txAux evidence, no plan supplied.
+    expect: mainSubExpect({
+      keyDisabled: true, rfLabel: 'TX', sessionLabel: 'key down',
+      zonelessControls: TX_AUX_ZONELESS_CONTROLS,
+    }),
   },
   {
     id: 'tx-phase-fault',
     what: 'TX fault — session fault, fault line shown, the App-owned fault reset affordance renders.',
     state: () => withMeters(mainSubState('MAIN')), caps: mainSubCaps,
     tx: tx({ phase: 'failed', radioTx: 'unknown', txRisk: 'uncertain', fault: 'audio-failed' }),
+    // MOR-1355: `mainSubCaps` carries txAux evidence, no plan supplied.
     expect: mainSubExpect({
       keyDisabled: true, rfLabel: 'TX?', sessionLabel: 'fault',
-      faultResetPresent: true, zonelessControls: 0,
+      faultResetPresent: true, zonelessControls: TX_AUX_ZONELESS_CONTROLS,
     }),
   },
   {
     id: 'connection-loss-stale',
     what: 'radio link lost, values retained but every field STALE — every fact degrades to unknown.',
     state: () => mainSubState('MAIN', stale), caps: mainSubCaps, tx: tx({}),
+    // MOR-1355: `mainSubCaps` carries txAux evidence, no plan supplied.
     expect: mainSubExpect({
       stripActive: [false, false], selectsEnabled: 4, selectsDisabled: 0,
       radioWideSwitchesDisabled: true, keyDisabled: true,
+      zonelessControls: TX_AUX_ZONELESS_CONTROLS,
     }),
   },
   {
     id: 'connection-loss-state-null',
     what: 'reconnect window — capabilities known, no state payload at all; everything present and inert.',
     state: () => null, caps: mainSubCaps, tx: tx({}),
+    // MOR-1355: `toRadioViewModel` gates only on `caps` being non-null
+    // (`radio-view-model-adapter.ts:1195`), so `mainSubCaps`'s txAux evidence
+    // still emits the group here even though `state` is null — no plan
+    // supplied, so still NO-ZONE.
     expect: mainSubExpect({
       stripActive: [false, false], tiles: 2, selectsEnabled: 0, selectsDisabled: 2,
       radioWideSwitchesDisabled: true, keyDisabled: true,
+      zonelessControls: TX_AUX_ZONELESS_CONTROLS,
     }),
   },
   {
@@ -631,9 +692,14 @@ const CORE_FIXTURES: readonly Fixture[] = [
     state: () => mainSubState('MAIN'), caps: mainSubCaps,
     tx: tx({ phase: 'failed', radioTx: 'unknown', txRisk: 'uncertain', fault: 'audio-failed' }),
     modGuard: { visible: true, sourceLabel: 'MIC' },
+    // MOR-1355: `mainSubCaps` carries txAux evidence, no plan supplied — the
+    // acceptance gate this fixture proves (the three TX-adjacent alerts are
+    // inside `rx-tx`, never zone-less) is UNCHANGED; the 13 txAux controls
+    // are a separate, honestly-disclosed zone-less class alongside it.
     expect: mainSubExpect({
       keyDisabled: true, rfLabel: 'TX?', sessionLabel: 'fault',
-      faultResetPresent: true, modInputWarningPresent: true, zonelessControls: 0,
+      faultResetPresent: true, modInputWarningPresent: true,
+      zonelessControls: TX_AUX_ZONELESS_CONTROLS,
     }),
   },
 ];
@@ -712,16 +778,68 @@ function toReferenceFixture(f: Fixture): Fixture {
 }
 
 /**
+ * MOR-1355 — the harness's first PLAN-FUL topology. `planned: true` makes
+ * `fixtures/main.ts` mount this fixture with a REAL
+ * `resolveSurfacePlan(dualReceiverCockpitLayout, …)` plan (default
+ * workspace — no operator preference), the same recipe
+ * `DualReceiverCockpit.component.test.ts`'s `render(defaultPlan())` proves.
+ * Same radio as `topology-2-main-sub` (state/caps/tx all byte-identical) so
+ * the ONLY variable is plan-ful vs plan-less — a controlled pair, not a new
+ * radio shape.
+ *
+ * Kept OUT of `CORE_FIXTURES` (and so out of `toReferenceFixture`'s
+ * `--reference` derivation) deliberately: a `--reference` twin would mount
+ * `ReferenceLayout`/`desktop-v2`'s wiring, whose manifest
+ * (`desktopV2Layout`) declares a DIFFERENT zone set (`receiver-deck`,
+ * `meters`, `scope-display`, `filter`, `rf-front-end` in addition to
+ * `tx-aux`) — plumbing that through is real, separately-scoped work
+ * (`main.ts` only resolves `dualReceiverCockpitLayout` today), not implied
+ * by this one topology. Left as a named follow-up in the build report
+ * rather than silently mounted plan-less under a `--planned` name that
+ * would claim more than it does.
+ *
+ * `zones` gains `tx-aux` (`DUAL_ZONES_PLANNED`) — the manifest's declared
+ * zone the resolved plan actually binds — and `zonelessControls: 0` is now
+ * HONEST: the same 13 `TxAuxSurface` controls every plan-less `main_sub`
+ * fixture above counts as NO-ZONE land inside `data-zone-id="tx-aux"` here.
+ * `assertions.ts`'s `focus-order-is-zone-order` proves the ordering claim:
+ * the zoned index sequence must still end at the LAST declared zone, which
+ * is `tx-aux` now, not `rx-tx` — MOR-1344's zone-INDEPENDENT
+ * `logical-focus-order-vfo-precedes-rx-tx-authority` is untouched by any of
+ * this (it never reads `data-zone-id` at all), so both the zone-aware and
+ * zone-free tab-order invariants are exercised on the SAME capture.
+ */
+const PLANNED_FIXTURES: readonly Fixture[] = [
+  {
+    id: 'topology-2-main-sub--planned',
+    what: '2/main_sub with a REAL resolved SurfacePlan (dualReceiverCockpitLayout, default '
+      + 'workspace) — tx-aux is genuinely BOUND, not merely declared; zonelessControls is honest 0.',
+    state: () => withMeters(mainSubState('MAIN')), caps: mainSubCaps, tx: tx({}),
+    planned: true,
+    expect: mainSubExpect({
+      zones: DUAL_ZONES_PLANNED,
+      scopeFacts: {
+        hardwareScope: { structural: true, operational: false },
+        audioFftScope: { structural: false, operational: false },
+      },
+      rxAudioSurfacePresent: false,
+    }),
+  },
+];
+
+/**
  * The full MOR-1085 grid: every `CORE_FIXTURES` (dual-receiver-cockpit)
  * entry, plus its reference-layout twin — except `tx-adjacent-alerts`, whose
  * whole point is the cockpit's OWN zone-containment acceptance gate (b) and
  * has no reference-layout equivalent (the reference/single composition has
  * no zone concept for the three alerts to be "inside" or "outside" of; see
- * `zonedComposition` in `assertions.ts`).
+ * `zonedComposition` in `assertions.ts`) — plus MOR-1355's `PLANNED_FIXTURES`
+ * (no reference twin either; see the comment above `PLANNED_FIXTURES`).
  */
 export const FIXTURES: readonly Fixture[] = [
   ...CORE_FIXTURES,
   ...CORE_FIXTURES.filter((f) => f.id !== 'tx-adjacent-alerts').map(toReferenceFixture),
+  ...PLANNED_FIXTURES,
 ];
 
 export const fixtureById = (id: string): Fixture | undefined =>

--- a/frontend/fixtures/main.ts
+++ b/frontend/fixtures/main.ts
@@ -23,6 +23,9 @@
  */
 import { flushSync, mount } from 'svelte';
 import '../src/app.css';
+import { dualReceiverCockpitLayout } from '../src/presentation/layouts/declarations';
+import { readWorkspace } from '../src/presentation/workspace/contract';
+import { resolveSurfacePlan, SURFACE_PLAN_CONTEXT_KEY } from '../src/presentation/workspace/resolution';
 import DualReceiverCockpit from '../src/skins/dual-receiver-cockpit/DualReceiverCockpit.svelte';
 import ReferenceLayout from './ReferenceLayout.svelte';
 import {
@@ -78,9 +81,37 @@ harness.tx = { ...IDLE_TX, ...fixture.tx };
 harness.modGuard = fixture.modGuard ?? { visible: false, sourceLabel: null };
 harness.calls = [];
 
+/**
+ * MOR-1355 — the ONE place this harness can supply a real resolved
+ * `SurfacePlan`, exactly the recipe
+ * `DualReceiverCockpit.component.test.ts`'s `render(plan?)` already proves:
+ * `mount`'s `context` option carries `SURFACE_PLAN_CONTEXT_KEY` down to
+ * `useSurfacePlan()`, so `SemanticRadioSurfaces.svelte`'s `zoneOwning()` stops
+ * being unconditionally null. `fixture.planned` is opt-in and per-fixture —
+ * every fixture that does not set it keeps mounting exactly as before
+ * (`context: undefined`, the pre-MOR-1355 plan-less shape catalog.ts's
+ * `baseCaps` comment still documents), which is deliberate: the ticket's
+ * instruction is to prove the plan-ful path exists, not to make it the only
+ * path — the plan-less captures still model the real gap MOR-1351 found
+ * (`fixtures/main.ts` supplying no plan at all).
+ *
+ * `readWorkspace({ version: 1 }).workspace` is the DEFAULT workspace — no
+ * operator `visibleSurfaces`/`zoneOrder` preference — over the REAL
+ * `dualReceiverCockpitLayout` manifest, i.e. exactly what `App` resolves for
+ * this layout the moment no preference has been saved. This is
+ * production's own default, not a fixture invention.
+ */
+const plan = fixture.planned
+  ? resolveSurfacePlan(dualReceiverCockpitLayout, readWorkspace({ version: 1 }).workspace)
+  : null;
+const context = plan === null
+  ? undefined
+  : new Map<unknown, unknown>([[SURFACE_PLAN_CONTEXT_KEY, () => plan]]);
+
 document.title = `MOR-1070 · ${fixture.id}`;
 mount(fixture.layout === 'reference' ? ReferenceLayout : DualReceiverCockpit, {
   target: document.getElementById('app')!,
+  context,
 });
 flushSync();
 

--- a/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
+++ b/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
@@ -204,7 +204,12 @@ function mainSubState(active: 'MAIN' | 'SUB' = 'MAIN'): ServerState {
  * (`render(defaultPlan())`, used by every MOR-1069 assertion in this file), so
  * `zoneOwning()` is NOT unconditionally null here — the earlier claim that it
  * was (pre-MOR-1351) was wrong for this file; that reasoning only holds for
- * `fixtures/catalog.ts`'s browser harness, which has no plan context at all.
+ * `fixtures/catalog.ts`'s browser harness, which had NO plan context at all
+ * pre-MOR-1355. As of MOR-1355 the browser harness ALSO resolves a plan, but
+ * only for its one `topology-2-main-sub--planned` fixture — every other
+ * `fixtures/catalog.ts` fixture is still plan-less by design (see that
+ * ticket's `main.ts`/`catalog.ts` comments), so the statement still holds for
+ * every capture except that one.
  *
  * MOR-1351: `modes`/`filters` and the rest of the capability tags were an
  * inert placeholder (`[]` / four tags) — the view-model groups those tags


### PR DESCRIPTION
## Summary

MOR-1355: the browser fixture harness gains its first PLAN-FUL topology (topology-2-main-sub--planned, mounted with the real resolveSurfacePlan(dualReceiverCockpitLayout, defaultWorkspace) via mount context) and the five deriveTxAux evidence tags return to baseCaps() (closing the MOR-1351 N1 deferral). 12 plan-less main_sub fixtures re-pinned zonelessControls 0->13 with per-fixture rationale; 6 correctly stay 0; the zone-order terminal assertion generalized from hardcoded rx-tx to last-declared-zone. Matrix 60->61 captures.

Config LOC 59 net (verifier-measured), production LOC 0.

## Review provenance

Verified by the fixtures/evidence opus anchor (session 8): PASS, no code fixes. The re-pin table audited IN FULL (44 cockpit captures, 0 mismatches vs rendered DOM); the terminal-zone generalization probed three ways and ruled NOT a weakening (declaring an unrendered 6th zone fails; zone reordering fails twice; reverting to the hardcoded form is a strict no-op for all 60 pre-existing captures); sabotage blast radius re-measured (plan-drop kills exactly the 3 zone-owned assertions; tag-drop hits 36 captures - 4x the builder's --only-filtered count); the 8C antenna prediction confirmed exactly with causation proven (8 flips, all tag-restoration, none plan-fulness). S8-landing fast-forward tested clean (61/61, zero movement). Suite 5881/5881.

Discharge ruling: MOR-1355 FULLY DISCHARGED - the harness no longer contains a single vacuous zonelessControls pin. The desktop-v2 blindness residual is ticketed separately as a pre-cutover evidence item (MOR-1379), deliberately NOT folded into S12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)