### PR TITLE
fix: TX-aux readout convention + IC-7300 mic/VOX/monitor poll coverage (MOR-1452)

### DIFF
--- a/frontend/src/semantic/TxAuxSurface.svelte
+++ b/frontend/src/semantic/TxAuxSurface.svelte
@@ -29,7 +29,7 @@
 <script module lang="ts">
   import type { TxAuxField } from './radio-view-model';
   import { pressedOf } from './pressed-of';
-  import { formatKnownLevel } from './format-level';
+  import { rawToPercentDisplay } from '../components-v2/controls/value-control/value-control-core';
   import { disabledReasonText } from './disabled-reason';
 
   /** On/off controls, `[field, label]`. ATU's reading is a three-state enum,
@@ -37,19 +37,27 @@
   export const TX_AUX_TOGGLES = [
     ['atu', 'ATU'], ['vox', 'VOX'], ['compressor', 'COMP'], ['monitor', 'MON'],
   ] as const;
-  /** `[field, label, min, max, step]` in RAW wire units — the MOR-1244
-   *  contract applies no normalisation, so these are exactly the ranges
-   *  `TxPanel`/`VoxPanel` have always used (RF power 0..1, VOX delay 0..20,
-   *  everything else 0..255). Rescaling here would silently move a level. */
+  /** `[field, label, min, max, step, format]` — the slider bound and step are
+   *  RAW wire units (the MOR-1244 contract applies no normalisation, so these
+   *  are exactly the ranges `TxPanel`/`VoxPanel` have always used: RF power
+   *  0..1, VOX delay 0..20, everything else 0..255 — rescaling the VALUE here
+   *  would silently move a level). `format` is the DISPLAY-only convention
+   *  (MOR-1452): every level slider on this surface reads back as a percent
+   *  of its own declared domain via `rawToPercentDisplay`, the same per-field
+   *  `displayFn` idiom `DspSurface` established — chosen over
+   *  `formatKnownLevel`'s hardcoded `[0,1]`-domain sniff (MOR-1447) because it
+   *  is domain-generic instead of special-casing one field shape, so RF power
+   *  (0..1), a raw 0..255 level, and VOX delay (0..20) all render as one
+   *  convention instead of three different ones. */
   export const TX_AUX_LEVELS = [
-    ['rfPower', 'RF power', 0, 1, 0.01],
-    ['micGain', 'Mic gain', 0, 255, 1],
-    ['driveGain', 'Drive gain', 0, 255, 1],
-    ['voxGain', 'VOX gain', 0, 255, 1],
-    ['antiVoxGain', 'Anti-VOX', 0, 255, 1],
-    ['voxDelay', 'VOX delay', 0, 20, 1],
-    ['compressorLevel', 'COMP level', 0, 255, 1],
-    ['monitorLevel', 'MON level', 0, 255, 1],
+    ['rfPower', 'RF power', 0, 1, 0.01, (v: number) => rawToPercentDisplay(v, 0, 1)],
+    ['micGain', 'Mic gain', 0, 255, 1, rawToPercentDisplay],
+    ['driveGain', 'Drive gain', 0, 255, 1, rawToPercentDisplay],
+    ['voxGain', 'VOX gain', 0, 255, 1, rawToPercentDisplay],
+    ['antiVoxGain', 'Anti-VOX', 0, 255, 1, rawToPercentDisplay],
+    ['voxDelay', 'VOX delay', 0, 20, 1, (v: number) => rawToPercentDisplay(v, 0, 20)],
+    ['compressorLevel', 'COMP level', 0, 255, 1, rawToPercentDisplay],
+    ['monitorLevel', 'MON level', 0, 255, 1, rawToPercentDisplay],
   ] as const;
   export type TxAuxToggleField = (typeof TX_AUX_TOGGLES)[number][0];
   export type TxAuxLevelField = (typeof TX_AUX_LEVELS)[number][0];
@@ -69,12 +77,12 @@
     f.reading.status !== 'known' ? '?'
       : typeof f.reading.value === 'boolean' ? (f.reading.value ? 'on' : 'off')
         : String(f.reading.value);
-  /** Same freshness discipline as `textOf`, but a KNOWN level reading is
-   *  formatted against its declared `[min, max]` domain (MOR-1447) instead of
-   *  `String()`-ing the raw wire fraction — e.g. RF power reading back as
-   *  the literal `0.5529411764705883` instead of "55%". */
-  const levelTextOf = (f: TxAuxField<number>, min: number, max: number): string =>
-    f.reading.status === 'known' ? formatKnownLevel(f.reading.value, min, max) : '?';
+  /** Same freshness discipline as `textOf`, but a KNOWN level reading is run
+   *  through its declared `format` (MOR-1452) instead of `String()`-ing the
+   *  raw wire value — e.g. RF power reading back as "80%" instead of the
+   *  literal `0.5529411764705883`, and mic gain as "50%" instead of `128`. */
+  const levelTextOf = (f: TxAuxField<number>, format: (v: number) => string): string =>
+    f.reading.status === 'known' ? format(f.reading.value) : '?';
   const numberOf = (f: TxAuxField<number>, fallback: number): number =>
     f.reading.status === 'known' ? f.reading.value : fallback;
 
@@ -152,7 +160,7 @@
       {/if}
     </div>
 
-    {#each TX_AUX_LEVELS as [field, label, min, max, step] (field)}
+    {#each TX_AUX_LEVELS as [field, label, min, max, step, format] (field)}
       {#if txAux[field].availability.structural}
         <label
           class="tx-aux-level" data-testid={`tx-aux-${field}`} data-field={field}
@@ -169,7 +177,7 @@
           {#if reasonTextOf(txAux[field]) !== undefined}
             <span id={reasonIdOf(field, txAux[field])} class="sr-only">{reasonTextOf(txAux[field])}</span>
           {/if}
-          <output>{levelTextOf(txAux[field], min, max)}</output>
+          <output>{levelTextOf(txAux[field], format)}</output>
         </label>
       {/if}
     {/each}

--- a/frontend/src/semantic/TxAuxSurface.svelte
+++ b/frontend/src/semantic/TxAuxSurface.svelte
@@ -37,27 +37,37 @@
   export const TX_AUX_TOGGLES = [
     ['atu', 'ATU'], ['vox', 'VOX'], ['compressor', 'COMP'], ['monitor', 'MON'],
   ] as const;
-  /** `[field, label, min, max, step, format]` — the slider bound and step are
-   *  RAW wire units (the MOR-1244 contract applies no normalisation, so these
-   *  are exactly the ranges `TxPanel`/`VoxPanel` have always used: RF power
-   *  0..1, VOX delay 0..20, everything else 0..255 — rescaling the VALUE here
-   *  would silently move a level). `format` is the DISPLAY-only convention
-   *  (MOR-1452): every level slider on this surface reads back as a percent
-   *  of its own declared domain via `rawToPercentDisplay`, the same per-field
-   *  `displayFn` idiom `DspSurface` established — chosen over
-   *  `formatKnownLevel`'s hardcoded `[0,1]`-domain sniff (MOR-1447) because it
-   *  is domain-generic instead of special-casing one field shape, so RF power
-   *  (0..1), a raw 0..255 level, and VOX delay (0..20) all render as one
-   *  convention instead of three different ones. */
+  /** `[field, label, min, max, step, format]` — every row is a 6-tuple (kept
+   *  uniform for `it.each` typing, not a mix of 5- and 6-element tuples) but
+   *  `format` is `undefined` for most fields. The slider bound and step are
+   *  RAW wire units (the MOR-1244 contract applies no normalisation, so
+   *  these are exactly the ranges `TxPanel`/`VoxPanel` have always used: RF
+   *  power 0..1, VOX delay 0..20, everything else 0..255 — rescaling the
+   *  VALUE here would silently move a level).
+   *
+   *  `format` is the DISPLAY-only convention (MOR-1452). An `undefined` row
+   *  gets the default — a percent of ITS OWN `min`/`max` (the SAME two
+   *  values bound to `<input min max>` a few lines below, not a duplicated
+   *  literal) via `rawToPercentDisplay`. That default is built at
+   *  `levelTextOf`'s call site, not stored per-row, precisely so it cannot
+   *  drift from a row's declared domain the way a bare `rawToPercentDisplay`
+   *  reference silently would (that reference reads ITS OWN [0,255] default
+   *  args, not the row's — invisible for every field that happens to declare
+   *  exactly 0..255, wrong the moment one doesn't; caught in review).
+   *
+   *  `voxDelay` overrides the default: its raw units are 0.1s steps (`20` ⇒
+   *  2.0s), a genuine duration, not a level fraction — a percent of it is
+   *  meaningless. Mirrors `VoxPanel.svelte`'s own `delayDisplay`, the
+   *  existing precedent for this exact field. */
   export const TX_AUX_LEVELS = [
-    ['rfPower', 'RF power', 0, 1, 0.01, (v: number) => rawToPercentDisplay(v, 0, 1)],
-    ['micGain', 'Mic gain', 0, 255, 1, rawToPercentDisplay],
-    ['driveGain', 'Drive gain', 0, 255, 1, rawToPercentDisplay],
-    ['voxGain', 'VOX gain', 0, 255, 1, rawToPercentDisplay],
-    ['antiVoxGain', 'Anti-VOX', 0, 255, 1, rawToPercentDisplay],
-    ['voxDelay', 'VOX delay', 0, 20, 1, (v: number) => rawToPercentDisplay(v, 0, 20)],
-    ['compressorLevel', 'COMP level', 0, 255, 1, rawToPercentDisplay],
-    ['monitorLevel', 'MON level', 0, 255, 1, rawToPercentDisplay],
+    ['rfPower', 'RF power', 0, 1, 0.01, undefined],
+    ['micGain', 'Mic gain', 0, 255, 1, undefined],
+    ['driveGain', 'Drive gain', 0, 255, 1, undefined],
+    ['voxGain', 'VOX gain', 0, 255, 1, undefined],
+    ['antiVoxGain', 'Anti-VOX', 0, 255, 1, undefined],
+    ['voxDelay', 'VOX delay', 0, 20, 1, (v: number) => `${(v * 0.1).toFixed(1)}s`],
+    ['compressorLevel', 'COMP level', 0, 255, 1, undefined],
+    ['monitorLevel', 'MON level', 0, 255, 1, undefined],
   ] as const;
   export type TxAuxToggleField = (typeof TX_AUX_TOGGLES)[number][0];
   export type TxAuxLevelField = (typeof TX_AUX_LEVELS)[number][0];
@@ -78,11 +88,21 @@
       : typeof f.reading.value === 'boolean' ? (f.reading.value ? 'on' : 'off')
         : String(f.reading.value);
   /** Same freshness discipline as `textOf`, but a KNOWN level reading is run
-   *  through its declared `format` (MOR-1452) instead of `String()`-ing the
-   *  raw wire value — e.g. RF power reading back as "80%" instead of the
-   *  literal `0.5529411764705883`, and mic gain as "50%" instead of `128`. */
-  const levelTextOf = (f: TxAuxField<number>, format: (v: number) => string): string =>
-    f.reading.status === 'known' ? format(f.reading.value) : '?';
+   *  through its `format` (MOR-1452) instead of `String()`-ing the raw wire
+   *  value — e.g. RF power reading back as "80%" instead of the literal
+   *  `0.5529411764705883`, and mic gain as "50%" instead of `128`. Absent a
+   *  per-row override, the default is built HERE, from the SAME `min`/`max`
+   *  the caller destructured for this field's `<input>` bounds — never a
+   *  bare `rawToPercentDisplay` reference, which would silently ignore them. */
+  const levelTextOf = (
+    f: TxAuxField<number>,
+    min: number,
+    max: number,
+    format?: (v: number) => string,
+  ): string => {
+    if (f.reading.status !== 'known') return '?';
+    return (format ?? ((v: number) => rawToPercentDisplay(v, min, max)))(f.reading.value);
+  };
   const numberOf = (f: TxAuxField<number>, fallback: number): number =>
     f.reading.status === 'known' ? f.reading.value : fallback;
 
@@ -177,7 +197,7 @@
           {#if reasonTextOf(txAux[field]) !== undefined}
             <span id={reasonIdOf(field, txAux[field])} class="sr-only">{reasonTextOf(txAux[field])}</span>
           {/if}
-          <output>{levelTextOf(txAux[field], format)}</output>
+          <output>{levelTextOf(txAux[field], min, max, format)}</output>
         </label>
       {/if}
     {/each}

--- a/frontend/src/semantic/__tests__/TxAuxSurface.test.ts
+++ b/frontend/src/semantic/__tests__/TxAuxSurface.test.ts
@@ -415,9 +415,9 @@ describe('level intents reach the caller with the field and the raw value', () =
   });
 });
 
-// ── 7. Readout formatting (MOR-1447) ────────────────────────────────────────
+// ── 7. Readout formatting (MOR-1452) ────────────────────────────────────────
 
-describe('the readout formats a 0..1 level as a percent, not the raw wire float', () => {
+describe('every TX-aux level slider reads back as a percent of its own domain', () => {
   // The mobile/narrow composition regression this pins: RF power read back
   // as the literal `0.5529411764705883` instead of a formatted percent.
   it('formats RF power as a rounded percent (fixture value 0.8 -> "80%")', () => {
@@ -427,13 +427,31 @@ describe('the readout formats a 0..1 level as a percent, not the raw wire float'
     });
   });
 
-  // Contrast: a raw 0..255 level and a small integer domain both keep
-  // reading as the plain number — only the declared 0..1 fraction is
-  // percent-formatted (`formatKnownLevel`'s domain-generic rule).
-  it('leaves a raw 0..255 level (mic gain) as the plain number', () => {
+  // MOR-1452: before this ticket, a raw 0..255 level (mic gain) rendered as
+  // the plain wire integer ("128") while RF power (0..1) already read as a
+  // percent — two conventions on the same panel. Both now read as a percent
+  // of their OWN declared domain: 128 of 0..255 is "50%", not "128".
+  it('formats a raw 0..255 level (mic gain) as a percent of its own domain, not the raw wire int', () => {
     withSurface(base(), snap(), (s) => {
       const output = s.control('micGain')!.querySelector('output')!;
-      expect(output.textContent).toBe('128');
+      expect(output.textContent).toBe('50%');
+    });
+  });
+
+  // Every other level field on the surface follows the same one convention —
+  // percent of its own declared [min, max], never a bare number regardless
+  // of whether the field's native range happens to be 0..255, 0..1, or 0..20.
+  it.each([
+    ['driveGain', '50%'],
+    ['voxGain', '20%'],
+    ['antiVoxGain', '12%'],
+    ['voxDelay', '100%'],
+    ['compressorLevel', '4%'],
+    ['monitorLevel', '50%'],
+  ])('formats %s as %s', (field, expected) => {
+    withSurface(base(), snap(), (s) => {
+      const output = s.control(field)!.querySelector('output')!;
+      expect(output.textContent).toBe(expected);
     });
   });
 });

--- a/frontend/src/semantic/__tests__/TxAuxSurface.test.ts
+++ b/frontend/src/semantic/__tests__/TxAuxSurface.test.ts
@@ -389,7 +389,7 @@ describe('this surface is never a second key path (safety note iii)', () => {
 // ── 6. Level intents carry the field and the raw value ─────────────────────
 
 describe('level intents reach the caller with the field and the raw value', () => {
-  it.each(TX_AUX_LEVELS)('emits (%s, value) on input', (field, _label, min, max, step) => {
+  it.each(TX_AUX_LEVELS)('emits (%s, value) on input', (field, _label, min, max, step, _format) => {
     const onLevelChange = vi.fn();
     withSurface(base(), snap(), (s) => {
       const input = s.input(field)!;
@@ -418,6 +418,13 @@ describe('level intents reach the caller with the field and the raw value', () =
 // ── 7. Readout formatting (MOR-1452) ────────────────────────────────────────
 
 describe('every TX-aux level slider reads back as a percent of its own domain', () => {
+  /** Same source-stripper the section-5 safety pins use, redefined locally
+   *  since it is a plain module-scope const there, not exported. */
+  const source = readFileSync('src/semantic/TxAuxSurface.svelte', 'utf8')
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/^\s*\/\/.*$/gm, '');
+
   // The mobile/narrow composition regression this pins: RF power read back
   // as the literal `0.5529411764705883` instead of a formatted percent.
   it('formats RF power as a rounded percent (fixture value 0.8 -> "80%")', () => {
@@ -440,12 +447,12 @@ describe('every TX-aux level slider reads back as a percent of its own domain', 
 
   // Every other level field on the surface follows the same one convention —
   // percent of its own declared [min, max], never a bare number regardless
-  // of whether the field's native range happens to be 0..255, 0..1, or 0..20.
+  // of whether the field's native range happens to be 0..255 or 0..1.
+  // `voxDelay` is deliberately excluded — see the seconds-unit test below.
   it.each([
     ['driveGain', '50%'],
     ['voxGain', '20%'],
     ['antiVoxGain', '12%'],
-    ['voxDelay', '100%'],
     ['compressorLevel', '4%'],
     ['monitorLevel', '50%'],
   ])('formats %s as %s', (field, expected) => {
@@ -453,5 +460,31 @@ describe('every TX-aux level slider reads back as a percent of its own domain', 
       const output = s.control(field)!.querySelector('output')!;
       expect(output.textContent).toBe(expected);
     });
+  });
+
+  // MOR-1452 review fix: VOX delay is a DURATION (0.1s raw steps), not a
+  // level fraction — a percent-of-domain reading ("100%" for the fixture's
+  // 20) hid the actual truth (2.0s) behind a number with no operator
+  // meaning. Mirrors `VoxPanel.svelte`'s own `delayDisplay` precedent for
+  // this exact field: `${(raw * 0.1).toFixed(1)}s`.
+  it('formats VOX delay as seconds, not a percent (fixture value 20 -> "2.0s")', () => {
+    withSurface(base(), snap(), (s) => {
+      const output = s.control('voxDelay')!.querySelector('output')!;
+      expect(output.textContent).toBe('2.0s');
+    });
+  });
+
+  // MUTATION KILLED: a bare `rawToPercentDisplay` reference (no wrapping) as
+  // a TX_AUX_LEVELS format silently reads ITS OWN default args (0, 255)
+  // instead of the row's declared [min, max] — invisible for every field
+  // that happens to declare exactly 0..255 (every plain level here), wrong
+  // the instant a domain doesn't match those defaults. The default format
+  // must be built from THIS row's own bound `min`/`max` at the call site
+  // (`levelTextOf`), not stored as a per-row literal or a bare reference, so
+  // a future domain change flows into the readout automatically instead of
+  // silently going stale.
+  it('builds the default percent format from the row\'s own bound min/max, not a bare rawToPercentDisplay reference', () => {
+    expect(source).not.toMatch(/,\s*rawToPercentDisplay\s*[,\]]/);
+    expect(source).toMatch(/rawToPercentDisplay\(v,\s*min,\s*max\)/);
   });
 });

--- a/rigs/ic7300.toml
+++ b/rigs/ic7300.toml
@@ -203,28 +203,37 @@ cadence_seconds = 0.3
 freshness_ttl_seconds = 1.0
 adaptive_decay = false
 
-# MOR-1452: mic/monitor/VOX/anti-VOX gain — same 3.0s/5.0s slow tier IC-7610
-# already uses for these 4 fields (rigs/ic7610.toml). Well below the ~500ms
-# keep-alive/freq/mode fast tier above; these are settings-panel levels, not
-# operating controls, so a 3s cadence is not a live-operation regression.
+# MOR-1452 (review fix): mic/monitor/VOX/anti-VOX gain. IC-7610 polls these
+# same 4 fields at 3.0s/5.0s (rigs/ic7610.toml), but IC-7610 is LAN — IC-7300
+# is SERIAL, sharing one ~20 transactions/s software floor
+# (_SERIAL_DEFAULT_CIV_MIN_INTERVAL_MS, 50ms/frame) across every poll,
+# operator command, AND the keep-alive on this same lane. Copying 3.0s
+# verbatim would add 4 fields / 3.0s = 1.333 q/s on top of this profile's
+# pre-existing ~19.667 q/s demand (freq/mode/keep-alive/af/rf/squelch/
+# att/preamp/agc/nb/nr/power/compressor/ptt/tuner/split, each 1/cadence) —
+# 21.0 q/s, structurally over the 20 q/s ceiling, degrading cadence on EVERY
+# polled field including PTT (0.3s) and freq/mode (1.5s). 15.0s/25.0s instead
+# adds only 4/15.0 = 0.267 q/s -> 19.933 q/s, leaving real headroom rather
+# than sitting exactly on the boundary. A live bench measurement at the gate
+# may justify tightening this later (tracked as a bench follow-up item).
 [state_acquisition.field_policies."global.operator_controls.mic_gain"]
-cadence_seconds = 3.0
-freshness_ttl_seconds = 5.0
+cadence_seconds = 15.0
+freshness_ttl_seconds = 25.0
 adaptive_decay = false
 
 [state_acquisition.field_policies."global.operator_controls.monitor_gain"]
-cadence_seconds = 3.0
-freshness_ttl_seconds = 5.0
+cadence_seconds = 15.0
+freshness_ttl_seconds = 25.0
 adaptive_decay = false
 
 [state_acquisition.field_policies."global.operator_controls.vox_gain"]
-cadence_seconds = 3.0
-freshness_ttl_seconds = 5.0
+cadence_seconds = 15.0
+freshness_ttl_seconds = 25.0
 adaptive_decay = false
 
 [state_acquisition.field_policies."global.operator_controls.anti_vox_gain"]
-cadence_seconds = 3.0
-freshness_ttl_seconds = 5.0
+cadence_seconds = 15.0
+freshness_ttl_seconds = 25.0
 adaptive_decay = false
 
 # ── Parameterized Capabilities ───────────────────────────────────

--- a/rigs/ic7300.toml
+++ b/rigs/ic7300.toml
@@ -139,6 +139,16 @@ polling_only = [
     "global.tx_state.ptt",
     "global.operator_controls.tuner_status",
     "global.tx_state.split",
+    # MOR-1452: documented-readable §19 0x14 sub-commands (0x0B/0x15/0x16/0x17,
+    # see docs/validation/cat-audits/ic7300.md) that the poller never queried —
+    # the TX-aux panel showed them as an honest but permanent "?". Same
+    # provider-generic `_GLOBAL_LEVEL_QUERY_SUBS` mapping IC-7610 already
+    # polls these 4 fields through; slow field_policies below, not the
+    # freq/mode/keep-alive fast tier.
+    "global.operator_controls.mic_gain",
+    "global.operator_controls.monitor_gain",
+    "global.operator_controls.vox_gain",
+    "global.operator_controls.anti_vox_gain",
 ]
 stream_like_meters = [
     "receiver.main.meters.s_meter",
@@ -191,6 +201,30 @@ meter_coalescing_window_seconds = 0.2
 [state_acquisition.field_policies."global.tx_state.ptt"]
 cadence_seconds = 0.3
 freshness_ttl_seconds = 1.0
+adaptive_decay = false
+
+# MOR-1452: mic/monitor/VOX/anti-VOX gain — same 3.0s/5.0s slow tier IC-7610
+# already uses for these 4 fields (rigs/ic7610.toml). Well below the ~500ms
+# keep-alive/freq/mode fast tier above; these are settings-panel levels, not
+# operating controls, so a 3s cadence is not a live-operation regression.
+[state_acquisition.field_policies."global.operator_controls.mic_gain"]
+cadence_seconds = 3.0
+freshness_ttl_seconds = 5.0
+adaptive_decay = false
+
+[state_acquisition.field_policies."global.operator_controls.monitor_gain"]
+cadence_seconds = 3.0
+freshness_ttl_seconds = 5.0
+adaptive_decay = false
+
+[state_acquisition.field_policies."global.operator_controls.vox_gain"]
+cadence_seconds = 3.0
+freshness_ttl_seconds = 5.0
+adaptive_decay = false
+
+[state_acquisition.field_policies."global.operator_controls.anti_vox_gain"]
+cadence_seconds = 3.0
+freshness_ttl_seconds = 5.0
 adaptive_decay = false
 
 # ── Parameterized Capabilities ───────────────────────────────────

--- a/tests/test_state_acquisition_policy.py
+++ b/tests/test_state_acquisition_policy.py
@@ -491,6 +491,13 @@ def test_ic7300_profile_enrolls_exact_supported_observation_rows() -> None:
         FieldPath.global_("tx_state", "ptt"),
         FieldPath.global_("operator_controls", "tuner_status"),
         FieldPath.global_("tx_state", "split"),
+        # MOR-1452: documented-readable 0x14 sub-commands (mic/monitor/VOX/
+        # anti-VOX gain, docs/validation/cat-audits/ic7300.md) added to the
+        # slow poll tier so the TX-aux panel stops showing a permanent "?".
+        FieldPath.global_("operator_controls", "mic_gain"),
+        FieldPath.global_("operator_controls", "monitor_gain"),
+        FieldPath.global_("operator_controls", "vox_gain"),
+        FieldPath.global_("operator_controls", "anti_vox_gain"),
     }
 
     assert set(acquisition.pollable_paths()) == expected_pollable
@@ -504,6 +511,25 @@ def test_ic7300_profile_enrolls_exact_supported_observation_rows() -> None:
         FieldPath.global_("operator_controls", "compressor_level"),
     ):
         assert acquisition.capability_for(path).command_response_observable is True
+
+    # MOR-1452: the 4 newly-polled fields sit at the SAME slow 3.0s/5.0s
+    # cadence IC-7610 already uses for these fields (rigs/ic7610.toml) — well
+    # below the fast freq/mode/keep-alive tier, and unchanged by this ticket.
+    for path in (
+        FieldPath.global_("operator_controls", "mic_gain"),
+        FieldPath.global_("operator_controls", "monitor_gain"),
+        FieldPath.global_("operator_controls", "vox_gain"),
+        FieldPath.global_("operator_controls", "anti_vox_gain"),
+    ):
+        policy = acquisition.policy_for(path)
+        assert policy.cadence_seconds == 3.0
+        assert policy.freshness_ttl_seconds == 5.0
+
+    fast_tier_ttl = acquisition.policy_for(
+        FieldPath.active("main", "freq_mode", "freq_hz")
+    ).freshness_ttl_seconds
+    assert fast_tier_ttl == acquisition.default_policy.freshness_ttl_seconds
+    assert fast_tier_ttl < 5.0
 
     assert (
         acquisition.capability_for(

--- a/tests/test_state_acquisition_policy.py
+++ b/tests/test_state_acquisition_policy.py
@@ -512,9 +512,12 @@ def test_ic7300_profile_enrolls_exact_supported_observation_rows() -> None:
     ):
         assert acquisition.capability_for(path).command_response_observable is True
 
-    # MOR-1452: the 4 newly-polled fields sit at the SAME slow 3.0s/5.0s
-    # cadence IC-7610 already uses for these fields (rigs/ic7610.toml) — well
-    # below the fast freq/mode/keep-alive tier, and unchanged by this ticket.
+    # MOR-1452 (review fix): the 4 newly-polled fields sit at 15.0s/25.0s, NOT
+    # IC-7610's 3.0s/5.0s for the same fields (rigs/ic7610.toml) — IC-7610 is
+    # LAN, IC-7300 is serial and shares one ~20 q/s software floor across
+    # every poll, operator command, and keep-alive on the same lane (see the
+    # serial-budget assertion below for the exact arithmetic that rules out
+    # 3.0s here).
     for path in (
         FieldPath.global_("operator_controls", "mic_gain"),
         FieldPath.global_("operator_controls", "monitor_gain"),
@@ -522,14 +525,34 @@ def test_ic7300_profile_enrolls_exact_supported_observation_rows() -> None:
         FieldPath.global_("operator_controls", "anti_vox_gain"),
     ):
         policy = acquisition.policy_for(path)
-        assert policy.cadence_seconds == 3.0
-        assert policy.freshness_ttl_seconds == 5.0
+        assert policy.cadence_seconds == 15.0
+        assert policy.freshness_ttl_seconds == 25.0
 
     fast_tier_ttl = acquisition.policy_for(
         FieldPath.active("main", "freq_mode", "freq_hz")
     ).freshness_ttl_seconds
     assert fast_tier_ttl == acquisition.default_policy.freshness_ttl_seconds
-    assert fast_tier_ttl < 5.0
+    assert fast_tier_ttl < 25.0
+
+    # MOR-1452 (review fix): pin the actual serial-lane arithmetic, not just
+    # the cadence numbers, so a future "just speed this field up a bit" edit
+    # cannot silently blow the shared IC-7300 serial budget again. The
+    # software floor is one CI-V frame per _SERIAL_DEFAULT_CIV_MIN_INTERVAL_MS
+    # (50ms => 20 transactions/s), shared by every poll, every operator
+    # command, AND the keep-alive — polling demand alone must leave headroom
+    # under that ceiling, not just avoid exceeding it exactly.
+    from rigplane.backends._icom_serial_base import (
+        _SERIAL_DEFAULT_CIV_MIN_INTERVAL_MS,
+    )
+
+    serial_ceiling_hz = 1000.0 / _SERIAL_DEFAULT_CIV_MIN_INTERVAL_MS
+    assert serial_ceiling_hz == 20.0
+    total_poll_demand_hz = sum(
+        1.0 / acquisition.policy_for(path).cadence_seconds
+        for path in acquisition.pollable_paths()
+    )
+    assert total_poll_demand_hz == pytest.approx(19.933, abs=0.001)
+    assert total_poll_demand_hz < serial_ceiling_hz
 
     assert (
         acquisition.capability_for(


### PR DESCRIPTION
## Summary

Two independent legs on the TX-aux panel, per MOR-1452.

- **Leg 1 (frontend, presentation):** `TxAuxSurface` mixed two display conventions — RF power (0..1 domain) already read back as a percent via `formatKnownLevel`'s `[0,1]`-only sniff (#2390/MOR-1447), while COMP level, mic gain, VOX gain, anti-VOX, and monitor level (all 0..255 domains) still rendered the raw wire integer. Adopted `DspSurface`'s established per-field `displayFn` idiom instead of extending `formatKnownLevel`'s domain sniff (per the ticket's own steer, since a per-field declaration composes cleanly with the existing `rawToPercentDisplay` helper for any domain shape, not just `[0,1]`). `TX_AUX_LEVELS` now carries a 6th tuple element — a format function built from `rawToPercentDisplay(v, min, max)` against each field's own declared domain. Every level slider now reads back as a percent of its own domain. Display only — the raw wire value passed to `onLevelChange` is unchanged.
- **Leg 2 (backend, poll coverage):** Mic gain, VOX gain, anti-VOX, and monitor level showed a permanent, honest `"?"` on the IC-7300 because the state poller never queried them — `docs/validation/cat-audits/ic7300.md` confirms all four are real, documented §19 sub-commands (CI-V `0x14 0x0B/0x15/0x16/0x17`) with existing `get_/set_` backend methods and `RadioState` fields already wired end to end. Added the 4 field paths to `rigs/ic7300.toml`'s `[state_acquisition.capabilities] polling_only` list — TOML-only, zero Python changes, since the CI-V query mapping (`_GLOBAL_LEVEL_QUERY_SUBS` in `acquisition_scheduler.py`) is already provider-generic and IC-7610-proven. **VOX delay stays honestly `"?"`** — see Deviations below.

> **Updated after independent review (see "Review fixes" below):** the field_policies cadence for the 4 new fields is **15.0s/25.0s**, not the IC-7610-matching 3.0s/5.0s this PR started with — IC-7610 is LAN, IC-7300 is serial and shares a hard ~20 transactions/s software floor across every poll, operator command, and the keep-alive; 3.0s would have pushed total poll demand from 19.667 q/s to 21.0 q/s, over the ceiling. VOX delay's display convention also changed from percent to seconds (a duration, not a level fraction).

## Per-leg design

**Leg 1** — `frontend/src/semantic/TxAuxSurface.svelte`
- `TX_AUX_LEVELS` (lines 44–55 pre-change): 5-tuple `[field, label, min, max, step]` → now 6-tuple with a `format` function per field.
- `levelTextOf` (was line 76–77): now takes `format: (v: number) => string` instead of `min`/`max`, calling `format(value)` on a known reading.
- Template loop (line ~155/172): destructures `format` from the tuple and passes it to `levelTextOf`.
- Import swapped: `formatKnownLevel` (from `./format-level`) → `rawToPercentDisplay` (from `../components-v2/controls/value-control/value-control-core`), the same helper `DspSurface` and the legacy `TxPanel`/`VoxPanel`/`DspPanel` already use for raw-level percent display.
- `RfFrontEndSurface.svelte` (unrelated panel, still uses `formatKnownLevel`) is untouched.

**Leg 2** — `rigs/ic7300.toml`
- Added `global.operator_controls.{mic_gain,monitor_gain,vox_gain,anti_vox_gain}` to `[state_acquisition.capabilities] polling_only`.
- Added a `[state_acquisition.field_policies."global.operator_controls.X"]` block per field: `cadence_seconds = 15.0`, `freshness_ttl_seconds = 25.0`, `adaptive_decay = false`.
- No Python changes: `acquisition_scheduler.py`'s `_GLOBAL_LEVEL_QUERY_SUBS` dict already maps `mic_gain→0x0B`, `monitor_gain→0x15`, `vox_gain→0x16`, `anti_vox_gain→0x17` under CI-V `0x14`, and is provider-neutral (already exercised by IC-7610).

## Review fixes (pushed as a second commit, `63638bee`)

An independent review of the first commit (`dd6bc4c9`) found two required fixes and one fold-in, all addressed:

1. **Serial cadence budget.** IC-7300 is USB/serial, not LAN like IC-7610 — every poll, every operator command, and the keep-alive share one software floor, `_SERIAL_DEFAULT_CIV_MIN_INTERVAL_MS = 50ms` (`src/rigplane/backends/_icom_serial_base.py`), i.e. a hard **20 transactions/s** ceiling on the whole CI-V link. Copying IC-7610's 3.0s cadence for the 4 new fields would have added `4 / 3.0 = 1.333 q/s` on top of this profile's pre-existing `19.667 q/s` demand (freq/mode/keep-alive/af/rf/squelch/att/preamp/agc/nb/nr/power/compressor/ptt/tuner/split, each contributing `1/cadence`) — **21.0 q/s, 105% of the ceiling**, which would degrade cadence on every polled field including PTT (0.3s) and freq/mode (1.5s), not just the 4 new ones. **Fixed to `cadence_seconds = 15.0` / `freshness_ttl_seconds = 25.0`** for real headroom: `4 / 15.0 = 0.267 q/s` → **19.933 q/s total (99.67%)**, comfortably under 20.0. A live bench measurement at the gate may justify tightening this later — noted as a bench follow-up item, not done here. `tests/test_state_acquisition_policy.py` now pins the actual arithmetic (`sum(1/cadence for every pollable path) == pytest.approx(19.933) < 20.0`), not just the raw cadence numbers, so a future "speed this field up a bit" edit can't silently blow the budget again.
2. **VOX delay's unit.** VOX delay's raw wire value is 0.1s steps (`20` ⇒ 2.0s) — a duration, not a level fraction. The initial percent convention rendered it as `"100%"`, which is technically consistent with the other sliders but operationally meaningless (hides the actual 2.0s truth behind a number with no unit). Gave it its own seconds formatter, mirroring `VoxPanel.svelte`'s existing `delayDisplay: ${(raw * 0.1).toFixed(1)}s` precedent for this exact field — `TxAuxSurface` now renders it as `"2.0s"`.
3. **Format-domain coupling (fold-in).** The first commit's `format: rawToPercentDisplay` — a bare function reference used directly as a tuple's 6th element — silently reads `rawToPercentDisplay`'s OWN default parameters (`min = 0, max = 255`) instead of the field's actually-declared `[min, max]` from earlier in that same tuple row. This was invisible because every affected field happens to declare exactly `0..255` (matching the default), but a future field with a different domain would render silently wrong. Fixed: the default percent format is now built at `levelTextOf`'s call site from the SAME `min`/`max` variables the template destructures for that row's `<input min max>` — mechanically tied to the declared domain, not a coincidence. `TX_AUX_LEVELS` rows are now uniformly 6-tuples (`format` is `undefined` where there's no override) rather than a mix of bare references and closures. Added a source-pattern regression test (`TxAuxSurface.test.ts`) that fails if a bare `rawToPercentDisplay` reference reappears in the tuple.

## Fields that became observed (CAT-audit citations)

Per `docs/validation/cat-audits/ic7300.md` command matrix:

| Field | CI-V | Backend | Status after this PR |
|---|---|---|---|
| Mic gain | `14 0B` | `get_/set_mic_gain` (`runtime/radio.py:2734/2743`) | now polled (slow tier) |
| Monitor level | `14 15` | `get_/set_monitor_gain` (`runtime/radio.py:2873/2882`) | now polled (slow tier) |
| VOX gain | `14 16` | `get_/set_vox_gain` (`runtime/radio.py:2888/2897`) | now polled (slow tier) |
| Anti-VOX | `14 17` | `get_/set_anti_vox_gain` (`runtime/radio.py:2901/2910`) | now polled (slow tier) |
| VOX delay | `1A 05 0191` | `get_/set_vox_delay` (`runtime/radio.py:2978/2989`) | **stays `"?"`** — see Deviations |
| RF power, COMP level | `14 0A`, `14 0E` | already polled pre-PR | display convention only fixed (Leg 1) |

## Deviations / split

- **VOX delay was NOT added to the poll tier.** It reads via a different CI-V shape — a `0x1A 0x05` ctl-mem register (`0x01 0x91` on IC-7300, vs. IC-7610's `0x02 0x92`), not the `0x14` sub-command family the other 4 fields share. The acquisition scheduler's `query_for_path`/`AcquisitionQuerySender` has no case for register-selector reads at all (only the `0x14` family + one hardcoded `0x1C 0x01` non-level query), and `runtime/_civ_rx.py`'s `_CMD1A_CTL_MEM_LEVEL_FIELDS` RX table has no entry for IC-7300's specific register — this is a pre-existing gap shared with IC-7610 (which doesn't poll `vox_delay` either), not an IC-7300-specific regression. Fixing it means extending the scheduler's query-sender signature and the RX-parsing table — a cross-cutting change to shared `core/`/`runtime/` code that risks scope creep well beyond a single-field fix and doesn't fit this ticket's guardrails. Left honestly `"?"` per the ticket's own instruction ("truly unreadable fields stay honestly `?`"); worth a small dedicated follow-up ticket.
- **Conformance fixture (`frontend/.../fixtures/ic7300-state.json`/`ic7300-capabilities.json`) was NOT recaptured — explicitly waived to a bench-access follow-up ticket, not silently skipped.** These are byte-faithful captures from the live IC-7300 bench (`node scripts/capture-profile.mjs http://<bench-host> ic7300`), and this agent has no access to that hardware. The pinned "honest refusals" assertion in `mor1428-ic7300-conformance.isolated.test.ts` (`micGain` unobserved) still passes because it's fixture-driven and the fixture is untouched — it will go stale (in the good direction) once someone with bench access re-runs the capture script and commits the refreshed pair. Backend correctness for the newly-polled fields is instead pinned at the acquisition-policy layer (`tests/test_state_acquisition_policy.py`), which doesn't need live hardware and exercises the exact same provider-generic query mechanism IC-7610 already proves works on real hardware.
- Both legs together are within their own files and well under the 200-LOC/leg cap, so no split was needed.

## Context (no action needed)

- The quick-CI run on an earlier head showed a red `test_serial_link_down_detected...` — an unrelated xdist wall-clock flake (being ticketed separately), not caused by this diff.

## Files

- `frontend/src/semantic/TxAuxSurface.svelte` (Leg 1, production)
- `frontend/src/semantic/__tests__/TxAuxSurface.test.ts` (Leg 1, tests)
- `rigs/ic7300.toml` (Leg 2, production/config)
- `tests/test_state_acquisition_policy.py` (Leg 2, tests)

## LOC (net production, final head, `git diff --numstat` per file)

- `frontend/src/semantic/TxAuxSurface.svelte`: +46/-26 across both commits → **+20 net** (Leg 1 + fold-in fix + VOX-delay-unit fix)
- `rigs/ic7300.toml`: +21/-12 across both commits → **+9 net over the original +34/-0** (cadence numbers changed, no field additions/removals) — i.e. still **+34 lines of new TOML total**, just at the corrected cadence
- Test files (`TxAuxSurface.test.ts`, `test_state_acquisition_policy.py`) carry the rest of the diff — not counted against the production LOC cap.
- Both legs remain well under the 200-LOC/leg production cap.

## Tests (final head `63638bee`)

**Local (worktree):**
- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` → **9040 passed, 12 skipped, 5 deselected, 11 xfailed, 1 xpassed** (0 failures)
- `uv run ruff check src/ tests/` → all checks passed
- `uv run ruff format --check src/ tests/` → 654 files already formatted
- `uv run mypy src/` → 13 errors in 4 files (matches documented pre-existing baseline exactly, no new errors)
- `uv run lint-imports` → 5 contracts kept, 0 broken
- `cd frontend && npx vitest run src/semantic/__tests__/TxAuxSurface.test.ts` → **99 passed** (readout-formatting cases + the new VOX-delay-seconds test + the format-domain-coupling regression test)
- `cd frontend && npx eslint src/semantic/TxAuxSurface.svelte src/semantic/__tests__/TxAuxSurface.test.ts` → clean
- `cd frontend && npm run check` → 4538 files, 0 errors, 0 warnings

**Remote testbed (full suites, per-repo policy):**
- `py`: 9040 passed, 0 failed; `ruff check` clean → **PASS**
- `fe`: 323/323 files, **6722/6722 tests** passed; `eslint` clean; `svelte-check` 0 errors/0 warnings → **PASS** (the 1 flaky test seen in an earlier local-only full-suite run, `fixture-capture-root-cwd.test.ts`, passed clean here — confirms it was a local environment artifact, not a real regression)

## Branch / commit

- Branch: `codex/MOR-1452-txaux-scales-polls`
- Head SHA: `63638bee9c41c1cbd560930f68fcf4bc2dc6b8d9`
- 3 commits: 2 per-leg (`dd6bc4c9`, and the frontend leg before it) + 1 review-fix commit (`63638bee`), each `fix: ... (MOR-1452)`

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
