### PR TITLE
fix: route digit keys to frequency entry when VFO focused (MOR-1444)

### DIFF
--- a/frontend/src/components-v2/layout/KeyboardHandler.svelte
+++ b/frontend/src/components-v2/layout/KeyboardHandler.svelte
@@ -6,6 +6,8 @@
     resolveSequenceContinuation,
     resolveSequenceStart,
     shouldIgnoreEvent,
+    isDigitKey,
+    isFrequencyDisplayFocused,
     formatShortcut,
     type KeyboardActionConfig,
     type KeyboardBindingConfig,
@@ -60,9 +62,45 @@
     onAction(action);
   }
 
+  /**
+   * MOR-1444: seeds BandSurface's frequency-entry input with a digit typed
+   * while the VFO/frequency display has focus, and moves focus into it.
+   * `[data-freq-entry]` is a production hook on that input (BandSurface.svelte)
+   * distinct from its test id. Every following keystroke targets the
+   * now-focused INPUT, which `shouldIgnoreEvent` already excludes from
+   * shortcut resolution above — so only the FIRST digit of a typed-entry
+   * gesture needs this routing; native typing takes it from there. Resets
+   * (rather than appends to) any stale leftover value, since this is the
+   * start of a fresh gesture. Returns false — letting the caller fall
+   * through to normal band-hotkey resolution — when the entry surface isn't
+   * mounted or is disabled (no band group on this skin, or BandSurface's own
+   * MOR-1322/rule-5 fail-closed gates: active receiver or tuning bounds not
+   * yet known).
+   */
+  function routeDigitToFrequencyEntry(digit: string): boolean {
+    const input = document.querySelector<HTMLInputElement>('[data-freq-entry]');
+    if (!input || input.disabled) return false;
+    input.focus();
+    input.value = digit;
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    return true;
+  }
+
   function handleKeydown(event: KeyboardEvent): void {
     if (!enabled) return;
     if (shouldIgnoreEvent(document.activeElement)) return;
+
+    // MOR-1444: with the VFO/frequency display focused, a digit keystroke
+    // must feed the frequency-entry box instead of resolving as a band
+    // hotkey — every rig profile's keyboard config binds "1".."9" to
+    // band_select, and without this guard `resolveAction` below hops bands
+    // on every typed digit. Band hotkeys are untouched everywhere else.
+    if (isDigitKey(event.key) && isFrequencyDisplayFocused(document.activeElement)) {
+      if (routeDigitToFrequencyEntry(event.key)) {
+        event.preventDefault();
+        return;
+      }
+    }
 
     // MOR-1449: Tab is reserved for the browser's native focus traversal and
     // must never be assignable to a shortcut — a rig profile's keyboard

--- a/frontend/src/components-v2/layout/KeyboardHandler.svelte
+++ b/frontend/src/components-v2/layout/KeyboardHandler.svelte
@@ -95,8 +95,21 @@
     // hotkey — every rig profile's keyboard config binds "1".."9" to
     // band_select, and without this guard `resolveAction` below hops bands
     // on every typed digit. Band hotkeys are untouched everywhere else.
-    if (isDigitKey(event.key) && isFrequencyDisplayFocused(document.activeElement)) {
+    // MOR-1444 B3 (round-2 review): a Ctrl/Cmd/Alt-modified digit is a
+    // browser or OS shortcut (Cmd+1 switches tabs in most browsers), never a
+    // frequency-entry keystroke — it must reach neither the entry input nor
+    // preventDefault().
+    if (
+      isDigitKey(event.key) && !event.ctrlKey && !event.metaKey && !event.altKey
+      && isFrequencyDisplayFocused(document.activeElement)
+    ) {
       if (routeDigitToFrequencyEntry(event.key)) {
+        // MOR-1444 B2 (round-2 review): mirrors the MOR-1449 Tab guard
+        // immediately below — an early return must still disarm a pending
+        // leader sequence, or the pill stays armed and a later keystroke
+        // (once focus leaves the now-focused, ignored-tag entry input) can
+        // complete an unintended leader sequence.
+        if (pendingSequence) clearLeaderState();
         event.preventDefault();
         return;
       }

--- a/frontend/src/components-v2/layout/__tests__/KeyboardHandler.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/KeyboardHandler.test.ts
@@ -230,16 +230,34 @@ describe('KeyboardHandler', () => {
           action: 'band_select',
           params: { index: 7 },
         },
+        {
+          id: 'focus-af',
+          section: 'Focus',
+          label: 'Go to AF',
+          sequence: ['g', 'a'],
+          action: 'focus_target',
+          params: { target: 'af' },
+        },
       ],
     };
 
-    function appendVfoFreqDisplay(): HTMLElement {
+    /**
+     * Mirrors VfoSurface.svelte's real DOM shape: a `[data-vfo-tile]` with
+     * the RECEIVER-wide `data-vfo-active` flag wrapping the `[data-vfo-freq]`
+     * span. `active` defaults to true so every pre-existing test below keeps
+     * exercising "the active receiver's display has focus".
+     */
+    function appendVfoFreqDisplay({ active = true }: { active?: boolean } = {}): HTMLElement {
+      const tile = document.createElement('div');
+      tile.setAttribute('data-vfo-tile', '');
+      tile.setAttribute('data-vfo-active', String(active));
       const wrapper = document.createElement('span');
       wrapper.setAttribute('data-vfo-freq', '');
       const focusTarget = document.createElement('div');
       focusTarget.tabIndex = 0;
       wrapper.appendChild(focusTarget);
-      document.body.appendChild(wrapper);
+      tile.appendChild(wrapper);
+      document.body.appendChild(tile);
       return focusTarget;
     }
 
@@ -323,5 +341,86 @@ describe('KeyboardHandler', () => {
       );
       expect(entryInput.value).toBe('');
     });
+
+    // MOR-1444 B1 (round-2 review) — REPRODUCED: on a dual-receiver cockpit
+    // (2/main_sub) both receivers mount a focusable [data-vfo-freq], since
+    // VfoSurface.svelte's hasTunableFrequency gates on isActiveSlot, not the
+    // radio-wide isActive. enterFrequency() always writes view.activeReceiver
+    // (SemanticRadioSurfaces.svelte), so routing a digit typed on the
+    // INACTIVE receiver's display would silently commit to the WRONG VFO —
+    // reopening the MOR-1322 B1 / MOR-1335 G4 cross-dispatch class. Digits
+    // must fall through to the band hotkey here exactly as if no VFO display
+    // were focused at all.
+    it('falls back to the band hotkey when the focused VFO tile is not the active receiver', () => {
+      const onAction = vi.fn();
+      mountHandler({ config: configWithDigitBinding, onAction });
+      const vfoFocusTarget = appendVfoFreqDisplay({ active: false });
+      const entryInput = appendFreqEntryInput();
+      vfoFocusTarget.focus();
+
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: '7', bubbles: true, cancelable: true }));
+
+      expect(onAction).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'band_select', params: { index: 7 } }),
+      );
+      expect(entryInput.value).toBe('');
+      expect(document.activeElement).toBe(vfoFocusTarget);
+    });
+
+    // MOR-1444 B2 (round-2 review) — REPRODUCED: the digit guard returned
+    // above the `if (pendingSequence)` block without disarming it, unlike
+    // the MOR-1449 Tab guard 12 lines below which explicitly does. Repro:
+    // "g" arms the leader pill, "7" (VFO focused) routes to the entry input
+    // and returns early — the pill must NOT still be armed afterward, or a
+    // later "a" within leaderTimeoutMs completes "g a" into an unintended
+    // focus_target once focus leaves the (ignored-tag) entry input.
+    it('disarms a pending leader sequence when a digit routes to the frequency-entry input', () => {
+      const onAction = vi.fn();
+      const target = mountHandler({ config: configWithDigitBinding, onAction });
+      const vfoFocusTarget = appendVfoFreqDisplay();
+      const entryInput = appendFreqEntryInput();
+
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'g' }));
+      flushSync();
+      expect(target.querySelector('.keyboard-leader-pill')).not.toBeNull();
+
+      vfoFocusTarget.focus();
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: '7', bubbles: true, cancelable: true }));
+      flushSync();
+      expect(target.querySelector('.keyboard-leader-pill')).toBeNull();
+
+      // The repro's "blur → next key within the timeout": had the leader
+      // stayed armed, this "a" would complete "g a" -> focus_target once
+      // focus leaves the entry input (an ignored tag while it holds focus).
+      entryInput.blur();
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'a', bubbles: true, cancelable: true }));
+      expect(onAction).not.toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'focus_target' }),
+      );
+    });
+
+    // MOR-1444 B3 (round-2 review) — a Ctrl/Cmd/Alt-modified digit is a
+    // BROWSER OR OS shortcut (Cmd+1 switches tabs in most browsers), not a
+    // frequency-entry keystroke. Routing it would both hijack focus into the
+    // entry input AND swallow the browser's own shortcut via preventDefault.
+    it.each(['ctrlKey', 'metaKey', 'altKey'] as const)(
+      'does not route a %s-modified digit to the entry input',
+      (modifier) => {
+        const onAction = vi.fn();
+        mountHandler({ config: configWithDigitBinding, onAction });
+        const vfoFocusTarget = appendVfoFreqDisplay();
+        const entryInput = appendFreqEntryInput();
+        vfoFocusTarget.focus();
+
+        const event = new KeyboardEvent('keydown', {
+          key: '7', [modifier]: true, bubbles: true, cancelable: true,
+        });
+        window.dispatchEvent(event);
+
+        expect(event.defaultPrevented).toBe(false);
+        expect(entryInput.value).toBe('');
+        expect(document.activeElement).toBe(vfoFocusTarget);
+      },
+    );
   });
 });

--- a/frontend/src/components-v2/layout/__tests__/KeyboardHandler.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/KeyboardHandler.test.ts
@@ -210,4 +210,118 @@ describe('KeyboardHandler', () => {
     expect(onAction).not.toHaveBeenCalled();
     expect(followUp.defaultPrevented).toBe(false);
   });
+
+  // MOR-1444 — every rig profile's keyboard config binds "1".."9" to
+  // `band_select` (rigs/_keyboard-default.toml). Typing a frequency with the
+  // VFO/frequency display focused used to hop bands on every digit instead
+  // of reaching BandSurface's typed-entry box. These pins cover both sides:
+  // digits route to the entry input while the VFO display has focus, and
+  // keep firing band hotkeys exactly as before everywhere else.
+  describe('digit routing to the frequency-entry input (MOR-1444)', () => {
+    const configWithDigitBinding: KeyboardConfig = {
+      ...config,
+      bindings: [
+        ...config.bindings,
+        {
+          id: 'band-7',
+          section: 'Band',
+          label: 'Select band 7',
+          sequence: ['7'],
+          action: 'band_select',
+          params: { index: 7 },
+        },
+      ],
+    };
+
+    function appendVfoFreqDisplay(): HTMLElement {
+      const wrapper = document.createElement('span');
+      wrapper.setAttribute('data-vfo-freq', '');
+      const focusTarget = document.createElement('div');
+      focusTarget.tabIndex = 0;
+      wrapper.appendChild(focusTarget);
+      document.body.appendChild(wrapper);
+      return focusTarget;
+    }
+
+    function appendFreqEntryInput(): HTMLInputElement {
+      const input = document.createElement('input');
+      input.setAttribute('data-freq-entry', '');
+      document.body.appendChild(input);
+      return input;
+    }
+
+    it('feeds the digit into the frequency-entry input and does not fire the band hotkey', () => {
+      const onAction = vi.fn();
+      mountHandler({ config: configWithDigitBinding, onAction });
+      const vfoFocusTarget = appendVfoFreqDisplay();
+      const entryInput = appendFreqEntryInput();
+      vfoFocusTarget.focus();
+      expect(document.activeElement).toBe(vfoFocusTarget);
+
+      const event = new KeyboardEvent('keydown', { key: '7', bubbles: true, cancelable: true });
+      window.dispatchEvent(event);
+
+      expect(event.defaultPrevented).toBe(true);
+      expect(onAction).not.toHaveBeenCalled();
+      expect(document.activeElement).toBe(entryInput);
+      expect(entryInput.value).toBe('7');
+    });
+
+    it('resets the entry to the freshly typed digit rather than appending to a stale value', () => {
+      const onAction = vi.fn();
+      mountHandler({ config: configWithDigitBinding, onAction });
+      const vfoFocusTarget = appendVfoFreqDisplay();
+      const entryInput = appendFreqEntryInput();
+      entryInput.value = '14250000';
+      vfoFocusTarget.focus();
+
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: '7', bubbles: true, cancelable: true }));
+
+      expect(entryInput.value).toBe('7');
+    });
+
+    it('still dispatches the band hotkey when focus is elsewhere', () => {
+      const onAction = vi.fn();
+      mountHandler({ config: configWithDigitBinding, onAction });
+      appendVfoFreqDisplay();
+      appendFreqEntryInput();
+      // Focus stays on document.body (the jsdom default) — nowhere near the
+      // VFO display.
+
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: '7', bubbles: true, cancelable: true }));
+
+      expect(onAction).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'band_select', params: { index: 7 } }),
+      );
+    });
+
+    it('falls back to the band hotkey when the VFO display is focused but no entry input exists', () => {
+      const onAction = vi.fn();
+      mountHandler({ config: configWithDigitBinding, onAction });
+      const vfoFocusTarget = appendVfoFreqDisplay();
+      vfoFocusTarget.focus();
+
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: '7', bubbles: true, cancelable: true }));
+
+      expect(onAction).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'band_select', params: { index: 7 } }),
+      );
+    });
+
+    it('falls back to the band hotkey when the entry input is disabled', () => {
+      const onAction = vi.fn();
+      mountHandler({ config: configWithDigitBinding, onAction });
+      const vfoFocusTarget = appendVfoFreqDisplay();
+      const entryInput = appendFreqEntryInput();
+      entryInput.disabled = true;
+      vfoFocusTarget.focus();
+
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: '7', bubbles: true, cancelable: true }));
+
+      expect(onAction).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'band_select', params: { index: 7 } }),
+      );
+      expect(entryInput.value).toBe('');
+    });
+  });
 });

--- a/frontend/src/components-v2/layout/__tests__/keyboard-map.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/keyboard-map.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
-import { DEFAULT_KEYBOARD_CONFIG, resolveAction, shouldIgnoreEvent } from '../keyboard-map';
+import {
+  DEFAULT_KEYBOARD_CONFIG,
+  isDigitKey,
+  isFrequencyDisplayFocused,
+  resolveAction,
+  shouldIgnoreEvent,
+} from '../keyboard-map';
 import {
   resetLocalExtensionKeyboardScope,
   setLocalExtensionKeyboardScope,
@@ -118,5 +124,54 @@ describe('shouldIgnoreEvent', () => {
     expect(shouldIgnoreEvent(null)).toBe(true);
 
     resetLocalExtensionKeyboardScope();
+  });
+});
+
+// MOR-1444 — digit keys must reach BandSurface's frequency-entry input
+// instead of a band hotkey when the VFO/frequency display has focus.
+describe('isDigitKey', () => {
+  it.each(['0', '1', '5', '9'])('treats %s as a digit', (key) => {
+    expect(isDigitKey(key)).toBe(true);
+  });
+
+  it.each(['a', 'Enter', 'Tab', '10', '', '-'])('does not treat %s as a digit', (key) => {
+    expect(isDigitKey(key)).toBe(false);
+  });
+});
+
+describe('isFrequencyDisplayFocused', () => {
+  it('is true when the active element sits inside a [data-vfo-freq] ancestor', () => {
+    const wrapper = document.createElement('span');
+    wrapper.setAttribute('data-vfo-freq', '');
+    const freqRoot = document.createElement('div');
+    wrapper.appendChild(freqRoot);
+    document.body.appendChild(wrapper);
+
+    expect(isFrequencyDisplayFocused(freqRoot)).toBe(true);
+
+    wrapper.remove();
+  });
+
+  it('is true for the [data-vfo-freq] element itself', () => {
+    const wrapper = document.createElement('span');
+    wrapper.setAttribute('data-vfo-freq', '');
+    document.body.appendChild(wrapper);
+
+    expect(isFrequencyDisplayFocused(wrapper)).toBe(true);
+
+    wrapper.remove();
+  });
+
+  it('is false for an element outside any [data-vfo-freq] ancestor', () => {
+    const el = document.createElement('div');
+    document.body.appendChild(el);
+
+    expect(isFrequencyDisplayFocused(el)).toBe(false);
+
+    el.remove();
+  });
+
+  it('is false for null', () => {
+    expect(isFrequencyDisplayFocused(null)).toBe(false);
   });
 });

--- a/frontend/src/components-v2/layout/__tests__/keyboard-map.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/keyboard-map.test.ts
@@ -140,26 +140,64 @@ describe('isDigitKey', () => {
 });
 
 describe('isFrequencyDisplayFocused', () => {
-  it('is true when the active element sits inside a [data-vfo-freq] ancestor', () => {
-    const wrapper = document.createElement('span');
-    wrapper.setAttribute('data-vfo-freq', '');
+  /**
+   * Mirrors VfoSurface.svelte's real DOM shape: a `[data-vfo-tile]` wrapping
+   * `data-vfo-active` (the RECEIVER-wide active flag) around a `[data-vfo-freq]`
+   * span. `active` defaults to true so the pre-existing tests below (written
+   * before the MOR-1444 B1 fix) keep exercising "the active tile's display".
+   */
+  function buildVfoTile(active = true): { tile: HTMLElement; freq: HTMLElement } {
+    const tile = document.createElement('div');
+    tile.setAttribute('data-vfo-tile', '');
+    tile.setAttribute('data-vfo-active', String(active));
+    const freq = document.createElement('span');
+    freq.setAttribute('data-vfo-freq', '');
+    tile.appendChild(freq);
+    document.body.appendChild(tile);
+    return { tile, freq };
+  }
+
+  it('is true when the active element sits inside the active tile\'s [data-vfo-freq]', () => {
+    const { tile, freq } = buildVfoTile(true);
     const freqRoot = document.createElement('div');
-    wrapper.appendChild(freqRoot);
-    document.body.appendChild(wrapper);
+    freq.appendChild(freqRoot);
 
     expect(isFrequencyDisplayFocused(freqRoot)).toBe(true);
 
-    wrapper.remove();
+    tile.remove();
   });
 
-  it('is true for the [data-vfo-freq] element itself', () => {
-    const wrapper = document.createElement('span');
-    wrapper.setAttribute('data-vfo-freq', '');
-    document.body.appendChild(wrapper);
+  it('is true for the [data-vfo-freq] element itself on the active tile', () => {
+    const { tile, freq } = buildVfoTile(true);
 
-    expect(isFrequencyDisplayFocused(wrapper)).toBe(true);
+    expect(isFrequencyDisplayFocused(freq)).toBe(true);
 
-    wrapper.remove();
+    tile.remove();
+  });
+
+  // MOR-1444 B1 — reproduced: on 2/main_sub both receivers mount a focusable
+  // [data-vfo-freq] (hasTunableFrequency gates on isActiveSlot, not isActive
+  // — VfoSurface.svelte:258-259), but only the ACTIVE RECEIVER's tile is the
+  // honest dispatch target for enterFrequency()'s view.activeReceiver write.
+  // Focusing the INACTIVE receiver's display must not qualify as "the VFO
+  // display is focused" for routing purposes — reopening the MOR-1322 B1 /
+  // MOR-1335 G4 cross-dispatch class this predicate exists to keep shut.
+  it('is false when the active element sits inside an INACTIVE tile\'s [data-vfo-freq]', () => {
+    const { tile, freq } = buildVfoTile(false);
+    const freqRoot = document.createElement('div');
+    freq.appendChild(freqRoot);
+
+    expect(isFrequencyDisplayFocused(freqRoot)).toBe(false);
+
+    tile.remove();
+  });
+
+  it('is false for the [data-vfo-freq] element itself on an inactive tile', () => {
+    const { tile, freq } = buildVfoTile(false);
+
+    expect(isFrequencyDisplayFocused(freq)).toBe(false);
+
+    tile.remove();
   });
 
   it('is false for an element outside any [data-vfo-freq] ancestor', () => {

--- a/frontend/src/components-v2/layout/keyboard-map.ts
+++ b/frontend/src/components-v2/layout/keyboard-map.ts
@@ -303,3 +303,20 @@ export function shouldIgnoreEvent(activeElement: Element | null): boolean {
   if (!activeElement) return false;
   return IGNORED_TAGS.has(activeElement.tagName);
 }
+
+/** MOR-1444: true for a single digit character ("0".."9"), the key class a
+ *  rig profile's keyboard config binds to `band_select`. */
+export function isDigitKey(key: string): boolean {
+  return key.length === 1 && key >= '0' && key <= '9';
+}
+
+/**
+ * MOR-1444: true when the active element is the VFO/frequency display or
+ * sits inside it. `data-vfo-freq` is the existing production hook on the
+ * wrapper `<span>` around `FrequencyDisplayInteractive` in `VfoSurface.svelte`
+ * — present for every VFO tile with a tunable frequency, no new markup
+ * needed.
+ */
+export function isFrequencyDisplayFocused(activeElement: Element | null): boolean {
+  return activeElement?.closest('[data-vfo-freq]') != null;
+}

--- a/frontend/src/components-v2/layout/keyboard-map.ts
+++ b/frontend/src/components-v2/layout/keyboard-map.ts
@@ -311,12 +311,26 @@ export function isDigitKey(key: string): boolean {
 }
 
 /**
- * MOR-1444: true when the active element is the VFO/frequency display or
- * sits inside it. `data-vfo-freq` is the existing production hook on the
- * wrapper `<span>` around `FrequencyDisplayInteractive` in `VfoSurface.svelte`
- * — present for every VFO tile with a tunable frequency, no new markup
- * needed.
+ * MOR-1444: true when the active element is the ACTIVE RECEIVER's
+ * VFO/frequency display, or sits inside it. `data-vfo-freq` is the existing
+ * production hook on the wrapper `<span>` around `FrequencyDisplayInteractive`
+ * in `VfoSurface.svelte` — present for every VFO tile with a tunable
+ * frequency, no new markup needed.
+ *
+ * MOR-1444 B1 (round-2 review, reproduced): `hasTunableFrequency` gates on
+ * `isActiveSlot`, not the radio-wide `isActive` (VfoSurface.svelte:258-259)
+ * — so on a dual-receiver cockpit BOTH receivers can mount a focusable
+ * `[data-vfo-freq]` at once. `enterFrequency()` always writes
+ * `view.activeReceiver` (SemanticRadioSurfaces.svelte), so qualifying on
+ * `[data-vfo-freq]` alone would let a digit typed on the INACTIVE receiver's
+ * display commit to the WRONG VFO — reopening the MOR-1322 B1 / MOR-1335 G4
+ * cross-dispatch class. The ancestor `[data-vfo-tile]`'s own
+ * `data-vfo-active` flag (VfoSurface.svelte:367) is the same fact
+ * `hasTunableFrequency`'s sibling `tuneFrequency` guard reads, so this stays
+ * a single source of truth rather than a second derivation.
  */
 export function isFrequencyDisplayFocused(activeElement: Element | null): boolean {
-  return activeElement?.closest('[data-vfo-freq]') != null;
+  const freq = activeElement?.closest('[data-vfo-freq]');
+  if (!freq) return false;
+  return freq.closest('[data-vfo-tile]')?.getAttribute('data-vfo-active') !== 'false';
 }

--- a/frontend/src/semantic/BandSurface.svelte
+++ b/frontend/src/semantic/BandSurface.svelte
@@ -167,6 +167,24 @@
     if (!entryReady) return;
     onEnterFrequency?.(typedHz);
   }
+  /** MOR-1444: Escape cancels a typed entry — clears the keystrokes without
+   *  dispatching, mirroring the "never coerce a malformed entry" rule above
+   *  rather than adding a second dispatch guard. */
+  function cancelEntry(): void {
+    entryText = '';
+  }
+  /** MOR-1444: Enter commits through the same `commitFrequency` path (and
+   *  therefore the same `entryReady` guard) the Set button already uses;
+   *  Escape cancels. Template-only wiring — no new prop, import or hook. */
+  function handleEntryKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      commitFrequency();
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      cancelEntry();
+    }
+  }
 </script>
 
 {#if band}
@@ -222,10 +240,11 @@
     <label class="band-row" data-testid="band-entry" data-bounds={boundsKnown}>
       <span class="band-name">FREQ</span>
       <input
-        type="number" data-testid="band-entry-input" step="1"
+        type="number" data-testid="band-entry-input" data-freq-entry step="1"
         min={band.tuneMinHz ?? undefined} max={band.tuneMaxHz ?? undefined}
         value={entryText} disabled={!receiverKnown || !boundsKnown}
         oninput={(event) => { entryText = event.currentTarget.value; }}
+        onkeydown={handleEntryKeydown}
       />
       <span data-testid="band-entry-range">{boundsKnown && band.tuneMinHz !== null
         && band.tuneMaxHz !== null

--- a/frontend/src/semantic/BandSurface.svelte
+++ b/frontend/src/semantic/BandSurface.svelte
@@ -183,6 +183,14 @@
     } else if (event.key === 'Escape') {
       event.preventDefault();
       cancelEntry();
+      // Round-2 review, recorder item 3: leaving focus in the (now-empty)
+      // input keeps it an "ignored tag" for KeyboardHandler's
+      // shouldIgnoreEvent, silently suppressing band hotkeys until a Tab.
+      // Blurring un-suppresses them immediately. This does not attempt to
+      // return focus to wherever the gesture started (this file has no
+      // reference to that, and the entry may have been reached without one)
+      // — the next Tab resumes from the document's normal order.
+      if (event.currentTarget instanceof HTMLElement) event.currentTarget.blur();
     }
   }
 </script>

--- a/frontend/src/semantic/BandSurface.svelte
+++ b/frontend/src/semantic/BandSurface.svelte
@@ -179,9 +179,24 @@
   function handleEntryKeydown(event: KeyboardEvent): void {
     if (event.key === 'Enter') {
       event.preventDefault();
+      // Round-3 review: preventDefault() alone never stops propagation —
+      // harmless here (Enter has no shipped window-level binding today),
+      // but this key is not itself the safety property, so it gets the
+      // same treatment as Escape rather than relying on that being true.
+      event.stopPropagation();
       commitFrequency();
     } else if (event.key === 'Escape') {
       event.preventDefault();
+      // Round-3 review (REQUIRED FIX): preventDefault() does NOT stop
+      // propagation. Every rig profile ships "Escape -> clear_rit_xit"
+      // (rigs/_keyboard-default.toml) on KeyboardHandler's window-level
+      // listener. Without stopPropagation, this keydown — after the blur
+      // below already moved document.activeElement off the (ignored-tag)
+      // input — would bubble to that listener and fire a REAL radio write
+      // (makeRitXitHandlers().onClear()), silently clearing the operator's
+      // RIT/XIT offset on a frequency-entry cancel. The ticket's "Esc
+      // cancels entry without dispatch" means this dispatch too.
+      event.stopPropagation();
       cancelEntry();
       // Round-2 review, recorder item 3: leaving focus in the (now-empty)
       // input keeps it an "ignored tag" for KeyboardHandler's

--- a/frontend/src/semantic/__tests__/BandSurface.test.ts
+++ b/frontend/src/semantic/__tests__/BandSurface.test.ts
@@ -16,8 +16,17 @@
  *       unobserved (the MOR-1322 B1 wrong-VFO class).
  *
  * Fast-pool-safe by construction (MOR-1272): no `vi.mock`, no `vi.stubGlobal`,
- * no global spy. The composed-tree pins live in the isolated-pool wiring file
+ * no global spy. The composed-tree pins for BandSurface's PROP wiring (how
+ * SemanticRadioSurfaces feeds it a view model and callbacks) live in the
+ * isolated-pool wiring file
  * `components-v2/wiring/__tests__/semantic-band-wiring.component.test.ts`.
+ *
+ * One deliberate exception (MOR-1444 round-3 review): the last describe
+ * block below mounts the real `KeyboardHandler` alongside the real
+ * `BandSurface` to pin a DOM EVENT-BUBBLING contract between them (Escape
+ * must not propagate past this component into the window keyboard seam).
+ * That is not prop wiring — no store, no transport, no `vi.mock` — so it
+ * stays fast-pool-safe and belongs with the Escape behavior it guards.
  */
 import { readFileSync } from 'node:fs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -31,6 +40,8 @@ import type { FrequencyPermit } from '$lib/utils/tx-permit';
 import type {
   BandChoice, BandViewModel, DisabledReason, RadioViewModel,
 } from '../radio-view-model';
+import KeyboardHandler from '../../components-v2/layout/KeyboardHandler.svelte';
+import type { KeyboardConfig } from '../../components-v2/layout/keyboard-map';
 
 const SOURCE = readFileSync('src/semantic/BandSurface.svelte', 'utf8');
 /** Comments stripped, so the file's own doctrine prose can never be what a
@@ -679,5 +690,78 @@ describe('keyboard entry commits on Enter and cancels on Escape (MOR-1444)', () 
     keydown(input, 'Escape');
     expect(document.activeElement).not.toBe(input);
     r.dispose();
+  });
+});
+
+/**
+ * Round-3 review — REQUIRED PIN. preventDefault() never stops propagation:
+ * before this fix, Escape in the entry input blurred it (moving
+ * document.activeElement to <body>, an un-ignored tag) and then kept
+ * bubbling — reaching KeyboardHandler's window-level listener with nothing
+ * left to suppress it. Every rig profile SHIPS "Escape -> clear_rit_xit"
+ * (rigs/_keyboard-default.toml), a REAL radio write
+ * (makeRitXitHandlers().onClear()) — so cancelling a frequency entry could
+ * silently clear the operator's RIT/XIT offset. The fixture below carries
+ * that exact shipped binding: without it, a passing test would prove
+ * nothing about whether Escape leaks past this component, since there'd be
+ * nothing on the other end to (not) fire.
+ *
+ * This mounts the REAL KeyboardHandler alongside the REAL BandSurface (not
+ * a hand-simulated stand-in for either), so a future change that drops
+ * `stopPropagation()` from BandSurface's Escape branch — or reorders it
+ * after the blur — fails this test via actual DOM event bubbling, the same
+ * mechanism that carries the bug in production.
+ */
+describe('Escape does not leak past BandSurface into the window keyboard seam (MOR-1444, round-3 review)', () => {
+  const BOUNDS = { tuneMinHz: 30000, tuneMaxHz: 60000000 } as const;
+
+  const configWithClearRitXit: KeyboardConfig = {
+    leaderKey: 'g',
+    leaderTimeoutMs: 1000,
+    altHints: true,
+    helpTitle: 'Test Keyboard Help',
+    bindings: [
+      {
+        id: 'clear-rit-xit',
+        section: 'RIT/XIT',
+        label: 'Clear offset',
+        sequence: ['Escape'],
+        action: 'clear_rit_xit',
+      },
+    ],
+  };
+
+  it('fires zero window-level actions and stays blurred when Escape cancels the entry', () => {
+    const onAction = vi.fn();
+    const khTarget = document.createElement('div');
+    document.body.appendChild(khTarget);
+    const kh = mount(KeyboardHandler, {
+      target: khTarget,
+      props: { config: configWithClearRitXit, onAction },
+    });
+    flushSync();
+
+    const onEnterFrequency = vi.fn();
+    const r = render(withB(BOUNDS), { onEnterFrequency });
+    const input = r.input()!;
+    typeFrequency(input, '14250000');
+    input.focus();
+    expect(document.activeElement).toBe(input);
+
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }));
+    flushSync();
+
+    // THE REGRESSION PIN: the shipped Escape -> clear_rit_xit binding must
+    // never fire from a frequency-entry cancel.
+    expect(onAction).not.toHaveBeenCalled();
+    // The ticket's own words: "Esc cancels entry without dispatch."
+    expect(onEnterFrequency).not.toHaveBeenCalled();
+    // Blur is retained (round-2 fix) — Escape still un-suppresses band
+    // hotkeys for whatever the operator does next.
+    expect(document.activeElement).not.toBe(input);
+
+    r.dispose();
+    unmount(kh);
+    khTarget.remove();
   });
 });

--- a/frontend/src/semantic/__tests__/BandSurface.test.ts
+++ b/frontend/src/semantic/__tests__/BandSurface.test.ts
@@ -618,3 +618,45 @@ describe('unknown is rendered as unknown (and F2 gets no local workaround)', () 
     r.dispose();
   });
 });
+
+/* ── keyboard entry: Enter commits via the same path as Set, Escape
+   cancels without dispatch (MOR-1444) ──────────────────────────── */
+
+describe('keyboard entry commits on Enter and cancels on Escape (MOR-1444)', () => {
+  const BOUNDS = { tuneMinHz: 30000, tuneMaxHz: 60000000 } as const;
+
+  function keydown(el: HTMLElement, key: string): void {
+    el.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true }));
+    flushSync();
+  }
+
+  it('commits the typed frequency on Enter, exactly like clicking Set', () => {
+    const onEnterFrequency = vi.fn();
+    const r = render(withB(BOUNDS), { onEnterFrequency });
+    typeFrequency(r.input()!, '14250000');
+    keydown(r.input()!, 'Enter');
+    expect(onEnterFrequency).toHaveBeenCalledExactlyOnceWith(14250000);
+    r.dispose();
+  });
+
+  // Kills: an Enter-commit path that bypasses the entryReady guard the Set
+  // button already goes through (carry-forward 5 / rule 5).
+  it('refuses to commit an out-of-range entry on Enter', () => {
+    const onEnterFrequency = vi.fn();
+    const r = render(withB(BOUNDS), { onEnterFrequency });
+    typeFrequency(r.input()!, '29999');
+    keydown(r.input()!, 'Enter');
+    expect(onEnterFrequency).not.toHaveBeenCalled();
+    r.dispose();
+  });
+
+  it('clears the entry on Escape without dispatching', () => {
+    const onEnterFrequency = vi.fn();
+    const r = render(withB(BOUNDS), { onEnterFrequency });
+    typeFrequency(r.input()!, '14250000');
+    keydown(r.input()!, 'Escape');
+    expect(onEnterFrequency).not.toHaveBeenCalled();
+    expect(r.input()!.value).toBe('');
+    r.dispose();
+  });
+});

--- a/frontend/src/semantic/__tests__/BandSurface.test.ts
+++ b/frontend/src/semantic/__tests__/BandSurface.test.ts
@@ -659,4 +659,25 @@ describe('keyboard entry commits on Enter and cancels on Escape (MOR-1444)', () 
     expect(r.input()!.value).toBe('');
     r.dispose();
   });
+
+  // Round-2 review, recorder item 3: leaving focus in the (now-emptied)
+  // entry input keeps it an "ignored tag" for KeyboardHandler's
+  // shouldIgnoreEvent, so band hotkeys would stay suppressed until the
+  // operator tabs away. Escape blurs the input so hotkeys work again
+  // immediately — it does not attempt to return focus to whatever
+  // originated the gesture (BandSurface has no reference to that; the
+  // gesture may not even have come through the keyboard seam), so the next
+  // Tab starts from the document's normal order rather than resuming where
+  // the operator was. That's a documented, honest trade-off, not a claim of
+  // full focus restoration.
+  it('blurs the entry input on Escape so band hotkeys are no longer suppressed by it', () => {
+    const r = render(withB(BOUNDS));
+    const input = r.input()!;
+    typeFrequency(input, '14250000');
+    input.focus();
+    expect(document.activeElement).toBe(input);
+    keydown(input, 'Escape');
+    expect(document.activeElement).not.toBe(input);
+    r.dispose();
+  });
 });


### PR DESCRIPTION
## Summary

Typing a frequency (e.g. `7100`) with the VFO/frequency display focused used to hop bands on every digit instead of reaching `BandSurface`'s typed frequency-entry box — every rig profile's keyboard config binds `"1".."9"` to `band_select` (`rigs/_keyboard-default.toml`), and `KeyboardHandler` had no way to tell "VFO display focused" apart from anywhere else. A typed-entry path already existed (`BandSurface`'s frequency entry input, exactness fixed in MOR-1425 round 3) but was unreachable via the natural gesture (focus VFO → type digits).

Band hotkeys now yield only when the ACTIVE receiver's VFO/frequency display has keyboard focus; everywhere else — including a focused but inactive-receiver display, a modified digit, or a leftover armed leader sequence — they behave exactly as before.

## Seam and design

- **`frontend/src/components-v2/layout/keyboard-map.ts`** — two new pure predicates parallel to the existing `shouldIgnoreEvent`:
  - `isDigitKey(key)` — true for a single `"0".."9"` character.
  - `isFrequencyDisplayFocused(activeElement)` — true when the active element is (or sits inside) the ACTIVE receiver's `[data-vfo-freq]`. `data-vfo-freq` is the existing production hook already on every VFO tile's frequency span (`VfoSurface.svelte`); the active-receiver qualification reads the ancestor `[data-vfo-tile]`'s existing `data-vfo-active` attribute — the same fact `VfoSurface.svelte`'s own `tuneFrequency` guard reads. No new markup needed for either.

- **`frontend/src/components-v2/layout/KeyboardHandler.svelte`** — `handleKeydown` gets one new guard, placed right after the existing `shouldIgnoreEvent` short-circuit and before the MOR-1449 Tab guard / leader-sequence / `resolveAction` resolution:
  - If the key is an **unmodified** digit (no Ctrl/Cmd/Alt) **and** the active receiver's VFO display is focused, `routeDigitToFrequencyEntry(digit)` looks up `[data-freq-entry]` (a new production attribute on `BandSurface`'s entry input, distinct from its test id), focuses it, resets its value to the freshly typed digit, and dispatches a synthetic `input` event so the input's own native `oninput` handler picks it up unmodified.
  - Only the **first** digit of a typed-entry gesture needs this routing: once focus moves onto the `<input>`, `shouldIgnoreEvent` already excludes `INPUT` from all shortcut resolution (pre-existing behavior), so every subsequent digit types natively.
  - On a successful route, a pending leader sequence is disarmed (`clearLeaderState()`) before returning — mirroring the MOR-1449 Tab guard immediately below.
  - `routeDigitToFrequencyEntry` returns `false` — falling through to normal band-hotkey resolution — when the entry input is absent (no `band` zone on this skin) or `disabled` (`BandSurface`'s own MOR-1322/rule-5 fail-closed gates: active receiver or tuning bounds not yet known). Digits never get silently swallowed with no honest target.

- **`frontend/src/semantic/BandSurface.svelte`** — Enter/Escape wiring on the existing entry `<input>`, template-only (`onkeydown={handleEntryKeydown}`, plus the new `data-freq-entry` attribute): no new prop, import, or lifecycle hook, so the file's locked-down doctrine tests (source-scan asserting it imports nothing but `./radio-view-model`, has no lifecycle hook/`$effect`, and takes exactly three props) stay untouched.
  - **Enter** calls the pre-existing `commitFrequency()` — the same `entryReady`-guarded path the "Set" button already uses, landing on the MOR-1425 `jump()` accumulator path (exact, unpaced, clears any pending burst).
  - **Escape** clears the typed entry (`entryText = ''`) without dispatching, then blurs the input.

Band-hotkey yield is therefore scoped entirely by DOM focus + the active-receiver flag — no new store, no eslint-boundary crossing (the DOM query lives in the layout-layer `KeyboardHandler.svelte`, which already does DOM-side-effect work such as `document.body.dataset.shortcutHints`).

## Round-2 review fixes

An independent review reproduced three under-scoping defects in the round-1 routing, all inside code this PR adds, plus one cheap UX gap. All four are fixed and pinned:

- **B1 — wrong-VFO cross-dispatch (reproduced).** `isFrequencyDisplayFocused` originally matched ANY `[data-vfo-freq]`, but `VfoSurface.svelte`'s `hasTunableFrequency` gates on `isActiveSlot`, not the radio-wide `isActive` — so on a dual-receiver cockpit (`2/main_sub`) BOTH receivers can mount a focusable frequency display at once, pinned by `VfoSurface.test.ts`'s "2/main_sub mounts exactly one control per RECEIVER" tests. `enterFrequency()` always writes `view.activeReceiver`, so focusing the SUB receiver's display and typing digits + Enter would have committed to MAIN — reopening the MOR-1322 B1 / MOR-1335 G4 cross-dispatch class as impossible. Fixed by qualifying the predicate against the ancestor `[data-vfo-tile]`'s `data-vfo-active` attribute.
- **B2 — pending leader not disarmed (reproduced).** The digit guard returned above the `if (pendingSequence)` block without `clearLeaderState()` — the exact hazard the MOR-1449 Tab guard 12 lines below exists to prevent. Repro: `g` (armed) → digit (routes, pill stays armed) → blur → `a` within the leader timeout → unintended `focus_target` fires. Fixed by mirroring the Tab guard.
- **B3 — modified digits swallowed.** Ctrl/Cmd/Alt+digit with the VFO display focused was routed into the entry input and `preventDefault`'ed, hijacking a browser or OS shortcut (Cmd+1 switches tabs in most browsers). Fixed by skipping the routing guard when `ctrlKey`/`metaKey`/`altKey` is set.
- **Recorder item 3 (cheap fix, applied).** Escape left focus in the now-empty entry input, which is an "ignored tag" for `shouldIgnoreEvent` — band hotkeys stayed suppressed until the operator tabbed away. Escape now blurs the input after clearing it. This does **not** attempt to return focus to wherever the gesture started — `BandSurface.svelte` has no reference to that (its locked-down doctrine tests forbid adding one), and the gesture may not even have come through the keyboard seam — so the next Tab resumes from the document's normal order rather than the operator's prior position. Documented here and inline rather than left as a silent wart.

## Round-3 review fix

Round-2's Escape-blur fix (recorder item 3) introduced its own defect, reproduced end-to-end by review:

- **Escape leaked into the window keyboard seam.** `preventDefault()` never stops propagation. After `cancelEntry()` + `blur()` ran, the Escape keydown kept bubbling from the entry `<input>` — and by the time it reached `KeyboardHandler`'s `svelte:window` listener, `document.activeElement` was already `<body>` (the blur had already fired), so `shouldIgnoreEvent` let it through to `resolveAction`. Every rig profile ships **`Escape → clear_rit_xit`** (`rigs/_keyboard-default.toml`), which dispatches a real radio write (`makeRitXitHandlers().onClear()`, `panel-commands.ts`) — an operator cancelling a frequency entry would have silently cleared their RIT/XIT offset, violating the ticket's "Esc cancels entry without dispatch" verbatim.
  - **Fix:** `event.stopPropagation()` added to both the Escape and Enter branches of `handleEntryKeydown` (Enter gets it too, defensively, even though no shipped binding currently targets it). This restores the exact pre-blur contract — the window listener never sees Escape/Enter from the entry input — while keeping the round-2 blur.
  - **Pin:** a new describe block in `BandSurface.test.ts` mounts the **real** `KeyboardHandler` alongside the **real** `BandSurface`, with a keyboard config carrying the actual shipped `Escape → clear_rit_xit` binding, and dispatches a real bubbling `keydown` through jsdom — not a hand-simulated stand-in for either component. **Mutation-checked**: temporarily removed the `stopPropagation()` call and reran the suite — the new pin failed exactly as predicted (`onAction` called once with `clear_rit_xit`); restored the line and reran clean. Diff of the reverted mutation was verified to be exactly the one line removed/restored, nothing else.

## Known scope gaps (recorded, not fixed here)

- **Composition coverage.** `BandSurface` mounts only in the single-composition layout (`SemanticRadioSurfaces.svelte` renders it exclusively when `strips !== 'dual'`, pinned by `semantic-band-wiring.component.test.ts`'s "renders NO band surface in the dual composition" test). On the dual-receiver cockpit, `[data-freq-entry]` never exists in the DOM, so `routeDigitToFrequencyEntry` always returns `false` and digits still band-hop there — the existing, honest "no entry surface on this skin" fallback, not a new defect. Extending frequency entry to the dual composition is unfixed by this PR and is being tracked as a separate follow-up.
- **Units.** `BandSurface`'s entry field works in **whole Hz**, by design (see the file's own doc comment: "the entry field works in whole Hz so a boundary comparison can never lose a digit to a decimal round-trip"). The ticket's own walkthrough example — typing the literal digits `7100` — types `entryText = "7100"`, i.e. **7100 Hz**, which will be refused as below every realistic band's `tuneMinHz` (tens of kHz upward). Reaching 7.100 MHz requires typing the full `7100000`. This is pre-existing `BandSurface` behavior, not introduced or changed by this PR, but is called out explicitly here so a re-walkthrough using the ticket's literal example isn't surprised by a refused entry. Whether the entry field should interpret partial digit strings as MHz/kHz is an owner decision, tracked separately from this PR.

## Tests added

- `keyboard-map.test.ts` — `isDigitKey` / `isFrequencyDisplayFocused` unit coverage: digit/non-digit keys; focused element inside vs. outside `[data-vfo-freq]`; the active-tile vs. inactive-tile qualification (B1); `null`.
- `KeyboardHandler.test.ts` — digit routes to the entry input and does not fire the band hotkey when the active receiver's VFO display has focus; resets (not appends to) a stale leftover entry value; **regression**: still dispatches the band hotkey when focus is elsewhere; falls back to the band hotkey when no entry input exists, it's disabled, or the focused tile is not the active receiver (B1); disarms a pending leader sequence on a successful route (B2); does not route a Ctrl/Cmd/Alt-modified digit (B3, `it.each` over all three modifiers).
- `BandSurface.test.ts` — Enter commits exactly like clicking "Set" (including refusing an out-of-range entry); Escape clears the entry without calling `onEnterFrequency`; Escape blurs the input (recorder item 3); Escape fires zero `KeyboardHandler` actions and stays blurred against a config carrying the shipped `clear_rit_xit` binding (round-3 pin, mutation-checked).

Pre-existing `#2388` Tab-traversal pins (MOR-1449) and the `BandSurface.svelte` doctrine/source-scan tests all still pass untouched — this change adds no new import, prop, or lifecycle hook to that file.

## Scope

3 production files, 125 net LOC across all three rounds (within the ≤3 files / ≤200 LOC guardrail):
- `frontend/src/components-v2/layout/keyboard-map.ts` (+31)
- `frontend/src/components-v2/layout/KeyboardHandler.svelte` (+51)
- `frontend/src/semantic/BandSurface.svelte` (+43/-1)

## Test plan

- [x] Local targeted: `keyboard-map.test.ts`, `KeyboardHandler.test.ts`, `BandSurface.test.ts`, `semantic-band-wiring.component.test.ts`, `VfoSurface.test.ts` — all green
- [x] `npx eslint .` — 0 errors (pre-existing unrelated warnings only, in `fixtures/capture.mjs`)
- [x] `npm run check` (svelte-check) — 0 errors, 0 warnings
- [x] Remote full suite (testbed, round 3, head `808d813b`) — `fe`: 323 files / 6682 tests PASS, lint PASS, svelte-check PASS
- [x] `origin/main` baseline on the same testbed (checked in round 2) — 323 files / 6654 tests PASS (confirms nothing pre-existing was already broken)

**Flake note (not from this PR):** one earlier local full run and one earlier remote run each hit 2 failures in `src/semantic/__tests__/disabled-reason.test.ts` (asserted English strings came back pseudo-localized). That file has no locale setup/teardown and runs in the `fast` vitest project, which is deliberately configured `isolate: false` (module state, including the i18n locale store, is shared across files in a worker — see the comment block above `projects` in `vite.config.ts`). Every other locale-touching test file resets locale in `afterEach`; this one doesn't. Confirmed pre-existing and unrelated to this PR's 3 production files (none touch i18n): reproduces at a low, non-deterministic rate depending on vitest's thread scheduling — an immediate rerun of the exact same commit passed clean both locally and on the remote testbed, and it is not touched by this diff. Flagged separately for a standalone fix (add `_resetLocale()` isolation to that file, or rename it into the `*.isolated.test.ts` pool).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

