### PR TITLE
feat: field-policy membership wave — VOX/MON, filter/PBT, DSP levels, RIT/CW (MOR-1483, MOR-1491, MOR-1492, MOR-1493)

### DIFF
--- a/rigs/ic7300.toml
+++ b/rigs/ic7300.toml
@@ -186,6 +186,14 @@ command_response_observable = [
     "receiver.main.operator_controls.filter_shape",
     "receiver.main.operator_controls.pbt_inner",
     "receiver.main.operator_controls.pbt_outer",
+    # MOR-1492 (field-policy membership wave, leg 3): DSP level facts.
+    "receiver.main.operator_controls.nr_level",
+    "receiver.main.operator_controls.nb_level",
+    "receiver.main.operator_toggles.auto_notch",
+    "receiver.main.operator_toggles.manual_notch",
+    "global.operator_controls.notch_filter",
+    "receiver.main.operator_controls.manual_notch_width",
+    "receiver.main.operator_controls.agc_time_constant",
 ]
 supported_controls = [
     "receiver.main.active.freq_mode.freq_hz",
@@ -297,6 +305,48 @@ reconciliation_priority = "command_response"
 adaptive_decay = false
 
 [state_acquisition.field_policies."receiver.main.operator_controls.pbt_outer"]
+cadence_seconds = 25.0
+freshness_ttl_seconds = 25.0
+reconciliation_priority = "command_response"
+adaptive_decay = false
+
+[state_acquisition.field_policies."receiver.main.operator_controls.nr_level"]
+cadence_seconds = 25.0
+freshness_ttl_seconds = 25.0
+reconciliation_priority = "command_response"
+adaptive_decay = false
+
+[state_acquisition.field_policies."receiver.main.operator_controls.nb_level"]
+cadence_seconds = 25.0
+freshness_ttl_seconds = 25.0
+reconciliation_priority = "command_response"
+adaptive_decay = false
+
+[state_acquisition.field_policies."receiver.main.operator_toggles.auto_notch"]
+cadence_seconds = 25.0
+freshness_ttl_seconds = 25.0
+reconciliation_priority = "command_response"
+adaptive_decay = false
+
+[state_acquisition.field_policies."receiver.main.operator_toggles.manual_notch"]
+cadence_seconds = 25.0
+freshness_ttl_seconds = 25.0
+reconciliation_priority = "command_response"
+adaptive_decay = false
+
+[state_acquisition.field_policies."global.operator_controls.notch_filter"]
+cadence_seconds = 25.0
+freshness_ttl_seconds = 25.0
+reconciliation_priority = "command_response"
+adaptive_decay = false
+
+[state_acquisition.field_policies."receiver.main.operator_controls.manual_notch_width"]
+cadence_seconds = 25.0
+freshness_ttl_seconds = 25.0
+reconciliation_priority = "command_response"
+adaptive_decay = false
+
+[state_acquisition.field_policies."receiver.main.operator_controls.agc_time_constant"]
 cadence_seconds = 25.0
 freshness_ttl_seconds = 25.0
 reconciliation_priority = "command_response"

--- a/rigs/ic7300.toml
+++ b/rigs/ic7300.toml
@@ -194,6 +194,17 @@ command_response_observable = [
     "global.operator_controls.notch_filter",
     "receiver.main.operator_controls.manual_notch_width",
     "receiver.main.operator_controls.agc_time_constant",
+    # MOR-1493 (field-policy membership wave, leg 4): RIT/XIT and CW keyer
+    # facts.
+    "global.operator_controls.rit_freq",
+    "global.tx_state.rit_on",
+    "global.tx_state.rit_tx",
+    "global.operator_controls.break_in",
+    "global.operator_controls.break_in_delay",
+    "global.operator_controls.key_speed",
+    "global.operator_controls.cw_pitch",
+    "receiver.main.operator_controls.audio_peak_filter",
+    "receiver.main.operator_toggles.twin_peak_filter",
 ]
 supported_controls = [
     "receiver.main.active.freq_mode.freq_hz",
@@ -347,6 +358,60 @@ reconciliation_priority = "command_response"
 adaptive_decay = false
 
 [state_acquisition.field_policies."receiver.main.operator_controls.agc_time_constant"]
+cadence_seconds = 25.0
+freshness_ttl_seconds = 25.0
+reconciliation_priority = "command_response"
+adaptive_decay = false
+
+[state_acquisition.field_policies."global.operator_controls.rit_freq"]
+cadence_seconds = 25.0
+freshness_ttl_seconds = 25.0
+reconciliation_priority = "command_response"
+adaptive_decay = false
+
+[state_acquisition.field_policies."global.tx_state.rit_on"]
+cadence_seconds = 25.0
+freshness_ttl_seconds = 25.0
+reconciliation_priority = "command_response"
+adaptive_decay = false
+
+[state_acquisition.field_policies."global.tx_state.rit_tx"]
+cadence_seconds = 25.0
+freshness_ttl_seconds = 25.0
+reconciliation_priority = "command_response"
+adaptive_decay = false
+
+[state_acquisition.field_policies."global.operator_controls.break_in"]
+cadence_seconds = 25.0
+freshness_ttl_seconds = 25.0
+reconciliation_priority = "command_response"
+adaptive_decay = false
+
+[state_acquisition.field_policies."global.operator_controls.break_in_delay"]
+cadence_seconds = 25.0
+freshness_ttl_seconds = 25.0
+reconciliation_priority = "command_response"
+adaptive_decay = false
+
+[state_acquisition.field_policies."global.operator_controls.key_speed"]
+cadence_seconds = 25.0
+freshness_ttl_seconds = 25.0
+reconciliation_priority = "command_response"
+adaptive_decay = false
+
+[state_acquisition.field_policies."global.operator_controls.cw_pitch"]
+cadence_seconds = 25.0
+freshness_ttl_seconds = 25.0
+reconciliation_priority = "command_response"
+adaptive_decay = false
+
+[state_acquisition.field_policies."receiver.main.operator_controls.audio_peak_filter"]
+cadence_seconds = 25.0
+freshness_ttl_seconds = 25.0
+reconciliation_priority = "command_response"
+adaptive_decay = false
+
+[state_acquisition.field_policies."receiver.main.operator_toggles.twin_peak_filter"]
 cadence_seconds = 25.0
 freshness_ttl_seconds = 25.0
 reconciliation_priority = "command_response"

--- a/rigs/ic7300.toml
+++ b/rigs/ic7300.toml
@@ -181,6 +181,11 @@ command_response_observable = [
     # that's new mechanism, not a table entry, so it's out of scope here.
     "global.tx_state.vox_on",
     "global.tx_state.monitor_on",
+    # MOR-1491 (field-policy membership wave, leg 2): filter/PBT facts.
+    "receiver.main.active.freq_mode.filter_width",
+    "receiver.main.operator_controls.filter_shape",
+    "receiver.main.operator_controls.pbt_inner",
+    "receiver.main.operator_controls.pbt_outer",
 ]
 supported_controls = [
     "receiver.main.active.freq_mode.freq_hz",
@@ -268,6 +273,30 @@ reconciliation_priority = "command_response"
 adaptive_decay = false
 
 [state_acquisition.field_policies."global.tx_state.monitor_on"]
+cadence_seconds = 25.0
+freshness_ttl_seconds = 25.0
+reconciliation_priority = "command_response"
+adaptive_decay = false
+
+[state_acquisition.field_policies."receiver.main.active.freq_mode.filter_width"]
+cadence_seconds = 25.0
+freshness_ttl_seconds = 25.0
+reconciliation_priority = "command_response"
+adaptive_decay = false
+
+[state_acquisition.field_policies."receiver.main.operator_controls.filter_shape"]
+cadence_seconds = 25.0
+freshness_ttl_seconds = 25.0
+reconciliation_priority = "command_response"
+adaptive_decay = false
+
+[state_acquisition.field_policies."receiver.main.operator_controls.pbt_inner"]
+cadence_seconds = 25.0
+freshness_ttl_seconds = 25.0
+reconciliation_priority = "command_response"
+adaptive_decay = false
+
+[state_acquisition.field_policies."receiver.main.operator_controls.pbt_outer"]
 cadence_seconds = 25.0
 freshness_ttl_seconds = 25.0
 reconciliation_priority = "command_response"

--- a/rigs/ic7300.toml
+++ b/rigs/ic7300.toml
@@ -170,6 +170,17 @@ command_response_observable = [
     "global.tx_state.ptt",
     "global.operator_controls.tuner_status",
     "global.tx_state.split",
+    # MOR-1483 (field-policy membership wave, leg 1): VOX/MON toggles.
+    # Non-polling (command_response only) — riding the MOR-1490
+    # prime_unobserved mechanism rather than a poll cadence; see the
+    # field_policies comment below. voxDelay (1A-05 ctl-mem 02-92) is NOT
+    # added here: its ingress decode already exists
+    # (``_CTL_MEM_VOX_DELAY_PREFIX``), but the scheduler's acquisition
+    # executor has no query builder for 2-byte ctl-mem sub-addressing
+    # (``AcquisitionQuerySender`` is a 3-tuple command/sub/receiver only) —
+    # that's new mechanism, not a table entry, so it's out of scope here.
+    "global.tx_state.vox_on",
+    "global.tx_state.monitor_on",
 ]
 supported_controls = [
     "receiver.main.active.freq_mode.freq_hz",
@@ -234,6 +245,32 @@ adaptive_decay = false
 [state_acquisition.field_policies."global.operator_controls.anti_vox_gain"]
 cadence_seconds = 15.0
 freshness_ttl_seconds = 25.0
+adaptive_decay = false
+
+# MOR-1483/1491/1492/1493 (field-policy membership wave): non-polling
+# (command_response) membership riding the MOR-1490 priming mechanism
+# (AcquisitionScheduler.prime_unobserved). These fields are deliberately
+# NOT in [state_acquisition.capabilities].polling_only above, so
+# due_requests() never touches them; instead prime_unobserved() queues a
+# BACKGROUND read for each once it's never-observed, re-deriving the
+# never-observed set every ~30s
+# (StateFreshnessService.PRIME_REDERIVE_INTERVAL_SECONDS) until each field
+# lands its first observation — worst case a few re-derive windows if the
+# scheduler's 5-path-per-call burst cap (prime_unobserved's
+# _PRIME_UNOBSERVED_BURST_LIMIT) paces this whole group across multiple
+# calls. cadence_seconds is pinned equal to freshness_ttl_seconds purely so
+# diagnostics don't show a misleadingly fast number — it is otherwise inert
+# here because these capabilities carry polling=False.
+[state_acquisition.field_policies."global.tx_state.vox_on"]
+cadence_seconds = 25.0
+freshness_ttl_seconds = 25.0
+reconciliation_priority = "command_response"
+adaptive_decay = false
+
+[state_acquisition.field_policies."global.tx_state.monitor_on"]
+cadence_seconds = 25.0
+freshness_ttl_seconds = 25.0
+reconciliation_priority = "command_response"
 adaptive_decay = false
 
 # ── Parameterized Capabilities ───────────────────────────────────

--- a/rigs/ic7610.toml
+++ b/rigs/ic7610.toml
@@ -225,6 +225,14 @@ polling_only = [
     "global.operator_controls.notch_filter",
     "receiver.main.operator_controls.manual_notch_width",
     "receiver.sub.operator_controls.manual_notch_width",
+    # MOR-1493 (field-policy membership wave, profile parity): break_in
+    # (16-47) / break_in_delay (14-0F) — same rationale/sourcing as above
+    # (documented S/R, already in [commands]/[break_in]). rit_freq/rit_on/
+    # rit_tx/key_speed/cw_pitch/audio_peak_filter/twin_peak_filter are
+    # already polled on this profile (see polling_only above) -- no addition
+    # needed for those.
+    "global.operator_controls.break_in",
+    "global.operator_controls.break_in_delay",
 ]
 stream_like_meters = [
     "receiver.main.meters.s_meter",
@@ -623,6 +631,19 @@ adaptive_decay = false
 [state_acquisition.field_policies."receiver.sub.operator_controls.manual_notch_width"]
 cadence_seconds = 1.5
 freshness_ttl_seconds = 3.0
+adaptive_decay = false
+
+# MOR-1493 (field-policy membership wave, profile parity). break_in matches
+# compressor_on/monitor_on/vox_on's 1.5s/3.0s 0x16-toggle tier; break_in_delay
+# matches notch_filter's 3.0s/5.0s 0x14-level tier above.
+[state_acquisition.field_policies."global.operator_controls.break_in"]
+cadence_seconds = 1.5
+freshness_ttl_seconds = 3.0
+adaptive_decay = false
+
+[state_acquisition.field_policies."global.operator_controls.break_in_delay"]
+cadence_seconds = 3.0
+freshness_ttl_seconds = 5.0
 adaptive_decay = false
 
 # ── Parameterized Capabilities ───────────────────────────────────

--- a/rigs/ic7610.toml
+++ b/rigs/ic7610.toml
@@ -208,6 +208,17 @@ polling_only = [
     "global.tx_state.split",
     "global.tx_state.dual_watch",
     "global.operator_controls.tuner_status",
+    # MOR-1491 (field-policy membership wave, profile parity): filter_shape
+    # (CI-V 0x16 0x56). docs/validation/cat-audits/ic7610.md documents this
+    # as S/R (``filter_shape.presence`` ✅), and rigs/ic7610.toml's own
+    # [commands] table already carries get/set_filter_shape — this only adds
+    # state_acquisition membership. Added to polling_only (not the new
+    # IC-7300 command_response/priming shape) to match every sibling 0x16
+    # DSP field already established on this profile above (e.g.
+    # audio_peak_filter). IC-7610 hardware retired 2026-08-04 — no live
+    # verification possible, so this rides the documented command table only.
+    "receiver.main.operator_controls.filter_shape",
+    "receiver.sub.operator_controls.filter_shape",
 ]
 stream_like_meters = [
     "receiver.main.meters.s_meter",
@@ -573,6 +584,19 @@ freshness_ttl_seconds = 3.0
 adaptive_decay = false
 
 [state_acquisition.field_policies."global.operator_controls.tuner_status"]
+cadence_seconds = 1.5
+freshness_ttl_seconds = 3.0
+adaptive_decay = false
+
+# MOR-1491 (field-policy membership wave, profile parity). Cadence tier
+# matches the closest existing sibling: filter_shape shares the 0x16-family
+# tier with audio_peak_filter/auto_notch (1.5s/3.0s).
+[state_acquisition.field_policies."receiver.main.operator_controls.filter_shape"]
+cadence_seconds = 1.5
+freshness_ttl_seconds = 3.0
+adaptive_decay = false
+
+[state_acquisition.field_policies."receiver.sub.operator_controls.filter_shape"]
 cadence_seconds = 1.5
 freshness_ttl_seconds = 3.0
 adaptive_decay = false

--- a/rigs/ic7610.toml
+++ b/rigs/ic7610.toml
@@ -219,6 +219,12 @@ polling_only = [
     # verification possible, so this rides the documented command table only.
     "receiver.main.operator_controls.filter_shape",
     "receiver.sub.operator_controls.filter_shape",
+    # MOR-1492 (field-policy membership wave, profile parity): notch_filter
+    # (14-0D) / manual_notch_width (16-57) — same rationale/sourcing as
+    # filter_shape above (documented S/R, already in [commands]/[notch]).
+    "global.operator_controls.notch_filter",
+    "receiver.main.operator_controls.manual_notch_width",
+    "receiver.sub.operator_controls.manual_notch_width",
 ]
 stream_like_meters = [
     "receiver.main.meters.s_meter",
@@ -597,6 +603,24 @@ freshness_ttl_seconds = 3.0
 adaptive_decay = false
 
 [state_acquisition.field_policies."receiver.sub.operator_controls.filter_shape"]
+cadence_seconds = 1.5
+freshness_ttl_seconds = 3.0
+adaptive_decay = false
+
+# MOR-1492 (field-policy membership wave, profile parity). notch_filter
+# matches nr_level/pbt_inner's 3.0s/5.0s 0x14-level tier; manual_notch_width
+# matches filter_shape's 1.5s/3.0s 0x16-family tier above.
+[state_acquisition.field_policies."global.operator_controls.notch_filter"]
+cadence_seconds = 3.0
+freshness_ttl_seconds = 5.0
+adaptive_decay = false
+
+[state_acquisition.field_policies."receiver.main.operator_controls.manual_notch_width"]
+cadence_seconds = 1.5
+freshness_ttl_seconds = 3.0
+adaptive_decay = false
+
+[state_acquisition.field_policies."receiver.sub.operator_controls.manual_notch_width"]
 cadence_seconds = 1.5
 freshness_ttl_seconds = 3.0
 adaptive_decay = false

--- a/src/rigplane/core/acquisition_scheduler.py
+++ b/src/rigplane/core/acquisition_scheduler.py
@@ -233,6 +233,9 @@ _RECEIVER_NONLEVEL_QUERIES: dict[str, tuple[int, int | None]] = {
     "preamp": (0x16, 0x02),
     "agc": (0x16, 0x12),
     "audio_peak_filter": (0x16, 0x32),
+    # filter_shape (MOR-1491): documented BCD-nibble 0x16 value read, same
+    # query shape as audio_peak_filter/agc above.
+    "filter_shape": (0x16, 0x56),
     "agc_time_constant": (0x1A, 0x04),
     "tone_freq": (0x1B, 0x00),
     "tsql_freq": (0x1B, 0x01),

--- a/src/rigplane/core/acquisition_scheduler.py
+++ b/src/rigplane/core/acquisition_scheduler.py
@@ -233,9 +233,11 @@ _RECEIVER_NONLEVEL_QUERIES: dict[str, tuple[int, int | None]] = {
     "preamp": (0x16, 0x02),
     "agc": (0x16, 0x12),
     "audio_peak_filter": (0x16, 0x32),
-    # filter_shape (MOR-1491): documented BCD-nibble 0x16 value read, same
-    # query shape as audio_peak_filter/agc above.
+    # filter_shape (MOR-1491) / manual_notch_width (MOR-1492): documented
+    # BCD-nibble 0x16 value reads, same query shape as audio_peak_filter/agc
+    # above.
     "filter_shape": (0x16, 0x56),
+    "manual_notch_width": (0x16, 0x57),
     "agc_time_constant": (0x1A, 0x04),
     "tone_freq": (0x1B, 0x00),
     "tsql_freq": (0x1B, 0x01),

--- a/src/rigplane/core/acquisition_scheduler.py
+++ b/src/rigplane/core/acquisition_scheduler.py
@@ -279,6 +279,10 @@ _GLOBAL_LEVEL_QUERY_SUBS: dict[str, int] = {
 # tuner on or start a tune (MOR-488 batch 5).
 _GLOBAL_NONLEVEL_QUERIES: dict[str, tuple[int, int | None]] = {
     "tuner_status": (0x1C, 0x01),
+    # break_in (MOR-1493): documented BCD-nibble 0x16 value read (OFF/SEMI/
+    # FULL), same query shape as compressor_on/monitor_on/vox_on above but
+    # 3-valued rather than a plain toggle.
+    "break_in": (0x16, 0x47),
 }
 _GLOBAL_METER_QUERY_SUBS: dict[str, int] = {
     "power": 0x11,
@@ -692,10 +696,12 @@ class AcquisitionScheduler:
         policy carries a ``cadence_seconds`` is therefore left to
         :meth:`due_requests` entirely; this method never touches it,
         regardless of whether it happens to also carry a ``field_policies``
-        entry. On the shipped IC-7300 profile this means
-        ``prime_unobserved`` queues nothing today — its effect is still
-        purely mechanism-only until a future non-polling field is added
-        (MOR-1491/1492/1493).
+        entry. On the shipped IC-7300 profile ``prime_unobserved`` now
+        actively primes the non-polling ``command_response`` field-policy
+        membership added by MOR-1483/1491/1492/1493 (VOX/MON toggles,
+        filter/PBT facts, DSP level facts, RIT/XIT and CW keyer facts) —
+        this mechanism was previously wired but exercised by nothing on any
+        shipped profile.
 
         Two further guards keep one call from flooding the transport:
 

--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -289,12 +289,13 @@ _OBSERVABLE_CMD14_FIELDS = {
     0x08: ("receiver", "operator_controls", "pbt_outer"),
     0x0A: ("global", "operator_controls", "power_level"),
     0x0B: ("global", "operator_controls", "mic_gain"),
-    # notch_filter (MOR-1492): documented BCD-pair 0x14 level, same decode
-    # as the other global level fields below; the legacy ``_handle_14``
-    # mirror write is suppressed for this sub via
-    # ``_CMD14_OBSERVATION_BACKED_SUBS``.
+    # notch_filter (MOR-1492) / break_in_delay (MOR-1493): documented
+    # BCD-pair 0x14 levels, same decode as the other global level fields
+    # below; the legacy ``_handle_14`` mirror write is suppressed for these
+    # subs via ``_CMD14_OBSERVATION_BACKED_SUBS``.
     0x0D: ("global", "operator_controls", "notch_filter"),
     0x0E: ("global", "operator_controls", "compressor_level"),
+    0x0F: ("global", "operator_controls", "break_in_delay"),
     0x12: ("receiver", "operator_controls", "nb_level"),
     0x15: ("global", "operator_controls", "monitor_gain"),
     0x16: ("global", "operator_controls", "vox_gain"),
@@ -329,6 +330,7 @@ _CMD14_OBSERVATION_BACKED_SUBS = frozenset(
         0x0B,  # mic_gain (global)
         0x0D,  # notch_filter (global — MOR-1492)
         0x0E,  # compressor_level (global)
+        0x0F,  # break_in_delay (global — MOR-1493)
         0x15,  # monitor_gain (global)
         0x09,  # cw_pitch (global)
         0x0C,  # key_speed (global, raw level → WPM — MOR-493)
@@ -347,6 +349,7 @@ _CMD16_OBSERVATION_BACKED_VALUE_SUBS = frozenset(
         0x12,  # agc (receiver, BCD nibble)
         0x32,  # audio_peak_filter (receiver, BCD nibble — MOR-452)
         0x56,  # filter_shape (receiver, BCD nibble — MOR-1491)
+        0x47,  # break_in (global, BCD nibble — MOR-1493)
     }
 )
 
@@ -426,6 +429,9 @@ _OBSERVABLE_CMD16_VALUE_FIELDS = {
     # ``_get_bcd_level(..., bcd_bytes=1)``).
     0x56: (("receiver", "operator_controls", "filter_shape"), "bcd_nibble"),
     0x57: (("receiver", "operator_controls", "manual_notch_width"), "bcd_nibble"),
+    # break_in (MOR-1493, global): same BCD-nibble decode, 3-valued
+    # (OFF/SEMI/FULL) rather than a plain toggle.
+    0x47: (("global", "operator_controls", "break_in"), "bcd_nibble"),
 }
 
 

--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -340,6 +340,7 @@ _CMD16_OBSERVATION_BACKED_VALUE_SUBS = frozenset(
         0x02,  # preamp (receiver, raw byte)
         0x12,  # agc (receiver, BCD nibble)
         0x32,  # audio_peak_filter (receiver, BCD nibble — MOR-452)
+        0x56,  # filter_shape (receiver, BCD nibble — MOR-1491)
     }
 )
 
@@ -413,6 +414,9 @@ _OBSERVABLE_CMD16_VALUE_FIELDS = {
     0x02: (("receiver", "operator_controls", "preamp"), "raw"),
     0x12: (("receiver", "operator_controls", "agc"), "bcd_nibble"),
     0x32: (("receiver", "operator_controls", "audio_peak_filter"), "bcd_nibble"),
+    # filter_shape (MOR-1491): same BCD-nibble decode as agc/audio_peak_filter
+    # above.
+    0x56: (("receiver", "operator_controls", "filter_shape"), "bcd_nibble"),
 }
 
 

--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -289,6 +289,11 @@ _OBSERVABLE_CMD14_FIELDS = {
     0x08: ("receiver", "operator_controls", "pbt_outer"),
     0x0A: ("global", "operator_controls", "power_level"),
     0x0B: ("global", "operator_controls", "mic_gain"),
+    # notch_filter (MOR-1492): documented BCD-pair 0x14 level, same decode
+    # as the other global level fields below; the legacy ``_handle_14``
+    # mirror write is suppressed for this sub via
+    # ``_CMD14_OBSERVATION_BACKED_SUBS``.
+    0x0D: ("global", "operator_controls", "notch_filter"),
     0x0E: ("global", "operator_controls", "compressor_level"),
     0x12: ("receiver", "operator_controls", "nb_level"),
     0x15: ("global", "operator_controls", "monitor_gain"),
@@ -322,6 +327,7 @@ _CMD14_OBSERVATION_BACKED_SUBS = frozenset(
         0x06,  # nr_level (receiver)
         0x12,  # nb_level (receiver)
         0x0B,  # mic_gain (global)
+        0x0D,  # notch_filter (global — MOR-1492)
         0x0E,  # compressor_level (global)
         0x15,  # monitor_gain (global)
         0x09,  # cw_pitch (global)
@@ -414,9 +420,12 @@ _OBSERVABLE_CMD16_VALUE_FIELDS = {
     0x02: (("receiver", "operator_controls", "preamp"), "raw"),
     0x12: (("receiver", "operator_controls", "agc"), "bcd_nibble"),
     0x32: (("receiver", "operator_controls", "audio_peak_filter"), "bcd_nibble"),
-    # filter_shape (MOR-1491): same BCD-nibble decode as agc/audio_peak_filter
-    # above.
+    # filter_shape (MOR-1491) / manual_notch_width (MOR-1492): same
+    # BCD-nibble decode as agc/audio_peak_filter above
+    # (``radio.get_manual_notch_width`` already reads this exact shape via
+    # ``_get_bcd_level(..., bcd_bytes=1)``).
     0x56: (("receiver", "operator_controls", "filter_shape"), "bcd_nibble"),
+    0x57: (("receiver", "operator_controls", "manual_notch_width"), "bcd_nibble"),
 }
 
 

--- a/tests/fixtures/civ_rx_frames.json
+++ b/tests/fixtures/civ_rx_frames.json
@@ -130,10 +130,10 @@
   },
   {
     "name": "cmd16_sub47_break_in_global_value",
-    "comment": "0x16/0x47 global value (break_in 0..2)",
+    "comment": "0x16/0x47 break_in is observation-backed (MOR-1493 field-policy membership wave); the legacy RadioState mirror is no longer written (stays at default).",
     "frame": {"command": 22, "sub": 71, "data": "02"},
     "expected_state": {
-      "break_in": 2
+      "break_in": 0
     }
   },
   {

--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -3011,7 +3011,6 @@ def test_update_radio_state_cmd14_receiver_dsp_levels_observation_backed(
 @pytest.mark.parametrize(  # type: ignore[untyped-decorator]
     ("sub", "raw", "field", "expected"),
     [
-        (0x0F, 104, "break_in_delay", 104),
         (0x14, 105, "drive_gain", 105),
     ],
 )
@@ -3041,9 +3040,10 @@ def test_update_radio_state_cmd14_global_dsp_levels(
         (0x17, 108, "anti_vox_gain", 108),
         # key_speed raw level 146 → 30 WPM via the linear key-speed map (MOR-493).
         (0x0C, 146, "key_speed", 30),
-        # notch_filter promoted to a neutral observation (MOR-1492
-        # field-policy membership wave); plain BCD-pair decode.
+        # notch_filter/break_in_delay promoted to neutral observations
+        # (MOR-1492/1493 field-policy membership wave); plain BCD-pair decode.
         (0x0D, 102, "notch_filter", 102),
+        (0x0F, 104, "break_in_delay", 104),
     ],
 )
 def test_update_radio_state_cmd14_global_dsp_levels_observation_backed(
@@ -3053,9 +3053,9 @@ def test_update_radio_state_cmd14_global_dsp_levels_observation_backed(
     field: str,
     expected: int,
 ) -> None:
-    """MOR-437/MOR-459/MOR-1492: cw_pitch/mic_gain/compressor_level/
+    """MOR-437/MOR-459/MOR-1492/MOR-1493: cw_pitch/mic_gain/compressor_level/
     monitor_gain, the VOX gain pair (vox_gain/anti_vox_gain), and
-    notch_filter are observation-backed; the legacy
+    notch_filter/break_in_delay are observation-backed; the legacy
     global RadioState mirror was removed.
 
     cw_pitch in particular asserts the exact non-linear raw→Hz mapping
@@ -3171,10 +3171,10 @@ def test_update_radio_state_cmd16_ipplus(radio_with_state: IcomRadio) -> None:
         # receiver toggle (MOR-466); 0x41 auto_notch, 0x44 compressor_on,
         # 0x45 monitor_on, 0x46 vox_on, 0x48 manual_notch (MOR-437); 0x12 agc +
         # 0x1A/0x04 agc_time_constant (BE-2); 0x32 audio_peak_filter +
-        # 0x4F twin_peak_filter (MOR-452); and 0x56 filter_shape (MOR-1491
-        # field-policy membership wave) are now observation-backed — the
-        # legacy RadioState mirror was removed, so they no longer belong here.
-        (0x16, 0x47, b"\x02", None, "radio", "break_in", 2),
+        # 0x4F twin_peak_filter (MOR-452); and 0x56 filter_shape + 0x47
+        # break_in (MOR-1491/1493 field-policy membership wave) are now
+        # observation-backed — the legacy RadioState mirror was removed, so
+        # they no longer belong here.
         (0x16, 0x50, b"\x01", None, "radio", "dial_lock", True),
         (0x16, 0x58, b"\x02", None, "radio", "ssb_tx_bandwidth", 2),
     ],
@@ -3253,6 +3253,21 @@ def test_update_radio_state_cmd16_manual_notch_width_observation_backed(
     # BCD-nibble decode of 0x02 == 2 (NAR).
     field = radio_with_state._state_store.snapshot().field(
         "receiver.1.operator_controls.manual_notch_width"
+    )
+    assert field.value == 2
+
+
+def test_update_radio_state_cmd16_break_in_observation_backed(
+    radio_with_state: IcomRadio,
+) -> None:
+    """MOR-1493: cmd 0x16/0x47 mirror removed; StateStore is source of truth."""
+    rs = radio_with_state._radio_state
+    frame = _make_frame(cmd=0x16, sub=0x47, data=b"\x02")
+    radio_with_state._civ_runtime._update_state_cache_from_frame(frame)
+    # BCD-nibble decode of 0x02 == 2 (FULL), matching the removed legacy mirror.
+    assert rs.break_in == 0
+    field = radio_with_state._state_store.snapshot().field(
+        "global.operator_controls.break_in"
     )
     assert field.value == 2
 

--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -3011,7 +3011,6 @@ def test_update_radio_state_cmd14_receiver_dsp_levels_observation_backed(
 @pytest.mark.parametrize(  # type: ignore[untyped-decorator]
     ("sub", "raw", "field", "expected"),
     [
-        (0x0D, 102, "notch_filter", 102),
         (0x0F, 104, "break_in_delay", 104),
         (0x14, 105, "drive_gain", 105),
     ],
@@ -3042,6 +3041,9 @@ def test_update_radio_state_cmd14_global_dsp_levels(
         (0x17, 108, "anti_vox_gain", 108),
         # key_speed raw level 146 → 30 WPM via the linear key-speed map (MOR-493).
         (0x0C, 146, "key_speed", 30),
+        # notch_filter promoted to a neutral observation (MOR-1492
+        # field-policy membership wave); plain BCD-pair decode.
+        (0x0D, 102, "notch_filter", 102),
     ],
 )
 def test_update_radio_state_cmd14_global_dsp_levels_observation_backed(
@@ -3051,8 +3053,9 @@ def test_update_radio_state_cmd14_global_dsp_levels_observation_backed(
     field: str,
     expected: int,
 ) -> None:
-    """MOR-437/MOR-459: cw_pitch/mic_gain/compressor_level/monitor_gain and the
-    VOX gain pair (vox_gain/anti_vox_gain) are observation-backed; the legacy
+    """MOR-437/MOR-459/MOR-1492: cw_pitch/mic_gain/compressor_level/
+    monitor_gain, the VOX gain pair (vox_gain/anti_vox_gain), and
+    notch_filter are observation-backed; the legacy
     global RadioState mirror was removed.
 
     cw_pitch in particular asserts the exact non-linear raw→Hz mapping
@@ -3237,6 +3240,21 @@ def test_update_radio_state_cmd16_filter_shape_observation_backed(
         "receiver.1.operator_controls.filter_shape"
     )
     assert field.value == 1
+
+
+def test_update_radio_state_cmd16_manual_notch_width_observation_backed(
+    radio_with_state: IcomRadio,
+) -> None:
+    """MOR-1492: cmd 0x16/0x57 has no legacy mirror at all — this is the first
+    time it lands anywhere; ``_handle_16`` never wrote it before either.
+    """
+    frame = _make_frame(cmd=0x16, sub=0x57, data=b"\x02", receiver=0x01)
+    radio_with_state._civ_runtime._update_state_cache_from_frame(frame)
+    # BCD-nibble decode of 0x02 == 2 (NAR).
+    field = radio_with_state._state_store.snapshot().field(
+        "receiver.1.operator_controls.manual_notch_width"
+    )
+    assert field.value == 2
 
 
 def test_update_radio_state_cmd16_twin_peak_filter_observation_backed(

--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -3167,12 +3167,12 @@ def test_update_radio_state_cmd16_ipplus(radio_with_state: IcomRadio) -> None:
         # 0x15/0x01 + 0x15/0x05 s_meter_sql_open promoted to the neutral ``dcd``
         # receiver toggle (MOR-466); 0x41 auto_notch, 0x44 compressor_on,
         # 0x45 monitor_on, 0x46 vox_on, 0x48 manual_notch (MOR-437); 0x12 agc +
-        # 0x1A/0x04 agc_time_constant (BE-2); and 0x32 audio_peak_filter +
-        # 0x4F twin_peak_filter (MOR-452) are now observation-backed — the legacy
-        # RadioState mirror was removed, so they no longer belong here.
+        # 0x1A/0x04 agc_time_constant (BE-2); 0x32 audio_peak_filter +
+        # 0x4F twin_peak_filter (MOR-452); and 0x56 filter_shape (MOR-1491
+        # field-policy membership wave) are now observation-backed — the
+        # legacy RadioState mirror was removed, so they no longer belong here.
         (0x16, 0x47, b"\x02", None, "radio", "break_in", 2),
         (0x16, 0x50, b"\x01", None, "radio", "dial_lock", True),
-        (0x16, 0x56, b"\x01", 0x01, "sub", "filter_shape", 1),
         (0x16, 0x58, b"\x02", None, "radio", "ssb_tx_bandwidth", 2),
     ],
 )
@@ -3222,6 +3222,21 @@ def test_update_radio_state_cmd16_audio_peak_filter_observation_backed(
         "receiver.1.operator_controls.audio_peak_filter"
     )
     assert field.value == 2
+
+
+def test_update_radio_state_cmd16_filter_shape_observation_backed(
+    radio_with_state: IcomRadio,
+) -> None:
+    """MOR-1491: cmd 0x16/0x56 mirror removed; StateStore is source of truth."""
+    rs = radio_with_state._radio_state
+    frame = _make_frame(cmd=0x16, sub=0x56, data=b"\x01", receiver=0x01)
+    radio_with_state._civ_runtime._update_state_cache_from_frame(frame)
+    # BCD-nibble decode of 0x01 == 1 (SOFT), matching the removed legacy mirror.
+    assert rs.sub.filter_shape == 0
+    field = radio_with_state._state_store.snapshot().field(
+        "receiver.1.operator_controls.filter_shape"
+    )
+    assert field.value == 1
 
 
 def test_update_radio_state_cmd16_twin_peak_filter_observation_backed(

--- a/tests/test_state_acquisition_policy.py
+++ b/tests/test_state_acquisition_policy.py
@@ -563,6 +563,92 @@ def test_ic7300_profile_enrolls_exact_supported_observation_rows() -> None:
     assert profile.cmd29_routes == frozenset()
 
 
+def test_ic7300_non_polling_field_policies_have_full_acquisition_chain() -> None:
+    """MOR-1483/1491/1492/1493 (field-policy membership wave) guard.
+
+    ``AcquisitionScheduler.prime_unobserved`` (MOR-1490) only has an effect on
+    a ``field_policies`` path whose capability is NOT pollable -- that is
+    exactly the shape a "poll membership" addition riding the priming
+    mechanism takes (see the mechanism's own docstring). A path added there
+    without a matching CI-V query mapping head-of-line-starves the burst cap
+    forever (``no_civ_query_mapping``); a path added without an ingress
+    observation mapping primes silently and never actually leaves ``UNKNOWN``.
+
+    This iterates the *real*, currently-loaded IC-7300 profile's
+    ``field_policies`` table generically -- filtered to non-polling entries,
+    a structural property, not a hardcoded list of field names -- so any
+    future membership addition of this shape is caught by this same test
+    without editing it.
+    """
+
+    from rigplane.core.acquisition_scheduler import IcomCivAcquisitionExecutor
+    from rigplane.runtime import _civ_rx
+
+    profile = get_radio_profile("IC-7300")
+    acquisition = profile.state_acquisition
+    assert acquisition is not None
+
+    async def _noop_send(command: int, sub: int | None, receiver: int | None) -> None:
+        return None
+
+    executor = IcomCivAcquisitionExecutor(_noop_send)
+
+    # Ingress mappings that live as hardcoded command/sub branches in
+    # ``_observations_from_frame`` rather than one of its lookup dicts:
+    # rit_freq/rit_on/rit_tx (cmd 0x21), agc_time_constant (cmd 0x1A sub
+    # 0x04), filter_width (cmd 0x1A sub 0x03, profile-dependent decode), and
+    # cw_pitch/key_speed (cmd 0x14, non-linear decode helpers). Kept as an
+    # explicit set -- not derivable from a dict import -- because the
+    # production code itself is branch-shaped there, not table-shaped;
+    # extend this set if a future field adds another such branch.
+    hardcoded_observable = {
+        ("global", "operator_controls", "rit_freq"),
+        ("global", "tx_state", "rit_on"),
+        ("global", "tx_state", "rit_tx"),
+        ("receiver", "operator_controls", "agc_time_constant"),
+        ("receiver", "freq_mode", "filter_width"),
+        ("global", "operator_controls", "cw_pitch"),
+        ("global", "operator_controls", "key_speed"),
+    }
+    table_observable = set(_civ_rx._OBSERVABLE_CMD14_FIELDS.values())
+    table_observable |= set(_civ_rx._OBSERVABLE_CMD15_FIELDS.values())
+    table_observable |= set(_civ_rx._OBSERVABLE_CMD16_FIELDS.values())
+    table_observable |= {
+        spec for spec, _decode_mode in _civ_rx._OBSERVABLE_CMD16_VALUE_FIELDS.values()
+    }
+    table_observable |= set(_civ_rx._OBSERVABLE_CMD1B_FIELDS.values())
+    known_observable = table_observable | hardcoded_observable
+
+    non_polling_paths = [
+        path
+        for path in acquisition.field_policies
+        if not acquisition.capability_for(path).can_poll
+    ]
+    # This membership wave is the reason any non-polling field_policies entry
+    # exists on IC-7300 at all -- guard against the set silently going empty
+    # again (e.g. a future edit moves everything back into polling_only and
+    # stops exercising prime_unobserved on this profile).
+    assert non_polling_paths
+
+    for path in non_polling_paths:
+        capability = acquisition.capability_for(path)
+        assert capability.command_response_observable or capability.unsolicited_push, (
+            f"{path}: non-polling field_policies entry with no acquisition hook"
+        )
+
+        query = executor.query_for_path(path)
+        assert query is not None, (
+            f"{path}: no CI-V query mapping (no_civ_query_mapping) -- "
+            "prime_unobserved would head-of-line-starve the burst cap on this"
+        )
+
+        key = (path.scope.value, path.family.value, path.name)
+        assert key in known_observable, (
+            f"{path}: no ingress observation mapping -- a primed read for "
+            "this path would never leave UNKNOWN"
+        )
+
+
 def test_ic7300_activation_does_not_change_ftx1_acquisition_contract() -> None:
     ftx1 = get_radio_profile("FTX-1")
     acquisition = ftx1.state_acquisition


### PR DESCRIPTION
## Summary

Field-policy membership wave: four Linear data tickets that add entries to `rigs/ic7300.toml [state_acquisition.field_policies]` (and, where a profile already declares the same get command, `rigs/ic7610.toml`), riding the just-merged MOR-1490 priming mechanism (`AcquisitionScheduler.prime_unobserved`). All 22 new IC-7300 fields are **non-polling** (`command_response_observable`, not `polling_only`) — `due_requests()` never touches them; `prime_unobserved()` queues a `BACKGROUND` read for each once it's never-observed, and `StateFreshnessService` re-derives the never-observed set every ~30s until each field lands its first observation.

Four commits, one per ticket, in order:

1. `feat: poll membership for VOX/MON toggles and VOX delay (MOR-1483)`
2. `feat: poll membership for filter/PBT facts (MOR-1491)`
3. `feat: poll membership for DSP level facts (MOR-1492)`
4. `feat: poll membership for RIT/XIT and CW keyer facts (MOR-1493)`

## Per-ticket coverage

### MOR-1483 — VOX/MON toggles + VOX delay — **partial**

| Field | Path | CI-V | Class | Profiles | Status |
|---|---|---|---|---|---|
| voxOn | `global.tx_state.vox_on` | 16-46 | command_response | ic7300 | full |
| monitorOn | `global.tx_state.monitor_on` | 16-45 | command_response | ic7300 | full |
| voxDelay | `global.operator_controls.vox_delay` | 1A-05 ctl-mem 02-92 | — | none | **skipped** |

voxOn/monitorOn already had a full query mapping (`IcomCivAcquisitionExecutor._GLOBAL_TX_TOGGLE_QUERIES`) and ingress observation mapping (`_OBSERVABLE_CMD16_FIELDS`) from prior work, so this is membership-only.

voxDelay is **not** closed. Its ingress decode already exists (`_CTL_MEM_VOX_DELAY_PREFIX`, MOR-459), but the scheduler's query executor (`AcquisitionQuerySender = Callable[[int, int | None, int | None], Awaitable[None]]`) has no way to build a 2-byte ctl-mem sub-address (0x1A 0x05 + 0x02 0x92) — it's a 3-tuple command/sub/receiver only. Adding this is new mechanism (widening the executor's query interface), not a table entry, so it's out of scope for this membership wave. No "Closes" for MOR-1483.

### MOR-1491 — filter/PBT facts — **full, closed**

| Field | Path | CI-V | Class | Profiles |
|---|---|---|---|---|
| filterWidth | `receiver.main.active.freq_mode.filter_width` | 1A-03 | command_response | ic7300 |
| filterShape | `receiver.main.operator_controls.filter_shape` | 16-56 | command_response | ic7300, ic7610 (polling, parity) |
| pbtInner | `receiver.main.operator_controls.pbt_inner` | 14-07 | command_response | ic7300 |
| pbtOuter | `receiver.main.operator_controls.pbt_outer` | 14-08 | command_response | ic7300 |

filter_width/pbt_inner/pbt_outer already had full query+ingress support. filter_shape needed both a new query mapping (`_RECEIVER_NONLEVEL_QUERIES`) and a new ingress mapping (`_OBSERVABLE_CMD16_VALUE_FIELDS`, BCD-nibble decode matching the existing agc/audio_peak_filter entries); the legacy `RadioState.filter_shape` mirror write is now suppressed the same way MOR-437/452 migrated its siblings.

### MOR-1492 — DSP level facts — **full, closed**

| Field | Path | CI-V | Class | Profiles |
|---|---|---|---|---|
| nrLevel | `receiver.main.operator_controls.nr_level` | 14-06 | command_response | ic7300 |
| nbLevel | `receiver.main.operator_controls.nb_level` | 14-12 | command_response | ic7300 |
| notch on (auto) | `receiver.main.operator_toggles.auto_notch` | 16-41 | command_response | ic7300 |
| notch on (manual) | `receiver.main.operator_toggles.manual_notch` | 16-48 | command_response | ic7300 |
| notchPosition | `global.operator_controls.notch_filter` | 14-0D | command_response | ic7300, ic7610 (polling, parity) |
| notchWidth | `receiver.main.operator_controls.manual_notch_width` | 16-57 | command_response | ic7300, ic7610 (polling, parity) |
| agcTime | `receiver.main.operator_controls.agc_time_constant` | 1A-04 | command_response | ic7300 |

nr_level/nb_level/auto_notch/manual_notch/agc_time_constant already had full query+ingress support. notch_filter already had a query mapping but needed a new ingress mapping (`_OBSERVABLE_CMD14_FIELDS`, plain BCD-pair decode). manual_notch_width had **neither**: added both a new query mapping and a new ingress mapping — BCD-nibble decode, matching `radio.get_manual_notch_width`'s existing `_get_bcd_level(bcd_bytes=1)` read exactly, so this is not a guess. This sub had no legacy `RadioState` mirror at all before this change (it was previously reachable only via the direct RPC method, never through the passive CI-V receive pipeline).

### MOR-1493 — RIT/XIT and CW keyer facts — **full, closed**

| Field | Path | CI-V | Class | Profiles |
|---|---|---|---|---|
| rit | `global.operator_controls.rit_freq` | 21-00 | command_response | ic7300 |
| rit on | `global.tx_state.rit_on` | 21-01 | command_response | ic7300 |
| xit (rit_tx) | `global.tx_state.rit_tx` | 21-02 | command_response | ic7300 |
| breakIn | `global.operator_controls.break_in` | 16-47 | command_response | ic7300, ic7610 (polling, parity) |
| breakInDelay | `global.operator_controls.break_in_delay` | 14-0F | command_response | ic7300, ic7610 (polling, parity) |
| keySpeed | `global.operator_controls.key_speed` | 14-0C | command_response | ic7300 |
| cwPitch | `global.operator_controls.cw_pitch` | 14-09 | command_response | ic7300 |
| APF | `receiver.main.operator_controls.audio_peak_filter` | 16-32 | command_response | ic7300 |
| TPF | `receiver.main.operator_toggles.twin_peak_filter` | 16-4F | command_response | ic7300 |

rit_freq/rit_on/rit_tx, key_speed, cw_pitch, APF, and TPF already had full query+ingress support. break_in_delay already had a query mapping but needed a new ingress mapping (plain BCD-pair decode). break_in had neither: new query mapping (`_GLOBAL_NONLEVEL_QUERIES`) and new ingress mapping (BCD-nibble decode) — the one golden fixture that asserted the now-removed legacy `break_in` mirror write (`tests/fixtures/civ_rx_frames.json`) is updated to match.

## IC-7610 profile parity

IC-7610 already had `vox_on`/`monitor_on`/`nr_level`/`nb_level`/`pbt_inner`/`pbt_outer`/`auto_notch`/`manual_notch`/`agc_time_constant`/`filter_width`/`audio_peak_filter`/`twin_peak_filter`/`rit_freq`/`rit_on`/`rit_tx`/`key_speed`/`cw_pitch` fully polled (`polling_only`) from prior work — no change needed for those. The 5 fields it was missing (`filter_shape`, `notch_filter`, `manual_notch_width`, `break_in`, `break_in_delay`) are all documented S/R in `docs/validation/cat-audits/ic7610.md` and already referenced in `rigs/ic7610.toml`'s own `[commands]`/`[notch]`/`[break_in]` tables — this PR only adds `state_acquisition` membership for them, at `polling_only` (matching every sibling 0x14/0x16 DSP field already established on that profile), **not** the new IC-7300 command_response/priming shape. IC-7610 hardware was retired 2026-08-04, so none of this rides live verification — it rides the documented command table only.

## Profiles explicitly skipped (command absent / mechanism absent)

- **X6200**: `[state_acquisition]` exists but declares none of these commands (its capability list is limited to freq/mode/filter_width/meters). No membership added — command genuinely absent from the profile.
- **IC-705 / IC-9700**: both declare `[apf]`/`[notch]`/`[break_in]` parameter tables (the radio driver supports the commands), but neither profile has a `[state_acquisition]` section at all — the acquisition-scheduler mechanism isn't wired for these radios yet. Adding field-policy membership first requires building out their entire `state_acquisition` section, which is a structural gap, not a data-only membership gap, and is out of scope for this wave.
- **X6100**: no `[state_acquisition]` section either — same as above.

## Populate timeline

`prime_unobserved()` caps at 5 *new* paths per call (`_PRIME_UNOBSERVED_BURST_LIMIT`, unchanged), and `StateFreshnessService` re-derives the never-observed set every ~30s (`PRIME_REDERIVE_INTERVAL_SECONDS`, unchanged). With 22 new IC-7300 fields (coalescing into fewer distinct `AcquisitionRequest`s where several paths share the same request key — verified live: the first call queues 3 requests covering 5 paths), the measured populate timeline on the real profile (review simulation) is: window 1 at t=0 (vox_on, monitor_on, filter_width, filter_shape, pbt_inner), then one 5-field window per ~30s — the last fields (audio_peak_filter, twin_peak_filter) are first observed at **~120s post-connect** (best case, every prime answered). MOR-1483's vox/mon toggles land at t=0 (sweep-order first). A dropped/unanswered prime read is retried by the next re-derivation, not a bespoke retry loop. This is the existing MOR-1490 mechanism working as designed, unmodified here; the ~120s tail is a mechanism-constants question, filed as MOR-1501 (adaptive prime pacing: ~5s re-derive while never-observed fields remain -> all 22 in ~20s).

## Verification

- `uv run pytest tests/test_state_acquisition_policy.py tests/test_acquisition_scheduler.py tests/test_rig_loader.py tests/test_civ_rx_coverage.py tests/test_civ_rx_dispatch_golden.py tests/test_civ_rx_mixin_host.py tests/test_state_pipeline_diagnostics.py -q` — 626 passed
- `uv run pytest tests/ -q --ignore=tests/integration` — 9128 passed, 12 skipped, 5 deselected, 14 xfailed, 1 xpassed, 0 failed
- `uv run ruff check src/ tests/` — all checks passed
- `uv run ruff format --check src/ tests/` — all formatted
- `uv run mypy src/` — 13 pre-existing baseline errors, all in files this PR doesn't touch (confirmed identical against a clean stash of this branch); 0 new
- `uv run lint-imports` — 5 contracts kept, 0 broken

New guard test: `tests/test_state_acquisition_policy.py::test_ic7300_non_polling_field_policies_have_full_acquisition_chain` — iterates the *real*, currently-loaded IC-7300 `field_policies` table generically (filtered to non-polling entries, a structural property, not a hardcoded field list) and asserts each has a declared capability hook, a buildable CI-V query, and an ingress observation mapping. This is the test that keeps future membership additions of this shape honest without needing to be edited.

## Guardrail deviation

Touches 7 files (`rigs/ic7300.toml`, `rigs/ic7610.toml`, `src/rigplane/core/acquisition_scheduler.py`, `src/rigplane/runtime/_civ_rx.py`, `tests/fixtures/civ_rx_frames.json`, `tests/test_civ_rx_coverage.py`, `tests/test_state_acquisition_policy.py`) against the "aim ≤4 files" guardrail. This is disclosed rather than hidden: the dispatch explicitly required checking cross-profile membership (`rigs/ic7610.toml`) and required fixing pre-existing golden/coverage tests that asserted the legacy `RadioState` mirror writes this migration correctly suppresses (matching the established MOR-437-family precedent) — both are load-bearing for correctness, not scope creep.

