### PR TITLE
refactor(#2317): migrate amber panels to honest projections (A14)

### DIFF
--- a/frontend/src/components-v2/panels/lcd/AmberCockpit.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberCockpit.svelte
@@ -6,7 +6,7 @@
   import {
     toTxProps, toRitXitProps, toVfoOpsProps, toMeterProps,
     toDspProps, toFilterProps,
-  } from '../../wiring/state-adapter';
+  } from '$lib/runtime/props/panel-props';
   import AmberFrequency from './AmberFrequency.svelte';
   import AmberSmeter from './AmberSmeter.svelte';
   import AmberAfScope from './AmberAfScope.svelte';
@@ -68,9 +68,52 @@
   let tx = $derived(toTxProps(radioState, null));
   let ritXit = $derived(toRitXitProps(radioState, null));
   let vfoOps = $derived(toVfoOpsProps(radioState, null));
-  let meter = $derived(toMeterProps(radioState));
+  let meter = $derived(toMeterProps(radioState, caps));
   let dsp = $derived(toDspProps(radioState, null));
   let filterProps = $derived(toFilterProps(radioState, caps));
+
+  // MOR-1409 A14: `panel-props`' honesty-hardened projections default an
+  // unobserved reading to `Number.NaN` instead of a plausible-looking
+  // stand-in (`ritXit.ritOffset`, `meter.rfPower`/`swr`/`alc`/`comp`,
+  // `filterProps.filterWidth` — plan §4.1/§4.2, correction `5247684776`).
+  // Three choke-point guards below keep that honest `NaN` from ever
+  // reaching a render path as a formatted "NaN" string or — worse, for the
+  // meter pipeline — a silently plausible full-scale reading
+  // (`meter-utils.ts`'s `piecewise()` clamp-and-fallthrough shape). Guards
+  // live here, at the owner-file boundary, never inside the frozen
+  // consumer components (`AmberSmeter`/`AmberFilterGhost`) or helpers
+  // (`meter-utils.ts`/`rit-utils.ts`/`smeter-scale.ts`) — adding a guard
+  // there would make a third/fourth production owner, contradicting
+  // ruling `5247582313`'s exactly-two-owner scope (plan §4.3 option (a)).
+
+  // Meter-format guard: fall back to the always-safe raw S-meter branch
+  // (never routed through the NaN-honesty projection) rather than
+  // re-fabricating the old `?? 0` default, which would silently defeat the
+  // whole migration. Source and value are derived together so the
+  // `<AmberSmeter source=…>` label never disagrees with what `value` holds.
+  function meterSourceIsFinite(source: MeterSource): boolean {
+    switch (source) {
+      case 'PO': return Number.isFinite(meter.rfPower);
+      case 'SWR': return Number.isFinite(meter.swr);
+      case 'ALC': return Number.isFinite(meter.alc);
+      case 'COMP': return Number.isFinite(meter.comp);
+      default: return true; // 'S' — raw field read, outside this projection
+    }
+  }
+
+  // RIT-offset guard: `formatOffsetKHz()` (rit-utils.ts, frozen) has no NaN
+  // branch and renders the literal "−NaN kHz" on an unobserved offset.
+  let ritOffsetLabel = $derived(
+    Number.isFinite(ritXit.ritOffset) ? formatOffsetKHz(ritXit.ritOffset) : '---',
+  );
+
+  // Filter-ratio guard: `AmberFilterGhost`/`AmberAfScope` (frozen) compute
+  // `filterWidth / filterWidthMax` with no NaN handling. `0` is a
+  // non-plausible, geometrically degenerate placeholder (collapses the
+  // ratio to the floor) — not a re-fabrication of the old 2400 Hz stand-in.
+  let safeFilterWidth = $derived(
+    Number.isFinite(filterProps.filterWidth) ? filterProps.filterWidth : 0,
+  );
 
   // ── LCD-specific derivations (no adapter equivalent) ──
   let rx = $derived(radioState?.active === 'SUB' ? radioState?.sub : radioState?.main);
@@ -85,8 +128,14 @@
     tx.txActive && userMeterSource === 'S' ? 'PO' : userMeterSource
   );
 
+  // The source actually safe to display — falls back to 'S' when the
+  // user-selected (or TX-auto-switched) source's field is unobserved.
+  let effectiveMeterSource = $derived<MeterSource>(
+    meterSourceIsFinite(activeMeterSource) ? activeMeterSource : 'S'
+  );
+
   let meterValue = $derived.by(() => {
-    switch (activeMeterSource) {
+    switch (effectiveMeterSource) {
       case 'PO': return meter.rfPower;
       case 'SWR': return meter.swr;
       case 'ALC': return meter.alc;
@@ -309,7 +358,7 @@
     return mainSMeter;                           // RX + B active: show A's own S-meter
   });
   let mainMeterSource = $derived<MeterSource>(
-    tx.txActive || vfoAActive ? activeMeterSource : 'S',
+    tx.txActive || vfoAActive ? effectiveMeterSource : 'S',
   );
 </script>
 
@@ -365,7 +414,7 @@
       {#if ritXit.ritActive || ritXit.xitActive}
         <div class="lcd-rit-row">
           <span class="rit-label">{ritXit.ritActive ? 'RIT' : 'XIT'}</span>
-          <span class="rit-value">{formatOffsetKHz(ritXit.ritOffset)}</span>
+          <span class="rit-value">{ritOffsetLabel}</span>
         </div>
       {/if}
 
@@ -417,7 +466,7 @@
           <AmberAfScope
             data={fftPixels}
             onRegisterPush={(fn) => { fftPush = fn; }}
-            filterWidth={filterProps.filterWidth}
+            filterWidth={safeFilterWidth}
             filterWidthMax={filterProps.filterWidthMax}
             ifShift={filterProps.ifShift}
             contour={contourLevel}
@@ -434,7 +483,7 @@
              Prevents the 1fr scope row from rendering as empty amber
              when the radio has no AF-FFT capability. -->
         <AmberFilterGhost
-          filterWidth={filterProps.filterWidth}
+          filterWidth={safeFilterWidth}
           filterWidthMax={filterProps.filterWidthMax}
         />
       {/if}

--- a/frontend/src/components-v2/panels/lcd/AmberScope.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberScope.svelte
@@ -2,7 +2,7 @@
   import { deriveAmberScopeProps } from '$lib/runtime/adapters/panel-adapters';
   import {
     toTxProps, toRitXitProps, toVfoOpsProps, toDspProps, toFilterProps,
-  } from '../../wiring/state-adapter';
+  } from '$lib/runtime/props/panel-props';
   import AmberFrequency from './AmberFrequency.svelte';
   import AmberAfScope from './AmberAfScope.svelte';
   import AmberFilterGhost from './AmberFilterGhost.svelte';
@@ -59,6 +59,18 @@
   let vfoOps = $derived(toVfoOpsProps(radioState, null));
   let dsp = $derived(toDspProps(radioState, null));
   let filterProps = $derived(toFilterProps(radioState, caps));
+
+  // MOR-1409 A14: `filterProps.filterWidth` is `Number.NaN` when
+  // unobserved (panel-props honesty hardening, plan §4.1/§4.2 finding #3).
+  // `AmberFilterGhost`/`AmberAfScope` (frozen consumers) compute
+  // `filterWidth / filterWidthMax` with no NaN handling — guard at this
+  // owner-file choke point instead of touching either frozen component.
+  // `0` is a non-plausible, geometrically degenerate placeholder (collapses
+  // the ratio to the floor), not a re-fabrication of the old 2400 Hz
+  // stand-in (mirrors AmberCockpit's identical guard).
+  let safeFilterWidth = $derived(
+    Number.isFinite(filterProps.filterWidth) ? filterProps.filterWidth : 0,
+  );
 
   // Active receiver for indicator zone data (unchanged from pre-#897)
   let rx = $derived(radioState?.active === 'SUB' ? radioState?.sub : radioState?.main);
@@ -259,7 +271,7 @@
         <AmberAfScope
           data={fftPixels}
           onRegisterPush={(fn) => { fftPush = fn; }}
-          filterWidth={filterProps.filterWidth}
+          filterWidth={safeFilterWidth}
           filterWidthMax={filterProps.filterWidthMax}
           ifShift={filterProps.ifShift}
           bandwidth={fftBandwidth}
@@ -267,7 +279,7 @@
         />
       {:else}
         <AmberFilterGhost
-          filterWidth={filterProps.filterWidth}
+          filterWidth={safeFilterWidth}
           filterWidthMax={filterProps.filterWidthMax}
         />
       {/if}

--- a/frontend/src/components-v2/panels/lcd/__tests__/AmberPanels.honesty-migration.isolated.test.ts
+++ b/frontend/src/components-v2/panels/lcd/__tests__/AmberPanels.honesty-migration.isolated.test.ts
@@ -1,0 +1,300 @@
+/**
+ * MOR-1409 A14 — AmberCockpit / AmberScope migration from the stale
+ * `wiring/state-adapter` projections to the honesty-hardened
+ * `$lib/runtime/props/panel-props` ones (Core #2317, ruling `5247582313`,
+ * correction `5247684776`).
+ *
+ * `panel-props.ts` defaults an unobserved reading to `Number.NaN` instead of
+ * a plausible-looking stand-in (`0` / `2400` / …). Three of the six migrated
+ * functions (`toRitXitProps`, `toMeterProps`, `toFilterProps`) introduce
+ * real `NaN` sentinels into values both owner files already render. This
+ * file proves the resulting silent-fallback risk is real (traced in the A14
+ * plan §4.2) and that both owner files gate their own render on the value
+ * actually being finite — never re-fabricating the old defaults, and never
+ * touching the frozen consumer files (`AmberSmeter.svelte`,
+ * `AmberFilterGhost.svelte`, `meter-utils.ts`, `smeter-scale.ts`, `rit-utils.ts`)
+ * per the two-owner constraint (`5247582313` clause 1).
+ *
+ * Mounts the real `AmberCockpit`/`AmberScope` trees; only the runtime/adapter
+ * seams are mocked to feed a controlled `ServerState` (mirrors
+ * `AmberCockpit.qsy-authority.isolated.test.ts` and
+ * `lcd-availability.isolated.test.ts`'s mounting shape).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount, unmount, flushSync } from 'svelte';
+import { readFileSync } from 'node:fs';
+import type { ServerState } from '$lib/types/state';
+
+const cockpitProps = vi.hoisted(() => ({
+  value: {
+    radioState: null as ServerState | null,
+    caps: null,
+    hasCapability: (_name: string) => true,
+    hasAudioFft: false,
+    hasDualReceiver: false,
+  },
+}));
+
+const scopeProps = vi.hoisted(() => ({
+  value: {
+    radioState: null as ServerState | null,
+    caps: null,
+    hasCapability: (_name: string) => true,
+    hasAudioFft: false,
+    hasDualReceiver: false,
+  },
+}));
+
+vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
+  deriveAmberCockpitProps: () => cockpitProps.value,
+  deriveAmberScopeProps: () => scopeProps.value,
+  deriveAmberTelemetryProps: () => ({ vdRaw: null, idRaw: null }),
+  getAmberCockpitHandlers: () => ({ onTuningChange: vi.fn() }),
+  getVfoHandlers: () => ({ onFreqChange: vi.fn(), onModeChange: vi.fn() }),
+  bindVfoTunerContext: () => ({ read: vi.fn(() => ({ view: null })) }),
+}));
+
+vi.mock('$lib/runtime/adapters/qsy-history-adapter', () => ({
+  deriveQsyRecent: () => [],
+}));
+
+vi.mock('$lib/runtime/frontend-runtime', () => ({
+  presentationResources: { acquire: vi.fn(() => ({})), release: vi.fn() },
+  runtime: {
+    send: vi.fn(),
+    scope: {
+      registerPresentationDriver: vi.fn(),
+      subscribe: vi.fn(() => vi.fn()),
+    },
+  },
+}));
+
+import AmberCockpit from '../AmberCockpit.svelte';
+import AmberScope from '../AmberScope.svelte';
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+let components: ReturnType<typeof mount>[] = [];
+
+function baseReceiver(overrides: Record<string, unknown> = {}) {
+  return {
+    freqHz: 14_074_000, mode: 'USB', filter: 1, dataMode: 0, sMeter: 0,
+    att: 0, preamp: 0, nb: false, nr: false, afLevel: 128, rfGain: 255,
+    squelch: 0, agc: 2,
+    ...overrides,
+  };
+}
+
+function mountCockpit(state: ServerState | null, hasAudioFft = false) {
+  cockpitProps.value = {
+    radioState: state,
+    caps: null,
+    hasCapability: () => true,
+    hasAudioFft,
+    hasDualReceiver: false,
+  };
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+  const component = mount(AmberCockpit, { target });
+  flushSync();
+  components.push(component);
+  return target;
+}
+
+function mountScope(state: ServerState | null, hasAudioFft = false) {
+  scopeProps.value = {
+    radioState: state,
+    caps: null,
+    hasCapability: () => true,
+    hasAudioFft,
+    hasDualReceiver: false,
+  };
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+  const component = mount(AmberScope, { target });
+  flushSync();
+  components.push(component);
+  return target;
+}
+
+beforeEach(() => {
+  components = [];
+});
+
+afterEach(() => {
+  components.forEach((c) => unmount(c));
+  document.body.innerHTML = '';
+});
+
+// ── Static: the projection swap itself ──────────────────────────────────────
+
+describe('AmberCockpit / AmberScope import migration (MOR-1409 A14)', () => {
+  it('AmberCockpit.svelte no longer imports wiring/state-adapter', () => {
+    const source = readFileSync('src/components-v2/panels/lcd/AmberCockpit.svelte', 'utf8');
+    expect(source).not.toMatch(/wiring\/state-adapter/);
+    expect(source).toContain("from '$lib/runtime/props/panel-props'");
+  });
+
+  it('AmberScope.svelte no longer imports wiring/state-adapter', () => {
+    const source = readFileSync('src/components-v2/panels/lcd/AmberScope.svelte', 'utf8');
+    expect(source).not.toMatch(/wiring\/state-adapter/);
+    expect(source).toContain("from '$lib/runtime/props/panel-props'");
+  });
+});
+
+// ── RIT-offset consumer-boundary guard (AmberCockpit only — AmberScope never
+//    reads ritOffset, per plan §3.2) ─────────────────────────────────────────
+
+describe('AmberCockpit RIT-offset NaN guard (MOR-1409 A14 plan §4.2 finding #1)', () => {
+  it('state === null: no RIT row at all (ritActive itself is false)', () => {
+    const target = mountCockpit(null);
+    expect(target.querySelector('.rit-value')).toBeNull();
+  });
+
+  it('connected but ritFreq unobserved: RIT is on, but the offset never renders "NaN"', () => {
+    const state = {
+      active: 'MAIN',
+      main: baseReceiver(),
+      sub: baseReceiver(),
+      ritOn: true,
+      // ritFreq intentionally absent — panel-props defaults it to NaN.
+    } as unknown as ServerState;
+
+    const target = mountCockpit(state);
+    const value = target.querySelector('.rit-value');
+    expect(value).not.toBeNull();
+    expect(value!.textContent).not.toContain('NaN');
+  });
+
+  it('connected with an observed ritFreq: the real offset still renders (guard is not overbroad)', () => {
+    const state = {
+      active: 'MAIN',
+      main: baseReceiver(),
+      sub: baseReceiver(),
+      ritOn: true,
+      ritFreq: 250,
+    } as unknown as ServerState;
+
+    const target = mountCockpit(state);
+    const value = target.querySelector('.rit-value');
+    expect(value!.textContent).toBe('+0.25 kHz');
+  });
+});
+
+// ── Meter-format silent-fallback guard (AmberCockpit only — AmberScope never
+//    imports toMeterProps, per plan §3.2) — correction 5247684776 ──────────
+
+describe('AmberCockpit meter-source silent-fallback guard (MOR-1409 A14 plan §4.2 finding #2)', () => {
+  function meterSourceButton(target: HTMLElement): HTMLButtonElement {
+    const btn = target.querySelector<HTMLButtonElement>('.lcd-meter-src-btn');
+    if (!btn) throw new Error('meter source button did not mount');
+    return btn;
+  }
+
+  it('powerMeter unobserved: selecting PO does not present a fabricated full-scale reading — falls back to S', () => {
+    const state = {
+      active: 'MAIN',
+      main: baseReceiver(),
+      sub: baseReceiver(),
+      // powerMeter intentionally absent — panel-props defaults meter.rfPower to NaN.
+    } as unknown as ServerState;
+
+    const target = mountCockpit(state);
+    const btn = meterSourceButton(target);
+    expect(btn.textContent).toBe('S');
+    btn.click();
+    flushSync();
+    // User selected PO, but the field is unobserved: the displayed source
+    // must not silently present the piecewise() clamp-and-fallthrough
+    // top-of-scale value as though it were a confirmed reading.
+    expect(btn.textContent).toBe('S');
+  });
+
+  it('powerMeter observed: selecting PO does present PO (guard is not overbroad)', () => {
+    const state = {
+      active: 'MAIN',
+      main: baseReceiver(),
+      sub: baseReceiver(),
+      powerMeter: 100,
+    } as unknown as ServerState;
+
+    const target = mountCockpit(state);
+    const btn = meterSourceButton(target);
+    btn.click();
+    flushSync();
+    expect(btn.textContent).toBe('PO');
+  });
+});
+
+// ── Filter-ratio consumer-boundary guard (both owner files, ghost fallback
+//    path — plan §4.2 finding #3) ───────────────────────────────────────────
+
+function ghostPassbandPoints(target: HTMLElement): string {
+  const el = target.querySelector('polyline.passband');
+  if (!el) throw new Error('AmberFilterGhost passband polyline did not mount');
+  return el.getAttribute('points') ?? '';
+}
+
+describe('AmberCockpit filter-ratio NaN guard (MOR-1409 A14 plan §4.2 finding #3)', () => {
+  it('state === null: the ghost passband geometry stays finite', () => {
+    const target = mountCockpit(null, false);
+    expect(ghostPassbandPoints(target)).not.toContain('NaN');
+  });
+
+  it('connected but filterWidth unobserved: the ghost passband geometry stays finite', () => {
+    const state = {
+      active: 'MAIN',
+      main: baseReceiver(),
+      sub: baseReceiver(),
+      // main.filterWidth intentionally absent — panel-props defaults
+      // filterProps.filterWidth to NaN.
+    } as unknown as ServerState;
+
+    const target = mountCockpit(state, false);
+    expect(ghostPassbandPoints(target)).not.toContain('NaN');
+  });
+
+  it('connected with an observed filterWidth: the ghost still renders real geometry (guard is not overbroad)', () => {
+    const state = {
+      active: 'MAIN',
+      main: baseReceiver({ filterWidth: 1800 }),
+      sub: baseReceiver(),
+    } as unknown as ServerState;
+
+    const target = mountCockpit(state, false);
+    const points = ghostPassbandPoints(target);
+    expect(points).not.toContain('NaN');
+    expect(points.length).toBeGreaterThan(0);
+  });
+});
+
+describe('AmberScope filter-ratio NaN guard (MOR-1409 A14 plan §4.2 finding #3)', () => {
+  it('state === null: the ghost passband geometry stays finite', () => {
+    const target = mountScope(null, false);
+    expect(ghostPassbandPoints(target)).not.toContain('NaN');
+  });
+
+  it('connected but filterWidth unobserved: the ghost passband geometry stays finite', () => {
+    const state = {
+      active: 'MAIN',
+      main: baseReceiver(),
+      sub: baseReceiver(),
+    } as unknown as ServerState;
+
+    const target = mountScope(state, false);
+    expect(ghostPassbandPoints(target)).not.toContain('NaN');
+  });
+
+  it('connected with an observed filterWidth: the ghost still renders real geometry (guard is not overbroad)', () => {
+    const state = {
+      active: 'MAIN',
+      main: baseReceiver({ filterWidth: 1800 }),
+      sub: baseReceiver(),
+    } as unknown as ServerState;
+
+    const target = mountScope(state, false);
+    const points = ghostPassbandPoints(target);
+    expect(points).not.toContain('NaN');
+    expect(points.length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/components-v2/panels/lcd/__tests__/lcd-availability.isolated.test.ts
+++ b/frontend/src/components-v2/panels/lcd/__tests__/lcd-availability.isolated.test.ts
@@ -43,14 +43,31 @@ vi.mock('$lib/runtime', () => ({
   },
 }));
 
-// state-adapter is a presentation-only seam here; AGC gating is driven by the
+// panel-props is a presentation-only seam here; AGC gating is driven by the
 // real field-status resolver, not these adapters.
-vi.mock('../../../wiring/state-adapter', () => ({
-  toTxProps: () => ({ txActive: false, voxActive: false, compActive: false, compLevel: 0, atuActive: false, atuTuning: false }),
-  toRitXitProps: () => ({ ritActive: false, xitActive: false, ritOffset: 0 }),
+//
+// MOR-1409 A14: re-pointed from the retired `wiring/state-adapter` mock to
+// `$lib/runtime/props/panel-props` (the hardened projection AmberScope now
+// imports). Every literal below is re-derived against the real hardened
+// contract, not transcribed from the stale one (plan §5 pre-authorization
+// wording): `ritOffset`/`xitOffset`/`filterWidth` use the real `NaN`
+// "unobserved" sentinel rather than the old fabricated `0`/`2400` defaults.
+// None of these three fields are asserted on by the tests in this file
+// (AGC-gating only), so the honest values are inert here — updated for
+// contract accuracy, not because a test requires it.
+vi.mock('$lib/runtime/props/panel-props', () => ({
+  toTxProps: () => ({
+    txActive: false, voxActive: false, compActive: false, compLevel: 0,
+    atuActive: false, atuTuning: false, hasTx: false, hasTuner: false, hasMonitor: false,
+  }),
+  toRitXitProps: () => ({
+    ritActive: false, xitActive: false,
+    ritOffset: Number.NaN, xitOffset: Number.NaN,
+    hasRit: true, hasXit: true,
+  }),
   toVfoOpsProps: () => ({ splitActive: false }),
   toDspProps: () => ({ notchMode: 'off', notchFreq: 0 }),
-  toFilterProps: () => ({ filterWidth: 2400, filterWidthMax: 4000, ifShift: 0 }),
+  toFilterProps: () => ({ filterWidth: Number.NaN, filterWidthMax: 9999, ifShift: 0 }),
 }));
 
 import AmberScope from '../AmberScope.svelte';


### PR DESCRIPTION
Part of #2317

## MOR-1409 gate A14 (LCD/amber panel migration to honest projections)

Per the session-15 re-anchor plan (SHA-256 `249a53c9…`) and coordinator rulings [5247582313](https://github.com/rigplane/rigplane-core/issues/2317#issuecomment-5247582313) (owner set; state-adapter deletion deferred to A15) and [5247684776](https://github.com/rigplane/rigplane-core/issues/2317#issuecomment-5247684776) (meter silent-fallback risk on record). Light-tier evidence per [5243153469](https://github.com/rigplane/rigplane-core/issues/2317#issuecomment-5243153469).

- `frontend/src/components-v2/panels/lcd/AmberCockpit.svelte` (63) — re-pointed to hardened `panel-props` (+ `caps` arg for `toMeterProps`); three choke-point guards inside the owner: `effectiveMeterSource` (falls PO/SWR/ALC/COMP back to the always-safe raw S-meter branch on non-finite fields, preventing the piecewise clamp from presenting a fabricated full-scale reading), `ritOffsetLabel` (finite-gated, `'---'` instead of `"−NaN kHz"`), `safeFilterWidth` (clamps before AmberFilterGhost/AmberAfScope ratio math).
- `frontend/src/components-v2/panels/lcd/AmberScope.svelte` (18) — same re-point; filter-ratio guard only (never imports toMeterProps or renders ritOffset, verified live).

Guards live entirely in the two owners' `$derived`s; `state-adapter.ts`, all leaf components (`AmberSmeter`/`AmberFilterGhost`/`AmberFrequency`), and pure helpers (`meter-utils`/`rit-utils`/`smeter-scale`) byte-identical to base. Documented deviation: RED tests written at the owner-file consumer boundary rather than calling frozen `meter-utils` directly (the plan's literal shape would have required editing a frozen file).

Production churn 81 (< 391 STOP; test evidence uncounted per standing accounting). Head `858a233dbe2b3ec41a29edc2c104b4b0e7d74037`, base `5e094dfade947ec36ee7262b47785e0ee2c9d562`.

## Evidence (once-through, no retry-to-green)

- Causal RED at exact base: 3 genuine failures incl. proof no PO→S fallback existed
- Mutation battery: 7/7 killed (import reverts ×2, meter-fallback bypass, RIT bypass reproducing literal "−NaN kHz", filter-ratio bypass in both files reproducing NaN SVG coordinates, toMeterProps arg-drop via TS2554), byte-exact restores verified
- Focused GREEN: 92/92; full suite: 317 files / 6606 tests, all green, no leak
- svelte-check/lint/boundaries/i18n: 0 errors; 16 frozen seams byte-identical; goldens untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)