### PR TITLE
fix: normalize hyphenated mode labels to Mode tokens (MOR-1487)

### DIFF
--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -1586,7 +1586,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         if isinstance(mode, Mode):
             return mode
         raw_mode = mode
-        mode_key = mode.strip().upper()
+        mode_key = mode.strip().upper().replace("-", "_")
         try:
             return Mode[mode_key]
         except KeyError as exc:

--- a/tests/test_mode_label_coercion.py
+++ b/tests/test_mode_label_coercion.py
@@ -1,0 +1,96 @@
+"""MOR-1487 regression guard: rig-TOML mode labels vs. ``Mode`` enum tokens.
+
+The frontend mode buttons send the rig-TOML display label verbatim (e.g.
+``"CW-R"``, ``"RTTY-R"``) to ``IcomRadio.set_mode`` / ``._coerce_mode``. The
+backend ``Mode`` enum uses underscored tokens (``Mode.CW_R``,
+``Mode.RTTY_R``). This module is a table-driven guard, built from the same
+``discover_rigs`` profile loader the rest of the test suite and production
+code use (see ``tests/test_rig_loader.py``), so that any *future* rig TOML
+that adds a hyphenated mode label re-uses this normalization instead of
+silently drifting out of sync with the enum again.
+
+Scope note: only rig profiles that are actually reachable through
+``IcomRadio``/``CoreRadio`` (the class that owns ``_coerce_mode``) are
+covered here — see ``_CORERADIO_ROUTED_MODELS`` below, mirrored from
+``backends/factory.py::create_radio``'s model routing. Two pre-existing
+label/enum gaps are unrelated to the hyphen-normalization bug this ticket
+fixes (the labels have no ``Mode`` enum member at all, hyphenated or not)
+and are marked ``xfail(strict=True)`` rather than silently excluded, so a
+future full fix is visible as an actionable failure:
+
+- IC-7610 ``PSK`` / ``PSK-R`` — no ``Mode.PSK`` / ``Mode.PSK_R`` member.
+- X6200 ``DIGI`` — no ``Mode.DIGI`` member.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rigplane.profiles.rig_loader import discover_rigs
+from rigplane.radio import IcomRadio
+from rigplane.types import Mode
+
+RIGS_DIR = Path(__file__).resolve().parent.parent / "rigs"
+
+# Model names for which backends/factory.py::create_radio routes to an
+# IcomRadio/CoreRadio-derived class (the class that owns _coerce_mode).
+# Keep in sync with the SerialBackendConfig branch there.
+#   - Yaesu models (FTX-1, ...) go to YaesuCatRadio, which has its own,
+#     unrelated mode mapping (backends/yaesu_cat/radio.py) — not covered.
+#   - Any other model (e.g. X6100, TX-500) is rejected by create_radio
+#     with "Unsupported serial model" — those TOMLs exist as
+#     doc/hamlib-reference profiles only and are not reachable through
+#     _coerce_mode today.
+_CORERADIO_ROUTED_MODELS = {"IC-705", "IC-7300", "IC-7610", "IC-9700", "X6200"}
+
+# (model, label) pairs with no Mode enum member at all — a separate,
+# pre-existing gap, not a hyphen/underscore drift bug.
+_KNOWN_UNMAPPED_LABELS = {
+    ("IC-7610", "PSK"),
+    ("IC-7610", "PSK-R"),
+    ("X6200", "DIGI"),
+}
+
+
+def _coerce_mode_cases() -> list[object]:
+    rigs = discover_rigs(RIGS_DIR)
+    cases = []
+    for model in sorted(_CORERADIO_ROUTED_MODELS):
+        rig = rigs[model]
+        for label in rig.modes:
+            case_id = f"{model}:{label}"
+            if (model, label) in _KNOWN_UNMAPPED_LABELS:
+                cases.append(
+                    pytest.param(
+                        model,
+                        label,
+                        id=case_id,
+                        marks=pytest.mark.xfail(
+                            strict=True,
+                            reason=(
+                                f"{model} {label!r}: no Mode enum member exists "
+                                "for this label (pre-existing gap, unrelated to "
+                                "MOR-1487's hyphen-normalization fix)"
+                            ),
+                        ),
+                    )
+                )
+            else:
+                cases.append(pytest.param(model, label, id=case_id))
+    return cases
+
+
+@pytest.mark.parametrize(("model", "label"), _coerce_mode_cases())
+def test_rig_toml_mode_labels_coerce(model: str, label: str) -> None:
+    """Every mode label shipped for a CoreRadio-routed rig must coerce.
+
+    Guards against future label/token drift between rig TOMLs (hyphenated
+    display labels) and ``core.types.Mode`` (underscored enum tokens).
+    """
+    coerced = IcomRadio._coerce_mode(label)
+    assert isinstance(coerced, Mode)
+    # The coerced enum member's name must match the label modulo the
+    # documented hyphen<->underscore normalization.
+    assert coerced.name == label.strip().upper().replace("-", "_")

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -1544,6 +1544,54 @@ class TestSetModeFireAndForget:
 
 
 # ---------------------------------------------------------------------------
+# MOR-1487: hyphenated display labels ("CW-R", "RTTY-R") must coerce to the
+# underscored Mode enum tokens (Mode.CW_R, Mode.RTTY_R). The frontend sends
+# rig-TOML display labels verbatim; _coerce_mode is the boundary that must
+# normalize them.
+# ---------------------------------------------------------------------------
+
+
+class TestCoerceModeHyphenNormalization:
+    """Unit tests for ``IcomRadio._coerce_mode`` — no radio/transport needed."""
+
+    def test_coerce_mode_hyphenated_cw_r(self) -> None:
+        assert IcomRadio._coerce_mode("CW-R") == Mode.CW_R
+
+    def test_coerce_mode_hyphenated_rtty_r(self) -> None:
+        assert IcomRadio._coerce_mode("RTTY-R") == Mode.RTTY_R
+
+    def test_coerce_mode_hyphenated_lowercase_and_whitespace(self) -> None:
+        """Hyphen normalization composes with existing case/whitespace tolerance."""
+        assert IcomRadio._coerce_mode("  cw-r  ") == Mode.CW_R
+        assert IcomRadio._coerce_mode(" rtty-r ") == Mode.RTTY_R
+
+    def test_coerce_mode_mode_enum_passthrough_unchanged(self) -> None:
+        """A ``Mode`` instance is returned as-is, no string processing."""
+        assert IcomRadio._coerce_mode(Mode.CW_R) is Mode.CW_R
+
+    def test_coerce_mode_underscored_token_unchanged(self) -> None:
+        """Existing underscored-token behavior is preserved."""
+        assert IcomRadio._coerce_mode("CW_R") == Mode.CW_R
+        assert IcomRadio._coerce_mode("RTTY_R") == Mode.RTTY_R
+
+    def test_coerce_mode_plain_token_case_insensitive(self) -> None:
+        """Plain (non-hyphenated) tokens keep working, any case/whitespace."""
+        assert IcomRadio._coerce_mode(" usb ") == Mode.USB
+        assert IcomRadio._coerce_mode("Lsb") == Mode.LSB
+
+    def test_coerce_mode_invalid_still_raises_with_supported_modes_message(
+        self,
+    ) -> None:
+        """Truly unknown mode names still raise with the supported-modes list."""
+        with pytest.raises(ValueError, match="Unknown mode") as exc_info:
+            IcomRadio._coerce_mode("not-a-mode")
+        message = str(exc_info.value)
+        assert "Supported modes:" in message
+        assert "CW_R" in message
+        assert "RTTY_R" in message
+
+
+# ---------------------------------------------------------------------------
 # #48 regression: CI-V timeout isolation
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

Rig-TOML mode lists use hyphenated display labels for reverse/digital
variants (`"CW-R"`, `"RTTY-R"`), and the frontend sends these labels
verbatim to `IcomRadio.set_mode`. The `Mode` enum, however, uses
underscored tokens (`Mode.CW_R`, `Mode.RTTY_R`). Sending a hyphenated
label raised `ValueError: Unknown mode` instead of resolving to the
correct enum member.

## Root cause

`_coerce_mode` (`src/rigplane/runtime/radio.py:1589`) only
strips whitespace and upper-cases the raw string before enum lookup —
it never normalized the hyphen used in display labels to the
underscore used in `Mode` member names.

## Fix

One-line normalization in `_coerce_mode`: `.replace("-", "_")` after
`.strip().upper()`, so `"CW-R"` → `"CW_R"` → `Mode.CW_R` and
`"RTTY-R"` → `"RTTY_R"` → `Mode.RTTY_R`. Existing behavior (plain
tokens, underscored tokens, `Mode` passthrough, case/whitespace
tolerance, invalid-mode error message) is unchanged.

## Tests

- `tests/test_radio.py::TestCoerceModeHyphenNormalization` — unit
  tests for `_coerce_mode` covering hyphenated labels, underscored
  tokens, plain tokens, `Mode` passthrough, and the invalid-mode
  error path.
- `tests/test_mode_label_coercion.py` (new) — table-driven regression
  guard, parametrized over every mode label in every
  `CoreRadio`-routed rig TOML (IC-705, IC-7300, IC-7610, IC-9700,
  X6200), asserting each label coerces to the correctly-named `Mode`
  member.

Targeted run: `tests/test_mode_label_coercion.py` +
`tests/test_radio.py::TestCoerceModeHyphenNormalization` → 48 passed,
3 xfailed. Full `tests/test_radio.py` → 246 passed. `ruff check` and
`ruff format --check` clean. `mypy src/` has 13 pre-existing errors
in unrelated files (none in `radio.py` or the changed test files) —
this diff introduces none. Full suite is left to CI per repo policy.

### Known label/token gaps (out of scope)

Two rig-TOML mode labels have no `Mode` enum member at all — not a
hyphen/underscore drift, a real missing token — and are unrelated to
this hyphen-normalization fix. Marked `xfail(strict=True)` in the new
regression guard so a future fix is visible as an actionable failure
instead of silently passing:

- IC-7610 `PSK` / `PSK-R` — no `Mode.PSK` / `Mode.PSK_R` member.
- X6200 `DIGI` — no `Mode.DIGI` member.

Closes MOR-1487

🤖 Generated with [Claude Code](https://claude.com/claude-code)
