### PR TITLE
refactor: bind auxiliary tune intents

### DIFF
--- a/frontend/src/components-v2/panels/lcd/AmberCockpit.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberCockpit.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import {
-    deriveAmberCockpitProps, getAmberCockpitHandlers,
+    bindVfoTunerContext, deriveAmberCockpitProps,
+    getAmberCockpitHandlers, getVfoHandlers,
   } from '$lib/runtime/adapters/panel-adapters';
   import {
     toTxProps, toRitXitProps, toVfoOpsProps, toMeterProps,
@@ -19,6 +20,8 @@
   import { formatOffsetKHz } from '../rit-utils';
 
   const handlers = getAmberCockpitHandlers();
+  const vfoHandlers = getVfoHandlers();
+  const vfoContext = bindVfoTunerContext();
 
   // MOR-429: gate per-receiver indicators on fieldStatus availability so an
   // unobserved/stale/default value is never presented as a confirmed reading.
@@ -244,10 +247,38 @@
     handlers.onTuningChange(freq, mode);
   });
 
+  function activeTuneReceiver(
+    view: ReturnType<typeof vfoContext.read>['view'],
+  ): 0 | 1 | null {
+    if (!view || view.activeReceiver.status !== 'known') return null;
+    const activeReceiver = view.activeReceiver.receiver;
+    if (view.disabledReasons.some(
+      ({ field, code }) => field === `receiver.${activeReceiver}`
+        && code === 'capability-unavailable',
+    )) return null;
+    const activeVfos = view.vfos.filter(
+      (vfo) => vfo.receiver === activeReceiver && vfo.isActive,
+    );
+    if (activeVfos.length !== 1) return null;
+    const activeVfo = activeVfos[0];
+    if (!activeVfo || activeVfo.frequencyHz === null) return null;
+    const { slot } = activeVfo;
+    if (!(slot.kind === 'slotted' || slot.kind === 'unslotted'
+      || (slot.kind === 'relative' && slot.role === 'selected'))) return null;
+    return activeReceiver === 'MAIN' ? 0 : 1;
+  }
+
   function handleQsyRecall(freqHz: number, mode: string): void {
-    // Route through runtime — same CI-V path as other frequency changes.
-    runtime.send('set_freq', { freq: freqHz });
-    if (mode) runtime.send('set_mode', { mode });
+    const view = vfoContext.read().view;
+    const receiver = activeTuneReceiver(view);
+    if (receiver === null || !Number.isSafeInteger(freqHz) || freqHz <= 0) return;
+    if (mode !== '') {
+      const modeFilter = view?.modeFilter;
+      if (!modeFilter || !modeFilter.currentMode.availability.operational
+        || !modeFilter.modeChoices.includes(mode)) return;
+    }
+    vfoHandlers.onFreqChange(freqHz, receiver);
+    if (mode !== '') vfoHandlers.onModeChange(mode, receiver);
   }
 
   // ── Peer cockpit derivations ──

--- a/frontend/src/components-v2/panels/lcd/__tests__/AmberCockpit.qsy-authority.isolated.test.ts
+++ b/frontend/src/components-v2/panels/lcd/__tests__/AmberCockpit.qsy-authority.isolated.test.ts
@@ -1,0 +1,251 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createSubscriber } from 'svelte/reactivity';
+import { flushSync, mount, unmount } from 'svelte';
+import { readFileSync } from 'node:fs';
+
+type Slot =
+  | { kind: 'slotted'; id: 'A' | 'B' }
+  | { kind: 'relative'; role: 'selected' | 'unselected' }
+  | { kind: 'unslotted' }
+  | { kind: 'unknown' };
+
+const h = vi.hoisted(() => ({
+  props: {
+    radioState: {
+      active: 'MAIN',
+      main: { freqHz: 14_074_000, mode: 'USB', filter: 1, sMeter: 0 },
+      sub: { freqHz: 7_100_000, mode: 'LSB', filter: 1, sMeter: 0 },
+    },
+    caps: null,
+    hasAudioFft: false,
+    hasDualReceiver: false,
+    hasCapability: () => false,
+  } as Record<string, unknown>,
+  recent: [{ freqHz: 14_250_000, mode: '', at: 1 }],
+  read: vi.fn(),
+  onFreqChange: vi.fn(),
+  onModeChange: vi.fn(),
+  onTuningChange: vi.fn(),
+  rawSend: vi.fn(),
+  derive: () => h.props,
+  notify: () => {},
+  acquire: vi.fn(() => Object.freeze({ resource: 'audio-fft', consumer: 'AmberCockpit' })),
+  release: vi.fn(),
+  subscribe: vi.fn(() => vi.fn()),
+}));
+
+vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
+  deriveAmberCockpitProps: () => h.derive(),
+  deriveAmberTelemetryProps: () => ({ vdRaw: null, idRaw: null }),
+  getAmberCockpitHandlers: () => ({ onTuningChange: h.onTuningChange }),
+  getVfoHandlers: () => ({
+    onFreqChange: h.onFreqChange,
+    onModeChange: h.onModeChange,
+  }),
+  bindVfoTunerContext: () => Object.freeze({ read: h.read }),
+}));
+
+vi.mock('$lib/runtime/adapters/qsy-history-adapter', () => ({
+  deriveQsyRecent: () => h.recent,
+}));
+
+vi.mock('$lib/runtime/frontend-runtime', () => ({
+  presentationResources: { acquire: h.acquire, release: h.release },
+  runtime: {
+    send: h.rawSend,
+    scope: {
+      registerPresentationDriver: vi.fn(),
+      subscribe: h.subscribe,
+    },
+  },
+}));
+
+import AmberCockpit from '../AmberCockpit.svelte';
+
+let component: ReturnType<typeof mount> | undefined;
+let target: HTMLDivElement;
+
+const available = Object.freeze({ structural: true, operational: true });
+
+function view(
+  receiver: 'MAIN' | 'SUB' = 'MAIN',
+  slot: Slot = { kind: 'slotted', id: 'A' },
+  frequencyHz: number | null = receiver === 'MAIN' ? 14_074_000 : 7_100_000,
+  modeChoices: readonly string[] = ['USB', 'LSB'],
+) {
+  return {
+    activeReceiver: { status: 'known', receiver },
+    vfos: [{
+      receiver, slot, label: receiver, frequencyHz, mode: 'USB', filter: 'FIL1',
+      isActive: true, isActiveSlot: true, isTxTarget: false,
+    }],
+    disabledReasons: [],
+    modeFilter: {
+      currentMode: { reading: { status: 'known', value: 'USB' }, availability: available },
+      modeChoices,
+    },
+  };
+}
+
+function mountCockpit(freqHz = 14_250_000, mode = ''): HTMLButtonElement {
+  h.recent = [{ freqHz, mode, at: 1 }];
+  component = mount(AmberCockpit, { target });
+  flushSync();
+  const button = target.querySelector<HTMLButtonElement>('.slot-qsy');
+  if (!button) throw new Error('reachable QSY chip did not mount');
+  return button;
+}
+
+beforeEach(() => {
+  target = document.createElement('div');
+  document.body.appendChild(target);
+  h.props = {
+    radioState: {
+      active: 'MAIN',
+      main: { freqHz: 14_074_000, mode: 'USB', filter: 1, sMeter: 0 },
+      sub: { freqHz: 7_100_000, mode: 'LSB', filter: 1, sMeter: 0 },
+    },
+    caps: null,
+    hasAudioFft: false,
+    hasDualReceiver: false,
+    hasCapability: () => false,
+  };
+  let update = () => {};
+  const subscribe = createSubscriber((notify) => {
+    update = notify;
+    return () => {};
+  });
+  h.derive = () => {
+    subscribe();
+    return h.props;
+  };
+  h.notify = () => update();
+  h.read.mockReset();
+  h.read.mockReturnValue({ view: view() });
+  for (const mock of [
+    h.onFreqChange, h.onModeChange, h.onTuningChange, h.rawSend,
+    h.acquire, h.release, h.subscribe,
+  ]) mock.mockClear();
+});
+
+afterEach(() => {
+  if (component) unmount(component);
+  component = undefined;
+  target.remove();
+});
+
+describe('MOR-1409 A05b Amber QSY authority', () => {
+  it('retains the FFT runtime owner but routes QSY only through adapter-bound VFO callbacks', () => {
+    const source = readFileSync('src/components-v2/panels/lcd/AmberCockpit.svelte', 'utf8');
+    expect(source).toContain('getVfoHandlers');
+    expect(source).toContain('bindVfoTunerContext');
+    expect(source).toContain('runtime.scope.registerPresentationDriver');
+    expect(source).not.toMatch(/\bruntime\.send\s*\(/);
+    expect(source).not.toMatch(/(?:sendCommand|dispatchRadioIntent|panel-commands|command-bus)/);
+    expect(source).not.toMatch(/(?:getCommandLifecycles|onCommandDelivery|onControlSessionTransition)/);
+  });
+
+  it.each([
+    ['MAIN slotted', 'MAIN', { kind: 'slotted', id: 'A' }, 0],
+    ['SUB unslotted', 'SUB', { kind: 'unslotted' }, 1],
+    ['one-RX MAIN relative-selected', 'MAIN', { kind: 'relative', role: 'selected' }, 0],
+  ] as const)('reads once and sends one empty-mode frequency callback for %s', (_name, receiver, slot, expected) => {
+    h.read.mockReturnValue({ view: view(receiver, slot) });
+    mountCockpit(14_250_000, '').click();
+    expect(h.read).toHaveBeenCalledOnce();
+    expect(h.onFreqChange).toHaveBeenCalledExactlyOnceWith(14_250_000, expected);
+    expect(h.onModeChange).not.toHaveBeenCalled();
+    expect(h.rawSend).not.toHaveBeenCalled();
+  });
+
+  it('preflights a non-empty mode atomically, then emits exact frequency-before-mode order to one receiver', () => {
+    const order: string[] = [];
+    h.onFreqChange.mockImplementation(() => { order.push('freq'); });
+    h.onModeChange.mockImplementation(() => { order.push('mode'); });
+    h.read.mockReturnValue({ view: view('SUB', { kind: 'slotted', id: 'B' }) });
+    mountCockpit(7_155_000, 'LSB').click();
+    expect(h.read).toHaveBeenCalledOnce();
+    expect(h.onFreqChange).toHaveBeenCalledExactlyOnceWith(7_155_000, 1);
+    expect(h.onModeChange).toHaveBeenCalledExactlyOnceWith('LSB', 1);
+    expect(order).toEqual(['freq', 'mode']);
+    expect(h.rawSend).not.toHaveBeenCalled();
+  });
+
+  it('performs a fresh single read for every successive click', () => {
+    h.read
+      .mockReturnValueOnce({ view: view('MAIN', { kind: 'unslotted' }) })
+      .mockReturnValueOnce({ view: view('SUB', { kind: 'unslotted' }) });
+    const qsy = mountCockpit(14_250_000, '');
+    qsy.click();
+    qsy.click();
+    expect(h.read).toHaveBeenCalledTimes(2);
+    expect(h.onFreqChange.mock.calls).toEqual([[14_250_000, 0], [14_250_000, 1]]);
+  });
+
+  it.each([
+    ['null view', null],
+    ['unknown receiver', { ...view(), activeReceiver: { status: 'unknown' } }],
+    ['impossible SUB', {
+      ...view('SUB'), disabledReasons: [{ field: 'receiver.SUB', code: 'capability-unavailable' }],
+    }],
+    ['zero active positions', { ...view(), vfos: view().vfos.map((v) => ({ ...v, isActive: false })) }],
+    ['multiple active positions', { ...view(), vfos: [...view().vfos, { ...view().vfos[0] }] }],
+    ['null active frequency', view('MAIN', { kind: 'slotted', id: 'A' }, null)],
+    ['unknown slot', view('MAIN', { kind: 'unknown' })],
+    ['relative unselected', view('MAIN', { kind: 'relative', role: 'unselected' })],
+  ])('rejects %s with zero callbacks', (_name, candidate) => {
+    h.read.mockReturnValue({ view: candidate });
+    mountCockpit().click();
+    expect(h.read).toHaveBeenCalledOnce();
+    expect(h.onFreqChange).not.toHaveBeenCalled();
+    expect(h.onModeChange).not.toHaveBeenCalled();
+    expect(h.rawSend).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY, 0, -1, 1.5,
+    Number.MAX_SAFE_INTEGER + 1,
+  ])('rejects invalid QSY frequency %s before any callback', (freqHz) => {
+    mountCockpit(freqHz, '').click();
+    expect(h.read).toHaveBeenCalledOnce();
+    expect(h.onFreqChange).not.toHaveBeenCalled();
+    expect(h.onModeChange).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['missing group', undefined],
+    ['unavailable current mode', {
+      currentMode: { reading: { status: 'known', value: 'USB' }, availability: { structural: true, operational: false } },
+      modeChoices: ['USB'],
+    }],
+    ['mode outside exact choices', {
+      currentMode: { reading: { status: 'known', value: 'USB' }, availability: available },
+      modeChoices: ['USB'],
+    }],
+  ])('rejects non-empty mode atomically for %s', (_name, modeFilter) => {
+    h.read.mockReturnValue({ view: { ...view(), modeFilter } });
+    mountCockpit(14_250_000, _name === 'mode outside exact choices' ? 'LSB' : 'USB').click();
+    expect(h.read).toHaveBeenCalledOnce();
+    expect(h.onFreqChange).not.toHaveBeenCalled();
+    expect(h.onModeChange).not.toHaveBeenCalled();
+  });
+
+  it('does not turn click/lifecycle-shaped noise into QSY history and records only a later view observation', () => {
+    const qsy = mountCockpit(14_250_000, 'USB');
+    const beforeClick = h.onTuningChange.mock.calls.length;
+    qsy.click();
+    expect(h.onTuningChange).toHaveBeenCalledTimes(beforeClick);
+
+    h.props = {
+      ...h.props,
+      radioState: {
+        ...(h.props.radioState as Record<string, unknown>),
+        main: { freqHz: 14_300_000, mode: 'USB', filter: 1, sMeter: 0 },
+      },
+    };
+    h.notify();
+    flushSync();
+    expect(h.onTuningChange).toHaveBeenLastCalledWith(14_300_000, 'USB');
+    expect(h.onTuningChange.mock.calls.length).toBe(beforeClick + 1);
+  });
+});

--- a/frontend/src/components-v2/panels/lcd/__tests__/audio-fft-demand.isolated.test.ts
+++ b/frontend/src/components-v2/panels/lcd/__tests__/audio-fft-demand.isolated.test.ts
@@ -50,6 +50,17 @@ const mocks = vi.hoisted(() => {
     sendRaw: vi.fn(),
     sendCommand: vi.fn(() => true),
     onMessage: vi.fn(() => () => {}),
+    txController: Object.freeze({
+      snapshot: vi.fn(() => Object.freeze({
+        phase: 'idle', intent: null, sourceId: null, leaseId: null, guard: null,
+        fault: null, radioTx: 'off', txRisk: 'none', mayOwnKey: false,
+      })),
+      subscribe: vi.fn(() => () => {}),
+      start: vi.fn(),
+      setIntent: vi.fn(),
+      release: vi.fn(),
+      resetFault: vi.fn(),
+    }),
   };
 });
 
@@ -73,6 +84,9 @@ vi.mock('$lib/runtime/commands/radio-intents', async () => {
   const { sendCommand } = await import('$lib/transport/ws-client');
   return { dispatchRadioIntent: ({ name, params }: { name: string; params: Record<string, unknown> }) => sendCommand(name, params) };
 });
+vi.mock('$lib/runtime/tx-controller/app-host', () => ({
+  getAppTxController: () => mocks.txController,
+}));
 
 const canonicalCapabilities: Capabilities = {
   model: 'test',

--- a/frontend/src/components-v2/panels/lcd/__tests__/audio-fft-demand.isolated.test.ts
+++ b/frontend/src/components-v2/panels/lcd/__tests__/audio-fft-demand.isolated.test.ts
@@ -13,6 +13,23 @@ type DefaultScopeStatusProbe = {
   transport: MockConnectionState;
   frameSeen: boolean;
 };
+type ScopeFrameProbe = Readonly<{
+  receiver: number;
+  mode: number;
+  startFreq: number;
+  endFreq: number;
+  pixels: Uint8Array;
+}>;
+type AmberAfScopePropsProbe = {
+  data: Uint8Array | null;
+  bandwidth?: number;
+  onRegisterPush?: (push: (pixels: Uint8Array) => void) => void;
+};
+
+const scopeChildProbe = vi.hoisted(() => ({
+  props: null as AmberAfScopePropsProbe | null,
+  pushed: vi.fn<(pixels: Uint8Array) => void>(),
+}));
 
 const mocks = vi.hoisted(() => {
   const binaryHandlers = new Set<(data: ArrayBuffer) => void>();
@@ -87,6 +104,26 @@ vi.mock('$lib/runtime/commands/radio-intents', async () => {
 vi.mock('$lib/runtime/tx-controller/app-host', () => ({
   getAppTxController: () => mocks.txController,
 }));
+vi.mock('../AmberAfScope.svelte', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../AmberAfScope.svelte')>();
+  const RealAmberAfScope = actual.default as unknown as (
+    anchor: Node,
+    props: AmberAfScopePropsProbe,
+  ) => unknown;
+  return {
+    default: (anchor: Node, props: AmberAfScopePropsProbe) => {
+      const registerWithParent = props.onRegisterPush;
+      props.onRegisterPush = (push) => {
+        registerWithParent?.((pixels) => {
+          scopeChildProbe.pushed(pixels);
+          push(pixels);
+        });
+      };
+      scopeChildProbe.props = props;
+      return RealAmberAfScope(anchor, props);
+    },
+  };
+});
 
 const canonicalCapabilities: Capabilities = {
   model: 'test',
@@ -146,6 +183,18 @@ describe('LCD audio-FFT demand ownership', () => {
     const configure = vi.spyOn(presentationResources, 'configure');
     const acquire = vi.spyOn(presentationResources, 'acquire');
     const release = vi.spyOn(presentationResources, 'release');
+    const realScopeSubscribe = runtime.scope.subscribe.bind(runtime.scope);
+    let cockpitFrameHandler: ((frame: ScopeFrameProbe) => void) | undefined;
+    let cockpitUnsubscribe: ReturnType<typeof vi.fn<() => void>> | undefined;
+    const scopeSubscribe = vi.spyOn(runtime.scope, 'subscribe').mockImplementation((handler) => {
+      const realUnsubscribe = realScopeSubscribe(handler);
+      const exactUnsubscribe = vi.fn(() => realUnsubscribe());
+      if (!cockpitFrameHandler) {
+        cockpitFrameHandler = handler;
+        cockpitUnsubscribe = exactUnsubscribe;
+      }
+      return exactUnsubscribe;
+    });
     const targets = [document.createElement('div'), document.createElement('div')];
     let cockpit: ReturnType<typeof mount> | undefined;
     let scope: ReturnType<typeof mount> | undefined;
@@ -209,6 +258,23 @@ describe('LCD audio-FFT demand ownership', () => {
       cockpit = mount(AmberCockpit, { target: targets[0] });
       flushSync();
       expect(presentationResources.snapshot('audio-fft').demand).toBe(1);
+      expect(scopeSubscribe).toHaveBeenCalledOnce();
+      expect(cockpitFrameHandler).toBeTypeOf('function');
+      expect(cockpitUnsubscribe).not.toHaveBeenCalled();
+
+      const distinctivePixels = new Uint8Array([3, 17, 91, 205, 254]);
+      cockpitFrameHandler?.({
+        receiver: 0,
+        mode: 1,
+        startFreq: 14_012_345,
+        endFreq: 14_098_765,
+        pixels: distinctivePixels,
+      });
+      flushSync();
+      expect(scopeChildProbe.pushed).toHaveBeenCalledExactlyOnceWith(distinctivePixels);
+      expect(scopeChildProbe.props?.data).toBe(distinctivePixels);
+      expect(scopeChildProbe.props?.bandwidth).toBe(86_420);
+
       scope = mount(AmberScope, { target: targets[1] });
       flushSync();
       await vi.waitFor(() => expect(mocks.channel.connect).toHaveBeenCalledTimes(1));
@@ -219,6 +285,7 @@ describe('LCD audio-FFT demand ownership', () => {
       expect(mocks.channel.onStateChange).toHaveBeenCalledTimes(1);
       expect(mocks.channel.binaryHandlerCount()).toBe(1);
       expect(mocks.channel.stateHandlerCount()).toBe(1);
+      expect(scopeSubscribe).toHaveBeenCalledTimes(2);
       expect(acquire.mock.calls.map(([resource, consumer]) => [resource, consumer])).toEqual([
         ['audio-fft', 'AmberCockpit'],
         ['audio-fft', 'AmberScope'],
@@ -240,6 +307,7 @@ describe('LCD audio-FFT demand ownership', () => {
 
       await unmount(cockpit);
       cockpit = undefined;
+      expect(cockpitUnsubscribe).toHaveBeenCalledOnce();
       expect(presentationResources.snapshot('audio-fft').demand).toBe(1);
       expect(mocks.channel.disconnect).not.toHaveBeenCalled();
       expect(mocks.channel.binaryHandlerCount()).toBe(1);
@@ -259,6 +327,14 @@ describe('LCD audio-FFT demand ownership', () => {
       expect(configure).toHaveBeenCalledTimes(configureCountAfterCleanup);
       await cleanup();
       expect(mocks.stopPolling).toHaveBeenCalledTimes(1);
+      for (const surface of [
+        mocks.txController.snapshot,
+        mocks.txController.subscribe,
+        mocks.txController.start,
+        mocks.txController.setIntent,
+        mocks.txController.release,
+        mocks.txController.resetFault,
+      ]) expect(surface).not.toHaveBeenCalled();
     } finally {
       if (cockpit) await unmount(cockpit);
       if (scope) await unmount(scope);

--- a/frontend/src/components/spectrum/EiBiBrowser.svelte
+++ b/frontend/src/components/spectrum/EiBiBrowser.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
-  import { sendCommand } from '../../lib/transport/ws-client';
+  import {
+    bindVfoTunerContext, getVfoHandlers,
+  } from '$lib/runtime/adapters/panel-adapters';
+
+  const vfoHandlers = getVfoHandlers();
+  const vfoContext = bindVfoTunerContext();
 
   let { visible = $bindable(false) } = $props();
 
@@ -140,9 +145,36 @@
 
   // ── Actions ──
 
-  function tuneToStation(s: any) {
-    const hz = Math.round(s.freq_khz * 1000);
-    sendCommand('set_freq', { freq: hz });
+  function activeTuneReceiver(
+    view: ReturnType<typeof vfoContext.read>['view'],
+  ): 0 | 1 | null {
+    if (!view || view.activeReceiver.status !== 'known') return null;
+    const activeReceiver = view.activeReceiver.receiver;
+    if (view.disabledReasons.some(
+      ({ field, code }) => field === `receiver.${activeReceiver}`
+        && code === 'capability-unavailable',
+    )) return null;
+    const activeVfos = view.vfos.filter(
+      (vfo) => vfo.receiver === activeReceiver && vfo.isActive,
+    );
+    if (activeVfos.length !== 1) return null;
+    const activeVfo = activeVfos[0];
+    if (!activeVfo || activeVfo.frequencyHz === null) return null;
+    const { slot } = activeVfo;
+    if (!(slot.kind === 'slotted' || slot.kind === 'unslotted'
+      || (slot.kind === 'relative' && slot.role === 'selected'))) return null;
+    return activeReceiver === 'MAIN' ? 0 : 1;
+  }
+
+  function tuneToStation(s: any): void {
+    const view = vfoContext.read().view;
+    const receiver = activeTuneReceiver(view);
+    const freqKHz = s?.freq_khz;
+    if (receiver === null || typeof freqKHz !== 'number'
+      || !Number.isFinite(freqKHz) || freqKHz <= 0) return;
+    const hz = Math.round(freqKHz * 1000);
+    if (!Number.isSafeInteger(hz) || hz <= 0) return;
+    vfoHandlers.onFreqChange(hz, receiver);
   }
 
   function handleRowClick(idx: number) {

--- a/frontend/src/components/spectrum/__tests__/EiBiBrowser.authority.isolated.test.ts
+++ b/frontend/src/components/spectrum/__tests__/EiBiBrowser.authority.isolated.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, tick, unmount } from 'svelte';
+import { readFileSync } from 'node:fs';
+
+type Slot =
+  | { kind: 'slotted'; id: 'A' | 'B' }
+  | { kind: 'relative'; role: 'selected' | 'unselected' }
+  | { kind: 'unslotted' }
+  | { kind: 'unknown' };
+
+const h = vi.hoisted(() => ({
+  freqKHz: 14_074.125 as unknown,
+  read: vi.fn(),
+  onFreqChange: vi.fn(),
+  onModeChange: vi.fn(),
+  rawSend: vi.fn(),
+  fetch: vi.fn(),
+}));
+
+vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
+  getVfoHandlers: () => ({
+    onFreqChange: h.onFreqChange,
+    onModeChange: h.onModeChange,
+  }),
+  bindVfoTunerContext: () => Object.freeze({ read: h.read }),
+}));
+
+vi.mock('$lib/transport/ws-client', () => ({
+  sendCommand: h.rawSend,
+}));
+
+import EiBiBrowser from '../EiBiBrowser.svelte';
+
+let component: ReturnType<typeof mount> | undefined;
+let target: HTMLDivElement;
+
+function view(
+  receiver: 'MAIN' | 'SUB' = 'MAIN',
+  slot: Slot = { kind: 'slotted', id: 'A' },
+  frequencyHz: number | null = receiver === 'MAIN' ? 14_074_000 : 7_100_000,
+) {
+  return {
+    activeReceiver: { status: 'known', receiver },
+    vfos: [{
+      receiver, slot, label: receiver, frequencyHz, mode: 'USB', filter: 'FIL1',
+      isActive: true, isActiveSlot: true, isTxTarget: false,
+    }],
+    disabledReasons: [],
+  };
+}
+
+async function mountBrowser(freqKHz: unknown = 14_074.125): Promise<HTMLTableRowElement> {
+  h.freqKHz = freqKHz;
+  component = mount(EiBiBrowser, { target, props: { visible: true } });
+  flushSync();
+  await vi.waitFor(() => {
+    expect(target.querySelector('.station-row')).not.toBeNull();
+  });
+  return target.querySelector<HTMLTableRowElement>('.station-row')!;
+}
+
+function doubleClick(row: HTMLTableRowElement): void {
+  row.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
+}
+
+beforeEach(() => {
+  target = document.createElement('div');
+  document.body.appendChild(target);
+  h.read.mockReset();
+  h.read.mockReturnValue({ view: view() });
+  h.onFreqChange.mockReset();
+  h.onModeChange.mockReset();
+  h.rawSend.mockReset();
+  h.fetch.mockReset();
+  h.fetch.mockImplementation(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.includes('/status')) {
+      return { ok: true, json: async () => ({ loaded: true, languages: [], countries: [] }) } as Response;
+    }
+    if (url.includes('/bands')) {
+      return { ok: true, json: async () => ({ bands: [] }) } as Response;
+    }
+    if (url.includes('/stations')) {
+      return {
+        ok: true,
+        json: async () => ({
+          stations: [{
+            freq_khz: h.freqKHz,
+            station: 'Authority Test', language_name: 'English', language: 'E',
+            time_str: '0000-2400', days: '', target: 'Test', country: 'T',
+            band: 'test', remarks: '', on_air: true,
+          }],
+          total: 1,
+          pages: 1,
+        }),
+      } as Response;
+    }
+    throw new Error(`unexpected fetch ${url}`);
+  });
+  vi.stubGlobal('fetch', h.fetch);
+});
+
+afterEach(() => {
+  if (component) unmount(component);
+  component = undefined;
+  target.remove();
+  vi.unstubAllGlobals();
+});
+
+describe('MOR-1409 A05b EiBi tune authority', () => {
+  it('has no direct transport/command edge and binds the reviewed VFO seam', () => {
+    const source = readFileSync('src/components/spectrum/EiBiBrowser.svelte', 'utf8');
+    expect(source).toContain('getVfoHandlers');
+    expect(source).toContain('bindVfoTunerContext');
+    expect(source).not.toMatch(/(?:transport\/ws-client|sendCommand|runtime\.send|dispatchRadioIntent)/);
+    expect(source).not.toMatch(/(?:panel-commands|command-bus|radio-intents|\$lib\/stores)/);
+  });
+
+  it.each([
+    ['MAIN slotted', 'MAIN', { kind: 'slotted', id: 'A' }, 0],
+    ['real SUB unslotted', 'SUB', { kind: 'unslotted' }, 1],
+    ['one-RX MAIN relative-selected', 'MAIN', { kind: 'relative', role: 'selected' }, 0],
+  ] as const)('reads once and emits one exact rounded frequency for %s', async (_name, receiver, slot, expected) => {
+    h.read.mockReturnValue({ view: view(receiver, slot) });
+    const row = await mountBrowser(14_074.1254);
+    doubleClick(row);
+    expect(h.read).toHaveBeenCalledOnce();
+    expect(h.onFreqChange).toHaveBeenCalledExactlyOnceWith(14_074_125, expected);
+    expect(h.onModeChange).not.toHaveBeenCalled();
+    expect(h.rawSend).not.toHaveBeenCalled();
+  });
+
+  it('keeps the real expanded-row Tune button on the same one-callback path', async () => {
+    const row = await mountBrowser(7_155.4996);
+    row.click();
+    await tick();
+    const tune = target.querySelector<HTMLButtonElement>('.tune-btn');
+    expect(tune).not.toBeNull();
+    tune!.click();
+    expect(h.read).toHaveBeenCalledOnce();
+    expect(h.onFreqChange).toHaveBeenCalledExactlyOnceWith(7_155_500, 0);
+  });
+
+  it('performs a fresh single read for every successive double-click', async () => {
+    h.read
+      .mockReturnValueOnce({ view: view('MAIN', { kind: 'unslotted' }) })
+      .mockReturnValueOnce({ view: view('SUB', { kind: 'unslotted' }) });
+    const row = await mountBrowser(7_100.5);
+    doubleClick(row);
+    doubleClick(row);
+    expect(h.read).toHaveBeenCalledTimes(2);
+    expect(h.onFreqChange.mock.calls).toEqual([[7_100_500, 0], [7_100_500, 1]]);
+  });
+
+  it.each([
+    ['null view', null],
+    ['unknown receiver', { ...view(), activeReceiver: { status: 'unknown' } }],
+    ['impossible SUB', {
+      ...view('SUB'), disabledReasons: [{ field: 'receiver.SUB', code: 'capability-unavailable' }],
+    }],
+    ['zero active positions', { ...view(), vfos: view().vfos.map((v) => ({ ...v, isActive: false })) }],
+    ['multiple active positions', { ...view(), vfos: [...view().vfos, { ...view().vfos[0] }] }],
+    ['null active frequency', view('MAIN', { kind: 'slotted', id: 'A' }, null)],
+    ['unknown slot', view('MAIN', { kind: 'unknown' })],
+    ['relative unselected', view('MAIN', { kind: 'relative', role: 'unselected' })],
+  ])('rejects %s with zero callbacks', async (_name, candidate) => {
+    h.read.mockReturnValue({ view: candidate });
+    const row = await mountBrowser();
+    doubleClick(row);
+    expect(h.read).toHaveBeenCalledOnce();
+    expect(h.onFreqChange).not.toHaveBeenCalled();
+    expect(h.onModeChange).not.toHaveBeenCalled();
+    expect(h.rawSend).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['numeric string', '7100.5'],
+    ['NaN', Number.NaN],
+    ['positive infinity', Number.POSITIVE_INFINITY],
+    ['negative infinity', Number.NEGATIVE_INFINITY],
+    ['zero', 0],
+    ['negative', -1],
+    ['positive rounded zero', 0.0001],
+    ['unsafe result', Number.MAX_SAFE_INTEGER / 1000 + 1],
+  ])('rejects %s before any callback', async (_name, freqKHz) => {
+    const row = await mountBrowser(freqKHz);
+    doubleClick(row);
+    expect(h.read).toHaveBeenCalledOnce();
+    expect(h.onFreqChange).not.toHaveBeenCalled();
+    expect(h.onModeChange).not.toHaveBeenCalled();
+    expect(h.rawSend).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
+++ b/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
@@ -141,8 +141,27 @@ const runtimeHarness = vi.hoisted(() => {
 
 const mockRuntime = runtimeHarness.runtime;
 
+const appTxHostHarness = vi.hoisted(() => {
+  const controller = Object.freeze({
+    snapshot: vi.fn(() => Object.freeze({
+      phase: 'idle', intent: null, sourceId: null, leaseId: null, guard: null,
+      fault: null, radioTx: 'off', txRisk: 'none', mayOwnKey: false,
+    })),
+    subscribe: vi.fn(() => () => {}),
+    start: vi.fn(),
+    setIntent: vi.fn(),
+    release: vi.fn(),
+    resetFault: vi.fn(),
+  });
+  return { controller, getAppTxController: vi.fn(() => controller) };
+});
+
 vi.mock('$lib/runtime/frontend-runtime', () => ({
   runtime: runtimeHarness.runtime,
+}));
+
+vi.mock('$lib/runtime/tx-controller/app-host', () => ({
+  getAppTxController: appTxHostHarness.getAppTxController,
 }));
 
 vi.mock('$lib/stores/radio.svelte', () => ({
@@ -236,6 +255,15 @@ describe('SpectrumPanel component', () => {
   it('mounts without errors', () => {
     const target = mountPanel();
     expect(target.querySelector('.spectrum-panel')).not.toBeNull();
+    expect(appTxHostHarness.getAppTxController).toHaveBeenCalledOnce();
+    for (const surface of [
+      appTxHostHarness.controller.snapshot,
+      appTxHostHarness.controller.subscribe,
+      appTxHostHarness.controller.start,
+      appTxHostHarness.controller.setIntent,
+      appTxHostHarness.controller.release,
+      appTxHostHarness.controller.resetFault,
+    ]) expect(surface).not.toHaveBeenCalled();
   });
 
   it('renders the toolbar section', () => {

--- a/frontend/src/lib/runtime/commands/__tests__/auxiliary-tune-authority.isolated.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/auxiliary-tune-authority.isolated.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  state: null as Record<string, unknown> | null,
+  caps: null as Record<string, unknown> | null,
+  unavailable: new Set<string>(),
+  sendCommand: vi.fn((
+    _name: string,
+    _params: Record<string, unknown>,
+    _id: string,
+    _options: { optimistic: boolean },
+  ) => true),
+  patchActiveReceiver: vi.fn(),
+  patchRadioState: vi.fn(),
+  patchReceiver: vi.fn(),
+}));
+
+vi.mock('$lib/transport/ws-client', () => ({
+  getControlSession: vi.fn(() => ({ state: 'connected', epoch: 47 })),
+  onCommandDelivery: vi.fn(() => () => undefined),
+  onControlSessionTransition: vi.fn(() => () => undefined),
+  sendCommand: h.sendCommand,
+}));
+
+vi.mock('$lib/stores/radio.svelte', () => ({
+  getActiveReceiver: vi.fn(() => h.state?.active === 'SUB' ? h.state?.sub : h.state?.main),
+  getRadioState: vi.fn(() => h.state),
+  isRadioFieldAvailable: vi.fn((path: string) => h.state !== null && !h.unavailable.has(path)),
+  patchActiveReceiver: h.patchActiveReceiver,
+  patchRadioState: h.patchRadioState,
+  patchReceiver: h.patchReceiver,
+}));
+
+vi.mock('$lib/state/field-status', () => ({
+  isFieldAvailable: vi.fn((_state: unknown, path: string) => h.state !== null && !h.unavailable.has(path)),
+}));
+
+vi.mock('$lib/stores/capabilities.svelte', () => ({
+  getCapabilities: vi.fn(() => h.caps),
+  capabilitiesMatchGeneration: vi.fn((generation: unknown) =>
+    Number.isSafeInteger(generation)
+    && h.caps?.stateContractVersion === 1
+    && h.caps?.providerGeneration === generation),
+  getControlRange: vi.fn(() => null),
+  hasAudioFft: vi.fn(() => false),
+  hasDualReceiver: vi.fn(() => h.caps?.receivers === 2),
+  hasCapability: vi.fn((name: string) => (h.caps?.capabilities as string[] | undefined)?.includes(name) ?? false),
+}));
+
+vi.mock('$lib/runtime/frontend-runtime', () => ({
+  runtime: {
+    get state() { return h.state; },
+    get caps() { return h.caps; },
+    get rxEnabled() { return false; },
+    setMuted: vi.fn(), setRxLive: vi.fn(), setRxVolume: vi.fn(), setVolume: vi.fn(),
+  },
+}));
+
+vi.mock('$lib/audio/audio-manager', () => ({ audioManager: { setAudioConfig: vi.fn() } }));
+vi.mock('$lib/stores/tuning.svelte', () => ({ getTuningStep: vi.fn(() => 1_000) }));
+vi.mock('$lib/runtime/tx-controller/app-host', () => ({
+  getAppTxController: () => ({ snapshot: () => Object.freeze({ phase: 'idle', radioTx: 'off' }) }),
+}));
+vi.mock('$lib/runtime/adapters/radio-view-model-adapter', () => ({ toRadioViewModel: vi.fn(() => null) }));
+vi.mock('$lib/runtime/adapters/qsy-history-adapter', () => ({ recordQsy: vi.fn() }));
+vi.mock('$lib/runtime/props/panel-props', () => ({
+  toAgcProps: vi.fn(), toModeProps: vi.fn(), toAntennaProps: vi.fn(),
+  toRfFrontEndProps: vi.fn(), toRitXitProps: vi.fn(), toScanProps: vi.fn(),
+  toCwProps: vi.fn(), toDspProps: vi.fn(), toTxProps: vi.fn(),
+  toFilterProps: vi.fn(), toBandSelectorProps: vi.fn(), toAudioSpectrumProps: vi.fn(),
+  toMemoryPanelProps: vi.fn(), toAmberTelemetryProps: vi.fn(), toVfoControlProps: vi.fn(),
+}));
+
+import { getVfoHandlers } from '$lib/runtime/adapters/panel-adapters';
+import { getCommandLifecycles, resetCommandLifecycle } from '$lib/stores/commands.svelte';
+
+function state() {
+  return {
+    stateContractVersion: 1,
+    providerGeneration: 47,
+    active: 'MAIN',
+    main: { freqHz: 14_074_000, mode: 'USB', filter: 1 },
+    sub: { freqHz: 7_100_000, mode: 'LSB', filter: 1 },
+  };
+}
+
+beforeEach(() => {
+  h.state = state();
+  h.caps = {
+    stateContractVersion: 1,
+    providerGeneration: 47,
+    receivers: 2,
+    vfoScheme: 'main_sub',
+    capabilities: ['dual_rx'],
+    modes: ['USB', 'LSB'],
+  };
+  h.unavailable.clear();
+  h.sendCommand.mockClear();
+  h.patchActiveReceiver.mockClear();
+  h.patchRadioState.mockClear();
+  h.patchReceiver.mockClear();
+  resetCommandLifecycle();
+});
+
+afterEach(() => resetCommandLifecycle());
+
+function calls(): Array<[string, Record<string, unknown>]> {
+  return h.sendCommand.mock.calls.map(([name, params]) => [name, params]);
+}
+
+function expectTypedLifecycle(): void {
+  const ids = h.sendCommand.mock.calls.map((call) => call[2]);
+  expect(ids.every((id) => typeof id === 'string' && id.length > 0)).toBe(true);
+  expect(new Set(ids).size).toBe(ids.length);
+  for (const call of h.sendCommand.mock.calls) expect(call[3]).toEqual({ optimistic: false });
+  expect(getCommandLifecycles()).toHaveLength(h.sendCommand.mock.calls.length);
+  expect(h.patchActiveReceiver).not.toHaveBeenCalled();
+  expect(h.patchRadioState).not.toHaveBeenCalled();
+  expect(h.patchReceiver).not.toHaveBeenCalled();
+  expect(calls().map(([name]) => name).some((name) => /ptt|transmit|key/i.test(name))).toBe(false);
+}
+
+describe('MOR-1409 A05b real auxiliary VFO intent seam', () => {
+  it('returns the exact canonical singleton handler object through the adapter', () => {
+    expect(getVfoHandlers()).toBe(getVfoHandlers());
+    expect(Object.keys(getVfoHandlers())).toContain('onFreqChange');
+    expect(Object.keys(getVfoHandlers())).toContain('onModeChange');
+  });
+
+  it('emits the Amber composite as exact frequency then mode with distinct non-optimistic lifecycles', () => {
+    const vfo = getVfoHandlers();
+    vfo.onFreqChange(7_155_000, 1);
+    vfo.onModeChange('LSB', 1);
+    expect(calls()).toEqual([
+      ['set_freq', { freq: 7_155_000, receiver: 1 }],
+      ['set_mode', { mode: 'LSB', receiver: 1 }],
+    ]);
+    expectTypedLifecycle();
+  });
+
+  it('emits empty-mode Amber and EiBi as one exact frequency callback each', () => {
+    const vfo = getVfoHandlers();
+    vfo.onFreqChange(14_250_000, 0);
+    vfo.onFreqChange(7_100_500, 1);
+    expect(calls()).toEqual([
+      ['set_freq', { freq: 14_250_000, receiver: 0 }],
+      ['set_freq', { freq: 7_100_500, receiver: 1 }],
+    ]);
+    expectTypedLifecycle();
+  });
+
+  it('fails closed at the inherited seam for unavailable receiver leaves or generation drift', () => {
+    const vfo = getVfoHandlers();
+    h.unavailable.add('main.freqHz');
+    vfo.onFreqChange(14_250_000, 0);
+    h.unavailable.clear();
+    h.caps = { ...h.caps!, providerGeneration: 48 };
+    vfo.onModeChange('USB', 0);
+    expect(h.sendCommand).not.toHaveBeenCalled();
+    expect(getCommandLifecycles()).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- route Amber memory/QSY recalls through the existing live VFO intent authority with fail-closed physical receiver/VFO/slot/frequency and atomic mode preflight
- route EiBi tuning through the same adapter-bound VFO authority with exact numeric kHz-to-Hz normalization
- preserve Observation-only QSY history and the existing Amber audio-FFT lifecycle
- add mounted component, real typed-seam, and frozen parent-harness coverage

Part of #2317

## Verification

- focused frontend: 333/333
- full frontend: 6264/6264
- backend non-integration: 8993 passed, 12 skipped, 11 xfailed, 1 xpassed
- 46 one-at-a-time adversarial mutations killed and restored
- retained fixture: 64/64 captures, 1951/1951 assertions, zero console/page errors
- ruff, import contracts, strict web mypy, generated/consumer contracts, architecture checks: pass
- IC-7610, X6200, and FTX-1 non-hardware release dry-run goldens: pass
- base/head whole-tree mypy diagnostics: byte-identical

No hardware, radio, PTT, DTR, or RTS operation was performed.
