### PR TITLE
feat: cut over the v3 desktop default

### DIFF
--- a/frontend/src/lib/stores/layout.svelte.ts
+++ b/frontend/src/lib/stores/layout.svelte.ts
@@ -3,7 +3,7 @@
  * store (`presentation/workspace/store.svelte.ts`), which owns the selection,
  * its validation and its persistence.
  *
- * 'auto'        = standard layout when any scope available (HW or audio FFT), LCD otherwise
+ * 'auto'        = desktop-v2 (the v3 default) on every non-mobile viewport
  * 'lcd'         = legacy alias for 'lcd-cockpit'
  * 'lcd-cockpit' = force LCD cockpit (TS-990S-style dual-cockpit)
  * 'lcd-scope'   = force LCD scope (IC-7300-style scope-dominant)
@@ -84,7 +84,8 @@ export function cycleLayoutMode(hasAnyScope: boolean): void {
     const idx = order.indexOf(normalizeLayoutMode(getLayoutMode()));
     setLayoutMode(order[(idx + 1) % order.length]);
   } else {
-    // No scope at all: always LCD, no toggle needed
+    // No scope: the legacy cycle shortcut explicitly selects LCD. This is an
+    // opt-out from the auto desktop-v2 default, not auto's resolution policy.
     setLayoutMode('lcd-cockpit');
   }
 }

--- a/frontend/src/presentation/languages/__tests__/registry.test.ts
+++ b/frontend/src/presentation/languages/__tests__/registry.test.ts
@@ -43,7 +43,12 @@ describe('the two frozen v3 declarations', () => {
 
   it('fieldline declares itself layout-incompatible with dual-receiver-cockpit as a manifest fact, not a capability check', () => {
     expect(fieldline.layoutCompatibility).toEqual([
-      expect.objectContaining({ layoutId: 'dual-receiver-cockpit', compatible: false }),
+      {
+        layoutId: 'dual-receiver-cockpit',
+        compatible: false,
+        reason: 'fieldline cannot serve as the desktop dual-receiver default at 0.6 relative density (MOR-977 §4.4).',
+      },
+      { layoutId: 'desktop-v2', compatible: true },
     ]);
   });
 

--- a/frontend/src/presentation/languages/declarations.ts
+++ b/frontend/src/presentation/languages/declarations.ts
@@ -35,7 +35,10 @@ export const studioline: DesignLanguageManifest = {
   // The mirror of fieldline's declaration below: two borderless channel
   // strips sharing one optical margin is the natural dual-receiver form
   // (MOR-977 §4.2.2), so the reference language says so as a manifest fact.
-  layoutCompatibility: [{ layoutId: 'dual-receiver-cockpit', compatible: true }],
+  layoutCompatibility: [
+    { layoutId: 'dual-receiver-cockpit', compatible: true },
+    { layoutId: 'desktop-v2', compatible: true },
+  ],
   renderers: {
     frequencyDisplay: studiolineFrequency,
     meters: studiolineMeter,
@@ -49,11 +52,14 @@ export const fieldline: DesignLanguageManifest = {
   tokens: FIELDLINE_TOKENS,
   // dense clamped out — fieldline runs at 0.6 relative density (MOR-977 §4.4).
   density: { kind: 'clamped', supported: ['comfortable', 'compact'] },
-  layoutCompatibility: [{
-    layoutId: 'dual-receiver-cockpit',
-    compatible: false,
-    reason: 'fieldline cannot serve as the desktop dual-receiver default at 0.6 relative density (MOR-977 §4.4).',
-  }],
+  layoutCompatibility: [
+    {
+      layoutId: 'dual-receiver-cockpit',
+      compatible: false,
+      reason: 'fieldline cannot serve as the desktop dual-receiver default at 0.6 relative density (MOR-977 §4.4).',
+    },
+    { layoutId: 'desktop-v2', compatible: true },
+  ],
   renderers: {
     frequencyDisplay: fieldlineFrequency,
     meters: fieldlineMeter,

--- a/frontend/src/presentation/layouts/__tests__/desktop-v2-registration.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/desktop-v2-registration.test.ts
@@ -43,7 +43,7 @@ describe('the desktop-v2 entrypoint is registered in the real registry', () => {
     const loaders = source.slice(start, source.indexOf('};', start));
     expect(loaders).toContain("'desktop-v2':");
     expect(source).toContain("if (layoutPreference === 'standard') return 'desktop-v2';");
-    expect(source).toContain('return ctx.hasAnyScope ? \'desktop-v2\' : \'lcd-cockpit\';');
+    expect(source).toContain("return 'desktop-v2';");
   });
 
   // Kills: a manifest that declares no compiled loader at all.

--- a/frontend/src/presentation/workspace/__tests__/preferences-adoption.test.ts
+++ b/frontend/src/presentation/workspace/__tests__/preferences-adoption.test.ts
@@ -58,16 +58,18 @@ afterEach(() => {
 
 describe('MOR-1082 — density resolves against the ACTIVE design language', () => {
   it('honours the operator override where the language supports it', () => {
+    expect(densityActivation(studioline, 'desktop-v2', 'dense')).toBe('dense');
+    expect(densityActivation(studioline, 'desktop-v2', 'compact')).toBe('compact');
     expect(densityActivation(studioline, 'dual-receiver-cockpit', 'dense')).toBe('dense');
     expect(densityActivation(studioline, 'dual-receiver-cockpit', 'compact')).toBe('compact');
   });
 
-  it('is inert wherever the language itself is not active (no cutover here)', () => {
+  it('is inert on the explicit legacy LCD opt-outs and other unadopted layouts', () => {
     // Same gate as `[data-design-language]` (MOR-1081/MOR-1278): density can
-    // never activate on a layout the language has not declared, so every
-    // shipped v2 skin keeps its current, density-free presentation.
-    for (const layoutId of ['desktop-v2', 'lcd-cockpit', 'lcd-scope', 'mobile', 'sdr-test']) {
+    // never activate on a layout the language has not declared.
+    for (const layoutId of ['lcd-cockpit', 'lcd-scope', 'mobile', 'sdr-test']) {
       expect(densityActivation(studioline, layoutId, 'dense')).toBeNull();
+      expect(densityActivation(fieldline, layoutId, 'compact')).toBeNull();
     }
     expect(densityActivation(fieldline, 'dual-receiver-cockpit', 'compact')).toBeNull();
     expect(densityActivation(undefined, 'dual-receiver-cockpit', 'compact')).toBeNull();
@@ -91,6 +93,8 @@ describe('MOR-1082 — density resolves against the ACTIVE design language', () 
 
   it('clamps an out-of-clamp override down to the active language default', () => {
     expect(fieldline.density).toEqual({ kind: 'clamped', supported: ['comfortable', 'compact'] });
+    expect(densityActivation(fieldline, 'desktop-v2', 'dense')).toBe('comfortable');
+    expect(densityActivation(fieldline, 'desktop-v2', 'compact')).toBe('compact');
     expect(densityActivation(activeFieldline, 'dual-receiver-cockpit', 'dense')).toBe('comfortable');
     expect(densityActivation(activeFieldline, 'dual-receiver-cockpit', 'compact')).toBe('compact');
   });

--- a/frontend/src/presentation/workspace/__tests__/selection-adoption.test.ts
+++ b/frontend/src/presentation/workspace/__tests__/selection-adoption.test.ts
@@ -180,7 +180,7 @@ describe('MOR-1081 — one workspace field set owns the selection', () => {
 });
 
 describe('MOR-1081 — capabilities cannot mutate the persisted preference', () => {
-  it('resolves `auto` against the rig at resolution time and leaves `auto` persisted', () => {
+  it('resolves `auto` to desktop-v2 without persisting the resolved skin', () => {
     const rec = recorder({
       [WORKSPACE_STORAGE_KEY]: workspaceJson({ layout: 'auto' }),
       [WORKSPACE_MIGRATION_SENTINEL_KEY]: '1',
@@ -196,7 +196,7 @@ describe('MOR-1081 — capabilities cannot mutate the persisted preference', () 
     });
 
     expect(withScope).toBe('desktop-v2');
-    expect(withoutScope).toBe('lcd-cockpit');
+    expect(withoutScope).toBe('desktop-v2');
     // The resolved skin is never written back over the preference.
     expect(getWorkspace().layout).toBe('auto');
     expect(rec.writes).toEqual([]);
@@ -267,13 +267,16 @@ describe('MOR-1257 — the ?layout= QA override survives adoption byte-exactly',
 });
 
 describe('MOR-1278 — the workspace is the only source [data-design-language] is written from', () => {
-  it('activates the selected language where its own manifest declares the layout', () => {
+  it('activates both selectable languages on the desktop-v2 cutover path', () => {
+    expect(designLanguageActivation(studioline, 'desktop-v2')).toBe('studioline');
+    expect(designLanguageActivation(fieldline, 'desktop-v2')).toBe('fieldline');
     expect(designLanguageActivation(studioline, 'dual-receiver-cockpit')).toBe('studioline');
   });
 
-  it('stays inert for a layout the language has not declared (no cutover here)', () => {
-    for (const layoutId of ['desktop-v2', 'lcd-cockpit', 'lcd-scope', 'mobile', 'sdr-test']) {
+  it('stays inert on the explicit legacy LCD opt-outs and other unadopted layouts', () => {
+    for (const layoutId of ['lcd-cockpit', 'lcd-scope', 'mobile', 'sdr-test']) {
       expect(designLanguageActivation(studioline, layoutId)).toBeNull();
+      expect(designLanguageActivation(fieldline, layoutId)).toBeNull();
     }
   });
 
@@ -283,6 +286,54 @@ describe('MOR-1278 — the workspace is the only source [data-design-language] i
 
   it('is inert when the selected id resolves to no registered manifest', () => {
     expect(designLanguageActivation(undefined, 'dual-receiver-cockpit')).toBeNull();
+  });
+
+  it('round-trips desktop -> LCD -> desktop without changing the selected language or legacy bytes', () => {
+    const rec = recorder({
+      [WORKSPACE_STORAGE_KEY]: workspaceJson({
+        layout: 'standard',
+        designLanguage: 'fieldline',
+        density: 'compact',
+        futureBenign: { preserved: true },
+      }),
+      [WORKSPACE_MIGRATION_SENTINEL_KEY]: '1',
+      [LEGACY_LAYOUT_KEY]: 'lcd-scope',
+      [LEGACY_THEME_KEY]: 'nord',
+    });
+    initWorkspaceStore(rec.storage);
+    const legacyBefore = new Map([
+      [LEGACY_LAYOUT_KEY, rec.data.get(LEGACY_LAYOUT_KEY)],
+      [LEGACY_THEME_KEY, rec.data.get(LEGACY_THEME_KEY)],
+    ]);
+
+    expect(designLanguageActivation(fieldline, resolveSkinId({
+      capabilities: null, layoutPreference: getLayoutMode(), isMobile: false, hasAnyScope: false,
+    }))).toBe('fieldline');
+
+    setLayoutMode('lcd-cockpit');
+    expect(designLanguageActivation(fieldline, resolveSkinId({
+      capabilities: null, layoutPreference: getLayoutMode(), isMobile: false, hasAnyScope: false,
+    }))).toBeNull();
+    expect(getWorkspace().designLanguage).toBe('fieldline');
+    expect(getWorkspace().density).toBe('compact');
+
+    setLayoutMode('standard');
+    expect(designLanguageActivation(fieldline, resolveSkinId({
+      capabilities: null, layoutPreference: getLayoutMode(), isMobile: false, hasAnyScope: false,
+    }))).toBe('fieldline');
+    expect(getWorkspace().designLanguage).toBe('fieldline');
+    expect(getWorkspace().density).toBe('compact');
+    expect(JSON.parse(rec.data.get(WORKSPACE_STORAGE_KEY)!)).toMatchObject({
+      layout: 'standard',
+      designLanguage: 'fieldline',
+      density: 'compact',
+      futureBenign: { preserved: true },
+    });
+    expect(new Map([
+      [LEGACY_LAYOUT_KEY, rec.data.get(LEGACY_LAYOUT_KEY)],
+      [LEGACY_THEME_KEY, rec.data.get(LEGACY_THEME_KEY)],
+    ])).toEqual(legacyBefore);
+    expect(foreignWrites(rec)).toEqual([]);
   });
 });
 

--- a/frontend/src/skins/__tests__/registry.test.ts
+++ b/frontend/src/skins/__tests__/registry.test.ts
@@ -56,8 +56,8 @@ describe('skin registry', () => {
 
   it.each([
     [true, 'desktop-v2'],
-    [false, 'lcd-cockpit'],
-  ] as const)('resolves auto according to scope availability (%s)', (hasAnyScope, skinId) => {
+    [false, 'desktop-v2'],
+  ] as const)('resolves auto to the v3 desktop default regardless of scope availability (%s)', (hasAnyScope, skinId) => {
     expect(resolve({ hasAnyScope })).toBe(skinId);
   });
 
@@ -105,7 +105,7 @@ describe('MOR-1257: QA-only dual-receiver-cockpit reachability', () => {
   // unmodified 'resolves forced %s preference to %s' cases above.
   it('leaves every other forced preference unaffected', () => {
     expect(resolve({ layoutPreference: 'standard' })).toBe('desktop-v2');
-    expect(resolve({ layoutPreference: 'auto', hasAnyScope: false })).toBe('lcd-cockpit');
+    expect(resolve({ layoutPreference: 'auto', hasAnyScope: false })).toBe('desktop-v2');
   });
 
   // Documents the chosen behaviour for the ticket's mobile/QA-override

--- a/frontend/src/skins/registry.ts
+++ b/frontend/src/skins/registry.ts
@@ -43,7 +43,8 @@ export interface SkinResolutionContext {
  * - User forced 'lcd' or 'lcd-cockpit' → lcd-cockpit
  * - User forced 'lcd-scope' → lcd-scope
  * - User forced 'standard' → desktop-v2
- * - Auto: use desktop-v2 if any scope is available, lcd-cockpit otherwise
+ * - Auto: use desktop-v2 (the v3 default); explicit LCD choices are the
+ *   recoverable compatibility-window opt-out
  */
 export function resolveSkinId(ctx: SkinResolutionContext): SkinId {
   if (ctx.isMobile) return 'mobile';
@@ -59,8 +60,10 @@ export function resolveSkinId(ctx: SkinResolutionContext): SkinId {
   if (layoutPreference === 'lcd-cockpit') return 'lcd-cockpit';
   if (layoutPreference === 'lcd-scope') return 'lcd-scope';
   if (layoutPreference === 'standard') return 'desktop-v2';
-  // auto: scope available → desktop, otherwise LCD
-  return ctx.hasAnyScope ? 'desktop-v2' : 'lcd-cockpit';
+  // MOR-1097 cutover: every non-mobile auto start uses the reworked
+  // desktop-v2 composition. Scope availability remains presentation data, not
+  // default-selection policy; explicit LCD preferences stay selectable.
+  return 'desktop-v2';
 }
 
 /**


### PR DESCRIPTION
## Summary

- make `desktop-v2` the unconditional non-mobile `auto` layout while preserving explicit LCD, mobile, SDR, standard, and QA choices
- activate both frozen v3 design-language families on `desktop-v2`; preserve Fieldline's dual-receiver incompatibility and keep legacy LCD/mobile/SDR layouts inert
- pin fresh, migrated, corrupt, future-schema, downgrade, and desktop-v2 ↔ LCD ↔ desktop-v2 workspace behavior without adding storage keys, telemetry, or migration schema

## Safety and rollback

- the compatibility-window opt-out is the existing explicit LCD layout selection
- the workspace round trip preserves language, density, benign unknown fields, and existing legacy layout/theme bytes
- no App/resource/TX authority code changed; the keyed switch suite proves one controller/guard/socket and no extra PTT ON/OFF during desktop-v2 ↔ LCD transitions

## Verification

- focused workspace/design-language/TX/resource/semantic matrix: 664 passed
- full frontend Vitest: 6018 passed
- i18n, Svelte/TypeScript, ESLint, boundary lint, state type generation, and production build passed
- full Python suite: 9083 passed, 68 skipped, 11 xfailed, 1 xpassed
- Ruff check/format, import-linter, and CI-scoped strict mypy passed
- Linux blocking pixel-diff is required on this PR head

Closes #2292
