### PR TITLE
feat: adaptive prime pacing, sweep cursor, and guard correspondence (MOR-1501)

### DIFF
--- a/src/rigplane/core/acquisition_scheduler.py
+++ b/src/rigplane/core/acquisition_scheduler.py
@@ -482,9 +482,11 @@ _MIN_RECONCILIATION_MAX_AGE = 1e-9
 # a single prime_unobserved() call will enqueue. Uncapped, a profile carrying
 # ~20 non-polling field_policies overrides would emit ~20 CI-V frames in one
 # drain cycle (~1s of serial time), starving BACKGROUND-priority meter/PTT
-# traffic that shares the same lane. StateFreshnessService's bounded 30s
-# re-derivation (see StateFreshnessService.PRIME_REDERIVE_INTERVAL_SECONDS)
-# picks up whatever this call didn't reach.
+# traffic that shares the same lane. StateFreshnessService's bounded,
+# adaptive re-derivation (see
+# StateFreshnessService.PRIME_ADAPTIVE_INTERVAL_SECONDS /
+# .PRIME_REDERIVE_INTERVAL_SECONDS) picks up whatever this call didn't
+# reach.
 _PRIME_UNOBSERVED_BURST_LIMIT = 5
 
 
@@ -502,6 +504,7 @@ class AcquisitionScheduler:
         "_failure_count_by_reason",
         "_next_id",
         "_pending_cadence_by_key",
+        "_prime_cursor",
         "_profile",
         "_requests_by_key",
     )
@@ -524,6 +527,12 @@ class AcquisitionScheduler:
         self._failed_request_count = 0
         self._failure_count_by_reason: dict[str, int] = {}
         self._next_id = 1
+        # Round-robin starting offset into field_policies for
+        # prime_unobserved (MOR-1501, A1 from #2415 review): see that
+        # method's docstring for why a fixed scan-from-zero starves any
+        # reachable field sitting behind >= `limit` permanently-unanswerable
+        # leaders in declaration order.
+        self._prime_cursor = 0
         self._external_cat_paused = False
         self._external_cat_owner: str | None = None
         self._external_cat_reason = ""
@@ -716,11 +725,12 @@ class AcquisitionScheduler:
         forever — no reconciliation hint is ever generated for it (MOR-1490).
 
         The caller (:class:`StateFreshnessService`) re-derives the never-
-        observed set at a bounded interval (see
-        :data:`StateFreshnessService.PRIME_REDERIVE_INTERVAL_SECONDS`) rather
-        than once per connect epoch — a dropped/unanswered prime must not
-        leave a field ``UNKNOWN`` for the life of the connection (MOR-1490
-        review R2, Finding 1). Every call runs at
+        observed set at a bounded, adaptive interval (see
+        :data:`StateFreshnessService.PRIME_ADAPTIVE_INTERVAL_SECONDS` and
+        :data:`StateFreshnessService.PRIME_REDERIVE_INTERVAL_SECONDS`)
+        rather than once per connect epoch — a dropped/unanswered prime must
+        not leave a field ``UNKNOWN`` for the life of the connection
+        (MOR-1490 review R2, Finding 1). Every call runs at
         :data:`AcquisitionPriority.BACKGROUND` so priming never competes with
         fast meters/PTT. Unsupported/hookless paths fall out through the
         normal :meth:`ensure_fresh` availability gate, and an unanswered
@@ -769,25 +779,30 @@ class AcquisitionScheduler:
           short of the burst cap below — reaching them only requires this
           method to be invoked again, not for the earlier paths to have
           been *answered*. In production, "invoked again" is gated by
+          :data:`StateFreshnessService.PRIME_ADAPTIVE_INTERVAL_SECONDS`
+          (~5s, while any policy field remains unobserved) or, once the
+          never-observed set has emptied,
           :data:`StateFreshnessService.PRIME_REDERIVE_INTERVAL_SECONDS`
-          (~30s), so that interval — not the leading paths' resolution — is
+          (~30s) — so that interval, not the leading paths' resolution, is
           the practical bound on how long a capped-out straggler waits.
         - **Burst cap** (``limit``, default
           :data:`_PRIME_UNOBSERVED_BURST_LIMIT`): at most ``limit`` *new*
           paths are queued per call, so a profile with many non-polling
           policy fields can't emit a burst of CI-V frames in one drain cycle
-          (MOR-1490 review R2, Finding 4). Fields are visited in
-          ``field_policies`` iteration order (profile-declaration order), so
-          the same leading fields are always favored over later ones; if a
-          future profile ever declared five or more *permanently*
-          unanswerable non-polling fields ahead of a reachable one in that
-          order, the reachable one would starve indefinitely rather than
-          merely waiting out one interval. A round-robin ``_prime_cursor``
-          (rotating the starting offset into ``field_policies`` each call)
-          is the planned fix for that head-of-line case, expected to land
-          alongside the MOR-1491/1492/1493 field-membership tickets that
-          would first make it reachable; no shipped profile has that shape
-          today.
+          (MOR-1490 review R2, Finding 4). Fields are visited starting from
+          ``_prime_cursor`` — a round-robin offset into ``field_policies``
+          (profile-declaration order) that this method advances past
+          whatever it scanned, wrapping at the end of the mapping (MOR-1501,
+          A1 from #2415 review) — rather than always restarting the scan at
+          index 0. A fixed scan-from-zero would let five or more
+          *permanently* unanswerable non-polling fields ahead of a reachable
+          one in declaration order starve that reachable one indefinitely:
+          each call would re-queue the same unanswerable leaders (freed back
+          to "not observed, not pending" the moment their request fails —
+          see :meth:`record_acquisition_failure`) and never reach past them.
+          Rotating the start point instead guarantees every field gets
+          scanned at least once every ``ceil(len(field_policies) / limit)``
+          calls regardless of how many leaders ahead of it are stuck.
 
         The returned tuple has at most one entry per distinct
         :class:`AcquisitionRequest` id — multiple primed paths that coalesce
@@ -800,11 +815,17 @@ class AcquisitionScheduler:
         pending = frozenset(
             path for request in self._requests_by_key.values() for path in request.paths
         )
+        items = tuple(self._profile.field_policies.items())
+        total = len(items)
         queued_by_id: dict[str, AcquisitionRequest] = {}
         queued_path_count = 0
-        for path, policy in self._profile.field_policies.items():
+        cursor = self._prime_cursor % total if total else 0
+        visited = 0
+        for offset in range(total):
             if queued_path_count >= limit:
                 break
+            visited = offset + 1
+            path, policy = items[(cursor + offset) % total]
             if path in observed or path in pending:
                 continue
             if (
@@ -831,7 +852,37 @@ class AcquisitionScheduler:
                 continue
             queued_path_count += 1
             queued_by_id[result.request.id] = result.request
+        if total:
+            self._prime_cursor = (cursor + visited) % total
         return tuple(queued_by_id.values())
+
+    def has_unobserved_policy_fields(
+        self,
+        observed_paths: Iterable[FieldPath],
+    ) -> bool:
+        """Return True if any explicit ``field_policies`` path is unobserved.
+
+        Shares :meth:`prime_unobserved`'s eligibility rules for *which*
+        fields it is responsible for (excludes cadence/poll-owned paths,
+        which are :meth:`due_requests`'s concern) but, unlike
+        ``prime_unobserved``, does NOT exclude already-pending paths: a path
+        with an outstanding, unanswered prime read is still unobserved, and
+        :class:`StateFreshnessService` uses this to decide whether to keep
+        re-deriving the prime sweep on its fast cadence or back off once the
+        never-observed set has genuinely emptied (MOR-1501).
+        """
+
+        observed = frozenset(observed_paths)
+        for path, policy in self._profile.field_policies.items():
+            if path in observed:
+                continue
+            if (
+                self._profile.capability_for(path).can_poll
+                and policy.cadence_seconds is not None
+            ):
+                continue
+            return True
+        return False
 
     def record_acquisition_result(
         self,
@@ -1577,15 +1628,31 @@ class StateFreshnessService:
     production delivery store.
     """
 
-    #: Minimum spacing between never-observed-field re-derivations (MOR-1490
-    #: review R2, Finding 1). A one-shot "prime once per connect epoch" flag
-    #: means a single dropped/unanswered prime read leaves the field
-    #: ``UNKNOWN`` until the process restarts — reconnects don't rebuild this
-    #: service, so nothing ever re-arms the flag. Re-deriving on a bounded
-    #: interval instead is self-extinguishing: once a field is observed it
-    #: drops out of the ``observed_paths`` gate in
-    #: :meth:`AcquisitionScheduler.prime_unobserved` and this loop stops doing
-    #: anything for it, without needing to track per-field completion here.
+    #: Fast re-derivation spacing used WHILE at least one explicit
+    #: ``field_policies`` field remains unobserved (MOR-1501, verifier-
+    #: prescribed on #2421's review). The flat 30s interval below left a
+    #: real IC-7300 connect with a ~120s populate tail for its 23 non-polling
+    #: policy fields: ``ceil(23 / _PRIME_UNOBSERVED_BURST_LIMIT) == 5`` waves
+    #: at 30s apart, even though each field's true CI-V round-trip cost is
+    #: ~1.1s. At 5s spacing the same 5 waves complete in ~20-25s — the burst
+    #: cap (unchanged, still the lane-protection knob) is what still bounds
+    #: each wave's size, this constant only bounds how long a capped-out
+    #: straggler waits between waves. See
+    #: :meth:`_reprime_unobserved_if_due` for the dead-link write-rate
+    #: consequence of shortening this interval.
+    PRIME_ADAPTIVE_INTERVAL_SECONDS: float = 5.0
+
+    #: Re-derivation spacing once the never-observed ``field_policies`` set
+    #: has genuinely emptied (MOR-1490 review R2, Finding 1; backoff target
+    #: added MOR-1501). A one-shot "prime once per connect epoch" flag means
+    #: a single dropped/unanswered prime read leaves the field ``UNKNOWN``
+    #: until the process restarts — reconnects don't rebuild this service,
+    #: so nothing ever re-arms the flag. Re-deriving on a bounded interval
+    #: instead is self-extinguishing: once every policy field is observed,
+    #: :meth:`AcquisitionScheduler.has_unobserved_policy_fields` goes False
+    #: and :meth:`_reprime_unobserved_if_due` backs off to this slower
+    #: interval so a fully-populated store isn't paying the fast (5s) check
+    #: forever.
     PRIME_REDERIVE_INTERVAL_SECONDS: float = 30.0
 
     __slots__ = (
@@ -1634,17 +1701,43 @@ class StateFreshnessService:
         return delta
 
     def _reprime_unobserved_if_due(self, *, now: float) -> None:
-        """Re-derive the never-observed-field prime at a bounded interval.
+        """Re-derive the never-observed-field prime at an adaptive interval.
 
         Replaces the earlier "once per connect epoch" latch (MOR-1490 review
         R2, Finding 1): that guard never reset on reconnect and permanently
         stranded a field at ``UNKNOWN`` if its one prime read was dropped.
-        Re-running this at most every
-        :data:`PRIME_REDERIVE_INTERVAL_SECONDS` costs one
-        ``store.snapshot()`` plus a loop over ``field_policies`` — cheap
-        relative to the 30s window, and it self-extinguishes per field the
-        moment that field is observed (see
-        :meth:`AcquisitionScheduler.prime_unobserved`).
+        The re-derivation spacing is itself adaptive (MOR-1501): it runs
+        every :data:`PRIME_ADAPTIVE_INTERVAL_SECONDS` while
+        :meth:`AcquisitionScheduler.has_unobserved_policy_fields` reports at
+        least one explicit ``field_policies`` path still unobserved, and
+        backs off to the slower :data:`PRIME_REDERIVE_INTERVAL_SECONDS` the
+        moment that set empties — cheap either way (one ``store.snapshot()``
+        plus a loop over ``field_policies``), so paying it more often while
+        fields are still missing is a fine trade against the ~120s populate
+        tail the flat 30s interval produced.
+
+        Dead-link write-rate honesty (R3 lesson from MOR-1490's own review,
+        applies again here): a capped-out straggler left short of the burst
+        cap costs nothing extra — it was skipped without being queued, so no
+        frame was sent for it. But a *leader* that WAS queued and then fails
+        (:meth:`AcquisitionScheduler.record_acquisition_failure`, e.g. an
+        unanswered field on a genuinely dead link) is freed back to "not
+        observed, not pending" and becomes eligible to be re-queued on the
+        very next re-derivation. Re-queueing is not free: every request
+        :meth:`AcquisitionScheduler.pending_requests` yields is later drained
+        by a real backend executor (e.g. ``IcomCivAcquisitionExecutor``)
+        that performs an actual ``send_query`` write to the wire — nothing
+        here is a no-op retry. Shortening the interval from 30s to 5s
+        therefore genuinely raises the worst-case re-attempt rate on a fully
+        dead link by ~6x: at most ``limit`` (the burst cap, unchanged)
+        frames per adaptive-interval window, i.e. <= 5 frames / 5s = 1
+        frame/s worst case, versus <= 5 frames / 30s ~= 0.167 frames/s
+        before. The count per window still cannot exceed the burst cap
+        (bounded, not growing) — the wire load stays a small, constant
+        fraction of the ~20 q/s serial ceiling
+        (``_SERIAL_DEFAULT_CIV_MIN_INTERVAL_MS``); it does not accumulate
+        across windows because record_acquisition_failure clears the
+        request rather than leaving it queued twice.
         """
 
         scheduler = self._scheduler
@@ -1652,9 +1745,15 @@ class StateFreshnessService:
             return
         if now < self._next_prime_monotonic:
             return
-        self._next_prime_monotonic = now + self.PRIME_REDERIVE_INTERVAL_SECONDS
-        observed = (field.path for field in self._store.snapshot().fields)
+        observed = tuple(field.path for field in self._store.snapshot().fields)
         scheduler.prime_unobserved(observed)
+        still_unobserved = scheduler.has_unobserved_policy_fields(observed)
+        interval = (
+            self.PRIME_ADAPTIVE_INTERVAL_SECONDS
+            if still_unobserved
+            else self.PRIME_REDERIVE_INTERVAL_SECONDS
+        )
+        self._next_prime_monotonic = now + interval
 
     async def run(self) -> None:
         """Run the periodic freshness loop until cancelled by the host."""

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -202,17 +202,21 @@ _FAST_INTERVAL: float = 0.025  # meters — wfview queue interval for LAN (25ms)
 _FAST_INTERVAL_SERIAL: float = 0.100  # serial: 10 polls/sec for responsive meters
 _SLOW_INTERVAL: float = 0.25  # levels/settings — rarely change
 
-# Floor for the derived tx_target field's own freshness TTL when a profile
-# has no [state_acquisition] block at all (MOR-1496 review R3, F1 follow-up).
-# ``4 * self._fast_interval`` alone is not a defensible TX-gate horizon: on a
-# LAN profile (``_FAST_INTERVAL`` = 25ms) that floors to 0.1s, which the
-# verifier measured causing 6.6 stale-transitions/s on an idle IC-705 (no
-# [state_acquisition] block). Matches the concrete 3.0s
-# ``freshness_ttl_seconds`` IC-7300's own ``[state_acquisition]`` block
-# already uses for this same field via ``policy_for`` — not the unrelated
-# generic ``AcquisitionPolicy`` dataclass default (15.0s, calibrated for
-# slower-changing fields, not a TX gate).
-_TX_TARGET_MIN_MAX_AGE: float = 3.0
+# Fallback for the derived tx_target field's own freshness TTL when a
+# profile has no [state_acquisition] block at all (MOR-1496 review R3, F1
+# follow-up). Renamed from ``_TX_TARGET_MIN_MAX_AGE`` (MOR-1501, #2422
+# review) — despite the "MIN" naming this is a straight substitute, not a
+# ``max()``-clamped floor: when a profile has no acquisition policy at all
+# there is no computed TTL to clamp against, so ``_tx_target_max_age`` swaps
+# this value in outright. ``4 * self._fast_interval`` alone is not a
+# defensible TX-gate horizon: on a LAN profile (``_FAST_INTERVAL`` = 25ms)
+# that floors to 0.1s, which the verifier measured causing 6.6
+# stale-transitions/s on an idle IC-705 (no [state_acquisition] block).
+# Matches the concrete 3.0s ``freshness_ttl_seconds`` IC-7300's own
+# ``[state_acquisition]`` block already uses for this same field via
+# ``policy_for`` — not the unrelated generic ``AcquisitionPolicy`` dataclass
+# default (15.0s, calibrated for slower-changing fields, not a TX gate).
+_TX_TARGET_FALLBACK_MAX_AGE: float = 3.0
 
 _KEY_ACCEPTED = frozenset({TxOutcome.ACCEPTED, TxOutcome.IDEMPOTENT})  # lease is ours
 
@@ -3534,10 +3538,10 @@ class RadioPoller:
         to ``default_policy`` for any path with no declared capability (3.0s
         on IC-7300) — which needs no capability declaration for
         ``tx_target`` itself; see :meth:`_publish_tx_target` for why that
-        declaration must never exist. Falls back to ``_TX_TARGET_MIN_MAX_AGE``
-        (floored, not a bare multiple of the poll loop's own fast interval —
-        see that constant's comment) if a profile has no acquisition policy
-        at all.
+        declaration must never exist. Falls back to
+        ``_TX_TARGET_FALLBACK_MAX_AGE`` (a fixed default, not a bare multiple
+        of the poll loop's own fast interval — see that constant's comment)
+        if a profile has no acquisition policy at all.
         """
         acquisition = self._profile.state_acquisition
         ttl = (
@@ -3547,7 +3551,7 @@ class RadioPoller:
                 FieldPath.global_("tx_state", "tx_target")
             ).freshness_ttl_seconds
         )
-        return ttl if ttl is not None else _TX_TARGET_MIN_MAX_AGE
+        return ttl if ttl is not None else _TX_TARGET_FALLBACK_MAX_AGE
 
     def _publish_tx_target(self) -> None:
         """Recompute and, if changed or stale, republish tx_target (MOR-1496).

--- a/tests/test_acquisition_scheduler.py
+++ b/tests/test_acquisition_scheduler.py
@@ -37,6 +37,7 @@ from rigplane.core.state_pipeline_contracts import (
     SourceMetadata,
 )
 from rigplane.core.state_store import FreshnessClock, FreshnessState, StateStore
+from rigplane.profiles import get_radio_profile
 from rigplane.profiles.rig_loader import load_rig
 
 
@@ -1612,22 +1613,33 @@ def test_state_freshness_service_primes_once_then_reconciliation_cadence_resumes
     assert reconciled[0].priority is AcquisitionPriority.RECONCILIATION
 
 
-def test_state_freshness_service_reprimes_unobserved_field_after_bounded_interval() -> (
+def test_state_freshness_service_reprimes_unobserved_field_on_adaptive_interval() -> (
     None
 ):
-    """MOR-1490 review R2, Finding 1: bounded re-derivation, not a one-shot latch.
+    """MOR-1490 review R2, Finding 1 + MOR-1501 adaptive pacing.
 
     Replaces the old "primes exactly once, ever" expectation. A boolean
     latch meant a single dropped prime read stranded the field at
     ``UNKNOWN`` until process restart — reconnects don't rebuild the
     scheduler/service, so nothing ever re-armed the flag. The fix re-derives
-    the never-observed set at a bounded interval
-    (:data:`StateFreshnessService.PRIME_REDERIVE_INTERVAL_SECONDS`):
+    the never-observed set at a bounded interval — and MOR-1501 makes that
+    interval adaptive: :data:`StateFreshnessService.
+    PRIME_ADAPTIVE_INTERVAL_SECONDS` (5s) while any explicit
+    ``field_policies`` field is still unobserved, backing off to
+    :data:`StateFreshnessService.PRIME_REDERIVE_INTERVAL_SECONDS` (30s) only
+    once the never-observed set has genuinely emptied (see the companion
+    backoff test below):
 
-    - no re-prime while inside the window;
-    - a re-prime once the window elapses, as long as the field is still
-      unobserved;
+    - no re-prime while inside the fast window;
+    - a re-prime once the fast window elapses, as long as the field is
+      still unobserved;
     - no re-prime once the field has been observed (self-extinguishing).
+
+    Ticks use a deliberately unaligned 1.3s spacing — not an exact divisor
+    of the 5.0s adaptive interval, per the #2422 review R3 lesson that a
+    tick cadence divisible into the window under test can mask off-by-one
+    boundary bugs — so the boundary crossing below is real arithmetic, not
+    a tick landing exactly on the edge by construction.
     """
 
     clock = FreshnessClock(start=320.0)
@@ -1648,7 +1660,8 @@ def test_state_freshness_service_reprimes_unobserved_field_after_bounded_interva
     service = StateFreshnessService(
         store=store, scheduler=scheduler, interval_seconds=1.0
     )
-    interval = StateFreshnessService.PRIME_REDERIVE_INTERVAL_SECONDS
+    fast_interval = StateFreshnessService.PRIME_ADAPTIVE_INTERVAL_SECONDS
+    assert fast_interval == 5.0
 
     service.tick(now=clock.now())
     primed = scheduler.pending_requests()
@@ -1671,14 +1684,20 @@ def test_state_freshness_service_reprimes_unobserved_field_after_bounded_interva
     )
     assert scheduler.pending_requests() == ()
 
-    # Inside the re-derivation window: no re-prime yet.
-    for _ in range(int(interval) - 1):
-        clock.advance(1.0)
+    # Inside the fast re-derivation window: no re-prime yet.
+    tick_step = 1.3
+    elapsed = 0.0
+    while elapsed + tick_step < fast_interval:
+        clock.advance(tick_step)
+        elapsed += tick_step
         service.tick(now=clock.now())
-    assert scheduler.pending_requests() == ()
+        assert scheduler.pending_requests() == (), (
+            f"re-primed early at elapsed={elapsed:.2f}s < {fast_interval}s"
+        )
 
-    # Window elapses: the still-unobserved field gets re-primed.
-    clock.advance(1.0)
+    # This tick crosses the fast-interval boundary: the still-unobserved
+    # field gets re-primed.
+    clock.advance(tick_step)
     service.tick(now=clock.now())
     reprimed = scheduler.pending_requests()
     assert len(reprimed) == 1
@@ -1689,15 +1708,268 @@ def test_state_freshness_service_reprimes_unobserved_field_after_bounded_interva
     scheduler.record_acquisition_result(reprimed[0], change)
     assert scheduler.pending_requests() == ()
 
-    # Advance past another full re-derivation window. The field is now
-    # observed, so prime_unobserved must self-extinguish for it — no
-    # "prime-unobserved" request should reappear (any ordinary stale-refresh
-    # reconciliation the freshness decay independently schedules is a
-    # separate, expected mechanism and is not asserted against here).
-    clock.advance(interval)
+    # Advance past another full fast window. The field is now observed, so
+    # prime_unobserved must self-extinguish for it — no "prime-unobserved"
+    # request should reappear (any ordinary stale-refresh reconciliation the
+    # freshness decay independently schedules is a separate, expected
+    # mechanism and is not asserted against here).
+    clock.advance(fast_interval)
     service.tick(now=clock.now())
     assert all(
         request.reason != "prime-unobserved" for request in scheduler.pending_requests()
+    )
+
+
+def test_state_freshness_service_backs_off_to_slow_interval_once_set_empties() -> None:
+    """MOR-1501: back off from the fast to the slow re-derivation interval.
+
+    Once every explicit ``field_policies`` field has been observed, the
+    never-observed set is empty and re-checking every
+    :data:`StateFreshnessService.PRIME_ADAPTIVE_INTERVAL_SECONDS` (5s) would
+    cost a ``store.snapshot()`` + ``field_policies`` scan forever for no
+    benefit. The service must schedule its NEXT re-derivation using
+    :data:`StateFreshnessService.PRIME_REDERIVE_INTERVAL_SECONDS` (30s)
+    instead. Observable behavior (no spurious "prime-unobserved" request)
+    is identical for either interval once the field is genuinely observed,
+    so the only way to actually distinguish "backed off" from "still on the
+    fast cadence" is the scheduled deadline itself — checked directly here.
+    """
+
+    clock = FreshnessClock(start=500.0)
+    mic_gain = FieldPath.global_("operator_controls", "mic_gain")
+    profile = RadioAcquisitionProfile(
+        provider="test_provider",
+        capabilities=(
+            FieldCapability(path=mic_gain, command_response_observable=True),
+        ),
+        field_policies={
+            mic_gain: AcquisitionPolicy(
+                cadence_seconds=15.0, freshness_ttl_seconds=25.0
+            ),
+        },
+    )
+    store = StateStore(freshness_clock=clock)
+    scheduler = AcquisitionScheduler(profile=profile, clock=clock)
+    service = StateFreshnessService(
+        store=store, scheduler=scheduler, interval_seconds=1.0
+    )
+    fast_interval = StateFreshnessService.PRIME_ADAPTIVE_INTERVAL_SECONDS
+    slow_interval = StateFreshnessService.PRIME_REDERIVE_INTERVAL_SECONDS
+    assert slow_interval > fast_interval
+
+    service.tick(now=clock.now())
+    primed = scheduler.pending_requests()
+    assert len(primed) == 1
+
+    # The radio answers immediately — the never-observed set empties.
+    change = store.apply(_observation(mic_gain, 40, at=clock.now(), max_age=25.0))
+    scheduler.record_acquisition_result(primed[0], change)
+    assert scheduler.pending_requests() == ()
+
+    # Unaligned advance past the fast interval only (see the companion
+    # adaptive-reprime test's docstring for why not an exact multiple).
+    clock.advance(fast_interval + 0.3)
+    service.tick(now=clock.now())
+    assert all(
+        request.reason != "prime-unobserved" for request in scheduler.pending_requests()
+    )
+    assert service._next_prime_monotonic == pytest.approx(  # noqa: SLF001
+        clock.now() + slow_interval
+    )
+
+
+def test_prime_unobserved_round_robin_cursor_reaches_fields_behind_dead_leaders() -> (
+    None
+):
+    """MOR-1501, A1 from #2415's review: round-robin ``_prime_cursor``.
+
+    Five PERMANENTLY unanswerable "leader" fields sit ahead of two healthy
+    fields in ``field_policies`` declaration order — exactly matching the
+    burst cap (``_PRIME_UNOBSERVED_BURST_LIMIT`` == 5). Without a
+    round-robin cursor, ``prime_unobserved`` always rescans from index 0:
+    each call re-queues the same 5 dead leaders (freed back to eligible by
+    ``record_acquisition_failure`` the instant they fail — the exact R3
+    re-drop cycle) and the loop never reaches the healthy fields behind
+    them — permanent starvation. With the cursor rotating past whatever it
+    scanned, the healthy fields must get primed within a small, bounded
+    number of invocations.
+    """
+
+    clock = FreshnessClock(start=700.0)
+    leaders = [
+        FieldPath.global_("operator_controls", f"dead_leader_{i}") for i in range(5)
+    ]
+    healthy = [FieldPath.global_("operator_controls", f"healthy_{i}") for i in range(2)]
+    all_paths = leaders + healthy
+    profile = RadioAcquisitionProfile(
+        provider="test_provider",
+        capabilities=tuple(
+            FieldCapability(path=path, command_response_observable=True)
+            for path in all_paths
+        ),
+        field_policies={
+            # Distinct policy per path so none of these coalesce — keeps
+            # the per-call path accounting unambiguous.
+            path: AcquisitionPolicy(
+                cadence_seconds=15.0 + index, freshness_ttl_seconds=25.0
+            )
+            for index, path in enumerate(all_paths)
+        },
+    )
+    scheduler = AcquisitionScheduler(profile=profile, clock=clock)
+
+    healthy_set = set(healthy)
+    leader_set = set(leaders)
+    seen_healthy: set[FieldPath] = set()
+    max_invocations = 3
+    for _ in range(max_invocations):
+        queued = scheduler.prime_unobserved(observed_paths=())
+        queued_paths = {path for request in queued for path in request.paths}
+        seen_healthy |= queued_paths & healthy_set
+        if seen_healthy == healthy_set:
+            break
+        for request in queued:
+            if set(request.paths) & leader_set:
+                scheduler.record_acquisition_failure(
+                    request,
+                    reason="acquisition_request_timeout",
+                    now=clock.now(),
+                    link_healthy=False,
+                )
+
+    assert seen_healthy == healthy_set, (
+        f"healthy fields never primed within {max_invocations} invocations "
+        "— round-robin cursor is not rotating past dead leaders"
+    )
+
+
+def test_state_freshness_service_dead_link_reprime_rate_stays_bounded() -> None:
+    """MOR-1501 R3 lesson: shortening the re-derivation interval from 30s to
+    5s makes a fully dead link get re-drop-cycled ~6x more often — a REAL
+    increase in wire-write attempts (every ``pending_requests()`` entry is
+    later drained by a real backend executor performing an actual
+    ``send_query`` write), not a free retry. This must stay BOUNDED — at
+    most the burst cap's worth of new attempts per adaptive-interval window
+    — not grow without bound across ticks.
+    """
+
+    clock = FreshnessClock(start=900.0)
+    dead_paths = [FieldPath.global_("operator_controls", f"dead_{i}") for i in range(5)]
+    profile = RadioAcquisitionProfile(
+        provider="test_provider",
+        capabilities=tuple(
+            FieldCapability(path=path, command_response_observable=True)
+            for path in dead_paths
+        ),
+        field_policies={
+            path: AcquisitionPolicy(
+                cadence_seconds=15.0 + index, freshness_ttl_seconds=25.0
+            )
+            for index, path in enumerate(dead_paths)
+        },
+    )
+    store = StateStore(freshness_clock=clock)
+    scheduler = AcquisitionScheduler(profile=profile, clock=clock)
+    service = StateFreshnessService(
+        store=store, scheduler=scheduler, interval_seconds=1.0
+    )
+    fast_interval = StateFreshnessService.PRIME_ADAPTIVE_INTERVAL_SECONDS
+
+    windows = 6
+    total_attempts = 0
+    for _ in range(windows):
+        service.tick(now=clock.now())
+        pending = scheduler.pending_requests()
+        # Never more outstanding than the burst cap — no unbounded growth.
+        assert len(pending) <= 5
+        total_attempts += len(pending)
+        for request in pending:
+            scheduler.record_acquisition_failure(
+                request,
+                reason="acquisition_request_timeout",
+                now=clock.now(),
+                link_healthy=False,
+            )
+        assert scheduler.pending_requests() == ()
+        clock.advance(fast_interval + 0.1)
+
+    # Every window on this fully-dead, always-failing link re-attempts
+    # exactly the burst cap's worth — 5 attempts * 6 windows here — not
+    # more (bounded rate), and not fewer (the mechanism keeps trying, which
+    # is the whole point of the fast adaptive interval).
+    assert total_attempts == 5 * windows
+
+
+def test_state_freshness_service_ic7300_non_polling_populate_completes_within_25s() -> (
+    None
+):
+    """MOR-1501 acceptance criterion.
+
+    Simulates the real IC-7300 acquisition profile's 23 non-polling
+    ``field_policies`` fields populating from a cold connect (empty store).
+    Before adaptive pacing, the flat 30s re-derivation interval combined
+    with the unchanged 5-field burst cap gave this profile a ~120s tail
+    (``ceil(23 / 5) == 5`` waves, 30s apart), even though each field's true
+    CI-V round-trip cost is ~1.1s — the interval, not the serial link, was
+    the bottleneck. With the 5s adaptive interval the same 5 waves complete
+    in ~20-25s. This drives the scheduler/service pair directly (no real
+    transport), answering every primed request as soon as it is queued —
+    the "best case" the acceptance criterion is stated against; real serial
+    latency (~1.1s/field) is much smaller than the 5s window and does not
+    change which wave a field lands in.
+    """
+
+    acquisition_profile = get_radio_profile("IC-7300")
+    acquisition = acquisition_profile.state_acquisition
+    assert acquisition is not None
+
+    non_polling_paths = frozenset(
+        path
+        for path in acquisition.field_policies
+        if not acquisition.capability_for(path).can_poll
+    )
+    # Measured baseline this ticket's motivation is stated against
+    # (MOR-1501) — guards against silent membership drift changing the
+    # shape of this regression test without anyone noticing.
+    assert len(non_polling_paths) == 23
+
+    clock = FreshnessClock(start=2000.0)
+    store = StateStore(freshness_clock=clock)
+    scheduler = AcquisitionScheduler(profile=acquisition, clock=clock)
+    service = StateFreshnessService(
+        store=store, scheduler=scheduler, interval_seconds=0.05
+    )
+
+    observed_at: dict[FieldPath, float] = {}
+    tick_step = 1.0
+    elapsed = 0.0
+    # Bound the simulation comfortably past the ~25s target so a real
+    # regression fails the assertion below instead of looping forever.
+    while elapsed <= 40.0 and len(observed_at) < len(non_polling_paths):
+        service.tick(now=clock.now())
+        for request in scheduler.pending_requests():
+            relevant = [path for path in request.paths if path in non_polling_paths]
+            if not relevant:
+                continue
+            last_change = None
+            for path in relevant:
+                last_change = store.apply(
+                    _observation(
+                        path, "primed", at=clock.now(), max_age=request.max_age
+                    )
+                )
+                observed_at.setdefault(path, elapsed)
+            assert last_change is not None
+            scheduler.record_acquisition_result(request, last_change)
+        clock.advance(tick_step)
+        elapsed += tick_step
+
+    missing = non_polling_paths - observed_at.keys()
+    assert not missing, (
+        f"never observed within simulation window: {sorted(str(p) for p in missing)}"
+    )
+    assert max(observed_at.values()) <= 25.0, (
+        f"slowest field observed at {max(observed_at.values())}s, target <=25s"
     )
 
 

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -4410,7 +4410,7 @@ async def test_tx_target_max_age_floors_fallback_for_profile_without_acquisition
     block, so the old bare ``4 * self._fast_interval`` fallback floored at
     0.1s on its LAN profile (25ms fast interval) — the verifier measured
     6.6 stale-transitions/s from that on an otherwise-idle radio. The
-    fallback must floor at ``_TX_TARGET_MIN_MAX_AGE`` instead."""
+    fallback must floor at ``_TX_TARGET_FALLBACK_MAX_AGE`` instead."""
 
     radio = _make_radio(model="IC-705")
     assert radio.profile.state_acquisition is None

--- a/tests/test_state_acquisition_policy.py
+++ b/tests/test_state_acquisition_policy.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import textwrap
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 
 import pytest
 
@@ -653,6 +653,129 @@ def test_ic7300_profile_enrolls_exact_supported_observation_rows() -> None:
     assert profile.cmd29_routes == frozenset()
 
 
+# Ingress mappings that live as hardcoded command/sub branches in
+# ``_observations_from_frame`` rather than one of its lookup dicts: rit_freq/
+# rit_on/rit_tx (cmd 0x21), agc_time_constant (cmd 0x1A sub 0x04),
+# filter_width (cmd 0x1A sub 0x03, profile-dependent decode), cw_pitch/
+# key_speed (cmd 0x14, non-linear decode helpers), and vox_delay (cmd 0x1A
+# sub 0x05, 2-byte ctl-mem prefix rather than a plain sub byte). Kept as an
+# explicit set -- not derivable from a dict import -- because the production
+# code itself is branch-shaped there, not table-shaped; extend this set if a
+# future field adds another such branch.
+_HARDCODED_OBSERVABLE_FIELDS = {
+    ("global", "operator_controls", "rit_freq"),
+    ("global", "tx_state", "rit_on"),
+    ("global", "tx_state", "rit_tx"),
+    ("receiver", "operator_controls", "agc_time_constant"),
+    ("receiver", "freq_mode", "filter_width"),
+    ("global", "operator_controls", "cw_pitch"),
+    ("global", "operator_controls", "key_speed"),
+    ("global", "operator_controls", "vox_delay"),
+}
+
+# Minimal, per-field synthetic response payload for the round-trip probe
+# below. For vox_delay this is APPENDED after the 2-byte ctl-mem prefix the
+# query itself supplies (see ``_round_trip_observes``); for every other
+# field it is the frame's entire ``data``. Values are chosen only to satisfy
+# each branch's own length/shape checks (e.g. "at least 3 bytes", "at least
+# 2 bytes") -- the decoded VALUE is never asserted, only that a matching
+# observation is produced at all.
+_HARDCODED_SYNTHETIC_PAYLOAD: dict[str, bytes] = {
+    "rit_freq": b"\x00\x00\x00",
+    "rit_on": b"\x01",
+    "rit_tx": b"\x01",
+    "agc_time_constant": b"\x00",
+    "filter_width": b"\x01",
+    "cw_pitch": b"\x00\x00",
+    "key_speed": b"\x00\x00",
+    "vox_delay": b"\x00",
+}
+
+
+def _table_backed_ingress_spec(command: int, sub: int) -> tuple[str, str, str] | None:
+    """Resolve the ingress table entry AT this exact (command, sub) key.
+
+    Mirrors ``_civ_rx._observations_from_frame``'s own table selection --
+    looked up by the SAME sub key the query uses, not scanned out of a union
+    of every table's values. That distinction matters: a transposed ingress
+    key (e.g. filter_shape accidentally keyed under 0x55 instead of the real
+    0x56) still leaves the correct spec present *somewhere* in a
+    ``set(table.values())`` union, so a plain membership check against that
+    union cannot catch it. A keyed ``.get(sub)`` lookup can: it fails (or
+    resolves to the WRONG spec) the moment the query's sub and the ingress
+    table's key disagree.
+    """
+
+    from rigplane.runtime import _civ_rx
+
+    if command == 0x14:
+        return _civ_rx._OBSERVABLE_CMD14_FIELDS.get(sub)
+    if command == 0x15:
+        return _civ_rx._OBSERVABLE_CMD15_FIELDS.get(sub)
+    if command == 0x16:
+        bool_spec = _civ_rx._OBSERVABLE_CMD16_FIELDS.get(sub)
+        if bool_spec is not None:
+            return bool_spec
+        value_entry = _civ_rx._OBSERVABLE_CMD16_VALUE_FIELDS.get(sub)
+        return None if value_entry is None else value_entry[0]
+    if command == 0x1B:
+        return _civ_rx._OBSERVABLE_CMD1B_FIELDS.get(sub)
+    return None
+
+
+def _round_trip_observes(
+    radio: Any,
+    path: FieldPath,
+    query: tuple[int, int | bytes | None, int | None],
+) -> None:
+    """Push a synthetic response for ``query`` through the REAL ingress
+    decode and assert ``path`` comes out the other side.
+
+    Unlike a static table/set lookup, this exercises the actual branch in
+    ``_observations_from_frame`` end to end: it fails just as loudly whether
+    the bug is a wrong sub byte, a wrong ctl-mem prefix (vox_delay), or a
+    branch condition that silently doesn't match the exact bytes
+    ``IcomCivAcquisitionExecutor.query_for_path`` sends -- there is no
+    static structure left to reason about that a value-set membership check
+    could paper over.
+    """
+
+    from rigplane.core.acquisition_scheduler import split_ctl_mem_sub
+    from rigplane.commands import CONTROLLER_ADDR
+    from rigplane.types import CivFrame
+
+    command, sub_raw, receiver = query
+    civ_sub, prefix = split_ctl_mem_sub(sub_raw)
+    payload = _HARDCODED_SYNTHETIC_PAYLOAD[path.name]
+    frame = CivFrame(
+        to_addr=CONTROLLER_ADDR,
+        from_addr=0x94,  # IC-7300's civ_addr (rigs/ic7300.toml)
+        command=command,
+        sub=civ_sub,
+        data=prefix + payload,
+        receiver=receiver,
+    )
+
+    observations = radio._civ_runtime._observations_from_frame(frame)  # noqa: SLF001
+    expected = (path.scope.value, path.family.value, path.name)
+    matched = [
+        observation
+        for observation in observations
+        if (
+            observation.path.scope.value,
+            observation.path.family.value,
+            observation.path.name,
+        )
+        == expected
+    ]
+    assert matched, (
+        f"{path}: synthetic response (command=0x{command:02x}, sub={civ_sub!r}, "
+        f"data={(prefix + payload).hex()}) produced no matching observation -- "
+        "either the ingress branch doesn't match what query_for_path actually "
+        "sends, or a primed read for this path would never leave UNKNOWN"
+    )
+
+
 def test_ic7300_non_polling_field_policies_have_full_acquisition_chain() -> None:
     """MOR-1483/1491/1492/1493 (field-policy membership wave) guard.
 
@@ -669,10 +792,24 @@ def test_ic7300_non_polling_field_policies_have_full_acquisition_chain() -> None
     a structural property, not a hardcoded list of field names -- so any
     future membership addition of this shape is caught by this same test
     without editing it.
+
+    MOR-1501 (#2430 note) hardened the ingress check itself: the previous
+    version only asserted the query's (scope, family, name) triple appeared
+    SOMEWHERE in the union of every ingress table's values, which cannot
+    catch a query-sub / ingress-key mismatch (e.g. a transposed 0x56 -> 0x55)
+    as long as the triple is still present at some OTHER key. Table-backed
+    fields are now checked by keyed lookup at the query's own sub byte;
+    branch-shaped fields (rit_freq/rit_on/rit_tx, agc_time_constant,
+    filter_width, cw_pitch, key_speed, vox_delay) are checked with an actual
+    round trip through ``_observations_from_frame`` using a synthetic
+    response built from the query's own command/sub/prefix bytes -- a
+    transposed sub or a wrong ctl-mem prefix both make the corresponding
+    branch condition fail to match, producing zero observations and a red
+    test either way.
     """
 
     from rigplane.core.acquisition_scheduler import IcomCivAcquisitionExecutor
-    from rigplane.runtime import _civ_rx
+    from rigplane.radio import IcomRadio
 
     profile = get_radio_profile("IC-7300")
     acquisition = profile.state_acquisition
@@ -684,37 +821,7 @@ def test_ic7300_non_polling_field_policies_have_full_acquisition_chain() -> None
         return None
 
     executor = IcomCivAcquisitionExecutor(_noop_send)
-
-    # Ingress mappings that live as hardcoded command/sub branches in
-    # ``_observations_from_frame`` rather than one of its lookup dicts:
-    # rit_freq/rit_on/rit_tx (cmd 0x21), agc_time_constant (cmd 0x1A sub
-    # 0x04), filter_width (cmd 0x1A sub 0x03, profile-dependent decode), and
-    # cw_pitch/key_speed (cmd 0x14, non-linear decode helpers). Kept as an
-    # explicit set -- not derivable from a dict import -- because the
-    # production code itself is branch-shaped there, not table-shaped;
-    # extend this set if a future field adds another such branch.
-    hardcoded_observable = {
-        ("global", "operator_controls", "rit_freq"),
-        ("global", "tx_state", "rit_on"),
-        ("global", "tx_state", "rit_tx"),
-        ("receiver", "operator_controls", "agc_time_constant"),
-        ("receiver", "freq_mode", "filter_width"),
-        ("global", "operator_controls", "cw_pitch"),
-        ("global", "operator_controls", "key_speed"),
-        # MOR-1483 (leg 2): voxDelay's ctl-mem (0x1A/0x05) ingress decode is a
-        # hardcoded branch keyed by a 2-byte control-number prefix, not a
-        # dict entry keyed by a plain sub byte -- same shape as the other
-        # entries in this set.
-        ("global", "operator_controls", "vox_delay"),
-    }
-    table_observable = set(_civ_rx._OBSERVABLE_CMD14_FIELDS.values())
-    table_observable |= set(_civ_rx._OBSERVABLE_CMD15_FIELDS.values())
-    table_observable |= set(_civ_rx._OBSERVABLE_CMD16_FIELDS.values())
-    table_observable |= {
-        spec for spec, _decode_mode in _civ_rx._OBSERVABLE_CMD16_VALUE_FIELDS.values()
-    }
-    table_observable |= set(_civ_rx._OBSERVABLE_CMD1B_FIELDS.values())
-    known_observable = table_observable | hardcoded_observable
+    radio = IcomRadio(host="192.168.1.100", model="IC-7300")
 
     non_polling_paths = [
         path
@@ -740,9 +847,22 @@ def test_ic7300_non_polling_field_policies_have_full_acquisition_chain() -> None
         )
 
         key = (path.scope.value, path.family.value, path.name)
-        assert key in known_observable, (
-            f"{path}: no ingress observation mapping -- a primed read for "
-            "this path would never leave UNKNOWN"
+        if key in _HARDCODED_OBSERVABLE_FIELDS:
+            _round_trip_observes(radio, path, query)
+            continue
+
+        command, sub = query[0], query[1]
+        assert isinstance(sub, int), (
+            f"{path}: table-backed field must query with a plain int sub, "
+            f"got {sub!r} -- extend _HARDCODED_OBSERVABLE_FIELDS if this is "
+            "actually a new branch-shaped ingress mapping"
+        )
+        resolved = _table_backed_ingress_spec(command, sub)
+        assert resolved == key, (
+            f"{path}: query sends command=0x{command:02x} sub=0x{sub:02x}, "
+            f"but the ingress table at that exact key resolves to {resolved} "
+            f"instead of {key} -- a primed read for this path would never "
+            "leave UNKNOWN"
         )
 
 


### PR DESCRIPTION
## Summary

Three items from MOR-1501, plus one trivial rename carried over from #2422's review:

1. **Adaptive prime pacing** — `StateFreshnessService` now re-derives `AcquisitionScheduler.prime_unobserved`'s sweep every `PRIME_ADAPTIVE_INTERVAL_SECONDS` (5.0s) while any explicit `field_policies` field remains unobserved, backing off to the existing `PRIME_REDERIVE_INTERVAL_SECONDS` (30.0s) once `AcquisitionScheduler.has_unobserved_policy_fields` reports the set has emptied. The flat 30s interval gave the real IC-7300 profile's 23 non-polling `field_policies` fields a ~120s populate tail (5-field burst cap × 5 waves × 30s), even though each field's true CI-V round-trip cost is ~1.1s — the interval, not the serial link, was the bottleneck. Burst cap is unchanged (still the lane-protection knob).
2. **Round-robin `_prime_cursor`** (A1 from #2415's review) — `prime_unobserved` now rotates its scan start point through `field_policies` instead of always restarting at index 0, so ≥ burst-cap permanently-unanswerable leaders in declaration order can no longer starve reachable fields behind them.
3. **Guard-test correspondence** (item 2 / #2430 note) — `test_ic7300_non_polling_field_policies_have_full_acquisition_chain` previously checked only that a query's `(scope, family, name)` triple appeared *somewhere* in the union of every ingress table's values, which cannot catch a query-sub / ingress-key mismatch (e.g. a transposed `0x56` → `0x55`) as long as the triple is still reachable at some other key. Table-backed fields are now checked via a keyed lookup at the query's own sub byte; branch-shaped fields (`rit_freq`/`rit_on`/`rit_tx`, `agc_time_constant`, `filter_width`, `cw_pitch`, `key_speed`, `vox_delay`) are checked with an actual round trip through `_observations_from_frame` using a synthetic response built from the query's own command/sub/prefix bytes. Manually verified (outside the committed suite) that both a transposed CMD16 sub and a wrong `vox_delay` ctl-mem prefix make the corresponding check fail red.
4. **Trivial rename** (from #2422's review) — `radio_poller.py`'s `_TX_TARGET_MIN_MAX_AGE` → `_TX_TARGET_FALLBACK_MAX_AGE`. Chose rename over a `max()`-clamped floor: despite the "MIN" naming, the constant was never actually clamped — it's an unconditional substitute used only when a profile has no acquisition policy at all (nothing to clamp against in that branch), so the new name matches what it actually does.

## R3 lesson honesty (dead-link write rate)

Shortening the re-derivation interval from 30s to 5s genuinely raises the worst-case re-attempt rate on a fully dead link by ~6x: a primed "leader" that fails via `record_acquisition_failure` is freed back to eligible on the very next re-derivation, and every `pending_requests()` entry is later drained by a real backend executor (`IcomCivAcquisitionExecutor`) that performs an actual `send_query` wire write — not a free retry. This is documented directly in `_reprime_unobserved_if_due`'s docstring and covered by a new test (`test_state_freshness_service_dead_link_reprime_rate_stays_bounded`) that drives a permanently-unanswerable profile through several adaptive windows and asserts the per-window attempt count never exceeds the burst cap (bounded, not growing) — worst case ≤5 frames/5s = 1 frame/s, vs ≤5 frames/30s ≈0.167 frames/s before, both well under the ~20 q/s serial ceiling.

## Acceptance / measurements

- New test `test_state_freshness_service_ic7300_non_polling_populate_completes_within_25s` drives the real IC-7300 acquisition profile's 23 non-polling `field_policies` fields from a cold connect and asserts every field is observed within 25s (best case, no serial-latency modeling — matches the "≤~25s" target since real ~1.1s/field latency is far smaller than the 5s window).
- Cadence-owned (`due_requests()`) t0 poll coverage is untouched by this change — it only touches the `prime_unobserved` re-derivation path (non-polling, BACKGROUND-priority fields).
- MOR-1484's polling-demand medians are unaffected for the same reason: that measurement is derived from `pollable_paths()`/cadence math, which this PR does not modify.

## Test plan

- [x] `uv run pytest tests/test_acquisition_scheduler.py tests/test_state_acquisition_policy.py tests/test_radio_poller_coverage.py -q` — all pass (92 tests across the two primary files, 7 new)
- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 9179 passed, 12 skipped, 5 deselected, 14 xfailed, 1 xpassed, 0 failures
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `uv run mypy src/` — same 13 pre-existing baseline errors as `origin/main` (verified via `git stash`), none introduced by this diff
- [x] `uv run lint-imports` — 5 contracts kept, 0 broken
- [x] Manually verified (standalone script, not committed) that the rewritten guard test's correspondence check catches a simulated `0x56→0x55` CMD16 sub transposition, and that the round-trip probe catches a simulated wrong `vox_delay` ctl-mem prefix

Closes MOR-1501