### PR TITLE
test: temporary required-quick frontend sentinel

### DIFF
--- a/frontend/quick-required-frontend-probe-20260807.md
+++ b/frontend/quick-required-frontend-probe-20260807.md
@@ -1,0 +1,3 @@
+# Required `quick` frontend probe
+
+Temporary unmerged sentinel used to verify the required `quick` context executes the complete Core and frontend legs for a frontend-path change.


### PR DESCRIPTION
Disposable, do-not-merge sentinel for the post-promotion required `quick` context. Expected classification: `core=true`, `frontend=true`, with the full Core/frontend/browser suite. This PR will be closed unmerged after evidence is recorded.