### PR TITLE
test: add IC-7300 profile conformance suite over live-captured fixture (MOR-1428)

### DIFF
--- a/frontend/scripts/capture-profile.mjs
+++ b/frontend/scripts/capture-profile.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+/**
+ * Live radio-profile capture (MOR-1428).
+ *
+ * Fetches `/api/v1/state` and `/api/v1/capabilities` from a running
+ * rigplane-core web server and writes them into the fixture pair a
+ * conformance suite consumes — e.g.
+ * `frontend/src/lib/runtime/adapters/__tests__/fixtures/ic7300-state.json`
+ * and `…/ic7300-capabilities.json`. Plain Node ESM, no dependencies
+ * (Node 18+ native `fetch`), so it runs standalone against any reachable
+ * stand — no vitest/vite pipeline required.
+ *
+ * This is a READ-ONLY GET against the two public state endpoints. It
+ * issues no writes, no CI-V commands, no WS traffic — safe to run against
+ * a live bench radio at any time.
+ *
+ * Usage
+ * -----
+ *   node scripts/capture-profile.mjs <baseUrl> <name> [outDir]
+ *
+ * `<baseUrl>` is required — there is no default — and must point at a
+ * reachable rigplane-core web server, e.g.:
+ *
+ *   node scripts/capture-profile.mjs http://localhost:8099 ic7300
+ *   node scripts/capture-profile.mjs http://localhost:8099 ic7300 \
+ *     src/lib/runtime/adapters/__tests__/fixtures
+ *
+ * Writes `<outDir>/<name>-state.json` and `<outDir>/<name>-capabilities.json`
+ * (default `outDir`: `src/lib/runtime/adapters/__tests__/fixtures`, relative
+ * to `frontend/`). Keys are recursively sorted so successive captures of an
+ * unchanged radio diff cleanly. Each file's top-level `_provenance` sibling
+ * fields are NOT embedded in the JSON itself (the payload must stay a
+ * byte-faithful capture of the real API response) — provenance (base URL,
+ * capture date, radio model, backend HEAD SHA) is printed to stdout for the
+ * caller to record in the fixture loader's header comment and the PR body.
+ */
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const FRONTEND_ROOT = resolve(SCRIPT_DIR, '..');
+const DEFAULT_OUT_DIR = 'src/lib/runtime/adapters/__tests__/fixtures';
+
+function sortKeysDeep(value) {
+  if (Array.isArray(value)) return value.map(sortKeysDeep);
+  if (value !== null && typeof value === 'object') {
+    const sorted = {};
+    for (const key of Object.keys(value).sort()) sorted[key] = sortKeysDeep(value[key]);
+    return sorted;
+  }
+  return value;
+}
+
+async function fetchJson(baseUrl, path) {
+  const url = new URL(path, baseUrl).toString();
+  const response = await fetch(url, { method: 'GET' });
+  if (!response.ok) {
+    throw new Error(`GET ${url} -> HTTP ${response.status}`);
+  }
+  return { url, body: await response.json() };
+}
+
+async function main() {
+  const [baseUrlArg, name, outDirArg] = process.argv.slice(2);
+  if (!baseUrlArg || !name) {
+    console.error('Usage: node scripts/capture-profile.mjs <baseUrl> <name> [outDir]');
+    process.exitCode = 1;
+    return;
+  }
+  const baseUrl = baseUrlArg.replace(/\/+$/, '');
+  const outDir = resolve(FRONTEND_ROOT, outDirArg ?? DEFAULT_OUT_DIR);
+
+  const [state, capabilities] = await Promise.all([
+    fetchJson(baseUrl, '/api/v1/state'),
+    fetchJson(baseUrl, '/api/v1/capabilities'),
+  ]);
+
+  await mkdir(outDir, { recursive: true });
+  const statePath = join(outDir, `${name}-state.json`);
+  const capsPath = join(outDir, `${name}-capabilities.json`);
+  await writeFile(statePath, `${JSON.stringify(sortKeysDeep(state.body), null, 2)}\n`, 'utf8');
+  await writeFile(capsPath, `${JSON.stringify(sortKeysDeep(capabilities.body), null, 2)}\n`, 'utf8');
+
+  const capturedAt = new Date().toISOString();
+  console.log('Captured profile:');
+  console.log(`  model:        ${capabilities.body.model ?? '(unknown)'}`);
+  console.log(`  receivers:    ${capabilities.body.receivers ?? '(unknown)'}`);
+  console.log(`  base URL:     ${baseUrl}`);
+  console.log(`  captured at:  ${capturedAt}`);
+  console.log(`  state ->      ${statePath}`);
+  console.log(`  caps  ->      ${capsPath}`);
+  console.log('');
+  console.log('Record base URL / capture date / radio model / backend HEAD SHA');
+  console.log('in the fixture loader\'s header comment and the PR body — the raw');
+  console.log('JSON payloads intentionally carry no provenance metadata of their');
+  console.log('own (they must stay a byte-faithful capture of the real API).');
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/frontend/src/lib/runtime/adapters/__tests__/fixtures/ic7300-capabilities.json
+++ b/frontend/src/lib/runtime/adapters/__tests__/fixtures/ic7300-capabilities.json
@@ -1,0 +1,1310 @@
+{
+  "agcLabels": {
+    "1": "FAST",
+    "2": "MID",
+    "3": "SLOW"
+  },
+  "agcModes": [
+    1,
+    2,
+    3
+  ],
+  "antennas": 1,
+  "attLabels": {},
+  "attValues": [
+    0,
+    20
+  ],
+  "audio": true,
+  "audioConfig": {
+    "channels": 1,
+    "codecs": [
+      "opus"
+    ],
+    "jitterCeilingMs": 300,
+    "jitterFloorMs": 50,
+    "sampleRate": 48000
+  },
+  "audioFftAvailable": true,
+  "audioTx": true,
+  "audioTxRequiredModInputSource": null,
+  "audioTxRoute": "usb",
+  "capabilities": [
+    "af_level",
+    "agc",
+    "antenna",
+    "apf",
+    "attenuator",
+    "audio",
+    "band_edge",
+    "break_in",
+    "bsr",
+    "compressor",
+    "cw",
+    "data_mode",
+    "dial_lock",
+    "filter_shape",
+    "filter_width",
+    "ip_plus",
+    "meters",
+    "monitor",
+    "nb",
+    "notch",
+    "nr",
+    "pbt",
+    "power_control",
+    "preamp",
+    "repeater_tone",
+    "rf_gain",
+    "rit",
+    "scan",
+    "scope",
+    "split",
+    "squelch",
+    "ssb_tx_bw",
+    "system_settings",
+    "tsql",
+    "tuner",
+    "tuning_step",
+    "twin_peak",
+    "tx",
+    "vox",
+    "xfc",
+    "xit"
+  ],
+  "controls": {
+    "af_level": {
+      "raw_max": 255,
+      "raw_min": 0
+    },
+    "attenuator": {
+      "style": "toggle"
+    },
+    "compressor_level": {
+      "raw_max": 255,
+      "raw_min": 0
+    },
+    "cw_pitch": {
+      "display_max": 900,
+      "display_min": 300,
+      "display_unit": "Hz",
+      "raw_max": 255,
+      "raw_min": 0
+    },
+    "mic_gain": {
+      "raw_max": 255,
+      "raw_min": 0
+    },
+    "monitor_gain": {
+      "raw_max": 255,
+      "raw_min": 0
+    },
+    "nb": {
+      "style": "toggle_and_level"
+    },
+    "nb_level": {
+      "raw_max": 255,
+      "raw_min": 0
+    },
+    "nr": {
+      "style": "toggle_and_level"
+    },
+    "nr_level": {
+      "raw_max": 255,
+      "raw_min": 0
+    },
+    "pbt_inner": {
+      "display_max": 1200,
+      "display_min": -1200,
+      "display_unit": "Hz",
+      "raw_center": 128,
+      "raw_max": 255,
+      "raw_min": 0
+    },
+    "pbt_outer": {
+      "display_max": 1200,
+      "display_min": -1200,
+      "display_unit": "Hz",
+      "raw_center": 128,
+      "raw_max": 255,
+      "raw_min": 0
+    },
+    "rf_gain": {
+      "raw_max": 255,
+      "raw_min": 0
+    },
+    "rf_power": {
+      "raw_max": 255,
+      "raw_min": 0
+    },
+    "rit": {
+      "display_max": 999,
+      "display_min": -999,
+      "display_unit": "Hz",
+      "raw_center": 0,
+      "raw_max": 999,
+      "raw_min": -999
+    },
+    "squelch": {
+      "raw_max": 255,
+      "raw_min": 0
+    }
+  },
+  "dataModeCount": 1,
+  "dataModeLabels": {
+    "0": "OFF",
+    "1": "DATA"
+  },
+  "filterConfig": {
+    "AM": {
+      "defaults": [
+        9000,
+        6000,
+        3000
+      ],
+      "fixed": false,
+      "maxHz": 10000,
+      "minHz": 200,
+      "segments": [
+        {
+          "hzMax": 10000,
+          "hzMin": 200,
+          "indexMin": 0,
+          "stepHz": 200
+        }
+      ],
+      "stepHz": 200
+    },
+    "CW": {
+      "defaults": [
+        1200,
+        500,
+        250
+      ],
+      "fixed": false,
+      "maxHz": 3600,
+      "minHz": 50,
+      "segments": [
+        {
+          "hzMax": 500,
+          "hzMin": 50,
+          "indexMin": 0,
+          "stepHz": 50
+        },
+        {
+          "hzMax": 3600,
+          "hzMin": 600,
+          "indexMin": 10,
+          "stepHz": 100
+        }
+      ]
+    },
+    "FM": {
+      "defaults": [
+        15000,
+        10000,
+        7000
+      ],
+      "fixed": true
+    },
+    "LSB": {
+      "defaults": [
+        3000,
+        2400,
+        1800
+      ],
+      "fixed": false,
+      "maxHz": 3600,
+      "minHz": 50,
+      "segments": [
+        {
+          "hzMax": 500,
+          "hzMin": 50,
+          "indexMin": 0,
+          "stepHz": 50
+        },
+        {
+          "hzMax": 3600,
+          "hzMin": 600,
+          "indexMin": 10,
+          "stepHz": 100
+        }
+      ]
+    },
+    "RTTY": {
+      "defaults": [
+        2400,
+        500,
+        250
+      ],
+      "fixed": false,
+      "maxHz": 2700,
+      "minHz": 50,
+      "segments": [
+        {
+          "hzMax": 500,
+          "hzMin": 50,
+          "indexMin": 0,
+          "stepHz": 50
+        },
+        {
+          "hzMax": 2700,
+          "hzMin": 600,
+          "indexMin": 10,
+          "stepHz": 100
+        }
+      ]
+    },
+    "USB": {
+      "defaults": [
+        3000,
+        2400,
+        1800
+      ],
+      "fixed": false,
+      "maxHz": 3600,
+      "minHz": 50,
+      "segments": [
+        {
+          "hzMax": 500,
+          "hzMin": 50,
+          "indexMin": 0,
+          "stepHz": 50
+        },
+        {
+          "hzMax": 3600,
+          "hzMin": 600,
+          "indexMin": 10,
+          "stepHz": 100
+        }
+      ]
+    }
+  },
+  "filterWidthMax": 9999,
+  "filterWidthMin": 50,
+  "filters": [
+    "FIL1",
+    "FIL2",
+    "FIL3"
+  ],
+  "freqRanges": [
+    {
+      "bands": [
+        {
+          "bsrCode": 1,
+          "default": 1825000,
+          "end": 2000000,
+          "name": "160m",
+          "start": 1800000
+        },
+        {
+          "bsrCode": 2,
+          "default": 3700000,
+          "end": 4000000,
+          "name": "80m",
+          "start": 3500000
+        },
+        {
+          "default": 5357000,
+          "end": 5410000,
+          "name": "60m",
+          "start": 5330000
+        },
+        {
+          "bsrCode": 3,
+          "default": 7100000,
+          "end": 7300000,
+          "name": "40m",
+          "start": 7000000
+        },
+        {
+          "bsrCode": 4,
+          "default": 10130000,
+          "end": 10150000,
+          "name": "30m",
+          "start": 10100000
+        },
+        {
+          "bsrCode": 5,
+          "default": 14200000,
+          "end": 14350000,
+          "name": "20m",
+          "start": 14000000
+        },
+        {
+          "bsrCode": 6,
+          "default": 18120000,
+          "end": 18168000,
+          "name": "17m",
+          "start": 18068000
+        },
+        {
+          "bsrCode": 7,
+          "default": 21200000,
+          "end": 21450000,
+          "name": "15m",
+          "start": 21000000
+        },
+        {
+          "bsrCode": 8,
+          "default": 24940000,
+          "end": 24990000,
+          "name": "12m",
+          "start": 24890000
+        },
+        {
+          "bsrCode": 9,
+          "default": 28500000,
+          "end": 29700000,
+          "name": "10m",
+          "start": 28000000
+        }
+      ],
+      "end": 60000000,
+      "label": "HF",
+      "start": 30000
+    },
+    {
+      "bands": [
+        {
+          "bsrCode": 10,
+          "default": 50125000,
+          "end": 54000000,
+          "name": "6m",
+          "start": 50000000
+        }
+      ],
+      "end": 54000000,
+      "label": "6m",
+      "start": 50000000
+    }
+  ],
+  "keyboard": {
+    "altHints": true,
+    "bindings": [
+      {
+        "action": "adjust_tuning_step",
+        "description": "Select the next tuning step value on the frontend.",
+        "id": "step-up",
+        "label": "Increase tuning step",
+        "params": {
+          "direction": "up"
+        },
+        "section": "Tuning",
+        "sequence": [
+          "ArrowUp"
+        ]
+      },
+      {
+        "action": "adjust_tuning_step",
+        "description": "Select the previous tuning step value on the frontend.",
+        "id": "step-down",
+        "label": "Decrease tuning step",
+        "params": {
+          "direction": "down"
+        },
+        "section": "Tuning",
+        "sequence": [
+          "ArrowDown"
+        ]
+      },
+      {
+        "action": "tune",
+        "description": "Tune the active receiver down by the current frontend tuning step.",
+        "id": "nudge-left",
+        "label": "Tune down",
+        "params": {
+          "direction": "down",
+          "fine": false
+        },
+        "repeatable": true,
+        "section": "Tuning",
+        "sequence": [
+          "ArrowLeft"
+        ]
+      },
+      {
+        "action": "tune",
+        "description": "Tune the active receiver up by the current frontend tuning step.",
+        "id": "nudge-right",
+        "label": "Tune up",
+        "params": {
+          "direction": "up",
+          "fine": false
+        },
+        "repeatable": true,
+        "section": "Tuning",
+        "sequence": [
+          "ArrowRight"
+        ]
+      },
+      {
+        "action": "tune",
+        "description": "Jump the active receiver up by 1 kHz.",
+        "id": "page-up",
+        "label": "Tune +1 kHz",
+        "params": {
+          "deltaHz": 1000
+        },
+        "repeatable": true,
+        "section": "Tuning",
+        "sequence": [
+          "PageUp"
+        ]
+      },
+      {
+        "action": "tune",
+        "description": "Jump the active receiver down by 1 kHz.",
+        "id": "page-down",
+        "label": "Tune -1 kHz",
+        "params": {
+          "deltaHz": -1000
+        },
+        "repeatable": true,
+        "section": "Tuning",
+        "sequence": [
+          "PageDown"
+        ]
+      },
+      {
+        "action": "band_select",
+        "id": "band-1",
+        "label": "160m",
+        "params": {
+          "index": 1
+        },
+        "section": "Bands",
+        "sequence": [
+          "1"
+        ]
+      },
+      {
+        "action": "band_select",
+        "id": "band-2",
+        "label": "80m",
+        "params": {
+          "index": 2
+        },
+        "section": "Bands",
+        "sequence": [
+          "2"
+        ]
+      },
+      {
+        "action": "band_select",
+        "id": "band-3",
+        "label": "60m",
+        "params": {
+          "index": 3
+        },
+        "section": "Bands",
+        "sequence": [
+          "3"
+        ]
+      },
+      {
+        "action": "band_select",
+        "id": "band-4",
+        "label": "40m",
+        "params": {
+          "index": 4
+        },
+        "section": "Bands",
+        "sequence": [
+          "4"
+        ]
+      },
+      {
+        "action": "band_select",
+        "id": "band-5",
+        "label": "30m",
+        "params": {
+          "index": 5
+        },
+        "section": "Bands",
+        "sequence": [
+          "5"
+        ]
+      },
+      {
+        "action": "band_select",
+        "id": "band-6",
+        "label": "20m",
+        "params": {
+          "index": 6
+        },
+        "section": "Bands",
+        "sequence": [
+          "6"
+        ]
+      },
+      {
+        "action": "band_select",
+        "id": "band-7",
+        "label": "15m",
+        "params": {
+          "index": 7
+        },
+        "section": "Bands",
+        "sequence": [
+          "7"
+        ]
+      },
+      {
+        "action": "band_select",
+        "id": "band-8",
+        "label": "10m",
+        "params": {
+          "index": 8
+        },
+        "section": "Bands",
+        "sequence": [
+          "8"
+        ]
+      },
+      {
+        "action": "band_select",
+        "id": "band-9",
+        "label": "6m",
+        "params": {
+          "index": 9
+        },
+        "section": "Bands",
+        "sequence": [
+          "9"
+        ]
+      },
+      {
+        "action": "mode_select",
+        "id": "mode-lsb",
+        "label": "LSB",
+        "params": {
+          "mode": "LSB"
+        },
+        "section": "Modes",
+        "sequence": [
+          "F1"
+        ]
+      },
+      {
+        "action": "mode_select",
+        "id": "mode-usb",
+        "label": "USB",
+        "params": {
+          "mode": "USB"
+        },
+        "section": "Modes",
+        "sequence": [
+          "F2"
+        ]
+      },
+      {
+        "action": "mode_select",
+        "id": "mode-cw",
+        "label": "CW",
+        "params": {
+          "mode": "CW"
+        },
+        "section": "Modes",
+        "sequence": [
+          "F3"
+        ]
+      },
+      {
+        "action": "mode_select",
+        "id": "mode-cwr",
+        "label": "CW-R",
+        "params": {
+          "mode": "CW-R"
+        },
+        "section": "Modes",
+        "sequence": [
+          "F4"
+        ]
+      },
+      {
+        "action": "mode_select",
+        "id": "mode-am",
+        "label": "AM",
+        "params": {
+          "mode": "AM"
+        },
+        "section": "Modes",
+        "sequence": [
+          "F5"
+        ]
+      },
+      {
+        "action": "mode_select",
+        "id": "mode-fm",
+        "label": "FM",
+        "params": {
+          "mode": "FM"
+        },
+        "section": "Modes",
+        "sequence": [
+          "F6"
+        ]
+      },
+      {
+        "action": "mode_select",
+        "id": "mode-rtty",
+        "label": "RTTY",
+        "params": {
+          "mode": "RTTY"
+        },
+        "section": "Modes",
+        "sequence": [
+          "F7"
+        ]
+      },
+      {
+        "action": "mode_select",
+        "id": "mode-rttyr",
+        "label": "RTTY-R",
+        "params": {
+          "mode": "RTTY-R"
+        },
+        "section": "Modes",
+        "sequence": [
+          "F8"
+        ]
+      },
+      {
+        "action": "mode_select",
+        "id": "mode-psk",
+        "label": "PSK",
+        "params": {
+          "mode": "PSK"
+        },
+        "section": "Modes",
+        "sequence": [
+          "F9"
+        ]
+      },
+      {
+        "action": "mode_select",
+        "id": "mode-pskr",
+        "label": "PSK-R",
+        "params": {
+          "mode": "PSK-R"
+        },
+        "section": "Modes",
+        "sequence": [
+          "F10"
+        ]
+      },
+      {
+        "action": "cycle_data_mode",
+        "id": "cycle-data-mode",
+        "label": "Cycle DATA",
+        "section": "Modes",
+        "sequence": [
+          "d"
+        ]
+      },
+      {
+        "action": "cycle_filter",
+        "id": "cycle-filter",
+        "label": "Next filter",
+        "params": {
+          "step": 1
+        },
+        "section": "Filter",
+        "sequence": [
+          "f"
+        ]
+      },
+      {
+        "action": "open_filter_settings",
+        "id": "open-filter-settings",
+        "label": "Filter settings",
+        "section": "Filter",
+        "sequence": [
+          "F"
+        ]
+      },
+      {
+        "action": "cycle_filter",
+        "id": "wider-filter",
+        "label": "Wider filter",
+        "params": {
+          "step": -1
+        },
+        "section": "Filter",
+        "sequence": [
+          "w"
+        ]
+      },
+      {
+        "action": "cycle_filter",
+        "id": "narrower-filter",
+        "label": "Narrower filter",
+        "params": {
+          "step": 1
+        },
+        "section": "Filter",
+        "sequence": [
+          "W"
+        ]
+      },
+      {
+        "action": "vfo_swap",
+        "id": "swap-vfo",
+        "label": "Swap VFO",
+        "section": "VFO",
+        "sequence": [
+          "Tab"
+        ]
+      },
+      {
+        "action": "vfo_equalize",
+        "id": "equalize-vfo",
+        "label": "Copy to other VFO",
+        "section": "VFO",
+        "sequence": [
+          "="
+        ]
+      },
+      {
+        "action": "toggle_split",
+        "id": "toggle-split",
+        "label": "Toggle split",
+        "section": "VFO",
+        "sequence": [
+          "s"
+        ]
+      },
+      {
+        "action": "switch_active_vfo",
+        "id": "switch-active-vfo",
+        "label": "Toggle active receiver",
+        "section": "VFO",
+        "sequence": [
+          "m"
+        ]
+      },
+      {
+        "action": "set_active_vfo",
+        "id": "activate-main",
+        "label": "Activate MAIN receiver",
+        "modifiers": [
+          "SHIFT"
+        ],
+        "params": {
+          "vfo": "MAIN"
+        },
+        "section": "VFO",
+        "sequence": [
+          "M"
+        ]
+      },
+      {
+        "action": "set_active_vfo",
+        "id": "activate-sub",
+        "label": "Activate SUB receiver",
+        "modifiers": [
+          "SHIFT"
+        ],
+        "params": {
+          "vfo": "SUB"
+        },
+        "section": "VFO",
+        "sequence": [
+          "S"
+        ]
+      },
+      {
+        "action": "toggle_nr",
+        "id": "toggle-nr",
+        "label": "Noise reduction",
+        "section": "DSP",
+        "sequence": [
+          "n"
+        ]
+      },
+      {
+        "action": "toggle_nb",
+        "id": "toggle-nb",
+        "label": "Noise blanker",
+        "section": "DSP",
+        "sequence": [
+          "b"
+        ]
+      },
+      {
+        "action": "cycle_agc",
+        "id": "cycle-agc",
+        "label": "Cycle AGC",
+        "section": "DSP",
+        "sequence": [
+          "a"
+        ]
+      },
+      {
+        "action": "cycle_preamp",
+        "id": "cycle-preamp",
+        "label": "Cycle preamp",
+        "section": "RF Front End",
+        "sequence": [
+          "p"
+        ]
+      },
+      {
+        "action": "cycle_att",
+        "id": "cycle-att",
+        "label": "Cycle attenuator",
+        "section": "RF Front End",
+        "sequence": [
+          "t"
+        ]
+      },
+      {
+        "action": "toggle_auto_notch",
+        "id": "toggle-auto-notch",
+        "label": "Auto notch",
+        "section": "DSP",
+        "sequence": [
+          "o"
+        ]
+      },
+      {
+        "action": "toggle_monitor",
+        "id": "toggle-monitor",
+        "label": "Monitor",
+        "section": "TX",
+        "sequence": [
+          "k"
+        ]
+      },
+      {
+        "action": "toggle_ip_plus",
+        "id": "toggle-ip-plus",
+        "label": "IP+",
+        "section": "DSP",
+        "sequence": [
+          "i"
+        ]
+      },
+      {
+        "action": "toggle_dial_lock",
+        "id": "toggle-dial-lock",
+        "label": "Dial lock",
+        "section": "System",
+        "sequence": [
+          "l"
+        ]
+      },
+      {
+        "action": "toggle_rit",
+        "id": "toggle-rit",
+        "label": "RIT",
+        "section": "RIT/XIT",
+        "sequence": [
+          "r"
+        ]
+      },
+      {
+        "action": "toggle_xit",
+        "id": "toggle-xit",
+        "label": "XIT",
+        "section": "RIT/XIT",
+        "sequence": [
+          "x"
+        ]
+      },
+      {
+        "action": "clear_rit_xit",
+        "id": "clear-rit-xit",
+        "label": "Clear offset",
+        "section": "RIT/XIT",
+        "sequence": [
+          "Escape"
+        ]
+      },
+      {
+        "action": "adjust_af_level",
+        "id": "af-level-up",
+        "label": "AF gain up",
+        "modifiers": [
+          "CTRL"
+        ],
+        "params": {
+          "delta": 5
+        },
+        "repeatable": true,
+        "section": "Levels",
+        "sequence": [
+          "ArrowUp"
+        ]
+      },
+      {
+        "action": "adjust_af_level",
+        "id": "af-level-down",
+        "label": "AF gain down",
+        "modifiers": [
+          "CTRL"
+        ],
+        "params": {
+          "delta": -5
+        },
+        "repeatable": true,
+        "section": "Levels",
+        "sequence": [
+          "ArrowDown"
+        ]
+      },
+      {
+        "action": "adjust_rf_gain",
+        "id": "rf-level-up",
+        "label": "RF gain up",
+        "modifiers": [
+          "CTRL",
+          "SHIFT"
+        ],
+        "params": {
+          "delta": 5
+        },
+        "repeatable": true,
+        "section": "Levels",
+        "sequence": [
+          "ArrowUp"
+        ]
+      },
+      {
+        "action": "adjust_rf_gain",
+        "id": "rf-level-down",
+        "label": "RF gain down",
+        "modifiers": [
+          "CTRL",
+          "SHIFT"
+        ],
+        "params": {
+          "delta": -5
+        },
+        "repeatable": true,
+        "section": "Levels",
+        "sequence": [
+          "ArrowDown"
+        ]
+      },
+      {
+        "action": "toggle_help",
+        "id": "help",
+        "label": "Keyboard help",
+        "section": "System",
+        "sequence": [
+          "?"
+        ]
+      },
+      {
+        "action": "focus_target",
+        "id": "focus-af",
+        "label": "Go to AF",
+        "params": {
+          "target": "af"
+        },
+        "section": "Focus",
+        "sequence": [
+          "g",
+          "a"
+        ]
+      },
+      {
+        "action": "focus_target",
+        "id": "focus-rf",
+        "label": "Go to RF",
+        "params": {
+          "target": "rf"
+        },
+        "section": "Focus",
+        "sequence": [
+          "g",
+          "r"
+        ]
+      },
+      {
+        "action": "focus_target",
+        "id": "focus-filter",
+        "label": "Go to Filter",
+        "params": {
+          "target": "filter"
+        },
+        "section": "Focus",
+        "sequence": [
+          "g",
+          "f"
+        ]
+      },
+      {
+        "action": "focus_target",
+        "id": "focus-mode",
+        "label": "Go to Mode",
+        "params": {
+          "target": "mode"
+        },
+        "section": "Focus",
+        "sequence": [
+          "g",
+          "m"
+        ]
+      },
+      {
+        "action": "focus_target",
+        "id": "focus-pbt",
+        "label": "Go to PBT",
+        "params": {
+          "target": "pbt"
+        },
+        "section": "Focus",
+        "sequence": [
+          "g",
+          "p"
+        ]
+      },
+      {
+        "action": "focus_target",
+        "id": "focus-waterfall",
+        "label": "Go to Waterfall",
+        "params": {
+          "target": "waterfall"
+        },
+        "section": "Focus",
+        "sequence": [
+          "g",
+          "w"
+        ]
+      },
+      {
+        "action": "focus_target",
+        "id": "focus-vfo",
+        "label": "Go to VFO",
+        "params": {
+          "target": "vfo"
+        },
+        "section": "Focus",
+        "sequence": [
+          "g",
+          "v"
+        ]
+      },
+      {
+        "action": "scope_span_step",
+        "description": "Step the scope span to the next smaller value.",
+        "id": "scope-span-down",
+        "label": "Decrease scope span",
+        "params": {
+          "direction": "down"
+        },
+        "section": "Spectrum",
+        "sequence": [
+          "["
+        ]
+      },
+      {
+        "action": "scope_span_step",
+        "description": "Step the scope span to the next larger value.",
+        "id": "scope-span-up",
+        "label": "Increase scope span",
+        "params": {
+          "direction": "up"
+        },
+        "section": "Spectrum",
+        "sequence": [
+          "]"
+        ]
+      },
+      {
+        "action": "scope_ref_step",
+        "description": "Lower the scope reference level by one step.",
+        "id": "scope-ref-down",
+        "label": "Decrease scope reference level",
+        "params": {
+          "direction": "down"
+        },
+        "section": "Spectrum",
+        "sequence": [
+          "-"
+        ]
+      },
+      {
+        "action": "scope_ref_step",
+        "description": "Raise the scope reference level by one step.",
+        "id": "scope-ref-up",
+        "label": "Increase scope reference level",
+        "params": {
+          "direction": "up"
+        },
+        "section": "Spectrum",
+        "sequence": [
+          "+"
+        ]
+      },
+      {
+        "action": "scope_toggle_hold",
+        "description": "Freeze or release the scope waterfall.",
+        "id": "scope-toggle-hold",
+        "label": "Toggle scope hold",
+        "modifiers": [
+          "SHIFT"
+        ],
+        "section": "Spectrum",
+        "sequence": [
+          "H"
+        ]
+      },
+      {
+        "action": "scope_toggle_dual",
+        "description": "Enable or disable simultaneous MAIN+SUB scope rendering.",
+        "id": "scope-toggle-dual",
+        "label": "Toggle dual scope",
+        "modifiers": [
+          "SHIFT"
+        ],
+        "section": "Spectrum",
+        "sequence": [
+          "D"
+        ]
+      },
+      {
+        "action": "scope_toggle_fst",
+        "description": "Cycle the scope sweep speed (FST).",
+        "id": "scope-toggle-fst",
+        "label": "Toggle fast scroll (FST)",
+        "modifiers": [
+          "SHIFT"
+        ],
+        "section": "Spectrum",
+        "sequence": [
+          "F"
+        ]
+      }
+    ],
+    "helpTitle": "Radio Keyboard",
+    "leaderKey": "g",
+    "leaderTimeoutMs": 1000
+  },
+  "meterCalibrations": {
+    "swr": [
+      {
+        "actual": 1,
+        "label": "1.0",
+        "raw": 0
+      },
+      {
+        "actual": 1.5,
+        "label": "1.5",
+        "raw": 48
+      },
+      {
+        "actual": 2,
+        "label": "2.0",
+        "raw": 80
+      },
+      {
+        "actual": 3,
+        "label": "3.0",
+        "raw": 120
+      },
+      {
+        "actual": 6,
+        "label": "6.0+",
+        "raw": 240
+      }
+    ]
+  },
+  "meterRedlines": {
+    "swr": 120
+  },
+  "model": "IC-7300",
+  "modes": [
+    "USB",
+    "LSB",
+    "CW",
+    "CW-R",
+    "AM",
+    "FM",
+    "RTTY",
+    "RTTY-R"
+  ],
+  "preLabels": {},
+  "preValues": [
+    0,
+    1,
+    2
+  ],
+  "providerGeneration": 1,
+  "receivers": 1,
+  "scope": true,
+  "scopeConfig": {
+    "amplitudeMax": 160,
+    "centerMode": true,
+    "defaultSpan": 3600
+  },
+  "scopeSource": "hardware",
+  "stateContractVersion": 1,
+  "tx": true,
+  "txBands": [
+    {
+      "end": 2000000,
+      "name": "160m",
+      "start": 1800000
+    },
+    {
+      "end": 4000000,
+      "name": "80m",
+      "start": 3500000
+    },
+    {
+      "end": 5410000,
+      "name": "60m",
+      "start": 5330000
+    },
+    {
+      "end": 7300000,
+      "name": "40m",
+      "start": 7000000
+    },
+    {
+      "end": 10150000,
+      "name": "30m",
+      "start": 10100000
+    },
+    {
+      "end": 14350000,
+      "name": "20m",
+      "start": 14000000
+    },
+    {
+      "end": 18168000,
+      "name": "17m",
+      "start": 18068000
+    },
+    {
+      "end": 21450000,
+      "name": "15m",
+      "start": 21000000
+    },
+    {
+      "end": 24990000,
+      "name": "12m",
+      "start": 24890000
+    },
+    {
+      "end": 29700000,
+      "name": "10m",
+      "start": 28000000
+    },
+    {
+      "end": 54000000,
+      "name": "6m",
+      "start": 50000000
+    }
+  ],
+  "vfoReadback": "selected_unselected",
+  "vfoScheme": "ab",
+  "webrtc": {
+    "available": true,
+    "enabled": false
+  }
+}

--- a/frontend/src/lib/runtime/adapters/__tests__/fixtures/ic7300-profile.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/fixtures/ic7300-profile.ts
@@ -1,0 +1,50 @@
+/**
+ * IC-7300 live-captured profile fixture (MOR-1428, Tier 2 v1).
+ *
+ * `ic7300-state.json` / `ic7300-capabilities.json` are a byte-faithful
+ * capture of `/api/v1/state` and `/api/v1/capabilities`, taken with
+ * `scripts/capture-profile.mjs` (read-only GET, no CI-V writes, no WS
+ * traffic) against a local RigPlane bench instance (IC-7300, serial
+ * backend):
+ *
+ *   node scripts/capture-profile.mjs http://localhost:8099 ic7300
+ *
+ * Provenance
+ * ----------
+ *   Source:         captured from a local RigPlane bench instance
+ *                   (IC-7300, serial backend)
+ *   Radio model:    IC-7300 (single-receiver, `vfoScheme: 'ab'`,
+ *                   `vfoReadback: 'selected_unselected'`)
+ *   Captured:       2026-08-11
+ *   Backend SHA:    e0b19814 (`origin/main`, includes the MOR-1409 A07-A15
+ *                   authority migration through c96ae052 plus the MOR-1418/
+ *                   MOR-1421/MOR-1423/MOR-1419/MOR-1427 single-RX fix wave —
+ *                   PRs #2372/#2374/#2376/#2373/#2377)
+ *
+ * The stand's `stateContractVersion`/`providerGeneration` (both `1`) match
+ * between the two payloads, as `toSpectrumAuthority` requires.
+ *
+ * What this fixture actually proves, in one line: `active` reads
+ * observed:false/availability:'missing' on this radio — the exact
+ * structurally-unobservable shape MOR-1418/MOR-1421/MOR-1423 fixed — while
+ * `main.freqHz`/`main.mode`/`main.filter`/`main.att`/`main.preamp`/
+ * `main.rfGain`/`main.agc`/`main.nb`/`main.nr`/`main.afLevel`/`split` are
+ * genuinely observed, and `ritOn`/`ritFreq`/`ritTx`/`micGain`/`main.nbLevel`/
+ * `main.activeSlot`/`main.vfoA.*`/`main.vfoB.*` are genuinely NOT — this is a
+ * live radio's real, partial observation state, not a synthetic all-or-
+ * nothing fixture. `mor1428-ic7300-conformance.isolated.test.ts` pins both
+ * halves: the families the fix wave revived, and the families that still
+ * correctly fail closed because a DIFFERENT leaf was never confirmed.
+ *
+ * Re-capture: re-run the script above against the live stand and commit the
+ * refreshed JSON pair plus an updated header comment here (capture date,
+ * backend HEAD SHA). The two JSON files carry no embedded metadata of their
+ * own on purpose — they must stay exactly what the API returned.
+ */
+import type { Capabilities } from '$lib/types/capabilities';
+import type { ServerState } from '$lib/types/state';
+import ic7300StateJson from './ic7300-state.json';
+import ic7300CapabilitiesJson from './ic7300-capabilities.json';
+
+export const IC7300_STATE = ic7300StateJson as unknown as ServerState;
+export const IC7300_CAPABILITIES = ic7300CapabilitiesJson as unknown as Capabilities;

--- a/frontend/src/lib/runtime/adapters/__tests__/fixtures/ic7300-state.json
+++ b/frontend/src/lib/runtime/adapters/__tests__/fixtures/ic7300-state.json
@@ -1,0 +1,1672 @@
+{
+  "active": "MAIN",
+  "alcMeter": 0,
+  "antiVoxGain": 0,
+  "breakIn": 0,
+  "breakInDelay": 0,
+  "compMeter": 0,
+  "compressorLevel": 151,
+  "compressorOn": true,
+  "connection": {
+    "controlConnected": true,
+    "radioReady": true,
+    "rigConnected": true
+  },
+  "cwPitch": 0,
+  "cwSpot": null,
+  "dashRatio": 0,
+  "data1ModInput": 1,
+  "data2ModInput": 0,
+  "data3ModInput": 20,
+  "dataOffModInput": null,
+  "dialLock": false,
+  "driveGain": 0,
+  "dualWatch": false,
+  "fieldStatus": {
+    "active": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "global.slow_state.active"
+    },
+    "alcMeter": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "global.meters.alc"
+    },
+    "antiVoxGain": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "global.operator_controls.anti_vox_gain"
+    },
+    "breakIn": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "global.operator_controls.break_in"
+    },
+    "breakInDelay": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "global.operator_controls.break_in_delay"
+    },
+    "compMeter": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "global.meters.comp"
+    },
+    "compressorLevel": {
+      "availability": "available",
+      "freshness": "fresh",
+      "lastObservedMonotonic": 969096.986551041,
+      "maxAge": null,
+      "observed": true,
+      "quality": [
+        "confirmed"
+      ],
+      "source": {
+        "capabilityId": "global.operator_controls.compressor_level",
+        "commandSource": null,
+        "nativeId": "civ:14:0e",
+        "provider": "icom_civ",
+        "sessionId": null,
+        "source": "command_response",
+        "transport": "civ"
+      },
+      "storePath": "global.operator_controls.compressor_level"
+    },
+    "compressorOn": {
+      "availability": "available",
+      "freshness": "fresh",
+      "lastObservedMonotonic": 969097.29602575,
+      "maxAge": null,
+      "observed": true,
+      "quality": [
+        "confirmed"
+      ],
+      "source": {
+        "capabilityId": "global.tx_state.compressor_on",
+        "commandSource": null,
+        "nativeId": "civ:16:44",
+        "provider": "icom_civ",
+        "sessionId": null,
+        "source": "command_response",
+        "transport": "civ"
+      },
+      "storePath": "global.tx_state.compressor_on"
+    },
+    "connection.controlConnected": {
+      "availability": "available",
+      "freshness": "fresh",
+      "lastObservedMonotonic": 930166.71185225,
+      "maxAge": null,
+      "observed": true,
+      "quality": [
+        "confirmed"
+      ],
+      "source": {
+        "capabilityId": null,
+        "commandSource": null,
+        "nativeId": null,
+        "provider": "web_lifecycle",
+        "sessionId": null,
+        "source": "local_reconcile",
+        "transport": "web"
+      },
+      "storePath": "connection.connection.control_connected"
+    },
+    "connection.radioReady": {
+      "availability": "available",
+      "freshness": "fresh",
+      "lastObservedMonotonic": 930166.71185225,
+      "maxAge": null,
+      "observed": true,
+      "quality": [
+        "confirmed"
+      ],
+      "source": {
+        "capabilityId": null,
+        "commandSource": null,
+        "nativeId": null,
+        "provider": "web_lifecycle",
+        "sessionId": null,
+        "source": "local_reconcile",
+        "transport": "web"
+      },
+      "storePath": "connection.connection.radio_ready"
+    },
+    "connection.rigConnected": {
+      "availability": "available",
+      "freshness": "fresh",
+      "lastObservedMonotonic": 930166.71185225,
+      "maxAge": null,
+      "observed": true,
+      "quality": [
+        "confirmed"
+      ],
+      "source": {
+        "capabilityId": null,
+        "commandSource": null,
+        "nativeId": null,
+        "provider": "web_lifecycle",
+        "sessionId": null,
+        "source": "local_reconcile",
+        "transport": "web"
+      },
+      "storePath": "connection.connection.connected"
+    },
+    "cwPitch": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "global.operator_controls.cw_pitch"
+    },
+    "cwSpot": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "global.slow_state.cw_spot"
+    },
+    "dashRatio": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "global.operator_controls.dash_ratio"
+    },
+    "data1ModInput": {
+      "availability": "available",
+      "freshness": "fresh",
+      "lastObservedMonotonic": 930166.544630791,
+      "maxAge": null,
+      "observed": true,
+      "quality": [
+        "confirmed"
+      ],
+      "source": {
+        "capabilityId": null,
+        "commandSource": null,
+        "nativeId": "data1_mod_input_readback",
+        "provider": "web_poller",
+        "sessionId": null,
+        "source": "poll_response",
+        "transport": null
+      },
+      "storePath": "global.slow_state.data1_mod_input"
+    },
+    "data2ModInput": {
+      "availability": "available",
+      "freshness": "fresh",
+      "lastObservedMonotonic": 930166.600346708,
+      "maxAge": null,
+      "observed": true,
+      "quality": [
+        "confirmed"
+      ],
+      "source": {
+        "capabilityId": null,
+        "commandSource": null,
+        "nativeId": "data2_mod_input_readback",
+        "provider": "web_poller",
+        "sessionId": null,
+        "source": "poll_response",
+        "transport": null
+      },
+      "storePath": "global.slow_state.data2_mod_input"
+    },
+    "data3ModInput": {
+      "availability": "available",
+      "freshness": "fresh",
+      "lastObservedMonotonic": 930166.65665925,
+      "maxAge": null,
+      "observed": true,
+      "quality": [
+        "confirmed"
+      ],
+      "source": {
+        "capabilityId": null,
+        "commandSource": null,
+        "nativeId": "data3_mod_input_readback",
+        "provider": "web_poller",
+        "sessionId": null,
+        "source": "poll_response",
+        "transport": null
+      },
+      "storePath": "global.slow_state.data3_mod_input"
+    },
+    "dataOffModInput": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "global.slow_state.data_off_mod_input"
+    },
+    "dialLock": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "global.tx_state.dial_lock"
+    },
+    "driveGain": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "global.operator_controls.drive_gain"
+    },
+    "dualWatch": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "global.tx_state.dual_watch"
+    },
+    "idMeter": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "global.meters.id"
+    },
+    "keySpeed": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "global.operator_controls.key_speed"
+    },
+    "main.activeSlot": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "receiver.main.vfo.active_slot"
+    },
+    "main.afLevel": {
+      "availability": "available",
+      "freshness": "fresh",
+      "lastObservedMonotonic": 969096.372859,
+      "maxAge": 10,
+      "observed": true,
+      "quality": [
+        "confirmed"
+      ],
+      "source": {
+        "capabilityId": "receiver.0.operator_controls.af_level",
+        "commandSource": null,
+        "nativeId": "civ:14:01",
+        "provider": "icom_civ",
+        "sessionId": null,
+        "source": "command_response",
+        "transport": "civ"
+      },
+      "storePath": "receiver.0.operator_controls.af_level"
+    },
+    "main.afMute": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "receiver.main.operator_toggles.af_mute"
+    },
+    "main.agc": {
+      "availability": "available",
+      "freshness": "fresh",
+      "lastObservedMonotonic": 969096.475518333,
+      "maxAge": null,
+      "observed": true,
+      "quality": [
+        "confirmed"
+      ],
+      "source": {
+        "capabilityId": "receiver.0.operator_controls.agc",
+        "commandSource": null,
+        "nativeId": "civ:16:12",
+        "provider": "icom_civ",
+        "sessionId": null,
+        "source": "command_response",
+        "transport": "civ"
+      },
+      "storePath": "receiver.0.operator_controls.agc"
+    },
+    "main.agcTimeConstant": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "receiver.main.operator_controls.agc_time_constant"
+    },
+    "main.antiVoxGain": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "receiver.main.operator_controls.anti_vox_gain"
+    },
+    "main.apfFreq": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "receiver.main.operator_controls.apf_freq"
+    },
+    "main.apfOn": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "receiver.main.operator_toggles.apf_on"
+    },
+    "main.apfTypeLevel": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "receiver.main.operator_controls.apf_type_level"
+    },
+    "main.att": {
+      "availability": "available",
+      "freshness": "fresh",
+      "lastObservedMonotonic": 969096.576384375,
+      "maxAge": null,
+      "observed": true,
+      "quality": [
+        "confirmed"
+      ],
+      "source": {
+        "capabilityId": "receiver.0.operator_controls.att",
+        "commandSource": null,
+        "nativeId": "civ:11",
+        "provider": "icom_civ",
+        "sessionId": null,
+        "source": "command_response",
+        "transport": "civ"
+      },
+      "storePath": "receiver.0.operator_controls.att"
+    },
+    "main.audioPeakFilter": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "receiver.main.operator_controls.audio_peak_filter"
+    },
+    "main.autoNotch": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "receiver.main.operator_toggles.auto_notch"
+    },
+    "main.breakInDelay": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "receiver.main.operator_controls.break_in_delay"
+    },
+    "main.compressorLevel": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "receiver.main.operator_controls.compressor_level"
+    },
+    "main.contour": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "receiver.main.slow_state.contour"
+    },
+    "main.cwPitch": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "receiver.main.operator_controls.cw_pitch"
+    },
+    "main.dataMode": {
+      "availability": "available",
+      "freshness": "fresh",
+      "lastObservedMonotonic": 969095.503348666,
+      "maxAge": 8.662066834047437,
+      "observed": true,
+      "quality": [
+        "confirmed"
+      ],
+      "source": {
+        "capabilityId": "receiver.0.active.freq_mode.data_mode",
+        "commandSource": null,
+        "nativeId": "civ:26",
+        "provider": "icom_civ",
+        "sessionId": null,
+        "source": "command_response",
+        "transport": "civ"
+      },
+      "storePath": "receiver.0.active.freq_mode.data_mode"
+    },
+    "main.dcd": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "receiver.main.operator_toggles.dcd"
+    },
+    "main.digisel": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "receiver.main.operator_toggles.digisel"
+    },
+    "main.digiselShift": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "receiver.main.operator_controls.digisel_shift"
+    },
+    "main.filter": {
+      "availability": "available",
+      "freshness": "fresh",
+      "lastObservedMonotonic": 969095.503370916,
+      "maxAge": 8.662044584052637,
+      "observed": true,
+      "quality": [
+        "confirmed"
+      ],
+      "source": {
+        "capabilityId": "receiver.0.active.freq_mode.filter_num",
+        "commandSource": null,
+        "nativeId": "civ:26",
+        "provider": "icom_civ",
+        "sessionId": null,
+        "source": "command_response",
+        "transport": "civ"
+      },
+      "storePath": "receiver.0.active.freq_mode.filter_num"
+    },
+    "main.filterShape": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "receiver.main.operator_controls.filter_shape"
+    },
+    "main.filterWidth": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "receiver.main.active.freq_mode.filter_width"
+    },
+    "main.freqHz": {
+      "availability": "available",
+      "freshness": "fresh",
+      "lastObservedMonotonic": 969096.834315875,
+      "maxAge": 7.331099625094794,
+      "observed": true,
+      "quality": [
+        "confirmed"
+      ],
+      "source": {
+        "capabilityId": "receiver.0.active.freq_mode.freq_hz",
+        "commandSource": null,
+        "nativeId": "civ:25",
+        "provider": "icom_civ",
+        "sessionId": null,
+        "source": "command_response",
+        "transport": "civ"
+      },
+      "storePath": "receiver.0.active.freq_mode.freq_hz"
+    },
+    "main.ifShift": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "receiver.main.operator_controls.if_shift"
+    },
+    "main.ipplus": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "receiver.main.operator_toggles.ipplus"
+    },
+    "main.keySpeed": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "receiver.main.operator_controls.key_speed"
+    },
+    "main.manualNotch": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "receiver.main.operator_toggles.manual_notch"
+    },
+    "main.manualNotchFreq": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "receiver.main.operator_controls.manual_notch_freq"
+    },
+    "main.manualNotchWidth": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "receiver.main.operator_controls.manual_notch_width"
+    },
+    "main.micGain": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "receiver.main.operator_controls.mic_gain"
+    },
+    "main.mode": {
+      "availability": "available",
+      "freshness": "fresh",
+      "lastObservedMonotonic": 969095.503315083,
+      "maxAge": 8.662100417073816,
+      "observed": true,
+      "quality": [
+        "confirmed"
+      ],
+      "source": {
+        "capabilityId": "receiver.0.active.freq_mode.mode",
+        "commandSource": null,
+        "nativeId": "civ:26",
+        "provider": "icom_civ",
+        "sessionId": null,
+        "source": "command_response",
+        "transport": "civ"
+      },
+      "storePath": "receiver.0.active.freq_mode.mode"
+    },
+    "main.monitorGain": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "receiver.main.operator_controls.monitor_gain"
+    },
+    "main.narrow": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "receiver.main.operator_toggles.narrow"
+    },
+    "main.nb": {
+      "availability": "available",
+      "freshness": "fresh",
+      "lastObservedMonotonic": 969096.935092833,
+      "maxAge": 10,
+      "observed": true,
+      "quality": [
+        "confirmed"
+      ],
+      "source": {
+        "capabilityId": "receiver.0.operator_toggles.nb",
+        "commandSource": null,
+        "nativeId": "civ:16:22",
+        "provider": "icom_civ",
+        "sessionId": null,
+        "source": "command_response",
+        "transport": "civ"
+      },
+      "storePath": "receiver.0.operator_toggles.nb"
+    },
+    "main.nbLevel": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "receiver.main.operator_controls.nb_level"
+    },
+    "main.nr": {
+      "availability": "available",
+      "freshness": "fresh",
+      "lastObservedMonotonic": 969097.037433,
+      "maxAge": 10,
+      "observed": true,
+      "quality": [
+        "confirmed"
+      ],
+      "source": {
+        "capabilityId": "receiver.0.operator_toggles.nr",
+        "commandSource": null,
+        "nativeId": "civ:16:40",
+        "provider": "icom_civ",
+        "sessionId": null,
+        "source": "command_response",
+        "transport": "civ"
+      },
+      "storePath": "receiver.0.operator_toggles.nr"
+    },
+    "main.nrLevel": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "receiver.main.operator_controls.nr_level"
+    },
+    "main.pbtInner": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "receiver.main.operator_controls.pbt_inner"
+    },
+    "main.pbtOuter": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "receiver.main.operator_controls.pbt_outer"
+    },
+    "main.preamp": {
+      "availability": "available",
+      "freshness": "fresh",
+      "lastObservedMonotonic": 969096.680044625,
+      "maxAge": null,
+      "observed": true,
+      "quality": [
+        "confirmed"
+      ],
+      "source": {
+        "capabilityId": "receiver.0.operator_controls.preamp",
+        "commandSource": null,
+        "nativeId": "civ:16:02",
+        "provider": "icom_civ",
+        "sessionId": null,
+        "source": "command_response",
+        "transport": "civ"
+      },
+      "storePath": "receiver.0.operator_controls.preamp"
+    },
+    "main.repeaterTone": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "receiver.main.operator_toggles.repeater_tone"
+    },
+    "main.repeaterTsql": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "receiver.main.operator_toggles.repeater_tsql"
+    },
+    "main.rfGain": {
+      "availability": "available",
+      "freshness": "fresh",
+      "lastObservedMonotonic": 969096.781336166,
+      "maxAge": 10,
+      "observed": true,
+      "quality": [
+        "confirmed"
+      ],
+      "source": {
+        "capabilityId": "receiver.0.operator_controls.rf_gain",
+        "commandSource": null,
+        "nativeId": "civ:14:02",
+        "provider": "icom_civ",
+        "sessionId": null,
+        "source": "command_response",
+        "transport": "civ"
+      },
+      "storePath": "receiver.0.operator_controls.rf_gain"
+    },
+    "main.sMeter": {
+      "availability": "available",
+      "freshness": "fresh",
+      "lastObservedMonotonic": 969097.241254291,
+      "maxAge": 2,
+      "observed": true,
+      "quality": [
+        "confirmed",
+        "uncalibrated"
+      ],
+      "source": {
+        "capabilityId": "receiver.0.meters.s_meter",
+        "commandSource": null,
+        "nativeId": "civ:15:02",
+        "provider": "icom_civ",
+        "sessionId": null,
+        "source": "command_response",
+        "transport": "civ"
+      },
+      "storePath": "receiver.0.meters.s_meter"
+    },
+    "main.sMeterSqlOpen": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "receiver.main.operator_toggles.dcd"
+    },
+    "main.squelch": {
+      "availability": "available",
+      "freshness": "fresh",
+      "lastObservedMonotonic": 969096.8825625,
+      "maxAge": null,
+      "observed": true,
+      "quality": [
+        "confirmed"
+      ],
+      "source": {
+        "capabilityId": "receiver.0.operator_controls.squelch",
+        "commandSource": null,
+        "nativeId": "civ:14:03",
+        "provider": "icom_civ",
+        "sessionId": null,
+        "source": "command_response",
+        "transport": "civ"
+      },
+      "storePath": "receiver.0.operator_controls.squelch"
+    },
+    "main.toneFreq": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "receiver.main.operator_controls.tone_freq"
+    },
+    "main.tsqlFreq": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "receiver.main.operator_controls.tsql_freq"
+    },
+    "main.twinPeakFilter": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "receiver.main.operator_toggles.twin_peak_filter"
+    },
+    "main.unselectedVfo.dataMode": {
+      "availability": "available",
+      "freshness": "fresh",
+      "lastObservedMonotonic": 969096.165458833,
+      "maxAge": 7.999956667074002,
+      "observed": true,
+      "quality": [
+        "confirmed"
+      ],
+      "source": {
+        "capabilityId": "receiver.0.unselected.freq_mode.data_mode",
+        "commandSource": null,
+        "nativeId": "civ:26",
+        "provider": "icom_civ",
+        "sessionId": null,
+        "source": "command_response",
+        "transport": "civ"
+      },
+      "storePath": "receiver.0.unselected.freq_mode.data_mode"
+    },
+    "main.unselectedVfo.filterNum": {
+      "availability": "available",
+      "freshness": "fresh",
+      "lastObservedMonotonic": 969096.16548175,
+      "maxAge": 7.999933750019409,
+      "observed": true,
+      "quality": [
+        "confirmed"
+      ],
+      "source": {
+        "capabilityId": "receiver.0.unselected.freq_mode.filter_num",
+        "commandSource": null,
+        "nativeId": "civ:26",
+        "provider": "icom_civ",
+        "sessionId": null,
+        "source": "command_response",
+        "transport": "civ"
+      },
+      "storePath": "receiver.0.unselected.freq_mode.filter_num"
+    },
+    "main.unselectedVfo.freqHz": {
+      "availability": "available",
+      "freshness": "fresh",
+      "lastObservedMonotonic": 969097.344755166,
+      "maxAge": 6.820660334080458,
+      "observed": true,
+      "quality": [
+        "confirmed"
+      ],
+      "source": {
+        "capabilityId": "receiver.0.unselected.freq_mode.freq_hz",
+        "commandSource": null,
+        "nativeId": "civ:25",
+        "provider": "icom_civ",
+        "sessionId": null,
+        "source": "command_response",
+        "transport": "civ"
+      },
+      "storePath": "receiver.0.unselected.freq_mode.freq_hz"
+    },
+    "main.unselectedVfo.mode": {
+      "availability": "available",
+      "freshness": "fresh",
+      "lastObservedMonotonic": 969096.1654155,
+      "maxAge": 8,
+      "observed": true,
+      "quality": [
+        "confirmed"
+      ],
+      "source": {
+        "capabilityId": "receiver.0.unselected.freq_mode.mode",
+        "commandSource": null,
+        "nativeId": "civ:26",
+        "provider": "icom_civ",
+        "sessionId": null,
+        "source": "command_response",
+        "transport": "civ"
+      },
+      "storePath": "receiver.0.unselected.freq_mode.mode"
+    },
+    "main.vfoA.dataMode": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "receiver.main.slot.A.freq_mode.data_mode"
+    },
+    "main.vfoA.filterNum": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "receiver.main.slot.A.freq_mode.filter_num"
+    },
+    "main.vfoA.freqHz": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "receiver.main.slot.A.freq_mode.freq_hz"
+    },
+    "main.vfoA.mode": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "receiver.main.slot.A.freq_mode.mode"
+    },
+    "main.vfoB.dataMode": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "receiver.main.slot.B.freq_mode.data_mode"
+    },
+    "main.vfoB.filterNum": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "receiver.main.slot.B.freq_mode.filter_num"
+    },
+    "main.vfoB.freqHz": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "receiver.main.slot.B.freq_mode.freq_hz"
+    },
+    "main.vfoB.mode": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "receiver.main.slot.B.freq_mode.mode"
+    },
+    "main.voxDelay": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "receiver.main.operator_controls.vox_delay"
+    },
+    "main.voxGain": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "receiver.main.operator_controls.vox_gain"
+    },
+    "mainSubTracking": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "global.tx_state.main_sub_tracking"
+    },
+    "micGain": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "global.operator_controls.mic_gain"
+    },
+    "monitorGain": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "global.operator_controls.monitor_gain"
+    },
+    "monitorOn": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "global.tx_state.monitor_on"
+    },
+    "nbDepth": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "global.operator_controls.nb_depth"
+    },
+    "nbWidth": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "global.operator_controls.nb_width"
+    },
+    "notchFilter": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "global.operator_controls.notch_filter"
+    },
+    "overflow": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "global.slow_state.overflow"
+    },
+    "powerLevel": {
+      "availability": "available",
+      "freshness": "fresh",
+      "lastObservedMonotonic": 969097.089196041,
+      "maxAge": 30,
+      "observed": true,
+      "quality": [
+        "confirmed"
+      ],
+      "source": {
+        "capabilityId": "global.operator_controls.power_level",
+        "commandSource": null,
+        "nativeId": "civ:14:0a",
+        "provider": "icom_civ",
+        "sessionId": null,
+        "source": "command_response",
+        "transport": "civ"
+      },
+      "storePath": "global.operator_controls.power_level"
+    },
+    "powerMeter": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "global.meters.power"
+    },
+    "powerOn": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "global.tx_state.power_on"
+    },
+    "ptt": {
+      "availability": "available",
+      "freshness": "fresh",
+      "lastObservedMonotonic": 969097.14197525,
+      "maxAge": 1,
+      "observed": true,
+      "quality": [
+        "confirmed"
+      ],
+      "source": {
+        "capabilityId": "global.tx_state.ptt",
+        "commandSource": null,
+        "nativeId": "civ:1c:00",
+        "provider": "icom_civ",
+        "sessionId": null,
+        "source": "command_response",
+        "transport": "civ"
+      },
+      "storePath": "global.tx_state.ptt"
+    },
+    "radioDetail.status": {
+      "availability": "available",
+      "freshness": "fresh",
+      "lastObservedMonotonic": 930166.71185225,
+      "maxAge": null,
+      "observed": true,
+      "quality": [
+        "confirmed"
+      ],
+      "source": {
+        "capabilityId": null,
+        "commandSource": null,
+        "nativeId": null,
+        "provider": "web_lifecycle",
+        "sessionId": null,
+        "source": "local_reconcile",
+        "transport": "web"
+      },
+      "storePath": "connection.connection.status"
+    },
+    "radioHealth.lastError": {
+      "availability": "available",
+      "freshness": "fresh",
+      "lastObservedMonotonic": 930166.71185225,
+      "maxAge": null,
+      "observed": true,
+      "quality": [
+        "confirmed"
+      ],
+      "source": {
+        "capabilityId": null,
+        "commandSource": null,
+        "nativeId": null,
+        "provider": "web_lifecycle",
+        "sessionId": null,
+        "source": "local_reconcile",
+        "transport": "web"
+      },
+      "storePath": "health.health.last_error"
+    },
+    "radioHealth.likelyCause": {
+      "availability": "available",
+      "freshness": "fresh",
+      "lastObservedMonotonic": 930166.71185225,
+      "maxAge": null,
+      "observed": true,
+      "quality": [
+        "confirmed"
+      ],
+      "source": {
+        "capabilityId": null,
+        "commandSource": null,
+        "nativeId": null,
+        "provider": "web_lifecycle",
+        "sessionId": null,
+        "source": "local_reconcile",
+        "transport": "web"
+      },
+      "storePath": "health.health.likely_cause"
+    },
+    "radioHealth.radioLink": {
+      "availability": "available",
+      "freshness": "fresh",
+      "lastObservedMonotonic": 930166.71185225,
+      "maxAge": null,
+      "observed": true,
+      "quality": [
+        "confirmed"
+      ],
+      "source": {
+        "capabilityId": null,
+        "commandSource": null,
+        "nativeId": null,
+        "provider": "web_lifecycle",
+        "sessionId": null,
+        "source": "local_reconcile",
+        "transport": "web"
+      },
+      "storePath": "health.health.radio_link"
+    },
+    "radioHealth.readiness": {
+      "availability": "available",
+      "freshness": "fresh",
+      "lastObservedMonotonic": 930166.71185225,
+      "maxAge": null,
+      "observed": true,
+      "quality": [
+        "confirmed"
+      ],
+      "source": {
+        "capabilityId": null,
+        "commandSource": null,
+        "nativeId": null,
+        "provider": "web_lifecycle",
+        "sessionId": null,
+        "source": "local_reconcile",
+        "transport": "web"
+      },
+      "storePath": "health.health.readiness"
+    },
+    "radioHealth.serverReachable": {
+      "availability": "available",
+      "freshness": "fresh",
+      "lastObservedMonotonic": 930166.71185225,
+      "maxAge": null,
+      "observed": true,
+      "quality": [
+        "confirmed"
+      ],
+      "source": {
+        "capabilityId": null,
+        "commandSource": null,
+        "nativeId": null,
+        "provider": "web_lifecycle",
+        "sessionId": null,
+        "source": "local_reconcile",
+        "transport": "web"
+      },
+      "storePath": "health.health.server_reachable"
+    },
+    "refAdjust": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "global.operator_controls.ref_adjust"
+    },
+    "ritFreq": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "global.operator_controls.rit_freq"
+    },
+    "ritOn": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "global.tx_state.rit_on"
+    },
+    "ritTx": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "global.tx_state.rit_tx"
+    },
+    "rxAntenna1": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "global.slow_state.rx_antenna_1"
+    },
+    "rxAntenna2": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "global.slow_state.rx_antenna_2"
+    },
+    "scanResumeMode": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "global.slow_state.scan_resume_mode"
+    },
+    "scanType": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "global.slow_state.scan_type"
+    },
+    "scanning": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "global.slow_state.scanning"
+    },
+    "scopeControls.centerType": {
+      "availability": "available",
+      "freshness": "fresh",
+      "lastObservedMonotonic": 968647.970072375,
+      "maxAge": null,
+      "observed": true,
+      "quality": [
+        "confirmed"
+      ],
+      "source": {
+        "capabilityId": "scope_controls.global.display.center_type",
+        "commandSource": null,
+        "nativeId": "civ:27:1c",
+        "provider": "icom_civ",
+        "sessionId": null,
+        "source": "command_response",
+        "transport": "civ"
+      },
+      "storePath": "scope_controls.global.display.center_type"
+    },
+    "scopeControls.dual": {
+      "availability": "available",
+      "freshness": "fresh",
+      "lastObservedMonotonic": 968647.759443666,
+      "maxAge": null,
+      "observed": true,
+      "quality": [
+        "confirmed"
+      ],
+      "source": {
+        "capabilityId": "scope_controls.global.display.dual",
+        "commandSource": null,
+        "nativeId": "civ:27:13",
+        "provider": "icom_civ",
+        "sessionId": null,
+        "source": "command_response",
+        "transport": "civ"
+      },
+      "storePath": "scope_controls.global.display.dual"
+    },
+    "scopeControls.duringTx": {
+      "availability": "available",
+      "freshness": "fresh",
+      "lastObservedMonotonic": 968647.863022375,
+      "maxAge": null,
+      "observed": true,
+      "quality": [
+        "confirmed"
+      ],
+      "source": {
+        "capabilityId": "scope_controls.global.display.during_tx",
+        "commandSource": null,
+        "nativeId": "civ:27:1b",
+        "provider": "icom_civ",
+        "sessionId": null,
+        "source": "command_response",
+        "transport": "civ"
+      },
+      "storePath": "scope_controls.global.display.during_tx"
+    },
+    "scopeControls.edge": {
+      "availability": "available",
+      "freshness": "fresh",
+      "lastObservedMonotonic": 968648.289367166,
+      "maxAge": null,
+      "observed": true,
+      "quality": [
+        "confirmed"
+      ],
+      "source": {
+        "capabilityId": "scope_controls.global.display.edge",
+        "commandSource": null,
+        "nativeId": "civ:27:16",
+        "provider": "icom_civ",
+        "sessionId": null,
+        "source": "command_response",
+        "transport": "civ"
+      },
+      "storePath": "scope_controls.global.display.edge"
+    },
+    "scopeControls.fixedEdge": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "scope_controls.global.display.fixed_edge"
+    },
+    "scopeControls.hold": {
+      "availability": "available",
+      "freshness": "fresh",
+      "lastObservedMonotonic": 968648.394131791,
+      "maxAge": null,
+      "observed": true,
+      "quality": [
+        "confirmed"
+      ],
+      "source": {
+        "capabilityId": "scope_controls.global.display.hold",
+        "commandSource": null,
+        "nativeId": "civ:27:17",
+        "provider": "icom_civ",
+        "sessionId": null,
+        "source": "command_response",
+        "transport": "civ"
+      },
+      "storePath": "scope_controls.global.display.hold"
+    },
+    "scopeControls.mode": {
+      "availability": "available",
+      "freshness": "fresh",
+      "lastObservedMonotonic": 968648.075839208,
+      "maxAge": null,
+      "observed": true,
+      "quality": [
+        "confirmed"
+      ],
+      "source": {
+        "capabilityId": "scope_controls.global.display.mode",
+        "commandSource": null,
+        "nativeId": "civ:27:14",
+        "provider": "icom_civ",
+        "sessionId": null,
+        "source": "command_response",
+        "transport": "civ"
+      },
+      "storePath": "scope_controls.global.display.mode"
+    },
+    "scopeControls.rbw": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "scope_controls.global.display.rbw"
+    },
+    "scopeControls.receiver": {
+      "availability": "available",
+      "freshness": "fresh",
+      "lastObservedMonotonic": 968648.717516125,
+      "maxAge": null,
+      "observed": true,
+      "quality": [
+        "confirmed"
+      ],
+      "source": {
+        "capabilityId": "scope_controls.global.display.receiver",
+        "commandSource": null,
+        "nativeId": "civ:27:1d",
+        "provider": "icom_civ",
+        "sessionId": null,
+        "source": "command_response",
+        "transport": "civ"
+      },
+      "storePath": "scope_controls.global.display.receiver"
+    },
+    "scopeControls.refDb": {
+      "availability": "available",
+      "freshness": "fresh",
+      "lastObservedMonotonic": 968648.501166166,
+      "maxAge": null,
+      "observed": true,
+      "quality": [
+        "confirmed"
+      ],
+      "source": {
+        "capabilityId": "scope_controls.global.display.ref_db",
+        "commandSource": null,
+        "nativeId": "civ:27:19",
+        "provider": "icom_civ",
+        "sessionId": null,
+        "source": "command_response",
+        "transport": "civ"
+      },
+      "storePath": "scope_controls.global.display.ref_db"
+    },
+    "scopeControls.span": {
+      "availability": "available",
+      "freshness": "fresh",
+      "lastObservedMonotonic": 968648.183267916,
+      "maxAge": null,
+      "observed": true,
+      "quality": [
+        "confirmed"
+      ],
+      "source": {
+        "capabilityId": "scope_controls.global.display.span",
+        "commandSource": null,
+        "nativeId": "civ:27:15",
+        "provider": "icom_civ",
+        "sessionId": null,
+        "source": "command_response",
+        "transport": "civ"
+      },
+      "storePath": "scope_controls.global.display.span"
+    },
+    "scopeControls.speed": {
+      "availability": "available",
+      "freshness": "fresh",
+      "lastObservedMonotonic": 968648.608424625,
+      "maxAge": null,
+      "observed": true,
+      "quality": [
+        "confirmed"
+      ],
+      "source": {
+        "capabilityId": "scope_controls.global.display.speed",
+        "commandSource": null,
+        "nativeId": "civ:27:1a",
+        "provider": "icom_civ",
+        "sessionId": null,
+        "source": "command_response",
+        "transport": "civ"
+      },
+      "storePath": "scope_controls.global.display.speed"
+    },
+    "scopeControls.vbwNarrow": {
+      "availability": "available",
+      "freshness": "fresh",
+      "lastObservedMonotonic": 968648.717475666,
+      "maxAge": null,
+      "observed": true,
+      "quality": [
+        "confirmed"
+      ],
+      "source": {
+        "capabilityId": "scope_controls.global.display.vbw_narrow",
+        "commandSource": null,
+        "nativeId": "civ:27:1d",
+        "provider": "icom_civ",
+        "sessionId": null,
+        "source": "command_response",
+        "transport": "civ"
+      },
+      "storePath": "scope_controls.global.display.vbw_narrow"
+    },
+    "split": {
+      "availability": "available",
+      "freshness": "fresh",
+      "lastObservedMonotonic": 969097.395403125,
+      "maxAge": null,
+      "observed": true,
+      "quality": [
+        "confirmed"
+      ],
+      "source": {
+        "capabilityId": "global.tx_state.split",
+        "commandSource": null,
+        "nativeId": "civ:0f",
+        "provider": "icom_civ",
+        "sessionId": null,
+        "source": "command_response",
+        "transport": "civ"
+      },
+      "storePath": "global.tx_state.split"
+    },
+    "ssbTxBandwidth": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "global.operator_controls.ssb_tx_bandwidth"
+    },
+    "swrMeter": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "global.meters.swr"
+    },
+    "tunerStatus": {
+      "availability": "available",
+      "freshness": "fresh",
+      "lastObservedMonotonic": 969097.190051,
+      "maxAge": null,
+      "observed": true,
+      "quality": [
+        "confirmed"
+      ],
+      "source": {
+        "capabilityId": "global.operator_controls.tuner_status",
+        "commandSource": null,
+        "nativeId": "civ:1c:01",
+        "provider": "icom_civ",
+        "sessionId": null,
+        "source": "command_response",
+        "transport": "civ"
+      },
+      "storePath": "global.operator_controls.tuner_status"
+    },
+    "tuningStep": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "global.slow_state.tuning_step"
+    },
+    "txAntenna": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "global.operator_controls.tx_antenna"
+    },
+    "txBandEdges": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "global.slow_state.tx_band_edges"
+    },
+    "txFreqMonitor": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "global.tx_state.tx_freq_monitor"
+    },
+    "txTarget": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "global.tx_state.tx_target"
+    },
+    "vdMeter": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "global.meters.vd"
+    },
+    "vfoSelect": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "global.slow_state.vfo_select"
+    },
+    "voxDelay": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "global.operator_controls.vox_delay"
+    },
+    "voxGain": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "global.operator_controls.vox_gain"
+    },
+    "voxOn": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "global.tx_state.vox_on"
+    },
+    "yaesu": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "global.slow_state.yaesu"
+    }
+  },
+  "freshnessRevision": 232,
+  "healthRevision": 1,
+  "idMeter": 0,
+  "keySpeed": 0,
+  "main": {
+    "activeSlot": "A",
+    "afLevel": 0.00392156862745098,
+    "afMute": false,
+    "agc": 3,
+    "agcTimeConstant": 0,
+    "apfFreq": 0,
+    "apfOn": false,
+    "apfTypeLevel": 0,
+    "att": 0,
+    "audioPeakFilter": 0,
+    "autoNotch": false,
+    "contour": 0,
+    "dataMode": 0,
+    "digisel": false,
+    "digiselShift": 0,
+    "filter": 1,
+    "filterShape": 0,
+    "filterWidth": null,
+    "freqHz": 14188000,
+    "ifShift": 0,
+    "ipplus": false,
+    "manualNotch": false,
+    "manualNotchFreq": 0,
+    "manualNotchWidth": 0,
+    "mode": "USB",
+    "narrow": false,
+    "nb": true,
+    "nbLevel": 0,
+    "nr": true,
+    "nrLevel": 0,
+    "pbtInner": 128,
+    "pbtOuter": 128,
+    "preamp": 0,
+    "repeaterTone": false,
+    "repeaterTsql": false,
+    "rfGain": 0.8196078431372549,
+    "sMeter": 0,
+    "sMeterSqlOpen": false,
+    "squelch": 0,
+    "toneFreq": 0,
+    "tsqlFreq": 0,
+    "twinPeakFilter": false,
+    "unselectedVfo": {
+      "dataMode": 0,
+      "filterNum": 1,
+      "freqHz": 14074000,
+      "mode": "USB"
+    },
+    "vfoA": {
+      "dataMode": 0,
+      "filterNum": null,
+      "freqHz": 0,
+      "mode": "USB"
+    },
+    "vfoB": {
+      "dataMode": 0,
+      "filterNum": null,
+      "freqHz": 0,
+      "mode": "USB"
+    }
+  },
+  "mainSubTracking": false,
+  "micGain": 0,
+  "monitorGain": 0,
+  "monitorOn": false,
+  "nbDepth": 0,
+  "nbWidth": 0,
+  "notchFilter": 0,
+  "observationSeq": 851011,
+  "overflow": false,
+  "powerLevel": 0.011764705882352941,
+  "powerMeter": 0,
+  "powerOn": true,
+  "providerGeneration": 1,
+  "ptt": false,
+  "publicStateSeq": 144497,
+  "radioDetail": {
+    "status": "connected"
+  },
+  "radioHealth": {
+    "lastError": null,
+    "likelyCause": "unknown",
+    "radioLink": "connected",
+    "readiness": "ready",
+    "serverReachable": true,
+    "sinceMs": 38930718
+  },
+  "refAdjust": 0,
+  "revision": 22144,
+  "ritFreq": 0,
+  "ritOn": false,
+  "ritTx": false,
+  "rxAntenna1": false,
+  "rxAntenna2": false,
+  "scanResumeMode": 0,
+  "scanType": 0,
+  "scanning": false,
+  "scopeControls": {
+    "centerType": 2,
+    "dual": false,
+    "duringTx": true,
+    "edge": 1,
+    "fixedEdge": {
+      "edge": 0,
+      "endHz": 0,
+      "rangeIndex": 0,
+      "startHz": 0
+    },
+    "hold": false,
+    "mode": 0,
+    "rbw": 0,
+    "receiver": 0,
+    "refDb": 5,
+    "span": 4,
+    "speed": 0,
+    "vbwNarrow": false
+  },
+  "split": false,
+  "ssbTxBandwidth": 0,
+  "stateContractVersion": 1,
+  "stateRevision": 22144,
+  "swrMeter": 0,
+  "tunerStatus": 0,
+  "tuningStep": 0,
+  "txAntenna": 1,
+  "txBandEdges": [],
+  "txFreqMonitor": false,
+  "txTarget": {
+    "reason": "not-observed",
+    "status": "unknown"
+  },
+  "updatedAt": "2026-08-11T13:39:37.278823+00:00",
+  "vdMeter": 0,
+  "vfoSelect": 0,
+  "voxDelay": 0,
+  "voxGain": 0,
+  "voxOn": false,
+  "wsClients": {
+    "audio": 0,
+    "control": 3,
+    "scope": 3
+  },
+  "yaesu": null
+}

--- a/frontend/src/lib/runtime/adapters/__tests__/mor1428-ic7300-conformance.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mor1428-ic7300-conformance.isolated.test.ts
@@ -1,0 +1,382 @@
+/**
+ * MOR-1428 — Tier 2 v1: IC-7300 profile conformance suite over the
+ * live-captured fixture.
+ *
+ * MOR-1409's A07-A15 authority migration (closed at `c96ae052`, #2317) left
+ * 6543+ green frontend tests coexisting with 12 dead control families on a
+ * real single-receiver radio: `knownActiveReceiver()` and its four sibling
+ * gates required the radio-wide `active` field to be positively observed
+ * before routing ANY receiver-scoped write, and the IC-7300's CI-V link
+ * never confirms that field (dual-RX-only echo) — every synthetic test
+ * fixture built `active: 'MAIN'` as an OBSERVED fact and therefore never
+ * caught it. The MOR-1418/1421/1423/1419 fix wave (this repo's
+ * `origin/main`, PRs #2372/#2374/#2376/#2373) made the active receiver
+ * resolve structurally from capabilities instead. This suite is the
+ * regression guard for that class of bug: every assertion below runs
+ * against `fixtures/ic7300-{state,capabilities}.json`, a byte-faithful
+ * capture of the real bench stand's `/api/v1/state` +
+ * `/api/v1/capabilities` (see `fixtures/ic7300-profile.ts` for full
+ * provenance) — not a synthetic state where every field is conveniently
+ * observed.
+ *
+ * Per-assertion mapping to the walkthrough findings this closes:
+ *   - `describe('view model...')`      -> MOR-1421 (activeReceiverId /
+ *                                          scope-adapter / VFO tile highlight)
+ *   - `describe('dual-receiver chrome...')` -> MOR-1421 (`hasDualReceiver`
+ *                                          gate, SemanticRadioSurfaces.svelte)
+ *   - `describe('handler dispatch...')` -> MOR-1418 (mode/filter/band/RF/AGC/
+ *                                          NB/NR/AF/RIT gate) and MOR-1423
+ *                                          (memory/keyboard/VFO-select gate)
+ *   - `describe('honest refusals...')`  -> MOR-988 §3.2 fail-closed doctrine:
+ *                                          the fix wave bypasses ONLY the
+ *                                          `active` gate — leaf fields the
+ *                                          radio genuinely never confirmed
+ *                                          (`ritOn`, `micGain`, `main.nbLevel`)
+ *                                          must still refuse.
+ *
+ * ISOLATED POOL (MOR-1272 naming convention): this file module-scope-mocks
+ * six store/transport modules the same way
+ * `panel-commands.intent.isolated.test.ts` does, for the identical reason —
+ * under the `fast` project's `isolate: false`, a sibling file importing the
+ * real modules later in the same worker could inherit this file's mocked
+ * instances from the shared module cache.
+ *
+ * Unlike `panel-commands.intent.isolated.test.ts`, this file does NOT mock
+ * `$lib/state/field-status` — that module is pure (reads `state.fieldStatus`
+ * directly, no store lookups), and the whole point of an over-the-fixture
+ * suite is to exercise it against the REAL captured `fieldStatus` map rather
+ * than a synthetic per-test override.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { ServerState } from '$lib/types/state';
+
+const h = vi.hoisted(() => ({
+  state: null as ServerState | null,
+  caps: null as Capabilities | null,
+  sendCommand: vi.fn((
+    _name: string,
+    _params: Record<string, unknown>,
+    _id?: string,
+  ) => true),
+  patchActiveReceiver: vi.fn(),
+  patchRadioState: vi.fn(),
+  patchReceiver: vi.fn(),
+  rxEnabled: false,
+  setMuted: vi.fn(),
+  setRxLive: vi.fn(),
+  setRxVolume: vi.fn(),
+  setVolume: vi.fn(),
+  setAudioConfig: vi.fn(),
+}));
+
+vi.mock('$lib/transport/ws-client', () => ({
+  getControlSession: vi.fn(() => ({ state: 'connected', epoch: 1 })),
+  onCommandDelivery: vi.fn(() => () => undefined),
+  onControlSessionTransition: vi.fn(() => () => undefined),
+  sendCommand: h.sendCommand,
+}));
+
+vi.mock('$lib/stores/radio.svelte', () => ({
+  getActiveReceiver: vi.fn(() => {
+    if (!h.state) return null;
+    return h.state.active === 'SUB' ? h.state.sub ?? null : h.state.main ?? null;
+  }),
+  getRadioState: vi.fn(() => h.state),
+  // Unused by panel-commands.ts (it reads `$lib/state/field-status`'s
+  // `isFieldAvailable` instead, which this file leaves REAL) — kept for
+  // mock-module shape completeness only.
+  isRadioFieldAvailable: vi.fn(() => false),
+  patchActiveReceiver: h.patchActiveReceiver,
+  patchRadioState: h.patchRadioState,
+  patchReceiver: h.patchReceiver,
+}));
+
+vi.mock('$lib/stores/capabilities.svelte', () => ({
+  getCapabilities: vi.fn(() => h.caps),
+  capabilitiesMatchGeneration: vi.fn((providerGeneration: unknown) =>
+    Number.isSafeInteger(providerGeneration)
+    && h.caps?.stateContractVersion === 1
+    && h.caps?.providerGeneration === providerGeneration),
+  getControlRange: vi.fn((name: string) =>
+    (h.caps?.controls as Record<string, unknown> | undefined)?.[name] ?? null),
+}));
+
+vi.mock('$lib/runtime/frontend-runtime', () => ({
+  runtime: {
+    get rxEnabled() { return h.rxEnabled; },
+    setMuted: h.setMuted,
+    setRxLive: h.setRxLive,
+    setRxVolume: h.setRxVolume,
+    setVolume: h.setVolume,
+  },
+}));
+
+vi.mock('$lib/audio/audio-manager', () => ({
+  audioManager: { setAudioConfig: h.setAudioConfig },
+}));
+
+vi.mock('$lib/stores/tuning.svelte', () => ({
+  getTuningStep: vi.fn(() => 1_000),
+}));
+
+import {
+  makeAgcHandlers,
+  makeBandHandlers,
+  makeDspHandlers,
+  makeFilterHandlers,
+  makeMemoryHandlers,
+  makeModeHandlers,
+  makeRfFrontEndHandlers,
+  makeRitXitHandlers,
+  makeRxAudioHandlers,
+  makeTxHandlers,
+  makeVfoHandlers,
+  dispatchKeyboardRadioAction,
+} from '../../commands/panel-commands';
+import { getCommandLifecycles, resetCommandLifecycle } from '$lib/stores/commands.svelte';
+import { validateRadioViewModel } from '../../../../semantic/radio-view-model';
+import { toRadioViewModel } from '../radio-view-model-adapter';
+import { toSpectrumAuthority } from '../scope-adapter';
+import { IC7300_CAPABILITIES, IC7300_STATE } from './fixtures/ic7300-profile';
+
+/** Deep clone so a test that mutates `h.state`/`h.caps` never leaks into a sibling. */
+function fixtureState(): ServerState {
+  return structuredClone(IC7300_STATE);
+}
+function fixtureCaps(): Capabilities {
+  return structuredClone(IC7300_CAPABILITIES);
+}
+
+function exactCalls(): Array<[string, Record<string, unknown>]> {
+  return h.sendCommand.mock.calls.map(([name, params]) => [name, params]);
+}
+
+function expectIntentTransport(): void {
+  for (const call of h.sendCommand.mock.calls) {
+    expect(call[2]).toEqual(expect.any(String));
+    expect(call).toHaveLength(3);
+  }
+  expect(getCommandLifecycles()).toHaveLength(h.sendCommand.mock.calls.length);
+}
+
+/* ── Section 1: real adapters over the raw fixture (no store mocking needed —
+ * toRadioViewModel/toSpectrumAuthority take state+caps as plain arguments). */
+
+describe('IC-7300 fixture — real toRadioViewModel/toSpectrumAuthority (MOR-1421)', () => {
+  it('resolves activeReceiver to MAIN though the live stand never observed `active` (MOR-1421)', () => {
+    // Confirms the fixture actually exercises the bug: the live radio's
+    // `active` field reads observed:false — the structurally-unobservable
+    // shape the fix targets, not a stand-in.
+    expect(IC7300_STATE.fieldStatus?.active?.observed).toBe(false);
+    expect(IC7300_CAPABILITIES.receivers).toBe(1);
+
+    const view = validateRadioViewModel(toRadioViewModel(IC7300_STATE, IC7300_CAPABILITIES));
+    expect(view.activeReceiver).toEqual({ status: 'known', receiver: 'MAIN' });
+    expect(view.disabledReasons).not.toContainEqual({
+      field: 'activeReceiver', code: 'field-not-observed',
+    });
+  });
+
+  it('marks exactly one VFO tile isActiveSlot && isActive', () => {
+    const view = validateRadioViewModel(toRadioViewModel(IC7300_STATE, IC7300_CAPABILITIES));
+    const activeTiles = view.vfos.filter((vfo) => vfo.isActive && vfo.isActiveSlot);
+    expect(activeTiles).toHaveLength(1);
+    expect(activeTiles[0].receiver).toBe('MAIN');
+  });
+
+  it('revives a non-null spectrum authority for receiver 0 at the fixture\'s live freq/mode', () => {
+    const authority = toSpectrumAuthority(IC7300_STATE, IC7300_CAPABILITIES);
+    expect(authority).not.toBeNull();
+    expect(authority).toMatchObject({
+      receiver: 0,
+      frequencyHz: IC7300_STATE.main!.freqHz,
+      mode: IC7300_STATE.main!.mode,
+    });
+  });
+
+  it('hides dual-watch / active-receiver readout chrome — hasDualReceiver gate is false (MOR-1421, #2376)', () => {
+    // Same plain expression `SemanticRadioSurfaces.svelte` computes at its
+    // seam: `(runtime.caps?.receivers ?? 1) > 1`. A single-receiver IC-7300
+    // fixture must resolve this to false — VfoSurface's radio-wide
+    // active-receiver readout and dual-watch toggle stay hidden.
+    const hasDualReceiver = (IC7300_CAPABILITIES.receivers ?? 1) > 1;
+    expect(hasDualReceiver).toBe(false);
+  });
+});
+
+/* ── Section 2: handler dispatch through the REAL panel-commands.ts
+ * factories, fed the fixture via the mocked store seams above. Every
+ * expectation names the WS frame (command name + exact params shape) the
+ * real factory must produce. */
+
+describe('IC-7300 fixture — handler dispatch through real factories (MOR-1418/MOR-1423)', () => {
+  beforeEach(() => {
+    h.state = fixtureState();
+    h.caps = fixtureCaps();
+    h.sendCommand.mockClear();
+    h.patchActiveReceiver.mockClear();
+    h.patchRadioState.mockClear();
+    h.patchReceiver.mockClear();
+    h.setAudioConfig.mockClear();
+    h.rxEnabled = false;
+  });
+
+  afterEach(() => {
+    resetCommandLifecycle();
+  });
+
+  it('mode: dispatches set_mode on receiver 0 although `active` was never observed', () => {
+    makeModeHandlers().onModeChange('CW');
+    expect(exactCalls()).toEqual([['set_mode', { mode: 'CW', receiver: 0 }]]);
+    expectIntentTransport();
+  });
+
+  it('filter: dispatches set_filter on receiver 0', () => {
+    makeFilterHandlers().onFilterChange(2);
+    expect(exactCalls()).toEqual([['set_filter', { filter: 2, receiver: 0 }]]);
+    expectIntentTransport();
+  });
+
+  it('band: dispatches set_band from a BSR-coded band select', () => {
+    makeBandHandlers().onBandSelect('20m', 14_225_000, 5);
+    expect(exactCalls()).toEqual([['set_band', { band: 5 }]]);
+    expectIntentTransport();
+  });
+
+  it('RF front end: dispatches set_attenuator / set_preamp / set_rf_gain on receiver 0', () => {
+    makeRfFrontEndHandlers().onAttChange(0);
+    makeRfFrontEndHandlers().onPreChange(1);
+    makeRfFrontEndHandlers().onRfGainChange(200);
+    expect(exactCalls()).toEqual([
+      ['set_attenuator', { db: 0, receiver: 0 }],
+      ['set_preamp', { level: 1, receiver: 0 }],
+      ['set_rf_gain', { level: 200, receiver: 0 }],
+    ]);
+    expectIntentTransport();
+  });
+
+  it('AGC: dispatches set_agc on receiver 0', () => {
+    makeAgcHandlers().onAgcModeChange(2);
+    expect(exactCalls()).toEqual([['set_agc', { mode: 2, receiver: 0 }]]);
+    expectIntentTransport();
+  });
+
+  it('NB: dispatches set_nb on receiver 0', () => {
+    makeDspHandlers().onNbToggle(true);
+    expect(exactCalls()).toEqual([['set_nb', { on: true, receiver: 0 }]]);
+    expectIntentTransport();
+  });
+
+  it('NR: dispatches set_nr on receiver 0', () => {
+    makeDspHandlers().onNrModeChange(1);
+    expect(exactCalls()).toEqual([['set_nr', { on: true, receiver: 0 }]]);
+    expectIntentTransport();
+  });
+
+  it('AF level: dispatches set_af_level on receiver 0', () => {
+    makeRxAudioHandlers().onAfLevelChange(0.5);
+    expect(exactCalls()).toEqual([['set_af_level', { level: 0.5, receiver: 0 }]]);
+    expectIntentTransport();
+  });
+
+  it('memory recall: dispatches set_memory_mode + memory_to_vfo (relative A/B identity, MOR-1423)', () => {
+    // The live stand's `main.activeSlot` is unobserved, but
+    // `vfoReadback: 'selected_unselected'` makes `relativeVfoIdentityUnknown`
+    // route the snapshot through `main.freqHz`/`main.mode` directly instead
+    // of the absolute A/B slot — both genuinely observed on this fixture.
+    const ok = makeMemoryHandlers().onRecall(7);
+    expect(ok).toBe(true);
+    expect(exactCalls()).toEqual([
+      ['set_memory_mode', { channel: 7 }],
+      ['memory_to_vfo', { channel: 7 }],
+    ]);
+    expectIntentTransport();
+  });
+
+  it('memory store: dispatches set_memory_mode + memory_write for the fixture\'s live freq/mode', () => {
+    const ok = makeMemoryHandlers().onStore(5, IC7300_STATE.main!.freqHz, IC7300_STATE.main!.mode);
+    expect(ok).toBe(true);
+    expect(exactCalls()).toEqual([
+      ['set_memory_mode', { channel: 5 }],
+      ['memory_write', {}],
+    ]);
+    expectIntentTransport();
+  });
+
+  it('keyboard context: dispatches set_split via dispatchKeyboardRadioAction(toggle_split)', () => {
+    expect(IC7300_STATE.split).toBe(false);
+    const handled = dispatchKeyboardRadioAction({ action: 'toggle_split' });
+    expect(handled).toBe(true);
+    expect(exactCalls()).toEqual([['set_split', { on: true }]]);
+    expectIntentTransport();
+  });
+
+  it('VFO A/B select: dispatches set_vfo for the target slot (no dependency on activeSlot)', () => {
+    // `onVfoSelect` never reads `main.activeSlot` — it resolves the receiver
+    // structurally (MOR-1423) and only checks the SLOT is reachable
+    // (`vfoScheme: 'ab'` supports A/B). Works although activeSlot is
+    // unobserved on this fixture.
+    makeVfoHandlers().onVfoSelect('MAIN', 'B');
+    expect(exactCalls()).toEqual([['set_vfo', { vfo: 'B' }]]);
+    expectIntentTransport();
+  });
+
+  it('onMainFreqChange: dispatches set_freq on receiver 0', () => {
+    makeVfoHandlers().onMainFreqChange(14_205_000);
+    expect(exactCalls()).toEqual([['set_freq', { freq: 14_205_000, receiver: 0 }]]);
+    expectIntentTransport();
+  });
+
+  it('RIT toggle: REFUSES — `ritOn` is genuinely unobserved on this fixture, not fabricated MAIN-bypassed (MOR-1418 scope boundary)', () => {
+    // `rit` is a declared capability and the single-RX `active` bypass is
+    // in effect, but `onRitToggle` ALSO gates on `knownTopLevelField('ritOn')`
+    // — a DIFFERENT field the fix wave never touches. The live IC-7300
+    // stand never confirmed ritOn in this session (nobody queried RIT), so
+    // this must still refuse: the fix bypasses exactly the `active` gate,
+    // nothing else.
+    expect(IC7300_CAPABILITIES.capabilities).toContain('rit');
+    expect(IC7300_STATE.fieldStatus?.ritOn?.observed).toBe(false);
+
+    makeRitXitHandlers().onRitToggle();
+
+    expect(h.sendCommand).not.toHaveBeenCalled();
+    expect(getCommandLifecycles()).toHaveLength(0);
+  });
+});
+
+/* ── Section 3: honest refusals pinned — genuinely-unobserved leaves on the
+ * live fixture must still fail closed. RIT (above) is the first; two more
+ * below. Each names the specific field the live radio never confirmed. */
+
+describe('IC-7300 fixture — honest refusals pinned (MOR-988 §3.2 fail-closed)', () => {
+  beforeEach(() => {
+    h.state = fixtureState();
+    h.caps = fixtureCaps();
+    h.sendCommand.mockClear();
+  });
+
+  afterEach(() => {
+    resetCommandLifecycle();
+  });
+
+  it('mic gain: REFUSES — micGain is unobserved on the live stand', () => {
+    expect(IC7300_STATE.fieldStatus?.micGain?.observed).toBe(false);
+
+    makeTxHandlers().onMicGainChange(100);
+
+    expect(h.sendCommand).not.toHaveBeenCalled();
+    expect(getCommandLifecycles()).toHaveLength(0);
+  });
+
+  it('NB level: REFUSES — main.nbLevel is unobserved on the live stand (main.nb itself IS observed)', () => {
+    expect(IC7300_STATE.fieldStatus?.['main.nbLevel']?.observed).toBe(false);
+    // Contrast: the boolean NB toggle IS observed and DOES dispatch (Section 2).
+    expect(IC7300_STATE.fieldStatus?.['main.nb']?.observed).toBe(true);
+
+    makeDspHandlers().onNbLevelChange(5);
+
+    expect(h.sendCommand).not.toHaveBeenCalled();
+    expect(getCommandLifecycles()).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Motivation

Vertical-contract gap: the IC-7300 adapter unit suite is green while 12
control families sat effectively dead — unit-level mocks confirmed the
adapter's *shape* but never proved it resolves real per-family dispatch
against a real capability/state factory pair, or that it correctly
refuses on leaves a given radio genuinely never observes. This suite
closes that gap with a byte-faithful fixture instead of a synthetic
all-or-nothing one.

## What the 20 tests pin

- **Per-family dispatch** through the real capability/state factories —
  not mocks — covering mode, filter, band, RF, AGC, NB, NR, AF, memory,
  keyboard, VFO-select, and frequency families.
- **Adapter-level facts**: `activeReceiver` resolves to known `MAIN`,
  tile highlight state, and spectrum authority resolution
  (`toSpectrumAuthority`, gated on matching `stateContractVersion` /
  `providerGeneration` between the two fixture payloads).
- **Honest refusals**: leaves that are structurally unobservable on
  *this* radio (`ritOn`, `ritFreq`, `ritTx`, `micGain`, `main.nbLevel`,
  `main.activeSlot`, `main.vfoA.*`, `main.vfoB.*`) continue to refuse
  (fail closed) rather than fabricate a value — even though sibling
  leaves on the very same family (freq/mode/filter/att/preamp/rf-gain/
  agc/nb/nr/af-level/split) genuinely do resolve on the captured
  fixture. This is the point of using a live-captured partial-
  observation snapshot instead of an all-true or all-false synthetic
  fixture: it proves the adapter distinguishes "this leaf was never
  confirmed" from "this leaf is false" on a per-leaf basis, not just
  per-family.

## Mutation-sanity evidence (manual, not part of CI)

- Reverting the MOR-1418 fix: **8/20** tests fail.
- Reverting the MOR-1421 fix: **3/20** tests fail.

Confirms the suite actually exercises the behavior it claims to pin
rather than just walking the adapter's happy path.

## Capture script

`frontend/scripts/capture-profile.mjs` is a dependency-free Node ESM
script (Node 18+ native `fetch`) that performs a **read-only GET**
against `/api/v1/state` and `/api/v1/capabilities` on a running
rigplane-core web server — no CI-V writes, no WS traffic. The base URL
is a **required** CLI argument with no default:

```
node scripts/capture-profile.mjs <baseUrl> <name> [outDir]
node scripts/capture-profile.mjs http://localhost:8099 ic7300
```

## Fixture provenance

`ic7300-state.json` / `ic7300-capabilities.json` were captured from a
local RigPlane bench instance (IC-7300, serial backend) on
**2026-08-11**, against backend SHA **`e0b19814`** (`origin/main`,
includes the MOR-1409 A07–A15 authority migration plus the MOR-1418/
MOR-1421/MOR-1423/MOR-1419/MOR-1427 single-RX fix wave). The two JSON
payloads carry no embedded metadata of their own by design — they stay
byte-faithful captures of the real API response; provenance lives in
the fixture loader's header comment (`ic7300-profile.ts`) and here.

## Linear

https://linear.app/morozsm/issue/MOR-1428

## Review status

**Independent verifier review pending — do not merge.**

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
