### PR TITLE
fix: retain relative VFO state across poll rotations

### DIFF
--- a/frontend/src/lib/transport/__tests__/ws-client-store.integration.test.ts
+++ b/frontend/src/lib/transport/__tests__/ws-client-store.integration.test.ts
@@ -247,6 +247,68 @@ describe('ws-client → real radio store gate (integration)', () => {
     expect(s?.fieldStatus?.['main.freqHz']).toEqual(nextFieldStatus['main.freqHz']);
   });
 
+  it('keeps a retained relative tuple visible and applies a live leaf delta', async () => {
+    const { wsClient, store } = await loadModules();
+    const status = (at: number) => ({
+      storePath: 'receiver.0.active.freq_mode.freq_hz',
+      observed: true,
+      freshness: 'fresh' as const,
+      availability: 'available' as const,
+      lastObservedMonotonic: at,
+      source: { provider: 'icom_civ' },
+    });
+    const fieldStatus = {
+      'main.freqHz': status(902_507),
+      'main.mode': status(902_507),
+      'main.unselectedVfo.freqHz': status(902_507),
+      'main.unselectedVfo.mode': status(902_507),
+    };
+    const initial = makeState({
+      revision: 5,
+      stateRevision: 5,
+      observationSeq: 8,
+      main: makeReceiver({
+        freqHz: 14_284_000,
+        mode: 'USB',
+        unselectedVfo: {
+          freqHz: 14_075_000, mode: 'USB', filterNum: 1, dataMode: 0,
+        },
+      }),
+      fieldStatus,
+    });
+
+    wsClient.connect('ws://test/api/v1/ws');
+    instances[0].simulateOpen();
+    sendStateUpdate(instances[0], fullEnvelope(initial));
+    sendStateUpdate(
+      instances[0],
+      deltaEnvelope(
+        makeState({
+          revision: 5, stateRevision: 5, freshnessRevision: 2,
+          observationSeq: 8,
+        }),
+        { fieldStatus },
+      ),
+    );
+
+    let current = store.getRadioState() as ServerStateWithObservation;
+    expect(current.main.freqHz).toBe(14_284_000);
+    expect(current.main.unselectedVfo?.freqHz).toBe(14_075_000);
+
+    const liveMain = { ...current.main, freqHz: 14_285_000 };
+    sendStateUpdate(
+      instances[0],
+      deltaEnvelope(
+        makeState({ revision: 6, stateRevision: 6, observationSeq: 9 }),
+        { main: liveMain, fieldStatus: { ...fieldStatus, 'main.freqHz': status(902_512) } },
+      ),
+    );
+
+    current = store.getRadioState() as ServerStateWithObservation;
+    expect(current.main.freqHz).toBe(14_285_000);
+    expect(current.main.unselectedVfo?.freqHz).toBe(14_075_000);
+  });
+
   it('rejects a stale delta even when observationSeq advances', async () => {
     const { wsClient, store } = await loadModules();
 

--- a/src/rigplane/core/state_store.py
+++ b/src/rigplane/core/state_store.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import copy
 import time
 from collections.abc import Iterable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from enum import StrEnum
 from typing import Any
 
@@ -185,6 +185,17 @@ class _FieldEntry:
     quality: tuple[str, ...]
 
 
+@dataclass(slots=True)
+class _RelativeVfoRetention:
+    generation: int
+    required_paths: frozenset[FieldPath]
+    paths: frozenset[FieldPath]
+    max_age: float
+    coherence_window: float
+    pending: dict[FieldPath, Observation]
+    expires_at: float | None = None
+
+
 class FreshnessClock:
     """Monotonic clock used by freshness expiration."""
 
@@ -235,6 +246,7 @@ class StateStore:
         "_history_floor_state_revision",
         "_max_history_count",
         "_observation_seq",
+        "_relative_vfo_retention",
         "_state_revision",
     )
 
@@ -251,6 +263,7 @@ class StateStore:
         self._state_revision = 0
         self._freshness_revision = 0
         self._observation_seq = 0
+        self._relative_vfo_retention: _RelativeVfoRetention | None = None
         self._entries: dict[FieldPath, _FieldEntry] = {}
         self._history: list[SnapshotDelta] = []
         self._history_floor_state_revision = 0
@@ -258,6 +271,18 @@ class StateStore:
 
     def apply(self, observation: Observation) -> ChangeSet:
         """Apply one confirmed observation and return its state ChangeSet."""
+
+        retention = self._relative_vfo_retention
+        if (
+            retention is not None
+            and observation.path in retention.paths
+            and observation.source.provider == "vfo_binding"
+        ):
+            retention.pending.clear()
+        return self._apply_one(observation)
+
+    def _apply_one(self, observation: Observation) -> ChangeSet:
+        """Apply one observation without relative-VFO staging."""
 
         self._observation_seq += 1
         previous_entry = self._entries.get(observation.path)
@@ -315,6 +340,226 @@ class StateStore:
         )
         return changeset
 
+    def configure_relative_vfo_retention(
+        self,
+        *,
+        generation: int,
+        max_age: float,
+        coherence_window: float,
+    ) -> None:
+        """Enable generation-scoped retention for Selected/Unselected tuples.
+
+        A complete frequency+mode base is required before relative fields enter
+        the canonical store. After that bootstrap, each same-generation leaf is
+        authoritative immediately; a complete coherent mandatory refresh is
+        required only to advance the common finite expiry deadline.
+        """
+
+        if generation < 0 or max_age <= 0 or coherence_window <= 0:
+            raise ValueError("relative VFO retention values must be positive")
+        paths = frozenset(
+            builder("0", "freq_mode", name)
+            for builder in (FieldPath.active, FieldPath.unselected)
+            for name in ("freq_hz", "mode", "filter_num", "data_mode")
+        )
+        now = self._freshness_clock.now()
+        existing = tuple(
+            Observation(
+                path=path,
+                value=entry.value,
+                source=entry.source,
+                timestamp_monotonic=entry.last_observed_monotonic,
+                quality=entry.quality,
+                max_age=entry.max_age,
+            )
+            for path, entry in self._entries.items()
+            if path in paths
+            and entry.freshness is FreshnessState.FRESH
+            and (
+                entry.max_age is None
+                or now - entry.last_observed_monotonic <= entry.max_age
+            )
+        )
+        self.discard(paths)
+        self._relative_vfo_retention = _RelativeVfoRetention(
+            generation=generation,
+            required_paths=frozenset(
+                path for path in paths if path.name in {"freq_hz", "mode"}
+            ),
+            paths=paths,
+            max_age=float(max_age),
+            coherence_window=float(coherence_window),
+            pending={},
+        )
+        self.apply_relative_vfo_observations(existing, generation=generation)
+
+    def reset_relative_vfo_retention(self, *, generation: int) -> ChangeSet:
+        """Clear all relative VFO proof and start one empty provider generation."""
+
+        retention = self._relative_vfo_retention
+        if retention is None:
+            return self._empty_changeset()
+        retention.generation = generation
+        retention.pending.clear()
+        retention.expires_at = None
+        return self.discard(retention.paths)
+
+    def apply_relative_vfo_observations(
+        self,
+        observations: Iterable[Observation],
+        *,
+        generation: int,
+    ) -> ChangeSet:
+        """Stage/bootstrap or immediately patch one relative VFO provider batch."""
+
+        batch = tuple(observations)
+        retention = self._relative_vfo_retention
+        if retention is None:
+            return self._apply_observation_batch(batch)
+        if not batch or generation != retention.generation:
+            return self._empty_changeset(
+                timestamp=max(
+                    (item.timestamp_monotonic for item in batch), default=None
+                ),
+            )
+
+        relative = tuple(
+            item
+            for item in batch
+            if item.path in retention.paths
+            and (
+                item.path not in self._entries
+                or item.timestamp_monotonic
+                >= self._entries[item.path].last_observed_monotonic
+            )
+        )
+        changesets: list[ChangeSet] = []
+        if not relative:
+            return self._empty_changeset()
+
+        newest_at = max(item.timestamp_monotonic for item in relative)
+        if retention.expires_at is not None and newest_at >= retention.expires_at:
+            expired = self.mark_stale_due(now=newest_at)
+            if expired.freshness:
+                changesets.append(
+                    replace(
+                        self._empty_changeset(timestamp=newest_at),
+                        freshness_paths=tuple(item.path for item in expired.freshness),
+                    )
+                )
+
+        if any(
+            item.path in retention.required_paths and item.value is None
+            for item in relative
+        ):
+            changesets.append(self.reset_relative_vfo_retention(generation=generation))
+            return self._merge_changesets(changesets)
+
+        for observation in relative:
+            previous = retention.pending.get(observation.path)
+            if (
+                previous is None
+                or observation.timestamp_monotonic >= previous.timestamp_monotonic
+            ):
+                retention.pending[observation.path] = observation
+
+        timestamps = (
+            retention.pending[path].timestamp_monotonic
+            for path in retention.required_paths
+            if path in retention.pending
+        )
+        required_times = tuple(timestamps)
+        complete = (
+            len(required_times) == len(retention.required_paths)
+            and max(required_times) - min(required_times) <= retention.coherence_window
+        )
+        if retention.expires_at is None:
+            if not complete:
+                return self._merge_changesets(changesets)
+            complete_at = max(required_times)
+            retention.expires_at = complete_at + retention.max_age
+            committed = tuple(
+                replace(
+                    item,
+                    max_age=retention.expires_at - item.timestamp_monotonic,
+                )
+                for item in retention.pending.values()
+                if abs(complete_at - item.timestamp_monotonic)
+                <= retention.coherence_window
+            )
+            changesets.append(self.discard(retention.paths))
+            changesets.append(self._apply_observation_batch(committed))
+        else:
+            immediate = tuple(
+                replace(
+                    item,
+                    max_age=retention.expires_at - item.timestamp_monotonic,
+                )
+                for item in relative
+            )
+            changesets.append(self._apply_observation_batch(immediate))
+            if not complete:
+                return self._merge_changesets(changesets)
+            retention.expires_at = max(required_times) + retention.max_age
+            for path in retention.paths:
+                entry = self._entries.get(path)
+                if entry is not None:
+                    entry.max_age = retention.expires_at - entry.last_observed_monotonic
+
+        retention.pending.clear()
+        return self._merge_changesets(changesets)
+
+    def _expire_relative_vfo(self, *, now: float) -> tuple[FieldPath, ...]:
+        retention = self._relative_vfo_retention
+        if retention is None or retention.expires_at is None:
+            return ()
+        if now < retention.expires_at:
+            return ()
+        retention.expires_at = None
+        retention.pending.clear()
+        return tuple(retention.paths)
+
+    def _apply_observation_batch(
+        self,
+        observations: tuple[Observation, ...],
+    ) -> ChangeSet:
+        return self._merge_changesets(
+            tuple(self._apply_one(item) for item in observations)
+        )
+
+    def _empty_changeset(self, *, timestamp: float | None = None) -> ChangeSet:
+        return ChangeSet(
+            revision=self._state_revision,
+            freshness_revision=self._freshness_revision,
+            observation_seq=self._observation_seq,
+            changes=(),
+            timestamp_monotonic=(
+                self._freshness_clock.now() if timestamp is None else timestamp
+            ),
+            sources=(),
+            coalesced=False,
+        )
+
+    def _merge_changesets(self, changesets: Iterable[ChangeSet]) -> ChangeSet:
+        parts = tuple(changesets)
+        if not parts:
+            return self._empty_changeset()
+        return ChangeSet(
+            revision=self._state_revision,
+            freshness_revision=self._freshness_revision,
+            observation_seq=self._observation_seq,
+            changes=tuple(change for part in parts for change in part.changes),
+            timestamp_monotonic=max(part.timestamp_monotonic for part in parts),
+            sources=tuple(source for part in parts for source in part.sources),
+            coalesced=any(part.coalesced for part in parts),
+            observed_paths=tuple(
+                path for part in parts for path in part.observed_paths
+            ),
+            freshness_paths=tuple(
+                path for part in parts for path in part.freshness_paths
+            ),
+        )
+
     def discard(self, paths: Iterable[FieldPath | str]) -> ChangeSet:
         """Remove session-scoped facts so a new provider epoch starts unknown.
 
@@ -368,10 +613,14 @@ class StateStore:
         timestamp = self._freshness_clock.now() if now is None else now
         transitions: list[FreshnessTransition] = []
         requests: list[ReconciliationRequest] = []
+        relative_due = set(self._expire_relative_vfo(now=timestamp))
         for path, entry in sorted(self._entries.items(), key=lambda item: str(item[0])):
             if entry.freshness is not FreshnessState.FRESH or entry.max_age is None:
                 continue
-            if timestamp - entry.last_observed_monotonic <= entry.max_age:
+            if (
+                path not in relative_due
+                and timestamp - entry.last_observed_monotonic <= entry.max_age
+            ):
                 continue
 
             self._freshness_revision += 1

--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -1416,9 +1416,12 @@ class CivRuntime:
                         self._remember_raw_received_frame_bytes(frame, frame_bytes)
                         self.deliver_raw_civ(frame_bytes)
                         try:
+                            generation = source_generation
+                            if self._host._civ_rx_task is asyncio.current_task():
+                                generation = self._host._civ_epoch
                             await self._route_civ_frame(
                                 frame,
-                                generation=self._host._civ_epoch,
+                                generation=generation,
                             )
                         except Exception:
                             logger.exception(
@@ -1468,7 +1471,12 @@ class CivRuntime:
             event = CivEvent(type=CivEventType.NAK, frame=frame)
         else:
             event = CivEvent(type=CivEventType.RESPONSE, frame=frame)
-            self._update_state_cache_from_frame(frame)
+            if generation != self._host._civ_epoch:
+                return
+            self._update_state_cache_from_frame(
+                frame,
+                source_generation=generation,
+            )
         self._publish_civ_event(event)
         claimed: _CivDataTransaction | None = None
         if self._host._civ_request_tracker.resolve(event, generation=generation):
@@ -1546,9 +1554,24 @@ class CivRuntime:
             except Exception:  # noqa: BLE001 — isolate listener failures
                 logger.exception("Raw CI-V listener raised")
 
-    def _update_state_cache_from_frame(self, frame: CivFrame) -> None:
+    def _update_state_cache_from_frame(
+        self,
+        frame: CivFrame,
+        *,
+        source_generation: int | None = None,
+    ) -> None:
         """Best-effort update of state cache from an incoming CI-V frame."""
-        self._apply_state_store_observations(frame)
+        current_generation = getattr(self._host, "_civ_epoch", 0)
+        if not isinstance(current_generation, int) or isinstance(
+            current_generation, bool
+        ):
+            current_generation = 0
+        self._apply_state_store_observations(
+            frame,
+            generation=(
+                current_generation if source_generation is None else source_generation
+            ),
+        )
 
         host = self._host
         _rs = getattr(host, "_radio_state", None)
@@ -1732,7 +1755,12 @@ class CivRuntime:
         except Exception:
             logger.warning("civ-rx: unexpected error in state update", exc_info=True)
 
-    def _apply_state_store_observations(self, frame: CivFrame) -> None:
+    def _apply_state_store_observations(
+        self,
+        frame: CivFrame,
+        *,
+        generation: int | None = None,
+    ) -> None:
         """Project supported CI-V ingress fields into the runtime StateStore."""
 
         try:
@@ -1752,6 +1780,21 @@ class CivRuntime:
                 frame.sub or 0,
                 exc_info=True,
             )
+            return
+
+        if (
+            frame.command in (0x00, 0x01, 0x03, 0x04, 0x25, 0x26)
+            and getattr(self._host._profile, "vfo_readback", "none")
+            == "selected_unselected"
+        ):
+            changeset = self._host._state_store.apply_relative_vfo_observations(
+                observations,
+                generation=(
+                    self._host._civ_epoch if generation is None else generation
+                ),
+            )
+            self._record_scheduler_results_for_changeset(changeset)
+            self._notify_state_store_changed(changeset)
             return
 
         for observation in observations:

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -465,6 +465,15 @@ class RadioPoller:
             self._FAST_CMDS_SERIAL if self._is_serial else self._FAST_CMDS_LAN
         )
         self._STATE_QUERIES = self._build_state_queries()
+        self._relative_vfo_retention_max_age: float | None = None
+        if self._profile.vfo_readback == "selected_unselected":
+            retention_age, coherence_window = self._relative_vfo_retention_policy()
+            self._relative_vfo_retention_max_age = retention_age
+            self._state_store.configure_relative_vfo_retention(
+                generation=self._provider_generation(),
+                max_age=retention_age,
+                coherence_window=coherence_window,
+            )
         if self._acquisition_executor is None:
             raw_executor = getattr(radio, "__dict__", {}).get("_acquisition_executor")
             execute = getattr(raw_executor, "execute", None)
@@ -500,6 +509,32 @@ class RadioPoller:
         # connect starts unarmed; overridable for tests.
         self._max_key_down_seconds: float = _MAX_KEY_DOWN_SECONDS
         self._max_key_down_timer: asyncio.TimerHandle | None = None
+
+    def _provider_generation(self) -> int:
+        generation = getattr(self._radio, "_civ_epoch", 0)
+        return (
+            generation
+            if isinstance(generation, int) and not isinstance(generation, bool)
+            else 0
+        )
+
+    def _relative_vfo_retention_policy(self) -> tuple[float, float]:
+        """Derive a finite tuple window from this provider's expected cadence."""
+
+        health_grace = getattr(self._radio, "_civ_ready_idle_timeout", 2.0)
+        if not isinstance(health_grace, (int, float)) or isinstance(health_grace, bool):
+            health_grace = 2.0
+        health_grace = max(0.1, float(health_grace))
+        acquisition = self._profile.state_acquisition
+        cadence = (
+            None if acquisition is None else acquisition.default_policy.cadence_seconds
+        )
+        expected_rotation = (
+            float(cadence)
+            if cadence is not None
+            else 2.0 * len(self._STATE_QUERIES) * self._fast_interval
+        )
+        return (2.0 * expected_rotation + health_grace, health_grace)
 
     def _apply_bsr_readback_observations(
         self,
@@ -2995,6 +3030,9 @@ class RadioPoller:
         """Invalidate connection-epoch A/B proof without touching TX facts."""
 
         self._vfo_binding_generation += 1
+        relative_reset = self._state_store.reset_relative_vfo_retention(
+            generation=self._provider_generation()
+        )
         try:
             setattr(self._radio, "_relative_vfo_observations_suspended", False)
         except Exception:
@@ -3013,7 +3051,7 @@ class RadioPoller:
                     for name in self._relative_vfo_fields()
                 )
         changeset = self._state_store.discard(paths)
-        if changeset.changes and self._on_state_event:
+        if (relative_reset.changes or changeset.changes) and self._on_state_event:
             self._on_state_event("vfo_identity_reset", {})
 
     def _discard_vfo_identity(self, receiver: int) -> None:

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -1850,6 +1850,12 @@ class WebServer:
         This is the PRIMARY update path.  Called whenever the radio sends
         a CI-V frame (solicited response or unsolicited change).
         """
+        if (
+            name == "connection_state"
+            and not data.get("connected")
+            and isinstance(self._radio_poller, RadioPoller)
+        ):
+            self._radio_poller.reset_vfo_session()
         self.broadcast_event(name, data)
         self._broadcast_state_update()
         if name == "connection_state":

--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -55,6 +55,7 @@ from rigplane.core.state_acquisition_policy import (
 from rigplane.core.state_diagnostics import StateDiagnosticsRecorder
 from rigplane.core.state_pipeline_contracts import FieldPath
 from rigplane.exceptions import ConnectionError
+from rigplane.profiles import resolve_radio_profile
 from rigplane.radio import IcomRadio
 from rigplane.radio_state import RadioState
 from rigplane.scope import ScopeFrame
@@ -126,6 +127,75 @@ def _acquisition_profile(
         ),
         default_policy=acquisition_policy,
     )
+
+
+@pytest.mark.asyncio
+async def test_relative_vfo_ingress_bootstraps_then_transceive_patches_immediately(
+    radio: IcomRadio,
+) -> None:
+    radio._profile = resolve_radio_profile(model="IC-7300")  # noqa: SLF001
+    radio._state_store.configure_relative_vfo_retention(  # noqa: SLF001
+        generation=radio._civ_epoch,  # noqa: SLF001
+        max_age=31.0,
+        coherence_window=5.0,
+    )
+    radio.send_civ = AsyncMock()  # type: ignore[method-assign]
+
+    for frame in (
+        _make_frame(cmd=0x25, data=b"\x00" + bcd_encode(14_284_000)),
+        _make_frame(cmd=0x26, data=bytes([0, Mode.USB.value, 0, 1])),
+        _make_frame(cmd=0x25, data=b"\x01" + bcd_encode(14_075_000)),
+        _make_frame(cmd=0x26, data=bytes([1, Mode.USB.value, 0, 1])),
+    ):
+        await radio._civ_runtime._route_civ_frame(  # noqa: SLF001
+            frame,
+            generation=radio._civ_epoch,  # noqa: SLF001
+        )
+
+    before = radio._state_store.snapshot()  # noqa: SLF001
+    old_mode = before.field("receiver.0.active.freq_mode.mode")
+    old_unselected = before.field("receiver.0.unselected.freq_mode.freq_hz")
+    await radio._civ_runtime._route_civ_frame(  # noqa: SLF001
+        _make_frame(
+            cmd=0x00,
+            data=bcd_encode(14_285_000),
+            to_addr=0x00,
+        ),
+        generation=radio._civ_epoch,  # noqa: SLF001
+    )
+
+    after = radio._state_store.snapshot()  # noqa: SLF001
+    knob = after.field("receiver.0.active.freq_mode.freq_hz")
+    assert knob.value == 14_285_000
+    assert knob.source.source == "civ_unsolicited"
+    assert knob.last_observed_monotonic > old_mode.last_observed_monotonic
+    assert after.field(old_mode.path).value == old_mode.value
+    assert after.field(old_unselected.path).value == old_unselected.value
+    radio.send_civ.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_relative_vfo_stale_or_invalid_generation_cannot_repopulate(
+    radio: IcomRadio,
+) -> None:
+    radio._profile = resolve_radio_profile(model="IC-7300")  # noqa: SLF001
+    radio._state_store.configure_relative_vfo_retention(  # noqa: SLF001
+        generation=radio._civ_epoch,  # noqa: SLF001
+        max_age=31.0,
+        coherence_window=5.0,
+    )
+    frame = _make_frame(cmd=0x25, data=b"\x00" + bcd_encode(14_285_000))
+
+    await radio._civ_runtime._route_civ_frame(  # noqa: SLF001
+        frame,
+        generation=radio._civ_epoch - 1,  # noqa: SLF001
+    )
+    await radio._civ_runtime._route_civ_frame(  # noqa: SLF001
+        frame,
+        generation=MagicMock(),
+    )
+
+    assert radio._state_store.snapshot().fields == ()  # noqa: SLF001
 
 
 # ---------------------------------------------------------------------------
@@ -2427,12 +2497,15 @@ async def test_route_civ_frame_contains_observation_decode_failures(
         "_publish_civ_event",
         side_effect=published.append,
     ):
-        await radio._civ_runtime._route_civ_frame(frame, generation=17)
+        await radio._civ_runtime._route_civ_frame(
+            frame,
+            generation=radio._civ_epoch,
+        )
 
     assert len(published) == 1
     assert published[0].frame == frame
     radio._civ_request_tracker.resolve.assert_called_once_with(
-        published[0], generation=17
+        published[0], generation=radio._civ_epoch
     )
     assert radio._state_store.snapshot().observation_seq == 0
 

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -1292,6 +1292,26 @@ async def test_relative_vfo_epoch_reset_discards_vfo_facts_but_not_ptt() -> None
     assert fields["global.tx_state.ptt"]["value"] is False
 
 
+@pytest.mark.parametrize(
+    ("model", "expected_seconds"),
+    (("IC-7300", 31.0), ("IC-705", 11.1)),
+)
+def test_relative_vfo_retention_window_follows_provider_poll_cadence(
+    model: str,
+    expected_seconds: float,
+) -> None:
+    radio = _make_radio(model=model)
+    radio._civ_ready_idle_timeout = 5.0
+
+    poller = RadioPoller(radio, CommandQueue())
+
+    expected_rotation = 2 * len(poller._STATE_QUERIES) * poller._fast_interval
+    assert poller._relative_vfo_retention_max_age == pytest.approx(
+        2 * expected_rotation + 5.0
+    )
+    assert poller._relative_vfo_retention_max_age == pytest.approx(expected_seconds)
+
+
 @pytest.mark.asyncio
 async def test_select_vfo_no_capability_logs_and_skips() -> None:
     """SelectVfo on a backend with neither new methods nor set_vfo: skip cleanly."""

--- a/tests/test_state_store.py
+++ b/tests/test_state_store.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
+from itertools import permutations
 from typing import Any
 
 import pytest
@@ -44,13 +46,83 @@ def _observation(
     *,
     at: float,
     max_age: float | None = None,
+    source: str = "poll_response",
 ) -> Observation:
     return Observation(
         path=path,
         value=value,
-        source=_source(),
+        source=SourceMetadata(
+            source=source,
+            provider="test",
+            transport="fake",
+            native_id="relative-vfo",
+        ),
         timestamp_monotonic=at,
         max_age=max_age,
+    )
+
+
+def _relative_vfo_observations(
+    *,
+    at: float,
+    selected_freq: int = 14_284_000,
+    selected_mode: str = "USB",
+    unselected_freq: int = 14_075_000,
+    unselected_mode: str = "USB",
+) -> tuple[Observation, ...]:
+    return (
+        _observation(
+            FieldPath.active("0", "freq_mode", "freq_hz"),
+            selected_freq,
+            at=at,
+            max_age=5.0,
+        ),
+        _observation(
+            FieldPath.active("0", "freq_mode", "mode"),
+            selected_mode,
+            at=at + 0.2,
+            max_age=5.0,
+        ),
+        _observation(
+            FieldPath.active("0", "freq_mode", "filter_num"),
+            1,
+            at=at + 0.2,
+        ),
+        _observation(
+            FieldPath.active("0", "freq_mode", "data_mode"),
+            0,
+            at=at + 0.2,
+        ),
+        _observation(
+            FieldPath.unselected("0", "freq_mode", "freq_hz"),
+            unselected_freq,
+            at=at + 0.4,
+            max_age=5.0,
+        ),
+        _observation(
+            FieldPath.unselected("0", "freq_mode", "mode"),
+            unselected_mode,
+            at=at + 0.6,
+            max_age=5.0,
+        ),
+        _observation(
+            FieldPath.unselected("0", "freq_mode", "filter_num"),
+            1,
+            at=at + 0.6,
+        ),
+        _observation(
+            FieldPath.unselected("0", "freq_mode", "data_mode"),
+            0,
+            at=at + 0.6,
+        ),
+    )
+
+
+def _relative_vfo_deadline(store: StateStore) -> float:
+    return max(
+        field.last_observed_monotonic + field.max_age
+        for field in store.snapshot().fields
+        if field.max_age is not None
     )
 
 
@@ -86,6 +158,198 @@ def test_noop_observations_do_not_advance_state_revision() -> None:
     assert second.changes == ()
     assert store.snapshot().state_revision == 1
     assert store.snapshot().observation_seq == 2
+
+
+def test_relative_vfo_bootstrap_is_atomic_then_live_leaves_patch_immediately() -> None:
+    clock = FreshnessClock(start=100.0)
+    store = StateStore(freshness_clock=clock)
+    store.configure_relative_vfo_retention(
+        generation=7,
+        max_age=31.0,
+        coherence_window=5.0,
+    )
+    base = _relative_vfo_observations(at=100.0)
+
+    for observation in base[:5]:
+        store.apply_relative_vfo_observations((observation,), generation=7)
+        assert store.snapshot().fields == ()
+
+    store.apply_relative_vfo_observations(base[5:], generation=7)
+    committed = store.snapshot()
+    assert committed.field("receiver.0.active.freq_mode.freq_hz").value == 14_284_000
+    assert (
+        committed.field("receiver.0.unselected.freq_mode.freq_hz").value == 14_075_000
+    )
+
+    knob_source = SourceMetadata(
+        source="civ_unsolicited",
+        provider="test",
+        transport="fake",
+        native_id="knob-frequency",
+    )
+    knob = Observation(
+        path=FieldPath.active("0", "freq_mode", "freq_hz"),
+        value=14_285_000,
+        source=knob_source,
+        timestamp_monotonic=101.0,
+        max_age=5.0,
+    )
+    store.apply_relative_vfo_observations((knob,), generation=7)
+
+    patched = store.snapshot()
+    selected = patched.field("receiver.0.active.freq_mode.freq_hz")
+    assert selected.value == 14_285_000
+    assert selected.last_observed_monotonic == 101.0
+    assert selected.source == knob_source
+    assert patched.field("receiver.0.active.freq_mode.mode").value == "USB"
+    assert patched.field("receiver.0.unselected.freq_mode.freq_hz").value == 14_075_000
+    assert _relative_vfo_deadline(store) == pytest.approx(131.6)
+
+    live_mode = (
+        _observation(
+            FieldPath.active("0", "freq_mode", "mode"),
+            "LSB",
+            at=101.1,
+            max_age=5.0,
+            source="civ_unsolicited",
+        ),
+        _observation(
+            FieldPath.active("0", "freq_mode", "filter_num"),
+            2,
+            at=101.1,
+            source="civ_unsolicited",
+        ),
+        _observation(
+            FieldPath.active("0", "freq_mode", "data_mode"),
+            1,
+            at=101.1,
+            source="civ_unsolicited",
+        ),
+    )
+    store.apply_relative_vfo_observations(live_mode, generation=7)
+    patched = store.snapshot()
+    assert patched.field("receiver.0.active.freq_mode.mode").value == "LSB"
+    assert patched.field("receiver.0.active.freq_mode.filter_num").value == 2
+    assert patched.field("receiver.0.active.freq_mode.data_mode").value == 1
+    assert _relative_vfo_deadline(store) == pytest.approx(131.6)
+
+
+def test_relative_vfo_mandatory_bootstrap_is_atomic_in_every_arrival_order() -> None:
+    mandatory = tuple(
+        item
+        for item in _relative_vfo_observations(at=10.0)
+        if item.path.name in {"freq_hz", "mode"}
+    )
+    for order in permutations(mandatory):
+        store = StateStore()
+        store.configure_relative_vfo_retention(
+            generation=1,
+            max_age=20.0,
+            coherence_window=5.0,
+        )
+        for item in order[:-1]:
+            store.apply_relative_vfo_observations((item,), generation=1)
+            assert store.snapshot().fields == ()
+        store.apply_relative_vfo_observations(order[-1:], generation=1)
+        assert {field.path for field in store.snapshot().fields} == {
+            item.path for item in mandatory
+        }
+
+
+def test_relative_vfo_complete_refresh_extends_one_common_expiry() -> None:
+    clock = FreshnessClock(start=902_507.0)
+    store = StateStore(freshness_clock=clock)
+    store.configure_relative_vfo_retention(
+        generation=3,
+        max_age=31.0,
+        coherence_window=5.0,
+    )
+    store.apply_relative_vfo_observations(
+        _relative_vfo_observations(at=902_507.0), generation=3
+    )
+    first_expiry = _relative_vfo_deadline(store)
+
+    clock.advance(13.13)
+    store.apply_relative_vfo_observations(
+        _relative_vfo_observations(at=clock.now()), generation=3
+    )
+    second_expiry = _relative_vfo_deadline(store)
+    assert second_expiry == pytest.approx(first_expiry + 13.13)
+
+    clock.advance(13.13)
+    store.apply_relative_vfo_observations(
+        _relative_vfo_observations(at=clock.now()), generation=3
+    )
+    assert _relative_vfo_deadline(store) == pytest.approx(second_expiry + 13.13)
+
+    clock.advance(5.1)
+    assert store.mark_stale_due().freshness == ()
+    assert all(
+        field.freshness is FreshnessState.FRESH for field in store.snapshot().fields
+    )
+
+
+def test_relative_vfo_expiry_is_atomic_and_lone_late_event_cannot_resurrect() -> None:
+    clock = FreshnessClock(start=10.0)
+    store = StateStore(freshness_clock=clock)
+    store.configure_relative_vfo_retention(
+        generation=4,
+        max_age=20.0,
+        coherence_window=5.0,
+    )
+    store.apply_relative_vfo_observations(
+        _relative_vfo_observations(at=10.0), generation=4
+    )
+    expires_at = _relative_vfo_deadline(store)
+
+    clock.advance(expires_at - clock.now())
+    delta = store.mark_stale_due()
+    assert len(delta.freshness) == 8
+    assert {transition.current for transition in delta.freshness} == {
+        FreshnessState.STALE
+    }
+    assert all(
+        field.freshness is FreshnessState.STALE for field in store.snapshot().fields
+    )
+
+    late_knob = _observation(
+        FieldPath.active("0", "freq_mode", "freq_hz"),
+        14_286_000,
+        at=clock.now() + 0.1,
+        max_age=5.0,
+        source="civ_unsolicited",
+    )
+    store.apply_relative_vfo_observations((late_knob,), generation=4)
+    assert all(
+        field.freshness is FreshnessState.STALE for field in store.snapshot().fields
+    )
+    assert store.snapshot().field(late_knob.path).value == 14_284_000
+
+
+def test_relative_vfo_reset_and_old_generation_are_fail_closed() -> None:
+    store = StateStore()
+    store.configure_relative_vfo_retention(
+        generation=1,
+        max_age=20.0,
+        coherence_window=5.0,
+    )
+    base = _relative_vfo_observations(at=10.0)
+    store.apply_relative_vfo_observations(base, generation=1)
+
+    store.reset_relative_vfo_retention(generation=2)
+    assert store.snapshot().fields == ()
+    store.apply_relative_vfo_observations(base, generation=1)
+    assert store.snapshot().fields == ()
+
+    store.apply_relative_vfo_observations(base[:1], generation=2)
+    assert store.snapshot().fields == ()
+
+    store.apply_relative_vfo_observations(base, generation=2)
+    store.apply_relative_vfo_observations(
+        (replace(base[0], value=None),),
+        generation=2,
+    )
+    assert store.snapshot().fields == ()
 
 
 def test_freshness_expiration_advances_freshness_without_state_change() -> None:

--- a/tests/test_web_runtime_helpers.py
+++ b/tests/test_web_runtime_helpers.py
@@ -177,6 +177,67 @@ def test_relative_unselected_vfo_reset_removes_complete_public_object() -> None:
     )
 
 
+def test_relative_vfo_public_payload_does_not_flap_at_leaf_ttl() -> None:
+    clock = FreshnessClock(start=902_507.0)
+    store = StateStore(freshness_clock=clock)
+    store.configure_relative_vfo_retention(
+        generation=1,
+        max_age=31.0,
+        coherence_window=5.0,
+    )
+    values = {
+        FieldPath.active("0", "freq_mode", "freq_hz"): 14_284_000,
+        FieldPath.active("0", "freq_mode", "mode"): "USB",
+        FieldPath.active("0", "freq_mode", "filter_num"): 1,
+        FieldPath.active("0", "freq_mode", "data_mode"): 0,
+        FieldPath.unselected("0", "freq_mode", "freq_hz"): 14_075_000,
+        FieldPath.unselected("0", "freq_mode", "mode"): "USB",
+        FieldPath.unselected("0", "freq_mode", "filter_num"): 1,
+        FieldPath.unselected("0", "freq_mode", "data_mode"): 0,
+    }
+    store.apply_relative_vfo_observations(
+        tuple(
+            _observation(path, value, at=clock.now(), max_age=5.0)
+            for path, value in values.items()
+        ),
+        generation=1,
+    )
+
+    clock.advance(5.1)
+    assert store.mark_stale_due().freshness == ()
+    retained = build_public_state_payload_from_snapshot(
+        store.snapshot(), radio=None, receiver_count=1
+    )
+    assert retained["main"]["freqHz"] == 14_284_000
+    assert retained["main"]["unselectedVfo"]["freqHz"] == 14_075_000
+    assert all(
+        retained["fieldStatus"][path]["freshness"] == "fresh"
+        for path in (
+            "main.freqHz",
+            "main.mode",
+            "main.unselectedVfo.freqHz",
+            "main.unselectedVfo.mode",
+        )
+    )
+
+    store.apply_relative_vfo_observations(
+        (
+            _observation(
+                FieldPath.active("0", "freq_mode", "freq_hz"),
+                14_285_000,
+                at=clock.now(),
+                max_age=5.0,
+            ),
+        ),
+        generation=1,
+    )
+    patched = build_public_state_payload_from_snapshot(
+        store.snapshot(), radio=None, receiver_count=1
+    )
+    assert patched["main"]["freqHz"] == 14_285_000
+    assert patched["main"]["unselectedVfo"] == retained["main"]["unselectedVfo"]
+
+
 def test_web_server_publishes_single_receiver_main_from_topology_only() -> None:
     from rigplane.profiles import resolve_radio_profile
 
@@ -219,6 +280,41 @@ def test_production_radio_poller_resets_vfo_identity_on_reconnect() -> None:
     server._on_radio_reconnect()  # noqa: SLF001
 
     assert "receiver.0.vfo.active_slot" not in store.snapshot().as_dict()
+
+
+def test_radio_disconnect_immediately_clears_retained_relative_vfo() -> None:
+    from rigplane.profiles import resolve_radio_profile
+    from rigplane.web.radio_poller import CommandQueue, RadioPoller
+
+    store = StateStore()
+    radio = MagicMock()
+    radio.model = "IC-7300"
+    radio.profile = resolve_radio_profile(model="IC-7300")
+    radio.capabilities = set(radio.profile.capabilities)
+    radio.managed_tx = None
+    server = WebServer(radio)
+    server._radio_poller = RadioPoller(  # noqa: SLF001
+        radio, CommandQueue(), state_store=store
+    )
+    store.apply_relative_vfo_observations(
+        (
+            _observation(FieldPath.active("0", "freq_mode", "freq_hz"), 1, at=1.0),
+            _observation(FieldPath.active("0", "freq_mode", "mode"), "USB", at=1.0),
+            _observation(FieldPath.unselected("0", "freq_mode", "freq_hz"), 2, at=1.0),
+            _observation(FieldPath.unselected("0", "freq_mode", "mode"), "USB", at=1.0),
+        ),
+        generation=0,
+    )
+
+    server._on_radio_state_change(  # noqa: SLF001
+        "connection_state", {"connected": False}
+    )
+
+    assert not {
+        path
+        for path in store.snapshot().as_dict()
+        if ".active.freq_mode." in path or ".unselected.freq_mode." in path
+    }
 
 
 def _tx_target_field(


### PR DESCRIPTION
Closes #2308

## Summary

- retain Selected/Unselected VFO frequency and mode across legacy poll rotations without publishing partial tuples
- apply authoritative same-generation leaf updates immediately after bootstrap while preserving untouched leaves and original observation metadata
- expire the retained relative VFO group atomically on a provider-cadence-derived deadline, and reset it on disconnect, generation change, or mandatory unavailable observations
- reject receive frames from stale or invalid CI-V generations before they can update public state

## Correctness contract

- Bootstrap requires a coherent four-leaf base: selected/unselected frequency and mode. Filter and data mode remain optional and are never fabricated.
- After bootstrap, each authoritative leaf update is visible immediately; a single leaf does not extend the common lifetime.
- Only a coherent mandatory refresh advances the deadline. At expiry, the complete relative group becomes stale in one delta, and a lone late event cannot resurrect it.
- Explicit A/B VFO binding continues to bypass relative retention and remains unchanged.

## Verification

- Full Python gate: `9133 passed, 68 skipped, 5 deselected, 11 xfailed, 1 xpassed`; zero failures.
- Dedicated command/ACK/ordering/managed-TX/PTT/audio/bridge/session/teardown matrix: `1688 passed, 4 skipped, 2 deselected`; zero failures.
- Focused StateStore + CI-V + radio + diagnostics: `620 passed`; zero failures.
- Full frontend: `292` files / `6030` tests passed; ESLint, i18n check, and production build passed.
- Exact-final-tree frontend WS/view-model regression: `2` files / `43` tests passed; Svelte/TypeScript check reported zero errors and warnings.
- `ruff check src/ tests/`, `ruff format --check src/ tests/`, changed-module mypy, import-linter, and `git diff --check` passed.

Repository-wide `mypy src/` continues to report 11 existing errors only in untouched `_control_phase.py` and `_audio_runtime_mixin.py`; this PR has no diff in either file.

## Scope and hardware

No production command queue, commander/send, ACK/result, PTT/TX safety, audio, or scope implementation is changed. No radio or remote Mac mini was used for this build; hardware validation remains separate.
