### PR TITLE
fix: reconfirm scope span/speed/ref after write to fix readout desync (MOR-1446)

### DIFF
--- a/frontend/src/lib/runtime/adapters/__tests__/mor1428-ic7300-conformance.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mor1428-ic7300-conformance.isolated.test.ts
@@ -130,6 +130,7 @@ import {
   makeRfFrontEndHandlers,
   makeRitXitHandlers,
   makeRxAudioHandlers,
+  makeScopeControlsHandlers,
   makeTxHandlers,
   makeVfoHandlers,
   dispatchKeyboardRadioAction,
@@ -356,6 +357,36 @@ describe('IC-7300 fixture — handler dispatch through real factories (MOR-1418/
 
     expect(h.sendCommand).not.toHaveBeenCalled();
     expect(getCommandLifecycles()).toHaveLength(0);
+  });
+
+  // MOR-1446: the live IC-7300 walkthrough found SPAN/SPEED/REF desynced —
+  // the radio applied the change (visible on the waterfall) but the
+  // `scopeControls.*` readout never advanced past its pre-write reading.
+  // The frontend dispatch leg was never the broken one (these three pin
+  // that): `scopeControls.span`/`speed`/`refDb` are all observed:true on
+  // this live fixture (see `ic7300-state.json`), so `acceptsScopeValue`
+  // passes and the real command factory sends the exact WS frame. The
+  // actual defect was the backend never re-confirming the leaf after a
+  // write (`radio_poller.py`'s `_reconfirm_scope_field`, MOR-1446 fix).
+  it('scope span: dispatches set_scope_span for the confirmed span leaf', () => {
+    expect(IC7300_STATE.fieldStatus?.['scopeControls.span']?.observed).toBe(true);
+    makeScopeControlsHandlers().onSpanChange(6);
+    expect(exactCalls()).toEqual([['set_scope_span', { span: 6 }]]);
+    expectIntentTransport();
+  });
+
+  it('scope speed: dispatches set_scope_speed for the confirmed speed leaf', () => {
+    expect(IC7300_STATE.fieldStatus?.['scopeControls.speed']?.observed).toBe(true);
+    makeScopeControlsHandlers().onSpeedChange(1);
+    expect(exactCalls()).toEqual([['set_scope_speed', { speed: 1 }]]);
+    expectIntentTransport();
+  });
+
+  it('scope ref: dispatches set_scope_ref for the confirmed refDb leaf', () => {
+    expect(IC7300_STATE.fieldStatus?.['scopeControls.refDb']?.observed).toBe(true);
+    makeScopeControlsHandlers().onRefChange(10);
+    expect(exactCalls()).toEqual([['set_scope_ref', { ref: 10 }]]);
+    expectIntentTransport();
   });
 });
 

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -2396,19 +2396,25 @@ class RadioPoller:
                     await radio.set_scope_span(span)
                     if self._radio_state:
                         self._radio_state.scope_controls.span = span
-                    await self._reconfirm_scope_field("get_scope_span", radio.get_scope_span)
+                    await self._reconfirm_scope_field(
+                        "get_scope_span", radio.get_scope_span
+                    )
             case SetScopeSpeed(speed=speed):
                 if CAP_SCOPE in self._caps:
                     await radio.set_scope_speed(speed)
                     if self._radio_state:
                         self._radio_state.scope_controls.speed = speed
-                    await self._reconfirm_scope_field("get_scope_speed", radio.get_scope_speed)
+                    await self._reconfirm_scope_field(
+                        "get_scope_speed", radio.get_scope_speed
+                    )
             case SetScopeRef(ref=ref):
                 if CAP_SCOPE in self._caps:
                     await radio.set_scope_ref(ref)
                     if self._radio_state:
                         self._radio_state.scope_controls.ref_db = float(ref)
-                    await self._reconfirm_scope_field("get_scope_ref", radio.get_scope_ref)
+                    await self._reconfirm_scope_field(
+                        "get_scope_ref", radio.get_scope_ref
+                    )
             case SetScopeHold(on=on):
                 if CAP_SCOPE in self._caps:
                     await radio.set_scope_hold(on)

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -1031,6 +1031,34 @@ class RadioPoller:
             await asyncio.sleep(self._adaptive_gap())
         logger.info("radio-poller: scope controls fetched (receiver=%d)", scope_rx)
 
+    async def _reconfirm_scope_field(self, label: str, getter: Any) -> None:
+        """Force a fresh confirmed observation for one scope-control leaf.
+
+        Scope-control fields are fetched once, at ``EnableScope`` time
+        (``_fetch_scope_controls`` above) and never touched again by the main
+        poll loop — by design, to avoid interfering with the high-rate scope
+        waveform stream. A ``Set*`` write only mutates the optimistic
+        ``RadioState.scope_controls`` mirror below; without a follow-up GET,
+        the StateStore's confirmed observation for that leaf is never
+        refreshed, so the public snapshot keeps re-applying the STALE
+        pre-write observation over the fresh optimistic value on every poll —
+        the ``scopeControls.<leaf>`` readout desync MOR-1446 reported (span
+        stuck at its pre-change reading, ref stuck at 0). Bounded by
+        ``_SCOPE_GETTER_TIMEOUT`` for the same reason as
+        ``_fetch_scope_controls``: a dropped response on a busy scope stream
+        must not stall the command queue.
+        """
+        try:
+            await asyncio.wait_for(getter(), timeout=self._SCOPE_GETTER_TIMEOUT)
+        except asyncio.TimeoutError:
+            logger.debug(
+                "radio-poller: %s reconfirm timed out after %.0f ms (response dropped)",
+                label,
+                self._SCOPE_GETTER_TIMEOUT * 1000,
+            )
+        except Exception:
+            logger.debug("radio-poller: %s reconfirm failed", label, exc_info=True)
+
     def _apply_global_control_observation(
         self,
         name: str,
@@ -2368,16 +2396,19 @@ class RadioPoller:
                     await radio.set_scope_span(span)
                     if self._radio_state:
                         self._radio_state.scope_controls.span = span
+                    await self._reconfirm_scope_field("get_scope_span", radio.get_scope_span)
             case SetScopeSpeed(speed=speed):
                 if CAP_SCOPE in self._caps:
                     await radio.set_scope_speed(speed)
                     if self._radio_state:
                         self._radio_state.scope_controls.speed = speed
+                    await self._reconfirm_scope_field("get_scope_speed", radio.get_scope_speed)
             case SetScopeRef(ref=ref):
                 if CAP_SCOPE in self._caps:
                     await radio.set_scope_ref(ref)
                     if self._radio_state:
                         self._radio_state.scope_controls.ref_db = float(ref)
+                    await self._reconfirm_scope_field("get_scope_ref", radio.get_scope_ref)
             case SetScopeHold(on=on):
                 if CAP_SCOPE in self._caps:
                     await radio.set_scope_hold(on)

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -74,6 +74,9 @@ from rigplane.web.radio_poller import (
     SetRfGain,
     SetScopeEdge,
     SetScopeRbw,
+    SetScopeRef,
+    SetScopeSpan,
+    SetScopeSpeed,
     SetScopeVbw,
     SetSplit,
     SetSquelch,
@@ -1915,6 +1918,77 @@ async def test_execute_set_scope_rbw_updates_state() -> None:
 
     radio.set_scope_rbw.assert_awaited_once_with(2)
     assert state.scope_controls.rbw == 2
+
+
+@pytest.mark.asyncio
+async def test_execute_set_scope_span_updates_state_and_reconfirms() -> None:
+    """MOR-1446: a span write must re-GET so the StateStore observation for
+    ``scope_controls.span`` refreshes — otherwise the stale pre-write
+    observation (last confirmed at ``EnableScope`` time) keeps overwriting
+    the fresh optimistic value on every subsequent state snapshot, and the
+    frontend readout desyncs from the radio's real span (MOR-1446 leg 1)."""
+    radio = _make_radio()
+    state = RadioState()
+    poller = RadioPoller(radio, StateCache(), CommandQueue(), radio_state=state)
+
+    await poller._execute(SetScopeSpan(span=6))  # noqa: SLF001
+
+    radio.set_scope_span.assert_awaited_once_with(6)
+    assert state.scope_controls.span == 6
+    radio.get_scope_span.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_execute_set_scope_speed_updates_state_and_reconfirms() -> None:
+    """MOR-1446 leg 3: SPEED reads as inert without the reconfirm — the
+    dispatch reaches the radio, but the readout never advances past its
+    pre-write reading."""
+    radio = _make_radio()
+    state = RadioState()
+    poller = RadioPoller(radio, StateCache(), CommandQueue(), radio_state=state)
+
+    await poller._execute(SetScopeSpeed(speed=2))  # noqa: SLF001
+
+    radio.set_scope_speed.assert_awaited_once_with(2)
+    assert state.scope_controls.speed == 2
+    radio.get_scope_speed.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_execute_set_scope_ref_updates_state_and_reconfirms() -> None:
+    """MOR-1446 leg 2: REF stays stuck at 0 without the reconfirm — the radio
+    applies the level (waterfall visibly changes) but the readout keeps
+    replaying the stale pre-write observation."""
+    radio = _make_radio()
+    state = RadioState()
+    poller = RadioPoller(radio, StateCache(), CommandQueue(), radio_state=state)
+
+    await poller._execute(SetScopeRef(ref=5))  # noqa: SLF001
+
+    radio.set_scope_ref.assert_awaited_once_with(5)
+    assert state.scope_controls.ref_db == 5.0
+    radio.get_scope_ref.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_execute_set_scope_span_reconfirm_timeout_does_not_raise() -> None:
+    """A dropped confirm response (busy scope stream) must not fail the
+    command — `_reconfirm_scope_field` bounds and swallows it exactly like
+    `_fetch_scope_controls` already does for the same class of getter."""
+    radio = _make_radio()
+    state = RadioState()
+
+    async def _never_resolves() -> int:
+        await asyncio.sleep(10)
+        return 0
+
+    radio.get_scope_span = _never_resolves
+    poller = RadioPoller(radio, StateCache(), CommandQueue(), radio_state=state)
+
+    await poller._execute(SetScopeSpan(span=6))  # noqa: SLF001
+
+    radio.set_scope_span.assert_awaited_once_with(6)
+    assert state.scope_controls.span == 6
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Live IC-7300 walkthrough (semantic scope-controls surface) reported three defects:

1. **SPAN**: "-" does nothing; "+" jumps to the max preset; the readout stays on its pre-change value while the spectrum axis shows the real (changed) span.
2. **REF**: the radio visibly applies the level (waterfall dB scale changes) but the readout always shows 0.
3. **SPEED**: no perceptible effect at all.

## Root cause (per-control diagnosis)

All three share **one** backend root cause — not three separate bugs, and not a per-radio span-step table problem:

- `src/rigplane/commands/scope.py`'s `_SCOPE_SPAN_PRESETS_HZ` / the frontend's `SPAN_LABELS` (`frontend/src/components/spectrum/spectrum-toolbar-logic.ts`) are used **identically for every Icom radio** — no vendor branching, no per-model override anywhere in the command-construction path (`_scope_runtime.py` never threads a `cmd_map` into the scope builders, so they always take the shared, protocol-level 0x27 sub-command table). `docs/validation/cat-audits/ic7300.md`'s own manual-vs-implementation table lists `27 15` (span) / `27 19` (ref) / `27 1A` (speed) for the IC-7300 with no discrepancy flagged. So the "per-radio span-step table" hypothesis in the ticket is disproved by code + the existing manual audit — no profile-schema change was needed or made.
- The real defect: `src/rigplane/web/radio_poller.py`'s `_fetch_scope_controls()` (the only place that issues confirmed `get_scope_*` reads) runs **once**, at `EnableScope` time, and is deliberately excluded from the main poll loop to avoid interfering with the high-rate scope waveform stream (see its docstring). `SetScopeSpan` / `SetScopeSpeed` / `SetScopeRef` (lines ~2355-2369, pre-fix) only mutated the **optimistic** `RadioState.scope_controls` mirror — they never re-queried the radio. The public state snapshot re-applies the StateStore's confirmed observation over that raw mirror on every build (`runtime_helpers.py`), so the **stale pre-write observation** (last confirmed at `EnableScope` time) kept clobbering the fresh optimistic value forever. That is exactly "readout stuck at the old value while the radio genuinely changed."
- **SPEED**'s "no effect at all" is the same bug, not a missing capability: its CI-V payload shape (`bytes([speed])`, sub `0x27 0x1A`) is byte-identical to `mode`/`edge`/`hold` (0x14/0x16/0x17), which the ticket does *not* report broken, and the IC-7300 capability fixture (`frontend/.../fixtures/ic7300-capabilities.json`) declares `scope: true` / `'scope' in capabilities`. Nothing in the dispatch or capability path singles SPEED out — so it is not capability-hidden, it was just the least visually obvious of the three symptoms.

## Fix

`src/rigplane/web/radio_poller.py`: added `_reconfirm_scope_field()` — after a span/speed/ref write, it issues a bounded confirm `get_scope_*()` (reusing the existing `_SCOPE_GETTER_TIMEOUT` and the same timeout/exception-swallowing pattern `_fetch_scope_controls()` already uses for a dropped response on a busy scope stream), forcing a genuine confirmed StateStore observation so the public readout tracks the radio. Gated only on the generic `scope` capability — no radio-specific branching.

## Tests

- `tests/test_radio_poller_coverage.py`: 4 new tests — span/speed/ref each assert the write dispatches with the right params **and** the reconfirm GET is awaited; a fourth pins that a dropped reconfirm response (timeout) does not raise.
- `frontend/src/lib/runtime/adapters/__tests__/mor1428-ic7300-conformance.isolated.test.ts` (the MOR-1428 IC-7300 profile conformance suite, extended per the ticket): 3 new dispatch-conformance cases pinning that `onSpanChange`/`onSpeedChange`/`onRefChange` send the exact `set_scope_span`/`set_scope_speed`/`set_scope_ref` WS frames against the live-captured IC-7300 fixture — proving the frontend dispatch leg was never the broken one.

## Scope / LOC

- Backend production: `src/rigplane/web/radio_poller.py`, 31 net LOC.
- 3 files total (1 production + 2 test files), 136 net LOC.
- No frontend production changes — diagnosis showed the frontend dispatch/readout binding was already correct for all three controls; the defect and fix are entirely backend (readback-confirmation gap).

## Test plan

- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 9024 passed, 0 failed
- [x] `uv run ruff check src/ tests/` — clean
- [x] `cd frontend && npx vitest run` — 6634 passed, 0 failed
- [x] `cd frontend && npm run lint` — clean
- [x] Public-boundary self-check on the diff before push — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)