### PR TITLE
fix: coalescing key includes receiver and selector target (MOR-1499)

### DIFF
--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -1010,8 +1010,31 @@ class ControlHandler:
         (levels, offsets, gains, ...) are deliberately excluded from
         target-keying — last-value-wins across DIFFERENT values remains
         the point of coalescing them.
+
+        NOTE (review B2): target-keying trades away MOR-1427's total
+        order PER NAME -- a coalesced frame for target A can flush after
+        a later immediate frame for target B. No in-tree dispatch site
+        emits same-target twice then a different target inside one 50 ms
+        window, so this is latent; if such a flow appears, flush pending
+        sibling keys of the same (name, receiver) family first.
+
+        NOTE (review B5): the target is interpolated with !r (int 1 and
+        str "1" under-coalesce -- the safe direction; the frontend sends
+        integers consistently), while receiver is interpolated bare after
+        normalization below, so 0/"0"/absent share one key.
         """
-        receiver = params.get("receiver", 0)
+        # Review B1: params comes straight off the wire and this runs
+        # BEFORE the _dispatch_command try/except -- a non-dict must not
+        # raise here (one malformed frame would otherwise tear down the
+        # whole control session); it just gets the default key.
+        if not isinstance(params, dict):
+            return f"{name}:0"
+        receiver_raw = params.get("receiver", 0)
+        # Review B3: normalize to the validated receiver domain so a
+        # hostile client cannot mint unbounded pacing buckets via
+        # receiver=0..N garbage; anything outside {0, 1} shares the
+        # default bucket (dispatch validation rejects it later anyway).
+        receiver = receiver_raw if receiver_raw in (0, 1) else 0
         target_param = self._COALESCE_TARGET_PARAM.get(name)
         if target_param is not None:
             return f"{name}:{receiver}:{params.get(target_param)!r}"

--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -454,6 +454,23 @@ class ControlHandler:
         }
     )
 
+    # MOR-1499: SELECTOR commands — the param carries a discrete TARGET
+    # (which filter/VFO/band), not a continuous magnitude — so the
+    # coalescing key also includes the selected target (see
+    # ``_coalesce_key``). Two different targets inside the pacing window
+    # (e.g. the frontend filter-preset flow: switch filter -> write width
+    # -> switch back) must both reach the radio instead of the first
+    # switch being silently superseded by the second. Deliberately NOT
+    # applied to value-carrying commands (levels, offsets, gains, ...):
+    # last-value-wins across DIFFERENT values is the whole point of
+    # coalescing those (MOR-1427).
+    _COALESCE_TARGET_PARAM: dict[str, str] = {
+        "set_filter": "filter",
+        "set_vfo": "vfo",
+        "select_vfo": "vfo",
+        "set_band": "band",
+    }
+
     def __init__(
         self,
         ws: Connection,
@@ -481,20 +498,24 @@ class ControlHandler:
         self._event_queue: BoundedQueue[dict[str, Any]] = BoundedQueue(
             maxsize=100,
         )
-        # Per-command rate limiting: command_name -> last physical-enqueue time.
+        # Per-command rate limiting: coalesce_key -> last physical-enqueue
+        # time (MOR-1499: keyed by ``_coalesce_key``, not the bare name).
         self._cmd_last: dict[str, float] = {}
         # Minimum interval between same command (seconds).
         # Continuous slider/knob drag sends dozens of set_* per second.
         self._CMD_MIN_INTERVAL = 0.05  # 50ms = max 20 commands/sec per client
         # MOR-1427: last-value-wins coalescing for commands arriving inside
         # the pacing window above, instead of the old silent hard-drop.
-        # command_name -> (command_id, params) of the most recent frame
-        # still waiting for its paced flush.
-        self._cmd_pending: dict[str, tuple[Any, dict[str, Any]]] = {}
-        # command_name -> the single deferred-flush task scheduled for it
-        # (one handle per (session, command) — this session owns them all).
+        # MOR-1499: all four dicts below are keyed by the *coalescing key*
+        # from ``_coalesce_key`` (name + receiver + selector target), not
+        # the bare command name — see that method's docstring.
+        # coalesce_key -> (command_id, name, params) of the most recent
+        # frame still waiting for its paced flush.
+        self._cmd_pending: dict[str, tuple[Any, str, dict[str, Any]]] = {}
+        # coalesce_key -> the single deferred-flush task scheduled for it
+        # (one handle per (session, key) — this session owns them all).
         self._cmd_flush_tasks: dict[str, asyncio.Task[None]] = {}
-        # command_name -> count of frames coalesced (superseded before they
+        # coalesce_key -> count of frames coalesced (superseded before they
         # could flush) in the current burst — reset once that burst flushes.
         self._cmd_coalesced: dict[str, int] = {}
         shared_service = getattr(server, "command_service", None)
@@ -943,8 +964,9 @@ class ControlHandler:
         # of hard-dropped — see _coalesce_command / _flush_coalesced_command.
         if name.startswith("set_"):
             now = time.monotonic()
-            last = self._cmd_last.get(name, 0.0)
-            # MOR-1427 review B1: a pending frame for this name must always
+            key = self._coalesce_key(name, params)
+            last = self._cmd_last.get(key, 0.0)
+            # MOR-1427 review B1: a pending frame for this key must always
             # win the race, even if the deferred flush task is running late
             # (event loop briefly busy past its deadline). Consulting only
             # the elapsed time here lets a newer frame slip past the gate
@@ -953,15 +975,51 @@ class ControlHandler:
             # stale one. Checking `_cmd_pending` closes that window: as long
             # as a frame is still waiting to flush, every new frame joins the
             # coalesce path instead of racing it.
-            if now - last < self._CMD_MIN_INTERVAL or name in self._cmd_pending:
-                await self._coalesce_command(name, cmd_id, params, now, last)
+            if now - last < self._CMD_MIN_INTERVAL or key in self._cmd_pending:
+                await self._coalesce_command(key, name, cmd_id, params, now, last)
                 return
-            self._cmd_last[name] = now
+            self._cmd_last[key] = now
 
         await self._dispatch_command(cmd_id, name, params)
 
+    def _coalesce_key(self, name: str, params: dict[str, Any]) -> str:
+        """Coalescing-bucket key for a SET command (MOR-1499).
+
+        MOR-1427 originally coalesced purely by command NAME, so two
+        frames with the same name but different meaning could wrongly
+        supersede each other:
+
+        - cross-receiver: ``set_nb`` on MAIN then SUB inside the pacing
+          window superseded MAIN's frame with SUB's — MAIN's toggle never
+          reached the radio.
+        - cross-target selectors: the frontend filter-preset flow
+          dispatches ``set_filter(A)``, ``set_filter_width(W)``,
+          ``set_filter(B)`` in one tick; both ``set_filter`` frames shared
+          one key, so the first switch was superseded and never applied —
+          the width landed on whichever filter was still active.
+
+        Fix: the key always includes the receiver (defaulting to 0, same
+        default every receiver-scoped command already applies) so distinct
+        receivers never collide — this is safe for receiver-less commands
+        too, since they always resolve to the same default and behave
+        exactly as before. For the small set of discrete-target SELECTOR
+        commands in ``_COALESCE_TARGET_PARAM``, the selected target also
+        joins the key, so two different targets are tracked (and flushed)
+        independently while repeated selections of the SAME target still
+        coalesce exactly as before. Continuous value-carrying commands
+        (levels, offsets, gains, ...) are deliberately excluded from
+        target-keying — last-value-wins across DIFFERENT values remains
+        the point of coalescing them.
+        """
+        receiver = params.get("receiver", 0)
+        target_param = self._COALESCE_TARGET_PARAM.get(name)
+        if target_param is not None:
+            return f"{name}:{receiver}:{params.get(target_param)!r}"
+        return f"{name}:{receiver}"
+
     async def _coalesce_command(
         self,
+        key: str,
         name: str,
         cmd_id: Any,
         params: dict[str, Any],
@@ -970,23 +1028,25 @@ class ControlHandler:
     ) -> None:
         """Last-value-wins coalescing for a frame inside the pacing window (MOR-1427).
 
-        The most recent frame for *name* always survives to the next paced
+        The most recent frame for *key* always survives to the next paced
         flush. Any frame it replaces gets an honest ``superseded`` reply
         right away instead of the old silent-drop ``throttled`` ack — it
         never reaches the command queue, so it must not claim it did.
         Physical-enqueue pacing (``_CMD_MIN_INTERVAL``) is unchanged: this
         only decides *which* frame's value is the one flushed when the
-        window reopens, never how often the window opens.
+        window reopens, never how often the window opens. *key* is the
+        MOR-1499 coalescing key (``_coalesce_key``); *name* is the actual
+        command name, carried alongside it for dispatch/logging.
         """
-        previous = self._cmd_pending.get(name)
+        previous = self._cmd_pending.get(key)
         if previous is not None:
-            prev_cmd_id, _ = previous
-            count = self._cmd_coalesced.get(name, 0) + 1
-            self._cmd_coalesced[name] = count
+            prev_cmd_id, _, _ = previous
+            count = self._cmd_coalesced.get(key, 0) + 1
+            self._cmd_coalesced[key] = count
             if count == 1 or count % 50 == 0:
                 logger.warning(
                     "rate-limit: coalescing %s (%.0fms since last, coalesced=%d)",
-                    name,
+                    key,
                     (now - last) * 1000,
                     count,
                 )
@@ -1000,31 +1060,31 @@ class ControlHandler:
                     }
                 )
             )
-        self._cmd_pending[name] = (cmd_id, params)
-        if name not in self._cmd_flush_tasks:
+        self._cmd_pending[key] = (cmd_id, name, params)
+        if key not in self._cmd_flush_tasks:
             delay = max(self._CMD_MIN_INTERVAL - (now - last), 0.0)
-            self._cmd_flush_tasks[name] = asyncio.create_task(
-                self._flush_coalesced_command(name, delay)
+            self._cmd_flush_tasks[key] = asyncio.create_task(
+                self._flush_coalesced_command(key, delay)
             )
 
-    async def _flush_coalesced_command(self, name: str, delay: float) -> None:
+    async def _flush_coalesced_command(self, key: str, delay: float) -> None:
         """Deferred physical enqueue for a coalesced burst (MOR-1427).
 
         Fires once, at the pacing boundary, and dispatches whichever frame
-        is the most recently pending one for *name* at that moment — never
+        is the most recently pending one for *key* at that moment — never
         necessarily the frame that originally triggered the delay.
         """
         try:
             if delay > 0.0:
                 await asyncio.sleep(delay)
         finally:
-            self._cmd_flush_tasks.pop(name, None)
-        pending = self._cmd_pending.pop(name, None)
+            self._cmd_flush_tasks.pop(key, None)
+        pending = self._cmd_pending.pop(key, None)
         if pending is None:
             return
-        cmd_id, params = pending
-        self._cmd_last[name] = time.monotonic()
-        self._cmd_coalesced[name] = 0
+        cmd_id, name, params = pending
+        self._cmd_last[key] = time.monotonic()
+        self._cmd_coalesced[key] = 0
         try:
             await self._dispatch_command(cmd_id, name, params)
         except asyncio.CancelledError:

--- a/tests/test_mor1427_rate_limiter_coalesce.py
+++ b/tests/test_mor1427_rate_limiter_coalesce.py
@@ -74,9 +74,22 @@ def _messages_by_id(ws: SimpleNamespace) -> dict[str, dict[str, Any]]:
     return out
 
 
+def _default_key(name: str) -> str:
+    """Coalescing key for a non-selector, receiver-less-in-params command.
+
+    MOR-1499: ``_cmd_pending``/``_cmd_flush_tasks``/``_cmd_coalesced`` are
+    keyed by ``ControlHandler._coalesce_key(name, params)``, not the bare
+    name. None of the commands this suite exercises (``set_freq``,
+    ``set_filter_width``) are selector-type or pass an explicit
+    ``receiver``, so their key is always ``f"{name}:0"`` (the same default
+    every receiver-scoped command already applies).
+    """
+    return f"{name}:0"
+
+
 async def _await_flush(handler: ControlHandler, name: str) -> None:
     """Wait for the deferred coalesced flush (if any) for *name* to complete."""
-    task = handler._cmd_flush_tasks.get(name)  # noqa: SLF001
+    task = handler._cmd_flush_tasks.get(_default_key(name))  # noqa: SLF001
     if task is not None:
         await task
 
@@ -252,14 +265,14 @@ async def test_coalesce_counter_is_accurate_and_logged(
 
         # 10 frames: 1 dispatched immediately, 9 coalesced-in, 8 of those
         # superseded before flush (the 9th survives to flush).
-        assert handler._cmd_coalesced.get("set_freq") == 8  # noqa: SLF001
+        assert handler._cmd_coalesced.get(_default_key("set_freq")) == 8  # noqa: SLF001
         assert any("set_freq" in rec.message for rec in caplog.records)
 
         await _await_flush(handler, "set_freq")
 
     # Counter resets once the burst actually flushes, so the next burst's
     # count is not inflated by a prior one.
-    assert handler._cmd_coalesced.get("set_freq", 0) == 0  # noqa: SLF001
+    assert handler._cmd_coalesced.get(_default_key("set_freq"), 0) == 0  # noqa: SLF001
 
 
 # ---------------------------------------------------------------------------
@@ -295,8 +308,8 @@ async def test_late_flush_gate_diverts_to_coalescing_when_frame_pending() -> Non
     await handler._handle_command(
         {"id": "f2", "name": "set_freq", "params": {"freq": base_freq + 1}}
     )
-    assert "set_freq" in handler._cmd_pending  # noqa: SLF001
-    assert "set_freq" in handler._cmd_flush_tasks  # noqa: SLF001
+    assert _default_key("set_freq") in handler._cmd_pending  # noqa: SLF001
+    assert _default_key("set_freq") in handler._cmd_flush_tasks  # noqa: SLF001
 
     # Block the event loop SYNCHRONOUSLY past the flush deadline. Real
     # wall-clock time now exceeds _CMD_MIN_INTERVAL since F1, but the
@@ -416,7 +429,7 @@ async def _run_one_battery_iteration(rng: random.Random) -> None:
 
         # Occasionally tear down mid-burst instead of dispatching further.
         if rng.random() < 0.2:
-            pending = handler._cmd_pending.get(primary)  # noqa: SLF001
+            pending = handler._cmd_pending.get(_default_key(primary))  # noqa: SLF001
             if pending is not None:
                 cancelled_id = str(pending[0])
             queue.put(PttOff())
@@ -487,8 +500,8 @@ async def _run_one_battery_iteration(rng: random.Random) -> None:
     # i.e. it always eventually wins, never gets silently stuck as
     # "superseded" with nothing superseding it.
     if not teardown_fired:
-        assert primary not in handler._cmd_pending  # noqa: SLF001
-        assert primary not in handler._cmd_flush_tasks  # noqa: SLF001
+        assert _default_key(primary) not in handler._cmd_pending  # noqa: SLF001
+        assert _default_key(primary) not in handler._cmd_flush_tasks  # noqa: SLF001
         if dispatched:
             last_dispatched_id = dispatched[-1][0]
             assert by_id[last_dispatched_id].get("result") != {"superseded": True}

--- a/tests/test_mor1499_coalesce_keys.py
+++ b/tests/test_mor1499_coalesce_keys.py
@@ -1,0 +1,234 @@
+"""RED/GREEN tests for MOR-1499: the MOR-1427 coalescing key must include the
+receiver and (for selector-type commands) the selected target, not just the
+bare command NAME.
+
+Bugs (both verifier-proven by inspection of
+``ControlHandler._coalesce_command`` / ``_cmd_pending``, keyed by
+``command_name`` alone):
+
+1. Frontend preset flow (``panel-commands.ts`` ``onFilterPresetChange``)
+   dispatches ``set_filter(A)``, ``set_filter_width(W)``, ``set_filter(B)``
+   in a single tick. Because both ``set_filter`` frames share the same
+   NAME-only key, the second silently supersedes the first inside the
+   pacing window -- "switch filter -> write width -> switch back" can
+   collapse to just the final switch, with the width written against
+   whichever filter was actually active on the radio at that moment.
+
+2. Cross-receiver: ``set_nb`` on MAIN followed by ``set_nb`` on SUB inside
+   the pacing window superseded MAIN's frame with SUB's -- MAIN's toggle
+   never reached the radio.
+
+Fix under test: the coalescing key (``ControlHandler._coalesce_key``) always
+includes the receiver, and for discrete-target SELECTOR commands
+(``set_filter``, ``set_vfo``/``select_vfo``, ``set_band`` --
+``_COALESCE_TARGET_PARAM``) also includes the selected target. Continuous
+value-carrying commands (levels, offsets, gains, ...) deliberately do NOT
+key off their value -- last-value-wins across DIFFERENT values remains the
+whole point of coalescing them (MOR-1427's original purpose), pinned here
+too so the fix does not regress it.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from rigplane.web.handlers import ControlHandler
+from rigplane.web.protocol import decode_json
+from rigplane.web.radio_poller import SetFilter, SetIfShift, SetNB
+
+pytestmark = pytest.mark.asyncio
+
+
+def _control_handler(
+    ws: object | None = None,
+    radio: object | None = None,
+    server: object | None = None,
+) -> ControlHandler:
+    if ws is None:
+        ws = SimpleNamespace(send_text=AsyncMock(), recv=AsyncMock())
+    return ControlHandler(ws, radio, "9.9.9", "IC-7610", server=server)
+
+
+class _QueueRecorder:
+    def __init__(self) -> None:
+        self.items: list[object] = []
+
+    def put(self, item: object) -> None:
+        self.items.append(item)
+
+
+def _sent_messages(ws: SimpleNamespace) -> list[dict[str, Any]]:
+    return [decode_json(c.args[0]) for c in ws.send_text.await_args_list]
+
+
+def _messages_by_id(ws: SimpleNamespace) -> dict[str, dict[str, Any]]:
+    out: dict[str, dict[str, Any]] = {}
+    for msg in _sent_messages(ws):
+        out[msg["id"]] = msg
+    return out
+
+
+async def _await_flush(handler: ControlHandler, key: str) -> None:
+    task = handler._cmd_flush_tasks.get(key)  # noqa: SLF001
+    if task is not None:
+        await task
+
+
+# ---------------------------------------------------------------------------
+# (a) set_filter with DIFFERENT targets in the pacing window: both switches
+#     must reach the radio -- neither supersedes the other.
+# ---------------------------------------------------------------------------
+
+
+async def test_set_filter_distinct_targets_both_reach_radio() -> None:
+    ws = SimpleNamespace(send_text=AsyncMock(), recv=AsyncMock())
+    queue = _QueueRecorder()
+    handler = _control_handler(
+        ws=ws, radio=SimpleNamespace(connected=True), server=SimpleNamespace(command_queue=queue)
+    )
+
+    # Mirrors onFilterPresetChange: switch to FIL1, then switch back to FIL2,
+    # dispatched back-to-back in the same pacing window.
+    await handler._handle_command(
+        {"id": "switch-to-1", "name": "set_filter", "params": {"filter": "FIL1", "receiver": 0}}
+    )
+    await handler._handle_command(
+        {"id": "switch-to-2", "name": "set_filter", "params": {"filter": "FIL2", "receiver": 0}}
+    )
+
+    # Distinct targets -> distinct coalescing keys -> both dispatch
+    # immediately, neither is superseded.
+    filter_writes = [item for item in queue.items if isinstance(item, SetFilter)]
+    assert [w.filter_num for w in filter_writes] == [1, 2]
+
+    by_id = _messages_by_id(ws)
+    assert by_id["switch-to-1"]["ok"] is True
+    assert by_id["switch-to-1"]["result"] == {"filter": "FIL1", "receiver": 0}
+    assert by_id["switch-to-2"]["ok"] is True
+    assert by_id["switch-to-2"]["result"] == {"filter": "FIL2", "receiver": 0}
+    assert by_id["switch-to-1"]["result"] != {"superseded": True}
+    assert by_id["switch-to-2"]["result"] != {"superseded": True}
+
+
+# ---------------------------------------------------------------------------
+# (b) set_filter with the SAME target repeated rapidly still coalesces --
+#     the per-target discrimination must not defeat MOR-1427's original
+#     purpose for repeated identical selections.
+# ---------------------------------------------------------------------------
+
+
+async def test_set_filter_same_target_still_coalesces() -> None:
+    ws = SimpleNamespace(send_text=AsyncMock(), recv=AsyncMock())
+    queue = _QueueRecorder()
+    handler = _control_handler(
+        ws=ws, radio=SimpleNamespace(connected=True), server=SimpleNamespace(command_queue=queue)
+    )
+
+    for i in range(3):
+        await handler._handle_command(
+            {
+                "id": f"click-{i}",
+                "name": "set_filter",
+                "params": {"filter": "FIL1", "receiver": 0},
+            }
+        )
+
+    # First click dispatches immediately (opens the window); the 2nd is
+    # superseded by the 3rd, which is the one that flushes.
+    filter_writes = [item for item in queue.items if isinstance(item, SetFilter)]
+    assert len(filter_writes) == 1
+    key = "set_filter:0:'FIL1'"
+    await _await_flush(handler, key)
+    filter_writes = [item for item in queue.items if isinstance(item, SetFilter)]
+    assert len(filter_writes) == 2
+    assert all(w.filter_num == 1 for w in filter_writes)
+
+    by_id = _messages_by_id(ws)
+    assert by_id["click-0"]["result"] == {"filter": "FIL1", "receiver": 0}
+    assert by_id["click-1"]["result"] == {"superseded": True}
+    assert by_id["click-2"]["result"] == {"filter": "FIL1", "receiver": 0}
+
+
+# ---------------------------------------------------------------------------
+# (c) Cross-receiver: set_nb on MAIN then SUB inside the pacing window --
+#     both must reach the radio, MAIN's toggle must not be superseded by
+#     SUB's.
+# ---------------------------------------------------------------------------
+
+
+async def test_set_nb_cross_receiver_both_reach_radio() -> None:
+    ws = SimpleNamespace(send_text=AsyncMock(), recv=AsyncMock())
+    queue = _QueueRecorder()
+    # Canonical dual-RX VFO methods (DualReceiverCapable) so the "dual_rx"
+    # capability tag isn't stripped by runtime_capabilities()'s isinstance
+    # check, and receiver=1 (SUB) passes _ensure_receiver_supported.
+    radio = SimpleNamespace(
+        connected=True,
+        capabilities={"nb", "dual_rx"},
+        swap_main_sub=AsyncMock(),
+        equalize_main_sub=AsyncMock(),
+        set_main_sub_tracking=AsyncMock(),
+        get_main_sub_tracking=AsyncMock(return_value=False),
+    )
+    handler = _control_handler(
+        ws=ws, radio=radio, server=SimpleNamespace(command_queue=queue)
+    )
+
+    await handler._handle_command(
+        {"id": "main-on", "name": "set_nb", "params": {"on": True, "receiver": 0}}
+    )
+    await handler._handle_command(
+        {"id": "sub-on", "name": "set_nb", "params": {"on": True, "receiver": 1}}
+    )
+
+    nb_writes = [item for item in queue.items if isinstance(item, SetNB)]
+    assert len(nb_writes) == 2
+    assert {(w.on, w.receiver) for w in nb_writes} == {(True, 0), (True, 1)}
+
+    by_id = _messages_by_id(ws)
+    assert by_id["main-on"]["result"] != {"superseded": True}
+    assert by_id["sub-on"]["result"] != {"superseded": True}
+
+
+# ---------------------------------------------------------------------------
+# (d) Regression pin: value-carrying commands on the SAME receiver still
+#     coalesce across DIFFERENT values -- last-value-wins, MOR-1427's
+#     original purpose, unaffected by the MOR-1499 key-shape change.
+# ---------------------------------------------------------------------------
+
+
+async def test_slider_command_still_coalesces_across_different_values() -> None:
+    ws = SimpleNamespace(send_text=AsyncMock(), recv=AsyncMock())
+    queue = _QueueRecorder()
+    radio = SimpleNamespace(connected=True, capabilities={"if_shift"})
+    handler = _control_handler(
+        ws=ws, radio=radio, server=SimpleNamespace(command_queue=queue)
+    )
+
+    n = 5
+    for i in range(n):
+        await handler._handle_command(
+            {
+                "id": str(i),
+                "name": "set_if_shift",
+                "params": {"offset": i * 10, "receiver": 0},
+            }
+        )
+
+    # Only the first frame enqueues synchronously.
+    assert len([item for item in queue.items if isinstance(item, SetIfShift)]) == 1
+    key = "set_if_shift:0"
+    await _await_flush(handler, key)
+
+    writes = [item for item in queue.items if isinstance(item, SetIfShift)]
+    assert len(writes) == 2
+    assert writes[0].offset == 0
+    assert writes[-1].offset == (n - 1) * 10
+
+    by_id = _messages_by_id(ws)
+    for i in range(1, n - 1):
+        assert by_id[str(i)]["result"] == {"superseded": True}

--- a/tests/test_mor1499_coalesce_keys.py
+++ b/tests/test_mor1499_coalesce_keys.py
@@ -88,16 +88,26 @@ async def test_set_filter_distinct_targets_both_reach_radio() -> None:
     ws = SimpleNamespace(send_text=AsyncMock(), recv=AsyncMock())
     queue = _QueueRecorder()
     handler = _control_handler(
-        ws=ws, radio=SimpleNamespace(connected=True), server=SimpleNamespace(command_queue=queue)
+        ws=ws,
+        radio=SimpleNamespace(connected=True),
+        server=SimpleNamespace(command_queue=queue),
     )
 
     # Mirrors onFilterPresetChange: switch to FIL1, then switch back to FIL2,
     # dispatched back-to-back in the same pacing window.
     await handler._handle_command(
-        {"id": "switch-to-1", "name": "set_filter", "params": {"filter": "FIL1", "receiver": 0}}
+        {
+            "id": "switch-to-1",
+            "name": "set_filter",
+            "params": {"filter": "FIL1", "receiver": 0},
+        }
     )
     await handler._handle_command(
-        {"id": "switch-to-2", "name": "set_filter", "params": {"filter": "FIL2", "receiver": 0}}
+        {
+            "id": "switch-to-2",
+            "name": "set_filter",
+            "params": {"filter": "FIL2", "receiver": 0},
+        }
     )
 
     # Distinct targets -> distinct coalescing keys -> both dispatch
@@ -125,7 +135,9 @@ async def test_set_filter_same_target_still_coalesces() -> None:
     ws = SimpleNamespace(send_text=AsyncMock(), recv=AsyncMock())
     queue = _QueueRecorder()
     handler = _control_handler(
-        ws=ws, radio=SimpleNamespace(connected=True), server=SimpleNamespace(command_queue=queue)
+        ws=ws,
+        radio=SimpleNamespace(connected=True),
+        server=SimpleNamespace(command_queue=queue),
     )
 
     for i in range(3):

--- a/tests/test_mor1499_coalesce_keys.py
+++ b/tests/test_mor1499_coalesce_keys.py
@@ -244,3 +244,30 @@ async def test_slider_command_still_coalesces_across_different_values() -> None:
     by_id = _messages_by_id(ws)
     for i in range(1, n - 1):
         assert by_id[str(i)]["result"] == {"superseded": True}
+
+
+# ---------------------------------------------------------------------------
+# (e) Review B1 regression: params comes straight off the wire and
+#     _coalesce_key runs BEFORE _dispatch_command's try/except -- a
+#     malformed (non-dict) params must yield a normal ok:false response,
+#     never an exception that would tear down the control session.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad_params", [None, [1], "x", 7])
+async def test_malformed_params_do_not_raise_and_reply_not_ok(
+    bad_params: Any,
+) -> None:
+    ws = SimpleNamespace(send_text=AsyncMock(), recv=AsyncMock())
+    queue = _QueueRecorder()
+    radio = SimpleNamespace(connected=True, capabilities={"nb"})
+    handler = _control_handler(
+        ws=ws, radio=radio, server=SimpleNamespace(command_queue=queue)
+    )
+
+    await handler._handle_command(
+        {"id": "bad", "name": "set_freq", "params": bad_params}
+    )
+
+    by_id = _messages_by_id(ws)
+    assert by_id["bad"]["ok"] is False


### PR DESCRIPTION
## Summary

MOR-1427's per-command rate-limiter coalescing (`ControlHandler._coalesce_command` / `_cmd_pending`) keyed purely by command **NAME**, so two SET frames with the same name but different meaning could wrongly supersede each other inside the 50ms pacing window.

### Failure mode 1 — cross-target selector (frontend preset flow)

`frontend/src/lib/runtime/commands/panel-commands.ts:840-877` (`onFilterPresetChange`) dispatches, in one synchronous tick:

```
set_filter(A) -> set_filter_width(W) -> set_filter(B)
```

Both `set_filter` frames shared the single key `"set_filter"`, so the first switch (to `A`) was silently superseded by the second (back to `B`) before it could reach the radio — the width write then landed against whichever filter was actually still active on the device, not the intended one.

### Failure mode 2 — cross-receiver

`set_nb` on MAIN followed by `set_nb` on SUB inside the pacing window shared the key `"set_nb"`, so MAIN's toggle was superseded by SUB's and never reached the radio.

## Key-shape decision

`ControlHandler._coalesce_key(name, params)`:

- **Receiver always discriminates.** The key folds in `params.get("receiver", 0)` — the same default every receiver-scoped command already applies, so this is a no-op for receiver-less commands (they always resolve to the same default and coalesce exactly as before). Fixes failure mode 2 generally, for any receiver-scoped command, not just `set_nb`.
- **Selector-type commands also discriminate on the selected target.** A small explicit set — `set_filter` (`filter`), `set_vfo` / `select_vfo` (`vfo`), `set_band` (`band`) — carries a discrete TARGET, not a continuous magnitude, so the key also includes the selected value (`_COALESCE_TARGET_PARAM`). Two different targets in the same window are now tracked and flushed independently; repeated selections of the *same* target still coalesce exactly as before (pinned in `test_set_filter_same_target_still_coalesces`).
- **Value-carrying commands are deliberately excluded from target-keying.** Levels, offsets, gains, etc. keep last-value-wins across *different* values — that's the entire point of MOR-1427's coalescing for continuous slider/knob drags. Pinned in `test_slider_command_still_coalesces_across_different_values` (a fresh `set_if_shift` regression check, since the existing `set_freq` suite already covers this implicitly).

This fully resolves failure mode 1 for `onFilterPresetChange` (at most one `set_filter_width` call per invocation, so no width-collision) and failure mode 2 in general.

## What remains — NOT fully covered

`onFilterDefaults` (same file, `panel-commands.ts:862-876`) loops over up to 3 filters in a single synchronous tick, each iteration dispatching `set_filter(i)` *and* `set_filter_width(defaults[i])`. Even with the target-keyed fix here, the **`set_filter_width` calls for different filters still collide** — `SetFilterWidth` has no explicit "which filter" param (its target is implicit: whatever filter is active on the radio *at the moment the command lands*), so there is no discriminating value to add to its coalescing key. Multiple width writes in that loop still coalesce down to the last one.

Fixing this requires either (a) giving `set_filter_width` an explicit target param to discriminate on, or (b) frontend-side serialization (await each round-trip before firing the next command) — both are frontend/protocol changes outside this backend-only PR's 3-file/400-LOC scope, per the ticket's own STOP instruction. Flagging as a likely follow-up ticket rather than silently declaring done.

Because of this gap, **not** tagging "Closes MOR-1499" — this PR closes both proven failure modes but not the full `onFilterDefaults` batch-preset scenario.

## Test plan

- [x] `tests/test_mor1499_coalesce_keys.py` (new) — 4 tests: distinct `set_filter` targets both reach the radio, same-target still coalesces, cross-receiver `set_nb` both reach the radio, slider command still coalesces across different values.
- [x] `tests/test_mor1427_rate_limiter_coalesce.py` — updated for the new key shape (`name:receiver[:target]` instead of bare name); all 7 original assertions unchanged in substance.
- [x] `uv run pytest` on the full control/web-handler test slice (1103 passed, 3 skipped) and the full non-integration suite (9136 passed, 0 failed).
- [x] `uv run ruff check src/ tests/` — clean.
- [x] `uv run mypy src/rigplane/web/handlers/control.py` — clean (13 pre-existing mypy errors elsewhere in the tree, unrelated to this diff, unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)