### PR TITLE
test: per-environment web-storage isolation for vitest (flaky isolated-pool fix)

### DIFF
--- a/frontend/src/__tests__/storage-isolation.isolated.test.ts
+++ b/frontend/src/__tests__/storage-isolation.isolated.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Web-storage isolation contract for the test suite.
+ *
+ * Node's `--localstorage-file` Storage (the repo-standard NODE_OPTIONS for
+ * vitest) is ONE store shared by every worker thread in the process.
+ * `isolate: true` gives each file a fresh module registry, but every file
+ * still read and wrote the same backing store, concurrently — a sibling
+ * file's `localStorage.setItem`/`clear` leaked into this worker's
+ * module-load reads and flipped tests red with no production change
+ * (`mod-input-tx-guard.isolated.test.ts` was the canonical victim:
+ * `mod-input-auto.svelte.ts` latches its opt-in pref at module load, and a
+ * leaked `rigplane:auto-lan-mod-input=true` silenced the MOR-617 guard).
+ *
+ * `vitest.setup.ts` shadows both storages with a per-environment in-memory
+ * implementation. This file pins that contract from inside the isolated
+ * pool: if the setup file is dropped from the config, the marker assertion
+ * fails deterministically, and the empty-at-load assertions become flaky —
+ * exactly the class of failure the setup exists to prevent.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { TEST_STORAGE_MARKER } from '../../vitest.setup';
+
+describe('per-file web-storage isolation (vitest.setup.ts)', () => {
+  it('localStorage is the test-owned in-memory stub, not a shared store', () => {
+    expect(
+      (localStorage as unknown as Record<string, unknown>)[TEST_STORAGE_MARKER],
+    ).toBe(true);
+    expect(
+      (sessionStorage as unknown as Record<string, unknown>)[TEST_STORAGE_MARKER],
+    ).toBe(true);
+  });
+
+  it('both storages start empty — no keys leak in from sibling test files', () => {
+    expect(localStorage.length).toBe(0);
+    expect(sessionStorage.length).toBe(0);
+  });
+
+  it('supports the full Storage surface the suite relies on', () => {
+    localStorage.setItem('probe', 'a');
+    expect(localStorage.getItem('probe')).toBe('a');
+    expect(localStorage.length).toBe(1);
+    expect(localStorage.key(0)).toBe('probe');
+    localStorage.removeItem('probe');
+    expect(localStorage.getItem('probe')).toBeNull();
+    localStorage.setItem('probe', 'b');
+    localStorage.clear();
+    expect(localStorage.length).toBe(0);
+  });
+});

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -79,6 +79,9 @@ export default defineConfig({
         test: {
           name: 'fast',
           environment: 'jsdom',
+          // Shadows the process-wide `--localstorage-file` store with a
+          // per-environment in-memory one — see vitest.setup.ts.
+          setupFiles: ['./vitest.setup.ts'],
           include: ['src/**/*.test.ts'],
           exclude: [
             'src/**/*.isolated.test.ts',
@@ -94,6 +97,10 @@ export default defineConfig({
         test: {
           name: 'isolated',
           environment: 'jsdom',
+          // Same storage shadowing as `fast`; under `isolate: true` this is
+          // what makes web storage genuinely per-file — the Node store is
+          // shared across worker threads and defeated the isolation.
+          setupFiles: ['./vitest.setup.ts'],
           include: [
             'src/**/*.isolated.test.ts',
             'src/**/*.component.test.ts',

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -1,0 +1,65 @@
+/**
+ * Per-environment web-storage isolation for vitest.
+ *
+ * The repo convention runs vitest with `NODE_OPTIONS="--localstorage-file=…"`
+ * (without it, Node's `localStorage` global throws and ~50+ unrelated tests
+ * fail as an env artifact). That file-backed Storage is ONE store shared by
+ * every worker thread in the process: `isolate: true` gives each test file a
+ * fresh module registry, but all files still read and write the same backing
+ * store, concurrently. Any file's `localStorage.setItem`/`clear` raced every
+ * other file's module-load reads and `beforeEach` seeding — the source of
+ * order-dependent flakes with no production change (canonical victim:
+ * `mod-input-tx-guard.isolated.test.ts`, silenced by a sibling file's leaked
+ * `rigplane:auto-lan-mod-input=true`; also the panel-order seeding in the
+ * semantic-desktop/lcd migration component tests).
+ *
+ * This setup file shadows `localStorage`/`sessionStorage` with an in-memory
+ * Storage per test environment: genuinely per-file under `isolate: true`,
+ * per-worker in the `fast` pool (strictly less shared than before). It uses
+ * `Object.defineProperty`, NOT `vi.stubGlobal`, on purpose: tests that stub
+ * storage themselves (e.g. the workspace purity suites) must have
+ * `vi.unstubAllGlobals()` restore to THIS stub, never to the shared Node
+ * store.
+ *
+ * Contract pinned by `src/__tests__/storage-isolation.isolated.test.ts`.
+ */
+
+/** Marker property test code can use to assert the stub is installed. */
+export const TEST_STORAGE_MARKER = '__rigplaneTestStorage';
+
+function makeMemoryStorage(): Storage {
+  const data = new Map<string, string>();
+  const storage: Storage = {
+    get length() {
+      return data.size;
+    },
+    key(index: number): string | null {
+      return [...data.keys()][index] ?? null;
+    },
+    getItem(key: string): string | null {
+      return data.get(String(key)) ?? null;
+    },
+    setItem(key: string, value: string): void {
+      data.set(String(key), String(value));
+    },
+    removeItem(key: string): void {
+      data.delete(String(key));
+    },
+    clear(): void {
+      data.clear();
+    },
+  };
+  Object.defineProperty(storage, TEST_STORAGE_MARKER, {
+    value: true,
+    enumerable: false,
+  });
+  return storage;
+}
+
+for (const name of ['localStorage', 'sessionStorage'] as const) {
+  Object.defineProperty(globalThis, name, {
+    value: makeMemoryStorage(),
+    writable: true,
+    configurable: true,
+  });
+}


### PR DESCRIPTION
## Problem

`frontend/src/lib/runtime/adapters/__tests__/mod-input-tx-guard.isolated.test.ts` > "arms the guard at startTx and still delegates to runtime" was flaky on `main` (failed 2 of 3 full-suite runs, always passed alone). `semantic-desktop-migration.component.test.ts` and `semantic-lcd-migration.component.test.ts` showed the same class of intermittent failure.

## Root cause

Node's `--localstorage-file` Storage (the repo-standard `NODE_OPTIONS` for vitest) is **one store shared by every worker thread in the process** (verified with a `worker_threads` experiment: writes are visible cross-thread). The `isolated` vitest project's `isolate: true` gives each file a fresh module registry — but not fresh web storage, so files racing in parallel workers leak keys and `localStorage.clear()` calls into each other.

Concretely: `mod-input-auto.isolated.test.ts` writes `rigplane:auto-lan-mod-input=true` (~25 call sites). `mod-input-auto.svelte.ts` latches that pref at module load; when the leak lands in the window where `mod-input-tx-guard.isolated.test.ts` loads its modules, `startTx` auto-patches the MOD source to LAN **before** the MOR-617 guard arms → `deriveModInputTxGuardProps().visible === false` at line 232. Reproduced **deterministically** by pre-seeding the backing file with that key. The component tests fail through the same channel from the other direction: concurrent clears/writes wipe their `rigplane:panel-order` / `rigplane:right-panel-order` seeding between `setItem` and render.

## Fix

- `frontend/vitest.setup.ts` — shadows `localStorage`/`sessionStorage` with an in-memory Storage per test environment: genuinely per-file under `isolate: true`, per-worker in the `fast` pool (strictly less shared than before). Uses `Object.defineProperty`, **not** `vi.stubGlobal`, so `vi.unstubAllGlobals()` in tests (e.g. the LCD migration suite) restores to the stub, never to the shared Node store. Composes with suites that stub storage themselves (workspace purity tests).
- `frontend/vite.config.ts` — wires the setup file into both projects.
- `frontend/src/__tests__/storage-isolation.isolated.test.ts` — pins the contract (stub installed, storage empty at file load, full Storage surface).

## Verification

- Pre-fix: 3-dir repro failed 2/3 runs at line 232; seeding the backing file → 100% deterministic failure.
- Post-fix: seeded (poisoned) backing store is inert; 3× the previously-flaky 3-dir run green; 3× full frontend suite green (291 files / 5960 tests).
- Bonus: the suite now also passes **without** `NODE_OPTIONS="--localstorage-file=…"` — the ~50–127 env-artifact failure class is gone (convention/CI can keep the flag; it's harmless).
- `npm run lint` clean, `npm run check` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)