### PR TITLE
feat: derive tx_target for Icom CI-V radios from slot identity, split, and per-slot frequencies (MOR-1496)

### DIFF
--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -1379,8 +1379,13 @@ class RadioPoller:
 
                 # 3b. Re-derive tx_target from currently observed active-VFO
                 # identity/split/frequency facts (MOR-1496). State-store reads
-                # only, no wire I/O — run every cycle so freshness tracks the
-                # weakest input instead of freezing at its last value.
+                # only, no wire I/O. NOT reached on every iteration — the
+                # external-CAT/backoff/dead-link branches above all `continue`
+                # past this — so the field carries its own TTL (F1,
+                # _tx_target_max_age) rather than relying on cadence to
+                # notice a stale input; _publish_tx_target itself skips the
+                # write when nothing changed and the stored entry is still
+                # fresh (F2).
                 try:
                     self._publish_tx_target()
                 except Exception:
@@ -3318,26 +3323,90 @@ class RadioPoller:
             frequency_hz=frequency,
         )
 
-    def _publish_tx_target(self) -> None:
-        """Recompute and republish the derived TX target (MOR-1496).
+    def _tx_target_max_age(self) -> float:
+        """TTL for the derived ``tx_target`` field itself (review R2, F1).
 
-        Called every poll-loop tick so the field's freshness tracks its
-        weakest input rather than decaying on its own clock — this derived
-        field carries no ``max_age`` of its own, so a stale input is only
-        reflected once re-derivation notices it. Uses ``apply_current`` (not
-        ``apply``): this runs synchronously off the just-read snapshot with
-        no ``await`` in between, so it always stamps the store's current
-        provider generation.
+        Without this, ``StateStore.mark_stale_due`` skips the field forever
+        (it only ages entries with ``max_age`` set — see its own docstring),
+        so a stale input would silently freeze ``tx_target`` at its last
+        FRESH value instead of degrading, a fail-open on a TX gate. Reuses
+        this profile's default acquisition TTL — ``policy_for`` falls back
+        to ``default_policy`` for any path with no declared capability (3.0s
+        on IC-7300) — which needs no capability declaration for
+        ``tx_target`` itself; see :meth:`_publish_tx_target` for why that
+        declaration must never exist. Falls back to a small multiple of the
+        poll loop's own fast interval if a profile has no acquisition policy
+        at all.
         """
+        acquisition = self._profile.state_acquisition
+        ttl = (
+            None
+            if acquisition is None
+            else acquisition.policy_for(
+                FieldPath.global_("tx_state", "tx_target")
+            ).freshness_ttl_seconds
+        )
+        return ttl if ttl is not None else self._fast_interval * 4
+
+    def _publish_tx_target(self) -> None:
+        """Recompute and, if changed or stale, republish tx_target (MOR-1496).
+
+        Reached only on poll-loop iterations that fall through to step 4 —
+        NOT "every tick": the external-CAT pause and the connection-backoff/
+        dead-link branches above all ``continue`` past this point, so the
+        weakest-input-tracking claim below depends on :meth:`_tx_target_max_age`
+        giving the field its own TTL (F1), not on this being called on a fixed
+        cadence.
+
+        Skips the store write when the recomputed value is unchanged AND the
+        currently stored entry is still FRESH (review R2, F2): re-applying an
+        identical value on every reachable tick was bumping the store's
+        global ``observation_seq`` for no semantic change, which busts
+        delivery-key no-op suppression and HTTP 304s for the WHOLE snapshot,
+        not just this field. A value change, or the stored entry having aged
+        past its own TTL, both still write — the latter is what lets a
+        healthy-again re-derivation heal the field back to FRESH after it
+        went stale.
+
+        Never declare ``global.tx_state.tx_target`` in any profile's
+        polling_only/unsolicited_push capability metadata (rigs/*.toml or
+        ``RadioAcquisitionProfile.field_policies``): its absence from
+        capability metadata is exactly what lets the TTL-driven
+        reconciliation request this ``max_age`` generates drop cleanly
+        instead of looping — ``AcquisitionScheduler.query_for_path`` has no
+        CI-V wire mapping for this derived field, so a declared/pollable
+        capability here would retry forever as ``no_civ_query_mapping``.
+
+        Uses ``apply_current`` (not ``apply``): this runs synchronously off
+        the just-read snapshot with no ``await`` in between, so it always
+        stamps the store's current provider generation.
+        """
+        if self._profile.vfo_readback != "selected_unselected":
+            return
+
+        target = self._compute_tx_target()
+        path = FieldPath.global_("tx_state", "tx_target")
+        try:
+            current = self._state_store.snapshot().field(path)
+        except KeyError:
+            current = None
+        if (
+            current is not None
+            and current.freshness is FreshnessState.FRESH
+            and current.value == target
+        ):
+            return
+
         observation = Observation(
-            path=FieldPath.global_("tx_state", "tx_target"),
-            value=self._compute_tx_target(),
+            path=path,
+            value=target,
             source=SourceMetadata(
                 source="local_reconcile",
                 provider="icom_civ",
                 native_id="tx_target_derivation",
             ),
             timestamp_monotonic=time.monotonic(),
+            max_age=self._tx_target_max_age(),
         )
         self._state_store.apply_current(observation)
 

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -201,6 +201,18 @@ _FAST_INTERVAL: float = 0.025  # meters — wfview queue interval for LAN (25ms)
 _FAST_INTERVAL_SERIAL: float = 0.100  # serial: 10 polls/sec for responsive meters
 _SLOW_INTERVAL: float = 0.25  # levels/settings — rarely change
 
+# Floor for the derived tx_target field's own freshness TTL when a profile
+# has no [state_acquisition] block at all (MOR-1496 review R3, F1 follow-up).
+# ``4 * self._fast_interval`` alone is not a defensible TX-gate horizon: on a
+# LAN profile (``_FAST_INTERVAL`` = 25ms) that floors to 0.1s, which the
+# verifier measured causing 6.6 stale-transitions/s on an idle IC-705 (no
+# [state_acquisition] block). Matches the concrete 3.0s
+# ``freshness_ttl_seconds`` IC-7300's own ``[state_acquisition]`` block
+# already uses for this same field via ``policy_for`` — not the unrelated
+# generic ``AcquisitionPolicy`` dataclass default (15.0s, calibrated for
+# slower-changing fields, not a TX gate).
+_TX_TARGET_MIN_MAX_AGE: float = 3.0
+
 _KEY_ACCEPTED = frozenset({TxOutcome.ACCEPTED, TxOutcome.IDEMPOTENT})  # lease is ours
 
 # MOR-1181: how long the shutdown TX-safety drain may hold teardown open.
@@ -3334,8 +3346,9 @@ class RadioPoller:
         to ``default_policy`` for any path with no declared capability (3.0s
         on IC-7300) — which needs no capability declaration for
         ``tx_target`` itself; see :meth:`_publish_tx_target` for why that
-        declaration must never exist. Falls back to a small multiple of the
-        poll loop's own fast interval if a profile has no acquisition policy
+        declaration must never exist. Falls back to ``_TX_TARGET_MIN_MAX_AGE``
+        (floored, not a bare multiple of the poll loop's own fast interval —
+        see that constant's comment) if a profile has no acquisition policy
         at all.
         """
         acquisition = self._profile.state_acquisition
@@ -3346,7 +3359,7 @@ class RadioPoller:
                 FieldPath.global_("tx_state", "tx_target")
             ).freshness_ttl_seconds
         )
-        return ttl if ttl is not None else self._fast_interval * 4
+        return ttl if ttl is not None else _TX_TARGET_MIN_MAX_AGE
 
     def _publish_tx_target(self) -> None:
         """Recompute and, if changed or stale, republish tx_target (MOR-1496).
@@ -3359,14 +3372,21 @@ class RadioPoller:
         cadence.
 
         Skips the store write when the recomputed value is unchanged AND the
-        currently stored entry is still FRESH (review R2, F2): re-applying an
+        currently stored entry is still comfortably FRESH — under HALF its
+        own TTL old (review R2, F2 + review R3 fix): re-applying an
         identical value on every reachable tick was bumping the store's
         global ``observation_seq`` for no semantic change, which busts
         delivery-key no-op suppression and HTTP 304s for the WHOLE snapshot,
-        not just this field. A value change, or the stored entry having aged
-        past its own TTL, both still write — the latter is what lets a
-        healthy-again re-derivation heal the field back to FRESH after it
-        went stale.
+        not just this field. The half-TTL renew margin is load-bearing, not
+        cosmetic: R2 skipped on value-equality alone with no age check, so on
+        a healthy radio the stored entry's ``last_observed_monotonic`` never
+        advanced between real changes — it aged out under its own TTL and
+        flapped known/unknown every TTL period purely from the skip itself
+        (verifier measured 12 transitions in 18s, each pushing a WS
+        broadcast). A value change, the stored entry crossing the half-TTL
+        mark, or it having aged fully past its own TTL, all still write —
+        the last of those is what lets a healthy-again re-derivation heal
+        the field back to FRESH after it actually went stale.
 
         Never declare ``global.tx_state.tx_target`` in any profile's
         polling_only/unsolicited_push capability metadata (rigs/*.toml or
@@ -3381,11 +3401,20 @@ class RadioPoller:
         the just-read snapshot with no ``await`` in between, so it always
         stamps the store's current provider generation.
         """
+        # IC-705 also has vfo_readback == "selected_unselected" but currently
+        # ships no [state_acquisition] block, so nothing ever actively polls
+        # split for it (AcquisitionScheduler.query_for_path's split mapping
+        # only fires through a scheduler built from that block) — tx_target
+        # is derived here regardless, but will sit at "not-observed" on that
+        # radio until split is ever observed. Tracked as a follow-up; not
+        # fixed here.
         if self._profile.vfo_readback != "selected_unselected":
             return
 
         target = self._compute_tx_target()
         path = FieldPath.global_("tx_state", "tx_target")
+        max_age = self._tx_target_max_age()
+        now = time.monotonic()
         try:
             current = self._state_store.snapshot().field(path)
         except KeyError:
@@ -3394,6 +3423,7 @@ class RadioPoller:
             current is not None
             and current.freshness is FreshnessState.FRESH
             and current.value == target
+            and now - current.last_observed_monotonic < max_age * 0.5
         ):
             return
 
@@ -3405,8 +3435,8 @@ class RadioPoller:
                 provider="icom_civ",
                 native_id="tx_target_derivation",
             ),
-            timestamp_monotonic=time.monotonic(),
-            max_age=self._tx_target_max_age(),
+            timestamp_monotonic=now,
+            max_age=max_age,
         )
         self._state_store.apply_current(observation)
 

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -94,8 +94,15 @@ from ..core.radio_protocol import (
     RelativeVfoReadbackCapable,
 )
 from ..core.state_diagnostics import StateDiagnosticsRecorder
-from ..core.state_store import StateStore
+from ..core.state_store import FreshnessState, StateSnapshot, StateStore
 from ..core.tx_safety import BACKEND_MAX_KEY_DOWN_SECONDS, TxOutcome
+from ..core.tx_target import (
+    KnownTxTarget,
+    TxReceiver,
+    TxSlot,
+    TxTarget,
+    UnknownTxTarget,
+)
 from .._state_queries import build_state_queries
 from ..profiles import RadioProfile, resolve_radio_profile
 from ..runtime.managed_tx_ingress import bind_managed_tx, refuse_key_without_owner
@@ -1369,6 +1376,17 @@ class RadioPoller:
                                 "radio-poller: unselected-slot poll error",
                                 exc_info=True,
                             )
+
+                # 3b. Re-derive tx_target from currently observed active-VFO
+                # identity/split/frequency facts (MOR-1496). State-store reads
+                # only, no wire I/O — run every cycle so freshness tracks the
+                # weakest input instead of freezing at its last value.
+                try:
+                    self._publish_tx_target()
+                except Exception:
+                    logger.debug(
+                        "radio-poller: tx_target derivation error", exc_info=True
+                    )
 
                 # 4. Wait for next cycle
                 await self._queue.wait(timeout=self._fast_interval)
@@ -3206,6 +3224,122 @@ class RadioPoller:
 
     def _discard_vfo_identity(self, receiver: int) -> None:
         self._state_store.discard(self._vfo_identity_paths(receiver))
+
+    def _tx_target_receiver(self) -> tuple[int, TxReceiver]:
+        """Resolve the receiver index + MAIN/SUB label carrying TX.
+
+        Mirrors :meth:`establish_vfo_identity`'s own resolution (MOR-1443).
+        """
+        receiver = 1 if self._current_active().upper() == "SUB" else 0
+        label: TxReceiver = "SUB" if receiver == 1 else "MAIN"
+        return receiver, label
+
+    @staticmethod
+    def _tx_target_input(
+        snapshot: StateSnapshot, path: FieldPath
+    ) -> tuple[Any, UnknownTxTarget | None]:
+        """Look up one derivation input: ``(value, None)`` if FRESH, else
+        ``(None, UnknownTxTarget(...))`` explaining why it cannot be used."""
+        try:
+            field = snapshot.field(path)
+        except KeyError:
+            return None, UnknownTxTarget(reason="not-observed")
+        if field.freshness is FreshnessState.STALE:
+            return None, UnknownTxTarget(reason="stale")
+        if field.freshness is not FreshnessState.FRESH:
+            return None, UnknownTxTarget(reason="not-observed")
+        return field.value, None
+
+    def _compute_tx_target(self) -> TxTarget:
+        """Derive TX target identity from already-observed CI-V facts (MOR-1496).
+
+        Unlike Yaesu CAT's native ``get_tx_func`` (see
+        ``backends/yaesu_cat/observations.py``), Icom CI-V never reports a TX
+        target directly. The facts that determine it are already tracked
+        independently in the state store: active-VFO identity
+        (``receiver.<rx>.vfo.active_slot``, established once per connect by
+        :meth:`establish_vfo_identity`, MOR-1443, since this CI-V scheme can
+        never passively report which slot is active), split
+        (``global.tx_state.split``, cmd 0x0F), and the selected/unselected
+        frequencies (``receiver.<rx>.[active|unselected].freq_mode.freq_hz``,
+        cmd 0x25).
+
+        Split OFF transmits on the selected-slot frequency; split ON
+        transmits on the OTHER (unselected) slot's frequency — do not copy
+        Yaesu's MAIN/SUB ``get_tx_func`` toggle semantics here, it answers a
+        different question. Any input unobserved or stale fails this closed;
+        each input is re-checked on every call, so the result's freshness is
+        only ever as good as its weakest input.
+
+        Only radios that can never passively report VFO identity
+        (``vfo_readback == "selected_unselected"``, the exact gate
+        :meth:`establish_vfo_identity` uses) get a derivation; other CI-V VFO
+        schemes (absolute readback, MAIN/SUB-only radios like IC-9700/IC-7610)
+        stay ``unsupported`` rather than guess at unvalidated split semantics.
+        """
+        if self._profile.vfo_readback != "selected_unselected":
+            return UnknownTxTarget(reason="unsupported")
+
+        receiver, receiver_label = self._tx_target_receiver()
+        receiver_id = str(receiver)
+        snapshot = self._state_store.snapshot()
+
+        slot, unknown = self._tx_target_input(
+            snapshot, FieldPath.active_slot(receiver_id)
+        )
+        if unknown is not None:
+            return unknown
+        if slot not in ("A", "B"):
+            return UnknownTxTarget(reason="contradiction")
+
+        split_value, unknown = self._tx_target_input(
+            snapshot, FieldPath.global_("tx_state", "split")
+        )
+        if unknown is not None:
+            return unknown
+        split_on = bool(split_value)
+
+        if split_on:
+            freq_path = FieldPath.unselected(receiver_id, "freq_mode", "freq_hz")
+            target_slot: TxSlot = "B" if slot == "A" else "A"
+        else:
+            freq_path = FieldPath.active(receiver_id, "freq_mode", "freq_hz")
+            target_slot = cast(TxSlot, slot)
+
+        frequency, unknown = self._tx_target_input(snapshot, freq_path)
+        if unknown is not None:
+            return unknown
+        if type(frequency) is not int or isinstance(frequency, bool) or frequency <= 0:
+            return UnknownTxTarget(reason="contradiction")
+
+        return KnownTxTarget(
+            receiver=receiver_label,
+            slot=target_slot,
+            frequency_hz=frequency,
+        )
+
+    def _publish_tx_target(self) -> None:
+        """Recompute and republish the derived TX target (MOR-1496).
+
+        Called every poll-loop tick so the field's freshness tracks its
+        weakest input rather than decaying on its own clock — this derived
+        field carries no ``max_age`` of its own, so a stale input is only
+        reflected once re-derivation notices it. Uses ``apply_current`` (not
+        ``apply``): this runs synchronously off the just-read snapshot with
+        no ``await`` in between, so it always stamps the store's current
+        provider generation.
+        """
+        observation = Observation(
+            path=FieldPath.global_("tx_state", "tx_target"),
+            value=self._compute_tx_target(),
+            source=SourceMetadata(
+                source="local_reconcile",
+                provider="icom_civ",
+                native_id="tx_target_derivation",
+            ),
+            timestamp_monotonic=time.monotonic(),
+        )
+        self._state_store.apply_current(observation)
 
     async def _select_and_bind_vfo_slot(
         self,

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -92,6 +92,7 @@ from rigplane.core.tx_safety import (
     TxSource,
 )
 from rigplane.web.handlers.control import ControlHandler
+from rigplane.web.runtime_helpers import build_public_state_payload_from_snapshot
 from rigplane.web.web_startup import stop_web_server
 
 # MOR-1181 asserts on ordered ``radio.calls`` against a REAL supervisor, so it
@@ -4394,9 +4395,10 @@ async def test_tx_target_unsupported_for_non_selected_unselected_profile() -> No
 
 
 @pytest.mark.asyncio
-async def test_run_publishes_tx_target_each_cycle() -> None:
-    """Integration proof: the main poll loop republishes tx_target every
-    cycle, not just the pure ``_compute_tx_target`` helper above."""
+async def test_run_publishes_tx_target_on_first_cycle() -> None:
+    """Integration proof: the main poll loop's step 3b actually reaches
+    ``_publish_tx_target`` (not just the pure ``_compute_tx_target`` helper
+    tested above) and performs the field's first-ever write."""
 
     radio = _make_radio(model="IC-7300")
     store = StateStore()
@@ -4407,3 +4409,116 @@ async def test_run_publishes_tx_target_each_cycle() -> None:
 
     field = store.snapshot().field("global.tx_state.tx_target")
     assert isinstance(field.value, (KnownTxTarget, UnknownTxTarget))
+
+
+@pytest.mark.asyncio
+async def test_publish_tx_target_never_writes_for_unsupported_profile() -> None:
+    """Review R2, F2: early-return before any state-store write for radios
+    ``_compute_tx_target`` would call ``unsupported`` — no reason to restate
+    that constant on every reachable poll-loop tick."""
+
+    radio = _make_radio(model="IC-9700")
+    store = StateStore()
+    poller = RadioPoller(radio, CommandQueue(), state_store=store)
+
+    poller._publish_tx_target()  # noqa: SLF001
+
+    assert "global.tx_state.tx_target" not in store.snapshot().as_dict()
+
+
+@pytest.mark.asyncio
+async def test_publish_tx_target_skips_noop_but_writes_on_change_or_ttl() -> None:
+    """Review R2, F2: an unchanged, still-FRESH value must not bump the
+    store's global ``observation_seq`` — that busts delivery-key no-op
+    suppression / HTTP 304s for the WHOLE snapshot, not just this field —
+    but a real value change, or the stored entry aging past its own TTL
+    (F1), both still write (the latter heals the field back to FRESH)."""
+
+    clock = FreshnessClock(start=10.0)
+    store = StateStore(freshness_clock=clock)
+    generation = store.begin_provider_generation()
+    radio = _make_radio(model="IC-7300")
+    _seed_tx_target_ready(
+        store,
+        generation=generation,
+        slot="A",
+        split=False,
+        active_freq=14_250_000,
+        now=10.0,
+    )
+    poller = RadioPoller(radio, CommandQueue(), state_store=store)
+
+    # _publish_tx_target stamps real time.monotonic() (matching production —
+    # StateFreshnessService.tick() also defaults to it); pin it to the same
+    # manual FreshnessClock domain as the store so mark_stale_due()'s own
+    # advance() lines up with what got written.
+    with patch("rigplane.web.radio_poller.time.monotonic", side_effect=clock.now):
+        poller._publish_tx_target()  # noqa: SLF001 — first write
+        seq_after_first = store.snapshot().observation_seq
+
+        poller._publish_tx_target()  # noqa: SLF001 — unchanged, fresh: no-op
+        assert store.snapshot().observation_seq == seq_after_first
+
+        _apply_tx_target_input(
+            store, FieldPath.global_("tx_state", "split"), True, generation=generation
+        )
+        poller._publish_tx_target()  # noqa: SLF001 — value changed: writes
+        seq_after_change = store.snapshot().observation_seq
+        assert seq_after_change > seq_after_first
+        assert store.snapshot().field(
+            "global.tx_state.tx_target"
+        ).value == KnownTxTarget(receiver="MAIN", slot="B", frequency_hz=7_150_000)
+
+        poller._publish_tx_target()  # noqa: SLF001 — unchanged again: no-op
+        assert store.snapshot().observation_seq == seq_after_change
+
+        clock.advance(3.5)  # past tx_target's 3.0s TTL; inputs' TTL is longer
+        store.mark_stale_due()
+        assert (
+            store.snapshot().field("global.tx_state.tx_target").freshness
+            is FreshnessState.STALE
+        )
+        poller._publish_tx_target()  # noqa: SLF001 — TTL expired: writes again
+        healed = store.snapshot().field("global.tx_state.tx_target")
+        assert healed.freshness is FreshnessState.FRESH
+        assert store.snapshot().observation_seq > seq_after_change
+
+
+@pytest.mark.asyncio
+async def test_tx_target_projection_degrades_to_stale_without_republish() -> None:
+    """Review R2, F1: with every input still fresh, letting tx_target's OWN
+    entry age past its OWN TTL without a fresh republish must still fail
+    the PUBLIC projection closed — not freeze it at the last known
+    identity (the exact fail-open the verifier's +600s probe caught)."""
+
+    clock = FreshnessClock(start=10.0)
+    store = StateStore(freshness_clock=clock)
+    generation = store.begin_provider_generation()
+    radio = _make_radio(model="IC-7300")
+    _seed_tx_target_ready(
+        store,
+        generation=generation,
+        slot="A",
+        split=False,
+        active_freq=14_250_000,
+        now=10.0,
+    )
+    poller = RadioPoller(radio, CommandQueue(), state_store=store)
+    with patch("rigplane.web.radio_poller.time.monotonic", side_effect=clock.now):
+        poller._publish_tx_target()  # noqa: SLF001
+
+    fresh_payload = build_public_state_payload_from_snapshot(
+        store.snapshot(), radio=None, receiver_count=1
+    )
+    assert (
+        fresh_payload["txTarget"]
+        == KnownTxTarget(receiver="MAIN", slot="A", frequency_hz=14_250_000).to_dict()
+    )
+
+    clock.advance(3.5)  # past tx_target's 3.0s TTL; inputs' own TTL is longer
+    store.mark_stale_due()  # NOT calling poller._publish_tx_target() again
+
+    stale_payload = build_public_state_payload_from_snapshot(
+        store.snapshot(), radio=None, receiver_count=1
+    )
+    assert stale_payload["txTarget"] == {"status": "unknown", "reason": "stale"}

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -30,7 +30,8 @@ from rigplane.core.state_pipeline_contracts import (
     SourceMetadata,
 )
 from rigplane.core.radio_protocol import RelativeVfoState
-from rigplane.core.state_store import StateStore
+from rigplane.core.state_store import FreshnessClock, FreshnessState, StateStore
+from rigplane.core.tx_target import KnownTxTarget, UnknownTxTarget
 from rigplane.core.types import CivFrame
 from rigplane.core.command_service import (
     CommandExecutionResult,
@@ -4139,3 +4140,270 @@ async def test_establish_vfo_identity_skips_during_external_cat_session() -> Non
 
     radio._set_vfo_slot_confirmed.assert_not_awaited()
     assert "receiver.0.vfo.active_slot" not in store.snapshot().as_dict()
+
+
+# ---------------------------------------------------------------------------
+# MOR-1496: derive tx_target for Icom CI-V radios from active-VFO identity
+# (MOR-1443), split, and per-slot frequencies — a pure re-derivation off
+# already-observed fields (Icom has no Yaesu-style ``get_tx_func`` fact).
+# ---------------------------------------------------------------------------
+
+
+def _apply_tx_target_input(
+    store: StateStore,
+    path: FieldPath,
+    value: Any,
+    *,
+    generation: int,
+    max_age: float | None = None,
+    now: float | None = None,
+) -> None:
+    store.apply(
+        Observation(
+            path=path,
+            value=value,
+            source=SourceMetadata(source="test", provider="test"),
+            timestamp_monotonic=time.monotonic() if now is None else now,
+            max_age=max_age,
+            provider_generation=generation,
+        )
+    )
+
+
+def _seed_tx_target_ready(
+    store: StateStore,
+    *,
+    generation: int,
+    slot: str = "A",
+    split: bool = False,
+    active_freq: int = 14_250_000,
+    unselected_freq: int = 7_150_000,
+    now: float | None = None,
+) -> None:
+    """Seed identity/split/selected+unselected freq — all four inputs.
+
+    IC-7300's ``RadioPoller.__init__`` wires
+    ``StateStore.configure_relative_vfo_retention``, which stages the
+    active/unselected ``freq_mode`` family behind a "complete tuple"
+    bootstrap: ``freq_hz`` alone never lands until its sibling ``mode`` for
+    BOTH slots also arrives within one coherence window. All six
+    observations here share one ``now`` so they land as a single bootstrap
+    batch; the retention system then owns their max_age (not a parameter
+    here — see the ``split`` staleness test for a case that bypasses it).
+    """
+
+    shared_now = time.monotonic() if now is None else now
+    _apply_tx_target_input(
+        store,
+        FieldPath.active_slot("0"),
+        slot,
+        generation=generation,
+        now=shared_now,
+    )
+    _apply_tx_target_input(
+        store,
+        FieldPath.global_("tx_state", "split"),
+        split,
+        generation=generation,
+        now=shared_now,
+    )
+    for builder, freq in (
+        (FieldPath.active, active_freq),
+        (FieldPath.unselected, unselected_freq),
+    ):
+        _apply_tx_target_input(
+            store,
+            builder("0", "freq_mode", "freq_hz"),
+            freq,
+            generation=generation,
+            now=shared_now,
+        )
+        _apply_tx_target_input(
+            store,
+            builder("0", "freq_mode", "mode"),
+            "USB",
+            generation=generation,
+            now=shared_now,
+        )
+
+
+@pytest.mark.asyncio
+async def test_tx_target_known_from_selected_freq_when_split_off() -> None:
+    """Split OFF: TX rides the selected-slot (active-VFO) frequency."""
+
+    radio = _make_radio(model="IC-7300")
+    store = StateStore()
+    generation = store.begin_provider_generation()
+    _seed_tx_target_ready(
+        store, generation=generation, slot="A", split=False, active_freq=14_250_000
+    )
+    poller = RadioPoller(radio, CommandQueue(), state_store=store)
+
+    target = poller._compute_tx_target()  # noqa: SLF001
+
+    assert target == KnownTxTarget(receiver="MAIN", slot="A", frequency_hz=14_250_000)
+
+
+@pytest.mark.asyncio
+async def test_tx_target_known_from_unselected_freq_when_split_on() -> None:
+    """Split ON: TX rides the OTHER (unselected) VFO's frequency."""
+
+    radio = _make_radio(model="IC-7300")
+    store = StateStore()
+    generation = store.begin_provider_generation()
+    _seed_tx_target_ready(
+        store, generation=generation, slot="A", split=True, unselected_freq=7_150_000
+    )
+    poller = RadioPoller(radio, CommandQueue(), state_store=store)
+
+    target = poller._compute_tx_target()  # noqa: SLF001
+
+    assert target == KnownTxTarget(receiver="MAIN", slot="B", frequency_hz=7_150_000)
+
+
+@pytest.mark.asyncio
+async def test_tx_target_follows_split_flip() -> None:
+    """Flipping split alone must flip the target on the next re-derivation."""
+
+    radio = _make_radio(model="IC-7300")
+    store = StateStore()
+    generation = store.begin_provider_generation()
+    _seed_tx_target_ready(
+        store,
+        generation=generation,
+        slot="B",
+        split=False,
+        active_freq=21_050_000,
+        unselected_freq=3_573_000,
+    )
+    poller = RadioPoller(radio, CommandQueue(), state_store=store)
+
+    off_target = poller._compute_tx_target()  # noqa: SLF001
+    assert off_target == KnownTxTarget(
+        receiver="MAIN", slot="B", frequency_hz=21_050_000
+    )
+
+    _apply_tx_target_input(
+        store, FieldPath.global_("tx_state", "split"), True, generation=generation
+    )
+
+    on_target = poller._compute_tx_target()  # noqa: SLF001
+    assert on_target == KnownTxTarget(receiver="MAIN", slot="A", frequency_hz=3_573_000)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "missing", ("identity", "split", "freq"), ids=("identity", "split", "freq")
+)
+async def test_tx_target_unknown_when_one_input_not_observed(missing: str) -> None:
+    """Any single required input missing (identity/split/freq) fails the
+    whole derivation closed — the other two alone are never enough."""
+
+    radio = _make_radio(model="IC-7300")
+    store = StateStore()
+    generation = store.begin_provider_generation()
+    if missing != "identity":
+        _apply_tx_target_input(
+            store, FieldPath.active_slot("0"), "A", generation=generation
+        )
+    if missing != "split":
+        _apply_tx_target_input(
+            store, FieldPath.global_("tx_state", "split"), False, generation=generation
+        )
+    if missing != "freq":
+        _apply_tx_target_input(
+            store,
+            FieldPath.active("0", "freq_mode", "freq_hz"),
+            14_250_000,
+            generation=generation,
+        )
+    poller = RadioPoller(radio, CommandQueue(), state_store=store)
+
+    target = poller._compute_tx_target()  # noqa: SLF001
+
+    assert target == UnknownTxTarget(reason="not-observed")
+
+
+@pytest.mark.asyncio
+async def test_tx_target_degrades_to_stale_when_input_goes_stale() -> None:
+    """A KnownTxTarget must not survive its weakest input aging out — the
+    field has no TTL of its own, so this only holds if re-derivation notices
+    the input went ``stale`` and republishes accordingly.
+
+    Ages out ``split`` (plain global field, ``max_age=1.0``) while leaving
+    identity/frequency alone (their own multi-second retention max_age, see
+    ``_seed_tx_target_ready``'s docstring) — isolating that ANY one stale
+    input fails the whole derivation, not a coincidental simultaneous decay.
+    """
+
+    clock = FreshnessClock(start=10.0)
+    store = StateStore(freshness_clock=clock)
+    generation = store.begin_provider_generation()
+    radio = _make_radio(model="IC-7300")
+    _seed_tx_target_ready(
+        store,
+        generation=generation,
+        slot="A",
+        split=False,
+        active_freq=14_250_000,
+        now=10.0,
+    )
+    _apply_tx_target_input(
+        store,
+        FieldPath.global_("tx_state", "split"),
+        False,
+        generation=generation,
+        max_age=1.0,
+        now=10.0,
+    )
+    poller = RadioPoller(radio, CommandQueue(), state_store=store)
+
+    fresh_target = poller._compute_tx_target()  # noqa: SLF001
+    assert fresh_target == KnownTxTarget(
+        receiver="MAIN", slot="A", frequency_hz=14_250_000
+    )
+
+    clock.advance(2.0)
+    store.mark_stale_due()
+
+    assert (
+        store.snapshot().field(FieldPath.global_("tx_state", "split")).freshness
+        is FreshnessState.STALE
+    )
+    assert (
+        store.snapshot().field(FieldPath.active("0", "freq_mode", "freq_hz")).freshness
+        is FreshnessState.FRESH
+    )
+    stale_target = poller._compute_tx_target()  # noqa: SLF001
+    assert stale_target == UnknownTxTarget(reason="stale")
+
+
+@pytest.mark.asyncio
+async def test_tx_target_unsupported_for_non_selected_unselected_profile() -> None:
+    """MAIN/SUB CI-V radios (IC-9700/IC-7610, ``vfo_readback == "none"``)
+    never get an unproven split derivation — only selected/unselected
+    single-VFO radios (IC-7300 live bench, IC-705 same scheme) do."""
+
+    radio = _make_radio(model="IC-9700")
+    store = StateStore()
+    poller = RadioPoller(radio, CommandQueue(), state_store=store)
+
+    target = poller._compute_tx_target()  # noqa: SLF001
+
+    assert target == UnknownTxTarget(reason="unsupported")
+
+
+@pytest.mark.asyncio
+async def test_run_publishes_tx_target_each_cycle() -> None:
+    """Integration proof: the main poll loop republishes tx_target every
+    cycle, not just the pure ``_compute_tx_target`` helper above."""
+
+    radio = _make_radio(model="IC-7300")
+    store = StateStore()
+    store.begin_provider_generation()
+    poller = RadioPoller(radio, CommandQueue(), state_store=store)
+
+    await _run_once(poller)
+
+    field = store.snapshot().field("global.tx_state.tx_target")
+    assert isinstance(field.value, (KnownTxTarget, UnknownTxTarget))

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -4395,6 +4395,25 @@ async def test_tx_target_unsupported_for_non_selected_unselected_profile() -> No
 
 
 @pytest.mark.asyncio
+async def test_tx_target_max_age_floors_fallback_for_profile_without_acquisition() -> (
+    None
+):
+    """Review R3: IC-705 has ``vfo_readback == "selected_unselected"`` (so
+    it DOES get a derivation) but currently ships no ``[state_acquisition]``
+    block, so the old bare ``4 * self._fast_interval`` fallback floored at
+    0.1s on its LAN profile (25ms fast interval) — the verifier measured
+    6.6 stale-transitions/s from that on an otherwise-idle radio. The
+    fallback must floor at ``_TX_TARGET_MIN_MAX_AGE`` instead."""
+
+    radio = _make_radio(model="IC-705")
+    assert radio.profile.state_acquisition is None
+    assert radio.profile.vfo_readback == "selected_unselected"
+    poller = RadioPoller(radio, CommandQueue(), state_store=StateStore())
+
+    assert poller._tx_target_max_age() == 3.0  # noqa: SLF001
+
+
+@pytest.mark.asyncio
 async def test_run_publishes_tx_target_on_first_cycle() -> None:
     """Integration proof: the main poll loop's step 3b actually reaches
     ``_publish_tx_target`` (not just the pure ``_compute_tx_target`` helper
@@ -4522,3 +4541,81 @@ async def test_tx_target_projection_degrades_to_stale_without_republish() -> Non
         store.snapshot(), radio=None, receiver_count=1
     )
     assert stale_payload["txTarget"] == {"status": "unknown", "reason": "stale"}
+
+
+@pytest.mark.asyncio
+async def test_tx_target_stays_known_across_several_ttl_periods_on_healthy_radio() -> (
+    None
+):
+    """Review R3: the R2 no-op skip compared value+freshness only, with no
+    age check, so on a HEALTHY radio (every input fresh, nothing ever
+    changing) it never re-stamped ``last_observed_monotonic`` — the stored
+    entry aged out under its own TTL and flapped known/unknown every TTL
+    period from the skip itself (verifier measured 12 transitions in 18s,
+    each pushing a WS broadcast; the CW keyer strip would blink "TX not
+    permitted" every ~3s). The renew-before-expiry margin (half the TTL)
+    must prevent that.
+
+    ``StateFreshnessService.tick()`` (which calls ``mark_stale_due``) and
+    step 3b (``_publish_tx_target``) are two INDEPENDENT asyncio tasks in
+    production — mark_stale_due's real 0.05s cadence is not synchronized
+    1:1 with publish, so this deliberately decouples them: publish runs
+    every 13 ticks (0.65s), a value with no common-multiple alignment to
+    the TTL's 60-tick (3.0s) boundary. A 1:1 or evenly-aligned cadence (e.g.
+    every 2 or every 20 ticks) would coincidentally re-heal the field within
+    the very iteration it goes stale often enough to mask the R2 bug
+    entirely — confirmed by hand against the un-fixed code: 13/17/21-tick
+    spacing reproduces dozens of stale ticks per run, while an aligned
+    spacing reproduces none. Runs across several tx_target TTL periods with
+    every input kept genuinely fresh throughout — the public projection,
+    read after EVERY mark_stale_due (whether or not that tick also
+    published), must never leave "known"."""
+
+    clock = FreshnessClock(start=10.0)
+    store = StateStore(freshness_clock=clock)
+    generation = store.begin_provider_generation()
+    radio = _make_radio(model="IC-7300")
+    _seed_tx_target_ready(
+        store,
+        generation=generation,
+        slot="A",
+        split=False,
+        active_freq=14_250_000,
+        now=10.0,
+    )
+    poller = RadioPoller(radio, CommandQueue(), state_store=store)
+    max_age = poller._tx_target_max_age()  # noqa: SLF001 — 3.0s on IC-7300
+    tick = 0.05  # StateFreshnessService's production tick interval
+    publish_every_ticks = 13  # deliberately unaligned with max_age / tick
+    total = max_age * 4  # several TTL periods
+
+    with patch("rigplane.web.radio_poller.time.monotonic", side_effect=clock.now):
+        poller._publish_tx_target()  # noqa: SLF001 — establish the first value
+        elapsed = 0.0
+        tick_count = 0
+        while elapsed < total:
+            clock.advance(tick)
+            elapsed += tick
+            tick_count += 1
+            # Re-observe every input periodically (well under the freq
+            # inputs' own 5.0s relative-VFO retention TTL and its coherence
+            # window) — models a healthy radio's continuous freq/split
+            # polling rather than relying on a TTL race between inputs.
+            if round(elapsed * 100) % 200 == 0:
+                _seed_tx_target_ready(
+                    store,
+                    generation=generation,
+                    slot="A",
+                    split=False,
+                    active_freq=14_250_000,
+                    now=clock.now(),
+                )
+            store.mark_stale_due()
+            if tick_count % publish_every_ticks == 0:
+                poller._publish_tx_target()  # noqa: SLF001
+            payload = build_public_state_payload_from_snapshot(
+                store.snapshot(), radio=None, receiver_count=1
+            )
+            assert payload["txTarget"]["status"] == "known", (
+                f"tx_target left known at t={elapsed:.2f}s: {payload['txTarget']}"
+            )


### PR DESCRIPTION
## Summary

`tx_target` (the derived fact TX-gates use to decide whether a known transmit frequency exists) was previously produced **only** by the Yaesu CAT backend (`KnownTxTarget` via native `get_tx_func`, see `backends/yaesu_cat/observations.py` / `poller.py`). Icom CI-V had no derivation at all, so any TX gate requiring a known target failed closed forever on Icom radios — on the live IC-7300 bench, the CW keyer strip permanently showed "TX not permitted: the TX target is not observed".

This PR derives `tx_target` for Icom CI-V radios from facts the state store already tracks, instead of adding a new hardware read.

## Mechanism / derivation seat

Icom CI-V has no native "TX target" fact the way Yaesu's `get_tx_func` does. The three neutral facts that determine it are already independently observed and stored:

- active-VFO identity — `receiver.<rx>.vfo.active_slot`, established once per connect by `establish_vfo_identity()` (MOR-1443), since this CI-V scheme can never passively report which slot (A/B) is active
- split — `global.tx_state.split` (CI-V cmd 0x0F)
- selected/unselected slot frequency — `receiver.<rx>.[active|unselected].freq_mode.freq_hz` (CI-V cmd 0x25)

`RadioPoller` (`src/rigplane/web/radio_poller.py`) is the shared CI-V poller for all Icom radios in this codebase (IC-7300, IC-705, IC-9700, IC-7610), the direct analogue of `YaesuCatPoller` for Yaesu — so the derivation lives there as three new methods (`_tx_target_receiver`, `_tx_target_input`, `_compute_tx_target`) plus a `_publish_tx_target()` that re-derives and republishes `global.tx_state.tx_target` on every poll-loop tick (new step "3b" in `_run()`, `radio_poller.py:1380`). This is a pure re-derivation off already-observed state-store fields — no new CI-V wire read was added.

Only radios with `vfo_readback == "selected_unselected"` (the exact capability gate `establish_vfo_identity()` itself uses — IC-7300/IC-705) get a derivation; other CI-V VFO schemes (absolute readback, MAIN/SUB-only dual-receiver radios like IC-9700/IC-7610) stay `unsupported` rather than guess at unvalidated split semantics on hardware this ticket never exercised.

## Semantics

| Condition | `tx_target` |
|---|---|
| split OFF, identity known, selected freq observed | `KnownTxTarget` = selected-slot frequency |
| split ON, identity known, unselected freq observed | `KnownTxTarget` = unselected-slot frequency |
| identity / split / freq unobserved | `UnknownTxTarget(reason="not-observed")` |
| identity / split / freq stale | `UnknownTxTarget(reason="stale")` |
| non-`selected_unselected` radio (IC-9700/IC-7610) | `UnknownTxTarget(reason="unsupported")` |

Each input is re-checked from the live state-store snapshot on every derivation call rather than cached, so the result's freshness is only ever as good as its weakest input — a single stale input degrades the whole result, matching MOR-1448's "no fabricated freshness" lesson. `slot` is populated honestly (unlike Yaesu, which always reports `slot=None`) since Icom genuinely tracks A/B identity.

## Yaesu unaffected

No Yaesu file was touched. `tests/test_yaesu_cat_observation_adapter.py` and `tests/test_yaesu_cat_poller.py` (106 tests) pass unchanged.

## Tests

New tests in `tests/test_radio_poller_coverage.py`:

- `test_tx_target_known_from_selected_freq_when_split_off`
- `test_tx_target_known_from_unselected_freq_when_split_on`
- `test_tx_target_follows_split_flip`
- `test_tx_target_unknown_when_one_input_not_observed` (parametrized: identity / split / freq)
- `test_tx_target_degrades_to_stale_when_input_goes_stale`
- `test_tx_target_unsupported_for_non_selected_unselected_profile`
- `test_run_publishes_tx_target_each_cycle` (integration proof through `RadioPoller._run()`)

## Verification

- `uv run pytest tests/test_radio_poller_coverage.py tests/test_yaesu_cat_observation_adapter.py tests/test_yaesu_cat_poller.py tests/test_managed_tx_assembly.py tests/test_state_pipeline_contracts.py tests/test_state_type_codegen.py tests/test_web_runtime_helpers.py tests/web/test_state_schema_conformance.py -q` → 607 passed
- `uv run pytest tests/ -q --ignore=tests/integration` → 9141 passed, 12 skipped, 5 deselected, 14 xfailed, 1 xpassed, 0 failed
- `uv run ruff check src/ tests/` → all checks passed
- `uv run mypy src/` → 13 pre-existing errors (baseline-identical, none introduced by this diff — confirmed against `origin/main`)

Closes MOR-1496

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Review R2 (verifier BLOCKED — 1 finding + 1 fold-in, both fixed)

### F1 — BLOCKING: fail-open TX gate (no TTL on the derived field)

The original `_publish_tx_target` built its `Observation` with no `max_age`. `StateStore.mark_stale_due` only ages entries that carry one (`state_store.py:777-778`); with none set, `tx_target` never decayed on its own. Step 3b sits below four `continue` branches in `_run()` (external CAT session pause, connection backoff ×2, dead-link timeout), so on any of those paths the underlying inputs (identity/split/freq) aged to `STALE` while `tx_target` itself froze at its last `KnownTxTarget` — a verifier probe showed the public projection still reporting `{status: "known", frequencyHz: 14250000}` at +600s with every input stale. On a hamlib-bridge session (external CAT pause) this is a fail-open TX gate.

**Fix:** `_publish_tx_target` now stamps `max_age` from `self._profile.state_acquisition.policy_for(...).freshness_ttl_seconds` (falls back to `default_policy` for any undeclared path — **3.0s on IC-7300**; falls back further to `4 × self._fast_interval` if a profile has no acquisition policy at all). `_project_tx_target` (`web/runtime_helpers.py:858-859`) already maps `STALE` → `{"status": "unknown", "reason": "stale"}`, so fail-closed comes free once the TTL is in place.

**Load-bearing caveat (now in a comment at the observation site, `radio_poller.py` `_publish_tx_target` docstring):** `global.tx_state.tx_target` must **never** be declared in any profile's `polling_only`/`unsolicited_push` capability metadata (`rigs/*.toml` or `RadioAcquisitionProfile.field_policies`). Its absence from capability metadata is exactly what lets the TTL-driven reconciliation request this `max_age` generates drop cleanly — `AcquisitionScheduler.query_for_path` has no CI-V wire mapping for a derived field, so declaring it pollable would loop forever on `no_civ_query_mapping`. Verified: `capability_for(tx_target)` still reports `availability=UNKNOWN, polling=False` after this change.

**New test:** `test_tx_target_projection_degrades_to_stale_without_republish` — publishes once, advances the freshness clock past the field's own TTL (inputs' own TTL stays longer), calls `store.mark_stale_due()` **without** re-running `_publish_tx_target`, and asserts the public payload (`build_public_state_payload_from_snapshot`) degrades to `{"status": "unknown", "reason": "stale"}` instead of freezing at the last known identity.

**Docstring correction:** the old `_publish_tx_target`/step-3b comments claimed "every tick" — corrected to state plainly that four `continue` branches skip step 3b entirely, which is exactly why the field needs its own TTL rather than relying on loop cadence.

### F2 — fold-in: no-op republish churn

`_publish_tx_target` applied on every reachable tick even when the recomputed value was unchanged, and even for profiles `_compute_tx_target` always reports `unsupported` for (IC-9700/IC-7610) — restating a constant ~40×/s, bumping the store's global `observation_seq` on every call regardless of semantic change and busting delivery-key no-op suppression / HTTP 304s for the **whole** snapshot, not just this field.

**Fix:**
- early-return before any store read/write when `vfo_readback != "selected_unselected"`;
- skip the `apply_current` call when the recomputed value equals the currently-stored value **and** that stored entry is still `FRESH` — a real value change, or the entry having aged past its own TTL (F1), both still write, so a healthy re-derivation heals the field back to `FRESH` after it goes stale.

**Tests:** `test_publish_tx_target_never_writes_for_unsupported_profile` (early-return proof) and `test_publish_tx_target_skips_noop_but_writes_on_change_or_ttl` (asserts `observation_seq` is unchanged on a repeated no-op call, but increments on a real split-flip and again after the TTL expires — the previous "publishes every tick" integration test was renamed to `test_run_publishes_tx_target_on_first_cycle` and now honestly asserts only the first-write wiring, not a per-tick guarantee).

### Verification (R2)

- `uv run pytest tests/test_radio_poller_coverage.py tests/test_yaesu_cat_observation_adapter.py tests/test_yaesu_cat_poller.py tests/test_managed_tx_assembly.py tests/test_state_pipeline_contracts.py tests/test_state_type_codegen.py tests/test_web_runtime_helpers.py tests/web/test_state_schema_conformance.py -q` → 610 passed
- `uv run ruff check src/ tests/` → all checks passed
- `uv run mypy src/rigplane/web/radio_poller.py` → success; `uv run mypy src/` → 13 pre-existing baseline errors, zero new (re-verified against unmodified tree)

New head: `8778f097adcde69d2daf87cb880164590c2f9cf0`


---

## Review R3 (verifier BLOCKED — 1 new defect introduced by R2's fix, both parts corrected)

R2's F1 fix (giving `tx_target` its own TTL) was itself confirmed correct by the verifier — all four `continue`-branch paths now decay the field as intended. But R2's F2 no-op skip introduced a **new** blocking defect: it compared value-equality and current freshness only, with **no age check**.

### Correct framing (the verifier's actual finding)

This is a general flap bug, **not** an IC-705-specific one. It reproduces on any radio with a normal, correctly-configured TTL (e.g. IC-7300's 3.0s): on a healthy radio where nothing ever changes, `_publish_tx_target` skips on every reachable tick (value unchanged, still `FRESH`) and so never re-stamps `last_observed_monotonic`. The stored entry's own clock is never refreshed, so it ages out under its own TTL and flaps `known` → `unknown/stale` → (next publish re-derives the same value and heals it) → `known`, repeating every TTL period, purely as a consequence of the skip itself — independent of whether split/freq/identity ever moved. The verifier measured 12 such transitions in 18s; each STALE transition pushes a WS broadcast carrying `txTarget: unknown/stale`, so the CW keyer strip would blink "TX not permitted" roughly every 3 seconds on an otherwise perfectly healthy radio.

IC-705 is a **separate, compounding** issue, not the root cause: it has `vfo_readback == "selected_unselected"` (so it does get a derivation) but ships no `[state_acquisition]` block, so the fallback TTL used `4 × self._fast_interval` — 0.1s on its LAN profile (25ms fast interval) — instead of a real per-radio configured value. That made the *same* flap bug cycle roughly 30× faster on IC-705 (6.6 stale-transitions/s on an idle radio) than on IC-7300, but the underlying defect is the missing age check in the skip condition, present for every radio regardless of TTL.

### Fix 1 — renew before expiry

`_publish_tx_target`'s skip condition now also requires the stored entry to be under **half its own TTL old**:

```python
max_age = self._tx_target_max_age()
now = time.monotonic()
...
and now - current.last_observed_monotonic < max_age * 0.5
```

Once an entry crosses the half-TTL mark, the next reachable tick writes again — even though the recomputed value is unchanged — resetting `last_observed_monotonic` comfortably before `StateStore.mark_stale_due` would ever mark it stale. On IC-7300 (3.0s TTL) this renews roughly every 1.5s whenever a poll-loop tick lands past that mark; write rate stays low (F2's intent is preserved — a real value change or genuine staleness both still write) while the flap is eliminated.

**Verified by hand, not just asserted:** re-ran the fixed vs. un-fixed skip condition against an intentionally **unaligned** publish cadence (every 13/17/21 ticks of a 0.05s freshness-service tick, against a 60-tick/3.0s TTL boundary — deliberately not a common multiple, since an aligned cadence, e.g. every 2 or every 20 ticks, coincidentally self-heals within the very tick it goes stale and hides the bug entirely). The un-fixed condition reproduced dozens of stale ticks per 600-tick run at every unaligned spacing tested; the fixed condition reproduced zero.

### Fix 2 — floor the fallback TTL

New `_TX_TARGET_MIN_MAX_AGE = 3.0` constant (`radio_poller.py`), replacing the bare `4 × self._fast_interval` fallback used when a profile has no `[state_acquisition]` block at all. Chosen to match the concrete `freshness_ttl_seconds` IC-7300's own `[state_acquisition]` block already uses for this same field via `policy_for` — not the unrelated generic `AcquisitionPolicy` dataclass default (15.0s, calibrated for slower-changing fields, not a TX gate). This only changes the *no-acquisition-policy-at-all* fallback; a profile with its own configured TTL still uses that value unchanged.

### Fix 3 — regression test across several TTL periods

New test `test_tx_target_stays_known_across_several_ttl_periods_on_healthy_radio`: holds every input fresh throughout, drives `_publish_tx_target` and `StateStore.mark_stale_due` as the two independent asyncio cadences they are in production (deliberately unaligned tick spacing — see above), across 4 TTL periods (12s simulated), and asserts the public projection (`build_public_state_payload_from_snapshot`) never leaves `"known"`. Confirmed to fail against the un-fixed skip condition (`unknown`/`stale` at t=3.00s) and pass with the fix.

### Fix 4 — IC-705 follow-up noted, not fixed here

One-line comment at the `vfo_readback` gate in `_publish_tx_target`: IC-705 has no `[state_acquisition]` block, so nothing ever actively polls `split` for it (`AcquisitionScheduler.query_for_path`'s split mapping only fires through a scheduler built from that block) — `tx_target` is still derived, but will sit at `not-observed` on that radio until split is ever observed by some other means. Tracked as a follow-up ticket by the coordinator; out of scope here. New unit test `test_tx_target_max_age_floors_fallback_for_profile_without_acquisition` confirms IC-705's TTL now floors at 3.0s instead of 0.1s.

### Verification (R3)

- `uv run pytest tests/test_radio_poller_coverage.py tests/test_yaesu_cat_observation_adapter.py tests/test_yaesu_cat_poller.py tests/test_managed_tx_assembly.py tests/test_state_pipeline_contracts.py tests/test_state_type_codegen.py tests/test_web_runtime_helpers.py tests/web/test_state_schema_conformance.py -q` → 612 passed
- `uv run ruff check` / `ruff format --check` → clean
- `uv run mypy src/rigplane/web/radio_poller.py` → success; `uv run mypy src/` → 13 pre-existing baseline errors, zero new

New head: `3386ce8bbc2ee75098251e8d99f54522545cdf3b`
