### PR TITLE
feat: scan controls usable with command-echoed state (MOR-1495)

### DIFF
--- a/frontend/src/components-v2/wiring/__tests__/semantic-ritxit-scan-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-ritxit-scan-wiring.component.test.ts
@@ -244,12 +244,26 @@ describe('the surface intents reach the shipped command vocabulary', () => {
     expect(sendCommand).toHaveBeenCalledExactlyOnceWith('set_rit_frequency', { freq: 0 });
   });
 
-  it('starting a scan sends scan_start with the last-observed type', () => {
+  // MOR-1495 review R2: type ownership moved to the surface's own local UI
+  // state (`selectedType`, default PROG/0x01) — START no longer depends on
+  // an OBSERVED scanType at all, which is what let a cold-start radio (no
+  // scan command ever issued) enable the control in the first place. See
+  // `RitXitScanSurface.svelte`'s file header and
+  // `semantic/__tests__/RitXitScanSurface.test.ts` for the full story.
+  // Cold-start (scanType never reported at all) is covered at the pure
+  // surface layer — `semantic/__tests__/RitXitScanSurface.test.ts` — where
+  // the fixture builder can express an unobserved field directly; this
+  // file's shared `liveState()` fixture always seeds every path `fresh`
+  // (see its own doc comment), so it cannot express that case. This test
+  // proves the piece THIS layer owns instead: even when the store DOES
+  // carry an observed scanType, the real command bus receives the
+  // surface's own default, never the observed value.
+  it('starting a scan sends scan_start with the surface\'s own default type, not the observed one', () => {
     useState(liveState({ scanning: false, scanType: 0x22 } as Partial<ServerState>));
     render();
     el('scan-toggle')!.click();
     flushSync();
-    expect(sendCommand).toHaveBeenCalledExactlyOnceWith('scan_start', { type: 0x22 });
+    expect(sendCommand).toHaveBeenCalledExactlyOnceWith('scan_start', { type: 0x01 });
   });
 
   it('stopping a scan sends scan_stop', () => {

--- a/frontend/src/semantic/RitXitScanSurface.svelte
+++ b/frontend/src/semantic/RitXitScanSurface.svelte
@@ -38,9 +38,23 @@
   per-field "ever reported", so a partial reporter surfaces exactly the
   fields it has reported, no more — expected, not a bug. Scan TYPE and
   RESUME-MODE label tables are UI-only in v2 and are deliberately not
-  reproduced here (out of scope, not backed by any 8A fact): scan is
-  restarted with the last OBSERVED type, never a fabricated default, and
-  resume mode is cycled by its raw masked value.
+  reproduced here (out of scope, not backed by any 8A fact): resume mode
+  is cycled by its raw masked value.
+
+  SCAN TYPE OWNERSHIP (MOR-1495 review R2 — verifier-caught bootstrap
+  deadlock). CI-V 0x0E is SET-ONLY: `scanType` can never become "known"
+  before a scan has ever been started, so the original "restart with the
+  last OBSERVED type, never a fabricated default" design meant NOTHING
+  could ever be the first start — START was permanently disabled on a
+  fresh connect, forever, because the only thing that could ever make
+  `scanType` known was a scan_start command the disabled button could
+  never send. `selectedType` below breaks that cycle: it is local UI
+  state (v2 `ScanPanel`'s own `selectedType` shape/default — PROG, 0x01),
+  not a claimed-observed radio fact, so sending it never fabricates an
+  "observed" value — it is honestly what it is, an operator/default
+  selection. `scanType`'s OWN displayed reading (`scan-type-value`) is
+  untouched by this and still shows only the genuinely last-observed
+  value, `UNKNOWN_TEXT` until one exists.
 -->
 <script module lang="ts">
   import type { RitXitField, ScanField } from './radio-view-model';
@@ -51,6 +65,8 @@
   export const OFFSET_MIN = -9999;
   export const OFFSET_MAX = 9999;
   export const OFFSET_STEP = 50;
+  /** v2 `ScanPanel`'s own default scan type for the next START — PROG. */
+  export const DEFAULT_SCAN_TYPE = 0x01;
 
   export const usable = (f: RitXitField<unknown> | ScanField<unknown>): boolean =>
     f.availability.structural && f.availability.operational && f.reading.status === 'known';
@@ -88,6 +104,10 @@
   let activeKnown = $derived(view.activeReceiver.status === 'known');
   let scanningOn = $derived(sc !== undefined && usable(sc.scanning)
     && sc.scanning.reading.status === 'known' && sc.scanning.reading.value === true);
+  /** Local UI selection for the NEXT scan START (MOR-1495 review R2 — see
+   *  file header). NOT an observed radio fact, so it needs no `usable()`
+   *  gate: it is honest about what it is from the moment it exists. */
+  let selectedType = $state(DEFAULT_SCAN_TYPE);
 
   // F2 (fix round, verify-MOR-1308): gated on the field's OWN observation,
   // not just the wrong-VFO guard — mirrors `TxAuxSurface.svelte`'s `toggle`.
@@ -110,7 +130,9 @@
   function toggleScan(): void {
     if (!sc || !usable(sc.scanning)) return;
     if (scanningOn) { onScanStop?.(); return; }
-    if (usable(sc.scanType) && sc.scanType.reading.status === 'known') onScanStart?.(sc.scanType.reading.value);
+    // MOR-1495 review R2: START no longer depends on an OBSERVED scanType
+    // (see file header) — it always sends the operator/default selection.
+    onScanStart?.(selectedType);
   }
   function cycleResume(): void {
     if (!sc || !usable(sc.scanResumeMode) || sc.scanResumeMode.reading.status !== 'known') return;
@@ -159,7 +181,7 @@
           <span data-testid="scan-status" data-observed={usable(sc.scanning)}>{textOf(sc.scanning)}</span>
           <button
             type="button" data-testid="scan-toggle" aria-pressed={pressedOf(sc.scanning)}
-            disabled={!usable(sc.scanning) || (!scanningOn && !usable(sc.scanType))}
+            disabled={!usable(sc.scanning)}
             onclick={toggleScan}
           >{scanningOn ? 'STOP' : 'START'}</button>
         {/if}

--- a/frontend/src/semantic/__tests__/RitXitScanSurface.test.ts
+++ b/frontend/src/semantic/__tests__/RitXitScanSurface.test.ts
@@ -400,7 +400,7 @@ function knownScan<T>(value: T, availability: Availability = ON): ScanField<T> {
   return { reading: { status: 'known', value }, availability };
 }
 
-describe('scan start/stop: guarded on a KNOWN scanning state, start also on a known type', () => {
+describe('scan start/stop: guarded on a KNOWN scanning state only (MOR-1495 review R2)', () => {
   it('disables the toggle while scanning itself is unobserved', () => {
     const r = render(withSc({ scanning: unreadScan<boolean>() }));
     expect(r.el('scan-toggle')!.hasAttribute('disabled')).toBe(true);
@@ -418,35 +418,35 @@ describe('scan start/stop: guarded on a KNOWN scanning state, start also on a kn
     r.dispose();
   });
 
-  it('disables start while idle and scanType has never been reported (no type to resume)', () => {
+  // Review R2 (verifier-caught bootstrap deadlock): CI-V 0x0E is SET-ONLY,
+  // so `scanType` can never become "known" before a scan has ever been
+  // started — gating START on it made a cold start impossible, since
+  // nothing could ever send the first scan_start that would have made the
+  // field known. `scanning` alone is enough to enable START now; the type
+  // is owned locally (below), never observed.
+  it('does NOT disable start merely because scanType has never been reported', () => {
     const r = render(withSc({ scanning: knownScan(false), scanType: unreadScan<number>(OFF_AVAIL) }));
-    expect(r.el('scan-toggle')!.hasAttribute('disabled')).toBe(true);
+    expect(r.el('scan-toggle')!.hasAttribute('disabled')).toBe(false);
     r.dispose();
   });
 
-  it('starts the last-observed scan type, never a fabricated one', () => {
-    const onScanStart = vi.fn();
-    const r = render(withSc({ scanning: knownScan(false), scanType: knownScan(0x22) }), { onScanStart });
-    r.el('scan-toggle')!.click();
-    flushSync();
-    expect(onScanStart).toHaveBeenCalledExactlyOnceWith(0x22);
-    r.dispose();
-  });
-
-  // F3 (fix round, verify-MOR-1308 M10): `scanning` is KNOWN idle here (the
-  // button IS disabled in this state, since `!scanningOn && !usable(scanType)`
-  // — so the attribute alone would satisfy a naive assertion). The bypass
-  // dispatch is the only way to prove the handler itself never falls through
-  // to a fabricated `type: 0`, unlike the sibling test above which only
-  // covers the `scanning`-unobserved early-return path.
-  it('never fabricates type 0 via a bypassed click while idle and scanType is unobserved', () => {
+  it('starts with the surface\'s own default type (PROG, 0x01) via a normal click, from a cold start where scanType has never been reported', () => {
     const onScanStart = vi.fn();
     const r = render(
       withSc({ scanning: knownScan(false), scanType: unreadScan<number>(OFF_AVAIL) }), { onScanStart },
     );
-    bypassClick(r.el('scan-toggle')!);
+    r.el('scan-toggle')!.click();
     flushSync();
-    expect(onScanStart).not.toHaveBeenCalled();
+    expect(onScanStart).toHaveBeenCalledExactlyOnceWith(0x01);
+    r.dispose();
+  });
+
+  it('starts with the local default even when a DIFFERENT type happens to be the last-observed one — type is never read from the observed fact', () => {
+    const onScanStart = vi.fn();
+    const r = render(withSc({ scanning: knownScan(false), scanType: knownScan(0x22) }), { onScanStart });
+    r.el('scan-toggle')!.click();
+    flushSync();
+    expect(onScanStart).toHaveBeenCalledExactlyOnceWith(0x01);
     r.dispose();
   });
 

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -1118,6 +1118,51 @@ class RadioPoller:
         else:
             self._state_store.apply(observation)
 
+    def _apply_global_command_echo_observation(
+        self,
+        name: str,
+        value: Any,
+        *,
+        family: str = "slow_state",
+        command_id: str | None = None,
+        source: CommandSource | None = None,
+        session_id: str | None = None,
+        command_service: CommandService | None = None,
+        provider_generation: int,
+    ) -> None:
+        """Apply a command-sourced (unconfirmable) value to the StateStore.
+
+        Sibling of :meth:`_apply_global_control_observation` for fields the
+        radio has NO read command for at all (e.g. IC-7300 scan, CI-V 0x0E —
+        CAT-audit confirmed SET-only, MOR-1495), so no follow-up GET can ever
+        turn this into a genuine readback the way NB depth/width or the
+        MOD-input sources do. Labelled ``command_response`` — never
+        ``poll_response`` — so the StateStore's own provenance stays honest
+        about the fact that this value was never confirmed by the radio, even
+        though the owner-ruled web presentation shows it plainly with no
+        "commanded, not confirmed" marker (MOR-1495 ruling). A front-panel
+        scan stop is invisible to the web until the operator presses STOP in
+        the web — accepted limitation, not fixable without a read command.
+        """
+        observation = Observation(
+            path=FieldPath.global_(family, name),
+            value=value,
+            source=SourceMetadata(
+                source="command_response",
+                provider="web_poller",
+                native_id=f"{name}_command_echo",
+                command_source=source,
+                session_id=session_id,
+            ),
+            timestamp_monotonic=time.monotonic(),
+            correlation_id=f"{command_id}:{name}" if command_id else None,
+            provider_generation=provider_generation,
+        )
+        if command_service is not None:
+            command_service.apply_observation(observation)
+        else:
+            self._state_store.apply(observation)
+
     async def _fetch_nb_controls(self) -> None:
         """One-shot readback of NB depth/width into the StateStore (MOR-491-B).
 
@@ -2071,17 +2116,51 @@ class RadioPoller:
                 if self._radio_state:
                     self._radio_state.scanning = True
                     self._radio_state.scan_type = st
+                # CI-V 0x0E is SET-ONLY on IC-7300 (CAT audit: no read
+                # command) — a command-echoed observation is the only way
+                # this ever leaves "missing" in the public fieldStatus
+                # projection (MOR-1495).
+                for name, value in (("scanning", True), ("scan_type", st)):
+                    self._apply_global_command_echo_observation(
+                        name,
+                        value,
+                        command_id=command_id,
+                        source=command_source,
+                        session_id=session_id,
+                        command_service=command_service,
+                        provider_generation=provider_generation,
+                    )
             case ScanStop():
                 await _r.scan_stop()
                 if self._radio_state:
                     self._radio_state.scanning = False
                     self._radio_state.scan_type = 0
+                for name, value in (("scanning", False), ("scan_type", 0)):
+                    self._apply_global_command_echo_observation(
+                        name,
+                        value,
+                        command_id=command_id,
+                        source=command_source,
+                        session_id=session_id,
+                        command_service=command_service,
+                        provider_generation=provider_generation,
+                    )
             case ScanSetDfSpan(span=span):
                 await _r.scan_set_df_span(span)
             case ScanSetResume(mode=resume_mode):
                 await _r.scan_set_resume(resume_mode)
+                masked = resume_mode & 0x0F
                 if self._radio_state:
-                    self._radio_state.scan_resume_mode = resume_mode & 0x0F
+                    self._radio_state.scan_resume_mode = masked
+                self._apply_global_command_echo_observation(
+                    "scan_resume_mode",
+                    masked,
+                    command_id=command_id,
+                    source=command_source,
+                    session_id=session_id,
+                    command_service=command_service,
+                    provider_generation=provider_generation,
+                )
             case SetDataMode(mode=mode, receiver=rx):
                 self._ensure_receiver_supported(rx, operation="set_data_mode")
                 if not 0 <= mode <= 3:

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -260,6 +260,29 @@ _MOD_INPUT_FIELDS: tuple[str, ...] = (
     "data3_mod_input",
 )
 
+# MOR-1495 review R2: the assumed scan-resume-mode default seeded at
+# connect (masked, i.e. already ``& 0x0F`` — matches how ``ScanSetResume``
+# stores it). No ``rigs/*.toml`` declares a scan-resume default, and CI-V
+# 0x0E has no read command to observe the radio's own power-on value, so
+# this can only ever be an ASSUMPTION, never a confirmed fact.
+#
+# A secondary source (Icom IC-7300 Full Manual, "Scan Set Mode" section, as
+# indexed by manualslib.com) describes SCAN RESUME as ON/OFF and states a
+# factory default of ON — but this was NOT independently cross-checked
+# against Icom's own primary PDF (this environment's fetch tooling could
+# not retrieve it: it exceeds the 10 MB single-fetch limit), and that
+# secondary source does not pin which CI-V sub-byte (0xD1/0xD2/0xD3)
+# corresponds to "ON" with the confidence this constant would need.
+# Seeding 0xD0 (OFF, masked 0x00) is the CONSERVATIVE choice instead: it is
+# the same "nothing is happening until commanded" assumption already made
+# for ``scanning=False`` immediately below, and being wrong about it is
+# low-stakes — it only affects a cosmetic default shown before the operator
+# ever cycles resume mode via the surface's own RESUME control.
+# TODO(MOR-1495 follow-up): confirm the true factory default against a
+# bench IC-7300 after a full/master reset (or Icom's own CI-V reference,
+# not just the operating manual) and correct this seed if it differs.
+_SCAN_RESUME_MODE_DEFAULT_MASKED = 0x00  # assumed 0xD0 (OFF) & 0x0F
+
 
 def _audio_tx_codec_and_rate(radio: Any) -> tuple[AudioCodec | None, int]:
     """Legacy TX-format resolution for radios WITHOUT the neutral
@@ -1163,6 +1186,57 @@ class RadioPoller:
         else:
             self._state_store.apply(observation)
 
+    def _seed_scan_facts_at_connect(self) -> None:
+        """Seed ``scanning``/``scan_resume_mode`` once at connect (and again
+        on soft-reconnect) so the scan START control can ever leave the
+        "missing" ``fieldStatus`` gate that keeps it disabled (MOR-1495
+        review R2 — verifier-caught bootstrap deadlock).
+
+        The round-1 fix (:meth:`_apply_global_command_echo_observation`,
+        called from the ``ScanStart``/``ScanStop``/``ScanSetResume`` command
+        handlers) is the ONLY writer of these fields — but the ONLY trigger
+        for those commands is the UI, and the UI's own ``usable()`` gate
+        (``RitXitScanSurface.svelte``) requires the fields to already be
+        known before it will enable the button that would send the very
+        first command. Nothing breaks that cycle without an explicit seed.
+
+        PURE LOCAL SEED — never sends anything to the radio. Unlike
+        :meth:`establish_vfo_identity` (its sibling call site in
+        :meth:`_run`'s startup section and in the server's reconnect path),
+        which commands VFO A over the wire and therefore pauses while an
+        external CAT session owns it, this seed touches only the local
+        StateStore and needs no such guard.
+
+        "Not scanning until we command it" is an ASSUMED-UNTIL-COMMANDED
+        fact — the same accepted-dishonesty class as this PR's documented
+        front-panel-scan-stop-is-invisible limitation, not a claim about
+        anything actually observed on the radio. A soft-reconnect reseeds
+        it unconditionally rather than trusting a pre-reconnect commanded
+        value, mirroring ``reset_vfo_session()``'s unconditional discard of
+        ``active_slot`` on every reconnect (MOR-1443) — the true state is
+        unknown again after any link drop.
+
+        ``scan_type`` is deliberately NOT seeded here: an assumed type
+        would let an unconfirmed guess masquerade as an observed radio
+        fact, which is exactly what the surface's other honesty gates
+        exist to prevent. The START flow instead owns the type as local UI
+        state (``RitXitScanSurface.svelte``'s own ``selectedType``,
+        mirroring v2 ``ScanPanel``'s shape/default), sent explicitly with
+        every ``scan_start`` command — so START no longer depends on an
+        observed type at all.
+        """
+        provider_generation = self._provider_generation()
+        self._apply_global_command_echo_observation(
+            "scanning",
+            False,
+            provider_generation=provider_generation,
+        )
+        self._apply_global_command_echo_observation(
+            "scan_resume_mode",
+            _SCAN_RESUME_MODE_DEFAULT_MASKED,
+            provider_generation=provider_generation,
+        )
+
     async def _fetch_nb_controls(self) -> None:
         """One-shot readback of NB depth/width into the StateStore (MOR-491-B).
 
@@ -1309,6 +1383,19 @@ class RadioPoller:
             # happening is worth surfacing above debug (review R2).
             logger.warning(
                 "radio-poller: auto VFO identity establish failed", exc_info=True
+            )
+
+        # MOR-1495 review R2: scan (CI-V 0x0E) is SET-ONLY, so nothing else
+        # ever seeds scanning/scan_resume_mode — without this, the web UI's
+        # scan controls stay disabled forever (bootstrap deadlock: the only
+        # writer of these fields is a scan command, and the only trigger for
+        # a scan command is a UI control gated on these fields already being
+        # known). Pure local seed — never touches the radio.
+        try:
+            self._seed_scan_facts_at_connect()
+        except Exception:
+            logger.warning(
+                "radio-poller: scan facts seed failed", exc_info=True
             )
 
         try:

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -1394,9 +1394,7 @@ class RadioPoller:
         try:
             self._seed_scan_facts_at_connect()
         except Exception:
-            logger.warning(
-                "radio-poller: scan facts seed failed", exc_info=True
-            )
+            logger.warning("radio-poller: scan facts seed failed", exc_info=True)
 
         try:
             while True:

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -2252,6 +2252,25 @@ class WebServer:
                             "reconnect: auto VFO identity establish failed",
                             exc_info=True,
                         )
+                    # MOR-1495 review R2: RadioPoller._run()'s one-time
+                    # startup section (same reasoning as
+                    # establish_vfo_identity above) never re-fires after a
+                    # soft-reconnect either, so re-seed scanning/
+                    # scan_resume_mode here too — otherwise a reconnect after
+                    # any scan command would leave the web trusting a
+                    # possibly-stale pre-reconnect value forever. Pure local
+                    # seed, unlike the VFO-identity call above — never writes
+                    # to the radio, so it needs no external-CAT-session guard
+                    # and cannot itself fail against the wire; the try/except
+                    # here only guards the StateStore call for consistency
+                    # with its sibling.
+                    try:
+                        self._radio_poller._seed_scan_facts_at_connect()
+                    except Exception:
+                        logger.warning(
+                            "reconnect: scan facts seed failed",
+                            exc_info=True,
+                        )
             # Re-enable scope after refetch completes.
             # Do NOT gate on self._radio_ready(): that property waits for
             # CI-V broadcast data, but on IC-7610 in the "deaf" firmware

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -53,6 +53,9 @@ from rigplane.web.radio_poller import (
     QuickDwTrigger,
     QuickSplitTrigger,
     RadioPoller,
+    ScanSetResume,
+    ScanStart,
+    ScanStop,
     SelectVfo,
     SendCiv,
     SetAfLevel,
@@ -236,6 +239,10 @@ def _make_radio(active: str = "MAIN", *, model: str = "IC-7610") -> MagicMock:
     radio.set_dual_watch = AsyncMock()
     radio.set_split = AsyncMock()
     radio.equalize_main_sub = AsyncMock()
+    radio.scan_start = AsyncMock()
+    radio.scan_stop = AsyncMock()
+    radio.scan_set_resume = AsyncMock()
+    radio.scan_set_df_span = AsyncMock()
     radio.swap_main_sub = AsyncMock()
 
     # Receiver-tier capabilities (issue #1170 / #1172).  ``select_receiver``
@@ -4619,3 +4626,124 @@ async def test_tx_target_stays_known_across_several_ttl_periods_on_healthy_radio
             assert payload["txTarget"]["status"] == "known", (
                 f"tx_target left known at t={elapsed:.2f}s: {payload['txTarget']}"
             )
+
+
+# ---------------------------------------------------------------------------
+# MOR-1495: scan START/RESUME command-echoed state.
+#
+# CI-V 0x0E (scan) is SET-ONLY on IC-7300 — the CAT audit confirms there is
+# no read command for scanning/scan type/resume mode, so the continuous
+# poller can never observe these fields the way it observes e.g. tuning_step
+# or cw_spot. Before this fix, ``ScanStart``/``ScanStop``/``ScanSetResume``
+# only mutated the legacy ``RadioState`` mirror — never applied a StateStore
+# observation — so ``global.slow_state.scanning``/``scan_type``/
+# ``scan_resume_mode`` stayed permanently ``missing`` in the public
+# ``fieldStatus`` projection (``runtime_helpers._build_snapshot_field_status``
+# seeds every ``_GLOBAL_SLOW_STATE_FIELDS`` entry ``missing`` until a real
+# observation lands). The frontend's ``usable()`` gate
+# (``RitXitScanSurface.svelte``) requires ``availability.operational`` —
+# i.e. ``fieldStatus[...].availability == 'available'`` — so the scan
+# START/RESUME controls stayed permanently disabled with "—" placeholders.
+#
+# Fix: apply a direct StateStore observation from the command itself (the
+# same "no confirming read, apply from the command's own known value" idiom
+# ``_read_mod_input``/``_apply_global_control_observation`` already use for
+# other global menu items the continuous poller cannot track), labelled
+# honestly as ``command_response`` (not ``poll_response``) since it is a
+# commanded value, not a radio readback. Owner ruling (MOR-1495): the UI
+# renders this plainly — no "commanded, not confirmed" marker — but the
+# SourceMetadata itself stays honest about provenance.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_scan_start_echoes_state_store_observation_and_public_state() -> None:
+    """ScanStart applies scanning=True + scan_type observations, not just the mirror."""
+    from rigplane.web.runtime_helpers import build_public_state_payload_from_snapshot
+
+    radio = _make_radio(active="MAIN", model="IC-7300")
+    store = StateStore()
+    state = RadioState()
+    poller = RadioPoller(radio, CommandQueue(), radio_state=state, state_store=store)
+
+    await poller._execute(ScanStart(scan_type=0x01))  # noqa: SLF001
+
+    radio.scan_start.assert_awaited_once_with(mode=0x01)
+    snapshot = store.snapshot()
+    assert snapshot.field(FieldPath.global_("slow_state", "scanning")).value is True
+    assert snapshot.field(FieldPath.global_("slow_state", "scan_type")).value == 0x01
+    # Legacy RadioState mirror stays coherent for compatibility consumers.
+    assert state.scanning is True
+    assert state.scan_type == 0x01
+
+    payload = build_public_state_payload_from_snapshot(
+        snapshot, radio=None, receiver_count=1
+    )
+    assert payload["scanning"] is True
+    assert payload["scanType"] == 0x01
+    assert payload["fieldStatus"]["scanning"]["availability"] == "available"
+    assert payload["fieldStatus"]["scanType"]["availability"] == "available"
+
+
+@pytest.mark.asyncio
+async def test_scan_stop_echoes_state_store_observation_and_public_state() -> None:
+    """ScanStop applies scanning=False + scan_type=0 observations."""
+    from rigplane.web.runtime_helpers import build_public_state_payload_from_snapshot
+
+    radio = _make_radio(active="MAIN", model="IC-7300")
+    store = StateStore()
+    state = RadioState()
+    poller = RadioPoller(radio, CommandQueue(), radio_state=state, state_store=store)
+
+    await poller._execute(ScanStart(scan_type=0x01))  # noqa: SLF001
+    await poller._execute(ScanStop())  # noqa: SLF001
+
+    radio.scan_stop.assert_awaited_once_with()
+    snapshot = store.snapshot()
+    assert snapshot.field(FieldPath.global_("slow_state", "scanning")).value is False
+    assert snapshot.field(FieldPath.global_("slow_state", "scan_type")).value == 0
+    assert state.scanning is False
+    assert state.scan_type == 0
+
+    payload = build_public_state_payload_from_snapshot(
+        snapshot, radio=None, receiver_count=1
+    )
+    assert payload["scanning"] is False
+    assert payload["fieldStatus"]["scanning"]["availability"] == "available"
+
+
+@pytest.mark.asyncio
+async def test_scan_set_resume_echoes_masked_state_store_observation() -> None:
+    """ScanSetResume applies the ``& 0x0F``-masked value, matching the mirror."""
+    radio = _make_radio(active="MAIN", model="IC-7300")
+    store = StateStore()
+    state = RadioState()
+    poller = RadioPoller(radio, CommandQueue(), radio_state=state, state_store=store)
+
+    await poller._execute(ScanSetResume(mode=0xD2))  # noqa: SLF001
+
+    radio.scan_set_resume.assert_awaited_once_with(0xD2)
+    snapshot = store.snapshot()
+    field = snapshot.field(FieldPath.global_("slow_state", "scan_resume_mode"))
+    assert field.value == 0x02
+    assert state.scan_resume_mode == 0x02
+
+
+@pytest.mark.asyncio
+async def test_scan_command_echo_is_not_labelled_a_poll_readback() -> None:
+    """Provenance stays honest: a commanded echo is not a ``poll_response``.
+
+    Distinguishes the fix from a naive reuse of
+    ``_apply_global_control_observation``'s default ``poll_response``/
+    ``*_readback`` labelling, which would misrepresent an unconfirmable
+    SET-only command as a genuine radio readback.
+    """
+    radio = _make_radio(active="MAIN", model="IC-7300")
+    store = StateStore()
+    poller = RadioPoller(radio, CommandQueue(), radio_state=RadioState(), state_store=store)
+
+    await poller._execute(ScanStart(scan_type=0x01))  # noqa: SLF001
+
+    field = store.snapshot().field(FieldPath.global_("slow_state", "scanning"))
+    assert field.source.source != "poll_response"
+    assert "readback" not in (field.source.native_id or "")

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -4740,7 +4740,9 @@ async def test_scan_command_echo_is_not_labelled_a_poll_readback() -> None:
     """
     radio = _make_radio(active="MAIN", model="IC-7300")
     store = StateStore()
-    poller = RadioPoller(radio, CommandQueue(), radio_state=RadioState(), state_store=store)
+    poller = RadioPoller(
+        radio, CommandQueue(), radio_state=RadioState(), state_store=store
+    )
 
     await poller._execute(ScanStart(scan_type=0x01))  # noqa: SLF001
 

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -4749,3 +4749,102 @@ async def test_scan_command_echo_is_not_labelled_a_poll_readback() -> None:
     field = store.snapshot().field(FieldPath.global_("slow_state", "scanning"))
     assert field.source.source != "poll_response"
     assert "readback" not in (field.source.native_id or "")
+
+
+# ---------------------------------------------------------------------------
+# MOR-1495 review R2: the round-1 fix above was necessary but not sufficient.
+#
+# The verifier caught a bootstrap deadlock: the command-echo observation is
+# the ONLY writer of scanning/scanType/scanResumeMode, but the only trigger
+# for a ScanStart/ScanStop/ScanSetResume command is the UI — and the UI's
+# ``usable()`` gate (``RitXitScanSurface.svelte``) requires those same
+# fields to already be "known" before it will enable the controls that
+# would issue the very first command. A fresh server (nothing ever
+# commanded) therefore stays grey forever: nothing can ever be the "first"
+# scan command, because nothing can enable the button that sends it.
+#
+# Fix: seed ``scanning=False`` and ``scan_resume_mode=<assumed default>``
+# ONCE at connect (poller startup) and again on soft-reconnect — the same
+# call-site pattern ``establish_vfo_identity`` already uses for the
+# analogous "some radios can never learn X passively" problem (MOR-1443).
+# This is a PURE LOCAL SEED: it never sends anything to the radio, so
+# (unlike ``establish_vfo_identity``, which writes VFO A over the wire) it
+# needs no external-CAT-session guard. "Not scanning until we command it"
+# is an ASSUMED-UNTIL-COMMANDED fact, the same accepted-dishonesty class as
+# the front-panel-scan-stop-is-invisible limitation this PR already
+# documents.
+#
+# ``scan_type`` is deliberately NOT seeded — an assumed type would let an
+# unconfirmed guess masquerade as an observed radio fact, which is exactly
+# what the surface's other honesty gates exist to prevent. Instead the
+# START flow now owns the type as local UI state (v2 ``ScanPanel``'s own
+# ``selectedType`` shape/default, PROG = 0x01), sent explicitly with every
+# ``scan_start`` — see the frontend changes in
+# ``frontend/src/semantic/RitXitScanSurface.svelte``.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_scan_facts_seeded_at_connect_break_the_bootstrap_deadlock() -> None:
+    """From an EMPTY store, no scan command EVER issued, poller startup
+    seeding alone must make scanning/scanResumeMode 'available' — otherwise
+    nothing else ever will, and the frontend's usable() gate can never open.
+    """
+    from rigplane.web.runtime_helpers import build_public_state_payload_from_snapshot
+
+    radio = _make_radio(active="MAIN", model="IC-7300")
+    store = StateStore()
+    poller = RadioPoller(
+        radio, CommandQueue(), radio_state=RadioState(), state_store=store
+    )
+
+    # No ScanStart/ScanStop/ScanSetResume ever executed — pure startup seed,
+    # exactly what runs once from RadioPoller._run()'s one-time section.
+    poller._seed_scan_facts_at_connect()  # noqa: SLF001
+
+    payload = build_public_state_payload_from_snapshot(
+        store.snapshot(), radio=None, receiver_count=1
+    )
+    assert payload["scanning"] is False
+    assert payload["fieldStatus"]["scanning"]["availability"] == "available"
+    assert payload["fieldStatus"]["scanResumeMode"]["availability"] == "available"
+    # scan_type stays unseeded — the surface owns it locally instead (below).
+    assert payload["fieldStatus"]["scanType"]["availability"] == "missing"
+    radio.scan_start.assert_not_awaited()
+    radio.scan_stop.assert_not_awaited()
+    radio.scan_set_resume.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_scan_facts_seed_is_a_pure_local_seed_no_radio_write() -> None:
+    """The seed must never touch the wire — only ``establish_vfo_identity``
+    (which this call site sits beside) is a commanded radio write; this is
+    the opposite case by design (MOR-1495 review R2 point 5)."""
+    radio = _make_radio(active="MAIN", model="IC-7300")
+    store = StateStore()
+    poller = RadioPoller(
+        radio, CommandQueue(), radio_state=RadioState(), state_store=store
+    )
+
+    poller._seed_scan_facts_at_connect()  # noqa: SLF001
+
+    radio.send_civ.assert_not_awaited()
+    assert radio.method_calls == []
+
+
+def test_scan_facts_seed_labelled_command_response_not_poll_response() -> None:
+    """Provenance stays honest for the seed too, mirroring the command-echo
+    test above — a local assumption is not a genuine radio readback."""
+    store = StateStore()
+    poller = RadioPoller(
+        _make_radio(active="MAIN", model="IC-7300"),
+        CommandQueue(),
+        radio_state=RadioState(),
+        state_store=store,
+    )
+
+    poller._seed_scan_facts_at_connect()  # noqa: SLF001
+
+    for name in ("scanning", "scan_resume_mode"):
+        field = store.snapshot().field(FieldPath.global_("slow_state", name))
+        assert field.source.source != "poll_response"

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -2881,6 +2881,45 @@ async def test_on_radio_reconnect_establishes_vfo_identity_after_readiness_gate(
 
 
 @pytest.mark.asyncio
+async def test_on_radio_reconnect_reseeds_scan_facts() -> None:
+    """MOR-1495 review R2: the scan-facts seed must re-run on every
+    soft-reconnect too, sitting right beside ``establish_vfo_identity`` in
+    the same ``finally`` block. ``RadioPoller._run()``'s one-time startup
+    section never fires again after a soft-reconnect (same reasoning as the
+    VFO-identity call above), so without this the scan controls would only
+    ever unlock once, at process start, and a reconnect would leave the web
+    trusting whatever pre-reconnect value happened to survive forever.
+    """
+    radio = _scope_radio(ready=False)
+    radio._fetch_initial_state = AsyncMock()
+    radio.profile = resolve_radio_profile(model="IC-7300")
+    radio.model = radio.profile.model
+    srv = WebServer(radio)
+
+    store = StateStore()
+    poller = RadioPoller(radio, CommandQueue(), state_store=store)
+    poller.establish_vfo_identity = AsyncMock()  # type: ignore[method-assign]
+    seed_call_count = 0
+    real_seed = poller._seed_scan_facts_at_connect  # noqa: SLF001
+
+    def _tracking_seed() -> None:
+        nonlocal seed_call_count
+        seed_call_count += 1
+        real_seed()
+
+    poller._seed_scan_facts_at_connect = _tracking_seed  # type: ignore[method-assign]  # noqa: SLF001
+    srv._radio_poller = poller  # noqa: SLF001
+
+    srv._on_radio_reconnect()  # noqa: SLF001
+    await asyncio.sleep(0.05)  # let the refetch task complete
+
+    assert seed_call_count == 1
+    field = store.snapshot().field(FieldPath.global_("slow_state", "scanning"))
+    assert field.value is False
+    assert field.source.source != "poll_response"
+
+
+@pytest.mark.asyncio
 async def test_ensure_scope_enabled_defers_enable_when_radio_not_ready() -> None:
     radio = _scope_radio(ready=False)
     srv = WebServer(radio)


### PR DESCRIPTION
## Summary

The scan START/RESUME controls in the RIT/XIT + scan semantic surface were
permanently disabled with "—" placeholders on IC-7300. Investigation found
both the frontend (`RitXitScanSurface.svelte`, its wiring in
`SemanticRadioSurfaces.svelte`, and the `scan_start`/`scan_stop`/
`scan_set_resume` intents) and the backend command dispatch path
(`control.py` handler → `radio_poller.py` → CI-V 0x0E builders in
`commands/vfo.py`) already existed end to end and were already
well-tested (`semantic-ritxit-scan-wiring.component.test.ts`).

**Root cause**: `ScanStart`/`ScanStop`/`ScanSetResume` in
`radio_poller.py` only mutated the legacy `RadioState` mirror, never
applied a `StateStore` observation. The web's public `fieldStatus`
projection (`runtime_helpers._build_snapshot_field_status`) seeds every
`_GLOBAL_SLOW_STATE_FIELDS` entry `missing` by default and only flips it
to `available` once a real observation lands. Every *other* field in
that set gets one — via continuous CI-V polling, a one-shot readback
getter (NB depth/width, MOD-input sources), or a confirmed
command-response (VFO slot binding). Scan has none of those: **CI-V
0x0E is SET-ONLY on the IC-7300 — the CAT audit confirms there is no
read/query command for scanning, scan type, or resume mode** — so
`scanning`/`scanType`/`scanResumeMode` stayed `missing` forever, and the
frontend's `usable()` gate (which requires `availability.operational`)
kept the controls disabled.

**Round-1 fix**: apply a command-sourced `StateStore` observation directly
from the command handler, via a new `_apply_global_command_echo_observation`
helper — a sibling of the existing `_apply_global_control_observation`
idiom already used for other un-pollable global menu items. Labelled
`source="command_response"` (never `"poll_response"`), so the
StateStore's own provenance metadata stays honest that this value was
never confirmed by the radio, even though the **owner-ruled** web
presentation shows it plainly with **no "commanded, not confirmed"
marker**.

## Round 2: bootstrap deadlock

Round-1 was necessary but not sufficient. The command-echo observation it
added is the **only** writer of `scanning`/`scanType`/`scanResumeMode` —
but the only trigger for a scan command is the UI, and the UI's own
`usable()` gate requires those same fields to already be known before it
will enable the controls that would send the very first command. A fresh
server (nothing ever commanded) stayed grey forever: nothing could ever be
the "first" scan command, because nothing could enable the button that
sends it. Round-1's tests missed this because they called
`poller._execute()` directly, bypassing the UI gate entirely.

**Fix**, following the `establish_vfo_identity` precedent (MOR-1443) for
"some CI-V facts can never be learned passively":

- Added `RadioPoller._seed_scan_facts_at_connect()` — a **pure local
  seed** (never touches the radio) that applies `scanning=False` and
  `scan_resume_mode=<assumed default>` via the existing command-echo
  machinery. Called once from `_run()`'s startup section (right beside
  `establish_vfo_identity`) and again from the server's soft-reconnect
  path (`server.py`, same `finally` block) — `RadioPoller._run()` never
  re-fires after a reconnect, so without the second call site a
  reconnect would strand the controls at whatever value survived the
  link drop, mirroring how `reset_vfo_session()` already unconditionally
  discards `active_slot` on every reconnect.
- `scan_resume_mode`'s seeded value (0xD0/OFF, masked `0x00`) is
  explicitly flagged in the code as an **assumption**, not a confirmed
  fact: no `rigs/*.toml` declares a default, and CI-V 0x0E has no read
  command, so it can never be independently confirmed by this codebase.
  A secondary source (an IC-7300 manual page indexed by manualslib.com)
  suggests the true factory default may be ON, but I could not
  independently verify that against Icom's own primary PDF (this
  environment's fetch tooling hit a 10 MB size limit on it) or pin which
  specific CI-V sub-byte "ON" corresponds to. OFF was chosen as the
  conservative default instead — wrong-but-safe, since it only affects a
  cosmetic default shown before the operator ever cycles resume mode. A
  `TODO(MOR-1495 follow-up)` comment names this gap for a bench check
  against a real factory-reset IC-7300.
- `scan_type` is deliberately **not** seeded — an assumed type would let
  an unconfirmed guess masquerade as an observed radio fact, which is
  exactly what the surface's other honesty gates exist to prevent.
  Instead `RitXitScanSurface.svelte` now owns the type as local UI state
  (`selectedType`, reusing v2 `ScanPanel`'s own shape/default: PROG,
  `0x01`), sent explicitly with every `scan_start`. This removes START's
  dependency on an observed `scanType` entirely, which is what let a
  cold-start radio enable the button in the first place. `scanType`'s own
  displayed reading is untouched — it still shows only the genuinely
  last-observed value.

**Correction to the round-1 "accepted limitation" note**: while verifying
this round's fix I found that CI-V 0x0E frames **do** already flow through
the RX pipeline — `_civ_rx.py`'s `_handle_0e` is registered in the frame
dispatch table and mutates the legacy `RadioState` mirror
(`rs.scanning = bool(sub_0e)`) on receipt. So an unsolicited/echoed 0x0E
frame is *not* actually invisible to the process today — it just isn't
routed into the `StateStore`/`fieldStatus` pipeline this PR's controls
read from, the same gap the round-1 fix closed for the command path.
Retiring the front-panel-stop limitation for real means wiring
`_handle_0e` into the observation pipeline too — **out of scope for this
PR**, tracked as a follow-up. The bench check below is what determines
whether that follow-up is worth doing.

**Bench-check note for MOR-1410**: watch the CI-V RX stream for a 0x0E
frame when scan is stopped from the IC-7300's own front panel. Given
`_handle_0e` already exists and is wired into dispatch, this seems likely
to fire — if it does, routing it through the observation pipeline
(instead of just the legacy mirror) would retire the front-panel-stop
limitation entirely.

## Test plan

- [x] `uv run pytest tests/test_radio_poller_coverage.py -k scan -q` —
      round-1 tests RED before that fix (`KeyError` on
      `global.slow_state.scanning`), GREEN after
- [x] `uv run pytest tests/test_radio_poller_coverage.py -k "seed_scan_facts_at_connect or scan_facts_seed" -q`
      — round-2 regression tests RED before the seed (`AttributeError`),
      GREEN after
- [x] `uv run pytest tests/test_web_server_coverage.py -k reseeds_scan_facts -q`
      — reconnect-path seed coverage, mirroring
      `test_on_radio_reconnect_establishes_vfo_identity_after_readiness_gate`
- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` —
      9164 passed, 12 skipped, 5 deselected, 14 xfailed, 1 xpassed (no
      regressions)
- [x] `uv run ruff check src/ tests/` — zero violations
- [x] `uv run mypy src/` — 13 pre-existing baseline errors, unchanged
      count/content vs `origin/main` (none in touched files)
- [x] `uv run lint-imports` — 5 contracts kept, 0 broken
- [x] `frontend`: `npx vitest run` — 329 files / 6958 tests passed,
      including updated `semantic-ritxit-scan-wiring.component.test.ts`
      (14/14) and `semantic/__tests__/RitXitScanSurface.test.ts` (49/49)
      — the pure-surface suite now covers the cold-start case directly
      (START enabled and dispatching with the default type even when
      `scanType` has never been reported)
- [x] `frontend`: `npm run lint` (eslint) — clean
- [x] `frontend`: `npm run check` (svelte-check + tsc) — 4545 files, 0
      errors, 0 warnings

## Test names added (round 2)

Backend (`tests/test_radio_poller_coverage.py`):
- `test_scan_facts_seeded_at_connect_break_the_bootstrap_deadlock`
- `test_scan_facts_seed_is_a_pure_local_seed_no_radio_write`
- `test_scan_facts_seed_labelled_command_response_not_poll_response`

Backend (`tests/test_web_server_coverage.py`):
- `test_on_radio_reconnect_reseeds_scan_facts`

Frontend (`semantic/__tests__/RitXitScanSurface.test.ts`, replacing
outdated round-1 assertions in the same `describe` block):
- `does NOT disable start merely because scanType has never been reported`
- `starts with the surface's own default type (PROG, 0x01) via a normal
  click, from a cold start where scanType has never been reported`
- `starts with the local default even when a DIFFERENT type happens to be
  the last-observed one — type is never read from the observed fact`

Frontend (`semantic-ritxit-scan-wiring.component.test.ts`, updated):
- `starting a scan sends scan_start with the surface's own default type,
  not the observed one`

Closes MOR-1495
