### PR TITLE
refactor(#2317): migrate mobile layout to canonical intent handlers (A13a)

### DIFF
--- a/frontend/src/components-v2/layout/MobileRadioLayout.svelte
+++ b/frontend/src/components-v2/layout/MobileRadioLayout.svelte
@@ -39,18 +39,21 @@
   } from './vfo-layout-tokens';
   import { getTxPermit } from '$lib/utils/tx-permit';
   import { getStepsForMode, formatStep, formatSValue, formatDbm, formatPower } from './mobile-layout-logic';
+  // MOR-1409 A13a: reads come from the A11/A12-hardened canonical projections
+  // and commands from the sanctioned adapter layer. The retired state-adapter
+  // twin under components-v2 is the stale side of a 15-of-15 divergence (it
+  // still fabricates 14.074 MHz / USB / FIL1 / a zero-meter reading for an
+  // unobserved rig), and the command-bus shim beside it is the
+  // identity-preserving re-export A15 deletes once its production importer
+  // count reaches zero.
   import {
     toVfoProps, toVfoOpsProps, toMeterProps,
     toRfFrontEndProps, toModeProps, toFilterProps, toAgcProps, toRitXitProps,
     toBandSelectorProps, toRxAudioProps, toDspProps, toTxProps, toCwProps, toAntennaProps, toScanProps,
-  } from '../wiring/state-adapter';
+  } from '$lib/runtime/props/panel-props';
   import {
-    makeVfoHandlers, makeKeyboardHandlers,
-    makeRfFrontEndHandlers, makeModeHandlers, makeFilterHandlers,
-    makeAgcHandlers, makeRitXitHandlers, makeBandHandlers, makePresetHandlers,
-    makeRxAudioHandlers, makeDspHandlers, makeTxHandlers, makeCwPanelHandlers,
-    makeAntennaHandlers, makeScanHandlers,
-  } from '../wiring/command-bus';
+    bindSemanticSurfaceHandlers, getPresetHandlers, getKeyboardHandlers,
+  } from '$lib/runtime/adapters/panel-adapters';
   import { getKeyboardConfig } from '$lib/stores/capabilities.svelte';
   import { getAppTxController } from '$lib/runtime/tx-controller/app-host';
   import { createMobilePttSurface, type MobilePttBinding } from '../wiring/mobile-ptt-surface';
@@ -67,11 +70,15 @@
   let mainVfo = $derived(toVfoProps(radioState, 'main'));
   let subVfo = $derived(toVfoProps(radioState, 'sub'));
   let vfoOps = $derived(toVfoOpsProps(radioState, caps));
-  let meter = $derived(toMeterProps(radioState));
+  let meter = $derived(toMeterProps(radioState, caps));
   let mode = $derived(toModeProps(radioState, caps));
   let filter = $derived(toFilterProps(radioState, caps));
   let band = $derived(toBandSelectorProps(radioState));
-  let rxAudio = $derived(toRxAudioProps(radioState, caps, audioState));
+  // The canonical projection takes a fourth argument the stale twin does not:
+  // audio-WS link health. Sourced from the same live getter the sanctioned
+  // `lib/runtime/adapters/audio-adapter.ts` uses — never a literal, which
+  // would re-introduce exactly the fabricated truth this gate removes.
+  let rxAudio = $derived(toRxAudioProps(radioState, caps, audioState, runtime.connectionAudio));
   let tx = $derived(toTxProps(radioState, caps));
   let rfFrontEnd = $derived(toRfFrontEndProps(radioState, caps));
   let agc = $derived(toAgcProps(radioState, caps));
@@ -82,21 +89,27 @@
   let scan = $derived(toScanProps(radioState));
 
   // ── Handlers ──
-  const vfoHandlers = makeVfoHandlers();
-  const keyboardHandlers = makeKeyboardHandlers();
-  const modeHandlers = makeModeHandlers();
-  const filterHandlers = makeFilterHandlers();
-  const bandHandlers = makeBandHandlers();
-  const presetHandlers = makePresetHandlers();
-  const rxAudioHandlers = makeRxAudioHandlers();
-  const txHandlers = makeTxHandlers();
-  const rfHandlers = makeRfFrontEndHandlers();
-  const agcHandlers = makeAgcHandlers();
-  const ritXitHandlers = makeRitXitHandlers();
-  const dspHandlers = makeDspHandlers();
-  const cwHandlers = makeCwPanelHandlers();
-  const antennaHandlers = makeAntennaHandlers();
-  const scanHandlers = makeScanHandlers();
+  // One binder call per mounted composition root (the A07 convention): it
+  // mints fresh family objects, matching the init-time `make*Handlers()`
+  // semantics this replaces, and filter handlers retain per-instance debounce
+  // state that a shared singleton would leak between mounts. `preset` and
+  // `keyboard` are not binder members, so they come from their accessors.
+  const surfaceHandlers = bindSemanticSurfaceHandlers();
+  const vfoHandlers = surfaceHandlers.vfo;
+  const keyboardHandlers = getKeyboardHandlers();
+  const modeHandlers = surfaceHandlers.mode;
+  const filterHandlers = surfaceHandlers.filter;
+  const bandHandlers = surfaceHandlers.band;
+  const presetHandlers = getPresetHandlers();
+  const rxAudioHandlers = surfaceHandlers.rxAudio;
+  const txHandlers = surfaceHandlers.tx;
+  const rfHandlers = surfaceHandlers.rfFrontEnd;
+  const agcHandlers = surfaceHandlers.agc;
+  const ritXitHandlers = surfaceHandlers.ritXit;
+  const dspHandlers = surfaceHandlers.dsp;
+  const cwHandlers = surfaceHandlers.cw;
+  const antennaHandlers = surfaceHandlers.antenna;
+  const scanHandlers = surfaceHandlers.scan;
 
   // ── VFO layout ──
   let receiverDeckElement = $state<HTMLElement | null>(null);
@@ -450,6 +463,37 @@
 
   // ── ATU status ──
   let atuStatus = $derived(tx.atuActive ? (tx.atuTuning ? 'tuning' : 'on') : 'off');
+
+  // ── Display-honesty guards (MOR-1409 A13a) ──
+  // The canonical meter projection reports `NaN` for a receiver that has
+  // never been read, where the retired twin fabricated a zero reading — a
+  // full-scale "S9" / "-73 dBm" for an operator no one has observed.
+  // `formatSValue`/`formatDbm` have no non-finite branch (`Math.min/max`
+  // propagate `NaN` straight into the template literal), so they render
+  // "S NaN" / "NaN dBm" — the same defect class that BLOCKED PR #2363.
+  // These are their ONLY production consumers, so per the single-consumer
+  // test the guards live here and `mobile-layout-logic.ts` stays untouched.
+  // Placeholders follow the established '---' segment convention.
+  function formatSValueDisplay(actual: number): string {
+    return Number.isFinite(actual) ? formatSValue(actual) : '---';
+  }
+  function formatDbmDisplay(actual: number): string {
+    return Number.isFinite(actual) ? formatDbm(actual) : '--- dBm';
+  }
+  // RIT/XIT share one offset field; an active RIT whose offset has never been
+  // reported must not render "+NaN".
+  function formatOffsetDisplay(hz: number): string {
+    return Number.isFinite(hz) ? `${hz >= 0 ? '+' : ''}${hz}` : '---';
+  }
+  // The TX dock meter takes raw numbers and formats all four rows itself
+  // (`formatPowerWatts`/`formatSwr`/`formatAlc` each render "NaN"-class
+  // strings). It is not an owner of this gate, and there is no honest finite
+  // value to substitute — a fabricated "SWR 1.0" on a live TX surface is
+  // worse than no reading at all — so the row is withheld until the meters
+  // are actually observed, which is one poll away.
+  let txMetersObserved = $derived(
+    Number.isFinite(meter.rfPower) && Number.isFinite(meter.swr) && Number.isFinite(meter.alc)
+  );
 </script>
 
 {#if isLandscape}
@@ -480,8 +524,8 @@
       {/each}
     </div>
     <div class="m-ls-meter">
-      <span class="m-ls-smeter">{formatSValue(meter.signal)}</span>
-      <span class="m-ls-dbm">{formatDbm(meter.signal)}</span>
+      <span class="m-ls-smeter">{formatSValueDisplay(meter.signal)}</span>
+      <span class="m-ls-dbm">{formatDbmDisplay(meter.signal)}</span>
     </div>
     <div class="m-ls-controls">
       <button class="m-ls-step-btn" onclick={() => (stepPickerOpen = !stepPickerOpen)}>
@@ -580,11 +624,11 @@
       {/if}
       {#if ritXit.ritActive}
         <span class="m-vfo-rit" title="RIT offset">
-          RIT {ritXit.ritOffset >= 0 ? '+' : ''}{ritXit.ritOffset}
+          RIT {formatOffsetDisplay(ritXit.ritOffset)}
         </span>
       {:else if ritXit.xitActive}
         <span class="m-vfo-rit" title="XIT offset">
-          XIT {ritXit.xitOffset >= 0 ? '+' : ''}{ritXit.xitOffset}
+          XIT {formatOffsetDisplay(ritXit.xitOffset)}
         </span>
       {/if}
     </div>
@@ -716,13 +760,13 @@
             <!-- Inline PTT button removed (#840) — PttFab at bottom-right
                  is the persistent, guarded TX affordance. -->
           </div>
-          {#if tx.txActive || txKeyed}
+          {#if (tx.txActive || txKeyed) && txMetersObserved}
             <div class="m-tx-meter">
               <DockMeterPanel
                 sValue={mainVfo.sValue}
-                rfPower={meter.rfPower ?? 0}
+                rfPower={meter.rfPower}
                 swr={meter.swr}
-                alc={meter.alc ?? 0}
+                alc={meter.alc}
                 txActive={true}
                 meterSource={mobileMeterSource}
                 onMeterSourceChange={selectMobileMeterSource}

--- a/frontend/src/components-v2/layout/__tests__/MobileRadioLayout.component.svelte.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/MobileRadioLayout.component.svelte.test.ts
@@ -125,8 +125,12 @@ const {
   onSubVfoClickSpy: vi.fn(),
   radioIntentSpy: vi.fn(),
 }));
-vi.mock('../../wiring/command-bus', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../../wiring/command-bus')>();
+// MOR-1409 A13a: the layout now binds its handler families through
+// `lib/runtime/adapters/panel-adapters`, so this fixture re-points one level
+// down at the command module both the adapter and the retired shim re-export.
+// Reference re-point only — every fake below is unchanged.
+vi.mock('$lib/runtime/commands/panel-commands', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('$lib/runtime/commands/panel-commands')>();
   const n = radioIntentSpy;
   return {
     ...actual,
@@ -178,9 +182,16 @@ vi.mock('$lib/runtime/tx-controller/app-host', () => ({
   getAppTxController: () => txHost.current,
 }));
 
-vi.mock('../wiring/state-adapter', () => {
+// MOR-1409 A13a: the layout reads the canonical projections now. This fixture
+// keeps its own fabricated values on purpose — the honesty behaviour of the
+// real projections is pinned by `MobileRadioLayout.honesty.isolated.test.ts`;
+// what this suite covers (chip IA, PTT, receiver pills, meter selection) needs
+// a populated rig, not an unobserved one. Reference re-point only.
+vi.mock('$lib/runtime/props/panel-props', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('$lib/runtime/props/panel-props')>();
   const vfo = { freq: 14074000, mode: 'USB', filter: 'FIL1', sValue: 0, badges: {}, receiver: 'main', isActive: true };
   return {
+    ...actual,
     toVfoProps: vi.fn(() => vfo), toVfoOpsProps: vi.fn(() => ({ split: false, dualWatch: false })),
     toMeterProps: vi.fn(() => ({ signal: 0, rfPower: 0, swr: 0, alc: 0, txActive: false, meterSource: 'S' })),
     toModeProps: vi.fn(() => ({ currentMode: 'USB', modes: ['USB', 'LSB', 'CW', 'AM', 'FM'], dataMode: 0 })),

--- a/frontend/src/components-v2/layout/__tests__/MobileRadioLayout.honesty.isolated.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/MobileRadioLayout.honesty.isolated.test.ts
@@ -1,0 +1,319 @@
+/**
+ * MOR-1409 A13a — MobileRadioLayout command-bus + projection migration.
+ *
+ * This gate re-points the mobile skin's 15 command-bus handler imports at the
+ * sanctioned adapter layer (`lib/runtime/adapters/panel-adapters.ts`) and its
+ * 16 read projections at the A11/A12-hardened
+ * `lib/runtime/props/panel-props.ts`.
+ *
+ * The read half is NOT a mechanical import swap: all 15 projection functions
+ * shared with `components-v2/wiring/state-adapter.ts` have diverged, because
+ * A11 and A12 hardened only `panel-props`. Migrating therefore imports the
+ * whole honesty change into a shipped skin at once, and every direct-render
+ * boundary in this layout has to be shown safe against `NaN` / `'---'`.
+ *
+ * Two rendered boundaries were live-traced as unsafe and are guarded inside
+ * this layout (it is their only production consumer, so per the 5246487510
+ * single-consumer test `mobile-layout-logic.ts` stays byte-identical):
+ * `formatSValue(meter.signal)` renders "S NaN"-class strings and
+ * `formatDbm(meter.signal)` renders the literal "NaN dBm".
+ *
+ * Each test names the mutation it exists to kill.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { mount, unmount, flushSync } from 'svelte';
+
+// ── Child components irrelevant to the read-boundary contract ──────────────
+vi.mock('../../../components/spectrum/SpectrumPanel.svelte', async () => {
+  const stub = await import('./SpectrumPanelStub.svelte');
+  return { default: stub.default };
+});
+vi.mock('../panels/lcd/AmberLcdDisplay.svelte', () => ({ default: function S() { return {}; } }));
+vi.mock('../display/FrequencyDisplay.svelte', () => ({ default: function S() { return {}; } }));
+vi.mock('../meters/LinearSMeter.svelte', () => ({ default: function S() { return {}; } }));
+vi.mock('../controls/CollapsiblePanel.svelte', () => ({ default: function S() { return {}; } }));
+vi.mock('../controls/BottomSheet.svelte', () => ({ default: function S() { return {}; } }));
+vi.mock('../controls/BandSelector.svelte', () => ({ default: function S() { return {}; } }));
+vi.mock('../controls/PttFab.svelte', () => ({ default: function S() { return {}; } }));
+vi.mock('../panels/FilterPanel.svelte', () => ({ default: function S() { return {}; } }));
+vi.mock('../panels/RxAudioPanel.svelte', () => ({ default: function S() { return {}; } }));
+vi.mock('../panels/TxPanel.svelte', () => ({ default: function S() { return {}; } }));
+vi.mock('../panels/DspPanel.svelte', () => ({ default: function S() { return {}; } }));
+vi.mock('../panels/AgcPanel.svelte', () => ({ default: function S() { return {}; } }));
+vi.mock('../panels/RfFrontEnd.svelte', () => ({ default: function S() { return {}; } }));
+vi.mock('../panels/RitXitPanel.svelte', () => ({ default: function S() { return {}; } }));
+vi.mock('../panels/AntennaPanel.svelte', () => ({ default: function S() { return {}; } }));
+vi.mock('../panels/ScanPanel.svelte', () => ({ default: function S() { return {}; } }));
+vi.mock('../panels/CwPanel.svelte', () => ({ default: function S() { return {}; } }));
+vi.mock('../panels/DockMeterPanel.svelte', () => ({ default: function S() { return {}; } }));
+vi.mock('../panels/EssentialsPanel.svelte', () => ({ default: function S() { return {}; } }));
+vi.mock('../panels/ModInputTxWarning.svelte', () => ({ default: function S() { return {}; } }));
+vi.mock('../wiring/SemanticRadioSurfaces.svelte', () => ({ default: function S() { return {}; } }));
+vi.mock('./mobile-chip-bar.svelte', () => ({ default: function S() { return {}; } }));
+vi.mock('./KeyboardHandler.svelte', () => ({ default: function S() { return {}; } }));
+vi.mock('$lib/Button', () => ({ HardwareButton: function S() { return {}; } }));
+vi.mock('lucide-svelte', () => {
+  const S = function () { return {}; };
+  return {
+    Settings: S, ChevronLeft: S, ChevronRight: S, ChevronsLeft: S, ChevronsRight: S,
+    Sliders: S, Radio: S, Mic: S, MicOff: S,
+  };
+});
+vi.mock('../controls/value-control', () => ({
+  ValueControl: function S() { return {}; },
+  normalizedPercentDisplay: (v: number) => `${Math.round(v * 100)}%`,
+}));
+vi.mock('./vfo-layout-tokens', () => ({
+  resolveVfoLayoutProfile: vi.fn(() => 'standard'),
+  vfoLayoutStyleVars: vi.fn(() => ''),
+}));
+
+// ── Stores: a connected radio that has reported nothing yet ────────────────
+// The layout's projections must be honest about that, not fabricate a
+// 14.074 MHz / USB / FIL1 / S0 / -73 dBm operator out of thin air.
+const radioStore = vi.hoisted(() => ({ current: null as Record<string, unknown> | null }));
+vi.mock('$lib/stores/radio.svelte', () => ({
+  radio: radioStore,
+  getActiveReceiver: vi.fn(),
+  getRadioState: vi.fn(() => radioStore.current),
+  subscribeRadioState: vi.fn(() => () => {}),
+}));
+vi.mock('$lib/stores/connection.svelte', () => ({
+  getConnectionStatus: vi.fn(() => 'connected'),
+  getRadioPowerOn: vi.fn(() => null),
+  getHttpConnected: vi.fn(() => true),
+  getWsConnected: vi.fn(() => true),
+  isStale: vi.fn(() => false),
+  isReconnecting: vi.fn(() => false),
+  getRadioStatus: vi.fn(() => 'ok'),
+  isAudioConnected: vi.fn(() => false),
+}));
+vi.mock('$lib/stores/audio.svelte', () => ({
+  getAudioState: vi.fn(() => ({
+    volume: 50, muted: false, rxEnabled: false, txEnabled: false,
+    micEnabled: false, bridgeRunning: false,
+  })),
+}));
+vi.mock('$lib/audio/audio-manager', () => ({
+  audioManager: { start: vi.fn(), stop: vi.fn(), setVolume: vi.fn(), toggleMute: vi.fn() },
+}));
+vi.mock('$lib/stores/capabilities.svelte', () => ({
+  hasTx: vi.fn(() => true), hasDualReceiver: vi.fn(() => false), hasAnyScope: vi.fn(() => false),
+  hasSpectrum: vi.fn(() => false), getCapabilities: vi.fn(() => null),
+  getKeyboardConfig: vi.fn(() => null), hasCapability: vi.fn(() => false),
+  receiverLabel: vi.fn((id: 'MAIN' | 'SUB') => id),
+  hasAudioFft: vi.fn(() => false),
+  getMeterCalibration: vi.fn(() => null), getMeterRedline: vi.fn(() => null),
+  getSmeterCalibration: vi.fn(() => null), getSmeterRedline: vi.fn(() => null),
+}));
+
+// The TX controller is not what this suite is about — a flat idle facade keeps
+// the layout mountable without pulling in the real state machine.
+vi.mock('$lib/runtime/tx-controller/app-host', () => ({
+  getAppTxController: () => ({
+    snapshot: () => ({ guard: null, intent: 'idle', radioTx: 'off' }),
+    subscribe: () => () => {},
+  }),
+}));
+
+import MobileRadioLayout from '../MobileRadioLayout.svelte';
+import mobileLayoutSource from '../MobileRadioLayout.svelte?raw';
+
+const LAYOUT_DIR = 'src/components-v2/layout/';
+
+let host: HTMLElement | null = null;
+let instance: Record<string, unknown> | null = null;
+
+function mountLayout(): HTMLElement {
+  host = document.createElement('div');
+  document.body.appendChild(host);
+  instance = mount(MobileRadioLayout, { target: host });
+  flushSync();
+  return host;
+}
+
+const originalWidth = window.innerWidth;
+const originalHeight = window.innerHeight;
+
+function setViewport(width: number, height: number): void {
+  Object.defineProperty(window, 'innerWidth', { value: width, configurable: true, writable: true });
+  Object.defineProperty(window, 'innerHeight', { value: height, configurable: true, writable: true });
+}
+
+beforeEach(() => {
+  setViewport(390, 844);
+  radioStore.current = null;
+});
+
+afterEach(() => {
+  if (instance) unmount(instance);
+  instance = null;
+  if (host) host.remove();
+  host = null;
+  setViewport(originalWidth, originalHeight);
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Static closure: the layout consumes the canonical modules only
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('MobileRadioLayout canonical module surface (MOR-1409 A13a)', () => {
+  // Kills: re-pointing any projection back at `components-v2/wiring/state-adapter`.
+  it('imports no projection from the legacy wiring state-adapter', () => {
+    expect(mobileLayoutSource).not.toContain('wiring/state-adapter');
+  });
+
+  // Kills: leaving any handler family on the `wiring/command-bus` shim, whose
+  // production importer count must reach zero for A15's deletion clause.
+  it('imports no handler family from the legacy command-bus shim', () => {
+    expect(mobileLayoutSource).not.toContain('wiring/command-bus');
+  });
+
+  // Kills: bypassing the adapter layer by importing the command module directly.
+  it('does not reach into lib/runtime/commands directly', () => {
+    expect(mobileLayoutSource).not.toContain('runtime/commands/panel-commands');
+  });
+
+  it('reads its projections from the hardened panel-props module', () => {
+    expect(mobileLayoutSource).toContain('$lib/runtime/props/panel-props');
+  });
+
+  it('binds its handlers through the sanctioned panel-adapters layer', () => {
+    expect(mobileLayoutSource).toContain('$lib/runtime/adapters/panel-adapters');
+  });
+
+  // Kills: calling `bindSemanticSurfaceHandlers()` more than once — the A07
+  // convention, since each call mints fresh per-instance debounce state.
+  it('calls the semantic surface binder exactly once', () => {
+    const calls = mobileLayoutSource.match(/bindSemanticSurfaceHandlers\(\)/g) ?? [];
+    expect(calls).toHaveLength(1);
+  });
+
+  // Kills: passing a literal for `toRxAudioProps`' fourth argument. The honest
+  // source is the same one `lib/runtime/adapters/audio-adapter.ts:18` uses.
+  it('sources toRxAudioProps audioConnected from live connection state', () => {
+    const call = mobileLayoutSource.match(/toRxAudioProps\([^)]*\)/)?.[0] ?? '';
+    expect(call).toContain('runtime.connectionAudio');
+    expect(call).not.toMatch(/,\s*(true|false)\s*\)/);
+  });
+
+  // Kills: absorbing the display guards into `mobile-layout-logic.ts`, which is
+  // a single-consumer helper module and therefore NOT an owner of this gate
+  // (correction 5246842617 §8, applying the 5246487510 single-consumer test).
+  it('leaves mobile-layout-logic.ts byte-identical', () => {
+    const bytes = readFileSync(`${LAYOUT_DIR}mobile-layout-logic.ts`);
+    expect(createHash('sha256').update(bytes).digest('hex')).toBe(
+      'db0062b97d7c33c3c12a91da5cf367e03343810d24957da0777941e226f1cd5a',
+    );
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Consumer boundaries: honest projections must not render as garbage
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('MobileRadioLayout honest-projection rendering (MOR-1409 A13a)', () => {
+  // Kills: dropping the finite guard from the landscape S-meter readout —
+  // `formatSValue(NaN)` returns the literal `S${NaN}`. This is the "NaNkHz"
+  // defect class that BLOCKED PR #2363, reproduced on the mobile skin.
+  it('guards the landscape S-meter readout against an unobserved signal', () => {
+    setViewport(844, 390);
+    const readout = mountLayout().querySelector('.m-ls-smeter')?.textContent ?? '';
+    expect(readout).not.toContain('NaN');
+    // `formatSValue(0)` — the state-adapter's fabricated zero-signal reading —
+    // renders a full-scale "S9" for a receiver that has reported nothing.
+    expect(readout).not.toBe('S9');
+    expect(readout).toContain('---');
+  });
+
+  // Kills: dropping the finite guard from the landscape dBm readout —
+  // `formatDbm(NaN)` renders the literal "NaN dBm".
+  it('guards the landscape dBm readout against an unobserved signal', () => {
+    setViewport(844, 390);
+    const readout = mountLayout().querySelector('.m-ls-dbm')?.textContent ?? '';
+    expect(readout).not.toContain('NaN');
+    expect(readout).not.toBe('-73 dBm');
+    expect(readout).toContain('---');
+  });
+
+  // Kills: restoring `toVfoProps`' fabricated 'USB' / 'FIL1' stand-ins by
+  // re-pointing the VFO projection at the stale state-adapter twin.
+  it('shows placeholder mode and filter labels, not fabricated USB / FIL1', () => {
+    const root = mountLayout();
+    expect(root.querySelector('.m-vfo-mode')?.textContent).toBe('---');
+    expect(root.querySelector('.m-vfo-filter')?.textContent).toBe('---');
+  });
+
+  // Kills: any guard that leaks "NaN" through a different portrait boundary —
+  // the portrait deck is where the idle mobile screen actually lives.
+  it('renders no "NaN" substring anywhere in portrait with nothing observed', () => {
+    const text = mountLayout().textContent ?? '';
+    expect(text).not.toContain('NaN');
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Connected-but-this-field-pending: the second variant every family needs.
+// A capability gate answers "does the rig support this", never "has this been
+// observed" — so each of these mounts a CONNECTED radio that has simply not
+// reported the field in question.
+// ───────────────────────────────────────────────────────────────────────────
+
+const CONNECTED_RX = {
+  freqHz: 14074000, mode: 'USB', filter: 1, sMeter: 12,
+  att: 0, preamp: 0, nb: false, nr: false,
+};
+
+describe('MobileRadioLayout pending-field boundaries (MOR-1409 A13a)', () => {
+  // Kills: dropping the RIT-offset guard. `toRitXitProps` reports `NaN` for an
+  // active RIT whose offset has never been sent, and the raw
+  // `offset >= 0 ? '+' : ''` template renders "NaN" for it.
+  it('guards the RIT offset badge when the offset has not been observed', () => {
+    radioStore.current = { active: 'MAIN', main: CONNECTED_RX, ritOn: true };
+    const badge = mountLayout().querySelector('.m-vfo-rit')?.textContent ?? '';
+    expect(badge).toContain('RIT');
+    expect(badge).not.toContain('NaN');
+    expect(badge).toContain('---');
+  });
+
+  // Kills: dropping the same guard on the XIT branch.
+  it('guards the XIT offset badge when the offset has not been observed', () => {
+    radioStore.current = { active: 'MAIN', main: CONNECTED_RX, ritTx: true };
+    const badge = mountLayout().querySelector('.m-vfo-rit')?.textContent ?? '';
+    expect(badge).toContain('XIT');
+    expect(badge).not.toContain('NaN');
+    expect(badge).toContain('---');
+  });
+
+  // Kills: removing the `txMetersObserved` gate on the TX dock meter. The
+  // panel formats all four rows itself and has no non-finite branch, so an
+  // ungated mount renders "NaNW" / "NaN" SWR / "NaN%" on a live TX surface.
+  it('withholds the TX dock meter while its readings are unobserved', () => {
+    radioStore.current = { active: 'MAIN', main: CONNECTED_RX, ptt: true };
+    const root = mountLayout();
+    const txChip = Array.from(root.querySelectorAll<HTMLButtonElement>('button'))
+      .find((b) => b.textContent?.trim() === 'TX');
+    txChip?.click();
+    flushSync();
+    expect(root.querySelector('.m-tx-meter')).toBeNull();
+    expect(root.textContent ?? '').not.toContain('NaN');
+  });
+
+  // Kills: a gate so broad it hides the meter for a rig that IS reporting —
+  // the readings must come back the moment they are observed.
+  it('renders the TX dock meter once its readings are observed', () => {
+    radioStore.current = {
+      active: 'MAIN', main: CONNECTED_RX, ptt: true,
+      powerMeter: 120, swrMeter: 30, alcMeter: 40,
+    };
+    const root = mountLayout();
+    const txChip = Array.from(root.querySelectorAll<HTMLButtonElement>('button'))
+      .find((b) => b.textContent?.trim() === 'TX');
+    txChip?.click();
+    flushSync();
+    expect(root.querySelector('.m-tx-meter')).not.toBeNull();
+    expect(root.textContent ?? '').not.toContain('NaN');
+  });
+});

--- a/frontend/src/components-v2/panels/EssentialsPanel.svelte
+++ b/frontend/src/components-v2/panels/EssentialsPanel.svelte
@@ -47,6 +47,18 @@
     onNrModeChange,
     onNotchModeChange,
   }: Props = $props();
+
+  // MOR-1409 A13a display-honesty guard (grant 5246842617 §3, in the
+  // 5246487510 shape — guards only, no other change to this file).
+  // `MobileRadioLayout` now feeds this panel the canonical RX-audio
+  // projection, which reports `Number.NaN` for an AF level the radio has
+  // never sent. `normalizedPercentDisplay` has no non-finite branch —
+  // `Math.round(Math.max(0, Math.min(1, NaN)) * 100)` is `NaN` — so the
+  // readout would render the literal "NaN%" on the default-active mobile
+  // chip. Same shape as `RxAudioPanel.svelte`'s guard for this exact field.
+  function formatAfLevelDisplay(v: number): string {
+    return Number.isFinite(v) ? normalizedPercentDisplay(v) : '--- %';
+  }
 </script>
 
 <div class="m-essentials">
@@ -124,7 +136,7 @@
     max={1}
     step={0.01}
     renderer="hbar"
-    displayFn={normalizedPercentDisplay}
+    displayFn={formatAfLevelDisplay}
     accentColor="var(--v2-accent-cyan-alt)"
     onChange={onAfLevelChange}
     variant="hardware-illuminated"

--- a/frontend/src/components-v2/panels/__tests__/EssentialsPanel.honesty.isolated.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/EssentialsPanel.honesty.isolated.test.ts
@@ -1,0 +1,101 @@
+/**
+ * MOR-1409 A13a — ESSENTIALS display-honesty boundary.
+ *
+ * `MobileRadioLayout.svelte` migrates its RX-audio projection from
+ * `components-v2/wiring/state-adapter.ts` (which fabricates `afLevel` as
+ * `rx?.afLevel ?? 0.5`) to the A11/A12-hardened
+ * `lib/runtime/props/panel-props.ts`, which returns `Number.NaN` for an
+ * unobserved AF level in local-monitor mode.
+ *
+ * `EssentialsPanel` renders that number through `normalizedPercentDisplay`,
+ * whose `Math.round(Math.max(0, Math.min(1, NaN)) * 100)` is `NaN` — the
+ * rendered string becomes the literal "NaN%". That is the same
+ * formatted-display defect class that BLOCKED PR #2363 ("NaNkHz") and that
+ * `RxAudioPanel.svelte:31-33` already guards for this exact field.
+ *
+ * This panel is A13a's one granted display-honesty guard owner
+ * (correction 5246842617 §3, in the 5246487510 shape): its AF readout is
+ * rendered unconditionally, so no guard placed inside `MobileRadioLayout`
+ * can reach it without re-fabricating a number.
+ *
+ * Each test names the mutation it kills.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { mount, unmount } from 'svelte';
+import type { ComponentProps } from 'svelte';
+import EssentialsPanel from '../EssentialsPanel.svelte';
+
+const noop = () => {};
+
+function baseProps(afLevel: number): ComponentProps<typeof EssentialsPanel> {
+  return {
+    vfoOps: { splitActive: false },
+    mode: { currentMode: '---', modes: [] },
+    filter: { currentFilter: 1, filterLabels: [] },
+    rxAudio: { monitorMode: 'local', afLevel },
+    dsp: { nbActive: false, nrMode: 0, notchMode: 'off' },
+    quickModes: [],
+    onSplitToggle: noop,
+    onSwap: noop,
+    onEqual: noop,
+    onModeChange: noop,
+    onModeMore: noop,
+    onFilterChange: noop,
+    onFilterMore: noop,
+    onMonitorModeChange: noop,
+    onAfLevelChange: noop,
+    onNbToggle: noop,
+    onNrModeChange: noop,
+    onNotchModeChange: noop,
+  };
+}
+
+let host: HTMLElement | null = null;
+let instance: Record<string, unknown> | null = null;
+
+function render(afLevel: number): HTMLElement {
+  host = document.createElement('div');
+  document.body.appendChild(host);
+  instance = mount(EssentialsPanel, { target: host, props: baseProps(afLevel) });
+  return host;
+}
+
+afterEach(() => {
+  if (instance) unmount(instance);
+  instance = null;
+  if (host) host.remove();
+  host = null;
+});
+
+describe('EssentialsPanel AF-level display honesty (MOR-1409 A13a)', () => {
+  // Kills: dropping the `Number.isFinite` guard from `formatAfLevelDisplay`
+  // (mutation battery #4-equivalent for this consumer).
+  it('never renders a "NaN" substring for an unobserved AF level', () => {
+    const text = render(Number.NaN).textContent ?? '';
+    expect(text).not.toContain('NaN');
+  });
+
+  // Kills: substituting a fabricated finite fallback (e.g. `?? 0` / `?? 0.5`)
+  // instead of the established '---' placeholder convention.
+  it('renders the established placeholder for an unobserved AF level', () => {
+    const text = render(Number.NaN).textContent ?? '';
+    expect(text).toContain('---');
+    expect(text).not.toContain('0%');
+    expect(text).not.toContain('50%');
+  });
+
+  // Kills: a guard that swallows real readings too (over-broad placeholder).
+  it('still renders a real observed AF level as a percentage', () => {
+    const text = render(0.42).textContent ?? '';
+    expect(text).toContain('42%');
+    expect(text).not.toContain('---');
+  });
+
+  // Kills: guarding only the extremes — 0 is a legitimate observed reading and
+  // must not be confused with "never observed".
+  it('renders an observed zero AF level as 0%, not as unknown', () => {
+    const text = render(0).textContent ?? '';
+    expect(text).toContain('0%');
+    expect(text).not.toContain('---');
+  });
+});

--- a/frontend/src/lib/runtime/adapters/__tests__/keyboard-system-accessors.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/keyboard-system-accessors.isolated.test.ts
@@ -1,0 +1,55 @@
+/**
+ * MOR-1409 A13a — the two missing adapter-layer handler accessors.
+ *
+ * `makeKeyboardHandlers` (needed by all three layouts) and
+ * `makeSystemHandlers` (needed by `RadioLayout`) had no sanctioned
+ * adapter-layer path at exact main `674fb8f3`: they are absent from
+ * `panel-adapters.ts` AND from `bindSemanticSurfaceHandlers()`'s frozen
+ * 16-member object. That gap — not LOC — is what fired A13's split
+ * (correction 5246842617 §2), and A13a closes it so A13b compiles on arrival.
+ *
+ * The grant is RESTRICTED: these two accessors, nothing else in the file.
+ * Each test names the mutation it kills.
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+const factories = vi.hoisted(() => ({
+  makeKeyboardHandlers: vi.fn(() => Object.freeze({ family: 'keyboard' })),
+  makeSystemHandlers: vi.fn(() => Object.freeze({ family: 'system' })),
+}));
+
+vi.mock('$lib/runtime/commands/panel-commands', async (importOriginal) => ({
+  ...await importOriginal<typeof import('$lib/runtime/commands/panel-commands')>(),
+  ...factories,
+}));
+vi.mock('$lib/runtime/frontend-runtime', () => ({
+  runtime: { get state() { return null; }, get caps() { return null; } },
+}));
+vi.mock('$lib/runtime/tx-controller/app-host', () => ({
+  getAppTxController: () => null,
+}));
+
+import { getKeyboardHandlers, getSystemHandlers } from '../panel-adapters';
+
+describe('panel-adapters keyboard/system accessors (MOR-1409 A13a)', () => {
+  // Kills: never adding the accessors — layouts would have to import the
+  // command module directly, leaving A15 a residue it is not scoped to remove.
+  it('exposes a keyboard handler accessor delegating to the command factory', () => {
+    expect(getKeyboardHandlers()).toEqual({ family: 'keyboard' });
+  });
+
+  it('exposes a system handler accessor delegating to the command factory', () => {
+    expect(getSystemHandlers()).toEqual({ family: 'system' });
+  });
+
+  // Kills: minting a fresh family object per call. Every other non-binder
+  // accessor in this module returns a module-scope singleton; keyboard and
+  // system must follow, or a layout that re-reads them would silently swap
+  // handler identity mid-life.
+  it('returns the same singleton on every call, like its 14 siblings', () => {
+    expect(getKeyboardHandlers()).toBe(getKeyboardHandlers());
+    expect(getSystemHandlers()).toBe(getSystemHandlers());
+    expect(factories.makeKeyboardHandlers).toHaveBeenCalledTimes(1);
+    expect(factories.makeSystemHandlers).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/lib/runtime/adapters/panel-adapters.ts
+++ b/frontend/src/lib/runtime/adapters/panel-adapters.ts
@@ -23,6 +23,7 @@ import {
   makeTxHandlers, makeFilterHandlers, makeBandHandlers,
   makePresetHandlers, makeAudioRoutingHandlers, makeRxAudioHandlers,
   makeVfoHandlers, makeScopeControlsHandlers, makeVoxHandlers, makeMemoryHandlers,
+  makeKeyboardHandlers, makeSystemHandlers,
 } from '../commands/panel-commands';
 import { toRadioViewModel } from './radio-view-model-adapter';
 import { getAppTxController, type AppTxController } from '../tx-controller/app-host';
@@ -145,6 +146,17 @@ export function bindSemanticSurfaceHandlers() {
     vox: makeVoxHandlers(),
   });
 }
+
+// ── Keyboard / System (MOR-1409 A13a) ──
+// These two families had no sanctioned adapter-layer path: they are absent
+// from this module AND from `bindSemanticSurfaceHandlers()`'s frozen object,
+// so the three layouts could only reach them through the `wiring/command-bus`
+// shim A15 deletes. Singletons, like every other non-binder accessor here —
+// neither family holds per-instance state.
+const _keyboardHandlers = makeKeyboardHandlers();
+export function getKeyboardHandlers() { return _keyboardHandlers; }
+const _systemHandlers = makeSystemHandlers();
+export function getSystemHandlers() { return _systemHandlers; }
 
 const _audioRoutingHandlers = makeAudioRoutingHandlers();
 export function getAudioRoutingHandlers() { return _audioRoutingHandlers; }


### PR DESCRIPTION
Part of #2317

## MOR-1409 gate A13a (mobile command-bus migration — first split leg)

Per the session-15 re-anchor plan (SHA-256 `208736cc…`) and the published split correction [5246842617](https://github.com/rigplane/rigplane-core/issues/2317#issuecomment-5246842617). FULL-CEREMONY gate per [5243153469](https://github.com/rigplane/rigplane-core/issues/2317#issuecomment-5243153469) (battery runs as a separate leg alongside this verifier).

- `frontend/src/components-v2/layout/MobileRadioLayout.svelte` (+75/−31) — all 15 command-bus imports re-pointed to canonical intent handlers (single binder call + `getPresetHandlers`/`getKeyboardHandlers`); projections re-pointed from the diverged `state-adapter` twins to the hardened `panel-props` (imports the A11+A12 honesty into the mobile skin); `toMeterProps` caps arg + `toRxAudioProps` honest 4th arg (`runtime.connectionAudio`); 3 display guards + TX-dock observation gate (no fabricated SWR on a live TX surface).
- `frontend/src/lib/runtime/adapters/panel-adapters.ts` (+12/−0) — RESTRICTED grant honored: `getKeyboardHandlers()` + `getSystemHandlers()` singletons only.
- `frontend/src/components-v2/panels/EssentialsPanel.svelte` (+13/−1) — reserved guard slot activated per the §4.4 trace (AF readout renders unconditionally; guard mirrors RxAudioPanel's).

Five-component trace results: ScanPanel/AmberLcdDisplay not affected (already canonical / A14 property), LinearSMeter safe (plan §4.3 row disproven by measurement — `sValue` is `?? 0` in both projections), EssentialsPanel + DockMeterPanel guarded.

Golden-drift enumeration: reasoned prediction of ZERO drift across all 40 i18n-visual goldens (fixtures supply a fully-populated rig; landscape-only formatters never captured; guarded rows unrendered in fixture state). Desktop-root STOP condition does not fire.

Production churn 132 (< 391 STOP). Head `78792d512e79c1afcb5705ec206f20a9efa67e7a`, base `674fb8f39eccc99888bc15f964f2bc6158306e41`.

## Evidence (once-through, no retry-to-green)

- Causal RED at exact base: 14 failed / 5 passed (frozen-seam pins intentionally green)
- Mutation battery: 13/13 killed (guards, RIT/XIT branches, TX-dock gate, literal 4th arg, double binder, command-bus re-import, state-adapter re-point, accessor singletons, frozen mobile-layout-logic edit), byte-exact restores verified
- Focused GREEN: 19/19; full suite: 314 files / 6579 tests, all passed, no leak
- svelte-check 4527 files / 0 errors; eslint, boundaries, i18n clean; all frozen seams byte-identical incl. `mobile-layout-logic.ts` (pinned + test-enforced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)