### PR TITLE
test: stub companion-endpoint probes in capture harness and log failed-resource URLs (MOR-1430)

### DIFF
--- a/frontend/fixtures/capture.mjs
+++ b/frontend/fixtures/capture.mjs
@@ -337,6 +337,33 @@ try {
     });
     const page = await context.newPage();
     const consoleErrors = [];
+    // MOR-1430: attached BEFORE `page.goto` below (deterministic — no race
+    // with navigation) alongside the console/pageerror traps.
+    //
+    // Chrome's own "Failed to load resource: the server responded with a
+    // status of ###" console entry (emitted for ANY failed fetch/XHR/script/
+    // stylesheet/image load, regardless of whether page JS catches the
+    // rejection) never carries the URL — Playwright's `console` event only
+    // exposes the rendered text, which Chrome deliberately keeps generic.
+    // That made a fixture-harness 404 unattributable from CI logs alone
+    // (MOR-1430 sub-defect 1). `page.on('response')` and `page.on(
+    // 'requestfailed')` DO carry the request identity, so this pushes one
+    // precise `method URL -> status` (or `-> errorText` for a network-level
+    // failure with no response at all, e.g. connection refused) entry per
+    // failed resource — independent of, and in addition to, Chrome's own
+    // generic console text below.
+    page.on('response', (response) => {
+      if (response.status() < 400) return;
+      consoleErrors.push(
+        `resource-error: ${response.request().method()} ${response.url()} -> ${response.status()}`,
+      );
+    });
+    page.on('requestfailed', (request) => {
+      consoleErrors.push(
+        `resource-failed: ${request.method()} ${request.url()} -> `
+        + `${request.failure()?.errorText ?? 'unknown error'}`,
+      );
+    });
     page.on('console', (m) => { if (m.type() === 'error') consoleErrors.push(m.text()); });
     page.on('pageerror', (e) => consoleErrors.push(`pageerror: ${e.message}`));
     if (spec.media) await page.emulateMedia(spec.media);

--- a/frontend/vite.fixtures.config.ts
+++ b/frontend/vite.fixtures.config.ts
@@ -4,10 +4,14 @@
  * (`vite --config vite.fixtures.config.ts`) and nothing in the app build,
  * `npm run dev`, `npm run lint`, `npm run check` or `vitest` reads it.
  *
- * It differs from the app config in exactly two ways:
+ * It differs from the app config in exactly three ways:
  *   1. no dev-server proxy — the harness is offline by construction;
  *   2. the `fixtureStubs` plugin below re-points the FOUR live seams the
  *      cockpit's tree reaches through at `fixtures/stubs/*`.
+ *   3. the `fixtureCompanionProbeStubs` plugin (MOR-1430) answers the two
+ *      companion-app probe endpoints deterministically instead of letting
+ *      them fall through to the dev server's 404 — see that plugin's header
+ *      comment for why.
  *
  * Everything else the capture renders is the shipped code: the real
  * `radio-view-model-adapter`, the real `derivePresentationCapabilities`, the
@@ -59,11 +63,65 @@ function fixtureStubs(): Plugin {
   };
 }
 
+/**
+ * MOR-1430 — deterministic answers for the companion-app probe endpoints.
+ *
+ * The real app fetches two same-origin routes that only a companion process
+ * (RC-28 / the local-extensions host) ever actually serves:
+ *   - `GET  /api/local/v1/ui/manifest`      (`$lib/local-extensions/manifest.ts`)
+ *   - `PUT  /api/local/v1/rc28/tuning-step` (`$lib/stores/tuning.svelte.ts`)
+ *
+ * Both call sites already treat "no companion" as a normal, silent condition
+ * — the manifest loader returns `null` on any non-ok response or unparseable
+ * body, and the tuning-step sync only `.catch()`s to swallow network-level
+ * failures. Neither checks `response.ok`, so an HTTP error status never
+ * throws in application code. But the browser itself does not know that: any
+ * fetch/XHR that resolves with a >=400 status gets its own
+ * "Failed to load resource: the server responded with a status of ###"
+ * console entry, regardless of how the page-level JS handles the response.
+ * On the fixture harness's offline dev server (no proxy, see file header),
+ * both routes are unhandled and fall through to Vite's 404 — which the
+ * capture harness's clean-console gate (`capture.mjs`) then fails on, for a
+ * *reference* fixture that has nothing to do with either endpoint. Because
+ * which fixture happens to still be mid-navigation when the probe's response
+ * lands is a race, the failing fixture roams from run to run (MOR-1430).
+ *
+ * The fix is to make the companion's ABSENCE a deterministic, silent 2xx
+ * here — not to special-case 404s in the console-error gate. A blanket
+ * allowance would hide a real regression (e.g. a typo'd fetch URL) behind
+ * "oh, that's just the companion". Answering with 204 No Content: `.ok` is
+ * true so both call sites take their normal no-op path, and there is no body
+ * to keep in sync with `LocalExtensionManifest`'s shape as it evolves. Every
+ * OTHER route keeps the strict default 404 — this is a two-route allowlist,
+ * not a tolerance policy.
+ */
+function fixtureCompanionProbeStubs(): Plugin {
+  const STUBBED_COMPANION_ROUTES: ReadonlySet<string> = new Set([
+    'GET /api/local/v1/ui/manifest',
+    'PUT /api/local/v1/rc28/tuning-step',
+  ]);
+  return {
+    name: 'mor-1430-fixture-companion-probe-stubs',
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        const [pathname] = (req.url ?? '').split('?');
+        const key = `${req.method} ${pathname}`;
+        if (!STUBBED_COMPANION_ROUTES.has(key)) {
+          next();
+          return;
+        }
+        res.statusCode = 204;
+        res.end();
+      });
+    },
+  };
+}
+
 export default defineConfig({
   // Root stays the app root so `svelte.config.js`, `public/` and the `../src`
   // imports resolve exactly as they do in a normal build; the harness is a
   // second HTML entry at `/fixtures/index.html`, not a second project.
-  plugins: [fixtureStubs(), svelte()],
+  plugins: [fixtureStubs(), fixtureCompanionProbeStubs(), svelte()],
   resolve: {
     alias: { $lib: path.resolve(here, 'src/lib') },
     conditions: ['svelte', 'browser'],


### PR DESCRIPTION
## Problem

`quick.yml`'s "Frontend fixture-harness capture" leg (`capture.mjs`) has failed a random *reference* fixture 3x in CI within a 90-minute window, across two unrelated PRs. Every occurrence:

- shows `✗ console: Failed to load resource: the server responded with a status of 404 ()` with no URL, method, or resource attached — impossible to attribute from CI logs alone
- has every behavior assertion passing (`N/N assertions`)
- fails a *different* fixture each time — the failure roams run to run

Two sub-defects:

1. **No attribution.** The console-error trap (`page.on('console', ...)`) only records Chrome's own generic message text ("Failed to load resource: the server responded with a status of ###"), which Chrome deliberately keeps free of the URL. There is no way to tell which resource failed from the printed log.
2. **A real 404.** The frontend deliberately probes two companion-app endpoints and JS-catches the failure as a normal "no companion" condition (`frontend/src/lib/local-extensions/manifest.ts`'s `loadLocalExtensionManifest` GET, `frontend/src/lib/stores/tuning.svelte.ts`'s `_syncToCompanion` PUT) — but the browser still emits its own console error for the failed network response regardless of how page JS handles it. The fixture harness's dev server has no proxy and doesn't answer either route, so both 404. Whichever fixture happens to still be mid-navigation when that response lands eats the console entry — a race, which is why the failing fixture roams.

## Fix

- **`frontend/fixtures/capture.mjs`**: attaches `page.on('response')` and `page.on('requestfailed')` listeners *before* `page.goto` (alongside the existing console/pageerror traps, so no timing race), pushing one precise `method URL -> status` (or `-> errorText` for a connection-level failure) entry per failed resource load. A future occurrence is now attributable straight from the CI log line.
- **`frontend/vite.fixtures.config.ts`**: a new `fixtureCompanionProbeStubs` dev-server middleware answers exactly `GET /api/local/v1/ui/manifest` and `PUT /api/local/v1/rc28/tuning-step` with a deterministic `204 No Content` — both call sites already treat a non-`ok` response as "no companion, carry on silently" (`manifest.ts` returns `null`, `tuning.svelte.ts` only `.catch()`s network-level failures), so `204` is a true, harmless "not present" answer, not a fabricated payload.

**Why stubbing beats allowlisting the console gate**: a blanket 404-tolerance rule would also hide a real regression (e.g. a typo'd fetch URL elsewhere) behind "oh, that's probably the companion". The stub is scoped to the exact method+path pair for these two known, intentional-degradation probes; every other route — including the wrong HTTP method on these same two paths — keeps the existing strict 404 and still fails the clean-console gate. A comment block in `vite.fixtures.config.ts` explains the companion-app contract this stubs against.

## Validation

- `node --check fixtures/capture.mjs` — syntax OK
- `node fixtures/capture.mjs --preflight-only` — PASS (the same `vite build` step CI's leg runs first)
- `npm run lint` — 0 errors (pre-existing 3 `no-console` disable-directive warnings in `capture.mjs`, unchanged, confirmed present on `main` before this diff too)
- `npm run check` — 0 errors, 0 warnings across 4531 files
- `npx vitest run` — 319 files / 6585 tests passed
- Manually verified against a live `vite --config vite.fixtures.config.ts` dev server: `GET /api/local/v1/ui/manifest` and `PUT /api/local/v1/rc28/tuning-step` now return `204`/`ok:true` with **no** console error emitted; the same path with the *wrong* method (`PUT` manifest, `GET` tuning-step) still 404s, confirming the gate stays strict everywhere else.
- Local Playwright Chromium is broken on this machine (`dlopen` failure on the cached build), so the actual `capture.mjs` matrix run (Playwright + the harness's own console gate) could not be exercised end-to-end locally — **`quick.yml`'s capture leg on this PR IS the test.**

Diff: harness/config only, 2 files, 87 net LOC. No `src/` production code touched.

Linear: https://linear.app/morozsm/issue/MOR-1430

Independent verifier review pending — do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)