### PR TITLE
feat(MOR-1370): scopeControls zone ownership on desktop-v2 (rework S6b-2) - MOR-1317 ledger empty

### DIFF
--- a/frontend/src/components-v2/layout/__tests__/RadioLayout.isolated.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/RadioLayout.isolated.test.ts
@@ -111,8 +111,6 @@ import App from '../../../App.svelte';
 import { extractVfoState, extractMeterState, hasLiveAudioFromState } from '../layout-utils';
 import { radio } from '$lib/stores/radio.svelte';
 import { resolveSkinId, type SkinId } from '../../../skins/registry';
-import { registerLayout, type LayoutManifest } from '../../../presentation/layouts/contract';
-import { desktopV2Layout } from '../../../presentation/layouts/declarations';
 
 // ---------------------------------------------------------------------------
 // extractVfoState
@@ -380,23 +378,6 @@ let components: ReturnType<typeof mount>[] = [];
  */
 const UNDECLARED = 'no-such-layout' as SkinId;
 
-/**
- * MOR-1369 (v3-rework S6b-1) — the `scopeControls` zone S6b-2 will declare
- * does not exist on `desktop-v2` yet, but the `hideScopeControls` channel
- * this slice wires must already compute correctly the moment one does.
- * Spread from the real desktop-v2 manifest, same `probeManifest` recipe as
- * `semantic-desktop-migration.component.test.ts`'s VFO_ONLY/RX_TX_ONLY
- * probes (S2/MOR-1313) — differs from the shipped layout in exactly the one
- * zone under test.
- */
-const SCOPE_CONTROLS_PROBE = 'scope-controls-probe' as SkinId;
-registerLayout({
-  ...desktopV2Layout,
-  id: SCOPE_CONTROLS_PROBE,
-  displayName: SCOPE_CONTROLS_PROBE,
-  zones: [...desktopV2Layout.zones, { id: 'scope-controls', surfaces: ['scopeControls'] }],
-} satisfies LayoutManifest);
-
 function mountLayout(skinId: SkinId = 'desktop-v2') {
   const t = document.createElement('div');
   document.body.appendChild(t);
@@ -505,23 +486,23 @@ describe('RadioLayout structure', () => {
 // (`SpectrumPanelStub`'s `data-hide-scope-controls`); the SpectrumToolbar
 // half (which controls are fact-backed vs client-side view options, per the
 // S10 boundary doc) is proven directly in `SpectrumToolbar.component.test.ts`.
-describe('SpectrumPanel hideScopeControls channel (MOR-1369, S6b-1)', () => {
-  it('passes hideScopeControls=false when no manifest declares a scopeControls zone (INERT today)', () => {
+//
+// MOR-1370 (S6b-2) graduates the flip: `desktop-v2` now REALLY declares a
+// `scope-controls` zone, so the synthetic probe manifest this describe used
+// to register is retired in favour of the real manifest — the same
+// graduation `semantic-desktop-migration.component.test.ts`'s `ZONES`
+// literal recorded for S7/S8/S9.
+describe('SpectrumPanel hideScopeControls channel (MOR-1369 S6b-1, MOR-1370 S6b-2)', () => {
+  it('passes hideScopeControls=true on real desktop-v2, which declares the scope-controls zone', () => {
     const t = mountLayout('desktop-v2');
     const stub = t.querySelector('.spectrum-panel-stub');
-    expect(stub?.getAttribute('data-hide-scope-controls')).toBe('false');
+    expect(stub?.getAttribute('data-hide-scope-controls')).toBe('true');
   });
 
-  it('stays false on an undeclared layout too (fail-safe direction)', () => {
+  it('stays false on an undeclared layout (fail-safe direction)', () => {
     const t = mountLayout(UNDECLARED);
     const stub = t.querySelector('.spectrum-panel-stub');
     expect(stub?.getAttribute('data-hide-scope-controls')).toBe('false');
-  });
-
-  it('passes hideScopeControls=true the moment a manifest declares a scopeControls zone (S6b-2 flip-test-ready)', () => {
-    const t = mountLayout(SCOPE_CONTROLS_PROBE);
-    const stub = t.querySelector('.spectrum-panel-stub');
-    expect(stub?.getAttribute('data-hide-scope-controls')).toBe('true');
   });
 });
 

--- a/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
@@ -1386,3 +1386,59 @@ describe('band, antenna and ritXitScan are zone-owned on desktop-v2 (MOR-1367, S
     expect(renderAll('desktop-v2').querySelectorAll(KEY_AUTHORITIES).length).toBe(1);
   });
 });
+
+/**
+ * MOR-1370 (v3-rework S6b-2) — `scopeControls` becomes ZONE-OWNED on
+ * `desktop-v2`, the LAST surface in the whole MOR-1262 vocabulary to
+ * graduate; `zone-ownership-coverage.test.ts`'s `RECORDED_REASONS` ledger is
+ * empty after this slice.
+ *
+ * Unlike every other family in this file, its legacy twin is not a
+ * sidebar/modal panel but the scope toolbar's fact-backed half
+ * (`SpectrumToolbar.svelte`, behind the MOR-1369 (S6b-1) `hideScopeControls`
+ * suppression channel — `RadioLayout.svelte` forwards
+ * `declared.has('scopeControls')` straight through to `SpectrumPanel`, which
+ * this file's `SpectrumPanelStub` mock records as `data-hide-scope-controls`).
+ * The toolbar's own leaf-level removal (the twelve `scopeControls.*` fields
+ * gone, the eight client-side view options untouched) is proven directly in
+ * `SpectrumToolbar.component.test.ts`'s S6b-1 pins — not re-proven here.
+ * `ScopeControlsSurface` is control-bearing (MOR-1304 canon) and mounts
+ * single-composition-only, so this describe has no dual-composition half to
+ * prove — that half, plus the zone-binding assertion (S6a's context-injection
+ * recipe), lives in `semantic-scope-controls-wiring.component.test.ts`.
+ *
+ * NON-VACUITY: `deriveScopeControls` gates only on the `scope` capability tag
+ * (`radio-view-model-adapter.ts:963`), which the outer file's default
+ * `capsFor('2/main_sub')` already declares — no special fixture is needed for
+ * the surface itself to fire, unlike S8's band/antenna/ritXitScan gates.
+ */
+describe('scopeControls is zone-owned on desktop-v2, retiring the toolbar fact-backed half (MOR-1370, S6b-2)', () => {
+  // THE CHANNEL, on the real manifest.
+  it('suppresses the fact-backed toolbar half on real desktop-v2', () => {
+    const t = render('desktop-v2');
+    const stub = t.querySelector('.spectrum-panel-stub');
+    expect(stub?.getAttribute('data-hide-scope-controls')).toBe('true');
+  });
+
+  // Mirrors the S6-pre matrix's own inertness half: a layout that declares NO
+  // scope-controls zone leaves the toolbar's fact-backed half on screen —
+  // proves the predicate reads the manifest, not a global flag.
+  it('leaves the toolbar unsuppressed on a layout that declares no scope-controls zone', () => {
+    const t = render(RX_TX_ONLY);
+    const stub = t.querySelector('.spectrum-panel-stub');
+    expect(stub?.getAttribute('data-hide-scope-controls')).toBe('false');
+  });
+
+  // §1.5 / MOR-1339: `compositionSurfaces(plan(desktopV2Layout))` grew by one
+  // more member, and no `{#each singleOrder}` branch was added for it — the
+  // semantic surface must render exactly ONCE. This is the double-presentation
+  // CLOSED assertion for the last family in the vocabulary.
+  it('presents the scopeControls surface exactly ONCE on desktop-v2', () => {
+    expect(render('desktop-v2').querySelectorAll('[data-testid="scope-controls-surface"]').length).toBe(1);
+  });
+
+  // R9: relocating the toolbar's fact-backed half adds no key/unkey authority.
+  it('adds no key authority when the scope-controls zone is declared', () => {
+    expect(render('desktop-v2').querySelectorAll(KEY_AUTHORITIES).length).toBe(1);
+  });
+});

--- a/frontend/src/components-v2/wiring/__tests__/semantic-scope-controls-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-scope-controls-wiring.component.test.ts
@@ -78,6 +78,18 @@ vi.mock('$lib/runtime/adapters/mod-input-tx-guard.svelte', () => ({
 import { sendCommand } from '$lib/transport/ws-client';
 import { resetRadioState, setRadioState } from '$lib/stores/radio.svelte';
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';
+// MOR-1370 (S6b-2): the REAL manifests + the REAL resolution seam, mirroring
+// `semantic-scope-display-wiring.component.test.ts`'s "MOR-1365 (S6a)"
+// section — the only way to prove the `scope-controls` zone binding and the
+// S5/S6-pre subtraction asymmetry, since `useSurfacePlan()` falls back to
+// `NO_PLAN` on a standalone mount.
+import {
+  desktopV2Layout, dualReceiverCockpitLayout,
+} from '../../../presentation/layouts/declarations';
+import { readWorkspace } from '../../../presentation/workspace/contract';
+import {
+  resolveSurfacePlan, SURFACE_PLAN_CONTEXT_KEY, type SurfacePlan,
+} from '../../../presentation/workspace/resolution';
 
 const IDLE: Snapshot = {
   phase: 'idle', intent: null, guard: null, radioTx: 'off', txRisk: 'none',
@@ -131,10 +143,13 @@ const NO_SCOPE_TAGS = ['tx'] as const;
 let target: HTMLDivElement;
 let component: ReturnType<typeof mount> | null = null;
 
-function render(props: { strips?: 'single' | 'dual' } = {}): void {
+function render(props: { strips?: 'single' | 'dual' } = {}, plan?: SurfacePlan): void {
   target = document.createElement('div');
   document.body.appendChild(target);
-  component = mount(SemanticRadioSurfaces, { target, props });
+  const context = plan === undefined
+    ? undefined
+    : new Map<unknown, unknown>([[SURFACE_PLAN_CONTEXT_KEY, () => plan]]);
+  component = mount(SemanticRadioSurfaces, { target, props, context });
   flushSync();
 }
 
@@ -285,5 +300,69 @@ describe('the surface mounts only in the single composition, never in dual', () 
     const outside = [...target.querySelectorAll<HTMLElement>('button, input, select, [tabindex]')]
       .filter((node) => node.closest('[data-zone-id]') === null);
     expect(outside).toEqual([]);
+  });
+});
+
+/* ── (d) MOR-1370 (S6b-2) — desktop-v2 REALLY declares the zone; the ──────
+   ── cockpit still mounts nothing (canon option (ii), single-only) ────── */
+
+/**
+ * `desktopV2Layout` now carries a `scope-controls` zone
+ * (`presentation/layouts/desktop-declarations.ts`). Unlike `scopeDisplay`
+ * (pure readout, bare in both compositions), `scopeControls` is
+ * control-bearing and mounts SINGLE-COMPOSITION-ONLY under the MOR-1304
+ * canon — so there is no dual-composition half of this claim to make; (b)
+ * above already proves the dual composition mounts nothing regardless of the
+ * plan. What this section adds, using the REAL manifest + the REAL
+ * `resolveSurfacePlan` seam (`semantic-scope-display-wiring.component
+ * .test.ts`'s "MOR-1365 (S6a)" shape):
+ *
+ *   (a) the zone binds — `zoneOwning('scopeControls')` now answers
+ *       `'scope-controls'` against desktop-v2's real plan, so the composed
+ *       tree wraps the surface in `<div data-zone-id="scope-controls">`;
+ *   (b) the S5/S6-pre asymmetry: a workspace that SUBTRACTS `scopeControls`
+ *       from that zone costs the operator the wrapper `<div>`, never the
+ *       controls — `zoned()` degrades to bare (S5-N3), so "the workspace hid
+ *       it" and "no zone declares it" are indistinguishable and both render
+ *       the pre-1370 bare element shape. MUTATION PROBE: remove the
+ *       `zoned(...)` mount from `scopeControlsSurface`'s call site and BOTH
+ *       tests below go red — (a) loses the wrapper, (b) loses the surface
+ *       entirely;
+ *   (c) the dual-receiver cockpit manifest is untouched by this slice, so the
+ *       surface keeps mounting NOTHING there — MOR-1069 unmoved, and this is
+ *       the one direction where "declared" and "undeclared" agree (both
+ *       absent), which is exactly what canon option (ii) requires: declaring
+ *       a zone on `desktop-v2` must never put a control into the cockpit.
+ */
+describe('desktop-v2 declares a REAL scope-controls zone; the cockpit mounts nothing (MOR-1370, S6b-2)', () => {
+  /** What App resolves for `layout` given a stored workspace `fields`. */
+  function planFor(layout: typeof desktopV2Layout, fields: Record<string, unknown>): SurfacePlan {
+    return resolveSurfacePlan(layout, readWorkspace({ version: 1, ...fields }).workspace);
+  }
+
+  it('binds the scope-controls zone id against desktop-v2\'s real plan', () => {
+    render({ strips: 'single' }, planFor(desktopV2Layout, {}));
+    expect(el('scope-controls-surface')!.closest('[data-zone-id="scope-controls"]')).not.toBeNull();
+  });
+
+  // THE ASYMMETRY (S5 shape): a workspace subtraction costs the wrapper, not
+  // the controls. MUTATION PROBE: reading the PLAN instead of the MANIFEST
+  // for suppression anywhere in this channel would make this subtraction
+  // able to resurrect the legacy toolbar half — this test only proves the
+  // surface side (the legacy-twin side is `semantic-desktop-migration
+  // .component.test.ts`'s job), but it is the half that shows the controls
+  // themselves never disappear.
+  it('degrades to a bare surface — never disappears — when the workspace subtracts scopeControls from its zone', () => {
+    render({ strips: 'single' }, planFor(desktopV2Layout, {
+      visibleSurfaces: { 'scope-controls': [] },
+    }));
+    const surface = el('scope-controls-surface')!;
+    expect(surface).not.toBeNull();
+    expect(surface.closest('[data-zone-id]')).toBeNull();
+  });
+
+  it('still mounts nothing in the dual-receiver cockpit — its manifest is untouched by this slice', () => {
+    render({ strips: 'dual' }, planFor(dualReceiverCockpitLayout, {}));
+    expect(el('scope-controls-surface')).toBeNull();
   });
 });

--- a/frontend/src/presentation/layouts/__tests__/desktop-v2-registration.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/desktop-v2-registration.test.ts
@@ -58,7 +58,7 @@ describe('declared zones now drive the DOM (MOR-1263 step 2, MOR-1313)', () => {
   it('declares receiver-deck:[vfo], rx-tx:[rxTx], tx-aux:[txAux], meters:[meters], '
     + 'scope-display:[scopeDisplay], filter:[filter], rf-front-end:[rfFrontEnd], '
     + 'band:[band], antenna:[antenna], rit-xit-scan:[ritXitScan], rx-audio:[rxAudio], '
-    + 'dsp:[dsp] and cw-keyer:[cwKeyer]', () => {
+    + 'dsp:[dsp], cw-keyer:[cwKeyer] and scope-controls:[scopeControls]', () => {
     expect(desktopV2Layout.zones).toEqual([
       { id: 'receiver-deck', surfaces: ['vfo'] },
       { id: 'rx-tx', surfaces: ['rxTx'] },
@@ -85,6 +85,9 @@ describe('declared zones now drive the DOM (MOR-1263 step 2, MOR-1313)', () => {
       { id: 'rx-audio', surfaces: ['rxAudio'] },
       { id: 'dsp', surfaces: ['dsp'] },
       { id: 'cw-keyer', surfaces: ['cwKeyer'] },
+      // MOR-1370 (S6b-2): scopeControls becomes zone-owned, the LAST surface
+      // in the MOR-1262 vocabulary to graduate. Not required.
+      { id: 'scope-controls', surfaces: ['scopeControls'] },
     ]);
     expect([...desktopV2Layout.requiredSemanticSurfaces].sort()).toEqual(['rxTx', 'vfo']);
   });
@@ -106,7 +109,7 @@ describe('declared zones now drive the DOM (MOR-1263 step 2, MOR-1313)', () => {
   // is per-zone rather than per-manifest-first-zone.
   it('its zones flatten to the surfaces the shell suppresses legacy twins for', () => {
     expect([...declaredSurfaces(getLayout('desktop-v2'))].sort())
-      .toEqual(['antenna', 'band', 'cwKeyer', 'dsp', 'filter', 'meters', 'rfFrontEnd', 'ritXitScan', 'rxAudio', 'rxTx', 'scopeDisplay', 'txAux', 'vfo']);
+      .toEqual(['antenna', 'band', 'cwKeyer', 'dsp', 'filter', 'meters', 'rfFrontEnd', 'ritXitScan', 'rxAudio', 'rxTx', 'scopeControls', 'scopeDisplay', 'txAux', 'vfo']);
   });
 });
 

--- a/frontend/src/presentation/layouts/__tests__/scope-controls-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/scope-controls-declarability.test.ts
@@ -1,15 +1,26 @@
 /**
- * MOR-1311 — `scopeControls` is DECLARABLE, and nothing declares it yet.
+ * MOR-1311 — `scopeControls` is DECLARABLE. MOR-1370 (S6b-2) declares it for
+ * real.
  *
  * Slice 11B (the LAST B-slice of the vocabulary program) adds the name to
  * `SEMANTIC_SURFACE_NAMES` so a manifest CAN mount the surface later; it
  * deliberately does not touch any manifest, and it adds no design-language
  * renderer slot (that set was frozen by MOR-1072).
  *
- * Same three pins as `cw-keyer-declarability.test.ts` /
- * `ritxit-scan-declarability.test.ts` / `rx-audio-declarability.test.ts`:
+ * MOR-1370 flips the second half, on `desktop-v2` ONLY: the cockpit manifest
+ * is deliberately untouched (S5 precedent, restated by 12B/MOR-1365 for the
+ * sibling `scopeDisplay` zone), so `scopeControls` stays undeclared — and
+ * therefore unmounted, per the MOR-1304 canon — everywhere else. The
+ * inventory below is a LITERAL of who declares it, mirroring
+ * `scope-display-declarability.test.ts`'s post-S6a shape. This is the LAST
+ * surface in the whole MOR-1262 vocabulary to graduate:
+ * `zone-ownership-coverage.test.ts`'s `RECORDED_REASONS` ledger is empty
+ * after this slice.
+ *
+ * Same three pins as `tx-aux-declarability.test.ts` / `meters-declarability.test.ts`
+ * / `scope-display-declarability.test.ts`:
  *   - drop the name and a future manifest's zone stops validating;
- *   - quietly add a `scopeControls` zone to a shipped manifest and the DOM
+ *   - quietly add a `scopeControls` zone to an unreviewed manifest and the DOM
  *     grows a zone id no layout review ever saw;
  *   - the renderer slot set stays exactly what MOR-1072 froze.
  */
@@ -49,17 +60,46 @@ describe('scopeControls is a declarable semantic surface', () => {
   });
 });
 
-describe('no shipped manifest declares a scopeControls zone in this slice', () => {
-  // Kills: slipping a scopeControls zone into an existing layout here — the
-  // MOR-1069 dual-receiver-cockpit tab-order assertion is written against
-  // the zones it declares today, so declaring one here would put toolbar
-  // controls in the cockpit with no updated sequence pin.
-  it.each([
+describe('exactly the reviewed manifests declare a scopeControls zone (MOR-1370)', () => {
+  /** The literal — extend by hand, with a layout review, never silently. */
+  const DECLARES_SCOPE_CONTROLS = ['desktop-v2'];
+
+  const ALL = [
     ['sdr-test', sdrTestLayout], ['dual-receiver-cockpit', dualReceiverCockpitLayout],
     ['lcd-cockpit', lcdCockpitLayout], ['lcd-scope', lcdScopeLayout],
     ['mobile', mobileLayout], ['desktop-v2', desktopV2Layout],
-  ])('%s declares no scopeControls zone and does not require the surface', (_id, manifest) => {
-    for (const zone of manifest.zones) expect(zone.surfaces).not.toContain('scopeControls');
+  ] as const;
+
+  // Kills BOTH directions: a family losing the zone S6b-2 gave it (the
+  // MOR-1069 dual-receiver-cockpit tab-order assertion is written against
+  // the zones it declares today, so a cockpit gain here would put toolbar
+  // controls in the cockpit with no updated sequence pin), and a family
+  // gaining one without review.
+  it('the declaring set is exactly the reviewed literal', () => {
+    const declaring = ALL
+      .filter(([, m]) => m.zones.some((z) => z.surfaces.includes('scopeControls')))
+      .map(([id]) => id)
+      .sort();
+    expect(declaring).toEqual([...DECLARES_SCOPE_CONTROLS].sort());
+  });
+
+  // Kills: declaring the zone under a drifted id — the wiring binds whatever
+  // the plan's key is, so the id IS the contract with the layout's arrangement.
+  it.each(DECLARES_SCOPE_CONTROLS)(
+    '%s declares it under the stable `scope-controls` id, alone in its zone',
+    (id) => {
+      const manifest = ALL.find(([name]) => name === id)![1];
+      const zone = manifest.zones.find((z) => z.surfaces.includes('scopeControls'))!;
+      expect(zone.id).toBe('scope-controls');
+      expect(zone.surfaces).toEqual(['scopeControls']);
+    },
+  );
+
+  // Kills: making scopeControls REQUIRED. A radio the `scope` evidence gate
+  // declines must still resolve this layout; the surface self-gates on
+  // `view.scopeControls`, and a required surface no zone could fill would be
+  // a resolution failure rather than an honest absence.
+  it.each(ALL)('%s does not require the scopeControls surface', (_id, manifest) => {
     expect(manifest.requiredSemanticSurfaces).not.toContain('scopeControls');
   });
 });

--- a/frontend/src/presentation/layouts/__tests__/zone-ownership-coverage.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/zone-ownership-coverage.test.ts
@@ -5,7 +5,8 @@
  * MOR-1317 is the defect "a surface exists in the vocabulary but nothing
  * decides whether the flagship skin owns it", and the rework tail closes it
  * family by family (S6a scopeDisplay, S7 filter/rfFrontEnd, S8
- * band/antenna/ritXitScan, S9 rxAudio/dsp/cwKeyer). What made it a defect
+ * band/antenna/ritXitScan, S9 rxAudio/dsp/cwKeyer, S6b-2 scopeControls). What
+ * made it a defect
  * rather than a backlog item is that the gap was invisible: a surface could be
  * added to `SEMANTIC_SURFACE_NAMES`, wired, shipped — and double-presented
  * beside its legacy twin forever — without any test noticing that nobody had
@@ -19,8 +20,11 @@
  * whole point. The reason strings are not decoration: they are what the next
  * slice reads instead of guessing.
  *
- * Deliberately NOT a claim that every surface belongs on desktop-v2. Two of
- * the recorded reasons are permanent-by-design; the rest name their slice.
+ * MOR-1370 (S6b-2) declares the `scopeControls` zone — the last excused
+ * surface in the vocabulary — which empties `RECORDED_REASONS` below. THE
+ * LEDGER IS NOW EMPTY: every `SEMANTIC_SURFACE_NAMES` member is zone-owned on
+ * `desktop-v2`, and the partition pin holds with zero excused entries. That is
+ * the intended terminal state, not a gap — MOR-1317 closes program-wide here.
  */
 import { describe, it, expect } from 'vitest';
 import {
@@ -36,17 +40,14 @@ const OWNED = declaredSurfaces(desktopV2Layout);
  * The complement, with the decision that put each name here. A surface leaves
  * this map only by gaining a `desktop-v2` zone in the same commit.
  *
- * `filter`, `rfFrontEnd` (S7), `band`, `antenna`, `ritXitScan` (S8) and
- * `rxAudio`, `dsp`, `cwKeyer` (S9, this slice) have all graduated to real
- * zones on `desktopV2Layout` — `OWNED` now covers them, so an entry here
- * would fail both the partition pin and the overlap pin below. `scopeControls`
- * is the one surface in the whole MOR-1262 vocabulary still excused.
+ * `filter`, `rfFrontEnd` (S7), `band`, `antenna`, `ritXitScan` (S8),
+ * `rxAudio`, `dsp`, `cwKeyer` (S9) and `scopeControls` (S6b-2, this slice)
+ * have all graduated to real zones on `desktopV2Layout` — `OWNED` now covers
+ * every one of them, so an entry here would fail both the partition pin and
+ * the overlap pin below. ALL GRADUATED: the map is empty, which is the
+ * terminal state this ledger exists to reach, not a gap.
  */
-const RECORDED_REASONS: Partial<Record<SemanticSurfaceName, string>> = {
-  scopeControls:
-    'S6b-2. 11B/MOR-1311 built the surface; the scope toolbar it replaces is not on the '
-    + 'MOR-1364 suppression channel yet, so declaring the zone today would double-present it.',
-};
+const RECORDED_REASONS: Partial<Record<SemanticSurfaceName, string>> = {};
 
 describe('MOR-1317 — every semantic surface has a desktop-v2 decision', () => {
   /**

--- a/frontend/src/presentation/layouts/desktop-declarations.ts
+++ b/frontend/src/presentation/layouts/desktop-declarations.ts
@@ -108,6 +108,26 @@ const DESKTOP_V2_ZONES = [
   { id: 'rx-audio', surfaces: ['rxAudio'] },
   { id: 'dsp', surfaces: ['dsp'] },
   { id: 'cw-keyer', surfaces: ['cwKeyer'] },
+  // MOR-1370 (S6b-2): scopeControls becomes zone-OWNED here — the LAST
+  // surface in the whole MOR-1262 vocabulary to graduate. Declaring it
+  // activates the MOR-1369 (S6b-1) suppression channel: `RadioLayout.svelte`
+  // already forwards `hideScopeControls={declared.has('scopeControls')}` to
+  // `SpectrumPanel`, retiring the scope toolbar's twelve fact-backed
+  // `scopeControls.*` leaves (mode/edge/span/speed/hold/refDb/dual/receiver/
+  // duringTx/centerType/vbwNarrow/rbw) while its eight client-side view
+  // options (AVG, PEAK, BRT, color scheme, fullscreen, band plan, layers,
+  // EiBi — S10 category (b), no wire field) keep rendering unconditionally.
+  // `ScopeControlsSurface` is control-bearing (MOR-1304 canon) and mounts
+  // single-composition-only, so the dual-receiver cockpit is untouched by
+  // this declaration.
+  //
+  // This empties `RECORDED_REASONS` in `zone-ownership-coverage.test.ts` —
+  // MOR-1317 closes, program-wide, on this line.
+  //
+  // Not `required`: a radio whose evidence gate declines the `scope`
+  // capability must still resolve this layout, and the surface self-gates on
+  // `view.scopeControls`.
+  { id: 'scope-controls', surfaces: ['scopeControls'] },
 ] as const;
 
 export const desktopV2Layout: LayoutManifest = {

--- a/frontend/src/presentation/workspace/__tests__/preferences-adoption.test.ts
+++ b/frontend/src/presentation/workspace/__tests__/preferences-adoption.test.ts
@@ -265,8 +265,9 @@ describe('MOR-1082 — the single-composition order comes from the same plan', (
     // desktop-v2 spreads the same two surfaces over two zones, plus its own
     // MOR-1336 (S4) tx-aux zone, MOR-1341 (S5) meters zone, MOR-1365 (S6a)
     // scope-display zone, the MOR-1366 (S7) filter/rf-front-end zones, the
-    // three MOR-1367 (S8) zones and the MOR-1368 (S9) rx-audio/dsp/cw-keyer
-    // zones — flattening never drops a later zone.
+    // three MOR-1367 (S8) zones, the MOR-1368 (S9) rx-audio/dsp/cw-keyer
+    // zones and the MOR-1370 (S6b-2) scope-controls zone — flattening never
+    // drops a later zone.
     //
     // §1.5 / MOR-1339 discipline: this list GROWS, but `singleOrder`'s `{#each}`
     // in `SemanticRadioSurfaces.svelte` gains NO branch for any of these
@@ -275,7 +276,7 @@ describe('MOR-1082 — the single-composition order comes from the same plan', (
     // `components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts`
     // is the counterpart that would catch a double mount.
     expect(compositionSurfaces(plan(desktopV2Layout), FALLBACK))
-      .toEqual(['vfo', 'rxTx', 'txAux', 'meters', 'scopeDisplay', 'filter', 'rfFrontEnd', 'band', 'antenna', 'ritXitScan', 'rxAudio', 'dsp', 'cwKeyer']);
+      .toEqual(['vfo', 'rxTx', 'txAux', 'meters', 'scopeDisplay', 'filter', 'rfFrontEnd', 'band', 'antenna', 'ritXitScan', 'rxAudio', 'dsp', 'cwKeyer', 'scopeControls']);
     expect(compositionSurfaces(plan(sdrTestLayout, { zoneOrder: { main: ['rxTx', 'vfo'] } }), FALLBACK))
       .toEqual(['rxTx', 'vfo']);
   });

--- a/frontend/src/presentation/workspace/contract.ts
+++ b/frontend/src/presentation/workspace/contract.ts
@@ -49,7 +49,7 @@ export const WORKSPACE_THEME_IDS = [
 export type WorkspaceThemeId = (typeof WORKSPACE_THEME_IDS)[number];
 
 /** Every zone id declared by a registered layout manifest (decisions 5 and 6). */
-export const WORKSPACE_ZONE_IDS = ['main', 'receiver-deck', 'rx-tx', 'primary-vfo', 'secondary-vfo', 'global', 'portrait-deck', 'control-column', 'tx-aux', 'meters', 'scope-display', 'filter', 'rf-front-end', 'band', 'antenna', 'rit-xit-scan', 'rx-audio', 'dsp', 'cw-keyer'] as const;
+export const WORKSPACE_ZONE_IDS = ['main', 'receiver-deck', 'rx-tx', 'primary-vfo', 'secondary-vfo', 'global', 'portrait-deck', 'control-column', 'tx-aux', 'meters', 'scope-display', 'filter', 'rf-front-end', 'band', 'antenna', 'rit-xit-scan', 'rx-audio', 'dsp', 'cw-keyer', 'scope-controls'] as const;
 export type WorkspaceZoneId = (typeof WORKSPACE_ZONE_IDS)[number];
 
 /** Decision 7: command-bus intent names (`set_compressor`), never module paths. */


### PR DESCRIPTION
## Summary

S6b-2 (MOR-1263 tail, the FINAL zone declaration): the scope-controls zone declared in the desktop-v2 manifest; the S6b-1 prop retires the legacy fact-backed toolbar half (client-side view options stay); RECORDED_REASONS is now EMPTY - MOR-1317 closes program-wide, with the partition test remaining a live guard (a fifteenth surface name fails until a zone-or-reason decision is made). Final zone order for the record: receiver-deck, rx-tx, tx-aux, meters, scope-display, filter, rf-front-end, band, antenna, rit-xit-scan, rx-audio, dsp, cw-keyer, scope-controls.

Production LOC 1 (verifier-measured; contract.ts single-line literal nets 0 per the standing F4 convention).

## Review provenance

Verified by the rework-domain opus anchor #3 (session 8): PASS, no required fixes. The MOR-1317 closure verified DIRECTLY, not inferred from the empty ledger: declaredSurfaces(desktopV2Layout) covers every one of the 14 SEMANTIC_SURFACE_NAMES, one zone per surface, none doubled; plan-level ownership holds on default AND pre-existing stored workspaces; the cockpit correctly does not own it. S6b-1's three production files sha-identical (the slice only flips an already-wired predicate). Probes: undeclare -> 10 RED across 8 files; re-add to the empty ledger -> partition + overlap both fire. Post-rebase P1 re-run red as required; landing suite 5948/5948 (an earlier 127-failure run was a localStorage-env artifact, reproduced clean with the documented flag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)