### PR TITLE
feat: add managed provider PTT lifecycle fence

### DIFF
--- a/src/rigplane/runtime/managed_ptt_lifecycle.py
+++ b/src/rigplane/runtime/managed_ptt_lifecycle.py
@@ -1,0 +1,182 @@
+"""Transport-free lifecycle fence for managed provider PTT effects.
+
+The adapter deliberately knows only how to identify the current physical port,
+dispatch a PTT write, and perform a separate authoritative PTT read.  The
+managed runtime remains the sole owner of leases, retries, watchdogs, and
+effect ordering.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+from rigplane.core.tx_safety import ProviderPttObservation, RadioTx
+
+_Observer = Callable[[ProviderPttObservation], None]
+
+
+@dataclass(frozen=True, slots=True)
+class _Binding:
+    provider_generation: int
+    lifecycle_generation: int
+    port_token: object
+    observer: _Observer
+
+
+class ProviderTxLifecycle:
+    """Fence callable-based provider PTT I/O to one captured physical port."""
+
+    def __init__(
+        self,
+        *,
+        port_token: Callable[[], object | None],
+        write_ptt: Callable[[bool], Awaitable[None]],
+        read_ptt: Callable[[], Awaitable[bool]],
+        clock: Callable[[], float] | None = None,
+        drain_timeout_seconds: float = 3.0,
+    ) -> None:
+        if not 0 < drain_timeout_seconds < float("inf"):
+            raise ValueError("drain_timeout_seconds must be positive and finite")
+        self._port_token = port_token
+        self._write_ptt = write_ptt
+        self._read_ptt = read_ptt
+        self._clock = clock or time.monotonic
+        self._drain_timeout = drain_timeout_seconds
+        self._binding: _Binding | None = None
+        self._lifecycle_generation = 0
+        self._observation_sequence = 0
+        self._retired_provider_generations: set[int] = set()
+        self._inflight: dict[asyncio.Task[object], _Binding] = {}
+
+    def _live_port_token(self) -> object | None:
+        try:
+            return self._port_token()
+        except Exception as exc:
+            raise ConnectionError("managed TX physical port token unavailable") from exc
+
+    def _require_current(
+        self, provider_generation: int, observer: _Observer | None = None
+    ) -> _Binding:
+        binding = self._binding
+        if (
+            binding is None
+            or binding.provider_generation != provider_generation
+            or binding.lifecycle_generation != self._lifecycle_generation
+            or self._live_port_token() is not binding.port_token
+            or (observer is not None and observer is not binding.observer)
+        ):
+            raise ConnectionError("managed TX physical port is stale")
+        return binding
+
+    def _require_binding(self, binding: _Binding) -> None:
+        if (
+            self._require_current(binding.provider_generation, binding.observer)
+            is not binding
+        ):
+            raise ConnectionError("managed TX physical port is stale")
+
+    def _capture_managed_tx_port(
+        self, provider_generation: int, observer: _Observer
+    ) -> bool:
+        if (
+            not isinstance(provider_generation, int)
+            or isinstance(provider_generation, bool)
+            or provider_generation < 0
+        ):
+            raise ValueError("provider_generation must be a non-negative integer")
+        if self._binding is not None:
+            raise ConnectionError("managed TX physical port is already captured")
+        if provider_generation in self._retired_provider_generations:
+            raise ConnectionError("managed TX provider generation is terminal")
+        token = self._live_port_token()
+        if token is None:
+            return False
+        self._lifecycle_generation += 1
+        self._binding = _Binding(
+            provider_generation,
+            self._lifecycle_generation,
+            token,
+            observer,
+        )
+        return True
+
+    def _poison(self, binding: _Binding) -> tuple[asyncio.Task[object], ...]:
+        if self._binding is not binding:
+            return ()
+        self._binding = None
+        self._lifecycle_generation += 1
+        self._retired_provider_generations.add(binding.provider_generation)
+        current = asyncio.current_task()
+        tasks = tuple(
+            task
+            for task, task_binding in self._inflight.items()
+            if task_binding is binding and task is not current
+        )
+        for task in tasks:
+            task.cancel()
+        return tasks
+
+    def _unbind_authoritative_ptt_observer(self) -> None:
+        if (binding := self._binding) is not None:
+            self._poison(binding)
+
+    def _track_current_task(self, binding: _Binding) -> asyncio.Task[object]:
+        task = asyncio.current_task()
+        if task is None:
+            raise RuntimeError("managed TX lifecycle requires an asyncio task")
+        self._inflight[task] = binding
+        return task
+
+    def _untrack(self, task: asyncio.Task[object], binding: _Binding) -> None:
+        if self._inflight.get(task) is binding:
+            self._inflight.pop(task, None)
+
+    async def _write_managed_ptt(self, provider_generation: int, on: bool) -> None:
+        binding = self._require_current(provider_generation)
+        task = self._track_current_task(binding)
+        try:
+            self._require_binding(binding)
+            await self._write_ptt(on)
+            self._require_binding(binding)
+        finally:
+            self._untrack(task, binding)
+
+    async def _request_authoritative_ptt_read(
+        self, *, provider_generation: int, observer: _Observer
+    ) -> None:
+        binding = self._require_current(provider_generation, observer)
+        task = self._track_current_task(binding)
+        try:
+            self._require_binding(binding)
+            value = await self._read_ptt()
+            if type(value) is not bool:
+                raise ValueError("authoritative PTT read must return bool")
+            self._require_binding(binding)
+            self._observation_sequence += 1
+            observer(
+                ProviderPttObservation(
+                    RadioTx.ON if value else RadioTx.OFF,
+                    provider_generation,
+                    self._observation_sequence,
+                    self._clock(),
+                )
+            )
+        finally:
+            self._untrack(task, binding)
+
+    async def _retire_managed_tx_port(self, provider_generation: int) -> None:
+        binding = self._binding
+        if binding is None:
+            if provider_generation in self._retired_provider_generations:
+                return
+            raise ConnectionError("managed TX physical port was not captured")
+        if binding.provider_generation != provider_generation:
+            raise ConnectionError("managed TX physical port is stale")
+
+        # Poison and issue cancellation before retirement's first await.
+        tasks = self._poison(binding)
+        if tasks:
+            await asyncio.wait(tasks, timeout=self._drain_timeout)

--- a/src/rigplane/runtime/managed_ptt_lifecycle.py
+++ b/src/rigplane/runtime/managed_ptt_lifecycle.py
@@ -50,6 +50,7 @@ class ProviderTxLifecycle:
         self._observation_sequence = 0
         self._retired_provider_generations: set[int] = set()
         self._inflight: dict[asyncio.Task[object], _Binding] = {}
+        self._inflight_writes: set[asyncio.Task[object]] = set()
 
     def _live_port_token(self) -> object | None:
         try:
@@ -89,6 +90,8 @@ class ProviderTxLifecycle:
             raise ValueError("provider_generation must be a non-negative integer")
         if self._binding is not None:
             raise ConnectionError("managed TX physical port is already captured")
+        if self._inflight_writes:
+            raise ConnectionError("managed TX prior write is still pending")
         if provider_generation in self._retired_provider_generations:
             raise ConnectionError("managed TX provider generation is terminal")
         token = self._live_port_token()
@@ -137,11 +140,13 @@ class ProviderTxLifecycle:
     async def _write_managed_ptt(self, provider_generation: int, on: bool) -> None:
         binding = self._require_current(provider_generation)
         task = self._track_current_task(binding)
+        self._inflight_writes.add(task)
         try:
             self._require_binding(binding)
             await self._write_ptt(on)
             self._require_binding(binding)
         finally:
+            self._inflight_writes.discard(task)
             self._untrack(task, binding)
 
     async def _request_authoritative_ptt_read(

--- a/tests/test_managed_ptt_lifecycle.py
+++ b/tests/test_managed_ptt_lifecycle.py
@@ -150,6 +150,50 @@ async def test_retirement_prevents_stale_on_after_replacement() -> None:
     assert writes == [False]
 
 
+async def test_replacement_waits_for_stubborn_old_write_to_be_terminal() -> None:
+    started, cancelled, release = asyncio.Event(), asyncio.Event(), asyncio.Event()
+    events: list[str] = []
+    port = _Port(object())
+
+    async def stubborn_write(on: bool) -> None:
+        started.set()
+        try:
+            await release.wait()
+        except asyncio.CancelledError:
+            cancelled.set()
+            await release.wait()
+        events.append(f"wire:{on}")
+
+    async def read() -> bool:
+        return False
+
+    lifecycle = _lifecycle(port, write=stubborn_write, read=read, drain_timeout=0.01)
+    assert lifecycle._capture_managed_tx_port(1, lambda _observation: None)
+    stale_on = asyncio.create_task(lifecycle._write_managed_ptt(1, True))
+    await started.wait()
+
+    before = time.monotonic()
+    await lifecycle._retire_managed_tx_port(1)
+    elapsed = time.monotonic() - before
+    assert cancelled.is_set()
+    assert elapsed < 0.2
+    assert not stale_on.done()
+
+    port.current = object()
+    try:
+        with pytest.raises(ConnectionError, match="write.*pending"):
+            lifecycle._capture_managed_tx_port(2, lambda _observation: None)
+    finally:
+        release.set()
+        with pytest.raises(ConnectionError, match="stale"):
+            await stale_on
+
+    assert events == ["wire:True"]
+    assert lifecycle._capture_managed_tx_port(2, lambda _observation: None)
+    events.append("replacement:valid")
+    assert events == ["wire:True", "replacement:valid"]
+
+
 @pytest.mark.parametrize("result", [RuntimeError("read failed"), 1])
 async def test_read_failure_or_malformed_value_never_becomes_truth(
     result: BaseException | int,

--- a/tests/test_managed_ptt_lifecycle.py
+++ b/tests/test_managed_ptt_lifecycle.py
@@ -1,0 +1,351 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from rigplane.core.tx_safety import ProviderPttObservation, RadioTx, TxOwner, TxSource
+from rigplane.runtime.managed_radio_runtime import ManagedRadioRuntime
+from rigplane.runtime.managed_tx_effect_service import managed_tx_effect_service
+
+
+@dataclass
+class _Port:
+    current: object | None
+
+
+def _lifecycle(
+    port: _Port,
+    *,
+    write: Callable[[bool], Awaitable[None]],
+    read: Callable[[], Awaitable[Any]],
+    drain_timeout: float = 0.02,
+):
+    from rigplane.runtime.managed_ptt_lifecycle import ProviderTxLifecycle
+
+    return ProviderTxLifecycle(
+        port_token=lambda: port.current,
+        write_ptt=write,
+        read_ptt=read,
+        clock=lambda: 12.5,
+        drain_timeout_seconds=drain_timeout,
+    )
+
+
+async def test_write_ack_alone_never_publishes_authoritative_ptt() -> None:
+    writes: list[bool] = []
+    observations: list[ProviderPttObservation] = []
+    port = _Port(object())
+
+    async def write(on: bool) -> None:
+        writes.append(on)
+
+    async def read() -> bool:
+        return True
+
+    lifecycle = _lifecycle(port, write=write, read=read)
+    assert lifecycle._capture_managed_tx_port(1, observations.append)
+
+    await lifecycle._write_managed_ptt(1, True)
+
+    assert writes == [True]
+    assert observations == []
+
+
+async def test_stale_generation_cannot_write_or_publish() -> None:
+    writes: list[bool] = []
+    observations: list[ProviderPttObservation] = []
+    observer = observations.append
+    port = _Port(object())
+
+    async def write(on: bool) -> None:
+        writes.append(on)
+
+    async def read() -> bool:
+        return True
+
+    lifecycle = _lifecycle(port, write=write, read=read)
+    assert lifecycle._capture_managed_tx_port(1, observer)
+    await lifecycle._retire_managed_tx_port(1)
+    port.current = object()
+    assert lifecycle._capture_managed_tx_port(2, observer)
+
+    with pytest.raises(ConnectionError, match="stale"):
+        await lifecycle._write_managed_ptt(1, True)
+    with pytest.raises(ConnectionError, match="stale"):
+        await lifecycle._request_authoritative_ptt_read(
+            provider_generation=1, observer=observer
+        )
+
+    assert writes == []
+    assert observations == []
+
+
+async def test_late_read_after_retirement_is_inert() -> None:
+    started, release = asyncio.Event(), asyncio.Event()
+    observations: list[ProviderPttObservation] = []
+    observer = observations.append
+    port = _Port(object())
+
+    async def write(_on: bool) -> None:
+        return None
+
+    async def read() -> bool:
+        started.set()
+        try:
+            await release.wait()
+        except asyncio.CancelledError:
+            await release.wait()
+        return True
+
+    lifecycle = _lifecycle(port, write=write, read=read)
+    assert lifecycle._capture_managed_tx_port(1, observer)
+    pending = asyncio.create_task(
+        lifecycle._request_authoritative_ptt_read(
+            provider_generation=1, observer=observer
+        )
+    )
+    await started.wait()
+    retirement = asyncio.create_task(lifecycle._retire_managed_tx_port(1))
+    await asyncio.sleep(0)
+    release.set()
+    await retirement
+
+    with pytest.raises(ConnectionError, match="stale"):
+        await pending
+    assert observations == []
+
+
+async def test_retirement_prevents_stale_on_after_replacement() -> None:
+    started, release = asyncio.Event(), asyncio.Event()
+    writes: list[bool] = []
+    port = _Port(object())
+
+    async def write(on: bool) -> None:
+        if not writes:
+            started.set()
+            await release.wait()
+        writes.append(on)
+
+    async def read() -> bool:
+        return False
+
+    lifecycle = _lifecycle(port, write=write, read=read)
+    assert lifecycle._capture_managed_tx_port(1, lambda _observation: None)
+    stale_on = asyncio.create_task(lifecycle._write_managed_ptt(1, True))
+    await started.wait()
+
+    await lifecycle._retire_managed_tx_port(1)
+    port.current = object()
+    assert lifecycle._capture_managed_tx_port(2, lambda _observation: None)
+
+    with pytest.raises(asyncio.CancelledError):
+        await stale_on
+    release.set()
+    await lifecycle._write_managed_ptt(2, False)
+    assert writes == [False]
+
+
+@pytest.mark.parametrize("result", [RuntimeError("read failed"), 1])
+async def test_read_failure_or_malformed_value_never_becomes_truth(
+    result: BaseException | int,
+) -> None:
+    observations: list[ProviderPttObservation] = []
+    observer = observations.append
+    port = _Port(object())
+
+    async def write(_on: bool) -> None:
+        return None
+
+    async def read() -> Any:
+        if isinstance(result, BaseException):
+            raise result
+        return result
+
+    lifecycle = _lifecycle(port, write=write, read=read)
+    assert lifecycle._capture_managed_tx_port(1, observer)
+
+    with pytest.raises((RuntimeError, ValueError)):
+        await lifecycle._request_authoritative_ptt_read(
+            provider_generation=1, observer=observer
+        )
+    assert observations == []
+
+
+async def test_authoritative_observation_sequence_is_monotonic() -> None:
+    values = iter((False, True, False))
+    observations: list[ProviderPttObservation] = []
+    observer = observations.append
+    port = _Port(object())
+
+    async def write(_on: bool) -> None:
+        return None
+
+    async def read() -> bool:
+        return next(values)
+
+    lifecycle = _lifecycle(port, write=write, read=read)
+    assert lifecycle._capture_managed_tx_port(7, observer)
+    for _ in range(3):
+        await lifecycle._request_authoritative_ptt_read(
+            provider_generation=7, observer=observer
+        )
+
+    assert [item.ptt_observation_seq for item in observations] == [1, 2, 3]
+    assert [item.value for item in observations] == [
+        RadioTx.OFF,
+        RadioTx.ON,
+        RadioTx.OFF,
+    ]
+    assert {item.provider_generation for item in observations} == {7}
+    assert {item.observed_at_monotonic for item in observations} == {12.5}
+
+
+async def test_physical_port_token_mismatch_fails_closed() -> None:
+    writes: list[bool] = []
+    observations: list[ProviderPttObservation] = []
+    observer = observations.append
+    port = _Port(object())
+
+    async def write(on: bool) -> None:
+        writes.append(on)
+
+    async def read() -> bool:
+        return False
+
+    lifecycle = _lifecycle(port, write=write, read=read)
+    assert lifecycle._capture_managed_tx_port(1, observer)
+    port.current = object()
+
+    with pytest.raises(ConnectionError, match="stale"):
+        await lifecycle._write_managed_ptt(1, True)
+    with pytest.raises(ConnectionError, match="stale"):
+        await lifecycle._request_authoritative_ptt_read(
+            provider_generation=1, observer=observer
+        )
+
+    assert writes == []
+    assert observations == []
+
+
+async def test_retirement_drain_is_bounded_and_cancellation_safe() -> None:
+    started, cancelled, release = asyncio.Event(), asyncio.Event(), asyncio.Event()
+    port = _Port(object())
+
+    async def write(_on: bool) -> None:
+        return None
+
+    async def stubborn_read() -> bool:
+        started.set()
+        try:
+            await release.wait()
+        except asyncio.CancelledError:
+            cancelled.set()
+            await release.wait()
+        return False
+
+    lifecycle = _lifecycle(port, write=write, read=stubborn_read, drain_timeout=0.01)
+
+    def observer(_observation: ProviderPttObservation) -> None:
+        return None
+
+    assert lifecycle._capture_managed_tx_port(1, observer)
+    pending = asyncio.create_task(
+        lifecycle._request_authoritative_ptt_read(
+            provider_generation=1, observer=observer
+        )
+    )
+    await started.wait()
+
+    before = time.monotonic()
+    await lifecycle._retire_managed_tx_port(1)
+    elapsed = time.monotonic() - before
+
+    assert cancelled.is_set()
+    assert elapsed < 0.2
+    assert not pending.done()
+    with pytest.raises(ConnectionError, match="stale"):
+        await lifecycle._write_managed_ptt(1, True)
+
+    release.set()
+    with pytest.raises(ConnectionError, match="stale"):
+        await pending
+
+    started_2, cancelled_2, release_2 = (
+        asyncio.Event(),
+        asyncio.Event(),
+        asyncio.Event(),
+    )
+    port_2 = _Port(object())
+
+    async def stubborn_read_2() -> bool:
+        started_2.set()
+        try:
+            await release_2.wait()
+        except asyncio.CancelledError:
+            cancelled_2.set()
+            await release_2.wait()
+        return True
+
+    lifecycle_2 = _lifecycle(
+        port_2, write=write, read=stubborn_read_2, drain_timeout=1.0
+    )
+    assert lifecycle_2._capture_managed_tx_port(2, observer)
+    pending_2 = asyncio.create_task(
+        lifecycle_2._request_authoritative_ptt_read(
+            provider_generation=2, observer=observer
+        )
+    )
+    await started_2.wait()
+    retirement_2 = asyncio.create_task(lifecycle_2._retire_managed_tx_port(2))
+    await cancelled_2.wait()
+    retirement_2.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await retirement_2
+    with pytest.raises(ConnectionError, match="stale"):
+        await lifecycle_2._write_managed_ptt(2, True)
+    release_2.set()
+    with pytest.raises(ConnectionError, match="stale"):
+        await pending_2
+
+
+async def test_lifecycle_drives_the_existing_managed_runtime_contract() -> None:
+    events: list[str] = []
+    keyed = False
+    port = _Port(object())
+
+    async def write(on: bool) -> None:
+        nonlocal keyed
+        events.append(f"write:{on}")
+        keyed = on
+
+    async def read() -> bool:
+        events.append("read")
+        return keyed
+
+    lifecycle = _lifecycle(port, write=write, read=read)
+    runtime = ManagedRadioRuntime(
+        "test",
+        service_factory=managed_tx_effect_service,
+        provider_lifecycle=lifecycle,
+    )
+    await runtime.replace_provider(ready=True)
+    await runtime.request_fresh_ptt()
+
+    owner = TxOwner(TxSource.WEBSOCKET, "ws-1")
+    keyed_transition = await runtime.request_on(owner)
+    assert runtime.tx_snapshot.radio_tx is RadioTx.ON
+    assert keyed_transition.snapshot.lease_id is not None
+    await runtime.request_off(owner, keyed_transition.snapshot.lease_id)
+
+    assert runtime.tx_snapshot.radio_tx is RadioTx.OFF
+    assert events == ["read", "write:True", "read", "write:False", "read"]
+    await runtime.shutdown(release_provider=_noop_release)
+
+
+async def _noop_release() -> None:
+    return None


### PR DESCRIPTION
## Summary

- add a transport-free callable-based `ProviderTxLifecycle`
- fence writes and authoritative reads to one captured physical-port token and provider generation
- publish only separately-read boolean PTT truth as monotonic `ProviderPttObservation` values
- poison a retiring generation before awaiting and bound cancellation/drain of in-flight effects

Part of #2328.

## Safety boundaries

- no provider wiring in this slice
- no transport, queue, lease, watchdog, StateStore, background timer, or PTT command encoding ownership
- write/ACK success never publishes TX/RX truth
- stale generation, stale physical-port token, malformed readback, late readback, and cancelled retirement all fail closed
- no hardware or TX actuation was used

## Validation

- controlled RED: 9/9 lifecycle cases failed before the module existed
- lifecycle contract: 10 passed
- focused managed-TX/runtime/effect/PTT suites: 312 passed
- full suite: 9136 passed, 129 skipped, 5 deselected, 11 xfailed, 1 xpassed
- Ruff: pass
- import-linter: 5 contracts kept, 0 broken
- owned-module mypy: pass
- full mypy: 11 pre-existing errors in `_control_phase.py` and `_audio_runtime_mixin.py`, reproduced unchanged on exact base `1a3b62d5d89e733dbec172c955ffd6df591764c7`
