### PR TITLE
fix: route typed digits to frequency entry from every tunable VFO display (MOR-1480)

### DIFF
--- a/frontend/src/components-v2/layout/KeyboardHandler.svelte
+++ b/frontend/src/components-v2/layout/KeyboardHandler.svelte
@@ -71,11 +71,15 @@
    * shortcut resolution above — so only the FIRST digit of a typed-entry
    * gesture needs this routing; native typing takes it from there. Resets
    * (rather than appends to) any stale leftover value, since this is the
-   * start of a fresh gesture. Returns false — letting the caller fall
-   * through to normal band-hotkey resolution — when the entry surface isn't
+   * start of a fresh gesture. Returns false when the entry surface isn't
    * mounted or is disabled (no band group on this skin, or BandSurface's own
    * MOR-1322/rule-5 fail-closed gates: active receiver or tuning bounds not
    * yet known).
+   *
+   * MOR-1480 owner ruling A: a false return no longer sends the caller on to
+   * band-hotkey resolution — see the swallow-always guard in `handleKeydown`
+   * below. This function only ever decides whether the digit gets ROUTED,
+   * never whether it gets SWALLOWED.
    */
   function routeDigitToFrequencyEntry(digit: string): boolean {
     const input = document.querySelector<HTMLInputElement>('[data-freq-entry]');
@@ -99,20 +103,36 @@
     // browser or OS shortcut (Cmd+1 switches tabs in most browsers), never a
     // frequency-entry keystroke — it must reach neither the entry input nor
     // preventDefault().
+    //
+    // MOR-1480 owner ruling A (post-verifier BLOCKED, explicit): a digit
+    // typed while focus is on ANY VFO frequency display — active OR
+    // inactive receiver, entry input present/enabled or not — must NEVER
+    // resolve as a band hotkey. This deliberately REVERSES the MOR-1444 B1
+    // recorded behavior for the INACTIVE-receiver case, where a digit used
+    // to fall through to `resolveAction()` and band-hop; on the inactive
+    // display it now routes nothing AND band-hops nothing. The swallow
+    // decision below keys off `[data-vfo-freq]` alone — ANY VFO display,
+    // regardless of `data-vfo-active` — via a direct DOM probe rather than
+    // `isFrequencyDisplayFocused()`, which is still consulted but only to
+    // decide whether to actually ROUTE the digit into the frequency-entry
+    // input: an inactive-receiver digit is swallowed but never routed, so it
+    // can't commit to the wrong VFO (see that function's MOR-1444 B1 doc in
+    // keyboard-map.ts).
     if (
       isDigitKey(event.key) && !event.ctrlKey && !event.metaKey && !event.altKey
-      && isFrequencyDisplayFocused(document.activeElement)
+      && document.activeElement?.closest('[data-vfo-freq]')
     ) {
-      if (routeDigitToFrequencyEntry(event.key)) {
-        // MOR-1444 B2 (round-2 review): mirrors the MOR-1449 Tab guard
-        // immediately below — an early return must still disarm a pending
-        // leader sequence, or the pill stays armed and a later keystroke
-        // (once focus leaves the now-focused, ignored-tag entry input) can
-        // complete an unintended leader sequence.
-        if (pendingSequence) clearLeaderState();
-        event.preventDefault();
-        return;
+      if (isFrequencyDisplayFocused(document.activeElement)) {
+        routeDigitToFrequencyEntry(event.key);
       }
+      // MOR-1444 B2 (round-2 review): mirrors the MOR-1449 Tab guard
+      // immediately below — an early return must still disarm a pending
+      // leader sequence, or the pill stays armed and a later keystroke
+      // (once focus leaves the now-focused, ignored-tag entry input) can
+      // complete an unintended leader sequence.
+      if (pendingSequence) clearLeaderState();
+      event.preventDefault();
+      return;
     }
 
     // MOR-1449: Tab is reserved for the browser's native focus traversal and

--- a/frontend/src/components-v2/layout/__tests__/KeyboardHandler.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/KeyboardHandler.test.ts
@@ -3,6 +3,8 @@ import { flushSync, mount, unmount } from 'svelte';
 
 import KeyboardHandler from '../KeyboardHandler.svelte';
 import type { KeyboardConfig, KeyboardActionConfig } from '../keyboard-map';
+import VfoSurface from '../../../semantic/VfoSurface.svelte';
+import { topologyFixtures } from '../../../semantic/fixtures/topologies';
 
 describe('KeyboardHandler', () => {
   let components: ReturnType<typeof mount>[] = [];
@@ -313,20 +315,35 @@ describe('KeyboardHandler', () => {
       );
     });
 
-    it('falls back to the band hotkey when the VFO display is focused but no entry input exists', () => {
+    // MOR-1480 owner ruling A (post-verifier BLOCKED, explicit): reverses
+    // this test's pre-ruling expectation. A digit typed while the VFO
+    // display has focus must NEVER resolve as a band hotkey, even when the
+    // entry surface isn't mounted at all (no band group on this skin, or
+    // BandSurface not yet rendered) — it is swallowed instead.
+    it('swallows the digit — never the band hotkey — when the VFO display is focused but no entry input exists', () => {
       const onAction = vi.fn();
       mountHandler({ config: configWithDigitBinding, onAction });
       const vfoFocusTarget = appendVfoFreqDisplay();
       vfoFocusTarget.focus();
 
-      window.dispatchEvent(new KeyboardEvent('keydown', { key: '7', bubbles: true, cancelable: true }));
+      const event = new KeyboardEvent('keydown', { key: '7', bubbles: true, cancelable: true });
+      window.dispatchEvent(event);
 
-      expect(onAction).toHaveBeenCalledWith(
-        expect.objectContaining({ action: 'band_select', params: { index: 7 } }),
+      expect(event.defaultPrevented).toBe(true);
+      expect(onAction).not.toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'band_select' }),
       );
+      // Nothing to route into — focus stays put, exactly as routing would
+      // leave it when the entry input is absent.
+      expect(document.activeElement).toBe(vfoFocusTarget);
     });
 
-    it('falls back to the band hotkey when the entry input is disabled', () => {
+    // MOR-1480 owner ruling A: reverses this test's pre-ruling expectation.
+    // A digit typed while the VFO display has focus must NEVER resolve as a
+    // band hotkey, even when BandSurface's own MOR-1322/rule-5 fail-closed
+    // gates have disabled the entry input (active receiver or tuning bounds
+    // not yet known) — it is swallowed instead of falling through.
+    it('swallows the digit — never the band hotkey — when the entry input is disabled', () => {
       const onAction = vi.fn();
       mountHandler({ config: configWithDigitBinding, onAction });
       const vfoFocusTarget = appendVfoFreqDisplay();
@@ -334,10 +351,12 @@ describe('KeyboardHandler', () => {
       entryInput.disabled = true;
       vfoFocusTarget.focus();
 
-      window.dispatchEvent(new KeyboardEvent('keydown', { key: '7', bubbles: true, cancelable: true }));
+      const event = new KeyboardEvent('keydown', { key: '7', bubbles: true, cancelable: true });
+      window.dispatchEvent(event);
 
-      expect(onAction).toHaveBeenCalledWith(
-        expect.objectContaining({ action: 'band_select', params: { index: 7 } }),
+      expect(event.defaultPrevented).toBe(true);
+      expect(onAction).not.toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'band_select' }),
       );
       expect(entryInput.value).toBe('');
     });
@@ -348,20 +367,27 @@ describe('KeyboardHandler', () => {
     // radio-wide isActive. enterFrequency() always writes view.activeReceiver
     // (SemanticRadioSurfaces.svelte), so routing a digit typed on the
     // INACTIVE receiver's display would silently commit to the WRONG VFO —
-    // reopening the MOR-1322 B1 / MOR-1335 G4 cross-dispatch class. Digits
-    // must fall through to the band hotkey here exactly as if no VFO display
-    // were focused at all.
-    it('falls back to the band hotkey when the focused VFO tile is not the active receiver', () => {
+    // reopening the MOR-1322 B1 / MOR-1335 G4 cross-dispatch class.
+    //
+    // MOR-1480 owner ruling A (post-verifier BLOCKED, explicit): REVERSES
+    // this test's original "falls back to the band hotkey" expectation.
+    // Owner ruled that a digit typed while focus is on ANY VFO display —
+    // including the INACTIVE receiver's — must never band-hop either. The
+    // digit is now swallowed: no routing (still protects against the
+    // wrong-VFO commit above) AND no band hotkey.
+    it('swallows the digit — routing nothing and band-hopping nothing — when the focused VFO tile is not the active receiver', () => {
       const onAction = vi.fn();
       mountHandler({ config: configWithDigitBinding, onAction });
       const vfoFocusTarget = appendVfoFreqDisplay({ active: false });
       const entryInput = appendFreqEntryInput();
       vfoFocusTarget.focus();
 
-      window.dispatchEvent(new KeyboardEvent('keydown', { key: '7', bubbles: true, cancelable: true }));
+      const event = new KeyboardEvent('keydown', { key: '7', bubbles: true, cancelable: true });
+      window.dispatchEvent(event);
 
-      expect(onAction).toHaveBeenCalledWith(
-        expect.objectContaining({ action: 'band_select', params: { index: 7 } }),
+      expect(event.defaultPrevented).toBe(true);
+      expect(onAction).not.toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'band_select' }),
       );
       expect(entryInput.value).toBe('');
       expect(document.activeElement).toBe(vfoFocusTarget);
@@ -424,18 +450,24 @@ describe('KeyboardHandler', () => {
     );
   });
 
-  // MOR-1480 — reproduced: the MOR-1444 guard above only recognized
-  // VfoSurface.svelte's `[data-vfo-tile]`-wrapped `[data-vfo-freq]` shape.
-  // desktop-v2's HEADER VFO display (VfoHeader.svelte -> VfoPanel.svelte)
-  // mounts `FrequencyDisplayInteractive` directly, with no `[data-vfo-tile]`
-  // ancestor — so a digit typed while it had focus fell through to
-  // `resolveAction()` and fired a real `band_select` hotkey (bench log
-  // pattern: typed digits produced uncommanded `set_band` + BSR band-recall
-  // traffic on the radio). This mounts the REAL `FrequencyDisplayInteractive`
-  // primitive standalone — the same shape `VfoPanel.svelte` renders it in —
-  // to prove the routing guard now recognizes it without any
-  // `[data-vfo-tile]` wrapper.
-  describe('digit routing from a bare FrequencyDisplayInteractive mount, no [data-vfo-tile] ancestor (MOR-1480)', () => {
+  // MOR-1480 verifier finding F1 (confirmed): `VfoHeader.svelte`/
+  // `VfoPanel.svelte` — the desktop-v2 HEADER VFO display this block
+  // originally targeted — never actually renders on any shipping skin
+  // (`RadioLayout.svelte:83` `semanticDeck` is true for every registered
+  // manifest; `VfoHeader` is the dead else-branch, pinned by
+  // `semantic-desktop-migration.component.test.ts` "drops the legacy twin").
+  // The live bug lives in the SEMANTIC tree instead — see the
+  // "digit routing against the real semantic VfoSurface tree" describe block
+  // below, which is the actual mechanism reproduction and fix verification.
+  //
+  // This block is kept as DEFENSE-IN-DEPTH coverage for
+  // `FrequencyDisplayInteractive`'s own `vfoFreqHook` self-attribution
+  // (`data-vfo-freq` + `data-vfo-active` on its own focusable root): it
+  // makes the primitive self-sufficient for any FUTURE non-semantic mount
+  // (e.g. a revived header), even though no current mount depends on it —
+  // `VfoSurface.svelte` opts out via `vfoFreqHook={false}` and supplies its
+  // own equivalent `[data-vfo-tile]`-wrapped `[data-vfo-freq]` hook instead.
+  describe('digit routing from a bare FrequencyDisplayInteractive mount, no [data-vfo-tile] ancestor — defense-in-depth for the primitive-level self-hook, not the live bug (MOR-1480)', () => {
     const configWithDigitBinding: KeyboardConfig = {
       ...config,
       bindings: [
@@ -492,20 +524,166 @@ describe('KeyboardHandler', () => {
       expect(entryInput.value).toBe('7');
     });
 
-    // Mirrors the MOR-1444 B1 dual-receiver protection: a standalone mount
-    // marked inactive (the non-active receiver's header tile) must still
-    // fall through to the band hotkey, not commit to the wrong VFO.
-    it('still falls through to the band hotkey when the standalone display is marked inactive', async () => {
+    // MOR-1480 owner ruling A: REVERSES this test's original "falls through
+    // to the band hotkey" expectation for the inactive-receiver case — a
+    // standalone mount marked inactive must swallow the digit (routing
+    // nothing, to avoid committing to the wrong VFO) AND never band-hop.
+    it('swallows the digit — routing nothing and band-hopping nothing — when the standalone display is marked inactive', async () => {
       const onAction = vi.fn();
       mountHandler({ config: configWithDigitBinding, onAction });
       const freqDisplay = await mountBareFrequencyDisplay(false);
       const entryInput = appendFreqEntryInput();
       freqDisplay.focus();
 
-      window.dispatchEvent(new KeyboardEvent('keydown', { key: '7', bubbles: true, cancelable: true }));
+      const event = new KeyboardEvent('keydown', { key: '7', bubbles: true, cancelable: true });
+      window.dispatchEvent(event);
 
-      expect(onAction).toHaveBeenCalledWith(
-        expect.objectContaining({ action: 'band_select', params: { index: 7 } }),
+      expect(event.defaultPrevented).toBe(true);
+      expect(onAction).not.toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'band_select' }),
+      );
+      expect(entryInput.value).toBe('');
+      expect(document.activeElement).toBe(freqDisplay);
+    });
+  });
+
+  // MOR-1480 — the ACTUAL live mechanism (verifier F1a) and owner ruling A,
+  // reproduced and verified against the REAL semantic tree instead of
+  // hand-rolled DOM or the dead header path: `VfoSurface.svelte`, mounted
+  // for real via the `2/main_sub` topology fixture. `hasTunableFrequency`
+  // gates on `isActiveSlot`, not radio-wide `isActive`
+  // (`VfoSurface.svelte:269`), so the fixture's SUB-A tile
+  // (`isActiveSlot: true`, `isActive: false`) mounts a focusable, tunable
+  // `[data-vfo-freq]` display while MAIN-A is the radio's active receiver —
+  // exactly the dual-receiver shape `BandSurface.svelte` and
+  // `SemanticRadioSurfaces.svelte` produce on the bench.
+  describe('digit routing against the real semantic VfoSurface tree (MOR-1480 mechanism + owner ruling A)', () => {
+    const configWithDigitBinding: KeyboardConfig = {
+      ...config,
+      bindings: [
+        ...config.bindings,
+        {
+          id: 'band-7',
+          section: 'Band',
+          label: 'Select band 7',
+          sequence: ['7'],
+          action: 'band_select',
+          params: { index: 7 },
+        },
+      ],
+    };
+
+    function mountRealVfoSurface(): HTMLElement {
+      const target = document.createElement('div');
+      document.body.appendChild(target);
+      const component = mount(VfoSurface, {
+        target,
+        props: { viewModel: topologyFixtures['2/main_sub'], onTuneFrequency: vi.fn() },
+      });
+      flushSync();
+      components.push(component);
+      return target;
+    }
+
+    function appendFreqEntryInput(): HTMLInputElement {
+      const input = document.createElement('input');
+      input.setAttribute('data-freq-entry', '');
+      document.body.appendChild(input);
+      return input;
+    }
+
+    /** The focusable root FrequencyDisplayInteractive mounts for a given receiver's active-slot tile. */
+    function focusTargetFor(surface: HTMLElement, receiver: 'MAIN' | 'SUB'): HTMLElement {
+      const el = surface.querySelector<HTMLElement>(
+        `[data-vfo-tile][data-vfo-receiver="${receiver}"] .freq`,
+      );
+      if (!el) throw new Error(`no tunable .freq found for receiver ${receiver}`);
+      return el;
+    }
+
+    // Verifier F1a mechanism, reproduced against the real tree: BandSurface
+    // disables/removes `[data-freq-entry]` when the active receiver or
+    // tuning bounds aren't yet known (`BandSurface.svelte:367-368`).
+    // `routeDigitToFrequencyEntry` returns `false` in both cases — pre-fix,
+    // the caller fell through to `resolveAction()` and fired `band_select`.
+    it('swallows the digit — no band_select — when the entry input is absent, focus on the real ACTIVE tile', () => {
+      const onAction = vi.fn();
+      mountHandler({ config: configWithDigitBinding, onAction });
+      const surface = mountRealVfoSurface();
+      const freqDisplay = focusTargetFor(surface, 'MAIN');
+      freqDisplay.focus();
+      expect(document.activeElement).toBe(freqDisplay);
+
+      const event = new KeyboardEvent('keydown', { key: '7', bubbles: true, cancelable: true });
+      window.dispatchEvent(event);
+
+      expect(event.defaultPrevented).toBe(true);
+      expect(onAction).not.toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'band_select' }),
+      );
+    });
+
+    it('swallows the digit — no band_select, no routing — when the entry input is disabled, focus on the real ACTIVE tile', () => {
+      const onAction = vi.fn();
+      mountHandler({ config: configWithDigitBinding, onAction });
+      const surface = mountRealVfoSurface();
+      const entryInput = appendFreqEntryInput();
+      entryInput.disabled = true;
+      const freqDisplay = focusTargetFor(surface, 'MAIN');
+      freqDisplay.focus();
+
+      const event = new KeyboardEvent('keydown', { key: '7', bubbles: true, cancelable: true });
+      window.dispatchEvent(event);
+
+      expect(event.defaultPrevented).toBe(true);
+      expect(onAction).not.toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'band_select' }),
+      );
+      expect(entryInput.value).toBe('');
+    });
+
+    // Repairs/keeps the "active display routes into the entry" case against
+    // the real tree (not just the hand-rolled MOR-1444 block above).
+    it('routes the digit into the frequency-entry input when the real ACTIVE tile is focused and the entry is enabled', () => {
+      const onAction = vi.fn();
+      mountHandler({ config: configWithDigitBinding, onAction });
+      const surface = mountRealVfoSurface();
+      const entryInput = appendFreqEntryInput();
+      const freqDisplay = focusTargetFor(surface, 'MAIN');
+      freqDisplay.focus();
+
+      const event = new KeyboardEvent('keydown', { key: '7', bubbles: true, cancelable: true });
+      window.dispatchEvent(event);
+
+      expect(event.defaultPrevented).toBe(true);
+      expect(onAction).not.toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'band_select' }),
+      );
+      expect(document.activeElement).toBe(entryInput);
+      expect(entryInput.value).toBe('7');
+    });
+
+    // MOR-1480 owner ruling A, reproduced against the real tree: SUB-A is
+    // tunable (`isActiveSlot: true`) but NOT the active receiver
+    // (`isActive: false`, MAIN is active in this fixture). Pre-rework code
+    // (isFrequencyDisplayFocused gating the swallow decision) fell through
+    // to resolveAction() and fired band_select here — this test must FAIL
+    // on that pre-rework code (see red-phase verification).
+    it('swallows the digit — no routing, no band_select — when the real INACTIVE-receiver tile is focused', () => {
+      const onAction = vi.fn();
+      mountHandler({ config: configWithDigitBinding, onAction });
+      const surface = mountRealVfoSurface();
+      const entryInput = appendFreqEntryInput();
+      const freqDisplay = focusTargetFor(surface, 'SUB');
+      freqDisplay.focus();
+      expect(document.activeElement).toBe(freqDisplay);
+
+      const event = new KeyboardEvent('keydown', { key: '7', bubbles: true, cancelable: true });
+      window.dispatchEvent(event);
+
+      expect(event.defaultPrevented).toBe(true);
+      expect(onAction).not.toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'band_select' }),
       );
       expect(entryInput.value).toBe('');
       expect(document.activeElement).toBe(freqDisplay);

--- a/frontend/src/components-v2/layout/__tests__/KeyboardHandler.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/KeyboardHandler.test.ts
@@ -423,4 +423,92 @@ describe('KeyboardHandler', () => {
       },
     );
   });
+
+  // MOR-1480 — reproduced: the MOR-1444 guard above only recognized
+  // VfoSurface.svelte's `[data-vfo-tile]`-wrapped `[data-vfo-freq]` shape.
+  // desktop-v2's HEADER VFO display (VfoHeader.svelte -> VfoPanel.svelte)
+  // mounts `FrequencyDisplayInteractive` directly, with no `[data-vfo-tile]`
+  // ancestor — so a digit typed while it had focus fell through to
+  // `resolveAction()` and fired a real `band_select` hotkey (bench log
+  // pattern: typed digits produced uncommanded `set_band` + BSR band-recall
+  // traffic on the radio). This mounts the REAL `FrequencyDisplayInteractive`
+  // primitive standalone — the same shape `VfoPanel.svelte` renders it in —
+  // to prove the routing guard now recognizes it without any
+  // `[data-vfo-tile]` wrapper.
+  describe('digit routing from a bare FrequencyDisplayInteractive mount, no [data-vfo-tile] ancestor (MOR-1480)', () => {
+    const configWithDigitBinding: KeyboardConfig = {
+      ...config,
+      bindings: [
+        ...config.bindings,
+        {
+          id: 'band-7',
+          section: 'Band',
+          label: 'Select band 7',
+          sequence: ['7'],
+          action: 'band_select',
+          params: { index: 7 },
+        },
+      ],
+    };
+
+    function appendFreqEntryInput(): HTMLInputElement {
+      const input = document.createElement('input');
+      input.setAttribute('data-freq-entry', '');
+      document.body.appendChild(input);
+      return input;
+    }
+
+    async function mountBareFrequencyDisplay(active = true) {
+      const { default: FrequencyDisplayInteractive } = await import(
+        '../../../primitives/frequency/FrequencyDisplayInteractive.svelte'
+      );
+      const target = document.createElement('div');
+      document.body.appendChild(target);
+      const component = mount(FrequencyDisplayInteractive, {
+        target,
+        props: { freq: 14074000, active },
+      });
+      flushSync();
+      components.push(component);
+      return target.querySelector<HTMLElement>('.freq')!;
+    }
+
+    it('routes a digit typed on a standalone active FrequencyDisplayInteractive to the frequency-entry input, not the band hotkey', async () => {
+      const onAction = vi.fn();
+      mountHandler({ config: configWithDigitBinding, onAction });
+      const freqDisplay = await mountBareFrequencyDisplay(true);
+      const entryInput = appendFreqEntryInput();
+      freqDisplay.focus();
+      expect(document.activeElement).toBe(freqDisplay);
+
+      const event = new KeyboardEvent('keydown', { key: '7', bubbles: true, cancelable: true });
+      window.dispatchEvent(event);
+
+      expect(event.defaultPrevented).toBe(true);
+      expect(onAction).not.toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'band_select' }),
+      );
+      expect(document.activeElement).toBe(entryInput);
+      expect(entryInput.value).toBe('7');
+    });
+
+    // Mirrors the MOR-1444 B1 dual-receiver protection: a standalone mount
+    // marked inactive (the non-active receiver's header tile) must still
+    // fall through to the band hotkey, not commit to the wrong VFO.
+    it('still falls through to the band hotkey when the standalone display is marked inactive', async () => {
+      const onAction = vi.fn();
+      mountHandler({ config: configWithDigitBinding, onAction });
+      const freqDisplay = await mountBareFrequencyDisplay(false);
+      const entryInput = appendFreqEntryInput();
+      freqDisplay.focus();
+
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: '7', bubbles: true, cancelable: true }));
+
+      expect(onAction).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'band_select', params: { index: 7 } }),
+      );
+      expect(entryInput.value).toBe('');
+      expect(document.activeElement).toBe(freqDisplay);
+    });
+  });
 });

--- a/frontend/src/components-v2/layout/__tests__/keyboard-map.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/keyboard-map.test.ts
@@ -229,30 +229,59 @@ describe('isFrequencyDisplayFocused', () => {
       return freq;
     }
 
-    it('is true for the self-attributed [data-vfo-freq] element itself', () => {
-      const freq = buildBareFreqDisplay(true);
-
-      expect(isFrequencyDisplayFocused(freq)).toBe(true);
-
-      freq.remove();
-    });
-
-    it('is true when the active element sits inside a self-attributed active [data-vfo-freq]', () => {
-      const freq = buildBareFreqDisplay(true);
-      const inner = document.createElement('span');
-      freq.appendChild(inner);
-
-      expect(isFrequencyDisplayFocused(inner)).toBe(true);
-
-      freq.remove();
-    });
-
     it('is false when the self-attributed [data-vfo-freq] is marked inactive', () => {
       const freq = buildBareFreqDisplay(false);
 
       expect(isFrequencyDisplayFocused(freq)).toBe(false);
 
       freq.remove();
+    });
+
+    /**
+     * F2 (verifier, confirmed): the two tests this replaced —
+     * "is true for the self-attributed [data-vfo-freq] element itself" and
+     * "...when the active element sits inside a self-attributed active
+     * [data-vfo-freq]" — were VACUOUS pre-fix: with no `[data-vfo-tile]`
+     * ancestor at all, `freq.closest('[data-vfo-tile]')` is `null` on BOTH
+     * the pre-fix and post-fix implementations, so `null?.getAttribute(...)
+     * !== 'false'` evaluates `undefined !== 'false'` — true — regardless of
+     * whether the code reads the element's OWN `data-vfo-active` first. They
+     * passed identically before and after the fix and proved nothing about
+     * the "own attribute wins" behavior the fix actually added.
+     *
+     * These two tests below discriminate: they wrap a self-attributed
+     * `[data-vfo-freq]` in an ANCESTOR `[data-vfo-tile]` whose own
+     * `data-vfo-active` DISAGREES with the element's own attribute. The
+     * pre-fix implementation only ever reads the ancestor tile's flag, so it
+     * gets these backwards; only reading the element's own attribute FIRST
+     * (falling back to the ancestor only when absent) gets them right.
+     */
+    function buildConflictingAncestorTile(ownActive: boolean, tileActive: boolean): HTMLElement {
+      const tile = document.createElement('div');
+      tile.setAttribute('data-vfo-tile', '');
+      tile.setAttribute('data-vfo-active', String(tileActive));
+      const freq = document.createElement('div');
+      freq.setAttribute('data-vfo-freq', '');
+      freq.setAttribute('data-vfo-active', String(ownActive));
+      tile.appendChild(freq);
+      document.body.appendChild(tile);
+      return freq;
+    }
+
+    it('prefers its own data-vfo-active=true over an ancestor [data-vfo-tile] marked inactive', () => {
+      const freq = buildConflictingAncestorTile(true, false);
+
+      expect(isFrequencyDisplayFocused(freq)).toBe(true);
+
+      freq.closest('[data-vfo-tile]')?.remove();
+    });
+
+    it('prefers its own data-vfo-active=false over an ancestor [data-vfo-tile] marked active', () => {
+      const freq = buildConflictingAncestorTile(false, true);
+
+      expect(isFrequencyDisplayFocused(freq)).toBe(false);
+
+      freq.closest('[data-vfo-tile]')?.remove();
     });
   });
 });

--- a/frontend/src/components-v2/layout/__tests__/keyboard-map.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/keyboard-map.test.ts
@@ -212,4 +212,47 @@ describe('isFrequencyDisplayFocused', () => {
   it('is false for null', () => {
     expect(isFrequencyDisplayFocused(null)).toBe(false);
   });
+
+  // MOR-1480 — reproduced: VfoPanel.svelte (mounted directly by the
+  // desktop-v2 header via VfoHeader.svelte/DualVfoDisplay.svelte, with NO
+  // [data-vfo-tile] ancestor) renders FrequencyDisplayInteractive, which now
+  // (per MOR-1480) emits `data-vfo-freq` + its own `data-vfo-active` directly
+  // on its focusable root. This block mirrors that self-attributed shape —
+  // no `[data-vfo-tile]` wrapper anywhere in the tree — the shape the
+  // pre-fix guard (ancestor-tile-only) silently failed to recognize.
+  describe('self-attributed [data-vfo-freq] with no [data-vfo-tile] ancestor (MOR-1480)', () => {
+    function buildBareFreqDisplay(active = true): HTMLElement {
+      const freq = document.createElement('div');
+      freq.setAttribute('data-vfo-freq', '');
+      freq.setAttribute('data-vfo-active', String(active));
+      document.body.appendChild(freq);
+      return freq;
+    }
+
+    it('is true for the self-attributed [data-vfo-freq] element itself', () => {
+      const freq = buildBareFreqDisplay(true);
+
+      expect(isFrequencyDisplayFocused(freq)).toBe(true);
+
+      freq.remove();
+    });
+
+    it('is true when the active element sits inside a self-attributed active [data-vfo-freq]', () => {
+      const freq = buildBareFreqDisplay(true);
+      const inner = document.createElement('span');
+      freq.appendChild(inner);
+
+      expect(isFrequencyDisplayFocused(inner)).toBe(true);
+
+      freq.remove();
+    });
+
+    it('is false when the self-attributed [data-vfo-freq] is marked inactive', () => {
+      const freq = buildBareFreqDisplay(false);
+
+      expect(isFrequencyDisplayFocused(freq)).toBe(false);
+
+      freq.remove();
+    });
+  });
 });

--- a/frontend/src/components-v2/layout/keyboard-map.ts
+++ b/frontend/src/components-v2/layout/keyboard-map.ts
@@ -312,10 +312,28 @@ export function isDigitKey(key: string): boolean {
 
 /**
  * MOR-1444: true when the active element is the ACTIVE RECEIVER's
- * VFO/frequency display, or sits inside it. `data-vfo-freq` is the existing
- * production hook on the wrapper `<span>` around `FrequencyDisplayInteractive`
- * in `VfoSurface.svelte` — present for every VFO tile with a tunable
- * frequency, no new markup needed.
+ * VFO/frequency display, or sits inside it. `data-vfo-freq` is a production
+ * hook: `FrequencyDisplayInteractive.svelte` (MOR-1480) emits it — plus its
+ * own `data-vfo-active` mirroring the same `active` prop it already uses for
+ * styling — directly on its focusable root, so EVERY mount of that primitive
+ * self-qualifies with no bespoke wrapper markup required. `VfoSurface.svelte`
+ * additionally wraps it in a `<span data-vfo-freq>` inside a `[data-vfo-tile]`
+ * for its own layout/testing needs; that wrapper carries no `data-vfo-active`
+ * of its own; and other historical structures.
+ *
+ * MOR-1480 (header/VfoPanel escape, reproduced): before this fix the guard
+ * required an ANCESTOR `[data-vfo-tile]` to supply `data-vfo-active` — a
+ * shape only `VfoSurface.svelte` produces. `VfoPanel.svelte` (mounted by the
+ * desktop-v2 header via `VfoHeader.svelte`/`DualVfoDisplay.svelte`) renders
+ * `FrequencyDisplayInteractive` directly, with no `[data-vfo-tile]` ancestor
+ * — so the guard silently failed there and a digit typed on the HEADER VFO
+ * display fell through to `resolveAction()` and fired real `band_select`
+ * hotkeys (bench-observed: typed digits produced uncommanded `set_band` +
+ * BSR band hops). Reading the matched `[data-vfo-freq]` element's OWN
+ * `data-vfo-active` first — falling back to the ancestor tile's only when the
+ * matched element doesn't carry the attribute itself — makes every current
+ * and future mount of the primitive self-sufficient instead of relying on a
+ * specific parent shape.
  *
  * MOR-1444 B1 (round-2 review, reproduced): `hasTunableFrequency` gates on
  * `isActiveSlot`, not the radio-wide `isActive` (VfoSurface.svelte:258-259)
@@ -324,13 +342,17 @@ export function isDigitKey(key: string): boolean {
  * `view.activeReceiver` (SemanticRadioSurfaces.svelte), so qualifying on
  * `[data-vfo-freq]` alone would let a digit typed on the INACTIVE receiver's
  * display commit to the WRONG VFO — reopening the MOR-1322 B1 / MOR-1335 G4
- * cross-dispatch class. The ancestor `[data-vfo-tile]`'s own
- * `data-vfo-active` flag (VfoSurface.svelte:367) is the same fact
- * `hasTunableFrequency`'s sibling `tuneFrequency` guard reads, so this stays
- * a single source of truth rather than a second derivation.
+ * cross-dispatch class. `data-vfo-active` (own or ancestor-tile) is the same
+ * fact `hasTunableFrequency`'s sibling `tuneFrequency` guard reads and the
+ * same fact `VfoPanel`'s/`VfoHeader`'s callers pass into
+ * `FrequencyDisplayInteractive`'s `active` prop (`extractVfoState`'s
+ * `isActive: activeReceiver === receiver`) — one source of truth, never a
+ * second derivation.
  */
 export function isFrequencyDisplayFocused(activeElement: Element | null): boolean {
   const freq = activeElement?.closest('[data-vfo-freq]');
   if (!freq) return false;
+  const ownActive = freq.getAttribute('data-vfo-active');
+  if (ownActive !== null) return ownActive !== 'false';
   return freq.closest('[data-vfo-tile]')?.getAttribute('data-vfo-active') !== 'false';
 }

--- a/frontend/src/components-v2/layout/keyboard-map.ts
+++ b/frontend/src/components-v2/layout/keyboard-map.ts
@@ -321,19 +321,21 @@ export function isDigitKey(key: string): boolean {
  * for its own layout/testing needs; that wrapper carries no `data-vfo-active`
  * of its own; and other historical structures.
  *
- * MOR-1480 (header/VfoPanel escape, reproduced): before this fix the guard
- * required an ANCESTOR `[data-vfo-tile]` to supply `data-vfo-active` — a
- * shape only `VfoSurface.svelte` produces. `VfoPanel.svelte` (mounted by the
- * desktop-v2 header via `VfoHeader.svelte`/`DualVfoDisplay.svelte`) renders
- * `FrequencyDisplayInteractive` directly, with no `[data-vfo-tile]` ancestor
- * — so the guard silently failed there and a digit typed on the HEADER VFO
- * display fell through to `resolveAction()` and fired real `band_select`
- * hotkeys (bench-observed: typed digits produced uncommanded `set_band` +
- * BSR band hops). Reading the matched `[data-vfo-freq]` element's OWN
- * `data-vfo-active` first — falling back to the ancestor tile's only when the
- * matched element doesn't carry the attribute itself — makes every current
- * and future mount of the primitive self-sufficient instead of relying on a
- * specific parent shape.
+ * MOR-1480 (verifier F1, CONFIRMED): the guard originally required an
+ * ANCESTOR `[data-vfo-tile]` to supply `data-vfo-active` — a shape only
+ * `VfoSurface.svelte` produces. That gap was first attributed to the
+ * desktop-v2 HEADER display (`VfoHeader.svelte` -> `VfoPanel.svelte`), which
+ * was WRONG: `VfoHeader` renders on NO shipping skin (`RadioLayout.svelte:83`
+ * `semanticDeck = declared.has('vfo')` is true for every registered manifest;
+ * the legacy else-branch at `RadioLayout.svelte:293-296` is pinned dead by
+ * `semantic-desktop-migration.component.test.ts`, "drops the legacy twin").
+ * Reading the matched `[data-vfo-freq]` element's OWN `data-vfo-active` first
+ * — falling back to the ancestor tile's only when absent — is kept purely as
+ * DEFENSE-IN-DEPTH so any future non-semantic mount is self-sufficient; NO
+ * current mount depends on it (`VfoSurface.svelte` opts out with
+ * `vfoFreqHook={false}`). The bench-observed uncommanded `set_band` + BSR
+ * hops came from the SEMANTIC tree — the `resolveAction()` fall-through now
+ * closed by the swallow-always guard in `KeyboardHandler.svelte`.
  *
  * MOR-1444 B1 (round-2 review, reproduced): `hasTunableFrequency` gates on
  * `isActiveSlot`, not the radio-wide `isActive` (VfoSurface.svelte:258-259)

--- a/frontend/src/components-v2/layout/keyboard-map.ts
+++ b/frontend/src/components-v2/layout/keyboard-map.ts
@@ -348,6 +348,15 @@ export function isDigitKey(key: string): boolean {
  * `FrequencyDisplayInteractive`'s `active` prop (`extractVfoState`'s
  * `isActive: activeReceiver === receiver`) — one source of truth, never a
  * second derivation.
+ *
+ * MOR-1480 owner ruling A: `KeyboardHandler.svelte`'s caller no longer treats
+ * a `false` return here as "let the digit fall through to `resolveAction()`"
+ * — every digit typed on ANY `[data-vfo-freq]` display is swallowed
+ * regardless of this function's answer (see the swallow-always guard in
+ * `handleKeydown`). This function's OWN return value is unchanged: it still
+ * answers "is the ACTIVE receiver's display focused", and the caller still
+ * uses that answer to decide whether to ROUTE the digit into the
+ * frequency-entry input, just no longer whether to swallow it.
  */
 export function isFrequencyDisplayFocused(activeElement: Element | null): boolean {
   const freq = activeElement?.closest('[data-vfo-freq]');

--- a/frontend/src/primitives/frequency/FrequencyDisplayInteractive.svelte
+++ b/frontend/src/primitives/frequency/FrequencyDisplayInteractive.svelte
@@ -45,11 +45,13 @@
      * `data-vfo-freq` + `data-vfo-active` (mirroring `active`) on its
      * focusable root, so the MOR-1444 keyboard routing guard
      * (`isFrequencyDisplayFocused` in `keyboard-map.ts`) recognizes ANY
-     * mount without a bespoke wrapper. Before this, only `VfoSurface.svelte`'s
-     * own `[data-vfo-tile]`-wrapped `[data-vfo-freq]` span qualified — so a
-     * digit typed on the desktop-v2 HEADER VFO display (`VfoPanel.svelte`,
-     * mounted with no such wrapper) fell through to a real `band_select`
-     * hotkey. `VfoSurface.svelte` already supplies its own equivalent hook —
+     * mount without a bespoke wrapper.
+     * DEFENSE-IN-DEPTH ONLY (verifier F1): no current mount depends on this
+     * — the `VfoPanel`/`VfoHeader` header path it originally targeted renders
+     * on no shipping skin, and `VfoSurface.svelte` (the one live mount) opts
+     * out with `vfoFreqHook={false}`. Kept so a future non-semantic mount of
+     * this primitive self-qualifies without bespoke wrapper markup.
+     * `VfoSurface.svelte` already supplies its own equivalent hook —
      * on the SAME wrapper element its own tests key `data-freq-tunable` off
      * of — so it opts out here with `vfoFreqHook={false}` to avoid a second,
      * nested `[data-vfo-freq]` match for every tunable tile.

--- a/frontend/src/primitives/frequency/FrequencyDisplayInteractive.svelte
+++ b/frontend/src/primitives/frequency/FrequencyDisplayInteractive.svelte
@@ -40,6 +40,21 @@
      * as every other `primitives/` component.
      */
     pendingAnnouncement?: string;
+    /**
+     * MOR-1480 — when true (the default), this primitive emits its own
+     * `data-vfo-freq` + `data-vfo-active` (mirroring `active`) on its
+     * focusable root, so the MOR-1444 keyboard routing guard
+     * (`isFrequencyDisplayFocused` in `keyboard-map.ts`) recognizes ANY
+     * mount without a bespoke wrapper. Before this, only `VfoSurface.svelte`'s
+     * own `[data-vfo-tile]`-wrapped `[data-vfo-freq]` span qualified — so a
+     * digit typed on the desktop-v2 HEADER VFO display (`VfoPanel.svelte`,
+     * mounted with no such wrapper) fell through to a real `band_select`
+     * hotkey. `VfoSurface.svelte` already supplies its own equivalent hook —
+     * on the SAME wrapper element its own tests key `data-freq-tunable` off
+     * of — so it opts out here with `vfoFreqHook={false}` to avoid a second,
+     * nested `[data-vfo-freq]` match for every tunable tile.
+     */
+    vfoFreqHook?: boolean;
   }
 
   let {
@@ -52,6 +67,7 @@
     onFreqChange,
     pendingDisplayHz = null,
     pendingAnnouncement,
+    vfoFreqHook = true,
   }: Props = $props();
 
   const pendingId = $props.id();
@@ -128,6 +144,8 @@
 <div
   class="freq" class:compact class:inactive={!active}
   data-freq-status={pending ? 'pending' : 'confirmed'}
+  data-vfo-freq={vfoFreqHook ? '' : undefined}
+  data-vfo-active={vfoFreqHook ? active : undefined}
   aria-describedby={pending && pendingAnnouncement ? pendingId : undefined}
   style={Object.entries(cssVars).map(([k, v]) => `${k}:${v}`).join(';')}
   tabindex="0" role="group" aria-label="Frequency display" onkeydown={handleKeyDown}

--- a/frontend/src/semantic/VfoSurface.svelte
+++ b/frontend/src/semantic/VfoSurface.svelte
@@ -404,6 +404,13 @@
               MOR-1425 tuning accumulator's delta — a positive-feedback
               runaway reproduced by the verifier (10 ticks of +10 Hz intent
               measured out to +1910 Hz actual; 30 ticks to +15.7 MHz).
+
+              MOR-1480: this wrapper `<span>` is ALREADY the
+              `[data-vfo-tile]`-wrapped `[data-vfo-freq]` hook
+              `isFrequencyDisplayFocused()` reads (with `data-freq-tunable`
+              on this SAME element, per the tests above) — `vfoFreqHook={false}`
+              stops `FrequencyDisplayInteractive` from nesting a second,
+              redundant `[data-vfo-freq]` inside it.
             -->
             <FrequencyDisplayInteractive
               freq={vfo.frequencyHz ?? 0}
@@ -413,6 +420,7 @@
               active={vfo.isActive}
               receiver={vfo.receiver === 'SUB' ? 'sub' : 'main'}
               onFreqChange={(hz) => tuneFrequency(vfo, hz)}
+              vfoFreqHook={false}
             />
           {:else}
             {freq?.text ?? formatFrequency(vfo.frequencyHz)}


### PR DESCRIPTION
## Symptom

Digits typed while a VFO frequency display has focus could still resolve as
band hotkeys — a real, uncommanded band hop on the connected radio. Bench
logs showed the pattern of a typed digit sequence producing `set_band`
command traffic followed by a BSR (band-stack-register) recall, exactly as
if the operator had pressed a band hotkey instead of typing into the
frequency entry.

## Round 1 (BLOCKED) — verifier findings, all confirmed

This PR originally shipped a production fix in `FrequencyDisplayInteractive`
(a self-attributed `data-vfo-freq`/`data-vfo-active` hook) targeting
desktop-v2's **header** VFO display (`VfoHeader.svelte` → `VfoPanel.svelte`).
An adversarial verifier found:

- **F1 (severe):** `VfoHeader`/`VfoPanel` never actually render on any
  shipping skin. `RadioLayout.svelte:83` computes
  `semanticDeck = declared.has('vfo')`, which is `true` for every registered
  manifest; `VfoHeader` is only reached on the `else` branch
  (`RadioLayout.svelte:293-296`), and that dead branch is already pinned by
  the passing test `semantic-desktop-migration.component.test.ts` ("drops
  the legacy twin"). The original diff's production DOM change therefore had
  **zero effect on any real skin**. The live mechanism instead lives in the
  SEMANTIC tree: `KeyboardHandler.svelte`'s digit guard falls through to
  `resolveAction()` (→ `band_select`) whenever
  `isFrequencyDisplayFocused()` returns `false` — which it deliberately does
  both (a) when `[data-freq-entry]` is missing or disabled
  (`BandSurface.svelte` disables it when the active receiver or tuning
  bounds aren't yet known) and (b) for the MOR-1444 B1 inactive-receiver
  case, as originally written.
- **F2:** two of the five original tests were vacuous pre-fix — they
  asserted `isFrequencyDisplayFocused` returns `true` for a self-attributed
  `[data-vfo-freq]` element with no `[data-vfo-tile]` ancestor, but with no
  ancestor tile at all the pre-fix implementation already evaluated to
  `true` regardless of whether it read the element's own attribute. They
  passed identically before and after the fix.
- **F3:** the new test file was missing its trailing newline.

## Owner ruling A (post-BLOCKED, explicit)

A digit typed while focus is on **any** VFO frequency display — active or
inactive receiver — must **never** resolve as a band hotkey. This
deliberately **reverses** the MOR-1444 B1 recorded behavior for the
inactive-receiver case: previously a digit on the inactive tile fell through
to `band_select`; now it routes nothing (still protecting against a wrong-
VFO commit) **and** band-hops nothing.

## Fix (this round)

`KeyboardHandler.svelte`'s digit guard in `handleKeydown` now swallows on
`document.activeElement?.closest('[data-vfo-freq]')` alone — any VFO
display, regardless of `data-vfo-active` — and only consults
`isFrequencyDisplayFocused()` (unchanged) to decide whether to actually
*route* the digit into `[data-freq-entry]`. The Ctrl/Cmd/Alt modifier
exemption (MOR-1444 B3, browser/OS shortcuts) is untouched. The ruling is
recorded as a comment at the guard.

`FrequencyDisplayInteractive`'s `vfoFreqHook` self-attribution from round 1
is **kept** as defense-in-depth for any future non-semantic mount (harmless,
and makes the swallow guard's `[data-vfo-freq]` selector match any future
mount that isn't `VfoSurface.svelte`), even though no currently-rendered
mount depends on it — the live fix that actually matters on the bench is
the `KeyboardHandler` guard above.

## Tests

- Rewrote the three MOR-1444 hand-rolled tests whose expectations ruling A
  reversed (missing entry input, disabled entry input, inactive tile) to
  assert swallow-always instead of fall-through.
- Added regression coverage mounting the **real** `VfoSurface.svelte`
  (via the `2/main_sub` topology fixture, whose SUB-A tile is tunable —
  `isActiveSlot: true` — but not the active receiver — `isActive: false`)
  for both the entry-absent/disabled mechanism and the inactive-tile ruling,
  verified red against pre-rework code before the guard change, green after.
- Fixed the two vacuous `keyboard-map.test.ts` cases (F2) with cases that
  put a self-attributed element's own `data-vfo-active` in direct conflict
  with an ancestor `[data-vfo-tile]`'s, which only the post-fix
  own-attribute-first implementation gets right.
- Added the trailing newline (F3).

Closes MOR-1480
