### PR TITLE
refactor(#2317): delegate keyboard tuning radio actions

### DIFF
--- a/frontend/src/components-v2/wiring/__tests__/keyboard-wiring.isolated.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/keyboard-wiring.isolated.test.ts
@@ -17,6 +17,11 @@ vi.mock('$lib/stores/radio.svelte', () => ({
 
 vi.mock('$lib/stores/capabilities.svelte', () => ({
   getCapabilities: vi.fn(() => ({
+    capabilities: ['bsr', 'preamp', 'attenuator', 'agc', 'nr', 'nb', 'notch', 'ip_plus'],
+    stateContractVersion: 1,
+    providerGeneration: 31,
+    receivers: 2,
+    vfoScheme: 'main_sub',
     freqRanges: [
       {
         start: 1,
@@ -34,6 +39,12 @@ vi.mock('$lib/stores/capabilities.svelte', () => ({
     filters: ['FIL1', 'FIL2', 'FIL3'],
     dataModeCount: 3,
   })),
+  capabilitiesMatchGeneration: vi.fn(() => true),
+  getControlRange: vi.fn(() => null),
+}));
+
+vi.mock('$lib/state/field-status', () => ({
+  isFieldAvailable: vi.fn(() => true),
 }));
 
 vi.mock('$lib/stores/tuning.svelte', () => ({
@@ -70,6 +81,13 @@ describe('makeKeyboardHandlers', () => {
     vi.mocked(sendCommand).mockClear();
     vi.mocked(patchActiveReceiver).mockClear();
     vi.mocked(patchRadioState).mockClear();
+    vi.mocked(getRadioState).mockReturnValue({
+      active: 'MAIN', providerGeneration: 31,
+      main: {
+        freqHz: 14_074_000, preamp: 1, dataMode: 2, mode: 'USB', filter: 2,
+        att: 0, agc: 2, nr: false, nb: false, autoNotch: false, ipplus: false,
+      },
+    } as any);
   });
 
   it('cycles to the next band by index', () => {
@@ -79,9 +97,6 @@ describe('makeKeyboardHandlers', () => {
   });
 
   it('cycles preamp values from capabilities', () => {
-    vi.mocked(getRadioState).mockReturnValue({ active: 'MAIN' } as any);
-    vi.mocked(getActiveReceiver).mockReturnValue({ preamp: 1 } as any);
-
     makeKeyboardHandlers().dispatch(makeAction('cycle_preamp'));
 
     expect(sendCommand).toHaveBeenCalledWith('set_preamp', { level: 2, receiver: 0 });
@@ -97,9 +112,6 @@ describe('makeKeyboardHandlers', () => {
   });
 
   it('cycles data mode values based on capability count', () => {
-    vi.mocked(getRadioState).mockReturnValue({ active: 'MAIN' } as any);
-    vi.mocked(getActiveReceiver).mockReturnValue({ dataMode: 3 } as any);
-
     makeKeyboardHandlers().dispatch(makeAction('cycle_data_mode'));
 
     expect(sendCommand).toHaveBeenCalledWith('set_data_mode', { mode: 0, receiver: 0 });
@@ -116,13 +128,10 @@ describe('makeKeyboardHandlers', () => {
   });
 
   it('tunes frequency by the current frontend step', () => {
-    vi.mocked(getRadioState).mockReturnValue({ active: 'MAIN' } as any);
-    vi.mocked(getActiveReceiver).mockReturnValue({ freqHz: 14_074_000 } as any);
-
     makeKeyboardHandlers().dispatch({ action: 'tune', params: { direction: 'up' }, id: 'tune-up', section: 'Tuning', sequence: ['ArrowRight'] });
 
-    expect(patchActiveReceiver).toHaveBeenCalledWith({ freqHz: 14_075_000 }, true);
     expect(sendCommand).toHaveBeenCalledWith('set_freq', { freq: 14_075_000, receiver: 0 });
+    expect(patchActiveReceiver).not.toHaveBeenCalled();
   });
 
   it('adjusts the frontend tuning step without sending a backend command', () => {

--- a/frontend/src/components-v2/wiring/command-bus.ts
+++ b/frontend/src/components-v2/wiring/command-bus.ts
@@ -11,9 +11,9 @@
 
 import { sendCommand } from '$lib/transport/ws-client';
 import { getActiveReceiver, getRadioState, patchActiveReceiver, patchRadioState } from '$lib/stores/radio.svelte';
-import { getCapabilities } from '$lib/stores/capabilities.svelte';
-import { adjustTuningStep, getTuningStep } from '$lib/stores/tuning.svelte';
+import { adjustTuningStep } from '$lib/stores/tuning.svelte';
 import { audioManager } from '$lib/audio/audio-manager';
+import { dispatchKeyboardRadioAction } from '$lib/runtime/commands/panel-commands';
 export {
   makeAgcHandlers,
   makeAudioRoutingHandlers,
@@ -37,12 +37,11 @@ import { clampRef, clampSpan } from '../../components/spectrum/spectrum-toolbar-
 
 /* ── Helpers ─────────────────────────────────────────────────── */
 
-/** Get the receiver param (0 = MAIN/active, 1 = SUB). */
-type Receiver = 0 | 1;
-
 function cmd(name: string, params: Record<string, unknown> = {}): void {
   sendCommand(name, params);
 }
+
+type Receiver = 0 | 1;
 
 function activeReceiverParam(): Receiver {
   return getRadioState()?.active === 'SUB' ? 1 : 0;
@@ -97,52 +96,13 @@ export function makeScopeControlsHandlers() {
   };
 }
 
-function cycleValue(values: number[], current: number): number {
-  if (values.length === 0) {
-    return current;
-  }
-  const idx = values.indexOf(current);
-  if (idx < 0 || idx === values.length - 1) {
-    return values[0];
-  }
-  return values[idx + 1];
-}
-
 export function makeKeyboardHandlers() {
   return {
     dispatch(action: KeyboardActionConfig): void {
+      if (dispatchKeyboardRadioAction(action)) return;
       switch (action.action) {
-        case 'tune': {
-          const rx = getActiveReceiver();
-          const baseFreq = rx?.freqHz ?? 0;
-          if (baseFreq <= 0) {
-            return;
-          }
-          const deltaHz = typeof action.params?.deltaHz === 'number'
-            ? action.params.deltaHz
-            : (action.params?.direction === 'down' ? -1 : 1) * getTuningStep();
-          const freq = baseFreq + deltaHz;
-          patchActiveReceiver({ freqHz: freq }, true);
-          cmd('set_freq', { freq, receiver: activeReceiverParam() });
-          return;
-        }
         case 'adjust_tuning_step': {
           adjustTuningStep(action.params?.direction === 'down' ? 'down' : 'up');
-          return;
-        }
-        case 'band_select': {
-          const index = Number(action.params?.index ?? 0);
-          if (index > 0) {
-            cmd('set_band', { band: index });
-          }
-          return;
-        }
-        case 'cycle_preamp': {
-          const values = getCapabilities()?.preValues ?? [0, 1];
-          const current = getActiveReceiver()?.preamp ?? values[0] ?? 0;
-          const level = cycleValue(values, current);
-          patchActiveReceiver({ preamp: level });
-          cmd('set_preamp', { level, receiver: activeReceiverParam() });
           return;
         }
         case 'toggle_split': {
@@ -151,85 +111,14 @@ export function makeKeyboardHandlers() {
           cmd('set_split', { on: next });
           return;
         }
-        case 'cycle_data_mode': {
-          const max = getCapabilities()?.dataModeCount ?? 0;
-          const current = getActiveReceiver()?.dataMode ?? 0;
-          const mode = current >= max ? 0 : current + 1;
-          patchActiveReceiver({ dataMode: mode }, true);
-          cmd('set_data_mode', { mode, receiver: activeReceiverParam() });
-          return;
-        }
         case 'open_filter_settings': {
           window.dispatchEvent(new CustomEvent('rigplane:open-filter-settings'));
-          return;
-        }
-        case 'mode_select': {
-          const mode = action.params?.mode;
-          if (typeof mode === 'string') {
-            patchActiveReceiver({ mode }, true);
-            cmd('set_mode', { mode, receiver: activeReceiverParam() });
-          }
-          return;
-        }
-        case 'cycle_filter': {
-          const current = getActiveReceiver()?.filter ?? 1;
-          const direction = action.params?.direction;
-          let next: number;
-          if (direction === 'wider') {
-            next = current <= 1 ? 3 : current - 1;
-          } else if (direction === 'narrower') {
-            next = current >= 3 ? 1 : current + 1;
-          } else {
-            next = current >= 3 ? 1 : current + 1;
-          }
-          patchActiveReceiver({ filter: next }, true);
-          cmd('set_filter', { filter: next, receiver: activeReceiverParam() });
-          return;
-        }
-        case 'toggle_nr': {
-          const on = !(getActiveReceiver()?.nr ?? false);
-          patchActiveReceiver({ nr: on }, true);
-          cmd('set_nr', { on, receiver: activeReceiverParam() });
-          return;
-        }
-        case 'toggle_nb': {
-          const on = !(getActiveReceiver()?.nb ?? false);
-          patchActiveReceiver({ nb: on }, true);
-          cmd('set_nb', { on, receiver: activeReceiverParam() });
-          return;
-        }
-        case 'cycle_agc': {
-          const modes = getCapabilities()?.agcModes ?? [1, 2, 3];
-          const current = getActiveReceiver()?.agc ?? modes[0] ?? 1;
-          const mode = cycleValue(modes, current);
-          patchActiveReceiver({ agc: mode }, true);
-          cmd('set_agc', { mode, receiver: activeReceiverParam() });
-          return;
-        }
-        case 'cycle_att': {
-          const values = getCapabilities()?.attValues ?? [0];
-          const current = getActiveReceiver()?.att ?? 0;
-          const db = cycleValue(values, current);
-          patchActiveReceiver({ att: db }, true);
-          cmd('set_attenuator', { db, receiver: activeReceiverParam() });
-          return;
-        }
-        case 'toggle_auto_notch': {
-          const on = !(getActiveReceiver()?.autoNotch ?? false);
-          patchActiveReceiver({ autoNotch: on }, true);
-          cmd('set_auto_notch', { on, receiver: activeReceiverParam() });
           return;
         }
         case 'toggle_monitor': {
           const on = !(getRadioState()?.monitorOn ?? false);
           patchRadioState({ monitorOn: on });
           cmd('set_monitor', { on });
-          return;
-        }
-        case 'toggle_ip_plus': {
-          const on = !(getActiveReceiver()?.ipplus ?? false);
-          patchActiveReceiver({ ipplus: on }, true);
-          cmd('set_ip_plus', { on, receiver: activeReceiverParam() });
           return;
         }
         case 'toggle_dial_lock': {

--- a/frontend/src/lib/runtime/commands/__tests__/keyboard-radio-delegation.isolated.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/keyboard-radio-delegation.isolated.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const root = resolve(import.meta.dirname, '../../../../..');
+const panelCommands = readFileSync(resolve(root, 'src/lib/runtime/commands/panel-commands.ts'), 'utf8');
+const commandBus = readFileSync(resolve(root, 'src/components-v2/wiring/command-bus.ts'), 'utf8');
+
+describe('MOR-1409 A03d1a keyboard radio delegation', () => {
+  it('requires the twelve-action canonical dispatcher boundary before deleting legacy bus ownership', () => {
+    expect(panelCommands).toContain('dispatchKeyboardRadioAction');
+    for (const action of [
+      'tune', 'band_select', 'mode_select', 'cycle_data_mode', 'cycle_filter',
+      'cycle_preamp', 'cycle_att', 'cycle_agc', 'toggle_nr', 'toggle_nb',
+      'toggle_auto_notch', 'toggle_ip_plus',
+    ]) {
+      expect(commandBus).not.toContain(`case '${action}'`);
+    }
+    expect(commandBus).not.toContain('function cycleValue');
+  });
+});

--- a/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.test.ts
@@ -77,6 +77,10 @@ vi.mock('$lib/audio/audio-manager', () => ({
   audioManager: { setAudioConfig: h.setAudioConfig },
 }));
 
+vi.mock('$lib/stores/tuning.svelte', () => ({
+  getTuningStep: vi.fn(() => 1_000),
+}));
+
 import {
   makeAgcHandlers,
   makeAntennaHandlers,
@@ -94,6 +98,7 @@ import {
   makeTxHandlers,
   makeVfoHandlers,
   makeVoxHandlers,
+  dispatchKeyboardRadioAction,
 } from '../panel-commands';
 import * as compatibilityBus from '$lib/../components-v2/wiring/command-bus';
 import { getCommandLifecycles, resetCommandLifecycle } from '$lib/stores/commands.svelte';
@@ -214,12 +219,19 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
         'tx', 'tuner', 'vox', 'compressor', 'monitor', 'drive_gain',
         'cw', 'break_in', 'apf', 'twin_peak', 'rx_antenna',
         'split', 'dual_rx', 'dual_watch', 'main_sub_tracking',
+        'bsr', 'preamp', 'attenuator', 'ip_plus',
       ],
       stateContractVersion: 1,
       providerGeneration: 31,
       receivers: 2,
       antennas: 2,
       vfoScheme: 'main_sub',
+      modes: ['USB', 'CW'],
+      filters: ['FIL1', 'FIL2', 'FIL3'],
+      dataModeCount: 3,
+      preValues: [0, 1, 2],
+      attValues: [0, 6, 12],
+      agcModes: [1, 2, 3],
       controls: {
         pbt_inner: { raw_min: 0, raw_max: 255, raw_center: 128, display_min: -1200, display_max: 1200 },
         nb_depth: { raw_min: 0, raw_max: 9, raw_center: 0, display_min: 1, display_max: 10 },
@@ -984,6 +996,82 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
     expect(h.sendCommand).not.toHaveBeenCalled();
     expect(h.setAudioConfig).not.toHaveBeenCalled();
     expect(getCommandLifecycles()).toHaveLength(0);
+  });
+
+  it('delegates exactly the A03d1a keyboard radio families through typed non-optimistic intent', () => {
+    const actions = [
+      { action: 'tune', params: { direction: 'up' } },
+      { action: 'band_select', params: { index: 3 } },
+      { action: 'mode_select', params: { mode: 'CW' } },
+      { action: 'cycle_data_mode' },
+      { action: 'cycle_filter', params: { direction: 'narrower' } },
+      { action: 'cycle_preamp' }, { action: 'cycle_att' }, { action: 'cycle_agc' },
+      { action: 'toggle_nr' }, { action: 'toggle_nb' },
+      { action: 'toggle_auto_notch' }, { action: 'toggle_ip_plus' },
+    ];
+
+    for (const action of actions) expect(dispatchKeyboardRadioAction(action)).toBe(true);
+
+    expect(exactCalls()).toEqual([
+      ['set_freq', { freq: 14_075_000, receiver: 0 }],
+      ['set_band', { band: 3 }],
+      ['set_mode', { mode: 'CW', receiver: 0 }],
+      ['set_data_mode', { mode: 2, receiver: 0 }],
+      ['set_filter', { filter: 3, receiver: 0 }],
+      ['set_preamp', { level: 1, receiver: 0 }],
+      ['set_attenuator', { db: 6, receiver: 0 }],
+      ['set_agc', { mode: 3, receiver: 0 }],
+      ['set_nr', { on: true, receiver: 0 }],
+      ['set_nb', { on: true, receiver: 0 }],
+      ['set_auto_notch', { on: true, receiver: 0 }],
+      ['set_ip_plus', { on: true, receiver: 0 }],
+    ]);
+    expectIntentTransport();
+    expect(h.patchActiveReceiver).not.toHaveBeenCalled();
+    expect(h.patchRadioState).not.toHaveBeenCalled();
+  });
+
+  it('fails closed for invalid keyboard input while leaving deferred and local actions to their current owner', () => {
+    h.unavailable.add('main.freqHz');
+    expect(dispatchKeyboardRadioAction({ action: 'tune', params: { direction: 'up' } })).toBe(true);
+    h.unavailable.clear();
+    h.caps = { ...h.caps!, providerGeneration: 99 };
+    expect(dispatchKeyboardRadioAction({ action: 'cycle_preamp' })).toBe(true);
+    h.caps = { ...h.caps!, providerGeneration: 31, receivers: 1, vfoScheme: 'ab' };
+    h.state = { ...oneReceiverAbState(), active: 'SUB' } as ServerState;
+    expect(dispatchKeyboardRadioAction({ action: 'toggle_nr' })).toBe(true);
+    h.state = oneReceiverAbState();
+    (h.state.main as any).preamp = 99;
+    expect(dispatchKeyboardRadioAction({ action: 'cycle_preamp' })).toBe(true);
+    expect(dispatchKeyboardRadioAction({ action: 'cycle_filter', params: { direction: 'sideways' } })).toBe(true);
+    expect(dispatchKeyboardRadioAction({ action: 'toggle_rit' })).toBe(false);
+    expect(dispatchKeyboardRadioAction({ action: 'scope_toggle_hold' })).toBe(false);
+    expect(dispatchKeyboardRadioAction({ action: 'open_filter_settings' })).toBe(false);
+    expect(dispatchKeyboardRadioAction({ action: 'ptt_on' })).toBe(false);
+    expect(h.sendCommand).not.toHaveBeenCalled();
+    expect(h.patchActiveReceiver).not.toHaveBeenCalled();
+    expect(h.patchRadioState).not.toHaveBeenCalled();
+    expect(getCommandLifecycles()).toHaveLength(0);
+  });
+
+  it('keeps a one-receiver MAIN with A/B and Unselected facts valid for keyboard tuning', () => {
+    h.state = oneReceiverAbState();
+    h.caps = { ...h.caps!, receivers: 1, vfoScheme: 'ab' };
+
+    expect(dispatchKeyboardRadioAction({ action: 'tune', params: { deltaHz: 500 } })).toBe(true);
+
+    expect(exactCalls()).toEqual([['set_freq', { freq: 14_074_500, receiver: 0 }]]);
+    expectIntentTransport();
+  });
+
+  it('turns auto-notch off without changing the independently observed manual-notch state', () => {
+    (h.state!.main as any).autoNotch = true;
+    (h.state!.main as any).manualNotch = true;
+
+    expect(dispatchKeyboardRadioAction({ action: 'toggle_auto_notch' })).toBe(true);
+
+    expect(exactCalls()).toEqual([['set_auto_notch', { on: false, receiver: 0 }]]);
+    expectIntentTransport();
   });
 
   it('keeps raw transport out of migrated blocks and Store writers out of their implementation', () => {

--- a/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.test.ts
@@ -1073,6 +1073,43 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
     expect(getCommandLifecycles()).toHaveLength(0);
   });
 
+  it('handles hostile keyboard params without reading accessors or reflecting deferred actions', () => {
+    const getter = vi.fn(() => { throw new Error('getter executed'); });
+    const accessor = Object.defineProperty({}, 'direction', { enumerable: true, get: getter });
+    const prototypeTrap = new Proxy({}, { getPrototypeOf: () => { throw new Error('prototype trap executed'); } });
+    const ownKeysTrap = new Proxy({}, { ownKeys: () => { throw new Error('ownKeys trap executed'); } });
+    const descriptorTrap = new Proxy({}, {
+      ownKeys: () => ['direction'],
+      getOwnPropertyDescriptor: () => { throw new Error('descriptor trap executed'); },
+    });
+    const dataGet = vi.fn(() => { throw new Error('data get trap executed'); });
+    const dataProxy = new Proxy({ direction: 'up' }, { get: dataGet });
+    const invalid = [null, [], 1, 'up', accessor, prototypeTrap, ownKeysTrap, descriptorTrap];
+
+    for (const params of invalid) {
+      expect(() => dispatchKeyboardRadioAction({ action: 'tune', params: params as Record<string, unknown> })).not.toThrow();
+      expect(dispatchKeyboardRadioAction({ action: 'tune', params: params as Record<string, unknown> })).toBe(true);
+    }
+    expect(getter).not.toHaveBeenCalled();
+    expect(dispatchKeyboardRadioAction({ action: 'toggle_rit', params: prototypeTrap as Record<string, unknown> })).toBe(false);
+    expect(h.sendCommand).not.toHaveBeenCalled();
+    expect(h.patchActiveReceiver).not.toHaveBeenCalled();
+    expect(h.patchRadioState).not.toHaveBeenCalled();
+    expect(getCommandLifecycles()).toHaveLength(0);
+
+    const nullPrototype = Object.assign(Object.create(null) as Record<string, unknown>, { direction: 'up' });
+    expect(dispatchKeyboardRadioAction({ action: 'tune', params: { direction: 'up' } })).toBe(true);
+    expect(dispatchKeyboardRadioAction({ action: 'tune', params: nullPrototype })).toBe(true);
+    expect(dispatchKeyboardRadioAction({ action: 'tune', params: dataProxy })).toBe(true);
+    expect(dataGet).not.toHaveBeenCalled();
+    expect(exactCalls()).toEqual([
+      ['set_freq', { freq: 14_075_000, receiver: 0 }],
+      ['set_freq', { freq: 14_075_000, receiver: 0 }],
+      ['set_freq', { freq: 14_075_000, receiver: 0 }],
+    ]);
+    expectIntentTransport();
+  });
+
   it('keeps a one-receiver MAIN with A/B and Unselected facts valid for keyboard tuning', () => {
     h.state = oneReceiverAbState();
     h.caps = { ...h.caps!, receivers: 1, vfoScheme: 'ab' };

--- a/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.test.ts
@@ -1054,6 +1054,25 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
     expect(getCommandLifecycles()).toHaveLength(0);
   });
 
+  it('handles null params and non-positive observed tuning frequencies without emitting', () => {
+    expect(() => dispatchKeyboardRadioAction({ action: 'tune', params: null as unknown as Record<string, unknown> })).not.toThrow();
+    expect(dispatchKeyboardRadioAction({ action: 'tune', params: null as unknown as Record<string, unknown> })).toBe(true);
+    expect(dispatchKeyboardRadioAction({ action: 'toggle_nr', params: null as unknown as Record<string, unknown> })).toBe(true);
+    expect(h.sendCommand).not.toHaveBeenCalled();
+    expect(getCommandLifecycles()).toHaveLength(0);
+
+    for (const frequency of [0, -500]) {
+      (h.state!.main as any).freqHz = frequency;
+      expect(dispatchKeyboardRadioAction({ action: 'tune', params: { deltaHz: 1_000 } })).toBe(true);
+      expect(dispatchKeyboardRadioAction({ action: 'band_select', params: { index: 3 } })).toBe(true);
+    }
+
+    expect(h.sendCommand).not.toHaveBeenCalled();
+    expect(h.patchActiveReceiver).not.toHaveBeenCalled();
+    expect(h.patchRadioState).not.toHaveBeenCalled();
+    expect(getCommandLifecycles()).toHaveLength(0);
+  });
+
   it('keeps a one-receiver MAIN with A/B and Unselected facts valid for keyboard tuning', () => {
     h.state = oneReceiverAbState();
     h.caps = { ...h.caps!, receivers: 1, vfoScheme: 'ab' };

--- a/frontend/src/lib/runtime/commands/panel-commands.ts
+++ b/frontend/src/lib/runtime/commands/panel-commands.ts
@@ -1016,9 +1016,17 @@ function keyboardDirection(value: unknown): 'up' | 'down' | null {
   return value === 'up' || value === 'down' ? value : null;
 }
 
+function keyboardParams(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return null;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null ? value as Record<string, unknown> : null;
+}
+
 /** Handles only the A03d1a radio family; invalid recognized actions fail closed. */
-export function dispatchKeyboardRadioAction({ action, params = {} }: KeyboardRadioAction): boolean {
+export function dispatchKeyboardRadioAction({ action, params }: KeyboardRadioAction): boolean {
   if (!KEYBOARD_RADIO_ACTIONS.has(action)) return false;
+  const safeParams = params === undefined ? {} : keyboardParams(params);
+  if (safeParams === null) return true;
   const context = currentKeyboardContext();
   if (!context) return true;
   const receiver = context.receiver;
@@ -1028,25 +1036,27 @@ export function dispatchKeyboardRadioAction({ action, params = {} }: KeyboardRad
   switch (action) {
     case 'tune': {
       const step = getTuningStep();
-      const direction = keyboardDirection(params.direction);
-      const delta = Number.isSafeInteger(params.deltaHz) ? params.deltaHz
+      const direction = keyboardDirection(safeParams.direction);
+      const delta = Number.isSafeInteger(safeParams.deltaHz) ? safeParams.deltaHz
         : direction && Number.isSafeInteger(step) && step > 0 ? (direction === 'down' ? -step : step) : null;
       const frequency = rx?.freqHz;
       const target = typeof delta === 'number' && Number.isSafeInteger(frequency) ? frequency + delta : null;
       if (keyboardReceiverField(context, 'freqHz') && Number.isSafeInteger(step) && step > 0
+        && typeof frequency === 'number' && Number.isSafeInteger(frequency) && frequency > 0
         && typeof target === 'number' && Number.isSafeInteger(target) && target > 0) makeVfoHandlers().onFreqChange(target, receiver);
       return true;
     }
     case 'band_select': {
-      const bsr = params.index;
+      const bsr = safeParams.index;
       const frequency = rx?.freqHz;
       if (has('bsr') && keyboardReceiverField(context, 'freqHz') && typeof bsr === 'number'
-        && Number.isSafeInteger(bsr) && bsr > 0 && Number.isSafeInteger(frequency)) makeBandHandlers().onBandSelect('', frequency, bsr);
+        && Number.isSafeInteger(bsr) && bsr > 0 && typeof frequency === 'number'
+        && Number.isSafeInteger(frequency) && frequency > 0) makeBandHandlers().onBandSelect('', frequency, bsr);
       return true;
     }
     case 'mode_select':
-      if (keyboardReceiverField(context, 'mode') && typeof params.mode === 'string' && params.mode.length > 0
-        && context.caps.modes.includes(params.mode)) makeModeHandlers().onModeChange(params.mode);
+      if (keyboardReceiverField(context, 'mode') && typeof safeParams.mode === 'string' && safeParams.mode.length > 0
+        && context.caps.modes.includes(safeParams.mode)) makeModeHandlers().onModeChange(safeParams.mode);
       return true;
     case 'cycle_data_mode': {
       const count = context.caps.dataModeCount;
@@ -1057,8 +1067,8 @@ export function dispatchKeyboardRadioAction({ action, params = {} }: KeyboardRad
       return true;
     }
     case 'cycle_filter': {
-      const delta = params.step === -1 || params.step === 1 ? params.step
-        : params.direction === 'wider' ? -1 : params.direction === 'narrower' ? 1 : null;
+      const delta = safeParams.step === -1 || safeParams.step === 1 ? safeParams.step
+        : safeParams.direction === 'wider' ? -1 : safeParams.direction === 'narrower' ? 1 : null;
       const count = context.caps.filters.length;
       const filter = rx?.filter;
       if (keyboardReceiverField(context, 'filter') && typeof filter === 'number' && Number.isSafeInteger(filter)

--- a/frontend/src/lib/runtime/commands/panel-commands.ts
+++ b/frontend/src/lib/runtime/commands/panel-commands.ts
@@ -1017,9 +1017,26 @@ function keyboardDirection(value: unknown): 'up' | 'down' | null {
 }
 
 function keyboardParams(value: unknown): Record<string, unknown> | null {
-  if (value === null || typeof value !== 'object' || Array.isArray(value)) return null;
-  const prototype = Object.getPrototypeOf(value);
-  return prototype === Object.prototype || prototype === null ? value as Record<string, unknown> : null;
+  if (value === null || typeof value !== 'object') return null;
+  try {
+    if (Array.isArray(value)) return null;
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) return null;
+    const params: Record<PropertyKey, unknown> = Object.create(null);
+    for (const key of Reflect.ownKeys(value)) {
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if (!descriptor || !('value' in descriptor)) return null;
+      Object.defineProperty(params, key, {
+        value: descriptor.value,
+        enumerable: descriptor.enumerable,
+        configurable: true,
+        writable: true,
+      });
+    }
+    return params;
+  } catch {
+    return null;
+  }
 }
 
 /** Handles only the A03d1a radio family; invalid recognized actions fail closed. */

--- a/frontend/src/lib/runtime/commands/panel-commands.ts
+++ b/frontend/src/lib/runtime/commands/panel-commands.ts
@@ -30,6 +30,7 @@ import { getModeFilter } from '$lib/radio/mode-filter-memory';
 import { modInputCommand, modInputStateKey } from '$lib/radio/mod-input';
 import { nbDepthDisplayToRaw, nrDisplayToRaw } from '$lib/radio/filter-controls';
 import { audioManager } from '$lib/audio/audio-manager';
+import { getTuningStep } from '$lib/stores/tuning.svelte';
 import { dispatchRadioIntent, isNormalizedLevel, type RadioIntent } from './radio-intents';
 
 /* ── Shared helpers ──────────────────────────────────────────────── */
@@ -553,6 +554,12 @@ export function makeDspHandlers() {
         dispatchRadioIntent({ name: 'set_manual_notch', params: { on: false, receiver } });
       }
     },
+    onAutoNotchToggle: () => {
+      const receiver = knownReceiverField('autoNotch');
+      const current = receiver === 0 ? getRadioState()?.main?.autoNotch : getRadioState()?.sub?.autoNotch;
+      if (!hasCapability('notch') || receiver === null || typeof current !== 'boolean') return;
+      dispatchRadioIntent({ name: 'set_auto_notch', params: { on: !current, receiver } });
+    },
     onNotchFreqChange: (value: number) => {
       const receiver = knownActiveReceiver();
       if (!hasCapability('notch') || receiver === null || !knownTopLevelField('notchFilter')
@@ -970,6 +977,126 @@ export function makeVfoHandlers() {
       dispatchRadioIntent({ name: 'set_main_sub_tracking', params: { on } });
     },
   };
+}
+
+/* ── Keyboard radio delegation (MOR-1409 A03d1a) ─────────────────── */
+
+type KeyboardRadioAction = { action: string; params?: Record<string, unknown> };
+type KeyboardContext = NonNullable<ReturnType<typeof currentA03cContext>> & { receiver: Receiver };
+
+const KEYBOARD_RADIO_ACTIONS = new Set([
+  'tune', 'band_select', 'mode_select', 'cycle_data_mode', 'cycle_filter',
+  'cycle_preamp', 'cycle_att', 'cycle_agc', 'toggle_nr', 'toggle_nb',
+  'toggle_auto_notch', 'toggle_ip_plus',
+]);
+
+function currentKeyboardContext(): KeyboardContext | null {
+  const context = currentA03cContext();
+  const active = context?.state.active;
+  if (!context || !knownA03cTopLevelField(context, 'active') || (active !== 'MAIN' && active !== 'SUB')) return null;
+  const receiver = knownA03cReceiver(context, active);
+  return receiver === null ? null : { ...context, receiver };
+}
+
+function keyboardReceiverField(context: KeyboardContext, field: string): boolean {
+  const receiver = context.receiver === 0 ? context.state.main : context.state.sub;
+  const value = receiver?.[field as never];
+  return value !== undefined && value !== null
+    && isFieldAvailable(context.state, `${context.receiver === 0 ? 'main' : 'sub'}.${field}`);
+}
+
+function keyboardCycle(values: unknown, current: unknown): number | null {
+  if (!Array.isArray(values) || values.length === 0 || !Number.isSafeInteger(current)
+    || !values.every(Number.isSafeInteger)) return null;
+  const index = values.indexOf(current);
+  return index < 0 ? null : values[(index + 1) % values.length] as number;
+}
+
+function keyboardDirection(value: unknown): 'up' | 'down' | null {
+  return value === 'up' || value === 'down' ? value : null;
+}
+
+/** Handles only the A03d1a radio family; invalid recognized actions fail closed. */
+export function dispatchKeyboardRadioAction({ action, params = {} }: KeyboardRadioAction): boolean {
+  if (!KEYBOARD_RADIO_ACTIONS.has(action)) return false;
+  const context = currentKeyboardContext();
+  if (!context) return true;
+  const receiver = context.receiver;
+  const rx = receiver === 0 ? context.state.main : context.state.sub;
+  const has = (name: string) => context.caps.capabilities.includes(name);
+
+  switch (action) {
+    case 'tune': {
+      const step = getTuningStep();
+      const direction = keyboardDirection(params.direction);
+      const delta = Number.isSafeInteger(params.deltaHz) ? params.deltaHz
+        : direction && Number.isSafeInteger(step) && step > 0 ? (direction === 'down' ? -step : step) : null;
+      const frequency = rx?.freqHz;
+      const target = typeof delta === 'number' && Number.isSafeInteger(frequency) ? frequency + delta : null;
+      if (keyboardReceiverField(context, 'freqHz') && Number.isSafeInteger(step) && step > 0
+        && typeof target === 'number' && Number.isSafeInteger(target) && target > 0) makeVfoHandlers().onFreqChange(target, receiver);
+      return true;
+    }
+    case 'band_select': {
+      const bsr = params.index;
+      const frequency = rx?.freqHz;
+      if (has('bsr') && keyboardReceiverField(context, 'freqHz') && typeof bsr === 'number'
+        && Number.isSafeInteger(bsr) && bsr > 0 && Number.isSafeInteger(frequency)) makeBandHandlers().onBandSelect('', frequency, bsr);
+      return true;
+    }
+    case 'mode_select':
+      if (keyboardReceiverField(context, 'mode') && typeof params.mode === 'string' && params.mode.length > 0
+        && context.caps.modes.includes(params.mode)) makeModeHandlers().onModeChange(params.mode);
+      return true;
+    case 'cycle_data_mode': {
+      const count = context.caps.dataModeCount;
+      if (keyboardReceiverField(context, 'dataMode') && typeof count === 'number' && Number.isSafeInteger(count) && count > 0
+        && Number.isSafeInteger(rx?.dataMode) && rx.dataMode >= 0 && rx.dataMode < count) {
+        makeModeHandlers().onDataModeChange((rx.dataMode + 1) % count);
+      }
+      return true;
+    }
+    case 'cycle_filter': {
+      const delta = params.step === -1 || params.step === 1 ? params.step
+        : params.direction === 'wider' ? -1 : params.direction === 'narrower' ? 1 : null;
+      const count = context.caps.filters.length;
+      const filter = rx?.filter;
+      if (keyboardReceiverField(context, 'filter') && typeof filter === 'number' && Number.isSafeInteger(filter)
+        && filter >= 1 && filter <= count && count > 0 && delta !== null) {
+        makeFilterHandlers().onFilterChange(((filter - 1 + delta + count) % count) + 1);
+      }
+      return true;
+    }
+    case 'cycle_preamp': {
+      const next = keyboardCycle(context.caps.preValues, rx?.preamp);
+      if (has('preamp') && keyboardReceiverField(context, 'preamp') && next !== null) makeRfFrontEndHandlers().onPreChange(next);
+      return true;
+    }
+    case 'cycle_att': {
+      const next = keyboardCycle(context.caps.attValues, rx?.att);
+      if (has('attenuator') && keyboardReceiverField(context, 'att') && next !== null) makeRfFrontEndHandlers().onAttChange(next);
+      return true;
+    }
+    case 'cycle_agc': {
+      const next = keyboardCycle(context.caps.agcModes, rx?.agc);
+      if (has('agc') && keyboardReceiverField(context, 'agc') && next !== null) makeAgcHandlers().onAgcModeChange(next);
+      return true;
+    }
+    case 'toggle_nr':
+      if (has('nr') && keyboardReceiverField(context, 'nr') && typeof rx?.nr === 'boolean') makeDspHandlers().onNrModeChange(rx.nr ? 0 : 1);
+      return true;
+    case 'toggle_nb':
+      if (has('nb') && keyboardReceiverField(context, 'nb') && typeof rx?.nb === 'boolean') makeDspHandlers().onNbToggle(!rx.nb);
+      return true;
+    case 'toggle_auto_notch':
+      if (has('notch') && keyboardReceiverField(context, 'autoNotch') && typeof rx?.autoNotch === 'boolean') makeDspHandlers().onAutoNotchToggle();
+      return true;
+    case 'toggle_ip_plus':
+      if (has('ip_plus') && keyboardReceiverField(context, 'ipplus') && typeof rx?.ipplus === 'boolean') makeRfFrontEndHandlers().onIpPlusToggle(!rx.ipplus);
+      return true;
+    default:
+      return true;
+  }
 }
 
 /* ── VOX Handlers ────────────────────────────────────────────────── */


### PR DESCRIPTION
Part of #2317

Implements A03d1a only, per the [421-line hard-stop correction](https://github.com/rigplane/rigplane-core/issues/2317#issuecomment-5232389953).

- Exact base: `94b36b25c401eaad9534c547ac33845842dd030a`
- Exact head: `98319e3992ffd6d8a521481ff8d4c0fbc4b291ca`
- Production owners: `panel-commands.ts`, `command-bus.ts`; numstat `+159/-116` (275 churn).
- Dispatcher recognizes only the 12 A03d1a keyboard radio actions; deferred/local actions retain their existing bus owners.
- First repair: malformed/non-record `params` fail closed while recognized; tune and band delegation require a safe positive observed current frequency.
- Second repair: recognized params are exception-safely materialized from own data properties only; accessors and reflection-trapping Proxy inputs fail closed without effects.
- Excluded production blobs, including `radio-intents.ts`, `state.ts`, `state-adapter.ts`, and `panel-props.ts`, remain byte-identical.
- RED committed before production; focused/frozen/full frontend and non-hardware backend gates, static/generated/consumer gates, and restored causal mutations passed.

No merge or auto-merge requested.