### PR TITLE
feat(MOR-1369): scope-toolbar suppression prop, inert (rework S6b-1)

### DIFF
--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -353,8 +353,14 @@
           <div class="spectrum-frame">
             <!-- Desktop: VfoHeader bridge owns DUAL + MAIN/SUB (#832); hide
                  the toolbar duplicate. Mobile/v1 layouts omit the prop so
-                 the toolbar retains them (#832 fallback). -->
-            <SpectrumPanel hideSourceControls={true} />
+                 the toolbar retains them (#832 fallback).
+                 `hideScopeControls` is the MOR-1369 (S6b-1) suppression
+                 channel: reuses the SAME `declared` set as `LeftSidebar`/
+                 `RightSidebar`/`StatusBar` above (S6-pre, MOR-1364) rather
+                 than a second derivation. Landed INERT — no manifest
+                 declares a `scopeControls` zone yet, so this is always
+                 `false` today; S6b-2 wires the zone that flips it. -->
+            <SpectrumPanel hideSourceControls={true} hideScopeControls={declared.has('scopeControls')} />
           </div>
         </div>
       {/if}

--- a/frontend/src/components-v2/layout/__tests__/RadioLayout.isolated.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/RadioLayout.isolated.test.ts
@@ -111,6 +111,8 @@ import App from '../../../App.svelte';
 import { extractVfoState, extractMeterState, hasLiveAudioFromState } from '../layout-utils';
 import { radio } from '$lib/stores/radio.svelte';
 import { resolveSkinId, type SkinId } from '../../../skins/registry';
+import { registerLayout, type LayoutManifest } from '../../../presentation/layouts/contract';
+import { desktopV2Layout } from '../../../presentation/layouts/declarations';
 
 // ---------------------------------------------------------------------------
 // extractVfoState
@@ -378,6 +380,23 @@ let components: ReturnType<typeof mount>[] = [];
  */
 const UNDECLARED = 'no-such-layout' as SkinId;
 
+/**
+ * MOR-1369 (v3-rework S6b-1) — the `scopeControls` zone S6b-2 will declare
+ * does not exist on `desktop-v2` yet, but the `hideScopeControls` channel
+ * this slice wires must already compute correctly the moment one does.
+ * Spread from the real desktop-v2 manifest, same `probeManifest` recipe as
+ * `semantic-desktop-migration.component.test.ts`'s VFO_ONLY/RX_TX_ONLY
+ * probes (S2/MOR-1313) — differs from the shipped layout in exactly the one
+ * zone under test.
+ */
+const SCOPE_CONTROLS_PROBE = 'scope-controls-probe' as SkinId;
+registerLayout({
+  ...desktopV2Layout,
+  id: SCOPE_CONTROLS_PROBE,
+  displayName: SCOPE_CONTROLS_PROBE,
+  zones: [...desktopV2Layout.zones, { id: 'scope-controls', surfaces: ['scopeControls'] }],
+} satisfies LayoutManifest);
+
 function mountLayout(skinId: SkinId = 'desktop-v2') {
   const t = document.createElement('div');
   document.body.appendChild(t);
@@ -476,6 +495,33 @@ describe('RadioLayout structure', () => {
   it('renders .vfo-header inside .receiver-deck for an undeclared layout', () => {
     const t = mountLayout(UNDECLARED);
     expect(t.querySelector('.receiver-deck .vfo-header')).not.toBeNull();
+  });
+});
+
+// MOR-1369 (v3-rework S6b-1) — the SpectrumPanel `hideScopeControls`
+// suppression channel. `RadioLayout` reuses the SAME `declared` set the
+// MOR-1364 (S6-pre) channel already derives (no second derivation), so this
+// is the pass-through half of that channel, proven at the boundary
+// (`SpectrumPanelStub`'s `data-hide-scope-controls`); the SpectrumToolbar
+// half (which controls are fact-backed vs client-side view options, per the
+// S10 boundary doc) is proven directly in `SpectrumToolbar.component.test.ts`.
+describe('SpectrumPanel hideScopeControls channel (MOR-1369, S6b-1)', () => {
+  it('passes hideScopeControls=false when no manifest declares a scopeControls zone (INERT today)', () => {
+    const t = mountLayout('desktop-v2');
+    const stub = t.querySelector('.spectrum-panel-stub');
+    expect(stub?.getAttribute('data-hide-scope-controls')).toBe('false');
+  });
+
+  it('stays false on an undeclared layout too (fail-safe direction)', () => {
+    const t = mountLayout(UNDECLARED);
+    const stub = t.querySelector('.spectrum-panel-stub');
+    expect(stub?.getAttribute('data-hide-scope-controls')).toBe('false');
+  });
+
+  it('passes hideScopeControls=true the moment a manifest declares a scopeControls zone (S6b-2 flip-test-ready)', () => {
+    const t = mountLayout(SCOPE_CONTROLS_PROBE);
+    const stub = t.querySelector('.spectrum-panel-stub');
+    expect(stub?.getAttribute('data-hide-scope-controls')).toBe('true');
   });
 });
 

--- a/frontend/src/components-v2/layout/__tests__/SpectrumPanelStub.svelte
+++ b/frontend/src/components-v2/layout/__tests__/SpectrumPanelStub.svelte
@@ -1,3 +1,11 @@
-<div class="spectrum-panel spectrum-panel-stub">
+<script lang="ts">
+  // MOR-1369 (S6b-1) — records the `hideScopeControls` prop RadioLayout
+  // passes through, so tests here can assert the channel wiring without
+  // paying for SpectrumPanel's full canvas/runtime mount (that coverage
+  // lives in SpectrumPanel.component.test.ts).
+  let { hideScopeControls = false }: { hideScopeControls?: boolean } = $props();
+</script>
+
+<div class="spectrum-panel spectrum-panel-stub" data-hide-scope-controls={hideScopeControls}>
   Spectrum Stub
 </div>

--- a/frontend/src/components/spectrum/SpectrumPanel.svelte
+++ b/frontend/src/components/spectrum/SpectrumPanel.svelte
@@ -42,7 +42,13 @@
   // bridge, issue #832) can suppress the duplicate in the toolbar. Layouts that
   // do not surface them (v1 desktop/mobile, v2 mobile chip view) omit the prop
   // and keep the controls reachable (#832 mobile/v1 fallback).
-  let { hideSourceControls = false } = $props();
+  //
+  // `hideScopeControls` is forwarded the same way (MOR-1369, v3-rework
+  // S6b-1): it hides the toolbar's fact-backed `scopeControls.*` half once a
+  // layout's manifest declares a `scopeControls` zone (S6b-2). Landed INERT
+  // — no manifest declares that zone yet, so `RadioLayout` always passes
+  // `false` today and this prop is a pure pass-through, no logic of its own.
+  let { hideSourceControls = false, hideScopeControls = false } = $props();
 
   // --- Component state ---
   let scopeConnected = $derived(runtime.scope.hardwareScopeConnected);
@@ -379,7 +385,7 @@
 />
 
 <div class="spectrum-panel" class:fullscreen onwheel={handleWheel}>
-  <SpectrumToolbar bind:enableAvg bind:enablePeakHold bind:brtLevel bind:colorScheme bind:fullscreen bind:showBandPlan bind:hiddenLayers bind:showEiBi {scopeDemandOn} onScopeDemandChange={setScopeDemand} {hideSourceControls} />
+  <SpectrumToolbar bind:enableAvg bind:enablePeakHold bind:brtLevel bind:colorScheme bind:fullscreen bind:showBandPlan bind:hiddenLayers bind:showEiBi {scopeDemandOn} onScopeDemandChange={setScopeDemand} {hideSourceControls} {hideScopeControls} />
   <div class="spectrum-with-scales">
     <div class="db-scale">
       {#each DB_TICKS as tick}

--- a/frontend/src/components/spectrum/SpectrumToolbar.svelte
+++ b/frontend/src/components/spectrum/SpectrumToolbar.svelte
@@ -37,6 +37,35 @@
      * leave this `false` so the scope source remains reachable (#832 follow-up).
      */
     hideSourceControls = false,
+    /**
+     * MOR-1369 (v3-rework S6b-1) — hides the FACT-BACKED half of this
+     * toolbar: the scope MODE/EDGE buttons, the SPAN/SPEED/HOLD/REF/DUAL/
+     * receiver controls, and the settings-gear popover (the four
+     * `ScopeSettingsPopover` leaves — centerType/rbw/duringTx/vbwNarrow).
+     * Every one of those reads a `scopeControls.*` field the backend gives a
+     * field-status entry for (the MOR-1311 `ScopeControlsSurface`
+     * vocabulary). Set by a layout whose manifest declares a `scopeControls`
+     * zone (S6b-2) — the semantic surface then owns that half.
+     *
+     * The client-side VIEW OPTIONS below — AVG/PEAK, BRT, color scheme,
+     * fullscreen, BANDS/layers, EiBi — have no wire field and no
+     * field-status entry (they configure the browser session, not the
+     * radio). Per the S10 boundary ruling
+     * (docs/plans/2026-08-06-settings-modal-boundary.md, category (b) — the
+     * same category as `LANGUAGE`/`WORKSPACE`), they stay legacy and are
+     * NEVER gated on this prop, in either direction. `VIEW ON/OFF`
+     * (`scopeDemandOn`) is client-side scope-streaming demand, not a
+     * `scopeControls.*` field either, and also stays unconditional.
+     *
+     * Landed INERT (MOR-1369, S6b-1): no manifest declares a `scopeControls`
+     * zone yet, so this defaults `false` and nothing renders differently.
+     * Safe only because an omitting caller keeps the prop `false` — the same
+     * shape as `hideSourceControls` above and the MOR-1364 `hideTxPanel`/
+     * `declared` channel (S5-N3: safe because the surface degrades to a bare
+     * render when unzoned, a guarantee that lives in
+     * `SemanticRadioSurfaces.svelte`, not here).
+     */
+    hideScopeControls = false,
   } = $props();
 
   let showSettings = $state(false);
@@ -181,36 +210,39 @@
         onclick={() => onScopeDemandChange(!scopeDemandOn)}
         title="Request scope viewer data"
       >VIEW {scopeDemandOn ? 'ON' : 'OFF'}</button>
-      <div class="toolbar-sub-separator"></div>
-      <div class="toolbar-group">
-        {#each MODE_BUTTONS as [m, label]}
-          <button
-            class="toolbar-btn small"
-            class:active={scopeModeAvailable && scopeControls?.mode === m}
-            disabled={!scopeModeAvailable}
-            onclick={() => sendCommand('set_scope_mode', { mode: m })}
-            title="Scope mode: {label}"
-          >{label}</button>
-        {/each}
-      </div>
-      {#if edgeApplicable}
+      {#if !hideScopeControls}
         <div class="toolbar-sub-separator"></div>
         <div class="toolbar-group">
-          <span class="toolbar-label">EDGE</span>
-          {#each [1, 2, 3, 4] as e}
+          {#each MODE_BUTTONS as [m, label]}
             <button
               class="toolbar-btn small"
-              class:active={scopeEdgeAvailable && scopeControls?.edge === e}
-              disabled={!scopeEdgeAvailable}
-              onclick={() => sendCommand('set_scope_edge', { edge: e })}
-            >{e}</button>
+              class:active={scopeModeAvailable && scopeControls?.mode === m}
+              disabled={!scopeModeAvailable}
+              onclick={() => sendCommand('set_scope_mode', { mode: m })}
+              title="Scope mode: {label}"
+            >{label}</button>
           {/each}
         </div>
+        {#if edgeApplicable}
+          <div class="toolbar-sub-separator"></div>
+          <div class="toolbar-group">
+            <span class="toolbar-label">EDGE</span>
+            {#each [1, 2, 3, 4] as e}
+              <button
+                class="toolbar-btn small"
+                class:active={scopeEdgeAvailable && scopeControls?.edge === e}
+                disabled={!scopeEdgeAvailable}
+                onclick={() => sendCommand('set_scope_edge', { edge: e })}
+              >{e}</button>
+            {/each}
+          </div>
+        {/if}
       {/if}
     </div>
-    <div class="toolbar-separator"></div>
-    <!-- Group C: Scope data (cyan wash) -->
-    <div class="toolbar-group-c">
+    {#if !hideScopeControls}
+      <div class="toolbar-separator"></div>
+      <!-- Group C: Scope data (cyan wash) -->
+      <div class="toolbar-group-c">
       {#if spanApplicable}
         <div class="toolbar-group step-group">
           <button class="toolbar-btn small step-arrow" disabled={!scopeSpanAvailable} onclick={() => cycleSpan(-1)} title="Decrease span">◀</button>
@@ -251,6 +283,7 @@
         </div>
       {/if}
     </div>
+    {/if}
   {/if}
   <div class="toolbar-separator"></div>
   <!-- Group D: Display (neutral wash) -->
@@ -287,7 +320,7 @@
             <button class="gear-btn" onclick={() => (brtLevel = clampBrt(brtLevel, 5))} aria-label="Increase brightness">+</button>
             <button class="gear-btn gear-btn-zero" onclick={() => (brtLevel = 0)} aria-label="Reset brightness">0</button>
           </div>
-          {#if hasCapability('scope')}
+          {#if hasCapability('scope') && !hideScopeControls}
             <div class="gear-row">
               <span class="gear-label">REF</span>
               <button class="gear-btn" disabled={!scopeRefAvailable} onclick={() => sendCommand('set_scope_ref', { ref: clampRef(scopeControls?.refDb ?? 0, -5) })} aria-label="Decrease reference">−</button>
@@ -357,7 +390,7 @@
     {/if}
     </div>
   </div>
-  {#if hasCapability('scope')}
+  {#if hasCapability('scope') && !hideScopeControls}
     <div class="toolbar-separator"></div>
     <!-- Group E: Settings (no wash) -->
     <div class="toolbar-group settings-group">

--- a/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
+++ b/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
@@ -202,10 +202,10 @@ import statusBarSource from '../../../components-v2/layout/StatusBar.svelte?raw'
 
 let components: ReturnType<typeof mount>[] = [];
 
-function mountPanel() {
+function mountPanel(props: Record<string, unknown> = {}) {
   const target = document.createElement('div');
   document.body.appendChild(target);
-  const component = mount(SpectrumPanel, { target, props: {} });
+  const component = mount(SpectrumPanel, { target, props });
   flushSync();
   components.push(component);
   return target;
@@ -432,6 +432,30 @@ describe('SpectrumPanel component', () => {
     expect(spectrumPanelSource).toContain('runtime.scope.subscribeHardware');
     expect(spectrumPanelSource).toContain('runtime.subscribeDx');
     expect(spectrumPanelSource).toContain('runtime.send');
+  });
+});
+
+// MOR-1369 (v3-rework S6b-1) — `hideScopeControls` is a pure pass-through to
+// the real (unmocked) SpectrumToolbar; no logic of its own lives here. One
+// direct DOM check per direction is enough to prove the wire is connected —
+// SpectrumToolbar.component.test.ts owns the exhaustive fact-backed/
+// view-option split.
+describe('SpectrumPanel hideScopeControls pass-through (MOR-1369, S6b-1)', () => {
+  it('omitting the prop keeps the toolbar fact-backed half reachable (default false)', () => {
+    const target = mountPanel();
+    const holdBtn = Array.from(target.querySelectorAll<HTMLButtonElement>('.toolbar-btn'))
+      .find((b) => b.textContent?.trim() === 'HOLD');
+    expect(holdBtn).toBeDefined();
+  });
+
+  it('forwards hideScopeControls=true to SpectrumToolbar, hiding the fact-backed half', () => {
+    const target = mountPanel({ hideScopeControls: true });
+    const buttons = Array.from(target.querySelectorAll<HTMLButtonElement>('.toolbar-btn'));
+    const labels = buttons.map((b) => b.textContent?.trim());
+    expect(labels).not.toContain('HOLD');
+    // the view-options half is unaffected by the forwarded prop
+    expect(labels).toContain('AVG');
+    expect(labels).toContain('PEAK');
   });
 });
 

--- a/frontend/src/components/spectrum/__tests__/SpectrumToolbar.component.test.ts
+++ b/frontend/src/components/spectrum/__tests__/SpectrumToolbar.component.test.ts
@@ -317,3 +317,90 @@ describe('SpectrumToolbar component', () => {
     expect(target.querySelector('.spectrum-toolbar')).toBeNull();
   });
 });
+
+// ── MOR-1369 (v3-rework S6b-1): scopeControls suppression channel ──────────
+//
+// The S10 boundary doc (docs/plans/2026-08-06-settings-modal-boundary.md)
+// rules the `scopeControls` vocabulary FACTS-only: the twelve
+// `scopeControls.*` leaves (mode/edge/span/speed/hold/refDb/dual/receiver +
+// the four ScopeSettingsPopover leaves — centerType/rbw/duringTx/vbwNarrow)
+// retire behind `hideScopeControls` once a manifest declares the zone
+// (S6b-2). The client-side VIEW OPTIONS (AVG/PEAK/BRT/color scheme/
+// fullscreen/BANDS/layers/EiBi) have no wire field and are NEVER gated on
+// this prop, in either direction — category (b), the same category as
+// LANGUAGE/WORKSPACE in the settings modal. `VIEW ON/OFF` (scope-streaming
+// demand) is client-side too and stays unconditional alongside them.
+describe('hideScopeControls channel (MOR-1369, S6b-1)', () => {
+  /** Tag + trimmed text + disabled-state signature of every focusable
+   *  element, in DOM order — the light-weight, single-component form of the
+   *  S6-pre/MOR-1364 element-stream capture method (full-app captures belong
+   *  to RadioLayout-level tests; this one only needs to prove ONE
+   *  component's stream is unchanged). */
+  function signature(root: HTMLElement): string {
+    return Array.from(root.querySelectorAll('button, select, input, [tabindex]'))
+      .map((el) => {
+        const disabled = (el as HTMLButtonElement).disabled ? '1' : '0';
+        return `${el.tagName}:${el.textContent?.trim() ?? ''}:${disabled}`;
+      })
+      .join('|');
+  }
+
+  it('renders an IDENTICAL control stream whether hideScopeControls is omitted or explicitly false (inertness proof)', () => {
+    const omitted = mountToolbar();
+    const omittedSig = signature(omitted);
+    unmount(components.pop()!);
+    document.body.innerHTML = '';
+
+    const explicit = mountToolbar({ hideScopeControls: false });
+    const explicitSig = signature(explicit);
+
+    expect(explicitSig).toBe(omittedSig);
+    expect(explicitSig.length).toBeGreaterThan(0);
+  });
+
+  it('hides exactly the fact-backed scopeControls half when hideScopeControls is true (S6b-2 flip-test-ready)', () => {
+    const target = mountToolbar({ hideScopeControls: true });
+    const buttons = Array.from(target.querySelectorAll<HTMLButtonElement>('.toolbar-btn'));
+    const labels = buttons.map((b) => b.textContent?.trim());
+
+    // mode buttons (scopeControls.mode)
+    expect(labels).not.toContain('CTR');
+    expect(labels).not.toContain('FIX');
+    expect(labels).not.toContain('S-C');
+    expect(labels).not.toContain('S-F');
+    // hold (scopeControls.hold)
+    expect(labels).not.toContain('HOLD');
+    // dual + receiver-switch (scopeControls.dual / scopeControls.receiver)
+    expect(labels).not.toContain('DUAL');
+    expect(labels).not.toContain('MAIN');
+    // span/speed/ref (scopeControls.span/.speed/.refDb) — the whole group
+    expect(target.querySelector('.toolbar-group-c')).toBeNull();
+    const spanLabel = Array.from(target.querySelectorAll('.toolbar-label'))
+      .find((el) => el.textContent?.trim() === 'SPAN');
+    expect(spanLabel).toBeUndefined();
+    // settings-gear popover (centerType/rbw/duringTx/vbwNarrow, MOR-1330)
+    expect(target.querySelector('.settings-group')).toBeNull();
+  });
+
+  it('NEVER gates the client-side view-options half, even when hideScopeControls is true (S10 category (b) — the never-gated pin)', () => {
+    const target = mountToolbar({ hideScopeControls: true });
+    const buttons = Array.from(target.querySelectorAll<HTMLButtonElement>('.toolbar-btn'));
+    const labels = buttons.map((b) => b.textContent?.trim());
+
+    expect(labels).toContain('AVG');
+    expect(labels).toContain('PEAK');
+    expect(labels).toContain('BANDS');
+    expect(labels.some((l) => l?.startsWith('VIEW'))).toBe(true); // scope-demand toggle
+    expect(target.querySelector('.icon-btn')).not.toBeNull(); // fullscreen
+    expect(target.querySelector('.toolbar-select')).not.toBeNull(); // color scheme
+    const brtLabel = Array.from(target.querySelectorAll('.toolbar-label'))
+      .find((el) => el.textContent?.trim() === 'BRT');
+    expect(brtLabel).toBeDefined();
+  });
+
+  it('renders the fact-backed half unchanged when hideScopeControls is false (control-stream parity)', () => {
+    const withFalse = mountToolbar({ hideScopeControls: false });
+    const withoutProp = mountToolbar();
+    expect(signature(withFalse)).toBe(signature(withoutProp));
+  });
+});


### PR DESCRIPTION
## Summary

S6b-1 (MOR-1263 tail): the hideScopeControls suppression prop plumbed through SpectrumToolbar/SpectrumPanel/RadioLayout, gating exactly the 12 fact-backed scopeControls leaves (toolbar 8 + settings-popover 4) while the 8 client-side view options plus STEP and VIEW ON/OFF are never gated in either direction - the mobile gear popover correctly split down the middle (BRT free, REF gated). Driven by declared.has('scopeControls') from the S6-pre channel - always false today, INERT (proven by element-stream capture: 107 nodes byte-identical). S6b-2 (the zone declaration) is now a 2-file slice.

Production LOC 5 (verifier-measured with whitespace-normalized method - nesting re-indents ~19 lines a naive differ would miscount).

## Review provenance

Verified by the rework-domain opus anchor #3 (session 8): PASS, no required fixes. The half-split re-derived from source with a brace-tracking parser, not checked against the table - all 12 fact-backed leaves gated, nothing else; fixedEdge in neither half (MOR-1354). Both gate directions pinned (leak probe 2 RED, un-gate probe 1 RED); the anchor's note that the never-gated pin is a REMOVAL pin (reads textContent, hidden= would slip) recorded. STEP reclassified by anchor ruling: a genuine radio fact with its own tuning_step capability tag, unmodelled by any surface - same class as memory in the S9 ledger, not a view option (matters for S12). Inertness proved by the anchor's own capture. Post-S9 rebase clean (0 conflicts); probes re-red on the merged tree. Suite 5937/5937.

🤖 Generated with [Claude Code](https://claude.com/claude-code)