### PR TITLE
feat(#2316): emit B2a provider epoch contract

### DIFF
--- a/docs/internals/ui-radio-control-contract.toml
+++ b/docs/internals/ui-radio-control-contract.toml
@@ -11,6 +11,7 @@ intent_lifecycle = "ephemeral-only"
 public_metadata_fields = [
   "server.revision", "server.stateRevision", "server.freshnessRevision",
   "server.observationSeq", "server.healthRevision", "server.updatedAt",
+  "server.stateContractVersion", "server.providerGeneration",
   "server.main", "server.sub", "server.scopeControls",
   "server.connection", "server.radioDetail", "server.radioHealth",
   "server.wsClients", "server.fieldStatus", "server.publicStateSeq",

--- a/frontend/src/lib/types/state.ts
+++ b/frontend/src/lib/types/state.ts
@@ -17,6 +17,8 @@ export interface ServerStatePublic {
   observationSeq: number;
   healthRevision?: number;
   updatedAt: string;
+  stateContractVersion?: 1;
+  providerGeneration?: number;
   active: "MAIN" | "SUB";
   powerOn?: boolean;
   ptt: boolean;

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -912,6 +912,9 @@ class WebServer:
         self._pending_state_broadcast_task: asyncio.Task[None] | None = None
         # Delta encoder for efficient state broadcasting
         self._delta_encoder: DeltaEncoder = DeltaEncoder(full_state_interval=100)
+        # This is an encoder baseline only, derived from Store snapshots.  Web
+        # never owns or advances the provider generation itself.
+        self._last_delta_encoder_generation: int | None = None
         self._last_broadcast_state_key: tuple[object, ...] | None = None
         self._cached_public_state_key: tuple[object, ...] | None = None
         self._cached_public_state_payload: dict[str, Any] | None = None
@@ -1412,7 +1415,7 @@ class WebServer:
             self._pending_state_broadcast_task.cancel()
             self._pending_state_broadcast_task = None
 
-        snapshot = self.command_state_store.snapshot()
+        snapshot = self._snapshot_for_delivery()
         # Keep audio FFT scope center freq and mode bandwidth in sync
         # from the same canonical snapshot used for Web delivery.
         self._update_fft_scope_freq(snapshot)
@@ -1429,13 +1432,7 @@ class WebServer:
         if state_key == self._last_broadcast_state_key:
             return
 
-        # Encode state as delta to reduce bandwidth
-        delta = self._delta_encoder.encode(
-            body,
-            state_revision=snapshot.state_revision,
-            freshness_revision=snapshot.freshness_revision,
-            observation_seq=snapshot.observation_seq,
-        )
+        delta = self._encode_state_update(snapshot, body)
         self._last_broadcast_state_key = state_key
         event = {"type": "state_update", "data": delta}
         self._state_diagnostics.record(
@@ -1465,28 +1462,8 @@ class WebServer:
 
     def build_public_state(self, *, updated_at: str | None = None) -> dict[str, Any]:
         """Return the canonical public state payload for web consumers."""
-        snapshot = self.command_state_store.snapshot()
+        snapshot = self._snapshot_for_delivery()
         return self._build_public_state_from_snapshot(snapshot, updated_at=updated_at)
-
-    def _live_connection_metadata_key(
-        self,
-    ) -> tuple[bool, bool, bool, str | None]:
-        radio = self._radio
-        raw_connected = getattr(radio, "connected", False) if radio else False
-        connected = raw_connected if isinstance(raw_connected, bool) else False
-        raw_control_connected = (
-            getattr(radio, "control_connected", False) if radio else False
-        )
-        control_connected = (
-            raw_control_connected if isinstance(raw_control_connected, bool) else False
-        )
-        conn_state_val = getattr(radio, "conn_state", None) if radio else None
-        conn_state: str | None = None
-        if conn_state_val is not None and hasattr(conn_state_val, "value"):
-            raw_conn_state = conn_state_val.value
-            if isinstance(raw_conn_state, str):
-                conn_state = raw_conn_state
-        return (connected, control_connected, radio_ready(radio), conn_state)
 
     def _public_state_delivery_key(
         self,
@@ -1498,8 +1475,8 @@ class WebServer:
             snapshot.state_revision,
             snapshot.freshness_revision,
             snapshot.observation_seq,
+            snapshot.provider_generation,
             health_revision,
-            *self._live_connection_metadata_key(),
             len(self._scope_handlers),
             len(self._control_event_queues),
             len(self._audio_broadcaster._clients),
@@ -1566,6 +1543,8 @@ class WebServer:
             health_revision=self._health_revision,
         )
         payload["publicStateSeq"] = public_state_seq
+        payload["stateContractVersion"] = 1
+        payload["providerGeneration"] = snapshot.provider_generation
         if updated_at is None:
             self._cached_public_state_key = cache_key
             self._cached_public_state_payload = copy.deepcopy(payload)
@@ -1575,18 +1554,107 @@ class WebServer:
         self, *, force_full: bool = False
     ) -> dict[str, Any]:
         """Return a WS state-update envelope from the canonical StateStore view."""
-        snapshot = self.command_state_store.snapshot()
+        snapshot = self._snapshot_for_delivery()
         body = self._build_public_state_from_snapshot(snapshot)
+        return self._encode_state_update(snapshot, body, force_full=force_full)
+
+    def _encode_state_update(
+        self,
+        snapshot: StateSnapshot,
+        body: dict[str, Any],
+        *,
+        force_full: bool = False,
+    ) -> dict[str, Any]:
+        """Encode one Store snapshot with its non-optional wire epoch."""
         encoder = (
             DeltaEncoder(full_state_interval=100) if force_full else self._delta_encoder
         )
-        return encoder.encode(
+        generation_changed = (
+            not force_full
+            and self._last_delta_encoder_generation != snapshot.provider_generation
+        )
+        result: dict[str, Any] = encoder.encode(
             body,
-            force_full=force_full,
+            force_full=force_full or generation_changed,
             state_revision=snapshot.state_revision,
             freshness_revision=snapshot.freshness_revision,
             observation_seq=snapshot.observation_seq,
         )
+        if not force_full:
+            self._last_delta_encoder_generation = snapshot.provider_generation
+        result["stateContractVersion"] = 1
+        result["providerGeneration"] = snapshot.provider_generation
+        return result
+
+    def _snapshot_for_delivery(self) -> StateSnapshot:
+        """Synchronously ensure Web lifecycle facts before a public snapshot."""
+        snapshot = self.command_state_store.snapshot()
+        generation = snapshot.provider_generation
+        radio = self._radio
+        raw_connected = (
+            getattr(radio, "connected", False) if radio is not None else False
+        )
+        connected = raw_connected if isinstance(raw_connected, bool) else False
+        raw_control_connected = (
+            getattr(radio, "control_connected", False) if radio is not None else False
+        )
+        control_connected = (
+            raw_control_connected if isinstance(raw_control_connected, bool) else False
+        )
+        conn_state = getattr(radio, "conn_state", None) if radio is not None else None
+        raw_status = getattr(conn_state, "value", None)
+        status = (
+            raw_status
+            if isinstance(raw_status, str)
+            else "connected"
+            if connected
+            else "disconnected"
+        )
+        health = self._build_radio_health()
+        source = SourceMetadata(
+            source="local_reconcile",
+            provider="web_lifecycle",
+            transport="web",
+        )
+        values = (
+            (FieldPath.parse("connection.connection.connected"), connected),
+            (FieldPath.parse("connection.connection.radio_ready"), radio_ready(radio)),
+            (
+                FieldPath.parse("connection.connection.control_connected"),
+                control_connected,
+            ),
+            (FieldPath.parse("connection.connection.status"), status),
+            (
+                FieldPath.parse("health.health.server_reachable"),
+                health["serverReachable"],
+            ),
+            (FieldPath.parse("health.health.radio_link"), health["radioLink"]),
+            (FieldPath.parse("health.health.readiness"), health["readiness"]),
+            (FieldPath.parse("health.health.likely_cause"), health["likelyCause"]),
+            (FieldPath.parse("health.health.last_error"), health["lastError"]),
+        )
+        existing = {field.path: field for field in snapshot.fields}
+        if all(
+            (field := existing.get(path)) is not None
+            and field.value == value
+            and field.provider_generation == generation
+            and field.source == source
+            and field.quality == ("confirmed",)
+            for path, value in values
+        ):
+            return snapshot
+        timestamp = time.monotonic()
+        for path, value in values:
+            self.command_state_store.apply(
+                Observation(
+                    path=path,
+                    value=value,
+                    source=source,
+                    timestamp_monotonic=timestamp,
+                    provider_generation=generation,
+                )
+            )
+        return self.command_state_store.snapshot()
 
     def sync_state_store_from_radio_state(
         self,
@@ -2264,7 +2332,9 @@ class WebServer:
 
     def _on_reconnect_status(self, status: dict[str, Any]) -> None:
         self._connection_status = dict(status)
+        self._snapshot_for_delivery()
         self.broadcast_event("connection_status", dict(status))
+        self._broadcast_state_update()
 
     async def start(self) -> None:
         """Start the HTTP/WS listener and RadioPoller (if radio is connected)."""
@@ -2904,7 +2974,7 @@ class WebServer:
     async def _serve_state(
         self, writer: asyncio.StreamWriter, headers: dict[str, str] | None = None
     ) -> None:
-        snapshot = self.command_state_store.snapshot()
+        snapshot = self._snapshot_for_delivery()
         body_dict = self._build_public_state_from_snapshot(snapshot)
         revision = int(body_dict.get("stateRevision", body_dict.get("revision", 0)))
         freshness_revision = int(body_dict.get("freshnessRevision", 0))
@@ -2975,6 +3045,7 @@ class WebServer:
     async def _serve_capabilities(
         self, writer: asyncio.StreamWriter, headers: dict[str, str] | None = None
     ) -> None:
+        snapshot = self._snapshot_for_delivery()
         caps = _runtime_capabilities(self._radio)
         tx_audio = browser_tx_audio_facts(self._radio)
         _raw_model = (
@@ -3006,6 +3077,8 @@ class WebServer:
 
         body = json.dumps(
             {
+                "stateContractVersion": 1,
+                "providerGeneration": snapshot.provider_generation,
                 "model": model,
                 "scope": "scope" in caps,
                 "audio": "audio" in caps,

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -176,6 +176,7 @@ _RADIO_MODEL_UNSPECIFIED = "unspecified"
 _MAX_POST_BODY = 256 * 1024  # 256 KiB — hard ceiling for all POST body reads
 _MAX_COMMAND_BATCH_STEPS = 128
 _COMMAND_BATCH_STEP_TIMEOUT = 10.0
+_DELIVERY_EPOCH_ATTEMPTS = 2
 # Ceiling on the managed TX rebind that fronts recovery, derived from what the
 # rebind actually costs: one provider retirement (a transport disconnect) plus
 # one serviced effect chain — the durable OFF write and the authoritative PTT
@@ -1415,7 +1416,11 @@ class WebServer:
             self._pending_state_broadcast_task.cancel()
             self._pending_state_broadcast_task = None
 
-        snapshot = self._snapshot_for_delivery()
+        try:
+            snapshot = self._snapshot_for_delivery()
+        except RuntimeError:
+            logger.warning("state broadcast skipped: provider generation churned")
+            return
         # Keep audio FFT scope center freq and mode bandwidth in sync
         # from the same canonical snapshot used for Web delivery.
         self._update_fft_scope_freq(snapshot)
@@ -1424,7 +1429,14 @@ class WebServer:
         # subscribed (a connecting client gets initial state on connect via force=True).
         if not force and not self._control_event_queues:
             return
-        body = self._build_public_state_from_snapshot(snapshot)
+        try:
+            snapshot, body = self._build_public_state_for_delivery()
+        except RuntimeError:
+            logger.warning("state broadcast skipped: provider generation churned")
+            return
+        if self.command_state_store.provider_generation != snapshot.provider_generation:
+            logger.warning("state broadcast skipped: provider generation changed")
+            return
         state_key = self._public_state_delivery_key(
             snapshot,
             health_revision=int(body.get("healthRevision", 0)),
@@ -1462,8 +1474,10 @@ class WebServer:
 
     def build_public_state(self, *, updated_at: str | None = None) -> dict[str, Any]:
         """Return the canonical public state payload for web consumers."""
-        snapshot = self._snapshot_for_delivery()
-        return self._build_public_state_from_snapshot(snapshot, updated_at=updated_at)
+        snapshot, payload = self._build_public_state_for_delivery(updated_at=updated_at)
+        if self.command_state_store.provider_generation != snapshot.provider_generation:
+            raise RuntimeError("provider generation changed during public delivery")
+        return payload
 
     def _public_state_delivery_key(
         self,
@@ -1554,9 +1568,28 @@ class WebServer:
         self, *, force_full: bool = False
     ) -> dict[str, Any]:
         """Return a WS state-update envelope from the canonical StateStore view."""
-        snapshot = self._snapshot_for_delivery()
-        body = self._build_public_state_from_snapshot(snapshot)
+        snapshot, body = self._build_public_state_for_delivery()
+        if self.command_state_store.provider_generation != snapshot.provider_generation:
+            raise RuntimeError("provider generation changed before state encoding")
         return self._encode_state_update(snapshot, body, force_full=force_full)
+
+    def _build_public_state_for_delivery(
+        self,
+        *,
+        updated_at: str | None = None,
+    ) -> tuple[StateSnapshot, dict[str, Any]]:
+        """Build a public body only from a still-current Store generation."""
+        for _attempt in range(_DELIVERY_EPOCH_ATTEMPTS):
+            snapshot = self._snapshot_for_delivery()
+            body = self._build_public_state_from_snapshot(
+                snapshot, updated_at=updated_at
+            )
+            if (
+                self.command_state_store.provider_generation
+                == snapshot.provider_generation
+            ):
+                return snapshot, body
+        raise RuntimeError("provider generation changed during public-state build")
 
     def _encode_state_update(
         self,
@@ -1588,73 +1621,97 @@ class WebServer:
 
     def _snapshot_for_delivery(self) -> StateSnapshot:
         """Synchronously ensure Web lifecycle facts before a public snapshot."""
-        snapshot = self.command_state_store.snapshot()
-        generation = snapshot.provider_generation
-        radio = self._radio
-        raw_connected = (
-            getattr(radio, "connected", False) if radio is not None else False
-        )
-        connected = raw_connected if isinstance(raw_connected, bool) else False
-        raw_control_connected = (
-            getattr(radio, "control_connected", False) if radio is not None else False
-        )
-        control_connected = (
-            raw_control_connected if isinstance(raw_control_connected, bool) else False
-        )
-        conn_state = getattr(radio, "conn_state", None) if radio is not None else None
-        raw_status = getattr(conn_state, "value", None)
-        status = (
-            raw_status
-            if isinstance(raw_status, str)
-            else "connected"
-            if connected
-            else "disconnected"
-        )
-        health = self._build_radio_health()
-        source = SourceMetadata(
-            source="local_reconcile",
-            provider="web_lifecycle",
-            transport="web",
-        )
-        values = (
-            (FieldPath.parse("connection.connection.connected"), connected),
-            (FieldPath.parse("connection.connection.radio_ready"), radio_ready(radio)),
-            (
-                FieldPath.parse("connection.connection.control_connected"),
-                control_connected,
-            ),
-            (FieldPath.parse("connection.connection.status"), status),
-            (
-                FieldPath.parse("health.health.server_reachable"),
-                health["serverReachable"],
-            ),
-            (FieldPath.parse("health.health.radio_link"), health["radioLink"]),
-            (FieldPath.parse("health.health.readiness"), health["readiness"]),
-            (FieldPath.parse("health.health.likely_cause"), health["likelyCause"]),
-            (FieldPath.parse("health.health.last_error"), health["lastError"]),
-        )
-        existing = {field.path: field for field in snapshot.fields}
-        if all(
-            (field := existing.get(path)) is not None
-            and field.value == value
-            and field.provider_generation == generation
-            and field.source == source
-            and field.quality == ("confirmed",)
-            for path, value in values
-        ):
-            return snapshot
-        timestamp = time.monotonic()
-        for path, value in values:
-            self.command_state_store.apply(
-                Observation(
-                    path=path,
-                    value=value,
-                    source=source,
-                    timestamp_monotonic=timestamp,
-                    provider_generation=generation,
-                )
+        for _attempt in range(_DELIVERY_EPOCH_ATTEMPTS):
+            snapshot = self.command_state_store.snapshot()
+            generation = snapshot.provider_generation
+            radio = self._radio
+            raw_connected = (
+                getattr(radio, "connected", False) if radio is not None else False
             )
-        return self.command_state_store.snapshot()
+            connected = raw_connected if isinstance(raw_connected, bool) else False
+            raw_control_connected = (
+                getattr(radio, "control_connected", False)
+                if radio is not None
+                else False
+            )
+            control_connected = (
+                raw_control_connected
+                if isinstance(raw_control_connected, bool)
+                else False
+            )
+            conn_state = (
+                getattr(radio, "conn_state", None) if radio is not None else None
+            )
+            raw_status = getattr(conn_state, "value", None)
+            status = (
+                raw_status
+                if isinstance(raw_status, str)
+                else "connected"
+                if connected
+                else "disconnected"
+            )
+            health = self._build_radio_health()
+            source = SourceMetadata(
+                source="local_reconcile",
+                provider="web_lifecycle",
+                transport="web",
+            )
+            values = (
+                (FieldPath.parse("connection.connection.connected"), connected),
+                (
+                    FieldPath.parse("connection.connection.radio_ready"),
+                    radio_ready(radio),
+                ),
+                (
+                    FieldPath.parse("connection.connection.control_connected"),
+                    control_connected,
+                ),
+                (FieldPath.parse("connection.connection.status"), status),
+                (
+                    FieldPath.parse("health.health.server_reachable"),
+                    health["serverReachable"],
+                ),
+                (FieldPath.parse("health.health.radio_link"), health["radioLink"]),
+                (FieldPath.parse("health.health.readiness"), health["readiness"]),
+                (
+                    FieldPath.parse("health.health.likely_cause"),
+                    health["likelyCause"],
+                ),
+                (FieldPath.parse("health.health.last_error"), health["lastError"]),
+            )
+            existing = {field.path: field for field in snapshot.fields}
+            complete = all(
+                (field := existing.get(path)) is not None
+                and field.value == value
+                and field.provider_generation == generation
+                and field.source == source
+                and field.quality == ("confirmed",)
+                for path, value in values
+            )
+            if not complete:
+                timestamp = time.monotonic()
+                for path, value in values:
+                    self.command_state_store.apply(
+                        Observation(
+                            path=path,
+                            value=value,
+                            source=source,
+                            timestamp_monotonic=timestamp,
+                            provider_generation=generation,
+                        )
+                    )
+            result = self.command_state_store.snapshot()
+            result_fields = {field.path: field for field in result.fields}
+            if result.provider_generation == generation and all(
+                (field := result_fields.get(path)) is not None
+                and field.value == value
+                and field.provider_generation == generation
+                and field.source == source
+                and field.quality == ("confirmed",)
+                for path, value in values
+            ):
+                return result
+        raise RuntimeError("provider generation changed during lifecycle ensure")
 
     def sync_state_store_from_radio_state(
         self,
@@ -2974,8 +3031,18 @@ class WebServer:
     async def _serve_state(
         self, writer: asyncio.StreamWriter, headers: dict[str, str] | None = None
     ) -> None:
-        snapshot = self._snapshot_for_delivery()
-        body_dict = self._build_public_state_from_snapshot(snapshot)
+        try:
+            snapshot, body_dict = self._build_public_state_for_delivery()
+        except RuntimeError:
+            body = b'{"error":"provider_generation_churn"}'
+            await _send_response(
+                writer,
+                503,
+                "Service Unavailable",
+                body,
+                {"Content-Type": "application/json"},
+            )
+            return
         revision = int(body_dict.get("stateRevision", body_dict.get("revision", 0)))
         freshness_revision = int(body_dict.get("freshnessRevision", 0))
         health_revision = int(body_dict.get("healthRevision", 0))
@@ -3043,9 +3110,24 @@ class WebServer:
         return result
 
     async def _serve_capabilities(
-        self, writer: asyncio.StreamWriter, headers: dict[str, str] | None = None
+        self,
+        writer: asyncio.StreamWriter,
+        headers: dict[str, str] | None = None,
+        *,
+        _delivery_attempt: int = 0,
     ) -> None:
-        snapshot = self._snapshot_for_delivery()
+        try:
+            snapshot = self._snapshot_for_delivery()
+        except RuntimeError:
+            body = b'{"error":"provider_generation_churn"}'
+            await _send_response(
+                writer,
+                503,
+                "Service Unavailable",
+                body,
+                {"Content-Type": "application/json"},
+            )
+            return
         caps = _runtime_capabilities(self._radio)
         tx_audio = browser_tx_audio_facts(self._radio)
         _raw_model = (
@@ -3075,76 +3157,91 @@ class WebServer:
             for r in profile.freq_ranges
         ]
 
-        body = json.dumps(
-            {
-                "stateContractVersion": 1,
-                "providerGeneration": snapshot.provider_generation,
-                "model": model,
-                "scope": "scope" in caps,
-                "audio": "audio" in caps,
-                "tx": "tx" in caps,
-                "audioTx": tx_audio.available,
-                "audioTxRoute": tx_audio.route,
-                "audioTxRequiredModInputSource": tx_audio.required_mod_input_source,
-                "capabilities": sorted(caps),
-                "receivers": profile.receiver_count,
-                "vfoScheme": profile.vfo_scheme,
-                "vfoReadback": profile.vfo_readback,
-                "freqRanges": freq_ranges,
-                "modes": list(profile.modes),
-                "filters": list(profile.filters),
-                "filterWidthMin": profile.filter_width_min,
-                "filterWidthMax": profile.filter_width_max,
-                "filterConfig": _serialize_filter_config(profile),
-                "attValues": list(profile.att_values) if profile.att_values else [0],
-                "attLabels": profile.att_labels if profile.att_labels else {},
-                "preValues": list(profile.pre_values) if profile.pre_values else [0],
-                "preLabels": profile.pre_labels if profile.pre_labels else {},
-                "agcModes": list(profile.agc_modes) if profile.agc_modes else [],
-                "agcLabels": profile.agc_labels if profile.agc_labels else {},
-                "dataModeCount": profile.data_mode_count,
-                "dataModeLabels": (
-                    profile.data_mode_labels if profile.data_mode_labels else {}
+        payload = {
+            "stateContractVersion": 1,
+            "providerGeneration": snapshot.provider_generation,
+            "model": model,
+            "scope": "scope" in caps,
+            "audio": "audio" in caps,
+            "tx": "tx" in caps,
+            "audioTx": tx_audio.available,
+            "audioTxRoute": tx_audio.route,
+            "audioTxRequiredModInputSource": tx_audio.required_mod_input_source,
+            "capabilities": sorted(caps),
+            "receivers": profile.receiver_count,
+            "vfoScheme": profile.vfo_scheme,
+            "vfoReadback": profile.vfo_readback,
+            "freqRanges": freq_ranges,
+            "modes": list(profile.modes),
+            "filters": list(profile.filters),
+            "filterWidthMin": profile.filter_width_min,
+            "filterWidthMax": profile.filter_width_max,
+            "filterConfig": _serialize_filter_config(profile),
+            "attValues": list(profile.att_values) if profile.att_values else [0],
+            "attLabels": profile.att_labels if profile.att_labels else {},
+            "preValues": list(profile.pre_values) if profile.pre_values else [0],
+            "preLabels": profile.pre_labels if profile.pre_labels else {},
+            "agcModes": list(profile.agc_modes) if profile.agc_modes else [],
+            "agcLabels": profile.agc_labels if profile.agc_labels else {},
+            "dataModeCount": profile.data_mode_count,
+            "dataModeLabels": (
+                profile.data_mode_labels if profile.data_mode_labels else {}
+            ),
+            "keyboard": _serialize_keyboard_config(profile),
+            "scopeSource": (
+                "hardware"
+                if self._hardware_scope_available
+                else ("audio_fft" if self._audio_fft_scope is not None else None)
+            ),
+            "audioFftAvailable": self._audio_fft_scope is not None,
+            "scopeConfig": {
+                "centerMode": True,
+                "amplitudeMax": 160,
+                "defaultSpan": (
+                    (self._audio_fft_scope.bandwidth_hz or 48000)
+                    if self._audio_fft_scope is not None
+                    else 500000
                 ),
-                "keyboard": _serialize_keyboard_config(profile),
-                "scopeSource": (
-                    "hardware"
-                    if self._hardware_scope_available
-                    else ("audio_fft" if self._audio_fft_scope is not None else None)
-                ),
-                "audioFftAvailable": self._audio_fft_scope is not None,
-                "scopeConfig": {
-                    "centerMode": True,
-                    "amplitudeMax": 160,
-                    "defaultSpan": (
-                        (self._audio_fft_scope.bandwidth_hz or 48000)
-                        if self._audio_fft_scope is not None
-                        else 500000
-                    ),
-                },
-                "audioConfig": {
-                    "sampleRate": 48000,
-                    "channels": 1,
-                    "codecs": ["opus"],
-                    "jitterFloorMs": get_audio_rx_jitter_floor_ms(),
-                    "jitterCeilingMs": get_audio_rx_jitter_ceiling_ms(),
-                },
-                "antennas": profile.antenna_tx_count,
-                "webrtc": {
-                    "available": webrtc_available(),
-                    "enabled": self._config.webrtc_enabled,
-                },
-                **({"controls": profile.controls} if profile.controls else {}),
-                "txBands": [
-                    {"name": b.name, "start": b.start, "end": b.end}
-                    for fr in profile.freq_ranges
-                    for b in fr.bands
-                ]
-                or None,
-                **self._get_meter_cal_payload(),
             },
-            separators=(",", ":"),
-        ).encode()
+            "audioConfig": {
+                "sampleRate": 48000,
+                "channels": 1,
+                "codecs": ["opus"],
+                "jitterFloorMs": get_audio_rx_jitter_floor_ms(),
+                "jitterCeilingMs": get_audio_rx_jitter_ceiling_ms(),
+            },
+            "antennas": profile.antenna_tx_count,
+            "webrtc": {
+                "available": webrtc_available(),
+                "enabled": self._config.webrtc_enabled,
+            },
+            **({"controls": profile.controls} if profile.controls else {}),
+            "txBands": [
+                {"name": b.name, "start": b.start, "end": b.end}
+                for fr in profile.freq_ranges
+                for b in fr.bands
+            ]
+            or None,
+            **self._get_meter_cal_payload(),
+        }
+        if self.command_state_store.provider_generation != snapshot.provider_generation:
+            if _delivery_attempt + 1 < _DELIVERY_EPOCH_ATTEMPTS:
+                await self._serve_capabilities(
+                    writer,
+                    headers,
+                    _delivery_attempt=_delivery_attempt + 1,
+                )
+                return
+            body = b'{"error":"provider_generation_churn"}'
+            await _send_response(
+                writer,
+                503,
+                "Service Unavailable",
+                body,
+                {"Content-Type": "application/json"},
+            )
+            return
+        body = json.dumps(payload, separators=(",", ":")).encode()
         await _send_json(writer, body, headers)
 
     async def _serve_dx_spots(self, writer: asyncio.StreamWriter) -> None:

--- a/src/rigplane/web/state_schema.py
+++ b/src/rigplane/web/state_schema.py
@@ -275,6 +275,10 @@ class ServerStatePublic(_Strict):
     observationSeq: int
     healthRevision: int = 0
     updatedAt: str
+    # Additive wire-contract metadata. Runtime B2 emission requires both;
+    # defaults preserve generated compile-time compatibility for old consumers.
+    stateContractVersion: Literal[1] = 1
+    providerGeneration: int = 0
 
     # Global slow-state / TX flags.
     # ``active`` is set to "MAIN"/"SUB" in exactly three places:

--- a/tests/test_state_pipeline_contracts.py
+++ b/tests/test_state_pipeline_contracts.py
@@ -845,7 +845,10 @@ def test_web_poller_command_response_no_op_remains_removed() -> None:
 async def test_web_delivery_payloads_use_snapshot_not_legacy_state_or_revision() -> (
     None
 ):
-    server, snapshot = _server_with_conflicting_legacy_state()
+    server, _ = _server_with_conflicting_legacy_state()
+    # B2 seeds the current-generation lifecycle tuple before first delivery.
+    server._snapshot_for_delivery()  # noqa: SLF001
+    snapshot = server.command_state_store.snapshot()
 
     public_payload = server.build_public_state()
     _assert_delivered_from_snapshot(public_payload, snapshot)
@@ -876,7 +879,9 @@ async def test_web_delivery_payloads_use_snapshot_not_legacy_state_or_revision()
 
 
 def test_web_state_change_callback_broadcasts_snapshot_without_revision_path() -> None:
-    server, snapshot = _server_with_conflicting_legacy_state()
+    server, _ = _server_with_conflicting_legacy_state()
+    server._snapshot_for_delivery()  # noqa: SLF001
+    snapshot = server.command_state_store.snapshot()
     queue: BoundedQueue[dict[str, Any]] = BoundedQueue(maxsize=16)
     server.register_control_event_queue(queue)
 

--- a/tests/test_state_pipeline_diagnostics.py
+++ b/tests/test_state_pipeline_diagnostics.py
@@ -117,18 +117,19 @@ def test_web_meter_write_delivers_state_store_revision_without_unrelated_trigger
     )
 
     payload = server.build_public_state()
+    snapshot = server.command_state_store.snapshot()
     assert payload["main"]["sMeter"] == 42
-    assert payload["revision"] == 1
-    assert payload["stateRevision"] == 1
-    assert payload["freshnessRevision"] == 1
+    assert payload["revision"] == snapshot.state_revision
+    assert payload["stateRevision"] == snapshot.state_revision
+    assert payload["freshnessRevision"] == snapshot.freshness_revision
 
     server._broadcast_state_update()
 
     queued = queue.get_nowait()
     assert queued["type"] == "state_update"
     assert queued["data"]["type"] == "full"
-    assert queued["data"]["stateRevision"] == 1
-    assert queued["data"]["freshnessRevision"] == 1
+    assert queued["data"]["stateRevision"] == snapshot.state_revision
+    assert queued["data"]["freshnessRevision"] == snapshot.freshness_revision
     assert queued["data"]["data"]["main"]["sMeter"] == 42
     assert queue.empty()
     assert server.state_diagnostics.snapshot()["counts"] == {

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -621,7 +621,8 @@ def test_state_store_freshness_refresh_broadcasts_without_semantic_change() -> N
     assert state_update["type"] == "state_update"
     assert any(
         item.kind == "web_delivery_trigger"
-        and item.details["freshness_revision"] == refreshed.freshness_revision
+        and item.details["freshness_revision"]
+        == srv.command_state_store.snapshot().freshness_revision
         for item in srv.state_diagnostics.events()
     )
     assert not any(
@@ -1928,8 +1929,13 @@ async def test_same_value_observation_metadata_updates_http_and_initial_ws_full_
     assert field_status["lastObservedMonotonic"] == 2.0
     assert field_status["maxAge"] == 10.0
     assert field_status["source"]["provider"] == "second"
-    assert http_body["observationSeq"] == 2
-    assert ws_body["observationSeq"] == 2
+    assert (
+        http_body["observationSeq"]
+        == srv.command_state_store.snapshot().observation_seq
+    )
+    assert (
+        ws_body["observationSeq"] == srv.command_state_store.snapshot().observation_seq
+    )
 
 
 def test_empty_state_store_marks_legacy_defaults_as_missing() -> None:
@@ -2029,8 +2035,13 @@ def test_meter_only_state_store_change_emits_web_delta_without_legacy_revision()
     assert event["type"] == "state_update"
     assert event["data"]["type"] == "delta"
     assert event["data"]["changed"]["main"]["sMeter"] == 55
-    assert event["data"]["stateRevision"] == 2
-    assert event["data"]["revision"] == 2
+    assert (
+        event["data"]["stateRevision"]
+        == srv.command_state_store.snapshot().state_revision
+    )
+    assert (
+        event["data"]["revision"] == srv.command_state_store.snapshot().state_revision
+    )
 
 
 def test_freshness_only_state_store_change_emits_web_delta() -> None:
@@ -2064,12 +2075,15 @@ def test_freshness_only_state_store_change_emits_web_delta() -> None:
 
     assert event["type"] == "state_update"
     assert event["data"]["type"] == "delta"
-    assert event["data"]["changed"]["freshnessRevision"] == 2
+    assert (
+        event["data"]["changed"]["freshnessRevision"]
+        == store.snapshot().freshness_revision
+    )
     field_status = event["data"]["changed"]["fieldStatus"]["main.sMeter"]
     assert field_status["observed"] is True
     assert field_status["freshness"] == "stale"
     assert field_status["availability"] == "stale"
-    assert event["data"]["stateRevision"] == 1
+    assert event["data"]["stateRevision"] == store.snapshot().state_revision
 
 
 def test_same_value_observation_metadata_change_emits_web_delta() -> None:
@@ -2119,8 +2133,14 @@ def test_same_value_observation_metadata_change_emits_web_delta() -> None:
     assert field_status["lastObservedMonotonic"] == 2.0
     assert field_status["maxAge"] == 10.0
     assert field_status["source"]["provider"] == "second"
-    assert event["data"]["stateRevision"] == 1
-    assert event["data"]["observationSeq"] == 2
+    assert (
+        event["data"]["stateRevision"]
+        == srv.command_state_store.snapshot().state_revision
+    )
+    assert (
+        event["data"]["observationSeq"]
+        == srv.command_state_store.snapshot().observation_seq
+    )
 
 
 def test_initial_full_state_envelope_does_not_consume_broadcast_delta() -> None:
@@ -2154,7 +2174,134 @@ def test_initial_full_state_envelope_does_not_consume_broadcast_delta() -> None:
 
     assert event["data"]["type"] == "delta"
     assert event["data"]["changed"]["ptt"] is True
-    assert event["data"]["stateRevision"] == 2
+    assert (
+        event["data"]["stateRevision"]
+        == srv.command_state_store.snapshot().state_revision
+    )
+
+
+def test_state_delivery_contract_is_bound_to_store_generation() -> None:
+    """Web delivery never derives its epoch from provider-private counters."""
+    radio = SimpleNamespace(
+        connected=True,
+        control_connected=True,
+        radio_ready=True,
+        capabilities=set(),
+        _civ_epoch=99,
+        managed_tx_generation=123,
+    )
+    srv = WebServer(radio)
+    generation = srv.command_state_store.begin_provider_generation()
+
+    envelope = srv.build_state_update_envelope()
+
+    assert envelope["type"] == "full"
+    assert envelope["stateContractVersion"] == 1
+    assert envelope["providerGeneration"] == generation
+    assert envelope["data"]["stateContractVersion"] == 1
+    assert envelope["data"]["providerGeneration"] == generation
+
+
+def test_generation_transition_forces_existing_encoder_to_emit_full() -> None:
+    srv = WebServer(None)
+    first = srv.build_state_update_envelope()
+    first_seq = first["data"]["publicStateSeq"]
+
+    generation = srv.command_state_store.begin_provider_generation()
+    next_frame = srv.build_state_update_envelope()
+
+    assert first["type"] == "full"
+    assert next_frame["type"] == "full"
+    assert next_frame["providerGeneration"] == generation
+    assert next_frame["data"]["providerGeneration"] == generation
+    assert next_frame["data"]["publicStateSeq"] > first_seq
+
+    same_generation = srv.build_state_update_envelope()
+    assert same_generation["type"] == "delta"
+    assert same_generation["stateContractVersion"] == 1
+    assert same_generation["providerGeneration"] == generation
+    assert "data" not in same_generation
+
+
+def test_lifecycle_observations_are_current_generation_and_idempotent() -> None:
+    radio = SimpleNamespace(
+        connected=True,
+        control_connected=False,
+        radio_ready=True,
+        capabilities=set(),
+    )
+    srv = WebServer(radio)
+    generation = srv.command_state_store.begin_provider_generation()
+
+    srv.build_public_state()
+    after_first = srv.command_state_store.snapshot()
+    expected = {
+        "connection.connection.connected",
+        "connection.connection.radio_ready",
+        "connection.connection.control_connected",
+        "connection.connection.status",
+        "health.health.server_reachable",
+        "health.health.radio_link",
+        "health.health.readiness",
+        "health.health.likely_cause",
+        "health.health.last_error",
+    }
+    fields = {str(field.path): field for field in after_first.fields}
+
+    assert expected <= fields.keys()
+    assert {fields[path].provider_generation for path in expected} == {generation}
+    assert {fields[path].source.source for path in expected} == {"local_reconcile"}
+    assert {fields[path].source.provider for path in expected} == {"web_lifecycle"}
+    assert len({fields[path].last_observed_monotonic for path in expected}) == 1
+
+    srv.build_public_state()
+    after_second = srv.command_state_store.snapshot()
+    assert after_second.state_revision == after_first.state_revision
+    assert after_second.freshness_revision == after_first.freshness_revision
+    assert after_second.observation_seq == after_first.observation_seq
+
+
+@pytest.mark.asyncio
+async def test_http_and_capabilities_share_the_current_store_generation() -> None:
+    srv = WebServer(None)
+    generation = srv.command_state_store.begin_provider_generation()
+
+    state_writer = _FakeWriter()
+    await srv._serve_state(state_writer)  # noqa: SLF001
+    _, state_body = _response_json(state_writer)
+    caps_writer = _FakeWriter()
+    await srv._serve_capabilities(caps_writer)  # noqa: SLF001
+    _, caps_body = _response_json(caps_writer)
+
+    assert state_body["stateContractVersion"] == 1
+    assert state_body["providerGeneration"] == generation
+    assert caps_body["stateContractVersion"] == 1
+    assert caps_body["providerGeneration"] == generation
+
+
+@pytest.mark.asyncio
+async def test_generation_transition_changes_state_etag() -> None:
+    srv = WebServer(None)
+    first_writer = _FakeWriter()
+    await srv._serve_state(first_writer)  # noqa: SLF001
+    first_header = first_writer.buffer.decode("ascii", errors="replace").split(
+        "\r\n\r\n", 1
+    )[0]
+    first_etag = next(
+        line for line in first_header.splitlines() if line.startswith("ETag:")
+    )
+
+    srv.command_state_store.begin_provider_generation()
+    next_writer = _FakeWriter()
+    await srv._serve_state(next_writer)  # noqa: SLF001
+    next_header = next_writer.buffer.decode("ascii", errors="replace").split(
+        "\r\n\r\n", 1
+    )[0]
+    next_etag = next(
+        line for line in next_header.splitlines() if line.startswith("ETag:")
+    )
+
+    assert next_etag != first_etag
 
 
 @pytest.mark.asyncio
@@ -2217,7 +2364,7 @@ async def test_state_response_refreshes_live_connection_payload_without_revision
     status2, control_changed = _response_json(writer2)
 
     assert status2 == 200
-    assert control_changed["stateRevision"] == initial["stateRevision"]
+    assert control_changed["stateRevision"] > initial["stateRevision"]
     assert control_changed["freshnessRevision"] == initial["freshnessRevision"]
     assert control_changed["healthRevision"] == initial["healthRevision"]
     assert control_changed["connection"]["controlConnected"] is True
@@ -2229,8 +2376,10 @@ async def test_state_response_refreshes_live_connection_payload_without_revision
     status3, connected_changed = _response_json(writer3)
 
     assert status3 == 200
-    assert connected_changed["stateRevision"] == initial["stateRevision"]
-    assert connected_changed["freshnessRevision"] == initial["freshnessRevision"]
+    assert connected_changed["stateRevision"] > control_changed["stateRevision"]
+    assert (
+        connected_changed["freshnessRevision"] == control_changed["freshnessRevision"]
+    )
     assert connected_changed["healthRevision"] == initial["healthRevision"]
     assert connected_changed["connection"]["rigConnected"] is False
     assert connected_changed["connection"]["radioReady"] is True
@@ -2262,7 +2411,7 @@ def test_broadcast_state_update_refreshes_live_connection_payload_without_revisi
 
     assert event["type"] == "state_update"
     assert event["data"]["type"] == "delta"
-    assert event["data"]["stateRevision"] == initial["stateRevision"]
+    assert event["data"]["stateRevision"] > initial["stateRevision"]
     assert event["data"]["freshnessRevision"] == initial["freshnessRevision"]
     assert event["data"]["changed"]["connection"]["controlConnected"] is True
 
@@ -2710,8 +2859,8 @@ async def test_state_response_includes_revision_and_updated_at() -> None:
 
 
 @pytest.mark.asyncio
-async def test_state_response_revision_zero_without_poller() -> None:
-    """The legacy revision alias comes from the StateStore, not RadioPoller."""
+async def test_state_response_includes_lifecycle_observations_without_poller() -> None:
+    """A first delivery synchronously seeds the Store-owned lifecycle tuple."""
     import json as _json
 
     srv = WebServer(None)
@@ -2721,8 +2870,8 @@ async def test_state_response_revision_zero_without_poller() -> None:
     text = writer.buffer.decode("ascii", errors="replace")
     body_start = text.index("\r\n\r\n") + 4
     data = _json.loads(text[body_start:])
-    assert data["revision"] == 0
-    assert data["stateRevision"] == 0
+    assert data["revision"] == data["stateRevision"]
+    assert data["stateRevision"] > 0
 
 
 @pytest.mark.asyncio
@@ -2756,8 +2905,14 @@ async def test_on_radio_state_change_broadcasts_canonical_state_payload() -> Non
     state_update = queue.get_nowait()
     assert event["type"] == "event"
     assert state_update["type"] == "state_update"
-    assert state_update["data"]["stateRevision"] == 1
-    assert state_update["data"]["revision"] == 1
+    assert (
+        state_update["data"]["stateRevision"]
+        == srv.command_state_store.snapshot().state_revision
+    )
+    assert (
+        state_update["data"]["revision"]
+        == srv.command_state_store.snapshot().state_revision
+    )
 
 
 @pytest.mark.asyncio
@@ -3117,7 +3272,7 @@ class TestStateEtag:
         text2 = writer2.buffer.decode("ascii", errors="replace")
         assert "200 OK" in text2.split("\r\n", 1)[0]
         body = json.loads(text2[text2.index("\r\n\r\n") + 4 :])
-        assert body["revision"] == 0
+        assert body["revision"] > 0
         assert body["healthRevision"] == 2
         assert body["radioHealth"]["likelyCause"] == "radio_not_responding"
 
@@ -3173,7 +3328,9 @@ class TestStateEtag:
         status, body = _response_json(writer2)
 
         assert status == 200
-        assert body["observationSeq"] == 2
+        assert (
+            body["observationSeq"] == srv.command_state_store.snapshot().observation_seq
+        )
         field_status = body["fieldStatus"]["main.freqHz"]
         assert field_status["lastObservedMonotonic"] == 2.0
         assert field_status["maxAge"] == 10.0

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -81,6 +81,29 @@ class _FakeWriter:
         return default
 
 
+class _GenerationAdvanceOnApplyStore(StateStore):
+    """Deterministically retire a captured lifecycle token during apply."""
+
+    def __init__(self, *, advance_on_apply: int) -> None:
+        super().__init__()
+        self.advance_on_apply = advance_on_apply
+        self.apply_calls = 0
+
+    def apply(self, observation: Observation):  # type: ignore[no-untyped-def]
+        self.apply_calls += 1
+        if self.apply_calls == self.advance_on_apply:
+            self.begin_provider_generation()
+        return super().apply(observation)
+
+
+class _GenerationAdvanceEveryApplyStore(StateStore):
+    """Force bounded lifecycle publication to fail closed under continuous churn."""
+
+    def apply(self, observation: Observation):  # type: ignore[no-untyped-def]
+        self.begin_provider_generation()
+        return super().apply(observation)
+
+
 def _reader_with(data: bytes) -> asyncio.StreamReader:
     reader = asyncio.StreamReader()
     reader.feed_data(data)
@@ -2259,6 +2282,115 @@ def test_lifecycle_observations_are_current_generation_and_idempotent() -> None:
     assert after_second.state_revision == after_first.state_revision
     assert after_second.freshness_revision == after_first.freshness_revision
     assert after_second.observation_seq == after_first.observation_seq
+
+
+@pytest.mark.parametrize("advance_on_apply", [1, 5])
+def test_lifecycle_retry_after_generation_advance_has_one_complete_current_tuple(
+    advance_on_apply: int,
+) -> None:
+    srv = WebServer(None)
+    store = _GenerationAdvanceOnApplyStore(advance_on_apply=advance_on_apply)
+    srv.command_state_store = store
+
+    payload = srv.build_public_state()
+    snapshot = store.snapshot()
+    lifecycle = {
+        field
+        for field in snapshot.fields
+        if str(field.path).startswith(("connection.connection.", "health.health."))
+    }
+    before_repeat = (
+        snapshot.state_revision,
+        snapshot.freshness_revision,
+        snapshot.observation_seq,
+    )
+
+    assert payload["providerGeneration"] == 1
+    assert snapshot.provider_generation == 1
+    assert len(lifecycle) == 9
+    assert {field.provider_generation for field in lifecycle} == {1}
+    assert {field.source.provider for field in lifecycle} == {"web_lifecycle"}
+    assert len({field.last_observed_monotonic for field in lifecycle}) == 1
+
+    srv.build_public_state()
+    repeated = store.snapshot()
+    assert (
+        repeated.state_revision,
+        repeated.freshness_revision,
+        repeated.observation_seq,
+    ) == before_repeat
+
+
+@pytest.mark.parametrize("wire", ["public", "websocket"])
+def test_public_and_ws_retry_when_profile_projection_retires_generation(
+    wire: str,
+) -> None:
+    srv = WebServer(None)
+    store = srv.command_state_store
+    get_profile = srv._get_profile  # noqa: SLF001
+    fired = False
+
+    def advancing_profile():
+        nonlocal fired
+        if not fired:
+            fired = True
+            store.begin_provider_generation()
+        return get_profile()
+
+    srv._get_profile = advancing_profile  # type: ignore[method-assign]
+    payload = (
+        srv.build_public_state()
+        if wire == "public"
+        else srv.build_state_update_envelope()["data"]
+    )
+
+    assert payload["providerGeneration"] == store.provider_generation == 1
+    assert payload["stateContractVersion"] == 1
+
+
+@pytest.mark.asyncio
+async def test_capabilities_retry_when_profile_build_retires_generation() -> None:
+    srv = WebServer(None)
+    store = srv.command_state_store
+    get_profile = srv._get_profile  # noqa: SLF001
+    fired = False
+
+    def advancing_profile():
+        nonlocal fired
+        if not fired:
+            fired = True
+            store.begin_provider_generation()
+        return get_profile()
+
+    srv._get_profile = advancing_profile  # type: ignore[method-assign]
+    writer = _FakeWriter()
+    await srv._serve_capabilities(writer)  # noqa: SLF001
+    status, payload = _response_json(writer)
+
+    assert status == 200
+    assert payload["providerGeneration"] == store.provider_generation == 1
+    assert payload["stateContractVersion"] == 1
+
+
+@pytest.mark.asyncio
+async def test_continuous_lifecycle_generation_churn_fails_closed_without_state_event() -> (
+    None
+):
+    srv = WebServer(None)
+    srv.command_state_store = _GenerationAdvanceEveryApplyStore()
+    queue: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=2)
+    srv.register_control_event_queue(queue)
+
+    with pytest.raises(RuntimeError, match="lifecycle ensure"):
+        srv.build_public_state()
+    srv._broadcast_state_update(force=True)  # noqa: SLF001
+    assert queue.empty()
+
+    writer = _FakeWriter()
+    await srv._serve_capabilities(writer)  # noqa: SLF001
+    status, payload = _response_json(writer)
+    assert status == 503
+    assert payload == {"error": "provider_generation_churn"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Related to #2316

B2a server/public-contract slice only.

- Emits Store-owned provider generation and contract version in public state, WS envelopes, and capabilities.
- Forces a full frame after a Store generation transition; lifecycle observations are synchronous and token-bound.
- Production scope: `web/server.py`, `web/state_schema.py`, generated `frontend/src/lib/types/state.ts`; no command, ACK, PTT, audio, scope, spectrum, queue, or provider-write changes.

Verification on head d909d428a4a98ad393173bc602af4a2e062ea6ef:
- focused 358 passed, 2 skipped
- dependent 310 passed
- full 9227 passed, 68 skipped, 5 deselected, 11 xfailed, 1 xpassed
- ruff, format, mypy, generated-types check, frontend check, import-linter, diff check: PASS

Independent exact-head `gpt-5.6-sol` xhigh review required. No auto-merge.