### PR TITLE
fix(#2316): fence standalone rigctld observations

### DIFF
--- a/src/rigplane/rigctld/handler.py
+++ b/src/rigplane/rigctld/handler.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from contextvars import ContextVar
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, cast
@@ -69,6 +69,10 @@ __all__ = ["RigctldHandler"]
 logger = logging.getLogger(__name__)
 _RIGCTLD_SESSION_ID: ContextVar[str | None] = ContextVar(
     "rigctld_session_id",
+    default=None,
+)
+_RIGCTLD_PROVIDER_GENERATION: ContextVar[int | None] = ContextVar(
+    "rigctld_provider_generation",
     default=None,
 )
 
@@ -563,6 +567,9 @@ class RigctldHandler:
             # server-driven freshness service) via ``state_store``.
             state_store = StateStore()
         self._state_store = state_store
+        self._provider_generation_capture: Callable[[], int] = lambda: (
+            self._state_store.provider_generation
+        )
         if state_model_service is None and isinstance(radio, StateModelCapable):
             state_model_service = radio.state_model_service
         if not isinstance(state_model_service, StateModelService):
@@ -573,6 +580,10 @@ class RigctldHandler:
             executor=_RigctldCommandExecutor(self),
             state_store=state_store,
         )
+
+    def bind_provider_generation(self, capture: Callable[[], int]) -> None:
+        """Bind the server-owned provider token capture for request ingress."""
+        self._provider_generation_capture = capture
 
     def _packet_data_mode_value(self) -> int | bool:
         value = self._config.wsjtx_data_mode
@@ -880,6 +891,9 @@ class RigctldHandler:
         source: Literal["hamlib_response", "state_poller"],
         max_age: float | None = None,
     ) -> None:
+        provider_generation = _RIGCTLD_PROVIDER_GENERATION.get()
+        if provider_generation is None:
+            return
         self._state_store.apply(
             Observation(
                 path=FieldPath.parse(path) if isinstance(path, str) else path,
@@ -891,6 +905,7 @@ class RigctldHandler:
                 ),
                 timestamp_monotonic=time.monotonic(),
                 max_age=max_age,
+                provider_generation=provider_generation,
             )
         )
 
@@ -974,6 +989,9 @@ class RigctldHandler:
         Returns:
             Response to send back.
         """
+        provider_token = _RIGCTLD_PROVIDER_GENERATION.set(
+            self._provider_generation_capture()
+        )
         token = _RIGCTLD_SESSION_ID.set(session_id)
         # Read-only gate
         try:
@@ -1018,6 +1036,7 @@ class RigctldHandler:
                 return _err(HamlibError.EINTERNAL)
         finally:
             _RIGCTLD_SESSION_ID.reset(token)
+            _RIGCTLD_PROVIDER_GENERATION.reset(provider_token)
 
     async def release_session_tx(self, session_id: str) -> None:
         """Hand back any managed TX lease ``session_id`` still holds.

--- a/src/rigplane/rigctld/server.py
+++ b/src/rigplane/rigctld/server.py
@@ -154,6 +154,8 @@ class RigctldServer:
         self._circuit_breaker: CircuitBreaker | None = _circuit_breaker
         self._server_was_running: bool = False
         self._state_store: StateStore | None = None
+        self._uses_fallback_state_store = False
+        self._fallback_state_store_attached = False
         self._acquisition_scheduler: AcquisitionScheduler | None = None
         self._state_model_service: StateModelService | None = None
         self._state_freshness_service: StateFreshnessService | None = None
@@ -379,6 +381,11 @@ class RigctldServer:
     def _bootstrap_state_acquisition(self) -> None:
         """Prepare StateStore-backed acquisition services for standalone rigctld."""
         self._state_store = self._radio_state_store()
+        self._uses_fallback_state_store = self._state_store is None
+        if self._state_store is None:
+            # The standalone server owns one fallback Store and passes that
+            # exact instance to its default handler. It is never handler-local.
+            self._state_store = StateStore()
         self._state_model_service = self._radio_state_model_service()
         self._state_freshness_service = self._radio_state_freshness_service()
         self._acquisition_executor = self._provided_acquisition_executor()
@@ -386,8 +393,6 @@ class RigctldServer:
         acquisition_profile = self._profile_state_acquisition()
         if acquisition_profile is None:
             return
-        if self._state_store is None:
-            self._state_store = StateStore()
         if self._state_model_service is not None:
             scheduler = getattr(self._radio, "_acquisition_scheduler", None)
             if isinstance(scheduler, AcquisitionScheduler):
@@ -681,16 +686,32 @@ class RigctldServer:
 
             self._protocol = _proto_mod
 
+        if self._state_store is None:
+            self._bootstrap_state_acquisition()
+
         if self._rig_handler is None:
             from . import handler as _handler_mod  # noqa: PLC0415, TID251
 
-            self._bootstrap_state_acquisition()
             self._rig_handler = _handler_mod.RigctldHandler(
                 self._radio,
                 self._config,
                 state_store=self._state_store,
                 state_model_service=self._state_model_service,
             )
+
+        store = self._state_store
+        if store is not None:
+            bind_provider_generation = getattr(
+                self._rig_handler, "bind_provider_generation", None
+            )
+            if callable(bind_provider_generation):
+                bind_provider_generation(lambda: store.provider_generation)
+            if (
+                self._uses_fallback_state_store
+                and not self._fallback_state_store_attached
+            ):
+                store.begin_provider_generation()
+                self._fallback_state_store_attached = True
 
         self._server = await asyncio.start_server(
             self._accept_client,
@@ -708,6 +729,14 @@ class RigctldServer:
 
     async def stop(self) -> None:
         """Close the listener and cancel all active client tasks."""
+        if (
+            self._uses_fallback_state_store
+            and self._fallback_state_store_attached
+            and self._state_store is not None
+        ):
+            self._state_store.begin_provider_generation()
+            self._fallback_state_store_attached = False
+
         if self._state_acquisition_drain_task is not None:
             self._state_acquisition_drain_task.cancel()
             try:

--- a/tests/test_rigctld_handler.py
+++ b/tests/test_rigctld_handler.py
@@ -331,6 +331,38 @@ async def test_get_freq_radio_state_fallback_records_state_store_observation(
     )
     assert field.value == 14_074_000
     assert field.source.source == "state_poller"
+    assert field.provider_generation == handler._state_store.provider_generation  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_handler_captures_fallback_store_token_before_awaited_get(
+    mock_radio: AsyncMock,
+) -> None:
+    """An old request may return a response, but cannot relabel its readback."""
+    store = StateStore()
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def delayed_get_freq() -> int:
+        started.set()
+        await release.wait()
+        return 14_074_000
+
+    mock_radio.get_freq.side_effect = delayed_get_freq
+    handler = RigctldHandler(mock_radio, RigctldConfig(), state_store=store)
+    request = asyncio.create_task(handler.execute(get_cmd("get_freq")))
+    await started.wait()
+    store.begin_provider_generation()
+    before = store.snapshot()
+    release.set()
+    response = await request
+
+    assert response.values == ["14074000"]
+    after = store.snapshot()
+    assert after.state_revision == before.state_revision
+    assert after.freshness_revision == before.freshness_revision
+    assert after.observation_seq == before.observation_seq
+    assert after.fields == before.fields
 
 
 @pytest.mark.asyncio
@@ -3409,6 +3441,36 @@ async def test_yaesu_get_level_af_backend_fallback_records_state_store(
     field = store.snapshot().field("receiver.main.operator_controls.af_level")
     assert field.value == 128
     assert field.source.source == "hamlib_response"
+
+
+@pytest.mark.asyncio
+async def test_routed_handler_readback_uses_request_captured_generation(
+    yaesu_radio: AsyncMock,
+) -> None:
+    store = StateStore()
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def delayed_get_af_level() -> int:
+        started.set()
+        await release.wait()
+        return 128
+
+    yaesu_radio.get_af_level.side_effect = delayed_get_af_level
+    handler = RigctldHandler(yaesu_radio, RigctldConfig(), state_store=store)
+    request = asyncio.create_task(handler.execute(get_cmd("get_level", "AF")))
+    await started.wait()
+    store.begin_provider_generation()
+    before = store.snapshot()
+    release.set()
+    response = await request
+
+    assert response.ok
+    after = store.snapshot()
+    assert after.state_revision == before.state_revision
+    assert after.freshness_revision == before.freshness_revision
+    assert after.observation_seq == before.observation_seq
+    assert after.fields == before.fields
 
 
 @pytest.mark.asyncio

--- a/tests/test_rigctld_server.py
+++ b/tests/test_rigctld_server.py
@@ -208,6 +208,7 @@ class _ApplyingAcquisitionExecutor:
                 ),
                 timestamp_monotonic=3.0,
                 max_age=request.policy.freshness_ttl_seconds,
+                provider_generation=store.provider_generation,
             )
         )
         scheduler.record_acquisition_result(request, change_set)
@@ -285,7 +286,7 @@ def _apply_store_value(
     *,
     max_age: float | None = None,
 ) -> None:
-    store.apply(
+    store.apply_current(
         Observation(
             path=path,
             value=value,
@@ -547,7 +548,7 @@ class TestLifecycle:
             state_model_service=model_service,
         )
 
-    async def test_start_without_acquisition_profile_keeps_handler_local_fallback(
+    async def test_standalone_fallback_store_begin_and_detach_each_advance_once(
         self, cfg: RigctldConfig
     ) -> None:
         radio = _ProfiledStandaloneRadio(
@@ -564,9 +565,16 @@ class TestLifecycle:
         ):
             srv = RigctldServer(radio, cfg)
             await srv.start()
+            assert isinstance(srv._state_store, StateStore)
+            assert srv._state_store.provider_generation == 1
+            await srv.stop()
             await srv.stop()
 
-        assert srv._state_store is None
+        assert isinstance(srv._state_store, StateStore)
+        # The standalone server, rather than its default handler, owns the
+        # one fallback Store. Attach and detach are the only lifecycle
+        # transitions it advances.
+        assert srv._state_store.provider_generation == 2
         assert srv._acquisition_scheduler is None
         assert srv._state_model_service is None
         assert srv._state_freshness_service is None
@@ -574,9 +582,70 @@ class TestLifecycle:
         handler_cls.assert_called_once_with(
             radio,
             cfg,
-            state_store=None,
+            state_store=srv._state_store,
             state_model_service=None,
         )
+
+    async def test_standalone_shared_store_is_never_advanced_by_server(
+        self, cfg: RigctldConfig
+    ) -> None:
+        radio = _ProfiledStandaloneRadio(
+            profile=type("Profile", (), {"state_acquisition": None})()
+        )
+        store = StateStore()
+        radio.state_store = store
+        fake_server = _FakeAsyncServer()
+
+        with patch(
+            "rigplane.rigctld.server.asyncio.start_server",
+            new=AsyncMock(return_value=fake_server),
+        ):
+            srv = RigctldServer(radio, cfg)
+            await srv.start()
+            assert store.provider_generation == 0
+            await srv.stop()
+
+        assert store.provider_generation == 0
+
+    async def test_standalone_stop_rejects_delayed_handler_readback_without_mutation(
+        self, cfg: RigctldConfig
+    ) -> None:
+        radio = _ProfiledStandaloneRadio(
+            profile=type("Profile", (), {"state_acquisition": None})()
+        )
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def delayed_get_freq() -> int:
+            started.set()
+            await release.wait()
+            return 14_074_000
+
+        radio.get_freq.side_effect = delayed_get_freq
+        srv = RigctldServer(radio, cfg)
+        await srv.start()
+        try:
+            assert isinstance(srv._state_store, StateStore)
+            handler = srv._rig_handler
+            request = asyncio.create_task(
+                handler.execute(_FREQ_CMD, session_id="delayed-readback")
+            )
+            await started.wait()
+            before = srv._state_store.snapshot()
+            stopping = asyncio.create_task(srv.stop())
+            await asyncio.sleep(0)
+            assert srv._state_store.provider_generation == 2
+            release.set()
+            await request
+            after = srv._state_store.snapshot()
+            assert after.state_revision == before.state_revision
+            assert after.freshness_revision == before.freshness_revision
+            assert after.observation_seq == before.observation_seq
+            assert after.fields == before.fields
+            await stopping
+        finally:
+            if srv._server is not None:
+                await srv.stop()
 
     async def test_stale_standalone_state_store_queues_acquisition_via_server_service(
         self, cfg: RigctldConfig
@@ -906,6 +975,7 @@ class TestLifecycle:
                         ),
                         timestamp_monotonic=3.0,
                         max_age=request.policy.freshness_ttl_seconds,
+                        provider_generation=srv._state_store.provider_generation,
                     )
                 )
                 srv._acquisition_scheduler.record_acquisition_result(


### PR DESCRIPTION
## Summary
- make RigctldServer the sole owner of one fallback StateStore lifecycle
- capture the Store provider generation before rigctld handler dispatch awaits
- reject delayed direct and routed readbacks instead of relabelling them

## Verification
- `uv run pytest tests/test_rigctld_server.py tests/test_rigctld_handler.py -q --tb=short`
- `uv run pytest tests/test_command_service.py tests/test_web_managed_tx_owner.py -q --tb=short`
- `uv run pytest tests/ -qq --tb=short`
- `uv run ruff check src/ tests/`
- `uv run lint-imports`
- `git diff --check`

Related to #2316