### PR TITLE
feat(#2317): add typed radio intent lifecycle seam

### DIFF
--- a/frontend/src/lib/runtime/commands/__tests__/radio-intents.isolated.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/radio-intents.isolated.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CommandDeliveryEvent, ControlSessionTransition } from '$lib/transport/ws-client';
+import type { RadioIntent } from '../radio-intents';
+
+const harness = vi.hoisted(() => ({
+  delivery: undefined as ((event: CommandDeliveryEvent) => void) | undefined,
+  transition: undefined as ((event: ControlSessionTransition) => void) | undefined,
+  session: { state: 'connected' as const, epoch: 7 },
+  sendCommand: vi.fn(() => true),
+}));
+
+vi.mock('$lib/transport/ws-client', () => ({
+  getControlSession: vi.fn(() => harness.session),
+  onCommandDelivery: vi.fn((handler: (event: CommandDeliveryEvent) => void) => {
+    harness.delivery = handler;
+    return () => {
+      if (harness.delivery === handler) harness.delivery = undefined;
+    };
+  }),
+  onControlSessionTransition: vi.fn((handler: (event: ControlSessionTransition) => void) => {
+    harness.transition = handler;
+    return () => {
+      if (harness.transition === handler) harness.transition = undefined;
+    };
+  }),
+  sendCommand: harness.sendCommand,
+}));
+
+describe('typed non-PTT radio intents', () => {
+  let intents: typeof import('../radio-intents');
+  let lifecycle: typeof import('$lib/stores/commands.svelte');
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    vi.resetModules();
+    harness.delivery = undefined;
+    harness.transition = undefined;
+    harness.session = { state: 'connected', epoch: 7 };
+    harness.sendCommand.mockReset().mockReturnValue(true);
+    intents = await import('../radio-intents');
+    lifecycle = await import('$lib/stores/commands.svelte');
+  });
+
+  afterEach(() => {
+    lifecycle.resetCommandLifecycle();
+    vi.useRealTimers();
+  });
+
+  it('sends one exact envelope and explicitly bypasses legacy optimistic mutation', () => {
+    const record = intents.dispatchRadioIntent({
+      id: 'freq-1',
+      name: 'set_freq',
+      params: { freq: 14_074_000, receiver: 0 },
+    });
+
+    expect(harness.sendCommand).toHaveBeenCalledTimes(1);
+    expect(harness.sendCommand).toHaveBeenCalledWith(
+      'set_freq',
+      { freq: 14_074_000, receiver: 0 },
+      'freq-1',
+      { optimistic: false },
+    );
+    expect(record).toMatchObject({ id: 'freq-1', originalEpoch: 7, status: 'pending' });
+    expect(lifecycle.getCommandLifecycle('freq-1', 7)?.status).toBe('pending');
+  });
+
+  it('correlates delivery without turning acknowledgement into radio truth', () => {
+    intents.dispatchRadioIntent({ id: 'mode-1', name: 'set_mode', params: { mode: 'CW', receiver: 1 } });
+    harness.delivery?.({
+      commandId: 'mode-1',
+      kind: 'transport-sent',
+      originalEpoch: 7,
+      eventEpoch: 7,
+    });
+    harness.delivery?.({ commandId: 'mode-1', kind: 'ack', originalEpoch: 7, eventEpoch: 7 });
+
+    expect(lifecycle.getCommandLifecycle('mode-1', 7)).toMatchObject({
+      status: 'acknowledged',
+      eventEpoch: 7,
+    });
+    expect(lifecycle.getCommandLifecycle('mode-1', 7)).not.toHaveProperty('confirmedValue');
+  });
+
+  it('isolates error, timeout, cancellation, and stale-session results', () => {
+    intents.dispatchRadioIntent({ id: 'error', name: 'set_vfo', params: { vfo: 'B' } });
+    harness.delivery?.({
+      commandId: 'error',
+      kind: 'response-error',
+      originalEpoch: 7,
+      eventEpoch: 7,
+      error: 'denied',
+    });
+    expect(lifecycle.getCommandLifecycle('error', 7)?.status).toBe('failed');
+
+    intents.dispatchRadioIntent({ id: 'timeout', name: 'set_freq', params: { freq: 1 } });
+    vi.advanceTimersByTime(5_000);
+    expect(lifecycle.getCommandLifecycle('timeout', 7)?.status).toBe('timed-out');
+
+    intents.dispatchRadioIntent({ id: 'provider', name: 'set_filter', params: { filter: 1 } });
+    harness.delivery?.({
+      commandId: 'provider', kind: 'error', originalEpoch: 7, eventEpoch: 7,
+      error: 'provider session replaced', cancelled: true,
+    });
+    expect(lifecycle.getCommandLifecycle('provider', 7)?.status).toBe('cancelled');
+
+    intents.dispatchRadioIntent({ id: 'cancel', name: 'set_filter', params: { filter: 2 } });
+    harness.transition?.({ state: 'disconnected', epoch: 7 });
+    expect(lifecycle.getCommandLifecycle('cancel', 7)?.status).toBe('cancelled');
+    harness.delivery?.({ commandId: 'cancel', kind: 'response-ok', originalEpoch: 7, eventEpoch: 8 });
+    expect(lifecycle.getCommandLifecycle('cancel', 7)?.status).toBe('cancelled');
+  });
+
+  it('makes every PTT spelling unavailable in types and rejects forged runtime input', () => {
+    if (false) {
+      // @ts-expect-error PTT is exclusively owned by the TX controller.
+      intents.dispatchRadioIntent({ name: 'ptt_on', params: {} });
+      // @ts-expect-error PTT is exclusively owned by the TX controller.
+      intents.dispatchRadioIntent({ name: 'ptt_off', params: {} });
+      // @ts-expect-error PTT is exclusively owned by the TX controller.
+      intents.dispatchRadioIntent({ name: 'ptt', params: { state: false } });
+    }
+
+    for (const name of ['ptt', 'ptt_on', 'ptt_off']) {
+      expect(() => intents.dispatchRadioIntent({ name, params: {} } as never)).toThrow(/non-PTT/i);
+    }
+    expect(harness.sendCommand).not.toHaveBeenCalled();
+    expect(lifecycle.getCommandLifecycles()).toHaveLength(0);
+  });
+
+  it('publishes the complete current non-PTT command-name set without a second authority', () => {
+    const rit: RadioIntent = { name: 'set_rit_frequency', params: { freq: 300 } };
+    expect(rit.params).toEqual({ freq: 300 });
+    if (false) {
+      // @ts-expect-error The shipped RIT command uses `freq`, not `value`.
+      const invalidRit: RadioIntent = { name: 'set_rit_frequency', params: { value: 300 } };
+      expect(invalidRit).toBeDefined();
+    }
+    expect(intents.RADIO_INTENT_NAMES).toHaveLength(92);
+    expect(new Set(intents.RADIO_INTENT_NAMES).size).toBe(92);
+    expect(intents.RADIO_INTENT_NAMES).toContain('set_data3_mod_input');
+    expect(intents.RADIO_INTENT_NAMES).not.toContain('ptt');
+    expect(intents.RADIO_INTENT_NAMES).not.toContain('ptt_on');
+    expect(intents.RADIO_INTENT_NAMES).not.toContain('ptt_off');
+  });
+});

--- a/frontend/src/lib/runtime/commands/__tests__/radio-intents.isolated.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/radio-intents.isolated.test.ts
@@ -127,6 +127,39 @@ describe('typed non-PTT radio intents', () => {
     expect(lifecycle.getCommandLifecycles()).toHaveLength(0);
   });
 
+  it('rejects forged malformed known intents before lifecycle or transport', () => {
+    const malformed = [
+      { name: 'set_freq', params: {} },
+      { name: 'set_freq', params: { freq: Number.NaN } },
+      { name: 'set_af_level', params: { level: 10, receiver: 7 } },
+      { name: 'set_vfo', params: { vfo: 'VFOA' } },
+      { name: 'set_mode', params: { mode: 'USB', receiver: 0, unexpected: true } },
+      { name: 'vfo_swap', params: { unexpected: true } },
+      { name: 'set_filter', params: { filter: 2 }, id: '' },
+      { name: 'set_filter', params: { filter: 2 }, id: 7 },
+    ];
+
+    for (const intent of malformed) {
+      expect(() => intents.dispatchRadioIntent(intent as never)).toThrow(/invalid radio intent/i);
+    }
+    expect(harness.sendCommand).not.toHaveBeenCalled();
+    expect(lifecycle.getCommandLifecycles()).toHaveLength(0);
+  });
+
+  it('rejects the 101st pending facade intent before transport', () => {
+    for (let i = 0; i < 100; i += 1) {
+      intents.dispatchRadioIntent({ id: `pending-${i}`, name: 'set_freq', params: { freq: i } });
+    }
+    expect(() => intents.dispatchRadioIntent({
+      id: 'overflow', name: 'set_freq', params: { freq: 101 },
+    })).toThrow(/capacity/i);
+
+    expect(harness.sendCommand).toHaveBeenCalledTimes(100);
+    expect(lifecycle.getCommandLifecycles()).toHaveLength(100);
+    expect(lifecycle.getCommandLifecycle('pending-0', 7)?.status).toBe('pending');
+    expect(lifecycle.getCommandLifecycle('overflow', 7)).toBeUndefined();
+  });
+
   it('publishes the complete current non-PTT command-name set without a second authority', () => {
     const rit: RadioIntent = { name: 'set_rit_frequency', params: { freq: 300 } };
     expect(rit.params).toEqual({ freq: 300 });

--- a/frontend/src/lib/runtime/commands/__tests__/radio-intents.isolated.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/radio-intents.isolated.test.ts
@@ -129,9 +129,19 @@ describe('typed non-PTT radio intents', () => {
 
   it('rejects forged malformed known intents before lifecycle or transport', () => {
     const malformed = [
+      null,
+      [],
       { name: 'set_freq', params: {} },
+      { name: 'set_freq', params: null },
+      { name: 'set_freq', params: [] },
+      { name: 'set_freq', params: { freq: '14074000' } },
       { name: 'set_freq', params: { freq: Number.NaN } },
+      { name: 'set_freq', params: { freq: Number.MAX_SAFE_INTEGER + 1 } },
+      { name: 'set_freq', params: { freq: 1.5 } },
+      { name: 'set_freq', params: { freq: 1 }, unexpected: true },
+      { name: 'set_compressor', params: { on: 1 } },
       { name: 'set_af_level', params: { level: 10, receiver: 7 } },
+      { name: 'set_af_level', params: { level: 10, receiver: '0' } },
       { name: 'set_vfo', params: { vfo: 'VFOA' } },
       { name: 'set_mode', params: { mode: 'USB', receiver: 0, unexpected: true } },
       { name: 'vfo_swap', params: { unexpected: true } },
@@ -144,6 +154,35 @@ describe('typed non-PTT radio intents', () => {
     }
     expect(harness.sendCommand).not.toHaveBeenCalled();
     expect(lifecycle.getCommandLifecycles()).toHaveLength(0);
+  });
+
+  it('accepts representative exact envelopes derived from every descriptor family', () => {
+    const representatives: RadioIntent[] = [
+      { name: 'vfo_swap', params: {} },
+      { name: 'memory_clear', params: { channel: 1 } },
+      { name: 'set_compressor', params: { on: true } },
+      { name: 'set_nb', params: { on: false, receiver: 0 } },
+      { name: 'set_mic_gain', params: { level: 10 } },
+      { name: 'set_af_level', params: { level: 10, receiver: 1 } },
+      { name: 'set_cw_pitch', params: { value: 10 } },
+      { name: 'set_pbt_inner', params: { value: 10, receiver: 0 } },
+      { name: 'set_data_mode', params: { mode: 1, receiver: 1 } },
+      { name: 'set_data3_mod_input', params: { source: 2 } },
+      { name: 'set_scope_mode', params: { mode: 1 } },
+      { name: 'set_scope_span', params: { span: 25_000 } },
+      { name: 'set_scope_speed', params: { speed: 2 } },
+      { name: 'scan_start', params: { type: 1 } },
+      { name: 'set_mode', params: { mode: 'USB', filter: 2, receiver: 0 } },
+      { name: 'set_filter', params: { filter: 2 } },
+      { name: 'set_vfo', params: { vfo: 'A' } },
+      { name: 'set_vfo', params: { vfo: 'B' } },
+      { name: 'set_vfo', params: { vfo: 'MAIN' } },
+      { name: 'set_vfo', params: { vfo: 'SUB' } },
+    ];
+
+    representatives.forEach((intent) => intents.dispatchRadioIntent(intent));
+    expect(harness.sendCommand).toHaveBeenCalledTimes(representatives.length);
+    expect(lifecycle.getCommandLifecycles()).toHaveLength(representatives.length);
   });
 
   it('rejects the 101st pending facade intent before transport', () => {

--- a/frontend/src/lib/runtime/commands/radio-intents.ts
+++ b/frontend/src/lib/runtime/commands/radio-intents.ts
@@ -2,107 +2,86 @@ import { acknowledgeCommand, beginCommand, cancelPendingCommands, failCommand, t
 import { makeCommandId } from '$lib/types/protocol';
 import { getControlSession, onCommandDelivery, onControlSessionTransition, sendCommand } from '$lib/transport/ws-client';
 
-type Empty = Record<string, never>;
-type Receiver = 0 | 1;
-const empty = ['cw_auto_tune', 'memory_write', 'quick_dualwatch', 'quick_split', 'scan_stop', 'vfo_equalize', 'vfo_swap'] as const;
-const channel = ['memory_clear', 'memory_to_vfo', 'set_memory_mode'] as const;
-const on = [
-  'set_antenna_1', 'set_antenna_2', 'set_compressor', 'set_dial_lock', 'set_dual_watch',
-  'set_main_sub_tracking', 'set_monitor', 'set_powerstat', 'set_rit_status', 'set_rit_tx_status',
-  'set_rx_antenna_ant1', 'set_rx_antenna_ant2', 'set_scope_during_tx', 'set_scope_hold', 'set_split', 'set_vox',
-] as const;
-const onReceiver = ['set_auto_notch', 'set_digisel', 'set_ip_plus', 'set_manual_notch', 'set_nb', 'set_nr', 'set_twin_peak'] as const;
-const level = [
-  'set_anti_vox_gain', 'set_break_in_delay', 'set_compressor_level', 'set_drive_gain', 'set_mic_gain',
-  'set_monitor_gain', 'set_nb_depth', 'set_nb_width', 'set_rf_power', 'set_vox_delay', 'set_vox_gain',
-] as const;
-const levelReceiver = ['set_af_level', 'set_nb_level', 'set_nr_level', 'set_preamp', 'set_rf_gain', 'set_squelch'] as const;
-const value = ['set_cw_pitch', 'set_tuner_status'] as const;
-const valueReceiver = ['set_agc_time_constant', 'set_manual_notch_width', 'set_notch_filter', 'set_pbt_inner', 'set_pbt_outer'] as const;
-const modeReceiver = ['set_agc', 'set_apf', 'set_data_mode'] as const;
-const modSource = ['set_data_off_mod_input', 'set_data1_mod_input', 'set_data2_mod_input', 'set_data3_mod_input'] as const;
-const numericMode = ['set_break_in', 'scan_set_resume', 'set_scope_mode', 'speak'] as const;
-const numericSpan = ['scan_set_df_span', 'set_scope_span'] as const;
-const numericSpeed = ['set_key_speed', 'set_scope_speed'] as const;
-const numericType = ['scan_start', 'set_keyer_type'] as const;
-const custom = [
-  ['set_attenuator', 'db:n,receiver:r'], ['set_band', 'band:n'], ['set_dash_ratio', 'ratio:n'],
-  ['set_filter', 'filter:n,receiver?:r'], ['set_filter_shape', 'shape:n,receiver:r'],
-  ['set_filter_width', 'width:n,receiver?:r'], ['set_freq', 'freq:n,receiver?:r'],
-  ['set_if_shift', 'offset:n,receiver:r'], ['set_mode', 'mode:s,filter?:n,receiver?:r'],
-  ['set_rit_frequency', 'freq:n'], ['set_scope_center_type', 'center_type:n'],
-  ['set_scope_dual', 'dual:b'], ['set_scope_edge', 'edge:n'], ['set_scope_rbw', 'rbw:n'],
-  ['set_scope_ref', 'ref:n'], ['set_scope_vbw', 'narrow:b'], ['switch_scope_receiver', 'receiver:r'],
-  ['set_vfo', 'vfo:v'],
-] as const;
-const customNames = custom.map(([name]) => name) as Array<(typeof custom)[number][0]>;
-const standardRules: ReadonlyArray<readonly [readonly string[], string]> = [
-  [empty, ''], [channel, 'channel:n'], [on, 'on:b'], [onReceiver, 'on:b,receiver:r'],
-  [level, 'level:n'], [levelReceiver, 'level:n,receiver:r'], [value, 'value:n'],
-  [valueReceiver, 'value:n,receiver:r'], [modeReceiver, 'mode:n,receiver:r'],
-  [modSource, 'source:n'], [numericMode, 'mode:n'], [numericSpan, 'span:n'],
-  [numericSpeed, 'speed:n'], [numericType, 'type:n'],
-];
+type FieldKind = 'boolean' | 'integer' | 'receiver' | 'string' | 'vfo';
+type FieldSpec = FieldKind | `${FieldKind}?`;
+type IntentSpec = { names: readonly string[]; params: Readonly<Record<string, FieldSpec>> };
 
-type Member<T extends readonly string[]> = T[number];
-export const RADIO_INTENT_NAMES = Object.freeze([
-  ...empty, ...channel, ...on, ...onReceiver, ...level, ...levelReceiver, ...value, ...valueReceiver,
-  ...modeReceiver, ...modSource, ...numericMode, ...numericSpan, ...numericSpeed, ...numericType, ...customNames,
-] as const);
-export type RadioIntentName = (typeof RADIO_INTENT_NAMES)[number];
-type RadioIntentParams<Name extends RadioIntentName> =
-  Name extends Member<typeof empty> ? Empty :
-  Name extends Member<typeof channel> ? { channel: number } :
-  Name extends Member<typeof on> ? { on: boolean } :
-  Name extends Member<typeof onReceiver> ? { on: boolean; receiver: Receiver } :
-  Name extends Member<typeof level> ? { level: number } :
-  Name extends Member<typeof levelReceiver> ? { level: number; receiver: Receiver } :
-  Name extends Member<typeof value> ? { value: number } :
-  Name extends Member<typeof valueReceiver> ? { value: number; receiver: Receiver } :
-  Name extends Member<typeof modeReceiver> ? { mode: number; receiver: Receiver } :
-  Name extends Member<typeof modSource> ? { source: number } :
-  Name extends Member<typeof numericMode> ? { mode: number } :
-  Name extends Member<typeof numericSpan> ? { span: number } :
-  Name extends Member<typeof numericSpeed> ? { speed: number } :
-  Name extends Member<typeof numericType> ? { type: number } :
-  Name extends 'set_attenuator' ? { db: number; receiver: Receiver } :
-  Name extends 'set_band' ? { band: number } :
-  Name extends 'set_dash_ratio' ? { ratio: number } :
-  Name extends 'set_filter' ? { filter: number; receiver?: Receiver } :
-  Name extends 'set_filter_shape' ? { shape: number; receiver: Receiver } :
-  Name extends 'set_filter_width' ? { width: number; receiver?: Receiver } :
-  Name extends 'set_freq' ? { freq: number; receiver?: Receiver } :
-  Name extends 'set_if_shift' ? { offset: number; receiver: Receiver } :
-  Name extends 'set_mode' ? { mode: string; filter?: number; receiver?: Receiver } :
-  Name extends 'set_rit_frequency' ? { freq: number } :
-  Name extends 'set_scope_center_type' ? { center_type: number } :
-  Name extends 'set_scope_dual' ? { dual: boolean } :
-  Name extends 'set_scope_edge' ? { edge: number } :
-  Name extends 'set_scope_rbw' ? { rbw: number } :
-  Name extends 'set_scope_ref' ? { ref: number } :
-  Name extends 'set_scope_vbw' ? { narrow: boolean } :
-  Name extends 'set_vfo' ? { vfo: 'A' | 'B' | 'MAIN' | 'SUB' } :
-  Name extends 'switch_scope_receiver' ? { receiver: Receiver } : never;
-export type RadioIntent = { [Name in RadioIntentName]: { name: Name; params: RadioIntentParams<Name>; id?: string } }[RadioIntentName];
-const radioIntentNames = new Set<string>(RADIO_INTENT_NAMES);
+const intentSpecs = [
+  { names: ['cw_auto_tune', 'memory_write', 'quick_dualwatch', 'quick_split', 'scan_stop', 'vfo_equalize', 'vfo_swap'], params: {} },
+  { names: ['memory_clear', 'memory_to_vfo', 'set_memory_mode'], params: { channel: 'integer' } },
+  { names: [
+    'set_antenna_1', 'set_antenna_2', 'set_compressor', 'set_dial_lock', 'set_dual_watch',
+    'set_main_sub_tracking', 'set_monitor', 'set_powerstat', 'set_rit_status', 'set_rit_tx_status',
+    'set_rx_antenna_ant1', 'set_rx_antenna_ant2', 'set_scope_during_tx', 'set_scope_hold', 'set_split', 'set_vox',
+  ], params: { on: 'boolean' } },
+  { names: ['set_auto_notch', 'set_digisel', 'set_ip_plus', 'set_manual_notch', 'set_nb', 'set_nr', 'set_twin_peak'], params: { on: 'boolean', receiver: 'receiver' } },
+  { names: [
+    'set_anti_vox_gain', 'set_break_in_delay', 'set_compressor_level', 'set_drive_gain', 'set_mic_gain',
+    'set_monitor_gain', 'set_nb_depth', 'set_nb_width', 'set_rf_power', 'set_vox_delay', 'set_vox_gain',
+  ], params: { level: 'integer' } },
+  { names: ['set_af_level', 'set_nb_level', 'set_nr_level', 'set_preamp', 'set_rf_gain', 'set_squelch'], params: { level: 'integer', receiver: 'receiver' } },
+  { names: ['set_cw_pitch', 'set_tuner_status'], params: { value: 'integer' } },
+  { names: ['set_agc_time_constant', 'set_manual_notch_width', 'set_notch_filter', 'set_pbt_inner', 'set_pbt_outer'], params: { value: 'integer', receiver: 'receiver' } },
+  { names: ['set_agc', 'set_apf', 'set_data_mode'], params: { mode: 'integer', receiver: 'receiver' } },
+  { names: ['set_data_off_mod_input', 'set_data1_mod_input', 'set_data2_mod_input', 'set_data3_mod_input'], params: { source: 'integer' } },
+  { names: ['set_break_in', 'scan_set_resume', 'set_scope_mode', 'speak'], params: { mode: 'integer' } },
+  { names: ['scan_set_df_span', 'set_scope_span'], params: { span: 'integer' } },
+  { names: ['set_key_speed', 'set_scope_speed'], params: { speed: 'integer' } },
+  { names: ['scan_start', 'set_keyer_type'], params: { type: 'integer' } },
+  { names: ['set_attenuator'], params: { db: 'integer', receiver: 'receiver' } },
+  { names: ['set_band'], params: { band: 'integer' } },
+  { names: ['set_dash_ratio'], params: { ratio: 'integer' } },
+  { names: ['set_filter'], params: { filter: 'integer', receiver: 'receiver?' } },
+  { names: ['set_filter_shape'], params: { shape: 'integer', receiver: 'receiver' } },
+  { names: ['set_filter_width'], params: { width: 'integer', receiver: 'receiver?' } },
+  { names: ['set_freq'], params: { freq: 'integer', receiver: 'receiver?' } },
+  { names: ['set_if_shift'], params: { offset: 'integer', receiver: 'receiver' } },
+  { names: ['set_mode'], params: { mode: 'string', filter: 'integer?', receiver: 'receiver?' } },
+  { names: ['set_rit_frequency'], params: { freq: 'integer' } },
+  { names: ['set_scope_center_type'], params: { center_type: 'integer' } },
+  { names: ['set_scope_dual'], params: { dual: 'boolean' } },
+  { names: ['set_scope_edge'], params: { edge: 'integer' } },
+  { names: ['set_scope_rbw'], params: { rbw: 'integer' } },
+  { names: ['set_scope_ref'], params: { ref: 'integer' } },
+  { names: ['set_scope_vbw'], params: { narrow: 'boolean' } },
+  { names: ['switch_scope_receiver'], params: { receiver: 'receiver' } },
+  { names: ['set_vfo'], params: { vfo: 'vfo' } },
+] as const satisfies readonly IntentSpec[];
 
-function matchesParams(name: string, params: Record<string, unknown>): boolean {
-  const rule = standardRules.find(([names]) => names.includes(name))?.[1]
-    ?? custom.find(([candidate]) => candidate === name)?.[1];
-  if (rule === undefined) return false;
-  const fields = rule === '' ? [] : rule.split(',');
-  const allowed = fields.map((field) => field.split(':')[0].replace('?', ''));
-  if (Object.keys(params).some((key) => !allowed.includes(key))) return false;
-  return fields.every((field) => {
-    const [rawKey, kind] = field.split(':');
-    const key = rawKey.replace('?', '');
-    if (!Object.prototype.hasOwnProperty.call(params, key)) return rawKey.endsWith('?');
-    const value = params[key];
-    return kind === 'n' ? typeof value === 'number' && Number.isFinite(value)
-      : kind === 'b' ? typeof value === 'boolean'
-        : kind === 'r' ? value === 0 || value === 1
-          : kind === 'v' ? value === 'A' || value === 'B' || value === 'MAIN' || value === 'SUB'
-            : typeof value === 'string' && value.length > 0;
+type Spec = (typeof intentSpecs)[number];
+type KindValue<K extends FieldKind> = K extends 'boolean' ? boolean : K extends 'receiver' ? 0 | 1
+  : K extends 'string' ? string : K extends 'vfo' ? 'A' | 'B' | 'MAIN' | 'SUB' : number;
+type RequiredKeys<S extends Readonly<Record<string, FieldSpec>>> = {
+  [K in keyof S]-?: S[K] extends `${FieldKind}?` ? never : K
+}[keyof S];
+type OptionalKeys<S extends Readonly<Record<string, FieldSpec>>> = Exclude<keyof S, RequiredKeys<S>>;
+type ParamsFor<S extends Readonly<Record<string, FieldSpec>>> = keyof S extends never ? Record<string, never> :
+  { [K in RequiredKeys<S>]: KindValue<Extract<S[K], FieldKind>> }
+  & { [K in OptionalKeys<S>]?: S[K] extends `${infer V extends FieldKind}?` ? KindValue<V> : never };
+type IntentFromSpec<S extends Spec> = S extends unknown ? {
+  [Name in S['names'][number]]: { name: Name; params: ParamsFor<S['params']>; id?: string }
+}[S['names'][number]] : never;
+export type RadioIntent = IntentFromSpec<Spec>;
+export type RadioIntentName = RadioIntent['name'];
+
+const specEntries = intentSpecs.flatMap(({ names, params }) => names.map((name) => [name, params] as const));
+export const RADIO_INTENT_NAMES = Object.freeze(specEntries.map(([name]) => name)) as readonly RadioIntentName[];
+const specsByName = new Map<string, Readonly<Record<string, FieldSpec>>>(specEntries);
+
+function matchesValue(kind: FieldKind, value: unknown): boolean {
+  if (kind === 'integer') return typeof value === 'number' && Number.isSafeInteger(value);
+  if (kind === 'boolean') return typeof value === 'boolean';
+  if (kind === 'receiver') return value === 0 || value === 1;
+  if (kind === 'vfo') return value === 'A' || value === 'B' || value === 'MAIN' || value === 'SUB';
+  return typeof value === 'string' && value.length > 0;
+}
+
+function matchesParams(spec: Readonly<Record<string, FieldSpec>>, params: Record<PropertyKey, unknown>): boolean {
+  if (Reflect.ownKeys(params).some((key) => typeof key !== 'string' || !Object.prototype.hasOwnProperty.call(spec, key))) return false;
+  return Object.entries(spec).every(([key, field]) => {
+    const optional = field.endsWith('?');
+    if (!Object.prototype.hasOwnProperty.call(params, key)) return optional;
+    return matchesValue((optional ? field.slice(0, -1) : field) as FieldKind, params[key]);
   });
 }
 
@@ -117,20 +96,22 @@ onControlSessionTransition((transition) => {
 });
 
 export function dispatchRadioIntent(intent: RadioIntent): CommandLifecycle {
-  const candidate = intent as { name?: unknown; params?: unknown; id?: unknown };
-  if (typeof candidate.name !== 'string' || !radioIntentNames.has(candidate.name)) {
-    throw new TypeError('Only a known non-PTT radio intent may be dispatched');
-  }
-  if (typeof candidate.params !== 'object' || candidate.params === null || Array.isArray(candidate.params)) {
-    throw new TypeError('Radio intent params must be an object');
-  }
-  if ((candidate.id !== undefined && (typeof candidate.id !== 'string' || candidate.id.length === 0))
-    || !matchesParams(candidate.name, candidate.params as Record<string, unknown>)) {
+  if (typeof intent !== 'object' || intent === null || Array.isArray(intent)) throw new TypeError('Invalid radio intent envelope');
+  const candidate = intent as unknown as Record<PropertyKey, unknown>;
+  if (Reflect.ownKeys(candidate).some((key) => typeof key !== 'string' || (key !== 'name' && key !== 'params' && key !== 'id'))) {
     throw new TypeError('Invalid radio intent envelope');
   }
-  const id = candidate.id ?? makeCommandId();
+  const name = candidate.name;
+  if (typeof name !== 'string' || !specsByName.has(name)) throw new TypeError('Only a known non-PTT radio intent may be dispatched');
+  const params = candidate.params;
+  if (typeof params !== 'object' || params === null || Array.isArray(params)
+    || !matchesParams(specsByName.get(name)!, params as Record<PropertyKey, unknown>)
+    || (candidate.id !== undefined && (typeof candidate.id !== 'string' || candidate.id.length === 0))) {
+    throw new TypeError('Invalid radio intent envelope');
+  }
+  const id = (candidate.id as string | undefined) ?? makeCommandId();
   const originalEpoch = getControlSession().epoch;
-  const lifecycle = beginCommand({ id, name: candidate.name, params: candidate.params as Record<string, unknown>, originalEpoch });
-  sendCommand(candidate.name, candidate.params as Record<string, unknown>, id, { optimistic: false });
+  const lifecycle = beginCommand({ id, name, params: params as Record<string, unknown>, originalEpoch });
+  sendCommand(name, params as Record<string, unknown>, id, { optimistic: false });
   return lifecycle;
 }

--- a/frontend/src/lib/runtime/commands/radio-intents.ts
+++ b/frontend/src/lib/runtime/commands/radio-intents.ts
@@ -26,16 +26,28 @@ const numericSpan = ['scan_set_df_span', 'set_scope_span'] as const;
 const numericSpeed = ['set_key_speed', 'set_scope_speed'] as const;
 const numericType = ['scan_start', 'set_keyer_type'] as const;
 const custom = [
-  'set_attenuator', 'set_band', 'set_dash_ratio', 'set_filter', 'set_filter_shape', 'set_filter_width',
-  'set_freq', 'set_if_shift', 'set_mode', 'set_rit_frequency', 'set_scope_center_type', 'set_scope_dual', 'set_scope_edge',
-  'set_scope_rbw', 'set_scope_ref', 'set_scope_vbw', 'switch_scope_receiver',
-  'set_vfo',
+  ['set_attenuator', 'db:n,receiver:r'], ['set_band', 'band:n'], ['set_dash_ratio', 'ratio:n'],
+  ['set_filter', 'filter:n,receiver?:r'], ['set_filter_shape', 'shape:n,receiver:r'],
+  ['set_filter_width', 'width:n,receiver?:r'], ['set_freq', 'freq:n,receiver?:r'],
+  ['set_if_shift', 'offset:n,receiver:r'], ['set_mode', 'mode:s,filter?:n,receiver?:r'],
+  ['set_rit_frequency', 'freq:n'], ['set_scope_center_type', 'center_type:n'],
+  ['set_scope_dual', 'dual:b'], ['set_scope_edge', 'edge:n'], ['set_scope_rbw', 'rbw:n'],
+  ['set_scope_ref', 'ref:n'], ['set_scope_vbw', 'narrow:b'], ['switch_scope_receiver', 'receiver:r'],
+  ['set_vfo', 'vfo:v'],
 ] as const;
+const customNames = custom.map(([name]) => name) as Array<(typeof custom)[number][0]>;
+const standardRules: ReadonlyArray<readonly [readonly string[], string]> = [
+  [empty, ''], [channel, 'channel:n'], [on, 'on:b'], [onReceiver, 'on:b,receiver:r'],
+  [level, 'level:n'], [levelReceiver, 'level:n,receiver:r'], [value, 'value:n'],
+  [valueReceiver, 'value:n,receiver:r'], [modeReceiver, 'mode:n,receiver:r'],
+  [modSource, 'source:n'], [numericMode, 'mode:n'], [numericSpan, 'span:n'],
+  [numericSpeed, 'speed:n'], [numericType, 'type:n'],
+];
 
 type Member<T extends readonly string[]> = T[number];
 export const RADIO_INTENT_NAMES = Object.freeze([
   ...empty, ...channel, ...on, ...onReceiver, ...level, ...levelReceiver, ...value, ...valueReceiver,
-  ...modeReceiver, ...modSource, ...numericMode, ...numericSpan, ...numericSpeed, ...numericType, ...custom,
+  ...modeReceiver, ...modSource, ...numericMode, ...numericSpan, ...numericSpeed, ...numericType, ...customNames,
 ] as const);
 export type RadioIntentName = (typeof RADIO_INTENT_NAMES)[number];
 type RadioIntentParams<Name extends RadioIntentName> =
@@ -69,10 +81,30 @@ type RadioIntentParams<Name extends RadioIntentName> =
   Name extends 'set_scope_rbw' ? { rbw: number } :
   Name extends 'set_scope_ref' ? { ref: number } :
   Name extends 'set_scope_vbw' ? { narrow: boolean } :
-  Name extends 'set_vfo' ? { vfo: string } :
-  Name extends 'switch_scope_receiver' ? { receiver: number } : never;
+  Name extends 'set_vfo' ? { vfo: 'A' | 'B' | 'MAIN' | 'SUB' } :
+  Name extends 'switch_scope_receiver' ? { receiver: Receiver } : never;
 export type RadioIntent = { [Name in RadioIntentName]: { name: Name; params: RadioIntentParams<Name>; id?: string } }[RadioIntentName];
 const radioIntentNames = new Set<string>(RADIO_INTENT_NAMES);
+
+function matchesParams(name: string, params: Record<string, unknown>): boolean {
+  const rule = standardRules.find(([names]) => names.includes(name))?.[1]
+    ?? custom.find(([candidate]) => candidate === name)?.[1];
+  if (rule === undefined) return false;
+  const fields = rule === '' ? [] : rule.split(',');
+  const allowed = fields.map((field) => field.split(':')[0].replace('?', ''));
+  if (Object.keys(params).some((key) => !allowed.includes(key))) return false;
+  return fields.every((field) => {
+    const [rawKey, kind] = field.split(':');
+    const key = rawKey.replace('?', '');
+    if (!Object.prototype.hasOwnProperty.call(params, key)) return rawKey.endsWith('?');
+    const value = params[key];
+    return kind === 'n' ? typeof value === 'number' && Number.isFinite(value)
+      : kind === 'b' ? typeof value === 'boolean'
+        : kind === 'r' ? value === 0 || value === 1
+          : kind === 'v' ? value === 'A' || value === 'B' || value === 'MAIN' || value === 'SUB'
+            : typeof value === 'string' && value.length > 0;
+  });
+}
 
 onCommandDelivery((event) => {
   if (event.kind === 'transport-sent') return;
@@ -92,7 +124,11 @@ export function dispatchRadioIntent(intent: RadioIntent): CommandLifecycle {
   if (typeof candidate.params !== 'object' || candidate.params === null || Array.isArray(candidate.params)) {
     throw new TypeError('Radio intent params must be an object');
   }
-  const id = typeof candidate.id === 'string' ? candidate.id : makeCommandId();
+  if ((candidate.id !== undefined && (typeof candidate.id !== 'string' || candidate.id.length === 0))
+    || !matchesParams(candidate.name, candidate.params as Record<string, unknown>)) {
+    throw new TypeError('Invalid radio intent envelope');
+  }
+  const id = candidate.id ?? makeCommandId();
   const originalEpoch = getControlSession().epoch;
   const lifecycle = beginCommand({ id, name: candidate.name, params: candidate.params as Record<string, unknown>, originalEpoch });
   sendCommand(candidate.name, candidate.params as Record<string, unknown>, id, { optimistic: false });

--- a/frontend/src/lib/runtime/commands/radio-intents.ts
+++ b/frontend/src/lib/runtime/commands/radio-intents.ts
@@ -1,0 +1,100 @@
+import { acknowledgeCommand, beginCommand, cancelPendingCommands, failCommand, type CommandLifecycle } from '$lib/stores/commands.svelte';
+import { makeCommandId } from '$lib/types/protocol';
+import { getControlSession, onCommandDelivery, onControlSessionTransition, sendCommand } from '$lib/transport/ws-client';
+
+type Empty = Record<string, never>;
+type Receiver = 0 | 1;
+const empty = ['cw_auto_tune', 'memory_write', 'quick_dualwatch', 'quick_split', 'scan_stop', 'vfo_equalize', 'vfo_swap'] as const;
+const channel = ['memory_clear', 'memory_to_vfo', 'set_memory_mode'] as const;
+const on = [
+  'set_antenna_1', 'set_antenna_2', 'set_compressor', 'set_dial_lock', 'set_dual_watch',
+  'set_main_sub_tracking', 'set_monitor', 'set_powerstat', 'set_rit_status', 'set_rit_tx_status',
+  'set_rx_antenna_ant1', 'set_rx_antenna_ant2', 'set_scope_during_tx', 'set_scope_hold', 'set_split', 'set_vox',
+] as const;
+const onReceiver = ['set_auto_notch', 'set_digisel', 'set_ip_plus', 'set_manual_notch', 'set_nb', 'set_nr', 'set_twin_peak'] as const;
+const level = [
+  'set_anti_vox_gain', 'set_break_in_delay', 'set_compressor_level', 'set_drive_gain', 'set_mic_gain',
+  'set_monitor_gain', 'set_nb_depth', 'set_nb_width', 'set_rf_power', 'set_vox_delay', 'set_vox_gain',
+] as const;
+const levelReceiver = ['set_af_level', 'set_nb_level', 'set_nr_level', 'set_preamp', 'set_rf_gain', 'set_squelch'] as const;
+const value = ['set_cw_pitch', 'set_tuner_status'] as const;
+const valueReceiver = ['set_agc_time_constant', 'set_manual_notch_width', 'set_notch_filter', 'set_pbt_inner', 'set_pbt_outer'] as const;
+const modeReceiver = ['set_agc', 'set_apf', 'set_data_mode'] as const;
+const modSource = ['set_data_off_mod_input', 'set_data1_mod_input', 'set_data2_mod_input', 'set_data3_mod_input'] as const;
+const numericMode = ['set_break_in', 'scan_set_resume', 'set_scope_mode', 'speak'] as const;
+const numericSpan = ['scan_set_df_span', 'set_scope_span'] as const;
+const numericSpeed = ['set_key_speed', 'set_scope_speed'] as const;
+const numericType = ['scan_start', 'set_keyer_type'] as const;
+const custom = [
+  'set_attenuator', 'set_band', 'set_dash_ratio', 'set_filter', 'set_filter_shape', 'set_filter_width',
+  'set_freq', 'set_if_shift', 'set_mode', 'set_rit_frequency', 'set_scope_center_type', 'set_scope_dual', 'set_scope_edge',
+  'set_scope_rbw', 'set_scope_ref', 'set_scope_vbw', 'switch_scope_receiver',
+  'set_vfo',
+] as const;
+
+type Member<T extends readonly string[]> = T[number];
+export const RADIO_INTENT_NAMES = Object.freeze([
+  ...empty, ...channel, ...on, ...onReceiver, ...level, ...levelReceiver, ...value, ...valueReceiver,
+  ...modeReceiver, ...modSource, ...numericMode, ...numericSpan, ...numericSpeed, ...numericType, ...custom,
+] as const);
+export type RadioIntentName = (typeof RADIO_INTENT_NAMES)[number];
+type RadioIntentParams<Name extends RadioIntentName> =
+  Name extends Member<typeof empty> ? Empty :
+  Name extends Member<typeof channel> ? { channel: number } :
+  Name extends Member<typeof on> ? { on: boolean } :
+  Name extends Member<typeof onReceiver> ? { on: boolean; receiver: Receiver } :
+  Name extends Member<typeof level> ? { level: number } :
+  Name extends Member<typeof levelReceiver> ? { level: number; receiver: Receiver } :
+  Name extends Member<typeof value> ? { value: number } :
+  Name extends Member<typeof valueReceiver> ? { value: number; receiver: Receiver } :
+  Name extends Member<typeof modeReceiver> ? { mode: number; receiver: Receiver } :
+  Name extends Member<typeof modSource> ? { source: number } :
+  Name extends Member<typeof numericMode> ? { mode: number } :
+  Name extends Member<typeof numericSpan> ? { span: number } :
+  Name extends Member<typeof numericSpeed> ? { speed: number } :
+  Name extends Member<typeof numericType> ? { type: number } :
+  Name extends 'set_attenuator' ? { db: number; receiver: Receiver } :
+  Name extends 'set_band' ? { band: number } :
+  Name extends 'set_dash_ratio' ? { ratio: number } :
+  Name extends 'set_filter' ? { filter: number; receiver?: Receiver } :
+  Name extends 'set_filter_shape' ? { shape: number; receiver: Receiver } :
+  Name extends 'set_filter_width' ? { width: number; receiver?: Receiver } :
+  Name extends 'set_freq' ? { freq: number; receiver?: Receiver } :
+  Name extends 'set_if_shift' ? { offset: number; receiver: Receiver } :
+  Name extends 'set_mode' ? { mode: string; filter?: number; receiver?: Receiver } :
+  Name extends 'set_rit_frequency' ? { freq: number } :
+  Name extends 'set_scope_center_type' ? { center_type: number } :
+  Name extends 'set_scope_dual' ? { dual: boolean } :
+  Name extends 'set_scope_edge' ? { edge: number } :
+  Name extends 'set_scope_rbw' ? { rbw: number } :
+  Name extends 'set_scope_ref' ? { ref: number } :
+  Name extends 'set_scope_vbw' ? { narrow: boolean } :
+  Name extends 'set_vfo' ? { vfo: string } :
+  Name extends 'switch_scope_receiver' ? { receiver: number } : never;
+export type RadioIntent = { [Name in RadioIntentName]: { name: Name; params: RadioIntentParams<Name>; id?: string } }[RadioIntentName];
+const radioIntentNames = new Set<string>(RADIO_INTENT_NAMES);
+
+onCommandDelivery((event) => {
+  if (event.kind === 'transport-sent') return;
+  if (event.cancelled) cancelPendingCommands(event.originalEpoch, event.error);
+  else if (event.kind === 'ack' || event.kind === 'response-ok') acknowledgeCommand(event.commandId, event.originalEpoch, event.eventEpoch);
+  else failCommand(event.commandId, event.originalEpoch, event.eventEpoch, event.error);
+});
+onControlSessionTransition((transition) => {
+  if (transition.state === 'disconnected') cancelPendingCommands(transition.epoch);
+});
+
+export function dispatchRadioIntent(intent: RadioIntent): CommandLifecycle {
+  const candidate = intent as { name?: unknown; params?: unknown; id?: unknown };
+  if (typeof candidate.name !== 'string' || !radioIntentNames.has(candidate.name)) {
+    throw new TypeError('Only a known non-PTT radio intent may be dispatched');
+  }
+  if (typeof candidate.params !== 'object' || candidate.params === null || Array.isArray(candidate.params)) {
+    throw new TypeError('Radio intent params must be an object');
+  }
+  const id = typeof candidate.id === 'string' ? candidate.id : makeCommandId();
+  const originalEpoch = getControlSession().epoch;
+  const lifecycle = beginCommand({ id, name: candidate.name, params: candidate.params as Record<string, unknown>, originalEpoch });
+  sendCommand(candidate.name, candidate.params as Record<string, unknown>, id, { optimistic: false });
+  return lifecycle;
+}

--- a/frontend/src/lib/stores/__tests__/commands.test.ts
+++ b/frontend/src/lib/stores/__tests__/commands.test.ts
@@ -1,85 +1,101 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-describe('commands store', () => {
+describe('command lifecycle store', () => {
   let store: typeof import('../commands.svelte');
 
   beforeEach(async () => {
+    vi.useFakeTimers();
     vi.resetModules();
     store = await import('../commands.svelte');
   });
 
-  it('starts empty', () => {
-    expect(store.getPendingCommands()).toHaveLength(0);
-    expect(store.hasPending()).toBe(false);
+  afterEach(() => {
+    store.resetCommandLifecycle();
+    vi.useRealTimers();
   });
 
-  it('addCommand creates a command with correct shape', () => {
-    const cmd = store.addCommand('set_freq', { freq: 14074000 });
-    expect(cmd.type).toBe('set_freq');
-    expect(cmd.payload).toEqual({ freq: 14074000 });
-    expect(cmd.status).toBe('pending');
-    expect(typeof cmd.id).toBe('string');
-    expect(cmd.id.length).toBeGreaterThan(0);
-    expect(cmd.createdAt).toBeGreaterThan(0);
-    expect(cmd.timeoutMs).toBe(5000);
+  it('records only bounded diagnostic lifecycle metadata', () => {
+    const command = store.beginCommand({
+      id: 'freq-1',
+      name: 'set_freq',
+      params: { freq: 14_074_000, receiver: 0 },
+      originalEpoch: 7,
+    });
+
+    expect(command).toMatchObject({
+      id: 'freq-1',
+      name: 'set_freq',
+      params: { freq: 14_074_000, receiver: 0 },
+      originalEpoch: 7,
+      status: 'pending',
+      timeoutMs: 5_000,
+    });
+    expect(command).not.toHaveProperty('confirmedValue');
+    expect(command).not.toHaveProperty('radioState');
+    expect(store.getCommandLifecycle('freq-1', 7)?.status).toBe('pending');
+    expect(store.hasPendingCommands()).toBe(true);
+    expect(() => store.beginCommand({ ...command })).toThrow(/duplicate command id/i);
   });
 
-  it('addCommand adds to queue', () => {
-    store.addCommand('set_freq', {});
-    store.addCommand('set_mode', {});
-    expect(store.getPendingCommands()).toHaveLength(2);
+  it('fences acknowledgement and failure by command id and originating epoch', () => {
+    store.beginCommand({ id: 'same', name: 'set_mode', params: { mode: 'USB' }, originalEpoch: 3 });
+    store.acknowledgeCommand('same', 2, 3);
+    expect(store.getCommandLifecycle('same', 3)?.status).toBe('pending');
+
+    store.acknowledgeCommand('same', 3, 4);
+    expect(store.getCommandLifecycle('same', 3)).toMatchObject({
+      status: 'acknowledged',
+      eventEpoch: 4,
+    });
+    store.failCommand('same', 3, 4, 'late NAK');
+    expect(store.getCommandLifecycle('same', 3)?.status).toBe('failed');
+
+    store.beginCommand({ id: 'failure', name: 'set_vfo', params: { vfo: 'B' }, originalEpoch: 5 });
+    store.failCommand('failure', 5, 5, 'denied');
+    expect(store.getCommandLifecycle('failure', 5)).toMatchObject({
+      status: 'failed',
+      error: 'denied',
+    });
   });
 
-  it('hasPending is true when pending commands exist', () => {
-    store.addCommand('set_freq', {});
-    expect(store.hasPending()).toBe(true);
+  it('cancels all pending work from the disconnected session and ignores stale results', () => {
+    store.beginCommand({ id: 'old-a', name: 'set_freq', params: { freq: 1 }, originalEpoch: 10 });
+    store.beginCommand({ id: 'old-b', name: 'set_mode', params: { mode: 'CW' }, originalEpoch: 10 });
+    store.beginCommand({ id: 'new', name: 'set_filter', params: { filter: 2 }, originalEpoch: 11 });
+
+    store.cancelPendingCommands(10, 'session-disconnected');
+    expect(store.getCommandLifecycle('old-a', 10)?.status).toBe('cancelled');
+    expect(store.getCommandLifecycle('old-b', 10)?.status).toBe('cancelled');
+    expect(store.getCommandLifecycle('new', 11)?.status).toBe('pending');
+
+    store.acknowledgeCommand('old-a', 10, 11);
+    expect(store.getCommandLifecycle('old-a', 10)?.status).toBe('cancelled');
   });
 
-  it('ackCommand transitions status to acked', () => {
-    const cmd = store.addCommand('set_freq', {});
-    store.ackCommand(cmd.id);
-    const found = store.getPendingCommands().find((c) => c.id === cmd.id);
-    expect(found?.status).toBe('acked');
+  it('uses the existing per-record timeout and isolates it from later commands', () => {
+    store.beginCommand({ id: 'slow', name: 'set_freq', params: { freq: 1 }, originalEpoch: 1, timeoutMs: 25 });
+    vi.advanceTimersByTime(10);
+    store.beginCommand({ id: 'fresh', name: 'set_freq', params: { freq: 2 }, originalEpoch: 1, timeoutMs: 25 });
+    vi.advanceTimersByTime(15);
+
+    expect(store.getCommandLifecycle('slow', 1)?.status).toBe('timed-out');
+    expect(store.getCommandLifecycle('fresh', 1)?.status).toBe('pending');
   });
 
-  it('failCommand transitions status to failed', () => {
-    const cmd = store.addCommand('set_freq', {});
-    store.failCommand(cmd.id);
-    const found = store.getPendingCommands().find((c) => c.id === cmd.id);
-    expect(found?.status).toBe('failed');
-  });
+  it('bounds retained lifecycle records and cleans up oldest terminal entries first', () => {
+    for (let i = 0; i < 110; i += 1) {
+      store.beginCommand({
+        id: `cmd-${i}`,
+        name: 'set_freq',
+        params: { freq: i },
+        originalEpoch: 1,
+      });
+      store.failCommand(`cmd-${i}`, 1, 1, 'fixture');
+    }
 
-  it('clearFinishedCommands removes acked and failed, keeps pending', () => {
-    const a = store.addCommand('set_freq', {});
-    const b = store.addCommand('set_mode', {});
-    const c = store.addCommand('ptt_on', {});
-
-    store.ackCommand(a.id);
-    store.failCommand(b.id);
-    // c stays pending
-
-    store.clearFinishedCommands();
-    const remaining = store.getPendingCommands();
-    expect(remaining).toHaveLength(1);
-    expect(remaining[0].id).toBe(c.id);
-  });
-
-  it('hasPending is false after all commands are cleared', () => {
-    const cmd = store.addCommand('set_freq', {});
-    store.ackCommand(cmd.id);
-    store.clearFinishedCommands();
-    expect(store.hasPending()).toBe(false);
-  });
-
-  it('ackCommand on unknown id is a no-op', () => {
-    store.addCommand('set_freq', {});
-    store.ackCommand('nonexistent-id');
-    expect(store.getPendingCommands()[0].status).toBe('pending');
-  });
-
-  it('addCommand generates unique IDs', () => {
-    const a = store.addCommand('set_freq', {});
-    const b = store.addCommand('set_freq', {});
-    expect(a.id).not.toBe(b.id);
+    const records = store.getCommandLifecycles();
+    expect(records).toHaveLength(100);
+    expect(records.some((record) => record.id === 'cmd-0')).toBe(false);
+    expect(records.some((record) => record.id === 'cmd-109')).toBe(true);
   });
 });

--- a/frontend/src/lib/stores/__tests__/commands.test.ts
+++ b/frontend/src/lib/stores/__tests__/commands.test.ts
@@ -98,4 +98,17 @@ describe('command lifecycle store', () => {
     expect(records.some((record) => record.id === 'cmd-0')).toBe(false);
     expect(records.some((record) => record.id === 'cmd-109')).toBe(true);
   });
+
+  it('rejects the 101st pending record without evicting live correlation', () => {
+    for (let i = 0; i < 100; i += 1) {
+      store.beginCommand({ id: `pending-${i}`, name: 'set_freq', params: { freq: i }, originalEpoch: 9 });
+    }
+    expect(() => store.beginCommand({
+      id: 'overflow', name: 'set_freq', params: { freq: 101 }, originalEpoch: 9,
+    })).toThrow(/capacity/i);
+
+    expect(store.getCommandLifecycles()).toHaveLength(100);
+    expect(store.getCommandLifecycle('pending-0', 9)?.status).toBe('pending');
+    expect(store.getCommandLifecycle('overflow', 9)).toBeUndefined();
+  });
 });

--- a/frontend/src/lib/stores/commands.svelte.ts
+++ b/frontend/src/lib/stores/commands.svelte.ts
@@ -21,12 +21,11 @@ function clearRecordTimer(command: CommandLifecycle): void {
   if (timer !== undefined) clearTimeout(timer);
   timers.delete(recordKey);
 }
-function boundRecords(): void {
-  while (commands.length > MAX_RETAINED_COMMANDS) {
-    const terminal = commands.findIndex((command) => command.status !== 'pending');
-    const index = terminal >= 0 ? terminal : 0;
-    clearRecordTimer(commands[index]); commands.splice(index, 1);
-  }
+function reserveRecordSlot(): void {
+  if (commands.length < MAX_RETAINED_COMMANDS) return;
+  const terminal = commands.findIndex((command) => command.status !== 'pending');
+  if (terminal < 0) throw new Error('Command lifecycle capacity exhausted');
+  clearRecordTimer(commands[terminal]); commands.splice(terminal, 1);
 }
 function transition(
   id: string, originalEpoch: number,
@@ -42,6 +41,7 @@ function transition(
 
 export function beginCommand(input: BeginCommandInput): CommandLifecycle {
   if (getCommandLifecycle(input.id, input.originalEpoch)) throw new Error('duplicate command id in control session');
+  reserveRecordSlot();
   const now = Date.now();
   const timeoutMs = input.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const command: CommandLifecycle = { ...input, timeoutMs, createdAt: now, updatedAt: now, status: 'pending' };
@@ -52,7 +52,6 @@ export function beginCommand(input: BeginCommandInput): CommandLifecycle {
     current.status = 'timed-out'; current.updatedAt = Date.now();
     timers.delete(key(current.id, current.originalEpoch));
   }, timeoutMs));
-  boundRecords();
   return command;
 }
 export const getCommandLifecycles = (): readonly CommandLifecycle[] => commands;

--- a/frontend/src/lib/stores/commands.svelte.ts
+++ b/frontend/src/lib/stores/commands.svelte.ts
@@ -1,54 +1,76 @@
-import type { PendingCommand } from '../types/state';
-import { makeCommandId } from '../types/protocol';
-
-// Command queue — commands awaiting server acknowledgment
-let commands = $state<PendingCommand[]>([]);
-
-let hasPendingDerived = $derived(commands.some((c) => c.status === 'pending'));
-
-export function getPendingCommands(): PendingCommand[] {
-  return commands;
+export type CommandLifecycleStatus = 'pending' | 'acknowledged' | 'failed' | 'cancelled' | 'timed-out';
+export interface CommandLifecycle {
+  id: string; name: string; params: Readonly<Record<string, unknown>>;
+  originalEpoch: number; eventEpoch?: number; createdAt: number; updatedAt: number;
+  timeoutMs: number; status: CommandLifecycleStatus; error?: string;
+}
+export interface BeginCommandInput {
+  id: string; name: string; params: Readonly<Record<string, unknown>>;
+  originalEpoch: number; timeoutMs?: number;
 }
 
-export function addCommand(type: string, payload: unknown): PendingCommand {
-  const cmd: PendingCommand = {
-    id: makeCommandId(),
-    type,
-    payload,
-    createdAt: Date.now(),
-    status: 'pending',
-    timeoutMs: 5000,
-  };
-  commands.push(cmd);
-  setTimeout(() => {
-    const current = commands.find((c) => c.id === cmd.id);
-    if (current?.status === 'pending') {
-      current.status = 'failed';
-    }
-  }, cmd.timeoutMs);
-  return cmd;
+const DEFAULT_TIMEOUT_MS = 5_000;
+const MAX_RETAINED_COMMANDS = 100;
+let commands = $state<CommandLifecycle[]>([]);
+const timers = new Map<string, ReturnType<typeof setTimeout>>();
+const key = (id: string, epoch: number): string => `${epoch}:${id}`;
+
+function clearRecordTimer(command: CommandLifecycle): void {
+  const recordKey = key(command.id, command.originalEpoch);
+  const timer = timers.get(recordKey);
+  if (timer !== undefined) clearTimeout(timer);
+  timers.delete(recordKey);
+}
+function boundRecords(): void {
+  while (commands.length > MAX_RETAINED_COMMANDS) {
+    const terminal = commands.findIndex((command) => command.status !== 'pending');
+    const index = terminal >= 0 ? terminal : 0;
+    clearRecordTimer(commands[index]); commands.splice(index, 1);
+  }
+}
+function transition(
+  id: string, originalEpoch: number,
+  status: 'acknowledged' | 'failed', eventEpoch: number, error?: string,
+): void {
+  const command = commands.find((item) => item.id === id && item.originalEpoch === originalEpoch
+    && (item.status === 'pending' || (status === 'failed' && item.status === 'acknowledged')));
+  if (!command) return;
+  command.status = status; command.eventEpoch = eventEpoch; command.updatedAt = Date.now();
+  if (error) command.error = error;
+  clearRecordTimer(command);
 }
 
-export function ackCommand(id: string): void {
-  const cmd = commands.find((c) => c.id === id);
-  if (cmd) cmd.status = 'acked';
+export function beginCommand(input: BeginCommandInput): CommandLifecycle {
+  if (getCommandLifecycle(input.id, input.originalEpoch)) throw new Error('duplicate command id in control session');
+  const now = Date.now();
+  const timeoutMs = input.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const command: CommandLifecycle = { ...input, timeoutMs, createdAt: now, updatedAt: now, status: 'pending' };
+  commands.push(command);
+  timers.set(key(command.id, command.originalEpoch), setTimeout(() => {
+    const current = getCommandLifecycle(command.id, command.originalEpoch);
+    if (current?.status !== 'pending') return;
+    current.status = 'timed-out'; current.updatedAt = Date.now();
+    timers.delete(key(current.id, current.originalEpoch));
+  }, timeoutMs));
+  boundRecords();
+  return command;
 }
-
-export function failCommand(id: string): void {
-  const cmd = commands.find((c) => c.id === id);
-  if (cmd) cmd.status = 'failed';
+export const getCommandLifecycles = (): readonly CommandLifecycle[] => commands;
+export const getCommandLifecycle = (id: string, epoch: number): CommandLifecycle | undefined =>
+  commands.find((command) => command.id === id && command.originalEpoch === epoch);
+export const hasPendingCommands = (): boolean => commands.some((command) => command.status === 'pending');
+export const acknowledgeCommand = (id: string, epoch: number, eventEpoch: number): void =>
+  transition(id, epoch, 'acknowledged', eventEpoch);
+export const failCommand = (id: string, epoch: number, eventEpoch: number, error = 'Command failed'): void =>
+  transition(id, epoch, 'failed', eventEpoch, error);
+export function cancelPendingCommands(epoch: number, error = 'session-disconnected'): void {
+  for (const command of commands) {
+    if (command.originalEpoch !== epoch || command.status !== 'pending') continue;
+    command.status = 'cancelled'; command.updatedAt = Date.now(); command.error = error;
+    clearRecordTimer(command);
+  }
 }
-
-/**
- * Remove all finished commands (both `acked` and `failed`) from the queue.
- * Only `pending` commands are kept. Call this after processing acknowledged
- * results to prevent unbounded queue growth. If you need to inspect or retry
- * failed commands, do so before calling this function.
- */
-export function clearFinishedCommands(): void {
-  commands = commands.filter((c) => c.status === 'pending');
-}
-
-export function hasPending(): boolean {
-  return hasPendingDerived;
+export function resetCommandLifecycle(): void {
+  for (const timer of timers.values()) clearTimeout(timer);
+  timers.clear(); commands = [];
 }

--- a/frontend/src/lib/transport/__tests__/ws-client.isolated.test.ts
+++ b/frontend/src/lib/transport/__tests__/ws-client.isolated.test.ts
@@ -280,6 +280,43 @@ describe('WsChannel', () => {
     ]);
   });
 
+  it('correlates generic non-PTT delivery in the sending session', async () => {
+    const { WsChannel } = await import('../ws-client');
+    const ch = new WsChannel();
+    const events: CommandDeliveryEvent[] = [];
+    ch.onCommandDelivery((event) => events.push(event));
+    ch.connect('ws://test');
+    instances[0].simulateOpen();
+
+    expect(ch.send({ type: 'cmd', name: 'set_freq', id: 'freq', params: { freq: 14_074_000 } })).toBe(true);
+    instances[0].simulateMessage(JSON.stringify({ type: 'ack', id: 'freq' }));
+    instances[0].simulateMessage(JSON.stringify({ type: 'response', id: 'freq', ok: true }));
+
+    expect(events).toEqual([
+      { commandId: 'freq', kind: 'transport-sent', originalEpoch: 1, eventEpoch: 1 },
+      { commandId: 'freq', kind: 'ack', originalEpoch: 1, eventEpoch: 1 },
+      { commandId: 'freq', kind: 'response-ok', originalEpoch: 1, eventEpoch: 1 },
+    ]);
+  });
+
+  it('cancels generic correlation at disconnect and ignores stale socket results', async () => {
+    const { WsChannel } = await import('../ws-client');
+    const ch = new WsChannel();
+    const events: CommandDeliveryEvent[] = [];
+    ch.onCommandDelivery((event) => events.push(event));
+    ch.connect('ws://test');
+    instances[0].simulateOpen();
+    ch.send({ type: 'cmd', name: 'set_vfo', id: 'old', params: { vfo: 'B' } });
+    instances[0].simulateClose();
+    vi.advanceTimersByTime(1_300);
+    instances[1].simulateOpen();
+    instances[0].simulateMessage(JSON.stringify({ type: 'response', id: 'old', ok: true }));
+
+    expect(events).toEqual([
+      { commandId: 'old', kind: 'transport-sent', originalEpoch: 1, eventEpoch: 1 },
+    ]);
+  });
+
   it('preserves queued OFF identity and distinguishes stale reconnect events', async () => {
     const { WsChannel } = await import('../ws-client');
     const ch = new WsChannel();
@@ -610,6 +647,44 @@ describe('control channel singleton', () => {
     sendCommand('set_data_mode', { mode: 2, receiver: 0 });
 
     expect(patchActiveReceiver).toHaveBeenCalledWith({ dataMode: 2 });
+  });
+
+  it('can bypass legacy optimism so only a contradictory Observation changes radio truth', async () => {
+    const { connect, sendCommand } = await import('../ws-client');
+    connect('ws://test/api/v1/ws');
+    instances[0].simulateOpen();
+    sendStateUpdate(instances[0], fullEnvelope(makeState({ revision: 1, main: makeReceiver({ freqHz: 14_074_000 }) })));
+    vi.mocked(patchActiveReceiver).mockClear();
+
+    expect(sendCommand(
+      'set_freq',
+      { freq: 7_074_000, receiver: 0 },
+      'freq-contradiction',
+      { optimistic: false },
+    )).toBe(true);
+    expect(patchActiveReceiver).not.toHaveBeenCalled();
+    expect(radioStoreMock.current?.main.freqHz).toBe(14_074_000);
+
+    const observed = makeState({ revision: 2, main: makeReceiver({ freqHz: 14_076_000 }) });
+    sendStateUpdate(instances[0], deltaEnvelope(observed, { main: observed.main }));
+    instances[0].simulateMessage(JSON.stringify({ type: 'ack', id: 'freq-contradiction' }));
+    expect(radioStoreMock.current?.main.freqHz).toBe(14_076_000);
+  });
+
+  it('cancels in-flight generic delivery when provider generation is replaced', async () => {
+    const { connect, onCommandDelivery, sendCommand } = await import('../ws-client');
+    const events: CommandDeliveryEvent[] = [];
+    onCommandDelivery((event) => events.push(event));
+    connect('ws://test/api/v1/ws');
+    instances[0].simulateOpen();
+    sendStateUpdate(instances[0], fullEnvelope(makeState({ providerGeneration: 0 })));
+    sendCommand('set_freq', { freq: 14_074_000 }, 'provider-pending', { optimistic: false });
+    sendStateUpdate(instances[0], fullEnvelope(makeState({ providerGeneration: 1 })));
+
+    expect(events).toMatchObject([
+      { commandId: 'provider-pending', kind: 'transport-sent', originalEpoch: 1, eventEpoch: 1 },
+      { commandId: 'provider-pending', kind: 'error', cancelled: true, error: 'provider session replaced' },
+    ]);
   });
 
   it('treats bare VFO B as a slot without switching MAIN to SUB', async () => {
@@ -1066,19 +1141,42 @@ describe('WsChannel send queue', () => {
     expect(JSON.parse(instances[0].sent[0]).params.freq).toBe(14100000);
   });
 
-  it('drops oldest commands when queue exceeds MAX_QUEUE_SIZE (20)', async () => {
+  it('never replays a stale offline non-idempotent command', async () => {
     const { WsChannel } = await import('../ws-client');
     const ch = new WsChannel();
+    const events: CommandDeliveryEvent[] = [];
+    ch.onCommandDelivery((event) => events.push(event));
+
+    expect(ch.send({ type: 'cmd', name: 'vfo_swap', id: 'swap', params: {} })).toBe(false);
+    ch.connect('ws://test');
+    instances[0].simulateOpen();
+
+    expect(instances[0].sent).toEqual([]);
+    expect(events).toEqual([{
+      commandId: 'swap',
+      kind: 'error',
+      originalEpoch: 0,
+      eventEpoch: 0,
+      error: 'offline non-idempotent command rejected',
+    }]);
+  });
+
+  it('rejects offline non-idempotent overflow instead of retaining a stale replay queue', async () => {
+    const { WsChannel } = await import('../ws-client');
+    const ch = new WsChannel();
+    const events: CommandDeliveryEvent[] = [];
+    ch.onCommandDelivery((event) => events.push(event));
 
     for (let i = 0; i < 25; i++) {
-      ch.send({ type: 'cmd', name: 'ptt', id: `cmd-${i}`, params: { i } });
+      ch.send({ type: 'cmd', name: 'set_af_level', id: `cmd-${i}`, params: { level: i } });
     }
 
     ch.connect('ws://test');
     instances[0].simulateOpen();
 
-    expect(instances[0].sent).toHaveLength(20);
-    expect(JSON.parse(instances[0].sent[0]).id).toBe('cmd-5');
+    expect(instances[0].sent).toEqual([]);
+    expect(events).toHaveLength(25);
+    expect(events.every((event) => event.kind === 'error')).toBe(true);
   });
 
   it('never replays offline PTT-on aliases and coalesces release aliases', async () => {
@@ -1125,16 +1223,17 @@ describe('WsChannel send queue', () => {
     for (let i = 0; i < 45; i++) {
       ch.send({ type: 'cmd', name: 'set_af_level', id: `ordinary-${i}`, params: { level: i } });
     }
+    ch.send({ type: 'cmd', name: 'set_freq', id: 'freq', params: { freq: 14_074_000 } });
+    ch.send({ type: 'cmd', name: 'set_mode', id: 'mode', params: { mode: 'USB' } });
+    ch.send({ type: 'cmd', name: 'set_filter', id: 'filter', params: { filter: 2 } });
 
     ch.connect('ws://test');
     instances[0].simulateOpen();
 
     const drained = instances[0].sent.map((frame) => JSON.parse(frame));
-    expect(drained).toHaveLength(21);
+    expect(drained).toHaveLength(4);
     expect(drained[0]).toMatchObject({ name: 'ptt_off', id: 'release' });
-    expect(drained.slice(1).map((cmd) => cmd.id)).toEqual(
-      Array.from({ length: 20 }, (_, i) => `ordinary-${i + 25}`),
-    );
+    expect(drained.slice(1).map((cmd) => cmd.id)).toEqual(['freq', 'mode', 'filter']);
   });
 
   it('allows one new queued release in a later offline episode', async () => {

--- a/frontend/src/lib/transport/__tests__/ws-client.isolated.test.ts
+++ b/frontend/src/lib/transport/__tests__/ws-client.isolated.test.ts
@@ -687,6 +687,28 @@ describe('control channel singleton', () => {
     ]);
   });
 
+  it('keeps all 100 live correlations and rejects the 101st facade send', async () => {
+    const { connect, disconnect } = await import('../ws-client');
+    const { dispatchRadioIntent } = await import('../../runtime/commands/radio-intents');
+    const lifecycle = await import('../../stores/commands.svelte');
+    connect('ws://test/api/v1/ws');
+    instances[0].simulateOpen();
+
+    for (let i = 0; i < 100; i += 1) {
+      dispatchRadioIntent({ id: `pending-${i}`, name: 'set_freq', params: { freq: i } });
+    }
+    expect(() => dispatchRadioIntent({
+      id: 'overflow', name: 'set_freq', params: { freq: 101 },
+    })).toThrow(/capacity/i);
+
+    expect(instances[0].sent).toHaveLength(100);
+    expect(lifecycle.getCommandLifecycles()).toHaveLength(100);
+    expect(lifecycle.getCommandLifecycle('pending-0', 1)?.status).toBe('pending');
+    expect(lifecycle.getCommandLifecycle('overflow', 1)).toBeUndefined();
+    lifecycle.resetCommandLifecycle();
+    disconnect();
+  });
+
   it('treats bare VFO B as a slot without switching MAIN to SUB', async () => {
     radioStoreMock.current = makeState({
       active: 'MAIN',

--- a/frontend/src/lib/transport/__tests__/ws-client.isolated.test.ts
+++ b/frontend/src/lib/transport/__tests__/ws-client.isolated.test.ts
@@ -299,6 +299,34 @@ describe('WsChannel', () => {
     ]);
   });
 
+  it('rejects the 101st direct generic send before the wire without evicting correlation', async () => {
+    const { WsChannel } = await import('../ws-client');
+    const ch = new WsChannel();
+    const events: CommandDeliveryEvent[] = [];
+    ch.onCommandDelivery((event) => events.push(event));
+    ch.connect('ws://test');
+    instances[0].simulateOpen();
+
+    for (let i = 0; i < 100; i += 1) {
+      expect(ch.send({
+        type: 'cmd', name: 'set_freq', id: `pending-${i}`, params: { freq: i },
+      })).toBe(true);
+    }
+    expect(ch.send({
+      type: 'cmd', name: 'set_freq', id: 'overflow', params: { freq: 101 },
+    })).toBe(false);
+    expect(instances[0].sent).toHaveLength(100);
+    expect(events.at(-1)).toMatchObject({
+      commandId: 'overflow', kind: 'error', error: 'delivery tracking capacity exceeded',
+    });
+
+    for (let i = 0; i < 100; i += 1) {
+      instances[0].simulateMessage(JSON.stringify({ type: 'response', id: `pending-${i}`, ok: true }));
+    }
+    expect(events.filter((event) => event.kind === 'response-ok')).toHaveLength(100);
+    expect(events).not.toContainEqual(expect.objectContaining({ commandId: 'pending-0', kind: 'error' }));
+  });
+
   it('cancels generic correlation at disconnect and ignores stale socket results', async () => {
     const { WsChannel } = await import('../ws-client');
     const ch = new WsChannel();

--- a/frontend/src/lib/transport/ws-client.ts
+++ b/frontend/src/lib/transport/ws-client.ts
@@ -335,6 +335,12 @@ export class WsChannel {
   }
 
   private _sendNonPtt(ws: WebSocket, pending: PendingNonPttCommand, eventEpoch: number): boolean {
+    if (this.trackedNonPttCommands.size >= MAX_TRACKED_NON_PTT_COMMANDS) {
+      this._rejectNonPtt(
+        pending.command.id, pending.originalEpoch, 'delivery tracking capacity exceeded', eventEpoch,
+      );
+      return false;
+    }
     try {
       ws.send(JSON.stringify(pending.command));
     } catch (error) {
@@ -345,12 +351,6 @@ export class WsChannel {
       return false;
     }
     const tracked: TrackedNonPttCommand = { ...pending, eventEpoch, seen: new Set() };
-    if (this.trackedNonPttCommands.size >= MAX_TRACKED_NON_PTT_COMMANDS) {
-      const oldestId = this.trackedNonPttCommands.keys().next().value!;
-      const oldest = this.trackedNonPttCommands.get(oldestId)!;
-      this.trackedNonPttCommands.delete(oldestId);
-      this._rejectNonPtt(oldest.command.id, oldest.originalEpoch, 'delivery tracking capacity exceeded', eventEpoch);
-    }
     this.trackedNonPttCommands.set(pending.command.id, tracked);
     this._emitTracked(tracked, 'transport-sent', tracked.eventEpoch);
     return true;

--- a/frontend/src/lib/transport/ws-client.ts
+++ b/frontend/src/lib/transport/ws-client.ts
@@ -17,6 +17,7 @@ export interface CommandDeliveryEvent {
   originalEpoch: number;
   eventEpoch: number;
   error?: string;
+  cancelled?: boolean;
 }
 type MessageHandler = (msg: WsIncoming) => void;
 type BinaryHandler = (data: ArrayBuffer) => void;
@@ -27,6 +28,11 @@ type PendingPttRelease = { command: WsCommand; originalEpoch: number };
 type TrackedPttCommand = PendingPttRelease & {
   seen: Set<CommandDeliveryKind>;
 };
+type PendingNonPttCommand = { command: WsCommand; originalEpoch: number };
+type TrackedNonPttCommand = PendingNonPttCommand & {
+  eventEpoch: number;
+  seen: Set<CommandDeliveryKind>;
+};
 
 const BACKOFF_BASE_MS = 1_000;
 const BACKOFF_MAX_MS = 30_000;
@@ -34,6 +40,7 @@ const HEARTBEAT_TIMEOUT_MS = 30_000;  // server may be idle on control WS
 const KEEPALIVE_INTERVAL_MS = 15_000; // send ping to prevent idle timeout
 const MAX_QUEUE_SIZE = 20;
 const MAX_TRACKED_PTT_COMMANDS = 100;
+const MAX_TRACKED_NON_PTT_COMMANDS = 100;
 
 // Command types where only the latest value matters (last write wins)
 const IDEMPOTENT_TYPES = new Set(['set_freq', 'set_mode', 'set_filter']);
@@ -58,10 +65,11 @@ export class WsChannel {
   private keepaliveTimer: ReturnType<typeof setInterval> | null = null;
   private attempt = 0;
   private intentionalClose = false;
-  private sendQueue: WsCommand[] = [];
+  private sendQueue: PendingNonPttCommand[] = [];
   private pendingPttRelease: PendingPttRelease | null = null;
   private transportEpoch = 0;
   private trackedPttCommands = new Map<string, TrackedPttCommand>();
+  private trackedNonPttCommands = new Map<string, TrackedNonPttCommand>();
   private commandDeliveryHandlers = new Set<CommandDeliveryHandler>();
   private messageHandlers = new Set<MessageHandler>();
   private binaryHandlers = new Set<BinaryHandler>();
@@ -136,10 +144,8 @@ export class WsChannel {
       const release = this.pendingPttRelease;
       this.pendingPttRelease = null;
       if (release) this._sendPtt(ws, release, socketEpoch);
-      const queued = this.sendQueue.splice(0).filter(
-        (cmd) => pttIntent(cmd.name, cmd.params) !== 'on',
-      );
-      for (const cmd of queued) ws.send(JSON.stringify(cmd));
+      const queued = this.sendQueue.splice(0);
+      for (const pending of queued) this._sendNonPtt(ws, pending, socketEpoch);
       // Re-send subscribe on every (re)connect so server pushes state immediately
       if (this._subscribeMsg) ws.send(JSON.stringify(this._subscribeMsg));
     };
@@ -183,6 +189,7 @@ export class WsChannel {
 
     ws.onclose = () => {
       this._clearHeartbeat();
+      this.trackedNonPttCommands.clear();
       this.ws = null;
       this.setState('disconnected');
       if (!this.intentionalClose) {
@@ -207,6 +214,7 @@ export class WsChannel {
     this._clearTimers();
     const { ws } = this;
     this.ws = null;
+    this.trackedNonPttCommands.clear();
     if (ws) {
       if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CLOSING) {
         ws.close();
@@ -230,32 +238,53 @@ export class WsChannel {
           this.transportEpoch,
         );
       }
-      try {
-        this.ws.send(JSON.stringify(cmd));
-        return true;
-      } catch {
-        return false;
-      }
+      return this._sendNonPtt(
+        this.ws,
+        { command: cmd, originalEpoch: this.transportEpoch },
+        this.transportEpoch,
+      );
     }
     const intent = pttIntent(cmd.name, cmd.params);
     if (intent === 'on') {
       return false;
     }
     if (intent === 'off') {
-      this.sendQueue = this.sendQueue.filter(
-        (queued) => pttIntent(queued.name, queued.params) !== 'on',
-      );
       this.pendingPttRelease = { command: cmd, originalEpoch: this.transportEpoch };
       return false;
     }
-    // Deduplicate idempotent commands — keep only the latest value
-    if (IDEMPOTENT_TYPES.has(cmd.name)) {
-      this.sendQueue = this.sendQueue.filter((c) => c.name !== cmd.name);
+    if (!IDEMPOTENT_TYPES.has(cmd.name)) {
+      this._emitDelivery({
+        commandId: cmd.id,
+        kind: 'error',
+        originalEpoch: this.transportEpoch,
+        eventEpoch: this.transportEpoch,
+        error: 'offline non-idempotent command rejected',
+      });
+      return false;
     }
-    this.sendQueue.push(cmd);
+    // Deduplicate idempotent commands — keep only the latest value
+    const superseded = this.sendQueue.find((pending) => pending.command.name === cmd.name);
+    if (superseded) {
+      this._emitDelivery({
+        commandId: superseded.command.id,
+        kind: 'error',
+        originalEpoch: superseded.originalEpoch,
+        eventEpoch: this.transportEpoch,
+        error: 'superseded by newer offline command',
+      });
+      this.sendQueue = this.sendQueue.filter((pending) => pending.command.name !== cmd.name);
+    }
+    this.sendQueue.push({ command: cmd, originalEpoch: this.transportEpoch });
     // Drop oldest if over limit
     if (this.sendQueue.length > MAX_QUEUE_SIZE) {
-      this.sendQueue.shift();
+      const dropped = this.sendQueue.shift()!;
+      this._emitDelivery({
+        commandId: dropped.command.id,
+        kind: 'error',
+        originalEpoch: dropped.originalEpoch,
+        eventEpoch: this.transportEpoch,
+        error: 'offline command queue capacity exceeded',
+      });
     }
     return false;
   }
@@ -289,6 +318,30 @@ export class WsChannel {
     return () => this.commandDeliveryHandlers.delete(handler);
   }
 
+  get sessionEpoch(): number {
+    return this.transportEpoch;
+  }
+
+  rejectNonPtt(commandId: string, error: string): void {
+    this._emitDelivery({
+      commandId,
+      kind: 'error',
+      originalEpoch: this.transportEpoch,
+      eventEpoch: this.transportEpoch,
+      error,
+    });
+  }
+
+  cancelNonPtt(error: string): void {
+    for (const tracked of this.trackedNonPttCommands.values()) {
+      this._emitDelivery({
+        commandId: tracked.command.id, kind: 'error', originalEpoch: tracked.originalEpoch,
+        eventEpoch: this.transportEpoch, error, cancelled: true,
+      });
+    }
+    this.trackedNonPttCommands.clear();
+  }
+
   private _sendPtt(ws: WebSocket, pending: PendingPttRelease, eventEpoch: number): boolean {
     try {
       ws.send(JSON.stringify(pending.command));
@@ -311,17 +364,77 @@ export class WsChannel {
     return true;
   }
 
+  private _sendNonPtt(ws: WebSocket, pending: PendingNonPttCommand, eventEpoch: number): boolean {
+    try {
+      ws.send(JSON.stringify(pending.command));
+    } catch (error) {
+      this._emitDelivery({
+        commandId: pending.command.id,
+        kind: 'error',
+        originalEpoch: pending.originalEpoch,
+        eventEpoch,
+        error: error instanceof Error ? error.message : 'WebSocket send failed',
+      });
+      return false;
+    }
+    const tracked: TrackedNonPttCommand = { ...pending, eventEpoch, seen: new Set() };
+    if (this.trackedNonPttCommands.size >= MAX_TRACKED_NON_PTT_COMMANDS) {
+      const oldestId = this.trackedNonPttCommands.keys().next().value!;
+      const oldest = this.trackedNonPttCommands.get(oldestId)!;
+      this.trackedNonPttCommands.delete(oldestId);
+      this._emitDelivery({
+        commandId: oldest.command.id,
+        kind: 'error',
+        originalEpoch: oldest.originalEpoch,
+        eventEpoch,
+        error: 'delivery tracking capacity exceeded',
+      });
+    }
+    this.trackedNonPttCommands.set(pending.command.id, tracked);
+    this._emitNonPttTracked(tracked, 'transport-sent');
+    return true;
+  }
+
   private _emitCommandResult(raw: Record<string, unknown>, eventEpoch: number): void {
     const id = raw.id;
     if (typeof id !== 'string') return;
     const tracked = this.trackedPttCommands.get(id);
-    if (!tracked) return;
-    if (raw.type === 'ack') this._emitTracked(tracked, 'ack', eventEpoch);
+    if (tracked && raw.type === 'ack') this._emitTracked(tracked, 'ack', eventEpoch);
     else if (raw.type === 'response') {
-      this._emitTracked(tracked, raw.ok === false ? 'response-error' : 'response-ok', eventEpoch);
+      if (tracked) this._emitTracked(tracked, raw.ok === false ? 'response-error' : 'response-ok', eventEpoch);
     } else if (raw.type === 'error' || raw.status === 'error') {
-      this._emitTracked(tracked, 'error', eventEpoch, String(raw.message ?? raw.error ?? 'Command failed'));
+      if (tracked) this._emitTracked(tracked, 'error', eventEpoch, String(raw.message ?? raw.error ?? 'Command failed'));
     }
+    const generic = this.trackedNonPttCommands.get(id);
+    if (!generic || generic.eventEpoch !== eventEpoch) return;
+    if (raw.type === 'ack') this._emitNonPttTracked(generic, 'ack');
+    else if (raw.type === 'response') {
+      this._emitNonPttTracked(
+        generic,
+        raw.ok === false ? 'response-error' : 'response-ok',
+        raw.ok === false ? String(raw.message ?? raw.error ?? 'Command failed') : undefined,
+      );
+      this.trackedNonPttCommands.delete(id);
+    } else if (raw.type === 'error' || raw.status === 'error') {
+      this._emitNonPttTracked(generic, 'error', String(raw.message ?? raw.error ?? 'Command failed'));
+      this.trackedNonPttCommands.delete(id);
+    }
+  }
+
+  private _emitNonPttTracked(
+    tracked: TrackedNonPttCommand,
+    kind: CommandDeliveryKind,
+    error?: string,
+  ): void {
+    if (tracked.seen.has(kind)) return;
+    tracked.seen.add(kind);
+    this._emitDelivery({
+      commandId: tracked.command.id,
+      kind,
+      originalEpoch: tracked.originalEpoch,
+      eventEpoch: tracked.eventEpoch,
+      ...(error ? { error } : {}),
+    });
   }
 
   private _emitTracked(
@@ -434,6 +547,7 @@ function highestSeenGeneration(): number | null {
 }
 
 function resetForProviderGeneration(generation: number): void {
+  _ctrl.cancelNonPtt('provider session replaced');
   _fullState = null;
   _hasReceivedFullState = false;
   _acceptedProviderGeneration = null;
@@ -690,17 +804,32 @@ export function onControlSessionTransition(handler: ControlSessionTransitionHand
   return _ctrl.onSessionTransition(handler);
 }
 
-export function sendCommand(name: string, params: Record<string, unknown> = {}, id?: string): boolean {
+export function getControlSession(): ControlSessionTransition {
+  return { state: _ctrl.state, epoch: _ctrl.sessionEpoch };
+}
+
+export function sendCommand(
+  name: string,
+  params: Record<string, unknown> = {},
+  id?: string,
+  options: { optimistic?: boolean } = {},
+): boolean {
+  const commandId = id ?? makeCommandId();
   if (!isLiveRadioAvailable() && pttIntent(name, params) !== 'off') {
     console.warn('[cmd] blocked while radio health is degraded', name);
+    if (pttIntent(name, params) === null) {
+      _ctrl.rejectNonPtt(commandId, 'radio health is degraded');
+    }
     return false;
   }
   // Auto-optimistic: apply UI patch immediately before sending
-  try { _applyOptimistic(name, params); } catch (e) { console.warn('[optimistic]', e); }
+  if (options.optimistic !== false) {
+    try { _applyOptimistic(name, params); } catch (e) { console.warn('[optimistic]', e); }
+  }
   return _ctrl.send({
     type: 'cmd',
     name,
-    id: id ?? makeCommandId(),
+    id: commandId,
     params,
   });
 }

--- a/frontend/src/lib/transport/ws-client.ts
+++ b/frontend/src/lib/transport/ws-client.ts
@@ -29,10 +29,7 @@ type TrackedPttCommand = PendingPttRelease & {
   seen: Set<CommandDeliveryKind>;
 };
 type PendingNonPttCommand = { command: WsCommand; originalEpoch: number };
-type TrackedNonPttCommand = PendingNonPttCommand & {
-  eventEpoch: number;
-  seen: Set<CommandDeliveryKind>;
-};
+type TrackedNonPttCommand = TrackedPttCommand & { eventEpoch: number };
 
 const BACKOFF_BASE_MS = 1_000;
 const BACKOFF_MAX_MS = 30_000;
@@ -253,38 +250,20 @@ export class WsChannel {
       return false;
     }
     if (!IDEMPOTENT_TYPES.has(cmd.name)) {
-      this._emitDelivery({
-        commandId: cmd.id,
-        kind: 'error',
-        originalEpoch: this.transportEpoch,
-        eventEpoch: this.transportEpoch,
-        error: 'offline non-idempotent command rejected',
-      });
+      this._rejectNonPtt(cmd.id, this.transportEpoch, 'offline non-idempotent command rejected');
       return false;
     }
     // Deduplicate idempotent commands — keep only the latest value
     const superseded = this.sendQueue.find((pending) => pending.command.name === cmd.name);
     if (superseded) {
-      this._emitDelivery({
-        commandId: superseded.command.id,
-        kind: 'error',
-        originalEpoch: superseded.originalEpoch,
-        eventEpoch: this.transportEpoch,
-        error: 'superseded by newer offline command',
-      });
+      this._rejectNonPtt(superseded.command.id, superseded.originalEpoch, 'superseded by newer offline command');
       this.sendQueue = this.sendQueue.filter((pending) => pending.command.name !== cmd.name);
     }
     this.sendQueue.push({ command: cmd, originalEpoch: this.transportEpoch });
     // Drop oldest if over limit
     if (this.sendQueue.length > MAX_QUEUE_SIZE) {
       const dropped = this.sendQueue.shift()!;
-      this._emitDelivery({
-        commandId: dropped.command.id,
-        kind: 'error',
-        originalEpoch: dropped.originalEpoch,
-        eventEpoch: this.transportEpoch,
-        error: 'offline command queue capacity exceeded',
-      });
+      this._rejectNonPtt(dropped.command.id, dropped.originalEpoch, 'offline command queue capacity exceeded');
     }
     return false;
   }
@@ -323,21 +302,12 @@ export class WsChannel {
   }
 
   rejectNonPtt(commandId: string, error: string): void {
-    this._emitDelivery({
-      commandId,
-      kind: 'error',
-      originalEpoch: this.transportEpoch,
-      eventEpoch: this.transportEpoch,
-      error,
-    });
+    this._rejectNonPtt(commandId, this.transportEpoch, error);
   }
 
   cancelNonPtt(error: string): void {
     for (const tracked of this.trackedNonPttCommands.values()) {
-      this._emitDelivery({
-        commandId: tracked.command.id, kind: 'error', originalEpoch: tracked.originalEpoch,
-        eventEpoch: this.transportEpoch, error, cancelled: true,
-      });
+      this._rejectNonPtt(tracked.command.id, tracked.originalEpoch, error, this.transportEpoch, true);
     }
     this.trackedNonPttCommands.clear();
   }
@@ -368,13 +338,10 @@ export class WsChannel {
     try {
       ws.send(JSON.stringify(pending.command));
     } catch (error) {
-      this._emitDelivery({
-        commandId: pending.command.id,
-        kind: 'error',
-        originalEpoch: pending.originalEpoch,
-        eventEpoch,
-        error: error instanceof Error ? error.message : 'WebSocket send failed',
-      });
+      this._rejectNonPtt(
+        pending.command.id, pending.originalEpoch,
+        error instanceof Error ? error.message : 'WebSocket send failed', eventEpoch,
+      );
       return false;
     }
     const tracked: TrackedNonPttCommand = { ...pending, eventEpoch, seen: new Set() };
@@ -382,16 +349,10 @@ export class WsChannel {
       const oldestId = this.trackedNonPttCommands.keys().next().value!;
       const oldest = this.trackedNonPttCommands.get(oldestId)!;
       this.trackedNonPttCommands.delete(oldestId);
-      this._emitDelivery({
-        commandId: oldest.command.id,
-        kind: 'error',
-        originalEpoch: oldest.originalEpoch,
-        eventEpoch,
-        error: 'delivery tracking capacity exceeded',
-      });
+      this._rejectNonPtt(oldest.command.id, oldest.originalEpoch, 'delivery tracking capacity exceeded', eventEpoch);
     }
     this.trackedNonPttCommands.set(pending.command.id, tracked);
-    this._emitNonPttTracked(tracked, 'transport-sent');
+    this._emitTracked(tracked, 'transport-sent', tracked.eventEpoch);
     return true;
   }
 
@@ -407,33 +368,28 @@ export class WsChannel {
     }
     const generic = this.trackedNonPttCommands.get(id);
     if (!generic || generic.eventEpoch !== eventEpoch) return;
-    if (raw.type === 'ack') this._emitNonPttTracked(generic, 'ack');
+    if (raw.type === 'ack') this._emitTracked(generic, 'ack', generic.eventEpoch);
     else if (raw.type === 'response') {
-      this._emitNonPttTracked(
+      this._emitTracked(
         generic,
         raw.ok === false ? 'response-error' : 'response-ok',
+        generic.eventEpoch,
         raw.ok === false ? String(raw.message ?? raw.error ?? 'Command failed') : undefined,
       );
       this.trackedNonPttCommands.delete(id);
     } else if (raw.type === 'error' || raw.status === 'error') {
-      this._emitNonPttTracked(generic, 'error', String(raw.message ?? raw.error ?? 'Command failed'));
+      this._emitTracked(generic, 'error', generic.eventEpoch, String(raw.message ?? raw.error ?? 'Command failed'));
       this.trackedNonPttCommands.delete(id);
     }
   }
 
-  private _emitNonPttTracked(
-    tracked: TrackedNonPttCommand,
-    kind: CommandDeliveryKind,
-    error?: string,
+  private _rejectNonPtt(
+    commandId: string, originalEpoch: number, error: string,
+    eventEpoch = this.transportEpoch, cancelled = false,
   ): void {
-    if (tracked.seen.has(kind)) return;
-    tracked.seen.add(kind);
     this._emitDelivery({
-      commandId: tracked.command.id,
-      kind,
-      originalEpoch: tracked.originalEpoch,
-      eventEpoch: tracked.eventEpoch,
-      ...(error ? { error } : {}),
+      commandId, kind: 'error', originalEpoch, eventEpoch, error,
+      ...(cancelled ? { cancelled } : {}),
     });
   }
 


### PR DESCRIPTION
## Summary

- add one typed non-PTT `RadioIntent` facade for all 92 currently reachable Web radio command envelopes
- repurpose the command store as bounded epoch/session lifecycle diagnostics only
- extend existing WebSocket delivery correlation to generic non-PTT commands with session/provider fencing and bounded tracking
- reject PTT names through the facade and reject stale offline non-idempotent replay
- preserve the exact legacy optimistic path for callers not yet migrated, the exact idempotent offline set, and PTT OFF priority/no-ON-replay

## Why

MOR-1409 needs a typed intent seam whose pending/ACK/error state cannot become displayed radio truth. This A02 package establishes that seam while the canonical StateStore/WS Observation remains the only UI radio-value authority.

## Safety and compatibility

The change does not add a radio Store, reducer, channel, poller, watchdog, provider path, or PTT path. The existing TX controller and PTT delivery tracker are unchanged. Facade dispatch explicitly bypasses legacy optimism; existing callers remain compatible until their later migration packages.

Production ownership is limited to three planned files with 391 changed production lines.

## Validation

- focused A02: 58 passed
- frozen PTT/TX regressions: 33 passed
- frontend check and lint: PASS
- full frontend: 6103 passed
- frontend build: PASS
- full backend: 9255 passed, 68 skipped, 5 deselected, 11 xfailed, 1 xpassed
- Ruff format/check and import contracts: PASS
- generated state types and consumer contracts: PASS
- diff check: PASS

Part of #2317

Linear: [MOR-1409](https://linear.app/morozsm/issue/MOR-1409/stop-ship-make-frontend-controls-pure-statestore-projections-plus)
