### PR TITLE
fix: rediscover renumbered serial node on reconnect (MOR-1453)

### DIFF
--- a/src/rigplane/audio/usb_driver.py
+++ b/src/rigplane/audio/usb_driver.py
@@ -592,6 +592,18 @@ class UsbAudioDriver:
             return self._duplex_stream.running
         return self._tx_stream is not None and self._tx_stream.running
 
+    def set_serial_port(self, serial_port: str | None) -> None:
+        """Rebind topology-based audio resolution to a new serial port.
+
+        Used after serial-node rediscovery (MOR-1453) so the next
+        ``start_rx``/``start_tx`` call re-resolves RX/TX device indices
+        against the radio's new (renumbered) device node instead of the
+        one captured at construction. ``_ensure_selected_devices``
+        recomputes the selection unconditionally on every call, so no
+        separate cache invalidation is needed here.
+        """
+        self._serial_port = serial_port
+
     @property
     def selected_rx_device(self) -> UsbAudioDevice | None:
         return self._selected_rx

--- a/src/rigplane/audio/usb_driver.py
+++ b/src/rigplane/audio/usb_driver.py
@@ -595,14 +595,20 @@ class UsbAudioDriver:
     def set_serial_port(self, serial_port: str | None) -> None:
         """Rebind topology-based audio resolution to a new serial port.
 
-        Used after serial-node rediscovery (MOR-1453) so the next
-        ``start_rx``/``start_tx`` call re-resolves RX/TX device indices
-        against the radio's new (renumbered) device node instead of the
-        one captured at construction. ``_ensure_selected_devices``
-        recomputes the selection unconditionally on every call, so no
-        separate cache invalidation is needed here.
+        Used after serial-node rediscovery (MOR-1453) so the next audio
+        resolution re-resolves RX/TX device indices against the radio's
+        new (renumbered) device node instead of the one captured at
+        construction. ``start_rx``/``start_tx`` call ``_ensure_selected_
+        devices`` unconditionally, so they always see the new port -- but
+        ``duplex_mode`` and ``selected_rx_device``/``selected_tx_device``
+        read the ``_selected_rx``/``_selected_tx`` cache directly without
+        forcing a fresh resolution, so it is cleared here to avoid
+        reporting a stale device from the old port between rediscovery
+        and the next start call.
         """
         self._serial_port = serial_port
+        self._selected_rx = None
+        self._selected_tx = None
 
     @property
     def selected_rx_device(self) -> UsbAudioDevice | None:

--- a/src/rigplane/backends/_icom_serial_base.py
+++ b/src/rigplane/backends/_icom_serial_base.py
@@ -504,11 +504,23 @@ class _IcomSerialRadioBase(CoreRadio):
         - PRIMARY: match candidates (OS-enumerated, filtered by
           ``_serial_reconnect_glob``) against our own USB ``serial_number``
           captured at the last connect -- no port is ever opened for this.
-        - FALLBACK (only when our adapter exposed no serial_number): the
-          CI-V probe, but skip -- never open -- a candidate whose vid/pid
-          is *known* to differ from ours. Narrows, does not eliminate, the
-          collision risk when neither side exposes a serial number and
-          both share (or lack) vid/pid -- documented residual gap.
+          An empty string (pyserial surfaces ``""``, not ``None``, for a
+          stripped-descriptor adapter on some Linux/Windows hosts) is
+          treated as "no fingerprint", not a wildcard -- falls through to
+          FALLBACK instead of matching any other empty-serial candidate.
+          A candidate is also rejected when its enumerated vid/pid is
+          *known* to differ from ours, closing coincidental cross-vendor
+          serial-string collisions.
+        - FALLBACK (adapter exposed no usable serial_number): the CI-V
+          probe, but skip -- never open -- a candidate whose vid/pid is
+          *known* to differ from ours. When our own identity is entirely
+          unknown (enumeration failed or never found our path), FALLBACK
+          runs with zero vid/pid filtering. Narrows, does not eliminate,
+          the collision risk when neither side exposes a serial number
+          and both share (or lack) vid/pid -- documented residual gap.
+          Ports rejected by ``discovery._is_candidate`` (e.g. non-USB or
+          virtual ports) are never enumerated and so never rediscoverable
+          -- silent by design, matching initial discovery's own filter.
         """
         if os.path.exists(self._serial_device):
             return
@@ -535,11 +547,16 @@ class _IcomSerialRadioBase(CoreRadio):
             None,
         )
         adopted: str | None = None
-        if target_serial is not None:
+        if target_serial:
             for candidate in candidates:
-                if candidate.serial_number == target_serial:
-                    adopted = candidate.device
-                    break
+                if candidate.serial_number != target_serial:
+                    continue
+                if target_vid is not None and candidate.vid not in (None, target_vid):
+                    continue
+                if target_pid is not None and candidate.pid not in (None, target_pid):
+                    continue
+                adopted = candidate.device
+                break
         else:
             for candidate in candidates:
                 if target_vid is not None and candidate.vid not in (None, target_vid):

--- a/src/rigplane/backends/_icom_serial_base.py
+++ b/src/rigplane/backends/_icom_serial_base.py
@@ -8,9 +8,12 @@ serial-backed radios (IC-705, IC-7300, IC-9700, IC-7610).
 from __future__ import annotations
 
 import asyncio
+import glob
 import logging
 import os
+import re
 import time
+from collections.abc import Awaitable
 from typing import TYPE_CHECKING, Callable, Literal, Protocol
 
 from .._connection_state import RadioConnectionState
@@ -45,6 +48,21 @@ def _env_bool(name: str, default: bool = False) -> bool:
     if raw is None:
         return default
     return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+# MOR-1453: trailing device-node suffix that encodes the physical USB port
+# (macOS ``/dev/cu.usbserial-1420``) or enumeration order (Linux
+# ``/dev/ttyUSB0``). Stripped to derive a glob pattern that matches sibling
+# nodes of the same USB-serial family after a replug renumbers the node.
+_TRAILING_NODE_SUFFIX_RE = re.compile(r"(-[0-9A-Za-z]+|[0-9]+)$")
+
+
+def _derive_reconnect_glob(device: str) -> str:
+    """Best-effort glob pattern matching sibling device nodes of *device*."""
+    stripped = _TRAILING_NODE_SUFFIX_RE.sub("", device)
+    if not stripped or stripped == device:
+        return device + "*"
+    return stripped + "*"
 
 
 class _SerialAudioDriver(Protocol):
@@ -117,6 +135,8 @@ class _IcomSerialRadioBase(CoreRadio):
         civ_link: SerialCivLink | None = None,
         session_driver: SerialSessionDriver | None = None,
         audio_driver: _SerialAudioDriver | None = None,
+        reconnect_glob: str | None = None,
+        _civ_identity_probe: Callable[[str], Awaitable[int | None]] | None = None,
     ) -> None:
         from .icom7610.drivers.serial_civ_link import SerialCivLink
         from .icom7610.drivers.serial_session import SerialSessionDriver
@@ -140,6 +160,13 @@ class _IcomSerialRadioBase(CoreRadio):
         self._serial_baudrate = baudrate
         self._serial_rx_device_override = rx_device
         self._serial_tx_device_override = tx_device
+        # MOR-1453: glob pattern used to rediscover a renumbered device node
+        # (e.g. macOS reassigning /dev/cu.usbserial-XXXX on a USB replug)
+        # when the configured path vanishes. Auto-derived unless overridden.
+        self._serial_reconnect_glob = reconnect_glob or _derive_reconnect_glob(device)
+        self._civ_identity_probe = (
+            _civ_identity_probe or self._default_civ_identity_probe
+        )
         if ptt_mode != "civ":
             raise ValueError(
                 "Unsupported serial PTT mode. Only 'civ' is currently supported."
@@ -161,6 +188,12 @@ class _IcomSerialRadioBase(CoreRadio):
         self._civ_min_interval = serial_min_interval_ms / 1000.0
         serial_link = civ_link or SerialCivLink(device=device, baudrate=baudrate)
         self._serial_session = session_driver or SerialSessionDriver(serial_link)
+        # MOR-1453: reference to the raw link, used to rebind its device path
+        # on rediscovery. ``None`` when a bespoke ``session_driver`` was
+        # supplied directly, since its internal link is then unreachable
+        # from here -- rediscovery degrades to updating ``_serial_device``
+        # and the audio topology hint only in that (currently unused) path.
+        self._serial_civ_link = serial_link if session_driver is None else None
         self._serial_audio_driver = audio_driver or UsbAudioDriver(
             AudioDeviceConfig(
                 rx_device=rx_device,
@@ -361,6 +394,7 @@ class _IcomSerialRadioBase(CoreRadio):
         await self._stop_civ_worker()
         await self._stop_civ_rx_pump()
         await self._serial_session.disconnect()
+        await self._maybe_rediscover_serial_device()
 
         try:
             await self._serial_session.connect()
@@ -399,6 +433,69 @@ class _IcomSerialRadioBase(CoreRadio):
                     "serial soft_reconnect: _on_reconnect callback failed",
                     exc_info=True,
                 )
+
+    # ------------------------------------------------------------------
+    # Renumbered-node rediscovery (MOR-1453)
+    # ------------------------------------------------------------------
+
+    async def _maybe_rediscover_serial_device(self) -> None:
+        """Rediscover a renumbered device node before retrying connect.
+
+        The configured device path is a fixed string, but on macOS it
+        encodes the physical USB port (``/dev/cu.usbserial-1420``), so
+        replugging the radio into a different port renames the node and
+        leaves ``soft_reconnect`` retrying a path that no longer exists
+        (follow-up from MOR-1440). When the configured path is verified
+        gone, scan sibling nodes matching ``_serial_reconnect_glob`` and
+        adopt the first one that answers a CI-V identity probe at our
+        configured address -- multi-adapter hosts must never grab a
+        different radio's port, so an unconfirmed or wrong-identity
+        candidate is left alone and the caller's normal retry/backoff
+        continues to apply.
+        """
+        if os.path.exists(self._serial_device):
+            return
+        candidates = sorted(
+            set(glob.glob(self._serial_reconnect_glob)) - {self._serial_device}
+        )
+        for candidate in candidates:
+            try:
+                address = await self._civ_identity_probe(candidate)
+            except Exception:
+                logger.debug(
+                    "serial rediscovery: identity probe failed for %s",
+                    candidate,
+                    exc_info=True,
+                )
+                continue
+            if address is None or address != self._radio_addr:
+                continue
+            logger.warning(
+                "rigplane (%s): serial node %s vanished; rediscovered radio "
+                "at %s (CI-V address 0x%02X confirmed)",
+                self.model,
+                self._serial_device,
+                candidate,
+                address,
+            )
+            self._serial_device = candidate
+            if self._serial_civ_link is not None:
+                set_device = getattr(self._serial_civ_link, "set_device", None)
+                if callable(set_device):
+                    set_device(candidate)
+            set_serial_port = getattr(
+                self._serial_audio_driver, "set_serial_port", None
+            )
+            if callable(set_serial_port):
+                set_serial_port(candidate)
+            return
+
+    async def _default_civ_identity_probe(self, port: str) -> int | None:
+        """Probe *port* for a CI-V radio and return its address, or ``None``."""
+        from .discovery import probe_serial_civ
+
+        result = await probe_serial_civ(port, baud_rates=[self._serial_baudrate])
+        return result.address if result is not None else None
 
     # ------------------------------------------------------------------
     # Scope

--- a/src/rigplane/backends/_icom_serial_base.py
+++ b/src/rigplane/backends/_icom_serial_base.py
@@ -8,7 +8,7 @@ serial-backed radios (IC-705, IC-7300, IC-9700, IC-7610).
 from __future__ import annotations
 
 import asyncio
-import glob
+import fnmatch
 import logging
 import os
 import re
@@ -25,6 +25,7 @@ from ..radio import CoreRadio
 from ..types import AudioCodec, ScopeCompletionPolicy, get_audio_capabilities
 
 if TYPE_CHECKING:
+    from .discovery import SerialPortCandidate
     from .icom7610.drivers.serial_civ_link import SerialCivLink
     from .icom7610.drivers.serial_session import SerialSessionDriver
     from ..profiles import RadioProfile
@@ -54,11 +55,18 @@ def _env_bool(name: str, default: bool = False) -> bool:
 # (macOS ``/dev/cu.usbserial-1420``) or enumeration order (Linux
 # ``/dev/ttyUSB0``). Stripped to derive a glob pattern that matches sibling
 # nodes of the same USB-serial family after a replug renumbers the node.
+# NOTE: the separator itself is eaten by the match, e.g.
+# ``/dev/cu.usbserial-1420`` -> ``/dev/cu.usbserial*`` (no trailing ``-``),
+# which also matches unhyphenated siblings like ``/dev/cu.usbserial9931``.
 _TRAILING_NODE_SUFFIX_RE = re.compile(r"(-[0-9A-Za-z]+|[0-9]+)$")
 
 
 def _derive_reconnect_glob(device: str) -> str:
-    """Best-effort glob pattern matching sibling device nodes of *device*."""
+    """Best-effort glob pattern matching sibling device nodes of *device*.
+
+    ``/dev/cu.usbserial-1420`` -> ``/dev/cu.usbserial*``;
+    ``/dev/ttyUSB0`` -> ``/dev/ttyUSB*``.
+    """
     stripped = _TRAILING_NODE_SUFFIX_RE.sub("", device)
     if not stripped or stripped == device:
         return device + "*"
@@ -91,6 +99,8 @@ class _SerialAudioDriver(Protocol):
 
     @property
     def tx_running(self) -> bool: ...
+
+    def set_serial_port(self, serial_port: str | None) -> None: ...
 
 
 class _IcomSerialRadioBase(CoreRadio):
@@ -137,6 +147,8 @@ class _IcomSerialRadioBase(CoreRadio):
         audio_driver: _SerialAudioDriver | None = None,
         reconnect_glob: str | None = None,
         _civ_identity_probe: Callable[[str], Awaitable[int | None]] | None = None,
+        _enumerate_serial_ports_fn: Callable[[], "list[SerialPortCandidate]"]
+        | None = None,
     ) -> None:
         from .icom7610.drivers.serial_civ_link import SerialCivLink
         from .icom7610.drivers.serial_session import SerialSessionDriver
@@ -160,12 +172,18 @@ class _IcomSerialRadioBase(CoreRadio):
         self._serial_baudrate = baudrate
         self._serial_rx_device_override = rx_device
         self._serial_tx_device_override = tx_device
-        # MOR-1453: glob pattern used to rediscover a renumbered device node
-        # (e.g. macOS reassigning /dev/cu.usbserial-XXXX on a USB replug)
-        # when the configured path vanishes. Auto-derived unless overridden.
+        # MOR-1453: rediscovery seams for a renumbered device node. Glob is
+        # auto-derived unless overridden; identity is captured fresh after
+        # each successful connect (see ``_capture_serial_identity``).
         self._serial_reconnect_glob = reconnect_glob or _derive_reconnect_glob(device)
         self._civ_identity_probe = (
             _civ_identity_probe or self._default_civ_identity_probe
+        )
+        self._enumerate_serial_ports_fn = (
+            _enumerate_serial_ports_fn or self._default_enumerate_serial_ports
+        )
+        self._serial_hw_identity: tuple[str | None, int | None, int | None] | None = (
+            None
         )
         if ptt_mode != "civ":
             raise ValueError(
@@ -188,11 +206,9 @@ class _IcomSerialRadioBase(CoreRadio):
         self._civ_min_interval = serial_min_interval_ms / 1000.0
         serial_link = civ_link or SerialCivLink(device=device, baudrate=baudrate)
         self._serial_session = session_driver or SerialSessionDriver(serial_link)
-        # MOR-1453: reference to the raw link, used to rebind its device path
-        # on rediscovery. ``None`` when a bespoke ``session_driver`` was
-        # supplied directly, since its internal link is then unreachable
-        # from here -- rediscovery degrades to updating ``_serial_device``
-        # and the audio topology hint only in that (currently unused) path.
+        # MOR-1453: raw link ref for rediscovery's set_device rebind. None
+        # when a bespoke session_driver was supplied (its link is then
+        # unreachable here -- currently unused in practice).
         self._serial_civ_link = serial_link if session_driver is None else None
         self._serial_audio_driver = audio_driver or UsbAudioDriver(
             AudioDeviceConfig(
@@ -347,6 +363,7 @@ class _IcomSerialRadioBase(CoreRadio):
         self._conn_state = RadioConnectionState.CONNECTED
         self._civ_stream_ready = self._serial_session.ready
         self._civ_recovering = not self._civ_stream_ready
+        self._capture_serial_identity()
         logger.info(
             "Connected to %s over serial (%s @ %d baud)",
             self.model,
@@ -417,6 +434,7 @@ class _IcomSerialRadioBase(CoreRadio):
         self._conn_state = RadioConnectionState.CONNECTED
         self._civ_stream_ready = self._serial_session.ready
         self._civ_recovering = not self._civ_stream_ready
+        self._capture_serial_identity()
         # MOR-1440 review round 2 (B1 item 2): this is the RECONNECTING ->
         # CONNECTED transition. Re-baseline the link-death detector here,
         # explicitly, rather than waiting for the next watchdog tick's
@@ -438,60 +456,128 @@ class _IcomSerialRadioBase(CoreRadio):
     # Renumbered-node rediscovery (MOR-1453)
     # ------------------------------------------------------------------
 
+    def _default_enumerate_serial_ports(self) -> "list[SerialPortCandidate]":
+        """Real OS port enumeration -- read-only, never opens a device."""
+        from .discovery import enumerate_serial_ports
+
+        return enumerate_serial_ports()
+
+    def _capture_serial_identity(self) -> None:
+        """Snapshot the connected adapter's hw identity for rediscovery.
+
+        Called after every successful connect/soft_reconnect so a
+        fingerprint (USB ``serial_number``, else vid/pid) is always fresh
+        for the *current* adapter, not assumed stable across the very
+        first connect (itself possibly post-replug). Resets to ``None``
+        when enumeration fails or the path isn't found (synthetic paths
+        in tests), rather than keeping a stale value.
+        """
+        self._serial_hw_identity = None
+        try:
+            enumerated = self._enumerate_serial_ports_fn()
+        except Exception:
+            logger.debug("serial identity capture failed", exc_info=True)
+            return
+        for candidate in enumerated:
+            if candidate.device == self._serial_device:
+                self._serial_hw_identity = (
+                    candidate.serial_number,
+                    candidate.vid,
+                    candidate.pid,
+                )
+                return
+
     async def _maybe_rediscover_serial_device(self) -> None:
         """Rediscover a renumbered device node before retrying connect.
 
-        The configured device path is a fixed string, but on macOS it
-        encodes the physical USB port (``/dev/cu.usbserial-1420``), so
-        replugging the radio into a different port renames the node and
-        leaves ``soft_reconnect`` retrying a path that no longer exists
-        (follow-up from MOR-1440). When the configured path is verified
-        gone, scan sibling nodes matching ``_serial_reconnect_glob`` and
-        adopt the first one that answers a CI-V identity probe at our
-        configured address -- multi-adapter hosts must never grab a
-        different radio's port, so an unconfirmed or wrong-identity
-        candidate is left alone and the caller's normal retry/backoff
-        continues to apply.
+        macOS encodes the physical USB port in the device path
+        (``/dev/cu.usbserial-1420``), so a replug renames the node and
+        leaves ``soft_reconnect`` retrying a vanished path forever
+        (follow-up from MOR-1440). No-op while the configured path exists.
+
+        Identity model (review round 2 design ruling): a CI-V address
+        probe as *primary* signal was rejected -- a different radio can
+        answer it (the documented IC-705/X6200 shared 0xA4 collision),
+        hijacking a neighbor's port and repeatedly writing CI-V frames
+        into that neighbor's live link. Instead:
+
+        - PRIMARY: match candidates (OS-enumerated, filtered by
+          ``_serial_reconnect_glob``) against our own USB ``serial_number``
+          captured at the last connect -- no port is ever opened for this.
+        - FALLBACK (only when our adapter exposed no serial_number): the
+          CI-V probe, but skip -- never open -- a candidate whose vid/pid
+          is *known* to differ from ours. Narrows, does not eliminate, the
+          collision risk when neither side exposes a serial number and
+          both share (or lack) vid/pid -- documented residual gap.
         """
         if os.path.exists(self._serial_device):
             return
+        try:
+            enumerated = self._enumerate_serial_ports_fn()
+        except Exception:
+            logger.debug("serial rediscovery: port enumeration failed", exc_info=True)
+            return
         candidates = sorted(
-            set(glob.glob(self._serial_reconnect_glob)) - {self._serial_device}
+            (
+                c
+                for c in enumerated
+                if c.device != self._serial_device
+                and fnmatch.fnmatch(c.device, self._serial_reconnect_glob)
+            ),
+            key=lambda c: c.device,
         )
-        for candidate in candidates:
-            try:
-                address = await self._civ_identity_probe(candidate)
-            except Exception:
-                logger.debug(
-                    "serial rediscovery: identity probe failed for %s",
-                    candidate,
-                    exc_info=True,
-                )
-                continue
-            if address is None or address != self._radio_addr:
-                continue
-            logger.warning(
-                "rigplane (%s): serial node %s vanished; rediscovered radio "
-                "at %s (CI-V address 0x%02X confirmed)",
-                self.model,
-                self._serial_device,
-                candidate,
-                address,
-            )
-            self._serial_device = candidate
-            if self._serial_civ_link is not None:
-                set_device = getattr(self._serial_civ_link, "set_device", None)
-                if callable(set_device):
-                    set_device(candidate)
-            set_serial_port = getattr(
-                self._serial_audio_driver, "set_serial_port", None
-            )
-            if callable(set_serial_port):
-                set_serial_port(candidate)
+        if not candidates:
             return
 
+        target_serial, target_vid, target_pid = self._serial_hw_identity or (
+            None,
+            None,
+            None,
+        )
+        adopted: str | None = None
+        if target_serial is not None:
+            for candidate in candidates:
+                if candidate.serial_number == target_serial:
+                    adopted = candidate.device
+                    break
+        else:
+            for candidate in candidates:
+                if target_vid is not None and candidate.vid not in (None, target_vid):
+                    continue
+                if target_pid is not None and candidate.pid not in (None, target_pid):
+                    continue
+                try:
+                    address = await self._civ_identity_probe(candidate.device)
+                except Exception:
+                    logger.debug(
+                        "serial rediscovery: identity probe failed for %s",
+                        candidate.device,
+                        exc_info=True,
+                    )
+                    continue
+                if address is not None and address == self._radio_addr:
+                    adopted = candidate.device
+                    break
+
+        if adopted is None:
+            return
+        logger.warning(
+            "rigplane (%s): serial node %s vanished; rediscovered radio at %s",
+            self.model,
+            self._serial_device,
+            adopted,
+        )
+        self._serial_device = adopted
+        if self._serial_civ_link is not None:
+            self._serial_civ_link.set_device(adopted)
+        self._serial_audio_driver.set_serial_port(adopted)
+
     async def _default_civ_identity_probe(self, port: str) -> int | None:
-        """Probe *port* for a CI-V radio and return its address, or ``None``."""
+        """Probe *port* for a CI-V radio and return its address, or ``None``.
+
+        FALLBACK only (see ``_maybe_rediscover_serial_device``) -- opens
+        the port and writes a real CI-V frame.
+        """
         from .discovery import probe_serial_civ
 
         result = await probe_serial_civ(port, baud_rates=[self._serial_baudrate])

--- a/src/rigplane/backends/icom7610/drivers/serial_civ_link.py
+++ b/src/rigplane/backends/icom7610/drivers/serial_civ_link.py
@@ -193,6 +193,20 @@ class SerialCivLink:
         """Readiness signal suitable for higher-level radio_ready logic."""
         return self._connected and self._healthy
 
+    def set_device(self, device: str) -> None:
+        """Rebind this link to a different device node path (MOR-1453).
+
+        Used when the configured path has vanished (e.g. a renumbered
+        macOS ``/dev/cu.usbserial-*`` node after a USB replug) and a
+        sibling node has been discovered and identity-confirmed. Only
+        valid while disconnected -- callers must ``disconnect()`` first.
+        """
+        if not device.strip():
+            raise ValueError("device must be non-empty")
+        if self._connected:
+            raise RuntimeError("Cannot change device while connected.")
+        self._device = device
+
     async def connect(self) -> None:
         """Open serial CI-V transport."""
         if self._connected:

--- a/tests/test_icom7610_serial_radio.py
+++ b/tests/test_icom7610_serial_radio.py
@@ -103,6 +103,10 @@ class _FakeSerialCivLink:
         self.sent_frames: list[bytes] = []
         self._responses: asyncio.Queue[bytes] = asyncio.Queue()
         self._responses_by_send: dict[int, list[bytes]] = {}
+        self.device_history: list[str] = []
+
+    def set_device(self, device: str) -> None:
+        self.device_history.append(device)
 
     async def connect(self) -> None:
         self.connect_calls += 1
@@ -701,6 +705,133 @@ async def test_serial_link_down_settles_after_successful_reconnect_same_node(
     )
     assert radio.conn_state == RadioConnectionState.CONNECTED
     assert radio.radio_ready is True
+
+    await radio.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_serial_soft_reconnect_rediscovers_renumbered_node(tmp_path) -> None:
+    """MOR-1453: a replug that renames the /dev node (macOS encodes the
+    physical USB port in the ``cu.usbserial-XXXX`` suffix) must be
+    rediscovered by glob and adopted once CI-V identity is confirmed,
+    instead of retrying a vanished path forever.
+    """
+    old_path = tmp_path / "cu.usbserial-1420"
+    old_path.write_text("")
+    new_path = tmp_path / "cu.usbserial-9931"
+
+    link = _FakeSerialCivLink()
+    audio = _FakeUsbAudioDriver()
+    probed: list[str] = []
+
+    async def _identity_probe(port: str) -> int | None:
+        probed.append(port)
+        return IC_7610_ADDR if port == str(new_path) else None
+
+    radio = Icom7610SerialRadio(
+        device=str(old_path),
+        civ_link=link,
+        audio_driver=audio,
+        reconnect_glob=str(tmp_path / "cu.usbserial-*"),
+        _civ_identity_probe=_identity_probe,
+    )
+    await radio.connect()
+    await radio._stop_civ_data_watchdog()  # deterministic: no background tick races.
+
+    # Simulate the replug: link health drops (as the watchdog would observe),
+    # the old node vanishes, and a new sibling node appears.
+    link.connected = False
+    link.ready = False
+    link.healthy = False
+    old_path.unlink()
+    new_path.write_text("")
+
+    await radio.soft_reconnect()
+
+    assert probed == [str(new_path)]
+    assert radio._serial_device == str(new_path)
+    assert link.device_history == [str(new_path)]
+    assert radio.conn_state == RadioConnectionState.CONNECTED
+    assert radio.radio_ready is True
+
+    await radio.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_serial_soft_reconnect_rejects_wrong_identity_node(tmp_path) -> None:
+    """MULTI-ADAPTER SAFETY (MOR-1453): a sibling node that answers with a
+    different radio's CI-V address must never be adopted.
+    """
+    old_path = tmp_path / "cu.usbserial-1420"
+    old_path.write_text("")
+    other_radio_path = tmp_path / "cu.usbserial-4471"
+
+    link = _FakeSerialCivLink()
+    probed: list[str] = []
+
+    async def _identity_probe(port: str) -> int | None:
+        probed.append(port)
+        return 0x94  # a different radio's CI-V address -- never ours
+
+    radio = Icom7610SerialRadio(
+        device=str(old_path),
+        civ_link=link,
+        reconnect_glob=str(tmp_path / "cu.usbserial-*"),
+        _civ_identity_probe=_identity_probe,
+    )
+    await radio.connect()
+    await radio._stop_civ_data_watchdog()
+
+    link.connected = False
+    link.ready = False
+    link.healthy = False
+    old_path.unlink()
+    other_radio_path.write_text("")
+
+    await radio.soft_reconnect()
+
+    assert probed == [str(other_radio_path)]
+    assert radio._serial_device == str(old_path)  # unchanged -- never adopted
+    assert link.device_history == []
+
+    await radio.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_serial_soft_reconnect_skips_rediscovery_when_path_still_present(
+    tmp_path,
+) -> None:
+    """Regression guard: rediscovery must never run while the configured
+    device node is still present -- the ordinary same-node reconnect path
+    (MOR-1440's lifecycle pins) sees zero behavior change.
+    """
+    device_path = tmp_path / "cu.usbserial-1420"
+    device_path.write_text("")
+
+    link = _FakeSerialCivLink(fail_connect_calls={2})
+    probed: list[str] = []
+
+    async def _identity_probe(port: str) -> int | None:
+        probed.append(port)
+        return IC_7610_ADDR
+
+    radio = Icom7610SerialRadio(
+        device=str(device_path),
+        civ_link=link,
+        _civ_identity_probe=_identity_probe,
+    )
+    await radio.connect()
+    await radio._stop_civ_data_watchdog()
+
+    link.connected = False
+    link.ready = False
+    link.healthy = False
+
+    with pytest.raises(ConnectionError, match="Failed to reconnect"):
+        await radio.soft_reconnect()
+
+    assert probed == []
+    assert radio._serial_device == str(device_path)
 
     await radio.disconnect()
 

--- a/tests/test_icom7610_serial_radio.py
+++ b/tests/test_icom7610_serial_radio.py
@@ -8,6 +8,11 @@ from types import SimpleNamespace
 import pytest
 
 from rigplane import IcomRadio, RadioConnectionState
+from rigplane.backends._icom_serial_base import (
+    _IcomSerialRadioBase,
+    _derive_reconnect_glob,
+)
+from rigplane.backends.discovery import SerialPortCandidate
 from rigplane.backends.ic705 import Ic705SerialRadio
 from rigplane.backends.icom7610 import Icom7610SerialRadio
 from rigplane import IC_7610_ADDR
@@ -21,6 +26,39 @@ from rigplane.exceptions import CommandError, ConnectionError
 from rigplane.exceptions import TimeoutError as RigplaneTimeoutError
 from rigplane.types import AudioCodec
 from rigplane.types import bcd_encode
+
+
+@pytest.fixture(autouse=True)
+def _no_real_serial_io(monkeypatch: pytest.MonkeyPatch) -> None:
+    """MOR-1453 test hermeticity (review round 2, B1).
+
+    Every construction in this module uses a synthetic device path with
+    no real backing hardware, but rediscovery's *default* enumeration/
+    identity-probe seams are the real OS-level ones unless a test
+    explicitly overrides them. On a host with a real USB-serial adapter
+    physically attached (the live bench, or a self-hosted CI runner),
+    the synthetic path can fail ``os.path.exists`` while a real sibling
+    node still matches the derived glob pattern -- reaching the FALLBACK
+    CI-V probe, which opens the real port and writes a real frame.
+    Patching the class-level defaults to safe no-ops for every test in
+    this module (tests that explicitly pass their own
+    ``_civ_identity_probe``/``_enumerate_serial_ports_fn`` are unaffected,
+    since an explicit constructor argument always wins over the default)
+    makes that impossible regardless of what hardware is attached.
+    """
+    monkeypatch.setattr(
+        _IcomSerialRadioBase,
+        "_default_enumerate_serial_ports",
+        lambda self: [],
+    )
+
+    async def _no_probe(self: object, port: str) -> int | None:
+        raise AssertionError(
+            f"unexpected real CI-V identity probe attempted on {port!r} "
+            "-- this test module must never perform real serial I/O"
+        )
+
+    monkeypatch.setattr(_IcomSerialRadioBase, "_default_civ_identity_probe", _no_probe)
 
 
 def _freq_response_frame(freq_hz: int) -> bytes:
@@ -159,6 +197,10 @@ class _FakeUsbAudioDriver:
         self.tx_frames: list[bytes] = []
         self.rx_starts = 0
         self.tx_starts = 0
+        self.serial_port_history: list[str | None] = []
+
+    def set_serial_port(self, serial_port: str | None) -> None:
+        self.serial_port_history.append(serial_port)
 
     async def start_rx(self, callback, **kwargs) -> None:  # type: ignore[no-untyped-def]
         _ = kwargs
@@ -711,46 +753,78 @@ async def test_serial_link_down_settles_after_successful_reconnect_same_node(
 
 @pytest.mark.asyncio
 async def test_serial_soft_reconnect_rediscovers_renumbered_node(tmp_path) -> None:
-    """MOR-1453: a replug that renames the /dev node (macOS encodes the
-    physical USB port in the ``cu.usbserial-XXXX`` suffix) must be
-    rediscovered by glob and adopted once CI-V identity is confirmed,
-    instead of retrying a vanished path forever.
+    """MOR-1453 review round 2 design ruling: PRIMARY identity is the USB
+    adapter's own hardware ``serial_number``, captured via OS enumeration
+    at the last successful connect -- no candidate port is ever opened to
+    confirm it, closing the IC-705/X6200 shared CI-V address 0xA4
+    collision entirely for adapters that expose one.
     """
     old_path = tmp_path / "cu.usbserial-1420"
     old_path.write_text("")
     new_path = tmp_path / "cu.usbserial-9931"
 
+    topology = {
+        "candidates": [
+            SerialPortCandidate(
+                device=str(old_path),
+                description="",
+                hwid=None,
+                vid=0x0403,
+                pid=0x6001,
+                serial_number="FT-ABC123",
+            ),
+        ],
+    }
+
+    def _enumerate() -> list[SerialPortCandidate]:
+        return list(topology["candidates"])
+
+    async def _probe_forbidden(port: str) -> int | None:
+        raise AssertionError(
+            f"CI-V probe must never run when PRIMARY serial_number "
+            f"identity is known (attempted on {port!r})"
+        )
+
     link = _FakeSerialCivLink()
     audio = _FakeUsbAudioDriver()
-    probed: list[str] = []
-
-    async def _identity_probe(port: str) -> int | None:
-        probed.append(port)
-        return IC_7610_ADDR if port == str(new_path) else None
 
     radio = Icom7610SerialRadio(
         device=str(old_path),
         civ_link=link,
         audio_driver=audio,
-        reconnect_glob=str(tmp_path / "cu.usbserial-*"),
-        _civ_identity_probe=_identity_probe,
+        reconnect_glob=str(tmp_path / "cu.usbserial*"),
+        _enumerate_serial_ports_fn=_enumerate,
+        _civ_identity_probe=_probe_forbidden,
     )
     await radio.connect()
     await radio._stop_civ_data_watchdog()  # deterministic: no background tick races.
+    assert radio._serial_hw_identity == ("FT-ABC123", 0x0403, 0x6001)
 
-    # Simulate the replug: link health drops (as the watchdog would observe),
-    # the old node vanishes, and a new sibling node appears.
+    # Simulate the replug: link health drops (as the watchdog would
+    # observe), the old node vanishes from the OS's enumeration, and a
+    # new node with the SAME hardware serial_number (same physical
+    # adapter) appears.
     link.connected = False
     link.ready = False
     link.healthy = False
     old_path.unlink()
     new_path.write_text("")
+    topology["candidates"] = [
+        SerialPortCandidate(
+            device=str(new_path),
+            description="",
+            hwid=None,
+            vid=0x0403,
+            pid=0x6001,
+            serial_number="FT-ABC123",
+        ),
+    ]
 
     await radio.soft_reconnect()
 
-    assert probed == [str(new_path)]
     assert radio._serial_device == str(new_path)
     assert link.device_history == [str(new_path)]
+    assert audio.serial_port_history == [str(new_path)]
     assert radio.conn_state == RadioConnectionState.CONNECTED
     assert radio.radio_ready is True
 
@@ -758,35 +832,137 @@ async def test_serial_soft_reconnect_rediscovers_renumbered_node(tmp_path) -> No
 
 
 @pytest.mark.asyncio
-async def test_serial_soft_reconnect_rejects_wrong_identity_node(tmp_path) -> None:
-    """MULTI-ADAPTER SAFETY (MOR-1453): a sibling node that answers with a
-    different radio's CI-V address must never be adopted.
+async def test_serial_soft_reconnect_fallback_skips_known_different_adapter(
+    tmp_path,
+) -> None:
+    """MOR-1453 review round 2 design ruling (port-hijack / 0xA4 collision
+    reproduction): FALLBACK (adapter exposes no serial_number) must never
+    probe -- never open -- a candidate whose enumerated vid/pid is a
+    KNOWN different adapter, even though it would answer at our CI-V
+    address if asked. The correct-vid/pid candidate is still probed and
+    adopted, proving the exclusion is scoped, not a blanket FALLBACK
+    disablement.
+    """
+    old_path = tmp_path / "cu.usbserial-1420"
+    old_path.write_text("")
+    our_new_path = tmp_path / "cu.usbserial-9931"  # same adapter, no serial_number
+    neighbor_path = tmp_path / "cu.usbserial-4471"  # a DIFFERENT radio
+
+    topology = {
+        "candidates": [
+            SerialPortCandidate(
+                device=str(old_path),
+                description="",
+                hwid=None,
+                vid=0x10C4,
+                pid=0xEA60,
+                serial_number=None,
+            ),
+        ],
+    }
+
+    def _enumerate() -> list[SerialPortCandidate]:
+        return list(topology["candidates"])
+
+    probed: list[str] = []
+
+    async def _identity_probe(port: str) -> int | None:
+        probed.append(port)
+        # Both would answer at our configured CI-V address if asked --
+        # the neighbor must never even be probed.
+        return IC_7610_ADDR
+
+    link = _FakeSerialCivLink()
+
+    radio = Icom7610SerialRadio(
+        device=str(old_path),
+        civ_link=link,
+        reconnect_glob=str(tmp_path / "cu.usbserial*"),
+        _enumerate_serial_ports_fn=_enumerate,
+        _civ_identity_probe=_identity_probe,
+    )
+    await radio.connect()
+    await radio._stop_civ_data_watchdog()
+    assert radio._serial_hw_identity == (None, 0x10C4, 0xEA60)
+
+    link.connected = False
+    link.ready = False
+    link.healthy = False
+    old_path.unlink()
+    our_new_path.write_text("")
+    neighbor_path.write_text("")
+    topology["candidates"] = [
+        SerialPortCandidate(
+            device=str(neighbor_path),
+            description="",
+            hwid=None,
+            vid=0x0403,  # KNOWN different adapter -- must never be opened
+            pid=0x6001,
+            serial_number=None,
+        ),
+        SerialPortCandidate(
+            device=str(our_new_path),
+            description="",
+            hwid=None,
+            vid=0x10C4,  # matches our own captured vid/pid
+            pid=0xEA60,
+            serial_number=None,
+        ),
+    ]
+
+    await radio.soft_reconnect()
+
+    assert probed == [str(our_new_path)]  # neighbor never probed/opened
+    assert radio._serial_device == str(our_new_path)
+    assert link.device_history == [str(our_new_path)]
+
+    await radio.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_serial_soft_reconnect_fallback_rejects_wrong_civ_address(
+    tmp_path,
+) -> None:
+    """FALLBACK safety: with identity fully unknown (no serial_number, no
+    vid/pid captured), a candidate that answers with the WRONG CI-V
+    address must never be adopted.
     """
     old_path = tmp_path / "cu.usbserial-1420"
     old_path.write_text("")
     other_radio_path = tmp_path / "cu.usbserial-4471"
 
-    link = _FakeSerialCivLink()
+    topology: dict[str, list[SerialPortCandidate]] = {"candidates": []}
+
+    def _enumerate() -> list[SerialPortCandidate]:
+        return list(topology["candidates"])
+
     probed: list[str] = []
 
     async def _identity_probe(port: str) -> int | None:
         probed.append(port)
         return 0x94  # a different radio's CI-V address -- never ours
 
+    link = _FakeSerialCivLink()
+
     radio = Icom7610SerialRadio(
         device=str(old_path),
         civ_link=link,
-        reconnect_glob=str(tmp_path / "cu.usbserial-*"),
+        reconnect_glob=str(tmp_path / "cu.usbserial*"),
+        _enumerate_serial_ports_fn=_enumerate,
         _civ_identity_probe=_identity_probe,
     )
     await radio.connect()
     await radio._stop_civ_data_watchdog()
+    assert radio._serial_hw_identity is None
 
     link.connected = False
     link.ready = False
     link.healthy = False
     old_path.unlink()
     other_radio_path.write_text("")
+    topology["candidates"] = [
+        SerialPortCandidate(device=str(other_radio_path), description="", hwid=None),
+    ]
 
     await radio.soft_reconnect()
 
@@ -801,27 +977,43 @@ async def test_serial_soft_reconnect_rejects_wrong_identity_node(tmp_path) -> No
 async def test_serial_soft_reconnect_skips_rediscovery_when_path_still_present(
     tmp_path,
 ) -> None:
-    """Regression guard: rediscovery must never run while the configured
-    device node is still present -- the ordinary same-node reconnect path
-    (MOR-1440's lifecycle pins) sees zero behavior change.
+    """Regression guard (MOR-1453 review round 2, B3): rediscovery must
+    never even enumerate while the configured device node is still
+    present -- the ordinary same-node reconnect path (MOR-1440's
+    lifecycle pins) sees zero behavior change. A real sibling candidate
+    (that would be adopted by serial_number if reached) is deliberately
+    present so a mutant that removes the ``os.path.exists`` guard is
+    caught instead of surviving on an empty candidate list.
     """
     device_path = tmp_path / "cu.usbserial-1420"
     device_path.write_text("")
+    sibling_path = tmp_path / "cu.usbserial-9931"
+    sibling_path.write_text("")
+
+    enumerate_calls: list[None] = []
+
+    def _enumerate() -> list[SerialPortCandidate]:
+        enumerate_calls.append(None)
+        return [
+            SerialPortCandidate(
+                device=str(sibling_path),
+                description="",
+                hwid=None,
+                serial_number="WOULD-BE-ADOPTED-IF-REACHED",
+            ),
+        ]
 
     link = _FakeSerialCivLink(fail_connect_calls={2})
-    probed: list[str] = []
-
-    async def _identity_probe(port: str) -> int | None:
-        probed.append(port)
-        return IC_7610_ADDR
 
     radio = Icom7610SerialRadio(
         device=str(device_path),
         civ_link=link,
-        _civ_identity_probe=_identity_probe,
+        reconnect_glob=str(tmp_path / "cu.usbserial*"),
+        _enumerate_serial_ports_fn=_enumerate,
     )
     await radio.connect()
     await radio._stop_civ_data_watchdog()
+    calls_after_connect = len(enumerate_calls)
 
     link.connected = False
     link.ready = False
@@ -830,10 +1022,32 @@ async def test_serial_soft_reconnect_skips_rediscovery_when_path_still_present(
     with pytest.raises(ConnectionError, match="Failed to reconnect"):
         await radio.soft_reconnect()
 
-    assert probed == []
+    # Rediscovery must never enumerate again while the configured path
+    # is still present -- the only enumeration is the one already
+    # counted from connect()'s identity capture.
+    assert len(enumerate_calls) == calls_after_connect
     assert radio._serial_device == str(device_path)
 
     await radio.disconnect()
+
+
+@pytest.mark.parametrize(
+    ("device", "expected"),
+    [
+        ("/dev/cu.usbserial-1420", "/dev/cu.usbserial*"),
+        ("/dev/cu.usbmodem-IC7610", "/dev/cu.usbmodem*"),
+        ("/dev/cu.SLAB_USBtoUART2", "/dev/cu.SLAB_USBtoUART*"),
+        ("/dev/ttyS0", "/dev/ttyS*"),
+        ("/dev/customdevice", "/dev/customdevice*"),
+    ],
+)
+def test_derive_reconnect_glob_table(device: str, expected: str) -> None:
+    """MOR-1453 review round 2 (B4): the derived pattern eats the
+    separator -- ``cu.usbserial-1420`` -> ``cu.usbserial*``, not
+    ``cu.usbserial-*`` -- and a path with no trailing digit/suffix run
+    falls back to appending ``*`` unchanged.
+    """
+    assert _derive_reconnect_glob(device) == expected
 
 
 @pytest.mark.asyncio

--- a/tests/test_icom7610_serial_radio.py
+++ b/tests/test_icom7610_serial_radio.py
@@ -832,6 +832,236 @@ async def test_serial_soft_reconnect_rediscovers_renumbered_node(tmp_path) -> No
 
 
 @pytest.mark.asyncio
+async def test_serial_soft_reconnect_recaptures_identity_after_adoption(
+    tmp_path,
+) -> None:
+    """MOR-1453 review round 3 (M7 gap): ``_capture_serial_identity()``
+    must run again after a successful adoption -- not just at the
+    original connect -- otherwise ``_serial_hw_identity`` keeps
+    describing the OLD node forever. ``pid`` is left unknown (``None``)
+    at the first capture (so it never gates the PRIMARY match) and only
+    becomes known post-replug, so the post-adoption value can only be
+    correct if the second capture actually ran.
+    """
+    old_path = tmp_path / "cu.usbserial-1420"
+    old_path.write_text("")
+    new_path = tmp_path / "cu.usbserial-9931"
+
+    topology = {
+        "candidates": [
+            SerialPortCandidate(
+                device=str(old_path),
+                description="",
+                hwid=None,
+                vid=0x0403,
+                pid=None,
+                serial_number="ADAPTER-SN",
+            ),
+        ],
+    }
+
+    def _enumerate() -> list[SerialPortCandidate]:
+        return list(topology["candidates"])
+
+    link = _FakeSerialCivLink()
+
+    radio = Icom7610SerialRadio(
+        device=str(old_path),
+        civ_link=link,
+        reconnect_glob=str(tmp_path / "cu.usbserial*"),
+        _enumerate_serial_ports_fn=_enumerate,
+    )
+    await radio.connect()
+    await radio._stop_civ_data_watchdog()
+    assert radio._serial_hw_identity == ("ADAPTER-SN", 0x0403, None)
+
+    link.connected = False
+    link.ready = False
+    link.healthy = False
+    old_path.unlink()
+    new_path.write_text("")
+    # Same adapter (same serial_number, matched by PRIMARY), but the OS
+    # now also surfaces a pid it didn't report before the replug.
+    topology["candidates"] = [
+        SerialPortCandidate(
+            device=str(new_path),
+            description="",
+            hwid=None,
+            vid=0x0403,
+            pid=0x1234,
+            serial_number="ADAPTER-SN",
+        ),
+    ]
+
+    await radio.soft_reconnect()
+
+    assert radio._serial_device == str(new_path)
+    # Only true if the post-adoption capture ran against the NEW path --
+    # a stale value from the original connect would still show pid=None.
+    assert radio._serial_hw_identity == ("ADAPTER-SN", 0x0403, 0x1234)
+
+    await radio.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_serial_soft_reconnect_primary_ignores_empty_string_serial(
+    tmp_path,
+) -> None:
+    """MOR-1453 review round 3 (reproduced defect): pyserial surfaces an
+    empty string, not ``None``, for a stripped-descriptor adapter on some
+    Linux/Windows hosts. An empty ``serial_number`` must never be treated
+    as a fingerprint -- ``'' == ''`` must not let a candidate get adopted
+    on the strength of PRIMARY matching alone.
+
+    The candidate's vid/pid are deliberately IDENTICAL to ours (two cheap
+    adapters of the same model, both with stripped descriptors) so the
+    PRIMARY vid/pid cross-check (fix item 2) cannot independently save
+    this test -- only treating ``""`` as "no fingerprint" (falling
+    through to FALLBACK) can. The FALLBACK probe is wired to return
+    ``None`` (unconfirmed), so a correct implementation must not adopt --
+    but it MUST have reached the probe at all, proving PRIMARY was
+    correctly bypassed rather than short-circuiting on the empty match.
+    """
+    old_path = tmp_path / "cu.usbserial-1420"
+    old_path.write_text("")
+    neighbor_path = tmp_path / "cu.usbserial-4471"  # a DIFFERENT, unrelated radio
+
+    topology = {
+        "candidates": [
+            SerialPortCandidate(
+                device=str(old_path),
+                description="",
+                hwid=None,
+                vid=0x10C4,  # CP210x
+                pid=0xEA60,
+                serial_number="",  # degenerate descriptor
+            ),
+        ],
+    }
+
+    def _enumerate() -> list[SerialPortCandidate]:
+        return list(topology["candidates"])
+
+    probed: list[str] = []
+
+    async def _identity_probe(port: str) -> int | None:
+        probed.append(port)
+        return None  # unconfirmed -- FALLBACK must not adopt on this alone
+
+    link = _FakeSerialCivLink()
+
+    radio = Icom7610SerialRadio(
+        device=str(old_path),
+        civ_link=link,
+        reconnect_glob=str(tmp_path / "cu.usbserial*"),
+        _enumerate_serial_ports_fn=_enumerate,
+        _civ_identity_probe=_identity_probe,
+    )
+    await radio.connect()
+    await radio._stop_civ_data_watchdog()
+    assert radio._serial_hw_identity == ("", 0x10C4, 0xEA60)
+
+    link.connected = False
+    link.ready = False
+    link.healthy = False
+    old_path.unlink()
+    neighbor_path.write_text("")
+    topology["candidates"] = [
+        SerialPortCandidate(
+            device=str(neighbor_path),
+            description="",
+            hwid=None,
+            vid=0x10C4,  # SAME vid/pid as ours -- does not gate FALLBACK
+            pid=0xEA60,
+            serial_number="",  # ALSO empty -- must not match on that alone
+        ),
+    ]
+
+    await radio.soft_reconnect()
+
+    # Empty serial must fall through to FALLBACK -- the probe must have
+    # run (proving PRIMARY did not short-circuit on '' == '') -- and,
+    # since it returned unconfirmed, nothing was adopted.
+    assert probed == [str(neighbor_path)]
+    assert radio._serial_device == str(old_path)  # unchanged -- never adopted
+    assert link.device_history == []
+
+    await radio.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_serial_soft_reconnect_primary_rejects_matching_serial_wrong_adapter(
+    tmp_path,
+) -> None:
+    """MOR-1453 review round 3 fix item 2: a candidate whose
+    ``serial_number`` coincidentally matches ours but whose vid/pid is
+    KNOWN to differ (a cross-vendor serial-string collision) must not be
+    adopted via PRIMARY -- and, since PRIMARY never opens a port, must
+    never be probed either.
+    """
+    old_path = tmp_path / "cu.usbserial-1420"
+    old_path.write_text("")
+    wrong_vendor_path = tmp_path / "cu.usbserial-4471"
+
+    topology = {
+        "candidates": [
+            SerialPortCandidate(
+                device=str(old_path),
+                description="",
+                hwid=None,
+                vid=0x10C4,
+                pid=0xEA60,
+                serial_number="SN-1234",
+            ),
+        ],
+    }
+
+    def _enumerate() -> list[SerialPortCandidate]:
+        return list(topology["candidates"])
+
+    async def _probe_forbidden(port: str) -> int | None:
+        raise AssertionError(
+            f"PRIMARY must never open a port, even to reject it ({port!r})"
+        )
+
+    link = _FakeSerialCivLink()
+
+    radio = Icom7610SerialRadio(
+        device=str(old_path),
+        civ_link=link,
+        reconnect_glob=str(tmp_path / "cu.usbserial*"),
+        _enumerate_serial_ports_fn=_enumerate,
+        _civ_identity_probe=_probe_forbidden,
+    )
+    await radio.connect()
+    await radio._stop_civ_data_watchdog()
+    assert radio._serial_hw_identity == ("SN-1234", 0x10C4, 0xEA60)
+
+    link.connected = False
+    link.ready = False
+    link.healthy = False
+    old_path.unlink()
+    wrong_vendor_path.write_text("")
+    topology["candidates"] = [
+        SerialPortCandidate(
+            device=str(wrong_vendor_path),
+            description="",
+            hwid=None,
+            vid=0x0403,  # KNOWN different vendor despite the serial match
+            pid=0x6001,
+            serial_number="SN-1234",  # coincidental collision
+        ),
+    ]
+
+    await radio.soft_reconnect()
+
+    assert radio._serial_device == str(old_path)  # unchanged -- never adopted
+    assert link.device_history == []
+
+    await radio.disconnect()
+
+
+@pytest.mark.asyncio
 async def test_serial_soft_reconnect_fallback_skips_known_different_adapter(
     tmp_path,
 ) -> None:
@@ -915,6 +1145,99 @@ async def test_serial_soft_reconnect_fallback_skips_known_different_adapter(
     assert probed == [str(our_new_path)]  # neighbor never probed/opened
     assert radio._serial_device == str(our_new_path)
     assert link.device_history == [str(our_new_path)]
+
+    await radio.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_serial_soft_reconnect_fallback_vid_and_pid_guards_are_independent(
+    tmp_path,
+) -> None:
+    """MOR-1453 review round 3 (M3b/M3c): the FALLBACK vid guard and pid
+    guard must each be independently load-bearing. One candidate differs
+    ONLY in vid, another ONLY in pid -- both must be skipped without ever
+    being probed; only the fully-matching candidate is probed and
+    adopted. A mutant that drops either individual guard (but not the
+    other) is caught by this test alone.
+    """
+    old_path = tmp_path / "cu.usbserial-1420"
+    old_path.write_text("")
+    vid_only_diff_path = tmp_path / "cu.usbserial-1111"
+    pid_only_diff_path = tmp_path / "cu.usbserial-2222"
+    match_path = tmp_path / "cu.usbserial-3333"
+
+    topology = {
+        "candidates": [
+            SerialPortCandidate(
+                device=str(old_path),
+                description="",
+                hwid=None,
+                vid=0x10C4,
+                pid=0xEA60,
+                serial_number=None,
+            ),
+        ],
+    }
+
+    def _enumerate() -> list[SerialPortCandidate]:
+        return list(topology["candidates"])
+
+    probed: list[str] = []
+
+    async def _identity_probe(port: str) -> int | None:
+        probed.append(port)
+        return IC_7610_ADDR
+
+    link = _FakeSerialCivLink()
+
+    radio = Icom7610SerialRadio(
+        device=str(old_path),
+        civ_link=link,
+        reconnect_glob=str(tmp_path / "cu.usbserial*"),
+        _enumerate_serial_ports_fn=_enumerate,
+        _civ_identity_probe=_identity_probe,
+    )
+    await radio.connect()
+    await radio._stop_civ_data_watchdog()
+    assert radio._serial_hw_identity == (None, 0x10C4, 0xEA60)
+
+    link.connected = False
+    link.ready = False
+    link.healthy = False
+    old_path.unlink()
+    for p in (vid_only_diff_path, pid_only_diff_path, match_path):
+        p.write_text("")
+    topology["candidates"] = [
+        SerialPortCandidate(
+            device=str(vid_only_diff_path),
+            description="",
+            hwid=None,
+            vid=0x0403,  # differs -- pid still matches
+            pid=0xEA60,
+            serial_number=None,
+        ),
+        SerialPortCandidate(
+            device=str(pid_only_diff_path),
+            description="",
+            hwid=None,
+            vid=0x10C4,  # matches -- pid differs
+            pid=0x6001,
+            serial_number=None,
+        ),
+        SerialPortCandidate(
+            device=str(match_path),
+            description="",
+            hwid=None,
+            vid=0x10C4,
+            pid=0xEA60,
+            serial_number=None,
+        ),
+    ]
+
+    await radio.soft_reconnect()
+
+    assert probed == [str(match_path)]
+    assert radio._serial_device == str(match_path)
 
     await radio.disconnect()
 

--- a/tests/test_serial_civ_link.py
+++ b/tests/test_serial_civ_link.py
@@ -391,3 +391,34 @@ def test_codec_keeps_already_framed_payload() -> None:
 def test_serial_civ_link_default_baudrate_is_115200() -> None:
     link = SerialCivLink(device="/dev/tty.usbmodem-IC7610")
     assert link._baudrate == 115200
+
+
+def test_set_device_rebinds_path_while_disconnected() -> None:
+    """MOR-1453: rediscovery rebinds the link to a renumbered device node."""
+    link = SerialCivLink(device="/dev/cu.usbserial-1420")
+    link.set_device("/dev/cu.usbserial-9931")
+    assert link._device == "/dev/cu.usbserial-9931"
+
+
+def test_set_device_rejects_empty_path() -> None:
+    link = SerialCivLink(device="/dev/cu.usbserial-1420")
+    with pytest.raises(ValueError, match="non-empty"):
+        link.set_device("   ")
+
+
+@pytest.mark.asyncio
+async def test_set_device_rejects_while_connected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    link = SerialCivLink(device="/dev/cu.usbserial-1420")
+
+    async def _open() -> tuple[_FakeReader, _FakeWriter]:
+        return _FakeReader(), _FakeWriter()
+
+    link._open_serial_connection = _open
+    await link.connect()
+    try:
+        with pytest.raises(RuntimeError, match="Cannot change device"):
+            link.set_device("/dev/cu.usbserial-9931")
+    finally:
+        await link.disconnect()

--- a/tests/test_usb_audio_stub.py
+++ b/tests/test_usb_audio_stub.py
@@ -385,6 +385,23 @@ def test_set_serial_port_rebinds_topology_resolution_hint() -> None:
     assert driver._serial_port == "/dev/cu.usbserial-9931"
 
 
+def test_set_serial_port_invalidates_cached_selection() -> None:
+    """MOR-1453 review round 2: ``duplex_mode`` and ``selected_rx_device``/
+    ``selected_tx_device`` read ``_selected_rx``/``_selected_tx`` directly
+    without forcing a fresh resolution, so a stale selection from the old
+    port must not survive a rebind.
+    """
+    driver, _ = _make_driver()
+    devices = driver.list_devices()
+    driver._selected_rx = devices[0]
+    driver._selected_tx = devices[0]
+
+    driver.set_serial_port("/dev/cu.usbserial-9931")
+
+    assert driver.selected_rx_device is None
+    assert driver.selected_tx_device is None
+
+
 def test_set_serial_port_accepts_none() -> None:
     driver, _ = _make_driver()
     driver.set_serial_port(None)

--- a/tests/test_usb_audio_stub.py
+++ b/tests/test_usb_audio_stub.py
@@ -374,3 +374,18 @@ async def test_usb_audio_driver_reports_rx_and_tx_effective_contract() -> None:
     assert contract.tx.device.name == "USB Audio CODEC"
     await driver.stop_tx()
     await driver.stop_rx()
+
+
+def test_set_serial_port_rebinds_topology_resolution_hint() -> None:
+    """MOR-1453: rediscovery rebinds audio topology resolution to the
+    radio's new (renumbered) serial device node.
+    """
+    driver, _ = _make_driver()
+    driver.set_serial_port("/dev/cu.usbserial-9931")
+    assert driver._serial_port == "/dev/cu.usbserial-9931"
+
+
+def test_set_serial_port_accepts_none() -> None:
+    driver, _ = _make_driver()
+    driver.set_serial_port(None)
+    assert driver._serial_port is None


### PR DESCRIPTION
## Summary

Follow-up to MOR-1440 (#2387): `soft_reconnect()` only ever retried the
fixed configured device path. On macOS the `/dev/cu.usbserial-XXXX`
suffix encodes the physical USB port, so replugging a radio into a
different port renames the node -- the configured path is gone for
good, and the honest "reconnecting" state introduced by MOR-1440 never
resolves without a manual restart.

**Updated after two rounds of review** (see commits): the identity
model below reflects a redesign requested in round 2 (CI-V address
probe demoted from primary to fallback-only, after a reproduced port
hijack), plus a round-3 fix for an empty-string `serial_number` defect
in that redesign.

## Seam

`_IcomSerialRadioBase.soft_reconnect()` in
`src/rigplane/backends/_icom_serial_base.py`: after tearing down the
CI-V worker/RX pump and disconnecting the session, it unconditionally
retried `self._serial_session.connect()` against the fixed
`self._serial_device` string set at construction -- no path
re-verification, no rediscovery.

## Design

- `_maybe_rediscover_serial_device()` runs right before the reconnect
  attempt. It is a no-op whenever `os.path.exists(self._serial_device)`
  is still true, so the existing same-node reconnect lifecycle (MOR-1440's
  pinned tests) sees zero behavior change.
- When the configured path is verified absent, candidates come from
  `backends.discovery.enumerate_serial_ports()` (real OS-level metadata,
  read-only -- never opens a device), filtered to `_serial_reconnect_glob`
  -- auto-derived from the configured device path. Note the derived
  pattern eats the separator: `/dev/cu.usbserial-1420` ->
  `/dev/cu.usbserial*` (no trailing `-`), not `/dev/cu.usbserial-*`;
  `/dev/ttyUSB0` -> `/dev/ttyUSB*`. Overridable via the new
  `reconnect_glob` constructor kwarg.
- **Identity model (multi-adapter safety):**
  - PRIMARY: match candidates against the USB adapter's own
    `serial_number`, captured via OS enumeration fresh after every
    successful connect/soft_reconnect (`_capture_serial_identity`). No
    candidate port is ever opened for this -- closes the 0xA4
    IC-705/X6200 collision entirely for adapters that expose a serial
    number. **An empty string is treated as "no fingerprint"**, not a
    wildcard (`if target_serial:`, not `is not None`) -- pyserial
    surfaces `""`, not `None`, for a stripped-descriptor adapter on some
    Linux/Windows hosts, and `'' == ''` must never match an unrelated
    empty-serial adapter. A candidate is also rejected when its
    enumerated vid/pid is *known* to differ from ours, closing
    coincidental cross-vendor serial-string collisions.
  - FALLBACK (adapter exposed no usable serial_number): the CI-V address
    probe (reuses `backends.discovery.probe_serial_civ`), but a
    candidate is skipped -- never opened -- when its enumerated vid/pid
    is *known* to differ from ours.
- On adoption: `self._serial_device` is updated, `SerialCivLink.set_device()`
  rebinds the underlying link (unconditional call -- rejects while
  connected), and `UsbAudioDriver.set_serial_port()` rebinds the audio
  topology hint *and clears the cached RX/TX selection*.

## Documented, not fixed (residual gaps, explicitly out of scope)

- When our own identity is entirely unknown (enumeration failed, or
  never found our configured path -- true for every synthetic test
  device path), FALLBACK runs with **zero vid/pid filtering** -- this is
  the round-1 probe behavior, narrowed but not eliminated by the round-2
  design.
- Ports rejected by `discovery._is_candidate` (non-USB, virtual, or
  Bluetooth device nodes) are never enumerated by
  `enumerate_serial_ports()` and so are never rediscoverable -- silent
  by design, matching initial discovery's own filter; a radio on such a
  node was never discoverable in the first place.
- FALLBACK's residual collision risk when neither adapter exposes a
  serial number and both share (or lack) vid/pid.
- `soft_reconnect`'s pathological port-flap recovery still does not park
  managed TX or stop audio the way `_declare_serial_link_down` does.
- The shared-CI-V-bus blind spot from MOR-1440 round 2 stands (any
  parsed frame resets link-death evidence).

## Tests (TDD)

`tests/test_icom7610_serial_radio.py`:
- An autouse fixture (`_no_real_serial_io`) patches the class-level
  default enumerate/probe seams to safe no-ops for every test in the
  module that doesn't explicitly override them -- a real USB-serial
  adapter physically attached to the test host can never be opened or
  written to by this module's ~45 fake-device constructions, regardless
  of what hardware is attached.
- `test_serial_soft_reconnect_rediscovers_renumbered_node` -- PRIMARY
  path: matching `serial_number`, CI-V probe would raise if ever called.
- `test_serial_soft_reconnect_recaptures_identity_after_adoption` --
  identity is re-captured after adoption, not stale from the original
  connect (pid unknown at first capture, only known at the second, so a
  stale value fails the assertion).
- `test_serial_soft_reconnect_primary_ignores_empty_string_serial` --
  round-3 defect repro: an empty-string serial match with IDENTICAL
  vid/pid on both sides (so the vid/pid safety net can't independently
  save the test) must fall through to FALLBACK, which then correctly
  declines to adopt on an unconfirmed probe.
- `test_serial_soft_reconnect_primary_rejects_matching_serial_wrong_adapter`
  -- a non-empty serial match with KNOWN-different vid/pid is never
  adopted and never even probed (PRIMARY opens no ports).
- `test_serial_soft_reconnect_fallback_vid_and_pid_guards_are_independent`
  -- one candidate differs ONLY in vid, one ONLY in pid; both skipped
  without probing, independently pinning each guard.
- `test_serial_soft_reconnect_fallback_rejects_wrong_civ_address` --
  identity fully unknown, candidate answers wrong CI-V address -> never
  adopted.
- `test_serial_soft_reconnect_skips_rediscovery_when_path_still_present`
  -- a real sibling candidate (adoptable by serial_number if reached) is
  deliberately present so removing the `os.path.exists` guard is caught.
- `test_derive_reconnect_glob_table` -- table-driven cases.
- Existing MOR-1440 lifecycle pins kept green unmodified.

`tests/test_serial_civ_link.py`: `set_device` rebinds/rejects correctly.
`tests/test_usb_audio_stub.py`: `set_serial_port` rebinds + invalidates cache.

## Mutation battery (manual, applied/verified-killed/reverted, one at a time)

| # | Mutant | Killed by |
|---|---|---|
| M1 | Remove `os.path.exists` guard | skip-rediscovery test |
| M2 | Remove `set_serial_port` call | PRIMARY rediscovery test |
| M3-both | Remove FALLBACK vid+pid exclusion | 2 tests |
| M3b | Remove vid-only guard | vid/pid-independence test |
| M3c | Remove pid-only guard | vid/pid-independence test |
| M4 | Invert PRIMARY/FALLBACK branch | 4 tests |
| M5 | Remove `set_device` call | 2 tests |
| M6 | Flip `if target_serial:` back to `is not None` (round-3 defect) | empty-string test |

All eight KILLED. (M6's first test attempt passed against both the buggy
and fixed code -- the added PRIMARY vid/pid check happened to
independently exclude the fixture's differing-vendor candidate. Rewrote
the test with matching vid/pid on both sides so only the truthiness
check protects it; then M6 was correctly caught.)

## Verification

- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` (local
  and via the remote testbed): 9039 passed, 12 skipped, 5 deselected, 11
  xfailed, 1 xpassed, 0 failed.
- `uv run mypy src/` -- 13 pre-existing baseline errors, unchanged;
  none in the 3 touched files.
- `uv run ruff check src/ tests/` -- all checks passed (local + remote).
- `uv run ruff format --check src/ tests/` -- clean.
- `uv run lint-imports` -- 5 contracts kept, 0 broken.

## Scope

- 3 production files touched, ~232 net production LOC total (215
  accepted at round 2, +~17 for the round-3 fix + documentation). All of
  it is either the mandated identity redesign or a direct, required fix
  for a reproduced defect in that redesign -- no speculative additions.
  - `src/rigplane/backends/_icom_serial_base.py`
  - `src/rigplane/backends/icom7610/drivers/serial_civ_link.py`
  - `src/rigplane/audio/usb_driver.py`
- Test files: `tests/test_icom7610_serial_radio.py`,
  `tests/test_serial_civ_link.py`, `tests/test_usb_audio_stub.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
