### PR TITLE
refactor(#2317): bind remaining panel commands

### DIFF
--- a/frontend/src/components-v2/panels/AudioRoutingControl.svelte
+++ b/frontend/src/components-v2/panels/AudioRoutingControl.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { makeAudioRoutingHandlers } from '../wiring/command-bus';
+  import { getAudioRoutingHandlers } from '$lib/runtime/adapters/panel-adapters';
   import { getReceiverLabel } from '$lib/runtime/adapters/capabilities-adapter';
 
   type AudioFocus = 'main' | 'sub' | 'both';
 
-  const handlers = makeAudioRoutingHandlers();
+  const handlers = getAudioRoutingHandlers();
 
   let focus: AudioFocus = $state('both');
   let splitStereo = $state(false);

--- a/frontend/src/components-v2/panels/__tests__/AudioRoutingControl.isolated.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/AudioRoutingControl.isolated.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mount, unmount, flushSync } from 'svelte';
+import { readFileSync } from 'node:fs';
 
 // Mock audio-manager so we can spy on setAudioConfig calls.
 const setAudioConfigSpy = vi.fn();
@@ -19,6 +20,25 @@ vi.mock('$lib/stores/capabilities.svelte', () => ({
   receiverLabel: (id: 'MAIN' | 'SUB') => id,
 }));
 
+const audioBinding = vi.hoisted(() => ({
+  handlers: undefined as any,
+  get: undefined as any,
+}));
+
+vi.mock('$lib/runtime/adapters/panel-adapters', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('$lib/runtime/adapters/panel-adapters')>();
+  const handlers = actual.getAudioRoutingHandlers();
+  audioBinding.handlers = {
+    ...handlers,
+    onFocusChange: vi.fn(handlers.onFocusChange),
+    onSplitStereoChange: vi.fn(handlers.onSplitStereoChange),
+    onChannelGainChange: vi.fn(handlers.onChannelGainChange),
+  };
+  audioBinding.get = vi.fn(() => audioBinding.handlers);
+  return { ...actual, getAudioRoutingHandlers: audioBinding.get };
+});
+
+import '$lib/runtime/adapters/panel-adapters';
 import AudioRoutingControl from '../AudioRoutingControl.svelte';
 
 let target: HTMLElement;
@@ -46,6 +66,10 @@ function installLocalStorage(): Map<string, string> {
 
 beforeEach(() => {
   setAudioConfigSpy.mockClear();
+  audioBinding.get.mockClear();
+  audioBinding.handlers.onFocusChange.mockClear();
+  audioBinding.handlers.onSplitStereoChange.mockClear();
+  audioBinding.handlers.onChannelGainChange.mockClear();
   originalLocalStorage = (globalThis as any).localStorage;
   installLocalStorage();
   target = document.createElement('div');
@@ -68,6 +92,16 @@ function mountControl() {
 }
 
 describe('AudioRoutingControl', () => {
+  it('uses only the stable local-audio adapter binding, with no panel authority escape', () => {
+    const source = readFileSync('src/components-v2/panels/AudioRoutingControl.svelte', 'utf8');
+    expect(source).toMatch(/import\s*\{\s*getAudioRoutingHandlers\s*\}\s*from\s*'\$lib\/runtime\/adapters\/panel-adapters'/);
+    for (const forbidden of [
+      'command-bus', 'panel-commands', 'radio-intents', "from '$lib/runtime'", '$lib/transport',
+      'audio-manager', '$lib/stores', 'dispatchRadioIntent', 'sendCommand', 'runtime.send',
+      'patchRadioState', 'import(', 'export {', 'export *',
+    ]) expect(source).not.toContain(forbidden);
+  });
+
   it('renders three focus buttons with radiogroup a11y', () => {
     mountControl();
     const radiogroup = target.querySelector('[role="radiogroup"]');
@@ -83,6 +117,7 @@ describe('AudioRoutingControl', () => {
     mainBtn.click();
     flushSync();
     expect(setAudioConfigSpy).toHaveBeenCalledWith({ focus: 'main' });
+    expect(audioBinding.handlers.onFocusChange).toHaveBeenCalledExactlyOnceWith('main');
     expect(localStorage.getItem('icom.audio.focus')).toBe('main');
     // aria-checked reflects new state
     expect(mainBtn.getAttribute('aria-checked')).toBe('true');
@@ -96,6 +131,7 @@ describe('AudioRoutingControl', () => {
     flushSync();
     expect(toggle.getAttribute('aria-pressed')).toBe('true');
     expect(setAudioConfigSpy).toHaveBeenCalledWith({ split_stereo: true });
+    expect(audioBinding.handlers.onSplitStereoChange).toHaveBeenCalledExactlyOnceWith(true);
     expect(localStorage.getItem('icom.audio.split_stereo')).toBe('1');
   });
 
@@ -107,6 +143,7 @@ describe('AudioRoutingControl', () => {
     mainSlider.dispatchEvent(new Event('input', { bubbles: true }));
     flushSync();
     expect(setAudioConfigSpy).toHaveBeenCalledWith({ main_gain_db: -12 });
+    expect(audioBinding.handlers.onChannelGainChange).toHaveBeenCalledExactlyOnceWith('main', -12);
     expect(localStorage.getItem('icom.audio.main_gain_db')).toBe('-12');
   });
 

--- a/frontend/src/components-v2/panels/lcd/VfoControlPanel.svelte
+++ b/frontend/src/components-v2/panels/lcd/VfoControlPanel.svelte
@@ -7,19 +7,19 @@
    * (A↔B, A=B, DW, SPLIT, XIT, CLR, TUNE, BK-OFF) were previously
    * rendered inside `AmberLcdDisplay` (`.lcd-vfo-ctrl-row`) and are
    * relocated here unchanged. Commands dispatched via the same
-   * wiring/command-bus handlers as before.
+   * adapter-bound handlers as before.
    */
   import {
     deriveVfoControlProps,
     deriveRitXitProps,
+    getVfoHandlers,
+    getRitXitHandlers,
+    getCwHandlers,
+    getTxHandlers,
+    bindVfoTunerContext,
   } from '$lib/runtime/adapters/panel-adapters';
   import { deriveVfoOps } from '$lib/runtime/adapters/vfo-adapter';
-  import {
-    makeVfoHandlers,
-    makeRitXitHandlers,
-    makeCwPanelHandlers,
-  } from '../../wiring/command-bus';
-  import { runtime } from '$lib/runtime';
+  import { keyBlockedReasons } from '../../../semantic/rx-tx-surface';
 
   /**
    * MOR-1092: in the migrated LCD entrypoints the semantic VFO surface owns
@@ -30,9 +30,17 @@
    */
   let { hideVfoFacts = false }: { hideVfoFacts?: boolean } = $props();
 
-  const vfoHandlers = makeVfoHandlers();
-  const ritXitHandlers = makeRitXitHandlers();
-  const cwHandlers = makeCwPanelHandlers();
+  const vfoHandlers = getVfoHandlers();
+  const ritXitHandlers = getRitXitHandlers();
+  const cwHandlers = getCwHandlers();
+  const txHandlers = getTxHandlers();
+  const tunerContext = bindVfoTunerContext();
+
+  function requestAtuTune(): void {
+    const { view, tx } = tunerContext.read();
+    if (!view || keyBlockedReasons(view, tx).length > 0) return;
+    txHandlers.onAtuTune();
+  }
 
   let p = $derived(deriveVfoControlProps());
   let ritXit = $derived(deriveRitXitProps());
@@ -53,7 +61,7 @@
     <button class="lcd-btn" onclick={ritXitHandlers.onClear}>CLR</button>
   {/if}
   {#if p.hasTuner}
-    <button class="lcd-btn" onclick={() => runtime.send('set_tuner_status', { value: 2 })}>TUNE</button>
+    <button class="lcd-btn" onclick={requestAtuTune}>TUNE</button>
   {/if}
   {#if p.isCwMode && p.hasCw && p.hasBreakIn}
     <button class="lcd-btn" class:active={p.breakInMode > 0} onclick={() => cwHandlers.onBreakInModeChange(p.breakInMode === 0 ? 1 : p.breakInMode === 1 ? 2 : 0)}>{p.breakInMode === 0 ? 'BK-OFF' : p.breakInMode === 1 ? 'SEMI' : 'FULL'}</button>

--- a/frontend/src/components-v2/panels/lcd/__tests__/VfoControlPanel.authority.isolated.test.ts
+++ b/frontend/src/components-v2/panels/lcd/__tests__/VfoControlPanel.authority.isolated.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mount, unmount, flushSync } from 'svelte';
 import { readFileSync } from 'node:fs';
+import { keyBlockedReasons, type KeyBlockedReason } from '../../../../semantic/rx-tx-surface';
 
 const bindings = vi.hoisted(() => ({
   vfo: { onSwap: vi.fn(), onEqual: vi.fn(), onDualWatchToggle: vi.fn(), onSplitToggle: vi.fn() },
@@ -16,8 +17,6 @@ const props = vi.hoisted(() => ({
   ops: { dualWatch: false, splitActive: false },
 }));
 
-const sharedGate = vi.hoisted(() => vi.fn(() => [] as readonly string[]));
-
 vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
   deriveVfoControlProps: () => props.vfo,
   deriveRitXitProps: () => props.ritXit,
@@ -29,7 +28,6 @@ vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
 }));
 
 vi.mock('$lib/runtime/adapters/vfo-adapter', () => ({ deriveVfoOps: () => props.ops }));
-vi.mock('../../../../semantic/rx-tx-surface', () => ({ keyBlockedReasons: sharedGate }));
 vi.mock('../../../wiring/command-bus', () => ({
   makeVfoHandlers: () => bindings.vfo,
   makeRitXitHandlers: () => bindings.ritXit,
@@ -43,9 +41,27 @@ let component: ReturnType<typeof mount> | undefined;
 let target: HTMLDivElement;
 
 const allowed = Object.freeze({
-  view: Object.freeze({ txTarget: { status: 'known' }, txPermit: { status: 'allowed' } }),
-  tx: Object.freeze({ phase: 'idle', radioTx: 'off', txRisk: 'none', mayOwnKey: false, fault: null }),
+  view: Object.freeze({ txTarget: { status: 'known' }, txPermit: { status: 'allowed' } }) as Parameters<typeof keyBlockedReasons>[0],
+  tx: Object.freeze({ phase: 'idle', radioTx: 'off', txRisk: 'none', mayOwnKey: false, fault: null }) as Parameters<typeof keyBlockedReasons>[1],
 });
+
+const blockedCases: readonly Readonly<{
+  name: string;
+  expected: KeyBlockedReason;
+  view: Parameters<typeof keyBlockedReasons>[0];
+  tx: Parameters<typeof keyBlockedReasons>[1];
+}>[] = [
+  { name: 'unknown target', expected: 'tx-target-unknown', view: { ...allowed.view, txTarget: { status: 'unknown' } } as typeof allowed.view, tx: allowed.tx },
+  { name: 'denied permit', expected: 'tx-permit-denied', view: { ...allowed.view, txPermit: { status: 'denied' } } as typeof allowed.view, tx: allowed.tx },
+  { name: 'unknown permit', expected: 'tx-permit-unknown', view: { ...allowed.view, txPermit: { status: 'unknown' } } as typeof allowed.view, tx: allowed.tx },
+  { name: 'fault', expected: 'tx-fault', view: allowed.view, tx: { ...allowed.tx, fault: 'fault' } as typeof allowed.tx },
+  { name: 'non-idle phase', expected: 'tx-busy', view: allowed.view, tx: { ...allowed.tx, phase: 'key-confirm-pending' } as typeof allowed.tx },
+  { name: 'key ownership', expected: 'tx-busy', view: allowed.view, tx: { ...allowed.tx, mayOwnKey: true } as typeof allowed.tx },
+  { name: 'TX risk', expected: 'tx-busy', view: allowed.view, tx: { ...allowed.tx, txRisk: 'uncertain' } as typeof allowed.tx },
+  { name: 'confirmed TX risk', expected: 'tx-busy', view: allowed.view, tx: { ...allowed.tx, txRisk: 'confirmed-on' } as typeof allowed.tx },
+  { name: 'radio TX on', expected: 'radio-transmitting', view: allowed.view, tx: { ...allowed.tx, radioTx: 'on' } as typeof allowed.tx },
+  { name: 'radio TX unknown', expected: 'rf-state-unknown', view: allowed.view, tx: { ...allowed.tx, radioTx: 'unknown' } as typeof allowed.tx },
+];
 
 function button(label: string): HTMLButtonElement {
   const found = Array.from(target.querySelectorAll('button')).find((node) => node.textContent?.trim() === label);
@@ -63,8 +79,6 @@ beforeEach(() => {
   document.body.appendChild(target);
   bindings.read.mockReset();
   bindings.read.mockReturnValue(allowed);
-  sharedGate.mockReset();
-  sharedGate.mockReturnValue([]);
   for (const group of [bindings.vfo, bindings.ritXit, bindings.cw, bindings.tx]) {
     for (const callback of Object.values(group)) callback.mockClear();
   }
@@ -110,26 +124,32 @@ describe('VfoControlPanel authority boundary', () => {
 
   it('reads tuner facts at click time and sends exactly one canonical callback only when shared gate permits', () => {
     mountPanel();
-    bindings.read.mockReturnValueOnce({ ...allowed, tx: { ...allowed.tx, radioTx: 'on' } });
-    sharedGate.mockImplementation(((_view: unknown, tx: { radioTx: string }) => tx.radioTx === 'on' ? ['radio-transmitting'] : []) as any);
+    const transmitting = { ...allowed.tx, radioTx: 'on' } as typeof allowed.tx;
+    bindings.read.mockReturnValueOnce({ ...allowed, tx: transmitting });
     button('TUNE').click();
     expect(bindings.read).toHaveBeenCalledOnce();
     expect(bindings.tx.onAtuTune).not.toHaveBeenCalled();
     bindings.read.mockReturnValue(allowed);
     button('TUNE').click();
     expect(bindings.read).toHaveBeenCalledTimes(2);
-    expect(sharedGate).toHaveBeenLastCalledWith(allowed.view, allowed.tx);
+    expect(keyBlockedReasons(allowed.view, transmitting)).toEqual(['radio-transmitting']);
+    expect(keyBlockedReasons(allowed.view, allowed.tx)).toEqual([]);
     expect(bindings.tx.onAtuTune).toHaveBeenCalledOnce();
   });
 
-  it.each([
-    'unknown-target', 'denied-permit', 'unknown-permit', 'fault', 'non-idle', 'owned-key',
-    'uncertain-risk', 'confirmed-risk', 'radio-on', 'radio-unknown', 'generation',
-    'capability', 'availability', 'physical-sub',
-  ])('emits zero TUNE callbacks for %s', (reason) => {
+  it.each(blockedCases)('emits zero TUNE callbacks for canonical $name', ({ expected, view, tx }) => {
     mountPanel();
-    bindings.read.mockReturnValue({ ...allowed, reason });
-    sharedGate.mockReturnValue([reason]);
+    expect(keyBlockedReasons(view, tx)).toContain(expected);
+    bindings.read.mockReturnValue({ view, tx });
+    button('TUNE').click();
+    expect(bindings.read).toHaveBeenCalledOnce();
+    expect(bindings.tx.onAtuTune).not.toHaveBeenCalled();
+  });
+
+  it.each(['generation', 'capability', 'availability', 'impossible physical SUB'])
+  ('emits zero TUNE callbacks when %s collapses the tuner view to null', () => {
+    mountPanel();
+    bindings.read.mockReturnValue({ view: null, tx: allowed.tx });
     button('TUNE').click();
     expect(bindings.read).toHaveBeenCalledOnce();
     expect(bindings.tx.onAtuTune).not.toHaveBeenCalled();

--- a/frontend/src/components-v2/panels/lcd/__tests__/VfoControlPanel.authority.isolated.test.ts
+++ b/frontend/src/components-v2/panels/lcd/__tests__/VfoControlPanel.authority.isolated.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount, unmount, flushSync } from 'svelte';
+import { readFileSync } from 'node:fs';
+
+const bindings = vi.hoisted(() => ({
+  vfo: { onSwap: vi.fn(), onEqual: vi.fn(), onDualWatchToggle: vi.fn(), onSplitToggle: vi.fn() },
+  ritXit: { onXitToggle: vi.fn(), onClear: vi.fn() },
+  cw: { onBreakInModeChange: vi.fn() },
+  tx: { onAtuTune: vi.fn() },
+  read: vi.fn(),
+}));
+
+const props = vi.hoisted(() => ({
+  vfo: { hasDualRx: true, hasSplit: true, hasRit: true, hasTuner: true, isCwMode: true, hasCw: true, hasBreakIn: true, breakInMode: 0 },
+  ritXit: { xitActive: false },
+  ops: { dualWatch: false, splitActive: false },
+}));
+
+const sharedGate = vi.hoisted(() => vi.fn(() => [] as readonly string[]));
+
+vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
+  deriveVfoControlProps: () => props.vfo,
+  deriveRitXitProps: () => props.ritXit,
+  getVfoHandlers: () => bindings.vfo,
+  getRitXitHandlers: () => bindings.ritXit,
+  getCwHandlers: () => bindings.cw,
+  getTxHandlers: () => bindings.tx,
+  bindVfoTunerContext: () => ({ read: bindings.read }),
+}));
+
+vi.mock('$lib/runtime/adapters/vfo-adapter', () => ({ deriveVfoOps: () => props.ops }));
+vi.mock('../../../../semantic/rx-tx-surface', () => ({ keyBlockedReasons: sharedGate }));
+vi.mock('../../../wiring/command-bus', () => ({
+  makeVfoHandlers: () => bindings.vfo,
+  makeRitXitHandlers: () => bindings.ritXit,
+  makeCwPanelHandlers: () => bindings.cw,
+}));
+vi.mock('$lib/runtime', () => ({ runtime: { send: vi.fn() } }));
+
+import VfoControlPanel from '../VfoControlPanel.svelte';
+
+let component: ReturnType<typeof mount> | undefined;
+let target: HTMLDivElement;
+
+const allowed = Object.freeze({
+  view: Object.freeze({ txTarget: { status: 'known' }, txPermit: { status: 'allowed' } }),
+  tx: Object.freeze({ phase: 'idle', radioTx: 'off', txRisk: 'none', mayOwnKey: false, fault: null }),
+});
+
+function button(label: string): HTMLButtonElement {
+  const found = Array.from(target.querySelectorAll('button')).find((node) => node.textContent?.trim() === label);
+  if (!found) throw new Error(`missing ${label}`);
+  return found as HTMLButtonElement;
+}
+
+function mountPanel() {
+  component = mount(VfoControlPanel, { target });
+  flushSync();
+}
+
+beforeEach(() => {
+  target = document.createElement('div');
+  document.body.appendChild(target);
+  bindings.read.mockReset();
+  bindings.read.mockReturnValue(allowed);
+  sharedGate.mockReset();
+  sharedGate.mockReturnValue([]);
+  for (const group of [bindings.vfo, bindings.ritXit, bindings.cw, bindings.tx]) {
+    for (const callback of Object.values(group)) callback.mockClear();
+  }
+});
+
+afterEach(() => {
+  if (component) unmount(component);
+  component = undefined;
+  target.remove();
+});
+
+describe('VfoControlPanel authority boundary', () => {
+  it('has only reviewed adapter bindings and the shared pure TUNE gate', () => {
+    const source = readFileSync('src/components-v2/panels/lcd/VfoControlPanel.svelte', 'utf8');
+    expect(source).toMatch(/getVfoHandlers/);
+    expect(source).toMatch(/getRitXitHandlers/);
+    expect(source).toMatch(/getCwHandlers/);
+    expect(source).toMatch(/getTxHandlers/);
+    expect(source).toMatch(/bindVfoTunerContext/);
+    expect(source).toMatch(/keyBlockedReasons/);
+    for (const forbidden of [
+      'command-bus', 'panel-commands', 'radio-intents', "from '$lib/runtime'", '$lib/transport',
+      '$lib/stores', 'audio-manager', 'dispatchRadioIntent', 'sendCommand', 'runtime.send',
+      'patchRadioState', 'cw_auto_tune', 'set_tuner_status', 'import(', 'export {', 'export *',
+    ]) expect(source).not.toContain(forbidden);
+  });
+
+  it('keeps callback identity, button order, and break-in parameters exact', () => {
+    mountPanel();
+    expect(Array.from(target.querySelectorAll('button')).map((node) => node.textContent?.trim()))
+      .toEqual(['A↔B', 'A=B', 'DW', 'SPLIT', 'XIT', 'CLR', 'TUNE', 'BK-OFF']);
+    button('A↔B').click(); button('A=B').click(); button('DW').click(); button('SPLIT').click();
+    button('XIT').click(); button('CLR').click(); button('BK-OFF').click();
+    expect(bindings.vfo.onSwap).toHaveBeenCalledOnce();
+    expect(bindings.vfo.onEqual).toHaveBeenCalledOnce();
+    expect(bindings.vfo.onDualWatchToggle).toHaveBeenCalledExactlyOnceWith(true);
+    expect(bindings.vfo.onSplitToggle).toHaveBeenCalledOnce();
+    expect(bindings.ritXit.onXitToggle).toHaveBeenCalledOnce();
+    expect(bindings.ritXit.onClear).toHaveBeenCalledOnce();
+    expect(bindings.cw.onBreakInModeChange).toHaveBeenCalledExactlyOnceWith(1);
+    expect(bindings.tx.onAtuTune).not.toHaveBeenCalled();
+  });
+
+  it('reads tuner facts at click time and sends exactly one canonical callback only when shared gate permits', () => {
+    mountPanel();
+    bindings.read.mockReturnValueOnce({ ...allowed, tx: { ...allowed.tx, radioTx: 'on' } });
+    sharedGate.mockImplementation(((_view: unknown, tx: { radioTx: string }) => tx.radioTx === 'on' ? ['radio-transmitting'] : []) as any);
+    button('TUNE').click();
+    expect(bindings.read).toHaveBeenCalledOnce();
+    expect(bindings.tx.onAtuTune).not.toHaveBeenCalled();
+    bindings.read.mockReturnValue(allowed);
+    button('TUNE').click();
+    expect(bindings.read).toHaveBeenCalledTimes(2);
+    expect(sharedGate).toHaveBeenLastCalledWith(allowed.view, allowed.tx);
+    expect(bindings.tx.onAtuTune).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    'unknown-target', 'denied-permit', 'unknown-permit', 'fault', 'non-idle', 'owned-key',
+    'uncertain-risk', 'confirmed-risk', 'radio-on', 'radio-unknown', 'generation',
+    'capability', 'availability', 'physical-sub',
+  ])('emits zero TUNE callbacks for %s', (reason) => {
+    mountPanel();
+    bindings.read.mockReturnValue({ ...allowed, reason });
+    sharedGate.mockReturnValue([reason]);
+    button('TUNE').click();
+    expect(bindings.read).toHaveBeenCalledOnce();
+    expect(bindings.tx.onAtuTune).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Bind the remaining Audio Routing and LCD VFO panel commands through the reviewed runtime adapter seam.
- Remove compatibility command-bus/raw-runtime TUNE authority; evaluate the shared blocker predicate at click time and invoke the canonical non-PTT handler only when allowed.
- Add focused authority, liveness, callback identity/order, deny-matrix, and source-guard coverage.

Closes #2317

Linear: MOR-1409

## Exact scope

- Base: `02612e49794c476bacfe1c840faae18947ca9f62`
- Head: `a20a51122551825a172b84cf259a786eb1315935`
- Production owners: exactly `AudioRoutingControl.svelte` and `VfoControlPanel.svelte`; production churn `+21/-13` (34 lines).
- Test owners: exactly `AudioRoutingControl.isolated.test.ts` and `VfoControlPanel.authority.isolated.test.ts`.
- Frozen A04a authority files are byte-identical to base; `git diff --check` is clean.

## Verification

- Causal RED: 20 assertions on exact base; focused GREEN: 59/59. Authority mutations each made focused tests RED and were restored byte-for-byte.
- Final frontend checks passed: type check, lint, boundary lint, and focused Vitest (5 files, 59/59).
- Full non-hardware backend suite passed fresh: `8993 passed, 12 skipped, 11 xfailed, 1 xpassed`.
- Ruff, formatting, import lint, strict web mypy, generation check, consumer contracts, targeted codegen/consumer tests, and dry-run validations all pass. Whole-tree mypy retains only the known 13 base-identical errors in four untouched backend files.
- Fixture evidence: both terminal manifests passed with 64/64 captures, 1,951/1,951 assertions, VFO Split 34/34, and zero invalid/failed/console/page errors. This used explicit Google Chrome 151.0.7922.77 fallback (`696e4277196f9bc4d6655285f617efb068a84d4c7fc498948f10d8a4e03f9663`) and is alternate-browser evidence, not pinned-Chrome-145 equivalence.

## Chronology and review

The earlier apparent fixture stop was corrected as a workflow violation caused by losing a live process handle, not a product/fixture failure. An earlier PTT timeout was independently attributed to an exact-base flake; the fresh clean full suite above passes. This PR intentionally has no Agent Review comment and requires fresh independent exact-head review before merge.
