### PR TITLE
fix(ci): restore RP-ML-006 visual smoke contract

### DIFF
--- a/.github/workflows/quick.yml
+++ b/.github/workflows/quick.yml
@@ -143,9 +143,6 @@ jobs:
 
       - name: Frontend i18n visual smoke (RP-ML-006)
         if: steps.filter.outputs.frontend == 'true'
-        # RP-ML-006 remains an explicitly advisory pre-existing suite. Do not
-        # count this step as blocking evidence for the quick check.
-        continue-on-error: true
         run: npm run test:e2e:i18n
         working-directory: frontend
 

--- a/frontend/src/lib/types/__tests__/i18n-visual-fixture.contract.test.ts
+++ b/frontend/src/lib/types/__tests__/i18n-visual-fixture.contract.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import { mockCapabilities } from '../../../../tests/e2e/i18n/fixtures';
+import { validateCapabilities } from '../capabilities';
+
+describe('RP-ML-006 i18n visual capability fixture', () => {
+  it('conforms to the complete public capabilities contract', () => {
+    expect(validateCapabilities(mockCapabilities)).toBe(mockCapabilities);
+  });
+
+  it('fails loudly when a required capability group drifts out of the fixture', () => {
+    const { audioConfig: _audioConfig, ...missingAudioConfig } = mockCapabilities;
+
+    expect(() => validateCapabilities(missingAudioConfig)).toThrow(
+      'Invalid capabilities payload at $.audioConfig: expected an object',
+    );
+  });
+});

--- a/frontend/tests/e2e/i18n/fixtures.ts
+++ b/frontend/tests/e2e/i18n/fixtures.ts
@@ -49,6 +49,9 @@ const subReceiver: ReceiverState = {
 
 export const mockState: ServerState = {
   revision: 1,
+  stateRevision: 1,
+  freshnessRevision: 1,
+  observationSeq: 1,
   updatedAt: '2026-05-19T00:00:00Z',
   active: 'MAIN',
   powerOn: true,
@@ -56,6 +59,10 @@ export const mockState: ServerState = {
   split: false,
   dualWatch: false,
   tunerStatus: 0,
+  txTarget: {
+    status: 'unknown',
+    reason: 'not-observed',
+  },
   main: baseReceiver,
   sub: subReceiver,
   connection: {
@@ -73,7 +80,6 @@ export const mockState: ServerState = {
   },
   radioDetail: {
     status: 'connected',
-    uptimeSeconds: 600,
   },
   meterSource: 'S',
   cwPitch: 600,
@@ -105,7 +111,6 @@ export const mockDisconnectedState: ServerState = {
   },
   radioDetail: {
     status: 'disconnected',
-    uptimeSeconds: 0,
   },
 };
 
@@ -167,6 +172,26 @@ export const mockCapabilities: Capabilities = {
     amplitudeMax: 100,
     defaultSpan: 100_000,
   },
+  // Keep this complete public capability group in sync with
+  // `validateCapabilities()`. The companion contract test deliberately
+  // removes a required member to prove that CI catches future drift.
+  audioConfig: {
+    sampleRate: 48_000,
+    channels: 2,
+    codecs: ['pcm_f32le'],
+  },
+  webrtc: {
+    available: false,
+    enabled: false,
+  },
+  txBands: [
+    { name: '160m', start: 1_800_000, end: 2_000_000 },
+    { name: '80m', start: 3_500_000, end: 4_000_000 },
+    { name: '40m', start: 7_000_000, end: 7_300_000 },
+    { name: '20m', start: 14_000_000, end: 14_350_000 },
+    { name: '15m', start: 21_000_000, end: 21_450_000 },
+    { name: '10m', start: 28_000_000, end: 29_700_000 },
+  ],
 };
 
 export const mockInfo = {


### PR DESCRIPTION
Closes #2322

Linear: MOR-1412

## Summary
- complete the stale RP-ML-006 state and capabilities fixtures against current public contracts
- exercise the exact production capability validator in a cheap frontend contract test, including a deliberately invalid fixture
- make the repaired Playwright smoke fail the required quick check loudly

## Verification
- `npm run check`
- `npm test` — 293 files / 6035 tests
- focused fixture-contract test — 2 tests
- `npm run build`

Local browser binary provisioning was incomplete; final all-36 Playwright evidence is required from Linux CI. The separate fixture-harness remains unchanged.