### PR TITLE
refactor(#2317): delegate keyboard dial scope actions

### DIFF
--- a/frontend/src/components-v2/wiring/command-bus.ts
+++ b/frontend/src/components-v2/wiring/command-bus.ts
@@ -10,7 +10,6 @@
  */
 
 import { sendCommand } from '$lib/transport/ws-client';
-import { getRadioState, patchRadioState } from '$lib/stores/radio.svelte';
 import { adjustTuningStep } from '$lib/stores/tuning.svelte';
 import { dispatchKeyboardRadioAction } from '$lib/runtime/commands/panel-commands';
 export {
@@ -32,7 +31,6 @@ export {
   makeVoxHandlers,
 } from '$lib/runtime/commands/panel-commands';
 import type { KeyboardActionConfig } from '../layout/keyboard-map';
-import { clampRef, clampSpan } from '../../components/spectrum/spectrum-toolbar-logic';
 
 /* ── Helpers ─────────────────────────────────────────────────── */
 
@@ -86,12 +84,6 @@ export function makeKeyboardHandlers() {
           window.dispatchEvent(new CustomEvent('rigplane:open-filter-settings'));
           return;
         }
-        case 'toggle_dial_lock': {
-          const on = !(getRadioState()?.dialLock ?? false);
-          patchRadioState({ dialLock: on });
-          cmd('set_dial_lock', { on });
-          return;
-        }
         case 'focus_target': {
           const target = action.params?.target;
           if (typeof target === 'string') {
@@ -113,42 +105,6 @@ export function makeKeyboardHandlers() {
               el.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
             }
           }
-          return;
-        }
-        case 'scope_span_step': {
-          const scope = getRadioState()?.scopeControls;
-          const current = scope?.span ?? 3;
-          const delta = action.params?.direction === 'down' ? -1 : 1;
-          const span = clampSpan(current, delta);
-          cmd('set_scope_span', { span });
-          return;
-        }
-        case 'scope_ref_step': {
-          const scope = getRadioState()?.scopeControls;
-          const current = scope?.refDb ?? 0;
-          const delta = action.params?.direction === 'down' ? -5 : 5;
-          const ref = clampRef(current, delta);
-          cmd('set_scope_ref', { ref });
-          return;
-        }
-        case 'scope_toggle_hold': {
-          const scope = getRadioState()?.scopeControls;
-          const on = !(scope?.hold ?? false);
-          cmd('set_scope_hold', { on });
-          return;
-        }
-        case 'scope_toggle_dual': {
-          const scope = getRadioState()?.scopeControls;
-          const dual = !(scope?.dual ?? false);
-          cmd('set_scope_dual', { dual });
-          return;
-        }
-        case 'scope_toggle_fst': {
-          const scope = getRadioState()?.scopeControls;
-          const currentSpeed = scope?.speed ?? 1;
-          // Toggle FST (speed=0) vs MID (speed=1).
-          const speed = currentSpeed === 0 ? 1 : 0;
-          cmd('set_scope_speed', { speed });
           return;
         }
         default:

--- a/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.test.ts
@@ -1061,6 +1061,37 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
     expect(h.setAudioConfig).toHaveBeenNthCalledWith(2, { focus: 'main' });
   });
 
+  it('delegates keyboard dial and scope controls only from known generation-bound scope metadata', () => {
+    h.caps = { ...h.caps!, capabilities: [...(h.caps!.capabilities as string[]), 'dial_lock', 'scope'] };
+    h.state = {
+      ...h.state!,
+      dialLock: false,
+      scopeControls: { span: 7, refDb: -30, hold: false, dual: false, speed: 0 },
+    } as ServerState;
+
+    const actions = [
+      { action: 'toggle_dial_lock' },
+      { action: 'scope_span_step', params: { direction: 'up' } },
+      { action: 'scope_ref_step', params: { direction: 'down' } },
+      { action: 'scope_toggle_hold' },
+      { action: 'scope_toggle_dual' },
+      { action: 'scope_toggle_fst' },
+    ];
+
+    for (const action of actions) expect(dispatchKeyboardRadioAction(action)).toBe(true);
+
+    expect(exactCalls()).toEqual([
+      ['set_dial_lock', { on: true }],
+      ['set_scope_span', { span: 7 }],
+      ['set_scope_ref', { ref: -30 }],
+      ['set_scope_hold', { on: true }],
+      ['set_scope_dual', { dual: true }],
+      ['set_scope_speed', { speed: 1 }],
+    ]);
+    expectIntentTransport();
+    expect(h.patchRadioState).not.toHaveBeenCalled();
+  });
+
   it('clamps only known normalized keyboard AF/RF readings and keeps active runtime AF local', () => {
     (h.state!.main as { afLevel: number; rfGain: number }).afLevel = 0.98;
     (h.state!.main as { afLevel: number; rfGain: number }).rfGain = 0.02;

--- a/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.test.ts
@@ -1062,7 +1062,7 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
   });
 
   it('delegates keyboard dial and scope controls only from known generation-bound scope metadata', () => {
-    h.caps = { ...h.caps!, capabilities: [...(h.caps!.capabilities as string[]), 'dial_lock', 'scope'] };
+    h.caps = { ...h.caps!, scope: true, capabilities: [...(h.caps!.capabilities as string[]), 'dial_lock', 'scope'] };
     h.state = {
       ...h.state!,
       dialLock: false,
@@ -1090,6 +1090,82 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
     ]);
     expectIntentTransport();
     expect(h.patchRadioState).not.toHaveBeenCalled();
+  });
+
+  it('fails closed for keyboard dial and scope defaults, stale metadata, bad ranges, and impossible dual topology', () => {
+    h.caps = { ...h.caps!, scope: true, capabilities: [...(h.caps!.capabilities as string[]), 'dial_lock', 'scope'] };
+    h.state = {
+      ...h.state!,
+      dialLock: 'false',
+      scopeControls: { span: 8, refDb: 1.5, hold: 'no', dual: false, speed: 3 },
+    } as unknown as ServerState;
+
+    for (const action of [
+      { action: 'toggle_dial_lock' },
+      { action: 'scope_span_step', params: { direction: 'sideways' } },
+      { action: 'scope_ref_step', params: { direction: 'up' } },
+      { action: 'scope_toggle_hold' }, { action: 'scope_toggle_fst' },
+    ]) expect(dispatchKeyboardRadioAction(action)).toBe(true);
+
+    h.state = oneReceiverAbState();
+    h.state = { ...h.state, dialLock: false, scopeControls: { span: 0, refDb: 10, hold: false, dual: false, speed: 2 } } as ServerState;
+    h.caps = { ...h.caps!, receivers: 1, vfoScheme: 'ab' };
+    expect(dispatchKeyboardRadioAction({ action: 'scope_toggle_dual' })).toBe(true);
+    expect(dispatchKeyboardRadioAction({ action: 'scope_span_step', params: { direction: 'down' } })).toBe(true);
+    expect(dispatchKeyboardRadioAction({ action: 'scope_ref_step', params: { direction: 'up' } })).toBe(true);
+    expect(dispatchKeyboardRadioAction({ action: 'scope_toggle_fst' })).toBe(true);
+    expect(exactCalls()).toEqual([
+      ['set_scope_span', { span: 0 }],
+      ['set_scope_ref', { ref: 10 }],
+      ['set_scope_speed', { speed: 0 }],
+    ]);
+    expectIntentTransport();
+
+    h.sendCommand.mockClear();
+    resetCommandLifecycle();
+    h.unavailable.add('scopeControls.span');
+    expect(dispatchKeyboardRadioAction({ action: 'scope_span_step', params: { direction: 'up' } })).toBe(true);
+    h.unavailable.clear();
+    h.caps = { ...h.caps!, scope: false };
+    expect(dispatchKeyboardRadioAction({ action: 'scope_toggle_hold' })).toBe(true);
+    h.caps = { ...h.caps!, scope: true, capabilities: (h.caps!.capabilities as string[]).filter((name) => name !== 'dial_lock') };
+    expect(dispatchKeyboardRadioAction({ action: 'toggle_dial_lock' })).toBe(true);
+    h.caps = { ...h.caps!, providerGeneration: 99 };
+    expect(dispatchKeyboardRadioAction({ action: 'toggle_dial_lock' })).toBe(true);
+    expect(h.sendCommand).not.toHaveBeenCalled();
+    expect(getCommandLifecycles()).toHaveLength(0);
+  });
+
+  it('rejects malformed scope direction and every non-integral or out-of-range observed step value', () => {
+    h.caps = { ...h.caps!, scope: true, capabilities: [...(h.caps!.capabilities as string[]), 'scope'] };
+    h.state = { ...h.state!, scopeControls: { span: 3, refDb: 0, hold: false, dual: false, speed: 1 } } as ServerState;
+    expect(dispatchKeyboardRadioAction({ action: 'scope_span_step', params: { direction: 'sideways' } })).toBe(true);
+    for (const span of [-1, 8, 1.5]) {
+      h.state = { ...h.state!, scopeControls: { span, refDb: 0, hold: false, dual: false, speed: 1 } } as ServerState;
+      expect(dispatchKeyboardRadioAction({ action: 'scope_span_step', params: { direction: 'up' } })).toBe(true);
+    }
+    for (const refDb of [-35, 15, 1.5]) {
+      h.state = { ...h.state!, scopeControls: { span: 3, refDb, hold: false, dual: false, speed: 1 } } as ServerState;
+      expect(dispatchKeyboardRadioAction({ action: 'scope_ref_step', params: { direction: 'up' } })).toBe(true);
+    }
+    expect(h.sendCommand).not.toHaveBeenCalled();
+    expect(getCommandLifecycles()).toHaveLength(0);
+  });
+
+  it('contains hostile parameters for each recognized dial and scope action before any effect', () => {
+    const getter = vi.fn(() => { throw new Error('getter executed'); });
+    const hostile = Object.defineProperty({}, 'direction', { enumerable: true, get: getter });
+    for (const action of [
+      'toggle_dial_lock', 'scope_span_step', 'scope_ref_step', 'scope_toggle_hold',
+      'scope_toggle_dual', 'scope_toggle_fst',
+    ]) {
+      expect(() => dispatchKeyboardRadioAction({ action, params: hostile })).not.toThrow();
+      expect(dispatchKeyboardRadioAction({ action, params: hostile })).toBe(true);
+    }
+    expect(getter).not.toHaveBeenCalled();
+    expect(h.sendCommand).not.toHaveBeenCalled();
+    expect(h.patchRadioState).not.toHaveBeenCalled();
+    expect(getCommandLifecycles()).toHaveLength(0);
   });
 
   it('clamps only known normalized keyboard AF/RF readings and keeps active runtime AF local', () => {
@@ -1169,7 +1245,7 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
     h.unavailable.add('ritOn');
     expect(dispatchKeyboardRadioAction({ action: 'toggle_rit' })).toBe(true);
     h.unavailable.clear();
-    expect(dispatchKeyboardRadioAction({ action: 'scope_toggle_hold' })).toBe(false);
+    expect(dispatchKeyboardRadioAction({ action: 'scope_toggle_hold' })).toBe(true);
     expect(dispatchKeyboardRadioAction({ action: 'open_filter_settings' })).toBe(false);
     expect(dispatchKeyboardRadioAction({ action: 'ptt_on' })).toBe(false);
     expect(h.sendCommand).not.toHaveBeenCalled();
@@ -1344,6 +1420,18 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
     for (const deferred of [
       'makeSystemHandlers', 'makeScopeControlsHandlers', 'makeKeyboardHandlers',
     ]) expect(busSource).toContain(`export function ${deferred}`);
+    for (const action of [
+      'toggle_dial_lock', 'scope_span_step', 'scope_ref_step', 'scope_toggle_hold',
+      'scope_toggle_dual', 'scope_toggle_fst',
+    ]) {
+      expect(panelSource).toContain(`'${action}'`);
+      expect(busSource).not.toContain(`case '${action}'`);
+    }
+    expect(busSource).not.toContain('patchRadioState');
+    expect(busSource).not.toContain('clampSpan');
+    expect(busSource).not.toContain('clampRef');
+    expect(panelSource).not.toContain('export function makeSystemHandlers');
+    expect(panelSource).not.toContain('export function makeScopeControlsHandlers');
     expect(panelSource).not.toContain('export function makeMeterHandlers');
     expect(busSource).not.toContain('export function makeMeterHandlers');
     expect(panelSource.match(/function toggleVox/g)).toHaveLength(1);

--- a/frontend/src/lib/runtime/commands/panel-commands.ts
+++ b/frontend/src/lib/runtime/commands/panel-commands.ts
@@ -991,6 +991,8 @@ const KEYBOARD_RADIO_ACTIONS = new Set([
   'toggle_rit', 'toggle_xit', 'clear_rit_xit',
   'adjust_af_level', 'adjust_rf_gain', 'toggle_monitor',
   'toggle_split', 'vfo_swap', 'vfo_equalize', 'switch_active_vfo', 'set_active_vfo',
+  'toggle_dial_lock', 'scope_span_step', 'scope_ref_step', 'scope_toggle_hold',
+  'scope_toggle_dual', 'scope_toggle_fst',
 ]);
 
 function currentKeyboardContext(): KeyboardContext | null {
@@ -1017,6 +1019,13 @@ function keyboardCycle(values: unknown, current: unknown): number | null {
 
 function keyboardDirection(value: unknown): 'up' | 'down' | null {
   return value === 'up' || value === 'down' ? value : null;
+}
+
+function keyboardScopeField(context: KeyboardContext, field: string): unknown | null {
+  const scope = context.state.scopeControls;
+  const value = (scope as unknown as Record<string, unknown> | undefined)?.[field];
+  return value !== undefined && value !== null && isFieldAvailable(context.state, `scopeControls.${field}`)
+    ? value : null;
 }
 
 function keyboardParams(value: unknown): Record<string, unknown> | null {
@@ -1177,6 +1186,51 @@ export function dispatchKeyboardRadioAction({ action, params }: KeyboardRadioAct
       if (safeParams.vfo === 'MAIN') makeVfoHandlers().onMainVfoClick();
       else if (safeParams.vfo === 'SUB' && context.caps.receivers >= 2 && has('dual_rx') && context.state.sub) makeVfoHandlers().onSubVfoClick();
       return true;
+    case 'toggle_dial_lock': {
+      const dialLock = context.state.dialLock;
+      if (has('dial_lock') && knownA03cTopLevelField(context, 'dialLock') && typeof dialLock === 'boolean') {
+        dispatchRadioIntent({ name: 'set_dial_lock', params: { on: !dialLock } });
+      }
+      return true;
+    }
+    case 'scope_span_step': {
+      const current = keyboardScopeField(context, 'span');
+      const direction = keyboardDirection(safeParams.direction);
+      if (context.caps.scope === true && has('scope') && direction && typeof current === 'number' && Number.isSafeInteger(current) && current >= 0 && current <= 7) {
+        dispatchRadioIntent({ name: 'set_scope_span', params: { span: Math.max(0, Math.min(7, current + (direction === 'down' ? -1 : 1))) } });
+      }
+      return true;
+    }
+    case 'scope_ref_step': {
+      const current = keyboardScopeField(context, 'refDb');
+      const direction = keyboardDirection(safeParams.direction);
+      if (context.caps.scope === true && has('scope') && direction && typeof current === 'number' && Number.isSafeInteger(current) && current >= -30 && current <= 10) {
+        dispatchRadioIntent({ name: 'set_scope_ref', params: { ref: Math.max(-30, Math.min(10, current + (direction === 'down' ? -5 : 5))) } });
+      }
+      return true;
+    }
+    case 'scope_toggle_hold': {
+      const hold = keyboardScopeField(context, 'hold');
+      if (context.caps.scope === true && has('scope') && typeof hold === 'boolean') {
+        dispatchRadioIntent({ name: 'set_scope_hold', params: { on: !hold } });
+      }
+      return true;
+    }
+    case 'scope_toggle_dual': {
+      const dual = keyboardScopeField(context, 'dual');
+      if (context.caps.scope === true && has('scope') && context.caps.receivers === 2
+        && has('dual_rx') && context.state.sub && typeof dual === 'boolean') {
+        dispatchRadioIntent({ name: 'set_scope_dual', params: { dual: !dual } });
+      }
+      return true;
+    }
+    case 'scope_toggle_fst': {
+      const speed = keyboardScopeField(context, 'speed');
+      if (context.caps.scope === true && has('scope') && typeof speed === 'number' && Number.isSafeInteger(speed) && speed >= 0 && speed <= 2) {
+        dispatchRadioIntent({ name: 'set_scope_speed', params: { speed: speed === 0 ? 1 : 0 } });
+      }
+      return true;
+    }
     default:
       return true;
   }


### PR DESCRIPTION
Part of #2317

Acceptance correction: https://github.com/rigplane/rigplane-core/issues/2317#issuecomment-5232389953

Exact base: `3e7d5898509ac7b596b886c1a1a4db6c6a662a9b`
Exact head: `39359b8ba616d5517811c2d415605f8459c5bc7e`

Two production owners only; immediate-base churn 98 (`panel-commands.ts` +54/-0, `command-bus.ts` +0/-44). RED-first then GREEN, hostile/default/generation/availability/range/direction/FST/topology/raw/Store/local/PTT/A03e mutation matrix restored. Full frontend 299 files / 6,171 PASS; backend non-hardware 8,993 passed, 12 skipped, 5 deselected, 11 xfailed, 1 xpassed; static/generated/consumer gates PASS.

A03e is excluded; no hardware claim. Builder report: `/private/tmp/build-mor1409-a03d2.md` SHA-256 `071ddd469ebfdc5872dfc59574a0ac065a2a006deaf5afdce27f721761bcaf23`.

Auto-merge remains off.