### PR TITLE
refactor(#2317): canonicalize runtime facade and remove state escape hatches (A08)

### DIFF
--- a/frontend/src/__tests__/presentation-switch-resources.component.test.ts
+++ b/frontend/src/__tests__/presentation-switch-resources.component.test.ts
@@ -74,6 +74,12 @@ vi.mock('$lib/transport/ws-client', () => ({
   onMessage: vi.fn(() => () => {}),
   addMessageHandler: vi.fn(() => () => {}),
   getChannel: vi.fn(),
+  // Stub parity for the frontend-runtime -> radio-intents edge (MOR-1409
+  // A08): the real intent facade registers delivery/session listeners at
+  // module scope.
+  onCommandDelivery: vi.fn(() => () => {}),
+  onControlSessionTransition: vi.fn(() => () => {}),
+  getControlSession: vi.fn(() => ({ epoch: 0 })),
 }));
 vi.mock('$lib/audio/audio-manager', () => ({
   audioManager: {

--- a/frontend/src/lib/local-extensions/__tests__/host-api.test.ts
+++ b/frontend/src/lib/local-extensions/__tests__/host-api.test.ts
@@ -3,6 +3,11 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { Capabilities } from '$lib/types/capabilities';
 import type { ServerState } from '$lib/types/state';
 import {
+  getCommandLifecycles,
+  resetCommandLifecycle,
+} from '$lib/stores/commands.svelte';
+import {
+  createDefaultLocalExtensionHostApi,
   createLocalExtensionHostApi,
   installLocalExtensionHostApi,
   LOCAL_EXTENSION_HOST_API_VERSION,
@@ -194,5 +199,59 @@ describe('installLocalExtensionHostApi', () => {
     // The first uninstall must not blow away the live api2.
     expect(fakeWindow.rigplaneExtensionHost).toBe(api2);
     expect(fakeWindow.icomLanExtensionHost).toBe(api2);
+  });
+});
+
+// MOR-1409 A08: the default extension dispatch is catalog-validated facade
+// delegation. This block runs against the real intent facade and command
+// lifecycle store (no module mocks — this file lives in the `fast` project):
+// a facade dispatch is observable as a lifecycle record, while a raw
+// transport bypass would leave no record.
+describe('createDefaultLocalExtensionHostApi (MOR-1409 A08)', () => {
+  afterEach(() => {
+    resetCommandLifecycle();
+  });
+
+  it('routes known catalog commands through the typed facade with a lifecycle record', () => {
+    const api = createDefaultLocalExtensionHostApi();
+    const before = getCommandLifecycles().length;
+
+    expect(api.dispatchCommand('vfo_swap')).toBe(true);
+
+    const records = getCommandLifecycles();
+    expect(records).toHaveLength(before + 1);
+    expect(records.at(-1)).toMatchObject({ name: 'vfo_swap', params: {} });
+  });
+
+  it('clones params so later caller mutation cannot alter the dispatched intent', () => {
+    const api = createDefaultLocalExtensionHostApi();
+    const params: Record<string, unknown> = { band: 20 };
+
+    expect(api.sendCommand('set_band', params)).toBe(true);
+    params.band = 40;
+
+    expect(getCommandLifecycles().at(-1)).toMatchObject({
+      name: 'set_band',
+      params: { band: 20 },
+    });
+  });
+
+  it('fails closed with false for unknown, PTT, and malformed commands', () => {
+    const api = createDefaultLocalExtensionHostApi();
+    const before = getCommandLifecycles().length;
+
+    // Unknown command names are rejected by the catalog.
+    expect(api.dispatchCommand('definitely_not_a_command')).toBe(false);
+    // PTT is not in the intent catalog — extensions cannot key the radio.
+    expect(api.dispatchCommand('ptt')).toBe(false);
+    expect(api.dispatchCommand('ptt_on')).toBe(false);
+    expect(api.dispatchCommand('ptt_off')).toBe(false);
+    // Malformed params fail validation before any transport is reached.
+    expect(api.sendCommand('set_band', { band: 'not-a-number' })).toBe(false);
+    expect(api.sendCommand('set_band', { band: 20, extra: true })).toBe(false);
+    expect(api.sendCommand('set_band')).toBe(false);
+
+    // Fail-closed dispatches never create a lifecycle record.
+    expect(getCommandLifecycles()).toHaveLength(before);
   });
 });

--- a/frontend/src/lib/local-extensions/host-api.ts
+++ b/frontend/src/lib/local-extensions/host-api.ts
@@ -2,7 +2,7 @@ import type { Capabilities } from '$lib/types/capabilities';
 import type { ServerState } from '$lib/types/state';
 import { getCapabilities } from '$lib/stores/capabilities.svelte';
 import { getRadioState, subscribeRadioState } from '$lib/stores/radio.svelte';
-import { sendCommand } from '$lib/transport/ws-client';
+import { dispatchRadioIntent, type RadioIntent } from '$lib/runtime/commands/radio-intents';
 import {
   resetLocalExtensionKeyboardScope,
   setLocalExtensionKeyboardScope,
@@ -88,6 +88,27 @@ export function createLocalExtensionHostApi(
   };
 }
 
+/**
+ * Default extension dispatch (MOR-1409 A08): catalog-validated delegation to
+ * the typed intent facade. Unknown names, PTT, and malformed params raise a
+ * validation error inside the facade before any transport is reached — the
+ * host API fails closed with `false`.
+ */
+function dispatchThroughIntentFacade(
+  name: string,
+  params?: Record<string, unknown>,
+): boolean {
+  if (typeof name !== 'string' || name.trim() === '') {
+    return false;
+  }
+  try {
+    dispatchRadioIntent({ name, params: params ?? {} } as RadioIntent);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export function createDefaultLocalExtensionHostApi(
   register: (extension: LocalExtensionRegistration) => void = () => {},
 ): LocalExtensionHostApiV1 {
@@ -95,7 +116,7 @@ export function createDefaultLocalExtensionHostApi(
     getState: getRadioState,
     getCapabilities,
     subscribeState: (handler) => subscribeRadioState(handler),
-    dispatchCommand: sendCommand,
+    dispatchCommand: dispatchThroughIntentFacade,
     setKeyboardScope: setLocalExtensionKeyboardScope,
     register,
   });

--- a/frontend/src/lib/runtime/__tests__/frontend-runtime.isolated.test.ts
+++ b/frontend/src/lib/runtime/__tests__/frontend-runtime.isolated.test.ts
@@ -31,10 +31,11 @@ vi.mock('$lib/transport/ws-client', () => ({
   addMessageHandler: vi.fn(() => () => {}),
   getChannel: vi.fn(),
 }));
-vi.mock('$lib/runtime/commands/radio-intents', async () => {
-  const { sendCommand } = await import('$lib/transport/ws-client');
-  return { dispatchRadioIntent: ({ name, params }: { name: string; params: Record<string, unknown> }) => sendCommand(name, params) };
-});
+vi.mock('$lib/runtime/commands/radio-intents', () => ({
+  dispatchRadioIntent: vi.fn(() => ({ id: 'test-lifecycle', status: 'pending' })),
+  isNormalizedLevel: (value: unknown) =>
+    typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 1,
+}));
 
 vi.mock('$lib/stores/capabilities.svelte', () => ({
   getCapabilities: vi.fn(() => null),
@@ -114,9 +115,10 @@ vi.mock('./system-controller', async () => {
 // ── Import modules under test after mocks are hoisted ──
 
 import { fetchCapabilities, startPolling } from '$lib/transport/http-client';
-import { connect, getChannel, onMessage, sendRaw } from '$lib/transport/ws-client';
+import { connect, getChannel, onMessage, sendCommand, sendRaw } from '$lib/transport/ws-client';
+import { dispatchRadioIntent } from '$lib/runtime/commands/radio-intents';
 import { setCapabilities, subscribeCapabilities } from '$lib/stores/capabilities.svelte';
-import { setRadioState } from '$lib/stores/radio.svelte';
+import { patchActiveReceiver, patchRadioState, setRadioState } from '$lib/stores/radio.svelte';
 import { audioManager } from '$lib/audio/audio-manager';
 import { systemController } from '../system-controller';
 import { clearLegacyPendingModInputRestore } from '../adapters/mod-input-auto.svelte';
@@ -499,6 +501,72 @@ describe('FrontendRuntime.bootstrap()', () => {
     // Both callers get the same cleanup function
     expect(cleanup1).toBe(cleanup2);
     expect(cleanup1).not.toBe(fakeStopPolling);
+  });
+});
+
+describe('FrontendRuntime command dispatch and state-hatch removal (MOR-1409 A08)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    configureAcceptedCapabilities();
+    (startPolling as ReturnType<typeof vi.fn>).mockReturnValue(fakeStopPolling);
+  });
+
+  it('delegates send() to the typed facade exactly once with no raw transport', async () => {
+    const rt = await freshRuntime();
+
+    rt.send('set_scope_dual', { dual: true });
+
+    expect(dispatchRadioIntent).toHaveBeenCalledExactlyOnceWith({
+      name: 'set_scope_dual',
+      params: { dual: true },
+    });
+    expect(sendCommand).not.toHaveBeenCalled();
+    expect(patchActiveReceiver).not.toHaveBeenCalled();
+    expect(patchRadioState).not.toHaveBeenCalled();
+
+    rt.send('switch_scope_receiver', { receiver: 1 });
+    expect(dispatchRadioIntent).toHaveBeenCalledTimes(2);
+    expect(dispatchRadioIntent).toHaveBeenLastCalledWith({
+      name: 'switch_scope_receiver',
+      params: { receiver: 1 },
+    });
+    expect(sendCommand).not.toHaveBeenCalled();
+  });
+
+  it('defaults missing params to an empty object', async () => {
+    const rt = await freshRuntime();
+
+    rt.send('vfo_swap');
+
+    expect(dispatchRadioIntent).toHaveBeenCalledExactlyOnceWith({
+      name: 'vfo_swap',
+      params: {},
+    });
+  });
+
+  it('swallows facade validation errors without throwing or double-dispatching', async () => {
+    const rt = await freshRuntime();
+    vi.mocked(dispatchRadioIntent).mockImplementationOnce(() => {
+      throw new TypeError('Only a known non-PTT radio intent may be dispatched');
+    });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    expect(() => rt.send('definitely_not_a_command')).not.toThrow();
+
+    expect(dispatchRadioIntent).toHaveBeenCalledTimes(1);
+    expect(sendCommand).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+
+  it('no longer exposes the patchActiveReceiver/patchState escape hatches', async () => {
+    const rt = await freshRuntime();
+    const surface = rt as unknown as Record<string, unknown>;
+
+    expect(surface.patchActiveReceiver).toBeUndefined();
+    expect(surface.patchState).toBeUndefined();
+    expect(patchActiveReceiver).not.toHaveBeenCalled();
+    expect(patchRadioState).not.toHaveBeenCalled();
   });
 });
 

--- a/frontend/src/lib/runtime/adapters/__tests__/mod-input-auto.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mod-input-auto.isolated.test.ts
@@ -1,14 +1,17 @@
 /**
- * Opt-in auto LAN MOD-input for network voice TX (MOR-618, T4 of epic MOR-614).
+ * Opt-in auto LAN MOD-input for network voice TX (MOR-618, T4 of epic MOR-614;
+ * de-optimism + facade dispatch: MOR-1409 A08).
  *
  * The feature is OFF by default — default UX stays the MOR-617 warn +
  * one-click guard. When the user opts in:
  *   - at web TX start, if the active DATA group's MOD-input source is known
- *     and != LAN(5): remember the previous source, set LAN via the existing
- *     per-group SET command, and suppress the MOR-617 warning (the
- *     optimistic LAN patch preempts the guard);
+ *     and != LAN(5): remember the previous source and dispatch the per-group
+ *     SET through the typed intent facade. The Store is never written
+ *     optimistically — the MOR-617 warning stays armed truthfully until
+ *     provider readback confirms LAN;
  *   - after authoritative PTT-off confirmation, restore the remembered source
- *     only if auto changed it and the group is still on LAN;
+ *     only if auto changed it and the group is still on LAN, again through
+ *     the facade with zero Store writes;
  *   - pending restore state is memory-only and cannot replay on reconnect.
  *
  * When OFF, behavior is exactly MOR-617 (warn-only, no silent changes).
@@ -16,12 +19,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('$lib/transport/ws-client', () => ({
+  // Raw-transport alarm: the adapter must never reach ws-client directly.
   sendCommand: vi.fn(() => true),
 }));
-vi.mock('$lib/runtime/commands/radio-intents', async () => {
-  const { sendCommand } = await import('$lib/transport/ws-client');
-  return { dispatchRadioIntent: ({ name, params }: { name: string; params: Record<string, unknown> }) => sendCommand(name, params) };
-});
+vi.mock('$lib/runtime/commands/radio-intents', () => ({
+  dispatchRadioIntent: vi.fn(() => ({ id: 'test-lifecycle', status: 'pending' })),
+  isNormalizedLevel: (value: unknown) =>
+    typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 1,
+}));
 
 vi.mock('$lib/audio/audio-manager', () => ({
   audioManager: {
@@ -43,6 +48,7 @@ vi.mock('$lib/runtime/frontend-runtime', () => ({
 }));
 
 import { sendCommand } from '$lib/transport/ws-client';
+import { dispatchRadioIntent } from '$lib/runtime/commands/radio-intents';
 import { runtime } from '$lib/runtime/frontend-runtime';
 import { getRadioState, resetRadioState, setRadioState } from '$lib/stores/radio.svelte';
 import { setCapabilities } from '$lib/stores/capabilities.svelte';
@@ -180,6 +186,7 @@ beforeEach(() => {
   localStorage.clear();
   vi.mocked(sendCommand).mockClear();
   vi.mocked(sendCommand).mockReturnValue(true);
+  vi.mocked(dispatchRadioIntent).mockClear();
   vi.mocked(runtime.startTx).mockClear();
   vi.mocked(runtime.startTx).mockResolvedValue(null);
   vi.mocked(runtime.stopTx).mockClear();
@@ -229,31 +236,38 @@ describe('OFF behavior is exactly MOR-617 (MOR-618)', () => {
 
     await getTxAudioControl().startTx();
 
+    expect(dispatchRadioIntent).not.toHaveBeenCalled();
     expect(sendCommand).not.toHaveBeenCalled();
     expect(deriveModInputTxGuardProps().visible).toBe(true);
     expect(pendingInStorage()).toBeNull();
 
     getTxAudioControl().stopLocalAudio();
+    expect(dispatchRadioIntent).not.toHaveBeenCalled();
     expect(sendCommand).not.toHaveBeenCalled();
     expect(runtime.stopTx).toHaveBeenCalledTimes(1);
   });
 });
 
-describe('auto-set at TX start (MOR-618)', () => {
-  it('sets LAN on the active group, remembers the previous source and suppresses the warning', async () => {
+describe('auto-set at TX start (MOR-618, MOR-1409 A08)', () => {
+  it('dispatches LAN for the active group through the facade with zero Store writes', async () => {
     setAutoLanModInputEnabled(true);
     setState({ main: receiver(1), data1ModInput: 0 });
 
     await getTxAudioControl().startTx();
 
-    expect(sendCommand).toHaveBeenCalledWith('set_data1_mod_input', { source: 5 });
+    // Exactly one facade dispatch, exact envelope, no raw transport.
+    expect(dispatchRadioIntent).toHaveBeenCalledExactlyOnceWith({
+      name: 'set_data1_mod_input',
+      params: { source: 5 },
+    });
+    expect(sendCommand).not.toHaveBeenCalled();
     expect(runtime.startTx).toHaveBeenCalledTimes(1);
-    // Optimistic patch preempts the MOR-617 guard — no warning.
-    expect(getRadioState()?.data1ModInput).toBe(5);
-    expect(deriveModInputTxGuardProps().visible).toBe(false);
+    // Truth-first: no optimistic Store write — the confirmed source stays MIC
+    // and the MOR-617 warning arms until provider readback confirms LAN.
+    expect(getRadioState()?.data1ModInput).toBe(0);
+    expect(deriveModInputTxGuardProps().visible).toBe(true);
     // The restore transaction is memory-only and cannot replay after reload.
     expect(pendingInStorage()).toBeNull();
-    expect(sendCommand).not.toHaveBeenCalledWith('arm_mod_input_restore', expect.anything());
   });
 
   it('routes to the ACTIVE receiver group (SUB on D2)', async () => {
@@ -269,8 +283,12 @@ describe('auto-set at TX start (MOR-618)', () => {
 
     await getTxAudioControl().startTx();
 
-    expect(sendCommand).toHaveBeenCalledWith('set_data2_mod_input', { source: 5 });
-    expect(sendCommand).not.toHaveBeenCalledWith('arm_mod_input_restore', expect.anything());
+    expect(dispatchRadioIntent).toHaveBeenCalledExactlyOnceWith({
+      name: 'set_data2_mod_input',
+      params: { source: 5 },
+    });
+    expect(sendCommand).not.toHaveBeenCalled();
+    expect(getRadioState()?.data2ModInput).toBe(3);
   });
 
   it('does nothing when the source is already LAN', async () => {
@@ -279,6 +297,7 @@ describe('auto-set at TX start (MOR-618)', () => {
 
     await getTxAudioControl().startTx();
 
+    expect(dispatchRadioIntent).not.toHaveBeenCalled();
     expect(sendCommand).not.toHaveBeenCalled();
     expect(pendingInStorage()).toBeNull();
   });
@@ -289,6 +308,7 @@ describe('auto-set at TX start (MOR-618)', () => {
 
     await getTxAudioControl().startTx();
 
+    expect(dispatchRadioIntent).not.toHaveBeenCalled();
     expect(sendCommand).not.toHaveBeenCalled();
   });
 
@@ -299,6 +319,7 @@ describe('auto-set at TX start (MOR-618)', () => {
 
     await getTxAudioControl().startTx();
 
+    expect(dispatchRadioIntent).not.toHaveBeenCalled();
     expect(sendCommand).not.toHaveBeenCalled();
   });
 
@@ -312,11 +333,12 @@ describe('auto-set at TX start (MOR-618)', () => {
 
     await getTxAudioControl().startTx();
 
+    expect(dispatchRadioIntent).not.toHaveBeenCalled();
     expect(sendCommand).not.toHaveBeenCalled();
   });
 });
 
-describe('confirmed restore after local TX audio stop (MOR-618, MOR-990)', () => {
+describe('confirmed restore after local TX audio stop (MOR-618, MOR-990, MOR-1409 A08)', () => {
   it('treats startTx while already running as a side-effect-free success', async () => {
     setAutoLanModInputEnabled(true);
     setState({ main: receiver(1), data1ModInput: 0 });
@@ -332,12 +354,14 @@ describe('confirmed restore after local TX audio stop (MOR-618, MOR-990)', () =>
       data2ModInput: 3,
     });
     dismissModInputTxGuard();
+    vi.mocked(dispatchRadioIntent).mockClear();
     vi.mocked(sendCommand).mockClear();
     vi.mocked(runtime.startTx).mockClear();
 
     await expect(control.startTx()).resolves.toBeNull();
 
     expect(runtime.startTx).not.toHaveBeenCalled();
+    expect(dispatchRadioIntent).not.toHaveBeenCalled();
     expect(sendCommand).not.toHaveBeenCalled();
     expect(getRadioState()?.data2ModInput).toBe(3);
     expect(deriveModInputTxGuardProps().visible).toBe(false);
@@ -357,10 +381,12 @@ describe('confirmed restore after local TX audio stop (MOR-618, MOR-990)', () =>
 
     setState({ main: receiver(1), data1ModInput: 0 });
     dismissModInputTxGuard();
+    vi.mocked(dispatchRadioIntent).mockClear();
     vi.mocked(sendCommand).mockClear();
 
     await expect(control.startTx()).resolves.toBe('TX audio start already in progress');
     expect(runtime.startTx).toHaveBeenCalledTimes(1);
+    expect(dispatchRadioIntent).not.toHaveBeenCalled();
     expect(sendCommand).not.toHaveBeenCalled();
     expect(deriveModInputTxGuardProps().visible).toBe(false);
 
@@ -381,15 +407,27 @@ describe('confirmed restore after local TX audio stop (MOR-618, MOR-990)', () =>
     control.stopLocalAudio();
 
     expect(runtime.stopTx).toHaveBeenCalledTimes(1);
-    expect(sendCommand).not.toHaveBeenCalledWith('set_data1_mod_input', { source: 0 });
+    expect(dispatchRadioIntent).not.toHaveBeenCalledWith({
+      name: 'set_data1_mod_input',
+      params: { source: 0 },
+    });
     expect(pendingInStorage()).toBeNull();
 
     pendingStart.resolve(null);
     await expect(start).resolves.toBeNull();
     expect(runtime.stopTx).toHaveBeenCalledTimes(2);
-    expect(sendCommand).not.toHaveBeenCalledWith('set_data1_mod_input', { source: 0 });
+    expect(dispatchRadioIntent).not.toHaveBeenCalledWith({
+      name: 'set_data1_mod_input',
+      params: { source: 0 },
+    });
+    // Readback confirms LAN landed, then confirmed OFF authorizes restore.
+    setState({ main: receiver(1), data1ModInput: 5 });
     confirmOff();
-    expect(sendCommand).toHaveBeenCalledWith('set_data1_mod_input', { source: 0 });
+    expect(dispatchRadioIntent).toHaveBeenCalledWith({
+      name: 'set_data1_mod_input',
+      params: { source: 0 },
+    });
+    expect(sendCommand).not.toHaveBeenCalled();
   });
 
   it('retains cancellation and cleanup when a late start returns an error', async () => {
@@ -407,10 +445,17 @@ describe('confirmed restore after local TX audio stop (MOR-618, MOR-990)', () =>
     pendingStart.resolve('TX MIC: capture failed');
     await expect(start).resolves.toBe('TX MIC: capture failed');
     expect(runtime.stopTx).toHaveBeenCalledTimes(2);
-    expect(sendCommand).not.toHaveBeenCalledWith('set_data1_mod_input', { source: 0 });
+    expect(dispatchRadioIntent).not.toHaveBeenCalledWith({
+      name: 'set_data1_mod_input',
+      params: { source: 0 },
+    });
     expect(pendingInStorage()).toBeNull();
+    setState({ main: receiver(1), data1ModInput: 5 });
     confirmOff();
-    expect(sendCommand).toHaveBeenCalledWith('set_data1_mod_input', { source: 0 });
+    expect(dispatchRadioIntent).toHaveBeenCalledWith({
+      name: 'set_data1_mod_input',
+      params: { source: 0 },
+    });
   });
 
   it('retains cancellation and cleanup when a late start rejects', async () => {
@@ -429,36 +474,50 @@ describe('confirmed restore after local TX audio stop (MOR-618, MOR-990)', () =>
     pendingStart.reject(startError);
     await expect(start).rejects.toBe(startError);
     expect(runtime.stopTx).toHaveBeenCalledTimes(2);
-    expect(sendCommand).not.toHaveBeenCalledWith('set_data1_mod_input', { source: 0 });
+    expect(dispatchRadioIntent).not.toHaveBeenCalledWith({
+      name: 'set_data1_mod_input',
+      params: { source: 0 },
+    });
     expect(pendingInStorage()).toBeNull();
+    setState({ main: receiver(1), data1ModInput: 5 });
     confirmOff();
-    expect(sendCommand).toHaveBeenCalledWith('set_data1_mod_input', { source: 0 });
+    expect(dispatchRadioIntent).toHaveBeenCalledWith({
+      name: 'set_data1_mod_input',
+      params: { source: 0 },
+    });
   });
 
   it('stops local audio without restoring, then restores after confirmed OFF', async () => {
     setAutoLanModInputEnabled(true);
     setState({ main: receiver(1), data1ModInput: 0 });
     await getTxAudioControl().startTx();
-    vi.mocked(sendCommand).mockClear();
+    // Provider readback confirms LAN during TX.
+    setState({ main: receiver(1), data1ModInput: 5 });
+    vi.mocked(dispatchRadioIntent).mockClear();
 
     getTxAudioControl().stopLocalAudio();
 
     expect(runtime.stopTx).toHaveBeenCalledTimes(1);
-    expect(sendCommand).not.toHaveBeenCalled();
+    expect(dispatchRadioIntent).not.toHaveBeenCalled();
     expect(pendingInStorage()).toBeNull();
 
     confirmOff();
 
-    expect(sendCommand).toHaveBeenCalledWith('set_data1_mod_input', { source: 0 });
-    expect(sendCommand).not.toHaveBeenCalledWith('disarm_mod_input_restore', expect.anything());
-    expect(getRadioState()?.data1ModInput).toBe(0);
+    expect(dispatchRadioIntent).toHaveBeenCalledExactlyOnceWith({
+      name: 'set_data1_mod_input',
+      params: { source: 0 },
+    });
+    expect(sendCommand).not.toHaveBeenCalled();
+    // No optimistic restore write: the Store keeps the last observed value
+    // (LAN) until the radio reads back the restored source.
+    expect(getRadioState()?.data1ModInput).toBe(5);
     expect(pendingInStorage()).toBeNull();
 
     // Restore is one-shot — a second stop sends nothing.
-    vi.mocked(sendCommand).mockClear();
+    vi.mocked(dispatchRadioIntent).mockClear();
     getTxAudioControl().stopLocalAudio();
     confirmOff();
-    expect(sendCommand).not.toHaveBeenCalled();
+    expect(dispatchRadioIntent).not.toHaveBeenCalled();
     expect(runtime.stopTx).toHaveBeenCalledTimes(1);
   });
 
@@ -466,19 +525,20 @@ describe('confirmed restore after local TX audio stop (MOR-618, MOR-990)', () =>
     setAutoLanModInputEnabled(true);
     setState({ main: receiver(1), data1ModInput: 0 });
     await getTxAudioControl().startTx();
-    // Write-through readback confirms LAN (drops the optimistic overlay)…
+    // Write-through readback confirms LAN…
     setState({ main: receiver(1), data1ModInput: 5 });
     // …then the user changed the group to USB(3) during TX.
     setState({ main: receiver(1), data1ModInput: 3 });
-    vi.mocked(sendCommand).mockClear();
+    vi.mocked(dispatchRadioIntent).mockClear();
 
     getTxAudioControl().stopLocalAudio();
-    expect(sendCommand).not.toHaveBeenCalled();
+    expect(dispatchRadioIntent).not.toHaveBeenCalled();
     confirmOff();
 
     // The manual choice wins: no frontend or backend restore mutation.
+    expect(dispatchRadioIntent).not.toHaveBeenCalled();
     expect(sendCommand).not.toHaveBeenCalled();
-    expect(sendCommand).not.toHaveBeenCalledWith('set_data1_mod_input', expect.anything());
+    expect(getRadioState()?.data1ModInput).toBe(3);
     expect(pendingInStorage()).toBeNull();
   });
 
@@ -486,13 +546,40 @@ describe('confirmed restore after local TX audio stop (MOR-618, MOR-990)', () =>
     setAutoLanModInputEnabled(true);
     setState({ main: receiver(1), data1ModInput: 0 });
     await getTxAudioControl().startTx();
+    setState({ main: receiver(1), data1ModInput: 5 });
     setAutoLanModInputEnabled(false);
-    vi.mocked(sendCommand).mockClear();
+    vi.mocked(dispatchRadioIntent).mockClear();
 
     getTxAudioControl().stopLocalAudio();
     confirmOff();
 
-    expect(sendCommand).toHaveBeenCalledWith('set_data1_mod_input', { source: 0 });
+    expect(dispatchRadioIntent).toHaveBeenCalledExactlyOnceWith({
+      name: 'set_data1_mod_input',
+      params: { source: 0 },
+    });
+  });
+
+  it('skips the restore when LAN was never observed, consuming the pending one-shot', async () => {
+    setAutoLanModInputEnabled(true);
+    setState({ main: receiver(1), data1ModInput: 0 });
+    await getTxAudioControl().startTx();
+    vi.mocked(dispatchRadioIntent).mockClear();
+
+    getTxAudioControl().stopLocalAudio();
+    confirmOff();
+
+    // Confirmed truth governs the restore: the Store never observed LAN, so
+    // sending the remembered source back would fight the observed state.
+    expect(dispatchRadioIntent).not.toHaveBeenCalled();
+    expect(sendCommand).not.toHaveBeenCalled();
+    expect(getRadioState()?.data1ModInput).toBe(0);
+
+    // The pending one-shot is consumed: a late LAN readback cannot trigger a
+    // stale restore afterwards.
+    setState({ main: receiver(1), data1ModInput: 5 });
+    getTxAudioControl().stopLocalAudio();
+    confirmOff();
+    expect(dispatchRadioIntent).not.toHaveBeenCalled();
   });
 
   it('retains the pending restore when TX audio fails until OFF is confirmed', async () => {
@@ -503,12 +590,19 @@ describe('confirmed restore after local TX audio stop (MOR-618, MOR-990)', () =>
     const err = await getTxAudioControl().startTx();
 
     expect(err).toBe('TX MIC: capture failed');
-    expect(sendCommand).toHaveBeenCalledWith('set_data1_mod_input', { source: 5 });
-    expect(sendCommand).not.toHaveBeenCalledWith('set_data1_mod_input', { source: 0 });
+    expect(dispatchRadioIntent).toHaveBeenCalledExactlyOnceWith({
+      name: 'set_data1_mod_input',
+      params: { source: 5 },
+    });
     expect(pendingInStorage()).toBeNull();
 
+    setState({ main: receiver(1), data1ModInput: 5 });
     confirmOff();
-    expect(sendCommand).toHaveBeenCalledWith('set_data1_mod_input', { source: 0 });
+    expect(dispatchRadioIntent).toHaveBeenCalledWith({
+      name: 'set_data1_mod_input',
+      params: { source: 0 },
+    });
+    expect(sendCommand).not.toHaveBeenCalled();
     expect(pendingInStorage()).toBeNull();
   });
 
@@ -516,8 +610,9 @@ describe('confirmed restore after local TX audio stop (MOR-618, MOR-990)', () =>
     setAutoLanModInputEnabled(true);
     setState({ main: receiver(1), data1ModInput: 0 });
     await getTxAudioControl().startTx();
+    setState({ main: receiver(1), data1ModInput: 5 });
     getTxAudioControl().stopLocalAudio();
-    vi.mocked(sendCommand).mockClear();
+    vi.mocked(dispatchRadioIntent).mockClear();
 
     const rejected: AuthoritativePttObservation[] = [
       offObservation({ pttObservationSeq: 41 }),
@@ -534,19 +629,23 @@ describe('confirmed restore after local TX audio stop (MOR-618, MOR-990)', () =>
     for (const observation of rejected) {
       getTxAudioControl().restoreModAfterConfirmedOff({ barrier: OFF_BARRIER, observation });
     }
-    expect(sendCommand).not.toHaveBeenCalled();
+    expect(dispatchRadioIntent).not.toHaveBeenCalled();
     expect(pendingInStorage()).toBeNull();
 
     confirmOff();
-    expect(sendCommand).toHaveBeenCalledWith('set_data1_mod_input', { source: 0 });
+    expect(dispatchRadioIntent).toHaveBeenCalledExactlyOnceWith({
+      name: 'set_data1_mod_input',
+      params: { source: 0 },
+    });
   });
 
   it('uses the field-specific monotonic marker when no PTT sequence exists', async () => {
     setAutoLanModInputEnabled(true);
     setState({ main: receiver(1), data1ModInput: 0 });
     await getTxAudioControl().startTx();
+    setState({ main: receiver(1), data1ModInput: 5 });
     getTxAudioControl().stopLocalAudio();
-    vi.mocked(sendCommand).mockClear();
+    vi.mocked(dispatchRadioIntent).mockClear();
 
     getTxAudioControl().restoreModAfterConfirmedOff({
       barrier: {
@@ -560,7 +659,10 @@ describe('confirmed restore after local TX audio stop (MOR-618, MOR-990)', () =>
       }),
     });
 
-    expect(sendCommand).toHaveBeenCalledWith('set_data1_mod_input', { source: 0 });
+    expect(dispatchRadioIntent).toHaveBeenCalledExactlyOnceWith({
+      name: 'set_data1_mod_input',
+      params: { source: 0 },
+    });
     expect(pendingInStorage()).toBeNull();
   });
 });
@@ -575,6 +677,7 @@ describe('legacy persisted restore migration (MOR-990)', () => {
 
     clearLegacyPendingModInputRestore();
 
+    expect(dispatchRadioIntent).not.toHaveBeenCalled();
     expect(sendCommand).not.toHaveBeenCalled();
     expect(getRadioState()?.data1ModInput).toBe(5);
     expect(pendingInStorage()).toBeNull();
@@ -590,6 +693,7 @@ describe('legacy persisted restore migration (MOR-990)', () => {
     setState({ main: receiver(1), data1ModInput: 5 });
     setState({ main: receiver(1), data1ModInput: 5 });
 
+    expect(dispatchRadioIntent).not.toHaveBeenCalled();
     expect(sendCommand).not.toHaveBeenCalled();
     expect(getRadioState()?.data1ModInput).toBe(5);
     expect(pendingInStorage()).toBeNull();
@@ -601,6 +705,7 @@ describe('legacy persisted restore migration (MOR-990)', () => {
 
     clearLegacyPendingModInputRestore();
 
+    expect(dispatchRadioIntent).not.toHaveBeenCalled();
     expect(sendCommand).not.toHaveBeenCalled();
     expect(getRadioState()?.data1ModInput).toBe(5);
     expect(pendingInStorage()).toBeNull();
@@ -619,13 +724,21 @@ it('keeps a hung cancelled start stopped and pending for reconciliation', async 
   control.stopLocalAudio();
 
   expect(runtime.stopTx).toHaveBeenCalledTimes(1);
-  expect(sendCommand).not.toHaveBeenCalledWith('set_data1_mod_input', { source: 0 });
+  expect(dispatchRadioIntent).not.toHaveBeenCalledWith({
+    name: 'set_data1_mod_input',
+    params: { source: 0 },
+  });
   expect(pendingInStorage()).toBeNull();
 
   // Settle only to keep this module-level adapter isolated from later files.
   pendingStart.resolve('test cleanup');
   await expect(start).resolves.toBe('test cleanup');
   expect(runtime.stopTx).toHaveBeenCalledTimes(2);
+  setState({ main: receiver(1), data1ModInput: 5 });
   confirmOff();
-  expect(sendCommand).toHaveBeenCalledWith('set_data1_mod_input', { source: 0 });
+  expect(dispatchRadioIntent).toHaveBeenCalledWith({
+    name: 'set_data1_mod_input',
+    params: { source: 0 },
+  });
+  expect(sendCommand).not.toHaveBeenCalled();
 });

--- a/frontend/src/lib/runtime/adapters/__tests__/mod-input-tx-guard.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mod-input-tx-guard.isolated.test.ts
@@ -16,10 +16,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 vi.mock('$lib/transport/ws-client', () => ({
   sendCommand: vi.fn(),
 }));
-vi.mock('$lib/runtime/commands/radio-intents', async () => {
-  const { sendCommand } = await import('$lib/transport/ws-client');
-  return { dispatchRadioIntent: ({ name, params }: { name: string; params: Record<string, unknown> }) => sendCommand(name, params) };
-});
+vi.mock('$lib/runtime/commands/radio-intents', () => ({
+  dispatchRadioIntent: vi.fn(() => ({ id: 'test-lifecycle', status: 'pending' })),
+  isNormalizedLevel: (value: unknown) =>
+    typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 1,
+}));
 
 vi.mock('$lib/audio/audio-manager', () => ({
   audioManager: {
@@ -41,6 +42,7 @@ vi.mock('$lib/runtime/frontend-runtime', () => ({
 }));
 
 import { sendCommand } from '$lib/transport/ws-client';
+import { dispatchRadioIntent } from '$lib/runtime/commands/radio-intents';
 import { runtime } from '$lib/runtime/frontend-runtime';
 import { resetRadioState, setRadioState } from '$lib/stores/radio.svelte';
 import { setCapabilities } from '$lib/stores/capabilities.svelte';
@@ -50,6 +52,10 @@ import {
   dismissModInputTxGuard,
   getModInputTxGuardHandlers,
 } from '../mod-input-tx-guard.svelte';
+import {
+  restoreModInputAfterTx,
+  setAutoLanModInputEnabled,
+} from '../mod-input-auto.svelte';
 import { getTxAudioControl } from '../tx-adapter';
 import type { ServerState } from '$lib/types/state';
 
@@ -118,7 +124,11 @@ function missingStatus() {
 
 beforeEach(() => {
   getTxAudioControl().stopLocalAudio();
+  // Reset the T4 opt-in and drain any pending restore between tests.
+  setAutoLanModInputEnabled(false);
+  restoreModInputAfterTx();
   vi.mocked(sendCommand).mockClear();
+  vi.mocked(dispatchRadioIntent).mockClear();
   vi.mocked(runtime.startTx).mockClear();
   vi.mocked(runtime.stopTx).mockClear();
   resetRadioState();
@@ -221,22 +231,28 @@ describe('guard clearing (MOR-617)', () => {
 });
 
 describe('one-click Set LAN (MOR-617)', () => {
-  it('sends the active group SET command with source=5', () => {
+  it('dispatches the active group SET intent with source=5', () => {
     setState({ main: receiver(1), data1ModInput: 0 });
     armModInputTxGuard();
 
     getModInputTxGuardHandlers().onSetLan();
 
-    expect(sendCommand).toHaveBeenCalledWith('set_data1_mod_input', { source: 5 });
+    expect(dispatchRadioIntent).toHaveBeenCalledWith({
+      name: 'set_data1_mod_input',
+      params: { source: 5 },
+    });
   });
 
-  it('routes to the DATA OFF command when DATA is off', () => {
+  it('routes to the DATA OFF intent when DATA is off', () => {
     setState({ main: receiver(0), dataOffModInput: 3 });
     armModInputTxGuard();
 
     getModInputTxGuardHandlers().onSetLan();
 
-    expect(sendCommand).toHaveBeenCalledWith('set_data_off_mod_input', { source: 5 });
+    expect(dispatchRadioIntent).toHaveBeenCalledWith({
+      name: 'set_data_off_mod_input',
+      params: { source: 5 },
+    });
   });
 });
 
@@ -257,5 +273,34 @@ describe('tx-adapter TX-start hook (MOR-617)', () => {
 
     expect(runtime.startTx).toHaveBeenCalledTimes(1);
     expect(deriveModInputTxGuardProps().visible).toBe(false);
+  });
+});
+
+describe('auto-LAN truth-first interplay (MOR-1409 A08)', () => {
+  it('stays armed and visible during an auto-LAN TX start until readback confirms LAN', async () => {
+    setAutoLanModInputEnabled(true);
+    setState({ main: receiver(1), data1ModInput: 0 });
+
+    await getTxAudioControl().startTx();
+
+    // T4 dispatched the LAN set through the facade, but the Store still holds
+    // the confirmed source (MIC): the guard arms truthfully and the warning
+    // is visible — no optimistic suppression.
+    expect(dispatchRadioIntent).toHaveBeenCalledWith({
+      name: 'set_data1_mod_input',
+      params: { source: 5 },
+    });
+    const armedProps = deriveModInputTxGuardProps();
+    expect(armedProps.visible).toBe(true);
+    expect(armedProps.sourceLabel).toBe('MIC');
+
+    // Synthetic authoritative readback confirms LAN → visibility clears
+    // reactively without any guard code involvement.
+    setRadioState(makeState({ revision: 2, main: receiver(1), data1ModInput: 5 }));
+    expect(deriveModInputTxGuardProps().visible).toBe(false);
+
+    // A rejected change reverting the source re-surfaces the warning.
+    setRadioState(makeState({ revision: 3, main: receiver(1), data1ModInput: 0 }));
+    expect(deriveModInputTxGuardProps().visible).toBe(true);
   });
 });

--- a/frontend/src/lib/runtime/adapters/mod-input-auto.svelte.ts
+++ b/frontend/src/lib/runtime/adapters/mod-input-auto.svelte.ts
@@ -6,9 +6,10 @@
  *
  *   - TX start (`tx-adapter.startTx`, before the MOR-617 guard arms): if the
  *     active DATA group's MOD-input source is known and != LAN(5), remember
- *     it, then set LAN through the same per-group SET command + optimistic
- *     patch as the ModePanel control (T1/MOR-615 backend, T2/MOR-616
- *     helpers). The optimistic LAN patch preempts the MOR-617 warning.
+ *     it, then dispatch the per-group SET through the typed intent facade
+ *     (T1/MOR-615 backend, T2/MOR-616 helpers). The Store is never written
+ *     optimistically (MOR-1409 A08): the MOR-617 warning stays armed
+ *     truthfully until provider readback confirms LAN.
  *   - after a field-specific authoritative PTT-off confirmation, restore the
  *     remembered source only if the group is still on LAN (a manual mid-TX
  *     change wins).
@@ -19,7 +20,7 @@
  * This module never touches the audio byte path.
  */
 
-import { getRadioState, patchRadioState } from '$lib/stores/radio.svelte';
+import { getRadioState } from '$lib/stores/radio.svelte';
 import { getCapabilities } from '$lib/stores/capabilities.svelte';
 import { getFieldAvailability } from '$lib/state/field-status';
 import {
@@ -29,7 +30,7 @@ import {
   type ModInputCommand,
   type ModInputStateKey,
 } from '$lib/radio/mod-input';
-import { sendCommand } from '$lib/transport/ws-client';
+import { dispatchRadioIntent } from '../commands/radio-intents';
 import type { ServerState } from '$lib/types/state';
 
 /** localStorage key of the opt-in preference ('true' / 'false'). */
@@ -113,7 +114,7 @@ function activeDataMode(state: ServerState | null): number {
 
 /**
  * Opt-in TX-start hook (called by `tx-adapter.startTx` BEFORE the MOR-617
- * guard arms, so the optimistic LAN patch keeps the warning quiet).
+ * guard arms; the guard stays truthfully visible until readback confirms).
  * Same quiet-gating as the guard: no state, no data_mode capability, group
  * not read, source unknown, or already LAN → no change, no pending.
  */
@@ -130,10 +131,13 @@ export function autoSetLanModInputForTx(): void {
   if (source === null || source === LAN_MOD_INPUT_SOURCE) return;
 
   pending = { command: modInputCommand(dataMode), key, source };
-  // Same optimistic-patch + per-group SET path as the ModePanel control
-  // (MOR-616); the backend confirms via write-through readback (MOR-615).
-  patchRadioState({ [key]: LAN_MOD_INPUT_SOURCE } as Partial<ServerState>);
-  sendCommand(pending.command, { source: LAN_MOD_INPUT_SOURCE });
+  // Same per-group SET path as the ModePanel control (MOR-616), routed
+  // through the typed facade; the backend confirms via write-through
+  // readback (MOR-615).
+  dispatchRadioIntent({
+    name: pending.command,
+    params: { source: LAN_MOD_INPUT_SOURCE },
+  });
 }
 
 /**
@@ -147,8 +151,7 @@ export function restoreModInputAfterTx(): void {
   if (!p) return;
   const current = getRadioState()?.[p.key] ?? null;
   if (current !== null && current !== LAN_MOD_INPUT_SOURCE) return;
-  patchRadioState({ [p.key]: p.source } as Partial<ServerState>);
-  sendCommand(p.command, { source: p.source });
+  dispatchRadioIntent({ name: p.command, params: { source: p.source } });
 }
 
 /**

--- a/frontend/src/lib/runtime/frontend-runtime.ts
+++ b/frontend/src/lib/runtime/frontend-runtime.ts
@@ -11,7 +11,7 @@
  * @see docs/plans/2026-04-12-target-frontend-architecture.md
  */
 
-import { radio, getRadioState, patchActiveReceiver, patchRadioState, setRadioState } from '$lib/stores/radio.svelte';
+import { radio, getRadioState, setRadioState } from '$lib/stores/radio.svelte';
 import { getCapabilities, subscribeCapabilities } from '$lib/stores/capabilities.svelte';
 import {
   getConnectionStatus,
@@ -25,9 +25,10 @@ import {
   getRadioPowerOn,
 } from '$lib/stores/connection.svelte';
 import { getAudioState, setVolume, setMuted, toggleMute } from '$lib/stores/audio.svelte';
-import { sendCommand, connect, onMessage, sendRaw } from '$lib/transport/ws-client';
+import { connect, onMessage, sendRaw } from '$lib/transport/ws-client';
 import { startPolling, setPollingMultiplier } from '$lib/transport/http-client';
 import { audioManager } from '$lib/audio/audio-manager';
+import { dispatchRadioIntent, type RadioIntent } from './commands/radio-intents';
 import { clearLegacyPendingModInputRestore } from './adapters/mod-input-auto.svelte';
 import { derivePresentationCapabilities } from './adapters/presentation-capabilities';
 import { systemController } from './system-controller';
@@ -36,7 +37,7 @@ import type { ScopeController, ScopeSource } from './scope-controller.svelte';
 import { PresentationResourceHost } from './resource-host';
 import type { ResourceHealth, ResourceLease } from './resource-demand';
 import { createSubscriber } from 'svelte/reactivity';
-import type { ServerState, ReceiverState } from '$lib/types/state';
+import type { ServerState } from '$lib/types/state';
 import type { Capabilities } from '$lib/types/capabilities';
 import type { WsIncoming } from '$lib/types/protocol';
 import type { ConnectionState } from '$lib/transport/ws-client';
@@ -350,21 +351,17 @@ class FrontendRuntime {
 
   // ── Command dispatch ──
 
-  /** Send a command to the radio backend. */
+  /**
+   * Dispatch a catalog-validated radio intent through the typed facade
+   * (MOR-1409 A08). Zero raw transport: unknown names or malformed params
+   * are rejected by the facade and logged, never sent.
+   */
   send(name: string, params?: Record<string, unknown>): void {
-    sendCommand(name, params ?? {});
-  }
-
-  // ── Optimistic state patches ──
-
-  /** Apply an optimistic patch to the active receiver's state. */
-  patchActiveReceiver(patch: Partial<ReceiverState>, lock?: boolean): void {
-    patchActiveReceiver(patch, lock);
-  }
-
-  /** Apply an optimistic patch to the top-level radio state. */
-  patchState(patch: Partial<ServerState>): void {
-    patchRadioState(patch);
+    try {
+      dispatchRadioIntent({ name, params: params ?? {} } as RadioIntent);
+    } catch (error) {
+      console.warn('[runtime] send() rejected non-catalog command', name, error);
+    }
   }
 
   // ── Audio control ──


### PR DESCRIPTION
Part of #2317

## MOR-1409 gate A08 (runtime facade + escape-hatch removal)

Three production owners per the session-15 re-anchor plan (SHA-256 `70a7a24e…`) as amended by published coordinator corrections [5241395868](https://github.com/rigplane/rigplane-core/issues/2317#issuecomment-5241395868) (send() retained as catalog-validated facade delegation; method deletion deferred to the gate owning its last callers), [5241521787](https://github.com/rigplane/rigplane-core/issues/2317#issuecomment-5241521787) (enforcement-exception shrink removed from A08 — plugin/TOML untouched, byte-identical to base), and [5241845386](https://github.com/rigplane/rigplane-core/issues/2317#issuecomment-5241845386) (seventh non-production owner grant, stub-parity only):

- `frontend/src/lib/runtime/adapters/mod-input-auto.svelte.ts` (+15/−12) — both optimistic `patchRadioState` writes deleted; raw `sendCommand` removed; auto-set/restore dispatch typed radio intents; truth-first semantics (restore fires after observed readback confirms LAN).
- `frontend/src/lib/local-extensions/host-api.ts` (+23/−2) — raw transport import replaced with intent-facade dispatch; fail-closed wrapper; public API/window globals unchanged.
- `frontend/src/lib/runtime/frontend-runtime.ts` (+14/−17) — `patchActiveReceiver()`/`patchState()` escape hatches deleted; `send(name, params)` retained as catalog-validated facade delegation with zero raw transport.

Non-production: 4 owner test suites rewritten/extended + `presentation-switch-resources.component.test.ts` stub-parity completion (granted; +6/−0, no assertion changes).

Production churn 83 (+52/−31), modeled 70, far under the 391 STOP. 8 changed paths. Head `3bcaeb23e70e4a45dc0b929a4874ee3b4cfb8708`, base `6536b956e345b2898145bb6d879113c1011bc188`.

## Exact-head evidence (fresh detached worktree, once-through, no retries)

- Causal RED at exact base: 20 failed / 58 passed (substantive); mutation battery 16/16 killed, byte-exact restores verified
- Focused: 165/165 PASS (owner suites + 38-test authority-boundary corpus)
- Full frontend suite: 311 files, 6469/6469 PASS
- Frontend build PASS; retained fixture capture 64/64, 0 invalid (verified Chrome fallback)
- Backend `pytest --ignore=tests/integration`: 8993 passed (floor met), 0 failures
- svelte-check, eslint, boundaries, i18n, ruff check/format, lint-imports, `mypy --strict src/rigplane/web`, gen_state_types, consumer contracts, architecture pytest (11), validate-release, `git diff --check` — all PASS
- Whole-tree mypy base vs head: byte-identical outputs (13 errors / 4 files baseline) — zero drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)