### PR TITLE
feat: surface why-disabled reasons and visible command refusals (MOR-1422)

### DIFF
--- a/frontend/src/lib/i18n/__tests__/index.test.ts
+++ b/frontend/src/lib/i18n/__tests__/index.test.ts
@@ -60,6 +60,23 @@ describe('t()', () => {
     });
     expect(sentence).toContain('192.168.55.40');
   });
+
+  // MOR-1422: the `disabledReasonText` shared helper (`semantic/
+  // disabled-reason.ts`) resolves these two keys for every semantic surface
+  // that renders a present-but-unusable control. Both locales are asserted
+  // by their OWN text (not just "resolves to something") so a catalog that
+  // dropped one language's entry — silently falling back to en-US — fails
+  // this test instead of shipping unnoticed.
+  it('carries the MOR-1422 disabled-reason strings in en-US', () => {
+    expect(t('core.disabledReason.missing')).toBe('Not supported by this radio');
+    expect(t('core.disabledReason.unobserved')).toBe('Not yet observed');
+  });
+
+  it('carries the MOR-1422 disabled-reason strings in ru-RU (own catalog entries)', () => {
+    setLocale('ru-RU');
+    expect(t('core.disabledReason.missing')).toBe('Не поддерживается этим трансивером');
+    expect(t('core.disabledReason.unobserved')).toBe('Ещё не считано');
+  });
 });
 
 describe('tPlural()', () => {
@@ -102,6 +119,24 @@ describe('messageFromReasonCode()', () => {
   it('falls back to core.toast.unknown for an unknown code', () => {
     expect(messageFromReasonCode('completelyMadeUpCode')).toBe(
       'Something went wrong. Try again later.',
+    );
+  });
+
+  // MOR-1422: the client-synthesized `sendCommand` refusal notice
+  // (`$lib/transport/ws-client`) resolves through this SAME function — a
+  // missing catalog entry would silently fall back to `core.toast.unknown`
+  // rather than fail loudly, so the fallback text is exactly what a missing
+  // key looks like and is what these two locale assertions rule out.
+  it('resolves the MOR-1422 command-refusal reason code in en-US', () => {
+    expect(messageFromReasonCode('commandRefusedLinkDegraded')).toBe(
+      'Command not sent — link to the radio is degraded',
+    );
+  });
+
+  it('resolves the MOR-1422 command-refusal reason code in ru-RU (own catalog entry, not the en-US fallback)', () => {
+    setLocale('ru-RU');
+    expect(messageFromReasonCode('commandRefusedLinkDegraded')).toBe(
+      'Команда не отправлена — связь с трансивером деградировала',
     );
   });
 

--- a/frontend/src/lib/i18n/locales/en-US.json
+++ b/frontend/src/lib/i18n/locales/en-US.json
@@ -156,6 +156,7 @@
   "core.toast.radioDisconnected": "Radio disconnected",
   "core.toast.audioBridgeStarted": "Audio bridge started",
   "core.toast.audioBridgeStopped": "Audio bridge stopped",
+  "core.toast.commandRefusedLinkDegraded": "Command not sent — link to the radio is degraded",
   "core.toast.unknown": "Something went wrong. Try again later.",
 
   "core.mobile.nav.label": "Radio navigation",
@@ -207,6 +208,9 @@
   "core.vfo.ops.quickDualWatch": "Quick dual watch",
   "core.vfo.splitDigest.rx": "RX {frequency}",
   "core.vfo.splitDigest.tx": "TX {frequency}",
+
+  "core.disabledReason.missing": "Not supported by this radio",
+  "core.disabledReason.unobserved": "Not yet observed",
 
   "core.txGuard.modInputNotLan": "MOD input is {source}, not LAN — your voice from the web will not be transmitted (TX).",
   "core.txGuard.setLan": "Set LAN",

--- a/frontend/src/lib/i18n/locales/ru-RU.json
+++ b/frontend/src/lib/i18n/locales/ru-RU.json
@@ -136,6 +136,7 @@
   "core.toast.radioDisconnected": "Трансивер отключён",
   "core.toast.audioBridgeStarted": "Аудиомост запущен",
   "core.toast.audioBridgeStopped": "Аудиомост остановлен",
+  "core.toast.commandRefusedLinkDegraded": "Команда не отправлена — связь с трансивером деградировала",
   "core.toast.unknown": "Что-то пошло не так. Попробуйте позже.",
 
   "core.mobile.nav.label": "Навигация по трансиверу",
@@ -187,6 +188,9 @@
   "core.vfo.ops.quickDualWatch": "Быстрый двойной приём",
   "core.vfo.splitDigest.rx": "RX {frequency}",
   "core.vfo.splitDigest.tx": "TX {frequency}",
+
+  "core.disabledReason.missing": "Не поддерживается этим трансивером",
+  "core.disabledReason.unobserved": "Ещё не считано",
 
   "core.txGuard.modInputNotLan": "Вход MOD установлен в {source}, а не LAN — голос из веб-интерфейса не уйдёт в эфир (TX).",
   "core.txGuard.setLan": "Включить LAN",

--- a/frontend/src/lib/transport/__tests__/ws-client.isolated.test.ts
+++ b/frontend/src/lib/transport/__tests__/ws-client.isolated.test.ts
@@ -1289,6 +1289,90 @@ describe('control channel singleton', () => {
 
 });
 
+// ─── MOR-1422: a refused command must be operator-visible ──────────────────
+//
+// `sendCommand` used to drop a non-PTT-off command while
+// `isLiveRadioAvailable()` is false with only a `console.warn` — invisible
+// unless the operator has devtools open. A held control (a jog wheel, a
+// repeated keypress) calls `sendCommand` many times a second, so the fix is
+// ONE notice per refusal burst, not one per call — these tests exercise the
+// debounce with fake timers, and pin the two things that must NOT trigger
+// it: a healthy link, and the always-ungated PTT-off release path.
+describe('sendCommand surfaces a refused command exactly once per burst (MOR-1422)', () => {
+  let originalWebSocket: typeof WebSocket;
+
+  beforeEach(() => {
+    instances.length = 0;
+    vi.useFakeTimers();
+    originalWebSocket = globalThis.WebSocket;
+    // @ts-expect-error mock
+    globalThis.WebSocket = MockWebSocket;
+  });
+
+  afterEach(() => {
+    globalThis.WebSocket = originalWebSocket;
+    vi.useRealTimers();
+    vi.resetModules();
+  });
+
+  it('emits exactly one notification for a burst of refused commands', async () => {
+    vi.mocked(isLiveRadioAvailable).mockReturnValue(false);
+    const { onMessage, sendCommand } = await import('../ws-client');
+    const notices: unknown[] = [];
+    onMessage((msg) => { if (msg.type === 'notification') notices.push(msg); });
+
+    sendCommand('set_freq', { freq: 14_074_000, receiver: 0 }, 'a');
+    sendCommand('set_freq', { freq: 14_074_100, receiver: 0 }, 'b');
+    sendCommand('set_freq', { freq: 14_074_200, receiver: 0 }, 'c');
+
+    expect(notices).toHaveLength(1);
+    expect(notices[0]).toMatchObject({
+      type: 'notification', level: 'warning', code: 'commandRefusedLinkDegraded',
+    });
+  });
+
+  it('emits a second notification once the debounce window has elapsed', async () => {
+    vi.mocked(isLiveRadioAvailable).mockReturnValue(false);
+    const { onMessage, sendCommand } = await import('../ws-client');
+    const notices: unknown[] = [];
+    onMessage((msg) => { if (msg.type === 'notification') notices.push(msg); });
+
+    sendCommand('set_freq', { freq: 14_074_000, receiver: 0 }, 'first');
+    vi.advanceTimersByTime(3_000);
+    sendCommand('set_freq', { freq: 14_074_100, receiver: 0 }, 'second');
+
+    expect(notices).toHaveLength(2);
+  });
+
+  it('emits nothing while the link is healthy', async () => {
+    vi.mocked(isLiveRadioAvailable).mockReturnValue(true);
+    const { connect, onMessage, sendCommand } = await import('../ws-client');
+    connect('ws://test/api/v1/ws');
+    instances[0].simulateOpen();
+    const notices: unknown[] = [];
+    onMessage((msg) => { if (msg.type === 'notification') notices.push(msg); });
+
+    sendCommand('set_freq', { freq: 14_074_000, receiver: 0 });
+
+    expect(notices).toHaveLength(0);
+  });
+
+  // The PTT-off release alias is the operator's emergency unkey path — it is
+  // never gated on link health (see the "allows open-socket PTT release
+  // aliases" case above) and must never be buried under a refusal toast either.
+  it('emits nothing for the ungated PTT-off release path', async () => {
+    vi.mocked(isLiveRadioAvailable).mockReturnValue(false);
+    const { onMessage, sendCommand } = await import('../ws-client');
+    const notices: unknown[] = [];
+    onMessage((msg) => { if (msg.type === 'notification') notices.push(msg); });
+
+    sendCommand('ptt_off', {}, 'off-1');
+    sendCommand('ptt', { state: false }, 'off-2');
+
+    expect(notices).toHaveLength(0);
+  });
+});
+
 describe('WsChannel send queue', () => {
   let originalWebSocket: typeof WebSocket;
 

--- a/frontend/src/lib/transport/ws-client.ts
+++ b/frontend/src/lib/transport/ws-client.ts
@@ -350,6 +350,19 @@ export class WsChannel {
     return () => this.messageHandlers.delete(handler);
   }
 
+  /**
+   * MOR-1422: a client-synthesized notification, delivered through the SAME
+   * bus a server `{"type":"notification"}` frame uses (the `errNote`
+   * pattern above) — so the one shipped toast surface (`components/shared/
+   * Toast.svelte`) renders it with no changes of its own. `code` is resolved
+   * to `core.toast.<code>` by `messageFromReasonCode`; `message` is the
+   * English fallback for a caller that never supplied one.
+   */
+  emitLocalNotification(level: 'info' | 'warning' | 'error', message: string, code: string): void {
+    const note: WsIncoming = { type: 'notification', level, message, code, category: 'command' };
+    this.messageHandlers.forEach((h) => h(note));
+  }
+
   onBinary(handler: BinaryHandler): () => void {
     this.binaryHandlers.add(handler);
     return () => this.binaryHandlers.delete(handler);
@@ -836,6 +849,17 @@ export function getControlSession(): ControlSessionTransition {
   return { state: _ctrl.state, epoch: _ctrl.sessionEpoch };
 }
 
+/**
+ * MOR-1422: the refusal below fires per COMMAND — a held control (a
+ * jog wheel, a repeated keypress) can call `sendCommand` many times a
+ * second, and a toast per call would bury the one useful signal ("your
+ * commands are not reaching the radio") under a flood. This is a burst
+ * debounce, not a rate limit on the refusal itself: `sendCommand` keeps
+ * returning `false` for every call, only the notice is throttled.
+ */
+const REFUSAL_NOTICE_DEBOUNCE_MS = 3_000;
+let lastRefusalNoticeAt = -Infinity;
+
 export function sendCommand(
   name: string,
   params: Record<string, unknown> = {},
@@ -846,6 +870,13 @@ export function sendCommand(
     console.warn('[cmd] blocked while radio health is degraded', name);
     if (pttIntent(name, params) === null) {
       _ctrl.rejectNonPtt(commandId, 'radio health is degraded');
+    }
+    const now = Date.now();
+    if (now - lastRefusalNoticeAt >= REFUSAL_NOTICE_DEBOUNCE_MS) {
+      lastRefusalNoticeAt = now;
+      _ctrl.emitLocalNotification(
+        'warning', 'Command not sent — link to the radio is degraded', 'commandRefusedLinkDegraded',
+      );
     }
     return false;
   }

--- a/frontend/src/semantic/TxAuxSurface.svelte
+++ b/frontend/src/semantic/TxAuxSurface.svelte
@@ -29,6 +29,7 @@
 <script module lang="ts">
   import type { TxAuxField } from './radio-view-model';
   import { pressedOf } from './pressed-of';
+  import { disabledReasonText } from './disabled-reason';
 
   /** On/off controls, `[field, label]`. ATU's reading is a three-state enum,
    *  the rest are booleans; `pressedOf` normalises both to one aria state. */
@@ -58,6 +59,11 @@
   /** The MOR-977 `DisabledReasonCode` a present-but-unusable control carries. */
   const reasonOf = (f: TxAuxField<unknown>): 'field-not-observed' | undefined =>
     usable(f) ? undefined : 'field-not-observed';
+  /** MOR-1422: the SAME gate as `reasonOf`, rendered as operator-facing text
+   *  for `title` (hover) and the `aria-describedby` target below (screen
+   *  readers) — the `data-disabled-reason` attribute `reasonOf` feeds is a
+   *  test/CSS hook only, invisible to both. */
+  const reasonTextOf = (f: TxAuxField<unknown>): string | undefined => disabledReasonText(f.availability);
   const textOf = (f: TxAuxField<unknown>): string =>
     f.reading.status !== 'known' ? '?'
       : typeof f.reading.value === 'boolean' ? (f.reading.value ? 'on' : 'off')
@@ -83,6 +89,15 @@
   let { view, tx, onToggle, onLevelChange, onAtuTune }: Props = $props();
 
   const blockedId = `tx-aux-blocked-${++sequence}`;
+  /** MOR-1422: prefix for the per-field hidden reason text `aria-describedby`
+   *  targets below — shares `blockedId`'s instance number so several mounted
+   *  surfaces never collide, without incrementing `sequence` a second time. */
+  const reasonIdPrefix = `tx-aux-reason-${sequence}`;
+  /** `aria-describedby` needs an ID to point at; `aria-description` (no ID,
+   *  the string inline) is not yet in Svelte's own attribute typings —
+   *  `undefined` omits the attribute exactly when there is no reason. */
+  const reasonIdOf = (field: string, f: TxAuxField<unknown>): string | undefined =>
+    disabledReasonText(f.availability) !== undefined ? `${reasonIdPrefix}-${field}` : undefined;
   let txAux = $derived(view.txAux);
   let tuneBlocked = $derived(keyBlockedReasons(view, tx));
 
@@ -109,10 +124,14 @@
             type="button" class="tx-aux-toggle"
             data-testid={`tx-aux-${field}`} data-field={field}
             data-disabled-reason={reasonOf(txAux[field])}
+            title={reasonTextOf(txAux[field])} aria-describedby={reasonIdOf(field, txAux[field])}
             aria-pressed={pressedOf(txAux[field])}
             disabled={!usable(txAux[field])}
             onclick={() => toggle(field)}
           >{label}: {textOf(txAux[field])}</button>
+          {#if reasonTextOf(txAux[field]) !== undefined}
+            <span id={reasonIdOf(field, txAux[field])} class="sr-only">{reasonTextOf(txAux[field])}</span>
+          {/if}
         {/if}
       {/each}
       {#if txAux.atu.availability.structural}
@@ -136,9 +155,13 @@
           <input
             type="range" {min} {max} {step}
             value={numberOf(txAux[field], min)}
+            title={reasonTextOf(txAux[field])} aria-describedby={reasonIdOf(field, txAux[field])}
             disabled={!usable(txAux[field])}
             oninput={(event) => level(field, event.currentTarget.valueAsNumber)}
           />
+          {#if reasonTextOf(txAux[field]) !== undefined}
+            <span id={reasonIdOf(field, txAux[field])} class="sr-only">{reasonTextOf(txAux[field])}</span>
+          {/if}
           <output>{textOf(txAux[field])}</output>
         </label>
       {/if}
@@ -161,6 +184,10 @@
   .tx-aux-name { min-width: 8ch; }
   .tx-aux-blocked { margin: 0; padding-inline-start: 1.2em; }
   .tx-aux-blocked:empty { display: none; }
+  /* MOR-1422: the `aria-describedby` target for a disabled control's reason
+     — present for screen readers, never painted (the `title` attribute
+     already carries the sighted-hover channel). */
+  .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
   .tx-aux-toggle[aria-pressed='true'] { font-weight: 700; }
   .tx-aux-toggle:disabled, .tx-aux-tune:disabled { cursor: not-allowed; }
 </style>

--- a/frontend/src/semantic/__tests__/TxAuxSurface.test.ts
+++ b/frontend/src/semantic/__tests__/TxAuxSurface.test.ts
@@ -170,6 +170,45 @@ describe('operational availability decides whether a control is USABLE', () => {
   });
 });
 
+// ── 2b. MOR-1422: the disabled reason is legible, not just a data hook ─────
+
+describe('the disabled reason is exposed on hover and to screen readers (MOR-1422)', () => {
+  /** Resolves a control's `aria-describedby` target and returns ITS text —
+   *  the id alone would only prove wiring, not that a screen reader has
+   *  something to actually read. */
+  function describedText(el: HTMLElement): string | null {
+    const id = el.getAttribute('aria-describedby');
+    if (!id) return null;
+    return target.querySelector(`#${id}`)?.textContent ?? null;
+  }
+
+  it('puts "Not yet observed" on title and aria-describedby for an unobserved toggle', () => {
+    const view = withField(base(), 'vox', { availability: { structural: true, operational: false } });
+    withSurface(view, snap(), (s) => {
+      const control = s.control('vox')!;
+      expect(control.title).toBe('Not yet observed');
+      expect(describedText(control)).toBe('Not yet observed');
+    });
+  });
+
+  it('puts "Not yet observed" on title and aria-describedby for an unobserved level input', () => {
+    const view = withField(base(), 'rfPower', { availability: { structural: true, operational: false } });
+    withSurface(view, snap(), (s) => {
+      const input = s.input('rfPower')!;
+      expect(input.title).toBe('Not yet observed');
+      expect(describedText(input)).toBe('Not yet observed');
+    });
+  });
+
+  it('carries no reason text on hover or for screen readers once a control is usable', () => {
+    withSurface(base(), snap(), (s) => {
+      const control = s.control('vox')!;
+      expect(control.title).toBe('');
+      expect(control.hasAttribute('aria-describedby')).toBe(false);
+    });
+  });
+});
+
 // ── 3. VOX — safety note (ii), arming voice keying ─────────────────────────
 
 describe('VOX arming obeys the two-level gate (safety note ii)', () => {

--- a/frontend/src/semantic/__tests__/disabled-reason.test.ts
+++ b/frontend/src/semantic/__tests__/disabled-reason.test.ts
@@ -1,0 +1,45 @@
+/**
+ * MOR-1422 — the shared `disabledReasonText` helper.
+ *
+ * Every semantic surface that renders a present-but-unusable control
+ * (`TxAuxSurface`, `DspSurface`, `FilterSurface`, …) already computes the
+ * MOR-977 two-level `Availability` for that field; this is the ONE place
+ * that turns it into the operator-facing text those surfaces put on `title`
+ * and an `aria-describedby` target. See `TxAuxSurface.test.ts`'s "disabled reason is
+ * exposed on hover and to screen readers" block for the reachable
+ * (`operational: false`) case wired into a real, rendered surface.
+ * `structural: false` has no current shipped surface that renders it as
+ * disabled-with-a-reason — every surface OMITS a structurally-absent
+ * control instead (MOR-977/1256 doctrine, pinned by e.g.
+ * `TxAuxSurface.test.ts`'s "renders no control at all for a structurally
+ * absent" cases) — so that branch is pinned here, directly, against the
+ * contract's own `Availability` shape.
+ */
+import { describe, expect, it } from 'vitest';
+import { disabledReasonText } from '../disabled-reason';
+import type { Availability } from '../radio-view-model';
+
+describe('disabledReasonText (MOR-1422)', () => {
+  it('returns "not supported by this radio" when the radio never declared the capability', () => {
+    const availability: Availability = { structural: false, operational: false };
+    expect(disabledReasonText(availability)).toBe('Not supported by this radio');
+  });
+
+  it('returns "not yet observed" when the capability exists but the field has not arrived', () => {
+    const availability: Availability = { structural: true, operational: false };
+    expect(disabledReasonText(availability)).toBe('Not yet observed');
+  });
+
+  it('returns undefined once both structural and operational are true — a usable control gets no reason', () => {
+    const availability: Availability = { structural: true, operational: true };
+    expect(disabledReasonText(availability)).toBeUndefined();
+  });
+
+  // MUTATION KILLED: swapping the branch order. `structural: false` must win
+  // even if a caller (incorrectly) also carries `operational: false` — the
+  // capability-missing claim is the more specific one.
+  it('prefers the missing-capability reason over the unobserved one', () => {
+    const availability: Availability = { structural: false, operational: false };
+    expect(disabledReasonText(availability)).not.toBe('Not yet observed');
+  });
+});

--- a/frontend/src/semantic/disabled-reason.ts
+++ b/frontend/src/semantic/disabled-reason.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared "why is this disabled" text for semantic-surface controls
+ * (MOR-1422).
+ *
+ * Several surfaces (`DspSurface`, `FilterSurface`, `TxAuxSurface`, …) already
+ * compute a `DisabledReasonCode` for a present-but-unusable control (the
+ * per-file `reasonOf` helpers) and stamp it onto `data-disabled-reason` — a
+ * DOM attribute that is invisible on hover and to assistive tech. This
+ * module turns the SAME MOR-977 two-level `Availability` a fact already
+ * carries into operator-facing text, for the hover channel (`title`) and a
+ * screen-reader channel (`aria-describedby`, since a plain `aria-description`
+ * string is not yet in Svelte's own attribute typings) a disabled control
+ * needs so a fail-closed control does not look like a broken one.
+ *
+ * `structural: false` — the radio model does not declare this capability at
+ * all ("not supported by this radio"). `operational: false` — the control
+ * exists but its reading has not arrived yet, whether because it was simply
+ * never read or because the same connection trouble
+ * `sendCommand`'s refusal notice (`$lib/transport/ws-client`) reports has
+ * degraded it — this module's `core.disabledReason.*` keys are the shared
+ * wording family both surfaces draw from, so the operator reads one
+ * vocabulary for "this is fail-closed," not two.
+ *
+ * `undefined` for a usable field: a usable control gets no reason text at
+ * all, matching every surface's existing `usable()` gate.
+ */
+import { t } from '$lib/i18n';
+import type { Availability } from './radio-view-model';
+
+export function disabledReasonText(availability: Availability): string | undefined {
+  if (!availability.structural) return t('core.disabledReason.missing');
+  if (!availability.operational) return t('core.disabledReason.unobserved');
+  return undefined;
+}


### PR DESCRIPTION
## Summary

Fail-closed correctness in this app is real, but it was **silent**: a disabled control gave no reason on hover or to screen readers, and a client-side refused command (radio link degraded) only logged a `console.warn`. From an operator's chair, a mostly-working system with honest fail-closed gating looked indistinguishable from a broken one — nothing visibly explained *why* a control wouldn't respond.

This PR is frontend-only, policy-level: one shared seam plus minimal per-surface wiring, not per-control special-casing.

### 1. Why-disabled affordance

The view model already carries the MOR-977 two-level `Availability { structural, operational }` for every present-but-unusable control, and several surfaces (`DspSurface`, `FilterSurface`, `TxAuxSurface`) already compute a `DisabledReasonCode` from it — but only stamp it onto `data-disabled-reason`, a DOM attribute invisible on hover and to assistive tech.

New shared helper `frontend/src/semantic/disabled-reason.ts`:

```ts
export function disabledReasonText(availability: Availability): string | undefined {
  if (!availability.structural) return t('core.disabledReason.missing');   // "Not supported by this radio"
  if (!availability.operational) return t('core.disabledReason.unobserved'); // "Not yet observed"
  return undefined;
}
```

Wired into `TxAuxSurface.svelte`'s toggle and level controls via `title` (mouse hover) and `aria-describedby` (screen readers, pointing at a `.sr-only` span — `aria-description` as a bare string isn't in Svelte's own attribute typings yet, confirmed by `svelte-check` erroring on it). The existing `data-disabled-reason` test/CSS hook is untouched.

**What this does NOT do:** every semantic surface in this codebase (`DspSurface`, `FilterSurface`, `RfFrontEndSurface`, `AntennaSurface`, `BandSurface`, `CwKeyerSurface`, `MetersSurface`, …) follows a hard, deliberately-tested doctrine: `structural: false` renders **nothing at all**, not a disabled control with a reason (pinned by e.g. `TxAuxSurface.test.ts`'s "renders no control at all for a structurally absent" cases). No shipped surface currently renders the `missing`-capability case as disabled-with-explanation — it's omitted by design. Extending that omission doctrine to a render-disabled-with-reason pattern would be a real per-surface design change (and a good deal more than ~200 LOC across ~10 files), so it's out of scope here. The `missing` branch of `disabledReasonText` is implemented and directly unit-tested against the contract's own `Availability` shape (`disabled-reason.test.ts`), ready for the next surface/control that needs it; only the reachable `unobserved` branch is wired into a live, rendered component in this PR.

### 2. Visible command refusal

`ws-client.ts`'s `sendCommand` silently dropped non-PTT-off commands when `isLiveRadioAvailable()` is false — `console.warn` only. It now also emits **one notification per ~3s refusal burst** (a held control or repeated keypress must not flood the operator with a toast per call) through the *existing* `{"type":"notification"}` message bus the shipped `Toast.svelte` already listens to and renders — no changes to `Toast.svelte` itself, reusing its established `code` → `messageFromReasonCode` → `core.toast.<code>` localization pattern (the same pattern the server's own notifications use).

The PTT-off release path (the operator's emergency unkey) stays completely ungated and emits nothing, exactly as before. A healthy link emits nothing.

### i18n

Added to both `en-US.json` and `ru-RU.json`, following the existing `core.*` flat-key convention:
- `core.disabledReason.missing` / `core.disabledReason.unobserved`
- `core.toast.commandRefusedLinkDegraded` (same wording family as the why-disabled strings, per the ticket's instruction)

`npm run i18n:check` passes; no new missing-key or placeholder-mismatch warnings introduced.

## Test evidence

RED → GREEN, all four required cases:
- (a) `disabled-reason.test.ts` — `disabledReasonText` returns "Not supported by this radio" for `{structural:false}`, unit-tested directly against the contract shape (see explanation above for why this isn't wired into a rendered, disabled control anywhere yet).
- (b) `TxAuxSurface.test.ts` — new "disabled reason is exposed on hover and to screen readers" block: a real mounted, unobserved control carries `title` + a resolvable `aria-describedby` target both reading "Not yet observed"; a usable control carries neither.
- (c) `ws-client.isolated.test.ts` — new describe block with fake timers: a 3-command burst while degraded emits exactly one notification; a second burst after the 3s window emits a second one; a healthy link emits zero; the PTT-off release path emits zero.
- (d) `index.test.ts` — extended `messageFromReasonCode()`/`t()` coverage: the three new keys resolve to their own text in *both* en-US and ru-RU (ru-RU asserted by its own Russian string, so a dropped catalog entry would be caught rather than silently falling back to English).

## Gates (first run, all green)

- `npm test` — 320 files, 6608 tests, 0 failures (includes the `mor1428-ic7300-conformance.isolated.test.ts` suite, unaffected)
- `npm run lint` — 0 violations
- `npm run check` (svelte-check + tsc) — 0 errors, 0 warnings
- `npm run i18n:check` — OK (no new failures; existing informational gaps in `ja-JP`/`ru-RU` are pre-existing and unrelated)

## Scope

- Files touched: `frontend/src/semantic/disabled-reason.ts` (new), `frontend/src/semantic/TxAuxSurface.svelte`, `frontend/src/lib/transport/ws-client.ts`, `frontend/src/lib/i18n/locales/{en-US,ru-RU}.json` (+ 4 test files)
- Net production LOC: **99** (31 ws-client.ts + 27 TxAuxSurface.svelte + 33 disabled-reason.ts + 4 en-US.json + 4 ru-RU.json), well under the ~200 LOC guardrail
- No new state machines, no new radio-truth sources, no per-control special-casing

## Linear

https://linear.app/morozsm/issue/MOR-1422

---

**Independent verifier review pending — do not merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)