### PR TITLE
MOR-1409 A03c1: canonical VFO and VOX authority

### DIFF
--- a/frontend/src/components-v2/wiring/__tests__/focus-mode-race.isolated.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/focus-mode-race.isolated.test.ts
@@ -16,8 +16,12 @@ vi.mock('$lib/stores/radio.svelte', () => ({
   patchReceiver: vi.fn(),
 }));
 vi.mock('$lib/stores/capabilities.svelte', () => ({
-  getCapabilities: vi.fn(() => ({ receivers: 2, vfoScheme: 'main_sub' })),
+  getCapabilities: vi.fn(() => ({ receivers: 2, vfoScheme: 'main_sub', capabilities: ['dual_rx'] })),
+  capabilitiesMatchGeneration: vi.fn(() => true),
   getControlRange: vi.fn(() => null),
+}));
+vi.mock('$lib/audio/audio-manager', () => ({
+  audioManager: { setAudioConfig: vi.fn() },
 }));
 
 import { sendCommand } from '$lib/transport/ws-client';

--- a/frontend/src/components-v2/wiring/__tests__/semantic-band-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-band-wiring.component.test.ts
@@ -56,6 +56,7 @@ vi.mock('$lib/stores/radio.svelte', () => ({
   patchActiveReceiver: vi.fn(), patchRadioState: vi.fn(), patchReceiver: vi.fn(),
 }));
 vi.mock('$lib/stores/capabilities.svelte', () => ({
+  capabilitiesMatchGeneration: vi.fn(() => true),
   getCapabilities: vi.fn(() => h.caps),
   getControlRange: vi.fn(() => null),
 }));

--- a/frontend/src/components-v2/wiring/__tests__/tx-aux-command-bus.isolated.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/tx-aux-command-bus.isolated.test.ts
@@ -24,9 +24,11 @@ vi.mock('$lib/runtime/commands/radio-intents', async () => {
 vi.mock('$lib/stores/radio.svelte', () => ({
   getActiveReceiver: vi.fn(() => null),
   getRadioState: vi.fn(() => ({
+    stateContractVersion: 1, providerGeneration: 1,
     active: 'MAIN', powerLevel: 0.5, micGain: 128, tunerStatus: 0, voxOn: false,
+    voxGain: 50, antiVoxGain: 25, voxDelay: 4,
     compressorOn: false, compressorLevel: 20, monitorOn: false, monitorGain: 20,
-    driveGain: 50,
+    driveGain: 50, main: {}, sub: {},
   })),
   patchActiveReceiver: vi.fn(),
   patchRadioState: vi.fn(),
@@ -36,7 +38,9 @@ vi.mock('$lib/state/field-status', () => ({ isFieldAvailable: vi.fn(() => true) 
 vi.mock('$lib/stores/capabilities.svelte', () => ({
   getCapabilities: vi.fn(() => ({
     capabilities: ['tx', 'tuner', 'vox', 'compressor', 'monitor', 'drive_gain'],
+    receivers: 2, vfoScheme: 'main_sub',
   })),
+  capabilitiesMatchGeneration: vi.fn(() => true),
   getControlRange: vi.fn(() => null),
 }));
 vi.mock('$lib/audio/audio-manager', () => ({

--- a/frontend/src/components-v2/wiring/__tests__/vfo-ops-command-bus.isolated.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/vfo-ops-command-bus.isolated.test.ts
@@ -27,10 +27,22 @@ vi.mock('$lib/runtime/commands/radio-intents', async () => {
 });
 vi.mock('$lib/stores/radio.svelte', () => ({
   getActiveReceiver: vi.fn(() => null),
-  getRadioState: vi.fn(() => ({ active: 'MAIN' })),
+  getRadioState: vi.fn(() => ({
+    stateContractVersion: 1, providerGeneration: 1, active: 'MAIN',
+    main: { freqHz: 14_074_000 }, sub: { freqHz: 7_074_000 },
+    split: false, dualWatch: false, mainSubTracking: false,
+  })),
   patchActiveReceiver: vi.fn(),
   patchRadioState: vi.fn(),
   patchReceiver: vi.fn(),
+}));
+vi.mock('$lib/stores/capabilities.svelte', () => ({
+  getCapabilities: vi.fn(() => ({
+    receivers: 2, vfoScheme: 'main_sub',
+    capabilities: ['dual_rx', 'dual_watch', 'split', 'main_sub_tracking'],
+  })),
+  capabilitiesMatchGeneration: vi.fn(() => true),
+  getControlRange: vi.fn(() => null),
 }));
 vi.mock('$lib/audio/audio-manager', () => ({
   audioManager: {

--- a/frontend/src/components-v2/wiring/__tests__/vfo-wiring.isolated.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/vfo-wiring.isolated.test.ts
@@ -17,7 +17,11 @@ vi.mock('$lib/stores/radio.svelte', () => ({
 }));
 
 vi.mock('$lib/stores/capabilities.svelte', () => ({
-  getCapabilities: vi.fn(() => ({ receivers: 2, vfoScheme: 'main_sub', capabilities: ['rit', 'xit'] })),
+  getCapabilities: vi.fn(() => ({
+    receivers: 2, vfoScheme: 'main_sub',
+    capabilities: ['rit', 'xit', 'split', 'dual_rx', 'dual_watch', 'main_sub_tracking'],
+  })),
+  capabilitiesMatchGeneration: vi.fn(() => true),
   getControlRange: vi.fn(() => null),
 }));
 
@@ -44,9 +48,14 @@ const originalDocumentQuerySelector = document.querySelector.bind(document);
 
 function receiverState(active: 'MAIN' | 'SUB') {
   return {
+    stateContractVersion: 1,
+    providerGeneration: 1,
     active,
-    main: { mode: 'USB', dataMode: 1, filter: 2, filterShape: 0, filterWidth: 2400 },
-    sub: { mode: 'CW', dataMode: 0, filter: 1, filterShape: 0, filterWidth: 500 },
+    main: { freqHz: 14_074_000, mode: 'USB', dataMode: 1, filter: 2, filterShape: 0, filterWidth: 2400 },
+    sub: { freqHz: 7_074_000, mode: 'CW', dataMode: 0, filter: 1, filterShape: 0, filterWidth: 500 },
+    split: false,
+    dualWatch: false,
+    mainSubTracking: false,
   } as any;
 }
 
@@ -92,6 +101,9 @@ describe('makeVfoHandlers', () => {
   beforeEach(() => {
     vi.mocked(sendCommand).mockClear();
     vi.mocked(patchRadioState).mockClear();
+    vi.mocked(patchReceiver).mockClear();
+    vi.mocked(audioManager.setAudioConfig).mockClear();
+    vi.mocked(getRadioState).mockReturnValue(receiverState('MAIN'));
   });
 
   afterEach(() => {
@@ -99,20 +111,20 @@ describe('makeVfoHandlers', () => {
   });
 
   it('sends explicit split=false when toggling from active split state', () => {
-    vi.mocked(getRadioState).mockReturnValue({ split: true } as any);
+    vi.mocked(getRadioState).mockReturnValue({ ...receiverState('MAIN'), split: true } as any);
 
     makeVfoHandlers().onSplitToggle();
 
-    expect(patchRadioState).toHaveBeenCalledWith({ split: false });
+    expect(patchRadioState).not.toHaveBeenCalled();
     expect(sendCommand).toHaveBeenCalledWith('set_split', { on: false });
   });
 
   it('sends explicit split=true when toggling from inactive split state', () => {
-    vi.mocked(getRadioState).mockReturnValue({ split: false } as any);
+    vi.mocked(getRadioState).mockReturnValue({ ...receiverState('MAIN'), split: false } as any);
 
     makeVfoHandlers().onSplitToggle();
 
-    expect(patchRadioState).toHaveBeenCalledWith({ split: true });
+    expect(patchRadioState).not.toHaveBeenCalled();
     expect(sendCommand).toHaveBeenCalledWith('set_split', { on: true });
   });
 
@@ -129,7 +141,7 @@ describe('makeVfoHandlers', () => {
 
     makeVfoHandlers().onMainModeClick();
 
-    expect(patchRadioState).toHaveBeenCalledWith({ active: 'MAIN' });
+    expect(patchRadioState).not.toHaveBeenCalled();
     expect(sendCommand).toHaveBeenCalledWith('set_vfo', { vfo: 'MAIN' });
     expect(scrollIntoView).toHaveBeenCalled();
   });
@@ -147,7 +159,7 @@ describe('makeVfoHandlers', () => {
 
     makeVfoHandlers().onSubModeClick();
 
-    expect(patchRadioState).toHaveBeenCalledWith({ active: 'SUB' });
+    expect(patchRadioState).not.toHaveBeenCalled();
     expect(sendCommand).toHaveBeenCalledWith('set_vfo', { vfo: 'SUB' });
     expect(scrollIntoView).toHaveBeenCalled();
   });
@@ -170,65 +182,56 @@ describe('makeVfoHandlers', () => {
     expect(sendCommand).toHaveBeenCalledWith('set_main_sub_tracking', { on: false });
   });
 
-  // Optimistic updates + audio focus follow for live MAIN/SUB UX.
-  describe('optimistic updates + audio focus', () => {
+  // State remains observation-owned while audio focus follows valid MAIN/SUB actions.
+  describe('observed truth + audio focus', () => {
     beforeEach(() => {
       vi.mocked(patchReceiver).mockClear();
       vi.mocked(audioManager.setAudioConfig).mockClear();
     });
 
-    it('onEqual optimistically copies MAIN freq/mode/filter to SUB before the poll', () => {
+    it('onEqual leaves observed receiver truth untouched', () => {
       vi.mocked(getRadioState).mockReturnValue({
+        stateContractVersion: 1, providerGeneration: 1, active: 'MAIN',
         main: { freqHz: 14_074_000, mode: 'USB', filter: 2 },
         sub: { freqHz: 28_500_000, mode: 'AM', filter: 3 },
       } as any);
 
       makeVfoHandlers().onEqual();
 
-      expect(patchReceiver).toHaveBeenCalledWith(
-        1,
-        { freqHz: 14_074_000, mode: 'USB', filter: 2 },
-      );
+      expect(patchReceiver).not.toHaveBeenCalled();
       expect(sendCommand).toHaveBeenCalledWith('vfo_equalize', {});
     });
 
-    it('onSwap optimistically exchanges freq/mode/filter between MAIN and SUB', () => {
+    it('onSwap leaves observed receiver truth untouched', () => {
       vi.mocked(getRadioState).mockReturnValue({
+        stateContractVersion: 1, providerGeneration: 1, active: 'MAIN',
         main: { freqHz: 14_074_000, mode: 'USB', filter: 2 },
         sub: { freqHz: 28_500_000, mode: 'AM', filter: 3 },
       } as any);
 
       makeVfoHandlers().onSwap();
 
-      // MAIN gets SUB's former values; SUB gets MAIN's former values.
-      expect(patchReceiver).toHaveBeenCalledWith(
-        0,
-        { freqHz: 28_500_000, mode: 'AM', filter: 3 },
-      );
-      expect(patchReceiver).toHaveBeenCalledWith(
-        1,
-        { freqHz: 14_074_000, mode: 'USB', filter: 2 },
-      );
+      expect(patchReceiver).not.toHaveBeenCalled();
       expect(sendCommand).toHaveBeenCalledWith('vfo_swap', {});
     });
 
-    it('onEqual without state does nothing optimistic but still fires command', () => {
+    it('onEqual without current state emits no command', () => {
       vi.mocked(getRadioState).mockReturnValue(null);
       makeVfoHandlers().onEqual();
       expect(patchReceiver).not.toHaveBeenCalled();
-      expect(sendCommand).toHaveBeenCalledWith('vfo_equalize', {});
+      expect(sendCommand).not.toHaveBeenCalled();
     });
 
     it('onMainVfoClick couples audio focus to MAIN', () => {
       makeVfoHandlers().onMainVfoClick();
-      expect(patchRadioState).toHaveBeenCalledWith({ active: 'MAIN' });
+      expect(patchRadioState).not.toHaveBeenCalled();
       expect(sendCommand).toHaveBeenCalledWith('set_vfo', { vfo: 'MAIN' });
       expect(audioManager.setAudioConfig).toHaveBeenCalledWith({ focus: 'main' });
     });
 
     it('onSubVfoClick couples audio focus to SUB', () => {
       makeVfoHandlers().onSubVfoClick();
-      expect(patchRadioState).toHaveBeenCalledWith({ active: 'SUB' });
+      expect(patchRadioState).not.toHaveBeenCalled();
       expect(sendCommand).toHaveBeenCalledWith('set_vfo', { vfo: 'SUB' });
       expect(audioManager.setAudioConfig).toHaveBeenCalledWith({ focus: 'sub' });
     });
@@ -242,11 +245,11 @@ describe('makeVfoHandlers', () => {
     });
 
     it('activates the receiver and the addressed A/B slot', () => {
-      vi.mocked(getRadioState).mockReturnValue({ active: 'MAIN' } as any);
+      vi.mocked(getRadioState).mockReturnValue(receiverState('MAIN'));
 
       makeVfoHandlers().onVfoSelect('SUB', 'B');
 
-      expect(patchRadioState).toHaveBeenCalledWith({ active: 'SUB' });
+      expect(patchRadioState).not.toHaveBeenCalled();
       expect(audioManager.setAudioConfig).toHaveBeenCalledWith({ focus: 'sub' });
       expect(sendCommand).toHaveBeenCalledWith('set_vfo', { vfo: 'SUB' });
       expect(sendCommand).toHaveBeenCalledWith('set_vfo', { vfo: 'B' });
@@ -256,7 +259,7 @@ describe('makeVfoHandlers', () => {
     // topology has no A/B to address and the radio would be re-slotted behind
     // the operator's back.
     it('sends no slot command for an unslotted position', () => {
-      vi.mocked(getRadioState).mockReturnValue({ active: 'MAIN' } as any);
+      vi.mocked(getRadioState).mockReturnValue(receiverState('MAIN'));
 
       makeVfoHandlers().onVfoSelect('SUB', null);
 
@@ -266,7 +269,7 @@ describe('makeVfoHandlers', () => {
     });
 
     it('switches slot without re-selecting the receiver already in use', () => {
-      vi.mocked(getRadioState).mockReturnValue({ active: 'MAIN' } as any);
+      vi.mocked(getRadioState).mockReturnValue(receiverState('MAIN'));
 
       makeVfoHandlers().onVfoSelect('MAIN', 'B');
 

--- a/frontend/src/components-v2/wiring/command-bus.ts
+++ b/frontend/src/components-v2/wiring/command-bus.ts
@@ -10,8 +10,7 @@
  */
 
 import { sendCommand } from '$lib/transport/ws-client';
-import { getActiveReceiver, getRadioState, patchActiveReceiver, patchRadioState, patchReceiver } from '$lib/stores/radio.svelte';
-import type { ReceiverState } from '$lib/types/state';
+import { getActiveReceiver, getRadioState, patchActiveReceiver, patchRadioState } from '$lib/stores/radio.svelte';
 import { getCapabilities } from '$lib/stores/capabilities.svelte';
 import { adjustTuningStep, getTuningStep } from '$lib/stores/tuning.svelte';
 import { audioManager } from '$lib/audio/audio-manager';
@@ -29,10 +28,11 @@ export {
   makeScanHandlers,
   makeTxHandlers,
   makeAntennaHandlers,
+  makeVfoHandlers,
+  makeVoxHandlers,
 } from '$lib/runtime/commands/panel-commands';
 import type { KeyboardActionConfig } from '../layout/keyboard-map';
 import { clampRef, clampSpan } from '../../components/spectrum/spectrum-toolbar-logic';
-import { setPendingFocus } from '$lib/radio/pending-focus';
 
 /* ── Helpers ─────────────────────────────────────────────────── */
 
@@ -47,33 +47,9 @@ function activeReceiverParam(): Receiver {
   return getRadioState()?.active === 'SUB' ? 1 : 0;
 }
 
-function focusModePanel(vfo: 'MAIN' | 'SUB'): void {
-  setPendingFocus(vfo);
-  patchRadioState({ active: vfo });
-  cmd('set_vfo', { vfo });
-
-  const modePanel = document.querySelector<HTMLElement>('[data-mode-panel="true"]');
-  if (!modePanel) {
-    return;
-  }
-
-  modePanel.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-  modePanel.dataset.highlight = 'true';
-  window.setTimeout(() => {
-    if (modePanel.dataset.highlight === 'true') {
-      delete modePanel.dataset.highlight;
-    }
-  }, 1200);
-}
-
 /* ── VFO Handlers ────────────────────────────────────────────── */
 
-/** Fields that ``0x07 0xB1`` (equalize) and ``0x07 0xB0`` (exchange)
- *  propagate between MAIN and SUB on the radio.  Frequency + mode are
- *  the two observable ones the user cares about; backend poll refreshes
- *  the rest within one cycle.  Keep the list minimal. */
-const _MAIN_SUB_EQUALIZE_FIELDS = ['freqHz', 'mode', 'filter'] as const;
-
+/** Temporary keyboard-only activation path; A03d delegates and removes it. */
 function _activateReceiver(target: 'MAIN' | 'SUB'): void {
   // Optimistic UI + WS command to select the receiver.
   patchRadioState({ active: target });
@@ -85,111 +61,6 @@ function _activateReceiver(target: 'MAIN' | 'SUB'): void {
   // clicking MAIN/SUB updated state + scope but left the audio focus
   // untouched, so the user heard MAIN while tuning SUB.
   audioManager.setAudioConfig({ focus: target === 'SUB' ? 'sub' : 'main' });
-}
-
-export function makeVfoHandlers() {
-  return {
-    onSwap: () => {
-      // IC-7610 ``0x07 0xB0`` swaps freq+mode+params between MAIN and SUB.
-      // Optimistically swap the two in the store so the UI reflects the
-      // change within one tick rather than waiting for the next poll.
-      const s = getRadioState();
-      if (s?.main && s?.sub) {
-        const mainSnap: Partial<ReceiverState> = {};
-        const subSnap: Partial<ReceiverState> = {};
-        for (const f of _MAIN_SUB_EQUALIZE_FIELDS) {
-          Object.assign(mainSnap, { [f]: s.sub[f] });
-          Object.assign(subSnap, { [f]: s.main[f] });
-        }
-        patchReceiver(0, mainSnap);
-        patchReceiver(1, subSnap);
-      }
-      cmd('vfo_swap');
-    },
-    onEqual: () => {
-      // IC-7610 ``0x07 0xB1`` copies MAIN state to SUB.  Optimistically
-      // mirror that in the store so the SUB readouts snap to MAIN's
-      // values immediately — previously users had to wait for the next
-      // poll cycle (~250ms) to see the change.
-      const s = getRadioState();
-      if (s?.main) {
-        const snap: Partial<ReceiverState> = {};
-        for (const f of _MAIN_SUB_EQUALIZE_FIELDS) {
-          Object.assign(snap, { [f]: s.main[f] });
-        }
-        patchReceiver(1, snap);
-      }
-      cmd('vfo_equalize');
-    },
-    onSplitToggle: () => {
-      const next = !(getRadioState()?.split ?? false);
-      patchRadioState({ split: next });
-      cmd('set_split', { on: next });
-    },
-    onMainVfoClick: () => _activateReceiver('MAIN'),
-    onSubVfoClick: () => _activateReceiver('SUB'),
-    /** Semantic VFO selection (MOR-1065): activate the receiver, then the A/B
-     *  slot when the topology has one. `set_vfo` carries either identity
-     *  (`command_service._active_receiver_value` / `_active_slot_value`).
-     *  `slot === null` means the position has no addressable slot — never a
-     *  guessed 'A'. */
-    onVfoSelect: (receiver: 'MAIN' | 'SUB', slot: 'A' | 'B' | null) => {
-      if (getRadioState()?.active !== receiver) _activateReceiver(receiver);
-      if (slot !== null) cmd('set_vfo', { vfo: slot });
-    },
-    onMainModeClick: () => focusModePanel('MAIN'),
-    onSubModeClick: () => focusModePanel('SUB'),
-    onMainFreqChange: (freq: number) => {
-      patchReceiver(0, { freqHz: freq }, true);
-      cmd('set_freq', { freq, receiver: 0 });
-    },
-    onSubFreqChange: (freq: number) => {
-      patchReceiver(1, { freqHz: freq }, true);
-      cmd('set_freq', { freq, receiver: 1 });
-    },
-    onFreqChange: (freq: number, receiver: Receiver = 0) => {
-      patchActiveReceiver({ freqHz: freq }, true);
-      cmd('set_freq', { freq, receiver });
-    },
-    onModeChange: (mode: string, receiver: Receiver = 0) => {
-      patchActiveReceiver({ mode }, true);
-      cmd('set_mode', { mode, receiver });
-    },
-    onFilterChange: (filter: number, receiver: Receiver = 0) => {
-      cmd('set_filter', { filter, receiver });
-    },
-    onDualWatchToggle: (on: boolean) => cmd('set_dual_watch', { on }),
-    // Epic #774 — composite triggers on the backend.  Double-click on the
-    // DW / SPLIT button fires these; backend emits equalize M→S then the
-    // corresponding toggle-on atomically.
-    onQuickDw: () => cmd('quick_dualwatch'),
-    onQuickSplit: () => cmd('quick_split'),
-    onTrackingToggle: (on: boolean) => cmd('set_main_sub_tracking', { on }),
-  };
-}
-
-/* ── VOX Handlers ───────────────────────────────────────────── */
-
-export function makeVoxHandlers() {
-  return {
-    onVoxToggle: () => {
-      const next = !(getRadioState()?.voxOn ?? false);
-      patchRadioState({ voxOn: next });
-      cmd('set_vox', { on: next });
-    },
-    onVoxGainChange: (level: number) => {
-      patchRadioState({ voxGain: level });
-      cmd('set_vox_gain', { level });
-    },
-    onAntiVoxGainChange: (level: number) => {
-      patchRadioState({ antiVoxGain: level });
-      cmd('set_anti_vox_gain', { level });
-    },
-    onVoxDelayChange: (level: number) => {
-      patchRadioState({ voxDelay: level });
-      cmd('set_vox_delay', { level });
-    },
-  };
 }
 
 /* ── Dual-RX audio routing (#756) ────────────────────────────────

--- a/frontend/src/lib/radio/pending-focus.isolated.test.ts
+++ b/frontend/src/lib/radio/pending-focus.isolated.test.ts
@@ -27,7 +27,8 @@ vi.mock('$lib/stores/radio.svelte', () => ({
 }));
 
 vi.mock('$lib/stores/capabilities.svelte', () => ({
-  getCapabilities: vi.fn(() => ({ receivers: 2, vfoScheme: 'main_sub' })),
+  getCapabilities: vi.fn(() => ({ receivers: 2, vfoScheme: 'main_sub', capabilities: ['dual_rx'] })),
+  capabilitiesMatchGeneration: vi.fn(() => true),
   getControlRange: vi.fn(() => null),
 }));
 

--- a/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.test.ts
@@ -26,6 +26,7 @@ const h = vi.hoisted(() => ({
   setRxLive: vi.fn(),
   setRxVolume: vi.fn(),
   setVolume: vi.fn(),
+  setAudioConfig: vi.fn(),
 }));
 
 vi.mock('$lib/transport/ws-client', () => ({
@@ -54,6 +55,10 @@ vi.mock('$lib/state/field-status', () => ({
 
 vi.mock('$lib/stores/capabilities.svelte', () => ({
   getCapabilities: vi.fn(() => h.caps),
+  capabilitiesMatchGeneration: vi.fn((providerGeneration: unknown) =>
+    Number.isSafeInteger(providerGeneration)
+    && h.caps?.stateContractVersion === 1
+    && h.caps?.providerGeneration === providerGeneration),
   getControlRange: vi.fn((name: string) =>
     (h.caps?.controls as Record<string, unknown> | undefined)?.[name] ?? null),
 }));
@@ -69,7 +74,7 @@ vi.mock('$lib/runtime/frontend-runtime', () => ({
 }));
 
 vi.mock('$lib/audio/audio-manager', () => ({
-  audioManager: { setAudioConfig: vi.fn() },
+  audioManager: { setAudioConfig: h.setAudioConfig },
 }));
 
 import {
@@ -86,6 +91,8 @@ import {
   makeRxAudioHandlers,
   makeScanHandlers,
   makeTxHandlers,
+  makeVfoHandlers,
+  makeVoxHandlers,
 } from '../panel-commands';
 import * as compatibilityBus from '$lib/../components-v2/wiring/command-bus';
 import { getCommandLifecycles, resetCommandLifecycle } from '$lib/stores/commands.svelte';
@@ -125,6 +132,8 @@ function state(active: 'MAIN' | 'SUB' = 'MAIN'): ServerState {
     sMeter: 0,
   };
   return {
+    stateContractVersion: 1,
+    providerGeneration: 31,
     active,
     main: { ...receiver },
     sub: { ...receiver, freqHz: 7_100_000 },
@@ -135,9 +144,15 @@ function state(active: 'MAIN' | 'SUB' = 'MAIN'): ServerState {
     nbWidth: 2,
     notchFilter: 64,
     powerLevel: 0.5,
+    split: false,
+    dualWatch: false,
+    mainSubTracking: false,
     micGain: 128,
     tunerStatus: 1,
     voxOn: false,
+    voxGain: 50,
+    antiVoxGain: 25,
+    voxDelay: 4,
     compressorOn: true,
     compressorLevel: 44,
     monitorOn: false,
@@ -197,7 +212,10 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
         'pbt', 'agc', 'rit', 'xit', 'nr', 'nb', 'notch', 'af_level',
         'tx', 'tuner', 'vox', 'compressor', 'monitor', 'drive_gain',
         'cw', 'break_in', 'apf', 'twin_peak', 'rx_antenna',
+        'split', 'dual_rx', 'dual_watch', 'main_sub_tracking',
       ],
+      stateContractVersion: 1,
+      providerGeneration: 31,
       receivers: 2,
       antennas: 2,
       vfoScheme: 'main_sub',
@@ -215,6 +233,7 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
     h.setRxLive.mockClear();
     h.setRxVolume.mockClear();
     h.setVolume.mockClear();
+    h.setAudioConfig.mockClear();
   });
 
   afterEach(() => {
@@ -757,6 +776,160 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
     expect(h.sendCommand).not.toHaveBeenCalled();
   });
 
+  it('exports canonical VFO and VOX factories through the compatibility bus', () => {
+    expect(compatibilityBus.makeVfoHandlers).toBe(makeVfoHandlers);
+    expect(compatibilityBus.makeVoxHandlers).toBe(makeVoxHandlers);
+  });
+
+  it('routes the complete VFO family through exact typed lifecycle without Store truth', () => {
+    const vfo = makeVfoHandlers();
+    vfo.onSwap();
+    vfo.onEqual();
+    vfo.onSplitToggle();
+    vfo.onMainVfoClick();
+    vfo.onSubVfoClick();
+    vfo.onVfoSelect('SUB', 'B');
+    vfo.onMainFreqChange(14_100_000);
+    vfo.onSubFreqChange(7_100_000);
+    vfo.onFreqChange(18_100_000, 0);
+    vfo.onModeChange('CW', 1);
+    vfo.onFilterChange(3, 0);
+    vfo.onDualWatchToggle(true);
+    vfo.onQuickDw();
+    vfo.onQuickSplit();
+    vfo.onTrackingToggle(true);
+
+    expect(exactCalls()).toEqual([
+      ['vfo_swap', {}],
+      ['vfo_equalize', {}],
+      ['set_split', { on: true }],
+      ['set_vfo', { vfo: 'MAIN' }],
+      ['set_vfo', { vfo: 'SUB' }],
+      ['set_vfo', { vfo: 'SUB' }],
+      ['set_vfo', { vfo: 'B' }],
+      ['set_freq', { freq: 14_100_000, receiver: 0 }],
+      ['set_freq', { freq: 7_100_000, receiver: 1 }],
+      ['set_freq', { freq: 18_100_000, receiver: 0 }],
+      ['set_mode', { mode: 'CW', receiver: 1 }],
+      ['set_filter', { filter: 3, receiver: 0 }],
+      ['set_dual_watch', { on: true }],
+      ['quick_dualwatch', {}],
+      ['quick_split', {}],
+      ['set_main_sub_tracking', { on: true }],
+    ]);
+    expectIntentTransport();
+    expect(h.patchActiveReceiver).not.toHaveBeenCalled();
+    expect(h.patchRadioState).not.toHaveBeenCalled();
+    expect(h.patchReceiver).not.toHaveBeenCalled();
+    expect(h.setAudioConfig).toHaveBeenNthCalledWith(1, { focus: 'main' });
+    expect(h.setAudioConfig).toHaveBeenNthCalledWith(2, { focus: 'sub' });
+    expect(h.setAudioConfig).toHaveBeenNthCalledWith(3, { focus: 'sub' });
+  });
+
+  it('preserves pending mode focus and local audio focus without patching radio truth', () => {
+    const panel = document.createElement('div');
+    panel.scrollIntoView = vi.fn();
+    const query = vi.spyOn(document, 'querySelector').mockReturnValue(panel);
+
+    makeVfoHandlers().onSubModeClick();
+    makeModeHandlers().onModeChange('CW');
+
+    expect(exactCalls()).toEqual([
+      ['set_vfo', { vfo: 'SUB' }],
+      ['set_mode', { mode: 'CW', receiver: 1 }],
+    ]);
+    expectIntentTransport();
+    expect(h.setAudioConfig).toHaveBeenCalledExactlyOnceWith({ focus: 'sub' });
+    expect(h.patchRadioState).not.toHaveBeenCalled();
+    expect(panel.scrollIntoView).toHaveBeenCalled();
+    query.mockRestore();
+  });
+
+  it('keeps physical MAIN orthogonal to one-RX A/B Selected/Unselected topology', () => {
+    h.state = oneReceiverAbState();
+    h.caps = {
+      capabilities: ['split', 'tx', 'vox'], receivers: 1, vfoScheme: 'ab',
+      stateContractVersion: 1, providerGeneration: 31,
+    };
+    const vfo = makeVfoHandlers();
+    vfo.onVfoSelect('MAIN', 'B');
+    vfo.onSwap();
+    vfo.onEqual();
+    vfo.onQuickSplit();
+    vfo.onMainFreqChange(14_101_000);
+
+    expect(exactCalls()).toEqual([
+      ['set_vfo', { vfo: 'B' }],
+      ['vfo_swap', {}],
+      ['vfo_equalize', {}],
+      ['quick_split', {}],
+      ['set_freq', { freq: 14_101_000, receiver: 0 }],
+    ]);
+    expectIntentTransport();
+
+    h.sendCommand.mockClear();
+    resetCommandLifecycle();
+    vfo.onSubVfoClick();
+    vfo.onVfoSelect('SUB', 'A');
+    vfo.onSubFreqChange(7_101_000);
+    expect(h.sendCommand).not.toHaveBeenCalled();
+    expect(h.setAudioConfig).not.toHaveBeenCalled();
+    expect(getCommandLifecycles()).toHaveLength(0);
+  });
+
+  it('shares one fail-closed VOX toggle and routes standalone VOX controls through lifecycle', () => {
+    const vox = makeVoxHandlers();
+    vox.onVoxToggle();
+    makeTxHandlers().onVoxToggle();
+    vox.onVoxGainChange(77);
+    vox.onAntiVoxGainChange(12);
+    vox.onVoxDelayChange(5);
+
+    expect(exactCalls()).toEqual([
+      ['set_vox', { on: true }],
+      ['set_vox', { on: true }],
+      ['set_vox_gain', { level: 77 }],
+      ['set_anti_vox_gain', { level: 12 }],
+      ['set_vox_delay', { level: 5 }],
+    ]);
+    expectIntentTransport();
+    expect(h.patchRadioState).not.toHaveBeenCalled();
+  });
+
+  it('fails closed for mismatched generation, stale toggles, invalid topology and malformed VFO/VOX inputs', () => {
+    const vfo = makeVfoHandlers();
+    const vox = makeVoxHandlers();
+    h.caps = { ...h.caps!, providerGeneration: 99 };
+    vfo.onSplitToggle();
+    vfo.onMainVfoClick();
+    vox.onVoxToggle();
+
+    h.caps = { ...h.caps!, providerGeneration: 31 };
+    h.unavailable.add('split');
+    h.unavailable.add('voxOn');
+    h.unavailable.add('voxGain');
+    h.unavailable.add('antiVoxGain');
+    h.unavailable.add('voxDelay');
+    vfo.onSplitToggle();
+    vox.onVoxToggle();
+    vfo.onVfoSelect('B' as unknown as 'MAIN', 'A');
+    vfo.onVfoSelect('MAIN', 'C' as unknown as 'A');
+    vfo.onFreqChange(14_100_000, undefined as unknown as 0);
+    vfo.onMainFreqChange(Number.NaN);
+    vfo.onModeChange('', 0);
+    vfo.onFilterChange(1.5, 0);
+    vox.onVoxGainChange(1.5);
+    vox.onAntiVoxGainChange(Number.NaN);
+    vox.onVoxDelayChange(Number.POSITIVE_INFINITY);
+    vox.onVoxGainChange(10);
+    vox.onAntiVoxGainChange(10);
+    vox.onVoxDelayChange(10);
+
+    expect(h.sendCommand).not.toHaveBeenCalled();
+    expect(h.setAudioConfig).not.toHaveBeenCalled();
+    expect(getCommandLifecycles()).toHaveLength(0);
+  });
+
   it('keeps raw transport out of migrated blocks and Store writers out of their implementation', () => {
     const panelSource = readFileSync(resolve(process.cwd(), 'src/lib/runtime/commands/panel-commands.ts'), 'utf8');
     const busSource = readFileSync(resolve(process.cwd(), 'src/components-v2/wiring/command-bus.ts'), 'utf8');
@@ -765,6 +938,7 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
       'makeModeHandlers', 'makePresetHandlers', 'makeRfFrontEndHandlers',
       'makeRitXitHandlers', 'makeRxAudioHandlers', 'makeCwPanelHandlers',
       'makeTxHandlers', 'makeAntennaHandlers', 'makeScanHandlers',
+      'makeVfoHandlers', 'makeVoxHandlers',
     ];
 
     for (const [index, name] of assignedNames.entries()) {
@@ -813,6 +987,8 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
       'cw_auto_tune', 'set_break_in_delay', 'set_monitor_gain', 'set_dash_ratio',
       'set_rf_power', 'set_mic_gain', 'set_tuner_status', 'set_vox', 'set_compressor',
       'set_compressor_level', 'set_monitor', 'set_drive_gain',
+      'set_vfo', 'vfo_swap', 'vfo_equalize', 'set_split', 'set_dual_watch',
+      'quick_dualwatch', 'quick_split', 'set_main_sub_tracking',
     ]) {
       expect(a03aNames).not.toContain(`'${name}'`);
     }
@@ -834,8 +1010,18 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
     expect(panelSource).not.toContain('set_keyer_type');
     expect(busSource).not.toContain('onKeyerTypeChange');
     expect(busSource).not.toContain('set_keyer_type');
-    expect(busSource).toContain('export function makeVoxHandlers');
-    expect(panelSource).not.toContain('export function makeVoxHandlers');
+    expect(busSource).not.toContain('export function makeVfoHandlers');
+    expect(busSource).not.toContain('export function makeVoxHandlers');
+    expect(panelSource).toContain('export function makeVfoHandlers');
+    expect(panelSource).toContain('export function makeVoxHandlers');
+    expect(busSource).toMatch(/function _activateReceiver\s*\(/);
+    expect(busSource).toContain("case 'set_active_vfo'");
+    for (const deferred of [
+      'makeAudioRoutingHandlers', 'makeMeterHandlers', 'makeSystemHandlers',
+      'makeScopeControlsHandlers', 'makeKeyboardHandlers',
+    ]) expect(busSource).toContain(`export function ${deferred}`);
+    expect(panelSource.match(/function toggleVox/g)).toHaveLength(1);
+    expect(panelSource.match(/onVoxToggle:\s*toggleVox/g)).toHaveLength(2);
     expect(panelSource).not.toMatch(/dispatchRadioIntent\(\{\s*name:\s*['"]ptt(?:_on|_off)?['"]/);
   });
 });

--- a/frontend/src/lib/runtime/commands/panel-commands.ts
+++ b/frontend/src/lib/runtime/commands/panel-commands.ts
@@ -18,13 +18,18 @@ import {
   getRadioState,
   patchRadioState,
 } from '$lib/stores/radio.svelte';
-import { getCapabilities, getControlRange } from '$lib/stores/capabilities.svelte';
+import {
+  capabilitiesMatchGeneration,
+  getCapabilities,
+  getControlRange,
+} from '$lib/stores/capabilities.svelte';
 import { isFieldAvailable } from '$lib/state/field-status';
 import { runtime } from '../frontend-runtime';
-import { consumePendingFocus } from '$lib/radio/pending-focus';
+import { consumePendingFocus, setPendingFocus } from '$lib/radio/pending-focus';
 import { getModeFilter } from '$lib/radio/mode-filter-memory';
 import { modInputCommand, modInputStateKey } from '$lib/radio/mod-input';
 import { nbDepthDisplayToRaw, nrDisplayToRaw } from '$lib/radio/filter-controls';
+import { audioManager } from '$lib/audio/audio-manager';
 import { dispatchRadioIntent, isNormalizedLevel, type RadioIntent } from './radio-intents';
 
 /* ── Shared helpers ──────────────────────────────────────────────── */
@@ -78,6 +83,51 @@ function knownTopLevelField(field: string): boolean {
   const state = getRadioState();
   const value = (state as unknown as Record<string, unknown> | null)?.[field];
   return state !== null && value !== undefined && value !== null && isFieldAvailable(state, field);
+}
+
+function currentA03cContext() {
+  const state = getRadioState();
+  const caps = getCapabilities();
+  if (!state || !caps || !capabilitiesMatchGeneration(state.providerGeneration)) return null;
+  const expectedReceivers = caps.vfoScheme === 'single' || caps.vfoScheme === 'ab' ? 1
+    : caps.vfoScheme === 'ab_shared' || caps.vfoScheme === 'main_sub' ? 2 : 0;
+  if (expectedReceivers === 0 || caps.receivers !== expectedReceivers) return null;
+  return { state, caps };
+}
+
+function knownA03cTopLevelField(
+  context: NonNullable<ReturnType<typeof currentA03cContext>>,
+  field: string,
+): boolean {
+  const value = (context.state as unknown as Record<string, unknown>)[field];
+  return value !== undefined && value !== null && isFieldAvailable(context.state, field);
+}
+
+function knownA03cReceiver(
+  context: NonNullable<ReturnType<typeof currentA03cContext>>,
+  target: 'MAIN' | 'SUB',
+  field?: string,
+): Receiver | null {
+  if (target !== 'MAIN' && target !== 'SUB') return null;
+  if (target === 'SUB'
+    && (context.caps.receivers < 2 || !context.caps.capabilities.includes('dual_rx'))) return null;
+  const receiver: Receiver = target === 'SUB' ? 1 : 0;
+  const state = receiver === 1 ? context.state.sub : context.state.main;
+  if (!state) return null;
+  if (!field) return receiver;
+  const value = (state as unknown as Record<string, unknown>)[field];
+  const path = `${receiver === 1 ? 'sub' : 'main'}.${field}`;
+  return value !== undefined && value !== null && isFieldAvailable(context.state, path)
+    ? receiver : null;
+}
+
+function toggleVox(): void {
+  const context = currentA03cContext();
+  const current = context?.state.voxOn;
+  if (!context || !context.caps.capabilities.includes('tx')
+    || !context.caps.capabilities.includes('vox')
+    || !knownA03cTopLevelField(context, 'voxOn') || typeof current !== 'boolean') return;
+  dispatchRadioIntent({ name: 'set_vox', params: { on: !current } });
 }
 
 /* ── Inlined PBT / IF-shift helpers (from filter-controls.ts) ────── */
@@ -489,12 +539,7 @@ export function makeTxHandlers() {
       if (!hasCapability('tx') || !hasCapability('tuner') || !knownTopLevelField('tunerStatus')) return;
       dispatchRadioIntent({ name: 'set_tuner_status', params: { value: 2 } });
     },
-    onVoxToggle: () => {
-      const current = getRadioState()?.voxOn;
-      if (!hasCapability('tx') || !hasCapability('vox') || !knownTopLevelField('voxOn')
-        || typeof current !== 'boolean') return;
-      dispatchRadioIntent({ name: 'set_vox', params: { on: !current } });
-    },
+    onVoxToggle: toggleVox,
     onCompToggle: () => {
       const current = getRadioState()?.compressorOn;
       if (!hasCapability('tx') || !hasCapability('compressor') || !knownTopLevelField('compressorOn')
@@ -724,6 +769,164 @@ export function makeRxAudioHandlers() {
         if (!hasCapability('af_level') || receiver === null) return;
         dispatchRadioIntent({ name: 'set_af_level', params: { level, receiver } });
       }
+    },
+  };
+}
+
+/* ── VFO Handlers ────────────────────────────────────────────────── */
+
+function activateReceiver(
+  target: 'MAIN' | 'SUB',
+  context = currentA03cContext(),
+): boolean {
+  if (!context || knownA03cReceiver(context, target) === null) return false;
+  dispatchRadioIntent({ name: 'set_vfo', params: { vfo: target } });
+  audioManager.setAudioConfig({ focus: target === 'SUB' ? 'sub' : 'main' });
+  return true;
+}
+
+function focusModePanel(target: 'MAIN' | 'SUB'): void {
+  if (!activateReceiver(target)) return;
+  setPendingFocus(target);
+  const modePanel = document.querySelector<HTMLElement>('[data-mode-panel="true"]');
+  if (!modePanel) return;
+  modePanel.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+  modePanel.dataset.highlight = 'true';
+  window.setTimeout(() => {
+    if (modePanel.dataset.highlight === 'true') delete modePanel.dataset.highlight;
+  }, 1200);
+}
+
+function supportsVfoSlot(
+  context: NonNullable<ReturnType<typeof currentA03cContext>>,
+  slot: 'A' | 'B' | null,
+): boolean {
+  if (slot === null) return true;
+  if (slot !== 'A' && slot !== 'B') return false;
+  return context.caps.vfoScheme === 'ab' || context.caps.vfoScheme === 'main_sub';
+}
+
+export function makeVfoHandlers() {
+  return {
+    onSwap: () => {
+      const context = currentA03cContext();
+      if (!context || context.caps.vfoScheme === 'single') return;
+      dispatchRadioIntent({ name: 'vfo_swap', params: {} });
+    },
+    onEqual: () => {
+      const context = currentA03cContext();
+      if (!context || context.caps.vfoScheme === 'single') return;
+      dispatchRadioIntent({ name: 'vfo_equalize', params: {} });
+    },
+    onSplitToggle: () => {
+      const context = currentA03cContext();
+      const current = context?.state.split;
+      if (!context || !context.caps.capabilities.includes('split')
+        || !knownA03cTopLevelField(context, 'split') || typeof current !== 'boolean') return;
+      dispatchRadioIntent({ name: 'set_split', params: { on: !current } });
+    },
+    onMainVfoClick: () => { activateReceiver('MAIN'); },
+    onSubVfoClick: () => { activateReceiver('SUB'); },
+    onVfoSelect: (receiver: 'MAIN' | 'SUB', slot: 'A' | 'B' | null) => {
+      const context = currentA03cContext();
+      if (!context || !knownA03cTopLevelField(context, 'active')
+        || knownA03cReceiver(context, receiver) === null
+        || !supportsVfoSlot(context, slot)) return;
+      if (context.state.active !== receiver && !activateReceiver(receiver, context)) return;
+      if (slot !== null) dispatchRadioIntent({ name: 'set_vfo', params: { vfo: slot } });
+    },
+    onMainModeClick: () => focusModePanel('MAIN'),
+    onSubModeClick: () => focusModePanel('SUB'),
+    onMainFreqChange: (freq: number) => {
+      const context = currentA03cContext();
+      if (!context || knownA03cReceiver(context, 'MAIN', 'freqHz') !== 0
+        || !Number.isSafeInteger(freq)) return;
+      dispatchRadioIntent({ name: 'set_freq', params: { freq, receiver: 0 } });
+    },
+    onSubFreqChange: (freq: number) => {
+      const context = currentA03cContext();
+      if (!context || knownA03cReceiver(context, 'SUB', 'freqHz') !== 1
+        || !Number.isSafeInteger(freq)) return;
+      dispatchRadioIntent({ name: 'set_freq', params: { freq, receiver: 1 } });
+    },
+    onFreqChange: (freq: number, receiver?: Receiver) => {
+      const context = currentA03cContext();
+      const target = receiver === 0 ? 'MAIN' : receiver === 1 ? 'SUB' : null;
+      if (!context || target === null || knownA03cReceiver(context, target, 'freqHz') !== receiver
+        || !Number.isSafeInteger(freq)) return;
+      dispatchRadioIntent({ name: 'set_freq', params: { freq, receiver } });
+    },
+    onModeChange: (mode: string, receiver?: Receiver) => {
+      const context = currentA03cContext();
+      const target = receiver === 0 ? 'MAIN' : receiver === 1 ? 'SUB' : null;
+      if (!context || target === null || knownA03cReceiver(context, target, 'mode') !== receiver
+        || typeof mode !== 'string' || mode.length === 0) return;
+      dispatchRadioIntent({ name: 'set_mode', params: { mode, receiver } });
+    },
+    onFilterChange: (filter: number, receiver?: Receiver) => {
+      const context = currentA03cContext();
+      const target = receiver === 0 ? 'MAIN' : receiver === 1 ? 'SUB' : null;
+      if (!context || target === null || knownA03cReceiver(context, target, 'filter') !== receiver
+        || !Number.isSafeInteger(filter)) return;
+      dispatchRadioIntent({ name: 'set_filter', params: { filter, receiver } });
+    },
+    onDualWatchToggle: (on: boolean) => {
+      const context = currentA03cContext();
+      if (!context || context.caps.receivers < 2
+        || !context.caps.capabilities.includes('dual_rx')
+        || !context.caps.capabilities.includes('dual_watch')
+        || !knownA03cTopLevelField(context, 'dualWatch') || typeof on !== 'boolean') return;
+      dispatchRadioIntent({ name: 'set_dual_watch', params: { on } });
+    },
+    onQuickDw: () => {
+      const context = currentA03cContext();
+      if (!context || context.caps.receivers < 2
+        || !context.caps.capabilities.includes('dual_rx')
+        || !context.caps.capabilities.includes('dual_watch')
+        || !knownA03cTopLevelField(context, 'dualWatch')) return;
+      dispatchRadioIntent({ name: 'quick_dualwatch', params: {} });
+    },
+    onQuickSplit: () => {
+      const context = currentA03cContext();
+      if (!context || context.caps.vfoScheme === 'single'
+        || !context.caps.capabilities.includes('split')
+        || !knownA03cTopLevelField(context, 'split')) return;
+      dispatchRadioIntent({ name: 'quick_split', params: {} });
+    },
+    onTrackingToggle: (on: boolean) => {
+      const context = currentA03cContext();
+      if (!context || context.caps.receivers < 2
+        || !context.caps.capabilities.includes('dual_rx')
+        || !context.caps.capabilities.includes('main_sub_tracking')
+        || !knownA03cTopLevelField(context, 'mainSubTracking') || typeof on !== 'boolean') return;
+      dispatchRadioIntent({ name: 'set_main_sub_tracking', params: { on } });
+    },
+  };
+}
+
+/* ── VOX Handlers ────────────────────────────────────────────────── */
+
+function knownVoxLevel(field: 'voxGain' | 'antiVoxGain' | 'voxDelay', level: number): boolean {
+  const context = currentA03cContext();
+  return context !== null && context.caps.capabilities.includes('tx')
+    && context.caps.capabilities.includes('vox')
+    && knownA03cTopLevelField(context, field) && Number.isSafeInteger(level);
+}
+
+export function makeVoxHandlers() {
+  return {
+    onVoxToggle: toggleVox,
+    onVoxGainChange: (level: number) => {
+      if (!knownVoxLevel('voxGain', level)) return;
+      dispatchRadioIntent({ name: 'set_vox_gain', params: { level } });
+    },
+    onAntiVoxGainChange: (level: number) => {
+      if (!knownVoxLevel('antiVoxGain', level)) return;
+      dispatchRadioIntent({ name: 'set_anti_vox_gain', params: { level } });
+    },
+    onVoxDelayChange: (level: number) => {
+      if (!knownVoxLevel('voxDelay', level)) return;
+      dispatchRadioIntent({ name: 'set_vox_delay', params: { level } });
     },
   };
 }


### PR DESCRIPTION
## Summary

- moves the complete VFO and standalone VOX command families into the canonical panel-command factory and leaves the compatibility bus as re-exports
- routes every migrated radio action through the existing typed lifecycle with no optimistic radio Store writes
- keeps physical MAIN/SUB orthogonal to VFO A/B: one-receiver MAIN+B, relative swap/equalize, and quick split remain valid while impossible physical SUB fails closed
- preserves pending mode focus and browser-local audio focus; leaves keyboard, browser-audio routing, meters, scope, system, PTT, audio, and spectrum ownership for their published later gates

Refs #2317

Acceptance addendum: https://github.com/rigplane/rigplane-core/issues/2317#issuecomment-5231690407

## Exact scope

- Base: `8a89b68ee7bec65125067879657b9599fbf935ca`
- Head: `ecbfb00a318d116b8e87ce72d391c3764a8da45e`
- Production owners: `panel-commands.ts`, `command-bus.ts`
- Production churn: 356 additions + deletions (hard cap 400)
- `radio-intents.ts`: byte-identical (`e3cb4f1f97cc9c87ce95afc0c5e6e269c67af290561fa75372adc6ea916550f3`)

## Verification

- focused VFO/VOX/lifecycle/topology suite: 193 passed
- frozen lifecycle/PTT/OFF/audio/scope/spectrum/diagnostics suite: 692 passed
- frontend full: 6153 passed
- frontend check, lint, boundary lint, i18n check, and production build: passed
- backend non-hardware full: 8993 passed, 12 skipped, 11 xfailed, 1 xpassed
- Ruff lint/format, import-linter, generated state types, and consumer contracts: passed
- required mutation probes: all made their focused tests RED and were fully restored

## Safety

- no generic PTT/TUNE coupling, TX action, radio/hardware access, or ACK-derived truth
- no keyboard delegation, audio-routing/meter migration, scope/system migration, or MOR-1414 work
- auto-merge remains off; independent exact-head review is required before merge
