### PR TITLE
fix: hold discrete pending until a confirming observation (MOR-1488)

### DIFF
--- a/frontend/src/components-v2/wiring/__tests__/semantic-discrete-pending-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-discrete-pending-wiring.component.test.ts
@@ -1,0 +1,300 @@
+/**
+ * MOR-1488 / MOR-1473 — the discrete-control pending affordance (MOR-1441
+ * leg 2: `FilterSurface`/`RfFrontEndSurface`/`DspSurface`'s `pendingFilter`/
+ * `pendingPreamp`/`pendingNb`/`pendingNr`), proved over the REAL wiring
+ * path: the real `$lib/stores/radio.svelte` + `$lib/stores/capabilities
+ * .svelte` stores (seeded through their own epoch-gated setters, never
+ * module-mocked — the PR #2409 "seed real store" idiom), a real
+ * `$lib/stores/commands.svelte` command lifecycle (populated by an actual
+ * click through the UNMOCKED `panel-commands.ts` handlers /
+ * `dispatchRadioIntent`), the real `panel-adapters.ts` pending accessors,
+ * and the real `SemanticRadioSurfaces` -> semantic-surface prop wiring.
+ *
+ * WHY THIS FILE EXISTS (MOR-1473, the test-gap ticket): MOR-1441 leg 2
+ * (#2410) added `getPendingFilterSelection`/`getPendingPreampLevel`/
+ * `getPendingNbOn`/`getPendingNrOn` and wired them through
+ * `SemanticRadioSurfaces` to the three semantic surfaces, but its own test
+ * (`lib/runtime/adapters/__tests__/mor1441-pending-discrete.isolated.test.ts`)
+ * only exercises the four accessor functions against a hand-built fake
+ * command list — it never mounts the wiring layer, so a dropped or
+ * misnamed prop between the `$derived`s in `SemanticRadioSurfaces.svelte`
+ * and the semantic surface's own `Props` would pass that suite unnoticed.
+ * The existing `semantic-dsp-wiring.component.test.ts` /
+ * `semantic-rf-front-end-wiring.component.test.ts` files replace every
+ * command-bus handler with a `vi.fn()` spy, so clicking never actually
+ * populates the real command-lifecycle store there either — a click in
+ * those files can never observe a 'pending' status.
+ *
+ * This file closes both gaps: it mounts the REAL wiring, drives a REAL
+ * command lifecycle for each of the five MOR-1441 pending accessors (leg
+ * 1's `pendingFrequencyHz` included, for completeness), and asserts the DOM
+ * marker the operator actually sees.
+ *
+ * Isolated pool by name (`*.component.test.ts`), per the MOR-1272 doctrine.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { ServerState } from '$lib/types/state';
+
+type Snapshot = {
+  phase: string; intent: string | null; guard: { leaseId: string } | null;
+  radioTx: string; txRisk: string; mayOwnKey: boolean; fault: string | null;
+};
+
+const IDLE: Snapshot = {
+  phase: 'idle', intent: null, guard: null, radioTx: 'off', txRisk: 'none',
+  mayOwnKey: false, fault: null,
+};
+
+// The App TX controller lives in Svelte context, provided by `AppGlobalHost`
+// in production; a standalone mount needs a stand-in or `getAppTxController`
+// throws. Not the seam this file tests — same stand-in role as every other
+// wiring-component test in this directory.
+vi.mock('$lib/runtime/tx-controller/app-host', () => ({
+  getAppTxController: () => ({
+    snapshot: () => IDLE,
+    subscribe: () => () => {},
+    start: vi.fn(), setIntent: vi.fn(), release: vi.fn(), resetFault: vi.fn(),
+  }),
+}));
+vi.mock('$lib/runtime/adapters/mod-input-tx-guard.svelte', () => ({
+  deriveModInputTxGuardProps: () => ({ visible: false, sourceLabel: null }),
+  getModInputTxGuardHandlers: () => ({ onSetLan: vi.fn(), onDismiss: vi.fn() }),
+}));
+// The ONE seam this file replaces: the actual network write. Everything
+// upstream of it stays real — `dispatchRadioIntent`, `beginCommand`, the
+// real `$lib/stores/commands.svelte` lifecycle list — so a pending entry
+// this file observes after CLICKING a real control is the exact one
+// production code creates, not a stand-in shape this file made up.
+vi.mock('$lib/transport/ws-client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('$lib/transport/ws-client')>();
+  return { ...actual, sendCommand: vi.fn(() => true) };
+});
+
+import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';
+import { setCapabilities, clearCapabilities } from '$lib/stores/capabilities.svelte';
+import { setRadioState, resetRadioState } from '$lib/stores/radio.svelte';
+import { acknowledgeCommand, getCommandLifecycles, resetCommandLifecycle } from '$lib/stores/commands.svelte';
+import { dispatchRadioIntent } from '$lib/runtime/commands/radio-intents';
+
+const PROVIDER_GENERATION = 0;
+const fresh = { storePath: 'x', observed: true, freshness: 'fresh' as const, availability: 'available' as const };
+
+/**
+ * Single-receiver (IC-7300/FTX-1-shaped) fixture — the live-bench topology
+ * the MOR-1488 symptom was reported against — with filter, preamp and nb/nr
+ * all evidenced, so `FilterSurface`/`RfFrontEndSurface`/`DspSurface` all
+ * mount live. Accepted by the REAL `setCapabilities`/`setRadioState` epoch
+ * gate, not read back through a mock.
+ */
+function liveCaps(): Capabilities {
+  return {
+    model: 'fixture', scope: false, audio: true, tx: true,
+    capabilities: ['audio', 'tx', 'preamp', 'nb', 'nr'],
+    preValues: [0, 1, 2], attValues: [0, 6, 12, 18],
+    receivers: 1, vfoScheme: 'single',
+    freqRanges: [], modes: ['USB', 'LSB'], filters: ['FIL1', 'FIL2', 'FIL3'],
+    audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
+    webrtc: { available: false, enabled: false }, txBands: null,
+    scopeSource: null, audioFftAvailable: false,
+    stateContractVersion: 1, providerGeneration: PROVIDER_GENERATION,
+  } as unknown as Capabilities;
+}
+
+function liveState(): ServerState {
+  const paths = [
+    'active', 'split', 'dualWatch', 'txTarget',
+    'main.freqHz', 'main.mode', 'main.filter', 'main.activeSlot',
+    'main.nb', 'main.nr', 'main.filterWidth', 'main.preamp',
+  ];
+  return {
+    stateContractVersion: 1,
+    providerGeneration: PROVIDER_GENERATION,
+    revision: 1, stateRevision: 1, freshnessRevision: 1, observationSeq: 1,
+    updatedAt: '2026-08-12T00:00:00Z',
+    active: 'MAIN', ptt: false, split: false, dualWatch: false, tunerStatus: 0,
+    txTarget: { status: 'known', receiver: 'MAIN', slot: 'A', frequencyHz: 14250000 },
+    main: {
+      freqHz: 14250000, mode: 'USB', filter: 1, dataMode: 0, sMeter: 20,
+      att: 0, preamp: 0, nb: false, nr: false, afLevel: 100, rfGain: 255, squelch: 0,
+      activeSlot: 'A', filterWidth: 2400,
+    },
+    connection: { rigConnected: true, radioReady: true, controlConnected: true },
+    fieldStatus: Object.fromEntries(paths.map((p) => [p, fresh])),
+  } as unknown as ServerState;
+}
+
+/**
+ * A confirming observation for `set_nb`: `liveState()` with `main.nb`
+ * flipped to `true` and every revision counter bumped past the initial
+ * fixture's — the exact "radio echoed the new value back" event, distinct
+ * from a transport ack, that the MOR-1488 fix waits for.
+ */
+function nbConfirmedState(): ServerState {
+  const base = liveState();
+  return {
+    ...base,
+    revision: 2, stateRevision: 2, freshnessRevision: 2, observationSeq: 2,
+    main: { ...base.main, nb: true },
+  } as unknown as ServerState;
+}
+
+let target: HTMLDivElement;
+let component: ReturnType<typeof mount> | null = null;
+
+function render(): void {
+  target = document.createElement('div');
+  document.body.appendChild(target);
+  component = mount(SemanticRadioSurfaces, { target, props: {} });
+  flushSync();
+}
+
+const q = <T extends HTMLElement>(sel: string) => target.querySelector(sel) as T | null;
+
+beforeEach(() => {
+  // Assert acceptance, not just call it — a rejected fixture would leave
+  // `runtime.state`/`runtime.caps` at `null` and every assertion below would
+  // pass or fail for the wrong reason (mirrors
+  // `FrequencyDisplayInteractive.component.svelte.test.ts`'s own discipline).
+  expect(setCapabilities(liveCaps())).toBe(true);
+  expect(setRadioState(liveState())).toBe(true);
+});
+
+afterEach(() => {
+  if (component) unmount(component);
+  component = null;
+  document.body.innerHTML = '';
+  resetRadioState();
+  clearCapabilities();
+  resetCommandLifecycle();
+});
+
+describe('discrete pending markers reach the mounted DOM over the real wiring path (MOR-1488, closes MOR-1473)', () => {
+  it('marks the clicked filter choice pending while set_filter is in flight (FilterSurface)', () => {
+    render();
+    expect(q('[data-testid="filter-select"]')!.dataset.filterStatus).toBe('confirmed');
+
+    q<HTMLButtonElement>('[data-testid="filter-select-2"]')!.click();
+    flushSync();
+
+    expect(q('[data-testid="filter-select"]')!.dataset.filterStatus).toBe('pending');
+    expect(q('[data-testid="filter-select-2"]')!.dataset.pending).toBe('true');
+    // The choice NOT targeted must not also read pending — a swapped/shared
+    // accessor (e.g. reading `pendingPreamp` here) would mark every choice,
+    // or none, rather than the one actually in flight.
+    expect(q('[data-testid="filter-select-1"]')!.dataset.pending).toBe('false');
+  });
+
+  it('marks the clicked preamp choice pending while set_preamp is in flight (RfFrontEndSurface)', () => {
+    render();
+    expect(q('[data-testid="rf-front-end-preamp"]')!.dataset.preampStatus).toBe('confirmed');
+
+    q<HTMLButtonElement>('[data-testid="rf-front-end-preamp-1"]')!.click();
+    flushSync();
+
+    expect(q('[data-testid="rf-front-end-preamp"]')!.dataset.preampStatus).toBe('pending');
+    expect(q('[data-testid="rf-front-end-preamp-1"]')!.dataset.pending).toBe('true');
+  });
+
+  it('marks the NB toggle pending while set_nb is in flight, NR untouched (DspSurface)', () => {
+    render();
+    expect(q('[data-testid="dsp-nbActive"]')!.dataset.pendingStatus).toBe('confirmed');
+    expect(q('[data-testid="dsp-nrActive"]')!.dataset.pendingStatus).toBe('confirmed');
+
+    q<HTMLButtonElement>('[data-testid="dsp-nbActive"]')!.click();
+    flushSync();
+
+    expect(q('[data-testid="dsp-nbActive"]')!.dataset.pendingStatus).toBe('pending');
+    // Kills a `pendingNb`/`pendingNr` swap in the wiring's two DSP props —
+    // the untouched toggle must stay confirmed.
+    expect(q('[data-testid="dsp-nrActive"]')!.dataset.pendingStatus).toBe('confirmed');
+  });
+
+  it('marks the NR toggle pending while set_nr is in flight, NB untouched (DspSurface)', () => {
+    render();
+    q<HTMLButtonElement>('[data-testid="dsp-nrActive"]')!.click();
+    flushSync();
+
+    expect(q('[data-testid="dsp-nrActive"]')!.dataset.pendingStatus).toBe('pending');
+    expect(q('[data-testid="dsp-nbActive"]')!.dataset.pendingStatus).toBe('confirmed');
+  });
+
+  // Leg 1 parity (MOR-1441's original `pendingFrequencyHz`) — same wiring
+  // seam (`SemanticRadioSurfaces`'s `$derived`s), same real-store path, so
+  // this suite proves leg 1 and leg 2 travel the identical wiring
+  // discipline rather than asserting leg 2 in isolation.
+  it('marks the VFO frequency readout pending while set_freq is in flight (VfoSurface, leg 1)', () => {
+    render();
+    const freqEl = () => target.querySelector('[data-vfo-receiver="MAIN"] [data-freq-status]') as HTMLElement | null;
+    expect(freqEl()?.dataset.freqStatus).toBe('confirmed');
+
+    dispatchRadioIntent({ name: 'set_freq', params: { freq: 14260000, receiver: 0 } });
+    flushSync();
+
+    expect(freqEl()?.dataset.freqStatus).toBe('pending');
+  });
+
+  it('clears the pending marker once the command resolves (acknowledged), for all four discrete controls', () => {
+    render();
+    q<HTMLButtonElement>('[data-testid="filter-select-2"]')!.click();
+    q<HTMLButtonElement>('[data-testid="rf-front-end-preamp-1"]')!.click();
+    q<HTMLButtonElement>('[data-testid="dsp-nbActive"]')!.click();
+    q<HTMLButtonElement>('[data-testid="dsp-nrActive"]')!.click();
+    flushSync();
+    expect(q('[data-testid="filter-select"]')!.dataset.filterStatus).toBe('pending');
+    expect(q('[data-testid="rf-front-end-preamp"]')!.dataset.preampStatus).toBe('pending');
+    expect(q('[data-testid="dsp-nbActive"]')!.dataset.pendingStatus).toBe('pending');
+    expect(q('[data-testid="dsp-nrActive"]')!.dataset.pendingStatus).toBe('pending');
+
+    // A resolved command must stop reading as pending — the leg-1 honesty
+    // rule (`mor1441-pending-discrete.isolated.test.ts`'s own doc comment)
+    // applied over the real wiring path this time, not the fake command list.
+    resetCommandLifecycle();
+    flushSync();
+
+    expect(q('[data-testid="filter-select"]')!.dataset.filterStatus).toBe('confirmed');
+    expect(q('[data-testid="rf-front-end-preamp"]')!.dataset.preampStatus).toBe('confirmed');
+    expect(q('[data-testid="dsp-nbActive"]')!.dataset.pendingStatus).toBe('confirmed');
+    expect(q('[data-testid="dsp-nrActive"]')!.dataset.pendingStatus).toBe('confirmed');
+  });
+
+  /**
+   * MOR-1488 live-bench finding: a transport ack is not a confirming
+   * observation. The WS ack for `set_nb` typically lands within
+   * milliseconds — long before the next state poll (~500ms keep-alive)
+   * echoes `main.nb` back — so a pending marker that clears on ack alone
+   * collapses to something the operator can never actually see, exactly
+   * the reported symptom ("values flip instantly, pending presented as
+   * confirmed"). This drives the command to 'acknowledged' directly
+   * (`acknowledgeCommand`, the same primitive `radio-intents.ts`'s
+   * `onCommandDelivery` ack handler calls) WITHOUT changing the confirmed
+   * radio state, and requires the marker to survive that ack — only a
+   * `setRadioState` observation that actually confirms the target
+   * (`main.nb === true`) may clear it.
+   */
+  it('keeps the NB marker pending across a transport ack until a confirming state observation arrives (MOR-1488)', () => {
+    render();
+    q<HTMLButtonElement>('[data-testid="dsp-nbActive"]')!.click();
+    flushSync();
+    expect(q('[data-testid="dsp-nbActive"]')!.dataset.pendingStatus).toBe('pending');
+
+    const command = getCommandLifecycles().find(
+      (candidate) => candidate.name === 'set_nb' && candidate.status === 'pending',
+    );
+    expect(command).toBeDefined();
+    acknowledgeCommand(command!.id, command!.originalEpoch, command!.originalEpoch);
+    flushSync();
+
+    // The ack alone must NOT confirm the marker — `main.nb` is still `false`
+    // in the store, so the operator has no honest evidence the radio applied
+    // the change yet.
+    expect(q('[data-testid="dsp-nbActive"]')!.dataset.pendingStatus).toBe('pending');
+
+    // The confirming observation: the radio's own state now echoes `nb: true`.
+    expect(setRadioState(nbConfirmedState())).toBe(true);
+    flushSync();
+
+    expect(q('[data-testid="dsp-nbActive"]')!.dataset.pendingStatus).toBe('confirmed');
+  });
+});

--- a/frontend/src/components-v2/wiring/__tests__/semantic-discrete-pending-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-discrete-pending-wiring.component.test.ts
@@ -140,6 +140,28 @@ function nbConfirmedState(): ServerState {
   } as unknown as ServerState;
 }
 
+/**
+ * A confirming-but-non-transitioning observation (MOR-1488 review R2,
+ * F2 test-theatre fix): `liveState()` with `main.nb` left at `false`
+ * (unchanged) but `observationSeq`/`freshnessRevision` advanced past the
+ * fixture's initial value — `stateRevision`/`revision` deliberately stay
+ * put. This is "the radio was freshly re-polled and nb is still off": no
+ * field value moved, so `core.state_store._apply_one` would never bump
+ * `stateRevision` for a push like this (it only bumps on `semantic_changed`)
+ * — but `observationSeq` bumps unconditionally, on every applied
+ * observation. A sequence guard keyed on `stateRevision` would never see
+ * this push as "newer" and would leave a pending record stuck until the
+ * grace backstop; a guard keyed on `observationSeq` (the implementation
+ * under test) settles it as the first post-ack observation, as intended.
+ */
+function nbReobservedState(): ServerState {
+  const base = liveState();
+  return {
+    ...base,
+    observationSeq: 2, freshnessRevision: 2,
+  } as unknown as ServerState;
+}
+
 let target: HTMLDivElement;
 let component: ReturnType<typeof mount> | null = null;
 
@@ -293,6 +315,48 @@ describe('discrete pending markers reach the mounted DOM over the real wiring pa
 
     // The confirming observation: the radio's own state now echoes `nb: true`.
     expect(setRadioState(nbConfirmedState())).toBe(true);
+    flushSync();
+
+    expect(q('[data-testid="dsp-nbActive"]')!.dataset.pendingStatus).toBe('confirmed');
+  });
+
+  /**
+   * MOR-1488 review R2 (F2, closes the "test theatre" finding): a fast
+   * double-toggle acks the SECOND (OFF) command while the receiver state
+   * still reflects the value from BEFORE either dispatch — the target of
+   * OFF (`false`) happens to equal that stale, pre-both-clicks snapshot. A
+   * plain "does the target match the current confirmed reading" comparison
+   * (the pre-R2 implementation) would clear the marker the instant OFF
+   * acks, even though nothing has actually been re-observed since either
+   * click. This proves the sequence guard blocks exactly that, and that the
+   * FIRST genuine post-ack push (even one that only reconfirms the
+   * already-correct value, never advancing `stateRevision`) is what
+   * actually settles it — the counters `nbConfirmedState()`'s sibling
+   * `nbReobservedState()` bumps are not decorative.
+   */
+  it('does not clear the marker from a stale pre-ack snapshot on a fast double-toggle, only on the next real push (MOR-1488 review R2, closes F2)', () => {
+    render();
+    expect(q('[data-testid="dsp-nbActive"]')!.dataset.pendingStatus).toBe('confirmed');
+
+    // Click ON, then OFF again before either is ever observed by a poll.
+    dispatchRadioIntent({ name: 'set_nb', params: { on: true, receiver: 0 } });
+    dispatchRadioIntent({ name: 'set_nb', params: { on: false, receiver: 0 } });
+    flushSync();
+    expect(q('[data-testid="dsp-nbActive"]')!.dataset.pendingStatus).toBe('pending');
+
+    const off = getCommandLifecycles().find(
+      (candidate) => candidate.name === 'set_nb' && candidate.params.on === false && candidate.status === 'pending',
+    );
+    expect(off).toBeDefined();
+    acknowledgeCommand(off!.id, off!.originalEpoch, off!.originalEpoch);
+    flushSync();
+
+    // OFF's target (false) already equals the stale confirmed snapshot —
+    // must NOT clear from that coincidence alone.
+    expect(q('[data-testid="dsp-nbActive"]')!.dataset.pendingStatus).toBe('pending');
+
+    // The first real post-ack push, even a non-transitioning reconfirmation.
+    expect(setRadioState(nbReobservedState())).toBe(true);
     flushSync();
 
     expect(q('[data-testid="dsp-nbActive"]')!.dataset.pendingStatus).toBe('confirmed');

--- a/frontend/src/components-v2/wiring/__tests__/semantic-discrete-pending-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-discrete-pending-wiring.component.test.ts
@@ -141,18 +141,24 @@ function nbConfirmedState(): ServerState {
 }
 
 /**
- * A confirming-but-non-transitioning observation (MOR-1488 review R2,
- * F2 test-theatre fix): `liveState()` with `main.nb` left at `false`
+ * A non-transitioning observation (MOR-1488 review R2, F2 test-theatre
+ * fix; reused for review R3): `liveState()` with `main.nb` left at `false`
  * (unchanged) but `observationSeq`/`freshnessRevision` advanced past the
  * fixture's initial value — `stateRevision`/`revision` deliberately stay
- * put. This is "the radio was freshly re-polled and nb is still off": no
- * field value moved, so `core.state_store._apply_one` would never bump
- * `stateRevision` for a push like this (it only bumps on `semantic_changed`)
- * — but `observationSeq` bumps unconditionally, on every applied
- * observation. A sequence guard keyed on `stateRevision` would never see
- * this push as "newer" and would leave a pending record stuck until the
- * grace backstop; a guard keyed on `observationSeq` (the implementation
- * under test) settles it as the first post-ack observation, as intended.
+ * put. This is "the radio was freshly re-polled (or an unrelated field's
+ * meter poll landed) and nb is still off": no field value moved, so
+ * `core.state_store._apply_one` would never bump `stateRevision` for a
+ * push like this (it only bumps on `semantic_changed`), but `observationSeq`
+ * bumps unconditionally, on every applied observation.
+ *
+ * Dual role by test: whether this push CONFIRMS or MISMATCHES depends only
+ * on what the in-flight command's own target is at each call site — this
+ * fixture always reports `nb: false`.
+ *   - R2's double-toggle test targets OFF (`false`): this push MATCHES and
+ *     is the genuine confirming observation that settles the record.
+ *   - R3's tests target ON (`true`, a single click): this push MISMATCHES
+ *     — proving a mismatched post-ack push must NOT retire the record (R3's
+ *     asymmetric settle), only a matching one or the grace backstop can.
  */
 function nbReobservedState(): ServerState {
   const base = liveState();
@@ -360,5 +366,78 @@ describe('discrete pending markers reach the mounted DOM over the real wiring pa
     flushSync();
 
     expect(q('[data-testid="dsp-nbActive"]')!.dataset.pendingStatus).toBe('confirmed');
+  });
+
+  /**
+   * MOR-1488 review R3: `observationSeq` bumps on EVERY applied field
+   * observation, not just a re-read of THIS command's field — a 25ms meter
+   * poll advances it exactly as much as the commanded field's own confirming
+   * re-read would, but that confirming re-read is a full poll round-robin
+   * away (~1.3s worst case), not the very next push. R2 settled the record
+   * on the first post-ack push regardless of match, which fired on the next
+   * unrelated meter poll (~50ms after ack) — collapsing the pending window
+   * right back to a few frames, the original bench symptom. `nbReobservedState()`
+   * (defined above, `main.nb` still `false`) doubles here as a stand-in for
+   * exactly that unrelated meter-poll push: it advances `observationSeq` but
+   * does not confirm THIS command's target (`true`). It must not clear the
+   * marker.
+   */
+  it('does not clear the marker on a post-ack push that advances observationSeq without confirming the target (MOR-1488 review R3)', () => {
+    render();
+    q<HTMLButtonElement>('[data-testid="dsp-nbActive"]')!.click();
+    flushSync();
+    expect(q('[data-testid="dsp-nbActive"]')!.dataset.pendingStatus).toBe('pending');
+
+    const command = getCommandLifecycles().find(
+      (candidate) => candidate.name === 'set_nb' && candidate.status === 'pending',
+    );
+    expect(command).toBeDefined();
+    acknowledgeCommand(command!.id, command!.originalEpoch, command!.originalEpoch);
+    flushSync();
+    expect(q('[data-testid="dsp-nbActive"]')!.dataset.pendingStatus).toBe('pending');
+
+    // A post-ack push arrives (observationSeq advances) but `main.nb` is
+    // still `false` — NOT the commanded `true`. Not evidence of failure,
+    // just an observation that has not reached this field's round-robin
+    // slot yet.
+    expect(setRadioState(nbReobservedState())).toBe(true);
+    flushSync();
+
+    expect(q('[data-testid="dsp-nbActive"]')!.dataset.pendingStatus).toBe('pending');
+  });
+
+  /**
+   * MOR-1488 review R3: the grace backstop, not the sequence guard, is what
+   * bounds an acknowledged command whose field is never actually observed
+   * to confirm. `ACK_CONFIRM_GRACE_MS` (2000ms, R3) budgets a full poll
+   * round-robin (~1.3s, `radio_poller.py:529-531`) plus headroom, so it
+   * retires the marker once that much time has passed since ack — even in
+   * the presence of a post-ack push that still does not confirm.
+   */
+  it('retires the marker via the 2000ms grace backstop once it has elapsed, even with a non-confirming push (MOR-1488 review R3)', () => {
+    vi.useFakeTimers();
+    try {
+      render();
+      q<HTMLButtonElement>('[data-testid="dsp-nbActive"]')!.click();
+      flushSync();
+      const command = getCommandLifecycles().find(
+        (candidate) => candidate.name === 'set_nb' && candidate.status === 'pending',
+      );
+      expect(command).toBeDefined();
+      acknowledgeCommand(command!.id, command!.originalEpoch, command!.originalEpoch);
+      flushSync();
+      expect(q('[data-testid="dsp-nbActive"]')!.dataset.pendingStatus).toBe('pending');
+
+      vi.advanceTimersByTime(2_001);
+      // Still non-confirming (`main.nb` stays `false`, target is `true`) —
+      // the sequence guard alone would leave this pending forever; only the
+      // elapsed grace window retires it.
+      expect(setRadioState(nbReobservedState())).toBe(true);
+      flushSync();
+
+      expect(q('[data-testid="dsp-nbActive"]')!.dataset.pendingStatus).toBe('confirmed');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/frontend/src/lib/runtime/adapters/__tests__/mor1441-pending-discrete.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mor1441-pending-discrete.isolated.test.ts
@@ -5,12 +5,17 @@
  * `getPendingNrOn` are the read side of the leg-2 pending-target affordance:
  * FilterSurface/RfFrontEndSurface/DspSurface show these instead of confirmed
  * radio truth while the matching intent is still in flight. Same authority
- * (the command-bus lifecycle list) and same honesty rule as leg 1's
- * `getPendingFrequencyHz` (`mor1441-pending-frequency.isolated.test.ts`): a
- * command that has already resolved (ack/fail/cancel/timeout) must never be
- * read as still pending.
+ * (the command-bus lifecycle list) as leg 1's `getPendingFrequencyHz`
+ * (`mor1441-pending-frequency.isolated.test.ts`), but a DIFFERENT release
+ * rule (MOR-1488): a terminal-without-further-meaning command (failed,
+ * cancelled, timed-out) must never be read as still pending, but a merely
+ * `'acknowledged'` one (the transport ack) stays pending until the radio's
+ * OWN observed state confirms the target — an ack proves only that the
+ * radio received the command, typically milliseconds before the next state
+ * poll actually echoes it back, and presenting that ack as confirmation is
+ * the exact live-bench fabrication MOR-1488 fixes.
  */
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 type FakeCommand = {
   name: string;
@@ -18,14 +23,16 @@ type FakeCommand = {
   createdAt: number;
   params: Record<string, unknown>;
 };
+type FakeReceiverState = Record<string, unknown>;
 
 const state: { commands: FakeCommand[] } = { commands: [] };
+const runtimeState: { state: { main: FakeReceiverState; sub: FakeReceiverState } | null } = { state: null };
 
 vi.mock('$lib/stores/commands.svelte', () => ({
   getCommandLifecycles: () => state.commands,
 }));
 vi.mock('$lib/runtime/frontend-runtime', () => ({
-  runtime: { get state() { return null; }, get caps() { return null; } },
+  runtime: { get state() { return runtimeState.state; }, get caps() { return null; } },
 }));
 vi.mock('$lib/runtime/tx-controller/app-host', () => ({
   getAppTxController: () => null,
@@ -47,6 +54,11 @@ type Case = {
   accessor: (receiver: 0 | 1) => number | boolean | null;
   intentName: string;
   paramKey: string;
+  /** The `ServerState.main`/`.sub` field this accessor's target is confirmed
+   *  against — differs from `paramKey` for preamp (`level` on the wire,
+   *  `preamp` on the receiver state), matching `panel-adapters.ts`'s own
+   *  `confirmedField` argument to `latestPendingParam`. */
+  confirmedField: string;
   value: number | boolean;
   otherValue: number | boolean;
 };
@@ -54,23 +66,27 @@ type Case = {
 const CASES: readonly Case[] = [
   {
     label: 'getPendingFilterSelection', accessor: getPendingFilterSelection,
-    intentName: 'set_filter', paramKey: 'filter', value: 2, otherValue: 3,
+    intentName: 'set_filter', paramKey: 'filter', confirmedField: 'filter', value: 2, otherValue: 3,
   },
   {
     label: 'getPendingPreampLevel', accessor: getPendingPreampLevel,
-    intentName: 'set_preamp', paramKey: 'level', value: 1, otherValue: 2,
+    intentName: 'set_preamp', paramKey: 'level', confirmedField: 'preamp', value: 1, otherValue: 2,
   },
   {
     label: 'getPendingNbOn', accessor: getPendingNbOn,
-    intentName: 'set_nb', paramKey: 'on', value: true, otherValue: false,
+    intentName: 'set_nb', paramKey: 'on', confirmedField: 'nb', value: true, otherValue: false,
   },
   {
     label: 'getPendingNrOn', accessor: getPendingNrOn,
-    intentName: 'set_nr', paramKey: 'on', value: true, otherValue: false,
+    intentName: 'set_nr', paramKey: 'on', confirmedField: 'nr', value: true, otherValue: false,
   },
 ];
 
-describe.each(CASES)('$label (MOR-1441 leg 2)', ({ accessor, intentName, paramKey, value, otherValue }) => {
+describe.each(CASES)('$label (MOR-1441 leg 2, MOR-1488)', (
+  { accessor, intentName, paramKey, confirmedField, value, otherValue },
+) => {
+  afterEach(() => { runtimeState.state = null; });
+
   it('returns the pending target for the given receiver', () => {
     state.commands = [cmd({ name: intentName, params: { [paramKey]: value, receiver: 0 } })];
     expect(accessor(0)).toBe(value);
@@ -86,14 +102,44 @@ describe.each(CASES)('$label (MOR-1441 leg 2)', ({ accessor, intentName, paramKe
     expect(accessor(0)).toBeNull();
   });
 
-  // THE kill: a resolved command misrepresented as still pending — the exact
-  // fabrication MOR-1441 forbids.
-  it.each(['acknowledged', 'failed', 'cancelled', 'timed-out'])(
+  // THE kill: a resolved-and-final command misrepresented as still pending —
+  // the exact fabrication MOR-1441 forbids. 'acknowledged' is deliberately
+  // NOT in this list (MOR-1488) — see the two tests below.
+  it.each(['failed', 'cancelled', 'timed-out'])(
     'ignores a %s command', (status) => {
       state.commands = [cmd({ name: intentName, status, params: { [paramKey]: value, receiver: 0 } })];
       expect(accessor(0)).toBeNull();
     },
   );
+
+  // MOR-1488 (live-bench finding): a transport ack is not a confirming
+  // observation. With no observed radio state yet (or one that has not
+  // caught up), an acknowledged command must still read as pending — this
+  // is the assertion that failed against the pre-fix code (it returned
+  // `null`, collapsing the pending window to something imperceptible live).
+  it('still returns the target for an acknowledged command when the confirmed state has not caught up', () => {
+    runtimeState.state = { main: { [confirmedField]: otherValue }, sub: {} };
+    state.commands = [cmd({ name: intentName, status: 'acknowledged', params: { [paramKey]: value, receiver: 0 } })];
+    expect(accessor(0)).toBe(value);
+  });
+
+  // The other half of the same rule: once the radio's OWN observed state
+  // confirms the target, the acknowledged command must stop reading as
+  // pending — the leg-1 "pending is display-only, confirmed reading stays
+  // authoritative" doctrine, now applied at the confirming-observation seam.
+  it('ignores an acknowledged command once the confirmed state matches the target', () => {
+    runtimeState.state = { main: { [confirmedField]: value }, sub: {} };
+    state.commands = [cmd({ name: intentName, status: 'acknowledged', params: { [paramKey]: value, receiver: 0 } })];
+    expect(accessor(0)).toBeNull();
+  });
+
+  // SUB receiver parity: the confirming read must follow the SAME receiver
+  // split as the command match, not always read MAIN.
+  it('confirms against the SUB receiver state for receiver 1', () => {
+    runtimeState.state = { main: {}, sub: { [confirmedField]: value } };
+    state.commands = [cmd({ name: intentName, status: 'acknowledged', params: { [paramKey]: value, receiver: 1 } })];
+    expect(accessor(1)).toBeNull();
+  });
 
   // Kills: reading the OLDEST pending command instead of the freshest.
   it('picks the freshest pending command when several are in flight', () => {

--- a/frontend/src/lib/runtime/adapters/panel-adapters.ts
+++ b/frontend/src/lib/runtime/adapters/panel-adapters.ts
@@ -254,24 +254,35 @@ function confirmedReceiverState(receiver: 0 | 1): ServerState['main'] | undefine
 }
 
 /**
- * Grace backstop (MOR-1488 review R2) — retire an acknowledged-pending
- * command this long after its ack even with no confirming observation.
- * Covers the never-confirms-at-all classes the sequence guard below cannot,
- * because none of them ever produce a post-ack state push to guard against:
- * (1) MOR-1445 post-ack execution failure — the server acks `ok:true` at
- *     enqueue time, and a later failure reaches only a session notification
- *     (`server.py` `commandExecutionFailed`) that `ws-client.ts`'s
- *     `_emitCommandResult` never maps back to this command id; (2) MOR-1427
- *     coalescing — `_cmd_pending` keys a 50ms coalescing window by command
- *     NAME only, so a superseded frame acks `ok:true`+`superseded` and never
- *     reaches the radio at all; (3) link death after ack. Without this
- *     backstop, any of the three leaves the marker claiming "in flight"
- *     forever. `Date.now()` itself is not reactive — this only takes effect
- *     the next time something re-invokes `latestPendingParam` (the next
- *     state push, or any other `$derived` recompute), not the instant the
- *     clock crosses the threshold.
+ * Grace backstop (MOR-1488 review R2, timing revised R3) — retire an
+ * acknowledged-pending command this long after its ack even with no
+ * confirming observation. Covers the never-confirms-at-all classes the
+ * sequence guard below cannot, because none of them ever produce a
+ * confirming post-ack push to guard against: (1) MOR-1445 post-ack
+ * execution failure — the server acks `ok:true` at enqueue time, and a
+ * later failure reaches only a session notification (`server.py`
+ * `commandExecutionFailed`) that `ws-client.ts`'s `_emitCommandResult`
+ * never maps back to this command id; (2) MOR-1427 coalescing —
+ * `_cmd_pending` keys a 50ms coalescing window by command NAME only, so a
+ * superseded frame acks `ok:true`+`superseded` and never reaches the radio
+ * at all; (3) link death after ack. Without this backstop, any of the three
+ * leaves the marker claiming "in flight" forever. `Date.now()` itself is
+ * not reactive — this only takes effect the next time something re-invokes
+ * `latestPendingParam` (the next state push, or any other `$derived`
+ * recompute), not the instant the clock crosses the threshold.
+ *
+ * 2000ms (R3, was 1500ms): review R3 found the commanded field's own
+ * confirming re-read is a full poll round-robin away, not the next state
+ * push — `_state_queries.py` schedules per-field reads across the
+ * round-robin and `radio_poller.py:529-531` cycles roughly 25 queries at
+ * ~25ms apiece, so worst case is ~1.3s for one full rotation. 1500ms left
+ * too little margin: a command acked just after its field's slot in the
+ * rotation could retire on the grace backstop moments before the actual
+ * confirming readback arrives. 2000ms budgets a full rotation (≈1.3s) plus
+ * headroom for scheduling jitter, matching the sequence guard below's
+ * "mismatch is not evidence of failure, only of not-yet-observed" doctrine.
  */
-const ACK_CONFIRM_GRACE_MS = 1_500;
+const ACK_CONFIRM_GRACE_MS = 2_000;
 
 /**
  * Shared by the four accessors below: the freshest command matching
@@ -302,14 +313,25 @@ const ACK_CONFIRM_GRACE_MS = 1_500;
  * that increments on every applied state push regardless of whether any
  * field's value actually changed; see `ackObservationSeq`'s own doc comment
  * for why `stateRevision` cannot serve this role) has advanced PAST the
- * ack-time value. The FIRST post-ack push settles the record either way and
- * it is no longer read as pending: if the confirmed field now matches the
- * target, the command is excluded (leg-1 "pending is display-only,
- * confirmed reading stays the group's sole selection source" doctrine); if
- * it still does not match, the command is ALSO excluded — the value did not
- * take, and continuing to claim "in flight" past that point would itself be
- * a fabrication. This bounds the pending window to exactly one poll cycle
- * past ack.
+ * ack-time value.
+ *
+ * MOR-1488 review R3 (asymmetric settle, revises R2's "either way"):
+ * `observationSeq` bumps on EVERY applied field observation — a 25ms meter
+ * poll (`core.state_store._apply_one`) advances it exactly as much as a
+ * genuine re-read of THIS command's field. But the commanded field's own
+ * confirming re-read is scheduled a full poll round-robin away
+ * (`_state_queries.py`, `radio_poller.py:529-531`, ~25 queries at ~25ms —
+ * up to ~1.3s worst case), not on the very next push. R2 retired the
+ * record on the first post-ack push regardless of match, which fires
+ * ~50ms after ack (the next unrelated meter poll) — collapsing the
+ * pending window back to a few frames, the exact symptom this PR set out
+ * to fix. So as of R3: a post-ack push whose confirmed field MATCHES the
+ * target is a real confirmation and clears the record (leg-1 "pending is
+ * display-only, confirmed reading stays the group's sole selection source"
+ * doctrine). A post-ack push that does NOT match is NOT evidence the value
+ * failed to take — it is far more likely an unrelated field's observation
+ * that simply hasn't reached this one's round-robin slot yet — so the
+ * record stays pending and is left to the grace backstop above to bound.
  *
  * When no `ackObservationSeq` was captured (no radio state had ever been
  * observed at ack time — a real gap only in cold-start/test-double
@@ -353,17 +375,19 @@ function latestPendingParam(
 
   const ackObservationSeq = latest.ackObservationSeq;
   const currentObservationSeq = runtime.state?.observationSeq;
-  if (ackObservationSeq === undefined || currentObservationSeq === undefined) {
-    // No sequencing data to guard with — fall back to a direct match.
-    return confirmedReceiverState(receiver)?.[confirmedField] === latest.value ? undefined : latest.value;
-  }
-  if (currentObservationSeq <= ackObservationSeq) {
+  if (ackObservationSeq !== undefined && currentObservationSeq !== undefined
+    && currentObservationSeq <= ackObservationSeq) {
     // No push observed since ack yet — stay pending regardless of any
     // coincidental match against the (necessarily stale) current snapshot.
     return latest.value;
   }
-  // First post-ack push: settle the record either way (see doc comment).
-  return undefined;
+  // Either the guard has no sequencing data to work with (fall back to a
+  // direct match, pre-R2 behavior) or a post-ack push has arrived: either
+  // way, only a MATCH settles the record (R3) — a mismatch here is not
+  // evidence the value failed to take (the commanded field's own
+  // confirming re-read is a full round-robin away, see doc comment above),
+  // so it stays pending for the grace backstop to bound instead.
+  return confirmedReceiverState(receiver)?.[confirmedField] === latest.value ? undefined : latest.value;
 }
 
 /** Freshest unconfirmed `set_filter` target for `receiver`, or `null`.

--- a/frontend/src/lib/runtime/adapters/panel-adapters.ts
+++ b/frontend/src/lib/runtime/adapters/panel-adapters.ts
@@ -254,6 +254,26 @@ function confirmedReceiverState(receiver: 0 | 1): ServerState['main'] | undefine
 }
 
 /**
+ * Grace backstop (MOR-1488 review R2) — retire an acknowledged-pending
+ * command this long after its ack even with no confirming observation.
+ * Covers the never-confirms-at-all classes the sequence guard below cannot,
+ * because none of them ever produce a post-ack state push to guard against:
+ * (1) MOR-1445 post-ack execution failure — the server acks `ok:true` at
+ *     enqueue time, and a later failure reaches only a session notification
+ *     (`server.py` `commandExecutionFailed`) that `ws-client.ts`'s
+ *     `_emitCommandResult` never maps back to this command id; (2) MOR-1427
+ *     coalescing — `_cmd_pending` keys a 50ms coalescing window by command
+ *     NAME only, so a superseded frame acks `ok:true`+`superseded` and never
+ *     reaches the radio at all; (3) link death after ack. Without this
+ *     backstop, any of the three leaves the marker claiming "in flight"
+ *     forever. `Date.now()` itself is not reactive — this only takes effect
+ *     the next time something re-invokes `latestPendingParam` (the next
+ *     state push, or any other `$derived` recompute), not the instant the
+ *     clock crosses the threshold.
+ */
+const ACK_CONFIRM_GRACE_MS = 1_500;
+
+/**
  * Shared by the four accessors below: the freshest command matching
  * `intentName`/`receiver` that has not reached a terminal failure/expiry
  * status, or `undefined`. Same authority and `>=` freshest-wins tie-break
@@ -266,16 +286,51 @@ function confirmedReceiverState(receiver: 0 | 1): ServerState['main'] | undefine
  * echoes the new value back (~500ms keep-alive, CLAUDE.md). Treating ack as
  * "no longer pending" (the pre-fix behavior) collapsed the italic pending
  * window to something imperceptible live, presenting an unconfirmed value
- * as confirmed. An acknowledged command whose target does not yet match
- * `confirmedField` on the receiver's observed state therefore still counts
- * as pending here; once the radio's own state confirms the target, the
- * command is excluded, matching the "pending is display-only, confirmed
- * reading stays the group's sole selection source" leg-1 doctrine.
+ * as confirmed.
+ *
+ * MOR-1488 review R2 (sequence guard, closes F2): matching the CURRENT
+ * confirmed snapshot at ack time is not enough on its own — that snapshot
+ * can predate the command entirely. A fast double-toggle (confirmed
+ * nb:false → click ON → click OFF before either is observed) acks the OFF
+ * command while the receiver state still reflects the value from BEFORE
+ * both clicks; OFF's target (false) happens to equal that stale snapshot,
+ * so a plain match would clear the marker immediately even though nothing
+ * has actually been re-observed since. `command.ackObservationSeq`
+ * (`commands.svelte.ts`, captured the instant a command reaches
+ * 'acknowledged') fixes this: the command stays pending until the runtime's
+ * current `observationSeq` (`$lib/stores/radio.svelte` — the one counter
+ * that increments on every applied state push regardless of whether any
+ * field's value actually changed; see `ackObservationSeq`'s own doc comment
+ * for why `stateRevision` cannot serve this role) has advanced PAST the
+ * ack-time value. The FIRST post-ack push settles the record either way and
+ * it is no longer read as pending: if the confirmed field now matches the
+ * target, the command is excluded (leg-1 "pending is display-only,
+ * confirmed reading stays the group's sole selection source" doctrine); if
+ * it still does not match, the command is ALSO excluded — the value did not
+ * take, and continuing to claim "in flight" past that point would itself be
+ * a fabrication. This bounds the pending window to exactly one poll cycle
+ * past ack.
+ *
+ * When no `ackObservationSeq` was captured (no radio state had ever been
+ * observed at ack time — a real gap only in cold-start/test-double
+ * scenarios) or the runtime currently has no observed state either, the
+ * sequence guard has nothing to compare against and falls back to a direct
+ * match against the current confirmed reading (the pre-R2 behavior).
+ *
+ * The match itself intentionally reads the receiver's plain schema value
+ * (`confirmedReceiverState(receiver)?.[confirmedField]`), not `fieldStatus`
+ * freshness — a field that has never been observed at all reads as
+ * `undefined` here, which never `===`-matches a real target value, so an
+ * unobserved field is correctly treated as "not yet confirmed" rather than
+ * silently matching.
  */
 function latestPendingParam(
   intentName: string, paramKey: string, receiver: 0 | 1, confirmedField: keyof ServerState['main'],
 ): unknown {
-  let latest: { createdAt: number; value: unknown; status: string } | null = null;
+  let latest: {
+    createdAt: number; value: unknown; status: string;
+    updatedAt: number; ackObservationSeq: number | undefined;
+  } | null = null;
   for (const command of getCommandLifecycles()) {
     if (command.name !== intentName) continue;
     if (command.status !== 'pending' && command.status !== 'acknowledged') continue;
@@ -283,13 +338,32 @@ function latestPendingParam(
     const value = command.params[paramKey];
     if (value === undefined) continue;
     if (!latest || command.createdAt >= latest.createdAt) {
-      latest = { createdAt: command.createdAt, value, status: command.status };
+      latest = {
+        createdAt: command.createdAt, value, status: command.status,
+        updatedAt: command.updatedAt, ackObservationSeq: command.ackObservationSeq,
+      };
     }
   }
   if (!latest) return undefined;
-  if (latest.status === 'acknowledged'
-    && confirmedReceiverState(receiver)?.[confirmedField] === latest.value) return undefined;
-  return latest.value;
+  if (latest.status !== 'acknowledged') return latest.value;
+
+  // Grace backstop: fires regardless of what the sequence guard below would
+  // otherwise decide — see the constant's own doc comment.
+  if (Date.now() - latest.updatedAt > ACK_CONFIRM_GRACE_MS) return undefined;
+
+  const ackObservationSeq = latest.ackObservationSeq;
+  const currentObservationSeq = runtime.state?.observationSeq;
+  if (ackObservationSeq === undefined || currentObservationSeq === undefined) {
+    // No sequencing data to guard with — fall back to a direct match.
+    return confirmedReceiverState(receiver)?.[confirmedField] === latest.value ? undefined : latest.value;
+  }
+  if (currentObservationSeq <= ackObservationSeq) {
+    // No push observed since ack yet — stay pending regardless of any
+    // coincidental match against the (necessarily stale) current snapshot.
+    return latest.value;
+  }
+  // First post-ack push: settle the record either way (see doc comment).
+  return undefined;
 }
 
 /** Freshest unconfirmed `set_filter` target for `receiver`, or `null`.

--- a/frontend/src/lib/runtime/adapters/panel-adapters.ts
+++ b/frontend/src/lib/runtime/adapters/panel-adapters.ts
@@ -243,49 +243,81 @@ export function getPendingFrequencyHz(receiver: 0 | 1): number | null {
 
 // ── Pending discrete-control targets (MOR-1441 leg 2) ──
 /**
- * Shared by the four accessors below: the freshest still-`'pending'`
- * command matching `intentName`/`receiver`, or `undefined`. Same authority
- * and `>=` freshest-wins tie-break as `getPendingFrequencyHz` above (leg 1,
- * review B3) — no second, parallel pending-state path.
+ * The receiver's confirmed (radio-observed) state slice, or `undefined`
+ * while unobserved — `runtime.state.main`/`.sub`, the same per-receiver
+ * split `getPendingFrequencyHz`'s sibling accessors read.
  */
-function latestPendingParam(intentName: string, paramKey: string, receiver: 0 | 1): unknown {
-  let latest: { createdAt: number; value: unknown } | null = null;
+function confirmedReceiverState(receiver: 0 | 1): ServerState['main'] | undefined {
+  const state = runtime.state;
+  if (!state) return undefined;
+  return receiver === 0 ? state.main : state.sub;
+}
+
+/**
+ * Shared by the four accessors below: the freshest command matching
+ * `intentName`/`receiver` that has not reached a terminal failure/expiry
+ * status, or `undefined`. Same authority and `>=` freshest-wins tie-break
+ * as `getPendingFrequencyHz` above (leg 1, review B3) — no second, parallel
+ * pending-state path.
+ *
+ * MOR-1488 (live-bench finding): a transport `'acknowledged'` (the WS ack)
+ * is NOT a confirming observation — it only proves the radio received the
+ * command, typically within milliseconds, well before the next state poll
+ * echoes the new value back (~500ms keep-alive, CLAUDE.md). Treating ack as
+ * "no longer pending" (the pre-fix behavior) collapsed the italic pending
+ * window to something imperceptible live, presenting an unconfirmed value
+ * as confirmed. An acknowledged command whose target does not yet match
+ * `confirmedField` on the receiver's observed state therefore still counts
+ * as pending here; once the radio's own state confirms the target, the
+ * command is excluded, matching the "pending is display-only, confirmed
+ * reading stays the group's sole selection source" leg-1 doctrine.
+ */
+function latestPendingParam(
+  intentName: string, paramKey: string, receiver: 0 | 1, confirmedField: keyof ServerState['main'],
+): unknown {
+  let latest: { createdAt: number; value: unknown; status: string } | null = null;
   for (const command of getCommandLifecycles()) {
-    if (command.name !== intentName || command.status !== 'pending') continue;
+    if (command.name !== intentName) continue;
+    if (command.status !== 'pending' && command.status !== 'acknowledged') continue;
     if (command.params.receiver !== receiver) continue;
     const value = command.params[paramKey];
     if (value === undefined) continue;
-    if (!latest || command.createdAt >= latest.createdAt) latest = { createdAt: command.createdAt, value };
+    if (!latest || command.createdAt >= latest.createdAt) {
+      latest = { createdAt: command.createdAt, value, status: command.status };
+    }
   }
-  return latest?.value;
+  if (!latest) return undefined;
+  if (latest.status === 'acknowledged'
+    && confirmedReceiverState(receiver)?.[confirmedField] === latest.value) return undefined;
+  return latest.value;
 }
 
-/** Freshest in-flight `set_filter` target for `receiver`, or `null`.
+/** Freshest unconfirmed `set_filter` target for `receiver`, or `null`.
  *  `FilterSurface` renders this as a marker on the targeted choice only —
  *  the confirmed reading stays the group's sole selection source (leg-1
  *  lesson: pending is display-only). */
 export function getPendingFilterSelection(receiver: 0 | 1): number | null {
-  const value = latestPendingParam('set_filter', 'filter', receiver);
+  const value = latestPendingParam('set_filter', 'filter', receiver, 'filter');
   return typeof value === 'number' ? value : null;
 }
 
-/** Freshest in-flight `set_preamp` target for `receiver`, or `null`. Never
+/** Freshest unconfirmed `set_preamp` target for `receiver`, or `null`. Never
  *  touches the MOR-1447 combined-knob/change-guard machinery, which reads
  *  only confirmed fields. */
 export function getPendingPreampLevel(receiver: 0 | 1): number | null {
-  const value = latestPendingParam('set_preamp', 'level', receiver);
+  const value = latestPendingParam('set_preamp', 'level', receiver, 'preamp');
   return typeof value === 'number' ? value : null;
 }
 
-/** Freshest in-flight `set_nb` target for `receiver`, or `null`. */
+/** Freshest unconfirmed `set_nb` target for `receiver`, or `null`. */
 export function getPendingNbOn(receiver: 0 | 1): boolean | null {
-  const value = latestPendingParam('set_nb', 'on', receiver);
+  const value = latestPendingParam('set_nb', 'on', receiver, 'nb');
   return typeof value === 'boolean' ? value : null;
 }
 
-/** Freshest in-flight `set_nr` target for `receiver`, or `null`. */
+/** Freshest unconfirmed `set_nr` target for `receiver`, or `null`. */
 export function getPendingNrOn(receiver: 0 | 1): boolean | null {
-  const value = latestPendingParam('set_nr', 'on', receiver);
+  const value = latestPendingParam('set_nr', 'on', receiver, 'nr');
   return typeof value === 'boolean' ? value : null;
 }
 

--- a/frontend/src/lib/stores/commands.svelte.ts
+++ b/frontend/src/lib/stores/commands.svelte.ts
@@ -1,8 +1,25 @@
+import { getRadioState } from './radio.svelte';
+
 export type CommandLifecycleStatus = 'pending' | 'acknowledged' | 'failed' | 'cancelled' | 'timed-out';
 export interface CommandLifecycle {
   id: string; name: string; params: Readonly<Record<string, unknown>>;
   originalEpoch: number; eventEpoch?: number; createdAt: number; updatedAt: number;
   timeoutMs: number; status: CommandLifecycleStatus; error?: string;
+  /**
+   * The radio-observed `observationSeq` (MOR-1488 review R2) at the instant
+   * this command transitioned to 'acknowledged', or `undefined` if no radio
+   * state had been observed yet. `observationSeq` is the one counter that
+   * increments on every applied state push regardless of whether any field's
+   * value actually changed (`core.state_store._apply_one` bumps it
+   * unconditionally, before the semantic-change check that gates
+   * `stateRevision`) — the "did a fresh poll cycle happen since ack" signal
+   * `panel-adapters.ts`'s `latestPendingParam` needs. `stateRevision` would
+   * NOT serve this: a poll that re-confirms an unchanged value never bumps
+   * it, which is exactly the case a fast double-toggle produces (the
+   * superseded command's target coincides with the pre-existing confirmed
+   * value) and would leave the sequence guard permanently unable to fire.
+   */
+  ackObservationSeq?: number;
 }
 export interface BeginCommandInput {
   id: string; name: string; params: Readonly<Record<string, unknown>>;
@@ -36,6 +53,7 @@ function transition(
   if (!command) return;
   command.status = status; command.eventEpoch = eventEpoch; command.updatedAt = Date.now();
   if (error) command.error = error;
+  if (status === 'acknowledged') command.ackObservationSeq = getRadioState()?.observationSeq;
   clearRecordTimer(command);
 }
 


### PR DESCRIPTION
## Live symptom

On the bench, Filter/Preamp/NB/NR values flip instantly when clicked — the
italic "pending" styling PR #2410 added for the command→confirm round trip
never visibly appears, even though a real round trip is happening.

## Root cause

`frontend/src/lib/runtime/adapters/panel-adapters.ts:251` — `latestPendingParam()`
(the shared engine behind `getPendingFilterSelection`/`getPendingPreampLevel`/
`getPendingNbOn`/`getPendingNrOn`) only counted a command as pending while its
lifecycle `status` was still `'pending'`.

`frontend/src/lib/runtime/commands/radio-intents.ts:99` — the `onCommandDelivery`
handler flips a command's status to `'acknowledged'` on the WS transport ack
alone. That ack typically returns within milliseconds — long before the next
state poll (~500ms control keep-alive) echoes the target value back into
`RadioState`. So the pending marker was clearing on transport ack, not on a
confirming state observation, collapsing the italic window to something
imperceptible live and presenting an unconfirmed value as confirmed.

## Wiring layer was NOT the defect

The MOR-1473 test gap (`SemanticRadioSurfaces.svelte`'s `{pendingFilter}`/
`{pendingPreamp}`/`{pendingNb}`/`{pendingNr}` prop-passing, never previously
proved over a real mount) is closed by
`frontend/src/components-v2/wiring/__tests__/semantic-discrete-pending-wiring.component.test.ts`,
a new wiring-component test that mounts the real `SemanticRadioSurfaces` over
seeded real `radio.svelte`/`capabilities.svelte` stores (the PR #2409 pattern)
and drives an unmocked command lifecycle via real clicks. All 6 of its
original assertions (filter/preamp/NB/NR pending markers + VFO leg-1 parity +
lifecycle-reset clears them) passed against unmodified `main` — the wiring
itself correctly passes every pending prop through. The actual defect was one
layer down, in how "still pending" was computed.

## Fix

`latestPendingParam()` now also considers `'acknowledged'` commands, but
continues to report them as pending only while the receiver's confirmed state
(`runtime.state.main`/`.sub`) has not yet caught up to the command's target;
once the confirmed field matches, the command is excluded exactly as before.
This is a fix inside the existing pending accessors — no redesign of #2410's
DOM/CSS presentation.

`pendingFrequencyHz` (MOR-1441 leg 1) shares the same ack-only release
mechanism and is very likely the same root cause behind MOR-1478's
stale-flash report, but is deliberately left untouched here — out of scope
for this fix.

## New/updated tests

- `semantic-discrete-pending-wiring.component.test.ts` (new): "keeps the NB
  marker pending across a transport ack until a confirming state observation
  arrives (MOR-1488)" — fails on the pre-fix code (ack alone cleared the
  marker), passes after the fix. Confirmed red-then-green by manually
  reverting the `panel-adapters.ts` fix hunk and re-running.
- `mor1441-pending-discrete.isolated.test.ts` (updated): the old
  `it.each(['acknowledged', 'failed', 'cancelled', 'timed-out'])('ignores a
  %s command', ...)` encoded the old (buggy) behavior for `'acknowledged'`.
  Replaced with: `failed`/`cancelled`/`timed-out` still ignored (unchanged),
  plus three new cases per accessor — acknowledged-without-confirmation
  (still pending), acknowledged-with-confirmation (no longer pending), and
  the SUB-receiver confirming split.

## Verification

- `npx vitest run` targeted at the touched/related files: 144 tests passed
  (`mor1441-pending-discrete.isolated.test.ts`,
  `semantic-discrete-pending-wiring.component.test.ts`,
  `semantic-dsp-wiring.component.test.ts`,
  `semantic-rf-front-end-wiring.component.test.ts`, `FilterSurface.test.ts`).
- `npx eslint` on the three touched files: clean.
- `npx svelte-check`: 0 errors, 0 warnings across 4545 files.
- Full local frontend suite intentionally NOT run this session (CPU
  contention risk against the 600s watchdog); CI on this PR covers it.

Closes MOR-1488.
Closes MOR-1473.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
## Review round 2

An independent verifier BLOCKED the first version on two findings.

**F1 — nothing retires an acknowledged-never-confirmed command.** The R1 fix
kept a command pending until the confirmed state caught up, but nothing
retired it if confirmation never arrived: `commands.svelte.ts` only clears
the record timer on ack, the timeout callback bails unless
`status === 'pending'`, and `cancelPendingCommands` skips non-pending
records. Three reachable never-confirm paths: (1) MOR-1445 post-ack
execution failure — the server acks `ok:true` at enqueue time and a later
failure reaches only a session notification the WS client never maps back to
the command id; (2) MOR-1427 coalescing — a superseded command frame acks
`ok:true`+`superseded` and never reaches the radio; (3) link death after ack.
Any of these left the marker italic forever.

**F2 — no observation-sequence guard.** The match compared the command's
target against the CURRENT confirmed snapshot with no check that the
snapshot was observed AFTER the ack. A fast double-toggle (confirmed
`nb:false` → click ON → click OFF before either is polled) acks the OFF
command while the receiver state still reflects the value from BEFORE both
clicks; OFF's target happens to equal that stale snapshot, so the R1
comparison cleared the marker immediately, presenting "confirmed" while the
first command could still be in flight. The R1 wiring test also bumped
`revision`/`stateRevision`/`freshnessRevision`/`observationSeq` in its
`nbConfirmedState()` fixture but the implementation never read any of them —
test theatre that would not have caught a broken sequence guard.

**Fix (one mechanism closes both):**

- `commands.svelte.ts`'s `transition()` now captures the runtime's current
  `observationSeq` onto the command record (`ackObservationSeq`) the instant
  a command reaches `'acknowledged'`. `observationSeq`
  (`$lib/stores/radio.svelte`) is the one counter that increments on every
  applied state push regardless of whether any field's value actually
  changed (backend: `core.state_store._apply_one` bumps it unconditionally,
  before the semantic-change check that gates `stateRevision`) — `revision`/
  `stateRevision` do not serve this role, since a poll that merely
  reconfirms an unchanged value never advances them, which is exactly the
  double-toggle case.
- `latestPendingParam()` (`panel-adapters.ts`) now stays pending while
  acknowledged AND no state push newer than the ack-time `observationSeq`
  has arrived. The FIRST post-ack push settles the record either way —
  match (confirmed, target reached) or mismatch (value did not take) both
  retire the pending marker, bounding the window to exactly one poll cycle
  past ack. This closes F2 directly (no stale-snapshot match) and closes F1
  for the "coalesced/superseded, but a later poll cycle happens anyway"
  case, since even a non-transitioning reconfirmation settles it.
- **Grace backstop**: an acknowledged command additionally retires once
  `Date.now() - updatedAt > 1_500ms` even with no confirming observation at
  all — this is what actually closes F1's three never-confirms-again
  classes (post-ack failure, coalescing, link death), none of which ever
  produce a post-ack push for the sequence guard to observe. `Date.now()`
  itself isn't reactive; the backstop takes effect the next time anything
  re-invokes the accessor (the next state push or `$derived` recompute), not
  at the instant the clock crosses the threshold.
- Test-theatre fix: `semantic-discrete-pending-wiring.component.test.ts`
  gained a new case proving the stale-snapshot double-toggle scenario stays
  pending across the OFF command's ack, and only clears on the first genuine
  post-ack push — including a `nbReobservedState()` fixture that advances
  only `observationSeq`/`freshnessRevision` (not `stateRevision`), so the
  test would fail if the implementation keyed the guard off the wrong
  counter.
- `latestPendingParam`'s doc comment now also notes the match reads the
  receiver's plain schema value, not `fieldStatus` freshness, and that an
  unobserved field (`undefined`) never spuriously matches a real target.

`pendingFrequencyHz` (MOR-1441 leg 1, MOR-1478) is untouched, as before.
## Review round 3

A second verifier pass found F1/F2 closed, but a new blocking finding: R2's
sequence guard settled a post-ack command on the FIRST post-ack push
regardless of match. `observationSeq` (`state_store.py`'s `_apply_one`)
increments on ANY applied field observation — meters poll at 25ms
(`radio_poller.py`) and the browser receives a push roughly every 50ms
(`server.py`) — while the commanded field's own confirming re-read is
scheduled a full poll round-robin away (`_state_queries.py` +
`radio_poller.py:529-531`, ~25 queries at ~25ms, up to ~1.3s worst case). So
R2's "first post-ack push settles it either way" fired on the very next
unrelated meter poll, ~50ms after ack — collapsing the italic pending window
back to a few frames and substantially reproducing the original bench
symptom.

**Fix — asymmetric settle, not "either way":**

- `latestPendingParam()` (`panel-adapters.ts`) keeps R2's guard for "no push
  since ack yet" (still blocks the F2 stale-match case), but a post-ack push
  now only clears the record when the confirmed field actually MATCHES the
  target. A mismatching post-ack push is not treated as evidence the command
  failed — it is far more likely an unrelated field's observation that
  simply hasn't reached this field's round-robin slot — so the record stays
  pending and is left for the grace backstop to bound.
- `ACK_CONFIRM_GRACE_MS`: 1500ms -> 2000ms, to budget a full poll
  round-robin (~1.3s worst case, `radio_poller.py:529-531`) plus scheduling
  headroom, since the grace backstop is now the mechanism that actually
  bounds the "field genuinely never gets a confirming re-read" case
  (MOR-1445/1427/link-death) rather than a match-blind first-push settle.
- Both R2 wiring tests still pass unchanged: the "confirming state
  observation" test and the double-toggle test both push a state where the
  target genuinely MATCHES, so the asymmetric settle still clears them on
  that (real) confirmation.
- New tests (`semantic-discrete-pending-wiring.component.test.ts`):
  - `'does not clear the marker on a post-ack push that advances
    observationSeq without confirming the target (MOR-1488 review R3)'` —
    an ack'd `set_nb(true)` command, then a post-ack push (`observationSeq`
    advanced, `main.nb` still `false`) must NOT clear the marker.
  - `'retires the marker via the 2000ms grace backstop once it has elapsed,
    even with a non-confirming push (MOR-1488 review R3)'` — fake timers,
    advance past 2000ms, push a still-non-confirming state; the marker
    retires via the backstop, not the sequence guard.
  - `nbReobservedState()` is reused for both R2 (where its target-false
    payload matches the double-toggle's OFF command) and R3 (where the same
    payload mismatches a target-true ON command) — its doc comment now
    explains the dual role.
