### PR TITLE
refactor(#2317): delegate keyboard audio vfo actions

### DIFF
--- a/frontend/src/components-v2/wiring/__tests__/keyboard-wiring.isolated.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/keyboard-wiring.isolated.test.ts
@@ -17,7 +17,7 @@ vi.mock('$lib/stores/radio.svelte', () => ({
 
 vi.mock('$lib/stores/capabilities.svelte', () => ({
   getCapabilities: vi.fn(() => ({
-    capabilities: ['bsr', 'preamp', 'attenuator', 'agc', 'nr', 'nb', 'notch', 'ip_plus'],
+    capabilities: ['bsr', 'preamp', 'attenuator', 'agc', 'nr', 'nb', 'notch', 'ip_plus', 'split', 'dual_rx'],
     stateContractVersion: 1,
     providerGeneration: 31,
     receivers: 2,
@@ -87,6 +87,10 @@ describe('makeKeyboardHandlers', () => {
         freqHz: 14_074_000, preamp: 1, dataMode: 2, mode: 'USB', filter: 2,
         att: 0, agc: 2, nr: false, nb: false, autoNotch: false, ipplus: false,
       },
+      sub: {
+        freqHz: 7_074_000, preamp: 1, dataMode: 2, mode: 'USB', filter: 2,
+        att: 0, agc: 2, nr: false, nb: false, autoNotch: false, ipplus: false,
+      },
     } as any);
   });
 
@@ -103,11 +107,14 @@ describe('makeKeyboardHandlers', () => {
   });
 
   it('toggles split using radio state', () => {
-    vi.mocked(getRadioState).mockReturnValue({ split: false } as any);
+    vi.mocked(getRadioState).mockReturnValue({
+      active: 'MAIN', providerGeneration: 31, split: false,
+      main: { freqHz: 14_074_000 }, sub: { freqHz: 7_074_000 },
+    } as any);
 
     makeKeyboardHandlers().dispatch(makeAction('toggle_split'));
 
-    expect(patchRadioState).toHaveBeenCalledWith({ split: true });
+    expect(patchRadioState).not.toHaveBeenCalled();
     expect(sendCommand).toHaveBeenCalledWith('set_split', { on: true });
   });
 
@@ -150,7 +157,7 @@ describe('makeKeyboardHandlers', () => {
 
     makeKeyboardHandlers().dispatch(makeAction('set_active_vfo', { vfo: 'SUB' }));
 
-    expect(patchRadioState).toHaveBeenCalledWith({ active: 'SUB' });
+    expect(patchRadioState).not.toHaveBeenCalled();
     expect(sendCommand).toHaveBeenCalledWith('set_vfo', { vfo: 'SUB' });
     expect(audioManager.setAudioConfig).toHaveBeenCalledWith({ focus: 'sub' });
 

--- a/frontend/src/components-v2/wiring/command-bus.ts
+++ b/frontend/src/components-v2/wiring/command-bus.ts
@@ -10,9 +10,8 @@
  */
 
 import { sendCommand } from '$lib/transport/ws-client';
-import { getActiveReceiver, getRadioState, patchActiveReceiver, patchRadioState } from '$lib/stores/radio.svelte';
+import { getRadioState, patchRadioState } from '$lib/stores/radio.svelte';
 import { adjustTuningStep } from '$lib/stores/tuning.svelte';
-import { audioManager } from '$lib/audio/audio-manager';
 import { dispatchKeyboardRadioAction } from '$lib/runtime/commands/panel-commands';
 export {
   makeAgcHandlers,
@@ -39,28 +38,6 @@ import { clampRef, clampSpan } from '../../components/spectrum/spectrum-toolbar-
 
 function cmd(name: string, params: Record<string, unknown> = {}): void {
   sendCommand(name, params);
-}
-
-type Receiver = 0 | 1;
-
-function activeReceiverParam(): Receiver {
-  return getRadioState()?.active === 'SUB' ? 1 : 0;
-}
-
-/* ── VFO Handlers ────────────────────────────────────────────── */
-
-/** Temporary keyboard-only activation path; A03d delegates and removes it. */
-function _activateReceiver(target: 'MAIN' | 'SUB'): void {
-  // Optimistic UI + WS command to select the receiver.
-  patchRadioState({ active: target });
-  cmd('set_vfo', { vfo: target });
-  // Couple audio focus to the selected receiver so operator hears the
-  // band they're now tuning.  In Dual-Watch mode the radio broadcasts
-  // both receivers' audio, and the web layer decides which channel to
-  // render via the Phones L/R Mix (#752/#755).  Without this coupling,
-  // clicking MAIN/SUB updated state + scope but left the audio focus
-  // untouched, so the user heard MAIN while tuning SUB.
-  audioManager.setAudioConfig({ focus: target === 'SUB' ? 'sub' : 'main' });
 }
 
 /* ── System Handlers ─────────────────────────────────────────── */
@@ -105,87 +82,14 @@ export function makeKeyboardHandlers() {
           adjustTuningStep(action.params?.direction === 'down' ? 'down' : 'up');
           return;
         }
-        case 'toggle_split': {
-          const next = !(getRadioState()?.split ?? false);
-          patchRadioState({ split: next });
-          cmd('set_split', { on: next });
-          return;
-        }
         case 'open_filter_settings': {
           window.dispatchEvent(new CustomEvent('rigplane:open-filter-settings'));
-          return;
-        }
-        case 'toggle_monitor': {
-          const on = !(getRadioState()?.monitorOn ?? false);
-          patchRadioState({ monitorOn: on });
-          cmd('set_monitor', { on });
           return;
         }
         case 'toggle_dial_lock': {
           const on = !(getRadioState()?.dialLock ?? false);
           patchRadioState({ dialLock: on });
           cmd('set_dial_lock', { on });
-          return;
-        }
-        case 'toggle_rit': {
-          const on = !(getRadioState()?.ritOn ?? false);
-          patchRadioState({ ritOn: on });
-          cmd('set_rit_status', { on });
-          return;
-        }
-        case 'toggle_xit': {
-          const on = !(getRadioState()?.ritTx ?? false);
-          patchRadioState({ ritTx: on });
-          cmd('set_rit_tx_status', { on });
-          return;
-        }
-        case 'clear_rit_xit': {
-          patchRadioState({ ritFreq: 0 });
-          cmd('set_rit_frequency', { freq: 0 });
-          return;
-        }
-        case 'adjust_af_level': {
-          const current = getActiveReceiver()?.afLevel ?? 0.5;
-          const delta = (action.params?.direction === 'down' ? -0.05 : 0.05);
-          const level = Math.max(0, Math.min(1, current + delta));
-          patchActiveReceiver({ afLevel: level }, true);
-          cmd('set_af_level', { level, receiver: activeReceiverParam() });
-          return;
-        }
-        case 'adjust_rf_gain': {
-          const current = getActiveReceiver()?.rfGain ?? 1;
-          const delta = (action.params?.direction === 'down' ? -0.05 : 0.05);
-          const level = Math.max(0, Math.min(1, current + delta));
-          patchActiveReceiver({ rfGain: level }, true);
-          cmd('set_rf_gain', { level, receiver: activeReceiverParam() });
-          return;
-        }
-        case 'vfo_swap': {
-          cmd('vfo_swap', {});
-          return;
-        }
-        case 'vfo_equalize': {
-          cmd('vfo_equalize', {});
-          return;
-        }
-        case 'switch_active_vfo': {
-          const state = getRadioState();
-          const next = state?.active === 'SUB' ? 'MAIN' : 'SUB';
-          patchRadioState({ active: next });
-          cmd('set_vfo', { vfo: next });
-          return;
-        }
-        case 'set_active_vfo': {
-          const target = action.params?.vfo;
-          if (target !== 'MAIN' && target !== 'SUB') {
-            return;
-          }
-          // Route through the same helper the VFO-click path uses so the
-          // audio focus follows the active receiver (#827 follow-up): a
-          // `m`/Shift+M/Shift+S keypress must behave identically to
-          // clicking MAIN/SUB, otherwise the operator tunes one side but
-          // keeps hearing the other in Dual-Watch / browser-audio flows.
-          _activateReceiver(target);
           return;
         }
         case 'focus_target': {

--- a/frontend/src/lib/runtime/commands/__tests__/keyboard-radio-delegation.isolated.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/keyboard-radio-delegation.isolated.test.ts
@@ -6,16 +6,23 @@ const root = resolve(import.meta.dirname, '../../../../..');
 const panelCommands = readFileSync(resolve(root, 'src/lib/runtime/commands/panel-commands.ts'), 'utf8');
 const commandBus = readFileSync(resolve(root, 'src/components-v2/wiring/command-bus.ts'), 'utf8');
 
-describe('MOR-1409 A03d1a keyboard radio delegation', () => {
-  it('requires the twelve-action canonical dispatcher boundary before deleting legacy bus ownership', () => {
+describe('MOR-1409 A03d1 keyboard radio delegation', () => {
+  it('requires the complete twenty-three-action canonical dispatcher boundary before deleting legacy bus ownership', () => {
     expect(panelCommands).toContain('dispatchKeyboardRadioAction');
     for (const action of [
       'tune', 'band_select', 'mode_select', 'cycle_data_mode', 'cycle_filter',
       'cycle_preamp', 'cycle_att', 'cycle_agc', 'toggle_nr', 'toggle_nb',
       'toggle_auto_notch', 'toggle_ip_plus',
+      'toggle_rit', 'toggle_xit', 'clear_rit_xit',
+      'adjust_af_level', 'adjust_rf_gain', 'toggle_monitor',
+      'toggle_split', 'vfo_swap', 'vfo_equalize', 'switch_active_vfo', 'set_active_vfo',
     ]) {
       expect(commandBus).not.toContain(`case '${action}'`);
     }
     expect(commandBus).not.toContain('function cycleValue');
+    expect(commandBus).not.toContain('activeReceiverParam');
+    expect(commandBus).not.toContain('function _activateReceiver');
+    expect(commandBus).not.toContain("case 'toggle_rit'");
+    expect(commandBus).not.toContain("case 'set_active_vfo'");
   });
 });

--- a/frontend/src/lib/runtime/commands/__tests__/local-audio-meter-authority.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/local-audio-meter-authority.test.ts
@@ -78,9 +78,9 @@ describe('MOR-1409 A03c2 local audio and meter authority', () => {
       expect(busSource).toContain(`export function ${deferred}`);
       expect(panelSource).not.toContain(`export function ${deferred}`);
     }
-    expect(busSource).toContain('function _activateReceiver');
-    expect(busSource).toContain("case 'set_active_vfo'");
-    expect(panelPropsSource).toContain('meterSource');
+    expect(busSource).not.toContain('function _activateReceiver');
+    expect(busSource).not.toContain("case 'set_active_vfo'");
+    expect(panelPropsSource).not.toContain('meterSource');
     expect(stateAdapterSource).toContain('meterSource');
   });
 });

--- a/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.test.ts
@@ -1032,6 +1032,7 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
   });
 
   it('delegates the complete A03d1b RIT, audio, monitor, and VFO keyboard families through typed intents', () => {
+    (h.state!.main as { rfGain: number }).rfGain = 128 / 255;
     const actions = [
       { action: 'toggle_rit' }, { action: 'toggle_xit' }, { action: 'clear_rit_xit' },
       { action: 'adjust_af_level', params: { direction: 'up' } },
@@ -1060,6 +1061,67 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
     expect(h.setAudioConfig).toHaveBeenNthCalledWith(2, { focus: 'main' });
   });
 
+  it('clamps only known normalized keyboard AF/RF readings and keeps active runtime AF local', () => {
+    (h.state!.main as { afLevel: number; rfGain: number }).afLevel = 0.98;
+    (h.state!.main as { afLevel: number; rfGain: number }).rfGain = 0.02;
+    expect(dispatchKeyboardRadioAction({ action: 'adjust_af_level', params: { direction: 'up' } })).toBe(true);
+    expect(dispatchKeyboardRadioAction({ action: 'adjust_rf_gain', params: { direction: 'down' } })).toBe(true);
+    expect(exactCalls()).toEqual([
+      ['set_af_level', { level: 1, receiver: 0 }],
+      ['set_rf_gain', { level: 0, receiver: 0 }],
+    ]);
+    expectIntentTransport();
+
+    h.sendCommand.mockClear();
+    resetCommandLifecycle();
+    h.rxEnabled = true;
+    (h.state!.main as { afLevel: number }).afLevel = 0.02;
+    expect(dispatchKeyboardRadioAction({ action: 'adjust_af_level', params: { direction: 'down' } })).toBe(true);
+    expect(h.setRxVolume).toHaveBeenCalledWith(0);
+    expect(h.setVolume).toHaveBeenCalledWith(0);
+    expect(h.sendCommand).not.toHaveBeenCalled();
+    expect(getCommandLifecycles()).toHaveLength(0);
+
+    h.rxEnabled = false;
+    (h.state!.main as { rfGain: number }).rfGain = 128;
+    expect(dispatchKeyboardRadioAction({ action: 'adjust_rf_gain', params: { direction: 'up' } })).toBe(true);
+    expect(dispatchKeyboardRadioAction({ action: 'adjust_rf_gain', params: { direction: 'sideways' } })).toBe(true);
+    expect(h.sendCommand).not.toHaveBeenCalled();
+  });
+
+  it('rejects impossible one-receiver SUB selection without changing local audio while retaining MAIN with A/B facts', () => {
+    h.state = oneReceiverAbState();
+    h.caps = { ...h.caps!, receivers: 1, vfoScheme: 'ab' };
+    expect(dispatchKeyboardRadioAction({ action: 'switch_active_vfo' })).toBe(true);
+    expect(dispatchKeyboardRadioAction({ action: 'set_active_vfo', params: { vfo: 'SUB' } })).toBe(true);
+    expect(h.sendCommand).not.toHaveBeenCalled();
+    expect(h.setAudioConfig).not.toHaveBeenCalled();
+
+    expect(dispatchKeyboardRadioAction({ action: 'set_active_vfo', params: { vfo: 'MAIN' } })).toBe(true);
+    expect(exactCalls()).toEqual([['set_vfo', { vfo: 'MAIN' }]]);
+    expectIntentTransport();
+    expect(h.setAudioConfig).toHaveBeenCalledExactlyOnceWith({ focus: 'main' });
+  });
+
+  it('contains hostile params for every newly recognized keyboard action without touching radio or audio state', () => {
+    const actions = [
+      'toggle_rit', 'toggle_xit', 'clear_rit_xit', 'adjust_af_level', 'adjust_rf_gain',
+      'toggle_monitor', 'toggle_split', 'vfo_swap', 'vfo_equalize', 'switch_active_vfo', 'set_active_vfo',
+    ];
+    const getter = vi.fn(() => { throw new Error('getter executed'); });
+    const hostile = Object.defineProperty({}, 'vfo', { enumerable: true, get: getter });
+
+    for (const action of actions) {
+      expect(() => dispatchKeyboardRadioAction({ action, params: hostile })).not.toThrow();
+      expect(dispatchKeyboardRadioAction({ action, params: hostile })).toBe(true);
+    }
+    expect(getter).not.toHaveBeenCalled();
+    expect(h.sendCommand).not.toHaveBeenCalled();
+    expect(h.setAudioConfig).not.toHaveBeenCalled();
+    expect(h.patchActiveReceiver).not.toHaveBeenCalled();
+    expect(h.patchRadioState).not.toHaveBeenCalled();
+  });
+
   it('fails closed for invalid keyboard input while leaving deferred and local actions to their current owner', () => {
     h.unavailable.add('main.freqHz');
     expect(dispatchKeyboardRadioAction({ action: 'tune', params: { direction: 'up' } })).toBe(true);
@@ -1073,7 +1135,9 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
     (h.state.main as any).preamp = 99;
     expect(dispatchKeyboardRadioAction({ action: 'cycle_preamp' })).toBe(true);
     expect(dispatchKeyboardRadioAction({ action: 'cycle_filter', params: { direction: 'sideways' } })).toBe(true);
+    h.unavailable.add('ritOn');
     expect(dispatchKeyboardRadioAction({ action: 'toggle_rit' })).toBe(true);
+    h.unavailable.clear();
     expect(dispatchKeyboardRadioAction({ action: 'scope_toggle_hold' })).toBe(false);
     expect(dispatchKeyboardRadioAction({ action: 'open_filter_settings' })).toBe(false);
     expect(dispatchKeyboardRadioAction({ action: 'ptt_on' })).toBe(false);

--- a/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.test.ts
@@ -1031,6 +1031,35 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
     expect(h.patchRadioState).not.toHaveBeenCalled();
   });
 
+  it('delegates the complete A03d1b RIT, audio, monitor, and VFO keyboard families through typed intents', () => {
+    const actions = [
+      { action: 'toggle_rit' }, { action: 'toggle_xit' }, { action: 'clear_rit_xit' },
+      { action: 'adjust_af_level', params: { direction: 'up' } },
+      { action: 'adjust_rf_gain', params: { direction: 'down' } },
+      { action: 'toggle_monitor' }, { action: 'toggle_split' }, { action: 'vfo_swap' },
+      { action: 'vfo_equalize' }, { action: 'switch_active_vfo' },
+      { action: 'set_active_vfo', params: { vfo: 'MAIN' } },
+    ];
+
+    for (const action of actions) expect(dispatchKeyboardRadioAction(action)).toBe(true);
+
+    expect(exactCalls()).toEqual([
+      ['set_rit_status', { on: true }],
+      ['set_rit_tx_status', { on: false }],
+      ['set_rit_frequency', { freq: 0 }],
+      ['set_af_level', { level: 50 / 255 + 0.05, receiver: 0 }],
+      ['set_rf_gain', { level: Math.round((128 / 255 - 0.05) * 255), receiver: 0 }],
+      ['set_monitor', { on: true }], ['set_split', { on: true }],
+      ['vfo_swap', {}], ['vfo_equalize', {}],
+      ['set_vfo', { vfo: 'SUB' }], ['set_vfo', { vfo: 'MAIN' }],
+    ]);
+    expectIntentTransport();
+    expect(h.patchActiveReceiver).not.toHaveBeenCalled();
+    expect(h.patchRadioState).not.toHaveBeenCalled();
+    expect(h.setAudioConfig).toHaveBeenNthCalledWith(1, { focus: 'sub' });
+    expect(h.setAudioConfig).toHaveBeenNthCalledWith(2, { focus: 'main' });
+  });
+
   it('fails closed for invalid keyboard input while leaving deferred and local actions to their current owner', () => {
     h.unavailable.add('main.freqHz');
     expect(dispatchKeyboardRadioAction({ action: 'tune', params: { direction: 'up' } })).toBe(true);
@@ -1044,7 +1073,7 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
     (h.state.main as any).preamp = 99;
     expect(dispatchKeyboardRadioAction({ action: 'cycle_preamp' })).toBe(true);
     expect(dispatchKeyboardRadioAction({ action: 'cycle_filter', params: { direction: 'sideways' } })).toBe(true);
-    expect(dispatchKeyboardRadioAction({ action: 'toggle_rit' })).toBe(false);
+    expect(dispatchKeyboardRadioAction({ action: 'toggle_rit' })).toBe(true);
     expect(dispatchKeyboardRadioAction({ action: 'scope_toggle_hold' })).toBe(false);
     expect(dispatchKeyboardRadioAction({ action: 'open_filter_settings' })).toBe(false);
     expect(dispatchKeyboardRadioAction({ action: 'ptt_on' })).toBe(false);
@@ -1091,7 +1120,7 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
       expect(dispatchKeyboardRadioAction({ action: 'tune', params: params as Record<string, unknown> })).toBe(true);
     }
     expect(getter).not.toHaveBeenCalled();
-    expect(dispatchKeyboardRadioAction({ action: 'toggle_rit', params: prototypeTrap as Record<string, unknown> })).toBe(false);
+    expect(dispatchKeyboardRadioAction({ action: 'toggle_rit', params: prototypeTrap as Record<string, unknown> })).toBe(true);
     expect(h.sendCommand).not.toHaveBeenCalled();
     expect(h.patchActiveReceiver).not.toHaveBeenCalled();
     expect(h.patchRadioState).not.toHaveBeenCalled();
@@ -1214,8 +1243,9 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
     expect(busSource).not.toContain('export function makeVoxHandlers');
     expect(panelSource).toContain('export function makeVfoHandlers');
     expect(panelSource).toContain('export function makeVoxHandlers');
-    expect(busSource).toMatch(/function _activateReceiver\s*\(/);
-    expect(busSource).toContain("case 'set_active_vfo'");
+    expect(busSource).not.toMatch(/function _activateReceiver\s*\(/);
+    expect(busSource).not.toContain('activeReceiverParam');
+    expect(busSource).not.toContain("case 'set_active_vfo'");
     for (const deferred of [
       'makeSystemHandlers', 'makeScopeControlsHandlers', 'makeKeyboardHandlers',
     ]) expect(busSource).toContain(`export function ${deferred}`);

--- a/frontend/src/lib/runtime/commands/panel-commands.ts
+++ b/frontend/src/lib/runtime/commands/panel-commands.ts
@@ -988,6 +988,9 @@ const KEYBOARD_RADIO_ACTIONS = new Set([
   'tune', 'band_select', 'mode_select', 'cycle_data_mode', 'cycle_filter',
   'cycle_preamp', 'cycle_att', 'cycle_agc', 'toggle_nr', 'toggle_nb',
   'toggle_auto_notch', 'toggle_ip_plus',
+  'toggle_rit', 'toggle_xit', 'clear_rit_xit',
+  'adjust_af_level', 'adjust_rf_gain', 'toggle_monitor',
+  'toggle_split', 'vfo_swap', 'vfo_equalize', 'switch_active_vfo', 'set_active_vfo',
 ]);
 
 function currentKeyboardContext(): KeyboardContext | null {
@@ -1120,6 +1123,59 @@ export function dispatchKeyboardRadioAction({ action, params }: KeyboardRadioAct
       return true;
     case 'toggle_ip_plus':
       if (has('ip_plus') && keyboardReceiverField(context, 'ipplus') && typeof rx?.ipplus === 'boolean') makeRfFrontEndHandlers().onIpPlusToggle(!rx.ipplus);
+      return true;
+    case 'toggle_rit':
+      if (has('rit') && knownA03cTopLevelField(context, 'ritOn')
+        && typeof context.state.ritOn === 'boolean') makeRitXitHandlers().onRitToggle();
+      return true;
+    case 'toggle_xit':
+      if (has('xit') && knownA03cTopLevelField(context, 'ritTx')
+        && typeof context.state.ritTx === 'boolean') makeRitXitHandlers().onXitToggle();
+      return true;
+    case 'clear_rit_xit':
+      if ((has('rit') || has('xit')) && knownA03cTopLevelField(context, 'ritFreq')
+        && Number.isSafeInteger(context.state.ritFreq)) makeRitXitHandlers().onClear();
+      return true;
+    case 'adjust_af_level': {
+      const direction = keyboardDirection(safeParams.direction);
+      const current = rx?.afLevel;
+      if (direction && keyboardReceiverField(context, 'afLevel') && isNormalizedLevel(current)) {
+        makeRxAudioHandlers().onAfLevelChange(Math.max(0, Math.min(1, current + (direction === 'down' ? -0.05 : 0.05))));
+      }
+      return true;
+    }
+    case 'adjust_rf_gain': {
+      const direction = keyboardDirection(safeParams.direction);
+      const current = rx?.rfGain;
+      if (direction && keyboardReceiverField(context, 'rfGain') && isNormalizedLevel(current)) {
+        const level = Math.max(0, Math.min(1, current + (direction === 'down' ? -0.05 : 0.05)));
+        makeRfFrontEndHandlers().onRfGainChange(Math.round(level * 255));
+      }
+      return true;
+    }
+    case 'toggle_monitor':
+      if (has('tx') && has('monitor') && knownA03cTopLevelField(context, 'monitorOn')
+        && typeof context.state.monitorOn === 'boolean') makeTxHandlers().onMonToggle();
+      return true;
+    case 'toggle_split':
+      if (has('split') && knownA03cTopLevelField(context, 'split')
+        && typeof context.state.split === 'boolean') makeVfoHandlers().onSplitToggle();
+      return true;
+    case 'vfo_swap':
+      makeVfoHandlers().onSwap();
+      return true;
+    case 'vfo_equalize':
+      makeVfoHandlers().onEqual();
+      return true;
+    case 'switch_active_vfo': {
+      const target = context.state.active === 'MAIN' ? 'SUB' : 'MAIN';
+      if (target === 'MAIN') makeVfoHandlers().onMainVfoClick();
+      else if (context.caps.receivers >= 2 && has('dual_rx') && context.state.sub) makeVfoHandlers().onSubVfoClick();
+      return true;
+    }
+    case 'set_active_vfo':
+      if (safeParams.vfo === 'MAIN') makeVfoHandlers().onMainVfoClick();
+      else if (safeParams.vfo === 'SUB' && context.caps.receivers >= 2 && has('dual_rx') && context.state.sub) makeVfoHandlers().onSubVfoClick();
       return true;
     default:
       return true;

--- a/frontend/src/lib/runtime/props/panel-props.ts
+++ b/frontend/src/lib/runtime/props/panel-props.ts
@@ -683,7 +683,6 @@ export interface MeterProps {
   vd: number;
   id: number;
   txActive: boolean;
-  meterSource: string;
   hasTx: boolean;
 }
 
@@ -702,7 +701,6 @@ export function toMeterProps(
     vd: state?.vdMeter ?? 0,
     id: state?.idMeter ?? 0,
     txActive: state?.ptt ?? false,
-    meterSource: (state as { meterSource?: string } | null)?.meterSource ?? 'S',
     hasTx: caps?.tx ?? false,
   };
 }


### PR DESCRIPTION
Part of #2317.

Implements frozen MOR-1409 A03d1b from exact base `d22b93752a10e122a39aef53318ef638a795ba3c`; see the [A03d1 hard-stop correction](https://github.com/rigplane/rigplane-core/issues/2317#issuecomment-5232389953).

- Delegates exactly 11 RIT/audio/monitor/VFO keyboard actions through the existing hostile-safe canonical typed intent path.
- Deletes matching legacy command-bus ownership, optimistic receiver activation, and only the runtime MeterProps meter-source residue.
- Production owners: `panel-commands.ts`, `command-bus.ts`, `panel-props.ts`; exact numstat +57/-99, churn 156.

Exact head: `5ed7dde5715218a7717ec3362d5efe9047d13121`.

Validation: causal RED, focused/frozen/full frontend, build, focused/backend suite, Ruff/format/import-lint/mypy/generated-state/consumer-contract gates.