### PR TITLE
fix: integrate IC-7300 state acquisition (MOR-1407)

### DIFF
--- a/rigs/ic7300.toml
+++ b/rigs/ic7300.toml
@@ -98,6 +98,93 @@ features = [
     "system_settings",
 ]
 
+[state_acquisition]
+provider = "icom_civ"
+default_cadence_seconds = 1.5
+default_freshness_ttl_seconds = 3.0
+default_reconciliation_priority = "poll"
+adaptive_decay = false
+external_cat_pause = "pause_polling"
+meter_coalescing_window_seconds = 0.2
+
+[state_acquisition.capabilities]
+unsolicited_push = [
+    "receiver.main.active.freq_mode.freq_hz",
+    "receiver.main.active.freq_mode.mode",
+]
+polling_only = [
+    "receiver.main.active.freq_mode.freq_hz",
+    "receiver.main.active.freq_mode.mode",
+    "receiver.main.unselected.freq_mode.freq_hz",
+    "receiver.main.unselected.freq_mode.mode",
+    "receiver.main.operator_controls.af_level",
+    "receiver.main.operator_controls.rf_gain",
+    "receiver.main.operator_controls.squelch",
+    "receiver.main.operator_controls.att",
+    "receiver.main.operator_controls.preamp",
+    "receiver.main.operator_controls.agc",
+    "receiver.main.operator_toggles.nb",
+    "receiver.main.operator_toggles.nr",
+    "global.operator_controls.power_level",
+    "global.tx_state.compressor_on",
+    "global.operator_controls.compressor_level",
+    "global.tx_state.ptt",
+    "global.operator_controls.tuner_status",
+    "global.tx_state.split",
+]
+stream_like_meters = [
+    "receiver.main.meters.s_meter",
+]
+command_response_observable = [
+    "receiver.main.active.freq_mode.freq_hz",
+    "receiver.main.active.freq_mode.mode",
+    "receiver.main.operator_controls.af_level",
+    "receiver.main.operator_controls.rf_gain",
+    "receiver.main.operator_controls.squelch",
+    "receiver.main.operator_controls.att",
+    "receiver.main.operator_controls.preamp",
+    "receiver.main.operator_controls.agc",
+    "receiver.main.operator_toggles.nb",
+    "receiver.main.operator_toggles.nr",
+    "global.operator_controls.power_level",
+    "global.tx_state.compressor_on",
+    "global.operator_controls.compressor_level",
+    "global.tx_state.ptt",
+    "global.operator_controls.tuner_status",
+    "global.tx_state.split",
+]
+supported_controls = [
+    "receiver.main.active.freq_mode.freq_hz",
+    "receiver.main.active.freq_mode.mode",
+    "receiver.main.operator_controls.af_level",
+    "receiver.main.operator_controls.rf_gain",
+    "receiver.main.operator_controls.squelch",
+    "receiver.main.operator_controls.att",
+    "receiver.main.operator_controls.preamp",
+    "receiver.main.operator_controls.agc",
+    "receiver.main.operator_toggles.nb",
+    "receiver.main.operator_toggles.nr",
+    "global.operator_controls.power_level",
+    "global.tx_state.compressor_on",
+    "global.operator_controls.compressor_level",
+    "global.tx_state.ptt",
+    "global.operator_controls.tuner_status",
+    "global.tx_state.split",
+]
+
+[state_acquisition.field_policies."receiver.main.meters.s_meter"]
+cadence_seconds = 0.2
+freshness_ttl_seconds = 2.0
+adaptive_decay = false
+meter_coalescing_window_seconds = 0.2
+
+# A bare 0x1C/0x00 read observes the front-panel TX state and carries no data
+# byte, so it cannot key the radio. Keep the existing PTT safety lane unchanged.
+[state_acquisition.field_policies."global.tx_state.ptt"]
+cadence_seconds = 0.3
+freshness_ttl_seconds = 1.0
+adaptive_decay = false
+
 # ── Parameterized Capabilities ───────────────────────────────────
 
 [attenuator]

--- a/src/rigplane/core/acquisition_scheduler.py
+++ b/src/rigplane/core/acquisition_scheduler.py
@@ -52,6 +52,7 @@ __all__ = [
 
 AcquisitionMethod = Literal["poll", "command_response", "wait_for_unsolicited"]
 AcquisitionQuerySender = Callable[[int, int | None, int | None], Awaitable[None]]
+CivCmd29Support = Callable[[int, int | None], bool]
 
 
 class AcquisitionPriority(StrEnum):
@@ -287,10 +288,16 @@ _CIV_ACQUISITION_PROVIDERS = frozenset(("icom_civ", "xiegu_civ"))
 class IcomCivAcquisitionExecutor:
     """CI-V path-to-query executor for compatible CI-V acquisition profiles."""
 
-    __slots__ = ("_send_query",)
+    __slots__ = ("_send_query", "_supports_cmd29")
 
-    def __init__(self, send_query: AcquisitionQuerySender) -> None:
+    def __init__(
+        self,
+        send_query: AcquisitionQuerySender,
+        *,
+        supports_cmd29: CivCmd29Support | None = None,
+    ) -> None:
         self._send_query = send_query
+        self._supports_cmd29 = supports_cmd29
 
     async def execute(
         self,
@@ -300,19 +307,33 @@ class IcomCivAcquisitionExecutor:
     ) -> AcquisitionExecutionResult:
         sent: list[FieldPath] = []
         failed: list[FieldPath] = []
+        failure_reason = ""
         for path in request.paths:
             if path in already_sent_paths:
                 continue
             query = self.query_for_path(path)
             if query is None:
                 failed.append(path)
+                failure_reason = failure_reason or "no_civ_query_mapping"
                 continue
-            await self._send_query(*query)
+            command, sub, receiver = query
+            if (
+                receiver is not None
+                and command not in (0x25, 0x26)
+                and self._supports_cmd29 is not None
+                and not self._supports_cmd29(command, sub)
+            ):
+                if receiver != 0:
+                    failed.append(path)
+                    failure_reason = failure_reason or "no_civ_receiver_route"
+                    continue
+                receiver = None
+            await self._send_query(command, sub, receiver)
             sent.append(path)
         return AcquisitionExecutionResult(
             sent_paths=tuple(sent),
             failed_paths=tuple(failed),
-            failure_reason="no_civ_query_mapping" if failed else "",
+            failure_reason=failure_reason,
         )
 
     def query_for_path(
@@ -323,11 +344,19 @@ class IcomCivAcquisitionExecutor:
         if path.scope.value == "receiver" and receiver is None:
             return None
         if path.scope.value == "receiver" and path.family.value == "freq_mode":
+            slot = None if path.slot is None else path.slot.value
+            if slot in {"A", "B"}:
+                return None
+            selector = 1 if slot == "unselected" else receiver
+            if slot == "unselected" and receiver != 0:
+                return None
             if path.name == "freq_hz":
-                return (0x25, None, receiver)
+                return (0x25, None, selector)
             if path.name == "mode":
-                return (0x26, None, receiver)
+                return (0x26, None, selector)
             if path.name == "filter_width":
+                if slot == "unselected":
+                    return None
                 return (0x1A, 0x03, receiver)
             return None
         if path.scope.value == "receiver" and path.family.value == "meters":
@@ -373,12 +402,17 @@ class IcomCivAcquisitionExecutor:
 def civ_acquisition_executor_for_provider(
     provider: str,
     send_query: AcquisitionQuerySender,
+    *,
+    supports_cmd29: CivCmd29Support | None = None,
 ) -> AcquisitionExecutor | None:
     """Return the shared CI-V executor for providers using this query envelope."""
 
     if provider not in _CIV_ACQUISITION_PROVIDERS:
         return None
-    return IcomCivAcquisitionExecutor(send_query)
+    return IcomCivAcquisitionExecutor(
+        send_query,
+        supports_cmd29=supports_cmd29,
+    )
 
 
 _PRIORITY_RANK: dict[AcquisitionPriority, int] = {

--- a/src/rigplane/rigctld/server.py
+++ b/src/rigplane/rigctld/server.py
@@ -276,12 +276,11 @@ class RigctldServer:
     # Lifecycle
     # ------------------------------------------------------------------
 
-    def _profile_state_acquisition(self) -> RadioAcquisitionProfile | None:
-        """Return profile acquisition metadata for the attached radio, if any."""
+    def _resolved_radio_profile(self) -> Any | None:
+        """Return the attached or model-resolved radio profile, if any."""
         raw_profile = getattr(self._radio, "profile", None)
-        acquisition_profile = getattr(raw_profile, "state_acquisition", None)
-        if acquisition_profile is not None:
-            return cast(RadioAcquisitionProfile, acquisition_profile)
+        if raw_profile is not None:
+            return raw_profile
 
         model = getattr(self._radio, "model", None)
         if not isinstance(model, str):
@@ -296,7 +295,15 @@ class RigctldServer:
                 "rigctld state acquisition: failed to resolve profile", exc_info=True
             )
             return None
-        return profile.state_acquisition
+        return profile
+
+    def _profile_state_acquisition(self) -> RadioAcquisitionProfile | None:
+        """Return profile acquisition metadata for the attached radio, if any."""
+        profile = self._resolved_radio_profile()
+        acquisition_profile = getattr(profile, "state_acquisition", None)
+        if acquisition_profile is None:
+            return None
+        return cast(RadioAcquisitionProfile, acquisition_profile)
 
     def _radio_state_store(self) -> StateStore | None:
         if not isinstance(self._radio, StateStoreCapable):
@@ -338,9 +345,12 @@ class RigctldServer:
             return None
         if not isinstance(self._radio, CivCommandCapable):
             return None
+        profile = self._resolved_radio_profile()
+        supports_cmd29 = getattr(profile, "supports_cmd29", None)
         return civ_acquisition_executor_for_provider(
             scheduler.provider,
             self._send_one_state_query,
+            supports_cmd29=supports_cmd29 if callable(supports_cmd29) else None,
         )
 
     def _attach_state_acquisition_services(

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -486,6 +486,7 @@ class RadioPoller:
             self._acquisition_executor = civ_acquisition_executor_for_provider(
                 self._acquisition_scheduler.provider,
                 self._send_one_state_query,
+                supports_cmd29=self._profile.supports_cmd29,
             )
         # Set by default — cleared at _run() start, re-set after initial fetch.
         # This prevents EnableScope from hanging in tests that don't call start().

--- a/tests/test_acquisition_scheduler.py
+++ b/tests/test_acquisition_scheduler.py
@@ -8,6 +8,8 @@ from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 from rigplane.core.acquisition_scheduler import (
     AcquisitionPriority,
     AcquisitionScheduler,
@@ -2253,3 +2255,96 @@ def test_ic7610_real_profile_tuner_pollable_tone_absent() -> None:
         if (cmd, sub) in {(0x16, 0x42), (0x16, 0x43), (0x1B, 0x00), (0x1B, 0x01)}
     }
     assert tone_tsql_cmds == set()
+
+
+@pytest.mark.asyncio
+async def test_ic7300_route_uses_plain_main_reads_and_fails_closed_for_sub() -> None:
+    """A no-cmd29 profile must never wrap MAIN reads or invent SUB routing."""
+
+    sent: list[tuple[int, int | None, int | None]] = []
+
+    async def send_query(
+        command: int,
+        sub: int | None,
+        receiver: int | None,
+    ) -> None:
+        sent.append((command, sub, receiver))
+
+    executor = IcomCivAcquisitionExecutor(
+        send_query,
+        supports_cmd29=lambda _command, _sub: False,
+    )
+    main_af = FieldPath.receiver("main", "operator_controls", "af_level")
+    sub_af = FieldPath.receiver("sub", "operator_controls", "af_level")
+    scheduler = AcquisitionScheduler(profile=_profile([main_af, sub_af]))
+    requests = scheduler.due_requests()
+
+    results = [
+        await executor.execute(request, already_sent_paths=frozenset())
+        for request in requests
+    ]
+
+    assert sent == [(0x14, 0x01, None)]
+    assert {path for result in results for path in result.sent_paths} == {main_af}
+    assert {path for result in results for path in result.failed_paths} == {sub_af}
+    assert all(
+        result.failure_reason in {"", "no_civ_receiver_route"} for result in results
+    )
+
+
+def test_ic7300_relative_vfo_paths_use_selected_unselected_25_26_selectors() -> None:
+    async def send_query(
+        command: int,
+        sub: int | None,
+        receiver: int | None,
+    ) -> None:
+        del command, sub, receiver
+
+    executor = IcomCivAcquisitionExecutor(
+        send_query,
+        supports_cmd29=lambda _command, _sub: False,
+    )
+
+    assert executor.query_for_path(
+        FieldPath.active("main", "freq_mode", "freq_hz")
+    ) == (0x25, None, 0)
+    assert executor.query_for_path(
+        FieldPath.unselected("main", "freq_mode", "freq_hz")
+    ) == (0x25, None, 1)
+    assert executor.query_for_path(FieldPath.active("main", "freq_mode", "mode")) == (
+        0x26,
+        None,
+        0,
+    )
+    assert executor.query_for_path(
+        FieldPath.unselected("main", "freq_mode", "mode")
+    ) == (0x26, None, 1)
+
+
+@pytest.mark.asyncio
+async def test_ic7300_executor_preserves_dedupe_for_plain_profile_route() -> None:
+    sent: list[tuple[int, int | None, int | None]] = []
+
+    async def send_query(
+        command: int,
+        sub: int | None,
+        receiver: int | None,
+    ) -> None:
+        sent.append((command, sub, receiver))
+
+    power = FieldPath.global_("operator_controls", "power_level")
+    compressor = FieldPath.global_("tx_state", "compressor_on")
+    scheduler = AcquisitionScheduler(profile=_profile([power, compressor]))
+    executor = IcomCivAcquisitionExecutor(
+        send_query,
+        supports_cmd29=lambda _command, _sub: False,
+    )
+
+    for request in scheduler.due_requests():
+        result = await executor.execute(
+            request,
+            already_sent_paths=frozenset({power}),
+        )
+        assert power not in result.sent_paths
+
+    assert sent == [(0x16, 0x44, None)]

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -376,9 +376,9 @@ async def test_x6200_scheduler_due_request_sends_civ_query_from_profile() -> Non
         wait_dispatch=False,
     )
     radio.send_civ.assert_any_await(
-        0x29,
-        sub=None,
-        data=b"\x00\x15\x02",
+        0x15,
+        sub=0x02,
+        data=b"",
         wait_response=False,
         priority=Priority.BACKGROUND,
         wait_dispatch=False,
@@ -414,6 +414,65 @@ async def test_xiegu_civ_scheduler_due_request_uses_civ_executor() -> None:
         priority=Priority.BACKGROUND,
         wait_dispatch=False,
     )
+
+
+@pytest.mark.asyncio
+async def test_ic7300_profile_scheduler_emits_only_passive_exact_wire_reads() -> None:
+    """IC-7300 joins the existing poller lane without cmd29 or another service."""
+
+    radio = _make_radio(active="MAIN", model="IC-7300")
+    profile = resolve_radio_profile(model="IC-7300")
+    assert profile.state_acquisition is not None
+    scheduler = AcquisitionScheduler(profile=profile.state_acquisition)
+    radio._acquisition_scheduler = scheduler
+    poller = RadioPoller(radio, CommandQueue(), radio_state=RadioState())
+
+    assert poller._acquisition_scheduler is scheduler  # noqa: SLF001
+    await poller._send_query()  # noqa: SLF001
+
+    radio.send_civ.assert_any_await(
+        0x25,
+        sub=None,
+        data=b"\x00",
+        wait_response=False,
+        priority=Priority.BACKGROUND,
+        wait_dispatch=False,
+    )
+    radio.send_civ.assert_any_await(
+        0x25,
+        sub=None,
+        data=b"\x01",
+        wait_response=False,
+        priority=Priority.BACKGROUND,
+        wait_dispatch=False,
+    )
+    radio.send_civ.assert_any_await(
+        0x26,
+        sub=None,
+        data=b"\x00",
+        wait_response=False,
+        priority=Priority.BACKGROUND,
+        wait_dispatch=False,
+    )
+    radio.send_civ.assert_any_await(
+        0x26,
+        sub=None,
+        data=b"\x01",
+        wait_response=False,
+        priority=Priority.BACKGROUND,
+        wait_dispatch=False,
+    )
+    for command, sub in ((0x14, 0x0A), (0x16, 0x44), (0x14, 0x0E)):
+        radio.send_civ.assert_any_await(
+            command,
+            sub=sub,
+            data=b"",
+            wait_response=False,
+            priority=Priority.BACKGROUND,
+            wait_dispatch=False,
+        )
+    assert all(call_.args[0] != 0x29 for call_ in radio.send_civ.await_args_list)
+    assert scheduler.pending_requests()
 
 
 @pytest.mark.asyncio
@@ -1294,7 +1353,7 @@ async def test_relative_vfo_epoch_reset_discards_vfo_facts_but_not_ptt() -> None
 
 @pytest.mark.parametrize(
     ("model", "expected_seconds"),
-    (("IC-7300", 31.0), ("IC-705", 11.1)),
+    (("IC-7300", 8.0), ("IC-705", 11.1)),
 )
 def test_relative_vfo_retention_window_follows_provider_poll_cadence(
     model: str,
@@ -1305,7 +1364,13 @@ def test_relative_vfo_retention_window_follows_provider_poll_cadence(
 
     poller = RadioPoller(radio, CommandQueue())
 
-    expected_rotation = 2 * len(poller._STATE_QUERIES) * poller._fast_interval
+    acquisition = radio.profile.state_acquisition
+    expected_rotation = (
+        acquisition.default_policy.cadence_seconds
+        if acquisition is not None
+        else 2 * len(poller._STATE_QUERIES) * poller._fast_interval
+    )
+    assert expected_rotation is not None
     assert poller._relative_vfo_retention_max_age == pytest.approx(
         2 * expected_rotation + 5.0
     )

--- a/tests/test_state_acquisition_policy.py
+++ b/tests/test_state_acquisition_policy.py
@@ -402,7 +402,7 @@ def test_loader_rejects_coerced_state_acquisition_values(
 def test_known_profiles_load_with_state_acquisition_compatibility() -> None:
     profiles = {rig.model: rig.to_profile() for rig in discover_rigs(RIGS_DIR).values()}
 
-    for expected in ("IC-7610", "FTX-1", "X6200"):
+    for expected in ("IC-7300", "IC-7610", "FTX-1", "X6200"):
         assert expected in profiles
         assert profiles[expected].state_acquisition is not None
 
@@ -415,7 +415,7 @@ def test_known_profiles_load_with_state_acquisition_compatibility() -> None:
 
 
 def test_known_profiles_stream_like_meters_use_fast_non_decaying_policies() -> None:
-    for model in ("IC-7610", "FTX-1", "X6200"):
+    for model in ("IC-7300", "IC-7610", "FTX-1", "X6200"):
         profile = get_radio_profile(model)
         acquisition = profile.state_acquisition
         assert acquisition is not None
@@ -463,3 +463,64 @@ def test_ftx1_profile_declares_slow_control_policies_for_polling_adapter() -> No
     assert ftx1.state_acquisition.capability_for(ptt).can_poll is True
     assert ftx1.state_acquisition.policy_for(af_level).freshness_ttl_seconds == 120.0
     assert ftx1.state_acquisition.policy_for(af_level).cadence_seconds == 30.0
+
+
+def test_ic7300_profile_enrolls_exact_supported_observation_rows() -> None:
+    profile = get_radio_profile("IC-7300")
+    acquisition = profile.state_acquisition
+    assert acquisition is not None
+    assert acquisition.provider == "icom_civ"
+
+    expected_pollable = {
+        FieldPath.active("main", "freq_mode", "freq_hz"),
+        FieldPath.active("main", "freq_mode", "mode"),
+        FieldPath.unselected("main", "freq_mode", "freq_hz"),
+        FieldPath.unselected("main", "freq_mode", "mode"),
+        FieldPath.receiver("main", "meters", "s_meter"),
+        FieldPath.receiver("main", "operator_controls", "af_level"),
+        FieldPath.receiver("main", "operator_controls", "rf_gain"),
+        FieldPath.receiver("main", "operator_controls", "squelch"),
+        FieldPath.receiver("main", "operator_controls", "att"),
+        FieldPath.receiver("main", "operator_controls", "preamp"),
+        FieldPath.receiver("main", "operator_controls", "agc"),
+        FieldPath.receiver("main", "operator_toggles", "nb"),
+        FieldPath.receiver("main", "operator_toggles", "nr"),
+        FieldPath.global_("operator_controls", "power_level"),
+        FieldPath.global_("tx_state", "compressor_on"),
+        FieldPath.global_("operator_controls", "compressor_level"),
+        FieldPath.global_("tx_state", "ptt"),
+        FieldPath.global_("operator_controls", "tuner_status"),
+        FieldPath.global_("tx_state", "split"),
+    }
+
+    assert set(acquisition.pollable_paths()) == expected_pollable
+    assert all(
+        acquisition.capability_for(path).availability is FieldAvailability.SUPPORTED
+        for path in expected_pollable
+    )
+    for path in (
+        FieldPath.global_("operator_controls", "power_level"),
+        FieldPath.global_("tx_state", "compressor_on"),
+        FieldPath.global_("operator_controls", "compressor_level"),
+    ):
+        assert acquisition.capability_for(path).command_response_observable is True
+
+    assert (
+        acquisition.capability_for(
+            FieldPath.receiver("sub", "operator_controls", "af_level")
+        ).availability
+        is FieldAvailability.UNKNOWN
+    )
+    assert profile.cmd29_routes == frozenset()
+
+
+def test_ic7300_activation_does_not_change_ftx1_acquisition_contract() -> None:
+    ftx1 = get_radio_profile("FTX-1")
+    acquisition = ftx1.state_acquisition
+    assert acquisition is not None
+
+    assert acquisition.provider == "yaesu_cat"
+    assert len(acquisition.capabilities) == 53
+    assert len(acquisition.field_policies) == 46
+    assert acquisition.default_policy.cadence_seconds == 2.0
+    assert acquisition.default_policy.freshness_ttl_seconds == 8.0


### PR DESCRIPTION
Closes #2315

## Summary

- enroll the IC-7300 in the existing `AcquisitionScheduler` / `RadioStateModelService` path with 19 registered, supported observation rows
- route relative VFO reads with the existing CI-V `0x25` / `0x26` selected and unselected selectors
- make shared CI-V acquisition profile-aware: plain MAIN reads for radios without command `0x29`, fail-closed unknown SUB routes, preserved `0x29` envelopes for profiles that support them
- cover RF Power (`14:0A`), COMP on/off (`16:44`), and COMP level (`14:0E`) through the shared scheduler rather than per-control code
- preserve the FTX-1 acquisition contract unchanged (53 capabilities, 46 field policies)

## Safety / scope

- RX/read acquisition only; no unsolicited writes
- no new poller, timer, state store, frontend branch, or per-control handler
- no changes to CI-V receive decoding (`_civ_rx.py`), StateStore/WS schema, command/ACK serialization, PTT, audio, scope, or spectrum pipelines
- production diff: 4 files, +145/-13 (net +132); the two one-/small-callsite changes keep Web and standalone rigctld on the same profile-aware executor
- exact base: `660e148b6e9be51f930b0266cfddd723c270ef18`

## Verification

- controlled RED -> GREEN: 6 binding tests
- `uv run pytest -q tests/test_acquisition_scheduler.py tests/test_radio_poller_coverage.py tests/test_state_acquisition_policy.py` — 216 passed
- `uv run pytest -q tests/test_rigctld_server.py tests/test_web_server.py` — 245 passed, 2 skipped
- `uv run pytest tests/ -q --tb=short` — 9172 passed, 68 skipped, 5 deselected, 11 xfailed, 1 xpassed
- `uv run ruff check src/ tests/` — passed
- `uv run ruff format src/ tests/` — applied; final ruff check passed
- `uv run lint-imports` — 5 contracts kept
- `uv run mypy src/rigplane/core/acquisition_scheduler.py src/rigplane/rigctld/server.py src/rigplane/web/radio_poller.py` — passed
- full `uv run mypy src/` still reports 11 existing errors in untouched `runtime/_control_phase.py` and `runtime/_audio_runtime_mixin.py`; no errors are in this PR's changed files

Hardware conformance remains explicitly deferred to MOR-1410 / #2318. This PR makes no live-hardware claim.
