### PR TITLE
fix: serve hashed /assets/ files with immutable cache, keep no-cache for entry files

### DIFF
--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -5295,6 +5295,14 @@ class WebServer:
 
         mime, _ = mimetypes.guess_type(str(target))
         ct = mime or "application/octet-stream"
+        # Vite emits content-hashed filenames under assets/, so those are
+        # safe to cache forever; everything else (index.html, favicon)
+        # keeps non-hashed names and must be revalidated on every load.
+        rel = target.relative_to(static_dir)
+        if rel.parts and rel.parts[0] == "assets":
+            cache = "public, max-age=31536000, immutable"
+        else:
+            cache = "no-cache, no-store, must-revalidate"
         await _send_response(
             writer,
             200,
@@ -5302,7 +5310,7 @@ class WebServer:
             body,
             {
                 "Content-Type": ct,
-                "Cache-Control": "no-cache, no-store, must-revalidate",
+                "Cache-Control": cache,
             },
         )
 

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -5277,7 +5277,7 @@ class WebServer:
         # Prevent path traversal
         static_dir = self._config.static_dir.resolve()
         target = (static_dir / filename).resolve()
-        if not str(target).startswith(str(static_dir)):
+        if not target.is_relative_to(static_dir):
             await _send_response(writer, 403, "Forbidden", b"Forbidden", {})
             return
 

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -1759,6 +1759,25 @@ async def test_serve_static_assets_immutable_others_no_cache(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_serve_static_rejects_name_prefix_sibling_dir(tmp_path) -> None:
+    """A sibling dir whose name starts with the static dir's name (e.g.
+    static.old next to static) must get 403, not file contents or a
+    connection-killing exception."""
+    static_dir = tmp_path / "static"
+    static_dir.mkdir()
+    sibling = tmp_path / "static.old"
+    sibling.mkdir()
+    (sibling / "secret.html").write_text("<html>secret</html>", encoding="utf-8")
+
+    srv = WebServer(None, WebConfig(static_dir=static_dir))
+    writer = _FakeWriter()
+    await srv._serve_static(writer, "../static.old/secret.html")  # noqa: SLF001
+    text = writer.buffer.decode("ascii", errors="replace")
+    assert "403 Forbidden" in text
+    assert "secret" not in text
+
+
+@pytest.mark.asyncio
 async def test_handle_websocket_missing_key_unknown_channel_and_control_handler() -> (
     None
 ):

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -1726,6 +1726,39 @@ async def test_serve_static_forbidden_missing_read_error_and_success(tmp_path) -
 
 
 @pytest.mark.asyncio
+async def test_serve_static_assets_immutable_others_no_cache(tmp_path) -> None:
+    """Content-hashed files under assets/ get long-lived immutable caching;
+    non-hashed entries (index.html, top-level files) keep no-cache."""
+    static_dir = tmp_path / "static"
+    assets = static_dir / "assets"
+    assets.mkdir(parents=True)
+    (static_dir / "index.html").write_text("<html>ok</html>", encoding="utf-8")
+    (static_dir / "favicon.svg").write_text("<svg/>", encoding="utf-8")
+    (assets / "index-BvQ0Yc9H.js").write_text("console.log(1)", encoding="utf-8")
+    (assets / "Orbitron-D3ZWvfzD.woff2").write_bytes(b"\x00font")
+
+    srv = WebServer(None, WebConfig(static_dir=static_dir))
+    immutable = "Cache-Control: public, max-age=31536000, immutable"
+    no_cache = "Cache-Control: no-cache, no-store, must-revalidate"
+
+    for asset in ("assets/index-BvQ0Yc9H.js", "assets/Orbitron-D3ZWvfzD.woff2"):
+        writer = _FakeWriter()
+        await srv._serve_static(writer, asset)  # noqa: SLF001
+        text = writer.buffer.decode("ascii", errors="replace")
+        assert "200 OK" in text
+        assert immutable in text, f"{asset}: expected immutable caching"
+        assert no_cache not in text
+
+    for plain in ("index.html", "favicon.svg"):
+        writer = _FakeWriter()
+        await srv._serve_static(writer, plain)  # noqa: SLF001
+        text = writer.buffer.decode("ascii", errors="replace")
+        assert "200 OK" in text
+        assert no_cache in text, f"{plain}: expected no-cache"
+        assert immutable not in text
+
+
+@pytest.mark.asyncio
 async def test_handle_websocket_missing_key_unknown_channel_and_control_handler() -> (
     None
 ):


### PR DESCRIPTION
## Summary

Since PR #2396 self-hosted the UI fonts (13 woff2, ~210 KB emitted as hashed Vite assets), every page load re-fetched them: `_serve_static` stamped `Cache-Control: no-cache, no-store, must-revalidate` on every static response.

This PR splits the cache policy in `_serve_static` (src/rigplane/web/server.py):

- files under `assets/` (Vite content-hashed filenames) → `Cache-Control: public, max-age=31536000, immutable`
- everything else (`index.html`, `favicon.svg`, other non-hashed entries) → unchanged `no-cache, no-store, must-revalidate`

The split is decided on the resolved path relative to `static_dir`, after the containment guard.

**Review follow-up (second commit):** independent review found the pre-existing traversal guard was a string-prefix check (`str(target).startswith(str(static_dir))`), which admits sibling dirs like the in-tree `static.old` — previously disclosing their contents, and with this PR's `relative_to()` raising an uncaught `ValueError` (connection closed with no response). The guard is now `Path.is_relative_to`, giving a deliberate 403 and making `relative_to()` total; a regression test with a name-prefix sibling dir is included.

## Tests

- `test_serve_static_assets_immutable_others_no_cache` — both header paths: JS + woff2 under `assets/` get immutable (and assert no-cache absent), `index.html` + `favicon.svg` keep no-cache (and assert immutable absent).
- `test_serve_static_rejects_name_prefix_sibling_dir` — `../static.old/…` style request → 403, no exception, no content leak.

Both written TDD — observed failing before their implementations.

## Verification

- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 9033 passed, 0 failures
- `uv run ruff check src/ tests/` — clean
- `uv run mypy src/rigplane/web/server.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)