### PR TITLE
test(MOR-1353): convert vi.mock('../command-bus') enumerating factories to importOriginal partial mocks

### DIFF
--- a/frontend/src/components-v2/layout/__tests__/MobileRadioLayout.component.svelte.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/MobileRadioLayout.component.svelte.test.ts
@@ -98,9 +98,11 @@ const {
   onMainVfoClickSpy: vi.fn(),
   onSubVfoClickSpy: vi.fn(),
 }));
-vi.mock('../../wiring/command-bus', () => {
+vi.mock('../../wiring/command-bus', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../wiring/command-bus')>();
   const n = vi.fn();
   return {
+    ...actual,
     makeVfoHandlers: () => ({
       onMainFreqChange: n, onSubFreqChange: n, onVfoSwap: n, onVfoEqual: n, onReceiverSelect: n,
       onMainVfoClick: onMainVfoClickSpy, onSubVfoClick: onSubVfoClickSpy,

--- a/frontend/src/components-v2/layout/__tests__/semantic-mobile-migration.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-mobile-migration.component.test.ts
@@ -123,9 +123,11 @@ vi.mock('$lib/stores/capabilities.svelte', () => ({
   getAgcLabels: vi.fn(() => ({ 0: 'OFF', 1: 'FAST', 2: 'MID', 3: 'SLOW' })),
   getVfoScheme: vi.fn(() => 'ab'), getAntennaCount: vi.fn(() => 1),
 }));
-vi.mock('../../wiring/command-bus', () => {
+vi.mock('../../wiring/command-bus', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../wiring/command-bus')>();
   const n = vi.fn();
   return {
+    ...actual,
     makeVfoHandlers: () => ({
       onMainFreqChange: n, onSubFreqChange: n, onVfoSwap: n, onVfoEqual: n, onReceiverSelect: n,
       onMainVfoClick: n, onSubVfoClick: n, onSplitToggle: n, onSwap: n, onEqual: n,

--- a/frontend/src/components-v2/wiring/__tests__/semantic-dsp-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-dsp-wiring.component.test.ts
@@ -83,86 +83,90 @@ vi.mock('$lib/runtime/adapters/mod-input-tx-guard.svelte', () => ({
 // The names below are the REAL `makeDspHandlers`/`makeAgcHandlers` surface —
 // agreement with the shipped module is proven separately, against the real
 // module, in `command-bus.test.ts`.
-vi.mock('../command-bus', () => ({
-  makeVfoHandlers: () => ({
-    onVfoSelect: h.noop, onSplitToggle: h.noop, onDualWatchToggle: h.noop,
-  }),
-  makeVoxHandlers: () => ({
-    onVoxToggle: h.noop, onVoxGainChange: h.noop,
-    onAntiVoxGainChange: h.noop, onVoxDelayChange: h.noop,
-  }),
-  makeTxHandlers: () => ({
-    onRfPowerChange: h.noop, onMicGainChange: h.noop, onAtuToggle: h.noop,
-    onAtuTune: h.noop, onVoxToggle: h.noop, onCompToggle: h.noop,
-    onCompLevelChange: h.noop, onMonToggle: h.noop,
-    onMonLevelChange: h.noop, onDriveGainChange: h.noop,
-  }),
-  // MOR-1279 slice 3B: the RX-audio intent vocabulary. This fixture declares
-  // no rxAudio capability, so none of these is reachable — same stand-in role
-  // as `makeVfoHandlers`/`makeTxHandlers` above.
-  makeRxAudioHandlers: () => ({ onMonitorModeChange: h.noop, onAfLevelChange: h.noop }),
-  makeAudioRoutingHandlers: () => ({ onFocusChange: h.noop, onSplitStereoChange: h.noop }),
-  // MOR-1304 — the wiring now also composes the modeFilter/filterPassband
-  // intent vocabulary; `makeModeHandlers` is composed at both call sites
-  // (rxAudio's MOD-input remedy and filterIntents), so the stub carries both.
-  // This fixture declares no filter capability, so none of these is
-  // reachable — same stand-in role as `makeVfoHandlers`/`makeTxHandlers` above.
-  makeModeHandlers: () => ({
-    onModInputChange: h.noop, onModeChange: h.noop, onDataModeChange: h.noop,
-  }),
-  makeFilterHandlers: () => ({
-    onFilterChange: h.noop, onFilterWidthChange: h.noop, onFilterShapeChange: h.noop,
-    onIfShiftChange: h.noop, onPbtInnerChange: h.noop, onPbtOuterChange: h.noop,
-  }),
-  makeDspHandlers: () => ({
-    onNrModeChange: h.nrMode, onNrLevelChange: h.nrLevel, onNbToggle: h.nbToggle,
-    onNbLevelChange: h.nbLevel, onNbDepthChange: h.nbDepth, onNbWidthChange: h.nbWidth,
-    onNotchModeChange: h.notchMode, onNotchFreqChange: h.notchFreq,
-    onManualNotchWidthChange: h.manualNotchWidth, onAgcTimeChange: h.agcTime,
-  }),
-  makeAgcHandlers: () => ({ onAgcModeChange: h.agcMode }),
-  // MOR-1306 — the wiring now also composes the RF-front-end intent
-  // vocabulary. This fixture declares no RF-front-end capability, so none of
-  // these is reachable — same stand-in role as `makeVfoHandlers`/
-  // `makeTxHandlers` above.
-  makeRfFrontEndHandlers: () => ({
-    onAttChange: h.noop, onPreChange: h.noop, onRfGainChange: h.noop,
-    onSquelchChange: h.noop, onDigiSelToggle: h.noop, onIpPlusToggle: h.noop,
-  }),
-  // MOR-1307 slice 7B: the band-select intent the band surface composes.
-  // This fixture declares no band capability, so it is never reachable —
-  // same stand-in role as `makeVfoHandlers`/`makeTxHandlers` above.
-  makeBandHandlers: () => ({ onBandSelect: h.noop }),
-  // MOR-1309 slice 8C: the wiring now also composes the antenna intent
-  // vocabulary unconditionally. This fixture declares no antenna capability,
-  // so none of these is reachable — same stand-in role as `makeBandHandlers`.
-  makeAntennaHandlers: () => ({ onSelectAnt1: h.noop, onSelectAnt2: h.noop, onToggleRxAnt: h.noop }),
-  // MOR-1308 — the wiring now also composes the RIT/XIT and scan intent
-  // vocabularies. This fixture declares no rit/xit capability or scan
-  // evidence, so none of these is reachable — same stand-in role as
-  // `makeVfoHandlers`/`makeTxHandlers` above.
-  makeRitXitHandlers: () => ({
-    onRitToggle: h.noop, onXitToggle: h.noop, onRitOffsetChange: h.noop,
-    onXitOffsetChange: h.noop, onClear: h.noop,
-  }),
-  makeScanHandlers: () => ({
-    onScanStart: h.noop, onScanStop: h.noop, onDfSpanChange: h.noop, onResumeChange: h.noop,
-  }),
-  // MOR-1310 slice 9B: the wiring now also composes the CW keyer intent
-  // vocabulary unconditionally. This fixture declares no cwKeyer capability,
-  // so none of these is reachable — same stand-in role as `makeRitXitHandlers`.
-  makeCwPanelHandlers: () => ({
-    onKeySpeedChange: h.noop, onCwPitchChange: h.noop, onBreakInDelayChange: h.noop,
-    onBreakInModeChange: h.noop, onApfChange: h.noop, onTwinPeakToggle: h.noop,
-    onReversePaddleToggle: h.noop,
-  }),
-  // MOR-1311 slice 11B: the scope-toolbar/popover intent vocabulary.
-  makeScopeControlsHandlers: () => ({
-    onModeChange: h.noop, onEdgeChange: h.noop, onSpanChange: h.noop, onSpeedChange: h.noop,
-    onHoldChange: h.noop, onRefChange: h.noop, onDualChange: h.noop, onReceiverChange: h.noop,
-    onDuringTxChange: h.noop, onCenterTypeChange: h.noop, onVbwChange: h.noop, onRbwChange: h.noop,
-  }),
-}));
+vi.mock('../command-bus', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../command-bus')>();
+  return {
+    ...actual,
+    makeVfoHandlers: () => ({
+      onVfoSelect: h.noop, onSplitToggle: h.noop, onDualWatchToggle: h.noop,
+    }),
+    makeVoxHandlers: () => ({
+      onVoxToggle: h.noop, onVoxGainChange: h.noop,
+      onAntiVoxGainChange: h.noop, onVoxDelayChange: h.noop,
+    }),
+    makeTxHandlers: () => ({
+      onRfPowerChange: h.noop, onMicGainChange: h.noop, onAtuToggle: h.noop,
+      onAtuTune: h.noop, onVoxToggle: h.noop, onCompToggle: h.noop,
+      onCompLevelChange: h.noop, onMonToggle: h.noop,
+      onMonLevelChange: h.noop, onDriveGainChange: h.noop,
+    }),
+    // MOR-1279 slice 3B: the RX-audio intent vocabulary. This fixture declares
+    // no rxAudio capability, so none of these is reachable — same stand-in role
+    // as `makeVfoHandlers`/`makeTxHandlers` above.
+    makeRxAudioHandlers: () => ({ onMonitorModeChange: h.noop, onAfLevelChange: h.noop }),
+    makeAudioRoutingHandlers: () => ({ onFocusChange: h.noop, onSplitStereoChange: h.noop }),
+    // MOR-1304 — the wiring now also composes the modeFilter/filterPassband
+    // intent vocabulary; `makeModeHandlers` is composed at both call sites
+    // (rxAudio's MOD-input remedy and filterIntents), so the stub carries both.
+    // This fixture declares no filter capability, so none of these is
+    // reachable — same stand-in role as `makeVfoHandlers`/`makeTxHandlers` above.
+    makeModeHandlers: () => ({
+      onModInputChange: h.noop, onModeChange: h.noop, onDataModeChange: h.noop,
+    }),
+    makeFilterHandlers: () => ({
+      onFilterChange: h.noop, onFilterWidthChange: h.noop, onFilterShapeChange: h.noop,
+      onIfShiftChange: h.noop, onPbtInnerChange: h.noop, onPbtOuterChange: h.noop,
+    }),
+    makeDspHandlers: () => ({
+      onNrModeChange: h.nrMode, onNrLevelChange: h.nrLevel, onNbToggle: h.nbToggle,
+      onNbLevelChange: h.nbLevel, onNbDepthChange: h.nbDepth, onNbWidthChange: h.nbWidth,
+      onNotchModeChange: h.notchMode, onNotchFreqChange: h.notchFreq,
+      onManualNotchWidthChange: h.manualNotchWidth, onAgcTimeChange: h.agcTime,
+    }),
+    makeAgcHandlers: () => ({ onAgcModeChange: h.agcMode }),
+    // MOR-1306 — the wiring now also composes the RF-front-end intent
+    // vocabulary. This fixture declares no RF-front-end capability, so none of
+    // these is reachable — same stand-in role as `makeVfoHandlers`/
+    // `makeTxHandlers` above.
+    makeRfFrontEndHandlers: () => ({
+      onAttChange: h.noop, onPreChange: h.noop, onRfGainChange: h.noop,
+      onSquelchChange: h.noop, onDigiSelToggle: h.noop, onIpPlusToggle: h.noop,
+    }),
+    // MOR-1307 slice 7B: the band-select intent the band surface composes.
+    // This fixture declares no band capability, so it is never reachable —
+    // same stand-in role as `makeVfoHandlers`/`makeTxHandlers` above.
+    makeBandHandlers: () => ({ onBandSelect: h.noop }),
+    // MOR-1309 slice 8C: the wiring now also composes the antenna intent
+    // vocabulary unconditionally. This fixture declares no antenna capability,
+    // so none of these is reachable — same stand-in role as `makeBandHandlers`.
+    makeAntennaHandlers: () => ({ onSelectAnt1: h.noop, onSelectAnt2: h.noop, onToggleRxAnt: h.noop }),
+    // MOR-1308 — the wiring now also composes the RIT/XIT and scan intent
+    // vocabularies. This fixture declares no rit/xit capability or scan
+    // evidence, so none of these is reachable — same stand-in role as
+    // `makeVfoHandlers`/`makeTxHandlers` above.
+    makeRitXitHandlers: () => ({
+      onRitToggle: h.noop, onXitToggle: h.noop, onRitOffsetChange: h.noop,
+      onXitOffsetChange: h.noop, onClear: h.noop,
+    }),
+    makeScanHandlers: () => ({
+      onScanStart: h.noop, onScanStop: h.noop, onDfSpanChange: h.noop, onResumeChange: h.noop,
+    }),
+    // MOR-1310 slice 9B: the wiring now also composes the CW keyer intent
+    // vocabulary unconditionally. This fixture declares no cwKeyer capability,
+    // so none of these is reachable — same stand-in role as `makeRitXitHandlers`.
+    makeCwPanelHandlers: () => ({
+      onKeySpeedChange: h.noop, onCwPitchChange: h.noop, onBreakInDelayChange: h.noop,
+      onBreakInModeChange: h.noop, onApfChange: h.noop, onTwinPeakToggle: h.noop,
+      onReversePaddleToggle: h.noop,
+    }),
+    // MOR-1311 slice 11B: the scope-toolbar/popover intent vocabulary.
+    makeScopeControlsHandlers: () => ({
+      onModeChange: h.noop, onEdgeChange: h.noop, onSpanChange: h.noop, onSpeedChange: h.noop,
+      onHoldChange: h.noop, onRefChange: h.noop, onDualChange: h.noop, onReceiverChange: h.noop,
+      onDuringTxChange: h.noop, onCenterTypeChange: h.noop, onVbwChange: h.noop, onRbwChange: h.noop,
+    }),
+  };
+});
 
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';
 import { desktopV2Layout } from '../../../presentation/layouts/declarations';

--- a/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
@@ -76,72 +76,76 @@ vi.mock('$lib/runtime/adapters/mod-input-tx-guard.svelte', () => ({
   deriveModInputTxGuardProps: () => ({ visible: false, sourceLabel: null }),
   getModInputTxGuardHandlers: () => ({ onSetLan: vi.fn(), onDismiss: vi.fn() }),
 }));
-vi.mock('../command-bus', () => ({
-  makeVfoHandlers: () => ({
-    onVfoSelect: h.noop, onSplitToggle: h.noop, onDualWatchToggle: h.noop,
-  }),
-  makeVoxHandlers: () => ({
-    onVoxToggle: h.noop, onVoxGainChange: h.noop,
-    onAntiVoxGainChange: h.noop, onVoxDelayChange: h.noop,
-  }),
-  makeTxHandlers: () => ({
-    onRfPowerChange: h.noop, onMicGainChange: h.noop, onAtuToggle: h.noop,
-    onAtuTune: h.noop, onVoxToggle: h.noop, onCompToggle: h.noop,
-    onCompLevelChange: h.noop, onMonToggle: h.noop,
-    onMonLevelChange: h.noop, onDriveGainChange: h.noop,
-  }),
-  // MOR-1279 slice 3B: the RX-audio intent vocabulary.
-  makeRxAudioHandlers: () => ({ onMonitorModeChange: h.noop, onAfLevelChange: h.noop }),
-  // MOR-1310 slice 9B: the semantic CW-keyer surface's setting intents.
-  makeCwPanelHandlers: () => ({
-    onKeySpeedChange: h.noop, onCwPitchChange: h.noop, onBreakInDelayChange: h.noop,
-    onBreakInModeChange: h.noop, onApfChange: h.noop, onTwinPeakToggle: h.noop,
-    onReversePaddleToggle: h.noop,
-  }),
-  makeAudioRoutingHandlers: () => ({ onFocusChange: h.noop, onSplitStereoChange: h.noop }),
-  // MOR-1304 — the wiring now also composes the modeFilter/filterPassband
-  // intent vocabulary; `makeModeHandlers` is composed at both call sites
-  // (rxAudio's MOD-input remedy and filterIntents), so the stub carries both.
-  makeModeHandlers: () => ({
-    onModInputChange: h.noop, onModeChange: h.noop, onDataModeChange: h.noop,
-  }),
-  makeFilterHandlers: () => ({
-    onFilterChange: h.noop, onFilterWidthChange: h.noop, onFilterShapeChange: h.noop,
-    onIfShiftChange: h.noop, onPbtInnerChange: h.noop, onPbtOuterChange: h.noop,
-  }),
-  // MOR-1305 — the wiring now also composes the dsp intent vocabulary. This
-  // fixture declares no dsp capability or state, so none of these is reachable.
-  makeDspHandlers: () => ({
-    onNrModeChange: h.noop, onNrLevelChange: h.noop, onNbToggle: h.noop,
-    onNbLevelChange: h.noop, onNbDepthChange: h.noop, onNbWidthChange: h.noop,
-    onNotchModeChange: h.noop, onNotchFreqChange: h.noop,
-    onManualNotchWidthChange: h.noop, onAgcTimeChange: h.noop,
-  }),
-  makeAgcHandlers: () => ({ onAgcModeChange: h.noop }),
-  // MOR-1306 slice 6B: the RF-front-end intent vocabulary.
-  makeRfFrontEndHandlers: () => ({
-    onAttChange: h.noop, onPreChange: h.noop, onRfGainChange: h.noop,
-    onSquelchChange: h.noop, onDigiSelToggle: h.noop, onIpPlusToggle: h.noop,
-  }),
-  // MOR-1307 slice 7B: the band-select intent the band surface composes.
-  makeBandHandlers: () => ({ onBandSelect: h.noop }),
-  // MOR-1309 slice 8C: the antenna intent vocabulary.
-  makeAntennaHandlers: () => ({ onSelectAnt1: h.noop, onSelectAnt2: h.noop, onToggleRxAnt: h.noop }),
-  // MOR-1308 slice 8B: the RIT/XIT and scan intent vocabularies.
-  makeRitXitHandlers: () => ({
-    onRitToggle: h.noop, onXitToggle: h.noop, onRitOffsetChange: h.noop,
-    onXitOffsetChange: h.noop, onClear: h.noop,
-  }),
-  makeScanHandlers: () => ({
-    onScanStart: h.noop, onScanStop: h.noop, onDfSpanChange: h.noop, onResumeChange: h.noop,
-  }),
-  // MOR-1311 slice 11B: the scope-toolbar/popover intent vocabulary.
-  makeScopeControlsHandlers: () => ({
-    onModeChange: h.noop, onEdgeChange: h.noop, onSpanChange: h.noop, onSpeedChange: h.noop,
-    onHoldChange: h.noop, onRefChange: h.noop, onDualChange: h.noop, onReceiverChange: h.noop,
-    onDuringTxChange: h.noop, onCenterTypeChange: h.noop, onVbwChange: h.noop, onRbwChange: h.noop,
-  }),
-}));
+vi.mock('../command-bus', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../command-bus')>();
+  return {
+    ...actual,
+    makeVfoHandlers: () => ({
+      onVfoSelect: h.noop, onSplitToggle: h.noop, onDualWatchToggle: h.noop,
+    }),
+    makeVoxHandlers: () => ({
+      onVoxToggle: h.noop, onVoxGainChange: h.noop,
+      onAntiVoxGainChange: h.noop, onVoxDelayChange: h.noop,
+    }),
+    makeTxHandlers: () => ({
+      onRfPowerChange: h.noop, onMicGainChange: h.noop, onAtuToggle: h.noop,
+      onAtuTune: h.noop, onVoxToggle: h.noop, onCompToggle: h.noop,
+      onCompLevelChange: h.noop, onMonToggle: h.noop,
+      onMonLevelChange: h.noop, onDriveGainChange: h.noop,
+    }),
+    // MOR-1279 slice 3B: the RX-audio intent vocabulary.
+    makeRxAudioHandlers: () => ({ onMonitorModeChange: h.noop, onAfLevelChange: h.noop }),
+    // MOR-1310 slice 9B: the semantic CW-keyer surface's setting intents.
+    makeCwPanelHandlers: () => ({
+      onKeySpeedChange: h.noop, onCwPitchChange: h.noop, onBreakInDelayChange: h.noop,
+      onBreakInModeChange: h.noop, onApfChange: h.noop, onTwinPeakToggle: h.noop,
+      onReversePaddleToggle: h.noop,
+    }),
+    makeAudioRoutingHandlers: () => ({ onFocusChange: h.noop, onSplitStereoChange: h.noop }),
+    // MOR-1304 — the wiring now also composes the modeFilter/filterPassband
+    // intent vocabulary; `makeModeHandlers` is composed at both call sites
+    // (rxAudio's MOD-input remedy and filterIntents), so the stub carries both.
+    makeModeHandlers: () => ({
+      onModInputChange: h.noop, onModeChange: h.noop, onDataModeChange: h.noop,
+    }),
+    makeFilterHandlers: () => ({
+      onFilterChange: h.noop, onFilterWidthChange: h.noop, onFilterShapeChange: h.noop,
+      onIfShiftChange: h.noop, onPbtInnerChange: h.noop, onPbtOuterChange: h.noop,
+    }),
+    // MOR-1305 — the wiring now also composes the dsp intent vocabulary. This
+    // fixture declares no dsp capability or state, so none of these is reachable.
+    makeDspHandlers: () => ({
+      onNrModeChange: h.noop, onNrLevelChange: h.noop, onNbToggle: h.noop,
+      onNbLevelChange: h.noop, onNbDepthChange: h.noop, onNbWidthChange: h.noop,
+      onNotchModeChange: h.noop, onNotchFreqChange: h.noop,
+      onManualNotchWidthChange: h.noop, onAgcTimeChange: h.noop,
+    }),
+    makeAgcHandlers: () => ({ onAgcModeChange: h.noop }),
+    // MOR-1306 slice 6B: the RF-front-end intent vocabulary.
+    makeRfFrontEndHandlers: () => ({
+      onAttChange: h.noop, onPreChange: h.noop, onRfGainChange: h.noop,
+      onSquelchChange: h.noop, onDigiSelToggle: h.noop, onIpPlusToggle: h.noop,
+    }),
+    // MOR-1307 slice 7B: the band-select intent the band surface composes.
+    makeBandHandlers: () => ({ onBandSelect: h.noop }),
+    // MOR-1309 slice 8C: the antenna intent vocabulary.
+    makeAntennaHandlers: () => ({ onSelectAnt1: h.noop, onSelectAnt2: h.noop, onToggleRxAnt: h.noop }),
+    // MOR-1308 slice 8B: the RIT/XIT and scan intent vocabularies.
+    makeRitXitHandlers: () => ({
+      onRitToggle: h.noop, onXitToggle: h.noop, onRitOffsetChange: h.noop,
+      onXitOffsetChange: h.noop, onClear: h.noop,
+    }),
+    makeScanHandlers: () => ({
+      onScanStart: h.noop, onScanStop: h.noop, onDfSpanChange: h.noop, onResumeChange: h.noop,
+    }),
+    // MOR-1311 slice 11B: the scope-toolbar/popover intent vocabulary.
+    makeScopeControlsHandlers: () => ({
+      onModeChange: h.noop, onEdgeChange: h.noop, onSpanChange: h.noop, onSpeedChange: h.noop,
+      onHoldChange: h.noop, onRefChange: h.noop, onDualChange: h.noop, onReceiverChange: h.noop,
+      onDuringTxChange: h.noop, onCenterTypeChange: h.noop, onVbwChange: h.noop, onRbwChange: h.noop,
+    }),
+  };
+});
 
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';
 

--- a/frontend/src/components-v2/wiring/__tests__/semantic-rf-front-end-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rf-front-end-wiring.component.test.ts
@@ -93,80 +93,84 @@ vi.mock('$lib/runtime/adapters/mod-input-tx-guard.svelte', () => ({
 // The real module's names/arities are covered by `stub-export-parity.test.ts`
 // and by TypeScript; this file only proves ROUTING, mirroring
 // `semantic-tx-aux-wiring.component.test.ts`'s own wholesale mock.
-vi.mock('../command-bus', () => ({
-  makeVfoHandlers: () => ({
-    onVfoSelect: h.noop, onSplitToggle: h.noop, onDualWatchToggle: h.noop,
-  }),
-  makeVoxHandlers: () => ({
-    onVoxToggle: h.noop, onVoxGainChange: h.noop, onAntiVoxGainChange: h.noop, onVoxDelayChange: h.noop,
-  }),
-  makeTxHandlers: () => ({
-    onRfPowerChange: h.noop, onMicGainChange: h.noop, onAtuToggle: h.noop, onAtuTune: h.noop,
-    onVoxToggle: h.noop, onCompToggle: h.noop, onCompLevelChange: h.noop, onMonToggle: h.noop,
-    onMonLevelChange: h.noop, onDriveGainChange: h.noop,
-  }),
-  makeRxAudioHandlers: () => ({ onMonitorModeChange: h.noop, onAfLevelChange: h.noop }),
-  makeAudioRoutingHandlers: () => ({ onFocusChange: h.noop, onSplitStereoChange: h.noop }),
-  // MOR-1304/MOR-1305 — the wiring's module scope also composes the
-  // filter/dsp intent vocabularies unconditionally; without stubs here the
-  // wiring's `makeFilterHandlers()`/`makeDspHandlers()`/`makeAgcHandlers()`
-  // calls throw before this file's own RF-front-end assertions ever run.
-  makeModeHandlers: () => ({
-    onModInputChange: h.noop, onModeChange: h.noop, onDataModeChange: h.noop,
-  }),
-  makeFilterHandlers: () => ({
-    onFilterChange: h.noop, onFilterWidthChange: h.noop, onFilterShapeChange: h.noop,
-    onIfShiftChange: h.noop, onPbtInnerChange: h.noop, onPbtOuterChange: h.noop,
-  }),
-  makeDspHandlers: () => ({
-    onNrModeChange: h.noop, onNrLevelChange: h.noop, onNbToggle: h.noop,
-    onNbLevelChange: h.noop, onNbDepthChange: h.noop, onNbWidthChange: h.noop,
-    onNotchModeChange: h.noop, onNotchFreqChange: h.noop,
-    onManualNotchWidthChange: h.noop, onAgcTimeChange: h.noop,
-  }),
-  makeAgcHandlers: () => ({ onAgcModeChange: h.noop }),
-  makeRfFrontEndHandlers: () => ({
-    onAttChange: h.att, onPreChange: h.pre, onRfGainChange: h.rfGain,
-    onSquelchChange: h.squelch, onDigiSelToggle: h.digiSel, onIpPlusToggle: h.ipPlus,
-  }),
-  // MOR-1307 slice 7B: the band-select intent the band surface composes.
-  // This fixture declares no band capability, so it is never reachable —
-  // same stand-in role as the noop handlers above.
-  makeBandHandlers: () => ({ onBandSelect: h.noop }),
-  // MOR-1309 slice 8C: the wiring's module scope also composes the antenna
-  // intent vocabulary unconditionally; without a stub here the wiring's
-  // `makeAntennaHandlers()` call throws before this file's own RF-front-end
-  // assertions ever run. This fixture declares no antenna capability, so
-  // none of these is reachable — same stand-in role as `makeBandHandlers`.
-  makeAntennaHandlers: () => ({ onSelectAnt1: h.noop, onSelectAnt2: h.noop, onToggleRxAnt: h.noop }),
-  // MOR-1308 — the wiring's module scope also composes the RIT/XIT and scan
-  // intent vocabularies unconditionally; without stubs here the wiring's
-  // `makeRitXitHandlers()`/`makeScanHandlers()` calls throw before this
-  // file's own RF-front-end assertions ever run.
-  makeRitXitHandlers: () => ({
-    onRitToggle: h.noop, onXitToggle: h.noop, onRitOffsetChange: h.noop,
-    onXitOffsetChange: h.noop, onClear: h.noop,
-  }),
-  makeScanHandlers: () => ({
-    onScanStart: h.noop, onScanStop: h.noop, onDfSpanChange: h.noop, onResumeChange: h.noop,
-  }),
-  // MOR-1310 slice 9B — the wiring's module scope also composes the CW keyer
-  // intent vocabulary unconditionally; without a stub here the wiring's
-  // `makeCwPanelHandlers()` call throws before this file's own RF-front-end
-  // assertions ever run. This fixture declares no cwKeyer capability, so
-  // none of these is reachable — same stand-in role as `makeRitXitHandlers`.
-  makeCwPanelHandlers: () => ({
-    onKeySpeedChange: h.noop, onCwPitchChange: h.noop, onBreakInDelayChange: h.noop,
-    onBreakInModeChange: h.noop, onApfChange: h.noop, onTwinPeakToggle: h.noop,
-    onReversePaddleToggle: h.noop,
-  }),
-  // MOR-1311 slice 11B: the scope-toolbar/popover intent vocabulary.
-  makeScopeControlsHandlers: () => ({
-    onModeChange: h.noop, onEdgeChange: h.noop, onSpanChange: h.noop, onSpeedChange: h.noop,
-    onHoldChange: h.noop, onRefChange: h.noop, onDualChange: h.noop, onReceiverChange: h.noop,
-    onDuringTxChange: h.noop, onCenterTypeChange: h.noop, onVbwChange: h.noop, onRbwChange: h.noop,
-  }),
-}));
+vi.mock('../command-bus', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../command-bus')>();
+  return {
+    ...actual,
+    makeVfoHandlers: () => ({
+      onVfoSelect: h.noop, onSplitToggle: h.noop, onDualWatchToggle: h.noop,
+    }),
+    makeVoxHandlers: () => ({
+      onVoxToggle: h.noop, onVoxGainChange: h.noop, onAntiVoxGainChange: h.noop, onVoxDelayChange: h.noop,
+    }),
+    makeTxHandlers: () => ({
+      onRfPowerChange: h.noop, onMicGainChange: h.noop, onAtuToggle: h.noop, onAtuTune: h.noop,
+      onVoxToggle: h.noop, onCompToggle: h.noop, onCompLevelChange: h.noop, onMonToggle: h.noop,
+      onMonLevelChange: h.noop, onDriveGainChange: h.noop,
+    }),
+    makeRxAudioHandlers: () => ({ onMonitorModeChange: h.noop, onAfLevelChange: h.noop }),
+    makeAudioRoutingHandlers: () => ({ onFocusChange: h.noop, onSplitStereoChange: h.noop }),
+    // MOR-1304/MOR-1305 — the wiring's module scope also composes the
+    // filter/dsp intent vocabularies unconditionally; without stubs here the
+    // wiring's `makeFilterHandlers()`/`makeDspHandlers()`/`makeAgcHandlers()`
+    // calls throw before this file's own RF-front-end assertions ever run.
+    makeModeHandlers: () => ({
+      onModInputChange: h.noop, onModeChange: h.noop, onDataModeChange: h.noop,
+    }),
+    makeFilterHandlers: () => ({
+      onFilterChange: h.noop, onFilterWidthChange: h.noop, onFilterShapeChange: h.noop,
+      onIfShiftChange: h.noop, onPbtInnerChange: h.noop, onPbtOuterChange: h.noop,
+    }),
+    makeDspHandlers: () => ({
+      onNrModeChange: h.noop, onNrLevelChange: h.noop, onNbToggle: h.noop,
+      onNbLevelChange: h.noop, onNbDepthChange: h.noop, onNbWidthChange: h.noop,
+      onNotchModeChange: h.noop, onNotchFreqChange: h.noop,
+      onManualNotchWidthChange: h.noop, onAgcTimeChange: h.noop,
+    }),
+    makeAgcHandlers: () => ({ onAgcModeChange: h.noop }),
+    makeRfFrontEndHandlers: () => ({
+      onAttChange: h.att, onPreChange: h.pre, onRfGainChange: h.rfGain,
+      onSquelchChange: h.squelch, onDigiSelToggle: h.digiSel, onIpPlusToggle: h.ipPlus,
+    }),
+    // MOR-1307 slice 7B: the band-select intent the band surface composes.
+    // This fixture declares no band capability, so it is never reachable —
+    // same stand-in role as the noop handlers above.
+    makeBandHandlers: () => ({ onBandSelect: h.noop }),
+    // MOR-1309 slice 8C: the wiring's module scope also composes the antenna
+    // intent vocabulary unconditionally; without a stub here the wiring's
+    // `makeAntennaHandlers()` call throws before this file's own RF-front-end
+    // assertions ever run. This fixture declares no antenna capability, so
+    // none of these is reachable — same stand-in role as `makeBandHandlers`.
+    makeAntennaHandlers: () => ({ onSelectAnt1: h.noop, onSelectAnt2: h.noop, onToggleRxAnt: h.noop }),
+    // MOR-1308 — the wiring's module scope also composes the RIT/XIT and scan
+    // intent vocabularies unconditionally; without stubs here the wiring's
+    // `makeRitXitHandlers()`/`makeScanHandlers()` calls throw before this
+    // file's own RF-front-end assertions ever run.
+    makeRitXitHandlers: () => ({
+      onRitToggle: h.noop, onXitToggle: h.noop, onRitOffsetChange: h.noop,
+      onXitOffsetChange: h.noop, onClear: h.noop,
+    }),
+    makeScanHandlers: () => ({
+      onScanStart: h.noop, onScanStop: h.noop, onDfSpanChange: h.noop, onResumeChange: h.noop,
+    }),
+    // MOR-1310 slice 9B — the wiring's module scope also composes the CW keyer
+    // intent vocabulary unconditionally; without a stub here the wiring's
+    // `makeCwPanelHandlers()` call throws before this file's own RF-front-end
+    // assertions ever run. This fixture declares no cwKeyer capability, so
+    // none of these is reachable — same stand-in role as `makeRitXitHandlers`.
+    makeCwPanelHandlers: () => ({
+      onKeySpeedChange: h.noop, onCwPitchChange: h.noop, onBreakInDelayChange: h.noop,
+      onBreakInModeChange: h.noop, onApfChange: h.noop, onTwinPeakToggle: h.noop,
+      onReversePaddleToggle: h.noop,
+    }),
+    // MOR-1311 slice 11B: the scope-toolbar/popover intent vocabulary.
+    makeScopeControlsHandlers: () => ({
+      onModeChange: h.noop, onEdgeChange: h.noop, onSpanChange: h.noop, onSpeedChange: h.noop,
+      onHoldChange: h.noop, onRefChange: h.noop, onDualChange: h.noop, onReceiverChange: h.noop,
+      onDuringTxChange: h.noop, onCenterTypeChange: h.noop, onVbwChange: h.noop, onRbwChange: h.noop,
+    }),
+  };
+});
 
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';
 // MOR-1366 (S7), N1 fold (verify-MOR-1365 ruling item 3): the REAL manifest +

--- a/frontend/src/components-v2/wiring/__tests__/semantic-rx-tx-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rx-tx-wiring.component.test.ts
@@ -100,76 +100,80 @@ vi.mock('$lib/runtime/adapters/mod-input-tx-guard.svelte', () => ({
   deriveModInputTxGuardProps: () => h.modInputGuard,
   getModInputTxGuardHandlers: () => ({ onSetLan: h.setLan, onDismiss: h.dismissWarning }),
 }));
-vi.mock('../command-bus', () => ({
-  makeVfoHandlers: () => ({
-    onVfoSelect: h.selectVfo,
-    onSplitToggle: h.splitToggle,
-    onDualWatchToggle: h.dualWatchToggle,
-  }),
-  // MOR-1265 — the wiring now also composes the txAux intent vocabulary.
-  makeVoxHandlers: () => ({
-    onVoxToggle: h.txAuxNoop, onVoxGainChange: h.txAuxNoop,
-    onAntiVoxGainChange: h.txAuxNoop, onVoxDelayChange: h.txAuxNoop,
-  }),
-  makeTxHandlers: () => ({
-    onRfPowerChange: h.txAuxNoop, onMicGainChange: h.txAuxNoop, onAtuToggle: h.txAuxNoop,
-    onAtuTune: h.txAuxNoop, onVoxToggle: h.txAuxNoop, onCompToggle: h.txAuxNoop,
-    onCompLevelChange: h.txAuxNoop, onMonToggle: h.txAuxNoop,
-    onMonLevelChange: h.txAuxNoop, onDriveGainChange: h.txAuxNoop,
-  }),
-  // MOR-1279 slice 3B: the RX-audio intent vocabulary.
-  makeRxAudioHandlers: () => ({ onMonitorModeChange: h.txAuxNoop, onAfLevelChange: h.txAuxNoop }),
-  // MOR-1310 slice 9B: the semantic CW-keyer surface's setting intents.
-  makeCwPanelHandlers: () => ({
-    onKeySpeedChange: h.txAuxNoop, onCwPitchChange: h.txAuxNoop, onBreakInDelayChange: h.txAuxNoop,
-    onBreakInModeChange: h.txAuxNoop, onApfChange: h.txAuxNoop, onTwinPeakToggle: h.txAuxNoop,
-    onReversePaddleToggle: h.txAuxNoop,
-  }),
-  makeAudioRoutingHandlers: () => ({ onFocusChange: h.txAuxNoop, onSplitStereoChange: h.txAuxNoop }),
-  // MOR-1304 — the wiring now also composes the modeFilter/filterPassband
-  // intent vocabulary; `makeModeHandlers` is composed at both call sites
-  // (rxAudio's MOD-input remedy and filterIntents), so the stub carries both.
-  makeModeHandlers: () => ({
-    onModInputChange: h.txAuxNoop, onModeChange: h.txAuxNoop, onDataModeChange: h.txAuxNoop,
-  }),
-  makeFilterHandlers: () => ({
-    onFilterChange: h.txAuxNoop, onFilterWidthChange: h.txAuxNoop, onFilterShapeChange: h.txAuxNoop,
-    onIfShiftChange: h.txAuxNoop, onPbtInnerChange: h.txAuxNoop, onPbtOuterChange: h.txAuxNoop,
-  }),
-  // MOR-1305 — the wiring now also composes the dsp intent vocabulary.
-  makeDspHandlers: () => ({
-    onNrModeChange: h.dspNoop, onNrLevelChange: h.dspNoop, onNbToggle: h.dspNoop,
-    onNbLevelChange: h.dspNoop, onNbDepthChange: h.dspNoop, onNbWidthChange: h.dspNoop,
-    onNotchModeChange: h.dspNoop, onNotchFreqChange: h.dspNoop,
-    onManualNotchWidthChange: h.dspNoop, onAgcTimeChange: h.dspNoop,
-  }),
-  makeAgcHandlers: () => ({ onAgcModeChange: h.dspNoop }),
-  // MOR-1306 slice 6B: the RF-front-end intent vocabulary.
-  makeRfFrontEndHandlers: () => ({
-    onAttChange: h.txAuxNoop, onPreChange: h.txAuxNoop, onRfGainChange: h.txAuxNoop,
-    onSquelchChange: h.txAuxNoop, onDigiSelToggle: h.txAuxNoop, onIpPlusToggle: h.txAuxNoop,
-  }),
-  // MOR-1307 slice 7B: the band-select intent the band surface composes.
-  makeBandHandlers: () => ({ onBandSelect: h.txAuxNoop }),
-  // MOR-1309 slice 8C: the antenna intent vocabulary.
-  makeAntennaHandlers: () => ({ onSelectAnt1: h.txAuxNoop, onSelectAnt2: h.txAuxNoop, onToggleRxAnt: h.txAuxNoop }),
-  // MOR-1308 slice 8B: the RIT/XIT and scan intent vocabularies.
-  makeRitXitHandlers: () => ({
-    onRitToggle: h.txAuxNoop, onXitToggle: h.txAuxNoop, onRitOffsetChange: h.txAuxNoop,
-    onXitOffsetChange: h.txAuxNoop, onClear: h.txAuxNoop,
-  }),
-  makeScanHandlers: () => ({
-    onScanStart: h.txAuxNoop, onScanStop: h.txAuxNoop, onDfSpanChange: h.txAuxNoop,
-    onResumeChange: h.txAuxNoop,
-  }),
-  // MOR-1311 slice 11B: the scope-toolbar/popover intent vocabulary.
-  makeScopeControlsHandlers: () => ({
-    onModeChange: h.txAuxNoop, onEdgeChange: h.txAuxNoop, onSpanChange: h.txAuxNoop,
-    onSpeedChange: h.txAuxNoop, onHoldChange: h.txAuxNoop, onRefChange: h.txAuxNoop,
-    onDualChange: h.txAuxNoop, onReceiverChange: h.txAuxNoop, onDuringTxChange: h.txAuxNoop,
-    onCenterTypeChange: h.txAuxNoop, onVbwChange: h.txAuxNoop, onRbwChange: h.txAuxNoop,
-  }),
-}));
+vi.mock('../command-bus', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../command-bus')>();
+  return {
+    ...actual,
+    makeVfoHandlers: () => ({
+      onVfoSelect: h.selectVfo,
+      onSplitToggle: h.splitToggle,
+      onDualWatchToggle: h.dualWatchToggle,
+    }),
+    // MOR-1265 — the wiring now also composes the txAux intent vocabulary.
+    makeVoxHandlers: () => ({
+      onVoxToggle: h.txAuxNoop, onVoxGainChange: h.txAuxNoop,
+      onAntiVoxGainChange: h.txAuxNoop, onVoxDelayChange: h.txAuxNoop,
+    }),
+    makeTxHandlers: () => ({
+      onRfPowerChange: h.txAuxNoop, onMicGainChange: h.txAuxNoop, onAtuToggle: h.txAuxNoop,
+      onAtuTune: h.txAuxNoop, onVoxToggle: h.txAuxNoop, onCompToggle: h.txAuxNoop,
+      onCompLevelChange: h.txAuxNoop, onMonToggle: h.txAuxNoop,
+      onMonLevelChange: h.txAuxNoop, onDriveGainChange: h.txAuxNoop,
+    }),
+    // MOR-1279 slice 3B: the RX-audio intent vocabulary.
+    makeRxAudioHandlers: () => ({ onMonitorModeChange: h.txAuxNoop, onAfLevelChange: h.txAuxNoop }),
+    // MOR-1310 slice 9B: the semantic CW-keyer surface's setting intents.
+    makeCwPanelHandlers: () => ({
+      onKeySpeedChange: h.txAuxNoop, onCwPitchChange: h.txAuxNoop, onBreakInDelayChange: h.txAuxNoop,
+      onBreakInModeChange: h.txAuxNoop, onApfChange: h.txAuxNoop, onTwinPeakToggle: h.txAuxNoop,
+      onReversePaddleToggle: h.txAuxNoop,
+    }),
+    makeAudioRoutingHandlers: () => ({ onFocusChange: h.txAuxNoop, onSplitStereoChange: h.txAuxNoop }),
+    // MOR-1304 — the wiring now also composes the modeFilter/filterPassband
+    // intent vocabulary; `makeModeHandlers` is composed at both call sites
+    // (rxAudio's MOD-input remedy and filterIntents), so the stub carries both.
+    makeModeHandlers: () => ({
+      onModInputChange: h.txAuxNoop, onModeChange: h.txAuxNoop, onDataModeChange: h.txAuxNoop,
+    }),
+    makeFilterHandlers: () => ({
+      onFilterChange: h.txAuxNoop, onFilterWidthChange: h.txAuxNoop, onFilterShapeChange: h.txAuxNoop,
+      onIfShiftChange: h.txAuxNoop, onPbtInnerChange: h.txAuxNoop, onPbtOuterChange: h.txAuxNoop,
+    }),
+    // MOR-1305 — the wiring now also composes the dsp intent vocabulary.
+    makeDspHandlers: () => ({
+      onNrModeChange: h.dspNoop, onNrLevelChange: h.dspNoop, onNbToggle: h.dspNoop,
+      onNbLevelChange: h.dspNoop, onNbDepthChange: h.dspNoop, onNbWidthChange: h.dspNoop,
+      onNotchModeChange: h.dspNoop, onNotchFreqChange: h.dspNoop,
+      onManualNotchWidthChange: h.dspNoop, onAgcTimeChange: h.dspNoop,
+    }),
+    makeAgcHandlers: () => ({ onAgcModeChange: h.dspNoop }),
+    // MOR-1306 slice 6B: the RF-front-end intent vocabulary.
+    makeRfFrontEndHandlers: () => ({
+      onAttChange: h.txAuxNoop, onPreChange: h.txAuxNoop, onRfGainChange: h.txAuxNoop,
+      onSquelchChange: h.txAuxNoop, onDigiSelToggle: h.txAuxNoop, onIpPlusToggle: h.txAuxNoop,
+    }),
+    // MOR-1307 slice 7B: the band-select intent the band surface composes.
+    makeBandHandlers: () => ({ onBandSelect: h.txAuxNoop }),
+    // MOR-1309 slice 8C: the antenna intent vocabulary.
+    makeAntennaHandlers: () => ({ onSelectAnt1: h.txAuxNoop, onSelectAnt2: h.txAuxNoop, onToggleRxAnt: h.txAuxNoop }),
+    // MOR-1308 slice 8B: the RIT/XIT and scan intent vocabularies.
+    makeRitXitHandlers: () => ({
+      onRitToggle: h.txAuxNoop, onXitToggle: h.txAuxNoop, onRitOffsetChange: h.txAuxNoop,
+      onXitOffsetChange: h.txAuxNoop, onClear: h.txAuxNoop,
+    }),
+    makeScanHandlers: () => ({
+      onScanStart: h.txAuxNoop, onScanStop: h.txAuxNoop, onDfSpanChange: h.txAuxNoop,
+      onResumeChange: h.txAuxNoop,
+    }),
+    // MOR-1311 slice 11B: the scope-toolbar/popover intent vocabulary.
+    makeScopeControlsHandlers: () => ({
+      onModeChange: h.txAuxNoop, onEdgeChange: h.txAuxNoop, onSpanChange: h.txAuxNoop,
+      onSpeedChange: h.txAuxNoop, onHoldChange: h.txAuxNoop, onRefChange: h.txAuxNoop,
+      onDualChange: h.txAuxNoop, onReceiverChange: h.txAuxNoop, onDuringTxChange: h.txAuxNoop,
+      onCenterTypeChange: h.txAuxNoop, onVbwChange: h.txAuxNoop, onRbwChange: h.txAuxNoop,
+    }),
+  };
+});
 
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';
 

--- a/frontend/src/components-v2/wiring/__tests__/semantic-scope-display-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-scope-display-wiring.component.test.ts
@@ -93,65 +93,69 @@ vi.mock('$lib/runtime/adapters/mod-input-tx-guard.svelte', () => ({
   deriveModInputTxGuardProps: () => ({ visible: false, sourceLabel: null }),
   getModInputTxGuardHandlers: () => ({ onSetLan: vi.fn(), onDismiss: vi.fn() }),
 }));
-vi.mock('../command-bus', () => ({
-  makeVfoHandlers: () => ({
-    onVfoSelect: h.noop, onSplitToggle: h.noop, onDualWatchToggle: h.noop,
-  }),
-  makeVoxHandlers: () => ({
-    onVoxToggle: h.noop, onVoxGainChange: h.noop,
-    onAntiVoxGainChange: h.noop, onVoxDelayChange: h.noop,
-  }),
-  makeTxHandlers: () => ({
-    onRfPowerChange: h.noop, onMicGainChange: h.noop, onAtuToggle: h.noop,
-    onAtuTune: h.noop, onVoxToggle: h.noop, onCompToggle: h.noop,
-    onCompLevelChange: h.noop, onMonToggle: h.noop,
-    onMonLevelChange: h.noop, onDriveGainChange: h.noop,
-  }),
-  makeRxAudioHandlers: () => ({ onMonitorModeChange: h.noop, onAfLevelChange: h.noop }),
-  makeAudioRoutingHandlers: () => ({ onFocusChange: h.noop, onSplitStereoChange: h.noop }),
-  makeModeHandlers: () => ({
-    onModInputChange: h.noop, onModeChange: h.noop, onDataModeChange: h.noop,
-  }),
-  // MOR-1312 slice 12B (rebase fix): `SemanticRadioSurfaces` now calls every
-  // one of these factories unconditionally at init — this file's own mock
-  // predates 4B-9B and only needs each module-scope call not to throw; none
-  // of these are reachable through the scopeDisplay-only fixtures below.
-  makeFilterHandlers: () => ({
-    onFilterChange: h.noop, onFilterWidthChange: h.noop, onFilterShapeChange: h.noop,
-    onIfShiftChange: h.noop, onPbtInnerChange: h.noop, onPbtOuterChange: h.noop,
-  }),
-  makeDspHandlers: () => ({
-    onNrModeChange: h.noop, onNrLevelChange: h.noop, onNbToggle: h.noop,
-    onNbLevelChange: h.noop, onNbDepthChange: h.noop, onNbWidthChange: h.noop,
-    onNotchModeChange: h.noop, onNotchFreqChange: h.noop,
-    onManualNotchWidthChange: h.noop, onAgcTimeChange: h.noop,
-  }),
-  makeAgcHandlers: () => ({ onAgcModeChange: h.noop }),
-  makeRfFrontEndHandlers: () => ({
-    onAttChange: h.noop, onPreChange: h.noop, onRfGainChange: h.noop,
-    onSquelchChange: h.noop, onDigiSelToggle: h.noop, onIpPlusToggle: h.noop,
-  }),
-  makeBandHandlers: () => ({ onBandSelect: h.noop }),
-  makeAntennaHandlers: () => ({ onSelectAnt1: h.noop, onSelectAnt2: h.noop, onToggleRxAnt: h.noop }),
-  makeRitXitHandlers: () => ({
-    onRitToggle: h.noop, onXitToggle: h.noop, onRitOffsetChange: h.noop,
-    onXitOffsetChange: h.noop, onClear: h.noop,
-  }),
-  makeScanHandlers: () => ({
-    onScanStart: h.noop, onScanStop: h.noop, onDfSpanChange: h.noop, onResumeChange: h.noop,
-  }),
-  makeCwPanelHandlers: () => ({
-    onKeySpeedChange: h.noop, onCwPitchChange: h.noop, onBreakInDelayChange: h.noop,
-    onBreakInModeChange: h.noop, onApfChange: h.noop, onTwinPeakToggle: h.noop,
-    onReversePaddleToggle: h.noop,
-  }),
-  // MOR-1311 slice 11B: the scope-toolbar/popover intent vocabulary.
-  makeScopeControlsHandlers: () => ({
-    onModeChange: h.noop, onEdgeChange: h.noop, onSpanChange: h.noop, onSpeedChange: h.noop,
-    onHoldChange: h.noop, onRefChange: h.noop, onDualChange: h.noop, onReceiverChange: h.noop,
-    onDuringTxChange: h.noop, onCenterTypeChange: h.noop, onVbwChange: h.noop, onRbwChange: h.noop,
-  }),
-}));
+vi.mock('../command-bus', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../command-bus')>();
+  return {
+    ...actual,
+    makeVfoHandlers: () => ({
+      onVfoSelect: h.noop, onSplitToggle: h.noop, onDualWatchToggle: h.noop,
+    }),
+    makeVoxHandlers: () => ({
+      onVoxToggle: h.noop, onVoxGainChange: h.noop,
+      onAntiVoxGainChange: h.noop, onVoxDelayChange: h.noop,
+    }),
+    makeTxHandlers: () => ({
+      onRfPowerChange: h.noop, onMicGainChange: h.noop, onAtuToggle: h.noop,
+      onAtuTune: h.noop, onVoxToggle: h.noop, onCompToggle: h.noop,
+      onCompLevelChange: h.noop, onMonToggle: h.noop,
+      onMonLevelChange: h.noop, onDriveGainChange: h.noop,
+    }),
+    makeRxAudioHandlers: () => ({ onMonitorModeChange: h.noop, onAfLevelChange: h.noop }),
+    makeAudioRoutingHandlers: () => ({ onFocusChange: h.noop, onSplitStereoChange: h.noop }),
+    makeModeHandlers: () => ({
+      onModInputChange: h.noop, onModeChange: h.noop, onDataModeChange: h.noop,
+    }),
+    // MOR-1312 slice 12B (rebase fix): `SemanticRadioSurfaces` now calls every
+    // one of these factories unconditionally at init — this file's own mock
+    // predates 4B-9B and only needs each module-scope call not to throw; none
+    // of these are reachable through the scopeDisplay-only fixtures below.
+    makeFilterHandlers: () => ({
+      onFilterChange: h.noop, onFilterWidthChange: h.noop, onFilterShapeChange: h.noop,
+      onIfShiftChange: h.noop, onPbtInnerChange: h.noop, onPbtOuterChange: h.noop,
+    }),
+    makeDspHandlers: () => ({
+      onNrModeChange: h.noop, onNrLevelChange: h.noop, onNbToggle: h.noop,
+      onNbLevelChange: h.noop, onNbDepthChange: h.noop, onNbWidthChange: h.noop,
+      onNotchModeChange: h.noop, onNotchFreqChange: h.noop,
+      onManualNotchWidthChange: h.noop, onAgcTimeChange: h.noop,
+    }),
+    makeAgcHandlers: () => ({ onAgcModeChange: h.noop }),
+    makeRfFrontEndHandlers: () => ({
+      onAttChange: h.noop, onPreChange: h.noop, onRfGainChange: h.noop,
+      onSquelchChange: h.noop, onDigiSelToggle: h.noop, onIpPlusToggle: h.noop,
+    }),
+    makeBandHandlers: () => ({ onBandSelect: h.noop }),
+    makeAntennaHandlers: () => ({ onSelectAnt1: h.noop, onSelectAnt2: h.noop, onToggleRxAnt: h.noop }),
+    makeRitXitHandlers: () => ({
+      onRitToggle: h.noop, onXitToggle: h.noop, onRitOffsetChange: h.noop,
+      onXitOffsetChange: h.noop, onClear: h.noop,
+    }),
+    makeScanHandlers: () => ({
+      onScanStart: h.noop, onScanStop: h.noop, onDfSpanChange: h.noop, onResumeChange: h.noop,
+    }),
+    makeCwPanelHandlers: () => ({
+      onKeySpeedChange: h.noop, onCwPitchChange: h.noop, onBreakInDelayChange: h.noop,
+      onBreakInModeChange: h.noop, onApfChange: h.noop, onTwinPeakToggle: h.noop,
+      onReversePaddleToggle: h.noop,
+    }),
+    // MOR-1311 slice 11B: the scope-toolbar/popover intent vocabulary.
+    makeScopeControlsHandlers: () => ({
+      onModeChange: h.noop, onEdgeChange: h.noop, onSpanChange: h.noop, onSpeedChange: h.noop,
+      onHoldChange: h.noop, onRefChange: h.noop, onDualChange: h.noop, onReceiverChange: h.noop,
+      onDuringTxChange: h.noop, onCenterTypeChange: h.noop, onVbwChange: h.noop, onRbwChange: h.noop,
+    }),
+  };
+});
 
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';
 // MOR-1365 (S6a): the REAL manifests + the REAL resolution seam, mirroring

--- a/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
@@ -88,75 +88,79 @@ vi.mock('$lib/runtime/adapters/mod-input-tx-guard.svelte', () => ({
 // The names below are the REAL `makeTxHandlers`/`makeVoxHandlers` surface —
 // agreement with the shipped module is proven separately, against the real
 // module, in `tx-aux-command-bus.isolated.test.ts`.
-vi.mock('../command-bus', () => ({
-  makeVfoHandlers: () => ({
-    onVfoSelect: h.noop, onSplitToggle: h.noop, onDualWatchToggle: h.noop,
-  }),
-  makeVoxHandlers: () => ({
-    onVoxToggle: h.voxToggle, onVoxGainChange: h.voxGain,
-    onAntiVoxGainChange: h.antiVoxGain, onVoxDelayChange: h.voxDelay,
-  }),
-  makeTxHandlers: () => ({
-    onRfPowerChange: h.rfPower, onMicGainChange: h.micGain, onAtuToggle: h.atuToggle,
-    onAtuTune: h.atuTune, onVoxToggle: h.voxToggle, onCompToggle: h.compToggle,
-    onCompLevelChange: h.compLevel, onMonToggle: h.monToggle,
-    onMonLevelChange: h.monLevel, onDriveGainChange: h.driveGain,
-  }),
-  // MOR-1279 slice 3B: the RX-audio intent vocabulary.
-  makeRxAudioHandlers: () => ({ onMonitorModeChange: h.noop, onAfLevelChange: h.noop }),
-  // MOR-1310 slice 9B: the semantic CW-keyer surface's setting intents.
-  makeCwPanelHandlers: () => ({
-    onKeySpeedChange: h.noop, onCwPitchChange: h.noop, onBreakInDelayChange: h.noop,
-    onBreakInModeChange: h.noop, onApfChange: h.noop, onTwinPeakToggle: h.noop,
-    onReversePaddleToggle: h.noop,
-  }),
-  makeAudioRoutingHandlers: () => ({ onFocusChange: h.noop, onSplitStereoChange: h.noop }),
-  // MOR-1304 — the wiring now also composes the modeFilter/filterPassband
-  // intent vocabulary; `makeModeHandlers` is composed at both call sites
-  // (rxAudio's MOD-input remedy and filterIntents), so the stub carries both.
-  makeModeHandlers: () => ({
-    onModInputChange: h.noop, onModeChange: h.noop, onDataModeChange: h.noop,
-  }),
-  makeFilterHandlers: () => ({
-    onFilterChange: h.noop, onFilterWidthChange: h.noop, onFilterShapeChange: h.noop,
-    onIfShiftChange: h.noop, onPbtInnerChange: h.noop, onPbtOuterChange: h.noop,
-  }),
-  // MOR-1305 — the wiring now also composes the dsp intent vocabulary. This
-  // fixture declares no dsp capability or state, so none of these is reachable.
-  makeDspHandlers: () => ({
-    onNrModeChange: h.noop, onNrLevelChange: h.noop, onNbToggle: h.noop,
-    onNbLevelChange: h.noop, onNbDepthChange: h.noop, onNbWidthChange: h.noop,
-    onNotchModeChange: h.noop, onNotchFreqChange: h.noop,
-    onManualNotchWidthChange: h.noop, onAgcTimeChange: h.noop,
-  }),
-  makeAgcHandlers: () => ({ onAgcModeChange: h.noop }),
-  // MOR-1306 slice 6B: the RF-front-end intent vocabulary — routing is pinned
-  // separately in `semantic-rf-front-end-wiring.component.test.ts`; this file
-  // only needs the wiring's module-scope `makeRfFrontEndHandlers()` call not
-  // to throw.
-  makeRfFrontEndHandlers: () => ({
-    onAttChange: h.noop, onPreChange: h.noop, onRfGainChange: h.noop,
-    onSquelchChange: h.noop, onDigiSelToggle: h.noop, onIpPlusToggle: h.noop,
-  }),
-  // MOR-1307 slice 7B: the band-select intent the band surface composes.
-  makeBandHandlers: () => ({ onBandSelect: h.noop }),
-  // MOR-1309 slice 8C: the antenna intent vocabulary.
-  makeAntennaHandlers: () => ({ onSelectAnt1: h.noop, onSelectAnt2: h.noop, onToggleRxAnt: h.noop }),
-  // MOR-1308 slice 8B: the RIT/XIT and scan intent vocabularies.
-  makeRitXitHandlers: () => ({
-    onRitToggle: h.noop, onXitToggle: h.noop, onRitOffsetChange: h.noop,
-    onXitOffsetChange: h.noop, onClear: h.noop,
-  }),
-  makeScanHandlers: () => ({
-    onScanStart: h.noop, onScanStop: h.noop, onDfSpanChange: h.noop, onResumeChange: h.noop,
-  }),
-  // MOR-1311 slice 11B: the scope-toolbar/popover intent vocabulary.
-  makeScopeControlsHandlers: () => ({
-    onModeChange: h.noop, onEdgeChange: h.noop, onSpanChange: h.noop, onSpeedChange: h.noop,
-    onHoldChange: h.noop, onRefChange: h.noop, onDualChange: h.noop, onReceiverChange: h.noop,
-    onDuringTxChange: h.noop, onCenterTypeChange: h.noop, onVbwChange: h.noop, onRbwChange: h.noop,
-  }),
-}));
+vi.mock('../command-bus', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../command-bus')>();
+  return {
+    ...actual,
+    makeVfoHandlers: () => ({
+      onVfoSelect: h.noop, onSplitToggle: h.noop, onDualWatchToggle: h.noop,
+    }),
+    makeVoxHandlers: () => ({
+      onVoxToggle: h.voxToggle, onVoxGainChange: h.voxGain,
+      onAntiVoxGainChange: h.antiVoxGain, onVoxDelayChange: h.voxDelay,
+    }),
+    makeTxHandlers: () => ({
+      onRfPowerChange: h.rfPower, onMicGainChange: h.micGain, onAtuToggle: h.atuToggle,
+      onAtuTune: h.atuTune, onVoxToggle: h.voxToggle, onCompToggle: h.compToggle,
+      onCompLevelChange: h.compLevel, onMonToggle: h.monToggle,
+      onMonLevelChange: h.monLevel, onDriveGainChange: h.driveGain,
+    }),
+    // MOR-1279 slice 3B: the RX-audio intent vocabulary.
+    makeRxAudioHandlers: () => ({ onMonitorModeChange: h.noop, onAfLevelChange: h.noop }),
+    // MOR-1310 slice 9B: the semantic CW-keyer surface's setting intents.
+    makeCwPanelHandlers: () => ({
+      onKeySpeedChange: h.noop, onCwPitchChange: h.noop, onBreakInDelayChange: h.noop,
+      onBreakInModeChange: h.noop, onApfChange: h.noop, onTwinPeakToggle: h.noop,
+      onReversePaddleToggle: h.noop,
+    }),
+    makeAudioRoutingHandlers: () => ({ onFocusChange: h.noop, onSplitStereoChange: h.noop }),
+    // MOR-1304 — the wiring now also composes the modeFilter/filterPassband
+    // intent vocabulary; `makeModeHandlers` is composed at both call sites
+    // (rxAudio's MOD-input remedy and filterIntents), so the stub carries both.
+    makeModeHandlers: () => ({
+      onModInputChange: h.noop, onModeChange: h.noop, onDataModeChange: h.noop,
+    }),
+    makeFilterHandlers: () => ({
+      onFilterChange: h.noop, onFilterWidthChange: h.noop, onFilterShapeChange: h.noop,
+      onIfShiftChange: h.noop, onPbtInnerChange: h.noop, onPbtOuterChange: h.noop,
+    }),
+    // MOR-1305 — the wiring now also composes the dsp intent vocabulary. This
+    // fixture declares no dsp capability or state, so none of these is reachable.
+    makeDspHandlers: () => ({
+      onNrModeChange: h.noop, onNrLevelChange: h.noop, onNbToggle: h.noop,
+      onNbLevelChange: h.noop, onNbDepthChange: h.noop, onNbWidthChange: h.noop,
+      onNotchModeChange: h.noop, onNotchFreqChange: h.noop,
+      onManualNotchWidthChange: h.noop, onAgcTimeChange: h.noop,
+    }),
+    makeAgcHandlers: () => ({ onAgcModeChange: h.noop }),
+    // MOR-1306 slice 6B: the RF-front-end intent vocabulary — routing is pinned
+    // separately in `semantic-rf-front-end-wiring.component.test.ts`; this file
+    // only needs the wiring's module-scope `makeRfFrontEndHandlers()` call not
+    // to throw.
+    makeRfFrontEndHandlers: () => ({
+      onAttChange: h.noop, onPreChange: h.noop, onRfGainChange: h.noop,
+      onSquelchChange: h.noop, onDigiSelToggle: h.noop, onIpPlusToggle: h.noop,
+    }),
+    // MOR-1307 slice 7B: the band-select intent the band surface composes.
+    makeBandHandlers: () => ({ onBandSelect: h.noop }),
+    // MOR-1309 slice 8C: the antenna intent vocabulary.
+    makeAntennaHandlers: () => ({ onSelectAnt1: h.noop, onSelectAnt2: h.noop, onToggleRxAnt: h.noop }),
+    // MOR-1308 slice 8B: the RIT/XIT and scan intent vocabularies.
+    makeRitXitHandlers: () => ({
+      onRitToggle: h.noop, onXitToggle: h.noop, onRitOffsetChange: h.noop,
+      onXitOffsetChange: h.noop, onClear: h.noop,
+    }),
+    makeScanHandlers: () => ({
+      onScanStart: h.noop, onScanStop: h.noop, onDfSpanChange: h.noop, onResumeChange: h.noop,
+    }),
+    // MOR-1311 slice 11B: the scope-toolbar/popover intent vocabulary.
+    makeScopeControlsHandlers: () => ({
+      onModeChange: h.noop, onEdgeChange: h.noop, onSpanChange: h.noop, onSpeedChange: h.noop,
+      onHoldChange: h.noop, onRefChange: h.noop, onDualChange: h.noop, onReceiverChange: h.noop,
+      onDuringTxChange: h.noop, onCenterTypeChange: h.noop, onVbwChange: h.noop, onRbwChange: h.noop,
+    }),
+  };
+});
 
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';
 // MOR-1082: the REAL manifests, through the app-wide registration barrel, and

--- a/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
+++ b/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
@@ -76,81 +76,85 @@ vi.mock('$lib/runtime/adapters/mod-input-tx-guard.svelte', () => ({
   deriveModInputTxGuardProps: () => h.modInputGuard,
   getModInputTxGuardHandlers: () => ({ onSetLan: vi.fn(), onDismiss: vi.fn() }),
 }));
-vi.mock('../../../components-v2/wiring/command-bus', () => ({
-  makeVfoHandlers: () => ({
-    onVfoSelect: h.selectVfo,
-    onSplitToggle: h.splitToggle,
-    onDualWatchToggle: h.dualWatchToggle,
-  }),
-  // MOR-1265 — the wiring now also composes the txAux intent vocabulary.
-  makeVoxHandlers: () => ({
-    onVoxToggle: h.txAuxNoop, onVoxGainChange: h.txAuxNoop,
-    onAntiVoxGainChange: h.txAuxNoop, onVoxDelayChange: h.txAuxNoop,
-  }),
-  makeTxHandlers: () => ({
-    onRfPowerChange: h.txAuxNoop, onMicGainChange: h.txAuxNoop, onAtuToggle: h.txAuxNoop,
-    onAtuTune: h.txAuxNoop, onVoxToggle: h.txAuxNoop, onCompToggle: h.txAuxNoop,
-    onCompLevelChange: h.txAuxNoop, onMonToggle: h.txAuxNoop,
-    onMonLevelChange: h.txAuxNoop, onDriveGainChange: h.txAuxNoop,
-  }),
-  // MOR-1279 slice 3B: the RX-audio intent vocabulary.
-  makeRxAudioHandlers: () => ({ onMonitorModeChange: h.txAuxNoop, onAfLevelChange: h.txAuxNoop }),
-  // MOR-1310 slice 9B: the semantic CW-keyer surface's setting intents.
-  makeCwPanelHandlers: () => ({
-    onKeySpeedChange: h.txAuxNoop, onCwPitchChange: h.txAuxNoop, onBreakInDelayChange: h.txAuxNoop,
-    onBreakInModeChange: h.txAuxNoop, onApfChange: h.txAuxNoop, onTwinPeakToggle: h.txAuxNoop,
-    onReversePaddleToggle: h.txAuxNoop,
-  }),
-  makeAudioRoutingHandlers: () => ({ onFocusChange: h.txAuxNoop, onSplitStereoChange: h.txAuxNoop }),
-  // MOR-1304 — the wiring now also composes the modeFilter/filterPassband
-  // intent vocabulary; `makeModeHandlers` is composed at both call sites
-  // (rxAudio's MOD-input remedy and filterIntents), so the stub carries both.
-  // The default fixture (`mainSubCaps()`) declares no filter capability, so
-  // the MOR-1280/1284 evidence gate omits both groups by default.
-  makeModeHandlers: () => ({
-    onModInputChange: h.txAuxNoop, onModeChange: h.txAuxNoop, onDataModeChange: h.txAuxNoop,
-  }),
-  makeFilterHandlers: () => ({
-    onFilterChange: h.txAuxNoop, onFilterWidthChange: h.txAuxNoop, onFilterShapeChange: h.txAuxNoop,
-    onIfShiftChange: h.txAuxNoop, onPbtInnerChange: h.txAuxNoop, onPbtOuterChange: h.txAuxNoop,
-  }),
-  // MOR-1305 — the wiring now also composes the dsp intent vocabulary.
-  makeDspHandlers: () => ({
-    onNrModeChange: h.dspNoop, onNrLevelChange: h.dspNoop, onNbToggle: h.dspNoop,
-    onNbLevelChange: h.dspNoop, onNbDepthChange: h.dspNoop, onNbWidthChange: h.dspNoop,
-    onNotchModeChange: h.dspNoop, onNotchFreqChange: h.dspNoop,
-    onManualNotchWidthChange: h.dspNoop, onAgcTimeChange: h.dspNoop,
-  }),
-  makeAgcHandlers: () => ({ onAgcModeChange: h.dspNoop }),
-  // MOR-1306 slice 6B: the RF-front-end intent vocabulary.
-  makeRfFrontEndHandlers: () => ({
-    onAttChange: h.txAuxNoop, onPreChange: h.txAuxNoop, onRfGainChange: h.txAuxNoop,
-    onSquelchChange: h.txAuxNoop, onDigiSelToggle: h.txAuxNoop, onIpPlusToggle: h.txAuxNoop,
-  }),
-  // MOR-1307 slice 7B: the band-select intent the band surface composes.
-  makeBandHandlers: () => ({ onBandSelect: h.txAuxNoop }),
-  // MOR-1309 slice 8C: the antenna intent vocabulary.
-  makeAntennaHandlers: () => ({ onSelectAnt1: h.txAuxNoop, onSelectAnt2: h.txAuxNoop, onToggleRxAnt: h.txAuxNoop }),
-  // MOR-1308 slice 8B: the RIT/XIT and scan intent vocabularies. MOR-1351
-  // hardened `mainSubCaps()` to carry `rit`/`xit` tags, so this group IS
-  // reachable through the default fixture below — these stubs are exercised,
-  // not merely composition-time stand-ins.
-  makeRitXitHandlers: () => ({
-    onRitToggle: h.txAuxNoop, onXitToggle: h.txAuxNoop, onRitOffsetChange: h.txAuxNoop,
-    onXitOffsetChange: h.txAuxNoop, onClear: h.txAuxNoop,
-  }),
-  makeScanHandlers: () => ({
-    onScanStart: h.txAuxNoop, onScanStop: h.txAuxNoop, onDfSpanChange: h.txAuxNoop,
-    onResumeChange: h.txAuxNoop,
-  }),
-  // MOR-1311 slice 11B: the scope-toolbar/popover intent vocabulary.
-  makeScopeControlsHandlers: () => ({
-    onModeChange: h.txAuxNoop, onEdgeChange: h.txAuxNoop, onSpanChange: h.txAuxNoop,
-    onSpeedChange: h.txAuxNoop, onHoldChange: h.txAuxNoop, onRefChange: h.txAuxNoop,
-    onDualChange: h.txAuxNoop, onReceiverChange: h.txAuxNoop, onDuringTxChange: h.txAuxNoop,
-    onCenterTypeChange: h.txAuxNoop, onVbwChange: h.txAuxNoop, onRbwChange: h.txAuxNoop,
-  }),
-}));
+vi.mock('../../../components-v2/wiring/command-bus', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../components-v2/wiring/command-bus')>();
+  return {
+    ...actual,
+    makeVfoHandlers: () => ({
+      onVfoSelect: h.selectVfo,
+      onSplitToggle: h.splitToggle,
+      onDualWatchToggle: h.dualWatchToggle,
+    }),
+    // MOR-1265 — the wiring now also composes the txAux intent vocabulary.
+    makeVoxHandlers: () => ({
+      onVoxToggle: h.txAuxNoop, onVoxGainChange: h.txAuxNoop,
+      onAntiVoxGainChange: h.txAuxNoop, onVoxDelayChange: h.txAuxNoop,
+    }),
+    makeTxHandlers: () => ({
+      onRfPowerChange: h.txAuxNoop, onMicGainChange: h.txAuxNoop, onAtuToggle: h.txAuxNoop,
+      onAtuTune: h.txAuxNoop, onVoxToggle: h.txAuxNoop, onCompToggle: h.txAuxNoop,
+      onCompLevelChange: h.txAuxNoop, onMonToggle: h.txAuxNoop,
+      onMonLevelChange: h.txAuxNoop, onDriveGainChange: h.txAuxNoop,
+    }),
+    // MOR-1279 slice 3B: the RX-audio intent vocabulary.
+    makeRxAudioHandlers: () => ({ onMonitorModeChange: h.txAuxNoop, onAfLevelChange: h.txAuxNoop }),
+    // MOR-1310 slice 9B: the semantic CW-keyer surface's setting intents.
+    makeCwPanelHandlers: () => ({
+      onKeySpeedChange: h.txAuxNoop, onCwPitchChange: h.txAuxNoop, onBreakInDelayChange: h.txAuxNoop,
+      onBreakInModeChange: h.txAuxNoop, onApfChange: h.txAuxNoop, onTwinPeakToggle: h.txAuxNoop,
+      onReversePaddleToggle: h.txAuxNoop,
+    }),
+    makeAudioRoutingHandlers: () => ({ onFocusChange: h.txAuxNoop, onSplitStereoChange: h.txAuxNoop }),
+    // MOR-1304 — the wiring now also composes the modeFilter/filterPassband
+    // intent vocabulary; `makeModeHandlers` is composed at both call sites
+    // (rxAudio's MOD-input remedy and filterIntents), so the stub carries both.
+    // The default fixture (`mainSubCaps()`) declares no filter capability, so
+    // the MOR-1280/1284 evidence gate omits both groups by default.
+    makeModeHandlers: () => ({
+      onModInputChange: h.txAuxNoop, onModeChange: h.txAuxNoop, onDataModeChange: h.txAuxNoop,
+    }),
+    makeFilterHandlers: () => ({
+      onFilterChange: h.txAuxNoop, onFilterWidthChange: h.txAuxNoop, onFilterShapeChange: h.txAuxNoop,
+      onIfShiftChange: h.txAuxNoop, onPbtInnerChange: h.txAuxNoop, onPbtOuterChange: h.txAuxNoop,
+    }),
+    // MOR-1305 — the wiring now also composes the dsp intent vocabulary.
+    makeDspHandlers: () => ({
+      onNrModeChange: h.dspNoop, onNrLevelChange: h.dspNoop, onNbToggle: h.dspNoop,
+      onNbLevelChange: h.dspNoop, onNbDepthChange: h.dspNoop, onNbWidthChange: h.dspNoop,
+      onNotchModeChange: h.dspNoop, onNotchFreqChange: h.dspNoop,
+      onManualNotchWidthChange: h.dspNoop, onAgcTimeChange: h.dspNoop,
+    }),
+    makeAgcHandlers: () => ({ onAgcModeChange: h.dspNoop }),
+    // MOR-1306 slice 6B: the RF-front-end intent vocabulary.
+    makeRfFrontEndHandlers: () => ({
+      onAttChange: h.txAuxNoop, onPreChange: h.txAuxNoop, onRfGainChange: h.txAuxNoop,
+      onSquelchChange: h.txAuxNoop, onDigiSelToggle: h.txAuxNoop, onIpPlusToggle: h.txAuxNoop,
+    }),
+    // MOR-1307 slice 7B: the band-select intent the band surface composes.
+    makeBandHandlers: () => ({ onBandSelect: h.txAuxNoop }),
+    // MOR-1309 slice 8C: the antenna intent vocabulary.
+    makeAntennaHandlers: () => ({ onSelectAnt1: h.txAuxNoop, onSelectAnt2: h.txAuxNoop, onToggleRxAnt: h.txAuxNoop }),
+    // MOR-1308 slice 8B: the RIT/XIT and scan intent vocabularies. MOR-1351
+    // hardened `mainSubCaps()` to carry `rit`/`xit` tags, so this group IS
+    // reachable through the default fixture below — these stubs are exercised,
+    // not merely composition-time stand-ins.
+    makeRitXitHandlers: () => ({
+      onRitToggle: h.txAuxNoop, onXitToggle: h.txAuxNoop, onRitOffsetChange: h.txAuxNoop,
+      onXitOffsetChange: h.txAuxNoop, onClear: h.txAuxNoop,
+    }),
+    makeScanHandlers: () => ({
+      onScanStart: h.txAuxNoop, onScanStop: h.txAuxNoop, onDfSpanChange: h.txAuxNoop,
+      onResumeChange: h.txAuxNoop,
+    }),
+    // MOR-1311 slice 11B: the scope-toolbar/popover intent vocabulary.
+    makeScopeControlsHandlers: () => ({
+      onModeChange: h.txAuxNoop, onEdgeChange: h.txAuxNoop, onSpanChange: h.txAuxNoop,
+      onSpeedChange: h.txAuxNoop, onHoldChange: h.txAuxNoop, onRefChange: h.txAuxNoop,
+      onDualChange: h.txAuxNoop, onReceiverChange: h.txAuxNoop, onDuringTxChange: h.txAuxNoop,
+      onCenterTypeChange: h.txAuxNoop, onVbwChange: h.txAuxNoop, onRbwChange: h.txAuxNoop,
+    }),
+  };
+});
 
 import DualReceiverCockpit from '../DualReceiverCockpit.svelte';
 // MOR-1068 F6: the manifest's declared zone ids, read through the app-wide


### PR DESCRIPTION
## Summary

Closes the one-sided stub-export-parity class: 9 hand-enumerated `vi.mock('../command-bus')` factories (the ticket's historical "four" had grown) converted to `importOriginal`-based partial mocks — `...actual` spread first, each file's overrides preserved byte-identical. New `make*Handlers` exports now flow through automatically instead of turning 100+ tests red per B-slice.

Deliberately NOT converted: 17 `$lib/runtime`/frontend-runtime mock sites — singleton module with one value export, no enumeration to drift; conversion would add risk for zero parity benefit.

## Evidence

- Class closure proven twice: builder probe (unused export) and the verifier's stronger discriminating probe — a new export **consumed in `SemanticRadioSurfaces`**: base = 9 files / 232 tests fail; HEAD = all pass with zero edits. Reverted clean.
- Overrides byte-identical: indent-normalized diff shows the only removed lines are the mock opener/closer; `...actual` first key in all nine.
- Full suite 289 files / 5948 tests green (builder ×1, verifier ×1); eslint clean; `npm run check` 4497 files / 0 errors (verifier-added gate).
- Test-only: 0 production LOC (+32 net test LOC).

## Notes for the record (verify-mor-1353.md)

- All 9 files run in the `isolate: true` pool; the conversion pins the REAL command-bus module graph (constructs inertly). Constraint for future conversions: never apply this recipe to `isolate: false` fast-pool files.
- Accepted cost of option (a): a future non-enumerated factory falls through to the real handler (blocks-and-warns) instead of a loud TypeError.

## Review provenance

Built by session-9 sonnet builder (build-mor-1353.md), independently verified by session-9 verifier anchor #1 (opus): **PASS**, commit unamended (verify-mor-1353.md, session-9 scratchpad).

🤖 Generated with [Claude Code](https://claude.com/claude-code)