### PR TITLE
fix: prime never-observed policy fields on the acquisition-scheduler path (MOR-1490)

### DIFF
--- a/src/rigplane/core/acquisition_scheduler.py
+++ b/src/rigplane/core/acquisition_scheduler.py
@@ -625,6 +625,50 @@ class AcquisitionScheduler:
 
     poll_due_requests = due_requests
 
+    def prime_unobserved(
+        self,
+        observed_paths: Iterable[FieldPath],
+        *,
+        reason: str = "prime-unobserved",
+    ) -> tuple[AcquisitionRequest, ...]:
+        """Queue one BACKGROUND read per never-observed field with a policy.
+
+        ``StateStore.mark_stale_due`` only decays fields already present in
+        the store (MOR-432 keeps decay externally driven, but it still can't
+        decay what was never entered), and :meth:`due_requests` only cadence-
+        polls capabilities flagged ``polling=True``. A field carrying an
+        explicit :attr:`RadioAcquisitionProfile.field_policies` override that
+        is neither polled nor ever observed would otherwise stay ``UNKNOWN``
+        forever — no reconciliation hint is ever generated for it (MOR-1490).
+
+        This is a one-shot catch-up: the caller (:class:`StateFreshnessService`)
+        invokes it once per connect epoch, at :data:`AcquisitionPriority.BACKGROUND`
+        so it never competes with fast meters/PTT. Unsupported/hookless paths
+        fall out through the normal :meth:`ensure_fresh` availability gate, and
+        an unanswered prime is dropped by the existing
+        :meth:`record_acquisition_failure` accounting — no bespoke retry loop.
+        """
+
+        observed = frozenset(observed_paths)
+        queued: list[AcquisitionRequest] = []
+        for path, policy in self._profile.field_policies.items():
+            if path in observed:
+                continue
+            max_age = policy.freshness_ttl_seconds
+            if max_age is None or max_age <= 0:
+                max_age = policy.cadence_seconds
+            if max_age is None or max_age <= 0:
+                max_age = _MIN_RECONCILIATION_MAX_AGE
+            result = self.ensure_fresh(
+                (path,),
+                max_age=max_age,
+                priority=AcquisitionPriority.BACKGROUND,
+                reason=reason,
+            )
+            if result.request is not None:
+                queued.append(result.request)
+        return tuple(queued)
+
     def record_acquisition_result(
         self,
         request: AcquisitionRequest,
@@ -1362,7 +1406,13 @@ class StateFreshnessService:
     production delivery store.
     """
 
-    __slots__ = ("_interval_seconds", "_on_delta", "_scheduler", "_store")
+    __slots__ = (
+        "_interval_seconds",
+        "_on_delta",
+        "_primed_unobserved",
+        "_scheduler",
+        "_store",
+    )
 
     def __init__(
         self,
@@ -1377,16 +1427,35 @@ class StateFreshnessService:
         self._scheduler = scheduler
         self._interval_seconds = interval_seconds
         self._on_delta = on_delta
+        self._primed_unobserved = False
 
     def tick(self, *, now: float | None = None) -> SnapshotDelta:
         """Advance stale fields once and queue reconciliation through scheduler."""
 
+        self._prime_unobserved_once()
         delta = self._store.mark_stale_due(now=now)
         for request in delta.reconciliation_requests:
             self._queue_reconciliation(request)
         if (delta.freshness or delta.reconciliation_requests) and self._on_delta:
             self._on_delta(delta)
         return delta
+
+    def _prime_unobserved_once(self) -> None:
+        """Queue the connect-epoch catch-up read exactly once (MOR-1490).
+
+        Guarded by a flag rather than re-derived every tick: recomputing the
+        never-observed set from a full store snapshot on every 50ms tick would
+        add needless work to the hot freshness loop for a one-time event.
+        """
+
+        if self._primed_unobserved:
+            return
+        self._primed_unobserved = True
+        scheduler = self._scheduler
+        if scheduler is None:
+            return
+        observed = (field.path for field in self._store.snapshot().fields)
+        scheduler.prime_unobserved(observed)
 
     async def run(self) -> None:
         """Run the periodic freshness loop until cancelled by the host."""

--- a/src/rigplane/core/acquisition_scheduler.py
+++ b/src/rigplane/core/acquisition_scheduler.py
@@ -669,20 +669,59 @@ class AcquisitionScheduler:
         ``observed_paths`` gate here and the ``field_policies`` sweep never
         matters again for it.
 
-        Two guards keep one call from flooding the transport:
+        **Cadence-owned paths are skipped entirely**, not just deduped
+        against an in-flight request (MOR-1490 review R3): a
+        ``field_policies`` override doesn't imply the field is
+        *unpolled* — on the shipped IC-7300 profile all six overrides
+        (``s_meter``, ``ptt``, and the four 15s-cadence gain fields) sit on
+        capabilities with ``polling=True``. Priming one of those anyway
+        queues a request under the exact same
+        ``_AcquisitionRequestKey`` that :meth:`due_requests`'s
+        ``_due_poll_groups`` groups by, and that method skips a whole
+        cadence *group* — not just the one path — the instant its key is
+        already present in the pending-request table. Concretely: priming
+        one of the four gain fields sharing one cadence key silently starved
+        the group's ordinary t0 poll for the other three (measured live on
+        IC-7300: ``anti_vox_gain``'s first observation moved from t=0 to
+        t=+15s). A path whose capability is pollable and whose resolved
+        policy carries a ``cadence_seconds`` is therefore left to
+        :meth:`due_requests` entirely; this method never touches it,
+        regardless of whether it happens to also carry a ``field_policies``
+        entry. On the shipped IC-7300 profile this means
+        ``prime_unobserved`` queues nothing today — its effect is still
+        purely mechanism-only until a future non-polling field is added
+        (MOR-1491/1492/1493).
 
-        - **Already-pending skip**: a path with an outstanding, unanswered
-          request (still present in the internal pending-request table) is
+        Two further guards keep one call from flooding the transport:
+
+        - **Already-pending skip**: a (non-cadence-owned) path with an
+          outstanding, unanswered request from a previous prime call is
           skipped — re-submitting it would just coalesce into the same
           request without sending an additional frame, so it doesn't need to
-          consume this call's budget.
+          consume this call's budget. Because it doesn't consume budget,
+          the very next call to this method reaches paths a prior call left
+          short of the burst cap below — reaching them only requires this
+          method to be invoked again, not for the earlier paths to have
+          been *answered*. In production, "invoked again" is gated by
+          :data:`StateFreshnessService.PRIME_REDERIVE_INTERVAL_SECONDS`
+          (~30s), so that interval — not the leading paths' resolution — is
+          the practical bound on how long a capped-out straggler waits.
         - **Burst cap** (``limit``, default
           :data:`_PRIME_UNOBSERVED_BURST_LIMIT`): at most ``limit`` *new*
           paths are queued per call, so a profile with many non-polling
           policy fields can't emit a burst of CI-V frames in one drain cycle
-          (MOR-1490 review R2, Finding 4). Paths beyond the cap are simply
-          not reached this call; the next bounded re-derivation picks them
-          up.
+          (MOR-1490 review R2, Finding 4). Fields are visited in
+          ``field_policies`` iteration order (profile-declaration order), so
+          the same leading fields are always favored over later ones; if a
+          future profile ever declared five or more *permanently*
+          unanswerable non-polling fields ahead of a reachable one in that
+          order, the reachable one would starve indefinitely rather than
+          merely waiting out one interval. A round-robin ``_prime_cursor``
+          (rotating the starting offset into ``field_policies`` each call)
+          is the planned fix for that head-of-line case, expected to land
+          alongside the MOR-1491/1492/1493 field-membership tickets that
+          would first make it reachable; no shipped profile has that shape
+          today.
 
         The returned tuple has at most one entry per distinct
         :class:`AcquisitionRequest` id — multiple primed paths that coalesce
@@ -701,6 +740,15 @@ class AcquisitionScheduler:
             if queued_path_count >= limit:
                 break
             if path in observed or path in pending:
+                continue
+            if (
+                self._profile.capability_for(path).can_poll
+                and policy.cadence_seconds is not None
+            ):
+                # due_requests() already owns this path via its cadence
+                # group; priming it here would collide with that group's
+                # request key and starve due_requests()'s t0 poll for every
+                # other path sharing the group (MOR-1490 review R3).
                 continue
             max_age = policy.freshness_ttl_seconds
             if max_age is None or max_age <= 0:
@@ -1493,7 +1541,15 @@ class StateFreshnessService:
         self._next_prime_monotonic = float("-inf")
 
     def tick(self, *, now: float | None = None) -> SnapshotDelta:
-        """Advance stale fields once and queue reconciliation through scheduler."""
+        """Advance stale fields once and queue reconciliation through scheduler.
+
+        Invariant: ``now`` (explicit or defaulted) must come from the same
+        monotonic domain as ``self._next_prime_monotonic`` — callers that
+        pass a manually-seeded :class:`FreshnessClock` value must do so on
+        every call, since the default fallback is real ``time.monotonic()``
+        and mixing the two domains within one service instance would make
+        the bounded re-derivation interval comparison meaningless.
+        """
 
         timestamp = time.monotonic() if now is None else now
         self._reprime_unobserved_if_due(now=timestamp)

--- a/src/rigplane/core/acquisition_scheduler.py
+++ b/src/rigplane/core/acquisition_scheduler.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from collections.abc import Awaitable, Callable, Iterable, Sequence
 from dataclasses import dataclass, replace
 from enum import StrEnum
@@ -423,6 +424,14 @@ _PRIORITY_RANK: dict[AcquisitionPriority, int] = {
     AcquisitionPriority.USER: 4,
 }
 _MIN_RECONCILIATION_MAX_AGE = 1e-9
+# MOR-1490 review R2 (Finding 4): cap the number of never-before-queued paths
+# a single prime_unobserved() call will enqueue. Uncapped, a profile carrying
+# ~20 non-polling field_policies overrides would emit ~20 CI-V frames in one
+# drain cycle (~1s of serial time), starving BACKGROUND-priority meter/PTT
+# traffic that shares the same lane. StateFreshnessService's bounded 30s
+# re-derivation (see StateFreshnessService.PRIME_REDERIVE_INTERVAL_SECONDS)
+# picks up whatever this call didn't reach.
+_PRIME_UNOBSERVED_BURST_LIMIT = 5
 
 
 class AcquisitionScheduler:
@@ -630,8 +639,9 @@ class AcquisitionScheduler:
         observed_paths: Iterable[FieldPath],
         *,
         reason: str = "prime-unobserved",
+        limit: int = _PRIME_UNOBSERVED_BURST_LIMIT,
     ) -> tuple[AcquisitionRequest, ...]:
-        """Queue one BACKGROUND read per never-observed field with a policy.
+        """Queue BACKGROUND reads for never-observed fields with a policy.
 
         ``StateStore.mark_stale_due`` only decays fields already present in
         the store (MOR-432 keeps decay externally driven, but it still can't
@@ -641,18 +651,56 @@ class AcquisitionScheduler:
         is neither polled nor ever observed would otherwise stay ``UNKNOWN``
         forever — no reconciliation hint is ever generated for it (MOR-1490).
 
-        This is a one-shot catch-up: the caller (:class:`StateFreshnessService`)
-        invokes it once per connect epoch, at :data:`AcquisitionPriority.BACKGROUND`
-        so it never competes with fast meters/PTT. Unsupported/hookless paths
-        fall out through the normal :meth:`ensure_fresh` availability gate, and
-        an unanswered prime is dropped by the existing
-        :meth:`record_acquisition_failure` accounting — no bespoke retry loop.
+        The caller (:class:`StateFreshnessService`) re-derives the never-
+        observed set at a bounded interval (see
+        :data:`StateFreshnessService.PRIME_REDERIVE_INTERVAL_SECONDS`) rather
+        than once per connect epoch — a dropped/unanswered prime must not
+        leave a field ``UNKNOWN`` for the life of the connection (MOR-1490
+        review R2, Finding 1). Every call runs at
+        :data:`AcquisitionPriority.BACKGROUND` so priming never competes with
+        fast meters/PTT. Unsupported/hookless paths fall out through the
+        normal :meth:`ensure_fresh` availability gate, and an unanswered
+        prime is dropped by the existing :meth:`record_acquisition_failure`
+        accounting — no bespoke retry loop. In production the very first
+        prime typically runs while the store is still near-empty (the
+        backend's initial fetch is still in flight), so most policy fields
+        prime on every start — that is expected and self-extinguishing: the
+        moment a field lands its first observation it drops out of both the
+        ``observed_paths`` gate here and the ``field_policies`` sweep never
+        matters again for it.
+
+        Two guards keep one call from flooding the transport:
+
+        - **Already-pending skip**: a path with an outstanding, unanswered
+          request (still present in the internal pending-request table) is
+          skipped — re-submitting it would just coalesce into the same
+          request without sending an additional frame, so it doesn't need to
+          consume this call's budget.
+        - **Burst cap** (``limit``, default
+          :data:`_PRIME_UNOBSERVED_BURST_LIMIT`): at most ``limit`` *new*
+          paths are queued per call, so a profile with many non-polling
+          policy fields can't emit a burst of CI-V frames in one drain cycle
+          (MOR-1490 review R2, Finding 4). Paths beyond the cap are simply
+          not reached this call; the next bounded re-derivation picks them
+          up.
+
+        The returned tuple has at most one entry per distinct
+        :class:`AcquisitionRequest` id — multiple primed paths that coalesce
+        into the same request (identical scope/family/receiver/slot/
+        acquisition-method/policy) are represented once, carrying the
+        merged ``paths`` (MOR-1490 review R2, Finding 3).
         """
 
         observed = frozenset(observed_paths)
-        queued: list[AcquisitionRequest] = []
+        pending = frozenset(
+            path for request in self._requests_by_key.values() for path in request.paths
+        )
+        queued_by_id: dict[str, AcquisitionRequest] = {}
+        queued_path_count = 0
         for path, policy in self._profile.field_policies.items():
-            if path in observed:
+            if queued_path_count >= limit:
+                break
+            if path in observed or path in pending:
                 continue
             max_age = policy.freshness_ttl_seconds
             if max_age is None or max_age <= 0:
@@ -665,9 +713,11 @@ class AcquisitionScheduler:
                 priority=AcquisitionPriority.BACKGROUND,
                 reason=reason,
             )
-            if result.request is not None:
-                queued.append(result.request)
-        return tuple(queued)
+            if result.request is None:
+                continue
+            queued_path_count += 1
+            queued_by_id[result.request.id] = result.request
+        return tuple(queued_by_id.values())
 
     def record_acquisition_result(
         self,
@@ -1406,10 +1456,21 @@ class StateFreshnessService:
     production delivery store.
     """
 
+    #: Minimum spacing between never-observed-field re-derivations (MOR-1490
+    #: review R2, Finding 1). A one-shot "prime once per connect epoch" flag
+    #: means a single dropped/unanswered prime read leaves the field
+    #: ``UNKNOWN`` until the process restarts — reconnects don't rebuild this
+    #: service, so nothing ever re-arms the flag. Re-deriving on a bounded
+    #: interval instead is self-extinguishing: once a field is observed it
+    #: drops out of the ``observed_paths`` gate in
+    #: :meth:`AcquisitionScheduler.prime_unobserved` and this loop stops doing
+    #: anything for it, without needing to track per-field completion here.
+    PRIME_REDERIVE_INTERVAL_SECONDS: float = 30.0
+
     __slots__ = (
         "_interval_seconds",
+        "_next_prime_monotonic",
         "_on_delta",
-        "_primed_unobserved",
         "_scheduler",
         "_store",
     )
@@ -1427,12 +1488,15 @@ class StateFreshnessService:
         self._scheduler = scheduler
         self._interval_seconds = interval_seconds
         self._on_delta = on_delta
-        self._primed_unobserved = False
+        # -inf so the first tick always primes immediately, regardless of
+        # what monotonic clock value the caller starts at.
+        self._next_prime_monotonic = float("-inf")
 
     def tick(self, *, now: float | None = None) -> SnapshotDelta:
         """Advance stale fields once and queue reconciliation through scheduler."""
 
-        self._prime_unobserved_once()
+        timestamp = time.monotonic() if now is None else now
+        self._reprime_unobserved_if_due(now=timestamp)
         delta = self._store.mark_stale_due(now=now)
         for request in delta.reconciliation_requests:
             self._queue_reconciliation(request)
@@ -1440,20 +1504,26 @@ class StateFreshnessService:
             self._on_delta(delta)
         return delta
 
-    def _prime_unobserved_once(self) -> None:
-        """Queue the connect-epoch catch-up read exactly once (MOR-1490).
+    def _reprime_unobserved_if_due(self, *, now: float) -> None:
+        """Re-derive the never-observed-field prime at a bounded interval.
 
-        Guarded by a flag rather than re-derived every tick: recomputing the
-        never-observed set from a full store snapshot on every 50ms tick would
-        add needless work to the hot freshness loop for a one-time event.
+        Replaces the earlier "once per connect epoch" latch (MOR-1490 review
+        R2, Finding 1): that guard never reset on reconnect and permanently
+        stranded a field at ``UNKNOWN`` if its one prime read was dropped.
+        Re-running this at most every
+        :data:`PRIME_REDERIVE_INTERVAL_SECONDS` costs one
+        ``store.snapshot()`` plus a loop over ``field_policies`` — cheap
+        relative to the 30s window, and it self-extinguishes per field the
+        moment that field is observed (see
+        :meth:`AcquisitionScheduler.prime_unobserved`).
         """
 
-        if self._primed_unobserved:
-            return
-        self._primed_unobserved = True
         scheduler = self._scheduler
         if scheduler is None:
             return
+        if now < self._next_prime_monotonic:
+            return
+        self._next_prime_monotonic = now + self.PRIME_REDERIVE_INTERVAL_SECONDS
         observed = (field.path for field in self._store.snapshot().fields)
         scheduler.prime_unobserved(observed)
 

--- a/tests/test_acquisition_scheduler.py
+++ b/tests/test_acquisition_scheduler.py
@@ -1347,6 +1347,82 @@ def test_prime_unobserved_skips_unsupported_and_hookless_fields() -> None:
     assert scheduler.pending_requests() == ()
 
 
+def test_prime_unobserved_deduplicates_requests_for_coalesced_fields() -> None:
+    """MOR-1490 review R2, Finding 3: return contract for shared-policy groups.
+
+    Two policy fields that map to the same internal request key (identical
+    scope/family/receiver/slot/acquisition-method/policy) coalesce into ONE
+    ``AcquisitionRequest`` carrying both paths. ``prime_unobserved`` must
+    return that request once, not once per field it queued — a caller
+    counting "how many reads got sent" from a raw per-call queue list would
+    otherwise double count.
+    """
+
+    clock = FreshnessClock(start=304.0)
+    mic_gain = FieldPath.global_("operator_controls", "mic_gain")
+    cw_pitch = FieldPath.global_("operator_controls", "cw_pitch")
+    shared_policy = AcquisitionPolicy(cadence_seconds=15.0, freshness_ttl_seconds=25.0)
+    profile = RadioAcquisitionProfile(
+        provider="test_provider",
+        capabilities=(
+            FieldCapability(path=mic_gain, command_response_observable=True),
+            FieldCapability(path=cw_pitch, command_response_observable=True),
+        ),
+        field_policies={
+            mic_gain: shared_policy,
+            cw_pitch: shared_policy,
+        },
+    )
+    scheduler = AcquisitionScheduler(profile=profile, clock=clock)
+
+    queued = scheduler.prime_unobserved(observed_paths=())
+
+    assert len(queued) == 1
+    assert set(queued[0].paths) == {mic_gain, cw_pitch}
+    assert len({request.id for request in queued}) == len(queued)
+
+
+def test_prime_unobserved_caps_new_paths_and_next_call_queues_the_rest() -> None:
+    """MOR-1490 review R2, Finding 4: bounded burst per invocation.
+
+    With more unobserved policy fields than the burst cap, one call queues
+    only the cap's worth of NEW paths; the remaining fields are left
+    untouched (not deferred, not failed) so a later call — in production the
+    next bounded re-derivation — picks them up.
+    """
+
+    clock = FreshnessClock(start=305.0)
+    paths = [FieldPath.global_("operator_controls", f"field_{i}") for i in range(7)]
+    profile = RadioAcquisitionProfile(
+        provider="test_provider",
+        capabilities=tuple(
+            FieldCapability(path=path, command_response_observable=True)
+            for path in paths
+        ),
+        field_policies={
+            # Distinct policy per path so none of these coalesce into a
+            # shared request — keeps the per-call path count unambiguous.
+            path: AcquisitionPolicy(
+                cadence_seconds=15.0 + index, freshness_ttl_seconds=25.0
+            )
+            for index, path in enumerate(paths)
+        },
+    )
+    scheduler = AcquisitionScheduler(profile=profile, clock=clock)
+
+    first = scheduler.prime_unobserved(observed_paths=())
+    first_paths = {path for request in first for path in request.paths}
+    assert len(first_paths) == 5
+
+    second = scheduler.prime_unobserved(observed_paths=())
+    second_paths = {path for request in second for path in request.paths}
+    # The first 5 paths already have an outstanding (unanswered) request and
+    # are skipped, not re-queued — so the second call reaches exactly the
+    # remaining, never-attempted paths.
+    assert second_paths == set(paths) - first_paths
+    assert first_paths | second_paths == set(paths)
+
+
 def test_state_freshness_service_primes_once_then_reconciliation_cadence_resumes() -> (
     None
 ):
@@ -1395,7 +1471,24 @@ def test_state_freshness_service_primes_once_then_reconciliation_cadence_resumes
     assert reconciled[0].priority is AcquisitionPriority.RECONCILIATION
 
 
-def test_state_freshness_service_primes_exactly_once_across_many_ticks() -> None:
+def test_state_freshness_service_reprimes_unobserved_field_after_bounded_interval() -> (
+    None
+):
+    """MOR-1490 review R2, Finding 1: bounded re-derivation, not a one-shot latch.
+
+    Replaces the old "primes exactly once, ever" expectation. A boolean
+    latch meant a single dropped prime read stranded the field at
+    ``UNKNOWN`` until process restart — reconnects don't rebuild the
+    scheduler/service, so nothing ever re-armed the flag. The fix re-derives
+    the never-observed set at a bounded interval
+    (:data:`StateFreshnessService.PRIME_REDERIVE_INTERVAL_SECONDS`):
+
+    - no re-prime while inside the window;
+    - a re-prime once the window elapses, as long as the field is still
+      unobserved;
+    - no re-prime once the field has been observed (self-extinguishing).
+    """
+
     clock = FreshnessClock(start=320.0)
     mic_gain = FieldPath.global_("operator_controls", "mic_gain")
     profile = RadioAcquisitionProfile(
@@ -1414,17 +1507,21 @@ def test_state_freshness_service_primes_exactly_once_across_many_ticks() -> None
     service = StateFreshnessService(
         store=store, scheduler=scheduler, interval_seconds=1.0
     )
+    interval = StateFreshnessService.PRIME_REDERIVE_INTERVAL_SECONDS
 
     service.tick(now=clock.now())
     primed = scheduler.pending_requests()
     assert len(primed) == 1
+    assert primed[0].reason == "prime-unobserved"
 
-    # The radio never answers. Once the caller reports the (real, unhealthy)
-    # timeout, the scheduler drops the request outright — this field has no
-    # cadence-driven retry (mic_gain here is command-response-only), so no
-    # automatic requeue happens. That IS the existing backoff idiom for
-    # non-cadence fields (see AcquisitionScheduler.record_acquisition_failure);
-    # priming must not invent a bespoke retry loop on top of it.
+    # The radio never answers this first prime. Once the caller reports the
+    # (real, unhealthy) timeout, the scheduler drops the request outright —
+    # this field has no cadence-driven retry (mic_gain here is
+    # command-response-only), so no automatic requeue happens. That IS the
+    # existing backoff idiom for non-cadence fields (see
+    # AcquisitionScheduler.record_acquisition_failure); priming must not
+    # invent a bespoke retry loop on top of it — the bounded re-derivation
+    # below is what eventually catches this field back up.
     scheduler.record_acquisition_failure(
         primed[0],
         reason="acquisition_request_timeout",
@@ -1433,12 +1530,34 @@ def test_state_freshness_service_primes_exactly_once_across_many_ticks() -> None
     )
     assert scheduler.pending_requests() == ()
 
-    for _ in range(50):
+    # Inside the re-derivation window: no re-prime yet.
+    for _ in range(int(interval) - 1):
         clock.advance(1.0)
         service.tick(now=clock.now())
-
-    # No hot loop: the one-shot prime never re-fires on its own.
     assert scheduler.pending_requests() == ()
+
+    # Window elapses: the still-unobserved field gets re-primed.
+    clock.advance(1.0)
+    service.tick(now=clock.now())
+    reprimed = scheduler.pending_requests()
+    assert len(reprimed) == 1
+    assert reprimed[0].reason == "prime-unobserved"
+
+    # The radio answers this time — the field becomes observed.
+    change = store.apply(_observation(mic_gain, 40, at=clock.now(), max_age=25.0))
+    scheduler.record_acquisition_result(reprimed[0], change)
+    assert scheduler.pending_requests() == ()
+
+    # Advance past another full re-derivation window. The field is now
+    # observed, so prime_unobserved must self-extinguish for it — no
+    # "prime-unobserved" request should reappear (any ordinary stale-refresh
+    # reconciliation the freshness decay independently schedules is a
+    # separate, expected mechanism and is not asserted against here).
+    clock.advance(interval)
+    service.tick(now=clock.now())
+    assert all(
+        request.reason != "prime-unobserved" for request in scheduler.pending_requests()
+    )
 
 
 def test_unchanged_acquisition_result_decays_cadence_exponentially_and_caps() -> None:

--- a/tests/test_acquisition_scheduler.py
+++ b/tests/test_acquisition_scheduler.py
@@ -17,6 +17,7 @@ from rigplane.core.acquisition_scheduler import (
     IcomCivAcquisitionExecutor,
     MeterObservationCoalescer,
     RadioStateModelService,
+    StateFreshnessService,
 )
 from rigplane.core.state_acquisition_policy import (
     AcquisitionPolicy,
@@ -1240,6 +1241,204 @@ def test_due_polling_skips_unsupported_unhooked_and_unsolicited_only_fields() ->
 
     assert len(requests) == 1
     assert requests[0].paths == (supported,)
+
+
+def test_prime_unobserved_queues_background_read_for_never_observed_policy_field() -> (
+    None
+):
+    clock = FreshnessClock(start=300.0)
+    mic_gain = FieldPath.global_("operator_controls", "mic_gain")
+    profile = RadioAcquisitionProfile(
+        provider="test_provider",
+        capabilities=(
+            FieldCapability(path=mic_gain, command_response_observable=True),
+        ),
+        field_policies={
+            mic_gain: AcquisitionPolicy(
+                cadence_seconds=15.0, freshness_ttl_seconds=25.0
+            ),
+        },
+    )
+    scheduler = AcquisitionScheduler(profile=profile, clock=clock)
+
+    queued = scheduler.prime_unobserved(observed_paths=())
+
+    assert len(queued) == 1
+    assert queued[0].paths == (mic_gain,)
+    assert queued[0].priority is AcquisitionPriority.BACKGROUND
+    assert queued[0].reason == "prime-unobserved"
+    assert queued[0].acquisition_method == "command_response"
+    assert queued[0].max_age == 25.0
+    assert scheduler.pending_requests() == queued
+
+
+def test_prime_unobserved_skips_already_observed_field() -> None:
+    clock = FreshnessClock(start=301.0)
+    mic_gain = FieldPath.global_("operator_controls", "mic_gain")
+    profile = RadioAcquisitionProfile(
+        provider="test_provider",
+        capabilities=(
+            FieldCapability(path=mic_gain, command_response_observable=True),
+        ),
+        field_policies={
+            mic_gain: AcquisitionPolicy(
+                cadence_seconds=15.0, freshness_ttl_seconds=25.0
+            ),
+        },
+    )
+    scheduler = AcquisitionScheduler(profile=profile, clock=clock)
+
+    queued = scheduler.prime_unobserved(observed_paths=(mic_gain,))
+
+    assert queued == ()
+    assert scheduler.pending_requests() == ()
+
+
+def test_prime_unobserved_does_not_touch_fields_without_explicit_policy_override() -> (
+    None
+):
+    clock = FreshnessClock(start=302.0)
+    unlisted = FieldPath.global_("operator_controls", "squelch")
+    profile = RadioAcquisitionProfile(
+        provider="test_provider",
+        capabilities=(
+            FieldCapability(path=unlisted, command_response_observable=True),
+        ),
+        default_policy=AcquisitionPolicy(
+            cadence_seconds=5.0, freshness_ttl_seconds=15.0
+        ),
+        # Deliberately no explicit `field_policies` entry for `unlisted` — the
+        # prime pass only catches up fields with an explicit policy override
+        # (MOR-1490 scope: mechanism only, not blanket priming of every field
+        # that merely falls back to the profile default).
+    )
+    scheduler = AcquisitionScheduler(profile=profile, clock=clock)
+
+    queued = scheduler.prime_unobserved(observed_paths=())
+
+    assert queued == ()
+    assert scheduler.pending_requests() == ()
+
+
+def test_prime_unobserved_skips_unsupported_and_hookless_fields() -> None:
+    clock = FreshnessClock(start=303.0)
+    unsupported = FieldPath.global_("tx_state", "power_on")
+    unhooked = FieldPath.global_("health", "state")
+    profile = RadioAcquisitionProfile(
+        provider="test_provider",
+        capabilities=(
+            FieldCapability(
+                path=unsupported,
+                availability=FieldAvailability.UNSUPPORTED,
+                diagnostic="not exposed",
+            ),
+            FieldCapability(path=unhooked),
+        ),
+        field_policies={
+            unsupported: AcquisitionPolicy(freshness_ttl_seconds=10.0),
+            unhooked: AcquisitionPolicy(freshness_ttl_seconds=10.0),
+        },
+    )
+    scheduler = AcquisitionScheduler(profile=profile, clock=clock)
+
+    queued = scheduler.prime_unobserved(observed_paths=())
+
+    assert queued == ()
+    assert scheduler.pending_requests() == ()
+
+
+def test_state_freshness_service_primes_once_then_reconciliation_cadence_resumes() -> (
+    None
+):
+    clock = FreshnessClock(start=310.0)
+    mic_gain = FieldPath.global_("operator_controls", "mic_gain")
+    profile = RadioAcquisitionProfile(
+        provider="test_provider",
+        capabilities=(
+            FieldCapability(path=mic_gain, command_response_observable=True),
+        ),
+        field_policies={
+            mic_gain: AcquisitionPolicy(
+                cadence_seconds=15.0, freshness_ttl_seconds=25.0
+            ),
+        },
+    )
+    store = StateStore(freshness_clock=clock)
+    scheduler = AcquisitionScheduler(profile=profile, clock=clock)
+    service = StateFreshnessService(
+        store=store, scheduler=scheduler, interval_seconds=1.0
+    )
+
+    delta = service.tick(now=clock.now())
+
+    primed = scheduler.pending_requests()
+    assert len(primed) == 1
+    assert primed[0].reason == "prime-unobserved"
+    assert primed[0].priority is AcquisitionPriority.BACKGROUND
+    assert delta.reconciliation_requests == ()
+
+    # Radio answers the primed read; production credits it the same way a
+    # normal acquisition result is credited.
+    change = store.apply(_observation(mic_gain, 40, at=clock.now(), max_age=25.0))
+    scheduler.record_acquisition_result(primed[0], change)
+    assert scheduler.pending_requests() == ()
+
+    # Advance past the field's max_age: ordinary stale-refresh cadence now
+    # owns this field exactly like any other observed field.
+    clock.advance(25.1)
+    delta2 = service.tick(now=clock.now())
+
+    assert delta2.reconciliation_requests[0].path == mic_gain
+    reconciled = scheduler.pending_requests()
+    assert len(reconciled) == 1
+    assert reconciled[0].reason == "stale"
+    assert reconciled[0].priority is AcquisitionPriority.RECONCILIATION
+
+
+def test_state_freshness_service_primes_exactly_once_across_many_ticks() -> None:
+    clock = FreshnessClock(start=320.0)
+    mic_gain = FieldPath.global_("operator_controls", "mic_gain")
+    profile = RadioAcquisitionProfile(
+        provider="test_provider",
+        capabilities=(
+            FieldCapability(path=mic_gain, command_response_observable=True),
+        ),
+        field_policies={
+            mic_gain: AcquisitionPolicy(
+                cadence_seconds=15.0, freshness_ttl_seconds=25.0
+            ),
+        },
+    )
+    store = StateStore(freshness_clock=clock)
+    scheduler = AcquisitionScheduler(profile=profile, clock=clock)
+    service = StateFreshnessService(
+        store=store, scheduler=scheduler, interval_seconds=1.0
+    )
+
+    service.tick(now=clock.now())
+    primed = scheduler.pending_requests()
+    assert len(primed) == 1
+
+    # The radio never answers. Once the caller reports the (real, unhealthy)
+    # timeout, the scheduler drops the request outright — this field has no
+    # cadence-driven retry (mic_gain here is command-response-only), so no
+    # automatic requeue happens. That IS the existing backoff idiom for
+    # non-cadence fields (see AcquisitionScheduler.record_acquisition_failure);
+    # priming must not invent a bespoke retry loop on top of it.
+    scheduler.record_acquisition_failure(
+        primed[0],
+        reason="acquisition_request_timeout",
+        now=clock.now(),
+        link_healthy=False,
+    )
+    assert scheduler.pending_requests() == ()
+
+    for _ in range(50):
+        clock.advance(1.0)
+        service.tick(now=clock.now())
+
+    # No hot loop: the one-shot prime never re-fires on its own.
+    assert scheduler.pending_requests() == ()
 
 
 def test_unchanged_acquisition_result_decays_cadence_exponentially_and_caps() -> None:

--- a/tests/test_acquisition_scheduler.py
+++ b/tests/test_acquisition_scheduler.py
@@ -1423,6 +1423,40 @@ def test_prime_unobserved_caps_new_paths_and_next_call_queues_the_rest() -> None
     assert first_paths | second_paths == set(paths)
 
 
+def test_prime_unobserved_skips_pollable_cadence_owned_fields() -> None:
+    """MOR-1490 review R3: don't compete with due_requests() for the same key.
+
+    A field_policies override doesn't mean the field is unpolled. If the
+    capability is pollable and the resolved policy carries a
+    cadence_seconds, due_requests() already owns this path through its
+    normal cadence group. Priming it here queues a request under the same
+    _AcquisitionRequestKey that _due_poll_groups() checks — and that method
+    skips the WHOLE group, not just this path, the instant the key is
+    already pending. On the real IC-7300 profile this measurably delayed
+    anti_vox_gain's first observation from t=0 to t=+15s, because it shares
+    a cadence key with three other primed gain fields. prime_unobserved()
+    must leave polling-owned fields alone entirely.
+    """
+
+    clock = FreshnessClock(start=306.0)
+    mic_gain = FieldPath.global_("operator_controls", "mic_gain")
+    profile = RadioAcquisitionProfile(
+        provider="test_provider",
+        capabilities=(FieldCapability(path=mic_gain, polling=True),),
+        field_policies={
+            mic_gain: AcquisitionPolicy(
+                cadence_seconds=15.0, freshness_ttl_seconds=25.0
+            ),
+        },
+    )
+    scheduler = AcquisitionScheduler(profile=profile, clock=clock)
+
+    queued = scheduler.prime_unobserved(observed_paths=())
+
+    assert queued == ()
+    assert scheduler.pending_requests() == ()
+
+
 def test_state_freshness_service_primes_once_then_reconciliation_cadence_resumes() -> (
     None
 ):


### PR DESCRIPTION
## Mechanism

On the acquisition-scheduler radio path, `_send_query()` in
`radio_poller.py` delegates entirely to `_send_scheduler_requests()`
whenever `self._acquisition_scheduler is not None`; the legacy
`_STATE_QUERIES`/`_FAST_CMDS` round-robin is never consumed on scheduler
radios.

`_send_scheduler_requests()` drains two sources of acquisition work:

- `AcquisitionScheduler.due_requests()` — cadence-polls capabilities
  flagged `polling=True`.
- `StateStore.mark_stale_due()` → `StateFreshnessService._queue_reconciliation()`
  — re-requests fields that have gone `STALE`.

`mark_stale_due()` only iterates `StateStore._entries`, which is
populated exclusively by `StateStore.apply()` (i.e. by an actual prior
observation). A field with an explicit `field_policies` override that is
**not** `polling=True` (e.g. command-response-observable-only fields)
and has never been observed is therefore never a member of `_entries`,
never goes stale, and never gets a reconciliation hint — it stays
`UNKNOWN` for the life of the connection. No priming pass existed to
cover this gap.

**Scope note (corrected in review round 3):** on every profile shipped
today, this gap is latent, not live — but as of round 3,
`prime_unobserved()` now *enforces* that rather than merely assuming it.
`rig_loader.py` resolves all 6 `ic7300` `field_policies` overrides
(`s_meter`, `ptt`, and the four 15s-cadence gain fields) to
`polling=True`, i.e. already covered by `due_requests()`. Round 2's
claim that this made the mechanism inert was correct in *intent* but not
yet true in code — `prime_unobserved()` at that point primed any
unobserved `field_policies` path regardless of whether it was also
polling-owned, which round 3 found actively regressed live polling (see
"Review round 3" below). With the round-3 fix,
`AcquisitionScheduler.prime_unobserved()` explicitly skips any path
whose capability is pollable and whose resolved policy carries a
`cadence_seconds`, so it now genuinely queues zero reads on the shipped
IC-7300 profile (verified: `scheduler.prime_unobserved(observed_paths=())`
against `load_rig("rigs/ic7300.toml")` returns `()`). It starts doing
real work only once a future ticket (MOR-1491/1492/1493) adds a
`field_policies` override for a field that is genuinely non-polling
(e.g. command-response-only). This PR does **not** by itself repair any
currently-observed live IC-7300 symptom; it puts the machinery in place
for the tickets that will.

## Fix

- `AcquisitionScheduler.prime_unobserved(observed_paths)`: for every
  path with an explicit `field_policies` entry that isn't already in
  `observed_paths`, isn't already covered by a pollable+cadenced
  capability (owned by `due_requests()` — see "Review round 3"), and
  doesn't already have an outstanding, unanswered request (see burst cap
  below), queue one read via the existing `ensure_fresh()` path.
  Unsupported/hookless paths fall out through the normal `ensure_fresh`
  availability gate, so it's safe to call over the full policy set.
- `StateFreshnessService.tick()` calls this at a **bounded interval**
  (`StateFreshnessService.PRIME_REDERIVE_INTERVAL_SECONDS = 30.0`, in
  `src/rigplane/core/acquisition_scheduler.py`), not once per connect
  epoch (see "Review round 2" below for why the original one-shot latch
  was wrong).
- Legacy `_STATE_QUERIES`/`_FAST_CMDS` radios are untouched — the fix
  lives entirely inside the scheduler branch.

### Priming priority

Priming requests are queued at `AcquisitionPriority.BACKGROUND` — the
same priority `due_requests()` already uses for ordinary policy-cadence
polling. This keeps the catch-up reads from competing with
higher-priority acquisition (fast meters, PTT, user-issued reads) for
the same serial/LAN transaction budget.

### Cadence ownership

`prime_unobserved()` skips any path whose capability is pollable
(`can_poll`) and whose resolved policy has a `cadence_seconds` — that
path is already owned by `due_requests()`'s ordinary cadence-group
polling. Priming it anyway would queue a request under the exact same
internal request key that `due_requests()`'s group-level dedupe checks,
which skips a whole cadence *group* (not just the primed path) the
instant that key is already pending. This was round 3's regression fix
— see below.

### Burst cap

A single `prime_unobserved()` call queues at most
`_PRIME_UNOBSERVED_BURST_LIMIT = 5` **new** paths (module constant in
`acquisition_scheduler.py`). Uncapped, a profile carrying ~20
non-polling `field_policies` overrides (the shape the MOR-1491/1492/1493
child tickets will introduce) would emit ~20 CI-V frames in one drain
cycle (~1s of serial time) — BACKGROUND priority alone doesn't protect
against this, since ordinary meter/PTT polling also queues at
BACKGROUND and shares the same lane. Paths already carrying an
outstanding unanswered request are skipped (not re-submitted, not
counted against the cap); because skipped paths don't consume budget,
the very next `prime_unobserved()` call reaches whatever a prior call
left behind — that only requires the method to be called again, not for
the leading paths to have been answered. In production, "called again"
is gated by the 30s re-derivation interval, so that interval is the
practical bound on how long a capped-out straggler waits. Fields are
visited in profile-declaration order, so today's sweep always favors
the same leading fields; a future profile with 5+ *permanently*
unanswerable non-polling fields ahead of a reachable one would starve
it indefinitely rather than just waiting out one interval — a
round-robin `_prime_cursor` is the planned fix for that shape, expected
alongside MOR-1491/1492/1493 (no shipped profile has this shape today).

## Tests (`tests/test_acquisition_scheduler.py`)

- `test_prime_unobserved_queues_background_read_for_never_observed_policy_field`
- `test_prime_unobserved_skips_already_observed_field`
- `test_prime_unobserved_does_not_touch_fields_without_explicit_policy_override`
- `test_prime_unobserved_skips_unsupported_and_hookless_fields`
- `test_prime_unobserved_deduplicates_requests_for_coalesced_fields` (R2)
- `test_prime_unobserved_caps_new_paths_and_next_call_queues_the_rest` (R2)
- `test_prime_unobserved_skips_pollable_cadence_owned_fields` (new, R3)
- `test_state_freshness_service_primes_once_then_reconciliation_cadence_resumes`
- `test_state_freshness_service_reprimes_unobserved_field_after_bounded_interval`
  (R2 — replaces `..._primes_exactly_once_across_many_ticks`)

## Verification

- `uv run pytest tests/test_acquisition_scheduler.py tests/test_state_store.py tests/test_state_acquisition_policy.py -q` — 120 passed
- `uv run pytest tests/test_radio_poller_coverage.py tests/test_civ_rx_coverage.py -q` — 513 passed
- `uv run pytest tests/test_rigctld_handler.py tests/test_rigctld_server.py -q` — 437 passed
- `uv run ruff check src/ tests/` — clean
- `uv run ruff format --check src/ tests/` — clean
- `uv run mypy src/rigplane/core/acquisition_scheduler.py` — clean (repo-wide `mypy src/` has 13 pre-existing baseline errors in unrelated files, none touched by this change)
- Manual check against the real profile: `scheduler.prime_unobserved(observed_paths=())` on `load_rig("rigs/ic7300.toml")` returns `()`, and `due_requests()` at t0 still returns the full 4-path `mic_gain`/`monitor_gain`/`vox_gain`/`anti_vox_gain` group intact (the group `due_requests()` was silently dropping before the round-3 fix)

Scope: mechanism only, per MOR-1490 — field-membership additions
(which specific fields should carry a `field_policies` override) are
separate tickets.

Closes MOR-1490

---

## Review round 2

An independent verifier BLOCKED round 1 on four findings; all four are
addressed in this round.

**Finding 1 (blocking) — prime latched per-process, not per-connect;
a dropped prime stranded the field until restart.** The original
`_primed_unobserved` boolean was set once and never reset, and
reconnect (`_on_radio_reconnect()` in `web/server.py`) does not rebuild
the scheduler/service. A prime fired at connect time into a dead link
(radio not yet powered on, transient link issue) was dropped with no
requeue, and the field stayed `UNKNOWN` for the rest of the process's
life. Fixed by replacing the latch with a bounded periodic
re-derivation: `StateFreshnessService` now stores
`_next_prime_monotonic` and re-runs `prime_unobserved()` at most every
`PRIME_REDERIVE_INTERVAL_SECONDS` (30s), still at BACKGROUND priority.
It self-extinguishes per field the moment that field is observed — no
per-field bookkeeping needed, since `observed_paths` already excludes
it. Cost per re-run: one `store.snapshot()` + a loop over
`field_policies`, i.e. negligible relative to the 30s window.
`test_state_freshness_service_reprimes_unobserved_field_after_bounded_interval`
replaces the old "primes exactly once, ever" test and asserts: no
re-prime inside the window, a re-prime once the window elapses for a
still-unobserved field, and no re-prime once the field becomes
observed. All "once per connect epoch" wording (code + this PR body) is
corrected to describe the real guarantee: re-derived at a bounded
interval until observed.

**Finding 2 (PR-body correction) — mechanism is inert on every shipped
profile today.** Added the "Scope note" under Mechanism above (later
corrected again in round 3 — see below): all 6 `ic7300` `field_policies`
currently resolve `polling=True` (`rig_loader.py`), so they're already
covered by `due_requests()`. At the time this was a description of
intent that the round-2 code did not yet enforce; round 3 closed that
gap.

**Finding 3 (return contract + multi-field grouping untested).** On a
real profile, multiple paths can coalesce into one `AcquisitionRequest`
(same scope/family/receiver/slot/acquisition-method/policy), and
`prime_unobserved()` was returning one list entry per queued *path*
rather than per distinct request — the docstring's "one read per path"
promise didn't match a coalesced return. Fixed by de-duplicating the
returned tuple by request id (each distinct request appears once,
carrying its merged paths); documented as "at most one entry per
distinct request id" in the docstring. Added
`test_prime_unobserved_deduplicates_requests_for_coalesced_fields`
covering a shared-policy multi-field profile. Also added the
verifier-suggested docstring note: in production the first prime
typically runs while the store is still near-empty (the backend's
initial fetch is in flight), so most policy fields prime on every
start — expected, and self-extinguishing once each field lands its
first observation.

**Finding 4 (prime burst cap).** Added `_PRIME_UNOBSERVED_BURST_LIMIT =
5` and a `limit` parameter on `prime_unobserved()` (default 5); paths
with an outstanding unanswered request are also skipped so they don't
consume the budget. `test_prime_unobserved_caps_new_paths_and_next_call_queues_the_rest`
verifies a 7-field profile queues exactly 5 new paths on the first call
and the remaining 2 on the next. Chose the existing 30s re-derivation
interval as the natural catch-up mechanism for any paths left behind by
the cap, rather than adding a second, shorter timer — kept simple per
the "no bespoke retry loop" principle already used elsewhere in this
file.

## Review round 3

Round 2's burst cap surfaced (and the verifier measured) a regression
that actually predates round 2: `prime_unobserved()` never distinguished
"unobserved and unpolled" from merely "unobserved" — it primed *any*
unobserved `field_policies` path, polling-owned or not.

**Regression — priming a polling-owned path starves its whole cadence
group.** On the shipped IC-7300 profile, `mic_gain`, `monitor_gain`,
`vox_gain`, and `anti_vox_gain` all declare an identical 15s-cadence
`field_policies` override and are all `polling=True`, so they resolve to
the *same* internal request key and form one `due_requests()` cadence
group. Before this fix, priming even one of them (they're all
unobserved at connect) queued a request under that shared key, and
`due_requests()`'s group-level dedupe — which skips a whole group the
instant its key is already pending — then skipped the group's t0 poll
entirely for all four fields, not just the primed one. Measured effect:
`anti_vox_gain`'s first observation moved from t=0 to t=+15s. This also
falsified round 2's "inert on every shipped profile" PR-body claim: the
mechanism was not actually inert in round-2 code, only in round-2
intent.

**Fix.** `prime_unobserved()` now skips a path outright when
`self._profile.capability_for(path).can_poll` is true and
`self._profile.policy_for(path).cadence_seconds is not None` — i.e.
whenever `due_requests()` already owns it — before ever consuming burst
budget on it. New test
`test_prime_unobserved_skips_pollable_cadence_owned_fields` asserts a
pollable, cadenced field_policies path yields an empty prime. Manually
re-verified against the live IC-7300 profile: `prime_unobserved()`
returns `()`, and `due_requests()` at t0 returns the full intact
4-path gain group (previously silently dropped).

**On the "capped-out stragglers" wording.** The round-3 regression
report characterized the burst cap's remainder as waiting "until the
leading primes are answered." Re-verified against
`test_prime_unobserved_caps_new_paths_and_next_call_queues_the_rest`
(unchanged from round 2): calling `prime_unobserved()` twice back to
back, with *no* answer or failure recorded for the leading 5 paths in
between, already reaches the remaining paths on the second call — the
already-pending skip means a path not yet answered still doesn't block
or re-consume budget on a later call. The accurate statement (now in
the docstring) is: reaching a capped-out straggler requires the method
to be *invoked again*, not for the leading paths to be *answered*; in
production the interval between invocations is bounded by
`PRIME_REDERIVE_INTERVAL_SECONDS` (~30s) regardless of the leading
paths' resolution state. Flagging this correction explicitly here in
case the "waits for answers" framing was based on a different code path
than what's in this diff.

**Advisories folded in (docstring only, no behavior change):**
- Noted that a round-robin `_prime_cursor` (rotating the starting offset
  into `field_policies` each call) is the planned fix for head-of-line
  starvation if a future profile ever declares 5+ permanently
  unanswerable non-polling fields ahead of a reachable one — not needed
  today since no shipped profile has that shape, but worth flagging
  ahead of MOR-1491/1492/1493.
- Added a one-line clock-domain invariant on `StateFreshnessService.tick()`:
  the `now` passed in (or its `time.monotonic()` fallback) must be drawn
  from the same monotonic domain used to seed `_next_prime_monotonic`,
  or the bounded re-derivation interval comparison is meaningless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
