### PR TITLE
fix(MOR-1389): truthful band TX denial reason for unknown-active-receiver state

### DIFF
--- a/frontend/src/semantic/BandSurface.svelte
+++ b/frontend/src/semantic/BandSurface.svelte
@@ -73,6 +73,16 @@
    *  TARGET may key, so what is missing is the band-scoped resolution itself
    *  (unobserved live frequency, or a frequency in no band of the plan). */
   export const UNRESOLVED_REASON = 'current band could not be resolved';
+  /** MOR-1389: the denial's words when `deriveBand`'s MOR-1356
+   *  `activeConfirmed` gate is what forced 'denied', with the current band
+   *  ITSELF resolved and rendered. `UNRESOLVED_REASON` is false in that
+   *  state — the band is not unresolved, the receiver serving it is
+   *  unconfirmed — so it needs its own, equally honest, sentence. Named for
+   *  exactly what `activeReceiver.status === 'unknown'` carries (rule (4)'s
+   *  own gate): identity is unconfirmed, not "stale" or "never observed" —
+   *  `seen()`'s three-part AND collapses those into one signal upstream, so
+   *  claiming more than this would be a fact this file does not have. */
+  export const ACTIVE_RECEIVER_UNCONFIRMED_REASON = 'active receiver identity was not confirmed';
 
   export const usable = (f: BandField<unknown>): boolean =>
     f.availability.structural && f.availability.operational && f.reading.status === 'known';
@@ -98,13 +108,28 @@
    *  'txPermit'` entry for EVERY non-allowed permit
    *  (radio-view-model-adapter.ts:1164-1170), so filtering on that field is
    *  the whole fix — a code match alone would misattribute an unrelated
-   *  capability gap as a TX-configuration fault (fix-round F2). */
+   *  capability gap as a TX-configuration fault (fix-round F2). This
+   *  `field === 'txPermit'` match is NEVER weakened or bypassed below.
+   *
+   *  MOR-1389: a `field: 'txPermit'` reason is not the only way `denied` can
+   *  arise. `deriveBand`'s MOR-1356 `activeConfirmed` gate can force it with
+   *  no such entry at all — the true reason is `field: 'activeReceiver'`,
+   *  which the match above correctly ignores (it is not a TX-scoped fault;
+   *  rule (3) reserves `TX_REASON_CODES` for those). Once the TX-scoped
+   *  search comes up empty, `view.activeReceiver.status` — the SAME top-level
+   *  fact rule (4)'s `receiverKnown` reads, not a re-derivation — decides
+   *  between the two remaining, mutually exclusive explanations: the
+   *  receiver is unconfirmed (band resolved, rendered above), or the band
+   *  itself could not be resolved (the pre-existing fallback, still true in
+   *  that state). */
   export function txDeniedReason(view: RadioViewModel): string {
     const hit = TX_REASON_CODES.find(
       (c) => view.disabledReasons.some((r) => r.code === c && r.field === 'txPermit'),
     );
     if (hit !== undefined) return REASON_LABEL[hit];
-    return view.txPermit.status === 'allowed' ? UNRESOLVED_REASON : UNKNOWN_TEXT;
+    if (view.txPermit.status !== 'allowed') return UNKNOWN_TEXT;
+    if (view.activeReceiver.status === 'unknown') return ACTIVE_RECEIVER_UNCONFIRMED_REASON;
+    return UNRESOLVED_REASON;
   }
 </script>
 

--- a/frontend/src/semantic/__tests__/BandSurface.test.ts
+++ b/frontend/src/semantic/__tests__/BandSurface.test.ts
@@ -23,7 +23,8 @@ import { readFileSync } from 'node:fs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
 import BandSurface, {
-  REASON_LABEL, UNKNOWN_TEXT, UNRESOLVED_REASON, defaultPermitLabel, mhz,
+  ACTIVE_RECEIVER_UNCONFIRMED_REASON, REASON_LABEL, UNKNOWN_TEXT, UNRESOLVED_REASON,
+  defaultPermitLabel, mhz,
 } from '../BandSurface.svelte';
 import { topologyFixtures, withBand } from '../fixtures/topologies';
 import type { FrequencyPermit } from '$lib/utils/tx-permit';
@@ -280,6 +281,81 @@ describe('the denial signal is the field value itself (carry-forward 3)', () => 
       ] as readonly DisabledReason[],
     });
     expect(r.text('tx-reason')).toBe(UNRESOLVED_REASON);
+    r.dispose();
+  });
+});
+
+/* ── three-way denial reason (MOR-1389, MOR-1356 verify §4.4) ──────
+   `deriveBand`'s MOR-1356 `activeConfirmed` gate can force `currentBandTx`
+   to 'denied' while the CURRENT BAND is resolved and rendered right above
+   the readout. Before this ticket, `txDeniedReason`'s F2 field==='txPermit'
+   match found no entry (the true reason is `field: 'activeReceiver'`) and
+   fell through to the "band could not be resolved" fallback — false, since
+   the band IS resolved. These three tests pin the resulting three-way
+   split; the middle one is the ticket's own repro. ────────────────── */
+
+describe('the three-way denial reason distinguishes an unconfirmed receiver (MOR-1389)', () => {
+  // Row 1 — genuinely out of band: band resolved, receiver confirmed, a
+  // recorded TX-scoped reason explains it. UNCHANGED by this ticket — F2's
+  // field==='txPermit' match still owns this text and must keep owning it.
+  it('keeps the recorded out-of-band explanation when the receiver IS confirmed', () => {
+    const view = withB({ currentBand: knownBand('20m'), currentBandTx: 'denied' });
+    const r = render({
+      ...view,
+      txPermit: DENIED,
+      disabledReasons: [{ field: 'txPermit', code: 'out-of-band' }] as readonly DisabledReason[],
+    });
+    expect(r.text('current-value')).toBe('20m');
+    expect(r.text('tx-reason')).toBe(REASON_LABEL['out-of-band']);
+    r.dispose();
+  });
+
+  // Row 2 — THE TICKET. `activeReceiver` is unknown, the band is resolved,
+  // and nothing in `disabledReasons` carries a `field: 'txPermit'` entry
+  // (`txPermit` itself reads allowed — MOR-1356's exact rendered repro).
+  // The old fallback said "current band could not be resolved" while
+  // `BAND` showed `20m` directly above it. The new text must be a TRUE
+  // sentence about the receiver, not the band.
+  it('names the unconfirmed receiver instead of the band-unresolved fallback', () => {
+    const view = withB({ currentBand: knownBand('20m'), currentBandTx: 'denied' });
+    const r = render({
+      ...view,
+      activeReceiver: { status: 'unknown' },
+      txPermit: ALLOWED,
+      disabledReasons: [
+        { field: 'activeReceiver', code: 'field-not-observed' },
+      ] as readonly DisabledReason[],
+    });
+    expect(r.text('current-value')).toBe('20m');
+    expect(r.text('tx-reason')).toBe(ACTIVE_RECEIVER_UNCONFIRMED_REASON);
+    expect(r.text('tx-reason')).not.toBe(UNRESOLVED_REASON);
+    r.dispose();
+  });
+
+  // Row 3 — the band genuinely could not be resolved: receiver confirmed,
+  // no out-of-band code. The fallback text is TRUE here and must survive
+  // untouched.
+  it('keeps the band-unresolved fallback when the band itself is unread', () => {
+    const view = withB({ currentBand: unreadBand(), currentBandTx: 'denied' });
+    const r = render({ ...view, txPermit: ALLOWED, disabledReasons: [] });
+    expect(r.text('current-value')).toBe(UNKNOWN_TEXT);
+    expect(r.text('tx-reason')).toBe(UNRESOLVED_REASON);
+    r.dispose();
+  });
+
+  // The distinguishing signal named in rule (4) — band-choice buttons dim
+  // while the active receiver is unconfirmed — must still hold in exactly
+  // the state row 2 renders the new sentence for.
+  it('still dims every band-choice button in the unconfirmed-receiver denial state', () => {
+    const r = render({
+      ...withB({ currentBand: knownBand('20m'), currentBandTx: 'denied' }),
+      activeReceiver: { status: 'unknown' },
+      txPermit: ALLOWED,
+      disabledReasons: [
+        { field: 'activeReceiver', code: 'field-not-observed' },
+      ] as readonly DisabledReason[],
+    });
+    for (const name of ['40m', '20m', 'MW']) expect(r.btn(`choice-${name}`)!.disabled).toBe(true);
     r.dispose();
   });
 });

--- a/frontend/src/semantic/__tests__/BandSurface.test.ts
+++ b/frontend/src/semantic/__tests__/BandSurface.test.ts
@@ -343,6 +343,30 @@ describe('the three-way denial reason distinguishes an unconfirmed receiver (MOR
     r.dispose();
   });
 
+  // ORDER PIN (added in verification). The two explanations can hold AT ONCE:
+  // a receiver that was never confirmed AND a recorded out-of-band fault. The
+  // F2 TX-scoped match must keep winning — it names a specific, actionable TX
+  // fault and is equally a cause of the denial, whereas the receiver sentence
+  // would bury it. Kills: hoisting the `activeReceiver` branch above the
+  // TX-scoped search. No other test in this file reaches that state — row 1
+  // above uses a CONFIRMED receiver — so without this the branch ORDER, which
+  // is what makes the three-way split safe, is unpinned.
+  it('lets a recorded out-of-band fault outrank an unconfirmed receiver', () => {
+    const r = render({
+      ...withB({ currentBand: knownBand('MW'), currentBandTx: 'denied' }),
+      activeReceiver: { status: 'unknown' },
+      txPermit: DENIED,
+      disabledReasons: [
+        { field: 'activeReceiver', code: 'field-not-observed' },
+        { field: 'txPermit', code: 'out-of-band' },
+      ] as readonly DisabledReason[],
+    });
+    expect(r.text('current-value')).toBe('MW');
+    expect(r.text('tx-reason')).toBe(REASON_LABEL['out-of-band']);
+    expect(r.text('tx-reason')).not.toBe(ACTIVE_RECEIVER_UNCONFIRMED_REASON);
+    r.dispose();
+  });
+
   // The distinguishing signal named in rule (4) — band-choice buttons dim
   // while the active receiver is unconfirmed — must still hold in exactly
   // the state row 2 renders the new sentence for.


### PR DESCRIPTION
## Summary

Fixes the epistemic lie made newly-reachable by MOR-1356: a denial caused by an unobserved/stale active receiver rendered "current band could not be resolved" while the band was resolved and on screen. `BandSurface`'s `txDeniedReason` now renders three truthful rows per the verifier-prescribed table (verify-mor-1356.md §4.4): (1) out-of-band keeps the MOR-1307 F2 field-matched text; (2) NEW unknown-active branch → "active receiver identity was not confirmed" (exactly what `seen()` backs — stale/never-observed/unavailable are collapsed upstream, so nothing more specific is claimable); (3) the unresolved-band fallback survives for genuinely-unresolved bands.

## Evidence

- All three rows verified through the real adapter → real surface → DOM instrument; row-2's condition proven a sufficient cause of denial (shares `activeReceiverId` with the permit's first conjunct) — no masking possible.
- Verifier fix in head 9a7c17d5: the branch ORDER (receiver branch must not bury a recorded out-of-band fault) was pinned by nothing — hoisting it survived all 120 scoped tests; an order pin was added and proven to kill that mutant unaided.
- 4 new tests (row 2 red→green; rows 1/3 regression pins); mutants: drop-new-branch, swap-texts, weaken-F2-match, hoist-order — all dead. MOR-1307 F1 caveat tests unmodified.
- LOC 3 net production (verifier binding; +28 raw is mostly doc comments). Full suite 292/6010.
- Follow-up of record: the adjacent tuning-target line overclaims "not observed" off the same gate — pre-existing, ticketed as MOR-1393 (operator-copy change, own review).

## Review provenance

Built by session-9 sonnet builder (build-mor-1389.md); verified by session-9 anchor #3 (opus): **PASS-with-fixes** (verify-mor-1389.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)