### PR TITLE
refactor(#2317): make batch-B adapters honest projections with consumer guards (A12)

### DIFF
--- a/frontend/src/components-v2/panels/CwPanel.svelte
+++ b/frontend/src/components-v2/panels/CwPanel.svelte
@@ -33,6 +33,25 @@
   let breakInActive = $derived(isBreakInActive(breakIn));
   let apfActive = $derived(isApfActive(apfMode));
   let breakInLabel = $derived(formatBreakIn(breakIn));
+
+  // MOR-1409 A12 (coordinator adjudication, Core #2317, comment 5246487510):
+  // `cwPitch`/`keySpeed` are `?? 600`/`?? 12` guarded above, but `??` does
+  // not catch `NaN` (only `null`/`undefined`) — a connected receiver that
+  // has never reported these optional fields still passes through as
+  // `NaN`, and neither `ValueControl` call below has a `displayFn`, so the
+  // default `${value}${unit}` renders the literal "NaN Hz"/"NaN WPM".
+  // Guard locally, same shape as FilterPanel.svelte's `formatWidthDisplay`.
+  // Preserves the exact prior finite-value format (the renderers' own
+  // unguarded default is `${localValue}${unit ? ' ' + unit : ''}`,
+  // a non-breaking space before the unit) — the guard only changes
+  // behavior for the non-finite case, per the grant's "no behavior/logic
+  // changes beyond the guards" restriction.
+  function formatCwPitchDisplay(hz: number): string {
+    return Number.isFinite(hz) ? `${hz} Hz` : '--- Hz';
+  }
+  function formatKeySpeedDisplay(wpm: number): string {
+    return Number.isFinite(wpm) ? `${wpm} WPM` : '--- WPM';
+  }
 </script>
 
 {#if showCw}
@@ -53,6 +72,7 @@
       accentColor="var(--v2-accent-cyan)"
       onChange={onCwPitchChange}
       variant="hardware-illuminated"
+      displayFn={formatCwPitchDisplay}
     />
 
     <ValueControl
@@ -67,6 +87,7 @@
       accentColor="var(--v2-accent-orange)"
       onChange={onKeySpeedChange}
       variant="hardware-illuminated"
+      displayFn={formatKeySpeedDisplay}
     />
 
     <div class="toggle-row">

--- a/frontend/src/components-v2/panels/FilterPanel.svelte
+++ b/frontend/src/components-v2/panels/FilterPanel.svelte
@@ -35,7 +35,12 @@
   let modalOpen = $state(false);
   let draftWidths = $state<number[]>([]);
 
-  let normalizedLabels = $derived(filterLabels.length > 0 ? filterLabels : ['FIL1', 'FIL2', 'FIL3']);
+  // MOR-1409 A12 (adjudication 5245697359, Core #2317): no re-fabricated
+  // FIL1/FIL2/FIL3 stand-in when `filterLabels` is the honest empty array
+  // (unknown filter catalog). Pass it through unchanged — the modal's
+  // `{#each normalizedLabels as label, index}` then renders zero rows,
+  // which is the correct "unavailable, not fabricated" behavior.
+  let normalizedLabels = $derived(filterLabels);
   let factoryDefaults = $derived.by(() => {
     const fallback = Array.from({ length: normalizedLabels.length }, () => filterWidth);
     const defaults = filterConfig?.defaults?.slice(0, normalizedLabels.length) ?? fallback;
@@ -100,6 +105,14 @@
   });
 
   function formatWidthDisplay(hz: number): string {
+    // MOR-1409 A12 (adjudication 5245697359, Core #2317): `panel-props.ts`'s
+    // `toFilterProps`/`toAudioSpectrumProps` now return NaN for an
+    // unobserved filterWidth instead of fabricating 2400 Hz. Guard at this
+    // choke point — the same `'---'`-family placeholder convention
+    // `frequency-format.ts` established at A11 (corr. 5245817033/5245876185)
+    // — rather than let `formatFilterWidth(NaN)` leak the literal "NaNkHz"
+    // into the BW readout and settings modal.
+    if (!Number.isFinite(hz)) return '--- Hz';
     const formatted = formatFilterWidth(hz);
     return formatted.includes('k') ? `${formatted}Hz` : `${formatted} Hz`;
   }
@@ -323,6 +336,7 @@
               accentColor={currentFilter === index + 1 ? 'var(--v2-accent-cyan)' : 'var(--v2-accent-green-bright)'}
               onChange={(value) => handlePresetChange(index, value)}
               variant="hardware-illuminated"
+              displayFn={formatWidthDisplay}
             />
           {/if}
         </div>

--- a/frontend/src/components-v2/panels/RitXitPanel.svelte
+++ b/frontend/src/components-v2/panels/RitXitPanel.svelte
@@ -27,6 +27,18 @@
   const xitShortcut = getShortcutHint('toggle_xit');
   const clearShortcut = getShortcutHint('clear_rit_xit');
 
+  // MOR-1409 A12 (coordinator adjudication, Core #2317, comment 5246487510):
+  // `hasRit`/`hasXit` gate on capability presence only — a connected
+  // receiver that has never reported `ritFreq` (optional field) still
+  // passes the gate with a `NaN` offset (panel-props.ts no longer
+  // fabricates `?? 0`). `formatOffsetKHz` (rit-utils.ts, not an A12 owner)
+  // has no NaN guard: `hz > 0` is false for NaN, so it falls to the
+  // negative branch and renders the literal "−NaN kHz". Guard locally,
+  // same shape as FilterPanel.svelte's `formatWidthDisplay`.
+  function formatOffsetDisplay(hz: number): string {
+    return Number.isFinite(hz) ? formatOffsetKHz(hz) : '--- kHz';
+  }
+
   function handleOffsetChange(value: number) {
     if (xitActive && !ritActive) {
       onXitOffsetChange(value);
@@ -41,13 +53,13 @@
       {#if hasRit}
         <div class="row">
           <HardwareButton indicator="dot" active={ritActive} color="cyan" onclick={onRitToggle} shortcutHint={ritShortcut} title={ritShortcut}>RIT</HardwareButton>
-          <span class="offset" class:active={ritActive}>{formatOffsetKHz(ritOffset)}</span>
+          <span class="offset" class:active={ritActive}>{formatOffsetDisplay(ritOffset)}</span>
         </div>
       {/if}
       {#if hasXit}
         <div class="row">
           <HardwareButton indicator="dot" active={xitActive} color="orange" onclick={onXitToggle} shortcutHint={xitShortcut} title={xitShortcut}>XIT</HardwareButton>
-          <span class="offset" class:active={xitActive}>{formatOffsetKHz(xitOffset)}</span>
+          <span class="offset" class:active={xitActive}>{formatOffsetDisplay(xitOffset)}</span>
         </div>
       {/if}
       <ValueControl
@@ -57,7 +69,7 @@
         max={9999}
         step={50}
         unit="kHz"
-        displayFn={formatOffsetKHz}
+        displayFn={formatOffsetDisplay}
         renderer="bipolar"
         accentColor="var(--v2-accent-cyan)"
         onChange={handleOffsetChange}

--- a/frontend/src/components-v2/panels/RxAudioPanel.svelte
+++ b/frontend/src/components-v2/panels/RxAudioPanel.svelte
@@ -18,6 +18,19 @@
   let showDisconnected = $derived(
     props.hasLiveAudio && props.monitorMode === 'live' && !props.isAudioConnected,
   );
+
+  // MOR-1409 A12 (coordinator adjudication, Core #2317, comment 5246487510):
+  // `hasAfLevel`/`hasLiveAudio` gate on capability presence only — a
+  // connected receiver that has never reported `afLevel` (optional field,
+  // local-monitor path) still passes the gate with `props.afLevel === NaN`
+  // (panel-props.ts no longer fabricates `?? 0.5`). `normalizedPercentDisplay`
+  // (value-control-core.ts, not an A12 owner) has no NaN guard —
+  // `Math.round(Math.max(0, Math.min(1, NaN)) * 100)` is `NaN`, rendering
+  // the literal "NaN%". Guard locally, same shape as FilterPanel.svelte's
+  // `formatWidthDisplay`.
+  function formatAfLevelDisplay(v: number): string {
+    return Number.isFinite(v) ? normalizedPercentDisplay(v) : '--- %';
+  }
 </script>
 
 {#if props.hasAfLevel || props.hasLiveAudio}
@@ -42,7 +55,7 @@
         max={1}
         step={0.01}
         renderer="hbar"
-        displayFn={normalizedPercentDisplay}
+        displayFn={formatAfLevelDisplay}
         accentColor="var(--v2-accent-cyan-alt)"
         shortcutHint={afShortcut}
         title={afShortcut}

--- a/frontend/src/components-v2/panels/__tests__/CwPanel.component.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/CwPanel.component.test.ts
@@ -164,3 +164,52 @@ describe('CwPanel APF/TPF mode gating (MOR-492)', () => {
     expect(mockHandlers.onTwinPeakToggle).not.toHaveBeenCalled();
   });
 });
+
+function vcValueFor(t: HTMLElement, label: string): string {
+  const headers = Array.from(t.querySelectorAll('.vc-header'));
+  const header = headers.find(
+    (h) => h.querySelector('.vc-label')?.textContent === label,
+  );
+  if (!header) throw new Error(`ValueControl labeled "${label}" not found`);
+  return header.querySelector('.vc-value')?.textContent ?? '';
+}
+
+/**
+ * A12 (MOR-1409, Core #2317, coordinator adjudication comment 5246487510)
+ * — a connected receiver that has never reported `cwPitch`/`keySpeed`
+ * (optional fields) passes the `hasCw` capability gate with `NaN` values
+ * (panel-props.ts no longer fabricates `?? 600`/`?? 12`; `p.cwPitch ?? 600`
+ * in this component's own script does not catch `NaN` either — only
+ * `null`/`undefined`). Unguarded, the default `ValueControl` display
+ * renders the literal "NaN Hz"/"NaN WPM" (verifier-executed probe on the
+ * unguarded candidate). The local `formatCwPitchDisplay`/
+ * `formatKeySpeedDisplay` guards must render the established
+ * '---'-family placeholder instead.
+ */
+describe('CwPanel — no "NaN" leak for unobserved pitch/speed (MOR-1409 A12)', () => {
+  it('does not render a "NaN" substring for CW Pitch when cwPitch is non-finite', () => {
+    const t = mountPanel({ cwPitch: Number.NaN });
+    expect(vcValueFor(t, 'CW Pitch')).not.toMatch(/NaN/);
+  });
+
+  it('renders the established "---"-family placeholder for a non-finite CW Pitch', () => {
+    const t = mountPanel({ cwPitch: Number.NaN });
+    expect(vcValueFor(t, 'CW Pitch')).toBe('---\u00a0Hz');
+  });
+
+  it('does not render a "NaN" substring for Key Speed when keySpeed is non-finite', () => {
+    const t = mountPanel({ keySpeed: Number.NaN });
+    expect(vcValueFor(t, 'Key Speed')).not.toMatch(/NaN/);
+  });
+
+  it('renders the established "---"-family placeholder for a non-finite Key Speed', () => {
+    const t = mountPanel({ keySpeed: Number.NaN });
+    expect(vcValueFor(t, 'Key Speed')).toBe('---\u00a0WPM');
+  });
+
+  it('still renders the real formatted values for finite pitch/speed', () => {
+    const t = mountPanel({ cwPitch: 700, keySpeed: 25 });
+    expect(vcValueFor(t, 'CW Pitch')).toBe('700\u00a0Hz');
+    expect(vcValueFor(t, 'Key Speed')).toBe('25\u00a0WPM');
+  });
+});

--- a/frontend/src/components-v2/panels/__tests__/FilterPanel.isolated.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/FilterPanel.isolated.test.ts
@@ -326,3 +326,82 @@ describe('IF Shift semantics', () => {
     expect(deriveIfShift(-150, 50)).toBe(-50);
   });
 });
+
+/**
+ * A12 (MOR-1409, Core #2317) — FilterPanel.svelte consumer-boundary fix.
+ *
+ * `panel-props.ts`'s `toFilterProps`/`toAudioSpectrumProps` now return a
+ * `NaN` sentinel for an unobserved `filterWidth` (no more fabricated 2400 Hz
+ * stand-in, deferred from A11 by adjudication 5245697359). Left unguarded,
+ * `formatWidthDisplay`'s call to `formatFilterWidth(NaN)` renders the
+ * literal substring "NaNkHz" in the BW readout (`:207-208`) and the
+ * fixed-config modal row (`:299`) — exactly the defect the adjudication
+ * named. The fix is a `Number.isFinite` guard inside FilterPanel's own
+ * local `formatWidthDisplay`, matching the `'--'`/`'---'` placeholder
+ * convention `frequency-format.ts` established at A11 (corr. 5245817033/
+ * 5245876185) — never the literal "NaN" substring.
+ *
+ * Separately, `:38`'s `normalizedLabels` re-fabrication
+ * (`filterLabels.length > 0 ? filterLabels : ['FIL1','FIL2','FIL3']`)
+ * substitutes the three-label default back in whenever `filterLabels` is
+ * the honest empty array (unknown capability) — this must pass the empty
+ * array through unchanged so the modal renders zero rows, not three
+ * fabricated ones.
+ */
+describe('FilterPanel — no fabricated defaults at the consumer boundary (MOR-1409 A12)', () => {
+  it('does not render a "NaN" substring in the BW readout for a non-finite filterWidth', () => {
+    const t = mountPanel({ filterWidth: Number.NaN });
+    const bwValue = t.querySelector('.bw-value')?.textContent ?? '';
+    expect(bwValue).not.toMatch(/NaN/);
+  });
+
+  it('renders the established "---"-family placeholder in the BW readout for a non-finite filterWidth', () => {
+    const t = mountPanel({ filterWidth: Number.NaN });
+    const bwValue = t.querySelector('.bw-value')?.textContent ?? '';
+    expect(bwValue).toBe('--- Hz');
+  });
+
+  it('still renders the real formatted width for a finite filterWidth', () => {
+    const t = mountPanel({ filterWidth: 2400 });
+    expect(t.querySelector('.bw-value')?.textContent).toBe('2.4kHz');
+  });
+
+  it('does not render a "NaN" substring in the fixed-config modal row for a non-finite filterWidth', () => {
+    const t = mountPanel({
+      filterWidth: Number.NaN,
+      filterConfig: { defaults: [], fixed: true, minHz: 50, maxHz: 3600, stepHz: 50 },
+    });
+    const gear = t.querySelector('.settings-button') as HTMLButtonElement;
+    gear.click();
+    flushSync();
+    const fixedValues = Array.from(document.querySelectorAll('.modal-fixed-value')).map(
+      (el) => el.textContent,
+    );
+    expect(fixedValues.some((text) => /NaN/.test(text ?? ''))).toBe(false);
+  });
+
+  it('renders zero filter-selector buttons for an empty (unknown) filterLabels catalog, not a fabricated FIL1/FIL2/FIL3', () => {
+    const t = mountPanel({ filterLabels: [] });
+    const buttons = Array.from(t.querySelectorAll('button')).map((button) => button.textContent?.trim());
+    expect(buttons).not.toContain('FIL1');
+    expect(buttons).not.toContain('FIL2');
+    expect(buttons).not.toContain('FIL3');
+  });
+
+  it('renders zero modal filter rows for an empty (unknown) filterLabels catalog', () => {
+    const t = mountPanel({ filterLabels: [] });
+    const gear = t.querySelector('.settings-button') as HTMLButtonElement;
+    gear.click();
+    flushSync();
+    const rows = document.querySelectorAll('.modal-filter-row');
+    expect(rows.length).toBe(0);
+  });
+
+  it('still renders the real filter-selector buttons for a populated filterLabels catalog', () => {
+    const t = mountPanel({ filterLabels: ['FIL1', 'FIL2'] });
+    const buttons = Array.from(t.querySelectorAll('button')).map((button) => button.textContent?.trim());
+    expect(buttons).toContain('FIL1');
+    expect(buttons).toContain('FIL2');
+    expect(buttons).not.toContain('FIL3');
+  });
+});

--- a/frontend/src/components-v2/panels/__tests__/RitXitPanel.isolated.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/RitXitPanel.isolated.test.ts
@@ -235,3 +235,41 @@ describe('RitXitPanel component', () => {
     expect(mockHandlers.onXitOffsetChange).toHaveBeenCalled();
   });
 });
+
+/**
+ * A12 (MOR-1409, Core #2317, coordinator adjudication comment 5246487510)
+ * — a connected receiver that has never reported `ritFreq`/`xitFreq`
+ * (optional fields) passes the `hasRit`/`hasXit` capability gate with a
+ * `NaN` offset (panel-props.ts no longer fabricates `?? 0`). Unguarded,
+ * `formatOffsetKHz(NaN)` renders the literal "−NaN kHz" (verifier-executed
+ * probe on the unguarded candidate). The local `formatOffsetDisplay` guard
+ * must render the established '---'-family placeholder instead.
+ */
+describe('RitXitPanel — no "NaN" leak for an unobserved offset (MOR-1409 A12)', () => {
+  it('does not render a "NaN" substring for the RIT offset readout when ritOffset is non-finite', () => {
+    const target = mountPanel({ ritActive: true, ritOffset: Number.NaN });
+    const offsetText = target.querySelector('.offset')?.textContent ?? '';
+    expect(offsetText).not.toMatch(/NaN/);
+  });
+
+  it('renders the established "---"-family placeholder for a non-finite RIT offset', () => {
+    const target = mountPanel({ ritActive: true, ritOffset: Number.NaN });
+    const offsetText = target.querySelector('.offset')?.textContent ?? '';
+    expect(offsetText).toBe('--- kHz');
+  });
+
+  it('does not render a "NaN" substring for the XIT offset readout when xitOffset is non-finite', () => {
+    const target = mountPanel({ xitActive: true, ritActive: false, xitOffset: Number.NaN });
+    const offsetSpans = target.querySelectorAll('.offset');
+    // XIT's span is the second `.offset` element when both hasRit/hasXit.
+    const xitOffsetText = offsetSpans[offsetSpans.length - 1]?.textContent ?? '';
+    expect(xitOffsetText).not.toMatch(/NaN/);
+    expect(xitOffsetText).toBe('--- kHz');
+  });
+
+  it('still renders the real formatted offset for a finite value', () => {
+    const target = mountPanel({ ritActive: true, ritOffset: 5000 });
+    const offsetText = target.querySelector('.offset')?.textContent ?? '';
+    expect(offsetText).toBe('+5.00 kHz');
+  });
+});

--- a/frontend/src/components-v2/panels/__tests__/RxAudioPanel.isolated.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/RxAudioPanel.isolated.test.ts
@@ -225,3 +225,39 @@ describe('callbacks', () => {
     expect(mockHandlers.onMonitorModeChange).toHaveBeenCalledWith('mute');
   });
 });
+
+function vcValueFor(t: HTMLElement, label: string): string {
+  const headers = Array.from(t.querySelectorAll('.vc-header'));
+  const header = headers.find(
+    (h) => h.querySelector('.vc-label')?.textContent === label,
+  );
+  if (!header) throw new Error(`ValueControl labeled "${label}" not found`);
+  return header.querySelector('.vc-value')?.textContent ?? '';
+}
+
+/**
+ * A12 (MOR-1409, Core #2317, coordinator adjudication comment 5246487510)
+ * — a connected receiver that has never reported `afLevel` (optional
+ * field, local-monitor path) passes the `hasAfLevel`/`hasLiveAudio`
+ * capability gate with `props.afLevel === NaN` (panel-props.ts no longer
+ * fabricates `?? 0.5`). Unguarded, `normalizedPercentDisplay(NaN)` renders
+ * the literal "NaN%" (verifier-executed probe on the unguarded candidate).
+ * The local `formatAfLevelDisplay` guard must render the established
+ * '---'-family placeholder instead.
+ */
+describe('RxAudioPanel — no "NaN" leak for an unobserved AF level (MOR-1409 A12)', () => {
+  it('does not render a "NaN" substring for AF Level when afLevel is non-finite', () => {
+    const t = mountPanel({ afLevel: Number.NaN, hasAfLevel: true, hasLiveAudio: false });
+    expect(vcValueFor(t, 'AF Level')).not.toMatch(/NaN/);
+  });
+
+  it('renders the established "---"-family placeholder for a non-finite AF Level', () => {
+    const t = mountPanel({ afLevel: Number.NaN, hasAfLevel: true, hasLiveAudio: false });
+    expect(vcValueFor(t, 'AF Level')).toBe('--- %');
+  });
+
+  it('still renders the real formatted percentage for a finite AF level', () => {
+    const t = mountPanel({ afLevel: 0.42, hasAfLevel: true, hasLiveAudio: false });
+    expect(vcValueFor(t, 'AF Level')).toBe('42%');
+  });
+});

--- a/frontend/src/components-v2/panels/audio-scope/__tests__/audio-spectrum-renderer.test.ts
+++ b/frontend/src/components-v2/panels/audio-scope/__tests__/audio-spectrum-renderer.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   pbtRawToHz,
   resetSmoothing,
   renderAudioSpectrum,
+  AudioSpectrumRendererState,
   type SpectrumState,
 } from '../audio-spectrum-renderer';
 
@@ -145,5 +146,77 @@ describe('renderAudioSpectrum', () => {
     resetSmoothing();
     const state = { ...baseState, bandwidth: 48000 };
     expect(() => renderAudioSpectrum(mockCtx(), 400, 160, state)).not.toThrow();
+  });
+
+  /**
+   * A12 (MOR-1409, Core #2317, coordinator adjudication comment
+   * 5246487510) — a connected receiver that has never reported
+   * `filterWidth` (optional field) reaches this renderer as `NaN`
+   * (panel-props.ts's `toAudioSpectrumProps` no longer fabricates
+   * `?? 2400`). Unguarded, the Filter label draw call renders the literal
+   * "Filter: NaN Hz" on the desktop AUDIO SCOPE canvas (verifier-executed
+   * probe on the unguarded candidate, `audio-spectrum-renderer.ts:152`).
+   * The guard must suppress/placeholder the label instead.
+   */
+  describe('Filter label — no "NaN" leak for a non-finite filterWidth (MOR-1409 A12)', () => {
+    function mockCtxWithFillTextSpy() {
+      const ctx = mockCtx();
+      const fillText = vi.fn();
+      Object.defineProperty(ctx, 'fillText', { value: fillText, writable: true });
+      return { ctx, fillText };
+    }
+
+    // `pixels: null` here is deliberate, not incidental: with populated
+    // `pixels` (this file's `baseState`), a non-finite `filterWidth`
+    // propagates into the trapezoid geometry (`bl`/`br` become NaN) and
+    // crashes the spectrum-line block below with `RangeError: Invalid
+    // array length` (`new Array(numPoints)`, numPoints itself NaN) —
+    // independently discovered while adding this test, BEFORE reaching
+    // the label draw call's own guard. That crash is a real, separate
+    // defect in the trapezoid/spectrum-line geometry math, out of this
+    // gate's restricted grant (label-guard only, no further
+    // behavior/logic changes) — flagged for the coordinator, not fixed
+    // here. `pixels: null` (a real, common state — before the first FFT
+    // frame arrives) isolates the label guard this gate DOES own from
+    // that separate crash.
+    it('does not draw a "NaN" substring in the Filter label for a non-finite filterWidth', () => {
+      const rs = new AudioSpectrumRendererState();
+      const { ctx, fillText } = mockCtxWithFillTextSpy();
+      const state = { ...baseState, filterWidth: Number.NaN, pixels: null };
+      renderAudioSpectrum(ctx, 400, 160, state, rs);
+      const filterLabelCall = fillText.mock.calls.find((call) =>
+        String(call[0]).startsWith('Filter:'),
+      );
+      expect(filterLabelCall?.[0]).not.toMatch(/NaN/);
+    });
+
+    it('draws the established "---"-family placeholder for a non-finite filterWidth', () => {
+      const rs = new AudioSpectrumRendererState();
+      const { ctx, fillText } = mockCtxWithFillTextSpy();
+      const state = { ...baseState, filterWidth: Number.NaN, pixels: null };
+      renderAudioSpectrum(ctx, 400, 160, state, rs);
+      const filterLabelCall = fillText.mock.calls.find((call) =>
+        String(call[0]).startsWith('Filter:'),
+      );
+      expect(filterLabelCall?.[0]).toBe('Filter: ---');
+    });
+
+    it('documents the separate, out-of-grant crash: a non-finite filterWidth WITH populated pixels throws (not this gate\'s fix)', () => {
+      const rs = new AudioSpectrumRendererState();
+      const { ctx } = mockCtxWithFillTextSpy();
+      const state = { ...baseState, filterWidth: Number.NaN };
+      expect(() => renderAudioSpectrum(ctx, 400, 160, state, rs)).toThrow(/Invalid array length/);
+    });
+
+    it('still draws the real formatted width for a finite filterWidth', () => {
+      const rs = new AudioSpectrumRendererState();
+      const { ctx, fillText } = mockCtxWithFillTextSpy();
+      const state = { ...baseState, filterWidth: 2400 };
+      renderAudioSpectrum(ctx, 400, 160, state, rs);
+      const filterLabelCall = fillText.mock.calls.find((call) =>
+        String(call[0]).startsWith('Filter:'),
+      );
+      expect(filterLabelCall?.[0]).toBe('Filter: 2400 Hz');
+    });
   });
 });

--- a/frontend/src/components-v2/panels/audio-scope/__tests__/audio-spectrum-renderer.test.ts
+++ b/frontend/src/components-v2/panels/audio-scope/__tests__/audio-spectrum-renderer.test.ts
@@ -166,20 +166,20 @@ describe('renderAudioSpectrum', () => {
       return { ctx, fillText };
     }
 
-    // `pixels: null` here is deliberate, not incidental: with populated
-    // `pixels` (this file's `baseState`), a non-finite `filterWidth`
-    // propagates into the trapezoid geometry (`bl`/`br` become NaN) and
-    // crashes the spectrum-line block below with `RangeError: Invalid
-    // array length` (`new Array(numPoints)`, numPoints itself NaN) —
-    // independently discovered while adding this test, BEFORE reaching
-    // the label draw call's own guard. That crash is a real, separate
-    // defect in the trapezoid/spectrum-line geometry math, out of this
-    // gate's restricted grant (label-guard only, no further
-    // behavior/logic changes) — flagged for the coordinator, not fixed
-    // here. `pixels: null` (a real, common state — before the first FFT
-    // frame arrives) isolates the label guard this gate DOES own from
-    // that separate crash.
-    it('does not draw a "NaN" substring in the Filter label for a non-finite filterWidth', () => {
+    // `pixels: null` here is deliberate, not incidental — it isolates
+    // this describe block's original (label-only) finding from the
+    // separate, more severe crash the second describe block below
+    // documents and fixes.
+    //
+    // MOR-1409 A12 follow-up (coordinator adjudication addendum, comment
+    // 5246612628): the guard scope EXPANDED from "placeholder the label"
+    // to "skip the entire filter-overlay geometry" — so a non-finite
+    // filterWidth now draws NO Filter-prefixed label at all (not even a
+    // placeholder), superseding this describe block's original two
+    // "does not draw a NaN substring" / "draws the placeholder" tests
+    // (the former is now vacuous — there is no label call to inspect —
+    // and is replaced by this single "no label at all" pin).
+    it('draws no Filter-prefixed label at all for a non-finite filterWidth (guard scope expanded, comment 5246612628)', () => {
       const rs = new AudioSpectrumRendererState();
       const { ctx, fillText } = mockCtxWithFillTextSpy();
       const state = { ...baseState, filterWidth: Number.NaN, pixels: null };
@@ -187,25 +187,58 @@ describe('renderAudioSpectrum', () => {
       const filterLabelCall = fillText.mock.calls.find((call) =>
         String(call[0]).startsWith('Filter:'),
       );
-      expect(filterLabelCall?.[0]).not.toMatch(/NaN/);
+      expect(filterLabelCall).toBeUndefined();
     });
 
-    it('draws the established "---"-family placeholder for a non-finite filterWidth', () => {
-      const rs = new AudioSpectrumRendererState();
-      const { ctx, fillText } = mockCtxWithFillTextSpy();
-      const state = { ...baseState, filterWidth: Number.NaN, pixels: null };
-      renderAudioSpectrum(ctx, 400, 160, state, rs);
-      const filterLabelCall = fillText.mock.calls.find((call) =>
-        String(call[0]).startsWith('Filter:'),
-      );
-      expect(filterLabelCall?.[0]).toBe('Filter: ---');
-    });
-
-    it('documents the separate, out-of-grant crash: a non-finite filterWidth WITH populated pixels throws (not this gate\'s fix)', () => {
+    /**
+     * A12 follow-up (MOR-1409, Core #2317, coordinator adjudication
+     * addendum comment 5246612628, extending 5246487510). The prior
+     * pin here documented that populated `pixels` + a non-finite
+     * `filterWidth` threw `RangeError: Invalid array length` — that was
+     * a real, more severe defect (not just a label glitch) newly
+     * reachable through A12's honest sentinel, out of the original
+     * label-only grant. The grant was expanded: the guard now skips the
+     * ENTIRE filter-overlay geometry (label, trapezoid, contour, notch,
+     * and the trapezoid-clipped spectrum line) when `filterWidth`/
+     * `animFilterWidth` is non-finite, so this same populated-pixels
+     * case must render without throwing and without any overlay.
+     */
+    it('renders without throwing for populated pixels + a non-finite filterWidth (was: RangeError)', () => {
       const rs = new AudioSpectrumRendererState();
       const { ctx } = mockCtxWithFillTextSpy();
       const state = { ...baseState, filterWidth: Number.NaN };
-      expect(() => renderAudioSpectrum(ctx, 400, 160, state, rs)).toThrow(/Invalid array length/);
+      expect(() => renderAudioSpectrum(ctx, 400, 160, state, rs)).not.toThrow();
+    });
+
+    it('draws no Filter-overlay label for populated pixels + a non-finite filterWidth', () => {
+      const rs = new AudioSpectrumRendererState();
+      const { ctx, fillText } = mockCtxWithFillTextSpy();
+      const state = { ...baseState, filterWidth: Number.NaN };
+      renderAudioSpectrum(ctx, 400, 160, state, rs);
+      const filterLabelCall = fillText.mock.calls.find((call) =>
+        String(call[0]).startsWith('Filter:'),
+      );
+      expect(filterLabelCall).toBeUndefined();
+    });
+
+    it('still draws the frequency-grid "0" center label for populated pixels + a non-finite filterWidth (the rest of the spectrum renders normally)', () => {
+      const rs = new AudioSpectrumRendererState();
+      const { ctx, fillText } = mockCtxWithFillTextSpy();
+      const state = { ...baseState, filterWidth: Number.NaN };
+      renderAudioSpectrum(ctx, 400, 160, state, rs);
+      const zeroLabelCall = fillText.mock.calls.find((call) => call[0] === '0');
+      expect(zeroLabelCall).not.toBeUndefined();
+    });
+
+    it('finite-value regression pin: the overlay is still drawn (Filter label present) for a finite filterWidth', () => {
+      const rs = new AudioSpectrumRendererState();
+      const { ctx, fillText } = mockCtxWithFillTextSpy();
+      const state = { ...baseState, filterWidth: 2400 };
+      renderAudioSpectrum(ctx, 400, 160, state, rs);
+      const filterLabelCall = fillText.mock.calls.find((call) =>
+        String(call[0]).startsWith('Filter:'),
+      );
+      expect(filterLabelCall?.[0]).toBe('Filter: 2400 Hz');
     });
 
     it('still draws the real formatted width for a finite filterWidth', () => {

--- a/frontend/src/components-v2/panels/audio-scope/audio-spectrum-renderer.ts
+++ b/frontend/src/components-v2/panels/audio-scope/audio-spectrum-renderer.ts
@@ -146,10 +146,22 @@ export function renderAudioSpectrum(
   const br = cx + topHalfW + slopeExtra;
 
   // ── Filter label (top) ──
+  // MOR-1409 A12 (coordinator adjudication, Core #2317, comment
+  // 5246487510): a connected receiver that has never reported
+  // `filterWidth` (optional field) still reaches this draw call as `NaN`
+  // (panel-props.ts's `toAudioSpectrumProps` no longer fabricates `?? 2400`)
+  // — `rs.animFilterWidth` latches to `NaN` and stays there (the animation
+  // step's own `Math.abs(fwDiff) > 200` check is itself `false` for a NaN
+  // diff, so it never recovers), and `Math.round(NaN)` renders the literal
+  // "Filter: NaN Hz" on the canvas. Suppress with a placeholder, matching
+  // the established dash convention (FilterPanel.svelte's `'--- Hz'`).
   ctx.font = '11px system-ui, sans-serif';
   ctx.textAlign = 'center';
   ctx.fillStyle = FILTER_LABEL_COLOR;
-  ctx.fillText(`Filter: ${Math.round(rs.animFilterWidth)} Hz`, width / 2, TOP_LABEL_H - 5);
+  const filterLabel = Number.isFinite(rs.animFilterWidth)
+    ? `Filter: ${Math.round(rs.animFilterWidth)} Hz`
+    : 'Filter: ---';
+  ctx.fillText(filterLabel, width / 2, TOP_LABEL_H - 5);
 
   // ── Frequency grid labels (bottom) ──
   const halfBw = bandwidth / 2;

--- a/frontend/src/components-v2/panels/audio-scope/audio-spectrum-renderer.ts
+++ b/frontend/src/components-v2/panels/audio-scope/audio-spectrum-renderer.ts
@@ -126,6 +126,26 @@ export function renderAudioSpectrum(
   rs.animFilterWidth += fwDiff * (Math.abs(fwDiff) > 200 ? 0.5 : 0.15);
   if (Math.abs(fwDiff) <= 1) rs.animFilterWidth = filterWidth;
 
+  // MOR-1409 A12 (coordinator adjudication addendum, Core #2317, comment
+  // 5246612628, extending 5246487510): a connected receiver that has
+  // never reported `filterWidth` reaches here as `NaN` (panel-props.ts's
+  // `toAudioSpectrumProps` no longer fabricates `?? 2400`) — and once
+  // `rs.animFilterWidth` latches to `NaN` it never recovers (the
+  // animation step's own `Math.abs(fwDiff) > 200` check is itself always
+  // `false` for a NaN diff). Every downstream trapezoid-geometry value
+  // (`topHalfW`/`tl`/`tr`/`bl`/`br`) inherits the NaN, and with populated
+  // `pixels` the spectrum-line block below would compute
+  // `numPoints = botRight - botLeft` as NaN and crash on
+  // `new Array(numPoints)` (`RangeError: Invalid array length`) — a defect
+  // the pre-A12 `?? 2400` fabrication masked. The entire filter-overlay
+  // geometry (label, trapezoid outline/fill, the trapezoid-clipped
+  // spectrum line, contour, manual notch — everything below that reads
+  // `rs.animFilterWidth`, `topHalfW`, `tl`/`tr`/`bl`/`br`) is skipped when
+  // non-finite; the background clear/fill and the bottom frequency grid
+  // (computed from `bandwidth`, independent of the filter passband) still
+  // render normally either way.
+  const showFilterOverlay = Number.isFinite(rs.animFilterWidth);
+
   // ── Trapezoid geometry ──
   const totalHalfW = width * 0.45;
   const whiskerLeft = width / 2 - totalHalfW;
@@ -146,22 +166,13 @@ export function renderAudioSpectrum(
   const br = cx + topHalfW + slopeExtra;
 
   // ── Filter label (top) ──
-  // MOR-1409 A12 (coordinator adjudication, Core #2317, comment
-  // 5246487510): a connected receiver that has never reported
-  // `filterWidth` (optional field) still reaches this draw call as `NaN`
-  // (panel-props.ts's `toAudioSpectrumProps` no longer fabricates `?? 2400`)
-  // — `rs.animFilterWidth` latches to `NaN` and stays there (the animation
-  // step's own `Math.abs(fwDiff) > 200` check is itself `false` for a NaN
-  // diff, so it never recovers), and `Math.round(NaN)` renders the literal
-  // "Filter: NaN Hz" on the canvas. Suppress with a placeholder, matching
-  // the established dash convention (FilterPanel.svelte's `'--- Hz'`).
-  ctx.font = '11px system-ui, sans-serif';
-  ctx.textAlign = 'center';
-  ctx.fillStyle = FILTER_LABEL_COLOR;
-  const filterLabel = Number.isFinite(rs.animFilterWidth)
-    ? `Filter: ${Math.round(rs.animFilterWidth)} Hz`
-    : 'Filter: ---';
-  ctx.fillText(filterLabel, width / 2, TOP_LABEL_H - 5);
+  // Skipped entirely when non-finite — see `showFilterOverlay` above.
+  if (showFilterOverlay) {
+    ctx.font = '11px system-ui, sans-serif';
+    ctx.textAlign = 'center';
+    ctx.fillStyle = FILTER_LABEL_COLOR;
+    ctx.fillText(`Filter: ${Math.round(rs.animFilterWidth)} Hz`, width / 2, TOP_LABEL_H - 5);
+  }
 
   // ── Frequency grid labels (bottom) ──
   const halfBw = bandwidth / 2;
@@ -197,76 +208,84 @@ export function renderAudioSpectrum(
   }
 
   // ── Draw trapezoid outline + whiskers ──
+  // Skipped entirely when non-finite — see `showFilterOverlay` above.
   const pbtActive = pbtInner !== 128 || pbtOuter !== 128;
 
-  if (pbtActive) {
-    // Twin PBT: draw two separate trapezoids with distinct colors
-    const innerHz = pbtRawToHz(pbtInner);
-    const outerHz = pbtRawToHz(pbtOuter);
+  if (showFilterOverlay) {
+    if (pbtActive) {
+      // Twin PBT: draw two separate trapezoids with distinct colors
+      const innerHz = pbtRawToHz(pbtInner);
+      const outerHz = pbtRawToHz(pbtOuter);
 
-    // Inner PBT trapezoid (cyan/blue)
-    const innerCx = width / 2 + (innerHz / shiftRef) * totalHalfW * 0.6;
-    const iTl = innerCx - topHalfW;
-    const iTr = innerCx + topHalfW;
-    const iBl = innerCx - topHalfW - slopeExtra;
-    const iBr = innerCx + topHalfW + slopeExtra;
+      // Inner PBT trapezoid (cyan/blue)
+      const innerCx = width / 2 + (innerHz / shiftRef) * totalHalfW * 0.6;
+      const iTl = innerCx - topHalfW;
+      const iTr = innerCx + topHalfW;
+      const iBl = innerCx - topHalfW - slopeExtra;
+      const iBr = innerCx + topHalfW + slopeExtra;
 
-    ctx.strokeStyle = 'rgba(80, 180, 255, 0.7)';
-    ctx.lineWidth = 1.5;
+      ctx.strokeStyle = 'rgba(80, 180, 255, 0.7)';
+      ctx.lineWidth = 1.5;
+      ctx.beginPath();
+      ctx.moveTo(whiskerLeft, trapBottom);
+      ctx.lineTo(iBl, trapBottom);
+      ctx.lineTo(iTl, trapTop);
+      ctx.lineTo(iTr, trapTop);
+      ctx.lineTo(iBr, trapBottom);
+      ctx.lineTo(whiskerRight, trapBottom);
+      ctx.stroke();
+
+      // Outer PBT trapezoid (orange)
+      const outerCx = width / 2 + (outerHz / shiftRef) * totalHalfW * 0.6;
+      const oTl = outerCx - topHalfW;
+      const oTr = outerCx + topHalfW;
+      const oBl = outerCx - topHalfW - slopeExtra;
+      const oBr = outerCx + topHalfW + slopeExtra;
+
+      ctx.strokeStyle = 'rgba(255, 160, 60, 0.7)';
+      ctx.lineWidth = 1.5;
+      ctx.beginPath();
+      ctx.moveTo(oBl, trapBottom);
+      ctx.lineTo(oTl, trapTop);
+      ctx.lineTo(oTr, trapTop);
+      ctx.lineTo(oBr, trapBottom);
+      ctx.stroke();
+    } else {
+      // No PBT: single white trapezoid
+      ctx.strokeStyle = TRAPEZOID_STROKE;
+      ctx.lineWidth = 1.5;
+      ctx.beginPath();
+      ctx.moveTo(whiskerLeft, trapBottom);
+      ctx.lineTo(bl, trapBottom);
+      ctx.lineTo(tl, trapTop);
+      ctx.lineTo(tr, trapTop);
+      ctx.lineTo(br, trapBottom);
+      ctx.lineTo(whiskerRight, trapBottom);
+      ctx.stroke();
+    }
+
+    // Light fill inside trapezoid
+    ctx.fillStyle = TRAPEZOID_FILL;
     ctx.beginPath();
-    ctx.moveTo(whiskerLeft, trapBottom);
-    ctx.lineTo(iBl, trapBottom);
-    ctx.lineTo(iTl, trapTop);
-    ctx.lineTo(iTr, trapTop);
-    ctx.lineTo(iBr, trapBottom);
-    ctx.lineTo(whiskerRight, trapBottom);
-    ctx.stroke();
-
-    // Outer PBT trapezoid (orange)
-    const outerCx = width / 2 + (outerHz / shiftRef) * totalHalfW * 0.6;
-    const oTl = outerCx - topHalfW;
-    const oTr = outerCx + topHalfW;
-    const oBl = outerCx - topHalfW - slopeExtra;
-    const oBr = outerCx + topHalfW + slopeExtra;
-
-    ctx.strokeStyle = 'rgba(255, 160, 60, 0.7)';
-    ctx.lineWidth = 1.5;
-    ctx.beginPath();
-    ctx.moveTo(oBl, trapBottom);
-    ctx.lineTo(oTl, trapTop);
-    ctx.lineTo(oTr, trapTop);
-    ctx.lineTo(oBr, trapBottom);
-    ctx.stroke();
-  } else {
-    // No PBT: single white trapezoid
-    ctx.strokeStyle = TRAPEZOID_STROKE;
-    ctx.lineWidth = 1.5;
-    ctx.beginPath();
-    ctx.moveTo(whiskerLeft, trapBottom);
-    ctx.lineTo(bl, trapBottom);
+    ctx.moveTo(bl, trapBottom);
     ctx.lineTo(tl, trapTop);
     ctx.lineTo(tr, trapTop);
     ctx.lineTo(br, trapBottom);
-    ctx.lineTo(whiskerRight, trapBottom);
-    ctx.stroke();
+    ctx.closePath();
+    ctx.fill();
   }
 
-  // Light fill inside trapezoid
-  ctx.fillStyle = TRAPEZOID_FILL;
-  ctx.beginPath();
-  ctx.moveTo(bl, trapBottom);
-  ctx.lineTo(tl, trapTop);
-  ctx.lineTo(tr, trapTop);
-  ctx.lineTo(br, trapBottom);
-  ctx.closePath();
-  ctx.fill();
-
   // ── Passband fraction (used for bin mapping below) ──
+  // Skipped entirely when non-finite — see `showFilterOverlay` above
+  // (this whole block, and everything it feeds, is what threw
+  // `RangeError: Invalid array length` pre-fix: `filterHz` is `NaN`,
+  // cascading into `botLeft`/`botRight`/`numPoints` all `NaN`, and
+  // `new Array(NaN)` throws).
   const filterHz = Math.round(rs.animFilterWidth);
   const passbandFrac = Math.min(1, filterHz / halfBw);
 
   // ── Spectrum: gradient fill + line, clipped to trapezoid ──
-  if (pixels && pixels.length > 0) {
+  if (showFilterOverlay && pixels && pixels.length > 0) {
     const botLeft = Math.max(0, Math.floor(bl));
     const botRight = Math.min(width, Math.ceil(br));
     const numPoints = botRight - botLeft;
@@ -352,7 +371,9 @@ export function renderAudioSpectrum(
   }
 
   // ── Contour (inside trapezoid) ──
-  if (contour > 0) {
+  // Skipped entirely when non-finite (positioned relative to the
+  // trapezoid's tl/tr, both NaN-tainted) — see `showFilterOverlay` above.
+  if (showFilterOverlay && contour > 0) {
     const contourX = tl + (contourFreq / 255) * (tr - tl);
     const depth = (contour / 255) * trapH * 0.4;
     const cWidth = (tr - tl) * 0.25;
@@ -366,7 +387,9 @@ export function renderAudioSpectrum(
   }
 
   // ── Manual notch (inside trapezoid) ──
-  if (manualNotch) {
+  // Skipped entirely when non-finite (positioned relative to the
+  // trapezoid's tl/tr, both NaN-tainted) — see `showFilterOverlay` above.
+  if (showFilterOverlay && manualNotch) {
     const notchX = tl + (notchFreq / 255) * (tr - tl);
     const depth = trapH * 0.55;
     const nHalfW = (tr - tl) * 0.06;

--- a/frontend/src/lib/runtime/adapters/__tests__/cw-keyer-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/cw-keyer-adapter.test.ts
@@ -255,12 +255,23 @@ describe('cwKeyer honesty gate — absent raw values never fabricate (MOR-1296)'
     },
   );
 
-  it("v2's own toCwProps DOES fabricate those defaults — the divergence is real, not vacuous", () => {
+  it("v2's own toCwProps still fabricates breakIn/reversePaddle — the divergence there is real, not vacuous", () => {
+    // MOR-1409 A12 (Core #2317): `toCwProps`' `keySpeed`/`cwPitch` fabricated
+    // defaults were removed (now `NaN`, matching the honest
+    // `radio-view-model`'s `unknown` reading below — see the next test) —
+    // that half of the divergence this test used to document is closed.
+    // `breakIn`/`reversePaddle` were outside A12's batch-B family (not
+    // named in the re-anchor plan's §3.3 literal table) and still fabricate
+    // their pre-A12 defaults; the divergence remains real for those two.
     const real = toCwProps(bareState(), fullCaps);
     expect(real.breakIn).toBe(0);
-    expect(real.keySpeed).toBe(12);
-    expect(real.cwPitch).toBe(600);
     expect(real.reversePaddle).toBe(false);
+  });
+
+  it("v2's own toCwProps no longer fabricates keySpeed/cwPitch (MOR-1409 A12) — divergence with the honest model closed", () => {
+    const real = toCwProps(bareState(), fullCaps);
+    expect(real.keySpeed).toBeNaN();
+    expect(real.cwPitch).toBeNaN();
   });
 
   it('an unrecognised break-in int reads unknown, where the real formatBreakIn falls back to OFF', () => {

--- a/frontend/src/lib/runtime/adapters/__tests__/rx-audio-adapter.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/rx-audio-adapter.test.ts
@@ -226,7 +226,7 @@ describe('rxAudio degrades honestly rather than to the shipped panel defaults', 
     expect(rxAudio.afLevel.reading).toEqual({ status: 'known', value: 0.31 });
   });
 
-  it('reports AF unknown when the radio field is unobserved — where the panel substitutes 0.5', () => {
+  it('reports AF unknown when the radio field is unobserved — matching the panel contract (MOR-1409 A12: no longer 0.5)', () => {
     const local: RxAudioSnapshot = { ...SNAP, rxEnabled: false };
     const state = audioState({
       main: { ...audioState().main, afLevel: undefined } as unknown as ServerState['main'],
@@ -235,10 +235,12 @@ describe('rxAudio degrades honestly rather than to the shipped panel defaults', 
     const rxAudio = model(state, caps(), local).rxAudio!;
     expect(rxAudio.afLevel.reading).toEqual({ status: 'unknown' });
     expect(rxAudio.afLevel.availability).toEqual({ structural: true, operational: false });
-    // The discriminating half: the shipped panel prop fabricates a mid-scale
-    // default from exactly this state. The contract must NOT.
+    // MOR-1409 A12 (Core #2317): the shipped panel prop used to fabricate a
+    // mid-scale 0.5 default from exactly this state — the divergence this
+    // test used to document. `toRxAudioProps.afLevel` now matches the
+    // honest model's `unknown` reading with its own `NaN` sentinel.
     expect(toRxAudioProps(state, caps(), { muted: false, rxEnabled: false, volume: 42 }, true).afLevel)
-      .toBe(0.5);
+      .toBeNaN();
   });
 
   it.each([

--- a/frontend/src/lib/runtime/props/__tests__/panel-props.no-fabricated-defaults.test.ts
+++ b/frontend/src/lib/runtime/props/__tests__/panel-props.no-fabricated-defaults.test.ts
@@ -1,26 +1,24 @@
 /**
- * A11 (MOR-1409, Core #2317) — static ownership scan + frozen-fact regression
- * pins for the batch-A projection fix in `panel-props.ts`.
+ * A11/A12 (MOR-1409, Core #2317) — static ownership scan + frozen-fact
+ * regression pins for the batch-A/batch-B projection-honesty fixes in
+ * `panel-props.ts`.
  *
  * Companion to `panel-props.test.ts`'s per-function behavioral RED tests.
  * This file asserts two things a per-function unit test cannot:
  *
- *  1. none of the SPECIFIC fabricated-default literal source patterns the
- *     A11 re-anchor plan's live audit named (14.074 MHz / USB / FIL1 / AGC
- *     MID / one antenna) remain anywhere in `panel-props.ts`'s source
- *     text — a belt-and-suspenders sweep on top of the behavioral tests, so
- *     a mutant that restores the literal in a place no existing behavioral
- *     test happens to probe is still caught. `toFilterProps.filterWidth`'s
- *     `?? 2400` is NOT in this forbidden set — per coordinator adjudication
- *     5245697359 (Core #2317), narrowing A11 after the independent verifier
- *     BLOCKED on a real consumer-boundary defect (a `NaN` sentinel there
- *     renders as the literal "NaNkHz" in `FilterPanel.svelte`'s BW readout
- *     and settings modal — a formatted-display consumer, not a comparison
- *     consumer like `findActiveBand`, reachable ungated on the shipped
- *     mobile skin). It moves to the batch-B/A12 guard rows below, alongside
- *     its `toAudioSpectrumProps` twin, so A12 inherits the pin along with
- *     the FilterPanel.svelte consumer-boundary fix that adjudication scopes
- *     to it;
+ *  1. none of the SPECIFIC fabricated-default literal source patterns named
+ *     by the A11/A12 re-anchor plans' live audits remain anywhere in
+ *     `panel-props.ts`'s source text — a belt-and-suspenders sweep on top
+ *     of the behavioral tests, so a mutant that restores the literal in a
+ *     place no existing behavioral test happens to probe is still caught.
+ *     `toFilterProps`/`toAudioSpectrumProps`' `?? 2400` moved here from
+ *     `stillPresentOutOfScope` at A12 — A11 narrowed it out (adjudication
+ *     5245697359, Core #2317: a `NaN` sentinel there renders the literal
+ *     "NaNkHz" in `FilterPanel.svelte`'s BW readout/settings modal, a
+ *     formatted-display consumer, not a comparison consumer), and A12 is
+ *     granted `FilterPanel.svelte` as a fourth production file specifically
+ *     to add that consumer-boundary guard (see `FilterPanel.isolated.test.ts`),
+ *     so the fabricated default can now be removed at the source;
  *  2. two frozen facts this gate must NOT disturb: `panel-adapters.ts` still
  *     makes zero `runtime.send()` calls (§3.4 of the plan — it only reads
  *     `runtime.state`/`runtime.caps`), and `RadioLayout.svelte` still has
@@ -62,16 +60,19 @@ function functionBody(source: string, name: string): string {
   return source.slice(start, next === -1 ? source.length : next);
 }
 
-describe('panel-props.ts batch-A functions carry no fabricated-default literal (MOR-1409 A11)', () => {
+describe('panel-props.ts batch-A/batch-B functions carry no fabricated-default literal (MOR-1409 A11/A12)', () => {
   const source = readSource(PANEL_PROPS_PATH);
 
-  // One row per batch-A function (plan §3.3) this gate fixes, and the exact
-  // source substring the live re-anchor audit named as its plausible-looking
-  // fabricated default. On exact base every one of these is present in its
-  // named function; after the fix none may remain THERE — batch-B/A12
-  // functions sharing the same substring elsewhere in the file are exempt
-  // (they are a later gate's own owner, per the plan's function-level split).
+  // One row per batch-A/batch-B function (plan §3.3) this program fixes, and
+  // the exact source substring the live re-anchor audits named as its
+  // plausible-looking fabricated default. On exact base at each gate's own
+  // anchor every one of these is present in its named function; after the
+  // fix none may remain THERE — functions this gate does NOT touch sharing
+  // the same substring elsewhere in the file are exempt (a later/earlier
+  // gate's own owner, per the plan's function-level split; see
+  // `stillPresentOutOfScope` below for A12's own explicit non-fixes).
   const forbidden: ReadonlyArray<readonly [fn: string, literal: string]> = [
+    // A11 (batch-A)
     ['toVfoProps', 'freq: 14074000,'],
     ['toVfoProps', "mode: 'USB',"],
     ['toVfoProps', "filter: 'FIL1',"],
@@ -84,27 +85,87 @@ describe('panel-props.ts batch-A functions carry no fabricated-default literal (
     ['toAgcProps', 'agcModes: caps?.agcModes ?? [1, 2, 3]'],
     ['toModeProps', "currentMode: rx?.mode ?? 'USB',"],
     ['toAntennaProps', 'antennaCount: caps?.antennas ?? 1,'],
+    // A12 (batch-B)
+    ['toRitXitProps', 'ritOffset: state?.ritFreq ?? 0,'],
+    ['toRitXitProps', 'xitOffset: state?.ritFreq ?? 0,'],
+    ['toModeProps', "['USB', 'LSB', 'CW', 'CW-R', 'AM', 'FM', 'RTTY', 'RTTY-R', 'PSK', 'PSK-R']"],
+    ['toCwProps', 'cwPitch: state?.cwPitch ?? 600,'],
+    ['toCwProps', 'keySpeed: state?.keySpeed ?? 12,'],
+    ['toCwProps', 'wpm: state?.keySpeed ?? 12,'],
+    ['toCwProps', 'sidetonePitch: state?.cwPitch ?? 600,'],
+    ['toCwProps', 'sidetoneLevel: state?.monitorGain ?? 128,'],
+    ['toCwProps', 'keyerType: 0,'],
+    ['toMeterProps', 'sValue: rx?.sMeter ?? 0,'],
+    ['toMeterProps', 'signal: rx?.sMeter ?? 0,'],
+    ['toMeterProps', 'rfPower: state?.powerMeter ?? 0,'],
+    ['toMeterProps', 'swr: state?.swrMeter ?? 0,'],
+    ['toMeterProps', 'alc: state?.alcMeter ?? 0,'],
+    ['toMeterProps', 'comp: state?.compMeter ?? 0,'],
+    ['toMeterProps', 'vd: state?.vdMeter ?? 0,'],
+    ['toMeterProps', 'id: state?.idMeter ?? 0,'],
+    ['toRxAudioProps', '(rx?.afLevel ?? 0.5)'],
+    ['toScanProps', 'scanType: state?.scanType ?? 0,'],
+    ['toScanProps', 'scanResumeMode: (state?.scanResumeMode ?? 0)'],
+    ['toAudioSpectrumProps', 'filterWidth: rx?.filterWidth ?? 2400,'],
+    ['toMemoryPanelProps', 'activeFreqHz: rx?.freqHz ?? 0,'],
+    ["toMemoryPanelProps", "activeMode: rx?.mode ?? '',"],
   ];
 
   it.each(forbidden)('%s does not contain %j', (fn, literal) => {
     expect(functionBody(source, fn)).not.toContain(literal);
   });
 
-  // Companion positive checks: the batch-B/A12 siblings that share the same
-  // fallback TEXT as a batch-A function above are explicitly confirmed
-  // UNCHANGED — proving the scan above is scoped correctly and this gate did
-  // not silently widen into A12's own owner functions. `toFilterProps`'s own
-  // `filterWidth ?? 2400` joins this list per adjudication 5245697359 (Core
-  // #2317): narrowed OUT of A11 (consumer-boundary defect — see file-header
-  // comment), deferred to A12 alongside its `toAudioSpectrumProps` twin.
+  it('toCwProps does not declare a keyerType field at all (dead output, removed not sentineled)', () => {
+    expect(functionBody(source, 'toCwProps')).not.toMatch(/\bkeyerType\b/);
+  });
+
+  it('toFilterProps.filterWidth no longer fabricates 2400 (A12 fix — was deferred at A11)', () => {
+    expect(functionBody(source, 'toFilterProps')).not.toContain('filterWidth: rx?.filterWidth ?? 2400,');
+  });
+
+  // Companion positive checks: functions/literals this program deliberately
+  // leaves untouched — either a later/earlier gate's own owner, or an A12
+  // builder-authored explicit non-fix decision (documented inline and in
+  // `panel-props.test.ts`).
   const stillPresentOutOfScope: ReadonlyArray<readonly [fn: string, literal: string]> = [
+    // toCwProps' internal mode-gate fallback feeds only apfDisabled/
+    // tpfDisabled (always the conservative/disabled direction) — not a
+    // fabrication target (plan §7 LOW item).
     ['toCwProps', "?? 'USB'"],
-    ['toFilterProps', '?? 2400'],
-    ['toAudioSpectrumProps', '?? 2400'],
+    // contourFreq is not yet exposed in ServerState at all — a placeholder
+    // for an unwired feature, a distinct class from every other literal in
+    // this sweep (plan §5, "not folded into the mechanical sweep").
+    ['toAudioSpectrumProps', 'contourFreq: 128,'],
+    // ritActive/xitActive/twinPeak/scanning keep a plain `boolean`
+    // contract: RitXitPanel.svelte/CwPanel.svelte/ScanPanel.svelte (none
+    // are A12 owners) each pass these straight into a `HardwareButton
+    // active={…}` prop typed `boolean | undefined` — widening to
+    // `boolean | null` broke `npm run check` in a file A12 is not granted.
+    // `false` is the conservative/off reading; each panel is gated on its
+    // own `hasCap` check regardless (see panel-props.ts's own header
+    // comments on these four fields).
+    ['toRitXitProps', 'ritActive: state?.ritOn ?? false,'],
+    ['toRitXitProps', 'xitActive: state?.ritTx ?? false,'],
+    ['toCwProps', 'twinPeak: rx?.twinPeakFilter ?? false,'],
+    ['toScanProps', 'scanning: state?.scanning ?? false,'],
+    // toTxProps' entire batch-B family — see the explicit non-fix
+    // rationale in panel-props.test.ts's "toTxProps — explicit non-fix"
+    // describe block: TxPanel.svelte's settings-modal ValueControl calls
+    // use an unguarded displayFn that would render "NaN%" for a non-finite
+    // input, and TxPanel.svelte is not one of A12's four granted
+    // production files. Deferred whole, not partially (numeric vs.
+    // boolean), to keep the family's honesty guarantee internally
+    // consistent for a future gate to finish.
+    ['toTxProps', 'rfPower: state?.powerLevel ?? 0.5,'],
+    ['toTxProps', 'micGain: state?.micGain ?? 128,'],
+    ['toTxProps', 'monLevel: state?.monitorGain ?? 128,'],
+    ['toTxProps', 'driveGain: state?.driveGain ?? 128,'],
+    ['toTxProps', 'voxActive: state?.voxOn ?? false,'],
+    ['toTxProps', 'compActive: state?.compressorOn ?? false,'],
   ];
 
   it.each(stillPresentOutOfScope)(
-    '%s (batch-B/A12, out of A11 scope) is untouched — still contains %j',
+    '%s (out of this gate\'s scope, explicit non-fix) is untouched — still contains %j',
     (fn, literal) => {
       expect(functionBody(source, fn)).toContain(literal);
     },

--- a/frontend/src/lib/runtime/props/__tests__/panel-props.test.ts
+++ b/frontend/src/lib/runtime/props/__tests__/panel-props.test.ts
@@ -4,13 +4,18 @@ import {
   toAgcProps,
   toAmberTelemetryProps,
   toAntennaProps,
+  toAudioSpectrumProps,
   toBandSelectorProps,
   toCwProps,
   toDspProps,
   toFilterProps,
+  toMemoryPanelProps,
+  toMeterProps,
   toModeProps,
   toRfFrontEndProps,
+  toRitXitProps,
   toRxAudioProps,
+  toScanProps,
   toTxProps,
   toVfoProps,
 } from '../panel-props';
@@ -654,16 +659,16 @@ describe('A11 — batch-A projections do not fabricate defaults (MOR-1409)', () 
       expect(props.filterLabels).toEqual([]);
     });
 
-    it('still fabricates the 2400 Hz width fallback — deliberately deferred to A12 (adjudication 5245697359, Core #2317)', () => {
-      // A NaN sentinel here renders as the literal "NaNkHz" in
-      // FilterPanel.svelte's BW readout and settings modal — a
-      // formatted-display consumer, unlike `findActiveBand`'s comparison
-      // consumer that the same-type-sentinel approach was validated
-      // against. Fixing it needs a FilterPanel.svelte consumer-boundary
-      // change, a fourth production file A11 is not granted; A12 owns this
-      // family (plus its `toAudioSpectrumProps` twin) per the adjudication.
+    it('does not invent the 2400 Hz width fallback (MOR-1409 A12, adjudication 5245697359, Core #2317)', () => {
+      // A11 deliberately kept `?? 2400` here: a NaN sentinel renders as the
+      // literal "NaNkHz" in FilterPanel.svelte's BW readout and settings
+      // modal — a formatted-display consumer, unlike `findActiveBand`'s
+      // comparison consumer. A12 is granted FilterPanel.svelte as a fourth
+      // production file specifically to add the consumer-boundary guard
+      // (see FilterPanel.isolated.test.ts), so the fabricated default can
+      // now be removed at the source without leaking "NaN" into the UI.
       const props = toFilterProps(null, null);
-      expect(props.filterWidth).toBe(2400);
+      expect(props.filterWidth).toBeNaN();
     });
 
     it('still reports the real values for a populated receiver and capabilities', () => {
@@ -725,6 +730,256 @@ describe('A11 — batch-A projections do not fabricate defaults (MOR-1409)', () 
     it('still reports the real declared antenna count', () => {
       const props = toAntennaProps(makeState(), { antennas: 2 } as any);
       expect(props.antennaCount).toBe(2);
+    });
+  });
+});
+
+/**
+ * A12 (MOR-1409, Core #2317) — batch-B projections stop fabricating a
+ * plausible-looking default for RIT/XIT, the mode catalog, CW pitch/speed/
+ * sidetone/keyer, meters, RX audio level, scan status, filter width (its
+ * `toFilterProps` twin), and the memory-panel "store VFO → channel" fields.
+ * Same non-fabricating-sentinel convention as A11: `NaN` for numbers whose
+ * type stays `number`, `'---'` for strings whose type stays `string`,
+ * `null` for the two RIT/XIT booleans whose type widens to `boolean | null`
+ * per the A12 re-anchor plan's §5 consumer-boundary matrix (both feed only
+ * a `hasCap`-gated panel — see the matrix's golden-safety column — so the
+ * type widening carries no rendering risk). `toCwProps.keyerType` is
+ * removed entirely (dead output field, no consumer, per the matrix). Every
+ * case below documents a value `panel-props.ts` used to invent on exact
+ * base; A11's own §3.3 confirms each literal was still present at the A12
+ * anchor.
+ */
+describe('A12 — batch-B projections do not fabricate defaults (MOR-1409)', () => {
+  describe('toRitXitProps', () => {
+    it('does not invent a zero offset when state is entirely absent (offset only — active stays boolean, see below)', () => {
+      const props = toRitXitProps(null, null);
+      expect(props.ritOffset).toBeNaN();
+      expect(props.xitOffset).toBeNaN();
+    });
+
+    it('ritActive/xitActive keep a plain boolean contract (false when absent) — RitXitPanel.svelte is not an A12 owner, see panel-props.ts header comment', () => {
+      // `RitXitPanel.svelte`'s `HardwareButton active={…}` prop is typed
+      // `boolean | undefined`; widening `ritActive`/`xitActive` to
+      // `boolean | null` breaks that (non-A12-owned) consumer's compile — a
+      // fifth production file A12 is not granted. `false` is the
+      // conservative "off" reading and the panel is gated on `hasRit`/
+      // `hasXit` regardless.
+      const props = toRitXitProps(null, null);
+      expect(props.ritActive).toBe(false);
+      expect(props.xitActive).toBe(false);
+    });
+
+    it('still reports the real observed RIT/XIT state', () => {
+      const props = toRitXitProps(
+        makeState({ ritOn: true, ritFreq: 150, ritTx: true }),
+        { capabilities: ['rit', 'xit'] } as any,
+      );
+      expect(props.ritActive).toBe(true);
+      expect(props.ritOffset).toBe(150);
+      expect(props.xitActive).toBe(true);
+      expect(props.xitOffset).toBe(150);
+    });
+  });
+
+  describe('toModeProps modes catalog', () => {
+    it('does not invent a 10-mode catalog without capabilities', () => {
+      const props = toModeProps(makeState(), null);
+      expect(props.modes).toEqual([]);
+    });
+
+    it('still reports the real capability-derived mode list', () => {
+      const props = toModeProps(makeState(), { modes: ['USB', 'LSB', 'CW'] } as any);
+      expect(props.modes).toEqual(['USB', 'LSB', 'CW']);
+    });
+  });
+
+  describe('toCwProps', () => {
+    it('does not invent pitch/speed/sidetone values when state is absent', () => {
+      const props = toCwProps(null, null);
+      expect(props.cwPitch).toBeNaN();
+      expect(props.keySpeed).toBeNaN();
+      expect(props.wpm).toBeNaN();
+      expect(props.sidetonePitch).toBeNaN();
+      expect(props.sidetoneLevel).toBeNaN();
+    });
+
+    it('twinPeak keeps a plain boolean contract (false when absent) — CwPanel.svelte is not an A12 owner, see panel-props.ts header comment', () => {
+      // `CwPanel.svelte`'s `HardwareButton active={…}` prop is typed
+      // `boolean | undefined`; widening `twinPeak` to `boolean | null`
+      // breaks that (non-A12-owned) consumer's compile — a fifth
+      // production file A12 is not granted. `false` is the conservative
+      // "off" reading and the panel is gated on `hasCw` regardless.
+      const props = toCwProps(null, null);
+      expect(props.twinPeak).toBe(false);
+    });
+
+    it('removes the dead keyerType output field entirely (no production consumer)', () => {
+      const props = toCwProps(makeState(), null);
+      expect('keyerType' in props).toBe(false);
+    });
+
+    it('still reports the real observed CW values', () => {
+      const props = toCwProps(
+        makeState({
+          cwPitch: 700,
+          keySpeed: 25,
+          main: { ...makeState().main, twinPeakFilter: true },
+        }),
+        null,
+      );
+      expect(props.cwPitch).toBe(700);
+      expect(props.keySpeed).toBe(25);
+      expect(props.wpm).toBe(25);
+      expect(props.sidetonePitch).toBe(700);
+      expect(props.twinPeak).toBe(true);
+    });
+  });
+
+  describe('toMeterProps', () => {
+    // No live `.svelte` consumer of `panel-props.ts`'s `toMeterProps` was
+    // found repo-wide (the desktop `MetersDockPanel.svelte` reads raw
+    // `radioState` fields directly; the LCD/mobile skins' `toMeterProps`
+    // is an independent, frozen `state-adapter.ts` copy). Zero golden risk
+    // either way — this is a direct unit-level pin, per the A12 re-anchor
+    // plan §5's row (a) resolution.
+    it('does not invent zero meter readings when state is absent', () => {
+      const props = toMeterProps(null, null);
+      expect(props.sValue).toBeNaN();
+      expect(props.signal).toBeNaN();
+      expect(props.rfPower).toBeNaN();
+      expect(props.swr).toBeNaN();
+      expect(props.alc).toBeNaN();
+      expect(props.comp).toBeNaN();
+      expect(props.vd).toBeNaN();
+      expect(props.id).toBeNaN();
+    });
+
+    it('still reports the real observed meter readings', () => {
+      const props = toMeterProps(
+        makeState({
+          powerMeter: 10,
+          swrMeter: 1.5,
+          alcMeter: 3,
+          compMeter: 4,
+          vdMeter: 137,
+          idMeter: 55,
+        }),
+        null,
+      );
+      expect(props.sValue).toBe(50);
+      expect(props.rfPower).toBe(10);
+      expect(props.swr).toBe(1.5);
+      expect(props.vd).toBe(137);
+      expect(props.id).toBe(55);
+    });
+  });
+
+  describe('toRxAudioProps afLevel', () => {
+    it('does not invent the 0.5 normalized AF level when state is absent (local mode)', () => {
+      const props = toRxAudioProps(null, null, { muted: false, rxEnabled: false, volume: 50 }, false);
+      expect(props.afLevel).toBeNaN();
+    });
+
+    it('still reports the real observed local AF level', () => {
+      const props = toRxAudioProps(
+        makeState({ main: { ...makeState().main, afLevel: 0.3 } }),
+        null,
+        { muted: false, rxEnabled: false, volume: 50 },
+        false,
+      );
+      expect(props.afLevel).toBe(0.3);
+    });
+  });
+
+  describe('toScanProps', () => {
+    it('does not invent scanType=0/scanResumeMode=0 when state is absent', () => {
+      const props = toScanProps(null);
+      expect(props.scanType).toBeNaN();
+      expect(props.scanResumeMode).toBeNaN();
+    });
+
+    it('scanning keeps a plain boolean contract (false when absent) — ScanPanel.svelte is not an A12 owner, see panel-props.ts header comment', () => {
+      // `ScanPanel.svelte`'s `HardwareButton active={…}` prop is typed
+      // `boolean | undefined`; widening `scanning` to `boolean | null`
+      // breaks that (non-A12-owned) consumer's compile — a fifth
+      // production file A12 is not granted. `false` is the conservative
+      // "not scanning" reading.
+      const props = toScanProps(null);
+      expect(props.scanning).toBe(false);
+    });
+
+    it('still reports the real observed scan state', () => {
+      const props = toScanProps(makeState({ scanning: true, scanType: 0x01, scanResumeMode: 0xd2 }));
+      expect(props.scanning).toBe(true);
+      expect(props.scanType).toBe(0x01);
+      expect(props.scanResumeMode).toBe(0x02);
+    });
+  });
+
+  describe('toAudioSpectrumProps filterWidth (toFilterProps twin)', () => {
+    it('does not invent the 2400 Hz width fallback when state is absent', () => {
+      const props = toAudioSpectrumProps(null, null);
+      expect(props.filterWidth).toBeNaN();
+    });
+
+    it('still reports the real observed filter width', () => {
+      const props = toAudioSpectrumProps(makeState({ main: { ...makeState().main, filterWidth: 1800 } }), null);
+      expect(props.filterWidth).toBe(1800);
+    });
+
+    it('still fabricates a centre contourFreq — explicit non-fix, distinct class (MOR-1409 A12)', () => {
+      // Per the A12 re-anchor plan §5: `contourFreq` is not yet exposed in
+      // `ServerState` at all — it is a placeholder for a feature not wired
+      // end-to-end, not a per-field "unobserved" case like every other
+      // literal in this file. Converting it to NaN was explicitly flagged
+      // as a distinct decision point, not folded into this mechanical sweep.
+      const props = toAudioSpectrumProps(null, null);
+      expect(props.contourFreq).toBe(128);
+    });
+  });
+
+  describe('toMemoryPanelProps', () => {
+    it('does not invent activeFreqHz=0/activeMode="" when state is absent', () => {
+      const props = toMemoryPanelProps(null, null);
+      expect(props.activeFreqHz).toBeNaN();
+      expect(props.activeMode).toBe('---');
+    });
+
+    it('still reports the real observed active-receiver frequency/mode', () => {
+      const props = toMemoryPanelProps(makeState(), null);
+      expect(props.activeFreqHz).toBe(14_074_000);
+      expect(props.activeMode).toBe('USB');
+    });
+  });
+
+  describe('toTxProps — explicit non-fix (MOR-1409 A12)', () => {
+    // TxPanel.svelte (panel-props.ts's `toTxProps`' only production
+    // consumer) is entirely hidden on the desktop-v2 skin
+    // (`hideTxPanel={semanticRxTx}`, true for desktop-v2 — zero golden
+    // risk there) but IS reachable on the mobile skin. Its settings-modal
+    // `ValueControl` calls for rfPower/micGain/monLevel/driveGain pass
+    // `displayFn={normalizedPercentDisplay}`/`rawToPercentDisplay`, neither
+    // of which guards a non-finite input — a `NaN` sentinel here would
+    // render the literal "NaN%" in a real, live, mobile-reachable surface
+    // (not covered by any committed golden — the only enforced
+    // `toHaveScreenshot` gate is the desktop-root capture, which always
+    // fixtures the receiver as populated). Fixing this cleanly needs a
+    // consumer-boundary guard in TxPanel.svelte, mirroring FilterPanel's
+    // fix in this same gate — but TxPanel.svelte is not one of A12's four
+    // granted production files. A12 defers the entire `toTxProps` batch-B
+    // family (rather than a partial boolean-only fix) rather than trade a
+    // plausible-looking-but-wrong value for a raw "NaN%" glitch in a file
+    // it cannot guard. This mirrors A11's own `toFilterProps.filterWidth`
+    // deferral to A12 exactly.
+    it('still fabricates the RF power / mic gain / mon level / drive gain / vox / comp defaults', () => {
+      const props = toTxProps(null, null);
+      expect(props.rfPower).toBe(0.5);
+      expect(props.micGain).toBe(128);
+      expect(props.monLevel).toBe(128);
+      expect(props.driveGain).toBe(128);
+      expect(props.voxActive).toBe(false);
+      expect(props.compActive).toBe(false);
     });
   });
 });

--- a/frontend/src/lib/runtime/props/panel-props.ts
+++ b/frontend/src/lib/runtime/props/panel-props.ts
@@ -358,24 +358,20 @@ export function toFilterProps(
     // `toAgcProps`'s `agcModes`) — unknown capabilities means an empty, not
     // invented, catalog.
     //
-    // `filterWidth` deliberately KEEPS its `?? 2400` fallback here (narrowed
-    // by coordinator adjudication 5245697359, Core #2317): a NaN sentinel
-    // renders as the literal "NaNkHz" in FilterPanel.svelte's BW readout
-    // (:207) and settings modal (:299/:317) — a formatted-display consumer,
-    // not a comparison consumer like `findActiveBand` — reachable ungated on
-    // the shipped mobile skin, and permanent for a connected rig that never
-    // reports width (not merely a disconnected-only case). The plan's
-    // same-type-sentinel guidance was validated only against a comparison
-    // consumer; it does not transplant to a formatted-display one without a
-    // FilterPanel.svelte consumer-boundary fix, which is a fourth production
-    // file A11 is not granted. Deferred to A12, which the same adjudication
-    // scopes to include this family plus its `toAudioSpectrumProps` twin
-    // (`?? 2400` below) and the FilterPanel.svelte consumer boundary itself.
+    // MOR-1409 A12 (adjudication 5245697359, Core #2317): `filterWidth` no
+    // longer fabricates a 2400 Hz stand-in. A11 deferred this fix — a NaN
+    // sentinel renders as the literal "NaNkHz" in FilterPanel.svelte's BW
+    // readout (:207) and settings modal (:299) — a formatted-display
+    // consumer, not a comparison consumer like `findActiveBand`. A12 is
+    // granted FilterPanel.svelte as a fourth production file specifically
+    // to add the consumer-boundary guard (`formatWidthDisplay`'s
+    // `Number.isFinite` check), so the fabricated default can now be
+    // removed here. See its `toAudioSpectrumProps` twin below.
     currentMode: rx?.mode ?? '---',
     currentFilter: rx?.filter ?? 1,
     filterShape: rx?.filterShape ?? 0,
     filterLabels: caps?.filters ?? [],
-    filterWidth: rx?.filterWidth ?? 2400,
+    filterWidth: rx?.filterWidth ?? Number.NaN,
     filterWidthMin:
       filterConfig?.minHz ??
       filterConfig?.table?.[0] ??
@@ -428,6 +424,20 @@ export function toAgcProps(
 /* ── RIT / XIT ───────────────────────────────────────────────── */
 
 export interface RitXitProps {
+  // MOR-1409 A12: no fabricated "off" reading for an unobserved RIT/XIT
+  // state — `ritOn`/`ritTx` are real device state (like `mode`/`freqHz`),
+  // not capability-availability flags. `ritActive`/`xitActive` keep their
+  // `boolean` (not `boolean | null`) contract: `RitXitPanel.svelte`'s
+  // `HardwareButton active={…}` prop is typed `boolean | undefined`, so
+  // widening to `boolean | null` here breaks that (non-A12-owned)
+  // consumer's compile — a fifth production file A12 is not granted. Both
+  // fields stay gated on `hasRit`/`hasXit` (`RitXitPanel.svelte` never
+  // renders a body for a cold/unsupported receiver regardless of this
+  // field's raw value — plan §5), and `false` is the conservative/off
+  // reading, the same non-fabrication class as `toCwProps`' internal
+  // `mode ?? 'USB'` gate literal (plan §7 LOW item) — never a
+  // plausible-looking *on* reading no one confirmed. `ritOffset`/
+  // `xitOffset` still fix to the standard `NaN` sentinel.
   ritActive: boolean;
   ritOffset: number;
   xitActive: boolean;
@@ -442,9 +452,9 @@ export function toRitXitProps(
 ): RitXitProps {
   return {
     ritActive: state?.ritOn ?? false,
-    ritOffset: state?.ritFreq ?? 0,
+    ritOffset: state?.ritFreq ?? Number.NaN,
     xitActive: state?.ritTx ?? false,
-    xitOffset: state?.ritFreq ?? 0,
+    xitOffset: state?.ritFreq ?? Number.NaN,
     hasRit: hasCap(caps, 'rit'),
     hasXit: hasCap(caps, 'xit'),
   };
@@ -479,9 +489,12 @@ export function toModeProps(
   return {
     // MOR-1409 A11: no fabricated USB stand-in for an unobserved mode.
     currentMode: rx?.mode ?? '---',
-    modes: caps?.modes ?? [
-      'USB', 'LSB', 'CW', 'CW-R', 'AM', 'FM', 'RTTY', 'RTTY-R', 'PSK', 'PSK-R',
-    ],
+    // MOR-1409 A12 (expanded mandate, adjudication 5245697359, Core #2317):
+    // no fabricated 10-mode invented catalog. `modes` is a
+    // capability-derived choice set — same convention as `toAgcProps`'
+    // `agcModes`/`toFilterProps`' `filterLabels` — unknown capabilities
+    // means an empty, not invented, catalog.
+    modes: caps?.modes ?? [],
     dataMode: rx?.dataMode ?? 0,
     hasDataMode: hasCap(caps, 'data_mode'),
     dataModeCount: caps?.dataModeCount ?? 0,
@@ -648,6 +661,11 @@ export interface CwProps {
   keySpeed: number;
   breakIn: number;
   apfMode: number;
+  // `twinPeak` keeps its `boolean` (not `boolean | null`) contract — see
+  // `toRitXitProps`' header comment: `CwPanel.svelte`'s `HardwareButton
+  // active={…}` prop is typed `boolean | undefined`, so widening breaks a
+  // non-A12-owned consumer's compile. `false` is the conservative "off"
+  // reading; `CwPanel.svelte` is gated on `hasCw` regardless.
   twinPeak: boolean;
   currentMode: string;
   apfDisabled: boolean;
@@ -658,7 +676,10 @@ export interface CwProps {
   sidetonePitch: number;
   sidetoneLevel: number;
   reversePaddle: boolean;
-  keyerType: number;
+  // MOR-1409 A12: `keyerType` removed entirely (was `keyerType: 0`,
+  // hardcoded, not even `??`-guarded). No `ServerState` field backs it and
+  // no production `.svelte` consumer reads `CwProps.keyerType` — dead
+  // output, deleted rather than sentineled (plan §3.3/§5).
   hasCw: boolean;
   hasBreakIn: boolean;
   hasApf: boolean;
@@ -679,21 +700,22 @@ export function toCwProps(
   const apfDisabled = !(mode === 'CW' || mode === 'CW-R');
   const tpfDisabled = !(mode === 'RTTY' || mode === 'RTTY-R');
   return {
-    cwPitch: state?.cwPitch ?? 600,
-    keySpeed: state?.keySpeed ?? 12,
+    // MOR-1409 A12: no fabricated 600 Hz pitch / 12 wpm keying speed / 128
+    // sidetone-level stand-ins for an unobserved CW receiver.
+    cwPitch: state?.cwPitch ?? Number.NaN,
+    keySpeed: state?.keySpeed ?? Number.NaN,
     breakIn: breakInVal,
     apfMode: rx?.apfTypeLevel ?? 0,
     twinPeak: rx?.twinPeakFilter ?? false,
     currentMode: mode,
     apfDisabled,
     tpfDisabled,
-    wpm: state?.keySpeed ?? 12,
+    wpm: state?.keySpeed ?? Number.NaN,
     breakInActive: breakInVal > 0,
     breakInDelay: state?.breakInDelay ?? 0,
-    sidetonePitch: state?.cwPitch ?? 600,
-    sidetoneLevel: state?.monitorGain ?? 128,
+    sidetonePitch: state?.cwPitch ?? Number.NaN,
+    sidetoneLevel: state?.monitorGain ?? Number.NaN,
     reversePaddle: (state?.dashRatio ?? 0) < 0,
-    keyerType: 0,
     hasCw: hasCap(caps, 'cw'),
     hasBreakIn: hasCap(caps, 'break_in'),
     hasApf: hasCap(caps, 'apf'),
@@ -721,15 +743,22 @@ export function toMeterProps(
   caps: Capabilities | null,
 ): MeterProps {
   const rx = state ? activeRx(state) : null;
+  // MOR-1409 A12: no fabricated zero-meter reading for an unobserved
+  // receiver — a real S0/zero-power/zero-SWR reading is indistinguishable
+  // from "never read" without this fix. No production `.svelte` file was
+  // found to call `toMeterProps` repo-wide (`MetersDockPanel.svelte`, the
+  // live desktop meter component, reads raw `radioState` fields directly,
+  // bypassing this function entirely — plan §5) — zero golden/display risk
+  // either way; this is a direct honesty fix at the projection layer.
   return {
-    sValue: rx?.sMeter ?? 0,
-    signal: rx?.sMeter ?? 0,
-    rfPower: state?.powerMeter ?? 0,
-    swr: state?.swrMeter ?? 0,
-    alc: state?.alcMeter ?? 0,
-    comp: state?.compMeter ?? 0,
-    vd: state?.vdMeter ?? 0,
-    id: state?.idMeter ?? 0,
+    sValue: rx?.sMeter ?? Number.NaN,
+    signal: rx?.sMeter ?? Number.NaN,
+    rfPower: state?.powerMeter ?? Number.NaN,
+    swr: state?.swrMeter ?? Number.NaN,
+    alc: state?.alcMeter ?? Number.NaN,
+    comp: state?.compMeter ?? Number.NaN,
+    vd: state?.vdMeter ?? Number.NaN,
+    id: state?.idMeter ?? Number.NaN,
     txActive: state?.ptt ?? false,
     hasTx: caps?.tx ?? false,
   };
@@ -769,10 +798,13 @@ export function toRxAudioProps(
     : audioState.rxEnabled && hasLiveAudio
       ? 'live'
       : 'local';
+  // MOR-1409 A12: no fabricated 0.5 normalized AF-level stand-in for an
+  // unobserved receiver in local mode. `RxAudioPanel.svelte` (this field's
+  // only production consumer) is gated on `hasAfLevel || hasLiveAudio`.
   const afLevel =
     monitorMode === 'live'
       ? audioState.volume / 100
-      : (rx?.afLevel ?? 0.5);
+      : (rx?.afLevel ?? Number.NaN);
   const hasDualReceiver = caps?.capabilities?.includes('dual_rx') ?? false;
   return {
     monitorMode,
@@ -842,6 +874,13 @@ export function toAntennaProps(
 /* ── Scan Panel ──────────────────────────────────────────────── */
 
 export interface ScanProps {
+  // `scanning` keeps its `boolean` (not `boolean | null`) contract — see
+  // `toRitXitProps`' header comment: `ScanPanel.svelte`'s `HardwareButton
+  // active={…}` prop is typed `boolean | undefined`, so widening breaks a
+  // non-A12-owned consumer's compile. `false` is the conservative "not
+  // scanning" reading. `scanType`/`scanResumeMode` still fix to `NaN` —
+  // pure comparison consumers (button `active` matching against a fixed
+  // value list), golden-safe (plan §5).
   scanning: boolean;
   scanType: number;
   scanResumeMode: number;
@@ -850,8 +889,11 @@ export interface ScanProps {
 export function toScanProps(state: ServerState | null): ScanProps {
   return {
     scanning: state?.scanning ?? false,
-    scanType: state?.scanType ?? 0,
-    scanResumeMode: (state?.scanResumeMode ?? 0) & 0x0f,
+    scanType: state?.scanType ?? Number.NaN,
+    scanResumeMode:
+      state?.scanResumeMode === undefined || state?.scanResumeMode === null
+        ? Number.NaN
+        : state.scanResumeMode & 0x0f,
   };
 }
 
@@ -879,7 +921,12 @@ export function toAudioSpectrumProps(
     : (filterConfig?.maxHz ?? caps?.filterWidthMax ?? 4000);
 
   return {
-    filterWidth: rx?.filterWidth ?? 2400,
+    // MOR-1409 A12: twin of `toFilterProps.filterWidth` above — same fix,
+    // same rationale, guarded at the same FilterPanel.svelte consumer
+    // boundary. The `AudioSpectrumPanel`/`AudioSpectrumCanvas` consumer
+    // path is a numeric/animation consumer (comparison-safe), not
+    // string-formatted.
+    filterWidth: rx?.filterWidth ?? Number.NaN,
     filterWidthMax,
     pbtInner: rx?.pbtInner ?? 128,
     pbtOuter: rx?.pbtOuter ?? 128,
@@ -908,9 +955,14 @@ export function toMemoryPanelProps(
 ): MemoryPanelProps {
   const rx = state ? activeRx(state) : null;
   const receiverKey = state?.active === 'SUB' ? 'sub' : 'main';
+  // MOR-1409 A12: no fabricated 0 Hz / empty-string stand-ins for an
+  // unobserved active receiver. Same `NaN`/`'---'` non-fabricating-sentinel
+  // convention `toVfoProps`/`toFilterProps` already use for the same
+  // field shapes — `MemoryPanel.svelte`'s "store VFO → channel" action only
+  // reads these on an explicit user click, never during initial render.
   return {
-    activeFreqHz: rx?.freqHz ?? 0,
-    activeMode: rx?.mode ?? '',
+    activeFreqHz: rx?.freqHz ?? Number.NaN,
+    activeMode: rx?.mode ?? '---',
     vfoIdentityKnown: !relativeVfoIdentityUnknown(state, caps, receiverKey),
   };
 }


### PR DESCRIPTION
Part of #2317

## MOR-1409 gate A12 (projection batch B + consumer boundaries)

Per the session-15 re-anchor plan (SHA-256 `99331e9b…`) with the expanded mandate from [5245697359](https://github.com/rigplane/rigplane-core/issues/2317#issuecomment-5245697359); consumer-boundary matrix method per the A11 lesson. Light-tier evidence per [5243153469](https://github.com/rigplane/rigplane-core/issues/2317#issuecomment-5243153469).

- `frontend/src/lib/runtime/props/panel-props.ts` (+92/−40) — batch-B honest projections: `toRitXitProps`, `toModeProps.modes` (invented 10-mode catalog removed), `toCwProps` (`keyerType` deleted), `toMeterProps`, `toRxAudioProps.afLevel`, `toScanProps`, `toMemoryPanelProps`, and the deferred `filterWidth` twins (`toFilterProps` + `toAudioSpectrumProps`) now render `NaN`/`'---'`/`[]` instead of fabricated defaults.
- `frontend/src/components-v2/panels/FilterPanel.svelte` (+15/−1) — `Number.isFinite` guard in local `formatWidthDisplay` (`'--- Hz'`), the `:38` `['FIL1','FIL2','FIL3']` re-fabrication removed, missing modal `displayFn` added.
- `radio-view-model-adapter.ts`, `panel-adapters.ts` — hash-confirmed untouched (matched plan prediction).

Matrix-row resolutions: `toMeterProps` has zero live consumers (unit-pinned); ScanPanel/MemoryPanel are desktop-reachable but comparison/click-handler-only consumers (golden-safe); ModePanel plan-caveat corrected by live trace (fallback path never fires under fixtured goldens). Explicit documented non-fixes pinned in the static scan: `toTxProps` family (TxPanel's unguarded `displayFn` would render "NaN%" — TxPanel is not an owner), the `boolean`-typed active flags, `contourFreq` placeholder, `toCwProps`' internal `'USB'` gate.

Production churn 148 (< 391 STOP). Head `57770b4d536114d8929f7499e7b35cc87f757472`, base `ff999602e14533c48e2f292e97a28f71362d1d65`.

## Evidence (once-through, no retry-to-green)

- Causal RED at exact base: 10/67 + 5/37 + 28/51 substantive failures across the three suites
- Mutation battery: 9/9 applicable killed (2 N/A per documented non-fix decisions), byte-exact restores verified
- Focused GREEN: 245/245; full suite 6538/6538 (one earlier run hit the known field-status mock leak, attributed standalone + fresh exact-base worktree)
- svelte-check/tsc, eslint, boundaries: clean; goldens and frozen seams byte-identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)