### PR TITLE
ci(MOR-1397): provision capture browser system dependencies

### DIFF
--- a/.github/workflows/full.yml
+++ b/.github/workflows/full.yml
@@ -227,9 +227,13 @@ jobs:
           npm ci
           npx playwright install chromium
 
+      - name: Install Playwright Chromium system dependencies
+        working-directory: frontend
+        run: sudo -E env "PATH=$PATH" npx playwright install-deps chromium
+
       # Blocking since MOR-1386 gate promotion — see the job header comment.
-      # The install step above already fails loud on its own if chromium
-      # provisioning breaks, so a red here means a fixture regression only.
+      # The browser and system-dependency steps above fail loud on their own,
+      # so a red here means a fixture regression only.
       - name: Run fixture-harness capture
         id: capture
         run: node frontend/fixtures/capture.mjs

--- a/.github/workflows/quick.yml
+++ b/.github/workflows/quick.yml
@@ -52,6 +52,7 @@ jobs:
             frontend:
               - 'frontend/**'
               - 'src/rigplane/web/**'
+              - '.github/workflows/quick.yml'
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
@@ -149,10 +150,16 @@ jobs:
           cd frontend
           npx playwright install chromium
 
+      - name: Install Playwright Chromium system dependencies
+        if: steps.filter.outputs.frontend == 'true'
+        working-directory: frontend
+        run: sudo -E env "PATH=$PATH" npx playwright install-deps chromium
+
       # MOR-1382 — wires the MOR-1070/1085/1087/1088 browser fixture-harness
       # capture (`frontend/fixtures/capture.mjs`) into the PR leg. Gated by
       # the SAME `steps.filter.outputs.frontend` path filter as the rest of
-      # this frontend block (frontend/** or src/rigplane/web/** changed) —
+      # this frontend block (frontend/**, src/rigplane/web/**, or this
+      # workflow changed) —
       # minimum Actions minutes is a hard project policy (CLAUDE.md), so
       # this never runs on an unrelated push/PR.
       #
@@ -160,8 +167,9 @@ jobs:
       # used to run `continue-on-error: true` for one cycle (MOR-1382);
       # that cycle is closed — quick-leg green on PR #2286 run 31127603844,
       # full-leg green on dispatched run 31137987620 — so the owner flipped
-      # it to blocking here. The chromium provisioning step above fails
-      # loud on its own, so a red here means a fixture regression only.
+      # it to blocking here. The browser and system-dependency provisioning
+      # steps above fail loud on their own, so a red here means a fixture
+      # regression only.
       - name: Frontend fixture-harness capture
         id: capture
         if: steps.filter.outputs.frontend == 'true'


### PR DESCRIPTION
Closes #2293

## Summary

Adds the proven fail-loud Playwright host-library provisioning step to the two Linux jobs that actually execute `frontend/fixtures/capture.mjs`: the frontend-filtered `quick` leg and `full.yml` `capture-harness` leg.

## Root cause

On fresh `mm-build-core-1`, `npx playwright install chromium` downloads Chromium but does not install host libraries. Core PR #2291 quick run `31183254418` therefore reached `browserType.launch()` and failed before its first capture with missing `libnspr4` / `libnss3`. `visual.yml` already demonstrated the exact working system-dependency command and remains unchanged.

## Scope and compatibility

Only `.github/workflows/quick.yml` and `.github/workflows/full.yml`. No production frontend, Python API, CLI, config, rigctld wire, fixtures, baselines, or `visual.yml` changes.

## Verification

- `git diff --check`
- `actionlint .github/workflows/quick.yml .github/workflows/full.yml` — only inherited custom self-hosted `build`-label diagnostics
- Local real Chromium capture on the base content: 61/61 captures valid, 1864/1864 assertions, 0 invalid
- Fresh PR quick run is the required Linux proof; full job is manual/scheduled or `[full-ci]`-gated and will be reported separately.