### PR TITLE
fix: hide capability-absent filter-shape buttons instead of rendering them dead (MOR-1503)

### DIFF
--- a/frontend/src/components-v2/panels/FilterPanel.svelte
+++ b/frontend/src/components-v2/panels/FilterPanel.svelte
@@ -13,6 +13,11 @@
   let currentMode = $derived(p.currentMode);
   let currentFilter = $derived(p.currentFilter);
   let filterShape = $derived(p.filterShape);
+  // MOR-1503: only radios with a REAL filter_shape command (Icom family,
+  // e.g. IC-7300) show the SHARP/SOFT shape buttons. The FTX-1 declares
+  // no `filter_shape` capability — rendering the buttons anyway is a dead
+  // control, same class as MOR-1494's IF-shift row.
+  let hasFilterShape = $derived(p.hasFilterShape ?? false);
   let filterLabels = $derived(p.filterLabels ?? ['FIL1', 'FIL2', 'FIL3']);
   let filterWidth = $derived(p.filterWidth);
   let filterWidthMin = $derived(p.filterWidthMin ?? 50);
@@ -342,29 +347,31 @@
         </div>
       {/each}
 
-      <div class="shape-section">
-        <div class="shape-title">Shape</div>
-        <div class="shape-buttons">
-          <button
-            type="button"
-            class="shape-button v2-control-button"
-            class:active={filterShape === 0}
-            style="--control-accent:var(--v2-accent-cyan); --control-active-text:var(--v2-text-white)"
-            onclick={() => onFilterShapeChange?.(0)}
-          >
-            SHARP
-          </button>
-          <button
-            type="button"
-            class="shape-button v2-control-button"
-            class:active={filterShape === 1}
-            style="--control-accent:var(--v2-accent-green-bright); --control-active-text:var(--v2-bg-darkest)"
-            onclick={() => onFilterShapeChange?.(1)}
-          >
-            SOFT
-          </button>
+      {#if hasFilterShape}
+        <div class="shape-section">
+          <div class="shape-title">Shape</div>
+          <div class="shape-buttons">
+            <button
+              type="button"
+              class="shape-button v2-control-button"
+              class:active={filterShape === 0}
+              style="--control-accent:var(--v2-accent-cyan); --control-active-text:var(--v2-text-white)"
+              onclick={() => onFilterShapeChange?.(0)}
+            >
+              SHARP
+            </button>
+            <button
+              type="button"
+              class="shape-button v2-control-button"
+              class:active={filterShape === 1}
+              style="--control-accent:var(--v2-accent-green-bright); --control-active-text:var(--v2-bg-darkest)"
+              onclick={() => onFilterShapeChange?.(1)}
+            >
+              SOFT
+            </button>
+          </div>
         </div>
-      </div>
+      {/if}
 
       {#if filterConfig?.fixed}
         <div class="modal-note">This mode uses fixed filter widths.</div>

--- a/frontend/src/components-v2/panels/__tests__/FilterPanel.isolated.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/FilterPanel.isolated.test.ts
@@ -7,6 +7,7 @@ const mockProps = {
   currentMode: 'USB',
   currentFilter: 2,
   filterShape: 0,
+  hasFilterShape: true,
   filterLabels: ['FIL1', 'FIL2', 'FIL3'],
   filterWidth: 2400,
   filterConfig: {
@@ -110,6 +111,7 @@ beforeEach(() => {
     currentMode: 'USB',
     currentFilter: 2,
     filterShape: 0,
+    hasFilterShape: true,
     filterLabels: ['FIL1', 'FIL2', 'FIL3'],
     filterWidth: 2400,
     filterConfig: {
@@ -318,6 +320,49 @@ describe('callbacks', () => {
     const button = Array.from(document.querySelectorAll('button')).find((el) => el.textContent?.trim() === 'SOFT') as HTMLButtonElement;
     button.click();
     expect(mockHandlers.onFilterShapeChange).toHaveBeenCalledWith(1);
+  });
+});
+
+/**
+ * MOR-1503: capability-absent controls must be HIDDEN, not shown dead
+ * (same class as MOR-1494's IF-shift row). `filter_shape` is a real
+ * command only on Icom radios (e.g. IC-7300, `rigs/ic7300.toml` declares
+ * the capability); the FTX-1's capability set does not include it, yet
+ * the settings modal rendered the SHARP/SOFT shape buttons
+ * unconditionally. The panel must render the shape section only when
+ * `hasFilterShape` (data-driven from the radio's own capability set) is
+ * true — never from a hardcoded model/family check.
+ */
+describe('filter shape visibility (MOR-1503)', () => {
+  it('hides the SHARP/SOFT shape buttons in the modal for an FTX-1-shaped capability set (no filter_shape)', () => {
+    const t = mountPanel({ hasFilterShape: false });
+    const gear = t.querySelector('.settings-button') as HTMLButtonElement;
+    gear.click();
+    flushSync();
+
+    const buttons = Array.from(document.querySelectorAll('button')).map((el) => el.textContent?.trim());
+    expect(buttons).not.toContain('SHARP');
+    expect(buttons).not.toContain('SOFT');
+  });
+
+  it('hides the whole shape section in the modal for an FTX-1-shaped capability set', () => {
+    const t = mountPanel({ hasFilterShape: false });
+    const gear = t.querySelector('.settings-button') as HTMLButtonElement;
+    gear.click();
+    flushSync();
+
+    expect(document.querySelector('.shape-section')).toBeNull();
+  });
+
+  it('renders the SHARP/SOFT shape buttons in the modal for an IC-7300-shaped capability set (filter_shape)', () => {
+    const t = mountPanel({ hasFilterShape: true });
+    const gear = t.querySelector('.settings-button') as HTMLButtonElement;
+    gear.click();
+    flushSync();
+
+    const buttons = Array.from(document.querySelectorAll('button')).map((el) => el.textContent?.trim());
+    expect(buttons).toContain('SHARP');
+    expect(buttons).toContain('SOFT');
   });
 });
 

--- a/frontend/src/lib/runtime/props/panel-props.ts
+++ b/frontend/src/lib/runtime/props/panel-props.ts
@@ -333,6 +333,7 @@ export interface FilterProps {
   currentMode: string;
   currentFilter: number;
   filterShape: number;
+  hasFilterShape: boolean;
   filterLabels: string[];
   filterWidth: number;
   filterWidthMin: number;
@@ -370,6 +371,14 @@ export function toFilterProps(
     currentMode: rx?.mode ?? '---',
     currentFilter: rx?.filter ?? 1,
     filterShape: rx?.filterShape ?? 0,
+    // MOR-1503: whether the radio has a REAL filter_shape command of its
+    // own (Icom family, e.g. IC-7300). The FTX-1 declares no
+    // `filter_shape` capability, so FilterPanel.svelte uses THIS flag to
+    // decide whether to show the SHARP/SOFT shape buttons — a
+    // capability-absent radio gets the section hidden instead of dead
+    // buttons commanding a control the radio does not have (same class
+    // as MOR-1494's IF-shift row).
+    hasFilterShape: hasCap(caps, 'filter_shape'),
     filterLabels: caps?.filters ?? [],
     filterWidth: rx?.filterWidth ?? Number.NaN,
     filterWidthMin:


### PR DESCRIPTION
## Summary

Fixes [MOR-1503](https://linear.app/morozsm/issue/MOR-1503/filterpanel-renders-sharpsoft-filter-shape-buttons-on-radios-without) — found while auditing `FilterPanel.svelte` for the MOR-1494 class of bug (capability-absent control rendered anyway).

The settings modal's `.shape-section` (SHARP/SOFT filter-shape buttons) rendered unconditionally. `filter_shape` is a real command only on Icom-family radios — `rigs/ic7300.toml`, `ic705.toml`, `ic7610.toml`, `ic9700.toml` declare the capability; `rigs/ftx1.toml` does not. On the FTX-1 the buttons were a dead control commanding a capability the radio does not have, while every other control in the panel is gated on a capability-derived flag from `toFilterProps`.

## Changes

- `panel-props.ts`: add `hasFilterShape: boolean` to `FilterProps`, computed as `hasCap(caps, 'filter_shape')` — data-driven from the radio's own capability set, never a hardcoded model/family check.
- `FilterPanel.svelte`: wrap the `.shape-section` block in `{#if hasFilterShape}`.
- `FilterPanel.isolated.test.ts`: TDD tests (watched fail first) — an FTX-1-shaped capability set (`hasFilterShape: false`) renders no SHARP/SOFT buttons and no shape section; an IC-7300-shaped set (`true`) renders them.

Same pattern as MOR-1494 (#2424); independent of that PR's changes (adjacent sections of the same files).

## Testing

- `npx vitest run src/components-v2/panels/__tests__/FilterPanel.isolated.test.ts` — 40/40 (RED verified first: the 2 new hide-tests failed against unconditional rendering)
- `npm run test` — 6939/6939 (full suite, two consecutive clean runs)
- `npm run check` — 0 errors / 0 warnings
- `npm run lint` and `npm run lint:boundaries` — clean

Python untouched (frontend-only diff); quick.yml gates the pytest leg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)