### PR TITLE
feat: add StateStore provider generation contract

### DIFF
--- a/src/rigplane/core/state_pipeline_contracts.py
+++ b/src/rigplane/core/state_pipeline_contracts.py
@@ -16,6 +16,7 @@ from rigplane.core.tx_target import tx_target_from_dict, validate_tx_target
 __all__ = [
     "CapabilityMetadata",
     "ChangeSet",
+    "LOCAL_MONOTONIC_CLOCK_DOMAIN",
     "CommandIntent",
     "CommandLifecycleEvent",
     "CommandLifecycleState",
@@ -33,6 +34,8 @@ __all__ = [
     "SourceMetadata",
     "VfoSlot",
 ]
+
+LOCAL_MONOTONIC_CLOCK_DOMAIN = "local_monotonic"
 
 
 ObservationSource = Literal[
@@ -654,10 +657,23 @@ class Observation:
     quality: tuple[str, ...] = ("confirmed",)
     correlation_id: str | None = None
     max_age: float | None = None
+    # Fixed bootstrap token for source compatibility; never late-bound by Store.apply.
+    provider_generation: int | None = 0
+    clock_domain: str | None = None
 
     def __post_init__(self) -> None:
         if self.max_age is not None and self.max_age < 0:
             raise ValueError("max_age must be non-negative")
+        if self.provider_generation is not None and (
+            not isinstance(self.provider_generation, int)
+            or isinstance(self.provider_generation, bool)
+            or self.provider_generation < 0
+        ):
+            raise ValueError("provider_generation must be a non-negative integer")
+        if self.clock_domain is not None and (
+            not isinstance(self.clock_domain, str) or not self.clock_domain
+        ):
+            raise ValueError("clock_domain must not be empty")
         for item in self.quality:
             _validate_token(item, label="quality")
         if str(self.path) == _TX_TARGET_PATH:
@@ -682,6 +698,8 @@ class Observation:
             "quality": list(self.quality),
             "correlationId": self.correlation_id,
             "maxAge": self.max_age,
+            "providerGeneration": self.provider_generation,
+            "clockDomain": self.clock_domain,
         }
 
     @classmethod
@@ -698,6 +716,20 @@ class Observation:
                 else str(value["correlationId"])
             ),
             max_age=None if value.get("maxAge") is None else float(value["maxAge"]),
+            provider_generation=(
+                0
+                if "providerGeneration" not in value
+                else None
+                if value["providerGeneration"] is None
+                else int(value["providerGeneration"])
+            ),
+            clock_domain=(
+                None
+                if "clockDomain" not in value
+                else None
+                if value["clockDomain"] is None
+                else str(value["clockDomain"])
+            ),
         )
 
 

--- a/src/rigplane/core/state_store.py
+++ b/src/rigplane/core/state_store.py
@@ -93,6 +93,8 @@ class FieldSnapshot:
     max_age: float | None
     source: SourceMetadata
     quality: tuple[str, ...] = ("confirmed",)
+    provider_generation: int = 0
+    clock_domain: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -103,6 +105,8 @@ class FieldSnapshot:
             "maxAge": self.max_age,
             "source": self.source.to_dict(),
             "quality": list(self.quality),
+            "providerGeneration": self.provider_generation,
+            "clockDomain": self.clock_domain,
         }
 
 
@@ -115,6 +119,7 @@ class StateSnapshot:
     observation_seq: int
     generated_at_monotonic: float
     fields: tuple[FieldSnapshot, ...]
+    provider_generation: int = 0
 
     @classmethod
     def empty(cls) -> StateSnapshot:
@@ -124,6 +129,7 @@ class StateSnapshot:
             observation_seq=0,
             generated_at_monotonic=0.0,
             fields=(),
+            provider_generation=0,
         )
 
     def field(self, path: FieldPath | str) -> FieldSnapshot:
@@ -142,6 +148,7 @@ class StateSnapshot:
             "freshnessRevision": self.freshness_revision,
             "observationSeq": self.observation_seq,
             "generatedAtMonotonic": self.generated_at_monotonic,
+            "providerGeneration": self.provider_generation,
             "fields": [field.to_dict() for field in self.fields],
         }
 
@@ -161,6 +168,7 @@ class SnapshotDelta:
     freshness: tuple[FreshnessTransition, ...] = ()
     reconciliation_requests: tuple[ReconciliationRequest, ...] = ()
     requires_full_snapshot: bool = False
+    provider_generation: int = 0
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -173,6 +181,7 @@ class SnapshotDelta:
                 request.to_dict() for request in self.reconciliation_requests
             ],
             "requiresFullSnapshot": self.requires_full_snapshot,
+            "providerGeneration": self.provider_generation,
         }
 
 
@@ -184,6 +193,8 @@ class _FieldEntry:
     max_age: float | None
     source: SourceMetadata
     quality: tuple[str, ...]
+    provider_generation: int
+    clock_domain: str | None
 
 
 @dataclass(slots=True)
@@ -247,6 +258,7 @@ class StateStore:
         "_history_floor_state_revision",
         "_max_history_count",
         "_observation_seq",
+        "_provider_generation",
         "_relative_vfo_retention",
         "_state_revision",
     )
@@ -264,20 +276,48 @@ class StateStore:
         self._state_revision = 0
         self._freshness_revision = 0
         self._observation_seq = 0
+        self._provider_generation = 0
         self._relative_vfo_retention: _RelativeVfoRetention | None = None
         self._entries: dict[FieldPath, _FieldEntry] = {}
         self._history: list[SnapshotDelta] = []
         self._history_floor_state_revision = 0
         self._history_floor_freshness_revision = 0
 
-    def apply(self, observation: Observation) -> ChangeSet:
-        """Apply one synchronous/current-provider observation.
+    @property
+    def provider_generation(self) -> int:
+        """Store-owned provider token; independent of transport/TX counters."""
 
-        Generation-bearing producers must use
-        :meth:`apply_relative_vfo_observations`; the generic callers that can
-        supply relative VFO paths are synchronous command/readback boundaries
-        and therefore have no detached producer generation to relabel here.
-        """
+        return self._provider_generation
+
+    def begin_provider_generation(self) -> int:
+        """Advance the provider token and atomically invalidate prior proof."""
+
+        self._provider_generation += 1
+        retention = self._relative_vfo_retention
+        if retention is not None:
+            retention.pending.clear()
+            retention.expires_at = None
+        removed = tuple(
+            FieldChange(path=path, previous=_copy_value(entry.value), current=None)
+            for path, entry in sorted(
+                self._entries.items(), key=lambda item: str(item[0])
+            )
+        )
+        self._entries.clear()
+        if removed:
+            self._state_revision += 1
+            self._append_history(
+                changes=removed,
+                freshness=(),
+                reconciliation_requests=(),
+            )
+        return self._provider_generation
+
+    def apply(self, observation: Observation) -> ChangeSet:
+        """Apply an explicitly generation-bound observation, or reject it."""
+
+        if not self._is_current_observation(observation):
+            return self._empty_changeset(timestamp=observation.timestamp_monotonic)
 
         retention = self._relative_vfo_retention
         if retention is not None and observation.path in retention.paths:
@@ -286,11 +326,24 @@ class StateStore:
             )
         return self._apply_one(observation)
 
+    def apply_current(self, observation: Observation) -> ChangeSet:
+        """Bind a synchronous observation; callers must cross no await/detach."""
+
+        return self.apply(
+            replace(observation, provider_generation=self._provider_generation)
+        )
+
     def _apply_one(self, observation: Observation) -> ChangeSet:
         """Apply one observation without relative-VFO staging."""
 
-        self._observation_seq += 1
         previous_entry = self._entries.get(observation.path)
+        if not self._is_current_observation(observation) or (
+            previous_entry is not None
+            and self._strictly_older_than_entry(observation, previous_entry)
+        ):
+            return self._empty_changeset(timestamp=observation.timestamp_monotonic)
+
+        self._observation_seq += 1
         previous_freshness = (
             FreshnessState.UNKNOWN
             if previous_entry is None
@@ -324,6 +377,8 @@ class StateStore:
             max_age=observation.max_age,
             source=observation.source,
             quality=observation.quality,
+            provider_generation=self._provider_generation,
+            clock_domain=observation.clock_domain,
         )
         changeset = ChangeSet(
             revision=self._state_revision,
@@ -376,6 +431,8 @@ class StateStore:
                 timestamp_monotonic=entry.last_observed_monotonic,
                 quality=entry.quality,
                 max_age=entry.max_age,
+                provider_generation=entry.provider_generation,
+                clock_domain=entry.clock_domain,
             )
             for path, entry in self._entries.items()
             if path in paths
@@ -421,7 +478,11 @@ class StateStore:
         retention = self._relative_vfo_retention
         if retention is None:
             return self._apply_observation_batch(batch)
-        if not batch or generation != retention.generation:
+        if (
+            not batch
+            or generation != retention.generation
+            or any(not self._is_current_observation(item) for item in batch)
+        ):
             return self._empty_changeset(
                 timestamp=max(
                     (item.timestamp_monotonic for item in batch), default=None
@@ -434,8 +495,7 @@ class StateStore:
             if item.path in retention.paths
             and (
                 item.path not in self._entries
-                or item.timestamp_monotonic
-                >= self._entries[item.path].last_observed_monotonic
+                or not self._strictly_older_than_entry(item, self._entries[item.path])
             )
         )
         changesets: list[ChangeSet] = []
@@ -462,9 +522,8 @@ class StateStore:
 
         for observation in relative:
             previous = retention.pending.get(observation.path)
-            if (
-                previous is None
-                or observation.timestamp_monotonic >= previous.timestamp_monotonic
+            if previous is None or not self._strictly_older_than_observation(
+                observation, previous
             ):
                 retention.pending[observation.path] = observation
 
@@ -614,6 +673,12 @@ class StateStore:
         self,
         observations: tuple[Observation, ...],
     ) -> ChangeSet:
+        if any(not self._is_current_observation(item) for item in observations):
+            return self._empty_changeset(
+                timestamp=max(
+                    (item.timestamp_monotonic for item in observations), default=None
+                )
+            )
         return self._merge_changesets(
             tuple(self._apply_one(item) for item in observations)
         )
@@ -743,6 +808,7 @@ class StateStore:
             changes=(),
             freshness=freshness,
             reconciliation_requests=reconciliation_requests,
+            provider_generation=self._provider_generation,
         )
         self._append_history(
             changes=(),
@@ -759,6 +825,7 @@ class StateStore:
             freshness_revision=self._freshness_revision,
             observation_seq=self._observation_seq,
             generated_at_monotonic=self._freshness_clock.now(),
+            provider_generation=self._provider_generation,
             fields=tuple(
                 FieldSnapshot(
                     path=path,
@@ -768,6 +835,8 @@ class StateStore:
                     max_age=entry.max_age,
                     source=entry.source,
                     quality=entry.quality,
+                    provider_generation=entry.provider_generation,
+                    clock_domain=entry.clock_domain,
                 )
                 for path, entry in sorted(
                     self._entries.items(),
@@ -788,6 +857,7 @@ class StateStore:
                 freshness=(),
                 reconciliation_requests=(),
                 requires_full_snapshot=True,
+                provider_generation=self._provider_generation,
             )
 
         changes: list[FieldChange] = []
@@ -814,11 +884,13 @@ class StateStore:
             changes=_copy_changes(tuple(changes)),
             freshness=tuple(freshness),
             reconciliation_requests=tuple(requests),
+            provider_generation=self._provider_generation,
         )
 
     def _requires_full_snapshot(self, snapshot: StateSnapshot) -> bool:
         return (
-            snapshot.state_revision < self._history_floor_state_revision
+            snapshot.provider_generation != self._provider_generation
+            or snapshot.state_revision < self._history_floor_state_revision
             or snapshot.freshness_revision < self._history_floor_freshness_revision
         )
 
@@ -857,9 +929,35 @@ class StateStore:
                 changes=_copy_changes(changes),
                 freshness=freshness,
                 reconciliation_requests=reconciliation_requests,
+                provider_generation=self._provider_generation,
             )
         )
         self._prune_history()
+
+    def _is_current_observation(self, observation: Observation) -> bool:
+        return observation.provider_generation == self._provider_generation
+
+    @staticmethod
+    def _strictly_older_than_entry(
+        observation: Observation, entry: _FieldEntry
+    ) -> bool:
+        return (
+            observation.provider_generation == entry.provider_generation
+            and observation.clock_domain is not None
+            and observation.clock_domain == entry.clock_domain
+            and observation.timestamp_monotonic < entry.last_observed_monotonic
+        )
+
+    @staticmethod
+    def _strictly_older_than_observation(
+        observation: Observation, previous: Observation
+    ) -> bool:
+        return (
+            observation.provider_generation == previous.provider_generation
+            and observation.clock_domain is not None
+            and observation.clock_domain == previous.clock_domain
+            and observation.timestamp_monotonic < previous.timestamp_monotonic
+        )
 
     def _prune_history(self) -> None:
         while len(self._history) > self._max_history_count:

--- a/tests/test_mor1408_state_generation_ordering.py
+++ b/tests/test_mor1408_state_generation_ordering.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+from rigplane.core.state_pipeline_contracts import (
+    FieldPath,
+    LOCAL_MONOTONIC_CLOCK_DOMAIN,
+    Observation,
+    SourceMetadata,
+)
+from rigplane.core.state_store import StateSnapshot, StateStore
+
+_LOCAL_CLOCK = LOCAL_MONOTONIC_CLOCK_DOMAIN
+_SOURCE = SourceMetadata(
+    source="poll_response",
+    provider="mor1408_test",
+    transport="fake",
+    native_id="sample",
+)
+
+
+def _observation(
+    path: FieldPath,
+    value: Any,
+    *,
+    at: float,
+    generation: int | None,
+    clock_domain: str | None = _LOCAL_CLOCK,
+) -> Observation:
+    return Observation(
+        path=path,
+        value=value,
+        source=_SOURCE,
+        timestamp_monotonic=at,
+        provider_generation=generation,
+        clock_domain=clock_domain,
+        max_age=30.0,
+    )
+
+
+def _relative_pair(*, generation: int, at: float = 10.0) -> tuple[Observation, ...]:
+    specs = (
+        (FieldPath.active("0", "freq_mode", "freq_hz"), 14_284_000, 0.0),
+        (FieldPath.active("0", "freq_mode", "mode"), "USB", 0.1),
+        (FieldPath.unselected("0", "freq_mode", "freq_hz"), 14_075_000, 0.2),
+        (FieldPath.unselected("0", "freq_mode", "mode"), "USB", 0.3),
+    )
+    return tuple(
+        _observation(path, value, at=at + offset, generation=generation)
+        for path, value, offset in specs
+    )
+
+
+def _configure_relative(store: StateStore, generation: int) -> None:
+    store.configure_relative_vfo_retention(
+        generation=generation, max_age=30.0, coherence_window=2.0
+    )
+
+
+def _mutation_surface(store: StateStore) -> tuple[object, ...]:
+    retention = store._relative_vfo_retention  # noqa: SLF001
+    snapshot = store.snapshot().to_dict()
+    snapshot.pop("generatedAtMonotonic")
+    return (
+        snapshot,
+        copy.deepcopy(store._history),  # noqa: SLF001
+        store._history_floor_state_revision,  # noqa: SLF001
+        store._history_floor_freshness_revision,  # noqa: SLF001
+        None if retention is None else copy.deepcopy(retention.pending),
+        None if retention is None else retention.expires_at,
+        None if retention is None else retention.generation,
+    )
+
+
+def test_begin_provider_generation_atomically_invalidates_all_live_and_relative_state() -> (
+    None
+):
+    store = StateStore()
+    external_epoch = 41
+    token = store.provider_generation
+    _configure_relative(store, external_epoch)
+    store.apply_relative_vfo_observations(
+        _relative_pair(generation=token), generation=external_epoch
+    )
+    store.apply_current(
+        _observation(
+            FieldPath.active_slot("0"),
+            "A",
+            at=10.4,
+            generation=None,
+        )
+    )
+    before = store.snapshot()
+    before_history_size = len(store._history)  # noqa: SLF001
+
+    next_token = store.begin_provider_generation()
+    after = store.snapshot()
+
+    assert next_token != token
+    assert after.provider_generation == next_token
+    assert after.fields == ()
+    assert after.state_revision == before.state_revision + 1
+    assert after.freshness_revision == before.freshness_revision
+    assert after.observation_seq == before.observation_seq
+    assert len(store._history) == before_history_size + 1  # noqa: SLF001
+    retention = store._relative_vfo_retention  # noqa: SLF001
+    assert retention is not None
+    assert retention.pending == {}
+    assert retention.expires_at is None
+    assert store.delta_since(before).requires_full_snapshot is True
+
+
+def test_old_generation_generic_observation_mutates_no_counter_history_or_provenance() -> (
+    None
+):
+    store = StateStore()
+    old_token = store.provider_generation
+    current_token = store.begin_provider_generation()
+    path = FieldPath.receiver("main", "meters", "s_meter")
+    store.apply(_observation(path, 42, at=20.0, generation=current_token))
+    before = _mutation_surface(store)
+
+    rejected = store.apply(_observation(path, 99, at=30.0, generation=old_token))
+
+    assert rejected.changes == ()
+    assert rejected.observed_paths == ()
+    assert _mutation_surface(store) == before
+
+
+def test_old_generation_relative_batch_mutates_no_pending_tuple_alias_or_expiry() -> (
+    None
+):
+    store = StateStore()
+    external_epoch = 9
+    old_token = store.provider_generation
+    _configure_relative(store, external_epoch)
+    current_token = store.begin_provider_generation()
+    store.apply_relative_vfo_observations(
+        _relative_pair(generation=current_token), generation=external_epoch
+    )
+    before = _mutation_surface(store)
+
+    rejected = store.apply_relative_vfo_observations(
+        _relative_pair(generation=old_token, at=40.0), generation=external_epoch
+    )
+
+    assert rejected.changes == ()
+    assert rejected.observed_paths == ()
+    assert _mutation_surface(store) == before
+
+
+def test_new_generation_accepts_numerically_lower_timestamp() -> None:
+    store = StateStore()
+    path = FieldPath.receiver("main", "meters", "s_meter")
+    store.apply(_observation(path, 10, at=1000.0, generation=store.provider_generation))
+    token = store.begin_provider_generation()
+
+    accepted = store.apply(_observation(path, 20, at=1.0, generation=token))
+
+    assert accepted.changes[0].current == 20
+    assert store.snapshot().field(path).last_observed_monotonic == 1.0
+
+
+def test_strictly_older_same_generation_same_local_clock_domain_is_rejected() -> None:
+    store = StateStore()
+    token = store.provider_generation
+    path = FieldPath.receiver("main", "meters", "s_meter")
+    store.apply(_observation(path, 20, at=20.0, generation=token))
+    before = _mutation_surface(store)
+
+    rejected = store.apply(_observation(path, 10, at=10.0, generation=token))
+
+    assert rejected.changes == ()
+    assert rejected.observed_paths == ()
+    assert _mutation_surface(store) == before
+
+
+def test_different_or_unknown_clock_domains_are_not_numerically_ordered() -> None:
+    store = StateStore()
+    token = store.provider_generation
+    path = FieldPath.receiver("main", "meters", "s_meter")
+    store.apply(
+        _observation(path, 20, at=20.0, generation=token, clock_domain="clock-a")
+    )
+
+    different = store.apply(
+        _observation(path, 10, at=10.0, generation=token, clock_domain="clock-b")
+    )
+    unknown = store.apply(
+        _observation(path, 5, at=5.0, generation=token, clock_domain=None)
+    )
+
+    assert different.changes[0].current == 10
+    assert unknown.changes[0].current == 5
+    assert store.snapshot().field(path).value == 5
+
+
+def test_missing_token_is_rejected_by_async_apply_and_apply_current_is_explicit() -> (
+    None
+):
+    store = StateStore()
+    path = FieldPath.global_("connection", "connected")
+    observation = _observation(path, True, at=1.0, generation=None)
+    before = _mutation_surface(store)
+
+    rejected = store.apply(observation)
+
+    assert rejected.changes == ()
+    assert _mutation_surface(store) == before
+    accepted = store.apply_current(observation)
+    assert accepted.changes[0].current is True
+    assert store.snapshot().field(path).provider_generation == store.provider_generation
+
+
+def test_snapshot_and_delta_carry_store_generation_not_external_epoch() -> None:
+    store = StateStore()
+    token = store.begin_provider_generation()
+    external_epoch = 88
+    _configure_relative(store, external_epoch)
+    baseline = StateSnapshot.empty()
+    store.apply_relative_vfo_observations(
+        _relative_pair(generation=token), generation=external_epoch
+    )
+
+    snapshot = store.snapshot()
+    delta = store.delta_since(baseline)
+
+    assert snapshot.provider_generation == token
+    assert {field.provider_generation for field in snapshot.fields} == {token}
+    assert delta.provider_generation == token
+    assert snapshot.to_dict()["providerGeneration"] == token
+    assert delta.to_dict()["providerGeneration"] == token
+
+
+def test_bootstrap_default_zero_is_fixed_and_never_late_bound() -> None:
+    store = StateStore()
+    path = FieldPath.global_("connection", "ready")
+    bootstrap = Observation(
+        path=path,
+        value=True,
+        source=SourceMetadata(source="test", provider="mor1408_test"),
+        timestamp_monotonic=1.0,
+    )
+    assert bootstrap.provider_generation == 0
+    store.apply(bootstrap)
+    token = store.begin_provider_generation()
+    before = _mutation_surface(store)
+
+    default_zero_created_after_advance = Observation(
+        path=path,
+        value=False,
+        source=bootstrap.source,
+        timestamp_monotonic=2.0,
+    )
+    missing = Observation(
+        path=path,
+        value=False,
+        source=bootstrap.source,
+        timestamp_monotonic=2.0,
+        provider_generation=None,
+    )
+
+    assert default_zero_created_after_advance.provider_generation == 0
+    assert store.apply(default_zero_created_after_advance).changes == ()
+    assert store.apply(missing).changes == ()
+    assert _mutation_surface(store) == before
+    accepted = store.apply_current(missing)
+    assert accepted.changes[0].current is False
+    assert store.snapshot().field(path).provider_generation == token


### PR DESCRIPTION
Part of #2316.

## What changed

- add immutable provider-generation and clock-domain metadata to observations and Store snapshots/deltas;
- add a Store-owned generation boundary that atomically invalidates prior live and relative-VFO proof;
- reject missing/stale provider tokens and strictly older observations only within one explicit comparable clock domain, before any revision, freshness, provenance, history, or relative-retention mutation;
- add `apply_current()` as an explicit synchronous-only compatibility boundary.

The constructor default generation is the fixed bootstrap token `0`; it is never resolved to the Store's current token at apply time. Once `begin_provider_generation()` advances the Store, an unadopted default-`0` observation fails closed. Producer adoption and Web publication are intentionally excluded from this B0 slice.

## Scope

- production ownership: `state_pipeline_contracts.py`, `state_store.py` only;
- no provider wiring, polling, commands/ACK, PTT, audio, scope, spectrum, WebSocket, frontend, or managed-TX change;
- exact base: `a7bf0abd8b2e403b84fb15f825cfde37ed01f8a1`;
- production churn: 158 lines (144 additions, 14 deletions), 130 net.

## Verification

- controlled baseline RED: exact eight required tests collected and failed 8/8 on the missing generation API;
- focused StateStore/contracts: 248 passed;
- full suite: 9187 passed, 68 skipped, 5 deselected, 11 xfailed, 1 xpassed;
- `ruff check src/ tests/`: pass;
- `ruff format --check` on changed files: pass;
- `lint-imports`: 5 contracts kept;
- mypy on both changed production files: pass.

Full-tree mypy still reports the same 11 pre-existing errors in `_control_phase.py` and `_audio_runtime_mixin.py`; they were reproduced unchanged on exact base `a7bf0abd` and are outside this PR.

Independent exact-head review is required. This builder does not provide `Agent Review: PASS` and will not merge the PR.
