### PR TITLE
docs: temporary required-quick docs sentinel

### DIFF
--- a/docs/quick-required-docs-probe-20260807.md
+++ b/docs/quick-required-docs-probe-20260807.md
@@ -1,0 +1,3 @@
+# Required `quick` docs-only probe
+
+Temporary unmerged sentinel used to verify that the required `quick` check reports successfully for a docs-only pull request.


### PR DESCRIPTION
Disposable, do-not-merge sentinel for the post-promotion required `quick` context. Expected classification: `core=false`, `frontend=false`. This PR will be closed unmerged after evidence is recorded.