### PR TITLE
fix: hide capability-absent IF shift control on both live mounts (MOR-1494)

### DIFF
--- a/frontend/src/components-v2/panels/FilterPanel.svelte
+++ b/frontend/src/components-v2/panels/FilterPanel.svelte
@@ -19,6 +19,12 @@
   let filterWidthMax = $derived(p.filterWidthMax ?? 9999);
   let filterConfig = $derived(p.filterConfig ?? null);
   let ifShift = $derived(p.ifShift);
+  // MOR-1494: only radios with a REAL if_shift command (Yaesu-family, e.g.
+  // FTX-1) show this control. Icom radios (PBT-only, e.g. IC-7300) have no
+  // if_shift command at all — showing it permanently disabled with a
+  // PBT-derived stand-in value is a dead control, not a usable one; PBT
+  // Inner/Outer below are the genuine controls for those radios.
+  let hasIfShift = $derived(p.hasIfShift ?? false);
   let pbtInner = $derived(p.pbtInner ?? 0);
   let pbtOuter = $derived(p.pbtOuter ?? 0);
   let hasPbt = $derived(p.hasPbt ?? false);
@@ -159,18 +165,20 @@
       variant="hardware-illuminated"
     />
 
-    <ValueControl
-      label="IF SHIFT"
-      value={ifShift}
-      min={-1200}
-      max={1200}
-      step={20}
-      unit="Hz"
-      renderer="bipolar"
-      accentColor="var(--v2-accent-cyan)"
-      onChange={onIfShiftChange}
-      variant="hardware-illuminated"
-    />
+    {#if hasIfShift}
+      <ValueControl
+        label="IF SHIFT"
+        value={ifShift}
+        min={-1200}
+        max={1200}
+        step={20}
+        unit="Hz"
+        renderer="bipolar"
+        accentColor="var(--v2-accent-cyan)"
+        onChange={onIfShiftChange}
+        variant="hardware-illuminated"
+      />
+    {/if}
 
     <div class="filter-actions">
       <button
@@ -221,19 +229,21 @@
       <span class="bw-value">{formatWidthDisplay(filterWidth)}</span>
     </div>
 
-    <ValueControl
-      label={hasPbt ? "IF Shift (derived)" : "IF Shift"}
-      value={ifShift}
-      min={-1200}
-      max={1200}
-      step={25}
-      unit="Hz"
-      renderer="bipolar"
-      accentColor="var(--v2-accent-cyan)"
-      disabled={hasPbt}
-      onChange={onIfShiftChange}
-      variant="hardware-illuminated"
-    />
+    {#if hasIfShift}
+      <ValueControl
+        label={hasPbt ? "IF Shift (derived)" : "IF Shift"}
+        value={ifShift}
+        min={-1200}
+        max={1200}
+        step={25}
+        unit="Hz"
+        renderer="bipolar"
+        accentColor="var(--v2-accent-cyan)"
+        disabled={hasPbt}
+        onChange={onIfShiftChange}
+        variant="hardware-illuminated"
+      />
+    {/if}
     {#if hasPbt}
       <ValueControl
         label="PBT Inner"

--- a/frontend/src/components-v2/panels/__tests__/FilterPanel.isolated.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/FilterPanel.isolated.test.ts
@@ -240,18 +240,26 @@ describe('IF Shift visibility (MOR-1494)', () => {
     expect(labels).not.toContain('IF Shift (derived)');
   });
 
-  it('renders only the real PBT Inner/Outer sliders for an IC-7300-shaped capability set', () => {
-    const t = mountPanel({ hasIfShift: false, hasPbt: true, pbtInner: 0, pbtOuter: 0 });
+  it('renders only the real PBT Inner/Outer sliders for an IC-7300-shaped capability set, bound to their own values', () => {
+    const t = mountPanel({ hasIfShift: false, hasPbt: true, pbtInner: 100, pbtOuter: -50 });
     const labels = Array.from(t.querySelectorAll('.vc-label')).map((el) => el.textContent);
     expect(labels).toContain('PBT Inner');
     expect(labels).toContain('PBT Outer');
-    expect(t.querySelectorAll('[role="slider"]').length).toBe(2);
+    const sliders = t.querySelectorAll<HTMLElement>('[role="slider"]');
+    expect(sliders.length).toBe(2);
+    // PBT Inner renders before PBT Outer (source order) -- values must track
+    // their OWN prop, not a shared/derived stand-in.
+    expect(sliders[0].getAttribute('aria-valuenow')).toBe('100');
+    expect(sliders[1].getAttribute('aria-valuenow')).toBe('-50');
   });
 
-  it('renders the IF Shift row for an FTX-1-shaped capability set (if_shift, no pbt)', () => {
-    const t = mountPanel({ hasIfShift: true, hasPbt: false });
+  it('renders the IF Shift row for an FTX-1-shaped capability set (if_shift, no pbt), bound to the real ifShift value', () => {
+    const t = mountPanel({ hasIfShift: true, hasPbt: false, ifShift: 275 });
     const labels = Array.from(t.querySelectorAll('.vc-label')).map((el) => el.textContent);
     expect(labels).toContain('IF Shift');
+    const sliders = t.querySelectorAll<HTMLElement>('[role="slider"]');
+    expect(sliders.length).toBe(1);
+    expect(sliders[0].getAttribute('aria-valuenow')).toBe('275');
   });
 
   it('leaves the FTX-1-shaped IF Shift slider enabled (no PBT to disable it on)', () => {

--- a/frontend/src/components-v2/panels/__tests__/FilterPanel.isolated.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/FilterPanel.isolated.test.ts
@@ -17,6 +17,7 @@ const mockProps = {
     stepHz: 50,
   } as { defaults: number[]; fixed: boolean; minHz: number; maxHz: number; stepHz: number } | null,
   ifShift: 0,
+  hasIfShift: true,
   hasPbt: false,
   pbtInner: 0,
   pbtOuter: 0,
@@ -120,6 +121,7 @@ beforeEach(() => {
       stepHz: 50,
     },
     ifShift: 0,
+    hasIfShift: true,
     hasPbt: false,
     pbtInner: 0,
     pbtOuter: 0,
@@ -218,6 +220,52 @@ describe('PBT sliders visibility', () => {
   it('renders 1 slider total when hasPbt=false', () => {
     const t = mountPanel();
     expect(t.querySelectorAll('[role="slider"]').length).toBe(1);
+  });
+});
+
+/**
+ * MOR-1494: capability-absent controls must be HIDDEN, not shown dead.
+ * IC-7300 (PBT-only, no `if_shift` command) previously rendered the IF
+ * Shift slider permanently disabled with a PBT-derived stand-in value.
+ * `if_shift` is a real command only on Yaesu-family radios (e.g. FTX-1);
+ * Icom radios expose PBT Inner/Outer instead. The panel must render
+ * IF Shift only when `hasIfShift` (data-driven from the radio's own
+ * capability set) is true — never from a hardcoded model/family check.
+ */
+describe('IF Shift visibility (MOR-1494)', () => {
+  it('hides the IF Shift row for an IC-7300-shaped capability set (pbt, no if_shift)', () => {
+    const t = mountPanel({ hasIfShift: false, hasPbt: true, pbtInner: 0, pbtOuter: 0 });
+    const labels = Array.from(t.querySelectorAll('.vc-label')).map((el) => el.textContent);
+    expect(labels).not.toContain('IF Shift');
+    expect(labels).not.toContain('IF Shift (derived)');
+  });
+
+  it('renders only the real PBT Inner/Outer sliders for an IC-7300-shaped capability set', () => {
+    const t = mountPanel({ hasIfShift: false, hasPbt: true, pbtInner: 0, pbtOuter: 0 });
+    const labels = Array.from(t.querySelectorAll('.vc-label')).map((el) => el.textContent);
+    expect(labels).toContain('PBT Inner');
+    expect(labels).toContain('PBT Outer');
+    expect(t.querySelectorAll('[role="slider"]').length).toBe(2);
+  });
+
+  it('renders the IF Shift row for an FTX-1-shaped capability set (if_shift, no pbt)', () => {
+    const t = mountPanel({ hasIfShift: true, hasPbt: false });
+    const labels = Array.from(t.querySelectorAll('.vc-label')).map((el) => el.textContent);
+    expect(labels).toContain('IF Shift');
+  });
+
+  it('leaves the FTX-1-shaped IF Shift slider enabled (no PBT to disable it on)', () => {
+    const t = mountPanel({ hasIfShift: true, hasPbt: false });
+    const sliders = t.querySelectorAll<HTMLElement>('[role="slider"]');
+    expect(sliders.length).toBe(1);
+    expect(sliders[0].getAttribute('aria-disabled')).not.toBe('true');
+  });
+
+  it('hides the IF Shift row when the capability set has neither if_shift nor pbt', () => {
+    const t = mountPanel({ hasIfShift: false, hasPbt: false });
+    const labels = Array.from(t.querySelectorAll('.vc-label')).map((el) => el.textContent);
+    expect(labels).not.toContain('IF Shift');
+    expect(t.querySelectorAll('[role="slider"]').length).toBe(0);
   });
 });
 

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -859,14 +859,26 @@
     UNLIKE `txAuxSurface`/`metersSurface` (and like `rxAudioSurface` above) it
     is rendered in the SINGLE composition ONLY (fix round, verify-MOR-1304 F1).
     `FilterSurface` renders up to 14 focusable controls (mode/filter/shape
-    buttons, width and passband-level sliders) and no manifest declares a
-    `filter` zone, so mounting it bare in the dual cockpit would put every one
-    of those controls outside every declared zone and after the `rx-tx` zone
-    that MOR-1069 requires to end the tab order — exactly the shape the
-    MOR-1279/MOR-1336 zone-mount ruling forbids for any control-bearing
-    surface. `'filter'` became DECLARABLE with this slice, so the cockpit
-    gains the surface the moment a rework slice's manifest declares a zone for
-    it — a layout decision, separately reviewed, exactly as rxAudio left it.
+    buttons, width and passband-level sliders) and the DUAL COCKPIT manifest
+    (`dual-receiver-cockpit.ts`) declares no `filter` zone, so mounting it
+    bare there would put every one of those controls outside every declared
+    zone and after the `rx-tx` zone that MOR-1069 requires to end the tab
+    order — exactly the shape the MOR-1279/MOR-1336 zone-mount ruling forbids
+    for any control-bearing surface. `'filter'` became DECLARABLE with this
+    slice, for whichever layout's manifest chooses to declare a zone for it —
+    a layout decision, separately reviewed, exactly as rxAudio left it.
+
+    CORRECTION (MOR-1494 review round): the SINGLE composition (`desktop-v2`)
+    already made that layout decision — `desktop-declarations.ts:71` declares
+    `{ id: 'filter', surfaces: ['filter'] }` (landed with MOR-1366, S7). Since
+    then `FilterSurface`, not `LeftSidebar`'s legacy `FilterPanel`, has been
+    the LIVE renderer on `desktop-v2` (`RadioLayout.svelte`'s
+    `!declared.has('filter')` suppression). This paragraph previously read as
+    if no manifest anywhere had declared the zone yet; it hadn't been updated
+    after S7 landed, and that staleness led a later review round to
+    misdiagnose which component renders the IF-shift control on desktop-v2.
+    The dual cockpit remains the one composition still undeclared for this
+    zone — the rest of this comment's reasoning about IT stands.
   -->
   {#snippet filterSurface()}
     {#if view?.modeFilter || view?.filterPassband}

--- a/frontend/src/lib/runtime/adapters/__tests__/filter-passband-adapter.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/filter-passband-adapter.isolated.test.ts
@@ -387,6 +387,48 @@ describe('ifShift raw-field vs PBT-derived branch selection (MOR-1284)', () => {
 });
 
 /**
+ * `ifShiftControlStructural` (MOR-1494 review round) — a SEPARATE,
+ * presentation-only flag `FilterSurface.svelte` uses to decide whether to
+ * show the IF-shift ROW, deliberately independent of `ifShift.availability.
+ * structural` above (which stays `hasIfShiftCap || hasPbtCap`, unchanged,
+ * because `scope-adapter.ts`'s passband-center overlay still needs the
+ * derived reading for a PBT-only radio). `ifShiftControlStructural` answers
+ * the narrower question: does the radio have a REAL `if_shift` command.
+ */
+describe('ifShiftControlStructural — the presentation-only IF-shift control gate (MOR-1494)', () => {
+  it('IC-7300-shaped (pbt, no if_shift): false, even though the derived fact stays structural', () => {
+    const view = model(bareState({
+      main: { ...bareState().main, pbtInner: 200, pbtOuter: 60 },
+      fieldStatus: { ...bareState().fieldStatus, 'main.pbtInner': fresh, 'main.pbtOuter': fresh },
+    }), caps({ capabilities: ['pbt'] }));
+    expect(view.filterPassband!.ifShiftControlStructural).toBe(false);
+    // The trap: a naive fix that reused `ifShiftStructural` for this flag
+    // too would silently break `scope-adapter.ts`'s derived reading for
+    // exactly this radio shape. It must stay untouched.
+    expect(view.filterPassband!.ifShift.availability.structural).toBe(true);
+    expect(view.filterPassband!.ifShift.reading.status).toBe('known');
+  });
+
+  it('FTX-1-shaped (if_shift, no pbt): true', () => {
+    const view = model(bareState({
+      main: { ...bareState().main, ifShift: 300 },
+      fieldStatus: { ...bareState().fieldStatus, 'main.ifShift': fresh },
+    }), caps({ capabilities: ['if_shift'] }));
+    expect(view.filterPassband!.ifShiftControlStructural).toBe(true);
+  });
+
+  it('neither if_shift nor pbt: false', () => {
+    const view = model(bareState(), caps({ filters: ['FIL1'] }));
+    expect(view.filterPassband!.ifShiftControlStructural).toBe(false);
+  });
+
+  it('both if_shift and pbt (hypothetical radio): true — a real if_shift command always wins the presentation gate', () => {
+    const view = model(bareState(), caps({ capabilities: ['if_shift', 'pbt'] }));
+    expect(view.filterPassband!.ifShiftControlStructural).toBe(true);
+  });
+});
+
+/**
  * HONESTY GATE (MOR-1284, following the 4A F2 lesson). `ifShift`'s derived
  * branch must never fabricate a reading from ONE observed PBT field and the
  * other's silently-defaulted value — the same "never emit a known value

--- a/frontend/src/lib/runtime/adapters/__tests__/scope-adapter.authority.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/scope-adapter.authority.isolated.test.ts
@@ -25,6 +25,7 @@ import {
   parseScopeFrame, snapSpectrumFilterWidth, toSpectrumAuthority,
 } from '../scope-adapter';
 import { toRadioViewModel } from '../radio-view-model-adapter';
+import { deriveIfShift, pbtRawToHz } from '$lib/radio/filter-controls';
 
 const fresh: FieldStatus = {
   storePath: 'fixture', observed: true, freshness: 'fresh', availability: 'available',
@@ -303,6 +304,27 @@ describe('MOR-1409 A06a1 canonical spectrum authority selector', () => {
     const changed = toSpectrumAuthority(state({ main: { ...receiver(14_074_000), filterWidth: 1800 } }), caps());
     expect(first?.digest).toBe(equal?.digest);
     expect(first?.digest).not.toBe(changed?.digest);
+  });
+
+  /**
+   * MOR-1494 review round — the trap. `FilterSurface.svelte`'s IF-shift ROW
+   * now hides for an IC-7300-shaped radio (pbt, no if_shift capability), via
+   * a NEW `ifShiftControlStructural` presentation flag. This authority's
+   * `ifShiftHz` must be UNAFFECTED: it reads `filterPassband.ifShift`
+   * directly (`toSpectrumAuthority`'s own `knownReading` call, keyed on the
+   * field's `reading.status`, never on `ifShiftControlStructural`), which
+   * still derives from PBT for exactly this radio shape. A fix that gated
+   * the DERIVED fact instead of adding a separate presentation flag would
+   * have silently broken this passband-center overlay.
+   */
+  it('IC-7300-shaped caps (pbt, no if_shift): ifShiftHz still derives from PBT (MOR-1494 trap)', () => {
+    const icomCaps = caps({
+      capabilities: ['scope', 'dual_rx', 'filter_width', 'data_mode', 'pbt'],
+    });
+    const result = toSpectrumAuthority(state(), icomCaps);
+    const expectedIfShiftHz = deriveIfShift(pbtRawToHz(140), pbtRawToHz(116));
+    expect(result?.ifShiftHz).toBe(expectedIfShiftHz);
+    expect(result?.ifShiftHz).not.toBeNull();
   });
 });
 

--- a/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
@@ -465,6 +465,21 @@ function deriveFilterPassband(
   return {
     filterShape: txAuxField(hasFilters, filterShapeObserved, numOrUndef(rx?.filterShape)),
     ifShift: txAuxField(ifShiftStructural, ifShiftOperational, ifShiftValue),
+    // MOR-1494 review round. Deliberately NOT `ifShiftStructural` above.
+    // `ifShiftStructural`/`ifShiftOperational`/`ifShiftValue` stay exactly as
+    // they were — a radio with `pbt` but no `if_shift` still gets an honest
+    // derived `ifShift` READING (`scope-adapter.ts`'s `toSpectrumAuthority`
+    // reads `filterPassband.ifShift` for the passband-center overlay on
+    // EVERY radio that has PBT, IC-7300 included, and must keep doing so).
+    // This flag answers a DIFFERENT question — does the radio have a REAL
+    // `if_shift` COMMAND of its own — for `FilterSurface.svelte` to decide
+    // whether to show the IF-shift CONTROL at all. IC-7300 (PBT-only) has no
+    // such command; showing the control permanently disabled with a
+    // PBT-derived stand-in is a dead control, not a usable one (the owner's
+    // MOR-1494 ruling: hide capability-absent controls, don't show them
+    // dead). See `FilterPassbandViewModel.ifShiftControlStructural`'s doc
+    // comment (`radio-view-model.ts`) for the full split.
+    ifShiftControlStructural: hasIfShiftCap,
     pbtInner: txAuxField(hasPbtCap, pbtInnerObserved, pbtInnerHz),
     pbtOuter: txAuxField(hasPbtCap, pbtOuterObserved, pbtOuterHz),
     dataMode: txAuxField(hasDataModeCap, dataModeObserved, numOrUndef(rx?.dataMode)),

--- a/frontend/src/lib/runtime/props/panel-props.ts
+++ b/frontend/src/lib/runtime/props/panel-props.ts
@@ -339,6 +339,7 @@ export interface FilterProps {
   filterWidthMax: number;
   filterConfig: FilterModeConfig | null;
   ifShift: number;
+  hasIfShift: boolean;
   hasPbt: boolean;
   pbtInner: number;
   pbtOuter: number;
@@ -388,6 +389,14 @@ export function toFilterProps(
     ifShift: hasCap(caps, 'if_shift')
       ? (rx?.ifShift ?? 0)
       : deriveIfShift(pbtInner, pbtOuter),
+    // MOR-1494: whether the radio has a REAL if_shift command of its own.
+    // Icom radios (PBT only, e.g. IC-7300) declare no `if_shift` capability
+    // at all — `ifShift` above still computes a PBT-derived display value
+    // for consumers that want it, but FilterPanel.svelte uses THIS flag to
+    // decide whether to show the IF-shift control, so a capability-absent
+    // radio gets the row hidden instead of a permanently-disabled control
+    // with a synthetic reading (PBT Inner/Outer are the real controls there).
+    hasIfShift: hasCap(caps, 'if_shift'),
     hasPbt: hasCap(caps, 'pbt'),
     pbtInner,
     pbtOuter,

--- a/frontend/src/semantic/FilterSurface.svelte
+++ b/frontend/src/semantic/FilterSurface.svelte
@@ -23,6 +23,18 @@
       `modeObserved`, `filterWidth` on its own `widthObserved`); this file
       never substitutes one field's gate for another's.
 
+  CAPABILITY-ABSENT CONTROLS ARE HIDDEN, NOT SHOWN DEAD (MOR-1494 review
+  round). The `ifShift` ROW is the ONE exception to rule (2) above: it gates
+  on `filterPassband.ifShiftControlStructural`, NOT on
+  `filterPassband.ifShift.availability.structural`. The latter stays `true`
+  for any radio with EITHER `if_shift` OR `pbt` (a PBT-only radio like
+  IC-7300 still gets an honest derived `ifShift` reading, e.g. for
+  `scope-adapter.ts`'s passband-center overlay) — showing that as a control
+  the operator can never actually turn is exactly the "shown dead" defect
+  MOR-1494 fixed. `ifShiftControlStructural` answers the narrower question
+  this row needs: does the radio have a REAL `if_shift` command. See
+  `radio-view-model.ts`'s `FilterPassbandViewModel` doc comment.
+
   PENDING AFFORDANCE (MOR-1441 leg 2). `pendingFilter` is a plain, command-
   bus-blind display prop — same "read at the wiring seam, hand down a plain
   value" precedent as `pendingFrequencyHz` (leg 1, `VfoSurface`). It marks
@@ -188,7 +200,7 @@
         </div>
       {/if}
       {#each FILTER_PASSBAND_LEVELS as [field, label, min, max, step] (field)}
-        {#if filterPassband[field].availability.structural}
+        {#if field === 'ifShift' ? filterPassband.ifShiftControlStructural : filterPassband[field].availability.structural}
           <label
             class="filter-level" data-testid={`filter-${field}`}
             data-disabled-reason={reasonOf(filterPassband[field])}

--- a/frontend/src/semantic/__tests__/FilterSurface.test.ts
+++ b/frontend/src/semantic/__tests__/FilterSurface.test.ts
@@ -61,6 +61,21 @@ function withPassbandField(
   };
 }
 
+/**
+ * MOR-1494 review round. `ifShiftControlStructural` is a plain boolean
+ * SIBLING of `ifShift` on `filterPassband` (see `radio-view-model.ts`'s
+ * `FilterPassbandViewModel` doc comment) — not a `FilterPassbandField`, so
+ * `withPassbandField` above (which only knows the `{reading, availability}`
+ * shape) cannot set it. A dedicated helper, same idiom as
+ * `withModeFilterField`/`withPassbandField`.
+ */
+function withIfShiftControlStructural(view: RadioViewModel, value: boolean): RadioViewModel {
+  return {
+    ...view,
+    filterPassband: { ...view.filterPassband!, ifShiftControlStructural: value } as FilterPassbandViewModel,
+  };
+}
+
 let target: HTMLDivElement;
 beforeEach(() => { target = document.createElement('div'); document.body.appendChild(target); });
 afterEach(() => { target.remove(); });
@@ -151,9 +166,76 @@ describe('structural availability decides whether a control EXISTS', () => {
     withSurface(view, (s) => expect(s.group('filter-data-mode')).toBeNull());
   });
 
-  it.each(FILTER_PASSBAND_LEVELS)('renders no "%s" control when structurally absent', (field) => {
-    const view = withPassbandField(base(), field, { availability: ABSENT });
-    withSurface(view, (s) => expect(s.group(`filter-${field}`)).toBeNull());
+  // `ifShift` is deliberately excluded from this generic sweep (MOR-1494
+  // review round) — its ROW gates on the separate `ifShiftControlStructural`
+  // flag, not on its OWN field's `availability.structural`, so setting that
+  // to ABSENT here would no longer hide it. See the dedicated
+  // "IF-shift control gate is separate from the derived fact" block below.
+  it.each(FILTER_PASSBAND_LEVELS.filter(([field]) => field !== 'ifShift'))(
+    'renders no "%s" control when structurally absent',
+    (field) => {
+      const view = withPassbandField(base(), field, { availability: ABSENT });
+      withSurface(view, (s) => expect(s.group(`filter-${field}`)).toBeNull());
+    },
+  );
+});
+
+// ── 2b. IF-shift control gate is separate from the derived fact (MOR-1494) ──
+
+/**
+ * MOR-1494 review round. IC-7300 (PBT-only, no `if_shift` command) rendered
+ * the IF Shift row permanently disabled with a PBT-derived stand-in value —
+ * a dead control shown instead of hidden. The fix splits the presentation
+ * gate (`ifShiftControlStructural`, this block) from the derived-fact gate
+ * (`ifShift.availability.structural`, UNCHANGED — pinned untouched by the
+ * last test below, which is the trap a naive fix would have missed:
+ * `scope-adapter.ts`'s passband-center overlay reads `filterPassband.ifShift`
+ * directly and must keep getting the PBT-derived reading for a radio just
+ * like this one).
+ */
+describe('IF-shift control gate is separate from the derived fact (MOR-1494)', () => {
+  it('IC-7300-shaped (pbt, no if_shift): hides the ifShift row', () => {
+    const view = withIfShiftControlStructural(base(), false);
+    withSurface(view, (s) => expect(s.group('filter-ifShift')).toBeNull());
+  });
+
+  it('IC-7300-shaped (pbt, no if_shift): the underlying derived ifShift FACT stays structural and known — scope-adapter.ts still gets it', () => {
+    const view = withIfShiftControlStructural(base(), false);
+    // `ifShiftControlStructural: false` here mirrors what the adapter would
+    // compute for a pbt-only radio; `ifShift`'s OWN field is UNTOUCHED by
+    // this override and stays exactly what `base()` (a "fully observed"
+    // fixture) gives it — the row-hiding change above must never reach into
+    // this field.
+    expect(view.filterPassband!.ifShift.availability.structural).toBe(true);
+    expect(view.filterPassband!.ifShift.reading).toEqual({ status: 'known', value: 0 });
+  });
+
+  it('FTX-1-shaped (if_shift, no pbt): renders the ifShift row, enabled, bound to the real value', () => {
+    // base() defaults ifShiftControlStructural to true (see fixtures/
+    // topologies.ts) — the FTX-1-shaped case, no override needed.
+    withSurface(base(), (s) => {
+      expect(s.group('filter-ifShift')).not.toBeNull();
+      expect(s.input('filter-ifShift')!.disabled).toBe(false);
+    });
+  });
+
+  it('neither if_shift nor pbt: hides the ifShift row, no crash', () => {
+    let view = withIfShiftControlStructural(base(), false);
+    view = withPassbandField(view, 'ifShift', {
+      availability: { structural: false, operational: false },
+    });
+    withSurface(view, (s) => expect(s.group('filter-ifShift')).toBeNull());
+  });
+
+  it('still applies operational gating (disabled + reason) to a structurally-shown ifShift row', () => {
+    const view = withPassbandField(base(), 'ifShift', {
+      availability: { structural: true, operational: false },
+    });
+    withSurface(view, (s) => {
+      expect(s.group('filter-ifShift')).not.toBeNull();
+      expect(s.input('filter-ifShift')!.disabled).toBe(true);
+      expect(s.group('filter-ifShift')!.dataset.disabledReason).toBe('field-not-observed');
+    });
   });
 });
 
@@ -178,6 +260,11 @@ describe('operational availability decides whether a control is USABLE', () => {
     });
   });
 
+  // `ifShift` stays in this sweep (unlike the structural-gating one above,
+  // MOR-1494 review round): `base()`'s `ifShiftControlStructural` is true
+  // and this override never touches it, so the row still shows; only the
+  // field's own `operational` (unaffected by the MOR-1494 split) decides
+  // whether it's disabled here.
   it.each(FILTER_PASSBAND_LEVELS)('keeps "%s" present but disabled when unreadable', (field) => {
     const view = withPassbandField(base(), field, { availability: PRESENT_UNREADABLE });
     withSurface(view, (s) => {

--- a/frontend/src/semantic/fixtures/topologies.ts
+++ b/frontend/src/semantic/fixtures/topologies.ts
@@ -285,6 +285,12 @@ export function withFilterPassband(fixture: RadioViewModel): RadioViewModel {
   const filterPassband: FilterPassbandViewModel = {
     filterShape: known(1),
     ifShift: known(0),
+    // MOR-1494 review round: "fully observed" means a radio with a REAL
+    // if_shift command (e.g. FTX-1), so this base fixture defaults the
+    // control-presentation gate to true — tests exercising the IC-7300-
+    // shaped (no if_shift) case override it explicitly via
+    // `withIfShiftControlStructural` in the consuming test file.
+    ifShiftControlStructural: true,
     pbtInner: known(0),
     pbtOuter: known(0),
     dataMode: known(0),

--- a/frontend/src/semantic/radio-view-model.ts
+++ b/frontend/src/semantic/radio-view-model.ts
@@ -336,6 +336,24 @@ export type FilterPassbandField<T> = TxAuxField<T>;
 export interface FilterPassbandViewModel {
   filterShape: FilterPassbandField<number>;
   ifShift: FilterPassbandField<number>;
+  /**
+   * MOR-1494 review round. `ifShift.availability.structural` above stays
+   * `hasIfShiftCap || hasPbtCap` UNCHANGED — that OR is a fact-derivation
+   * gate (a radio with `pbt` but no `if_shift` still gets an honest derived
+   * `ifShift` READING, e.g. for `scope-adapter.ts`'s passband-center
+   * overlay). This is a SEPARATE, presentation-only gate: whether the radio
+   * has a REAL `if_shift` COMMAND of its own. IC-7300 (PBT-only) has none —
+   * showing its IF-shift CONTROL permanently disabled with a PBT-derived
+   * stand-in is a dead control (the owner's MOR-1494 ruling: hide
+   * capability-absent controls, don't show them dead). `FilterSurface.svelte`
+   * gates the ifShift ROW on this flag, and ONLY this flag — never on
+   * `ifShift.availability.structural`, which stays reserved for consumers of
+   * the derived fact itself (see `deriveFilterPassband`'s doc comment).
+   * A plain boolean, not `FilterPassbandField`-wrapped, for the same reason
+   * `ModeFilterViewModel.modeChoices`/`filterChoices` aren't: a structural
+   * fact about the radio MODEL, not a live reading that can itself go stale.
+   */
+  ifShiftControlStructural: boolean;
   pbtInner: FilterPassbandField<number>;
   pbtOuter: FilterPassbandField<number>;
   dataMode: FilterPassbandField<number>;
@@ -1380,14 +1398,19 @@ function validateModeFilter(value: unknown, path: string): ModeFilterViewModel {
   };
 }
 
-/** N4 again: exactly the five facts the adapter reads, no speculative keys.
+/** N4 again: exactly the six facts the adapter reads, no speculative keys.
  *  See `radio-view-model-adapter.ts::deriveFilterPassband`. */
 function validateFilterPassband(value: unknown, path: string): FilterPassbandViewModel {
   const v = record(value, path);
-  exactKeys(v, ['filterShape', 'ifShift', 'pbtInner', 'pbtOuter', 'dataMode'], path);
+  exactKeys(
+    v,
+    ['filterShape', 'ifShift', 'ifShiftControlStructural', 'pbtInner', 'pbtOuter', 'dataMode'],
+    path,
+  );
   return {
     filterShape: validateTxAuxField(v.filterShape, `${path}.filterShape`, num),
     ifShift: validateTxAuxField(v.ifShift, `${path}.ifShift`, num),
+    ifShiftControlStructural: bool(v.ifShiftControlStructural, `${path}.ifShiftControlStructural`),
     pbtInner: validateTxAuxField(v.pbtInner, `${path}.pbtInner`, num),
     pbtOuter: validateTxAuxField(v.pbtOuter, `${path}.pbtOuter`, num),
     dataMode: validateTxAuxField(v.dataMode, `${path}.dataMode`, num),


### PR DESCRIPTION
## Summary

IC-7300 (and other Icom/PBT-only radios) have no `if_shift` CI-V command at all -- `if_shift` is a real command only on Yaesu-family radios (e.g. FTX-1, `rigs/ftx1.toml`). Two components can render the filter panel, gated per skin by which layout zones are declared, and both needed the same class of fix:

- **desktop-v2 (the live renderer there): `frontend/src/semantic/FilterSurface.svelte`.** `desktop-declarations.ts:71` declares `{ id: 'filter', surfaces: ['filter'] }` (landed with MOR-1366, S7), which makes `LeftSidebar.svelte` suppress the legacy `FilterPanel` (`!declared.has('filter')`) -- `FilterSurface` is what actually renders there. It showed the IF-shift row permanently disabled with a PBT-derived `'?'`/stand-in value, because `filterPassband.ifShift.availability.structural` is `hasIfShiftCap || hasPbtCap` -- true for any PBT radio, including IC-7300.
- **mobile: `frontend/src/components-v2/panels/FilterPanel.svelte`.** `mobile-declarations.ts` declares no `filter` zone, so `MobileRadioLayout.svelte`'s unconditional `FilterPanel` mount is genuinely live there, and it had the analogous bug (`disabled={hasPbt}`, shown unconditionally).

### The split (owner's MOR-1494 ruling: hide capability-absent controls, don't show them dead)

`filterPassband.ifShift`'s own structural/operational/reading facts stay **unchanged** -- `scope-adapter.ts`'s `toSpectrumAuthority` reads `filterPassband.ifShift` directly for its passband-center overlay and must keep getting the PBT-derived value on a PBT-only radio. A naive fix that gated the derived fact itself would have silently broken that overlay.

Instead, a new, separate, presentation-only flag answers the narrower question "does the radio have a REAL `if_shift` command":

- `radio-view-model-adapter.ts`: `deriveFilterPassband` now also computes `ifShiftControlStructural: hasIfShiftCap`.
- `radio-view-model.ts`: `FilterPassbandViewModel` gains `ifShiftControlStructural: boolean` (plain, not `TxAuxField`-wrapped -- a structural fact about the radio model, same precedent as `modeChoices`/`filterChoices`), plus validator support.
- `FilterSurface.svelte`: the ifShift row gates on `filterPassband.ifShiftControlStructural` specifically, not on `filterPassband.ifShift.availability.structural` (which `pbtInner`/`pbtOuter` still use, unchanged).
- `panel-props.ts` / `FilterPanel.svelte` (mobile): analogous `hasIfShift` flag gates the mobile IF Shift row the same way.
- `SemanticRadioSurfaces.svelte`: corrected a stale comment (pre-MOR-1366) that had claimed no manifest declares a `filter` zone -- it does now, on `desktop-v2`, pointing at `desktop-declarations.ts:71`.

## Tests

`frontend/src/semantic/__tests__/FilterSurface.test.ts`, new `describe('IF-shift control gate is separate from the derived fact (MOR-1494)')`:
- `IC-7300-shaped (pbt, no if_shift): hides the ifShift row`
- `IC-7300-shaped (pbt, no if_shift): the underlying derived ifShift FACT stays structural and known -- scope-adapter.ts still gets it`
- `FTX-1-shaped (if_shift, no pbt): renders the ifShift row, enabled, bound to the real value`
- `neither if_shift nor pbt: hides the ifShift row, no crash`
- `still applies operational gating (disabled + reason) to a structurally-shown ifShift row`

`frontend/src/lib/runtime/adapters/__tests__/filter-passband-adapter.isolated.test.ts`, new `describe('ifShiftControlStructural — the presentation-only IF-shift control gate (MOR-1494)')`: IC-7300-shaped / FTX-1-shaped / neither / both-capabilities cases, including the trap pin (derived fact stays structural+known for the IC-7300 case).

`frontend/src/lib/runtime/adapters/__tests__/scope-adapter.authority.isolated.test.ts`, new test: `IC-7300-shaped caps (pbt, no if_shift): ifShiftHz still derives from PBT (MOR-1494 trap)` -- proves the scope passband-center overlay is unaffected.

`frontend/src/components-v2/panels/__tests__/FilterPanel.isolated.test.ts` (mobile half, from round 1, strengthened per review): positive tests now assert slider VALUE binding via `aria-valuenow`, not just presence/enabled state.

All pre-existing tests in every touched file, the wider `panel-props`/adapter/wiring suites (2420+ tests), `eslint`, `lint:boundaries`, and `svelte-check` (0 errors/warnings across 4545 files) remain green.

Closes MOR-1494

🤖 Generated with [Claude Code](https://claude.com/claude-code)