### PR TITLE
refactor(#2317): bind memory panel intents

### DIFF
--- a/frontend/src/components-v2/panels/MemoryPanel.svelte
+++ b/frontend/src/components-v2/panels/MemoryPanel.svelte
@@ -6,11 +6,11 @@
    * so this panel tracks channel data locally (localStorage) and provides
    * controls for recall, store, clear, and channel selection.
    */
-  import { runtime } from '$lib/runtime';
-  import { deriveMemoryPanelProps } from '$lib/runtime/adapters/panel-adapters';
+  import { deriveMemoryPanelProps, getMemoryHandlers } from '$lib/runtime/adapters/panel-adapters';
   import { formatFrequencyString } from '../display/frequency-format';
 
   let p = $derived(deriveMemoryPanelProps());
+  const memory = getMemoryHandlers();
 
   const STORAGE_KEY = 'rigplane:memory-channels';
   const MAX_CHANNELS = 99;
@@ -56,19 +56,14 @@
   }
 
   function recallChannel(ch: number) {
-    if (!p.vfoIdentityKnown) return;
-    runtime.send('set_memory_mode', { channel: ch });
-    runtime.send('memory_to_vfo', { channel: ch });
+    if (!memory.onRecall(ch)) return;
     selectedChannel = ch;
   }
 
   function storeVfoToChannel(ch: number) {
-    if (!p.vfoIdentityKnown) return;
     const freq = p.activeFreqHz;
     const mode = p.activeMode;
-
-    runtime.send('set_memory_mode', { channel: ch });
-    runtime.send('memory_write', {});
+    if (!memory.onStore(ch, freq, mode)) return;
 
     // Track locally
     const updated = new Map(channels);
@@ -79,7 +74,7 @@
   }
 
   function clearChannel(ch: number) {
-    runtime.send('memory_clear', { channel: ch });
+    if (!memory.onClear(ch)) return;
 
     // Remove from local tracking
     const updated = new Map(channels);

--- a/frontend/src/components-v2/panels/__tests__/MemoryPanel.authority.isolated.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/MemoryPanel.authority.isolated.test.ts
@@ -42,4 +42,74 @@ describe('MOR-1409 A05a MemoryPanel authority boundary', () => {
     expect(document.querySelector('.ch-freq')?.textContent).toContain('14.074');
     expect(localStorage.getItem('rigplane:memory-channels')).toContain('14074000');
   });
+
+  it('updates accepted recall/store/clear local state and persists the catalog changes', async () => {
+    localStorage.setItem('rigplane:memory-channels', JSON.stringify({
+      2: { freq: 7_100_000, mode: 'LSB', name: 'saved' },
+    }));
+    handlers.onRecall.mockReturnValueOnce(true);
+    handlers.onStore.mockReturnValueOnce(true);
+    handlers.onClear.mockReturnValueOnce(true);
+    component = mount(MemoryPanel, { target: document.body });
+    await tick();
+
+    (document.querySelector('[data-channel="2"] .recall-btn') as HTMLButtonElement).click();
+    await tick();
+    expect(document.querySelector('[data-channel="2"]')?.classList.contains('selected')).toBe(true);
+
+    (document.querySelector('.store-btn') as HTMLButtonElement).click();
+    await tick();
+    (document.querySelector('.store-confirm') as HTMLButtonElement).click();
+    await tick();
+    expect(document.querySelector('[data-channel="1"] .ch-freq')?.textContent).toContain('14.074');
+    expect(JSON.parse(localStorage.getItem('rigplane:memory-channels') ?? '{}')).toMatchObject({
+      1: { freq: 14_074_000, mode: 'USB', name: '' },
+    });
+
+    (document.querySelector('[data-channel="1"] .clear-btn') as HTMLButtonElement).click();
+    await tick();
+    (document.querySelector('[data-channel="1"] .clear-confirm') as HTMLButtonElement).click();
+    await tick();
+    expect(document.querySelector('[data-channel="1"]')).toBeNull();
+    expect(JSON.parse(localStorage.getItem('rigplane:memory-channels') ?? '{}')).not.toHaveProperty('1');
+  });
+
+  it('keeps local selection and catalog unchanged after rejected or exceptional actions', async () => {
+    const original = JSON.stringify({ 2: { freq: 7_100_000, mode: 'LSB', name: 'saved' } });
+    localStorage.setItem('rigplane:memory-channels', original);
+    component = mount(MemoryPanel, { target: document.body });
+    await tick();
+
+    (document.querySelector('[data-channel="2"] .recall-btn') as HTMLButtonElement).click();
+    await tick();
+    expect(document.querySelector('[data-channel="2"]')?.classList.contains('selected')).toBe(false);
+    (document.querySelector('.store-btn') as HTMLButtonElement).click();
+    await tick();
+    (document.querySelector('.store-confirm') as HTMLButtonElement).click();
+    await tick();
+    (document.querySelector('[data-channel="2"] .clear-btn') as HTMLButtonElement).click();
+    await tick();
+    (document.querySelector('[data-channel="2"] .clear-confirm') as HTMLButtonElement).click();
+    await tick();
+    expect(localStorage.getItem('rigplane:memory-channels')).toBe(original);
+    expect(document.querySelector('[data-channel="2"] .ch-freq')?.textContent).toContain('7.100');
+
+    const preventUnhandled = (event: ErrorEvent) => event.preventDefault();
+    window.addEventListener('error', preventUnhandled);
+    try {
+      handlers.onRecall.mockImplementationOnce(() => { throw new Error('recall failure'); });
+      (document.querySelector('[data-channel="2"] .recall-btn') as HTMLButtonElement).click();
+      await tick();
+      expect(document.querySelector('[data-channel="2"]')?.classList.contains('selected')).toBe(false);
+      handlers.onStore.mockImplementationOnce(() => { throw new Error('store failure'); });
+      (document.querySelector('.store-confirm') as HTMLButtonElement).click();
+      await tick();
+      handlers.onClear.mockImplementationOnce(() => { throw new Error('clear failure'); });
+      (document.querySelector('[data-channel="2"] .clear-confirm') as HTMLButtonElement).click();
+      await tick();
+      expect(localStorage.getItem('rigplane:memory-channels')).toBe(original);
+    } finally {
+      window.removeEventListener('error', preventUnhandled);
+    }
+  });
 });

--- a/frontend/src/components-v2/panels/__tests__/MemoryPanel.authority.isolated.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/MemoryPanel.authority.isolated.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mount, tick, unmount } from 'svelte';
+import { readFileSync } from 'node:fs';
+
+const handlers = vi.hoisted(() => ({ onRecall: vi.fn(() => false), onStore: vi.fn(() => false), onClear: vi.fn(() => false) }));
+const props = vi.hoisted(() => ({ activeFreqHz: 14_074_000, activeMode: 'USB', vfoIdentityKnown: true }));
+vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
+  deriveMemoryPanelProps: () => props,
+  getMemoryHandlers: () => handlers,
+}));
+
+import MemoryPanel from '../MemoryPanel.svelte';
+
+let component: ReturnType<typeof mount> | undefined;
+afterEach(() => { if (component) unmount(component); component = undefined; localStorage.clear(); vi.clearAllMocks(); });
+
+describe('MOR-1409 A05a MemoryPanel authority boundary', () => {
+  it('uses the adapter-bound handlers instead of raw runtime command sends', () => {
+    const source = readFileSync('src/components-v2/panels/MemoryPanel.svelte', 'utf8');
+    expect(source).toContain('getMemoryHandlers');
+    expect(source).not.toContain("from '$lib/runtime'");
+    expect(source).not.toMatch(/\bruntime\.send\b/);
+    expect(source).toMatch(/if \(!memory\.onRecall\(ch\)\) return;\s+selectedChannel = ch;/);
+    expect(source).toMatch(/if \(!memory\.onStore\(ch, freq, mode\)\) return;/);
+    expect(source).toMatch(/if \(!memory\.onClear\(ch\)\) return;/);
+    expect(source).not.toMatch(/(?:getCommandLifecycles|onCommandDelivery|onControlSessionTransition)/);
+  });
+
+  it('does not mutate action-local state or persistence after a rejected clear', async () => {
+    handlers.onStore.mockReturnValueOnce(true);
+    component = mount(MemoryPanel, { target: document.body });
+    await tick();
+    (document.querySelector('.store-btn') as HTMLButtonElement).click();
+    await tick();
+    (document.querySelector('.store-confirm') as HTMLButtonElement).click();
+    await tick();
+    (document.querySelector('.clear-btn') as HTMLButtonElement).click();
+    await tick();
+    (document.querySelector('.clear-confirm') as HTMLButtonElement).click();
+    await tick();
+    expect(handlers.onClear).toHaveBeenCalledWith(1);
+    expect(document.querySelector('.ch-freq')?.textContent).toContain('14.074');
+    expect(localStorage.getItem('rigplane:memory-channels')).toContain('14074000');
+  });
+});

--- a/frontend/src/lib/runtime/adapters/__tests__/memory-handler-binder.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/memory-handler-binder.isolated.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const factory = vi.hoisted(() => vi.fn(() => Object.freeze({ onRecall: vi.fn(), onStore: vi.fn(), onClear: vi.fn() })));
+vi.mock('$lib/runtime/commands/panel-commands', async (importOriginal) => ({
+  ...await importOriginal<typeof import('$lib/runtime/commands/panel-commands')>(),
+  makeMemoryHandlers: factory,
+}));
+vi.mock('$lib/runtime/frontend-runtime', () => ({ runtime: { state: null, caps: null } }));
+
+import { getMemoryHandlers } from '../panel-adapters';
+
+describe('MOR-1409 A05a memory handler binder', () => {
+  it('creates one canonical memory handler object and returns its exact identity', () => {
+    const first = getMemoryHandlers();
+    const second = getMemoryHandlers();
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(first).toBe(second);
+    expect(first).toBe(factory.mock.results[0]!.value);
+  });
+});

--- a/frontend/src/lib/runtime/adapters/panel-adapters.ts
+++ b/frontend/src/lib/runtime/adapters/panel-adapters.ts
@@ -22,7 +22,7 @@ import {
   makeCwPanelHandlers, makeDspHandlers,
   makeTxHandlers, makeFilterHandlers, makeBandHandlers,
   makePresetHandlers, makeAudioRoutingHandlers, makeRxAudioHandlers,
-  makeVfoHandlers, makeScopeControlsHandlers, makeVoxHandlers,
+  makeVfoHandlers, makeScopeControlsHandlers, makeVoxHandlers, makeMemoryHandlers,
 } from '../commands/panel-commands';
 import { toRadioViewModel } from './radio-view-model-adapter';
 import { getAppTxController, type AppTxController } from '../tx-controller/app-host';
@@ -180,6 +180,8 @@ export function deriveAudioSpectrumProps() {
 export function deriveMemoryPanelProps() {
   return toMemoryPanelProps(runtime.state, runtime.caps);
 }
+const _memoryHandlers = makeMemoryHandlers();
+export function getMemoryHandlers() { return _memoryHandlers; }
 
 // ── Amber Telemetry ──
 export function deriveAmberTelemetryProps() {

--- a/frontend/src/lib/runtime/commands/__tests__/memory-command-authority.isolated.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/memory-command-authority.isolated.test.ts
@@ -101,6 +101,31 @@ describe('MOR-1409 A05a memory command authority', () => {
     expect(h.calls).toHaveLength(0);
   });
 
+  it('rejects each supplied store value that no longer equals the observed snapshot', () => {
+    const handlers = makeMemoryHandlers();
+    expect(handlers.onStore(1, 7_100_000, 'USB')).toBe(false);
+    expect(handlers.onStore(1, 14_074_000, 'LSB')).toBe(false);
+    expect(h.calls).toHaveLength(0);
+  });
+
+  it('requires a non-empty, observed, fresh, and available mode leaf before store dispatch', () => {
+    const handlers = makeMemoryHandlers();
+    (h.state!.main.vfoA as { mode: string }).mode = '';
+    expect(handlers.onStore(1, 14_074_000, '')).toBe(false);
+
+    for (const modeStatus of [
+      undefined,
+      { ...fresh, observed: false },
+      { ...fresh, freshness: 'stale' },
+      { ...fresh, availability: 'unavailable' },
+    ]) {
+      h.state = state();
+      (h.state!.fieldStatus as Record<string, unknown>)['main.vfoA.mode'] = modeStatus;
+      expect(handlers.onStore(1, 14_074_000, 'USB')).toBe(false);
+    }
+    expect(h.calls).toHaveLength(0);
+  });
+
   it('rejects absent active identity, generation drift, and impossible physical topology before dispatch', () => {
     const handlers = makeMemoryHandlers();
     h.state = { ...h.state!, active: undefined } as unknown as ServerState;

--- a/frontend/src/lib/runtime/commands/__tests__/memory-command-authority.isolated.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/memory-command-authority.isolated.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { ServerState } from '$lib/types/state';
+
+const h = vi.hoisted(() => ({
+  state: null as ServerState | null,
+  caps: null as Capabilities | null,
+  calls: [] as Array<{ name: string; params: Record<string, unknown>; id: string; options: { optimistic: boolean } }>,
+  throwOnCall: 0,
+}));
+
+vi.mock('$lib/stores/radio.svelte', () => ({
+  getRadioState: () => h.state,
+  getActiveReceiver: () => h.state?.active === 'SUB' ? h.state.sub : h.state?.main,
+}));
+vi.mock('$lib/stores/capabilities.svelte', () => ({
+  getCapabilities: () => h.caps,
+  capabilitiesMatchGeneration: (generation: number) => generation === h.caps?.providerGeneration,
+  getControlRange: () => null,
+}));
+vi.mock('$lib/state/field-status', () => ({
+  getFieldStatus: (state: ServerState | null, path: string) => state?.fieldStatus?.[path],
+  isFieldAvailable: (state: ServerState | null, path: string) => state?.fieldStatus?.[path]?.availability === 'available',
+}));
+vi.mock('$lib/transport/ws-client', () => ({
+  getControlSession: () => ({ state: 'connected', epoch: 7 }),
+  onCommandDelivery: () => () => undefined,
+  onControlSessionTransition: () => () => undefined,
+  sendCommand: (name: string, params: Record<string, unknown>, id: string, options: { optimistic: boolean }) => {
+    if (h.throwOnCall === h.calls.length + 1) throw new Error('injected dispatcher failure');
+    h.calls.push({ name, params, id, options });
+    return true;
+  },
+}));
+vi.mock('$lib/runtime/frontend-runtime', () => ({ runtime: {} }));
+vi.mock('$lib/audio/audio-manager', () => ({ audioManager: {} }));
+vi.mock('$lib/stores/tuning.svelte', () => ({ getTuningStep: () => 1_000 }));
+
+import { makeMemoryHandlers } from '../panel-commands';
+import { resetCommandLifecycle } from '$lib/stores/commands.svelte';
+
+const fresh = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' } as const;
+
+function state(scheme: Capabilities['vfoScheme'] = 'main_sub'): ServerState {
+  const receiver = { freqHz: 14_074_000, mode: 'USB', activeSlot: 'A', vfoA: { freqHz: 14_074_000, mode: 'USB' } };
+  const fieldStatus: Record<string, typeof fresh> = {
+    active: fresh, 'main.activeSlot': fresh, 'main.vfoA.freqHz': fresh, 'main.vfoA.mode': fresh,
+    'main.freqHz': fresh, 'main.mode': fresh, 'sub.activeSlot': fresh, 'sub.vfoA.freqHz': fresh, 'sub.vfoA.mode': fresh,
+    'sub.freqHz': fresh, 'sub.mode': fresh,
+  };
+  return { stateContractVersion: 1, providerGeneration: 7, active: 'MAIN', main: receiver, sub: receiver, fieldStatus } as unknown as ServerState;
+}
+
+function caps(scheme: Capabilities['vfoScheme']): Capabilities {
+  const receivers = scheme === 'single' || scheme === 'ab' ? 1 : 2;
+  return { stateContractVersion: 1, providerGeneration: 7, vfoScheme: scheme, receivers,
+    capabilities: receivers === 2 ? ['dual_rx'] : [], modes: ['USB'] } as unknown as Capabilities;
+}
+
+describe('MOR-1409 A05a memory command authority', () => {
+  beforeEach(() => { h.calls.length = 0; h.throwOnCall = 0; h.state = state(); h.caps = caps('main_sub'); });
+  afterEach(() => resetCommandLifecycle());
+
+  it('uses strict observed state and starts ordered non-optimistic intents with distinct lifecycle ids', () => {
+    const handlers = makeMemoryHandlers();
+    expect(handlers.onRecall(1)).toBe(true);
+    expect(handlers.onStore(2, 14_074_000, 'USB')).toBe(true);
+    expect(handlers.onClear(99)).toBe(true);
+    expect(h.calls.map(({ name, params }) => ({ name, params }))).toEqual([
+      { name: 'set_memory_mode', params: { channel: 1 } }, { name: 'memory_to_vfo', params: { channel: 1 } },
+      { name: 'set_memory_mode', params: { channel: 2 } }, { name: 'memory_write', params: {} },
+      { name: 'memory_clear', params: { channel: 99 } },
+    ]);
+    expect(new Set(h.calls.map((call) => call.id)).size).toBe(h.calls.length);
+    expect(h.calls.every((call) => call.options.optimistic === false)).toBe(true);
+  });
+
+  it('accepts real relative and unslotted topology identities without inventing A or B', () => {
+    for (const scheme of ['ab', 'single', 'ab_shared'] as const) {
+      h.state = state(scheme);
+      h.caps = caps(scheme);
+      if (scheme === 'ab') {
+        h.caps = { ...h.caps, vfoReadback: 'selected_unselected' };
+        delete (h.state.fieldStatus as Record<string, unknown>)['main.activeSlot'];
+      }
+      expect(makeMemoryHandlers().onRecall(3)).toBe(true);
+    }
+  });
+
+  it('rejects all invalid channels and stale/default/unavailable authority before dispatch', () => {
+    const handlers = makeMemoryHandlers();
+    for (const invalid of [0, 100, NaN, Infinity, 1.5, Number.MAX_SAFE_INTEGER + 1]) {
+      expect(handlers.onRecall(invalid)).toBe(false);
+    }
+    (h.state!.fieldStatus as Record<string, unknown>)['main.vfoA.freqHz'] = { ...fresh, freshness: 'stale' };
+    expect(handlers.onStore(1, 14_074_000, 'USB')).toBe(false);
+    h.state = state();
+    (h.state.main.vfoA as { freqHz: number }).freqHz = 0;
+    expect(handlers.onStore(1, 0, 'USB')).toBe(false);
+    expect(h.calls).toHaveLength(0);
+  });
+
+  it('rejects absent active identity, generation drift, and impossible physical topology before dispatch', () => {
+    const handlers = makeMemoryHandlers();
+    h.state = { ...h.state!, active: undefined } as unknown as ServerState;
+    expect(handlers.onRecall(1)).toBe(false);
+    h.state = state();
+    h.caps = { ...caps('main_sub'), providerGeneration: 8 };
+    expect(handlers.onRecall(1)).toBe(false);
+    h.caps = { ...caps('main_sub'), capabilities: [] };
+    h.state = { ...state(), active: 'SUB' };
+    expect(handlers.onRecall(1)).toBe(false);
+    h.state = state();
+    h.caps = caps('main_sub');
+    delete (h.state.fieldStatus as Record<string, unknown>)['main.activeSlot'];
+    expect(handlers.onRecall(1)).toBe(false);
+    expect(h.calls).toHaveLength(0);
+  });
+
+  it('propagates member exceptions without false success or a rollback transaction', () => {
+    h.throwOnCall = 1;
+    expect(() => makeMemoryHandlers().onRecall(1)).toThrow('injected dispatcher failure');
+    expect(h.calls).toHaveLength(0);
+
+    h.throwOnCall = 2;
+    expect(() => makeMemoryHandlers().onRecall(1)).toThrow('injected dispatcher failure');
+    expect(h.calls.map((call) => call.name)).toEqual(['set_memory_mode']);
+  });
+
+  it('keeps memory ownership out of raw transport, optimistic state, and Store writers', () => {
+    const source = readFileSync('src/lib/runtime/commands/panel-commands.ts', 'utf8');
+    const memory = source.slice(source.indexOf('/* ── Memory Handlers'));
+    expect(memory).not.toMatch(/\b(?:sendCommand|patchRadioState|patchReceiver|patchActiveReceiver|optimistic)\b/);
+  });
+});

--- a/frontend/src/lib/runtime/commands/panel-commands.ts
+++ b/frontend/src/lib/runtime/commands/panel-commands.ts
@@ -21,10 +21,11 @@ import {
   getCapabilities,
   getControlRange,
 } from '$lib/stores/capabilities.svelte';
-import { isFieldAvailable } from '$lib/state/field-status';
+import { getFieldStatus, isFieldAvailable } from '$lib/state/field-status';
 import { runtime } from '../frontend-runtime';
 import { consumePendingFocus, setPendingFocus } from '$lib/radio/pending-focus';
 import { getModeFilter } from '$lib/radio/mode-filter-memory';
+import { relativeVfoIdentityUnknown } from '../props/panel-props';
 import { modInputCommand, modInputStateKey } from '$lib/radio/mod-input';
 import { nbDepthDisplayToRaw, nrDisplayToRaw } from '$lib/radio/filter-controls';
 import { audioManager } from '$lib/audio/audio-manager';
@@ -169,6 +170,87 @@ function mapIfShiftToPbt(
   return {
     pbtInner: clampToBipolarRange(currentPbtInner + delta),
     pbtOuter: clampToBipolarRange(currentPbtOuter + delta),
+  };
+}
+
+/* ── Memory Handlers ─────────────────────────────────────────────── */
+
+type MemorySnapshot = { frequencyHz: number | null; mode: string | null };
+
+function observedAvailableField(
+  state: NonNullable<ReturnType<typeof getRadioState>>,
+  path: string,
+): boolean {
+  const status = getFieldStatus(state, path);
+  return status?.observed === true && status.freshness === 'fresh'
+    && status.availability === 'available';
+}
+
+function currentMemorySnapshot(): MemorySnapshot | null {
+  const context = currentA03cContext();
+  const active = context?.state.active;
+  if (!context || !observedAvailableField(context.state, 'active')
+    || (active !== 'MAIN' && active !== 'SUB')
+    || knownA03cReceiver(context, active) === null) return null;
+
+  const receiverKey = active === 'SUB' ? 'sub' : 'main';
+  const receiver = context.state[receiverKey];
+  if (!receiver) return null;
+
+  let source: { freqHz?: number; mode?: string } = receiver;
+  let base = `${receiverKey}.`;
+  const relative = context.caps.vfoScheme === 'ab'
+    && relativeVfoIdentityUnknown(context.state, context.caps, receiverKey);
+  const unslotted = context.caps.vfoScheme === 'single'
+    || context.caps.vfoScheme === 'ab_shared';
+  if (!relative && !unslotted) {
+    const slot = receiver.activeSlot;
+    if (!observedAvailableField(context.state, `${receiverKey}.activeSlot`)
+      || (slot !== 'A' && slot !== 'B')) return null;
+    const slotKey = slot === 'A' ? 'vfoA' : 'vfoB';
+    const slotted = receiver[slotKey];
+    if (!slotted) return null;
+    source = slotted;
+    base = `${receiverKey}.${slotKey}.`;
+  }
+
+  const frequencyHz = source.freqHz;
+  const mode = source.mode;
+  return {
+    frequencyHz: observedAvailableField(context.state, `${base}freqHz`)
+      && Number.isSafeInteger(frequencyHz) && (frequencyHz as number) > 0
+      ? frequencyHz as number : null,
+    mode: observedAvailableField(context.state, `${base}mode`)
+      && typeof mode === 'string' && mode.length > 0 ? mode : null,
+  };
+}
+
+function validMemoryChannel(channel: number): boolean {
+  return Number.isSafeInteger(channel) && channel >= 1 && channel <= 99;
+}
+
+export function makeMemoryHandlers() {
+  return {
+    onRecall: (channel: number): boolean => {
+      if (!validMemoryChannel(channel) || currentMemorySnapshot() === null) return false;
+      dispatchRadioIntent({ name: 'set_memory_mode', params: { channel } });
+      dispatchRadioIntent({ name: 'memory_to_vfo', params: { channel } });
+      return true;
+    },
+    onStore: (channel: number, frequencyHz: number, mode: string): boolean => {
+      const snapshot = currentMemorySnapshot();
+      if (!validMemoryChannel(channel) || !snapshot || snapshot.frequencyHz === null
+        || snapshot.mode === null || frequencyHz !== snapshot.frequencyHz
+        || mode !== snapshot.mode) return false;
+      dispatchRadioIntent({ name: 'set_memory_mode', params: { channel } });
+      dispatchRadioIntent({ name: 'memory_write', params: {} });
+      return true;
+    },
+    onClear: (channel: number): boolean => {
+      if (!validMemoryChannel(channel) || currentMemorySnapshot() === null) return false;
+      dispatchRadioIntent({ name: 'memory_clear', params: { channel } });
+      return true;
+    },
   };
 }
 


### PR DESCRIPTION
Part of #2317

## Scope

- Base: `c7a5341da6237e367ddcc6ceaa9d78335e8d16ea`
- Head: `e44ecc5c4df213ad4fcfa4ec5156d428b5a48b7a`
- Production owners only: `panel-commands.ts`, `panel-adapters.ts`, and `MemoryPanel.svelte`.
- Production churn: 91 additions, 12 deletions (103 total); three isolated owned tests strengthened in a test-only follow-up.

## Authority and failure semantics

`makeMemoryHandlers` performs all semantic preflight before canonical typed dispatch. Recall emits `set_memory_mode` then `memory_to_vfo`; store emits `set_memory_mode` then `memory_write`; clear emits `memory_clear`. It returns `false` only before zero dispatch and returns `true` only after synchronous members complete. A member exception propagates; a second-member exception may leave the first initiated, with no rollback.

The panel owns a singleton adapter binding and changes its local unconfirmed catalog only after a `true` result. Rejection and exceptions produce no action-local mutation. Later lifecycle/ACK/NAK/timeout/cancel/reconnect events neither confirm nor roll back that local catalog. Local name editing remains intact.

## Final exact-head evidence

- Focused authority matrix: 8 files / 211 tests.
- Full frontend: 306 files / 6213 tests, build and static checks PASS.
- Fresh fixture: 64/64 scenarios, 1951/1951 assertions, Split 34/34, zero errors; manifest SHA-256 `0e457d4b892fd01e866fd19d6a669e056249c4db9040de14da9303eab4b97202` using the documented Chrome 151 fallback.
- Full non-hardware backend: 8993 passed, 12 skipped, 11 xfailed, 1 xpassed. Required static/generated/consumer/architecture/release dry-run gates PASS.
- Independent exact-head review: `Agent Review: PASS e44ecc5c4df213ad4fcfa4ec5156d428b5a48b7a`; required Agent Review Gate SUCCESS.

The test-only follow-up causally covers observed/requested frequency and mode equality, blank mode rejection, mode freshness/availability, and accepted-clear local deletion. Production bytes did not change in that follow-up.
