### PR TITLE
feat: TX/PA meter acquisition membership with TX-aware gating (MOR-1485)

### DIFF
--- a/rigs/ic7300.toml
+++ b/rigs/ic7300.toml
@@ -149,6 +149,26 @@ polling_only = [
     "global.operator_controls.monitor_gain",
     "global.operator_controls.vox_gain",
     "global.operator_controls.anti_vox_gain",
+    # MOR-1485: TX/PA meters (0x15 0x11-0x16). ``[commands]`` already declares
+    # get_power_meter/get_swr/get_alc/get_comp_meter/get_vd_meter/get_id_meter
+    # below and the scheduler's query mapping
+    # (``_GLOBAL_METER_QUERY_SUBS``/``IcomCivAcquisitionExecutor``) already
+    # handles the whole "global.meters.*" family generically — nothing there
+    # was IC-7300-specific or missing. The gap was purely acquisition
+    # membership: no field_policies entry meant due_requests() never touched
+    # these paths, so rigctld's own one-shot reads (proven healthy —
+    # ``_OBSERVABLE_CMD15_FIELDS``, ``_civ_rx.py``) were the only thing that
+    # ever populated them, and the always-polling web panel never saw a live
+    # value. Not stream_like_meters (that class is pinned to <=0.25s/<=2.0s
+    # by test_known_profiles_stream_like_meters_use_fast_non_decaying_policies
+    # for every profile including this one) — plain polling_only instead,
+    # with cadence chosen for THIS profile's serial budget below.
+    "global.meters.power",
+    "global.meters.swr",
+    "global.meters.alc",
+    "global.meters.comp",
+    "global.meters.vd",
+    "global.meters.id",
 ]
 stream_like_meters = [
     "receiver.main.meters.s_meter",
@@ -269,6 +289,64 @@ adaptive_decay = false
 [state_acquisition.field_policies."global.operator_controls.anti_vox_gain"]
 cadence_seconds = 15.0
 freshness_ttl_seconds = 25.0
+adaptive_decay = false
+
+# MOR-1485 (TX/PA meters dead on serial): owner ruling splits the six 0x15
+# meters into two gating shapes.
+#
+# Po/SWR/ALC/COMP are meaningful only while transmitting (`tx_only = true`),
+# so AcquisitionScheduler.due_requests skips their cadence group entirely
+# while PTT reads false -- ZERO steady-state (RX) serial cost. 1.0s cadence
+# is chosen for TX-window responsiveness, matching this profile's own
+# 1.5s-or-faster tier for everything else that matters live; it only ever
+# fires during a TX segment, transiently adding 4 fields / 1.0s = 4.0 q/s on
+# top of this profile's ~19.967 q/s RX-state demand (see vd/id below) for as
+# long as the key is down -- an accepted, TX-scoped tradeoff, not a
+# steady-state regression of the MOR-1484 serial medians.
+[state_acquisition.field_policies."global.meters.power"]
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
+adaptive_decay = false
+tx_only = true
+
+[state_acquisition.field_policies."global.meters.swr"]
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
+adaptive_decay = false
+tx_only = true
+
+[state_acquisition.field_policies."global.meters.alc"]
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
+adaptive_decay = false
+tx_only = true
+
+[state_acquisition.field_policies."global.meters.comp"]
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
+adaptive_decay = false
+tx_only = true
+
+# Vd/Id are supply telemetry, not TX readings -- the radio answers them in RX
+# too (proven: rigctld's ``_OBSERVABLE_CMD15_FIELDS`` one-shots already flip
+# these to observed outside TX), so they poll unconditionally (``tx_only``
+# defaults false). The pre-existing RX-state demand (19.933 q/s) already
+# sits only 0.067 q/s below the 20 q/s serial ceiling (see the serial-budget
+# assertion in tests/test_state_acquisition_policy.py) -- there is no room
+# for anything faster than a very slow cadence here without regressing every
+# OTHER field's actual throughput, which is exactly what MOR-1485 must not do
+# to the MOR-1484 medians. 60.0s spends under half of that remaining headroom
+# (2 fields / 60.0s = 0.033 q/s, 19.933 -> 19.967 q/s) while still refreshing
+# a slowly-varying supply rail/current reading roughly once a minute --
+# "live", just not fast.
+[state_acquisition.field_policies."global.meters.vd"]
+cadence_seconds = 60.0
+freshness_ttl_seconds = 90.0
+adaptive_decay = false
+
+[state_acquisition.field_policies."global.meters.id"]
+cadence_seconds = 60.0
+freshness_ttl_seconds = 90.0
 adaptive_decay = false
 
 # MOR-1483/1491/1492/1493 (field-policy membership wave): non-polling

--- a/src/rigplane/core/acquisition_scheduler.py
+++ b/src/rigplane/core/acquisition_scheduler.py
@@ -595,12 +595,22 @@ class AcquisitionScheduler:
         )
 
     def due_requests(
-        self, *, now: float | None = None
+        self, *, now: float | None = None, tx_active: bool = False
     ) -> tuple[AcquisitionRequest, ...]:
-        """Queue and return policy-cadence poll requests that are due."""
+        """Queue and return policy-cadence poll requests that are due.
+
+        ``tx_active`` gates cadence groups whose policy carries ``tx_only``
+        (MOR-1485): while False, those groups are skipped entirely (not just
+        deduped) — no query is sent and their cadence clock is left
+        untouched, so the moment a caller passes ``tx_active=True`` a group
+        that has been due all along fires immediately rather than waiting a
+        fresh cadence interval from the TX-start moment. Callers derive
+        ``tx_active`` from their own observed PTT state; this method has no
+        opinion on where that comes from.
+        """
 
         timestamp = self._clock.now() if now is None else now
-        groups = self._due_poll_groups(timestamp)
+        groups = self._due_poll_groups(timestamp, tx_active=tx_active)
         queued: list[AcquisitionRequest] = []
         for key, grouped_paths in groups:
             policy = key.policy
@@ -1106,6 +1116,8 @@ class AcquisitionScheduler:
     def _due_poll_groups(
         self,
         now: float,
+        *,
+        tx_active: bool = False,
     ) -> tuple[tuple[_AcquisitionRequestKey, tuple[FieldPath, ...]], ...]:
         due: list[tuple[_AcquisitionRequestKey, FieldPath]] = []
         for key, paths in self._poll_cadence_groups().items():
@@ -1113,6 +1125,11 @@ class AcquisitionScheduler:
                 continue
             policy = key.policy
             if policy.cadence_seconds is None:
+                continue
+            if policy.tx_only and not tx_active:
+                # MOR-1485: skip entirely rather than dedupe/defer — no query
+                # sent, no cadence clock touched, so a group due since before
+                # TX started fires on the very next tx_active=True call.
                 continue
             state = self._cadence_state_for(key, policy, now=now)
             if state.next_due_monotonic <= now:

--- a/src/rigplane/core/state_acquisition_policy.py
+++ b/src/rigplane/core/state_acquisition_policy.py
@@ -228,6 +228,13 @@ class AcquisitionPolicy:
         ExternalCatPauseBehavior.PAUSE_POLLING
     )
     meter_coalescing: MeterCoalescingPolicy | None = None
+    #: MOR-1485: cadence-poll membership that only fires while the backend
+    #: has observed PTT true (e.g. TX/PA meters that read meaningfully only
+    #: during transmit). Honored by ``AcquisitionScheduler.due_requests``'s
+    #: ``tx_active`` gate, not by ``ensure_fresh`` (an explicit caller-
+    #: triggered read is never blocked by this flag). Inert when
+    #: ``cadence_seconds`` is ``None`` (nothing left for it to gate).
+    tx_only: bool = False
 
     def __post_init__(self) -> None:
         cadence = _optional_positive_float(
@@ -252,6 +259,11 @@ class AcquisitionPolicy:
             "external_cat_pause",
             ExternalCatPauseBehavior(str(self.external_cat_pause)),
         )
+        object.__setattr__(
+            self,
+            "tx_only",
+            _strict_bool(self.tx_only, label="tx_only"),
+        )
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -269,6 +281,7 @@ class AcquisitionPolicy:
                 if self.meter_coalescing is None
                 else self.meter_coalescing.to_dict()
             ),
+            "txOnly": self.tx_only,
         }
 
     @classmethod
@@ -283,6 +296,7 @@ class AcquisitionPolicy:
                     "adaptiveDecay",
                     "externalCatPause",
                     "meterCoalescing",
+                    "txOnly",
                 }
             ),
             label="acquisition policy",
@@ -318,6 +332,7 @@ class AcquisitionPolicy:
             meter_coalescing=MeterCoalescingPolicy.from_dict(
                 value.get("meterCoalescing")
             ),
+            tx_only=bool(value.get("txOnly", False)),
         )
 
 

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -610,6 +610,7 @@ _ACQUISITION_POLICY_KEYS = frozenset(
         "adaptive_decay_max_cadence_seconds",
         "external_cat_pause",
         "meter_coalescing_window_seconds",
+        "tx_only",
     }
 )
 
@@ -757,6 +758,15 @@ def _parse_acquisition_policy(
                 )
                 if "meter_coalescing_window_seconds" in raw
                 else None
+            ),
+            tx_only=_strict_policy_bool(
+                filename,
+                prefix,
+                labels.get("tx_only", "tx_only"),
+                raw.get(
+                    "tx_only",
+                    defaults.tx_only if defaults is not None else False,
+                ),
             ),
         )
     except (TypeError, ValueError) as exc:

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -2883,8 +2883,13 @@ class RadioPoller:
             return
         now = time.monotonic()
         # MOR-1485: gate tx_only cadence membership (TX/PA meters) on observed
-        # PTT — same RadioState read _pick_high_meter already uses for the
-        # legacy LAN two-tier meter scheme.
+        # PTT via the RadioState mirror. That mirror is LIVE on the scheduler
+        # path: _civ_rx._handle_1c deliberately keeps writing RadioState.ptt
+        # (its siblings migrated to observations; PTT is dual-written), and
+        # global.tx_state.ptt is cadence-polled at 0.3s by this very
+        # scheduler — so the mirror refreshes from the scheduler's own
+        # traffic. (_pick_high_meter reads the same field, but only on the
+        # legacy non-scheduler branch — not a precedent for this path.)
         tx_active = (
             getattr(self._radio_state, "ptt", False)
             if self._radio_state is not None

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -2882,7 +2882,15 @@ class RadioPoller:
         if scheduler is None:
             return
         now = time.monotonic()
-        scheduler.due_requests(now=now)
+        # MOR-1485: gate tx_only cadence membership (TX/PA meters) on observed
+        # PTT — same RadioState read _pick_high_meter already uses for the
+        # legacy LAN two-tier meter scheme.
+        tx_active = (
+            getattr(self._radio_state, "ptt", False)
+            if self._radio_state is not None
+            else False
+        )
+        scheduler.due_requests(now=now, tx_active=tx_active)
         pending = scheduler.pending_requests()
         pending_ids = {request.id for request in pending}
         for request_id in tuple(self._acquisition_in_flight):

--- a/tests/test_acquisition_scheduler.py
+++ b/tests/test_acquisition_scheduler.py
@@ -1316,7 +1316,7 @@ def test_due_polling_tx_only_group_fires_immediately_when_tx_starts() -> None:
     for offset in range(10):
         assert scheduler.due_requests(now=402.0 + offset, tx_active=False) == ()
 
-    requests = scheduler.due_requests(now=412.0, tx_active=True)
+    requests = scheduler.due_requests(now=411.5, tx_active=True)
 
     assert len(requests) == 1
     assert requests[0].paths == (power,)

--- a/tests/test_acquisition_scheduler.py
+++ b/tests/test_acquisition_scheduler.py
@@ -1243,6 +1243,113 @@ def test_due_polling_skips_unsupported_unhooked_and_unsolicited_only_fields() ->
     assert requests[0].paths == (supported,)
 
 
+def test_due_polling_skips_tx_only_cadence_group_while_not_tx_active() -> None:
+    """MOR-1485: a ``tx_only`` policy must not be queried outside TX."""
+
+    clock = FreshnessClock(start=400.0)
+    power = FieldPath.global_("meters", "power")
+    profile = _profile(
+        [power],
+        field_policies={
+            power: AcquisitionPolicy(
+                cadence_seconds=1.0,
+                freshness_ttl_seconds=2.0,
+                tx_only=True,
+            ),
+        },
+    )
+    scheduler = AcquisitionScheduler(profile=profile, clock=clock)
+
+    requests = scheduler.due_requests(now=clock.now(), tx_active=False)
+
+    assert requests == ()
+    assert scheduler.pending_requests() == ()
+
+
+def test_due_polling_emits_tx_only_cadence_group_once_tx_active() -> None:
+    """MOR-1485: the same ``tx_only`` group fires once PTT is observed true."""
+
+    clock = FreshnessClock(start=401.0)
+    power = FieldPath.global_("meters", "power")
+    profile = _profile(
+        [power],
+        field_policies={
+            power: AcquisitionPolicy(
+                cadence_seconds=1.0,
+                freshness_ttl_seconds=2.0,
+                tx_only=True,
+            ),
+        },
+    )
+    scheduler = AcquisitionScheduler(profile=profile, clock=clock)
+
+    requests = scheduler.due_requests(now=clock.now(), tx_active=True)
+
+    assert len(requests) == 1
+    assert requests[0].paths == (power,)
+    assert requests[0].reason == "policy-cadence"
+
+
+def test_due_polling_tx_only_group_fires_immediately_when_tx_starts() -> None:
+    """MOR-1485: skipping while RX must not delay a group once TX starts.
+
+    Repeated RX-state ``due_requests`` calls must leave the ``tx_only``
+    group's cadence clock untouched (not just deduped) -- so the very first
+    call with ``tx_active=True`` fires it immediately, rather than waiting a
+    fresh cadence interval measured from the TX-start timestamp.
+    """
+
+    clock = FreshnessClock(start=402.0)
+    power = FieldPath.global_("meters", "power")
+    profile = _profile(
+        [power],
+        field_policies={
+            power: AcquisitionPolicy(
+                cadence_seconds=1.0,
+                freshness_ttl_seconds=2.0,
+                tx_only=True,
+            ),
+        },
+    )
+    scheduler = AcquisitionScheduler(profile=profile, clock=clock)
+
+    for offset in range(10):
+        assert scheduler.due_requests(now=402.0 + offset, tx_active=False) == ()
+
+    requests = scheduler.due_requests(now=412.0, tx_active=True)
+
+    assert len(requests) == 1
+    assert requests[0].paths == (power,)
+
+
+def test_due_polling_tx_only_does_not_gate_non_tx_only_meter_in_same_call() -> None:
+    """MOR-1485: ``tx_active=False`` only skips groups that opt into gating."""
+
+    clock = FreshnessClock(start=403.0)
+    power = FieldPath.global_("meters", "power")
+    vd = FieldPath.global_("meters", "vd")
+    profile = _profile(
+        [power, vd],
+        field_policies={
+            power: AcquisitionPolicy(
+                cadence_seconds=1.0,
+                freshness_ttl_seconds=2.0,
+                tx_only=True,
+            ),
+            vd: AcquisitionPolicy(
+                cadence_seconds=5.0,
+                freshness_ttl_seconds=10.0,
+            ),
+        },
+    )
+    scheduler = AcquisitionScheduler(profile=profile, clock=clock)
+
+    requests = scheduler.due_requests(now=clock.now(), tx_active=False)
+
+    assert len(requests) == 1
+    assert requests[0].paths == (vd,)
+
+
 def test_prime_unobserved_queues_background_read_for_never_observed_policy_field() -> (
     None
 ):

--- a/tests/test_state_acquisition_policy.py
+++ b/tests/test_state_acquisition_policy.py
@@ -172,6 +172,27 @@ def test_schema_from_dict_rejects_unknown_and_coerced_values() -> None:
     with pytest.raises(ValueError, match="provider must be a string"):
         RadioAcquisitionProfile.from_dict({"provider": 123})
 
+    with pytest.raises(ValueError, match="tx_only must be a bool"):
+        AcquisitionPolicy(cadence_seconds=1.0, freshness_ttl_seconds=2.0, tx_only="yes")  # type: ignore[arg-type]
+
+
+def test_acquisition_policy_tx_only_defaults_false_and_round_trips() -> None:
+    """MOR-1485: ``tx_only`` defaults false and survives a to_dict/from_dict trip."""
+
+    default_policy = AcquisitionPolicy()
+    assert default_policy.tx_only is False
+
+    tx_only_policy = AcquisitionPolicy(
+        cadence_seconds=1.0,
+        freshness_ttl_seconds=2.0,
+        tx_only=True,
+    )
+    payload = json.loads(json.dumps(tx_only_policy.to_dict()))
+    assert payload["txOnly"] is True
+    restored = AcquisitionPolicy.from_dict(payload)
+    assert restored == tx_only_policy
+    assert restored.tx_only is True
+
 
 def test_field_capability_direct_construction_rejects_coerced_controls() -> None:
     freq = FieldPath.active("main", "freq_mode", "freq_hz")
@@ -286,6 +307,37 @@ def test_loader_parses_x6200_like_tuning_policy_without_delivery_branches(
     assert policy.capability_for(mode).command_response_observable is True
     assert policy.policy_for(mode).reconciliation_priority == "command_response"
     assert profile.set_mode_via_selected is True
+
+
+def test_loader_parses_tx_only_field_policy_flag(tmp_path: Path) -> None:
+    """MOR-1485: ``tx_only = true`` in a field_policies table parses through."""
+
+    toml = _minimal_state_acquisition_toml(
+        """
+        [state_acquisition]
+        provider = "icom_civ"
+        default_cadence_seconds = 2.0
+        default_freshness_ttl_seconds = 8.0
+
+        [state_acquisition.capabilities]
+        polling_only = ["global.meters.power"]
+
+        [state_acquisition.field_policies."global.meters.power"]
+        cadence_seconds = 1.0
+        freshness_ttl_seconds = 2.0
+        tx_only = true
+        """
+    )
+
+    profile = load_rig(_write_toml(tmp_path, toml)).to_profile()
+    policy = profile.state_acquisition
+    power = FieldPath.global_("meters", "power")
+
+    assert policy is not None
+    assert policy.policy_for(power).tx_only is True
+    # A path with no field_policies override must not silently inherit
+    # tx_only=True from some other field's override.
+    assert policy.default_policy.tx_only is False
 
 
 def test_loader_rejects_polling_unsupported_fields(tmp_path: Path) -> None:
@@ -498,6 +550,16 @@ def test_ic7300_profile_enrolls_exact_supported_observation_rows() -> None:
         FieldPath.global_("operator_controls", "monitor_gain"),
         FieldPath.global_("operator_controls", "vox_gain"),
         FieldPath.global_("operator_controls", "anti_vox_gain"),
+        # MOR-1485: TX/PA meters. Statically pollable (the capability layer
+        # doesn't know about runtime TX/RX gating) even though power/swr/alc/
+        # comp only actually fire while ``tx_only`` reads true at runtime —
+        # see the dedicated tx_only-partitioned demand assertion below.
+        FieldPath.global_("meters", "power"),
+        FieldPath.global_("meters", "swr"),
+        FieldPath.global_("meters", "alc"),
+        FieldPath.global_("meters", "comp"),
+        FieldPath.global_("meters", "vd"),
+        FieldPath.global_("meters", "id"),
     }
 
     assert set(acquisition.pollable_paths()) == expected_pollable
@@ -547,12 +609,40 @@ def test_ic7300_profile_enrolls_exact_supported_observation_rows() -> None:
 
     serial_ceiling_hz = 1000.0 / _SERIAL_DEFAULT_CIV_MIN_INTERVAL_MS
     assert serial_ceiling_hz == 20.0
-    total_poll_demand_hz = sum(
+
+    # MOR-1485: TX/PA meters split the pollable set into an always-on
+    # (RX-state) share and a tx_only share that AcquisitionScheduler.
+    # due_requests only ever queries while PTT reads true (see
+    # test_acquisition_scheduler.py's due_polling_*tx_only* coverage for the
+    # gating behavior itself). The RX-state share is what MOR-1484's live
+    # medians (s_meter/ptt/freq) were measured against, so THAT figure is the
+    # one that must stay near the pre-existing ~19.933 q/s baseline -- not
+    # the transient TX-window total.
+    rx_state_demand_hz = sum(
         1.0 / acquisition.policy_for(path).cadence_seconds
         for path in acquisition.pollable_paths()
+        if not acquisition.policy_for(path).tx_only
     )
-    assert total_poll_demand_hz == pytest.approx(19.933, abs=0.001)
-    assert total_poll_demand_hz < serial_ceiling_hz
+    tx_only_demand_hz = sum(
+        1.0 / acquisition.policy_for(path).cadence_seconds
+        for path in acquisition.pollable_paths()
+        if acquisition.policy_for(path).tx_only
+    )
+    # Pre-existing baseline (MOR-1452) was 19.933 q/s, already only 0.067 q/s
+    # below the 20 q/s ceiling. MOR-1485 adds only Vd/Id (2 fields / 60.0s =
+    # 0.033 q/s) to the always-on RX-state total, spending under half of that
+    # remaining headroom (19.933 -> 19.967 q/s) and staying BELOW the
+    # ceiling — required, not just desirable, since exceeding it would
+    # necessarily slow every other polled field's real throughput and risk
+    # regressing the MOR-1484 medians this profile is measured against.
+    assert rx_state_demand_hz == pytest.approx(19.967, abs=0.001)
+    assert rx_state_demand_hz < serial_ceiling_hz
+    # Po/SWR/ALC/COMP: 4 fields / 1.0s = 4.0 q/s, ONLY while tx_only gating
+    # lets them through (PTT observed true) — a transient TX-window cost, not
+    # a steady-state one.
+    assert tx_only_demand_hz == pytest.approx(4.0, abs=0.001)
+    total_during_tx_hz = rx_state_demand_hz + tx_only_demand_hz
+    assert total_during_tx_hz == pytest.approx(23.967, abs=0.001)
 
     assert (
         acquisition.capability_for(


### PR DESCRIPTION
## Summary

IC-7300 serial never queried CI-V `0x15 0x11-0x16` (Po/SWR/ALC/COMP/Vd/Id): no `field_policies` entry meant `AcquisitionScheduler.due_requests()` never touched these paths. The query mapping (`IcomCivAcquisitionExecutor`/`_GLOBAL_METER_QUERY_SUBS`) and ingress decode (`_OBSERVABLE_CMD15_FIELDS`) already handled the whole `global.meters.*` family generically — ingress health was already proven by rigctld's one-shot reads flipping these fields to observed. The gap was purely acquisition membership.

Closes MOR-1485.

## Gating decision (owner ruling)

- **Po/SWR/ALC/COMP** are meaningful only during TX. A new `AcquisitionPolicy.tx_only` flag (data-driven, `tx_only = true` in the field's TOML `field_policies` table) is honored by `AcquisitionScheduler.due_requests()`: while PTT reads false the group is **skipped entirely**, not deduped/deferred — no query sent, cadence clock untouched — so a group that's been "due" throughout RX fires **immediately** the instant `tx_active=True` is passed in, rather than waiting a fresh cadence interval from TX-start. `web/radio_poller.py::_send_scheduler_requests` derives `tx_active` from `RadioState.ptt` (the same read `_pick_high_meter` already uses for the legacy LAN two-tier scheme).
- **Vd/Id** are supply telemetry — the radio answers them in RX too (proven), so they poll unconditionally (`tx_only` defaults `false`).

## Serial budget math (IC-7300 only; IC-7610 is LAN, unaffected)

The ~20 q/s software floor is `_SERIAL_DEFAULT_CIV_MIN_INTERVAL_MS` (50 ms/frame). Pre-existing RX-state demand was already `19.933 q/s` — only `0.067 q/s` of headroom below the ceiling.

- **Vd/Id** (always-on): 2 fields / 60.0 s cadence = `0.033 q/s` → RX-state total `19.933 → 19.967 q/s`, staying under the 20 q/s ceiling with margin to spare (60 s was chosen precisely because faster options — 5 s, 15 s — blow the remaining 0.067 q/s headroom; verified by `test_ic7300_profile_enrolls_exact_supported_observation_rows`'s new budget assertions).
- **Po/SWR/ALC/COMP** (`tx_only`): 4 fields / 1.0 s cadence = `4.0 q/s`, **only while transmitting** → zero steady-state RX cost, `23.967 q/s` transient total during TX. This is an accepted TX-window tradeoff (the ticket's whole point is these meters must populate during TX), not a regression of the MOR-1484 RX-state medians (s_meter 0.36s, ptt 0.46s, freq 1.3s observed) — those were measured under the ~19.933 q/s RX-state load, which our RX-state addition (+0.17%... actually +0.033/19.933 ≈ +0.17%) is far below the 53-80% gap MOR-1484 already found between configured and observed cadences.

## Cross-profile

- **IC-7610**: already fully done (`rigs/ic7610.toml` already declares all six meters unconditionally at LAN's cheap 0.2 s cadence, no `tx_only` needed there) — verified before touching anything, no changes made.
- **ic705/ic9700/x6100/tx500**: none have a `[state_acquisition]` section at all (not on the new scheduler) — out of scope.

## Frontend

None needed, confirmed before writing any TOML: `web/runtime_helpers.py`'s `_GLOBAL_METER_FIELDS = {"alc","power","swr","comp","vd","id"}` already generically projects `global.meters.*` into `ServerState.{power,swr,alc,comp,vd,id}Meter`, and the v2 panel (`MetersSurface.svelte`/`radio-view-model-adapter.ts`, #2412) already renders from there — TX-meter `relevant` flagging is driven by TX authority, not backend polling choices, so gating here is purely a serial-budget concern, not a correctness one.

## rigctld `l ALC` RPRT -1 (investigated, not fixed)

Real, well-defined gap: `ALC` is entirely absent from `rigctld/handler.py`'s `all_levels` set / `_level_path()` / response-formatting branches (unlike `SWR`/`RFPOWER_METER`/`COMP_METER`/`ID_METER`/`VD_METER`, each of which has one). `Radio.get_alc()` already exists (`commands/meters.py`). Fixing it touches 3-4 coordinated spots in the same function rather than a single line, so it's left for a follow-up ticket rather than expanding this change's footprint.

## Test plan

- [x] `uv run pytest tests/test_acquisition_scheduler.py tests/test_state_acquisition_policy.py -q` — new + existing tests green
- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — full suite, 9140 passed / 0 failed
- [x] `uv run ruff check src/ tests/` — zero violations
- [x] `uv run ruff format --check` on touched files — clean
- [x] `uv run mypy src/` — identical pre-existing 13 errors (none introduced)
- [x] `uv run lint-imports` — all 5 contracts kept

New/changed tests:
- `test_due_polling_skips_tx_only_cadence_group_while_not_tx_active`
- `test_due_polling_emits_tx_only_cadence_group_once_tx_active`
- `test_due_polling_tx_only_group_fires_immediately_when_tx_starts`
- `test_due_polling_tx_only_does_not_gate_non_tx_only_meter_in_same_call`
- `test_acquisition_policy_tx_only_defaults_false_and_round_trips`
- `test_loader_parses_tx_only_field_policy_flag`
- `test_schema_from_dict_rejects_unknown_and_coerced_values` (extended: `tx_only must be a bool`)
- `test_ic7300_profile_enrolls_exact_supported_observation_rows` (updated: 6 new pollable paths + RX-state/tx-only partitioned budget assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Review round 2 (verifier merge conditions)

- Skip-not-defer semantics are now BOUND by the test: the TX-start probe moved off the cadence boundary (now=411.5), so a defer-instead-of-skip mutation fails it (validated both directions by the verifier).
- The tx_active comment now cites the real mechanism (_handle_1c's deliberate PTT mirror dual-write, refreshed by this scheduler's own 0.3s ptt cadence) instead of the legacy-only _pick_high_meter precedent.
- **Framing note (verifier-required): the TX meters are an INDICATOR, not a protection interlock.** First Po/SWR frame lands ~0.4-0.9s after key-down (ptt observation median 0.35s + group drain + round trip). The radio's own SWR/PA protection acts in milliseconds; this readout is operator feedback, not a safety mechanism — MOR-1485 must not be cited as delivering SWR protection.
- Owner tuning question recorded (non-blocking): Id at 60s cadence means a typical 30s transmission can pass without a single PA-current sample; a tx_only ~1-2s companion tier for Id (or 30s for both Vd/Id) costs 0.07-0.13 q/s — inside lane noise. Ticketed for the owner's call.
