### PR TITLE
fix(web): recover slow WebSocket clients with full baselines

### DIFF
--- a/src/rigplane/core/_bounded_queue.py
+++ b/src/rigplane/core/_bounded_queue.py
@@ -16,6 +16,7 @@ differ across callsites and forcing a single policy would erase that.
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 from typing import Generic, TypeVar
 
 T = TypeVar("T")
@@ -64,6 +65,34 @@ class BoundedQueue(Generic[T]):
             except asyncio.QueueEmpty:
                 pass
         self._queue.put_nowait(item)
+
+    def replace_matching_with_front(
+        self, item: T, predicate: Callable[[T], bool]
+    ) -> None:
+        """Replace queued matches with ``item`` at the front.
+
+        Non-matching entries retain FIFO order.  When a full queue contains no
+        match, only its oldest entry is sacrificed to make room, matching the
+        existing state-update priority.  Drained entries are accounted for
+        before retained entries are re-queued, so ``join()`` still reflects
+        exactly the items that can subsequently be consumed.
+        """
+        retained: list[T] = []
+        while True:
+            try:
+                queued = self._queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+            self._queue.task_done()
+            if not predicate(queued):
+                retained.append(queued)
+
+        if self._queue.maxsize > 0 and len(retained) >= self._queue.maxsize:
+            retained.pop(0)
+
+        self._queue.put_nowait(item)
+        for queued in retained:
+            self._queue.put_nowait(queued)
 
     def full(self) -> bool:
         """Return ``True`` if the queue has reached ``maxsize``."""

--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -515,15 +515,25 @@ class ControlHandler:
         # Sent directly (not via event queue) so it arrives right after hello
         # and before the recv loop — no interleaving with command responses.
         if self._server is not None:
-            self._server.register_control_event_queue(self._event_queue)
+            initial = self._server.register_control_event_queue(self._event_queue)
+            # Old focused handler doubles have no StateStore-backed
+            # registration API and return a MagicMock/None.  Production
+            # WebServer always returns the canonical shared-encoder baseline.
+            if not isinstance(initial, dict):
+                initial = {"type": "full", "data": {}}
             try:
                 msg = {
                     "type": "state_update",
-                    "data": self._server.build_state_update_envelope(force_full=True),
+                    "data": initial,
                 }
                 await self._ws.send_text(encode_json(msg))
-            except Exception:
+            except BaseException as exc:
                 logger.debug("control: failed to send initial state", exc_info=True)
+                self._server.unregister_control_event_queue(self._event_queue)
+                if isinstance(exc, asyncio.CancelledError):
+                    raise
+                return
+            self._enqueue_current_dx_spots()
         event_task: asyncio.Task[None] = asyncio.create_task(self._event_sender_loop())
         try:
             # Inside the try, so the finally below owns every exit from here on;
@@ -848,6 +858,9 @@ class ControlHandler:
         if isinstance(streams, list):
             self._subscribed_streams.update(str(s) for s in streams)
         await self._send_state_snapshot()
+        # Yield once so the sole sender loop can begin the queued baseline
+        # before an immediately-following receive/EOF tears the session down.
+        await asyncio.sleep(0)
 
     async def _handle_unsubscribe(self, msg: dict[str, Any]) -> None:
         streams = msg.get("streams", [])
@@ -860,7 +873,13 @@ class ControlHandler:
         # snapshot-based envelope from the server's StateStore. When a server is
         # attached (production), that envelope is authoritative.
         payload: dict[str, Any]
-        if self._server is not None:
+        enqueue_baseline = getattr(self._server, "enqueue_control_state_baseline", None)
+        if callable(enqueue_baseline):
+            enqueue_baseline(self._event_queue)
+            payload = {}
+        elif self._server is not None:
+            # Focused legacy handler doubles predate C's queued-baseline API.
+            # They exercise envelope shape only, never the live sender path.
             payload = self._server.build_state_update_envelope(force_full=True)
         else:
             # Server-less handler-test path only: no StateStore is available, so
@@ -868,12 +887,20 @@ class ControlHandler:
             # the branch above; this fallback never runs with a live server.
             payload = {"type": "full", "data": {}}
 
-        msg_out = {"type": "state_update", "data": payload}
-        await self._ws.send_text(encode_json(msg_out))
-        # Send current DX spots if available
+        if not callable(enqueue_baseline):
+            msg_out = {"type": "state_update", "data": payload}
+            await self._ws.send_text(encode_json(msg_out))
+
+        self._enqueue_current_dx_spots()
+
+    def _enqueue_current_dx_spots(self) -> None:
+        """Queue buffered DX spots after the current state baseline."""
         if self._server is not None and hasattr(self._server, "_spot_buffer"):
             spots = self._server._spot_buffer.get_spots()
-            await self._ws.send_text(encode_json({"type": "dx_spots", "spots": spots}))
+            try:
+                self._event_queue.put_nowait({"type": "dx_spots", "spots": spots})
+            except asyncio.QueueFull:
+                logger.debug("control: dropping DX spots behind full state queue")
 
     async def _handle_command(self, msg: dict[str, Any]) -> None:
         cmd_id = msg.get("id", "")

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -1347,12 +1347,19 @@ class WebServer:
         """Behavior-neutral state-pipeline diagnostics recorder."""
         return self._state_diagnostics
 
-    def register_control_event_queue(self, q: BoundedQueue[dict[str, Any]]) -> None:
-        """Register a ControlHandler event queue for broadcast."""
+    def register_control_event_queue(
+        self, q: BoundedQueue[dict[str, Any]]
+    ) -> dict[str, Any]:
+        """Register a client and return its shared-encoder full baseline."""
         existing_queues = set(self._control_event_queues)
         self._control_event_queues.add(q)
-        if q not in existing_queues:
-            self._broadcast_ws_client_state_update(queues=existing_queues)
+        try:
+            return self._publish_control_state_baseline(q, peers=existing_queues)
+        except BaseException:
+            # Registration is transactional: an unbased queue must never
+            # survive a failed/cancelled baseline encode.
+            self._control_event_queues.discard(q)
+            raise
 
     def unregister_control_event_queue(self, q: BoundedQueue[dict[str, Any]]) -> None:
         """Unregister a ControlHandler event queue."""
@@ -1429,11 +1436,7 @@ class WebServer:
         # subscribed (a connecting client gets initial state on connect via force=True).
         if not force and not self._control_event_queues:
             return
-        try:
-            snapshot, body = self._build_public_state_for_delivery()
-        except RuntimeError:
-            logger.warning("state broadcast skipped: provider generation churned")
-            return
+        body = self._build_public_state_from_snapshot(snapshot)
         if self.command_state_store.provider_generation != snapshot.provider_generation:
             logger.warning("state broadcast skipped: provider generation changed")
             return
@@ -1441,7 +1444,7 @@ class WebServer:
             snapshot,
             health_revision=int(body.get("healthRevision", 0)),
         )
-        if state_key == self._last_broadcast_state_key:
+        if not force and state_key == self._last_broadcast_state_key:
             return
 
         delta = self._encode_state_update(snapshot, body)
@@ -1460,10 +1463,69 @@ class WebServer:
         )
 
         target_queues = self._control_event_queues if queues is None else queues
-        for q in list(target_queues):
-            # A state_update supersedes older queued state; coalesce-to-latest on a
-            # stalled/slow consumer instead of dropping the freshest + log-flooding.
-            q.put_drop_oldest(event)
+        self._fanout_state_update(target_queues, event, body)
+
+    def enqueue_control_state_baseline(self, q: BoundedQueue[dict[str, Any]]) -> None:
+        """Queue a full baseline for one already-running control client."""
+        self._publish_control_state_baseline(
+            q, peers=self._control_event_queues - {q}, queue_baseline=True
+        )
+
+    def _publish_control_state_baseline(
+        self,
+        q: BoundedQueue[dict[str, Any]],
+        *,
+        peers: Collection[BoundedQueue[dict[str, Any]]],
+        queue_baseline: bool = False,
+    ) -> dict[str, Any]:
+        """Encode once, fan out normally, and derive one client's full base."""
+        snapshot, body = self._build_public_state_for_delivery()
+        if self.command_state_store.provider_generation != snapshot.provider_generation:
+            raise RuntimeError("provider generation changed before state encoding")
+        encoded = self._encode_state_update(snapshot, body)
+        self._last_broadcast_state_key = self._public_state_delivery_key(
+            snapshot, health_revision=int(body.get("healthRevision", 0))
+        )
+        event = {"type": "state_update", "data": encoded}
+        self._fanout_state_update(peers, event, body)
+        baseline = self._derive_full_state_update(encoded, body)
+        if queue_baseline:
+            q.replace_matching_with_front(
+                {"type": "state_update", "data": baseline},
+                lambda queued: queued.get("type") == "state_update",
+            )
+        return baseline
+
+    def _fanout_state_update(
+        self,
+        queues: Collection[BoundedQueue[dict[str, Any]]],
+        event: dict[str, Any],
+        body: dict[str, Any],
+    ) -> None:
+        """Deliver one shared state encode, recovering only overflowed queues."""
+        for q in list(queues):
+            try:
+                q.put_nowait(event)
+            except asyncio.QueueFull:
+                q.replace_matching_with_front(
+                    {
+                        "type": "state_update",
+                        "data": self._derive_full_state_update(event["data"], body),
+                    },
+                    lambda queued: queued.get("type") == "state_update",
+                )
+
+    @staticmethod
+    def _derive_full_state_update(
+        encoded: dict[str, Any], body: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Convert one shared encode into a same-sequence full envelope."""
+        full = copy.deepcopy(encoded)
+        full["type"] = "full"
+        full.pop("changed", None)
+        full.pop("removed", None)
+        full["data"] = body
+        return full
 
     async def _delayed_state_broadcast(self, delay: float) -> None:
         try:
@@ -1599,22 +1661,17 @@ class WebServer:
         force_full: bool = False,
     ) -> dict[str, Any]:
         """Encode one Store snapshot with its non-optional wire epoch."""
-        encoder = (
-            DeltaEncoder(full_state_interval=100) if force_full else self._delta_encoder
-        )
         generation_changed = (
-            not force_full
-            and self._last_delta_encoder_generation != snapshot.provider_generation
+            self._last_delta_encoder_generation != snapshot.provider_generation
         )
-        result: dict[str, Any] = encoder.encode(
+        result: dict[str, Any] = self._delta_encoder.encode(
             body,
             force_full=force_full or generation_changed,
             state_revision=snapshot.state_revision,
             freshness_revision=snapshot.freshness_revision,
             observation_seq=snapshot.observation_seq,
         )
-        if not force_full:
-            self._last_delta_encoder_generation = snapshot.provider_generation
+        self._last_delta_encoder_generation = snapshot.provider_generation
         result["stateContractVersion"] = 1
         result["providerGeneration"] = snapshot.provider_generation
         return result

--- a/tests/test_bounded_queue.py
+++ b/tests/test_bounded_queue.py
@@ -101,3 +101,47 @@ async def test_task_done_allows_join() -> None:
     assert q.get_nowait() == 2
     q.task_done()
     await asyncio.wait_for(q._queue.join(), timeout=0.1)
+
+
+@pytest.mark.asyncio
+async def test_replace_matching_with_front_keeps_nonmatches_fifo_and_joinable() -> None:
+    q: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=5)
+    for item in (
+        {"type": "state_update", "data": 1},
+        {"type": "notification", "data": "first"},
+        {"type": "state_update", "data": 2},
+        {"type": "event", "data": "second"},
+    ):
+        q.put_nowait(item)
+
+    q.replace_matching_with_front(
+        {"type": "state_update", "data": "recovery"},
+        lambda item: item["type"] == "state_update",
+    )
+
+    drained = [q.get_nowait() for _ in range(q.qsize())]
+    assert drained == [
+        {"type": "state_update", "data": "recovery"},
+        {"type": "notification", "data": "first"},
+        {"type": "event", "data": "second"},
+    ]
+    for _ in drained:
+        q.task_done()
+    await asyncio.wait_for(q._queue.join(), timeout=0.1)
+
+
+def test_replace_matching_with_front_evicts_only_oldest_nonmatch_when_full() -> None:
+    q: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=3)
+    for label in ("first", "second", "third"):
+        q.put_nowait({"type": "notification", "data": label})
+
+    q.replace_matching_with_front(
+        {"type": "state_update", "data": "recovery"},
+        lambda item: item["type"] == "state_update",
+    )
+
+    assert [q.get_nowait() for _ in range(3)] == [
+        {"type": "state_update", "data": "recovery"},
+        {"type": "notification", "data": "second"},
+        {"type": "notification", "data": "third"},
+    ]

--- a/tests/test_mor1408_slow_client_recovery.py
+++ b/tests/test_mor1408_slow_client_recovery.py
@@ -1,0 +1,356 @@
+"""Adversarial delivery checks for MOR-1408 C's shared WebSocket baseline."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from rigplane.core._bounded_queue import BoundedQueue
+from rigplane.core.state_pipeline_contracts import (
+    FieldPath,
+    Observation,
+    SourceMetadata,
+)
+from rigplane.web._delta_encoder import apply_delta
+from rigplane.web.handlers.control import ControlHandler
+from rigplane.web.server import WebServer
+
+
+_SOURCE = SourceMetadata(source="test", provider="mor1408", transport="fake")
+
+
+def _observe(server: WebServer, value: int) -> None:
+    server.command_state_store.apply(
+        Observation(
+            path=FieldPath.active("0", "freq_mode", "freq_hz"),
+            value=value,
+            source=_SOURCE,
+            timestamp_monotonic=time.monotonic(),
+            provider_generation=server.command_state_store.provider_generation,
+        )
+    )
+    server._last_state_broadcast = 0.0  # noqa: SLF001
+
+
+def _event_data(queue: BoundedQueue[dict[str, Any]]) -> dict[str, Any]:
+    event = queue.get_nowait()
+    assert event["type"] == "state_update"
+    return event["data"]
+
+
+def _drain(queue: BoundedQueue[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [queue.get_nowait() for _ in range(queue.qsize())]
+
+
+def _state_data(frames: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [frame["data"] for frame in frames if frame["type"] == "state_update"]
+
+
+def test_overflow_replaces_all_queued_state_frames_with_same_encode_full() -> None:
+    server = WebServer(None)
+    slow: BoundedQueue[dict[str, Any]] = BoundedQueue(maxsize=3)
+    initial = server.register_control_event_queue(slow)
+    assert initial["type"] == "full"
+    _observe(server, 14_070_000)
+    server._broadcast_state_update(force=True)  # noqa: SLF001
+    baseline = _event_data(slow)
+    assert baseline["type"] == "delta"
+
+    _observe(server, 14_071_000)
+    server._broadcast_state_update(force=True)  # noqa: SLF001
+    _observe(server, 14_072_000)
+    server._broadcast_state_update(force=True)  # noqa: SLF001
+    _observe(server, 14_073_000)
+    server._broadcast_state_update(force=True)  # noqa: SLF001
+    _observe(server, 14_074_000)
+    server._broadcast_state_update(force=True)  # noqa: SLF001
+
+    recovery = _event_data(slow)
+    assert recovery["type"] == "full"
+    assert slow.empty()
+    assert recovery["transportSeq"] == server._delta_encoder.revision  # noqa: SLF001
+
+    _observe(server, 14_075_000)
+    server._broadcast_state_update(force=True)  # noqa: SLF001
+    next_delta = _event_data(slow)
+    assert next_delta["type"] == "delta"
+    assert apply_delta(recovery["data"], next_delta) == server.build_public_state()
+
+
+def test_mixed_queue_overflow_preserves_nonstate_order_after_recovery_full() -> None:
+    server = WebServer(None)
+    slow: BoundedQueue[dict[str, Any]] = BoundedQueue(maxsize=4)
+    server.register_control_event_queue(slow)
+    slow.put_nowait({"type": "notification", "name": "a", "data": {}})
+    _observe(server, 14_070_000)
+    server._broadcast_state_update(force=True)  # noqa: SLF001
+    slow.put_nowait({"type": "event", "name": "b", "data": {}})
+    _observe(server, 14_071_000)
+    server._broadcast_state_update(force=True)  # noqa: SLF001
+    _observe(server, 14_072_000)
+    server._broadcast_state_update(force=True)  # noqa: SLF001
+
+    frames = [slow.get_nowait() for _ in range(slow.qsize())]
+    assert frames[0]["data"]["type"] == "full"
+    assert [frame["name"] for frame in frames[1:]] == ["a", "b"]
+
+
+def test_registration_and_subscribe_share_one_encoder_sequence_with_peers() -> None:
+    server = WebServer(None)
+    peer: BoundedQueue[dict[str, Any]] = BoundedQueue(maxsize=8)
+    first = server.register_control_event_queue(peer)
+    assert first["type"] == "full"
+    _observe(server, 14_070_000)
+    server._broadcast_state_update(force=True)  # noqa: SLF001
+    peer_base = _event_data(peer)
+    assert peer_base["type"] == "delta"
+
+    newcomer: BoundedQueue[dict[str, Any]] = BoundedQueue(maxsize=8)
+    initial = server.register_control_event_queue(newcomer)
+    peer_update = _event_data(peer)
+    assert initial["type"] == "full"
+    assert peer_update["type"] == "delta"
+    assert initial["transportSeq"] == peer_update["transportSeq"]
+    assert initial["data"] == apply_delta(
+        apply_delta(first["data"], peer_base), peer_update
+    )
+
+    _observe(server, 14_071_000)
+    server._broadcast_state_update(force=True)  # noqa: SLF001
+    peer_delta = _event_data(peer)
+    newcomer_delta = _event_data(newcomer)
+    assert peer_delta == newcomer_delta
+    assert apply_delta(initial["data"], newcomer_delta) == server.build_public_state()
+
+    server.enqueue_control_state_baseline(newcomer)
+    resubscribe = _event_data(newcomer)
+    peer_after_subscribe = _event_data(peer)
+    assert resubscribe["type"] == "full"
+    assert resubscribe["transportSeq"] == peer_after_subscribe["transportSeq"]
+
+
+def test_repeated_overflow_keeps_only_the_latest_recovery_full() -> None:
+    server = WebServer(None)
+    slow: BoundedQueue[dict[str, Any]] = BoundedQueue(maxsize=3)
+    server.register_control_event_queue(slow)
+
+    for freq in range(14_070_000, 14_070_007):
+        _observe(server, freq)
+        server._broadcast_state_update(force=True)  # noqa: SLF001
+
+    states = _state_data(_drain(slow))
+    assert len(states) == 1
+    assert states[0]["type"] == "full"
+    assert states[0]["data"]["main"]["freqHz"] == 14_070_006
+
+
+def test_fast_and_two_independently_slow_clients_share_one_encode() -> None:
+    server = WebServer(None)
+    fast: BoundedQueue[dict[str, Any]] = BoundedQueue(maxsize=8)
+    slow_a: BoundedQueue[dict[str, Any]] = BoundedQueue(maxsize=2)
+    slow_b: BoundedQueue[dict[str, Any]] = BoundedQueue(maxsize=2)
+    server.register_control_event_queue(fast)
+    server.register_control_event_queue(slow_a)
+    server.register_control_event_queue(slow_b)
+    _drain(fast)
+    _drain(slow_a)
+    _drain(slow_b)
+
+    # Fill only the two slow queues with their own ordinary delta chains.
+    for freq in (14_070_000, 14_071_000):
+        _observe(server, freq)
+        server._broadcast_state_update(force=True)  # noqa: SLF001
+        _drain(fast)
+    _observe(server, 14_072_000)
+    server._broadcast_state_update(force=True)  # noqa: SLF001
+
+    fast_update = _event_data(fast)
+    slow_a_update = _event_data(slow_a)
+    slow_b_update = _event_data(slow_b)
+    assert fast_update["type"] == "delta"
+    assert slow_a_update["type"] == slow_b_update["type"] == "full"
+    assert fast_update["transportSeq"] == slow_a_update["transportSeq"]
+    assert fast_update["transportSeq"] == slow_b_update["transportSeq"]
+    for key in (
+        "stateContractVersion",
+        "providerGeneration",
+        "revision",
+        "stateRevision",
+        "freshnessRevision",
+        "observationSeq",
+    ):
+        assert slow_a_update[key] == fast_update[key]
+        assert slow_b_update[key] == fast_update[key]
+    assert slow_a_update["data"] == slow_b_update["data"] == server.build_public_state()
+
+
+def test_inflight_delta_precedes_recovery_full_after_overflow() -> None:
+    server = WebServer(None)
+    slow: BoundedQueue[dict[str, Any]] = BoundedQueue(maxsize=3)
+    direct_baseline = server.register_control_event_queue(slow)
+    _observe(server, 14_070_000)
+    server._broadcast_state_update(force=True)  # noqa: SLF001
+    in_flight = _event_data(slow)
+    assert in_flight["type"] == "delta"
+
+    for freq in (14_071_000, 14_072_000, 14_073_000, 14_074_000):
+        _observe(server, freq)
+        server._broadcast_state_update(force=True)  # noqa: SLF001
+
+    recovery = _event_data(slow)
+    assert recovery["type"] == "full"
+    assert (
+        apply_delta(direct_baseline["data"], in_flight)["main"]["freqHz"] == 14_070_000
+    )
+    assert recovery["data"]["main"]["freqHz"] == 14_074_000
+
+
+def test_provider_generation_full_evicts_all_old_generation_state_frames() -> None:
+    server = WebServer(None)
+    slow: BoundedQueue[dict[str, Any]] = BoundedQueue(maxsize=3)
+    server.register_control_event_queue(slow)
+    old_generation = server.command_state_store.provider_generation
+    for freq in (14_070_000, 14_071_000, 14_072_000):
+        _observe(server, freq)
+        server._broadcast_state_update(force=True)  # noqa: SLF001
+
+    new_generation = server.command_state_store.begin_provider_generation()
+    _observe(server, 7_074_000)
+    server._broadcast_state_update(force=True)  # noqa: SLF001
+
+    states = _state_data(_drain(slow))
+    assert len(states) == 1
+    assert states[0]["type"] == "full"
+    assert states[0]["providerGeneration"] == new_generation
+    assert states[0]["providerGeneration"] != old_generation
+    assert states[0]["data"]["main"]["freqHz"] == 7_074_000
+
+
+def test_handshake_b_to_h_to_d_missing_key_counterexample_converges() -> None:
+    server = WebServer(None)
+    peer: BoundedQueue[dict[str, Any]] = BoundedQueue(maxsize=8)
+    base = server.register_control_event_queue(peer)
+    _observe(server, 14_070_000)  # B -> H changes the key.
+    server._broadcast_state_update(force=True)  # noqa: SLF001
+    peer_h = _event_data(peer)
+    newcomer: BoundedQueue[dict[str, Any]] = BoundedQueue(maxsize=8)
+    newcomer_h = server.register_control_event_queue(newcomer)
+    peer_handshake = _event_data(peer)
+    _observe(server, 0)  # H -> D returns the changed key to B's value.
+    server._broadcast_state_update(force=True)  # noqa: SLF001
+    peer_d = _event_data(peer)
+    newcomer_d = _event_data(newcomer)
+
+    peer_state = apply_delta(apply_delta(base["data"], peer_h), peer_handshake)
+    assert peer_state == newcomer_h["data"]
+    assert apply_delta(peer_state, peer_d) == apply_delta(
+        newcomer_h["data"], newcomer_d
+    )
+    assert apply_delta(newcomer_h["data"], newcomer_d) == server.build_public_state()
+
+
+@pytest.mark.asyncio
+async def test_initial_send_cancellation_unregisters_before_liveness() -> None:
+    class CancelInitialSend:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def send_text(self, _payload: str) -> None:
+            self.calls += 1
+            if self.calls == 2:
+                raise asyncio.CancelledError
+
+        async def recv(self) -> tuple[int, bytes]:
+            raise AssertionError(
+                "receive loop must not start after initial-send cancellation"
+            )
+
+    server = WebServer(None)
+    handler = ControlHandler(
+        CancelInitialSend(),
+        None,
+        "test",
+        "IC-TEST",
+        server=server,
+    )
+    with pytest.raises(asyncio.CancelledError):
+        await handler.run()
+
+    assert handler._event_queue not in server._control_event_queues  # noqa: SLF001
+    assert server.command_queue._live_sessions is None  # noqa: SLF001
+
+
+def test_registration_encode_failure_is_transactional() -> None:
+    server = WebServer(None)
+    queue: BoundedQueue[dict[str, Any]] = BoundedQueue(maxsize=3)
+
+    def fail() -> tuple[object, dict[str, Any]]:
+        raise RuntimeError("generation churn")
+
+    server._build_public_state_for_delivery = fail  # type: ignore[method-assign]
+    with pytest.raises(RuntimeError, match="generation churn"):
+        server.register_control_event_queue(queue)
+    assert queue not in server._control_event_queues  # noqa: SLF001
+
+
+def test_disconnect_reconnect_has_no_recovery_structure_and_new_full() -> None:
+    server = WebServer(None)
+    old: BoundedQueue[dict[str, Any]] = BoundedQueue(maxsize=2)
+    server.register_control_event_queue(old)
+    _observe(server, 14_070_000)
+    server._broadcast_state_update(force=True)  # noqa: SLF001
+    _observe(server, 14_071_000)
+    server._broadcast_state_update(force=True)  # noqa: SLF001
+    server.unregister_control_event_queue(old)
+
+    new: BoundedQueue[dict[str, Any]] = BoundedQueue(maxsize=2)
+    baseline = server.register_control_event_queue(new)
+    assert old not in server._control_event_queues  # noqa: SLF001
+    assert new in server._control_event_queues  # noqa: SLF001
+    assert baseline["type"] == "full"
+    assert baseline["data"] == server.build_public_state()
+    assert not any("recovery" in name for name in vars(server))
+
+
+@pytest.mark.asyncio
+async def test_subscribe_queues_full_then_dx_and_future_delta_converges() -> None:
+    class Ws:
+        async def send_text(self, _payload: str) -> None:
+            raise AssertionError(
+                "subscribe must not direct-send beside the sender loop"
+            )
+
+    server = WebServer(None)
+    peer: BoundedQueue[dict[str, Any]] = BoundedQueue(maxsize=8)
+    peer_base = server.register_control_event_queue(peer)
+    handler = ControlHandler(Ws(), None, "test", "IC-TEST", server=server)
+    server.register_control_event_queue(handler._event_queue)  # noqa: SLF001
+    peer_on_join = _event_data(peer)
+    server._spot_buffer = SimpleNamespace(get_spots=lambda: [{"call": "K1ABC"}])  # type: ignore[assignment]  # noqa: SLF001
+
+    _observe(server, 14_070_000)
+    server._broadcast_state_update(force=True)  # noqa: SLF001
+    peer_h = _event_data(peer)
+    await handler._send_state_snapshot()  # noqa: SLF001
+
+    queued = _drain(handler._event_queue)  # noqa: SLF001
+    assert queued[0]["type"] == "state_update"
+    assert queued[0]["data"]["type"] == "full"
+    assert queued[1] == {"type": "dx_spots", "spots": [{"call": "K1ABC"}]}
+    peer_subscribe = _event_data(peer)
+    assert queued[0]["data"]["transportSeq"] == peer_subscribe["transportSeq"]
+
+    _observe(server, 14_071_000)
+    server._broadcast_state_update(force=True)  # noqa: SLF001
+    peer_d = _event_data(peer)
+    handler_d = _event_data(handler._event_queue)  # noqa: SLF001
+    peer_h_state = apply_delta(apply_delta(peer_base["data"], peer_on_join), peer_h)
+    assert apply_delta(peer_h_state, peer_subscribe) == queued[0]["data"]["data"]
+    assert peer_d == handler_d
+    assert (
+        apply_delta(queued[0]["data"]["data"], handler_d) == server.build_public_state()
+    )

--- a/tests/test_state_pipeline_contracts.py
+++ b/tests/test_state_pipeline_contracts.py
@@ -858,13 +858,12 @@ async def test_web_delivery_payloads_use_snapshot_not_legacy_state_or_revision()
     _assert_delivered_from_snapshot(envelope["data"], snapshot)
 
     queue: BoundedQueue[dict[str, Any]] = BoundedQueue(maxsize=16)
-    server.register_control_event_queue(queue)
+    registration_full = server.register_control_event_queue(queue)
+    assert registration_full["type"] == "full"
+    _assert_delivered_from_snapshot(registration_full["data"], snapshot)
     server._last_state_broadcast = 0.0  # noqa: SLF001
     server._broadcast_state_update()  # noqa: SLF001
-    broadcast = queue.get_nowait()
-    assert broadcast["type"] == "state_update"
-    assert broadcast["data"]["type"] == "full"
-    _assert_delivered_from_snapshot(broadcast["data"]["data"], snapshot)
+    assert queue.empty()
 
     writer = _FakeWriter()
     await server._serve_state(writer)  # noqa: SLF001
@@ -878,12 +877,16 @@ async def test_web_delivery_payloads_use_snapshot_not_legacy_state_or_revision()
     assert after_delivery.as_dict() == snapshot.as_dict()
 
 
-def test_web_state_change_callback_broadcasts_snapshot_without_revision_path() -> None:
+def test_web_state_change_callback_forwards_without_fabricating_store_delivery() -> (
+    None
+):
     server, _ = _server_with_conflicting_legacy_state()
     server._snapshot_for_delivery()  # noqa: SLF001
     snapshot = server.command_state_store.snapshot()
     queue: BoundedQueue[dict[str, Any]] = BoundedQueue(maxsize=16)
-    server.register_control_event_queue(queue)
+    registration_full = server.register_control_event_queue(queue)
+    assert registration_full["type"] == "full"
+    _assert_delivered_from_snapshot(registration_full["data"], snapshot)
 
     server._on_radio_state_change(  # noqa: SLF001
         "legacy_radio_state_changed",
@@ -891,15 +894,12 @@ def test_web_state_change_callback_broadcasts_snapshot_without_revision_path() -
     )
 
     forwarded = queue.get_nowait()
-    broadcast = queue.get_nowait()
     assert forwarded == {
         "type": "event",
         "name": "legacy_radio_state_changed",
         "data": {"revision": _LEGACY_POLLER_REVISION, "freq": 14_250_000},
     }
-    assert broadcast["type"] == "state_update"
-    assert broadcast["data"]["type"] == "full"
-    _assert_delivered_from_snapshot(broadcast["data"]["data"], snapshot)
+    assert queue.empty()
     assert not any(
         item.kind == "revision_producing_event"
         for item in server.state_diagnostics.events()

--- a/tests/test_state_pipeline_diagnostics.py
+++ b/tests/test_state_pipeline_diagnostics.py
@@ -16,6 +16,7 @@ from rigplane.core.state_diagnostics import StateDiagnosticsRecorder
 from rigplane.radio_state import RadioState
 from rigplane.runtime._civ_rx import CivRuntime
 from rigplane.types import CivFrame
+from rigplane.web._delta_encoder import apply_delta
 from rigplane.web.server import WebConfig, WebServer
 
 
@@ -97,7 +98,8 @@ def test_web_meter_write_delivers_state_store_revision_without_unrelated_trigger
 ):
     server = WebServer(config=WebConfig(state_diagnostics=True))
     queue: BoundedQueue[dict[str, Any]] = BoundedQueue(maxsize=8)
-    server.register_control_event_queue(queue)
+    registration_full = server.register_control_event_queue(queue)
+    assert registration_full["type"] == "full"
 
     server.command_state_store.apply(
         Observation(
@@ -127,10 +129,14 @@ def test_web_meter_write_delivers_state_store_revision_without_unrelated_trigger
 
     queued = queue.get_nowait()
     assert queued["type"] == "state_update"
-    assert queued["data"]["type"] == "full"
-    assert queued["data"]["stateRevision"] == snapshot.state_revision
-    assert queued["data"]["freshnessRevision"] == snapshot.freshness_revision
-    assert queued["data"]["data"]["main"]["sMeter"] == 42
+    delta = queued["data"]
+    assert delta["type"] == "delta"
+    assert delta["stateRevision"] == snapshot.state_revision
+    assert delta["freshnessRevision"] == snapshot.freshness_revision
+    assert delta["observationSeq"] == snapshot.observation_seq
+    assert delta["changed"]["main"]["sMeter"] == 42
+    assert delta["changed"]["fieldStatus"]["main.sMeter"]["observed"] is True
+    assert apply_delta(registration_full["data"], delta) == payload
     assert queue.empty()
     assert server.state_diagnostics.snapshot()["counts"] == {
         "direct_state_write": 1,

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -549,13 +549,8 @@ def test_ws_client_lifecycle_delta_includes_public_state_sequence() -> None:
     srv = WebServer(None)
     observer: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=8)
     peer: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=8)
-    srv.register_control_event_queue(observer)
-
-    srv._broadcast_state_update(force=True)  # noqa: SLF001
-    first = observer.get_nowait()
-    assert first["type"] == "state_update"
-    first_envelope = first["data"]
-    assert isinstance(first_envelope, dict)
+    first_envelope = srv.register_control_event_queue(observer)
+    assert first_envelope["type"] == "full"
     initial = first_envelope["data"]
     assert isinstance(initial, dict)
 
@@ -1883,8 +1878,8 @@ async def test_http_snapshot_matches_initial_ws_full_state_for_same_store_revisi
     handler = ControlHandler(ws, None, "0.0.0-test", "IC-TEST", server=srv)
     await handler._send_state_snapshot()  # noqa: SLF001
 
-    assert sent[0]["type"] == "state_update"
-    ws_body = sent[0]["data"]["data"]  # type: ignore[index]
+    assert sent == []
+    ws_body = handler._event_queue.get_nowait()["data"]["data"]  # noqa: SLF001
     assert ws_body == http_body
     assert http_body["fieldStatus"] == ws_body["fieldStatus"]
     assert http_body["fieldStatus"]["main.freqHz"]["observed"] is True
@@ -1946,7 +1941,8 @@ async def test_same_value_observation_metadata_updates_http_and_initial_ws_full_
     handler = ControlHandler(ws, None, "0.0.0-test", "IC-TEST", server=srv)
     await handler._send_state_snapshot()  # noqa: SLF001
 
-    ws_body = sent[0]["data"]["data"]  # type: ignore[index]
+    assert sent == []
+    ws_body = handler._event_queue.get_nowait()["data"]["data"]  # noqa: SLF001
     assert ws_body == http_body
     field_status = http_body["fieldStatus"]["main.freqHz"]
     assert field_status["lastObservedMonotonic"] == 2.0
@@ -2191,12 +2187,20 @@ def test_initial_full_state_envelope_does_not_consume_broadcast_delta() -> None:
     assert initial["type"] == "full"
     assert initial["data"]["ptt"] is True
 
+    srv.command_state_store.apply(
+        _store_observation(
+            FieldPath.global_("tx_state", "ptt"),
+            False,
+            at=1.2,
+        )
+    )
+
     srv._last_state_broadcast = 0.0  # noqa: SLF001
     srv._broadcast_state_update()  # noqa: SLF001
     event = q.get_nowait()
 
     assert event["data"]["type"] == "delta"
-    assert event["data"]["changed"]["ptt"] is True
+    assert event["data"]["changed"]["ptt"] is False
     assert (
         event["data"]["stateRevision"]
         == srv.command_state_store.snapshot().state_revision
@@ -2379,7 +2383,8 @@ async def test_continuous_lifecycle_generation_churn_fails_closed_without_state_
     srv = WebServer(None)
     srv.command_state_store = _GenerationAdvanceEveryApplyStore()
     queue: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=2)
-    srv.register_control_event_queue(queue)
+    with pytest.raises(RuntimeError, match="lifecycle ensure"):
+        srv.register_control_event_queue(queue)
 
     with pytest.raises(RuntimeError, match="lifecycle ensure"):
         srv.build_public_state()
@@ -2529,11 +2534,8 @@ def test_broadcast_state_update_refreshes_live_connection_payload_without_revisi
     radio = _LiveConnectionRadio()
     srv = WebServer(radio)
     q: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=16)
-    srv.register_control_event_queue(q)
-
-    srv._broadcast_state_update()  # noqa: SLF001
-    first = q.get_nowait()
-    initial = first["data"]["data"]
+    first = srv.register_control_event_queue(q)
+    initial = first["data"]
 
     radio.control_connected = True
 


### PR DESCRIPTION
Closes #2316\n\nImplements MOR-1408 C per-client fail-full delivery: one shared encoder, transactional direct baselines, per-queue state coalescing, and adversarial coverage. Full suite: 9186 passed, 129 skipped, 5 deselected, 11 xfailed, 1 xpassed.