### PR TITLE
fix: restore Tab focus traversal on desktop-v2 (MOR-1449)

### DIFF
--- a/frontend/src/components-v2/layout/KeyboardHandler.svelte
+++ b/frontend/src/components-v2/layout/KeyboardHandler.svelte
@@ -64,6 +64,13 @@
     if (!enabled) return;
     if (shouldIgnoreEvent(document.activeElement)) return;
 
+    // MOR-1449: Tab is reserved for the browser's native focus traversal and
+    // must never be assignable to a shortcut — a rig profile's keyboard
+    // config (e.g. rigs/_keyboard-default.toml's "swap-vfo" binding) is not
+    // trusted to keep it free. Bail out before any sequence/binding
+    // resolution can call preventDefault() on it.
+    if (event.key === 'Tab') return;
+
     if (event.key === 'Alt' && keyboardConfig.altHints) {
       document.body.dataset.shortcutHints = 'true';
       return;

--- a/frontend/src/components-v2/layout/KeyboardHandler.svelte
+++ b/frontend/src/components-v2/layout/KeyboardHandler.svelte
@@ -66,10 +66,18 @@
 
     // MOR-1449: Tab is reserved for the browser's native focus traversal and
     // must never be assignable to a shortcut — a rig profile's keyboard
-    // config (e.g. rigs/_keyboard-default.toml's "swap-vfo" binding) is not
-    // trusted to keep it free. Bail out before any sequence/binding
-    // resolution can call preventDefault() on it.
-    if (event.key === 'Tab') return;
+    // config is not trusted to keep it free (rigs/_keyboard-default.toml
+    // used to bind it to "swap-vfo"; every rig profile inherits that shared
+    // default via rig_loader.py's merge). Bail out before any sequence/
+    // binding resolution can call preventDefault() on it. A pending leader
+    // sequence must still be disarmed — Tab already didn't preventDefault
+    // there pre-fix (resolveSequenceContinuation only matches the recorded
+    // second key), but skipping clearLeaderState() would leave the leader
+    // pill armed and swallow the NEXT keystroke for up to leaderTimeoutMs.
+    if (event.key === 'Tab') {
+      if (pendingSequence) clearLeaderState();
+      return;
+    }
 
     if (event.key === 'Alt' && keyboardConfig.altHints) {
       document.body.dataset.shortcutHints = 'true';

--- a/frontend/src/components-v2/layout/__tests__/KeyboardHandler.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/KeyboardHandler.test.ts
@@ -113,4 +113,61 @@ describe('KeyboardHandler', () => {
     window.dispatchEvent(new KeyboardEvent('keyup', { key: 'Alt' }));
     expect(document.body.dataset.shortcutHints).toBeUndefined();
   });
+
+  // MOR-1449 — rigs/_keyboard-default.toml (loaded into production keyboard
+  // configs for every rig, including ic7300.toml's own copy) binds the bare
+  // "Tab" key to the `vfo_swap` action ("swap-vfo"). Because `resolveAction`
+  // matched it like any other single-key binding, `handleKeydown` called
+  // `event.preventDefault()` on every Tab press outside a form field — which
+  // silently eats the browser's native focus-traversal everywhere in the app,
+  // not just on the bound action. Tab must never be assignable to a shortcut,
+  // regardless of what a rig profile's config declares.
+  const configWithTabBinding: KeyboardConfig = {
+    ...config,
+    bindings: [
+      ...config.bindings,
+      {
+        id: 'swap-vfo',
+        section: 'VFO',
+        label: 'Swap VFO',
+        sequence: ['Tab'],
+        action: 'vfo_swap',
+      },
+    ],
+  };
+
+  it('never intercepts Tab, even when a rig config binds it to a shortcut', () => {
+    const onAction = vi.fn();
+    mountHandler({ config: configWithTabBinding, onAction });
+
+    const event = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true });
+    window.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(onAction).not.toHaveBeenCalled();
+  });
+
+  it('never intercepts Shift+Tab, even when a rig config binds Tab to a shortcut', () => {
+    const onAction = vi.fn();
+    mountHandler({ config: configWithTabBinding, onAction });
+
+    const event = new KeyboardEvent('keydown', {
+      key: 'Tab', shiftKey: true, bubbles: true, cancelable: true,
+    });
+    window.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(onAction).not.toHaveBeenCalled();
+  });
+
+  it('still dispatches other single-key actions when a Tab binding is present', () => {
+    const onAction = vi.fn();
+    mountHandler({ config: configWithTabBinding, onAction });
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' }));
+
+    expect(onAction).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'tune', params: { direction: 'up', fine: false } }),
+    );
+  });
 });

--- a/frontend/src/components-v2/layout/__tests__/KeyboardHandler.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/KeyboardHandler.test.ts
@@ -114,14 +114,19 @@ describe('KeyboardHandler', () => {
     expect(document.body.dataset.shortcutHints).toBeUndefined();
   });
 
-  // MOR-1449 — rigs/_keyboard-default.toml (loaded into production keyboard
-  // configs for every rig, including ic7300.toml's own copy) binds the bare
-  // "Tab" key to the `vfo_swap` action ("swap-vfo"). Because `resolveAction`
-  // matched it like any other single-key binding, `handleKeydown` called
-  // `event.preventDefault()` on every Tab press outside a form field — which
-  // silently eats the browser's native focus-traversal everywhere in the app,
-  // not just on the bound action. Tab must never be assignable to a shortcut,
-  // regardless of what a rig profile's config declares.
+  // MOR-1449 — rigs/_keyboard-default.toml used to bind the bare "Tab" key
+  // to the `vfo_swap` action ("swap-vfo"). rig_loader.py loads that shared
+  // default for EVERY rig profile and merges rig-local overrides on top
+  // (profiles/rig_loader.py:1259), so all eight rig profiles inherited the
+  // binding — not just ic7300.toml, which never declared it itself. Because
+  // `resolveAction` matched it like any other single-key binding,
+  // `handleKeydown` called `event.preventDefault()` on every Tab press
+  // outside a form field — which silently ate the browser's native
+  // focus-traversal everywhere in the app, not just on the bound action.
+  // The dead binding has since been deleted from the TOML (MOR-1449 fix),
+  // but Tab must never be assignable to a shortcut regardless of what any
+  // current or future rig profile's config declares — this config object
+  // reconstructs the pre-fix shape to pin that invariant directly.
   const configWithTabBinding: KeyboardConfig = {
     ...config,
     bindings: [
@@ -132,6 +137,14 @@ describe('KeyboardHandler', () => {
         label: 'Swap VFO',
         sequence: ['Tab'],
         action: 'vfo_swap',
+      },
+      {
+        id: 'focus-af',
+        section: 'Focus',
+        label: 'Go to AF',
+        sequence: ['g', 'a'],
+        action: 'focus_target',
+        params: { target: 'af' },
       },
     ],
   };
@@ -169,5 +182,32 @@ describe('KeyboardHandler', () => {
     expect(onAction).toHaveBeenCalledWith(
       expect.objectContaining({ action: 'tune', params: { direction: 'up', fine: false } }),
     );
+  });
+
+  // Reproduces the round-2 review finding: an early `return` on Tab BEFORE
+  // the `if (pendingSequence)` branch would skip `clearLeaderState()`. Pre-fix,
+  // Tab mid-sequence disarmed the leader fine (it simply didn't match the
+  // recorded second key, so `resolveSequenceContinuation` returned null and
+  // `clearLeaderState()` still ran). A naive Tab guard placed above that
+  // branch would regress it: the leader pill would stay armed and the NEXT
+  // keystroke ('a' here) would be swallowed for up to leaderTimeoutMs and
+  // could fire an unintended `focus_target` action instead of doing nothing.
+  it('disarms a pending leader sequence on Tab instead of leaving it armed', () => {
+    const onAction = vi.fn();
+    const target = mountHandler({ config: configWithTabBinding, onAction });
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'g' }));
+    flushSync();
+    expect(target.querySelector('.keyboard-leader-pill')).not.toBeNull();
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true }));
+    flushSync();
+    expect(target.querySelector('.keyboard-leader-pill')).toBeNull();
+
+    const followUp = new KeyboardEvent('keydown', { key: 'a', bubbles: true, cancelable: true });
+    window.dispatchEvent(followUp);
+
+    expect(onAction).not.toHaveBeenCalled();
+    expect(followUp.defaultPrevented).toBe(false);
   });
 });

--- a/frontend/src/components-v2/layout/__tests__/tab-traversal.isolated.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/tab-traversal.isolated.test.ts
@@ -1,0 +1,232 @@
+/**
+ * MOR-1449 — Tab focus traversal was completely dead on the default
+ * desktop-v2 composition. Root cause: `rigs/_keyboard-default.toml` (loaded
+ * for every rig, including ic7300.toml's own copy) binds the bare "Tab" key
+ * to the `vfo_swap` action ("swap-vfo"). `KeyboardHandler`'s
+ * `handleKeydown` resolved it like any other single-key shortcut and called
+ * `event.preventDefault()`, which silently ate the browser's native
+ * focus-traversal everywhere in the app outside a form field — arrow-key
+ * tuning kept working (a different binding) while Tab produced zero visible
+ * reaction: no traversal, no focus ring, no reachable VFO.
+ *
+ * These tests mount the REAL desktop-v2 `RadioLayout` composition with a
+ * keyboard config that reproduces the production rig-profile shape
+ * (including the "swap-vfo"/Tab binding), so they exercise the exact
+ * composition and config path the live walkthrough hit — not just the
+ * `KeyboardHandler` unit in isolation (see `KeyboardHandler.test.ts` for
+ * that narrower pin).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount, unmount, flushSync } from 'svelte';
+
+vi.mock('../../../components/spectrum/SpectrumPanel.svelte', async () => {
+  const stub = await import('./SpectrumPanelStub.svelte');
+  return { default: stub.default };
+});
+
+vi.mock('../../../lib/local-extensions/LocalExtensionsHost.svelte', async () => {
+  const stub = await import('./SpectrumPanelStub.svelte');
+  return { default: stub.default };
+});
+
+vi.mock('$lib/stores/layout.svelte', () => ({
+  useLcdLayout: vi.fn(() => false),
+  getLayoutMode: vi.fn(() => 'standard'),
+  cycleLayoutMode: vi.fn(),
+  setLayoutMode: vi.fn(),
+}));
+
+vi.mock('../../../lib/utils/battery', () => ({
+  initBatteryMonitor: vi.fn(async () => vi.fn()),
+}));
+
+vi.mock('../../../lib/media/media-session', () => ({
+  initMediaSession: vi.fn(),
+  destroyMediaSession: vi.fn(),
+}));
+
+const rt = vi.hoisted(() => ({ state: null as unknown }));
+
+vi.mock('$lib/runtime', () => ({
+  runtime: {
+    get state() { return rt.state; },
+    caps: null,
+    connectionStatus: 'disconnected',
+    radioPowerOn: null,
+    connection: { status: 'disconnected', radioPowerOn: null },
+    audio: { rxEnabled: false, txEnabled: false, volume: 50, muted: false },
+    connectionAudio: false,
+    defaultScopeStatus: {
+      source: null, available: false, resourceSelected: false, demand: 0,
+      lifecycle: 'inactive', transport: 'disconnected', frameSeen: false,
+    },
+    scope: { hardwareScopeConnected: false },
+  },
+}));
+
+vi.mock('$lib/stores/connection.svelte', () => ({
+  getConnectionStatus: vi.fn(() => ({ connected: false })),
+  getWsConnected: vi.fn(() => false),
+  getRadioPowerOn: vi.fn(() => null),
+  getRadioStatus: vi.fn(() => 'disconnected'),
+  isScopeConnected: vi.fn(() => false),
+  isAudioConnected: vi.fn(() => false),
+  getRigConnected: vi.fn(() => false),
+  getRadioReady: vi.fn(() => false),
+  getRadioHealth: vi.fn(() => null),
+  markScopeFrame: vi.fn(),
+}));
+
+vi.mock('$lib/stores/tuning.svelte', () => ({
+  applyModeDefault: vi.fn(),
+}));
+
+vi.mock('$lib/runtime/tx-controller/app-host', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('$lib/runtime/tx-controller/app-host')>();
+  return {
+    ...actual,
+    getAppTxController: () => ({
+      snapshot: () => ({ phase: 'idle', intent: null, guard: null, radioTx: 'unknown', txRisk: 'none', mayOwnKey: false, fault: null }),
+      subscribe: () => () => {},
+      start: vi.fn(),
+      setIntent: vi.fn(),
+      release: vi.fn(),
+      resetFault: vi.fn(),
+    }),
+  };
+});
+
+// Mirrors the real production shape: a keyboard config with the
+// "swap-vfo"/Tab binding from rigs/_keyboard-default.toml, plus the tuning
+// arrows so the "arrow keys still work" acceptance criterion is exercised
+// through the same composition.
+const KEYBOARD_CONFIG_WITH_TAB_BINDING = {
+  leaderKey: 'g',
+  leaderTimeoutMs: 1000,
+  altHints: true,
+  helpTitle: 'Radio Keyboard',
+  bindings: [
+    {
+      id: 'nudge-right', section: 'Tuning', label: 'Tune up',
+      sequence: ['ArrowRight'], action: 'tune', repeatable: true,
+      params: { direction: 'up', fine: false },
+    },
+    {
+      id: 'swap-vfo', section: 'VFO', label: 'Swap VFO',
+      sequence: ['Tab'], action: 'vfo_swap',
+    },
+  ],
+};
+
+vi.mock('$lib/stores/capabilities.svelte', () => ({
+  hasTx: vi.fn(() => true),
+  hasDualReceiver: vi.fn(() => false),
+  hasAudio: vi.fn(() => false),
+  hasSpectrum: vi.fn(() => true),
+  hasAnyScope: vi.fn(() => false),
+  isAudioFftScope: vi.fn(() => false),
+  hasAudioFft: vi.fn(() => false),
+  getScopeSource: vi.fn(() => null),
+  hasCapability: vi.fn(() => false),
+  vfoLabel: vi.fn((slot: 'A' | 'B') => (slot === 'A' ? 'MAIN' : 'SUB')),
+  receiverLabel: vi.fn((id: 'MAIN' | 'SUB') => id),
+  vfoSlotLabel: vi.fn((slot: 'A' | 'B') => (slot === 'A' ? 'VFO A' : 'VFO B')),
+  getCapabilities: vi.fn(() => ({ freqRanges: [], modes: [], filters: [] })),
+  setCapabilities: vi.fn(),
+  getAgcModes: vi.fn(() => [0, 1, 2, 3]),
+  getAgcLabels: vi.fn(() => ({ 0: 'OFF', 1: 'FAST', 2: 'MID', 3: 'SLOW' })),
+  getSupportedModes: vi.fn(() => ['USB', 'LSB', 'CW', 'AM', 'FM']),
+  getSupportedFilters: vi.fn(() => ['FIL1', 'FIL2', 'FIL3']),
+  getAttValues: vi.fn(() => [0, 10, 20]),
+  getAttLabels: vi.fn(() => ({ 0: '0dB', 10: '10dB', 20: '20dB' })),
+  getPreValues: vi.fn(() => [0, 1, 2]),
+  getPreLabels: vi.fn(() => ({ 0: 'OFF', 1: 'PRE1', 2: 'PRE2' })),
+  getKeyboardConfig: vi.fn(() => KEYBOARD_CONFIG_WITH_TAB_BINDING),
+  getVfoScheme: vi.fn(() => 'ab'),
+  getAntennaCount: vi.fn(() => 1),
+  getSmeterCalibration: vi.fn(() => null),
+  getSmeterRedline: vi.fn(() => null),
+  getMeterCalibration: vi.fn(() => null),
+  getMeterRedline: vi.fn(() => null),
+  getControlRange: vi.fn(() => ({ min: 0, max: 255 })),
+}));
+
+import RadioLayout from '../RadioLayout.svelte';
+
+let components: ReturnType<typeof mount>[] = [];
+
+function mountLayout(skinId: any = 'desktop-v2') {
+  const t = document.createElement('div');
+  document.body.appendChild(t);
+  const component = mount(RadioLayout, { target: t, props: { skinId } });
+  flushSync();
+  components.push(component);
+  return t;
+}
+
+beforeEach(() => {
+  components = [];
+  rt.state = null;
+  Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1440 });
+  Object.defineProperty(window, 'innerHeight', { writable: true, configurable: true, value: 900 });
+});
+
+afterEach(() => {
+  components.forEach((c) => unmount(c));
+  document.body.innerHTML = '';
+  rt.state = null;
+});
+
+describe('MOR-1449: Tab focus traversal on the desktop-v2 composition', () => {
+  it('does not prevent a bare Tab keydown, even though the production keyboard config binds Tab to vfo_swap', () => {
+    mountLayout('desktop-v2');
+
+    const event = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true });
+    window.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('does not prevent Shift+Tab either', () => {
+    mountLayout('desktop-v2');
+
+    const event = new KeyboardEvent('keydown', {
+      key: 'Tab', shiftKey: true, bubbles: true, cancelable: true,
+    });
+    window.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('still dispatches the arrow-key tuning shortcut through the same config', () => {
+    const t = mountLayout('desktop-v2');
+    // Sanity: the composition mounted the real layout, not an error branch.
+    expect(t.querySelector('.radio-layout')).not.toBeNull();
+
+    const event = new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true, cancelable: true });
+    window.dispatchEvent(event);
+
+    // The tuning shortcut still calls preventDefault (unchanged behaviour) —
+    // it is a real binding, unlike Tab.
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('conformance pin: the desktop-v2 composition exposes real tabbable elements, none pinned to tabindex=-1', () => {
+    const t = mountLayout('desktop-v2');
+
+    const focusable = Array.from(
+      t.querySelectorAll<HTMLElement>('button, input, textarea, select, a[href], [tabindex]'),
+    );
+
+    // Primary surfaces (StatusBar controls, band selector, panel toggles, …)
+    // must produce a non-trivial set of genuinely tabbable elements — an
+    // empty or near-empty set would mean Tab has nowhere to land regardless
+    // of whether it is prevented.
+    expect(focusable.length).toBeGreaterThan(5);
+
+    const strandedByNegativeTabindex = focusable.filter(
+      (el) => el.getAttribute('tabindex') === '-1',
+    );
+    expect(strandedByNegativeTabindex).toEqual([]);
+  });
+});

--- a/frontend/src/components-v2/layout/__tests__/tab-traversal.isolated.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/tab-traversal.isolated.test.ts
@@ -1,13 +1,20 @@
 /**
  * MOR-1449 — Tab focus traversal was completely dead on the default
- * desktop-v2 composition. Root cause: `rigs/_keyboard-default.toml` (loaded
- * for every rig, including ic7300.toml's own copy) binds the bare "Tab" key
- * to the `vfo_swap` action ("swap-vfo"). `KeyboardHandler`'s
- * `handleKeydown` resolved it like any other single-key shortcut and called
- * `event.preventDefault()`, which silently ate the browser's native
- * focus-traversal everywhere in the app outside a form field — arrow-key
- * tuning kept working (a different binding) while Tab produced zero visible
- * reaction: no traversal, no focus ring, no reachable VFO.
+ * desktop-v2 composition. Root cause: `rigs/_keyboard-default.toml` used to
+ * bind the bare "Tab" key to the `vfo_swap` action ("swap-vfo").
+ * `profiles/rig_loader.py:1259` loads that shared default TOML for EVERY
+ * rig profile and merges each rig's local overrides on top — so all eight
+ * rig profiles inherited the binding this way, not because any individual
+ * rig (ic7300.toml included — it declares no `[ui.keyboard]` section of its
+ * own) redeclared it. `KeyboardHandler`'s `handleKeydown` resolved it like
+ * any other single-key shortcut and called `event.preventDefault()`, which
+ * silently ate the browser's native focus-traversal everywhere in the app
+ * outside a form field — arrow-key tuning kept working (a different
+ * binding) while Tab produced zero visible reaction: no traversal, no focus
+ * ring, no reachable VFO. The dead TOML binding has since been deleted; the
+ * frontend fix (reserving Tab unconditionally) is what these tests pin,
+ * reconstructing the pre-fix config shape rather than depending on the
+ * TOML no longer declaring it.
  *
  * These tests mount the REAL desktop-v2 `RadioLayout` composition with a
  * keyboard config that reproduces the production rig-profile shape
@@ -18,6 +25,9 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mount, unmount, flushSync } from 'svelte';
+import {
+  IC7300_STATE, IC7300_CAPABILITIES,
+} from '../../../lib/runtime/adapters/__tests__/fixtures/ic7300-profile';
 
 vi.mock('../../../components/spectrum/SpectrumPanel.svelte', async () => {
   const stub = await import('./SpectrumPanelStub.svelte');
@@ -45,12 +55,12 @@ vi.mock('../../../lib/media/media-session', () => ({
   destroyMediaSession: vi.fn(),
 }));
 
-const rt = vi.hoisted(() => ({ state: null as unknown }));
+const rt = vi.hoisted(() => ({ state: null as unknown, caps: null as unknown }));
 
 vi.mock('$lib/runtime', () => ({
   runtime: {
     get state() { return rt.state; },
-    caps: null,
+    get caps() { return rt.caps; },
     connectionStatus: 'disconnected',
     radioPowerOn: null,
     connection: { status: 'disconnected', radioPowerOn: null },
@@ -167,6 +177,7 @@ function mountLayout(skinId: any = 'desktop-v2') {
 beforeEach(() => {
   components = [];
   rt.state = null;
+  rt.caps = null;
   Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1440 });
   Object.defineProperty(window, 'innerHeight', { writable: true, configurable: true, value: 900 });
 });
@@ -175,6 +186,7 @@ afterEach(() => {
   components.forEach((c) => unmount(c));
   document.body.innerHTML = '';
   rt.state = null;
+  rt.caps = null;
 });
 
 describe('MOR-1449: Tab focus traversal on the desktop-v2 composition', () => {
@@ -211,7 +223,7 @@ describe('MOR-1449: Tab focus traversal on the desktop-v2 composition', () => {
     expect(event.defaultPrevented).toBe(true);
   });
 
-  it('conformance pin: the desktop-v2 composition exposes real tabbable elements, none pinned to tabindex=-1', () => {
+  it('conformance pin: the desktop-v2 composition exposes real tabbable elements', () => {
     const t = mountLayout('desktop-v2');
 
     const focusable = Array.from(
@@ -224,9 +236,47 @@ describe('MOR-1449: Tab focus traversal on the desktop-v2 composition', () => {
     // of whether it is prevented.
     expect(focusable.length).toBeGreaterThan(5);
 
-    const strandedByNegativeTabindex = focusable.filter(
-      (el) => el.getAttribute('tabindex') === '-1',
-    );
-    expect(strandedByNegativeTabindex).toEqual([]);
+    // Scoped, not blanket: `tabindex="-1"` is a legitimate pattern for
+    // programmatically-focusable containers that are NOT part of the tab
+    // order by design (e.g. RadioLayout's `.settings-modal`,
+    // StatusBar's `.np-detail` — both real dialogs already in this tree). A
+    // blanket "zero tabindex=-1 anywhere" assertion would false-red on those
+    // and on any future modal. Instead, pin specific PRIMARY interactive
+    // controls this composition is known to expose — the ones an operator
+    // actually needs to reach — and require each to be a real tab stop.
+    const PRIMARY_CONTROL_SELECTORS = [
+      '.status-bar .report-btn',
+      '.status-bar .settings-btn',
+      '.status-bar .skin-select',
+      '.status-bar .power-toggle-btn',
+      '.band-tab',
+    ];
+    for (const selector of PRIMARY_CONTROL_SELECTORS) {
+      const matches = Array.from(t.querySelectorAll<HTMLElement>(selector));
+      expect(matches.length, `expected at least one match for ${selector}`).toBeGreaterThan(0);
+      for (const el of matches) {
+        expect(
+          el.getAttribute('tabindex'),
+          `${selector} must not be pinned out of the tab order (tabindex=-1)`,
+        ).not.toBe('-1');
+      }
+    }
+  });
+
+  it('wired-state mount: the VFO frequency control is a real tab stop (tabindex=0) once the radio view model is live', () => {
+    // Uses the byte-faithful IC-7300 capture (same fixture MOR-1428's
+    // conformance suite pins) rather than a synthetic all-observed state —
+    // this is the shape a live walkthrough actually produces, and the
+    // disconnected/no-caps mount above (rt.state=null) renders the VFO tile
+    // as a plain, non-interactive text span (`hasTunableFrequency` requires
+    // an observed frequency), so it could never have caught a regression
+    // that makes the VFO itself untabbable — the ticket's actual concern.
+    rt.state = IC7300_STATE;
+    rt.caps = IC7300_CAPABILITIES;
+    const t = mountLayout('desktop-v2');
+
+    const freq = t.querySelector<HTMLElement>('.vfo-freq .freq');
+    expect(freq, 'expected the interactive frequency control to mount, not the plain-text fallback').not.toBeNull();
+    expect(freq!.getAttribute('tabindex')).toBe('0');
   });
 });

--- a/rigs/_keyboard-default.toml
+++ b/rigs/_keyboard-default.toml
@@ -283,13 +283,6 @@ action = "cycle_filter"
 step = 1
 
 [[keyboard.bindings]]
-id = "swap-vfo"
-section = "VFO"
-label = "Swap VFO"
-key = "Tab"
-action = "vfo_swap"
-
-[[keyboard.bindings]]
 id = "equalize-vfo"
 section = "VFO"
 label = "Copy to other VFO"


### PR DESCRIPTION
## Summary

Tab focus traversal was completely dead on the default desktop-v2
composition (High, found on a live IC-7300 walkthrough, scenario 9
hard-fail): pressing Tab produced zero reaction anywhere — no traversal, no
focus ring, and keyboard-only reach of the VFO was impossible — while
arrow-key tuning kept working fine.

**Root cause** (`rigs/_keyboard-default.toml`, pre-fix lines 285-290): the
shared rig keyboard profile bound the bare `Tab` key to the `vfo_swap`
action (`id = "swap-vfo"`). `profiles/rig_loader.py:1259` loads this shared
default TOML for **every** rig profile and merges each rig's local
overrides on top — so all eight rig profiles inherited the binding this
way, including IC-7300 (`ic7300.toml` declares no `[ui.keyboard]` section
and no `Tab` string of its own — it inherits 100% from the shared default).
`KeyboardHandler.svelte`'s `handleKeydown` resolved that binding exactly
like any other single-key shortcut and called `event.preventDefault()` —
silently eating the browser's native focus-traversal everywhere outside a
form field. Arrow keys kept tuning because that's a *different* binding;
Tab specifically was consumed by the VFO-swap shortcut instead of ever
reaching the DOM's native focus-order algorithm, so the `:focus-visible`
ring machinery (MOR-1232, already correctly wired) never got a chance to
fire.

**Fix:** `handleKeydown` now bails out before any sequence/binding
resolution whenever `event.key === 'Tab'`, disarming a pending leader
sequence first if one is armed (see round-2 fix 1 below). Tab is reserved
for native focus traversal unconditionally — the frontend keyboard
dispatcher is the last line of defense before `preventDefault()`, and it
must never trust a rig profile's TOML config (present or future) to keep
Tab free. `Shift+Tab` was already unaffected (the binding declared no
modifiers, so the existing `modifiersMatch` check already rejected it). The
dead TOML binding itself has been deleted (round-2 fix 2); the `vfo_swap`
action remains reachable via its existing UI button
(`VfoOps.svelte`'s "Swap VFOs" control, mounted via `VfoHeader.svelte`).

## Round 2 — independent verifier findings addressed

An independent verifier reviewed the initial fix and returned BLOCKED with
three required fixes (core mechanism, mutation-check, and Shift+Tab were
all confirmed correct):

1. **Reproduced regression** — the Tab guard sat before the
   `if (pendingSequence)` branch and skipped `clearLeaderState()`. Pre-fix,
   Tab mid-sequence already didn't `preventDefault` (it just never matched
   the recorded second key) but still disarmed the leader via that branch.
   The naive round-1 guard broke that: pressing `g` then `Tab` left the
   leader pill visibly armed and could swallow or misroute the *next*
   keystroke for up to `leaderTimeoutMs` (1000ms). Fixed:
   `if (event.key === 'Tab') { if (pendingSequence) clearLeaderState(); return; }`,
   plus a new test (`disarms a pending leader sequence on Tab instead of
   leaving it armed`) that reproduces the regression against a naive guard
   (confirmed red) and passes against the real fix (confirmed green).
2. **Coordinator-authorized** — deleted the dead `swap-vfo`/`Tab` binding
   from `rigs/_keyboard-default.toml`. Post-fix it could never fire, so
   leaving it declared would have the keyboard help overlay advertise a
   shortcut that doesn't work — an operator-facing lie. Verified nothing
   references the binding id or `Tab` key in
   `tests/test_rig_loader.py`/`test_rig_ic7610.py`/
   `test_web_capability_guards.py` (183/183 still pass). Not rebound to
   another key (product-design decision, out of scope) and no loader-side
   reserved-key validation added (ticketed separately). **This TOML edit is
   the 4th touched file — an authorized deviation from the repo's 3-file
   guardrail**, approved by the coordinator for this round.
3. **Factual corrections** — "also redeclared in `ic7300.toml`" was false;
   corrected throughout (comments + this body) to describe the real
   inheritance mechanism via `rig_loader.py`'s merge. Also corrected: the
   "Swap VFOs" button lives in `VfoOps.svelte`, not `VfoSurface.svelte`.

Plus two test-only refinements from the verifier's recorder items:

- **A** — `tab-traversal.isolated.test.ts` now also mounts with the real
  byte-faithful IC-7300 fixture (`ic7300-profile.ts`'s `IC7300_STATE`/
  `IC7300_CAPABILITIES`, the same fixture MOR-1428's conformance suite
  pins) and asserts the VFO frequency control renders as a genuine
  `tabindex="0"` tab stop once the radio view model is live. The prior
  disconnected-shell mount (`rt.state=null`) rendered the VFO tile as inert
  plain text and could never have caught a regression making the VFO
  itself untabbable — the ticket's actual acceptance criterion.
- **B** — replaced the blanket "no `tabindex=-1` anywhere" assertion with a
  scoped check over specific enumerated primary controls (StatusBar's
  report/settings/skin-select/power-toggle buttons, BandSelector's
  band-tab buttons). `tabindex=-1` is legitimate for programmatically-
  focusable, intentionally-non-tabbable containers already in this tree
  (`RadioLayout.svelte:375`'s `.settings-modal`, `StatusBar.svelte:313`'s
  `.np-detail`) — a blanket ban would false-red on those and on any future
  modal.

## Fix

- `frontend/src/components-v2/layout/KeyboardHandler.svelte` — early-return
  on `event.key === 'Tab'` before any shortcut resolution, disarming a
  pending leader sequence first. Net +8 lines (mostly comment).
- `rigs/_keyboard-default.toml` — deleted the dead `swap-vfo`/`Tab`
  binding (net -7 lines, pure removal).

## Tests (TDD — written first, confirmed red, then green, each round)

- `KeyboardHandler.test.ts`:
  - `never intercepts Tab, even when a rig config binds it to a shortcut`
  - `never intercepts Shift+Tab, even when a rig config binds Tab to a shortcut`
  - `still dispatches other single-key actions when a Tab binding is present`
  - `disarms a pending leader sequence on Tab instead of leaving it armed` (round 2)
- `tab-traversal.isolated.test.ts` (new) — mounts the real desktop-v2
  `RadioLayout` composition with a keyboard config shaped like the actual
  production rig profile (including the `swap-vfo`/Tab binding):
  - `does not prevent a bare Tab keydown, even though the production
    keyboard config binds Tab to vfo_swap`
  - `does not prevent Shift+Tab either`
  - `still dispatches the arrow-key tuning shortcut through the same config`
  - `conformance pin: the desktop-v2 composition exposes real tabbable
    elements` (scoped, round 2)
  - `wired-state mount: the VFO frequency control is a real tab stop
    (tabindex=0) once the radio view model is live` (round 2, IC-7300 fixture)

Every new/changed test was confirmed to fail against the pre-fix or
naive-fix code and pass against the real fix before being committed.

## Test plan

- [x] `npx vitest run` — full frontend suite, 6640/6640 passed
- [x] `npm run lint` — clean
- [x] `npm run check` (svelte-check + tsc) — 0 errors, 0 warnings
- [x] `uv run pytest tests/test_rig_loader.py tests/test_rig_ic7610.py
      tests/test_web_capability_guards.py -q` — 183/183 passed
- [x] `uv run ruff check src/ tests/` — clean
- [x] Manual re-verification each round: reverted the relevant production
      fix and re-ran the new test — it failed as expected, confirming the
      test actually exercises the regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)