### PR TITLE
fix: per-radio attenuator validation and visible post-ack errors (MOR-1445)

### DIFF
--- a/frontend/src/lib/i18n/__tests__/index.test.ts
+++ b/frontend/src/lib/i18n/__tests__/index.test.ts
@@ -140,6 +140,25 @@ describe('messageFromReasonCode()', () => {
     );
   });
 
+  // MOR-1445: a command accepted at enqueue can still fail once the poller
+  // actually executes it against the radio. The server broadcasts this
+  // reason code (with the backend exception text threaded as `reason`) so
+  // the operator sees a localized toast instead of a raw English string.
+  // ja-JP is a known, separately-tracked backlog gap for this code (same
+  // status as commandRefusedLinkDegraded above) — not asserted here.
+  it('resolves the MOR-1445 post-ack command-failure reason code in en-US, threading the reason', () => {
+    expect(
+      messageFromReasonCode('commandExecutionFailed', { reason: 'radio did not respond' }),
+    ).toBe('Command failed: radio did not respond');
+  });
+
+  it('resolves the MOR-1445 post-ack command-failure reason code in ru-RU (own catalog entry, not the en-US fallback)', () => {
+    setLocale('ru-RU');
+    expect(
+      messageFromReasonCode('commandExecutionFailed', { reason: 'radio did not respond' }),
+    ).toBe('Команда не выполнена: radio did not respond');
+  });
+
   it('rejects malformed codes safely (returns the unknown toast)', () => {
     expect(messageFromReasonCode('../injection.attempt')).toBe(
       'Something went wrong. Try again later.',

--- a/frontend/src/lib/i18n/__tests__/index.test.ts
+++ b/frontend/src/lib/i18n/__tests__/index.test.ts
@@ -141,9 +141,10 @@ describe('messageFromReasonCode()', () => {
   });
 
   // MOR-1445: a command accepted at enqueue can still fail once the poller
-  // actually executes it against the radio. The server broadcasts this
-  // reason code (with the backend exception text threaded as `reason`) so
-  // the operator sees a localized toast instead of a raw English string.
+  // actually executes it against the radio. The server sends this reason
+  // code to the issuing session only, never a broadcast (with the backend
+  // exception text threaded as `reason`) so the operator sees a localized
+  // toast instead of a raw English string.
   // ja-JP is a known, separately-tracked backlog gap for this code (same
   // status as commandRefusedLinkDegraded above) — not asserted here.
   it('resolves the MOR-1445 post-ack command-failure reason code in en-US, threading the reason', () => {

--- a/frontend/src/lib/i18n/locales/en-US.json
+++ b/frontend/src/lib/i18n/locales/en-US.json
@@ -157,6 +157,7 @@
   "core.toast.audioBridgeStarted": "Audio bridge started",
   "core.toast.audioBridgeStopped": "Audio bridge stopped",
   "core.toast.commandRefusedLinkDegraded": "Command not sent — link to the radio is degraded",
+  "core.toast.commandExecutionFailed": "Command failed: {reason}",
   "core.toast.unknown": "Something went wrong. Try again later.",
 
   "core.mobile.nav.label": "Radio navigation",

--- a/frontend/src/lib/i18n/locales/ru-RU.json
+++ b/frontend/src/lib/i18n/locales/ru-RU.json
@@ -137,6 +137,7 @@
   "core.toast.audioBridgeStarted": "Аудиомост запущен",
   "core.toast.audioBridgeStopped": "Аудиомост остановлен",
   "core.toast.commandRefusedLinkDegraded": "Команда не отправлена — связь с трансивером деградировала",
+  "core.toast.commandExecutionFailed": "Команда не выполнена: {reason}",
   "core.toast.unknown": "Что-то пошло не так. Попробуйте позже.",
 
   "core.mobile.nav.label": "Навигация по трансиверу",

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -3803,7 +3803,9 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         The attenuator state is updated optimistically.
 
         Args:
-            db: Attenuation in dB (0..45 in 3 dB steps).
+            db: Attenuation in dB. Valid values are declared per radio by the
+                profile's ``[attenuator] values`` (e.g. IC-7300 has a single
+                20 dB step; IC-7610 has 0..45 in 3 dB steps).
             receiver: RECEIVER_MAIN (0) or RECEIVER_SUB (1).
         """
         self._check_connected()
@@ -3812,8 +3814,20 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._require_cmd29_route(
             0x11, None, receiver=receiver, operation="set_attenuator_level"
         )
-        if db < 0 or db > 45 or db % 3 != 0:
-            raise ValueError(f"Attenuator level must be 0..45 in 3 dB steps, got {db}")
+        att_values = self._profile.att_values
+        if att_values is None:
+            # Data-driven only: no universal numeric fallback. A profile that
+            # declares the "attenuator" capability must also declare its
+            # valid dB steps via [attenuator] values in its rig TOML.
+            raise CommandError(
+                f"set_attenuator_level is not supported by profile "
+                f"{self._profile.model} (missing capability: attenuator values)"
+            )
+        if db not in att_values:
+            raise ValueError(
+                f"Attenuator level must be one of {sorted(att_values)} dB "
+                f"for {self._profile.model}, got {db}"
+            )
         cmd29 = self._profile.supports_cmd29(0x11)
         civ = set_attenuator_level(
             db, to_addr=self._radio_addr, receiver=receiver, command29=cmd29

--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -525,7 +525,9 @@ class ControlHandler:
         # Sent directly (not via event queue) so it arrives right after hello
         # and before the recv loop — no interleaving with command responses.
         if self._server is not None:
-            initial = self._server.register_control_event_queue(self._event_queue)
+            initial = self._server.register_control_event_queue(
+                self._event_queue, session_id=self._session_id
+            )
             # Old focused handler doubles have no StateStore-backed
             # registration API and return a MagicMock/None.  Production
             # WebServer always returns the canonical shared-encoder baseline.
@@ -539,7 +541,9 @@ class ControlHandler:
                 await self._ws.send_text(encode_json(msg))
             except BaseException as exc:
                 logger.debug("control: failed to send initial state", exc_info=True)
-                self._server.unregister_control_event_queue(self._event_queue)
+                self._server.unregister_control_event_queue(
+                    self._event_queue, session_id=self._session_id
+                )
                 if isinstance(exc, asyncio.CancelledError):
                     raise
                 return
@@ -571,7 +575,9 @@ class ControlHandler:
             except asyncio.CancelledError:
                 pass
             if self._server is not None:
-                self._server.unregister_control_event_queue(self._event_queue)
+                self._server.unregister_control_event_queue(
+                    self._event_queue, session_id=self._session_id
+                )
 
     async def _event_sender_loop(self) -> None:
         """Drain event queue and forward events to WebSocket."""

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -54,6 +54,7 @@ from ..core.command_service import (
 )
 from ..core.state_pipeline_contracts import (
     CommandIntent,
+    CommandLifecycleEvent,
     CommandSource,
     FieldPath,
     Observation,
@@ -733,6 +734,18 @@ class WebServer:
             executor=_SharedControlCommandExecutor(self),
             state_store=self.command_state_store,
         )
+        # Command ids currently between "acknowledged" and a terminal
+        # lifecycle state — see _on_command_lifecycle_event (MOR-1445).
+        self._acked_command_ids: set[str] = set()
+        # MOR-1445: a websocket-queued command can be acknowledged at enqueue
+        # and only fail later, once RadioPoller actually executes it against
+        # the radio (e.g. a validation error the poller surfaces post-ack).
+        # CommandService already carries NAK semantics for that via
+        # fail_command()/lifecycle "failed"/"timed_out" — nothing previously
+        # subscribed to it, so the operator got no signal. Client-side
+        # refusals already toast via MOR-1422; this covers the execution-time
+        # gap.
+        self.command_service.subscribe_lifecycle(self._on_command_lifecycle_event)
         self._http_command_service = CommandService(
             executor=_HttpCommandExecutor(self),
             state_store=self.command_state_store,
@@ -1906,6 +1919,28 @@ class WebServer:
                 logger.debug(
                     "broadcast_notification: queue full, dropping notification"
                 )
+
+    def _on_command_lifecycle_event(self, event: CommandLifecycleEvent) -> None:
+        """Surface a post-ack command execution failure to the operator (MOR-1445).
+
+        A synchronous enqueue-time rejection (e.g. an unsupported command)
+        fails before ever reaching "acknowledged" and is already returned to
+        the requesting client as a WS response, and refused-before-enqueue
+        commands already toast client-side (MOR-1422) — neither needs a
+        broadcast here. The gap this closes is the queued command that WAS
+        acknowledged and only failed later, once RadioPoller actually
+        executed it against the radio (fail_command()/"failed"/"timed_out"),
+        which previously reached no one.
+        """
+        if event.state == "acknowledged":
+            self._acked_command_ids.add(event.command_id)
+            return
+        was_acked = event.command_id in self._acked_command_ids
+        self._acked_command_ids.discard(event.command_id)
+        if was_acked and event.state in ("failed", "timed_out"):
+            self.broadcast_notification(
+                "error", event.message or "Command failed", "command"
+            )
 
     def _broadcast_dx_spot(self, spot: Any) -> None:
         """Add DX spot to buffer and push dx_spot message to all control clients."""

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -458,6 +458,30 @@ async def _read_capped_body(
     )
 
 
+def _notification_payload(
+    level: str,
+    message: str,
+    category: str,
+    *,
+    code: str | None,
+    params: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Build the wire-schema notification dict shared by broadcast and
+    targeted (single-session) sends. See WebServer.broadcast_notification
+    for the field contract."""
+    notification: dict[str, Any] = {
+        "type": "notification",
+        "level": level,
+        "message": message,
+        "category": category,
+    }
+    if code is not None:
+        notification["code"] = code
+    if params:
+        notification["params"] = dict(params)
+    return notification
+
+
 def _redact_token_in_path(path: str) -> str:
     """Return `path` with any `token=` query value replaced by `***`.
 
@@ -734,9 +758,6 @@ class WebServer:
             executor=_SharedControlCommandExecutor(self),
             state_store=self.command_state_store,
         )
-        # Command ids currently between "acknowledged" and a terminal
-        # lifecycle state — see _on_command_lifecycle_event (MOR-1445).
-        self._acked_command_ids: set[str] = set()
         # MOR-1445: a websocket-queued command can be acknowledged at enqueue
         # and only fail later, once RadioPoller actually executes it against
         # the radio (e.g. a validation error the poller surfaces post-ack).
@@ -744,7 +765,9 @@ class WebServer:
         # fail_command()/lifecycle "failed"/"timed_out" — nothing previously
         # subscribed to it, so the operator got no signal. Client-side
         # refusals already toast via MOR-1422; this covers the execution-time
-        # gap.
+        # gap. Only self.command_service (the websocket-queued path) is
+        # subscribed — self._http_command_service below executes synchronously
+        # and its caller already sees the exception directly.
         self.command_service.subscribe_lifecycle(self._on_command_lifecycle_event)
         self._http_command_service = CommandService(
             executor=_HttpCommandExecutor(self),
@@ -826,6 +849,10 @@ class WebServer:
         self._state_store_freshness_task: asyncio.Task[None] | None = None
         # Control handler event queues
         self._control_event_queues: set[BoundedQueue[dict[str, Any]]] = set()
+        # session_id -> that session's event queue, for targeted (non-broadcast)
+        # sends — e.g. a post-ack command-failure notification belongs only to
+        # the session that issued the command (MOR-1445/MOR-1422 doctrine).
+        self._session_queues: dict[str, BoundedQueue[dict[str, Any]]] = {}
         # State broadcast throttle
         self._last_state_broadcast: float = 0.0
         self._pending_state_broadcast_task: asyncio.Task[None] | None = None
@@ -1266,23 +1293,37 @@ class WebServer:
         return self._state_diagnostics
 
     def register_control_event_queue(
-        self, q: BoundedQueue[dict[str, Any]]
+        self,
+        q: BoundedQueue[dict[str, Any]],
+        *,
+        session_id: str | None = None,
     ) -> dict[str, Any]:
         """Register a client and return its shared-encoder full baseline."""
         existing_queues = set(self._control_event_queues)
         self._control_event_queues.add(q)
+        if session_id is not None:
+            self._session_queues[session_id] = q
         try:
             return self._publish_control_state_baseline(q, peers=existing_queues)
         except BaseException:
             # Registration is transactional: an unbased queue must never
             # survive a failed/cancelled baseline encode.
             self._control_event_queues.discard(q)
+            if session_id is not None:
+                self._session_queues.pop(session_id, None)
             raise
 
-    def unregister_control_event_queue(self, q: BoundedQueue[dict[str, Any]]) -> None:
+    def unregister_control_event_queue(
+        self,
+        q: BoundedQueue[dict[str, Any]],
+        *,
+        session_id: str | None = None,
+    ) -> None:
         """Unregister a ControlHandler event queue."""
         was_registered = q in self._control_event_queues
         self._control_event_queues.discard(q)
+        if session_id is not None and self._session_queues.get(session_id) is q:
+            self._session_queues.pop(session_id, None)
         if was_registered:
             self._broadcast_ws_client_state_update()
 
@@ -1902,16 +1943,9 @@ class WebServer:
 
         Existing clients that only read ``message`` continue to work unchanged.
         """
-        notification: dict[str, Any] = {
-            "type": "notification",
-            "level": level,
-            "message": message,
-            "category": category,
-        }
-        if code is not None:
-            notification["code"] = code
-        if params:
-            notification["params"] = dict(params)
+        notification = _notification_payload(
+            level, message, category, code=code, params=params
+        )
         for q in list(self._control_event_queues):
             try:
                 q.put_nowait(notification)
@@ -1920,27 +1954,95 @@ class WebServer:
                     "broadcast_notification: queue full, dropping notification"
                 )
 
+    def send_notification_to_session(
+        self,
+        session_id: str,
+        level: str,
+        message: str,
+        category: str = "system",
+        *,
+        code: str | None = None,
+        params: dict[str, Any] | None = None,
+    ) -> bool:
+        """Send a notification to exactly one session's WS connection.
+
+        Same wire schema as :meth:`broadcast_notification`, but delivered
+        only to the session that registered under *session_id* (see
+        :meth:`register_control_event_queue`). Used for feedback that
+        belongs to whoever acted, not to every connected client — e.g. a
+        post-ack command-failure notification (MOR-1445), matching the
+        MOR-1422 refusal-toast doctrine. Returns ``False`` (no-op) if the
+        session is not currently registered (already disconnected) or its
+        queue is full.
+        """
+        q = self._session_queues.get(session_id)
+        if q is None:
+            return False
+        notification = _notification_payload(
+            level, message, category, code=code, params=params
+        )
+        try:
+            q.put_nowait(notification)
+        except asyncio.QueueFull:
+            logger.debug(
+                "send_notification_to_session: queue full, dropping notification "
+                "(session=%s)",
+                session_id,
+            )
+            return False
+        return True
+
     def _on_command_lifecycle_event(self, event: CommandLifecycleEvent) -> None:
-        """Surface a post-ack command execution failure to the operator (MOR-1445).
+        """Surface a post-ack command execution failure to its issuing
+        session only (MOR-1445) — never a broadcast.
 
         A synchronous enqueue-time rejection (e.g. an unsupported command)
         fails before ever reaching "acknowledged" and is already returned to
         the requesting client as a WS response, and refused-before-enqueue
-        commands already toast client-side (MOR-1422) — neither needs a
-        broadcast here. The gap this closes is the queued command that WAS
-        acknowledged and only failed later, once RadioPoller actually
+        commands already toast client-side (MOR-1422) — neither needs
+        anything sent here. The gap this closes is the queued command that
+        WAS acknowledged and only failed later, once RadioPoller actually
         executed it against the radio (fail_command()/"failed"/"timed_out"),
         which previously reached no one.
+
+        Unified with the MOR-1422 refusal-toast doctrine: error feedback
+        belongs to whoever acted. Other connected clients saw no state
+        change from this command and would get pure noise from a broadcast,
+        so this targets exactly the session recorded on the intent
+        (threaded through as "session_id" in lifecycle event details by
+        command_intent_from_request / fail_command) via
+        send_notification_to_session — never broadcast_notification.
+
+        Stateless by design: "was this command ever acknowledged" is derived
+        from CommandService's own recorded history on demand, not tracked in
+        a WebServer-owned dict. A command whose target has no FieldPath (e.g.
+        "set_tuner") never reaches a "reconciled" state, and a scoped
+        overlay can expire silently with no lifecycle event at all — either
+        would leak a hand-maintained "currently acknowledged" set forever.
+        Recomputing from history has no such failure mode: nothing to leak.
         """
-        if event.state == "acknowledged":
-            self._acked_command_ids.add(event.command_id)
+        if event.state not in ("failed", "timed_out"):
             return
-        was_acked = event.command_id in self._acked_command_ids
-        self._acked_command_ids.discard(event.command_id)
-        if was_acked and event.state in ("failed", "timed_out"):
-            self.broadcast_notification(
-                "error", event.message or "Command failed", "command"
-            )
+        was_acknowledged = any(
+            e.command_id == event.command_id and e.state == "acknowledged"
+            for e in self.command_service.lifecycle_events()
+        )
+        if not was_acknowledged:
+            return
+        session_id = event.details.get("session_id") if event.details else None
+        if not isinstance(session_id, str):
+            # No identifiable issuing session (e.g. a non-websocket source) —
+            # the issuer-only doctrine means there is no one left to notify.
+            return
+        reason = event.message or "unknown error"
+        self.send_notification_to_session(
+            session_id,
+            "error",
+            f"Command failed: {reason}",
+            "command",
+            code="commandExecutionFailed",
+            params={"reason": reason},
+        )
 
     def _broadcast_dx_spot(self, spot: Any) -> None:
         """Add DX spot to buffer and push dx_spot message to all control clients."""

--- a/tests/test_radio_coverage.py
+++ b/tests/test_radio_coverage.py
@@ -525,7 +525,7 @@ async def test_get_attenuator_level_raises_when_no_state(
 
 
 async def test_set_attenuator_level_invalid_db_raises(radio: IcomRadio) -> None:
-    with pytest.raises(ValueError, match="3 dB steps"):
+    with pytest.raises(ValueError, match="must be one of"):
         await radio.set_attenuator_level(7)  # not a multiple of 3
 
 
@@ -539,6 +539,73 @@ async def test_set_attenuator_level_valid_sends_command(
 ) -> None:
     await radio.set_attenuator_level(18)
     assert len(mock_transport.sent_packets) > 0
+
+
+# ---------------------------------------------------------------------------
+# set_attenuator_level() per-radio validation (MOR-1445)
+#
+# The `radio` fixture defaults to IC-7610 (0..45 dB, 3 dB steps — the
+# existing tests above cover that regression). IC-7300 declares a single
+# 20 dB attenuator step (rigs/ic7300.toml [attenuator] values = [0, 20]);
+# validation must come from the radio's declared `att_values`, not a
+# universal constant.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def ic7300_radio(mock_transport: MockTransport):
+    r = IcomRadio("192.168.1.101", timeout=0.05, model="IC-7300")
+    r._civ_transport = mock_transport
+    r._ctrl_transport = mock_transport
+    r._connected = True
+    yield r
+    r._connected = False
+
+
+async def test_set_attenuator_level_ic7300_accepts_declared_20db(
+    ic7300_radio: IcomRadio, mock_transport: MockTransport
+) -> None:
+    """IC-7300's real attenuator step (20 dB) must be accepted."""
+    await ic7300_radio.set_attenuator_level(20)
+    assert len(mock_transport.sent_packets) > 0
+
+
+async def test_set_attenuator_level_ic7300_rejects_undeclared_value(
+    ic7300_radio: IcomRadio,
+) -> None:
+    """IC-7610's 18 dB step is not a valid IC-7300 attenuator value."""
+    with pytest.raises(ValueError, match="20"):
+        await ic7300_radio.set_attenuator_level(18)
+
+
+async def test_set_attenuator_level_ic7610_rejects_ic7300_step(
+    radio: IcomRadio,
+) -> None:
+    """Regression: the 0..45/3dB radio (IC-7610) still rejects out-of-set values."""
+    with pytest.raises(ValueError, match="45"):
+        await radio.set_attenuator_level(20)
+
+
+async def test_set_attenuator_level_no_declared_values_raises_command_error(
+    mock_transport: MockTransport,
+) -> None:
+    """Data-driven only: a profile with no declared att_values must fail
+    loud (CommandError naming the missing capability), never fall back to
+    a hardcoded numeric range (owner directive, MOR-1445)."""
+    import dataclasses
+
+    from rigplane.profiles import get_radio_profile
+
+    undeclared = dataclasses.replace(get_radio_profile("IC-7300"), att_values=None)
+    r = IcomRadio("192.168.1.102", timeout=0.05, profile=undeclared)
+    r._civ_transport = mock_transport
+    r._ctrl_transport = mock_transport
+    r._connected = True
+    try:
+        with pytest.raises(CommandError, match="missing capability"):
+            await r.set_attenuator_level(20)
+    finally:
+        r._connected = False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -3026,10 +3026,18 @@ def _register_two_sessions(
 async def test_post_ack_command_failure_notifies_issuer_only() -> None:
     """A command that fails AFTER being acknowledged reaches the session
     that issued it, and only that session — a second connected client
-    (bystander) gets nothing."""
+    (bystander) gets nothing.
+
+    Keeps the __init__-created ``srv.command_service`` (with its real
+    ``subscribe_lifecycle`` wiring) and swaps only its executor, instead of
+    replacing the service via ``_wire_stub_command_service``. Deleting the
+    production ``subscribe_lifecycle`` call in ``WebServer.__init__`` must
+    turn this test red; a test-side redundant subscribe would mask that.
+    """
     srv = WebServer()
     issuer_q, bystander_q = _register_two_sessions(srv)
-    service = _wire_stub_command_service(srv, _StubCommandExecutor())
+    srv.command_service._executor = _StubCommandExecutor()  # noqa: SLF001
+    service = srv.command_service
 
     intent = command_intent_from_request(
         "set_attenuator",
@@ -3087,10 +3095,18 @@ async def test_command_failure_before_ack_notifies_no_one() -> None:
 @pytest.mark.asyncio
 async def test_command_timed_out_after_ack_notifies_issuer_only() -> None:
     """timed_out is a terminal failure too and must also reach only the
-    issuing session, not a broadcast."""
+    issuing session, not a broadcast.
+
+    Also keeps the __init__-created ``srv.command_service`` (see the
+    docstring on test_post_ack_command_failure_notifies_issuer_only above)
+    so the session_id threading exercised through
+    handlers/control.py's register_control_event_queue(session_id=...)
+    call sites runs against production wiring in more than one test.
+    """
     srv = WebServer()
     issuer_q, bystander_q = _register_two_sessions(srv)
-    service = _wire_stub_command_service(srv, _StubCommandExecutor())
+    srv.command_service._executor = _StubCommandExecutor()  # noqa: SLF001
+    service = srv.command_service
 
     intent = command_intent_from_request(
         "set_attenuator",

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -14,6 +14,8 @@ import pytest
 
 from rigplane._bounded_queue import BoundedQueue
 from rigplane.core.command_service import (
+    CommandExecutionResult,
+    CommandService,
     command_intent_from_request,
     command_response_observation,
 )
@@ -23,6 +25,7 @@ from rigplane.core.acquisition_scheduler import (
     StateFreshnessService,
 )
 from rigplane.core.state_pipeline_contracts import (
+    CommandIntent,
     FieldPath,
     Observation,
     SourceMetadata,
@@ -2954,113 +2957,206 @@ async def test_broadcast_notification_omits_code_for_legacy_path() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Post-ack command execution failure -> operator notification (MOR-1445)
+# Post-ack command execution failure -> issuer-only notification (MOR-1445)
 #
 # A websocket-queued command (e.g. set_attenuator) is acknowledged at
 # enqueue time and only actually fails later, once RadioPoller executes it
 # against the radio. CommandService already has NAK semantics for this via
 # fail_command()/lifecycle "failed"/"timed_out", but nothing was subscribed
-# to it, so the operator never learned the command silently failed. These
-# tests exercise WebServer's subscriber wiring directly at the handler
-# level, without a real RadioPoller/websocket.
+# to it, so the operator never learned the command silently failed.
+#
+# Per owner ruling, delivery is scoped to the session that issued the
+# command only — never a broadcast to every connected client — unifying
+# with the MOR-1422 refusal-toast doctrine (error feedback belongs to
+# whoever acted; other clients saw no state change and would get noise).
+#
+# These tests drive the real CommandService.execute() round trip (accepted
+# -> queued -> sent -> acknowledged is production code, not hand-emitted
+# states) through a stub executor, with WebServer's actual subscriber
+# (_on_command_lifecycle_event) wired the same way __init__ wires it. Only
+# the later, separate fail_command() call — the real entry point
+# RadioPoller._mark_queued_command_failed() uses — stands in for the poller
+# discovering the failure after the fact.
 # ---------------------------------------------------------------------------
 
 
+class _StubCommandExecutor:
+    """Executor test double: succeeds, or raises synchronously like a
+    real executor rejecting a command before it ever reaches the queue."""
+
+    def __init__(self, *, raises: Exception | None = None) -> None:
+        self._raises = raises
+
+    async def execute(self, intent: CommandIntent) -> CommandExecutionResult:
+        if self._raises is not None:
+            raise self._raises
+        return CommandExecutionResult()
+
+
+def _wire_stub_command_service(
+    srv: WebServer, executor: _StubCommandExecutor
+) -> CommandService:
+    """Swap in a stub executor, keeping the production notification wiring
+    under test (same subscribe_lifecycle call WebServer.__init__ makes)."""
+    service = CommandService(executor=executor, state_store=srv.command_state_store)
+    service.subscribe_lifecycle(srv._on_command_lifecycle_event)  # noqa: SLF001
+    srv.command_service = service
+    return service
+
+
+def _register_two_sessions(
+    srv: WebServer,
+) -> tuple[BoundedQueue[dict[str, object]], BoundedQueue[dict[str, object]]]:
+    """Register an issuing session's queue and a bystander session's queue.
+
+    Drains both afterwards: registering the second queue pushes a baseline
+    state_update to existing peers, which would otherwise be the first
+    (unrelated) message a test reads back out.
+    """
+    issuer_q: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=16)
+    bystander_q: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=16)
+    srv.register_control_event_queue(issuer_q, session_id="session-issuer")
+    srv.register_control_event_queue(bystander_q, session_id="session-bystander")
+    _drain_queue(issuer_q)
+    _drain_queue(bystander_q)
+    return issuer_q, bystander_q
+
+
 @pytest.mark.asyncio
-async def test_post_ack_command_failure_broadcasts_operator_notification() -> None:
-    """A command that fails AFTER being acknowledged reaches the operator."""
+async def test_post_ack_command_failure_notifies_issuer_only() -> None:
+    """A command that fails AFTER being acknowledged reaches the session
+    that issued it, and only that session — a second connected client
+    (bystander) gets nothing."""
     srv = WebServer()
-    q: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=16)
-    srv.register_control_event_queue(q)
+    issuer_q, bystander_q = _register_two_sessions(srv)
+    service = _wire_stub_command_service(srv, _StubCommandExecutor())
 
     intent = command_intent_from_request(
         "set_attenuator",
         {"db": 20, "receiver": 0},
         source="websocket",
         command_id="cmd-att-1",
+        session_id="session-issuer",
     )
-    srv.command_service.emit_lifecycle(intent, "accepted")
-    srv.command_service.emit_lifecycle(intent, "acknowledged")
+    await service.execute(intent)  # real accepted/queued/sent/acknowledged path
 
-    fired = srv.command_service.fail_command(
+    fired = service.fail_command(
         "cmd-att-1",
-        message="Attenuator level must be one of [0, 45] dB for IC-7610, got 20",
+        message="Attenuator level must be one of [0, 20] dB for IC-7300, got 18",
     )
 
     assert fired is True
-    n = q.get_nowait()
+    n = issuer_q.get_nowait()
     assert n["type"] == "notification"
     assert n["level"] == "error"
     assert n["category"] == "command"
-    assert "Attenuator level" in n["message"]
+    assert n["code"] == "commandExecutionFailed"
+    assert "Attenuator level" in n["params"]["reason"]
+    assert issuer_q.empty()  # exactly one notification, not more
+    assert bystander_q.empty()  # zero — never broadcast
 
 
 @pytest.mark.asyncio
-async def test_command_failure_before_ack_does_not_broadcast() -> None:
-    """A command rejected before enqueue/ack must not double-broadcast.
+async def test_command_failure_before_ack_notifies_no_one() -> None:
+    """A command rejected before enqueue/ack must not notify anyone here.
 
     That synchronous rejection is already returned to the requesting client
     as a WS response (and, client-side, as a refusal toast per MOR-1422) —
-    broadcasting it to every connected client here would be a duplicate.
+    a second notification from this seam would be a duplicate.
     """
     srv = WebServer()
-    q: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=16)
-    srv.register_control_event_queue(q)
+    issuer_q, bystander_q = _register_two_sessions(srv)
+    service = _wire_stub_command_service(
+        srv, _StubCommandExecutor(raises=ValueError("bad db value"))
+    )
 
     intent = command_intent_from_request(
         "set_attenuator",
         {"db": 999, "receiver": 0},
         source="websocket",
         command_id="cmd-att-2",
+        session_id="session-issuer",
     )
-    srv.command_service.emit_lifecycle(intent, "accepted")
-    # No "acknowledged" — this mirrors a synchronous executor rejection.
-    srv.command_service.emit_lifecycle(intent, "failed", message="bad db value")
+    with pytest.raises(ValueError, match="bad db value"):
+        await service.execute(intent)  # mirrors a synchronous executor rejection
 
-    assert q.empty()
+    assert issuer_q.empty()
+    assert bystander_q.empty()
 
 
 @pytest.mark.asyncio
-async def test_command_timed_out_after_ack_broadcasts_notification() -> None:
-    """timed_out is a terminal failure too and must also reach the operator."""
+async def test_command_timed_out_after_ack_notifies_issuer_only() -> None:
+    """timed_out is a terminal failure too and must also reach only the
+    issuing session, not a broadcast."""
     srv = WebServer()
-    q: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=16)
-    srv.register_control_event_queue(q)
+    issuer_q, bystander_q = _register_two_sessions(srv)
+    service = _wire_stub_command_service(srv, _StubCommandExecutor())
 
     intent = command_intent_from_request(
         "set_attenuator",
         {"db": 20, "receiver": 0},
         source="websocket",
         command_id="cmd-att-3",
+        session_id="session-issuer",
     )
-    srv.command_service.emit_lifecycle(intent, "accepted")
-    srv.command_service.emit_lifecycle(intent, "acknowledged")
+    await service.execute(intent)
 
-    srv.command_service.fail_command(
-        "cmd-att-3", message="radio did not respond", timed_out=True
-    )
+    service.fail_command("cmd-att-3", message="radio did not respond", timed_out=True)
 
-    n = q.get_nowait()
+    n = issuer_q.get_nowait()
     assert n["level"] == "error"
-    assert n["message"] == "radio did not respond"
+    assert n["code"] == "commandExecutionFailed"
+    assert n["params"]["reason"] == "radio did not respond"
+    assert bystander_q.empty()
 
 
 @pytest.mark.asyncio
-async def test_successful_command_does_not_leak_acked_id_tracking() -> None:
-    """A command that succeeds (never fails) must not accumulate tracking state."""
+async def test_send_notification_to_session_unknown_session_is_a_noop() -> None:
+    """A session that already disconnected (or never existed) is not an
+    error — the send is just dropped, matching the queue-full drop pattern
+    used elsewhere on this class."""
     srv = WebServer()
+    assert srv.send_notification_to_session("nonexistent", "error", "x") is False
 
-    intent = command_intent_from_request(
+
+@pytest.mark.asyncio
+async def test_target_none_and_scoped_commands_do_not_leak_state_on_success() -> None:
+    """Repro from code review: a command whose _command_target() is None
+    (e.g. set_tuner) gets pending_policy="none" and never reaches a
+    "reconciled" state; a scoped command's overlay can also expire with no
+    terminal lifecycle event at all. A hand-maintained "currently
+    acknowledged" id set would leak forever in both cases. The fix removed
+    that dict entirely — _on_command_lifecycle_event recomputes "was this
+    acknowledged" from CommandService's own history on demand, so there is
+    no WebServer-owned per-command state to leak in the first place.
+    """
+    srv = WebServer()
+    q: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=16)
+    srv.register_control_event_queue(q)
+    service = _wire_stub_command_service(srv, _StubCommandExecutor())
+
+    # set_tuner: unmapped by _command_target() -> target=None -> pending_policy="none".
+    tuner_intent = command_intent_from_request(
+        "set_tuner", {"on": True}, source="websocket", command_id="cmd-tuner-1"
+    )
+    assert tuner_intent.target is None
+    await service.execute(tuner_intent)
+
+    # set_attenuator: scoped (target is not None) but still just acknowledged,
+    # never explicitly reconciled/confirmed in this test.
+    att_intent = command_intent_from_request(
         "set_attenuator",
         {"db": 20, "receiver": 0},
         source="websocket",
-        command_id="cmd-att-4",
+        command_id="cmd-att-5",
     )
-    srv.command_service.emit_lifecycle(intent, "accepted")
-    srv.command_service.emit_lifecycle(intent, "acknowledged")
-    srv.command_service.emit_lifecycle(intent, "confirmed")
+    assert att_intent.target is not None
+    await service.execute(att_intent)
 
-    assert "cmd-att-4" not in srv._acked_command_ids
+    # No notification for either — both succeeded — and no per-command
+    # bookkeeping attribute exists on WebServer to have accumulated entries.
+    assert q.empty()
+    assert not hasattr(srv, "_acked_command_ids")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -2954,6 +2954,116 @@ async def test_broadcast_notification_omits_code_for_legacy_path() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Post-ack command execution failure -> operator notification (MOR-1445)
+#
+# A websocket-queued command (e.g. set_attenuator) is acknowledged at
+# enqueue time and only actually fails later, once RadioPoller executes it
+# against the radio. CommandService already has NAK semantics for this via
+# fail_command()/lifecycle "failed"/"timed_out", but nothing was subscribed
+# to it, so the operator never learned the command silently failed. These
+# tests exercise WebServer's subscriber wiring directly at the handler
+# level, without a real RadioPoller/websocket.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_post_ack_command_failure_broadcasts_operator_notification() -> None:
+    """A command that fails AFTER being acknowledged reaches the operator."""
+    srv = WebServer()
+    q: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=16)
+    srv.register_control_event_queue(q)
+
+    intent = command_intent_from_request(
+        "set_attenuator",
+        {"db": 20, "receiver": 0},
+        source="websocket",
+        command_id="cmd-att-1",
+    )
+    srv.command_service.emit_lifecycle(intent, "accepted")
+    srv.command_service.emit_lifecycle(intent, "acknowledged")
+
+    fired = srv.command_service.fail_command(
+        "cmd-att-1",
+        message="Attenuator level must be one of [0, 45] dB for IC-7610, got 20",
+    )
+
+    assert fired is True
+    n = q.get_nowait()
+    assert n["type"] == "notification"
+    assert n["level"] == "error"
+    assert n["category"] == "command"
+    assert "Attenuator level" in n["message"]
+
+
+@pytest.mark.asyncio
+async def test_command_failure_before_ack_does_not_broadcast() -> None:
+    """A command rejected before enqueue/ack must not double-broadcast.
+
+    That synchronous rejection is already returned to the requesting client
+    as a WS response (and, client-side, as a refusal toast per MOR-1422) —
+    broadcasting it to every connected client here would be a duplicate.
+    """
+    srv = WebServer()
+    q: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=16)
+    srv.register_control_event_queue(q)
+
+    intent = command_intent_from_request(
+        "set_attenuator",
+        {"db": 999, "receiver": 0},
+        source="websocket",
+        command_id="cmd-att-2",
+    )
+    srv.command_service.emit_lifecycle(intent, "accepted")
+    # No "acknowledged" — this mirrors a synchronous executor rejection.
+    srv.command_service.emit_lifecycle(intent, "failed", message="bad db value")
+
+    assert q.empty()
+
+
+@pytest.mark.asyncio
+async def test_command_timed_out_after_ack_broadcasts_notification() -> None:
+    """timed_out is a terminal failure too and must also reach the operator."""
+    srv = WebServer()
+    q: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=16)
+    srv.register_control_event_queue(q)
+
+    intent = command_intent_from_request(
+        "set_attenuator",
+        {"db": 20, "receiver": 0},
+        source="websocket",
+        command_id="cmd-att-3",
+    )
+    srv.command_service.emit_lifecycle(intent, "accepted")
+    srv.command_service.emit_lifecycle(intent, "acknowledged")
+
+    srv.command_service.fail_command(
+        "cmd-att-3", message="radio did not respond", timed_out=True
+    )
+
+    n = q.get_nowait()
+    assert n["level"] == "error"
+    assert n["message"] == "radio did not respond"
+
+
+@pytest.mark.asyncio
+async def test_successful_command_does_not_leak_acked_id_tracking() -> None:
+    """A command that succeeds (never fails) must not accumulate tracking state."""
+    srv = WebServer()
+
+    intent = command_intent_from_request(
+        "set_attenuator",
+        {"db": 20, "receiver": 0},
+        source="websocket",
+        command_id="cmd-att-4",
+    )
+    srv.command_service.emit_lifecycle(intent, "accepted")
+    srv.command_service.emit_lifecycle(intent, "acknowledged")
+    srv.command_service.emit_lifecycle(intent, "confirmed")
+
+    assert "cmd-att-4" not in srv._acked_command_ids
+
+
+# ---------------------------------------------------------------------------
 # Sprint 0B compatibility: canonical state revision + updatedAt (#158)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Root cause

Live evidence on IC-7300: clicking the attenuator did nothing; server log showed the command was enqueued/acked and then rejected during execution:

```
enqueue_command: set_attenuator params={'db': 20, 'receiver': 0, ...}
WARNING radio-poller: cmd error: SetAttenuator
ValueError: Attenuator level must be 0..45 in 3 dB steps, got 20
```

Two defects:

1. **Hardcoded validation** — `CoreRadio.set_attenuator_level()` (`src/rigplane/runtime/radio.py`) enforced IC-7610's attenuator rule ("0..45 in 3 dB steps") as a universal constant. IC-7300's attenuator is a single 20 dB step (`rigs/ic7300.toml` `[attenuator] values = [0, 20]`) — the frontend was sending the *correct* value and getting rejected by another radio family's rule.
2. **Silent post-ack failure** — the command was accepted at enqueue (ack), and only failed later once `RadioPoller` actually executed it against the radio. `CommandService` already has NAK semantics for this (`fail_command()` → lifecycle `"failed"`/`"timed_out"`), but nothing was subscribed to those events, so the operator got no signal. MOR-1422's refusal toast only covers synchronous pre-enqueue client-side refusals.

## Fix

1. `set_attenuator_level()` now validates `db` against the radio's own declared `profile.att_values` (already populated per-radio from each rig's TOML `[attenuator] values`, and already exposed to the frontend via `web/server.py`'s capabilities payload — it just wasn't consulted by the backend setter). No hardcoded numeric range remains in runtime code. A profile that declares the `attenuator` capability but has no `[attenuator] values` section fails loud with `CommandError` naming the missing declaration, instead of silently falling back to a hardcoded range.
2. `WebServer` subscribes to `CommandService` lifecycle events (`command_service.subscribe_lifecycle`) and, when a command that was already acknowledged later reaches a terminal failure state (`"failed"` or `"timed_out"`), sends an `"error"` notification (existing `broadcast_notification`/`send_notification_to_session` — same WS `"notification"` wire schema the Toast component renders) **to the session that issued the command only** — never a broadcast to every connected client (see round-2 owner ruling below).

## Round-2 review (independent verifier: BLOCKED on the NAK half; attenuator half verified sound as-is)

**Fix A — stateless leak fix.** The original NAK-wiring used a `WebServer`-owned `_acked_command_ids: set[str]`, tracking "currently acknowledged" ids and clearing them only on `failed`/`timed_out`. The verifier reproduced a real leak: a command whose `_command_target()` is `None` (e.g. `set_tuner`) gets `pending_policy="none"` and never reaches a `"reconciled"` state; a scoped command's pending overlay can also expire silently with no lifecycle event at all (`_purge_expired`). Both leaked their id forever. The dict is now removed entirely — `_on_command_lifecycle_event` recomputes "was this command ever acknowledged" from `CommandService`'s own recorded lifecycle history on demand (`command_service.lifecycle_events()`), an equivalent stateless check with nothing to leak by construction. Tests were rewritten to drive a **real** `CommandService.execute()` round trip through a stub executor (not hand-emitted lifecycle states), including a direct repro of the `set_tuner`/scoped-no-leak scenario.

**Fix B — localization contract (RP-ML-005).** The notification now carries a stable reason code, `commandExecutionFailed`, with the exception text threaded through as a `reason` param — following the exact `core.toast.<code>` pattern the four existing `broadcast_notification` call sites use (`radioConnected`, `radioDisconnected`, `audioBridgeStarted`, `audioBridgeStopped`). `en-US` and `ru-RU` catalog entries were added, plus matching `messageFromReasonCode()` unit tests. `ja-JP` is a known, separately-tracked backlog gap for this code — same status as MOR-1422's `commandRefusedLinkDegraded`, which also has no `ja-JP` entry yet.

**Owner ruling — issuer-only delivery, not broadcast.** Post-ack failure notifications are unified with the MOR-1422 refusal-toast doctrine: error feedback belongs to whoever acted; a client that saw no state change from someone else's command should not get noise from it. `WebServer` now tracks `_session_queues: dict[str, BoundedQueue]` (session_id → that session's WS event queue) and exposes `send_notification_to_session(session_id, ...)`. `register_control_event_queue`/`unregister_control_event_queue` take an optional `session_id` (wired from `ControlHandler._session_id`). `_on_command_lifecycle_event` reads the issuing `session_id` already threaded onto the lifecycle event's `details` by `command_intent_from_request()`/`fail_command()` and sends to that one connection only — it never calls `broadcast_notification`. If no session_id is present (e.g. a hypothetical non-websocket source), nothing is sent to anyone, consistent with the issuer-only doctrine.

## Disclosures

- **rigctld behavior change:** `rigctld/handler.py:2051-2057` snaps hamlib's `L ATT` command to a hardcoded `[0, 6, 12, 18]` table — a *third*, separately-ticketed hardcoded-attenuator-range instance, not touched by this PR. With the backend validation now strict, a nonzero `L ATT` value that isn't one of the target radio's declared `att_values` returns `RPRT -1` (`EINVAL`, via rigctld's existing `ValueError` → `EINVAL` mapping) instead of silently BCD-encoding and sending an invalid CI-V byte to the radio. More honest, but a visible behavior change for hamlib clients against any non-IC-7610 rig with nonzero `L ATT`.
- **HTTP scope:** `self._http_command_service` (the synchronous HTTP command path) is **not** subscribed to `_on_command_lifecycle_event` — this notification path is websocket-only. HTTP callers already see the exception directly since their executor awaits synchronously.
- **db=1 acceptance change:** `db=1` is now correctly *accepted* for `(0,1)`-profile radios (e.g. X6200, whose attenuator is a raw on/off toggle over CI-V `0x11`, not a dB-BCD value — verified against the X6200 CI-V command map / `docs/validation/cat-audits/x6200.md`). Previously the old universal `db % 3 != 0` check rejected `db=1` even though it was the radio's own correct value — an incidental additional fix from the same root-cause change.

## Audit findings (not fixed here — follow-up)

Same-neighborhood check for other hardcoded/unused-range issues in `runtime/radio.py`:

- `set_preamp()` never validates `level` against the profile's declared `pre_values` (present on `RadioProfile`, already exposed to the frontend, never consulted by the backend setter) — same data-driven-but-unused pattern as the attenuator bug, but a different failure mode (silently accepts an invalid step rather than rejecting a valid one) with no reported live bug. Deferred given the broader test blast radius (many call sites across radio families).
- `set_agc()` validates `mode` via the `AgcMode` enum rather than the profile's declared `agc_modes` — same unused-declaration pattern, also deferred.
- `set_rf_gain`/`set_af_level`/`set_squelch` (`0..255`) and memory channel/band/register bounds are universal Icom CI-V protocol constants (not per-radio semantics like attenuator/preamp steps) — not data-driven violations, left as-is.

## Tests (TDD)

- `tests/test_radio_coverage.py`: IC-7300 accepts its declared 20 dB step and rejects IC-7610's 18 dB step; IC-7610 regression keeps its existing 0..45/3dB validation; a profile with the `attenuator` capability but no declared `att_values` raises `CommandError` naming the missing capability.
- `tests/test_web_server_coverage.py`: real `CommandService.execute()` round trip (via a stub executor) proves a command that fails after being acknowledged notifies **only** the issuing session (a second, bystander session gets zero messages); a command rejected before ack notifies no one; `timed_out` after ack also notifies the issuer only; `set_tuner` (target=None) and a scoped `set_attenuator` that succeeds leave no per-command tracking state behind (`_acked_command_ids` no longer exists at all); `send_notification_to_session` on an unknown/disconnected session is a no-op.
- `frontend/src/lib/i18n/__tests__/index.test.ts`: `commandExecutionFailed` resolves in `en-US` and in `ru-RU` (own catalog entry, not the `en-US` fallback), with the `reason` param threaded through.

## Suite results

- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 9029 passed, 12 skipped, 5 deselected, 11 xfailed, 1 xpassed, 0 failed
- `uv run mypy src/` — 13 pre-existing errors, all in files untouched by this PR (`backends/yaesu_cat/poller.py`, `runtime/_control_phase.py`, `runtime/_audio_runtime_mixin.py`, `web/radio_poller.py`); zero in the files this PR changes
- `uv run ruff check src/ tests/` — all checks passed
- `uv run ruff format src/ tests/` — no changes
- `uv run lint-imports` — 5/5 contracts kept
- `npx vitest run src/lib/i18n/__tests__/index.test.ts` (frontend) — 22/22 passed
- `node scripts/i18n-check.mjs` (frontend) — clean (informational-only notes about pre-existing, unrelated `ja-JP`/`ru-RU` catalog gaps)

## Scope

Files: `src/rigplane/runtime/radio.py`, `src/rigplane/web/server.py`, `src/rigplane/web/handlers/control.py`, `frontend/src/lib/i18n/locales/en-US.json`, `frontend/src/lib/i18n/locales/ru-RU.json`. Test files: `tests/test_radio_coverage.py`, `tests/test_web_server_coverage.py`, `frontend/src/lib/i18n/__tests__/index.test.ts`.

Known separately-tracked, unrelated CI item: the `quick` workflow's i18n-visual baseline check (`studioline--light--production-root.png`) is currently red on `main` itself (identical diff reproduced on a clean `main` run) — being diagnosed/fixed separately. Will rebase/merge `main` into this branch once that lands so `quick` goes green here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
