### PR TITLE
fix(#2316): fail closed on browser provider epochs

### DIFF
--- a/frontend/src/__tests__/presentation-switch-tx.component.test.ts
+++ b/frontend/src/__tests__/presentation-switch-tx.component.test.ts
@@ -67,6 +67,9 @@ vi.mock('$lib/stores/radio.svelte', () => ({
 vi.mock('$lib/stores/capabilities.svelte', () => ({
   getCapabilities: () => h.caps,
   hasAnyScope: () => false,
+  capabilitiesMatchGeneration: () => true,
+  clearCapabilities: () => {},
+  setCapabilities: () => true,
 }));
 vi.mock('$lib/runtime/adapters/tx-adapter', () => ({
   getTxAudioControl: () => ({

--- a/frontend/src/components-v2/panels/lcd/__tests__/audio-fft-demand.isolated.test.ts
+++ b/frontend/src/components-v2/panels/lcd/__tests__/audio-fft-demand.isolated.test.ts
@@ -86,6 +86,8 @@ const canonicalCapabilities: Capabilities = {
   audioConfig: { sampleRate: 48_000, channels: 1, codecs: ['pcm16'] },
   webrtc: { available: false, enabled: false },
   txBands: null,
+  stateContractVersion: 1,
+  providerGeneration: 0,
 };
 
 function radioState(revision: number) {
@@ -96,6 +98,7 @@ function radioState(revision: number) {
   };
   return {
     revision, stateRevision: revision, active: 'MAIN',
+    stateContractVersion: 1, providerGeneration: 0,
     main: receiver, sub: { ...receiver },
   } as never;
 }

--- a/frontend/src/components-v2/wiring/__tests__/semantic-cw-keyer-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-cw-keyer-wiring.component.test.ts
@@ -98,6 +98,7 @@ vi.mock('$lib/runtime/adapters/mod-input-tx-guard.svelte', () => ({
 
 import { sendCommand } from '$lib/transport/ws-client';
 import { resetRadioState, setRadioState } from '$lib/stores/radio.svelte';
+import { setCapabilities } from '$lib/stores/capabilities.svelte';
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';
 
 /**
@@ -142,6 +143,7 @@ function liveState(over: Partial<ServerState> = {}, mode = 'CW'): ServerState {
   });
   return {
     active: 'MAIN', split: false, dualWatch: false, ptt: false,
+    stateContractVersion: 1, providerGeneration: 0,
     breakIn: 1, breakInDelay: 64, keySpeed: 24, cwPitch: 600, dashRatio: 0,
     txTarget: { status: 'known', receiver: 'MAIN', slot: 'A', frequencyHz: 14250000 },
     main: receiver(14250000, 0), sub: receiver(14300000, 2),
@@ -162,6 +164,7 @@ const liveCaps = (tags: readonly string[]): Capabilities => ({
   webrtc: { available: false, enabled: false },
   txBands: [{ start: 14000000, end: 14350000, name: '20m' }],
   scopeSource: null, audioFftAvailable: false,
+  stateContractVersion: 1, providerGeneration: 0,
 } as unknown as Capabilities);
 
 /** A full CW radio: keyer, break-in, APF and the twin-peak filter. */
@@ -200,6 +203,7 @@ function useState(state: ServerState): void {
 }
 
 beforeEach(() => {
+  setCapabilities(liveCaps(CW_TAGS));
   useState(liveState());
   h.caps = liveCaps(CW_TAGS);
   h.snapshot = { ...IDLE };

--- a/frontend/src/components-v2/wiring/__tests__/semantic-cw-keyer-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-cw-keyer-wiring.component.test.ts
@@ -140,13 +140,18 @@ function liveState(over: Partial<ServerState> = {}, mode = 'CW'): ServerState {
   const receiver = (hz: number, apfTypeLevel: number) => ({
     ...slot(hz, mode), vfoA: slot(hz, mode), vfoB: slot(hz + 50000, mode), activeSlot: 'A',
     filter: 1, apfTypeLevel, twinPeakFilter: false,
+    sMeter: 0, att: 0, preamp: 0, nb: false, nr: false,
+    afLevel: 0, rfGain: 0, squelch: 0,
   });
   return {
+    revision: 1, stateRevision: 1, freshnessRevision: 1, observationSeq: 1,
+    updatedAt: '2026-08-08T00:00:00Z', tunerStatus: 0,
     active: 'MAIN', split: false, dualWatch: false, ptt: false,
     stateContractVersion: 1, providerGeneration: 0,
     breakIn: 1, breakInDelay: 64, keySpeed: 24, cwPitch: 600, dashRatio: 0,
     txTarget: { status: 'known', receiver: 'MAIN', slot: 'A', frequencyHz: 14250000 },
     main: receiver(14250000, 0), sub: receiver(14300000, 2),
+    connection: { rigConnected: true, radioReady: true, controlConnected: true },
     ...over,
     fieldStatus: Object.fromEntries(paths.map((p) => [p, fresh])),
   } as unknown as ServerState;
@@ -413,7 +418,7 @@ describe('the surface mounts only where a declared zone can hold it', () => {
   it('leaves the cockpit with no focusable control outside a declared zone', () => {
     render({ strips: 'dual' });
     const outside = [...target.querySelectorAll<HTMLElement>('button, input, select, [tabindex]')]
-      .filter((node) => node.closest('[data-zone-id]') === null);
+      .filter((node) => !node.matches(':disabled') && node.closest('[data-zone-id]') === null);
     expect(outside).toEqual([]);
   });
 });

--- a/frontend/src/components-v2/wiring/__tests__/semantic-ritxit-scan-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-ritxit-scan-wiring.component.test.ts
@@ -107,13 +107,18 @@ function liveState(over: Partial<ServerState> = {}): ServerState {
   }
   const receiver = (hz: number) => ({
     ...slot(hz), vfoA: slot(hz), vfoB: slot(hz + 50000), activeSlot: 'A', filter: 1,
+    sMeter: 0, att: 0, preamp: 0, nb: false, nr: false,
+    afLevel: 0, rfGain: 0, squelch: 0,
   });
   return {
+    revision: 1, stateRevision: 1, freshnessRevision: 1, observationSeq: 1,
+    updatedAt: '2026-08-08T00:00:00Z', tunerStatus: 0,
     active: 'MAIN', split: false, dualWatch: false, ptt: false,
     stateContractVersion: 1, providerGeneration: 0,
     ritOn: true, ritTx: false, ritFreq: 250, scanning: false, scanType: 0x01, scanResumeMode: 1,
     txTarget: { status: 'known', receiver: 'MAIN', slot: 'A', frequencyHz: 14250000 },
     main: receiver(14250000), sub: receiver(14300000),
+    connection: { rigConnected: true, radioReady: true, controlConnected: true },
     ...over,
     fieldStatus: Object.fromEntries(paths.map((p) => [p, fresh])),
   } as unknown as ServerState;
@@ -292,7 +297,7 @@ describe('the surface mounts only in the single composition, never in dual', () 
   it('leaves the cockpit composition with no focusable control outside a declared zone', () => {
     render({ strips: 'dual' });
     const outside = [...target.querySelectorAll<HTMLElement>('button, input, select, [tabindex]')]
-      .filter((node) => node.closest('[data-zone-id]') === null);
+      .filter((node) => !node.matches(':disabled') && node.closest('[data-zone-id]') === null);
     expect(outside).toEqual([]);
   });
 });

--- a/frontend/src/components-v2/wiring/__tests__/semantic-ritxit-scan-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-ritxit-scan-wiring.component.test.ts
@@ -83,6 +83,7 @@ import { sendCommand } from '$lib/transport/ws-client';
 // agree with `h.state` (below) keeps the toggle direction deterministic and
 // independent of whatever a prior test in this file left behind.
 import { resetRadioState, setRadioState } from '$lib/stores/radio.svelte';
+import { setCapabilities } from '$lib/stores/capabilities.svelte';
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';
 
 const IDLE: Snapshot = {
@@ -109,6 +110,7 @@ function liveState(over: Partial<ServerState> = {}): ServerState {
   });
   return {
     active: 'MAIN', split: false, dualWatch: false, ptt: false,
+    stateContractVersion: 1, providerGeneration: 0,
     ritOn: true, ritTx: false, ritFreq: 250, scanning: false, scanType: 0x01, scanResumeMode: 1,
     txTarget: { status: 'known', receiver: 'MAIN', slot: 'A', frequencyHz: 14250000 },
     main: receiver(14250000), sub: receiver(14300000),
@@ -124,6 +126,7 @@ const liveCaps = (tags: readonly string[]): Capabilities => ({
   webrtc: { available: false, enabled: false },
   txBands: [{ start: 14000000, end: 14350000, name: '20m' }],
   scopeSource: null, audioFftAvailable: false,
+  stateContractVersion: 1, providerGeneration: 0,
 } as unknown as Capabilities);
 
 /** `rit`/`xit` capability tags are what makes the ritXit group present;
@@ -153,6 +156,7 @@ function useState(state: ServerState): void {
 
 beforeEach(() => {
   resetRadioState();
+  setCapabilities(liveCaps(RIT_XIT_TAGS));
   useState(liveState());
   h.caps = liveCaps(RIT_XIT_TAGS);
   h.snapshot = { ...IDLE };

--- a/frontend/src/lib/runtime/adapters/__tests__/dsp-adapter.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/dsp-adapter.isolated.test.ts
@@ -30,7 +30,8 @@ function caps(overrides: Partial<Capabilities> = {}): Capabilities {
     receivers: 1, vfoScheme: 'single', freqRanges: [], modes: [], filters: [],
     audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
     webrtc: { available: false, enabled: false },
-    txBands: [], scopeSource: 'hardware', audioFftAvailable: false, ...overrides,
+    txBands: [], scopeSource: 'hardware', audioFftAvailable: false,
+    stateContractVersion: 1, providerGeneration: 0, ...overrides,
   } as Capabilities;
 }
 

--- a/frontend/src/lib/runtime/adapters/__tests__/filter-passband-adapter.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/filter-passband-adapter.isolated.test.ts
@@ -31,7 +31,8 @@ function caps(overrides: Partial<Capabilities> = {}): Capabilities {
     receivers: 1, vfoScheme: 'single', freqRanges: [], modes: [], filters: [],
     audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
     webrtc: { available: false, enabled: false },
-    txBands: [], scopeSource: 'hardware', audioFftAvailable: false, ...overrides,
+    txBands: [], scopeSource: 'hardware', audioFftAvailable: false,
+    stateContractVersion: 1, providerGeneration: 0, ...overrides,
   } as Capabilities;
 }
 

--- a/frontend/src/lib/runtime/adapters/__tests__/mod-input-auto.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mod-input-auto.isolated.test.ts
@@ -95,6 +95,8 @@ function makeState(overrides: Record<string, unknown> = {}): ServerState {
     split: false,
     dualWatch: false,
     tunerStatus: 0,
+    stateContractVersion: 1,
+    providerGeneration: 0,
     main: receiver(0),
     sub: receiver(0),
     ...overrides,
@@ -168,7 +170,7 @@ beforeEach(() => {
   vi.mocked(runtime.startTx).mockResolvedValue(null);
   vi.mocked(runtime.stopTx).mockClear();
   resetRadioState();
-  setCapabilities({ capabilities: ['data_mode'] } as never);
+  setCapabilities({ capabilities: ['data_mode'], stateContractVersion: 1, providerGeneration: 0 } as never);
   dismissModInputTxGuard();
 });
 
@@ -193,10 +195,10 @@ describe('toggle (MOR-618)', () => {
     setState({ main: receiver(1), data1ModInput: 0 });
     expect(deriveAutoLanModInputProps().available).toBe(true);
 
-    setCapabilities({ capabilities: [] } as never);
+    setCapabilities({ capabilities: [], stateContractVersion: 1, providerGeneration: 0 } as never);
     expect(deriveAutoLanModInputProps().available).toBe(false);
 
-    setCapabilities({ capabilities: ['data_mode'] } as never);
+    setCapabilities({ capabilities: ['data_mode'], stateContractVersion: 1, providerGeneration: 0 } as never);
     setState({
       main: receiver(1),
       data1ModInput: 0,
@@ -277,7 +279,7 @@ describe('auto-set at TX start (MOR-618)', () => {
 
   it('does nothing without the data_mode capability', async () => {
     setAutoLanModInputEnabled(true);
-    setCapabilities({ capabilities: [] } as never);
+    setCapabilities({ capabilities: [], stateContractVersion: 1, providerGeneration: 0 } as never);
     setState({ main: receiver(1), data1ModInput: 0 });
 
     await getTxAudioControl().startTx();

--- a/frontend/src/lib/runtime/adapters/__tests__/mod-input-auto.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mod-input-auto.isolated.test.ts
@@ -113,6 +113,10 @@ function setState(overrides: Record<string, unknown> = {}): void {
   setRadioState(makeState(overrides));
 }
 
+function useDualReceiverCapabilities(): void {
+  setCapabilities({ capabilities: ['data_mode'], receivers: 2, vfoScheme: 'main_sub', stateContractVersion: 1, providerGeneration: 0 } as never);
+}
+
 function missingStatus() {
   return {
     storePath: 'test.path',
@@ -250,6 +254,7 @@ describe('auto-set at TX start (MOR-618)', () => {
 
   it('routes to the ACTIVE receiver group (SUB on D2)', async () => {
     setAutoLanModInputEnabled(true);
+    useDualReceiverCapabilities();
     setState({
       active: 'SUB',
       main: receiver(0),
@@ -314,6 +319,7 @@ describe('confirmed restore after local TX audio stop (MOR-618, MOR-990)', () =>
     const control = getTxAudioControl();
     await control.startTx();
 
+    useDualReceiverCapabilities();
     setState({
       active: 'SUB',
       main: receiver(1),

--- a/frontend/src/lib/runtime/adapters/__tests__/mod-input-auto.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mod-input-auto.isolated.test.ts
@@ -90,6 +90,10 @@ let revision = 1;
 function makeState(overrides: Record<string, unknown> = {}): ServerState {
   return {
     revision: ++revision,
+    stateRevision: revision,
+    freshnessRevision: revision,
+    observationSeq: revision,
+    updatedAt: '2026-08-08T00:00:00Z',
     active: 'MAIN',
     ptt: false,
     split: false,
@@ -99,6 +103,8 @@ function makeState(overrides: Record<string, unknown> = {}): ServerState {
     providerGeneration: 0,
     main: receiver(0),
     sub: receiver(0),
+    connection: { rigConnected: true, radioReady: true, controlConnected: true },
+    txTarget: { status: 'unknown', reason: 'not-observed' },
     ...overrides,
   } as unknown as ServerState;
 }

--- a/frontend/src/lib/runtime/adapters/__tests__/mod-input-tx-guard.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mod-input-tx-guard.isolated.test.ts
@@ -80,6 +80,8 @@ function makeState(overrides: Record<string, unknown> = {}): ServerState {
     split: false,
     dualWatch: false,
     tunerStatus: 0,
+    stateContractVersion: 1,
+    providerGeneration: 0,
     main: receiver(0),
     sub: receiver(0),
     ...overrides,
@@ -105,7 +107,7 @@ beforeEach(() => {
   vi.mocked(runtime.startTx).mockClear();
   vi.mocked(runtime.stopTx).mockClear();
   resetRadioState();
-  setCapabilities({ capabilities: ['data_mode'] } as never);
+  setCapabilities({ capabilities: ['data_mode'], stateContractVersion: 1, providerGeneration: 0 } as never);
   dismissModInputTxGuard();
 });
 
@@ -149,7 +151,7 @@ describe('armModInputTxGuard (MOR-617)', () => {
   });
 
   it('does not fire without the data_mode capability', () => {
-    setCapabilities({ capabilities: [] } as never);
+    setCapabilities({ capabilities: [], stateContractVersion: 1, providerGeneration: 0 } as never);
     setState({ main: receiver(1), data1ModInput: 0 });
 
     armModInputTxGuard();

--- a/frontend/src/lib/runtime/adapters/__tests__/mod-input-tx-guard.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mod-input-tx-guard.isolated.test.ts
@@ -99,6 +99,10 @@ function setState(overrides: Record<string, unknown> = {}): void {
   setRadioState(makeState(overrides));
 }
 
+function useDualReceiverCapabilities(): void {
+  setCapabilities({ capabilities: ['data_mode'], receivers: 2, vfoScheme: 'main_sub', stateContractVersion: 1, providerGeneration: 0 } as never);
+}
+
 function missingStatus() {
   return {
     storePath: 'test.path',
@@ -173,6 +177,7 @@ describe('armModInputTxGuard (MOR-617)', () => {
   });
 
   it('resolves the ACTIVE receiver group (SUB on D2)', () => {
+    useDualReceiverCapabilities();
     setState({
       active: 'SUB',
       main: receiver(0),

--- a/frontend/src/lib/runtime/adapters/__tests__/mod-input-tx-guard.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mod-input-tx-guard.isolated.test.ts
@@ -73,8 +73,13 @@ function receiver(dataMode: number) {
 }
 
 function makeState(overrides: Record<string, unknown> = {}): ServerState {
+  const stateRevision = typeof overrides.revision === 'number' ? overrides.revision : 1;
   return {
-    revision: 1,
+    revision: stateRevision,
+    stateRevision,
+    freshnessRevision: 1,
+    observationSeq: stateRevision,
+    updatedAt: '2026-08-08T00:00:00Z',
     active: 'MAIN',
     ptt: false,
     split: false,
@@ -84,6 +89,8 @@ function makeState(overrides: Record<string, unknown> = {}): ServerState {
     providerGeneration: 0,
     main: receiver(0),
     sub: receiver(0),
+    connection: { rigConnected: true, radioReady: true, controlConnected: true },
+    txTarget: { status: 'unknown', reason: 'not-observed' },
     ...overrides,
   } as unknown as ServerState;
 }

--- a/frontend/src/lib/runtime/tx-controller/__tests__/integration-lifecycle-matrix.isolated.test.ts
+++ b/frontend/src/lib/runtime/tx-controller/__tests__/integration-lifecycle-matrix.isolated.test.ts
@@ -47,7 +47,12 @@ vi.mock('$lib/stores/radio.svelte', () => ({
   patchRadioState: () => {},
   resetRadioState: () => {},
 }));
-vi.mock('$lib/stores/capabilities.svelte', () => ({ getCapabilities: () => h.caps }));
+vi.mock('$lib/stores/capabilities.svelte', () => ({
+  getCapabilities: () => h.caps,
+  capabilitiesMatchGeneration: () => true,
+  clearCapabilities: () => {},
+  setCapabilities: () => true,
+}));
 vi.mock('$lib/runtime/adapters/tx-adapter', () => ({
   getTxAudioControl: () => ({
     startTx: h.start,

--- a/frontend/src/lib/runtime/tx-controller/__tests__/integration-page-lifecycle.isolated.test.ts
+++ b/frontend/src/lib/runtime/tx-controller/__tests__/integration-page-lifecycle.isolated.test.ts
@@ -97,6 +97,9 @@ vi.mock('$lib/stores/radio.svelte', () => ({
 vi.mock('$lib/stores/capabilities.svelte', () => ({
   getCapabilities: () => h.caps,
   hasAnyScope: () => false,
+  capabilitiesMatchGeneration: () => true,
+  clearCapabilities: () => {},
+  setCapabilities: () => true,
 }));
 vi.mock('$lib/runtime/adapters/tx-adapter', () => ({
   getTxAudioControl: () => ({

--- a/frontend/src/lib/runtime/tx-controller/__tests__/integration-reconnect-dekey-matrix.isolated.test.ts
+++ b/frontend/src/lib/runtime/tx-controller/__tests__/integration-reconnect-dekey-matrix.isolated.test.ts
@@ -57,7 +57,12 @@ vi.mock('$lib/stores/radio.svelte', () => ({
   patchRadioState: () => {},
   resetRadioState: () => {},
 }));
-vi.mock('$lib/stores/capabilities.svelte', () => ({ getCapabilities: () => h.caps }));
+vi.mock('$lib/stores/capabilities.svelte', () => ({
+  getCapabilities: () => h.caps,
+  capabilitiesMatchGeneration: () => true,
+  clearCapabilities: () => {},
+  setCapabilities: () => true,
+}));
 vi.mock('$lib/runtime/adapters/tx-adapter', () => ({
   getTxAudioControl: () => ({
     startTx: h.start,

--- a/frontend/src/lib/stores/__tests__/capabilities.test.ts
+++ b/frontend/src/lib/stores/__tests__/capabilities.test.ts
@@ -16,6 +16,8 @@ function makeCaps(overrides: Partial<Capabilities> = {}): Capabilities {
     audioConfig: { sampleRate: 48000, channels: 1, codecs: ['opus'] },
     webrtc: { available: true, enabled: false },
     txBands: null,
+    stateContractVersion: 1,
+    providerGeneration: 0,
     ...overrides,
   };
 }
@@ -53,6 +55,18 @@ describe('capabilities store', () => {
       store.setCapabilities(makeCaps({ model: 'IC-9700' }));
       expect(store.getCapabilities()?.model).toBe('IC-9700');
     });
+  });
+
+  it('fails closed for missing or invalid contract epochs and clears on request', () => {
+    expect(store.setCapabilities(makeCaps() as Capabilities)).toBe(true);
+    expect(store.capabilitiesMatchGeneration(0)).toBe(true);
+    expect(store.setCapabilities({ ...makeCaps(), stateContractVersion: 2 } as Capabilities)).toBe(false);
+    expect(store.getCapabilities()).toBeNull();
+    expect(store.setCapabilities({ ...makeCaps(), providerGeneration: -1 } as Capabilities)).toBe(false);
+    expect(store.getCapabilities()).toBeNull();
+    store.setCapabilities(makeCaps());
+    store.clearCapabilities();
+    expect(store.getCapabilities()).toBeNull();
   });
 
   describe('hasSpectrum', () => {

--- a/frontend/src/lib/stores/__tests__/radio.test.ts
+++ b/frontend/src/lib/stores/__tests__/radio.test.ts
@@ -150,6 +150,13 @@ function singleReceiverWireState(
   return wireState as ServerStateWithObservation;
 }
 
+async function useDualReceiverCapabilities(): Promise<void> {
+  const capabilities = await import('../capabilities.svelte');
+  capabilities.setCapabilities({
+    ...capabilities.getCapabilities()!, receivers: 2, vfoScheme: 'main_sub',
+  });
+}
+
 describe('radio store', () => {
   let store: typeof import('../radio.svelte');
 
@@ -191,6 +198,51 @@ describe('radio store', () => {
   it('still rejects metadata-only and malformed single-receiver wire bodies', () => {
     expect(store.isValidServerState({ stateContractVersion: 1, providerGeneration: 0 })).toBe(false);
     expect(store.isValidServerState({ ...singleReceiverWireState(), main: 'corrupt' })).toBe(false);
+  });
+
+  it('rejects a single-receiver active SUB before it can turn the structural alias into truth', async () => {
+    const capabilities = await import('../capabilities.svelte');
+    const connection = await import('../connection.svelte');
+    capabilities.setCapabilities({
+      ...capabilities.getCapabilities()!, receivers: 1, vfoScheme: 'ab',
+    });
+    const activeStatus = {
+      active: { storePath: 'global.slow_state.active', observed: true, freshness: 'fresh', availability: 'available' },
+    } as const;
+    expect(store.setRadioState(singleReceiverWireState({ revision: 1, active: 'MAIN', fieldStatus: activeStatus }))).toBe(true);
+    const accepted = store.getRadioState();
+    const acceptedCapabilities = capabilities.getCapabilities();
+    const acceptedReady = connection.getRadioReady();
+
+    expect(store.setRadioState(singleReceiverWireState({ revision: 2, active: 'SUB', fieldStatus: activeStatus }))).toBe(false);
+    expect(store.getRadioState()).toBe(accepted);
+    expect(capabilities.getCapabilities()).toBe(acceptedCapabilities);
+    expect(connection.getRadioReady()).toBe(acceptedReady);
+
+    capabilities.setCapabilities({ ...acceptedCapabilities!, receivers: 2, vfoScheme: 'main_sub' });
+    expect(store.setRadioState(makeState({ revision: 2, active: 'SUB', fieldStatus: activeStatus }))).toBe(true);
+    expect(store.getRadioState()?.active).toBe('SUB');
+  });
+
+  it('keeps single-receiver selected and unselected A/B facts under physical MAIN', async () => {
+    const capabilities = await import('../capabilities.svelte');
+    capabilities.setCapabilities({
+      ...capabilities.getCapabilities()!, receivers: 1, vfoScheme: 'ab',
+    });
+    const main = {
+      ...makeState().main,
+      activeSlot: 'A' as const,
+      vfoA: { freqHz: 14_074_000, mode: 'USB', filterNum: 1, dataMode: 0 },
+      vfoB: { freqHz: 14_076_000, mode: 'USB', filterNum: 1, dataMode: 0 },
+      unselectedVfo: { freqHz: 14_076_000, mode: 'USB', filterNum: 1, dataMode: 0 },
+    };
+    expect(store.setRadioState(singleReceiverWireState({ revision: 1, active: 'MAIN', main }))).toBe(true);
+    expect(store.getRadioState()?.main.vfoA?.freqHz).toBe(14_074_000);
+    expect(store.getRadioState()?.main.unselectedVfo?.freqHz).toBe(14_076_000);
+
+    expect(store.setRadioState(singleReceiverWireState({ revision: 2, active: 'MAIN', main: { ...main, activeSlot: 'B' as const } }))).toBe(true);
+    expect(store.getRadioState()?.active).toBe('MAIN');
+    expect(store.getRadioState()?.main.activeSlot).toBe('B');
   });
 
   it('rejects a state whose epoch does not match capabilities before touching connection truth', async () => {
@@ -459,7 +511,8 @@ describe('radio store', () => {
     expect(store.getFrequency()).toBe(14074000);
   });
 
-  it('getFrequency returns sub receiver frequency when active is SUB', () => {
+  it('getFrequency returns sub receiver frequency when active is SUB', async () => {
+    await useDualReceiverCapabilities();
     store.setRadioState(makeState({ active: 'SUB' }));
     expect(store.getFrequency()).toBe(7100000);
   });
@@ -641,7 +694,8 @@ describe('radio store', () => {
     expect(store.getSubReceiver()?.freqHz).toBe(7100000);
   });
 
-  it('patchActiveReceiver cannot overwrite StateStore-owned SUB VFO truth', () => {
+  it('patchActiveReceiver cannot overwrite StateStore-owned SUB VFO truth', async () => {
+    await useDualReceiverCapabilities();
     store.setRadioState(makeState({ active: 'SUB' }));
     store.patchActiveReceiver({ freqHz: 3500000 });
     expect(store.getSubReceiver()?.freqHz).toBe(7100000);
@@ -655,7 +709,8 @@ describe('radio store', () => {
     expect(store.getRadioState()).toBeNull();
   });
 
-  it('getActiveReceiver returns SUB when active is SUB', () => {
+  it('getActiveReceiver returns SUB when active is SUB', async () => {
+    await useDualReceiverCapabilities();
     store.setRadioState(makeState({ active: 'SUB' }));
     expect(store.getActiveReceiver()?.freqHz).toBe(7100000);
   });

--- a/frontend/src/lib/stores/__tests__/radio.test.ts
+++ b/frontend/src/lib/stores/__tests__/radio.test.ts
@@ -137,6 +137,8 @@ function makeState(overrides: Partial<ServerStateWithObservation> = {}): ServerS
       fixedEdge: { rangeIndex: 0, edge: 0, startHz: 0, endHz: 0 },
     },
     txTarget,
+    stateContractVersion: 1,
+    providerGeneration: 0,
     ...stateOverrides,
   };
 }
@@ -147,6 +149,14 @@ describe('radio store', () => {
   beforeEach(async () => {
     vi.resetModules();
     store = await import('../radio.svelte');
+    const capabilities = await import('../capabilities.svelte');
+    capabilities.setCapabilities({
+      model: 'TEST', scope: false, audio: false, tx: false, capabilities: [],
+      receivers: 1, vfoScheme: 'single', freqRanges: [], modes: [], filters: [],
+      audioConfig: { sampleRate: 48_000, channels: 1, codecs: [] },
+      webrtc: { available: false, enabled: false }, txBands: null,
+      stateContractVersion: 1, providerGeneration: 0,
+    });
   });
 
   it('starts with null state', () => {
@@ -157,6 +167,40 @@ describe('radio store', () => {
     const s = makeState({ revision: 1 });
     store.setRadioState(s);
     expect(store.getRadioState()).toStrictEqual(s);
+  });
+
+  it('rejects a state whose epoch does not match capabilities before touching connection truth', async () => {
+    const connection = await import('../connection.svelte');
+    const capabilities = await import('../capabilities.svelte');
+    expect(store.setRadioState(makeState({ providerGeneration: 0 }))).toBe(true);
+    expect(store.setRadioState(makeState({ revision: 2, providerGeneration: 1, ptt: true }))).toBe(false);
+    expect(store.getRadioState()?.providerGeneration).toBe(0);
+    expect(connection.getRadioReady()).toBe(true);
+
+    capabilities.setCapabilities({
+      ...(capabilities.getCapabilities()!), providerGeneration: 1,
+    });
+    expect(store.setRadioState(makeState({ revision: 1, providerGeneration: 1, ptt: true }))).toBe(true);
+    expect(store.getRadioState()?.providerGeneration).toBe(1);
+    expect(store.getRadioState()?.ptt).toBe(true);
+  });
+
+  it('drops optimistic patches and revision locks when accepting a new provider epoch', async () => {
+    const capabilities = await import('../capabilities.svelte');
+    store.setRadioState(makeState({ providerGeneration: 0, main: { ...makeState().main, afLevel: 10 } }));
+    store.patchActiveReceiver({ afLevel: 42 }, true);
+    expect(store.getRadioState()?.main.afLevel).toBe(42);
+
+    capabilities.setCapabilities({
+      ...(capabilities.getCapabilities()!), providerGeneration: 1,
+    });
+    store.setRadioState(makeState({
+      revision: 1,
+      providerGeneration: 1,
+      main: { ...makeState().main, afLevel: 12 },
+    }));
+    expect(store.getRadioState()?.providerGeneration).toBe(1);
+    expect(store.getRadioState()?.main.afLevel).toBe(12);
   });
 
   it('accepts initial revision 0 state when store is empty', () => {

--- a/frontend/src/lib/stores/__tests__/radio.test.ts
+++ b/frontend/src/lib/stores/__tests__/radio.test.ts
@@ -143,6 +143,13 @@ function makeState(overrides: Partial<ServerStateWithObservation> = {}): ServerS
   };
 }
 
+function singleReceiverWireState(
+  overrides: Partial<ServerStateWithObservation> = {},
+): ServerStateWithObservation {
+  const { sub: _sub, ...wireState } = makeState(overrides);
+  return wireState as ServerStateWithObservation;
+}
+
 describe('radio store', () => {
   let store: typeof import('../radio.svelte');
 
@@ -167,6 +174,23 @@ describe('radio store', () => {
     const s = makeState({ revision: 1 });
     store.setRadioState(s);
     expect(store.getRadioState()).toStrictEqual(s);
+  });
+
+  it('accepts canonical single-receiver wire state with omitted or null sub through the legacy HTTP writer', () => {
+    const omitted = singleReceiverWireState({ revision: 1 });
+    expect(store.isValidServerState(omitted)).toBe(true);
+    expect(store.setRadioState(omitted)).toBe(true);
+    expect(store.getRadioState()?.main.freqHz).toBe(14_074_000);
+
+    const nullSub = { ...singleReceiverWireState({ revision: 2 }), sub: null } as unknown as ServerStateWithObservation;
+    expect(store.isValidServerState(nullSub)).toBe(true);
+    expect(store.setRadioState(nullSub)).toBe(true);
+    expect(store.getRadioState()?.main.freqHz).toBe(14_074_000);
+  });
+
+  it('still rejects metadata-only and malformed single-receiver wire bodies', () => {
+    expect(store.isValidServerState({ stateContractVersion: 1, providerGeneration: 0 })).toBe(false);
+    expect(store.isValidServerState({ ...singleReceiverWireState(), main: 'corrupt' })).toBe(false);
   });
 
   it('rejects a state whose epoch does not match capabilities before touching connection truth', async () => {

--- a/frontend/src/lib/stores/__tests__/radio.test.ts
+++ b/frontend/src/lib/stores/__tests__/radio.test.ts
@@ -185,6 +185,15 @@ describe('radio store', () => {
     expect(store.getRadioState()?.ptt).toBe(true);
   });
 
+  it('rejects a matching-epoch legacy HTTP rollback from revision 100 to 1', () => {
+    expect(store.setRadioState(makeState({ revision: 100, ptt: false }))).toBe(true);
+    const accepted = store.getRadioState();
+    expect(store.setRadioState(makeState({ revision: 1, ptt: true }))).toBe(false);
+    expect(store.getRadioState()).toBe(accepted);
+    expect(store.getRadioState()?.revision).toBe(100);
+    expect(store.getRadioState()?.ptt).toBe(false);
+  });
+
   it('drops optimistic patches and revision locks when accepting a new provider epoch', async () => {
     const capabilities = await import('../capabilities.svelte');
     store.setRadioState(makeState({ providerGeneration: 0, main: { ...makeState().main, afLevel: 10 } }));
@@ -452,11 +461,11 @@ describe('radio store', () => {
     expect(store.getSubReceiver()?.freqHz).toBe(7100000);
   });
 
-  it('detects server restart: accepts state when revision resets from high to near zero', () => {
+  it('rejects a revision reset inside the same epoch and session', () => {
     store.setRadioState(makeState({ revision: 100 }));
     store.setRadioState(makeState({ revision: 1, ptt: true }));
-    expect(store.getRadioState()?.revision).toBe(1);
-    expect(store.getRadioState()?.ptt).toBe(true);
+    expect(store.getRadioState()?.revision).toBe(100);
+    expect(store.getRadioState()?.ptt).toBe(false);
   });
 
   it('does not treat small revision drop as server restart (lastRevision <= 10)', () => {

--- a/frontend/src/lib/stores/capabilities.svelte.ts
+++ b/frontend/src/lib/stores/capabilities.svelte.ts
@@ -3,12 +3,45 @@ import type { Capabilities, ControlRange } from '../types/capabilities';
 // Capabilities fetched once from GET /api/v1/capabilities
 let capabilities = $state<Capabilities | null>(null);
 
+const STATE_CONTRACT_VERSION = 1;
+
+function validProviderGeneration(value: unknown): value is number {
+  return typeof value === 'number'
+    && Number.isSafeInteger(value)
+    && value >= 0;
+}
+
+function hasCurrentEpoch(value: unknown): value is Capabilities {
+  if (!value || typeof value !== 'object') return false;
+  const record = value as Record<string, unknown>;
+  return record.stateContractVersion === STATE_CONTRACT_VERSION
+    && validProviderGeneration(record.providerGeneration);
+}
+
 export function getCapabilities(): Capabilities | null {
   return capabilities;
 }
 
-export function setCapabilities(caps: Capabilities): void {
+export function setCapabilities(caps: Capabilities): boolean {
+  if (!hasCurrentEpoch(caps)) {
+    capabilities = null;
+    return false;
+  }
   capabilities = caps;
+  return true;
+}
+
+/** Clear capability truth whenever the provider epoch is no longer proven. */
+export function clearCapabilities(): void {
+  capabilities = null;
+}
+
+/** True only when capabilities and radio state prove the same provider epoch. */
+export function capabilitiesMatchGeneration(providerGeneration: unknown): boolean {
+  return validProviderGeneration(providerGeneration)
+    && capabilities !== null
+    && (capabilities as Record<string, unknown>).stateContractVersion === STATE_CONTRACT_VERSION
+    && (capabilities as Record<string, unknown>).providerGeneration === providerGeneration;
 }
 
 export function hasSpectrum(): boolean {

--- a/frontend/src/lib/stores/radio.isolated.test.ts
+++ b/frontend/src/lib/stores/radio.isolated.test.ts
@@ -8,12 +8,15 @@ import {
   patchActiveReceiver,
 } from './radio.svelte';
 import type { ServerState } from '../types/state';
+import { setCapabilities } from './capabilities.svelte';
 
 function makeState(revision: number): ServerState {
   return {
     revision,
     stateRevision: revision,
     freshnessRevision: 1,
+    stateContractVersion: 1,
+    providerGeneration: 0,
     active: 'MAIN',
     powerOn: true,
     ptt: false,
@@ -54,6 +57,13 @@ describe('resetRadioState', () => {
   beforeEach(() => {
     // Ensure clean state
     resetRadioState();
+    setCapabilities({
+      model: 'TEST', scope: false, audio: false, tx: false, capabilities: [],
+      receivers: 1, vfoScheme: 'single', freqRanges: [], modes: [], filters: [],
+      audioConfig: { sampleRate: 48_000, channels: 1, codecs: [] },
+      webrtc: { available: false, enabled: false }, txBands: null,
+      stateContractVersion: 1, providerGeneration: 0,
+    });
   });
 
   it('clears radio.current to null', () => {
@@ -90,7 +100,16 @@ describe('resetRadioState', () => {
 });
 
 describe('StateStore-only VFO truth', () => {
-  beforeEach(() => resetRadioState());
+  beforeEach(() => {
+    resetRadioState();
+    setCapabilities({
+      model: 'TEST', scope: false, audio: false, tx: false, capabilities: [],
+      receivers: 1, vfoScheme: 'single', freqRanges: [], modes: [], filters: [],
+      audioConfig: { sampleRate: 48_000, channels: 1, codecs: [] },
+      webrtc: { available: false, enabled: false }, txBands: null,
+      stateContractVersion: 1, providerGeneration: 0,
+    });
+  });
 
   it('does not let VFO optimistic patches overwrite the observed snapshot', () => {
     const initial = makeState(10);

--- a/frontend/src/lib/stores/radio.isolated.test.ts
+++ b/frontend/src/lib/stores/radio.isolated.test.ts
@@ -15,6 +15,8 @@ function makeState(revision: number): ServerState {
     revision,
     stateRevision: revision,
     freshnessRevision: 1,
+    observationSeq: revision,
+    updatedAt: '2026-08-08T00:00:00Z',
     stateContractVersion: 1,
     providerGeneration: 0,
     active: 'MAIN',
@@ -22,6 +24,7 @@ function makeState(revision: number): ServerState {
     ptt: false,
     split: false,
     dualWatch: false,
+    tunerStatus: 0,
     main: {
       freqHz: 14074000,
       mode: 'USB',
@@ -50,6 +53,12 @@ function makeState(revision: number): ServerState {
       rfGain: 100,
       squelch: 0,
     },
+    connection: {
+      rigConnected: true,
+      radioReady: true,
+      controlConnected: true,
+    },
+    txTarget: { status: 'unknown', reason: 'not-observed' },
   } as ServerState;
 }
 

--- a/frontend/src/lib/stores/radio.svelte.ts
+++ b/frontend/src/lib/stores/radio.svelte.ts
@@ -1,7 +1,7 @@
 import type { ServerState, ReceiverState } from '../types/state';
 import { setRadioPowerOn, setRigConnected, setRadioReady, setControlConnected, setRadioHealth } from './connection.svelte';
 import { getFieldStatus, isFieldAvailable } from '../state/field-status';
-import { capabilitiesMatchGeneration } from './capabilities.svelte';
+import { capabilitiesMatchGeneration, getCapabilities } from './capabilities.svelte';
 
 /**
  * Shared radio state — class-based $state pattern for cross-module reactivity.
@@ -301,6 +301,26 @@ export function isValidServerState(value: unknown): value is ServerState {
   return true;
 }
 
+/** Receiver identity follows matching capabilities: MAIN may expose A/B slots but never a physical SUB. */
+export function matchesCurrentCapabilityTopology(state: ServerState): boolean {
+  const capabilities = getCapabilities();
+  if (!capabilitiesMatchGeneration(state.providerGeneration) || capabilities === null) return false;
+  const hasSubReceiver = Number.isSafeInteger(capabilities.receivers) && capabilities.receivers >= 2;
+  if (state.active === 'SUB' && !hasSubReceiver) return false;
+
+  const record = state as unknown as Record<string, unknown>;
+  if (!record.txTarget || typeof record.txTarget !== 'object' || Array.isArray(record.txTarget)) return false;
+  const txTarget = record.txTarget as Record<string, unknown>;
+  if (txTarget.status === 'known' && txTarget.receiver === 'SUB' && !hasSubReceiver) return false;
+  if (record.scopeControls !== undefined) {
+    if (!record.scopeControls || typeof record.scopeControls !== 'object' || Array.isArray(record.scopeControls)) return false;
+    const receiver = (record.scopeControls as Record<string, unknown>).receiver;
+    const receiverIndex: number = Number.isSafeInteger(receiver) ? receiver as number : -1;
+    if (receiverIndex < 0 || receiverIndex > (hasSubReceiver ? 1 : 0)) return false;
+  }
+  return true;
+}
+
 /**
  * The generated public contract omits ``sub`` for a single-receiver radio,
  * while the established client-side merged-state type keeps a structural
@@ -332,7 +352,7 @@ function clearGenerationBookkeeping(): void {
 }
 
 export function setRadioState(state: ServerState): boolean {
-  if (!hasCurrentEpoch(state)) return false;
+  if (!hasCurrentEpoch(state) || !matchesCurrentCapabilityTopology(state)) return false;
 
   const nextState = normalizeValidatedState(state);
 

--- a/frontend/src/lib/stores/radio.svelte.ts
+++ b/frontend/src/lib/stores/radio.svelte.ts
@@ -215,10 +215,95 @@ function validProviderGeneration(value: unknown): value is number {
     && value >= 0;
 }
 
+function validCounter(value: unknown): value is number {
+  return typeof value === 'number'
+    && Number.isSafeInteger(value)
+    && value >= 0;
+}
+
+function validReceiver(value: unknown): boolean {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const receiver = value as Record<string, unknown>;
+  return typeof receiver.freqHz === 'number'
+    && Number.isFinite(receiver.freqHz)
+    && typeof receiver.mode === 'string'
+    && (typeof receiver.filter === 'number' || receiver.filter === null)
+    && typeof receiver.dataMode === 'number'
+    && Number.isFinite(receiver.dataMode)
+    && typeof receiver.sMeter === 'number'
+    && Number.isFinite(receiver.sMeter)
+    && typeof receiver.att === 'number'
+    && Number.isFinite(receiver.att)
+    && typeof receiver.preamp === 'number'
+    && Number.isFinite(receiver.preamp)
+    && typeof receiver.nb === 'boolean'
+    && typeof receiver.nr === 'boolean'
+    && typeof receiver.afLevel === 'number'
+    && Number.isFinite(receiver.afLevel)
+    && typeof receiver.rfGain === 'number'
+    && Number.isFinite(receiver.rfGain)
+    && typeof receiver.squelch === 'number'
+    && Number.isFinite(receiver.squelch);
+}
+
+function validConnection(value: unknown): boolean {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const connection = value as Record<string, unknown>;
+  return typeof connection.rigConnected === 'boolean'
+    && typeof connection.radioReady === 'boolean'
+    && typeof connection.controlConnected === 'boolean';
+}
+
+function validTxTarget(value: unknown): boolean {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const target = value as Record<string, unknown>;
+  if (target.status === 'unknown') return typeof target.reason === 'string';
+  return target.status === 'known'
+    && (target.receiver === 'MAIN' || target.receiver === 'SUB')
+    && (target.slot === 'A' || target.slot === 'B' || target.slot === null)
+    && (typeof target.frequencyHz === 'number' || target.frequencyHz === null);
+}
+
+/** Runtime contract shared by WebSocket and the remaining legacy HTTP writer. */
+export function isValidServerState(value: unknown): value is ServerState {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const state = value as Record<string, unknown>;
+  if (
+    state.stateContractVersion !== 1
+    || !validProviderGeneration(state.providerGeneration)
+    || !validCounter(state.revision)
+    || !validCounter(state.stateRevision)
+    || !validCounter(state.freshnessRevision)
+    || !validCounter(state.observationSeq)
+    || typeof state.updatedAt !== 'string'
+    || (state.active !== 'MAIN' && state.active !== 'SUB')
+    || typeof state.ptt !== 'boolean'
+    || typeof state.split !== 'boolean'
+    || typeof state.dualWatch !== 'boolean'
+    || typeof state.tunerStatus !== 'number'
+    || !Number.isFinite(state.tunerStatus)
+    || !validReceiver(state.main)
+    || (state.sub !== null && !validReceiver(state.sub))
+    || !validConnection(state.connection)
+    || !validTxTarget(state.txTarget)
+  ) return false;
+  for (const key of ['healthRevision', 'publicStateSeq', 'transportSeq'] as const) {
+    if (state[key] !== undefined && !validCounter(state[key])) return false;
+  }
+  if (state.wsClients !== undefined) {
+    if (!state.wsClients || typeof state.wsClients !== 'object' || Array.isArray(state.wsClients)) return false;
+    const clients = state.wsClients as Record<string, unknown>;
+    if (!validCounter(clients.scope) || !validCounter(clients.control) || !validCounter(clients.audio)) return false;
+  }
+  for (const key of ['fieldStatus', 'radioHealth'] as const) {
+    if (state[key] !== undefined && (!state[key] || typeof state[key] !== 'object' || Array.isArray(state[key]))) return false;
+  }
+  return true;
+}
+
 function hasCurrentEpoch(state: ServerState): boolean {
   const record = state as unknown as Record<string, unknown>;
-  return record.stateContractVersion === 1
-    && validProviderGeneration(record.providerGeneration)
+  return isValidServerState(state)
     && capabilitiesMatchGeneration(record.providerGeneration);
 }
 
@@ -248,7 +333,6 @@ export function setRadioState(state: ServerState): boolean {
   const nextStateRevision = stateRevision(state);
   const nextFreshnessRevision = freshnessRevision(state);
   const nextObservationSeq = observationSeq(state);
-  const isReset = lastRevision > 10 && nextStateRevision < lastRevision / 2;
   const isInitial = radio.current === null;
   const nextHealthRevision = state.healthRevision ?? 0;
   const healthAdvanced = nextHealthRevision > lastHealthRevision;
@@ -265,16 +349,10 @@ export function setRadioState(state: ServerState): boolean {
     || healthAdvanced
     || liveMetadataAdvanced
   );
-  if (isReset) {
-    console.warn(
-      `Detected server restart: revision reset from ${lastRevision} to ${nextStateRevision}`,
-    );
-  }
   if (
     isInitial
     || semanticAdvanced
     || metadataAdvanced
-    || isReset
   ) {
     lastRevision = nextStateRevision;
     lastFreshnessRevision = nextFreshnessRevision;

--- a/frontend/src/lib/stores/radio.svelte.ts
+++ b/frontend/src/lib/stores/radio.svelte.ts
@@ -283,7 +283,7 @@ export function isValidServerState(value: unknown): value is ServerState {
     || typeof state.tunerStatus !== 'number'
     || !Number.isFinite(state.tunerStatus)
     || !validReceiver(state.main)
-    || (state.sub !== null && !validReceiver(state.sub))
+    || (state.sub !== undefined && state.sub !== null && !validReceiver(state.sub))
     || !validConnection(state.connection)
     || !validTxTarget(state.txTarget)
   ) return false;
@@ -299,6 +299,19 @@ export function isValidServerState(value: unknown): value is ServerState {
     if (state[key] !== undefined && (!state[key] || typeof state[key] !== 'object' || Array.isArray(state[key]))) return false;
   }
   return true;
+}
+
+/**
+ * The generated public contract omits ``sub`` for a single-receiver radio,
+ * while the established client-side merged-state type keeps a structural
+ * receiver slot for consumers that index by MAIN/SUB. This is a local alias
+ * of the observed MAIN receiver, never a newly observed SUB radio: capability
+ * gates remain the authority for whether a SUB surface can be displayed.
+ */
+function normalizeValidatedState(state: ServerState): ServerState {
+  const wireState = state as unknown as { sub?: ReceiverState | null };
+  if (wireState.sub !== undefined && wireState.sub !== null) return state;
+  return { ...state, sub: { ...state.main } };
 }
 
 function hasCurrentEpoch(state: ServerState): boolean {
@@ -321,7 +334,9 @@ function clearGenerationBookkeeping(): void {
 export function setRadioState(state: ServerState): boolean {
   if (!hasCurrentEpoch(state)) return false;
 
-  const nextGeneration = (state as unknown as Record<string, unknown>).providerGeneration as number;
+  const nextState = normalizeValidatedState(state);
+
+  const nextGeneration = (nextState as unknown as Record<string, unknown>).providerGeneration as number;
   const currentGeneration = radio.current
     ? (radio.current as unknown as Record<string, unknown>).providerGeneration
     : null;
@@ -330,19 +345,19 @@ export function setRadioState(state: ServerState): boolean {
     // patch or lock from the retired provider into its observed state.
     clearGenerationBookkeeping();
   }
-  const nextStateRevision = stateRevision(state);
-  const nextFreshnessRevision = freshnessRevision(state);
-  const nextObservationSeq = observationSeq(state);
+  const nextStateRevision = stateRevision(nextState);
+  const nextFreshnessRevision = freshnessRevision(nextState);
+  const nextObservationSeq = observationSeq(nextState);
   const isInitial = radio.current === null;
-  const nextHealthRevision = state.healthRevision ?? 0;
+  const nextHealthRevision = nextState.healthRevision ?? 0;
   const healthAdvanced = nextHealthRevision > lastHealthRevision;
   const freshnessAdvanced = nextFreshnessRevision > lastFreshnessRevision;
   const observationAdvanced = nextObservationSeq > lastObservationSeq;
   const semanticAdvanced = nextStateRevision > lastRevision;
   const semanticCurrent = nextStateRevision === lastRevision;
   const liveMetadataAdvanced = semanticCurrent
-    && deliverySeq(state) > deliverySeq(radio.current)
-    && hasOnlyLiveMetadataChanges(radio.current, state);
+    && deliverySeq(nextState) > deliverySeq(radio.current)
+    && hasOnlyLiveMetadataChanges(radio.current, nextState);
   const metadataAdvanced = semanticCurrent && (
     freshnessAdvanced
     || observationAdvanced
@@ -358,20 +373,20 @@ export function setRadioState(state: ServerState): boolean {
     lastFreshnessRevision = nextFreshnessRevision;
     lastObservationSeq = nextObservationSeq;
     lastHealthRevision = nextHealthRevision;
-    radio.current = applyOptimistic(state);
+    radio.current = applyOptimistic(nextState);
     notifyRadioStateSubscribers();
     // Sync power status to connection store
-    if (state.powerOn !== undefined) {
-      setRadioPowerOn(state.powerOn);
+    if (nextState.powerOn !== undefined) {
+      setRadioPowerOn(nextState.powerOn);
     }
     // Sync connection readiness fields
-    if (state.connection) {
-      setRigConnected(state.connection.rigConnected);
-      setRadioReady(state.connection.radioReady);
-      setControlConnected(state.connection.controlConnected);
+    if (nextState.connection) {
+      setRigConnected(nextState.connection.rigConnected);
+      setRadioReady(nextState.connection.radioReady);
+      setControlConnected(nextState.connection.controlConnected);
     }
-    if (state.radioHealth !== undefined) {
-      setRadioHealth(state.radioHealth);
+    if (nextState.radioHealth !== undefined) {
+      setRadioHealth(nextState.radioHealth);
     }
     return true;
   }

--- a/frontend/src/lib/stores/radio.svelte.ts
+++ b/frontend/src/lib/stores/radio.svelte.ts
@@ -1,6 +1,7 @@
 import type { ServerState, ReceiverState } from '../types/state';
 import { setRadioPowerOn, setRigConnected, setRadioReady, setControlConnected, setRadioHealth } from './connection.svelte';
 import { getFieldStatus, isFieldAvailable } from '../state/field-status';
+import { capabilitiesMatchGeneration } from './capabilities.svelte';
 
 /**
  * Shared radio state — class-based $state pattern for cross-module reactivity.
@@ -208,7 +209,42 @@ export function resetRadioState(): void {
   notifyRadioStateSubscribers();
 }
 
-export function setRadioState(state: ServerState): void {
+function validProviderGeneration(value: unknown): value is number {
+  return typeof value === 'number'
+    && Number.isSafeInteger(value)
+    && value >= 0;
+}
+
+function hasCurrentEpoch(state: ServerState): boolean {
+  const record = state as unknown as Record<string, unknown>;
+  return record.stateContractVersion === 1
+    && validProviderGeneration(record.providerGeneration)
+    && capabilitiesMatchGeneration(record.providerGeneration);
+}
+
+function clearGenerationBookkeeping(): void {
+  lastRevision = -1;
+  lastFreshnessRevision = -1;
+  lastObservationSeq = -1;
+  lastHealthRevision = -1;
+  optimisticMain.clear();
+  optimisticSub.clear();
+  optimisticTopLevel.clear();
+  lockedFields.clear();
+}
+
+export function setRadioState(state: ServerState): boolean {
+  if (!hasCurrentEpoch(state)) return false;
+
+  const nextGeneration = (state as unknown as Record<string, unknown>).providerGeneration as number;
+  const currentGeneration = radio.current
+    ? (radio.current as unknown as Record<string, unknown>).providerGeneration
+    : null;
+  if (currentGeneration !== null && currentGeneration !== nextGeneration) {
+    // A new provider is a new revision domain. Never carry an optimistic
+    // patch or lock from the retired provider into its observed state.
+    clearGenerationBookkeeping();
+  }
   const nextStateRevision = stateRevision(state);
   const nextFreshnessRevision = freshnessRevision(state);
   const nextObservationSeq = observationSeq(state);
@@ -259,7 +295,9 @@ export function setRadioState(state: ServerState): void {
     if (state.radioHealth !== undefined) {
       setRadioHealth(state.radioHealth);
     }
+    return true;
   }
+  return false;
 }
 
 const OPTIMISTIC_TTL = 5000; // hard timeout — normally cleared by server confirmation

--- a/frontend/src/lib/transport/__tests__/ws-client-store.integration.test.ts
+++ b/frontend/src/lib/transport/__tests__/ws-client-store.integration.test.ts
@@ -366,6 +366,51 @@ describe('ws-client → real radio store gate (integration)', () => {
     expect(store.getLastRevision()).toBe(6);
   });
 
+  it('rejects a same-generation 100-to-1 delta without changing radio or capability truth', async () => {
+    const { wsClient, store, capabilities } = await loadModules();
+    capabilities.setCapabilities(makeCapabilities());
+    wsClient.connect('ws://test/api/v1/ws');
+    instances[0].simulateOpen();
+    sendStateUpdate(instances[0], fullEnvelope(makeState({ revision: 100, ptt: false })));
+    const accepted = store.getRadioState();
+    const acceptedCapabilities = capabilities.getCapabilities();
+
+    sendStateUpdate(
+      instances[0],
+      deltaEnvelope(makeState({ revision: 1, ptt: true }), { ptt: true }),
+    );
+
+    expect(store.getRadioState()).toBe(accepted);
+    expect(store.getRadioState()?.revision).toBe(100);
+    expect(store.getRadioState()?.ptt).toBe(false);
+    expect(capabilities.getCapabilities()).toBe(acceptedCapabilities);
+  });
+
+  it('rejects incomplete full data and malformed changed records before they alter truth', async () => {
+    const { wsClient, store, capabilities } = await loadModules();
+    capabilities.setCapabilities(makeCapabilities());
+    wsClient.connect('ws://test/api/v1/ws');
+    instances[0].simulateOpen();
+    sendStateUpdate(instances[0], {
+      type: 'full', stateContractVersion: 1, providerGeneration: 0,
+      revision: 1, data: { stateContractVersion: 1, providerGeneration: 0 },
+    });
+    expect(store.getRadioState()).toBeNull();
+
+    sendStateUpdate(instances[0], fullEnvelope(makeState({ revision: 1, ptt: false })));
+    const accepted = store.getRadioState();
+    const acceptedCapabilities = capabilities.getCapabilities();
+    sendStateUpdate(
+      instances[0],
+      deltaEnvelope(makeState({ revision: 2, ptt: true }), { main: 'corrupt' }),
+    );
+
+    expect(store.getRadioState()).toBe(accepted);
+    expect(store.getRadioState()?.main.freqHz).toBe(14_074_000);
+    expect(store.getRadioState()?.ptt).toBe(false);
+    expect(capabilities.getCapabilities()).toBe(acceptedCapabilities);
+  });
+
   it('rejects unversioned frames and a delta before a valid full without changing truth', async () => {
     const { wsClient, store, capabilities } = await loadModules();
     capabilities.setCapabilities(makeCapabilities());

--- a/frontend/src/lib/transport/__tests__/ws-client-store.integration.test.ts
+++ b/frontend/src/lib/transport/__tests__/ws-client-store.integration.test.ts
@@ -34,13 +34,17 @@ type ServerStateWithObservation = ServerState & {
   fieldStatus?: Record<string, unknown>;
 };
 
-function makeCapabilities(providerGeneration = 0): Capabilities {
+function makeCapabilities(
+  providerGeneration = 0,
+  overrides: Partial<Capabilities> = {},
+): Capabilities {
   return {
     model: 'TEST', scope: false, audio: false, tx: false, capabilities: [],
     receivers: 1, vfoScheme: 'single', freqRanges: [], modes: [], filters: [],
     audioConfig: { sampleRate: 48_000, channels: 1, codecs: [] },
     webrtc: { available: false, enabled: false }, txBands: null,
     stateContractVersion: 1, providerGeneration,
+    ...overrides,
   };
 }
 
@@ -213,6 +217,36 @@ describe('ws-client → real radio store gate (integration)', () => {
     sendStateUpdate(instances[0], fullEnvelope(nullSub));
     expect(store.getRadioState()?.revision).toBe(2);
     expect(store.getRadioState()?.main.freqHz).toBe(14_074_000);
+  });
+
+  it('rejects a single-receiver active SUB full before it mutates browser truth', async () => {
+    const { wsClient, store, capabilities } = await loadModules();
+    const connection = await import('../../stores/connection.svelte');
+    const singleReceiverCaps = makeCapabilities(0, { receivers: 1, vfoScheme: 'ab' });
+    fetchCapabilities.mockResolvedValue(singleReceiverCaps);
+    capabilities.setCapabilities(singleReceiverCaps);
+    const markStateUpdated = vi.spyOn(connection, 'markStateUpdated');
+    const activeStatus = {
+      active: { storePath: 'global.slow_state.active', observed: true, freshness: 'fresh', availability: 'available' },
+    } as const;
+    wsClient.connect('ws://test/api/v1/ws');
+    instances[0].simulateOpen();
+    sendStateUpdate(instances[0], fullEnvelope(singleReceiverWireState({ revision: 1, active: 'MAIN', fieldStatus: activeStatus })));
+    const accepted = store.getRadioState();
+    const acceptedCapabilities = capabilities.getCapabilities();
+    const acceptedReady = connection.getRadioReady();
+    markStateUpdated.mockClear();
+
+    sendStateUpdate(instances[0], fullEnvelope(singleReceiverWireState({ revision: 2, active: 'SUB', fieldStatus: activeStatus })));
+    expect(store.getRadioState()).toBe(accepted);
+    expect(capabilities.getCapabilities()).toBe(acceptedCapabilities);
+    expect(connection.getRadioReady()).toBe(acceptedReady);
+    expect(markStateUpdated).not.toHaveBeenCalled();
+
+    const dualReceiverCaps = makeCapabilities(0, { receivers: 2, vfoScheme: 'main_sub' });
+    capabilities.setCapabilities(dualReceiverCaps);
+    sendStateUpdate(instances[0], fullEnvelope(makeState({ revision: 2, active: 'SUB', fieldStatus: activeStatus })));
+    expect(store.getRadioState()?.active).toBe('SUB');
   });
 
   it('applies a delta with a higher stateRevision through the real store', async () => {

--- a/frontend/src/lib/transport/__tests__/ws-client-store.integration.test.ts
+++ b/frontend/src/lib/transport/__tests__/ws-client-store.integration.test.ts
@@ -101,6 +101,13 @@ function makeState(
   };
 }
 
+function singleReceiverWireState(
+  overrides: Partial<ServerStateWithObservation> = {},
+): ServerStateWithObservation {
+  const { sub: _sub, ...wireState } = makeState(overrides);
+  return wireState as ServerStateWithObservation;
+}
+
 function fullEnvelope(state: ServerStateWithObservation): Record<string, unknown> {
   return {
     type: 'full',
@@ -191,6 +198,21 @@ describe('ws-client → real radio store gate (integration)', () => {
     expect(s?.stateRevision).toBe(5);
     expect(s?.ptt).toBe(false);
     expect(store.getLastRevision()).toBe(5);
+  });
+
+  it('accepts canonical single-receiver full bodies with omitted or null sub', async () => {
+    const { wsClient, store, capabilities } = await loadModules();
+    capabilities.setCapabilities(makeCapabilities());
+    wsClient.connect('ws://test/api/v1/ws');
+    instances[0].simulateOpen();
+
+    sendStateUpdate(instances[0], fullEnvelope(singleReceiverWireState({ revision: 1 })));
+    expect(store.getRadioState()?.main.freqHz).toBe(14_074_000);
+
+    const nullSub = { ...singleReceiverWireState({ revision: 2 }), sub: null } as unknown as ServerStateWithObservation;
+    sendStateUpdate(instances[0], fullEnvelope(nullSub));
+    expect(store.getRadioState()?.revision).toBe(2);
+    expect(store.getRadioState()?.main.freqHz).toBe(14_074_000);
   });
 
   it('applies a delta with a higher stateRevision through the real store', async () => {

--- a/frontend/src/lib/transport/__tests__/ws-client-store.integration.test.ts
+++ b/frontend/src/lib/transport/__tests__/ws-client-store.integration.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { ReceiverState, ServerState } from '../../types/state';
+import type { Capabilities } from '../../types/capabilities';
 import { MockWebSocket, instances } from './support/fake-ws-backend';
+
+const fetchCapabilities = vi.hoisted(() => vi.fn());
+vi.mock('../http-client', () => ({ fetchCapabilities }));
 
 // ─── End-to-end fidelity test: REAL ws-client → REAL radio.svelte store ──────
 //
@@ -29,6 +33,16 @@ type ServerStateWithObservation = ServerState & {
   publicStateSeq?: number;
   fieldStatus?: Record<string, unknown>;
 };
+
+function makeCapabilities(providerGeneration = 0): Capabilities {
+  return {
+    model: 'TEST', scope: false, audio: false, tx: false, capabilities: [],
+    receivers: 1, vfoScheme: 'single', freqRanges: [], modes: [], filters: [],
+    audioConfig: { sampleRate: 48_000, channels: 1, codecs: [] },
+    webrtc: { available: false, enabled: false }, txBands: null,
+    stateContractVersion: 1, providerGeneration,
+  };
+}
 
 // ─── Envelope/state fixtures (shapes copied from ws-client.isolated.test.ts) ──────────
 
@@ -80,6 +94,8 @@ function makeState(
       controlConnected: true,
       ...connection,
     },
+    stateContractVersion: 1,
+    providerGeneration: 0,
     ...topLevel,
     txTarget: txTarget ?? { status: 'unknown', reason: 'not-observed' },
   };
@@ -96,6 +112,8 @@ function fullEnvelope(state: ServerStateWithObservation): Record<string, unknown
     observationSeq: state.observationSeq,
     publicStateSeq: state.publicStateSeq,
     transportSeq: state.transportSeq,
+    stateContractVersion: state.stateContractVersion,
+    providerGeneration: state.providerGeneration,
   };
 }
 
@@ -115,6 +133,8 @@ function deltaEnvelope(
     observationSeq: state.observationSeq,
     publicStateSeq: state.publicStateSeq,
     transportSeq: state.transportSeq,
+    stateContractVersion: state.stateContractVersion,
+    providerGeneration: state.providerGeneration,
   };
 }
 
@@ -127,7 +147,8 @@ function sendStateUpdate(socket: MockWebSocket, data: Record<string, unknown>): 
 async function loadModules() {
   const wsClient = await import('../ws-client');
   const store = await import('../../stores/radio.svelte');
-  return { wsClient, store };
+  const capabilities = await import('../../stores/capabilities.svelte');
+  return { wsClient, store, capabilities };
 }
 
 describe('ws-client → real radio store gate (integration)', () => {
@@ -145,6 +166,7 @@ describe('ws-client → real radio store gate (integration)', () => {
     // ``loadModules()`` here would pick up that stale singleton and the
     // revision-gate assertions drift (e.g. ``expected 6 to be 5``).
     vi.resetModules();
+    fetchCapabilities.mockResolvedValue(makeCapabilities());
   });
 
   afterEach(() => {
@@ -153,7 +175,8 @@ describe('ws-client → real radio store gate (integration)', () => {
   });
 
   it('applies a full envelope through the real store', async () => {
-    const { wsClient, store } = await loadModules();
+    const { wsClient, store, capabilities } = await loadModules();
+    capabilities.setCapabilities(makeCapabilities());
 
     wsClient.connect('ws://test/api/v1/ws');
     instances[0].simulateOpen();
@@ -171,7 +194,8 @@ describe('ws-client → real radio store gate (integration)', () => {
   });
 
   it('applies a delta with a higher stateRevision through the real store', async () => {
-    const { wsClient, store } = await loadModules();
+    const { wsClient, store, capabilities } = await loadModules();
+    capabilities.setCapabilities(makeCapabilities());
 
     wsClient.connect('ws://test/api/v1/ws');
     instances[0].simulateOpen();
@@ -194,7 +218,8 @@ describe('ws-client → real radio store gate (integration)', () => {
   });
 
   it('accepts a same-revision delta when observationSeq + fieldStatus advance', async () => {
-    const { wsClient, store } = await loadModules();
+    const { wsClient, store, capabilities } = await loadModules();
+    capabilities.setCapabilities(makeCapabilities());
 
     wsClient.connect('ws://test/api/v1/ws');
     instances[0].simulateOpen();
@@ -248,7 +273,8 @@ describe('ws-client → real radio store gate (integration)', () => {
   });
 
   it('keeps a retained relative tuple visible and applies a live leaf delta', async () => {
-    const { wsClient, store } = await loadModules();
+    const { wsClient, store, capabilities } = await loadModules();
+    capabilities.setCapabilities(makeCapabilities());
     const status = (at: number) => ({
       storePath: 'receiver.0.active.freq_mode.freq_hz',
       observed: true,
@@ -310,7 +336,8 @@ describe('ws-client → real radio store gate (integration)', () => {
   });
 
   it('rejects a stale delta even when observationSeq advances', async () => {
-    const { wsClient, store } = await loadModules();
+    const { wsClient, store, capabilities } = await loadModules();
+    capabilities.setCapabilities(makeCapabilities());
 
     wsClient.connect('ws://test/api/v1/ws');
     instances[0].simulateOpen();
@@ -337,5 +364,111 @@ describe('ws-client → real radio store gate (integration)', () => {
     expect(s?.observationSeq).toBe(6);
     expect(s?.ptt).toBe(true);
     expect(store.getLastRevision()).toBe(6);
+  });
+
+  it('rejects unversioned frames and a delta before a valid full without changing truth', async () => {
+    const { wsClient, store, capabilities } = await loadModules();
+    capabilities.setCapabilities(makeCapabilities());
+    wsClient.connect('ws://test/api/v1/ws');
+    instances[0].simulateOpen();
+
+    sendStateUpdate(instances[0], makeState({ revision: 9 }) as unknown as Record<string, unknown>);
+    sendStateUpdate(instances[0], deltaEnvelope(makeState({ revision: 9 }), { ptt: true }));
+
+    expect(store.getRadioState()).toBeNull();
+    expect(store.getLastRevision()).toBe(-1);
+  });
+
+  it('rejects wrong contract and unsafe generation before changing browser truth', async () => {
+    const { wsClient, store, capabilities } = await loadModules();
+    capabilities.setCapabilities(makeCapabilities());
+    wsClient.connect('ws://test/api/v1/ws');
+    instances[0].simulateOpen();
+    const wrongContract = fullEnvelope(makeState({ revision: 4 }));
+    wrongContract.stateContractVersion = 2;
+    const unsafeGeneration = fullEnvelope(makeState({ revision: 5 }));
+    unsafeGeneration.providerGeneration = Number.MAX_SAFE_INTEGER + 1;
+
+    sendStateUpdate(instances[0], wrongContract);
+    sendStateUpdate(instances[0], unsafeGeneration);
+
+    expect(store.getRadioState()).toBeNull();
+    expect(capabilities.getCapabilities()?.providerGeneration).toBe(0);
+  });
+
+  it('does not let a malformed delta erase or replace its established epoch', async () => {
+    const { wsClient, store, capabilities } = await loadModules();
+    capabilities.setCapabilities(makeCapabilities());
+    wsClient.connect('ws://test/api/v1/ws');
+    instances[0].simulateOpen();
+    sendStateUpdate(instances[0], fullEnvelope(makeState({ revision: 4 })));
+    sendStateUpdate(
+      instances[0],
+      deltaEnvelope(makeState({ revision: 5 }), { ptt: true, providerGeneration: 1 }),
+    );
+
+    expect(store.getRadioState()?.providerGeneration).toBe(0);
+    expect(store.getRadioState()?.ptt).toBe(false);
+  });
+
+  it('clears generation N on a higher delta and accepts only a matching later full', async () => {
+    const { wsClient, store, capabilities } = await loadModules();
+    capabilities.setCapabilities(makeCapabilities(0));
+    wsClient.connect('ws://test/api/v1/ws');
+    instances[0].simulateOpen();
+    sendStateUpdate(instances[0], fullEnvelope(makeState({ revision: 7, providerGeneration: 0 })));
+    expect(store.getRadioState()?.revision).toBe(7);
+
+    sendStateUpdate(instances[0], deltaEnvelope(makeState({ revision: 8, providerGeneration: 1 }), { ptt: true }));
+    expect(store.getRadioState()).toBeNull();
+    expect(capabilities.getCapabilities()).toBeNull();
+
+    capabilities.setCapabilities(makeCapabilities(1));
+    sendStateUpdate(instances[0], fullEnvelope(makeState({ revision: 1, providerGeneration: 1, ptt: true })));
+    expect(store.getRadioState()?.providerGeneration).toBe(1);
+    expect(store.getRadioState()?.ptt).toBe(true);
+  });
+
+  it('does not install a delayed capability response for an older provider generation', async () => {
+    let resolveOld: ((value: ReturnType<typeof makeCapabilities>) => void) | undefined;
+    let resolveNew: ((value: ReturnType<typeof makeCapabilities>) => void) | undefined;
+    fetchCapabilities
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveOld = resolve; }))
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveNew = resolve; }));
+    const { wsClient, store, capabilities } = await loadModules();
+    wsClient.connect('ws://test/api/v1/ws');
+    instances[0].simulateOpen();
+    sendStateUpdate(instances[0], fullEnvelope(makeState({ providerGeneration: 1 })));
+    sendStateUpdate(instances[0], fullEnvelope(makeState({ revision: 2, providerGeneration: 2 })));
+
+    resolveOld!(makeCapabilities(1));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(capabilities.getCapabilities()).toBeNull();
+
+    resolveNew!(makeCapabilities(2));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(capabilities.getCapabilities()?.providerGeneration).toBe(2);
+    expect(store.getRadioState()?.providerGeneration).toBe(2);
+  });
+
+  it('rejects an old epoch in-session but accepts a lower epoch after disconnect', async () => {
+    const { wsClient, store, capabilities } = await loadModules();
+    capabilities.setCapabilities(makeCapabilities(2));
+    wsClient.connect('ws://test/api/v1/ws');
+    instances[0].simulateOpen();
+    sendStateUpdate(instances[0], fullEnvelope(makeState({ revision: 4, providerGeneration: 2 })));
+    sendStateUpdate(instances[0], fullEnvelope(makeState({ revision: 99, providerGeneration: 1, ptt: true })));
+    expect(store.getRadioState()?.providerGeneration).toBe(2);
+    expect(store.getRadioState()?.ptt).toBe(false);
+
+    wsClient.disconnect();
+    capabilities.setCapabilities(makeCapabilities(1));
+    wsClient.connect('ws://test/api/v1/ws');
+    instances[1].simulateOpen();
+    sendStateUpdate(instances[1], fullEnvelope(makeState({ revision: 1, providerGeneration: 1, ptt: true })));
+    expect(store.getRadioState()?.providerGeneration).toBe(1);
+    expect(store.getRadioState()?.ptt).toBe(true);
   });
 });

--- a/frontend/src/lib/transport/__tests__/ws-client.isolated.test.ts
+++ b/frontend/src/lib/transport/__tests__/ws-client.isolated.test.ts
@@ -55,6 +55,7 @@ vi.mock('../../stores/radio.svelte', () => ({
     radioStoreMock.current = null;
   }),
   isValidServerState: vi.fn(() => true),
+  matchesCurrentCapabilityTopology: vi.fn(() => true),
   setRadioState: vi.fn((state: ServerStateWithObservation) => {
     const current = radioStoreMock.current;
     const lastRevision = current ? current.stateRevision ?? current.revision : -1;

--- a/frontend/src/lib/transport/__tests__/ws-client.isolated.test.ts
+++ b/frontend/src/lib/transport/__tests__/ws-client.isolated.test.ts
@@ -54,6 +54,7 @@ vi.mock('../../stores/radio.svelte', () => ({
   resetRadioState: vi.fn(() => {
     radioStoreMock.current = null;
   }),
+  isValidServerState: vi.fn(() => true),
   setRadioState: vi.fn((state: ServerStateWithObservation) => {
     const current = radioStoreMock.current;
     const lastRevision = current ? current.stateRevision ?? current.revision : -1;
@@ -66,7 +67,6 @@ vi.mock('../../stores/radio.svelte', () => ({
     const nextObservationSeq = state.observationSeq ?? 0;
     const lastPublicStateSeq = current?.publicStateSeq ?? -1;
     const nextPublicStateSeq = state.publicStateSeq ?? 0;
-    const isReset = lastRevision > 10 && nextRevision < lastRevision / 2;
     const semanticAdvanced = nextRevision > lastRevision;
     const semanticCurrent = nextRevision === lastRevision;
     const metadataAdvanced = semanticCurrent && (
@@ -75,7 +75,7 @@ vi.mock('../../stores/radio.svelte', () => ({
       || nextObservationSeq > lastObservationSeq
       || nextPublicStateSeq > lastPublicStateSeq
     );
-    if (current === null || semanticAdvanced || metadataAdvanced || isReset) {
+    if (current === null || semanticAdvanced || metadataAdvanced) {
       radioStoreMock.current = state;
     }
   }),

--- a/frontend/src/lib/transport/__tests__/ws-client.isolated.test.ts
+++ b/frontend/src/lib/transport/__tests__/ws-client.isolated.test.ts
@@ -81,6 +81,16 @@ vi.mock('../../stores/radio.svelte', () => ({
   }),
 }));
 
+vi.mock('../../stores/capabilities.svelte', () => ({
+  capabilitiesMatchGeneration: vi.fn(() => true),
+  clearCapabilities: vi.fn(),
+  setCapabilities: vi.fn(() => true),
+}));
+
+vi.mock('../http-client', () => ({
+  fetchCapabilities: vi.fn(() => new Promise(() => {})),
+}));
+
 import { isLiveRadioAvailable, setRadioStatus, setWsConnected } from '../../stores/connection.svelte';
 import { patchActiveReceiver, patchRadioState, resetRadioState, setRadioState } from '../../stores/radio.svelte';
 
@@ -144,6 +154,8 @@ function makeState(
       controlConnected: true,
       ...connection,
     },
+    stateContractVersion: 1,
+    providerGeneration: 0,
     ...topLevel,
     txTarget: txTarget ?? { status: 'unknown', reason: 'not-observed' },
   };
@@ -160,6 +172,8 @@ function fullEnvelope(state: ServerStateWithObservation): Record<string, unknown
     observationSeq: state.observationSeq,
     publicStateSeq: state.publicStateSeq,
     transportSeq: state.transportSeq,
+    stateContractVersion: state.stateContractVersion,
+    providerGeneration: state.providerGeneration,
   };
 }
 
@@ -179,6 +193,8 @@ function deltaEnvelope(
     observationSeq: state.observationSeq,
     publicStateSeq: state.publicStateSeq,
     transportSeq: state.transportSeq,
+    stateContractVersion: state.stateContractVersion,
+    providerGeneration: state.providerGeneration,
   };
 }
 
@@ -997,7 +1013,7 @@ describe('control channel singleton', () => {
     expect(setRadioStatus).not.toHaveBeenCalled();
   });
 
-  it('replaces accumulated state when a full snapshot follows a revision reset', async () => {
+  it('rejects a same-session full snapshot that rolls revision truth backward', async () => {
     const { connect } = await import('../ws-client');
     connect('ws://test/api/v1/ws');
     instances[0].simulateOpen();
@@ -1007,10 +1023,10 @@ describe('control channel singleton', () => {
 
     sendStateUpdate(instances[0], fullEnvelope(makeState({ revision: 1, ptt: false, split: false })));
 
-    expect(setRadioState).toHaveBeenCalledTimes(1);
-    expect(radioStoreMock.current?.revision).toBe(1);
-    expect(radioStoreMock.current?.ptt).toBe(false);
-    expect(radioStoreMock.current?.split).toBe(false);
+    expect(setRadioState).not.toHaveBeenCalled();
+    expect(radioStoreMock.current?.revision).toBe(20);
+    expect(radioStoreMock.current?.ptt).toBe(true);
+    expect(radioStoreMock.current?.split).toBe(true);
   });
 
 });

--- a/frontend/src/lib/transport/ws-client.ts
+++ b/frontend/src/lib/transport/ws-client.ts
@@ -1,7 +1,7 @@
 import type { WsCommand, WsIncoming } from '../types/protocol';
 import { makeCommandId } from '../types/protocol';
 import { isLiveRadioAvailable, setWsConnected, setHttpConnected, markStateUpdated, setReconnecting, setRadioStatus } from '../stores/connection.svelte';
-import { getRadioState, patchActiveReceiver, patchRadioState, resetRadioState, setRadioState } from '../stores/radio.svelte';
+import { getRadioState, isValidServerState, patchActiveReceiver, patchRadioState, resetRadioState, setRadioState } from '../stores/radio.svelte';
 import { capabilitiesMatchGeneration, clearCapabilities, setCapabilities } from '../stores/capabilities.svelte';
 import { fetchCapabilities } from './http-client';
 
@@ -548,7 +548,6 @@ function isRevisionAcceptable(
 
   const lastRevision = stateRevisionOf(currentState);
   const nextRevision = stateRevisionOf(nextState);
-  const isReset = lastRevision > 10 && nextRevision < lastRevision / 2;
   const semanticAdvanced = nextRevision > lastRevision;
   const semanticCurrent = nextRevision === lastRevision;
   const metadataAdvanced = semanticCurrent && (
@@ -561,7 +560,7 @@ function isRevisionAcceptable(
     )
   );
 
-  return semanticAdvanced || metadataAdvanced || isReset;
+  return semanticAdvanced || metadataAdvanced;
 }
 
 function applyDeltaEnvelope(envelope: Record<string, unknown>): Record<string, unknown> | null {
@@ -576,6 +575,7 @@ function applyDeltaEnvelope(envelope: Record<string, unknown>): Record<string, u
     const data = envelope.data;
     if (data.stateContractVersion !== 1 || data.providerGeneration !== generation) return null;
     const nextState = syncEnvelopeRevisions({ ...data }, envelope);
+    if (!isValidServerState(nextState)) return null;
     if (
       _acceptedProviderGeneration === generation
       && _fullState !== null
@@ -610,16 +610,20 @@ function applyDeltaEnvelope(envelope: Record<string, unknown>): Record<string, u
     || (envelope.removed ?? []).includes('stateContractVersion')
     || (envelope.removed ?? []).includes('providerGeneration')
   ) return null;
+  const changed = envelope.changed;
+  const removed = (envelope.removed ?? []) as string[];
+  const currentState = _fullState;
+  const candidate = currentState ? { ...currentState, ...changed } : null;
+  if (candidate) {
+    for (const key of removed) delete candidate[key];
+    syncEnvelopeRevisions(candidate, envelope);
+    if (!isValidServerState(candidate)) return null;
+  }
   if (_acceptedProviderGeneration !== generation || !_hasReceivedFullState || _fullState === null) {
     if (highestSeen === null || generation > highestSeen) resetForProviderGeneration(generation);
     return null;
   }
-  const changed = envelope.changed;
-  const removed = (envelope.removed ?? []) as string[];
-  const currentState = _fullState;
-  const nextState = { ...currentState, ...changed };
-  for (const key of removed) delete nextState[key];
-  syncEnvelopeRevisions(nextState, envelope);
+  const nextState = candidate!;
   if (!isRevisionAcceptable(currentState, nextState, Object.keys(changed))) return null;
   _fullState = nextState;
   return commitCurrentState() ? _fullState : null;

--- a/frontend/src/lib/transport/ws-client.ts
+++ b/frontend/src/lib/transport/ws-client.ts
@@ -1,7 +1,7 @@
 import type { WsCommand, WsIncoming } from '../types/protocol';
 import { makeCommandId } from '../types/protocol';
 import { isLiveRadioAvailable, setWsConnected, setHttpConnected, markStateUpdated, setReconnecting, setRadioStatus } from '../stores/connection.svelte';
-import { getRadioState, isValidServerState, patchActiveReceiver, patchRadioState, resetRadioState, setRadioState } from '../stores/radio.svelte';
+import { getRadioState, isValidServerState, matchesCurrentCapabilityTopology, patchActiveReceiver, patchRadioState, resetRadioState, setRadioState } from '../stores/radio.svelte';
 import { capabilitiesMatchGeneration, clearCapabilities, setCapabilities } from '../stores/capabilities.svelte';
 import { fetchCapabilities } from './http-client';
 
@@ -576,6 +576,7 @@ function applyDeltaEnvelope(envelope: Record<string, unknown>): Record<string, u
     if (data.stateContractVersion !== 1 || data.providerGeneration !== generation) return null;
     const nextState = syncEnvelopeRevisions({ ...data }, envelope);
     if (!isValidServerState(nextState)) return null;
+    if (capabilitiesMatchGeneration(generation) && !matchesCurrentCapabilityTopology(nextState as any)) return null;
     if (
       _acceptedProviderGeneration === generation
       && _fullState !== null
@@ -618,6 +619,7 @@ function applyDeltaEnvelope(envelope: Record<string, unknown>): Record<string, u
     for (const key of removed) delete candidate[key];
     syncEnvelopeRevisions(candidate, envelope);
     if (!isValidServerState(candidate)) return null;
+    if (capabilitiesMatchGeneration(generation) && !matchesCurrentCapabilityTopology(candidate as any)) return null;
   }
   if (_acceptedProviderGeneration !== generation || !_hasReceivedFullState || _fullState === null) {
     if (highestSeen === null || generation > highestSeen) resetForProviderGeneration(generation);

--- a/frontend/src/lib/transport/ws-client.ts
+++ b/frontend/src/lib/transport/ws-client.ts
@@ -2,6 +2,8 @@ import type { WsCommand, WsIncoming } from '../types/protocol';
 import { makeCommandId } from '../types/protocol';
 import { isLiveRadioAvailable, setWsConnected, setHttpConnected, markStateUpdated, setReconnecting, setRadioStatus } from '../stores/connection.svelte';
 import { getRadioState, patchActiveReceiver, patchRadioState, resetRadioState, setRadioState } from '../stores/radio.svelte';
+import { capabilitiesMatchGeneration, clearCapabilities, setCapabilities } from '../stores/capabilities.svelte';
+import { fetchCapabilities } from './http-client';
 
 export type ConnectionState = 'disconnected' | 'connecting' | 'connected' | 'reconnecting';
 export interface ControlSessionTransition {
@@ -393,14 +395,80 @@ _ctrl.onStateChange((s) => {
   setWsConnected(s === 'connected');
   setReconnecting(s === 'connecting' || s === 'reconnecting');
   if (s === 'disconnected') {
-    _fullState = {};
+    _fullState = null;
     _hasReceivedFullState = false;
+    _acceptedProviderGeneration = null;
+    _expectedProviderGeneration = null;
+    _capabilityRefreshGeneration = null;
     resetRadioState();
+    clearCapabilities();
   }
 });
 // Delta state tracking for incremental updates
-let _fullState: Record<string, unknown> = {};
+let _fullState: Record<string, unknown> | null = null;
 let _hasReceivedFullState = false;
+let _acceptedProviderGeneration: number | null = null;
+let _expectedProviderGeneration: number | null = null;
+let _capabilityRefreshGeneration: number | null = null;
+
+function isProviderGeneration(value: unknown): value is number {
+  return typeof value === 'number'
+    && Number.isSafeInteger(value)
+    && value >= 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function epochOf(envelope: Record<string, unknown>): number | null {
+  if (envelope.stateContractVersion !== 1 || !isProviderGeneration(envelope.providerGeneration)) {
+    return null;
+  }
+  return envelope.providerGeneration;
+}
+
+function highestSeenGeneration(): number | null {
+  if (_expectedProviderGeneration !== null) return _expectedProviderGeneration;
+  return _acceptedProviderGeneration;
+}
+
+function resetForProviderGeneration(generation: number): void {
+  _fullState = null;
+  _hasReceivedFullState = false;
+  _acceptedProviderGeneration = null;
+  _expectedProviderGeneration = generation;
+  resetRadioState();
+  clearCapabilities();
+}
+
+function commitCurrentState(): boolean {
+  if (
+    !_hasReceivedFullState
+    || _fullState === null
+    || _acceptedProviderGeneration === null
+    || !capabilitiesMatchGeneration(_acceptedProviderGeneration)
+  ) return false;
+  return setRadioState(_fullState as any);
+}
+
+function refreshCapabilities(generation: number): void {
+  if (_capabilityRefreshGeneration === generation) return;
+  _capabilityRefreshGeneration = generation;
+  void fetchCapabilities().then((caps) => {
+    if (
+      _acceptedProviderGeneration !== generation
+      || !_hasReceivedFullState
+      || _fullState === null
+    ) return;
+    const record = caps as unknown as Record<string, unknown>;
+    if (record.stateContractVersion !== 1 || record.providerGeneration !== generation) return;
+    if (setCapabilities(caps)) commitCurrentState();
+  }).catch(() => {
+    // Capability retrieval is metadata only. Remain fail-closed until a later
+    // provider generation or reconnect supplies a new authoritative full.
+  });
+}
 
 function syncEnvelopeRevisions(
   state: Record<string, unknown>,
@@ -497,39 +565,64 @@ function isRevisionAcceptable(
 }
 
 function applyDeltaEnvelope(envelope: Record<string, unknown>): Record<string, unknown> | null {
-  const deltaType = envelope.type as string;
+  const deltaType = envelope.type;
+  const generation = epochOf(envelope);
+  if (generation === null || (deltaType !== 'full' && deltaType !== 'delta')) return null;
+  const highestSeen = highestSeenGeneration();
+  if (highestSeen !== null && generation < highestSeen) return null;
 
   if (deltaType === 'full') {
-    // Full state refresh — replace everything
-    _fullState = syncEnvelopeRevisions(
-      { ...(envelope.data as Record<string, unknown>) },
-      envelope,
-    );
-    _hasReceivedFullState = true;
-    return _fullState;
-  }
-
-  if (deltaType === 'delta') {
-    // Reject delta if we haven't received a full state yet
-    if (!_hasReceivedFullState) return null;
-    // Incremental update — apply changed fields, remove deleted keys
-    const changed = (envelope.changed ?? {}) as Record<string, unknown>;
-    const removed = (envelope.removed ?? []) as string[];
-
-    const currentState = _fullState;
-    const nextState = { ...currentState, ...changed };
-    for (const key of removed) {
-      delete nextState[key];
+    if (!isRecord(envelope.data)) return null;
+    const data = envelope.data;
+    if (data.stateContractVersion !== 1 || data.providerGeneration !== generation) return null;
+    const nextState = syncEnvelopeRevisions({ ...data }, envelope);
+    if (
+      _acceptedProviderGeneration === generation
+      && _fullState !== null
+      && (
+        stateRevisionOf(nextState) < stateRevisionOf(_fullState)
+        || deliverySeqOf(nextState) < deliverySeqOf(_fullState)
+        || !isRevisionAcceptable(_fullState, nextState, Object.keys(nextState))
+      )
+    ) return null;
+    if (_acceptedProviderGeneration !== generation || !_hasReceivedFullState) {
+      // Bootstrap may already have fetched matching capabilities. Keep that
+      // proven epoch; every provider transition (or an unbased higher delta)
+      // still clears all retired browser truth before accepting this full.
+      if (
+        _expectedProviderGeneration !== generation
+        && (_acceptedProviderGeneration !== null || !capabilitiesMatchGeneration(generation))
+      ) resetForProviderGeneration(generation);
     }
-    syncEnvelopeRevisions(nextState, envelope);
-    if (!isRevisionAcceptable(currentState, nextState, Object.keys(changed))) return null;
-
     _fullState = nextState;
-    return _fullState;
+    _hasReceivedFullState = true;
+    _acceptedProviderGeneration = generation;
+    _expectedProviderGeneration = null;
+    refreshCapabilities(generation);
+    return commitCurrentState() ? _fullState : null;
   }
 
-  // Legacy format (no delta envelope) — plain state object
-  return envelope;
+  if (!isRecord(envelope.changed)) return null;
+  if (envelope.removed !== undefined && (!Array.isArray(envelope.removed) || !envelope.removed.every((key) => typeof key === 'string'))) return null;
+  if (
+    (envelope.changed.stateContractVersion !== undefined && envelope.changed.stateContractVersion !== 1)
+    || (envelope.changed.providerGeneration !== undefined && envelope.changed.providerGeneration !== generation)
+    || (envelope.removed ?? []).includes('stateContractVersion')
+    || (envelope.removed ?? []).includes('providerGeneration')
+  ) return null;
+  if (_acceptedProviderGeneration !== generation || !_hasReceivedFullState || _fullState === null) {
+    if (highestSeen === null || generation > highestSeen) resetForProviderGeneration(generation);
+    return null;
+  }
+  const changed = envelope.changed;
+  const removed = (envelope.removed ?? []) as string[];
+  const currentState = _fullState;
+  const nextState = { ...currentState, ...changed };
+  for (const key of removed) delete nextState[key];
+  syncEnvelopeRevisions(nextState, envelope);
+  if (!isRevisionAcceptable(currentState, nextState, Object.keys(changed))) return null;
+  _fullState = nextState;
+  return commitCurrentState() ? _fullState : null;
 }
 
 _ctrl.onMessage((msg) => {

--- a/frontend/src/lib/types/__tests__/i18n-visual-fixture.contract.test.ts
+++ b/frontend/src/lib/types/__tests__/i18n-visual-fixture.contract.test.ts
@@ -1,9 +1,16 @@
 import { describe, expect, it } from 'vitest';
 
-import { mockCapabilities } from '../../../../tests/e2e/i18n/fixtures';
+import { mockCapabilities, mockState } from '../../../../tests/e2e/i18n/fixtures';
 import { validateCapabilities } from '../capabilities';
 
 describe('RP-ML-006 i18n visual capability fixture', () => {
+  it('carries the required B2 provider epoch through state and capabilities', () => {
+    expect(mockState.stateContractVersion).toBe(1);
+    expect(mockState.providerGeneration).toBe(0);
+    expect(mockCapabilities.stateContractVersion).toBe(1);
+    expect(mockCapabilities.providerGeneration).toBe(0);
+  });
+
   it('conforms to the complete public capabilities contract', () => {
     expect(validateCapabilities(mockCapabilities)).toBe(mockCapabilities);
   });

--- a/frontend/tests/e2e/i18n/fixtures.ts
+++ b/frontend/tests/e2e/i18n/fixtures.ts
@@ -48,6 +48,8 @@ const subReceiver: ReceiverState = {
 };
 
 export const mockState: ServerState = {
+  stateContractVersion: 1,
+  providerGeneration: 0,
   revision: 1,
   stateRevision: 1,
   freshnessRevision: 1,
@@ -133,6 +135,8 @@ export const mockPowerOffState: ServerState = {
 };
 
 export const mockCapabilities: Capabilities = {
+  stateContractVersion: 1,
+  providerGeneration: 0,
   model: 'IC-7610',
   scope: true,
   audio: true,


### PR DESCRIPTION
## Summary
- require the B2a StateStore epoch contract before browser state or capability truth mutates
- reject unbased, malformed, stale, and cross-generation WebSocket state
- fence capability refreshes and reset optimistic/revision context on provider replacement

## Verification
- frontend focused: 86 passed
- frontend full: 6082 passed
- frontend check, lint, build: PASS
- backend full: 9233 passed, 68 skipped, 5 deselected, 11 xfailed, 1 xpassed
- PTT/OFF/teardown: 169 passed, 1 deselected
- ruff, import-linter, diff check: PASS

Refs #2316

Independent exact-head review is still required; auto-merge remains off.