### PR TITLE
fix: operator-legible TX readiness wording (MOR-1448)

### DIFF
--- a/frontend/src/components-v2/wiring/__tests__/semantic-band-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-band-wiring.component.test.ts
@@ -24,6 +24,7 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
+import { t } from '$lib/i18n';
 import type { Capabilities } from '$lib/types/capabilities';
 import type { ServerState } from '$lib/types/state';
 
@@ -475,6 +476,16 @@ describe('a split TX target surfaces the caveat, end to end (fix-round F1)', () 
     render();
     expect(el('tx-value')!.textContent!.trim()).toBe('allowed');
     expect(el('tx-caveat')).not.toBeNull();
-    expect(el('tx-caveat')!.textContent).toContain('denied');
+    // MOR-1448 review F2/F4: pinned to the FULL rendered caveat text, end to
+    // end through the real adapter, not a loose substring. The old
+    // `.toContain('denied')` check would have kept passing even if the
+    // sentence itself regressed to contract-speak or a raw-enum interpolation
+    // — the composed text below is the actual honest-wording contract:
+    // `out-of-band` names the TRANSMIT frequency (SUB's 7.250, not the
+    // displayed MAIN/20m frequency) as the thing that's out of range, and
+    // the caveat states plainly that transmitting there is not allowed.
+    expect(el('tx-caveat')!.textContent).toBe(t('core.band.tx.caveat.denied', {
+      reason: t('core.band.tx.reason.outOfBand'),
+    }));
   });
 });

--- a/frontend/src/lib/i18n/locales/en-US.json
+++ b/frontend/src/lib/i18n/locales/en-US.json
@@ -214,12 +214,13 @@
   "core.vfo.splitDigest.rx": "RX {frequency}",
   "core.vfo.splitDigest.tx": "TX {frequency}",
 
-  "core.band.tx.reason.outOfBand": "this frequency is outside your configured transmit ranges — tune to a frequency inside an allowed band to transmit here",
-  "core.band.tx.reason.targetUnknown": "the transmit frequency has not been read from the radio yet — press PTT or select a VFO to set it",
+  "core.band.tx.reason.outOfBand": "your transmit frequency is outside the configured transmit ranges — tune the transmitting VFO into an allowed band",
+  "core.band.tx.reason.targetUnknown": "this radio has not reported which VFO transmits, so the transmit frequency cannot be confirmed",
   "core.band.tx.reason.rangesNotConfigured": "no transmit ranges are configured for this radio, so permission cannot be checked here",
-  "core.band.tx.reason.bandUnresolved": "the current band could not be determined from the frequency read from the radio",
+  "core.band.tx.reason.bandUnresolved": "the current band could not be determined",
   "core.band.tx.reason.receiverUnconfirmed": "the active receiver has not been confirmed yet — select a receiver to continue",
-  "core.band.tx.caveat": "TX is allowed on this frequency, but your actual transmit frequency is {status}: {reason}",
+  "core.band.tx.caveat.denied": "TX is allowed on this frequency, but transmitting at your actual frequency is not allowed: {reason}",
+  "core.band.tx.caveat.unknown": "TX is allowed on this frequency, but your actual transmit frequency is unconfirmed: {reason}",
 
   "core.disabledReason.missing": "Not supported by this radio",
   "core.disabledReason.unobserved": "Not yet observed",

--- a/frontend/src/lib/i18n/locales/en-US.json
+++ b/frontend/src/lib/i18n/locales/en-US.json
@@ -214,6 +214,13 @@
   "core.vfo.splitDigest.rx": "RX {frequency}",
   "core.vfo.splitDigest.tx": "TX {frequency}",
 
+  "core.band.tx.reason.outOfBand": "this frequency is outside your configured transmit ranges — tune to a frequency inside an allowed band to transmit here",
+  "core.band.tx.reason.targetUnknown": "the transmit frequency has not been read from the radio yet — press PTT or select a VFO to set it",
+  "core.band.tx.reason.rangesNotConfigured": "no transmit ranges are configured for this radio, so permission cannot be checked here",
+  "core.band.tx.reason.bandUnresolved": "the current band could not be determined from the frequency read from the radio",
+  "core.band.tx.reason.receiverUnconfirmed": "the active receiver has not been confirmed yet — select a receiver to continue",
+  "core.band.tx.caveat": "TX is allowed on this frequency, but your actual transmit frequency is {status}: {reason}",
+
   "core.disabledReason.missing": "Not supported by this radio",
   "core.disabledReason.unobserved": "Not yet observed",
 

--- a/frontend/src/lib/i18n/locales/en-US.json
+++ b/frontend/src/lib/i18n/locales/en-US.json
@@ -215,7 +215,7 @@
   "core.vfo.splitDigest.tx": "TX {frequency}",
 
   "core.band.tx.reason.outOfBand": "your transmit frequency is outside the configured transmit ranges — tune the transmitting VFO into an allowed band",
-  "core.band.tx.reason.targetUnknown": "this radio has not reported which VFO transmits, so the transmit frequency cannot be confirmed",
+  "core.band.tx.reason.targetUnknown": "the radio has not confirmed the frequency it would transmit on",
   "core.band.tx.reason.rangesNotConfigured": "no transmit ranges are configured for this radio, so permission cannot be checked here",
   "core.band.tx.reason.bandUnresolved": "the current band could not be determined",
   "core.band.tx.reason.receiverUnconfirmed": "the active receiver has not been confirmed yet — select a receiver to continue",

--- a/frontend/src/lib/i18n/locales/ru-RU.json
+++ b/frontend/src/lib/i18n/locales/ru-RU.json
@@ -194,12 +194,13 @@
   "core.vfo.splitDigest.rx": "RX {frequency}",
   "core.vfo.splitDigest.tx": "TX {frequency}",
 
-  "core.band.tx.reason.outOfBand": "эта частота вне ваших настроенных диапазонов передачи — перейдите на частоту внутри разрешённого диапазона, чтобы передавать здесь",
-  "core.band.tx.reason.targetUnknown": "частота передатчика ещё не считана с радио — нажмите PTT или выберите VFO, чтобы она установилась",
+  "core.band.tx.reason.outOfBand": "ваша частота передачи вне настроенных диапазонов передачи — переведите передающий VFO в разрешённый диапазон",
+  "core.band.tx.reason.targetUnknown": "это радио не сообщает, какой VFO передаёт, поэтому частота передачи не может быть подтверждена",
   "core.band.tx.reason.rangesNotConfigured": "для этого радио не настроены диапазоны передачи, поэтому проверить разрешение здесь нельзя",
-  "core.band.tx.reason.bandUnresolved": "текущий диапазон не удалось определить по частоте, считанной с радио",
+  "core.band.tx.reason.bandUnresolved": "текущий диапазон не удалось определить",
   "core.band.tx.reason.receiverUnconfirmed": "активный приёмник ещё не подтверждён — выберите приёмник, чтобы продолжить",
-  "core.band.tx.caveat": "TX разрешён на этой частоте, но ваша фактическая частота передачи — {status}: {reason}",
+  "core.band.tx.caveat.denied": "TX разрешён на этой частоте, но передача на вашей фактической частоте не разрешена: {reason}",
+  "core.band.tx.caveat.unknown": "TX разрешён на этой частоте, но ваша фактическая частота передачи не подтверждена: {reason}",
 
   "core.disabledReason.missing": "Не поддерживается этим трансивером",
   "core.disabledReason.unobserved": "Ещё не считано",

--- a/frontend/src/lib/i18n/locales/ru-RU.json
+++ b/frontend/src/lib/i18n/locales/ru-RU.json
@@ -195,7 +195,7 @@
   "core.vfo.splitDigest.tx": "TX {frequency}",
 
   "core.band.tx.reason.outOfBand": "ваша частота передачи вне настроенных диапазонов передачи — переведите передающий VFO в разрешённый диапазон",
-  "core.band.tx.reason.targetUnknown": "это радио не сообщает, какой VFO передаёт, поэтому частота передачи не может быть подтверждена",
+  "core.band.tx.reason.targetUnknown": "радио не подтвердило частоту, на которой оно будет передавать",
   "core.band.tx.reason.rangesNotConfigured": "для этого радио не настроены диапазоны передачи, поэтому проверить разрешение здесь нельзя",
   "core.band.tx.reason.bandUnresolved": "текущий диапазон не удалось определить",
   "core.band.tx.reason.receiverUnconfirmed": "активный приёмник ещё не подтверждён — выберите приёмник, чтобы продолжить",

--- a/frontend/src/lib/i18n/locales/ru-RU.json
+++ b/frontend/src/lib/i18n/locales/ru-RU.json
@@ -194,6 +194,13 @@
   "core.vfo.splitDigest.rx": "RX {frequency}",
   "core.vfo.splitDigest.tx": "TX {frequency}",
 
+  "core.band.tx.reason.outOfBand": "эта частота вне ваших настроенных диапазонов передачи — перейдите на частоту внутри разрешённого диапазона, чтобы передавать здесь",
+  "core.band.tx.reason.targetUnknown": "частота передатчика ещё не считана с радио — нажмите PTT или выберите VFO, чтобы она установилась",
+  "core.band.tx.reason.rangesNotConfigured": "для этого радио не настроены диапазоны передачи, поэтому проверить разрешение здесь нельзя",
+  "core.band.tx.reason.bandUnresolved": "текущий диапазон не удалось определить по частоте, считанной с радио",
+  "core.band.tx.reason.receiverUnconfirmed": "активный приёмник ещё не подтверждён — выберите приёмник, чтобы продолжить",
+  "core.band.tx.caveat": "TX разрешён на этой частоте, но ваша фактическая частота передачи — {status}: {reason}",
+
   "core.disabledReason.missing": "Не поддерживается этим трансивером",
   "core.disabledReason.unobserved": "Ещё не считано",
 

--- a/frontend/src/semantic/BandSurface.svelte
+++ b/frontend/src/semantic/BandSurface.svelte
@@ -76,11 +76,15 @@
     'capability-unavailable': 'core.band.tx.reason.rangesNotConfigured',
   };
   /** Resolves a `TX_REASON_CODES` entry to its operator-legible sentence in
-   *  the active locale. An unrecognised code (should not happen —
-   *  `TX_REASON_CODES` is the only caller) fails closed to `UNKNOWN_TEXT`
-   *  rather than surfacing the raw code. */
+   *  the active locale. MOR-1448 review F5: `Object.hasOwn`, not the `in`
+   *  operator — `in` also matches inherited `Object.prototype` keys (e.g. a
+   *  code of `'toString'` or `'constructor'`), which would then resolve
+   *  `REASON_KEY[code]` to an inherited FUNCTION rather than undefined and
+   *  hand `t()` a non-string key instead of failing closed. `hasOwn` makes
+   *  "unrecognised code" mean exactly "no OWN entry", so it reliably falls
+   *  through to `UNKNOWN_TEXT` rather than surfacing garbage. */
   export const reasonLabel = (code: DisabledReasonCode | string): string =>
-    code in REASON_KEY ? t(REASON_KEY[code]) : UNKNOWN_TEXT;
+    Object.hasOwn(REASON_KEY, code) ? t(REASON_KEY[code]) : UNKNOWN_TEXT;
   /** The denial's words when no code explains it: `txPermit` says the TX
    *  TARGET may key, so what is missing is the band-scoped resolution itself
    *  (unobserved live frequency, or a frequency in no band of the plan). */
@@ -189,16 +193,22 @@
    * MOR-1448: the fix-round F1 caveat as ONE operator-legible sentence,
    * replacing the old `TX target {status}: {reason}` contract-vocabulary
    * concatenation (raw field/code words leaking straight into the operator
-   * UI). Still states the true tri-state `status` word verbatim (rule 1 —
-   * the verdict is never softened or hidden) and the SAME `txDeniedReason`
-   * explanation; only the sentence it is assembled into changed. Pure
-   * string assembly — no gating, dispatch, or state-machine logic touched.
+   * UI). Review round F4: the tri-state `status` is no longer interpolated
+   * as a raw English enum word into (in particular) the ru-RU sentence —
+   * that produced "частота передачи — unknown: …", an English word stranded
+   * mid-Russian-prose. Instead each non-`'allowed'` status picks its OWN
+   * catalog key, so the verdict is still stated explicitly (rule 1 — never
+   * softened or hidden) but as actual language in every locale: `denied`
+   * reads as "transmitting there is not allowed", `unknown` as "your actual
+   * transmit frequency cannot be confirmed". The `reason` half is still the
+   * SAME `txDeniedReason` explanation. Pure string assembly — no gating,
+   * dispatch, or state-machine logic touched.
    */
   export function txCaveatMessage(view: RadioViewModel): string {
-    return t('core.band.tx.caveat', {
-      status: view.txPermit.status,
-      reason: txDeniedReason(view),
-    });
+    const key = view.txPermit.status === 'denied'
+      ? 'core.band.tx.caveat.denied'
+      : 'core.band.tx.caveat.unknown';
+    return t(key, { reason: txDeniedReason(view) });
   }
 </script>
 

--- a/frontend/src/semantic/BandSurface.svelte
+++ b/frontend/src/semantic/BandSurface.svelte
@@ -51,6 +51,7 @@
   unread fact renders `UNKNOWN_TEXT`, never a fabricated 14.074 MHz.
 -->
 <script module lang="ts">
+  import { t } from '$lib/i18n';
   import type {
     BandChoice, BandField, DisabledReasonCode, RadioViewModel,
   } from './radio-view-model';
@@ -64,25 +65,37 @@
   export const TX_REASON_CODES: readonly DisabledReasonCode[] = [
     'out-of-band', 'tx-target-unknown', 'capability-unavailable',
   ];
-  export const REASON_LABEL: Record<string, string> = {
-    'out-of-band': 'live frequency is outside the configured TX ranges',
-    'tx-target-unknown': 'TX target frequency was never observed',
-    'capability-unavailable': 'TX ranges are not configured',
+  /** MOR-1448: catalog keys behind each denial-explaining code — the
+   *  operator-legible sentence, not the internal code. Kept as a lookup
+   *  table (not the rendered text itself) so `reasonLabel` resolves through
+   *  `t()` fresh on every call, staying correct across a live locale
+   *  switch instead of freezing the string at module-load time. */
+  const REASON_KEY: Record<string, string> = {
+    'out-of-band': 'core.band.tx.reason.outOfBand',
+    'tx-target-unknown': 'core.band.tx.reason.targetUnknown',
+    'capability-unavailable': 'core.band.tx.reason.rangesNotConfigured',
   };
+  /** Resolves a `TX_REASON_CODES` entry to its operator-legible sentence in
+   *  the active locale. An unrecognised code (should not happen —
+   *  `TX_REASON_CODES` is the only caller) fails closed to `UNKNOWN_TEXT`
+   *  rather than surfacing the raw code. */
+  export const reasonLabel = (code: DisabledReasonCode | string): string =>
+    code in REASON_KEY ? t(REASON_KEY[code]) : UNKNOWN_TEXT;
   /** The denial's words when no code explains it: `txPermit` says the TX
    *  TARGET may key, so what is missing is the band-scoped resolution itself
    *  (unobserved live frequency, or a frequency in no band of the plan). */
-  export const UNRESOLVED_REASON = 'current band could not be resolved';
+  export const unresolvedReason = (): string => t('core.band.tx.reason.bandUnresolved');
   /** MOR-1389: the denial's words when `deriveBand`'s MOR-1356
    *  `activeConfirmed` gate is what forced 'denied', with the current band
-   *  ITSELF resolved and rendered. `UNRESOLVED_REASON` is false in that
+   *  ITSELF resolved and rendered. `unresolvedReason` is false in that
    *  state — the band is not unresolved, the receiver serving it is
    *  unconfirmed — so it needs its own, equally honest, sentence. Named for
    *  exactly what `activeReceiver.status === 'unknown'` carries (rule (4)'s
    *  own gate): identity is unconfirmed, not "stale" or "never observed" —
    *  `seen()`'s three-part AND collapses those into one signal upstream, so
    *  claiming more than this would be a fact this file does not have. */
-  export const ACTIVE_RECEIVER_UNCONFIRMED_REASON = 'active receiver identity was not confirmed';
+  export const activeReceiverUnconfirmedReason = (): string =>
+    t('core.band.tx.reason.receiverUnconfirmed');
 
   export const usable = (f: BandField<unknown>): boolean =>
     f.availability.structural && f.availability.operational && f.reading.status === 'known';
@@ -166,10 +179,26 @@
     const hit = TX_REASON_CODES.find(
       (c) => view.disabledReasons.some((r) => r.code === c && r.field === 'txPermit'),
     );
-    if (hit !== undefined) return REASON_LABEL[hit];
+    if (hit !== undefined) return reasonLabel(hit);
     if (view.txPermit.status !== 'allowed') return UNKNOWN_TEXT;
-    if (view.activeReceiver.status === 'unknown') return ACTIVE_RECEIVER_UNCONFIRMED_REASON;
-    return UNRESOLVED_REASON;
+    if (view.activeReceiver.status === 'unknown') return activeReceiverUnconfirmedReason();
+    return unresolvedReason();
+  }
+
+  /**
+   * MOR-1448: the fix-round F1 caveat as ONE operator-legible sentence,
+   * replacing the old `TX target {status}: {reason}` contract-vocabulary
+   * concatenation (raw field/code words leaking straight into the operator
+   * UI). Still states the true tri-state `status` word verbatim (rule 1 —
+   * the verdict is never softened or hidden) and the SAME `txDeniedReason`
+   * explanation; only the sentence it is assembled into changed. Pure
+   * string assembly — no gating, dispatch, or state-machine logic touched.
+   */
+  export function txCaveatMessage(view: RadioViewModel): string {
+    return t('core.band.tx.caveat', {
+      status: view.txPermit.status,
+      reason: txDeniedReason(view),
+    });
   }
 </script>
 
@@ -289,7 +318,7 @@
              e.g. under split, or while the TX target is simply unobserved.
              That disagreement must never live only in `data-tx-permit-status`
              — a data attribute is invisible to an operator. -->
-        <span data-testid="band-tx-caveat">TX target {view.txPermit.status}: {txDeniedReason(view)}</span>
+        <span data-testid="band-tx-caveat">{txCaveatMessage(view)}</span>
       {/if}
     </p>
 

--- a/frontend/src/semantic/__tests__/BandSurface.test.ts
+++ b/frontend/src/semantic/__tests__/BandSurface.test.ts
@@ -32,9 +32,10 @@ import { readFileSync } from 'node:fs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
 import BandSurface, {
-  ACTIVE_RECEIVER_UNCONFIRMED_REASON, REASON_LABEL, UNKNOWN_TEXT, UNRESOLVED_REASON,
+  activeReceiverUnconfirmedReason, reasonLabel, UNKNOWN_TEXT, unresolvedReason,
   defaultPermitLabel, mhz,
 } from '../BandSurface.svelte';
+import { t } from '$lib/i18n';
 import { topologyFixtures, withBand } from '../fixtures/topologies';
 import type { FrequencyPermit } from '$lib/utils/tx-permit';
 import type {
@@ -105,19 +106,32 @@ function typeFrequency(input: HTMLInputElement, value: string): void {
 describe('the band surface derives nothing (7B carry-forward 1)', () => {
   // Kills: importing the permit function, the band plan, capabilities or the
   // command bus — any of which would let a second permit derivation exist.
-  it('imports nothing but the fact contract', () => {
+  // MOR-1448: `$lib/i18n` joined the fact contract as the ONE permitted
+  // import beyond `./radio-view-model` — pure operator-wording lookup
+  // (`t()`), never a second fact derivation. See the two tests below for
+  // the narrowed guard this replaces.
+  it('imports nothing but the fact contract, plus the i18n wording lookup', () => {
     const specifiers = [...CODE.matchAll(/from\s+'([^']+)'/g)].map((m) => m[1]);
     expect(specifiers.length).toBeGreaterThan(0);
-    expect([...new Set(specifiers)]).toEqual(['./radio-view-model']);
+    expect([...new Set(specifiers)]).toEqual(['$lib/i18n', './radio-view-model']);
   });
 
   it('never mentions the permit derivation, the band plan or a capability read', () => {
     for (const forbidden of [
       'getFrequencyPermit', 'getTxPermit', 'txBands', 'freqRanges', 'flattenBands',
-      'findActiveBand', 'capabilities', 'hasCap', '$lib/', 'sendCommand',
+      'findActiveBand', 'capabilities', 'hasCap', 'sendCommand',
     ]) {
       expect(CODE).not.toContain(forbidden);
     }
+  });
+
+  // MOR-1448: the blanket `$lib/` ban above narrowed to name its one
+  // exception explicitly, rather than silently dropping the guard. Any
+  // OTHER `$lib/*` import (transport, capabilities, tx-permit, command
+  // bus, ...) still fails this test.
+  it('imports no $lib module except the i18n catalog lookup', () => {
+    const libSpecifiers = [...CODE.matchAll(/from\s+'(\$lib\/[^']+)'/g)].map((m) => m[1]);
+    expect(new Set(libSpecifiers)).toEqual(new Set(['$lib/i18n']));
   });
 
   it('declares no lifecycle hook and no effect', () => {
@@ -179,9 +193,9 @@ describe('currentBandTx is the live-frequency answer (carry-forwards 1 + 2)', ()
   // Carry-forward 2: the tri-state nuance the binary collapse cannot carry is
   // taken from the TOP-LEVEL txPermit + disabledReasons, not re-derived.
   it.each([
-    ['out-of-band', REASON_LABEL['out-of-band']],
-    ['tx-target-unknown', REASON_LABEL['tx-target-unknown']],
-    ['capability-unavailable', REASON_LABEL['capability-unavailable']],
+    ['out-of-band', reasonLabel('out-of-band')],
+    ['tx-target-unknown', reasonLabel('tx-target-unknown')],
+    ['capability-unavailable', reasonLabel('capability-unavailable')],
   ])('explains a denial with the recorded %s reason', (code, label) => {
     const view = withB({ currentBandTx: 'denied' });
     const r = render({
@@ -226,7 +240,7 @@ describe('the TX-target permit caveat (fix-round F1)', () => {
     });
     expect(r.text('tx-value')).toBe('allowed');
     expect(r.el('tx-caveat')).not.toBeNull();
-    expect(r.text('tx-caveat')).toContain(REASON_LABEL['out-of-band']);
+    expect(r.text('tx-caveat')).toContain(reasonLabel('out-of-band'));
     r.dispose();
   });
 
@@ -243,7 +257,7 @@ describe('the TX-target permit caveat (fix-round F1)', () => {
     });
     expect(r.text('tx-value')).toBe('allowed');
     expect(r.el('tx-caveat')).not.toBeNull();
-    expect(r.text('tx-caveat')).toContain(REASON_LABEL['tx-target-unknown']);
+    expect(r.text('tx-caveat')).toContain(reasonLabel('tx-target-unknown'));
     r.dispose();
   });
 
@@ -258,6 +272,64 @@ describe('the TX-target permit caveat (fix-round F1)', () => {
   });
 });
 
+/* ── MOR-1448: operator-legible wording, pinned against a contract-speak
+   regression. The old strip read "TX target unknown: TX target frequency
+   was never observed" — internal field/code vocabulary leaked straight
+   into the operator UI. These tests pin (a) each readiness reason to its
+   catalog key, so the mapping — not just today's rendered text — is what
+   future edits must keep honest, and (b) that none of the old jargon
+   phrases can silently return. ──────────────────────────────────────── */
+
+describe('MOR-1448 — every TX readiness reason resolves to operator-legible copy', () => {
+  const CONTRACT_SPEAK = [
+    'was never observed', 'TX target unknown', 'TX target allowed', 'TX target denied',
+    'field:', 'fieldStatus',
+  ];
+
+  it.each([
+    ['out-of-band', 'core.band.tx.reason.outOfBand'],
+    ['tx-target-unknown', 'core.band.tx.reason.targetUnknown'],
+    ['capability-unavailable', 'core.band.tx.reason.rangesNotConfigured'],
+  ] as const)('maps disabledReasons code %s to catalog key %s', (code, key) => {
+    expect(reasonLabel(code)).toBe(t(key));
+  });
+
+  it('maps the band-unresolved fallback to its catalog key', () => {
+    expect(unresolvedReason()).toBe(t('core.band.tx.reason.bandUnresolved'));
+  });
+
+  it('maps the unconfirmed-receiver fallback to its catalog key', () => {
+    expect(activeReceiverUnconfirmedReason()).toBe(t('core.band.tx.reason.receiverUnconfirmed'));
+  });
+
+  it('assembles the rendered caveat through the core.band.tx.caveat catalog key', () => {
+    const view = withB({ currentBand: knownBand('20m'), currentBandTx: 'allowed' });
+    const r = render({
+      ...view,
+      txPermit: { status: 'unknown', reason: 'tx-target-unknown' },
+      disabledReasons: [{ field: 'txPermit', code: 'tx-target-unknown' }] as readonly DisabledReason[],
+    });
+    expect(r.text('tx-caveat')).toBe(t('core.band.tx.caveat', {
+      status: 'unknown',
+      reason: t('core.band.tx.reason.targetUnknown'),
+    }));
+    r.dispose();
+  });
+
+  it('never leaks the old field/code contract-speak into any reason or caveat string', () => {
+    const rendered = [
+      reasonLabel('out-of-band'), reasonLabel('tx-target-unknown'),
+      reasonLabel('capability-unavailable'), unresolvedReason(),
+      activeReceiverUnconfirmedReason(),
+      t('core.band.tx.caveat', { status: 'unknown', reason: reasonLabel('tx-target-unknown') }),
+      t('core.band.tx.caveat', { status: 'denied', reason: reasonLabel('out-of-band') }),
+    ];
+    for (const text of rendered) {
+      for (const phrase of CONTRACT_SPEAK) expect(text).not.toContain(phrase);
+    }
+  });
+});
+
 /* ── (c) no band-scoped disabledReason exists, by design ────────── */
 
 describe('the denial signal is the field value itself (carry-forward 3)', () => {
@@ -268,7 +340,7 @@ describe('the denial signal is the field value itself (carry-forward 3)', () => 
     const view = withB({ currentBand: knownBand('20m'), currentBandTx: 'denied' });
     const r = render({ ...view, txPermit: ALLOWED, disabledReasons: [] });
     expect(r.text('tx-value')).toBe('denied');
-    expect(r.text('tx-reason')).toBe(UNRESOLVED_REASON);
+    expect(r.text('tx-reason')).toBe(unresolvedReason());
     r.dispose();
   });
 
@@ -291,7 +363,7 @@ describe('the denial signal is the field value itself (carry-forward 3)', () => 
         { field: 'scope.audioFftScope', code: 'capability-unavailable' },
       ] as readonly DisabledReason[],
     });
-    expect(r.text('tx-reason')).toBe(UNRESOLVED_REASON);
+    expect(r.text('tx-reason')).toBe(unresolvedReason());
     r.dispose();
   });
 });
@@ -317,7 +389,7 @@ describe('the three-way denial reason distinguishes an unconfirmed receiver (MOR
       disabledReasons: [{ field: 'txPermit', code: 'out-of-band' }] as readonly DisabledReason[],
     });
     expect(r.text('current-value')).toBe('20m');
-    expect(r.text('tx-reason')).toBe(REASON_LABEL['out-of-band']);
+    expect(r.text('tx-reason')).toBe(reasonLabel('out-of-band'));
     r.dispose();
   });
 
@@ -338,8 +410,8 @@ describe('the three-way denial reason distinguishes an unconfirmed receiver (MOR
       ] as readonly DisabledReason[],
     });
     expect(r.text('current-value')).toBe('20m');
-    expect(r.text('tx-reason')).toBe(ACTIVE_RECEIVER_UNCONFIRMED_REASON);
-    expect(r.text('tx-reason')).not.toBe(UNRESOLVED_REASON);
+    expect(r.text('tx-reason')).toBe(activeReceiverUnconfirmedReason());
+    expect(r.text('tx-reason')).not.toBe(unresolvedReason());
     r.dispose();
   });
 
@@ -350,7 +422,7 @@ describe('the three-way denial reason distinguishes an unconfirmed receiver (MOR
     const view = withB({ currentBand: unreadBand(), currentBandTx: 'denied' });
     const r = render({ ...view, txPermit: ALLOWED, disabledReasons: [] });
     expect(r.text('current-value')).toBe(UNKNOWN_TEXT);
-    expect(r.text('tx-reason')).toBe(UNRESOLVED_REASON);
+    expect(r.text('tx-reason')).toBe(unresolvedReason());
     r.dispose();
   });
 
@@ -373,8 +445,8 @@ describe('the three-way denial reason distinguishes an unconfirmed receiver (MOR
       ] as readonly DisabledReason[],
     });
     expect(r.text('current-value')).toBe('MW');
-    expect(r.text('tx-reason')).toBe(REASON_LABEL['out-of-band']);
-    expect(r.text('tx-reason')).not.toBe(ACTIVE_RECEIVER_UNCONFIRMED_REASON);
+    expect(r.text('tx-reason')).toBe(reasonLabel('out-of-band'));
+    expect(r.text('tx-reason')).not.toBe(activeReceiverUnconfirmedReason());
     r.dispose();
   });
 

--- a/frontend/src/semantic/__tests__/BandSurface.test.ts
+++ b/frontend/src/semantic/__tests__/BandSurface.test.ts
@@ -111,7 +111,10 @@ describe('the band surface derives nothing (7B carry-forward 1)', () => {
   // (`t()`), never a second fact derivation. See the two tests below for
   // the narrowed guard this replaces.
   it('imports nothing but the fact contract, plus the i18n wording lookup', () => {
-    const specifiers = [...CODE.matchAll(/from\s+'([^']+)'/g)].map((m) => m[1]);
+    // MOR-1448 review F6: quote-agnostic — a double-quoted import must be
+    // caught exactly like a single-quoted one, not slip past a single-quote
+    // -only pattern.
+    const specifiers = [...CODE.matchAll(/from\s+['"]([^'"]+)['"]/g)].map((m) => m[1]);
     expect(specifiers.length).toBeGreaterThan(0);
     expect([...new Set(specifiers)]).toEqual(['$lib/i18n', './radio-view-model']);
   });
@@ -130,7 +133,8 @@ describe('the band surface derives nothing (7B carry-forward 1)', () => {
   // OTHER `$lib/*` import (transport, capabilities, tx-permit, command
   // bus, ...) still fails this test.
   it('imports no $lib module except the i18n catalog lookup', () => {
-    const libSpecifiers = [...CODE.matchAll(/from\s+'(\$lib\/[^']+)'/g)].map((m) => m[1]);
+    // MOR-1448 review F6: same quote-agnostic fix as above.
+    const libSpecifiers = [...CODE.matchAll(/from\s+['"](\$lib\/[^'"]+)['"]/g)].map((m) => m[1]);
     expect(new Set(libSpecifiers)).toEqual(new Set(['$lib/i18n']));
   });
 
@@ -281,9 +285,23 @@ describe('the TX-target permit caveat (fix-round F1)', () => {
    phrases can silently return. ──────────────────────────────────────── */
 
 describe('MOR-1448 — every TX readiness reason resolves to operator-legible copy', () => {
+  // Review round F1-F4 add specific phrases that must never come back:
+  //   F1 — 'press PTT' was a FABRICATED remedy for `targetUnknown`: on Icom
+  //        rigs the unconfirmed state is permanent (no CAT emitter for
+  //        txTarget at all), so telling the operator to press PTT was
+  //        actively wrong, not just jargon.
+  //   F3 — 'read from the radio' falsely implied a frequency reading was
+  //        attempted for the `bandUnresolved` fallback, which fires
+  //        precisely when the band was never read.
+  //   F4 — 'frequency is denied' / 'frequency is unknown' were the old
+  //        non-idiomatic, raw-enum-interpolated caveat construction
+  //        (`TX target {status}: …` and its English-word-in-ru-prose
+  //        successor) — the caveat is now assembled from a PER-STATUS
+  //        catalog key instead of an interpolated tri-state word.
   const CONTRACT_SPEAK = [
     'was never observed', 'TX target unknown', 'TX target allowed', 'TX target denied',
-    'field:', 'fieldStatus',
+    'field:', 'fieldStatus', 'press PTT', 'read from the radio',
+    'frequency is denied', 'frequency is unknown',
   ];
 
   it.each([
@@ -302,16 +320,33 @@ describe('MOR-1448 — every TX readiness reason resolves to operator-legible co
     expect(activeReceiverUnconfirmedReason()).toBe(t('core.band.tx.reason.receiverUnconfirmed'));
   });
 
-  it('assembles the rendered caveat through the core.band.tx.caveat catalog key', () => {
+  // MOR-1448 review F4: the caveat's tri-state status now selects a WHOLE
+  // catalog key (`.unknown` / `.denied`) instead of interpolating the raw
+  // English status word into (in particular) translated prose. Both
+  // branches are pinned below so swapping either key — or reintroducing a
+  // `{status}` placeholder — fails a test by name.
+  it('assembles the rendered caveat through the core.band.tx.caveat.unknown catalog key', () => {
     const view = withB({ currentBand: knownBand('20m'), currentBandTx: 'allowed' });
     const r = render({
       ...view,
       txPermit: { status: 'unknown', reason: 'tx-target-unknown' },
       disabledReasons: [{ field: 'txPermit', code: 'tx-target-unknown' }] as readonly DisabledReason[],
     });
-    expect(r.text('tx-caveat')).toBe(t('core.band.tx.caveat', {
-      status: 'unknown',
+    expect(r.text('tx-caveat')).toBe(t('core.band.tx.caveat.unknown', {
       reason: t('core.band.tx.reason.targetUnknown'),
+    }));
+    r.dispose();
+  });
+
+  it('assembles the rendered caveat through the core.band.tx.caveat.denied catalog key', () => {
+    const view = withB({ currentBand: knownBand('20m'), currentBandTx: 'allowed' });
+    const r = render({
+      ...view,
+      txPermit: DENIED,
+      disabledReasons: [{ field: 'txPermit', code: 'out-of-band' }] as readonly DisabledReason[],
+    });
+    expect(r.text('tx-caveat')).toBe(t('core.band.tx.caveat.denied', {
+      reason: t('core.band.tx.reason.outOfBand'),
     }));
     r.dispose();
   });
@@ -321,8 +356,8 @@ describe('MOR-1448 — every TX readiness reason resolves to operator-legible co
       reasonLabel('out-of-band'), reasonLabel('tx-target-unknown'),
       reasonLabel('capability-unavailable'), unresolvedReason(),
       activeReceiverUnconfirmedReason(),
-      t('core.band.tx.caveat', { status: 'unknown', reason: reasonLabel('tx-target-unknown') }),
-      t('core.band.tx.caveat', { status: 'denied', reason: reasonLabel('out-of-band') }),
+      t('core.band.tx.caveat.unknown', { reason: reasonLabel('tx-target-unknown') }),
+      t('core.band.tx.caveat.denied', { reason: reasonLabel('out-of-band') }),
     ];
     for (const text of rendered) {
       for (const phrase of CONTRACT_SPEAK) expect(text).not.toContain(phrase);


### PR DESCRIPTION
## Summary

Strings-only rewrite of the TX readiness strip wording (MOR-1422 legibility family, last wave-2 child of MOR-1413). The strip previously leaked contract vocabulary into operator UI ("TX target unknown: TX target frequency was never observed").

- `BandSurface.svelte` reason/caveat literals moved to i18n (`core.band.tx.reason.*` + `core.band.tx.caveat`), en-US + ru-RU, rewritten in actionable operator language (what is true + what the operator can do); honest semantics unchanged — no gating, state-machine, or dispatch changes.
- Exported reason constants became functions so wording resolves reactively through `t()`; faceplate terms (TX, PTT, VFO) stay untranslated inside ru per the locale-invariance policy.
- New test block pins each reason code and the caveat to its catalog key, plus a regression test forbidding the old contract-speak phrases from reappearing.

Sibling contract-speak in `RxTxSurface`/`CwKeyerSurface` is deliberately out of scope (different surfaces; noted for follow-up).

## Testing

- Full frontend suite (vitest + eslint + svelte-check) green on the remote testbed at `7866a7cb`: PASS.
- Targeted: BandSurface + band wiring + i18n guard suites 123/123; i18n catalogs 191/191; `npm run i18n:check` 0 errors; svelte-check 0/0.

Closes MOR-1448.

🤖 Generated with [Claude Code](https://claude.com/claude-code)