### PR TITLE
fix(#2316): bind Core observations to Store generations

### DIFF
--- a/src/rigplane/core/command_service.py
+++ b/src/rigplane/core/command_service.py
@@ -142,6 +142,7 @@ class CommandService:
         self._record_intent_overlay(intent)
         self.emit_lifecycle(intent, "queued")
         self.emit_lifecycle(intent, "sent")
+        provider_generation = self._state_store.provider_generation
 
         try:
             executor_result = await self._executor.execute(intent)
@@ -165,7 +166,14 @@ class CommandService:
         self.emit_lifecycle(intent, "acknowledged", details=executor_result.details)
         changes: list[ChangeSet] = []
         for observation in executor_result.observations:
-            changes.append(self.apply_observation(observation))
+            changes.append(
+                self.apply_observation(
+                    replace(
+                        observation,
+                        provider_generation=provider_generation,
+                    )
+                )
+            )
 
         return CommandServiceResult(
             lifecycle_events=tuple(self._events[start:]),
@@ -178,7 +186,11 @@ class CommandService:
 
         observation = self._normalize_correlated_readback_observation(observation)
         changeset = self._state_store.apply(observation)
-        self._reconcile_observation(observation, changeset)
+        if (
+            changeset.observed_paths
+            and observation.provider_generation == self._state_store.provider_generation
+        ):
+            self._reconcile_observation(observation, changeset)
         return changeset
 
     def fail_command(

--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -584,8 +584,13 @@ class CivRuntime:
     def start_pump(self) -> None:
         """Start always-on CI-V receive pump."""
         if self._host._civ_rx_task is None or self._host._civ_rx_task.done():
+            source_generation = self._host._civ_epoch
+            store_provider_generation = self._host._state_store.provider_generation
             self._host._civ_rx_task = asyncio.create_task(
-                self._civ_rx_loop(source_generation=self._host._civ_epoch)
+                self._civ_rx_loop(
+                    source_generation=source_generation,
+                    store_provider_generation=store_provider_generation,
+                )
             )
 
     def bind_ptt_observer(
@@ -854,6 +859,7 @@ class CivRuntime:
         self._host._civ_epoch = self._host._civ_request_tracker.advance_generation(
             ConnectionError(f"CI-V generation advanced: {reason}")
         )
+        self._host._state_store.begin_provider_generation()
         for token in self._managed_tx_ports.values():
             if token.civ_source_generation == source_generation:
                 self._poison_managed_tx_port(token)
@@ -1376,7 +1382,12 @@ class CivRuntime:
         )
         return non_scope_packets + kept_scope
 
-    async def _civ_rx_loop(self, *, source_generation: int) -> None:
+    async def _civ_rx_loop(
+        self,
+        *,
+        source_generation: int,
+        store_provider_generation: int,
+    ) -> None:
         """Continuously consume CI-V transport packets and route events."""
         assert self._host._civ_transport is not None
         self._active_rx_source_generation = source_generation
@@ -1416,12 +1427,10 @@ class CivRuntime:
                         self._remember_raw_received_frame_bytes(frame, frame_bytes)
                         self.deliver_raw_civ(frame_bytes)
                         try:
-                            generation = source_generation
-                            if self._host._civ_rx_task is asyncio.current_task():
-                                generation = self._host._civ_epoch
                             await self._route_civ_frame(
                                 frame,
-                                generation=generation,
+                                generation=source_generation,
+                                store_provider_generation=store_provider_generation,
                             )
                         except Exception:
                             logger.exception(
@@ -1434,7 +1443,13 @@ class CivRuntime:
             if self._active_rx_source_generation == source_generation:
                 self._active_rx_source_generation = None
 
-    async def _route_civ_frame(self, frame: CivFrame, *, generation: int) -> None:
+    async def _route_civ_frame(
+        self,
+        frame: CivFrame,
+        *,
+        generation: int,
+        store_provider_generation: int | None = None,
+    ) -> None:
         """Route one parsed CI-V frame into command/scope event paths."""
         if frame.from_addr != self._host._radio_addr:
             return
@@ -1476,6 +1491,7 @@ class CivRuntime:
             self._update_state_cache_from_frame(
                 frame,
                 source_generation=generation,
+                store_provider_generation=store_provider_generation,
             )
         self._publish_civ_event(event)
         claimed: _CivDataTransaction | None = None
@@ -1559,17 +1575,15 @@ class CivRuntime:
         frame: CivFrame,
         *,
         source_generation: int | None = None,
+        store_provider_generation: int | None = None,
     ) -> None:
         """Best-effort update of state cache from an incoming CI-V frame."""
-        current_generation = getattr(self._host, "_civ_epoch", 0)
-        if not isinstance(current_generation, int) or isinstance(
-            current_generation, bool
-        ):
-            current_generation = 0
         self._apply_state_store_observations(
             frame,
             generation=(
-                current_generation if source_generation is None else source_generation
+                self._host._state_store.provider_generation
+                if store_provider_generation is None
+                else store_provider_generation
             ),
         )
 
@@ -1782,6 +1796,19 @@ class CivRuntime:
             )
             return
 
+        store_provider_generation = (
+            self._host._state_store.provider_generation
+            if generation is None
+            else generation
+        )
+        observations = tuple(
+            _replace_dataclass(
+                observation,
+                provider_generation=store_provider_generation,
+            )
+            for observation in observations
+        )
+
         if (
             frame.command in (0x00, 0x01, 0x03, 0x04, 0x25, 0x26)
             and getattr(self._host._profile, "vfo_readback", "none")
@@ -1789,9 +1816,7 @@ class CivRuntime:
         ):
             changeset = self._host._state_store.apply_relative_vfo_observations(
                 observations,
-                generation=(
-                    self._host._civ_epoch if generation is None else generation
-                ),
+                generation=store_provider_generation,
             )
             self._record_scheduler_results_for_changeset(changeset)
             self._notify_state_store_changed(changeset)

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -3127,7 +3127,10 @@ class RadioPoller:
                     "selected/unselected provider lacks confirmed VFO selection"
                 )
             await confirmed_select(slot, receiver=receiver)
-            if generation != self._vfo_binding_generation:
+            if (
+                generation != self._vfo_binding_generation
+                or provider_generation != self._provider_generation()
+            ):
                 return
 
             self._discard_vfo_identity(receiver)
@@ -3139,8 +3142,16 @@ class RadioPoller:
             if not isinstance(self._radio, RelativeVfoReadbackCapable):
                 raise CommandError("provider lacks relative VFO readback")
             selected = await self._radio.read_relative_vfo(selected=True)
+            if (
+                generation != self._vfo_binding_generation
+                or provider_generation != self._provider_generation()
+            ):
+                return
             unselected = await self._radio.read_relative_vfo(selected=False)
-            if generation != self._vfo_binding_generation:
+            if (
+                generation != self._vfo_binding_generation
+                or provider_generation != self._provider_generation()
+            ):
                 return
             receiver_id = str(receiver)
             for state, relative_slot in (
@@ -3165,7 +3176,11 @@ class RadioPoller:
                 self._on_state_event("vfo_changed", {"vfo": slot, "receiver": receiver})
         except BaseException:
             # After ACK the target remains known even if passive readback fails.
-            if generation == self._vfo_binding_generation and not selection_confirmed:
+            if (
+                generation == self._vfo_binding_generation
+                and provider_generation == self._provider_generation()
+                and not selection_confirmed
+            ):
                 self._discard_vfo_identity(receiver)
             raise
         finally:

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -512,12 +512,7 @@ class RadioPoller:
         self._max_key_down_timer: asyncio.TimerHandle | None = None
 
     def _provider_generation(self) -> int:
-        generation = getattr(self._radio, "_civ_epoch", 0)
-        return (
-            generation
-            if isinstance(generation, int) and not isinstance(generation, bool)
-            else 0
-        )
+        return cast(int, self._state_store.provider_generation)
 
     def _relative_vfo_retention_policy(self) -> tuple[float, float]:
         """Derive a finite tuple window from this provider's expected cadence."""
@@ -546,6 +541,7 @@ class RadioPoller:
         source: CommandSource,
         session_id: str | None,
         command_service: CommandService | None,
+        provider_generation: int,
     ) -> None:
         observed_at = time.monotonic()
         metadata = SourceMetadata(
@@ -562,6 +558,7 @@ class RadioPoller:
                 source=metadata,
                 timestamp_monotonic=observed_at,
                 correlation_id=f"{command_id}:freq" if command_id else None,
+                provider_generation=provider_generation,
             ),
             Observation(
                 path=FieldPath.active("0", "freq_mode", "mode"),
@@ -569,6 +566,7 @@ class RadioPoller:
                 source=metadata,
                 timestamp_monotonic=observed_at,
                 correlation_id=f"{command_id}:mode" if command_id else None,
+                provider_generation=provider_generation,
             ),
         )
         for observation in observations:
@@ -1043,6 +1041,7 @@ class RadioPoller:
         source: CommandSource | None = None,
         session_id: str | None = None,
         command_service: CommandService | None = None,
+        provider_generation: int,
     ) -> None:
         """Apply a confirmed global readback value to the StateStore.
 
@@ -1065,6 +1064,7 @@ class RadioPoller:
             ),
             timestamp_monotonic=time.monotonic(),
             correlation_id=f"{command_id}:{name}" if command_id else None,
+            provider_generation=provider_generation,
         )
         if command_service is not None:
             command_service.apply_observation(observation)
@@ -1085,6 +1085,7 @@ class RadioPoller:
         """
         if CAP_NB not in self._caps:
             return
+        provider_generation = self._provider_generation()
         radio: Any = self._radio
         getters: tuple[tuple[str, str, Any], ...] = (
             ("nb_depth", "get_nb_depth", getattr(radio, "get_nb_depth", None)),
@@ -1098,7 +1099,11 @@ class RadioPoller:
             except Exception:
                 logger.debug("radio-poller: %s failed", label, exc_info=True)
                 continue
-            self._apply_global_control_observation(name, value)
+            self._apply_global_control_observation(
+                name,
+                value,
+                provider_generation=provider_generation,
+            )
         logger.info("radio-poller: NB controls fetched")
 
     async def _read_mod_input(
@@ -1109,12 +1114,18 @@ class RadioPoller:
         source: CommandSource | None = None,
         session_id: str | None = None,
         command_service: CommandService | None = None,
+        provider_generation: int | None = None,
     ) -> None:
         """Read one DATA-group MOD-input source into the StateStore + mirror.
 
         Resilient: a read error or timeout is logged at debug and never kills
         the caller (mirrors ``_fetch_nb_controls``).
         """
+        generation = (
+            self._provider_generation()
+            if provider_generation is None
+            else provider_generation
+        )
         getter = getattr(self._radio, f"get_{name}", None)
         if getter is None:
             return
@@ -1133,6 +1144,7 @@ class RadioPoller:
             source=source,
             session_id=session_id,
             command_service=command_service,
+            provider_generation=generation,
         )
 
     async def _fetch_mod_inputs(self) -> None:
@@ -1539,6 +1551,7 @@ class RadioPoller:
         command_service: CommandService | None = None,
     ) -> None:
         radio = self._radio
+        provider_generation = self._provider_generation()
         _r: Any = radio  # cast for capability methods not on base Radio protocol
         # Alias the command source under a distinct name: ``source`` is reused as
         # a match capture variable by several ``case Set*ModInput(source=...)``
@@ -2094,6 +2107,7 @@ class RadioPoller:
                             source=source,
                             session_id=session_id,
                             command_service=command_service,
+                            provider_generation=provider_generation,
                         )
                         # Update local state immediately (don't wait for transceive echo)
                         if self._radio_state:
@@ -2157,6 +2171,7 @@ class RadioPoller:
                             source=source,
                             session_id=session_id,
                             command_service=command_service,
+                            provider_generation=provider_generation,
                         )
                     else:
                         set_vfo_slot = getattr(radio, "set_vfo_slot", None)
@@ -2513,6 +2528,7 @@ class RadioPoller:
                             source=command_source,
                             session_id=session_id,
                             command_service=command_service,
+                            provider_generation=provider_generation,
                         )
             case SetNbWidth(level=level, receiver=rx):
                 self._ensure_receiver_supported(rx, operation="set_nb_width")
@@ -2536,6 +2552,7 @@ class RadioPoller:
                             source=command_source,
                             session_id=session_id,
                             command_service=command_service,
+                            provider_generation=provider_generation,
                         )
             case SetDashRatio(value=value):
                 if CAP_CW in self._caps:
@@ -2595,6 +2612,7 @@ class RadioPoller:
                         source=command_source,
                         session_id=session_id,
                         command_service=command_service,
+                        provider_generation=provider_generation,
                     )
             case SetData1ModInput(source=mod_source):
                 if CAP_DATA_MODE in self._caps:
@@ -2605,6 +2623,7 @@ class RadioPoller:
                         source=command_source,
                         session_id=session_id,
                         command_service=command_service,
+                        provider_generation=provider_generation,
                     )
             case SetData2ModInput(source=mod_source):
                 if CAP_DATA_MODE in self._caps:
@@ -2615,6 +2634,7 @@ class RadioPoller:
                         source=command_source,
                         session_id=session_id,
                         command_service=command_service,
+                        provider_generation=provider_generation,
                     )
             case SetData3ModInput(source=mod_source):
                 if CAP_DATA_MODE in self._caps:
@@ -2625,6 +2645,7 @@ class RadioPoller:
                         source=command_source,
                         session_id=session_id,
                         command_service=command_service,
+                        provider_generation=provider_generation,
                     )
             case SetAudioPeakFilter(on=on, receiver=rx):
                 self._ensure_receiver_supported(rx, operation="set_audio_peak_filter")
@@ -3068,6 +3089,7 @@ class RadioPoller:
         source: CommandSource,
         session_id: str | None,
         command_service: CommandService | None,
+        provider_generation: int,
     ) -> None:
         """Select once, then bind only transaction-scoped passive readback."""
 
@@ -3089,6 +3111,7 @@ class RadioPoller:
                 ),
                 timestamp_monotonic=time.monotonic(),
                 correlation_id=command_id,
+                provider_generation=provider_generation,
             )
             if command_service is not None:
                 command_service.apply_observation(observation)

--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -138,8 +138,10 @@ async def test_relative_vfo_ingress_bootstraps_then_transceive_patches_immediate
     radio: IcomRadio,
 ) -> None:
     radio._profile = resolve_radio_profile(model="IC-7300")  # noqa: SLF001
+    store_generation = radio._state_store.begin_provider_generation()  # noqa: SLF001
+    assert store_generation != radio._civ_epoch  # noqa: SLF001
     radio._state_store.configure_relative_vfo_retention(  # noqa: SLF001
-        generation=radio._civ_epoch,  # noqa: SLF001
+        generation=store_generation,
         max_age=31.0,
         coherence_window=5.0,
     )
@@ -169,6 +171,7 @@ async def test_relative_vfo_ingress_bootstraps_then_transceive_patches_immediate
                 native_id="explicit_slot_ack_readback",
             ),
             timestamp_monotonic=time.monotonic(),
+            provider_generation=store_generation,
         )
     )
     for frame in (
@@ -213,6 +216,7 @@ async def test_relative_vfo_ingress_bootstraps_then_transceive_patches_immediate
     assert knob.last_observed_monotonic > old_mode.last_observed_monotonic
     assert after.field(old_mode.path).value == old_mode.value
     assert after.field(old_unselected.path).value == old_unselected.value
+    assert knob.provider_generation == store_generation
     radio.send_civ.assert_not_awaited()
 
 
@@ -920,7 +924,13 @@ async def test_civ_rx_loop_drains_extra_packets_from_queue(
 
     frames_routed = [0]
 
-    async def counting_route(frame: CivFrame, *, generation: int) -> None:
+    async def counting_route(
+        frame: CivFrame,
+        *,
+        generation: int,
+        store_provider_generation: int | None = None,
+    ) -> None:
+        del store_provider_generation
         frames_routed[0] += 1
 
     # Run rx loop briefly: get the queued packet, drain extra, then timeout and exit
@@ -981,7 +991,13 @@ async def test_civ_rx_loop_skips_short_packets(
 
     frames_routed = [0]
 
-    async def counting_route(frame: CivFrame, *, generation: int) -> None:
+    async def counting_route(
+        frame: CivFrame,
+        *,
+        generation: int,
+        store_provider_generation: int | None = None,
+    ) -> None:
+        del store_provider_generation
         frames_routed[0] += 1
 
     with patch.object(
@@ -1023,7 +1039,13 @@ async def test_civ_rx_loop_skips_invalid_civ_frames(
 
     frames_routed = [0]
 
-    async def counting_route(frame: CivFrame, *, generation: int) -> None:
+    async def counting_route(
+        frame: CivFrame,
+        *,
+        generation: int,
+        store_provider_generation: int | None = None,
+    ) -> None:
+        del store_provider_generation
         frames_routed[0] += 1
 
     with patch.object(
@@ -1047,7 +1069,13 @@ async def test_civ_rx_loop_handles_route_exception(
     civ = build_civ_frame(CONTROLLER_ADDR, IC_7610_ADDR, 0x03, data=freq_data)
     transport.queue_response(_wrap_civ_in_udp(civ))
 
-    async def exploding_route(frame: CivFrame, *, generation: int) -> None:
+    async def exploding_route(
+        frame: CivFrame,
+        *,
+        generation: int,
+        store_provider_generation: int | None = None,
+    ) -> None:
+        del store_provider_generation
         raise RuntimeError("route exploded")
 
     with patch.object(
@@ -1062,6 +1090,130 @@ async def test_civ_rx_loop_handles_route_exception(
             except asyncio.CancelledError:
                 pass
     # Loop should have survived the exception
+
+
+@pytest.mark.asyncio
+async def test_running_old_pump_is_not_relabelled_when_host_civ_epoch_advances(
+    radio: IcomRadio, transport: MockTransport
+) -> None:
+    """The captured CI-V epoch remains the first stale-pump guard."""
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    original_receive = transport.receive_packet
+
+    async def delayed_receive(*, timeout: float) -> bytes:
+        entered.set()
+        await release.wait()
+        return await original_receive(timeout=timeout)
+
+    freq = 14_074_000
+    frame_bytes = build_civ_frame(
+        CONTROLLER_ADDR,
+        IC_7610_ADDR,
+        0x03,
+        data=bcd_encode(freq),
+    )
+    transport.queue_response(_wrap_civ_in_udp(frame_bytes))
+    transport.receive_packet = delayed_receive  # type: ignore[method-assign]
+    old_store_generation = radio._state_store.provider_generation  # noqa: SLF001
+
+    radio._civ_runtime.start_pump()  # noqa: SLF001
+    await entered.wait()
+    radio._civ_epoch = radio._civ_request_tracker.advance_generation(  # noqa: SLF001
+        ConnectionError("test epoch advance")
+    )
+    assert radio._state_store.provider_generation == old_store_generation  # noqa: SLF001
+    release.set()
+    await asyncio.sleep(0.05)
+    await radio._civ_runtime.stop_pump()  # noqa: SLF001
+
+    with pytest.raises(KeyError):
+        radio._state_store.snapshot().field(  # noqa: SLF001
+            "receiver.0.freq_mode.freq_hz"
+        )
+
+
+def test_advance_generation_advances_independent_store_token(radio: IcomRadio) -> None:
+    radio._state_store.begin_provider_generation()  # noqa: SLF001
+    old_civ = radio._civ_epoch  # noqa: SLF001
+    old_store = radio._state_store.provider_generation  # noqa: SLF001
+
+    radio._civ_runtime.advance_generation("test replacement")  # noqa: SLF001
+
+    assert radio._civ_epoch != old_civ  # noqa: SLF001
+    assert radio._state_store.provider_generation == old_store + 1  # noqa: SLF001
+    assert radio._state_store.provider_generation != radio._civ_epoch  # noqa: SLF001
+
+
+def test_old_generation_generic_civ_result_changes_no_store_state(
+    radio: IcomRadio,
+) -> None:
+    old_store_generation = radio._state_store.provider_generation  # noqa: SLF001
+    radio._civ_runtime.advance_generation("test replacement")  # noqa: SLF001
+    before = radio._state_store.snapshot().to_dict()  # noqa: SLF001
+    before.pop("generatedAtMonotonic")
+
+    radio._civ_runtime._apply_state_store_observations(  # noqa: SLF001
+        _make_frame(cmd=0x14, sub=0x01, data=_bcd2(128)),
+        generation=old_store_generation,
+    )
+
+    after = radio._state_store.snapshot().to_dict()  # noqa: SLF001
+    after.pop("generatedAtMonotonic")
+    assert after == before
+
+
+def test_current_generation_generic_civ_result_is_accepted(radio: IcomRadio) -> None:
+    radio._civ_runtime.advance_generation("test replacement")  # noqa: SLF001
+    current_store_generation = radio._state_store.provider_generation  # noqa: SLF001
+
+    radio._civ_runtime._apply_state_store_observations(  # noqa: SLF001
+        _make_frame(cmd=0x14, sub=0x01, data=_bcd2(128)),
+        generation=current_store_generation,
+    )
+
+    field = radio._state_store.snapshot().field(  # noqa: SLF001
+        "receiver.0.operator_controls.af_level"
+    )
+    assert field.provider_generation == current_store_generation
+
+
+def test_old_generation_queued_meter_flush_mutates_nothing_after_reconnect(
+    radio: IcomRadio,
+) -> None:
+    path = FieldPath.receiver("main", "meters", "s_meter")
+    policy = AcquisitionPolicy(
+        cadence_seconds=1.0,
+        freshness_ttl_seconds=4.0,
+        meter_coalescing=MeterCoalescingPolicy(window_seconds=0.2),
+    )
+    radio._acquisition_scheduler = AcquisitionScheduler(  # noqa: SLF001
+        profile=_acquisition_profile(path, policy=policy)
+    )
+    radio._meter_observation_coalescer = MeterObservationCoalescer()  # noqa: SLF001
+    generation = radio._state_store.provider_generation  # noqa: SLF001
+
+    with patch("rigplane.runtime._civ_rx.time.monotonic", return_value=100.0):
+        radio._civ_runtime._apply_state_store_observations(  # noqa: SLF001
+            _make_frame(cmd=0x15, sub=0x02, data=_bcd2(111)),
+            generation=generation,
+        )
+    with patch("rigplane.runtime._civ_rx.time.monotonic", return_value=100.05):
+        radio._civ_runtime._apply_state_store_observations(  # noqa: SLF001
+            _make_frame(cmd=0x15, sub=0x02, data=_bcd2(222)),
+            generation=generation,
+        )
+    assert radio._meter_observation_coalescer._pending  # noqa: SLF001
+
+    radio._civ_runtime.advance_generation("test replacement")  # noqa: SLF001
+    before = radio._state_store.snapshot().to_dict()  # noqa: SLF001
+    before.pop("generatedAtMonotonic")
+    radio._civ_runtime.flush_due_meter_observations(now=100.3)  # noqa: SLF001
+
+    after = radio._state_store.snapshot().to_dict()  # noqa: SLF001
+    after.pop("generatedAtMonotonic")
+    assert after == before
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_civ_rx_mixin_host.py
+++ b/tests/test_civ_rx_mixin_host.py
@@ -13,6 +13,7 @@ import pytest
 
 from rigplane.runtime._civ_rx import CivRuntime
 from rigplane.exceptions import ConnectionError
+from rigplane.core.state_store import StateStore
 
 
 @dataclass
@@ -35,6 +36,7 @@ class _FakeCivHost:
         self._civ_request_tracker = _DummyTracker()
         self._civ_epoch = self._civ_request_tracker.generation
         self._civ_transport = object()
+        self._state_store = StateStore()
 
 
 class TestCivRuntimeHost:
@@ -49,6 +51,7 @@ class TestCivRuntimeHost:
         runtime.advance_generation("unit-test")
 
         assert host._civ_epoch == 1
+        assert host._state_store.provider_generation == 1
         assert tracker.last_error is not None
         assert "unit-test" in str(tracker.last_error)
 

--- a/tests/test_command_service.py
+++ b/tests/test_command_service.py
@@ -220,10 +220,7 @@ async def test_execute_acknowledges_without_confirming_state_when_executor_has_n
 
 @pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_execute_captures_generation_before_awaited_executor_result() -> None:
-    """A command result must retain the Store token captured before await."""
-
-    started = asyncio.Event()
-    release = asyncio.Event()
+    started, release = asyncio.Event(), asyncio.Event()
     store = StateStore()
 
     class DelayedExecutor:
@@ -244,59 +241,35 @@ async def test_execute_captures_generation_before_awaited_executor_result() -> N
     await started.wait()
     store.begin_provider_generation()
     release.set()
-    result = await task
+    await task
 
-    assert result.observation_changes[0].observed_paths == ()
-    assert _states(service.lifecycle_events()) == [
-        "accepted",
-        "queued",
-        "sent",
-        "acknowledged",
-    ]
+    assert _states(service.lifecycle_events())[-1] == "acknowledged"
     assert service.pending_overlays(source="websocket", session_id="ws-a")
-    with pytest.raises(KeyError):
-        store.snapshot().field(_freq_path())
+    assert _freq_path() not in {field.path for field in store.snapshot().fields}
 
 
-def test_rejected_or_empty_changeset_does_not_reconcile_overlay() -> None:
+@pytest.mark.parametrize("stale", (True, False), ids=("rejected", "current"))
+def test_only_current_non_empty_changeset_reconciles_overlay(stale: bool) -> None:
     store = StateStore()
+    generation = store.begin_provider_generation()
     service = CommandService(executor=FakeExecutor(), state_store=store)
     intent = _intent()
     service.emit_lifecycle(intent, "accepted")
     service._record_intent_overlay(intent)  # noqa: SLF001
-    stale_generation = store.provider_generation
-    store.begin_provider_generation()
+    if stale:
+        store.begin_provider_generation()
 
     changeset = service.apply_observation(
         replace(
             _observation(_freq_path(), 14_074_000, at=10.0),
-            provider_generation=stale_generation,
+            provider_generation=generation,
         )
     )
 
-    assert changeset.observed_paths == ()
-    assert service.pending_overlays(source="websocket", session_id="ws-a")
-    assert "reconciled" not in _states(service.lifecycle_events())
-
-
-def test_accepted_current_non_empty_changeset_reconciles_overlay() -> None:
-    store = StateStore()
-    current_generation = store.begin_provider_generation()
-    service = CommandService(executor=FakeExecutor(), state_store=store)
-    intent = _intent()
-    service.emit_lifecycle(intent, "accepted")
-    service._record_intent_overlay(intent)  # noqa: SLF001
-
-    changeset = service.apply_observation(
-        replace(
-            _observation(_freq_path(), 14_074_000, at=10.0),
-            provider_generation=current_generation,
-        )
-    )
-
-    assert changeset.observed_paths == (_freq_path(),)
-    assert service.pending_overlays(source="websocket", session_id="ws-a") == ()
-    assert _states(service.lifecycle_events()) == ["accepted", "reconciled"]
+    pending = service.pending_overlays(source="websocket", session_id="ws-a")
+    assert bool(changeset.observed_paths) is not stale
+    assert bool(pending) is stale
+    assert ("reconciled" in _states(service.lifecycle_events())) is not stale
 
 
 def test_pending_overlays_are_projected_by_source_session_command_and_path() -> None:

--- a/tests/test_command_service.py
+++ b/tests/test_command_service.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Sequence
+from dataclasses import replace
 from typing import Any, cast
 
 import pytest
@@ -214,6 +216,87 @@ async def test_execute_acknowledges_without_confirming_state_when_executor_has_n
         session_id="ws-a",
         paths=(_freq_path(),),
     ) == {_freq_path(): 14_074_000}
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_execute_captures_generation_before_awaited_executor_result() -> None:
+    """A command result must retain the Store token captured before await."""
+
+    started = asyncio.Event()
+    release = asyncio.Event()
+    store = StateStore()
+
+    class DelayedExecutor:
+        async def execute(self, intent: CommandIntent) -> CommandExecutionResult:
+            started.set()
+            await release.wait()
+            return CommandExecutionResult(
+                observations=(
+                    replace(
+                        _observation(_freq_path(), 14_074_000, at=10.0),
+                        provider_generation=store.provider_generation,
+                    ),
+                )
+            )
+
+    service = CommandService(executor=DelayedExecutor(), state_store=store)
+    task = asyncio.create_task(service.execute(_intent()))
+    await started.wait()
+    store.begin_provider_generation()
+    release.set()
+    result = await task
+
+    assert result.observation_changes[0].observed_paths == ()
+    assert _states(service.lifecycle_events()) == [
+        "accepted",
+        "queued",
+        "sent",
+        "acknowledged",
+    ]
+    assert service.pending_overlays(source="websocket", session_id="ws-a")
+    with pytest.raises(KeyError):
+        store.snapshot().field(_freq_path())
+
+
+def test_rejected_or_empty_changeset_does_not_reconcile_overlay() -> None:
+    store = StateStore()
+    service = CommandService(executor=FakeExecutor(), state_store=store)
+    intent = _intent()
+    service.emit_lifecycle(intent, "accepted")
+    service._record_intent_overlay(intent)  # noqa: SLF001
+    stale_generation = store.provider_generation
+    store.begin_provider_generation()
+
+    changeset = service.apply_observation(
+        replace(
+            _observation(_freq_path(), 14_074_000, at=10.0),
+            provider_generation=stale_generation,
+        )
+    )
+
+    assert changeset.observed_paths == ()
+    assert service.pending_overlays(source="websocket", session_id="ws-a")
+    assert "reconciled" not in _states(service.lifecycle_events())
+
+
+def test_accepted_current_non_empty_changeset_reconciles_overlay() -> None:
+    store = StateStore()
+    current_generation = store.begin_provider_generation()
+    service = CommandService(executor=FakeExecutor(), state_store=store)
+    intent = _intent()
+    service.emit_lifecycle(intent, "accepted")
+    service._record_intent_overlay(intent)  # noqa: SLF001
+
+    changeset = service.apply_observation(
+        replace(
+            _observation(_freq_path(), 14_074_000, at=10.0),
+            provider_generation=current_generation,
+        )
+    )
+
+    assert changeset.observed_paths == (_freq_path(),)
+    assert service.pending_overlays(source="websocket", session_id="ws-a") == ()
+    assert _states(service.lifecycle_events()) == ["accepted", "reconciled"]
 
 
 def test_pending_overlays_are_projected_by_source_session_command_and_path() -> None:

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -1228,7 +1228,9 @@ class TestAckSinkRobustness:
     ) -> None:
         radio._civ_runtime.start_pump()
         try:
+            await radio._civ_runtime.stop_pump()
             radio._civ_runtime.advance_generation("unit-test-reconnect")
+            radio._civ_runtime.start_pump()
 
             mock_transport.queue_response_on_send(1, _freq_response(14_074_000))
             mock_transport.queue_response_on_send(2, _mode_response(Mode.USB))

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -96,11 +96,11 @@ from test_web_managed_tx_owner import _KEY, _TEARDOWN, _poller, _Radio, _Supervi
 
 
 @pytest.mark.asyncio
-async def test_direct_getter_result_started_in_old_generation_is_rejected() -> None:
+@pytest.mark.parametrize("stale", (True, False), ids=("stale", "current"))
+async def test_direct_getter_uses_generation_captured_before_await(stale: bool) -> None:
     store = StateStore()
-    started_generation = store.begin_provider_generation()
-    started = asyncio.Event()
-    release = asyncio.Event()
+    generation = store.begin_provider_generation()
+    started, release = asyncio.Event(), asyncio.Event()
     radio = _make_radio(model="IC-7300")
 
     async def delayed_getter() -> int:
@@ -113,28 +113,16 @@ async def test_direct_getter_result_started_in_old_generation_is_rejected() -> N
 
     task = asyncio.create_task(poller._read_mod_input("data1_mod_input"))  # noqa: SLF001
     await started.wait()
-    replacement_generation = store.begin_provider_generation()
-    assert replacement_generation != started_generation
+    if stale:
+        store.begin_provider_generation()
     release.set()
     await task
 
-    with pytest.raises(KeyError):
-        store.snapshot().field("global.slow_state.data1_mod_input")
-
-
-@pytest.mark.asyncio
-async def test_current_generation_direct_getter_result_is_accepted() -> None:
-    store = StateStore()
-    current_generation = store.begin_provider_generation()
-    radio = _make_radio(model="IC-7300")
-    radio.get_data1_mod_input = AsyncMock(return_value=3)
-    poller = RadioPoller(radio, CommandQueue(), state_store=store)
-
-    await poller._read_mod_input("data1_mod_input")  # noqa: SLF001
-
-    field = store.snapshot().field("global.slow_state.data1_mod_input")
-    assert field.value == 3
-    assert field.provider_generation == current_generation
+    if stale:
+        assert "global.slow_state.data1_mod_input" not in store.snapshot().as_dict()
+    else:
+        field = store.snapshot().field("global.slow_state.data1_mod_input")
+        assert (field.value, field.provider_generation) == (2, generation)
 
 
 class _NoopCommandExecutor:
@@ -1305,7 +1293,7 @@ async def test_relative_vfo_ack_maps_selected_and_complement_then_rebinds() -> N
         RelativeVfoState(14_250_000, "USB", 1, 0),
     )
     store = StateStore()
-    current_generation = store.begin_provider_generation()
+    store.begin_provider_generation()
     poller = RadioPoller(radio, CommandQueue(), radio_state=state, state_store=store)
 
     assert "receiver.0.vfo.active_slot" not in store.snapshot().as_dict()
@@ -1314,9 +1302,6 @@ async def test_relative_vfo_ack_maps_selected_and_complement_then_rebinds() -> N
     assert first.field("receiver.0.vfo.active_slot").value == "B"
     assert first.field("receiver.0.slot.B.freq_mode.freq_hz").value == 14_200_000
     assert first.field("receiver.0.slot.A.freq_mode.freq_hz").value == 7_100_000
-    assert first.field("receiver.0.vfo.active_slot").provider_generation == (
-        current_generation
-    )
 
     await poller._execute(SelectVfo("A"))  # noqa: SLF001
     second = store.snapshot()
@@ -1328,6 +1313,69 @@ async def test_relative_vfo_ack_maps_selected_and_complement_then_rebinds() -> N
         call("A", receiver=0),
     ]
     assert radio.set_vfo_slot.await_count == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "failure",
+    (None, CommandError("stale select failed")),
+    ids=("success", "exception"),
+)
+async def test_stale_select_vfo_preserves_replacement_generation_identity(
+    failure: CommandError | None,
+) -> None:
+    store = StateStore()
+    store.begin_provider_generation()
+    state = RadioState()
+    state.main.active_slot = "A"
+    events: list[tuple[str, dict[str, Any]]] = []
+    entered, release = asyncio.Event(), asyncio.Event()
+    radio = _make_radio(model="IC-7300")
+    radio._radio_state = state
+
+    async def delayed_select(*_args: Any, **_kwargs: Any) -> None:
+        entered.set()
+        await release.wait()
+        if failure is not None:
+            raise failure
+
+    radio._set_vfo_slot_confirmed = AsyncMock(side_effect=delayed_select)
+    poller = RadioPoller(
+        radio,
+        CommandQueue(),
+        radio_state=state,
+        state_store=store,
+        on_state_event=lambda name, data: events.append((name, data)),
+    )
+
+    task = asyncio.create_task(poller._execute(SelectVfo("B")))  # noqa: SLF001
+    await entered.wait()
+    replacement_generation = store.begin_provider_generation()
+    expected = {
+        FieldPath.active_slot("0"): "A",
+        FieldPath.vfo_slot("0", "A", "freq_mode", "freq_hz"): 7_100_000,
+    }
+    for path, value in expected.items():
+        store.apply(
+            Observation(
+                path=path,
+                value=value,
+                source=SourceMetadata(source="test", provider="replacement"),
+                timestamp_monotonic=time.monotonic(),
+                provider_generation=replacement_generation,
+            )
+        )
+    release.set()
+    if failure is None:
+        await task
+    else:
+        with pytest.raises(CommandError, match="stale select failed"):
+            await task
+
+    snapshot = store.snapshot()
+    assert {path: snapshot.field(path).value for path in expected} == expected
+    assert state.main.active_slot == "A"
+    assert events == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -95,6 +95,48 @@ from rigplane.web.web_startup import stop_web_server
 from test_web_managed_tx_owner import _KEY, _TEARDOWN, _poller, _Radio, _Supervisor
 
 
+@pytest.mark.asyncio
+async def test_direct_getter_result_started_in_old_generation_is_rejected() -> None:
+    store = StateStore()
+    started_generation = store.begin_provider_generation()
+    started = asyncio.Event()
+    release = asyncio.Event()
+    radio = _make_radio(model="IC-7300")
+
+    async def delayed_getter() -> int:
+        started.set()
+        await release.wait()
+        return 2
+
+    radio.get_data1_mod_input = delayed_getter
+    poller = RadioPoller(radio, CommandQueue(), state_store=store)
+
+    task = asyncio.create_task(poller._read_mod_input("data1_mod_input"))  # noqa: SLF001
+    await started.wait()
+    replacement_generation = store.begin_provider_generation()
+    assert replacement_generation != started_generation
+    release.set()
+    await task
+
+    with pytest.raises(KeyError):
+        store.snapshot().field("global.slow_state.data1_mod_input")
+
+
+@pytest.mark.asyncio
+async def test_current_generation_direct_getter_result_is_accepted() -> None:
+    store = StateStore()
+    current_generation = store.begin_provider_generation()
+    radio = _make_radio(model="IC-7300")
+    radio.get_data1_mod_input = AsyncMock(return_value=3)
+    poller = RadioPoller(radio, CommandQueue(), state_store=store)
+
+    await poller._read_mod_input("data1_mod_input")  # noqa: SLF001
+
+    field = store.snapshot().field("global.slow_state.data1_mod_input")
+    assert field.value == 3
+    assert field.provider_generation == current_generation
+
+
 class _NoopCommandExecutor:
     async def execute(self, intent: object) -> CommandExecutionResult:
         del intent
@@ -1263,6 +1305,7 @@ async def test_relative_vfo_ack_maps_selected_and_complement_then_rebinds() -> N
         RelativeVfoState(14_250_000, "USB", 1, 0),
     )
     store = StateStore()
+    current_generation = store.begin_provider_generation()
     poller = RadioPoller(radio, CommandQueue(), radio_state=state, state_store=store)
 
     assert "receiver.0.vfo.active_slot" not in store.snapshot().as_dict()
@@ -1271,6 +1314,9 @@ async def test_relative_vfo_ack_maps_selected_and_complement_then_rebinds() -> N
     assert first.field("receiver.0.vfo.active_slot").value == "B"
     assert first.field("receiver.0.slot.B.freq_mode.freq_hz").value == 14_200_000
     assert first.field("receiver.0.slot.A.freq_mode.freq_hz").value == 7_100_000
+    assert first.field("receiver.0.vfo.active_slot").provider_generation == (
+        current_generation
+    )
 
     await poller._execute(SelectVfo("A"))  # noqa: SLF001
     second = store.snapshot()

--- a/tests/test_state_pipeline_diagnostics.py
+++ b/tests/test_state_pipeline_diagnostics.py
@@ -7,6 +7,7 @@ from typing import Any
 from rigplane.core._bounded_queue import BoundedQueue
 from rigplane.core._state_cache import StateCache
 from rigplane.core.state_pipeline_contracts import (
+    ChangeSet,
     FieldPath,
     Observation,
     SourceMetadata,
@@ -22,6 +23,7 @@ class _FakeCivHost:
     def __init__(self, diagnostics: StateDiagnosticsRecorder) -> None:
         self._radio_state = RadioState()
         self._state_cache = StateCache()
+        self._state_store = _NoopStateStore()
         self._on_state_change = self._on_notify
         self._notifications: list[tuple[str, dict[str, Any]]] = []
         self._state_diagnostics = diagnostics
@@ -32,6 +34,22 @@ class _FakeCivHost:
 
     def _on_notify(self, name: str, data: dict[str, Any]) -> None:
         self._notifications.append((name, data))
+
+
+class _NoopStateStore:
+    """Keep this legacy-diagnostic host intentionally outside Store delivery."""
+
+    provider_generation = 0
+
+    def apply(self, observation: Observation) -> ChangeSet:
+        return ChangeSet(
+            revision=0,
+            freshness_revision=0,
+            observation_seq=0,
+            changes=(),
+            timestamp_monotonic=observation.timestamp_monotonic,
+            sources=(),
+        )
 
 
 def test_state_diagnostics_are_inert_until_enabled() -> None:


### PR DESCRIPTION
## Summary

- capture the independent StateStore provider token alongside the existing CI-V epoch before the RX pump detaches
- keep the CI-V epoch as the first stale-producer guard and use the captured Store token as the second guard for generic, relative-VFO, and coalesced meter observations
- bind RadioPoller direct/read-after-write observations before their first await and prevent rejected or empty CommandService ChangeSets from reconciling overlays

## Scope

This is the bounded **B-adopt-Core** slice only. It changes exactly the three authorized production files and does not change Web startup, Yaesu, rigctld, WebSocket publication, frontend state, commands, ACK ownership, PTT, audio, scope, spectrum, or radio writes.

Related to #2316

## Evidence

- TDD RED: 6 expected failures across the new adversarial generation/reconciliation cases
- focused adversarial: 10 passed
- focused Core/StateStore/relative-VFO/Command/PTT: 1026 passed
- final changed-domain suite: 833 passed
- full suite: 9147 passed, 129 skipped, 5 deselected, 11 xfailed, 1 xpassed
- Ruff: pass
- Ruff format check: pass
- import-linter: 5 contracts kept, 0 broken
- `git diff --check`: pass
- mypy: no new errors; 9 unchanged pre-existing `no-any-return` findings remain in untouched lines of `_civ_rx.py` and `command_service.py`

## Size

- production: +85/-25, net +60 across exactly 3 files
- total: +394/-30, net +364
