### PR TITLE
test: reset i18n locale in disabled-reason.test.ts to fix cross-file leak

### DIFF
--- a/frontend/src/semantic/__tests__/disabled-reason.test.ts
+++ b/frontend/src/semantic/__tests__/disabled-reason.test.ts
@@ -15,11 +15,24 @@
  * absent" cases) — so that branch is pinned here, directly, against the
  * contract's own `Availability` shape.
  */
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { _resetLocale } from '$lib/i18n/store.svelte';
 import { disabledReasonText } from '../disabled-reason';
 import type { Availability } from '../radio-view-model';
 
 describe('disabledReasonText (MOR-1422)', () => {
+  // `disabledReasonText` reads the shared i18n locale singleton via `t()`, and
+  // this file runs in the non-isolated "fast" vitest project where module
+  // state leaks across files within a worker — pin the locale per test so a
+  // preceding pseudo-locale test cannot garble the expected English strings.
+  beforeEach(() => {
+    _resetLocale();
+  });
+
+  afterEach(() => {
+    _resetLocale();
+  });
+
   it('returns "not supported by this radio" when the radio never declared the capability', () => {
     const availability: Availability = { structural: false, operational: false };
     expect(disabledReasonText(availability)).toBe('Not supported by this radio');


### PR DESCRIPTION
## Problem

`frontend/src/semantic/__tests__/disabled-reason.test.ts` runs in the non-isolated `fast` vitest project (`isolate: false` — module state, including the i18n locale singleton read by `t()`, is shared across test files within a worker thread). It was the only locale-touching test file with no `_resetLocale()` setup/teardown.

When vitest's duration-based thread bin-packing happens to place it right after a file that leaves the locale mutated — `src/lib/i18n/__tests__/index.test.ts` sets `qps-ploc` in its last tests and its `afterEach` only clears `localStorage`, never the in-module locale — the hardcoded English assertions (`'Not supported by this radio'`, `'Not yet observed'`) fail on garbled pseudo-locale bracketed output.

This surfaced as an intermittent, non-deterministic full-suite failure during MOR-1444 (#2395): the same commit failed one full run (2/4 tests in this file) and passed clean on immediate rerun. The hazard is latent on `main` and order-dependent — any change to adjacent files' test counts can expose or hide it.

## Fix

Pin the locale per test with `beforeEach`/`afterEach` calling `_resetLocale()` from `$lib/i18n/store.svelte`, mirroring the pattern already used by every other locale-dependent test file (`index.test.ts`, `locale-contract.test.ts`, `store.test.ts`, `pseudo-locale.smoke.test.ts`, `LanguageSelector.test.ts`, `Toast.component.test.ts`). This keeps the file in the fast pool — `disabledReasonText` is a pure function that needs no isolation once the locale is pinned.

## Verification

Deterministic repro (fails without the fix, 2/4 tests; passes with it, 24/24):

```
npx vitest run --project fast --no-file-parallelism \
  src/lib/i18n/__tests__/index.test.ts \
  src/semantic/__tests__/disabled-reason.test.ts
```

- Full frontend suite: 323 files / 6654 tests passed
- `npx eslint src/semantic/__tests__/disabled-reason.test.ts` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)