### PR TITLE
refactor(#2317): migrate CW and TX auxiliary intents

### DIFF
--- a/frontend/src/components-v2/wiring/__tests__/semantic-antenna-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-antenna-wiring.component.test.ts
@@ -41,6 +41,18 @@ const h = vi.hoisted(() => ({
 }));
 
 vi.mock('$lib/transport/ws-client', () => ({ sendCommand: vi.fn() }));
+vi.mock('$lib/stores/radio.svelte', () => ({
+  getActiveReceiver: vi.fn(() => {
+    const state = h.state as ServerState | null;
+    return state?.active === 'SUB' ? state.sub ?? null : state?.main ?? null;
+  }),
+  getRadioState: vi.fn(() => h.state as ServerState | null),
+  patchActiveReceiver: vi.fn(), patchRadioState: vi.fn(), patchReceiver: vi.fn(),
+}));
+vi.mock('$lib/stores/capabilities.svelte', () => ({
+  getCapabilities: vi.fn(() => h.caps as Capabilities | null),
+  getControlRange: vi.fn(() => null),
+}));
 vi.mock('$lib/runtime/commands/radio-intents', async () => {
   const { sendCommand } = await import('$lib/transport/ws-client');
   return { dispatchRadioIntent: ({ name, params }: { name: string; params: Record<string, unknown> }) => sendCommand(name, params) };

--- a/frontend/src/components-v2/wiring/__tests__/tx-aux-command-bus.isolated.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/tx-aux-command-bus.isolated.test.ts
@@ -23,10 +23,21 @@ vi.mock('$lib/runtime/commands/radio-intents', async () => {
 });
 vi.mock('$lib/stores/radio.svelte', () => ({
   getActiveReceiver: vi.fn(() => null),
-  getRadioState: vi.fn(() => ({ active: 'MAIN' })),
+  getRadioState: vi.fn(() => ({
+    active: 'MAIN', powerLevel: 0.5, micGain: 128, tunerStatus: 0, voxOn: false,
+    compressorOn: false, compressorLevel: 20, monitorOn: false, monitorGain: 20,
+    driveGain: 50,
+  })),
   patchActiveReceiver: vi.fn(),
   patchRadioState: vi.fn(),
   patchReceiver: vi.fn(),
+}));
+vi.mock('$lib/state/field-status', () => ({ isFieldAvailable: vi.fn(() => true) }));
+vi.mock('$lib/stores/capabilities.svelte', () => ({
+  getCapabilities: vi.fn(() => ({
+    capabilities: ['tx', 'tuner', 'vox', 'compressor', 'monitor', 'drive_gain'],
+  })),
+  getControlRange: vi.fn(() => null),
 }));
 vi.mock('$lib/audio/audio-manager', () => ({
   audioManager: {

--- a/frontend/src/components-v2/wiring/command-bus.ts
+++ b/frontend/src/components-v2/wiring/command-bus.ts
@@ -18,6 +18,7 @@ import { audioManager } from '$lib/audio/audio-manager';
 export {
   makeAgcHandlers,
   makeBandHandlers,
+  makeCwPanelHandlers,
   makeDspHandlers,
   makeFilterHandlers,
   makeModeHandlers,
@@ -25,6 +26,9 @@ export {
   makeRfFrontEndHandlers,
   makeRitXitHandlers,
   makeRxAudioHandlers,
+  makeScanHandlers,
+  makeTxHandlers,
+  makeAntennaHandlers,
 } from '$lib/runtime/commands/panel-commands';
 import type { KeyboardActionConfig } from '../layout/keyboard-map';
 import { clampRef, clampSpan } from '../../components/spectrum/spectrum-toolbar-logic';
@@ -164,72 +168,6 @@ export function makeVfoHandlers() {
   };
 }
 
-/** CW panel — RightSidebar / CwPanel.svelte */
-export function makeCwPanelHandlers() {
-  return {
-    onCwPitchChange: (value: number) => {
-      patchRadioState({ cwPitch: value });
-      cmd('set_cw_pitch', { value });
-    },
-    onKeySpeedChange: (speed: number) => {
-      patchRadioState({ keySpeed: speed });
-      cmd('set_key_speed', { speed });
-    },
-    onBreakInToggle: () => {
-      const current = getRadioState()?.breakIn ?? 0;
-      const next = current > 0 ? 0 : 1;
-      patchRadioState({ breakIn: next });
-      cmd('set_break_in', { mode: next });
-    },
-    onBreakInModeChange: (mode: number) => {
-      patchRadioState({ breakIn: mode });
-      cmd('set_break_in', { mode });
-    },
-    onApfChange: (mode: number) => {
-      const receiver = activeReceiverParam();
-      patchActiveReceiver({ apfTypeLevel: mode }, true);
-      cmd('set_apf', { mode, receiver });
-    },
-    onTwinPeakToggle: () => {
-      const receiver = activeReceiverParam();
-      const state = getRadioState();
-      const rx = receiver === 0 ? state?.main : state?.sub;
-      const current = rx?.twinPeakFilter ?? false;
-      const next = !current;
-      patchActiveReceiver({ twinPeakFilter: next }, true);
-      cmd('set_twin_peak', { on: next, receiver });
-    },
-    onAutoTune: () => {
-      cmd('cw_auto_tune', {});
-    },
-    onWpmChange: (speed: number) => {
-      patchRadioState({ keySpeed: speed });
-      cmd('set_key_speed', { speed });
-    },
-    onBreakInDelayChange: (level: number) => {
-      patchRadioState({ breakInDelay: level });
-      cmd('set_break_in_delay', { level });
-    },
-    onSidetonePitchChange: (value: number) => {
-      patchRadioState({ cwPitch: value });
-      cmd('set_cw_pitch', { value });
-    },
-    onSidetoneLevelChange: (level: number) => {
-      patchRadioState({ monitorGain: level });
-      cmd('set_monitor_gain', { level });
-    },
-    onReversePaddleToggle: () => {
-      const current = getRadioState()?.dashRatio ?? 0;
-      const next = current < 0 ? 0 : -1;
-      patchRadioState({ dashRatio: next });
-      cmd('set_dash_ratio', { ratio: next });
-    },
-    onKeyerTypeChange: (type: number) => {
-      cmd('set_keyer_type', { type });
-    },
-  };
-}
-
 /* ── VOX Handlers ───────────────────────────────────────────── */
 
 export function makeVoxHandlers() {
@@ -250,56 +188,6 @@ export function makeVoxHandlers() {
     onVoxDelayChange: (level: number) => {
       patchRadioState({ voxDelay: level });
       cmd('set_vox_delay', { level });
-    },
-  };
-}
-
-/* ── TX Handlers ─────────────────────────────────────────────── */
-
-export function makeTxHandlers() {
-  return {
-    onRfPowerChange: (level: number) => {
-      patchRadioState({ powerLevel: level });
-      cmd('set_rf_power', { level });
-    },
-    onMicGainChange: (level: number) => {
-      patchRadioState({ micGain: level });
-      cmd('set_mic_gain', { level });
-    },
-    onAtuToggle: () => {
-      const next = (getRadioState()?.tunerStatus ?? 0) > 0 ? 0 : 1;
-      patchRadioState({ tunerStatus: next });
-      cmd('set_tuner_status', { value: next });
-    },
-    onAtuTune: () => {
-      cmd('set_tuner_status', { value: 2 }); // Start tuning
-    },
-    onVoxToggle: () => {
-      const next = !(getRadioState()?.voxOn ?? false);
-      patchRadioState({ voxOn: next });
-      cmd('set_vox', { on: next });
-    },
-    onCompToggle: () => {
-      const next = !(getRadioState()?.compressorOn ?? false);
-      patchRadioState({ compressorOn: next });
-      cmd('set_compressor', { on: next });
-    },
-    onCompLevelChange: (level: number) => {
-      patchRadioState({ compressorLevel: level });
-      cmd('set_compressor_level', { level });
-    },
-    onMonToggle: () => {
-      const next = !(getRadioState()?.monitorOn ?? false);
-      patchRadioState({ monitorOn: next });
-      cmd('set_monitor', { on: next });
-    },
-    onMonLevelChange: (level: number) => {
-      patchRadioState({ monitorGain: level });
-      cmd('set_monitor_gain', { level });
-    },
-    onDriveGainChange: (level: number) => {
-      patchRadioState({ driveGain: level });
-      cmd('set_drive_gain', { level });
     },
   };
 }
@@ -382,38 +270,6 @@ export function makeAudioRoutingHandlers() {
   };
 }
 
-/* ── Antenna Handlers ────────────────────────────────────────── */
-
-export function makeAntennaHandlers() {
-  return {
-    onSelectAnt1: () => {
-      // Preserve current RX-ANT state when switching TX antenna.
-      const rxOn = getRadioState()?.rxAntenna1 ?? false;
-      patchRadioState({ txAntenna: 1 });
-      cmd('set_antenna_1', { on: rxOn });
-    },
-    onSelectAnt2: () => {
-      const rxOn = getRadioState()?.rxAntenna2 ?? false;
-      patchRadioState({ txAntenna: 2 });
-      cmd('set_antenna_2', { on: rxOn });
-    },
-    onToggleRxAnt: () => {
-      // RX-ANT is encoded as data byte of 0x12 0x00/0x01 and is tied to the current TX ANT.
-      const s = getRadioState();
-      const tx = s?.txAntenna ?? 1;
-      const current = tx === 2 ? (s?.rxAntenna2 ?? false) : (s?.rxAntenna1 ?? false);
-      const next = !current;
-      if (tx === 2) {
-        patchRadioState({ txAntenna: 2, rxAntenna2: next });
-        cmd('set_rx_antenna_ant2', { on: next });
-      } else {
-        patchRadioState({ txAntenna: 1, rxAntenna1: next });
-        cmd('set_rx_antenna_ant1', { on: next });
-      }
-    },
-  };
-}
-
 /* ── Meter Handlers ──────────────────────────────────────────── */
 
 export function makeMeterHandlers() {
@@ -431,28 +287,6 @@ export function makeSystemHandlers() {
     onDialLock: (on: boolean) => cmd('set_dial_lock', { on }),
     onPowerOff: () => cmd('set_powerstat', { on: false }),
     onSpeak: () => cmd('speak', { mode: 0 }),
-  };
-}
-
-/* ── Scan Handlers ──────────────────────────────────────────── */
-
-export function makeScanHandlers() {
-  return {
-    onScanStart: (type: number) => {
-      patchRadioState({ scanning: true, scanType: type });
-      cmd('scan_start', { type });
-    },
-    onScanStop: () => {
-      patchRadioState({ scanning: false, scanType: 0 });
-      cmd('scan_stop');
-    },
-    onDfSpanChange: (span: number) => {
-      cmd('scan_set_df_span', { span });
-    },
-    onResumeChange: (mode: number) => {
-      patchRadioState({ scanResumeMode: mode & 0x0F });
-      cmd('scan_set_resume', { mode });
-    },
   };
 }
 

--- a/frontend/src/lib/runtime/adapters/__tests__/cw-keyer-purity.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/cw-keyer-purity.isolated.test.ts
@@ -140,7 +140,7 @@ describe('cwKeyer fact construction is not a key path (MOR-1296, safety constrai
   it('the adapter contains none of the CW command verbs the shipped handlers send', () => {
     for (const verb of [
       'set_break_in', 'set_break_in_delay', 'cw_auto_tune', 'set_key_speed',
-      'set_cw_pitch', 'set_apf', 'set_twin_peak', 'set_keyer_type', 'set_dash_ratio', 'set_ptt',
+      'set_cw_pitch', 'set_apf', 'set_twin_peak', 'set_dash_ratio', 'set_ptt',
     ]) {
       expect(adapterSource).not.toContain(verb);
     }

--- a/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.test.ts
@@ -74,7 +74,9 @@ vi.mock('$lib/audio/audio-manager', () => ({
 
 import {
   makeAgcHandlers,
+  makeAntennaHandlers,
   makeBandHandlers,
+  makeCwPanelHandlers,
   makeDspHandlers,
   makeFilterHandlers,
   makeModeHandlers,
@@ -82,6 +84,8 @@ import {
   makeRfFrontEndHandlers,
   makeRitXitHandlers,
   makeRxAudioHandlers,
+  makeScanHandlers,
+  makeTxHandlers,
 } from '../panel-commands';
 import * as compatibilityBus from '$lib/../components-v2/wiring/command-bus';
 import { getCommandLifecycles, resetCommandLifecycle } from '$lib/stores/commands.svelte';
@@ -116,6 +120,8 @@ function state(active: 'MAIN' | 'SUB' = 'MAIN'): ServerState {
     autoNotch: false,
     manualNotch: false,
     manualNotchWidth: 1,
+    apfTypeLevel: 1,
+    twinPeakFilter: false,
     sMeter: 0,
   };
   return {
@@ -128,6 +134,26 @@ function state(active: 'MAIN' | 'SUB' = 'MAIN'): ServerState {
     nbDepth: 4,
     nbWidth: 2,
     notchFilter: 64,
+    powerLevel: 0.5,
+    micGain: 128,
+    tunerStatus: 1,
+    voxOn: false,
+    compressorOn: true,
+    compressorLevel: 44,
+    monitorOn: false,
+    monitorGain: 72,
+    driveGain: 80,
+    cwPitch: 600,
+    keySpeed: 24,
+    breakIn: 2,
+    breakInDelay: 64,
+    dashRatio: 0,
+    txAntenna: 1,
+    rxAntenna1: false,
+    rxAntenna2: true,
+    scanning: false,
+    scanType: 0x22,
+    scanResumeMode: 2,
     fieldStatus: {
       active: freshStatus,
       'main.dataMode': freshStatus,
@@ -167,8 +193,13 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
     h.state = state();
     h.unavailable.clear();
     h.caps = {
-      capabilities: ['pbt', 'agc', 'rit', 'xit', 'nr', 'nb', 'notch', 'af_level'],
+      capabilities: [
+        'pbt', 'agc', 'rit', 'xit', 'nr', 'nb', 'notch', 'af_level',
+        'tx', 'tuner', 'vox', 'compressor', 'monitor', 'drive_gain',
+        'cw', 'break_in', 'apf', 'twin_peak', 'rx_antenna',
+      ],
       receivers: 2,
+      antennas: 2,
       vfoScheme: 'main_sub',
       controls: {
         pbt_inner: { raw_min: 0, raw_max: 255, raw_center: 128, display_min: -1200, display_max: 1200 },
@@ -201,6 +232,10 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
     expect(compatibilityBus.makeBandHandlers).toBe(makeBandHandlers);
     expect(compatibilityBus.makePresetHandlers).toBe(makePresetHandlers);
     expect(compatibilityBus.makeRxAudioHandlers).toBe(makeRxAudioHandlers);
+    expect(compatibilityBus.makeCwPanelHandlers).toBe(makeCwPanelHandlers);
+    expect(compatibilityBus.makeTxHandlers).toBe(makeTxHandlers);
+    expect(compatibilityBus.makeAntennaHandlers).toBe(makeAntennaHandlers);
+    expect(compatibilityBus.makeScanHandlers).toBe(makeScanHandlers);
   });
 
   it('routes mode, DATA mode, and MOD input through exact lifecycle envelopes without Store writes', () => {
@@ -384,6 +419,130 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
     }
 
     expect(h.setMuted).toHaveBeenCalled();
+    expect(h.sendCommand).not.toHaveBeenCalled();
+    expect(getCommandLifecycles()).toHaveLength(0);
+  });
+
+  it('routes the complete CW factory through exact non-PTT lifecycle without optimistic truth', () => {
+    const cw = makeCwPanelHandlers();
+    cw.onCwPitchChange(700);
+    cw.onKeySpeedChange(28);
+    cw.onBreakInToggle();
+    cw.onBreakInModeChange(1);
+    cw.onApfChange(2);
+    cw.onTwinPeakToggle();
+    cw.onAutoTune();
+    cw.onWpmChange(32);
+    cw.onBreakInDelayChange(75);
+    cw.onSidetonePitchChange(650);
+    cw.onSidetoneLevelChange(44);
+    cw.onReversePaddleToggle();
+
+    expect(exactCalls()).toEqual([
+      ['set_cw_pitch', { value: 700 }],
+      ['set_key_speed', { speed: 28 }],
+      ['set_break_in', { mode: 0 }],
+      ['set_break_in', { mode: 1 }],
+      ['set_apf', { mode: 2, receiver: 0 }],
+      ['set_twin_peak', { on: true, receiver: 0 }],
+      ['cw_auto_tune', {}],
+      ['set_key_speed', { speed: 32 }],
+      ['set_break_in_delay', { level: 75 }],
+      ['set_cw_pitch', { value: 650 }],
+      ['set_monitor_gain', { level: 44 }],
+      ['set_dash_ratio', { ratio: -1 }],
+    ]);
+    expectIntentTransport();
+    expect(h.patchActiveReceiver).not.toHaveBeenCalled();
+    expect(h.patchRadioState).not.toHaveBeenCalled();
+  });
+
+  it('routes complete TX auxiliaries without PTT coupling or optimistic truth', () => {
+    const tx = makeTxHandlers();
+    tx.onRfPowerChange(0.42);
+    tx.onMicGainChange(200);
+    tx.onAtuToggle();
+    tx.onAtuTune();
+    tx.onVoxToggle();
+    tx.onCompToggle();
+    tx.onCompLevelChange(33);
+    tx.onMonToggle();
+    tx.onMonLevelChange(99);
+    tx.onDriveGainChange(100);
+
+    expect(exactCalls()).toEqual([
+      ['set_rf_power', { level: 0.42 }],
+      ['set_mic_gain', { level: 200 }],
+      ['set_tuner_status', { value: 0 }],
+      ['set_tuner_status', { value: 2 }],
+      ['set_vox', { on: true }],
+      ['set_compressor', { on: false }],
+      ['set_compressor_level', { level: 33 }],
+      ['set_monitor', { on: true }],
+      ['set_monitor_gain', { level: 99 }],
+      ['set_drive_gain', { level: 100 }],
+    ]);
+    expectIntentTransport();
+    expect(exactCalls().map(([name]) => name)).not.toContain('ptt');
+    expect(h.patchRadioState).not.toHaveBeenCalled();
+  });
+
+  it('preserves exact antenna and scan command names and params without Store truth', () => {
+    const antenna = makeAntennaHandlers();
+    antenna.onSelectAnt1();
+    antenna.onSelectAnt2();
+    antenna.onToggleRxAnt();
+    const scan = makeScanHandlers();
+    scan.onScanStart(0x22);
+    scan.onScanStop();
+    scan.onDfSpanChange(25_000);
+    scan.onResumeChange(0xd2);
+
+    expect(exactCalls()).toEqual([
+      ['set_antenna_1', { on: false }],
+      ['set_antenna_2', { on: true }],
+      ['set_rx_antenna_ant1', { on: true }],
+      ['scan_start', { type: 0x22 }],
+      ['scan_stop', {}],
+      ['scan_set_df_span', { span: 25_000 }],
+      ['scan_set_resume', { mode: 0xd2 }],
+    ]);
+    expectIntentTransport();
+    expect(h.patchRadioState).not.toHaveBeenCalled();
+  });
+
+  it('fails closed for stale or malformed CW, TX, and antenna-derived inputs', () => {
+    h.unavailable.add('breakIn');
+    makeCwPanelHandlers().onBreakInToggle();
+    h.unavailable.add('main.twinPeakFilter');
+    makeCwPanelHandlers().onTwinPeakToggle();
+    h.unavailable.add('tunerStatus');
+    makeTxHandlers().onAtuToggle();
+    h.unavailable.add('voxOn');
+    makeTxHandlers().onVoxToggle();
+    h.unavailable.add('txAntenna');
+    makeAntennaHandlers().onToggleRxAnt();
+    makeTxHandlers().onRfPowerChange(Number.NaN);
+    makeScanHandlers().onScanStart(1.5);
+
+    expect(h.sendCommand).not.toHaveBeenCalled();
+    expect(getCommandLifecycles()).toHaveLength(0);
+  });
+
+  it('accepts one-RX MAIN CW facts but rejects impossible physical SUB without reading VFO slots', () => {
+    h.state = oneReceiverAbState();
+    h.caps = {
+      capabilities: ['cw', 'apf', 'twin_peak'], receivers: 1, antennas: 1, vfoScheme: 'ab',
+    };
+    makeCwPanelHandlers().onApfChange(2);
+    expect(exactCalls()).toEqual([['set_apf', { mode: 2, receiver: 0 }]]);
+    expectIntentTransport();
+
+    h.sendCommand.mockClear();
+    resetCommandLifecycle();
+    h.state = { ...oneReceiverAbState(), active: 'SUB' } as ServerState;
+    makeCwPanelHandlers().onApfChange(2);
+    makeCwPanelHandlers().onAutoTune();
     expect(h.sendCommand).not.toHaveBeenCalled();
     expect(getCommandLifecycles()).toHaveLength(0);
   });
@@ -604,7 +763,8 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
     const assignedNames = [
       'makeAgcHandlers', 'makeBandHandlers', 'makeDspHandlers', 'makeFilterHandlers',
       'makeModeHandlers', 'makePresetHandlers', 'makeRfFrontEndHandlers',
-      'makeRitXitHandlers', 'makeRxAudioHandlers',
+      'makeRitXitHandlers', 'makeRxAudioHandlers', 'makeCwPanelHandlers',
+      'makeTxHandlers', 'makeAntennaHandlers', 'makeScanHandlers',
     ];
 
     for (const [index, name] of assignedNames.entries()) {
@@ -646,11 +806,36 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
       expect(a03aNames).not.toContain(`'${name}'`);
     }
 
+    for (const name of [
+      'set_antenna_1', 'set_antenna_2', 'set_rx_antenna_ant1', 'set_rx_antenna_ant2',
+      'scan_start', 'scan_stop', 'scan_set_df_span', 'scan_set_resume',
+      'set_cw_pitch', 'set_key_speed', 'set_break_in', 'set_apf', 'set_twin_peak',
+      'cw_auto_tune', 'set_break_in_delay', 'set_monitor_gain', 'set_dash_ratio',
+      'set_rf_power', 'set_mic_gain', 'set_tuner_status', 'set_vox', 'set_compressor',
+      'set_compressor_level', 'set_monitor', 'set_drive_gain',
+    ]) {
+      expect(a03aNames).not.toContain(`'${name}'`);
+    }
+
     for (const factory of ['makeBandHandlers', 'makePresetHandlers']) {
       const start = panelSource.indexOf(`export function ${factory}`);
       const end = panelSource.indexOf('\nexport function ', start + 1);
       expect(panelSource.slice(start, end)).not.toMatch(/\b(?:activeSlot|vfoA|vfoB|unselectedVfo)\b/);
     }
+    for (const factory of ['makeCwPanelHandlers', 'makeTxHandlers', 'makeAntennaHandlers', 'makeScanHandlers']) {
+      const start = panelSource.indexOf(`export function ${factory}`);
+      const end = panelSource.indexOf('\nexport function ', start + 1);
+      const block = panelSource.slice(start, end);
+      expect(block).not.toMatch(/\bcmd\s*\(/);
+      expect(block).not.toMatch(/\b(?:activeSlot|vfoA|vfoB|unselectedVfo)\b/);
+      expect(block).toContain('dispatchRadioIntent');
+    }
+    expect(panelSource).not.toContain('onKeyerTypeChange');
+    expect(panelSource).not.toContain('set_keyer_type');
+    expect(busSource).not.toContain('onKeyerTypeChange');
+    expect(busSource).not.toContain('set_keyer_type');
+    expect(busSource).toContain('export function makeVoxHandlers');
+    expect(panelSource).not.toContain('export function makeVoxHandlers');
     expect(panelSource).not.toMatch(/dispatchRadioIntent\(\{\s*name:\s*['"]ptt(?:_on|_off)?['"]/);
   });
 });

--- a/frontend/src/lib/runtime/commands/__tests__/radio-intents.isolated.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/radio-intents.isolated.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { CommandDeliveryEvent, ControlSessionTransition } from '$lib/transport/ws-client';
 import type { RadioIntent } from '../radio-intents';
@@ -127,6 +129,27 @@ describe('typed non-PTT radio intents', () => {
     expect(lifecycle.getCommandLifecycles()).toHaveLength(0);
   });
 
+  it('removes dormant keyer type from both the type and runtime vocabulary', () => {
+    if (false) {
+      // @ts-expect-error There is no observed keyer-type fact or executable command.
+      intents.dispatchRadioIntent({ name: 'set_keyer_type', params: { type: 1 } });
+    }
+    expect(() => intents.dispatchRadioIntent({
+      name: 'set_keyer_type', params: { type: 1 },
+    } as never)).toThrow(/non-PTT/i);
+    expect(intents.RADIO_INTENT_NAMES).not.toContain('set_keyer_type');
+    expect(harness.sendCommand).not.toHaveBeenCalled();
+    expect(lifecycle.getCommandLifecycles()).toHaveLength(0);
+  });
+
+  it('contains lifecycle only and cannot write radio truth from ACK or result', () => {
+    const source = readFileSync(resolve(process.cwd(), 'src/lib/runtime/commands/radio-intents.ts'), 'utf8');
+    expect(source).not.toMatch(/from ['"]\$lib\/stores\/radio/);
+    expect(source).not.toMatch(/\b(?:patchActiveReceiver|patchRadioState|patchReceiver)\s*\(/);
+    expect(source).not.toContain('set_keyer_type');
+    expect(source).not.toMatch(/['"]ptt(?:_on|_off)?['"]/);
+  });
+
   it('rejects forged malformed known intents before lifecycle or transport', () => {
     const malformed = [
       null,
@@ -181,6 +204,19 @@ describe('typed non-PTT radio intents', () => {
     } as never)).toThrow(TypeError);
   });
 
+  it('accepts the shipped fractional RF-power scale without weakening integer TX fields', () => {
+    intents.dispatchRadioIntent({
+      id: 'rf-fraction', name: 'set_rf_power', params: { level: 0.42 },
+    });
+
+    expect(harness.sendCommand).toHaveBeenCalledExactlyOnceWith(
+      'set_rf_power', { level: 0.42 }, 'rf-fraction', { optimistic: false },
+    );
+    expect(() => intents.dispatchRadioIntent({
+      name: 'set_mic_gain', params: { level: 0.42 },
+    } as never)).toThrow(TypeError);
+  });
+
   it('accepts representative exact envelopes derived from every descriptor family', () => {
     const representatives: RadioIntent[] = [
       { name: 'vfo_swap', params: {} },
@@ -232,11 +268,12 @@ describe('typed non-PTT radio intents', () => {
       const invalidRit: RadioIntent = { name: 'set_rit_frequency', params: { value: 300 } };
       expect(invalidRit).toBeDefined();
     }
-    expect(intents.RADIO_INTENT_NAMES).toHaveLength(92);
-    expect(new Set(intents.RADIO_INTENT_NAMES).size).toBe(92);
+    expect(intents.RADIO_INTENT_NAMES).toHaveLength(91);
+    expect(new Set(intents.RADIO_INTENT_NAMES).size).toBe(91);
     expect(intents.RADIO_INTENT_NAMES).toContain('set_data3_mod_input');
     expect(intents.RADIO_INTENT_NAMES).not.toContain('ptt');
     expect(intents.RADIO_INTENT_NAMES).not.toContain('ptt_on');
     expect(intents.RADIO_INTENT_NAMES).not.toContain('ptt_off');
+    expect(intents.RADIO_INTENT_NAMES).not.toContain('set_keyer_type');
   });
 });

--- a/frontend/src/lib/runtime/commands/panel-commands.ts
+++ b/frontend/src/lib/runtime/commands/panel-commands.ts
@@ -16,7 +16,6 @@ import { sendCommand } from '$lib/transport/ws-client';
 import {
   getActiveReceiver,
   getRadioState,
-  patchActiveReceiver,
   patchRadioState,
 } from '$lib/stores/radio.svelte';
 import { getCapabilities, getControlRange } from '$lib/stores/capabilities.svelte';
@@ -43,10 +42,6 @@ function cmd(name: string, params: Record<string, unknown> = {}): void {
     return;
   }
   sendCommand(name, params);
-}
-
-function activeReceiverParam(): Receiver {
-  return getRadioState()?.active === 'SUB' ? 1 : 0;
 }
 
 function knownActiveReceiver(field?: string, target?: 'MAIN' | 'SUB'): Receiver | null {
@@ -200,26 +195,30 @@ export function makeModeHandlers() {
 export function makeAntennaHandlers() {
   return {
     onSelectAnt1: () => {
-      const rxOn = (getRadioState() as any)?.rxAntenna1 ?? false;
-      patchRadioState({ txAntenna: 1 });
-      cmd('set_antenna_1', { on: rxOn });
+      const state = getRadioState();
+      if ((getCapabilities()?.antennas ?? 0) < 2 || !knownTopLevelField('rxAntenna1')
+        || typeof state?.rxAntenna1 !== 'boolean') return;
+      dispatchRadioIntent({ name: 'set_antenna_1', params: { on: state.rxAntenna1 } });
     },
     onSelectAnt2: () => {
-      const rxOn = (getRadioState() as any)?.rxAntenna2 ?? false;
-      patchRadioState({ txAntenna: 2 });
-      cmd('set_antenna_2', { on: rxOn });
+      const state = getRadioState();
+      if ((getCapabilities()?.antennas ?? 0) < 2 || !knownTopLevelField('rxAntenna2')
+        || typeof state?.rxAntenna2 !== 'boolean') return;
+      dispatchRadioIntent({ name: 'set_antenna_2', params: { on: state.rxAntenna2 } });
     },
     onToggleRxAnt: () => {
-      const s = getRadioState() as any;
-      const tx = (s?.txAntenna ?? 1) as number;
-      const current = tx === 2 ? (s?.rxAntenna2 ?? false) : (s?.rxAntenna1 ?? false);
+      const state = getRadioState();
+      const tx = state?.txAntenna;
+      if ((getCapabilities()?.antennas ?? 0) < 2 || !hasCapability('rx_antenna')
+        || !knownTopLevelField('txAntenna') || (tx !== 1 && tx !== 2)) return;
+      const field = tx === 2 ? 'rxAntenna2' : 'rxAntenna1';
+      const current = tx === 2 ? state?.rxAntenna2 : state?.rxAntenna1;
+      if (!knownTopLevelField(field) || typeof current !== 'boolean') return;
       const next = !current;
       if (tx === 2) {
-        patchRadioState({ txAntenna: 2, rxAntenna2: next });
-        cmd('set_rx_antenna_ant2', { on: next });
+        dispatchRadioIntent({ name: 'set_rx_antenna_ant2', params: { on: next } });
       } else {
-        patchRadioState({ txAntenna: 1, rxAntenna1: next });
-        cmd('set_rx_antenna_ant1', { on: next });
+        dispatchRadioIntent({ name: 'set_rx_antenna_ant1', params: { on: next } });
       }
     },
   };
@@ -302,19 +301,19 @@ export function makeRitXitHandlers() {
 export function makeScanHandlers() {
   return {
     onScanStart: (type: number) => {
-      patchRadioState({ scanning: true, scanType: type });
-      cmd('scan_start', { type });
+      if (!Number.isSafeInteger(type)) return;
+      dispatchRadioIntent({ name: 'scan_start', params: { type } });
     },
     onScanStop: () => {
-      patchRadioState({ scanning: false, scanType: 0 });
-      cmd('scan_stop');
+      dispatchRadioIntent({ name: 'scan_stop', params: {} });
     },
     onDfSpanChange: (span: number) => {
-      cmd('scan_set_df_span', { span });
+      if (!Number.isSafeInteger(span)) return;
+      dispatchRadioIntent({ name: 'scan_set_df_span', params: { span } });
     },
     onResumeChange: (mode: number) => {
-      patchRadioState({ scanResumeMode: mode & 0x0f });
-      cmd('scan_set_resume', { mode });
+      if (!Number.isSafeInteger(mode)) return;
+      dispatchRadioIntent({ name: 'scan_set_resume', params: { mode } });
     },
   };
 }
@@ -334,64 +333,64 @@ export function makeMeterHandlers() {
 export function makeCwPanelHandlers() {
   return {
     onCwPitchChange: (value: number) => {
-      patchRadioState({ cwPitch: value });
-      cmd('set_cw_pitch', { value });
+      if (!hasCapability('cw') || !knownTopLevelField('cwPitch') || !Number.isSafeInteger(value)) return;
+      dispatchRadioIntent({ name: 'set_cw_pitch', params: { value } });
     },
     onKeySpeedChange: (speed: number) => {
-      patchRadioState({ keySpeed: speed });
-      cmd('set_key_speed', { speed });
+      if (!hasCapability('cw') || !knownTopLevelField('keySpeed') || !Number.isSafeInteger(speed)) return;
+      dispatchRadioIntent({ name: 'set_key_speed', params: { speed } });
     },
     onBreakInToggle: () => {
-      const current = getRadioState()?.breakIn ?? 0;
-      const next = current > 0 ? 0 : 1;
-      patchRadioState({ breakIn: next });
-      cmd('set_break_in', { mode: next });
+      const current = getRadioState()?.breakIn;
+      if (!hasCapability('cw') || !hasCapability('break_in') || !knownTopLevelField('breakIn')
+        || !Number.isSafeInteger(current)) return;
+      dispatchRadioIntent({ name: 'set_break_in', params: { mode: (current as number) > 0 ? 0 : 1 } });
     },
     onBreakInModeChange: (mode: number) => {
-      patchRadioState({ breakIn: mode });
-      cmd('set_break_in', { mode });
+      if (!hasCapability('cw') || !hasCapability('break_in') || !knownTopLevelField('breakIn')
+        || !Number.isSafeInteger(mode)) return;
+      dispatchRadioIntent({ name: 'set_break_in', params: { mode } });
     },
     onApfChange: (mode: number) => {
-      const receiver = activeReceiverParam();
-      patchActiveReceiver({ apfTypeLevel: mode }, true);
-      cmd('set_apf', { mode, receiver });
+      const receiver = knownReceiverField('apfTypeLevel');
+      if (!hasCapability('cw') || !hasCapability('apf') || receiver === null
+        || !Number.isSafeInteger(mode)) return;
+      dispatchRadioIntent({ name: 'set_apf', params: { mode, receiver } });
     },
     onTwinPeakToggle: () => {
-      const receiver = activeReceiverParam();
+      const receiver = knownReceiverField('twinPeakFilter');
       const state = getRadioState();
       const rx = receiver === 0 ? state?.main : state?.sub;
-      const current = rx?.twinPeakFilter ?? false;
-      const next = !current;
-      patchActiveReceiver({ twinPeakFilter: next }, true);
-      cmd('set_twin_peak', { on: next, receiver });
+      if (!hasCapability('cw') || !hasCapability('twin_peak') || receiver === null
+        || typeof rx?.twinPeakFilter !== 'boolean') return;
+      dispatchRadioIntent({ name: 'set_twin_peak', params: { on: !rx.twinPeakFilter, receiver } });
     },
     onAutoTune: () => {
-      cmd('cw_auto_tune', {});
+      if (!hasCapability('cw') || knownActiveReceiver() === null) return;
+      dispatchRadioIntent({ name: 'cw_auto_tune', params: {} });
     },
     onWpmChange: (speed: number) => {
-      patchRadioState({ keySpeed: speed });
-      cmd('set_key_speed', { speed });
+      if (!hasCapability('cw') || !knownTopLevelField('keySpeed') || !Number.isSafeInteger(speed)) return;
+      dispatchRadioIntent({ name: 'set_key_speed', params: { speed } });
     },
     onBreakInDelayChange: (level: number) => {
-      patchRadioState({ breakInDelay: level });
-      cmd('set_break_in_delay', { level });
+      if (!hasCapability('cw') || !hasCapability('break_in') || !knownTopLevelField('breakInDelay')
+        || !Number.isSafeInteger(level)) return;
+      dispatchRadioIntent({ name: 'set_break_in_delay', params: { level } });
     },
     onSidetonePitchChange: (value: number) => {
-      patchRadioState({ cwPitch: value });
-      cmd('set_cw_pitch', { value });
+      if (!hasCapability('cw') || !knownTopLevelField('cwPitch') || !Number.isSafeInteger(value)) return;
+      dispatchRadioIntent({ name: 'set_cw_pitch', params: { value } });
     },
     onSidetoneLevelChange: (level: number) => {
-      patchRadioState({ monitorGain: level });
-      cmd('set_monitor_gain', { level });
+      if (!hasCapability('cw') || !knownTopLevelField('monitorGain') || !Number.isSafeInteger(level)) return;
+      dispatchRadioIntent({ name: 'set_monitor_gain', params: { level } });
     },
     onReversePaddleToggle: () => {
-      const current = getRadioState()?.dashRatio ?? 0;
-      const next = current < 0 ? 0 : -1;
-      patchRadioState({ dashRatio: next });
-      cmd('set_dash_ratio', { ratio: next });
-    },
-    onKeyerTypeChange: (type: number) => {
-      cmd('set_keyer_type', { type });
+      const current = getRadioState()?.dashRatio;
+      if (!hasCapability('cw') || !knownTopLevelField('dashRatio')
+        || !Number.isSafeInteger(current)) return;
+      dispatchRadioIntent({ name: 'set_dash_ratio', params: { ratio: (current as number) < 0 ? 0 : -1 } });
     },
   };
 }
@@ -473,47 +472,55 @@ export function makeDspHandlers() {
 export function makeTxHandlers() {
   return {
     onRfPowerChange: (level: number) => {
-      patchRadioState({ powerLevel: level });
-      cmd('set_rf_power', { level });
+      if (!hasCapability('tx') || !knownTopLevelField('powerLevel') || !Number.isFinite(level)) return;
+      dispatchRadioIntent({ name: 'set_rf_power', params: { level } });
     },
     onMicGainChange: (level: number) => {
-      patchRadioState({ micGain: level });
-      cmd('set_mic_gain', { level });
+      if (!hasCapability('tx') || !knownTopLevelField('micGain') || !Number.isSafeInteger(level)) return;
+      dispatchRadioIntent({ name: 'set_mic_gain', params: { level } });
     },
     onAtuToggle: () => {
-      const next = (getRadioState()?.tunerStatus ?? 0) > 0 ? 0 : 1;
-      patchRadioState({ tunerStatus: next });
-      cmd('set_tuner_status', { value: next });
+      const current = getRadioState()?.tunerStatus;
+      if (!hasCapability('tx') || !hasCapability('tuner') || !knownTopLevelField('tunerStatus')
+        || !Number.isSafeInteger(current)) return;
+      dispatchRadioIntent({ name: 'set_tuner_status', params: { value: (current as number) > 0 ? 0 : 1 } });
     },
     onAtuTune: () => {
-      cmd('set_tuner_status', { value: 2 }); // Start tuning
+      if (!hasCapability('tx') || !hasCapability('tuner') || !knownTopLevelField('tunerStatus')) return;
+      dispatchRadioIntent({ name: 'set_tuner_status', params: { value: 2 } });
     },
     onVoxToggle: () => {
-      const next = !(getRadioState()?.voxOn ?? false);
-      patchRadioState({ voxOn: next });
-      cmd('set_vox', { on: next });
+      const current = getRadioState()?.voxOn;
+      if (!hasCapability('tx') || !hasCapability('vox') || !knownTopLevelField('voxOn')
+        || typeof current !== 'boolean') return;
+      dispatchRadioIntent({ name: 'set_vox', params: { on: !current } });
     },
     onCompToggle: () => {
-      const next = !(getRadioState()?.compressorOn ?? false);
-      patchRadioState({ compressorOn: next });
-      cmd('set_compressor', { on: next });
+      const current = getRadioState()?.compressorOn;
+      if (!hasCapability('tx') || !hasCapability('compressor') || !knownTopLevelField('compressorOn')
+        || typeof current !== 'boolean') return;
+      dispatchRadioIntent({ name: 'set_compressor', params: { on: !current } });
     },
     onCompLevelChange: (level: number) => {
-      patchRadioState({ compressorLevel: level });
-      cmd('set_compressor_level', { level });
+      if (!hasCapability('tx') || !hasCapability('compressor') || !knownTopLevelField('compressorLevel')
+        || !Number.isSafeInteger(level)) return;
+      dispatchRadioIntent({ name: 'set_compressor_level', params: { level } });
     },
     onMonToggle: () => {
-      const next = !(getRadioState()?.monitorOn ?? false);
-      patchRadioState({ monitorOn: next });
-      cmd('set_monitor', { on: next });
+      const current = getRadioState()?.monitorOn;
+      if (!hasCapability('tx') || !hasCapability('monitor') || !knownTopLevelField('monitorOn')
+        || typeof current !== 'boolean') return;
+      dispatchRadioIntent({ name: 'set_monitor', params: { on: !current } });
     },
     onMonLevelChange: (level: number) => {
-      patchRadioState({ monitorGain: level });
-      cmd('set_monitor_gain', { level });
+      if (!hasCapability('tx') || !hasCapability('monitor') || !knownTopLevelField('monitorGain')
+        || !Number.isSafeInteger(level)) return;
+      dispatchRadioIntent({ name: 'set_monitor_gain', params: { level } });
     },
     onDriveGainChange: (level: number) => {
-      patchRadioState({ driveGain: level });
-      cmd('set_drive_gain', { level });
+      if (!hasCapability('tx') || !hasCapability('drive_gain') || !knownTopLevelField('driveGain')
+        || !Number.isSafeInteger(level)) return;
+      dispatchRadioIntent({ name: 'set_drive_gain', params: { level } });
     },
   };
 }

--- a/frontend/src/lib/runtime/commands/radio-intents.ts
+++ b/frontend/src/lib/runtime/commands/radio-intents.ts
@@ -2,7 +2,7 @@ import { acknowledgeCommand, beginCommand, cancelPendingCommands, failCommand, t
 import { makeCommandId } from '$lib/types/protocol';
 import { getControlSession, onCommandDelivery, onControlSessionTransition, sendCommand } from '$lib/transport/ws-client';
 
-type FieldKind = 'boolean' | 'integer' | 'normalized' | 'receiver' | 'string' | 'vfo';
+type FieldKind = 'boolean' | 'integer' | 'normalized' | 'number' | 'receiver' | 'string' | 'vfo';
 type FieldSpec = FieldKind | `${FieldKind}?`;
 type IntentSpec = { names: readonly string[]; params: Readonly<Record<string, FieldSpec>> };
 
@@ -17,9 +17,10 @@ const intentSpecs = [
   { names: ['set_auto_notch', 'set_digisel', 'set_ip_plus', 'set_manual_notch', 'set_nb', 'set_nr', 'set_twin_peak'], params: { on: 'boolean', receiver: 'receiver' } },
   { names: [
     'set_anti_vox_gain', 'set_break_in_delay', 'set_compressor_level', 'set_drive_gain', 'set_mic_gain',
-    'set_monitor_gain', 'set_nb_depth', 'set_nb_width', 'set_rf_power', 'set_vox_delay', 'set_vox_gain',
+    'set_monitor_gain', 'set_nb_depth', 'set_nb_width', 'set_vox_delay', 'set_vox_gain',
   ], params: { level: 'integer' } },
   { names: ['set_af_level'], params: { level: 'normalized', receiver: 'receiver' } },
+  { names: ['set_rf_power'], params: { level: 'number' } },
   { names: ['set_nb_level', 'set_nr_level', 'set_preamp', 'set_rf_gain', 'set_squelch'], params: { level: 'integer', receiver: 'receiver' } },
   { names: ['set_cw_pitch', 'set_tuner_status'], params: { value: 'integer' } },
   { names: ['set_agc_time_constant', 'set_manual_notch_width', 'set_notch_filter', 'set_pbt_inner', 'set_pbt_outer'], params: { value: 'integer', receiver: 'receiver' } },
@@ -28,7 +29,7 @@ const intentSpecs = [
   { names: ['set_break_in', 'scan_set_resume', 'set_scope_mode', 'speak'], params: { mode: 'integer' } },
   { names: ['scan_set_df_span', 'set_scope_span'], params: { span: 'integer' } },
   { names: ['set_key_speed', 'set_scope_speed'], params: { speed: 'integer' } },
-  { names: ['scan_start', 'set_keyer_type'], params: { type: 'integer' } },
+  { names: ['scan_start'], params: { type: 'integer' } },
   { names: ['set_attenuator'], params: { db: 'integer', receiver: 'receiver' } },
   { names: ['set_band'], params: { band: 'integer' } },
   { names: ['set_dash_ratio'], params: { ratio: 'integer' } },
@@ -76,6 +77,7 @@ export function isNormalizedLevel(value: unknown): value is number {
 function matchesValue(kind: FieldKind, value: unknown): boolean {
   if (kind === 'integer') return typeof value === 'number' && Number.isSafeInteger(value);
   if (kind === 'normalized') return isNormalizedLevel(value);
+  if (kind === 'number') return typeof value === 'number' && Number.isFinite(value);
   if (kind === 'boolean') return typeof value === 'boolean';
   if (kind === 'receiver') return value === 0 || value === 1;
   if (kind === 'vfo') return value === 'A' || value === 'B' || value === 'MAIN' || value === 'SUB';


### PR DESCRIPTION
## Summary

- migrate the complete CW, TX-auxiliary, antenna, and scan handler families to the existing typed non-PTT lifecycle facade
- replace their compatibility-bus duplicates with immediate canonical re-exports and remove optimistic radio Store writes/default-derived commands
- atomically remove executable `onKeyerTypeChange` / `set_keyer_type` while preserving App-owned PTT safety and the later unique VOX family

Part of #2317. This head implements A03b2 from the superseding [whole-family re-slice addendum](https://github.com/rigplane/rigplane-core/issues/2317#issuecomment-5230879753).

## Scope and safety

- exact base: `17d7aaf32fde6f5df12c1e465b9d8a97934ddeaf`
- exact head: `9b72f0cfd95da0797b886caa24f687e9ed071483`
- production ownership: exactly the three authorized command files
- production churn: `353` (`98` additions + `255` deletions), below the hard `400` stop
- no generic PTT representation, automatic TX/TUNE/PTT, ACK/result radio truth, VFO-path change, frequency inference, backend production, hardware, audio, scope, spectrum, or MOR-1414 work
- physical MAIN/SUB remains independent of VFO A/B Selected/Unselected; impossible physical SUB fails closed while one-receiver MAIN A/B remains valid

## Validation

- focused/compat: `357/357`
- A02 lifecycle/correlation: `93/93`
- broad TX/PTT/OFF: `130/130`
- full frontend: `6147/6147`; check, lint, and production build PASS
- full backend, Python 3.11 with all extras and hardware integration excluded: `8993` passed, `12` skipped, `11` xfailed, `1` xpassed
- Ruff lint/format, import-linter `5/5`, generated state types, consumer contracts `2/2`, AF boundary `5/5`, and diff/status checks PASS
- fifteen causal mutations were killed and fully restored, including global interception, raw/duplicate/optimistic paths, malformed envelope/RF conversion, keyer residue, PTT representation/OFF regression, topology bypass, A03b1 AF weakening, and premature VOX migration

Builder report: `/private/tmp/build-mor1409-a03b2-prep.md`. Independent exact-head verification remains required; this PR does not claim builder PASS.
