### PR TITLE
feat: warn once when RX capture delivers only digital silence (MOR-1436)

### DIFF
--- a/src/rigplane/audio/usb_driver.py
+++ b/src/rigplane/audio/usb_driver.py
@@ -31,10 +31,20 @@ from .backend import (
 
 logger = logging.getLogger(__name__)
 
+_SILENCE_WARN_SECONDS = 10
+"""Consecutive bit-exact-zero RX seconds before the silence watchdog warns."""
+
 _DEPENDENCY_HINT = (
     "USB audio backend requires optional dependencies sounddevice and numpy. "
     "Install with: pip install rigplane[bridge]"
 )
+
+
+def _is_silent_frame(frame: bytes) -> bool:
+    """Cheap bit-exact-zero check — one memcmp, no per-sample Python loop."""
+    return bool(frame) and frame == bytes(len(frame))
+
+
 # Ordered by selection preference (lower index = stronger match). The
 # C-Media identity ranks the Xiegu X6200's audio codec ahead of an unknown
 # commodity device on platforms without topology resolution (MOR-219). It is
@@ -814,6 +824,44 @@ class UsbAudioDriver:
             f"{device.name}; tried {list(self._sample_rate_candidates(requested_sample_rate))}."
         )
 
+    def _silence_watchdog(
+        self, callback: Callable[[bytes], None], frame_ms: int
+    ) -> Callable[[bytes], None]:
+        """Wrap *callback* to warn once on sustained bit-exact RX silence.
+
+        macOS silently hands microphone-unpermissioned capture contexts
+        (e.g. ssh-spawned processes) all-zero CoreAudio frames: the stream
+        opens fine and frames keep flowing, but every sample is exactly 0 —
+        indistinguishable from a live capture of true silence without this
+        check. Tracks consecutive all-zero frames with a plain counter (no
+        new timer); warns once after ``_SILENCE_WARN_SECONDS``, then logs
+        one INFO on recovery and re-arms for the next silent stretch.
+        """
+        threshold = max(1, -(-(_SILENCE_WARN_SECONDS * 1000) // max(1, frame_ms)))
+        state = {"silent_frames": 0, "warned": False}
+
+        def _watchdog(frame: bytes) -> None:
+            if _is_silent_frame(frame):
+                state["silent_frames"] += 1
+                if state["silent_frames"] == threshold and not state["warned"]:
+                    state["warned"] = True
+                    logger.warning(
+                        "usb-audio: RX capture has delivered only digital "
+                        "silence for ~%ds — the input may lack OS capture "
+                        "permission (macOS: grant Microphone to the "
+                        "launching app/context) or the radio's USB audio "
+                        "output may be off",
+                        _SILENCE_WARN_SECONDS,
+                    )
+            else:
+                if state["warned"]:
+                    logger.info("RX audio signal detected")
+                state["silent_frames"] = 0
+                state["warned"] = False
+            callback(frame)
+
+        return _watchdog
+
     def _store_stream_contract(self, contract: UsbAudioStreamContract) -> None:
         if contract.direction == "rx":
             self._usb_audio_contract = UsbAudioContract(
@@ -891,7 +939,7 @@ class UsbAudioDriver:
                 deliver_channels=contract.channels,
                 rx_audio_channel=self._config.rx_audio_channel,
             )
-            await self._rx_stream.start(callback)
+            await self._rx_stream.start(self._silence_watchdog(callback, fm))
             self._store_stream_contract(contract)
             logger.info(
                 "usb-audio: RX capture running — device=[%d] %s",

--- a/tests/test_usb_audio_rx_silence_watchdog_mor1436.py
+++ b/tests/test_usb_audio_rx_silence_watchdog_mor1436.py
@@ -1,0 +1,155 @@
+"""MOR-1436 — RX-capture silence watchdog.
+
+Bench incident: macOS hands microphone-unpermissioned capture contexts (e.g.
+ssh-spawned processes) all-zero CoreAudio frames — the stream opens fine and
+frames keep flowing, but every sample is exactly 0. The server streamed
+digital silence for hours with zero indication. ``UsbAudioDriver.start_rx``
+now wraps the delivered callback with a cheap all-zero-frame counter that
+warns once after ~10s of unbroken bit-exact silence and logs one INFO on
+recovery, re-arming for the next silent stretch — no periodic spam, no new
+timers, no change to frame delivery itself.
+
+Frames are ``frame_ms=1000`` (one frame == one second) so ten injected
+zero-frames model the ~10s threshold without a slow test.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from rigplane.audio.backend import AudioDeviceId, AudioDeviceInfo, FakeAudioBackend
+from rigplane.audio.usb_driver import UsbAudioDriver
+
+_LOGGER_NAME = "rigplane.audio.usb_driver"
+_SILENT_FRAME = b"\x00" * 1920
+_LOUD_FRAME = b"\x11\x22" * 960
+
+
+def _fake_devices() -> list[AudioDeviceInfo]:
+    return [
+        AudioDeviceInfo(
+            id=AudioDeviceId(1),
+            name="USB Audio CODEC",
+            input_channels=1,
+            output_channels=1,
+            default_samplerate=48_000,
+            is_default_input=True,
+            is_default_output=True,
+        ),
+    ]
+
+
+def _make_driver() -> tuple[UsbAudioDriver, FakeAudioBackend]:
+    backend = FakeAudioBackend(_fake_devices())
+    driver = UsbAudioDriver(backend=backend)
+    return driver, backend
+
+
+def _warning_records(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
+    return [
+        r
+        for r in caplog.records
+        if r.name == _LOGGER_NAME and r.levelno == logging.WARNING
+    ]
+
+
+def _info_records(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
+    return [
+        r
+        for r in caplog.records
+        if r.name == _LOGGER_NAME
+        and r.levelno == logging.INFO
+        and "RX audio signal detected" in r.getMessage()
+    ]
+
+
+@pytest.mark.asyncio
+async def test_silence_watchdog_warns_once_after_threshold(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """(a) N seconds of zero frames -> exactly one warning."""
+    driver, backend = _make_driver()
+    await driver.start_rx(lambda _frame: None, frame_ms=1000)
+    stream = backend.rx_streams[0]
+
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        for _ in range(10):
+            stream.inject_frame(_SILENT_FRAME)
+
+    warnings = _warning_records(caplog)
+    assert len(warnings) == 1
+    assert "digital silence" in warnings[0].getMessage()
+    assert "Microphone" in warnings[0].getMessage()
+
+
+@pytest.mark.asyncio
+async def test_silence_watchdog_does_not_repeat_while_still_silent(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """(b) continued zeros after the threshold -> no repeat warning."""
+    driver, backend = _make_driver()
+    await driver.start_rx(lambda _frame: None, frame_ms=1000)
+    stream = backend.rx_streams[0]
+
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        for _ in range(30):
+            stream.inject_frame(_SILENT_FRAME)
+
+    assert len(_warning_records(caplog)) == 1
+
+
+@pytest.mark.asyncio
+async def test_silence_watchdog_recovers_and_rearms(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """(c) a non-zero frame after warning -> recovery INFO + re-arm."""
+    driver, backend = _make_driver()
+    await driver.start_rx(lambda _frame: None, frame_ms=1000)
+    stream = backend.rx_streams[0]
+
+    with caplog.at_level(logging.INFO, logger=_LOGGER_NAME):
+        for _ in range(10):
+            stream.inject_frame(_SILENT_FRAME)
+        assert len(_warning_records(caplog)) == 1
+
+        stream.inject_frame(_LOUD_FRAME)
+        assert len(_info_records(caplog)) == 1
+
+        # Re-armed: another full silent stretch warns again.
+        for _ in range(10):
+            stream.inject_frame(_SILENT_FRAME)
+
+    assert len(_warning_records(caplog)) == 2
+    assert len(_info_records(caplog)) == 1
+
+
+@pytest.mark.asyncio
+async def test_silence_watchdog_silent_on_normal_audio(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """(d) normal (non-zero) audio from the start -> no warning."""
+    driver, backend = _make_driver()
+    await driver.start_rx(lambda _frame: None, frame_ms=1000)
+    stream = backend.rx_streams[0]
+
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        for _ in range(30):
+            stream.inject_frame(_LOUD_FRAME)
+
+    assert len(_warning_records(caplog)) == 0
+
+
+@pytest.mark.asyncio
+async def test_silence_watchdog_delivers_every_frame_unchanged() -> None:
+    """No behavior change to frame delivery itself: callback sees each frame."""
+    driver, backend = _make_driver()
+    received: list[bytes] = []
+    await driver.start_rx(received.append, frame_ms=1000)
+    stream = backend.rx_streams[0]
+
+    stream.inject_frame(_SILENT_FRAME)
+    stream.inject_frame(_LOUD_FRAME)
+
+    assert received == [_SILENT_FRAME, _LOUD_FRAME]


### PR DESCRIPTION
## Summary

- A bench host's launching context lacked OS microphone permission; macOS CoreAudio delivered silent zeros for hours with no indication. The RX capture stream opened fine and frames kept flowing, but every sample was exactly 0 — indistinguishable from a genuinely quiet receiver without deliberately checking.
- `UsbAudioDriver.start_rx` now wraps the delivered callback with a cheap, counter-based all-zero-frame watchdog: after ~10 seconds of unbroken bit-exact silence it logs **one** WARNING naming the likely cause (missing OS microphone permission on macOS, or the radio's USB audio output being off), then logs **one** INFO on recovery and re-arms for the next silent stretch. No periodic spam, no new timers (frame-counter based), no change to frame delivery, keep-alive, or the TX path.

## Fix description

- New `_is_silent_frame()` helper in `src/rigplane/audio/usb_driver.py`: a single `bytes == bytes(len(...))` memcmp, no per-sample Python loop.
- New `UsbAudioDriver._silence_watchdog()`: wraps the caller's RX callback, tracks consecutive all-zero frames against a threshold derived from `frame_ms` (~10s), warns once, and resets/logs INFO on the first non-zero frame.
- Wired in at the single existing RX-capture chokepoint (`self._rx_stream.start(...)` in `start_rx`), the same path the existing `usb-audio: opening RX capture` / `usb-audio: RX capture running` logs already cover.
- Net production diff: `src/rigplane/audio/usb_driver.py` +49/-1 lines (48 net).

## Test evidence

New file `tests/test_usb_audio_rx_silence_watchdog_mor1436.py`, TDD RED → GREEN:

- RED (pre-implementation, `git stash` of the production change): 3 of 5 new tests failed as expected (no warning/recovery logging existed yet); the 2 tests that don't depend on the new logging (no-warning-on-loud-audio, delivery-unchanged) passed trivially.
- GREEN (implementation restored): all 5 new tests pass —
  (a) ~10s of zero frames → exactly one WARNING containing "digital silence" and "Microphone"
  (b) continued zeros past the threshold → no repeat warning
  (c) a non-zero frame after warning → one recovery INFO ("RX audio signal detected") + re-arm (a second silent stretch warns again)
  (d) normal (non-zero) audio from the start → no warning
  - plus a delivery-invariance check: the wrapped callback still receives every frame unchanged.

## Gates (all run once, no retry-to-green)

- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` → 9012 passed, 12 skipped, 5 deselected, 11 xfailed, 1 xpassed
- `uv run mypy src/` → 13 pre-existing errors in 4 unrelated files, 0 in `usb_driver.py` (delta 0)
- `uv run ruff check src/ tests/` → all checks passed
- `uv run ruff format --check src/ tests/` → 654 files already formatted
- `uv run lint-imports` → 5 contracts kept, 0 broken

## Linear

https://linear.app/morozsm/issue/MOR-1436

---

Independent verifier review pending — do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)