### PR TITLE
fix: gate spectrum drag-to-tune on frequency authority only (MOR-1497)

### DIFF
--- a/frontend/src/components/spectrum/SpectrumPanel.svelte
+++ b/frontend/src/components/spectrum/SpectrumPanel.svelte
@@ -109,6 +109,11 @@
   );
   let spanHz = $derived(endFreq > startFreq ? endFreq - startFreq : 0);
   let spectrumAuthority = $derived(toSpectrumAuthority(runtime.state, runtime.caps));
+  // MOR-1497: the grab cursor must not promise a drag the gate will refuse.
+  // Mirrors completeFrequencyAuthority's condition exactly.
+  let canPan = $derived(
+    spectrumAuthority !== null && spectrumAuthority.frequencyHz !== null,
+  );
   let scopeMode = $derived(frameScopeMode);
   // Tuning indicator: center for CTR/SCROLL-C, proportional for FIX/SCROLL-F
   let isFixedScope = $derived(isFixedScopeFn(scopeMode));
@@ -199,6 +204,18 @@
     return current;
   }
 
+  // MOR-1497: plain drag-to-pan only moves frequency — it must not be gated
+  // on passband fields (mode/filterWidthHz/ifShiftHz) it never reads. On
+  // Icom radios ifShiftHz is structurally unobservable (no IF-shift command,
+  // PBT-only), so completeGestureAuthority(false) returned null forever and
+  // silently disabled the drag gesture while the grab cursor kept implying
+  // it worked. Passband-resize (handlePassbandResizeStart) keeps the full
+  // gate — it genuinely needs mode/filterWidthHz/ifShiftHz/rule.
+  function completeFrequencyAuthority(): SpectrumAuthority | null {
+    const current = readAuthority();
+    return current && current.frequencyHz !== null ? current : null;
+  }
+
   function readSampleGeometry(element: HTMLElement): SampleGeometry | null {
     const { width } = element.getBoundingClientRect();
     if (!Number.isFinite(width) || width <= 0 || !Number.isFinite(startFreq)
@@ -216,6 +233,24 @@
     const current = readAuthority();
     const geometry = readSampleGeometry(element);
     return current?.digest === capture.authority.digest
+      && geometry?.frameMode === capture.geometry.frameMode
+      && geometry.startFreq === capture.geometry.startFreq
+      && geometry.endFreq === capture.geometry.endFreq
+      && geometry.elementWidth === capture.geometry.elementWidth;
+  }
+
+  // MOR-1497: freq-only counterpart of captureStillCurrent for plain
+  // drag-to-pan. The full digest includes passband fields (mode/
+  // filterWidthHz/ifShiftHz/rule/scopeControls/...) the pan gesture never
+  // reads, so re-checking it would spuriously abort a completed pan whenever
+  // any of those unrelated fields changed mid-drag. Re-check only the
+  // identity/geometry the gesture actually depends on.
+  function captureFrequencyStillCurrent(capture: GestureCapture, element: HTMLElement): boolean {
+    const current = readAuthority();
+    const geometry = readSampleGeometry(element);
+    return current?.providerGeneration === capture.authority.providerGeneration
+      && current.receiver === capture.authority.receiver
+      && current.frequencyHz === capture.authority.frequencyHz
       && geometry?.frameMode === capture.geometry.frameMode
       && geometry.startFreq === capture.geometry.startFreq
       && geometry.endFreq === capture.geometry.endFreq
@@ -340,7 +375,7 @@
     if (event.button !== 0 || resizeCapture) return;
     if (event.target instanceof Element && event.target.closest('button, select, input')) return;
     const surface = event.currentTarget as HTMLElement | null;
-    const accepted = completeGestureAuthority(false);
+    const accepted = completeFrequencyAuthority();
     const geometry = surface ? readSampleGeometry(surface) : null;
     if (!surface || !accepted || !geometry) return;
     const rect = surface.getBoundingClientRect();
@@ -378,7 +413,7 @@
     const capture = dragCapture;
     if (!capture || capture.pointerId !== event.pointerId || !dragSurface) return;
     const candidate = dragCandidate;
-    const stable = captureStillCurrent(capture, dragSurface);
+    const stable = captureFrequencyStillCurrent(capture, dragSurface);
     dragging = false;
     dragCapture = null;
     dragSurface = null;
@@ -444,7 +479,7 @@
         <div class="tick" style="top: {tick.position}%">{tick.label}</div>
       {/each}
     </div>
-    <div class="spectrum-area" class:panning={dragging} bind:this={spectrumArea} onpointerdown={handleDragStart} role="presentation">
+    <div class="spectrum-area" class:panning={dragging} class:draggable={canPan} bind:this={spectrumArea} onpointerdown={handleDragStart} role="presentation">
       {#if !scopeDemandOn}
         <div class="scope-disconnected-overlay scope-demand-off-overlay">Scope viewer OFF</div>
       {:else if !scopeConnected}
@@ -474,7 +509,7 @@
   {/if}
   <div class="waterfall-area">
     <div class="waterfall-scale"></div>
-    <div class="waterfall-content" class:panning={dragging} bind:this={waterfallContent} onpointerdown={handleDragStart} role="presentation">
+    <div class="waterfall-content" class:panning={dragging} class:draggable={canPan} bind:this={waterfallContent} onpointerdown={handleDragStart} role="presentation">
       <WaterfallCanvas options={waterfallOptions} onFreqClick={handleTune} onRegisterPush={(fn) => waterfallPush = fn} />
       <DxOverlay spots={dxSpots} {startFreq} {endFreq} onTune={handleTune} />
       <!-- Tuning + passband indicator overlays the waterfall -->
@@ -552,6 +587,10 @@
     min-width: 0;
     min-height: 0;
     position: relative;
+    cursor: default;
+  }
+
+  .spectrum-area.draggable {
     cursor: grab;
   }
 
@@ -602,6 +641,10 @@
     flex: 1 1 auto;
     min-width: 0;
     position: relative;
+    cursor: default;
+  }
+
+  .waterfall-content.draggable {
     cursor: grab;
   }
 

--- a/frontend/src/components/spectrum/SpectrumPanel.svelte
+++ b/frontend/src/components/spectrum/SpectrumPanel.svelte
@@ -110,9 +110,11 @@
   let spanHz = $derived(endFreq > startFreq ? endFreq - startFreq : 0);
   let spectrumAuthority = $derived(toSpectrumAuthority(runtime.state, runtime.caps));
   // MOR-1497: the grab cursor must not promise a drag the gate will refuse.
-  // Mirrors completeFrequencyAuthority's condition exactly.
+  // Mirrors the FULL drag-start gate: frequency authority AND usable sample
+  // geometry (before the first scope frame endFreq <= startFreq, so
+  // handleDragStart bails — the cursor must not claim otherwise).
   let canPan = $derived(
-    spectrumAuthority !== null && spectrumAuthority.frequencyHz !== null,
+    spectrumAuthority !== null && spectrumAuthority.frequencyHz !== null && spanHz > 0,
   );
   let scopeMode = $derived(frameScopeMode);
   // Tuning indicator: center for CTR/SCROLL-C, proportional for FIX/SCROLL-F

--- a/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
+++ b/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
@@ -930,9 +930,9 @@ describe('SpectrumPanel Observation authority and final-gesture intents', () => 
   });
 
   // MOR-1497: the grab cursor is decorative CSS unless it reflects whether a
-  // drag is actually possible — withhold it exactly when the frequency-only
-  // gate (completeFrequencyAuthority) would refuse the gesture.
-  it('withholds the draggable cursor class when frequency authority is absent, grants it when present (MOR-1497)', () => {
+  // drag is actually possible — withhold it exactly when the drag-start gate
+  // (frequency authority AND usable sample geometry) would refuse the gesture.
+  it('withholds the draggable cursor class until both frequency authority and scope geometry exist (MOR-1497)', () => {
     authorityHarness.state.current = authority({ frequencyHz: null });
     const withoutFreq = mountPanel();
     expect(withoutFreq.querySelector('.spectrum-area')?.classList.contains('draggable')).toBe(false);
@@ -940,6 +940,13 @@ describe('SpectrumPanel Observation authority and final-gesture intents', () => 
 
     authorityHarness.state.current = authority({ filterWidthHz: null, ifShiftHz: null });
     const withFreqOnly = mountPanel();
+    // Before the first scope frame the sample geometry is unusable
+    // (endFreq <= startFreq) and handleDragStart would bail — the cursor
+    // must not promise a drag that cannot happen.
+    expect(withFreqOnly.querySelector('.spectrum-area')?.classList.contains('draggable')).toBe(false);
+    expect(withFreqOnly.querySelector('.waterfall-content')?.classList.contains('draggable')).toBe(false);
+
+    emitFrame();
     expect(withFreqOnly.querySelector('.spectrum-area')?.classList.contains('draggable')).toBe(true);
     expect(withFreqOnly.querySelector('.waterfall-content')?.classList.contains('draggable')).toBe(true);
   });

--- a/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
+++ b/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
@@ -873,16 +873,6 @@ describe('SpectrumPanel Observation authority and final-gesture intents', () => 
     ['provider generation', { providerGeneration: 18 }],
     ['physical receiver', { receiver: 1 as const }],
     ['frequency', { frequencyHz: 14_050_300 }],
-    ['mode', { mode: 'LSB' }],
-    ['filter', { filter: 'FIL2' }],
-    ['width', { filterWidthHz: 2_500 }],
-    ['IF shift', { ifShiftHz: 50 }],
-    ['PBT inner', { pbtInnerHz: 50 }],
-    ['PBT outer', { pbtOuterHz: 50 }],
-    ['filter shape', { filterShape: 2 }],
-    ['DATA', { dataMode: 1 }],
-    ['rule', { rule: Object.freeze({ kind: 'step' as const, minHz: 200, maxHz: 5_000, stepHz: 100 }) }],
-    ['scope controls in full digest', { scopeControls: Object.freeze({ mode: 3 }) }],
   ])('rejects final drag after %s drift', (_label, overrides) => {
     const target = mountPanel();
     emitFrame();
@@ -892,6 +882,66 @@ describe('SpectrumPanel Observation authority and final-gesture intents', () => 
     authorityHarness.state.current = authority(overrides);
     pointer(spectrum, 'pointerup', 30, 120);
     expect(handlerHarness.vfo.onFreqChange).not.toHaveBeenCalled();
+  });
+
+  // MOR-1497: plain drag-to-pan only moves frequency, so drift in passband
+  // fields it never reads must NOT abort an otherwise-stable pan. Before the
+  // fix these all shared one full-digest recheck with passband-resize, which
+  // made irrelevant field churn spuriously cancel a completed drag.
+  it.each([
+    ['mode', { mode: 'LSB' }],
+    ['filter', { filter: 'FIL2' }],
+    ['width', { filterWidthHz: 2_500 }],
+    ['IF shift', { ifShiftHz: 50 }],
+    ['PBT inner', { pbtInnerHz: 50 }],
+    ['PBT outer', { pbtOuterHz: 50 }],
+    ['filter shape', { filterShape: 2 }],
+    ['DATA', { dataMode: 1 }],
+    ['rule', { rule: Object.freeze({ kind: 'step' as const, minHz: 200, maxHz: 5_000, stepHz: 100 }) }],
+    ['scope controls', { scopeControls: Object.freeze({ mode: 3 }) }],
+  ])('completes final drag despite %s drift, which plain panning does not depend on (MOR-1497)', (_label, overrides) => {
+    const target = mountPanel();
+    emitFrame();
+    const { spectrum } = prepareGeometry(target);
+    pointer(spectrum, 'pointerdown', 33, 100);
+    pointer(spectrum, 'pointermove', 33, 120);
+    authorityHarness.state.current = authority(overrides);
+    pointer(spectrum, 'pointerup', 33, 120);
+    expect(handlerHarness.vfo.onFreqChange).toHaveBeenCalledOnce();
+    expect(handlerHarness.vfo.onFreqChange).toHaveBeenCalledWith(14_040_000, 0);
+  });
+
+  // MOR-1497 regression: drag-to-pan was gated on completeGestureAuthority(false),
+  // which required mode/filterWidthHz/ifShiftHz to all be non-null. On Icom
+  // radios ifShiftHz is structurally unobservable (PBT-only, no IF-shift
+  // command) so the gate returned null forever and every drag silently
+  // no-op'd behind a grab cursor that promised it would work.
+  it('completes a plain drag when filter width and IF shift are unobserved (MOR-1497)', () => {
+    authorityHarness.state.current = authority({ filterWidthHz: null, ifShiftHz: null });
+    const target = mountPanel();
+    emitFrame();
+    const { spectrum } = prepareGeometry(target);
+    pointer(spectrum, 'pointerdown', 40, 100);
+    pointer(spectrum, 'pointermove', 40, 120);
+    expect(handlerHarness.vfo.onFreqChange).not.toHaveBeenCalled();
+    pointer(spectrum, 'pointerup', 40, 120);
+    expect(handlerHarness.vfo.onFreqChange).toHaveBeenCalledOnce();
+    expect(handlerHarness.vfo.onFreqChange).toHaveBeenCalledWith(14_040_000, 0);
+  });
+
+  // MOR-1497: the grab cursor is decorative CSS unless it reflects whether a
+  // drag is actually possible — withhold it exactly when the frequency-only
+  // gate (completeFrequencyAuthority) would refuse the gesture.
+  it('withholds the draggable cursor class when frequency authority is absent, grants it when present (MOR-1497)', () => {
+    authorityHarness.state.current = authority({ frequencyHz: null });
+    const withoutFreq = mountPanel();
+    expect(withoutFreq.querySelector('.spectrum-area')?.classList.contains('draggable')).toBe(false);
+    expect(withoutFreq.querySelector('.waterfall-content')?.classList.contains('draggable')).toBe(false);
+
+    authorityHarness.state.current = authority({ filterWidthHz: null, ifShiftHz: null });
+    const withFreqOnly = mountPanel();
+    expect(withFreqOnly.querySelector('.spectrum-area')?.classList.contains('draggable')).toBe(true);
+    expect(withFreqOnly.querySelector('.waterfall-content')?.classList.contains('draggable')).toBe(true);
   });
 
   it.each([


### PR DESCRIPTION
## Symptom

Dragging the spectrum/waterfall to pan the visible frequency window did nothing: the grab cursor appeared and the pointer tracked visually, but releasing the drag never retuned the radio (no `onFreqChange`, no `set_freq`). Click-to-tune and scroll-to-tune on the same panel worked fine.

## Root cause

`handleDragStart` in `SpectrumPanel.svelte` gated the drag gesture on `completeGestureAuthority(false)`, which requires `frequencyHz`, `mode`, `filterWidthHz`, **and** `ifShiftHz` to all be observed (via `toSpectrumAuthority` in `scope-adapter.ts`). That gate was introduced in `e1be9c7e` ("refactor(#2317): migrate spectrum panel authority") — before that refactor, drag-start depended on frequency alone.

On Icom radios, `ifShiftHz` is **structurally unobservable**: Icom transceivers have no IF-shift CI-V command at all — they are PBT-only. That field can never transition from `null`, no matter how much polling coverage improves. `filterWidthHz` is also currently unobserved on IC-7300. So `completeGestureAuthority(false)` returns `null` on every call, `handleDragStart` bails at line 345 before capturing a gesture, and `handleDragMove`/`handleDragEnd` then short-circuit on the missing capture — the pan never fires. This is why a poll-coverage fix (e.g. wiring up filter-width polling) would **not** have healed this on its own: even with `filterWidthHz` fixed, `ifShiftHz` remains permanently `null` on this radio family, so the AND-gate would still return `null` forever.

Meanwhile `.spectrum-area { cursor: grab }` was unconditional CSS, so the UI kept promising a working drag regardless of gate state — a misleading affordance.

## Fix

- Added `completeFrequencyAuthority()`: a frequency-only gate (mirrors the same null-check class already used by click-to-tune), used by `handleDragStart` instead of the full `completeGestureAuthority(false)`.
- Added `captureFrequencyStillCurrent()`: a freq + receiver + providerGeneration + geometry recheck for `handleDragEnd`, replacing the full-digest `captureStillCurrent()` for this gesture. The full digest includes passband fields (`mode`/`filterWidthHz`/`ifShiftHz`/`rule`/`scopeControls`/...) that plain panning never reads, so reusing it meant unrelated field churn mid-drag could spuriously cancel an otherwise-stable pan. The passband-resize gesture (`handlePassbandResizeStart`/`handleResizeEnd`) is untouched and keeps the original full gate + full-digest recheck — it genuinely needs `mode`/`filterWidthHz`/`ifShiftHz`/`rule`.
- Cursor honesty: added a `canPan` derived (same condition as the new gate) and a `.draggable` class on `.spectrum-area`/`.waterfall-content`. The grab cursor now only shows when a drag can actually complete; CSS default is `cursor: default`.

## Tests

All in `frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts`:

- `completes a plain drag when filter width and IF shift are unobserved (MOR-1497)` — the primary regression test: authority with `frequencyHz` present but `filterWidthHz`/`ifShiftHz` null (the IC-7300 shape), drags past the threshold, asserts `onFreqChange` fires with the panned frequency.
- `completes final drag despite %s drift, which plain panning does not depend on (MOR-1497)` (`it.each`, 10 cases: mode/filter/width/IF shift/PBT inner/PBT outer/filter shape/DATA/rule/scope controls) — proves the narrowed drag-end recheck no longer spuriously aborts on irrelevant passband drift.
- `rejects final drag after %s drift` (narrowed to 3 cases: provider generation/physical receiver/frequency) — the safety recheck is preserved for the fields the gesture actually uses.
- `withholds the draggable cursor class when frequency authority is absent, grants it when present (MOR-1497)` — cursor-honesty coverage.

## Verification

- `npx vitest run src/components/spectrum/__tests__/SpectrumPanel.component.test.ts` — 83 passed
- `npx vitest run` on the nearest existing spectrum suites (`spectrum-panel-logic.test.ts`, `SpectrumToolbar.component.test.ts`, `spectrum-toolbar.test.ts`, `spectrum-renderer.test.ts`) — 162 passed
- `npx eslint` on both touched files — zero violations
- `npm run check` (svelte-check + tsc) — 0 errors, 0 warnings

Closes MOR-1497

🤖 Generated with [Claude Code](https://claude.com/claude-code)
