### PR TITLE
fix(#2317): keep meter selection local to presentation

### DIFF
--- a/frontend/src/components-v2/layout/MobileRadioLayout.svelte
+++ b/frontend/src/components-v2/layout/MobileRadioLayout.svelte
@@ -21,6 +21,7 @@
   import ScanPanel from '../panels/ScanPanel.svelte';
   import CwPanel from '../panels/CwPanel.svelte';
   import DockMeterPanel from '../panels/DockMeterPanel.svelte';
+  import type { MeterSource } from '../panels/meter-utils';
   import KeyboardHandler from './KeyboardHandler.svelte';
   import SemanticRadioSurfaces from '../wiring/SemanticRadioSurfaces.svelte';
   import MobileChipBar from './mobile-chip-bar.svelte';
@@ -44,7 +45,7 @@
     toBandSelectorProps, toRxAudioProps, toDspProps, toTxProps, toCwProps, toAntennaProps, toScanProps,
   } from '../wiring/state-adapter';
   import {
-    makeVfoHandlers, makeMeterHandlers, makeKeyboardHandlers,
+    makeVfoHandlers, makeKeyboardHandlers,
     makeRfFrontEndHandlers, makeModeHandlers, makeFilterHandlers,
     makeAgcHandlers, makeRitXitHandlers, makeBandHandlers, makePresetHandlers,
     makeRxAudioHandlers, makeDspHandlers, makeTxHandlers, makeCwPanelHandlers,
@@ -82,7 +83,6 @@
 
   // ── Handlers ──
   const vfoHandlers = makeVfoHandlers();
-  const meterHandlers = makeMeterHandlers();
   const keyboardHandlers = makeKeyboardHandlers();
   const modeHandlers = makeModeHandlers();
   const filterHandlers = makeFilterHandlers();
@@ -130,6 +130,13 @@
   let filterModalOpen = $state(false);
   let txSettingsOpen = $state(false);
   let powerModalOpen = $state(false);
+  let mobileMeterSource = $state<MeterSource>('POWER');
+
+  function selectMobileMeterSource(source: string) {
+    if (source === 'S' || source === 'SWR' || source === 'POWER') {
+      mobileMeterSource = source;
+    }
+  }
 
   // ── Chip-scroll IA (#839) ──
   let activeChipId = $state('essentials');
@@ -717,8 +724,8 @@
                 swr={meter.swr}
                 alc={meter.alc ?? 0}
                 txActive={true}
-                meterSource="po"
-                onMeterSourceChange={() => {}}
+                meterSource={mobileMeterSource}
+                onMeterSourceChange={selectMobileMeterSource}
               />
             </div>
           {/if}

--- a/frontend/src/components-v2/layout/__tests__/MobileRadioLayout.component.svelte.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/MobileRadioLayout.component.svelte.test.ts
@@ -26,6 +26,24 @@ vi.mock('../panels/RitXitPanel.svelte', () => ({ default: function S() { return 
 vi.mock('../panels/AntennaPanel.svelte', () => ({ default: function S() { return {}; } }));
 vi.mock('../panels/ScanPanel.svelte', () => ({ default: function S() { return {}; } }));
 vi.mock('../panels/CwPanel.svelte', () => ({ default: function S() { return {}; } }));
+const meterBoundary = vi.hoisted(() => ({
+  props: null as null | {
+    meterSource: string;
+    onMeterSourceChange: (source: string) => void;
+  },
+}));
+vi.mock('../../panels/DockMeterPanel.svelte', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../panels/DockMeterPanel.svelte')>();
+  return {
+    default: function DockMeterPanelBoundary(
+      anchor: Parameters<typeof actual.default>[0],
+      props: Parameters<typeof actual.default>[1],
+    ) {
+      meterBoundary.props = props;
+      return actual.default(anchor, props);
+    },
+  };
+});
 vi.mock('./KeyboardHandler.svelte', () => ({ default: function S() { return {}; } }));
 // Note: ../panels/EssentialsPanel.svelte and ./mobile-chip-bar.svelte are intentionally
 // NOT mocked — the chip-scroll IA contract (#839) is part of what these tests cover.
@@ -104,13 +122,15 @@ vi.mock('$lib/transport/ws-client', async (importOriginal) => ({
 const {
   onMainVfoClickSpy,
   onSubVfoClickSpy,
+  radioIntentSpy,
 } = vi.hoisted(() => ({
   onMainVfoClickSpy: vi.fn(),
   onSubVfoClickSpy: vi.fn(),
+  radioIntentSpy: vi.fn(),
 }));
 vi.mock('../../wiring/command-bus', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../wiring/command-bus')>();
-  const n = vi.fn();
+  const n = radioIntentSpy;
   return {
     ...actual,
     makeVfoHandlers: () => ({
@@ -323,7 +343,9 @@ beforeEach(() => {
   vi.mocked(getTxPermit).mockReturnValue('allowed');
   (radio as unknown as { current: { active?: 'MAIN' | 'SUB' } | null }).current = null;
   radioSubscriberTracker.active = 0;
+  meterBoundary.props = null;
   wsFrameSpy.mockClear();
+  radioIntentSpy.mockClear();
   resetCommandLifecycle();
   onMainVfoClickSpy.mockClear();
   onSubVfoClickSpy.mockClear();
@@ -398,6 +420,7 @@ describe('MOR-1409 local mobile meter selection', () => {
       receiverPatches: vi.mocked(patchReceiver).mock.calls.length,
       subscribers: radioSubscriberTracker.active,
       wsFrames: wsFrameSpy.mock.calls.length,
+      intents: radioIntentSpy.mock.calls.length,
       commands: tx.sends.length,
       lifecycle: JSON.parse(JSON.stringify(getCommandLifecycles())),
       txLifecycle: tx.controller.snapshot(),
@@ -410,12 +433,27 @@ describe('MOR-1409 local mobile meter selection', () => {
       expect(buttons[index].classList.contains('active')).toBe(true);
     }
 
+    buttons[0].click();
+    flushSync();
+    expect(meterBoundary.props?.meterSource).toBe('S');
+
+    for (const forged of ['po', 'UNKNOWN'] as const) {
+      // Deliberately bypass the child control's canonical buttons at the test
+      // boundary: `po` is the legacy type residue and UNKNOWN is out of type.
+      meterBoundary.props?.onMeterSourceChange(forged as never);
+      flushSync();
+      expect(meterBoundary.props?.meterSource).toBe('S');
+      expect(t.querySelector('.status-tag.source')?.getAttribute('data-source')).toBe('S');
+      expect(buttons[0].classList.contains('active')).toBe(true);
+    }
+
     expect(radio.current).toEqual(before.radio);
     expect(vi.mocked(patchActiveReceiver).mock.calls.length).toBe(before.activePatches);
     expect(vi.mocked(patchRadioState).mock.calls.length).toBe(before.radioPatches);
     expect(vi.mocked(patchReceiver).mock.calls.length).toBe(before.receiverPatches);
     expect(radioSubscriberTracker.active).toBe(before.subscribers);
     expect(wsFrameSpy.mock.calls).toHaveLength(before.wsFrames);
+    expect(radioIntentSpy.mock.calls).toHaveLength(before.intents);
     expect(tx.sends).toHaveLength(before.commands);
     expect(JSON.parse(JSON.stringify(getCommandLifecycles()))).toEqual(before.lifecycle);
     expect(tx.controller.snapshot()).toEqual(before.txLifecycle);

--- a/frontend/src/components-v2/layout/__tests__/MobileRadioLayout.component.svelte.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/MobileRadioLayout.component.svelte.test.ts
@@ -11,7 +11,6 @@ vi.mock('../../../components/spectrum/SpectrumPanel.svelte', async () => {
 vi.mock('../panels/lcd/AmberLcdDisplay.svelte', () => ({ default: function S() { return {}; } }));
 vi.mock('../display/FrequencyDisplay.svelte', () => ({ default: function S() { return {}; } }));
 vi.mock('../meters/LinearSMeter.svelte', () => ({ default: function S() { return {}; } }));
-vi.mock('../controls/CollapsiblePanel.svelte', () => ({ default: function S() { return {}; } }));
 vi.mock('../controls/BottomSheet.svelte', () => ({ default: function S() { return {}; } }));
 vi.mock('../controls/BandSelector.svelte', () => ({ default: function S() { return {}; } }));
 vi.mock('../panels/FilterPanel.svelte', () => ({ default: function S() { return {}; } }));
@@ -27,7 +26,6 @@ vi.mock('../panels/RitXitPanel.svelte', () => ({ default: function S() { return 
 vi.mock('../panels/AntennaPanel.svelte', () => ({ default: function S() { return {}; } }));
 vi.mock('../panels/ScanPanel.svelte', () => ({ default: function S() { return {}; } }));
 vi.mock('../panels/CwPanel.svelte', () => ({ default: function S() { return {}; } }));
-vi.mock('../panels/DockMeterPanel.svelte', () => ({ default: function S() { return {}; } }));
 vi.mock('./KeyboardHandler.svelte', () => ({ default: function S() { return {}; } }));
 // Note: ../panels/EssentialsPanel.svelte and ./mobile-chip-bar.svelte are intentionally
 // NOT mocked — the chip-scroll IA contract (#839) is part of what these tests cover.
@@ -49,6 +47,7 @@ vi.mock('./vfo-layout-tokens', () => ({
 }));
 
 // -- Store mocks --
+const radioSubscriberTracker = vi.hoisted(() => ({ active: 0 }));
 vi.mock('$lib/stores/radio.svelte', () => ({
   radio: { current: null as { active?: 'MAIN' | 'SUB' } | null },
   getActiveReceiver: vi.fn(),
@@ -56,6 +55,11 @@ vi.mock('$lib/stores/radio.svelte', () => ({
   patchActiveReceiver: vi.fn(),
   patchRadioState: vi.fn(),
   patchReceiver: vi.fn(),
+  subscribeRadioState: vi.fn((handler: (state: null) => void) => {
+    radioSubscriberTracker.active += 1;
+    handler(null);
+    return () => { radioSubscriberTracker.active -= 1; };
+  }),
 }));
 vi.mock('$lib/stores/connection.svelte', () => ({
   getConnectionStatus: vi.fn(() => ({ connected: false })),
@@ -91,6 +95,12 @@ vi.mock('$lib/stores/capabilities.svelte', () => ({
 }));
 
 // -- Wiring mocks --
+const wsFrameSpy = vi.hoisted(() => vi.fn());
+vi.mock('$lib/transport/ws-client', async (importOriginal) => ({
+  ...await importOriginal<typeof import('$lib/transport/ws-client')>(),
+  sendCommand: wsFrameSpy,
+}));
+
 const {
   onMainVfoClickSpy,
   onSubVfoClickSpy,
@@ -172,7 +182,10 @@ vi.mock('../wiring/state-adapter', () => {
 import MobileRadioLayout from '../MobileRadioLayout.svelte';
 import mobileLayoutSource from '../MobileRadioLayout.svelte?raw';
 import { hasTx, hasDualReceiver } from '$lib/stores/capabilities.svelte';
-import { radio } from '$lib/stores/radio.svelte';
+import {
+  patchActiveReceiver, patchRadioState, patchReceiver, radio, subscribeRadioState,
+} from '$lib/stores/radio.svelte';
+import { getCommandLifecycles, resetCommandLifecycle } from '$lib/stores/commands.svelte';
 import { getTxPermit } from '$lib/utils/tx-permit';
 
 // ---------------------------------------------------------------------------
@@ -309,6 +322,9 @@ beforeEach(() => {
   vi.mocked(hasDualReceiver).mockReturnValue(false);
   vi.mocked(getTxPermit).mockReturnValue('allowed');
   (radio as unknown as { current: { active?: 'MAIN' | 'SUB' } | null }).current = null;
+  radioSubscriberTracker.active = 0;
+  wsFrameSpy.mockClear();
+  resetCommandLifecycle();
   onMainVfoClickSpy.mockClear();
   onSubVfoClickSpy.mockClear();
 });
@@ -357,6 +373,63 @@ describe('MobileRadioLayout structure', () => {
 
   it('renders settings button', () => {
     expect(mountMobile().querySelector('.m-settings-btn')).not.toBeNull();
+  });
+});
+
+describe('MOR-1409 local mobile meter selection', () => {
+  it('changes only component-local presentation state', () => {
+    tx.authority(true);
+    const unsubscribe = subscribeRadioState(() => {});
+    const t = mountMobile();
+    const txChip = Array.from(t.querySelectorAll<HTMLButtonElement>('.m-chip'))
+      .find((button) => button.textContent?.trim() === 'TX');
+    expect(txChip).toBeDefined();
+    txChip!.click();
+    flushSync();
+
+    const buttons = Array.from(t.querySelectorAll<HTMLButtonElement>('.meter-source-btn'));
+    expect(buttons.map((button) => button.textContent?.trim())).toEqual(['S', 'SWR', 'Po']);
+    expect(buttons[2].classList.contains('active')).toBe(true);
+
+    const before = {
+      radio: structuredClone(radio.current),
+      activePatches: vi.mocked(patchActiveReceiver).mock.calls.length,
+      radioPatches: vi.mocked(patchRadioState).mock.calls.length,
+      receiverPatches: vi.mocked(patchReceiver).mock.calls.length,
+      subscribers: radioSubscriberTracker.active,
+      wsFrames: wsFrameSpy.mock.calls.length,
+      commands: tx.sends.length,
+      lifecycle: JSON.parse(JSON.stringify(getCommandLifecycles())),
+      txLifecycle: tx.controller.snapshot(),
+    };
+
+    for (const [index, source] of ['S', 'SWR', 'POWER'].entries()) {
+      buttons[index].click();
+      flushSync();
+      expect(t.querySelector('.status-tag.source')?.getAttribute('data-source')).toBe(source);
+      expect(buttons[index].classList.contains('active')).toBe(true);
+    }
+
+    expect(radio.current).toEqual(before.radio);
+    expect(vi.mocked(patchActiveReceiver).mock.calls.length).toBe(before.activePatches);
+    expect(vi.mocked(patchRadioState).mock.calls.length).toBe(before.radioPatches);
+    expect(vi.mocked(patchReceiver).mock.calls.length).toBe(before.receiverPatches);
+    expect(radioSubscriberTracker.active).toBe(before.subscribers);
+    expect(wsFrameSpy.mock.calls).toHaveLength(before.wsFrames);
+    expect(tx.sends).toHaveLength(before.commands);
+    expect(JSON.parse(JSON.stringify(getCommandLifecycles()))).toEqual(before.lifecycle);
+    expect(tx.controller.snapshot()).toEqual(before.txLifecycle);
+    unsubscribe();
+  });
+
+  it('has no meter factory, Store writer, transport, intent, or lifecycle route', () => {
+    expect(mobileLayoutSource).not.toContain('makeMeterHandlers');
+    expect(mobileLayoutSource).not.toContain('patchRadioState');
+    expect(mobileLayoutSource).not.toContain('sendCommand');
+    expect(mobileLayoutSource).not.toContain('dispatchRadioIntent');
+    expect(mobileLayoutSource).not.toContain('commandLifecycle');
+    expect(mobileLayoutSource).toContain('meterSource={mobileMeterSource}');
+    expect(mobileLayoutSource).toContain('onMeterSourceChange={selectMobileMeterSource}');
   });
 });
 

--- a/frontend/src/components-v2/layout/__tests__/RadioLayout.isolated.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/RadioLayout.isolated.test.ts
@@ -202,7 +202,7 @@ describe('extractMeterState', () => {
     expect(result.swr).toBe(0);
     expect(result.alc).toBe(0);
     expect(result.txActive).toBe(false);
-    expect(result.meterSource).toBe('S');
+    expect(result).not.toHaveProperty('meterSource');
   });
 
   it('extracts sValue from radioState.main', () => {
@@ -224,10 +224,10 @@ describe('extractMeterState', () => {
     expect(result.alc).toBe(64);
   });
 
-  it('extracts txActive and meterSource', () => {
+  it('extracts txActive without projecting local presentation state', () => {
     const result = extractMeterState({ txActive: true, meterSource: 'SWR' });
     expect(result.txActive).toBe(true);
-    expect(result.meterSource).toBe('SWR');
+    expect(result).not.toHaveProperty('meterSource');
   });
 
   it('extracts txActive from ptt field', () => {

--- a/frontend/src/components-v2/layout/layout-utils.ts
+++ b/frontend/src/components-v2/layout/layout-utils.ts
@@ -41,7 +41,6 @@ export function extractMeterState(radioState: any) {
     swr: radioState?.swrMeter ?? radioState?.tx?.swr ?? 0,
     alc: radioState?.alcMeter ?? radioState?.tx?.alc ?? 0,
     txActive: radioState?.txActive ?? radioState?.ptt ?? false,
-    meterSource: radioState?.meterSource ?? 'S',
   };
 }
 

--- a/frontend/src/lib/runtime/adapters/__tests__/mor1409-meter-adapter-reachability.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mor1409-meter-adapter-reachability.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const panelAdaptersSource = readFileSync(
+  'src/lib/runtime/adapters/panel-adapters.ts',
+  'utf8',
+);
+const mobileLayoutSource = readFileSync(
+  'src/components-v2/layout/MobileRadioLayout.svelte',
+  'utf8',
+);
+const layoutUtilsSource = readFileSync(
+  'src/components-v2/layout/layout-utils.ts',
+  'utf8',
+);
+
+describe('MOR-1409 dead meter adapter graph', () => {
+  it('has no production consumer, allocation, or projection residue', () => {
+    expect(mobileLayoutSource).not.toContain('makeMeterHandlers');
+    for (const retired of [
+      'makeMeterHandlers',
+      'getMeterHandlers',
+      'deriveMeterProps',
+      'toMeterProps',
+      'MeterProps',
+    ]) {
+      expect(panelAdaptersSource).not.toContain(retired);
+    }
+    expect(layoutUtilsSource).not.toContain('meterSource');
+  });
+});

--- a/frontend/src/lib/runtime/adapters/panel-adapters.ts
+++ b/frontend/src/lib/runtime/adapters/panel-adapters.ts
@@ -11,7 +11,7 @@ import { runtime } from '../frontend-runtime';
 import {
   toAgcProps, toModeProps, toAntennaProps,
   toRfFrontEndProps, toRitXitProps, toScanProps,
-  toMeterProps, toCwProps, toDspProps, toTxProps,
+  toCwProps, toDspProps, toTxProps,
   toFilterProps, toBandSelectorProps,
   toAudioSpectrumProps, toMemoryPanelProps,
   toAmberTelemetryProps, toVfoControlProps,
@@ -19,7 +19,7 @@ import {
 import {
   makeAgcHandlers, makeModeHandlers, makeAntennaHandlers,
   makeRfFrontEndHandlers, makeRitXitHandlers, makeScanHandlers,
-  makeMeterHandlers, makeCwPanelHandlers, makeDspHandlers,
+  makeCwPanelHandlers, makeDspHandlers,
   makeTxHandlers, makeFilterHandlers, makeBandHandlers,
   makePresetHandlers,
 } from '../commands/panel-commands';
@@ -34,7 +34,7 @@ import type { Capabilities } from '$lib/types/capabilities';
 export type {
   AgcProps, ModeProps, AntennaProps,
   RfFrontEndProps, RitXitProps, ScanProps,
-  MeterProps, CwProps, DspProps, TxProps,
+  CwProps, DspProps, TxProps,
   FilterProps, BandSelectorProps,
   AudioSpectrumProps, MemoryPanelProps,
   AmberTelemetryProps, VfoControlProps,
@@ -81,13 +81,6 @@ export function deriveScanProps() {
 }
 const _scanHandlers = makeScanHandlers();
 export function getScanHandlers() { return _scanHandlers; }
-
-// ── Meter ──
-export function deriveMeterProps() {
-  return toMeterProps(runtime.state, runtime.caps);
-}
-const _meterHandlers = makeMeterHandlers();
-export function getMeterHandlers() { return _meterHandlers; }
 
 // ── CW ──
 export function deriveCwProps() {


### PR DESCRIPTION
Part of #2317

Implements the bounded MOR-1409 A03-pre meter-authority cleanup from the measured execution addendum:
https://github.com/rigplane/rigplane-core/issues/2317#issuecomment-5230424844

- keeps the mobile meter selector as validated component-local presentation state (`S`, `SWR`, `POWER`)
- disconnects the dead meter handler/factory graph from mounted mobile and panel-adapter production paths
- removes `meterSource` from the radio-state meter projection without adding a Store, command, WebSocket, lifecycle, or transport writer
- leaves the reserved factory bodies for the later A03c deletion slice untouched

Evidence:
- RED: focused contract suite failed 5/93 before production changes
- GREEN: focused suite 93/93; three discriminating mutation probes failed and were restored
- frontend: 6112 tests; check 0 errors/warnings; lint and build pass
- backend: 9255 passed, 68 skipped, 5 deselected, 11 xfailed, 1 xpassed
- Ruff lint/format, import-linter 5/5, state-type check, consumer contracts 2/2, i18n, mypy, and diff check pass

Auto-merge remains off. Independent exact-head Agent Review is required before merge.