### PR TITLE
fix(MOR-1356): gate deriveBand TX permit on the same seen() criterion as activeReceiver

### DIFF
--- a/frontend/src/lib/runtime/adapters/__tests__/band-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/band-adapter.test.ts
@@ -55,6 +55,10 @@ function caps(overrides: Partial<Capabilities> = {}): Capabilities {
 
 const fresh: FieldStatus = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' };
 const stale: FieldStatus = { storePath: 'x', observed: true, freshness: 'stale', availability: 'stale' };
+/** The two remaining ways `seen()` can fail on a field that HAS a status
+ *  entry — never observed, and observed-but-unavailable (MOR-1356). */
+const unobserved: FieldStatus = { storePath: 'x', observed: false, freshness: 'unknown', availability: 'missing' };
+const missing: FieldStatus = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'missing' };
 
 /** The exact shape `rf-front-end-adapter.test.ts`'s own baseline uses. */
 function bareState(overrides: Partial<ServerState> = {}): ServerState {
@@ -334,6 +338,118 @@ describe('currentBandTx fails closed (MOR-1294)', () => {
     }), hfCaps);
     expect(view.band!.currentBand.reading).toEqual({ status: 'unknown' });
     expect(view.band!.currentBandTx).toBe('denied');
+  });
+});
+
+/**
+ * SAFETY — THE PERMIT IS SCOPED TO AN OBSERVED RECEIVER (MOR-1356, 7A
+ * follow-up). `deriveBand` picks the receiver it samples from the RAW
+ * `state.active`, which carries no evidence of its own; `activeReceiver`
+ * (the model's own answer to "which receiver is live") requires the
+ * three-part `seen()` gate. The model could therefore report
+ * `activeReceiver: unknown` and, in the same breath, a `currentBandTx:
+ * 'allowed'` scoped to a receiver it never confirmed — a TX permit resting
+ * on a guess.
+ *
+ * The gate added here is the SAME criterion `activeReceiver` uses, not a
+ * parallel one: the sameness is asserted structurally below (every state in
+ * the matrix must agree), so a future divergence in either direction goes
+ * red. The fail-closed representation is `'denied'` — the shipped
+ * `getTxPermit` collapse this group already uses everywhere else for an
+ * unknown input ("unknown fails closed", `$lib/utils/tx-permit`), NOT a new
+ * tri-state: `currentBandTx` is `TxPermit`, validated against
+ * `TX_PERMITS = ['allowed', 'denied']` (`radio-view-model.ts`).
+ *
+ * SCOPE: only the permit. Every other band fact keeps the ordinary-fact
+ * convention 7A landed with (pinned by the last case here).
+ */
+describe('currentBandTx fails closed on an unconfirmed active receiver (MOR-1356)', () => {
+  /** MAIN at 14.195, inside the 20m TX allocation: the permit derivation
+   *  itself says 'allowed', so every denial below is the GATE, not the
+   *  frequency — the pin cannot pass vacuously. */
+  const LIVE_HZ = 14195000;
+
+  const UNCONFIRMED: ReadonlyArray<readonly [label: string, state: () => ServerState]> = [
+    [
+      'the active-receiver field was never observed at all (no status entry)',
+      () => {
+        const status = { ...bareState().fieldStatus };
+        delete (status as Record<string, unknown>).active;
+        return bareState({ fieldStatus: status });
+      },
+    ],
+    [
+      'the active-receiver field carries an unobserved status',
+      () => bareState({ fieldStatus: { ...bareState().fieldStatus, active: unobserved } }),
+    ],
+    [
+      'the active-receiver reading is stale',
+      () => bareState({ fieldStatus: { ...bareState().fieldStatus, active: stale } }),
+    ],
+    [
+      'the active-receiver field is observed and fresh but not available',
+      () => bareState({ fieldStatus: { ...bareState().fieldStatus, active: missing } }),
+    ],
+    [
+      'the raw active value is not a receiver the model recognises',
+      () => bareState({ active: 'BOTH' as unknown as ServerState['active'] }),
+    ],
+  ];
+
+  it('sanity: the same fixture with a confirmed active receiver really reads allowed', () => {
+    const view = model(bareState(), hfCaps);
+    expect(view.activeReceiver).toEqual({ status: 'known', receiver: 'MAIN' });
+    expect(view.band!.currentBandTx).toBe('allowed');
+    expect(getTxPermit(LIVE_HZ, HAM_TX_BANDS)).toBe('allowed');
+  });
+
+  it.each(UNCONFIRMED)('reads denied when %s', (_label, makeState) => {
+    const view = model(makeState(), hfCaps);
+    // The model itself does not know which receiver is live…
+    expect(view.activeReceiver).toEqual({ status: 'unknown' });
+    // …so the frequency-only permit (which still says allowed) must not be
+    // promoted into a permit for a receiver nobody confirmed.
+    expect(getTxPermit(LIVE_HZ, HAM_TX_BANDS)).toBe('allowed');
+    expect(view.band!.currentBandTx).toBe('denied');
+  });
+
+  it('uses the SAME criterion activeReceiver does — allowed implies a known active receiver', () => {
+    const states: ServerState[] = [
+      bareState(),
+      bareState({ active: 'SUB', fieldStatus: { ...bareState().fieldStatus, 'sub.freqHz': fresh } }),
+      ...UNCONFIRMED.map(([, makeState]) => makeState()),
+    ];
+    const dualCaps = caps({
+      freqRanges: HF_RANGES, txBands: HAM_TX_BANDS, receivers: 2, vfoScheme: 'main_sub',
+      capabilities: ['tx', 'dual_rx'],
+    });
+    const seenPermits = new Set<string>();
+    for (const state of states) {
+      for (const capabilities of [hfCaps, dualCaps]) {
+        const view = model(state, capabilities);
+        seenPermits.add(view.band!.currentBandTx);
+        if (view.band!.currentBandTx === 'allowed') {
+          expect(view.activeReceiver.status).toBe('known');
+        }
+      }
+    }
+    // Both branches actually occurred — the implication above is not vacuous.
+    expect(seenPermits).toEqual(new Set(['allowed', 'denied']));
+  });
+
+  it('leaves every NON-permit band fact on the ordinary-fact convention (no scope creep)', () => {
+    const status = { ...bareState().fieldStatus };
+    delete (status as Record<string, unknown>).active;
+    const gated = model(bareState({ fieldStatus: status }), hfCaps).band!;
+    const confirmed = model(bareState(), hfCaps).band!;
+    expect(gated.currentBand).toEqual(confirmed.currentBand);
+    expect(gated.currentBand.reading).toEqual({ status: 'known', value: '20m' });
+    expect(gated.bandChoices).toEqual(confirmed.bandChoices);
+    expect(gated.tuneMinHz).toBe(confirmed.tuneMinHz);
+    expect(gated.tuneMaxHz).toBe(confirmed.tuneMaxHz);
+    // Only the permit differs.
+    expect(confirmed.currentBandTx).toBe('allowed');
+    expect(gated.currentBandTx).toBe('denied');
   });
 });
 

--- a/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
@@ -84,6 +84,19 @@ function seen(state: ServerState | null, path: string): boolean {
     && status.availability === 'available';
 }
 
+/**
+ * THE active-receiver identity — `seen()` plus a positively recognised
+ * MAIN/SUB reading. Extracted (MOR-1356) so `toRadioViewModel`'s
+ * `activeReceiver` fact and `deriveBand`'s receiver-scoped TX permit share
+ * ONE criterion rather than two that can drift apart: the model must not be
+ * able to say "I don't know which receiver is active" and, in the same
+ * payload, hand out a TX permit scoped to the receiver it just guessed.
+ */
+function activeReceiverId(state: ServerState | null): ReceiverId | null {
+  const active = state?.active;
+  return seen(state, 'active') && (active === 'MAIN' || active === 'SUB') ? active : null;
+}
+
 function boolFact(state: ServerState | null, path: string, value: unknown): Fact {
   return seen(state, path) && typeof value === 'boolean'
     ? { status: 'known', value }
@@ -669,7 +682,11 @@ function deriveRfFrontEndMutex(rfFrontEnd: RfFrontEndViewModel | undefined): Rea
  *    tunes far outside its TX allocations). Reading permission off the plan
  *    is the fail-open defect the slice's safety note names.
  *  - it never states a permit on unknown input. `currentBandTx` is `'allowed'`
- *    only when the current band is POSITIVELY known, has a choice entry, AND
+ *    only when the ACTIVE RECEIVER is positively confirmed (MOR-1356 — the
+ *    permit is scoped to that receiver's frequency, so an unconfirmed
+ *    identity makes it a permit for a guess; `activeReceiverId` is the ONE
+ *    gate, shared with the model's `activeReceiver` fact), the current band
+ *    is POSITIVELY known, has a choice entry, AND
  *    the live-frequency permit is POSITIVELY `allowed`; everything else
  *    collapses to `'denied'` exactly as the shipped `getTxPermit` does
  *    ("unknown fails closed", `$lib/utils/tx-permit`). An unknown input must
@@ -704,6 +721,12 @@ function deriveBand(
 
   const onSub = state?.active === 'SUB';
   const rx = onSub ? state?.sub : state?.main;
+  // MOR-1356: which receiver the raw `state.active` names is an ORDINARY fact
+  // — every reading below keeps reading it ungated, per this file's own
+  // convention. The PERMIT is the exception: `activeReceiverId` is the SAME
+  // gate `activeReceiver` uses, so a receiver identity the model itself
+  // reports as unknown cannot carry TX permission (see `currentBandTx`).
+  const activeConfirmed = activeReceiverId(state) !== null;
   const freqObserved = topFieldAvailable(state, onSub ? 'sub.freqHz' : 'main.freqHz');
   const freqHz = numOrUndef(rx?.freqHz);
   // Never over a `?? 14074000` stand-in, where the shipped `toBandSelectorProps`
@@ -727,8 +750,8 @@ function deriveBand(
   const liveFreqPermit = freqObserved && freqHz !== undefined
     ? getFrequencyPermit(freqHz, caps.txBands)
     : getFrequencyPermit(null, caps.txBands);
-  const currentBandTx: TxPermit = reading.status === 'known' && currentChoice !== undefined
-    && liveFreqPermit.status === 'allowed' ? 'allowed' : 'denied';
+  const currentBandTx: TxPermit = activeConfirmed && reading.status === 'known'
+    && currentChoice !== undefined && liveFreqPermit.status === 'allowed' ? 'allowed' : 'denied';
 
   const starts = freqRanges.map((range) => range.start).filter((hz) => Number.isFinite(hz));
   const ends = freqRanges.map((range) => range.end).filter((hz) => Number.isFinite(hz));
@@ -1197,10 +1220,9 @@ export function toRadioViewModel(
   const topology = presentation.topology;
   if (!topology) return null;
 
+  const activeId = activeReceiverId(state);
   const activeReceiver: { status: 'known'; receiver: ReceiverId } | { status: 'unknown' } =
-    seen(state, 'active') && (state?.active === 'MAIN' || state?.active === 'SUB')
-      ? { status: 'known', receiver: state.active }
-      : { status: 'unknown' };
+    activeId !== null ? { status: 'known', receiver: activeId } : { status: 'unknown' };
 
   // TX identity and permit come from the SAME derivation the App TX authority
   // uses (`deriveTxCapabilities`), so the surfaces cannot disagree with the


### PR DESCRIPTION
## Summary

`deriveBand` computed a band TX permit from raw `state.active` with no seen() gate — the model could report `activeReceiver: unknown` while emitting `currentBandTx: 'allowed'` for a receiver it never confirmed. TX permits are the one fact class where this carries safety weight (7B verification finding N4, routed to the 7A facts layer).

Fix: extracted `activeReceiverId(state)` (observed + fresh + available + recognized MAIN/SUB) consumed by BOTH `toRadioViewModel.activeReceiver` and the permit — sameness is structural, plus a matrix pin (`allowed ⇒ activeReceiver known`, both branches non-vacuous). Unknown fails closed to the existing `'denied'` (validator `TX_PERMITS` precedent; no new representation). All other band facts keep the ordinary-fact convention (no-scope-creep deep-equal pin).

## Evidence

- 7 new tests red→green; band + 7B suites 133/133 incl. the MOR-1307 TX-HERE caveat tests unmodified.
- Verifier's 25-cell differential matrix (5 freshness × 5 raw active values) recomputing the pre-extraction expression from HEAD~1: 25/25 identical — no regression outside the ticket.
- 4 mutants dead (verifier re-ran with larger kill sets: 7/14/2; the no-scope-creep pin kills all three re-run mutants).
- LOC +4 net production (verifier-measured, binding). Suite 289/5956 ×3.

## Finding of record

The denial REASON text for the newly-reachable unknown-active state is wrong ("current band could not be resolved" — the band IS resolved and on screen; the true reason is the unobserved active receiver, filtered by `txDeniedReason`'s field guard). Ruled non-blocking (wrong sentence ≠ permit-on-a-guess; band-choice dimming gives a distinguishing signal) and ticketed separately.

## Review provenance

Built by session-9 opus builder (build-mor-1356.md); verified by session-9 anchor #2 (opus): **PASS** (verify-mor-1356.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)