### PR TITLE
refactor(MOR-1358): shared pressedOf helper - aria-pressed unknown-omission class closed

### DIFF
--- a/frontend/src/semantic/CwKeyerSurface.svelte
+++ b/frontend/src/semantic/CwKeyerSurface.svelte
@@ -52,6 +52,7 @@
 -->
 <script module lang="ts">
   import type { BreakInMode, CwKeyerField, DisabledReasonCode } from './radio-view-model';
+  import { pressedOf } from './pressed-of';
 
   /** Break-in as THREE ABSOLUTE choices, `[label, wire mode]`. Absolute, not a
    *  toggle: a toggle computed from an unread reading arms a guess, and here
@@ -205,8 +206,7 @@
     {#if cw.reversePaddle.availability.structural}
       <button
         type="button" class="cw-keyer-toggle" data-testid="cw-keyer-reverse-paddle"
-        aria-pressed={cw.reversePaddle.reading.status === 'known'
-          ? cw.reversePaddle.reading.value : undefined}
+        aria-pressed={pressedOf(cw.reversePaddle)}
         disabled={!usable(cw.reversePaddle)}
         onclick={toggleReversePaddle}
       >Reverse paddle: {textOf(cw.reversePaddle)}</button>
@@ -244,7 +244,7 @@
       <div class="cw-keyer-row" data-testid="cw-keyer-twin-peak" data-observed={usable(cw.twinPeak)}>
         <button
           type="button" class="cw-keyer-toggle" data-testid="cw-keyer-twin-peak-toggle"
-          aria-pressed={cw.twinPeak.reading.status === 'known' ? cw.twinPeak.reading.value : undefined}
+          aria-pressed={pressedOf(cw.twinPeak)}
           disabled={!usable(cw.twinPeak) || mutexed('twinPeak')}
           onclick={toggleTwinPeak}
         >TPF: {textOf(cw.twinPeak)}</button>

--- a/frontend/src/semantic/DspSurface.svelte
+++ b/frontend/src/semantic/DspSurface.svelte
@@ -38,6 +38,7 @@
   import { buildAgcOptions } from '../components-v2/panels/agc-utils';
   import { NOTCH_WIDTH_LABELS, formatAgcTime } from '../components-v2/panels/dsp-panel-logic';
   import { rawToPercentDisplay } from '../components-v2/controls/value-control/value-control-core';
+  import { pressedOf } from './pressed-of';
 
   /** On/off controls, `[field, label]`. */
   export const DSP_TOGGLES = [['nrActive', 'NR'], ['nbActive', 'NB']] as const;
@@ -70,8 +71,6 @@
     const v = f.reading.value;
     return typeof v === 'boolean' ? (v ? 'on' : 'off') : format ? format(v as number) : String(v);
   };
-  const pressedOf = (f: DspField<unknown>): boolean | undefined =>
-    f.reading.status === 'known' ? f.reading.value !== false : undefined;
 </script>
 
 <script lang="ts">

--- a/frontend/src/semantic/RfFrontEndSurface.svelte
+++ b/frontend/src/semantic/RfFrontEndSurface.svelte
@@ -41,6 +41,7 @@
 -->
 <script module lang="ts">
   import type { DisabledReasonCode, RfFrontEndField } from './radio-view-model';
+  import { pressedOf } from './pressed-of';
 
   /** The one rendering of "not read". Never 0, never the last value. */
   export const UNKNOWN_TEXT = '?';
@@ -180,7 +181,7 @@
         <button
           type="button" class="rf-front-end-toggle"
           data-testid={`rf-front-end-${field}`} data-observed={usable(rf[field])}
-          aria-pressed={rf[field].reading.status === 'known' ? rf[field].reading.value : undefined}
+          aria-pressed={pressedOf(rf[field])}
           disabled={!usable(rf[field])}
           onclick={() => toggle(field)}
         >{label}: {textOf(rf[field])}</button>

--- a/frontend/src/semantic/RitXitScanSurface.svelte
+++ b/frontend/src/semantic/RitXitScanSurface.svelte
@@ -44,6 +44,7 @@
 -->
 <script module lang="ts">
   import type { RitXitField, ScanField } from './radio-view-model';
+  import { pressedOf } from './pressed-of';
 
   export const UNKNOWN_TEXT = '—';
   /** O2 — v2's own `RitXitPanel` bounds, verbatim. */
@@ -56,13 +57,6 @@
   export const textOf = (f: RitXitField<unknown> | ScanField<unknown>): string =>
     f.reading.status === 'known' ? String(f.reading.value) : UNKNOWN_TEXT;
   const isOn = (f: RitXitField<boolean>): boolean => f.reading.status === 'known' && f.reading.value === true;
-  /** F2 (fix round, verify-MOR-1308). `TxAuxSurface.svelte`'s `pressedOf`,
-   *  verbatim shape: `boolean | undefined` so `aria-pressed` is OMITTED —
-   *  never `"false"` — when the reading is unknown. Claiming "off" for a
-   *  field this surface has never observed is the same fabrication the
-   *  B-wave criterion forbids for the underlying dispatch below. */
-  const pressedOf = (f: RitXitField<boolean> | ScanField<boolean>): boolean | undefined =>
-    f.reading.status === 'known' ? f.reading.value : undefined;
 </script>
 
 <script lang="ts">

--- a/frontend/src/semantic/TxAuxSurface.svelte
+++ b/frontend/src/semantic/TxAuxSurface.svelte
@@ -28,6 +28,7 @@
 -->
 <script module lang="ts">
   import type { TxAuxField } from './radio-view-model';
+  import { pressedOf } from './pressed-of';
 
   /** On/off controls, `[field, label]`. ATU's reading is a three-state enum,
    *  the rest are booleans; `pressedOf` normalises both to one aria state. */
@@ -61,8 +62,6 @@
     f.reading.status !== 'known' ? '?'
       : typeof f.reading.value === 'boolean' ? (f.reading.value ? 'on' : 'off')
         : String(f.reading.value);
-  const pressedOf = (f: TxAuxField<unknown>): boolean | undefined =>
-    f.reading.status === 'known' ? f.reading.value !== false && f.reading.value !== 'off' : undefined;
   const numberOf = (f: TxAuxField<number>, fallback: number): number =>
     f.reading.status === 'known' ? f.reading.value : fallback;
 

--- a/frontend/src/semantic/__tests__/CwKeyerSurface.test.ts
+++ b/frontend/src/semantic/__tests__/CwKeyerSurface.test.ts
@@ -101,11 +101,16 @@ const slide = (el: HTMLInputElement, value: number) => {
 describe('the CW-keyer surface is NOT a key path (decomposition R9)', () => {
   /** The whole static import closure of the file, allow-listed. Kills: adding
    *  ANY import that could reach the TX controller, the transport or the
-   *  permit utility — including through a relative specifier. */
-  it('imports nothing but the fact contract', () => {
+   *  permit utility — including through a relative specifier.
+   *  `./pressed-of` (MOR-1358) is allow-listed alongside the fact contract:
+   *  it is a pure, dependency-free `aria-pressed` derivation shared with
+   *  four sibling surfaces, itself importing only a TYPE from
+   *  `./radio-view-model` — it cannot reach the TX controller, the
+   *  transport or the permit utility any more than the fact contract can. */
+  it('imports nothing but the fact contract and the shared pressedOf helper', () => {
     const specifiers = [...CODE.matchAll(/from\s+'([^']+)'/g)].map((m) => m[1]);
     expect(specifiers.length).toBeGreaterThan(0);
-    expect([...new Set(specifiers)]).toEqual(['./radio-view-model']);
+    expect([...new Set(specifiers)]).toEqual(['./radio-view-model', './pressed-of']);
   });
 
   // Kills: `onMount(() => …)` and every relative of it, plus a dynamic import

--- a/frontend/src/semantic/__tests__/CwKeyerSurface.test.ts
+++ b/frontend/src/semantic/__tests__/CwKeyerSurface.test.ts
@@ -106,7 +106,10 @@ describe('the CW-keyer surface is NOT a key path (decomposition R9)', () => {
    *  it is a pure, dependency-free `aria-pressed` derivation shared with
    *  four sibling surfaces, itself importing only a TYPE from
    *  `./radio-view-model` — it cannot reach the TX controller, the
-   *  transport or the permit utility any more than the fact contract can. */
+   *  transport or the permit utility any more than the fact contract can.
+   *  This check regexes THIS file's specifiers only, so that premise is
+   *  pinned one level down by `pressed-of.test.ts`'s `'has no runtime
+   *  import'` case (verify-MOR-1358 F1) — the two together are the closure. */
   it('imports nothing but the fact contract and the shared pressedOf helper', () => {
     const specifiers = [...CODE.matchAll(/from\s+'([^']+)'/g)].map((m) => m[1]);
     expect(specifiers.length).toBeGreaterThan(0);

--- a/frontend/src/semantic/__tests__/pressed-of.test.ts
+++ b/frontend/src/semantic/__tests__/pressed-of.test.ts
@@ -18,6 +18,7 @@
  * keep passing unmodified because the wiring — `aria-pressed={pressedOf(f)}`
  * — is unchanged; only the definition moved.
  */
+import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import { pressedOf } from '../pressed-of';
 import type { Availability, TxAuxField } from '../radio-view-model';
@@ -47,7 +48,24 @@ describe('pressedOf (MOR-1358)', () => {
     expect(pressedOf(known('off'))).toBe(false);
   });
 
-  it.each(['on', 'tuning'])('returns true for a known enum reading of "%s"', (value) => {
+  it.each(['on', 'tuning'] as const)('returns true for a known enum reading of "%s"', (value) => {
     expect(pressedOf(known(value))).toBe(true);
+  });
+
+  /** verify-MOR-1358 F1. `CwKeyerSurface` is SAFETY-CRITICAL (MOR-1310) and
+   *  its "imports nothing but the fact contract" allow-list was widened to
+   *  admit `./pressed-of`. That allow-list regexes `CwKeyerSurface.svelte`'s
+   *  OWN specifiers only — it cannot see one level down — so the premise the
+   *  widening rests on ("pure, dependency-free, imports only a type") was
+   *  unpinned. This is that pin. Kills: any value import added here, which
+   *  would become a runtime edge from the safety-critical surface into
+   *  whatever it reaches (the TX controller, the transport, the permit
+   *  utility) without any existing test noticing. */
+  it('has no runtime import — the safety allow-lists that name it depend on this', () => {
+    const source = readFileSync('src/semantic/pressed-of.ts', 'utf8');
+    const statements = [...source.matchAll(/^import\b[^;]*;/gm)].map((m) => m[0]);
+    expect(statements.length).toBeGreaterThan(0);
+    for (const statement of statements) expect(statement.startsWith('import type ')).toBe(true);
+    for (const forbidden of ['import(', 'require(']) expect(source).not.toContain(forbidden);
   });
 });

--- a/frontend/src/semantic/__tests__/pressed-of.test.ts
+++ b/frontend/src/semantic/__tests__/pressed-of.test.ts
@@ -1,0 +1,53 @@
+/**
+ * MOR-1358 — the shared `pressedOf` helper, extracted from `TxAuxSurface`
+ * (MOR-1265, slice 1B) after three later slices (`DspSurface` 5B,
+ * `RitXitScanSurface` 8B, `CwKeyerSurface` 9B) independently re-derived and
+ * pinned the same rule, and a fourth (`RfFrontEndSurface` 6B) shipped the
+ * same inline shape unpinned.
+ *
+ * ONE test file for the rule, replacing the class of per-slice
+ * `aria-pressed`-omission pins: on an UNOBSERVED reading, `pressedOf` must
+ * return `undefined` (Svelte OMITS the attribute), never `false`
+ * (`aria-pressed="false"` would fabricate a positively-known OFF claim about
+ * a reading the radio never reported). Every migrated surface
+ * (`TxAuxSurface`, `DspSurface`, `RitXitScanSurface`, `RfFrontEndSurface`,
+ * `CwKeyerSurface`) now imports this one function instead of a local copy —
+ * the per-surface component tests that already exercise their own DOM
+ * wiring (e.g. `RitXitScanSurface.test.ts`'s "omits aria-pressed" cases,
+ * `CwKeyerSurface.test.ts`'s "disables and refuses … while unobserved")
+ * keep passing unmodified because the wiring — `aria-pressed={pressedOf(f)}`
+ * — is unchanged; only the definition moved.
+ */
+import { describe, expect, it } from 'vitest';
+import { pressedOf } from '../pressed-of';
+import type { Availability, TxAuxField } from '../radio-view-model';
+
+const ON: Availability = { structural: true, operational: true };
+
+const unread = <T>(): TxAuxField<T> => ({ reading: { status: 'unknown' }, availability: ON });
+const known = <T>(value: T): TxAuxField<T> => ({ reading: { status: 'known', value }, availability: ON });
+
+describe('pressedOf (MOR-1358)', () => {
+  it('returns undefined for an unobserved reading — never false', () => {
+    expect(pressedOf(unread<boolean>())).toBeUndefined();
+  });
+
+  it('returns true for a known plain-boolean true reading', () => {
+    expect(pressedOf(known(true))).toBe(true);
+  });
+
+  it('returns false for a known plain-boolean false reading', () => {
+    expect(pressedOf(known(false))).toBe(false);
+  });
+
+  // The `AtuStatus` three-state enum (`'off' | 'on' | 'tuning'`) is the
+  // reason the comparison is `!== false && !== 'off'` rather than a plain
+  // boolean cast — TxAuxSurface's verbatim ATU shape.
+  it('returns false for a known enum reading of "off"', () => {
+    expect(pressedOf(known('off'))).toBe(false);
+  });
+
+  it.each(['on', 'tuning'])('returns true for a known enum reading of "%s"', (value) => {
+    expect(pressedOf(known(value))).toBe(true);
+  });
+});

--- a/frontend/src/semantic/pressed-of.ts
+++ b/frontend/src/semantic/pressed-of.ts
@@ -1,0 +1,28 @@
+/**
+ * Shared `aria-pressed` derivation for semantic-surface toggle controls
+ * (MOR-1358).
+ *
+ * Extracted from `TxAuxSurface.svelte` (MOR-1265, slice 1B), which held the
+ * correct shape from the start. Three later slices (`DspSurface` 5B,
+ * `RitXitScanSurface` 8B, `CwKeyerSurface` 9B) independently re-derived and
+ * pinned the same rule — `RfFrontEndSurface` (6B) has the same inline shape
+ * unpinned — instead of importing one answer: on an UNOBSERVED reading,
+ * `aria-pressed` must be OMITTED (`undefined`), never `"false"`.
+ * `aria-pressed="false"` is not the absence of a claim, it is the claim
+ * "this control is OFF" about a reading the radio never reported — the same
+ * fail-closed-presentation doctrine every semantic surface in this directory
+ * follows for text (`textOf`/`fmt` render `?`/`—`, never a v2 default).
+ *
+ * `value !== false && value !== 'off'` (not a plain boolean cast) is
+ * deliberate: it normalises both plain booleans (`vox`, `nrActive`, …) and
+ * the `AtuStatus` three-state enum (`'off' | 'on' | 'tuning'`) to one aria
+ * state without the caller pre-converting — verbatim the shape
+ * `TxAuxSurface` shipped for the ATU toggle.
+ */
+import type { TxAuxField } from './radio-view-model';
+
+export function pressedOf(field: TxAuxField<unknown>): boolean | undefined {
+  return field.reading.status === 'known'
+    ? field.reading.value !== false && field.reading.value !== 'off'
+    : undefined;
+}

--- a/frontend/src/semantic/pressed-of.ts
+++ b/frontend/src/semantic/pressed-of.ts
@@ -18,10 +18,25 @@
  * the `AtuStatus` three-state enum (`'off' | 'on' | 'tuning'`) to one aria
  * state without the caller pre-converting — verbatim the shape
  * `TxAuxSurface` shipped for the ATU toggle.
+ *
+ * The parameter is `TxAuxField<boolean | AtuStatus>`, NOT `TxAuxField<unknown>`
+ * (verify-MOR-1358 F2): that is the exact domain the body is correct over.
+ * A numeric level field would type-check under `unknown` and then read as
+ * PRESSED for every value including `0` (`0 !== false` is `true`) — the same
+ * fabricated-claim class this helper exists to prevent. `RitXitScanSurface`
+ * and `ScopeControlsSurface` both declared `<boolean>` locally; widening to
+ * `unknown` during the extraction would have dropped that protection.
+ *
+ * NOTE — this module must stay dependency-free at RUNTIME. `CwKeyerSurface`
+ * is safety-critical (MOR-1310) and its "imports nothing but the fact
+ * contract" allow-list now names `./pressed-of`; that allow-list only scans
+ * `CwKeyerSurface`'s own specifiers, so the purity of this file is what makes
+ * the widened allow-list sound. It is pinned by `pressed-of.test.ts`'s
+ * `'has no runtime import'` case — do not add a value import here.
  */
-import type { TxAuxField } from './radio-view-model';
+import type { AtuStatus, TxAuxField } from './radio-view-model';
 
-export function pressedOf(field: TxAuxField<unknown>): boolean | undefined {
+export function pressedOf(field: TxAuxField<boolean | AtuStatus>): boolean | undefined {
   return field.reading.status === 'known'
     ? field.reading.value !== false && field.reading.value !== 'off'
     : undefined;


### PR DESCRIPTION
## Summary

Extracts TxAuxSurface's correct `pressedOf` (unobserved toggle → aria-pressed OMITTED, never "false") to `frontend/src/semantic/pressed-of.ts` and migrates the five applicable surfaces (txAux, dsp, ritXitScan, rfFrontEnd, cwKeyer×2 toggles). One shared unit test replaces per-slice re-litigation. FilterSurface deliberately excluded — its choice groups correctly use isSelected/"false" semantics. ScopeControlsSurface follow-up: MOR-1383.

## Verifier fixes (in head 0a1ecf60)

- F1: the safety-critical CwKeyer import allow-list admitted `./pressed-of` on an unpinned premise — the helper's runtime purity is now itself pinned (a value import would be detected).
- F2: signature narrowed `TxAuxField<unknown>` → `TxAuxField<boolean | AtuStatus>` — under `unknown`, a numeric level field type-checked and read as PRESSED at 0.

## Evidence

- Three of five local copies were NOT byte-identical to the TxAux original; every divergence proven a no-op over the runtime-validated domain (bool / AtuStatus).
- 8-mutant battery: 7 killed, 1 proven equivalent.
- LOC +4 net production (binding, verifier re-measured); suite 290 files / 5955 tests green.

## Review provenance

Built by session-9 sonnet builder (build-mor-1358.md); verified by session-9 anchor #2 (opus): **PASS-with-fixes** (verify-mor-1358.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)