### PR TITLE
fix: keep live VFO aliases coherent

### DIFF
--- a/frontend/src/components-v2/display/__tests__/FrequencyDisplayInteractive.component.svelte.test.ts
+++ b/frontend/src/components-v2/display/__tests__/FrequencyDisplayInteractive.component.svelte.test.ts
@@ -83,7 +83,7 @@ afterEach(() => {
 });
 
 describe('FrequencyDisplayInteractive click-to-tune over the radio store (MOR-475)', () => {
-  it('scroll after an in-flight stale causal poll steps from the COMMANDED freq, not the stale server value', () => {
+  it('scroll steps from the last StateStore frequency, never an unconfirmed intent', () => {
     // Initial server freq.
     store.setRadioState(makeMinimalState({
       revision: 1,
@@ -106,17 +106,16 @@ describe('FrequencyDisplayInteractive click-to-tune over the radio store (MOR-47
       main: { ...makeMinimalState().main, freqHz: 14074000 },
     }));
 
-    // Drive the prop through the real adapter — the overlay must SURVIVE the
-    // stale poll so this reflects the commanded freq (14100000), no flash.
+    // Old MOR-475 expectation stepped from the command intent. MOR-1403 makes
+    // the StateStore observation the sole VFO truth seen by the adapter.
     const vfo = toVfoProps(store.getRadioState(), 'main');
-    expect(vfo.freq).toBe(14100000);
+    expect(vfo.freq).toBe(14074000);
 
     const onFreqChange = vi.fn();
     const t = mountDisplay({ freq: vfo.freq, onFreqChange });
 
-    // Digits in DOM order for 14100000: MHz[1,4] kHz[1,0,0] Hz[0,0,0].
-    // The 1 kHz digit (multiplier 1000) is the 5th .digit (index 4) — re-derived
-    // against splitFrequencyToDigits/groupDigitsForDisplay for 14100000.
+    // Digits in DOM order for 14074000: MHz[1,4] kHz[0,7,4] Hz[0,0,0].
+    // The 1 kHz digit (multiplier 1000) remains index 4.
     const digits = Array.from(t.querySelectorAll<HTMLElement>('.digit'));
     const oneKhzDigit = digits[4];
     expect(oneKhzDigit).toBeDefined();
@@ -124,9 +123,9 @@ describe('FrequencyDisplayInteractive click-to-tune over the radio store (MOR-47
     oneKhzDigit.dispatchEvent(new WheelEvent('wheel', { deltaY: -1, bubbles: true }));
     flushSync();
 
-    // Relative tune steps from the commanded 14100000, not the stale 14074000.
+    // Relative tune steps from confirmed 14074000, not requested 14100000.
     expect(onFreqChange).toHaveBeenCalledTimes(1);
-    expect(onFreqChange).toHaveBeenCalledWith(14101000);
-    expect(onFreqChange).not.toHaveBeenCalledWith(14075000);
+    expect(onFreqChange).toHaveBeenCalledWith(14075000);
+    expect(onFreqChange).not.toHaveBeenCalledWith(14101000);
   });
 });

--- a/frontend/src/lib/runtime/adapters/__tests__/radio-view-model-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/radio-view-model-adapter.test.ts
@@ -271,6 +271,30 @@ describe('unobserved facts survive as the explicit unknown branch', () => {
     expect(view.vfos.filter((v) => v.isActive).map((v) => v.label)).toEqual(['MAIN A']);
   });
 
+  it('projects each newer coherent bound alias revision without client arbitration', () => {
+    const capabilities = caps({
+      vfoScheme: 'ab', receivers: 1, capabilities: SINGLE,
+      vfoReadback: 'selected_unselected',
+    });
+    for (const frequencyHz of [14_164_000, 14_130_000, 14_123_000]) {
+      const base = observedState();
+      const view = model({
+        ...base,
+        main: {
+          ...base.main,
+          freqHz: frequencyHz,
+          vfoA: slot(frequencyHz),
+          vfoB: slot(14_076_000),
+          activeSlot: 'A',
+        },
+      } as ServerState, capabilities);
+      expect(view.vfos.map((vfo) => [vfo.label, vfo.frequencyHz])).toEqual([
+        ['MAIN A', frequencyHz],
+        ['MAIN B', 14_076_000],
+      ]);
+    }
+  });
+
   // ── MOR-1335 (G4): the per-receiver active slot ─────────────────────────
   //
   // `isActive` answers "is this the ACTIVE RECEIVER's active VFO" and is

--- a/frontend/src/lib/stores/__tests__/radio.test.ts
+++ b/frontend/src/lib/stores/__tests__/radio.test.ts
@@ -556,18 +556,18 @@ describe('radio store', () => {
     expect(store.getRadioState()?.ptt).toBe(false);
   });
 
-  it('patchActiveReceiver patches MAIN when active is MAIN', () => {
+  it('patchActiveReceiver cannot overwrite StateStore-owned MAIN VFO truth', () => {
     store.setRadioState(makeState({ active: 'MAIN' }));
     store.patchActiveReceiver({ freqHz: 21074000 });
-    expect(store.getMainReceiver()?.freqHz).toBe(21074000);
+    expect(store.getMainReceiver()?.freqHz).toBe(14074000);
     // SUB should remain unchanged
     expect(store.getSubReceiver()?.freqHz).toBe(7100000);
   });
 
-  it('patchActiveReceiver patches SUB when active is SUB', () => {
+  it('patchActiveReceiver cannot overwrite StateStore-owned SUB VFO truth', () => {
     store.setRadioState(makeState({ active: 'SUB' }));
     store.patchActiveReceiver({ freqHz: 3500000 });
-    expect(store.getSubReceiver()?.freqHz).toBe(3500000);
+    expect(store.getSubReceiver()?.freqHz).toBe(7100000);
     // MAIN should remain unchanged
     expect(store.getMainReceiver()?.freqHz).toBe(14074000);
   });
@@ -587,9 +587,9 @@ describe('radio store', () => {
     expect(store.getActiveReceiver()).toBeNull();
   });
 
-  // --- freq optimistic overlay vs causal advance (MOR-475) ---
+  // --- StateStore-owned VFO truth vs legacy optimistic intent (MOR-1403) ---
 
-  it('keeps an unlocked freqHz overlay when a causally-newer DIFFERING snapshot arrives (no false clear)', () => {
+  it('shows a causally-newer differing StateStore frequency instead of unlocked intent', () => {
     store.setRadioState(makeState({
       revision: 1,
       stateRevision: 1,
@@ -598,14 +598,13 @@ describe('radio store', () => {
       main: { ...makeState().main, freqHz: 14074000 },
     }));
 
-    // Unlocked optimistic patch (click-to-tune) to a new freq.
+    // Old MOR-475 expectation: the requested frequency immediately became
+    // displayed truth. MOR-1403 assigns that fact exclusively to StateStore.
     store.patchActiveReceiver({ freqHz: 14100000 });
-    expect(store.getMainReceiver()?.freqHz).toBe(14100000);
+    expect(store.getMainReceiver()?.freqHz).toBe(14074000);
 
-    // Server emits a causally-newer snapshot (observationSeq + freshnessRevision
-    // advance) reporting a DIFFERENT freq well outside the 500 Hz tolerance.
-    // This is the classic in-flight stale poll: causal advance alone must NOT
-    // drop the unlocked overlay, or the commanded freq would flash away.
+    // A confirmed radio-side value owns the display even when it contradicts
+    // the requested intent.
     store.setRadioState(makeState({
       revision: 1,
       stateRevision: 1,
@@ -614,13 +613,11 @@ describe('radio store', () => {
       main: { ...makeState().main, freqHz: 14200000 },
     }));
 
-    // The overlay must HOLD the commanded value — value-match (tolerance) or the
-    // freq TTL are the only legitimate clear conditions, not a bare causal advance.
-    expect(store.getMainReceiver()?.freqHz).toBe(14100000);
-    expect(store.getFrequency()).toBe(14100000);
+    expect(store.getMainReceiver()?.freqHz).toBe(14200000);
+    expect(store.getFrequency()).toBe(14200000);
   });
 
-  it('does not flash the stale freq: unlocked overlay survives an in-flight causal stale poll, clears on value-match', () => {
+  it('changes VFO truth only when each confirmed StateStore observation arrives', () => {
     store.setRadioState(makeState({
       revision: 1,
       stateRevision: 1,
@@ -629,13 +626,11 @@ describe('radio store', () => {
       main: { ...makeState().main, freqHz: 14074000 },
     }));
 
-    // Click-to-tune: unlocked optimistic patch to the commanded freq.
+    // Intent alone is not radio truth.
     store.patchActiveReceiver({ freqHz: 14100000 });
-    expect(store.getMainReceiver()?.freqHz).toBe(14100000);
+    expect(store.getMainReceiver()?.freqHz).toBe(14074000);
 
-    // An in-flight poll captured BEFORE the click lands: causally newer
-    // (observationSeq + freshnessRevision advance) but still carrying the OLD freq.
-    // The overlay must survive — otherwise the display flashes the stale 14074000.
+    // A newer observation carrying the same value remains the displayed fact.
     store.setRadioState(makeState({
       revision: 1,
       stateRevision: 1,
@@ -643,10 +638,9 @@ describe('radio store', () => {
       freshnessRevision: 2,
       main: { ...makeState().main, freqHz: 14074000 },
     }));
-    expect(store.getMainReceiver()?.freqHz).toBe(14100000);
+    expect(store.getMainReceiver()?.freqHz).toBe(14074000);
 
-    // The backend (post MOR-484) now reports the live commanded freq: value-match
-    // within tolerance clears the overlay and the display equals the server value.
+    // The confirmed readback then advances the display.
     store.setRadioState(makeState({
       revision: 1,
       stateRevision: 1,
@@ -657,7 +651,7 @@ describe('radio store', () => {
     expect(store.getMainReceiver()?.freqHz).toBe(14100000);
   });
 
-  it('keeps a locked freqHz overlay despite a causally-newer differing snapshot', () => {
+  it('does not let a locked VFO intent hide a newer StateStore observation', () => {
     store.setRadioState(makeState({
       revision: 1,
       stateRevision: 1,
@@ -666,9 +660,9 @@ describe('radio store', () => {
       main: { ...makeState().main, freqHz: 14074000 },
     }));
 
-    // Locked optimistic patch (rapid input) — must survive the lock window.
+    // Legacy lock metadata cannot own a displayed radio fact.
     store.patchActiveReceiver({ freqHz: 14100000 }, true);
-    expect(store.getMainReceiver()?.freqHz).toBe(14100000);
+    expect(store.getMainReceiver()?.freqHz).toBe(14074000);
 
     // Causally-newer differing snapshot arrives within the lock window.
     store.setRadioState(makeState({
@@ -679,11 +673,10 @@ describe('radio store', () => {
       main: { ...makeState().main, freqHz: 14150000 },
     }));
 
-    // Lock holds: causal advance must NOT override a locked overlay.
-    expect(store.getMainReceiver()?.freqHz).toBe(14100000);
+    expect(store.getMainReceiver()?.freqHz).toBe(14150000);
   });
 
-  it('falls back to server freq after the lowered freq TTL with no causal advance', () => {
+  it('does not give VFO intent a TTL ownership window over StateStore', () => {
     vi.useFakeTimers();
     store.setRadioState(makeState({
       revision: 1,
@@ -693,9 +686,9 @@ describe('radio store', () => {
       main: { ...makeState().main, freqHz: 14074000 },
     }));
 
-    // Unlocked freq patch.
+    // VFO intent never becomes observed radio truth, before or after any TTL.
     store.patchActiveReceiver({ freqHz: 14100000 });
-    expect(store.getMainReceiver()?.freqHz).toBe(14100000);
+    expect(store.getMainReceiver()?.freqHz).toBe(14074000);
 
     // Advance past the lowered freq TTL (1500ms) but under the old 5000ms TTL.
     vi.advanceTimersByTime(2000);
@@ -709,7 +702,7 @@ describe('radio store', () => {
       main: { ...makeState().main, freqHz: 14080000 },
     }));
 
-    // Freq TTL elapsed → server value wins.
+    // The next accepted StateStore revision is visible immediately.
     expect(store.getMainReceiver()?.freqHz).toBe(14080000);
 
     vi.useRealTimers();

--- a/frontend/src/lib/stores/radio.isolated.test.ts
+++ b/frontend/src/lib/stores/radio.isolated.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { radio, setRadioState, resetRadioState, getRadioState, getLastRevision } from './radio.svelte';
+import {
+  radio,
+  setRadioState,
+  resetRadioState,
+  getRadioState,
+  getLastRevision,
+  patchActiveReceiver,
+} from './radio.svelte';
 import type { ServerState } from '../types/state';
 
 function makeState(revision: number): ServerState {
@@ -79,5 +86,55 @@ describe('resetRadioState', () => {
     setRadioState(makeState(5));
     resetRadioState();
     expect(getRadioState()).toBeNull();
+  });
+});
+
+describe('StateStore-only VFO truth', () => {
+  beforeEach(() => resetRadioState());
+
+  it('does not let VFO optimistic patches overwrite the observed snapshot', () => {
+    const initial = makeState(10);
+    initial.main.activeSlot = 'A';
+    setRadioState(initial);
+
+    patchActiveReceiver({
+      freqHz: 14_200_000,
+      mode: 'LSB',
+      filter: 2,
+      dataMode: 1,
+      activeSlot: 'B',
+    }, true);
+
+    expect(getRadioState()?.main).toMatchObject({
+      freqHz: 14_074_000,
+      mode: 'USB',
+      filter: 1,
+      dataMode: 0,
+      activeSlot: 'A',
+    });
+
+    const observed = makeState(11);
+    Object.assign(observed.main, {
+      freqHz: 14_123_000,
+      mode: 'CW',
+      filter: 3,
+      dataMode: 1,
+      activeSlot: 'B',
+    });
+    setRadioState(observed);
+    expect(getRadioState()?.main).toMatchObject({
+      freqHz: 14_123_000,
+      mode: 'CW',
+      filter: 3,
+      dataMode: 1,
+      activeSlot: 'B',
+    });
+  });
+
+  it('retains optimistic support for non-VFO fields outside MOR-1403', () => {
+    setRadioState(makeState(20));
+
+    patchActiveReceiver({ afLevel: 42 }, true);
+    expect(getRadioState()?.main.afLevel).toBe(42);
   });
 });

--- a/frontend/src/lib/stores/radio.svelte.ts
+++ b/frontend/src/lib/stores/radio.svelte.ts
@@ -98,6 +98,14 @@ const optimisticSub = new Map<string, { value: unknown; expires: number; serverV
 // Kept until server confirms or TTL expires.
 const optimisticTopLevel = new Map<string, { value: unknown; expires: number }>();
 
+// VFO readouts are observed radio truth. Commands may be pending elsewhere,
+// but their requested values must never cover a newer StateStore snapshot.
+// MOR-1405 owns removal of the remaining non-VFO optimistic surfaces.
+const VFO_TRUTH_FIELDS = new Set([
+  'freqHz', 'mode', 'filter', 'dataMode', 'activeSlot',
+  'vfoA', 'vfoB', 'unselectedVfo', 'filterWidth', 'filterShape',
+]);
+
 // Top-level structural keys that should never be held optimistically
 const STRUCTURAL_KEYS = new Set(['revision', 'main', 'sub', 'active', 'connection', 'updatedAt']);
 
@@ -112,6 +120,11 @@ function applyOptimistic(state: ServerState): ServerState {
     const rx = { ...serverRx };
     let changed = false;
     for (const [field, entry] of map) {
+      if (VFO_TRUTH_FIELDS.has(field)) {
+        map.delete(field);
+        lockedFields.delete(`${key}.${field}`);
+        continue;
+      }
       // Check if field is locked (rapid input protection)
       const lockKey = `${key}.${field}`;
       const lockExpires = lockedFields.get(lockKey);
@@ -266,8 +279,10 @@ export function patchActiveReceiver(patch: Partial<ReceiverState>, lock = false)
   const key = s.active === 'SUB' ? 'sub' : 'main';
   const map = key === 'sub' ? optimisticSub : optimisticMain;
   const currentRx = s[key];
+  const accepted: Partial<ReceiverState> = {};
 
   for (const [field, value] of Object.entries(patch)) {
+    if (VFO_TRUTH_FIELDS.has(field)) continue;
     // Skip updating locked fields from WS echo (preserve user input lock)
     const lockKey = `${key}.${field}`;
     const lockExpires = lockedFields.get(lockKey);
@@ -283,10 +298,12 @@ export function patchActiveReceiver(patch: Partial<ReceiverState>, lock = false)
     }
     const expires = Date.now() + (field === 'freqHz' ? OPTIMISTIC_FREQ_TTL : OPTIMISTIC_TTL);
     map.set(field, { value, expires, serverValueAtPatch: (currentRx as any)[field] });
+    (accepted as any)[field] = value;
   }
+  if (Object.keys(accepted).length === 0) return;
   radio.current = {
     ...s,
-    [key]: { ...s[key], ...patch },
+    [key]: { ...s[key], ...accepted },
   };
   notifyRadioStateSubscribers();
 }
@@ -302,8 +319,10 @@ export function patchReceiver(receiver: 0 | 1, patch: Partial<ReceiverState>, lo
   const key = receiver === 1 ? 'sub' : 'main';
   const map = key === 'sub' ? optimisticSub : optimisticMain;
   const currentRx = s[key];
+  const accepted: Partial<ReceiverState> = {};
 
   for (const [field, value] of Object.entries(patch)) {
+    if (VFO_TRUTH_FIELDS.has(field)) continue;
     const lockKey = `${key}.${field}`;
     const lockExpires = lockedFields.get(lockKey);
     if (lockExpires && Date.now() < lockExpires && !lock) {
@@ -314,10 +333,12 @@ export function patchReceiver(receiver: 0 | 1, patch: Partial<ReceiverState>, lo
     }
     const expires = Date.now() + (field === 'freqHz' ? OPTIMISTIC_FREQ_TTL : OPTIMISTIC_TTL);
     map.set(field, { value, expires, serverValueAtPatch: (currentRx as any)[field] });
+    (accepted as any)[field] = value;
   }
+  if (Object.keys(accepted).length === 0) return;
   radio.current = {
     ...s,
-    [key]: { ...s[key], ...patch },
+    [key]: { ...s[key], ...accepted },
   };
   notifyRadioStateSubscribers();
 }

--- a/src/rigplane/core/state_store.py
+++ b/src/rigplane/core/state_store.py
@@ -15,6 +15,7 @@ from rigplane.core.state_pipeline_contracts import (
     FieldPath,
     Observation,
     SourceMetadata,
+    VfoSlot,
 )
 
 _DEFAULT_MAX_HISTORY_COUNT = 4096
@@ -278,7 +279,9 @@ class StateStore:
             and observation.path in retention.paths
             and observation.source.provider == "vfo_binding"
         ):
-            retention.pending.clear()
+            return self.apply_relative_vfo_observations(
+                (observation,), generation=retention.generation
+            )
         return self._apply_one(observation)
 
     def _apply_one(self, observation: Observation) -> ChangeSet:
@@ -402,7 +405,7 @@ class StateStore:
         retention.generation = generation
         retention.pending.clear()
         retention.expires_at = None
-        return self.discard(retention.paths)
+        return self.discard(self._relative_vfo_session_paths(retention))
 
     def apply_relative_vfo_observations(
         self,
@@ -488,7 +491,11 @@ class StateStore:
                 <= retention.coherence_window
             )
             changesets.append(self.discard(retention.paths))
-            changesets.append(self._apply_observation_batch(committed))
+            changesets.append(
+                self._apply_observation_batch(
+                    self._with_bound_relative_vfo_aliases(committed)
+                )
+            )
         else:
             immediate = tuple(
                 replace(
@@ -497,7 +504,11 @@ class StateStore:
                 )
                 for item in relative
             )
-            changesets.append(self._apply_observation_batch(immediate))
+            changesets.append(
+                self._apply_observation_batch(
+                    self._with_bound_relative_vfo_aliases(immediate)
+                )
+            )
             if not complete:
                 return self._merge_changesets(changesets)
             retention.expires_at = max(required_times) + retention.max_age
@@ -505,9 +516,82 @@ class StateStore:
                 entry = self._entries.get(path)
                 if entry is not None:
                     entry.max_age = retention.expires_at - entry.last_observed_monotonic
+                alias_path = self._bound_relative_vfo_alias_path(path)
+                alias_entry = (
+                    None if alias_path is None else self._entries.get(alias_path)
+                )
+                if alias_entry is not None:
+                    alias_entry.max_age = (
+                        retention.expires_at - alias_entry.last_observed_monotonic
+                    )
 
         retention.pending.clear()
         return self._merge_changesets(changesets)
+
+    def _relative_vfo_session_paths(
+        self,
+        retention: _RelativeVfoRetention,
+    ) -> frozenset[FieldPath]:
+        """Return relative values plus all identity-bound aliases for reset."""
+
+        receiver_ids = {
+            path.receiver_id for path in retention.paths if path.receiver_id is not None
+        }
+        identity = {
+            path
+            for receiver_id in receiver_ids
+            for path in (
+                FieldPath.active_slot(receiver_id),
+                *(
+                    FieldPath.vfo_slot(receiver_id, slot, "freq_mode", name)
+                    for slot in ("A", "B")
+                    for name in ("freq_hz", "mode", "filter_num", "data_mode")
+                ),
+            )
+        }
+        return retention.paths | frozenset(identity)
+
+    def _bound_relative_vfo_alias_path(
+        self,
+        path: FieldPath,
+    ) -> FieldPath | None:
+        """Map one relative path through current observed A/B identity."""
+
+        if path.receiver_id is None or path.slot not in {
+            VfoSlot.ACTIVE,
+            VfoSlot.UNSELECTED,
+        }:
+            return None
+        binding = self._entries.get(FieldPath.active_slot(path.receiver_id))
+        if (
+            binding is None
+            or binding.freshness is not FreshnessState.FRESH
+            or binding.value not in {"A", "B"}
+        ):
+            return None
+        selected_slot = str(binding.value)
+        slot = (
+            selected_slot
+            if path.slot is VfoSlot.ACTIVE
+            else "B"
+            if selected_slot == "A"
+            else "A"
+        )
+        return FieldPath.vfo_slot(path.receiver_id, slot, path.family.value, path.name)
+
+    def _with_bound_relative_vfo_aliases(
+        self,
+        observations: tuple[Observation, ...],
+    ) -> tuple[Observation, ...]:
+        """Mirror confirmed relative leaves into bound aliases in one batch."""
+
+        expanded: list[Observation] = []
+        for observation in observations:
+            expanded.append(observation)
+            alias_path = self._bound_relative_vfo_alias_path(observation.path)
+            if alias_path is not None:
+                expanded.append(replace(observation, path=alias_path))
+        return tuple(expanded)
 
     def _expire_relative_vfo(self, *, now: float) -> tuple[FieldPath, ...]:
         retention = self._relative_vfo_retention

--- a/src/rigplane/core/state_store.py
+++ b/src/rigplane/core/state_store.py
@@ -271,14 +271,16 @@ class StateStore:
         self._history_floor_freshness_revision = 0
 
     def apply(self, observation: Observation) -> ChangeSet:
-        """Apply one confirmed observation and return its state ChangeSet."""
+        """Apply one synchronous/current-provider observation.
+
+        Generation-bearing producers must use
+        :meth:`apply_relative_vfo_observations`; the generic callers that can
+        supply relative VFO paths are synchronous command/readback boundaries
+        and therefore have no detached producer generation to relabel here.
+        """
 
         retention = self._relative_vfo_retention
-        if (
-            retention is not None
-            and observation.path in retention.paths
-            and observation.source.provider == "vfo_binding"
-        ):
+        if retention is not None and observation.path in retention.paths:
             return self.apply_relative_vfo_observations(
                 (observation,), generation=retention.generation
             )

--- a/src/rigplane/core/state_store.py
+++ b/src/rigplane/core/state_store.py
@@ -601,7 +601,12 @@ class StateStore:
             return ()
         retention.expires_at = None
         retention.pending.clear()
-        return tuple(retention.paths)
+        aliases = {
+            alias
+            for path in retention.paths
+            if (alias := self._bound_relative_vfo_alias_path(path)) is not None
+        }
+        return tuple(retention.paths | aliases)
 
     def _apply_observation_batch(
         self,
@@ -699,13 +704,13 @@ class StateStore:
         requests: list[ReconciliationRequest] = []
         relative_due = set(self._expire_relative_vfo(now=timestamp))
         for path, entry in sorted(self._entries.items(), key=lambda item: str(item[0])):
-            if entry.freshness is not FreshnessState.FRESH or entry.max_age is None:
+            if entry.freshness is not FreshnessState.FRESH:
                 continue
-            if (
-                path not in relative_due
-                and timestamp - entry.last_observed_monotonic <= entry.max_age
-            ):
-                continue
+            if path not in relative_due:
+                if entry.max_age is None:
+                    continue
+                if timestamp - entry.last_observed_monotonic <= entry.max_age:
+                    continue
 
             self._freshness_revision += 1
             entry.freshness = FreshnessState.STALE

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -3119,9 +3119,9 @@ class RadioPoller:
             if generation != self._vfo_binding_generation:
                 return
             receiver_id = str(receiver)
-            for state, relative_slot, absolute_slot in (
-                (selected, "selected", slot),
-                (unselected, "unselected", "B" if slot == "A" else "A"),
+            for state, relative_slot in (
+                (selected, "selected"),
+                (unselected, "unselected"),
             ):
                 for name in self._relative_vfo_fields():
                     value = getattr(state, name)
@@ -3131,12 +3131,6 @@ class RadioPoller:
                         else FieldPath.unselected(receiver_id, "freq_mode", name)
                     )
                     apply(relative_path, value)
-                    apply(
-                        FieldPath.vfo_slot(
-                            receiver_id, absolute_slot, "freq_mode", name
-                        ),
-                        value,
-                    )
             logger.info(
                 "radio-poller: confirmed VFO slot=%s receiver=%d generation=%d",
                 slot,

--- a/tests/test_bsr_band_switching.py
+++ b/tests/test_bsr_band_switching.py
@@ -11,12 +11,18 @@ Covers:
 
 from __future__ import annotations
 
+import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from rigplane.profiles import resolve_radio_profile
+from rigplane.core.state_pipeline_contracts import (
+    FieldPath,
+    Observation,
+    SourceMetadata,
+)
 from rigplane.radio_state import RadioState
 from rigplane.rigctld.state_cache import StateCache
 from rigplane.web.radio_poller import (
@@ -119,6 +125,45 @@ def _bsr_response_frame(
     )
 
 
+def _bootstrap_selected_unselected(poller: RadioPoller) -> None:
+    observed_at = time.monotonic()
+    source = SourceMetadata(
+        source="poll_response",
+        provider="test",
+        transport="fake",
+        native_id="initial_vfo_pair",
+    )
+    pair = tuple(
+        Observation(
+            path=path,
+            value=value,
+            source=source,
+            timestamp_monotonic=observed_at,
+        )
+        for path, value in (
+            (FieldPath.active("0", "freq_mode", "freq_hz"), 14_190_000),
+            (FieldPath.active("0", "freq_mode", "mode"), "USB"),
+            (FieldPath.unselected("0", "freq_mode", "freq_hz"), 14_075_000),
+            (FieldPath.unselected("0", "freq_mode", "mode"), "USB"),
+        )
+    )
+    generation = poller._provider_generation()  # noqa: SLF001
+    poller._state_store.apply_relative_vfo_observations(  # noqa: SLF001
+        pair, generation=generation
+    )
+    poller._state_store.apply(  # noqa: SLF001
+        Observation(
+            path=FieldPath.active_slot("0"),
+            value="A",
+            source=source,
+            timestamp_monotonic=observed_at,
+        )
+    )
+    poller._state_store.apply_relative_vfo_observations(  # noqa: SLF001
+        pair, generation=generation
+    )
+
+
 # ---------------------------------------------------------------------------
 # SetBand handler tests
 # ---------------------------------------------------------------------------
@@ -153,6 +198,7 @@ class TestSetBandBSRRecall:
         radio.send_civ = AsyncMock(return_value=bsr_resp)
 
         poller = _make_poller(radio, model="IC-7300")
+        _bootstrap_selected_unselected(poller)
         snapshot_before = poller._state_store.snapshot()  # noqa: SLF001
 
         await poller._execute(SetBand(band=3))  # noqa: SLF001
@@ -169,8 +215,58 @@ class TestSetBandBSRRecall:
         assert mode_field.source.source == "poll_response"
         assert mode_field.source.provider == "web_poller"
         assert mode_field.source.native_id == "bsr_readback"
+        assert (
+            snapshot_after.field("receiver.0.slot.A.freq_mode.freq_hz").value == 7207000
+        )
+        assert snapshot_after.field("receiver.0.slot.A.freq_mode.mode").value == "LSB"
         assert poller._radio_state.main.freq == 7207000  # noqa: SLF001
         assert poller._radio_state.main.mode == "LSB"  # noqa: SLF001
+
+    @pytest.mark.asyncio
+    async def test_bsr_readback_stages_until_initial_pair_is_complete(self) -> None:
+        radio = _make_radio(model="IC-7300")
+        freq_bcd = b"\x00\x70\x20\x07\x00"  # 7207000 in BCD
+        radio.send_civ = AsyncMock(
+            return_value=_bsr_response_frame(0x03, 0x01, freq_bcd, 0x00, 0x01)
+        )
+        poller = _make_poller(radio, model="IC-7300")
+
+        await poller._execute(SetBand(band=3))  # noqa: SLF001
+
+        assert poller._state_store.snapshot().fields == ()  # noqa: SLF001
+        observed_at = time.monotonic()
+        source = SourceMetadata(
+            source="poll_response",
+            provider="test",
+            transport="fake",
+            native_id="initial_unselected_pair",
+        )
+        poller._state_store.apply_relative_vfo_observations(  # noqa: SLF001
+            (
+                Observation(
+                    path=FieldPath.unselected("0", "freq_mode", "freq_hz"),
+                    value=14_075_000,
+                    source=source,
+                    timestamp_monotonic=observed_at,
+                ),
+                Observation(
+                    path=FieldPath.unselected("0", "freq_mode", "mode"),
+                    value="USB",
+                    source=source,
+                    timestamp_monotonic=observed_at,
+                ),
+            ),
+            generation=poller._provider_generation(),  # noqa: SLF001
+        )
+
+        snapshot = poller._state_store.snapshot()  # noqa: SLF001
+        assert snapshot.field("receiver.0.active.freq_mode.freq_hz").value == 7207000
+        assert snapshot.field("receiver.0.active.freq_mode.mode").value == "LSB"
+        assert (
+            snapshot.field("receiver.0.unselected.freq_mode.freq_hz").value
+            == 14_075_000
+        )
+        assert snapshot.field("receiver.0.unselected.freq_mode.mode").value == "USB"
 
     @pytest.mark.asyncio
     async def test_bsr_recall_emits_events(self) -> None:

--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -53,7 +53,11 @@ from rigplane.core.state_acquisition_policy import (
     RadioAcquisitionProfile,
 )
 from rigplane.core.state_diagnostics import StateDiagnosticsRecorder
-from rigplane.core.state_pipeline_contracts import FieldPath
+from rigplane.core.state_pipeline_contracts import (
+    FieldPath,
+    Observation,
+    SourceMetadata,
+)
 from rigplane.exceptions import ConnectionError
 from rigplane.profiles import resolve_radio_profile
 from rigplane.radio import IcomRadio
@@ -152,21 +156,59 @@ async def test_relative_vfo_ingress_bootstraps_then_transceive_patches_immediate
             generation=radio._civ_epoch,  # noqa: SLF001
         )
 
+    # The explicit A selection is already ACK-confirmed at this boundary.
+    # Replaying the existing relative readback binds both aliases without any
+    # select/swap/write side path.
+    radio._state_store.apply(  # noqa: SLF001
+        Observation(
+            path=FieldPath.active_slot("0"),
+            value="A",
+            source=SourceMetadata(
+                source="command_response",
+                provider="vfo_binding",
+                native_id="explicit_slot_ack_readback",
+            ),
+            timestamp_monotonic=time.monotonic(),
+        )
+    )
+    for frame in (
+        _make_frame(cmd=0x25, data=b"\x00" + bcd_encode(14_284_000)),
+        _make_frame(cmd=0x26, data=bytes([0, Mode.USB.value, 0, 1])),
+        _make_frame(cmd=0x25, data=b"\x01" + bcd_encode(14_075_000)),
+        _make_frame(cmd=0x26, data=bytes([1, Mode.USB.value, 0, 1])),
+    ):
+        await radio._civ_runtime._route_civ_frame(  # noqa: SLF001
+            frame,
+            generation=radio._civ_epoch,  # noqa: SLF001
+        )
+
     before = radio._state_store.snapshot()  # noqa: SLF001
     old_mode = before.field("receiver.0.active.freq_mode.mode")
     old_unselected = before.field("receiver.0.unselected.freq_mode.freq_hz")
-    await radio._civ_runtime._route_civ_frame(  # noqa: SLF001
-        _make_frame(
-            cmd=0x00,
-            data=bcd_encode(14_285_000),
-            to_addr=0x00,
-        ),
-        generation=radio._civ_epoch,  # noqa: SLF001
-    )
+    old_b = before.field("receiver.0.slot.B.freq_mode.freq_hz")
+    for frequency in (14_130_000, 14_123_000):
+        await radio._civ_runtime._route_civ_frame(  # noqa: SLF001
+            _make_frame(
+                cmd=0x00,
+                data=bcd_encode(frequency),
+                to_addr=0x00,
+            ),
+            generation=radio._civ_epoch,  # noqa: SLF001
+        )
+        same_revision = radio._state_store.snapshot()  # noqa: SLF001
+        assert (
+            same_revision.field("receiver.0.active.freq_mode.freq_hz").value
+            == frequency
+        )
+        assert (
+            same_revision.field("receiver.0.slot.A.freq_mode.freq_hz").value
+            == frequency
+        )
+        assert same_revision.field(old_b.path).value == old_b.value
 
     after = radio._state_store.snapshot()  # noqa: SLF001
     knob = after.field("receiver.0.active.freq_mode.freq_hz")
-    assert knob.value == 14_285_000
+    assert knob.value == 14_123_000
     assert knob.source.source == "civ_unsolicited"
     assert knob.last_observed_monotonic > old_mode.last_observed_monotonic
     assert after.field(old_mode.path).value == old_mode.value

--- a/tests/test_command_service.py
+++ b/tests/test_command_service.py
@@ -130,6 +130,62 @@ async def test_execute_emits_lifecycle_events_and_applies_response_observations(
     assert service.pending_overlays(source="websocket", session_id="ws-a") == ()
 
 
+def test_apply_observation_projects_relative_web_command_to_bound_vfo() -> None:
+    clock = FreshnessClock(start=10.0)
+    store = StateStore(freshness_clock=clock)
+    store.configure_relative_vfo_retention(
+        generation=1,
+        max_age=30.0,
+        coherence_window=5.0,
+    )
+    relative = (
+        _observation(
+            FieldPath.active("0", "freq_mode", "freq_hz"), 14_190_000, at=10.0
+        ),
+        _observation(FieldPath.active("0", "freq_mode", "mode"), "USB", at=10.1),
+        _observation(
+            FieldPath.unselected("0", "freq_mode", "freq_hz"),
+            14_075_000,
+            at=10.2,
+        ),
+        _observation(FieldPath.unselected("0", "freq_mode", "mode"), "USB", at=10.3),
+    )
+    store.apply_relative_vfo_observations(relative, generation=1)
+    store.apply(_observation(FieldPath.active_slot("0"), "A", at=10.4))
+    store.apply_relative_vfo_observations(relative, generation=1)
+    service = CommandService(
+        executor=FakeExecutor(),
+        state_store=store,
+        clock=clock.now,
+    )
+    command = Observation(
+        path=FieldPath.active("0", "freq_mode", "freq_hz"),
+        value=14_130_000,
+        source=SourceMetadata(
+            source="command_response",
+            provider="web_command",
+            transport="websocket",
+            command_source="websocket",
+            session_id="ws-a",
+        ),
+        timestamp_monotonic=11.0,
+        correlation_id="spectrum-drag",
+    )
+
+    changeset = service.apply_observation(command)
+    snapshot = store.snapshot()
+
+    assert {change.path for change in changeset.changes} == {
+        command.path,
+        FieldPath.vfo_slot("0", "A", "freq_mode", "freq_hz"),
+    }
+    assert snapshot.field(command.path).value == 14_130_000
+    assert (
+        snapshot.field(FieldPath.vfo_slot("0", "A", "freq_mode", "freq_hz")).value
+        == 14_130_000
+    )
+
+
 @pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_execute_acknowledges_without_confirming_state_when_executor_has_no_observation() -> (
     None

--- a/tests/test_state_store.py
+++ b/tests/test_state_store.py
@@ -12,6 +12,7 @@ from rigplane.core.state_pipeline_contracts import (
     FieldPath,
     Observation,
     SourceMetadata,
+    VfoSlot,
 )
 from rigplane.core.acquisition_scheduler import (
     AcquisitionPriority,
@@ -232,6 +233,199 @@ def test_relative_vfo_bootstrap_is_atomic_then_live_leaves_patch_immediately() -
     assert patched.field("receiver.0.active.freq_mode.filter_num").value == 2
     assert patched.field("receiver.0.active.freq_mode.data_mode").value == 1
     assert _relative_vfo_deadline(store) == pytest.approx(131.6)
+
+
+@pytest.mark.parametrize("active_slot", ["A", "B"])
+@pytest.mark.parametrize("source", ["civ_unsolicited", "command_response"])
+def test_bound_relative_vfo_leaf_updates_matching_absolute_alias_atomically(
+    active_slot: str,
+    source: str,
+) -> None:
+    clock = FreshnessClock(start=100.0)
+    store = StateStore(freshness_clock=clock)
+    store.configure_relative_vfo_retention(
+        generation=7,
+        max_age=31.0,
+        coherence_window=5.0,
+    )
+    store.apply_relative_vfo_observations(
+        _relative_vfo_observations(at=100.0), generation=7
+    )
+    store.apply(_observation(FieldPath.active_slot("0"), active_slot, at=100.1))
+
+    selected_slot = active_slot
+    unselected_slot = "B" if active_slot == "A" else "A"
+    for relative, absolute, values in (
+        ("active", selected_slot, (14_130_000, "LSB", 2, 1)),
+        ("unselected", unselected_slot, (14_076_000, "CW", 3, 1)),
+    ):
+        paths = tuple(
+            (
+                FieldPath.active("0", "freq_mode", name)
+                if relative == "active"
+                else FieldPath.unselected("0", "freq_mode", name)
+            )
+            for name in ("freq_hz", "mode", "filter_num", "data_mode")
+        )
+        observations = tuple(
+            _observation(path, value, at=101.0, max_age=5.0, source=source)
+            for path, value in zip(paths, values, strict=True)
+        )
+        before = store.snapshot()
+        changeset = store.apply_relative_vfo_observations(observations, generation=7)
+        after = store.snapshot()
+
+        assert changeset.revision == after.state_revision
+        assert after.state_revision == before.state_revision + 8
+        for path, value in zip(paths, values, strict=True):
+            relative_field = after.field(path)
+            alias_path = FieldPath.vfo_slot("0", absolute, "freq_mode", path.name)
+            alias_field = after.field(alias_path)
+            assert alias_field.value == value == relative_field.value
+            assert alias_field.source == relative_field.source
+            assert (
+                alias_field.last_observed_monotonic
+                == relative_field.last_observed_monotonic
+            )
+            assert alias_field.max_age == relative_field.max_age
+            assert alias_path in changeset.observed_paths
+            assert path in changeset.observed_paths
+
+    snapshot = store.snapshot()
+    assert (
+        snapshot.field(
+            FieldPath.vfo_slot("0", selected_slot, "freq_mode", "freq_hz")
+        ).value
+        == 14_130_000
+    )
+    assert (
+        snapshot.field(
+            FieldPath.vfo_slot("0", unselected_slot, "freq_mode", "freq_hz")
+        ).value
+        == 14_076_000
+    )
+
+
+def test_bound_relative_vfo_aliases_expire_and_old_generation_cannot_repopulate() -> (
+    None
+):
+    clock = FreshnessClock(start=10.0)
+    store = StateStore(freshness_clock=clock)
+    store.configure_relative_vfo_retention(
+        generation=1,
+        max_age=20.0,
+        coherence_window=5.0,
+    )
+    store.apply_relative_vfo_observations(
+        _relative_vfo_observations(at=10.0), generation=1
+    )
+    store.apply(_observation(FieldPath.active_slot("0"), "A", at=10.1))
+    knob = _observation(
+        FieldPath.active("0", "freq_mode", "freq_hz"),
+        14_130_000,
+        at=11.0,
+        max_age=5.0,
+        source="civ_unsolicited",
+    )
+    store.apply_relative_vfo_observations((knob,), generation=1)
+    alias = FieldPath.vfo_slot("0", "A", "freq_mode", "freq_hz")
+    assert store.snapshot().field(alias).value == 14_130_000
+
+    store.reset_relative_vfo_retention(generation=2)
+    store.discard((FieldPath.active_slot("0"), alias))
+    store.apply_relative_vfo_observations(
+        (replace(knob, value=14_123_000),), generation=1
+    )
+
+    with pytest.raises(KeyError):
+        store.snapshot().field(alias)
+
+
+def test_bound_relative_vfo_alias_shares_complete_pair_expiry() -> None:
+    clock = FreshnessClock(start=10.0)
+    store = StateStore(freshness_clock=clock)
+    store.configure_relative_vfo_retention(
+        generation=1,
+        max_age=20.0,
+        coherence_window=5.0,
+    )
+    store.apply_relative_vfo_observations(
+        _relative_vfo_observations(at=10.0), generation=1
+    )
+    store.apply(_observation(FieldPath.active_slot("0"), "A", at=10.1))
+    store.apply_relative_vfo_observations(
+        (
+            _observation(
+                FieldPath.active("0", "freq_mode", "freq_hz"),
+                14_130_000,
+                at=11.0,
+                max_age=5.0,
+                source="civ_unsolicited",
+            ),
+        ),
+        generation=1,
+    )
+    alias = FieldPath.vfo_slot("0", "A", "freq_mode", "freq_hz")
+    relative = FieldPath.active("0", "freq_mode", "freq_hz")
+    assert (
+        store.snapshot().field(alias).max_age
+        == store.snapshot().field(relative).max_age
+    )
+
+    clock.advance(20.7)
+    store.mark_stale_due()
+    snapshot = store.snapshot()
+    assert snapshot.field(relative).freshness is FreshnessState.STALE
+    assert snapshot.field(alias).freshness is FreshnessState.STALE
+
+
+def test_explicit_binding_readback_uses_same_retention_and_alias_semantics() -> None:
+    clock = FreshnessClock(start=50.0)
+    store = StateStore(freshness_clock=clock)
+    store.configure_relative_vfo_retention(
+        generation=3,
+        max_age=20.0,
+        coherence_window=5.0,
+    )
+    store.apply_relative_vfo_observations(
+        _relative_vfo_observations(at=50.0), generation=3
+    )
+    store.apply(_observation(FieldPath.active_slot("0"), "A", at=51.0))
+    binding_source = SourceMetadata(
+        source="command_response",
+        provider="vfo_binding",
+        transport="fake",
+        native_id="explicit_slot_ack_readback",
+    )
+    binding = tuple(
+        replace(item, source=binding_source, timestamp_monotonic=51.0)
+        for item in _relative_vfo_observations(
+            at=51.0,
+            selected_freq=14_164_000,
+            unselected_freq=14_076_000,
+        )
+    )
+    for observation in binding:
+        store.apply(observation)
+
+    snapshot = store.snapshot()
+    for relative_slot, absolute_slot in (
+        (VfoSlot.ACTIVE, "A"),
+        (VfoSlot.UNSELECTED, "B"),
+    ):
+        for name in ("freq_hz", "mode", "filter_num", "data_mode"):
+            relative = next(
+                field
+                for field in snapshot.fields
+                if field.path.slot is relative_slot and field.path.name == name
+            )
+            alias = snapshot.field(
+                FieldPath.vfo_slot("0", absolute_slot, "freq_mode", name)
+            )
+            assert alias.value == relative.value
+            assert alias.source == relative.source == binding_source
+            assert alias.max_age == relative.max_age
+            assert alias.max_age is not None
 
 
 def test_relative_vfo_mandatory_bootstrap_is_atomic_in_every_arrival_order() -> None:

--- a/tests/test_state_store.py
+++ b/tests/test_state_store.py
@@ -306,6 +306,167 @@ def test_bound_relative_vfo_leaf_updates_matching_absolute_alias_atomically(
     )
 
 
+@pytest.mark.parametrize(
+    ("radio_frequency", "command_steps"),
+    (
+        (14_190_000, (14_185_000, 14_170_000, 14_150_000, 14_130_000)),
+        (14_210_000, (14_205_000, 14_195_000, 14_185_000, 14_180_000)),
+    ),
+)
+def test_web_command_frequency_trace_updates_bound_alias_without_civ_catchup(
+    radio_frequency: int,
+    command_steps: tuple[int, ...],
+) -> None:
+    store = StateStore()
+    store.configure_relative_vfo_retention(
+        generation=1,
+        max_age=30.0,
+        coherence_window=5.0,
+    )
+    base = _relative_vfo_observations(at=10.0, selected_freq=radio_frequency)
+    store.apply_relative_vfo_observations(base, generation=1)
+    store.apply(_observation(FieldPath.active_slot("0"), "A", at=10.7))
+    store.apply_relative_vfo_observations(base, generation=1)
+    sibling = store.snapshot().field(
+        FieldPath.vfo_slot("0", "B", "freq_mode", "freq_hz")
+    )
+    path = FieldPath.active("0", "freq_mode", "freq_hz")
+    alias_path = FieldPath.vfo_slot("0", "A", "freq_mode", "freq_hz")
+    for index, commanded_frequency in enumerate(command_steps):
+        observation = Observation(
+            path=path,
+            value=commanded_frequency,
+            source=SourceMetadata(
+                source="command_response",
+                provider="web_command",
+                transport="websocket",
+                native_id="spectrum_drag",
+                command_source="websocket",
+                session_id="hardware-trace",
+            ),
+            timestamp_monotonic=11.0 + index / 10,
+            quality=("confirmed",),
+            correlation_id=f"drag-command-{index}",
+        )
+
+        before = store.snapshot()
+        changeset = store.apply(observation)
+        after = store.snapshot()
+        relative = after.field(path)
+        alias = after.field(alias_path)
+
+        assert changeset.revision == after.state_revision == before.state_revision + 2
+        assert {change.path for change in changeset.changes} == {path, alias_path}
+        assert set(changeset.observed_paths) == {path, alias_path}
+        assert relative.value == alias.value == commanded_frequency
+        assert relative.source == alias.source == observation.source
+        assert (
+            relative.last_observed_monotonic
+            == alias.last_observed_monotonic
+            == observation.timestamp_monotonic
+        )
+        assert relative.quality == alias.quality == observation.quality
+        assert relative.max_age == alias.max_age
+        assert after.field(sibling.path) == sibling
+
+
+@pytest.mark.parametrize("active_slot", ["A", "B"])
+@pytest.mark.parametrize("relative_slot", [VfoSlot.ACTIVE, VfoSlot.UNSELECTED])
+def test_direct_relative_apply_projects_every_leaf_to_current_bound_alias(
+    active_slot: str,
+    relative_slot: VfoSlot,
+) -> None:
+    store = StateStore()
+    store.configure_relative_vfo_retention(
+        generation=4,
+        max_age=30.0,
+        coherence_window=5.0,
+    )
+    base = _relative_vfo_observations(at=20.0)
+    store.apply_relative_vfo_observations(base, generation=4)
+    store.apply(_observation(FieldPath.active_slot("0"), active_slot, at=20.7))
+    store.apply_relative_vfo_observations(base, generation=4)
+    unselected_slot = "B" if active_slot == "A" else "A"
+    alias_slot = active_slot if relative_slot is VfoSlot.ACTIVE else unselected_slot
+    sibling_slot = unselected_slot if relative_slot is VfoSlot.ACTIVE else active_slot
+
+    for index, (name, value) in enumerate(
+        (("freq_hz", 14_181_000), ("mode", "LSB"), ("filter_num", 2), ("data_mode", 1))
+    ):
+        path = (
+            FieldPath.active("0", "freq_mode", name)
+            if relative_slot is VfoSlot.ACTIVE
+            else FieldPath.unselected("0", "freq_mode", name)
+        )
+        alias_path = FieldPath.vfo_slot("0", alias_slot, "freq_mode", name)
+        sibling_path = FieldPath.vfo_slot("0", sibling_slot, "freq_mode", name)
+        sibling = store.snapshot().field(sibling_path)
+        observation = Observation(
+            path=path,
+            value=value,
+            source=SourceMetadata(
+                source="command_response",
+                provider="web_command",
+                transport="websocket",
+                native_id=f"set_{name}",
+                command_source="websocket",
+                session_id="leaf-matrix",
+            ),
+            timestamp_monotonic=21.0 + index,
+            quality=("confirmed", "authoritative"),
+            correlation_id=f"command-{name}",
+        )
+
+        before = store.snapshot()
+        changeset = store.apply(observation)
+        after = store.snapshot()
+        relative = after.field(path)
+        alias = after.field(alias_path)
+
+        assert changeset.revision == after.state_revision == before.state_revision + 2
+        assert {change.path for change in changeset.changes} == {path, alias_path}
+        assert set(changeset.observed_paths) == {path, alias_path}
+        assert relative.value == alias.value == value
+        assert relative.source == alias.source == observation.source
+        assert (
+            relative.last_observed_monotonic
+            == alias.last_observed_monotonic
+            == observation.timestamp_monotonic
+        )
+        assert relative.quality == alias.quality == observation.quality
+        assert relative.max_age == alias.max_age
+        assert after.field(sibling_path) == sibling
+
+
+def test_direct_relative_apply_without_observed_identity_does_not_invent_alias() -> (
+    None
+):
+    store = StateStore()
+    store.configure_relative_vfo_retention(
+        generation=2,
+        max_age=30.0,
+        coherence_window=5.0,
+    )
+    store.apply_relative_vfo_observations(
+        _relative_vfo_observations(at=30.0), generation=2
+    )
+    path = FieldPath.active("0", "freq_mode", "freq_hz")
+
+    changeset = store.apply(
+        _observation(
+            path,
+            14_182_000,
+            at=31.0,
+            source="command_response",
+        )
+    )
+
+    assert {change.path for change in changeset.changes} == {path}
+    assert changeset.observed_paths == (path,)
+    snapshot_paths = {field.path for field in store.snapshot().fields}
+    assert not any(item.slot in {VfoSlot.A, VfoSlot.B} for item in snapshot_paths)
+
+
 def test_bound_relative_vfo_aliases_expire_and_old_generation_cannot_repopulate() -> (
     None
 ):
@@ -339,6 +500,43 @@ def test_bound_relative_vfo_aliases_expire_and_old_generation_cannot_repopulate(
 
     with pytest.raises(KeyError):
         store.snapshot().field(alias)
+
+
+def test_detached_old_generation_cannot_overwrite_reconnected_vfo_pair() -> None:
+    store = StateStore()
+    store.configure_relative_vfo_retention(
+        generation=1,
+        max_age=20.0,
+        coherence_window=5.0,
+    )
+    first = _relative_vfo_observations(at=10.0)
+    store.apply_relative_vfo_observations(first, generation=1)
+    detached_old_task = replace(first[0], value=14_199_000, timestamp_monotonic=11.0)
+
+    store.reset_relative_vfo_retention(generation=2)
+    reconnected = _relative_vfo_observations(
+        at=20.0,
+        selected_freq=14_181_000,
+        unselected_freq=14_076_000,
+    )
+    store.apply_relative_vfo_observations(reconnected, generation=2)
+    store.apply(_observation(FieldPath.active_slot("0"), "A", at=20.7))
+    store.apply_relative_vfo_observations(reconnected, generation=2)
+    before = store.snapshot()
+
+    changeset = store.apply_relative_vfo_observations(
+        (detached_old_task,), generation=1
+    )
+
+    after = store.snapshot()
+    assert changeset.changes == ()
+    assert changeset.observed_paths == ()
+    assert after.state_revision == before.state_revision
+    assert after.freshness_revision == before.freshness_revision
+    assert after.observation_seq == before.observation_seq
+    assert after.fields == before.fields
+    assert after.field("receiver.0.active.freq_mode.freq_hz").value == 14_181_000
+    assert after.field("receiver.0.slot.A.freq_mode.freq_hz").value == 14_181_000
 
 
 def test_bound_relative_vfo_alias_shares_complete_pair_expiry() -> None:

--- a/tests/test_state_store.py
+++ b/tests/test_state_store.py
@@ -379,6 +379,64 @@ def test_bound_relative_vfo_alias_shares_complete_pair_expiry() -> None:
     assert snapshot.field(alias).freshness is FreshnessState.STALE
 
 
+@pytest.mark.parametrize("active_slot", ["A", "B"])
+def test_bound_relative_vfo_pair_and_all_aliases_expire_at_exact_deadline(
+    active_slot: str,
+) -> None:
+    clock = FreshnessClock(start=10.0)
+    store = StateStore(freshness_clock=clock)
+    store.configure_relative_vfo_retention(
+        generation=1,
+        max_age=20.0,
+        coherence_window=5.0,
+    )
+    pair = _relative_vfo_observations(at=10.0)
+    store.apply_relative_vfo_observations(pair, generation=1)
+    store.apply(_observation(FieldPath.active_slot("0"), active_slot, at=10.7))
+    store.apply_relative_vfo_observations(
+        tuple(replace(item, timestamp_monotonic=10.7) for item in pair),
+        generation=1,
+    )
+    deadline = _relative_vfo_deadline(store)
+    tuple_paths = {
+        path
+        for builder in (FieldPath.active, FieldPath.unselected)
+        for path in (
+            builder("0", "freq_mode", name)
+            for name in ("freq_hz", "mode", "filter_num", "data_mode")
+        )
+    }
+    alias_paths = {
+        FieldPath.vfo_slot("0", slot, "freq_mode", name)
+        for slot in ("A", "B")
+        for name in ("freq_hz", "mode", "filter_num", "data_mode")
+    }
+    all_value_paths = tuple_paths | alias_paths
+    assert all(
+        store.snapshot().field(path).freshness is FreshnessState.FRESH
+        for path in all_value_paths
+    )
+
+    assert store.mark_stale_due(now=deadline - 0.001).freshness == ()
+    assert all(
+        store.snapshot().field(path).freshness is FreshnessState.FRESH
+        for path in all_value_paths
+    )
+
+    exact = store.mark_stale_due(now=deadline)
+    assert {transition.path for transition in exact.freshness} == all_value_paths
+    assert all(
+        store.snapshot().field(path).freshness is FreshnessState.STALE
+        for path in all_value_paths
+    )
+    assert (
+        store.snapshot().field(FieldPath.active_slot("0")).freshness
+        is FreshnessState.FRESH
+    )
+
+    assert store.mark_stale_due(now=deadline + 1.0).freshness == ()
+
+
 def test_explicit_binding_readback_uses_same_retention_and_alias_semantics() -> None:
     clock = FreshnessClock(start=50.0)
     store = StateStore(freshness_clock=clock)

--- a/tests/test_web_runtime_helpers.py
+++ b/tests/test_web_runtime_helpers.py
@@ -238,6 +238,61 @@ def test_relative_vfo_public_payload_does_not_flap_at_leaf_ttl() -> None:
     assert patched["main"]["unselectedVfo"] == retained["main"]["unselectedVfo"]
 
 
+def test_bound_vfo_public_projection_tracks_live_selected_and_retains_sibling() -> None:
+    store = StateStore()
+    store.configure_relative_vfo_retention(
+        generation=1,
+        max_age=31.0,
+        coherence_window=5.0,
+    )
+    base = {
+        FieldPath.active("0", "freq_mode", "freq_hz"): 14_164_000,
+        FieldPath.active("0", "freq_mode", "mode"): "USB",
+        FieldPath.active("0", "freq_mode", "filter_num"): 1,
+        FieldPath.active("0", "freq_mode", "data_mode"): 0,
+        FieldPath.unselected("0", "freq_mode", "freq_hz"): 14_076_000,
+        FieldPath.unselected("0", "freq_mode", "mode"): "USB",
+        FieldPath.unselected("0", "freq_mode", "filter_num"): 1,
+        FieldPath.unselected("0", "freq_mode", "data_mode"): 0,
+    }
+    store.apply_relative_vfo_observations(
+        tuple(_observation(path, value, at=10.0) for path, value in base.items()),
+        generation=1,
+    )
+    store.apply(_observation(FieldPath.active_slot("0"), "A", at=10.1))
+    store.apply_relative_vfo_observations(
+        tuple(_observation(path, value, at=10.2) for path, value in base.items()),
+        generation=1,
+    )
+
+    for revision_freq in (14_130_000, 14_123_000):
+        store.apply_relative_vfo_observations(
+            (
+                Observation(
+                    path=FieldPath.active("0", "freq_mode", "freq_hz"),
+                    value=revision_freq,
+                    source=SourceMetadata(
+                        source="civ_unsolicited",
+                        provider="icom_civ",
+                        native_id="civ:00",
+                    ),
+                    timestamp_monotonic=11.0,
+                ),
+            ),
+            generation=1,
+        )
+        payload = build_public_state_payload_from_snapshot(
+            store.snapshot(), radio=None, receiver_count=1
+        )
+        assert payload["main"]["freqHz"] == revision_freq
+        assert payload["main"]["vfoA"]["freqHz"] == revision_freq
+        assert payload["main"]["vfoB"]["freqHz"] == 14_076_000
+        assert (
+            payload["fieldStatus"]["main.freqHz"]["source"]
+            == payload["fieldStatus"]["main.vfoA.freqHz"]["source"]
+        )
+
+
 def test_web_server_publishes_single_receiver_main_from_topology_only() -> None:
     from rigplane.profiles import resolve_radio_profile
 

--- a/tests/test_web_runtime_helpers.py
+++ b/tests/test_web_runtime_helpers.py
@@ -293,6 +293,88 @@ def test_bound_vfo_public_projection_tracks_live_selected_and_retains_sibling() 
         )
 
 
+@pytest.mark.parametrize("active_slot", ["A", "B"])
+def test_bound_vfo_public_projection_expires_together_at_exact_deadline(
+    active_slot: str,
+) -> None:
+    clock = FreshnessClock(start=10.0)
+    store = StateStore(freshness_clock=clock)
+    store.configure_relative_vfo_retention(
+        generation=1,
+        max_age=20.0,
+        coherence_window=5.0,
+    )
+    values = {
+        FieldPath.active("0", "freq_mode", "freq_hz"): 14_164_000,
+        FieldPath.active("0", "freq_mode", "mode"): "USB",
+        FieldPath.active("0", "freq_mode", "filter_num"): 1,
+        FieldPath.active("0", "freq_mode", "data_mode"): 0,
+        FieldPath.unselected("0", "freq_mode", "freq_hz"): 14_076_000,
+        FieldPath.unselected("0", "freq_mode", "mode"): "USB",
+        FieldPath.unselected("0", "freq_mode", "filter_num"): 1,
+        FieldPath.unselected("0", "freq_mode", "data_mode"): 0,
+    }
+    pair = tuple(_observation(path, value, at=10.0) for path, value in values.items())
+    store.apply_relative_vfo_observations(pair, generation=1)
+    store.apply(_observation(FieldPath.active_slot("0"), active_slot, at=10.7))
+    store.apply_relative_vfo_observations(
+        tuple(
+            Observation(
+                path=item.path,
+                value=item.value,
+                source=item.source,
+                timestamp_monotonic=10.7,
+                max_age=item.max_age,
+            )
+            for item in pair
+        ),
+        generation=1,
+    )
+    deadline = max(
+        field.last_observed_monotonic + field.max_age
+        for field in store.snapshot().fields
+        if field.max_age is not None
+    )
+    public_paths = (
+        "main.freqHz",
+        "main.mode",
+        "main.filter",
+        "main.dataMode",
+        "main.unselectedVfo.freqHz",
+        "main.unselectedVfo.mode",
+        "main.unselectedVfo.filterNum",
+        "main.unselectedVfo.dataMode",
+        "main.vfoA.freqHz",
+        "main.vfoA.mode",
+        "main.vfoA.filterNum",
+        "main.vfoA.dataMode",
+        "main.vfoB.freqHz",
+        "main.vfoB.mode",
+        "main.vfoB.filterNum",
+        "main.vfoB.dataMode",
+    )
+
+    store.mark_stale_due(now=deadline - 0.001)
+    before = build_public_state_payload_from_snapshot(
+        store.snapshot(), radio=None, receiver_count=1
+    )
+    assert all(
+        before["fieldStatus"][path]["freshness"] == "fresh"
+        and before["fieldStatus"][path]["availability"] == "available"
+        for path in public_paths
+    )
+
+    store.mark_stale_due(now=deadline)
+    exact = build_public_state_payload_from_snapshot(
+        store.snapshot(), radio=None, receiver_count=1
+    )
+    assert all(
+        exact["fieldStatus"][path]["freshness"] == "stale"
+        and exact["fieldStatus"][path]["availability"] == "stale"
+        for path in public_paths
+    )
+
+
 def test_web_server_publishes_single_receiver_main_from_topology_only() -> None:
     from rigplane.profiles import resolve_radio_profile
 


### PR DESCRIPTION
## Summary

- keep current-generation Selected/Unselected VFO observations and bound A/B aliases coherent inside one StateStore publication
- route explicit A/B binding readback through the same retention/alias semantics and remove the poller's duplicate alias copy
- prevent VFO-specific optimistic frontend patches/locks from overriding StateStore truth while leaving non-VFO behavior for MOR-1405
- preserve generation/reset/expiry guarantees and add IC-7300-shaped 14.164 -> 14.130 -> 14.123 no-send regressions

Closes #2310.

## Safety boundary

No command queue, ordered future, commander/send, ACK ownership, PTT/TX, audio, scope, spectrum data plane, transport, timer, or polling-loop implementation changed.

## Verification

- full Python: 9,141 passed, 68 skipped, 5 deselected, 11 xfailed, 1 xpassed
- full frontend: 6,033 passed
- command/ACK/PTT/audio/scope integrity: 1,722 passed, 5 skipped, 3 deselected
- ruff check and format: pass
- import-linter: 5 contracts kept, 0 broken
- frontend check, lint, architecture boundaries, i18n, production build: pass
- mypy: identical 11 pre-existing errors on exact base and candidate; zero new

## Frozen LOC

Production HEAD~1..HEAD: +114 / -15, net +99, churn 129.

Real IC-7300 acceptance and fresh exact-head independent Agent Review remain required before merge.
