### PR TITLE
fix: RF gain/squelch sliders snap to 0/100%, add shared readout formatter (MOR-1447)

### DIFF
--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -250,10 +250,24 @@
    * above. `RF_FRONT_END_LEVEL_INTENT` maps the surface's field-addressed
    * `onLevelChange` onto the two real level handlers, mirroring
    * `TX_AUX_LEVEL_INTENT`.
+   *
+   * MOR-1447: `RfFrontEndSurface`'s `onLevelChange` reports the radio's own
+   * normalized 0..1 reading verbatim (its own "RAW wire units, no rescale"
+   * contract — `RfFrontEndSurface.svelte`'s file header) but the REAL
+   * `onRfGainChange`/`onSquelchChange` dispatch a raw 0-255 wire integer and
+   * refuse anything else (`Number.isSafeInteger` guard, `panel-commands.ts`).
+   * Converting at THIS seam, not inside `semanticHandlers` itself, keeps
+   * `bindSemanticSurfaceHandlers()`'s pinned "exact factory object, unreshaped"
+   * contract (`semantic-surface-handler-binder.isolated.test.ts`) intact.
+   * Unconverted, this was the MOR-1447 regression: an intermediate slider
+   * drag (e.g. 0.34) silently failed the integer guard, so dragging only ever
+   * landed on 0%/100% (the two values that already happen to be safe
+   * integers).
    */
   const rfFrontEndIntents = semanticHandlers.rfFrontEnd;
   const RF_FRONT_END_LEVEL_INTENT: Record<RfFrontEndLevelField, (value: number) => void> = {
-    rfGain: rfFrontEndIntents.onRfGainChange, squelch: rfFrontEndIntents.onSquelchChange,
+    rfGain: (value) => rfFrontEndIntents.onRfGainChange(Math.round(value * 255)),
+    squelch: (value) => rfFrontEndIntents.onSquelchChange(Math.round(value * 255)),
   };
   const RF_FRONT_END_TOGGLE_INTENT: Record<RfFrontEndToggleField, (next: boolean) => void> = {
     digiSel: rfFrontEndIntents.onDigiSelToggle, ipPlus: rfFrontEndIntents.onIpPlusToggle,

--- a/frontend/src/components-v2/wiring/__tests__/semantic-rf-front-end-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rf-front-end-wiring.component.test.ts
@@ -280,23 +280,29 @@ describe('every rfFrontEnd intent reaches its own command-bus handler, none cros
     for (const other of ALL.filter((s) => s !== h.att)) expect(other).not.toHaveBeenCalled();
   });
 
-  it('routes the RF-gain slider to onRfGainChange, verbatim', () => {
+  // MOR-1447: the surface reports the radio's normalized 0..1 reading (no
+  // rescale, per `RfFrontEndSurface.svelte`'s own contract), but the REAL
+  // `onRfGainChange` dispatches a raw 0-255 wire integer and refuses
+  // anything else — so the wiring must convert on the way through. This was
+  // the input-snaps-to-0%-or-100% regression: an unconverted intermediate
+  // drag silently failed the real handler's integer guard.
+  it('routes the RF-gain slider to onRfGainChange, converted to the raw 0-255 wire level', () => {
     render();
     const input = el('rfGain')!.querySelector('input')!;
     input.value = '0.55';
     input.dispatchEvent(new Event('input', { bubbles: true }));
     flushSync();
-    expect(h.rfGain).toHaveBeenCalledExactlyOnceWith(0.55);
+    expect(h.rfGain).toHaveBeenCalledExactlyOnceWith(Math.round(0.55 * 255));
     for (const other of ALL.filter((s) => s !== h.rfGain)) expect(other).not.toHaveBeenCalled();
   });
 
-  it('routes the squelch slider to onSquelchChange, verbatim', () => {
+  it('routes the squelch slider to onSquelchChange, converted to the raw 0-255 wire level', () => {
     render();
     const input = el('squelch')!.querySelector('input')!;
     input.value = '0.2';
     input.dispatchEvent(new Event('input', { bubbles: true }));
     flushSync();
-    expect(h.squelch).toHaveBeenCalledExactlyOnceWith(0.2);
+    expect(h.squelch).toHaveBeenCalledExactlyOnceWith(Math.round(0.2 * 255));
     for (const other of ALL.filter((s) => s !== h.squelch)) expect(other).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/lib/runtime/adapters/__tests__/mor1428-ic7300-conformance.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mor1428-ic7300-conformance.isolated.test.ts
@@ -139,6 +139,7 @@ import { isFieldAvailable } from '$lib/state/field-status';
 import { validateRadioViewModel } from '../../../../semantic/radio-view-model';
 import { toRadioViewModel } from '../radio-view-model-adapter';
 import { toSpectrumAuthority } from '../scope-adapter';
+import { getRfFrontEndHandlers } from '../panel-adapters';
 import { IC7300_CAPABILITIES, IC7300_STATE } from './fixtures/ic7300-profile';
 
 /** Deep clone so a test that mutates `h.state`/`h.caps` never leaks into a sibling. */
@@ -258,14 +259,37 @@ describe('IC-7300 fixture — handler dispatch through real factories (MOR-1418/
     expectIntentTransport();
   });
 
-  it('RF front end: dispatches set_attenuator / set_preamp / set_rf_gain on receiver 0', () => {
+  it('RF front end: dispatches set_attenuator / set_preamp / set_rf_gain / set_squelch on receiver 0', () => {
     makeRfFrontEndHandlers().onAttChange(0);
     makeRfFrontEndHandlers().onPreChange(1);
     makeRfFrontEndHandlers().onRfGainChange(200);
+    makeRfFrontEndHandlers().onSquelchChange(51);
     expect(exactCalls()).toEqual([
       ['set_attenuator', { db: 0, receiver: 0 }],
       ['set_preamp', { level: 1, receiver: 0 }],
       ['set_rf_gain', { level: 200, receiver: 0 }],
+      ['set_squelch', { level: 51, receiver: 0 }],
+    ]);
+    expectIntentTransport();
+  });
+
+  // MOR-1447 regression: the live stand's captured `main.rfGain` reading
+  // (`fixtures/ic7300-state.json`) is the exact normalized float
+  // `0.8196078431372549` a slider drag reports — the walkthrough that found
+  // dragging RF gain/squelch snapping to 0%/100% only. `getRfFrontEndHandlers`
+  // (unlike the raw-int `makeRfFrontEndHandlers` exercised above) is the
+  // adapter seam every slider actually calls, and must convert that
+  // normalized reading to the raw wire integer `set_rf_gain` requires instead
+  // of failing the real handler's integer guard.
+  it('RF gain/squelch sliders: getRfFrontEndHandlers converts a normalized drag to the raw wire level (MOR-1447)', () => {
+    expect(IC7300_STATE.main!.rfGain).toBeCloseTo(0.8196078431372549);
+
+    getRfFrontEndHandlers().onRfGainChange(IC7300_STATE.main!.rfGain!);
+    getRfFrontEndHandlers().onSquelchChange(0.2);
+
+    expect(exactCalls()).toEqual([
+      ['set_rf_gain', { level: 209, receiver: 0 }],
+      ['set_squelch', { level: 51, receiver: 0 }],
     ]);
     expectIntentTransport();
   });

--- a/frontend/src/lib/runtime/adapters/panel-adapters.ts
+++ b/frontend/src/lib/runtime/adapters/panel-adapters.ts
@@ -69,7 +69,36 @@ export function getAntennaHandlers() { return _antennaHandlers; }
 export function deriveRfFrontEndProps() {
   return toRfFrontEndProps(runtime.state, runtime.caps);
 }
-const _rfHandlers = makeRfFrontEndHandlers();
+/**
+ * `onRfGainChange`/`onSquelchChange` dispatch `set_rf_gain`/`set_squelch`
+ * over the wire as a raw 0-255 integer (`radio-intents.ts`'s `level:
+ * 'integer'`, matching `core.radio_protocol.set_rf_gain`'s "0-255 scale"
+ * contract) and refuse anything else (`Number.isSafeInteger` guard,
+ * `panel-commands.ts`). Every RF-gain/squelch slider in this codebase
+ * (`RfFrontEnd.svelte`'s `ValueControl`/`DualParamRenderer`,
+ * `RfFrontEndSurface.svelte`'s raw `<input type="range">`) instead reports
+ * the radio's own normalized 0..1 reading — so an intermediate drag (e.g.
+ * 0.34) silently failed the integer guard, and only the two endpoints (0 and
+ * 1, which happen to already be safe integers) ever dispatched. That is the
+ * MOR-1447 regression: dragging snapped to 0%/100% only.
+ *
+ * Applied here for `getRfFrontEndHandlers()` (the legacy `RfFrontEnd.svelte`
+ * panel's singleton seam) only — NOT inside `bindSemanticSurfaceHandlers()`,
+ * which is pinned to hand back each family's exact, unwrapped factory object
+ * (`semantic-surface-handler-binder.isolated.test.ts`).
+ * `SemanticRadioSurfaces.svelte` performs the equivalent conversion itself at
+ * its `RF_FRONT_END_LEVEL_INTENT` seam for that path.
+ */
+function withNormalizedRfLevels(
+  handlers: ReturnType<typeof makeRfFrontEndHandlers>,
+): ReturnType<typeof makeRfFrontEndHandlers> {
+  return {
+    ...handlers,
+    onRfGainChange: (level: number) => handlers.onRfGainChange(Math.round(level * 255)),
+    onSquelchChange: (level: number) => handlers.onSquelchChange(Math.round(level * 255)),
+  };
+}
+const _rfHandlers = withNormalizedRfLevels(makeRfFrontEndHandlers());
 export function getRfFrontEndHandlers() { return _rfHandlers; }
 
 // ── RIT/XIT ──
@@ -136,6 +165,13 @@ export function bindSemanticSurfaceHandlers() {
     dsp: makeDspHandlers(),
     filter: makeFilterHandlers(),
     mode: makeModeHandlers(),
+    // NOT wrapped with `withNormalizedRfLevels` here: `bindSemanticSurfaceHandlers()`
+    // is pinned (`semantic-surface-handler-binder.isolated.test.ts`) to hand
+    // back each family's EXACT factory object, unreshaped — the wrapping this
+    // module does for `getRfFrontEndHandlers()` below would break that
+    // identity contract. `SemanticRadioSurfaces.svelte` does the equivalent
+    // normalized-to-raw conversion itself, at its `RF_FRONT_END_LEVEL_INTENT`
+    // seam, for the same reason.
     rfFrontEnd: makeRfFrontEndHandlers(),
     ritXit: makeRitXitHandlers(),
     rxAudio: makeRxAudioHandlers(),

--- a/frontend/src/semantic/RfFrontEndSurface.svelte
+++ b/frontend/src/semantic/RfFrontEndSurface.svelte
@@ -42,6 +42,7 @@
 <script module lang="ts">
   import type { DisabledReasonCode, RfFrontEndField } from './radio-view-model';
   import { pressedOf } from './pressed-of';
+  import { formatKnownLevel } from './format-level';
 
   /** The one rendering of "not read". Never 0, never the last value. */
   export const UNKNOWN_TEXT = '?';
@@ -52,6 +53,11 @@
   /** Honest text: an unread fact reads as unknown, never as a stale value. */
   export const textOf = (f: RfFrontEndField<unknown>): string =>
     f.reading.status === 'known' ? String(f.reading.value) : UNKNOWN_TEXT;
+  /** Same freshness discipline as `textOf`, but a KNOWN level reading is
+   *  formatted against its declared `[min, max]` domain (MOR-1447) instead of
+   *  `String()`-ing the raw wire fraction. */
+  const levelTextOf = (f: RfFrontEndField<number>, min: number, max: number): string =>
+    f.reading.status === 'known' ? formatKnownLevel(f.reading.value, min, max) : UNKNOWN_TEXT;
   const isValue = (f: RfFrontEndField<unknown>, value: unknown): boolean =>
     f.reading.status === 'known' && f.reading.value === value;
 
@@ -171,7 +177,7 @@
             disabled={!usable(rf[field])}
             oninput={(event) => changeLevel(field, event.currentTarget.valueAsNumber)}
           />
-          <output>{textOf(rf[field])}</output>
+          <output>{levelTextOf(rf[field], min, max)}</output>
         </label>
       {/if}
     {/each}

--- a/frontend/src/semantic/TxAuxSurface.svelte
+++ b/frontend/src/semantic/TxAuxSurface.svelte
@@ -29,6 +29,7 @@
 <script module lang="ts">
   import type { TxAuxField } from './radio-view-model';
   import { pressedOf } from './pressed-of';
+  import { formatKnownLevel } from './format-level';
   import { disabledReasonText } from './disabled-reason';
 
   /** On/off controls, `[field, label]`. ATU's reading is a three-state enum,
@@ -68,6 +69,12 @@
     f.reading.status !== 'known' ? '?'
       : typeof f.reading.value === 'boolean' ? (f.reading.value ? 'on' : 'off')
         : String(f.reading.value);
+  /** Same freshness discipline as `textOf`, but a KNOWN level reading is
+   *  formatted against its declared `[min, max]` domain (MOR-1447) instead of
+   *  `String()`-ing the raw wire fraction — e.g. RF power reading back as
+   *  the literal `0.5529411764705883` instead of "55%". */
+  const levelTextOf = (f: TxAuxField<number>, min: number, max: number): string =>
+    f.reading.status === 'known' ? formatKnownLevel(f.reading.value, min, max) : '?';
   const numberOf = (f: TxAuxField<number>, fallback: number): number =>
     f.reading.status === 'known' ? f.reading.value : fallback;
 
@@ -162,7 +169,7 @@
           {#if reasonTextOf(txAux[field]) !== undefined}
             <span id={reasonIdOf(field, txAux[field])} class="sr-only">{reasonTextOf(txAux[field])}</span>
           {/if}
-          <output>{textOf(txAux[field])}</output>
+          <output>{levelTextOf(txAux[field], min, max)}</output>
         </label>
       {/if}
     {/each}

--- a/frontend/src/semantic/__tests__/RfFrontEndSurface.test.ts
+++ b/frontend/src/semantic/__tests__/RfFrontEndSurface.test.ts
@@ -266,6 +266,22 @@ describe('RF gain and squelch render as 0..1 sliders, no rescale', () => {
     expect(onLevelChange).not.toHaveBeenCalled();
     r.dispose();
   });
+
+  // MOR-1447: the readout must format the known 0..1 fraction as a percent,
+  // not the raw wire float — the live IC-7300 walkthrough regression this
+  // pins reads `main.rfGain` back as the literal `0.8196078431372549`.
+  it('renders a known RF-gain reading as a rounded percent, not the raw wire float', () => {
+    const r = render(withRf({ rfGain: known(0.8196078431372549) }));
+    expect(r.text('rfGain')).toContain('82%');
+    expect(r.text('rfGain')).not.toContain('0.8196078431372549');
+    r.dispose();
+  });
+
+  it('renders a known squelch reading as a rounded percent too', () => {
+    const r = render(withRf({ squelch: known(0.2) }));
+    expect(r.text('squelch')).toContain('20%');
+    r.dispose();
+  });
 });
 
 describe('DIGI-SEL and IP+ render as toggles and emit the FLIPPED value', () => {

--- a/frontend/src/semantic/__tests__/TxAuxSurface.test.ts
+++ b/frontend/src/semantic/__tests__/TxAuxSurface.test.ts
@@ -414,3 +414,26 @@ describe('level intents reach the caller with the field and the raw value', () =
     });
   });
 });
+
+// ── 7. Readout formatting (MOR-1447) ────────────────────────────────────────
+
+describe('the readout formats a 0..1 level as a percent, not the raw wire float', () => {
+  // The mobile/narrow composition regression this pins: RF power read back
+  // as the literal `0.5529411764705883` instead of a formatted percent.
+  it('formats RF power as a rounded percent (fixture value 0.8 -> "80%")', () => {
+    withSurface(base(), snap(), (s) => {
+      const output = s.control('rfPower')!.querySelector('output')!;
+      expect(output.textContent).toBe('80%');
+    });
+  });
+
+  // Contrast: a raw 0..255 level and a small integer domain both keep
+  // reading as the plain number — only the declared 0..1 fraction is
+  // percent-formatted (`formatKnownLevel`'s domain-generic rule).
+  it('leaves a raw 0..255 level (mic gain) as the plain number', () => {
+    withSurface(base(), snap(), (s) => {
+      const output = s.control('micGain')!.querySelector('output')!;
+      expect(output.textContent).toBe('128');
+    });
+  });
+});

--- a/frontend/src/semantic/__tests__/format-level.test.ts
+++ b/frontend/src/semantic/__tests__/format-level.test.ts
@@ -1,0 +1,50 @@
+/**
+ * MOR-1447 — the shared `formatKnownLevel` readout helper.
+ *
+ * Extracted so every semantic-surface level slider (`RfFrontEndSurface`'s RF
+ * gain/squelch, `TxAuxSurface`'s RF power, …) renders a KNOWN reading the
+ * same honest way instead of each surface's `textOf` doing `String(value)`
+ * on a raw wire float. That raw path is the live MOR-1447 regression: an
+ * IC-7300 walkthrough read RF gain back as the literal wire float
+ * `0.8196078431372549` (captured verbatim in
+ * `lib/runtime/adapters/__tests__/fixtures/ic7300-state.json`'s
+ * `main.rfGain`) instead of a formatted "82%".
+ *
+ * `[min, max]` come from the SAME per-field domain tuple the surface already
+ * declares for its `<input type="range">` (`RF_FRONT_END_LEVELS` /
+ * `TX_AUX_LEVELS`) — the function stays generic over that declared scale
+ * rather than special-casing a field name or a radio vendor, so a control
+ * whose domain is genuinely raw (mic gain 0..255, VOX delay 0..20 seconds)
+ * keeps rendering its native number, and only a field the surface itself
+ * declares as a 0..1 fraction is percent-formatted.
+ */
+import { describe, expect, it } from 'vitest';
+import { formatKnownLevel } from '../format-level';
+
+describe('formatKnownLevel (MOR-1447)', () => {
+  it('formats a 0..1 fraction as a rounded percent — the MOR-1447 repro value', () => {
+    // The exact live-captured value from ic7300-state.json's `main.rfGain`.
+    expect(formatKnownLevel(0.8196078431372549, 0, 1)).toBe('82%');
+  });
+
+  it('formats a second 0..1 field (e.g. RF power) the same way', () => {
+    expect(formatKnownLevel(0.5529411764705883, 0, 1)).toBe('55%');
+  });
+
+  it('rounds 0 and 1 to the clean endpoints', () => {
+    expect(formatKnownLevel(0, 0, 1)).toBe('0%');
+    expect(formatKnownLevel(1, 0, 1)).toBe('100%');
+  });
+
+  it('leaves a non-fractional domain (e.g. raw 0..255 mic gain) as the plain number', () => {
+    expect(formatKnownLevel(128, 0, 255)).toBe('128');
+  });
+
+  it('leaves a small integer domain (e.g. VOX delay 0..20 seconds) as the plain number', () => {
+    expect(formatKnownLevel(5, 0, 20)).toBe('5');
+  });
+
+  it('leaves a non-zero-based 0..1-width domain as the plain number (not treated as a fraction)', () => {
+    expect(formatKnownLevel(1.5, 1, 2)).toBe('1.5');
+  });
+});

--- a/frontend/src/semantic/format-level.ts
+++ b/frontend/src/semantic/format-level.ts
@@ -1,0 +1,21 @@
+/**
+ * Shared readout formatter for semantic-surface level sliders (MOR-1447).
+ *
+ * A KNOWN reading on a control declared with a 0..1-wide domain (RF gain,
+ * squelch, RF power, …) is a wire-protocol fraction, not a number meant for
+ * display — rendering it with `String(value)` is what produced the live
+ * IC-7300 regression (`0.8196078431372549` on screen instead of "82%").
+ * Every OTHER declared domain (raw 0..255 levels, second counts, …) already
+ * reads as a clean integer and is left untouched.
+ *
+ * Generic over the declared `[min, max]` domain — the same tuple the surface
+ * already passes to its `<input type="range">` — rather than a field name or
+ * a radio-vendor branch, so this stays correct for any future control that
+ * declares the same 0..1 fraction shape.
+ */
+export function formatKnownLevel(value: number, min: number, max: number): string {
+  if (min === 0 && max === 1) {
+    return `${Math.round(value * 100)}%`;
+  }
+  return String(value);
+}


### PR DESCRIPTION
## Root cause

**Input snap-to-0%/100% (ticket bullet 1).** Every RF-gain/squelch slider reports the radio's own normalized `0..1` reading:
- `frontend/src/components-v2/panels/RfFrontEnd.svelte` (legacy panel, `ValueControl`/`DualParamRenderer`, `min=0 max=1 step=0.01`)
- `frontend/src/semantic/RfFrontEndSurface.svelte:60-63,168-173` (raw `<input type="range">`, documented "RAW wire units (0..1 fractions, no rescale)")

but the real handlers dispatch `set_rf_gain`/`set_squelch` as a raw **0-255 wire integer** and refuse anything else:
- `frontend/src/lib/runtime/commands/panel-commands.ts:373-381` — `onRfGainChange`/`onSquelchChange` guard with `Number.isSafeInteger(level)`
- `frontend/src/lib/runtime/commands/radio-intents.ts:24` — `set_rf_gain`/`set_squelch` declared `level: 'integer'`
- `src/rigplane/core/radio_protocol.py:309-325` — `set_rf_gain(level: int)`/`set_squelch(level: int)`, "Level in 0-255 scale"

An intermediate drag (e.g. `0.34`) silently failed the integer guard and never dispatched. Only the two endpoints (`0`/`1`) happen to already be safe integers, so dragging visually "snapped" to 0%/100% — exactly the reported regression.

Desktop-v2 (the flagship skin every real Icom radio uses, `desktop-declarations.ts:144-147`) declares an `rfFrontEnd` zone (`desktop-declarations.ts:72`), which suppresses the legacy panel in favor of `RfFrontEndSurface.svelte` wired through `components-v2/wiring/SemanticRadioSurfaces.svelte:255-256` — that is the live path the IC-7300 walkthrough hit.

**Raw float readout (ticket bullet 2).** Both semantic surfaces rendered a KNOWN `0..1` reading with `String(value)`:
- `RfFrontEndSurface.svelte`'s `textOf` — RF gain/squelch
- `TxAuxSurface.svelte`'s `textOf` — RF power (the "mobile/narrow composition… `0.5529411764705883`" instance named in the ticket)

The fixture `frontend/src/lib/runtime/adapters/__tests__/fixtures/ic7300-state.json`'s `main.rfGain: 0.8196078431372549` is the exact live-captured value from the ticket's repro.

## Fix

**Input path** — convert normalized level to the raw wire integer at the two seams that pass it through unconverted, reusing the same `Math.round(level * 255)` shape `panel-commands.ts`'s `adjust_rf_gain` keyboard case already used:
- `lib/runtime/adapters/panel-adapters.ts` — `getRfFrontEndHandlers()` (the legacy panel's singleton, still live on `mobile`/`dual-receiver-cockpit` skins, which don't declare an `rfFrontEnd` zone) wraps `onRfGainChange`/`onSquelchChange`.
- `components-v2/wiring/SemanticRadioSurfaces.svelte` — `RF_FRONT_END_LEVEL_INTENT` (the desktop-v2 live path) converts inline.

Not wrapped inside `bindSemanticSurfaceHandlers()` itself: that binder is pinned to hand back each family's exact, unreshaped factory object (`semantic-surface-handler-binder.isolated.test.ts`), so the conversion lives at each consumer's own seam instead.

**Readout formatting** — new `frontend/src/semantic/format-level.ts`, a `formatKnownLevel(value, min, max)` shared by `RfFrontEndSurface.svelte` and `TxAuxSurface.svelte`. Generic over the field's declared `[min, max]` domain (the same tuple already passed to the `<input type="range">`) rather than a field name or vendor branch — a `0..1`-declared field renders `"82%"`; a raw-scale field (mic gain `0..255`, VOX delay `0..20`s) keeps rendering its plain number, untouched.

**Conformance suite** — extended `mor1428-ic7300-conformance.isolated.test.ts` (MOR-1428/#2380) with a `set_squelch` dispatch case and a round-trip case that feeds the fixture's captured `0.8196078431372549` `rfGain` reading through `getRfFrontEndHandlers()` and asserts the wire frame is `{ level: 209 }`.

## Tests

- `frontend/src/semantic/__tests__/format-level.test.ts` (new) — unit tests for the formatter, including the exact repro values from the ticket.
- `frontend/src/semantic/__tests__/RfFrontEndSurface.test.ts` — readout format cases for RF gain/squelch.
- `frontend/src/semantic/__tests__/TxAuxSurface.test.ts` — readout format case for RF power; contrast case for a raw-scale field.
- `frontend/src/components-v2/wiring/__tests__/semantic-rf-front-end-wiring.component.test.ts` — updated the two "verbatim" pins to expect the converted raw wire level (this file previously pinned the bug as intended behavior).
- `frontend/src/lib/runtime/adapters/__tests__/mor1428-ic7300-conformance.isolated.test.ts` — extended per the ticket's explicit ask.

Full frontend suite: **6642/6642 passing** (322 files). `eslint src/`: 0 violations. `svelte-check`: 0 errors/warnings.

## LOC

5 production files touched, **84 net production LOC** (`git diff --stat`: 88 insertions − 4 deletions), well under the 200 LOC budget. Exceeds the usual 3-file guardrail by 2 files — unavoidable given the bug has two independent live call sites (legacy panel vs. the desktop-v2 semantic surface) plus the new shared formatter module; noted here for visibility rather than split further, since all three pieces are small and load-bearing for the same regression.

## Deferred: combined Icom RF/SQL knob (ticket bullet 3)

Confirmed this is a real regression, not a missing feature: the legacy `RfFrontEnd.svelte` panel already has a working combined-knob implementation (`components-v2/controls/value-control/DualParamRenderer.svelte` + `dualParamValuesFromNormX` in `value-control-core.ts`, wired whenever both `rfGain`/`squelch` are shown) that implements exactly the described Icom mapping (center = RF max + SQL min, hard left = RF min, hard right = SQL max). The MOR-1366 zone-declaration switchover to `RfFrontEndSurface.svelte` on desktop-v2 dropped it — that surface renders two independent raw sliders with no combined-knob option. (Note: no `sdr-test`-skin implementation was found; the actual reference implementation is `DualParamRenderer.svelte`, not the skin named in the ticket.)

Splitting this out because porting it correctly is a materially separate change: `RfFrontEndSurface.svelte` is presentation-only with pinned two-slider-emission tests, and the surface has no capability signal today to decide "combined" vs. "separate" — per the owner's data-driven directive, that decision must come from an explicit profile/capability declaration (e.g. a `rfSqlControlModel` field: `'combined' | 'separate'`), not a vendor/model-name branch in frontend code. Concrete follow-up shape:

1. **Backend**: add a control-model flag to the Icom profile/capabilities schema (`src/rigplane/profiles/`, `Capabilities` type) declaring `rfSqlControlModel: 'combined' | 'separate'` (or similar), defaulting to `'separate'` for backends that don't declare it.
2. **Frontend capability plumbing**: surface that flag through `Capabilities`/the view model, alongside the existing `rf_gain`/`squelch` capability booleans.
3. **Semantic surface**: extend `RfFrontEndSurface.svelte` (or a sibling component) to render `DualParamRenderer`'s mapping (`dualParamValuesFromNormX`/`dualParamNormXFromValues` from `value-control-core.ts`, ported/generalized rather than re-derived) when the profile declares `'combined'`, falling back to today's two independent sliders otherwise.
4. **Tests**: new conformance cases pinning the mapping (center/hard-left/hard-right/blend) against the flag, plus a case proving a non-declaring profile keeps separate sliders.

Not started in this PR to stay within the LOC budget and avoid a backend + frontend schema change riding on a slider-input bugfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)