### PR TITLE
fix: coalesce rate-limited value writes and ack them honestly (MOR-1427)

### DIFF
--- a/docs/api/command-catalog.md
+++ b/docs/api/command-catalog.md
@@ -30,7 +30,7 @@ protocol examples.
 
 ## Rate limiting
 
-`set_*` commands over WebSocket are rate-limited to one per 50 ms per client. Commands arriving before the interval expires receive an immediate ACK with `{"throttled": true}` and are not enqueued. HTTP endpoints are not throttled at this layer.
+`set_*` commands over WebSocket are physically enqueued at most once per 50 ms per client, per command name. Commands arriving before the interval expires are coalesced with last-value-wins semantics (MOR-1427) rather than dropped: the newest frame in the window always survives to the next paced enqueue. Any frame it replaces before that flush receives an immediate ACK with `{"superseded": true}` and is never enqueued; the surviving frame gets the normal enqueue ACK at the pacing boundary. HTTP endpoints are not throttled at this layer.
 
 ## Batch eligibility rules
 

--- a/docs/api/web.md
+++ b/docs/api/web.md
@@ -1089,10 +1089,23 @@ is rejected with `"error":"radio_not_ready"` instead of a silent enqueue-ACK
 (MOR-620). Unkeying (`ptt` with `state:false`, or `ptt_off`) always goes
 through: it is the safe direction.
 
-Rate-limited high-frequency `set_*` commands are ACKed with:
+High-frequency `set_*` commands (same command name, same session, arriving
+faster than one per 50ms) are coalesced with last-value-wins semantics
+(MOR-1427) instead of being dropped. Only one physical enqueue happens per
+50ms pacing window: the newest frame in the window always survives to that
+enqueue, and any frame it replaces before flush is ACKed immediately with an
+honest supersede reply instead of a real result:
 
 ```json
-{"type":"response","id":"42","ok":true,"result":{"throttled":true}}
+{"type":"response","id":"41","ok":true,"result":{"superseded":true}}
+```
+
+The frame that is actually enqueued at the pacing boundary — always the most
+recent one received, never an older one — gets the normal enqueue ACK, exactly
+like a command that was never rate-limited:
+
+```json
+{"type":"response","id":"42","ok":true,"result":{"freq":14074000,"receiver":0}}
 ```
 
 ### State update stream (`/api/v1/ws`)

--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -483,7 +483,6 @@ class ControlHandler:
         )
         # Per-command rate limiting: command_name -> last physical-enqueue time.
         self._cmd_last: dict[str, float] = {}
-        self._cmd_drops: dict[str, int] = {}
         # Minimum interval between same command (seconds).
         # Continuous slider/knob drag sends dozens of set_* per second.
         self._CMD_MIN_INTERVAL = 0.05  # 50ms = max 20 commands/sec per client
@@ -939,11 +938,19 @@ class ControlHandler:
         if name.startswith("set_"):
             now = time.monotonic()
             last = self._cmd_last.get(name, 0.0)
-            if now - last < self._CMD_MIN_INTERVAL:
+            # MOR-1427 review B1: a pending frame for this name must always
+            # win the race, even if the deferred flush task is running late
+            # (event loop briefly busy past its deadline). Consulting only
+            # the elapsed time here lets a newer frame slip past the gate
+            # and dispatch immediately while an OLDER frame is still queued
+            # for flush — the flush then overwrites the newer value with the
+            # stale one. Checking `_cmd_pending` closes that window: as long
+            # as a frame is still waiting to flush, every new frame joins the
+            # coalesce path instead of racing it.
+            if now - last < self._CMD_MIN_INTERVAL or name in self._cmd_pending:
                 await self._coalesce_command(name, cmd_id, params, now, last)
                 return
             self._cmd_last[name] = now
-            self._cmd_drops[name] = 0
 
         await self._dispatch_command(cmd_id, name, params)
 
@@ -1012,7 +1019,24 @@ class ControlHandler:
         cmd_id, params = pending
         self._cmd_last[name] = time.monotonic()
         self._cmd_coalesced[name] = 0
-        await self._dispatch_command(cmd_id, name, params)
+        try:
+            await self._dispatch_command(cmd_id, name, params)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            # MOR-1427 review N3: this task is fire-and-forget (nothing
+            # awaits it in production — only tests do, via
+            # _cmd_flush_tasks). _dispatch_command already catches command
+            # failures internally and replies with an error frame; this
+            # guards the outer edge case (e.g. the reply write itself
+            # failing on a dead socket) so it cannot escape as an
+            # unretrieved task exception.
+            logger.warning(
+                "control: deferred flush of %r (id=%r) failed",
+                name,
+                cmd_id,
+                exc_info=True,
+            )
 
     def _cancel_pending_command_flushes(self) -> None:
         """Cancel in-flight coalesced-flush tasks on session teardown (MOR-1427).

--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -481,12 +481,23 @@ class ControlHandler:
         self._event_queue: BoundedQueue[dict[str, Any]] = BoundedQueue(
             maxsize=100,
         )
-        # Per-command rate limiting: command_name -> (last_time, drop_count)
+        # Per-command rate limiting: command_name -> last physical-enqueue time.
         self._cmd_last: dict[str, float] = {}
         self._cmd_drops: dict[str, int] = {}
         # Minimum interval between same command (seconds).
         # Continuous slider/knob drag sends dozens of set_* per second.
         self._CMD_MIN_INTERVAL = 0.05  # 50ms = max 20 commands/sec per client
+        # MOR-1427: last-value-wins coalescing for commands arriving inside
+        # the pacing window above, instead of the old silent hard-drop.
+        # command_name -> (command_id, params) of the most recent frame
+        # still waiting for its paced flush.
+        self._cmd_pending: dict[str, tuple[Any, dict[str, Any]]] = {}
+        # command_name -> the single deferred-flush task scheduled for it
+        # (one handle per (session, command) — this session owns them all).
+        self._cmd_flush_tasks: dict[str, asyncio.Task[None]] = {}
+        # command_name -> count of frames coalesced (superseded before they
+        # could flush) in the current burst — reset once that burst flushes.
+        self._cmd_coalesced: dict[str, int] = {}
         shared_service = getattr(server, "command_service", None)
         if isinstance(shared_service, CommandService):
             self._command_service = shared_service
@@ -554,6 +565,7 @@ class ControlHandler:
             self._release_ptt_on_teardown()
             self._publish_session_liveness(live=False)
             self._clear_mod_input_restore_on_teardown()
+            self._cancel_pending_command_flushes()
             event_task.cancel()
             try:
                 await event_task
@@ -920,36 +932,110 @@ class ControlHandler:
             return
 
         # ── Server-side rate limiting (per client, per command) ──
-        # Only throttle SET commands (continuous slider/knob drag).
-        # GET and read-only commands pass through.
+        # Only pace SET commands (continuous slider/knob drag). GET and
+        # read-only commands pass through. MOR-1427: a command arriving
+        # inside the pacing window is coalesced (last-value-wins) instead
+        # of hard-dropped — see _coalesce_command / _flush_coalesced_command.
         if name.startswith("set_"):
             now = time.monotonic()
             last = self._cmd_last.get(name, 0.0)
             if now - last < self._CMD_MIN_INTERVAL:
-                drops = self._cmd_drops.get(name, 0) + 1
-                self._cmd_drops[name] = drops
-                if drops == 1 or drops % 50 == 0:
-                    logger.warning(
-                        "rate-limit: dropping %s (%.0fms since last, dropped=%d)",
-                        name,
-                        (now - last) * 1000,
-                        drops,
-                    )
-                # Still ACK the client so it doesn't stall
-                await self._ws.send_text(
-                    encode_json(
-                        {
-                            "type": "response",
-                            "id": cmd_id,
-                            "ok": True,
-                            "result": {"throttled": True},
-                        }
-                    )
-                )
+                await self._coalesce_command(name, cmd_id, params, now, last)
                 return
             self._cmd_last[name] = now
             self._cmd_drops[name] = 0
 
+        await self._dispatch_command(cmd_id, name, params)
+
+    async def _coalesce_command(
+        self,
+        name: str,
+        cmd_id: Any,
+        params: dict[str, Any],
+        now: float,
+        last: float,
+    ) -> None:
+        """Last-value-wins coalescing for a frame inside the pacing window (MOR-1427).
+
+        The most recent frame for *name* always survives to the next paced
+        flush. Any frame it replaces gets an honest ``superseded`` reply
+        right away instead of the old silent-drop ``throttled`` ack — it
+        never reaches the command queue, so it must not claim it did.
+        Physical-enqueue pacing (``_CMD_MIN_INTERVAL``) is unchanged: this
+        only decides *which* frame's value is the one flushed when the
+        window reopens, never how often the window opens.
+        """
+        previous = self._cmd_pending.get(name)
+        if previous is not None:
+            prev_cmd_id, _ = previous
+            count = self._cmd_coalesced.get(name, 0) + 1
+            self._cmd_coalesced[name] = count
+            if count == 1 or count % 50 == 0:
+                logger.warning(
+                    "rate-limit: coalescing %s (%.0fms since last, coalesced=%d)",
+                    name,
+                    (now - last) * 1000,
+                    count,
+                )
+            await self._ws.send_text(
+                encode_json(
+                    {
+                        "type": "response",
+                        "id": prev_cmd_id,
+                        "ok": True,
+                        "result": {"superseded": True},
+                    }
+                )
+            )
+        self._cmd_pending[name] = (cmd_id, params)
+        if name not in self._cmd_flush_tasks:
+            delay = max(self._CMD_MIN_INTERVAL - (now - last), 0.0)
+            self._cmd_flush_tasks[name] = asyncio.create_task(
+                self._flush_coalesced_command(name, delay)
+            )
+
+    async def _flush_coalesced_command(self, name: str, delay: float) -> None:
+        """Deferred physical enqueue for a coalesced burst (MOR-1427).
+
+        Fires once, at the pacing boundary, and dispatches whichever frame
+        is the most recently pending one for *name* at that moment — never
+        necessarily the frame that originally triggered the delay.
+        """
+        try:
+            if delay > 0.0:
+                await asyncio.sleep(delay)
+        finally:
+            self._cmd_flush_tasks.pop(name, None)
+        pending = self._cmd_pending.pop(name, None)
+        if pending is None:
+            return
+        cmd_id, params = pending
+        self._cmd_last[name] = time.monotonic()
+        self._cmd_coalesced[name] = 0
+        await self._dispatch_command(cmd_id, name, params)
+
+    def _cancel_pending_command_flushes(self) -> None:
+        """Cancel in-flight coalesced-flush tasks on session teardown (MOR-1427).
+
+        A flush firing after the socket is gone would enqueue a stale
+        command on behalf of a session that no longer exists and try to
+        write an ack to a dead transport. Bookkeeping only — the command
+        queue and radio state are untouched; this never enqueues anything.
+        """
+        for task in self._cmd_flush_tasks.values():
+            task.cancel()
+        self._cmd_flush_tasks.clear()
+        self._cmd_pending.clear()
+
+    async def _dispatch_command(
+        self, cmd_id: Any, name: str, params: dict[str, Any]
+    ) -> None:
+        """Validate, enqueue, and ACK a single command.
+
+        Shared by the immediate pass-through path and the deferred
+        coalesced flush (MOR-1427) so both produce byte-identical
+        validation/enqueue/ack behavior.
+        """
         if name not in self._COMMANDS:
             await self._ws.send_text(
                 encode_json(

--- a/tests/test_mor1427_rate_limiter_coalesce.py
+++ b/tests/test_mor1427_rate_limiter_coalesce.py
@@ -1,0 +1,260 @@
+"""RED/GREEN tests for MOR-1427: rate-limited SET commands must coalesce
+(last-value-wins) instead of being silently dropped.
+
+Bug (live-measured on the RC stand): ``ControlHandler._handle_command``'s
+per-command rate limiter hard-drops any ``set_*`` command arriving within
+``_CMD_MIN_INTERVAL`` (50ms) of the previous same-name command on the same
+session, while still ACKing the dropped frame with ``ok: true``. A 10-frame
+incrementing ``set_freq`` burst applied only 1 value and silently lost 9.
+
+Fix under test: a command arriving inside the pacing window is coalesced
+(last-value-wins) rather than dropped. The pacing itself (one physical
+enqueue per ``_CMD_MIN_INTERVAL``) is preserved. A frame that gets replaced
+before it is flushed receives an honest ``{ok: true, result: {superseded:
+true}}`` reply instead of the old ``{throttled: true}`` fiction; the frame
+that is actually flushed gets the real enqueue ack.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from rigplane.web.handlers import ControlHandler
+from rigplane.web.protocol import decode_json
+from rigplane.web.radio_poller import PttOff, SetFreq
+
+pytestmark = pytest.mark.asyncio
+
+
+class _QueueRecorder:
+    """Mirrors the recorder used in tests/test_handlers_coverage.py."""
+
+    def __init__(self) -> None:
+        self.items: list[object] = []
+
+    def put(self, item: object) -> None:
+        self.items.append(item)
+
+
+def _control_handler(
+    ws: object | None = None,
+    radio: object | None = None,
+    server: object | None = None,
+    session_id: str | None = None,
+) -> ControlHandler:
+    if ws is None:
+        ws = SimpleNamespace(send_text=AsyncMock(), recv=AsyncMock())
+    return ControlHandler(
+        ws,
+        radio,
+        "9.9.9",
+        "IC-7610",
+        server=server,
+        session_id=session_id,
+    )
+
+
+def _sent_messages(ws: SimpleNamespace) -> list[dict[str, Any]]:
+    return [decode_json(c.args[0]) for c in ws.send_text.await_args_list]
+
+
+def _messages_by_id(ws: SimpleNamespace) -> dict[str, dict[str, Any]]:
+    """Last message observed for each command id (each id should get exactly one)."""
+    out: dict[str, dict[str, Any]] = {}
+    for msg in _sent_messages(ws):
+        out[msg["id"]] = msg
+    return out
+
+
+async def _await_flush(handler: ControlHandler, name: str) -> None:
+    """Wait for the deferred coalesced flush (if any) for *name* to complete."""
+    task = handler._cmd_flush_tasks.get(name)  # noqa: SLF001
+    if task is not None:
+        await task
+
+
+# ---------------------------------------------------------------------------
+# (a) Burst of N incrementing targets -> pacing-allowed enqueue count,
+#     final enqueued value is the LAST target.
+# ---------------------------------------------------------------------------
+
+
+async def test_burst_coalesces_to_last_value_not_dropped() -> None:
+    ws = SimpleNamespace(send_text=AsyncMock(), recv=AsyncMock())
+    queue = _QueueRecorder()
+    handler = _control_handler(
+        ws=ws,
+        radio=SimpleNamespace(connected=True),
+        server=SimpleNamespace(command_queue=queue),
+    )
+
+    n = 10
+    base_freq = 14_000_000
+    for i in range(n):
+        await handler._handle_command(
+            {"id": str(i), "name": "set_freq", "params": {"freq": base_freq + i}}
+        )
+
+    # Only the first frame is enqueued synchronously (paces the window open).
+    assert len(queue.items) == 1
+    assert isinstance(queue.items[0], SetFreq)
+    assert queue.items[0].freq == base_freq
+
+    await _await_flush(handler, "set_freq")
+
+    # Exactly one more physical enqueue happens at the paced flush, carrying
+    # the LAST target in the burst — never lost, never any of the middle ones.
+    assert len(queue.items) == 2
+    assert isinstance(queue.items[1], SetFreq)
+    assert queue.items[1].freq == base_freq + n - 1
+
+
+# ---------------------------------------------------------------------------
+# (b) Superseded frames get the honest reply shape; applied frames get the
+#     real ack. Every frame gets exactly one reply.
+# ---------------------------------------------------------------------------
+
+
+async def test_superseded_frames_get_honest_reply_flushed_frame_gets_real_ack() -> None:
+    ws = SimpleNamespace(send_text=AsyncMock(), recv=AsyncMock())
+    queue = _QueueRecorder()
+    handler = _control_handler(
+        ws=ws,
+        radio=SimpleNamespace(connected=True),
+        server=SimpleNamespace(command_queue=queue),
+    )
+
+    n = 10
+    base_freq = 14_000_000
+    for i in range(n):
+        await handler._handle_command(
+            {"id": str(i), "name": "set_freq", "params": {"freq": base_freq + i}}
+        )
+    await _await_flush(handler, "set_freq")
+
+    by_id = _messages_by_id(ws)
+    assert set(by_id) == {str(i) for i in range(n)}
+
+    # id "0" was dispatched immediately — real ack, no superseded marker.
+    assert by_id["0"]["ok"] is True
+    assert by_id["0"]["result"] == {"freq": base_freq, "receiver": 0}
+
+    # ids "1".."8" were each replaced by a newer frame before they could
+    # flush — honest supersede reply, never claims unqualified success.
+    for i in range(1, n - 1):
+        msg = by_id[str(i)]
+        assert msg["ok"] is True
+        assert msg["result"] == {"superseded": True}
+
+    # id "9" (the last target) is the one actually flushed — real ack.
+    last_id = str(n - 1)
+    assert by_id[last_id]["ok"] is True
+    assert by_id[last_id]["result"] == {"freq": base_freq + n - 1, "receiver": 0}
+
+
+# ---------------------------------------------------------------------------
+# (c) Commands slower than 50ms apart behave byte-identically to today:
+#     both dispatch immediately, no coalescing, no supersede replies.
+# ---------------------------------------------------------------------------
+
+
+async def test_slower_than_window_commands_are_unaffected() -> None:
+    ws = SimpleNamespace(send_text=AsyncMock(), recv=AsyncMock())
+    queue = _QueueRecorder()
+    handler = _control_handler(
+        ws=ws,
+        radio=SimpleNamespace(connected=True),
+        server=SimpleNamespace(command_queue=queue),
+    )
+
+    await handler._handle_command(
+        {"id": "x", "name": "set_freq", "params": {"freq": 14_074_000}}
+    )
+    await asyncio.sleep(handler._CMD_MIN_INTERVAL + 0.02)  # noqa: SLF001
+    await handler._handle_command(
+        {"id": "y", "name": "set_freq", "params": {"freq": 14_075_000}}
+    )
+
+    assert len(queue.items) == 2
+    assert [item.freq for item in queue.items] == [14_074_000, 14_075_000]
+
+    by_id = _messages_by_id(ws)
+    assert by_id["x"]["result"] == {"freq": 14_074_000, "receiver": 0}
+    assert by_id["y"]["result"] == {"freq": 14_075_000, "receiver": 0}
+    assert not handler._cmd_pending  # noqa: SLF001
+    assert not handler._cmd_flush_tasks  # noqa: SLF001
+
+
+# ---------------------------------------------------------------------------
+# (d) PTT / TX-off paths are NOT subject to this limiter at all — pin it.
+# ---------------------------------------------------------------------------
+
+
+async def test_ptt_off_bursts_are_never_rate_limited_or_coalesced() -> None:
+    ws = SimpleNamespace(send_text=AsyncMock(), recv=AsyncMock())
+    queue = _QueueRecorder()
+    handler = _control_handler(
+        ws=ws,
+        radio=SimpleNamespace(connected=True),
+        server=SimpleNamespace(command_queue=queue),
+    )
+
+    n = 5
+    for i in range(n):
+        await handler._handle_command(
+            {"id": f"ptt-{i}", "name": "ptt_off", "params": {}}
+        )
+
+    # Every single PTT OFF physically enqueues immediately — no coalescing,
+    # no pending state, regardless of how tightly they are spaced.
+    assert len(queue.items) == n
+    assert all(isinstance(item, PttOff) for item in queue.items)
+    assert "ptt_off" not in handler._cmd_pending  # noqa: SLF001
+    assert "ptt_off" not in handler._cmd_flush_tasks  # noqa: SLF001
+
+    by_id = _messages_by_id(ws)
+    for i in range(n):
+        msg = by_id[f"ptt-{i}"]
+        assert msg["ok"] is True
+        assert msg["result"] == {}
+
+
+# ---------------------------------------------------------------------------
+# (e) Counter accuracy: every coalesce/supersede event is counted exactly.
+# ---------------------------------------------------------------------------
+
+
+async def test_coalesce_counter_is_accurate_and_logged(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    ws = SimpleNamespace(send_text=AsyncMock(), recv=AsyncMock())
+    queue = _QueueRecorder()
+    handler = _control_handler(
+        ws=ws,
+        radio=SimpleNamespace(connected=True),
+        server=SimpleNamespace(command_queue=queue),
+    )
+
+    n = 10
+    with caplog.at_level(logging.WARNING, logger="rigplane.web.handlers.control"):
+        for i in range(n):
+            await handler._handle_command(
+                {"id": str(i), "name": "set_freq", "params": {"freq": 14_000_000 + i}}
+            )
+
+        # 10 frames: 1 dispatched immediately, 9 coalesced-in, 8 of those
+        # superseded before flush (the 9th survives to flush).
+        assert handler._cmd_coalesced.get("set_freq") == 8  # noqa: SLF001
+        assert any("set_freq" in rec.message for rec in caplog.records)
+
+        await _await_flush(handler, "set_freq")
+
+    # Counter resets once the burst actually flushes, so the next burst's
+    # count is not inflated by a prior one.
+    assert handler._cmd_coalesced.get("set_freq", 0) == 0  # noqa: SLF001

--- a/tests/test_mor1427_rate_limiter_coalesce.py
+++ b/tests/test_mor1427_rate_limiter_coalesce.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import random
+import time
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock
@@ -27,7 +29,7 @@ import pytest
 
 from rigplane.web.handlers import ControlHandler
 from rigplane.web.protocol import decode_json
-from rigplane.web.radio_poller import PttOff, SetFreq
+from rigplane.web.radio_poller import PttOff, SetFilterWidth, SetFreq, SetMode
 
 pytestmark = pytest.mark.asyncio
 
@@ -258,3 +260,262 @@ async def test_coalesce_counter_is_accurate_and_logged(
     # Counter resets once the burst actually flushes, so the next burst's
     # count is not inflated by a prior one.
     assert handler._cmd_coalesced.get("set_freq", 0) == 0  # noqa: SLF001
+
+
+# ---------------------------------------------------------------------------
+# (f) MOR-1427 review B1 regression pin: a pending frame must always win the
+#     race, even once the raw pacing window has elapsed, if the deferred
+#     flush task has not actually run yet (event loop stalled past its
+#     deadline). Consulting only elapsed time let a newer frame bypass the
+#     gate and dispatch immediately while an OLDER frame was still queued
+#     for flush -- the flush then overwrote the newer value with the stale
+#     one. See src/rigplane/web/handlers/control.py `_handle_command`.
+# ---------------------------------------------------------------------------
+
+
+async def test_late_flush_gate_diverts_to_coalescing_when_frame_pending() -> None:
+    ws = SimpleNamespace(send_text=AsyncMock(), recv=AsyncMock())
+    queue = _QueueRecorder()
+    handler = _control_handler(
+        ws=ws,
+        radio=SimpleNamespace(connected=True),
+        server=SimpleNamespace(command_queue=queue),
+    )
+
+    base_freq = 14_000_000
+
+    # F1: dispatched immediately -- opens the pacing window.
+    await handler._handle_command(
+        {"id": "f1", "name": "set_freq", "params": {"freq": base_freq}}
+    )
+    assert len(queue.items) == 1
+
+    # F2: arrives inside the window -> coalesced, schedules the deferred
+    # flush task for "set_freq".
+    await handler._handle_command(
+        {"id": "f2", "name": "set_freq", "params": {"freq": base_freq + 1}}
+    )
+    assert "set_freq" in handler._cmd_pending  # noqa: SLF001
+    assert "set_freq" in handler._cmd_flush_tasks  # noqa: SLF001
+
+    # Block the event loop SYNCHRONOUSLY past the flush deadline. Real
+    # wall-clock time now exceeds _CMD_MIN_INTERVAL since F1, but the
+    # sleeping flush task has not been resumed by the loop yet -- this is
+    # exactly the window the fix must close.
+    time.sleep(handler._CMD_MIN_INTERVAL + 0.02)  # noqa: SLF001
+
+    # F3: arrives after the raw window has elapsed by wall-clock time, while
+    # F2 is still the pending frame (flush task has not run). Must still be
+    # coalesced -- not dispatched immediately ahead of F2's queued flush.
+    await handler._handle_command(
+        {"id": "f3", "name": "set_freq", "params": {"freq": base_freq + 2}}
+    )
+
+    await _await_flush(handler, "set_freq")
+
+    # The LAST physical enqueue carries F3's value -- never the stale F2.
+    assert len(queue.items) == 2
+    assert isinstance(queue.items[1], SetFreq)
+    assert queue.items[1].freq == base_freq + 2
+
+    by_id = _messages_by_id(ws)
+    assert set(by_id) == {"f1", "f2", "f3"}
+    assert by_id["f1"]["ok"] is True
+    assert by_id["f1"]["result"] == {"freq": base_freq, "receiver": 0}
+    assert by_id["f2"]["ok"] is True
+    assert by_id["f2"]["result"] == {"superseded": True}
+    assert by_id["f3"]["ok"] is True
+    assert by_id["f3"]["result"] == {"freq": base_freq + 2, "receiver": 0}
+
+    # Every id got exactly one reply.
+    assert ws.send_text.await_count == 3
+
+
+# ---------------------------------------------------------------------------
+# (g) Battery/property test (MOR-1427 review evidence-tier requirement):
+#     many randomized bursts, with synchronous loop stalls injected at
+#     randomized offsets around the flush boundary, occasional cross-name
+#     interleaving, and occasional mid-burst teardown. Fixed seeds keep this
+#     deterministic in CI. Runtime budget: well under ~20s.
+#
+#     Invariants asserted per iteration:
+#       (a) the last physical write for a name always carries the value of
+#           the last frame dispatched for that name (unless that frame was
+#           still pending at a mid-burst teardown, per N4);
+#       (b) every frame id receives at most one reply, and exactly one
+#           unless it was cancelled by mid-burst teardown;
+#       (c) after a mid-burst teardown, no set_* command reaches the queue
+#           after the teardown's PTT OFF marker.
+# ---------------------------------------------------------------------------
+
+_BATTERY_PRIMARY_NAMES = ("set_freq", "set_filter_width")
+
+
+def _battery_value_for(name: str, n: int) -> int:
+    return 14_000_000 + n if name == "set_freq" else 500 + n
+
+
+def _battery_params_for(name: str, value: int) -> dict[str, Any]:
+    return {"freq": value} if name == "set_freq" else {"width": value}
+
+
+def _battery_dataclass_for(name: str) -> type:
+    return SetFreq if name == "set_freq" else SetFilterWidth
+
+
+def _reply_id_counts(ws: SimpleNamespace) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for msg in _sent_messages(ws):
+        counts[msg["id"]] = counts.get(msg["id"], 0) + 1
+    return counts
+
+
+async def _run_one_battery_iteration(rng: random.Random) -> None:
+    ws = SimpleNamespace(send_text=AsyncMock(), recv=AsyncMock())
+    queue = _QueueRecorder()
+    handler = _control_handler(
+        ws=ws,
+        radio=SimpleNamespace(connected=True),
+        server=SimpleNamespace(command_queue=queue),
+    )
+    # Shrink the pacing window so stalls stay small (same code path, faster
+    # wall-clock) -- _CMD_MIN_INTERVAL is a plain instance attribute.
+    handler._CMD_MIN_INTERVAL = 0.01  # noqa: SLF001
+
+    primary = rng.choice(_BATTERY_PRIMARY_NAMES)
+    secondary = _BATTERY_PRIMARY_NAMES[1 - _BATTERY_PRIMARY_NAMES.index(primary)]
+
+    burst_len = rng.randint(1, 8)
+    dispatched: list[tuple[str, int]] = []  # (id, value) for `primary`, in order
+    teardown_index: int | None = None  # index into queue.items of the PTT OFF marker
+    cancelled_id: str | None = None
+    teardown_fired = False
+
+    for step in range(burst_len):
+        # Occasionally stall the loop synchronously, at a randomized offset
+        # around the flush boundary (sometimes short of it, sometimes past
+        # it -- exercising the exact B1 race window).
+        if rng.random() < 0.35:
+            time.sleep(rng.uniform(0.0, handler._CMD_MIN_INTERVAL * 1.6))  # noqa: SLF001
+
+        # Occasionally interleave a one-shot secondary-name command. It is
+        # never itself rate-limited within this iteration (fresh handler,
+        # first frame for that name), so it must not perturb the primary
+        # burst's coalescing state.
+        if rng.random() < 0.25:
+            sec_id = f"sec-{step}"
+            await handler._handle_command(
+                {
+                    "id": sec_id,
+                    "name": secondary,
+                    "params": _battery_params_for(
+                        secondary, _battery_value_for(secondary, step)
+                    ),
+                }
+            )
+
+        # Occasionally tear down mid-burst instead of dispatching further.
+        if rng.random() < 0.2:
+            pending = handler._cmd_pending.get(primary)  # noqa: SLF001
+            if pending is not None:
+                cancelled_id = str(pending[0])
+            queue.put(PttOff())
+            teardown_index = len(queue.items) - 1
+            handler._cancel_pending_command_flushes()  # noqa: SLF001
+            teardown_fired = True
+            break
+
+        cmd_id = str(step)
+        value = _battery_value_for(primary, step)
+        dispatched.append((cmd_id, value))
+        await handler._handle_command(
+            {
+                "id": cmd_id,
+                "name": primary,
+                "params": _battery_params_for(primary, value),
+            }
+        )
+
+    if not teardown_fired:
+        # Let any still-pending flush for either name settle physically
+        # before asserting.
+        await _await_flush(handler, primary)
+        await _await_flush(handler, secondary)
+    else:
+        # Give any already-cancelled callback a chance to unwind; nothing
+        # further should ever append to the queue after this point.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+    reply_counts = _reply_id_counts(ws)
+
+    # (b) every id gets at most one reply; exactly one unless cancelled.
+    for cmd_id, _ in dispatched:
+        if cmd_id == cancelled_id:
+            assert reply_counts.get(cmd_id, 0) == 0, (
+                f"cancelled id {cmd_id!r} unexpectedly got a reply"
+            )
+        else:
+            assert reply_counts.get(cmd_id, 0) == 1, (
+                f"id {cmd_id!r} got {reply_counts.get(cmd_id, 0)} replies, expected 1"
+            )
+    assert all(count <= 1 for count in reply_counts.values())
+
+    # (a) the last physical write for `primary` carries the value of the
+    # last frame that actually completed (real, non-superseded ack).
+    by_id = _messages_by_id(ws)
+    real_ack_dispatched = [
+        (cmd_id, value)
+        for cmd_id, value in dispatched
+        if cmd_id in by_id and by_id[cmd_id].get("result") != {"superseded": True}
+    ]
+    primary_cls = _battery_dataclass_for(primary)
+    primary_writes = [item for item in queue.items if isinstance(item, primary_cls)]
+    if real_ack_dispatched:
+        last_id, last_value = real_ack_dispatched[-1]
+        assert primary_writes, f"expected a physical write for {primary!r}"
+        last_write = primary_writes[-1]
+        written_value = last_write.freq if primary == "set_freq" else last_write.width
+        assert written_value == last_value, (
+            f"last physical write for {primary!r} carries {written_value!r}, "
+            f"expected {last_value!r} (id {last_id!r})"
+        )
+
+    # If nothing was cancelled, the burst fully drained: no pending state,
+    # no outstanding flush tasks, and (if any frames were sent) the very
+    # last dispatched frame must be among the real (non-superseded) acks --
+    # i.e. it always eventually wins, never gets silently stuck as
+    # "superseded" with nothing superseding it.
+    if not teardown_fired:
+        assert primary not in handler._cmd_pending  # noqa: SLF001
+        assert primary not in handler._cmd_flush_tasks  # noqa: SLF001
+        if dispatched:
+            last_dispatched_id = dispatched[-1][0]
+            assert by_id[last_dispatched_id].get("result") != {"superseded": True}
+
+    # (c) after a mid-burst teardown, no set_* command reaches the queue
+    # after the teardown's PTT OFF marker.
+    if teardown_fired:
+        assert teardown_index is not None
+        for item in queue.items[teardown_index + 1 :]:
+            assert not isinstance(item, (SetFreq, SetFilterWidth, SetMode)), (
+                f"set_* command {item!r} reached the queue after teardown"
+            )
+        assert not handler._cmd_pending  # noqa: SLF001
+        assert not handler._cmd_flush_tasks  # noqa: SLF001
+
+
+async def test_battery_coalescing_survives_stalls_interleaving_and_teardown() -> None:
+    """MOR-1427 review evidence-tier requirement: property/burst battery.
+
+    200 iterations across 4 fixed seeds, each with a randomized burst,
+    randomized synchronous loop stalls around the flush boundary, occasional
+    cross-name interleaving, and occasional mid-burst teardown.
+    """
+    started = time.monotonic()
+    for seed in (1427, 1405, 2377, 42):
+        rng = random.Random(seed)
+        for _ in range(50):
+            await _run_one_battery_iteration(rng)
+    elapsed = time.monotonic() - started
+    assert elapsed < 20.0, f"battery took {elapsed:.1f}s, budget is 20s"


### PR DESCRIPTION
## Root cause

`ControlHandler._handle_command` in `src/rigplane/web/handlers/control.py` (`_CMD_MIN_INTERVAL = 0.05`) hard-drops any `set_*` command arriving within 50ms of the previous same-name command on the same WS session — no queue, no coalescing, no trailing flush — while still ACKing the dropped frame with `ok: true` / `result: {throttled: true}`.

**Live-measured evidence (RC stand):** a 10-frame incrementing `set_freq` burst sent back-to-back applied only the first value; the other 9 were silently lost forever, each acked as if successful.

## Fix

Replace the silent drop with **last-value-wins coalescing** per `(session, command name)`:

- The 50ms physical-enqueue pace is unchanged — this only changes *which* frame's value gets enqueued when the window reopens, never how often it reopens.
- A single deferred-flush `asyncio.Task` per command name (`_cmd_flush_tasks[name]`) fires at the pacing boundary and enqueues whichever frame is most recently pending (`_cmd_pending[name]`) at that moment.
- A frame that gets replaced by a newer one before it flushes gets an **honest reply now**: `{ok: true, result: {superseded: true}}`. The frame that actually flushes gets the real enqueue ack (`{ok: true, result: {...actual result...}}`).
- Flush tasks are cancelled on session teardown (`_cancel_pending_command_flushes`, wired into `run()`'s `finally`) so a dead socket never gets a stale late enqueue.
- Coalesce/supersede events are counted per command name (`_cmd_coalesced`) and logged at WARNING on the 1st and every 50th, mirroring the removed drop-log cadence — no per-event INFO spam.

### Chosen reply-contract shape and why it preserves ACK matching

Read `frontend/src/lib/transport/ws-client.ts` before choosing: `_emitCommandResult` matches purely by `id` and only branches on `raw.type === 'response'` / `raw.ok`. It does **not** inspect `result.throttled` today, and won't inspect `result.superseded` either. Keeping `ok: true` for the superseded reply means:

- The frontend's existing id-based ACK/delivery-tracking contract (`trackedNonPttCommands`, `response-ok` vs `response-error`) is untouched — no matching logic changes required.
- The `superseded: true` marker is available for a future frontend consumer without being a breaking change today.
- This is strictly more honest than the old `throttled: true` (which claimed success for a frame whose value never reached the radio at all): `superseded` says "your value was replaced by a newer one that did reach the radio," which is true under last-value-wins semantics.

An alternative (defer acks entirely / never reply to superseded frames) was rejected — it would leave frontend-tracked commands unresolved indefinitely, which is worse for the existing tracking-capacity/cleanup logic in `ws-client.ts`.

## PTT safety finding

`ptt`, `ptt_on`, `ptt_off` are **not** subject to this limiter today — the rate-limit gate only triggers on `name.startswith("set_")`, and none of the PTT command names start with `set_`. Confirmed by reading the code and pinned with a new regression test (`test_ptt_off_bursts_are_never_rate_limited_or_coalesced`) sending a tight burst of `ptt_off` and asserting every frame enqueues immediately with no coalescing state touched. **No STOP-SHIP finding** — this part of the system was already correct.

## Deliberate behavior changes

Two intentional deviations from MOR-1405's "preserve command serialization/order" freeze, both accepted as strictly better than main's silent drop, and called out explicitly per review:

- **Cross-name ordering can differ from arrival order when a same-name frame is deferred.** Coalescing only groups frames by command *name*; a different command name arriving while a same-name frame is pending is dispatched on its own schedule, so the physical enqueue order across names is no longer guaranteed to match arrival order. Example: `set_freq, set_freq, set_mode` can enqueue as `SetFreq, SetMode, SetFreq` instead of `SetFreq, SetMode`. Nothing is lost either way (main drops the second `set_freq` outright); this is strictly better than main, but it is a real ordering change. Worst realistic interaction: a `set_mode` deferred behind a pending `set_filter_width` flush can land *after* the width write and reset the filter width to that mode's default — an operator dragging a filter-width slider while also switching mode in the same window could see the width silently reset. No safety-critical command (PTT) is affected — PTT bypasses this limiter entirely (see above).
- **Teardown cancels pending frames without replying to them.** `_cancel_pending_command_flushes()` cancels every in-flight `_cmd_flush_tasks` entry at session teardown and never sends a reply for the still-pending frame it was carrying. This is acceptable because the socket is already gone by that point (nothing to write to), and the frontend's `ws-client.ts` clears its own tracked-command bookkeeping on socket close, so no client-side command is left waiting on a reply that will never arrive.

## Tests (TDD)

New file: `tests/test_mor1427_rate_limiter_coalesce.py` (5 tests, all RED before the fix, all GREEN after):

- `test_burst_coalesces_to_last_value_not_dropped` — 10-frame incrementing burst → exactly 2 physical enqueues (1 immediate + 1 paced flush), and the flushed value is the **last** target, never lost.
- `test_superseded_frames_get_honest_reply_flushed_frame_gets_real_ack` — every one of the 10 frames gets exactly one reply; ids 1–8 get `{superseded: true}`, id 0 and id 9 get real acks with their actual `SetFreq` result.
- `test_slower_than_window_commands_are_unaffected` — two `set_freq` calls spaced >50ms apart behave byte-identically to today: both dispatch immediately, no pending/flush state left behind.
- `test_ptt_off_bursts_are_never_rate_limited_or_coalesced` — PTT-safety regression pin (see above).
- `test_coalesce_counter_is_accurate_and_logged` — the coalesce counter is exactly 8 for the 9-vs-8-superseded 10-frame burst, a WARNING log fires, and the counter resets to 0 once that burst flushes.

RED (before fix): all 5 failed — `AttributeError: 'ControlHandler' object has no attribute '_cmd_pending'` / `_cmd_flush_tasks` / `_cmd_coalesced` (the coalescing state didn't exist yet), confirming the old hard-drop behavior.

GREEN (after fix): all 5 pass.

## Review fixes (round 2)

The first review round returned BLOCKED. Fixed at `ecb99b8f`:

- **B1 (blocking):** the immediate-dispatch gate now also diverts to coalescing when `name in self._cmd_pending`, closing a race where a late-running deferred flush let a newer frame dispatch immediately while an older pending frame was still queued, overwriting the newer value. Pinned with `test_late_flush_gate_diverts_to_coalescing_when_frame_pending`.
- **B2 (blocking):** `docs/api/web.md` and `docs/api/command-catalog.md` updated to describe the `{"superseded": true}` reply and last-value-wins enqueue semantics, replacing the stale `{"throttled": true}` / "not enqueued" description.
- **N2:** removed the dead `_cmd_drops` write-only counter.
- **N3:** the deferred flush task's `_dispatch_command` call is now wrapped so an escaping exception is caught and logged instead of becoming an unretrieved task exception.
- **Evidence-tier battery test** (`test_battery_coalescing_survives_stalls_interleaving_and_teardown`): 200 fixed-seed randomized iterations injecting loop stalls around the flush boundary, cross-name interleaving, and mid-burst teardown; asserts last-physical-write-wins, exactly-one-reply-per-id, and no post-teardown enqueue. Runs in ~3s.

## Suite evidence

At `ecb99b8f` (post-review-fix head):

- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` → **9000 passed, 12 skipped, 5 deselected, 11 xfailed, 1 xpassed, 0 failed** (307.67s).
- `uv run mypy src/` → 13 pre-existing errors, all outside `control.py` (in `yaesu_cat/poller.py`, `runtime/_control_phase.py`, `runtime/_audio_runtime_mixin.py`, `web/radio_poller.py`) — **delta = 0**.
- `uv run ruff check src/ tests/` → All checks passed.
- `uv run ruff format --check src/ tests/` → all files formatted.

## Scope

4 files changed: `src/rigplane/web/handlers/control.py`, `docs/api/web.md`, `docs/api/command-catalog.md`, and the test file. No new abstractions beyond the single deferred-flush handle per (session, command) explicitly permitted by the ticket.

Linear: https://linear.app/morozsm/issue/MOR-1427

Independent verifier review pending on the round-2 fixes — do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
