### PR TITLE
refactor(#2317): migrate scope-settings, VFO header, media-session authority (A07)

### DIFF
--- a/docs/internals/ui-radio-control-contract.toml
+++ b/docs/internals/ui-radio-control-contract.toml
@@ -561,9 +561,7 @@ owner = "MOR-1409"
 reason = "Presentation consumes read-only view models and typed intent facades; exact legacy edges may only shrink"
 exceptions = [
   { path = "src/components-v2/layout/StatusBar.svelte", count = 1, owner = "MOR-1409" },
-  { path = "src/components-v2/layout/VfoHeader.svelte", count = 1, owner = "MOR-1409" },
   { path = "src/components/spectrum/EiBiBrowser.svelte", count = 1, owner = "MOR-1409" },
-  { path = "src/components/spectrum/ScopeSettingsPopover.svelte", count = 1, owner = "MOR-1409" },
 ]
 
 [[guards]]
@@ -572,10 +570,8 @@ kind = "legacyWriterOwners"
 owner = "MOR-1409"
 reason = "Only the WS reducer is the final owner; exact migration debt cannot expand"
 exceptions = [
-  { path = "src/components-v2/layout/VfoHeader.svelte", count = 1, owner = "MOR-1409" },
   { path = "src/components-v2/wiring/command-bus.ts", count = 1, owner = "MOR-1409" },
   { path = "src/components-v2/wiring/state-adapter.ts", count = 1, owner = "MOR-1409" },
-  { path = "src/lib/media/media-session.ts", count = 1, owner = "MOR-1409" },
   { path = "src/lib/runtime/adapters/mod-input-auto.svelte.ts", count = 1, owner = "MOR-1409" },
   { path = "src/lib/runtime/commands/panel-commands.ts", count = 1, owner = "MOR-1409" },
   { path = "src/lib/runtime/frontend-runtime.ts", count = 1, owner = "MOR-1409" },

--- a/frontend/scripts/radio-authority-eslint-plugin.mjs
+++ b/frontend/scripts/radio-authority-eslint-plugin.mjs
@@ -19,15 +19,11 @@ const SCOPE_METADATA = new Set([
 
 const LEGACY_PRESENTATION_AUTHORITY = new Set([
   'src/components-v2/layout/StatusBar.svelte',
-  'src/components-v2/layout/VfoHeader.svelte',
   'src/components/spectrum/EiBiBrowser.svelte',
-  'src/components/spectrum/ScopeSettingsPopover.svelte',
 ]);
 const LEGACY_WRITER_OWNERS = new Set([
-  'src/components-v2/layout/VfoHeader.svelte',
   'src/components-v2/wiring/command-bus.ts',
   'src/components-v2/wiring/state-adapter.ts',
-  'src/lib/media/media-session.ts',
   'src/lib/runtime/adapters/mod-input-auto.svelte.ts',
   'src/lib/runtime/commands/panel-commands.ts',
   'src/lib/runtime/frontend-runtime.ts',

--- a/frontend/src/components-v2/layout/VfoHeader.svelte
+++ b/frontend/src/components-v2/layout/VfoHeader.svelte
@@ -12,8 +12,10 @@
   import VfoPanel from '../vfo/VfoPanel.svelte';
   import VfoOps from '../vfo/VfoOps.svelte';
   import DualVfoDisplay from '../panels/vfo/DualVfoDisplay.svelte';
-  import { hasDualReceiver } from '$lib/stores/capabilities.svelte';
-  import { patchRadioState } from '$lib/stores/radio.svelte';
+  import { hasCapability, hasDualReceiver } from '$lib/stores/capabilities.svelte';
+  import { runtime } from '$lib/runtime/frontend-runtime';
+  import { toSpectrumAuthority } from '$lib/runtime/adapters/scope-adapter';
+  import { bindSemanticSurfaceHandlers, getVfoHandlers } from '$lib/runtime/adapters/panel-adapters';
   import { formatFrequency } from '../display/frequency-format';
   import type { VfoLayoutProfile } from './vfo-layout-tokens';
   import type { VfoStateProps } from './layout-utils';
@@ -61,25 +63,47 @@
     splitActive,
     dualWatchActive,
     txVfo,
-    scopeStatus = null,
     onSwap = () => {},
     onEqual = () => {},
     onSplitToggle = () => {},
     onQuickSplit = () => {},
     onDualWatchToggle = (_on: boolean) => {},
     onQuickDw = () => {},
-    onMainVfoClick,
-    onSubVfoClick,
     onMainModeClick,
     onSubModeClick,
     onMainFreqChange,
     onSubFreqChange,
     onSpeak,
-    onScopeDualToggle,
-    onScopeReceiverChange,
   }: Props = $props();
 
   let dualReceiver = $derived(hasDualReceiver());
+  let scopeCapable = $derived(hasCapability('scope'));
+  const vfoHandlers = getVfoHandlers();
+  const scopeHandlers = bindSemanticSurfaceHandlers().scopeControls;
+  let scopeControls = $derived(toSpectrumAuthority(runtime.state, runtime.caps)?.scopeControls ?? null);
+
+  type NumberScopeField = 'span' | 'speed' | 'receiver';
+  type BooleanScopeField = 'dual';
+
+  function acceptedNumber(field: NumberScopeField, min: number, max: number): number | null {
+    const fact = scopeControls?.[field];
+    if (!fact?.availability?.structural || !fact.availability.operational
+      || fact.reading?.status !== 'known' || !Number.isSafeInteger(fact.reading.value)
+      || fact.reading.value < min || fact.reading.value > max) return null;
+    return fact.reading.value;
+  }
+
+  function acceptedBoolean(field: BooleanScopeField): boolean | null {
+    const fact = scopeControls?.[field];
+    if (!fact?.availability?.structural || !fact.availability.operational
+      || fact.reading?.status !== 'known' || typeof fact.reading.value !== 'boolean') return null;
+    return fact.reading.value;
+  }
+
+  let scopeSpan = $derived(acceptedNumber('span', 0, 7));
+  let scopeSpeed = $derived(acceptedNumber('speed', 0, 2));
+  let scopeReceiver = $derived(acceptedNumber('receiver', 0, 1));
+  let scopeDual = $derived(acceptedBoolean('dual'));
 
   function formatBridgeFrequency(freq: number): string {
     const { mhz, khz } = formatFrequency(freq);
@@ -93,14 +117,10 @@
   let activeReceiver = $derived<'MAIN' | 'SUB'>(mainVfo.isActive ? 'MAIN' : 'SUB');
 
   function handleActiveReceiverChange(next: 'MAIN' | 'SUB'): void {
-    // Optimistic local patch so the toggle reflects the change
-    // immediately; the click handlers below also fire the backend
-    // command via the command-bus wiring.
-    patchRadioState({ active: next });
     if (next === 'MAIN') {
-      onMainVfoClick?.();
+      vfoHandlers.onMainVfoClick();
     } else {
-      onSubVfoClick?.();
+      vfoHandlers.onSubVfoClick();
     }
   }
 
@@ -127,11 +147,10 @@
       active={mainVfo.isActive ? 'MAIN' : 'SUB'}
       {layoutProfile}
       onActivate={(receiver) => {
-        patchRadioState({ active: receiver });
         if (receiver === 'MAIN') {
-          onMainVfoClick?.();
+          vfoHandlers.onMainVfoClick();
         } else {
-          onSubVfoClick?.();
+          vfoHandlers.onSubVfoClick();
         }
       }}
       onMainModeClick={onMainModeClick}
@@ -144,7 +163,7 @@
       <VfoPanel
         {...mainVfo}
         {layoutProfile}
-        onVfoClick={onMainVfoClick}
+        onVfoClick={vfoHandlers.onMainVfoClick}
         onModeClick={onMainModeClick}
         onFreqChange={onMainFreqChange}
       />
@@ -167,7 +186,7 @@
         {onQuickDw}
       />
 
-      {#if scopeStatus}
+      {#if scopeCapable}
         <div class="scope-status" data-testid="scope-status">
           <span class="scope-status-title">SCOPE</span>
           {#if dualReceiver}
@@ -175,28 +194,31 @@
               <button
                 type="button"
                 class="scope-pill"
-                class:active={scopeStatus.receiver !== 1}
-                onclick={() => onScopeReceiverChange?.(0)}
-                title={`Set scope source to MAIN (current: ${scopeStatus.receiver === 1 ? 'SUB' : 'MAIN'})`}
+                class:active={scopeReceiver === 0}
+                disabled={scopeReceiver === null}
+                onclick={() => { if (scopeReceiver !== null) scopeHandlers.onReceiverChange(0); }}
+                title="Set scope source to MAIN"
               >MAIN</button>
               <button
                 type="button"
                 class="scope-pill"
-                class:active={scopeStatus.receiver === 1}
-                onclick={() => onScopeReceiverChange?.(1)}
-                title={`Set scope source to SUB (current: ${scopeStatus.receiver === 1 ? 'SUB' : 'MAIN'})`}
+                class:active={scopeReceiver === 1}
+                disabled={scopeReceiver === null}
+                onclick={() => { if (scopeReceiver !== null) scopeHandlers.onReceiverChange(1); }}
+                title="Set scope source to SUB"
               >SUB</button>
             </div>
             <button
               type="button"
               class="scope-dual"
-              class:active={scopeStatus.dual}
-              onclick={() => onScopeDualToggle?.()}
-              title={`Toggle dual scope (currently ${scopeStatus.dual ? 'ON' : 'OFF'})`}
+              class:active={scopeDual === true}
+              disabled={scopeDual === null}
+              onclick={() => { if (scopeDual !== null) scopeHandlers.onDualChange(!scopeDual); }}
+              title="Toggle dual scope"
             >DUAL</button>
           {/if}
           <span class="scope-status-row scope-digest">
-            {SPAN_LABELS[scopeStatus.span] ?? '\u00b125k'} {SPEED_LABELS[scopeStatus.speed] ?? 'MID'}
+            {scopeSpan === null ? '\u2014' : SPAN_LABELS[scopeSpan]} {scopeSpeed === null ? '\u2014' : SPEED_LABELS[scopeSpeed]}
           </span>
         </div>
       {/if}

--- a/frontend/src/components-v2/layout/__tests__/vfo-header.isolated.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/vfo-header.isolated.test.ts
@@ -1,223 +1,343 @@
-/**
- * Tests for the SCOPE status block in VfoHeader bridge (issue #832).
- *
- * The block renders only when `scopeStatus` prop is non-null, shows the
- * MAIN/SUB source pills + DUAL toggle only when dual receiver is available,
- * and always shows the SPAN/SPEED read-only digest.
- */
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mount, unmount, flushSync } from 'svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { VfoStateProps } from '../layout-utils';
 
-// ── Mocks ──────────────────────────────────────────────────────────────────
-vi.mock('$lib/stores/capabilities.svelte', () => ({
-  hasDualReceiver: vi.fn(() => true),
-  hasTx: vi.fn(() => true),
-  hasSpectrum: vi.fn(() => false),
-  hasAnyScope: vi.fn(() => false),
-  hasAudioFft: vi.fn(() => false),
-  hasCapability: vi.fn(() => false),
-  getScopeSource: vi.fn(() => null),
-  vfoLabel: vi.fn((slot: 'A' | 'B') => (slot === 'A' ? 'MAIN' : 'SUB')),
-  receiverLabel: vi.fn((id: 'MAIN' | 'SUB') => id),
-  vfoSlotLabel: vi.fn((slot: 'A' | 'B') => (slot === 'A' ? 'VFO A' : 'VFO B')),
-  getCapabilities: vi.fn(() => ({ freqRanges: [], modes: [], filters: [] })),
-  getVfoScheme: vi.fn(() => 'main_sub'),
-  getAgcModes: vi.fn(() => [0, 1, 2, 3]),
-  getAgcLabels: vi.fn(() => ({ 0: 'OFF', 1: 'FAST', 2: 'MID', 3: 'SLOW' })),
-  getSupportedModes: vi.fn(() => ['USB', 'LSB', 'CW', 'AM', 'FM']),
-  getSupportedFilters: vi.fn(() => ['FIL1', 'FIL2', 'FIL3']),
-  getAttValues: vi.fn(() => [0, 10, 20]),
-  getAttLabels: vi.fn(() => ({ 0: '0dB', 10: '10dB', 20: '20dB' })),
-  getPreValues: vi.fn(() => [0, 1, 2]),
-  getPreLabels: vi.fn(() => ({ 0: 'OFF', 1: 'PRE1', 2: 'PRE2' })),
-  getAntennaCount: vi.fn(() => 1),
-  getSmeterCalibration: vi.fn(() => null),
-  getSmeterRedline: vi.fn(() => null),
-  getMeterCalibration: vi.fn(() => null),
-  getMeterRedline: vi.fn(() => null),
-  getControlRange: vi.fn(() => ({ min: 0, max: 255 })),
+const childHarness = vi.hoisted(() => ({
+  vfoOpsProps: null as Record<string, any> | null,
+  dualVfoProps: null as Record<string, any> | null,
+  vfoPanelProps: null as Record<string, any> | null,
 }));
 
+vi.mock('../../vfo/VfoOps.svelte', () => ({
+  default: function VfoOpsStub(_anchor: unknown, props: Record<string, any>) {
+    childHarness.vfoOpsProps = props;
+    return {};
+  },
+}));
+vi.mock('../../panels/vfo/DualVfoDisplay.svelte', () => ({
+  default: function DualVfoDisplayStub(_anchor: unknown, props: Record<string, any>) {
+    childHarness.dualVfoProps = props;
+    return {};
+  },
+}));
+vi.mock('../../vfo/VfoPanel.svelte', () => ({
+  default: function VfoPanelStub(_anchor: unknown, props: Record<string, any>) {
+    childHarness.vfoPanelProps = props;
+    return {};
+  },
+}));
+
+const capabilityHarness = vi.hoisted(() => ({ dual: true, scope: true }));
+vi.mock('$lib/stores/capabilities.svelte', () => ({
+  hasDualReceiver: vi.fn(() => capabilityHarness.dual),
+  hasCapability: vi.fn((name: string) => name === 'scope' && capabilityHarness.scope),
+  getVfoScheme: vi.fn(() => 'main_sub'),
+}));
+
+const runtimeHarness = vi.hoisted(() => ({
+  runtime: {
+    state: Object.freeze({ identity: 'header-state' }),
+    caps: Object.freeze({ identity: 'header-capabilities' }),
+  },
+}));
+
+const authorityHarness = vi.hoisted(() => {
+  const harness = {
+    current: null as any,
+    toSpectrumAuthority: vi.fn(() => harness.current),
+  };
+  return harness;
+});
+
+const binderHarness = vi.hoisted(() => {
+  const scopeControls = Object.freeze({
+    onModeChange: vi.fn(), onEdgeChange: vi.fn(), onSpanChange: vi.fn(),
+    onSpeedChange: vi.fn(), onHoldChange: vi.fn(), onRefChange: vi.fn(),
+    onDualChange: vi.fn(), onReceiverChange: vi.fn(), onDuringTxChange: vi.fn(),
+    onCenterTypeChange: vi.fn(), onVbwChange: vi.fn(), onRbwChange: vi.fn(),
+  });
+  const bound = Object.freeze({ scopeControls });
+  const vfo = Object.freeze({
+    onMainVfoClick: vi.fn(),
+    onSubVfoClick: vi.fn(),
+    onFreqChange: vi.fn(),
+  });
+  return {
+    scopeControls,
+    vfo,
+    bindSemanticSurfaceHandlers: vi.fn(() => bound),
+    getVfoHandlers: vi.fn(() => vfo),
+  };
+});
+
+const storeAlarm = vi.hoisted(() => ({ patchRadioState: vi.fn() }));
+
+vi.mock('$lib/runtime/frontend-runtime', () => ({ runtime: runtimeHarness.runtime }));
+vi.mock('$lib/runtime/adapters/scope-adapter', () => ({
+  toSpectrumAuthority: authorityHarness.toSpectrumAuthority,
+}));
+vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
+  bindSemanticSurfaceHandlers: binderHarness.bindSemanticSurfaceHandlers,
+  getVfoHandlers: binderHarness.getVfoHandlers,
+}));
 vi.mock('$lib/stores/radio.svelte', () => ({
   radio: { current: null },
   getActiveReceiver: vi.fn(),
   getRadioState: vi.fn(),
   patchActiveReceiver: vi.fn(),
-  patchRadioState: vi.fn(),
+  patchRadioState: storeAlarm.patchRadioState,
   patchReceiver: vi.fn(),
 }));
 
-import VfoHeader, { type ScopeStatusProps } from '../VfoHeader.svelte';
-import { hasDualReceiver } from '$lib/stores/capabilities.svelte';
-import type { VfoStateProps } from '../layout-utils';
+import VfoHeader from '../VfoHeader.svelte';
+
+type Field<T> = {
+  reading: { status: 'known'; value: T } | { status: 'unknown' };
+  availability: { structural: boolean; operational: boolean };
+};
+
+function field<T>(value: T, options: {
+  known?: boolean;
+  structural?: boolean;
+  operational?: boolean;
+} = {}): Field<T> {
+  const { known = true, structural = true, operational = true } = options;
+  return Object.freeze({
+    reading: known
+      ? Object.freeze({ status: 'known' as const, value })
+      : Object.freeze({ status: 'unknown' as const }),
+    availability: Object.freeze({ structural, operational }),
+  });
+}
+
+function scopeFacts(overrides: Record<string, unknown> = {}) {
+  return Object.freeze({
+    mode: field(0), edge: field(1), span: field(3), speed: field(1),
+    hold: field(false), refDb: field(0), dual: field(false), receiver: field(0),
+    duringTx: field(false), centerType: field(0), vbwNarrow: field(false), rbw: field(0),
+    ...overrides,
+  });
+}
+
+function authority(overrides: Record<string, unknown> = {}) {
+  return Object.freeze({ scopeControls: scopeFacts(), ...overrides });
+}
 
 const mainVfo: VfoStateProps = {
-  receiver: 'main',
-  freq: 14074000,
-  mode: 'USB',
-  filter: 'FIL1',
-  sValue: 0,
-  isActive: true,
-  badges: {},
+  receiver: 'main', freq: 14_074_000, mode: 'USB', filter: 'FIL1',
+  sValue: 0, isActive: true, badges: {},
 };
-
 const subVfo: VfoStateProps = {
-  receiver: 'sub',
-  freq: 7074000,
-  mode: 'LSB',
-  filter: 'FIL1',
-  sValue: 0,
-  isActive: false,
-  badges: {},
+  receiver: 'sub', freq: 7_074_000, mode: 'LSB', filter: 'FIL1',
+  sValue: 0, isActive: false, badges: {},
 };
 
-let components: ReturnType<typeof mount>[] = [];
-const mountedTargets: HTMLElement[] = [];
+const components: ReturnType<typeof mount>[] = [];
+const targets: HTMLElement[] = [];
 
-function mountHeader(props: Record<string, unknown> = {}) {
+function mountHeader(overrides: Record<string, unknown> = {}) {
   const target = document.createElement('div');
   document.body.appendChild(target);
-  mountedTargets.push(target);
-  const component = mount(VfoHeader, {
-    target,
-    props: {
-      mainVfo,
-      subVfo,
-      splitActive: false,
-      dualWatchActive: false,
-      txVfo: 'main',
-      ...props,
-    },
-  });
-  flushSync();
+  targets.push(target);
+  const props = {
+    mainVfo: { ...mainVfo },
+    subVfo: { ...subVfo },
+    splitActive: false,
+    dualWatchActive: false,
+    txVfo: 'main' as const,
+    scopeStatus: { dual: true, receiver: 1, span: 7, speed: 2 },
+    ...overrides,
+  };
+  const component = mount(VfoHeader, { target, props });
   components.push(component);
-  return target;
+  flushSync();
+  return { target, props };
+}
+
+function button(root: HTMLElement, label: string): HTMLButtonElement | undefined {
+  return Array.from(root.querySelectorAll<HTMLButtonElement>('button'))
+    .find((item) => item.textContent?.trim() === label);
 }
 
 beforeEach(() => {
-  components = [];
-  mountedTargets.length = 0;
   vi.clearAllMocks();
-  vi.mocked(hasDualReceiver).mockReturnValue(true);
+  childHarness.vfoOpsProps = null;
+  childHarness.dualVfoProps = null;
+  childHarness.vfoPanelProps = null;
+  capabilityHarness.dual = true;
+  capabilityHarness.scope = true;
+  authorityHarness.current = authority();
 });
 
 afterEach(() => {
-  components.forEach((c) => unmount(c));
-  for (const t of mountedTargets) {
-    t.remove();
-  }
-  mountedTargets.length = 0;
+  while (components.length > 0) unmount(components.pop()!);
+  while (targets.length > 0) targets.pop()!.remove();
 });
 
-describe('VfoHeader SCOPE status block', () => {
-  it('hides the block when scopeStatus is null', () => {
-    const target = mountHeader({ scopeStatus: null });
+describe('VfoHeader confirmed receiver authority', () => {
+  it('binds one canonical VFO and scope object per mount', () => {
+    mountHeader();
+    expect(binderHarness.getVfoHandlers).toHaveBeenCalledTimes(1);
+    expect(binderHarness.bindSemanticSurfaceHandlers).toHaveBeenCalledTimes(1);
+    expect(authorityHarness.toSpectrumAuthority).toHaveBeenCalledWith(
+      runtimeHarness.runtime.state,
+      runtimeHarness.runtime.caps,
+    );
+  });
+
+  it('VfoOps receiver selection calls only the canonical handler and leaves highlight observed', () => {
+    const passedSub = vi.fn();
+    mountHeader({ onSubVfoClick: passedSub });
+    expect(childHarness.vfoOpsProps?.activeVfo).toBe('MAIN');
+    childHarness.vfoOpsProps?.onActiveVfoChange('SUB');
+    flushSync();
+    expect(binderHarness.vfo.onSubVfoClick).toHaveBeenCalledTimes(1);
+    expect(binderHarness.vfo.onMainVfoClick).not.toHaveBeenCalled();
+    expect(passedSub).not.toHaveBeenCalled();
+    expect(storeAlarm.patchRadioState).not.toHaveBeenCalled();
+    expect(childHarness.vfoOpsProps?.activeVfo).toBe('MAIN');
+  });
+
+  it('the retained DualVfoDisplay compatibility callback uses the same canonical handlers', () => {
+    const passedMain = vi.fn();
+    const passedSub = vi.fn();
+    mountHeader({ onMainVfoClick: passedMain, onSubVfoClick: passedSub });
+    childHarness.dualVfoProps?.onActivate('SUB');
+    childHarness.dualVfoProps?.onActivate('MAIN');
+    expect(binderHarness.vfo.onSubVfoClick).toHaveBeenCalledTimes(1);
+    expect(binderHarness.vfo.onMainVfoClick).toHaveBeenCalledTimes(1);
+    expect(passedMain).not.toHaveBeenCalled();
+    expect(passedSub).not.toHaveBeenCalled();
+    expect(storeAlarm.patchRadioState).not.toHaveBeenCalled();
+  });
+
+  it('a contradictory observation rerender wins immediately and no click creates truth', () => {
+    mountHeader();
+    childHarness.vfoOpsProps?.onActiveVfoChange('SUB');
+    expect(childHarness.vfoOpsProps?.activeVfo).toBe('MAIN');
+    unmount(components.pop()!);
+    targets.pop()!.remove();
+    mountHeader({
+      mainVfo: { ...mainVfo, isActive: false },
+      subVfo: { ...subVfo, isActive: true },
+    });
+    expect(childHarness.vfoOpsProps?.activeVfo).toBe('SUB');
+    expect(storeAlarm.patchRadioState).not.toHaveBeenCalled();
+  });
+
+  it('single-MAIN path also uses the canonical VFO handler', () => {
+    capabilityHarness.dual = false;
+    const passedMain = vi.fn();
+    mountHeader({ onMainVfoClick: passedMain });
+    childHarness.vfoPanelProps?.onVfoClick();
+    expect(binderHarness.vfo.onMainVfoClick).toHaveBeenCalledTimes(1);
+    expect(passedMain).not.toHaveBeenCalled();
+  });
+});
+
+describe('VfoHeader scope bridge authority', () => {
+  it('ignores contradictory legacy props and renders the selector digest', () => {
+    const { target } = mountHeader({
+      scopeStatus: { dual: true, receiver: 1, span: 7, speed: 2 },
+    });
+    const digest = target.querySelector('.scope-digest')?.textContent?.replace(/\s+/g, ' ').trim();
+    expect(digest).toBe('±25k MID');
+    expect(button(target, 'MAIN')?.classList.contains('active')).toBe(true);
+    expect(button(target, 'SUB')?.classList.contains('active')).toBe(false);
+    expect(button(target, 'DUAL')?.classList.contains('active')).toBe(false);
+  });
+
+  it('valid source and dual gestures call exactly one bound typed action', () => {
+    const passedReceiver = vi.fn();
+    const passedDual = vi.fn();
+    const { target } = mountHeader({
+      onScopeReceiverChange: passedReceiver,
+      onScopeDualToggle: passedDual,
+    });
+    button(target, 'SUB')?.click();
+    expect(binderHarness.scopeControls.onReceiverChange).toHaveBeenCalledWith(1);
+    expect(binderHarness.scopeControls.onReceiverChange).toHaveBeenCalledTimes(1);
+    expect(passedReceiver).not.toHaveBeenCalled();
+    vi.clearAllMocks();
+    button(target, 'DUAL')?.click();
+    expect(binderHarness.scopeControls.onDualChange).toHaveBeenCalledWith(true);
+    expect(binderHarness.scopeControls.onDualChange).toHaveBeenCalledTimes(1);
+    expect(passedDual).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['unknown', { known: false }],
+    ['structural false', { structural: false }],
+    ['operational false', { operational: false }],
+  ] as const)('%s scope facts render neutral and disable source/dual actions', (_label, options) => {
+    authorityHarness.current = authority({
+      scopeControls: scopeFacts({
+        dual: field(false, options),
+        receiver: field(0, options),
+        span: field(3, options),
+        speed: field(1, options),
+      }),
+    });
+    const { target } = mountHeader();
+    expect(target.querySelector('.scope-digest')?.textContent?.replace(/\s+/g, ' ').trim()).toBe('— —');
+    for (const label of ['MAIN', 'SUB', 'DUAL']) {
+      expect(button(target, label)?.disabled).toBe(true);
+      expect(button(target, label)?.classList.contains('active')).toBe(false);
+      button(target, label)?.click();
+    }
+    expect(binderHarness.scopeControls.onReceiverChange).not.toHaveBeenCalled();
+    expect(binderHarness.scopeControls.onDualChange).not.toHaveBeenCalled();
+  });
+
+  it('malformed and selector-null facts never restore MAIN/±25k/MID defaults', () => {
+    authorityHarness.current = authority({
+      scopeControls: scopeFacts({
+        receiver: field(2), dual: field('off'), span: field(99), speed: field(99),
+      }),
+    });
+    const malformed = mountHeader().target;
+    expect(malformed.querySelector('.scope-digest')?.textContent?.replace(/\s+/g, ' ').trim()).toBe('— —');
+    expect(button(malformed, 'MAIN')?.classList.contains('active')).toBe(false);
+    expect(button(malformed, 'SUB')?.classList.contains('active')).toBe(false);
+
+    unmount(components.pop()!);
+    targets.pop()!.remove();
+    authorityHarness.current = null;
+    const absent = mountHeader().target;
+    expect(absent.querySelector('.scope-digest')?.textContent?.replace(/\s+/g, ' ').trim()).toBe('— —');
+  });
+
+  it('one physical receiver hides source and dual controls but keeps neutral/read-only digest', () => {
+    capabilityHarness.dual = false;
+    authorityHarness.current = authority({
+      scopeControls: scopeFacts({
+        dual: field(false, { structural: false }),
+        receiver: field(0, { structural: false }),
+      }),
+    });
+    const { target } = mountHeader();
+    expect(button(target, 'MAIN')).toBeUndefined();
+    expect(button(target, 'SUB')).toBeUndefined();
+    expect(button(target, 'DUAL')).toBeUndefined();
+    expect(target.querySelector('.scope-digest')?.textContent?.replace(/\s+/g, ' ').trim()).toBe('±25k MID');
+  });
+
+  it('hides the entire bridge only when structural scope capability is absent', () => {
+    capabilityHarness.scope = false;
+    const { target } = mountHeader();
     expect(target.querySelector('[data-testid="scope-status"]')).toBeNull();
   });
+});
 
-  it('renders SCOPE title when scopeStatus is provided', () => {
-    const scopeStatus: ScopeStatusProps = { dual: false, receiver: 0, span: 3, speed: 1 };
-    const target = mountHeader({ scopeStatus });
-    const block = target.querySelector('[data-testid="scope-status"]');
-    expect(block).not.toBeNull();
-    expect(block!.textContent).toContain('SCOPE');
-  });
-
-  it('renders MAIN and SUB pills when dual receiver', () => {
-    const scopeStatus: ScopeStatusProps = { dual: false, receiver: 0, span: 3, speed: 1 };
-    const target = mountHeader({ scopeStatus });
-    const pills = Array.from(target.querySelectorAll<HTMLButtonElement>('.scope-pill'));
-    const labels = pills.map((p) => p.textContent?.trim());
-    expect(labels).toEqual(['MAIN', 'SUB']);
-  });
-
-  it('marks the active scope source pill as active (receiver=0 → MAIN)', () => {
-    const scopeStatus: ScopeStatusProps = { dual: false, receiver: 0, span: 3, speed: 1 };
-    const target = mountHeader({ scopeStatus });
-    const pills = Array.from(target.querySelectorAll<HTMLButtonElement>('.scope-pill'));
-    expect(pills[0].classList.contains('active')).toBe(true);
-    expect(pills[1].classList.contains('active')).toBe(false);
-  });
-
-  it('marks SUB pill active when receiver=1', () => {
-    const scopeStatus: ScopeStatusProps = { dual: false, receiver: 1, span: 3, speed: 1 };
-    const target = mountHeader({ scopeStatus });
-    const pills = Array.from(target.querySelectorAll<HTMLButtonElement>('.scope-pill'));
-    expect(pills[0].classList.contains('active')).toBe(false);
-    expect(pills[1].classList.contains('active')).toBe(true);
-  });
-
-  it('renders DUAL toggle with active state when scopeStatus.dual is true', () => {
-    const scopeStatus: ScopeStatusProps = { dual: true, receiver: 0, span: 3, speed: 1 };
-    const target = mountHeader({ scopeStatus });
-    const dualBtn = target.querySelector<HTMLButtonElement>('.scope-dual');
-    expect(dualBtn).not.toBeNull();
-    expect(dualBtn!.textContent?.trim()).toBe('DUAL');
-    expect(dualBtn!.classList.contains('active')).toBe(true);
-  });
-
-  it('hides MAIN/SUB pills and DUAL toggle when dual receiver is not available', () => {
-    vi.mocked(hasDualReceiver).mockReturnValue(false);
-    const scopeStatus: ScopeStatusProps = { dual: false, receiver: 0, span: 3, speed: 1 };
-    const target = mountHeader({ scopeStatus });
-    expect(target.querySelector('.scope-pill')).toBeNull();
-    expect(target.querySelector('.scope-dual')).toBeNull();
-    // Digest still present
-    expect(target.querySelector('.scope-digest')).not.toBeNull();
-  });
-
-  it('renders SPAN/SPEED digest from scopeStatus', () => {
-    const scopeStatus: ScopeStatusProps = { dual: false, receiver: 0, span: 3, speed: 1 };
-    const target = mountHeader({ scopeStatus });
-    const digest = target.querySelector('.scope-digest');
-    expect(digest).not.toBeNull();
-    const text = digest!.textContent!.replace(/\s+/g, ' ').trim();
-    expect(text).toBe('\u00b125k MID');
-  });
-
-  it('renders correct digest values for different span/speed indices', () => {
-    const scopeStatus: ScopeStatusProps = { dual: false, receiver: 0, span: 5, speed: 0 };
-    const target = mountHeader({ scopeStatus });
-    const digest = target.querySelector('.scope-digest');
-    const text = digest!.textContent!.replace(/\s+/g, ' ').trim();
-    expect(text).toBe('\u00b1100k FST');
-  });
-
-  it('falls back to default digest labels for out-of-range indices', () => {
-    const scopeStatus: ScopeStatusProps = { dual: false, receiver: 0, span: 99, speed: 99 };
-    const target = mountHeader({ scopeStatus });
-    const digest = target.querySelector('.scope-digest');
-    const text = digest!.textContent!.replace(/\s+/g, ' ').trim();
-    expect(text).toBe('\u00b125k MID');
-  });
-
-  it('invokes onScopeReceiverChange with 1 when SUB pill is clicked', () => {
-    const onScopeReceiverChange = vi.fn();
-    const scopeStatus: ScopeStatusProps = { dual: false, receiver: 0, span: 3, speed: 1 };
-    const target = mountHeader({ scopeStatus, onScopeReceiverChange });
-    const pills = Array.from(target.querySelectorAll<HTMLButtonElement>('.scope-pill'));
-    pills[1].click();
-    flushSync();
-    expect(onScopeReceiverChange).toHaveBeenCalledWith(1);
-  });
-
-  it('invokes onScopeReceiverChange with 0 when MAIN pill is clicked', () => {
-    const onScopeReceiverChange = vi.fn();
-    const scopeStatus: ScopeStatusProps = { dual: false, receiver: 1, span: 3, speed: 1 };
-    const target = mountHeader({ scopeStatus, onScopeReceiverChange });
-    const pills = Array.from(target.querySelectorAll<HTMLButtonElement>('.scope-pill'));
-    pills[0].click();
-    flushSync();
-    expect(onScopeReceiverChange).toHaveBeenCalledWith(0);
-  });
-
-  it('invokes onScopeDualToggle when DUAL is clicked', () => {
-    const onScopeDualToggle = vi.fn();
-    const scopeStatus: ScopeStatusProps = { dual: false, receiver: 0, span: 3, speed: 1 };
-    const target = mountHeader({ scopeStatus, onScopeDualToggle });
-    const dualBtn = target.querySelector<HTMLButtonElement>('.scope-dual');
-    dualBtn!.click();
-    flushSync();
-    expect(onScopeDualToggle).toHaveBeenCalledTimes(1);
+describe('VfoHeader source boundary', () => {
+  it('has one selector/binder path and no optimistic or legacy action authority', () => {
+    const source = readFileSync(resolve(process.cwd(), 'src/components-v2/layout/VfoHeader.svelte'), 'utf8');
+    expect(source).toContain('toSpectrumAuthority(runtime.state, runtime.caps)');
+    expect(source.match(/bindSemanticSurfaceHandlers\(\)/g)).toHaveLength(1);
+    expect(source.match(/getVfoHandlers\(\)/g)).toHaveLength(1);
+    expect(source).not.toMatch(/patchRadioState|stores\/radio\.svelte/);
+    expect(source).not.toMatch(/onScopeReceiverChange\?\.|onScopeDualToggle\?\./);
   });
 });

--- a/frontend/src/components/spectrum/ScopeSettingsPopover.svelte
+++ b/frontend/src/components/spectrum/ScopeSettingsPopover.svelte
@@ -1,10 +1,55 @@
 <script lang="ts">
-  import { radio } from '../../lib/stores/radio.svelte';
-  import { sendCommand } from '../../lib/transport/ws-client';
+  import { runtime } from '$lib/runtime/frontend-runtime';
+  import { toSpectrumAuthority } from '$lib/runtime/adapters/scope-adapter';
+  import { bindSemanticSurfaceHandlers } from '$lib/runtime/adapters/panel-adapters';
 
   let { onClose }: { onClose: () => void } = $props();
 
-  let scopeControls = $derived(radio.current?.scopeControls);
+  const scopeHandlers = bindSemanticSurfaceHandlers().scopeControls;
+  let scopeControls = $derived(toSpectrumAuthority(runtime.state, runtime.caps)?.scopeControls ?? null);
+
+  type NumberScopeField = 'centerType' | 'rbw';
+  type BooleanScopeField = 'vbwNarrow' | 'duringTx';
+
+  function acceptedNumber(field: NumberScopeField, min: number, max: number): number | null {
+    const fact = scopeControls?.[field];
+    if (!fact?.availability?.structural || !fact.availability.operational
+      || fact.reading?.status !== 'known' || !Number.isSafeInteger(fact.reading.value)
+      || fact.reading.value < min || fact.reading.value > max) return null;
+    return fact.reading.value;
+  }
+
+  function acceptedBoolean(field: BooleanScopeField): boolean | null {
+    const fact = scopeControls?.[field];
+    if (!fact?.availability?.structural || !fact.availability.operational
+      || fact.reading?.status !== 'known' || typeof fact.reading.value !== 'boolean') return null;
+    return fact.reading.value;
+  }
+
+  let centerType = $derived(acceptedNumber('centerType', 0, 2));
+  let vbwNarrow = $derived(acceptedBoolean('vbwNarrow'));
+  let rbw = $derived(acceptedNumber('rbw', 0, 2));
+  let duringTx = $derived(acceptedBoolean('duringTx'));
+
+  function selectCenterType(value: number): void {
+    if (centerType === null || !Number.isSafeInteger(value) || value < 0 || value > 2) return;
+    scopeHandlers.onCenterTypeChange(value);
+  }
+
+  function selectVbw(value: boolean): void {
+    if (vbwNarrow === null) return;
+    scopeHandlers.onVbwChange(value);
+  }
+
+  function selectRbw(value: number): void {
+    if (rbw === null || !Number.isSafeInteger(value) || value < 0 || value > 2) return;
+    scopeHandlers.onRbwChange(value);
+  }
+
+  function selectDuringTx(value: boolean): void {
+    if (duringTx === null) return;
+    scopeHandlers.onDuringTxChange(value);
+  }
 
   const CENTER_TYPE_LABELS: [number, string][] = [[0, 'Filter'], [1, 'Carrier'], [2, 'Abs.Freq']];
   const RBW_LABELS: [number, string][] = [[0, 'Wide'], [1, 'Mid'], [2, 'Narrow']];
@@ -30,8 +75,9 @@
       {#each CENTER_TYPE_LABELS as [val, label]}
         <button
           class="setting-btn"
-          class:active={scopeControls?.centerType === val}
-          onclick={() => sendCommand('set_scope_center_type', { center_type: val })}
+          class:active={centerType === val}
+          disabled={centerType === null}
+          onclick={() => selectCenterType(val)}
         >{label}</button>
       {/each}
     </div>
@@ -42,13 +88,15 @@
     <div class="setting-buttons">
       <button
         class="setting-btn"
-        class:active={!(scopeControls?.vbwNarrow ?? false)}
-        onclick={() => sendCommand('set_scope_vbw', { narrow: false })}
+        class:active={vbwNarrow === false}
+        disabled={vbwNarrow === null}
+        onclick={() => selectVbw(false)}
       >Wide</button>
       <button
         class="setting-btn"
-        class:active={scopeControls?.vbwNarrow ?? false}
-        onclick={() => sendCommand('set_scope_vbw', { narrow: true })}
+        class:active={vbwNarrow === true}
+        disabled={vbwNarrow === null}
+        onclick={() => selectVbw(true)}
       >Narrow</button>
     </div>
   </div>
@@ -59,8 +107,9 @@
       {#each RBW_LABELS as [val, label]}
         <button
           class="setting-btn"
-          class:active={scopeControls?.rbw === val}
-          onclick={() => sendCommand('set_scope_rbw', { rbw: val })}
+          class:active={rbw === val}
+          disabled={rbw === null}
+          onclick={() => selectRbw(val)}
         >{label}</button>
       {/each}
     </div>
@@ -71,13 +120,15 @@
     <div class="setting-buttons">
       <button
         class="setting-btn"
-        class:active={!(scopeControls?.duringTx ?? false)}
-        onclick={() => sendCommand('set_scope_during_tx', { on: false })}
+        class:active={duringTx === false}
+        disabled={duringTx === null}
+        onclick={() => selectDuringTx(false)}
       >Off</button>
       <button
         class="setting-btn"
-        class:active={scopeControls?.duringTx ?? false}
-        onclick={() => sendCommand('set_scope_during_tx', { on: true })}
+        class:active={duringTx === true}
+        disabled={duringTx === null}
+        onclick={() => selectDuringTx(true)}
       >On</button>
     </div>
   </div>

--- a/frontend/src/components/spectrum/__tests__/ScopeSettingsPopover.authority.isolated.test.ts
+++ b/frontend/src/components/spectrum/__tests__/ScopeSettingsPopover.authority.isolated.test.ts
@@ -1,0 +1,253 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const runtimeHarness = vi.hoisted(() => ({
+  runtime: {
+    state: Object.freeze({ identity: 'popover-state' }),
+    caps: Object.freeze({ identity: 'popover-capabilities' }),
+  },
+}));
+
+const authorityHarness = vi.hoisted(() => {
+  const harness = {
+    current: null as any,
+    toSpectrumAuthority: vi.fn(() => harness.current),
+  };
+  return harness;
+});
+
+const binderHarness = vi.hoisted(() => {
+  const scopeControls = Object.freeze({
+    onModeChange: vi.fn(),
+    onEdgeChange: vi.fn(),
+    onSpanChange: vi.fn(),
+    onSpeedChange: vi.fn(),
+    onHoldChange: vi.fn(),
+    onRefChange: vi.fn(),
+    onDualChange: vi.fn(),
+    onReceiverChange: vi.fn(),
+    onDuringTxChange: vi.fn(),
+    onCenterTypeChange: vi.fn(),
+    onVbwChange: vi.fn(),
+    onRbwChange: vi.fn(),
+  });
+  const bound = Object.freeze({ scopeControls });
+  return {
+    scopeControls,
+    bindSemanticSurfaceHandlers: vi.fn(() => bound),
+  };
+});
+
+const rawRadioAlarm = vi.hoisted(() => ({
+  current: {
+    scopeControls: {
+      centerType: 0,
+      vbwNarrow: false,
+      rbw: 0,
+      duringTx: false,
+    },
+  } as any,
+}));
+const rawSendAlarm = vi.hoisted(() => vi.fn());
+
+vi.mock('$lib/runtime/frontend-runtime', () => ({ runtime: runtimeHarness.runtime }));
+vi.mock('$lib/runtime/adapters/scope-adapter', () => ({
+  toSpectrumAuthority: authorityHarness.toSpectrumAuthority,
+}));
+vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
+  bindSemanticSurfaceHandlers: binderHarness.bindSemanticSurfaceHandlers,
+}));
+vi.mock('$lib/stores/radio.svelte', () => ({ radio: rawRadioAlarm }));
+vi.mock('$lib/transport/ws-client', () => ({ sendCommand: rawSendAlarm }));
+
+import ScopeSettingsPopover from '../ScopeSettingsPopover.svelte';
+
+type Field<T> = {
+  reading: { status: 'known'; value: T } | { status: 'unknown' };
+  availability: { structural: boolean; operational: boolean };
+};
+
+function field<T>(value: T, options: {
+  known?: boolean;
+  structural?: boolean;
+  operational?: boolean;
+} = {}): Field<T> {
+  const { known = true, structural = true, operational = true } = options;
+  return Object.freeze({
+    reading: known
+      ? Object.freeze({ status: 'known' as const, value })
+      : Object.freeze({ status: 'unknown' as const }),
+    availability: Object.freeze({ structural, operational }),
+  });
+}
+
+function facts(overrides: Record<string, unknown> = {}) {
+  return Object.freeze({
+    mode: field(0), edge: field(1), span: field(3), speed: field(1),
+    hold: field(false), refDb: field(0), dual: field(false), receiver: field(0),
+    duringTx: field(true), centerType: field(1), vbwNarrow: field(true), rbw: field(1),
+    ...overrides,
+  });
+}
+
+function authority(scopeControls: ReturnType<typeof facts> | null = facts()) {
+  return Object.freeze({ scopeControls });
+}
+
+const components: ReturnType<typeof mount>[] = [];
+const targets: HTMLElement[] = [];
+
+function mountPopover(onClose = vi.fn()) {
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+  targets.push(target);
+  const component = mount(ScopeSettingsPopover, { target, props: { onClose } });
+  components.push(component);
+  flushSync();
+  return { target, onClose };
+}
+
+function button(root: HTMLElement, label: string): HTMLButtonElement {
+  const found = Array.from(root.querySelectorAll<HTMLButtonElement>('button'))
+    .find((item) => item.textContent?.trim() === label);
+  if (!found) throw new Error(`button ${label} not found`);
+  return found;
+}
+
+function radioButtons(root: HTMLElement): HTMLButtonElement[] {
+  return Array.from(root.querySelectorAll<HTMLButtonElement>('.setting-btn'));
+}
+
+function familyButtons(root: HTMLElement, family: string): HTMLButtonElement[] {
+  const group = Array.from(root.querySelectorAll<HTMLElement>('.setting-group'))
+    .find((item) => item.querySelector('.setting-label')?.textContent?.trim() === family);
+  if (!group) throw new Error(`family ${family} not found`);
+  return Array.from(group.querySelectorAll<HTMLButtonElement>('.setting-btn'));
+}
+
+function radioSpies(): ReturnType<typeof vi.fn>[] {
+  return [
+    binderHarness.scopeControls.onCenterTypeChange,
+    binderHarness.scopeControls.onVbwChange,
+    binderHarness.scopeControls.onRbwChange,
+    binderHarness.scopeControls.onDuringTxChange,
+  ];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  authorityHarness.current = authority();
+  rawRadioAlarm.current = {
+    scopeControls: { centerType: 0, vbwNarrow: false, rbw: 0, duringTx: false },
+  };
+});
+
+afterEach(() => {
+  while (components.length > 0) unmount(components.pop()!);
+  while (targets.length > 0) targets.pop()!.remove();
+});
+
+describe('ScopeSettingsPopover radio authority', () => {
+  it('uses one selector and one bound scope family and renders only known observations active', () => {
+    const { target } = mountPopover();
+    expect(authorityHarness.toSpectrumAuthority).toHaveBeenCalledWith(
+      runtimeHarness.runtime.state,
+      runtimeHarness.runtime.caps,
+    );
+    expect(binderHarness.bindSemanticSurfaceHandlers).toHaveBeenCalledTimes(1);
+    expect(button(target, 'Carrier').classList.contains('active')).toBe(true);
+    expect(button(target, 'Narrow').classList.contains('active')).toBe(true);
+    expect(button(target, 'Mid').classList.contains('active')).toBe(true);
+    expect(button(target, 'On').classList.contains('active')).toBe(true);
+    expect(rawSendAlarm).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['Filter', 'onCenterTypeChange', 0],
+    ['Wide', 'onVbwChange', false],
+    ['Narrow', 'onVbwChange', true],
+    ['Narrow', 'onRbwChange', 2],
+    ['Off', 'onDuringTxChange', false],
+    ['On', 'onDuringTxChange', true],
+  ] as const)('%s emits exactly one canonical %s action', (label, name, value) => {
+    const { target } = mountPopover();
+    const candidates = Array.from(target.querySelectorAll<HTMLButtonElement>('button'))
+      .filter((item) => item.textContent?.trim() === label);
+    const control = name === 'onRbwChange' ? candidates.at(-1)! : candidates[0];
+    control.click();
+    flushSync();
+    expect(binderHarness.scopeControls[name]).toHaveBeenCalledTimes(1);
+    expect(binderHarness.scopeControls[name]).toHaveBeenCalledWith(value);
+    expect(radioSpies().reduce((count, spy) => count + spy.mock.calls.length, 0)).toBe(1);
+    expect(rawSendAlarm).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['centerType', 'Center Type', 1, 3],
+    ['vbwNarrow', 'VBW', true, 'yes'],
+    ['rbw', 'RBW', 1, 3],
+    ['duringTx', 'During TX', true, 1],
+  ] as const)('%s fails closed for unknown, unavailable and malformed readings', (name, family, valid, invalid) => {
+    for (const replacement of [
+      field(valid, { known: false }),
+      field(valid, { structural: false }),
+      field(valid, { operational: false }),
+      field(invalid as never),
+    ]) {
+      authorityHarness.current = authority(facts({ [name]: replacement }));
+      const { target } = mountPopover();
+      for (const control of familyButtons(target, family)) {
+        expect(control.disabled).toBe(true);
+        expect(control.classList.contains('active')).toBe(false);
+        control.click();
+      }
+      flushSync();
+      for (const spy of radioSpies()) expect(spy).not.toHaveBeenCalled();
+      expect(rawSendAlarm).not.toHaveBeenCalled();
+      unmount(components.pop()!);
+      targets.pop()!.remove();
+      vi.clearAllMocks();
+    }
+  });
+
+  it('selector null disables every radio family without fabricating false-like choices', () => {
+    authorityHarness.current = null;
+    const { target } = mountPopover();
+    expect(radioButtons(target)).toHaveLength(10);
+    for (const control of radioButtons(target)) {
+      expect(control.disabled).toBe(true);
+      expect(control.classList.contains('active')).toBe(false);
+      control.click();
+    }
+    flushSync();
+    for (const spy of radioSpies()) expect(spy).not.toHaveBeenCalled();
+    expect(rawSendAlarm).not.toHaveBeenCalled();
+  });
+
+  it('close button, backdrop and keyboard close locally with zero radio action', () => {
+    const { target, onClose } = mountPopover();
+    button(target, 'x').click();
+    const backdrop = target.querySelector<HTMLElement>('.popover-backdrop')!;
+    backdrop.click();
+    backdrop.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    backdrop.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    backdrop.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+    flushSync();
+    expect(onClose).toHaveBeenCalledTimes(5);
+    for (const spy of radioSpies()) expect(spy).not.toHaveBeenCalled();
+    expect(rawSendAlarm).not.toHaveBeenCalled();
+  });
+
+  it('source has one canonical fact/action route and no raw Store or transport authority', () => {
+    const source = readFileSync(
+      resolve(process.cwd(), 'src/components/spectrum/ScopeSettingsPopover.svelte'),
+      'utf8',
+    );
+    expect(source).toContain('toSpectrumAuthority(runtime.state, runtime.caps)');
+    expect(source.match(/bindSemanticSurfaceHandlers\(\)/g)).toHaveLength(1);
+    expect(source).toContain('bindSemanticSurfaceHandlers().scopeControls');
+    expect(source).not.toMatch(/stores\/radio\.svelte|sendCommand|\?\? false/);
+  });
+});

--- a/frontend/src/components/spectrum/__tests__/SpectrumToolbar.component.test.ts
+++ b/frontend/src/components/spectrum/__tests__/SpectrumToolbar.component.test.ts
@@ -555,18 +555,30 @@ describe('source and enforcement boundary', () => {
     expect(source).not.toMatch(/\.agc\b|\.antenna\b|\.audioRouting\b|\.band\b|\.cw\b|\.dsp\b|\.filter\b|\.mode\b|\.rfFrontEnd\b|\.ritXit\b|\.rxAudio\b|\.scan\b|\.tx\b|\.vfo\b|\.vox\b/);
   });
 
-  it('removes only Toolbar presentation exceptions and preserves the A07 owner', () => {
+  it('removes only Toolbar and A07 presentation/writer exceptions', () => {
     const plugin = readFileSync(pluginPath, 'utf8');
     const contract = readFileSync(contractPath, 'utf8');
     expect(plugin).not.toContain("  'src/components/spectrum/SpectrumToolbar.svelte',");
     expect(contract).not.toContain('  { path = "src/components/spectrum/SpectrumToolbar.svelte", count = 1, owner = "MOR-1409" },');
-    expect(plugin).toContain("  'src/components/spectrum/ScopeSettingsPopover.svelte',");
-    expect(contract).toContain('  { path = "src/components/spectrum/ScopeSettingsPopover.svelte", count = 1, owner = "MOR-1409" },');
+    for (const path of [
+      'src/components-v2/layout/VfoHeader.svelte',
+      'src/components/spectrum/ScopeSettingsPopover.svelte',
+      'src/lib/media/media-session.ts',
+    ]) {
+      expect(plugin).not.toContain(`  '${path}',`);
+      expect(contract).not.toContain(`  { path = "${path}", count = 1, owner = "MOR-1409" },`);
+    }
+    expect(plugin).toContain("  'src/components-v2/layout/StatusBar.svelte',");
+    expect(plugin).toContain("  'src/components/spectrum/EiBiBrowser.svelte',");
+    expect(contract).toContain('  { path = "src/components-v2/layout/StatusBar.svelte", count = 1, owner = "MOR-1409" },');
+    expect(contract).toContain('  { path = "src/components/spectrum/EiBiBrowser.svelte", count = 1, owner = "MOR-1409" },');
   });
 
-  it('keeps ScopeSettingsPopover and all Toolbar CSS byte-frozen', () => {
-    const popoverHash = createHash('sha256').update(readFileSync(popoverPath)).digest('hex');
-    expect(popoverHash).toBe('95315314a00536667b30ff47d99249852884f8a1cbdb3966127b62c7987cb5bc');
+  it('releases the old popover hash pin while keeping all Toolbar CSS byte-frozen', () => {
+    const popover = readFileSync(popoverPath, 'utf8');
+    expect(popover).toContain('toSpectrumAuthority(runtime.state, runtime.caps)');
+    expect(popover).toContain('bindSemanticSurfaceHandlers().scopeControls');
+    expect(popover).not.toMatch(/stores\/radio\.svelte|sendCommand|\?\? false/);
     const source = readFileSync(sourcePath, 'utf8');
     const cssHash = createHash('sha256').update(source.slice(source.indexOf('<style>'))).digest('hex');
     expect(cssHash).toBe('eb9e75ed2988082d6966d6727f73d3d77651086df38b1458aed3e9c274725fb7');

--- a/frontend/src/lib/media/__tests__/media-session.isolated.test.ts
+++ b/frontend/src/lib/media/__tests__/media-session.isolated.test.ts
@@ -1,31 +1,83 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 
-// Mock dependencies before importing the module under test
-vi.mock('../../stores/tuning.svelte', () => ({
-  tuneBy: vi.fn(() => 14_074_000),
+const runtimeHarness = vi.hoisted(() => ({
+  runtime: {
+    state: Object.freeze({ identity: 'media-state' }),
+    caps: Object.freeze({ identity: 'media-capabilities' }),
+  },
 }));
 
-vi.mock('../../stores/radio.svelte', () => ({
+const viewHarness = vi.hoisted(() => {
+  const harness = {
+    current: null as any,
+    toRadioViewModel: vi.fn(() => harness.current),
+  };
+  return harness;
+});
+
+const tuningHarness = vi.hoisted(() => ({
+  step: 1_000,
+  getTuningStep: vi.fn(() => 1_000),
+  snapToStep: vi.fn((frequency: number) => Math.round(frequency / 1_000) * 1_000),
+}));
+
+const vfoHarness = vi.hoisted(() => {
+  const handlers = Object.freeze({
+    onMainVfoClick: vi.fn(),
+    onSubVfoClick: vi.fn(),
+    onFreqChange: vi.fn(),
+  });
+  return {
+    handlers,
+    getVfoHandlers: vi.fn(() => handlers),
+  };
+});
+
+const legacyAlarm = vi.hoisted(() => ({
+  tuneBy: vi.fn(),
   patchActiveReceiver: vi.fn(),
-  getRadioState: vi.fn(() => ({ ptt: false })),
+  sendCommand: vi.fn(),
 }));
 
-vi.mock('../../transport/ws-client', () => ({
-  sendCommand: vi.fn(() => true),
+vi.mock('$lib/runtime/frontend-runtime', () => ({ runtime: runtimeHarness.runtime }));
+vi.mock('$lib/runtime/adapters/radio-view-model-adapter', () => ({
+  toRadioViewModel: viewHarness.toRadioViewModel,
 }));
+vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
+  getVfoHandlers: vfoHarness.getVfoHandlers,
+}));
+vi.mock('$lib/stores/tuning.svelte', () => ({
+  getTuningStep: tuningHarness.getTuningStep,
+  snapToStep: tuningHarness.snapToStep,
+  tuneBy: legacyAlarm.tuneBy,
+}));
+vi.mock('$lib/stores/radio.svelte', () => ({
+  patchActiveReceiver: legacyAlarm.patchActiveReceiver,
+  getRadioState: vi.fn(),
+}));
+vi.mock('$lib/transport/ws-client', () => ({ sendCommand: legacyAlarm.sendCommand }));
 
-// Minimal AudioContext mock
+function activeView(
+  receiver: 'MAIN' | 'SUB' = 'MAIN',
+  frequencyHz: number | null = 14_074_000,
+  slot: Record<string, unknown> = { kind: 'slotted', id: 'A' },
+) {
+  return Object.freeze({
+    activeReceiver: Object.freeze({ status: 'known' as const, receiver }),
+    vfos: Object.freeze([
+      Object.freeze({ receiver, isActive: true, frequencyHz, slot: Object.freeze(slot) }),
+    ]),
+  });
+}
+
 function createMockAudioContext() {
   const oscillator = {
-    connect: vi.fn(),
-    start: vi.fn(),
-    stop: vi.fn(),
-    disconnect: vi.fn(),
+    connect: vi.fn(), start: vi.fn(), stop: vi.fn(), disconnect: vi.fn(),
   };
   const gainNode = {
-    gain: { value: 1 },
-    connect: vi.fn(),
-    disconnect: vi.fn(),
+    gain: { value: 1 }, connect: vi.fn(), disconnect: vi.fn(),
   };
   const ctx = {
     createOscillator: vi.fn(() => oscillator),
@@ -36,239 +88,286 @@ function createMockAudioContext() {
   return { ctx, oscillator, gainNode };
 }
 
-describe('media-session', () => {
+describe('media-session cycle-safe radio authority', () => {
   let mod: typeof import('../media-session');
-  let tuningMod: typeof import('../../stores/tuning.svelte');
-  let radioMod: typeof import('../../stores/radio.svelte');
-  let wsMod: typeof import('../../transport/ws-client');
-
   const handlers = new Map<string, MediaSessionActionHandler | null>();
   const existingPlayHandler = vi.fn<MediaSessionActionHandler>();
   const existingPauseHandler = vi.fn<MediaSessionActionHandler>();
   let mockAudio: ReturnType<typeof createMockAudioContext>;
   let audioContexts: ReturnType<typeof createMockAudioContext>[];
 
-  function expectNoPttCommands(): void {
-    const pttCommands = new Set(['ptt', 'ptt_on', 'ptt_off']);
-    const commands = vi.mocked(wsMod.sendCommand).mock.calls.map(([command]) => command);
-    expect(commands.filter((command) => pttCommands.has(command))).toEqual([]);
+  function installMediaSession(): void {
+    handlers.clear();
+    handlers.set('play', existingPlayHandler);
+    handlers.set('pause', existingPauseHandler);
+    Object.defineProperty(navigator, 'mediaSession', {
+      value: {
+        metadata: null,
+        setActionHandler: vi.fn((action: string, handler: MediaSessionActionHandler | null) => {
+          handlers.set(action, handler);
+        }),
+      },
+      writable: true,
+      configurable: true,
+    });
+  }
+
+  function fire(action: 'previoustrack' | 'nexttrack'): void {
+    const handler = handlers.get(action);
+    if (!handler) throw new Error(`${action} handler not installed`);
+    handler({ action } as MediaSessionActionDetails);
   }
 
   beforeEach(async () => {
     vi.resetModules();
     vi.clearAllMocks();
-    handlers.clear();
-    handlers.set('play', existingPlayHandler);
-    handlers.set('pause', existingPauseHandler);
+    viewHarness.current = activeView();
+    tuningHarness.step = 1_000;
+    tuningHarness.getTuningStep.mockImplementation(() => tuningHarness.step);
+    tuningHarness.snapToStep.mockImplementation(
+      (frequency: number) => Math.round(frequency / tuningHarness.step) * tuningHarness.step,
+    );
+    vfoHarness.getVfoHandlers.mockImplementation(() => vfoHarness.handlers);
 
     mockAudio = createMockAudioContext();
     audioContexts = [];
-    // AudioContext and MediaMetadata are used with `new`, so mock as classes
-    vi.stubGlobal(
-      'AudioContext',
-      class {
-        createOscillator;
-        createGain;
-        destination;
-        close;
+    vi.stubGlobal('AudioContext', class {
+      createOscillator;
+      createGain;
+      destination;
+      close;
 
-        constructor() {
-          const audio = audioContexts.length === 0 ? mockAudio : createMockAudioContext();
-          audioContexts.push(audio);
-          this.createOscillator = audio.ctx.createOscillator;
-          this.createGain = audio.ctx.createGain;
-          this.destination = audio.ctx.destination;
-          this.close = audio.ctx.close;
-        }
-      },
-    );
-    vi.stubGlobal(
-      'MediaMetadata',
-      class {
-        title: string;
-        artist: string;
-        constructor(opts: { title: string; artist: string }) {
-          this.title = opts.title;
-          this.artist = opts.artist;
-        }
-      },
-    );
-
-    // Install navigator.mediaSession mock
-    const mediaSession = {
-      metadata: null as any,
-      setActionHandler: vi.fn((action: string, handler: MediaSessionActionHandler | null) => {
-        handlers.set(action, handler);
-      }),
-    };
-    Object.defineProperty(navigator, 'mediaSession', {
-      value: mediaSession,
-      writable: true,
-      configurable: true,
+      constructor() {
+        const audio = audioContexts.length === 0 ? mockAudio : createMockAudioContext();
+        audioContexts.push(audio);
+        this.createOscillator = audio.ctx.createOscillator;
+        this.createGain = audio.ctx.createGain;
+        this.destination = audio.ctx.destination;
+        this.close = audio.ctx.close;
+      }
     });
+    vi.stubGlobal('MediaMetadata', class {
+      title: string;
+      artist: string;
+      constructor(options: { title: string; artist: string }) {
+        this.title = options.title;
+        this.artist = options.artist;
+      }
+    });
+    installMediaSession();
 
     mod = await import('../media-session');
-    tuningMod = await import('../../stores/tuning.svelte');
-    radioMod = await import('../../stores/radio.svelte');
-    wsMod = await import('../../transport/ws-client');
   });
 
   afterEach(() => {
     mod.destroyMediaSession();
+    vi.unstubAllGlobals();
   });
 
-  it('registers only tuning action handlers on init', () => {
-    mod.initMediaSession();
+  it('does not bind the canonical accessor during module import', () => {
+    expect(vfoHarness.getVfoHandlers).not.toHaveBeenCalled();
+  });
 
-    expect(handlers.has('previoustrack')).toBe(true);
-    expect(handlers.has('nexttrack')).toBe(true);
+  it('binds exactly once on first successful init, before registration, and not on duplicate init/actions', () => {
+    const order: string[] = [];
+    vfoHarness.getVfoHandlers.mockImplementation(() => {
+      order.push('bind');
+      return vfoHarness.handlers;
+    });
+    vi.mocked(navigator.mediaSession.setActionHandler).mockImplementation((action, handler) => {
+      order.push(`register:${action}`);
+      handlers.set(action, handler);
+    });
+    mod.initMediaSession();
+    mod.initMediaSession();
+    fire('previoustrack');
+    fire('nexttrack');
+    expect(order[0]).toBe('bind');
+    expect(vfoHarness.getVfoHandlers).toHaveBeenCalledTimes(1);
+  });
+
+  it('feature-missing init is a no-op and does not bind', () => {
+    delete (navigator as { mediaSession?: MediaSession }).mediaSession;
+    mod.initMediaSession();
+    expect(vfoHarness.getVfoHandlers).not.toHaveBeenCalled();
+    expect(vfoHarness.handlers.onFreqChange).not.toHaveBeenCalled();
+  });
+
+  it('preserves unrelated MediaSession handlers and registers only previous/next', () => {
+    mod.initMediaSession();
     expect(handlers.get('play')).toBe(existingPlayHandler);
     expect(handlers.get('pause')).toBe(existingPauseHandler);
-  });
-
-  it('sets MediaSession metadata', () => {
-    mod.initMediaSession();
-
+    expect(handlers.get('previoustrack')).toEqual(expect.any(Function));
+    expect(handlers.get('nexttrack')).toEqual(expect.any(Function));
     expect(navigator.mediaSession.metadata).toMatchObject({
-      title: 'RigPlane',
-      artist: 'Radio Control',
+      title: 'RigPlane', artist: 'Radio Control',
     });
   });
 
-  it('starts silent audio context on init', () => {
+  it.each([
+    ['MAIN', 'previoustrack', 14_073_000, 0],
+    ['MAIN', 'nexttrack', 14_075_000, 0],
+    ['SUB', 'previoustrack', 14_073_000, 1],
+    ['SUB', 'nexttrack', 14_075_000, 1],
+  ] as const)('%s %s emits one exact canonical frequency intent', (receiver, action, target, physical) => {
+    viewHarness.current = activeView(receiver);
     mod.initMediaSession();
-
-    expect(mockAudio.ctx.createOscillator).toHaveBeenCalled();
-    expect(mockAudio.ctx.createGain).toHaveBeenCalled();
-    expect(mockAudio.gainNode.gain.value).toBe(0);
-    expect(mockAudio.oscillator.connect).toHaveBeenCalledWith(mockAudio.gainNode);
-    expect(mockAudio.gainNode.connect).toHaveBeenCalledWith(mockAudio.ctx.destination);
-    expect(mockAudio.oscillator.start).toHaveBeenCalled();
+    fire(action);
+    expect(viewHarness.toRadioViewModel).toHaveBeenCalledWith(
+      runtimeHarness.runtime.state,
+      runtimeHarness.runtime.caps,
+    );
+    expect(vfoHarness.handlers.onFreqChange).toHaveBeenCalledTimes(1);
+    expect(vfoHarness.handlers.onFreqChange).toHaveBeenCalledWith(target, physical);
+    expect(legacyAlarm.tuneBy).not.toHaveBeenCalled();
+    expect(legacyAlarm.patchActiveReceiver).not.toHaveBeenCalled();
+    expect(legacyAlarm.sendCommand).not.toHaveBeenCalled();
   });
 
-  it('previoustrack handler tunes down', () => {
+  it('one-receiver Selected/Unselected identity remains physical MAIN', () => {
+    viewHarness.current = activeView('MAIN', 14_074_000, { kind: 'relative', id: 'selected' });
     mod.initMediaSession();
-    const handler = handlers.get('previoustrack')!;
-    handler({ action: 'previoustrack' } as MediaSessionActionDetails);
-
-    expect(tuningMod.tuneBy).toHaveBeenCalledWith(-1);
-    expect(radioMod.patchActiveReceiver).toHaveBeenCalledWith({ freqHz: 14_074_000 }, true);
-    expect(wsMod.sendCommand).toHaveBeenCalledWith('set_freq', { freq: 14_074_000, receiver: 0 });
+    fire('nexttrack');
+    expect(vfoHarness.handlers.onFreqChange).toHaveBeenCalledWith(14_075_000, 0);
   });
 
-  it('nexttrack handler tunes up', () => {
+  it.each([
+    ['null view', null],
+    ['unknown receiver', { activeReceiver: { status: 'unknown' }, vfos: [] }],
+    ['no active VFO', { activeReceiver: { status: 'known', receiver: 'MAIN' }, vfos: [
+      { receiver: 'MAIN', isActive: false, frequencyHz: 14_074_000 },
+    ] }],
+    ['multiple active VFOs', { activeReceiver: { status: 'known', receiver: 'MAIN' }, vfos: [
+      { receiver: 'MAIN', isActive: true, frequencyHz: 14_074_000 },
+      { receiver: 'MAIN', isActive: true, frequencyHz: 7_074_000 },
+    ] }],
+    ['mismatched active VFO', { activeReceiver: { status: 'known', receiver: 'SUB' }, vfos: [
+      { receiver: 'MAIN', isActive: true, frequencyHz: 14_074_000 },
+    ] }],
+  ])('%s fails closed with zero intent', (_label, model) => {
+    viewHarness.current = model;
     mod.initMediaSession();
-    const handler = handlers.get('nexttrack')!;
-    handler({ action: 'nexttrack' } as MediaSessionActionDetails);
-
-    expect(tuningMod.tuneBy).toHaveBeenCalledWith(1);
-    expect(radioMod.patchActiveReceiver).toHaveBeenCalledWith({ freqHz: 14_074_000 }, true);
-    expect(wsMod.sendCommand).toHaveBeenCalledWith('set_freq', { freq: 14_074_000, receiver: 0 });
+    fire('nexttrack');
+    expect(vfoHarness.handlers.onFreqChange).not.toHaveBeenCalled();
+    expect(legacyAlarm.tuneBy).not.toHaveBeenCalled();
+    expect(legacyAlarm.patchActiveReceiver).not.toHaveBeenCalled();
+    expect(legacyAlarm.sendCommand).not.toHaveBeenCalled();
   });
 
-  it('does not send command when tuneBy returns 0', () => {
-    // Make tuneBy return 0 (no active receiver / freq unknown)
-    vi.mocked(tuningMod.tuneBy).mockReturnValueOnce(0);
+  it.each([null, 0, -1, Number.NaN, Number.POSITIVE_INFINITY, Number.MAX_SAFE_INTEGER + 1])(
+    'unsafe confirmed frequency %s fails closed',
+    (frequency) => {
+      viewHarness.current = activeView('MAIN', frequency);
+      mod.initMediaSession();
+      fire('nexttrack');
+      expect(vfoHarness.handlers.onFreqChange).not.toHaveBeenCalled();
+      expect(legacyAlarm.tuneBy).not.toHaveBeenCalled();
+      expect(legacyAlarm.patchActiveReceiver).not.toHaveBeenCalled();
+      expect(legacyAlarm.sendCommand).not.toHaveBeenCalled();
+    },
+  );
 
+  it.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY, 1.5])(
+    'unsafe local step %s fails closed',
+    (step) => {
+      tuningHarness.step = step;
+      mod.initMediaSession();
+      fire('nexttrack');
+      expect(vfoHarness.handlers.onFreqChange).not.toHaveBeenCalled();
+      expect(legacyAlarm.tuneBy).not.toHaveBeenCalled();
+      expect(legacyAlarm.patchActiveReceiver).not.toHaveBeenCalled();
+      expect(legacyAlarm.sendCommand).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY, Number.MAX_SAFE_INTEGER + 1, 14_074_000])(
+    'unsafe/no-op snapped target %s fails closed',
+    (target) => {
+      tuningHarness.snapToStep.mockReturnValueOnce(target);
+      mod.initMediaSession();
+      fire('nexttrack');
+      expect(vfoHarness.handlers.onFreqChange).not.toHaveBeenCalled();
+      expect(legacyAlarm.tuneBy).not.toHaveBeenCalled();
+      expect(legacyAlarm.patchActiveReceiver).not.toHaveBeenCalled();
+      expect(legacyAlarm.sendCommand).not.toHaveBeenCalled();
+    },
+  );
+
+  it('unexpectedly absent cached handler object fails closed', () => {
+    vfoHarness.getVfoHandlers.mockReturnValueOnce(null as never);
     mod.initMediaSession();
-    const handler = handlers.get('previoustrack')!;
-
-    // Clear any calls from initMediaSession setup
-    vi.mocked(wsMod.sendCommand).mockClear();
-    vi.mocked(radioMod.patchActiveReceiver).mockClear();
-
-    handler({ action: 'previoustrack' } as MediaSessionActionDetails);
-
-    expect(wsMod.sendCommand).not.toHaveBeenCalled();
-    expect(radioMod.patchActiveReceiver).not.toHaveBeenCalled();
+    fire('nexttrack');
+    expect(vfoHarness.handlers.onFreqChange).not.toHaveBeenCalled();
+    expect(legacyAlarm.sendCommand).not.toHaveBeenCalled();
   });
 
-  it('never emits legacy or preferred PTT commands', () => {
+  it('destroy/reinitialize retains one canonical object and never rebinds', () => {
+    const replacement = Object.freeze({ ...vfoHarness.handlers, onFreqChange: vi.fn() });
+    vfoHarness.getVfoHandlers
+      .mockReturnValueOnce(vfoHarness.handlers)
+      .mockReturnValueOnce(replacement);
     mod.initMediaSession();
-
-    handlers.get('previoustrack')?.({
-      action: 'previoustrack',
-    } as MediaSessionActionDetails);
-    handlers.get('nexttrack')?.({ action: 'nexttrack' } as MediaSessionActionDetails);
+    fire('nexttrack');
     mod.destroyMediaSession();
-
-    expectNoPttCommands();
+    mod.initMediaSession();
+    fire('nexttrack');
+    expect(vfoHarness.getVfoHandlers).toHaveBeenCalledTimes(1);
+    expect(vfoHarness.handlers.onFreqChange).toHaveBeenCalledTimes(2);
+    expect(replacement.onFreqChange).not.toHaveBeenCalled();
   });
 
-  it('is idempotent across repeated init calls', () => {
+  it('keeps silent audio/idempotence/cleanup behavior and never adds PTT/TUNE handlers', () => {
     mod.initMediaSession();
     mod.initMediaSession();
-
     expect(mockAudio.ctx.createOscillator).toHaveBeenCalledTimes(1);
     expect(mockAudio.ctx.createGain).toHaveBeenCalledTimes(1);
-    expect(navigator.mediaSession.setActionHandler).toHaveBeenCalledTimes(2);
-  });
-
-  it('destroyMediaSession clears handlers and stops audio', () => {
-    mod.initMediaSession();
-    mod.destroyMediaSession();
-
-    // Only the handlers owned by this module are cleared (set to null).
-    const setHandler = navigator.mediaSession.setActionHandler as ReturnType<typeof vi.fn>;
-    const calls = setHandler.mock.calls as Array<[string, MediaSessionActionHandler | null]>;
-    const clearedActions = calls.filter((call) => call[1] === null).map(([action]) => action);
-    expect(clearedActions).toEqual(['previoustrack', 'nexttrack']);
-    expect(calls.map(([action]) => action)).not.toContain('play');
-    expect(calls.map(([action]) => action)).not.toContain('pause');
-    expect(handlers.get('play')).toBe(existingPlayHandler);
-    expect(handlers.get('pause')).toBe(existingPauseHandler);
-    expect(mockAudio.oscillator.stop).toHaveBeenCalled();
-    expect(mockAudio.ctx.close).toHaveBeenCalled();
-    expectNoPttCommands();
-  });
-
-  it('is idempotent across repeated destroy calls', () => {
-    mod.initMediaSession();
+    expect(mockAudio.gainNode.gain.value).toBe(0);
+    expect(mockAudio.oscillator.start).toHaveBeenCalledTimes(1);
+    expect(Array.from(handlers.keys())).not.toEqual(expect.arrayContaining(['ptt', 'ptt_on', 'ptt_off']));
     mod.destroyMediaSession();
     mod.destroyMediaSession();
-
-    const setHandler = navigator.mediaSession.setActionHandler as ReturnType<typeof vi.fn>;
-    const calls = setHandler.mock.calls as Array<[string, MediaSessionActionHandler | null]>;
     expect(mockAudio.oscillator.stop).toHaveBeenCalledTimes(1);
     expect(mockAudio.ctx.close).toHaveBeenCalledTimes(1);
-    expect(calls.map(([action, handler]) => ({ action, clears: handler === null }))).toEqual([
-      { action: 'previoustrack', clears: false },
-      { action: 'nexttrack', clears: false },
-      { action: 'previoustrack', clears: true },
-      { action: 'nexttrack', clears: true },
-    ]);
-  });
-
-  it('starts a fresh owned session after init, destroy, init', () => {
-    mod.initMediaSession();
-    const firstPreviousTrackHandler = handlers.get('previoustrack');
-    mod.destroyMediaSession();
-    mod.initMediaSession();
-
-    expect(audioContexts).toHaveLength(2);
-    expect(audioContexts[0]).not.toBe(audioContexts[1]);
-    expect(audioContexts[0].oscillator.stop).toHaveBeenCalledTimes(1);
-    expect(audioContexts[1].oscillator.start).toHaveBeenCalledTimes(1);
-    expect(handlers.get('previoustrack')).not.toBe(firstPreviousTrackHandler);
-    expect(handlers.get('nexttrack')).toEqual(expect.any(Function));
     expect(handlers.get('play')).toBe(existingPlayHandler);
     expect(handlers.get('pause')).toBe(existingPauseHandler);
-    expectNoPttCommands();
   });
 
-  describe('without MediaSession API', () => {
-    beforeEach(() => {
-      // Delete the property so 'mediaSession' in navigator === false
-      delete (navigator as any).mediaSession;
-    });
+  it('starts a fresh silent-audio session after destroy while retaining the radio binding', () => {
+    mod.initMediaSession();
+    const firstHandler = handlers.get('previoustrack');
+    mod.destroyMediaSession();
+    mod.initMediaSession();
+    expect(audioContexts).toHaveLength(2);
+    expect(audioContexts[0]).not.toBe(audioContexts[1]);
+    expect(handlers.get('previoustrack')).not.toBe(firstHandler);
+    expect(vfoHarness.getVfoHandlers).toHaveBeenCalledTimes(1);
+  });
 
-    it('initMediaSession is a no-op', () => {
-      // Should not throw
-      expect(() => mod.initMediaSession()).not.toThrow();
-    });
+  it('source has static cycle-safe imports, nullable cache, and zero legacy authority', () => {
+    const source = readFileSync(resolve(process.cwd(), 'src/lib/media/media-session.ts'), 'utf8');
+    expect(source).toContain("import { runtime } from '../runtime/frontend-runtime'");
+    expect(source).toContain("import { getVfoHandlers } from '../runtime/adapters/panel-adapters'");
+    expect(source).toMatch(/let vfoHandlers: ReturnType<typeof getVfoHandlers> \| null = null/);
+    expect(source).toContain('vfoHandlers ??= getVfoHandlers()');
+    expect(source).not.toMatch(/tuneBy|patchActiveReceiver|sendCommand|set_tuner_status|cw_auto_tune|\bptt\b/i);
+  });
 
-    it('destroyMediaSession is a no-op', () => {
-      expect(() => mod.destroyMediaSession()).not.toThrow();
-    });
+  it('the real panel-adapter/frontend-runtime/system-controller/media graph imports without TDZ', async () => {
+    mod.destroyMediaSession();
+    vi.resetModules();
+    vi.doUnmock('../../runtime/adapters/panel-adapters');
+    vi.doUnmock('../../runtime/frontend-runtime');
+    vi.doUnmock('../../runtime/system-controller');
+    vi.doUnmock('../../runtime/adapters/radio-view-model-adapter');
+    vi.doUnmock('../../stores/tuning.svelte');
+    vi.doUnmock('$lib/runtime/adapters/panel-adapters');
+    vi.doUnmock('$lib/runtime/frontend-runtime');
+    vi.doUnmock('$lib/runtime/adapters/radio-view-model-adapter');
+    vi.doUnmock('$lib/stores/tuning.svelte');
+    vi.doUnmock('$lib/stores/radio.svelte');
+    vi.doUnmock('$lib/transport/ws-client');
+    vi.doUnmock('../media-session');
+    const actual = await import('../../runtime/adapters/panel-adapters');
+    expect(actual.getVfoHandlers()).toBe(actual.getVfoHandlers());
   });
 });

--- a/frontend/src/lib/media/media-session.ts
+++ b/frontend/src/lib/media/media-session.ts
@@ -6,9 +6,10 @@
  * A silent audio loop keeps the MediaSession active on mobile browsers.
  */
 
-import { tuneBy } from '../stores/tuning.svelte';
-import { patchActiveReceiver } from '../stores/radio.svelte';
-import { sendCommand } from '../transport/ws-client';
+import { runtime } from '../runtime/frontend-runtime';
+import { toRadioViewModel } from '../runtime/adapters/radio-view-model-adapter';
+import { getVfoHandlers } from '../runtime/adapters/panel-adapters';
+import { getTuningStep, snapToStep } from '../stores/tuning.svelte';
 
 const TAG = '[media-session]';
 
@@ -16,13 +17,26 @@ let audioCtx: AudioContext | null = null;
 let oscillator: OscillatorNode | null = null;
 let gainNode: GainNode | null = null;
 let isInitialized = false;
+let vfoHandlers: ReturnType<typeof getVfoHandlers> | null = null;
 
 /** Tune the active receiver by `steps` increments and send to radio. */
 function tuneStep(steps: number): void {
-  const newFreq = tuneBy(steps);
-  if (newFreq <= 0) return;
-  patchActiveReceiver({ freqHz: newFreq }, true);
-  sendCommand('set_freq', { freq: newFreq, receiver: 0 });
+  if (!vfoHandlers) return;
+  const view = toRadioViewModel(runtime.state, runtime.caps);
+  if (!view || view.activeReceiver.status !== 'known') return;
+  const receiver = view.activeReceiver.receiver;
+  const active = view.vfos.filter((vfo) =>
+    vfo.isActive && vfo.receiver === receiver);
+  if (active.length !== 1) return;
+  const current = active[0].frequencyHz;
+  const step = getTuningStep();
+  if (!Number.isSafeInteger(current) || current === null || current <= 0
+    || !Number.isSafeInteger(step) || step <= 0) return;
+  const candidate = current + steps * step;
+  if (!Number.isSafeInteger(candidate)) return;
+  const newFreq = snapToStep(candidate);
+  if (!Number.isSafeInteger(newFreq) || newFreq <= 0 || newFreq === current) return;
+  vfoHandlers.onFreqChange(newFreq, receiver === 'SUB' ? 1 : 0);
 }
 
 /** Start a silent audio loop so the browser keeps MediaSession alive. */
@@ -69,6 +83,7 @@ export function initMediaSession(): void {
     return;
   }
 
+  vfoHandlers ??= getVfoHandlers();
   isInitialized = true;
   startSilentAudio();
 


### PR DESCRIPTION
Part of #2317

## MOR-1409 gate A07 (corrected, cycle-safe consumers)

Migrates three production owners to canonical StateStore-projection + typed-intent authority:

- `frontend/src/components/spectrum/ScopeSettingsPopover.svelte` (+66/−15) — raw `radio` store and `sendCommand` removed; reads only `toSpectrumAuthority(...)?.scopeControls`; handlers bound once at init; fail-closed rendering on unknown/malformed state; fabricated `?? false` defaults removed.
- `frontend/src/components-v2/layout/VfoHeader.svelte` (+50/−28) — optimistic `patchRadioState` paths removed; all entry paths route through canonical `getVfoHandlers()` bound once at init; highlight is observation-derived; scope bridge capability-gated and fail-closed; fabricated fallbacks removed.
- `frontend/src/lib/media/media-session.ts` (+22/−7) — cycle-safe rule: static import of `getVfoHandlers` with zero calls at module evaluation; bind/cache exactly once on first successful `initMediaSession()` after feature/idempotence guards; identical handler object preserved across destroy/reinitialize; absent cache fails closed.

Plus: authority-eslint-plugin + contract TOML shrink by exactly the four migrated exception entries (mirrored), and isolated/component tests for all three owners (new `ScopeSettingsPopover.authority.isolated.test.ts`; media-session module-graph tests include a real unmocked four-leg import-cycle test).

Production churn 188 (< 391 cap). 9 changed paths total. Head `c590857f9bd646b2e74385723eaa060c3a0e5092`, base `eaa4dc3c38eeb6b34b72fd4af9e4443598670512`.

## Exact-head evidence (fresh detached worktree, once-through, no retries)

- Full frontend suite: 311 files, 6460/6460 PASS
- Frontend build: PASS (4166 modules)
- Retained fixture capture: 64/64 captures, 1951/1951 assertions, 0 invalid
- Backend `pytest --ignore=tests/integration`: 8993 passed (floor met), 0 failures
- svelte-check 0/0; eslint, boundaries, i18n 0; ruff check/format 0; lint-imports 0; `mypy --strict src/rigplane/web` 0; gen_state_types --check 0; consumer contracts 0; architecture pytest 238 passed; validate-release all steps passed
- Whole-tree mypy base vs head: byte-identical outputs (13 errors / 4 files on both, documented baseline) — zero drift
- Mutation battery M1–M38: all substantive RED, all restored
- Exact-base authority causal RED: 60 failed / 80 passed (substantive), candidate focused GREEN 140/140

🤖 Generated with [Claude Code](https://claude.com/claude-code)