### PR TITLE
fix: treat unobserved powerOn as unknown, not powered-off (MOR-1439)

### DIFF
--- a/frontend/src/lib/runtime/adapters/__tests__/mor1428-ic7300-conformance.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mor1428-ic7300-conformance.isolated.test.ts
@@ -135,6 +135,7 @@ import {
   dispatchKeyboardRadioAction,
 } from '../../commands/panel-commands';
 import { getCommandLifecycles, resetCommandLifecycle } from '$lib/stores/commands.svelte';
+import { isFieldAvailable } from '$lib/state/field-status';
 import { validateRadioViewModel } from '../../../../semantic/radio-view-model';
 import { toRadioViewModel } from '../radio-view-model-adapter';
 import { toSpectrumAuthority } from '../scope-adapter';
@@ -202,6 +203,19 @@ describe('IC-7300 fixture — real toRadioViewModel/toSpectrumAuthority (MOR-142
     // active-receiver readout and dual-watch toggle stay hidden.
     const hasDualReceiver = (IC7300_CAPABILITIES.receivers ?? 1) > 1;
     expect(hasDualReceiver).toBe(false);
+  });
+
+  it('carries the powerOn trap shape — raw true but never observed (MOR-1439)', () => {
+    // Confirms the fixture actually exercises the MOR-1439 bug: like `active`
+    // above, the IC-7300's serial link never confirms powerstat, so
+    // `fieldStatus.powerOn` reads observed:false/availability:'missing' even
+    // though the raw top-level `powerOn` happens to read `true` here. Ingestion
+    // (radio.svelte.ts) must gate on this field-status entry via
+    // `isFieldAvailable`, not trust the raw value — see
+    // `stores/__tests__/radio.test.ts` for the ingestion-level RED/GREEN pins.
+    expect(IC7300_STATE.powerOn).toBe(true);
+    expect(IC7300_STATE.fieldStatus?.powerOn?.observed).toBe(false);
+    expect(isFieldAvailable(IC7300_STATE, 'powerOn')).toBe(false);
   });
 });
 

--- a/frontend/src/lib/stores/__tests__/radio.test.ts
+++ b/frontend/src/lib/stores/__tests__/radio.test.ts
@@ -698,4 +698,90 @@ describe('radio store', () => {
     expect(store.getMainReceiver()?.freqHz).toBe(14100000);
     expect(store.getFrequency()).toBe(14100000);
   });
+
+  // --- radioPowerOn honesty (MOR-1439) ---
+  //
+  // The IC-7300's serial CI-V link never reports powerstat (structural, like
+  // `active` before MOR-1418/1421/1423 — see the ic7300-profile fixture
+  // header). The live stand's captured `/api/v1/state` carries raw
+  // `powerOn: true` with `fieldStatus.powerOn` at `observed: false` /
+  // `availability: 'missing'`: an UNCONFIRMED value, not a fact. Trusting the
+  // raw boolean regardless of observedness let a never-updated default (or a
+  // stale optimistic value) collapse into a confident true/false the UI then
+  // rendered as certainty — including StatusBar's forced powered-off
+  // presentation on `radioPowerOn === false`. An unobserved powerOn must
+  // resolve to `null` ("unknown") in both directions; only a genuinely
+  // observed reading may resolve to a definite boolean.
+
+  it('collapses an unobserved raw powerOn=true to unknown — live IC-7300 trap shape (MOR-1439)', async () => {
+    const connection = await import('../connection.svelte');
+    store.setRadioState(makeState({
+      revision: 1,
+      powerOn: true,
+      fieldStatus: {
+        powerOn: {
+          storePath: 'global.tx_state.power_on',
+          observed: false,
+          freshness: 'unknown',
+          availability: 'missing',
+        },
+      },
+    }));
+
+    expect(connection.getRadioPowerOn()).toBeNull();
+  });
+
+  it('collapses an unobserved raw powerOn=false to unknown, never forced-off (MOR-1439)', async () => {
+    const connection = await import('../connection.svelte');
+    store.setRadioState(makeState({
+      revision: 1,
+      powerOn: false,
+      fieldStatus: {
+        powerOn: {
+          storePath: 'global.tx_state.power_on',
+          observed: false,
+          freshness: 'unknown',
+          availability: 'missing',
+        },
+      },
+    }));
+
+    expect(connection.getRadioPowerOn()).toBeNull();
+  });
+
+  it('still forces a definite false on a genuinely OBSERVED powerOn=false (regression)', async () => {
+    const connection = await import('../connection.svelte');
+    store.setRadioState(makeState({
+      revision: 1,
+      powerOn: false,
+      fieldStatus: {
+        powerOn: {
+          storePath: 'global.tx_state.power_on',
+          observed: true,
+          freshness: 'fresh',
+          availability: 'available',
+        },
+      },
+    }));
+
+    expect(connection.getRadioPowerOn()).toBe(false);
+  });
+
+  it('passes through a genuinely OBSERVED powerOn=true (normal case)', async () => {
+    const connection = await import('../connection.svelte');
+    store.setRadioState(makeState({
+      revision: 1,
+      powerOn: true,
+      fieldStatus: {
+        powerOn: {
+          storePath: 'global.tx_state.power_on',
+          observed: true,
+          freshness: 'fresh',
+          availability: 'available',
+        },
+      },
+    }));
+
+    expect(connection.getRadioPowerOn()).toBe(true);
+  });
 });

--- a/frontend/src/lib/stores/radio.svelte.ts
+++ b/frontend/src/lib/stores/radio.svelte.ts
@@ -282,9 +282,14 @@ export function setRadioState(state: ServerState): boolean {
     lastHealthRevision = nextHealthRevision;
     radio.current = nextState;
     notifyRadioStateSubscribers();
-    // Sync power status to connection store
+    // Sync power status to connection store. MOR-1439: the IC-7300's serial
+    // CI-V link never confirms powerstat (structural, like `active` before
+    // MOR-1418/1421/1423) — an unobserved raw value is not a fact and must
+    // collapse to `null` ("unknown"), never a confident true/false, or the UI
+    // renders certainty (including StatusBar's forced powered-off
+    // presentation) for a reading the radio never actually gave.
     if (nextState.powerOn !== undefined) {
-      setRadioPowerOn(nextState.powerOn);
+      setRadioPowerOn(isFieldAvailable(nextState, 'powerOn') ? nextState.powerOn : null);
     }
     // Sync connection readiness fields
     if (nextState.connection) {


### PR DESCRIPTION
## Summary

- Live-traced bug: the operator's UI showed the full powered-off presentation (both status indicators red, tooltip "Radio ↔ Server: disconnected") while the radio was connected, tuning, and audibly receiving.
- Root cause: the IC-7300's serial CI-V link never confirms powerstat (structural, the same gap `active` had before the MOR-1418/1421/1423 fix wave). The live stand's captured state carries raw `powerOn: true` while `fieldStatus.powerOn` reads `observed: false` / `availability: 'missing'` — an unconfirmed value, not a fact.
- Collapse point: `frontend/src/lib/stores/radio.svelte.ts` (state-ingestion `setRadioState`, power-sync block) trusted the raw `powerOn` boolean unconditionally, regardless of observedness. An unobserved value collapsed into a confident `true`/`false` that `StatusBar.svelte`'s `isPoweredOff = radioPowerOn === false` then rendered as certainty.
- Fix: gate the sync on `isFieldAvailable(state, 'powerOn')`. An unobserved raw value now resolves to `null` ("unknown") in both directions, never a fabricated boolean. `StatusBar.svelte` and `AppGlobalHost.svelte` already treat `radioPowerOn` tri-state honestly (`=== false` only fires on a definite observed reading, and the power-button tooltip already has an "unknown" branch) — no changes needed there, the collapse was solely in the producer.

## Test plan

- [x] RED first: added ingestion-level tests in `frontend/src/lib/stores/__tests__/radio.test.ts` for the trap shape in both directions (raw `true`/unobserved, raw `false`/unobserved) plus regression pins (observed `false` still forces off, observed `true` passes through) — confirmed failing (2 failed) before the fix.
- [x] Extended the MOR-1428 IC-7300 conformance suite (`mor1428-ic7300-conformance.isolated.test.ts`) with a fixture-shape assertion confirming the live-captured `ic7300-state.json` already carries the trap shape (`powerOn: true`, `fieldStatus.powerOn.observed: false`) — no fixture changes needed, the committed capture already matches live.
- [x] GREEN after the fix: `npx vitest run` on the two touched files — 65/65 passed.
- [x] `npm test` — 6631/6631 passed, first run.
- [x] `npm run lint` — zero violations, first run.
- [x] `npm run check` — 0 errors, 0 warnings, first run.
- [x] Net production diff: 7 lines (mostly comment) in `radio.svelte.ts` — well under the 200 LOC budget.

Linear: https://linear.app/morozsm/issue/MOR-1439

Independent verifier review pending — do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)