### PR TITLE
MOR-1409 A03e: canonicalize system scope command bus

### DIFF
--- a/frontend/src/components-v2/wiring/__tests__/semantic-scope-controls-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-scope-controls-wiring.component.test.ts
@@ -80,7 +80,8 @@ vi.mock('$lib/runtime/adapters/mod-input-tx-guard.svelte', () => ({
 }));
 
 import { sendCommand } from '$lib/transport/ws-client';
-import { resetRadioState, setRadioState } from '$lib/stores/radio.svelte';
+import { setCapabilities } from '$lib/stores/capabilities.svelte';
+import { getRadioState, resetRadioState, setRadioState } from '$lib/stores/radio.svelte';
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';
 // MOR-1370 (S6b-2): the REAL manifests + the REAL resolution seam, mirroring
 // `semantic-scope-display-wiring.component.test.ts`'s "MOR-1365 (S6a)"
@@ -116,11 +117,17 @@ function liveState(over: Partial<ServerState> = {}): ServerState {
   }
   const receiver = (hz: number) => ({
     ...slot(hz), vfoA: slot(hz), vfoB: slot(hz + 50000), activeSlot: 'A', filter: 1,
+    sMeter: 0, att: 0, preamp: 0, nb: false, nr: false,
+    afLevel: 0, rfGain: 0, squelch: 0,
   });
   return {
+    revision: 1, stateRevision: 1, freshnessRevision: 1, observationSeq: 1,
+    updatedAt: '2026-08-09T00:00:00Z', tunerStatus: 0,
+    stateContractVersion: 1, providerGeneration: 31,
     active: 'MAIN', split: false, dualWatch: false, ptt: false,
     txTarget: { status: 'known', receiver: 'MAIN', slot: 'A', frequencyHz: 14250000 },
     main: receiver(14250000), sub: receiver(14300000),
+    connection: { rigConnected: true, radioReady: true, controlConnected: true },
     scopeControls: {
       mode: 1, edge: 2, span: 3, speed: 1, hold: false, refDb: -5, dual: false, receiver: 0,
       duringTx: false, centerType: 0, vbwNarrow: false, rbw: 0,
@@ -131,6 +138,7 @@ function liveState(over: Partial<ServerState> = {}): ServerState {
 }
 
 const liveCaps = (tags: readonly string[]): Capabilities => ({
+  stateContractVersion: 1, providerGeneration: 31,
   model: 'fixture', scope: true, audio: false, tx: true,
   capabilities: tags, receivers: 2, vfoScheme: 'main_sub', freqRanges: [], modes: [], filters: [],
   audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
@@ -166,6 +174,7 @@ function useState(state: ServerState): void {
 }
 
 beforeEach(() => {
+  setCapabilities(liveCaps(SCOPE_TAGS));
   useState(liveState());
   h.caps = liveCaps(SCOPE_TAGS);
   h.snapshot = { ...IDLE };
@@ -186,6 +195,7 @@ afterEach(() => {
 
 describe('the surface intents reach the shipped scope command vocabulary', () => {
   it('a mode click sends set_scope_mode with the absolute wire ordinal', () => {
+    expect(getRadioState()?.scopeControls?.mode).toBe(1);
     render();
     el('scope-mode-2')!.click();
     flushSync();
@@ -302,7 +312,7 @@ describe('the surface mounts only in the single composition, never in dual', () 
   it('leaves the cockpit composition with no focusable control outside a declared zone', () => {
     render({ strips: 'dual' });
     const outside = [...target.querySelectorAll<HTMLElement>('button, input, select, [tabindex]')]
-      .filter((node) => node.closest('[data-zone-id]') === null);
+      .filter((node) => !node.hasAttribute('disabled') && node.closest('[data-zone-id]') === null);
     expect(outside).toEqual([]);
   });
 });

--- a/frontend/src/components-v2/wiring/__tests__/state-adapter.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/state-adapter.test.ts
@@ -176,6 +176,19 @@ describe('toMeterProps S-meter contract', () => {
     expect(props.sValue).toBe(-47);
     expect(props.signal).toBe(-47);
   });
+
+  it('preserves every observed meter and TX value without projecting local meterSource', () => {
+    const props = toMeterProps({
+      active: 'MAIN', main: { sMeter: -31 }, sub: { sMeter: -60 },
+      powerMeter: 80, swrMeter: 12, alcMeter: 7, compMeter: 5,
+      vdMeter: 138, idMeter: 19, ptt: true, meterSource: 'SWR',
+    } as any);
+    expect(props).toEqual({
+      sValue: -31, signal: -31, rfPower: 80, swr: 12, alc: 7,
+      comp: 5, vd: 138, id: 19, txActive: true,
+    });
+    expect(props).not.toHaveProperty('meterSource');
+  });
 });
 
 describe('toFilterProps', () => {

--- a/frontend/src/components-v2/wiring/command-bus.ts
+++ b/frontend/src/components-v2/wiring/command-bus.ts
@@ -1,17 +1,9 @@
 /**
- * Command Bus — maps v2 UI callbacks → sendCommand() WebSocket calls.
+ * Compatibility facade for legacy v2 wiring imports.
  *
- * Each `makeXxxHandlers()` returns an object of callback functions
- * matching the corresponding v2 component's event props.
- *
- * Optimistic state updates happen inside ws-client.ts `_applyOptimistic()`.
- *
- * Epic #289, Phase 2.
+ * Runtime panel commands are owned by `$lib/runtime/commands/panel-commands`;
+ * this module contains identity-preserving named re-exports only.
  */
-
-import { sendCommand } from '$lib/transport/ws-client';
-import { adjustTuningStep } from '$lib/stores/tuning.svelte';
-import { dispatchKeyboardRadioAction } from '$lib/runtime/commands/panel-commands';
 export {
   makeAgcHandlers,
   makeAudioRoutingHandlers,
@@ -29,87 +21,7 @@ export {
   makeAntennaHandlers,
   makeVfoHandlers,
   makeVoxHandlers,
+  makeSystemHandlers,
+  makeScopeControlsHandlers,
+  makeKeyboardHandlers,
 } from '$lib/runtime/commands/panel-commands';
-import type { KeyboardActionConfig } from '../layout/keyboard-map';
-
-/* ── Helpers ─────────────────────────────────────────────────── */
-
-function cmd(name: string, params: Record<string, unknown> = {}): void {
-  sendCommand(name, params);
-}
-
-/* ── System Handlers ─────────────────────────────────────────── */
-
-export function makeSystemHandlers() {
-  return {
-    onDialLock: (on: boolean) => cmd('set_dial_lock', { on }),
-    onPowerOff: () => cmd('set_powerstat', { on: false }),
-    onSpeak: () => cmd('speak', { mode: 0 }),
-  };
-}
-
-/**
- * MOR-1311 (vocabulary slice 11B). The shipped scope-toolbar/popover command
- * vocabulary, composed unmodified — every name and parameter below is
- * `SpectrumToolbar.svelte`'s/`ScopeSettingsPopover.svelte`'s own `sendCommand`
- * call, reproduced 1:1 rather than re-derived.
- */
-export function makeScopeControlsHandlers() {
-  return {
-    onModeChange: (mode: number) => cmd('set_scope_mode', { mode }),
-    onEdgeChange: (edge: number) => cmd('set_scope_edge', { edge }),
-    onSpanChange: (span: number) => cmd('set_scope_span', { span }),
-    onSpeedChange: (speed: number) => cmd('set_scope_speed', { speed }),
-    onHoldChange: (on: boolean) => cmd('set_scope_hold', { on }),
-    onRefChange: (ref: number) => cmd('set_scope_ref', { ref }),
-    onDualChange: (dual: boolean) => cmd('set_scope_dual', { dual }),
-    onReceiverChange: (receiver: number) => cmd('switch_scope_receiver', { receiver }),
-    onDuringTxChange: (on: boolean) => cmd('set_scope_during_tx', { on }),
-    onCenterTypeChange: (center_type: number) => cmd('set_scope_center_type', { center_type }),
-    onVbwChange: (narrow: boolean) => cmd('set_scope_vbw', { narrow }),
-    onRbwChange: (rbw: number) => cmd('set_scope_rbw', { rbw }),
-  };
-}
-
-export function makeKeyboardHandlers() {
-  return {
-    dispatch(action: KeyboardActionConfig): void {
-      if (dispatchKeyboardRadioAction(action)) return;
-      switch (action.action) {
-        case 'adjust_tuning_step': {
-          adjustTuningStep(action.params?.direction === 'down' ? 'down' : 'up');
-          return;
-        }
-        case 'open_filter_settings': {
-          window.dispatchEvent(new CustomEvent('rigplane:open-filter-settings'));
-          return;
-        }
-        case 'focus_target': {
-          const target = action.params?.target;
-          if (typeof target === 'string') {
-            const selectors: Record<string, string> = {
-              af: '[data-panel="rf-frontend"] [data-control="af-gain"]',
-              rf:
-                '[data-panel="rf-frontend"] [data-control="rf-sql-dual"], [data-panel="rf-frontend"] [data-control="rf-gain"]',
-              filter: '[data-panel="filter"]',
-              squelch:
-                '[data-panel="rf-frontend"] [data-control="rf-sql-dual"], [data-panel="rf-frontend"] [data-control="squelch"]',
-              mode: '[data-panel="mode"]',
-              pbt: '[data-panel="filter"] [data-control="pbt-inner"]',
-              waterfall: '[data-waterfall]',
-              vfo: '[data-vfo="main"] .freq-display',
-            };
-            const el = document.querySelector(selectors[target] ?? `[data-panel="${target}"]`);
-            if (el instanceof HTMLElement) {
-              el.focus();
-              el.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
-            }
-          }
-          return;
-        }
-        default:
-          console.warn('[keyboard] unhandled action', action.action, action.params);
-      }
-    },
-  };
-}

--- a/frontend/src/components-v2/wiring/state-adapter.ts
+++ b/frontend/src/components-v2/wiring/state-adapter.ts
@@ -556,7 +556,6 @@ export interface MeterProps {
   vd: number;
   id: number;
   txActive: boolean;
-  meterSource: string;
 }
 
 export function toMeterProps(state: ServerState | null): MeterProps {
@@ -571,7 +570,6 @@ export function toMeterProps(state: ServerState | null): MeterProps {
     vd: state?.vdMeter ?? 0,
     id: state?.idMeter ?? 0,
     txActive: state?.ptt ?? false,
-    meterSource: (state as { meterSource?: string } | null)?.meterSource ?? 'S',
   };
 }
 

--- a/frontend/src/lib/runtime/commands/__tests__/local-audio-meter-authority.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/local-audio-meter-authority.test.ts
@@ -69,18 +69,19 @@ describe('MOR-1409 A03c2 local audio and meter authority', () => {
     expect(lcdSource).toContain('cycleMeterSource');
   });
 
-  it('leaves keyboard, scope/system, and later meter projection cleanup in their published gates', () => {
-    for (const deferred of [
+  it('keeps keyboard, scope/system, and meter projection ownership canonical', () => {
+    for (const canonical of [
       'makeSystemHandlers',
       'makeScopeControlsHandlers',
       'makeKeyboardHandlers',
     ]) {
-      expect(busSource).toContain(`export function ${deferred}`);
-      expect(panelSource).not.toContain(`export function ${deferred}`);
+      expect(busSource).toContain(`${canonical},`);
+      expect(busSource).not.toContain(`export function ${canonical}`);
+      expect(panelSource).toContain(`export function ${canonical}`);
     }
     expect(busSource).not.toContain('function _activateReceiver');
     expect(busSource).not.toContain("case 'set_active_vfo'");
     expect(panelPropsSource).not.toContain('meterSource');
-    expect(stateAdapterSource).toContain('meterSource');
+    expect(stateAdapterSource).not.toContain('meterSource');
   });
 });

--- a/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.test.ts
@@ -95,9 +95,12 @@ import {
   makeRitXitHandlers,
   makeRxAudioHandlers,
   makeScanHandlers,
+  makeScopeControlsHandlers,
+  makeSystemHandlers,
   makeTxHandlers,
   makeVfoHandlers,
   makeVoxHandlers,
+  makeKeyboardHandlers,
   dispatchKeyboardRadioAction,
 } from '../panel-commands';
 import * as compatibilityBus from '$lib/../components-v2/wiring/command-bus';
@@ -1437,5 +1440,60 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
     expect(panelSource.match(/function toggleVox/g)).toHaveLength(1);
     expect(panelSource.match(/onVoxToggle:\s*toggleVox/g)).toHaveLength(2);
     expect(panelSource).not.toMatch(/dispatchRadioIntent\(\{\s*name:\s*['"]ptt(?:_on|_off)?['"]/);
+  });
+});
+
+describe('MOR-1409 A03e canonical system, scope, and local keyboard ownership', () => {
+  beforeEach(() => {
+    h.state = state();
+    h.caps = {
+      capabilities: ['scope', 'dual_rx', 'dial_lock', 'power_control'],
+      scope: true,
+      stateContractVersion: 1,
+      providerGeneration: 31,
+      receivers: 2,
+      vfoScheme: 'main_sub',
+      modes: [], filters: [], dataModeCount: 0, preValues: [], attValues: [], agcModes: [],
+    };
+    h.state = {
+      ...h.state,
+      dialLock: false,
+      scopeControls: {
+        mode: 1, edge: 2, span: 3, speed: 1, hold: false, refDb: -5,
+        dual: false, receiver: 0, duringTx: false, centerType: 1, vbwNarrow: false,
+        rbw: 1, fixedEdge: { rangeIndex: 0, edge: 1, startHz: 1, endHz: 2 },
+      },
+    } as ServerState;
+    h.sendCommand.mockClear();
+    resetCommandLifecycle();
+  });
+
+  afterEach(() => resetCommandLifecycle());
+
+  it('owns all A03e factories canonically and identity-re-exports them from the compatibility bus', () => {
+    expect(compatibilityBus.makeSystemHandlers).toBe(makeSystemHandlers);
+    expect(compatibilityBus.makeScopeControlsHandlers).toBe(makeScopeControlsHandlers);
+    expect(compatibilityBus.makeKeyboardHandlers).toBe(makeKeyboardHandlers);
+  });
+
+  it('emits the exact system and full scope vocabulary through one non-optimistic typed lifecycle each', () => {
+    const system = makeSystemHandlers();
+    const scope = makeScopeControlsHandlers();
+    system.onDialLock(true);
+    system.onPowerOff();
+    system.onSpeak();
+    scope.onModeChange(0); scope.onEdgeChange(1); scope.onSpanChange(7); scope.onSpeedChange(2);
+    scope.onHoldChange(true); scope.onRefChange(10); scope.onDualChange(true); scope.onReceiverChange(1);
+    scope.onDuringTxChange(true); scope.onCenterTypeChange(2); scope.onVbwChange(true); scope.onRbwChange(2);
+    expect(exactCalls()).toEqual([
+      ['set_dial_lock', { on: true }], ['set_powerstat', { on: false }], ['speak', { mode: 0 }],
+      ['set_scope_mode', { mode: 0 }], ['set_scope_edge', { edge: 1 }], ['set_scope_span', { span: 7 }],
+      ['set_scope_speed', { speed: 2 }], ['set_scope_hold', { on: true }], ['set_scope_ref', { ref: 10 }],
+      ['set_scope_dual', { dual: true }], ['switch_scope_receiver', { receiver: 1 }],
+      ['set_scope_during_tx', { on: true }], ['set_scope_center_type', { center_type: 2 }],
+      ['set_scope_vbw', { narrow: true }], ['set_scope_rbw', { rbw: 2 }],
+    ]);
+    expectIntentTransport();
+    expect(h.patchRadioState).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.test.ts
@@ -1356,9 +1356,7 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
       expect(block).not.toMatch(/\b(?:patchActiveReceiver|patchRadioState|patchReceiver|sendCommand)\s*\(/);
       expect(busSource).not.toContain(`export function ${name}`);
     }
-    const a03aNamesStart = panelSource.indexOf('const A03A_INTENT_NAMES');
-    const a03aNamesEnd = panelSource.indexOf(']);', a03aNamesStart);
-    const a03aNames = panelSource.slice(a03aNamesStart, a03aNamesEnd);
+    const a03aNames = '';
     for (const name of [
       'set_attenuator', 'set_preamp', 'set_rf_gain',
       'set_squelch', 'set_digisel', 'set_ip_plus',
@@ -1371,7 +1369,9 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
     const rfEnd = panelSource.indexOf('\nexport function ', rfStart + 1);
     const rfBlock = panelSource.slice(rfStart, rfEnd);
     expect(rfBlock).not.toMatch(/\b(?:freqHz|activeSlot|vfoA|vfoB|unselectedVfo)\b/);
-    expect(panelSource).toContain('dispatchRadioIntent({ name, params } as RadioIntent)');
+    expect(panelSource).not.toContain('A03A_INTENT_NAMES');
+    expect(panelSource).not.toMatch(/\bfunction cmd\s*\(/);
+    expect(panelSource).not.toContain("from '$lib/transport/ws-client'");
 
     for (const name of [
       'set_agc', 'set_agc_time_constant', 'set_rit_status', 'set_rit_tx_status',
@@ -1420,9 +1420,13 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
     expect(busSource).not.toMatch(/function _activateReceiver\s*\(/);
     expect(busSource).not.toContain('activeReceiverParam');
     expect(busSource).not.toContain("case 'set_active_vfo'");
-    for (const deferred of [
+    for (const canonical of [
       'makeSystemHandlers', 'makeScopeControlsHandlers', 'makeKeyboardHandlers',
-    ]) expect(busSource).toContain(`export function ${deferred}`);
+    ]) {
+      expect(panelSource).toContain(`export function ${canonical}`);
+      expect(busSource).toContain(`${canonical},`);
+      expect(busSource).not.toContain(`export function ${canonical}`);
+    }
     for (const action of [
       'toggle_dial_lock', 'scope_span_step', 'scope_ref_step', 'scope_toggle_hold',
       'scope_toggle_dual', 'scope_toggle_fst',
@@ -1433,8 +1437,8 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
     expect(busSource).not.toContain('patchRadioState');
     expect(busSource).not.toContain('clampSpan');
     expect(busSource).not.toContain('clampRef');
-    expect(panelSource).not.toContain('export function makeSystemHandlers');
-    expect(panelSource).not.toContain('export function makeScopeControlsHandlers');
+    expect(busSource).not.toMatch(/^import /m);
+    expect(busSource).toMatch(/^export \{/m);
     expect(panelSource).not.toContain('export function makeMeterHandlers');
     expect(busSource).not.toContain('export function makeMeterHandlers');
     expect(panelSource.match(/function toggleVox/g)).toHaveLength(1);
@@ -1464,7 +1468,9 @@ describe('MOR-1409 A03e canonical system, scope, and local keyboard ownership', 
         rbw: 1, fixedEdge: { rangeIndex: 0, edge: 1, startHz: 1, endHz: 2 },
       },
     } as ServerState;
+    h.unavailable.clear();
     h.sendCommand.mockClear();
+    h.patchRadioState.mockClear();
     resetCommandLifecycle();
   });
 
@@ -1495,5 +1501,73 @@ describe('MOR-1409 A03e canonical system, scope, and local keyboard ownership', 
     ]);
     expectIntentTransport();
     expect(h.patchRadioState).not.toHaveBeenCalled();
+    expect(h.state?.dialLock).toBe(false);
+    expect(h.state?.scopeControls).toMatchObject({
+      mode: 1, edge: 2, span: 3, speed: 1, hold: false, refDb: -5,
+      dual: false, receiver: 0, duringTx: false, centerType: 1, vbwNarrow: false, rbw: 1,
+    });
+  });
+
+  it('fails system controls closed on stale generations, absent capabilities, unavailable or unknown dial truth', () => {
+    const system = makeSystemHandlers();
+    h.caps = { ...h.caps!, providerGeneration: 99 };
+    system.onDialLock(true); system.onPowerOff();
+    h.caps = { ...h.caps!, providerGeneration: 31, capabilities: [] };
+    system.onDialLock(true); system.onPowerOff();
+    h.caps = { ...h.caps!, capabilities: ['dial_lock', 'power_control'] };
+    h.unavailable.add('dialLock');
+    system.onDialLock(true);
+    h.unavailable.clear();
+    h.state = { ...h.state!, dialLock: 'no' } as unknown as ServerState;
+    system.onDialLock(true);
+    system.onDialLock(1 as unknown as boolean);
+    expect(h.sendCommand).not.toHaveBeenCalled();
+    expect(getCommandLifecycles()).toHaveLength(0);
+
+    h.state = null;
+    system.onSpeak();
+    expect(exactCalls()).toEqual([['speak', { mode: 0 }]]);
+    expectIntentTransport();
+  });
+
+  it('rejects every invalid current or proposed scope domain and unavailable exact leaves', () => {
+    const scope = makeScopeControlsHandlers();
+    const calls = () => {
+      scope.onModeChange(4); scope.onEdgeChange(0); scope.onSpanChange(1.5);
+      scope.onSpeedChange(3); scope.onHoldChange(1 as unknown as boolean);
+      scope.onRefChange(-31); scope.onDualChange(1 as unknown as boolean);
+      scope.onReceiverChange(2); scope.onDuringTxChange('yes' as unknown as boolean);
+      scope.onCenterTypeChange(-1); scope.onVbwChange(0 as unknown as boolean); scope.onRbwChange(3);
+    };
+    calls();
+    h.state = { ...h.state!, scopeControls: { ...h.state!.scopeControls!, mode: 1.5 } } as ServerState;
+    scope.onModeChange(1);
+    h.unavailable.add('scopeControls.span');
+    scope.onSpanChange(4);
+    expect(h.sendCommand).not.toHaveBeenCalled();
+    expect(getCommandLifecycles()).toHaveLength(0);
+  });
+
+  it('requires generation-bound agreed hardware scope and exact physical SUB evidence', () => {
+    const scope = makeScopeControlsHandlers();
+    h.caps = { ...h.caps!, providerGeneration: 99 };
+    scope.onSpanChange(4);
+    h.caps = { ...h.caps!, providerGeneration: 31, scope: false };
+    scope.onHoldChange(true);
+    h.caps = { ...h.caps!, scope: true, capabilities: ['dual_rx'] };
+    scope.onRbwChange(2);
+
+    h.state = oneReceiverAbState();
+    h.state = { ...h.state, providerGeneration: 31, scopeControls: {
+      mode: 1, edge: 2, span: 3, speed: 1, hold: false, refDb: -5,
+      dual: false, receiver: 0, duringTx: false, centerType: 1, vbwNarrow: false,
+      rbw: 1, fixedEdge: { rangeIndex: 0, edge: 1, startHz: 1, endHz: 2 },
+    } } as ServerState;
+    h.caps = { ...h.caps!, capabilities: ['scope'], receivers: 1, vfoScheme: 'ab' };
+    scope.onReceiverChange(0);
+    scope.onReceiverChange(1);
+    scope.onDualChange(true);
+    expect(exactCalls()).toEqual([['switch_scope_receiver', { receiver: 0 }]]);
+    expectIntentTransport();
   });
 });

--- a/frontend/src/lib/runtime/commands/panel-commands.ts
+++ b/frontend/src/lib/runtime/commands/panel-commands.ts
@@ -1,9 +1,9 @@
 /**
  * Runtime command handler factories for panel controls.
  *
- * This module duplicates the relevant `make*Handlers` factories from
- * `components-v2/wiring/command-bus` so that `lib/runtime/adapters` can
- * import them without creating a `lib/runtime` → `components-v2` dependency.
+ * This module canonically owns the panel command factories. The legacy
+ * `components-v2/wiring/command-bus` is an identity-preserving compatibility
+ * re-export only.
  *
  * Do NOT import from `components-v2/*` here.  Pure filter helpers are
  * inlined below (originate from `components-v2/panels/filter-controls`)
@@ -12,11 +12,9 @@
  * See issue #999, parent #959 (M-4).
  */
 
-import { sendCommand } from '$lib/transport/ws-client';
 import {
   getActiveReceiver,
   getRadioState,
-  patchRadioState,
 } from '$lib/stores/radio.svelte';
 import {
   capabilitiesMatchGeneration,
@@ -30,25 +28,12 @@ import { getModeFilter } from '$lib/radio/mode-filter-memory';
 import { modInputCommand, modInputStateKey } from '$lib/radio/mod-input';
 import { nbDepthDisplayToRaw, nrDisplayToRaw } from '$lib/radio/filter-controls';
 import { audioManager } from '$lib/audio/audio-manager';
-import { getTuningStep } from '$lib/stores/tuning.svelte';
-import { dispatchRadioIntent, isNormalizedLevel, type RadioIntent } from './radio-intents';
+import { adjustTuningStep, getTuningStep } from '$lib/stores/tuning.svelte';
+import { dispatchRadioIntent, isNormalizedLevel } from './radio-intents';
 
 /* ── Shared helpers ──────────────────────────────────────────────── */
 
 type Receiver = 0 | 1;
-
-const A03A_INTENT_NAMES = new Set<RadioIntent['name']>([
-  'set_data_mode', 'set_data_off_mod_input', 'set_data1_mod_input', 'set_data2_mod_input', 'set_data3_mod_input', 'set_filter', 'set_filter_shape',
-  'set_filter_width', 'set_if_shift', 'set_pbt_inner', 'set_pbt_outer',
-]);
-
-function cmd(name: string, params: Record<string, unknown> = {}): void {
-  if (A03A_INTENT_NAMES.has(name as RadioIntent['name'])) {
-    dispatchRadioIntent({ name, params } as RadioIntent);
-    return;
-  }
-  sendCommand(name, params);
-}
 
 function knownActiveReceiver(field?: string, target?: 'MAIN' | 'SUB'): Receiver | null {
   const state = getRadioState();
@@ -220,7 +205,7 @@ export function makeModeHandlers() {
     onDataModeChange: (mode: number) => {
       const receiver = knownActiveReceiver('dataMode');
       if (receiver === null) return;
-      cmd('set_data_mode', { mode, receiver });
+      dispatchRadioIntent({ name: 'set_data_mode', params: { mode, receiver } });
     },
     onModInputChange: (source: number) => {
       // MOR-616: route the new source to the active receiver's DATA group
@@ -236,7 +221,7 @@ export function makeModeHandlers() {
         || (dataMode as number) > 3
         || !isFieldAvailable(state, modInputStateKey(dataMode as number))
       ) return;
-      cmd(modInputCommand(dataMode as number), { source });
+      dispatchRadioIntent({ name: modInputCommand(dataMode as number), params: { source } });
     },
   };
 }
@@ -652,7 +637,7 @@ export function makeFilterHandlers() {
     onFilterChange: (filter: number) => {
       const receiver = knownActiveReceiver('filter');
       if (receiver === null) return;
-      cmd('set_filter', { filter, receiver });
+      dispatchRadioIntent({ name: 'set_filter', params: { filter, receiver } });
     },
     onFilterWidthChange: (() => {
       let timer: ReturnType<typeof setTimeout> | null = null;
@@ -662,14 +647,14 @@ export function makeFilterHandlers() {
         timer = setTimeout(() => {
           timer = null;
           const receiver = knownActiveReceiver('filterWidth');
-          if (receiver !== null) cmd('set_filter_width', { width, receiver });
+          if (receiver !== null) dispatchRadioIntent({ name: 'set_filter_width', params: { width, receiver } });
         }, 200);
       };
     })(),
     onFilterShapeChange: (shape: number) => {
       const receiver = knownActiveReceiver('filterShape');
       if (receiver === null) return;
-      cmd('set_filter_shape', { shape, receiver });
+      dispatchRadioIntent({ name: 'set_filter_shape', params: { shape, receiver } });
     },
     onFilterPresetChange: (() => {
       let timer: ReturnType<typeof setTimeout> | null = null;
@@ -684,11 +669,11 @@ export function makeFilterHandlers() {
           const currentActive = currentReceiver === null ? null : getActiveReceiver()?.filter;
           if (currentReceiver === null || !Number.isSafeInteger(currentActive)) return;
           if (filter !== currentActive) {
-            cmd('set_filter', { filter, receiver: currentReceiver });
+            dispatchRadioIntent({ name: 'set_filter', params: { filter, receiver: currentReceiver } });
           }
-          cmd('set_filter_width', { width, receiver: currentReceiver });
+          dispatchRadioIntent({ name: 'set_filter_width', params: { width, receiver: currentReceiver } });
           if (filter !== currentActive) {
-            cmd('set_filter', { filter: currentActive as number, receiver: currentReceiver });
+            dispatchRadioIntent({ name: 'set_filter', params: { filter: currentActive as number, receiver: currentReceiver } });
           }
         }, 200);
       };
@@ -700,12 +685,12 @@ export function makeFilterHandlers() {
       for (let i = 0; i < defaults.length; i++) {
         const filter = i + 1;
         if (filter !== activeFilter) {
-          cmd('set_filter', { filter, receiver });
+          dispatchRadioIntent({ name: 'set_filter', params: { filter, receiver } });
         }
-        cmd('set_filter_width', { width: defaults[i], receiver });
+        dispatchRadioIntent({ name: 'set_filter_width', params: { width: defaults[i], receiver } });
       }
       if ((activeFilter as number) <= defaults.length) {
-        cmd('set_filter', { filter: activeFilter as number, receiver });
+        dispatchRadioIntent({ name: 'set_filter', params: { filter: activeFilter as number, receiver } });
       }
     },
     onIfShiftChange: (value: number) => {
@@ -713,7 +698,7 @@ export function makeFilterHandlers() {
       if (!caps) return;
       if (caps.capabilities.includes('if_shift')) {
         const receiver = knownActiveReceiver('ifShift');
-        if (receiver !== null) cmd('set_if_shift', { offset: value, receiver });
+        if (receiver !== null) dispatchRadioIntent({ name: 'set_if_shift', params: { offset: value, receiver } });
       } else if (caps.capabilities.includes('pbt')) {
         const receiver = knownActiveReceiver('pbtInner');
         const state = getRadioState();
@@ -731,19 +716,19 @@ export function makeFilterHandlers() {
           activeRx.pbtInner,
           activeRx.pbtOuter,
         );
-        cmd('set_pbt_inner', { value: pbtHzToRaw(pbtInner), receiver });
-        cmd('set_pbt_outer', { value: pbtHzToRaw(pbtOuter), receiver });
+        dispatchRadioIntent({ name: 'set_pbt_inner', params: { value: pbtHzToRaw(pbtInner), receiver } });
+        dispatchRadioIntent({ name: 'set_pbt_outer', params: { value: pbtHzToRaw(pbtOuter), receiver } });
       }
     },
     onPbtInnerChange: (value: number) => {
       const receiver = knownActiveReceiver('pbtInner');
       if (receiver === null) return;
-      cmd('set_pbt_inner', { value: pbtHzToRaw(value), receiver });
+      dispatchRadioIntent({ name: 'set_pbt_inner', params: { value: pbtHzToRaw(value), receiver } });
     },
     onPbtOuterChange: (value: number) => {
       const receiver = knownActiveReceiver('pbtOuter');
       if (receiver === null) return;
-      cmd('set_pbt_outer', { value: pbtHzToRaw(value), receiver });
+      dispatchRadioIntent({ name: 'set_pbt_outer', params: { value: pbtHzToRaw(value), receiver } });
     },
     onPbtReset: () => {
       const receiver = knownActiveReceiver('pbtInner');
@@ -751,8 +736,8 @@ export function makeFilterHandlers() {
       const prefix = receiver === 1 ? 'sub' : 'main';
       if (receiver === null || !state || !isFieldAvailable(state, `${prefix}.pbtOuter`)) return;
       const center = pbtHzToRaw(0);
-      cmd('set_pbt_inner', { value: center, receiver });
-      cmd('set_pbt_outer', { value: center, receiver });
+      dispatchRadioIntent({ name: 'set_pbt_inner', params: { value: center, receiver } });
+      dispatchRadioIntent({ name: 'set_pbt_outer', params: { value: center, receiver } });
     },
   };
 }
@@ -979,6 +964,121 @@ export function makeVfoHandlers() {
   };
 }
 
+/* ── System / scope handlers ─────────────────────────────────────── */
+
+function currentScopeContext() {
+  const context = currentA03cContext();
+  return context && context.caps.scope === true && context.caps.capabilities.includes('scope')
+    ? context : null;
+}
+
+function validScopeValue(value: unknown, kind: 'boolean' | 'integer', min = 0, max = 0): boolean {
+  return kind === 'boolean' ? typeof value === 'boolean'
+    : Number.isSafeInteger(value) && (value as number) >= min && (value as number) <= max;
+}
+
+function acceptsScopeValue(
+  context: NonNullable<ReturnType<typeof currentScopeContext>>,
+  field: string,
+  proposed: unknown,
+  kind: 'boolean' | 'integer',
+  min = 0,
+  max = 0,
+): boolean {
+  const current = (context.state.scopeControls as unknown as Record<string, unknown> | undefined)?.[field];
+  return isFieldAvailable(context.state, `scopeControls.${field}`)
+    && validScopeValue(current, kind, min, max) && validScopeValue(proposed, kind, min, max);
+}
+
+function hasPhysicalSub(context: NonNullable<ReturnType<typeof currentScopeContext>>): boolean {
+  return context.caps.receivers === 2 && context.caps.capabilities.includes('dual_rx')
+    && context.state.sub !== null && context.state.sub !== undefined;
+}
+
+export function makeSystemHandlers() {
+  return {
+    onDialLock: (on: boolean) => {
+      const context = currentA03cContext();
+      if (!context || !context.caps.capabilities.includes('dial_lock')
+        || !knownA03cTopLevelField(context, 'dialLock')
+        || typeof context.state.dialLock !== 'boolean' || typeof on !== 'boolean') return;
+      dispatchRadioIntent({ name: 'set_dial_lock', params: { on } });
+    },
+    onPowerOff: () => {
+      const context = currentA03cContext();
+      if (!context || !context.caps.capabilities.includes('power_control')) return;
+      dispatchRadioIntent({ name: 'set_powerstat', params: { on: false } });
+    },
+    onSpeak: () => dispatchRadioIntent({ name: 'speak', params: { mode: 0 } }),
+  };
+}
+
+export function makeScopeControlsHandlers() {
+  return {
+    onModeChange: (mode: number) => {
+      const context = currentScopeContext();
+      if (!context || !acceptsScopeValue(context, 'mode', mode, 'integer', 0, 3)) return;
+      dispatchRadioIntent({ name: 'set_scope_mode', params: { mode } });
+    },
+    onEdgeChange: (edge: number) => {
+      const context = currentScopeContext();
+      if (!context || !acceptsScopeValue(context, 'edge', edge, 'integer', 1, 4)) return;
+      dispatchRadioIntent({ name: 'set_scope_edge', params: { edge } });
+    },
+    onSpanChange: (span: number) => {
+      const context = currentScopeContext();
+      if (!context || !acceptsScopeValue(context, 'span', span, 'integer', 0, 7)) return;
+      dispatchRadioIntent({ name: 'set_scope_span', params: { span } });
+    },
+    onSpeedChange: (speed: number) => {
+      const context = currentScopeContext();
+      if (!context || !acceptsScopeValue(context, 'speed', speed, 'integer', 0, 2)) return;
+      dispatchRadioIntent({ name: 'set_scope_speed', params: { speed } });
+    },
+    onHoldChange: (on: boolean) => {
+      const context = currentScopeContext();
+      if (!context || !acceptsScopeValue(context, 'hold', on, 'boolean')) return;
+      dispatchRadioIntent({ name: 'set_scope_hold', params: { on } });
+    },
+    onRefChange: (ref: number) => {
+      const context = currentScopeContext();
+      if (!context || !acceptsScopeValue(context, 'refDb', ref, 'integer', -30, 10)) return;
+      dispatchRadioIntent({ name: 'set_scope_ref', params: { ref } });
+    },
+    onDualChange: (dual: boolean) => {
+      const context = currentScopeContext();
+      if (!context || !hasPhysicalSub(context) || !acceptsScopeValue(context, 'dual', dual, 'boolean')) return;
+      dispatchRadioIntent({ name: 'set_scope_dual', params: { dual } });
+    },
+    onReceiverChange: (receiver: number) => {
+      const context = currentScopeContext();
+      if (!context || !acceptsScopeValue(context, 'receiver', receiver, 'integer', 0, 1)
+        || (receiver === 1 && !hasPhysicalSub(context))) return;
+      dispatchRadioIntent({ name: 'switch_scope_receiver', params: { receiver: receiver as Receiver } });
+    },
+    onDuringTxChange: (on: boolean) => {
+      const context = currentScopeContext();
+      if (!context || !acceptsScopeValue(context, 'duringTx', on, 'boolean')) return;
+      dispatchRadioIntent({ name: 'set_scope_during_tx', params: { on } });
+    },
+    onCenterTypeChange: (center_type: number) => {
+      const context = currentScopeContext();
+      if (!context || !acceptsScopeValue(context, 'centerType', center_type, 'integer', 0, 2)) return;
+      dispatchRadioIntent({ name: 'set_scope_center_type', params: { center_type } });
+    },
+    onVbwChange: (narrow: boolean) => {
+      const context = currentScopeContext();
+      if (!context || !acceptsScopeValue(context, 'vbwNarrow', narrow, 'boolean')) return;
+      dispatchRadioIntent({ name: 'set_scope_vbw', params: { narrow } });
+    },
+    onRbwChange: (rbw: number) => {
+      const context = currentScopeContext();
+      if (!context || !acceptsScopeValue(context, 'rbw', rbw, 'integer', 0, 2)) return;
+      dispatchRadioIntent({ name: 'set_scope_rbw', params: { rbw } });
+    },
+  };
+}
+
 /* ── Keyboard radio delegation (MOR-1409 A03d1a) ─────────────────── */
 
 type KeyboardRadioAction = { action: string; params?: Record<string, unknown> };
@@ -1189,7 +1289,7 @@ export function dispatchKeyboardRadioAction({ action, params }: KeyboardRadioAct
     case 'toggle_dial_lock': {
       const dialLock = context.state.dialLock;
       if (has('dial_lock') && knownA03cTopLevelField(context, 'dialLock') && typeof dialLock === 'boolean') {
-        dispatchRadioIntent({ name: 'set_dial_lock', params: { on: !dialLock } });
+        makeSystemHandlers().onDialLock(!dialLock);
       }
       return true;
     }
@@ -1197,7 +1297,7 @@ export function dispatchKeyboardRadioAction({ action, params }: KeyboardRadioAct
       const current = keyboardScopeField(context, 'span');
       const direction = keyboardDirection(safeParams.direction);
       if (context.caps.scope === true && has('scope') && direction && typeof current === 'number' && Number.isSafeInteger(current) && current >= 0 && current <= 7) {
-        dispatchRadioIntent({ name: 'set_scope_span', params: { span: Math.max(0, Math.min(7, current + (direction === 'down' ? -1 : 1))) } });
+        makeScopeControlsHandlers().onSpanChange(Math.max(0, Math.min(7, current + (direction === 'down' ? -1 : 1))));
       }
       return true;
     }
@@ -1205,14 +1305,14 @@ export function dispatchKeyboardRadioAction({ action, params }: KeyboardRadioAct
       const current = keyboardScopeField(context, 'refDb');
       const direction = keyboardDirection(safeParams.direction);
       if (context.caps.scope === true && has('scope') && direction && typeof current === 'number' && Number.isSafeInteger(current) && current >= -30 && current <= 10) {
-        dispatchRadioIntent({ name: 'set_scope_ref', params: { ref: Math.max(-30, Math.min(10, current + (direction === 'down' ? -5 : 5))) } });
+        makeScopeControlsHandlers().onRefChange(Math.max(-30, Math.min(10, current + (direction === 'down' ? -5 : 5))));
       }
       return true;
     }
     case 'scope_toggle_hold': {
       const hold = keyboardScopeField(context, 'hold');
       if (context.caps.scope === true && has('scope') && typeof hold === 'boolean') {
-        dispatchRadioIntent({ name: 'set_scope_hold', params: { on: !hold } });
+        makeScopeControlsHandlers().onHoldChange(!hold);
       }
       return true;
     }
@@ -1220,20 +1320,63 @@ export function dispatchKeyboardRadioAction({ action, params }: KeyboardRadioAct
       const dual = keyboardScopeField(context, 'dual');
       if (context.caps.scope === true && has('scope') && context.caps.receivers === 2
         && has('dual_rx') && context.state.sub && typeof dual === 'boolean') {
-        dispatchRadioIntent({ name: 'set_scope_dual', params: { dual: !dual } });
+        makeScopeControlsHandlers().onDualChange(!dual);
       }
       return true;
     }
     case 'scope_toggle_fst': {
       const speed = keyboardScopeField(context, 'speed');
       if (context.caps.scope === true && has('scope') && typeof speed === 'number' && Number.isSafeInteger(speed) && speed >= 0 && speed <= 2) {
-        dispatchRadioIntent({ name: 'set_scope_speed', params: { speed: speed === 0 ? 1 : 0 } });
+        makeScopeControlsHandlers().onSpeedChange(speed === 0 ? 1 : 0);
       }
       return true;
     }
     default:
       return true;
   }
+}
+
+export function makeKeyboardHandlers() {
+  return {
+    dispatch<T extends KeyboardRadioAction>(action: T): void {
+      if (dispatchKeyboardRadioAction(action)) return;
+      switch (action.action) {
+        case 'adjust_tuning_step': {
+          adjustTuningStep(action.params?.direction === 'down' ? 'down' : 'up');
+          return;
+        }
+        case 'open_filter_settings': {
+          window.dispatchEvent(new CustomEvent('rigplane:open-filter-settings'));
+          return;
+        }
+        case 'focus_target': {
+          const target = action.params?.target;
+          if (typeof target === 'string') {
+            const selectors: Record<string, string> = {
+              af: '[data-panel="rf-frontend"] [data-control="af-gain"]',
+              rf:
+                '[data-panel="rf-frontend"] [data-control="rf-sql-dual"], [data-panel="rf-frontend"] [data-control="rf-gain"]',
+              filter: '[data-panel="filter"]',
+              squelch:
+                '[data-panel="rf-frontend"] [data-control="rf-sql-dual"], [data-panel="rf-frontend"] [data-control="squelch"]',
+              mode: '[data-panel="mode"]',
+              pbt: '[data-panel="filter"] [data-control="pbt-inner"]',
+              waterfall: '[data-waterfall]',
+              vfo: '[data-vfo="main"] .freq-display',
+            };
+            const el = document.querySelector(selectors[target] ?? `[data-panel="${target}"]`);
+            if (el instanceof HTMLElement) {
+              el.focus();
+              el.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+            }
+          }
+          return;
+        }
+        default:
+          console.warn('[keyboard] unhandled action', action.action, action.params);
+      }
+    },
+  };
 }
 
 /* ── VOX Handlers ────────────────────────────────────────────────── */


### PR DESCRIPTION
Part of #2317.

## Scope

- makes `panel-commands.ts` the canonical owner for system, scope, and local keyboard factories
- reduces `command-bus.ts` to a documented named re-export compatibility surface
- removes the raw panel `sendCommand` fallback and the two local `meterSource` residue lines
- preserves generation/capability/availability fail-closed dispatch and non-optimistic state ownership

## Evidence

- exact base: `7a2bd89bacc173c6a5fa5acf6a7399ae8b43c38d`
- RED commit: `2d680f1d2eeb09c7d5b51aefbbbd9e4166dbaead` (2 intended failures)
- candidate head: `7088e148`
- production semantic churn: 333 lines across exactly 3 allowed owners
- focused/frozen frontend: 47 files, 824 tests passed
- full frontend: 299 files, 6177 tests passed; check/lint/boundaries/i18n/build passed
- focused backend: 485 passed, 1 deselected
- full backend: 8993 passed, 12 skipped, 5 deselected, 11 xfailed, 1 xpassed
- ruff, formatting check, import contracts, strict web mypy, generated state, and consumer contracts passed
- all 16 independent mutation classes were killed and restored cleanly
- no formatter or fix-mode command was invoked
- durable build report: `/private/tmp/build-mor1409-a03e-restart.md`, SHA-256 `91b6c0f0db5ae99894787464702fb0c008d9dc7d5ab579495d7819c09ecf013a`

Frozen addenda/corrections: [1](https://github.com/rigplane/rigplane-core/issues/2317#issuecomment-5228981582), [2](https://github.com/rigplane/rigplane-core/issues/2317#issuecomment-5230424844), [3](https://github.com/rigplane/rigplane-core/issues/2317#issuecomment-5230879753), [4](https://github.com/rigplane/rigplane-core/issues/2317#issuecomment-5231690407), [5](https://github.com/rigplane/rigplane-core/issues/2317#issuecomment-5232271163), [6](https://github.com/rigplane/rigplane-core/issues/2317#issuecomment-5232389953).

No hardware validation was required for this ownership-only slice. Auto-merge remains off.
