### PR TITLE
refactor(#2317): remove ws-client optimistic machinery (A09a)

### DIFF
--- a/frontend/src/lib/runtime/commands/__tests__/auxiliary-tune-authority.isolated.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/auxiliary-tune-authority.isolated.test.ts
@@ -8,7 +8,6 @@ const h = vi.hoisted(() => ({
     _name: string,
     _params: Record<string, unknown>,
     _id: string,
-    _options: { optimistic: boolean },
   ) => true),
   patchActiveReceiver: vi.fn(),
   patchRadioState: vi.fn(),
@@ -112,7 +111,7 @@ function expectTypedLifecycle(): void {
   const ids = h.sendCommand.mock.calls.map((call) => call[2]);
   expect(ids.every((id) => typeof id === 'string' && id.length > 0)).toBe(true);
   expect(new Set(ids).size).toBe(ids.length);
-  for (const call of h.sendCommand.mock.calls) expect(call[3]).toEqual({ optimistic: false });
+  for (const call of h.sendCommand.mock.calls) expect(call).toHaveLength(3);
   expect(getCommandLifecycles()).toHaveLength(h.sendCommand.mock.calls.length);
   expect(h.patchActiveReceiver).not.toHaveBeenCalled();
   expect(h.patchRadioState).not.toHaveBeenCalled();

--- a/frontend/src/lib/runtime/commands/__tests__/memory-command-authority.isolated.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/memory-command-authority.isolated.test.ts
@@ -6,7 +6,7 @@ import type { ServerState } from '$lib/types/state';
 const h = vi.hoisted(() => ({
   state: null as ServerState | null,
   caps: null as Capabilities | null,
-  calls: [] as Array<{ name: string; params: Record<string, unknown>; id: string; options: { optimistic: boolean } }>,
+  calls: [] as Array<{ name: string; params: Record<string, unknown>; id: string; extraArgs: unknown[] }>,
   throwOnCall: 0,
 }));
 
@@ -27,9 +27,9 @@ vi.mock('$lib/transport/ws-client', () => ({
   getControlSession: () => ({ state: 'connected', epoch: 7 }),
   onCommandDelivery: () => () => undefined,
   onControlSessionTransition: () => () => undefined,
-  sendCommand: (name: string, params: Record<string, unknown>, id: string, options: { optimistic: boolean }) => {
+  sendCommand: (name: string, params: Record<string, unknown>, id: string, ...extraArgs: unknown[]) => {
     if (h.throwOnCall === h.calls.length + 1) throw new Error('injected dispatcher failure');
-    h.calls.push({ name, params, id, options });
+    h.calls.push({ name, params, id, extraArgs });
     return true;
   },
 }));
@@ -73,7 +73,7 @@ describe('MOR-1409 A05a memory command authority', () => {
       { name: 'memory_clear', params: { channel: 99 } },
     ]);
     expect(new Set(h.calls.map((call) => call.id)).size).toBe(h.calls.length);
-    expect(h.calls.every((call) => call.options.optimistic === false)).toBe(true);
+    expect(h.calls.every((call) => call.extraArgs.length === 0)).toBe(true);
   });
 
   it('accepts real relative and unslotted topology identities without inventing A or B', () => {

--- a/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.test.ts
@@ -17,7 +17,6 @@ const h = vi.hoisted(() => ({
     _name: string,
     _params: Record<string, unknown>,
     _id?: string,
-    _options?: { optimistic: boolean },
   ) => true),
   patchActiveReceiver: vi.fn(),
   patchRadioState: vi.fn(),
@@ -211,7 +210,7 @@ function exactCalls(): Array<[string, Record<string, unknown>]> {
 function expectIntentTransport(): void {
   for (const call of h.sendCommand.mock.calls) {
     expect(call[2]).toEqual(expect.any(String));
-    expect(call[3]).toEqual({ optimistic: false });
+    expect(call).toHaveLength(3);
   }
   expect(getCommandLifecycles()).toHaveLength(h.sendCommand.mock.calls.length);
 }

--- a/frontend/src/lib/runtime/commands/__tests__/radio-intents.isolated.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/radio-intents.isolated.test.ts
@@ -8,7 +8,7 @@ const harness = vi.hoisted(() => ({
   delivery: undefined as ((event: CommandDeliveryEvent) => void) | undefined,
   transition: undefined as ((event: ControlSessionTransition) => void) | undefined,
   session: { state: 'connected' as const, epoch: 7 },
-  sendCommand: vi.fn(() => true),
+  sendCommand: vi.fn((..._args: unknown[]) => true),
 }));
 
 vi.mock('$lib/transport/ws-client', () => ({
@@ -48,7 +48,7 @@ describe('typed non-PTT radio intents', () => {
     vi.useRealTimers();
   });
 
-  it('sends one exact envelope and explicitly bypasses legacy optimistic mutation', () => {
+  it('sends one exact three-argument envelope with no optimistic side channel', () => {
     const record = intents.dispatchRadioIntent({
       id: 'freq-1',
       name: 'set_freq',
@@ -60,8 +60,8 @@ describe('typed non-PTT radio intents', () => {
       'set_freq',
       { freq: 14_074_000, receiver: 0 },
       'freq-1',
-      { optimistic: false },
     );
+    expect(harness.sendCommand.mock.calls[0]).toHaveLength(3);
     expect(record).toMatchObject({ id: 'freq-1', originalEpoch: 7, status: 'pending' });
     expect(lifecycle.getCommandLifecycle('freq-1', 7)?.status).toBe('pending');
   });
@@ -194,7 +194,7 @@ describe('typed non-PTT radio intents', () => {
     }));
 
     levels.forEach((level, index) => expect(harness.sendCommand).toHaveBeenNthCalledWith(
-      index + 1, 'set_af_level', { level, receiver: 0 }, `af-normalized-${index}`, { optimistic: false },
+      index + 1, 'set_af_level', { level, receiver: 0 }, `af-normalized-${index}`,
     ));
     expect(lifecycle.getCommandLifecycles()).toHaveLength(levels.length);
     expect(lifecycle.getCommandLifecycles()).toEqual(expect.arrayContaining(levels.map((_, index) =>
@@ -210,7 +210,7 @@ describe('typed non-PTT radio intents', () => {
     });
 
     expect(harness.sendCommand).toHaveBeenCalledExactlyOnceWith(
-      'set_rf_power', { level: 0.42 }, 'rf-fraction', { optimistic: false },
+      'set_rf_power', { level: 0.42 }, 'rf-fraction',
     );
     expect(() => intents.dispatchRadioIntent({
       name: 'set_mic_gain', params: { level: 0.42 },
@@ -243,6 +243,7 @@ describe('typed non-PTT radio intents', () => {
 
     representatives.forEach((intent) => intents.dispatchRadioIntent(intent));
     expect(harness.sendCommand).toHaveBeenCalledTimes(representatives.length);
+    expect(harness.sendCommand.mock.calls.every((call) => call.length === 3)).toBe(true);
     expect(lifecycle.getCommandLifecycles()).toHaveLength(representatives.length);
   });
 

--- a/frontend/src/lib/runtime/commands/radio-intents.ts
+++ b/frontend/src/lib/runtime/commands/radio-intents.ts
@@ -120,6 +120,6 @@ export function dispatchRadioIntent(intent: RadioIntent): CommandLifecycle {
   const id = (candidate.id as string | undefined) ?? makeCommandId();
   const originalEpoch = getControlSession().epoch;
   const lifecycle = beginCommand({ id, name, params: params as Record<string, unknown>, originalEpoch });
-  sendCommand(name, params as Record<string, unknown>, id, { optimistic: false });
+  sendCommand(name, params as Record<string, unknown>, id);
   return lifecycle;
 }

--- a/frontend/src/lib/transport/__tests__/ws-client.isolated.test.ts
+++ b/frontend/src/lib/transport/__tests__/ws-client.isolated.test.ts
@@ -203,6 +203,76 @@ function sendStateUpdate(socket: MockWebSocket, data: Record<string, unknown>): 
   socket.simulateMessage(JSON.stringify({ type: 'state_update', data }));
 }
 
+function makeScopeControls(): NonNullable<ServerStateWithObservation['scopeControls']> {
+  return {
+    receiver: 0,
+    dual: false,
+    mode: 0,
+    span: 10_000,
+    edge: 1,
+    hold: false,
+    refDb: 0,
+    speed: 2,
+    duringTx: false,
+    centerType: 0,
+    vbwNarrow: false,
+    rbw: 0,
+    fixedEdge: { rangeIndex: 0, edge: 1, startHz: 14_000_000, endHz: 14_250_000 },
+  };
+}
+
+// Every command name (including aliases) that the retired legacy
+// auto-optimistic switch used to map to a Store patch. sendCommand must treat
+// each as pure transport: exactly one WS envelope, zero Store writes.
+const LEGACY_OPTIMISTIC_FAMILY: ReadonlyArray<readonly [string, Record<string, unknown>]> = [
+  ['set_freq', { freq: 7_074_000 }],
+  ['set_mode', { mode: 'CW' }],
+  ['set_data_mode', { mode: 1 }],
+  ['set_filter', { filter: 'FIL2' }],
+  ['set_nb', { on: true }],
+  ['set_nr', { on: true }],
+  ['set_nb_level', { level: 5 }],
+  ['set_nr_level', { level: 5 }],
+  ['set_af_level', { level: 42 }],
+  ['set_rf_gain', { level: 42 }],
+  ['set_squelch', { level: 3 }],
+  ['set_att', { level: 12 }],
+  ['set_attenuator', { db: 12 }],
+  ['set_preamp', { level: 1 }],
+  ['set_filter_width', { width: 2_400 }],
+  ['set_digisel', { on: true }],
+  ['set_ip_plus', { on: true }],
+  ['set_ipplus', { on: true }],
+  ['set_dual_watch', { on: true }],
+  ['set_split', { on: true }],
+  ['set_rit_status', { on: true }],
+  ['set_rit_tx_status', { on: true }],
+  ['set_rit_frequency', { freq: 120 }],
+  ['set_tuner_status', { value: 1 }],
+  ['set_mic_gain', { level: 30 }],
+  ['set_cw_pitch', { value: 600 }],
+  ['set_key_speed', { speed: 22 }],
+  ['set_break_in', { mode: 1 }],
+  ['set_vox', { on: true }],
+  ['set_compressor', { on: true }],
+  ['set_comp', { on: true }],
+  ['set_compressor_level', { level: 4 }],
+  ['set_monitor', { on: true }],
+  ['set_monitor_gain', { level: 15 }],
+  ['set_vfo', { vfo: 'B' }],
+  ['set_vfo', { vfo: 'SUB' }],
+  ['set_vfo', { vfo: 'VFOB' }],
+  ['select_vfo', { vfo: 'A' }],
+  ['set_scope_mode', { mode: 1 }],
+  ['set_scope_span', { span: 25_000 }],
+  ['set_scope_hold', { on: true }],
+  ['set_scope_ref', { ref: -10 }],
+  ['set_antenna_1', { on: true }],
+  ['set_antenna_2', { on: true }],
+  ['set_rx_antenna_ant1', { on: true }],
+  ['set_rx_antenna_ant2', { on: true }],
+];
+
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
 describe('WsChannel', () => {
@@ -669,27 +739,138 @@ describe('control channel singleton', () => {
     ]);
   });
 
-  it('applies optimistic data mode updates before sending', async () => {
-    const { sendCommand } = await import('../ws-client');
+  it('keeps the seeded snapshot byte-identical for representative three-argument dispatches', async () => {
+    const { connect, sendCommand } = await import('../ws-client');
+    connect('ws://test/api/v1/ws');
+    instances[0].simulateOpen();
+    sendStateUpdate(instances[0], fullEnvelope(makeState({
+      revision: 1,
+      main: makeReceiver({ freqHz: 14_074_000 }),
+      scopeControls: makeScopeControls(),
+    })));
+    const before = JSON.stringify(radioStoreMock.current);
+    vi.mocked(patchActiveReceiver).mockClear();
+    vi.mocked(patchRadioState).mockClear();
+    const sentBefore = instances[0].sent.length;
 
-    sendCommand('set_data_mode', { mode: 2, receiver: 0 });
+    const representatives: ReadonlyArray<readonly [string, Record<string, unknown>]> = [
+      ['set_freq', { freq: 7_074_000 }],
+      ['set_split', { on: true }],
+      ['set_af_level', { level: 42 }],
+      ['set_vfo', { vfo: 'SUB' }],
+      ['set_scope_span', { span: 25_000 }],
+    ];
+    representatives.forEach(([name, params], index) => {
+      expect(sendCommand(name, params, `representative-${index}`)).toBe(true);
+    });
 
-    expect(patchActiveReceiver).toHaveBeenCalledWith({ dataMode: 2 });
+    expect(patchActiveReceiver).not.toHaveBeenCalled();
+    expect(patchRadioState).not.toHaveBeenCalled();
+    expect(JSON.stringify(radioStoreMock.current)).toBe(before);
+    expect(instances[0].sent.slice(sentBefore).map((frame) => JSON.parse(frame))).toEqual(
+      representatives.map(([name, params], index) => ({
+        type: 'cmd', name, id: `representative-${index}`, params,
+      })),
+    );
   });
 
-  it('can bypass legacy optimism so only a contradictory Observation changes radio truth', async () => {
+  it('never writes the Store for any command in the legacy optimistic family', async () => {
+    const { connect, sendCommand } = await import('../ws-client');
+    connect('ws://test/api/v1/ws');
+    instances[0].simulateOpen();
+    sendStateUpdate(instances[0], fullEnvelope(makeState({
+      revision: 1,
+      main: makeReceiver({ freqHz: 14_074_000, activeSlot: 'A' }),
+      scopeControls: makeScopeControls(),
+    })));
+    const before = JSON.stringify(radioStoreMock.current);
+    vi.mocked(patchActiveReceiver).mockClear();
+    vi.mocked(patchRadioState).mockClear();
+    const sentBefore = instances[0].sent.length;
+
+    LEGACY_OPTIMISTIC_FAMILY.forEach(([name, params], index) => {
+      expect(sendCommand(name, params, `family-${index}`)).toBe(true);
+    });
+
+    expect(patchActiveReceiver).not.toHaveBeenCalled();
+    expect(patchRadioState).not.toHaveBeenCalled();
+    expect(JSON.stringify(radioStoreMock.current)).toBe(before);
+    expect(instances[0].sent.slice(sentBefore).map((frame) => JSON.parse(frame))).toEqual(
+      LEGACY_OPTIMISTIC_FAMILY.map(([name, params], index) => ({
+        type: 'cmd', name, id: `family-${index}`, params,
+      })),
+    );
+  });
+
+  it('ignores a legacy fourth optimistic argument in either direction', async () => {
+    const { connect, sendCommand } = await import('../ws-client');
+    connect('ws://test/api/v1/ws');
+    instances[0].simulateOpen();
+    sendStateUpdate(instances[0], fullEnvelope(makeState({
+      revision: 1,
+      main: makeReceiver({ freqHz: 14_074_000 }),
+    })));
+    const before = JSON.stringify(radioStoreMock.current);
+    vi.mocked(patchActiveReceiver).mockClear();
+    vi.mocked(patchRadioState).mockClear();
+
+    const legacySend = sendCommand as unknown as (
+      name: string,
+      params: Record<string, unknown>,
+      id?: string,
+      options?: { optimistic?: boolean },
+    ) => boolean;
+    expect(legacySend('set_freq', { freq: 7_074_000 }, 'legacy-opt-in', { optimistic: true })).toBe(true);
+    expect(legacySend('set_split', { on: true }, 'legacy-opt-out', { optimistic: false })).toBe(true);
+
+    expect(patchActiveReceiver).not.toHaveBeenCalled();
+    expect(patchRadioState).not.toHaveBeenCalled();
+    expect(JSON.stringify(radioStoreMock.current)).toBe(before);
+  });
+
+  it('rejects degraded-health non-PTT dispatch with a truthful delivery error', async () => {
+    vi.mocked(isLiveRadioAvailable).mockReturnValue(false);
+    const { onCommandDelivery, sendCommand } = await import('../ws-client');
+    const events: CommandDeliveryEvent[] = [];
+    const unsubscribe = onCommandDelivery((event) => events.push(event));
+
+    expect(sendCommand('set_freq', { freq: 14_074_000 }, 'degraded-freq')).toBe(false);
+
+    expect(events).toEqual([{
+      commandId: 'degraded-freq',
+      kind: 'error',
+      originalEpoch: 0,
+      eventEpoch: 0,
+      error: 'radio health is degraded',
+    }]);
+    unsubscribe();
+  });
+
+  it('propagates the transport queue verdict for offline non-idempotent dispatch', async () => {
+    const { onCommandDelivery, sendCommand } = await import('../ws-client');
+    const events: CommandDeliveryEvent[] = [];
+    const unsubscribe = onCommandDelivery((event) => events.push(event));
+
+    expect(sendCommand('vfo_swap', {}, 'offline-swap')).toBe(false);
+
+    expect(events).toEqual([{
+      commandId: 'offline-swap',
+      kind: 'error',
+      originalEpoch: 0,
+      eventEpoch: 0,
+      error: 'offline non-idempotent command rejected',
+    }]);
+    unsubscribe();
+  });
+
+  it('never mutates radio truth on dispatch; only a contradictory Observation changes it', async () => {
     const { connect, sendCommand } = await import('../ws-client');
     connect('ws://test/api/v1/ws');
     instances[0].simulateOpen();
     sendStateUpdate(instances[0], fullEnvelope(makeState({ revision: 1, main: makeReceiver({ freqHz: 14_074_000 }) })));
     vi.mocked(patchActiveReceiver).mockClear();
 
-    expect(sendCommand(
-      'set_freq',
-      { freq: 7_074_000, receiver: 0 },
-      'freq-contradiction',
-      { optimistic: false },
-    )).toBe(true);
+    expect(sendCommand('set_freq', { freq: 7_074_000, receiver: 0 }, 'freq-contradiction')).toBe(true);
     expect(patchActiveReceiver).not.toHaveBeenCalled();
     expect(radioStoreMock.current?.main.freqHz).toBe(14_074_000);
 
@@ -706,7 +887,7 @@ describe('control channel singleton', () => {
     connect('ws://test/api/v1/ws');
     instances[0].simulateOpen();
     sendStateUpdate(instances[0], fullEnvelope(makeState({ providerGeneration: 0 })));
-    sendCommand('set_freq', { freq: 14_074_000 }, 'provider-pending', { optimistic: false });
+    sendCommand('set_freq', { freq: 14_074_000 }, 'provider-pending');
     sendStateUpdate(instances[0], fullEnvelope(makeState({ providerGeneration: 1 })));
 
     expect(events).toMatchObject([
@@ -737,34 +918,30 @@ describe('control channel singleton', () => {
     disconnect();
   });
 
-  it('treats bare VFO B as a slot without switching MAIN to SUB', async () => {
-    radioStoreMock.current = makeState({
+  it('treats set_vfo as pure transport without fabricating receiver or slot truth', async () => {
+    const { connect, sendCommand } = await import('../ws-client');
+    connect('ws://test/api/v1/ws');
+    instances[0].simulateOpen();
+    sendStateUpdate(instances[0], fullEnvelope(makeState({
+      revision: 1,
       active: 'MAIN',
       main: makeReceiver({ activeSlot: 'A' }),
-    });
-    const { sendCommand } = await import('../ws-client');
+    })));
+    vi.mocked(patchActiveReceiver).mockClear();
+    vi.mocked(patchRadioState).mockClear();
+    const sentBefore = instances[0].sent.length;
 
-    sendCommand('set_vfo', { vfo: 'B' });
+    expect(sendCommand('set_vfo', { vfo: 'B' }, 'vfo-slot')).toBe(true);
+    expect(sendCommand('set_vfo', { vfo: 'SUB' }, 'vfo-receiver')).toBe(true);
 
-    expect(patchActiveReceiver).toHaveBeenCalledWith({ activeSlot: 'B' });
+    expect(patchActiveReceiver).not.toHaveBeenCalled();
     expect(patchRadioState).not.toHaveBeenCalled();
     expect(radioStoreMock.current?.active).toBe('MAIN');
-    expect(radioStoreMock.current?.main.activeSlot).toBe('B');
-  });
-
-  it('treats explicit SUB as a receiver selection', async () => {
-    radioStoreMock.current = makeState({
-      active: 'MAIN',
-      main: makeReceiver({ activeSlot: 'A' }),
-    });
-    const { sendCommand } = await import('../ws-client');
-
-    sendCommand('set_vfo', { vfo: 'SUB' });
-
-    expect(patchRadioState).toHaveBeenCalledWith({ active: 'SUB' });
-    expect(patchActiveReceiver).not.toHaveBeenCalled();
-    expect(radioStoreMock.current?.active).toBe('SUB');
     expect(radioStoreMock.current?.main.activeSlot).toBe('A');
+    expect(instances[0].sent.slice(sentBefore).map((frame) => JSON.parse(frame))).toEqual([
+      { type: 'cmd', name: 'set_vfo', id: 'vfo-slot', params: { vfo: 'B' } },
+      { type: 'cmd', name: 'set_vfo', id: 'vfo-receiver', params: { vfo: 'SUB' } },
+    ]);
   });
 
   it('sendCommand returns false and queues when not connected', async () => {

--- a/frontend/src/lib/transport/ws-client.ts
+++ b/frontend/src/lib/transport/ws-client.ts
@@ -1,7 +1,7 @@
 import type { WsCommand, WsIncoming } from '../types/protocol';
 import { makeCommandId } from '../types/protocol';
 import { isLiveRadioAvailable, setWsConnected, setHttpConnected, markStateUpdated, setReconnecting, setRadioStatus } from '../stores/connection.svelte';
-import { getRadioState, isValidServerState, matchesCurrentCapabilityTopology, patchActiveReceiver, patchRadioState, resetRadioState, setRadioState } from '../stores/radio.svelte';
+import { isValidServerState, matchesCurrentCapabilityTopology, resetRadioState, setRadioState } from '../stores/radio.svelte';
 import { capabilitiesMatchGeneration, clearCapabilities, setCapabilities } from '../stores/capabilities.svelte';
 import { fetchCapabilities } from './http-client';
 
@@ -768,7 +768,6 @@ export function sendCommand(
   name: string,
   params: Record<string, unknown> = {},
   id?: string,
-  options: { optimistic?: boolean } = {},
 ): boolean {
   const commandId = id ?? makeCommandId();
   if (!isLiveRadioAvailable() && pttIntent(name, params) !== 'off') {
@@ -778,193 +777,12 @@ export function sendCommand(
     }
     return false;
   }
-  // Auto-optimistic: apply UI patch immediately before sending
-  if (options.optimistic !== false) {
-    try { _applyOptimistic(name, params); } catch (e) { console.warn('[optimistic]', e); }
-  }
   return _ctrl.send({
     type: 'cmd',
     name,
     id: commandId,
     params,
   });
-}
-
-/** Auto-optimistic update mapping: command → state patch */
-function _applyOptimistic(name: string, params: Record<string, unknown>): void {
-  switch (name) {
-    case 'set_freq':
-      if (typeof params.freq === 'number') patchActiveReceiver({ freqHz: params.freq });
-      break;
-    case 'set_mode':
-      if (typeof params.mode === 'string') patchActiveReceiver({ mode: params.mode });
-      break;
-    case 'set_data_mode':
-      if (typeof params.mode === 'number') patchActiveReceiver({ dataMode: params.mode });
-      break;
-    case 'set_filter':
-      if (typeof params.filter === 'string') {
-        const n = parseInt((params.filter as string).replace('FIL', ''), 10);
-        if (n >= 1 && n <= 3) patchActiveReceiver({ filter: n });
-      }
-      break;
-    case 'set_nb':
-      if (typeof params.on === 'boolean') {
-        const patch: Record<string, unknown> = { nb: params.on };
-        if (!params.on) patch.nbLevel = 0;
-        patchActiveReceiver(patch);
-      }
-      break;
-    case 'set_nr':
-      if (typeof params.on === 'boolean') {
-        const patch: Record<string, unknown> = { nr: params.on };
-        if (!params.on) patch.nrLevel = 0;
-        patchActiveReceiver(patch);
-      }
-      break;
-    case 'set_nb_level':
-      if (typeof params.level === 'number') {
-        patchActiveReceiver({ nbLevel: params.level, nb: params.level > 0 });
-      }
-      break;
-    case 'set_nr_level':
-      if (typeof params.level === 'number') {
-        patchActiveReceiver({ nrLevel: params.level, nr: params.level > 0 });
-      }
-      break;
-    case 'set_af_level':
-      if (typeof params.level === 'number') patchActiveReceiver({ afLevel: params.level });
-      break;
-    case 'set_rf_gain':
-      if (typeof params.level === 'number') patchActiveReceiver({ rfGain: params.level });
-      break;
-    case 'set_squelch':
-      if (typeof params.level === 'number') patchActiveReceiver({ squelch: params.level });
-      break;
-    case 'set_att':
-      if (typeof params.level === 'number') patchActiveReceiver({ att: params.level });
-      break;
-    case 'set_attenuator':
-      if (typeof params.db === 'number') patchActiveReceiver({ att: params.db });
-      else if (typeof params.level === 'number') patchActiveReceiver({ att: params.level });
-      break;
-    case 'set_preamp':
-      if (typeof params.level === 'number') patchActiveReceiver({ preamp: params.level });
-      break;
-    case 'set_filter_width':
-      if (typeof params.width === 'number') patchActiveReceiver({ filterWidth: params.width });
-      break;
-    case 'set_digisel':
-      if (typeof params.on === 'boolean') patchActiveReceiver({ digisel: params.on });
-      break;
-    case 'set_ip_plus':
-    case 'set_ipplus':  // backward-compat alias
-      if (typeof params.on === 'boolean') patchActiveReceiver({ ipplus: params.on });
-      break;
-    case 'set_dual_watch':
-      if (typeof params.on === 'boolean') patchRadioState({ dualWatch: params.on });
-      break;
-    case 'set_split':
-      if (typeof params.on === 'boolean') patchRadioState({ split: params.on });
-      break;
-    case 'set_rit_status':
-      if (typeof params.on === 'boolean') patchRadioState({ ritOn: params.on });
-      break;
-    case 'set_rit_tx_status':
-      if (typeof params.on === 'boolean') patchRadioState({ ritTx: params.on });
-      break;
-    case 'set_rit_frequency':
-      if (typeof params.freq === 'number') patchRadioState({ ritFreq: params.freq });
-      break;
-    case 'set_tuner_status':
-      if (typeof params.value === 'number') patchRadioState({ tunerStatus: params.value });
-      break;
-    case 'set_mic_gain':
-      if (typeof params.level === 'number') patchRadioState({ micGain: params.level });
-      break;
-    case 'set_cw_pitch':
-      if (typeof params.value === 'number') patchRadioState({ cwPitch: params.value });
-      break;
-    case 'set_key_speed':
-      if (typeof params.speed === 'number') patchRadioState({ keySpeed: params.speed });
-      break;
-    case 'set_break_in':
-      if (typeof params.mode === 'number') patchRadioState({ breakIn: params.mode });
-      break;
-    case 'set_vox':
-      if (typeof params.on === 'boolean') patchRadioState({ voxOn: params.on });
-      break;
-    case 'set_compressor':
-    case 'set_comp':
-      if (typeof params.on === 'boolean') patchRadioState({ compressorOn: params.on });
-      break;
-    case 'set_compressor_level':
-      if (typeof params.level === 'number') patchRadioState({ compressorLevel: params.level });
-      break;
-    case 'set_monitor':
-      if (typeof params.on === 'boolean') patchRadioState({ monitorOn: params.on });
-      break;
-    case 'set_monitor_gain':
-      if (typeof params.level === 'number') patchRadioState({ monitorGain: params.level });
-      break;
-    case 'set_vfo':
-    case 'select_vfo':  // backward-compat alias
-      if (typeof params.vfo === 'string') {
-        const vfo = params.vfo.toUpperCase();
-        if (vfo === 'A' || vfo === 'B') {
-          patchActiveReceiver({ activeSlot: vfo });
-        } else if (vfo === 'MAIN' || vfo === 'SUB') {
-          patchRadioState({ active: vfo });
-        } else if (vfo === 'VFOA' || vfo === 'VFOB') {
-          // Legacy dual-receiver aliases retain their historical meaning.
-          patchRadioState({ active: vfo === 'VFOB' ? 'SUB' : 'MAIN' });
-        }
-      }
-      break;
-
-    case 'set_scope_mode': {
-      const sm = getRadioState();
-      if (sm?.scopeControls && typeof params.mode === 'number') {
-        patchRadioState({ scopeControls: { ...sm.scopeControls, mode: params.mode } });
-      }
-      break;
-    }
-    case 'set_scope_span': {
-      const ss = getRadioState();
-      if (ss?.scopeControls && typeof params.span === 'number') {
-        patchRadioState({ scopeControls: { ...ss.scopeControls, span: params.span } });
-      }
-      break;
-    }
-    case 'set_scope_hold': {
-      const sh = getRadioState();
-      if (sh?.scopeControls && typeof params.on === 'boolean') {
-        patchRadioState({ scopeControls: { ...sh.scopeControls, hold: params.on } });
-      }
-      break;
-    }
-    case 'set_scope_ref': {
-      const sr = getRadioState();
-      if (sr?.scopeControls && typeof params.ref === 'number') {
-        patchRadioState({ scopeControls: { ...sr.scopeControls, refDb: params.ref } });
-      }
-      break;
-    }
-
-    case 'set_antenna_1':
-      // IC-7610: 0x12 0x00 selects ANT1 and the data byte encodes RX-ANT.
-      patchRadioState({ txAntenna: 1, rxAntenna1: !!params.on });
-      break;
-    case 'set_antenna_2':
-      patchRadioState({ txAntenna: 2, rxAntenna2: !!params.on });
-      break;
-    case 'set_rx_antenna_ant1':
-      if (typeof params.on === 'boolean') patchRadioState({ txAntenna: 1, rxAntenna1: params.on });
-      break;
-    case 'set_rx_antenna_ant2':
-      if (typeof params.on === 'boolean') patchRadioState({ txAntenna: 2, rxAntenna2: params.on });
-      break;
-  }
 }
 
 export function onMessage(handler: MessageHandler): () => void {


### PR DESCRIPTION
Part of #2317

## MOR-1409 gate A09a (ws-client de-optimism, transport leg)

First leg of the published A09 reslice ([correction 5242285764](https://github.com/rigplane/rigplane-core/issues/2317#issuecomment-5242285764)); plan `/private/tmp/plan-mor1409-a09-reanchor-session15.md` (SHA-256 `2560b9d5…`). The optimistic path was already production-dead after A08 (every production dispatcher sends `optimistic: false` or a PTT name with no optimistic mapping).

- `frontend/src/lib/transport/ws-client.ts` (+1/−183) — `_applyOptimistic` deleted (177 lines, all 44 patch call sites), auto-optimistic branch and `optimistic` option removed; final signature `sendCommand(name, params = {}, id?)`. Degraded-health gate, PTT delivery path, queue rules untouched.
- `frontend/src/lib/runtime/commands/radio-intents.ts` (+1/−1) — fourth argument dropped. Intent catalog frozen/untouched.

Production churn 186 (model ≈188, far under the 391 STOP). Enforcement plugin/TOML and all 17 frozen seams byte-identical to base. Head `d5edea0ad3650a60031d4a1164eb8d9986ebceea`, base `3b7b31a2c69925f6cc178965db5bc7cf6de54d7e`.

## Evidence (once-through, no retry-to-green)

- Causal RED at pristine base: 49 failed / 114 passed (all substantive patch-write/arity pins)
- Focused GREEN: 250/250 (5 owner suites + architecture-boundaries control)
- Mutation battery: 8/8 killed by intended detectors, byte-exact restores hash-verified
- Full frontend suite: first pass hit the known pre-existing isolate:false panel-props leak (13 failures, first-failure log preserved); symmetric attribution: pristine exact-base green 6469/6469, cache-free candidate green 6472/6472 — leak is order-dependent and pre-existing (`panel-commands.intent.test.ts` field-status stub), not candidate-caused
- svelte-check, eslint, lint:boundaries: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)