### PR TITLE
feat(MOR-1345): SWR/ALC fault-highlight border on the semantic meters surface

### DIFF
--- a/frontend/src/components-v2/meters/BarGauge.svelte
+++ b/frontend/src/components-v2/meters/BarGauge.svelte
@@ -16,10 +16,12 @@
     zones?: readonly Zone[];
     compact?: boolean;
     showPeak?: boolean;    // MOR-1282: optional peak-hold marker
+    fault?: boolean;       // MOR-1345: SWR/ALC over-threshold fault highlight
   }
 
   let {
     value, label, displayValue, zones = DEFAULT_ZONES, compact = false, showPeak = false,
+    fault = false,
   }: Props = $props();
 
   // ── Segment geometry ────────────────────────────────────────────────────────
@@ -117,15 +119,19 @@
   height="auto"
   preserveAspectRatio="xMidYMid meet"
   role="group"
+  data-fault={fault ? 'true' : 'false'}
   ondblclick={resetPeak}
 >
-  <!-- Container background -->
+  <!-- Container background. MOR-1345: an over-threshold SWR/ALC reading
+       (the same `isSwrFault`/`isAlcFault` predicates the legacy dock's
+       border comes from) swaps the outline for the shared red accent — the
+       one place this gauge already owns colour (zone segments, above). -->
   <rect
     x="0" y="0" width="300" height={TOTAL_HEIGHT}
     rx="6"
     fill="var(--v2-bg-darkest)"
-    stroke="var(--v2-bg-panel)"
-    stroke-width="1"
+    stroke={fault ? 'var(--v2-accent-red, #ff4040)' : 'var(--v2-bg-panel)'}
+    stroke-width={fault ? 2 : 1}
   />
 
   <!-- Label -->

--- a/frontend/src/components-v2/meters/__tests__/BarGauge.fault.test.ts
+++ b/frontend/src/components-v2/meters/__tests__/BarGauge.fault.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { mount, unmount, flushSync } from 'svelte';
+import BarGauge from '../BarGauge.svelte';
+
+// MOR-1345: BarGauge's optional fault-highlight channel. `MetersSurface`
+// (the semantic meters surface) computes the fault FACT from the shared
+// `isSwrFault`/`isAlcFault` predicates and hands this component a boolean —
+// BarGauge is the one place the semantic vertical already owns colour
+// (zone segments, peak marker), so the actual highlight is drawn here, not
+// in the colour-free surface file. Defaults to `false`: every OTHER BarGauge
+// consumer (Po/Id/Vd/COMP tiles, and every pre-existing call site) never
+// passes the prop and must render exactly as it did before this ticket.
+
+let target: HTMLDivElement;
+afterEach(() => { target?.remove(); });
+
+function render(props: Record<string, unknown>) {
+  target = document.createElement('div');
+  document.body.appendChild(target);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const component = mount(BarGauge as any, { target, props });
+  flushSync();
+  const svg = target.querySelector('svg')!;
+  return {
+    dispose: () => unmount(component),
+    svg,
+    containerRect: svg.querySelector('rect')!,
+  };
+}
+
+const BASE = { value: 0.5, label: 'SWR', displayValue: '2.3' };
+
+describe('BarGauge fault highlight (MOR-1345)', () => {
+  it('defaults to no fault when the prop is omitted', () => {
+    const g = render(BASE);
+    expect(g.svg.getAttribute('data-fault')).toBe('false');
+    g.dispose();
+  });
+
+  // MUTATION KILLED: the fault prop not reaching the container stroke.
+  it('marks data-fault and swaps the container stroke to the accent-red token when fault=true', () => {
+    const g = render({ ...BASE, fault: true });
+    expect(g.svg.getAttribute('data-fault')).toBe('true');
+    expect(g.containerRect.getAttribute('stroke')).toBe('var(--v2-accent-red, #ff4040)');
+    expect(g.containerRect.getAttribute('stroke-width')).toBe('2');
+    g.dispose();
+  });
+
+  it('keeps the ordinary panel-border stroke when fault=false', () => {
+    const g = render({ ...BASE, fault: false });
+    expect(g.containerRect.getAttribute('stroke')).toBe('var(--v2-bg-panel)');
+    expect(g.containerRect.getAttribute('stroke-width')).toBe('1');
+    g.dispose();
+  });
+});

--- a/frontend/src/semantic/MetersSurface.svelte
+++ b/frontend/src/semantic/MetersSurface.svelte
@@ -20,6 +20,13 @@
       They are text AND shape, so the state survives forced-colors (MOR-977).
   (3) An unobserved meter renders as an explicit `?`, never as a gauge at
       zero. "0 W into the antenna" and "not measured" are different claims.
+  (4) FAULT (MOR-1345): SWR/ALC over-threshold highlighting is a FACT this
+      surface computes from the SAME `isSwrFault`/`isAlcFault` predicates the
+      legacy dock's border reads (`meter-utils`, imported not copied), gated
+      on `relevant` (this field's own TX-authority conclusion, rule 1) AND
+      "observed" (rule 3) — an unobserved reading is never a fault. The
+      colour itself is drawn by `BarGauge` (below), which already owns
+      colour; this file only ever hands it a boolean.
 
   Two-level availability (MOR-977/1256): `structural: false` renders NOTHING —
   "this radio has no SWR meter" is a different claim from "the SWR meter is
@@ -39,7 +46,8 @@
   import type { MeterField, MetersViewModel } from './radio-view-model';
   import {
     alcLevel, compLevel, formatAlc, formatAmps, formatCompDb, formatPowerWatts,
-    formatSwr, formatVolts, idLevel, normalizePower, sLevel, swrLevel, vdLevel,
+    formatSwr, formatVolts, idLevel, isAlcFault, isSwrFault, normalizePower, sLevel,
+    swrLevel, vdLevel,
   } from '../components-v2/panels/meter-utils';
   import { renderSlot } from './design-language-renderers';
 
@@ -62,6 +70,18 @@
     ['drainVoltage', 'Vd', vdLevel, formatVolts, false],
     ['compression', 'COMP', compLevel, formatCompDb, false],
   ] as const satisfies readonly Scale[];
+
+  /**
+   * MOR-1345: fields with an over-threshold FAULT — the SAME `isSwrFault`/
+   * `isAlcFault` predicates `MetersDockPanel`'s border reads, imported (not
+   * copied) so the two surfaces can never disagree about what counts as a
+   * fault. Only SWR and ALC have a threshold; every other bar has none, and
+   * this surface invents none — an absent entry means "never faults".
+   */
+  const FAULT_CHECKS: Partial<Record<BarKey, (raw: number) => boolean>> = {
+    swr: isSwrFault,
+    alc: isAlcFault,
+  };
 
   /** Level 1 — does this radio HAVE the meter at all. */
   const present = (f: MeterField): boolean => f.availability.structural;
@@ -136,16 +156,17 @@
 
     {#each METER_BARS as [field, label, level, format, showPeak] (field)}
       {#if present(meters[field]) && (field !== 'compression' || compressorOn)}
+        {@const isObserved = observed(meters[field])}
+        {@const raw = rawOf(meters[field])}
+        {@const fault = isObserved && meters[field].relevant
+          && (FAULT_CHECKS[field]?.(raw) ?? false)}
         <div
           class="meter-tile" data-meter-tile data-meter={field} data-testid={`meter-${field}`}
-          data-relevant={meters[field].relevant} data-observed={observed(meters[field])}
+          data-relevant={meters[field].relevant} data-observed={isObserved} data-fault={fault}
           role="group" aria-label={`${label} meter`}
         >
-          {#if observed(meters[field])}
-            <BarGauge
-              value={level(rawOf(meters[field]))} {label}
-              displayValue={format(rawOf(meters[field]))} compact {showPeak}
-            />
+          {#if isObserved}
+            <BarGauge value={level(raw)} {label} displayValue={format(raw)} compact {showPeak} {fault} />
           {:else}
             <span class="meter-unknown">{label} ?</span>
           {/if}

--- a/frontend/src/semantic/__tests__/MetersSurface.test.ts
+++ b/frontend/src/semantic/__tests__/MetersSurface.test.ts
@@ -76,6 +76,20 @@ function withField(
   };
 }
 
+/** Drives ONE meter field's raw KNOWN reading (MOR-1345 fault fixtures need
+ *  specific SWR/ALC amplitudes `withField` was never asked to carry). */
+function withRaw(view: RadioViewModel, field: MeterKey, value: number): RadioViewModel {
+  const meters = view.meters!;
+  const current: MeterField = meters[field];
+  return {
+    ...view,
+    meters: {
+      ...meters,
+      [field]: { ...current, reading: { status: 'known', value } } satisfies MeterField,
+    } as MetersViewModel,
+  };
+}
+
 /** Sets the MOR-1244 `txAux.compressor` fact, or drops the whole group. */
 function compressor(view: RadioViewModel, value: boolean | 'unknown' | 'no-group'): RadioViewModel {
   if (value === 'no-group') {
@@ -519,5 +533,123 @@ describe('MetersSurface and MetersDockPanel are on the same peak-hold channel', 
     expect(dockSource).toMatch(/import\s*\{[^}]*PEAK_DECAY_MS[^}]*\}\s*from\s*'\.\/meter-utils'/);
     expect(barGaugeSource).not.toMatch(/const\s+PEAK_DECAY_MS\s*=/);
     expect(dockSource).not.toMatch(/const\s+PEAK_DECAY_MS\s*=/);
+  });
+});
+
+// ── 11. Fault highlighting (MOR-1345) — dock's border, ported honestly ─────
+
+describe('SWR/ALC fault highlighting reuses the dock\'s own threshold', () => {
+  // MUTATION KILLED: a locally-invented threshold instead of the shared
+  // predicate. Raw 80 is the dock's own "exactly SWR 2.0" boundary fixture
+  // (MetersDockPanel.isolated.test.ts) — not a fault.
+  it('does not fault SWR at exactly the 2.0 boundary (raw=80)', () => {
+    const view = withRaw(base('transmitting'), 'swr', 80);
+    withSurface(view, (s) => {
+      expect(s.tile('swr')!.dataset.fault).toBe('false');
+    });
+  });
+
+  it('faults SWR just above the boundary (raw=90 -> ratio 2.25)', () => {
+    const view = withRaw(base('transmitting'), 'swr', 90);
+    withSurface(view, (s) => {
+      expect(s.tile('swr')!.dataset.fault).toBe('true');
+    });
+  });
+
+  it('does not fault ALC at exactly the 90% boundary (raw=108)', () => {
+    const view = withRaw(base('transmitting'), 'alc', 108);
+    withSurface(view, (s) => {
+      expect(s.tile('alc')!.dataset.fault).toBe('false');
+    });
+  });
+
+  it('faults ALC just above the boundary (raw=115 -> 95.8%)', () => {
+    const view = withRaw(base('transmitting'), 'alc', 115);
+    withSurface(view, (s) => {
+      expect(s.tile('alc')!.dataset.fault).toBe('true');
+    });
+  });
+
+  // MUTATION KILLED (wrong channel): swapping which predicate gates which
+  // field. At raw=90 the two predicates DISAGREE (isSwrFault(90)=true,
+  // isAlcFault(90)=false), so a swapped FAULT_CHECKS map flips both
+  // assertions below.
+  it('never cross-applies the SWR predicate to ALC or vice-versa (raw=90 on both)', () => {
+    const view = withRaw(withRaw(base('transmitting'), 'swr', 90), 'alc', 90);
+    withSurface(view, (s) => {
+      expect(s.tile('swr')!.dataset.fault).toBe('true');
+      expect(s.tile('alc')!.dataset.fault).toBe('false');
+    });
+  });
+
+  // MUTATION KILLED: firing fault on a field with no threshold at all
+  // (Po/Id/Vd/COMP never have one — the dock never highlights them either).
+  it.each(['power', 'drainCurrent', 'drainVoltage'] as const)(
+    'never marks "%s" as a fault regardless of amplitude',
+    (field) => {
+      const view = withRaw(base('transmitting'), field, 255);
+      withSurface(view, (s) => {
+        expect(s.tile(field)!.dataset.fault).toBe('false');
+      });
+    },
+  );
+
+  // MUTATION KILLED: dropping the `relevant` gate — an over-threshold SWR
+  // reading that lingers while the fact layer says the meter is NOT relevant
+  // (e.g. RX) must not highlight, exactly like the dock's own TX gate.
+  it('does not fault an over-threshold reading the fact layer marks irrelevant', () => {
+    const view = withField(withRaw(base('transmitting'), 'swr', 120), 'swr', { relevant: false });
+    withSurface(view, (s) => {
+      expect(s.tile('swr')!.dataset.relevant).toBe('false');
+      expect(s.tile('swr')!.dataset.fault).toBe('false');
+    });
+  });
+
+  // MUTATION KILLED: dropping the "observed" gate — unknown is not a fault
+  // (omission doctrine). Sets a huge underlying raw amplitude so a fault
+  // computed from `rawOf`'s 0-fallback (rather than from `observed`) would
+  // also read false by coincidence; the real guard is exercised by directly
+  // marking the reading unknown regardless of what a resumed reading would be.
+  it('does not fault an unobserved (unknown) reading even when relevant', () => {
+    const view = withField(base('transmitting'), 'swr', { unknown: true, relevant: true });
+    withSurface(view, (s) => {
+      expect(s.tile('swr')!.dataset.observed).toBe('false');
+      expect(s.tile('swr')!.dataset.fault).toBe('false');
+      expect(s.tile('swr')!.querySelector('svg')).toBeNull();
+    });
+  });
+
+  // Threads the boolean through to the REAL BarGauge (no stub) — mirrors the
+  // MOR-1282 peak-marker test's own "real component" discipline.
+  it('threads the fault flag into the real BarGauge SVG', () => {
+    const view = withRaw(base('transmitting'), 'swr', 120);
+    withSurface(view, (s) => {
+      const svg = s.tile('swr')!.querySelector('svg');
+      expect(svg?.getAttribute('data-fault')).toBe('true');
+    });
+    const clean = withRaw(base('transmitting'), 'swr', 20);
+    withSurface(clean, (s) => {
+      const svg = s.tile('swr')!.querySelector('svg');
+      expect(svg?.getAttribute('data-fault')).toBe('false');
+    });
+  });
+
+  // MUTATION KILLED: either surface reimplementing the threshold instead of
+  // importing the shared predicates — the same instrument as the PEAK_DECAY_MS
+  // parity test above (block 10), now for `isSwrFault`/`isAlcFault`.
+  it('both MetersSurface and MetersDockPanel import isSwrFault/isAlcFault from the shared meter-utils module', () => {
+    const dockSource = readFileSync('src/components-v2/panels/MetersDockPanel.svelte', 'utf8');
+    expect(SOURCE).toMatch(/import\s*\{[^}]*isSwrFault[^}]*\}\s*from\s*'\.\.\/components-v2\/panels\/meter-utils'/);
+    expect(SOURCE).toMatch(/import\s*\{[^}]*isAlcFault[^}]*\}\s*from\s*'\.\.\/components-v2\/panels\/meter-utils'/);
+    expect(dockSource).toMatch(/import\s*\{[^}]*isSwrFault[^}]*\}\s*from\s*'\.\/meter-utils'/);
+    expect(dockSource).toMatch(/import\s*\{[^}]*isAlcFault[^}]*\}\s*from\s*'\.\/meter-utils'/);
+    expect(SOURCE).not.toMatch(/function\s+isSwrFault|function\s+isAlcFault/);
+  });
+
+  // The base surface itself stays colour-free (MOR-977) — the highlight's
+  // actual colour is drawn by BarGauge, which already owns colour.
+  it('carries the fault as a boolean/attribute only — its own stylesheet stays colour-free', () => {
+    const styles = SOURCE.slice(SOURCE.indexOf('<style>'));
+    expect(styles).not.toMatch(/#[0-9a-f]{3,8}\b|\brgb\(|\bhsl\(/i);
   });
 });

--- a/frontend/src/semantic/__tests__/MetersSurface.test.ts
+++ b/frontend/src/semantic/__tests__/MetersSurface.test.ts
@@ -32,6 +32,7 @@ import type {
   Availability, MeterField, MeterRfState, MetersViewModel, RadioViewModel,
 } from '../radio-view-model';
 import { RF_LABEL, RF_MARK } from '../rx-tx-surface';
+import { isAlcFault, isSwrFault } from '../../components-v2/panels/meter-utils';
 
 /** Source scans below run over the CODE, with comments stripped — the same
  *  instrument (and the same reason) as `TxAuxSurface.test.ts`: a behavioural
@@ -605,11 +606,18 @@ describe('SWR/ALC fault highlighting reuses the dock\'s own threshold', () => {
     });
   });
 
-  // MUTATION KILLED: dropping the "observed" gate — unknown is not a fault
-  // (omission doctrine). Sets a huge underlying raw amplitude so a fault
-  // computed from `rawOf`'s 0-fallback (rather than from `observed`) would
-  // also read false by coincidence; the real guard is exercised by directly
-  // marking the reading unknown regardless of what a resumed reading would be.
+  // Unknown is not a fault (omission doctrine).
+  //
+  // HONEST SCOPE (verify-MOR-1345): dropping the `isObserved` conjunct alone
+  // does NOT go red here, and that is not a weakness in this test — it is an
+  // EQUIVALENT mutant under `rawOf`'s current contract. `rawOf` returns `0`
+  // for an unknown reading, `swrRatio(0)` is 1.0 and `alcLevel(0)` is 0, so
+  // neither predicate can fire on an unobserved field however the conjunction
+  // is written. What this test DOES kill is the dangerous combination: change
+  // `rawOf`'s fallback to a hazardous value AND drop the guard, and it goes
+  // red (verifier mutant M6b). The guard is therefore load-bearing the moment
+  // that fallback changes — which is why the next test pins the fallback
+  // itself, so the two edits can never pass independently.
   it('does not fault an unobserved (unknown) reading even when relevant', () => {
     const view = withField(base('transmitting'), 'swr', { unknown: true, relevant: true });
     withSurface(view, (s) => {
@@ -617,6 +625,23 @@ describe('SWR/ALC fault highlighting reuses the dock\'s own threshold', () => {
       expect(s.tile('swr')!.dataset.fault).toBe('false');
       expect(s.tile('swr')!.querySelector('svg')).toBeNull();
     });
+  });
+
+  // MUTATION KILLED (verifier mutant M6a, verify-MOR-1345): changing `rawOf`'s
+  // unknown-fallback to a value either predicate would fault on. Today the
+  // whole meters suite stays GREEN through such a change, because the
+  // `isObserved` conjunct above absorbs it — so the fallback is the silent
+  // assumption the "unknown never faults" property actually rests on, and
+  // nothing else in the repo pins it. Source-scanned rather than behavioural
+  // because `rawOf` is module-private to the component: a behavioural test
+  // cannot observe a fallback the render path never reaches.
+  it('pins rawOf\'s unknown-fallback to a value neither fault predicate fires on', () => {
+    const fallback = /reading\.status === 'known' \? f\.reading\.value : (-?\d+(?:\.\d+)?)/.exec(SOURCE);
+    expect(fallback, 'rawOf no longer has a numeric literal fallback').not.toBeNull();
+    const raw = Number(fallback![1]);
+    expect(raw).toBe(0);
+    expect(isSwrFault(raw)).toBe(false);
+    expect(isAlcFault(raw)).toBe(false);
   });
 
   // Threads the boolean through to the REAL BarGauge (no stub) — mirrors the


### PR DESCRIPTION
## Summary

The legacy MetersDockPanel renders a fault-highlight border on SWR/ALC over-threshold; the semantic meters surface didn't — the second of two known dock features gating dock retirement (the first, peak-hold, was MOR-1282). Doctrine gate resolved cleanly: the fault truth ALREADY lives in shared production code (`isSwrFault`/`isAlcFault` in `meter-utils.ts`) — dock and surface now consume the SAME source, no thresholds fabricated.

`MetersSurface.svelte` computes the fault per tile (gated on observed + relevant, never fires on unknown) and threads a boolean into `BarGauge.svelte`, which swaps its container stroke to `--v2-accent-red` — the surface's colour-free stylesheet doctrine (MOR-977 regex test) stays intact, same split as MOR-1282.

## Evidence

- Boundary tests match the dock's own fixtures; verifier recomputed the knot-table values independently (SWR 80→exactly 2.0, 90→2.25; ALC 108→0.9000, 115→0.9583).
- Unknown fail-quiet, RX/irrelevant suppression, wrong-channel guard, no-invented-fault on Po/Id/Vd, source-scan parity pin (both consumers import meter-utils).
- Mutants: 3 killed (verifier-reproduced); M4 (dropped isObserved gate) adjudicated GENUINELY EQUIVALENT (rawOf→0 anchors at the knot origin — unkillable black-box). The unpinned assumption behind that equivalence is now pinned: verifier's M6a probe (fallback→200) was green pre-fix; a source-scan pin on the fallback now kills it. Misleading in-file comment corrected.
- LOC +9 net production (verifier-measured, binding; report's 27 was raw lines). Suite 290/5965 ×2.
- MOR-1385 (peak-marker relevance gate) neither half-fixed nor worsened; this build's `{@const}` block reduces its future fix to one expression.

## Review provenance

Built by session-9 sonnet builder (build-mor-1345.md); verified by session-9 anchor #2 (opus): **PASS-with-fixes** in head 8ed2b47a (verify-mor-1345.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)