### PR TITLE
Fix non-mutating single-RX VFO bootstrap

### DIFF
--- a/frontend/src/components-v2/panels/MemoryPanel.svelte
+++ b/frontend/src/components-v2/panels/MemoryPanel.svelte
@@ -56,12 +56,14 @@
   }
 
   function recallChannel(ch: number) {
+    if (!p.vfoIdentityKnown) return;
     runtime.send('set_memory_mode', { channel: ch });
     runtime.send('memory_to_vfo', { channel: ch });
     selectedChannel = ch;
   }
 
   function storeVfoToChannel(ch: number) {
+    if (!p.vfoIdentityKnown) return;
     const freq = p.activeFreqHz;
     const mode = p.activeMode;
 
@@ -128,6 +130,9 @@
     <button
       type="button"
       class="store-btn"
+      disabled={!p.vfoIdentityKnown}
+      data-disabled-reason={!p.vfoIdentityKnown ? 'vfo-identity-unknown' : undefined}
+      title={!p.vfoIdentityKnown ? 'VFO identity is unknown' : undefined}
       onclick={() => { storeTarget = storeTarget === null ? findNextEmpty() : null; }}
     >
       VFO {'->'} M
@@ -146,7 +151,10 @@
           bind:value={storeTarget}
         />
       </label>
-      <button type="button" class="action-btn store-confirm" onclick={() => storeVfoToChannel(storeTarget!)}>
+      <button type="button" class="action-btn store-confirm"
+        disabled={!p.vfoIdentityKnown}
+        data-disabled-reason={!p.vfoIdentityKnown ? 'vfo-identity-unknown' : undefined}
+        onclick={() => storeVfoToChannel(storeTarget!)}>
         Store
       </button>
       <button type="button" class="action-btn cancel-btn" onclick={() => (storeTarget = null)}>
@@ -203,6 +211,8 @@
               type="button"
               class="action-btn recall-btn"
               title="Recall to VFO"
+              disabled={!p.vfoIdentityKnown}
+              data-disabled-reason={!p.vfoIdentityKnown ? 'vfo-identity-unknown' : undefined}
               onclick={() => recallChannel(ch)}
             >
               {'>>'}VFO
@@ -241,6 +251,8 @@
               type="button"
               class="action-btn store-btn-inline"
               title="Store VFO to this channel"
+              disabled={!p.vfoIdentityKnown}
+              data-disabled-reason={!p.vfoIdentityKnown ? 'vfo-identity-unknown' : undefined}
               onclick={() => storeVfoToChannel(ch)}
             >
               {'<<'}VFO

--- a/frontend/src/lib/runtime/adapters/__tests__/radio-view-model-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/radio-view-model-adapter.test.ts
@@ -19,6 +19,7 @@ import {
   validateRadioViewModel, type RadioViewModel,
 } from '../../../../semantic/radio-view-model';
 import { topologyFixtures } from '../../../../semantic/fixtures/topologies';
+import { toMemoryPanelProps } from '../../props/panel-props';
 import { toRadioViewModel } from '../radio-view-model-adapter';
 
 const DUAL = ['scope', 'audio', 'tx', 'dual_rx'];
@@ -120,6 +121,101 @@ describe('topology is derived from real capabilities', () => {
 });
 
 describe('unobserved facts survive as the explicit unknown branch', () => {
+  it('projects fresh relative values without fabricating A/B identity', () => {
+    const base = observedState();
+    const fieldStatus = {
+      ...base.fieldStatus,
+      'main.freqHz': fresh,
+      'main.mode': fresh,
+      'main.filter': fresh,
+      'main.unselectedVfo.freqHz': fresh,
+      'main.unselectedVfo.mode': fresh,
+      'main.unselectedVfo.filterNum': fresh,
+    } as Record<string, FieldStatus>;
+    delete fieldStatus['main.activeSlot'];
+    const view = model({
+      ...base,
+      main: {
+        ...base.main,
+        unselectedVfo: slot(7_100_000, 'LSB'),
+      },
+      fieldStatus,
+    } as ServerState, caps({
+      vfoScheme: 'ab', receivers: 1, capabilities: SINGLE,
+      vfoReadback: 'selected_unselected',
+    }));
+
+    expect(view.vfos.map((vfo) => [vfo.slot, vfo.frequencyHz, vfo.label])).toEqual([
+      [{ kind: 'relative', role: 'selected' }, 14_250_000, 'Selected VFO'],
+      [{ kind: 'relative', role: 'unselected' }, 7_100_000, 'Unselected VFO'],
+    ]);
+    expect(view.vfos.filter((vfo) => vfo.isActive)).toHaveLength(1);
+    expect(view.vfos.some((vfo) => vfo.slot.kind === 'slotted')).toBe(false);
+  });
+
+  it('keeps selected-only relative readback neutral while the unselected tuple is unavailable', () => {
+    const base = observedState();
+    const fieldStatus = { ...base.fieldStatus } as Record<string, FieldStatus>;
+    delete fieldStatus['main.activeSlot'];
+    const capabilities = caps({
+      vfoScheme: 'ab', receivers: 1, capabilities: SINGLE,
+      vfoReadback: 'selected_unselected',
+    });
+    const state = {
+      ...base,
+      main: { ...base.main, unselectedVfo: undefined },
+      fieldStatus,
+    } as ServerState;
+
+    const view = model(state, capabilities);
+    expect(view.vfos.map((vfo) => [vfo.slot, vfo.frequencyHz])).toEqual([
+      [{ kind: 'relative', role: 'selected' }, 14_250_000],
+      [{ kind: 'relative', role: 'unselected' }, null],
+    ]);
+    expect(view.vfos.some((vfo) => vfo.slot.kind === 'slotted')).toBe(false);
+    expect(toMemoryPanelProps(state, capabilities).vfoIdentityKnown).toBe(false);
+  });
+
+  it('keeps an older selected-only payload neutral without local persistence guesses', () => {
+    const base = observedState();
+    const fieldStatus = { ...base.fieldStatus } as Record<string, FieldStatus>;
+    delete fieldStatus['main.activeSlot'];
+    for (const slotKey of ['vfoA', 'vfoB']) {
+      for (const leaf of ['freqHz', 'mode', 'filterNum', 'dataMode']) {
+        delete fieldStatus[`main.${slotKey}.${leaf}`];
+      }
+    }
+    const capabilities = caps({
+      vfoScheme: 'ab', receivers: 1, capabilities: SINGLE,
+    });
+    const state = {
+      ...base,
+      main: {
+        ...base.main, vfoA: undefined, vfoB: undefined, unselectedVfo: undefined,
+      },
+      fieldStatus,
+    } as ServerState;
+
+    const view = model(state, capabilities);
+    expect(view.vfos.map((vfo) => [vfo.slot, vfo.frequencyHz])).toEqual([
+      [{ kind: 'relative', role: 'selected' }, 14_250_000],
+      [{ kind: 'relative', role: 'unselected' }, null],
+    ]);
+    expect(toMemoryPanelProps(state, capabilities).vfoIdentityKnown).toBe(false);
+  });
+
+  it('leaves an explicitly absolute single-RX A/B contract literal', () => {
+    const base = observedState();
+    const fieldStatus = { ...base.fieldStatus } as Record<string, FieldStatus>;
+    delete fieldStatus['main.activeSlot'];
+    const view = model({ ...base, fieldStatus } as ServerState, caps({
+      vfoScheme: 'ab', receivers: 1, capabilities: SINGLE, vfoReadback: 'absolute',
+    }));
+    expect(view.vfos.map((vfo) => vfo.slot)).toEqual([
+      { kind: 'slotted', id: 'A' }, { kind: 'slotted', id: 'B' },
+    ]);
+  });
+
   // MUTATION KILLED: `activeReceiver: { status: 'known', receiver: state.active ?? 'MAIN' }`
   // — the classic "default to MAIN" that MOR-988 §3.2 forbids.
   it('never fabricates an active receiver, and marks no VFO active', () => {

--- a/frontend/src/lib/runtime/adapters/panel-adapters.ts
+++ b/frontend/src/lib/runtime/adapters/panel-adapters.ts
@@ -133,7 +133,7 @@ export function deriveAudioSpectrumProps() {
 
 // ── Memory Panel ──
 export function deriveMemoryPanelProps() {
-  return toMemoryPanelProps(runtime.state);
+  return toMemoryPanelProps(runtime.state, runtime.caps);
 }
 
 // ── Amber Telemetry ──

--- a/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
@@ -39,7 +39,10 @@ import { isFieldAvailable } from '$lib/state/field-status';
 import { modInputStateKey } from '$lib/radio/mod-input';
 import { flattenBands, findActiveBand } from '$lib/radio/band-plan';
 import { getFrequencyPermit, type FrequencyPermit, type TxPermit } from '$lib/utils/tx-permit';
-import { resolveFilterModeConfig } from '$lib/runtime/props/panel-props';
+import {
+  relativeVfoIdentityUnknown,
+  resolveFilterModeConfig,
+} from '$lib/runtime/props/panel-props';
 import {
   deriveIfShift, pbtRangeFromCaps, pbtRawToHz,
   controlRangeFromCapsOrDefault, nrRawToDisplay, nbDepthRawToDisplay,
@@ -62,7 +65,11 @@ import {
 // keeps its inline union and only `.lifecycle` gets the real type.
 import type { ResourceHealth } from '$lib/runtime/resource-demand';
 
-type Slot = { kind: 'slotted'; id: VfoSlotId } | { kind: 'unslotted' } | { kind: 'unknown' };
+type Slot =
+  | { kind: 'slotted'; id: VfoSlotId }
+  | { kind: 'relative'; role: 'selected' | 'unselected' }
+  | { kind: 'unslotted' }
+  | { kind: 'unknown' };
 type Fact = { status: 'known'; value: boolean } | { status: 'unknown' };
 type Reason = {
   field: string;
@@ -120,7 +127,9 @@ function readings(
 }
 
 const sameSlot = (a: Slot, b: Slot): boolean =>
-  a.kind === 'slotted' && b.kind === 'slotted' ? a.id === b.id : a.kind === b.kind;
+  a.kind === 'slotted' && b.kind === 'slotted' ? a.id === b.id
+    : a.kind === 'relative' && b.kind === 'relative' ? a.role === b.role
+      : a.kind === b.kind;
 
 function hasCap(caps: Capabilities | null, name: string): boolean {
   return caps?.capabilities?.includes(name) ?? false;
@@ -1258,13 +1267,26 @@ export function toRadioViewModel(
     // MAIN A active on evidence the radio never provided.
     const activeSlot = seen(state, `${key}.activeSlot`)
       && (rx?.activeSlot === 'A' || rx?.activeSlot === 'B') ? rx.activeSlot : null;
+    const relativeIdentityUnknown = relativeVfoIdentityUnknown(state, caps, key);
     const positions: Position[] = slots === null
       ? [{ slot: { kind: 'unslotted' }, base: `${key}.`, filterKey: 'filter', src: rx }]
-      : slots.every((id) => rx?.[SLOT_KEY[id]] != null)
-        ? slots.map((id) => ({
-          slot: { kind: 'slotted', id }, base: `${key}.${SLOT_KEY[id]}.`,
-          filterKey: 'filterNum', src: rx?.[SLOT_KEY[id]] ?? null,
-        }))
+      : relativeIdentityUnknown
+          ? [
+            {
+              slot: { kind: 'relative', role: 'selected' }, base: `${key}.`,
+              filterKey: 'filter', src: rx,
+            },
+            {
+              slot: { kind: 'relative', role: 'unselected' },
+              base: `${key}.unselectedVfo.`, filterKey: 'filterNum',
+              src: rx?.unselectedVfo ?? null,
+            },
+          ]
+        : slots.every((id) => rx?.[SLOT_KEY[id]] != null)
+          ? slots.map((id) => ({
+            slot: { kind: 'slotted', id }, base: `${key}.${SLOT_KEY[id]}.`,
+            filterKey: 'filterNum', src: rx?.[SLOT_KEY[id]] ?? null,
+          }))
         // A slotted scheme whose slot view was never observed: ONE position of
         // unknown slot identity. Synthesising 'A' here is exactly the
         // fabrication MOR-988 §3.2 forbids.
@@ -1275,11 +1297,15 @@ export function toRadioViewModel(
       // only on the active one. `activeSlot` is already the gated read above,
       // so an unobserved reading is `null` and BOTH slots fail closed here; an
       // unslotted (or unknown-slot) position is its receiver's only one.
-      const isActiveSlot = slot.kind !== 'slotted' || slot.id === activeSlot;
+      const isActiveSlot = slot.kind === 'relative' ? slot.role === 'selected'
+        : slot.kind !== 'slotted' || slot.id === activeSlot;
       return {
         receiver,
         slot,
-        label: slot.kind === 'slotted' ? `${receiver} ${slot.id}` : receiver,
+        label: slot.kind === 'slotted' ? `${receiver} ${slot.id}`
+          : slot.kind === 'relative'
+            ? (slot.role === 'selected' ? 'Selected VFO' : 'Unselected VFO')
+            : receiver,
         ...readings(state, base, filterKey, src),
         // Unchanged in meaning, restated on the new fact: the radio-wide active
         // VFO IS the active receiver's active slot.

--- a/frontend/src/lib/runtime/props/panel-props.ts
+++ b/frontend/src/lib/runtime/props/panel-props.ts
@@ -52,6 +52,40 @@ function activeFieldShown(state: ServerState | null, field: string): boolean {
   );
 }
 
+function fieldObserved(state: ServerState | null, field: string): boolean {
+  const status = state?.fieldStatus?.[field];
+  return status?.observed === true
+    && status.freshness === 'fresh'
+    && status.availability === 'available';
+}
+
+/**
+ * Whether a single-RX A/B surface must remain in Selected/Unselected mode.
+ *
+ * Current servers declare the provider readback contract explicitly. For an
+ * older compatible capabilities payload, absence of any observed absolute A
+ * and B slot facts is the conservative signal that literal A/B identity is
+ * not available. State values alone are deliberately insufficient because
+ * legacy receiver defaults can contain fabricated-looking slot objects.
+ */
+export function relativeVfoIdentityUnknown(
+  state: ServerState | null,
+  caps: Capabilities | null,
+  receiverKey: 'main' | 'sub' = 'main',
+): boolean {
+  if (!state || !caps || caps.receivers !== 1 || caps.vfoScheme !== 'ab') return false;
+  if (fieldObserved(state, `${receiverKey}.activeSlot`)) return false;
+  if (caps.vfoReadback === 'selected_unselected') return true;
+  if (caps.vfoReadback !== undefined) return false;
+
+  const hasObservedAbsoluteSlots = (['vfoA', 'vfoB'] as const).every((slotKey) =>
+    (['freqHz', 'mode', 'filterNum', 'dataMode'] as const).some((leaf) =>
+      fieldObserved(state, `${receiverKey}.${slotKey}.${leaf}`),
+    ),
+  );
+  return !hasObservedAbsoluteSlots;
+}
+
 /* ── VFO ─────────────────────────────────────────────────────── */
 
 export interface VfoStateProps {
@@ -822,13 +856,20 @@ export interface MemoryPanelProps {
   activeFreqHz: number;
   /** Active receiver mode — used by "store VFO → channel". */
   activeMode: string;
+  /** False only during a relative Selected/Unselected bootstrap epoch. */
+  vfoIdentityKnown: boolean;
 }
 
-export function toMemoryPanelProps(state: ServerState | null): MemoryPanelProps {
+export function toMemoryPanelProps(
+  state: ServerState | null,
+  caps: Capabilities | null = null,
+): MemoryPanelProps {
   const rx = state ? activeRx(state) : null;
+  const receiverKey = state?.active === 'SUB' ? 'sub' : 'main';
   return {
     activeFreqHz: rx?.freqHz ?? 0,
     activeMode: rx?.mode ?? '',
+    vfoIdentityKnown: !relativeVfoIdentityUnknown(state, caps, receiverKey),
   };
 }
 

--- a/frontend/src/lib/state/__tests__/fixtures/empty-store-field-status.json
+++ b/frontend/src/lib/state/__tests__/fixtures/empty-store-field-status.json
@@ -419,6 +419,30 @@
     "observed": false,
     "storePath": "receiver.main.operator_toggles.twin_peak_filter"
   },
+  "main.unselectedVfo.dataMode": {
+    "availability": "missing",
+    "freshness": "unknown",
+    "observed": false,
+    "storePath": "receiver.main.unselected.freq_mode.data_mode"
+  },
+  "main.unselectedVfo.filterNum": {
+    "availability": "missing",
+    "freshness": "unknown",
+    "observed": false,
+    "storePath": "receiver.main.unselected.freq_mode.filter_num"
+  },
+  "main.unselectedVfo.freqHz": {
+    "availability": "missing",
+    "freshness": "unknown",
+    "observed": false,
+    "storePath": "receiver.main.unselected.freq_mode.freq_hz"
+  },
+  "main.unselectedVfo.mode": {
+    "availability": "missing",
+    "freshness": "unknown",
+    "observed": false,
+    "storePath": "receiver.main.unselected.freq_mode.mode"
+  },
   "main.vfoA.dataMode": {
     "availability": "missing",
     "freshness": "unknown",
@@ -994,6 +1018,30 @@
     "freshness": "unknown",
     "observed": false,
     "storePath": "receiver.sub.operator_toggles.twin_peak_filter"
+  },
+  "sub.unselectedVfo.dataMode": {
+    "availability": "missing",
+    "freshness": "unknown",
+    "observed": false,
+    "storePath": "receiver.sub.unselected.freq_mode.data_mode"
+  },
+  "sub.unselectedVfo.filterNum": {
+    "availability": "missing",
+    "freshness": "unknown",
+    "observed": false,
+    "storePath": "receiver.sub.unselected.freq_mode.filter_num"
+  },
+  "sub.unselectedVfo.freqHz": {
+    "availability": "missing",
+    "freshness": "unknown",
+    "observed": false,
+    "storePath": "receiver.sub.unselected.freq_mode.freq_hz"
+  },
+  "sub.unselectedVfo.mode": {
+    "availability": "missing",
+    "freshness": "unknown",
+    "observed": false,
+    "storePath": "receiver.sub.unselected.freq_mode.mode"
   },
   "sub.vfoA.dataMode": {
     "availability": "missing",

--- a/frontend/src/lib/transport/__tests__/http-client.test.ts
+++ b/frontend/src/lib/transport/__tests__/http-client.test.ts
@@ -241,6 +241,17 @@ describe('fetchCapabilities', () => {
     await expect(fetchCapabilities()).resolves.toMatchObject({ vfoScheme, receivers });
   });
 
+  it('accepts both a declared VFO readback contract and an older absent field', async () => {
+    const { fetchCapabilities } = await import('../http-client');
+    mockCapabilities(makeCapabilities({ vfoReadback: 'selected_unselected' }));
+    await expect(fetchCapabilities()).resolves.toMatchObject({
+      vfoReadback: 'selected_unselected',
+    });
+
+    mockCapabilities(makeCapabilities());
+    await expect(fetchCapabilities()).resolves.not.toHaveProperty('vfoReadback');
+  });
+
   it.each([
     ['null', null],
     ['an explicit empty list', []],
@@ -276,6 +287,7 @@ describe('fetchCapabilities', () => {
     ['$.vfoScheme', { vfoScheme: undefined }],
     ['$.vfoScheme', { vfoScheme: 'unknown' }],
     ['$.vfoScheme', { vfoScheme: 'single', receivers: 2 }],
+    ['$.vfoReadback', { vfoReadback: 'relative' }],
     ['$.freqRanges[0]', { freqRanges: [null] }],
     ['$.freqRanges[0].start', { freqRanges: [{}] }],
     ['$.freqRanges[0].start', { freqRanges: [{ start: true, end: 2, label: 'HF' }] }],

--- a/frontend/src/lib/types/capabilities.ts
+++ b/frontend/src/lib/types/capabilities.ts
@@ -77,6 +77,7 @@ export interface ControlRange {
 }
 
 export type VfoScheme = 'single' | 'ab' | 'ab_shared' | 'main_sub';
+export type VfoReadback = 'absolute' | 'selected_unselected' | 'none';
 
 export interface WebRtcCapabilities {
   available: boolean;
@@ -101,6 +102,8 @@ export interface Capabilities {
   capabilities: string[];
   receivers: number;
   vfoScheme: VfoScheme;
+  /** Provider identity semantics; absent on older compatible servers. */
+  vfoReadback?: VfoReadback;
   freqRanges: FreqRange[];
   modes: string[];
   filters: string[];
@@ -248,6 +251,12 @@ export function validateCapabilities(value: unknown): Capabilities {
   const expectedReceivers = raw.vfoScheme === 'single' || raw.vfoScheme === 'ab' ? 1 : 2;
   if (raw.receivers !== expectedReceivers) {
     invalid('$.vfoScheme', `${String(raw.vfoScheme)} with receivers=${expectedReceivers}`);
+  }
+  if (Object.prototype.hasOwnProperty.call(raw, 'vfoReadback')) {
+    const readbacks: readonly VfoReadback[] = ['absolute', 'selected_unselected', 'none'];
+    if (!readbacks.includes(raw.vfoReadback as VfoReadback)) {
+      invalid('$.vfoReadback', readbacks.join(' | '));
+    }
   }
 
   if (!Array.isArray(raw.freqRanges)) invalid('$.freqRanges', 'an array');

--- a/frontend/src/lib/types/state.ts
+++ b/frontend/src/lib/types/state.ts
@@ -145,6 +145,7 @@ export interface ReceiverStatePublic {
   vfoA?: VfoSlotPublic;
   vfoB?: VfoSlotPublic;
   activeSlot?: string;
+  unselectedVfo?: VfoSlotPublic | null;
   freqHz: number;
   mode: string;
   filter: number | null;

--- a/frontend/src/presentation/languages/projection.ts
+++ b/frontend/src/presentation/languages/projection.ts
@@ -59,6 +59,7 @@ function primitive(value: unknown, path: string): Primitive {
 
 function projectSlot(slot: VfoSlot): string {
   if (slot.kind === 'slotted') return primitive(slot.id, 'slot.id') as string;
+  if (slot.kind === 'relative') return primitive(slot.role, 'slot.role') as string;
   return slot.kind; // 'unslotted' | 'unknown' — both already explicit, distinct strings
 }
 

--- a/frontend/src/semantic/VfoSurface.svelte
+++ b/frontend/src/semantic/VfoSurface.svelte
@@ -144,14 +144,25 @@
    */
   let vfoPool = $derived(selectionPoolSize ?? viewModel.vfos.length);
   let hasVfoPair = $derived(vfoPool > 1);
+  let relativeIdentityUnknown = $derived(viewModel.vfos.some((vfo) => vfo.slot.kind === 'relative'));
+  let relativeReceiver = $derived(
+    viewModel.vfos.find((vfo) => vfo.slot.kind === 'relative')?.receiver ?? null,
+  );
+  let relativeSelectionPending = $state(false);
+  const relativeSelectionHelp = 'Current A/B identity is unknown. Selecting this VFO will change the radio selection and establish identity.';
 
   function slotKey(slot: VfoSlot): string {
-    return slot.kind === 'slotted' ? slot.id : slot.kind;
+    if (slot.kind === 'slotted') return slot.id;
+    if (slot.kind === 'relative') return slot.role;
+    return slot.kind;
   }
 
   function roleLabel(vfo: VfoViewModel): string {
     const { slot } = vfo;
     if (slot.kind === 'slotted') return `${vfo.receiver} ${slot.id}`;
+    if (slot.kind === 'relative') {
+      return slot.role === 'selected' ? 'Selected VFO' : 'Unselected VFO';
+    }
     if (slot.kind === 'unknown') return `${vfo.receiver} (${t('core.vfo.state.unknown')})`;
     return vfo.receiver;
   }
@@ -238,12 +249,19 @@
   }
 
   function isSelectable(vfo: VfoViewModel): boolean {
-    return hasVfoPair && !vfo.isActive;
+    return hasVfoPair && vfo.slot.kind !== 'relative' && !vfo.isActive;
   }
 
   function selectVfo(vfo: VfoViewModel): void {
     if (!isSelectable(vfo) || vfo.slot.kind === 'unknown' || disabled) return;
     onSelectVfo?.({ receiver: vfo.receiver, slot: vfo.slot });
+  }
+
+  function selectAbsoluteSlot(id: 'A' | 'B'): void {
+    if (disabled || relativeSelectionPending || relativeReceiver === null) return;
+    relativeSelectionPending = true;
+    onSelectVfo?.({ receiver: relativeReceiver, slot: { kind: 'slotted', id } });
+    window.setTimeout(() => { relativeSelectionPending = false; }, 2500);
   }
 
   function triState(fact: BooleanFact): 'true' | 'false' | 'mixed' {
@@ -279,12 +297,12 @@
    * unrelated unknown would invent a dependency the radio does not have.
    */
   function quickSplit(): void {
-    if (viewModel.split.status !== 'known') return;
+    if (relativeIdentityUnknown || viewModel.split.status !== 'known') return;
     onQuickSplit?.();
   }
 
   function quickDualWatch(): void {
-    if (viewModel.dualWatch.status !== 'known') return;
+    if (relativeIdentityUnknown || viewModel.dualWatch.status !== 'known') return;
     onQuickDualWatch?.();
   }
 
@@ -380,6 +398,22 @@
       </div>
     {/each}
   </div>
+  {#if relativeIdentityUnknown && relativeReceiver !== null}
+    <div class="vfo-identity-selectors" data-testid="vfo-identity-selectors">
+      <button
+        type="button" class="vfo-select" data-vfo-select-absolute="A"
+        title={relativeSelectionHelp} aria-label="Select VFO A"
+        disabled={disabled || relativeSelectionPending}
+        onclick={() => selectAbsoluteSlot('A')}
+      >Select VFO A</button>
+      <button
+        type="button" class="vfo-select" data-vfo-select-absolute="B"
+        title={relativeSelectionHelp} aria-label="Select VFO B"
+        disabled={disabled || relativeSelectionPending}
+        onclick={() => selectAbsoluteSlot('B')}
+      >Select VFO B</button>
+    </div>
+  {/if}
   {/if}
 
   {#if showRadioWideFacts}
@@ -417,23 +451,29 @@
       Button text is the accessible name; no `aria-label` duplicates it.
     -->
     {#if hasVfoPair}
-      <div class="vfo-ops" data-testid="vfo-ops">
-        <button type="button" class="vfo-op" data-vfo-equalize onclick={() => onEqualizeVfos?.()}>
+      <div
+        class="vfo-ops" data-testid="vfo-ops"
+        data-disabled-reason={relativeIdentityUnknown ? 'vfo-identity-unknown' : undefined}
+        title={relativeIdentityUnknown ? relativeSelectionHelp : undefined}
+      >
+        <button type="button" class="vfo-op" data-vfo-equalize
+          disabled={relativeIdentityUnknown} onclick={() => { if (!relativeIdentityUnknown) onEqualizeVfos?.(); }}>
           {t('core.vfo.ops.equalize')}
         </button>
-        <button type="button" class="vfo-op" data-vfo-swap onclick={() => onSwapVfos?.()}>
+        <button type="button" class="vfo-op" data-vfo-swap
+          disabled={relativeIdentityUnknown} onclick={() => { if (!relativeIdentityUnknown) onSwapVfos?.(); }}>
           {t('core.vfo.ops.swap')}
         </button>
         <button
           type="button" class="vfo-op" data-vfo-quick-split
-          disabled={viewModel.split.status === 'unknown'}
+          disabled={relativeIdentityUnknown || viewModel.split.status === 'unknown'}
           onclick={quickSplit}
         >
           {t('core.vfo.ops.quickSplit')}
         </button>
         <button
           type="button" class="vfo-op" data-vfo-quick-dual-watch
-          disabled={viewModel.dualWatch.status === 'unknown'}
+          disabled={relativeIdentityUnknown || viewModel.dualWatch.status === 'unknown'}
           onclick={quickDualWatch}
         >
           {t('core.vfo.ops.quickDualWatch')}
@@ -463,7 +503,7 @@
   .vfo-badge { padding: 1px 4px; border-radius: 3px; font-size: 10px; color: var(--v2-accent-red, #ff2020); border: 1px solid var(--v2-accent-red, #ff2020); }
   .vfo-select, .fact-toggle, .vfo-op { border: 1px solid var(--v2-border-panel, rgba(255, 255, 255, 0.12)); border-radius: 4px; background: transparent; color: inherit; cursor: pointer; padding: 3px 6px; }
   .vfo-select:disabled, .fact-toggle:disabled, .vfo-op:disabled { color: var(--v2-text-disabled, rgba(255, 255, 255, 0.3)); cursor: not-allowed; }
-  .fact-toggles, .vfo-ops { display: flex; gap: 6px; flex-wrap: wrap; }
+  .fact-toggles, .vfo-ops, .vfo-identity-selectors { display: flex; gap: 6px; flex-wrap: wrap; }
   .split-digest { display: flex; gap: 8px; margin: 0; font-size: 11px; color: var(--v2-text-subdued, rgba(255, 255, 255, 0.55)); }
   .split-digest[data-split-active='false'] { opacity: 0.64; }
 </style>

--- a/frontend/src/semantic/__tests__/VfoSurface.test.ts
+++ b/frontend/src/semantic/__tests__/VfoSurface.test.ts
@@ -226,6 +226,95 @@ describe('uncertainty is rendered explicitly, never defaulted', () => {
 // ── Selection intents: payload correctness + disabled/absent gating ────────
 
 describe('VFO selection intent', () => {
+  it('relative bootstrap shows honest values and explicit A/B selectors with duplicate protection', () => {
+    vi.useFakeTimers();
+    const onSelectVfo = vi.fn();
+    const base = topologyFixtures['1/ab'];
+    const model: RadioViewModel = validateRadioViewModel({
+      ...base,
+      vfos: [
+        {
+          ...base.vfos[0], slot: { kind: 'relative', role: 'selected' },
+          label: 'Selected VFO', isActive: true, isActiveSlot: true,
+        },
+        {
+          ...base.vfos[1], slot: { kind: 'relative', role: 'unselected' },
+          label: 'Unselected VFO', isActive: false, isActiveSlot: false,
+        },
+      ],
+    });
+    const target = mountSurface({ viewModel: model, onSelectVfo });
+    const selected = target.querySelector<HTMLElement>('[data-vfo-slot="selected"]')!;
+    const unselected = target.querySelector<HTMLElement>('[data-vfo-slot="unselected"]')!;
+    expect(selected.textContent).toContain('Selected VFO');
+    expect(unselected.textContent).toContain('Unselected VFO');
+    expect(target.querySelector('[data-vfo-active="true"]')).toBe(selected);
+
+    const a = target.querySelector<HTMLButtonElement>('[data-vfo-select-absolute="A"]')!;
+    const b = target.querySelector<HTMLButtonElement>('[data-vfo-select-absolute="B"]')!;
+    expect(a.textContent).toBe('Select VFO A');
+    expect(b.textContent).toBe('Select VFO B');
+    expect(a.title).toBe('Current A/B identity is unknown. Selecting this VFO will change the radio selection and establish identity.');
+    b.click();
+    flushSync();
+    a.click();
+    expect(onSelectVfo).toHaveBeenCalledOnce();
+    expect(onSelectVfo).toHaveBeenCalledWith({
+      receiver: 'MAIN', slot: { kind: 'slotted', id: 'B' },
+    });
+    expect(a.disabled).toBe(true);
+    expect(b.disabled).toBe(true);
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it('relative bootstrap disables identity-dependent VFO operations', () => {
+    const base = topologyFixtures['1/ab'];
+    const model: RadioViewModel = validateRadioViewModel({
+      ...base,
+      vfos: base.vfos.map((vfo, index) => ({
+        ...vfo,
+        slot: {
+          kind: 'relative', role: index === 0 ? 'selected' : 'unselected',
+        },
+        label: index === 0 ? 'Selected VFO' : 'Unselected VFO',
+        isActive: index === 0,
+        isActiveSlot: index === 0,
+      })),
+    });
+    const target = mountSurface({ viewModel: model });
+    const ops = target.querySelector<HTMLElement>('[data-testid="vfo-ops"]')!;
+    expect(ops.dataset.disabledReason).toBe('vfo-identity-unknown');
+    expect(Array.from(ops.querySelectorAll<HTMLButtonElement>('button')).every((button) => button.disabled)).toBe(true);
+  });
+
+  it('selected-only bootstrap keeps the selected value and marks unselected unavailable', () => {
+    const base = topologyFixtures['1/ab'];
+    const model: RadioViewModel = validateRadioViewModel({
+      ...base,
+      vfos: [
+        {
+          ...base.vfos[0], slot: { kind: 'relative', role: 'selected' },
+          label: 'Selected VFO', frequencyHz: 14_250_000,
+          isActive: true, isActiveSlot: true,
+        },
+        {
+          ...base.vfos[1], slot: { kind: 'relative', role: 'unselected' },
+          label: 'Unselected VFO', frequencyHz: null, mode: null, filter: null,
+          isActive: false, isActiveSlot: false,
+        },
+      ],
+    });
+    const target = mountSurface({ viewModel: model });
+    expect(target.querySelector('[data-vfo-slot="selected"] .vfo-freq')?.textContent)
+      .toContain('14.250000 MHz');
+    expect(target.querySelector('[data-vfo-slot="unselected"] .vfo-freq')?.textContent)
+      .toBe('—');
+    expect(target.querySelector('[data-testid="vfo-ops"]')?.getAttribute('data-disabled-reason'))
+      .toBe('vfo-identity-unknown');
+    expect(target.querySelectorAll('[data-vfo-select-absolute]')).toHaveLength(2);
+  });
+
   it('clicking a selectable inactive VFO emits onSelectVfo with the exact receiver+slot payload', () => {
     const onSelectVfo = vi.fn();
     const target = mountSurface({ viewModel: topologyFixtures['2/main_sub'], onSelectVfo });

--- a/frontend/src/semantic/radio-view-model.ts
+++ b/frontend/src/semantic/radio-view-model.ts
@@ -31,6 +31,7 @@ export type VfoSlotId = 'A' | 'B';
  */
 export type VfoSlot =
   | { kind: 'slotted'; id: VfoSlotId }
+  | { kind: 'relative'; role: 'selected' | 'unselected' }
   | { kind: 'unslotted' }
   | { kind: 'unknown' };
 
@@ -1086,6 +1087,13 @@ function validateVfoSlot(value: unknown, path: string): VfoSlot {
     exactKeys(v, ['kind', 'id'], path);
     return { kind: 'slotted', id: oneOf(v.id, SLOT_IDS, `${path}.id`) };
   }
+  if (v.kind === 'relative') {
+    exactKeys(v, ['kind', 'role'], path);
+    return {
+      kind: 'relative',
+      role: oneOf(v.role, ['selected', 'unselected'] as const, `${path}.role`),
+    };
+  }
   if (v.kind === 'unslotted') {
     exactKeys(v, ['kind'], path);
     return { kind: 'unslotted' };
@@ -1094,10 +1102,12 @@ function validateVfoSlot(value: unknown, path: string): VfoSlot {
     exactKeys(v, ['kind'], path);
     return { kind: 'unknown' };
   }
-  invalid(`${path}.kind`, `'slotted' | 'unslotted' | 'unknown'`);
+  invalid(`${path}.kind`, `'slotted' | 'relative' | 'unslotted' | 'unknown'`);
 }
 function slotEqual(a: VfoSlot, b: VfoSlot): boolean {
-  return a.kind === 'slotted' && b.kind === 'slotted' ? a.id === b.id : a.kind === b.kind;
+  if (a.kind === 'slotted' && b.kind === 'slotted') return a.id === b.id;
+  if (a.kind === 'relative' && b.kind === 'relative') return a.role === b.role;
+  return a.kind === b.kind;
 }
 
 function validateActiveRx(value: unknown, path: string): ActiveRx {

--- a/rigs/ic705.toml
+++ b/rigs/ic705.toml
@@ -268,6 +268,7 @@ defaults = [7000, 7000, 7000]
 
 [vfo]
 scheme = "ab"
+readback = "selected_unselected"
 main_select = [0x00]
 sub_select = [0x01]
 swap_ab = [0xB0]

--- a/rigs/ic7300.toml
+++ b/rigs/ic7300.toml
@@ -242,6 +242,7 @@ defaults = [15000, 10000, 7000]
 
 [vfo]
 scheme = "ab"
+readback = "selected_unselected"
 main_select = [0x00]  # VFO A
 sub_select = [0x01]   # VFO B
 swap_ab = [0xB0]

--- a/src/rigplane/core/radio_protocol.py
+++ b/src/rigplane/core/radio_protocol.py
@@ -84,6 +84,8 @@ __all__ = [
     "ReceiverBankCapable",
     "TransceiverBankCapable",
     "VfoSlotCapable",
+    "RelativeVfoReadbackCapable",
+    "RelativeVfoState",
     "StateCacheCapable",
     "StateModelCapable",
     "StateModelService",
@@ -1468,6 +1470,25 @@ class VfoSlotCapable(Protocol):
 
     async def equalize_vfo_ab(self, receiver: int = 0) -> None:
         """Copy the active VFO's state to the inactive VFO on ``receiver``."""
+        ...
+
+
+@dataclass(frozen=True, slots=True)
+class RelativeVfoState:
+    """Provider-neutral Selected/Unselected frequency-mode tuple."""
+
+    freq_hz: int
+    mode: str
+    filter_num: int | None = None
+    data_mode: int = 0
+
+
+@runtime_checkable
+class RelativeVfoReadbackCapable(Protocol):
+    """Radio can read Selected/Unselected VFOs without selecting or swapping."""
+
+    async def read_relative_vfo(self, *, selected: bool) -> RelativeVfoState:
+        """Return a fresh tuple for the radio's current relative role."""
         ...
 
 

--- a/src/rigplane/core/state_pipeline_contracts.py
+++ b/src/rigplane/core/state_pipeline_contracts.py
@@ -90,6 +90,7 @@ class VfoSlot(StrEnum):
     """VFO slot dimension for receiver-scoped frequency/mode fields."""
 
     ACTIVE = "active"
+    UNSELECTED = "unselected"
     A = "A"
     B = "B"
 
@@ -227,8 +228,11 @@ class FieldPath:
             raise ValueError("scope_controls field paths cannot include VFO slot")
         if scope is FieldScope.SCOPE_CONTROLS and family is not FieldFamily.DISPLAY:
             raise ValueError("scope_controls field paths must use display family")
-        if slot is VfoSlot.ACTIVE and scope is not FieldScope.RECEIVER:
-            raise ValueError("active VFO slot is only valid for receiver fields")
+        if (
+            slot in (VfoSlot.ACTIVE, VfoSlot.UNSELECTED)
+            and scope is not FieldScope.RECEIVER
+        ):
+            raise ValueError("relative VFO slot is only valid for receiver fields")
         if slot is not None and family is not FieldFamily.FREQ_MODE:
             raise ValueError("VFO slot paths are only valid for freq_mode fields")
 
@@ -269,10 +273,11 @@ class FieldPath:
             if len(parts) != 6:
                 raise ValueError(f"receiver slot path must have 6 parts: {raw!r}")
             return cls.vfo_slot(receiver, parts[3], parts[4], parts[5])
-        if marker == VfoSlot.ACTIVE.value:
+        if marker in (VfoSlot.ACTIVE.value, VfoSlot.UNSELECTED.value):
             if len(parts) != 5:
-                raise ValueError(f"receiver active path must have 5 parts: {raw!r}")
-            return cls.active(receiver, parts[3], parts[4])
+                raise ValueError(f"receiver relative path must have 5 parts: {raw!r}")
+            builder = cls.active if marker == VfoSlot.ACTIVE.value else cls.unselected
+            return builder(receiver, parts[3], parts[4])
         if len(parts) != 4:
             raise ValueError(f"receiver field path must have 4 parts: {raw!r}")
         return cls.receiver(receiver, marker, parts[3])
@@ -332,6 +337,16 @@ class FieldPath:
         )
 
     @classmethod
+    def unselected(cls, receiver_id: str, family: str, name: str) -> FieldPath:
+        return cls(
+            scope=FieldScope.RECEIVER,
+            receiver_id=receiver_id,
+            slot=VfoSlot.UNSELECTED,
+            family=_validate_family(family),
+            name=name,
+        )
+
+    @classmethod
     def active_slot(cls, receiver_id: str) -> FieldPath:
         return cls.receiver(receiver_id, FieldFamily.VFO.value, "active_slot")
 
@@ -364,7 +379,7 @@ class FieldPath:
     def __str__(self) -> str:
         if self.scope is FieldScope.RECEIVER:
             assert self.receiver_id is not None
-            if self.slot is VfoSlot.ACTIVE:
+            if self.slot in (VfoSlot.ACTIVE, VfoSlot.UNSELECTED):
                 return ".".join(
                     [
                         self.scope.value,
@@ -911,6 +926,14 @@ def _receiver_specs(receiver_id: str) -> tuple[FieldSpec, ...]:
             unit="hz",
         ),
         spec(FieldPath.active(receiver_id, "freq_mode", "mode"), "str", writable=True),
+        spec(
+            FieldPath.unselected(receiver_id, "freq_mode", "freq_hz"),
+            "int",
+            unit="hz",
+        ),
+        spec(FieldPath.unselected(receiver_id, "freq_mode", "mode"), "str"),
+        spec(FieldPath.unselected(receiver_id, "freq_mode", "filter_num"), "int"),
+        spec(FieldPath.unselected(receiver_id, "freq_mode", "data_mode"), "int"),
         spec(
             FieldPath.vfo_slot(receiver_id, "A", "freq_mode", "freq_hz"),
             "int",

--- a/src/rigplane/core/state_store.py
+++ b/src/rigplane/core/state_store.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import copy
 import time
+from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import StrEnum
 from typing import Any
@@ -313,6 +314,46 @@ class StateStore:
             reconciliation_requests=(),
         )
         return changeset
+
+    def discard(self, paths: Iterable[FieldPath | str]) -> ChangeSet:
+        """Remove session-scoped facts so a new provider epoch starts unknown.
+
+        This is deliberately not an observation: removing prior-session proof
+        must not manufacture a fresh value or source. A semantic revision is
+        emitted when at least one field existed so snapshot consumers publish
+        the corresponding ``missing`` field status.
+        """
+
+        removed: list[FieldChange] = []
+        for item in paths:
+            path = FieldPath.parse(item) if isinstance(item, str) else item
+            entry = self._entries.pop(path, None)
+            if entry is None:
+                continue
+            removed.append(
+                FieldChange(
+                    path=path,
+                    previous=_copy_value(entry.value),
+                    current=None,
+                )
+            )
+        changes = tuple(removed)
+        if changes:
+            self._state_revision += 1
+            self._append_history(
+                changes=changes,
+                freshness=(),
+                reconciliation_requests=(),
+            )
+        return ChangeSet(
+            revision=self._state_revision,
+            freshness_revision=self._freshness_revision,
+            observation_seq=self._observation_seq,
+            changes=changes,
+            timestamp_monotonic=self._freshness_clock.now(),
+            sources=(),
+            coalesced=False,
+        )
 
     def mark_stale_due(self, *, now: float | None = None) -> SnapshotDelta:
         """Mark overdue fresh fields stale and emit reconciliation hints.

--- a/src/rigplane/profiles/__init__.py
+++ b/src/rigplane/profiles/__init__.py
@@ -154,6 +154,9 @@ class RadioProfile:
     swap_main_sub_code: int | None = None
     equal_main_sub_code: int | None = None
     vfo_scheme: str = "main_sub"
+    # How provider readbacks identify VFO state. ``selected_unselected``
+    # exposes relative radio facts without claiming absolute A/B identity.
+    vfo_readback: str = "none"
     has_lan: bool = False
     freq_ranges: tuple[FreqRangeInfo, ...] = ()
     modes: tuple[str, ...] = ()

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -54,6 +54,7 @@ VALID_KEYBOARD_MODIFIERS = {"SHIFT", "CTRL", "ALT", "META"}
 VALID_AUDIO_SAMPLE_RATES_HZ = {8000, 12000, 16000, 24000, 48000}
 VALID_BROWSER_RX_TRANSPORTS = {"auto", "pcm", "opus"}
 VALID_RX_AUDIO_CHANNELS = {"mix", "left", "right"}
+VALID_VFO_READBACK = {"absolute", "selected_unselected", "none"}
 DEFAULT_KEYBOARD_PROFILE_NAME = "_keyboard-default.toml"
 
 _REQUIRED_SECTIONS = ("radio", "capabilities", "modes", "filters", "vfo")
@@ -79,6 +80,7 @@ class RigConfig:
     modes: tuple[str, ...]
     filters: tuple[str, ...]
     vfo_scheme: str
+    vfo_readback: str
     vfo_main_select: tuple[int, ...] | None
     vfo_sub_select: tuple[int, ...] | None
     vfo_swap_ab: tuple[int, ...] | None
@@ -177,6 +179,7 @@ class RigConfig:
             swap_main_sub_code=swap_main_sub,
             equal_main_sub_code=equal_main_sub,
             vfo_scheme=self.vfo_scheme,
+            vfo_readback=self.vfo_readback,
             has_lan=self.has_lan,
             freq_ranges=ranges,
             modes=tuple(self.modes),
@@ -1013,6 +1016,12 @@ def load_rig(path: Path) -> RigConfig:
             f"{filename}: [vfo].scheme must be one of {VALID_VFO_SCHEMES}, "
             f"got {scheme!r}"
         )
+    vfo_readback = vfo.get("readback", "none")
+    if vfo_readback not in VALID_VFO_READBACK:
+        raise RigLoadError(
+            f"{filename}: [vfo].readback must be one of "
+            f"{sorted(VALID_VFO_READBACK)}, got {vfo_readback!r}"
+        )
     expected_receiver_count = 1 if scheme in {"single", "ab"} else 2
     receiver_count = radio["receiver_count"]
     if (
@@ -1395,6 +1404,7 @@ def load_rig(path: Path) -> RigConfig:
         filter_config=filter_config,
         max_watts=max_watts,
         vfo_scheme=scheme,
+        vfo_readback=vfo_readback,
         vfo_main_select=vfo_main,
         vfo_sub_select=vfo_sub,
         vfo_swap_ab=vfo_swap_ab,

--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -1942,6 +1942,19 @@ class CivRuntime:
         receiver_id, _, slot_override = self._receiver_context(frame)
         observations: list[Observation] = []
 
+        if (
+            frame.command in (0x25, 0x26)
+            and getattr(self._host._profile, "vfo_readback", "none")
+            == "selected_unselected"
+            and getattr(self._host, "_relative_vfo_observations_suspended", False)
+            is True
+        ):
+            # An explicit slot-select owns this short causal window. Its
+            # transaction-bound readback is published by RadioPoller; dropping
+            # ambient responses here prevents pre-ACK tuples being bound to the
+            # newly selected absolute slot.
+            return ()
+
         if frame.command in (0x00, 0x03):
             if len(frame.data) == _FREQ_BCD_LEN:
                 observations.append(
@@ -1983,19 +1996,42 @@ class CivRuntime:
         elif frame.command == 0x25 and len(frame.data) >= 6:
             from rigplane.types import bcd_decode
 
-            target_receiver = "1" if frame.data[0] else "0"
+            relative = (
+                getattr(self._host._profile, "vfo_readback", "none")
+                == "selected_unselected"
+                and self._host._profile.receiver_count == 1
+            )
+            path = (
+                FieldPath.unselected("0", "freq_mode", "freq_hz")
+                if relative and frame.data[0] == 0x01
+                else FieldPath.active(
+                    "1" if frame.data[0] else "0", "freq_mode", "freq_hz"
+                )
+            )
             observations.append(
                 self._observation(
-                    FieldPath.active(target_receiver, "freq_mode", "freq_hz"),
+                    path,
                     bcd_decode(frame.data[1:6]),
                     frame=frame,
                 )
             )
         elif frame.command == 0x26 and len(frame.data) >= 2:
-            target_receiver = "1" if frame.data[0] else "0"
+            relative = (
+                getattr(self._host._profile, "vfo_readback", "none")
+                == "selected_unselected"
+                and self._host._profile.receiver_count == 1
+            )
+
+            def path_for(name: str) -> FieldPath:
+                if relative and frame.data[0] == 0x01:
+                    return FieldPath.unselected("0", "freq_mode", name)
+                return FieldPath.active(
+                    "1" if frame.data[0] else "0", "freq_mode", name
+                )
+
             observations.append(
                 self._observation(
-                    FieldPath.active(target_receiver, "freq_mode", "mode"),
+                    path_for("mode"),
                     Mode(frame.data[1]).name,
                     frame=frame,
                 )
@@ -2007,7 +2043,7 @@ class CivRuntime:
                 # reached the web UI. Project it as the active-slot data_mode.
                 observations.append(
                     self._observation(
-                        FieldPath.active(target_receiver, "freq_mode", "data_mode"),
+                        path_for("data_mode"),
                         int(frame.data[2]),
                         frame=frame,
                     )
@@ -2015,7 +2051,7 @@ class CivRuntime:
             if len(frame.data) >= 4:
                 observations.append(
                     self._observation(
-                        FieldPath.active(target_receiver, "freq_mode", "filter_num"),
+                        path_for("filter_num"),
                         int(frame.data[3]),
                         frame=frame,
                     )
@@ -2080,15 +2116,17 @@ class CivRuntime:
             mapping = _OBSERVABLE_CMD15_FIELDS.get(frame.sub or 0)
             if mapping is not None:
                 raw_value = self._decode_level(frame.data)
-                value: int | float = raw_value
-                quality = ("confirmed",)
+                meter_value: int | float = raw_value
+                quality: tuple[str, ...] = ("confirmed",)
                 meter_key = _CMD15_METER_CALIBRATION_KEYS.get(mapping)
                 if meter_key is not None:
-                    value, quality = self._calibrated_meter_value(raw_value, meter_key)
+                    meter_value, quality = self._calibrated_meter_value(
+                        raw_value, meter_key
+                    )
                 observations.append(
                     self._observation(
                         self._field_path(mapping, receiver_id=receiver_id),
-                        value,
+                        meter_value,
                         frame=frame,
                         quality=quality,
                     )

--- a/src/rigplane/runtime/_dual_rx_runtime.py
+++ b/src/rigplane/runtime/_dual_rx_runtime.py
@@ -23,6 +23,7 @@ from rigplane.commands import (
     get_freq,
     get_mode,
     parse_frequency_response,
+    parse_ack_nak,
     parse_mode_response,
     set_freq,
     set_mode,
@@ -32,6 +33,7 @@ from rigplane.commands import get_selected_mode as _get_selected_mode_cmd
 from rigplane.commands import set_selected_mode as _set_selected_mode_cmd
 from rigplane.commands import get_unselected_freq as _get_unselected_freq_cmd
 from rigplane.commands import get_unselected_mode as _get_unselected_mode_cmd
+from rigplane.core.radio_protocol import RelativeVfoState
 from rigplane.commands import (
     parse_selected_freq_response as _parse_selected_freq_response,
 )
@@ -279,6 +281,27 @@ class DualRxRuntimeMixin(_MixinBase):  # type: ignore[misc]
         _rcvr, mode, _data_mode, filt = _parse_selected_mode_response(resp)
         return mode, filt
 
+    async def read_relative_vfo(self, *, selected: bool) -> RelativeVfoState:
+        """Read one Selected/Unselected tuple without changing radio state."""
+
+        freq_cmd = _get_selected_freq_cmd if selected else _get_unselected_freq_cmd
+        mode_cmd = _get_selected_mode_cmd if selected else _get_unselected_mode_cmd
+        role = "selected" if selected else "unselected"
+        freq_resp = await self._send_civ_expect(
+            freq_cmd(to_addr=self._radio_addr), label=f"get_{role}_freq"
+        )
+        _receiver, freq = _parse_selected_freq_response(freq_resp)
+        mode_resp = await self._send_civ_expect(
+            mode_cmd(to_addr=self._radio_addr), label=f"get_{role}_mode"
+        )
+        _receiver, mode, data_mode, filt = _parse_selected_mode_response(mode_resp)
+        return RelativeVfoState(
+            freq_hz=freq,
+            mode=mode.name,
+            filter_num=filt,
+            data_mode=0 if data_mode is None else int(data_mode),
+        )
+
     # ------------------------------------------------------------------
     # Explicit swap/equalize — MAIN/SUB vs A/B (issue #714)
     # ------------------------------------------------------------------
@@ -512,20 +535,36 @@ class DualRxRuntimeMixin(_MixinBase):  # type: ignore[misc]
         Raises :class:`ValueError` for an invalid slot or out-of-range
         receiver index.
         """
+        await self._set_vfo_slot_impl(slot, receiver=receiver, confirmed=False)
+
+    async def _set_vfo_slot_confirmed(self, slot: str, receiver: int = 0) -> None:
+        """Private ACK-confirmed path; public ``set_vfo_slot`` stays fire-and-forget."""
+
+        await self._set_vfo_slot_impl(slot, receiver=receiver, confirmed=True)
+
+    async def _set_vfo_slot_impl(
+        self, slot: str, *, receiver: int, confirmed: bool
+    ) -> None:
+        operation = "set_vfo_slot_confirmed" if confirmed else "set_vfo_slot"
+
         self._check_connected()
-        self._check_vfo_slot_receiver(receiver, operation="set_vfo_slot")
+        self._check_vfo_slot_receiver(receiver, operation=operation)
         norm_slot = self._normalize_vfo_slot(slot)
         slot_code = 0x00 if norm_slot == "A" else 0x01
 
-        async def _emit_slot() -> None:
+        async def emit() -> None:
             civ = build_civ_frame(
                 self._radio_addr,
                 CONTROLLER_ADDR,
                 _CMD_VFO,
                 data=bytes([slot_code]),
             )
-            await self._send_civ_raw(civ, wait_response=False)
-            # Update cached per-receiver active_slot for subsequent get_vfo_slot.
+            if confirmed:
+                response = await self._send_civ_expect(civ, label=operation)
+                if parse_ack_nak(response) is not True:
+                    raise CommandError(f"Radio rejected VFO slot {norm_slot}")
+            else:
+                await self._send_civ_raw(civ, wait_response=False)
             rx_state = (
                 self._radio_state.sub
                 if (receiver == 1 and self.receiver_count > 1)
@@ -536,8 +575,8 @@ class DualRxRuntimeMixin(_MixinBase):  # type: ignore[misc]
         if self.receiver_count > 1:
             await self._run_with_receiver_vfo_fallback(
                 receiver=receiver,
-                operation="set_vfo_slot",
-                action=_emit_slot,
+                operation=operation,
+                action=emit,
             )
         else:
-            await _emit_slot()
+            await emit()

--- a/src/rigplane/runtime/_runtime_protocols.py
+++ b/src/rigplane/runtime/_runtime_protocols.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
     from rigplane.civ import CivEvent, CivRequestTracker
     from rigplane.commander import IcomCommander
     from rigplane.radio_state import RadioState
+    from rigplane.profiles import RadioProfile
     from rigplane.core.state_store import StateStore
     from rigplane.scope import ScopeAssembler, ScopeFrame
     from rigplane.transport import IcomTransport
@@ -85,6 +86,8 @@ class CivRuntimeHost(Protocol):
     _last_vfo: "str | None"
     _civ_retry_slice_timeout: float
     _radio_addr: int
+    _profile: "RadioProfile"
+    _relative_vfo_observations_suspended: bool
 
     # Global radio state and callbacks
     _radio_state: "RadioState"

--- a/src/rigplane/runtime/_state_queries.py
+++ b/src/rigplane/runtime/_state_queries.py
@@ -55,6 +55,11 @@ def build_state_queries(
         # filter/attenuator/preamp that don't come via transceive.
         queries.append((0x25, None, receiver))  # frequency
         queries.append((0x26, None, receiver))  # mode
+        if receiver == 0 and profile.vfo_readback == "selected_unselected":
+            # ``sub=1`` is an internal selector consumed by the senders below;
+            # receiver remains 0/None so it never invents a SUB topology.
+            queries.append((0x25, 0x01, None))  # unselected frequency
+            queries.append((0x26, 0x01, None))  # unselected mode
 
         # Per-receiver state queries.  On dual-receiver radios these use
         # cmd29 wrapping.  On single-receiver radios without cmd29 we send
@@ -128,13 +133,15 @@ def build_state_queries(
             (0x14, 0x09, None),  # CW pitch (global)
             (0x14, 0x0C, None),  # Key speed (global)
             (0x0F, None, None),  # Split (global)
-            (0x07, 0xD2, None),  # Active receiver
-            (0x07, 0xC2, None),  # Dual Watch status
             (0x21, 0x00, None),  # RIT frequency
             (0x21, 0x01, None),  # RIT status
             (0x21, 0x02, None),  # RIT TX status
         ]
     )
+    if profile.receiver_count > 1:
+        queries.append((0x07, 0xD2, None))  # Active receiver
+    if "dual_watch" in capabilities:
+        queries.append((0x07, 0xC2, None))  # Dual Watch status
 
     # Common feature queries (data-driven: if radio has the command, poll it)
     _COMMON_FEATURE_QUERIES: list[tuple[int, int]] = [

--- a/src/rigplane/runtime/radio_initial_state.py
+++ b/src/rigplane/runtime/radio_initial_state.py
@@ -62,7 +62,18 @@ async def fetch_initial_state(radio: IcomRadio) -> None:
         ok = 0
         for cmd_byte, sub_byte, receiver in queries:
             try:
-                if receiver is not None:
+                if (
+                    receiver is None
+                    and cmd_byte in (0x25, 0x26)
+                    and sub_byte == 0x01
+                    and radio._profile.vfo_readback == "selected_unselected"
+                ):
+                    await radio.send_civ(
+                        cmd_byte,
+                        data=b"\x01",
+                        wait_response=False,
+                    )
+                elif receiver is not None:
                     if cmd_byte in (0x25, 0x26):
                         # Freq/mode: receiver byte as data payload
                         await radio.send_civ(

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -1,8 +1,9 @@
-"""RadioPoller — fire-and-forget CI-V serialiser.
+"""RadioPoller — CI-V command and acquisition serialiser.
 
 ## ARCHITECTURE PRINCIPLE: FIRE-AND-FORGET ONLY
 
-All CI-V communication MUST be fire-and-forget.  Never await a CI-V response.
+Background CI-V acquisition MUST be fire-and-forget.  Do not await responses
+from the streaming poll path.
 
 Why: The IC-7610 scope streams ~225 CI-V packets/sec on port 50002.  When
 a request-response command waits for a specific reply, the response packet
@@ -20,8 +21,10 @@ How it works:
    RadioState mirrors remain compatibility surfaces only.
 4. Poll freshness stays local to the poller; broadcast events notify on changes.
 
-DO NOT add request-response (await get_frequency, await get_mode, etc.)
-to this module. If you need new data, add parsing to the CI-V RX path instead.
+The one deliberate request-response exception is an explicit user command
+whose positive ACK is itself required evidence.  Such a transaction remains
+on the provider's existing serialized command lane and may perform bounded,
+read-only post-ACK readback; it must never be used by background acquisition.
 """
 
 from __future__ import annotations
@@ -86,7 +89,10 @@ from ..core.state_pipeline_contracts import (
     Observation,
     SourceMetadata,
 )
-from ..core.radio_protocol import ManagedTxApi
+from ..core.radio_protocol import (
+    ManagedTxApi,
+    RelativeVfoReadbackCapable,
+)
 from ..core.state_diagnostics import StateDiagnosticsRecorder
 from ..core.state_store import StateStore
 from ..core.tx_safety import BACKEND_MAX_KEY_DOWN_SECONDS, TxOutcome
@@ -486,6 +492,7 @@ class RadioPoller:
         # than once per _UNSELECTED_SLOT_INTERVAL.
         self._last_user_write_ts: float = 0.0
         self._last_unselected_poll: dict[int, float] = {}
+        self._vfo_binding_generation = 0
         # MOR-615: (main, sub) data_mode pair seen at the last MOD-input fetch;
         # a change triggers a refetch of the per-DATA-group MOD-input sources.
         self._mod_input_data_modes: tuple[int, int] | None = None
@@ -872,7 +879,19 @@ class RadioPoller:
         does not park the poll loop on the commander future (MOR-497ii); the
         response still arrives via the CI-V RX path.
         """
-        if receiver is not None:
+        if (
+            receiver is None
+            and cmd_byte in (0x25, 0x26)
+            and sub_byte == 0x01
+            and self._profile.vfo_readback == "selected_unselected"
+        ):
+            await self._civ(
+                cmd_byte,
+                data=b"\x01",
+                priority=priority,
+                wait_dispatch=False,
+            )
+        elif receiver is not None:
             if cmd_byte in (0x25, 0x26):
                 await self._civ(
                     cmd_byte,
@@ -2093,35 +2112,36 @@ class RadioPoller:
                     self._ensure_receiver_supported(
                         receiver, operation="select_vfo_slot"
                     )
-                    set_vfo_slot = getattr(radio, "set_vfo_slot", None)
-                    if set_vfo_slot is not None:
-                        await set_vfo_slot(slot, receiver=receiver)
-                        logger.info(
-                            "radio-poller: set_vfo_slot=%s receiver=%d",
+                    if self._profile.vfo_readback == "selected_unselected":
+                        await self._select_and_bind_vfo_slot(
                             slot,
-                            receiver,
+                            receiver=receiver,
+                            active_name=active_name,
+                            command_id=command_id,
+                            source=source,
+                            session_id=session_id,
+                            command_service=command_service,
                         )
                     else:
-                        legacy_set_vfo = getattr(radio, "set_vfo", None)
-                        if legacy_set_vfo is None:
-                            logger.warning(
-                                "radio-poller: select_vfo(%s) — backend lacks "
-                                "set_vfo_slot and set_vfo; skipping",
-                                vfo,
+                        set_vfo_slot = getattr(radio, "set_vfo_slot", None)
+                        if set_vfo_slot is not None:
+                            await set_vfo_slot(slot, receiver=receiver)
+                        else:
+                            legacy_set_vfo = getattr(radio, "set_vfo", None)
+                            if legacy_set_vfo is None:
+                                logger.warning(
+                                    "radio-poller: select_vfo(%s) — backend lacks "
+                                    "set_vfo_slot and set_vfo; skipping",
+                                    vfo,
+                                )
+                                return
+                            await legacy_set_vfo(slot)
+                        if self._radio_state is not None:
+                            self._radio_state.receiver(active_name).active_slot = slot
+                        if self._on_state_event:
+                            self._on_state_event(
+                                "vfo_changed", {"vfo": slot, "receiver": receiver}
                             )
-                            return
-                        await legacy_set_vfo(slot)
-                        logger.info(
-                            "radio-poller: legacy set_vfo=%s "
-                            "(backend lacks VfoSlotCapable)",
-                            slot,
-                        )
-                    if self._radio_state is not None:
-                        self._radio_state.receiver(active_name).active_slot = slot
-                    if self._on_state_event:
-                        self._on_state_event(
-                            "vfo_changed", {"vfo": slot, "receiver": receiver}
-                        )
                     return
 
                 if vfo_upper in ("SUB", "1") or (
@@ -2956,6 +2976,145 @@ class RadioPoller:
     async def _poll_unselected_slot(self, receiver: int) -> None:
         """Intentionally do nothing; swap/query/swap is not passive polling."""
         _ = receiver
+
+    @staticmethod
+    def _relative_vfo_fields() -> tuple[str, ...]:
+        return ("freq_hz", "mode", "filter_num", "data_mode")
+
+    def _vfo_identity_paths(self, receiver: int) -> tuple[FieldPath, ...]:
+        receiver_id = str(receiver)
+        paths: list[FieldPath] = [FieldPath.active_slot(receiver_id)]
+        for slot in ("A", "B"):
+            paths.extend(
+                FieldPath.vfo_slot(receiver_id, slot, "freq_mode", name)
+                for name in self._relative_vfo_fields()
+            )
+        return tuple(paths)
+
+    def reset_vfo_session(self) -> None:
+        """Invalidate connection-epoch A/B proof without touching TX facts."""
+
+        self._vfo_binding_generation += 1
+        try:
+            setattr(self._radio, "_relative_vfo_observations_suspended", False)
+        except Exception:
+            pass
+        paths: list[FieldPath] = []
+        for receiver in range(self._profile.receiver_count):
+            paths.extend(self._vfo_identity_paths(receiver))
+            receiver_id = str(receiver)
+            paths.extend(
+                FieldPath.unselected(receiver_id, "freq_mode", name)
+                for name in self._relative_vfo_fields()
+            )
+            if self._profile.vfo_readback == "selected_unselected":
+                paths.extend(
+                    FieldPath.active(receiver_id, "freq_mode", name)
+                    for name in self._relative_vfo_fields()
+                )
+        changeset = self._state_store.discard(paths)
+        if changeset.changes and self._on_state_event:
+            self._on_state_event("vfo_identity_reset", {})
+
+    def _discard_vfo_identity(self, receiver: int) -> None:
+        self._state_store.discard(self._vfo_identity_paths(receiver))
+
+    async def _select_and_bind_vfo_slot(
+        self,
+        slot: str,
+        *,
+        receiver: int,
+        active_name: str,
+        command_id: str | None,
+        source: CommandSource,
+        session_id: str | None,
+        command_service: CommandService | None,
+    ) -> None:
+        """Select once, then bind only transaction-scoped passive readback."""
+
+        self._vfo_binding_generation += 1
+        generation = self._vfo_binding_generation
+        selection_confirmed = False
+        setattr(self._radio, "_relative_vfo_observations_suspended", True)
+
+        def apply(path: FieldPath, value: Any) -> None:
+            observation = Observation(
+                path=path,
+                value=value,
+                source=SourceMetadata(
+                    source="command_response",
+                    provider="vfo_binding",
+                    command_source=source,
+                    session_id=session_id,
+                    native_id="explicit_slot_ack_readback",
+                ),
+                timestamp_monotonic=time.monotonic(),
+                correlation_id=command_id,
+            )
+            if command_service is not None:
+                command_service.apply_observation(observation)
+            else:
+                self._state_store.apply(observation)
+
+        try:
+            confirmed_select = getattr(self._radio, "_set_vfo_slot_confirmed", None)
+            if confirmed_select is None or not asyncio.iscoroutinefunction(
+                confirmed_select
+            ):
+                raise CommandError(
+                    "selected/unselected provider lacks confirmed VFO selection"
+                )
+            await confirmed_select(slot, receiver=receiver)
+            if generation != self._vfo_binding_generation:
+                return
+
+            self._discard_vfo_identity(receiver)
+            selection_confirmed = True
+            apply(FieldPath.active_slot(str(receiver)), slot)
+            if self._radio_state is not None:
+                self._radio_state.receiver(active_name).active_slot = slot
+
+            if not isinstance(self._radio, RelativeVfoReadbackCapable):
+                raise CommandError("provider lacks relative VFO readback")
+            selected = await self._radio.read_relative_vfo(selected=True)
+            unselected = await self._radio.read_relative_vfo(selected=False)
+            if generation != self._vfo_binding_generation:
+                return
+            receiver_id = str(receiver)
+            for state, relative_slot, absolute_slot in (
+                (selected, "selected", slot),
+                (unselected, "unselected", "B" if slot == "A" else "A"),
+            ):
+                for name in self._relative_vfo_fields():
+                    value = getattr(state, name)
+                    relative_path = (
+                        FieldPath.active(receiver_id, "freq_mode", name)
+                        if relative_slot == "selected"
+                        else FieldPath.unselected(receiver_id, "freq_mode", name)
+                    )
+                    apply(relative_path, value)
+                    apply(
+                        FieldPath.vfo_slot(
+                            receiver_id, absolute_slot, "freq_mode", name
+                        ),
+                        value,
+                    )
+            logger.info(
+                "radio-poller: confirmed VFO slot=%s receiver=%d generation=%d",
+                slot,
+                receiver,
+                generation,
+            )
+            if self._on_state_event:
+                self._on_state_event("vfo_changed", {"vfo": slot, "receiver": receiver})
+        except BaseException:
+            # After ACK the target remains known even if passive readback fails.
+            if generation == self._vfo_binding_generation and not selection_confirmed:
+                self._discard_vfo_identity(receiver)
+            raise
+        finally:
+            if generation == self._vfo_binding_generation:
+                setattr(self._radio, "_relative_vfo_observations_suspended", False)
 
     def _emit(self, name: str, data: dict[str, Any]) -> None:
         if self._on_state_event is not None:

--- a/src/rigplane/web/runtime_helpers.py
+++ b/src/rigplane/web/runtime_helpers.py
@@ -237,6 +237,17 @@ def _snapshot_field_public_paths(path: FieldPath) -> tuple[str, ...]:
                         _receiver_public_key(target),
                     ),
                 )
+            if path.slot is VfoSlot.UNSELECTED:
+                target = _VFO_SLOT_FIELDS.get(path.name)
+                if target is None:
+                    return ()
+                return (
+                    _public_field_path(
+                        receiver_key,
+                        "unselectedVfo",
+                        _receiver_public_key(target),
+                    ),
+                )
             if path.slot not in (None, VfoSlot.ACTIVE):
                 return ()
             target = _RECEIVER_FREQ_MODE_FIELDS.get(path.name)
@@ -367,6 +378,16 @@ def _default_receiver_field_status(
                 ),
                 FieldPath.vfo_slot(receiver_key, slot_name, "freq_mode", name),
             )
+    for name, state_key in _VFO_SLOT_FIELDS.items():
+        _set_missing_field_status(
+            statuses,
+            _public_field_path(
+                receiver_key,
+                "unselectedVfo",
+                _receiver_public_key(state_key),
+            ),
+            FieldPath.unselected(receiver_key, "freq_mode", name),
+        )
     _set_missing_field_status(
         statuses,
         _public_field_path(receiver_key, "activeSlot"),
@@ -815,7 +836,8 @@ def _project_tx_target(field: FieldSnapshot) -> dict[str, object]:
         )
     except (TypeError, ValueError):
         return {"status": "unknown", "reason": "contradiction"}
-    return cast(dict[str, object], target.to_dict())
+    projected: dict[str, object] = target.to_dict()
+    return projected
 
 
 def _project_scope_fixed_edge(value: Any) -> dict[str, int]:
@@ -847,7 +869,8 @@ def _canonical_snapshot_fields(snapshot: StateSnapshot) -> tuple[FieldSnapshot, 
     path = FieldPath.global_("tx_state", "tx_target")
     targets = tuple(field for field in snapshot.fields if field.path == path)
     if len(targets) < 2:
-        return cast(tuple[FieldSnapshot, ...], snapshot.fields)
+        canonical: tuple[FieldSnapshot, ...] = snapshot.fields
+        return canonical
     newest_at = max(field.last_observed_monotonic for field in targets)
     newest = tuple(f for f in targets if f.last_observed_monotonic == newest_at)
     rank = (FreshnessState.FRESH, FreshnessState.UNKNOWN, FreshnessState.STALE)
@@ -883,6 +906,17 @@ def _apply_snapshot_field(
                 target = _VFO_SLOT_FIELDS.get(path.name)
                 if target is not None:
                     slot_state[target] = value
+                return
+            if path.slot is VfoSlot.UNSELECTED:
+                receiver = state.get(receiver_key)
+                if not isinstance(receiver, dict):
+                    return
+                relative = receiver.setdefault("unselected_vfo", {})
+                if not isinstance(relative, dict):
+                    return
+                target = _VFO_SLOT_FIELDS.get(path.name)
+                if target is not None:
+                    relative[target] = value
                 return
             if path.slot not in (None, VfoSlot.ACTIVE):
                 return
@@ -985,6 +1019,17 @@ def _project_snapshot_state_dict(
     state = copy.deepcopy(_EMPTY_STATE_DICT)
     for field in snapshot.fields:
         _apply_snapshot_field(state, field, radio=radio)
+    required_relative_fields = frozenset(_VFO_SLOT_FIELDS.values())
+    for receiver_key in ("main", "sub"):
+        receiver = state.get(receiver_key)
+        if not isinstance(receiver, dict):
+            continue
+        relative = receiver.get("unselected_vfo")
+        if (
+            not isinstance(relative, dict)
+            or frozenset(relative) != required_relative_fields
+        ):
+            receiver.pop("unselected_vfo", None)
     return cast(dict[str, Any], state)
 
 

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -822,6 +822,7 @@ class WebServer:
             on_delta=self._on_state_freshness_delta,
         )
         self._bootstrap_state_acquisition()
+        self._publish_single_receiver_topology()
         self.command_service = CommandService(
             executor=_SharedControlCommandExecutor(self),
             state_store=self.command_state_store,
@@ -1056,6 +1057,36 @@ class WebServer:
             setattr(radio, "_meter_observation_coalescer", coalescer)
         except Exception:
             logger.debug("state acquisition: failed to attach services", exc_info=True)
+
+    def _publish_single_receiver_topology(self) -> None:
+        """Publish MAIN when the declared topology has exactly one receiver.
+
+        This is a provider-neutral structural fact.  It carries no A/B or TX
+        meaning and has no freshness deadline because topology cannot decay
+        within a provider connection epoch.
+        """
+
+        if self._radio is None:
+            return
+        try:
+            profile = self._get_profile()
+        except Exception:
+            logger.debug("topology: failed to resolve radio profile", exc_info=True)
+            return
+        if profile.receiver_count != 1:
+            return
+        self.command_state_store.apply(
+            Observation(
+                path=FieldPath.global_("slow_state", "active"),
+                value="MAIN",
+                source=SourceMetadata(
+                    source="local_reconcile",
+                    provider="radio_topology",
+                    native_id="single_receiver_main",
+                ),
+                timestamp_monotonic=time.monotonic(),
+            )
+        )
 
     def _radio_ready(self) -> bool:
         """Backend view of radio readiness (CI-V healthy)."""
@@ -1934,6 +1965,12 @@ class WebServer:
 
     def _on_radio_reconnect(self) -> None:
         """Called after soft_reconnect — refetch state and re-enable scope."""
+        # A/B identity and relative samples are connection-epoch facts.  Clear
+        # them before any new-epoch read can arrive; the topology-derived MAIN
+        # fact is independently valid and is reasserted without touching TX.
+        if isinstance(self._radio_poller, RadioPoller):
+            self._radio_poller.reset_vfo_session()
+        self._publish_single_receiver_topology()
         # Clear poller readiness so scope waits for refetch to complete
         if self._radio_poller is not None:
             self._radio_poller._initial_fetch_done.clear()
@@ -2545,6 +2582,7 @@ class WebServer:
                     "filterWidthMax": profile.filter_width_max,
                     "filterConfig": _serialize_filter_config(profile),
                     "vfoScheme": profile.vfo_scheme,
+                    "vfoReadback": profile.vfo_readback,
                     "hasLan": profile.has_lan,
                     "attValues": (
                         list(profile.att_values) if profile.att_values else None
@@ -2972,6 +3010,7 @@ class WebServer:
                 "capabilities": sorted(caps),
                 "receivers": profile.receiver_count,
                 "vfoScheme": profile.vfo_scheme,
+                "vfoReadback": profile.vfo_readback,
                 "freqRanges": freq_ranges,
                 "modes": list(profile.modes),
                 "filters": list(profile.filters),

--- a/src/rigplane/web/state_schema.py
+++ b/src/rigplane/web/state_schema.py
@@ -84,6 +84,9 @@ class ReceiverStatePublic(_Strict):
     vfoA: VfoSlotPublic
     vfoB: VfoSlotPublic
     activeSlot: str = "A"
+    # Relative inactive-VFO readback for providers that cannot prove absolute
+    # A/B identity. Additive and optional for older providers/clients.
+    unselectedVfo: VfoSlotPublic | None = None
 
     # Legacy active-slot scalars (derived from the active slot). ``freq`` is
     # renamed to ``freqHz`` by ``_RECEIVER_KEY_MAP``; the rest pass through.

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -8,7 +8,7 @@ import time
 from collections.abc import Callable
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 
@@ -24,7 +24,12 @@ from rigplane.core.state_acquisition_policy import (
     FieldCapability,
     RadioAcquisitionProfile,
 )
-from rigplane.core.state_pipeline_contracts import FieldPath
+from rigplane.core.state_pipeline_contracts import (
+    FieldPath,
+    Observation,
+    SourceMetadata,
+)
+from rigplane.core.radio_protocol import RelativeVfoState
 from rigplane.core.state_store import StateStore
 from rigplane.core.types import CivFrame
 from rigplane.core.command_service import (
@@ -209,6 +214,13 @@ def _make_radio(active: str = "MAIN", *, model: str = "IC-7610") -> MagicMock:
 
     radio.select_receiver = AsyncMock(side_effect=_select_receiver)
     radio.set_vfo_slot = AsyncMock()
+    radio._set_vfo_slot_confirmed = AsyncMock()
+    radio.read_relative_vfo = AsyncMock(
+        side_effect=(
+            RelativeVfoState(14_200_000, "USB", 1, 0),
+            RelativeVfoState(7_100_000, "LSB", 2, 0),
+        )
+    )
     radio.get_dual_watch = AsyncMock(return_value=False)
     radio.set_tuner_status = AsyncMock()
     radio.get_tuner_status = AsyncMock(return_value=0)
@@ -1172,10 +1184,112 @@ async def test_single_receiver_vfo_b_selects_slot_without_sub_receiver() -> None
 
     await poller._execute(SelectVfo("B"))  # noqa: SLF001
 
-    radio.set_vfo_slot.assert_awaited_once_with("B", receiver=0)
+    radio._set_vfo_slot_confirmed.assert_awaited_once_with("B", receiver=0)
+    radio.set_vfo_slot.assert_not_awaited()
     radio.select_receiver.assert_not_awaited()
     assert state.active == "MAIN"
     assert state.main.active_slot == "B"
+
+
+@pytest.mark.asyncio
+async def test_relative_vfo_ack_maps_selected_and_complement_then_rebinds() -> None:
+    state = RadioState()
+    state.active = "MAIN"
+    radio = _make_radio(model="IC-7300")
+    radio._radio_state = state
+    radio.read_relative_vfo.side_effect = (
+        RelativeVfoState(14_200_000, "USB", 1, 0),
+        RelativeVfoState(7_100_000, "LSB", 2, 0),
+        RelativeVfoState(7_200_000, "LSB", 2, 0),
+        RelativeVfoState(14_250_000, "USB", 1, 0),
+    )
+    store = StateStore()
+    poller = RadioPoller(radio, CommandQueue(), radio_state=state, state_store=store)
+
+    assert "receiver.0.vfo.active_slot" not in store.snapshot().as_dict()
+    await poller._execute(SelectVfo("B"))  # noqa: SLF001
+    first = store.snapshot()
+    assert first.field("receiver.0.vfo.active_slot").value == "B"
+    assert first.field("receiver.0.slot.B.freq_mode.freq_hz").value == 14_200_000
+    assert first.field("receiver.0.slot.A.freq_mode.freq_hz").value == 7_100_000
+
+    await poller._execute(SelectVfo("A"))  # noqa: SLF001
+    second = store.snapshot()
+    assert second.field("receiver.0.vfo.active_slot").value == "A"
+    assert second.field("receiver.0.slot.A.freq_mode.freq_hz").value == 7_200_000
+    assert second.field("receiver.0.slot.B.freq_mode.freq_hz").value == 14_250_000
+    assert radio._set_vfo_slot_confirmed.await_args_list == [
+        call("B", receiver=0),
+        call("A", receiver=0),
+    ]
+    assert radio.set_vfo_slot.await_count == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "failure",
+    (
+        CommandError("NAK"),
+        RigplaneTimeoutError("select timeout"),
+        asyncio.CancelledError(),
+    ),
+)
+async def test_relative_vfo_failed_select_leaves_identity_unknown(
+    failure: BaseException,
+) -> None:
+    radio = _make_radio(model="IC-7300")
+    radio._radio_state = RadioState()
+    radio._set_vfo_slot_confirmed.side_effect = failure
+    store = StateStore()
+    poller = RadioPoller(radio, CommandQueue(), state_store=store)
+
+    with pytest.raises(type(failure)):
+        await poller._execute(SelectVfo("B"))  # noqa: SLF001
+
+    assert "receiver.0.vfo.active_slot" not in store.snapshot().as_dict()
+    radio.read_relative_vfo.assert_not_awaited()
+    assert radio._relative_vfo_observations_suspended is False
+
+
+@pytest.mark.asyncio
+async def test_relative_vfo_readback_failure_retains_ack_identity_only() -> None:
+    radio = _make_radio(model="IC-7300")
+    radio._radio_state = RadioState()
+    radio.read_relative_vfo.side_effect = RigplaneTimeoutError("read timeout")
+    store = StateStore()
+    poller = RadioPoller(radio, CommandQueue(), state_store=store)
+
+    with pytest.raises(RigplaneTimeoutError):
+        await poller._execute(SelectVfo("B"))  # noqa: SLF001
+
+    snapshot = store.snapshot()
+    assert snapshot.field("receiver.0.vfo.active_slot").value == "B"
+    assert "receiver.0.slot.B.freq_mode.freq_hz" not in snapshot.as_dict()
+
+
+@pytest.mark.asyncio
+async def test_relative_vfo_epoch_reset_discards_vfo_facts_but_not_ptt() -> None:
+    radio = _make_radio(model="IC-7300")
+    radio._radio_state = RadioState()
+    store = StateStore()
+    poller = RadioPoller(radio, CommandQueue(), state_store=store)
+    store.apply(
+        Observation(
+            path=FieldPath.global_("tx_state", "ptt"),
+            value=False,
+            source=SourceMetadata(source="test", provider="test"),
+            timestamp_monotonic=time.monotonic(),
+        )
+    )
+    await poller._execute(SelectVfo("B"))  # noqa: SLF001
+
+    poller.reset_vfo_session()
+
+    fields = store.snapshot().as_dict()
+    assert "receiver.0.vfo.active_slot" not in fields
+    assert "receiver.0.active.freq_mode.freq_hz" not in fields
+    assert "receiver.0.unselected.freq_mode.freq_hz" not in fields
+    assert fields["global.tx_state.ptt"]["value"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_state_queries.py
+++ b/tests/test_state_queries.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, call, patch
 
 import pytest
 
@@ -43,11 +43,13 @@ class TestBuildStateQueries:
         assert 1 in freq_receivers
 
     def test_ic7300_single_receiver(self) -> None:
-        """IC-7300 has 1 receiver — freq/mode only for rx 0."""
+        """IC-7300 has selected/unselected reads on its one receiver."""
         profile = resolve_radio_profile(model="IC-7300")
         queries = build_state_queries(profile, _ic7300_caps())
-        freq_receivers = [q[2] for q in queries if q[0] == 0x25]
-        assert freq_receivers == [0]
+        freq_queries = [q for q in queries if q[0] == 0x25]
+        assert freq_queries == [(0x25, None, 0), (0x25, 0x01, None)]
+        assert (0x07, 0xD2, None) not in queries
+        assert (0x07, 0xC2, None) not in queries
 
     def test_ic7610_includes_scope_queries(self) -> None:
         """IC-7610 should have scope sub-commands (0x27)."""
@@ -154,6 +156,23 @@ class TestFetchInitialState:
         await radio._fetch_initial_state()
         assert radio.send_civ.call_count == len(queries)
         assert radio._initial_state_fetched is True
+
+    @pytest.mark.asyncio
+    async def test_single_rx_unselected_selector_is_data_not_sub_receiver(
+        self, radio
+    ) -> None:
+        radio._profile = resolve_radio_profile(model="IC-7300")
+
+        await radio._fetch_initial_state()
+
+        assert (
+            call(0x25, data=b"\x01", wait_response=False)
+            in radio.send_civ.await_args_list
+        )
+        assert (
+            call(0x26, data=b"\x01", wait_response=False)
+            in radio.send_civ.await_args_list
+        )
 
     @pytest.mark.asyncio
     async def test_sets_flag_on_success(self, radio) -> None:

--- a/tests/test_web_capability_guards.py
+++ b/tests/test_web_capability_guards.py
@@ -108,6 +108,7 @@ class TestInfoEndpoint:
         await srv._serve_info(writer)  # noqa: SLF001
         data = _parse_json_body(writer)
         assert data["capabilities"]["vfoScheme"] == "ab"
+        assert data["capabilities"]["vfoReadback"] == "selected_unselected"
 
     @pytest.mark.asyncio
     async def test_info_includes_has_lan_true(self):
@@ -251,6 +252,7 @@ class TestCapabilitiesEndpoint:
         data = _parse_json_body(writer)
         assert data["receivers"] == 1
         assert data["vfoScheme"] == "ab"
+        assert data["vfoReadback"] == "selected_unselected"
 
     @pytest.mark.asyncio
     async def test_capabilities_include_filter_config(self):

--- a/tests/test_web_runtime_helpers.py
+++ b/tests/test_web_runtime_helpers.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Callable
+from itertools import permutations
 from typing import Any
 
 import pytest
@@ -106,6 +107,118 @@ def _observation(
         max_age=max_age,
         quality=quality,
     )
+
+
+def test_relative_unselected_vfo_projects_only_as_complete_public_object() -> None:
+    values = {
+        "freq_hz": 7_100_000,
+        "mode": "LSB",
+        "filter_num": 2,
+        "data_mode": 0,
+    }
+    for order in permutations(values):
+        store = StateStore()
+        for index, name in enumerate(order):
+            store.apply(
+                _observation(
+                    FieldPath.unselected("0", "freq_mode", name),
+                    values[name],
+                    at=10.0 + index,
+                )
+            )
+            payload = build_public_state_payload_from_snapshot(
+                store.snapshot(), radio=None, receiver_count=1
+            )
+            if index < len(values) - 1:
+                assert "unselectedVfo" not in payload["main"]
+                public_leaf = {
+                    "freq_hz": "freqHz",
+                    "mode": "mode",
+                    "filter_num": "filterNum",
+                    "data_mode": "dataMode",
+                }[name]
+                assert (
+                    payload["fieldStatus"][f"main.unselectedVfo.{public_leaf}"][
+                        "observed"
+                    ]
+                    is True
+                )
+            else:
+                assert payload["main"]["unselectedVfo"] == {
+                    "freqHz": 7_100_000,
+                    "mode": "LSB",
+                    "filterNum": 2,
+                    "dataMode": 0,
+                }
+
+
+def test_relative_unselected_vfo_reset_removes_complete_public_object() -> None:
+    store = StateStore()
+    paths = [
+        FieldPath.unselected("0", "freq_mode", name)
+        for name in ("freq_hz", "mode", "filter_num", "data_mode")
+    ]
+    for path, value in zip(paths, (7_100_000, "LSB", 2, 0), strict=True):
+        store.apply(_observation(path, value, at=10.0))
+
+    before = build_public_state_payload_from_snapshot(
+        store.snapshot(), radio=None, receiver_count=1
+    )
+    assert before["main"]["unselectedVfo"]["freqHz"] == 7_100_000
+
+    store.discard(paths)
+    after = build_public_state_payload_from_snapshot(
+        store.snapshot(), radio=None, receiver_count=1
+    )
+    assert "unselectedVfo" not in after["main"]
+    assert all(
+        after["fieldStatus"][f"main.unselectedVfo.{leaf}"]["observed"] is False
+        for leaf in ("freqHz", "mode", "filterNum", "dataMode")
+    )
+
+
+def test_web_server_publishes_single_receiver_main_from_topology_only() -> None:
+    from rigplane.profiles import resolve_radio_profile
+
+    store = StateStore()
+    radio = MagicMock()
+    radio.model = "IC-7300"
+    radio.profile = resolve_radio_profile(model="IC-7300")
+    radio.state_store = store
+    radio.capabilities = set(radio.profile.capabilities)
+    radio.managed_tx = None
+
+    WebServer(radio)
+
+    snapshot = store.snapshot()
+    assert snapshot.field("global.slow_state.active").value == "MAIN"
+    assert "global.tx_state.ptt" not in snapshot.as_dict()
+    assert "receiver.0.vfo.active_slot" not in snapshot.as_dict()
+
+
+def test_production_radio_poller_resets_vfo_identity_on_reconnect() -> None:
+    from rigplane.profiles import resolve_radio_profile
+    from rigplane.web.radio_poller import CommandQueue, RadioPoller
+
+    store = StateStore()
+    radio = MagicMock()
+    radio.model = "IC-7300"
+    radio.profile = resolve_radio_profile(model="IC-7300")
+    radio.state_store = store
+    radio.capabilities = set(radio.profile.capabilities)
+    radio.managed_tx = None
+    server = WebServer(radio)
+    poller = RadioPoller(radio, CommandQueue(), state_store=store)
+    server._radio_poller = poller  # noqa: SLF001
+    store.apply(_observation(FieldPath.active_slot("0"), "B", at=10.0))
+
+    def close_spawned(coro: Any) -> None:
+        coro.close()
+
+    server._spawn = close_spawned  # type: ignore[method-assign]  # noqa: SLF001
+    server._on_radio_reconnect()  # noqa: SLF001
+
+    assert "receiver.0.vfo.active_slot" not in store.snapshot().as_dict()
 
 
 def _tx_target_field(


### PR DESCRIPTION
Closes #2306

## Summary

- model single-receiver dual-VFO readback as provider-neutral Selected/Unselected state without fabricating A/B identity
- derive MAIN from single-receiver topology, preserve relative values at cold start, and reset session-scoped slot identity on reconnect
- establish A/B only after one explicit ACK-confirmed selection, then bind post-ACK read-only Selected/Unselected tuples to the target and complement
- render neutral Selected/Unselected UI with explicit A/B selection and fail-closed identity-dependent operation/memory guards
- keep selected-only and older-compatible payloads neutral from canonical capability/field evidence even before Unselected is available
- publish optional `unselectedVfo` atomically only after all four required leaves are observed

## Safety / compatibility

- no background select, swap, frequency write, mode write, PTT, or TX inference was added
- public `VfoSlotCapable.set_vfo_slot` remains fire-and-forget; ACK evidence uses a private Icom transaction only for the explicit Web selection path
- single-RX Unselected uses CI-V data selector `01`, never receiver/SUB topology semantics
- `main.unselectedVfo` is additive and optional; existing selected scalar and A/B keys remain compatible

## Verifier findings addressed

- neutral Selected/Unselected mode no longer depends on `unselectedVfo` object presence; Selected stays useful while Unselected is unavailable, explicit A/B selectors remain visible, and ambiguous operations remain gated
- older capability payloads fall back to observed canonical A/B facts only; local storage and default slot objects are not identity evidence
- partial Unselected observations retain per-field status internally but never emit a structurally partial public object; all arrival orders and reset are covered
- four mypy errors in PR-touched `_civ_rx.py` / `runtime_helpers.py` were removed with typing-only changes
- two local typed assignments reconcile non-strict full mypy with strict Web mypy under `follow_imports=skip`, without runtime/schema behavior changes or ignores

## Verification

- `uv run pytest -q`: **9122 passed, 68 skipped, 5 deselected, 11 xfailed, 1 xpassed**
- `npm test`: **292 files / 6029 tests passed**
- focused backend discriminator: **231/231 passed**
- focused frontend discriminator: **238/238 passed**
- Python 3.11 quick-equivalent non-integration suite: **8798 passed, 73 skipped, 11 xfailed, 1 xpassed**
- `uv run ruff check src/ tests/`: pass
- scoped `uv run ruff format --check ...`: pass
- `uv run lint-imports`: 5 contracts kept, 0 broken
- `npm run lint`: pass
- `npm run check`: 0 errors, 0 warnings
- state TypeScript and field-status fixture generators: current
- `uv run mypy --strict src/rigplane/web`: 0 errors in 26 files

## Known repository baseline

`uv run mypy src/` reports exactly 11 baseline errors, all in untouched `_control_phase.py` and `_audio_runtime_mixin.py`; PR-touched paths are clean.

Hardware validation is intentionally deferred to the separate supervised IC-7300 bench step; this PR neither opens nor keys hardware.
