### PR TITLE
fix: preserve VFO and M.SCOPE state

### DIFF
--- a/frontend/src/lib/transport/__tests__/ws-client.isolated.test.ts
+++ b/frontend/src/lib/transport/__tests__/ws-client.isolated.test.ts
@@ -595,6 +595,36 @@ describe('control channel singleton', () => {
     expect(patchActiveReceiver).toHaveBeenCalledWith({ dataMode: 2 });
   });
 
+  it('treats bare VFO B as a slot without switching MAIN to SUB', async () => {
+    radioStoreMock.current = makeState({
+      active: 'MAIN',
+      main: makeReceiver({ activeSlot: 'A' }),
+    });
+    const { sendCommand } = await import('../ws-client');
+
+    sendCommand('set_vfo', { vfo: 'B' });
+
+    expect(patchActiveReceiver).toHaveBeenCalledWith({ activeSlot: 'B' });
+    expect(patchRadioState).not.toHaveBeenCalled();
+    expect(radioStoreMock.current?.active).toBe('MAIN');
+    expect(radioStoreMock.current?.main.activeSlot).toBe('B');
+  });
+
+  it('treats explicit SUB as a receiver selection', async () => {
+    radioStoreMock.current = makeState({
+      active: 'MAIN',
+      main: makeReceiver({ activeSlot: 'A' }),
+    });
+    const { sendCommand } = await import('../ws-client');
+
+    sendCommand('set_vfo', { vfo: 'SUB' });
+
+    expect(patchRadioState).toHaveBeenCalledWith({ active: 'SUB' });
+    expect(patchActiveReceiver).not.toHaveBeenCalled();
+    expect(radioStoreMock.current?.active).toBe('SUB');
+    expect(radioStoreMock.current?.main.activeSlot).toBe('A');
+  });
+
   it('sendCommand returns false and queues when not connected', async () => {
     const { sendCommand, isConnected } = await import('../ws-client');
     expect(isConnected()).toBe(false);

--- a/frontend/src/lib/transport/ws-client.ts
+++ b/frontend/src/lib/transport/ws-client.ts
@@ -726,8 +726,15 @@ function _applyOptimistic(name: string, params: Record<string, unknown>): void {
     case 'set_vfo':
     case 'select_vfo':  // backward-compat alias
       if (typeof params.vfo === 'string') {
-        const isSub = ['SUB', 'B'].includes(params.vfo.toUpperCase());
-        patchRadioState({ active: isSub ? 'SUB' : 'MAIN' });
+        const vfo = params.vfo.toUpperCase();
+        if (vfo === 'A' || vfo === 'B') {
+          patchActiveReceiver({ activeSlot: vfo });
+        } else if (vfo === 'MAIN' || vfo === 'SUB') {
+          patchRadioState({ active: vfo });
+        } else if (vfo === 'VFOA' || vfo === 'VFOB') {
+          // Legacy dual-receiver aliases retain their historical meaning.
+          patchRadioState({ active: vfo === 'VFOB' ? 'SUB' : 'MAIN' });
+        }
       }
       break;
 

--- a/src/rigplane/backends/_icom_serial_base.py
+++ b/src/rigplane/backends/_icom_serial_base.py
@@ -374,6 +374,12 @@ class _IcomSerialRadioBase(CoreRadio):
     # Scope
     # ------------------------------------------------------------------
 
+    async def get_scope_session_state(self) -> tuple[bool, bool]:
+        """Reject unsupported serial scope sessions before any CI-V mutation."""
+        self._check_connected()
+        self._ensure_scope_baud_guardrail()
+        return await super().get_scope_session_state()
+
     async def enable_scope(
         self,
         *,

--- a/src/rigplane/commands/__init__.py
+++ b/src/rigplane/commands/__init__.py
@@ -250,6 +250,8 @@ from .dsp import (
 
 # --- scope.py ---
 from .scope import (
+    get_scope_data_output_enabled,
+    get_scope_enabled,
     get_scope_center_type,
     get_scope_during_tx,
     get_scope_edge,
@@ -264,6 +266,8 @@ from .scope import (
     get_scope_speed,
     get_scope_vbw,
     parse_scope_center_type_response,
+    parse_scope_data_output_enabled_response,
+    parse_scope_enabled_response,
     parse_scope_during_tx_response,
     parse_scope_edge_response,
     parse_scope_fixed_edge_response,
@@ -589,6 +593,8 @@ __all__ = [
     "scope_data_output",
     "scope_data_output_on",
     "scope_data_output_off",
+    "get_scope_data_output_enabled",
+    "get_scope_enabled",
     "get_scope_main_sub",
     "scope_main_sub",
     "get_scope_single_dual",
@@ -615,6 +621,8 @@ __all__ = [
     "scope_set_fixed_edge",
     "get_scope_rbw",
     "scope_set_rbw",
+    "parse_scope_data_output_enabled_response",
+    "parse_scope_enabled_response",
     "parse_scope_main_sub_response",
     "parse_scope_single_dual_response",
     "parse_scope_mode_response",

--- a/src/rigplane/commands/scope.py
+++ b/src/rigplane/commands/scope.py
@@ -194,6 +194,17 @@ def scope_on(
     )
 
 
+def get_scope_enabled(
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, cmd_map: CommandMap | None = None
+) -> bytes:
+    """Query whether the radio's panel scope is currently enabled."""
+    if cmd_map is not None:
+        return _build_from_map(
+            cmd_map, "scope_on", to_addr=to_addr, from_addr=from_addr
+        )
+    return _scope_query(_SUB_SCOPE_ON, to_addr=to_addr, from_addr=from_addr)
+
+
 def scope_off(
     to_addr: int, from_addr: int = CONTROLLER_ADDR, cmd_map: CommandMap | None = None
 ) -> bytes:
@@ -227,6 +238,17 @@ def scope_data_output(
         sub=_SUB_SCOPE_DATA_OUTPUT,
         data=b"\x01" if on else b"\x00",
     )
+
+
+def get_scope_data_output_enabled(
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, cmd_map: CommandMap | None = None
+) -> bytes:
+    """Query whether CI-V scope waveform output is currently enabled."""
+    if cmd_map is not None:
+        return _build_from_map(
+            cmd_map, "scope_data_output", to_addr=to_addr, from_addr=from_addr
+        )
+    return _scope_query(_SUB_SCOPE_DATA_OUTPUT, to_addr=to_addr, from_addr=from_addr)
 
 
 def scope_data_output_on(
@@ -806,6 +828,16 @@ def scope_set_rbw(
 
 
 # --- Parse functions ---
+
+
+def parse_scope_enabled_response(frame: CivFrame) -> bool:
+    """Parse a ``0x27 0x10`` panel-scope state response."""
+    return _decode_scope_bool(frame, _SUB_SCOPE_ON)
+
+
+def parse_scope_data_output_enabled_response(frame: CivFrame) -> bool:
+    """Parse a ``0x27 0x11`` waveform-output state response."""
+    return _decode_scope_bool(frame, _SUB_SCOPE_DATA_OUTPUT)
 
 
 def parse_scope_main_sub_response(frame: CivFrame) -> int:

--- a/src/rigplane/core/command_service.py
+++ b/src/rigplane/core/command_service.py
@@ -916,13 +916,13 @@ def command_intent_from_request(
         normalized["rit_tx"] = hz != 0
     elif command_name in ("set_vfo", "select_vfo"):
         raw_vfo = normalized.get("vfo", "A")
-        active_slot = _active_slot_value(raw_vfo)
+        receiver_count = _receiver_count_value(normalized)
+        active_slot = _active_slot_value(raw_vfo, receiver_count=receiver_count)
         if active_slot is not None:
             normalized["active_slot"] = active_slot
-        active = _active_receiver_value(raw_vfo)
+        active = _active_receiver_value(raw_vfo, receiver_count=receiver_count)
         if active is not None:
             normalized["active"] = active
-        receiver_count = _receiver_count_value(normalized)
         if receiver_count is not None:
             normalized["receiver_count"] = receiver_count
     elif command_name == "set_level":
@@ -1088,20 +1088,20 @@ def _ptt_value(name: str, params: Mapping[str, Any]) -> bool:
     return False
 
 
-def _active_slot_value(value: Any) -> str | None:
+def _active_slot_value(value: Any, *, receiver_count: int | None) -> str | None:
     text = str(value).strip().upper()
-    if text in ("B", "VFOB", "SUB", "1"):
+    if text == "B" or (text == "VFOB" and (receiver_count or 1) < 2):
         return "B"
-    if text in ("A", "VFOA", "MAIN", "0"):
+    if text == "A" or (text == "VFOA" and (receiver_count or 1) < 2):
         return "A"
     return None
 
 
-def _active_receiver_value(value: Any) -> str | None:
+def _active_receiver_value(value: Any, *, receiver_count: int | None) -> str | None:
     text = str(value).strip().upper()
-    if text in ("B", "VFOB", "SUB", "1"):
+    if text in ("SUB", "1") or (text == "VFOB" and (receiver_count or 1) >= 2):
         return "SUB"
-    if text in ("A", "VFOA", "MAIN", "0"):
+    if text in ("MAIN", "0") or (text == "VFOA" and (receiver_count or 1) >= 2):
         return "MAIN"
     return None
 

--- a/src/rigplane/runtime/_scope_runtime.py
+++ b/src/rigplane/runtime/_scope_runtime.py
@@ -21,8 +21,10 @@ from rigplane.commands import (
     parse_ack_nak,
     parse_civ_frame,
     parse_scope_center_type_response,
+    parse_scope_data_output_enabled_response,
     parse_scope_during_tx_response,
     parse_scope_edge_response,
+    parse_scope_enabled_response,
     parse_scope_fixed_edge_response,
     parse_scope_hold_response,
     parse_scope_main_sub_response,
@@ -34,6 +36,10 @@ from rigplane.commands import (
     parse_scope_speed_response,
     parse_scope_vbw_response,
 )
+from rigplane.commands import (
+    get_scope_data_output_enabled as _get_scope_data_output_enabled_cmd,
+)
+from rigplane.commands import get_scope_enabled as _get_scope_enabled_cmd
 from rigplane.commands import get_scope_center_type as _get_scope_center_type_cmd
 from rigplane.commands import get_scope_during_tx as _get_scope_during_tx_cmd
 from rigplane.commands import get_scope_edge as _get_scope_edge_cmd
@@ -49,6 +55,7 @@ from rigplane.commands import get_scope_speed as _get_scope_speed_cmd
 from rigplane.commands import get_scope_vbw as _get_scope_vbw_cmd
 from rigplane.commands import scope_data_output as _scope_data_output_cmd
 from rigplane.commands import scope_main_sub as _scope_main_sub_cmd
+from rigplane.commands import scope_off as _scope_off_cmd
 from rigplane.commands import scope_on as _scope_on_cmd
 from rigplane.commands import scope_set_center_type as _scope_set_center_type_cmd
 from rigplane.commands import scope_set_during_tx as _scope_set_during_tx_cmd
@@ -161,6 +168,37 @@ class ScopeRuntimeMixin(_MixinBase):  # type: ignore[misc]
                 )
             except asyncio.TimeoutError:
                 raise TimeoutError("Scope enable verification timed out (no data seen)")
+
+    async def get_scope_session_state(self) -> tuple[bool, bool]:
+        """Read panel-scope and waveform-output state without changing either."""
+        self._check_connected()
+        panel_response = await self._send_civ_expect(
+            _get_scope_enabled_cmd(to_addr=self._radio_addr),
+            label="get_scope_enabled",
+        )
+        output_response = await self._send_civ_expect(
+            _get_scope_data_output_enabled_cmd(to_addr=self._radio_addr),
+            label="get_scope_data_output_enabled",
+        )
+        return (
+            parse_scope_enabled_response(panel_response),
+            parse_scope_data_output_enabled_response(output_response),
+        )
+
+    async def restore_scope_session_state(self, state: tuple[bool, bool]) -> None:
+        """Restore the exact panel/output state captured before a web session."""
+        self._check_connected()
+        panel_enabled, output_enabled = state
+        await self._send_civ_raw(
+            (_scope_on_cmd if panel_enabled else _scope_off_cmd)(
+                to_addr=self._radio_addr
+            ),
+            wait_response=False,
+        )
+        await self._send_civ_raw(
+            _scope_data_output_cmd(output_enabled, to_addr=self._radio_addr),
+            wait_response=False,
+        )
 
     async def disable_scope(
         self, *, policy: ScopeCompletionPolicy | str = ScopeCompletionPolicy.FAST

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -478,6 +478,8 @@ class RadioPoller:
         self._initial_fetch_done.set()
         self._scope_enable_deferred = False
         self._scope_demand_generation = queue.latest_scope_demand_generation
+        self._scope_session_state: tuple[bool, bool] | None = None
+        self._scope_session_active = False
         # Issue #715: track user-initiated freq/mode writes so the unselected-
         # slot poll subroutine can debounce around them, and per-receiver
         # timestamps so each receiver's unselected slot is refreshed no more
@@ -1330,6 +1332,74 @@ class RadioPoller:
         self._scope_demand_generation = generation
         return False
 
+    async def _enable_scope_session(self, *, policy: str) -> None:
+        """Capture scope state once, then enable through the existing wire lane."""
+        radio = self._radio
+        get_state = getattr(radio, "get_scope_session_state", None)
+        restore_state = getattr(radio, "restore_scope_session_state", None)
+        if get_state is None or restore_state is None:
+            raise CommandError(
+                "scope backend cannot preserve pre-session panel/output state"
+            )
+        if self._scope_session_state is None:
+            self._scope_session_state = await get_state()
+        try:
+            await radio.enable_scope(policy=policy)  # type: ignore[attr-defined]
+        except BaseException:
+            # Once enable starts, its wire effect is uncertain: FAST can fail
+            # after the panel ON write, and VERIFY can time out after both ON
+            # writes were applied.  Roll back before reporting failure.  The
+            # captured tuple remains owned if rollback itself fails, allowing a
+            # later DisableScope teardown to retry deterministically.
+            self._scope_session_active = True
+            try:
+                await self.restore_scope_session()
+            except BaseException:
+                logger.exception(
+                    "radio-poller: scope enable failed and rollback is pending"
+                )
+            raise
+        self._scope_session_active = True
+
+    async def restore_scope_session(self) -> None:
+        """Restore exactly what the first successful scope viewer inherited."""
+        if not self._scope_session_active or self._scope_session_state is None:
+            return
+        if getattr(self._radio, "external_cat_session_active", False) is True:
+            raise CommandError(
+                "scope restore deferred while an external CAT session owns the wire"
+            )
+        restore_state = getattr(self._radio, "restore_scope_session_state", None)
+        if restore_state is None:
+            raise CommandError(
+                "scope backend cannot restore pre-session panel/output state"
+            )
+        await restore_state(self._scope_session_state)
+        self._scope_session_active = False
+        self._scope_session_state = None
+
+    async def restore_scope_after_shutdown(self) -> None:
+        """Restore scope through this stopped poller's sole command executor.
+
+        ``stop_web_server`` calls this only after ``stop()`` and the final TX
+        safety drain.  Re-entering ``_execute`` therefore uses the same sole
+        poller executor as the live ``CommandQueue`` consumer, with no second
+        task or radio-control lane.  The backend write continues through its
+        existing ``_send_civ_raw`` / ``IcomCommander`` serialization.
+        """
+        if CAP_SCOPE not in self._caps:
+            raise CommandError("scope restore unavailable on this radio")
+        generation = (
+            max(
+                self._scope_demand_generation,
+                self._queue.latest_scope_demand_generation,
+            )
+            + 1
+        )
+        await self._execute(DisableScope(generation=generation))
+        if self._scope_session_active:
+            raise CommandError("scope restore did not settle")
+
     def _managed_tx(
         self, source: CommandSource, session_id: str | None
     ) -> ManagedTxApi | None:
@@ -2008,22 +2078,62 @@ class RadioPoller:
                         logger.warning("set_band: unknown bsr_code=%d", band)
             case SelectVfo(vfo=vfo):
                 self._last_user_write_ts = time.monotonic()
-                # Select the target receiver via the public
-                # ``ReceiverBankCapable.select_receiver`` (issue #1172).
-                # Pre-#771 this used a MAIN↔SUB swap (0x07 0xB0) as a hack
-                # so that LAN audio (MAIN-only at the time) would "follow"
-                # the selected receiver.  After #721/#755 introduced
-                # Phones L/R Mix + audio_config, audio routing is
-                # independent of which receiver is selected, and the swap
-                # hack actively corrupted user state on every click
-                # (frequencies/modes traded places).  Wave 4-A landed
-                # ``select_receiver`` (CI-V 0x07 0xD0/0xD1) on every
-                # backend, so the poller now goes through the typed API
-                # rather than a raw ``_civ`` write.  Idempotent: re-clicking
-                # the active receiver emits no CI-V (the state event still
-                # fires so UI listeners can refresh).
                 vfo_upper = vfo.upper()
-                is_sub = vfo_upper in ("SUB", "B")
+                slot: str | None = None
+                if vfo_upper in ("A", "B"):
+                    slot = vfo_upper
+                elif self._profile.receiver_count == 1 and vfo_upper in (
+                    "VFOA",
+                    "VFOB",
+                ):
+                    slot = vfo_upper[-1]
+                if slot is not None:
+                    active_name = self._current_active().upper()
+                    receiver = 1 if active_name == "SUB" else 0
+                    self._ensure_receiver_supported(
+                        receiver, operation="select_vfo_slot"
+                    )
+                    set_vfo_slot = getattr(radio, "set_vfo_slot", None)
+                    if set_vfo_slot is not None:
+                        await set_vfo_slot(slot, receiver=receiver)
+                        logger.info(
+                            "radio-poller: set_vfo_slot=%s receiver=%d",
+                            slot,
+                            receiver,
+                        )
+                    else:
+                        legacy_set_vfo = getattr(radio, "set_vfo", None)
+                        if legacy_set_vfo is None:
+                            logger.warning(
+                                "radio-poller: select_vfo(%s) — backend lacks "
+                                "set_vfo_slot and set_vfo; skipping",
+                                vfo,
+                            )
+                            return
+                        await legacy_set_vfo(slot)
+                        logger.info(
+                            "radio-poller: legacy set_vfo=%s "
+                            "(backend lacks VfoSlotCapable)",
+                            slot,
+                        )
+                    if self._radio_state is not None:
+                        self._radio_state.receiver(active_name).active_slot = slot
+                    if self._on_state_event:
+                        self._on_state_event(
+                            "vfo_changed", {"vfo": slot, "receiver": receiver}
+                        )
+                    return
+
+                if vfo_upper in ("SUB", "1") or (
+                    self._profile.receiver_count > 1 and vfo_upper == "VFOB"
+                ):
+                    is_sub = True
+                elif vfo_upper in ("MAIN", "0") or (
+                    self._profile.receiver_count > 1 and vfo_upper == "VFOA"
+                ):
+                    is_sub = False
+                else:
+                    raise CommandError(f"unknown VFO selection {vfo!r}")
                 if is_sub:
                     self._ensure_receiver_supported(1, operation="select_vfo")
                 current = self._current_active()
@@ -2093,10 +2203,6 @@ class RadioPoller:
                                 "radio-poller: scope follow failed",
                                 exc_info=True,
                             )
-                if self._radio_state is not None:
-                    # Compatibility mirror until web state delivery reads the
-                    # active-slot projection from StateStore.
-                    self._radio_state.main.active_slot = "B" if is_sub else "A"
                 if self._on_state_event:
                     self._on_state_event("vfo_changed", {"vfo": vfo})
             case VfoSwap():
@@ -2128,15 +2234,15 @@ class RadioPoller:
                     else:
                         if self._scope_demand_is_stale(generation):
                             return
-                        await radio.enable_scope(policy=policy)
+                        await self._enable_scope_session(policy=policy)
                         logger.info("radio-poller: scope enabled")
                         await self._fetch_scope_controls()
             case DisableScope(generation=generation):
                 if CAP_SCOPE in self._caps:
                     if self._scope_demand_is_stale(generation):
                         return
-                    await radio.disable_scope()
-                    logger.info("radio-poller: scope disabled")
+                    await self.restore_scope_session()
+                    logger.info("radio-poller: scope session state restored")
             case SwitchScopeReceiver(receiver=receiver):
                 # Fire-and-forget scope receiver select (0x27 0x12)
                 self._ensure_receiver_supported(
@@ -2836,141 +2942,20 @@ class RadioPoller:
             await self._send_one_state_query(cmd_byte, sub_byte, receiver)
         self._poll_index += 1
 
-    # Issue #715: unselected-slot slow-poll cycle.
-    # Rate-limit and debounce thresholds are conservative — this cycle
-    # is a correctness feature (populate vfo_b) not a throughput one.
+    # Issue #2303: passive observation must never select or exchange a VFO.
+    # Inactive A/B state may therefore remain unknown/stale until a genuinely
+    # non-mutating provider read exists for the active profile.
     _UNSELECTED_SLOT_INTERVAL: float = 5.0  # sec between refreshes per rx
     _UNSELECTED_SLOT_DEBOUNCE: float = 0.5  # sec after last user freq/mode write
 
     def _unselected_slot_gate(self, receiver: int) -> bool:
-        """Return True iff it is safe to read the unselected slot on *receiver*."""
-        if self._radio_state is None or getattr(self._radio_state, "ptt", False):
-            return False
-        if self._queue.has_commands:
-            return False
-        now = time.monotonic()
-        if (now - self._last_user_write_ts) < self._UNSELECTED_SLOT_DEBOUNCE:
-            return False
-        last = self._last_unselected_poll.get(receiver, 0.0)
-        if (now - last) < self._UNSELECTED_SLOT_INTERVAL:
-            return False
-        if not self._profile.supports_receiver(receiver):
-            return False
-        # Need a true A/B-within-receiver swap primitive. swap_main_sub_code
-        # is NOT a fallback — on IC-7610 the 0x07 0xB0 byte toggles MAIN↔SUB,
-        # not A↔B inside a receiver, which would flip the radio's active-RX
-        # state on every slow-poll cycle.
-        if self._profile.swap_ab_code is None:
-            return False
-        return True
+        """Return False: exchange-based inactive-slot reads mutate hardware."""
+        _ = receiver
+        return False
 
     async def _poll_unselected_slot(self, receiver: int) -> None:
-        """Read freq+mode of the inactive VFO slot on *receiver*.
-
-        Uses a transient ``host._vfo_slot_override`` flag so ``_civ_rx.py``
-        routes the 0x03/0x04 responses to the opposite slot.  On dual-RX
-        profiles the target receiver is selected first via ``0x07`` and
-        restored after.  Swap → query → swap-back keeps the radio's
-        active-slot state unchanged for the user.
-        """
-        if not self._unselected_slot_gate(receiver):
-            return
-        rs = self._radio_state
-        assert rs is not None  # gate guarantees
-        rx_name = "MAIN" if receiver == 0 else "SUB"
-        rx_state = rs.receiver(rx_name)
-        target_slot = "B" if rx_state.active_slot == "A" else "A"
-        swap_code = self._profile.swap_ab_code
-        assert swap_code is not None  # gate guarantees (see _unselected_slot_gate)
-        # Pre-select MAIN/SUB on dual-RX rigs so the swap hits the intended
-        # receiver.  Restore after the read.
-        pre_switched = False
-        pre_code: int | None = None
-        post_code: int | None = None
-        if self._profile.receiver_count > 1:
-            current = self._current_active()
-            if rx_name != current:
-                if rx_name == "SUB" and self._profile.vfo_sub_code is not None:
-                    pre_code = self._profile.vfo_sub_code
-                    post_code = self._profile.vfo_main_code
-                elif rx_name == "MAIN" and self._profile.vfo_main_code is not None:
-                    pre_code = self._profile.vfo_main_code
-                    post_code = self._profile.vfo_sub_code
-                if pre_code is None or post_code is None:
-                    return  # profile cannot switch — skip
-        override_map = getattr(self._radio, "_vfo_slot_override", None)
-        if not isinstance(override_map, dict):
-            override_map = {}
-            try:
-                self._radio._vfo_slot_override = override_map  # type: ignore[attr-defined]
-            except AttributeError:
-                return  # host refuses attribute — skip silently
-        try:
-            if pre_code is not None:
-                await self._civ(
-                    0x07,
-                    data=bytes([pre_code]),
-                    priority=Priority.BACKGROUND,
-                    wait_dispatch=False,
-                )
-                await asyncio.sleep(self._adaptive_gap())
-                pre_switched = True
-            # Swap A/B within the selected receiver.
-            await self._civ(
-                0x07,
-                data=bytes([swap_code]),
-                priority=Priority.BACKGROUND,
-                wait_dispatch=False,
-            )
-            await asyncio.sleep(self._adaptive_gap())
-            # Responses for the queries below must route to the opposite slot.
-            override_map[rx_name] = target_slot
-            await self._civ(
-                0x03, data=b"", priority=Priority.BACKGROUND, wait_dispatch=False
-            )
-            await asyncio.sleep(self._adaptive_gap())
-            await self._civ(
-                0x04, data=b"", priority=Priority.BACKGROUND, wait_dispatch=False
-            )
-            # Give the CI-V RX pump a moment to drain responses before we
-            # swap back (the override stays set until *after* swap-back
-            # so any late 0x03/0x04 response still routes to the
-            # opposite slot rather than polluting vfo_a via the property
-            # setter).
-            await asyncio.sleep(self._adaptive_gap() * 2)
-        finally:
-            # Always try to swap back so the radio ends in the original
-            # slot even when a query errored.  Override is cleared after
-            # the swap-back send + a gap to cover in-flight responses.
-            try:
-                await self._civ(
-                    0x07,
-                    data=bytes([swap_code]),
-                    priority=Priority.BACKGROUND,
-                    wait_dispatch=False,
-                )
-            except Exception:
-                logger.warning(
-                    "radio-poller: failed to restore VFO A/B on receiver=%d",
-                    receiver,
-                    exc_info=True,
-                )
-            await asyncio.sleep(self._adaptive_gap())
-            override_map.pop(rx_name, None)
-            if pre_switched and post_code is not None:
-                try:
-                    await self._civ(
-                        0x07,
-                        data=bytes([post_code]),
-                        priority=Priority.BACKGROUND,
-                        wait_dispatch=False,
-                    )
-                except Exception:
-                    logger.warning(
-                        "radio-poller: failed to restore MAIN/SUB selection",
-                        exc_info=True,
-                    )
-        self._last_unselected_poll[receiver] = time.monotonic()
+        """Intentionally do nothing; swap/query/swap is not passive polling."""
+        _ = receiver
 
     def _emit(self, name: str, data: dict[str, Any]) -> None:
         if self._on_state_event is not None:

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -839,7 +839,9 @@ class WebServer:
         self._client_tasks: set[asyncio.Task[None]] = set()
         self._scope_handlers: set["ScopeHandler"] = set()
         self._audio_scope_handlers: set["ScopeHandler"] = set()
+        # Confirmed hardware-session state only.  A queued command is not proof.
         self._scope_enabled = False
+        self._scope_enable_failed = False
         self._scope_demand_generation = 0
         self._scope_enable_lock: asyncio.Lock = asyncio.Lock()
         self._scope_disable_grace: float = 2.0
@@ -1103,10 +1105,15 @@ class WebServer:
                         len(self._scope_handlers),
                     )
                     return
+                if self._scope_enable_failed:
+                    logger.debug("scope: enable previously rejected; not retrying")
+                    return
                 if self._radio_ready():
-                    self._command_queue.put(EnableScope(generation=generation))
-                    self._scope_enabled = True
-                    logger.info("scope: enable queued")
+                    if await self._execute_scope_command(
+                        EnableScope(generation=generation)
+                    ):
+                        self._scope_enabled = True
+                        logger.info("scope: enable confirmed")
                 else:
                     self._schedule_scope_enable_when_ready(
                         reason="handler_connect", generation=generation
@@ -1128,34 +1135,58 @@ class WebServer:
             and self._hardware_scope_available
         ):
             self._set_scope_data_callback(None)
-            if self._scope_enabled:
+            if self._scope_enabled or self._scope_enable_failed:
                 self._spawn(
                     self._disable_scope_async(generation=self._scope_demand_generation)
                 )
+
+    async def _execute_scope_command(self, command: EnableScope | DisableScope) -> bool:
+        """Execute a scope command through the existing ordered command pipeline."""
+        future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+        self._command_queue.put_ordered(command, future=future)
+        try:
+            await future
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            if isinstance(command, EnableScope) and not self._scope_enabled:
+                self._scope_enable_failed = True
+            logger.warning("scope: %s failed: %s", type(command).__name__, exc)
+            return False
+        if isinstance(command, EnableScope):
+            self._scope_enable_failed = False
+        return True
 
     async def _disable_scope_async(self, *, generation: int) -> None:
         """Disable scope on the radio when no more handlers are connected."""
         if self._radio is None or not self._hardware_scope_available:
             return
         await asyncio.sleep(self._scope_disable_grace)
-        if self._scope_handlers:
-            logger.debug("scope: disable task aborted — handler reconnected")
-            if self._radio is not None:
-                self._set_scope_data_callback(self._broadcast_scope)
-            return
-        if generation != self._scope_demand_generation:
-            logger.debug("scope: disable task superseded by newer viewer demand")
-            return
-        self._command_queue.put(DisableScope(generation=generation))
-        if not self._scope_handlers:
-            self._scope_enabled = False
-            logger.info("scope: disable queued (no active handlers)")
-        else:
-            logger.debug(
-                "scope: disable queued but new handler present — will re-enable"
-            )
-            if self._radio is not None:
-                self._set_scope_data_callback(self._broadcast_scope)
+        async with self._scope_enable_lock:
+            if self._scope_handlers:
+                logger.debug("scope: disable task aborted — handler reconnected")
+                if self._radio is not None:
+                    self._set_scope_data_callback(self._broadcast_scope)
+                return
+            if generation != self._scope_demand_generation:
+                logger.debug("scope: disable task superseded by newer viewer demand")
+                return
+            if await self._execute_scope_command(DisableScope(generation=generation)):
+                self._scope_enabled = False
+                self._scope_enable_failed = False
+                logger.info("scope: pre-session state restored (no active handlers)")
+
+    async def restore_scope_before_shutdown(self) -> None:
+        """Restore confirmed scope ownership before the poller is stopped."""
+        async with self._scope_enable_lock:
+            if not self._scope_enabled and not self._scope_enable_failed:
+                return
+            self._scope_demand_generation += 1
+            if await self._execute_scope_command(
+                DisableScope(generation=self._scope_demand_generation)
+            ):
+                self._scope_enabled = False
+                self._scope_enable_failed = False
 
     def _dispatch_audio_fft_frame(self, frame: Any) -> None:
         """Fan out an audio FFT frame to the relevant scope channels.
@@ -1944,16 +1975,17 @@ class WebServer:
                 self._scope_handlers
                 and self._radio is not None
                 and self._hardware_scope_available
+                and not self._scope_enable_failed
             ):
                 self._set_scope_data_callback(self._broadcast_scope)
-                self._command_queue.put(
+                if await self._execute_scope_command(
                     EnableScope(generation=self._scope_demand_generation)
-                )
-                self._scope_enabled = True
-                logger.info(
-                    "scope: re-enable queued after reconnect (%d handlers)",
-                    len(self._scope_handlers),
-                )
+                ):
+                    self._scope_enabled = True
+                    logger.info(
+                        "scope: re-enable confirmed after reconnect (%d handlers)",
+                        len(self._scope_handlers),
+                    )
 
         self._spawn(_refetch_and_reenable())
 
@@ -1995,15 +2027,19 @@ class WebServer:
                     return
                 if not self._hardware_scope_available:
                     return
+                if self._scope_enable_failed:
+                    return
                 if self._radio_ready():
                     self._set_scope_data_callback(self._broadcast_scope)
-                    self._command_queue.put(EnableScope(generation=generation))
-                    self._scope_enabled = True
-                    logger.info(
-                        "scope: enable queued after %s (%d handlers)",
-                        reason,
-                        len(self._scope_handlers),
-                    )
+                    if await self._execute_scope_command(
+                        EnableScope(generation=generation)
+                    ):
+                        self._scope_enabled = True
+                        logger.info(
+                            "scope: enable confirmed after %s (%d handlers)",
+                            reason,
+                            len(self._scope_handlers),
+                        )
                     return
                 if time.monotonic() >= deadline:
                     logger.warning(
@@ -2055,6 +2091,8 @@ class WebServer:
                     self._scope_last_nonzero = time.monotonic()  # reset timer
                     retries = 0
                     continue
+                if not self._scope_enabled:
+                    continue
                 now = time.monotonic()
                 if self._scope_last_nonzero == 0.0:
                     # Never seen non-zero — might be starting up
@@ -2071,7 +2109,7 @@ class WebServer:
                             )
                             retries += 1  # log once
                         continue
-                    self._command_queue.put(
+                    await self._execute_scope_command(
                         EnableScope(generation=self._scope_demand_generation)
                     )
                     self._scope_last_nonzero = now  # reset to avoid spam

--- a/src/rigplane/web/web_startup.py
+++ b/src/rigplane/web/web_startup.py
@@ -32,6 +32,8 @@ __all__ = ["start_web_server", "stop_web_server"]
 
 logger = logging.getLogger(__name__)
 
+_SHUTDOWN_SCOPE_RESTORE_TIMEOUT_S = 1.0
+
 
 def _reuse_port_supported() -> bool:
     return sys.platform != "win32"
@@ -317,6 +319,45 @@ async def stop_web_server(server: WebServer) -> None:
     #    pending PttOff entries and discards the rest (MOR-1181).
     if radio_poller is not None:
         await radio_poller.drain_tx_safety_commands()
+
+    # 10. Scope restoration is intentionally subordinate to the final unkey.
+    # A queued DisableScope cannot complete once the poller is stopped (and may
+    # never have been serviceable if it already crashed), while waiting for it
+    # before step 9 can prevent a teardown PttOff from even being enqueued.
+    # With the poller loop gone, restore its owned snapshot directly on the same
+    # radio lane, bounded so a failed link cannot hold shutdown open.  On every
+    # incomplete path the flags/snapshot stay intact and the log records that
+    # restoration remains pending.
+    scope_restore_pending = bool(
+        getattr(server, "_scope_enabled", False)
+        or getattr(server, "_scope_enable_failed", False)
+    )
+    if scope_restore_pending:
+        if radio_poller is None:
+            logger.warning(
+                "scope: shutdown restore pending; radio poller is unavailable"
+            )
+        else:
+            try:
+                await asyncio.wait_for(
+                    radio_poller.restore_scope_after_shutdown(),
+                    timeout=_SHUTDOWN_SCOPE_RESTORE_TIMEOUT_S,
+                )
+            except TimeoutError:
+                logger.warning(
+                    "scope: shutdown restore timed out after %.1fs; state remains "
+                    "pending",
+                    _SHUTDOWN_SCOPE_RESTORE_TIMEOUT_S,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "scope: shutdown restore failed; state remains pending: %s",
+                    exc,
+                )
+            else:
+                server._scope_enabled = False
+                server._scope_enable_failed = False
+                logger.info("scope: pre-session state restored during shutdown")
 
     # Radio disconnect is handled by the caller's context manager
     # (async with radio: in _run). Do NOT disconnect here.

--- a/tests/test_command_service.py
+++ b/tests/test_command_service.py
@@ -1174,6 +1174,37 @@ def test_command_intent_targets_observable_production_write_paths(
     assert observation.value == expected_value
 
 
+@pytest.mark.parametrize(
+    ("vfo", "receiver_count", "expected_slot", "expected_receiver"),
+    [
+        ("A", 1, "A", None),
+        ("B", 1, "B", None),
+        ("B", 2, "B", None),
+        ("MAIN", 2, None, "MAIN"),
+        ("SUB", 2, None, "SUB"),
+        ("VFOA", 1, "A", None),
+        ("VFOB", 1, "B", None),
+        ("VFOA", 2, None, "MAIN"),
+        ("VFOB", 2, None, "SUB"),
+    ],
+)
+def test_vfo_intent_keeps_slot_and_receiver_namespaces_separate(
+    vfo: str,
+    receiver_count: int,
+    expected_slot: str | None,
+    expected_receiver: str | None,
+) -> None:
+    intent = command_intent_from_request(
+        "set_vfo",
+        {"vfo": vfo, "receiver_count": receiver_count},
+        source="websocket",
+        command_id=f"vfo-{vfo}-{receiver_count}",
+    )
+
+    assert intent.params.get("active_slot") == expected_slot
+    assert intent.params.get("active") == expected_receiver
+
+
 @pytest.mark.asyncio
 async def test_set_level_command_overlay_keeps_raw_byte_value_for_current_contract() -> (
     None

--- a/tests/test_icom7610_serial_radio.py
+++ b/tests/test_icom7610_serial_radio.py
@@ -17,6 +17,7 @@ from rigplane.commands import (
     parse_civ_frame,
 )
 from rigplane.exceptions import CommandError, ConnectionError
+from rigplane.exceptions import TimeoutError as RigplaneTimeoutError
 from rigplane.types import AudioCodec
 from rigplane.types import bcd_encode
 
@@ -60,6 +61,16 @@ def _scope_wave_frame(
         0x27,
         sub=0x00,
         data=payload,
+    )
+
+
+def _scope_state_response(sub: int, enabled: bool) -> bytes:
+    return build_civ_frame(
+        CONTROLLER_ADDR,
+        IC_7610_ADDR,
+        0x27,
+        sub=sub,
+        data=bytes([enabled]),
     )
 
 
@@ -504,6 +515,122 @@ async def test_serial_scope_low_baud_guardrail_rejects_without_override() -> Non
     with pytest.raises(CommandError, match="baudrate"):
         await radio.enable_scope(policy="fast")
     await radio.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_scope_session_restore_preserves_panel_and_output_state_exactly() -> None:
+    link = _FakeSerialCivLink()
+    link.queue_response_on_send(1, _scope_state_response(0x10, True))
+    link.queue_response_on_send(2, _scope_state_response(0x11, False))
+    radio = Icom7610SerialRadio(
+        device="/dev/ttyUSB0",
+        civ_link=link,
+    )
+    await radio.connect()
+
+    initial = await radio.get_scope_session_state()
+    await radio.enable_scope(policy="fast")
+    await radio.restore_scope_session_state(initial)
+    await radio.disconnect()
+
+    signatures = [
+        (frame.command, frame.sub, frame.data)
+        for payload in link.sent_frames
+        if len(payload) >= 6
+        for frame in [parse_civ_frame(payload)]
+    ]
+    assert initial == (True, False)
+    assert signatures == [
+        (0x27, 0x10, b""),
+        (0x27, 0x11, b""),
+        (0x27, 0x10, b"\x01"),
+        (0x27, 0x11, b"\x01"),
+        (0x27, 0x10, b"\x01"),
+        (0x27, 0x11, b"\x00"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_rejected_low_baud_scope_enable_never_emits_scope_off() -> None:
+    from rigplane.web.radio_poller import (
+        CommandQueue,
+        DisableScope,
+        EnableScope,
+        RadioPoller,
+    )
+
+    link = _FakeSerialCivLink()
+    radio = Icom7610SerialRadio(
+        device="/dev/ttyUSB0",
+        baudrate=19200,
+        civ_link=link,
+    )
+    await radio.connect()
+    queue = CommandQueue()
+    poller = RadioPoller(radio, queue, radio_state=radio.radio_state)
+
+    with pytest.raises(CommandError, match="baudrate"):
+        await poller._execute(EnableScope(generation=1))
+    await poller._execute(DisableScope(generation=2))
+    await radio.disconnect()
+
+    signatures = [
+        (frame.command, frame.sub, frame.data)
+        for payload in link.sent_frames
+        if len(payload) >= 6
+        for frame in [parse_civ_frame(payload)]
+    ]
+    assert signatures == []
+    assert (0x27, 0x10, b"\x00") not in signatures
+    assert (0x27, 0x11, b"\x00") not in signatures
+
+
+@pytest.mark.asyncio
+async def test_verify_timeout_after_scope_on_rolls_back_exact_initial_state() -> None:
+    from rigplane.web.radio_poller import (
+        CommandQueue,
+        DisableScope,
+        EnableScope,
+        RadioPoller,
+    )
+
+    link = _FakeSerialCivLink()
+    link.queue_response_on_send(1, _scope_state_response(0x10, False))
+    link.queue_response_on_send(2, _scope_state_response(0x11, False))
+    radio = Icom7610SerialRadio(
+        device="/dev/ttyUSB0",
+        civ_link=link,
+    )
+    await radio.connect()
+    real_enable_scope = radio.enable_scope
+
+    async def enable_scope_with_short_verify(*, policy: str) -> None:
+        await real_enable_scope(policy=policy, timeout=0.01)
+
+    radio.enable_scope = enable_scope_with_short_verify  # type: ignore[method-assign]
+    poller = RadioPoller(radio, CommandQueue(), radio_state=radio.radio_state)
+
+    with pytest.raises(RigplaneTimeoutError, match="verification timed out"):
+        await poller._execute(EnableScope(policy="verify", generation=1))
+    sent_before_disable = len(link.sent_frames)
+    await poller._execute(DisableScope(generation=2))
+    assert len(link.sent_frames) == sent_before_disable
+    await radio.disconnect()
+
+    signatures = [
+        (frame.command, frame.sub, frame.data)
+        for payload in link.sent_frames
+        if len(payload) >= 6
+        for frame in [parse_civ_frame(payload)]
+    ]
+    assert signatures == [
+        (0x27, 0x10, b""),
+        (0x27, 0x11, b""),
+        (0x27, 0x10, b"\x01"),
+        (0x27, 0x11, b"\x01"),
+        (0x27, 0x10, b"\x00"),
+        (0x27, 0x11, b"\x00"),
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_poller_poll_priority.py
+++ b/tests/test_poller_poll_priority.py
@@ -74,18 +74,14 @@ async def test_state_query_sends_background_priority() -> None:
 
 
 @pytest.mark.asyncio
-async def test_unselected_slot_poll_sends_background_priority() -> None:
-    # IC-7300 has swap_ab_code set and receiver_count == 1, so the
-    # unselected-slot gate is satisfiable with a simple swap→query→swap-back.
+async def test_unselected_slot_poll_sends_no_vfo_selection_frames() -> None:
     radio = _make_radio(model="IC-7300", active="MAIN")
     poller = RadioPoller(radio, CommandQueue(), radio_state=RadioState())
 
-    assert poller._unselected_slot_gate(0)  # noqa: SLF001  (sanity: gate open)
+    assert not poller._unselected_slot_gate(0)  # noqa: SLF001
     await poller._poll_unselected_slot(0)  # noqa: SLF001
 
-    assert radio.send_civ.await_count >= 1
-    for call in radio.send_civ.await_args_list:
-        assert _priority_of(call) == Priority.BACKGROUND
+    radio.send_civ.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from rigplane.commands.commander import IcomCommander, Priority
+from rigplane.core.capabilities import CAP_SCOPE
 from rigplane.core.acquisition_scheduler import (
     AcquisitionScheduler,
     MeterObservationCoalescer,
@@ -137,8 +138,8 @@ class _InjectedAcquisitionExecutor:
         )
 
 
-def _make_radio(active: str = "MAIN") -> MagicMock:
-    profile = resolve_radio_profile(model="IC-7610")
+def _make_radio(active: str = "MAIN", *, model: str = "IC-7610") -> MagicMock:
+    profile = resolve_radio_profile(model=model)
     radio = MagicMock()
     radio.profile = profile
     radio.model = profile.model
@@ -220,6 +221,8 @@ def _make_radio(active: str = "MAIN") -> MagicMock:
     # QuickDwTrigger / QuickSplitTrigger composites.
     radio.enable_scope = AsyncMock()
     radio.disable_scope = AsyncMock()
+    radio.get_scope_session_state = AsyncMock(return_value=(False, False))
+    radio.restore_scope_session_state = AsyncMock()
     radio.on_scope_data = MagicMock()
     radio.capture_scope_frame = AsyncMock()
     radio.capture_scope_frames = AsyncMock()
@@ -1121,7 +1124,7 @@ async def test_execute_event_emitting_commands_and_vfo_paths() -> None:
     await poller._execute(DisableScope())  # noqa: SLF001
     await poller._execute(SwitchScopeReceiver(1))  # noqa: SLF001
     radio.enable_scope.assert_awaited_once_with(policy="fast")
-    radio.disable_scope.assert_awaited_once()
+    radio.restore_scope_session_state.assert_awaited_once_with((False, False))
     with pytest.raises(CommandError, match="receiver=2"):
         await poller._execute(SwitchScopeReceiver(2))  # noqa: SLF001
 
@@ -1156,6 +1159,23 @@ async def test_select_vfo_legacy_backend_falls_back_to_set_vfo() -> None:
 
     radio.set_vfo.assert_awaited_once_with("SUB")
     assert any(name == "vfo_changed" for name, _ in events)
+
+
+@pytest.mark.asyncio
+async def test_single_receiver_vfo_b_selects_slot_without_sub_receiver() -> None:
+    state = RadioState()
+    state.active = "MAIN"
+    state.main.active_slot = "A"
+    radio = _make_radio(model="IC-7300")
+    radio._radio_state = state
+    poller = RadioPoller(radio, StateCache(), CommandQueue(), radio_state=state)
+
+    await poller._execute(SelectVfo("B"))  # noqa: SLF001
+
+    radio.set_vfo_slot.assert_awaited_once_with("B", receiver=0)
+    radio.select_receiver.assert_not_awaited()
+    assert state.active == "MAIN"
+    assert state.main.active_slot == "B"
 
 
 @pytest.mark.asyncio
@@ -1625,7 +1645,7 @@ async def test_stale_deferred_enable_cannot_requeue_after_newer_disable() -> Non
         await poller._execute(command)  # noqa: SLF001
 
     radio.enable_scope.assert_not_awaited()
-    radio.disable_scope.assert_awaited_once()
+    radio.restore_scope_session_state.assert_not_awaited()
     assert queue.has_commands is False
 
 
@@ -1657,6 +1677,38 @@ async def test_current_scope_generation_preserves_recovery_enable() -> None:
     await poller._execute(EnableScope(generation=5))  # noqa: SLF001
 
     assert radio.enable_scope.await_count == 2
+    radio.get_scope_session_state.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("initial", [(True, False), (False, False)])
+async def test_scope_session_restores_exact_initial_state(
+    initial: tuple[bool, bool],
+) -> None:
+    radio = _make_radio()
+    radio.get_scope_session_state.return_value = initial
+    poller = RadioPoller(radio, StateCache(), CommandQueue(), radio_state=RadioState())
+
+    await poller._execute(EnableScope(generation=1))  # noqa: SLF001
+    await poller._execute(EnableScope(generation=1))  # noqa: SLF001
+    await poller._execute(DisableScope(generation=2))  # noqa: SLF001
+
+    radio.get_scope_session_state.assert_awaited_once()
+    assert radio.enable_scope.await_count == 2
+    radio.restore_scope_session_state.assert_awaited_once_with(initial)
+
+
+@pytest.mark.asyncio
+async def test_failed_scope_enable_rolls_back_captured_state() -> None:
+    radio = _make_radio()
+    radio.enable_scope.side_effect = ConnectionError("scope unavailable at low baud")
+    poller = RadioPoller(radio, StateCache(), CommandQueue(), radio_state=RadioState())
+
+    with pytest.raises(ConnectionError, match="low baud"):
+        await poller._execute(EnableScope(generation=1))  # noqa: SLF001
+    await poller._execute(DisableScope(generation=2))  # noqa: SLF001
+
+    radio.restore_scope_session_state.assert_awaited_once_with((False, False))
 
 
 @pytest.mark.asyncio
@@ -2281,7 +2333,7 @@ async def test_select_vfo_success_keeps_pending_overlay_until_observation() -> N
     await service.execute(
         command_intent_from_request(
             "set_vfo",
-            {"vfo": "SUB"},
+            {"vfo": "SUB", "receiver_count": 2},
             source="websocket",
             command_id="ws-set-vfo",
         )
@@ -3209,7 +3261,11 @@ def _writable_control_session(queue: CommandQueue) -> ControlHandler:
 
 
 def _shutdown_server(
-    poller: RadioPoller, client_tasks: list[asyncio.Task[None]]
+    poller: RadioPoller | None,
+    client_tasks: list[asyncio.Task[None]],
+    *,
+    scope_enabled: bool = False,
+    scope_enable_failed: bool = False,
 ) -> SimpleNamespace:
     """The subset of ``WebServer`` that ``stop_web_server`` actually touches."""
     return SimpleNamespace(
@@ -3230,6 +3286,8 @@ def _shutdown_server(
         _client_tasks=client_tasks,
         _server=None,
         _server_was_running=True,
+        _scope_enabled=scope_enabled,
+        _scope_enable_failed=scope_enable_failed,
     )
 
 
@@ -3258,6 +3316,113 @@ async def test_server_shutdown_delivers_the_unkey_its_client_enqueues_late() -> 
     assert supervisor.outcomes[-1] is TxOutcome.ACCEPTED
     assert radio.calls == ["start_tx", *_TEARDOWN]
     assert queue.has_commands is False
+
+
+def _scope_shutdown_poller(
+    *, external_cat_session_active: bool = False
+) -> tuple[RadioPoller, _Radio, CommandQueue]:
+    """Stopped-poller restore harness over the same executor as the TX drain."""
+    radio = _Radio(None)
+    radio.capabilities.add(CAP_SCOPE)
+    radio.external_cat_session_active = external_cat_session_active
+    queue = CommandQueue()
+    poller = RadioPoller(radio, queue)  # type: ignore[arg-type]
+    poller._scope_session_state = (True, False)  # noqa: SLF001
+    poller._scope_session_active = True  # noqa: SLF001
+    return poller, radio, queue
+
+
+@pytest.mark.asyncio
+async def test_shutdown_restores_scope_after_final_unkey_on_same_executor() -> None:
+    """Scope restoration stays on the sole poller executor and follows PTT OFF."""
+    poller, radio, queue = _scope_shutdown_poller()
+
+    async def _restore_scope(state: tuple[bool, bool]) -> None:
+        radio.calls.append(f"restore_scope{state}")
+
+    radio.restore_scope_session_state = _restore_scope  # type: ignore[attr-defined]
+    queue.put(PttOff(), command_id="shutdown-off", source="websocket")
+    server = _shutdown_server(poller, [], scope_enabled=True)
+
+    with patch.object(poller, "_execute", wraps=poller._execute) as execute:  # noqa: SLF001
+        await stop_web_server(server)  # type: ignore[arg-type]
+
+    # Both writes entered through this one stopped poller's existing executor;
+    # no parallel queue consumer or second radio-control lane is created.
+    assert [type(call.args[0]) for call in execute.await_args_list] == [
+        PttOff,
+        DisableScope,
+    ]
+    assert radio.calls == [
+        "set_ptt(False)",
+        *_TEARDOWN,
+        "restore_scope(True, False)",
+    ]
+    assert not server._scope_enabled
+    assert not server._scope_enable_failed
+    assert poller._scope_session_state is None  # noqa: SLF001
+    assert poller._scope_session_active is False  # noqa: SLF001
+    assert queue.has_commands is False
+
+
+@pytest.mark.asyncio
+async def test_shutdown_external_cat_defers_scope_but_still_delivers_unkey(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    poller, radio, queue = _scope_shutdown_poller(external_cat_session_active=True)
+    restore = AsyncMock()
+    radio.restore_scope_session_state = restore  # type: ignore[attr-defined]
+    queue.put(PttOff(), command_id="shutdown-off", source="websocket")
+    server = _shutdown_server(poller, [], scope_enabled=True)
+
+    with caplog.at_level(logging.WARNING, logger="rigplane.web.web_startup"):
+        await stop_web_server(server)  # type: ignore[arg-type]
+
+    assert radio.calls == ["set_ptt(False)", *_TEARDOWN]
+    restore.assert_not_awaited()
+    assert server._scope_enabled
+    assert poller._scope_session_state == (True, False)  # noqa: SLF001
+    assert poller._scope_session_active is True  # noqa: SLF001
+    assert "external CAT session owns the wire" in caplog.text
+    assert "state remains pending" in caplog.text
+
+
+@pytest.mark.parametrize("failure", ["error", "timeout"])
+@pytest.mark.asyncio
+async def test_shutdown_scope_restore_failure_never_delays_final_unkey(
+    failure: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    poller, radio, queue = _scope_shutdown_poller()
+    restore_started = asyncio.Event()
+
+    async def _restore_scope(_state: tuple[bool, bool]) -> None:
+        restore_started.set()
+        if failure == "error":
+            raise ConnectionError("scope link failed")
+        await asyncio.Event().wait()
+
+    radio.restore_scope_session_state = _restore_scope  # type: ignore[attr-defined]
+    queue.put(PttOff(), command_id="shutdown-off", source="websocket")
+    server = _shutdown_server(poller, [], scope_enabled=True)
+
+    started = time.monotonic()
+    with (
+        patch("rigplane.web.web_startup._SHUTDOWN_SCOPE_RESTORE_TIMEOUT_S", 0.02),
+        caplog.at_level(logging.WARNING, logger="rigplane.web.web_startup"),
+    ):
+        await stop_web_server(server)  # type: ignore[arg-type]
+    elapsed = time.monotonic() - started
+
+    assert restore_started.is_set()
+    assert elapsed < 1.0
+    assert radio.calls == ["set_ptt(False)", *_TEARDOWN]
+    assert server._scope_enabled
+    assert poller._scope_session_state == (True, False)  # noqa: SLF001
+    assert poller._scope_session_active is True  # noqa: SLF001
+    expected = "timed out" if failure == "timeout" else "failed"
+    assert expected in caplog.text
+    assert "state remains pending" in caplog.text
 
 
 # --- MOR-1220: the unmanaged max-key-down backstop -------------------------

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -18,6 +18,8 @@ from rigplane import IC_7610_ADDR
 from rigplane.commands import (
     CONTROLLER_ADDR,
     build_civ_frame,
+    get_scope_data_output_enabled,
+    get_scope_enabled,
     get_scope_center_type,
     get_scope_during_tx,
     get_scope_edge,
@@ -31,6 +33,9 @@ from rigplane.commands import (
     get_scope_span,
     get_scope_speed,
     get_scope_vbw,
+    parse_civ_frame,
+    parse_scope_data_output_enabled_response,
+    parse_scope_enabled_response,
     scope_data_output_off,
     scope_data_output_on,
     scope_main_sub,
@@ -695,6 +700,19 @@ class TestScopeCommandBuilders:
         assert frame[5] == 0x10
         assert frame[6] == 0x00
 
+    def test_get_scope_enabled_is_read_only(self) -> None:
+        assert get_scope_enabled() == b"\xfe\xfe\x98\xe0\x27\x10\xfd"
+
+    def test_parse_scope_enabled_response(self) -> None:
+        off = parse_civ_frame(
+            build_civ_frame(CONTROLLER_ADDR, IC_7610_ADDR, 0x27, sub=0x10, data=b"\x00")
+        )
+        on = parse_civ_frame(
+            build_civ_frame(CONTROLLER_ADDR, IC_7610_ADDR, 0x27, sub=0x10, data=b"\x01")
+        )
+        assert parse_scope_enabled_response(off) is False
+        assert parse_scope_enabled_response(on) is True
+
     def test_scope_data_output_on(self) -> None:
         frame = scope_data_output_on()
         assert frame[4] == 0x27
@@ -706,6 +724,19 @@ class TestScopeCommandBuilders:
         assert frame[4] == 0x27
         assert frame[5] == 0x11
         assert frame[6] == 0x00
+
+    def test_get_scope_data_output_enabled_is_read_only(self) -> None:
+        assert get_scope_data_output_enabled() == b"\xfe\xfe\x98\xe0\x27\x11\xfd"
+
+    def test_parse_scope_data_output_enabled_response(self) -> None:
+        off = parse_civ_frame(
+            build_civ_frame(CONTROLLER_ADDR, IC_7610_ADDR, 0x27, sub=0x11, data=b"\x00")
+        )
+        on = parse_civ_frame(
+            build_civ_frame(CONTROLLER_ADDR, IC_7610_ADDR, 0x27, sub=0x11, data=b"\x01")
+        )
+        assert parse_scope_data_output_enabled_response(off) is False
+        assert parse_scope_data_output_enabled_response(on) is True
 
     def test_scope_main_sub_main(self) -> None:
         frame = scope_main_sub(0)

--- a/tests/test_selected_freq_mode.py
+++ b/tests/test_selected_freq_mode.py
@@ -356,8 +356,7 @@ class TestVfoSlotOverrideCivRx:
 
 
 class TestPollerUnselectedSlotGate:
-    """Poller gates the unselected-slot read behind PTT, queue pressure,
-    recent user writes, and a per-receiver rate limit."""
+    """Passive polling never exchanges foreground A/B or MAIN/SUB state."""
 
     def _make_poller(self, model: str, active: str = "MAIN"):
         from types import SimpleNamespace
@@ -395,11 +394,23 @@ class TestPollerUnselectedSlotGate:
         assert radio.send_civ.await_count == 0
 
     @pytest.mark.asyncio
-    async def test_ic7300_single_receiver_polls_vfo_b(self) -> None:
-        poller, radio, state = self._make_poller("IC-7300")
-        await poller._poll_unselected_slot(0)
-        # swap + 0x03 + 0x04 + swap-back = 4 sends
-        assert radio.send_civ.await_count == 4
+    @pytest.mark.parametrize("model", ["IC-7300", "IC-705", "IC-7610"])
+    async def test_passive_unselected_slot_poll_emits_zero_vfo_frames(
+        self, model: str
+    ) -> None:
+        poller, radio, state = self._make_poller(model)
+        state.main.active_slot = "A"
+        state.main.freq = 14_213_000
+        state.main.active_slot = "B"
+        state.main.freq = 14_075_000
+        state.main.active_slot = "A"
+        before = state.to_dict()
+
+        for _ in range(3):
+            await poller._poll_unselected_slot(0)
+
+        radio.send_civ.assert_not_awaited()
+        assert state.to_dict() == before
 
     @pytest.mark.asyncio
     async def test_gate_skips_when_ptt_active(self) -> None:

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -16,6 +16,7 @@ import asyncio
 import base64
 import hashlib
 import json
+import logging
 import struct
 from types import SimpleNamespace
 from typing import Any
@@ -293,10 +294,16 @@ def _add_scope_capable_attrs(radio: MagicMock) -> MagicMock:
 
     NOTE: Keep this in sync with `ScopeCapable` Protocol in `radio_protocol.py`.
     """
+    raw_capabilities = radio.__dict__.get("capabilities")
+    radio.capabilities = (
+        {*raw_capabilities, "scope"} if isinstance(raw_capabilities, set) else {"scope"}
+    )
     radio.on_scope_data = MagicMock()
     radio.scope_stream = MagicMock()
     radio.enable_scope = AsyncMock()
     radio.disable_scope = AsyncMock()
+    radio.get_scope_session_state = AsyncMock(return_value=(False, False))
+    radio.restore_scope_session_state = AsyncMock()
     radio.capture_scope_frame = AsyncMock()
     radio.capture_scope_frames = AsyncMock()
     radio.get_scope_during_tx = AsyncMock(return_value=False)
@@ -329,6 +336,48 @@ def _add_scope_capable_attrs(radio: MagicMock) -> MagicMock:
     radio.set_scope_hold = AsyncMock()
 
     return radio
+
+
+async def _drive_scope_pipeline(server: WebServer, awaitable: Any) -> list[Any]:
+    """Drive the real ordered queue/poller path for direct WebServer unit tests.
+
+    Production starts ``RadioPoller`` with the server.  The narrow lifecycle
+    tests below construct ``WebServer`` directly, so this harness services the
+    same queue entries and futures without inventing a runtime fallback path.
+    The poller is retained on the server so its captured scope-session state
+    survives from enable through restore.
+    """
+    from rigplane.web.radio_poller import RadioPoller
+
+    poller = server._radio_poller  # noqa: SLF001
+    if poller is None:
+        poller = RadioPoller(
+            server._radio,  # type: ignore[arg-type]  # noqa: SLF001
+            server._command_queue,  # noqa: SLF001
+            radio_state=server._radio_state,  # noqa: SLF001
+        )
+        server._radio_poller = poller  # noqa: SLF001
+
+    task = asyncio.ensure_future(awaitable)
+    executed: list[Any] = []
+    deadline = asyncio.get_running_loop().time() + 2.0
+    while asyncio.get_running_loop().time() < deadline:
+        await asyncio.sleep(0.001)
+        for entry in server._command_queue.drain_entries():  # noqa: SLF001
+            executed.append(entry.command)
+            try:
+                await poller._execute(entry.command)  # noqa: SLF001
+            except Exception as exc:
+                if entry.future is not None and not entry.future.done():
+                    entry.future.set_exception(exc)
+            else:
+                if entry.future is not None and not entry.future.done():
+                    entry.future.set_result(None)
+        if task.done() and not server._command_queue.has_commands:  # noqa: SLF001
+            await task
+            return executed
+    task.cancel()
+    raise AssertionError("scope pipeline did not settle")
 
 
 # ---------------------------------------------------------------------------
@@ -2299,17 +2348,16 @@ class TestScopeLifecycle:
         server._scope_disable_grace = 0
 
         h = MagicMock()
-        await server.ensure_scope_enabled(h)
+        commands = await _drive_scope_pipeline(server, server.ensure_scope_enabled(h))
 
         server.unregister_scope_handler(h)
-        await asyncio.sleep(0.05)  # let async task complete
+        commands += await _drive_scope_pipeline(server, asyncio.sleep(0.05))
 
         # DisableScope goes through command queue, not direct radio call
         from rigplane.web.radio_poller import DisableScope, EnableScope, RadioPoller
 
-        cmds = server._command_queue.drain()
-        enable = next(c for c in cmds if isinstance(c, EnableScope))
-        disable = next(c for c in cmds if isinstance(c, DisableScope))
+        enable = next(c for c in commands if isinstance(c, EnableScope))
+        disable = next(c for c in commands if isinstance(c, DisableScope))
         assert disable.generation > enable.generation
 
         # A delayed old enable cannot roll back the queue watermark or revive
@@ -2318,7 +2366,7 @@ class TestScopeLifecycle:
         poller = RadioPoller(radio, server._command_queue, radio_state=RadioState())
         for command in server._command_queue.drain():
             await poller._execute(command)  # noqa: SLF001
-        radio.enable_scope.assert_not_awaited()
+        assert radio.enable_scope.await_count == 1
         assert not server._scope_enabled
 
     async def test_scope_flag_reset_on_disable(self) -> None:
@@ -2334,7 +2382,7 @@ class TestScopeLifecycle:
         h = MagicMock()
         server._scope_handlers.add(h)
         server.unregister_scope_handler(h)
-        await asyncio.sleep(0.05)
+        await _drive_scope_pipeline(server, asyncio.sleep(0.05))
 
         assert not server._scope_enabled
 
@@ -2353,6 +2401,34 @@ class TestScopeLifecycle:
         await asyncio.sleep(0.05)
 
         radio.disable_scope.assert_not_awaited()
+
+    async def test_shutdown_with_pending_scope_and_no_poller_is_fail_open(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A dead executor cannot block the later client-teardown phase."""
+        radio = _add_scope_capable_attrs(MagicMock())
+        server = WebServer(radio)
+        server._scope_enabled = True
+        client_teardown = asyncio.Event()
+
+        async def _client() -> None:
+            try:
+                await asyncio.Event().wait()
+            finally:
+                client_teardown.set()
+
+        client = asyncio.create_task(_client())
+        await asyncio.sleep(0)
+        server._client_tasks.add(client)
+
+        with caplog.at_level(logging.WARNING, logger="rigplane.web.web_startup"):
+            await asyncio.wait_for(server.stop(), timeout=0.5)
+
+        assert client_teardown.is_set()
+        assert server._radio_poller is None
+        assert server._scope_enabled  # retained as pending restoration evidence
+        assert not server._command_queue.has_commands
+        assert "radio poller is unavailable" in caplog.text
 
 
 # ---------------------------------------------------------------------------
@@ -2500,14 +2576,17 @@ class TestScopeEnableAtomic:
         handlers = [MagicMock() for _ in range(5)]
 
         # Call ensure_scope_enabled for all 5 handlers concurrently
-        await asyncio.gather(*[server.ensure_scope_enabled(h) for h in handlers])
+        commands = await _drive_scope_pipeline(
+            server,
+            asyncio.gather(*[server.ensure_scope_enabled(h) for h in handlers]),
+        )
 
         # EnableScope goes through command queue
         from rigplane.web.radio_poller import EnableScope
 
-        cmds = server._command_queue.drain()
-        enable_cmds = [c for c in cmds if isinstance(c, EnableScope)]
-        assert len(enable_cmds) >= 1, "At least one EnableScope should be queued"
+        enable_cmds = [c for c in commands if isinstance(c, EnableScope)]
+        assert len(enable_cmds) == 1
+        radio.enable_scope.assert_awaited_once()
         assert len(server._scope_handlers) == 5
 
     async def test_all_handlers_registered_after_concurrent_enables(self) -> None:
@@ -2519,7 +2598,10 @@ class TestScopeEnableAtomic:
         server = WebServer(radio)
         handlers = [MagicMock() for _ in range(5)]
 
-        await asyncio.gather(*[server.ensure_scope_enabled(h) for h in handlers])
+        await _drive_scope_pipeline(
+            server,
+            asyncio.gather(*[server.ensure_scope_enabled(h) for h in handlers]),
+        )
 
         for h in handlers:
             assert h in server._scope_handlers
@@ -2556,16 +2638,21 @@ class TestScopeEnableAtomic:
         server = WebServer(radio)
 
         h1, h2, h3 = MagicMock(), MagicMock(), MagicMock()
-        await server.ensure_scope_enabled(h1)
-        await server.ensure_scope_enabled(h2)
-        await server.ensure_scope_enabled(h3)
+        commands = await _drive_scope_pipeline(
+            server,
+            asyncio.gather(
+                server.ensure_scope_enabled(h1),
+                server.ensure_scope_enabled(h2),
+                server.ensure_scope_enabled(h3),
+            ),
+        )
 
         # EnableScope goes through command queue
         from rigplane.web.radio_poller import EnableScope
 
-        cmds = server._command_queue.drain()
-        enable_cmds = [c for c in cmds if isinstance(c, EnableScope)]
-        assert len(enable_cmds) >= 1, "At least one EnableScope should be queued"
+        enable_cmds = [c for c in commands if isinstance(c, EnableScope)]
+        assert len(enable_cmds) == 1
+        radio.enable_scope.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------
@@ -2586,16 +2673,15 @@ class TestScopeReconnect:
         server = WebServer(radio)
         server._scope_disable_grace = 0
         h = MagicMock()
-        await server.ensure_scope_enabled(h)
+        commands = await _drive_scope_pipeline(server, server.ensure_scope_enabled(h))
         assert server._scope_enabled
 
         server.unregister_scope_handler(h)
-        await asyncio.sleep(0.05)
+        commands += await _drive_scope_pipeline(server, asyncio.sleep(0.05))
 
         from rigplane.web.radio_poller import DisableScope
 
-        cmds = server._command_queue.drain()
-        assert any(isinstance(c, DisableScope) for c in cmds)
+        assert any(isinstance(c, DisableScope) for c in commands)
         assert not server._scope_enabled
 
     async def test_enable_scope_queued_again_after_full_disconnect(self) -> None:
@@ -2612,21 +2698,17 @@ class TestScopeReconnect:
 
         # First connect
         h1 = MagicMock()
-        await server.ensure_scope_enabled(h1)
+        await _drive_scope_pipeline(server, server.ensure_scope_enabled(h1))
 
         # Disconnect
         server.unregister_scope_handler(h1)
-        await asyncio.sleep(0.05)
+        await _drive_scope_pipeline(server, asyncio.sleep(0.05))
         assert not server._scope_enabled
-
-        # Drain queue
-        server._command_queue.drain()
 
         # Reconnect — must queue EnableScope again
         h2 = MagicMock()
-        await server.ensure_scope_enabled(h2)
-        cmds = server._command_queue.drain()
-        assert any(isinstance(c, EnableScope) for c in cmds)
+        commands = await _drive_scope_pipeline(server, server.ensure_scope_enabled(h2))
+        assert any(isinstance(c, EnableScope) for c in commands)
 
     async def test_disable_task_aborts_if_new_handler_reconnects(self) -> None:
         """If a new handler connects before the disable task runs,
@@ -2639,10 +2721,10 @@ class TestScopeReconnect:
         server = WebServer(radio)
 
         h1 = MagicMock()
-        await server.ensure_scope_enabled(h1)
+        commands = await _drive_scope_pipeline(server, server.ensure_scope_enabled(h1))
         from rigplane.web.radio_poller import EnableScope
 
-        (initial_enable,) = server._command_queue.drain()
+        (initial_enable,) = commands
         assert isinstance(initial_enable, EnableScope)
 
         # Unregister h1 — schedules disable task but doesn't await it yet
@@ -2650,7 +2732,7 @@ class TestScopeReconnect:
 
         # Register h2 before the event loop runs the disable task
         h2 = MagicMock()
-        await server.ensure_scope_enabled(h2)
+        await _drive_scope_pipeline(server, server.ensure_scope_enabled(h2))
 
         # Now let the event loop run the disable task
         await asyncio.sleep(0.05)
@@ -2673,13 +2755,13 @@ class TestScopeReconnect:
         server = WebServer(radio)
 
         h1 = MagicMock()
-        await server.ensure_scope_enabled(h1)
+        await _drive_scope_pipeline(server, server.ensure_scope_enabled(h1))
         server.unregister_scope_handler(h1)
         await asyncio.sleep(0.05)
 
         h2 = MagicMock()
         h2._running = True
-        await server.ensure_scope_enabled(h2)
+        await _drive_scope_pipeline(server, server.ensure_scope_enabled(h2))
 
         frame = ScopeFrame(0, 0, 14_000_000, 14_350_000, bytes(10), False)
         server._broadcast_scope(frame)
@@ -2729,25 +2811,24 @@ class TestScopeDemandGeneration:
     async def test_scope_health_recovery_uses_current_generation(self) -> None:
         server, _ = self._make_server()
         handler = MagicMock()
-        await server.ensure_scope_enabled(handler)
+        commands = await _drive_scope_pipeline(
+            server, server.ensure_scope_enabled(handler)
+        )
 
         from rigplane.web.radio_poller import EnableScope
 
-        (initial_enable,) = server._command_queue.drain()
+        (initial_enable,) = commands
         assert isinstance(initial_enable, EnableScope)
         server._scope_health_interval = 0
         server._scope_health_max_retries = 1
         server._scope_last_nonzero = -1
 
         monitor = asyncio.create_task(server._scope_health_monitor())
-        for _ in range(10):
-            await asyncio.sleep(0)
-            if server._command_queue.has_commands:
-                break
+        recovery_commands = await _drive_scope_pipeline(server, asyncio.sleep(0.01))
         monitor.cancel()
         await monitor
 
-        (recovery,) = server._command_queue.drain()
+        (recovery,) = [c for c in recovery_commands if isinstance(c, EnableScope)]
         assert isinstance(recovery, EnableScope)
         assert recovery.generation == initial_enable.generation > 0
 
@@ -2755,15 +2836,19 @@ class TestScopeDemandGeneration:
         server, radio = self._make_server()
         radio._fetch_initial_state = AsyncMock()
         handler = MagicMock()
-        await server.ensure_scope_enabled(handler)
+        commands = await _drive_scope_pipeline(
+            server, server.ensure_scope_enabled(handler)
+        )
 
         from rigplane.web.radio_poller import EnableScope
 
-        (initial_enable,) = server._command_queue.drain()
+        (initial_enable,) = commands
         server._on_radio_reconnect()
-        await asyncio.gather(*list(server._bg_tasks))
+        reconnect_commands = await _drive_scope_pipeline(
+            server, asyncio.gather(*list(server._bg_tasks))
+        )
 
-        (reconnect_enable,) = server._command_queue.drain()
+        (reconnect_enable,) = reconnect_commands
         assert isinstance(reconnect_enable, EnableScope)
         assert reconnect_enable.generation == initial_enable.generation
 
@@ -2782,23 +2867,25 @@ class TestScopeDemandGeneration:
         radio._fetch_initial_state = delayed_fetch
         server._scope_disable_grace = 0.01
         first = MagicMock()
-        await server.ensure_scope_enabled(first)
-        (initial_enable,) = server._command_queue.drain()
+        commands = await _drive_scope_pipeline(
+            server, server.ensure_scope_enabled(first)
+        )
+        (initial_enable,) = commands
 
         server._on_radio_reconnect()
         await fetch_started.wait()
         server.unregister_scope_handler(first)
         if viewer_returns:
-            await server.ensure_scope_enabled(MagicMock())
+            await _drive_scope_pipeline(
+                server, server.ensure_scope_enabled(MagicMock())
+            )
         release_fetch.set()
-        await asyncio.sleep(0.02)
+        scope_commands = await _drive_scope_pipeline(server, asyncio.sleep(0.02))
 
         from rigplane.web.radio_poller import EnableScope
 
         enables = [
-            command
-            for command in server._command_queue.drain()
-            if isinstance(command, EnableScope)
+            command for command in scope_commands if isinstance(command, EnableScope)
         ]
         if viewer_returns:
             assert len(enables) == 1
@@ -2812,18 +2899,19 @@ class TestScopeDemandGeneration:
         server, _ = self._make_server()
         server._scope_disable_grace = 0.01
         first, second = MagicMock(), MagicMock()
-        await server.ensure_scope_enabled(first)
-        server._command_queue.drain()
+        await _drive_scope_pipeline(server, server.ensure_scope_enabled(first))
 
         from rigplane.web.radio_poller import DisableScope
 
         with patch.object(
-            server._command_queue, "put", wraps=server._command_queue.put
+            server._command_queue,
+            "put_ordered",
+            wraps=server._command_queue.put_ordered,
         ) as put_spy:
             server.unregister_scope_handler(first)
-            await server.ensure_scope_enabled(second)
+            await _drive_scope_pipeline(server, server.ensure_scope_enabled(second))
             server.unregister_scope_handler(second)
-            await asyncio.sleep(0.02)
+            await _drive_scope_pipeline(server, asyncio.sleep(0.02))
 
         disables = [
             call.args[0]

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -2434,9 +2434,10 @@ async def test_ensure_scope_enabled_skips_when_scope_capability_absent() -> None
 
 @pytest.mark.asyncio
 async def test_scope_health_monitor_disconnected_and_reenable() -> None:
-    radio = _scope_radio(connected=False)
+    radio = _scope_radio(ready=False, connected=False)
     srv = WebServer(radio)
     srv._scope_handlers.add(MagicMock())
+    srv._scope_enabled = True
     srv._scope_health_interval = 0.01
     srv._scope_last_nonzero = 0.0
 
@@ -2447,6 +2448,7 @@ async def test_scope_health_monitor_disconnected_and_reenable() -> None:
     assert srv._scope_last_nonzero > 0
 
     radio.connected = True
+    radio.radio_ready = True
     srv._scope_last_nonzero = time.monotonic() - 1.0
     task = asyncio.create_task(srv._scope_health_monitor())  # noqa: SLF001
     await asyncio.sleep(0.03)
@@ -2454,6 +2456,23 @@ async def test_scope_health_monitor_disconnected_and_reenable() -> None:
     await asyncio.gather(task, return_exceptions=True)
     cmds = srv.command_queue.drain()
     assert any(isinstance(c, EnableScope) for c in cmds)
+
+
+@pytest.mark.asyncio
+async def test_scope_health_monitor_unconfirmed_session_does_not_reenable() -> None:
+    radio = _scope_radio(ready=True, connected=True)
+    srv = WebServer(radio)
+    srv._scope_handlers.add(MagicMock())
+    srv._scope_enabled = False
+    srv._scope_health_interval = 0.01
+    srv._scope_last_nonzero = time.monotonic() - 1.0
+
+    task = asyncio.create_task(srv._scope_health_monitor())  # noqa: SLF001
+    await asyncio.sleep(0.03)
+    task.cancel()
+    await asyncio.gather(task, return_exceptions=True)
+
+    assert not srv.command_queue.has_commands
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Closes #2303. Linear: MOR-1399.

- remove the mutating inactive-VFO poll path, so passive observation emits zero A/B or MAIN/SUB selection frames
- keep A/B slot selection separate from MAIN/SUB receiver selection in command intent, RadioPoller, and frontend optimistic state
- capture panel-scope and waveform-output state once and restore the exact inherited pair after the last viewer or shutdown
- preflight unsupported low-baud scope sessions before any CI-V frame; roll back exact state if enable fails after a partial wire mutation
- preserve final PTT OFF priority when scope restoration is unavailable, externally quiesced, failed, or timed out

DTR/RTS and the established LAN/USB transport implementation are unchanged.

## Root cause

The five-second inactive-slot poll implemented a read as swap/query/swap, physically selecting A/B on single-receiver radios. Bare B was also interpreted as SUB by parts of the web command path. Separately, WebServer treated a queued scope enable as success and later queued unconditional disable commands. The first shutdown restoration then awaited that queued command before client cancellation, so a missing/stopped/quiesced poller could hang shutdown before the established final PTT OFF drain.

## Scope ownership and shutdown safety

Live web delivery/ack remains exclusively on `CommandQueue.put_ordered(..., future=...)` and the sole RadioPoller executor; no parallel queue, consumer, task, ACK manager, transport, or radio lane was added.

The first scope enable captures read-only panel/output state. Low-baud rejection now happens before capture and emits zero total frames. If enable writes ON/ON and VERIFY later times out, the captured state is restored immediately; if rollback fails, the snapshot stays pending for a later deterministic retry.

Shutdown first stops the poller, cancels/gathers clients, and runs the MOR-1181 PTT-only safety drain. Only after de-key does it attempt a one-second bounded scope restore. This is a shutdown safety drain, not a second live delivery path: with the sole poller consumer stopped, it synchronously re-enters that same poller's `_execute(DisableScope)` and the existing backend `IcomCommander` lane. Unavailable poller, external CAT ownership, restore error, or timeout emits no further scope write, retains pending evidence, and cannot block shutdown.

Independent verification found both the partial-enable rollback gap and the unbounded pre-PTT shutdown wait; both are fixed in this head.

## Verification

- Python 3.11 CI-equivalent non-hardware suite: 8,787 passed, 73 skipped, 11 xfailed, 1 xpassed (8,872 collected), exit 0
- wider affected suite: 638 passed, 2 skipped
- exact shutdown/PTT discriminators: 6 passed, including real WebServer/no-poller fail-open, late PTT teardown, same-executor `[PttOff, DisableScope]` order, external CAT, error, and timeout
- exact serial fake-wire coverage: zero total frames on low-baud rejection; OFF/OFF rollback after ON/ON plus VERIFY timeout
- frontend: 292 Vitest files / 6,020 tests passed; Svelte/TypeScript 0 errors and 0 warnings; i18n, ESLint, and production build passed
- Ruff: passed (645 files); import-linter: 5 contracts kept; IC-7610/X6200/FTX-1 golden gates passed; `git diff --check` passed

Full mypy still reports 15 pre-existing errors in four untouched modules: `_control_phase.py`, `_audio_runtime_mixin.py`, `_civ_rx.py`, and `runtime_helpers.py`.

## Scope and remaining gates

- frozen builder measurement against `HEAD~1`: production +153 net non-comment/non-blank LOC; tests +424 net; raw churn +931/-278 across 18 files; independent remeasurement is binding
- no real radio, USB serial port, LAN radio session, PTT, or RF operation was opened
- physical IC-7300 acceptance remains required under MOR-1098 before release clearance
- do not merge without green required checks and a fresh independent exact-head Agent Review PASS
