### PR TITLE
feat(#2317): add spectrum authority infrastructure

### DIFF
--- a/frontend/src/lib/runtime/adapters/__tests__/scope-adapter.authority.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/scope-adapter.authority.isolated.test.ts
@@ -1,0 +1,344 @@
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Capabilities, FilterModeConfig } from '$lib/types/capabilities';
+import type { FieldStatus, ServerState } from '$lib/types/state';
+
+const h = vi.hoisted(() => ({
+  modelOverride: null as unknown,
+  calls: 0,
+}));
+
+vi.mock('../radio-view-model-adapter', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../radio-view-model-adapter')>();
+  return {
+    ...actual,
+    toRadioViewModel: (...args: Parameters<typeof actual.toRadioViewModel>) => {
+      h.calls += 1;
+      return h.modelOverride ?? actual.toRadioViewModel(...args);
+    },
+  };
+});
+
+import {
+  parseScopeFrame, snapSpectrumFilterWidth, toSpectrumAuthority,
+} from '../scope-adapter';
+import { toRadioViewModel } from '../radio-view-model-adapter';
+
+const fresh: FieldStatus = {
+  storePath: 'fixture', observed: true, freshness: 'fresh', availability: 'available',
+};
+const stale: FieldStatus = {
+  storePath: 'fixture', observed: true, freshness: 'stale', availability: 'stale',
+};
+const SEGMENT_RULE: FilterModeConfig = {
+  defaults: [3000, 2400, 1800], fixed: false, minHz: 50, maxHz: 3600,
+  segments: [
+    { hzMin: 50, hzMax: 500, stepHz: 50, indexMin: 0 },
+    { hzMin: 600, hzMax: 3600, stepHz: 100, indexMin: 10 },
+  ],
+};
+const TABLE_RULE: FilterModeConfig = {
+  defaults: [2400, 1800, 300], fixed: false, table: [300, 600, 1200, 1800, 2400, 3000],
+};
+const STEP_RULE: FilterModeConfig = {
+  defaults: [3050, 1750, 550], fixed: false, minHz: 250, maxHz: 3550, stepHz: 100,
+};
+
+function receiver(frequencyHz: number, mode = 'USB') {
+  return {
+    freqHz: frequencyHz, mode, filter: 2, dataMode: 1, filterWidth: 2400,
+    filterShape: 1, pbtInner: 140, pbtOuter: 116, ifShift: 0,
+    att: 0, preamp: 0, nb: false, nr: false, afLevel: 1, rfGain: 1, squelch: 0, sMeter: 0,
+  };
+}
+
+function fieldStatus(): Record<string, FieldStatus> {
+  const paths = [
+    'active', 'split', 'dualWatch', 'txTarget',
+    'main.freqHz', 'main.mode', 'main.filter', 'main.filterWidth', 'main.filterShape',
+    'main.dataMode', 'main.pbtInner', 'main.pbtOuter', 'main.ifShift',
+    'sub.freqHz', 'sub.mode', 'sub.filter', 'sub.filterWidth', 'sub.filterShape',
+    'sub.dataMode', 'sub.pbtInner', 'sub.pbtOuter', 'sub.ifShift',
+    ...[
+      'mode', 'edge', 'span', 'speed', 'hold', 'refDb', 'dual', 'receiver',
+      'duringTx', 'centerType', 'vbwNarrow', 'rbw',
+    ].map((leaf) => `scopeControls.${leaf}`),
+  ];
+  return Object.fromEntries(paths.map((path) => [path, { ...fresh, storePath: path }]));
+}
+
+function state(overrides: Partial<ServerState> = {}): ServerState {
+  return {
+    stateContractVersion: 1, providerGeneration: 7,
+    active: 'MAIN', split: false, dualWatch: false, ptt: false, tunerStatus: 0,
+    txTarget: { status: 'known', receiver: 'MAIN', slot: null, frequencyHz: 14_074_000 },
+    main: receiver(14_074_000), sub: receiver(7_074_000, 'LSB'),
+    scopeControls: {
+      mode: 0, edge: 1, span: 3, speed: 1, hold: false, refDb: -5,
+      dual: false, receiver: 0, duringTx: false, centerType: 1, vbwNarrow: false, rbw: 1,
+      fixedEdge: { rangeIndex: 0, edge: 1, startHz: 14_000_000, endHz: 14_350_000 },
+    },
+    fieldStatus: fieldStatus(),
+    ...overrides,
+  } as ServerState;
+}
+
+function caps(overrides: Partial<Capabilities> = {}): Capabilities {
+  return {
+    model: 'fixture', scope: true, audio: true, tx: true,
+    stateContractVersion: 1, providerGeneration: 7,
+    capabilities: ['scope', 'dual_rx', 'filter_width', 'data_mode', 'pbt', 'if_shift'],
+    receivers: 2, vfoScheme: 'main_sub', freqRanges: [], modes: ['USB', 'LSB'], filters: ['FIL1'],
+    filterConfig: { USB: SEGMENT_RULE, LSB: SEGMENT_RULE },
+    audioConfig: { sampleRate: 48_000, channels: 1, codecs: ['pcm16'] },
+    webrtc: { available: false, enabled: false }, txBands: [],
+    ...overrides,
+  } as Capabilities;
+}
+
+function withStatus(base: ServerState, path: string, status: FieldStatus | undefined): ServerState {
+  const statuses = { ...base.fieldStatus } as Record<string, FieldStatus>;
+  if (status) statuses[path] = { ...status, storePath: path };
+  else delete statuses[path];
+  return { ...base, fieldStatus: statuses } as ServerState;
+}
+
+afterEach(() => {
+  h.modelOverride = null;
+  h.calls = 0;
+});
+
+describe('MOR-1409 A06a1 canonical spectrum authority selector', () => {
+  it('delegates once, returns deterministic deeply immutable facts, and leaves inputs untouched', () => {
+    const inputState = state();
+    const inputCaps = caps();
+    const beforeState = structuredClone(inputState);
+    const beforeCaps = structuredClone(inputCaps);
+
+    const first = toSpectrumAuthority(inputState, inputCaps);
+    const second = toSpectrumAuthority(inputState, inputCaps);
+
+    expect(h.calls).toBe(2);
+    expect(first).toEqual(second);
+    expect(first).toMatchObject({
+      providerGeneration: 7, receiver: 0, frequencyHz: 14_074_000,
+      mode: 'USB', filter: 'FIL2', filterWidthHz: 2400,
+      filterShape: 1, ifShiftHz: 0, pbtInnerHz: 113, pbtOuterHz: -112, dataMode: 1,
+      rule: { kind: 'segments', minHz: 50, maxHz: 3600 },
+    });
+    expect(first?.digest).toBe(second?.digest);
+    expect(Object.isFrozen(first)).toBe(true);
+    expect(Object.isFrozen(first?.rule)).toBe(true);
+    expect(Object.isFrozen(first?.rule?.kind === 'segments' ? first.rule.segments : null)).toBe(true);
+    expect(Object.isFrozen(first?.scopeControls)).toBe(true);
+    expect(Object.isFrozen(first?.scopeControls?.mode)).toBe(true);
+    expect(Object.isFrozen(first?.scopeControls?.mode.reading)).toBe(true);
+    expect(inputState).toEqual(beforeState);
+    expect(inputCaps).toEqual(beforeCaps);
+    expect(Object.isFrozen(inputState)).toBe(false);
+    expect(Object.isFrozen(inputCaps)).toBe(false);
+    expect(Object.isFrozen(inputCaps.capabilities)).toBe(false);
+
+    inputState.scopeControls!.mode = 3;
+    inputCaps.capabilities.push('later');
+    expect(first?.scopeControls?.mode.reading).toEqual({ status: 'known', value: 0 });
+  });
+
+  it.each([
+    [state({ stateContractVersion: undefined }), caps()],
+    [state(), caps({ stateContractVersion: undefined })],
+    [state({ providerGeneration: -1 }), caps()],
+    [state({ providerGeneration: 8 }), caps()],
+    [state(), caps({ providerGeneration: 8 })],
+    [state(), caps({ receivers: 1 })],
+    [state(), caps({ vfoScheme: 'single' })],
+  ] as Array<[ServerState, Capabilities]>)('rejects invalid epoch/topology row %#', (s, c) => {
+    expect(toSpectrumAuthority(s, c)).toBeNull();
+  });
+
+  it('rejects unknown active identity and physical SUB without valid dual topology', () => {
+    expect(toSpectrumAuthority(withStatus(state(), 'active', stale), caps())).toBeNull();
+    const sub = state({ active: 'SUB' });
+    expect(toSpectrumAuthority(sub, caps({ capabilities: ['scope', 'filter_width', 'data_mode'] }))).toBeNull();
+  });
+
+  it('maps valid dual MAIN/SUB to physical 0/1 with their canonical VFO facts', () => {
+    const main = toSpectrumAuthority(state(), caps());
+    const sub = toSpectrumAuthority(state({ active: 'SUB' }), caps());
+    expect(main).toMatchObject({ receiver: 0, frequencyHz: 14_074_000, mode: 'USB' });
+    expect(sub).toMatchObject({ receiver: 1, frequencyHz: 7_074_000, mode: 'LSB' });
+  });
+
+  it.each([
+    ['single', undefined],
+    ['ab', 'selected_unselected'],
+  ] as const)('maps one-receiver %s/relative identity to physical MAIN/0', (vfoScheme, vfoReadback) => {
+    const s = state({ active: 'MAIN', sub: receiver(7_074_000) as ServerState['sub'] });
+    const c = caps({
+      receivers: 1, vfoScheme, vfoReadback,
+      capabilities: ['scope', 'filter_width', 'data_mode', 'pbt', 'if_shift'],
+    });
+    expect(toSpectrumAuthority(s, c)).toMatchObject({ receiver: 0, frequencyHz: 14_074_000 });
+  });
+
+  it('rejects zero active canonical VFOs in an unobserved absolute A/B slot view', () => {
+    const s = state({
+      main: {
+        ...receiver(14_074_000), activeSlot: 'A',
+        vfoA: { freqHz: 14_074_000, mode: 'USB', filterNum: 2, dataMode: 1 },
+        vfoB: { freqHz: 7_074_000, mode: 'LSB', filterNum: 1, dataMode: 0 },
+      },
+    } as Partial<ServerState>);
+    expect(toSpectrumAuthority(s, caps({
+      receivers: 1, vfoScheme: 'ab', vfoReadback: 'absolute',
+      capabilities: ['scope', 'filter_width', 'data_mode', 'pbt', 'if_shift'],
+    }))).toBeNull();
+  });
+
+  it('rejects a delegated model with multiple active canonical VFOs', () => {
+    const model = toRadioViewModel(state(), caps());
+    expect(model).not.toBeNull();
+    h.modelOverride = {
+      ...model!,
+      vfos: model!.vfos.map((vfo, index) => ({ ...vfo, isActive: index < 2 })),
+    };
+    expect(toSpectrumAuthority(state(), caps())).toBeNull();
+  });
+
+  it('degrades an independently stale frequency to null without losing receiver identity', () => {
+    const result = toSpectrumAuthority(withStatus(state(), 'main.freqHz', stale), caps());
+    expect(result).toMatchObject({ receiver: 0, frequencyHz: null, mode: 'USB' });
+  });
+
+  it.each([
+    ['main.mode', 'mode'], ['main.filterWidth', 'filterWidthHz'],
+    ['main.dataMode', 'dataMode'], ['main.filterShape', 'filterShape'],
+    ['main.ifShift', 'ifShiftHz'], ['main.pbtInner', 'pbtInnerHz'], ['main.pbtOuter', 'pbtOuterHz'],
+  ] as const)('degrades stale %s only through its projected fact/rule', (path, key) => {
+    const result = toSpectrumAuthority(withStatus(state(), path, stale), caps());
+    expect(result).not.toBeNull();
+    expect(result?.[key]).toBeNull();
+    if (path === 'main.mode' || path === 'main.filterWidth' || path === 'main.dataMode') {
+      expect(result?.rule).toBeNull();
+    }
+  });
+
+  it('requires active-VFO and modeFilter parity before constructing a rule', () => {
+    const model = toRadioViewModel(state(), caps());
+    expect(model?.modeFilter).toBeDefined();
+    h.modelOverride = {
+      ...model!, modeFilter: {
+        ...model!.modeFilter!, currentMode: {
+          ...model!.modeFilter!.currentMode, reading: { status: 'known', value: 'CW' },
+        },
+      },
+    };
+    expect(toSpectrumAuthority(state(), caps())).toMatchObject({ mode: 'USB', rule: null });
+  });
+
+  it.each([
+    { defaults: [2400], fixed: true, table: [2400] },
+    { defaults: [2400], fixed: false },
+    { defaults: [], fixed: false, table: [] },
+    { defaults: [], fixed: false, table: [600, 300] },
+    { defaults: [], fixed: false, table: [300], segments: SEGMENT_RULE.segments },
+    { ...SEGMENT_RULE, segments: [{ hzMin: 50, hzMax: 525, stepHz: 50, indexMin: 0 }] },
+    { ...STEP_RULE, stepHz: 0 },
+  ] as FilterModeConfig[])('normalizes fixed/unresolved/malformed rule %# to null', (rule) => {
+    expect(toSpectrumAuthority(state(), caps({ filterConfig: { USB: rule } }))?.rule).toBeNull();
+  });
+
+  it.each([
+    [TABLE_RULE, 'table'], [SEGMENT_RULE, 'segments'], [STEP_RULE, 'step'],
+  ] as const)('normalizes valid %s metadata without sharing input arrays', (rule, kind) => {
+    const inputCaps = caps({ filterConfig: { USB: rule } });
+    const normalized = toSpectrumAuthority(state(), inputCaps)?.rule;
+    expect(normalized?.kind).toBe(kind);
+    expect(Object.isFrozen(normalized)).toBe(true);
+    expect(normalized).not.toBe(rule);
+  });
+
+  it('uses structural DATA-OFF only when data_mode is unsupported', () => {
+    const s = withStatus(state(), 'main.dataMode', stale);
+    const withoutData = caps({
+      capabilities: ['scope', 'dual_rx', 'filter_width', 'pbt', 'if_shift'],
+      filterConfig: { USB: STEP_RULE },
+    });
+    expect(toSpectrumAuthority(s, withoutData)).toMatchObject({ dataMode: null, rule: { kind: 'step' } });
+    expect(toSpectrumAuthority(s, caps({ filterConfig: { USB: STEP_RULE } }))).toMatchObject({ rule: null });
+  });
+
+  it('changes the digest with canonical facts but not with mutable input identity', () => {
+    const first = toSpectrumAuthority(state(), caps());
+    const equal = toSpectrumAuthority(structuredClone(state()), structuredClone(caps()));
+    const changed = toSpectrumAuthority(state({ main: { ...receiver(14_074_000), filterWidth: 1800 } }), caps());
+    expect(first?.digest).toBe(equal?.digest);
+    expect(first?.digest).not.toBe(changed?.digest);
+  });
+});
+
+describe('MOR-1409 A06a1 deterministic filter-width snapping', () => {
+  const rule = (config: FilterModeConfig) =>
+    toSpectrumAuthority(state(), caps({ filterConfig: { USB: config } }))!.rule;
+
+  it('snaps tables to the nearest exact entry and resolves ties low', () => {
+    const table = rule(TABLE_RULE);
+    expect(snapSpectrumFilterWidth(1700, table)).toBe(1800);
+    expect(snapSpectrumFilterWidth(1500, table)).toBe(1200);
+    expect(snapSpectrumFilterWidth(-1, table)).toBe(300);
+    expect(snapSpectrumFilterWidth(99_999, table)).toBe(3000);
+  });
+
+  it('snaps segments from each hzMin, across gaps, with deterministic tie-low', () => {
+    const segments = rule(SEGMENT_RULE);
+    expect(snapSpectrumFilterWidth(624, segments)).toBe(600);
+    expect(snapSpectrumFilterWidth(626, segments)).toBe(600);
+    expect(snapSpectrumFilterWidth(550, segments)).toBe(500);
+    expect(snapSpectrumFilterWidth(575, segments)).toBe(600);
+    expect(snapSpectrumFilterWidth(75, segments)).toBe(50);
+    expect(snapSpectrumFilterWidth(9_999, segments)).toBe(3600);
+    const offset = rule({
+      defaults: [275], fixed: false, minHz: 75, maxHz: 275,
+      segments: [{ hzMin: 75, hzMax: 275, stepHz: 50, indexMin: 0 }],
+    });
+    expect(snapSpectrumFilterWidth(100, offset)).toBe(75);
+  });
+
+  it('snaps simple steps from the resolved minimum and rejects invalid inputs', () => {
+    const step = rule(STEP_RULE);
+    expect(snapSpectrumFilterWidth(299, step)).toBe(250);
+    expect(snapSpectrumFilterWidth(300, step)).toBe(250);
+    expect(snapSpectrumFilterWidth(301, step)).toBe(350);
+    expect(snapSpectrumFilterWidth(Number.NaN, step)).toBeNull();
+    expect(snapSpectrumFilterWidth(1000, null)).toBeNull();
+    expect(snapSpectrumFilterWidth(1000, { kind: 'step', minHz: 0, maxHz: 10, stepHz: 0 })).toBeNull();
+  });
+});
+
+describe('MOR-1409 A06a1 decoder and purity boundary', () => {
+  it('keeps ScopeFrame/parseScopeFrame prefix byte-identical and decoding unchanged', () => {
+    const source = readFileSync(resolve(process.cwd(), 'src/lib/runtime/adapters/scope-adapter.ts'), 'utf8');
+    const prefixEnd = source.indexOf('\n}\n', source.indexOf('export function parseScopeFrame')) + 3;
+    const prefix = source.slice(0, prefixEnd);
+    expect(createHash('sha256').update(prefix).digest('hex'))
+      .toBe('e1ab452f4ab31dbe68a883b87708a3b9942145e50ef2a3e9e33904aa5fc838c1');
+    const buffer = new ArrayBuffer(17);
+    const view = new DataView(buffer);
+    view.setUint8(0, 0x01); view.setUint8(1, 1); view.setUint8(2, 2);
+    view.setUint32(3, 14_000_000, true); view.setUint32(7, 14_350_000, true);
+    view.setUint16(14, 1, true); view.setUint8(16, 0xff);
+    expect(parseScopeFrame(buffer)).toEqual({
+      receiver: 1, mode: 2, startFreq: 14_000_000, endFreq: 14_350_000,
+      pixels: new Uint8Array([0xff]),
+    });
+  });
+
+  it('keeps frame/pixel/runtime/store/transport inputs outside the selector permission path', () => {
+    const source = readFileSync(resolve(process.cwd(), 'src/lib/runtime/adapters/scope-adapter.ts'), 'utf8');
+    const selector = source.slice(source.indexOf('export function toSpectrumAuthority'));
+    expect(selector).toMatch(/toSpectrumAuthority\(\s*state[^,]*,\s*caps/);
+    expect(selector).not.toMatch(/ScopeFrame|pixels|Uint8Array|FrontendRuntime|radio\.svelte|transport|sendCommand/);
+  });
+});

--- a/frontend/src/lib/runtime/adapters/scope-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/scope-adapter.ts
@@ -25,3 +25,209 @@ export function parseScopeFrame(buf: ArrayBuffer): ScopeFrame | null {
     pixels: new Uint8Array(buf, 16, pixelCount),
   });
 }
+
+import type { Capabilities, FilterModeConfig, FilterSegmentConfig } from '$lib/types/capabilities';
+import type { ServerState } from '$lib/types/state';
+import type { ScopeControlsViewModel } from '../../../semantic/radio-view-model';
+import { resolveFilterModeConfig } from '$lib/runtime/props/panel-props';
+import { toRadioViewModel } from './radio-view-model-adapter';
+
+type DeepReadonly<T> = T extends readonly (infer U)[] ? readonly DeepReadonly<U>[]
+  : T extends object ? { readonly [K in keyof T]: DeepReadonly<T[K]> } : T;
+
+export type SpectrumFilterRule =
+  | Readonly<{ kind: 'table'; minHz: number; maxHz: number; values: readonly number[] }>
+  | Readonly<{
+    kind: 'segments'; minHz: number; maxHz: number;
+    segments: readonly Readonly<FilterSegmentConfig>[];
+  }>
+  | Readonly<{ kind: 'step'; minHz: number; maxHz: number; stepHz: number }>;
+
+export interface SpectrumAuthority {
+  readonly providerGeneration: number;
+  readonly receiver: 0 | 1;
+  readonly frequencyHz: number | null;
+  readonly mode: string | null;
+  readonly filter: string | null;
+  readonly filterWidthHz: number | null;
+  readonly filterShape: number | null;
+  readonly ifShiftHz: number | null;
+  readonly pbtInnerHz: number | null;
+  readonly pbtOuterHz: number | null;
+  readonly dataMode: number | null;
+  readonly rule: SpectrumFilterRule | null;
+  readonly scopeControls: DeepReadonly<ScopeControlsViewModel> | null;
+  readonly digest: string;
+}
+
+const positiveInteger = (value: unknown): value is number =>
+  Number.isSafeInteger(value) && (value as number) > 0;
+const nonnegativeInteger = (value: unknown): value is number =>
+  Number.isSafeInteger(value) && (value as number) >= 0;
+const finiteNumber = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value);
+const strictlySeen = (state: ServerState, path: string): boolean => {
+  const status = state.fieldStatus?.[path];
+  return status?.observed === true && status.freshness === 'fresh'
+    && status.availability === 'available';
+};
+
+function immutableClone<T>(value: T): DeepReadonly<T> {
+  if (Array.isArray(value)) return Object.freeze(value.map(immutableClone)) as DeepReadonly<T>;
+  if (value !== null && typeof value === 'object') {
+    const clone = Object.fromEntries(Object.entries(value).map(([key, item]) => [key, immutableClone(item)]));
+    return Object.freeze(clone) as DeepReadonly<T>;
+  }
+  return value as DeepReadonly<T>;
+}
+
+function validSegments(segments: readonly FilterSegmentConfig[], minHz: number, maxHz: number): boolean {
+  if (segments.length === 0 || segments[0].hzMin !== minHz
+    || segments[segments.length - 1].hzMax !== maxHz) return false;
+  let priorHzMax = 0;
+  let priorIndexMax = -1;
+  for (const segment of segments) {
+    if (!positiveInteger(segment.hzMin) || !positiveInteger(segment.hzMax)
+      || !positiveInteger(segment.stepHz) || !nonnegativeInteger(segment.indexMin)
+      || segment.hzMin > segment.hzMax
+      || (segment.hzMax - segment.hzMin) % segment.stepHz !== 0
+      || segment.hzMin <= priorHzMax || segment.indexMin <= priorIndexMax) return false;
+    priorHzMax = segment.hzMax;
+    priorIndexMax = segment.indexMin + ((segment.hzMax - segment.hzMin) / segment.stepHz);
+    if (!Number.isSafeInteger(priorIndexMax)) return false;
+  }
+  return true;
+}
+
+function normalizeFilterRule(config: FilterModeConfig | null): SpectrumFilterRule | null {
+  if (!config || config.fixed || (config.table !== undefined && config.segments !== undefined)) return null;
+  if (config.table !== undefined) {
+    const values = config.table;
+    if (values.length === 0 || values.some((value, index) =>
+      !positiveInteger(value) || (index > 0 && value <= values[index - 1]))) return null;
+    const minHz = values[0];
+    const maxHz = values[values.length - 1];
+    if ((config.minHz !== undefined && config.minHz !== minHz)
+      || (config.maxHz !== undefined && config.maxHz !== maxHz)) return null;
+    return { kind: 'table', minHz, maxHz, values: [...values] };
+  }
+  if (config.segments !== undefined) {
+    if (!positiveInteger(config.minHz) || !positiveInteger(config.maxHz)
+      || config.minHz > config.maxHz || !validSegments(config.segments, config.minHz, config.maxHz)) return null;
+    return { kind: 'segments', minHz: config.minHz, maxHz: config.maxHz,
+      segments: config.segments.map((segment) => ({ ...segment })) };
+  }
+  if (!positiveInteger(config.minHz) || !positiveInteger(config.maxHz)
+    || !positiveInteger(config.stepHz) || config.minHz > config.maxHz
+    || (config.maxHz - config.minHz) % config.stepHz !== 0) return null;
+  return { kind: 'step', minHz: config.minHz, maxHz: config.maxHz, stepHz: config.stepHz };
+}
+
+function knownReading<T>(
+  state: ServerState,
+  path: string,
+  field: { readonly reading: { readonly status: 'known'; readonly value: T } | { readonly status: 'unknown' } }
+    | undefined,
+): T | null {
+  return strictlySeen(state, path) && field?.reading.status === 'known' ? field.reading.value : null;
+}
+
+function activeVfoPath(receiver: 'MAIN' | 'SUB', slot: { readonly kind: string; readonly id?: string }): string {
+  const key = receiver === 'SUB' ? 'sub' : 'main';
+  return slot.kind === 'slotted' && (slot.id === 'A' || slot.id === 'B')
+    ? `${key}.${slot.id === 'A' ? 'vfoA' : 'vfoB'}.` : `${key}.`;
+}
+
+export function toSpectrumAuthority(
+  state: ServerState | null,
+  caps: Capabilities | null,
+): SpectrumAuthority | null {
+  const generation = state?.providerGeneration;
+  const capsGeneration = caps?.providerGeneration;
+  if (!state || !caps || state.stateContractVersion !== 1 || caps.stateContractVersion !== 1
+    || !nonnegativeInteger(generation) || !nonnegativeInteger(capsGeneration)
+    || generation !== capsGeneration) return null;
+  const expectedReceivers = caps.vfoScheme === 'single' || caps.vfoScheme === 'ab' ? 1
+    : caps.vfoScheme === 'ab_shared' || caps.vfoScheme === 'main_sub' ? 2 : 0;
+  if (expectedReceivers === 0 || caps.receivers !== expectedReceivers) return null;
+  const model = toRadioViewModel(state, caps);
+  if (!model || model.activeReceiver.status !== 'known'
+    || model.activeReceiver.receiver !== state.active) return null;
+  const receiverName = model.activeReceiver.receiver;
+  if (receiverName === 'SUB'
+    && (caps.receivers !== 2 || !caps.capabilities.includes('dual_rx') || !state.sub)) return null;
+  const activeVfos = model.vfos.filter((vfo) => vfo.isActive);
+  if (activeVfos.length !== 1 || activeVfos[0].receiver !== receiverName) return null;
+  const activeVfo = activeVfos[0];
+  const receiver: 0 | 1 = receiverName === 'SUB' ? 1 : 0;
+  const key = receiver === 1 ? 'sub' : 'main';
+  const base = activeVfoPath(receiverName, activeVfo.slot);
+  const frequencyHz = strictlySeen(state, `${base}freqHz`) && finiteNumber(activeVfo.frequencyHz)
+    ? activeVfo.frequencyHz : null;
+  const mode = strictlySeen(state, `${base}mode`) && typeof activeVfo.mode === 'string'
+    && activeVfo.mode.length > 0 ? activeVfo.mode : null;
+  const filter = strictlySeen(state, `${base}${activeVfo.slot.kind === 'slotted' ? 'filterNum' : 'filter'}`)
+    && typeof activeVfo.filter === 'string' ? activeVfo.filter : null;
+  const modeFilter = model.modeFilter;
+  const passband = model.filterPassband;
+  const modeFact = knownReading(state, `${key}.mode`, modeFilter?.currentMode);
+  const widthFact = knownReading(state, `${key}.filterWidth`, modeFilter?.filterWidth);
+  const dataFact = knownReading(state, `${key}.dataMode`, passband?.dataMode);
+  const filterWidthHz = positiveInteger(widthFact) ? widthFact : null;
+  const dataMode = nonnegativeInteger(dataFact) ? dataFact : null;
+  const supportsData = caps.capabilities.includes('data_mode');
+  const rule = mode !== null && modeFact === mode && filterWidthHz !== null
+    && (!supportsData || dataMode !== null) && caps.capabilities.includes('filter_width')
+    ? normalizeFilterRule(resolveFilterModeConfig(caps, mode, supportsData ? dataMode! : 0)) : null;
+  const core = {
+    providerGeneration: generation,
+    receiver,
+    frequencyHz,
+    mode,
+    filter,
+    filterWidthHz,
+    filterShape: finiteNumber(knownReading(state, `${key}.filterShape`, passband?.filterShape))
+      ? knownReading(state, `${key}.filterShape`, passband?.filterShape) as number : null,
+    ifShiftHz: finiteNumber(knownReading(state, `${key}.ifShift`, passband?.ifShift))
+      ? knownReading(state, `${key}.ifShift`, passband?.ifShift) as number : null,
+    pbtInnerHz: finiteNumber(knownReading(state, `${key}.pbtInner`, passband?.pbtInner))
+      ? knownReading(state, `${key}.pbtInner`, passband?.pbtInner) as number : null,
+    pbtOuterHz: finiteNumber(knownReading(state, `${key}.pbtOuter`, passband?.pbtOuter))
+      ? knownReading(state, `${key}.pbtOuter`, passband?.pbtOuter) as number : null,
+    dataMode,
+    rule,
+    scopeControls: model.scopeControls ? immutableClone(model.scopeControls) : null,
+  };
+  return immutableClone({ ...core, digest: JSON.stringify(core) });
+}
+
+function snapStep(raw: number, minHz: number, maxHz: number, stepHz: number): number {
+  const bounded = Math.max(minHz, Math.min(maxHz, raw));
+  const lower = minHz + Math.floor((bounded - minHz) / stepHz) * stepHz;
+  const upper = Math.min(maxHz, lower + stepHz);
+  return bounded - lower <= upper - bounded ? lower : upper;
+}
+
+export function snapSpectrumFilterWidth(
+  raw: number,
+  rule: SpectrumFilterRule | null,
+): number | null {
+  if (!finiteNumber(raw) || !rule || !positiveInteger(rule.minHz) || !positiveInteger(rule.maxHz)
+    || rule.minHz > rule.maxHz) return null;
+  if (rule.kind === 'table') {
+    if (rule.values.length === 0 || rule.values[0] !== rule.minHz
+      || rule.values[rule.values.length - 1] !== rule.maxHz
+      || rule.values.some((value, index) =>
+        !positiveInteger(value) || (index > 0 && value <= rule.values[index - 1]))) return null;
+    return rule.values.reduce((best, value) =>
+      Math.abs(raw - value) < Math.abs(raw - best) ? value : best);
+  }
+  if (rule.kind === 'segments') {
+    if (!validSegments(rule.segments, rule.minHz, rule.maxHz)) return null;
+    return rule.segments.map((segment) => snapStep(raw, segment.hzMin, segment.hzMax, segment.stepHz))
+      .reduce((best, value) => Math.abs(raw - value) < Math.abs(raw - best)
+        || (Math.abs(raw - value) === Math.abs(raw - best) && value < best) ? value : best);
+  }
+  if (!positiveInteger(rule.stepHz) || (rule.maxHz - rule.minHz) % rule.stepHz !== 0) return null;
+  return snapStep(raw, rule.minHz, rule.maxHz, rule.stepHz);
+}

--- a/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Capabilities, FilterModeConfig } from '$lib/types/capabilities';
 import type { ServerState } from '$lib/types/state';
 
 const h = vi.hoisted(() => ({
@@ -49,6 +50,10 @@ vi.mock('$lib/stores/radio.svelte', () => ({
 }));
 
 vi.mock('$lib/state/field-status', () => ({
+  getFieldStatus: vi.fn((_state: ServerState | null, path: string) =>
+    h.unavailable.has(path)
+      ? { storePath: path, observed: true, freshness: 'stale', availability: 'stale' }
+      : h.state?.fieldStatus?.[path]),
   isFieldAvailable: vi.fn((_state: ServerState | null, path: string) =>
     h.state !== null && !h.unavailable.has(path)),
 }));
@@ -1569,5 +1574,224 @@ describe('MOR-1409 A03e canonical system, scope, and local keyboard ownership', 
     scope.onDualChange(true);
     expect(exactCalls()).toEqual([['switch_scope_receiver', { receiver: 0 }]]);
     expectIntentTransport();
+  });
+});
+
+const A06_SEGMENTS: FilterModeConfig = {
+  defaults: [3000, 2400, 1800], fixed: false, minHz: 50, maxHz: 3600,
+  segments: [
+    { hzMin: 50, hzMax: 500, stepHz: 50, indexMin: 0 },
+    { hzMin: 600, hzMax: 3600, stepHz: 100, indexMin: 10 },
+  ],
+};
+const A06_TABLE: FilterModeConfig = {
+  defaults: [2400, 1800, 300], fixed: false,
+  table: [300, 600, 1200, 1800, 2400, 3000],
+};
+const A06_STEP: FilterModeConfig = {
+  defaults: [3050, 1750, 550], fixed: false, minHz: 250, maxHz: 3550, stepHz: 100,
+};
+
+function a06State(active: 'MAIN' | 'SUB' = 'MAIN'): ServerState {
+  const current = state(active);
+  const paths = [
+    'active', 'main.mode', 'main.filterWidth', 'main.dataMode',
+    'sub.mode', 'sub.filterWidth', 'sub.dataMode',
+  ];
+  return {
+    ...current,
+    fieldStatus: Object.fromEntries(paths.map((path) => [path, { ...freshStatus, storePath: path }])),
+  } as ServerState;
+}
+
+function a06Caps(rule: FilterModeConfig = A06_SEGMENTS): Capabilities {
+  return {
+    model: 'fixture', scope: true, audio: true, tx: true,
+    capabilities: ['filter_width', 'data_mode', 'dual_rx'],
+    stateContractVersion: 1, providerGeneration: 31,
+    receivers: 2, vfoScheme: 'main_sub', freqRanges: [], modes: ['USB'], filters: ['FIL1'],
+    filterConfig: { USB: rule },
+    audioConfig: { sampleRate: 48_000, channels: 1, codecs: ['pcm16'] },
+    webrtc: { available: false, enabled: false }, txBands: [],
+  };
+}
+
+describe('MOR-1409 A06a1 synchronous final filter-width authority', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    h.state = a06State();
+    h.caps = a06Caps() as unknown as Record<string, unknown>;
+    h.unavailable.clear();
+    h.sendCommand.mockClear();
+    resetCommandLifecycle();
+  });
+
+  afterEach(() => {
+    resetCommandLifecycle();
+    vi.useRealTimers();
+  });
+
+  it.each([
+    ['segmented', A06_SEGMENTS, 2400],
+    ['table', A06_TABLE, 1800],
+    ['simple-step', A06_STEP, 1750],
+  ] as const)('commits one exact synchronous %s intent with no timer', (_name, rule, width) => {
+    h.caps = a06Caps(rule) as unknown as Record<string, unknown>;
+    makeFilterHandlers().onFilterWidthCommit(width, 0, 31);
+
+    expect(exactCalls()).toEqual([['set_filter_width', { width, receiver: 0 }]]);
+    expectIntentTransport();
+    // The one timer belongs to the existing command-lifecycle timeout. The
+    // new handler itself stays synchronous and owns no debounce/timer.
+    expect(vi.getTimerCount()).toBe(1);
+    const source = readFileSync(resolve(process.cwd(), 'src/lib/runtime/commands/panel-commands.ts'), 'utf8');
+    const commitBlock = source.slice(source.indexOf('onFilterWidthCommit:'), source.indexOf('onFilterShapeChange:'));
+    expect(commitBlock).not.toContain('setTimeout');
+    expect(h.patchActiveReceiver).not.toHaveBeenCalled();
+    expect(h.patchRadioState).not.toHaveBeenCalled();
+    expect(h.patchReceiver).not.toHaveBeenCalled();
+  });
+
+  it('accepts the valid observed dual-SUB physical receiver exactly once', () => {
+    h.state = a06State('SUB');
+    makeFilterHandlers().onFilterWidthCommit(2400, 1, 31);
+
+    expect(exactCalls()).toEqual([['set_filter_width', { width: 2400, receiver: 1 }]]);
+    expectIntentTransport();
+  });
+
+  it('retains the legacy delayed handler independently of the synchronous member', () => {
+    const handlers = makeFilterHandlers();
+    handlers.onFilterWidthChange(1800);
+    expect(h.sendCommand).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(1);
+    vi.advanceTimersByTime(199);
+    expect(h.sendCommand).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(exactCalls()).toEqual([['set_filter_width', { width: 1800, receiver: 0 }]]);
+  });
+
+  it('rejects unsafe generations, mismatched epochs, stale identity, and target disagreement', () => {
+    const commit = (generation: number, receiver: 0 | 1 = 0) =>
+      makeFilterHandlers().onFilterWidthCommit(2400, receiver, generation);
+    commit(-1); commit(Number.MAX_SAFE_INTEGER + 1); commit(30);
+    h.caps = { ...a06Caps(), providerGeneration: 32 } as unknown as Record<string, unknown>;
+    commit(31);
+    h.caps = a06Caps() as unknown as Record<string, unknown>;
+    h.unavailable.add('active'); commit(31);
+    h.unavailable.clear(); commit(31, 1);
+    expect(h.sendCommand).not.toHaveBeenCalled();
+    expect(getCommandLifecycles()).toHaveLength(0);
+  });
+
+  it('rejects every impossible SUB topology and absent physical SUB state', () => {
+    h.state = a06State('SUB');
+    const attempt = () => makeFilterHandlers().onFilterWidthCommit(2400, 1, 31);
+    for (const caps of [
+      { ...a06Caps(), capabilities: ['filter_width', 'data_mode'] },
+      { ...a06Caps(), receivers: 1, vfoScheme: 'ab' },
+      { ...a06Caps(), receivers: 1 },
+      { ...a06Caps(), vfoScheme: 'single' },
+    ]) {
+      h.caps = caps as unknown as Record<string, unknown>; attempt();
+    }
+    h.caps = a06Caps() as unknown as Record<string, unknown>;
+    h.state = { ...a06State('SUB'), sub: null } as unknown as ServerState;
+    attempt();
+    expect(h.sendCommand).not.toHaveBeenCalled();
+  });
+
+  it('requires fresh positive current mode, width and supported DATA facts', () => {
+    const attempt = () => makeFilterHandlers().onFilterWidthCommit(2400, 0, 31);
+    for (const path of ['main.mode', 'main.filterWidth', 'main.dataMode']) {
+      h.unavailable.add(path); attempt(); h.unavailable.clear();
+    }
+    for (const [field, value] of [
+      ['mode', ''], ['filterWidth', 0], ['filterWidth', Number.NaN], ['dataMode', -1],
+    ] as const) {
+      h.state = { ...a06State(), main: { ...a06State().main, [field]: value } } as ServerState;
+      attempt();
+    }
+    h.state = a06State();
+    h.caps = { ...a06Caps(), capabilities: ['filter_width'] } as unknown as Record<string, unknown>;
+    h.unavailable.add('main.dataMode');
+    attempt();
+    expect(exactCalls()).toEqual([['set_filter_width', { width: 2400, receiver: 0 }]]);
+  });
+
+  it('rejects missing capability, unresolved/fixed/default-only rules and unsafe candidates', () => {
+    const attempt = (width: number = 2400) => makeFilterHandlers().onFilterWidthCommit(width, 0, 31);
+    h.caps = { ...a06Caps(), capabilities: ['data_mode'] } as unknown as Record<string, unknown>; attempt();
+    h.caps = { ...a06Caps(), filterConfig: {} } as unknown as Record<string, unknown>; attempt();
+    h.caps = a06Caps({ defaults: [2400], fixed: true, table: [2400] }) as unknown as Record<string, unknown>; attempt();
+    h.caps = a06Caps({ defaults: [2400], fixed: false, minHz: 50, maxHz: 3600 }) as unknown as Record<string, unknown>; attempt();
+    h.caps = a06Caps() as unknown as Record<string, unknown>;
+    attempt(0); attempt(Number.NaN); attempt(Number.MAX_SAFE_INTEGER + 1);
+    expect(h.sendCommand).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { defaults: [], fixed: false, table: [] },
+    { defaults: [], fixed: false, table: [300, 300, 600] },
+    { defaults: [], fixed: false, table: [600, 300] },
+    { defaults: [], fixed: false, minHz: 400, maxHz: 2400, table: [300, 600, 2400] },
+    { defaults: [], fixed: false, table: [300, 600], segments: A06_SEGMENTS.segments },
+  ] as FilterModeConfig[])('rejects malformed table metadata %#', (rule) => {
+    h.caps = a06Caps(rule) as unknown as Record<string, unknown>;
+    makeFilterHandlers().onFilterWidthCommit(600, 0, 31);
+    expect(h.sendCommand).not.toHaveBeenCalled();
+  });
+
+  it('rejects table nonmembers even inside its numeric bounds', () => {
+    h.caps = a06Caps(A06_TABLE) as unknown as Record<string, unknown>;
+    makeFilterHandlers().onFilterWidthCommit(2000, 0, 31);
+    expect(h.sendCommand).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { ...A06_SEGMENTS, segments: [] },
+    { ...A06_SEGMENTS, segments: [{ hzMin: 0, hzMax: 500, stepHz: 50, indexMin: 0 }] },
+    { ...A06_SEGMENTS, segments: [{ hzMin: 500, hzMax: 50, stepHz: 50, indexMin: 0 }] },
+    { ...A06_SEGMENTS, segments: [{ hzMin: 50, hzMax: 525, stepHz: 50, indexMin: 0 }] },
+    { ...A06_SEGMENTS, segments: [
+      { hzMin: 50, hzMax: 500, stepHz: 50, indexMin: 0 },
+      { hzMin: 500, hzMax: 3600, stepHz: 100, indexMin: 10 },
+    ] },
+    { ...A06_SEGMENTS, segments: [
+      { hzMin: 50, hzMax: 500, stepHz: 50, indexMin: 5 },
+      { hzMin: 600, hzMax: 3600, stepHz: 100, indexMin: 4 },
+    ] },
+    { ...A06_SEGMENTS, minHz: 100 },
+    { ...A06_SEGMENTS, maxHz: 3500 },
+  ] as FilterModeConfig[])('rejects malformed segment metadata %#', (rule) => {
+    h.caps = a06Caps(rule) as unknown as Record<string, unknown>;
+    makeFilterHandlers().onFilterWidthCommit(300, 0, 31);
+    expect(h.sendCommand).not.toHaveBeenCalled();
+  });
+
+  it('rejects segment gaps and hzMin-relative misalignment', () => {
+    makeFilterHandlers().onFilterWidthCommit(550, 0, 31);
+    makeFilterHandlers().onFilterWidthCommit(625, 0, 31);
+    h.caps = a06Caps({
+      defaults: [275], fixed: false, minHz: 75, maxHz: 275,
+      segments: [{ hzMin: 75, hzMax: 275, stepHz: 50, indexMin: 0 }],
+    }) as unknown as Record<string, unknown>;
+    makeFilterHandlers().onFilterWidthCommit(100, 0, 31);
+    expect(h.sendCommand).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { ...A06_STEP, minHz: 0 }, { ...A06_STEP, maxHz: 100 },
+    { ...A06_STEP, stepHz: 0 }, { ...A06_STEP, stepHz: 1.5 },
+  ] as FilterModeConfig[])('rejects malformed simple-step metadata %#', (rule) => {
+    h.caps = a06Caps(rule) as unknown as Record<string, unknown>;
+    makeFilterHandlers().onFilterWidthCommit(200, 0, 31);
+    expect(h.sendCommand).not.toHaveBeenCalled();
+  });
+
+  it('anchors simple-step alignment at the resolved minimum', () => {
+    h.caps = a06Caps(A06_STEP) as unknown as Record<string, unknown>;
+    makeFilterHandlers().onFilterWidthCommit(300, 0, 31);
+    expect(h.sendCommand).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/lib/runtime/commands/panel-commands.ts
+++ b/frontend/src/lib/runtime/commands/panel-commands.ts
@@ -25,7 +25,8 @@ import { getFieldStatus, isFieldAvailable } from '$lib/state/field-status';
 import { runtime } from '../frontend-runtime';
 import { consumePendingFocus, setPendingFocus } from '$lib/radio/pending-focus';
 import { getModeFilter } from '$lib/radio/mode-filter-memory';
-import { relativeVfoIdentityUnknown } from '../props/panel-props';
+import { relativeVfoIdentityUnknown, resolveFilterModeConfig } from '../props/panel-props';
+import type { FilterModeConfig, FilterSegmentConfig } from '$lib/types/capabilities';
 import { modInputCommand, modInputStateKey } from '$lib/radio/mod-input';
 import { nbDepthDisplayToRaw, nrDisplayToRaw } from '$lib/radio/filter-controls';
 import { audioManager } from '$lib/audio/audio-manager';
@@ -714,6 +715,54 @@ export function makeTxHandlers() {
 
 /* ── Filter Handlers ─────────────────────────────────────────────── */
 
+const positiveSafeInteger = (value: unknown): value is number =>
+  Number.isSafeInteger(value) && (value as number) > 0;
+
+function validFilterSegments(segments: readonly FilterSegmentConfig[], minHz: number, maxHz: number): boolean {
+  if (segments.length === 0 || segments[0].hzMin !== minHz
+    || segments[segments.length - 1].hzMax !== maxHz) return false;
+  let previousHzMax = 0;
+  let previousIndexMax = -1;
+  for (const segment of segments) {
+    if (!positiveSafeInteger(segment.hzMin) || !positiveSafeInteger(segment.hzMax)
+      || !positiveSafeInteger(segment.stepHz) || !Number.isSafeInteger(segment.indexMin)
+      || segment.indexMin < 0 || segment.hzMin > segment.hzMax
+      || (segment.hzMax - segment.hzMin) % segment.stepHz !== 0
+      || segment.hzMin <= previousHzMax || segment.indexMin <= previousIndexMax) return false;
+    previousHzMax = segment.hzMax;
+    previousIndexMax = segment.indexMin + ((segment.hzMax - segment.hzMin) / segment.stepHz);
+    if (!Number.isSafeInteger(previousIndexMax)) return false;
+  }
+  return true;
+}
+
+function validResolvedFilterWidth(width: number, rule: FilterModeConfig | null): boolean {
+  if (!positiveSafeInteger(width) || !rule || rule.fixed) return false;
+  const hasTable = rule.table !== undefined;
+  const hasSegments = rule.segments !== undefined;
+  if (hasTable && hasSegments) return false;
+  if (hasTable) {
+    const table = rule.table!;
+    if (table.length === 0 || table.some((value, index) =>
+      !positiveSafeInteger(value) || (index > 0 && value <= table[index - 1]))) return false;
+    if ((rule.minHz !== undefined && rule.minHz !== table[0])
+      || (rule.maxHz !== undefined && rule.maxHz !== table[table.length - 1])) return false;
+    return table.includes(width);
+  }
+  if (hasSegments) {
+    if (!positiveSafeInteger(rule.minHz) || !positiveSafeInteger(rule.maxHz)
+      || rule.minHz > rule.maxHz
+      || !validFilterSegments(rule.segments!, rule.minHz, rule.maxHz)) return false;
+    const segment = rule.segments!.find(({ hzMin, hzMax }) => width >= hzMin && width <= hzMax);
+    return segment !== undefined && (width - segment.hzMin) % segment.stepHz === 0;
+  }
+  return positiveSafeInteger(rule.minHz) && positiveSafeInteger(rule.maxHz)
+    && positiveSafeInteger(rule.stepHz) && rule.minHz <= rule.maxHz
+    && (rule.maxHz - rule.minHz) % rule.stepHz === 0
+    && width >= rule.minHz && width <= rule.maxHz
+    && (width - rule.minHz) % rule.stepHz === 0;
+}
+
 export function makeFilterHandlers() {
   return {
     onFilterChange: (filter: number) => {
@@ -733,6 +782,38 @@ export function makeFilterHandlers() {
         }, 200);
       };
     })(),
+    onFilterWidthCommit: (
+      width: number,
+      receiver: Receiver,
+      expectedProviderGeneration: number,
+    ): void => {
+      const context = currentA03cContext();
+      const stateGeneration = context?.state.providerGeneration;
+      const active = context?.state.active;
+      if (!context || !Number.isSafeInteger(expectedProviderGeneration)
+        || expectedProviderGeneration < 0 || !Number.isSafeInteger(stateGeneration)
+        || expectedProviderGeneration !== stateGeneration
+        || !observedAvailableField(context.state, 'active')
+        || (active !== 'MAIN' && active !== 'SUB')
+        || (active === 'MAIN' ? 0 : 1) !== receiver
+        || knownA03cReceiver(context, active, 'mode') !== receiver
+        || knownA03cReceiver(context, active, 'filterWidth') !== receiver
+        || !context.caps.capabilities.includes('filter_width')) return;
+      const key = receiver === 1 ? 'sub' : 'main';
+      const observed = context.state[key];
+      const mode = observed?.mode;
+      const currentWidth = observed?.filterWidth;
+      if (!observed || !observedAvailableField(context.state, `${key}.mode`)
+        || !observedAvailableField(context.state, `${key}.filterWidth`)
+        || typeof mode !== 'string' || mode.length === 0 || !positiveSafeInteger(currentWidth)) return;
+      const supportsData = context.caps.capabilities.includes('data_mode');
+      const dataMode = supportsData ? observed.dataMode : 0;
+      if (supportsData && (!observedAvailableField(context.state, `${key}.dataMode`)
+        || !Number.isSafeInteger(dataMode) || (dataMode as number) < 0)) return;
+      const rule = resolveFilterModeConfig(context.caps, mode, dataMode as number);
+      if (!validResolvedFilterWidth(width, rule)) return;
+      dispatchRadioIntent({ name: 'set_filter_width', params: { width, receiver } });
+    },
     onFilterShapeChange: (shape: number) => {
       const receiver = knownActiveReceiver('filterShape');
       if (receiver === null) return;


### PR DESCRIPTION
## Summary

- add a synchronous final filter-width commit member that revalidates generation, physical receiver, fresh radio facts, capability, and the resolved table/segment/step rule before emitting one typed intent
- add one pure immutable spectrum-authority selector and deterministic filter-width snap helper while preserving the existing scope-frame decoder byte-for-byte
- cover valid dual SUB/receiver 1, one-receiver relative identity, malformed rules, stale facts, immutability, snapping, and decoder/purity boundaries

## Scope and safety

This is the corrected A06a1 infrastructure slice only. It changes exactly the two production owners and two authorized tests. SpectrumPanel, enforcement, transports, stores, generated files, and hardware paths are unchanged. Production churn is 289 changed lines, below the 391 STOP threshold.

No radio, serial port, LAN rig session, PTT, TUNE, DTR/RTS, RF path, or hardware validation was used.

## Verification

- focused: 126 tests passed
- adversarial: all 24 singleton mutations produced substantive RED and were restored
- frontend exact-head: type check, lint, boundaries, i18n, 6,333 tests, production build
- exact-head fixture: 64/64 valid captures, 1,951/1,951 assertions, zero console/page errors
- backend: 8,993 passed; static, generated-state, consumer, architecture, schema, and release dry-run gates passed
- whole-tree mypy: base/head byte-identical 13 pre-existing diagnostics in the same four files

Part of #2317
