### PR TITLE
fix: apply single-receiver default to memory, keyboard, and VFO-select gates (MOR-1423)

### DIFF
--- a/frontend/src/lib/runtime/commands/__tests__/memory-command-authority.isolated.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/memory-command-authority.isolated.test.ts
@@ -126,6 +126,32 @@ describe('MOR-1409 A05a memory command authority', () => {
     expect(h.calls).toHaveLength(0);
   });
 
+  it('routes recall/store/clear on a single-receiver radio although active is structurally unobservable (MOR-1423)', () => {
+    h.caps = caps('ab');
+    h.state = state('ab');
+    delete (h.state.fieldStatus as Record<string, unknown>).active;
+
+    const handlers = makeMemoryHandlers();
+    expect(handlers.onRecall(1)).toBe(true);
+    expect(handlers.onStore(2, 14_074_000, 'USB')).toBe(true);
+    expect(handlers.onClear(99)).toBe(true);
+    expect(h.calls.map(({ name, params }) => ({ name, params }))).toEqual([
+      { name: 'set_memory_mode', params: { channel: 1 } }, { name: 'memory_to_vfo', params: { channel: 1 } },
+      { name: 'set_memory_mode', params: { channel: 2 } }, { name: 'memory_write', params: {} },
+      { name: 'memory_clear', params: { channel: 99 } },
+    ]);
+  });
+
+  it('still requires observed active on dual-receiver radios for recall/store/clear (no regression, MOR-1423)', () => {
+    delete (h.state!.fieldStatus as Record<string, unknown>).active;
+
+    const handlers = makeMemoryHandlers();
+    expect(handlers.onRecall(1)).toBe(false);
+    expect(handlers.onStore(1, 14_074_000, 'USB')).toBe(false);
+    expect(handlers.onClear(1)).toBe(false);
+    expect(h.calls).toHaveLength(0);
+  });
+
   it('rejects absent active identity, generation drift, and impossible physical topology before dispatch', () => {
     const handlers = makeMemoryHandlers();
     h.state = { ...h.state!, active: undefined } as unknown as ServerState;

--- a/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.isolated.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.isolated.test.ts
@@ -707,6 +707,52 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
     expect(getCommandLifecycles()).toHaveLength(0);
   });
 
+  it('routes VFO slot selection on a single-receiver radio although active is structurally unobservable (MOR-1423)', () => {
+    h.caps = {
+      capabilities: ['split', 'tx', 'vox'], receivers: 1, vfoScheme: 'ab',
+      stateContractVersion: 1, providerGeneration: 31,
+    };
+    h.state = oneReceiverAbState();
+    h.unavailable.add('active');
+
+    makeVfoHandlers().onVfoSelect('MAIN', 'B');
+
+    expect(exactCalls()).toEqual([['set_vfo', { vfo: 'B' }]]);
+    expectIntentTransport();
+  });
+
+  it('still requires observed active on dual-receiver radios for VFO slot selection (no regression, MOR-1423)', () => {
+    h.unavailable.add('active');
+
+    makeVfoHandlers().onVfoSelect('MAIN', 'B');
+
+    expect(h.sendCommand).not.toHaveBeenCalled();
+    expect(getCommandLifecycles()).toHaveLength(0);
+  });
+
+  it('routes keyboard-delegated radio actions on a single-receiver radio although active is structurally unobservable (MOR-1423)', () => {
+    h.caps = {
+      capabilities: ['rit'], receivers: 1, vfoScheme: 'ab',
+      stateContractVersion: 1, providerGeneration: 31,
+    };
+    h.state = oneReceiverAbState();
+    h.unavailable.add('active');
+
+    expect(dispatchKeyboardRadioAction({ action: 'toggle_rit' })).toBe(true);
+
+    expect(exactCalls()).toEqual([['set_rit_status', { on: true }]]);
+    expectIntentTransport();
+  });
+
+  it('still requires observed active on dual-receiver radios for keyboard-delegated radio actions (no regression, MOR-1423)', () => {
+    h.unavailable.add('active');
+
+    expect(dispatchKeyboardRadioAction({ action: 'toggle_rit' })).toBe(true);
+
+    expect(h.sendCommand).not.toHaveBeenCalled();
+    expect(getCommandLifecycles()).toHaveLength(0);
+  });
+
   it('rejects pending physical SUB on one-RX A/B Selected/Unselected topology', () => {
     h.caps = { capabilities: ['pbt'], receivers: 1, vfoScheme: 'ab' };
     h.state = oneReceiverAbState();

--- a/frontend/src/lib/runtime/commands/panel-commands.ts
+++ b/frontend/src/lib/runtime/commands/panel-commands.ts
@@ -195,8 +195,14 @@ function observedAvailableField(
 
 function currentMemorySnapshot(): MemorySnapshot | null {
   const context = currentA03cContext();
-  const active = context?.state.active;
-  if (!context || !observedAvailableField(context.state, 'active')
+  // MOR-1423: same single-receiver `active` bypass as knownActiveReceiver
+  // (MOR-1418) — on a one-receiver radio, active is tautologically MAIN
+  // even when structurally unobservable. Dual-RX still requires observation.
+  const activeObserved = context !== null && observedAvailableField(context.state, 'active');
+  const singleReceiver = context?.caps.receivers === 1;
+  const active = context
+    && (activeObserved ? context.state.active : singleReceiver ? 'MAIN' : undefined);
+  if (!context
     || (active !== 'MAIN' && active !== 'SUB')
     || knownA03cReceiver(context, active) === null) return null;
 
@@ -1063,10 +1069,17 @@ export function makeVfoHandlers() {
     onSubVfoClick: () => { activateReceiver('SUB'); },
     onVfoSelect: (receiver: 'MAIN' | 'SUB', slot: 'A' | 'B' | null) => {
       const context = currentA03cContext();
-      if (!context || !knownA03cTopLevelField(context, 'active')
+      // MOR-1423: same single-receiver `active` bypass as knownActiveReceiver
+      // (MOR-1418) — on a one-receiver radio, active is tautologically MAIN
+      // even when structurally unobservable. Dual-RX still requires observation.
+      const activeObserved = context !== null && knownA03cTopLevelField(context, 'active');
+      const singleReceiver = context?.caps.receivers === 1;
+      const active = context
+        && (activeObserved ? context.state.active : singleReceiver ? 'MAIN' : undefined);
+      if (!context || (active !== 'MAIN' && active !== 'SUB')
         || knownA03cReceiver(context, receiver) === null
         || !supportsVfoSlot(context, slot)) return;
-      if (context.state.active !== receiver && !activateReceiver(receiver, context)) return;
+      if (active !== receiver && !activateReceiver(receiver, context)) return;
       if (slot !== null) dispatchRadioIntent({ name: 'set_vfo', params: { vfo: slot } });
     },
     onMainModeClick: () => focusModePanel('MAIN'),
@@ -1271,8 +1284,14 @@ const KEYBOARD_RADIO_ACTIONS = new Set([
 
 function currentKeyboardContext(): KeyboardContext | null {
   const context = currentA03cContext();
-  const active = context?.state.active;
-  if (!context || !knownA03cTopLevelField(context, 'active') || (active !== 'MAIN' && active !== 'SUB')) return null;
+  // MOR-1423: same single-receiver `active` bypass as knownActiveReceiver
+  // (MOR-1418) — on a one-receiver radio, active is tautologically MAIN
+  // even when structurally unobservable. Dual-RX still requires observation.
+  const activeObserved = context !== null && knownA03cTopLevelField(context, 'active');
+  const singleReceiver = context?.caps.receivers === 1;
+  const active = context
+    && (activeObserved ? context.state.active : singleReceiver ? 'MAIN' : undefined);
+  if (!context || (active !== 'MAIN' && active !== 'SUB')) return null;
   const receiver = knownA03cReceiver(context, active);
   return receiver === null ? null : { ...context, receiver };
 }


### PR DESCRIPTION
## Summary

PR #2372 (MOR-1418) fixed `knownActiveReceiver()` and `onFilterWidthCommit` so they no longer require positive observation of the radio-wide `active` (MAIN/SUB) field before routing writes on single-receiver radios (IC-7300, IC-705, X6200) — no CI-V echo ever sets `active` on those radios, so it never becomes observed and the gate was permanently closed.

An exhaustive grep for remaining `active`-observation gates in `frontend/src` found three more call sites in `frontend/src/lib/runtime/commands/panel-commands.ts` with the identical latent gate, all now fixed with the same `receivers === 1` → default `'MAIN'` policy:

1. `currentMemorySnapshot` (~line 199) — blocked memory recall/store/clear.
2. `currentKeyboardContext` (~line 1284) — blocked keyboard shortcut actions.
3. `onVfoSelect`'s `knownA03cTopLevelField(context, 'active')` gate (~line 1072) — the dead "select VFO" A/B link on IC-7300 (`SemanticRadioSurfaces.svelte:448` → `selectVfo`).

## Pattern (identical to #2372)

- `getCapabilities()?.receivers === 1` **and** `active` not observed → default the receiver/slot context to `'MAIN'`.
- `active` observed → honor the observed value, unchanged semantics (including impossible-SUB rejection).
- `receivers > 1` or capabilities unknown → byte-identical to prior behavior.
- No fields marked observed, no `fieldStatus` changes, no leaf-field read gates relaxed.

## Test evidence

TDD: added failing tests first, confirmed RED with the production change reverted (`git stash` of `panel-commands.ts` only), then GREEN with it restored.

- `frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.isolated.test.ts` — 2 new tests (VFO-select single-RX dispatch + dual-RX regression) + 2 new tests (keyboard-delegated action single-RX dispatch + dual-RX regression). File: 92 → 94 tests, all pass.
- `frontend/src/lib/runtime/commands/__tests__/memory-command-authority.isolated.test.ts` — 2 new tests (memory recall/store/clear single-RX dispatch + dual-RX regression), reusing that file's own `state(scheme)`/`caps(scheme)` fixtures (its default fixtures already carry the VFO-slot fieldStatus these handlers need, unlike `panel-commands.intent.isolated.test.ts`'s dual-RX `state()`, which doesn't populate `activeSlot`/`vfoA`).

RED (before fix): `Test Files 2 failed | Tests 3 failed | 99 passed (102)`
GREEN (after fix): `Test Files 2 passed | Tests 102 passed (102)`

Full suite: `npm test` → `Test Files 317 passed | Tests 6549 passed (6549)`, zero failures.
`npm run lint` → zero violations.
`npm run check` → `4526 FILES 0 ERRORS 0 WARNINGS`.

## Scope

3 files changed, 97 insertions(+), 6 deletions(-). Net production LOC in `panel-commands.ts`: +25 (31 insertions / 6 deletions), well under the 200 LOC budget. No new abstractions.

Linear: https://linear.app/morozsm/issue/MOR-1423

---

**Independent verifier review pending — do not merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)