### PR TITLE
fix(#2317): separate Web command results from radio truth

### DIFF
--- a/frontend/src/__tests__/architecture-boundaries.test.ts
+++ b/frontend/src/__tests__/architecture-boundaries.test.ts
@@ -14,10 +14,24 @@
  */
 import { describe, it, expect } from 'vitest';
 import { ESLint } from 'eslint';
+import { readFileSync, readdirSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 
 const FRONTEND_ROOT = path.resolve(fileURLToPath(import.meta.url), '../../..');
+
+function productionSources(root: string): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    const absolute = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name !== '__tests__') files.push(...productionSources(absolute));
+    } else if (/\.(?:svelte|ts)$/.test(entry.name) && !/\.test\./.test(entry.name)) {
+      files.push(absolute);
+    }
+  }
+  return files;
+}
 
 /**
  * Counts import-boundary violations under EITHER rule id. The adapters zone
@@ -52,6 +66,20 @@ async function authorityRuleIds(code: string, filePath: string): Promise<string[
 }
 
 describe('v3 package boundaries (MOR-1061)', () => {
+  it('keeps accepted capability installation owned only by the WS reducer', () => {
+    const runtimeSource = readFileSync(
+      path.join(FRONTEND_ROOT, 'src/lib/runtime/frontend-runtime.ts'),
+      'utf8',
+    );
+    expect(runtimeSource).not.toMatch(/\b(?:fetchCapabilities|setCapabilities)\s*\(/);
+
+    const storePath = path.join(FRONTEND_ROOT, 'src/lib/stores/capabilities.svelte.ts');
+    const callers = productionSources(path.join(FRONTEND_ROOT, 'src'))
+      .filter((file) => file !== storePath)
+      .filter((file) => /\b(?:setCapabilities|clearCapabilities)\s*\(/.test(readFileSync(file, 'utf8')))
+      .map((file) => path.relative(FRONTEND_ROOT, file));
+    expect(callers).toEqual(['src/lib/transport/ws-client.ts']);
+  });
   it('rejects semantic importing skins', async () => {
     const hits = await restrictedImportHits(
       `import LcdSkin from '../skins/amber-lcd/LcdSkin.svelte';`,

--- a/frontend/src/__tests__/presentation-switch-resources.component.test.ts
+++ b/frontend/src/__tests__/presentation-switch-resources.component.test.ts
@@ -21,8 +21,8 @@
  *
  * Pinned here:
  *   1. a desktop → LCD → SDR → mobile → desktop sweep opens the control
- *      socket once, fetches capabilities once, subscribes once, and never
- *      restarts RX audio — with the same AudioManager instance throughout;
+ *      socket once, consumes one accepted capability-store subscription, and
+ *      never restarts RX audio — with the same AudioManager throughout;
  *   2. between two presentations that BOTH demand a resource, the channel is
  *      never disconnected and the driver handle is the identical object;
  *   3. switching to a presentation that genuinely has no viewer for a
@@ -40,6 +40,7 @@ import type { SkinId } from '../skins/registry';
 
 type Pending = { id: SkinId; resolve: (component: unknown) => void };
 type FakeChannel = ReturnType<typeof makeChannel>;
+type CapabilityListener = (caps: unknown | null) => void;
 
 const h = vi.hoisted(() => ({
   pending: [] as Pending[],
@@ -49,6 +50,11 @@ const h = vi.hoisted(() => ({
   provide: vi.fn(),
   txHost: undefined as { refreshAuthority: () => void; dispose: () => void } | undefined,
   notifyCaps: () => {},
+  emitAcceptedCapabilities: (_caps: unknown | null) => {},
+  acceptedCapabilities: null as unknown | null,
+  capabilityListeners: new Set<CapabilityListener>(),
+  subscribeCapabilities: vi.fn(),
+  unsubscribeCapabilities: vi.fn(),
 }));
 
 // ── Bottom boundary only: transport, HTTP, audio, scope channels ──
@@ -93,9 +99,30 @@ vi.mock('$lib/stores/capabilities.svelte', async () => {
   let update = () => {};
   const subscribe = createSubscriber((notify) => { update = notify; return () => {}; });
   h.notifyCaps = () => update();
+  h.emitAcceptedCapabilities = (caps: unknown | null) => {
+    h.acceptedCapabilities = caps;
+    update();
+    for (const listener of h.capabilityListeners) listener(caps);
+  };
+  h.subscribeCapabilities.mockImplementation((listener: CapabilityListener) => {
+    h.capabilityListeners.add(listener);
+    listener(h.acceptedCapabilities);
+    let active = true;
+    return () => {
+      if (!active) return;
+      active = false;
+      h.capabilityListeners.delete(listener);
+      h.unsubscribeCapabilities();
+    };
+  });
   return {
-    getCapabilities: vi.fn(() => { subscribe(); return null; }),
-    setCapabilities: vi.fn(),
+    getCapabilities: vi.fn(() => { subscribe(); return h.acceptedCapabilities; }),
+    setCapabilities: vi.fn((caps: unknown) => {
+      h.emitAcceptedCapabilities(caps);
+      return true;
+    }),
+    clearCapabilities: vi.fn(() => { h.emitAcceptedCapabilities(null); }),
+    subscribeCapabilities: h.subscribeCapabilities,
     hasSpectrum: vi.fn(() => false),
     hasAnyScope: vi.fn(() => false),
   };
@@ -207,6 +234,8 @@ const caps = {
   audioFftAvailable: true,
   capabilities: ['audio', 'scope'],
   scopeSource: 'hardware',
+  stateContractVersion: 1,
+  providerGeneration: 0,
 } as never;
 
 /** A scope WS channel whose connect/disconnect are the open/close counters. */
@@ -254,6 +283,7 @@ function resetAppSession(): void {
   const rt = runtime as unknown as Record<string, unknown>;
   rt._bootstrapCleanup = null;
   rt._bootstrapInFlight = null;
+  rt._capabilitiesUnsubscribe = null;
   rt._rxAudioLease = null;
   rt._ended = false;
   (rt._dxSubscribers as Map<unknown, unknown>).clear();
@@ -350,12 +380,13 @@ describe('MOR-1086 — resource identity across a presentation switch', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     h.pending.length = 0;
+    h.capabilityListeners.clear();
+    h.acceptedCapabilities = caps;
     document.body.innerHTML = '';
     Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1200 });
     Object.defineProperty(window, 'innerHeight', { configurable: true, value: 800 });
     channels = { scope: makeChannel('scope'), 'audio-scope': makeChannel('audio-scope') };
     vi.mocked(getChannel).mockImplementation((name: string) => channels[name] as never);
-    vi.mocked(fetchCapabilities).mockResolvedValue(caps);
     vi.mocked(startPolling).mockReturnValue(vi.fn());
     h.loadSkin.mockImplementation(
       (id: SkinId) => new Promise((resolve) => { h.pending.push({ id, resolve }); }),
@@ -391,8 +422,8 @@ describe('MOR-1086 — resource identity across a presentation switch', () => {
 
   // MUTATION KILLED: routing a presentation switch through anything that
   // re-runs bootstrap (re-mounting App per skin, tearing the runtime down on
-  // swap). Each hop would re-open the control socket, re-fetch capabilities,
-  // re-send the events subscription and restart RX audio.
+  // swap). Each hop would re-open the control socket, re-subscribe to accepted
+  // capabilities, re-send the events subscription and restart RX audio.
   it('sweeps every presentation family without touching the control socket or RX audio', async () => {
     await mountApp();
     runtime.setRxLive(true);          // the operator is listening
@@ -416,8 +447,9 @@ describe('MOR-1086 — resource identity across a presentation switch', () => {
     }
     expect(document.querySelector('.spectrum-panel-stub')).toBe(globalHost);
 
-    // Control plane: opened once, described once, subscribed once.
-    expect(fetchCapabilities).toHaveBeenCalledTimes(1);
+    // Control plane: opened once and follows the accepted capability store.
+    expect(fetchCapabilities).not.toHaveBeenCalled();
+    expect(h.subscribeCapabilities).toHaveBeenCalledTimes(1);
     expect(connect).toHaveBeenCalledTimes(1);
     expect(sendRaw).toHaveBeenCalledTimes(1);
     expect(startPolling).toHaveBeenCalledTimes(1);
@@ -524,7 +556,8 @@ describe('MOR-1086 — resource identity across a presentation switch', () => {
     expect(audioManager.stopRx).not.toHaveBeenCalled();
     // The control plane never noticed the churn either.
     expect(connect).toHaveBeenCalledTimes(1);
-    expect(fetchCapabilities).toHaveBeenCalledTimes(1);
+    expect(fetchCapabilities).not.toHaveBeenCalled();
+    expect(h.subscribeCapabilities).toHaveBeenCalledTimes(1);
     expect(sendRaw).toHaveBeenCalledTimes(1);
   });
 
@@ -546,6 +579,7 @@ describe('MOR-1086 — resource identity across a presentation switch', () => {
     expect(closes('scope')).toBe(1);
     expect(closes('audio-scope')).toBe(1);
     expect(audioManager.stopRx).toHaveBeenCalledTimes(1);
+    expect(h.unsubscribeCapabilities).toHaveBeenCalledTimes(1);
     expect(presentationResources.snapshot('hardware-scope')).toMatchObject({
       demand: 0, health: 'inactive', activeHandle: undefined,
     });

--- a/frontend/src/components-v2/panels/lcd/__tests__/audio-fft-demand.isolated.test.ts
+++ b/frontend/src/components-v2/panels/lcd/__tests__/audio-fft-demand.isolated.test.ts
@@ -113,7 +113,6 @@ describe('LCD audio-FFT demand ownership', () => {
   it('boots canonical authority and shares only the two mounted panel leases', async () => {
     vi.resetModules();
     vi.clearAllMocks();
-    mocks.fetchCapabilities.mockResolvedValue(canonicalCapabilities);
     mocks.startPolling.mockReturnValue(mocks.stopPolling);
     vi.stubGlobal('ResizeObserver', class {
       observe() {}
@@ -125,6 +124,7 @@ describe('LCD audio-FFT demand ownership', () => {
     const { default: AmberScope } = await import('../AmberScope.svelte');
     const { presentationResources, runtime } = await import('$lib/runtime/frontend-runtime');
     const { setRadioState } = await import('$lib/stores/radio.svelte');
+    const { clearCapabilities, setCapabilities } = await import('$lib/stores/capabilities.svelte');
     const configure = vi.spyOn(presentationResources, 'configure');
     const acquire = vi.spyOn(presentationResources, 'acquire');
     const release = vi.spyOn(presentationResources, 'release');
@@ -140,21 +140,37 @@ describe('LCD audio-FFT demand ownership', () => {
       expect(mocks.getChannel).not.toHaveBeenCalled();
 
       cleanup = await runtime.bootstrap();
-      runtime.scope.registerPresentationDriver(
-        presentationResources,
-        { available: true, selected: true },
-      );
+      expect(mocks.fetchCapabilities).not.toHaveBeenCalled();
+      expect(presentationResources.snapshot('hardware-scope')).toMatchObject({
+        available: false, selected: false, demand: 0, health: 'inactive',
+      });
+      expect(presentationResources.snapshot('audio-fft')).toMatchObject({
+        available: false, selected: false, demand: 0, health: 'inactive',
+      });
+      expect(presentationResources.snapshot('rx-audio')).toMatchObject({
+        available: false, selected: true, demand: 0, health: 'inactive',
+      });
+      expect(mocks.getChannel).not.toHaveBeenCalled();
+      expect(mocks.sendCommand).not.toHaveBeenCalled();
+
+      expect(setCapabilities(canonicalCapabilities)).toBe(true);
       const audioConfigurations = configure.mock.calls.filter(
         ([resource]) => resource === 'audio-fft',
       );
-      expect(audioConfigurations).toHaveLength(1);
+      expect(audioConfigurations).toHaveLength(2);
       expect(audioConfigurations[0]?.[1]).toMatchObject({
+        available: false, selected: false,
+      });
+      expect(audioConfigurations[1]?.[1]).toMatchObject({
         available: true, selected: true,
       });
       expect(presentationResources.snapshot('hardware-scope')).toMatchObject({
         available: true, selected: true, demand: 0, health: 'inactive',
       });
       expect(presentationResources.snapshot('audio-fft')).toMatchObject({
+        available: true, selected: true, demand: 0, health: 'inactive',
+      });
+      expect(presentationResources.snapshot('rx-audio')).toMatchObject({
         available: true, selected: true, demand: 0, health: 'inactive',
       });
       if (hasDefaultScopeStatus(runtime)) {
@@ -199,7 +215,7 @@ describe('LCD audio-FFT demand ownership', () => {
       await Promise.resolve();
       expect(acquire).toHaveBeenCalledTimes(2);
       expect(release).not.toHaveBeenCalled();
-      expect(configure.mock.calls.filter(([resource]) => resource === 'audio-fft')).toHaveLength(1);
+      expect(configure.mock.calls.filter(([resource]) => resource === 'audio-fft')).toHaveLength(2);
       expect(mocks.getChannel).toHaveBeenCalledTimes(1);
       expect(mocks.channel.connect).toHaveBeenCalledTimes(1);
       expect(mocks.sendCommand).not.toHaveBeenCalled();
@@ -220,12 +236,16 @@ describe('LCD audio-FFT demand ownership', () => {
       expect(release).toHaveBeenCalledTimes(2);
 
       await cleanup();
+      const configureCountAfterCleanup = configure.mock.calls.length;
+      clearCapabilities();
+      expect(configure).toHaveBeenCalledTimes(configureCountAfterCleanup);
       await cleanup();
       expect(mocks.stopPolling).toHaveBeenCalledTimes(1);
     } finally {
       if (cockpit) await unmount(cockpit);
       if (scope) await unmount(scope);
       if (cleanup) await cleanup();
+      clearCapabilities();
       for (const target of targets) target.remove();
       vi.doUnmock('$lib/transport/http-client');
       vi.doUnmock('$lib/transport/ws-client');

--- a/frontend/src/lib/runtime/__tests__/frontend-runtime.isolated.test.ts
+++ b/frontend/src/lib/runtime/__tests__/frontend-runtime.isolated.test.ts
@@ -35,6 +35,7 @@ vi.mock('$lib/transport/ws-client', () => ({
 vi.mock('$lib/stores/capabilities.svelte', () => ({
   getCapabilities: vi.fn(() => null),
   setCapabilities: vi.fn(),
+  subscribeCapabilities: vi.fn(),
   hasSpectrum: vi.fn(() => false),
   hasAnyScope: vi.fn(() => false),
 }));
@@ -110,7 +111,7 @@ vi.mock('./system-controller', async () => {
 
 import { fetchCapabilities, startPolling } from '$lib/transport/http-client';
 import { connect, getChannel, onMessage, sendRaw } from '$lib/transport/ws-client';
-import { setCapabilities } from '$lib/stores/capabilities.svelte';
+import { setCapabilities, subscribeCapabilities } from '$lib/stores/capabilities.svelte';
 import { setRadioState } from '$lib/stores/radio.svelte';
 import { audioManager } from '$lib/audio/audio-manager';
 import { systemController } from '../system-controller';
@@ -133,14 +134,17 @@ async function freshRuntime() {
     _ended: boolean;
     _dxSubscribers: Map<number, unknown>;
     _dxControlUnsubscribe: (() => void) | null;
+    _capabilitiesUnsubscribe: (() => void) | null;
   };
   rt._dxControlUnsubscribe?.();
+  rt._capabilitiesUnsubscribe?.();
   rt._dxSubscribers?.clear();
   rt._bootstrapCleanup = null;
   rt._bootstrapInFlight = null;
   rt._rxAudioLease = null;
   rt._ended = false;
   rt._dxControlUnsubscribe = null;
+  rt._capabilitiesUnsubscribe = null;
   return mod.runtime;
 }
 
@@ -155,7 +159,16 @@ const fakeCaps = {
   vfoScheme: 'ab',
   scopeSource: 'audio_fft',
   audioFftAvailable: true,
+  stateContractVersion: 1,
+  providerGeneration: 0,
 } as any;
+
+function configureAcceptedCapabilities(caps: any = fakeCaps): void {
+  (subscribeCapabilities as ReturnType<typeof vi.fn>).mockImplementation((listener) => {
+    listener(caps);
+    return vi.fn();
+  });
+}
 const fakeStopPolling = vi.fn();
 const deferred = <T>() => {
   let resolve!: (value: T) => void;
@@ -270,8 +283,66 @@ describe('PresentationResourceHost', () => {
 describe('FrontendRuntime.bootstrap()', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    (fetchCapabilities as ReturnType<typeof vi.fn>).mockResolvedValue(fakeCaps);
+    configureAcceptedCapabilities();
     (startPolling as ReturnType<typeof vi.fn>).mockReturnValue(fakeStopPolling);
+  });
+
+  it('waits for accepted capability-store generations before configuring resources', async () => {
+    const teardown = vi.spyOn(presentationResources, 'teardown')
+      .mockImplementation(async () => {});
+    const capabilityUnsubscribe = vi.fn();
+    (subscribeCapabilities as ReturnType<typeof vi.fn>).mockImplementation((listener) => {
+      listener(null);
+      return capabilityUnsubscribe;
+    });
+    const rt = await freshRuntime();
+
+    const cleanup = await rt.bootstrap();
+
+    expect(fetchCapabilities).not.toHaveBeenCalled();
+    expect(setCapabilities).not.toHaveBeenCalled();
+    expect(presentationResources.snapshot('hardware-scope')).toMatchObject({
+      available: false, selected: false, demand: 0,
+    });
+    expect(presentationResources.snapshot('audio-fft')).toMatchObject({
+      available: false, selected: false, demand: 0,
+    });
+    expect(presentationResources.snapshot('rx-audio')).toMatchObject({
+      available: false, demand: 0,
+    });
+
+    const listener = (subscribeCapabilities as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0];
+    expect(listener).toEqual(expect.any(Function));
+    listener({
+      ...fakeCaps,
+      stateContractVersion: 1,
+      providerGeneration: 7,
+      scope: true,
+      capabilities: ['audio', 'scope'],
+      scopeSource: 'hardware',
+    });
+    expect(presentationResources.snapshot('hardware-scope')).toMatchObject({
+      available: true, selected: true, demand: 0,
+    });
+    expect(presentationResources.snapshot('audio-fft')).toMatchObject({
+      available: true, selected: true, demand: 0,
+    });
+    expect(presentationResources.snapshot('rx-audio')).toMatchObject({
+      available: true, demand: 0,
+    });
+    expect(audioManager.startRx).not.toHaveBeenCalled();
+    expect(getChannel).not.toHaveBeenCalled();
+
+    listener(null);
+    expect(presentationResources.snapshot('hardware-scope').available).toBe(false);
+    expect(presentationResources.snapshot('audio-fft').available).toBe(false);
+    expect(presentationResources.snapshot('rx-audio').available).toBe(false);
+    expect(audioManager.startRx).not.toHaveBeenCalled();
+    expect(getChannel).not.toHaveBeenCalled();
+
+    await cleanup();
+    expect(capabilityUnsubscribe).toHaveBeenCalledTimes(1);
+    teardown.mockRestore();
   });
 
   it('runs the full bootstrap sequence on the first call', async () => {
@@ -279,12 +350,11 @@ describe('FrontendRuntime.bootstrap()', () => {
 
     const cleanup = await rt.bootstrap();
 
-    // 1. fetchCapabilities called
-    expect(fetchCapabilities).toHaveBeenCalledTimes(1);
+    // 1. Accepted capability-store listener registered; no HTTP capability writer.
+    expect(subscribeCapabilities).toHaveBeenCalledTimes(1);
+    expect(fetchCapabilities).not.toHaveBeenCalled();
     expect(clearLegacyPendingModInputRestore).toHaveBeenCalledTimes(1);
-
-    // 2. capabilities pushed into store
-    expect(setCapabilities).toHaveBeenCalledWith(fakeCaps);
+    expect(setCapabilities).not.toHaveBeenCalled();
 
     // 3. polling started once (initial startPolling call; registerPolling registers
     //    a factory that calls startPolling only when systemController.connect() fires)
@@ -308,7 +378,7 @@ describe('FrontendRuntime.bootstrap()', () => {
     const cleanup2 = await rt.bootstrap();
 
     // Transport functions only invoked once total
-    expect(fetchCapabilities).toHaveBeenCalledTimes(1);
+    expect(subscribeCapabilities).toHaveBeenCalledTimes(1);
     expect(connect).toHaveBeenCalledTimes(1);
     expect(sendRaw).toHaveBeenCalledTimes(1);
 
@@ -345,7 +415,7 @@ describe('FrontendRuntime.bootstrap()', () => {
 
     const second = await rt.bootstrap();
 
-    expect(fetchCapabilities).toHaveBeenCalledTimes(2);
+    expect(subscribeCapabilities).toHaveBeenCalledTimes(2);
     expect(connect).toHaveBeenCalledTimes(2);
     expect(sendRaw).toHaveBeenCalledTimes(2);
     expect(second).not.toBe(cleanup);
@@ -360,17 +430,19 @@ describe('FrontendRuntime.bootstrap()', () => {
     // a third bootstrap silently re-runs the transport chain on a live
     // runtime.
     await cleanup();
-    expect(fetchCapabilities).toHaveBeenCalledTimes(2);
+    expect(subscribeCapabilities).toHaveBeenCalledTimes(2);
     expect(await rt.bootstrap()).toBe(second);
 
     await second();
     teardown.mockRestore();
   });
 
-  it('propagates fetchCapabilities error and allows retry', async () => {
+  it('propagates capability-listener setup error and allows retry', async () => {
     const rt = await freshRuntime();
     const error = new Error('network failure');
-    (fetchCapabilities as ReturnType<typeof vi.fn>).mockRejectedValueOnce(error);
+    (subscribeCapabilities as ReturnType<typeof vi.fn>).mockImplementationOnce(() => {
+      throw error;
+    });
 
     await expect(rt.bootstrap()).rejects.toThrow('network failure');
 
@@ -379,10 +451,10 @@ describe('FrontendRuntime.bootstrap()', () => {
     expect(sendRaw).not.toHaveBeenCalled();
 
     // Runtime is not latched — retry should work
-    (fetchCapabilities as ReturnType<typeof vi.fn>).mockResolvedValue(fakeCaps);
+    configureAcceptedCapabilities();
     const cleanup = await rt.bootstrap();
     expect(typeof cleanup).toBe('function');
-    expect(fetchCapabilities).toHaveBeenCalledTimes(2);
+    expect(subscribeCapabilities).toHaveBeenCalledTimes(2);
   });
 
   it('startPolling callback calls setRadioState with the received state', async () => {
@@ -415,7 +487,7 @@ describe('FrontendRuntime.bootstrap()', () => {
     const [cleanup1, cleanup2] = await Promise.all([rt.bootstrap(), rt.bootstrap()]);
 
     // Each transport function called exactly once, not twice
-    expect(fetchCapabilities).toHaveBeenCalledTimes(1);
+    expect(subscribeCapabilities).toHaveBeenCalledTimes(1);
     expect(startPolling).toHaveBeenCalledTimes(1);
     expect(connect).toHaveBeenCalledTimes(1);
     expect(sendRaw).toHaveBeenCalledTimes(1);
@@ -429,7 +501,7 @@ describe('FrontendRuntime.bootstrap()', () => {
 describe('FrontendRuntime hardware scope and DX facades', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    (fetchCapabilities as ReturnType<typeof vi.fn>).mockResolvedValue(fakeCaps);
+    configureAcceptedCapabilities();
     (startPolling as ReturnType<typeof vi.fn>).mockReturnValue(fakeStopPolling);
   });
 
@@ -466,10 +538,10 @@ describe('FrontendRuntime hardware scope and DX facades', () => {
 describe('FrontendRuntime canonical default scope status', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    configureAcceptedCapabilities();
     (startPolling as ReturnType<typeof vi.fn>).mockReturnValue(fakeStopPolling);
   });
   it('keeps capability-denied hardware inert', async () => {
-    (fetchCapabilities as ReturnType<typeof vi.fn>).mockResolvedValue(fakeCaps);
     const rt = await freshRuntime();
     await rt.bootstrap();
     expect(presentationResources.snapshot('hardware-scope')).toMatchObject({
@@ -481,7 +553,7 @@ describe('FrontendRuntime canonical default scope status', () => {
     (getChannel as ReturnType<typeof vi.fn>).mockImplementation(
       (name) => name === 'scope' ? hardware : audio,
     );
-    (fetchCapabilities as ReturnType<typeof vi.fn>).mockResolvedValue({
+    configureAcceptedCapabilities({
       ...fakeCaps, capabilities: ['audio', 'scope'], scopeSource: 'hardware',
     });
     const rt = await freshRuntime();
@@ -532,7 +604,7 @@ describe('FrontendRuntime canonical default scope status', () => {
   });
   it('publishes the audio default and inert facts without fallback', async () => {
     (getChannel as ReturnType<typeof vi.fn>).mockReturnValue(makeScopeChannel());
-    (fetchCapabilities as ReturnType<typeof vi.fn>).mockResolvedValue({
+    configureAcceptedCapabilities({
       ...fakeCaps, scope: true, capabilities: ['audio', 'scope'], scopeSource: 'audio_fft',
     });
     const rt = await freshRuntime();
@@ -550,7 +622,7 @@ describe('FrontendRuntime canonical default scope status', () => {
     await settle();
     expect(rt.defaultScopeStatus.lifecycle).toBe('failed');
     presentationResources.release(failedLease);
-    (fetchCapabilities as ReturnType<typeof vi.fn>).mockResolvedValue({
+    configureAcceptedCapabilities({
       ...fakeCaps, scope: true, capabilities: ['audio', 'scope'], scopeSource: 'invalid',
       audioFftAvailable: false,
     });
@@ -571,7 +643,7 @@ describe('FrontendRuntime canonical default scope status', () => {
   it('shares, coalesces, and exactly tears down the reactive bridge', async () => {
     const hardware = makeScopeChannel();
     (getChannel as ReturnType<typeof vi.fn>).mockReturnValue(hardware);
-    (fetchCapabilities as ReturnType<typeof vi.fn>).mockResolvedValue({
+    configureAcceptedCapabilities({
       ...fakeCaps, capabilities: ['audio', 'scope'], scopeSource: 'hardware',
     });
     const rt = await freshRuntime();
@@ -585,9 +657,14 @@ describe('FrontendRuntime canonical default scope status', () => {
     expect([hostListeners.size, healthListeners.size]).toEqual([0, 0]);
     const stopFirst = observe(), stopShared = observe();
     expect([hostListeners.size, healthListeners.size]).toEqual([1, 1]);
-    (fetchCapabilities as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('offline'));
+    (subscribeCapabilities as ReturnType<typeof vi.fn>).mockImplementationOnce(() => {
+      throw new Error('offline');
+    });
     await expect(rt.bootstrap()).rejects.toThrow('offline');
     expect([hostListeners.size, healthListeners.size]).toEqual([1, 1]);
+    configureAcceptedCapabilities({
+      ...fakeCaps, capabilities: ['audio', 'scope'], scopeSource: 'hardware',
+    });
     await rt.bootstrap();
     const lease = rt.acquireHardwareScope('viewer');
     await settle();
@@ -613,7 +690,7 @@ describe('FrontendRuntime canonical default scope status', () => {
 describe('FrontendRuntime RX LIVE intent', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    (fetchCapabilities as ReturnType<typeof vi.fn>).mockResolvedValue(fakeCaps);
+    configureAcceptedCapabilities();
     (startPolling as ReturnType<typeof vi.fn>).mockReturnValue(fakeStopPolling);
     presentationResources.retry('rx-audio');
   });
@@ -659,7 +736,7 @@ describe('FrontendRuntime RX LIVE intent', () => {
 
   it('does not start while unavailable or implicitly retry a rejected start', async () => {
     const unavailable = await freshRuntime();
-    (fetchCapabilities as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+    configureAcceptedCapabilities({
       ...fakeCaps,
       audio: false,
       capabilities: [],
@@ -671,6 +748,7 @@ describe('FrontendRuntime RX LIVE intent', () => {
     unavailable.setRxLive(false);
 
     const failed = await freshRuntime();
+    configureAcceptedCapabilities();
     await failed.bootstrap();
     (audioManager.startRx as ReturnType<typeof vi.fn>).mockImplementationOnce(() => {
       throw new Error('offline');
@@ -698,7 +776,7 @@ describe('FrontendRuntime RX LIVE intent', () => {
       onStateChange: vi.fn(() => vi.fn()),
     };
     (getChannel as ReturnType<typeof vi.fn>).mockReturnValue(channel);
-    (fetchCapabilities as ReturnType<typeof vi.fn>).mockResolvedValue({
+    configureAcceptedCapabilities({
       ...fakeCaps,
       scope: true,
       capabilities: ['audio', 'scope'],

--- a/frontend/src/lib/runtime/frontend-runtime.ts
+++ b/frontend/src/lib/runtime/frontend-runtime.ts
@@ -12,7 +12,7 @@
  */
 
 import { radio, getRadioState, patchActiveReceiver, patchRadioState, setRadioState } from '$lib/stores/radio.svelte';
-import { getCapabilities, setCapabilities } from '$lib/stores/capabilities.svelte';
+import { getCapabilities, subscribeCapabilities } from '$lib/stores/capabilities.svelte';
 import {
   getConnectionStatus,
   isConnected,
@@ -26,7 +26,7 @@ import {
 } from '$lib/stores/connection.svelte';
 import { getAudioState, setVolume, setMuted, toggleMute } from '$lib/stores/audio.svelte';
 import { sendCommand, connect, onMessage, sendRaw } from '$lib/transport/ws-client';
-import { fetchCapabilities, startPolling, setPollingMultiplier } from '$lib/transport/http-client';
+import { startPolling, setPollingMultiplier } from '$lib/transport/http-client';
 import { audioManager } from '$lib/audio/audio-manager';
 import { clearLegacyPendingModInputRestore } from './adapters/mod-input-auto.svelte';
 import { derivePresentationCapabilities } from './adapters/presentation-capabilities';
@@ -71,6 +71,7 @@ export interface DefaultScopeStatus {
 class FrontendRuntime {
   private _bootstrapCleanup: (() => void) | null = null;
   private _bootstrapInFlight: Promise<() => void> | null = null;
+  private _capabilitiesUnsubscribe: (() => void) | null = null;
   private _rxAudioLease: ResourceLease | null = null;
   private _ended = false;
   private _dxSubscribers = new Map<number, (message: DxMessage) => void>();
@@ -215,10 +216,44 @@ class FrontendRuntime {
     };
   }
 
+  private _configurePresentationResources(caps: Capabilities | null): void {
+    if (caps === null) {
+      this._defaultScopeSource = null;
+      presentationResources.configure('hardware-scope', {
+        available: false,
+        selected: false,
+      });
+      presentationResources.configure('audio-fft', {
+        available: false,
+        selected: false,
+      });
+      presentationResources.configure('rx-audio', {
+        available: false,
+        selected: true,
+      });
+      return;
+    }
+
+    const presentationCaps = derivePresentationCapabilities(caps);
+    this._defaultScopeSource = presentationCaps.scope.defaultSource;
+    presentationResources.configure('hardware-scope', {
+      available: presentationCaps.scope.hardwareScopeAvailable,
+      selected: presentationCaps.scope.hardwareScopeAvailable,
+    });
+    presentationResources.configure('audio-fft', {
+      available: presentationCaps.scope.audioFftAvailable,
+      selected: presentationCaps.scope.audioFftAvailable,
+    });
+    presentationResources.configure('rx-audio', {
+      available: caps.audio === true && caps.capabilities.includes('audio'),
+      selected: true,
+    });
+  }
+
   // ── Bootstrap ──
 
   /**
-   * Initialize the full transport stack: capabilities → polling → WebSocket → subscribe.
+   * Initialize the full transport stack: capability listener → polling → WebSocket → subscribe.
    *
    * Idempotent: if already started, returns the existing cleanup function without
    * re-running any transport calls. Concurrent callers share a single in-flight promise
@@ -263,22 +298,9 @@ class FrontendRuntime {
     // cached state or issuing any radio command.
     clearLegacyPendingModInputRestore();
 
-    // 1. Fetch capabilities and push into the store.
-    const caps = await fetchCapabilities();
-    setCapabilities(caps);
-    const presentationCaps = derivePresentationCapabilities(caps);
-    this._defaultScopeSource = presentationCaps.scope.defaultSource;
-    presentationResources.configure('hardware-scope', {
-      available: presentationCaps.scope.hardwareScopeAvailable,
-      selected: presentationCaps.scope.hardwareScopeAvailable,
-    });
-    presentationResources.configure('audio-fft', {
-      available: presentationCaps.scope.audioFftAvailable,
-      selected: presentationCaps.scope.audioFftAvailable,
-    });
-    presentationResources.configure('rx-audio', {
-      available: caps.audio === true && caps.capabilities.includes('audio'),
-      selected: true,
+    // 1. Follow only capabilities accepted by the B2 WS epoch gate.
+    this._capabilitiesUnsubscribe = subscribeCapabilities((caps) => {
+      this._configurePresentationResources(caps);
     });
 
     // 2. Register polling lifecycle with SystemController so connect/disconnect works.
@@ -310,11 +332,15 @@ class FrontendRuntime {
       this._dxSubscribers.clear();
       const unsubscribeDx = this._dxControlUnsubscribe;
       this._dxControlUnsubscribe = null;
+      const unsubscribeCapabilities = this._capabilitiesUnsubscribe;
+      this._capabilitiesUnsubscribe = null;
       try { unsubscribeDx?.(); } finally {
-        const stopScopeStatus = this._defaultScopeStop;
-        this._defaultScopeStop = null;
-        try { stopScopeStatus?.(); } finally {
-          try { await presentationResources.teardown(); } finally { stopPolling(); }
+        try { unsubscribeCapabilities?.(); } finally {
+          const stopScopeStatus = this._defaultScopeStop;
+          this._defaultScopeStop = null;
+          try { stopScopeStatus?.(); } finally {
+            try { await presentationResources.teardown(); } finally { stopPolling(); }
+          }
         }
       }
     })();

--- a/frontend/src/lib/stores/__tests__/capabilities.test.ts
+++ b/frontend/src/lib/stores/__tests__/capabilities.test.ts
@@ -69,6 +69,24 @@ describe('capabilities store', () => {
     expect(store.getCapabilities()).toBeNull();
   });
 
+  it('notifies subscribers synchronously for accepted install and clear only while subscribed', () => {
+    const seen: Array<Capabilities | null> = [];
+    const unsubscribe = store.subscribeCapabilities((caps) => { seen.push(caps); });
+    const generation0 = makeCaps({ providerGeneration: 0 });
+    const generation1 = makeCaps({ providerGeneration: 1, model: 'IC-7300' });
+
+    expect(seen).toEqual([null]);
+    expect(store.setCapabilities(generation0)).toBe(true);
+    store.clearCapabilities();
+    expect(store.setCapabilities(generation1)).toBe(true);
+    expect(seen).toEqual([null, generation0, null, generation1]);
+
+    unsubscribe();
+    unsubscribe();
+    store.clearCapabilities();
+    expect(seen).toEqual([null, generation0, null, generation1]);
+  });
+
   describe('hasSpectrum', () => {
     it('returns true when scope is true', () => {
       store.setCapabilities(makeCaps({ scope: true }));

--- a/frontend/src/lib/stores/capabilities.svelte.ts
+++ b/frontend/src/lib/stores/capabilities.svelte.ts
@@ -1,7 +1,9 @@
 import type { Capabilities, ControlRange } from '../types/capabilities';
 
-// Capabilities fetched once from GET /api/v1/capabilities
+// Capabilities accepted from the generation-gated WebSocket full snapshot.
 let capabilities = $state<Capabilities | null>(null);
+type CapabilitiesSubscriber = (caps: Capabilities | null) => void;
+const subscribers = new Set<CapabilitiesSubscriber>();
 
 const STATE_CONTRACT_VERSION = 1;
 
@@ -18,6 +20,16 @@ function hasCurrentEpoch(value: unknown): value is Capabilities {
     && validProviderGeneration(record.providerGeneration);
 }
 
+function notifySubscribers(): void {
+  for (const subscriber of subscribers) {
+    try {
+      subscriber(capabilities);
+    } catch (error) {
+      console.warn('Capability subscriber failed', error);
+    }
+  }
+}
+
 export function getCapabilities(): Capabilities | null {
   return capabilities;
 }
@@ -25,15 +37,30 @@ export function getCapabilities(): Capabilities | null {
 export function setCapabilities(caps: Capabilities): boolean {
   if (!hasCurrentEpoch(caps)) {
     capabilities = null;
+    notifySubscribers();
     return false;
   }
   capabilities = caps;
+  notifySubscribers();
   return true;
 }
 
 /** Clear capability truth whenever the provider epoch is no longer proven. */
 export function clearCapabilities(): void {
   capabilities = null;
+  notifySubscribers();
+}
+
+/** Observe only capability values accepted by the epoch-validating store. */
+export function subscribeCapabilities(subscriber: CapabilitiesSubscriber): () => void {
+  subscribers.add(subscriber);
+  subscriber(capabilities);
+  let active = true;
+  return () => {
+    if (!active) return;
+    active = false;
+    subscribers.delete(subscriber);
+  };
 }
 
 /** True only when capabilities and radio state prove the same provider epoch. */

--- a/frontend/tests/e2e/i18n/i18n-visual.spec.ts
+++ b/frontend/tests/e2e/i18n/i18n-visual.spec.ts
@@ -16,8 +16,9 @@
  *   - `page.route('**\/api/v1/state')`, `capabilities`, `info` return JSON
  *     from `fixtures.ts`.
  *   - The control WebSocket is replaced with a polyfilled class that
- *     auto-opens and exposes a global `__i18nWsDispatch(msg)` hook for
- *     pushing fake `notification` frames (used for the Toast surface).
+ *     auto-opens, emits the canonical registration full, and exposes a global
+ *     `__i18nWsDispatch(msg)` hook for pushing fake `notification` frames
+ *     (used for the Toast surface).
  *
  * Assertion floor (no screenshot diffs are forced — see README):
  *   - Page text MUST NOT contain `[missing:` (lookup-miss marker).
@@ -103,9 +104,27 @@ function locStorageInit(locale: SupportedLocale) {
  * `window.__i18nWsDispatch(msg)` for the test to push `notification`
  * frames into the open control channel.
  */
-const WS_STUB_INIT = `
+function wsStubInit(selectedState: typeof mockState): string {
+  const initialControlFrame = {
+    type: 'state_update',
+    data: {
+      type: 'full',
+      data: selectedState,
+      revision: selectedState.revision,
+      stateRevision: selectedState.stateRevision,
+      freshnessRevision: selectedState.freshnessRevision,
+      healthRevision: selectedState.healthRevision,
+      observationSeq: selectedState.observationSeq,
+      publicStateSeq: selectedState.publicStateSeq,
+      transportSeq: selectedState.transportSeq,
+      stateContractVersion: selectedState.stateContractVersion,
+      providerGeneration: selectedState.providerGeneration,
+    },
+  };
+  return `
   (() => {
     const sockets = [];
+    const initialControlFrame = ${JSON.stringify(initialControlFrame)};
 
     class StubWebSocket extends EventTarget {
       constructor(url) {
@@ -128,6 +147,12 @@ const WS_STUB_INIT = `
           const evt = new Event('open');
           this.dispatchEvent(evt);
           if (typeof this.onopen === 'function') this.onopen(evt);
+          if (new URL(String(this.url), window.location.href).pathname === '/api/v1/ws') {
+            const payload = JSON.stringify(initialControlFrame);
+            const message = new MessageEvent('message', { data: payload });
+            this.dispatchEvent(message);
+            if (typeof this.onmessage === 'function') this.onmessage(message);
+          }
         });
       }
       send(_data) {
@@ -159,6 +184,7 @@ const WS_STUB_INIT = `
     };
   })();
 `;
+}
 
 async function routeMockBackend(page: Page, state = mockState): Promise<void> {
   const json = (route: Route, body: unknown) =>
@@ -207,6 +233,7 @@ async function preparePage(
   viewport: ViewportSpec,
   options: { state?: typeof mockState; workspace?: Record<string, unknown> } = {},
 ): Promise<void> {
+  const selectedState = options.state ?? mockState;
   await page.setViewportSize({ width: viewport.width, height: viewport.height });
   await page.addInitScript(locStorageInit(locale));
   if (options.workspace !== undefined) {
@@ -214,8 +241,8 @@ async function preparePage(
       localStorage.setItem('rigplane:workspace', JSON.stringify(workspace));
     }, options.workspace);
   }
-  await page.addInitScript(WS_STUB_INIT);
-  await routeMockBackend(page, options.state ?? mockState);
+  await page.addInitScript(wsStubInit(selectedState));
+  await routeMockBackend(page, selectedState);
 }
 
 function screenshotPath(

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -421,18 +421,6 @@ class _HttpCommandExecutor:
         raise ValueError(f"unsupported HTTP command intent: {intent.name!r}")
 
 
-# MOR-616: SET command name -> ``global.slow_state.<field>`` for the
-# per-DATA-group MOD-input selector. The optimistic overlay and the poller
-# readback (radio_poller._apply_global_control_observation) must agree on these
-# paths for last-writer-wins reconciliation to work.
-_MOD_INPUT_COMMAND_FIELDS: dict[str, str] = {
-    "set_data_off_mod_input": "data_off_mod_input",
-    "set_data1_mod_input": "data1_mod_input",
-    "set_data2_mod_input": "data2_mod_input",
-    "set_data3_mod_input": "data3_mod_input",
-}
-
-
 @dataclass(slots=True)
 class _SharedControlCommandExecutor:
     server: "WebServer"
@@ -449,90 +437,7 @@ class _SharedControlCommandExecutor:
             source=intent.source,
             command_service=self.server.command_service,
         )
-        # MOR-485: publish an optimistic command-response overlay for set_freq
-        # so the projected snapshot reflects the commanded value immediately
-        # instead of snapping back until the deferred readback lands. Emitted
-        # only on enqueue SUCCESS (a raised enqueue never reaches here, so the
-        # optimistic value is never written for a failed set). The ACTIVE slot
-        # matches the readback emitters in runtime/_civ_rx.py and the projection
-        # in web/runtime_helpers.py.
-        #
-        # MOR-334 regression fix: ``set_mode`` and ``set_data_mode`` had the
-        # identical snap-back defect MOR-485 fixed for freq — the executor
-        # returned an ack with no observation, so the published mode reverted to
-        # the stale store value until the readback (deferred ~2-4.3s by
-        # external_cat_pause=pause_polling, longer than the frontend optimistic
-        # TTL) landed. The same active-slot path keeps later readbacks
-        # reconciling via last-writer-wins (front-panel tracking preserved).
-        observations = self._optimistic_observations(intent)
-        return CommandExecutionResult(details=result, observations=observations)
-
-    def _optimistic_observations(
-        self, intent: CommandIntent
-    ) -> tuple[Observation, ...]:
-        # During an external-CAT session (e.g. WSJT-X via the Hamlib/rigctld
-        # bridge) the external master owns the wire: RigPlane's poller pauses
-        # (radio_poller._run gate) and rigctld get_freq serves the cached store
-        # projection without eliciting a fresh radio readback. An optimistic
-        # command-response overlay published here can therefore never be
-        # reconciled by a readback — it pins a fabricated freq/mode the radio is
-        # not on and the operating-UI display sticks at the command echo for the
-        # whole session. Suppress the overlay so the projection keeps tracking
-        # the radio's real last-known/live value (bridge CI-V readbacks still
-        # land via _civ_rx, and post-session reconcile_state refreshes it).
-        # Normal (non-external-CAT) responsiveness is unchanged: the poller
-        # readback continues to displace the overlay via last-writer-wins.
-        if getattr(self.server._radio, "external_cat_session_active", False) is True:
-            return ()
-        receiver = str(int(intent.params.get("receiver", 0)))
-        session_id = (
-            str(intent.params["session_id"])
-            if intent.params.get("session_id")
-            else None
-        )
-
-        def _observation(path: FieldPath, value: Any) -> Observation:
-            return Observation(
-                path=path,
-                value=value,
-                source=SourceMetadata(
-                    source="command_response",
-                    provider="web_command",
-                    command_source=intent.source,
-                    session_id=session_id,
-                ),
-                timestamp_monotonic=time.monotonic(),
-                correlation_id=intent.id,
-            )
-
-        def _active(name: str, value: Any) -> Observation:
-            return _observation(FieldPath.active(receiver, "freq_mode", name), value)
-
-        if intent.name == "set_freq":
-            return (_active("freq_hz", int(intent.params["freq_hz"])),)
-        if intent.name == "set_mode":
-            return (_active("mode", str(intent.params["mode"])),)
-        if intent.name == "set_data_mode":
-            return (_active("data_mode", int(intent.params["mode"])),)
-        # MOR-616 regression fix: the per-DATA-group MOD-input selector
-        # (set_data_off/1/2/3_mod_input, payload ``{source: int}``) had the same
-        # snap-back defect — the executor returned an ack with no observation, so
-        # the published source reverted to the stale store value until the
-        # deferred readback (radio_poller._fetch_mod_inputs, gated behind
-        # external_cat_pause and a data_mode-change refetch) landed, longer than
-        # the frontend optimistic TTL. The readback writes the confirmed value to
-        # ``global.slow_state.<field>`` via _apply_global_control_observation, so
-        # the overlay must target the SAME path to keep last-writer-wins
-        # reconciliation (front-panel tracking preserved).
-        mod_input_field = _MOD_INPUT_COMMAND_FIELDS.get(intent.name)
-        if mod_input_field is not None:
-            return (
-                _observation(
-                    FieldPath.global_("slow_state", mod_input_field),
-                    int(intent.params["source"]),
-                ),
-            )
-        return ()
+        return CommandExecutionResult(details=result)
 
 
 async def _read_capped_body(
@@ -4680,12 +4585,6 @@ class WebServer:
                         command_id=f"http-power-{time.monotonic_ns()}",
                     )
                 )
-                # Compatibility delivery mirror until web state responses read
-                # power directly from StateStore; command lifecycle and
-                # reconciliation are owned by CommandService.
-                if self._radio_state is not None:
-                    self._radio_state.power_on = is_on
-                self._on_radio_state_change("powerstat_changed", {"power_on": is_on})
                 resp = {"status": "ok", "power": power_state}
             elif path == "/api/v1/radio/cw/send":
                 body_bytes = b""

--- a/tests/test_mor1409_web_authority.py
+++ b/tests/test_mor1409_web_authority.py
@@ -112,7 +112,10 @@ async def test_success_is_lifecycle_only_until_provider_observation(
     assert after_provider.observation_seq == before_snapshot.observation_seq + 1
     assert after_provider.field(path).value == requested
     assert public_value(server.build_public_state()) == requested
-    assert public_value(server.build_state_update_envelope(force_full=True)["data"]) == requested
+    assert (
+        public_value(server.build_state_update_envelope(force_full=True)["data"])
+        == requested
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_mor1409_web_authority.py
+++ b/tests/test_mor1409_web_authority.py
@@ -1,0 +1,159 @@
+"""MOR-1409 A01: command lifecycle must not manufacture radio truth."""
+
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from rigplane.core.command_service import command_intent_from_request
+from rigplane.core.state_pipeline_contracts import (
+    FieldPath,
+    Observation,
+    SourceMetadata,
+)
+from rigplane.web.server import WebConfig, WebServer
+
+
+_CASES = (
+    (
+        "set_freq",
+        {"freq": 14_200_000, "receiver": 0},
+        FieldPath.active("0", "freq_mode", "freq_hz"),
+        14_074_000,
+        14_200_000,
+        lambda state: state["main"]["freqHz"],
+    ),
+    (
+        "set_mode",
+        {"mode": "CW", "receiver": 0},
+        FieldPath.active("0", "freq_mode", "mode"),
+        "USB",
+        "CW",
+        lambda state: state["main"]["mode"],
+    ),
+    (
+        "set_data_mode",
+        {"mode": 1, "receiver": 0},
+        FieldPath.active("0", "freq_mode", "data_mode"),
+        0,
+        1,
+        lambda state: state["main"]["dataMode"],
+    ),
+    (
+        "set_data2_mod_input",
+        {"source": 5},
+        FieldPath.global_("slow_state", "data2_mod_input"),
+        0,
+        5,
+        lambda state: state["data2ModInput"],
+    ),
+)
+
+
+def _observation(path: FieldPath, value: object, generation: int) -> Observation:
+    return Observation(
+        path=path,
+        value=value,
+        source=SourceMetadata(source="poll_response", provider="test_provider"),
+        timestamp_monotonic=time.monotonic(),
+        provider_generation=generation,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("name", "params", "path", "confirmed", "requested", "public_value"),
+    _CASES,
+)
+async def test_success_is_lifecycle_only_until_provider_observation(
+    name: str,
+    params: dict[str, object],
+    path: FieldPath,
+    confirmed: object,
+    requested: object,
+    public_value,
+) -> None:
+    radio = SimpleNamespace(connected=True, capabilities={"data_mode"})
+    server = WebServer(radio, WebConfig())
+    server.command_queue.put = lambda *_args, **_kwargs: None  # type: ignore[method-assign]
+    generation = server.command_state_store.provider_generation
+    server.command_service.apply_observation(_observation(path, confirmed, generation))
+
+    before_public = server.build_public_state()
+    before_ws = server.build_state_update_envelope(force_full=True)["data"]
+    before_snapshot = server.command_state_store.snapshot()
+
+    result = await server.command_service.execute(
+        command_intent_from_request(
+            name,
+            params,
+            source="websocket",
+            command_id=f"a01-{name}",
+        )
+    )
+
+    after_command = server.command_state_store.snapshot()
+    assert result.executor_result.observations == ()
+    assert after_command.state_revision == before_snapshot.state_revision
+    assert after_command.observation_seq == before_snapshot.observation_seq
+    assert after_command.field(path).value == confirmed
+    assert server.build_public_state() == before_public
+    assert server.build_state_update_envelope(force_full=True)["data"] == before_ws
+
+    changes = server.command_service.apply_observation(
+        _observation(path, requested, generation)
+    )
+
+    after_provider = server.command_state_store.snapshot()
+    assert changes.observed_paths == (path,)
+    assert after_provider.state_revision == before_snapshot.state_revision + 1
+    assert after_provider.observation_seq == before_snapshot.observation_seq + 1
+    assert after_provider.field(path).value == requested
+    assert public_value(server.build_public_state()) == requested
+    assert public_value(server.build_state_update_envelope(force_full=True)["data"]) == requested
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("name", "params", "path", "confirmed", "_requested", "_public_value"),
+    _CASES,
+)
+async def test_failed_enqueue_changes_no_radio_truth(
+    name: str,
+    params: dict[str, object],
+    path: FieldPath,
+    confirmed: object,
+    _requested: object,
+    _public_value,
+) -> None:
+    radio = SimpleNamespace(connected=True, capabilities={"data_mode"})
+    server = WebServer(radio, WebConfig())
+    generation = server.command_state_store.provider_generation
+    server.command_service.apply_observation(_observation(path, confirmed, generation))
+
+    def reject(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("enqueue rejected")
+
+    server.command_queue.put = reject  # type: ignore[method-assign]
+    before_public = server.build_public_state()
+    before_ws = server.build_state_update_envelope(force_full=True)["data"]
+    before_snapshot = server.command_state_store.snapshot()
+
+    with pytest.raises(RuntimeError, match="enqueue rejected"):
+        await server.command_service.execute(
+            command_intent_from_request(
+                name,
+                params,
+                source="websocket",
+                command_id=f"a01-failed-{name}",
+            )
+        )
+
+    after = server.command_state_store.snapshot()
+    assert after.state_revision == before_snapshot.state_revision
+    assert after.observation_seq == before_snapshot.observation_seq
+    assert after.field(path).value == confirmed
+    assert server.build_public_state() == before_public
+    assert server.build_state_update_envelope(force_full=True)["data"] == before_ws

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -903,7 +903,7 @@ async def test_http_raw_civ_transaction_enters_command_lifecycle() -> None:
 
 
 @pytest.mark.asyncio
-async def test_http_power_enters_command_service_and_keeps_delivery_mirror() -> None:
+async def test_http_power_is_lifecycle_only_until_provider_observation() -> None:
     radio = SimpleNamespace(
         connected=True,
         control_connected=True,
@@ -911,6 +911,12 @@ async def test_http_power_enters_command_service_and_keeps_delivery_mirror() -> 
         set_powerstat=AsyncMock(),
     )
     srv = WebServer(radio, WebConfig())
+    srv._radio_state.power_on = True  # noqa: SLF001
+    state_change = MagicMock()
+    srv._on_radio_state_change = state_change  # type: ignore[method-assign]
+    before_public = srv.build_public_state()
+    before_ws = srv.build_state_update_envelope(force_full=True)["data"]
+    before_snapshot = srv.command_state_store.snapshot()
     writer = _FakeWriter()
     payload = json.dumps({"state": "off"}).encode()
 
@@ -926,7 +932,13 @@ async def test_http_power_enters_command_service_and_keeps_delivery_mirror() -> 
     assert status == 200
     assert body == {"status": "ok", "power": "off"}
     radio.set_powerstat.assert_awaited_once_with(False)
-    assert srv._radio_state.power_on is False  # noqa: SLF001
+    assert srv._radio_state.power_on is True  # noqa: SLF001
+    state_change.assert_not_called()
+    after_snapshot = srv.command_state_store.snapshot()
+    assert after_snapshot.state_revision == before_snapshot.state_revision
+    assert after_snapshot.observation_seq == before_snapshot.observation_seq
+    assert srv.build_public_state() == before_public
+    assert srv.build_state_update_envelope(force_full=True)["data"] == before_ws
     with pytest.raises(KeyError):
         srv.command_state_store.snapshot().field("global.tx_state.power_on")
 
@@ -1022,12 +1034,7 @@ async def test_http_command_batch_preparation_uses_shared_command_service(
 
 
 @pytest.mark.asyncio
-async def test_set_freq_publishes_command_overlay_for_main_before_readback() -> None:
-    # MOR-485: a set_freq through the shared (WS) command executor must write
-    # the commanded freq into the command_state_store and projected public
-    # state immediately, with no readback observation applied first. The stored
-    # receiver_id is numeric ("0") to match the readback emitters in
-    # runtime/_civ_rx.py; the projection maps "0" -> main.freqHz.
+async def test_set_freq_success_does_not_publish_main_truth_before_readback() -> None:
     radio = SimpleNamespace(connected=True, capabilities=set())
     srv = WebServer(radio, WebConfig())
     srv.command_queue.put = lambda *a, **k: None  # type: ignore[method-assign]
@@ -1040,17 +1047,14 @@ async def test_set_freq_publishes_command_overlay_for_main_before_readback() -> 
     )
     await srv.command_service.execute(intent)
 
-    snapshot = srv.command_state_store.snapshot()
-    assert (
-        snapshot.field(FieldPath.active("0", "freq_mode", "freq_hz")).value
-        == 14_074_000
-    )
-    assert srv.build_public_state()["main"]["freqHz"] == 14_074_000
+    with pytest.raises(KeyError):
+        srv.command_state_store.snapshot().field(
+            FieldPath.active("0", "freq_mode", "freq_hz")
+        )
 
 
 @pytest.mark.asyncio
-async def test_set_freq_publishes_command_overlay_for_sub_before_readback() -> None:
-    # MOR-485: receiver 1 must project to the sub slot / sub.freqHz.
+async def test_set_freq_success_does_not_publish_sub_truth_before_readback() -> None:
     radio = SimpleNamespace(
         connected=True,
         capabilities={"dual_rx"},
@@ -1067,11 +1071,10 @@ async def test_set_freq_publishes_command_overlay_for_sub_before_readback() -> N
     )
     await srv.command_service.execute(intent)
 
-    snapshot = srv.command_state_store.snapshot()
-    assert (
-        snapshot.field(FieldPath.active("1", "freq_mode", "freq_hz")).value == 7_074_000
-    )
-    assert srv.build_public_state()["sub"]["freqHz"] == 7_074_000
+    with pytest.raises(KeyError):
+        srv.command_state_store.snapshot().field(
+            FieldPath.active("1", "freq_mode", "freq_hz")
+        )
 
 
 @pytest.mark.asyncio
@@ -1180,11 +1183,7 @@ async def test_set_freq_optimistic_overlay_suppressed_during_external_cat() -> N
 
 
 @pytest.mark.asyncio
-async def test_set_freq_optimistic_overlay_kept_without_external_cat() -> None:
-    # Guard: with NO external-CAT session, the optimistic overlay must still be
-    # planted immediately so a web dial-spin feels instant (the normal poller
-    # readback displaces it later via last-writer-wins). The external-CAT
-    # suppression must not regress normal responsiveness.
+async def test_set_freq_success_never_becomes_truth_without_readback() -> None:
     radio = SimpleNamespace(
         connected=True,
         capabilities=set(),
@@ -1201,9 +1200,10 @@ async def test_set_freq_optimistic_overlay_kept_without_external_cat() -> None:
     )
     await srv.command_service.execute(intent)
 
-    freq_path = FieldPath.active("0", "freq_mode", "freq_hz")
-    assert srv.command_state_store.snapshot().field(freq_path).value == 14_260_000
-    assert srv.build_public_state()["main"]["freqHz"] == 14_260_000
+    with pytest.raises(KeyError):
+        srv.command_state_store.snapshot().field(
+            FieldPath.active("0", "freq_mode", "freq_hz")
+        )
 
 
 @pytest.mark.asyncio
@@ -1234,13 +1234,7 @@ async def test_set_freq_failure_does_not_publish_command_overlay() -> None:
 
 
 @pytest.mark.asyncio
-async def test_set_mode_publishes_command_overlay_before_readback() -> None:
-    # MOR-334 regression (mode reverts ~1s after the user sets it): a set_mode
-    # through the shared (WS) command executor must write the commanded mode
-    # into the command_state_store and projected public state immediately,
-    # mirroring the MOR-485 set_freq fix. Without the optimistic observation the
-    # published mode snapped back to the stale store value until the deferred
-    # readback (delayed by external_cat_pause=pause_polling) landed.
+async def test_set_mode_success_does_not_publish_truth_before_readback() -> None:
     radio = SimpleNamespace(connected=True, capabilities=set())
     srv = WebServer(radio, WebConfig())
     srv.command_queue.put = lambda *a, **k: None  # type: ignore[method-assign]
@@ -1253,9 +1247,10 @@ async def test_set_mode_publishes_command_overlay_before_readback() -> None:
     )
     await srv.command_service.execute(intent)
 
-    mode_path = FieldPath.active("0", "freq_mode", "mode")
-    assert srv.command_state_store.snapshot().field(mode_path).value == "CW"
-    assert srv.build_public_state()["main"]["mode"] == "CW"
+    with pytest.raises(KeyError):
+        srv.command_state_store.snapshot().field(
+            FieldPath.active("0", "freq_mode", "mode")
+        )
 
 
 @pytest.mark.asyncio
@@ -1316,10 +1311,7 @@ async def test_set_mode_failure_does_not_publish_command_overlay() -> None:
 
 
 @pytest.mark.asyncio
-async def test_set_data_mode_publishes_command_overlay_before_readback() -> None:
-    # MOR-334 regression: data_mode (D1/D2/D3) must be published optimistically
-    # just like mode, so the DATA indicator reflects the user's set immediately
-    # instead of reverting until the deferred readback lands.
+async def test_set_data_mode_success_does_not_publish_truth_before_readback() -> None:
     radio = SimpleNamespace(connected=True, capabilities={"data_mode"})
     srv = WebServer(radio, WebConfig())
     srv.command_queue.put = lambda *a, **k: None  # type: ignore[method-assign]
@@ -1332,18 +1324,14 @@ async def test_set_data_mode_publishes_command_overlay_before_readback() -> None
     )
     await srv.command_service.execute(intent)
 
-    data_mode_path = FieldPath.active("0", "freq_mode", "data_mode")
-    assert srv.command_state_store.snapshot().field(data_mode_path).value == 1
-    assert srv.build_public_state()["main"]["dataMode"] == 1
+    with pytest.raises(KeyError):
+        srv.command_state_store.snapshot().field(
+            FieldPath.active("0", "freq_mode", "data_mode")
+        )
 
 
 @pytest.mark.asyncio
-async def test_set_mod_input_publishes_command_overlay_before_readback() -> None:
-    # MOR-616 regression: the MOD-input source selector (set_data*_mod_input)
-    # had the same snap-back defect as freq/mode — the executor returned an ack
-    # with no observation, so the published source reverted to "—"/stale until
-    # the deferred readback landed. The overlay must write the commanded source
-    # to the SAME ``global.slow_state.<field>`` path the poller readback uses.
+async def test_set_mod_input_success_does_not_publish_truth_before_readback() -> None:
     radio = SimpleNamespace(connected=True, capabilities={"data_mode"})
     srv = WebServer(radio, WebConfig())
     srv.command_queue.put = lambda *a, **k: None  # type: ignore[method-assign]
@@ -1356,9 +1344,10 @@ async def test_set_mod_input_publishes_command_overlay_before_readback() -> None
     )
     await srv.command_service.execute(intent)
 
-    mod_path = FieldPath.global_("slow_state", "data2_mod_input")
-    assert srv.command_state_store.snapshot().field(mod_path).value == 5
-    assert srv.build_public_state()["data2ModInput"] == 5
+    with pytest.raises(KeyError):
+        srv.command_state_store.snapshot().field(
+            FieldPath.global_("slow_state", "data2_mod_input")
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Part of #2317

## Summary
- stop treating successful Web frequency, mode, data-mode, and modulation-input commands as radio observations
- remove the HTTP power-state mirror/event while preserving typed command execution and result handling
- make capability-dependent frontend resources follow only the generation-gated accepted capability store
- start hardware scope, audio FFT, and RX audio unavailable until accepted capabilities arrive

## Verification
- focused backend: 119 passed
- focused frontend: 142 passed
- residual resource integration: 8 passed
- full frontend: 6098 passed
- full backend: 9255 passed, 68 skipped, 11 xfailed, 1 xpassed
- frontend check, lint, build; Ruff; import contracts; generated state types; consumer contracts; diff check: passed

## Scope
- 3 production owners, 204 changed production LOC
- no PTT/TX, HTTP polling, radio-store, WS-client, or radio command-path changes
- no hardware actions performed