### PR TITLE
test: reset i18n locale singleton in afterEach to stop cross-file leak

### DIFF
--- a/frontend/src/lib/i18n/__tests__/index.test.ts
+++ b/frontend/src/lib/i18n/__tests__/index.test.ts
@@ -13,6 +13,7 @@ beforeEach(() => {
 
 afterEach(() => {
   localStorage.clear();
+  _resetLocale();
 });
 
 describe('t()', () => {

--- a/frontend/src/lib/i18n/__tests__/locale-contract.test.ts
+++ b/frontend/src/lib/i18n/__tests__/locale-contract.test.ts
@@ -17,6 +17,7 @@ beforeEach(() => {
 
 afterEach(() => {
   localStorage.clear();
+  _resetLocale();
   vi.restoreAllMocks();
 });
 


### PR DESCRIPTION
## Summary

Producer-side follow-up to #2397. The "fast" vitest project runs with `isolate: false`, so module state is shared across test files within a worker. `frontend/src/lib/i18n/__tests__/index.test.ts` and `frontend/src/lib/i18n/__tests__/locale-contract.test.ts` call `setLocale()` (including `qps-ploc`) but their `afterEach` only cleared `localStorage`, leaving the module-level locale singleton (`store.svelte.ts`) mutated after the file finished. Any future locale-reading test file without its own reset was exposed to the same intermittent, thread-scheduling-dependent failure class that hit `disabled-reason.test.ts` (fixed on the consumer side in #2397).

Fix: add `_resetLocale()` to the `afterEach` of both files. One line per file; no production code touched.

## Verification

- `cd frontend && npx vitest run` — 323 files / 6682 tests passed
- `npx eslint` on both changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)