### PR TITLE
feat: smart kHz/MHz/Hz interpretation for frequency entry (MOR-1462)

### DIFF
--- a/frontend/src/semantic/BandSurface.svelte
+++ b/frontend/src/semantic/BandSurface.svelte
@@ -99,6 +99,46 @@
   export const defaultPermitLabel = (choice: BandChoice): string =>
     `TX at ${mhz(choice.defaultHz)}: ${choice.defaultHzTxPermit.status}`;
 
+  /**
+   * MOR-1462 (owner ruling B) — the standard ham direct-entry heuristic. A
+   * decimal point always means MHz, parsed as an EXACT DECIMAL STRING to
+   * integer Hz (never `Number(text) * 1e6` — a float round-trip can miss
+   * the exact Hz a double cannot represent, which rule 5's boundary
+   * comparison must never lose a digit to). A bare integer is read as kHz
+   * when that reading falls inside the radio's declared tunable range, Hz
+   * when only the raw reading does, and kHz WINS when both do (the
+   * ambiguous case — e.g. a range wide enough that both `7100` and
+   * `7100`×1000 are in-band). `null` means the SAME visible refusal a
+   * malformed or out-of-range entry already produced (rule 5, unrelaxed):
+   * `entryReady` stays false and nothing dispatches.
+   */
+  export function interpretFrequencyEntry(
+    raw: string, minHz: number, maxHz: number,
+  ): number | null {
+    const text = raw.trim();
+    if (text === '' || !Number.isFinite(minHz) || !Number.isFinite(maxHz)) return null;
+    if (text.includes('.')) return parseMhzToHz(text, minHz, maxHz);
+    if (!/^\d+$/.test(text)) return null;
+    const value = Number(text);
+    const asKhz = value * 1000;
+    if (asKhz >= minHz && asKhz <= maxHz) return asKhz;
+    if (value >= minHz && value <= maxHz) return value;
+    return null;
+  }
+
+  /** MHz decimal string -> exact integer Hz by scaling the DIGITS
+   *  themselves, so `14.0741` lands on exactly 14074100 with no
+   *  double-precision round-trip. More than 6 fractional digits is finer
+   *  than 1 Hz and is refused outright, same as an out-of-range value. */
+  function parseMhzToHz(text: string, minHz: number, maxHz: number): number | null {
+    const match = /^(\d+)\.(\d+)$/.exec(text);
+    if (!match) return null;
+    const [, whole, frac] = match;
+    if (frac.length > 6) return null;
+    const hz = Number(whole) * 1_000_000 + Number(frac.padEnd(6, '0'));
+    return hz >= minHz && hz <= maxHz ? hz : null;
+  }
+
   /** Rule (3): consulted ONLY once `currentBandTx` already said `denied` (or,
    *  from the fix-round F1 caveat, once the authoritative `txPermit` itself is
    *  not `allowed`) — and only over TX-SCOPED entries. `capability-unavailable`
@@ -152,20 +192,27 @@
   /** The operator's raw keystrokes, kept as typed: an empty or malformed entry
    *  must stay refusable rather than coerce to 0 Hz. */
   let entryText = $state('');
-  let typedHz = $derived(entryText.trim() === '' ? Number.NaN : Number(entryText));
-  let inRange = $derived(
-    Number.isFinite(typedHz) && band?.tuneMinHz != null && band?.tuneMaxHz != null
-      && typedHz >= band.tuneMinHz && typedHz <= band.tuneMaxHz,
+  /** MOR-1462: the smart kHz/MHz/Hz interpretation of `entryText`, or `null`
+   *  while it cannot resolve to an in-range Hz value. Bounds must be KNOWN
+   *  first (rule 5) — this stays `null`, never a guess, until they are. */
+  let interpretedHz = $derived(
+    boundsKnown && band?.tuneMinHz != null && band?.tuneMaxHz != null
+      ? interpretFrequencyEntry(entryText, band.tuneMinHz, band.tuneMaxHz)
+      : null,
   );
-  let entryReady = $derived(receiverKnown && boundsKnown && inRange);
+  let entryReady = $derived(receiverKnown && boundsKnown && interpretedHz !== null);
+  /** The operator-visible confirmation of what their keystrokes resolved to
+   *  — shown before commit so a kHz/MHz/Hz misread is caught before it
+   *  tunes, per the ticket's own "→ 7.100 MHz" example. */
+  let entryHint = $derived(interpretedHz !== null ? `→ ${mhz(interpretedHz)}` : '');
 
   function selectBand(choice: BandChoice): void {
     if (!receiverKnown) return;
     onSelectBand?.(choice.name, choice.defaultHz, choice.bsrCode);
   }
   function commitFrequency(): void {
-    if (!entryReady) return;
-    onEnterFrequency?.(typedHz);
+    if (!entryReady || interpretedHz === null) return;
+    onEnterFrequency?.(interpretedHz);
   }
   /** MOR-1444: Escape cancels a typed entry — clears the keystrokes without
    *  dispatching, mirroring the "never coerce a malformed entry" rule above
@@ -262,13 +309,25 @@
 
     <label class="band-row" data-testid="band-entry" data-bounds={boundsKnown}>
       <span class="band-name">FREQ</span>
+      <!-- MOR-1462: type="text"/inputmode="decimal" rather than
+           type="number" — the smart interpretation accepts kHz-scale
+           keystrokes numerically far below `tuneMinHz` (a valid kHz entry
+           for a band whose bounds are stated in Hz), which a native
+           number-input min/max would flag as invalid despite being
+           correct; unit resolution is entirely this file's own JS-side
+           `interpretFrequencyEntry`, not the browser's. The
+           `[data-freq-entry]` hook and the reset-on-first-digit routing in
+           KeyboardHandler.svelte are type-agnostic (`.value =`/`input`
+           event only) and are unaffected by this change. -->
       <input
-        type="number" data-testid="band-entry-input" data-freq-entry step="1"
-        min={band.tuneMinHz ?? undefined} max={band.tuneMaxHz ?? undefined}
+        type="text" inputmode="decimal" data-testid="band-entry-input" data-freq-entry
         value={entryText} disabled={!receiverKnown || !boundsKnown}
         oninput={(event) => { entryText = event.currentTarget.value; }}
         onkeydown={handleEntryKeydown}
       />
+      {#if entryHint}
+        <span data-testid="band-entry-hint">{entryHint}</span>
+      {/if}
       <span data-testid="band-entry-range">{boundsKnown && band.tuneMinHz !== null
         && band.tuneMaxHz !== null
         ? `${mhz(band.tuneMinHz)} … ${mhz(band.tuneMaxHz)}`

--- a/frontend/src/semantic/BandSurface.svelte
+++ b/frontend/src/semantic/BandSurface.svelte
@@ -203,8 +203,13 @@
   let entryReady = $derived(receiverKnown && boundsKnown && interpretedHz !== null);
   /** The operator-visible confirmation of what their keystrokes resolved to
    *  — shown before commit so a kHz/MHz/Hz misread is caught before it
-   *  tunes, per the ticket's own "→ 7.100 MHz" example. */
-  let entryHint = $derived(interpretedHz !== null ? `→ ${mhz(interpretedHz)}` : '');
+   *  tunes, per the ticket's own "→ 7.100 MHz" example. Gated on
+   *  `entryReady` (review hardening), not just a resolvable `interpretedHz`
+   *  — otherwise a valid-looking target could render next to a Set button
+   *  the receiver-unknown gate has permanently disabled. */
+  let entryHint = $derived(
+    entryReady && interpretedHz !== null ? `→ ${mhz(interpretedHz)}` : '',
+  );
 
   function selectBand(choice: BandChoice): void {
     if (!receiverKnown) return;

--- a/frontend/src/semantic/__tests__/BandSurface.test.ts
+++ b/frontend/src/semantic/__tests__/BandSurface.test.ts
@@ -454,13 +454,19 @@ describe('defaultHzTxPermit is never presented as band-wide permission (carry-fo
 /* ── (d) frequency entry validates against the envelope ─────────── */
 
 describe('frequency entry validates against tuneMinHz/tuneMaxHz (carry-forward 5)', () => {
-  const BOUNDS = { tuneMinHz: 30000, tuneMaxHz: 60000000 } as const;
+  // MOR-1462: a realistic BAND-SCOPED range (20m), not the general-coverage
+  // 30 kHz … 60 MHz fixture used elsewhere in this file — every boundary
+  // value below is 8 digits, so its ×1000 kHz reading is always far outside
+  // this range and the smart-unit heuristic falls through to the Hz path
+  // unambiguously. That keeps this block a pin on the Hz BOUNDARY check
+  // itself, not on unit selection (MOR-1462 owns that, in its own block).
+  const BOUNDS = { tuneMinHz: 14000000, tuneMaxHz: 14350000 } as const;
 
   it.each([
-    ['one hertz below the minimum', 29999, false],
-    ['exactly the minimum', 30000, true],
-    ['exactly the maximum', 60000000, true],
-    ['one hertz above the maximum', 60000001, false],
+    ['one hertz below the minimum', 13999999, false],
+    ['exactly the minimum', 14000000, true],
+    ['exactly the maximum', 14350000, true],
+    ['one hertz above the maximum', 14350001, false],
   ])('%s is accepted=%s', (_label, hz, accepted) => {
     const onEnterFrequency = vi.fn();
     const r = render(withB(BOUNDS), { onEnterFrequency });
@@ -475,7 +481,7 @@ describe('frequency entry validates against tuneMinHz/tuneMaxHz (carry-forward 5
 
   // Kills: dropping the handler-side range check. `disabled` alone satisfies a
   // `.click()`-based assertion, so the guard is bypassed here on its own.
-  it.each([29999, 60000001])('refuses %i even when the disabled attribute is bypassed', (hz) => {
+  it.each([13999999, 14350001])('refuses %i even when the disabled attribute is bypassed', (hz) => {
     const onEnterFrequency = vi.fn();
     const r = render(withB(BOUNDS), { onEnterFrequency });
     typeFrequency(r.input()!, String(hz));
@@ -484,11 +490,17 @@ describe('frequency entry validates against tuneMinHz/tuneMaxHz (carry-forward 5
     r.dispose();
   });
 
-  it('publishes the envelope as the input min/max as well', () => {
+  // MOR-1462: the input's native min/max is GONE — a kHz-scale keystroke
+  // (e.g. `7100`) is a valid, in-range reading despite sitting numerically
+  // far below a Hz-stated `tuneMinHz`, so a native constraint would flag it
+  // invalid for a reason this file's own JS-side interpretation disagrees
+  // with. `entry-range` still publishes the envelope in prose.
+  it('publishes the envelope in the entry-range text, with no native min/max to contradict unit-aware validation', () => {
     const r = render(withB(BOUNDS));
-    expect(r.input()!.getAttribute('min')).toBe('30000');
-    expect(r.input()!.getAttribute('max')).toBe('60000000');
-    expect(r.text('entry-range')).toBe(`${mhz(30000)} … ${mhz(60000000)}`);
+    expect(r.input()!.getAttribute('min')).toBeNull();
+    expect(r.input()!.getAttribute('max')).toBeNull();
+    expect(r.input()!.getAttribute('inputmode')).toBe('decimal');
+    expect(r.text('entry-range')).toBe(`${mhz(14000000)} … ${mhz(14350000)}`);
     r.dispose();
   });
 
@@ -500,6 +512,106 @@ describe('frequency entry validates against tuneMinHz/tuneMaxHz (carry-forward 5
     expect(r.btn('entry-set')!.disabled).toBe(true);
     bypassClick(r.btn('entry-set')!);
     expect(onEnterFrequency).not.toHaveBeenCalled();
+    r.dispose();
+  });
+});
+
+/* ── smart kHz/MHz/Hz interpretation of a typed entry (MOR-1462) ──
+   Owner ruling B, the standard ham direct-entry heuristic: a decimal point
+   means MHz (exact decimal-string-to-Hz, no float round-trip); a bare
+   integer is kHz when ×1000 is in range, Hz when only the raw reading is,
+   and kHz wins the ambiguous case where both are. Commit still lands on the
+   MOR-1425 exact-jump path (`onEnterFrequency` receives the interpreted
+   Hz), and Enter/Set share the one `entryReady` guard, same as MOR-1444. */
+
+describe('smart kHz/MHz/Hz interpretation of a typed entry (MOR-1462, owner ruling B)', () => {
+  // General-coverage range (30 kHz … 60 MHz) — wide enough that a bare
+  // integer's kHz reading and its raw-Hz reading can BOTH be in range,
+  // which is exactly the ambiguity the ticket rules on.
+  const BOUNDS = { tuneMinHz: 30000, tuneMaxHz: 60000000 } as const;
+
+  it.each([
+    ['bare kHz-scale integer', '7100', 7100000],
+    ['another bare kHz-scale integer', '14074', 14074000],
+    ['MHz decimal, one fractional digit', '7.1', 7100000],
+    ['MHz decimal, exact to the Hz (no float round-trip)', '14.0741', 14074100],
+    ['already-Hz integer, out of kHz range', '7100000', 7100000],
+  ])('interprets %s (%s) as %i Hz and dispatches it exactly', (_label, typed, expectedHz) => {
+    const onEnterFrequency = vi.fn();
+    const r = render(withB(BOUNDS), { onEnterFrequency });
+    typeFrequency(r.input()!, typed);
+    expect(r.btn('entry-set')!.disabled).toBe(false);
+    r.btn('entry-set')!.click();
+    flushSync();
+    expect(onEnterFrequency).toHaveBeenCalledExactlyOnceWith(expectedHz);
+    r.dispose();
+  });
+
+  // THE AMBIGUITY PIN. Both readings of `40000` are in range (40 kHz raw,
+  // 40 MHz ×1000) — the ticket rules kHz wins.
+  it('resolves a kHz-vs-Hz ambiguous entry to kHz', () => {
+    const onEnterFrequency = vi.fn();
+    const r = render(withB(BOUNDS), { onEnterFrequency });
+    typeFrequency(r.input()!, '40000');
+    r.btn('entry-set')!.click();
+    flushSync();
+    expect(onEnterFrequency).toHaveBeenCalledExactlyOnceWith(40000000);
+    r.dispose();
+  });
+
+  it('refuses an entry that is out of range under every reading, dispatching nothing', () => {
+    const onEnterFrequency = vi.fn();
+    const r = render(withB(BOUNDS), { onEnterFrequency });
+    // ~100 MHz raw, ~100 GHz ×1000 — both out of the 30 kHz … 60 MHz range.
+    typeFrequency(r.input()!, '99999999');
+    expect(r.btn('entry-set')!.disabled).toBe(true);
+    bypassClick(r.btn('entry-set')!);
+    expect(onEnterFrequency).not.toHaveBeenCalled();
+    r.dispose();
+  });
+
+  it('refuses a decimal entry finer than 1 Hz (more than 6 fractional digits)', () => {
+    const onEnterFrequency = vi.fn();
+    const r = render(withB(BOUNDS), { onEnterFrequency });
+    typeFrequency(r.input()!, '14.1234567');
+    expect(r.btn('entry-set')!.disabled).toBe(true);
+    bypassClick(r.btn('entry-set')!);
+    expect(onEnterFrequency).not.toHaveBeenCalled();
+    r.dispose();
+  });
+
+  it('refuses an in-progress decimal with no fractional digits yet', () => {
+    const r = render(withB(BOUNDS));
+    typeFrequency(r.input()!, '14.');
+    expect(r.btn('entry-set')!.disabled).toBe(true);
+    r.dispose();
+  });
+
+  it('shows the interpreted MHz value as a commit hint before Set is pressed', () => {
+    const r = render(withB(BOUNDS));
+    typeFrequency(r.input()!, '7100');
+    expect(r.text('entry-hint')).toBe(`→ ${mhz(7100000)}`);
+    r.dispose();
+  });
+
+  it('shows no hint while the entry cannot be resolved', () => {
+    const r = render(withB(BOUNDS));
+    typeFrequency(r.input()!, 'abc');
+    expect(r.el('entry-hint')).toBeNull();
+    r.dispose();
+  });
+
+  // Commit still lands on the SAME MOR-1425 exact-jump path Enter/Set
+  // already share for an integer entry — no second dispatch shape for MHz.
+  it('commits an MHz decimal entry on Enter, exactly like Set', () => {
+    const onEnterFrequency = vi.fn();
+    const r = render(withB(BOUNDS), { onEnterFrequency });
+    typeFrequency(r.input()!, '14.0741');
+    r.input()!.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }),
+    );
+    flushSync();
+    expect(onEnterFrequency).toHaveBeenCalledExactlyOnceWith(14074100);
     r.dispose();
   });
 });
@@ -651,11 +763,14 @@ describe('keyboard entry commits on Enter and cancels on Escape (MOR-1444)', () 
   });
 
   // Kills: an Enter-commit path that bypasses the entryReady guard the Set
-  // button already goes through (carry-forward 5 / rule 5).
+  // button already goes through (carry-forward 5 / rule 5). '29' is out of
+  // range under BOTH readings (29 Hz and 29 kHz = 29000 Hz both sit below
+  // `tuneMinHz`), so this stays a pure entryReady-guard pin, independent of
+  // MOR-1462's unit selection.
   it('refuses to commit an out-of-range entry on Enter', () => {
     const onEnterFrequency = vi.fn();
     const r = render(withB(BOUNDS), { onEnterFrequency });
-    typeFrequency(r.input()!, '29999');
+    typeFrequency(r.input()!, '29');
     keydown(r.input()!, 'Enter');
     expect(onEnterFrequency).not.toHaveBeenCalled();
     r.dispose();

--- a/frontend/src/semantic/__tests__/BandSurface.test.ts
+++ b/frontend/src/semantic/__tests__/BandSurface.test.ts
@@ -535,6 +535,14 @@ describe('smart kHz/MHz/Hz interpretation of a typed entry (MOR-1462, owner ruli
     ['another bare kHz-scale integer', '14074', 14074000],
     ['MHz decimal, one fractional digit', '7.1', 7100000],
     ['MHz decimal, exact to the Hz (no float round-trip)', '14.0741', 14074100],
+    // Verifier-flagged: `14.0741` alone does NOT distinguish digit-scaling
+    // from `Math.trunc(Number(text) * 1_000_000)` — `Number('14.0741') *
+    // 1e6 === 14074100` exactly in IEEE-754. `8.000001`/`1.000001` are
+    // witnesses where the float product genuinely lands a fraction below
+    // the integer (e.g. 8000000.999999999), so a truncating float
+    // round-trip is off by exactly 1 Hz. THESE are the exactness pin.
+    ['MHz decimal where float*1e6 truncates 1 Hz low', '8.000001', 8000001],
+    ['MHz decimal where float*1e6 truncates 1 Hz low (2)', '1.000001', 1000001],
     ['already-Hz integer, out of kHz range', '7100000', 7100000],
   ])('interprets %s (%s) as %i Hz and dispatches it exactly', (_label, typed, expectedHz) => {
     const onEnterFrequency = vi.fn();
@@ -597,6 +605,18 @@ describe('smart kHz/MHz/Hz interpretation of a typed entry (MOR-1462, owner ruli
   it('shows no hint while the entry cannot be resolved', () => {
     const r = render(withB(BOUNDS));
     typeFrequency(r.input()!, 'abc');
+    expect(r.el('entry-hint')).toBeNull();
+    r.dispose();
+  });
+
+  // Review hardening: the hint must not render a target next to a Set
+  // button the MOR-1322 receiver-known gate has disabled — an interpretable
+  // entry alone is not enough, `entryReady` (the SAME gate Set/Enter use)
+  // decides the hint too.
+  it('hides the hint when the entry parses but the active receiver is unknown', () => {
+    const r = render({ ...withB(BOUNDS), activeReceiver: { status: 'unknown' } });
+    typeFrequency(r.input()!, '7100');
+    expect(r.btn('entry-set')!.disabled).toBe(true);
     expect(r.el('entry-hint')).toBeNull();
     r.dispose();
   });


### PR DESCRIPTION
## Summary

BandSurface's direct frequency entry (used by the Set button, Enter commit, and MOR-1444's digit routing) previously accepted only literal whole-Hz keystrokes, so a standard kHz-style entry like `7100` was refused as below-min. This applies owner ruling B — the standard ham direct-entry heuristic:

- A decimal point in the typed text means **MHz**, parsed straight from the decimal string to an exact integer Hz (no `Number(text) * 1e6` float round-trip — digit-scaling instead, so `14.0741` lands on exactly `14074100`). More than 6 fractional digits is refused.
- A bare integer is read as **kHz** when `value * 1000` falls inside the radio's declared tunable range, **Hz** when only the raw value does, and **kHz wins** when both readings are in range (the ambiguous case).
- Out of range under every reading still takes the existing visible-refusal path — Set/Enter stay disabled, nothing dispatches.

The interpreted Hz value is now shown to the operator as a commit hint (e.g. `→ 7.100 MHz`) before Set/Enter fires, so a kHz/MHz/Hz misread is caught before it tunes. Commit still lands on the same MOR-1425 exact-jump path, dispatching the exact integer Hz.

The entry input moved from `type="number"` to `type="text"` with `inputmode="decimal"`, and the native `min`/`max` attributes (stated in Hz) were dropped — they would otherwise flag a valid kHz-scale keystroke as invalid, since unit resolution is entirely this file's own `interpretFrequencyEntry`, not the browser's. The `[data-freq-entry]` production hook and `KeyboardHandler`'s reset-on-first-digit routing (MOR-1444) are type-agnostic (`.value =` + `input` event only) and are unaffected.

## Acceptance literals (all pinned)

| typed | interpreted Hz |
|---|---|
| `7100` | `7100000` |
| `14074` | `14074000` |
| `7.1` | `7100000` |
| `14.0741` | `14074100` (exact) |
| `7100000` | `7100000` |
| out-of-range (every reading) | refused, zero dispatch |
| ambiguous (both readings in range) | kHz wins |

## Files changed

- `frontend/src/semantic/BandSurface.svelte` — parser (`interpretFrequencyEntry`/`parseMhzToHz`), `entryHint`, input type change
- `frontend/src/semantic/__tests__/BandSurface.test.ts` — updated pre-existing Hz-boundary tests to a realistic band-scoped range (20m) to avoid colliding with the new kHz-ambiguity heuristic, plus a new MOR-1462 test block covering the acceptance literals above, the ambiguity pin, 6-fractional-digit refusal, and the commit hint

## Review round 1 fixes

- **Weak exactness witness.** `14.0741` alone does not distinguish `parseMhzToHz`'s digit-scaling from a `Math.trunc(Number(text) * 1_000_000)` float round-trip mutation — `Number('14.0741') * 1e6 === 14074100` exactly in IEEE-754. Added `8.000001` → `8000001` and `1.000001` → `1000001` as witnesses where the float product genuinely lands below the integer (`8.000000999999...`), so a truncating float round-trip is off by exactly 1 Hz. Mutation-tested: applying the float-truncation mutation reds both new cases (`8000000`/`1000000` instead of `8000001`/`1000001`) while leaving the rest of the suite green; reverted with a byte-identical diff against the pre-mutation source.
- **Entry-hint hardening.** `entryHint` now gates on `entryReady` (the same guard Set/Enter already use) instead of only a resolvable `interpretedHz`, so a parseable entry no longer shows a target next to a Set button the MOR-1322 receiver-known gate has disabled. New regression test pins this.

## Follow-up notes (non-blocking)

- **kHz-wins changes how sub-60kHz raw Hz is reached on general-coverage rigs.** With kHz preferred whenever both readings are in range, typing `30000` on a radio whose tunable range extends to 60 MHz now means 30 MHz, not 30 kHz — the raw-Hz reading for anything below ~60 kHz is no longer reachable via a bare integer on that class of rig; `0.03` (decimal/MHz form) remains the way to reach 30 kHz directly. Worth a release-notes callout per the owner ruling, since it's a user-visible behavior change for anyone who was relying on literal-Hz entry at the low end of a general-coverage range.
- **Comma-locale decimal keypads.** Some Android IME numeric/decimal keyboards emit `,` rather than `.` as the decimal separator; `interpretFrequencyEntry` only recognizes `.`, so a comma-separated MHz entry from such a keypad is refused rather than accepted. Flagging as a bench-check item for mobile skins rather than fixing blind here, since the correct behavior (accept `,` as an alias, or rely on `inputmode="decimal"` normalizing it) needs to be verified against actual device IME behavior rather than assumed.

## Test plan

- [x] `npx vitest run src/semantic/__tests__/BandSurface.test.ts src/components-v2/wiring/__tests__/semantic-band-wiring.component.test.ts src/components-v2/wiring/__tests__/single-receiver-active-wiring.component.test.ts src/components-v2/layout/__tests__/KeyboardHandler.test.ts src/components-v2/layout/__tests__/keyboard-map.test.ts` — 153/153 passed (MOR-1425 exactness pins + MOR-1444 routing/Escape-stopPropagation pins all green)
- [x] Mutation proof on `parseMhzToHz` (float-truncation mutation) — reds the two new exactness-witness cases, reverts clean (see "Review round 1 fixes" above)
- [x] `npm run check` (svelte-check + tsc) — 0 errors, 0 warnings
- [x] `npx eslint src/semantic/BandSurface.svelte src/semantic/__tests__/BandSurface.test.ts` — clean
- [x] Full frontend suite (pre-review-fix commit): 6727 tests, 1 failure (`fixture-capture-root-cwd.test.ts`, the documented known flake), passed on isolated rerun

🤖 Generated with [Claude Code](https://claude.com/claude-code)
