### PR TITLE
fix: detect serial link death, propagate honestly, and stop doomed traffic (MOR-1440)

### DIFF
--- a/src/rigplane/backends/_icom_serial_base.py
+++ b/src/rigplane/backends/_icom_serial_base.py
@@ -90,6 +90,14 @@ class _IcomSerialRadioBase(CoreRadio):
     # retried every _SERIAL_WATCHDOG_RETRY_S and flooded the log with full
     # tracebacks twice a second while the port was gone.
     _SERIAL_WATCHDOG_RETRY_MAX_S = 5.0
+    # Consecutive CI-V command timeouts (no ACK/response within
+    # ``_civ_get_timeout``) that force the connection state machine into
+    # link-down. The raw serial health flag (``SerialCivLink.healthy``) only
+    # flips when a read/write syscall raises; a USB-serial adapter that
+    # vanishes without the OS surfacing an error leaves it stuck healthy
+    # forever (MOR-1440 bench evidence). CI-V timeouts on the existing
+    # keep-alive cadence are the reliable probe.
+    _SERIAL_LINK_DOWN_TIMEOUT_THRESHOLD = 3
 
     def __init__(
         self,
@@ -165,6 +173,12 @@ class _IcomSerialRadioBase(CoreRadio):
             backend=None,  # default PortAudioBackend
         )
         self._serial_audio_seq = 0
+        # MOR-1440 link-down detection: consecutive-timeout evidence tracked
+        # against the CI-V request tracker's lifetime counters (see
+        # ``_serial_civ_timeout_evidence_crossed_threshold``).
+        self._civ_consecutive_timeouts = 0
+        self._civ_watchdog_last_seen_timeouts = 0
+        self._civ_watchdog_last_seen_rx_packets = 0
 
     # ------------------------------------------------------------------
     # Backend identity
@@ -724,6 +738,12 @@ class _IcomSerialRadioBase(CoreRadio):
                     RadioConnectionState.RECONNECTING,
                 ):
                     continue
+                if (
+                    self._conn_state == RadioConnectionState.CONNECTED
+                    and self._serial_civ_timeout_evidence_crossed_threshold()
+                ):
+                    await self._declare_serial_link_down()
+                    continue
                 if self._serial_session.ready:
                     self._civ_stream_ready = True
                     self._civ_recovering = False
@@ -778,6 +798,61 @@ class _IcomSerialRadioBase(CoreRadio):
         if delay > cap:
             return cap
         return delay
+
+    def _serial_civ_timeout_evidence_crossed_threshold(self) -> bool:
+        """Track consecutive CI-V command timeouts as live-link evidence.
+
+        Deliberately does *not* key off ``_last_civ_data_received``: this
+        watchdog's own "still ready" fast path re-stamps that timestamp every
+        tick purely because the raw health flag reads true (see the branch
+        below), which would mask a silently-dead link exactly like the raw
+        flag does. ``rx_packet_count`` only advances when a frame was
+        actually parsed off the wire (``SerialCivTransport.receive_packet``),
+        so it is unaffected by that stamp and safe to use as the "real
+        traffic happened" reset signal.
+        """
+        total = self._civ_request_tracker.timeout_count
+        rx_count = getattr(self._civ_transport, "rx_packet_count", None)
+        rx_advanced = isinstance(rx_count, int) and rx_count > (
+            self._civ_watchdog_last_seen_rx_packets
+        )
+        if rx_advanced:
+            self._civ_consecutive_timeouts = 0
+        elif total > self._civ_watchdog_last_seen_timeouts:
+            self._civ_consecutive_timeouts += (
+                total - self._civ_watchdog_last_seen_timeouts
+            )
+        self._civ_watchdog_last_seen_timeouts = total
+        if isinstance(rx_count, int):
+            self._civ_watchdog_last_seen_rx_packets = rx_count
+        return (
+            self._civ_consecutive_timeouts >= self._SERIAL_LINK_DOWN_TIMEOUT_THRESHOLD
+        )
+
+    async def _declare_serial_link_down(self) -> None:
+        """Force the state machine to link-down on consecutive CI-V timeouts.
+
+        Mirrors ``soft_disconnect``'s ordering: park managed TX first (a
+        WRITE_ON granted on the strength of a provider still marked ready
+        must not land on a dead wire), then stop audio, then tear down the
+        raw serial link so the next watchdog tick's ``ready`` check reads
+        honest state instead of a stale healthy flag that would otherwise
+        undo this transition.
+        """
+        logger.error(
+            "rigplane (%s): serial link-down on %s — %d consecutive CI-V "
+            "command timeout(s) with no response; marking connection reconnecting",
+            self.model,
+            self._serial_device,
+            self._civ_consecutive_timeouts,
+        )
+        self._conn_state = RadioConnectionState.RECONNECTING
+        self._civ_stream_ready = False
+        self._civ_recovering = True
+        self._civ_consecutive_timeouts = 0
+        await self._park_managed_tx()
+        await self._stop_serial_audio_driver()
+        await self._serial_session.disconnect()
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/src/rigplane/backends/_icom_serial_base.py
+++ b/src/rigplane/backends/_icom_serial_base.py
@@ -179,6 +179,14 @@ class _IcomSerialRadioBase(CoreRadio):
         self._civ_consecutive_timeouts = 0
         self._civ_watchdog_last_seen_timeouts = 0
         self._civ_watchdog_last_seen_rx_packets = 0
+        # MOR-1440 review round 2: identity of the transport the above two
+        # baselines were last measured against. Every (re)connect installs a
+        # *brand-new* ``SerialCivTransport`` (see
+        # ``SerialSessionDriver.connect``), so ``rx_packet_count`` restarts at
+        # 0 while these baselines would otherwise keep a stale high-water
+        # mark from the outgoing transport — see
+        # ``_civ_watchdog_rebaseline``.
+        self._civ_watchdog_last_transport: object | None = None
 
     # ------------------------------------------------------------------
     # Backend identity
@@ -375,6 +383,14 @@ class _IcomSerialRadioBase(CoreRadio):
         self._conn_state = RadioConnectionState.CONNECTED
         self._civ_stream_ready = self._serial_session.ready
         self._civ_recovering = not self._civ_stream_ready
+        # MOR-1440 review round 2 (B1 item 2): this is the RECONNECTING ->
+        # CONNECTED transition. Re-baseline the link-death detector here,
+        # explicitly, rather than waiting for the next watchdog tick's
+        # transport-identity check to notice: any CI-V command timeouts
+        # banked while the evidence check was short-circuited during
+        # RECONNECTING (see ``_serial_civ_watchdog_loop``) must not be
+        # credited against the link that just recovered.
+        self._civ_watchdog_rebaseline()
         if self._on_reconnect is not None:
             try:
                 self._on_reconnect()
@@ -799,6 +815,38 @@ class _IcomSerialRadioBase(CoreRadio):
             return cap
         return delay
 
+    def _civ_watchdog_rebaseline(self) -> None:
+        """Reset link-death detector baselines against current state.
+
+        MOR-1440 review round 2 (B1): every (re)connect installs a
+        brand-new ``SerialCivTransport`` (``SerialSessionDriver.connect``
+        always constructs one, even on reconnect), so its
+        ``rx_packet_count`` restarts at 0 — a stale high-water mark from the
+        outgoing transport would otherwise make the "real traffic happened"
+        reset signal read false by construction right when it matters most.
+        Likewise, ``_civ_request_tracker.timeout_count`` is a lifetime
+        counter never reset on reconnect, so a frozen
+        ``_civ_watchdog_last_seen_timeouts`` baseline (left stale by the
+        RECONNECTING short-circuit in ``_serial_civ_watchdog_loop``) would
+        otherwise credit an entire outage's worth of banked timeouts as one
+        lump delta against the link that just recovered.
+
+        Called from two places: (a) lazily, inside
+        :meth:`_serial_civ_timeout_evidence_crossed_threshold`, whenever the
+        transport identity has changed since the last tick — a defensive net
+        that catches any path that swaps ``_civ_transport`` — and (b)
+        explicitly at the end of :meth:`soft_reconnect`, the actual
+        RECONNECTING -> CONNECTED transition, so the outage's banked
+        timeouts never survive to the first post-recovery evidence check.
+        """
+        rx_count = getattr(self._civ_transport, "rx_packet_count", None)
+        self._civ_watchdog_last_seen_rx_packets = (
+            rx_count if isinstance(rx_count, int) else 0
+        )
+        self._civ_watchdog_last_seen_timeouts = self._civ_request_tracker.timeout_count
+        self._civ_consecutive_timeouts = 0
+        self._civ_watchdog_last_transport = self._civ_transport
+
     def _serial_civ_timeout_evidence_crossed_threshold(self) -> bool:
         """Track consecutive CI-V command timeouts as live-link evidence.
 
@@ -810,7 +858,24 @@ class _IcomSerialRadioBase(CoreRadio):
         actually parsed off the wire (``SerialCivTransport.receive_packet``),
         so it is unaffected by that stamp and safe to use as the "real
         traffic happened" reset signal.
+
+        Shared-bus blind spot: on a shared CI-V bus (multiple radios/
+        controllers on the same serial line), ``rx_packet_count`` advances
+        for *any* frame this transport parses off the wire, including a
+        transceive broadcast from another device — not only responses to
+        our own commands. That is an acceptable false "still alive" signal
+        (traffic proves the physical bus is up), just not scoped to "this
+        radio is answering us" as tightly as it may look. Not applicable to
+        direct USB-CI-V connections (e.g. IC-7300), which have no shared bus.
+
+        MOR-1440 review round 2 (B1): a (re)connect can swap in a brand-new
+        transport between ticks. If it has, re-baseline against it instead
+        of judging this tick — see :meth:`_civ_watchdog_rebaseline`.
         """
+        if self._civ_transport is not self._civ_watchdog_last_transport:
+            self._civ_watchdog_rebaseline()
+            return False
+
         total = self._civ_request_tracker.timeout_count
         rx_count = getattr(self._civ_transport, "rx_packet_count", None)
         rx_advanced = isinstance(rx_count, int) and rx_count > (
@@ -832,12 +897,20 @@ class _IcomSerialRadioBase(CoreRadio):
     async def _declare_serial_link_down(self) -> None:
         """Force the state machine to link-down on consecutive CI-V timeouts.
 
-        Mirrors ``soft_disconnect``'s ordering: park managed TX first (a
-        WRITE_ON granted on the strength of a provider still marked ready
-        must not land on a dead wire), then stop audio, then tear down the
-        raw serial link so the next watchdog tick's ``ready`` check reads
-        honest state instead of a stale healthy flag that would otherwise
-        undo this transition.
+        Orders the *safety-critical* part of ``soft_disconnect``'s teardown
+        the same way it does: park managed TX first (a WRITE_ON granted on
+        the strength of a provider still marked ready must not land on a
+        dead wire), then stop audio, then tear down the raw serial link so
+        the next watchdog tick's ``ready`` check reads honest state instead
+        of a stale healthy flag that would otherwise undo this transition.
+
+        Deliberately does *not* mirror the rest of ``soft_disconnect``: it
+        leaves the CI-V worker and RX pump running and does not advance the
+        CI-V generation. The watchdog needs both alive to drive recovery
+        (``soft_reconnect`` — called from ``_serial_civ_watchdog_loop`` right
+        after this — is what tears them down and rebuilds them for the new
+        transport); a full disconnect-style teardown here would leave
+        nothing to restart the recovery loop.
         """
         logger.error(
             "rigplane (%s): serial link-down on %s — %d consecutive CI-V "

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -1294,6 +1294,17 @@ class RadioPoller:
                     )
                     continue
                 except Exception:
+                    # MOR-1440: a dead serial link surfaces here as a bare
+                    # TimeoutError (CI-V transport recovery-wait gate), not
+                    # ConnectionError — back off same as the branch above
+                    # instead of hammering a doomed wire every poll cycle.
+                    if not bool(getattr(self._radio, "connected", True)):
+                        _backoff = min(_backoff + 0.5, _MAX_BACKOFF)
+                        logger.info(
+                            "radio-poller: radio disconnected, backing off %.1fs",
+                            _backoff,
+                        )
+                        continue
                     logger.debug("radio-poller: query error", exc_info=True)
 
                 # 2b. data_mode changed (web command or front panel) => refetch

--- a/tests/test_icom7610_serial_radio.py
+++ b/tests/test_icom7610_serial_radio.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from types import SimpleNamespace
 
 import pytest
 
@@ -515,6 +516,191 @@ async def test_serial_link_down_while_ptt_active_parks_managed_tx_safely() -> No
     )
 
     assert managed_tx.ready_calls == [False]
+
+    await radio.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_serial_civ_watchdog_rebaselines_after_transport_swap_with_banked_timeouts() -> (
+    None
+):
+    """MOR-1440 review round 2 (B1 / probe a): stale baselines must not
+    survive a transport swap.
+
+    Reproduces the verifier's fake-transport probe directly against the
+    detector. Every (re)connect installs a *brand-new* ``SerialCivTransport``
+    whose ``rx_packet_count`` restarts at 0 (``SerialSessionDriver.connect``
+    always constructs a fresh one), while ``_civ_request_tracker.timeout_count``
+    is a lifetime counter that survives the swap untouched. Without
+    re-baselining, a transport that just delivered genuine frames on a
+    healthy, recovered link can still be declared dead from timeout evidence
+    banked against the *old* transport/outage.
+    """
+    link = _FakeSerialCivLink()
+    radio = Icom7610SerialRadio(device="/dev/ttyUSB0", civ_link=link)
+    await radio.connect()
+
+    old_transport = radio._civ_transport
+    threshold = radio._SERIAL_LINK_DOWN_TIMEOUT_THRESHOLD
+
+    # Simulate having already baselined against the OLD (pre-outage)
+    # transport, which delivered enough real traffic to build a
+    # rx_packet_count high-water mark well above what a brand-new transport
+    # starts at.
+    radio._civ_watchdog_last_transport = old_transport
+    radio._civ_watchdog_last_seen_rx_packets = 50
+    radio._civ_watchdog_last_seen_timeouts = radio._civ_request_tracker.timeout_count
+    radio._civ_consecutive_timeouts = 0
+
+    # Outage: `threshold` CI-V command timeouts land on the tracker while the
+    # watchdog is RECONNECTING. Its own evidence check short-circuits for any
+    # state other than CONNECTED (see the loop in
+    # ``_serial_civ_watchdog_loop``), so these are unconsumed until the next
+    # CONNECTED tick -- e.g. a background poll already in flight when the
+    # outage started, timing out mid-outage.
+    for _ in range(threshold):
+        radio._civ_request_tracker.note_timeout()
+
+    # Reconnect installs a brand-new transport (as SerialSessionDriver.connect()
+    # always does) that has already delivered real, fresh frames on the
+    # recovered link.
+    fresh_transport = SimpleNamespace(rx_packet_count=5)
+    radio._civ_transport = fresh_transport  # type: ignore[assignment]
+
+    crossed = radio._serial_civ_timeout_evidence_crossed_threshold()
+
+    assert crossed is False, (
+        "a freshly (re)connected transport that just delivered genuine "
+        "frames must not be declared dead from timeouts banked against the "
+        "OLD transport/outage"
+    )
+    assert radio._civ_consecutive_timeouts == 0
+    assert radio._civ_watchdog_last_transport is fresh_transport
+    assert radio._civ_watchdog_last_seen_rx_packets == 5
+    assert (
+        radio._civ_watchdog_last_seen_timeouts
+        == radio._civ_request_tracker.timeout_count
+    )
+
+    # Restore a real transport before teardown: the background CI-V RX pump
+    # (started by ``connect()``) and ``disconnect()`` both call real methods
+    # on ``_civ_transport`` that the bare stub above does not implement.
+    radio._civ_transport = old_transport  # type: ignore[assignment]
+    await radio.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_serial_soft_reconnect_rebaselines_watchdog_state() -> None:
+    """MOR-1440 review round 2 (B1 item 2): the RECONNECTING -> CONNECTED
+    transition in ``soft_reconnect`` must re-baseline the detector so an
+    outage's banked timeouts are never credited to the just-recovered link.
+    """
+    link = _FakeSerialCivLink()
+    radio = Icom7610SerialRadio(device="/dev/ttyUSB0", civ_link=link)
+    await radio.connect()
+    await radio._stop_civ_data_watchdog()  # deterministic: no background tick races.
+
+    # Simulate an outage that banked timeouts while short-circuited (state
+    # RECONNECTING, per ``_serial_civ_watchdog_loop``): frozen baseline vs. a
+    # tracker total that kept climbing underneath it.
+    radio._civ_watchdog_last_seen_timeouts = radio._civ_request_tracker.timeout_count
+    for _ in range(5):
+        radio._civ_request_tracker.note_timeout()
+    radio._civ_consecutive_timeouts = 2
+    radio._conn_state = RadioConnectionState.RECONNECTING
+    await radio._serial_session.disconnect()
+
+    await radio.soft_reconnect()
+
+    assert radio.conn_state == RadioConnectionState.CONNECTED
+    assert radio._civ_consecutive_timeouts == 0
+    assert (
+        radio._civ_watchdog_last_seen_timeouts
+        == radio._civ_request_tracker.timeout_count
+    )
+    assert getattr(radio, "_civ_watchdog_last_transport", None) is radio._civ_transport
+
+    await radio.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_serial_link_down_settles_after_successful_reconnect_same_node(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """MOR-1440 review round 2 (B3 / probe b): off -> on, SAME node, must
+    settle to exactly ONE link-down declaration.
+
+    The existing 4 link-down tests all exercise ``fail_connect_calls=set(range(2,
+    100))`` -- reconnect never succeeds -- which hid this defect entirely.
+    Here the first reconnect attempt fails once (simulating the node still
+    being briefly gone) and the second succeeds on the SAME node
+    (``fail_connect_calls={2}``), widening the RECONNECTING window enough to
+    deterministically confirm it via polling. While genuinely RECONNECTING,
+    one more CI-V command times out -- representing e.g. a background poll
+    that was already in flight when the outage started -- landing while the
+    watchdog's evidence check is short-circuited for any state other than
+    CONNECTED (see ``_serial_civ_watchdog_loop``), so it is banked,
+    unconsumed, until the next CONNECTED tick. Pre-fix, that banked evidence
+    gets credited as a lump against the just-recovered, healthy link on the
+    very first evidence-check tick after reconnect (see
+    ``_serial_civ_timeout_evidence_crossed_threshold``): a second, SPURIOUS
+    link-down declaration on a link that actually recovered. The commander
+    worker executes CI-V commands strictly one at a time, so this cannot be
+    reproduced with genuinely concurrent in-flight sends -- direct
+    ``note_timeout()`` calls are the honest way to model "another in-flight
+    request timed out during the blind window" deterministically.
+    """
+    import logging
+
+    link = _FakeSerialCivLink(fail_connect_calls={2})
+    radio = Icom7610SerialRadio(device="/dev/ttyUSB0", civ_link=link)
+    radio._civ_min_interval = 0.001
+    radio._civ_get_timeout = 0.02
+    radio._SERIAL_WATCHDOG_INTERVAL_S = 0.005
+    radio._SERIAL_WATCHDOG_RETRY_S = 0.1
+    threshold = radio._SERIAL_LINK_DOWN_TIMEOUT_THRESHOLD
+
+    await radio.connect()
+    assert radio.radio_ready is True
+
+    frame = build_civ_frame(CONTROLLER_ADDR, IC_7610_ADDR, _CMD_FREQ_GET)
+
+    with caplog.at_level(logging.ERROR, logger="rigplane.backends._icom_serial_base"):
+        for _ in range(threshold):
+            with pytest.raises(RigplaneTimeoutError):
+                await radio._send_civ_raw(frame, wait_response=True)
+
+        assert await _wait_until(
+            lambda: radio.conn_state == RadioConnectionState.RECONNECTING,
+            timeout_s=2.0,
+        )
+
+        # Bank `threshold` timeouts while genuinely RECONNECTING (confirmed
+        # above) -- synchronous, no `await` in between, so nothing else can
+        # run and move the state machine before these land.
+        for _ in range(threshold):
+            radio._civ_request_tracker.note_timeout()
+
+        assert await _wait_until(
+            lambda: radio.conn_state == RadioConnectionState.CONNECTED,
+            timeout_s=2.0,
+        )
+
+        # A few more watchdog ticks to let the evidence check evaluate the
+        # now-idle, recovered link.
+        await asyncio.sleep(radio._SERIAL_WATCHDOG_INTERVAL_S * 10)
+
+    error_lines = [
+        r
+        for r in caplog.records
+        if r.levelno >= logging.ERROR and "link-down" in r.getMessage()
+    ]
+    assert len(error_lines) == 1, (
+        f"expected exactly one link-down ERROR line across the whole "
+        f"off->on-same-node cycle, got {len(error_lines)}"
+    )
+    assert radio.conn_state == RadioConnectionState.CONNECTED
+    assert radio.radio_ready is True
 
     await radio.disconnect()
 

--- a/tests/test_icom7610_serial_radio.py
+++ b/tests/test_icom7610_serial_radio.py
@@ -359,6 +359,166 @@ async def test_serial_disconnect_cleans_watchdog_when_already_disconnected() -> 
     assert getattr(radio, "_civ_data_watchdog_task", None) is None
 
 
+class _FakeManagedTxRuntime:
+    """Minimal stand-in for the managed-TX supervisor (real async signature)."""
+
+    def __init__(self) -> None:
+        self.target_id = "fake-managed-tx"
+        self.ready_calls: list[bool] = []
+
+    async def set_provider_ready(self, *, ready: bool) -> None:
+        self.ready_calls.append(ready)
+
+
+@pytest.mark.asyncio
+async def test_serial_link_down_detected_when_healthy_flag_stays_stuck_true(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """MOR-1440: a vanished USB-serial device that never raises OSError/EOF.
+
+    ``SerialCivLink.healthy`` only flips false on a read/write exception. A
+    dead adapter that silently stops answering (observed on the bench) leaves
+    it stuck ``True`` forever, so the pre-existing watchdog (which only reacts
+    to that flag) never notices. Consecutive CI-V command timeouts must force
+    the state machine to link-down regardless of what the raw flag reports.
+    """
+    import logging
+
+    # No responses ever queued -> every awaited command times out. Reconnect
+    # attempts also fail (device never returns on the same path) so the
+    # detected link-down state doesn't self-heal mid-assertion.
+    link = _FakeSerialCivLink(fail_connect_calls=set(range(2, 100)))
+    radio = Icom7610SerialRadio(device="/dev/ttyUSB0", civ_link=link)
+    radio._civ_min_interval = 0.001
+    radio._civ_get_timeout = 0.03
+    radio._SERIAL_WATCHDOG_INTERVAL_S = 0.005
+
+    await radio.connect()
+    assert radio.radio_ready is True
+
+    frame = build_civ_frame(CONTROLLER_ADDR, IC_7610_ADDR, _CMD_FREQ_GET)
+
+    with caplog.at_level(logging.ERROR, logger="rigplane.backends._icom_serial_base"):
+        # First timeout alone must not trip anything, and the raw flag must
+        # still report healthy — this is exactly the evidence the low-level
+        # watchdog (keyed off that flag) cannot see on its own.
+        with pytest.raises(RigplaneTimeoutError):
+            await radio._send_civ_raw(frame, wait_response=True)
+        assert link.healthy is True
+        assert radio.conn_state == RadioConnectionState.CONNECTED
+
+        for _ in range(radio._SERIAL_LINK_DOWN_TIMEOUT_THRESHOLD - 1):
+            with pytest.raises(RigplaneTimeoutError):
+                await radio._send_civ_raw(frame, wait_response=True)
+
+        assert await _wait_until(
+            lambda: radio.conn_state == RadioConnectionState.RECONNECTING,
+            timeout_s=2.0,
+        )
+
+    error_lines = [
+        r
+        for r in caplog.records
+        if r.levelno >= logging.ERROR and "link-down" in r.getMessage()
+    ]
+    assert len(error_lines) == 1, (
+        f"expected exactly one link-down ERROR line, got {len(error_lines)}"
+    )
+
+    assert radio.connected is False
+    assert radio.radio_ready is False
+
+    await radio.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_serial_link_down_propagates_to_web_radio_health() -> None:
+    """MOR-1440: honest propagation — radioHealth reflects link-down, not 'connected'."""
+    from rigplane.web.runtime_helpers import classify_radio_health
+
+    link = _FakeSerialCivLink(fail_connect_calls=set(range(2, 100)))
+    radio = Icom7610SerialRadio(device="/dev/ttyUSB0", civ_link=link)
+    radio._civ_min_interval = 0.001
+    radio._civ_get_timeout = 0.03
+    radio._SERIAL_WATCHDOG_INTERVAL_S = 0.005
+    await radio.connect()
+
+    frame = build_civ_frame(CONTROLLER_ADDR, IC_7610_ADDR, _CMD_FREQ_GET)
+    for _ in range(radio._SERIAL_LINK_DOWN_TIMEOUT_THRESHOLD):
+        with pytest.raises(RigplaneTimeoutError):
+            await radio._send_civ_raw(frame, wait_response=True)
+    assert await _wait_until(
+        lambda: radio.conn_state == RadioConnectionState.RECONNECTING, timeout_s=2.0
+    )
+
+    health = classify_radio_health(radio)
+    assert health["radioLink"] != "connected"
+    assert health["radioLink"] == "reconnecting"
+
+    await radio.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_serial_link_down_stops_audio_capture() -> None:
+    """MOR-1440: audio capture must stop on link-down, same radio same USB."""
+    link = _FakeSerialCivLink(fail_connect_calls=set(range(2, 100)))
+    usb_audio = _FakeUsbAudioDriver()
+    radio = Icom7610SerialRadio(
+        device="/dev/ttyUSB0", civ_link=link, audio_driver=usb_audio
+    )
+    radio._civ_min_interval = 0.001
+    radio._civ_get_timeout = 0.03
+    radio._SERIAL_WATCHDOG_INTERVAL_S = 0.005
+    await radio.connect()
+
+    received: list[object] = []
+    await radio.start_rx(received.append)
+    assert usb_audio.rx_running is True
+
+    frame = build_civ_frame(CONTROLLER_ADDR, IC_7610_ADDR, _CMD_FREQ_GET)
+    for _ in range(radio._SERIAL_LINK_DOWN_TIMEOUT_THRESHOLD):
+        with pytest.raises(RigplaneTimeoutError):
+            await radio._send_civ_raw(frame, wait_response=True)
+    assert await _wait_until(
+        lambda: radio.conn_state == RadioConnectionState.RECONNECTING, timeout_s=2.0
+    )
+
+    assert usb_audio.rx_running is False
+
+    await radio.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_serial_link_down_while_ptt_active_parks_managed_tx_safely() -> None:
+    """MOR-1440: link-down with a TX-active session must not orphan the key.
+
+    Mirrors ``soft_disconnect``'s existing PTT-off teardown discipline: mark
+    the managed-TX provider not-ready so any lease held across the gap is
+    refused rather than granted onto a dead wire.
+    """
+    link = _FakeSerialCivLink(fail_connect_calls=set(range(2, 100)))
+    radio = Icom7610SerialRadio(device="/dev/ttyUSB0", civ_link=link)
+    radio._civ_min_interval = 0.001
+    radio._civ_get_timeout = 0.03
+    radio._SERIAL_WATCHDOG_INTERVAL_S = 0.005
+    await radio.connect()
+
+    managed_tx = _FakeManagedTxRuntime()
+    radio._managed_tx_runtime = managed_tx  # type: ignore[assignment]
+
+    frame = build_civ_frame(CONTROLLER_ADDR, IC_7610_ADDR, _CMD_FREQ_GET)
+    for _ in range(radio._SERIAL_LINK_DOWN_TIMEOUT_THRESHOLD):
+        with pytest.raises(RigplaneTimeoutError):
+            await radio._send_civ_raw(frame, wait_response=True)
+    assert await _wait_until(
+        lambda: radio.conn_state == RadioConnectionState.RECONNECTING, timeout_s=2.0
+    )
+
+    assert managed_tx.ready_calls == [False]
+
+    await radio.disconnect()
+
+
 @pytest.mark.asyncio
 async def test_serial_audio_opus_contract_uses_usb_driver_lifecycle() -> None:
     usb_audio = _FakeUsbAudioDriver()

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -1713,6 +1713,45 @@ async def test_run_backoff_and_query_error_paths() -> None:
         await poller2._run()  # noqa: SLF001
 
 
+@pytest.mark.asyncio
+async def test_run_backs_off_on_bare_timeout_when_radio_reports_disconnected(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """MOR-1440: a dead serial link surfaces as a bare exception (the CI-V
+    transport recovery-wait gate raises ``TimeoutError``, not
+    ``ConnectionError``) once the radio's own state machine already knows
+    the link is down. The poller must back off instead of silently
+    retrying a doomed wire every cycle (previously logged at DEBUG only).
+    """
+    radio = _make_radio()
+    radio.connected = False
+    poller = RadioPoller(radio, StateCache(), CommandQueue())
+
+    call_count = {"n": 0}
+
+    async def _send_query_side_effect(*_args: object, **_kwargs: object) -> None:
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise TimeoutError("CI-V transport recovery timed out")
+        # Stop the loop after observing the backoff branch once — a plain
+        # CancelledError is a BaseException, so it isn't swallowed by the
+        # generic ``except Exception`` the backoff-retry probe also runs.
+        raise asyncio.CancelledError()
+
+    poller._send_query = AsyncMock(side_effect=_send_query_side_effect)  # noqa: SLF001
+    poller._queue.wait = AsyncMock(side_effect=asyncio.CancelledError())  # noqa: SLF001
+    with (
+        patch("rigplane.web.radio_poller.asyncio.sleep", new=AsyncMock()),
+        caplog.at_level(logging.INFO, logger="rigplane.web.radio_poller"),
+    ):
+        await poller._run()  # noqa: SLF001
+
+    backoff_lines = [
+        r for r in caplog.records if "radio disconnected, backing off" in r.getMessage()
+    ]
+    assert backoff_lines, "expected a backoff log line when radio.connected is False"
+
+
 def test_start_stop_running_and_emit_helpers() -> None:
     radio = _make_radio()
     poller = RadioPoller(radio, StateCache(), CommandQueue())


### PR DESCRIPTION
## Summary

With an IC-7300 on `--backend serial`, physically powering the radio off (its USB device node vanishes, including the `/dev/cu.usbserial-*` path) produced **zero reaction**: no error line, the radio-poller kept enqueueing commands, audio capture kept counting packets from the vanished USB codec, and only scope-health noticed all-zero frames. Powering the radio back on produced no reconnect. `radioHealth.radioLink` stayed `"connected"` throughout.

## Diagnosis

The connection state machine (`RadioConnectionState`) and a serial watchdog (`_serial_civ_watchdog_loop` in `src/rigplane/backends/_icom_serial_base.py`) already exist, but the watchdog only reacts to `SerialCivLink.healthy` (`src/rigplane/backends/icom7610/drivers/serial_civ_link.py`), which flips `False` only when a `read()`/`write()` syscall raises `OSError`/`SerialException`. A USB-serial adapter that vanishes without the OS surfacing that error (a real, observed failure mode) leaves the flag stuck `True` forever — so the watchdog, and everything downstream that depends on it (`radio_ready`, `connected`, `classify_radio_health` in `src/rigplane/web/runtime_helpers.py`), never notices.

Two further gaps compounded this:

1. **No consecutive-timeout signal.** CI-V command timeouts are recorded as a lifetime total (`CivRequestTracker.timeout_count`, `src/rigplane/core/civ.py`) but nothing converts a run of unanswered commands into a link-down decision for serial. Timeouts logged only at DEBUG (`src/rigplane/runtime/_civ_rx.py:3416`, `:963`).
2. **The poller doesn't distinguish exception types.** `RadioPoller._run()` in `src/rigplane/web/radio_poller.py` only backs off on `ConnectionError`/`RadioConnectionError` (line ~1290); a dead link surfaces as a bare `TimeoutError` (from the CI-V transport recovery-wait gate, `_wait_for_civ_transport_recovery` in `_civ_rx.py`), which fell through to a silent per-cycle DEBUG log with no backoff (line ~1296-97, pre-fix).

## What this PR builds (detection + propagation)

`src/rigplane/backends/_icom_serial_base.py`:
- Tracks **consecutive CI-V command timeouts** independently of the raw health flag, using the existing ~500ms control keep-alive cadence as the probe (unweakened). Genuine RX activity is detected via `SerialCivTransport.rx_packet_count` (only advances when a frame was actually parsed off the wire) — deliberately *not* `_last_civ_data_received`, because the watchdog's own pre-existing "still ready" fast path re-stamps that timestamp every tick purely because the raw flag reads true, which would have silently defeated this detection the same way the flag itself does.
- After **3 consecutive timeouts** with no genuine response, `_declare_serial_link_down()` fires: one clear `logger.error(...)` line, transitions `_conn_state` to `RECONNECTING`, parks managed TX (`_park_managed_tx()` — the same PTT-off discipline `soft_disconnect()` already uses: marks the provider not-ready so a lease held across the gap is refused rather than granted onto a dead wire), stops the serial audio driver, and disconnects the raw serial link (so the *next* watchdog tick reads honest `ready=False` instead of a stale flag undoing the transition).
- Once `_conn_state` is `RECONNECTING`, the pre-existing `classify_radio_health()` correctly reports `radioLink: "reconnecting"` (not `"connected"`) via its `conn_state in {"connecting","reconnecting"}` branch — no web-layer changes needed.

`src/rigplane/web/radio_poller.py`:
- The bare-`Exception` catch in `_run()`'s fast-query path now checks `radio.connected`; when false it applies the same backoff as the `ConnectionError` branch instead of hammering a doomed wire every poll cycle at DEBUG-only visibility.

## Split: reconnect-on-return

Item 4 from the ticket (watch for the serial device to return via glob rediscovery, since the physical port path suffix changes across replug) is **out of scope for this PR** to stay within the LOC/complexity bound. Today, once link-down fires, the existing `soft_reconnect()`/watchdog retry loop (already covered by `test_serial_watchdog_retries_after_transient_soft_reconnect_failure` etc.) keeps retrying the **fixed configured device path** with capped exponential backoff — it will recover if the device comes back on the same path, but not on a renumbered one. Filing this as a follow-up ticket for a second PR.

## Test evidence

RED (new tests fail without the fix, confirmed via `git stash` on just the two production files):
```
FAILED test_serial_link_down_detected_when_healthy_flag_stays_stuck_true - AttributeError: no attribute '_SERIAL_LINK_DOWN_TIMEOUT_THRESHOLD'
FAILED test_serial_link_down_propagates_to_web_radio_health
FAILED test_serial_link_down_stops_audio_capture
FAILED test_serial_link_down_while_ptt_active_parks_managed_tx_safely
FAILED test_run_backs_off_on_bare_timeout_when_radio_reports_disconnected - AssertionError: expected a backoff log line
```

GREEN (after the fix): all 5 new tests + the full existing serial/poller suites pass.

New tests (fake-transport based, no live hardware): `tests/test_icom7610_serial_radio.py` (4 tests — detection with the raw `healthy` flag deliberately never dropping, honest `radioHealth` propagation, audio-stop on link-down, PTT-safety parking pinned with a fake managed-TX runtime with a real async signature) and `tests/test_radio_poller_coverage.py` (1 test — poller backoff on a bare timeout once `radio.connected` is false).

## Gates

- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 9017 passed, 12 skipped, 5 deselected, 11 xfailed, 1 xpassed, 0 failed
- `uv run mypy src/` — 13 pre-existing errors, delta 0 (confirmed identical against baseline `main`)
- `uv run ruff check src/ tests/` — all checks passed
- `uv run ruff format --check src/ tests/` — clean
- `uv run lint-imports` — 5 kept, 0 broken

Net production LOC: 86 (2 files: `_icom_serial_base.py` +75, `radio_poller.py` +11).

Linear: https://linear.app/morozsm/issue/MOR-1440

## Review fixes (round 2)

An independent verifier BLOCKED the round-1 diff: stale link-death detector baselines
survived the CI-V transport swap on reconnect, causing a spurious *second* link-down
declaration immediately after a genuine, healthy same-node recovery (reproduced: off →
on same node = 2 declarations, 1 spurious). Addressed in a follow-up commit on this
branch:

- **B1 (blocking).** `connect()`/`soft_reconnect()` always install a brand-new
  `SerialCivTransport` (`rx_packet_count` restarts at 0), but
  `_civ_watchdog_last_seen_rx_packets`/`_civ_watchdog_last_seen_timeouts` kept the
  pre-reconnect high-water mark, and the RECONNECTING short-circuit in the watchdog loop
  froze `last_seen_timeouts` while the outage's CI-V timeouts kept accumulating
  underneath it — landing as one unconsumed lump credited against the just-recovered
  link on the first post-reconnect evidence-check tick. Fixed by tracking
  `_civ_watchdog_last_transport` and adding `_civ_watchdog_rebaseline()`: called lazily
  whenever the evidence check observes the transport identity has changed (returns
  `False` for that tick instead of judging it), and explicitly at the end of
  `soft_reconnect()`'s RECONNECTING → CONNECTED transition, so banked outage timeouts
  never survive to judge the recovered link.
- **B3 (test gap).** Added three regression tests to
  `tests/test_icom7610_serial_radio.py`: a direct probe pinning the stale-baseline
  cross-threshold bug (a freshly reconnected transport that just delivered genuine
  frames must not be declared dead from timeouts banked against the old
  transport/outage), a `soft_reconnect()` rebaseline check, and a full off → on-same-node
  lifecycle test asserting exactly one link-down declaration per incident and that the
  link stays `CONNECTED` after recovery. The existing 4 link-down tests all used
  `fail_connect_calls=set(range(2, 100))` (reconnect never succeeds), which is exactly
  why this defect shipped green.
- **C (non-blocking).** `_declare_serial_link_down`'s docstring claimed it "mirrors
  `soft_disconnect`'s ordering"; it deliberately doesn't (skips worker/pump teardown and
  generation advance, since the watchdog needs both alive to drive recovery). Docstring
  now states the divergence explicitly instead of the full-mirror claim.
- **A (non-blocking).** Documented the shared-CI-V-bus blind spot on the
  `rx_packet_count` reset signal directly in
  `_serial_civ_timeout_evidence_crossed_threshold`'s docstring: any parsed frame resets
  it, including another device's transceive broadcast on a shared bus; not applicable to
  direct USB-CI-V connections (e.g. IC-7300).

TDD: all three new tests written first and confirmed RED against the pre-fix code via
`git stash` on just the production file (the off → on-same-node test reproduced exactly
"2 link-down declarations" pre-fix), then GREEN after the fix.

Gates (first run, no retry-to-green):
- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 9020 passed, 12
  skipped, 5 deselected, 11 xfailed, 1 xpassed, 0 failed
- `uv run mypy src/` — 13 pre-existing errors, delta 0
- `uv run ruff check src/ tests/` — all checks passed
- `uv run ruff format --check src/ tests/` — clean
- `uv run lint-imports` — 5 kept, 0 broken

Net diff this round: `_icom_serial_base.py` +85/-6 (production fix ~40 net LOC, rest
docstrings), `tests/test_icom7610_serial_radio.py` +186 (3 new tests).

**Independent verifier review pending — do not merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
