### PR TITLE
fix: surface the gating reason on disabled VFO ops and TUNE (MOR-1481)

### DIFF
--- a/frontend/src/lib/i18n/locales/en-US.json
+++ b/frontend/src/lib/i18n/locales/en-US.json
@@ -213,6 +213,10 @@
   "core.vfo.ops.quickDualWatch": "Quick dual watch",
   "core.vfo.splitDigest.rx": "RX {frequency}",
   "core.vfo.splitDigest.tx": "TX {frequency}",
+  "core.vfo.select.unknownSlotReason": "The radio has not confirmed this VFO's A/B identity yet, so it can't be selected.",
+  "core.vfo.select.receiverUnavailableReason": "This receiver is not available right now, so it can't be selected.",
+  "core.vfo.split.unknownReason": "The radio has not confirmed the split state yet.",
+  "core.vfo.dualWatch.unknownReason": "The radio has not confirmed the dual watch state yet.",
 
   "core.band.tx.reason.outOfBand": "your transmit frequency is outside the configured transmit ranges — tune the transmitting VFO into an allowed band",
   "core.band.tx.reason.targetUnknown": "the radio has not confirmed the frequency it would transmit on",

--- a/frontend/src/lib/i18n/locales/en-US.json
+++ b/frontend/src/lib/i18n/locales/en-US.json
@@ -215,8 +215,10 @@
   "core.vfo.splitDigest.tx": "TX {frequency}",
   "core.vfo.select.unknownSlotReason": "The radio has not confirmed this VFO's A/B identity yet, so it can't be selected.",
   "core.vfo.select.receiverUnavailableReason": "This receiver is not available right now, so it can't be selected.",
+  "core.vfo.select.pendingReason": "Waiting for the radio to confirm the selection.",
   "core.vfo.split.unknownReason": "The radio has not confirmed the split state yet.",
   "core.vfo.dualWatch.unknownReason": "The radio has not confirmed the dual watch state yet.",
+  "core.vfo.ops.identityUnknownReason": "The radio has not confirmed which VFO is A and which is B yet — press Select VFO A or Select VFO B first.",
 
   "core.band.tx.reason.outOfBand": "your transmit frequency is outside the configured transmit ranges — tune the transmitting VFO into an allowed band",
   "core.band.tx.reason.targetUnknown": "the radio has not confirmed the frequency it would transmit on",

--- a/frontend/src/lib/i18n/locales/ru-RU.json
+++ b/frontend/src/lib/i18n/locales/ru-RU.json
@@ -195,8 +195,10 @@
   "core.vfo.splitDigest.tx": "TX {frequency}",
   "core.vfo.select.unknownSlotReason": "Радио ещё не подтвердило идентичность (A/B) этого VFO, поэтому его нельзя выбрать.",
   "core.vfo.select.receiverUnavailableReason": "Этот приёмник сейчас недоступен, поэтому его нельзя выбрать.",
+  "core.vfo.select.pendingReason": "Ожидание подтверждения выбора от радио.",
   "core.vfo.split.unknownReason": "Радио ещё не подтвердило состояние split.",
   "core.vfo.dualWatch.unknownReason": "Радио ещё не подтвердило состояние dual watch.",
+  "core.vfo.ops.identityUnknownReason": "Радио ещё не подтвердило, какой VFO — A, а какой — B. Сначала нажмите Select VFO A или Select VFO B.",
 
   "core.band.tx.reason.outOfBand": "ваша частота передачи вне настроенных диапазонов передачи — переведите передающий VFO в разрешённый диапазон",
   "core.band.tx.reason.targetUnknown": "радио не подтвердило частоту, на которой оно будет передавать",

--- a/frontend/src/lib/i18n/locales/ru-RU.json
+++ b/frontend/src/lib/i18n/locales/ru-RU.json
@@ -193,6 +193,10 @@
   "core.vfo.ops.quickDualWatch": "Быстрый dual watch",
   "core.vfo.splitDigest.rx": "RX {frequency}",
   "core.vfo.splitDigest.tx": "TX {frequency}",
+  "core.vfo.select.unknownSlotReason": "Радио ещё не подтвердило идентичность (A/B) этого VFO, поэтому его нельзя выбрать.",
+  "core.vfo.select.receiverUnavailableReason": "Этот приёмник сейчас недоступен, поэтому его нельзя выбрать.",
+  "core.vfo.split.unknownReason": "Радио ещё не подтвердило состояние split.",
+  "core.vfo.dualWatch.unknownReason": "Радио ещё не подтвердило состояние dual watch.",
 
   "core.band.tx.reason.outOfBand": "ваша частота передачи вне настроенных диапазонов передачи — переведите передающий VFO в разрешённый диапазон",
   "core.band.tx.reason.targetUnknown": "радио не подтвердило частоту, на которой оно будет передавать",

--- a/frontend/src/semantic/TxAuxSurface.svelte
+++ b/frontend/src/semantic/TxAuxSurface.svelte
@@ -83,6 +83,24 @@
    *  readers) — the `data-disabled-reason` attribute `reasonOf` feeds is a
    *  test/CSS hook only, invisible to both. */
   const reasonTextOf = (f: TxAuxField<unknown>): string | undefined => disabledReasonText(f.availability);
+  /** MOR-1481: TUNE's own predicate for the ATU reading being unusable.
+   *  Deliberately NOT a bare `reasonTextOf(atu)` call: `disabledReasonText`
+   *  only reads `availability` (structural/operational) and has no view of
+   *  `reading.status`, so it misses the common startup window where
+   *  availability is fully declared but the reading has not arrived yet —
+   *  exactly the gap that left TUNE's `title` null while the button was
+   *  already disabled by `!usable(txAux.atu)` (the live-bench MOR-1481
+   *  report: "ATU: on" observed, yet no reason on hover — that case is the
+   *  TX-authority block below, but the same bug pattern applies here too).
+   *  Draws from the SAME two catalog keys `disabledReasonText` resolves — a
+   *  synthetic `{ structural: true, operational: false }` reaches its
+   *  "not yet observed" branch — so this is not a new vocabulary, just the
+   *  predicate widened to match what `disabled` on this button actually
+   *  gates on. */
+  const tuneAtuReasonText = (atu: TxAuxField<unknown>): string | undefined =>
+    (!atu.availability.structural
+      ? disabledReasonText(atu.availability)
+      : usable(atu) ? undefined : disabledReasonText({ structural: true, operational: false }));
   const textOf = (f: TxAuxField<unknown>): string =>
     f.reading.status !== 'known' ? '?'
       : typeof f.reading.value === 'boolean' ? (f.reading.value ? 'on' : 'off')
@@ -135,6 +153,28 @@
     disabledReasonText(f.availability) !== undefined ? `${reasonIdPrefix}-${field}` : undefined;
   let txAux = $derived(view.txAux);
   let tuneBlocked = $derived(keyBlockedReasons(view, tx));
+  /** MOR-1481: shares `reasonIdPrefix`'s instance number, same convention as
+   *  `reasonIdOf` above — a DEDICATED target, because `tuneAtuReasonText` is
+   *  a wider predicate than the ATU toggle's own `reasonIdOf('atu', …)` span
+   *  (see that function's comment) and the two can't always share one
+   *  element. */
+  const tuneAtuReasonId = `${reasonIdPrefix}-tune-atu`;
+  let tuneAtuReason = $derived(txAux ? tuneAtuReasonText(txAux.atu) : undefined);
+  /** MOR-1481: TUNE's own disabled reason — the ATU reading's unusability
+   *  when THAT is what blocks it, else the TX-authority `tuneBlocked`
+   *  reasons (rule (1) — same predicate, same import, as the key button),
+   *  joined the same way the visible `.tx-aux-blocked` list below already
+   *  states them. Never both: an unusable ATU reading makes the
+   *  TX-authority question moot. */
+  let tuneReasonText = $derived(
+    tuneAtuReason
+    ?? (tuneBlocked.length > 0 ? tuneBlocked.map((code) => BLOCKED_LABEL[code]).join('; ') : undefined),
+  );
+  let tuneDescribedBy = $derived(
+    [tuneAtuReason !== undefined ? tuneAtuReasonId : undefined, tuneBlocked.length > 0 ? blockedId : undefined]
+      .filter((id): id is string => id !== undefined)
+      .join(' ') || undefined,
+  );
 
   function toggle(field: TxAuxToggleField): void {
     if (txAux && usable(txAux[field])) onToggle?.(field);
@@ -173,10 +213,13 @@
         <!-- Transmit-causing. See the file header, rule (1). -->
         <button
           type="button" class="tx-aux-tune"
-          data-testid="tx-aux-atu-tune" aria-describedby={blockedId}
+          data-testid="tx-aux-atu-tune" title={tuneReasonText} aria-describedby={tuneDescribedBy}
           disabled={tuneBlocked.length > 0 || !usable(txAux.atu)}
           onclick={requestTune}
         >TUNE</button>
+        {#if tuneAtuReason !== undefined}
+          <span id={tuneAtuReasonId} class="sr-only">{tuneAtuReason}</span>
+        {/if}
       {/if}
     </div>
 

--- a/frontend/src/semantic/TxAuxSurface.svelte
+++ b/frontend/src/semantic/TxAuxSurface.svelte
@@ -78,29 +78,25 @@
   /** The MOR-977 `DisabledReasonCode` a present-but-unusable control carries. */
   const reasonOf = (f: TxAuxField<unknown>): 'field-not-observed' | undefined =>
     usable(f) ? undefined : 'field-not-observed';
-  /** MOR-1422: the SAME gate as `reasonOf`, rendered as operator-facing text
-   *  for `title` (hover) and the `aria-describedby` target below (screen
-   *  readers) — the `data-disabled-reason` attribute `reasonOf` feeds is a
-   *  test/CSS hook only, invisible to both. */
-  const reasonTextOf = (f: TxAuxField<unknown>): string | undefined => disabledReasonText(f.availability);
-  /** MOR-1481: TUNE's own predicate for the ATU reading being unusable.
-   *  Deliberately NOT a bare `reasonTextOf(atu)` call: `disabledReasonText`
-   *  only reads `availability` (structural/operational) and has no view of
-   *  `reading.status`, so it misses the common startup window where
-   *  availability is fully declared but the reading has not arrived yet —
-   *  exactly the gap that left TUNE's `title` null while the button was
-   *  already disabled by `!usable(txAux.atu)` (the live-bench MOR-1481
-   *  report: "ATU: on" observed, yet no reason on hover — that case is the
-   *  TX-authority block below, but the same bug pattern applies here too).
-   *  Draws from the SAME two catalog keys `disabledReasonText` resolves — a
+  /** MOR-1481 rework (R2): widened from a bare `disabledReasonText(f.availability)`
+   *  call. That original only read `availability` (structural/operational)
+   *  and had no view of `reading.status`, while `disabled` on every control
+   *  below gates on `usable(f)` — structural AND operational AND
+   *  `reading.status === 'known'`. The gap between the two predicates left
+   *  ALL TWELVE fields (not just TUNE, which was the first one caught on the
+   *  live bench) present-and-disabled with NO `title`/`aria-describedby`
+   *  whenever availability was fully declared but the reading itself had
+   *  not arrived yet. The predicate now matches what `disabled` actually
+   *  gates on — usable(), i.e. including reading.status — so reasonOf's
+   *  data hook and the operator-facing text can no longer disagree. Draws
+   *  from the SAME two catalog keys `disabledReasonText` resolves — a
    *  synthetic `{ structural: true, operational: false }` reaches its
    *  "not yet observed" branch — so this is not a new vocabulary, just the
-   *  predicate widened to match what `disabled` on this button actually
-   *  gates on. */
-  const tuneAtuReasonText = (atu: TxAuxField<unknown>): string | undefined =>
-    (!atu.availability.structural
-      ? disabledReasonText(atu.availability)
-      : usable(atu) ? undefined : disabledReasonText({ structural: true, operational: false }));
+   *  predicate widened to match `disabled`. */
+  const reasonTextOf = (f: TxAuxField<unknown>): string | undefined =>
+    (!f.availability.structural
+      ? disabledReasonText(f.availability)
+      : usable(f) ? undefined : disabledReasonText({ structural: true, operational: false }));
   const textOf = (f: TxAuxField<unknown>): string =>
     f.reading.status !== 'known' ? '?'
       : typeof f.reading.value === 'boolean' ? (f.reading.value ? 'on' : 'off')
@@ -148,18 +144,22 @@
   const reasonIdPrefix = `tx-aux-reason-${sequence}`;
   /** `aria-describedby` needs an ID to point at; `aria-description` (no ID,
    *  the string inline) is not yet in Svelte's own attribute typings —
-   *  `undefined` omits the attribute exactly when there is no reason. */
+   *  `undefined` omits the attribute exactly when there is no reason. Gates
+   *  on `reasonTextOf` itself (MOR-1481 rework R2), not a separate
+   *  `disabledReasonText(f.availability)` check — a second predicate here
+   *  could disagree with the text it is supposed to point at. */
   const reasonIdOf = (field: string, f: TxAuxField<unknown>): string | undefined =>
-    disabledReasonText(f.availability) !== undefined ? `${reasonIdPrefix}-${field}` : undefined;
+    reasonTextOf(f) !== undefined ? `${reasonIdPrefix}-${field}` : undefined;
   let txAux = $derived(view.txAux);
   let tuneBlocked = $derived(keyBlockedReasons(view, tx));
   /** MOR-1481: shares `reasonIdPrefix`'s instance number, same convention as
-   *  `reasonIdOf` above — a DEDICATED target, because `tuneAtuReasonText` is
-   *  a wider predicate than the ATU toggle's own `reasonIdOf('atu', …)` span
-   *  (see that function's comment) and the two can't always share one
-   *  element. */
+   *  `reasonIdOf` above — a DEDICATED target for TUNE's own reason span,
+   *  distinct from the ATU toggle's `reasonIdOf('atu', …)` span even though
+   *  both now read the same `reasonTextOf` (MOR-1481 rework R2: TUNE and the
+   *  ATU toggle are two different controls and must not share one
+   *  `aria-describedby` element). */
   const tuneAtuReasonId = `${reasonIdPrefix}-tune-atu`;
-  let tuneAtuReason = $derived(txAux ? tuneAtuReasonText(txAux.atu) : undefined);
+  let tuneAtuReason = $derived(txAux ? reasonTextOf(txAux.atu) : undefined);
   /** MOR-1481: TUNE's own disabled reason — the ATU reading's unusability
    *  when THAT is what blocks it, else the TX-authority `tuneBlocked`
    *  reasons (rule (1) — same predicate, same import, as the key button),
@@ -170,10 +170,18 @@
     tuneAtuReason
     ?? (tuneBlocked.length > 0 ? tuneBlocked.map((code) => BLOCKED_LABEL[code]).join('; ') : undefined),
   );
+  /** MOR-1481 rework (R2): mirrors `tuneReasonText`'s own `??` exclusivity —
+   *  it must, since `title` and `aria-describedby` describe the SAME
+   *  control and cannot disagree about how many reasons apply. The prior
+   *  shape concatenated `tuneAtuReasonId` and `blockedId` whenever BOTH
+   *  conditions were independently true, even though `tuneReasonText` above
+   *  shows only the ATU reason in that case (an unusable ATU reading makes
+   *  the TX-authority question moot) — a screen reader would then read a
+   *  second, TX-authority reason the visible `title` never mentioned. */
   let tuneDescribedBy = $derived(
-    [tuneAtuReason !== undefined ? tuneAtuReasonId : undefined, tuneBlocked.length > 0 ? blockedId : undefined]
-      .filter((id): id is string => id !== undefined)
-      .join(' ') || undefined,
+    tuneAtuReason !== undefined
+      ? tuneAtuReasonId
+      : (tuneBlocked.length > 0 ? blockedId : undefined),
   );
 
   function toggle(field: TxAuxToggleField): void {

--- a/frontend/src/semantic/VfoSurface.svelte
+++ b/frontend/src/semantic/VfoSurface.svelte
@@ -208,13 +208,15 @@
     return undefined;
   }
 
-  /** MOR-1481: equalize/swap carry exactly the one gate their `.vfo-ops`
-   *  container's own `title` already states. A `title`/`aria-describedby`
-   *  on an ancestor is not treated as the DESCENDANT control's own hover
-   *  text or accessible description, so this restates it on the button
-   *  itself. */
+  /** MOR-1481 rework (R2): this is the OPS ROW's own reason — no button here
+   *  "selects a VFO" (that is what `relativeSelectionHelp` describes, and it
+   *  is correct on the Select VFO A/B resolver buttons below, which DO). On
+   *  equalize/swap/quick-split/quick-dual-watch the operator has not
+   *  selected anything; the honest claim is that identity itself is
+   *  unresolved, so this draws from its own catalog key instead of
+   *  reusing the resolver buttons' English-only literal. */
   function identityOnlyReasonText(): string | undefined {
-    return relativeIdentityUnknown ? relativeSelectionHelp : undefined;
+    return relativeIdentityUnknown ? t('core.vfo.ops.identityUnknownReason') : undefined;
   }
   /** MOR-1481: quick-split's own operational gate
    *  (`viewModel.split.status === 'unknown'`) is the SAME condition
@@ -223,12 +225,12 @@
    *  apply — it is the more actionable claim (the A/B resolver exists for
    *  it), while nothing on this surface resolves an unread split state. */
   function quickSplitReasonText(): string | undefined {
-    if (relativeIdentityUnknown) return relativeSelectionHelp;
+    if (relativeIdentityUnknown) return t('core.vfo.ops.identityUnknownReason');
     return viewModel.split.status === 'unknown' ? t('core.vfo.split.unknownReason') : undefined;
   }
   /** Mirrors `quickSplitReasonText` for dual watch. */
   function quickDualWatchReasonText(): string | undefined {
-    if (relativeIdentityUnknown) return relativeSelectionHelp;
+    if (relativeIdentityUnknown) return t('core.vfo.ops.identityUnknownReason');
     return viewModel.dualWatch.status === 'unknown' ? t('core.vfo.dualWatch.unknownReason') : undefined;
   }
 
@@ -500,19 +502,30 @@
     {/each}
   </div>
   {#if relativeIdentityUnknown && relativeReceiver !== null}
+    {@const absoluteReason = disabled
+      ? t('core.vfo.select.receiverUnavailableReason')
+      : relativeSelectionPending
+        ? t('core.vfo.select.pendingReason')
+        : undefined}
+    {@const absoluteReasonId = reasonId('select-absolute', absoluteReason)}
     <div class="vfo-identity-selectors" data-testid="vfo-identity-selectors">
       <button
         type="button" class="vfo-select" data-vfo-select-absolute="A"
-        title={relativeSelectionHelp} aria-label="Select VFO A"
+        title={absoluteReason ?? relativeSelectionHelp} aria-label="Select VFO A"
+        aria-describedby={absoluteReasonId}
         disabled={disabled || relativeSelectionPending}
         onclick={() => selectAbsoluteSlot('A')}
       >Select VFO A</button>
       <button
         type="button" class="vfo-select" data-vfo-select-absolute="B"
-        title={relativeSelectionHelp} aria-label="Select VFO B"
+        title={absoluteReason ?? relativeSelectionHelp} aria-label="Select VFO B"
+        aria-describedby={absoluteReasonId}
         disabled={disabled || relativeSelectionPending}
         onclick={() => selectAbsoluteSlot('B')}
       >Select VFO B</button>
+      {#if absoluteReason !== undefined}
+        <span id={absoluteReasonId} class="sr-only">{absoluteReason}</span>
+      {/if}
     </div>
   {/if}
   {/if}

--- a/frontend/src/semantic/VfoSurface.svelte
+++ b/frontend/src/semantic/VfoSurface.svelte
@@ -586,7 +586,7 @@
       <div
         class="vfo-ops" data-testid="vfo-ops"
         data-disabled-reason={relativeIdentityUnknown ? 'vfo-identity-unknown' : undefined}
-        title={relativeIdentityUnknown ? relativeSelectionHelp : undefined}
+        title={identityOnlyReasonText()}
       >
         <button type="button" class="vfo-op" data-vfo-equalize
           title={equalizeReason} aria-describedby={reasonId('equalize', equalizeReason)}

--- a/frontend/src/semantic/VfoSurface.svelte
+++ b/frontend/src/semantic/VfoSurface.svelte
@@ -28,6 +28,11 @@
     receiver: ReceiverId;
     slot: VfoSlot;
   }
+
+  /** MOR-1481: per-instance counter for disabled-reason `aria-describedby`
+   *  targets, same convention as `TxAuxSurface`'s own `sequence` — several
+   *  mounted surfaces (dual-receiver cockpit) must not collide. */
+  let sequence = 0;
 </script>
 
 <script lang="ts">
@@ -177,6 +182,55 @@
   );
   let relativeSelectionPending = $state(false);
   const relativeSelectionHelp = 'Current A/B identity is unknown. Selecting this VFO will change the radio selection and establish identity.';
+
+  /** MOR-1481: this instance's id prefix for disabled-reason
+   *  `aria-describedby` targets (mirrors `TxAuxSurface`'s `reasonIdPrefix`). */
+  const reasonIdPrefix = `vfo-reason-${++sequence}`;
+  /** `aria-describedby` needs an id to point at; `undefined` omits the
+   *  attribute exactly when there is no reason — same convention as
+   *  `TxAuxSurface`'s `reasonIdOf`. */
+  function reasonId(suffix: string, text: string | undefined): string | undefined {
+    return text !== undefined ? `${reasonIdPrefix}-${suffix}` : undefined;
+  }
+
+  /**
+   * MOR-1481 — the operator-facing reason a per-tile select control is
+   * disabled. `selectDisabled` (computed per-tile below) combines two
+   * independent gates, and this mirrors them in the same priority: THIS
+   * VFO's own slot identity never resolved (the more specific claim — the
+   * A/B resolver buttons only apply while every VFO reads `relative`, not
+   * this case) beats the MOR-1256 strip-level `disabled` prop (the receiver
+   * itself is operationally unavailable).
+   */
+  function selectReasonText(vfo: VfoViewModel): string | undefined {
+    if (vfo.slot.kind === 'unknown') return t('core.vfo.select.unknownSlotReason');
+    if (disabled) return t('core.vfo.select.receiverUnavailableReason');
+    return undefined;
+  }
+
+  /** MOR-1481: equalize/swap carry exactly the one gate their `.vfo-ops`
+   *  container's own `title` already states. A `title`/`aria-describedby`
+   *  on an ancestor is not treated as the DESCENDANT control's own hover
+   *  text or accessible description, so this restates it on the button
+   *  itself. */
+  function identityOnlyReasonText(): string | undefined {
+    return relativeIdentityUnknown ? relativeSelectionHelp : undefined;
+  }
+  /** MOR-1481: quick-split's own operational gate
+   *  (`viewModel.split.status === 'unknown'`) is the SAME condition
+   *  `toggleSplit`'s fact-toggle carries below, so the two share one
+   *  catalog key rather than a parallel vocabulary. Identity wins when both
+   *  apply — it is the more actionable claim (the A/B resolver exists for
+   *  it), while nothing on this surface resolves an unread split state. */
+  function quickSplitReasonText(): string | undefined {
+    if (relativeIdentityUnknown) return relativeSelectionHelp;
+    return viewModel.split.status === 'unknown' ? t('core.vfo.split.unknownReason') : undefined;
+  }
+  /** Mirrors `quickSplitReasonText` for dual watch. */
+  function quickDualWatchReasonText(): string | undefined {
+    if (relativeIdentityUnknown) return relativeSelectionHelp;
+    return viewModel.dualWatch.status === 'unknown' ? t('core.vfo.dualWatch.unknownReason') : undefined;
+  }
 
   function slotKey(slot: VfoSlot): string {
     if (slot.kind === 'slotted') return slot.id;
@@ -423,16 +477,22 @@
           <span class="vfo-badge" data-vfo-tx-badge>{t('core.vfo.txTarget.label')}</span>
         {/if}
         {#if selectable}
+          {@const selectReason = selectReasonText(vfo)}
           <button
             type="button"
             class="vfo-select"
             data-vfo-select
             disabled={selectDisabled}
+            title={selectReason}
+            aria-describedby={reasonId(`select-${i}`, selectReason)}
             aria-label={t('core.vfo.selectAction', { label: vfo.label })}
             onclick={() => selectVfo(vfo)}
           >
             {vfo.label}
           </button>
+          {#if selectReason !== undefined}
+            <span id={reasonId(`select-${i}`, selectReason)} class="sr-only">{selectReason}</span>
+          {/if}
         {:else}
           <span class="vfo-label" data-vfo-label>{vfo.label}</span>
         {/if}
@@ -458,6 +518,8 @@
   {/if}
 
   {#if showRadioWideFacts}
+    {@const splitReason = viewModel.split.status === 'unknown' ? t('core.vfo.split.unknownReason') : undefined}
+    {@const dualWatchReason = viewModel.dualWatch.status === 'unknown' ? t('core.vfo.dualWatch.unknownReason') : undefined}
     <div class="fact-toggles">
       <button
         type="button"
@@ -466,11 +528,16 @@
         role="switch"
         aria-checked={triState(viewModel.split)}
         aria-label={t('core.vfo.split.label')}
+        title={splitReason}
+        aria-describedby={reasonId('split', splitReason)}
         disabled={viewModel.split.status === 'unknown'}
         onclick={toggleSplit}
       >
         {t('core.vfo.split.label')}: {stateWord(viewModel.split)}
       </button>
+      {#if splitReason !== undefined}
+        <span id={reasonId('split', splitReason)} class="sr-only">{splitReason}</span>
+      {/if}
       {#if hasDualReceiver}
         <button
           type="button"
@@ -479,11 +546,16 @@
           role="switch"
           aria-checked={triState(viewModel.dualWatch)}
           aria-label={t('core.vfo.dualWatch.label')}
+          title={dualWatchReason}
+          aria-describedby={reasonId('dual-watch', dualWatchReason)}
           disabled={viewModel.dualWatch.status === 'unknown'}
           onclick={toggleDualWatch}
         >
           {t('core.vfo.dualWatch.label')}: {stateWord(viewModel.dualWatch)}
         </button>
+        {#if dualWatchReason !== undefined}
+          <span id={reasonId('dual-watch', dualWatchReason)} class="sr-only">{dualWatchReason}</span>
+        {/if}
       {/if}
     </div>
 
@@ -494,21 +566,28 @@
       Button text is the accessible name; no `aria-label` duplicates it.
     -->
     {#if hasVfoPair}
+      {@const equalizeReason = identityOnlyReasonText()}
+      {@const swapReason = identityOnlyReasonText()}
+      {@const quickSplitReason = quickSplitReasonText()}
+      {@const quickDualWatchReason = quickDualWatchReasonText()}
       <div
         class="vfo-ops" data-testid="vfo-ops"
         data-disabled-reason={relativeIdentityUnknown ? 'vfo-identity-unknown' : undefined}
         title={relativeIdentityUnknown ? relativeSelectionHelp : undefined}
       >
         <button type="button" class="vfo-op" data-vfo-equalize
+          title={equalizeReason} aria-describedby={reasonId('equalize', equalizeReason)}
           disabled={relativeIdentityUnknown} onclick={() => { if (!relativeIdentityUnknown) onEqualizeVfos?.(); }}>
           {t('core.vfo.ops.equalize')}
         </button>
         <button type="button" class="vfo-op" data-vfo-swap
+          title={swapReason} aria-describedby={reasonId('swap', swapReason)}
           disabled={relativeIdentityUnknown} onclick={() => { if (!relativeIdentityUnknown) onSwapVfos?.(); }}>
           {t('core.vfo.ops.swap')}
         </button>
         <button
           type="button" class="vfo-op" data-vfo-quick-split
+          title={quickSplitReason} aria-describedby={reasonId('quick-split', quickSplitReason)}
           disabled={relativeIdentityUnknown || viewModel.split.status === 'unknown'}
           onclick={quickSplit}
         >
@@ -516,11 +595,24 @@
         </button>
         <button
           type="button" class="vfo-op" data-vfo-quick-dual-watch
+          title={quickDualWatchReason} aria-describedby={reasonId('quick-dual-watch', quickDualWatchReason)}
           disabled={relativeIdentityUnknown || viewModel.dualWatch.status === 'unknown'}
           onclick={quickDualWatch}
         >
           {t('core.vfo.ops.quickDualWatch')}
         </button>
+        {#if equalizeReason !== undefined}
+          <span id={reasonId('equalize', equalizeReason)} class="sr-only">{equalizeReason}</span>
+        {/if}
+        {#if swapReason !== undefined}
+          <span id={reasonId('swap', swapReason)} class="sr-only">{swapReason}</span>
+        {/if}
+        {#if quickSplitReason !== undefined}
+          <span id={reasonId('quick-split', quickSplitReason)} class="sr-only">{quickSplitReason}</span>
+        {/if}
+        {#if quickDualWatchReason !== undefined}
+          <span id={reasonId('quick-dual-watch', quickDualWatchReason)} class="sr-only">{quickDualWatchReason}</span>
+        {/if}
       </div>
 
       <!--
@@ -549,4 +641,8 @@
   .fact-toggles, .vfo-ops, .vfo-identity-selectors { display: flex; gap: 6px; flex-wrap: wrap; }
   .split-digest { display: flex; gap: 8px; margin: 0; font-size: 11px; color: var(--v2-text-subdued, rgba(255, 255, 255, 0.55)); }
   .split-digest[data-split-active='false'] { opacity: 0.64; }
+  /* MOR-1481: the `aria-describedby` target for a disabled control's reason
+     — present for screen readers, never painted (the `title` attribute
+     already carries the sighted-hover channel). Mirrors `TxAuxSurface`. */
+  .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
 </style>

--- a/frontend/src/semantic/__tests__/TxAuxSurface.test.ts
+++ b/frontend/src/semantic/__tests__/TxAuxSurface.test.ts
@@ -23,7 +23,7 @@ import TxAuxSurface, {
 } from '../TxAuxSurface.svelte';
 import { topologyFixtures, withTxAux } from '../fixtures/topologies';
 import type { Availability, RadioViewModel, TxAuxViewModel } from '../radio-view-model';
-import { keyBlockedReasons, type TxAuthoritySnapshot } from '../rx-tx-surface';
+import { BLOCKED_LABEL, keyBlockedReasons, type TxAuthoritySnapshot } from '../rx-tx-surface';
 
 const IDLE_RX: TxAuthoritySnapshot = {
   phase: 'idle', intent: null, radioTx: 'off', txRisk: 'none', mayOwnKey: false, fault: null,
@@ -339,6 +339,78 @@ describe('ATU TUNE is gated by the App TX authority, exactly like the key intent
   it('disables TUNE while the ATU status itself is unobserved', () => {
     const view = withField(base(), 'atu', { unknown: true });
     withSurface(view, snap(), (s) => expect(s.tune()!.disabled).toBe(true));
+  });
+});
+
+// ── 4b. MOR-1481: TUNE's own disabled reason ────────────────────────────────
+
+describe('TUNE carries its own disabled reason (MOR-1481)', () => {
+  /** Resolves EVERY `aria-describedby` target (the attribute may hold more
+   *  than one id — the ATU reason and the visible TX-authority list can
+   *  both apply, though never in the same test here) and returns the
+   *  concatenated text — the id alone would only prove wiring, not that a
+   *  screen reader has something to actually read. */
+  function describedText(el: HTMLElement): string | null {
+    const ids = el.getAttribute('aria-describedby')?.split(' ').filter(Boolean) ?? [];
+    if (ids.length === 0) return null;
+    return ids.map((id) => target.querySelector(`#${id}`)?.textContent ?? '').join(' ');
+  }
+
+  it('carries no reason text on hover or for screen readers once TUNE is usable', () => {
+    withSurface(base(), snap(), (s) => {
+      const tune = s.tune()!;
+      expect(tune.title).toBe('');
+      expect(tune.hasAttribute('aria-describedby')).toBe(false);
+    });
+  });
+
+  // The live-bench MOR-1481 report: ATU showed as observed ("ATU: on"), so
+  // this is the TX-authority block, not the ATU-unusable one — and TUNE's
+  // `title` was `null` regardless of which reason applied.
+  it.each(BLOCKING)('puts the TX-authority block reason on TUNE\'s title and aria-describedby while %s', (_label, over) => {
+    const view = base();
+    const tx = snap(over);
+    withSurface(view, tx, (s) => {
+      const tune = s.tune()!;
+      const expected = keyBlockedReasons(view, tx).map((code) => BLOCKED_LABEL[code]).join('; ');
+      expect(tune.title).toBe(expected);
+      expect(describedText(tune)).toBe(expected);
+    });
+  });
+
+  // MUTATION KILL: joining only the FIRST reason (or dropping the join
+  // entirely) instead of every code `keyBlockedReasons` returns.
+  it('joins multiple simultaneous TX-authority reasons on TUNE\'s title', () => {
+    const view = base();
+    const tx = snap({ fault: 'on-timeout', radioTx: 'on' });
+    const reasons = keyBlockedReasons(view, tx);
+    expect(reasons.length).toBeGreaterThan(1);
+    withSurface(view, tx, (s) => {
+      expect(s.tune()!.title).toBe(reasons.map((code) => BLOCKED_LABEL[code]).join('; '));
+    });
+  });
+
+  // The gap this ticket exists to close: `disabledReasonText` (used
+  // elsewhere in this file) only reads `availability`, so a fully-available
+  // ATU whose READING just has not arrived yet would otherwise leave
+  // `title` empty despite `disabled` being true.
+  it('puts "Not yet observed" on TUNE\'s title and aria-describedby when the ATU reading itself is unobserved, even with availability fully declared', () => {
+    const view = withField(base(), 'atu', { unknown: true });
+    withSurface(view, snap(), (s) => {
+      const tune = s.tune()!;
+      expect(tune.title).toBe('Not yet observed');
+      expect(describedText(tune)).toBe('Not yet observed');
+    });
+  });
+
+  // Never both: an unusable ATU reading makes the TX-authority question
+  // moot, so its reason wins even while a TX-authority block also applies.
+  it('prefers the ATU-unobserved reason over a TX-authority block when both apply', () => {
+    const view = withField(base(), 'atu', { unknown: true });
+    const tx = snap({ fault: 'on-timeout' });
+    withSurface(view, tx, (s) => {
+      expect(s.tune()!.title).toBe('Not yet observed');
+    });
   });
 });
 

--- a/frontend/src/semantic/__tests__/TxAuxSurface.test.ts
+++ b/frontend/src/semantic/__tests__/TxAuxSurface.test.ts
@@ -207,6 +207,32 @@ describe('the disabled reason is exposed on hover and to screen readers (MOR-142
       expect(control.hasAttribute('aria-describedby')).toBe(false);
     });
   });
+
+  // MOR-1481 rework (R2). The gap this witness closes: `reasonTextOf` used to
+  // be a bare `disabledReasonText(f.availability)` call, which only reads
+  // `availability` (structural/operational) and has no view of
+  // `reading.status` — while `disabled` on every control gates on `usable(f)`,
+  // which DOES include `reading.status`. A field with availability fully
+  // declared but an unobserved reading was therefore rendered disabled with
+  // NO title and NO aria-describedby, for EVERY ONE of the twelve fields on
+  // this surface (TUNE was merely the first instance caught on the live
+  // bench; the fix had to move into the shared `reasonTextOf`/`reasonIdOf`
+  // helpers so all twelve stop sharing the defect, not just ATU).
+  it.each(ALL_FIELDS)(
+    'puts "Not yet observed" on title and aria-describedby for "%s" when only its READING is unobserved',
+    (field) => {
+      const view = withField(base(), field, { unknown: true });
+      withSurface(view, snap(), (s) => {
+        // Toggles carry title/aria-describedby on the <button> itself; level
+        // fields carry it on the <input> inside the <label> (same split
+        // `isDisabled` above already draws).
+        const control = s.control(field)!;
+        const el = control instanceof HTMLButtonElement ? control : s.input(field)!;
+        expect(el.title, field).toBe('Not yet observed');
+        expect(describedText(el), field).toBe('Not yet observed');
+      });
+    },
+  );
 });
 
 // ── 3. VOX — safety note (ii), arming voice keying ─────────────────────────
@@ -410,6 +436,24 @@ describe('TUNE carries its own disabled reason (MOR-1481)', () => {
     const tx = snap({ fault: 'on-timeout' });
     withSurface(view, tx, (s) => {
       expect(s.tune()!.title).toBe('Not yet observed');
+    });
+  });
+
+  // MOR-1481 rework (R2, finding 4): `aria-describedby` must agree with
+  // `title` about how many reasons apply — a screen reader reading a second,
+  // TX-authority-block reason the visible title never mentions would
+  // contradict the "never both" doctrine above. Both `keyBlockedReasons`
+  // (fault latched) AND the ATU-unobserved gate apply simultaneously here,
+  // so this is the actual "both" case, not a vacuous one.
+  it('points aria-describedby at exactly the ATU reason, never both, when a TX-authority block also applies', () => {
+    const view = withField(base(), 'atu', { unknown: true });
+    const tx = snap({ fault: 'on-timeout' });
+    expect(keyBlockedReasons(view, tx).length).toBeGreaterThan(0);
+    withSurface(view, tx, (s) => {
+      const tune = s.tune()!;
+      const ids = tune.getAttribute('aria-describedby')?.split(' ').filter(Boolean) ?? [];
+      expect(ids).toHaveLength(1);
+      expect(describedText(tune)).toBe('Not yet observed');
     });
   });
 });

--- a/frontend/src/semantic/__tests__/VfoSurface.test.ts
+++ b/frontend/src/semantic/__tests__/VfoSurface.test.ts
@@ -796,6 +796,128 @@ describe('VFO ops (MOR-1321) — unknown honesty on the quick triggers', () => {
   });
 });
 
+describe('VFO ops disabled reasons (MOR-1481)', () => {
+  const base = topologyFixtures['2/main_sub'];
+
+  /** Resolves a control's `aria-describedby` target and returns ITS text —
+   *  the id alone would only prove wiring, not that a screen reader has
+   *  something to actually read. Mirrors `TxAuxSurface.test.ts`'s helper. */
+  function describedText(target: HTMLElement, el: HTMLElement): string | null {
+    const id = el.getAttribute('aria-describedby');
+    if (!id) return null;
+    return target.querySelector(`#${id}`)?.textContent ?? null;
+  }
+
+  it('carries no reason text on hover or for screen readers on any op button once every fact is known', () => {
+    const target = mountSurface({ viewModel: base });
+    for (const op of ['equalize', 'swap', 'quick-split', 'quick-dual-watch'] as const) {
+      const button = target.querySelector<HTMLButtonElement>(`[data-vfo-${op}]`)!;
+      expect(button.title, op).toBe('');
+      expect(button.hasAttribute('aria-describedby'), op).toBe(false);
+    }
+  });
+
+  it('puts the identity reason on every op button\'s own title and aria-describedby while A/B identity is unknown', () => {
+    const model: RadioViewModel = validateRadioViewModel({
+      ...topologyFixtures['1/ab'],
+      vfos: topologyFixtures['1/ab'].vfos.map((vfo, index) => ({
+        ...vfo,
+        slot: { kind: 'relative', role: index === 0 ? 'selected' : 'unselected' },
+        label: index === 0 ? 'Selected VFO' : 'Unselected VFO',
+        isActive: index === 0,
+        isActiveSlot: index === 0,
+      })),
+    });
+    const target = mountSurface({ viewModel: model });
+    const expected = 'Current A/B identity is unknown. Selecting this VFO will change the radio selection and establish identity.';
+    for (const op of ['equalize', 'swap', 'quick-split', 'quick-dual-watch'] as const) {
+      const button = target.querySelector<HTMLButtonElement>(`[data-vfo-${op}]`)!;
+      expect(button.disabled, op).toBe(true);
+      expect(button.title, op).toBe(expected);
+      expect(describedText(target, button), op).toBe(expected);
+    }
+  });
+
+  it('puts a split-specific reason on quick split (and the split fact-toggle) while identity is known but split is unknown', () => {
+    const model = validateRadioViewModel({ ...base, split: { status: 'unknown' } });
+    const target = mountSurface({ viewModel: model });
+    const button = target.querySelector<HTMLButtonElement>('[data-vfo-quick-split]')!;
+    expect(button.disabled).toBe(true);
+    expect(button.title).toBe('The radio has not confirmed the split state yet.');
+    expect(describedText(target, button)).toBe('The radio has not confirmed the split state yet.');
+    // Neither equalize nor swap depends on split — neither carries this reason.
+    expect(target.querySelector<HTMLButtonElement>('[data-vfo-equalize]')!.title).toBe('');
+    const toggle = target.querySelector<HTMLButtonElement>('[data-vfo-split]')!;
+    expect(toggle.title).toBe('The radio has not confirmed the split state yet.');
+    expect(describedText(target, toggle)).toBe('The radio has not confirmed the split state yet.');
+  });
+
+  it('puts a dual-watch-specific reason on quick dual watch (and the dual-watch fact-toggle) while identity is known but dualWatch is unknown', () => {
+    const model = validateRadioViewModel({ ...base, dualWatch: { status: 'unknown' } });
+    const target = mountSurface({ viewModel: model });
+    const button = target.querySelector<HTMLButtonElement>('[data-vfo-quick-dual-watch]')!;
+    expect(button.disabled).toBe(true);
+    expect(button.title).toBe('The radio has not confirmed the dual watch state yet.');
+    expect(describedText(target, button)).toBe('The radio has not confirmed the dual watch state yet.');
+    const toggle = target.querySelector<HTMLButtonElement>('[data-vfo-dual-watch]')!;
+    expect(toggle.title).toBe('The radio has not confirmed the dual watch state yet.');
+    expect(describedText(target, toggle)).toBe('The radio has not confirmed the dual watch state yet.');
+  });
+
+  it('a per-tile select control disabled by its own unknown slot carries a reason', () => {
+    const base1ab = topologyFixtures['1/ab'];
+    const model: RadioViewModel = validateRadioViewModel({
+      ...base1ab,
+      vfos: [base1ab.vfos[0], { ...base1ab.vfos[1], slot: { kind: 'unknown' } }],
+    });
+    const target = mountSurface({ viewModel: model });
+    const button = target.querySelectorAll<HTMLButtonElement>('[data-vfo-select]')[0];
+    const expected = "The radio has not confirmed this VFO's A/B identity yet, so it can't be selected.";
+    expect(button.disabled).toBe(true);
+    expect(button.title).toBe(expected);
+    expect(describedText(target, button)).toBe(expected);
+  });
+
+  it('a per-tile select control forced off by the MOR-1256 strip-level `disabled` prop carries a reason', () => {
+    const target = mountSurface({ viewModel: base, disabled: true });
+    const button = target.querySelectorAll<HTMLButtonElement>('[data-vfo-select]')[0];
+    const expected = "This receiver is not available right now, so it can't be selected.";
+    expect(button.disabled).toBe(true);
+    expect(button.title).toBe(expected);
+    expect(describedText(target, button)).toBe(expected);
+  });
+
+  it('an enabled per-tile select control carries no reason', () => {
+    const target = mountSurface({ viewModel: base });
+    const button = target.querySelector<HTMLButtonElement>('[data-vfo-select]')!;
+    expect(button.disabled).toBe(false);
+    expect(button.title).toBe('');
+    expect(button.hasAttribute('aria-describedby')).toBe(false);
+  });
+
+  // Two independently mounted surfaces (the dual-receiver cockpit's real
+  // shape) must not collide on `aria-describedby` target ids.
+  it('reason ids stay unique across two mounted surfaces', () => {
+    const model: RadioViewModel = validateRadioViewModel({
+      ...topologyFixtures['1/ab'],
+      vfos: topologyFixtures['1/ab'].vfos.map((vfo, index) => ({
+        ...vfo,
+        slot: { kind: 'relative', role: index === 0 ? 'selected' : 'unselected' },
+        label: index === 0 ? 'Selected VFO' : 'Unselected VFO',
+        isActive: index === 0,
+        isActiveSlot: index === 0,
+      })),
+    });
+    const targetA = mountSurface({ viewModel: model });
+    const targetB = mountSurface({ viewModel: model });
+    const idA = targetA.querySelector<HTMLButtonElement>('[data-vfo-equalize]')!.getAttribute('aria-describedby');
+    const idB = targetB.querySelector<HTMLButtonElement>('[data-vfo-equalize]')!.getAttribute('aria-describedby');
+    expect(idA).not.toBeNull();
+    expect(idB).not.toBeNull();
+    expect(idA).not.toBe(idB);
+  });
+});
+
 describe('split RX/TX digest (MOR-1321)', () => {
   // Kills: reading TX off the active VFO (or RX off the TX target) — the two
   // sides would then agree by construction and the digest could never show the

--- a/frontend/src/semantic/__tests__/VfoSurface.test.ts
+++ b/frontend/src/semantic/__tests__/VfoSurface.test.ts
@@ -23,6 +23,7 @@ import VfoSurface from '../VfoSurface.svelte';
 import { validateRadioViewModel, type RadioViewModel, type VfoSlot } from '../radio-view-model';
 import { topologyFixtures, withAudioOnlyScope, type TopologyFixtureId } from '../fixtures/topologies';
 import { createTuningAccumulator } from '$lib/runtime/commands/tuning-accumulator';
+import { setLocale, _resetLocale } from '$lib/i18n/store.svelte';
 
 const ids: readonly TopologyFixtureId[] = ['1/single', '1/ab', '2/ab_shared', '2/main_sub'];
 
@@ -829,12 +830,46 @@ describe('VFO ops disabled reasons (MOR-1481)', () => {
       })),
     });
     const target = mountSurface({ viewModel: model });
-    const expected = 'Current A/B identity is unknown. Selecting this VFO will change the radio selection and establish identity.';
+    // MOR-1481 rework (R2): the ops row is not a resolver button — no button
+    // here "selects a VFO", so its reason must NOT be the resolver buttons'
+    // `relativeSelectionHelp` literal (false here: it is a different claim,
+    // and that literal is also not in the i18n catalog). This is the honest
+    // catalog text instead.
+    const falseResolverLiteral = 'Current A/B identity is unknown. Selecting this VFO will change the radio selection and establish identity.';
+    const expected = 'The radio has not confirmed which VFO is A and which is B yet — press Select VFO A or Select VFO B first.';
     for (const op of ['equalize', 'swap', 'quick-split', 'quick-dual-watch'] as const) {
       const button = target.querySelector<HTMLButtonElement>(`[data-vfo-${op}]`)!;
       expect(button.disabled, op).toBe(true);
       expect(button.title, op).toBe(expected);
+      expect(button.title, op).not.toBe(falseResolverLiteral);
       expect(describedText(target, button), op).toBe(expected);
+    }
+  });
+
+  // MOR-1481 rework (R2): the catalog key resolves per-locale, not just an
+  // honest-in-English literal — pin ru-RU directly so a future regression
+  // back to a hardcoded (English-only) string is caught even if it happens
+  // to read as plausible prose in English.
+  it('resolves the ops-row identity reason from the i18n catalog and renders Russian under ru-RU', () => {
+    const model: RadioViewModel = validateRadioViewModel({
+      ...topologyFixtures['1/ab'],
+      vfos: topologyFixtures['1/ab'].vfos.map((vfo, index) => ({
+        ...vfo,
+        slot: { kind: 'relative', role: index === 0 ? 'selected' : 'unselected' },
+        label: index === 0 ? 'Selected VFO' : 'Unselected VFO',
+        isActive: index === 0,
+        isActiveSlot: index === 0,
+      })),
+    });
+    setLocale('ru-RU');
+    try {
+      const target = mountSurface({ viewModel: model });
+      const expectedRu = 'Радио ещё не подтвердило, какой VFO — A, а какой — B. Сначала нажмите Select VFO A или Select VFO B.';
+      const button = target.querySelector<HTMLButtonElement>('[data-vfo-equalize]')!;
+      expect(button.title).toBe(expectedRu);
+      expect(describedText(target, button)).toBe(expectedRu);
+    } finally {
+      _resetLocale();
     }
   });
 
@@ -893,6 +928,64 @@ describe('VFO ops disabled reasons (MOR-1481)', () => {
     expect(button.disabled).toBe(false);
     expect(button.title).toBe('');
     expect(button.hasAttribute('aria-describedby')).toBe(false);
+  });
+
+  // MOR-1481 rework (R2): the Select VFO A/B resolver buttons used to render
+  // no reason at all whenever the MOR-1256 strip-level `disabled` prop forced
+  // them off (a silent, unexplained disabled control), and always fell back
+  // to `relativeSelectionHelp` while a resolution was merely pending (a
+  // promise the radio was not, in that instant, capable of keeping).
+  describe('Select VFO A/B resolver buttons carry an honest reason (MOR-1481 rework)', () => {
+    const relativeModel = (): RadioViewModel => validateRadioViewModel({
+      ...topologyFixtures['1/ab'],
+      vfos: topologyFixtures['1/ab'].vfos.map((vfo, index) => ({
+        ...vfo,
+        slot: { kind: 'relative', role: index === 0 ? 'selected' : 'unselected' },
+        label: index === 0 ? 'Selected VFO' : 'Unselected VFO',
+        isActive: index === 0,
+        isActiveSlot: index === 0,
+      })),
+    });
+
+    it('carries the receiver-unavailable reason when forced off by the strip-level `disabled` prop', () => {
+      const target = mountSurface({ viewModel: relativeModel(), disabled: true });
+      const expected = "This receiver is not available right now, so it can't be selected.";
+      for (const id of ['A', 'B'] as const) {
+        const button = target.querySelector<HTMLButtonElement>(`[data-vfo-select-absolute="${id}"]`)!;
+        expect(button.disabled, id).toBe(true);
+        expect(button.title, id).toBe(expected);
+        expect(describedText(target, button), id).toBe(expected);
+      }
+    });
+
+    it('carries the pending reason — not the receiver-unavailable one — while a resolution is in flight', () => {
+      vi.useFakeTimers();
+      const onSelectVfo = vi.fn();
+      const target = mountSurface({ viewModel: relativeModel(), onSelectVfo });
+      const a = target.querySelector<HTMLButtonElement>('[data-vfo-select-absolute="A"]')!;
+      const b = target.querySelector<HTMLButtonElement>('[data-vfo-select-absolute="B"]')!;
+      a.click();
+      flushSync();
+      const expected = 'Waiting for the radio to confirm the selection.';
+      expect(a.disabled).toBe(true);
+      expect(a.title).toBe(expected);
+      expect(describedText(target, a)).toBe(expected);
+      expect(b.disabled).toBe(true);
+      expect(b.title).toBe(expected);
+      expect(describedText(target, b)).toBe(expected);
+      vi.runOnlyPendingTimers();
+      vi.useRealTimers();
+    });
+
+    it('falls back to `relativeSelectionHelp` when neither disabled nor pending applies', () => {
+      const target = mountSurface({ viewModel: relativeModel() });
+      const a = target.querySelector<HTMLButtonElement>('[data-vfo-select-absolute="A"]')!;
+      expect(a.disabled).toBe(false);
+      expect(a.title).toBe(
+        'Current A/B identity is unknown. Selecting this VFO will change the radio selection and establish identity.',
+      );
+      expect(a.hasAttribute('aria-describedby')).toBe(false);
+    });
   });
 
   // Two independently mounted surfaces (the dual-receiver cockpit's real

--- a/frontend/src/semantic/__tests__/VfoSurface.test.ts
+++ b/frontend/src/semantic/__tests__/VfoSurface.test.ts
@@ -844,6 +844,10 @@ describe('VFO ops disabled reasons (MOR-1481)', () => {
       expect(button.title, op).not.toBe(falseResolverLiteral);
       expect(describedText(target, button), op).toBe(expected);
     }
+    // R3: the ops-row CONTAINER's hover title must carry the same honest
+    // catalog text, not the resolver literal (its gaps are hoverable).
+    const opsRow = target.querySelector('[data-testid="vfo-ops"]')!;
+    expect(opsRow.getAttribute('title')).toBe(expected);
   });
 
   // MOR-1481 rework (R2): the catalog key resolves per-locale, not just an
@@ -882,6 +886,8 @@ describe('VFO ops disabled reasons (MOR-1481)', () => {
     expect(describedText(target, button)).toBe('The radio has not confirmed the split state yet.');
     // Neither equalize nor swap depends on split — neither carries this reason.
     expect(target.querySelector<HTMLButtonElement>('[data-vfo-equalize]')!.title).toBe('');
+    // R3: identity is known here — the ops-row container carries no title.
+    expect(target.querySelector('[data-testid="vfo-ops"]')!.getAttribute('title')).toBeNull();
     const toggle = target.querySelector<HTMLButtonElement>('[data-vfo-split]')!;
     expect(toggle.title).toBe('The radio has not confirmed the split state yet.');
     expect(describedText(target, toggle)).toBe('The radio has not confirmed the split state yet.');

--- a/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
+++ b/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
@@ -842,10 +842,15 @@ describe('operational audio-scope availability (scope=false + audioFft=true)', (
   const markup = (): string => target.innerHTML
     .replace(/rx-tx-\d+/g, 'rx-tx-N')
     .replace(/tx-aux-blocked-\d+/g, 'tx-aux-blocked-N')
-    // MOR-1481: TUNE's own dedicated reason id carries the same per-instance
-    // `TxAuxSurface` counter as `tx-aux-blocked-N` above — same volatility,
-    // same normalization.
-    .replace(/tx-aux-reason-\d+-tune-atu/g, 'tx-aux-reason-N-tune-atu');
+    // MOR-1481 rework (R2): every per-field reason id (`tx-aux-reason-N-atu`,
+    // `-vox`, `-rfPower`, … and TUNE's own dedicated `-tune-atu`) carries the
+    // same per-instance `TxAuxSurface` counter as `tx-aux-blocked-N` above —
+    // same volatility, same normalization. Before the rework, a field whose
+    // availability was fully declared but whose READING was unobserved
+    // rendered no reason id at all (the very defect the rework fixes), so
+    // this test never observed more than the TUNE-specific id; now every
+    // field does, and the general form is required.
+    .replace(/tx-aux-reason-\d+-/g, 'tx-aux-reason-N-');
 
   it('changes nothing in the cockpit, and denies nothing about the radio', () => {
     h.state = mainSubState('MAIN');

--- a/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
+++ b/frontend/src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts
@@ -841,7 +841,11 @@ describe('operational audio-scope availability (scope=false + audioFft=true)', (
    */
   const markup = (): string => target.innerHTML
     .replace(/rx-tx-\d+/g, 'rx-tx-N')
-    .replace(/tx-aux-blocked-\d+/g, 'tx-aux-blocked-N');
+    .replace(/tx-aux-blocked-\d+/g, 'tx-aux-blocked-N')
+    // MOR-1481: TUNE's own dedicated reason id carries the same per-instance
+    // `TxAuxSurface` counter as `tx-aux-blocked-N` above — same volatility,
+    // same normalization.
+    .replace(/tx-aux-reason-\d+-tune-atu/g, 'tx-aux-reason-N-tune-atu');
 
   it('changes nothing in the cockpit, and denies nothing about the radio', () => {
     h.state = mainSubState('MAIN');


### PR DESCRIPTION
## Summary

MOR-1422 surfaced operator-facing reasons on disabled controls across the semantic surfaces, but several spots were left with silent `disabled` (no `title`, no `aria-describedby`), or with a `title`/`aria-describedby` that was actively false — see MOR-1481:

1. **VFO ops row** (`VfoSurface.svelte`) — Equalize VFOs / Swap VFOs / Quick split / Quick dual watch go disabled with no reason when A/B identity is unknown. The per-tile "Select VFO A/B" control also goes disabled silently, either because that VFO's own slot identity hasn't resolved, or because the MOR-1256 strip-level `disabled` prop forces the whole receiver off.
2. **TX-aux TUNE button** (`TxAuxSurface.svelte`) — disabled with no reason, whether blocked by the ATU reading being unobserved or by a TX-authority block.

Round 2 (see below) found the round-1 fix for (1) used a false, English-only string on the ops row, and that the round-1 fix for (2) only widened the predicate for TUNE instead of the shared helper every other TX-aux field also uses.

## Mechanism reused

No new pattern — this extends the existing MOR-1422 idiom (title + `aria-describedby` + hidden `.sr-only` span + per-instance id counter to avoid collisions across mounted surfaces):

- `frontend/src/semantic/disabled-reason.ts:30` — `disabledReasonText()`, the shared `Availability → text` mapping introduced by MOR-1422.
- `frontend/src/semantic/TxAuxSurface.svelte` — `reasonIdOf()`, the existing per-field `aria-describedby` id helper.
- `frontend/src/semantic/TxAuxSurface.svelte` — `.sr-only` style, unchanged, reused as-is.

TX-aux's shared `reasonTextOf` (as of round 2) draws from the *same* `disabledReasonText` catalog keys, just widened to also catch the case where availability is fully declared but the reading itself hasn't arrived (`disabledReasonText` alone only reads `availability`, not `reading.status`) — not a new vocabulary. This predicate now backs every one of the twelve TX-aux fields, not just TUNE.

VfoSurface had no MOR-1422 wiring at all before this ticket, so it gets its own local `reasonId()` / per-op reason-text functions, shaped the same way (title + `aria-describedby` + `.sr-only` span + instance counter). As of round 2, the ops row (Equalize/Swap/Quick split/Quick dual watch) draws its identity-unknown wording from its own dedicated catalog key (`core.vfo.ops.identityUnknownReason`) rather than reusing the Select VFO A/B resolver buttons' `relativeSelectionHelp` string — see finding 1 below for why that reuse was wrong.

## Wording (en-US / ru-RU)

| Key | en-US | ru-RU |
|---|---|---|
| `core.vfo.select.unknownSlotReason` | The radio has not confirmed this VFO's A/B identity yet, so it can't be selected. | Радио ещё не подтвердило идентичность (A/B) этого VFO, поэтому его нельзя выбрать. |
| `core.vfo.select.receiverUnavailableReason` | This receiver is not available right now, so it can't be selected. | Этот приёмник сейчас недоступен, поэтому его нельзя выбрать. |
| `core.vfo.select.pendingReason` | Waiting for the radio to confirm the selection. | Ожидание подтверждения выбора от радио. |
| `core.vfo.split.unknownReason` | The radio has not confirmed the split state yet. | Радио ещё не подтвердило состояние split. |
| `core.vfo.dualWatch.unknownReason` | The radio has not confirmed the dual watch state yet. | Радио ещё не подтвердило состояние dual watch. |
| `core.vfo.ops.identityUnknownReason` | The radio has not confirmed which VFO is A and which is B yet — press Select VFO A or Select VFO B first. | Радио ещё не подтвердило, какой VFO — A, а какой — B. Сначала нажмите Select VFO A или Select VFO B. |

The Select VFO A/B resolver buttons still fall back to the pre-existing `relativeSelectionHelp` string when neither disabled nor pending applies — that string is correct there (those buttons genuinely do select a VFO). TUNE reuses the existing `core.disabledReason.unobserved` ("Not yet observed") key for the ATU-unobserved case, and the existing TX-authority `BLOCKED_LABEL` strings (joined with `; `) for the TX-authority case.

## Review round 2

An independent verifier BLOCKED the round-1 PR with four findings, all addressed in this update:

1. **Ops row used a false, uncataloged string.** `identityOnlyReasonText()` (and the equivalent `quickSplitReasonText`/`quickDualWatchReasonText` paths) put the literal `relativeSelectionHelp` — "Selecting this VFO will change the radio selection and establish identity." — on Equalize/Swap/Quick split/Quick dual watch. That is false there (no button on the ops row "selects a VFO"; the button is disabled) and the literal was never in the i18n catalog. Fixed by adding `core.vfo.ops.identityUnknownReason` (en-US/ru-RU) and switching all three functions to it. The Select VFO A/B resolver buttons keep `relativeSelectionHelp` as their own fallback title — correct there, unchanged.

2. **TxAuxSurface's reason predicate disagreed with `disabled` for 11 of 12 fields.** `reasonTextOf`/`reasonIdOf` computed from a bare `disabledReasonText(f.availability)`, which only reads structural/operational — while `disabled` on every control gates on `usable(f)`, which also requires `reading.status === 'known'`. Any field with availability fully declared but an unobserved reading was therefore rendered disabled with no `title`/`aria-describedby` at all. TUNE alone had a widened predicate (`tuneAtuReasonText`) fixing this for itself; round 2 moves that fix into the shared `reasonTextOf`, deletes `tuneAtuReasonText`, and has `tuneAtuReason` call `reasonTextOf(txAux.atu)` — so all twelve fields, not just TUNE, get an honest reason.

3. **Select VFO A/B resolver buttons were silently disabled or over-promised.** Under the MOR-1256 strip-level `disabled` prop they went disabled with no reason at all; while `relativeSelectionPending`, they still showed `relativeSelectionHelp`'s promise ("selecting this VFO will change the radio selection") even though the radio was, in that instant, not capable of acting on another selection. Fixed with `absoluteReason = disabled ? receiverUnavailableReason : relativeSelectionPending ? pendingReason : undefined`, `title={absoluteReason ?? relativeSelectionHelp}`, and a shared `aria-describedby` + `.sr-only` span. New key: `core.vfo.select.pendingReason`.

4. **`tuneDescribedBy` could point at a reason `title` never showed.** It concatenated the ATU-reason id and the TX-authority blocked-list id whenever both conditions independently held, even though `tuneReasonText` (the visible `title`) shows only the ATU reason in that case — the file's own "never both" doctrine. **Decision: reshaped `tuneDescribedBy` to mirror `tuneReasonText`'s `??` exclusivity** (drop the blocked-list id when the ATU reason applies), rather than keeping both ids and rewriting the doctrine comment to describe a genuine two-reason case — the doctrine ("an unusable ATU reading makes the TX-authority question moot") is the intended design, and `aria-describedby` should not tell a screen reader something `title` does not.

New witnesses added:
- `resolves the ops-row identity reason from the i18n catalog and renders Russian under ru-RU` (asserts it is NOT the raw `relativeSelectionHelp` literal)
- `carries the receiver-unavailable reason when forced off by the strip-level 'disabled' prop` / `carries the pending reason ... while a resolution is in flight` / `falls back to 'relativeSelectionHelp' when neither disabled nor pending applies` (Select VFO A/B resolver buttons)
- `it.each(ALL_FIELDS)('puts "Not yet observed" on title and aria-describedby for "%s" when only its READING is unobserved', ...)` — all twelve TX-aux fields
- `points aria-describedby at exactly the ATU reason, never both, when a TX-authority block also applies`

`DualReceiverCockpit.component.test.ts`'s golden-markup id normalization widened from the TUNE-only `tx-aux-reason-\d+-tune-atu → tx-aux-reason-N-tune-atu` pattern to the general `tx-aux-reason-\d+- → tx-aux-reason-N-` form, since finding 2's fix now surfaces a real per-instance-numbered `aria-describedby` id for every TX-aux field, not only TUNE's.

## Tests

`frontend/src/semantic/__tests__/VfoSurface.test.ts` — `describe('VFO ops disabled reasons (MOR-1481)', ...)`:
- no reason text/`aria-describedby` on any op button once every fact is known
- identity-unknown reason on every op button's own `title` + `aria-describedby` (round 2: catalog text, not the resolver buttons' literal)
- ru-RU rendering of the ops-row identity reason (round 2)
- split-specific reason on quick split and the split fact-toggle (identity known, split unknown)
- dual-watch-specific reason on quick dual watch and the dual-watch fact-toggle
- per-tile select disabled by its own unknown slot carries a reason
- per-tile select forced off by the MOR-1256 strip-level `disabled` prop carries a reason
- an enabled per-tile select carries no reason
- reason ids stay unique across two mounted surfaces (dual-receiver cockpit shape)
- Select VFO A/B resolver buttons: disabled / pending / fallback reasons (round 2)

`frontend/src/semantic/__tests__/TxAuxSurface.test.ts` — `describe('TUNE carries its own disabled reason (MOR-1481)', ...)` plus round-2 additions:
- no reason once TUNE is usable
- TX-authority block reason on `title`/`aria-describedby` for each blocking condition (`it.each(BLOCKING)`)
- multiple simultaneous TX-authority reasons get joined on `title`
- "Not yet observed" reason when the ATU reading itself is unobserved despite availability being fully declared
- the ATU-unobserved reason wins over a TX-authority block when both apply
- (round 2) `aria-describedby` points at exactly one id — never both — in that same both-apply case
- (round 2) `it.each` over all twelve TX-aux fields: title/`aria-describedby` when only the reading is unobserved

## Verification

- `npx vitest run src/semantic src/skins` → 40 files / 1353 tests passed (1336 baseline + 17 new witnesses)
- `npx eslint` on the 7 touched source/test files → clean
- `npx svelte-check --tsconfig ./tsconfig.app.json` → 0 errors, 0 warnings

Closes MOR-1481.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
