### PR TITLE
feat: multi-byte sub-address acquisition queries; voxDelay joins the poll plan (MOR-1483)

### DIFF
--- a/rigs/ic7300.toml
+++ b/rigs/ic7300.toml
@@ -193,14 +193,17 @@ command_response_observable = [
     # MOR-1483 (field-policy membership wave, leg 1): VOX/MON toggles.
     # Non-polling (command_response only) — riding the MOR-1490
     # prime_unobserved mechanism rather than a poll cadence; see the
-    # field_policies comment below. voxDelay (1A-05 ctl-mem 02-92) is NOT
-    # added here: its ingress decode already exists
-    # (``_CTL_MEM_VOX_DELAY_PREFIX``), but the scheduler's acquisition
-    # executor has no query builder for 2-byte ctl-mem sub-addressing
-    # (``AcquisitionQuerySender`` is a 3-tuple command/sub/receiver only) —
-    # that's new mechanism, not a table entry, so it's out of scope here.
+    # field_policies comment below.
     "global.tx_state.vox_on",
     "global.tx_state.monitor_on",
+    # MOR-1483 (leg 2): voxDelay (1A-05 ctl-mem 01-91, this radio's control
+    # number — see docs/validation/cat-audits/ic7300.md) is now addable:
+    # AcquisitionQuerySender's ``sub`` element can carry the CI-V sub-command
+    # byte plus the 2-byte ctl-mem control number as ``bytes``
+    # (IcomCivAcquisitionExecutor._GLOBAL_CTL_MEM_QUERIES), and the ingress
+    # decode already matches this prefix too. Non-polling, same
+    # prime_unobserved mechanism as the toggles above.
+    "global.operator_controls.vox_delay",
     # MOR-1491 (field-policy membership wave, leg 2): filter/PBT facts.
     "receiver.main.active.freq_mode.filter_width",
     "receiver.main.operator_controls.filter_shape",
@@ -370,6 +373,14 @@ reconciliation_priority = "command_response"
 adaptive_decay = false
 
 [state_acquisition.field_policies."global.tx_state.monitor_on"]
+cadence_seconds = 25.0
+freshness_ttl_seconds = 25.0
+reconciliation_priority = "command_response"
+adaptive_decay = false
+
+# MOR-1483 (leg 2): voxDelay joins the same non-polling membership as the
+# VOX/MON toggles above.
+[state_acquisition.field_policies."global.operator_controls.vox_delay"]
 cadence_seconds = 25.0
 freshness_ttl_seconds = 25.0
 reconciliation_priority = "command_response"

--- a/src/rigplane/core/acquisition_scheduler.py
+++ b/src/rigplane/core/acquisition_scheduler.py
@@ -48,12 +48,38 @@ __all__ = [
     "RadioStateModelService",
     "StateFreshnessService",
     "civ_acquisition_executor_for_provider",
+    "split_ctl_mem_sub",
 ]
 
 
 AcquisitionMethod = Literal["poll", "command_response", "wait_for_unsolicited"]
-AcquisitionQuerySender = Callable[[int, int | None, int | None], Awaitable[None]]
+# ``sub`` is normally a single CI-V sub-command byte (or ``None`` for a
+# no-sub-byte read). It is ``bytes`` only for multi-byte ctl-mem
+# sub-addressing (0x1A/0x05 "quick set" reads, e.g. voxDelay's 2-byte control
+# number, MOR-1483): the first byte is the CI-V sub-command byte and any
+# remaining bytes are additional payload data that must follow it in the
+# frame. Both ``AcquisitionQuerySender`` implementations (web radio_poller,
+# rigctld) must split it via ``split_ctl_mem_sub`` before building the frame.
+AcquisitionQuerySender = Callable[
+    [int, int | bytes | None, int | None], Awaitable[None]
+]
 CivCmd29Support = Callable[[int, int | None], bool]
+
+
+def split_ctl_mem_sub(sub: int | bytes | None) -> tuple[int | None, bytes]:
+    """Split an ``AcquisitionQuerySender`` ``sub`` element into CI-V parts.
+
+    Returns ``(civ_sub, extra_data)`` where ``civ_sub`` is the single byte to
+    pass as the CI-V frame's sub-command field and ``extra_data`` is any
+    additional payload bytes that must follow it (empty for the common
+    single-byte-or-none case). Shared by both backend executors so the
+    multi-byte ctl-mem representation (see ``AcquisitionQuerySender``) is
+    decoded identically everywhere.
+    """
+
+    if isinstance(sub, (bytes, bytearray)):
+        return (sub[0] if sub else None), bytes(sub[1:])
+    return sub, b""
 
 
 class AcquisitionPriority(StrEnum):
@@ -284,6 +310,21 @@ _GLOBAL_NONLEVEL_QUERIES: dict[str, tuple[int, int | None]] = {
     # 3-valued rather than a plain toggle.
     "break_in": (0x16, 0x47),
 }
+# Global operator-control reads that need the 0x1A ctl-mem ("quick set")
+# multi-byte sub-address (MOR-1483): the CI-V sub-command byte (0x05)
+# followed by a 2-byte per-model control number, packed together as
+# ``bytes`` (see ``AcquisitionQuerySender``'s docstring for the split
+# convention). Pinned to IC-7300's control number -- the live reference
+# profile (``rigs/ic7300.toml``'s ``get_vox_delay`` = ``1A 05 01 91``). This
+# mapping is shared across every icom_civ/xiegu_civ profile and has no
+# per-instance radio-model injection, so it cannot vary the control number
+# per model; IC-7610 is retired hardware
+# (docs/validation/cat-audits/ic7610.md: ``1A 05 0292``) and unverifiable on
+# real hardware, so a primed voxDelay read routed through this mapping on an
+# IC-7610 profile would address the wrong ctl-mem register.
+_GLOBAL_CTL_MEM_QUERIES: dict[str, bytes] = {
+    "vox_delay": b"\x05\x01\x91",
+}
 _GLOBAL_METER_QUERY_SUBS: dict[str, int] = {
     "power": 0x11,
     "swr": 0x12,
@@ -331,6 +372,7 @@ class IcomCivAcquisitionExecutor:
                 receiver is not None
                 and command not in (0x25, 0x26)
                 and self._supports_cmd29 is not None
+                and not isinstance(sub, (bytes, bytearray))
                 and not self._supports_cmd29(command, sub)
             ):
                 if receiver != 0:
@@ -349,7 +391,7 @@ class IcomCivAcquisitionExecutor:
     def query_for_path(
         self,
         path: FieldPath,
-    ) -> tuple[int, int | None, int | None] | None:
+    ) -> tuple[int, int | bytes | None, int | None] | None:
         receiver = _RECEIVER_IDS.get(path.receiver_id or "")
         if path.scope.value == "receiver" and receiver is None:
             return None
@@ -401,6 +443,9 @@ class IcomCivAcquisitionExecutor:
         if path.scope.value == "global" and path.family.value == "operator_controls":
             if path.name == "rit_freq":
                 return (0x21, 0x00, None)
+            ctl_mem = _GLOBAL_CTL_MEM_QUERIES.get(path.name)
+            if ctl_mem is not None:
+                return (0x1A, ctl_mem, None)
             nonlevel = _GLOBAL_NONLEVEL_QUERIES.get(path.name)
             if nonlevel is not None:
                 return (nonlevel[0], nonlevel[1], None)

--- a/src/rigplane/rigctld/server.py
+++ b/src/rigplane/rigctld/server.py
@@ -30,6 +30,7 @@ from ..core.acquisition_scheduler import (
     RadioStateModelService,
     StateFreshnessService,
     civ_acquisition_executor_for_provider,
+    split_ctl_mem_sub,
 )
 from ..core.state_diagnostics import StateDiagnosticsRecorder
 from ..core.state_pipeline_contracts import FieldPath
@@ -452,15 +453,25 @@ class RigctldServer:
     async def _send_one_state_query(
         self,
         cmd_byte: int,
-        sub_byte: int | None,
+        sub_byte: int | bytes | None,
         receiver: int | None,
     ) -> None:
+        """Send a single acquisition-scheduler CI-V state query.
+
+        ``sub_byte`` is ``bytes`` only for multi-byte ctl-mem sub-addressing
+        (0x1A/0x05 "quick set" reads, e.g. voxDelay, MOR-1483) — always a
+        global (``receiver is None``) read today, so only the final branch
+        below needs to split it via ``split_ctl_mem_sub``.
+        """
         radio = self._radio
         if not isinstance(radio, CivCommandCapable):
             raise _AcquisitionExecutorUnavailable(
                 "radio does not support CI-V state acquisition sends"
             )
         if receiver is not None:
+            assert not isinstance(sub_byte, (bytes, bytearray)), (
+                "multi-byte ctl-mem sub-addressing is global-only (receiver=None)"
+            )
             if cmd_byte in (0x25, 0x26):
                 await radio.send_civ(
                     cmd_byte,
@@ -473,10 +484,11 @@ class RigctldServer:
                 inner += bytes([sub_byte])
             await radio.send_civ(0x29, data=inner, wait_response=False)
             return
+        civ_sub, extra_data = split_ctl_mem_sub(sub_byte)
         await radio.send_civ(
             cmd_byte,
-            sub=sub_byte,
-            data=b"",
+            sub=civ_sub,
+            data=extra_data,
             wait_response=False,
         )
 

--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -555,11 +555,20 @@ _CMD1A_CTL_MEM_LEVEL_FIELDS = {
     b"\x02\x92": ("vox_delay", 1),
 }
 
-# 0x1A/0x05 ctl-mem prefix whose RadioState mirror write was migrated to the
-# StateStore observation pipeline (MOR-459). ``_handle_1a`` skips the redundant
-# ``setattr`` mirror for this prefix; ``_observations_from_frame`` is the source
-# of truth and reuses the identical ``parse_level_response`` decode.
+# 0x1A/0x05 ctl-mem prefix(es) whose RadioState mirror write was migrated to
+# the StateStore observation pipeline (MOR-459). ``_handle_1a`` skips the
+# redundant ``setattr`` mirror for these prefixes; ``_observations_from_frame``
+# is the source of truth and reuses the identical ``parse_level_response``
+# decode. Two prefixes because voxDelay's ctl-mem control number is
+# per-model, not a CI-V-wide constant: 0x02 0x92 is IC-7610's (retired
+# hardware, docs/validation/cat-audits/ic7610.md), 0x01 0x91 is IC-7300's —
+# the live reference (docs/validation/cat-audits/ic7300.md; MOR-1483 leg 2).
 _CTL_MEM_VOX_DELAY_PREFIX = b"\x02\x92"
+_CTL_MEM_VOX_DELAY_PREFIX_IC7300 = b"\x01\x91"
+_CTL_MEM_VOX_DELAY_PREFIXES = (
+    _CTL_MEM_VOX_DELAY_PREFIX,
+    _CTL_MEM_VOX_DELAY_PREFIX_IC7300,
+)
 
 # CI-V data watchdog (wfview icomudpcivdata::watchdog)
 # If no CI-V data for this long, send open_close to restart the stream.
@@ -2322,11 +2331,13 @@ class CivRuntime:
         elif (
             frame.command == 0x1A
             and frame.sub == 0x05
-            and frame.data.startswith(_CTL_MEM_VOX_DELAY_PREFIX)
+            and bytes(frame.data[:2]) in _CTL_MEM_VOX_DELAY_PREFIXES
         ):
             # VOX hang delay: 1-byte BCD ctl-mem level, reusing the exact decode
-            # of ``_handle_1a`` (``parse_level_response`` with the 0x02 0x92
-            # prefix). Promoted to a global operator-control int (MOR-459).
+            # of ``_handle_1a``. The 2-byte ctl-mem control number is
+            # per-model (``_CTL_MEM_VOX_DELAY_PREFIXES``), so match whichever
+            # one the frame actually carries. Promoted to a global
+            # operator-control int (MOR-459; multi-model MOR-1483 leg 2).
             observations.append(
                 self._observation(
                     FieldPath.global_("operator_controls", "vox_delay"),
@@ -2334,7 +2345,7 @@ class CivRuntime:
                         frame,
                         command=0x1A,
                         sub=0x05,
-                        prefix=_CTL_MEM_VOX_DELAY_PREFIX,
+                        prefix=bytes(frame.data[:2]),
                         bcd_bytes=1,
                     ),
                     frame=frame,

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -82,6 +82,7 @@ from ..core.acquisition_scheduler import (
     AcquisitionScheduler,
     MeterObservationCoalescer,
     civ_acquisition_executor_for_provider,
+    split_ctl_mem_sub,
 )
 from ..core.state_pipeline_contracts import (
     CommandSource,
@@ -918,7 +919,7 @@ class RadioPoller:
     async def _send_one_state_query(
         self,
         cmd_byte: int,
-        sub_byte: int | None,
+        sub_byte: int | bytes | None,
         receiver: int | None,
         *,
         priority: Priority = Priority.BACKGROUND,
@@ -931,6 +932,11 @@ class RadioPoller:
         here are fire-and-forget (``wait_dispatch=False``) so the poll burst
         does not park the poll loop on the commander future (MOR-497ii); the
         response still arrives via the CI-V RX path.
+
+        ``sub_byte`` is ``bytes`` only for multi-byte ctl-mem sub-addressing
+        (0x1A/0x05 "quick set" reads, e.g. voxDelay, MOR-1483) — always a
+        global (``receiver is None``) read today, so only the final
+        non-receiver, non-scope branch below needs to split it.
         """
         if (
             receiver is None
@@ -945,6 +951,9 @@ class RadioPoller:
                 wait_dispatch=False,
             )
         elif receiver is not None:
+            assert not isinstance(sub_byte, (bytes, bytearray)), (
+                "multi-byte ctl-mem sub-addressing is global-only (receiver=None)"
+            )
             if cmd_byte in (0x25, 0x26):
                 await self._civ(
                     cmd_byte,
@@ -964,6 +973,7 @@ class RadioPoller:
             scope_rx = 0
             if self._radio_state:
                 scope_rx = self._radio_state.scope_controls.receiver
+            assert isinstance(sub_byte, int)
             await self._civ(
                 cmd_byte,
                 sub=sub_byte,
@@ -972,10 +982,11 @@ class RadioPoller:
                 wait_dispatch=False,
             )
         else:
+            civ_sub, extra_data = split_ctl_mem_sub(sub_byte)
             await self._civ(
                 cmd_byte,
-                sub=sub_byte,
-                data=b"",
+                sub=civ_sub,
+                data=extra_data,
                 priority=priority,
                 wait_dispatch=False,
             )

--- a/tests/test_acquisition_scheduler.py
+++ b/tests/test_acquisition_scheduler.py
@@ -2491,6 +2491,70 @@ def test_ic7610_real_profile_tx_vox_pollable_and_emit_reads() -> None:
     assert expected <= set(sent)
 
 
+def test_ic7300_vox_delay_query_for_path_ctl_mem_multibyte_sub() -> None:
+    """MOR-1483 (leg 2): voxDelay's CI-V read is a 2-byte ctl-mem sub-address
+
+    (``1A 05 01 91`` — see ``rigs/ic7300.toml``'s ``get_vox_delay``), which the
+    plain ``(command, sub, receiver)`` 3-tuple cannot express with ``sub`` as a
+    single byte. ``query_for_path`` now returns the CI-V sub-command byte
+    (0x05) followed by the 2-byte ctl-mem control number packed into ``sub``
+    as ``bytes`` — the minimal extension of the existing envelope.
+    """
+
+    vox_delay = FieldPath.global_("operator_controls", "vox_delay")
+    executor = IcomCivAcquisitionExecutor(_unused_send_query)
+
+    query = executor.query_for_path(vox_delay)
+
+    assert query == (0x1A, b"\x05\x01\x91", None)
+
+
+async def _unused_send_query(
+    command: int, sub: int | bytes | None, receiver: int | None
+) -> None:
+    raise AssertionError("send_query should not be invoked by query_for_path")
+
+
+def test_ic7300_real_profile_vox_delay_is_primed_and_executor_builds_multibyte_frame() -> (
+    None
+):
+    """MOR-1483 (leg 2) end-to-end: never-observed voxDelay, policy present.
+
+    ``prime_unobserved`` queues a BACKGROUND read for the never-observed
+    ``global.operator_controls.vox_delay`` field (membership added to
+    ``rigs/ic7300.toml``'s non-polling ``field_policies``/
+    ``command_response_observable`` alongside voxOn/monitorOn), and the CI-V
+    executor must build the correct multi-byte ``1A 05 01 91`` frame for it —
+    the exact wire bytes ``rigs/ic7300.toml``'s ``get_vox_delay`` declares.
+    """
+
+    acquisition = load_rig(RIGS_DIR / "ic7300.toml").to_profile().state_acquisition
+    assert acquisition is not None
+
+    vox_delay = FieldPath.global_("operator_controls", "vox_delay")
+    assert acquisition.capability_for(vox_delay).can_poll is False
+    assert acquisition.capability_for(vox_delay).command_response_observable is True
+
+    clock = FreshnessClock(start=400.0)
+    scheduler = AcquisitionScheduler(profile=acquisition, clock=clock)
+
+    queued = scheduler.prime_unobserved(observed_paths=())
+    request = next(req for req in queued if vox_delay in req.paths)
+    assert request.acquisition_method == "command_response"
+
+    sent: list[tuple[int, int | bytes | None, int | None]] = []
+
+    async def send_query(
+        command: int, sub: int | bytes | None, receiver: int | None
+    ) -> None:
+        sent.append((command, sub, receiver))
+
+    executor = IcomCivAcquisitionExecutor(send_query)
+    execution = asyncio.run(executor.execute(request, already_sent_paths=frozenset()))
+    assert execution.failed_paths == ()
+    assert (0x1A, b"\x05\x01\x91", None) in sent
+
+
 def test_ic7610_real_profile_vfo_global_query_for_path() -> None:
     sent: list[tuple[int, int | None, int | None]] = []
 

--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -1979,12 +1979,22 @@ _VALUE_CONTROL_CASES = (
         30,
     ),
     # 0x1A 0x05 0x02 0x92 vox_delay: 1-byte BCD ctl-mem level (0-20) promoted to
-    # a global operator-control int (MOR-459).
+    # a global operator-control int (MOR-459). This is IC-7610's ctl-mem
+    # control number.
     (
         _make_frame(cmd=0x1A, sub=0x05, data=b"\x02\x92\x12"),
         "global.operator_controls.vox_delay",
         "voxDelay",
         12,
+    ),
+    # 0x1A 0x05 0x01 0x91 vox_delay (MOR-1483 leg 2): same field, IC-7300's
+    # ctl-mem control number — different per-model 2-byte prefix than the
+    # 0x02 0x92 case above, decoded through the same generic prefix match.
+    (
+        _make_frame(cmd=0x1A, sub=0x05, data=b"\x01\x91\x15"),
+        "global.operator_controls.vox_delay",
+        "voxDelay",
+        15,
     ),
     # 0x10 tuning_step: device step index (0-8), BCD nibble-pair byte 0x05 → 5;
     # NOT Hz. Promoted to a global slow-state int (MOR-461).

--- a/tests/test_state_acquisition_policy.py
+++ b/tests/test_state_acquisition_policy.py
@@ -678,7 +678,9 @@ def test_ic7300_non_polling_field_policies_have_full_acquisition_chain() -> None
     acquisition = profile.state_acquisition
     assert acquisition is not None
 
-    async def _noop_send(command: int, sub: int | None, receiver: int | None) -> None:
+    async def _noop_send(
+        command: int, sub: int | bytes | None, receiver: int | None
+    ) -> None:
         return None
 
     executor = IcomCivAcquisitionExecutor(_noop_send)
@@ -699,6 +701,11 @@ def test_ic7300_non_polling_field_policies_have_full_acquisition_chain() -> None
         ("receiver", "freq_mode", "filter_width"),
         ("global", "operator_controls", "cw_pitch"),
         ("global", "operator_controls", "key_speed"),
+        # MOR-1483 (leg 2): voxDelay's ctl-mem (0x1A/0x05) ingress decode is a
+        # hardcoded branch keyed by a 2-byte control-number prefix, not a
+        # dict entry keyed by a plain sub byte -- same shape as the other
+        # entries in this set.
+        ("global", "operator_controls", "vox_delay"),
     }
     table_observable = set(_civ_rx._OBSERVABLE_CMD14_FIELDS.values())
     table_observable |= set(_civ_rx._OBSERVABLE_CMD15_FIELDS.values())


### PR DESCRIPTION
## Summary

Completes the remaining leg of MOR-1483 (voxOn/monitorOn already landed in #2421). `voxDelay` never became observed on IC-7300 because of two compounding gaps:

1. **Query-mapping gap**: its CI-V read is a 2-byte ctl-mem sub-address (`1A 05 01 91`), but `AcquisitionQuerySender`'s `(command, sub, receiver)` 3-tuple limited `sub` to a single byte — it could not express the extra control-number bytes.
2. **Ingress-decode gap** (found during this leg, not previously documented): `_civ_rx.py`'s vox_delay observation branch only matched IC-7610's ctl-mem prefix (`02 92`), not IC-7300's (`01 91`). Even a correctly-sent IC-7300 read would never have produced an observation.

## Representation chosen

`AcquisitionQuerySender`'s `sub` element becomes `int | bytes | None`. When `bytes`, the first byte is the CI-V sub-command byte and the remainder is additional payload data that must follow it in the frame — e.g. `b"\x05\x01\x91"` for voxDelay (sub=0x05, then the 2-byte ctl-mem control number). A new `split_ctl_mem_sub()` helper in `acquisition_scheduler.py` decodes this once; both `AcquisitionQuerySender` implementations now call it before building their CI-V frame.

`query_for_path()` maps `global.operator_controls.vox_delay` to `(0x1A, b"\x05\x01\x91", None)`, pinned to **IC-7300's** ctl-mem control number (the live reference profile). This mapping is shared across every icom_civ/xiegu_civ profile with no per-instance radio-model injection, so it cannot vary the control number per model.

**IC-7610 scope note**: IC-7610 uses a different control number (`02 92`, per `docs/validation/cat-audits/ic7610.md`) and is retired, unverifiable hardware (per repo CLAUDE.md). Rather than wire IC-7610's `field_policies` membership to a query mapping pinned to the wrong control number, I deliberately left IC-7610 parity out of this PR — it's flagged as a follow-up below.

## The same-commit trap

Landing a `field_policies` entry without a matching CI-V query mapping would head-of-line-starve `AcquisitionScheduler.prime_unobserved`'s burst cap forever (`no_civ_query_mapping`, since the field would always fail to dequeue and never expire from the never-observed set). Landing a mapping without the ingress-decode fix would prime silently and the field would never leave `UNKNOWN`. All three pieces (query mapping, ingress decode, `field_policies`/capability membership) land in this single commit, matching the structural guard test's own acceptance-harness role:
`test_ic7300_non_polling_field_policies_have_full_acquisition_chain` (`tests/test_state_acquisition_policy.py`), extended here with voxDelay's hardcoded-branch observability entry.

## File-count note

This touches 5 production files, one over the nominal 4-file guidance. `AcquisitionQuerySender` has exactly two concrete implementations (`web/radio_poller.py`, `rigctld/server.py`); widening its type forces both to stay structurally compatible (mypy `strict = true` on `rigplane.web.*`) and both would otherwise crash at runtime (`bytearray.append()` on a `bytes` sub) if a profile ever primes a multi-byte ctl-mem field through them. I judged this correctness requirement more important than strict file-count adherence.

## Testing

- `query_for_path` unit test for the multi-byte tuple shape
- Real-IC-7300-profile end-to-end test: `prime_unobserved` → `executor.execute()` builds the correct `(0x1A, b"\x05\x01\x91", None)` wire query
- `_VALUE_CONTROL_CASES` ingress case proving the `01 91` prefix decodes to an observed field (exercises the real `_update_state_cache_from_frame` path)
- Extended the structural guard test's `hardcoded_observable` set

```
uv run pytest tests/test_acquisition_scheduler.py tests/test_state_acquisition_policy.py tests/test_civ_rx_coverage.py tests/test_rig_loader.py tests/test_radio_poller_coverage.py tests/test_rigctld_server.py tests/test_rigctld_server_coverage.py -q
# 803 passed

uv run pytest tests/ -q --ignore=tests/integration
# 9167 passed, 12 skipped, 5 deselected, 14 xfailed, 1 xpassed (pre-existing flaky xfail, unrelated: test_naming_parity x6100)

uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/
# clean

uv run mypy src/
# 13 pre-existing errors, identical to main baseline — zero new errors

uv run lint-imports
# 5 kept, 0 broken
```

## Follow-up (not in this PR)

IC-7610 voxDelay parity: `rigs/ic7610.toml` already declares `get_vox_delay = [0x1A, 0x05, 0x02, 0x92]` for direct SET/GET commands, but adding it to IC-7610's non-polling acquisition membership would need either (a) per-instance profile injection into `IcomCivAcquisitionExecutor` for the ctl-mem control number, or (b) accepting that the shared query mapping sends the wrong control number on real hardware. Given IC-7610 is retired and unverifiable, this is a documentation/design decision for a future ticket rather than a blocking gap.

Closes MOR-1483.

🤖 Generated with [Claude Code](https://claude.com/claude-code)