### PR TITLE
chore: gitignore frontend/fixtures-dist (built fixture-harness bundle)

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -32,3 +32,7 @@ test-results
 
 # Fixture verification capture output (verification-only, never committed).
 fixtures-baselines/
+
+# Built fixture-harness bundle (vite.fixtures.config.ts outDir). Regenerated
+# by fixtures/capture.mjs and by the vitest capture-preflight test.
+fixtures-dist/


### PR DESCRIPTION
## What

Adds `fixtures-dist/` to `frontend/.gitignore`, next to the existing `fixtures-baselines/` entry.

## Why

`frontend/fixtures-dist/` is the `build.outDir` of `vite.fixtures.config.ts` (the MOR-1070 additive fixture-harness config). It is generated by:

- `fixtures/capture.mjs` / `capture-ptt.mjs` (`await build({ configFile: vite.fixtures.config.ts })`), and
- since MOR-1409 A04a, the vitest test `src/components-v2/wiring/__tests__/fixture-capture-root-cwd.test.ts`, which runs `capture.mjs --preflight-only` on every plain `vitest run`.

The directory (~70 built files: skin/layout JS+CSS bundles, icons) was not covered by any .gitignore, so every checkout/worktree that ran the frontend tests ended up with dozens of untracked files — polluting `git status` and blocking plain `git worktree remove`.

Verified purely generated: the only reference to `fixtures-dist` in the repo is the `outDir` itself; nothing reads it from version control, and no files under it are tracked (`git ls-files frontend/fixtures-dist` is empty).

## Verification

- `git check-ignore -v frontend/fixtures-dist/apple-touch-icon.png` → matched by `frontend/.gitignore:38`
- No tracked files affected (pure .gitignore addition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)