### PR TITLE
refactor(#2317): bind semantic surface commands

### DIFF
--- a/frontend/fixtures/capture.mjs
+++ b/frontend/fixtures/capture.mjs
@@ -509,6 +509,7 @@ const manifest = {
       '$lib/runtime',
       '$lib/runtime/tx-controller/app-host',
       '$lib/runtime/adapters/mod-input-tx-guard.svelte',
+      '$lib/runtime/adapters/panel-adapters',
       'components-v2/wiring/command-bus',
     ],
     productionFilesChanged: 0,
@@ -516,7 +517,7 @@ const manifest = {
   intentionalDifferences: [
     'The cockpit is mounted DIRECTLY (fixtures/main.ts) — resolveSkinId() has no '
     + 'cockpit branch on this commit, so no navigation path can produce these views.',
-    'Four live seams are stubbed (see harness.stubbedSeams); every other module in the '
+    'Five live seams are stubbed (see harness.stubbedSeams); every other module in the '
     + 'render path — adapter, capability derivation, semantic surfaces, i18n, CSS — is shipped code.',
     'Screenshots are taken with Playwright `animations: "disabled"` and `caret: "hide"` for '
     + 'determinism. The cockpit declares no animation of its own; the only transition in the '

--- a/frontend/fixtures/capture.mjs
+++ b/frontend/fixtures/capture.mjs
@@ -38,7 +38,11 @@ const PORT = Number(arg('--port', '5199'));
 // The page console cannot observe Vite's dependency scanner or transform
 // errors. Build this exact additive config first so any server-side failure is
 // terminal rather than allowing a visually valid capture to escape.
-await build({ configFile: path.join(FRONTEND, 'vite.fixtures.config.ts'), logLevel: 'error' });
+await build({
+  root: FRONTEND,
+  configFile: path.join(FRONTEND, 'vite.fixtures.config.ts'),
+  logLevel: 'error',
+});
 
 /* ── viewports ─────────────────────────────────────────────────────────── */
 const VIEWPORTS = {

--- a/frontend/fixtures/capture.mjs
+++ b/frontend/fixtures/capture.mjs
@@ -17,7 +17,7 @@ import { execFileSync } from 'node:child_process';
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { chromium } from '@playwright/test';
-import { createServer } from 'vite';
+import { build, createServer } from 'vite';
 
 const FRONTEND = path.resolve(import.meta.dirname, '..');
 const REPO = path.resolve(FRONTEND, '..');
@@ -34,6 +34,11 @@ const ONLY = arg('--only', null);
 // parallel run pick its own port without touching the single-port default any
 // script or doc already assumes.
 const PORT = Number(arg('--port', '5199'));
+
+// The page console cannot observe Vite's dependency scanner or transform
+// errors. Build this exact additive config first so any server-side failure is
+// terminal rather than allowing a visually valid capture to escape.
+await build({ configFile: path.join(FRONTEND, 'vite.fixtures.config.ts'), logLevel: 'error' });
 
 /* ── viewports ─────────────────────────────────────────────────────────── */
 const VIEWPORTS = {

--- a/frontend/fixtures/capture.mjs
+++ b/frontend/fixtures/capture.mjs
@@ -9,6 +9,7 @@
  * differences.
  *
  *   node fixtures/capture.mjs [--out <dir>] [--only <substring>]
+ *   node fixtures/capture.mjs --preflight-only
  *
  * The server is always closed, including on failure.
  */
@@ -34,6 +35,7 @@ const ONLY = arg('--only', null);
 // parallel run pick its own port without touching the single-port default any
 // script or doc already assumes.
 const PORT = Number(arg('--port', '5199'));
+const PREFLIGHT_ONLY = argv.includes('--preflight-only');
 
 // The page console cannot observe Vite's dependency scanner or transform
 // errors. Build this exact additive config first so any server-side failure is
@@ -43,6 +45,11 @@ await build({
   configFile: path.join(FRONTEND, 'vite.fixtures.config.ts'),
   logLevel: 'error',
 });
+
+if (PREFLIGHT_ONLY) {
+  console.log('PASS fixture build preflight');
+  process.exit(0);
+}
 
 /* ── viewports ─────────────────────────────────────────────────────────── */
 const VIEWPORTS = {

--- a/frontend/fixtures/stubs/panel-adapters.ts
+++ b/frontend/fixtures/stubs/panel-adapters.ts
@@ -1,0 +1,17 @@
+/** Verification-only semantic command binder: records through the existing fixture bus stub. */
+import {
+  makeAgcHandlers, makeAntennaHandlers, makeAudioRoutingHandlers, makeBandHandlers,
+  makeCwPanelHandlers, makeDspHandlers, makeFilterHandlers, makeModeHandlers,
+  makeRfFrontEndHandlers, makeRitXitHandlers, makeRxAudioHandlers, makeScanHandlers,
+  makeScopeControlsHandlers, makeTxHandlers, makeVfoHandlers, makeVoxHandlers,
+} from './command-bus';
+
+export function bindSemanticSurfaceHandlers() {
+  return Object.freeze({
+    agc: makeAgcHandlers(), antenna: makeAntennaHandlers(), audioRouting: makeAudioRoutingHandlers(),
+    band: makeBandHandlers(), cw: makeCwPanelHandlers(), dsp: makeDspHandlers(),
+    filter: makeFilterHandlers(), mode: makeModeHandlers(), rfFrontEnd: makeRfFrontEndHandlers(),
+    ritXit: makeRitXitHandlers(), rxAudio: makeRxAudioHandlers(), scan: makeScanHandlers(),
+    scopeControls: makeScopeControlsHandlers(), tx: makeTxHandlers(), vfo: makeVfoHandlers(), vox: makeVoxHandlers(),
+  });
+}

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -26,6 +26,7 @@
   import { runtime } from '$lib/runtime';
   import { toRadioViewModel } from '$lib/runtime/adapters/radio-view-model-adapter';
   import { getAppTxController } from '$lib/runtime/tx-controller/app-host';
+  import { bindSemanticSurfaceHandlers } from '$lib/runtime/adapters/panel-adapters';
   import type { SemanticSurfaceName } from '../../presentation/layouts/contract';
   import {
     compositionSurfaces, useSurfacePlan, zoneShowsSurface,
@@ -56,12 +57,6 @@
   import ScopeControlsSurface, {
     type ScopeChoiceField, type ScopeToggleField,
   } from '../../semantic/ScopeControlsSurface.svelte';
-  import {
-    makeAgcHandlers, makeAntennaHandlers, makeAudioRoutingHandlers, makeBandHandlers,
-    makeCwPanelHandlers, makeDspHandlers, makeFilterHandlers, makeModeHandlers,
-    makeRfFrontEndHandlers, makeRitXitHandlers, makeRxAudioHandlers, makeScanHandlers,
-    makeScopeControlsHandlers, makeTxHandlers, makeVfoHandlers, makeVoxHandlers,
-  } from './command-bus';
   import {
     forReceiver, receiversOf, isActiveStrip, isOperationalStrip,
   } from './dual-receiver-strips';
@@ -151,18 +146,19 @@
       .filter(({ zoneId }) => zoneShows(zoneId, 'vfo'));
   }
 
-  const vfo = makeVfoHandlers();
+  const semanticHandlers = bindSemanticSurfaceHandlers();
+  const vfo = semanticHandlers.vfo;
   /** MOR-1307: the shipped band vocabulary, composed rather than forked. */
-  const band = makeBandHandlers();
+  const band = semanticHandlers.band;
   /**
    * MOR-1265. The two v2 handler factories already carry every txAux intent
    * (`makeVoxHandlers` owns gain/anti-VOX/delay, `makeTxHandlers` the rest);
    * composing them keeps ONE command vocabulary rather than a v3 fork of it.
    * The two maps below exist so the pure surface can stay field-addressed —
-   * agreement with the shipped command-bus names is pinned in
-   * `__tests__/tx-aux-command-bus.isolated.test.ts` against the REAL module.
+   * agreement with the shipped canonical handler names is pinned against the
+   * real command module.
    */
-  const txAuxIntents = { ...makeVoxHandlers(), ...makeTxHandlers() };
+  const txAuxIntents = { ...semanticHandlers.vox, ...semanticHandlers.tx };
   const TX_AUX_TOGGLE_INTENT: Record<TxAuxToggleField, () => void> = {
     atu: txAuxIntents.onAtuToggle, vox: txAuxIntents.onVoxToggle,
     compressor: txAuxIntents.onCompToggle, monitor: txAuxIntents.onMonToggle,
@@ -175,7 +171,7 @@
   };
   /**
    * MOR-1279. The RX-audio intent vocabulary, composed from the SHIPPED
-   * command bus rather than forked: monitor mode + AF level from
+   * canonical handlers rather than forked: monitor mode + AF level from
    * `makeRxAudioHandlers` (whose `onAfLevelChange` takes 0..1 — the contract's
    * own unit, so nothing rescales on the way out either), routing from
    * `makeAudioRoutingHandlers`, and the MOD-input remedy from
@@ -183,8 +179,8 @@
    * `ModInputTxWarning`'s "Set LAN" fires, so a mismatch has one fix, not two.
    * `ModInputTxWarning` itself is untouched and stays in the rx-tx zone.
    */
-  const rxAudioIntents = makeRxAudioHandlers();
-  const routingIntents = makeAudioRoutingHandlers();
+  const rxAudioIntents = semanticHandlers.rxAudio;
+  const routingIntents = semanticHandlers.audioRouting;
   /**
    * MOR-1309. The antenna intent vocabulary, composed from the SHIPPED command
    * bus rather than forked — `set_antenna_1`/`set_antenna_2`/the two RX-ANT
@@ -193,11 +189,11 @@
    * command-addressed; a port the bus cannot name is unreachable by
    * construction rather than by a silent no-op.
    */
-  const antennaIntents = makeAntennaHandlers();
+  const antennaIntents = semanticHandlers.antenna;
   const ANTENNA_PORT_INTENT: Record<number, () => void> = {
     1: antennaIntents.onSelectAnt1, 2: antennaIntents.onSelectAnt2,
   };
-  const setModInputLan = () => makeModeHandlers().onModInputChange(LAN_MOD_INPUT_SOURCE);
+  const setModInputLan = () => semanticHandlers.mode.onModInputChange(LAN_MOD_INPUT_SOURCE);
   /**
    * MOR-1304. `makeModeHandlers` owns mode/dataMode intents, `makeFilterHandlers`
    * the rest — the SAME v2 command vocabulary `FilterPanel` already dispatches
@@ -205,15 +201,15 @@
    * Unlike `txAuxIntents` above, `FilterSurface`'s props already match these
    * names 1:1, so no per-field `Record` indirection is needed.
    */
-  const filterIntents = { ...makeModeHandlers(), ...makeFilterHandlers() };
+  const filterIntents = { ...semanticHandlers.mode, ...semanticHandlers.filter };
   /**
    * MOR-1305. `makeDspHandlers`/`makeAgcHandlers` already carry every dsp
    * intent; the two maps below keep the pure surface field-addressed, same
    * precedent as `TX_AUX_*_INTENT` above — agreement with the shipped
-   * command-bus names is exercised against the REAL module in the component
+   * canonical handler names is exercised against the real module in the component
    * test, not re-asserted here.
    */
-  const dspIntents = makeDspHandlers();
+  const dspIntents = semanticHandlers.dsp;
   const DSP_TOGGLE_INTENT: Record<DspToggleField, (next: boolean) => void> = {
     nrActive: (next) => dspIntents.onNrModeChange(next ? 1 : 0),
     nbActive: (next) => dspIntents.onNbToggle(next),
@@ -224,7 +220,7 @@
     notchFreq: dspIntents.onNotchFreqChange, manualNotchWidth: dspIntents.onManualNotchWidthChange,
     agcTimeConstant: dspIntents.onAgcTimeChange,
   };
-  const agcIntents = makeAgcHandlers();
+  const agcIntents = semanticHandlers.agc;
   /**
    * `agcLabels`/`nbLevelMax`/`nbLevelPercent` are pure caps-echo display
    * metadata, NOT `dsp` facts (MOR-1290/MOR-1305 carry-forward 1) — read
@@ -243,7 +239,7 @@
    * `onLevelChange` onto the two real level handlers, mirroring
    * `TX_AUX_LEVEL_INTENT`.
    */
-  const rfFrontEndIntents = makeRfFrontEndHandlers();
+  const rfFrontEndIntents = semanticHandlers.rfFrontEnd;
   const RF_FRONT_END_LEVEL_INTENT: Record<RfFrontEndLevelField, (value: number) => void> = {
     rfGain: rfFrontEndIntents.onRfGainChange, squelch: rfFrontEndIntents.onSquelchChange,
   };
@@ -257,8 +253,8 @@
    * handlers write `ritFreq` via the same `set_rit_frequency` command); this
    * wiring adds no re-derivation, only 1:1 plumbing.
    */
-  const ritXitIntents = makeRitXitHandlers();
-  const scanIntents = makeScanHandlers();
+  const ritXitIntents = semanticHandlers.ritXit;
+  const scanIntents = semanticHandlers.scan;
   /**
    * MOR-1310 (slice 9B). The CW intent vocabulary, composed from the SHIPPED
    * `makeCwPanelHandlers` rather than forked. `onAutoTune` is deliberately NOT
@@ -266,7 +262,7 @@
    * control for it (MOR-1244 ATU-TUNE precedent). Nothing here keys — exactly
    * one `<RxTxSurface>` stays the key/unkey authority (decomposition R9).
    */
-  const cwIntents = makeCwPanelHandlers();
+  const cwIntents = semanticHandlers.cw;
   const CW_LEVEL_INTENT: Record<CwLevelField, (value: number) => void> = {
     keyerSpeed: cwIntents.onKeySpeedChange, pitchHz: cwIntents.onCwPitchChange,
     breakInDelay: cwIntents.onBreakInDelayChange,
@@ -277,7 +273,7 @@
    * maps keep the pure surface field-addressed, same precedent as
    * `TX_AUX_*_INTENT`/`DSP_*_INTENT` above.
    */
-  const scopeIntents = makeScopeControlsHandlers();
+  const scopeIntents = semanticHandlers.scopeControls;
   const SCOPE_TOGGLE_INTENT: Record<ScopeToggleField, (next: boolean) => void> = {
     hold: scopeIntents.onHoldChange, dual: scopeIntents.onDualChange,
     duringTx: scopeIntents.onDuringTxChange, vbwNarrow: scopeIntents.onVbwChange,
@@ -408,7 +404,7 @@
 
   /**
    * MOR-1322 (S3b) — per-digit tuning, routed to the SAME per-receiver
-   * command-bus handlers the legacy VfoHeader used (`onMainFreqChange` /
+   * canonical VFO handlers the legacy VfoHeader used (`onMainFreqChange` /
    * `onSubFreqChange`), which own the optimistic patch and the `set_freq`
    * command. No new key path and no TX semantics (R9): this moves a frequency,
    * it never keys the transmitter.

--- a/frontend/src/components-v2/wiring/__tests__/fixture-adapter-command-seam.isolated.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/fixture-adapter-command-seam.isolated.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const config = readFileSync('vite.fixtures.config.ts', 'utf8');
+const stub = readFileSync('fixtures/stubs/panel-adapters.ts', 'utf8');
+
+describe('fixture semantic command seam (MOR-1409 A04a)', () => {
+  it('intercepts the adapter binder and records every canonical semantic family', () => {
+    expect(config).toContain("'src/lib/runtime/adapters/panel-adapters.ts': 'fixtures/stubs/panel-adapters.ts'");
+    expect(stub).toContain('bindSemanticSurfaceHandlers');
+    for (const family of ['agc', 'antenna', 'audioRouting', 'band', 'cw', 'dsp', 'filter', 'mode', 'rfFrontEnd', 'ritXit', 'rxAudio', 'scan', 'scopeControls', 'tx', 'vfo', 'vox']) {
+      expect(stub).toContain(`${family}:`);
+    }
+  });
+});

--- a/frontend/src/components-v2/wiring/__tests__/fixture-capture-root-cwd.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/fixture-capture-root-cwd.test.ts
@@ -4,13 +4,13 @@ import { describe, expect, it } from 'vitest';
 
 describe('fixture capture repository-root invocation (MOR-1409 A04a)', () => {
   it('anchors its Vite preflight at the frontend app root', () => {
-    const repoRoot = resolve(process.cwd(), '..');
+    const repoRoot = resolve(import.meta.dirname, '../../../../..');
     const output = execFileSync(
       process.execPath,
-      ['frontend/fixtures/capture.mjs', '--only', 'keyboard-activation-vfo-split', '--port', '5211'],
+      ['frontend/fixtures/capture.mjs', '--preflight-only'],
       { cwd: repoRoot, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
     );
 
-    expect(output).toContain('PASS  keyboard-activation-vfo-split--desktop  (34/34 assertions)');
-  }, 30_000);
+    expect(output).toContain('PASS fixture build preflight');
+  }, 15_000);
 });

--- a/frontend/src/components-v2/wiring/__tests__/fixture-capture-root-cwd.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/fixture-capture-root-cwd.test.ts
@@ -1,0 +1,16 @@
+import { execFileSync } from 'node:child_process';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('fixture capture repository-root invocation (MOR-1409 A04a)', () => {
+  it('anchors its Vite preflight at the frontend app root', () => {
+    const repoRoot = resolve(process.cwd(), '..');
+    const output = execFileSync(
+      process.execPath,
+      ['frontend/fixtures/capture.mjs', '--only', 'keyboard-activation-vfo-split', '--port', '5211'],
+      { cwd: repoRoot, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+    );
+
+    expect(output).toContain('PASS  keyboard-activation-vfo-split--desktop  (34/34 assertions)');
+  }, 30_000);
+});

--- a/frontend/src/components-v2/wiring/__tests__/semantic-dsp-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-dsp-wiring.component.test.ts
@@ -83,8 +83,8 @@ vi.mock('$lib/runtime/adapters/mod-input-tx-guard.svelte', () => ({
 // The names below are the REAL `makeDspHandlers`/`makeAgcHandlers` surface —
 // agreement with the shipped module is proven separately, against the real
 // module, in `command-bus.test.ts`.
-vi.mock('../command-bus', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../command-bus')>();
+vi.mock('$lib/runtime/commands/panel-commands', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('$lib/runtime/commands/panel-commands')>();
   return {
     ...actual,
     makeVfoHandlers: () => ({

--- a/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
@@ -76,8 +76,8 @@ vi.mock('$lib/runtime/adapters/mod-input-tx-guard.svelte', () => ({
   deriveModInputTxGuardProps: () => ({ visible: false, sourceLabel: null }),
   getModInputTxGuardHandlers: () => ({ onSetLan: vi.fn(), onDismiss: vi.fn() }),
 }));
-vi.mock('../command-bus', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../command-bus')>();
+vi.mock('$lib/runtime/commands/panel-commands', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('$lib/runtime/commands/panel-commands')>();
   return {
     ...actual,
     makeVfoHandlers: () => ({

--- a/frontend/src/components-v2/wiring/__tests__/semantic-rf-front-end-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rf-front-end-wiring.component.test.ts
@@ -93,8 +93,8 @@ vi.mock('$lib/runtime/adapters/mod-input-tx-guard.svelte', () => ({
 // The real module's names/arities are covered by `stub-export-parity.test.ts`
 // and by TypeScript; this file only proves ROUTING, mirroring
 // `semantic-tx-aux-wiring.component.test.ts`'s own wholesale mock.
-vi.mock('../command-bus', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../command-bus')>();
+vi.mock('$lib/runtime/commands/panel-commands', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('$lib/runtime/commands/panel-commands')>();
   return {
     ...actual,
     makeVfoHandlers: () => ({

--- a/frontend/src/components-v2/wiring/__tests__/semantic-rx-tx-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rx-tx-wiring.component.test.ts
@@ -100,8 +100,8 @@ vi.mock('$lib/runtime/adapters/mod-input-tx-guard.svelte', () => ({
   deriveModInputTxGuardProps: () => h.modInputGuard,
   getModInputTxGuardHandlers: () => ({ onSetLan: h.setLan, onDismiss: h.dismissWarning }),
 }));
-vi.mock('../command-bus', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../command-bus')>();
+vi.mock('$lib/runtime/commands/panel-commands', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('$lib/runtime/commands/panel-commands')>();
   return {
     ...actual,
     makeVfoHandlers: () => ({

--- a/frontend/src/components-v2/wiring/__tests__/semantic-scope-display-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-scope-display-wiring.component.test.ts
@@ -93,8 +93,8 @@ vi.mock('$lib/runtime/adapters/mod-input-tx-guard.svelte', () => ({
   deriveModInputTxGuardProps: () => ({ visible: false, sourceLabel: null }),
   getModInputTxGuardHandlers: () => ({ onSetLan: vi.fn(), onDismiss: vi.fn() }),
 }));
-vi.mock('../command-bus', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../command-bus')>();
+vi.mock('$lib/runtime/commands/panel-commands', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('$lib/runtime/commands/panel-commands')>();
   return {
     ...actual,
     makeVfoHandlers: () => ({

--- a/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
@@ -88,8 +88,8 @@ vi.mock('$lib/runtime/adapters/mod-input-tx-guard.svelte', () => ({
 // The names below are the REAL `makeTxHandlers`/`makeVoxHandlers` surface —
 // agreement with the shipped module is proven separately, against the real
 // module, in `tx-aux-command-bus.isolated.test.ts`.
-vi.mock('../command-bus', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../command-bus')>();
+vi.mock('$lib/runtime/commands/panel-commands', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('$lib/runtime/commands/panel-commands')>();
   return {
     ...actual,
     makeVfoHandlers: () => ({

--- a/frontend/src/lib/runtime/adapters/__tests__/semantic-surface-handler-binder.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/semantic-surface-handler-binder.isolated.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const factories = vi.hoisted(() => Object.fromEntries([
+  'makeAgcHandlers', 'makeAntennaHandlers', 'makeAudioRoutingHandlers',
+  'makeBandHandlers', 'makeCwPanelHandlers', 'makeDspHandlers',
+  'makeFilterHandlers', 'makeModeHandlers', 'makeRfFrontEndHandlers',
+  'makeRitXitHandlers', 'makeRxAudioHandlers', 'makeScanHandlers',
+  'makeScopeControlsHandlers', 'makeTxHandlers', 'makeVfoHandlers', 'makeVoxHandlers',
+].map((name) => [name, vi.fn(() => Object.freeze({ name }))])));
+const tuner = vi.hoisted(() => ({
+  state: { revision: 1 },
+  caps: { generation: 1 },
+  snapshot: Object.freeze({ phase: 'idle', radioTx: 'off' }) as Readonly<{ phase: string; radioTx: string }>,
+  view: { activeReceiver: 'MAIN' },
+  controller: null as unknown,
+}));
+
+vi.mock('$lib/runtime/commands/panel-commands', async (importOriginal) => ({
+  ...await importOriginal<typeof import('$lib/runtime/commands/panel-commands')>(),
+  ...factories,
+}));
+vi.mock('$lib/runtime/frontend-runtime', () => ({
+  runtime: {
+    get state() { return tuner.state; },
+    get caps() { return tuner.caps; },
+  },
+}));
+vi.mock('$lib/runtime/tx-controller/app-host', () => ({
+  getAppTxController: () => tuner.controller,
+}));
+vi.mock('$lib/runtime/adapters/radio-view-model-adapter', () => ({
+  toRadioViewModel: vi.fn(() => tuner.view),
+}));
+
+import { bindSemanticSurfaceHandlers, bindVfoTunerContext } from '../panel-adapters';
+
+const expected = {
+  agc: 'makeAgcHandlers', antenna: 'makeAntennaHandlers', audioRouting: 'makeAudioRoutingHandlers',
+  band: 'makeBandHandlers', cw: 'makeCwPanelHandlers', dsp: 'makeDspHandlers',
+  filter: 'makeFilterHandlers', mode: 'makeModeHandlers', rfFrontEnd: 'makeRfFrontEndHandlers',
+  ritXit: 'makeRitXitHandlers', rxAudio: 'makeRxAudioHandlers', scan: 'makeScanHandlers',
+  scopeControls: 'makeScopeControlsHandlers', tx: 'makeTxHandlers', vfo: 'makeVfoHandlers', vox: 'makeVoxHandlers',
+} as const;
+
+describe('semantic surface handler binder (MOR-1409 A04a)', () => {
+  it('creates every canonical family exactly once and retains each exact factory object', () => {
+    for (const factory of Object.values(factories)) vi.mocked(factory).mockClear();
+
+    const bound = bindSemanticSurfaceHandlers();
+
+    expect(Object.isFrozen(bound)).toBe(true);
+    for (const [family, factoryName] of Object.entries(expected)) {
+      const factory = vi.mocked(factories[factoryName]);
+      expect(factory).toHaveBeenCalledTimes(1);
+      expect(bound[family as keyof typeof bound]).toBe(factory.mock.results[0]!.value);
+    }
+  });
+
+  it('keeps the semantic root behind the adapter binder rather than a command facade', () => {
+    const source = readFileSync('src/components-v2/wiring/SemanticRadioSurfaces.svelte', 'utf8');
+    expect(source).toContain("from '$lib/runtime/adapters/panel-adapters';");
+    expect(source).not.toMatch(/from ['"][^'"]*(?:command-bus|panel-commands)['"]/);
+    expect(source).not.toMatch(/\b(?:dispatchRadioIntent|sendCommand)\b/);
+  });
+
+  it('binds a live read-only tuner context without leaking TX mutation authority', () => {
+    tuner.controller = { snapshot: vi.fn(() => tuner.snapshot) };
+    const context = bindVfoTunerContext();
+    const first = context.read();
+    tuner.snapshot = Object.freeze({ phase: 'fault', radioTx: 'unknown' });
+    const second = context.read();
+
+    expect(Object.isFrozen(context)).toBe(true);
+    expect(Object.isFrozen(first)).toBe(true);
+    expect(first.tx).not.toBe(second.tx);
+    expect(second.tx).toBe(tuner.snapshot);
+    expect(second.view).toBe(tuner.view);
+    for (const name of ['start', 'setIntent', 'release', 'resetFault']) {
+      expect(context).not.toHaveProperty(name);
+      expect(second).not.toHaveProperty(name);
+    }
+  });
+});

--- a/frontend/src/lib/runtime/adapters/panel-adapters.ts
+++ b/frontend/src/lib/runtime/adapters/panel-adapters.ts
@@ -21,8 +21,11 @@ import {
   makeRfFrontEndHandlers, makeRitXitHandlers, makeScanHandlers,
   makeCwPanelHandlers, makeDspHandlers,
   makeTxHandlers, makeFilterHandlers, makeBandHandlers,
-  makePresetHandlers,
+  makePresetHandlers, makeAudioRoutingHandlers, makeRxAudioHandlers,
+  makeVfoHandlers, makeScopeControlsHandlers, makeVoxHandlers,
 } from '../commands/panel-commands';
+import { toRadioViewModel } from './radio-view-model-adapter';
+import { getAppTxController, type AppTxController } from '../tx-controller/app-host';
 import {
   hasAudioFft, hasDualReceiver, hasCapability,
 } from '$lib/stores/capabilities.svelte';
@@ -118,6 +121,55 @@ const _bandHandlers = makeBandHandlers();
 export function getBandHandlers() { return _bandHandlers; }
 const _presetHandlers = makePresetHandlers();
 export function getPresetHandlers() { return _presetHandlers; }
+
+// ── A04 semantic composition bindings ──
+// This binder deliberately creates fresh family objects for each mounted
+// composition root: filter handlers retain per-instance debounce state.
+export function bindSemanticSurfaceHandlers() {
+  return Object.freeze({
+    agc: makeAgcHandlers(),
+    antenna: makeAntennaHandlers(),
+    audioRouting: makeAudioRoutingHandlers(),
+    band: makeBandHandlers(),
+    cw: makeCwPanelHandlers(),
+    dsp: makeDspHandlers(),
+    filter: makeFilterHandlers(),
+    mode: makeModeHandlers(),
+    rfFrontEnd: makeRfFrontEndHandlers(),
+    ritXit: makeRitXitHandlers(),
+    rxAudio: makeRxAudioHandlers(),
+    scan: makeScanHandlers(),
+    scopeControls: makeScopeControlsHandlers(),
+    tx: makeTxHandlers(),
+    vfo: makeVfoHandlers(),
+    vox: makeVoxHandlers(),
+  });
+}
+
+const _audioRoutingHandlers = makeAudioRoutingHandlers();
+export function getAudioRoutingHandlers() { return _audioRoutingHandlers; }
+const _vfoHandlers = makeVfoHandlers();
+export function getVfoHandlers() { return _vfoHandlers; }
+
+export type VfoTunerRead = Readonly<{
+  tx: ReturnType<AppTxController['snapshot']>;
+  view: ReturnType<typeof toRadioViewModel>;
+}>;
+export type VfoTunerContext = Readonly<{ read(): VfoTunerRead }>;
+
+/** Captures the App TX facade once, while read() projects only live read-only facts. */
+export function bindVfoTunerContext(): VfoTunerContext {
+  const tx = getAppTxController();
+  return Object.freeze({
+    read: () => {
+      const snapshot = tx.snapshot();
+      return Object.freeze({
+        tx: snapshot,
+        view: toRadioViewModel(runtime.state, runtime.caps, snapshot),
+      });
+    },
+  });
+}
 
 // ── Audio Spectrum ──
 export function deriveAudioSpectrumProps() {

--- a/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
+++ b/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
@@ -76,8 +76,8 @@ vi.mock('$lib/runtime/adapters/mod-input-tx-guard.svelte', () => ({
   deriveModInputTxGuardProps: () => h.modInputGuard,
   getModInputTxGuardHandlers: () => ({ onSetLan: vi.fn(), onDismiss: vi.fn() }),
 }));
-vi.mock('../../../components-v2/wiring/command-bus', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../../../components-v2/wiring/command-bus')>();
+vi.mock('$lib/runtime/commands/panel-commands', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('$lib/runtime/commands/panel-commands')>();
   return {
     ...actual,
     makeVfoHandlers: () => ({

--- a/frontend/vite.fixtures.config.ts
+++ b/frontend/vite.fixtures.config.ts
@@ -15,9 +15,9 @@
  * catalog, the real `app.css` + `components-v2/theme` token layer.
  *
  * Stubbing by RESOLVED ABSOLUTE PATH (not by alias on the import specifier) is
- * deliberate: `SemanticRadioSurfaces` imports `./command-bus` relatively, and
- * a string alias on `./command-bus` would match any same-named relative import
- * anywhere in the graph.
+ * deliberate: the semantic root reaches its command callbacks through the
+ * existing adapter seam, while legacy layout callers retain the relative bus
+ * seam. A string alias would match unrelated same-named relative imports.
  */
 import path from 'node:path';
 import { defineConfig, type Plugin } from 'vite';
@@ -30,6 +30,7 @@ const STUBS: Readonly<Record<string, string>> = {
   'src/lib/runtime/index.ts': 'fixtures/stubs/runtime.ts',
   'src/lib/runtime/tx-controller/app-host.ts': 'fixtures/stubs/app-host.ts',
   'src/lib/runtime/adapters/mod-input-tx-guard.svelte.ts': 'fixtures/stubs/mod-input-tx-guard.ts',
+  'src/lib/runtime/adapters/panel-adapters.ts': 'fixtures/stubs/panel-adapters.ts',
   'src/components-v2/wiring/command-bus.ts': 'fixtures/stubs/command-bus.ts',
 };
 

--- a/frontend/vite.fixtures.config.ts
+++ b/frontend/vite.fixtures.config.ts
@@ -24,6 +24,8 @@ import { defineConfig, type Plugin } from 'vite';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 
 const here = import.meta.dirname;
+const semanticRoot = path.resolve(here, 'src/components-v2/wiring/SemanticRadioSurfaces.svelte');
+const panelAdapters = path.resolve(here, 'src/lib/runtime/adapters/panel-adapters.ts');
 
 /** production module (repo-relative) → fixture stub (repo-relative) */
 const STUBS: Readonly<Record<string, string>> = {
@@ -48,7 +50,12 @@ function fixtureStubs(): Plugin {
       if (stubPaths.has(importer.split('?')[0])) return null;
       const resolved = await this.resolve(source, importer, { ...options, skipSelf: true });
       if (!resolved) return null;
-      return table.get(resolved.id.split('?')[0]) ?? null;
+      const target = resolved.id.split('?')[0];
+      // The adapter has a broad shipped export surface. Only the semantic
+      // composition root uses the fixture-only binder; every other importer
+      // must resolve the real adapter module unchanged.
+      if (target === panelAdapters && importer.split('?')[0] !== semanticRoot) return null;
+      return table.get(target) ?? null;
     },
   };
 }


### PR DESCRIPTION
Part of #2317.

Supersedes the stopped direct-import attempt under issue correction 5233790429. Binds all sixteen semantic command families through the existing per-component adapter seam; SemanticRadioSurfaces no longer imports the compatibility bus or command module. Adds stable VFO/local-audio bindings and a read-only live tuner context for the serial A04b consumer gate.

Validation: frontend 6,179 tests, check, lint, boundary lint, i18n check, build; backend non-hardware pytest; Ruff/import-linter; generated-state and consumer contracts.

Known baseline: strict `uv run mypy src/` reports 13 existing errors in four untouched backend files.

Auto-merge remains off. No close keyword.