### PR TITLE
refactor(#2317): migrate desktop and LCD layouts, delete runtime send facade (A13b)

### DIFF
--- a/frontend/src/__tests__/app-global-host.component.test.ts
+++ b/frontend/src/__tests__/app-global-host.component.test.ts
@@ -61,7 +61,6 @@ vi.mock('$lib/runtime', async () => {
     },
     get scope() { return { hardwareScopeConnected: false }; },
     bootstrap: h.bootstrap,
-    setPollingMultiplier: vi.fn(),
   };
   return { runtime: h.runtime };
 });

--- a/frontend/src/__tests__/lazy-presentation.component.test.ts
+++ b/frontend/src/__tests__/lazy-presentation.component.test.ts
@@ -52,7 +52,6 @@ vi.mock('../lib/runtime/frontend-runtime', () => ({
     get state() { return { stateRevision: 1, freshnessRevision: 1, observationSeq: 1, ptt: false }; },
     get caps() { return { tx: true, capabilities: ['tx'] }; },
     bootstrap: h.bootstrap,
-    setPollingMultiplier: vi.fn(),
   },
   presentationResources: {
     snapshot: (resource: string) => ({ demand: h.demand.get(resource) ?? 0 }),

--- a/frontend/src/__tests__/presentation-switch-tx.component.test.ts
+++ b/frontend/src/__tests__/presentation-switch-tx.component.test.ts
@@ -114,7 +114,6 @@ vi.mock('../lib/runtime/frontend-runtime', async () => {
       get state() { subscribe(); return h.runtimeState; },
       get caps() { subscribe(); return h.runtimeCaps; },
       bootstrap: h.bootstrap,
-      setPollingMultiplier: vi.fn(),
     },
     // Resource-demand continuity has its own dedicated proof
     // (presentation-switch-resources.component.test.ts, against the REAL

--- a/frontend/src/components-v2/layout/LcdLayout.svelte
+++ b/frontend/src/components-v2/layout/LcdLayout.svelte
@@ -28,7 +28,7 @@
   import KeyboardHandler from './KeyboardHandler.svelte';
   import StatusBar from './StatusBar.svelte';
   import SemanticRadioSurfaces from '../wiring/SemanticRadioSurfaces.svelte';
-  import { makeKeyboardHandlers } from '../wiring/command-bus';
+  import { getKeyboardHandlers } from '$lib/runtime/adapters/panel-adapters';
 
   // Twin-skin variant selector (#887). Default preserves today's behavior.
   // `scope` currently falls through to cockpit until C-PR1 (#895) delivers
@@ -42,7 +42,7 @@
   let displayMode = $derived(getLcdDisplayMode());
   let activeMode = $derived(radioState?.active === 'SUB' ? radioState?.sub?.mode : radioState?.main?.mode);
 
-  const keyboardHandlers = makeKeyboardHandlers();
+  const keyboardHandlers = getKeyboardHandlers();
 
   $effect(() => {
     if (activeMode) {

--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -14,7 +14,7 @@
   
   import { runtime } from '$lib/runtime';
   import { applyModeDefault } from '$lib/stores/tuning.svelte';
-  import { getKeyboardConfig, hasCapability, hasSpectrum } from '$lib/stores/capabilities.svelte';
+  import { getKeyboardConfig, hasSpectrum } from '$lib/stores/capabilities.svelte';
   import type { SkinId } from '../../skins/registry';
   import { declaredSurfaces, getLayout } from '../../presentation/layouts/contract';
   // Side-effect import: populates the LAYOUT registry `getLayout` resolves
@@ -40,17 +40,10 @@
     vfoLayoutStyleVars,
     type VfoLayoutScaleOverrides,
   } from './vfo-layout-tokens';
+  import { toVfoProps, toVfoOpsProps } from '$lib/runtime/props/panel-props';
   import {
-    toVfoProps, toVfoOpsProps,
-    toRfFrontEndProps, toAgcProps, toRitXitProps,
-    toBandSelectorProps, toDspProps, toCwProps,
-  } from '../wiring/state-adapter';
-  import {
-    makeKeyboardHandlers, makeVfoHandlers,
-    makeRfFrontEndHandlers, makeAgcHandlers, makeRitXitHandlers,
-    makeBandHandlers, makePresetHandlers, makeDspHandlers, makeCwPanelHandlers,
-    makeSystemHandlers,
-  } from '../wiring/command-bus';
+    getVfoHandlers, getKeyboardHandlers, getSystemHandlers,
+  } from '$lib/runtime/adapters/panel-adapters';
   import MobileRadioLayout from './MobileRadioLayout.svelte';
   import LcdLayout from './LcdLayout.svelte';
   import CollapsiblePanel from '../controls/CollapsiblePanel.svelte';
@@ -167,28 +160,19 @@
     txState.radioTx === 'on' || txState.txRisk === 'confirmed-on' || txState.txRisk === 'uncertain',
   );
 
-  // Scope digest for VfoHeader bridge (issue #832).  Gate on `scope` capability;
-  // VfoHeader treats null as "hide the block".
-  let scopeStatus = $derived.by(() => {
-    if (!hasCapability('scope')) return null;
-    const sc = (radioState as { scopeControls?: { dual?: boolean; receiver?: number; span?: number; speed?: number } } | null)?.scopeControls;
-    if (!sc) return null;
-    return {
-      dual: sc.dual ?? false,
-      receiver: sc.receiver ?? 0,
-      span: sc.span ?? 3,
-      speed: sc.speed ?? 1,
-    };
-  });
-
-  function handleScopeDualToggle(): void {
-    const current = (radioState as { scopeControls?: { dual?: boolean } } | null)?.scopeControls?.dual ?? false;
-    runtime.send('set_scope_dual', { dual: !current });
-  }
-
-  function handleScopeReceiverChange(receiver: 0 | 1): void {
-    runtime.send('switch_scope_receiver', { receiver });
-  }
+  // MOR-1409 A13b (correction 5246842617): the scope-status bridge to
+  // VfoHeader (issue #832) — a `$derived.by` digest plus two handler
+  // functions that each called the runtime's typed-facade dispatcher for
+  // 'set_scope_dual'/'switch_scope_receiver' — is deleted rather than
+  // migrated. `VfoHeader` already self-wires scope handling through its own
+  // `bindSemanticSurfaceHandlers().scopeControls` (the A07 idiom) and has
+  // ignored these exact legacy props since; see
+  // `vfo-header.isolated.test.ts`'s `VfoHeader source boundary` pin, which
+  // asserts VfoHeader's source never dereferences either optional prop.
+  // RadioLayout was the last production caller of that dispatcher; deleting
+  // this dead bridge (rather than re-pointing it at the binder for a prop
+  // VfoHeader still ignores) is what lets the dispatcher method itself
+  // delete from `frontend-runtime.ts` below.
   let keyboardConfig = $derived(getKeyboardConfig());
   let activeMode = $derived(radioState?.active === 'SUB' ? radioState?.sub?.mode : radioState?.main?.mode);
 
@@ -214,25 +198,19 @@
     overrides: manualVfoScaleOverrides,
   }));
 
-  // Derived props for settings modal
-  let rfFrontEnd = $derived(toRfFrontEndProps(radioState, caps));
-  let agc = $derived(toAgcProps(radioState, caps));
-  let ritXit = $derived(toRitXitProps(radioState, caps));
-  let band = $derived(toBandSelectorProps(radioState));
-  let dsp = $derived(toDspProps(radioState, caps));
-  let cw = $derived(toCwProps(radioState, caps));
+  // MOR-1409 A13b: `rfFrontEnd`/`agc`/`ritXit`/`band`/`dsp`/`cw` (and their
+  // matching `make*Handlers()` constructions) are removed here rather than
+  // re-pointed at the canonical modules — live inspection found none of
+  // them referenced anywhere in this file's template. `RfFrontEnd`,
+  // `AgcPanel`, `DspPanel`, `RitXitPanel`, `CwPanel`, and `BandSelector`
+  // (below) now self-source their state through the semantic surfaces;
+  // these were dead prop/handler constructions left over from before that
+  // migration.
 
-  // Command handlers via command-bus
-  const vfoHandlers = makeVfoHandlers();
-  const keyboardHandlers = makeKeyboardHandlers();
-  const rfHandlers = makeRfFrontEndHandlers();
-  const agcHandlers = makeAgcHandlers();
-  const ritXitHandlers = makeRitXitHandlers();
-  const bandHandlers = makeBandHandlers();
-  const presetHandlers = makePresetHandlers();
-  const systemHandlers = makeSystemHandlers();
-  const dspHandlers = makeDspHandlers();
-  const cwHandlers = makeCwPanelHandlers();
+  // Command handlers via the sanctioned adapter layer
+  const vfoHandlers = getVfoHandlers();
+  const keyboardHandlers = getKeyboardHandlers();
+  const systemHandlers = getSystemHandlers();
 
   // Settings modal state
   let settingsOpen = $state(false);
@@ -335,9 +313,6 @@
         onSubFreqChange={vfoHandlers.onSubFreqChange}
         onSubModeClick={vfoHandlers.onSubModeClick}
         onSpeak={systemHandlers.onSpeak}
-        {scopeStatus}
-        onScopeDualToggle={handleScopeDualToggle}
-        onScopeReceiverChange={handleScopeReceiverChange}
       />
     {/if}
   </section>

--- a/frontend/src/components-v2/layout/__tests__/LcdLayout.command-bus-migration.isolated.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/LcdLayout.command-bus-migration.isolated.test.ts
@@ -1,0 +1,184 @@
+/**
+ * MOR-1409 A13b — LcdLayout command-bus migration (correction 5246842617,
+ * the second A13 split leg).
+ *
+ * LcdLayout has exactly one command-bus import: `makeKeyboardHandlers`,
+ * wired once to `KeyboardHandler`'s `onAction`. This gate re-points it at
+ * the sanctioned `getKeyboardHandlers()` accessor A13a added to
+ * `lib/runtime/adapters/panel-adapters.ts`, closing the last layout
+ * importer of the `wiring/command-bus` shim (A15's deletion clause is
+ * satisfiable once RadioLayout/LcdLayout both migrate — see the sibling
+ * RadioLayout.command-bus-migration.isolated.test.ts for that half).
+ *
+ * Each test names the mutation it exists to kill.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount, unmount, flushSync } from 'svelte';
+
+vi.mock('../../../lib/local-extensions/LocalExtensionsHost.svelte', async () => {
+  const stub = await import('./SpectrumPanelStub.svelte');
+  return { default: stub.default };
+});
+vi.mock('$lib/stores/layout.svelte', () => ({
+  useLcdLayout: vi.fn(() => true),
+  getLayoutMode: vi.fn(() => 'lcd-cockpit'),
+  cycleLayoutMode: vi.fn(),
+  setLayoutMode: vi.fn(),
+}));
+vi.mock('$lib/stores/tuning.svelte', () => ({ applyModeDefault: vi.fn() }));
+vi.mock('$lib/stores/lcd-display-mode.svelte', () => ({
+  getLcdDisplayMode: vi.fn(() => 'clean'),
+  setLcdDisplayMode: vi.fn(),
+  LCD_DISPLAY_MODES: ['clean', 'vintage', 'crt', 'flicker'],
+}));
+vi.mock('$lib/stores/connection.svelte', () => ({
+  getConnectionStatus: vi.fn(() => ({ connected: false })),
+  getRadioPowerOn: vi.fn(() => null),
+  getRadioStatus: vi.fn(() => 'disconnected'),
+  isScopeConnected: vi.fn(() => false),
+  isAudioConnected: vi.fn(() => false),
+  getHttpConnected: vi.fn(() => false),
+  getRigConnected: vi.fn(() => false),
+  getRadioReady: vi.fn(() => false),
+  getRadioHealth: vi.fn(() => null),
+  markScopeFrame: vi.fn(),
+}));
+
+const rt = vi.hoisted(() => ({ state: null as unknown }));
+
+vi.mock('$lib/runtime', () => ({
+  runtime: {
+    get state() { return rt.state; },
+    caps: null,
+    connectionStatus: 'disconnected',
+    radioPowerOn: null,
+    connection: { status: 'disconnected', radioPowerOn: null },
+    audio: { rxEnabled: false, txEnabled: false, volume: 50, muted: false },
+    connectionAudio: false,
+    defaultScopeStatus: {
+      source: null, available: false, resourceSelected: false, demand: 0,
+      lifecycle: 'inactive', transport: 'disconnected', frameSeen: false,
+    },
+    scope: { hardwareScopeConnected: false, registerPresentationDriver: vi.fn(), subscribe: vi.fn(() => () => {}) },
+    bootstrap: vi.fn(async () => vi.fn()),
+  },
+  presentationResources: {
+    acquire: vi.fn(() => ({ resource: 'x', consumer: 'x' })),
+    release: vi.fn(),
+    configure: vi.fn(),
+    snapshot: vi.fn(() => ({ demand: 0, health: 'inactive' })),
+  },
+}));
+
+vi.mock('$lib/runtime/tx-controller/app-host', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('$lib/runtime/tx-controller/app-host')>();
+  return {
+    ...actual,
+    getAppTxController: () => ({
+      snapshot: () => ({ phase: 'idle', intent: null, guard: null, radioTx: 'off', txRisk: 'none', mayOwnKey: false, fault: null }),
+      subscribe: () => () => {},
+      start: vi.fn(),
+      setIntent: vi.fn(),
+      release: vi.fn(),
+      resetFault: vi.fn(),
+    }),
+  };
+});
+
+vi.mock('$lib/stores/capabilities.svelte', () => ({
+  hasTx: vi.fn(() => true),
+  hasDualReceiver: vi.fn(() => false),
+  hasAudio: vi.fn(() => false),
+  hasSpectrum: vi.fn(() => false),
+  hasAnyScope: vi.fn(() => false),
+  isAudioFftScope: vi.fn(() => false),
+  hasAudioFft: vi.fn(() => false),
+  getScopeSource: vi.fn(() => null),
+  hasCapability: vi.fn(() => false),
+  vfoLabel: vi.fn((slot: 'A' | 'B') => (slot === 'A' ? 'MAIN' : 'SUB')),
+  receiverLabel: vi.fn((id: 'MAIN' | 'SUB') => id),
+  vfoSlotLabel: vi.fn((slot: 'A' | 'B') => (slot === 'A' ? 'VFO A' : 'VFO B')),
+  getCapabilities: vi.fn(() => ({ freqRanges: [], modes: [], filters: [] })),
+  setCapabilities: vi.fn(),
+  getAgcModes: vi.fn(() => [0, 1, 2, 3]),
+  getAgcLabels: vi.fn(() => ({ 0: 'OFF', 1: 'FAST', 2: 'MID', 3: 'SLOW' })),
+  getSupportedModes: vi.fn(() => ['USB', 'LSB', 'CW', 'AM', 'FM']),
+  getSupportedFilters: vi.fn(() => ['FIL1', 'FIL2', 'FIL3']),
+  getAttValues: vi.fn(() => [0, 10, 20]),
+  getAttLabels: vi.fn(() => ({ 0: '0dB', 10: '10dB', 20: '20dB' })),
+  getPreValues: vi.fn(() => [0, 1, 2]),
+  getPreLabels: vi.fn(() => ({ 0: 'OFF', 1: 'PRE1', 2: 'PRE2' })),
+  getKeyboardConfig: vi.fn(() => null),
+  getVfoScheme: vi.fn(() => 'ab'),
+  getAntennaCount: vi.fn(() => 1),
+  getSmeterCalibration: vi.fn(() => null),
+  getSmeterRedline: vi.fn(() => null),
+  getMeterCalibration: vi.fn(() => null),
+  getMeterRedline: vi.fn(() => null),
+  getControlRange: vi.fn(() => ({ min: 0, max: 255 })),
+}));
+
+vi.stubGlobal('ResizeObserver', class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+});
+
+import LcdLayout from '../LcdLayout.svelte';
+import lcdLayoutSource from '../LcdLayout.svelte?raw';
+
+let components: ReturnType<typeof mount>[] = [];
+
+function mountLayout(variant: 'cockpit' | 'scope' = 'cockpit') {
+  const t = document.createElement('div');
+  document.body.appendChild(t);
+  const component = mount(LcdLayout, { target: t, props: { variant } });
+  flushSync();
+  components.push(component);
+  return t;
+}
+
+beforeEach(() => {
+  components = [];
+  rt.state = null;
+});
+
+afterEach(() => {
+  components.forEach((c) => unmount(c));
+  document.body.innerHTML = '';
+  rt.state = null;
+});
+
+describe('LcdLayout canonical module surface (MOR-1409 A13b)', () => {
+  // Kills: leaving `makeKeyboardHandlers` on the `wiring/command-bus` shim —
+  // this is the shim's LAST layout importer besides RadioLayout; A15's
+  // deletion clause needs both migrated.
+  it('imports no handler family from the legacy command-bus shim', () => {
+    expect(lcdLayoutSource).not.toContain('wiring/command-bus');
+  });
+
+  it('does not reach into lib/runtime/commands directly', () => {
+    expect(lcdLayoutSource).not.toContain('runtime/commands/panel-commands');
+  });
+
+  it('binds its keyboard handler through the sanctioned panel-adapters layer', () => {
+    expect(lcdLayoutSource).toContain('$lib/runtime/adapters/panel-adapters');
+    expect(lcdLayoutSource).toContain('getKeyboardHandlers');
+  });
+
+  it('contains zero runtime.send( references', () => {
+    expect(lcdLayoutSource).not.toMatch(/runtime\.send\(/);
+  });
+});
+
+describe('LcdLayout mounts on the migrated handler surface (MOR-1409 A13b)', () => {
+  it('renders .lcd-layout for the cockpit variant without throwing', () => {
+    const t = mountLayout('cockpit');
+    expect(t.querySelector('.lcd-layout')).not.toBeNull();
+  });
+
+  it('renders .lcd-layout for the scope variant without throwing', () => {
+    const t = mountLayout('scope');
+    expect(t.querySelector('.lcd-layout')).not.toBeNull();
+  });
+});

--- a/frontend/src/components-v2/layout/__tests__/RadioLayout.command-bus-migration.isolated.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/RadioLayout.command-bus-migration.isolated.test.ts
@@ -1,0 +1,259 @@
+/**
+ * MOR-1409 A13b — RadioLayout + LcdLayout command-bus migration, send()
+ * facade deletion (correction 5246842617, the second A13 split leg).
+ *
+ * RadioLayout's read side (mainVfo/subVfo/vfoOps) moves from the legacy
+ * `wiring/state-adapter` twin to the A11/A12-hardened
+ * `lib/runtime/props/panel-props`; its live handler families
+ * (vfo/keyboard/system) move from the `wiring/command-bus` shim to the
+ * sanctioned `lib/runtime/adapters/panel-adapters` accessors A13a added
+ * (`getKeyboardHandlers`, `getSystemHandlers`).
+ *
+ * Live inspection at this anchor found `rfFrontEnd`/`agc`/`ritXit`/`band`/
+ * `dsp`/`cw` (and their matching `make*Handlers` constructions) are
+ * computed but never referenced by RadioLayout's template — every panel
+ * that used to consume them (`RfFrontEnd`, `AgcPanel`, `DspPanel`,
+ * `RitXitPanel`, `CwPanel`, `BandSelector`) now self-sources through the
+ * semantic surfaces. They are deleted outright rather than re-pointed at an
+ * equally dead binder call.
+ *
+ * The two `runtime.send()` scope call sites (`handleScopeDualToggle`,
+ * `handleScopeReceiverChange`) are RadioLayout's only remaining production
+ * `send()` callers. Their sole consumer, `VfoHeader`, already ignores the
+ * legacy `scopeStatus`/`onScopeDualToggle`/`onScopeReceiverChange` props it
+ * still declares — `VfoHeader scope bridge authority` in
+ * `vfo-header.isolated.test.ts:341` pins
+ * `expect(source).not.toMatch(/onScopeReceiverChange\?\.|onScopeDualToggle\?\./)`
+ * as proof VfoHeader self-wires scope handling via its own
+ * `bindSemanticSurfaceHandlers().scopeControls` (the A07 idiom). RadioLayout
+ * is the last caller of that vestigial bridge; this gate deletes it rather
+ * than migrating dead code to an equally-dead binder call.
+ *
+ * Each test names the mutation it exists to kill.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount, unmount, flushSync } from 'svelte';
+
+vi.mock('../../../components/spectrum/SpectrumPanel.svelte', async () => {
+  const stub = await import('./SpectrumPanelStub.svelte');
+  return { default: stub.default };
+});
+
+vi.mock('../../../lib/local-extensions/LocalExtensionsHost.svelte', async () => {
+  const stub = await import('./SpectrumPanelStub.svelte');
+  return { default: stub.default };
+});
+
+vi.mock('$lib/stores/layout.svelte', () => ({
+  useLcdLayout: vi.fn(() => false),
+  getLayoutMode: vi.fn(() => 'standard'),
+  cycleLayoutMode: vi.fn(),
+  setLayoutMode: vi.fn(),
+}));
+
+vi.mock('../../../lib/utils/battery', () => ({
+  initBatteryMonitor: vi.fn(async () => vi.fn()),
+}));
+
+vi.mock('../../../lib/media/media-session', () => ({
+  initMediaSession: vi.fn(),
+  destroyMediaSession: vi.fn(),
+}));
+
+const rt = vi.hoisted(() => ({ state: null as unknown }));
+
+vi.mock('$lib/runtime', () => ({
+  runtime: {
+    get state() { return rt.state; },
+    caps: null,
+    connectionStatus: 'disconnected',
+    radioPowerOn: null,
+    connection: { status: 'disconnected', radioPowerOn: null },
+    audio: { rxEnabled: false, txEnabled: false, volume: 50, muted: false },
+    connectionAudio: false,
+    defaultScopeStatus: {
+      source: null, available: false, resourceSelected: false, demand: 0,
+      lifecycle: 'inactive', transport: 'disconnected', frameSeen: false,
+    },
+    scope: { hardwareScopeConnected: false },
+  },
+}));
+
+vi.mock('$lib/stores/connection.svelte', () => ({
+  getConnectionStatus: vi.fn(() => ({ connected: false })),
+  getRadioPowerOn: vi.fn(() => null),
+  getRadioStatus: vi.fn(() => 'disconnected'),
+  isScopeConnected: vi.fn(() => false),
+  isAudioConnected: vi.fn(() => false),
+  getHttpConnected: vi.fn(() => false),
+  getRigConnected: vi.fn(() => false),
+  getRadioReady: vi.fn(() => false),
+  getRadioHealth: vi.fn(() => null),
+  markScopeFrame: vi.fn(),
+}));
+
+vi.mock('$lib/stores/tuning.svelte', () => ({
+  applyModeDefault: vi.fn(),
+}));
+
+vi.mock('$lib/runtime/tx-controller/app-host', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('$lib/runtime/tx-controller/app-host')>();
+  return {
+    ...actual,
+    getAppTxController: () => ({
+      snapshot: () => ({ phase: 'idle', intent: null, guard: null, radioTx: 'unknown', txRisk: 'none', mayOwnKey: false, fault: null }),
+      subscribe: () => () => {},
+      start: vi.fn(),
+      setIntent: vi.fn(),
+      release: vi.fn(),
+      resetFault: vi.fn(),
+    }),
+  };
+});
+
+vi.mock('$lib/stores/capabilities.svelte', () => ({
+  hasTx: vi.fn(() => true),
+  hasDualReceiver: vi.fn(() => false),
+  hasAudio: vi.fn(() => false),
+  hasSpectrum: vi.fn(() => true),
+  hasAnyScope: vi.fn(() => false),
+  isAudioFftScope: vi.fn(() => false),
+  hasAudioFft: vi.fn(() => false),
+  getScopeSource: vi.fn(() => null),
+  hasCapability: vi.fn(() => false),
+  vfoLabel: vi.fn((slot: 'A' | 'B') => (slot === 'A' ? 'MAIN' : 'SUB')),
+  receiverLabel: vi.fn((id: 'MAIN' | 'SUB') => id),
+  vfoSlotLabel: vi.fn((slot: 'A' | 'B') => (slot === 'A' ? 'VFO A' : 'VFO B')),
+  getCapabilities: vi.fn(() => ({ freqRanges: [], modes: [], filters: [] })),
+  setCapabilities: vi.fn(),
+  getAgcModes: vi.fn(() => [0, 1, 2, 3]),
+  getAgcLabels: vi.fn(() => ({ 0: 'OFF', 1: 'FAST', 2: 'MID', 3: 'SLOW' })),
+  getSupportedModes: vi.fn(() => ['USB', 'LSB', 'CW', 'AM', 'FM']),
+  getSupportedFilters: vi.fn(() => ['FIL1', 'FIL2', 'FIL3']),
+  getAttValues: vi.fn(() => [0, 10, 20]),
+  getAttLabels: vi.fn(() => ({ 0: '0dB', 10: '10dB', 20: '20dB' })),
+  getPreValues: vi.fn(() => [0, 1, 2]),
+  getPreLabels: vi.fn(() => ({ 0: 'OFF', 1: 'PRE1', 2: 'PRE2' })),
+  getKeyboardConfig: vi.fn(() => null),
+  getVfoScheme: vi.fn(() => 'ab'),
+  getAntennaCount: vi.fn(() => 1),
+  getSmeterCalibration: vi.fn(() => null),
+  getSmeterRedline: vi.fn(() => null),
+  getMeterCalibration: vi.fn(() => null),
+  getMeterRedline: vi.fn(() => null),
+  getControlRange: vi.fn(() => ({ min: 0, max: 255 })),
+}));
+
+import RadioLayout from '../RadioLayout.svelte';
+import radioLayoutSource from '../RadioLayout.svelte?raw';
+
+let components: ReturnType<typeof mount>[] = [];
+
+/** Undeclared layout id: reaches the legacy VFO/TX branch (`<VfoHeader>`),
+ *  the only branch RadioLayout's own read/handler surface still feeds. */
+const UNDECLARED = 'no-such-layout' as any;
+
+function mountLayout(skinId: any = UNDECLARED) {
+  const t = document.createElement('div');
+  document.body.appendChild(t);
+  const component = mount(RadioLayout, { target: t, props: { skinId } });
+  flushSync();
+  components.push(component);
+  return t;
+}
+
+beforeEach(() => {
+  components = [];
+  rt.state = null;
+  Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1440 });
+  Object.defineProperty(window, 'innerHeight', { writable: true, configurable: true, value: 900 });
+});
+
+afterEach(() => {
+  components.forEach((c) => unmount(c));
+  document.body.innerHTML = '';
+  rt.state = null;
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Static closure: the layout consumes the canonical modules only
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('RadioLayout canonical module surface (MOR-1409 A13b)', () => {
+  // Kills: re-pointing mainVfo/subVfo/vfoOps back at the legacy wiring twin.
+  it('imports no projection from the legacy wiring state-adapter', () => {
+    expect(radioLayoutSource).not.toContain('wiring/state-adapter');
+  });
+
+  // Kills: leaving any handler family on the `wiring/command-bus` shim, whose
+  // production importer count must reach zero for A15's deletion clause.
+  it('imports no handler family from the legacy command-bus shim', () => {
+    expect(radioLayoutSource).not.toContain('wiring/command-bus');
+  });
+
+  // Kills: bypassing the adapter layer by importing the command module directly.
+  it('does not reach into lib/runtime/commands directly', () => {
+    expect(radioLayoutSource).not.toContain('runtime/commands/panel-commands');
+  });
+
+  it('reads its VFO projections from the hardened panel-props module', () => {
+    expect(radioLayoutSource).toContain('$lib/runtime/props/panel-props');
+  });
+
+  it('binds its handlers through the sanctioned panel-adapters layer', () => {
+    expect(radioLayoutSource).toContain('$lib/runtime/adapters/panel-adapters');
+    expect(radioLayoutSource).toContain('getVfoHandlers');
+    expect(radioLayoutSource).toContain('getKeyboardHandlers');
+    expect(radioLayoutSource).toContain('getSystemHandlers');
+  });
+
+  // Kills: restoring any of the dead RF-front-end/AGC/RIT-XIT/band/DSP/CW
+  // props or handler constructions this gate removes as unreachable.
+  it('no longer constructs the unreferenced RF/AGC/RIT-XIT/band/DSP/CW handler families', () => {
+    expect(radioLayoutSource).not.toMatch(/makeRfFrontEndHandlers|makeAgcHandlers|makeRitXitHandlers/);
+    expect(radioLayoutSource).not.toMatch(/makeBandHandlers|makePresetHandlers|makeDspHandlers|makeCwPanelHandlers/);
+    expect(radioLayoutSource).not.toMatch(/toRfFrontEndProps|toAgcProps|toRitXitProps|toBandSelectorProps|toDspProps|toCwProps/);
+  });
+
+  // Kills: reintroducing `runtime.send(` anywhere in RadioLayout — its two
+  // scope call sites are the method's last production callers.
+  it('contains zero runtime.send( references', () => {
+    expect(radioLayoutSource).not.toMatch(/runtime\.send\(/);
+  });
+
+  // Kills: reviving the dead scope-status bridge (`scopeStatus`,
+  // `handleScopeDualToggle`, `handleScopeReceiverChange`) that fed
+  // VfoHeader's already-ignored legacy props.
+  it('no longer computes or wires the dead VfoHeader scope-status bridge', () => {
+    expect(radioLayoutSource).not.toMatch(/function handleScopeDualToggle\(/);
+    expect(radioLayoutSource).not.toMatch(/function handleScopeReceiverChange\(/);
+    expect(radioLayoutSource).not.toMatch(/\bscopeStatus\s*=\s*\$derived/);
+    expect(radioLayoutSource).not.toMatch(/\{scopeStatus\}/);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Consumer boundary: the migrated projection/handler surface still mounts
+// ───────────────────────────────────────────────────────────────────────────
+//
+// `toVfoProps`/`toVfoOpsProps`'s own honesty contract (NaN/'---' instead of
+// a fabricated 14074000/USB/FIL1 reading) is unit-tested at its source in
+// `lib/runtime/props/__tests__/panel-props.no-fabricated-defaults.test.ts`;
+// RadioLayout's obligation is only to call the canonical two-arg signature
+// and render without error, which these prove.
+
+describe('RadioLayout mounts on the migrated projection/handler surface (MOR-1409 A13b)', () => {
+  it('renders the legacy VFO header for an undeclared layout without throwing', () => {
+    const t = mountLayout();
+    expect(t.querySelector('.receiver-deck .vfo-header')).not.toBeNull();
+  });
+
+  it('wires KeyboardHandler to a working dispatch function post-migration', () => {
+    const t = mountLayout();
+    const handler = t.querySelector('.receiver-deck')?.parentElement;
+    expect(handler).not.toBeNull();
+    // Smoke: mounting must not throw when `getKeyboardHandlers()`/
+    // `getSystemHandlers()`/`getVfoHandlers()` replace the command-bus calls.
+    expect(t.querySelector('.radio-layout')).not.toBeNull();
+  });
+});

--- a/frontend/src/components-v2/layout/__tests__/RadioLayout.isolated.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/RadioLayout.isolated.test.ts
@@ -52,8 +52,6 @@ vi.mock('../../../lib/runtime/frontend-runtime', () => ({
     },
     scope: { hardwareScopeConnected: false },
     bootstrap: vi.fn(async () => vi.fn()),
-    setPollingMultiplier: vi.fn(),
-    send: vi.fn(),
   },
 }));
 
@@ -81,7 +79,6 @@ vi.mock('$lib/runtime', () => ({
       lifecycle: 'inactive', transport: 'disconnected', frameSeen: false,
     },
     scope: { hardwareScopeConnected: false },
-    send: vi.fn(),
   },
 }));
 

--- a/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
@@ -46,8 +46,6 @@ const h = vi.hoisted(() => {
       },
       scope: { hardwareScopeConnected: false },
       bootstrap: async () => () => {},
-      setPollingMultiplier: () => {},
-      send: () => {},
     },
   };
 });

--- a/frontend/src/components-v2/layout/__tests__/semantic-lcd-migration.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-lcd-migration.component.test.ts
@@ -104,8 +104,6 @@ const h = vi.hoisted(() => {
             lifecycle: 'inactive', transport: 'disconnected', frameSeen: false,
           },
           bootstrap: async () => () => {},
-          setPollingMultiplier: () => {},
-          send: () => {},
         };
       })();
       return h.runtimePromise;

--- a/frontend/src/components-v2/layout/__tests__/top-row-visual-regression.isolated.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/top-row-visual-regression.isolated.test.ts
@@ -45,7 +45,6 @@ vi.mock('$lib/runtime', () => ({
       lifecycle: 'inactive', transport: 'disconnected', frameSeen: false,
     },
     scope: { hardwareScopeConnected: false },
-    send: vi.fn(),
   },
 }));
 

--- a/frontend/src/components-v2/panels/lcd/__tests__/VfoControlPanel.authority.isolated.test.ts
+++ b/frontend/src/components-v2/panels/lcd/__tests__/VfoControlPanel.authority.isolated.test.ts
@@ -33,7 +33,7 @@ vi.mock('../../../wiring/command-bus', () => ({
   makeRitXitHandlers: () => bindings.ritXit,
   makeCwPanelHandlers: () => bindings.cw,
 }));
-vi.mock('$lib/runtime', () => ({ runtime: { send: vi.fn() } }));
+vi.mock('$lib/runtime', () => ({ runtime: {} }));
 
 import VfoControlPanel from '../VfoControlPanel.svelte';
 

--- a/frontend/src/lib/runtime/__tests__/frontend-runtime.isolated.test.ts
+++ b/frontend/src/lib/runtime/__tests__/frontend-runtime.isolated.test.ts
@@ -112,8 +112,7 @@ vi.mock('./system-controller', async () => {
 // ── Import modules under test after mocks are hoisted ──
 
 import { fetchCapabilities } from '$lib/transport/http-client';
-import { connect, getChannel, onMessage, sendCommand, sendRaw } from '$lib/transport/ws-client';
-import { dispatchRadioIntent } from '$lib/runtime/commands/radio-intents';
+import { connect, getChannel, onMessage, sendRaw } from '$lib/transport/ws-client';
 import { setCapabilities, subscribeCapabilities } from '$lib/stores/capabilities.svelte';
 import { audioManager } from '$lib/audio/audio-manager';
 import { clearLegacyPendingModInputRestore } from '../adapters/mod-input-auto.svelte';
@@ -449,10 +448,15 @@ describe('FrontendRuntime.bootstrap()', () => {
     expect(subscribeCapabilities).toHaveBeenCalledTimes(2);
   });
 
-  it('setPollingMultiplier is an inert no-op (MOR-1409 A09b; the HTTP-client cadence state it used to feed is gone as of A10)', async () => {
+  // MOR-1409 A13b (correction 5246842617 §5): the inert no-op stub is
+  // deleted in the same head that removes `send()`'s last two production
+  // callers (RadioLayout.svelte's scope-dual/scope-receiver toggles) — no
+  // separate post-A13 micro-slice is needed for either deletion.
+  it('no longer exposes setPollingMultiplier (MOR-1409 A13b — the inert A09b stub is deleted)', async () => {
     const rt = await freshRuntime();
+    const surface = rt as unknown as Record<string, unknown>;
 
-    expect(() => rt.setPollingMultiplier(5)).not.toThrow();
+    expect(surface.setPollingMultiplier).toBeUndefined();
   });
 
   it('serializes concurrent callers — both share single in-flight bootstrap', async () => {
@@ -477,50 +481,16 @@ describe('FrontendRuntime command dispatch and state-hatch removal (MOR-1409 A08
     configureAcceptedCapabilities();
   });
 
-  it('delegates send() to the typed facade exactly once with no raw transport', async () => {
+  // MOR-1409 A13b (correction 5246842617 §5): `send()` is deleted in the
+  // same head that migrates its last two production callers
+  // (RadioLayout.svelte's scope-dual/scope-receiver toggles) to
+  // `bindSemanticSurfaceHandlers().scopeControls`. Same surface-absence
+  // idiom as the `patchActiveReceiver`/`patchState` pin below (A08).
+  it('no longer exposes send() (MOR-1409 A13b — the typed-facade delegator is deleted)', async () => {
     const rt = await freshRuntime();
+    const surface = rt as unknown as Record<string, unknown>;
 
-    rt.send('set_scope_dual', { dual: true });
-
-    expect(dispatchRadioIntent).toHaveBeenCalledExactlyOnceWith({
-      name: 'set_scope_dual',
-      params: { dual: true },
-    });
-    expect(sendCommand).not.toHaveBeenCalled();
-
-    rt.send('switch_scope_receiver', { receiver: 1 });
-    expect(dispatchRadioIntent).toHaveBeenCalledTimes(2);
-    expect(dispatchRadioIntent).toHaveBeenLastCalledWith({
-      name: 'switch_scope_receiver',
-      params: { receiver: 1 },
-    });
-    expect(sendCommand).not.toHaveBeenCalled();
-  });
-
-  it('defaults missing params to an empty object', async () => {
-    const rt = await freshRuntime();
-
-    rt.send('vfo_swap');
-
-    expect(dispatchRadioIntent).toHaveBeenCalledExactlyOnceWith({
-      name: 'vfo_swap',
-      params: {},
-    });
-  });
-
-  it('swallows facade validation errors without throwing or double-dispatching', async () => {
-    const rt = await freshRuntime();
-    vi.mocked(dispatchRadioIntent).mockImplementationOnce(() => {
-      throw new TypeError('Only a known non-PTT radio intent may be dispatched');
-    });
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-
-    expect(() => rt.send('definitely_not_a_command')).not.toThrow();
-
-    expect(dispatchRadioIntent).toHaveBeenCalledTimes(1);
-    expect(sendCommand).not.toHaveBeenCalled();
-    expect(warn).toHaveBeenCalledTimes(1);
-    warn.mockRestore();
+    expect(surface.send).toBeUndefined();
   });
 
   it('no longer exposes the patchActiveReceiver/patchState escape hatches', async () => {

--- a/frontend/src/lib/runtime/frontend-runtime.ts
+++ b/frontend/src/lib/runtime/frontend-runtime.ts
@@ -27,7 +27,6 @@ import {
 import { getAudioState, setVolume, setMuted, toggleMute } from '$lib/stores/audio.svelte';
 import { connect, onMessage, sendRaw } from '$lib/transport/ws-client';
 import { audioManager } from '$lib/audio/audio-manager';
-import { dispatchRadioIntent, type RadioIntent } from './commands/radio-intents';
 import { clearLegacyPendingModInputRestore } from './adapters/mod-input-auto.svelte';
 import { derivePresentationCapabilities } from './adapters/presentation-capabilities';
 import { systemController } from './system-controller';
@@ -339,21 +338,6 @@ class FrontendRuntime {
     return cleanup;
   }
 
-  // ── Command dispatch ──
-
-  /**
-   * Dispatch a catalog-validated radio intent through the typed facade
-   * (MOR-1409 A08). Zero raw transport: unknown names or malformed params
-   * are rejected by the facade and logged, never sent.
-   */
-  send(name: string, params?: Record<string, unknown>): void {
-    try {
-      dispatchRadioIntent({ name, params: params ?? {} } as RadioIntent);
-    } catch (error) {
-      console.warn('[runtime] send() rejected non-catalog command', name, error);
-    }
-  }
-
   // ── Audio control ──
 
   acquireHardwareScope(consumer: string): ResourceLease {
@@ -434,17 +418,6 @@ class FrontendRuntime {
     toggleMute();
   }
 
-  /**
-   * Inert no-op (MOR-1409 A09b — the HTTP polling writer is gone; WS is the
-   * sole state writer, and there is no cadence left to adjust). Kept only so
-   * its sole caller, `App.svelte:258` (an A10 owner, battery monitor), keeps
-   * compiling until A10 removes that call; this stub is deleted by the
-   * published post-A13 micro-slice that also removes `send()`
-   * (correction 5241395868).
-   */
-  setPollingMultiplier(_m: number): void {
-    // Intentionally empty.
-  }
 }
 
 /** Singleton runtime instance. */

--- a/frontend/src/lib/runtime/props/__tests__/panel-props.no-fabricated-defaults.test.ts
+++ b/frontend/src/lib/runtime/props/__tests__/panel-props.no-fabricated-defaults.test.ts
@@ -178,11 +178,14 @@ describe('frozen facts this gate must not disturb (MOR-1409 A11 regression pins)
     expect(source).not.toContain('runtime.send(');
   });
 
-  it('RadioLayout.svelte still has exactly the two documented send() call sites (correction 5241395868)', () => {
+  // MOR-1409 A13b (correction 5246842617 §5) supersedes this pin: the two
+  // documented call sites were RadioLayout's — and the whole method's —
+  // last production callers. They are deleted (not migrated to a live
+  // binder call — VfoHeader already ignores the legacy props they fed; see
+  // `vfo-header.isolated.test.ts`'s `VfoHeader source boundary` pin) in the
+  // same head that removes `FrontendRuntime.send()` itself.
+  it('RadioLayout.svelte makes zero runtime.send() calls (MOR-1409 A13b — send() is deleted)', () => {
     const source = readSource(RADIO_LAYOUT_PATH);
-    const matches = source.match(/runtime\.send\(/g) ?? [];
-    expect(matches).toHaveLength(2);
-    expect(source).toContain("runtime.send('set_scope_dual', { dual: !current });");
-    expect(source).toContain("runtime.send('switch_scope_receiver', { receiver });");
+    expect(source).not.toMatch(/runtime\.send\(/);
   });
 });

--- a/frontend/src/lib/runtime/tx-controller/__tests__/app-lifecycle.component.test.ts
+++ b/frontend/src/lib/runtime/tx-controller/__tests__/app-lifecycle.component.test.ts
@@ -50,7 +50,7 @@ vi.mock('../../../../lib/runtime/frontend-runtime', async () => {
     runtime: {
       get state() { subscribe(); return h.radio; },
       get caps() { subscribe(); return h.caps; },
-      bootstrap: h.bootstrap, setPollingMultiplier: vi.fn(),
+      bootstrap: h.bootstrap,
     },
     // MOR-1060 swap-bridge surface; inert here (nothing is demanded).
     presentationResources: {

--- a/frontend/src/lib/runtime/tx-controller/__tests__/integration-page-lifecycle.isolated.test.ts
+++ b/frontend/src/lib/runtime/tx-controller/__tests__/integration-page-lifecycle.isolated.test.ts
@@ -149,7 +149,6 @@ vi.mock('../../../../lib/runtime/frontend-runtime', async () => {
         return h.runtimeCaps;
       },
       bootstrap: h.bootstrap,
-      setPollingMultiplier: vi.fn(),
     },
     presentationResources: {
       snapshot: () => ({ demand: 0 }),


### PR DESCRIPTION
Part of #2317

## MOR-1409 gate A13b (desktop/LCD command-bus migration + send()/stub deletion — second split leg)

Per the session-15 re-anchor plan (SHA-256 `208736cc…`) and split correction [5246842617](https://github.com/rigplane/rigplane-core/issues/2317#issuecomment-5246842617) items 3/5. FULL-CEREMONY gate per [5243153469](https://github.com/rigplane/rigplane-core/issues/2317#issuecomment-5243153469).

- `frontend/src/components-v2/layout/RadioLayout.svelte` (churn 85) — projections re-pointed from `state-adapter` to hardened `panel-props`; handlers re-pointed to canonical `getVfoHandlers`/`getKeyboardHandlers`/`getSystemHandlers`; the two `runtime.send()` scope calls migrated; **evidence-backed deviation**: six dead legacy handler families (rfFrontEnd/agc/ritXit/band/dsp/cw) and the scopeStatus bridge deleted rather than re-pointed — panels self-source via semantic surfaces, and `vfo-header.isolated.test.ts:341` pins that VfoHeader ignores the legacy scope props (A07 idiom).
- `frontend/src/components-v2/layout/LcdLayout.svelte` (churn 4) — `makeKeyboardHandlers` → `getKeyboardHandlers`.
- `frontend/src/lib/runtime/frontend-runtime.ts` (churn 27, deletions only) — `send()` facade and inert `setPollingMultiplier` stub deleted in the same head that removes their last callers, per 5241395868 §2 / 5242285764 §2; no post-A13 micro-slice needed for these.

Deletion proof: tree-wide zero `runtime.send(` code references (sole hit is a pre-existing doc comment); `command-bus` production importers now zero (A15's deletion clause satisfiable); `state-adapter` production importers reduced to exactly AmberCockpit/AmberScope (A14's set, as the plan predicted).

Production churn 116 (< 391 STOP). Head `3d0c3b6669c7ea5a45332038c8b2cdf87fb16ec1`, base `e96788e1fbf9e161e931b5098d40cbfb03296ed0`.

## Evidence (once-through, no retry-to-green)

- Causal RED per owner at exact base (7/10, 2/6, 2/23 substantive)
- Mutation battery: 6 applied, all killed, byte-exact restores verified (3 plan mutations N/A — targeted code deleted outright, documented)
- Focused GREEN: 15 files / 322 tests; full suite: 316 files / 6593 tests passed (one intermediate field-status-leak flake in an unrelated file attributed standalone 43/43)
- svelte-check 0/0; eslint, boundaries, i18n clean; state-adapter/AmberCockpit/AmberScope (A14) and command-bus (A15) untouched; enforcement plugin/TOML and goldens untouched
- 11 mechanical stub-parity mock cleanups recorded per the pre-authorization class

🤖 Generated with [Claude Code](https://claude.com/claude-code)