### PR TITLE
fix: accumulate rapid tuning steps on the pending target (MOR-1425)

### DIFF
--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -420,8 +420,25 @@
    * `onSubFreqChange`), which own the optimistic patch and the `set_freq`
    * command. No new key path and no TX semantics (R9): this moves a frequency,
    * it never keys the transmitter.
+   *
+   * MOR-1425 review round 2 (B1 residual): this function funnels TWO
+   * different gesture shapes into the same per-receiver VFO handlers —
+   * `VfoSurface`'s per-digit wheel/arrow tuning below (a genuine RELATIVE
+   * step, `kind` defaults to `'step'` so every existing digit-path call site
+   * needs no change) and `enterFrequency`/`selectBand`'s bandless fallback
+   * (both an ABSOLUTE typed/default target). `onMainFreqChange`/
+   * `onSubFreqChange` themselves stay unconditional-`step()` (unchanged, so
+   * every other caller — `RadioLayout`'s legacy `VfoHeader` wiring,
+   * `MobileRadioLayout`'s `tuneBy` — is unaffected); an absolute source
+   * routes around them entirely, through `vfo.onFreqChange`'s `'jump'` path
+   * (review B1's original fix, already proven for spectrum click-to-tune /
+   * EiBi / QSY recall), which clears any in-flight burst and emits the exact
+   * target immediately, unpaced.
    */
-  function tuneFrequency(receiver: 'MAIN' | 'SUB', frequencyHz: number): void {
+  function tuneFrequency(
+    receiver: 'MAIN' | 'SUB', frequencyHz: number, kind: 'jump' | 'step' = 'step',
+  ): void {
+    if (kind === 'jump') { vfo.onFreqChange(frequencyHz, receiver === 'MAIN' ? 0 : 1, 'jump'); return; }
     if (receiver === 'SUB') vfo.onSubFreqChange(frequencyHz);
     else vfo.onMainFreqChange(frequencyHz);
   }
@@ -447,13 +464,19 @@
   function selectBand(name: string, defaultHz: number, bsrCode: number | null): void {
     const active = view?.activeReceiver;
     if (active?.status !== 'known') return;
+    // MOR-1425 review round 2 (B1 residual): this bandless fallback is an
+    // ABSOLUTE band default, not a step from the current frequency — 'jump'
+    // so a hot digit-tuning burst on this receiver never absorbs it.
     if (bsrCode !== null) band.onBandSelect(name, defaultHz, bsrCode);
-    else tuneFrequency(active.receiver, defaultHz);
+    else tuneFrequency(active.receiver, defaultHz, 'jump');
   }
   function enterFrequency(frequencyHz: number): void {
     const active = view?.activeReceiver;
     if (active?.status !== 'known') return;
-    tuneFrequency(active.receiver, frequencyHz);
+    // MOR-1425 review round 2 (B1 residual): a typed frequency is the most
+    // explicitly ABSOLUTE gesture in the UI — 'jump', same reasoning as
+    // `selectBand` above.
+    tuneFrequency(active.receiver, frequencyHz, 'jump');
   }
 
   function selectVfo(target: VfoSelection): void {

--- a/frontend/src/components-v2/wiring/__tests__/keyboard-wiring.isolated.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/keyboard-wiring.isolated.test.ts
@@ -5,7 +5,10 @@ vi.mock('$lib/transport/ws-client', () => ({
 }));
 vi.mock('$lib/runtime/commands/radio-intents', async () => {
   const { sendCommand } = await import('$lib/transport/ws-client');
-  return { dispatchRadioIntent: ({ name, params }: { name: string; params: Record<string, unknown> }) => sendCommand(name, params) };
+  return {
+    dispatchRadioIntent: ({ name, params }: { name: string; params: Record<string, unknown> }) => sendCommand(name, params),
+    currentControlSessionEpoch: () => 0,
+  };
 });
 
 vi.mock('$lib/stores/radio.svelte', () => ({

--- a/frontend/src/components-v2/wiring/__tests__/semantic-band-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-band-wiring.component.test.ts
@@ -45,7 +45,10 @@ const h = vi.hoisted(() => ({
 vi.mock('$lib/transport/ws-client', () => ({ sendCommand: vi.fn() }));
 vi.mock('$lib/runtime/commands/radio-intents', async () => {
   const { sendCommand } = await import('$lib/transport/ws-client');
-  return { dispatchRadioIntent: ({ name, params }: { name: string; params: Record<string, unknown> }) => sendCommand(name, params) };
+  return {
+    dispatchRadioIntent: ({ name, params }: { name: string; params: Record<string, unknown> }) => sendCommand(name, params),
+    currentControlSessionEpoch: () => 0,
+  };
 });
 vi.mock('$lib/stores/radio.svelte', () => ({
   getRadioState: vi.fn(() => h.state),

--- a/frontend/src/components-v2/wiring/__tests__/semantic-band-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-band-wiring.component.test.ts
@@ -287,6 +287,79 @@ describe('every band intent lands on the ACTIVE receiver (MOR-1322 B1 class)', (
   });
 });
 
+/*
+ * ── MOR-1425 review round 2 (B1 residual) ──────────────────────────────
+ *
+ * `tuneFrequency` (the shared per-receiver dispatcher behind BOTH the
+ * digit-tuning path and this surface's two absolute sources) used to funnel
+ * everything through the unconditional `step()` accumulate path. A hot
+ * digit-tuning burst on the active receiver (VfoSurface's wheel/arrow
+ * tuning, elsewhere in the composed tree) left a live pending-target window
+ * open; a typed frequency entry or a bandless band pick landing inside that
+ * window was treated as ANOTHER relative step and accumulated onto the
+ * stale pending target instead of landing at the exact value the operator
+ * asked for — reproduced live as "5 wheel ticks then typing 7_100_000 →
+ * emitted 7_105_000" and "3 ticks then a bandless band select → 3 kHz off".
+ * `enterFrequency`/`selectBand`'s bandless fallback now route through
+ * `tuneFrequency(..., 'jump')`, which clears the burst and emits the exact
+ * target immediately, unpaced (`tuning-accumulator.ts`'s `jump()`).
+ *
+ * Fake timers: the accumulator's own pacing (`quietWindowMs`/`paceMs`)
+ * needs a controllable clock so the burst stays provably HOT for the whole
+ * test and a stray late flush can be proven absent, same pattern as
+ * `panel-commands.intent.isolated.test.ts`'s MOR-1425 burst tests.
+ */
+describe('absolute band intents land exactly, unpaced, even mid a hot digit-tuning burst (MOR-1425 review round 2, B1 residual)', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('a typed frequency entry (BandSurface) lands EXACTLY, immediately, with no accumulated offset', () => {
+    render();
+    const vfo = makeVfoHandlers();
+    const confirmed = 14250000; // MAIN's confirmed freq (liveState default; MAIN is active)
+    // Prime a HOT digit-tuning burst on MAIN: the first gesture is a cold
+    // start (emits immediately), the second lands inside the quiet window
+    // and is held, paced — exactly the "wheel toward a signal" shape.
+    vfo.onMainFreqChange(confirmed + 1_000);
+    vfo.onMainFreqChange(confirmed + 1_000);
+    expect(setFreqCalls()).toEqual([['set_freq', { freq: confirmed + 1_000, receiver: 0 }]]);
+
+    typeFrequency('7100000');
+    btn('entry-set')!.click();
+    flushSync();
+
+    // The typed ABSOLUTE target must land EXACTLY and IMMEDIATELY — not
+    // folded into the still-hot burst's accumulated target (the
+    // 7_105_000-style offset), and not held for the burst's own pace timer.
+    expect(setFreqCalls().at(-1)).toEqual(['set_freq', { freq: 7100000, receiver: 0 }]);
+
+    // The jump clears the burst's pending flush — advancing past its pace
+    // window must never emit a stray third call.
+    vi.advanceTimersByTime(60);
+    expect(setFreqCalls()).toHaveLength(2);
+  });
+
+  it('a bandless band select lands EXACTLY, immediately, with no accumulated offset', () => {
+    render();
+    const vfo = makeVfoHandlers();
+    const confirmed = 14250000;
+    vfo.onMainFreqChange(confirmed + 1_000);
+    vfo.onMainFreqChange(confirmed + 1_000);
+    expect(setFreqCalls()).toEqual([['set_freq', { freq: confirmed + 1_000, receiver: 0 }]]);
+
+    // 'MW' carries no BSR code (see BAND_PLAN above) — the bandless
+    // `set_freq` fallback, the same absolute-default gesture reproduced
+    // live as "3 ticks then bandless band select → 3 kHz off".
+    btn('choice-MW')!.click();
+    flushSync();
+
+    expect(setFreqCalls().at(-1)).toEqual(['set_freq', { freq: 1000000, receiver: 0 }]);
+
+    vi.advanceTimersByTime(60);
+    expect(setFreqCalls()).toHaveLength(2);
+  });
+});
+
 /* ── (d) the wiring's own guard, independent of the surface's ───── */
 
 describe('the wiring refuses a receiver-scoped write with no known active receiver', () => {

--- a/frontend/src/components-v2/wiring/__tests__/single-receiver-active-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/single-receiver-active-wiring.component.test.ts
@@ -43,7 +43,10 @@ const h = vi.hoisted(() => ({
 vi.mock('$lib/transport/ws-client', () => ({ sendCommand: vi.fn() }));
 vi.mock('$lib/runtime/commands/radio-intents', async () => {
   const { sendCommand } = await import('$lib/transport/ws-client');
-  return { dispatchRadioIntent: ({ name, params }: { name: string; params: Record<string, unknown> }) => sendCommand(name, params) };
+  return {
+    dispatchRadioIntent: ({ name, params }: { name: string; params: Record<string, unknown> }) => sendCommand(name, params),
+    currentControlSessionEpoch: () => 0,
+  };
 });
 vi.mock('$lib/stores/radio.svelte', () => ({
   getRadioState: vi.fn(() => h.state),

--- a/frontend/src/components/spectrum/SpectrumPanel.svelte
+++ b/frontend/src/components/spectrum/SpectrumPanel.svelte
@@ -330,7 +330,9 @@
     if (current?.frequencyHz === null || current?.frequencyHz === undefined
       || !Number.isSafeInteger(step) || step <= 0) return;
     const frequency = snapFrequency(current.frequencyHz + (event.deltaY > 0 ? -step : step));
-    if (frequency !== null) vfoHandlers.onFreqChange(frequency, current.receiver);
+    // MOR-1425 review B1: a fixed one-step relative gesture (like digit-tuning
+    // wheel ticks), not an absolute target — keep the accumulate path.
+    if (frequency !== null) vfoHandlers.onFreqChange(frequency, current.receiver, 'step');
   }
 
   // --- Drag-to-pan (grab and slide the spectrum window) ---

--- a/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
+++ b/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
@@ -619,7 +619,9 @@ describe('SpectrumPanel component', () => {
     });
     panel.dispatchEvent(wheelEvent);
     expect(handlerHarness.vfo.onFreqChange).toHaveBeenCalledOnce();
-    expect(handlerHarness.vfo.onFreqChange).toHaveBeenCalledWith(14_075_000, 0);
+    // MOR-1425 review B1: scroll-to-tune is a fixed one-step relative
+    // gesture — it opts into the accumulate path explicitly.
+    expect(handlerHarness.vfo.onFreqChange).toHaveBeenCalledWith(14_075_000, 0, 'step');
     expect(mockRuntime.send).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/lib/media/__tests__/media-session.isolated.test.ts
+++ b/frontend/src/lib/media/__tests__/media-session.isolated.test.ts
@@ -218,7 +218,9 @@ describe('media-session cycle-safe radio authority', () => {
       runtimeHarness.runtime.caps,
     );
     expect(vfoHarness.handlers.onFreqChange).toHaveBeenCalledTimes(1);
-    expect(vfoHarness.handlers.onFreqChange).toHaveBeenCalledWith(target, physical);
+    // MOR-1425 review B1: media-key tuning is a fixed step increment, not
+    // an absolute target — it opts into the accumulate path explicitly.
+    expect(vfoHarness.handlers.onFreqChange).toHaveBeenCalledWith(target, physical, 'step');
     expect(legacyAlarm.tuneBy).not.toHaveBeenCalled();
     expect(legacyAlarm.patchActiveReceiver).not.toHaveBeenCalled();
     expect(legacyAlarm.sendCommand).not.toHaveBeenCalled();
@@ -228,7 +230,7 @@ describe('media-session cycle-safe radio authority', () => {
     viewHarness.current = activeView('MAIN', 14_074_000, { kind: 'relative', id: 'selected' });
     mod.initMediaSession();
     fire('nexttrack');
-    expect(vfoHarness.handlers.onFreqChange).toHaveBeenCalledWith(14_075_000, 0);
+    expect(vfoHarness.handlers.onFreqChange).toHaveBeenCalledWith(14_075_000, 0, 'step');
   });
 
   it.each([

--- a/frontend/src/lib/media/media-session.ts
+++ b/frontend/src/lib/media/media-session.ts
@@ -36,7 +36,9 @@ function tuneStep(steps: number): void {
   if (!Number.isSafeInteger(candidate)) return;
   const newFreq = snapToStep(candidate);
   if (!Number.isSafeInteger(newFreq) || newFreq <= 0 || newFreq === current) return;
-  vfoHandlers.onFreqChange(newFreq, receiver === 'SUB' ? 1 : 0);
+  // MOR-1425 review B1: a fixed step-increment gesture — keep the
+  // accumulate path, not the absolute-jump default.
+  vfoHandlers.onFreqChange(newFreq, receiver === 'SUB' ? 1 : 0, 'step');
 }
 
 /** Start a silent audio loop so the browser keeps MediaSession alive. */

--- a/frontend/src/lib/runtime/commands/__tests__/auxiliary-tune-authority.isolated.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/auxiliary-tune-authority.isolated.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const h = vi.hoisted(() => ({
   state: null as Record<string, unknown> | null,
@@ -83,7 +83,18 @@ function state() {
   };
 }
 
+// MOR-1425: `getVfoHandlers()` is a module-level singleton, so its tuning
+// accumulator persists across the `it()` blocks below. Fake timers stay
+// active (and only ever move forward) for the whole file: each `beforeEach`
+// advances the shared clock well past the accumulator's quiet window so a
+// receiver touched by a prior test starts this one cold, exactly as it did
+// before MOR-1425. Re-calling `useFakeTimers()` per test would instead
+// resync "now" to real wall time and cancel out the advance.
+beforeAll(() => vi.useFakeTimers());
+afterAll(() => vi.useRealTimers());
+
 beforeEach(() => {
+  vi.advanceTimersByTime(10_000);
   h.state = state();
   h.caps = {
     stateContractVersion: 1,

--- a/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.isolated.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.isolated.test.ts
@@ -952,6 +952,12 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
     vfo.onVfoSelect('SUB', 'B');
     vfo.onMainFreqChange(14_100_000);
     vfo.onSubFreqChange(7_100_000);
+    // MOR-1425: onMainFreqChange and this onFreqChange(_, 0) call both target
+    // receiver 0 — advance past the tuning accumulator's quiet window so this
+    // is a fresh, independent, immediately-emitted step, not a burst
+    // continuation (the accumulator's own behavior is covered separately in
+    // `tuning-accumulator.test.ts` and the MOR-1425 tests below).
+    vi.advanceTimersByTime(4_500);
     vfo.onFreqChange(18_100_000, 0);
     vfo.onModeChange('CW', 1);
     vfo.onFilterChange(3, 0);
@@ -1036,6 +1042,47 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
     expect(h.sendCommand).not.toHaveBeenCalled();
     expect(h.setAudioConfig).not.toHaveBeenCalled();
     expect(getCommandLifecycles()).toHaveLength(0);
+  });
+
+  it('MOR-1425: a burst of rapid steps within one round trip accumulates onto the pending target, not the stale confirmed value', () => {
+    const vfo = makeVfoHandlers();
+    const confirmed = h.state!.main!.freqHz; // 14_074_000, unchanged for the whole burst
+    const step = 1_000;
+    // Every gesture computes its target off the STILL-CONFIRMED value, the
+    // exact MOR-1425 mechanism (the presentation layer's `freq` prop does
+    // not advance until the round trip completes).
+    for (let i = 1; i <= 5; i++) vfo.onMainFreqChange(confirmed + step);
+
+    // First step is an immediate, unpaced cold start.
+    expect(h.sendCommand).toHaveBeenCalledTimes(1);
+    expect(exactCalls()[0]).toEqual(['set_freq', { freq: confirmed + step, receiver: 0 }]);
+
+    // The remaining 4 steps accumulate and flush once, paced.
+    vi.advanceTimersByTime(60);
+    expect(h.sendCommand).toHaveBeenCalledTimes(2);
+    expect(exactCalls().at(-1)).toEqual(['set_freq', { freq: confirmed + 5 * step, receiver: 0 }]);
+    // MOR-1425 invariant: never an optimistic patch — the display stays
+    // last-confirmed radio truth throughout the whole burst.
+    expect(h.patchActiveReceiver).not.toHaveBeenCalled();
+    expect(h.patchRadioState).not.toHaveBeenCalled();
+    expect(h.patchReceiver).not.toHaveBeenCalled();
+  });
+
+  it('MOR-1425: a contradictory confirmed frequency mid-burst resets accumulation to the new truth', () => {
+    const vfo = makeVfoHandlers();
+    const confirmed = h.state!.main!.freqHz;
+    vfo.onMainFreqChange(confirmed + 1_000); // cold, immediate
+    vfo.onMainFreqChange(confirmed + 1_000); // hot, accumulates, paced
+
+    // The operator turned the physical knob: a new confirmed frequency the
+    // accumulator's own pending sequence did not predict.
+    const physical = confirmed + 500_000;
+    h.state = { ...h.state!, main: { ...h.state!.main!, freqHz: physical } };
+    vfo.onMainFreqChange(physical + 1_000);
+
+    // The reset step is itself a cold start: immediate, carrying a target
+    // measured from the NEW physical truth.
+    expect(exactCalls().at(-1)).toEqual(['set_freq', { freq: physical + 1_000, receiver: 0 }]);
   });
 
   it('shares one fail-closed VOX toggle and routes standalone VOX controls through lifecycle', () => {

--- a/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.isolated.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.isolated.test.ts
@@ -952,12 +952,13 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
     vfo.onVfoSelect('SUB', 'B');
     vfo.onMainFreqChange(14_100_000);
     vfo.onSubFreqChange(7_100_000);
-    // MOR-1425: onMainFreqChange and this onFreqChange(_, 0) call both target
-    // receiver 0 — advance past the tuning accumulator's quiet window so this
-    // is a fresh, independent, immediately-emitted step, not a burst
-    // continuation (the accumulator's own behavior is covered separately in
-    // `tuning-accumulator.test.ts` and the MOR-1425 tests below).
-    vi.advanceTimersByTime(4_500);
+    // MOR-1425 review B1: onMainFreqChange and this onFreqChange(_, 0) call
+    // both target receiver 0, mid-burst (no timer advance) — this
+    // onFreqChange call carries no `kind`, so it defaults to 'jump': an
+    // ABSOLUTE target that must land EXACTLY, immediately, and unpaced,
+    // clearing the still-hot onMainFreqChange burst rather than accumulating
+    // a delta onto it (the accumulator's own behavior is covered separately
+    // in `tuning-accumulator.test.ts` and the MOR-1425 tests below).
     vfo.onFreqChange(18_100_000, 0);
     vfo.onModeChange('CW', 1);
     vfo.onFilterChange(3, 0);
@@ -1069,10 +1070,20 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
   });
 
   it('MOR-1425: a contradictory confirmed frequency mid-burst resets accumulation to the new truth', () => {
+    // Driven through the real wiring (not the low-level accumulator
+    // directly) so this fails if the accumulator is ever un-wired from
+    // `onMainFreqChange` — the previous version of this test asserted only
+    // the LAST emitted value, which a naive direct-dispatch (no burst
+    // logic at all) would also have produced, since every call here
+    // computes its own target off the freq it was given. The call COUNT
+    // below is what actually depends on the accumulator being live: the
+    // 2nd gesture must be paced (held, not sent) until the 3rd gesture's
+    // contradiction both resets AND cancels it.
     const vfo = makeVfoHandlers();
     const confirmed = h.state!.main!.freqHz;
-    vfo.onMainFreqChange(confirmed + 1_000); // cold, immediate
-    vfo.onMainFreqChange(confirmed + 1_000); // hot, accumulates, paced
+    vfo.onMainFreqChange(confirmed + 1_000); // cold, immediate: target C+1_000
+    vfo.onMainFreqChange(confirmed + 1_000); // hot, accumulates to C+2_000, paced (NOT sent yet)
+    expect(h.sendCommand).toHaveBeenCalledTimes(1);
 
     // The operator turned the physical knob: a new confirmed frequency the
     // accumulator's own pending sequence did not predict.
@@ -1081,8 +1092,30 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
     vfo.onMainFreqChange(physical + 1_000);
 
     // The reset step is itself a cold start: immediate, carrying a target
-    // measured from the NEW physical truth.
+    // measured from the NEW physical truth — and it must be the ONLY
+    // second call: without the accumulator, the 2nd gesture above would
+    // already have been sent immediately, making this the THIRD call.
+    expect(h.sendCommand).toHaveBeenCalledTimes(2);
     expect(exactCalls().at(-1)).toEqual(['set_freq', { freq: physical + 1_000, receiver: 0 }]);
+
+    // The pre-reset paced flush must never fire and emit a stray 3rd call.
+    vi.advanceTimersByTime(60);
+    expect(h.sendCommand).toHaveBeenCalledTimes(2);
+  });
+
+  it("MOR-1425 review B1: onFreqChange(freq, receiver, 'step') opts a relative gesture into the accumulate path instead of the 'jump' default", () => {
+    const vfo = makeVfoHandlers();
+    const confirmed = h.state!.main!.freqHz;
+    // Two 'step' gestures at the SAME receiver, mid-burst: the media-key /
+    // spectrum-wheel shape (fixed increment off confirmed truth), not an
+    // arbitrary absolute target.
+    vfo.onFreqChange(confirmed + 1_000, 0, 'step'); // cold, immediate
+    vfo.onFreqChange(confirmed + 1_000, 0, 'step'); // hot, accumulates, paced
+    expect(h.sendCommand).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(60);
+    expect(h.sendCommand).toHaveBeenCalledTimes(2);
+    expect(exactCalls().at(-1)).toEqual(['set_freq', { freq: confirmed + 2_000, receiver: 0 }]);
   });
 
   it('shares one fail-closed VOX toggle and routes standalone VOX controls through lifecycle', () => {
@@ -1438,8 +1471,14 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
     expect(getCommandLifecycles()).toHaveLength(0);
 
     const nullPrototype = Object.assign(Object.create(null) as Record<string, unknown>, { direction: 'up' });
+    // MOR-1425 review B5: 'tune' now shares ONE accumulator across calls
+    // (fixed from the pre-review bug where each call got independent
+    // state) — advance past the quiet window between calls so these three
+    // are independent cold starts, not one accumulating burst.
     expect(dispatchKeyboardRadioAction({ action: 'tune', params: { direction: 'up' } })).toBe(true);
+    vi.advanceTimersByTime(4_500);
     expect(dispatchKeyboardRadioAction({ action: 'tune', params: nullPrototype })).toBe(true);
+    vi.advanceTimersByTime(4_500);
     expect(dispatchKeyboardRadioAction({ action: 'tune', params: dataProxy })).toBe(true);
     expect(dataGet).not.toHaveBeenCalled();
     expect(exactCalls()).toEqual([

--- a/frontend/src/lib/runtime/commands/__tests__/tuning-accumulator.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/tuning-accumulator.test.ts
@@ -1,0 +1,118 @@
+/**
+ * MOR-1425 — unit tests for the rapid tuning-step accumulator in isolation
+ * from the store/transport wiring (see `panel-commands.intent.isolated.test.ts`
+ * for the end-to-end wiring coverage through `makeVfoHandlers()`).
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTuningAccumulator, type TuningAccumulator } from '../tuning-accumulator';
+
+describe('MOR-1425 tuning accumulator', () => {
+  let emit: ReturnType<typeof vi.fn<(receiver: number, freq: number) => { status: string }>>;
+  let acc: TuningAccumulator;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    emit = vi.fn((_receiver: number, _freq: number) => ({ status: 'pending' }));
+    acc = createTuningAccumulator({ emit, paceMs: 60, quietWindowMs: 4_000 });
+  });
+
+  it('(f) emits an isolated single step immediately, unpaced', () => {
+    acc.step(0, 14_074_000, 14_075_000);
+    expect(emit).toHaveBeenCalledExactlyOnceWith(0, 14_075_000);
+  });
+
+  it('(a) N rapid steps within one round trip accumulate onto the pending target, and the last frame carries confirmed + N*step', () => {
+    const confirmed = 14_074_000;
+    const step = 1_000;
+    const N = 20;
+    for (let i = 1; i <= N; i++) {
+      // Each gesture computes target = displayed (still-stale confirmed) +
+      // step — exactly the operator-captured mechanism from MOR-1425.
+      acc.step(0, confirmed, confirmed + step);
+    }
+    // First (cold) step emitted immediately; the rest are paced.
+    expect(emit).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(60);
+    const lastCall = emit.mock.calls.at(-1)!;
+    expect(lastCall).toEqual([0, confirmed + N * step]);
+  });
+
+  it('(b) paced emissions during a sustained burst are at least ~60ms apart', () => {
+    const confirmed = 14_074_000;
+    acc.step(0, confirmed, confirmed + 1_000); // cold, immediate
+    expect(emit).toHaveBeenCalledTimes(1);
+
+    acc.step(0, confirmed, confirmed + 2_000); // hot, schedules a flush
+    expect(emit).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(59);
+    expect(emit).toHaveBeenCalledTimes(1); // not yet — under the pace window
+    vi.advanceTimersByTime(1);
+    expect(emit).toHaveBeenCalledTimes(2); // paced flush fires at >=60ms
+
+    acc.step(0, confirmed, confirmed + 3_000); // hot again, schedules another
+    vi.advanceTimersByTime(59);
+    expect(emit).toHaveBeenCalledTimes(2);
+    vi.advanceTimersByTime(1);
+    expect(emit).toHaveBeenCalledTimes(3);
+  });
+
+  it('(c) a contradictory confirmed observation resets accumulation — the next step bases on the new truth', () => {
+    const confirmed = 14_074_000;
+    acc.step(0, confirmed, confirmed + 1_000); // cold, immediate: target 14_075_000
+    acc.step(0, confirmed, confirmed + 2_000); // hot: target 14_076_000, paced
+
+    // The operator turned the physical knob: a confirmed freq that matches
+    // neither our frozen baseline (14_074_000) nor our pending target
+    // (14_076_000).
+    const physical = 14_200_000;
+    acc.step(0, physical, physical + 1_000);
+
+    // The reset step is itself a cold start: immediate, unpaced, and its
+    // delta is measured from the NEW physical truth, not the old baseline.
+    expect(emit).toHaveBeenLastCalledWith(0, physical + 1_000);
+  });
+
+  it('(c) a confirmed observation that matches our own predicted target is NOT a contradiction', () => {
+    const confirmed = 14_074_000;
+    acc.step(0, confirmed, confirmed + 1_000); // cold, immediate: target 14_075_000
+    // Our own first write lands mid-burst — confirmed truth now equals what
+    // we predicted. This must rebase, not reset: the next step's delta is
+    // measured from the new (matching) baseline and continues accumulating.
+    acc.step(0, confirmed + 1_000, confirmed + 1_000 + 1_000);
+    vi.advanceTimersByTime(60);
+    expect(emit).toHaveBeenLastCalledWith(0, confirmed + 2_000);
+  });
+
+  it('(d) the accumulator expires after the quiet window and the next step is a fresh cold start', () => {
+    const confirmed = 14_074_000;
+    acc.step(0, confirmed, confirmed + 1_000);
+    expect(emit).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(4_001); // past quietWindowMs with no further activity
+
+    acc.step(0, confirmed, confirmed + 1_000);
+    // A fresh cold start emits immediately again — no pacing delay, and
+    // the target is not double-accumulated from the expired burst.
+    expect(emit).toHaveBeenCalledTimes(2);
+    expect(emit).toHaveBeenLastCalledWith(0, confirmed + 1_000);
+  });
+
+  it('expires immediately on a terminal command-lifecycle status (NAK/error)', () => {
+    emit.mockReturnValueOnce({ status: 'failed' });
+    const confirmed = 14_074_000;
+    acc.step(0, confirmed, confirmed + 1_000); // cold, immediate — fails
+
+    acc.step(0, confirmed, confirmed + 2_000);
+    // Treated as a fresh cold start (the prior burst is dead), not an
+    // accumulation onto a target that will never be retried.
+    expect(emit).toHaveBeenCalledTimes(2);
+    expect(emit).toHaveBeenLastCalledWith(0, confirmed + 2_000);
+  });
+
+  it('tracks receivers independently', () => {
+    acc.step(0, 14_074_000, 14_075_000);
+    acc.step(1, 7_100_000, 7_101_000);
+    expect(emit).toHaveBeenNthCalledWith(1, 0, 14_075_000);
+    expect(emit).toHaveBeenNthCalledWith(2, 1, 7_101_000);
+  });
+});

--- a/frontend/src/lib/runtime/commands/__tests__/tuning-accumulator.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/tuning-accumulator.test.ts
@@ -3,8 +3,13 @@
  * from the store/transport wiring (see `panel-commands.intent.isolated.test.ts`
  * for the end-to-end wiring coverage through `makeVfoHandlers()`).
  */
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { createTuningAccumulator, type TuningAccumulator } from '../tuning-accumulator';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createTuningAccumulator,
+  getSharedTuningAccumulator,
+  resetSharedTuningAccumulatorForTests,
+  type TuningAccumulator,
+} from '../tuning-accumulator';
 
 describe('MOR-1425 tuning accumulator', () => {
   let emit: ReturnType<typeof vi.fn<(receiver: number, freq: number) => { status: string }>>;
@@ -97,14 +102,27 @@ describe('MOR-1425 tuning accumulator', () => {
     expect(emit).toHaveBeenLastCalledWith(0, confirmed + 1_000);
   });
 
-  it('expires immediately on a terminal command-lifecycle status (NAK/error)', () => {
-    emit.mockReturnValueOnce({ status: 'failed' });
+  it('(e) expires when the retained lifecycle OBJECT mutates to a terminal status after emit — the real dispatchRadioIntent shape (review B3)', () => {
+    // `dispatchRadioIntent` returns a `CommandLifecycle` object that starts
+    // 'pending' and is MUTATED IN PLACE later, once the transport resolves
+    // it — never replaced with a fresh object carrying the final status.
+    // A mock that returns `{status:'failed'}` straight away (the pre-fix
+    // test) exercises a shape production never produces.
+    const lifecycle = { status: 'pending' };
+    emit.mockReturnValueOnce(lifecycle);
     const confirmed = 14_074_000;
-    acc.step(0, confirmed, confirmed + 1_000); // cold, immediate — fails
+    acc.step(0, confirmed, confirmed + 1_000); // cold, immediate — still pending
+
+    // The async failure arrives later by mutating the SAME retained object,
+    // exactly like `failCommand`/`acknowledgeCommand` do in production.
+    lifecycle.status = 'failed';
 
     acc.step(0, confirmed, confirmed + 2_000);
     // Treated as a fresh cold start (the prior burst is dead), not an
-    // accumulation onto a target that will never be retried.
+    // accumulation onto a target that will never be retried. If the
+    // accumulator had snapshotted `.status` at emit time instead of
+    // retaining the object, this step would see the STALE 'pending' value
+    // and wrongly accumulate (paced, not immediate) instead.
     expect(emit).toHaveBeenCalledTimes(2);
     expect(emit).toHaveBeenLastCalledWith(0, confirmed + 2_000);
   });
@@ -114,5 +132,118 @@ describe('MOR-1425 tuning accumulator', () => {
     acc.step(1, 7_100_000, 7_101_000);
     expect(emit).toHaveBeenNthCalledWith(1, 0, 14_075_000);
     expect(emit).toHaveBeenNthCalledWith(2, 1, 7_101_000);
+  });
+
+  it('(g) jump(receiver, freq) clears accumulator state and emits the exact frequency immediately, unpaced — even mid-burst (review B1)', () => {
+    const confirmed = 14_074_000;
+    acc.step(0, confirmed, confirmed + 1_000); // cold, immediate
+    acc.step(0, confirmed, confirmed + 1_000); // hot, accumulates, paced flush pending
+    expect(emit).toHaveBeenCalledTimes(1);
+
+    acc.jump(0, 18_100_000); // absolute target — must land EXACTLY, not accumulate
+    expect(emit).toHaveBeenCalledTimes(2);
+    expect(emit).toHaveBeenLastCalledWith(0, 18_100_000);
+
+    // The pending paced flush from the pre-jump burst must not fire
+    // afterward and corrupt the jump target.
+    vi.advanceTimersByTime(60);
+    expect(emit).toHaveBeenCalledTimes(2);
+
+    // The next step is a fresh cold start off the jumped-to frequency, not
+    // a continuation of the pre-jump burst.
+    acc.step(0, 18_100_000, 18_101_000);
+    expect(emit).toHaveBeenCalledTimes(3);
+    expect(emit).toHaveBeenLastCalledWith(0, 18_101_000);
+  });
+
+  it('(h) an intermediate own-write echo mid-burst rebases without reset — accumulation survives and emitted targets never go backward (review B2)', () => {
+    const confirmed = 14_074_000;
+    const step = 1_000;
+
+    acc.step(0, confirmed, confirmed + step); // cold, immediate: target C+1_000
+    acc.step(0, confirmed, confirmed + step); // hot: target C+2_000, paced
+    acc.step(0, confirmed, confirmed + step); // hot: target C+3_000, same paced flush
+    vi.advanceTimersByTime(60); // flush carries the latest target: C+3_000
+
+    acc.step(0, confirmed, confirmed + step); // hot, still no echo yet: target C+4_000, paced
+    vi.advanceTimersByTime(60); // flush: C+4_000 already sent to the radio
+
+    // The echo of the VERY FIRST write (C+1_000 — long superseded by the
+    // C+4_000 already in flight) finally lands: an INTERMEDIATE target, not
+    // the frozen baseline (C) and not the current pending target either —
+    // exactly the failure mode from the live capture (review B2).
+    acc.step(0, confirmed + step, confirmed + 2 * step);
+    vi.advanceTimersByTime(60);
+
+    const targets = emit.mock.calls.map(([, freq]) => freq);
+    expect(targets).toEqual([
+      confirmed + step,
+      confirmed + 3 * step,
+      confirmed + 4 * step,
+      confirmed + 5 * step,
+    ]);
+    for (let i = 1; i < targets.length; i++) {
+      expect(targets[i]).toBeGreaterThanOrEqual(targets[i - 1]);
+    }
+  });
+
+  it('(i) resets accumulation when the control-session epoch changes mid-burst (review B4)', () => {
+    let epoch = 1;
+    const local = createTuningAccumulator({ emit, paceMs: 60, quietWindowMs: 4_000, epoch: () => epoch });
+    const confirmed = 14_074_000;
+    local.step(0, confirmed, confirmed + 1_000); // cold, immediate
+    local.step(0, confirmed, confirmed + 1_000); // hot, paced
+
+    epoch = 2; // reconnect — a NEW control session
+    local.step(0, confirmed, confirmed + 1_000);
+
+    // Treated as a fresh cold start under the new epoch, not a continuation
+    // of the pre-reconnect accumulation.
+    expect(emit).toHaveBeenCalledTimes(2);
+    expect(emit).toHaveBeenLastCalledWith(0, confirmed + 1_000);
+  });
+
+  it('(j) resets accumulation when the capabilities generation changes mid-burst (review B4)', () => {
+    let generation: number | null = 7;
+    const local = createTuningAccumulator({ emit, paceMs: 60, quietWindowMs: 4_000, generation: () => generation });
+    const confirmed = 14_074_000;
+    local.step(0, confirmed, confirmed + 1_000); // cold, immediate
+    local.step(0, confirmed, confirmed + 1_000); // hot, paced
+
+    generation = 8; // radio switch / re-negotiated capabilities
+    local.step(0, confirmed, confirmed + 1_000);
+
+    expect(emit).toHaveBeenCalledTimes(2);
+    expect(emit).toHaveBeenLastCalledWith(0, confirmed + 1_000);
+  });
+});
+
+describe('MOR-1425 getSharedTuningAccumulator (review B5)', () => {
+  afterEach(() => resetSharedTuningAccumulatorForTests());
+
+  it('returns the SAME instance across repeated calls, independent of caller options — the fix for two live accumulators per receiver', () => {
+    vi.useFakeTimers();
+    const sharedEmit = vi.fn((_r: number, _f: number) => ({ status: 'pending' }));
+    const first = getSharedTuningAccumulator({ emit: sharedEmit, paceMs: 60, quietWindowMs: 4_000 });
+    // A second "composition root" constructs its OWN options object (its
+    // own emit spy) — this must not create a second, independently-tracked
+    // accumulator for the same receiver.
+    const second = getSharedTuningAccumulator({ emit: vi.fn(), paceMs: 60, quietWindowMs: 4_000 });
+    expect(second).toBe(first);
+
+    const confirmed = 14_074_000;
+    const step = 1_000;
+    first.step(0, confirmed, confirmed + step); // cold, immediate
+    expect(sharedEmit).toHaveBeenCalledTimes(1);
+
+    // If `second` tracked independent state, this would ALSO be a cold,
+    // immediate start (on `second`'s own emit spy). Because it shares
+    // `first`'s pending burst instead, it accumulates and paces.
+    second.step(0, confirmed, confirmed + step);
+    expect(sharedEmit).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(60);
+    expect(sharedEmit).toHaveBeenCalledTimes(2);
+    expect(sharedEmit).toHaveBeenLastCalledWith(0, confirmed + 2 * step);
+    vi.useRealTimers();
   });
 });

--- a/frontend/src/lib/runtime/commands/panel-commands.ts
+++ b/frontend/src/lib/runtime/commands/panel-commands.ts
@@ -32,6 +32,7 @@ import { nbDepthDisplayToRaw, nrDisplayToRaw } from '$lib/radio/filter-controls'
 import { audioManager } from '$lib/audio/audio-manager';
 import { adjustTuningStep, getTuningStep } from '$lib/stores/tuning.svelte';
 import { dispatchRadioIntent, isNormalizedLevel } from './radio-intents';
+import { createTuningAccumulator } from './tuning-accumulator';
 
 /* ── Shared helpers ──────────────────────────────────────────────── */
 
@@ -1047,6 +1048,25 @@ function supportsVfoSlot(
 }
 
 export function makeVfoHandlers() {
+  // MOR-1425: per-instance rapid-tuning-step accumulator — same precedent as
+  // the per-instance debounce state in `makeFilterHandlers()` above. Digit
+  // tuning's displayed-value-plus-step target collapses under a burst faster
+  // than the confirm round trip; this absorbs steps onto the pending target
+  // instead of dispatching the same stale target repeatedly. Constructed
+  // lazily (not here at factory-call time): `panel-adapters.ts` calls this
+  // factory at MODULE TOP LEVEL for its singleton accessor, and eager work
+  // here runs during initial module-graph evaluation, where this file's own
+  // import cycle with `system-controller`/`media-session` leaves freshly
+  // added imports TDZ-guarded. Every other handler below already defers all
+  // work (including its imports) to call time for the same reason.
+  let tuning: ReturnType<typeof createTuningAccumulator> | null = null;
+  function tuningAccumulator(): ReturnType<typeof createTuningAccumulator> {
+    return tuning ??= createTuningAccumulator({
+      emit: (receiver, freq) =>
+        dispatchRadioIntent({ name: 'set_freq', params: { freq, receiver: receiver as Receiver } }),
+    });
+  }
+
   return {
     onSwap: () => {
       const context = currentA03cContext();
@@ -1086,22 +1106,27 @@ export function makeVfoHandlers() {
     onSubModeClick: () => focusModePanel('SUB'),
     onMainFreqChange: (freq: number) => {
       const context = currentA03cContext();
+      const main = context?.state.main;
       if (!context || knownA03cReceiver(context, 'MAIN', 'freqHz') !== 0
-        || !Number.isSafeInteger(freq)) return;
-      dispatchRadioIntent({ name: 'set_freq', params: { freq, receiver: 0 } });
+        || !Number.isSafeInteger(freq) || !main) return;
+      tuningAccumulator().step(0, main.freqHz, freq);
     },
     onSubFreqChange: (freq: number) => {
       const context = currentA03cContext();
+      const sub = context?.state.sub;
       if (!context || knownA03cReceiver(context, 'SUB', 'freqHz') !== 1
-        || !Number.isSafeInteger(freq)) return;
-      dispatchRadioIntent({ name: 'set_freq', params: { freq, receiver: 1 } });
+        || !Number.isSafeInteger(freq) || !sub) return;
+      tuningAccumulator().step(1, sub.freqHz, freq);
     },
     onFreqChange: (freq: number, receiver?: Receiver) => {
       const context = currentA03cContext();
       const target = receiver === 0 ? 'MAIN' : receiver === 1 ? 'SUB' : null;
-      if (!context || target === null || knownA03cReceiver(context, target, 'freqHz') !== receiver
+      if (!context || target === null || receiver === undefined
+        || knownA03cReceiver(context, target, 'freqHz') !== receiver
         || !Number.isSafeInteger(freq)) return;
-      dispatchRadioIntent({ name: 'set_freq', params: { freq, receiver } });
+      const confirmed = receiver === 1 ? context.state.sub : context.state.main;
+      if (!confirmed) return;
+      tuningAccumulator().step(receiver, confirmed.freqHz, freq);
     },
     onModeChange: (mode: string, receiver?: Receiver) => {
       const context = currentA03cContext();

--- a/frontend/src/lib/runtime/commands/panel-commands.ts
+++ b/frontend/src/lib/runtime/commands/panel-commands.ts
@@ -31,8 +31,8 @@ import { modInputCommand, modInputStateKey } from '$lib/radio/mod-input';
 import { nbDepthDisplayToRaw, nrDisplayToRaw } from '$lib/radio/filter-controls';
 import { audioManager } from '$lib/audio/audio-manager';
 import { adjustTuningStep, getTuningStep } from '$lib/stores/tuning.svelte';
-import { dispatchRadioIntent, isNormalizedLevel } from './radio-intents';
-import { createTuningAccumulator } from './tuning-accumulator';
+import { currentControlSessionEpoch, dispatchRadioIntent, isNormalizedLevel } from './radio-intents';
+import { getSharedTuningAccumulator } from './tuning-accumulator';
 
 /* ── Shared helpers ──────────────────────────────────────────────── */
 
@@ -1048,22 +1048,21 @@ function supportsVfoSlot(
 }
 
 export function makeVfoHandlers() {
-  // MOR-1425: per-instance rapid-tuning-step accumulator — same precedent as
-  // the per-instance debounce state in `makeFilterHandlers()` above. Digit
-  // tuning's displayed-value-plus-step target collapses under a burst faster
-  // than the confirm round trip; this absorbs steps onto the pending target
-  // instead of dispatching the same stale target repeatedly. Constructed
-  // lazily (not here at factory-call time): `panel-adapters.ts` calls this
-  // factory at MODULE TOP LEVEL for its singleton accessor, and eager work
-  // here runs during initial module-graph evaluation, where this file's own
-  // import cycle with `system-controller`/`media-session` leaves freshly
-  // added imports TDZ-guarded. Every other handler below already defers all
-  // work (including its imports) to call time for the same reason.
-  let tuning: ReturnType<typeof createTuningAccumulator> | null = null;
-  function tuningAccumulator(): ReturnType<typeof createTuningAccumulator> {
-    return tuning ??= createTuningAccumulator({
+  // MOR-1425: rapid-tuning-step accumulator, shared module-wide (review
+  // B5) — NOT per-instance: `panel-adapters.ts` holds both a singleton
+  // accessor and fresh per-composition-root calls, and two independently-
+  // tracked accumulators for the same receiver would be blind to each
+  // other's writes. `epoch`/`generation` are the same session/capabilities
+  // reads `dispatchRadioIntent` itself uses (review B4).
+  function tuningAccumulator(): ReturnType<typeof getSharedTuningAccumulator> {
+    return getSharedTuningAccumulator({
       emit: (receiver, freq) =>
         dispatchRadioIntent({ name: 'set_freq', params: { freq, receiver: receiver as Receiver } }),
+      epoch: currentControlSessionEpoch,
+      generation: () => {
+        const value = getCapabilities()?.providerGeneration;
+        return typeof value === 'number' ? value : null;
+      },
     });
   }
 
@@ -1118,12 +1117,17 @@ export function makeVfoHandlers() {
         || !Number.isSafeInteger(freq) || !sub) return;
       tuningAccumulator().step(1, sub.freqHz, freq);
     },
-    onFreqChange: (freq: number, receiver?: Receiver) => {
+    // MOR-1425 review B1: callers mix ABSOLUTE targets (spectrum click/
+    // drag, EiBi/QSY recall) and RELATIVE steps (spectrum scroll, media
+    // keys, keyboard 'tune'). Defaults to 'jump' — absolute correctness by
+    // default — so only true step sources opt in with 'step'.
+    onFreqChange: (freq: number, receiver?: Receiver, kind: 'jump' | 'step' = 'jump') => {
       const context = currentA03cContext();
       const target = receiver === 0 ? 'MAIN' : receiver === 1 ? 'SUB' : null;
       if (!context || target === null || receiver === undefined
         || knownA03cReceiver(context, target, 'freqHz') !== receiver
         || !Number.isSafeInteger(freq)) return;
+      if (kind === 'jump') { tuningAccumulator().jump(receiver, freq); return; }
       const confirmed = receiver === 1 ? context.state.sub : context.state.main;
       if (!confirmed) return;
       tuningAccumulator().step(receiver, confirmed.freqHz, freq);
@@ -1390,7 +1394,7 @@ export function dispatchKeyboardRadioAction({ action, params }: KeyboardRadioAct
       const target = typeof delta === 'number' && Number.isSafeInteger(frequency) ? frequency + delta : null;
       if (keyboardReceiverField(context, 'freqHz') && Number.isSafeInteger(step) && step > 0
         && typeof frequency === 'number' && Number.isSafeInteger(frequency) && frequency > 0
-        && typeof target === 'number' && Number.isSafeInteger(target) && target > 0) makeVfoHandlers().onFreqChange(target, receiver);
+        && typeof target === 'number' && Number.isSafeInteger(target) && target > 0) makeVfoHandlers().onFreqChange(target, receiver, 'step');
       return true;
     }
     case 'band_select': {

--- a/frontend/src/lib/runtime/commands/radio-intents.ts
+++ b/frontend/src/lib/runtime/commands/radio-intents.ts
@@ -103,6 +103,13 @@ onControlSessionTransition((transition) => {
   if (transition.state === 'disconnected') cancelPendingCommands(transition.epoch);
 });
 
+/** The control-session epoch `dispatchRadioIntent` itself reads (MOR-1425
+ *  review B4) — exposed so callers outside this module (which must not
+ *  import transport directly) can detect a reconnect mid-burst. */
+export function currentControlSessionEpoch(): number {
+  return getControlSession().epoch;
+}
+
 export function dispatchRadioIntent(intent: RadioIntent): CommandLifecycle {
   if (typeof intent !== 'object' || intent === null || Array.isArray(intent)) throw new TypeError('Invalid radio intent envelope');
   const candidate = intent as unknown as Record<PropertyKey, unknown>;

--- a/frontend/src/lib/runtime/commands/tuning-accumulator.ts
+++ b/frontend/src/lib/runtime/commands/tuning-accumulator.ts
@@ -1,0 +1,156 @@
+/**
+ * MOR-1425 — rapid tuning-step accumulator.
+ *
+ * Digit-tuning gestures (wheel ticks, arrow presses) compute their target as
+ * `displayed value + step` in the presentation layer (see
+ * `primitives/frequency/FrequencyDisplayInteractive.svelte`), but the
+ * displayed value is last-confirmed radio truth and only advances after a
+ * full `set_freq` round trip (~0.5-2s measured on live hardware, operator
+ * evidence on MOR-1425). A burst of gestures inside one round trip all
+ * compute the SAME target relative to the same stale display, so N steps
+ * net one write — the collapse this module fixes.
+ *
+ * This holds an ephemeral PENDING TARGET per receiver: while a burst is
+ * "hot" (within `quietWindowMs` of the last step), each new gesture's delta
+ * from the FROZEN baseline (confirmed truth at the start of the burst)
+ * accumulates onto the pending target instead of being computed against —
+ * and discarded relative to — the same stale baseline every time. Emission
+ * is paced just above the server's 50ms same-command coalescing window
+ * (MOR-1427, `control.py` `_CMD_MIN_INTERVAL`) so a burst collapses to a
+ * few paced `set_freq` frames carrying the latest accumulated target, not
+ * one per gesture.
+ *
+ * Invariants (design-bearing, see MOR-1425):
+ *  - the DISPLAY stays last-confirmed truth; this module never patches a
+ *    store and has no store dependency — it only calls the injected `emit`.
+ *  - a confirmed observation that matches neither the frozen baseline nor
+ *    our own accumulated target is a contradiction (the operator moved the
+ *    physical dial) and resets accumulation immediately; the next step
+ *    rebuilds its baseline from that new truth.
+ *  - a confirmed observation that DOES match our own accumulated target is
+ *    our own write landing mid-burst — not a contradiction — and simply
+ *    rebases the frozen baseline so further deltas stay correct once the
+ *    presentation layer re-renders against it.
+ *  - the accumulator quietly expires `quietWindowMs` after the last step
+ *    (default ~2x the observed confirm round trip) or immediately on a
+ *    terminal (failed/cancelled/timed-out) command lifecycle.
+ *  - the very first step of a cold window emits immediately, unpaced —
+ *    single-step tuning behaves exactly as it did before this module.
+ */
+
+const DEFAULT_PACE_MS = 60; // just above the server's 50ms coalescing window
+const DEFAULT_QUIET_WINDOW_MS = 4_000; // ~2x the observed confirm round trip
+
+const TERMINAL_STATUSES = new Set(['failed', 'cancelled', 'timed-out']);
+
+interface PendingTuning {
+  /** Confirmed radio truth this burst's deltas are measured against. */
+  baseline: number;
+  /** Latest accumulated target — the honest prediction of where we're heading. */
+  target: number;
+  /** Wall-clock deadline; no further activity past this and the burst expires. */
+  quietUntil: number;
+  /** Non-null while a paced flush is scheduled. */
+  flushTimer: ReturnType<typeof setTimeout> | null;
+  /** Wall-clock time the last frame was actually emitted, for pacing. */
+  lastEmitAt: number;
+  /** Status of the last emitted command's lifecycle, if known. */
+  lastStatus: string | null;
+}
+
+export interface TuningAccumulatorOptions {
+  /** Sends one `set_freq` for `receiver` at `freq`; returns its lifecycle
+   *  status when known, so a NAK/failure can expire the burst early. */
+  emit: (receiver: number, freq: number) => { status: string } | void;
+  now?: () => number;
+  paceMs?: number;
+  quietWindowMs?: number;
+}
+
+export interface TuningAccumulator {
+  /**
+   * Feed one gesture. `confirmedFreq` is the CURRENT confirmed radio truth
+   * for `receiver`; `requestedFreq` is the ABSOLUTE target the presentation
+   * layer computed off its own (possibly stale) displayed value.
+   */
+  step(receiver: number, confirmedFreq: number, requestedFreq: number): void;
+}
+
+export function createTuningAccumulator(options: TuningAccumulatorOptions): TuningAccumulator {
+  const {
+    emit,
+    // A plain `now = Date.now` default would capture a reference to
+    // whatever `Date.now` IS AT CONSTRUCTION TIME. `makeVfoHandlers()` is
+    // called once at module import for the singleton accessor
+    // (`getVfoHandlers()` in `panel-adapters.ts`) — well before any test's
+    // `vi.useFakeTimers()` swaps the global — so a captured reference would
+    // silently keep reading real wall-clock time forever. Looking up
+    // `Date.now` fresh on every call instead tracks whatever is currently
+    // installed as the global, faked or not.
+    now = () => Date.now(),
+    paceMs = DEFAULT_PACE_MS,
+    quietWindowMs = DEFAULT_QUIET_WINDOW_MS,
+  } = options;
+  const pending = new Map<number, PendingTuning>();
+
+  function clear(receiver: number): void {
+    const state = pending.get(receiver);
+    if (state?.flushTimer) clearTimeout(state.flushTimer);
+    pending.delete(receiver);
+  }
+
+  function flush(receiver: number): void {
+    const state = pending.get(receiver);
+    if (!state) return;
+    state.flushTimer = null;
+    state.lastEmitAt = now();
+    state.lastStatus = emit(receiver, state.target)?.status ?? null;
+  }
+
+  function scheduleFlush(receiver: number): void {
+    const state = pending.get(receiver);
+    if (!state || state.flushTimer !== null) return;
+    const wait = Math.max(0, paceMs - (now() - state.lastEmitAt));
+    state.flushTimer = setTimeout(() => flush(receiver), wait);
+  }
+
+  return {
+    step(receiver, confirmedFreq, requestedFreq) {
+      const t = now();
+      const state = pending.get(receiver);
+      let hot = state !== undefined
+        && t < state.quietUntil
+        && !TERMINAL_STATUSES.has(state.lastStatus ?? '');
+
+      if (hot && confirmedFreq !== state!.baseline) {
+        if (confirmedFreq === state!.target) {
+          // Our own accumulated write landed mid-burst: rebase and continue.
+          state!.baseline = confirmedFreq;
+        } else {
+          // Matches neither the frozen baseline nor our own predicted
+          // target: a physical observation we did not cause (invariant 3).
+          hot = false;
+        }
+      }
+
+      if (!hot) {
+        clear(receiver);
+        const fresh: PendingTuning = {
+          baseline: confirmedFreq,
+          target: requestedFreq,
+          quietUntil: t + quietWindowMs,
+          flushTimer: null,
+          lastEmitAt: t,
+          lastStatus: null,
+        };
+        pending.set(receiver, fresh);
+        fresh.lastStatus = emit(receiver, requestedFreq)?.status ?? null;
+        return;
+      }
+
+      state!.target += requestedFreq - state!.baseline;
+      state!.quietUntil = t + quietWindowMs;
+      scheduleFlush(receiver);
+    },
+  };
+}

--- a/frontend/src/lib/runtime/commands/tuning-accumulator.ts
+++ b/frontend/src/lib/runtime/commands/tuning-accumulator.ts
@@ -2,46 +2,52 @@
  * MOR-1425 — rapid tuning-step accumulator.
  *
  * Digit-tuning gestures (wheel ticks, arrow presses) compute their target as
- * `displayed value + step` in the presentation layer (see
- * `primitives/frequency/FrequencyDisplayInteractive.svelte`), but the
- * displayed value is last-confirmed radio truth and only advances after a
- * full `set_freq` round trip (~0.5-2s measured on live hardware, operator
- * evidence on MOR-1425). A burst of gestures inside one round trip all
- * compute the SAME target relative to the same stale display, so N steps
- * net one write — the collapse this module fixes.
+ * `displayed value + step`, but the displayed value is last-confirmed radio
+ * truth and only advances after a full `set_freq` round trip (~0.5-2s on
+ * live hardware). A burst inside one round trip all computes the SAME
+ * target off the same stale display, so N steps net one write — the
+ * collapse this module fixes by holding an ephemeral PENDING TARGET per
+ * receiver: while a burst is "hot" (within `quietWindowMs` of the last
+ * step), each gesture's delta from the FROZEN baseline accumulates onto the
+ * target instead. Emission is paced just above the server's 50ms
+ * same-command coalescing window (MOR-1427).
  *
- * This holds an ephemeral PENDING TARGET per receiver: while a burst is
- * "hot" (within `quietWindowMs` of the last step), each new gesture's delta
- * from the FROZEN baseline (confirmed truth at the start of the burst)
- * accumulates onto the pending target instead of being computed against —
- * and discarded relative to — the same stale baseline every time. Emission
- * is paced just above the server's 50ms same-command coalescing window
- * (MOR-1427, `control.py` `_CMD_MIN_INTERVAL`) so a burst collapses to a
- * few paced `set_freq` frames carrying the latest accumulated target, not
- * one per gesture.
+ * `step()` is for RELATIVE gestures only (wheel/arrow, one fixed increment
+ * per call). ABSOLUTE targets (click-to-tune, station/QSY recall) go
+ * through `jump()` instead (review B1): a burst delta computed against an
+ * absolute target is meaningless, so `jump()` clears any in-flight burst
+ * for the receiver and emits the exact frequency immediately, unpaced.
  *
- * Invariants (design-bearing, see MOR-1425):
- *  - the DISPLAY stays last-confirmed truth; this module never patches a
- *    store and has no store dependency — it only calls the injected `emit`.
- *  - a confirmed observation that matches neither the frozen baseline nor
- *    our own accumulated target is a contradiction (the operator moved the
- *    physical dial) and resets accumulation immediately; the next step
- *    rebuilds its baseline from that new truth.
- *  - a confirmed observation that DOES match our own accumulated target is
- *    our own write landing mid-burst — not a contradiction — and simply
- *    rebases the frozen baseline so further deltas stay correct once the
- *    presentation layer re-renders against it.
- *  - the accumulator quietly expires `quietWindowMs` after the last step
- *    (default ~2x the observed confirm round trip) or immediately on a
- *    terminal (failed/cancelled/timed-out) command lifecycle.
- *  - the very first step of a cold window emits immediately, unpaced —
- *    single-step tuning behaves exactly as it did before this module.
+ * Invariants:
+ *  - this module never patches a store — it only calls the injected `emit`.
+ *  - a confirmed observation on the CLOSED SEGMENT between the frozen
+ *    baseline and the current target (direction of travel) is one of our
+ *    own writes landing mid-burst — including an INTERMEDIATE target
+ *    already superseded by further accumulation, not just the final one
+ *    (review B2) — and rebases the baseline without discarding the target.
+ *    Off-segment is a genuine contradiction (the operator moved the
+ *    physical dial): reset, and rebuild the baseline from the new truth.
+ *  - the burst expires after `quietWindowMs` of inactivity, immediately on
+ *    a terminal (failed/cancelled/timed-out) lifecycle — the lifecycle
+ *    OBJECT is retained and `.status` read fresh each step/flush, since
+ *    it's mutated in place after `emit` returns, not replaced (review B3) —
+ *    or on a control-session epoch / capabilities-generation change (review
+ *    B4), so a burst never carries across a reconnect or radio switch.
+ *  - the first step of a cold window emits immediately, unpaced.
+ *  - ONE accumulator per receiver, globally (review B5): `createTuningAccumulator`
+ *    stays a plain per-call factory (used by tests); production code goes
+ *    through `getSharedTuningAccumulator`, a module singleton so every
+ *    caller shares the same pending-burst state per receiver.
  */
 
 const DEFAULT_PACE_MS = 60; // just above the server's 50ms coalescing window
 const DEFAULT_QUIET_WINDOW_MS = 4_000; // ~2x the observed confirm round trip
 
 const TERMINAL_STATUSES = new Set(['failed', 'cancelled', 'timed-out']);
+
+/** Structural — matches `CommandLifecycle` without importing it (this
+ *  module stays store/transport-free; see the file-level invariants). */
+interface EmittedLifecycle { status: string }
 
 interface PendingTuning {
   /** Confirmed radio truth this burst's deltas are measured against. */
@@ -54,26 +60,45 @@ interface PendingTuning {
   flushTimer: ReturnType<typeof setTimeout> | null;
   /** Wall-clock time the last frame was actually emitted, for pacing. */
   lastEmitAt: number;
-  /** Status of the last emitted command's lifecycle, if known. */
-  lastStatus: string | null;
+  /** Last emitted lifecycle OBJECT, mutated in place by the caller — read
+   *  fresh, never snapshotted (review B3). */
+  lastLifecycle: EmittedLifecycle | null;
+  /** Session epoch / capabilities generation this burst started under; a
+   *  mismatch at any later step/flush expires it (review B4). */
+  epoch: number;
+  generation: number | null;
 }
 
 export interface TuningAccumulatorOptions {
   /** Sends one `set_freq` for `receiver` at `freq`; returns its lifecycle
-   *  status when known, so a NAK/failure can expire the burst early. */
-  emit: (receiver: number, freq: number) => { status: string } | void;
+   *  object when known, so a NAK/failure can expire the burst early. */
+  emit: (receiver: number, freq: number) => EmittedLifecycle | void;
   now?: () => number;
   paceMs?: number;
   quietWindowMs?: number;
+  /** Current control-session epoch / capabilities generation (review B4);
+   *  default to a constant so options that omit them never force a reset. */
+  epoch?: () => number;
+  generation?: () => number | null;
 }
 
 export interface TuningAccumulator {
-  /**
-   * Feed one gesture. `confirmedFreq` is the CURRENT confirmed radio truth
-   * for `receiver`; `requestedFreq` is the ABSOLUTE target the presentation
-   * layer computed off its own (possibly stale) displayed value.
-   */
+  /** Feed one RELATIVE gesture: `confirmedFreq` is the current confirmed
+   *  radio truth for `receiver`, `requestedFreq` the absolute target the
+   *  presentation layer computed off its own (possibly stale) display. */
   step(receiver: number, confirmedFreq: number, requestedFreq: number): void;
+  /** Feed one ABSOLUTE-target gesture (click-to-tune, station/QSY recall):
+   *  clears any in-flight burst and emits `freq` unpaced (review B1). */
+  jump(receiver: number, freq: number): void;
+}
+
+/** True when `observed` lies on the closed segment between `baseline` and
+ *  `target`, in the direction of travel (review B2) — covers both
+ *  endpoints and every intermediate target a burst has already emitted. */
+function isOnSegment(baseline: number, target: number, observed: number): boolean {
+  return target >= baseline
+    ? observed >= baseline && observed <= target
+    : observed <= baseline && observed >= target;
 }
 
 export function createTuningAccumulator(options: TuningAccumulatorOptions): TuningAccumulator {
@@ -90,6 +115,8 @@ export function createTuningAccumulator(options: TuningAccumulatorOptions): Tuni
     now = () => Date.now(),
     paceMs = DEFAULT_PACE_MS,
     quietWindowMs = DEFAULT_QUIET_WINDOW_MS,
+    epoch: getEpoch = () => 0,
+    generation: getGeneration = () => null,
   } = options;
   const pending = new Map<number, PendingTuning>();
 
@@ -99,12 +126,17 @@ export function createTuningAccumulator(options: TuningAccumulatorOptions): Tuni
     pending.delete(receiver);
   }
 
+  function sessionChanged(state: PendingTuning): boolean {
+    return state.epoch !== getEpoch() || state.generation !== getGeneration();
+  }
+
   function flush(receiver: number): void {
     const state = pending.get(receiver);
     if (!state) return;
+    if (sessionChanged(state)) { clear(receiver); return; }
     state.flushTimer = null;
     state.lastEmitAt = now();
-    state.lastStatus = emit(receiver, state.target)?.status ?? null;
+    state.lastLifecycle = emit(receiver, state.target) ?? null;
   }
 
   function scheduleFlush(receiver: number): void {
@@ -114,37 +146,45 @@ export function createTuningAccumulator(options: TuningAccumulatorOptions): Tuni
     state.flushTimer = setTimeout(() => flush(receiver), wait);
   }
 
+  function beginFresh(receiver: number, t: number, baseline: number, target: number): PendingTuning {
+    clear(receiver);
+    const fresh: PendingTuning = {
+      baseline,
+      target,
+      quietUntil: t + quietWindowMs,
+      flushTimer: null,
+      lastEmitAt: t,
+      lastLifecycle: null,
+      epoch: getEpoch(),
+      generation: getGeneration(),
+    };
+    pending.set(receiver, fresh);
+    return fresh;
+  }
+
   return {
     step(receiver, confirmedFreq, requestedFreq) {
       const t = now();
       const state = pending.get(receiver);
       let hot = state !== undefined
         && t < state.quietUntil
-        && !TERMINAL_STATUSES.has(state.lastStatus ?? '');
+        && !sessionChanged(state)
+        && !TERMINAL_STATUSES.has(state.lastLifecycle?.status ?? '');
 
-      if (hot && confirmedFreq !== state!.baseline) {
-        if (confirmedFreq === state!.target) {
-          // Our own accumulated write landed mid-burst: rebase and continue.
+      if (hot) {
+        if (isOnSegment(state!.baseline, state!.target, confirmedFreq)) {
+          // Our own write landing mid-burst — the frozen baseline or any
+          // intermediate target we already emitted — rebase and continue.
           state!.baseline = confirmedFreq;
         } else {
-          // Matches neither the frozen baseline nor our own predicted
-          // target: a physical observation we did not cause (invariant 3).
+          // Off the segment: a physical observation we did not cause.
           hot = false;
         }
       }
 
       if (!hot) {
-        clear(receiver);
-        const fresh: PendingTuning = {
-          baseline: confirmedFreq,
-          target: requestedFreq,
-          quietUntil: t + quietWindowMs,
-          flushTimer: null,
-          lastEmitAt: t,
-          lastStatus: null,
-        };
-        pending.set(receiver, fresh);
-        fresh.lastStatus = emit(receiver, requestedFreq)?.status ?? null;
+        const fresh = beginFresh(receiver, t, confirmedFreq, requestedFreq);
+        fresh.lastLifecycle = emit(receiver, requestedFreq) ?? null;
         return;
       }
 
@@ -152,5 +192,25 @@ export function createTuningAccumulator(options: TuningAccumulatorOptions): Tuni
       state!.quietUntil = t + quietWindowMs;
       scheduleFlush(receiver);
     },
+    jump(receiver, freq) {
+      // No pending burst to leave behind: an absolute target carries no
+      // "baseline" a future relative step could honestly accumulate from.
+      clear(receiver);
+      emit(receiver, freq);
+    },
   };
+}
+
+let singleton: TuningAccumulator | null = null;
+
+/** Module-level singleton (review B5): options are captured from the FIRST
+ *  caller only — every real caller wires functionally identical ones, so
+ *  every `makeVfoHandlers()` instance shares one pending-burst state. */
+export function getSharedTuningAccumulator(options: TuningAccumulatorOptions): TuningAccumulator {
+  return singleton ??= createTuningAccumulator(options);
+}
+
+/** Test-only: clears the shared singleton for a clean slate between tests. */
+export function resetSharedTuningAccumulatorForTests(): void {
+  singleton = null;
 }

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -24,6 +24,9 @@
  * Contract pinned by `src/__tests__/storage-isolation.isolated.test.ts`.
  */
 
+import { afterEach } from 'vitest';
+import { resetSharedTuningAccumulatorForTests } from './src/lib/runtime/commands/tuning-accumulator';
+
 /** Marker property test code can use to assert the stub is installed. */
 export const TEST_STORAGE_MARKER = '__rigplaneTestStorage';
 
@@ -63,3 +66,13 @@ for (const name of ['localStorage', 'sessionStorage'] as const) {
     configurable: true,
   });
 }
+
+// MOR-1425 review B5: the tuning accumulator is now a module-level
+// singleton shared by every `makeVfoHandlers()` caller (production
+// correctness — see `tuning-accumulator.ts`). Left unreset, a "hot" burst
+// left pending by one test's fake-timer clock is misread as still-hot by
+// the next test in the same file (`isolate: true` is per-FILE, not
+// per-test — same class of leak `localStorage` above was patched for).
+afterEach(() => {
+  resetSharedTuningAccumulatorForTests();
+});


### PR DESCRIPTION
## Mechanism (operator-captured evidence)

On the RC stand (IC-7300 serial), rapid digit-tuning gestures (wheel ticks, arrow presses) collapse to roughly one step per round trip. Each gesture computes its target as `displayed value + step` in the presentation layer, but the displayed value is last-confirmed radio truth and only advances after a full `set_freq` round trip. The operator's WS frame dump showed the mechanism directly: ~20 consecutive identical `set_freq` targets (e.g. `14143990` repeated ~20x) — every gesture inside one round trip computed the SAME target relative to the same stale display, so a burst of N steps netted one write.

A burst-probe measurement on the same stand found `cmd→ok` ~5-6ms but `cmd→confirmed state` ~1.9-2.1s (real CI-V write + poller readback cycle) — the collapse is a client-side pacing problem against `state_update`, not a server throughput limit (the server's now-merged MOR-1427 coalescer sustains ~20 writes/s with last-value-wins + honest `superseded` acks on its 50ms window).

## Fix

Added `frontend/src/lib/runtime/commands/tuning-accumulator.ts`, a small ephemeral accumulator wired into `makeVfoHandlers()`'s `onMainFreqChange` / `onSubFreqChange` / `onFreqChange` in `panel-commands.ts` (the seam every digit-tuning gesture already funnels through). While a burst is "hot", each gesture's delta from the frozen confirmed baseline accumulates onto a pending target instead of being computed against — and discarded relative to — the same stale baseline every time. Emission is paced at ~60ms, just above the server's 50ms same-command coalescing window.

### Invariants preserved

- **Display honesty**: the accumulator never patches a store or the presentation layer — it only calls `dispatchRadioIntent`. The displayed frequency stays last-confirmed radio truth for the whole burst (verified: no `patchActiveReceiver`/`patchRadioState`/`patchReceiver` calls during a burst).
- **Contradiction wins**: a confirmed observation off the segment between the frozen baseline and the current predicted target (the operator turned the physical knob) resets accumulation immediately; the next step rebases on the new truth. An observation on that segment — including an intermediate target already superseded by further accumulation, not just the final one — rebases without resetting (round 2, finding B2).
- **Expiry**: the accumulator clears after a quiet window (~2x the observed confirm round trip) with no further steps, immediately on a terminal (failed/cancelled/timed-out) command lifecycle, or on a control-session epoch / capabilities-generation change (round 2, findings B3/B4).
- **Single-step parity**: an isolated step still emits immediately, unpaced — no new abstraction fires or delay appears outside a rapid burst.
- **Intent separation**: relative step gestures (wheel/arrow, media keys, keyboard tune) accumulate; absolute-target gestures (click-to-tune, drag, station/QSY recall) jump — clearing any in-flight burst and landing exactly, unpaced (round 2, finding B1).
- **One accumulator per receiver, globally**: every caller — the panel-adapters singleton and any per-composition-root `makeVfoHandlers()` — shares the same pending-burst state (round 2, finding B5).

## Test evidence

- `frontend/src/lib/runtime/commands/__tests__/tuning-accumulator.test.ts` — dedicated unit tests for the accumulator in isolation (fake timers): N-step accumulation, ≥60ms pacing, contradiction reset, rebase-not-reset on our own write landing (including intermediate echoes), quiet-window expiry, terminal-status expiry (real mutable-lifecycle shape), isolated single-step immediacy, per-receiver independence, absolute jump mid-burst, epoch/generation-change reset, and shared-singleton identity.
- `frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.isolated.test.ts` — end-to-end tests through the real `makeVfoHandlers()` wiring covering burst accumulation, contradiction reset (discriminating on send-command call count), the absolute-jump default, and explicit step opt-in.

## Gates (first run, no retry-to-green)

- `npm test` — 320 files / 6595 tests passed
- `npm run lint` — clean
- `npm run check` (svelte-check + tsc) — 0 errors, 0 warnings

Net production LOC: ~186 (156 new in `tuning-accumulator.ts`, +30 net in `panel-commands.ts`), under the 200 LOC budget. No new abstractions beyond the accumulator module. Frontend-only — no transport, store-truth, or server changes.

## Review fixes (round 2)

Independent adversarial review at head `22e2ef3f` returned **BLOCKED** on five findings (B1-B5); all five are resolved as of head `35168dc6`. Branch was rebased onto current `main` (5 commits, clean merge, no conflicts) before this round.

- **B1 (absolute-jump gestures corrupted by burst delta)** — `step()` gains a sibling `jump(receiver, freq)` on the accumulator: clears any in-flight burst for the receiver and emits the exact frequency immediately, unpaced. `onFreqChange(freq, receiver, kind)` takes an explicit `kind` param defaulting to `'jump'` (absolute correctness by default); only genuine relative-step sources (spectrum scroll-to-tune, media-key tuning, keyboard `'tune'`) opt in with `'step'`. `onMainFreqChange`/`onSubFreqChange` are exclusively fed by digit-tuning gestures and keep the accumulate path unconditionally. The masking `advanceTimersByTime(4_500)` is removed from the `panel-commands.intent.isolated.test.ts` regression test — the pinned `set_freq 18_100_000` assertion now passes unpaced, mid-burst, on its own.
- **B2 (own-write echo recognized only for the final target)** — echo recognition now accepts any confirmed frequency on the closed segment between the frozen baseline and the current target, in the direction of travel — covering intermediate targets a burst already emitted, not just the final one — and rebases the baseline without discarding accumulation. Added a hand-verified intermediate-echo mid-burst unit test asserting the exact emitted-frame sequence and that it is monotonic (never backward).
- **B3 (terminal-status expiry inert in production)** — the accumulator now retains the `CommandLifecycle` OBJECT returned by `emit` and reads `.status` fresh at each `step`/`flush`, instead of snapshotting a string at emit time. The unit test drives a mutable `{status:'pending'}` object that is later mutated to `'failed'`, matching the real `dispatchRadioIntent`/`beginCommand` shape instead of a mock that returns the final status upfront.
- **B4 (no reset on session epoch / capabilities generation change)** — `step()`/`flush()` compare the control-session epoch and capabilities generation captured at burst start against current values (the same sources `dispatchRadioIntent` itself reads, exposed via a new `currentControlSessionEpoch()` export in `radio-intents.ts` — `tuning-accumulator.ts` stays free of store/transport imports) and reset on any mismatch. New unit tests cover both.
- **B5 (two live accumulators per receiver)** — hoisted to a true module-level singleton (`getSharedTuningAccumulator`), shared by the panel-adapters singleton accessor and every per-composition-root `makeVfoHandlers()` call, replacing the previous per-factory-call instance. `createTuningAccumulator` remains a plain factory for test isolation. Tests get a global per-test reset of the shared singleton via `vitest.setup.ts` (the same class of fix already applied there for `localStorage`), since the singleton now persists module-wide across `it()` blocks in a file.

Also made the contradictory-frequency wiring test discriminating: it now asserts `sendCommand` call counts (which fail if the accumulator is ever un-wired from `onMainFreqChange`), not just the final emitted value, which a naive non-accumulating dispatch would also have produced.

**Gates after fixes (first run, no retry-to-green):**
- `npm test` — 320 files / 6609 tests passed
- `npm run lint` — clean
- `npm run check` (svelte-check + tsc) — 0 errors, 0 warnings
- `mor1428-ic7300-conformance.isolated.test.ts` — 20/20 passed (stays green)

**Production LOC**: honest total for the whole PR (vs `main`) is **268 insertions / 12 deletions, net +256** — over the 200 budget. `tuning-accumulator.ts` is a new file (216 lines) carrying most of the growth: the jump path, segment-based echo logic, retained-lifecycle tracking, epoch/generation checks, and the shared-singleton wrapper are all real, load-bearing fixes for the five BLOCKER findings, not incidental additions. Comments were trimmed during this round to reduce the overage where it didn't cost clarity; prioritizing correctness over the budget per the round-2 instructions.

Linear: https://linear.app/morozsm/issue/MOR-1425

**Independent verifier re-review requested — do not merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Review fixes (round 3)

Independent adversarial review at head `35168dc6` (round 2) returned **BLOCKED** on one residual finding, B1-residual: `SemanticRadioSurfaces.tuneFrequency` still funneled two ABSOLUTE sources — `enterFrequency` (BandSurface's typed frequency entry) and `selectBand`'s bandless band-default fallback — through the same unconditional-step path as `VfoSurface`'s per-digit wheel/arrow tuning, so a hot digit-tuning burst on the active receiver absorbed a typed/band-select target into its accumulated offset instead of landing exactly (reproduced live: type `7_100_000` mid-burst -> emits `7_105_000`; bandless band select mid-burst -> 3 kHz off).

Resolved as of head `f72ea7ae`: `tuneFrequency` gains a `'jump' | 'step'` `kind` param, defaulting to `'step'` so the existing digit-tuning call site (`VfoSurface`'s `onTuneFrequency`) needs no change. `enterFrequency`/`selectBand`'s bandless fallback now pass `'jump'`, which routes around `onMainFreqChange`/`onSubFreqChange` entirely, through `vfo.onFreqChange`'s existing jump path (proven in round 2 for spectrum click-to-tune / EiBi / QSY recall) — clears any in-flight burst and emits the exact target immediately, unpaced. `onMainFreqChange`/`onSubFreqChange` themselves are unchanged, so `RadioLayout`'s legacy `VfoHeader` wiring and `MobileRadioLayout`'s `tuneBy` are unaffected.

Audited every caller of `tuneFrequency`/`onMainFreqChange`/`onSubFreqChange`/`onFreqChange` across the frontend for the same absolute-into-step class: `AmberCockpit`'s QSY recall, `SpectrumPanel`'s click-to-tune/drag-to-pan, `EiBiBrowser`'s station recall, and `media-session.ts`'s media-key tuning were all already correctly classified (jump-by-default or explicit `'step'`); the residual was isolated to `SemanticRadioSurfaces.tuneFrequency`.

Added two wiring tests to `semantic-band-wiring.component.test.ts` under fake timers: a typed frequency entry and a bandless band select, each fired mid a hot digit-tuning burst on the active receiver, asserting the exact absolute target lands immediately with no accumulated offset, and that the burst's own paced flush never fires a stray extra call. RED/GREEN verified by reverting just the `tuneFrequency`/`enterFrequency`/`selectBand` kind-threading: both new tests fail with the offset signature (`14251000` instead of the requested `7100000`/`1000000`) — the accumulated stale target, not the requested one; restoring the fix returns both to green, with all other tests unaffected.

**Gates after the fix (first run, no retry-to-green):**
- `npm test` — 320 files / 6611 tests passed
- `npm run lint` — clean
- `npm run check` (svelte-check + tsc) — 0 errors, 0 warnings
- `mor1428-ic7300-conformance.isolated.test.ts` — 20/20 passed

**Production diff this round**: 2 files changed (`SemanticRadioSurfaces.svelte`, `semantic-band-wiring.component.test.ts`), 99 insertions / 3 deletions — no new abstractions, no other files touched.

**Independent verifier re-review requested — do not merge.**
