### PR TITLE
refactor(web): migrate A03b1 receive control intents

### DIFF
--- a/frontend/src/components-v2/wiring/__tests__/dsp-nb-depth.isolated.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/dsp-nb-depth.isolated.test.ts
@@ -15,11 +15,21 @@ vi.mock('$lib/runtime/commands/radio-intents', async () => {
 });
 
 vi.mock('$lib/stores/radio.svelte', () => ({
-  getActiveReceiver: vi.fn(() => null),
-  getRadioState: vi.fn(() => ({ active: 'MAIN' })),
+  getActiveReceiver: vi.fn(() => ({ nb: false, nbLevel: 0 })),
+  getRadioState: vi.fn(() => ({
+    active: 'MAIN', main: { nb: false, nbLevel: 0 }, sub: { nb: false, nbLevel: 0 },
+    nbDepth: 4, nbWidth: 2,
+  })),
   patchActiveReceiver: vi.fn(),
   patchRadioState: vi.fn(),
   patchReceiver: vi.fn(),
+}));
+
+vi.mock('$lib/stores/capabilities.svelte', () => ({
+  getCapabilities: vi.fn(() => ({
+    capabilities: ['nb'], receivers: 2, vfoScheme: 'main_sub', controls: { nb_depth: {} },
+  })),
+  getControlRange: vi.fn(() => null),
 }));
 
 vi.mock('$lib/audio/audio-manager', () => ({
@@ -63,9 +73,9 @@ describe.each([
     expect(sendCommand).toHaveBeenCalledWith('set_nb_depth', { level: 9 });
   });
 
-  it('stores the wire value optimistically (matches polled readback units)', () => {
+  it('does not store the wire value optimistically; Observation remains truth', () => {
     makeHandlers().onNbDepthChange(6);
-    expect(patchRadioState).toHaveBeenCalledWith({ nbDepth: 5 });
+    expect(patchRadioState).not.toHaveBeenCalled();
   });
 });
 

--- a/frontend/src/components-v2/wiring/__tests__/dsp-nr-level.isolated.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/dsp-nr-level.isolated.test.ts
@@ -15,11 +15,18 @@ vi.mock('$lib/runtime/commands/radio-intents', async () => {
 });
 
 vi.mock('$lib/stores/radio.svelte', () => ({
-  getActiveReceiver: vi.fn(() => null),
-  getRadioState: vi.fn(() => ({ active: 'MAIN' })),
+  getActiveReceiver: vi.fn(() => ({ nr: false, nrLevel: 0 })),
+  getRadioState: vi.fn(() => ({
+    active: 'MAIN', main: { nr: false, nrLevel: 0 }, sub: { nr: false, nrLevel: 0 },
+  })),
   patchActiveReceiver: vi.fn(),
   patchRadioState: vi.fn(),
   patchReceiver: vi.fn(),
+}));
+
+vi.mock('$lib/stores/capabilities.svelte', () => ({
+  getCapabilities: vi.fn(() => ({ capabilities: ['nr'], receivers: 2, vfoScheme: 'main_sub' })),
+  getControlRange: vi.fn(() => null),
 }));
 
 vi.mock('$lib/audio/audio-manager', () => ({
@@ -62,8 +69,8 @@ describe.each([
     expect(sendCommand).toHaveBeenCalledWith('set_nr_level', { level: 0, receiver: 0 });
   });
 
-  it('stores the raw wire value optimistically (matches polled readback units)', () => {
+  it('does not store the raw wire value optimistically; Observation remains truth', () => {
     makeHandlers().onNrLevelChange(15);
-    expect(patchActiveReceiver).toHaveBeenCalledWith({ nrLevel: 255 }, true);
+    expect(patchActiveReceiver).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components-v2/wiring/__tests__/rx-audio-authority.isolated.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/rx-audio-authority.isolated.test.ts
@@ -17,6 +17,11 @@ vi.mock('$lib/stores/radio.svelte', () => ({
   patchReceiver: vi.fn(),
 }));
 
+vi.mock('$lib/stores/capabilities.svelte', () => ({
+  getCapabilities: vi.fn(() => ({ capabilities: ['af_level'], receivers: 1, vfoScheme: 'ab' })),
+  getControlRange: vi.fn(() => null),
+}));
+
 vi.mock('$lib/audio/audio-manager', () => ({
   audioManager: {
     rxEnabled: false,
@@ -85,7 +90,7 @@ describe('RX-audio presentation command authority (MOR-1124)', () => {
 
     expect(sendCommand).toHaveBeenNthCalledWith(1, 'set_af_level', { level: 0, receiver: 0 });
     expect(sendCommand).toHaveBeenNthCalledWith(2, 'set_af_level', { level: 0.42, receiver: 0 });
-    expect(patchActiveReceiver).toHaveBeenCalledWith({ afLevel: 0.42 }, true);
+    expect(patchActiveReceiver).not.toHaveBeenCalled();
     expect(setMuted).toHaveBeenNthCalledWith(1, true);
     expect(setMuted).toHaveBeenNthCalledWith(2, false);
   });

--- a/frontend/src/components-v2/wiring/__tests__/rx-audio-authority.isolated.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/rx-audio-authority.isolated.test.ts
@@ -2,11 +2,18 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
 
 vi.mock('$lib/transport/ws-client', () => ({
+  getControlSession: vi.fn(() => ({ state: 'connected', epoch: 1 })),
+  onCommandDelivery: vi.fn(() => () => undefined),
+  onControlSessionTransition: vi.fn(() => () => undefined),
   sendCommand: vi.fn(),
 }));
-vi.mock('$lib/runtime/commands/radio-intents', async () => {
+vi.mock('$lib/runtime/commands/radio-intents', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('$lib/runtime/commands/radio-intents')>();
   const { sendCommand } = await import('$lib/transport/ws-client');
-  return { dispatchRadioIntent: ({ name, params }: { name: string; params: Record<string, unknown> }) => sendCommand(name, params) };
+  return {
+    ...actual,
+    dispatchRadioIntent: ({ name, params }: { name: string; params: Record<string, unknown> }) => sendCommand(name, params),
+  };
 });
 
 vi.mock('$lib/stores/radio.svelte', () => ({

--- a/frontend/src/components-v2/wiring/__tests__/semantic-band-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-band-wiring.component.test.ts
@@ -47,6 +47,18 @@ vi.mock('$lib/runtime/commands/radio-intents', async () => {
   const { sendCommand } = await import('$lib/transport/ws-client');
   return { dispatchRadioIntent: ({ name, params }: { name: string; params: Record<string, unknown> }) => sendCommand(name, params) };
 });
+vi.mock('$lib/stores/radio.svelte', () => ({
+  getRadioState: vi.fn(() => h.state),
+  getActiveReceiver: vi.fn(() => {
+    const state = h.state as ServerState | null;
+    return state?.active === 'SUB' ? state.sub ?? null : state?.main ?? null;
+  }),
+  patchActiveReceiver: vi.fn(), patchRadioState: vi.fn(), patchReceiver: vi.fn(),
+}));
+vi.mock('$lib/stores/capabilities.svelte', () => ({
+  getCapabilities: vi.fn(() => h.caps),
+  getControlRange: vi.fn(() => null),
+}));
 vi.mock('$lib/audio/audio-manager', () => ({
   audioManager: {
     get rxEnabled() { return h.rxEnabled; },

--- a/frontend/src/components-v2/wiring/__tests__/semantic-rx-audio-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rx-audio-wiring.component.test.ts
@@ -51,10 +51,19 @@ const h = vi.hoisted(() => ({
   setRxVolume: vi.fn(),
 }));
 
-vi.mock('$lib/transport/ws-client', () => ({ sendCommand: vi.fn() }));
-vi.mock('$lib/runtime/commands/radio-intents', async () => {
+vi.mock('$lib/transport/ws-client', () => ({
+  getControlSession: vi.fn(() => ({ state: 'connected', epoch: 1 })),
+  onCommandDelivery: vi.fn(() => () => undefined),
+  onControlSessionTransition: vi.fn(() => () => undefined),
+  sendCommand: vi.fn(),
+}));
+vi.mock('$lib/runtime/commands/radio-intents', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('$lib/runtime/commands/radio-intents')>();
   const { sendCommand } = await import('$lib/transport/ws-client');
-  return { dispatchRadioIntent: ({ name, params }: { name: string; params: Record<string, unknown> }) => sendCommand(name, params) };
+  return {
+    ...actual,
+    dispatchRadioIntent: ({ name, params }: { name: string; params: Record<string, unknown> }) => sendCommand(name, params),
+  };
 });
 vi.mock('$lib/stores/radio.svelte', () => ({
   getRadioState: vi.fn(() => h.state),

--- a/frontend/src/components-v2/wiring/__tests__/vfo-wiring.isolated.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/vfo-wiring.isolated.test.ts
@@ -17,7 +17,7 @@ vi.mock('$lib/stores/radio.svelte', () => ({
 }));
 
 vi.mock('$lib/stores/capabilities.svelte', () => ({
-  getCapabilities: vi.fn(() => ({ receivers: 2, vfoScheme: 'main_sub', capabilities: [] })),
+  getCapabilities: vi.fn(() => ({ receivers: 2, vfoScheme: 'main_sub', capabilities: ['rit', 'xit'] })),
   getControlRange: vi.fn(() => null),
 }));
 
@@ -322,6 +322,9 @@ describe('makeModeHandlers', () => {
 describe('makeBandHandlers', () => {
   beforeEach(() => {
     vi.mocked(sendCommand).mockClear();
+    vi.mocked(getRadioState).mockReturnValue({
+      active: 'MAIN', main: { freqHz: 14_074_000 }, sub: { freqHz: 7_074_000 },
+    } as any);
   });
 
   it('emits set_band when bsrCode is provided', () => {
@@ -341,19 +344,22 @@ describe('makeRitXitHandlers', () => {
   beforeEach(() => {
     vi.mocked(sendCommand).mockClear();
     vi.mocked(patchRadioState).mockClear();
+    vi.mocked(getRadioState).mockReturnValue({
+      active: 'MAIN', main: { freqHz: 14_074_000 }, sub: { freqHz: 7_074_000 }, ritFreq: 250,
+    } as any);
   });
 
   it('emits set_rit_frequency for RIT offset changes', () => {
     makeRitXitHandlers().onRitOffsetChange(350);
 
-    expect(patchRadioState).toHaveBeenCalledWith({ ritFreq: 350 });
+    expect(patchRadioState).not.toHaveBeenCalled();
     expect(sendCommand).toHaveBeenCalledWith('set_rit_frequency', { freq: 350 });
   });
 
   it('emits set_rit_frequency for XIT offset changes', () => {
     makeRitXitHandlers().onXitOffsetChange(-450);
 
-    expect(patchRadioState).toHaveBeenCalledWith({ ritFreq: -450 });
+    expect(patchRadioState).not.toHaveBeenCalled();
     expect(sendCommand).toHaveBeenCalledWith('set_rit_frequency', { freq: -450 });
   });
 });

--- a/frontend/src/components-v2/wiring/command-bus.ts
+++ b/frontend/src/components-v2/wiring/command-bus.ts
@@ -15,9 +15,18 @@ import type { ReceiverState } from '$lib/types/state';
 import { getCapabilities } from '$lib/stores/capabilities.svelte';
 import { adjustTuningStep, getTuningStep } from '$lib/stores/tuning.svelte';
 import { audioManager } from '$lib/audio/audio-manager';
-export { makeFilterHandlers, makeModeHandlers, makeRfFrontEndHandlers, makeRxAudioHandlers } from '$lib/runtime/commands/panel-commands';
+export {
+  makeAgcHandlers,
+  makeBandHandlers,
+  makeDspHandlers,
+  makeFilterHandlers,
+  makeModeHandlers,
+  makePresetHandlers,
+  makeRfFrontEndHandlers,
+  makeRitXitHandlers,
+  makeRxAudioHandlers,
+} from '$lib/runtime/commands/panel-commands';
 import type { KeyboardActionConfig } from '../layout/keyboard-map';
-import { nbDepthDisplayToRaw, nrDisplayToRaw } from '$lib/radio/filter-controls';
 import { clampRef, clampSpan } from '../../components/spectrum/spectrum-toolbar-logic';
 import { setPendingFocus } from '$lib/radio/pending-focus';
 
@@ -152,119 +161,6 @@ export function makeVfoHandlers() {
     onQuickDw: () => cmd('quick_dualwatch'),
     onQuickSplit: () => cmd('quick_split'),
     onTrackingToggle: (on: boolean) => cmd('set_main_sub_tracking', { on }),
-  };
-}
-
-/* ── AGC Handlers ────────────────────────────────────────────── */
-
-export function makeAgcHandlers() {
-  return {
-    onAgcModeChange: (mode: number) => {
-      patchActiveReceiver({ agc: mode });
-      cmd('set_agc', { mode, receiver: activeReceiverParam() });
-    },
-  };
-}
-
-/* ── RIT / XIT Handlers ──────────────────────────────────────── */
-
-export function makeRitXitHandlers() {
-  return {
-    onRitToggle: () => {
-      const next = !(getRadioState()?.ritOn ?? false);
-      patchRadioState({ ritOn: next });
-      cmd('set_rit_status', { on: next });
-    },
-    onXitToggle: () => {
-      const next = !(getRadioState()?.ritTx ?? false);
-      patchRadioState({ ritTx: next });
-      cmd('set_rit_tx_status', { on: next });
-    },
-    onRitOffsetChange: (hz: number) => {
-      patchRadioState({ ritFreq: hz });
-      cmd('set_rit_frequency', { freq: hz });
-    },
-    onXitOffsetChange: (hz: number) => {
-      // RIT and ∂TX share the same offset register
-      patchRadioState({ ritFreq: hz });
-      cmd('set_rit_frequency', { freq: hz });
-    },
-    onClear: () => {
-      patchRadioState({ ritFreq: 0 });
-      cmd('set_rit_frequency', { freq: 0 });
-    },
-  };
-}
-
-/* ── DSP Handlers ────────────────────────────────────────────── */
-
-export function makeDspHandlers() {
-  return {
-    onNrModeChange: (mode: number) => {
-      const on = mode > 0;
-      const receiver = activeReceiverParam();
-      patchActiveReceiver({ nr: on });
-      cmd('set_nr', { on, receiver });
-    },
-    onNrLevelChange: (level: number) => {
-      const receiver = activeReceiverParam();
-      // MOR-490: slider is 0-15 (front-panel scale); wire is 0-255 BCD.
-      // Store the raw wire value optimistically so it matches the polled
-      // readback (which the adapter scales raw -> display).
-      const raw = nrDisplayToRaw(level);
-      patchActiveReceiver({ nrLevel: raw }, true);
-      cmd('set_nr_level', { level: raw, receiver });
-    },
-    onNbToggle: (on: boolean) => {
-      const receiver = activeReceiverParam();
-      patchActiveReceiver({ nb: on });
-      cmd('set_nb', { on, receiver });
-    },
-    onNbLevelChange: (level: number) => {
-      const receiver = activeReceiverParam();
-      patchActiveReceiver({ nbLevel: level }, true);
-      cmd('set_nb_level', { level, receiver });
-    },
-    onNotchModeChange: (mode: string) => {
-      const receiver = activeReceiverParam();
-      if (mode === 'auto') {
-        patchActiveReceiver({ autoNotch: true, manualNotch: false });
-        cmd('set_auto_notch', { on: true, receiver });
-      } else if (mode === 'manual') {
-        patchActiveReceiver({ autoNotch: false, manualNotch: true });
-        cmd('set_manual_notch', { on: true, receiver });
-      } else {
-        patchActiveReceiver({ autoNotch: false, manualNotch: false });
-        cmd('set_auto_notch', { on: false, receiver });
-        cmd('set_manual_notch', { on: false, receiver });
-      }
-    },
-    onNotchFreqChange: (value: number) => {
-      const receiver = activeReceiverParam();
-      cmd('set_notch_filter', { value, receiver });
-    },
-    onNbDepthChange: (level: number) => {
-      // MOR-498: slider is 1-10 (front-panel scale); wire is 0-9.  Store the
-      // wire value optimistically so it matches the polled/NB-B readback
-      // (which the adapter offsets wire -> display).
-      const wire = nbDepthDisplayToRaw(level);
-      patchRadioState({ nbDepth: wire });
-      cmd('set_nb_depth', { level: wire });
-    },
-    onNbWidthChange: (level: number) => {
-      patchRadioState({ nbWidth: level });
-      cmd('set_nb_width', { level });
-    },
-    onManualNotchWidthChange: (value: number) => {
-      const receiver = activeReceiverParam();
-      patchActiveReceiver({ manualNotchWidth: value }, true);
-      cmd('set_manual_notch_width', { value, receiver });
-    },
-    onAgcTimeChange: (value: number) => {
-      const receiver = activeReceiverParam();
-      patchActiveReceiver({ agcTimeConstant: value }, true);
-      cmd('set_agc_time_constant', { value, receiver });
-    },
   };
 }
 
@@ -482,34 +378,6 @@ export function makeAudioRoutingHandlers() {
         main_gain_db: mainDb ?? 0,
         sub_gain_db: subDb ?? 0,
       };
-    },
-  };
-}
-
-/* ── Band Selector Handlers ──────────────────────────────────── */
-
-export function makePresetHandlers() {
-  return {
-    onPresetSelect: (freq: number, mode: string, filter?: number) => {
-      cmd('set_freq', { freq, receiver: 0 });
-      cmd('set_mode', { mode, filter: filter ?? 1, receiver: 0 });
-    },
-    onFreqPreset: (freq: number, mode: string, filter?: number) => {
-      cmd('set_freq', { freq, receiver: 0 });
-      cmd('set_mode', { mode, filter: filter ?? 1, receiver: 0 });
-    },
-  };
-}
-
-export function makeBandHandlers() {
-  return {
-    onBandSelect: (_name: string, freq: number, bsrCode?: number) => {
-      if (bsrCode !== undefined) {
-        cmd('set_band', { band: bsrCode });
-      } else {
-        // Bands without BSR code (e.g. 60m) — fall back to direct freq set
-        cmd('set_freq', { freq, receiver: 0 });
-      }
     },
   };
 }

--- a/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.test.ts
@@ -106,7 +106,7 @@ function state(active: 'MAIN' | 'SUB' = 'MAIN'): ServerState {
     agcTimeConstant: 4,
     digisel: false,
     ipplus: false,
-    afLevel: 50,
+    afLevel: 50 / 255,
     rfGain: 128,
     squelch: 0,
     nb: false,
@@ -308,7 +308,7 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
 
     expect(exactCalls()).toEqual([
       ['set_af_level', { level: 0, receiver: 0 }],
-      ['set_af_level', { level: 50, receiver: 0 }],
+      ['set_af_level', { level: 50 / 255, receiver: 0 }],
       ['set_af_level', { level: 0.42, receiver: 0 }],
     ]);
     expectIntentTransport();
@@ -325,6 +325,67 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
     expect(h.setRxVolume).toHaveBeenCalledWith(0.37);
     expect(h.setVolume).toHaveBeenCalledWith(37);
     expect(h.sendCommand).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid normalized AF input before radio lifecycle or transport', () => {
+    const rxAudio = makeRxAudioHandlers();
+    for (const level of [-0.01, 1.01, 10, Number.NaN, Number.POSITIVE_INFINITY]) {
+      rxAudio.onAfLevelChange(level);
+    }
+
+    expect(h.sendCommand).not.toHaveBeenCalled();
+    expect(getCommandLifecycles()).toHaveLength(0);
+  });
+
+  it('rejects invalid browser-local AF input before any local or radio effect', () => {
+    h.rxEnabled = true;
+    const rxAudio = makeRxAudioHandlers();
+    for (const level of [-0.01, 1.01, 10, Number.NaN, Number.POSITIVE_INFINITY]) {
+      rxAudio.onAfLevelChange(level);
+    }
+
+    expect(h.setRxVolume).not.toHaveBeenCalled();
+    expect(h.setVolume).not.toHaveBeenCalled();
+    expect(h.sendCommand).not.toHaveBeenCalled();
+    expect(getCommandLifecycles()).toHaveLength(0);
+  });
+
+  it('accepts exact normalized AF endpoints unchanged on radio and browser-local paths', () => {
+    const rxAudio = makeRxAudioHandlers();
+    rxAudio.onAfLevelChange(0);
+    rxAudio.onAfLevelChange(1);
+
+    expect(exactCalls()).toEqual([
+      ['set_af_level', { level: 0, receiver: 0 }],
+      ['set_af_level', { level: 1, receiver: 0 }],
+    ]);
+    expectIntentTransport();
+
+    h.sendCommand.mockClear();
+    resetCommandLifecycle();
+    h.rxEnabled = true;
+    rxAudio.onAfLevelChange(0);
+    rxAudio.onAfLevelChange(1);
+    expect(h.setRxVolume).toHaveBeenNthCalledWith(1, 0);
+    expect(h.setRxVolume).toHaveBeenNthCalledWith(2, 1);
+    expect(h.setVolume).toHaveBeenNthCalledWith(1, 0);
+    expect(h.setVolume).toHaveBeenNthCalledWith(2, 100);
+    expect(h.sendCommand).not.toHaveBeenCalled();
+    expect(getCommandLifecycles()).toHaveLength(0);
+  });
+
+  it('never turns an invalid observed AF level into a mute or restore command', () => {
+    const rxAudio = makeRxAudioHandlers();
+    for (const level of [-0.01, 1.01, 10, Number.NaN, Number.POSITIVE_INFINITY]) {
+      h.state = state();
+      h.state!.main!.afLevel = level;
+      rxAudio.onMonitorModeChange('mute');
+      rxAudio.onMonitorModeChange('local');
+    }
+
+    expect(h.setMuted).toHaveBeenCalled();
+    expect(h.sendCommand).not.toHaveBeenCalled();
+    expect(getCommandLifecycles()).toHaveLength(0);
   });
 
   it('fails closed for stale derived inputs, unsupported DSP, and impossible one-RX physical SUB', () => {

--- a/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.test.ts
@@ -21,6 +21,11 @@ const h = vi.hoisted(() => ({
   patchActiveReceiver: vi.fn(),
   patchRadioState: vi.fn(),
   patchReceiver: vi.fn(),
+  rxEnabled: false,
+  setMuted: vi.fn(),
+  setRxLive: vi.fn(),
+  setRxVolume: vi.fn(),
+  setVolume: vi.fn(),
 }));
 
 vi.mock('$lib/transport/ws-client', () => ({
@@ -55,11 +60,11 @@ vi.mock('$lib/stores/capabilities.svelte', () => ({
 
 vi.mock('$lib/runtime/frontend-runtime', () => ({
   runtime: {
-    rxEnabled: false,
-    setMuted: vi.fn(),
-    setRxLive: vi.fn(),
-    setRxVolume: vi.fn(),
-    setVolume: vi.fn(),
+    get rxEnabled() { return h.rxEnabled; },
+    setMuted: h.setMuted,
+    setRxLive: h.setRxLive,
+    setRxVolume: h.setRxVolume,
+    setVolume: h.setVolume,
   },
 }));
 
@@ -68,10 +73,15 @@ vi.mock('$lib/audio/audio-manager', () => ({
 }));
 
 import {
+  makeAgcHandlers,
+  makeBandHandlers,
+  makeDspHandlers,
   makeFilterHandlers,
   makeModeHandlers,
   makePresetHandlers,
   makeRfFrontEndHandlers,
+  makeRitXitHandlers,
+  makeRxAudioHandlers,
 } from '../panel-commands';
 import * as compatibilityBus from '$lib/../components-v2/wiring/command-bus';
 import { getCommandLifecycles, resetCommandLifecycle } from '$lib/stores/commands.svelte';
@@ -93,13 +103,19 @@ function state(active: 'MAIN' | 'SUB' = 'MAIN'): ServerState {
     att: 0,
     preamp: 0,
     agc: 2,
+    agcTimeConstant: 4,
     digisel: false,
     ipplus: false,
     afLevel: 50,
     rfGain: 128,
     squelch: 0,
     nb: false,
+    nbLevel: 3,
     nr: false,
+    nrLevel: 68,
+    autoNotch: false,
+    manualNotch: false,
+    manualNotchWidth: 1,
     sMeter: 0,
   };
   return {
@@ -109,6 +125,9 @@ function state(active: 'MAIN' | 'SUB' = 'MAIN'): ServerState {
     ritOn: false,
     ritTx: true,
     ritFreq: 300,
+    nbDepth: 4,
+    nbWidth: 2,
+    notchFilter: 64,
     fieldStatus: {
       active: freshStatus,
       'main.dataMode': freshStatus,
@@ -142,23 +161,29 @@ function expectIntentTransport(): void {
   expect(getCommandLifecycles()).toHaveLength(h.sendCommand.mock.calls.length);
 }
 
-describe('MOR-1409 A03a canonical RX/filter/core intent handlers', () => {
+describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     h.state = state();
     h.unavailable.clear();
     h.caps = {
-      capabilities: ['pbt'],
+      capabilities: ['pbt', 'agc', 'rit', 'xit', 'nr', 'nb', 'notch', 'af_level'],
       receivers: 2,
       vfoScheme: 'main_sub',
       controls: {
         pbt_inner: { raw_min: 0, raw_max: 255, raw_center: 128, display_min: -1200, display_max: 1200 },
+        nb_depth: { raw_min: 0, raw_max: 9, raw_center: 0, display_min: 1, display_max: 10 },
       },
     };
     h.sendCommand.mockClear();
     h.patchActiveReceiver.mockClear();
     h.patchRadioState.mockClear();
     h.patchReceiver.mockClear();
+    h.rxEnabled = false;
+    h.setMuted.mockClear();
+    h.setRxLive.mockClear();
+    h.setRxVolume.mockClear();
+    h.setVolume.mockClear();
   });
 
   afterEach(() => {
@@ -166,10 +191,16 @@ describe('MOR-1409 A03a canonical RX/filter/core intent handlers', () => {
     vi.useRealTimers();
   });
 
-  it('exports the A03a1 and A03a2 canonical factories from the compatibility bus', () => {
+  it('exports every landed A03a and A03b1 canonical factory from the compatibility bus', () => {
     expect(compatibilityBus.makeModeHandlers).toBe(makeModeHandlers);
     expect(compatibilityBus.makeFilterHandlers).toBe(makeFilterHandlers);
     expect(compatibilityBus.makeRfFrontEndHandlers).toBe(makeRfFrontEndHandlers);
+    expect(compatibilityBus.makeAgcHandlers).toBe(makeAgcHandlers);
+    expect(compatibilityBus.makeRitXitHandlers).toBe(makeRitXitHandlers);
+    expect(compatibilityBus.makeDspHandlers).toBe(makeDspHandlers);
+    expect(compatibilityBus.makeBandHandlers).toBe(makeBandHandlers);
+    expect(compatibilityBus.makePresetHandlers).toBe(makePresetHandlers);
+    expect(compatibilityBus.makeRxAudioHandlers).toBe(makeRxAudioHandlers);
   });
 
   it('routes mode, DATA mode, and MOD input through exact lifecycle envelopes without Store writes', () => {
@@ -187,17 +218,133 @@ describe('MOR-1409 A03a canonical RX/filter/core intent handlers', () => {
     expect(h.patchRadioState).not.toHaveBeenCalled();
   });
 
-  it('keeps both deferred preset callbacks wholly on the legacy raw path', () => {
+  it('routes both preset callbacks through exact frequency-then-mode lifecycle records', () => {
     const preset = makePresetHandlers();
     preset.onPresetSelect(14_074_000, 'USB', 2);
     preset.onFreqPreset(7_074_000, 'CW');
 
-    expect(h.sendCommand.mock.calls).toEqual([
+    expect(exactCalls()).toEqual([
       ['set_freq', { freq: 14_074_000, receiver: 0 }],
       ['set_mode', { mode: 'USB', filter: 2, receiver: 0 }],
       ['set_freq', { freq: 7_074_000, receiver: 0 }],
       ['set_mode', { mode: 'CW', filter: 1, receiver: 0 }],
     ]);
+    expectIntentTransport();
+  });
+
+  it('routes AGC and the complete shared RIT/XIT family through typed lifecycle without Store writes', () => {
+    makeAgcHandlers().onAgcModeChange(3);
+    const rit = makeRitXitHandlers();
+    rit.onRitToggle();
+    rit.onXitToggle();
+    rit.onRitOffsetChange(450);
+    rit.onXitOffsetChange(-325);
+    rit.onClear();
+
+    expect(exactCalls()).toEqual([
+      ['set_agc', { mode: 3, receiver: 0 }],
+      ['set_rit_status', { on: true }],
+      ['set_rit_tx_status', { on: false }],
+      ['set_rit_frequency', { freq: 450 }],
+      ['set_rit_frequency', { freq: -325 }],
+      ['set_rit_frequency', { freq: 0 }],
+    ]);
+    expectIntentTransport();
+    expect(h.patchActiveReceiver).not.toHaveBeenCalled();
+    expect(h.patchRadioState).not.toHaveBeenCalled();
+  });
+
+  it('preserves the complete DSP conversions and notch command order on typed lifecycle', () => {
+    const dsp = makeDspHandlers();
+    dsp.onNrModeChange(1);
+    dsp.onNrLevelChange(8);
+    dsp.onNbToggle(true);
+    dsp.onNbLevelChange(7);
+    dsp.onNotchModeChange('off');
+    dsp.onNotchFreqChange(96);
+    dsp.onNbDepthChange(6);
+    dsp.onNbWidthChange(4);
+    dsp.onManualNotchWidthChange(2);
+    dsp.onAgcTimeChange(5);
+
+    expect(exactCalls()).toEqual([
+      ['set_nr', { on: true, receiver: 0 }],
+      ['set_nr_level', { level: 136, receiver: 0 }],
+      ['set_nb', { on: true, receiver: 0 }],
+      ['set_nb_level', { level: 7, receiver: 0 }],
+      ['set_auto_notch', { on: false, receiver: 0 }],
+      ['set_manual_notch', { on: false, receiver: 0 }],
+      ['set_notch_filter', { value: 96, receiver: 0 }],
+      ['set_nb_depth', { level: 5 }],
+      ['set_nb_width', { level: 4 }],
+      ['set_manual_notch_width', { value: 2, receiver: 0 }],
+      ['set_agc_time_constant', { value: 5, receiver: 0 }],
+    ]);
+    expectIntentTransport();
+    expect(h.patchActiveReceiver).not.toHaveBeenCalled();
+    expect(h.patchRadioState).not.toHaveBeenCalled();
+  });
+
+  it('keeps band/preset on the known physical receiver without inspecting A/B frequency topology', () => {
+    h.state = state('SUB');
+    makeBandHandlers().onBandSelect('60m', 5_357_000);
+    makeBandHandlers().onBandSelect('20m', 14_225_000, 5);
+    makePresetHandlers().onPresetSelect(7_074_000, 'CW', 1);
+
+    expect(exactCalls()).toEqual([
+      ['set_freq', { freq: 5_357_000, receiver: 1 }],
+      ['set_band', { band: 5 }],
+      ['set_freq', { freq: 7_074_000, receiver: 1 }],
+      ['set_mode', { mode: 'CW', filter: 1, receiver: 1 }],
+    ]);
+    expectIntentTransport();
+  });
+
+  it('preserves browser-local RX effects while radio AF commands use observed truth and typed lifecycle', () => {
+    const rxAudio = makeRxAudioHandlers();
+    rxAudio.onMonitorModeChange('mute');
+    rxAudio.onMonitorModeChange('local');
+    rxAudio.onAfLevelChange(0.42);
+
+    expect(exactCalls()).toEqual([
+      ['set_af_level', { level: 0, receiver: 0 }],
+      ['set_af_level', { level: 50, receiver: 0 }],
+      ['set_af_level', { level: 0.42, receiver: 0 }],
+    ]);
+    expectIntentTransport();
+    expect(h.setMuted).toHaveBeenNthCalledWith(1, true);
+    expect(h.setMuted).toHaveBeenNthCalledWith(2, false);
+    expect(h.setRxLive).toHaveBeenNthCalledWith(1, false);
+    expect(h.setRxLive).toHaveBeenNthCalledWith(2, false);
+    expect(h.patchActiveReceiver).not.toHaveBeenCalled();
+
+    h.sendCommand.mockClear();
+    resetCommandLifecycle();
+    h.rxEnabled = true;
+    rxAudio.onAfLevelChange(0.37);
+    expect(h.setRxVolume).toHaveBeenCalledWith(0.37);
+    expect(h.setVolume).toHaveBeenCalledWith(37);
+    expect(h.sendCommand).not.toHaveBeenCalled();
+  });
+
+  it('fails closed for stale derived inputs, unsupported DSP, and impossible one-RX physical SUB', () => {
+    h.unavailable.add('ritOn');
+    h.unavailable.add('main.autoNotch');
+    makeRitXitHandlers().onRitToggle();
+    makeDspHandlers().onNotchModeChange('auto');
+
+    h.state = { ...oneReceiverAbState(), active: 'SUB' } as ServerState;
+    h.caps = { capabilities: ['agc', 'rit', 'xit', 'nr', 'nb', 'notch', 'af_level'], receivers: 1, vfoScheme: 'ab' };
+    makeAgcHandlers().onAgcModeChange(2);
+    makeBandHandlers().onBandSelect('60m', 5_357_000);
+    makeRxAudioHandlers().onAfLevelChange(0.5);
+
+    h.state = state();
+    h.unavailable.clear();
+    h.caps = { capabilities: [], receivers: 2, vfoScheme: 'main_sub' };
+    makeDspHandlers().onNrModeChange(1);
+
+    expect(h.sendCommand).not.toHaveBeenCalled();
     expect(getCommandLifecycles()).toHaveLength(0);
   });
 
@@ -393,7 +540,11 @@ describe('MOR-1409 A03a canonical RX/filter/core intent handlers', () => {
   it('keeps raw transport out of migrated blocks and Store writers out of their implementation', () => {
     const panelSource = readFileSync(resolve(process.cwd(), 'src/lib/runtime/commands/panel-commands.ts'), 'utf8');
     const busSource = readFileSync(resolve(process.cwd(), 'src/components-v2/wiring/command-bus.ts'), 'utf8');
-    const assignedNames = ['makeFilterHandlers', 'makeModeHandlers', 'makeRfFrontEndHandlers'];
+    const assignedNames = [
+      'makeAgcHandlers', 'makeBandHandlers', 'makeDspHandlers', 'makeFilterHandlers',
+      'makeModeHandlers', 'makePresetHandlers', 'makeRfFrontEndHandlers',
+      'makeRitXitHandlers', 'makeRxAudioHandlers',
+    ];
 
     for (const [index, name] of assignedNames.entries()) {
       const start = panelSource.indexOf(`export function ${name}`);
@@ -423,5 +574,22 @@ describe('MOR-1409 A03a canonical RX/filter/core intent handlers', () => {
     const rfBlock = panelSource.slice(rfStart, rfEnd);
     expect(rfBlock).not.toMatch(/\b(?:freqHz|activeSlot|vfoA|vfoB|unselectedVfo)\b/);
     expect(panelSource).toContain('dispatchRadioIntent({ name, params } as RadioIntent)');
+
+    for (const name of [
+      'set_agc', 'set_agc_time_constant', 'set_rit_status', 'set_rit_tx_status',
+      'set_rit_frequency', 'set_band', 'set_freq', 'set_mode', 'set_nr',
+      'set_nr_level', 'set_nb', 'set_nb_level', 'set_auto_notch',
+      'set_manual_notch', 'set_notch_filter', 'set_nb_depth', 'set_nb_width',
+      'set_manual_notch_width', 'set_af_level',
+    ]) {
+      expect(a03aNames).not.toContain(`'${name}'`);
+    }
+
+    for (const factory of ['makeBandHandlers', 'makePresetHandlers']) {
+      const start = panelSource.indexOf(`export function ${factory}`);
+      const end = panelSource.indexOf('\nexport function ', start + 1);
+      expect(panelSource.slice(start, end)).not.toMatch(/\b(?:activeSlot|vfoA|vfoB|unselectedVfo)\b/);
+    }
+    expect(panelSource).not.toMatch(/dispatchRadioIntent\(\{\s*name:\s*['"]ptt(?:_on|_off)?['"]/);
   });
 });

--- a/frontend/src/lib/runtime/commands/__tests__/radio-intents.isolated.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/radio-intents.isolated.test.ts
@@ -140,10 +140,16 @@ describe('typed non-PTT radio intents', () => {
       { name: 'set_freq', params: { freq: 1.5 } },
       { name: 'set_freq', params: { freq: 1 }, unexpected: true },
       { name: 'set_compressor', params: { on: 1 } },
+      { name: 'set_af_level', params: { level: -0.01, receiver: 0 } },
+      { name: 'set_af_level', params: { level: 1.01, receiver: 0 } },
+      { name: 'set_af_level', params: { level: 10, receiver: 0 } },
+      { name: 'set_af_level', params: { level: '0.5', receiver: 0 } },
       { name: 'set_af_level', params: { level: 10, receiver: 7 } },
       { name: 'set_af_level', params: { level: 10, receiver: '0' } },
       { name: 'set_af_level', params: { level: Number.NaN, receiver: 0 } },
       { name: 'set_af_level', params: { level: Number.POSITIVE_INFINITY, receiver: 0 } },
+      { name: 'set_af_level', params: { level: 0.5, receiver: 0, unexpected: true } },
+      { name: 'set_af_level', params: { level: 0.5, receiver: 0 }, unexpected: true },
       { name: 'set_vfo', params: { vfo: 'VFOA' } },
       { name: 'set_mode', params: { mode: 'USB', receiver: 0, unexpected: true } },
       { name: 'vfo_swap', params: { unexpected: true } },
@@ -158,17 +164,18 @@ describe('typed non-PTT radio intents', () => {
     expect(lifecycle.getCommandLifecycles()).toHaveLength(0);
   });
 
-  it('accepts the shipped fractional AF-level scale without weakening integer fields', () => {
-    intents.dispatchRadioIntent({
-      id: 'af-fraction', name: 'set_af_level', params: { level: 0.42, receiver: 0 },
-    });
+  it('accepts exact normalized AF boundaries and fractions without weakening integer fields', () => {
+    const levels = [0, 1, 50 / 255] as const;
+    levels.forEach((level, index) => intents.dispatchRadioIntent({
+      id: `af-normalized-${index}`, name: 'set_af_level', params: { level, receiver: 0 },
+    }));
 
-    expect(harness.sendCommand).toHaveBeenCalledExactlyOnceWith(
-      'set_af_level', { level: 0.42, receiver: 0 }, 'af-fraction', { optimistic: false },
-    );
-    expect(lifecycle.getCommandLifecycles()).toEqual([
-      expect.objectContaining({ id: 'af-fraction', name: 'set_af_level', status: 'pending' }),
-    ]);
+    levels.forEach((level, index) => expect(harness.sendCommand).toHaveBeenNthCalledWith(
+      index + 1, 'set_af_level', { level, receiver: 0 }, `af-normalized-${index}`, { optimistic: false },
+    ));
+    expect(lifecycle.getCommandLifecycles()).toHaveLength(levels.length);
+    expect(lifecycle.getCommandLifecycles()).toEqual(expect.arrayContaining(levels.map((_, index) =>
+      expect.objectContaining({ id: `af-normalized-${index}`, name: 'set_af_level', status: 'pending' }))));
     expect(() => intents.dispatchRadioIntent({
       name: 'set_nr_level', params: { level: 0.42, receiver: 0 },
     } as never)).toThrow(TypeError);
@@ -181,7 +188,7 @@ describe('typed non-PTT radio intents', () => {
       { name: 'set_compressor', params: { on: true } },
       { name: 'set_nb', params: { on: false, receiver: 0 } },
       { name: 'set_mic_gain', params: { level: 10 } },
-      { name: 'set_af_level', params: { level: 10, receiver: 1 } },
+      { name: 'set_af_level', params: { level: 50 / 255, receiver: 1 } },
       { name: 'set_cw_pitch', params: { value: 10 } },
       { name: 'set_pbt_inner', params: { value: 10, receiver: 0 } },
       { name: 'set_data_mode', params: { mode: 1, receiver: 1 } },

--- a/frontend/src/lib/runtime/commands/__tests__/radio-intents.isolated.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/radio-intents.isolated.test.ts
@@ -142,6 +142,8 @@ describe('typed non-PTT radio intents', () => {
       { name: 'set_compressor', params: { on: 1 } },
       { name: 'set_af_level', params: { level: 10, receiver: 7 } },
       { name: 'set_af_level', params: { level: 10, receiver: '0' } },
+      { name: 'set_af_level', params: { level: Number.NaN, receiver: 0 } },
+      { name: 'set_af_level', params: { level: Number.POSITIVE_INFINITY, receiver: 0 } },
       { name: 'set_vfo', params: { vfo: 'VFOA' } },
       { name: 'set_mode', params: { mode: 'USB', receiver: 0, unexpected: true } },
       { name: 'vfo_swap', params: { unexpected: true } },
@@ -154,6 +156,22 @@ describe('typed non-PTT radio intents', () => {
     }
     expect(harness.sendCommand).not.toHaveBeenCalled();
     expect(lifecycle.getCommandLifecycles()).toHaveLength(0);
+  });
+
+  it('accepts the shipped fractional AF-level scale without weakening integer fields', () => {
+    intents.dispatchRadioIntent({
+      id: 'af-fraction', name: 'set_af_level', params: { level: 0.42, receiver: 0 },
+    });
+
+    expect(harness.sendCommand).toHaveBeenCalledExactlyOnceWith(
+      'set_af_level', { level: 0.42, receiver: 0 }, 'af-fraction', { optimistic: false },
+    );
+    expect(lifecycle.getCommandLifecycles()).toEqual([
+      expect.objectContaining({ id: 'af-fraction', name: 'set_af_level', status: 'pending' }),
+    ]);
+    expect(() => intents.dispatchRadioIntent({
+      name: 'set_nr_level', params: { level: 0.42, receiver: 0 },
+    } as never)).toThrow(TypeError);
   });
 
   it('accepts representative exact envelopes derived from every descriptor family', () => {

--- a/frontend/src/lib/runtime/commands/panel-commands.ts
+++ b/frontend/src/lib/runtime/commands/panel-commands.ts
@@ -26,7 +26,7 @@ import { consumePendingFocus } from '$lib/radio/pending-focus';
 import { getModeFilter } from '$lib/radio/mode-filter-memory';
 import { modInputCommand, modInputStateKey } from '$lib/radio/mod-input';
 import { nbDepthDisplayToRaw, nrDisplayToRaw } from '$lib/radio/filter-controls';
-import { dispatchRadioIntent, type RadioIntent } from './radio-intents';
+import { dispatchRadioIntent, isNormalizedLevel, type RadioIntent } from './radio-intents';
 
 /* ── Shared helpers ──────────────────────────────────────────────── */
 
@@ -692,8 +692,7 @@ export function makeRxAudioHandlers() {
         const receiver = knownReceiverField('afLevel');
         const state = getRadioState();
         const currentAf = receiver === 1 ? state?.sub?.afLevel : state?.main?.afLevel;
-        if (hasCapability('af_level') && receiver !== null && typeof currentAf === 'number'
-          && Number.isFinite(currentAf)) {
+        if (hasCapability('af_level') && receiver !== null && isNormalizedLevel(currentAf)) {
           if (savedAfLevel === null) savedAfLevel = currentAf;
           dispatchRadioIntent({ name: 'set_af_level', params: { level: 0, receiver } });
         }
@@ -709,14 +708,13 @@ export function makeRxAudioHandlers() {
       }
     },
     onAfLevelChange: (level: number) => {
+      if (!isNormalizedLevel(level)) return;
       if (runtime.rxEnabled) {
-        if (typeof level !== 'number' || !Number.isFinite(level)) return;
         runtime.setRxVolume(level);
         runtime.setVolume(Math.round(level * 100));
       } else {
         const receiver = knownReceiverField('afLevel');
-        if (!hasCapability('af_level') || receiver === null
-          || typeof level !== 'number' || !Number.isFinite(level)) return;
+        if (!hasCapability('af_level') || receiver === null) return;
         dispatchRadioIntent({ name: 'set_af_level', params: { level, receiver } });
       }
     },

--- a/frontend/src/lib/runtime/commands/panel-commands.ts
+++ b/frontend/src/lib/runtime/commands/panel-commands.ts
@@ -66,6 +66,25 @@ function knownActiveReceiver(field?: string, target?: 'MAIN' | 'SUB'): Receiver 
   return field && !isFieldAvailable(state, `${prefix}.${field}`) ? null : receiver;
 }
 
+function hasCapability(name: string): boolean {
+  return getCapabilities()?.capabilities.includes(name) ?? false;
+}
+
+function knownReceiverField(field: string): Receiver | null {
+  const receiver = knownActiveReceiver(field);
+  if (receiver === null) return null;
+  const state = getRadioState();
+  const target = receiver === 1 ? state?.sub : state?.main;
+  const value = (target as unknown as Record<string, unknown> | null | undefined)?.[field];
+  return value === undefined || value === null ? null : receiver;
+}
+
+function knownTopLevelField(field: string): boolean {
+  const state = getRadioState();
+  const value = (state as unknown as Record<string, unknown> | null)?.[field];
+  return state !== null && value !== undefined && value !== null && isFieldAvailable(state, field);
+}
+
 /* ── Inlined PBT / IF-shift helpers (from filter-controls.ts) ────── */
 // TODO: replace with `$lib/radio/filter-controls` once #996 lands.
 
@@ -127,8 +146,9 @@ function mapIfShiftToPbt(
 export function makeAgcHandlers() {
   return {
     onAgcModeChange: (mode: number) => {
-      patchActiveReceiver({ agc: mode });
-      cmd('set_agc', { mode, receiver: activeReceiverParam() });
+      const receiver = knownReceiverField('agc');
+      if (!hasCapability('agc') || receiver === null || !Number.isSafeInteger(mode)) return;
+      dispatchRadioIntent({ name: 'set_agc', params: { mode, receiver } });
     },
   };
 }
@@ -247,27 +267,32 @@ export function makeRfFrontEndHandlers() {
 export function makeRitXitHandlers() {
   return {
     onRitToggle: () => {
-      const next = !(getRadioState()?.ritOn ?? false);
-      patchRadioState({ ritOn: next });
-      cmd('set_rit_status', { on: next });
+      const state = getRadioState();
+      if (!hasCapability('rit') || knownActiveReceiver() === null
+        || !knownTopLevelField('ritOn') || typeof state?.ritOn !== 'boolean') return;
+      dispatchRadioIntent({ name: 'set_rit_status', params: { on: !state.ritOn } });
     },
     onXitToggle: () => {
-      const next = !(getRadioState()?.ritTx ?? false);
-      patchRadioState({ ritTx: next });
-      cmd('set_rit_tx_status', { on: next });
+      const state = getRadioState();
+      if (!hasCapability('xit') || knownActiveReceiver() === null
+        || !knownTopLevelField('ritTx') || typeof state?.ritTx !== 'boolean') return;
+      dispatchRadioIntent({ name: 'set_rit_tx_status', params: { on: !state.ritTx } });
     },
     onRitOffsetChange: (hz: number) => {
-      patchRadioState({ ritFreq: hz });
-      cmd('set_rit_frequency', { freq: hz });
+      if (!hasCapability('rit') || knownActiveReceiver() === null
+        || !knownTopLevelField('ritFreq') || !Number.isSafeInteger(hz)) return;
+      dispatchRadioIntent({ name: 'set_rit_frequency', params: { freq: hz } });
     },
     onXitOffsetChange: (hz: number) => {
       // RIT and XIT share the same offset register
-      patchRadioState({ ritFreq: hz });
-      cmd('set_rit_frequency', { freq: hz });
+      if (!hasCapability('xit') || knownActiveReceiver() === null
+        || !knownTopLevelField('ritFreq') || !Number.isSafeInteger(hz)) return;
+      dispatchRadioIntent({ name: 'set_rit_frequency', params: { freq: hz } });
     },
     onClear: () => {
-      patchRadioState({ ritFreq: 0 });
-      cmd('set_rit_frequency', { freq: 0 });
+      if ((!hasCapability('rit') && !hasCapability('xit')) || knownActiveReceiver() === null
+        || !knownTopLevelField('ritFreq')) return;
+      dispatchRadioIntent({ name: 'set_rit_frequency', params: { freq: 0 } });
     },
   };
 }
@@ -376,69 +401,69 @@ export function makeCwPanelHandlers() {
 export function makeDspHandlers() {
   return {
     onNrModeChange: (mode: number) => {
-      const on = mode > 0;
-      const receiver = activeReceiverParam();
-      patchActiveReceiver({ nr: on });
-      cmd('set_nr', { on, receiver });
+      const receiver = knownReceiverField('nr');
+      if (!hasCapability('nr') || receiver === null || !Number.isSafeInteger(mode)) return;
+      dispatchRadioIntent({ name: 'set_nr', params: { on: mode > 0, receiver } });
     },
     onNrLevelChange: (level: number) => {
-      const receiver = activeReceiverParam();
+      const receiver = knownReceiverField('nrLevel');
+      if (!hasCapability('nr') || receiver === null || !Number.isFinite(level)) return;
       // MOR-490: slider is 0-15 (front-panel scale); wire is 0-255 BCD.
-      // Store the raw wire value optimistically so it matches the polled
-      // readback (which the adapter scales raw -> display).
       const raw = nrDisplayToRaw(level);
-      patchActiveReceiver({ nrLevel: raw }, true);
-      cmd('set_nr_level', { level: raw, receiver });
+      dispatchRadioIntent({ name: 'set_nr_level', params: { level: raw, receiver } });
     },
     onNbToggle: (on: boolean) => {
-      const receiver = activeReceiverParam();
-      patchActiveReceiver({ nb: on });
-      cmd('set_nb', { on, receiver });
+      const receiver = knownReceiverField('nb');
+      if (!hasCapability('nb') || receiver === null || typeof on !== 'boolean') return;
+      dispatchRadioIntent({ name: 'set_nb', params: { on, receiver } });
     },
     onNbLevelChange: (level: number) => {
-      const receiver = activeReceiverParam();
-      patchActiveReceiver({ nbLevel: level }, true);
-      cmd('set_nb_level', { level, receiver });
+      const receiver = knownReceiverField('nbLevel');
+      if (!hasCapability('nb') || receiver === null || !Number.isSafeInteger(level)) return;
+      dispatchRadioIntent({ name: 'set_nb_level', params: { level, receiver } });
     },
     onNotchModeChange: (mode: string) => {
-      const receiver = activeReceiverParam();
+      const receiver = knownReceiverField('autoNotch');
+      if (!hasCapability('notch') || receiver === null
+        || knownReceiverField('manualNotch') !== receiver
+        || (mode !== 'auto' && mode !== 'manual' && mode !== 'off')) return;
       if (mode === 'auto') {
-        patchActiveReceiver({ autoNotch: true, manualNotch: false });
-        cmd('set_auto_notch', { on: true, receiver });
+        dispatchRadioIntent({ name: 'set_auto_notch', params: { on: true, receiver } });
       } else if (mode === 'manual') {
-        patchActiveReceiver({ autoNotch: false, manualNotch: true });
-        cmd('set_manual_notch', { on: true, receiver });
+        dispatchRadioIntent({ name: 'set_manual_notch', params: { on: true, receiver } });
       } else {
-        patchActiveReceiver({ autoNotch: false, manualNotch: false });
-        cmd('set_auto_notch', { on: false, receiver });
-        cmd('set_manual_notch', { on: false, receiver });
+        dispatchRadioIntent({ name: 'set_auto_notch', params: { on: false, receiver } });
+        dispatchRadioIntent({ name: 'set_manual_notch', params: { on: false, receiver } });
       }
     },
     onNotchFreqChange: (value: number) => {
-      const receiver = activeReceiverParam();
-      cmd('set_notch_filter', { value, receiver });
+      const receiver = knownActiveReceiver();
+      if (!hasCapability('notch') || receiver === null || !knownTopLevelField('notchFilter')
+        || !Number.isSafeInteger(value)) return;
+      dispatchRadioIntent({ name: 'set_notch_filter', params: { value, receiver } });
     },
     onNbDepthChange: (level: number) => {
       // MOR-498: slider is 1-10 (front-panel scale); wire is 0-9.  Store the
-      // wire value optimistically so it matches the polled/NB-B readback
-      // (which the adapter offsets wire -> display).
+      // wire value the backend expects (the adapter offsets wire -> display).
+      if (!getCapabilities()?.controls?.nb_depth || knownActiveReceiver() === null
+        || !knownTopLevelField('nbDepth') || !Number.isFinite(level)) return;
       const wire = nbDepthDisplayToRaw(level);
-      patchRadioState({ nbDepth: wire });
-      cmd('set_nb_depth', { level: wire });
+      dispatchRadioIntent({ name: 'set_nb_depth', params: { level: wire } });
     },
     onNbWidthChange: (level: number) => {
-      patchRadioState({ nbWidth: level });
-      cmd('set_nb_width', { level });
+      if (!getCapabilities()?.controls?.nb_depth || knownActiveReceiver() === null
+        || !knownTopLevelField('nbWidth') || !Number.isSafeInteger(level)) return;
+      dispatchRadioIntent({ name: 'set_nb_width', params: { level } });
     },
     onManualNotchWidthChange: (value: number) => {
-      const receiver = activeReceiverParam();
-      patchActiveReceiver({ manualNotchWidth: value }, true);
-      cmd('set_manual_notch_width', { value, receiver });
+      const receiver = knownReceiverField('manualNotchWidth');
+      if (!hasCapability('notch') || receiver === null || !Number.isSafeInteger(value)) return;
+      dispatchRadioIntent({ name: 'set_manual_notch_width', params: { value, receiver } });
     },
     onAgcTimeChange: (value: number) => {
-      const receiver = activeReceiverParam();
-      patchActiveReceiver({ agcTimeConstant: value }, true);
-      cmd('set_agc_time_constant', { value, receiver });
+      const receiver = knownReceiverField('agcTimeConstant');
+      if (!hasCapability('agc') || receiver === null || !Number.isSafeInteger(value)) return;
+      dispatchRadioIntent({ name: 'set_agc_time_constant', params: { value, receiver } });
     },
   };
 }
@@ -610,10 +635,13 @@ export function makeFilterHandlers() {
 export function makeBandHandlers() {
   return {
     onBandSelect: (_name: string, freq: number, bsrCode?: number) => {
+      const receiver = knownReceiverField('freqHz');
+      if (receiver === null || !Number.isSafeInteger(freq)
+        || (bsrCode !== undefined && !Number.isSafeInteger(bsrCode))) return;
       if (bsrCode !== undefined) {
-        cmd('set_band', { band: bsrCode });
+        dispatchRadioIntent({ name: 'set_band', params: { band: bsrCode } });
       } else {
-        cmd('set_freq', { freq, receiver: 0 });
+        dispatchRadioIntent({ name: 'set_freq', params: { freq, receiver } });
       }
     },
   };
@@ -622,15 +650,17 @@ export function makeBandHandlers() {
 /* ── Preset Handlers ─────────────────────────────────────────────── */
 
 export function makePresetHandlers() {
+  const select = (freq: number, mode: string, filter = 1): void => {
+    const receiver = knownReceiverField('freqHz');
+    if (receiver === null || knownReceiverField('mode') !== receiver
+      || !Number.isSafeInteger(freq) || typeof mode !== 'string' || mode.length === 0
+      || !Number.isSafeInteger(filter)) return;
+    dispatchRadioIntent({ name: 'set_freq', params: { freq, receiver } });
+    dispatchRadioIntent({ name: 'set_mode', params: { mode, filter, receiver } });
+  };
   return {
-    onPresetSelect: (freq: number, mode: string, filter?: number) => {
-      cmd('set_freq', { freq, receiver: 0 });
-      cmd('set_mode', { mode, filter: filter ?? 1, receiver: 0 });
-    },
-    onFreqPreset: (freq: number, mode: string, filter?: number) => {
-      cmd('set_freq', { freq, receiver: 0 });
-      cmd('set_mode', { mode, filter: filter ?? 1, receiver: 0 });
-    },
+    onPresetSelect: select,
+    onFreqPreset: select,
   };
 }
 
@@ -641,10 +671,14 @@ let savedAfLevel: number | null = null;
 export function makeRxAudioHandlers() {
   return {
     onMonitorModeChange: (mode: string) => {
+      if (mode !== 'live' && mode !== 'mute' && mode !== 'local' && mode !== 'radio') return;
       if (mode === 'live') {
         runtime.setMuted(false);
         if (savedAfLevel !== null) {
-          cmd('set_af_level', { level: savedAfLevel, receiver: activeReceiverParam() });
+          const receiver = knownReceiverField('afLevel');
+          if (hasCapability('af_level') && receiver !== null) {
+            dispatchRadioIntent({ name: 'set_af_level', params: { level: savedAfLevel, receiver } });
+          }
           savedAfLevel = null;
         }
         runtime.setRxLive(true);
@@ -655,28 +689,35 @@ export function makeRxAudioHandlers() {
 
       if (mode === 'mute') {
         runtime.setMuted(true);
-        const rx = getRadioState();
-        const key = rx?.active === 'SUB' ? 'sub' : 'main';
-        const currentAf = rx?.[key]?.afLevel ?? 0.5;
-        if (savedAfLevel === null) savedAfLevel = currentAf;
-        cmd('set_af_level', { level: 0, receiver: activeReceiverParam() });
+        const receiver = knownReceiverField('afLevel');
+        const state = getRadioState();
+        const currentAf = receiver === 1 ? state?.sub?.afLevel : state?.main?.afLevel;
+        if (hasCapability('af_level') && receiver !== null && typeof currentAf === 'number'
+          && Number.isFinite(currentAf)) {
+          if (savedAfLevel === null) savedAfLevel = currentAf;
+          dispatchRadioIntent({ name: 'set_af_level', params: { level: 0, receiver } });
+        }
       } else {
         runtime.setMuted(false);
         if (savedAfLevel !== null) {
-          cmd('set_af_level', { level: savedAfLevel, receiver: activeReceiverParam() });
-          patchActiveReceiver({ afLevel: savedAfLevel }, true);
+          const receiver = knownReceiverField('afLevel');
+          if (hasCapability('af_level') && receiver !== null) {
+            dispatchRadioIntent({ name: 'set_af_level', params: { level: savedAfLevel, receiver } });
+          }
           savedAfLevel = null;
         }
       }
     },
     onAfLevelChange: (level: number) => {
       if (runtime.rxEnabled) {
+        if (typeof level !== 'number' || !Number.isFinite(level)) return;
         runtime.setRxVolume(level);
         runtime.setVolume(Math.round(level * 100));
       } else {
-        const receiver = activeReceiverParam();
-        patchActiveReceiver({ afLevel: level }, true);
-        cmd('set_af_level', { level, receiver });
+        const receiver = knownReceiverField('afLevel');
+        if (!hasCapability('af_level') || receiver === null
+          || typeof level !== 'number' || !Number.isFinite(level)) return;
+        dispatchRadioIntent({ name: 'set_af_level', params: { level, receiver } });
       }
     },
   };

--- a/frontend/src/lib/runtime/commands/radio-intents.ts
+++ b/frontend/src/lib/runtime/commands/radio-intents.ts
@@ -2,7 +2,7 @@ import { acknowledgeCommand, beginCommand, cancelPendingCommands, failCommand, t
 import { makeCommandId } from '$lib/types/protocol';
 import { getControlSession, onCommandDelivery, onControlSessionTransition, sendCommand } from '$lib/transport/ws-client';
 
-type FieldKind = 'boolean' | 'integer' | 'receiver' | 'string' | 'vfo';
+type FieldKind = 'boolean' | 'integer' | 'number' | 'receiver' | 'string' | 'vfo';
 type FieldSpec = FieldKind | `${FieldKind}?`;
 type IntentSpec = { names: readonly string[]; params: Readonly<Record<string, FieldSpec>> };
 
@@ -19,7 +19,8 @@ const intentSpecs = [
     'set_anti_vox_gain', 'set_break_in_delay', 'set_compressor_level', 'set_drive_gain', 'set_mic_gain',
     'set_monitor_gain', 'set_nb_depth', 'set_nb_width', 'set_rf_power', 'set_vox_delay', 'set_vox_gain',
   ], params: { level: 'integer' } },
-  { names: ['set_af_level', 'set_nb_level', 'set_nr_level', 'set_preamp', 'set_rf_gain', 'set_squelch'], params: { level: 'integer', receiver: 'receiver' } },
+  { names: ['set_af_level'], params: { level: 'number', receiver: 'receiver' } },
+  { names: ['set_nb_level', 'set_nr_level', 'set_preamp', 'set_rf_gain', 'set_squelch'], params: { level: 'integer', receiver: 'receiver' } },
   { names: ['set_cw_pitch', 'set_tuner_status'], params: { value: 'integer' } },
   { names: ['set_agc_time_constant', 'set_manual_notch_width', 'set_notch_filter', 'set_pbt_inner', 'set_pbt_outer'], params: { value: 'integer', receiver: 'receiver' } },
   { names: ['set_agc', 'set_apf', 'set_data_mode'], params: { mode: 'integer', receiver: 'receiver' } },
@@ -70,6 +71,7 @@ const specsByName = new Map<string, Readonly<Record<string, FieldSpec>>>(specEnt
 
 function matchesValue(kind: FieldKind, value: unknown): boolean {
   if (kind === 'integer') return typeof value === 'number' && Number.isSafeInteger(value);
+  if (kind === 'number') return typeof value === 'number' && Number.isFinite(value);
   if (kind === 'boolean') return typeof value === 'boolean';
   if (kind === 'receiver') return value === 0 || value === 1;
   if (kind === 'vfo') return value === 'A' || value === 'B' || value === 'MAIN' || value === 'SUB';

--- a/frontend/src/lib/runtime/commands/radio-intents.ts
+++ b/frontend/src/lib/runtime/commands/radio-intents.ts
@@ -2,7 +2,7 @@ import { acknowledgeCommand, beginCommand, cancelPendingCommands, failCommand, t
 import { makeCommandId } from '$lib/types/protocol';
 import { getControlSession, onCommandDelivery, onControlSessionTransition, sendCommand } from '$lib/transport/ws-client';
 
-type FieldKind = 'boolean' | 'integer' | 'number' | 'receiver' | 'string' | 'vfo';
+type FieldKind = 'boolean' | 'integer' | 'normalized' | 'receiver' | 'string' | 'vfo';
 type FieldSpec = FieldKind | `${FieldKind}?`;
 type IntentSpec = { names: readonly string[]; params: Readonly<Record<string, FieldSpec>> };
 
@@ -19,7 +19,7 @@ const intentSpecs = [
     'set_anti_vox_gain', 'set_break_in_delay', 'set_compressor_level', 'set_drive_gain', 'set_mic_gain',
     'set_monitor_gain', 'set_nb_depth', 'set_nb_width', 'set_rf_power', 'set_vox_delay', 'set_vox_gain',
   ], params: { level: 'integer' } },
-  { names: ['set_af_level'], params: { level: 'number', receiver: 'receiver' } },
+  { names: ['set_af_level'], params: { level: 'normalized', receiver: 'receiver' } },
   { names: ['set_nb_level', 'set_nr_level', 'set_preamp', 'set_rf_gain', 'set_squelch'], params: { level: 'integer', receiver: 'receiver' } },
   { names: ['set_cw_pitch', 'set_tuner_status'], params: { value: 'integer' } },
   { names: ['set_agc_time_constant', 'set_manual_notch_width', 'set_notch_filter', 'set_pbt_inner', 'set_pbt_outer'], params: { value: 'integer', receiver: 'receiver' } },
@@ -69,9 +69,13 @@ const specEntries = intentSpecs.flatMap(({ names, params }) => names.map((name) 
 export const RADIO_INTENT_NAMES = Object.freeze(specEntries.map(([name]) => name)) as readonly RadioIntentName[];
 const specsByName = new Map<string, Readonly<Record<string, FieldSpec>>>(specEntries);
 
+export function isNormalizedLevel(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 1;
+}
+
 function matchesValue(kind: FieldKind, value: unknown): boolean {
   if (kind === 'integer') return typeof value === 'number' && Number.isSafeInteger(value);
-  if (kind === 'number') return typeof value === 'number' && Number.isFinite(value);
+  if (kind === 'normalized') return isNormalizedLevel(value);
   if (kind === 'boolean') return typeof value === 'boolean';
   if (kind === 'receiver') return value === 0 || value === 1;
   if (kind === 'vfo') return value === 'A' || value === 'B' || value === 'MAIN' || value === 'SUB';

--- a/tests/test_command_service.py
+++ b/tests/test_command_service.py
@@ -1525,6 +1525,13 @@ def test_normalized_level_command_expectation_matches_radio_scale(
     assert observation.value > 0.9
 
 
+def test_normalized_af_level_fifty_round_trips_to_raw_fifty() -> None:
+    """The public AF fixture stays normalized while the server owns raw conversion."""
+    from rigplane.web.handlers.control import _normalized_or_raw_level
+
+    assert _normalized_or_raw_level(50 / 255) == 50
+
+
 @pytest.mark.asyncio
 async def test_raw_external_rigctld_level_readback_normalizes_before_reconcile() -> (
     None


### PR DESCRIPTION
Refs #2317.

Implements the bounded MOR-1409 A03b1 gate from the durable superseding whole-family re-slice addendum:
https://github.com/rigplane/rigplane-core/issues/2317#issuecomment-5230879753

## Scope

- canonicalize the complete AGC family, including AGC time;
- canonicalize complete RIT/XIT, band, frequency/mode preset, DSP/noise/notch, and RX-audio radio-control families;
- replace migrated compatibility-bus factories with immediate re-exports;
- dispatch migrated radio commands factory-locally through the typed non-PTT lifecycle facade;
- remove migrated optimistic Store writes, raw duplicate bodies, and unknown-derived defaults;
- preserve RIT/XIT shared offset, DSP conversions/notch order, exact frequency-then-mode preset order, browser-local RX effects, and the existing VFO command path;
- accept one physical MAIN receiver with A/B Selected/Unselected while rejecting impossible physical SUB; never infer receiver identity from VFO or frequency.

Exact base: `5f1b38a0bc6df5914a8f846e8f97fa08e8ac4334`

Exact head: `f6fef6111109e42c887fde1fd2e3576216505fcb`

Production churn: 345 changed lines across exactly three authorized owners (`command-bus.ts` 154, `panel-commands.ts` 185, `radio-intents.ts` 6), inside the published 270-350 projection and below the 400-line hard stop.

## Verification

- RED-first focused proof: 7 expected failures, 15 passes before implementation;
- focused complete A03b1 family set: 116/116 passed;
- A02 lifecycle/correlation: 65/65 passed;
- frozen PTT/OFF: 33/33 passed;
- full frontend: 297 files, 6135 tests passed; check/lint/build passed;
- full backend excluding hardware integration: 8992 passed, 12 skipped, 5 deselected, 11 xfailed, 1 xpassed;
- Ruff, format, import-linter, generated state types, consumer contracts, diff/status, and exact-base checks passed;
- ten required mutation probes were killed separately, restored, and followed by clean exact-tree reruns.

No A03b2, backend/provider, audio transport, meter, scope/spectrum, binder/layout/skin, MOR-1414, PTT representation, VFO-path, DTR/RTS, or automatic TX/TUNE/PTT change is included.

Auto-merge remains off. A fresh independent exact-head review is required before merge. Any head change invalidates prior evidence.
