### PR TITLE
test: add fixture audio runtime axis

### DIFF
--- a/frontend/fixtures/assertions.ts
+++ b/frontend/fixtures/assertions.ts
@@ -556,6 +556,25 @@ export function runAssertions(
     check('rx-audio-surface-presence', present === expected.rxAudioSurfacePresent,
       `rx-audio-surface present=${present} · expected ${expected.rxAudioSurfacePresent}`);
   }
+  if (expected.rxAudio !== undefined) {
+    const monitor = q<HTMLElement>('[data-testid="rx-audio-monitor"]');
+    const liveChoice = q<HTMLElement>('[data-testid="rx-audio-monitor-live"]');
+    const af = q<HTMLInputElement>('[data-testid="rx-audio-af"] input[type="range"]');
+    const actualMode = monitor?.dataset.monitorMode ?? null;
+    const actualConnection = liveChoice?.dataset.liveLink === undefined
+      ? null : liveChoice.dataset.liveLink === 'true';
+    const actualVolume = actualMode === 'live' && af ? af.valueAsNumber * 100 : null;
+    check('rx-audio-runtime-axis',
+      actualMode === expected.rxAudio.monitorMode
+      && actualConnection === expected.rxAudio.connectionAudio
+      && actualVolume === expected.rxAudio.volume,
+      `mode=${actualMode} volume=${actualVolume} connectionAudio=${actualConnection} · expected `
+      + `${expected.rxAudio.monitorMode}/${expected.rxAudio.volume}/`
+      + `${expected.rxAudio.connectionAudio}`);
+    const linkPresent = q('[data-testid="rx-audio-link"]') !== null;
+    check('rx-audio-link-presence', linkPresent === expected.rxAudio.linkPresent,
+      `rx-audio-link present=${linkPresent} · expected ${expected.rxAudio.linkPresent}`);
+  }
   // The `scope`/`scopeControls` FACTS (MOR-1298/1299) exist in the view
   // model regardless of which composition mounts it — computed here by
   // calling the real, unmodified adapter with the fixture's own state/caps

--- a/frontend/fixtures/capture.mjs
+++ b/frontend/fixtures/capture.mjs
@@ -200,6 +200,12 @@ const MATRIX = [
     name: 'topology-2-main-sub--planned--desktop', fixture: 'topology-2-main-sub--planned',
     viewport: 'desktop',
   },
+  // S. MOR-1392 — a controlled audio-runtime axis on the reference layout.
+  // These are behavior-assertion cells, not PNG hash baselines (MOR-1390).
+  ...['rx-audio-live-link-down', 'rx-audio-live-link-up', 'rx-audio-muted-link-down']
+    .map((id) => ({
+      name: `${id}--reference--desktop`, fixture: `${id}--reference`, viewport: 'desktop',
+    })),
 ];
 
 /* ── build identity ────────────────────────────────────────────────────── */

--- a/frontend/fixtures/catalog.ts
+++ b/frontend/fixtures/catalog.ts
@@ -18,7 +18,9 @@
  */
 import type { Capabilities } from '$lib/types/capabilities';
 import type { ServerState } from '$lib/types/state';
-import { IDLE_TX, type ModGuardProps, type TxSnapshot } from './harness-state';
+import {
+  IDLE_TX, type AudioRuntimeState, type ModGuardProps, type TxSnapshot,
+} from './harness-state';
 
 const fresh = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' };
 const stale = { storePath: 'x', observed: true, freshness: 'stale', availability: 'stale' };
@@ -326,6 +328,13 @@ export interface Expectation {
    * so existing fixtures are unaffected; set where the contrast matters.
    */
   rxAudioSurfacePresent?: boolean;
+  /** Browser-audio facts rendered by `RxAudioSurface` for an axis fixture. */
+  rxAudio?: {
+    monitorMode: 'local' | 'live' | 'mute';
+    volume: number | null;
+    connectionAudio: boolean;
+    linkPresent: boolean;
+  };
   /**
    * MOR-1085 checklist item 5. The `view.scope.{hardwareScope,audioFftScope}`
    * facts (MOR-1298/1299 vocabulary), checked directly against the real
@@ -350,6 +359,8 @@ export interface Fixture {
   caps: () => Capabilities | null;
   tx: TxSnapshot;
   modGuard?: ModGuardProps;
+  /** MOR-1392. Independent overrides of the fixture runtime's audio facts. */
+  audioRuntime?: Partial<AudioRuntimeState>;
   /**
    * MOR-1085. Which real component this fixture mounts: the
    * dual-receiver-cockpit shell (default, unchanged from MOR-1070) or
@@ -766,6 +777,7 @@ function toReferenceFixture(f: Fixture): Fixture {
     what: `${f.what} [reference layout: SemanticRadioSurfaces strips="single", the wiring `
       + 'desktop-v2/sdr-test compose today — see ReferenceLayout.svelte].',
     state: f.state, caps: f.caps, tx: f.tx, modGuard: f.modGuard,
+    audioRuntime: f.audioRuntime,
     layout: 'reference',
     expect: {
       ...f.expect,
@@ -776,6 +788,45 @@ function toReferenceFixture(f: Fixture): Fixture {
     },
   };
 }
+
+/**
+ * MOR-1392 — the browser-audio axis, isolated from topology/TX fixtures.
+ * These three cells share one radio and one reference layout; only the
+ * runtime audio facts vary. The down/up pair pins both link polarities while
+ * live is selected, and the mute/down cell proves `muted` wins over
+ * `rxEnabled` without making an epistemically false link-loss claim.
+ */
+const audioRuntimeFixture = (
+  id: string,
+  audioRuntime: Partial<AudioRuntimeState>,
+  rxAudio: NonNullable<Expectation['rxAudio']>,
+): Fixture => toReferenceFixture({
+  id,
+  what: `MOR-1392 audio-runtime axis: ${id}.`,
+  state: () => mainSubState('MAIN'),
+  caps: mainSubCaps,
+  tx: tx({}),
+  audioRuntime,
+  expect: mainSubExpect({ rxAudioSurfacePresent: true, rxAudio }),
+});
+
+const AUDIO_RUNTIME_FIXTURES: readonly Fixture[] = [
+  audioRuntimeFixture(
+    'rx-audio-live-link-down',
+    { rxEnabled: true, muted: false, volume: 37, connectionAudio: false },
+    { monitorMode: 'live', volume: 37, connectionAudio: false, linkPresent: true },
+  ),
+  audioRuntimeFixture(
+    'rx-audio-live-link-up',
+    { rxEnabled: true, muted: false, volume: 73, connectionAudio: true },
+    { monitorMode: 'live', volume: 73, connectionAudio: true, linkPresent: false },
+  ),
+  audioRuntimeFixture(
+    'rx-audio-muted-link-down',
+    { rxEnabled: true, muted: true, volume: 19, connectionAudio: false },
+    { monitorMode: 'mute', volume: null, connectionAudio: false, linkPresent: false },
+  ),
+];
 
 /**
  * MOR-1355 — the harness's first PLAN-FUL topology. `planned: true` makes
@@ -840,6 +891,7 @@ export const FIXTURES: readonly Fixture[] = [
   ...CORE_FIXTURES,
   ...CORE_FIXTURES.filter((f) => f.id !== 'tx-adjacent-alerts').map(toReferenceFixture),
   ...PLANNED_FIXTURES,
+  ...AUDIO_RUNTIME_FIXTURES,
 ];
 
 export const fixtureById = (id: string): Fixture | undefined =>

--- a/frontend/fixtures/harness-state.ts
+++ b/frontend/fixtures/harness-state.ts
@@ -32,6 +32,20 @@ export interface ModGuardProps {
   sourceLabel: string | null;
 }
 
+export interface AudioRuntimeState {
+  rxEnabled: boolean;
+  muted: boolean;
+  volume: number;
+  connectionAudio: boolean;
+}
+
+export const DEFAULT_AUDIO_RUNTIME: AudioRuntimeState = {
+  rxEnabled: false,
+  muted: false,
+  volume: 50,
+  connectionAudio: false,
+};
+
 export const IDLE_TX: TxSnapshot = {
   phase: 'idle', intent: null, guard: null,
   radioTx: 'off', txRisk: 'none', mayOwnKey: false, fault: null,
@@ -47,6 +61,7 @@ export const harness = {
   caps: null as Capabilities | null,
   tx: { ...IDLE_TX } as TxSnapshot,
   modGuard: { visible: false, sourceLabel: null } as ModGuardProps,
+  audioRuntime: { ...DEFAULT_AUDIO_RUNTIME } as AudioRuntimeState,
   calls: [] as HarnessCall[],
   listeners: new Set<(next: TxSnapshot) => void>(),
 };

--- a/frontend/fixtures/main.ts
+++ b/frontend/fixtures/main.ts
@@ -32,7 +32,7 @@ import {
   runAssertions, styleProbe, tokenSnapshot, type AssertionOptions,
 } from './assertions';
 import { fixtureById } from './catalog';
-import { harness, IDLE_TX } from './harness-state';
+import { DEFAULT_AUDIO_RUNTIME, harness, IDLE_TX } from './harness-state';
 
 const params = new URLSearchParams(window.location.search);
 const id = params.get('fixture') ?? 'topology-2-main-sub';
@@ -79,6 +79,7 @@ harness.state = fixture.state();
 harness.caps = fixture.caps();
 harness.tx = { ...IDLE_TX, ...fixture.tx };
 harness.modGuard = fixture.modGuard ?? { visible: false, sourceLabel: null };
+harness.audioRuntime = { ...DEFAULT_AUDIO_RUNTIME, ...fixture.audioRuntime };
 harness.calls = [];
 
 /**

--- a/frontend/fixtures/stubs/runtime.ts
+++ b/frontend/fixtures/stubs/runtime.ts
@@ -7,11 +7,10 @@ import { harness } from '../harness-state';
  * (`rxAudioSnapshot`'s `muted`/`rxEnabled`/`volume`/`connected`) and this stub
  * had no such fields — a `TypeError: Cannot read properties of undefined
  * (reading 'muted')` at first render, one seam over from the command-bus
- * export gaps this ticket also fixes. No fixture varies audio-runtime state
- * (`fixtures/catalog.ts` has no such override), so the fixed defaults below
- * mirror the real module's construction-time values
- * (`$lib/stores/audio.svelte.ts`'s initial `audioState`) rather than reading
- * from `harness` — there is nothing yet for a fixture to set.
+ * export gaps this ticket also fixes. MOR-1392 adds the fixture-level audio
+ * axis, so this stub now reads the selected fixture's merged runtime facts
+ * from `harness`; fixtures without overrides retain the same construction-
+ * time defaults through `DEFAULT_AUDIO_RUNTIME` in `harness-state.ts`.
  */
 /**
  * MOR-1312 (slice 12B): `SemanticRadioSurfaces` gained a
@@ -29,8 +28,11 @@ const DEFAULT_SCOPE_STATUS = {
 export const runtime = {
   get state() { return harness.state; },
   get caps() { return harness.caps; },
-  get audio() { return { rxEnabled: false, volume: 50, muted: false }; },
-  get connectionAudio() { return false; },
+  get audio() {
+    const { rxEnabled, volume, muted } = harness.audioRuntime;
+    return { rxEnabled, volume, muted };
+  },
+  get connectionAudio() { return harness.audioRuntime.connectionAudio; },
   get defaultScopeStatus() { return DEFAULT_SCOPE_STATUS; },
   get radioPowerOn() { return null; },
   get scope() { return { hardwareScopeConnected: false }; },


### PR DESCRIPTION
## What changed

- add a fixture-level audio-runtime override axis for `rxEnabled`, `muted`, `volume`, and `connectionAudio`
- feed merged fixture audio facts through the harness runtime stub while preserving existing defaults
- add controlled reference-layout cells for live/down, live/up, and mute/down
- add browser assertions for the derived monitor mode, live volume, connection fact, and `rx-audio-link-presence`

## Why

MOR-1384 restored the live-audio link-loss readout, but the fixture runtime pinned `rxEnabled: false`, leaving that state unreachable in every browser capture. The prior verifier showed the blindness directly: assertions stayed unchanged while reference-layout pixels changed. This PR makes the audio state family behaviorally observable without introducing a PNG hash gate.

## Scope and compatibility

Fixture harness only; no production frontend, Python API, CLI, config, or rigctld wire behavior changes. The six-file harness chain is the explicit narrow guardrail waiver recorded in #2290. MOR-1396-owned visual workflow and approved-baseline paths are untouched.

## Discriminating proof

- before runtime wiring, the live/down cell failed 2 assertions: derived mode was `local` and the link-loss readout was absent
- after wiring, all three audio cells pass 29/29 assertions
- ablation forcing the new link observation to `false` makes only live/down invalid (28/29, `rx-audio-link-presence`); live/up and mute/down remain 29/29

## Validation

- `node frontend/fixtures/capture.mjs` — 64/64 valid, 1951/1951 assertions
- `npm run i18n:check` — pass
- `npm run check` — 0 errors, 0 warnings
- `NODE_OPTIONS="--experimental-webstorage --localstorage-file=<fresh>" npx vitest run` — 292 files, 6017 tests pass
- `npm run build` — pass
- `npx eslint src/` — pass
- `uv run pytest tests/ -q --tb=short` — 9083 passed, 68 skipped, 5 deselected, 11 xfailed, 1 xpassed
- `uv run ruff check src/ tests/` — pass
- `uv run ruff format --check src/ tests/` — 645 files formatted
- `uv run lint-imports` — 5 contracts kept
- `uv run mypy --strict src/rigplane/web` — pass

Broad `uv run mypy src/` still reports 15 pre-existing errors in four unchanged Python files; this PR has no `src/` diff.

Closes #2290
