### PR TITLE
feat: profile-declared combined RF/SQL knob control model (MOR-1447)

### DIFF
--- a/docs/api/rig-loader.md
+++ b/docs/api/rig-loader.md
@@ -105,6 +105,7 @@ class RigConfig:
     pre_values: tuple[int, ...] | None
     agc_modes: tuple[int, ...] | None
     agc_labels: dict[str, str] | None
+    rf_sql_control_model: str = "separate"   # "separate" | "combined" (Icom-style single RF/SQL knob)
     protocol_type: str = "civ"               # "civ" | "kenwood_cat" | "yaesu_cat"
     protocol_address: int | None = None
     protocol_baud: int | None = None
@@ -219,6 +220,7 @@ except RigLoadError as e:
 | `[protocol].type` valid (if present) | `[protocol].type must be one of {'civ', 'kenwood_cat', 'yaesu_cat'}` |
 | `[controls.X].style` valid (if present) | `[controls.X].style must be one of {'toggle', 'stepped', ...}` |
 | `[[rules]].kind` valid (if present) | `rule kind must be one of {'mutex', 'disables', 'requires', 'value_limit'}` |
+| `[capabilities].rf_sql_control_model` valid (if present) | `[capabilities].rf_sql_control_model must be one of ['combined', 'separate']` |
 | `[modes].list` non-empty | `[modes].list must not be empty` |
 | `[filters].list` non-empty | `[filters].list must not be empty` |
 

--- a/docs/guide/rig-profiles.md
+++ b/docs/guide/rig-profiles.md
@@ -108,9 +108,19 @@ features = [
     "preamp",     # preamplifier
     # ... see _schema.md for full list
 ]
+rf_sql_control_model = "combined"  # optional; default "separate"
 ```
 
 The capability list controls Web UI guards — features not listed are hidden.
+
+`rf_sql_control_model` declares whether RF gain and squelch are two
+independent controls (`"separate"`, the default — most radios) or one
+physical concentric knob (`"combined"` — e.g. IC-7300: hard left = RF
+min/SQL min, center = RF max/SQL min, hard right = SQL max/RF max). The Web
+UI renders whichever model the profile declares; only set `"combined"` when
+the radio's manual or a CAT audit in `docs/validation/cat-audits/` confirms
+the physical layout — it is a hardware-layout fact, not something CI-V
+command support implies.
 
 ### `[controls]` — UI Control Styles (new)
 

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -265,6 +265,16 @@
    * integers).
    */
   const rfFrontEndIntents = semanticHandlers.rfFrontEnd;
+  /**
+   * MOR-1447 leg 2. The profile-declared RF/SQL control model — data-driven
+   * from `[capabilities].rf_sql_control_model` in the rig TOML, read at this
+   * seam straight off `runtime.caps`, same "caps-echo display metadata"
+   * precedent as `hasDualReceiver`/`agcLabels` above. `RfFrontEndSurface`
+   * itself renders whichever model this resolves to and stays otherwise
+   * capability-blind; there is no vendor/model-name branch anywhere in this
+   * file or in the surface.
+   */
+  let rfSqlControlModel = $derived(runtime.caps?.rfSqlControlModel ?? 'separate');
   const RF_FRONT_END_LEVEL_INTENT: Record<RfFrontEndLevelField, (value: number) => void> = {
     rfGain: (value) => rfFrontEndIntents.onRfGainChange(Math.round(value * 255)),
     squelch: (value) => rfFrontEndIntents.onSquelchChange(Math.round(value * 255)),
@@ -888,6 +898,7 @@
     {#if view?.rfFrontEnd}
       <RfFrontEndSurface
         {view}
+        controlModel={rfSqlControlModel}
         onPreampChange={(level) => rfFrontEndIntents.onPreChange(level)}
         onAttenuatorChange={(db) => rfFrontEndIntents.onAttChange(db)}
         onLevelChange={(field, value) => RF_FRONT_END_LEVEL_INTENT[field](value)}

--- a/frontend/src/components-v2/wiring/__tests__/semantic-rf-front-end-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rf-front-end-wiring.component.test.ts
@@ -506,6 +506,40 @@ describe('MOR-1447 leg 2: the combined RF/SQL knob, when the profile declares it
     const input = el('rf-sql')!.querySelector('input')!;
     expect(input.valueAsNumber).toBeCloseTo(0.632, 3);
   });
+
+  // Verifier follow-up R1, pinned end-to-end through the real
+  // `RF_FRONT_END_LEVEL_INTENT` seam (not just the pure surface): an
+  // unconditional pair-emit would double-dispatch on every drag, including
+  // ones where one half is already at its target — the queue-lag/"Commander
+  // stopped" hazard shape on the live serial IC-7300 gate radio.
+  it('a drag landing on the ALREADY-CONFIRMED position dispatches NEITHER set_rf_gain nor set_squelch', () => {
+    h.caps = liveCaps(true, 'combined');
+    h.state = liveState(true);
+    // The knob's own "center, at rest" position: RF max, SQL min.
+    (h.state as unknown as { main: { rfGain: number; squelch: number } }).main.rfGain = 1;
+    (h.state as unknown as { main: { rfGain: number; squelch: number } }).main.squelch = 0;
+    render();
+    const input = el('rf-sql')!.querySelector('input')!;
+    input.value = '0.5';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    expect(h.rfGain).not.toHaveBeenCalled();
+    expect(h.squelch).not.toHaveBeenCalled();
+  });
+
+  it('a drag that only moves RF dispatches set_rf_gain ONLY — SQL is already at its target, no redundant set_squelch', () => {
+    h.caps = liveCaps(true, 'combined');
+    h.state = liveState(true);
+    (h.state as unknown as { main: { rfGain: number; squelch: number } }).main.rfGain = 1;
+    (h.state as unknown as { main: { rfGain: number; squelch: number } }).main.squelch = 0;
+    render();
+    const input = el('rf-sql')!.querySelector('input')!;
+    input.value = '0'; // hard left: RF -> 0 (changes), SQL stays 0 (unchanged)
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    expect(h.rfGain).toHaveBeenCalledExactlyOnceWith(0);
+    expect(h.squelch).not.toHaveBeenCalled();
+  });
 });
 
 /* ── MOR-1366 (S7), N1 fold — desktop-v2's REAL rf-front-end zone binds ─── */

--- a/frontend/src/components-v2/wiring/__tests__/semantic-rf-front-end-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rf-front-end-wiring.component.test.ts
@@ -214,7 +214,10 @@ function liveState(withRfFrontEnd: boolean): ServerState {
   } as unknown as ServerState;
 }
 
-const liveCaps = (withRfFrontEnd: boolean): Capabilities => ({
+// MOR-1447 leg 2: `rfSqlControlModel` defaults to omitted/'separate' — only the
+// combined-knob describe block below passes 'combined' explicitly, so every
+// pre-existing test in this file keeps exercising the unchanged two-slider path.
+const liveCaps = (withRfFrontEnd: boolean, rfSqlControlModel?: 'separate' | 'combined'): Capabilities => ({
   model: 'fixture', scope: false, audio: true, tx: true,
   capabilities: withRfFrontEnd
     ? ['audio', 'tx', 'dual_rx', 'preamp', 'attenuator', 'rf_gain', 'squelch', 'digisel', 'ip_plus']
@@ -225,6 +228,7 @@ const liveCaps = (withRfFrontEnd: boolean): Capabilities => ({
   webrtc: { available: false, enabled: false },
   txBands: [{ start: 14000000, end: 14350000, name: '20m' }],
   scopeSource: null, audioFftAvailable: false,
+  ...(rfSqlControlModel !== undefined ? { rfSqlControlModel } : {}),
 } as unknown as Capabilities);
 
 let target: HTMLDivElement;
@@ -286,13 +290,18 @@ describe('every rfFrontEnd intent reaches its own command-bus handler, none cros
   // anything else — so the wiring must convert on the way through. This was
   // the input-snaps-to-0%-or-100% regression: an unconverted intermediate
   // drag silently failed the real handler's integer guard.
+  // MOR-1447 verifier follow-up: literal expected value, not the same
+  // `Math.round(...)` formula the production seam itself uses — a mutation
+  // that swapped `Math.round` for `Math.trunc`/`Math.floor` would still pass
+  // a formula-mirroring assertion (140.25 truncates to 140 too). 0.55*255 is
+  // pinned as the literal 140.
   it('routes the RF-gain slider to onRfGainChange, converted to the raw 0-255 wire level', () => {
     render();
     const input = el('rfGain')!.querySelector('input')!;
     input.value = '0.55';
     input.dispatchEvent(new Event('input', { bubbles: true }));
     flushSync();
-    expect(h.rfGain).toHaveBeenCalledExactlyOnceWith(Math.round(0.55 * 255));
+    expect(h.rfGain).toHaveBeenCalledExactlyOnceWith(140);
     for (const other of ALL.filter((s) => s !== h.rfGain)) expect(other).not.toHaveBeenCalled();
   });
 
@@ -302,8 +311,21 @@ describe('every rfFrontEnd intent reaches its own command-bus handler, none cros
     input.value = '0.2';
     input.dispatchEvent(new Event('input', { bubbles: true }));
     flushSync();
-    expect(h.squelch).toHaveBeenCalledExactlyOnceWith(Math.round(0.2 * 255));
+    expect(h.squelch).toHaveBeenCalledExactlyOnceWith(51);
     for (const other of ALL.filter((s) => s !== h.squelch)) expect(other).not.toHaveBeenCalled();
+  });
+
+  // Rounding-rule pin (MOR-1447 leg 1 verifier follow-up item a): 0.5 is the
+  // exact tie case where `Math.round` (128) and a truncating conversion
+  // (127) diverge — 0.5*255 = 127.5. The literal 128 is the ONLY value that
+  // proves `Math.round` specifically, not merely "some" integer conversion.
+  it('rounds a 0.5 drag to the raw wire level 128, not the truncated 127', () => {
+    render();
+    const input = el('rfGain')!.querySelector('input')!;
+    input.value = '0.5';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    expect(h.rfGain).toHaveBeenCalledExactlyOnceWith(128);
   });
 
   // (d): `onDigiSelToggle`/`onIpPlusToggle` take an explicit `on: boolean` —
@@ -374,6 +396,115 @@ describe('the surface mounts only when the view model carries the group', () => 
     (h.state as unknown as { ptt: boolean }).ptt = true;
     flushSync();
     expect(el('surface')!.outerHTML).toBe(before);
+  });
+});
+
+/* ── MOR-1447 leg 2: the profile-declared combined RF/SQL knob ──────────
+ * IC-7300 is the live gate radio for `rf_sql_control_model = "combined"`
+ * (`rigs/ic7300.toml`). These cases pin the dispatch/value contract this
+ * wiring must honor once `runtime.caps.rfSqlControlModel` reads "combined":
+ * ONE knob position maps to BOTH `set_rf_gain`/`set_squelch`, over the exact
+ * same normalized→raw-0-255 seam (`RF_FRONT_END_LEVEL_INTENT`) leg 1 fixed —
+ * no new conversion path, no vendor branch. */
+
+describe('MOR-1447 leg 2: the combined RF/SQL knob, when the profile declares it', () => {
+  const ALL = [h.att, h.pre, h.rfGain, h.squelch, h.digiSel, h.ipPlus];
+
+  it('renders ONE rf-sql control, not the two separate sliders', () => {
+    h.caps = liveCaps(true, 'combined');
+    render();
+    expect(el('rf-sql')).not.toBeNull();
+    expect(el('rfGain')).toBeNull();
+    expect(el('squelch')).toBeNull();
+  });
+
+  it('keeps rendering the two separate sliders when the profile omits the declaration', () => {
+    h.caps = liveCaps(true); // no rfSqlControlModel -> defaults to 'separate'
+    render();
+    expect(el('rf-sql')).toBeNull();
+    expect(el('rfGain')).not.toBeNull();
+    expect(el('squelch')).not.toBeNull();
+  });
+
+  // Hard left: RF min, SQL min — both converted to the raw 0-255 wire level.
+  it('routes a hard-left drag to RF min / SQL min, both raw wire integers', () => {
+    h.caps = liveCaps(true, 'combined');
+    render();
+    const input = el('rf-sql')!.querySelector('input')!;
+    input.value = '0';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    expect(h.rfGain).toHaveBeenCalledExactlyOnceWith(0);
+    expect(h.squelch).toHaveBeenCalledExactlyOnceWith(0);
+    for (const other of ALL.filter((s) => s !== h.rfGain && s !== h.squelch)) {
+      expect(other).not.toHaveBeenCalled();
+    }
+  });
+
+  // Center (inside the dead zone): RF max, SQL min — the hardware's default
+  // "everything wide open, no squelch" rest position.
+  it('routes the knob center to RF max / SQL min', () => {
+    h.caps = liveCaps(true, 'combined');
+    render();
+    const input = el('rf-sql')!.querySelector('input')!;
+    input.value = '0.5';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    expect(h.rfGain).toHaveBeenCalledExactlyOnceWith(255);
+    expect(h.squelch).toHaveBeenCalledExactlyOnceWith(0);
+  });
+
+  // Hard right: SQL max, RF forced to max too (owner semantics: "hard right
+  // = SQL max (RF max)").
+  it('routes a hard-right drag to SQL max / RF max, both raw wire integers', () => {
+    h.caps = liveCaps(true, 'combined');
+    render();
+    const input = el('rf-sql')!.querySelector('input')!;
+    input.value = '1';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    expect(h.rfGain).toHaveBeenCalledExactlyOnceWith(255);
+    expect(h.squelch).toHaveBeenCalledExactlyOnceWith(255);
+  });
+
+  // Left-of-center: RF sweeps, SQL stays pinned at min. Literal expected
+  // values (not re-derived from the mapping formula) — 0.23 lands exactly
+  // halfway across the left leg (`dualParamValuesFromNormX`'s own math,
+  // ported from `DualParamRenderer`/`value-control-core.ts`).
+  it('sweeps RF only on a left-of-center drag, leaving SQL pinned at min', () => {
+    h.caps = liveCaps(true, 'combined');
+    render();
+    const input = el('rf-sql')!.querySelector('input')!;
+    input.value = '0.23';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    expect(h.rfGain).toHaveBeenCalledExactlyOnceWith(128);
+    expect(h.squelch).toHaveBeenCalledExactlyOnceWith(0);
+  });
+
+  // Right-of-center: RF pinned at max, SQL sweeps.
+  it('sweeps SQL only on a right-of-center drag, leaving RF pinned at max', () => {
+    h.caps = liveCaps(true, 'combined');
+    render();
+    const input = el('rf-sql')!.querySelector('input')!;
+    input.value = '0.77';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    expect(h.rfGain).toHaveBeenCalledExactlyOnceWith(255);
+    expect(h.squelch).toHaveBeenCalledExactlyOnceWith(128);
+  });
+
+  // Readback projection: SQL above min projects the knob to the right leg
+  // (RF forced to max) — the one honest reading when the physical knob
+  // cannot express "RF below max AND SQL above min" at once.
+  it('positions the knob on the right leg when SQL reads above min, on initial render', () => {
+    h.caps = liveCaps(true, 'combined');
+    h.state = liveState(true);
+    (h.state as unknown as { main: { rfGain: number; squelch: number } }).main.rfGain = 0.8196078431372549;
+    (h.state as unknown as { main: { rfGain: number; squelch: number } }).main.squelch = 0.2;
+    render();
+    const input = el('rf-sql')!.querySelector('input')!;
+    expect(input.valueAsNumber).toBeCloseTo(0.632, 3);
   });
 });
 

--- a/frontend/src/lib/runtime/adapters/__tests__/mor1428-ic7300-conformance.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mor1428-ic7300-conformance.isolated.test.ts
@@ -141,6 +141,9 @@ import { validateRadioViewModel } from '../../../../semantic/radio-view-model';
 import { toRadioViewModel } from '../radio-view-model-adapter';
 import { toSpectrumAuthority } from '../scope-adapter';
 import { getRfFrontEndHandlers } from '../panel-adapters';
+import {
+  dualParamNormXFromValues, dualParamValuesFromNormX,
+} from '../../../../components-v2/controls/value-control/value-control-core';
 import { IC7300_CAPABILITIES, IC7300_STATE } from './fixtures/ic7300-profile';
 
 /** Deep clone so a test that mutates `h.state`/`h.caps` never leaks into a sibling. */
@@ -293,6 +296,52 @@ describe('IC-7300 fixture — handler dispatch through real factories (MOR-1418/
       ['set_squelch', { level: 51, receiver: 0 }],
     ]);
     expectIntentTransport();
+  });
+
+  // MOR-1447 leg 2: IC-7300 is the live gate radio for
+  // `rf_sql_control_model = "combined"` (`rigs/ic7300.toml`). The captured
+  // fixture predates the declaration (a byte-faithful capture, never
+  // hand-edited — see the file header), so `IC7300_CAPABILITIES` itself
+  // still reads the default `rfSqlControlModel: undefined` -> "separate".
+  // These cases prove the DATA the combined knob would actually move,
+  // against the real captured `main.rfGain`/`main.squelch` readings, through
+  // the exact SAME `dualParamValuesFromNormX`/raw-0-255 rescale seam
+  // `RfFrontEndSurface.svelte`/`SemanticRadioSurfaces.svelte` use — ported
+  // from `DualParamRenderer`/`value-control-core.ts`, not re-derived here.
+  describe('combined RF/SQL knob (MOR-1447 leg 2) — dispatch/value cases against the real fixture', () => {
+    it('the live capture is squelch-at-min / RF-mid — the left leg of the combined knob', () => {
+      expect(IC7300_STATE.main!.rfGain).toBeCloseTo(0.8196078431372549);
+      expect(IC7300_STATE.main!.squelch).toBe(0);
+    });
+
+    it('readback projection places the knob on the left leg for the real captured reading', () => {
+      const normX = dualParamNormXFromValues(
+        IC7300_STATE.main!.rfGain!, IC7300_STATE.main!.squelch!, 0, 1,
+      );
+      expect(normX).toBeCloseTo(0.377, 3);
+    });
+
+    it('a hard-right drag from the captured position dispatches SQL max / RF max, raw 255/255', () => {
+      const { rf: nextRf, sql: nextSql } = dualParamValuesFromNormX(1, 0, 1, 0.01);
+      getRfFrontEndHandlers().onRfGainChange(nextRf);
+      getRfFrontEndHandlers().onSquelchChange(nextSql);
+      expect(exactCalls()).toEqual([
+        ['set_rf_gain', { level: 255, receiver: 0 }],
+        ['set_squelch', { level: 255, receiver: 0 }],
+      ]);
+      expectIntentTransport();
+    });
+
+    it('a left-of-center drag (normX 0.23) dispatches RF 128 / SQL 0, raw wire integers', () => {
+      const { rf: nextRf, sql: nextSql } = dualParamValuesFromNormX(0.23, 0, 1, 0.01);
+      getRfFrontEndHandlers().onRfGainChange(nextRf);
+      getRfFrontEndHandlers().onSquelchChange(nextSql);
+      expect(exactCalls()).toEqual([
+        ['set_rf_gain', { level: 128, receiver: 0 }],
+        ['set_squelch', { level: 0, receiver: 0 }],
+      ]);
+      expectIntentTransport();
+    });
   });
 
   it('AGC: dispatches set_agc on receiver 0', () => {

--- a/frontend/src/lib/types/capabilities.ts
+++ b/frontend/src/lib/types/capabilities.ts
@@ -116,6 +116,10 @@ export interface Capabilities {
   preLabels?: Record<string, string>;  // Preamp labels (e.g. {"0":"OFF","1":"P1","2":"P2"})
   agcModes?: number[];    // AGC mode values (e.g. [1,2,3] = FAST/MID/SLOW)
   agcLabels?: Record<string, string>;  // AGC mode labels (e.g. {"1":"FAST","2":"MID","3":"SLOW"})
+  /** RF/SQL control model (MOR-1447 leg 2): "separate" (default, two
+   *  independent controls) or "combined" (Icom-style single RF/SQL knob).
+   *  Absent on older servers — treat as "separate". */
+  rfSqlControlModel?: 'separate' | 'combined';
   dataModeCount?: number;
   dataModeLabels?: Record<string, string>;
   keyboard?: KeyboardConfig | null;

--- a/frontend/src/semantic/RfFrontEndSurface.svelte
+++ b/frontend/src/semantic/RfFrontEndSurface.svelte
@@ -179,8 +179,21 @@
     const { rf: nextRf, sql: nextSql } = dualParamValuesFromNormX(
       normX, RF_SQL_MIN, RF_SQL_MAX, RF_SQL_STEP,
     );
-    changeLevel('rfGain', nextRf);
-    changeLevel('squelch', nextSql);
+    // Per-field change guard, mirroring `DualParamRenderer.svelte`'s
+    // `emitPair` (`value-control-core.ts`'s companion component — only emits
+    // a field that actually moved). Without this, every input event
+    // unconditionally re-sends BOTH fields — a left-leg drag spams redundant
+    // `set_squelch(0)` and a right-leg drag spams redundant `set_rf_gain(255)`
+    // on every tick, roughly doubling the CI-V write rate versus both the
+    // real hardware knob and the leg-1 two-slider path. On the live serial
+    // IC-7300 gate radio that write-rate doubling is the queue-lag/"Commander
+    // stopped" hazard shape.
+    if (rf.rfGain.reading.status === 'known' && nextRf !== rf.rfGain.reading.value) {
+      changeLevel('rfGain', nextRf);
+    }
+    if (rf.squelch.reading.status === 'known' && nextSql !== rf.squelch.reading.value) {
+      changeLevel('squelch', nextSql);
+    }
   }
   function toggle(field: RfFrontEndToggleField): void {
     const f = rf?.[field];

--- a/frontend/src/semantic/RfFrontEndSurface.svelte
+++ b/frontend/src/semantic/RfFrontEndSurface.svelte
@@ -61,12 +61,26 @@
   const isValue = (f: RfFrontEndField<unknown>, value: unknown): boolean =>
     f.reading.status === 'known' && f.reading.value === value;
 
-  /** `[field, label, min, max, step]`, RAW wire units (0..1 fractions, no
-   *  rescale) — same discipline as `TxAuxSurface.TX_AUX_LEVELS`. */
+  /** `[field, label, min, max, step]`. The radio's own normalized 0..1
+   *  reading (a wire-protocol FRACTION, not the raw 0-255 wire unit) — same
+   *  discipline as `TxAuxSurface.TX_AUX_LEVELS`. Rescaled to the raw 0-255
+   *  integer `set_rf_gain`/`set_squelch` require at the wiring seam
+   *  (`SemanticRadioSurfaces.svelte`'s `RF_FRONT_END_LEVEL_INTENT`, MOR-1447),
+   *  never inside this presentation-only file. */
   export const RF_FRONT_END_LEVELS = [
     ['rfGain', 'RF gain', 0, 1, 0.01],
     ['squelch', 'Squelch', 0, 1, 0.01],
   ] as const;
+  /** The combined-knob domain (MOR-1447 leg 2): both `rfGain` and `squelch`
+   *  share this [0,1] range, an invariant of the combined control model —
+   *  `dualParamValuesFromNormX`/`dualParamNormXFromValues` map ONE knob
+   *  position onto both fields over the SAME domain. */
+  const [, , RF_SQL_MIN, RF_SQL_MAX, RF_SQL_STEP] = RF_FRONT_END_LEVELS[0];
+  /** Profile-declared control model (MOR-1447 leg 2, data-driven from
+   *  `[capabilities].rf_sql_control_model` in the rig TOML — never a
+   *  vendor/model-name branch in code). `'separate'` is the default: two
+   *  independent sliders, unchanged from leg 1. */
+  export type RfSqlControlModel = 'separate' | 'combined';
   /** `[field, label]` on/off controls. */
   export const RF_FRONT_END_TOGGLES = [
     ['digiSel', 'DIGI-SEL'], ['ipPlus', 'IP+'],
@@ -84,9 +98,16 @@
 
 <script lang="ts">
   import type { RadioViewModel } from './radio-view-model';
+  import {
+    dualParamValuesFromNormX,
+    dualParamNormXFromValues,
+  } from '../components-v2/controls/value-control/value-control-core';
 
   interface Props {
     view: RadioViewModel;
+    /** Icom-style single-knob RF/SQL (MOR-1447 leg 2). Defaults to
+     *  `'separate'` — the two independent sliders leg 1 fixed. */
+    controlModel?: RfSqlControlModel;
     onPreampChange?: (level: number) => void;
     onAttenuatorChange?: (db: number) => void;
     onLevelChange?: (field: RfFrontEndLevelField, value: number) => void;
@@ -97,7 +118,9 @@
      *  it rather than the wiring re-reading raw state to derive it. */
     onToggle?: (field: RfFrontEndToggleField, next: boolean) => void;
   }
-  let { view, onPreampChange, onAttenuatorChange, onLevelChange, onToggle }: Props = $props();
+  let {
+    view, controlModel = 'separate', onPreampChange, onAttenuatorChange, onLevelChange, onToggle,
+  }: Props = $props();
 
   let rf = $derived(view.rfFrontEnd);
   /** Carry-forwards 2/3: matched on the DOTTED field path, never re-derived
@@ -114,6 +137,50 @@
   }
   function changeLevel(field: RfFrontEndLevelField, value: number): void {
     if (rf && usable(rf[field])) onLevelChange?.(field, value);
+  }
+  /** MOR-1447 leg 2: both fields structurally present AND the profile
+   *  declares the combined knob — the gate for rendering ONE control instead
+   *  of two. A profile that declares `'combined'` but only observes one of
+   *  the pair structurally falls back to the two-slider rendering below
+   *  (the per-field `{#if rf[field].availability.structural}` gates still
+   *  apply), same "render what's actually there" discipline as every other
+   *  field in this file. */
+  let combinedUsable = $derived(
+    controlModel === 'combined'
+    && !!rf?.rfGain.availability.structural
+    && !!rf?.squelch.availability.structural,
+  );
+  const knownOr = (f: RfFrontEndField<number> | undefined, fallback: number): number =>
+    f && f.reading.status === 'known' ? f.reading.value : fallback;
+  /** Readback projection (MOR-1447 leg 2): the honest inverse of the
+   *  hardware knob. Ported verbatim from `dualParamNormXFromValues`
+   *  (`components-v2/controls/value-control/value-control-core.ts`) — the
+   *  same math `DualParamRenderer.svelte` already draws with. Ambiguity
+   *  handling is inherited from that function: if SQL reads above its
+   *  minimum, the knob is projected to the right leg (RF forced to max) —
+   *  the physical knob genuinely cannot express "RF below max AND SQL above
+   *  min" at once, so this is the one honest reading, not a guess.
+   */
+  let combinedNormX = $derived(
+    dualParamNormXFromValues(
+      knownOr(rf?.rfGain, RF_SQL_MIN),
+      knownOr(rf?.squelch, RF_SQL_MIN),
+      RF_SQL_MIN,
+      RF_SQL_MAX,
+    ),
+  );
+  function changeCombined(normX: number): void {
+    // Both halves must be independently usable, not merely structurally
+    // present (mirrors carry-forward 2/3's "the handler itself refuses to
+    // emit, independent of `disabled`" discipline): one physical knob must
+    // not silently half-write the pair — e.g. move RF while SQL is degraded
+    // and stays untouched, desyncing what looks like a single control.
+    if (!rf || !usable(rf.rfGain) || !usable(rf.squelch)) return;
+    const { rf: nextRf, sql: nextSql } = dualParamValuesFromNormX(
+      normX, RF_SQL_MIN, RF_SQL_MAX, RF_SQL_STEP,
+    );
+    changeLevel('rfGain', nextRf);
+    changeLevel('squelch', nextSql);
   }
   function toggle(field: RfFrontEndToggleField): void {
     const f = rf?.[field];
@@ -164,23 +231,41 @@
       </div>
     {/if}
 
-    {#each RF_FRONT_END_LEVELS as [field, label, min, max, step] (field)}
-      {#if rf[field].availability.structural}
-        <label
-          class="rf-front-end-level" data-testid={`rf-front-end-${field}`}
-          data-observed={usable(rf[field])}
+    {#if combinedUsable}
+      <label
+        class="rf-front-end-level" data-testid="rf-front-end-rf-sql"
+        data-observed={usable(rf.rfGain) && usable(rf.squelch)}
+      >
+        <span class="rf-front-end-name">RF/SQL</span>
+        <input
+          type="range" min={RF_SQL_MIN} max={RF_SQL_MAX} step={RF_SQL_STEP}
+          value={combinedNormX}
+          disabled={!usable(rf.rfGain) || !usable(rf.squelch)}
+          oninput={(event) => changeCombined(event.currentTarget.valueAsNumber)}
+        />
+        <output
+          >{levelTextOf(rf.rfGain, RF_SQL_MIN, RF_SQL_MAX)} / {levelTextOf(rf.squelch, RF_SQL_MIN, RF_SQL_MAX)}</output
         >
-          <span class="rf-front-end-name">{label}</span>
-          <input
-            type="range" {min} {max} {step}
-            value={rf[field].reading.status === 'known' ? rf[field].reading.value : 0}
-            disabled={!usable(rf[field])}
-            oninput={(event) => changeLevel(field, event.currentTarget.valueAsNumber)}
-          />
-          <output>{levelTextOf(rf[field], min, max)}</output>
-        </label>
-      {/if}
-    {/each}
+      </label>
+    {:else}
+      {#each RF_FRONT_END_LEVELS as [field, label, min, max, step] (field)}
+        {#if rf[field].availability.structural}
+          <label
+            class="rf-front-end-level" data-testid={`rf-front-end-${field}`}
+            data-observed={usable(rf[field])}
+          >
+            <span class="rf-front-end-name">{label}</span>
+            <input
+              type="range" {min} {max} {step}
+              value={rf[field].reading.status === 'known' ? rf[field].reading.value : 0}
+              disabled={!usable(rf[field])}
+              oninput={(event) => changeLevel(field, event.currentTarget.valueAsNumber)}
+            />
+            <output>{levelTextOf(rf[field], min, max)}</output>
+          </label>
+        {/if}
+      {/each}
+    {/if}
 
     {#each RF_FRONT_END_TOGGLES as [field, label] (field)}
       {#if rf[field].availability.structural}

--- a/frontend/src/semantic/__tests__/RfFrontEndSurface.test.ts
+++ b/frontend/src/semantic/__tests__/RfFrontEndSurface.test.ts
@@ -318,40 +318,61 @@ describe('the combined RF/SQL knob (controlModel="combined")', () => {
     r.dispose();
   });
 
-  it('emits BOTH rfGain and squelch on a hard-left drag: RF min, SQL min', () => {
+  // Per-field change guard (verifier follow-up R1, mirrors
+  // `DualParamRenderer.svelte`'s `emitPair`): only a field whose mapped
+  // value actually differs from its current confirmed reading emits. `base()`
+  // starts at rfGain=known(1)/squelch=known(0) — the knob's own "center, at
+  // rest" position — so each case below is chosen to isolate exactly ONE
+  // field changing, mirroring the real single-knob write pattern instead of
+  // spamming a redundant re-send of the field that didn't move.
+
+  it('a hard-left drag emits ONLY rfGain — squelch is already at min, unchanged', () => {
     const onLevelChange = vi.fn();
     const r = render(base(), { controlModel: 'combined', onLevelChange });
     const input = r.el('rf-sql')!.querySelector('input')!;
     input.value = '0';
     input.dispatchEvent(new Event('input', { bubbles: true }));
     flushSync();
-    expect(onLevelChange).toHaveBeenCalledTimes(2);
-    expect(onLevelChange).toHaveBeenNthCalledWith(1, 'rfGain', 0);
-    expect(onLevelChange).toHaveBeenNthCalledWith(2, 'squelch', 0);
+    expect(onLevelChange).toHaveBeenCalledExactlyOnceWith('rfGain', 0);
     r.dispose();
   });
 
-  it('emits RF max / SQL min at the knob center (the dead zone default)', () => {
+  it('the knob center emits NOTHING — RF is already max and SQL already min, the "at rest" position', () => {
     const onLevelChange = vi.fn();
     const r = render(base(), { controlModel: 'combined', onLevelChange });
     const input = r.el('rf-sql')!.querySelector('input')!;
     input.value = '0.5';
     input.dispatchEvent(new Event('input', { bubbles: true }));
     flushSync();
-    expect(onLevelChange).toHaveBeenNthCalledWith(1, 'rfGain', 1);
-    expect(onLevelChange).toHaveBeenNthCalledWith(2, 'squelch', 0);
+    expect(onLevelChange).not.toHaveBeenCalled();
     r.dispose();
   });
 
-  it('emits SQL max / RF max on a hard-right drag — owner semantics: "hard right = SQL max (RF max)"', () => {
+  it('a hard-right drag emits ONLY squelch — RF is already at max, unchanged (owner semantics: "hard right = SQL max (RF max)")', () => {
     const onLevelChange = vi.fn();
     const r = render(base(), { controlModel: 'combined', onLevelChange });
     const input = r.el('rf-sql')!.querySelector('input')!;
     input.value = '1';
     input.dispatchEvent(new Event('input', { bubbles: true }));
     flushSync();
-    expect(onLevelChange).toHaveBeenNthCalledWith(1, 'rfGain', 1);
-    expect(onLevelChange).toHaveBeenNthCalledWith(2, 'squelch', 1);
+    expect(onLevelChange).toHaveBeenCalledExactlyOnceWith('squelch', 1);
+    r.dispose();
+  });
+
+  it('a leg-crossing drag emits BOTH — RF and SQL are both actually moving, unlike the single-leg cases above', () => {
+    const onLevelChange = vi.fn();
+    // Starts already on the right leg (RF max, SQL 0.5) instead of at rest,
+    // then crosses to the left leg — both halves genuinely change value.
+    const r = render(withRf({ rfGain: known(1), squelch: known(0.5) }), {
+      controlModel: 'combined', onLevelChange,
+    });
+    const input = r.el('rf-sql')!.querySelector('input')!;
+    input.value = '0.23';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    expect(onLevelChange).toHaveBeenCalledTimes(2);
+    expect(onLevelChange).toHaveBeenCalledWith('rfGain', 0.5);
+    expect(onLevelChange).toHaveBeenCalledWith('squelch', 0);
     r.dispose();
   });
 
@@ -383,7 +404,7 @@ describe('the combined RF/SQL knob (controlModel="combined")', () => {
     r.dispose();
   });
 
-  it('disables the combined slider and emits nothing while either field is unusable', () => {
+  it('disables the combined slider and emits nothing while squelch is unusable', () => {
     const onLevelChange = vi.fn();
     const r = render(withRf({ squelch: unread<number>(DEGRADED) }), {
       controlModel: 'combined', onLevelChange,
@@ -391,6 +412,24 @@ describe('the combined RF/SQL knob (controlModel="combined")', () => {
     const input = r.el('rf-sql')!.querySelector('input')!;
     expect(input.disabled).toBe(true);
     input.value = '1';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    expect(onLevelChange).not.toHaveBeenCalled();
+    r.dispose();
+  });
+
+  // Verifier follow-up R2: the mirror of the case above. A mutation that
+  // dropped ONLY the `!usable(rf.rfGain)` half of the guard (leaving
+  // `!usable(rf.squelch)` in place) would still pass the test above — it
+  // needs this independent mirror to be killed.
+  it('disables the combined slider and emits nothing while rfGain is unusable', () => {
+    const onLevelChange = vi.fn();
+    const r = render(withRf({ rfGain: unread<number>(DEGRADED) }), {
+      controlModel: 'combined', onLevelChange,
+    });
+    const input = r.el('rf-sql')!.querySelector('input')!;
+    expect(input.disabled).toBe(true);
+    input.value = '0';
     input.dispatchEvent(new Event('input', { bubbles: true }));
     flushSync();
     expect(onLevelChange).not.toHaveBeenCalled();

--- a/frontend/src/semantic/__tests__/RfFrontEndSurface.test.ts
+++ b/frontend/src/semantic/__tests__/RfFrontEndSurface.test.ts
@@ -284,6 +284,120 @@ describe('RF gain and squelch render as 0..1 sliders, no rescale', () => {
   });
 });
 
+/* ── MOR-1447 leg 2: the combined RF/SQL knob ────────────────────── */
+
+describe('the combined RF/SQL knob (controlModel="combined")', () => {
+  it('renders one rf-sql control instead of the two separate sliders', () => {
+    const r = render(base(), { controlModel: 'combined' });
+    expect(r.el('rf-sql')).not.toBeNull();
+    expect(r.el('rfGain')).toBeNull();
+    expect(r.el('squelch')).toBeNull();
+    r.dispose();
+  });
+
+  it('keeps the two separate sliders when controlModel is "separate" (default)', () => {
+    const r = render(base());
+    expect(r.el('rf-sql')).toBeNull();
+    expect(r.el('rfGain')).not.toBeNull();
+    expect(r.el('squelch')).not.toBeNull();
+    r.dispose();
+  });
+
+  it('falls back to the two-slider rendering if either field is structurally absent, even when combined is declared', () => {
+    const r = render(withRf({ squelch: unread(OFF) }), { controlModel: 'combined' });
+    expect(r.el('rf-sql')).toBeNull();
+    expect(r.el('rfGain')).not.toBeNull();
+    expect(r.el('squelch')).toBeNull(); // squelch itself is absent, per its own structural gate
+    r.dispose();
+  });
+
+  it('declares the combined slider on the 0..1 scale', () => {
+    const r = render(base(), { controlModel: 'combined' });
+    const input = r.el('rf-sql')!.querySelector('input')!;
+    expect([input.min, input.max]).toEqual(['0', '1']);
+    r.dispose();
+  });
+
+  it('emits BOTH rfGain and squelch on a hard-left drag: RF min, SQL min', () => {
+    const onLevelChange = vi.fn();
+    const r = render(base(), { controlModel: 'combined', onLevelChange });
+    const input = r.el('rf-sql')!.querySelector('input')!;
+    input.value = '0';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    expect(onLevelChange).toHaveBeenCalledTimes(2);
+    expect(onLevelChange).toHaveBeenNthCalledWith(1, 'rfGain', 0);
+    expect(onLevelChange).toHaveBeenNthCalledWith(2, 'squelch', 0);
+    r.dispose();
+  });
+
+  it('emits RF max / SQL min at the knob center (the dead zone default)', () => {
+    const onLevelChange = vi.fn();
+    const r = render(base(), { controlModel: 'combined', onLevelChange });
+    const input = r.el('rf-sql')!.querySelector('input')!;
+    input.value = '0.5';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    expect(onLevelChange).toHaveBeenNthCalledWith(1, 'rfGain', 1);
+    expect(onLevelChange).toHaveBeenNthCalledWith(2, 'squelch', 0);
+    r.dispose();
+  });
+
+  it('emits SQL max / RF max on a hard-right drag — owner semantics: "hard right = SQL max (RF max)"', () => {
+    const onLevelChange = vi.fn();
+    const r = render(base(), { controlModel: 'combined', onLevelChange });
+    const input = r.el('rf-sql')!.querySelector('input')!;
+    input.value = '1';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    expect(onLevelChange).toHaveBeenNthCalledWith(1, 'rfGain', 1);
+    expect(onLevelChange).toHaveBeenNthCalledWith(2, 'squelch', 1);
+    r.dispose();
+  });
+
+  // Readback projection: SQL known above min projects the knob to the right
+  // leg (RF forced to max) — the physical knob cannot express "RF below max
+  // AND SQL above min" simultaneously, so this is the one honest reading.
+  it('positions the knob on the right leg when SQL reads above min', () => {
+    const r = render(withRf({ rfGain: known(0.8196078431372549), squelch: known(0.2) }), {
+      controlModel: 'combined',
+    });
+    const input = r.el('rf-sql')!.querySelector('input')!;
+    expect(input.valueAsNumber).toBeCloseTo(0.632, 3);
+    r.dispose();
+  });
+
+  // Readback projection: RF known below max with SQL at min projects to the
+  // left leg.
+  it('positions the knob on the left leg when RF reads below max and SQL is at min', () => {
+    const r = render(withRf({ rfGain: known(0.5), squelch: known(0) }), { controlModel: 'combined' });
+    const input = r.el('rf-sql')!.querySelector('input')!;
+    expect(input.valueAsNumber).toBeCloseTo(0.23, 3);
+    r.dispose();
+  });
+
+  it('shows a combined RF/SQL readout formatted as two percentages', () => {
+    const r = render(withRf({ rfGain: known(0.5), squelch: known(0.2) }), { controlModel: 'combined' });
+    expect(r.text('rf-sql')).toContain('50%');
+    expect(r.text('rf-sql')).toContain('20%');
+    r.dispose();
+  });
+
+  it('disables the combined slider and emits nothing while either field is unusable', () => {
+    const onLevelChange = vi.fn();
+    const r = render(withRf({ squelch: unread<number>(DEGRADED) }), {
+      controlModel: 'combined', onLevelChange,
+    });
+    const input = r.el('rf-sql')!.querySelector('input')!;
+    expect(input.disabled).toBe(true);
+    input.value = '1';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    expect(onLevelChange).not.toHaveBeenCalled();
+    r.dispose();
+  });
+});
+
 describe('DIGI-SEL and IP+ render as toggles and emit the FLIPPED value', () => {
   it.each(RF_FRONT_END_TOGGLES)('shows the observed %s state as pressed/unpressed', (field) => {
     const r = render(withRf({ [field]: known(true) } as Partial<RfFrontEndViewModel>));

--- a/rigs/ic7300.toml
+++ b/rigs/ic7300.toml
@@ -97,6 +97,14 @@ features = [
     # System
     "system_settings",
 ]
+# MOR-1447 leg 2: the IC-7300 front panel wires RF gain and squelch as one
+# physical concentric knob (hard left = RF min/SQL min, center = RF max/SQL
+# min, hard right = SQL max/RF max) — the live gate radio for this control
+# model. Other Icom-family profiles (IC-7610, IC-705, IC-9700) stay on the
+# "separate" default: no CAT audit/manual excerpt in this repo documents
+# their physical RF/SQL layout, so declaring "combined" for them would be a
+# guess rather than a data-driven fact.
+rf_sql_control_model = "combined"
 
 [state_acquisition]
 provider = "icom_civ"

--- a/src/rigplane/profiles/__init__.py
+++ b/src/rigplane/profiles/__init__.py
@@ -173,6 +173,11 @@ class RadioProfile:
     pre_labels: dict[str, str] | None = None
     agc_modes: tuple[int, ...] | None = None
     agc_labels: dict[str, str] | None = None
+    # MOR-1447 leg 2: "separate" (default, two independent controls) or
+    # "combined" (Icom-style single RF/SQL knob). Data-driven from
+    # ``[capabilities].rf_sql_control_model`` in the rig TOML — never a
+    # vendor/model-name branch in code.
+    rf_sql_control_model: str = "separate"
     data_mode_count: int = 0
     data_mode_labels: dict[str, str] | None = None
     # When True, MAIN set_mode routes through CI-V 0x26 0x00 (set selected

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -55,6 +55,11 @@ VALID_AUDIO_SAMPLE_RATES_HZ = {8000, 12000, 16000, 24000, 48000}
 VALID_BROWSER_RX_TRANSPORTS = {"auto", "pcm", "opus"}
 VALID_RX_AUDIO_CHANNELS = {"mix", "left", "right"}
 VALID_VFO_READBACK = {"absolute", "selected_unselected", "none"}
+# MOR-1447 leg 2. Icom hardware wires RF gain and squelch as one physical
+# knob (hard left = RF min/SQL min, center = RF max/SQL min, hard right =
+# SQL max/RF max); "separate" is the default two-independent-controls model
+# every other rig uses.
+VALID_RF_SQL_CONTROL_MODELS = {"separate", "combined"}
 DEFAULT_KEYBOARD_PROFILE_NAME = "_keyboard-default.toml"
 
 _REQUIRED_SECTIONS = ("radio", "capabilities", "modes", "filters", "vfo")
@@ -97,6 +102,9 @@ class RigConfig:
     pre_labels: dict[str, str] | None
     agc_modes: tuple[int, ...] | None
     agc_labels: dict[str, str] | None
+    # MOR-1447 leg 2: "separate" (default) or "combined" (Icom-style single
+    # RF/SQL knob — see ``VALID_RF_SQL_CONTROL_MODELS``).
+    rf_sql_control_model: str = "separate"
     filter_width_min: int = 50
     filter_width_max: int = 9999
     filter_width_encoding: str = "segmented_bcd_index"
@@ -196,6 +204,7 @@ class RigConfig:
             pre_labels=self.pre_labels,
             agc_modes=self.agc_modes,
             agc_labels=self.agc_labels,
+            rf_sql_control_model=self.rf_sql_control_model,
             data_mode_count=self.data_mode_count,
             data_mode_labels=self.data_mode_labels,
             set_mode_via_selected="set_selected_mode" in self.commands,
@@ -994,6 +1003,12 @@ def load_rig(path: Path) -> RigConfig:
                 f"{filename}: unknown capability {cap!r}. "
                 f"Known: {sorted(KNOWN_CAPABILITIES)}"
             )
+    rf_sql_control_model = data["capabilities"].get("rf_sql_control_model", "separate")
+    if rf_sql_control_model not in VALID_RF_SQL_CONTROL_MODELS:
+        raise RigLoadError(
+            f"{filename}: [capabilities].rf_sql_control_model must be one of "
+            f"{sorted(VALID_RF_SQL_CONTROL_MODELS)}, got {rf_sql_control_model!r}"
+        )
 
     # Validate [validation].write_only_controls — each entry must be a declared
     # capability. These route through the validate set-and-observe engine path
@@ -1421,6 +1436,7 @@ def load_rig(path: Path) -> RigConfig:
         pre_labels=pre_labels,
         agc_modes=agc_modes,
         agc_labels=agc_labels,
+        rf_sql_control_model=rf_sql_control_model,
         data_mode_count=data_mode_count,
         data_mode_labels=data_mode_labels,
         protocol_type=protocol_type,

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -2716,6 +2716,7 @@ class WebServer:
                     "preLabels": profile.pre_labels,
                     "agcModes": list(profile.agc_modes) if profile.agc_modes else None,
                     "agcLabels": profile.agc_labels,
+                    "rfSqlControlModel": profile.rf_sql_control_model,
                     "antennas": profile.antenna_tx_count,
                     "dataModeCount": profile.data_mode_count,
                     "dataModeLabels": profile.data_mode_labels,
@@ -3172,6 +3173,7 @@ class WebServer:
             "preLabels": profile.pre_labels if profile.pre_labels else {},
             "agcModes": list(profile.agc_modes) if profile.agc_modes else [],
             "agcLabels": profile.agc_labels if profile.agc_labels else {},
+            "rfSqlControlModel": profile.rf_sql_control_model,
             "dataModeCount": profile.data_mode_count,
             "dataModeLabels": (
                 profile.data_mode_labels if profile.data_mode_labels else {}

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -168,6 +168,41 @@ provider = 123
         with pytest.raises(RigLoadError, match="vfo.*scheme"):
             load_rig(p)
 
+    def test_rf_sql_control_model_defaults_to_separate(self, tmp_path):
+        p = _write_toml(tmp_path, _MINIMAL_TOML)
+        rig = load_rig(p)
+        assert rig.rf_sql_control_model == "separate"
+        assert rig.to_profile().rf_sql_control_model == "separate"
+
+    def test_rf_sql_control_model_combined(self, tmp_path):
+        toml = _MINIMAL_TOML.replace(
+            'features = ["audio", "scope", "meters", "tx"]',
+            'features = ["audio", "scope", "meters", "tx"]\n'
+            'rf_sql_control_model = "combined"',
+        )
+        p = _write_toml(tmp_path, toml)
+        rig = load_rig(p)
+        assert rig.rf_sql_control_model == "combined"
+        assert rig.to_profile().rf_sql_control_model == "combined"
+
+    def test_rf_sql_control_model_invalid(self, tmp_path):
+        toml = _MINIMAL_TOML.replace(
+            'features = ["audio", "scope", "meters", "tx"]',
+            'features = ["audio", "scope", "meters", "tx"]\n'
+            'rf_sql_control_model = "concentric"',
+        )
+        p = _write_toml(tmp_path, toml)
+        with pytest.raises(RigLoadError, match="rf_sql_control_model"):
+            load_rig(p)
+
+    def test_ic7300_declares_combined_rf_sql_control_model(self):
+        rig = load_rig(RIGS_DIR / "ic7300.toml")
+        assert rig.rf_sql_control_model == "combined"
+
+    def test_ic7610_stays_separate_rf_sql_control_model(self):
+        rig = load_rig(RIGS_DIR / "ic7610.toml")
+        assert rig.rf_sql_control_model == "separate"
+
     @pytest.mark.parametrize(
         ("scheme", "receiver_count"),
         [

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -706,6 +706,9 @@ class TestHttpEndpoints:
         assert "audio" in data
         assert "modes" in data
         assert isinstance(data["modes"], list)
+        # MOR-1447 leg 2: RF/SQL control-model declaration always present,
+        # defaulting to "separate" unless the profile declares "combined".
+        assert data["rfSqlControlModel"] in ("separate", "combined")
 
     async def test_state_endpoint_contains_radio_ready(self, server: WebServer) -> None:
         host, port = _addr(server)

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -2406,6 +2406,38 @@ async def test_http_and_capabilities_share_the_current_store_generation() -> Non
 
 
 @pytest.mark.asyncio
+async def test_capabilities_reports_combined_rf_sql_control_model_for_ic7300() -> None:
+    """MOR-1447 leg 2: IC-7300's declared combined RF/SQL knob reaches the wire."""
+
+    class _Ic7300Radio:
+        model = "IC-7300"
+        capabilities: set[str] = set()
+
+    srv = WebServer(_Ic7300Radio())
+    writer = _FakeWriter()
+    await srv._serve_capabilities(writer)  # noqa: SLF001
+    _, payload = _response_json(writer)
+
+    assert payload["rfSqlControlModel"] == "combined"
+
+
+@pytest.mark.asyncio
+async def test_capabilities_defaults_to_separate_rf_sql_control_model() -> None:
+    """A profile that doesn't declare the combined knob stays "separate"."""
+
+    class _Ic7610Radio:
+        model = "IC-7610"
+        capabilities: set[str] = set()
+
+    srv = WebServer(_Ic7610Radio())
+    writer = _FakeWriter()
+    await srv._serve_capabilities(writer)  # noqa: SLF001
+    _, payload = _response_json(writer)
+
+    assert payload["rfSqlControlModel"] == "separate"
+
+
+@pytest.mark.asyncio
 async def test_generation_transition_changes_state_etag() -> None:
     srv = WebServer(None)
     first_writer = _FakeWriter()


### PR DESCRIPTION
## Summary

MOR-1447 leg 2 of 2. Leg 1 (#2390, merged) fixed the two-slider intermediate-drag regression (RF gain/squelch snapping to 0%/100% only) and added the shared readout formatter. This leg restores the Icom combined RF/SQL knob control model that the MOR-1366 semantic-surface swap dropped, gated entirely by profile data — no vendor/model-name branch anywhere.

Owner semantics (Icom hardware): RF/SQL is one physical concentric knob — hard left = RF min/SQL min, center = RF max/SQL min, hard right = SQL max/RF max, intermediate positions blend accordingly.

## Capabilities-flow seam

Followed the exact existing path `agcLabels`/`vfoScheme` already use — no new plumbing pattern:

- `rigs/*.toml`: `[capabilities].rf_sql_control_model` (new, optional, default `"separate"`)
- `src/rigplane/profiles/rig_loader.py`: parsed + validated (`VALID_RF_SQL_CONTROL_MODELS`) at the `[capabilities]` block (mirrors `features`/`vfo.scheme` validation), carried on `RigConfig.rf_sql_control_model` → `RigConfig.to_profile()`
- `src/rigplane/profiles/__init__.py`: `RadioProfile.rf_sql_control_model: str = "separate"`
- `src/rigplane/web/server.py`: `"rfSqlControlModel": profile.rf_sql_control_model` added to both `_serve_capabilities` (the payload `runtime.caps` actually consumes, `/api/v1/capabilities`) and `_serve_info` (legacy endpoint, for consistency with the other profile-echo fields)
- `frontend/src/lib/types/capabilities.ts`: `Capabilities.rfSqlControlModel?: 'separate' | 'combined'` (optional — absent on older servers reads as `'separate'`)
- `frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte`: `rfSqlControlModel = $derived(runtime.caps?.rfSqlControlModel ?? 'separate')`, same "caps-echo display metadata" precedent as `hasDualReceiver`/`agcLabels` at that seam, passed to `<RfFrontEndSurface controlModel={rfSqlControlModel} .../>`

## What was ported from DualParamRenderer

`RfFrontEndSurface.svelte` imports `dualParamValuesFromNormX`/`dualParamNormXFromValues` directly from `components-v2/controls/value-control/value-control-core.ts` (the same pure functions `DualParamRenderer.svelte` already draws with) — the math is reused verbatim, not re-derived. This matches the existing precedent of `DspSurface.svelte` importing `rawToPercentDisplay` from the same module: semantic surfaces already import pure value-control math, just not the full illuminated-hardware visual component (this surface stays plain-DOM presentation-only, consistent with its existing two-slider markup).

When the profile declares `"combined"` and both `rfGain`/`squelch` are structurally present, the surface renders ONE `<input type="range">` (domain `[0,1]`, same as the two individual sliders) instead of two. Dragging computes `{rf, sql}` via `dualParamValuesFromNormX` and calls the *same* `onLevelChange('rfGain', …)` / `onLevelChange('squelch', …)` prop twice — reusing the existing intent seam unmodified (`RF_FRONT_END_LEVEL_INTENT`'s normalized→raw-0-255 `Math.round(value * 255)` conversion, from leg 1, is untouched).

A profile that declares `"combined"` but only observes one of the pair structurally falls back to the two-slider rendering (each field's own structural gate still applies) — "render what's actually there," same discipline as every other field in the file.

## Readback projection

`combinedNormX` is `dualParamNormXFromValues(rfGain, squelch, 0, 1)` — the inverse mapping, also ported unmodified. Ambiguity handling: if squelch reads above its minimum, the knob is projected to the right leg (RF forced to max) — the physical knob genuinely cannot express "RF below max AND SQL above min" simultaneously, so this is the one honest reading, not a guess. Pinned in both `RfFrontEndSurface.test.ts` and the IC-7300 conformance suite using the real captured `main.rfGain = 0.8196078431372549` / `main.squelch = 0` reading (left leg) and a synthetic right-leg case.

The emit guard additionally checks `usable()` (not just structural) on *both* halves before dispatching either — one physical knob must not silently half-write the pair (e.g. move RF while SQL is degraded and stays untouched). Caught by a test during TDD (`disables the combined slider and emits nothing while either field is unusable`).

## Per-profile declaration decisions

- **`rigs/ic7300.toml` → `"combined"`.** The live gate radio for this ticket; owner-specified explicitly.
- **`rigs/ic7610.toml`, `rigs/ic705.toml`, `rigs/ic9700.toml` → left at the `"separate"` default.** No CAT audit or manual excerpt in `docs/validation/cat-audits/` documents the physical RF/SQL knob layout for these profiles (CAT audits cover CI-V command mapping, not front-panel hardware layout) — IC-7610 and IC-705 have audits but neither discusses the knob; IC-9700 has no audit at all. Declaring `"combined"` for them would be a guess, not a data-driven fact, so they stay on the regression-tested two-slider path until a documented source confirms it.
- **X6200/X6100 (Xiegu), TX-500 (lab599), FTX-1 (Yaesu) → not applicable.** Not Icom-family radios; untouched, still `"separate"`.

## Tests

- Backend: `tests/test_rig_loader.py` (parse/validate/default, IC-7300 declares combined, IC-7610 stays separate), `tests/test_web_server.py` + `tests/test_web_server_coverage.py` (payload field presence, IC-7300 → `"combined"`, IC-7610 → `"separate"`)
- Frontend pure surface: `frontend/src/semantic/__tests__/RfFrontEndSurface.test.ts` (renders one vs two controls, domain, hard-left/center/hard-right dispatch, both-leg readback projection, combined readout formatting, usability emit-guard)
- Frontend wiring: `frontend/src/components-v2/wiring/__tests__/semantic-rf-front-end-wiring.component.test.ts` (caps-driven model selection, dispatch through the real `RF_FRONT_END_LEVEL_INTENT` seam, literal 140/128 rounding pins)
- Frontend conformance: `frontend/src/lib/runtime/adapters/__tests__/mor1428-ic7300-conformance.isolated.test.ts` — dispatch/value cases against the real captured IC-7300 fixture (`main.rfGain = 0.8196078431372549`, `main.squelch = 0`): readback projection literal, hard-right and left-of-center drags dispatching through `getRfFrontEndHandlers()`
- Doc-drift fix: `RF_FRONT_END_LEVELS`'s header comment corrected (wire unit is a 0..1 normalized fraction rescaled to raw 0-255 at the wiring seam, not "raw wire units, no rescale")

## Net production LOC

131 net (150 insertions − 19 deletions) across 7 production files, under the 200 LOC budget. Touches more than the default 3-file guardrail — this leg's own brief explicitly scoped "frontend + minimal profile TOML (+ capabilities plumbing if the flag doesn't flow yet)," and the plumbing chain (TOML → RigConfig → RadioProfile → server payload → frontend type → wiring → surface) is inherently that many files; each hop is a 1-2 line mechanical addition following an existing field's exact path.

## Suite results

- `uv run pytest tests/ -q --tb=short --ignore=tests/integration`: 9031 passed, 12 skipped, 5 deselected, 11 xfailed, 1 xpassed
- `uv run ruff check src/ tests/`: all checks passed
- `uv run mypy src/rigplane/profiles/ src/rigplane/web/server.py`: no issues
- `npx vitest run` (frontend): 323 files / 6678 tests passed (no flake encountered — `fixture-capture-root-cwd.test.ts` ran clean in the full run, no standalone rerun needed)
- `npx svelte-check` / `npx tsc -p tsconfig.node.json` / `npx eslint src/`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
