### PR TITLE
feat: pending-target affordance for frequency tuning (MOR-1441)

### DIFF
--- a/frontend/fixtures/stubs/panel-adapters.ts
+++ b/frontend/fixtures/stubs/panel-adapters.ts
@@ -15,3 +15,16 @@ export function bindSemanticSurfaceHandlers() {
     scopeControls: makeScopeControlsHandlers(), tx: makeTxHandlers(), vfo: makeVfoHandlers(), vox: makeVoxHandlers(),
   });
 }
+
+/**
+ * MOR-1441 — `SemanticRadioSurfaces.svelte` now also imports
+ * `getPendingFrequencyHz` from the real `panel-adapters` module. Per this
+ * file's own MOR-1271/MOR-1320 lesson, an export missing here fails at
+ * MODULE RESOLUTION and takes the whole fixture harness dark, not merely
+ * degraded — so the stub always needs it, even though the deterministic
+ * offline harness never has a real in-flight command to report. `null`
+ * ("nothing pending") is the correct and only honest answer here.
+ */
+export function getPendingFrequencyHz(_receiver: 0 | 1): number | null {
+  return null;
+}

--- a/frontend/src/components-v2/display/__tests__/FrequencyDisplayInteractive.component.svelte.test.ts
+++ b/frontend/src/components-v2/display/__tests__/FrequencyDisplayInteractive.component.svelte.test.ts
@@ -208,4 +208,31 @@ describe('FrequencyDisplayInteractive pending-target marker (MOR-1441)', () => {
     expect(onFreqChange).toHaveBeenCalledWith(CONFIRMED + 1000);
     expect(onFreqChange).not.toHaveBeenCalledWith(PENDING + 1000);
   });
+
+  // MOR-1441 round-2 review: the wheel pin above does not cover the
+  // click-to-select + ArrowUp/ArrowDown path, a separate reachable gesture
+  // (`handleKeyDown`, lines ~100/104) with its OWN `adjustFreqByDigit(freq, ...)`
+  // call sites — a keyboard-only regression of the same bug (sourcing from
+  // `pendingDisplayHz` instead of `freq`) would reproduce the identical
+  // runaway on this path alone and slip past the wheel-only pin.
+  it('MUTATION KILL: arrow keys on a pending display compute from CONFIRMED, not the pending value', () => {
+    const CONFIRMED = 14250000;
+    const PENDING = 14260000; // already 10 kHz ahead of confirmed
+    const onFreqChange = vi.fn();
+    const t = mountDisplay({ freq: CONFIRMED, pendingDisplayHz: PENDING, onFreqChange });
+
+    const digits = t.querySelectorAll<HTMLElement>('.digit');
+    digits[digits.length - 1].click(); // select the 1 Hz digit
+    const group = t.querySelector<HTMLElement>('.freq')!;
+    group.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true, cancelable: true }));
+    group.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, cancelable: true }));
+    flushSync();
+
+    expect(onFreqChange).toHaveBeenCalledTimes(2);
+    // THE assertion: confirmed ± 1 Hz. The pre-fix code would have computed
+    // from PENDING (14260001/14259999) here instead.
+    expect(onFreqChange.mock.calls[0][0]).toBe(CONFIRMED + 1);
+    expect(onFreqChange.mock.calls[1][0]).toBe(CONFIRMED - 1);
+    expect(onFreqChange).not.toHaveBeenCalledWith(PENDING + 1);
+  });
 });

--- a/frontend/src/components-v2/display/__tests__/FrequencyDisplayInteractive.component.svelte.test.ts
+++ b/frontend/src/components-v2/display/__tests__/FrequencyDisplayInteractive.component.svelte.test.ts
@@ -135,8 +135,8 @@ describe('FrequencyDisplayInteractive click-to-tune over the radio store (MOR-47
 describe('FrequencyDisplayInteractive pending-target marker (MOR-1441)', () => {
   // Kills: rendering a pending target with no distinguishing marker — the
   // readout would then present an unconfirmed value as confirmed truth.
-  it('marks the group data-freq-status="pending" when pending is true', () => {
-    const t = mountDisplay({ freq: 14260000, pending: true });
+  it('marks the group data-freq-status="pending" when pendingDisplayHz is set', () => {
+    const t = mountDisplay({ freq: 14250000, pendingDisplayHz: 14260000 });
     const group = t.querySelector<HTMLElement>('.freq')!;
     expect(group.dataset.freqStatus).toBe('pending');
   });
@@ -147,5 +147,65 @@ describe('FrequencyDisplayInteractive pending-target marker (MOR-1441)', () => {
     const t = mountDisplay({ freq: 14074000 });
     const group = t.querySelector<HTMLElement>('.freq')!;
     expect(group.dataset.freqStatus).toBe('confirmed');
+  });
+
+  // B2 (screen-reader honesty): the italic/opacity marker is a VISUAL-only
+  // channel. Kills: a pending frequency read aloud by a screen reader as
+  // though it were confirmed, with no distinguishing word at all.
+  it('exposes the pending state to assistive tech via a rendered, linked word', () => {
+    const t = mountDisplay({
+      freq: 14250000,
+      pendingDisplayHz: 14260000,
+      pendingAnnouncement: 'Pending, not yet confirmed',
+    });
+    const group = t.querySelector<HTMLElement>('.freq')!;
+    const describedById = group.getAttribute('aria-describedby');
+    expect(describedById).toBeTruthy();
+    const description = t.querySelector<HTMLElement>(`#${describedById}`)!;
+    expect(description).toBeTruthy();
+    expect(description.textContent).toBe('Pending, not yet confirmed');
+    expect(description.classList.contains('sr-only')).toBe(true);
+  });
+
+  // Kills: rendering the marker attribute/DOM but skipping the aria link
+  // when the confirmed (non-pending) readout is shown — no phantom
+  // describedby pointing at nothing.
+  it('carries no aria-describedby when confirmed', () => {
+    const t = mountDisplay({ freq: 14074000 });
+    const group = t.querySelector<HTMLElement>('.freq')!;
+    expect(group.hasAttribute('aria-describedby')).toBe(false);
+  });
+
+  // ── MOR-1441 REVIEW FIX: the display→gesture→accumulator seam ──────────
+  // Reproduced defect: an earlier revision fed the PENDING display value
+  // into the SAME `freq` prop the gesture handlers use for arithmetic, so
+  // `adjustFreqByDigit` computed off an already-drifted base and every hot
+  // tick fed a growing excess back into the MOR-1425 tuning accumulator
+  // (positive feedback — 10 ticks of +10 Hz intent measured out to
+  // +1910 Hz actual against the real accumulator). THE kill: a wheel tick
+  // must request `confirmed + step`, never `pendingDisplayHz + step`.
+  it('MUTATION KILL: a wheel tick on a pending display computes from CONFIRMED, not the pending value', () => {
+    const CONFIRMED = 14250000;
+    const PENDING = 14260000; // already 10 kHz ahead of confirmed
+    const onFreqChange = vi.fn();
+    const t = mountDisplay({ freq: CONFIRMED, pendingDisplayHz: PENDING, onFreqChange });
+
+    // Digits render the PENDING value (14260000): confirm the fixture is
+    // genuinely showing a pending target, not accidentally testing the
+    // confirmed-only path.
+    const digitsText = Array.from(t.querySelectorAll<HTMLElement>('.digit')).map((d) => d.textContent).join('');
+    expect(digitsText).toBe('14260000');
+
+    // The 1 kHz digit — same DOM position/multiplier convention as the
+    // MOR-475 test above.
+    const oneKhzDigit = t.querySelectorAll<HTMLElement>('.digit')[4];
+    oneKhzDigit.dispatchEvent(new WheelEvent('wheel', { deltaY: -1, bubbles: true }));
+    flushSync();
+
+    expect(onFreqChange).toHaveBeenCalledTimes(1);
+    // THE assertion: confirmed + 1kHz step. The pre-fix code would have
+    // requested 14261000 (pending + step) here instead.
+    expect(onFreqChange).toHaveBeenCalledWith(CONFIRMED + 1000);
+    expect(onFreqChange).not.toHaveBeenCalledWith(PENDING + 1000);
   });
 });

--- a/frontend/src/components-v2/display/__tests__/FrequencyDisplayInteractive.component.svelte.test.ts
+++ b/frontend/src/components-v2/display/__tests__/FrequencyDisplayInteractive.component.svelte.test.ts
@@ -130,3 +130,22 @@ describe('FrequencyDisplayInteractive click-to-tune over the radio store (MOR-47
     expect(onFreqChange).toHaveBeenCalledWith(14075000);
   });
 });
+
+// ── MOR-1441: pending-target affordance ─────────────────────────────────
+describe('FrequencyDisplayInteractive pending-target marker (MOR-1441)', () => {
+  // Kills: rendering a pending target with no distinguishing marker — the
+  // readout would then present an unconfirmed value as confirmed truth.
+  it('marks the group data-freq-status="pending" when pending is true', () => {
+    const t = mountDisplay({ freq: 14260000, pending: true });
+    const group = t.querySelector<HTMLElement>('.freq')!;
+    expect(group.dataset.freqStatus).toBe('pending');
+  });
+
+  // Kills: defaulting to "pending" — the plain confirmed readout (every
+  // existing caller, pre-MOR-1441) must stay marked "confirmed".
+  it('marks the group data-freq-status="confirmed" by default', () => {
+    const t = mountDisplay({ freq: 14074000 });
+    const group = t.querySelector<HTMLElement>('.freq')!;
+    expect(group.dataset.freqStatus).toBe('confirmed');
+  });
+});

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -245,6 +245,32 @@
    */
   let hasDualReceiver = $derived((runtime.caps?.receivers ?? 1) > 1);
   /**
+   * MOR-1441 (review B5) — memoized across `pendingFrequencyHzCache`: this
+   * `$derived` re-runs on ANY command-lifecycle mutation (`getCommandLifecycles()`
+   * is one shared reactive array covering every intent, not just `set_freq`),
+   * so an unrelated command's ack/timeout would otherwise mint a brand-new
+   * `{MAIN?,SUB?}` object every time — per-keystroke prop-identity churn for
+   * every consumer down the `VfoSurface`/`FrequencyDisplayInteractive` chain,
+   * even when neither receiver's pending value actually changed. Returning
+   * the SAME object when both values are unchanged lets Svelte's own
+   * reference-equality check skip that downstream work.
+   */
+  type PendingFrequencyHzCache = {
+    main: number | null; sub: number | null; value: Partial<Record<'MAIN' | 'SUB', number>>;
+  };
+  let pendingFrequencyHzCache: PendingFrequencyHzCache | null = null;
+  function computePendingFrequencyHz(): Partial<Record<'MAIN' | 'SUB', number>> {
+    const main = getPendingFrequencyHz(0);
+    const sub = getPendingFrequencyHz(1);
+    const cache: PendingFrequencyHzCache | null = pendingFrequencyHzCache;
+    if (cache !== null && cache.main === main && cache.sub === sub) return cache.value;
+    const result: Partial<Record<'MAIN' | 'SUB', number>> = {};
+    if (main !== null) result.MAIN = main;
+    if (sub !== null) result.SUB = sub;
+    pendingFrequencyHzCache = { main, sub, value: result };
+    return result;
+  }
+  /**
    * MOR-1441 — the pending (not-yet-confirmed) frequency target per
    * receiver, for `VfoSurface`'s digit control to render distinctly from
    * confirmed radio truth while a hot tuning burst is in flight. Read at
@@ -252,14 +278,7 @@
    * `hasDualReceiver` above) so `VfoSurface` stays command-bus-blind,
    * receiving only the plain per-receiver value.
    */
-  let pendingFrequencyHz = $derived((() => {
-    const result: Partial<Record<'MAIN' | 'SUB', number>> = {};
-    const main = getPendingFrequencyHz(0);
-    const sub = getPendingFrequencyHz(1);
-    if (main !== null) result.MAIN = main;
-    if (sub !== null) result.SUB = sub;
-    return result;
-  })());
+  let pendingFrequencyHz = $derived(computePendingFrequencyHz());
   /**
    * MOR-1306. The RF-front-end intent vocabulary, composed from the SHIPPED
    * command bus rather than forked — same discipline as `rxAudioIntents`

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -26,7 +26,7 @@
   import { runtime } from '$lib/runtime';
   import { toRadioViewModel } from '$lib/runtime/adapters/radio-view-model-adapter';
   import { getAppTxController } from '$lib/runtime/tx-controller/app-host';
-  import { bindSemanticSurfaceHandlers } from '$lib/runtime/adapters/panel-adapters';
+  import { bindSemanticSurfaceHandlers, getPendingFrequencyHz } from '$lib/runtime/adapters/panel-adapters';
   import type { SemanticSurfaceName } from '../../presentation/layouts/contract';
   import {
     compositionSurfaces, useSurfacePlan, zoneShowsSurface,
@@ -244,6 +244,22 @@
    * only this plain boolean.
    */
   let hasDualReceiver = $derived((runtime.caps?.receivers ?? 1) > 1);
+  /**
+   * MOR-1441 — the pending (not-yet-confirmed) frequency target per
+   * receiver, for `VfoSurface`'s digit control to render distinctly from
+   * confirmed radio truth while a hot tuning burst is in flight. Read at
+   * this seam (same "caps-echo display metadata" precedent as
+   * `hasDualReceiver` above) so `VfoSurface` stays command-bus-blind,
+   * receiving only the plain per-receiver value.
+   */
+  let pendingFrequencyHz = $derived((() => {
+    const result: Partial<Record<'MAIN' | 'SUB', number>> = {};
+    const main = getPendingFrequencyHz(0);
+    const sub = getPendingFrequencyHz(1);
+    if (main !== null) result.MAIN = main;
+    if (sub !== null) result.SUB = sub;
+    return result;
+  })());
   /**
    * MOR-1306. The RF-front-end intent vocabulary, composed from the SHIPPED
    * command bus rather than forked — same discipline as `rxAudioIntents`
@@ -556,6 +572,7 @@
               onSelectVfo={selectVfo}
               onTuneFrequency={tuneFrequency}
               disabled={!isOperationalStrip(view, receiverId)}
+              {pendingFrequencyHz}
             />
           </div>
         {/each}
@@ -616,6 +633,7 @@
         onSwapVfos={vfo.onSwap}
         onQuickSplit={vfo.onQuickSplit}
         onQuickDualWatch={vfo.onQuickDw}
+        {pendingFrequencyHz}
       />
     {/if}
   {/snippet}

--- a/frontend/src/lib/i18n/locales/en-US.json
+++ b/frontend/src/lib/i18n/locales/en-US.json
@@ -198,6 +198,7 @@
   "core.vfo.activeReceiver.unknown": "Active receiver: unknown",
   "core.vfo.selectAction": "Select {label}",
   "core.vfo.txTarget.label": "TX target",
+  "core.vfo.freq.pendingAnnouncement": "Pending, not yet confirmed",
   "core.vfo.split.label": "Split",
   "core.vfo.dualWatch.label": "Dual watch",
   "core.vfo.state.on": "on",

--- a/frontend/src/lib/i18n/locales/ru-RU.json
+++ b/frontend/src/lib/i18n/locales/ru-RU.json
@@ -178,6 +178,7 @@
   "core.vfo.activeReceiver.unknown": "Активный приёмник: неизвестно",
   "core.vfo.selectAction": "Выбрать {label}",
   "core.vfo.txTarget.label": "Цель TX",
+  "core.vfo.freq.pendingAnnouncement": "В ожидании, ещё не подтверждено",
   "core.vfo.split.label": "Сплит",
   "core.vfo.dualWatch.label": "Двойной приём",
   "core.vfo.state.on": "включено",

--- a/frontend/src/lib/runtime/adapters/__tests__/mor1441-pending-frequency.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mor1441-pending-frequency.isolated.test.ts
@@ -86,4 +86,18 @@ describe('panel-adapters pending-frequency accessor (MOR-1441)', () => {
     state.commands = [cmd({ name: 'set_mode', params: { mode: 'USB', receiver: 0 } })];
     expect(getPendingFrequencyHz(0)).toBeNull();
   });
+
+  // B3 (review): a `>` tie-break freezes on the EARLIER of two same-`createdAt`
+  // commands (millisecond-resolution timestamps, and a double-dispatch within
+  // one ms is real — the MOR-1425 accumulator can flush and a caller step in
+  // the same tick). `getCommandLifecycles()` returns commands in dispatch
+  // (array) order, so on a tie the LATER array entry is the actually-freshest
+  // one. Kills: reverting `>=` back to `>`.
+  it('on a same-millisecond createdAt tie, prefers the LATER dispatched command (array order)', () => {
+    state.commands = [
+      cmd({ createdAt: 5, params: { freq: 14100000, receiver: 0 } }),
+      cmd({ createdAt: 5, params: { freq: 14105000, receiver: 0 } }),
+    ];
+    expect(getPendingFrequencyHz(0)).toBe(14105000);
+  });
 });

--- a/frontend/src/lib/runtime/adapters/__tests__/mor1441-pending-frequency.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mor1441-pending-frequency.isolated.test.ts
@@ -1,0 +1,89 @@
+/**
+ * MOR-1441 — the pending-frequency accessor.
+ *
+ * `getPendingFrequencyHz` is the read side of the pending-target
+ * affordance: `VfoSurface`'s digit control shows this instead of confirmed
+ * radio truth while a `set_freq` intent for the receiver is still in
+ * flight, so the operator sees where a hot tuning burst (MOR-1425) is
+ * heading rather than a stale confirmed value. It must never surface a
+ * command that has already resolved (ack/fail/cancel/timeout) as though it
+ * were still pending — that would present RESOLVED state as PENDING, the
+ * exact honesty violation MOR-1441 exists to prevent.
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+type FakeCommand = {
+  name: string;
+  status: string;
+  createdAt: number;
+  params: Record<string, unknown>;
+};
+
+const state: { commands: FakeCommand[] } = { commands: [] };
+
+vi.mock('$lib/stores/commands.svelte', () => ({
+  getCommandLifecycles: () => state.commands,
+}));
+vi.mock('$lib/runtime/frontend-runtime', () => ({
+  runtime: { get state() { return null; }, get caps() { return null; } },
+}));
+vi.mock('$lib/runtime/tx-controller/app-host', () => ({
+  getAppTxController: () => null,
+}));
+vi.mock('$lib/runtime/adapters/radio-view-model-adapter', () => ({
+  toRadioViewModel: () => null,
+}));
+
+import { getPendingFrequencyHz } from '../panel-adapters';
+
+const cmd = (over: Partial<FakeCommand> = {}): FakeCommand => ({
+  name: 'set_freq',
+  status: 'pending',
+  createdAt: 0,
+  params: { freq: 14100000, receiver: 0 },
+  ...over,
+});
+
+describe('panel-adapters pending-frequency accessor (MOR-1441)', () => {
+  it('returns the pending set_freq target for the given receiver', () => {
+    state.commands = [cmd({ params: { freq: 14100000, receiver: 0 } })];
+    expect(getPendingFrequencyHz(0)).toBe(14100000);
+  });
+
+  it('returns null when no set_freq command is pending for that receiver', () => {
+    state.commands = [cmd({ params: { freq: 14100000, receiver: 1 } })];
+    expect(getPendingFrequencyHz(0)).toBeNull();
+  });
+
+  it('returns null when no commands are in flight at all', () => {
+    state.commands = [];
+    expect(getPendingFrequencyHz(0)).toBeNull();
+  });
+
+  // THE kill: an acknowledged/failed/cancelled/timed-out command has
+  // RESOLVED — reading it as pending would misrepresent resolved state as
+  // still in flight, exactly the fabrication MOR-1441 forbids.
+  it.each(['acknowledged', 'failed', 'cancelled', 'timed-out'])(
+    'ignores a %s set_freq command', (status) => {
+      state.commands = [cmd({ status, params: { freq: 14100000, receiver: 0 } })];
+      expect(getPendingFrequencyHz(0)).toBeNull();
+    },
+  );
+
+  // Kills: reading the OLDEST pending command instead of the freshest — the
+  // operator must see where the burst is heading NOW, not its first step.
+  it('picks the freshest pending command when several are in flight', () => {
+    state.commands = [
+      cmd({ createdAt: 1, params: { freq: 14100000, receiver: 0 } }),
+      cmd({ createdAt: 2, params: { freq: 14110000, receiver: 0 } }),
+    ];
+    expect(getPendingFrequencyHz(0)).toBe(14110000);
+  });
+
+  // Kills: matching on intent name alone — a pending `set_mode` must never
+  // be mistaken for a pending frequency target.
+  it('ignores commands for a different intent name', () => {
+    state.commands = [cmd({ name: 'set_mode', params: { mode: 'USB', receiver: 0 } })];
+    expect(getPendingFrequencyHz(0)).toBeNull();
+  });
+});

--- a/frontend/src/lib/runtime/adapters/panel-adapters.ts
+++ b/frontend/src/lib/runtime/adapters/panel-adapters.ts
@@ -31,6 +31,7 @@ import {
   hasAudioFft, hasDualReceiver, hasCapability,
 } from '$lib/stores/capabilities.svelte';
 import { recordQsy } from './qsy-history-adapter';
+import { getCommandLifecycles } from '$lib/stores/commands.svelte';
 import type { ServerState } from '$lib/types/state';
 import type { Capabilities } from '$lib/types/capabilities';
 
@@ -208,6 +209,33 @@ export function getSystemHandlers() { return _systemHandlers; }
 export function getActiveFrequencyHz(): number | null {
   const view = toRadioViewModel(runtime.state, runtime.caps);
   return view?.vfos.find((candidate) => candidate.isActive)?.frequencyHz ?? null;
+}
+
+// ── Pending frequency target (MOR-1441) ──
+/**
+ * The freshest still-in-flight `set_freq` target for `receiver` (`0` =
+ * MAIN, `1` = SUB — the wire encoding `dispatchRadioIntent` uses), or
+ * `null` when no `set_freq` intent is currently pending for it.
+ *
+ * This is the pending target the MOR-1425 tuning accumulator races toward
+ * during a hot burst — read off the command-bus lifecycle list rather than
+ * a second, parallel path into the accumulator's own internal (non-
+ * reactive) map. `getCommandLifecycles()` is already the accumulator's own
+ * echo/expiry authority: an ack, failure, cancellation, or timeout are
+ * exactly the events that end a command's `'pending'` status, so a caller
+ * reading this inside `$derived()` gets the snap-back-to-confirmed behavior
+ * for free, with no separate polling or expiry timer to maintain.
+ */
+export function getPendingFrequencyHz(receiver: 0 | 1): number | null {
+  let latest: { createdAt: number; freq: number } | null = null;
+  for (const command of getCommandLifecycles()) {
+    if (command.name !== 'set_freq' || command.status !== 'pending') continue;
+    if (command.params.receiver !== receiver) continue;
+    const freq = command.params.freq;
+    if (typeof freq !== 'number') continue;
+    if (!latest || command.createdAt > latest.createdAt) latest = { createdAt: command.createdAt, freq };
+  }
+  return latest?.freq ?? null;
 }
 
 const _audioRoutingHandlers = makeAudioRoutingHandlers();

--- a/frontend/src/lib/runtime/adapters/panel-adapters.ts
+++ b/frontend/src/lib/runtime/adapters/panel-adapters.ts
@@ -233,7 +233,10 @@ export function getPendingFrequencyHz(receiver: 0 | 1): number | null {
     if (command.params.receiver !== receiver) continue;
     const freq = command.params.freq;
     if (typeof freq !== 'number') continue;
-    if (!latest || command.createdAt > latest.createdAt) latest = { createdAt: command.createdAt, freq };
+    // `>=`, not `>`: `getCommandLifecycles()` is in dispatch (array) order, so
+    // on a same-millisecond `createdAt` tie the LATER entry in that order is
+    // the actually-freshest one — `>` would freeze on the earlier of the two.
+    if (!latest || command.createdAt >= latest.createdAt) latest = { createdAt: command.createdAt, freq };
   }
   return latest?.freq ?? null;
 }

--- a/frontend/src/primitives/frequency/FrequencyDisplayInteractive.svelte
+++ b/frontend/src/primitives/frequency/FrequencyDisplayInteractive.svelte
@@ -2,6 +2,18 @@
   import { splitFrequencyToDigits, groupDigitsForDisplay, adjustFreqByDigit, type DigitInfo } from './frequency-tuning';
 
   interface Props {
+    /**
+     * CONFIRMED radio truth — and, deliberately, the SOLE arithmetic base
+     * for every gesture below. MOR-1441 regression (verifier-reproduced):
+     * an earlier revision let `freq` carry the PENDING target while a hot
+     * burst was in flight, so `adjustFreqByDigit` computed off a value that
+     * already included the burst's own not-yet-confirmed delta — each tick
+     * added `(pending − confirmed) + step` instead of `step`, a positive
+     * feedback loop that compounded roughly every pacing window (10 ticks
+     * of +10 Hz intent measured out to +1910 Hz actual; 30 ticks to
+     * +15.7 MHz — a TX-out-of-band hazard). `freq` must never be sourced
+     * from `pendingDisplayHz` — that is precisely the bug.
+     */
     freq: number;
     compact?: boolean;
     active?: boolean;
@@ -10,14 +22,24 @@
     maxFreq?: number;
     onFreqChange?: (freq: number) => void;
     /**
-     * MOR-1441 — `true` while `freq` is a pending (not-yet-confirmed)
-     * tuning target rather than confirmed radio truth. The digit readout
-     * still shows `freq` (so the operator sees where a hot burst is
-     * heading), but marks it `data-freq-status="pending"` instead of
-     * `"confirmed"` — a structural marker a caller can assert on, never a
-     * color-only distinction (MOR-977 forced-colors doctrine).
+     * MOR-1441 — the pending (not-yet-confirmed) tuning target, DISPLAY
+     * ONLY: when non-null the digit readout shows THIS value instead of
+     * `freq` (so the operator sees where a hot burst is heading) and marks
+     * `data-freq-status="pending"` — but every gesture still computes its
+     * next target from `freq` alone. Never plumb this into `adjustFreqByDigit`
+     * or any arithmetic path; see the `freq` doc above for why.
      */
-    pending?: boolean;
+    pendingDisplayHz?: number | null;
+    /**
+     * MOR-1441 (B2) — already-localized text announcing the pending state
+     * to assistive tech. The `data-freq-status`/italic marker is a VISUAL
+     * channel only; without a rendered word (screen-reader convention, see
+     * `TxAuxSurface.svelte`'s `.sr-only`/`aria-describedby` pair) an AT user
+     * hears the pending frequency read as though it were confirmed. Passed
+     * in rather than resolved here — this primitive stays i18n-blind, same
+     * as every other `primitives/` component.
+     */
+    pendingAnnouncement?: string;
   }
 
   let {
@@ -28,9 +50,12 @@
     minFreq = 0,
     maxFreq = 999_000_000,
     onFreqChange,
-    pending = false,
+    pendingDisplayHz = null,
+    pendingAnnouncement,
   }: Props = $props();
-  
+
+  const pendingId = $props.id();
+
   // Receiver-aware CSS custom properties
   let cssVars = $derived({
     '--freq-active-color': `var(--v2-vfo-${receiver}-freq-active)`,
@@ -46,7 +71,10 @@
   let selectedDigitIndex = $state<number | null>(null);
   let hoveredDigitIndex = $state<number | null>(null);
 
-  let allDigits = $derived(splitFrequencyToDigits(freq));
+  let pending = $derived(pendingDisplayHz !== null);
+  // RENDER off the pending target when present — `freq` (confirmed) stays
+  // untouched by this and is read ONLY inside the gesture handlers below.
+  let allDigits = $derived(splitFrequencyToDigits(pendingDisplayHz ?? freq));
   let groups = $derived(groupDigitsForDisplay(allDigits));
 
   function handleWheel(digit: DigitInfo, event: WheelEvent) {
@@ -97,7 +125,13 @@
 
 <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
 <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
-<div class="freq" class:compact class:inactive={!active} data-freq-status={pending ? 'pending' : 'confirmed'} style={Object.entries(cssVars).map(([k, v]) => `${k}:${v}`).join(';')} tabindex="0" role="group" aria-label="Frequency display" onkeydown={handleKeyDown}>
+<div
+  class="freq" class:compact class:inactive={!active}
+  data-freq-status={pending ? 'pending' : 'confirmed'}
+  aria-describedby={pending && pendingAnnouncement ? pendingId : undefined}
+  style={Object.entries(cssVars).map(([k, v]) => `${k}:${v}`).join(';')}
+  tabindex="0" role="group" aria-label="Frequency display" onkeydown={handleKeyDown}
+>
   {#each groups.mhz as digit}
     <!-- svelte-ignore a11y_no_static_element_interactions -->
     <!-- svelte-ignore a11y_click_events_have_key_events -->
@@ -139,6 +173,9 @@
       onmouseleave={handleDigitLeave}
     >{digit.char}</span>
   {/each}
+  {#if pending && pendingAnnouncement}
+    <span id={pendingId} class="sr-only">{pendingAnnouncement}</span>
+  {/if}
 </div>
 
 <style>
@@ -204,5 +241,13 @@
     opacity: 0.5;
     margin: 0 0.02em;
     pointer-events: none;
+  }
+
+  /* MOR-1441 (B2) — the visual pending marker's assistive-tech twin: a
+     rendered word, not just italic/opacity (which convey nothing to a
+     screen reader). Same convention as `TxAuxSurface.svelte`'s `.sr-only`. */
+  .sr-only {
+    position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+    overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
   }
 </style>

--- a/frontend/src/primitives/frequency/FrequencyDisplayInteractive.svelte
+++ b/frontend/src/primitives/frequency/FrequencyDisplayInteractive.svelte
@@ -9,6 +9,15 @@
     minFreq?: number;
     maxFreq?: number;
     onFreqChange?: (freq: number) => void;
+    /**
+     * MOR-1441 — `true` while `freq` is a pending (not-yet-confirmed)
+     * tuning target rather than confirmed radio truth. The digit readout
+     * still shows `freq` (so the operator sees where a hot burst is
+     * heading), but marks it `data-freq-status="pending"` instead of
+     * `"confirmed"` — a structural marker a caller can assert on, never a
+     * color-only distinction (MOR-977 forced-colors doctrine).
+     */
+    pending?: boolean;
   }
 
   let {
@@ -19,6 +28,7 @@
     minFreq = 0,
     maxFreq = 999_000_000,
     onFreqChange,
+    pending = false,
   }: Props = $props();
   
   // Receiver-aware CSS custom properties
@@ -87,7 +97,7 @@
 
 <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
 <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
-<div class="freq" class:compact class:inactive={!active} style={Object.entries(cssVars).map(([k, v]) => `${k}:${v}`).join(';')} tabindex="0" role="group" aria-label="Frequency display" onkeydown={handleKeyDown}>
+<div class="freq" class:compact class:inactive={!active} data-freq-status={pending ? 'pending' : 'confirmed'} style={Object.entries(cssVars).map(([k, v]) => `${k}:${v}`).join(';')} tabindex="0" role="group" aria-label="Frequency display" onkeydown={handleKeyDown}>
   {#each groups.mhz as digit}
     <!-- svelte-ignore a11y_no_static_element_interactions -->
     <!-- svelte-ignore a11y_click_events_have_key_events -->
@@ -152,6 +162,14 @@
 
   .freq.inactive {
     color: var(--freq-inactive-color, var(--v2-text-muted));
+  }
+
+  /* MOR-1441 — a pending (unconfirmed) target never renders identically to
+     confirmed radio truth. Structural (italic + reduced opacity), never a
+     color-only tell, same doctrine as the `data-observed` convention. */
+  .freq[data-freq-status='pending'] {
+    font-style: italic;
+    opacity: 0.75;
   }
 
   .digit {

--- a/frontend/src/semantic/VfoSurface.svelte
+++ b/frontend/src/semantic/VfoSurface.svelte
@@ -394,9 +394,21 @@
           aria-disabled={hasTunableFrequency(vfo) && disabled ? 'true' : undefined}
         >
           {#if hasTunableFrequency(vfo)}
+            <!--
+              MOR-1441 REVIEW FIX (severe): `freq` is ALWAYS confirmed radio
+              truth (`vfo.frequencyHz`), never `pendingHz` — the pending
+              target is display-only, via `pendingDisplayHz`. Passing
+              `pendingHz` as `freq` fed the growing pending value back into
+              `FrequencyDisplayInteractive`'s own gesture arithmetic
+              (`adjustFreqByDigit(freq, ...)`), which itself feeds the
+              MOR-1425 tuning accumulator's delta — a positive-feedback
+              runaway reproduced by the verifier (10 ticks of +10 Hz intent
+              measured out to +1910 Hz actual; 30 ticks to +15.7 MHz).
+            -->
             <FrequencyDisplayInteractive
-              freq={pendingHz ?? vfo.frequencyHz ?? 0}
-              pending={pendingHz !== null}
+              freq={vfo.frequencyHz ?? 0}
+              pendingDisplayHz={pendingHz}
+              pendingAnnouncement={pendingHz !== null ? t('core.vfo.freq.pendingAnnouncement') : undefined}
               compact
               active={vfo.isActive}
               receiver={vfo.receiver === 'SUB' ? 'sub' : 'main'}

--- a/frontend/src/semantic/VfoSurface.svelte
+++ b/frontend/src/semantic/VfoSurface.svelte
@@ -114,6 +114,16 @@
      */
     onTuneFrequency?: (receiver: ReceiverId, frequencyHz: number) => void;
     /**
+     * MOR-1441 — the pending (not-yet-confirmed) tuning target for a
+     * receiver, keyed by `ReceiverId`. The caller (`SemanticRadioSurfaces`,
+     * which already holds the command-bus for the MOR-1421 `hasDualReceiver`
+     * precedent) computes this from the in-flight `set_freq` intent; this
+     * surface stays command-bus-blind and only renders the plain value it is
+     * handed. Absent (or missing that receiver's key) renders the plain
+     * confirmed readout, exactly as before this prop existed.
+     */
+    pendingFrequencyHz?: Partial<Record<ReceiverId, number>>;
+    /**
      * MOR-1321 (v3-rework slice S3a) — the VFO-scoped ACTIONS the legacy
      * `VfoOps` bridge carried and the semantic deck lost at MOR-1313: equalize
      * (copy one VFO onto the other), swap, and the two composite "quick"
@@ -144,6 +154,7 @@
     disabled = false,
     hasDualReceiver = true,
     onTuneFrequency,
+    pendingFrequencyHz,
     onEqualizeVfos,
     onSwapVfos,
     onQuickSplit,
@@ -358,6 +369,7 @@
       {@const selectable = isSelectable(vfo)}
       {@const selectDisabled = selectable && (vfo.slot.kind === 'unknown' || disabled)}
       {@const freq = frequencyDisplay(vfo)}
+      {@const pendingHz = pendingFrequencyHz?.[vfo.receiver] ?? null}
       <div
         class="vfo-tile"
         class:is-active={vfo.isActive}
@@ -383,7 +395,8 @@
         >
           {#if hasTunableFrequency(vfo)}
             <FrequencyDisplayInteractive
-              freq={vfo.frequencyHz ?? 0}
+              freq={pendingHz ?? vfo.frequencyHz ?? 0}
+              pending={pendingHz !== null}
               compact
               active={vfo.isActive}
               receiver={vfo.receiver === 'SUB' ? 'sub' : 'main'}

--- a/frontend/src/semantic/__tests__/VfoSurface.test.ts
+++ b/frontend/src/semantic/__tests__/VfoSurface.test.ts
@@ -1011,6 +1011,43 @@ describe('per-digit tuning (MOR-1322) — intents (R9: frequency, never TX)', ()
   });
 });
 
+// ── MOR-1441: pending-target affordance ─────────────────────────────────
+describe('pending-target affordance (MOR-1441)', () => {
+  // Kills: rendering the pending target with no distinguishing marker, or
+  // rendering the CONFIRMED digits while a pending target exists — either
+  // way the operator loses sight of where a hot burst is heading, or the
+  // pending value gets presented as confirmed truth.
+  it('renders the pending target, marked distinct from confirmed, on the receiver that has one', () => {
+    const t = mountSurface({
+      viewModel: tunableTile,
+      onTuneFrequency: vi.fn(),
+      pendingFrequencyHz: { MAIN: 14260000 },
+    });
+    const main = activeSlot(t); // MAIN's active tile (isActive: true)
+    const mainGroup = main.querySelector<HTMLElement>('.freq')!;
+    expect(mainGroup.dataset.freqStatus).toBe('pending');
+    const digitsText = [...main.querySelectorAll('.digit')].map((d) => d.textContent).join('');
+    expect(digitsText).toBe('14260000');
+    expect(digitsText).not.toBe(String(tunableTile.vfos[0].frequencyHz));
+
+    // SUB's active-slot tile has no pending entry — stays confirmed.
+    const sub = activeSlots(t).find((sl) => tileOf(sl).dataset.vfoReceiver === 'SUB')!;
+    const subGroup = sub.querySelector<HTMLElement>('.freq')!;
+    expect(subGroup.dataset.freqStatus).toBe('confirmed');
+  });
+
+  // Kills: leaving the marker "pending" (or the digits stuck on a stale
+  // target) once no in-flight `set_freq` exists for the receiver — the
+  // MOR-1441 snap-to-confirmed-on-echo/expiry rule.
+  it('renders confirmed digits when no pending target is supplied', () => {
+    const t = mountSurface({ viewModel: tunableTile, onTuneFrequency: vi.fn() });
+    const group = activeSlot(t).querySelector<HTMLElement>('.freq')!;
+    expect(group.dataset.freqStatus).toBe('confirmed');
+    const digitsText = [...activeSlot(t).querySelectorAll('.digit')].map((d) => d.textContent).join('');
+    expect(digitsText).toBe(String(tunableTile.vfos[0].frequencyHz));
+  });
+});
+
 describe('per-digit tuning (MOR-1322) — the operational guard, pinned independently', () => {
   const wheel = (el: Element) =>
     el.dispatchEvent(new WheelEvent('wheel', { deltaY: -1, bubbles: true, cancelable: true }));

--- a/frontend/src/semantic/__tests__/VfoSurface.test.ts
+++ b/frontend/src/semantic/__tests__/VfoSurface.test.ts
@@ -22,6 +22,7 @@ import type { ComponentProps } from 'svelte';
 import VfoSurface from '../VfoSurface.svelte';
 import { validateRadioViewModel, type RadioViewModel, type VfoSlot } from '../radio-view-model';
 import { topologyFixtures, withAudioOnlyScope, type TopologyFixtureId } from '../fixtures/topologies';
+import { createTuningAccumulator } from '$lib/runtime/commands/tuning-accumulator';
 
 const ids: readonly TopologyFixtureId[] = ['1/single', '1/ab', '2/ab_shared', '2/main_sub'];
 
@@ -1045,6 +1046,69 @@ describe('pending-target affordance (MOR-1441)', () => {
     expect(group.dataset.freqStatus).toBe('confirmed');
     const digitsText = [...activeSlot(t).querySelectorAll('.digit')].map((d) => d.textContent).join('');
     expect(digitsText).toBe(String(tunableTile.vfos[0].frequencyHz));
+  });
+
+  // ── MOR-1441 REVIEW FIX: the anti-runaway pin ───────────────────────────
+  // Reproduced defect: VfoSurface fed the PENDING display value into
+  // `FrequencyDisplayInteractive`'s `freq` prop, which doubles as the SOLE
+  // arithmetic base for wheel/arrow gestures. Every hot tick then computed
+  // its next target off an already-drifted base and fed the excess back
+  // into the MOR-1425 tuning accumulator's own delta — a positive-feedback
+  // loop the verifier reproduced against the REAL accumulator (10 ticks of
+  // +10 Hz intent -> +1910 Hz actual; 30 ticks -> +15.7 MHz; a TX-out-of-
+  // band hazard). This drives the actual production seam — VfoSurface's
+  // `onTuneFrequency` feeding a REAL `createTuningAccumulator`, with
+  // `pendingFrequencyHz` updated between ticks exactly as a live re-render
+  // would (`SemanticRadioSurfaces` re-deriving it from the accumulator's own
+  // emitted target). THE kill: N hot ticks must land on confirmed + N*step,
+  // never runaway growth.
+  it('MUTATION KILL: N hot wheel ticks accumulate linearly (confirmed + N*step), never runaway', () => {
+    vi.useFakeTimers();
+    try {
+      const CONFIRMED = tunableTile.vfos[0].frequencyHz!; // MAIN's active tile
+      const N = 10;
+      let target = CONFIRMED;
+      const accumulator = createTuningAccumulator({
+        emit: (_receiver, freq) => { target = freq; },
+        paceMs: 0,
+      });
+
+      let pendingFrequencyHz: Partial<Record<'MAIN' | 'SUB', number>> = {};
+      let stepSize: number | null = null;
+
+      for (let i = 0; i < N; i++) {
+        let requested: number | null = null;
+        const onTuneFrequency = (_receiver: 'MAIN' | 'SUB', hz: number) => {
+          requested = hz;
+          accumulator.step(0, CONFIRMED, hz);
+        };
+        const el = document.createElement('div');
+        document.body.appendChild(el);
+        const component = mount(VfoSurface, {
+          target: el,
+          props: { viewModel: tunableTile, onTuneFrequency, pendingFrequencyHz },
+        });
+        flushSync();
+
+        const digits = activeSlot(el).querySelectorAll<HTMLElement>('.digit');
+        const oneKhzDigit = digits[digits.length - 4]; // 1 kHz place, robust to MHz digit-count trim
+        oneKhzDigit.dispatchEvent(new WheelEvent('wheel', { deltaY: -1, bubbles: true }));
+        flushSync();
+        vi.advanceTimersByTime(1); // flush the accumulator's paced emit
+
+        unmount(component);
+        document.body.removeChild(el);
+
+        expect(requested, `tick ${i}`).not.toBeNull();
+        if (stepSize === null) stepSize = requested! - CONFIRMED;
+        pendingFrequencyHz = { MAIN: target };
+      }
+
+      expect(stepSize).not.toBeNull();
+      expect(target).toBe(CONFIRMED + N * stepSize!);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

- Post-MOR-1425, the frequency digit readout tracked confirmed radio truth only, so during a hot tuning burst it lagged up to 0.5-2s behind the accumulator's in-flight target. Add a pending-target affordance: the digit control now shows the in-flight `set_freq` target, marked distinctly, instead of a stale confirmed value.
- `getPendingFrequencyHz(receiver)` (`frontend/src/lib/runtime/adapters/panel-adapters.ts`) is a pure read of the command-bus lifecycle list (`$lib/stores/commands.svelte`) for the freshest still-`'pending'` `set_freq` intent per receiver. It deliberately does NOT add a second read path into the MOR-1425 tuning accumulator's own internal (non-reactive) map — the lifecycle list is already the accumulator's own echo/expiry authority (ack/fail/cancel/timeout all end `'pending'` status), so the snap-to-confirmed-on-echo/expiry behavior falls out for free, with no new timer or polling.
- `SemanticRadioSurfaces.svelte` derives the per-receiver pending value and hands it to `VfoSurface` as a plain, command-bus-blind prop (`pendingFrequencyHz`), same precedent as MOR-1421's `hasDualReceiver`.
- `VfoSurface` passes it down to `FrequencyDisplayInteractive`, which renders the pending target's digits with `data-freq-status="pending"` instead of `"confirmed"` — a structural marker (never a color-only tell, per the MOR-977 forced-colors doctrine), so a pending value can never be mistaken for confirmed truth.
- Also fixes the offline fixture-capture harness stub (`frontend/fixtures/stubs/panel-adapters.ts`), which must mirror every export of the real module or the whole harness fails at module resolution (same MOR-1271/MOR-1320 lesson already documented in `fixtures/stubs/command-bus.ts`).

## Scope note / deviation

This PR covers the **frequency digit control only**. The ticket's broadened scope also asked for a lightweight pending style on discrete controls (filter select, preamp, NB/NR). That reuses the same command-bus-derived pattern established here, but needs its own per-surface wiring across `FilterSurface`, `DspSurface`, and `RfFrontEndSurface` (three separate presentation-only surfaces under the MOR-1063 ADR, each requiring its own new prop + template change + tests). Rather than risk scope creep in `SemanticRadioSurfaces.svelte` — a large, heavily-invariant wiring file — within this change, it is split out to a follow-up, per the ticket's own explicit MOR-1447-precedent fallback ("freq first, discrete second").

## Test plan

- [x] New unit tests for `getPendingFrequencyHz` (`frontend/src/lib/runtime/adapters/__tests__/mor1441-pending-frequency.isolated.test.ts`): pending/absent/resolved (ack/fail/cancel/timeout)/freshest-of-several/wrong-intent-name cases.
- [x] New `VfoSurface` tests asserting the pending marker is distinct from confirmed and that digits reflect the pending target, not confirmed, while pending.
- [x] New `FrequencyDisplayInteractive` tests for the `data-freq-status` marker.
- [x] Full frontend suite (remote): 324 files / 6728 tests pass, `npm run lint` clean, `npm run check` (svelte-check + tsc) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)