### PR TITLE
docs: disposable always-reporting quick probe

### DIFF
--- a/docs/validation/quick-always-reporting-probe.md
+++ b/docs/validation/quick-always-reporting-probe.md
@@ -1,0 +1,4 @@
+# Quick always-reporting probe
+
+This disposable documentation-only change verifies that the stable `quick`
+check reports success while Core and frontend work remain unselected.


### PR DESCRIPTION
Disposable docs-only probe for #2296 / MOR-1398.

Expected result: a stable `quick` check exists and succeeds; classifier outputs `core=false` and `frontend=false`; all uv/Python/frontend/browser/capture/test steps are skipped.

Do not merge. Close after evidence is recorded.