### PR TITLE
fix(MOR-1376): PTT generation-identity liveness guard (with MOR-1378 extraction)

### DIFF
--- a/frontend/fixtures/capture-ptt.mjs
+++ b/frontend/fixtures/capture-ptt.mjs
@@ -237,22 +237,24 @@ const SCENARIOS = [
     },
   },
   {
-    // MOR-1088 FINDING (verification-only — NOT fixed in this slice, file a
-    // follow-up ticket): a double orientation flip within the 50ms hold-delay
-    // window lets an ABANDONED older-surface press spuriously key a BRAND NEW
-    // recognizer generation that the operator never actually pressed.
-    // `fabDown`/`fabUp`'s liveness guard (`MobileRadioLayout.svelte` ~L396-406,
-    // mirrored here) checks only the coarse `surface` label ('portrait' vs
-    // 'landscape'), not which SPECIFIC recognizer generation armed the timer —
-    // the ResourceDemand handle-identity trap class (see standing memory: a
-    // stale async callback acts on whatever a shared mutable slot currently
-    // points to, without checking it is still ITS OWN handle). This assertion
-    // PINS the currently observed (unsafe) behavior as a regression floor —
-    // it must fail loudly if a future change makes it WORSE (more than one
-    // spurious call, or a guard belonging to neither generation) — it does
-    // NOT assert the ticket's ideal "a newer key owner survives" property,
-    // which this code does not currently meet.
-    name: 'orientation-double-flip-ghost-press-known-gap',
+    // MOR-1376 (was the MOR-1088 flagship FINDING, now FIXED and pinned SAFE).
+    // A double orientation flip within the 50ms hold-delay window used to let
+    // an ABANDONED older-surface press spuriously key a BRAND NEW recognizer
+    // generation the operator never pressed: `fabDown`/`fabUp`'s liveness guard
+    // checked only the coarse surface label ('portrait' vs 'landscape'), not
+    // which SPECIFIC recognizer generation armed the timer — the ResourceDemand
+    // handle-identity trap class (a stale async callback acting on whatever a
+    // shared mutable slot currently points to, without checking it is still ITS
+    // OWN handle). MOR-1376 moved the identity into the binding: each
+    // generation hands out its own fabDown/fabUp, PttFab snapshots them when a
+    // press arms, and a destroyed generation is inert.
+    //
+    // This assertion now pins the SAFE property in BOTH directions: the ghost
+    // must NOT key (a regression that reinstates the shared forwarder fails on
+    // `guard`/`calls`), and the surviving surface must still be usable (an
+    // over-broad guard that bricks the live FAB fails on the deliberate press
+    // at the end).
+    name: 'orientation-double-flip-newer-owner-survives',
     async run(page) {
       // Abandoned press on the FIRST portrait surface — never released, still
       // inside its 50ms hold-delay when we rotate away from it twice.
@@ -263,18 +265,23 @@ const SCENARIOS = [
       await page.evaluate(() => window.__ptt.setSurface('portrait')); // generation 3 — a NEW, unrelated recognizer
       const g3guardBeforeGhost = await page.evaluate(() => window.__ptt.guardId());
       // The FIRST press's 50ms timer (armed at t=0) fires around now (~t=50),
-      // long after generation 3 replaced generation 1 — the guard checked at
-      // fire time is only the current LIVE surface label, and we are back in
-      // portrait, so it passes even though generation 3 never pressed anything.
+      // long after generation 3 replaced generation 1. It resolves to
+      // generation 1's own (destroyed, inert) handler, so nothing keys.
       await wait(page, 60);
       const afterGhostWindow = await snap(page);
+      // Direction 2: generation 3 is untouched, not collaterally disarmed.
+      await pointer(page, '.ptt-fab', 'pointerdown');
+      await wait(page, 70);
+      const afterRealPress = await snap(page);
       return {
         ok: g3guardBeforeGhost === null // generation 3 starts clean, as expected
-          && afterGhostWindow.guardId !== null && afterGhostWindow.calls === 1, // KNOWN GAP: ghost keyed it anyway
+          && afterGhostWindow.guardId === null && afterGhostWindow.calls === 0 // SAFE: no ghost key
+          && afterRealPress.guardId !== null && afterRealPress.calls === 1,    // and a real press still keys
         detail: `generation-3 guard before ghost=${g3guardBeforeGhost !== null} (expected false) · `
           + `after the abandoned generation-1 press's delayed timer fires: `
-          + `guard=${afterGhostWindow.guardId !== null} calls=${afterGhostWindow.calls} `
-          + '(expected true/1 — KNOWN GAP, not the ideal "newer owner survives"; regression floor only, see comment above)',
+          + `guard=${afterGhostWindow.guardId !== null} calls=${afterGhostWindow.calls} (expected false/0) · `
+          + `after a deliberate press on the surviving surface: `
+          + `guard=${afterRealPress.guardId !== null} calls=${afterRealPress.calls} (expected true/1)`,
       };
     },
   },

--- a/frontend/fixtures/ptt-main.ts
+++ b/frontend/fixtures/ptt-main.ts
@@ -16,17 +16,20 @@
  * `ReferenceLayout.svelte` already makes for `RadioLayout` (a lighter,
  * real-component stand-in, not a re-simulation).
  *
- * The orientation-swap wiring below (recreate-one-recognizer-per-surface,
- * shared `fabDown`/`fabUp` reading LIVE state) is a hand-mirror of
- * `MobileRadioLayout.svelte`'s own `$effect`, not an import of it. Scenarios
- * below prove the PATTERN is load-bearing where mirrored faithfully, not that
- * MobileRadioLayout.svelte's own copy is byte-identical (verified by direct
- * reading instead). Extraction into a shared mountable function is MOR-1378.
- * `PttFab.svelte` itself is mounted unmodified.
+ * The orientation-swap wiring below is NO LONGER a hand-mirror: MOR-1378
+ * extracted `MobileRadioLayout.svelte`'s own `$effect` into
+ * `components-v2/wiring/mobile-ptt-surface.ts`, and this harness now imports
+ * and drives that REAL, unmodified module — the same code the shipped layout
+ * composes. `PttFab.svelte` is likewise mounted unmodified. What remains
+ * harness-local is only the host facade (a fixed fake authority/eligibility in
+ * place of the WS-backed session projector) and the surface swap trigger the
+ * component gets from its `isLandscape` `$derived`.
  */
 import { mount, unmount } from 'svelte';
 import { TxController, type TxControllerDependencies } from '../src/lib/runtime/tx-controller/controller';
-import { createPttGesture, type PttGesture } from '../src/components-v2/wiring/tx-ptt-gesture';
+import {
+  createMobilePttSurface, type MobilePttBinding,
+} from '../src/components-v2/wiring/mobile-ptt-surface';
 import type {
   Eligibility, PttMarker, PttObservation, TxGuard,
 } from '../src/lib/runtime/tx-controller/model';
@@ -80,49 +83,49 @@ const controller = new TxController(
 );
 controller.subscribe((s) => setPttMode(s.intent === 'latched' ? 'latched' : s.guard !== null ? 'held' : 'idle'));
 
-// The same 4-verb facade `tx-controller/app-host.ts` exposes over
+// The same facade `tx-controller/app-host.ts` exposes over
 // `controller.dispatch` — rebuilt here against a fixed eligibility/PTT
-// observation instead of `browser-dependencies.ts`'s WS-session projector.
-const facade = {
-  start: (sourceId: string, leaseId: string) => controller.dispatch(
-    { type: 'start', sourceId, leaseId, intent: 'momentary', eligibility, ptt: observation() }),
-  setIntent: (sourceId: string, guard: TxGuard) => controller.dispatch(
-    { type: 'intent', sourceId, guard, intent: 'latched' }),
-  release: (sourceId: string, guard: TxGuard) => controller.dispatch(
-    { type: 'release', sourceId, guard, commandId: deps.commandId('off') }),
+// observation instead of `browser-dependencies.ts`'s WS-session projector, and
+// shaped to `MobilePttHost` so the REAL `createMobilePttSurface` runs on it.
+const host = {
+  snapshot: () => controller.snapshot(),
+  resetFault: () => controller.dispatch({ type: 'reset-fault' }),
+  start: (sourceId: string, leaseId: string) => {
+    calls.push('tx.start');
+    controller.dispatch({ type: 'start', sourceId, leaseId, intent: 'momentary', eligibility, ptt: observation() });
+  },
+  setIntent: (sourceId: string, guard: TxGuard) => {
+    calls.push('tx.latch');
+    controller.dispatch({ type: 'intent', sourceId, guard, intent: 'latched' });
+  },
+  release: (sourceId: string, guard: TxGuard) => {
+    calls.push('tx.release');
+    controller.dispatch({ type: 'release', sourceId, guard, commandId: deps.commandId('off') });
+  },
 };
 
-// ── orientation-swap wiring (mirrors MobileRadioLayout.svelte) ──────────
+// ── orientation swap — drives the REAL wiring module (MOR-1378) ─────────
 let surface: 'portrait' | 'landscape' = 'portrait';
-let seq = 0;
 let generation = 0;
-let ptt: PttGesture | null = null;
+let ptt: MobilePttBinding | null = null;
 let fabInstance: object | null = null;
 const portraitEl = document.getElementById('portrait-slot')!;
 const landscapeEl = document.getElementById('landscape-slot')!;
 
-// Stable, shared across every surface generation — reads LIVE `surface`/`ptt`
-// at call time, exactly like the real component's `fabDown`/`fabUp`. This is
-// the function whose staleness guard MOR-1088 sabotage-tests (see build
-// report item 10/11): a press begun on an old surface can still fire this
-// after a rotation swapped in a new recognizer.
-function fabDown(): void { if (surface === 'portrait') ptt?.down(); }
-function fabUp(): void { if (surface === 'portrait') ptt?.up(); }
-
 function applySurface(): void {
   ptt?.destroy();
-  const sourceId = `mobile-ptt-${surface}-${++seq}`;
-  generation = seq;
-  let leaseSeq = 0;
-  ptt = createPttGesture(
-    { guard: () => controller.snapshot().guard, latched: () => controller.snapshot().intent === 'latched' },
-    {
-      start: () => { calls.push('tx.start'); facade.start(sourceId, `${sourceId}-${++leaseSeq}`); },
-      latch: (guard) => { calls.push('tx.latch'); facade.setIntent(sourceId, guard); },
-      release: (guard) => { calls.push('tx.release'); facade.release(sourceId, guard); },
-    },
+  generation += 1;
+  ptt = createMobilePttSurface(
+    surface, host,
     { schedule: (cb, ms) => setTimeout(cb, ms), cancel: (h) => clearTimeout(h as ReturnType<typeof setTimeout>) },
+    () => surface,
   );
+  // Reads the LIVE binding slot at call time, faithfully modelling how Svelte
+  // compiles `onDown={fabDown}` in the shipped component: the layout's stable
+  // handler forwards to whatever `ptt` currently holds. This is the staleness
+  // the MOR-1088 double-flip scenario exercises.
+  const fabDown = (): void => ptt?.fabDown();
+  const fabUp = (): void => ptt?.fabUp();
   if (fabInstance) { unmount(fabInstance); fabInstance = null; }
   portraitEl.replaceChildren();
   landscapeEl.replaceChildren();

--- a/frontend/fixtures/ptt-main.ts
+++ b/frontend/fixtures/ptt-main.ts
@@ -118,14 +118,13 @@ function applySurface(): void {
   ptt = createMobilePttSurface(
     surface, host,
     { schedule: (cb, ms) => setTimeout(cb, ms), cancel: (h) => clearTimeout(h as ReturnType<typeof setTimeout>) },
-    () => surface,
   );
-  // Reads the LIVE binding slot at call time, faithfully modelling how Svelte
-  // compiles `onDown={fabDown}` in the shipped component: the layout's stable
-  // handler forwards to whatever `ptt` currently holds. This is the staleness
-  // the MOR-1088 double-flip scenario exercises.
-  const fabDown = (): void => ptt?.fabDown();
-  const fabUp = (): void => ptt?.fabUp();
+  // MOR-1376: hand the FAB THIS generation's own handlers, exactly as the
+  // shipped layout's `onDown={ptt?.fabDown}` now does — never a stable
+  // forwarder that re-reads the live binding slot. A press stranded by a
+  // rotation then completes against the generation it was armed on.
+  const fabDown = ptt.fabDown;
+  const fabUp = ptt.fabUp;
   if (fabInstance) { unmount(fabInstance); fabInstance = null; }
   portraitEl.replaceChildren();
   landscapeEl.replaceChildren();

--- a/frontend/src/components-v2/controls/PttFab.svelte
+++ b/frontend/src/components-v2/controls/PttFab.svelte
@@ -51,6 +51,14 @@
   let engaged = false;               // true once onDown() was invoked
   let startX = 0;
   let startY = 0;
+  // MOR-1376: the callbacks the CURRENT press was armed against. The hold timer
+  // below is deliberately not cleared on unmount, so a rotation can destroy this
+  // FAB mid-delay; reading the `onDown`/`onUp` props at fire time would then
+  // resolve to whatever handler the parent has live BY THEN — a recognizer
+  // generation that never saw this press. Snapshot them while the press is
+  // still this instance's own, and complete the press against those.
+  let armedDown: (() => void) | null = null;
+  let armedUp: (() => void) | null = null;
 
   // TX-permit two-step arm state. First press arms; second press within
   // the window engages. A timer resets armedAt back to 0 when the window
@@ -75,8 +83,9 @@
   function cancelPress() {
     clearHoldTimer();
     if (engaged) {
-      // A press that already engaged — release cleanly.
-      onUp();
+      // A press that already engaged — release cleanly, against the handler
+      // that press was armed on (MOR-1376).
+      armedUp?.();
       engaged = false;
     }
   }
@@ -114,12 +123,14 @@
     startX = event.clientX;
     startY = event.clientY;
     engaged = false;
+    armedDown = onDown;
+    armedUp = onUp;
 
     holdTimer = setTimeout(() => {
       holdTimer = null;
       engaged = true;
       vibrate(10);
-      onDown();
+      armedDown?.();
     }, HOLD_DELAY_MS);
   }
 
@@ -139,7 +150,7 @@
       return;
     }
     if (engaged) {
-      onUp();
+      armedUp?.();
       engaged = false;
     }
   }

--- a/frontend/src/components-v2/layout/MobileRadioLayout.svelte
+++ b/frontend/src/components-v2/layout/MobileRadioLayout.svelte
@@ -346,7 +346,7 @@
   let pttSurface: 'none' | 'portrait' | 'landscape' = $derived(
     !txCapable ? 'none' : isLandscape ? 'landscape' : 'portrait'
   );
-  let ptt: MobilePttBinding | null = null;
+  let ptt = $state<MobilePttBinding | null>(null);
 
   $effect(() => {
     const surface = pttSurface;
@@ -354,18 +354,17 @@
     const binding = createMobilePttSurface(surface, txCtl, {
       schedule: (callback, ms) => setTimeout(callback, ms),
       cancel: (handle) => clearTimeout(handle as ReturnType<typeof setTimeout>),
-    }, () => pttSurface);
+    });
     ptt = binding;
     return () => { ptt = null; binding.destroy(); };
   });
 
-  function fabDown() {
-    ptt?.fabDown();
-  }
-
-  function fabUp() {
-    ptt?.fabUp();
-  }
+  // MOR-1376: the FAB gets THIS generation's own handlers, never a stable
+  // forwarder that re-reads `ptt`. PttFab snapshots them when a press arms, so
+  // a press stranded by a rotation completes against the (now destroyed)
+  // binding it started on instead of spuriously keying whichever generation is
+  // live 50 ms later — see `mobile-ptt-surface.ts` for the full rationale.
+  const noPtt = () => {};
 
   // ── Landscape PTT guards (#843 parity with FAB) ──
   // Adds pointermove-8px cancel + haptic + TX-permit dim-state so the
@@ -890,8 +889,8 @@
   <PttFab
     mode={pttMode}
     txPermit={txPermit}
-    onDown={fabDown}
-    onUp={fabUp}
+    onDown={ptt?.fabDown ?? noPtt}
+    onUp={ptt?.fabUp ?? noPtt}
   />
 {/if}
 

--- a/frontend/src/components-v2/layout/MobileRadioLayout.svelte
+++ b/frontend/src/components-v2/layout/MobileRadioLayout.svelte
@@ -1,14 +1,3 @@
-<script module lang="ts">
-  /**
-   * Per-surface PTT lease identity. The portrait FAB and the landscape strip
-   * are separate recognizer instances and a rotation swaps one for the other,
-   * so each needs its own sourceId: the App TX controller keys lease ownership
-   * by sourceId, and a shared id would let a torn-down surface release — or
-   * latch — a lease the freshly created one, or another source entirely, owns.
-   */
-  let mobilePttSeq = 0;
-</script>
-
 <script lang="ts">
   import { runtime } from '$lib/runtime';
   import { t } from '$lib/i18n';
@@ -63,7 +52,7 @@
   } from '../wiring/command-bus';
   import { getKeyboardConfig } from '$lib/stores/capabilities.svelte';
   import { getAppTxController } from '$lib/runtime/tx-controller/app-host';
-  import { createPttGesture, type PttGesture } from '../wiring/tx-ptt-gesture';
+  import { createMobilePttSurface, type MobilePttBinding } from '../wiring/mobile-ptt-surface';
   import { onMount, onDestroy } from 'svelte';
 
   // ── State — via runtime ──
@@ -348,61 +337,34 @@
     'var(--v2-text-dim, #555)'
   );
 
-  // One recognizer per input surface. The portrait FAB and the landscape strip
-  // are never mounted together and a rotation swaps one for the other; a shared
-  // recognizer would carry an armed release window across that swap, where the
-  // first press on the new surface would be misread as the second half of a
-  // double-tap. Re-keying the effect on the surface destroys the old recognizer
-  // instead — `destroy()` releases a live lease exactly once, which is why
-  // rotating away while keyed or latched now drops TX rather than stranding it.
+  // One recognizer per input surface — the orchestration itself lives in
+  // `wiring/mobile-ptt-surface.ts` (MOR-1378) so it is testable and mountable
+  // without this component's runtime-store dependencies. Re-keying the effect
+  // on the surface destroys the old binding, which releases a live lease
+  // exactly once: rotating away while keyed or latched drops TX rather than
+  // stranding it.
   let pttSurface: 'none' | 'portrait' | 'landscape' = $derived(
     !txCapable ? 'none' : isLandscape ? 'landscape' : 'portrait'
   );
-  let ptt: PttGesture | null = null;
+  let ptt: MobilePttBinding | null = null;
 
   $effect(() => {
     const surface = pttSurface;
     if (surface === 'none') return;
-    const sourceId = `mobile-ptt-${surface}-${++mobilePttSeq}`;
-    let leaseSeq = 0;
-    const gesture = createPttGesture(
-      // Read the controller DIRECTLY rather than the subscribed `txState`:
-      // teardown runs after the subscription has already been dropped, and a
-      // stale snapshot there would release a guard that has since moved on.
-      {
-        guard: () => txCtl.snapshot().guard,
-        latched: () => txCtl.snapshot().intent === 'latched',
-      },
-      {
-        start: () => {
-          // A stale fault would swallow the start (the model only leaves
-          // 'failed' on an explicit reset), so clear it as part of the press —
-          // otherwise one denied press bricks mobile TX for the session.
-          if (txCtl.snapshot().phase === 'failed') txCtl.resetFault();
-          txCtl.start(sourceId, `${sourceId}-${++leaseSeq}`, 'momentary');
-        },
-        latch: (guard) => txCtl.setIntent(sourceId, guard, 'latched'),
-        release: (guard) => txCtl.release(sourceId, guard),
-      },
-      {
-        schedule: (callback, ms) => setTimeout(callback, ms),
-        cancel: (handle) => clearTimeout(handle as ReturnType<typeof setTimeout>),
-      },
-    );
-    ptt = gesture;
-    return () => { ptt = null; gesture.destroy(); };
+    const binding = createMobilePttSurface(surface, txCtl, {
+      schedule: (callback, ms) => setTimeout(callback, ms),
+      cancel: (handle) => clearTimeout(handle as ReturnType<typeof setTimeout>),
+    }, () => pttSurface);
+    ptt = binding;
+    return () => { ptt = null; binding.destroy(); };
   });
 
-  // PttFab's 50 ms hold timer is not cleared when it unmounts, so a press that
-  // began in portrait can still fire onDown() after a rotation has already
-  // swapped in the landscape recognizer. Both FAB entry points therefore check
-  // that portrait is still the live surface before touching the recognizer.
   function fabDown() {
-    if (pttSurface === 'portrait') ptt?.down();
+    ptt?.fabDown();
   }
 
   function fabUp() {
-    if (pttSurface === 'portrait') ptt?.up();
+    ptt?.fabUp();
   }
 
   // ── Landscape PTT guards (#843 parity with FAB) ──

--- a/frontend/src/components-v2/layout/__tests__/MobileRadioLayout.component.svelte.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/MobileRadioLayout.component.svelte.test.ts
@@ -799,6 +799,44 @@ describe('mobile PTT via the App TX controller (MOR-1012)', () => {
     expect(tx.controller.snapshot().phase).toBe('idle');
   });
 
+  // C.14b (MOR-1376) — the SAFETY case a coarse 'portrait'/'landscape' liveness
+  // label cannot see. Rotating away and straight back inside the 50 ms hold
+  // delay leaves the FIRST surface's abandoned press pointing at a recognizer
+  // generation that never saw a finger: the label says 'portrait' again, so the
+  // guard passes and TX keys with no press behind it — and no pointer capture
+  // left to release it. The press must complete against the generation it was
+  // armed on, not whatever happens to be live when its timer fires.
+  it('does not key a fresh recognizer when a double flip strands a press mid-hold-delay', () => {
+    const t = mountMobile();
+    pointer(fabEl(t), 'pointerdown'); // generation 1 arms its 50 ms hold timer
+    vi.advanceTimersByTime(HOLD_MS - 30);
+    rotate(true);                     // generation 2
+    rotate(false);                    // generation 3 — a brand new recognizer
+    vi.advanceTimersByTime(HOLD_MS);  // generation 1's orphaned timer fires here
+    flushSync();
+
+    expect(tx.dependencies.startAudio).not.toHaveBeenCalled();
+    expect(tx.controller.snapshot().phase).toBe('idle');
+    expect(tx.controller.snapshot().guard).toBeNull();
+  });
+
+  // The other direction: the guard must block the ghost, not the operator. The
+  // surface that survives the double flip stays fully usable.
+  it('still keys on the surviving surface after a double flip stranded a press', () => {
+    const t = mountMobile();
+    pointer(fabEl(t), 'pointerdown');
+    vi.advanceTimersByTime(HOLD_MS - 30);
+    rotate(true);
+    rotate(false);
+    vi.advanceTimersByTime(HOLD_MS * 4); // well past the stranded timer
+    flushSync();
+    expect(tx.controller.snapshot().phase).toBe('idle');
+
+    fabPress(t); // a real press, on the live FAB
+    expect(tx.dependencies.startAudio).toHaveBeenCalledOnce();
+    expect(tx.controller.snapshot().phase).toBe('audio-start-pending');
+  });
+
   // -- D: other lease sources on the same controller -------------------------
 
   // D.15 — the guard alone always matches (it is the single live lease), so the

--- a/frontend/src/components-v2/layout/__tests__/MobileRadioLayout.component.svelte.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/MobileRadioLayout.component.svelte.test.ts
@@ -884,6 +884,9 @@ describe('mobile PTT via the App TX controller (MOR-1012)', () => {
     // Deliberately NOT asserting on 'ptt' as a bare substring — PttFab and the
     // landscape lsPtt* handlers legitimately keep it.
     expect(mobileLayoutSource).toContain('getAppTxController');
-    expect(mobileLayoutSource).toContain('createPttGesture');
+    // MOR-1378: the recognizer wiring moved to wiring/mobile-ptt-surface.ts —
+    // this layout now composes it instead of building the gesture inline.
+    expect(mobileLayoutSource).toContain('createMobilePttSurface');
+    expect(mobileLayoutSource).not.toContain('createPttGesture');
   });
 });

--- a/frontend/src/components-v2/layout/__tests__/semantic-mobile-migration.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-mobile-migration.component.test.ts
@@ -454,7 +454,8 @@ describe('mobile press-and-hold PTT identity (MOR-1011/1012, unchanged)', () => 
   // re-asserted here because this slice edits the same file).
   it('still routes every mobile TX path through the App controller alone', () => {
     expect(mobileLayoutSource).toContain('getAppTxController');
-    expect(mobileLayoutSource).toContain('createPttGesture');
+    // MOR-1378: the recognizer wiring lives in wiring/mobile-ptt-surface.ts now.
+    expect(mobileLayoutSource).toContain('createMobilePttSurface');
     // Deliberately NOT asserting on 'ptt_on'/'ptt_off' as bare substrings —
     // the retirement note in the layout's own comments names them.
     for (const retired of [

--- a/frontend/src/components-v2/wiring/mobile-ptt-surface.ts
+++ b/frontend/src/components-v2/wiring/mobile-ptt-surface.ts
@@ -1,0 +1,102 @@
+/**
+ * Mobile PTT surface orchestration (MOR-1378) — the per-input-surface
+ * recognizer wiring MobileRadioLayout re-runs on every rotation, lifted out of
+ * the component so it is independently mountable.
+ *
+ * Same seam-only doctrine as `tx-ptt-gesture.ts`, which this composes: a small
+ * host facade in, a binding out. No Svelte, no `$lib/runtime` store singletons,
+ * no DOM — so a unit test or the MOR-1088 evidence harness can drive the REAL
+ * orchestration instead of hand-mirroring it.
+ *
+ * WHY ONE RECOGNIZER PER SURFACE. The portrait FAB and the landscape strip are
+ * never mounted together and a rotation swaps one for the other; a shared
+ * recognizer would carry an armed release window across that swap, where the
+ * first press on the new surface would be misread as the second half of a
+ * double-tap. Each surface therefore gets its own binding, and `destroy()`
+ * releases a live lease exactly once — which is why rotating away while keyed
+ * or latched drops TX rather than stranding it.
+ *
+ * WHY THE SOURCE ID IS PER SURFACE. The App TX controller keys lease ownership
+ * by sourceId; a shared id would let a torn-down surface release — or latch —
+ * a lease the freshly created one, or another source entirely, owns.
+ */
+import { createPttGesture, type Guard, type PttGesture } from './tx-ptt-gesture';
+
+export type MobilePttSurface = 'portrait' | 'landscape';
+
+/** The slice of the App TX controller facade this orchestration needs. */
+export interface MobilePttHost {
+  snapshot(): {
+    readonly guard: Guard | null;
+    readonly intent: 'momentary' | 'latched' | null;
+    readonly phase: string;
+  };
+  resetFault(): void;
+  start(sourceId: string, leaseId: string, intent: 'momentary'): void;
+  setIntent(sourceId: string, guard: Guard, intent: 'latched'): void;
+  release(sourceId: string, guard: Guard): void;
+}
+
+export type MobilePttSurfaceDeps = {
+  schedule(callback: () => void, ms: number): unknown;
+  cancel(handle: unknown): void;
+  doubleTapMs?: number;
+};
+
+export interface MobilePttBinding {
+  /** Direct, undelayed entry points — the landscape strip's own handlers. */
+  down(): void;
+  up(): void;
+  /**
+   * Portrait FAB entry points. PttFab's 50 ms hold timer is not cleared when it
+   * unmounts, so a press begun in portrait can still fire after a rotation has
+   * already swapped the recognizer — these are guarded, `down`/`up` are not.
+   */
+  fabDown(): void;
+  fabUp(): void;
+  destroy(): void;
+}
+
+/** Monotonic across every surface generation this module ever hands out. */
+let surfaceSeq = 0;
+
+export function createMobilePttSurface(
+  surface: MobilePttSurface,
+  host: MobilePttHost,
+  deps: MobilePttSurfaceDeps,
+  /** Reads the surface that is live NOW — the FAB liveness guard's input. */
+  liveSurface: () => MobilePttSurface | 'none',
+): MobilePttBinding {
+  const sourceId = `mobile-ptt-${surface}-${++surfaceSeq}`;
+  let leaseSeq = 0;
+
+  const gesture: PttGesture = createPttGesture(
+    // Read the host DIRECTLY rather than a subscribed snapshot: teardown runs
+    // after the component's subscription has already been dropped, and a stale
+    // snapshot there would release a guard that has since moved on.
+    {
+      guard: () => host.snapshot().guard,
+      latched: () => host.snapshot().intent === 'latched',
+    },
+    {
+      start: () => {
+        // A stale fault would swallow the start (the model only leaves
+        // 'failed' on an explicit reset), so clear it as part of the press —
+        // otherwise one denied press bricks mobile TX for the session.
+        if (host.snapshot().phase === 'failed') host.resetFault();
+        host.start(sourceId, `${sourceId}-${++leaseSeq}`, 'momentary');
+      },
+      latch: (guard) => host.setIntent(sourceId, guard, 'latched'),
+      release: (guard) => host.release(sourceId, guard),
+    },
+    deps,
+  );
+
+  return {
+    down: () => gesture.down(),
+    up: () => gesture.up(),
+    fabDown: () => { if (liveSurface() === 'portrait') gesture.down(); },
+    fabUp: () => { if (liveSurface() === 'portrait') gesture.up(); },
+    destroy: () => gesture.destroy(),
+  };
+}

--- a/frontend/src/components-v2/wiring/mobile-ptt-surface.ts
+++ b/frontend/src/components-v2/wiring/mobile-ptt-surface.ts
@@ -51,6 +51,15 @@ export interface MobilePttBinding {
    * Portrait FAB entry points. PttFab's 50 ms hold timer is not cleared when it
    * unmounts, so a press begun in portrait can still fire after a rotation has
    * already swapped the recognizer — these are guarded, `down`/`up` are not.
+   *
+   * MOR-1376: the guard is THIS binding's own identity, not a live orientation
+   * label. Hand these two out per generation (the FAB must capture them while
+   * the press is armed) and a stranded press can only ever complete against the
+   * generation it started on — which, once rotated away from, is destroyed and
+   * inert. A shared forwarder reading a mutable `binding` slot reintroduces the
+   * bug: a portrait → landscape → portrait double flip inside the 50 ms delay
+   * puts the label back to 'portrait' and spuriously keys a generation the
+   * operator never pressed (ResourceDemand handle-identity trap class).
    */
   fabDown(): void;
   fabUp(): void;
@@ -64,11 +73,10 @@ export function createMobilePttSurface(
   surface: MobilePttSurface,
   host: MobilePttHost,
   deps: MobilePttSurfaceDeps,
-  /** Reads the surface that is live NOW — the FAB liveness guard's input. */
-  liveSurface: () => MobilePttSurface | 'none',
 ): MobilePttBinding {
   const sourceId = `mobile-ptt-${surface}-${++surfaceSeq}`;
   let leaseSeq = 0;
+  let alive = true;
 
   const gesture: PttGesture = createPttGesture(
     // Read the host DIRECTLY rather than a subscribed snapshot: teardown runs
@@ -92,11 +100,17 @@ export function createMobilePttSurface(
     deps,
   );
 
+  // `alive` is this generation's identity, captured in the closures below.
+  // `createPttGesture` already no-ops once destroyed, so this is belt-and-
+  // braces — but it is the assertion that makes the guard readable, and it also
+  // covers the landscape binding (whose fabDown/fabUp are never wired to a FAB)
+  // without consulting anything mutable outside this call.
+  const live = (): boolean => alive && surface === 'portrait';
   return {
     down: () => gesture.down(),
     up: () => gesture.up(),
-    fabDown: () => { if (liveSurface() === 'portrait') gesture.down(); },
-    fabUp: () => { if (liveSurface() === 'portrait') gesture.up(); },
-    destroy: () => gesture.destroy(),
+    fabDown: () => { if (live()) gesture.down(); },
+    fabUp: () => { if (live()) gesture.up(); },
+    destroy: () => { alive = false; gesture.destroy(); },
   };
 }


### PR DESCRIPTION
## Summary

Two sequenced commits closing the flagship MOR-1088 safety finding (mobile PTT ghost-key on double orientation flip):

1. **MOR-1378** (`refactor`): PTT orientation-swap wiring extracted from `MobileRadioLayout.svelte` into `components-v2/wiring/mobile-ptt-surface.ts` (tx-ptt-gesture.ts precedent; seam-only, no Svelte/stores/DOM). Zero behavior change — proven by checking out the commit alone: all 43 layout tests + the 13-scenario 1088 harness stay green INCLUDING the unsafe-floor assertion. The 1088 harness now mounts the REAL orchestration (closes 1088-F3).
2. **MOR-1376** (`fix`): the coarse portrait/landscape liveness guard replaced by generation identity, three necessary parts (each proven necessary by verifier ablation): the binding captures its own alive+surface identity; the layout hands PttFab the live binding's methods; PttFab snapshots onDown/onUp at press-arm (Svelte compiles per-generation markup handlers into getters — verified by compilation). The 1088 assertion flipped from pinning the unsafe floor to bidirectional-safe (ghost must not key AND surviving surface stays usable), sabotage-proven red both directions.

## Evidence

- Red→green reproduced by the verifier: 2 pre-fix failures against the real component → 45/45 post-fix.
- Two verifier ablations (remove arm-capture; revert forwarder) both restore the ghost — fix is minimal.
- 7 adversarial probes green (AP3 pointercancel-in-stranded-window is a new discriminating case; AP7 mirror ghost-release inconclusive in jsdom, flagged for the Chromium harness).
- LOC: +38 net production (extraction) + 0 (fix), verifier re-measured. Suite 5950/5950 (the `semantic-desktop-migration` intermittent reproduces on byte-identical-to-main trees — pre-existing, ticketed separately).
- Adjudications of record: orphaned 50ms timer left harmless (clearing it belongs in its own change — ticketed); PttFab arm-capture contract accepted (`engaged ⟹ armedUp !== null` verified).

## Review provenance

Built by session-9 opus builder (build-mor-1376.md); verified by session-9 anchor #2 (opus): **PASS, no fixes** (verify-mor-1376.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)