### PR TITLE
fix: disable auto-step on companion tuning-step override (MOR-1442)

### DIFF
--- a/frontend/src/lib/stores/__tests__/tuning.isolated.test.ts
+++ b/frontend/src/lib/stores/__tests__/tuning.isolated.test.ts
@@ -1,0 +1,100 @@
+/**
+ * MOR-1442 — regression coverage for the tuning-STEP store.
+ *
+ * Reported symptom: during a live walkthrough, the tuning STEP control
+ * (STEP arrows in SpectrumToolbar.svelte, backed by
+ * `$lib/stores/tuning.svelte`) spontaneously changed value (5kHz -> 1kHz)
+ * while the operator was interacting with the spectrum/waterfall, with no
+ * click on the STEP control itself.
+ *
+ * Root cause: `setTuningStepFromCompanion` (the RC-28 hardware companion's
+ * step sync, wired from `ws-client.ts`'s `companion_state` handler) updated
+ * `_step` WITHOUT disabling `_autoStep` — unlike the browser's own STEP
+ * control (`setTuningStep`), which always disables auto-step on a manual
+ * override. Because auto-step stayed on, the very next radio-reported mode
+ * change replayed `applyModeDefault(mode)` — wired as a `$effect` on
+ * `activeMode` in both RadioLayout.svelte and LcdLayout.svelte, firing on
+ * ANY mode update pushed from the backend, including a radio's own
+ * band-stack-register mode recall while the operator jump-tunes across the
+ * waterfall via SpectrumPanel.svelte's `handleTune` click-to-tune — and
+ * silently discarded the companion-set step back to the per-mode default.
+ * No control in the browser session was ever clicked.
+ *
+ * This file exercises the real store module (not a mock, unlike every
+ * other test that touches `$lib/stores/tuning.svelte`) so the actual
+ * interaction between the companion path and the mode-driven auto-step
+ * path is under test, not stubbed away. `applyModeDefault` and
+ * `setTuningStepFromCompanion` are the exact functions the real wiring
+ * calls (RadioLayout.svelte:220 / LcdLayout.svelte:49, and
+ * ws-client.ts:815 respectively) — calling them directly here is
+ * equivalent to driving the bug through the actual component effects,
+ * without the overhead of mounting them.
+ */
+
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+let tuning: typeof import('../tuning.svelte');
+
+beforeAll(async () => {
+  // Stub fetch before the module's first evaluation: `tuning.svelte.ts`
+  // fires a `_syncToCompanion` PUT at module top level and on every
+  // `_persistState()` call. A dynamic import inside `beforeAll` (after the
+  // stub is installed) guarantees this runs before that top-level call —
+  // a plain top-of-file static import would NOT, since static imports are
+  // always evaluated before any of this file's own statements.
+  vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true } as Response)));
+  tuning = await import('../tuning.svelte');
+});
+
+describe('tuning step store — companion override vs. mode-driven auto-step (MOR-1442)', () => {
+  beforeEach(() => {
+    // Deterministic starting point for every test, independent of
+    // execution order within this file: a real STEP-control click always
+    // lands on a known value and always disables auto-step, so this is a
+    // legitimate way to reset both `_step` and `_autoStep` without an
+    // exported test-only reset hook. `radio.current` is null in this
+    // environment, so re-enabling auto-step here does not itself touch
+    // `_step` (see `setAutoStep`'s mode lookup guard).
+    tuning.setTuningStep(1_000);
+    tuning.setAutoStep(true);
+  });
+
+  it('bug repro: a companion-set step must survive a later mode change', () => {
+    tuning.setTuningStepFromCompanion(5_000);
+    expect(tuning.getTuningStep()).toBe(5_000);
+
+    // The mode-driven auto-step effect, as wired in RadioLayout.svelte and
+    // LcdLayout.svelte, fires on every radio-reported mode change.
+    tuning.applyModeDefault('USB');
+
+    expect(tuning.getTuningStep()).toBe(5_000);
+  });
+
+  it('a companion step change disables auto-step, matching the browser STEP control', () => {
+    expect(tuning.isAutoStep()).toBe(true);
+    tuning.setTuningStepFromCompanion(5_000);
+    expect(tuning.isAutoStep()).toBe(false);
+  });
+
+  it('control case: the browser STEP control already protected itself from this', () => {
+    tuning.setTuningStep(5_000);
+    expect(tuning.isAutoStep()).toBe(false);
+    tuning.applyModeDefault('USB');
+    expect(tuning.getTuningStep()).toBe(5_000);
+  });
+
+  it('auto-step still tracks mode when the operator never overrode the step at all', () => {
+    expect(tuning.isAutoStep()).toBe(true);
+    tuning.applyModeDefault('CW');
+    expect(tuning.getTuningStep()).toBe(10);
+    tuning.applyModeDefault('USB');
+    expect(tuning.getTuningStep()).toBe(1_000);
+  });
+
+  it('a companion echo matching the already-current step is a no-op, no spurious auto-step disable', () => {
+    expect(tuning.isAutoStep()).toBe(true);
+    tuning.setTuningStepFromCompanion(1_000); // matches the beforeEach baseline exactly
+    expect(tuning.getTuningStep()).toBe(1_000);
+    expect(tuning.isAutoStep()).toBe(true);
+  });
+});

--- a/frontend/src/lib/stores/tuning.svelte.ts
+++ b/frontend/src/lib/stores/tuning.svelte.ts
@@ -82,7 +82,19 @@ export function setTuningStep(hz: number): void {
   _persistState();
 }
 
-/** Update step from companion (RC-28) without affecting auto-step preference. */
+/**
+ * Update step from a companion device (RC-28).
+ *
+ * MOR-1442: a companion step change is a real operator action on a
+ * step-labeled control — just a physical one, external to the browser —
+ * so it must disable auto-step exactly like the browser's own STEP
+ * control (`setTuningStep`) does. Previously this left `_autoStep` on,
+ * so the very next radio-reported mode change (e.g. the radio's own
+ * band-stack-register mode recall while jump-tuning across the
+ * waterfall) replayed `applyModeDefault()` and silently discarded the
+ * companion-set step back to the per-mode default, with no action on
+ * any control in the browser session at all.
+ */
 export function setTuningStepFromCompanion(hz: number): void {
   if (!(TUNING_STEPS as readonly number[]).includes(hz)) {
     return;
@@ -91,6 +103,7 @@ export function setTuningStepFromCompanion(hz: number): void {
     return; // no change — avoid redundant PUT back
   }
   _step = hz;
+  _autoStep = false; // manual override (via companion) disables auto, same as setTuningStep
   _persistState();
 }
 


### PR DESCRIPTION
## Summary

**Status update after independent review**: this PR closes a real, code-audited invariant hole in the tuning-step store, but that hole is very unlikely to have been the mechanism the walkthrough actually hit. A more likely live trigger has been identified (below) and is unverified. **MOR-1442 stays OPEN** pending bench reproduction; this PR is a correct, narrower fix landed along the way, not a claimed closure of the ticket.

## What this PR fixes: an invariant hole found by code audit

`setTuningStepFromCompanion` (`frontend/src/lib/stores/tuning.svelte.ts:86-95`) is the RC-28 hardware companion's step-sync path, consumed from `companion_state` WS messages in `frontend/src/lib/transport/ws-client.ts:810-817`. It updated `_step` **without disabling `_autoStep`** — the only one of the store's four `_step`-writing paths that didn't. Every other path (`setTuningStep`, `setAutoStep`, `applyModeDefault`) is internally consistent about that flag. Left as-is, a companion-set step could be silently discarded by a later `applyModeDefault(mode)` call (wired as a `$effect` on `activeMode` in both `RadioLayout.svelte:218-222` and `LcdLayout.svelte:47-50`, firing on any backend-pushed mode change) — with no action on any control in the browser session.

**Important caveat (downgraded from the original PR description):** `companion_state` has **zero producers anywhere in rigplane-core** — repo-wide grep finds only the WS message-type union (`frontend/src/lib/types/protocol.ts`), the consumer in `ws-client.ts`, and one `docs/CHANGELOG.md` line. The RC-28 companion itself is Pro-side. Unless RigPlane Pro *and* a physical RC-28 were attached to the walkthrough bench (**unverified**), this code path could not have fired during that session at all. The original PR framed this as "the root cause of MOR-1442" — that causal claim is not supportable from what's in this repo and is withdrawn. What's accurate: this is a real invariant hole, found by auditing every `_step` writer for consistency, independent of whether it explains the walkthrough symptom.

## More likely live trigger: global ArrowUp/ArrowDown, unverified

`frontend/src/components-v2/layout/keyboard-map.ts:28-43` binds `ArrowUp` -> `adjust_tuning_step` (`direction: 'up'`) and `ArrowDown` -> `adjust_tuning_step` (`direction: 'down'`) as **global, unscoped** keyboard shortcuts. They're wired via `<svelte:window onkeydown={handleKeydown} .../>` in `frontend/src/components-v2/layout/KeyboardHandler.svelte:177`, guarded only by `shouldIgnoreEvent(document.activeElement)` (which excludes text-input focus, not "no focus" / focus on a non-editable element such as the spectrum canvas) and `event.preventDefault()` (which also suppresses the browser's native arrow-key page scroll).

`TUNING_STEPS = [10, 50, 100, 250, 500, 1000, 5000, 10000, 25000, 100000]` — 5000 sits at index 6, and `adjustTuningStep('down')` moves to index 5 = **1000**. A single ArrowDown press while the spectrum/waterfall panel has page focus (no input focused) reproduces the exact reported transition, through a fully reachable, already-wired path, with no companion or Pro dependency.

This is named here as the more likely mechanism, **to be confirmed or refuted on the bench** (see Status below) — not asserted as proven.

## Design ruling requested (owner decision at the gate)

Independent of which mechanism actually fired, the mode-driven `applyModeDefault` auto-step reset is *designed* behavior (`MODE_DEFAULTS` table + code comment "auto-select step based on mode" in `tuning.svelte.ts`) whose entire communication to the operator is:

- A 9px, unlabeled `"A"` glyph (`frontend/src/components/spectrum/SpectrumToolbar.svelte:234`, `.auto-badge { font-size: 9px; }` at line 570-574) — no `aria-label`, no title/tooltip.
- **Absent entirely on the amber-lcd skin**: `LcdLayout.svelte` imports and calls `applyModeDefault` (line 18, 49) — the reset logic is fully wired there — but never renders `SpectrumToolbar`, so that skin has zero visible indicator that auto-step exists or ever fires.
- No transient announcement when a reset actually happens (the STEP value just silently changes).
- **No UI path to re-enable auto-step once disabled**: `setAutoStep` is exported but has no caller anywhere in the app besides the store module itself and tests — it's effectively write-once, off-forever from the operator's perspective. This PR's own fix compounds that: an RC-28 companion step turn now also permanently disables auto-step, with no way back short of clearing `localStorage`.

This needs an explicit owner ruling at the gate: is the current (pre- and post-this-PR) legibility of mode-driven auto-step acceptable, or does it need a bounded child ticket (visible announcement on reset, a real re-enable affordance, and/or an amber-lcd indicator)?

## Status

- **This PR**: closes the companion-override-vs-auto-step invariant hole described above. Verified correct and minimal by independent review (3/3 mutation kills, full suite green). No code change from that review round; head SHA is unchanged.
- **MOR-1442 itself stays OPEN.** The walkthrough symptom is not confirmed to be explained by this fix. Next step is a bench reproduction attempt: retune across a band edge via waterfall click-to-tune (a) with the ArrowUp/Down keys never touched and no companion attached, and (b) deliberately pressing ArrowDown while the spectrum panel has focus, to determine which (if either) mechanism the operator actually hit.

## Recorded follow-ups (not fixed in this PR — out of scope)

- `adjustTuningStep`'s `idx < 0` branch (`tuning.svelte.ts`, the "step value isn't a known step" fallback) writes `_step = DEFAULT_STEP` without disabling `_autoStep`, the same class of inconsistency this PR fixes for the companion path. Currently unreachable — every `_step` writer constrains values to `TUNING_STEPS` members — but worth closing for defense-in-depth if this store is touched again.
- `frontend/src/components-v2/layout/MobileRadioLayout.svelte` keeps a fully separate, private `tuningStep` local `$state` (line 184) with its own mode-driven reset effect (line 187-192), entirely independent of the shared `$lib/stores/tuning.svelte` store this PR touches. Worth a follow-up to decide whether that divergence is intentional or should be reconciled.

## Files changed (2)

- `frontend/src/lib/stores/tuning.svelte.ts` — production fix (+14/-1 net)
- `frontend/src/lib/stores/__tests__/tuning.isolated.test.ts` — new regression test file (100 LOC)

## Test plan

- [x] `npx vitest run src/lib/stores/__tests__/tuning.isolated.test.ts` — RED confirmed pre-fix (`expected 1000 to be 5000`), GREEN post-fix
- [x] `npx vitest run` (full frontend suite) — 325 files / 6747 tests passed, zero failures, no flake hit
- [x] `npx eslint .` — 0 errors (3 pre-existing unrelated warnings in `fixtures/capture.mjs`)
- [x] `npm run check` (svelte-check + tsc) — 0 errors, 0 warnings

Linear: MOR-1442

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
