### PR TITLE
MOR-1409 A03c2: canonicalize local audio routing

### DIFF
--- a/frontend/fixtures/stubs/command-bus.ts
+++ b/frontend/fixtures/stubs/command-bus.ts
@@ -30,7 +30,7 @@
  * exports but nothing in the fixture-mounted tree references yet
  * (`makeAgcHandlers`, `makeAntennaHandlers`, `makeBandHandlers`,
  * `makeCwPanelHandlers`, `makeDspHandlers`, `makeFilterHandlers`,
- * `makeKeyboardHandlers`, `makeMeterHandlers`, `makePresetHandlers`,
+ * `makeKeyboardHandlers`, `makePresetHandlers`,
  * `makeRfFrontEndHandlers`, `makeRitXitHandlers`, `makeScanHandlers`,
  * `makeSystemHandlers`). Full parity is the only guard the test can enforce
  * without also encoding "and here is every place in the tree that imports
@@ -174,10 +174,6 @@ export function makeBandHandlers() {
 
 export function makeAntennaHandlers() {
   return recorders('antenna', ['onSelectAnt1', 'onSelectAnt2', 'onToggleRxAnt'] as const);
-}
-
-export function makeMeterHandlers() {
-  return recorders('meter', ['onMeterSourceChange'] as const);
 }
 
 export function makeSystemHandlers() {

--- a/frontend/src/components-v2/wiring/command-bus.ts
+++ b/frontend/src/components-v2/wiring/command-bus.ts
@@ -16,6 +16,7 @@ import { adjustTuningStep, getTuningStep } from '$lib/stores/tuning.svelte';
 import { audioManager } from '$lib/audio/audio-manager';
 export {
   makeAgcHandlers,
+  makeAudioRoutingHandlers,
   makeBandHandlers,
   makeCwPanelHandlers,
   makeDspHandlers,
@@ -61,94 +62,6 @@ function _activateReceiver(target: 'MAIN' | 'SUB'): void {
   // clicking MAIN/SUB updated state + scope but left the audio focus
   // untouched, so the user heard MAIN while tuning SUB.
   audioManager.setAudioConfig({ focus: target === 'SUB' ? 'sub' : 'main' });
-}
-
-/* ── Dual-RX audio routing (#756) ────────────────────────────────
- * UI surface for the pipeline plumbed in #755 (audio_config WS +
- * CI-V Phones L/R Mix) and #757 (RxPlayer routing graph).  Three
- * widgets: focus selector, stereo split toggle, per-channel gain.
- */
-
-const LS_FOCUS = 'icom.audio.focus';
-const LS_SPLIT = 'icom.audio.split_stereo';
-const LS_MAIN_DB = 'icom.audio.main_gain_db';
-const LS_SUB_DB = 'icom.audio.sub_gain_db';
-
-type AudioFocus = 'main' | 'sub' | 'both';
-
-function _ls<T>(key: string, parse: (raw: string) => T | null): T | null {
-  try {
-    const raw = localStorage.getItem(key);
-    if (raw === null) return null;
-    return parse(raw);
-  } catch {
-    return null;
-  }
-}
-
-function _lsSet(key: string, value: string): void {
-  try { localStorage.setItem(key, value); } catch { /* quota / private mode — ignore */ }
-}
-
-export function makeAudioRoutingHandlers() {
-  return {
-    onFocusChange: (focus: AudioFocus) => {
-      audioManager.setAudioConfig({ focus });
-      _lsSet(LS_FOCUS, focus);
-    },
-    onSplitStereoChange: (on: boolean) => {
-      audioManager.setAudioConfig({ split_stereo: on });
-      _lsSet(LS_SPLIT, on ? '1' : '0');
-    },
-    onChannelGainChange: (channel: 'main' | 'sub', db: number) => {
-      const safe = Number.isFinite(db) ? db : 0;
-      if (channel === 'main') {
-        audioManager.setAudioConfig({ main_gain_db: safe });
-        _lsSet(LS_MAIN_DB, String(safe));
-      } else {
-        audioManager.setAudioConfig({ sub_gain_db: safe });
-        _lsSet(LS_SUB_DB, String(safe));
-      }
-    },
-    restoreFromStorage: () => {
-      const focus = _ls<AudioFocus>(LS_FOCUS, (r) =>
-        r === 'main' || r === 'sub' || r === 'both' ? r : null
-      );
-      const split = _ls<boolean>(LS_SPLIT, (r) => r === '1');
-      const mainDb = _ls<number>(LS_MAIN_DB, (r) => {
-        const n = Number(r);
-        return Number.isFinite(n) ? n : null;
-      });
-      const subDb = _ls<number>(LS_SUB_DB, (r) => {
-        const n = Number(r);
-        return Number.isFinite(n) ? n : null;
-      });
-      const cfg: Record<string, unknown> = {};
-      if (focus !== null) cfg.focus = focus;
-      if (split !== null) cfg.split_stereo = split;
-      if (mainDb !== null) cfg.main_gain_db = mainDb;
-      if (subDb !== null) cfg.sub_gain_db = subDb;
-      if (Object.keys(cfg).length > 0) {
-        audioManager.setAudioConfig(cfg);
-      }
-      return {
-        focus: focus ?? 'both' as AudioFocus,
-        split_stereo: split ?? false,
-        main_gain_db: mainDb ?? 0,
-        sub_gain_db: subDb ?? 0,
-      };
-    },
-  };
-}
-
-/* ── Meter Handlers ──────────────────────────────────────────── */
-
-export function makeMeterHandlers() {
-  return {
-    onMeterSourceChange: (source: string) => {
-      patchRadioState({ meterSource: source as 'S' | 'SWR' | 'POWER' });
-    },
-  };
 }
 
 /* ── System Handlers ─────────────────────────────────────────── */

--- a/frontend/src/lib/runtime/commands/__tests__/local-audio-meter-authority.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/local-audio-meter-authority.test.ts
@@ -1,0 +1,86 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const panelSource = readFileSync(
+  'src/lib/runtime/commands/panel-commands.ts',
+  'utf8',
+);
+const busSource = readFileSync(
+  'src/components-v2/wiring/command-bus.ts',
+  'utf8',
+);
+const stateSource = readFileSync('src/lib/types/state.ts', 'utf8');
+const fixtureBusSource = readFileSync('fixtures/stubs/command-bus.ts', 'utf8');
+const panelPropsSource = readFileSync('src/lib/runtime/props/panel-props.ts', 'utf8');
+const stateAdapterSource = readFileSync(
+  'src/components-v2/wiring/state-adapter.ts',
+  'utf8',
+);
+const mobileSource = readFileSync(
+  'src/components-v2/layout/MobileRadioLayout.svelte',
+  'utf8',
+);
+const lcdSource = readFileSync(
+  'src/components-v2/panels/lcd/AmberCockpit.svelte',
+  'utf8',
+);
+
+function factoryBlock(source: string, factory: string): string {
+  const start = source.indexOf(`export function ${factory}`);
+  expect(start).toBeGreaterThanOrEqual(0);
+  const next = source.indexOf('\nexport function ', start + 1);
+  return source.slice(start, next < 0 ? source.length : next);
+}
+
+describe('MOR-1409 A03c2 local audio and meter authority', () => {
+  it('owns the complete audio-routing factory canonically and keeps the bus as a re-export', () => {
+    const block = factoryBlock(panelSource, 'makeAudioRoutingHandlers');
+    expect(busSource).toContain('makeAudioRoutingHandlers,');
+    expect(busSource).not.toContain('export function makeAudioRoutingHandlers');
+    expect(block).toContain('audioManager.setAudioConfig');
+    expect(panelSource).toContain("const LS_FOCUS = 'icom.audio.focus'");
+    expect(panelSource).toContain("const LS_SPLIT = 'icom.audio.split_stereo'");
+    expect(panelSource).toContain("const LS_MAIN_DB = 'icom.audio.main_gain_db'");
+    expect(panelSource).toContain("const LS_SUB_DB = 'icom.audio.sub_gain_db'");
+    expect(block).toContain('Number.isFinite');
+    expect(block).not.toMatch(
+      /\b(?:cmd|sendCommand|dispatchRadioIntent|patchRadioState|patchActiveReceiver|patchReceiver)\s*\(/,
+    );
+  });
+
+  it('deletes both dead meter factories, their fixture no-op, and Store-writer residue', () => {
+    expect(panelSource).not.toContain('export function makeMeterHandlers');
+    expect(busSource).not.toContain('export function makeMeterHandlers');
+    expect(fixtureBusSource).not.toContain('export function makeMeterHandlers');
+    expect(`${panelSource}\n${busSource}`).not.toMatch(
+      /patchRadioState\s*\(\s*\{\s*meterSource\s*:/,
+    );
+  });
+
+  it('removes only the hand-written ServerState augmentation and preserves local selectors', () => {
+    const handWrittenState = stateSource.slice(stateSource.indexOf('// END GENERATED'));
+    expect(handWrittenState).not.toContain('meterSource');
+    expect(handWrittenState).toContain('transportSeq?: number');
+    expect(handWrittenState).toContain('sub: ReceiverState');
+
+    expect(mobileSource).toContain("$state<MeterSource>('POWER')");
+    expect(mobileSource).toContain('selectMobileMeterSource');
+    expect(lcdSource).toContain("$state<MeterSource>('S')");
+    expect(lcdSource).toContain('cycleMeterSource');
+  });
+
+  it('leaves keyboard, scope/system, and later meter projection cleanup in their published gates', () => {
+    for (const deferred of [
+      'makeSystemHandlers',
+      'makeScopeControlsHandlers',
+      'makeKeyboardHandlers',
+    ]) {
+      expect(busSource).toContain(`export function ${deferred}`);
+      expect(panelSource).not.toContain(`export function ${deferred}`);
+    }
+    expect(busSource).toContain('function _activateReceiver');
+    expect(busSource).toContain("case 'set_active_vfo'");
+    expect(panelPropsSource).toContain('meterSource');
+    expect(stateAdapterSource).toContain('meterSource');
+  });
+});

--- a/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.test.ts
@@ -80,6 +80,7 @@ vi.mock('$lib/audio/audio-manager', () => ({
 import {
   makeAgcHandlers,
   makeAntennaHandlers,
+  makeAudioRoutingHandlers,
   makeBandHandlers,
   makeCwPanelHandlers,
   makeDspHandlers,
@@ -238,6 +239,7 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
 
   afterEach(() => {
     resetCommandLifecycle();
+    localStorage.clear();
     vi.useRealTimers();
   });
 
@@ -255,6 +257,60 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
     expect(compatibilityBus.makeTxHandlers).toBe(makeTxHandlers);
     expect(compatibilityBus.makeAntennaHandlers).toBe(makeAntennaHandlers);
     expect(compatibilityBus.makeScanHandlers).toBe(makeScanHandlers);
+    expect(compatibilityBus.makeAudioRoutingHandlers).toBe(makeAudioRoutingHandlers);
+  });
+
+  it('keeps audio routing local with exact storage, finite-gain, and restore semantics', () => {
+    localStorage.clear();
+    const handlers = makeAudioRoutingHandlers();
+
+    expect(handlers.restoreFromStorage()).toEqual({
+      focus: 'both',
+      split_stereo: false,
+      main_gain_db: 0,
+      sub_gain_db: 0,
+    });
+    expect(h.setAudioConfig).not.toHaveBeenCalled();
+
+    handlers.onFocusChange('sub');
+    handlers.onSplitStereoChange(true);
+    handlers.onChannelGainChange('main', Number.NaN);
+    handlers.onChannelGainChange('sub', -3);
+
+    expect(h.setAudioConfig.mock.calls).toEqual([
+      [{ focus: 'sub' }],
+      [{ split_stereo: true }],
+      [{ main_gain_db: 0 }],
+      [{ sub_gain_db: -3 }],
+    ]);
+    expect(localStorage.getItem('icom.audio.focus')).toBe('sub');
+    expect(localStorage.getItem('icom.audio.split_stereo')).toBe('1');
+    expect(localStorage.getItem('icom.audio.main_gain_db')).toBe('0');
+    expect(localStorage.getItem('icom.audio.sub_gain_db')).toBe('-3');
+    expect(h.sendCommand).not.toHaveBeenCalled();
+    expect(h.patchActiveReceiver).not.toHaveBeenCalled();
+    expect(h.patchRadioState).not.toHaveBeenCalled();
+    expect(h.patchReceiver).not.toHaveBeenCalled();
+    expect(getCommandLifecycles()).toHaveLength(0);
+
+    localStorage.setItem('icom.audio.focus', 'invalid');
+    localStorage.setItem('icom.audio.split_stereo', '0');
+    localStorage.setItem('icom.audio.main_gain_db', 'not-finite');
+    localStorage.setItem('icom.audio.sub_gain_db', '2');
+    h.setAudioConfig.mockClear();
+
+    expect(handlers.restoreFromStorage()).toEqual({
+      focus: 'both',
+      split_stereo: false,
+      main_gain_db: 0,
+      sub_gain_db: 2,
+    });
+    expect(h.setAudioConfig).toHaveBeenCalledExactlyOnceWith({
+      split_stereo: false,
+      sub_gain_db: 2,
+    });
+    expect(h.sendCommand).not.toHaveBeenCalled();
+    expect(getCommandLifecycles()).toHaveLength(0);
   });
 
   it('routes mode, DATA mode, and MOD input through exact lifecycle envelopes without Store writes', () => {
@@ -938,7 +994,7 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
       'makeModeHandlers', 'makePresetHandlers', 'makeRfFrontEndHandlers',
       'makeRitXitHandlers', 'makeRxAudioHandlers', 'makeCwPanelHandlers',
       'makeTxHandlers', 'makeAntennaHandlers', 'makeScanHandlers',
-      'makeVfoHandlers', 'makeVoxHandlers',
+      'makeVfoHandlers', 'makeVoxHandlers', 'makeAudioRoutingHandlers',
     ];
 
     for (const [index, name] of assignedNames.entries()) {
@@ -1017,9 +1073,10 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
     expect(busSource).toMatch(/function _activateReceiver\s*\(/);
     expect(busSource).toContain("case 'set_active_vfo'");
     for (const deferred of [
-      'makeAudioRoutingHandlers', 'makeMeterHandlers', 'makeSystemHandlers',
-      'makeScopeControlsHandlers', 'makeKeyboardHandlers',
+      'makeSystemHandlers', 'makeScopeControlsHandlers', 'makeKeyboardHandlers',
     ]) expect(busSource).toContain(`export function ${deferred}`);
+    expect(panelSource).not.toContain('export function makeMeterHandlers');
+    expect(busSource).not.toContain('export function makeMeterHandlers');
     expect(panelSource.match(/function toggleVox/g)).toHaveLength(1);
     expect(panelSource.match(/onVoxToggle:\s*toggleVox/g)).toHaveLength(2);
     expect(panelSource).not.toMatch(/dispatchRadioIntent\(\{\s*name:\s*['"]ptt(?:_on|_off)?['"]/);

--- a/frontend/src/lib/runtime/commands/panel-commands.ts
+++ b/frontend/src/lib/runtime/commands/panel-commands.ts
@@ -368,12 +368,80 @@ export function makeScanHandlers() {
   };
 }
 
-/* ── Meter Handlers ──────────────────────────────────────────────── */
+/* ── Dual-RX audio routing (#756) ──────────────────────────────────
+ * UI surface for the pipeline plumbed in #755 (audio_config WS +
+ * CI-V Phones L/R Mix) and #757 (RxPlayer routing graph).  Three
+ * widgets: focus selector, stereo split toggle, per-channel gain.
+ */
 
-export function makeMeterHandlers() {
+const LS_FOCUS = 'icom.audio.focus';
+const LS_SPLIT = 'icom.audio.split_stereo';
+const LS_MAIN_DB = 'icom.audio.main_gain_db';
+const LS_SUB_DB = 'icom.audio.sub_gain_db';
+
+type AudioFocus = 'main' | 'sub' | 'both';
+
+function _ls<T>(key: string, parse: (raw: string) => T | null): T | null {
+  try {
+    const raw = localStorage.getItem(key);
+    if (raw === null) return null;
+    return parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function _lsSet(key: string, value: string): void {
+  try { localStorage.setItem(key, value); } catch { /* quota / private mode — ignore */ }
+}
+
+export function makeAudioRoutingHandlers() {
   return {
-    onMeterSourceChange: (source: string) => {
-      patchRadioState({ meterSource: source as 'S' | 'SWR' | 'POWER' });
+    onFocusChange: (focus: AudioFocus) => {
+      audioManager.setAudioConfig({ focus });
+      _lsSet(LS_FOCUS, focus);
+    },
+    onSplitStereoChange: (on: boolean) => {
+      audioManager.setAudioConfig({ split_stereo: on });
+      _lsSet(LS_SPLIT, on ? '1' : '0');
+    },
+    onChannelGainChange: (channel: 'main' | 'sub', db: number) => {
+      const safe = Number.isFinite(db) ? db : 0;
+      if (channel === 'main') {
+        audioManager.setAudioConfig({ main_gain_db: safe });
+        _lsSet(LS_MAIN_DB, String(safe));
+      } else {
+        audioManager.setAudioConfig({ sub_gain_db: safe });
+        _lsSet(LS_SUB_DB, String(safe));
+      }
+    },
+    restoreFromStorage: () => {
+      const focus = _ls<AudioFocus>(LS_FOCUS, (r) =>
+        r === 'main' || r === 'sub' || r === 'both' ? r : null
+      );
+      const split = _ls<boolean>(LS_SPLIT, (r) => r === '1');
+      const mainDb = _ls<number>(LS_MAIN_DB, (r) => {
+        const n = Number(r);
+        return Number.isFinite(n) ? n : null;
+      });
+      const subDb = _ls<number>(LS_SUB_DB, (r) => {
+        const n = Number(r);
+        return Number.isFinite(n) ? n : null;
+      });
+      const cfg: Record<string, unknown> = {};
+      if (focus !== null) cfg.focus = focus;
+      if (split !== null) cfg.split_stereo = split;
+      if (mainDb !== null) cfg.main_gain_db = mainDb;
+      if (subDb !== null) cfg.sub_gain_db = subDb;
+      if (Object.keys(cfg).length > 0) {
+        audioManager.setAudioConfig(cfg);
+      }
+      return {
+        focus: focus ?? 'both' as AudioFocus,
+        split_stereo: split ?? false,
+        main_gain_db: mainDb ?? 0,
+        sub_gain_db: subDb ?? 0,
+      };
     },
   };
 }

--- a/frontend/src/lib/types/state.ts
+++ b/frontend/src/lib/types/state.ts
@@ -311,19 +311,14 @@ export type FieldAvailability = FieldStatusPublic['availability'];
  * The state object the frontend holds.
  *
  * Extends the generated, server-sent `ServerStatePublic` contract with the
- * fields that are NOT part of the wire payload but live on the merged
- * client-side state:
+ * envelope field that is NOT part of the wire payload but lives on the
+ * merged client-side state:
  *
- * - `meterSource`: pure client-only optimistic UI state. The server never
- *   sends it; it is patched locally by the command bus / state adapter
- *   (MOR-881 contract correction — it used to be declared on the server
- *   contract by mistake).
  * - `transportSeq`: a WS envelope-only sequence field that `ws-client.ts`
  *   hoists onto the accumulated state object for ordering. Not server-sent
  *   inside `data`/`changed`.
  */
 export interface ServerState extends ServerStatePublic {
-  meterSource?: 'S' | 'SWR' | 'POWER';
   transportSeq?: number;
   // Client-side invariant: the merged state always carries a `sub` receiver
   // (the single-receiver wire payload omits it, but consumers — e.g.

--- a/frontend/tests/e2e/i18n/fixtures.ts
+++ b/frontend/tests/e2e/i18n/fixtures.ts
@@ -83,7 +83,6 @@ export const mockState: ServerState = {
   radioDetail: {
     status: 'connected',
   },
-  meterSource: 'S',
   cwPitch: 600,
   micGain: 50,
   compressorOn: false,


### PR DESCRIPTION
## Summary

- move browser-local audio routing and its exact localStorage behavior into the canonical panel command module
- keep the compatibility command bus as a re-export only
- delete both proven-unreachable meter writer factories, the fixture no-op, and the stale hand-written `ServerState.meterSource` augmentation
- preserve component-local LCD/mobile meter selection and all deferred A03d/A03e handlers

Issue: #2317

Published split addendum: https://github.com/rigplane/rigplane-core/issues/2317#issuecomment-5231690407

Exact base: `b18ea1fe134d0de55269b9718ef9dac8801ccb32`

## Safety and scope

- production ownership is limited to the three published files
- production churn is 174 changed lines (one below the 175-230 estimate because the exact move/deletion was smaller; hard cap 400)
- `radio-intents.ts` remains byte-identical (`e3cb4f1f97cc9c87ce95afc0c5e6e269c67af290561fa75372adc6ea916550f3`)
- no Store radio patch, WebSocket/command intent, lifecycle, PTT, audio transport/pipeline, scope, spectrum, backend, or radio-provider change
- browser audio persistence keys, defaults, finite-gain handling, and local-only behavior are preserved

## Verification

- causal RED-first authority tests; 10 required mutations went RED independently and were restored
- focused/reachability/component selection: 14 files, 313 passed
- frozen A02 + PTT/OFF + audio/scope/spectrum/diagnostics: 39 files, 607 passed
- final exact-scope restoration selection: 5 files, 63 passed
- full frontend: 298 files, 6,156 passed
- frontend check: 0 errors, 0 warnings
- frontend lint, boundary lint, i18n check, and production build: passed
- full backend all-extras: 9,256 passed, 68 skipped, 5 deselected, 11 xfailed, 1 xpassed
- Ruff lint/format: passed (652 files formatted)
- import-linter: 5 contracts kept, 0 broken
- generated state types: up to date
- consumer contracts: 2/2 passed
- `git diff --check`: passed

No hardware assertion is made by this browser-local cleanup. Auto-merge remains off; fresh independent exact-head review is required before merge.
