### PR TITLE
fix: error toasts persist until dismissed (MOR-1489)

### DIFF
--- a/frontend/src/components/shared/Toast.svelte
+++ b/frontend/src/components/shared/Toast.svelte
@@ -23,6 +23,12 @@
 
   let toasts = $state<ToastItem[]>([]);
 
+  /**
+   * Auto-dismiss delay for non-error toasts (info/warning), ms. One knob —
+   * do not hardcode per-toast timeouts elsewhere.
+   */
+  const AUTO_DISMISS_MS = 5_000;
+
   function dismiss(id: string) {
     toasts = toasts.filter((t) => t.id !== id);
   }
@@ -35,7 +41,17 @@
   ) {
     const id = makeCommandId();
     toasts = [...toasts, { id, level, message, code, params }];
-    setTimeout(() => dismiss(id), 5_000);
+    // MOR-1489: error toasts stay on screen until the operator dismisses
+    // them (click anywhere on the toast — the existing close affordance).
+    // WCAG 2.2.1 (Timing Adjustable) recommends that time-limited messages
+    // conveying important information — errors in particular — either not
+    // time out or let the user extend/disable the limit; operators on the
+    // bench reported error toasts (e.g. a command-failure notification)
+    // disappearing before they could read them. Info/warning toasts are
+    // transient status updates and keep the timed auto-dismiss.
+    if (level !== 'error') {
+      setTimeout(() => dismiss(id), AUTO_DISMISS_MS);
+    }
   }
 
   /**

--- a/frontend/src/components/shared/Toast.svelte
+++ b/frontend/src/components/shared/Toast.svelte
@@ -29,6 +29,19 @@
    */
   const AUTO_DISMISS_MS = 5_000;
 
+  /**
+   * MOR-1489 review R2: sticky errors removed the old 5s TTL, which was
+   * also the flood bound. A reconnect-triggered sendQueue flush, a run of
+   * acknowledged-then-failed commands, or a control that errors on every
+   * click (MOR-1487 class) can each emit many `error` toasts back to back
+   * with no dedup. Uncapped, that stacks click-intercepting nodes over the
+   * cockpit — on mobile a handful already covers the viewport. Cap how many
+   * sticky errors can be visible at once, evicting the oldest first, same
+   * spirit as `REFUSAL_NOTICE_DEBOUNCE_MS` guarding the warning path in
+   * ws-client.ts.
+   */
+  const MAX_STICKY_ERRORS = 3;
+
   function dismiss(id: string) {
     toasts = toasts.filter((t) => t.id !== id);
   }
@@ -51,6 +64,13 @@
     // transient status updates and keep the timed auto-dismiss.
     if (level !== 'error') {
       setTimeout(() => dismiss(id), AUTO_DISMISS_MS);
+      return;
+    }
+    const errorIds = toasts.filter((toast) => toast.level === 'error').map((toast) => toast.id);
+    const overflow = errorIds.length - MAX_STICKY_ERRORS;
+    if (overflow > 0) {
+      const evictIds = new Set(errorIds.slice(0, overflow));
+      toasts = toasts.filter((toast) => !evictIds.has(toast.id));
     }
   }
 

--- a/frontend/src/components/shared/__tests__/Toast.component.test.ts
+++ b/frontend/src/components/shared/__tests__/Toast.component.test.ts
@@ -41,17 +41,41 @@ let host: HTMLDivElement;
 let app: ReturnType<typeof mount> | null = null;
 
 // jsdom lacks Web Animations API; Svelte's `fly` transition calls
-// `element.animate(...)`. Stub with a noop animation so the toast mounts.
+// `element.animate(...)` and then assigns `animation.onfinish` itself to
+// know when the outro transition has completed and the element can be
+// removed from the DOM (see svelte/internal/client/dom/elements/transitions).
+// A stub that never invokes `onfinish` leaves dismissed toasts stuck in the
+// DOM forever, which would falsely fail every dismissal assertion below.
+// Schedule the completion via `setTimeout` (honoring the animation's own
+// `duration`) so it plays nicely with `vi.useFakeTimers()`.
 if (typeof (Element.prototype as any).animate !== 'function') {
-  (Element.prototype as any).animate = function animate(): Animation {
-    return {
-      cancel() {},
-      finish() {},
-      onfinish: null,
+  (Element.prototype as any).animate = function animate(
+    _keyframes: unknown,
+    options?: number | { duration?: number },
+  ): Animation {
+    const duration = typeof options === 'number' ? options : (options?.duration ?? 0);
+    const fake = {
+      playState: 'running' as AnimationPlayState,
+      currentTime: 0,
+      onfinish: null as (() => void) | null,
       oncancel: null,
+      cancel() {
+        fake.playState = 'idle';
+      },
+      finish() {
+        fake.playState = 'finished';
+        fake.onfinish?.();
+      },
       addEventListener() {},
       removeEventListener() {},
-    } as unknown as Animation;
+    };
+    setTimeout(() => {
+      if (fake.playState === 'running') {
+        fake.playState = 'finished';
+        fake.onfinish?.();
+      }
+    }, duration);
+    return fake as unknown as Animation;
   };
 }
 
@@ -167,5 +191,106 @@ describe('Toast — reason-code resolution', () => {
     const txt = getToastText();
     expect(txt.startsWith('⟦')).toBe(true);
     expect(txt.endsWith('⟧')).toBe(true);
+  });
+});
+
+describe('Toast — dismissal timing (MOR-1489)', () => {
+  // Operators reported error toasts (e.g. the command-failure toast from a
+  // mode-error bench case) auto-dismissing before they could be read. Error
+  // toasts must now stay on screen until the operator dismisses them; only
+  // info/warning toasts keep the old timed auto-dismiss.
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function countToasts(): number {
+    return host.querySelectorAll('.toast').length;
+  }
+
+  /**
+   * Advances the fake clock by `ms` and flushes Svelte's effect queue, then
+   * advances a bit further and flushes again so the outro (`fly`)
+   * transition's own (polyfilled) animation timer — only *scheduled* once
+   * the dismiss effect runs, which itself only happens on the flush after
+   * the dismiss timer fires — gets a chance to complete too. A single
+   * advance+flush stops short of detaching the node from the DOM.
+   */
+  function settle(ms: number): void {
+    vi.advanceTimersByTime(ms);
+    flushSync();
+    vi.advanceTimersByTime(200);
+    flushSync();
+  }
+
+  it('does not auto-dismiss an error toast, even long after the old 5s timeout', () => {
+    app = mount(Toast, { target: host });
+    flushSync();
+
+    dispatchNotification({
+      level: 'error',
+      message: 'Command failed: invalid mode for this band',
+    });
+    flushSync();
+
+    expect(countToasts()).toBe(1);
+
+    settle(60_000);
+
+    expect(countToasts()).toBe(1);
+  });
+
+  it('dismisses an error toast when the operator clicks it (existing close affordance)', () => {
+    app = mount(Toast, { target: host });
+    flushSync();
+
+    dispatchNotification({
+      level: 'error',
+      message: 'Command failed: invalid mode for this band',
+    });
+    flushSync();
+    expect(countToasts()).toBe(1);
+
+    const toastEl = host.querySelector<HTMLButtonElement>('.toast.error');
+    toastEl?.click();
+    settle(0);
+
+    expect(countToasts()).toBe(0);
+  });
+
+  it('still auto-dismisses a warning toast after the default timeout', () => {
+    app = mount(Toast, { target: host });
+    flushSync();
+
+    dispatchNotification({
+      level: 'warning',
+      message: 'Link to the radio is degraded',
+    });
+    flushSync();
+    expect(countToasts()).toBe(1);
+
+    settle(5_000);
+
+    expect(countToasts()).toBe(0);
+  });
+
+  it('still auto-dismisses an info toast after the default timeout', () => {
+    app = mount(Toast, { target: host });
+    flushSync();
+
+    dispatchNotification({
+      level: 'info',
+      message: 'Radio connected',
+      code: 'radioConnected',
+    });
+    flushSync();
+    expect(countToasts()).toBe(1);
+
+    settle(5_000);
+
+    expect(countToasts()).toBe(0);
   });
 });

--- a/frontend/src/components/shared/__tests__/Toast.component.test.ts
+++ b/frontend/src/components/shared/__tests__/Toast.component.test.ts
@@ -294,3 +294,43 @@ describe('Toast — dismissal timing (MOR-1489)', () => {
     expect(countToasts()).toBe(0);
   });
 });
+
+describe('Toast — sticky error cap (MOR-1489 review R2)', () => {
+  // Sticky errors removed the old 5s TTL, which doubled as a flood bound:
+  // a reconnect-triggered sendQueue flush, a run of acknowledged-then-failed
+  // commands, or a control that errors on every click can each emit many
+  // `error` toasts back to back. Cap how many stay on screen at once,
+  // evicting the oldest first, so a burst can't cover the cockpit in
+  // click-intercepting nodes.
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function errorMessages(): string[] {
+    return Array.from(host.querySelectorAll('.toast.error .toast-msg')).map(
+      (el) => el.textContent?.trim() ?? '',
+    );
+  }
+
+  it('holds at most MAX_STICKY_ERRORS error toasts, evicting the oldest first', () => {
+    app = mount(Toast, { target: host });
+    flushSync();
+
+    const total = 5; // MAX_STICKY_ERRORS (3) + 2
+    for (let i = 1; i <= total; i++) {
+      dispatchNotification({ level: 'error', message: `Command failed #${i}` });
+      flushSync();
+    }
+    // Let every evicted toast's outro transition finish detaching its node.
+    vi.advanceTimersByTime(200);
+    flushSync();
+
+    const messages = errorMessages();
+    expect(messages).toHaveLength(3);
+    expect(messages).toEqual(['Command failed #3', 'Command failed #4', 'Command failed #5']);
+  });
+});


### PR DESCRIPTION
## Ruling

Owner ruling: error toasts must remain readable until explicitly dismissed — the previous auto-dismiss window was too fast for operators to read before it disappeared. Repro case: the command-failure toast surfaced from the mode-error bench scenario (`src/components/shared/Toast.svelte`).

Prior behavior: every toast — info, warning, or error — auto-dismissed after a flat 5s (`setTimeout(() => dismiss(id), 5_000)`), regardless of severity.

Fix: error-severity toasts now skip the auto-dismiss timer entirely and stay on screen until the operator dismisses them via the existing click-to-dismiss affordance (the whole toast is a `<button>`, with a visible `×` glyph). Info/warning toasts are unchanged — still a single `AUTO_DISMISS_MS = 5_000` knob, not per-toast hardcoding.

A WCAG 2.2.1 (Timing Adjustable) comment is included at the call site: time-limited messages conveying important information should either not time out or let the user control the limit — which is exactly the operator complaint here.

## Behavior: error vs info/warning

| Toast level | Before | After |
|---|---|---|
| `error` | Auto-dismiss at 5s | **Sticky** — stays until clicked (existing `×`/click-anywhere affordance), capped at `MAX_STICKY_ERRORS = 3` simultaneously visible (see R2 below) |
| `warning` | Auto-dismiss at 5s | Unchanged — auto-dismiss at 5s |
| `info` | Auto-dismiss at 5s | Unchanged — auto-dismiss at 5s |

## Tests

Added to `src/components/shared/__tests__/Toast.component.test.ts` (`Toast — dismissal timing (MOR-1489)`):
- `does not auto-dismiss an error toast, even long after the old 5s timeout`
- `dismisses an error toast when the operator clicks it (existing close affordance)`
- `still auto-dismisses a warning toast after the default timeout`
- `still auto-dismisses an info toast after the default timeout`

These use `vi.useFakeTimers()` + a two-phase `advance → flushSync → advance → flushSync` helper, since the dismiss timer and the outro (`fly`) transition's own animation timer run in separate effect ticks under fake timers — a single advance was enough to make a test pass for the wrong reason (node never left the DOM in either the buggy or fixed code path). The file's pre-existing `Element.prototype.animate` jsdom polyfill was also fixed: it previously never invoked `animation.onfinish`, which Svelte assigns directly, so a dismissed toast's outro transition never completed and the node was never detached from the DOM in tests — now it resolves via a real `setTimeout` honoring the animation's own `duration`, compatible with fake timers.

`npx vitest run src/components/shared/__tests__/Toast.component.test.ts` — 10/10 passed.
`npx eslint src/components/shared/Toast.svelte src/components/shared/__tests__/Toast.component.test.ts` — zero violations.

No new imports; `Toast.svelte` stays in `src/components/shared/`, no cross-layer boundary changes.

## Review R2 update

Verifier finding: sticky errors are unbounded — the removed 5s TTL was also the flood bound. In-tree burst paths can each emit many `error` toasts back to back with no dedup: a reconnect-triggered `sendQueue` flush (`ws-client.ts`), a run of acknowledged-then-failed commands (`server.py`), or a control that errors on every click (MOR-1487 class). Uncapped, that stacks click-intercepting toast nodes over the cockpit — on mobile a handful already covers the viewport.

Fix: `MAX_STICKY_ERRORS = 3` in `Toast.svelte`. Once a new error toast would exceed the cap, the oldest sticky error toasts are evicted first (info/warning unaffected). Same spirit as `REFUSAL_NOTICE_DEBOUNCE_MS`, which already guards the warning path in `ws-client.ts`.

Added test: `Toast — sticky error cap (MOR-1489 review R2) > holds at most MAX_STICKY_ERRORS error toasts, evicting the oldest first` — dispatches 5 error toasts (`MAX_STICKY_ERRORS + 2`), asserts the DOM holds exactly 3, and that they are the 3 newest.

Re-verified:
- `npx vitest run --project isolated src/components/shared/__tests__/Toast.component.test.ts` — 11/11 passed.
- `npx vitest run --project isolated src/__tests__/app-global-host.component.test.ts src/components-v2/layout/__tests__/semantic-lcd-migration.component.test.ts src/components-v2/layout/__tests__/semantic-mobile-migration.component.test.ts` — 60/60 passed (neighbor Toast-mounting suites).
- `npx eslint src/components/shared/Toast.svelte src/components/shared/__tests__/Toast.component.test.ts` — zero violations.

Head SHA after R2: `292646f4073598f7be38a60ecd1f0dd226205cb2`.

Closes MOR-1489
