### PR TITLE
fix: PBT facts degrade to unavailable when caps omit the range (MOR-1291)

### DIFF
--- a/frontend/src/lib/radio/filter-controls.ts
+++ b/frontend/src/lib/radio/filter-controls.ts
@@ -49,18 +49,28 @@ function pbtRange(): PbtRange {
  * a caller already has in hand rather than a module-global. Returns
  * `undefined` when the caps object carries no usable range, so `pbtRawToHz`/
  * `pbtHzToRaw` fall through to their own store-lookup default.
+ *
+ * MOR-1291: "usable" requires each of `raw_center`/`display_min`/
+ * `display_max` to be a finite number (rejecting `NaN`/`Infinity`, not just
+ * `undefined`), plus `raw_center !== 0` and `display_max !== 0` — both are
+ * divisors in `pbtRawToHz`/`pbtHzToRaw`, so a zero there would silently
+ * produce `NaN`/`Infinity` "known" readings rather than an honest
+ * unavailable one. A caps payload with a malformed `pbt_inner` entry is
+ * treated the same as one with no entry at all: `undefined`, never a
+ * fabricated or garbage value.
  */
 export function pbtRangeFromCaps(caps: Capabilities | null | undefined): PbtRange | undefined {
   const ctrl = caps?.controls?.pbt_inner;
+  if (!ctrl) return undefined;
+  const { raw_center: rawCenter, display_min: displayMin, display_max: displayMax } = ctrl;
   if (
-    ctrl &&
-    ctrl.raw_center !== undefined &&
-    ctrl.display_min !== undefined &&
-    ctrl.display_max !== undefined
+    typeof rawCenter !== 'number' || !Number.isFinite(rawCenter) || rawCenter === 0
+    || typeof displayMin !== 'number' || !Number.isFinite(displayMin)
+    || typeof displayMax !== 'number' || !Number.isFinite(displayMax) || displayMax === 0
   ) {
-    return { rawCenter: ctrl.raw_center, displayMin: ctrl.display_min, displayMax: ctrl.display_max };
+    return undefined;
   }
-  return undefined;
+  return { rawCenter, displayMin, displayMax };
 }
 
 /**
@@ -77,8 +87,17 @@ export function pbtRawToHz(raw: number, range?: PbtRange): number {
   return Math.round((raw - rawCenter) * (displayMax / rawCenter));
 }
 
-export function pbtHzToRaw(hz: number): number {
-  const { rawCenter, displayMax } = pbtRange();
+/**
+ * `range`, when supplied (MOR-1291, mirroring `pbtRawToHz`'s own `range`
+ * parameter, MOR-1284 F1), is used INSTEAD of the capabilities STORE lookup
+ * — pass `pbtRangeFromCaps(caps)` from a caller that already holds a `caps`
+ * argument so the conversion is a pure function of that argument rather than
+ * a hidden dependency on module-global store state. Every EXISTING call site
+ * omits `range` and keeps today's store-lookup behavior unchanged — this
+ * parameter is strictly additive.
+ */
+export function pbtHzToRaw(hz: number, range?: PbtRange): number {
+  const { rawCenter, displayMax } = range ?? pbtRange();
   const raw = Math.round(hz * (rawCenter / displayMax) + rawCenter);
   return Math.max(0, Math.min(255, raw));
 }

--- a/frontend/src/lib/runtime/adapters/__tests__/filter-passband-adapter.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/filter-passband-adapter.isolated.test.ts
@@ -44,6 +44,20 @@ function caps(overrides: Partial<Capabilities> = {}): Capabilities {
 const NEUTRAL_STORE_CAPS = caps();
 afterEach(() => setCapabilities(NEUTRAL_STORE_CAPS));
 
+/**
+ * MOR-1291: the IC-7610/IC-7300-shaped range a REAL radio profile's caps
+ * payload declares in its own `controls.pbt_inner` entry. Since the adapter
+ * no longer falls back to the capabilities STORE (or any other default) for
+ * `pbtInner`/`pbtOuter`/`ifShift` when `caps` omits its own range, every test
+ * below that wants those fields to be structurally present must declare this
+ * (or another explicit) range on its `caps` fixture — a bare `capabilities:
+ * ['pbt']` with no `controls` entry is now the "unsupported/unavailable"
+ * case, not an implicit stand-in for this shape.
+ */
+const DEFAULT_PBT_RANGE: ControlRange = {
+  raw_min: 0, raw_max: 255, raw_center: 128, display_min: -1200, display_max: 1200,
+};
+
 const fresh: FieldStatus = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' };
 const stale: FieldStatus = { storePath: 'x', observed: true, freshness: 'stale', availability: 'stale' };
 
@@ -112,7 +126,9 @@ describe('filterPassband evidence gate (MOR-1284, N3)', () => {
 
 describe('filterPassband per-field structural gates (MOR-1284)', () => {
   it('filterShape is structurally absent with no declared filters, even with pbt present', () => {
-    const view = model(bareState(), caps({ capabilities: ['pbt'] }));
+    const view = model(bareState(), caps({
+      capabilities: ['pbt'], controls: { pbt_inner: DEFAULT_PBT_RANGE },
+    }));
     expect(view.filterPassband!.filterShape.availability.structural).toBe(false);
     expect(view.filterPassband!.pbtInner.availability.structural).toBe(true);
   });
@@ -122,6 +138,38 @@ describe('filterPassband per-field structural gates (MOR-1284)', () => {
     expect(view.filterPassband!.pbtInner.availability.structural).toBe(false);
     expect(view.filterPassband!.pbtOuter.availability.structural).toBe(false);
     expect(view.filterPassband!.filterShape.availability.structural).toBe(true);
+  });
+
+  /**
+   * MOR-1291: the `pbt` capability tag ALONE is no longer enough —
+   * `pbtInner`/`pbtOuter` also require a usable `pbt_inner` range declared by
+   * THIS caps object. Without it there is no fabricated IC-7610-shaped
+   * substitute; the fields are structurally absent, same as if the `pbt`
+   * capability were missing entirely.
+   */
+  it('pbtInner/pbtOuter are structurally absent when pbt is declared but caps carries no usable pbt_inner range', () => {
+    const view = model(bareState(), caps({ capabilities: ['pbt'] }));
+    expect(view.filterPassband!.pbtInner).toEqual({
+      reading: { status: 'unknown' }, availability: { structural: false, operational: false },
+    });
+    expect(view.filterPassband!.pbtOuter).toEqual({
+      reading: { status: 'unknown' }, availability: { structural: false, operational: false },
+    });
+  });
+
+  it.each([
+    ['raw_center missing', { raw_min: 0, raw_max: 255, display_min: -1200, display_max: 1200 }],
+    ['display_min missing', { raw_min: 0, raw_max: 255, raw_center: 128, display_max: 1200 }],
+    ['display_max missing', { raw_min: 0, raw_max: 255, raw_center: 128, display_min: -1200 }],
+    ['display_max is zero (division-by-zero guard)', { raw_min: 0, raw_max: 255, raw_center: 128, display_min: -1200, display_max: 0 }],
+    ['raw_center is zero (division-by-zero guard)', { raw_min: 0, raw_max: 255, raw_center: 0, display_min: -1200, display_max: 1200 }],
+    ['display_max is NaN', { raw_min: 0, raw_max: 255, raw_center: 128, display_min: -1200, display_max: Number.NaN }],
+  ] as const)('pbtInner/pbtOuter are structurally absent for an invalid pbt_inner range — %s', (_label, badRange) => {
+    const view = model(bareState(), caps({
+      capabilities: ['pbt'], controls: { pbt_inner: badRange as unknown as ControlRange },
+    }));
+    expect(view.filterPassband!.pbtInner.availability.structural).toBe(false);
+    expect(view.filterPassband!.pbtOuter.availability.structural).toBe(false);
   });
 
   it('dataMode is structurally absent without the data_mode capability, even with filters+pbt present', () => {
@@ -164,35 +212,48 @@ describe('dataMode derivation (MOR-1284)', () => {
 });
 
 /**
- * PARITY PIN (MOR-1284, following the 4A F1 lesson). `pbtInner`/`pbtOuter`/
- * `ifShift` must consume the REAL `$lib/radio/filter-controls` helpers, not
- * a re-derived formula. The discriminating axis a naive re-implementation
- * would miss is the SAME one the X6200 CAT audit flagged for filter-width
- * tables: `pbtRawToHz` reads its raw<->Hz scale from the capabilities
- * STORE's `controls.pbt_inner` (rawCenter/displayMax), not from a constant.
- * A hand-rolled `(raw - 128) * (1200 / 128)` inside the adapter would match
- * every row that leaves the store at its IC-7610-shaped default and silently
- * diverge the instant a radio profile declares a non-default `pbt_inner`
- * control range — exactly the class of bug the 9-row `resolveFilterModeConfig`
- * matrix in `mode-filter-adapter.test.ts` killed for filter width.
+ * PARITY PIN (MOR-1284, following the 4A F1 lesson; MOR-1291 update). Every
+ * row now declares its OWN explicit `controls.pbt_inner` range — including
+ * the "default IC-7610-shaped" rows, which used to rely on `caps` omitting
+ * the range and `pbtRawToHz` falling through to the capabilities STORE.
+ * MOR-1291 removed that fallback from the fact layer: a `caps` object must
+ * declare its own range, explicitly, the same way a real IC-7610/IC-7300
+ * profile's capabilities payload does. `pbtInner`/`pbtOuter`/`ifShift` must
+ * consume the REAL `$lib/radio/filter-controls` helpers, not a re-derived
+ * formula — the discriminating axis a naive re-implementation would miss is
+ * the SAME one the X6200 CAT audit flagged for filter-width tables:
+ * `pbtRawToHz` reads its raw<->Hz scale from its `range` ARGUMENT, not from a
+ * constant. A hand-rolled `(raw - 128) * (1200 / 128)` inside the adapter
+ * would match every row that leaves the range at its IC-7610-shaped default
+ * and silently diverge the instant a radio profile declares a non-default
+ * `pbt_inner` control range — exactly the class of bug the 9-row
+ * `resolveFilterModeConfig` matrix in `mode-filter-adapter.test.ts` killed
+ * for filter width.
  *
  * Each row's "expected" value is computed by calling the SAME shipped
- * `pbtRawToHz`/`deriveIfShift` this test imports directly — this is a
+ * `pbtRawToHz`/`deriveIfShift` this test imports directly, with the SAME
+ * explicit range the row's `caps` fixture declares — this is a
  * regression/mutation-kill pin on the ADAPTER's wiring to those functions,
  * not a re-proof of their own arithmetic.
  */
-describe('pbtInner/pbtOuter/ifShift parity with the real filter-controls helpers (MOR-1284)', () => {
+describe('pbtInner/pbtOuter/ifShift parity with the real filter-controls helpers (MOR-1284, MOR-1291)', () => {
   const customPbtRange: ControlRange = {
     raw_min: 0, raw_max: 200, raw_center: 100, display_min: -900, display_max: 900,
   };
 
   const MATRIX: ReadonlyArray<{
-    name: string; controls?: Record<string, ControlRange>; pbtInner: number; pbtOuter: number;
+    name: string; controls: Record<string, ControlRange>; pbtInner: number; pbtOuter: number;
   }> = [
-    { name: 'default IC-7610 range, both centered (128/128)', pbtInner: 128, pbtOuter: 128 },
-    { name: 'default range, odd raw values that force rounding', pbtInner: 191, pbtOuter: 64 },
     {
-      name: 'custom capabilities-store PBT range (rawCenter 100, displayMax 900), asymmetric',
+      name: 'default IC-7610 range, both centered (128/128)',
+      controls: { pbt_inner: DEFAULT_PBT_RANGE }, pbtInner: 128, pbtOuter: 128,
+    },
+    {
+      name: 'default range, odd raw values that force rounding',
+      controls: { pbt_inner: DEFAULT_PBT_RANGE }, pbtInner: 191, pbtOuter: 64,
+    },
+    {
+      name: 'custom capabilities-declared PBT range (rawCenter 100, displayMax 900), asymmetric',
       controls: { pbt_inner: customPbtRange }, pbtInner: 50, pbtOuter: 175,
     },
     {
@@ -202,18 +263,20 @@ describe('pbtInner/pbtOuter/ifShift parity with the real filter-controls helpers
   ];
 
   it.each(MATRIX)('$name', ({ controls, pbtInner, pbtOuter }) => {
-    // The SAME caps object drives both the global store (what `pbtRawToHz`
-    // reads) and the adapter's `caps` parameter (what `hasCap` reads) —
-    // mirroring how `frontend-runtime.ts` wires `setCapabilities` and
-    // `runtime.caps` from one shared object in production.
-    const parityCaps = caps({ capabilities: ['pbt'], ...(controls ? { controls } : {}) });
-    setCapabilities(parityCaps);
+    const parityCaps = caps({ capabilities: ['pbt'], controls });
+    // The store is deliberately left at an UNRELATED shape (the neutral
+    // default) for every row — MOR-1291 proof-of-independence: the caps
+    // object's OWN range must drive the result, never the store.
+    setCapabilities(NEUTRAL_STORE_CAPS);
 
-    // Independently-derived expectation from the REAL imported functions —
-    // NOT a copy of the adapter's inputs; the adapter's OUTPUT is compared
-    // against what the shipped helpers themselves say.
-    const expectedInnerHz = pbtRawToHz(pbtInner);
-    const expectedOuterHz = pbtRawToHz(pbtOuter);
+    // Independently-derived expectation from the REAL imported functions,
+    // called with the SAME explicit range the row's `caps` fixture
+    // declares — NOT a copy of the adapter's inputs; the adapter's OUTPUT is
+    // compared against what the shipped helpers themselves say.
+    const range = controls.pbt_inner;
+    const explicitRange = { rawCenter: range.raw_center!, displayMin: range.display_min!, displayMax: range.display_max! };
+    const expectedInnerHz = pbtRawToHz(pbtInner, explicitRange);
+    const expectedOuterHz = pbtRawToHz(pbtOuter, explicitRange);
     const expectedIfShift = deriveIfShift(expectedInnerHz, expectedOuterHz);
 
     const view = model(bareState({
@@ -231,10 +294,12 @@ describe('pbtInner/pbtOuter/ifShift parity with the real filter-controls helpers
   });
 
   it('the custom-range rows actually produce a different scale than the default (sanity on the discriminator itself)', () => {
-    setCapabilities(NEUTRAL_STORE_CAPS);
-    const defaultHz = pbtRawToHz(50);
-    setCapabilities(caps({ controls: { pbt_inner: customPbtRange } }));
-    const customHz = pbtRawToHz(50);
+    const defaultHz = pbtRawToHz(50, { rawCenter: 128, displayMin: -1200, displayMax: 1200 });
+    const customHz = pbtRawToHz(50, {
+      rawCenter: customPbtRange.raw_center!,
+      displayMin: customPbtRange.display_min!,
+      displayMax: customPbtRange.display_max!,
+    });
     expect(customHz).not.toBe(defaultHz);
   });
 
@@ -245,9 +310,9 @@ describe('pbtInner/pbtOuter/ifShift parity with the real filter-controls helpers
     // diverge on exactly one side of this assertion.
     const wideRange: ControlRange = { raw_min: 0, raw_max: 255, raw_center: 128, display_min: -2000, display_max: 2000 };
     const parityCaps = caps({ capabilities: ['pbt'], controls: { pbt_inner: wideRange } });
-    setCapabilities(parityCaps);
+    setCapabilities(NEUTRAL_STORE_CAPS); // store deliberately unrelated — caps' own range must drive this
 
-    const expectedInnerHz = pbtRawToHz(255);
+    const expectedInnerHz = pbtRawToHz(255, { rawCenter: 128, displayMin: -2000, displayMax: 2000 });
     const expectedIfShift = deriveIfShift(expectedInnerHz, expectedInnerHz);
     expect(Math.abs(expectedInnerHz)).toBeGreaterThan(1200);
     expect(Math.abs(expectedIfShift)).toBe(1200);
@@ -263,22 +328,24 @@ describe('pbtInner/pbtOuter/ifShift parity with the real filter-controls helpers
 });
 
 /**
- * F1 (BLOCKER, verify round 1). `pbtInner`/`pbtOuter`/`ifShift` must be a
- * PURE function of `(state, caps)` — never of the capabilities STORE
- * singleton `pbtRawToHz` otherwise falls back to. Before the fix,
- * `deriveFilterPassband` called `pbtRawToHz(raw)` with no range argument, so
- * identical `(state, caps)` produced DIFFERENT facts depending on whatever
- * the store happened to hold, and — worse — a radio whose OWN `caps`
- * declared a non-default `controls.pbt_inner` range read a confidently wrong
- * `{status:'known'}` value sourced from an unrelated (e.g. still-empty)
- * store, exactly the fabrication class MOR-1280's F2 fix closed for
- * filterWidthMin/Max. Fix: `pbtRangeFromCaps(caps)` derives the range
- * explicitly from THIS call's own `caps` argument and is passed into
- * `pbtRawToHz` — the store lookup is now used ONLY when `caps` carries no
- * usable range of its own (the honest "we don't know this radio's scale"
- * case), never as an override of a range `caps` already declares.
+ * F1 (BLOCKER, verify round 1; MOR-1291 supersedes the store-fallback half
+ * of this pin). `pbtInner`/`pbtOuter`/`ifShift` must be a PURE function of
+ * `(state, caps)` — never of the capabilities STORE singleton. Before the
+ * MOR-1284 F1 fix, `deriveFilterPassband` called `pbtRawToHz(raw)` with no
+ * range argument, so identical `(state, caps)` produced DIFFERENT facts
+ * depending on whatever the store happened to hold, and — worse — a radio
+ * whose OWN `caps` declared a non-default `controls.pbt_inner` range read a
+ * confidently wrong `{status:'known'}` value sourced from an unrelated
+ * (e.g. still-empty) store, exactly the fabrication class MOR-1280's F2 fix
+ * closed for filterWidthMin/Max. F1 fixed the "caps declares its own range"
+ * half via `pbtRangeFromCaps(caps)`; MOR-1291 closes the REMAINING half —
+ * `caps` declaring NO range of its own no longer falls through to the store
+ * for a plausible substitute either. It is now structurally absent, full
+ * stop, so the store's content can never leak into the fact at all —
+ * "true independence" below, not merely "self-consistent with whatever the
+ * store happened to hold at read time" (the old block's weaker property).
  */
-describe('pbtInner/pbtOuter/ifShift are deterministic in (state, caps) — MOR-1284 F1', () => {
+describe('pbtInner/pbtOuter/ifShift are deterministic in (state, caps) — MOR-1284 F1, MOR-1291', () => {
   const rangeA: ControlRange = { raw_min: 0, raw_max: 255, raw_center: 128, display_min: -1200, display_max: 1200 };
   const rangeB: ControlRange = { raw_min: 0, raw_max: 200, raw_center: 100, display_min: -900, display_max: 900 };
   // The `caps` argument itself declares NO `controls.pbt_inner` — this is
@@ -294,21 +361,25 @@ describe('pbtInner/pbtOuter/ifShift are deterministic in (state, caps) — MOR-1
     ['store A (default-shaped)', caps({ controls: { pbt_inner: rangeA } })],
     ['store B (non-default)', caps({ controls: { pbt_inner: rangeB } })],
     ['store EMPTY (no controls at all)', caps()],
-  ] as const)('identical (state, caps) ⇒ identical facts, regardless of the store — %s', (_label, storeCaps) => {
-    setCapabilities(storeCaps);
-    const view = model(stateWithPbt, capsWithNoOwnRange);
-    // `capsWithNoOwnRange` has no `controls.pbt_inner` of its own, so
-    // `pbtRangeFromCaps` returns `undefined` and the adapter's own
-    // documented fallback (store lookup) applies HERE — this block's point
-    // is that a `caps` argument WITHOUT its own range still degrades
-    // predictably to "whatever pbtRange()'s try/catch default is" rather
-    // than reading three different values for three different stores when
-    // nothing about the request changed. Assert against the one real
-    // conversion function, not a hand-copied constant.
-    const expected = pbtRawToHz(200);
-    expect(view.filterPassband!.pbtInner.reading).toEqual({ status: 'known', value: expected });
-    expect(view.filterPassband!.pbtOuter.reading).toEqual({ status: 'known', value: expected });
-  });
+  ] as const)(
+    'TRUE INDEPENDENCE PIN (MOR-1291): caps without its own range obtains NOTHING from the store — structurally absent regardless of store A / B / EMPTY — %s',
+    (_label, storeCaps) => {
+      setCapabilities(storeCaps);
+      const view = model(stateWithPbt, capsWithNoOwnRange);
+      // `capsWithNoOwnRange` has no `controls.pbt_inner` of its own, so
+      // `pbtRangeFromCaps` returns `undefined` — MOR-1291: the adapter no
+      // longer falls through to the store for ANY substitute value here, so
+      // the fact is identically structurally-absent across all three store
+      // shapes, never merely "the same known value the store happens to
+      // agree with itself on".
+      const absent = {
+        reading: { status: 'unknown' as const }, availability: { structural: false, operational: false },
+      };
+      expect(view.filterPassband!.pbtInner).toEqual(absent);
+      expect(view.filterPassband!.pbtOuter).toEqual(absent);
+      expect(view.filterPassband!.ifShift).toEqual(absent);
+    },
+  );
 
   it('caps-declared range WINS over a conflicting store — the pre-capabilities-landed boot window (verifier Probe 2)', () => {
     // The store sits at its neutral/empty default (the ordinary "capabilities
@@ -318,8 +389,8 @@ describe('pbtInner/pbtOuter/ifShift are deterministic in (state, caps) — MOR-1
     const capsWithOwnRange = caps({ capabilities: ['pbt'], controls: { pbt_inner: rangeB } });
     const view = model(stateWithPbt, capsWithOwnRange);
     const expectedFromCaps = pbtRawToHz(200, { rawCenter: 100, displayMin: -900, displayMax: 900 });
-    const expectedFromEmptyStore = pbtRawToHz(200); // what the OLD store-only code would have said
-    expect(expectedFromCaps).not.toBe(expectedFromEmptyStore);
+    const shapeAStoreWouldHaveGiven = pbtRawToHz(200, { rawCenter: 128, displayMin: -1200, displayMax: 1200 });
+    expect(expectedFromCaps).not.toBe(shapeAStoreWouldHaveGiven);
     expect(view.filterPassband!.pbtInner.reading).toEqual({ status: 'known', value: expectedFromCaps });
   });
 
@@ -366,7 +437,7 @@ describe('ifShift raw-field vs PBT-derived branch selection (MOR-1284)', () => {
 
   it('without if_shift capability but with pbt, derives from PBT even when a stray raw ifShift field is present', () => {
     setCapabilities(NEUTRAL_STORE_CAPS);
-    const pbtOnlyCaps = caps({ capabilities: ['pbt'] });
+    const pbtOnlyCaps = caps({ capabilities: ['pbt'], controls: { pbt_inner: DEFAULT_PBT_RANGE } });
     const view = model(bareState({
       main: { ...bareState().main, ifShift: 900, pbtInner: 128, pbtOuter: 128 },
       fieldStatus: {
@@ -374,7 +445,8 @@ describe('ifShift raw-field vs PBT-derived branch selection (MOR-1284)', () => {
         'main.pbtInner': fresh, 'main.pbtOuter': fresh,
       },
     }), pbtOnlyCaps);
-    const expected = deriveIfShift(pbtRawToHz(128), pbtRawToHz(128));
+    const defaultRange = { rawCenter: 128, displayMin: -1200, displayMax: 1200 };
+    const expected = deriveIfShift(pbtRawToHz(128, defaultRange), pbtRawToHz(128, defaultRange));
     expect(view.filterPassband!.ifShift.reading).toEqual({ status: 'known', value: expected });
     expect(view.filterPassband!.ifShift.reading).not.toEqual({ status: 'known', value: 900 });
   });
@@ -390,23 +462,45 @@ describe('ifShift raw-field vs PBT-derived branch selection (MOR-1284)', () => {
  * `ifShiftControlStructural` (MOR-1494 review round) — a SEPARATE,
  * presentation-only flag `FilterSurface.svelte` uses to decide whether to
  * show the IF-shift ROW, deliberately independent of `ifShift.availability.
- * structural` above (which stays `hasIfShiftCap || hasPbtCap`, unchanged,
- * because `scope-adapter.ts`'s passband-center overlay still needs the
- * derived reading for a PBT-only radio). `ifShiftControlStructural` answers
- * the narrower question: does the radio have a REAL `if_shift` command.
+ * structural` above (which is `hasIfShiftCap || (hasPbtCap && hasPbtRange)`
+ * as of MOR-1291 — see that block's own header comment — because
+ * `scope-adapter.ts`'s passband-center overlay still needs the derived
+ * reading for a PBT-only radio THAT DECLARES A USABLE RANGE).
+ * `ifShiftControlStructural` answers the narrower question: does the radio
+ * have a REAL `if_shift` command.
  */
 describe('ifShiftControlStructural — the presentation-only IF-shift control gate (MOR-1494)', () => {
-  it('IC-7300-shaped (pbt, no if_shift): false, even though the derived fact stays structural', () => {
+  it('IC-7300-shaped (pbt + declared range, no if_shift): false, even though the derived fact stays structural', () => {
     const view = model(bareState({
       main: { ...bareState().main, pbtInner: 200, pbtOuter: 60 },
       fieldStatus: { ...bareState().fieldStatus, 'main.pbtInner': fresh, 'main.pbtOuter': fresh },
-    }), caps({ capabilities: ['pbt'] }));
+    }), caps({ capabilities: ['pbt'], controls: { pbt_inner: DEFAULT_PBT_RANGE } }));
     expect(view.filterPassband!.ifShiftControlStructural).toBe(false);
     // The trap: a naive fix that reused `ifShiftStructural` for this flag
     // too would silently break `scope-adapter.ts`'s derived reading for
     // exactly this radio shape. It must stay untouched.
     expect(view.filterPassband!.ifShift.availability.structural).toBe(true);
     expect(view.filterPassband!.ifShift.reading.status).toBe('known');
+  });
+
+  /**
+   * MOR-1291: the NEW degrade case — `pbt` declared but NO usable range.
+   * `ifShiftControlStructural` stays `false` (still no real `if_shift`
+   * command; unaffected by the range), but now the underlying derived
+   * `ifShift` FACT also becomes structurally absent, since there is no scale
+   * to derive an Hz value with. This is the fabrication path MOR-1291
+   * closes — a caps-declared-but-rangeless PBT radio no longer gets an
+   * IC-7610-shaped stand-in reading via the store fallback.
+   */
+  it('IC-7300-shaped WITHOUT a declared PBT range: ifShiftControlStructural stays false, AND the derived ifShift fact becomes structurally absent too', () => {
+    const view = model(bareState({
+      main: { ...bareState().main, pbtInner: 200, pbtOuter: 60 },
+      fieldStatus: { ...bareState().fieldStatus, 'main.pbtInner': fresh, 'main.pbtOuter': fresh },
+    }), caps({ capabilities: ['pbt'] }));
+    expect(view.filterPassband!.ifShiftControlStructural).toBe(false);
+    expect(view.filterPassband!.ifShift).toEqual({
+      reading: { status: 'unknown' }, availability: { structural: false, operational: false },
+    });
   });
 
   it('FTX-1-shaped (if_shift, no pbt): true', () => {
@@ -436,7 +530,7 @@ describe('ifShiftControlStructural — the presentation-only IF-shift control ga
  * enforces for filterWidthMin/Max vs `modeObserved`.
  */
 describe('filterPassband honesty gate — no derivation from a half-observed input (MOR-1284, F2 lesson)', () => {
-  const pbtCaps = caps({ capabilities: ['pbt'] });
+  const pbtCaps = caps({ capabilities: ['pbt'], controls: { pbt_inner: DEFAULT_PBT_RANGE } });
 
   it('pbtInner observed, pbtOuter UNOBSERVED — ifShift must NOT derive from a fabricated pbtOuter default', () => {
     const view = model(bareState({

--- a/frontend/src/lib/runtime/adapters/__tests__/scope-adapter.authority.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/scope-adapter.authority.isolated.test.ts
@@ -93,6 +93,12 @@ function caps(overrides: Partial<Capabilities> = {}): Capabilities {
     capabilities: ['scope', 'dual_rx', 'filter_width', 'data_mode', 'pbt', 'if_shift'],
     receivers: 2, vfoScheme: 'main_sub', freqRanges: [], modes: ['USB', 'LSB'], filters: ['FIL1'],
     filterConfig: { USB: SEGMENT_RULE, LSB: SEGMENT_RULE },
+    // MOR-1291: a REAL `pbt`-capable radio's capabilities payload declares
+    // its own `controls.pbt_inner` range (IC-7610-shaped here) — the
+    // frontend fact layer no longer fabricates this scale from a store
+    // fallback when it is omitted, so this fixture must carry it explicitly
+    // for `pbtInnerHz`/`pbtOuterHz`/`ifShiftHz` below to stay populated.
+    controls: { pbt_inner: { raw_min: 0, raw_max: 255, raw_center: 128, display_min: -1200, display_max: 1200 } },
     audioConfig: { sampleRate: 48_000, channels: 1, codecs: ['pcm16'] },
     webrtc: { available: false, enabled: false }, txBands: [],
     ...overrides,

--- a/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
@@ -399,19 +399,29 @@ function deriveModeFilter(
  *  - `filterShape` is OPTIONAL and undeclared by any capability tag of its
  *    own; it is part of the same filter subsystem 4A's `filterWidth` is, so
  *    its structural gate is the SAME `hasFilters` signal that field uses.
- *  - `pbtInner`/`pbtOuter` are OPTIONAL, gated on `hasCap(caps, 'pbt')` —
- *    `toFilterProps`'s own `hasPbt` capability, verbatim.
+ *  - `pbtInner`/`pbtOuter` are OPTIONAL, gated on `hasCap(caps, 'pbt')` AND a
+ *    usable `pbt_inner` range declared by THIS `caps` argument itself
+ *    (`pbtRangeFromCaps`, MOR-1291) — `toFilterProps`'s own `hasPbt`
+ *    capability check alone is not enough here: unlike the v2 `panel-props.ts`
+ *    path, this fact layer never falls back to a plausible IC-7610-shaped
+ *    default (rawCenter 128 / ±1200 Hz) when a radio's own capabilities omit
+ *    the range. A `pbt`-capable radio with no declared scale is exposed as
+ *    structurally absent, not as a confidently-known reading sourced from
+ *    module-global store state.
  *  - `ifShift` mirrors `toFilterProps`'s own conditional BYTE-FOR-BYTE: a
  *    radio with the `if_shift` capability reports its own raw field; one
- *    without it, but WITH `pbt`, gets `deriveIfShift(pbtInner, pbtOuter)` —
- *    the ONE shipped fallback, not a re-derivation. Structural is therefore
- *    the OR of both paths (same "real OR, not a stand-in for AND" discipline
- *    `deriveRxAudio`'s `hasAfLevel` uses); operational for the derived path
- *    requires BOTH pbtInner AND pbtOuter to be honestly observed — deriving
- *    from one observed and one silently-defaulted-to-128 input is exactly
- *    the fabrication `deriveModeFilter`'s F2 fix forbids, so neither pbtInner
- *    nor pbtOuter nor ifShift ever computes over the OTHER field's ` ?? 128`
- *    fallback the way `toFilterProps` does.
+ *    without it, but WITH `pbt` AND a usable PBT range, gets
+ *    `deriveIfShift(pbtInner, pbtOuter)` — the ONE shipped fallback, not a
+ *    re-derivation. Structural is therefore the OR of both paths (same "real
+ *    OR, not a stand-in for AND" discipline `deriveRxAudio`'s `hasAfLevel`
+ *    uses), with the derived side additionally requiring the PBT range
+ *    (MOR-1291, same reasoning as `pbtInner`/`pbtOuter` above — there is no
+ *    scale to derive an Hz value with otherwise); operational for the
+ *    derived path requires BOTH pbtInner AND pbtOuter to be honestly
+ *    observed — deriving from one observed and one silently-defaulted-to-128
+ *    input is exactly the fabrication `deriveModeFilter`'s F2 fix forbids, so
+ *    neither pbtInner nor pbtOuter nor ifShift ever computes over the OTHER
+ *    field's ` ?? 128` fallback the way `toFilterProps` does.
  */
 function deriveFilterPassband(
   state: ServerState | null, caps: Capabilities | null,
@@ -446,13 +456,34 @@ function deriveFilterPassband(
   // `__tests__/filter-passband-adapter.isolated.test.ts`. Computed only from the
   // field's OWN raw value — never from a `?? 128` stand-in — so an unobserved
   // pbtInner/pbtOuter never silently seeds a derived ifShift.
+  //
+  // MOR-1291: `pbtScale` is used ONLY when it resolves to a CONCRETE range.
+  // Unlike `controlRangeFromCapsOrDefault`'s `nr_level`/`nb_depth` story
+  // below, PBT has no per-radio-model default worth falling back to — the
+  // IC-7610-shaped `{rawCenter:128, displayMin:-1200, displayMax:1200}`
+  // `pbtRawToHz`/`pbtHzToRaw` fall back to (via their own store lookup, when
+  // called with NO `range` argument) is exactly the fabrication this ticket
+  // closes: a caps object that declares the `pbt` capability but omits its
+  // OWN `controls.pbt_inner` range is treated as an honest "this radio's PBT
+  // scale is unknown", never silently coerced to a plausible-looking IC-7610
+  // reading sourced from module-global store state. `pbtRawToHz` is
+  // therefore never invoked with `pbtScale` absent — the store-fallback
+  // branch inside it exists only for the unrelated legacy `panel-props.ts`
+  // v2 call sites that still call it with no `range` argument at all.
   const pbtScale = pbtRangeFromCaps(caps);
+  const hasPbtRange = pbtScale !== undefined;
   const pbtInnerRaw = numOrUndef(rx?.pbtInner);
   const pbtOuterRaw = numOrUndef(rx?.pbtOuter);
-  const pbtInnerHz = pbtInnerRaw !== undefined ? pbtRawToHz(pbtInnerRaw, pbtScale) : undefined;
-  const pbtOuterHz = pbtOuterRaw !== undefined ? pbtRawToHz(pbtOuterRaw, pbtScale) : undefined;
+  const pbtInnerHz = pbtScale && pbtInnerRaw !== undefined ? pbtRawToHz(pbtInnerRaw, pbtScale) : undefined;
+  const pbtOuterHz = pbtScale && pbtOuterRaw !== undefined ? pbtRawToHz(pbtOuterRaw, pbtScale) : undefined;
 
-  const ifShiftStructural = hasIfShiftCap || hasPbtCap;
+  // `hasPbtRange` gates the DERIVED path the same way `hasPbtCap` alone used
+  // to: a radio that declares `pbt` but no usable `pbt_inner` range can never
+  // actually produce a PBT-derived ifShift Hz value (there is no scale to
+  // convert with), so claiming `structural: true` there would promise a
+  // reading that can never arrive. `hasIfShiftCap`'s own branch is untouched
+  // — a REAL if_shift command needs no PBT scale at all.
+  const ifShiftStructural = hasIfShiftCap || (hasPbtCap && hasPbtRange);
   const ifShiftOperational = hasIfShiftCap
     ? ifShiftRawObserved
     : (pbtInnerObserved && pbtOuterObserved);
@@ -480,8 +511,15 @@ function deriveFilterPassband(
     // dead). See `FilterPassbandViewModel.ifShiftControlStructural`'s doc
     // comment (`radio-view-model.ts`) for the full split.
     ifShiftControlStructural: hasIfShiftCap,
-    pbtInner: txAuxField(hasPbtCap, pbtInnerObserved, pbtInnerHz),
-    pbtOuter: txAuxField(hasPbtCap, pbtOuterObserved, pbtOuterHz),
+    // MOR-1291: structural requires BOTH the `pbt` capability tag AND a
+    // usable `pbt_inner` range from THIS caps argument — a radio that
+    // declares the capability but omits (or malforms) its own range is
+    // exposed as structurally absent (unavailable), same "hide, don't show
+    // dead" doctrine `ifShiftControlStructural` above already established,
+    // never a plausible IC-7610-shaped reading manufactured from a
+    // module-global store fallback (see the `pbtScale` doc comment above).
+    pbtInner: txAuxField(hasPbtCap && hasPbtRange, pbtInnerObserved, pbtInnerHz),
+    pbtOuter: txAuxField(hasPbtCap && hasPbtRange, pbtOuterObserved, pbtOuterHz),
     dataMode: txAuxField(hasDataModeCap, dataModeObserved, numOrUndef(rx?.dataMode)),
   };
 }

--- a/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.isolated.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.isolated.test.ts
@@ -923,6 +923,48 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
     expect(h.patchActiveReceiver).not.toHaveBeenCalled();
   });
 
+  /**
+   * MOR-1291 (handler-level no-command assertion). A radio can declare the
+   * `pbt` capability tag without declaring a usable `controls.pbt_inner`
+   * range (or with a malformed one). Before this fix, `makeFilterHandlers`'s
+   * PBT/IF-shift handlers inlined their own `pbtHzToRaw`/`pbtRange`
+   * duplicate, which silently fell back to an IC-7610-shaped default
+   * (rawCenter 128, ±1200 Hz) and dispatched a plausible-looking
+   * `set_pbt_inner`/`set_pbt_outer` command regardless. An unavailable
+   * control must never emit a backend command — every PBT-touching handler
+   * must instead produce NO command at all.
+   */
+  it('emits no command from any PBT/IF-shift handler when caps declares pbt but carries no usable pbt_inner range', () => {
+    h.caps = { ...h.caps, controls: {} } as Record<string, unknown>;
+    const filter = makeFilterHandlers();
+
+    filter.onPbtInnerChange(100);
+    filter.onPbtOuterChange(-100);
+    filter.onPbtReset();
+    filter.onIfShiftChange(300);
+
+    expect(h.sendCommand).not.toHaveBeenCalled();
+    expect(getCommandLifecycles()).toHaveLength(0);
+  });
+
+  it('emits no command from any PBT/IF-shift handler when the declared pbt_inner range is malformed (division-by-zero guard)', () => {
+    h.caps = {
+      ...h.caps,
+      controls: {
+        pbt_inner: { raw_min: 0, raw_max: 255, raw_center: 128, display_min: -1200, display_max: 0 },
+      },
+    } as Record<string, unknown>;
+    const filter = makeFilterHandlers();
+
+    filter.onPbtInnerChange(100);
+    filter.onPbtOuterChange(-100);
+    filter.onPbtReset();
+    filter.onIfShiftChange(300);
+
+    expect(h.sendCommand).not.toHaveBeenCalled();
+    expect(getCommandLifecycles()).toHaveLength(0);
+  });
+
   it('fails closed when receiver identity or required observed values are unavailable', () => {
     h.state = null;
     makeModeHandlers().onModeChange('AM');

--- a/frontend/src/lib/runtime/commands/panel-commands.ts
+++ b/frontend/src/lib/runtime/commands/panel-commands.ts
@@ -19,7 +19,6 @@ import {
 import {
   capabilitiesMatchGeneration,
   getCapabilities,
-  getControlRange,
 } from '$lib/stores/capabilities.svelte';
 import { getFieldStatus, isFieldAvailable } from '$lib/state/field-status';
 import { runtime } from '../frontend-runtime';
@@ -28,7 +27,9 @@ import { getModeFilter } from '$lib/radio/mode-filter-memory';
 import { relativeVfoIdentityUnknown, resolveFilterModeConfig } from '../props/panel-props';
 import type { FilterModeConfig, FilterSegmentConfig } from '$lib/types/capabilities';
 import { modInputCommand, modInputStateKey } from '$lib/radio/mod-input';
-import { nbDepthDisplayToRaw, nrDisplayToRaw } from '$lib/radio/filter-controls';
+import {
+  mapIfShiftToPbt, nbDepthDisplayToRaw, nrDisplayToRaw, pbtHzToRaw, pbtRangeFromCaps,
+} from '$lib/radio/filter-controls';
 import { audioManager } from '$lib/audio/audio-manager';
 import { adjustTuningStep, getTuningStep } from '$lib/stores/tuning.svelte';
 import { currentControlSessionEpoch, dispatchRadioIntent, isNormalizedLevel } from './radio-intents';
@@ -125,61 +126,18 @@ function toggleVox(): void {
   dispatchRadioIntent({ name: 'set_vox', params: { on: !current } });
 }
 
-/* ── Inlined PBT / IF-shift helpers (from filter-controls.ts) ────── */
-// TODO: replace with `$lib/radio/filter-controls` once #996 lands.
-
-const FILTER_BIPOLAR_MIN = -1200;
-const FILTER_BIPOLAR_MAX = 1200;
-
-const PBT_DEFAULTS = { rawCenter: 128, displayMin: -1200, displayMax: 1200 } as const;
-
-function pbtRange() {
-  try {
-    const ctrl = getControlRange('pbt_inner');
-    if (
-      ctrl &&
-      ctrl.raw_center !== undefined &&
-      ctrl.display_min !== undefined &&
-      ctrl.display_max !== undefined
-    ) {
-      return {
-        rawCenter: ctrl.raw_center,
-        displayMin: ctrl.display_min,
-        displayMax: ctrl.display_max,
-      };
-    }
-  } catch {
-    // capabilities store not available (e.g. in tests)
-  }
-  return PBT_DEFAULTS;
-}
-
-function pbtHzToRaw(hz: number): number {
-  const { rawCenter, displayMax } = pbtRange();
-  const raw = Math.round(hz * (rawCenter / displayMax) + rawCenter);
-  return Math.max(0, Math.min(255, raw));
-}
-
-function clampToBipolarRange(value: number): number {
-  return Math.max(FILTER_BIPOLAR_MIN, Math.min(FILTER_BIPOLAR_MAX, Math.round(value)));
-}
-
-function deriveIfShift(pbtInner: number, pbtOuter: number): number {
-  return clampToBipolarRange((pbtInner + pbtOuter) / 2);
-}
-
-function mapIfShiftToPbt(
-  targetIfShift: number,
-  currentPbtInner: number,
-  currentPbtOuter: number,
-): { pbtInner: number; pbtOuter: number } {
-  const currentIfShift = deriveIfShift(currentPbtInner, currentPbtOuter);
-  const delta = clampToBipolarRange(targetIfShift) - currentIfShift;
-  return {
-    pbtInner: clampToBipolarRange(currentPbtInner + delta),
-    pbtOuter: clampToBipolarRange(currentPbtOuter + delta),
-  };
-}
+/* ── PBT / IF-shift helpers ──────────────────────────────────────── */
+// MOR-1291: the local re-implementations that used to live here (`pbtRange`,
+// `pbtHzToRaw`, `clampToBipolarRange`, `deriveIfShift`, `mapIfShiftToPbt`)
+// are gone — this module now imports the ONE shipped versions from
+// `$lib/radio/filter-controls` (the neutral module #996 introduced). The
+// duplicate `pbtRange()` silently fell back to an IC-7610-shaped default
+// (rawCenter 128, ±1200 Hz) via the capabilities STORE whenever a radio's
+// caps omitted `controls.pbt_inner` — exactly the fabricated-command class
+// this ticket closes. `pbtRangeFromCaps(getCapabilities())` below is called
+// at each PBT command site instead, and the handler bails (emits nothing)
+// when it comes back `undefined`, rather than ever falling through to
+// `pbtHzToRaw`'s own store-fallback branch.
 
 /* ── Memory Handlers ─────────────────────────────────────────────── */
 
@@ -881,6 +839,14 @@ export function makeFilterHandlers() {
         const receiver = knownActiveReceiver('ifShift');
         if (receiver !== null) dispatchRadioIntent({ name: 'set_if_shift', params: { offset: value, receiver } });
       } else if (caps.capabilities.includes('pbt')) {
+        // MOR-1291: a radio can declare the `pbt` capability tag without
+        // (yet, or ever) declaring a usable `controls.pbt_inner` range — no
+        // fabricated IC-7610-shaped scale (rawCenter 128, ±1200 Hz) stands in
+        // for a range this radio's OWN capabilities never provided. Missing
+        // or malformed range ⇒ no command, same fail-closed shape every
+        // other guard below already uses.
+        const pbtRange = pbtRangeFromCaps(caps);
+        if (!pbtRange) return;
         const receiver = knownActiveReceiver('pbtInner');
         const state = getRadioState();
         const activeRx = getActiveReceiver();
@@ -897,26 +863,34 @@ export function makeFilterHandlers() {
           activeRx.pbtInner,
           activeRx.pbtOuter,
         );
-        dispatchRadioIntent({ name: 'set_pbt_inner', params: { value: pbtHzToRaw(pbtInner), receiver } });
-        dispatchRadioIntent({ name: 'set_pbt_outer', params: { value: pbtHzToRaw(pbtOuter), receiver } });
+        dispatchRadioIntent({ name: 'set_pbt_inner', params: { value: pbtHzToRaw(pbtInner, pbtRange), receiver } });
+        dispatchRadioIntent({ name: 'set_pbt_outer', params: { value: pbtHzToRaw(pbtOuter, pbtRange), receiver } });
       }
     },
     onPbtInnerChange: (value: number) => {
+      // MOR-1291: see `onIfShiftChange`'s pbt branch above — no command
+      // without a caps-declared PBT range.
+      const pbtRange = pbtRangeFromCaps(getCapabilities());
+      if (!pbtRange) return;
       const receiver = knownActiveReceiver('pbtInner');
       if (receiver === null) return;
-      dispatchRadioIntent({ name: 'set_pbt_inner', params: { value: pbtHzToRaw(value), receiver } });
+      dispatchRadioIntent({ name: 'set_pbt_inner', params: { value: pbtHzToRaw(value, pbtRange), receiver } });
     },
     onPbtOuterChange: (value: number) => {
+      const pbtRange = pbtRangeFromCaps(getCapabilities());
+      if (!pbtRange) return;
       const receiver = knownActiveReceiver('pbtOuter');
       if (receiver === null) return;
-      dispatchRadioIntent({ name: 'set_pbt_outer', params: { value: pbtHzToRaw(value), receiver } });
+      dispatchRadioIntent({ name: 'set_pbt_outer', params: { value: pbtHzToRaw(value, pbtRange), receiver } });
     },
     onPbtReset: () => {
+      const pbtRange = pbtRangeFromCaps(getCapabilities());
+      if (!pbtRange) return;
       const receiver = knownActiveReceiver('pbtInner');
       const state = getRadioState();
       const prefix = receiver === 1 ? 'sub' : 'main';
       if (receiver === null || !state || !isFieldAvailable(state, `${prefix}.pbtOuter`)) return;
-      const center = pbtHzToRaw(0);
+      const center = pbtHzToRaw(0, pbtRange);
       dispatchRadioIntent({ name: 'set_pbt_inner', params: { value: center, receiver } });
       dispatchRadioIntent({ name: 'set_pbt_outer', params: { value: center, receiver } });
     },

--- a/frontend/src/semantic/radio-view-model.ts
+++ b/frontend/src/semantic/radio-view-model.ts
@@ -337,11 +337,14 @@ export interface FilterPassbandViewModel {
   filterShape: FilterPassbandField<number>;
   ifShift: FilterPassbandField<number>;
   /**
-   * MOR-1494 review round. `ifShift.availability.structural` above stays
-   * `hasIfShiftCap || hasPbtCap` UNCHANGED — that OR is a fact-derivation
-   * gate (a radio with `pbt` but no `if_shift` still gets an honest derived
-   * `ifShift` READING, e.g. for `scope-adapter.ts`'s passband-center
-   * overlay). This is a SEPARATE, presentation-only gate: whether the radio
+   * MOR-1494 review round. `ifShift.availability.structural` above is a
+   * fact-derivation gate — `hasIfShiftCap || (hasPbtCap && hasPbtRange)`
+   * as of MOR-1291 (previously `hasIfShiftCap || hasPbtCap`; a radio that
+   * declares `pbt` but no usable `pbt_inner` range can never actually
+   * produce a derived reading, so it no longer claims structural presence
+   * either). A radio with `pbt` AND a declared range still gets an honest
+   * derived `ifShift` READING, e.g. for `scope-adapter.ts`'s passband-center
+   * overlay. This is a SEPARATE, presentation-only gate: whether the radio
    * has a REAL `if_shift` COMMAND of its own. IC-7300 (PBT-only) has none —
    * showing its IF-shift CONTROL permanently disabled with a PBT-derived
    * stand-in is a dead control (the owner's MOR-1494 ruling: hide


### PR DESCRIPTION
## Summary

MOR-1291: the 4A′ determinism fix (`pbtRangeFromCaps` + explicit `range?` param, PR #2216) covered the case where capabilities *declare* a `pbt_inner` range. It left one gap: when a `pbt`-capable radio's capabilities *omit* (or malform) that range, both the fact-derivation adapter and the command handlers silently fell through to a store lookup that defaults to an IC-7610-shaped scale (`rawCenter 128`, `±1200 Hz`) — a plausible-looking but fabricated value/command for a radio whose actual PBT scale is unknown.

This closes that gap per the owner's explicit directive (supersedes the ticket's older "default-range constant" option): missing/invalid PBT range now degrades to an honest **unavailable** control — never a fabricated default.

## Before / after

| Scenario | Before | After |
|---|---|---|
| `caps` declares `pbt` **with** a `controls.pbt_inner` range (IC-7300/IC-7610) | `pbtInner`/`pbtOuter`/`ifShift` known, PBT commands emitted | **Unchanged** — same known readings, same commands |
| `caps` declares `pbt` **without** a `controls.pbt_inner` range | `pbtInner`/`pbtOuter`/`ifShift` reported `known` with a value computed from an IC-7610-shaped default (or whatever the capabilities STORE happened to hold) — Case-B non-determinism | `pbtInner`/`pbtOuter` structurally **absent** (`availability.structural: false`); `ifShift`'s PBT-derived path also becomes structurally absent (a real `if_shift` capability is unaffected) |
| `caps.controls.pbt_inner` present but malformed (e.g. `display_max: 0`, `NaN`, missing fields) | Same fabricated-default fallback as above (or a `NaN`/`Infinity` "known" reading in the divide-by-zero case) | Treated identically to "no range at all" — structurally absent |
| User drags the PBT inner/outer slider, or IF-shift (PBT-derived path), with no usable range | `panel-commands.ts`'s own duplicated `pbtRange()`/`pbtHzToRaw()` inline helpers silently fell back to the IC-7610 default and dispatched `set_pbt_inner`/`set_pbt_outer` anyway | `onPbtInnerChange`/`onPbtOuterChange`/`onPbtReset`/`onIfShiftChange`'s PBT branch bail with **no command dispatched** |
| `FilterSurface.svelte` (V3) rendering | PBT sliders shown "live" with a store-fallback value even when the radio's own caps carried no range | PBT rows hidden entirely (existing `availability.structural`-gated rendering — no new UI code needed) |

## What changed

- **`frontend/src/lib/radio/filter-controls.ts`** — `pbtRangeFromCaps` now validates `raw_center`/`display_min`/`display_max` are finite numbers and non-zero (avoids `NaN`/`Infinity` from a divide-by-zero on a malformed entry), degrading a malformed `pbt_inner` the same as a missing one. `pbtHzToRaw` gained the same optional explicit `range` param `pbtRawToHz` already had (strictly additive; every existing call site is unaffected).
- **`frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts`** (`deriveFilterPassband`) — `pbtRawToHz` is now only ever called when `pbtRangeFromCaps(caps)` resolves to a concrete range; `pbtInner`/`pbtOuter`'s structural gate is now `hasPbtCap && hasPbtRange`, and `ifShift`'s derived-path structural gate is `hasIfShiftCap || (hasPbtCap && hasPbtRange)`. IC-7300/IC-7610 are unaffected — their profiles declare the range explicitly. The `#2424` scope-adapter trap (PBT-derived `ifShiftHz` still flowing through for a real IC-7300-shaped radio) is preserved and re-verified.
- **`frontend/src/lib/runtime/commands/panel-commands.ts`** — removed the inlined duplicate PBT/IF-shift helpers (`pbtRange`/`pbtHzToRaw`/`clampToBipolarRange`/`deriveIfShift`/`mapIfShiftToPbt`, marked `TODO: replace... once #996 lands`) in favor of importing the one shipped `$lib/radio/filter-controls` versions (narrow consolidation, no behavior change beyond the fallback removal). `onPbtInnerChange`/`onPbtOuterChange`/`onPbtReset`/`onIfShiftChange`'s PBT branch now call `pbtRangeFromCaps(getCapabilities())` and return without dispatching when it comes back `undefined`.
- **`frontend/src/semantic/radio-view-model.ts`** — doc-comment update only, reflecting the new `ifShift.availability.structural` gate.
- Test fixtures/updates (see below).

## Tests

- `frontend/src/lib/runtime/adapters/__tests__/filter-passband-adapter.isolated.test.ts` (44 tests):
  - Explicit PBT range maps raw correctly (parity matrix, now with every row — including the "default IC-7610 shape" rows — declaring its range explicitly rather than relying on an implicit store fallback).
  - **True-independence pin**: `caps` without its own range is structurally absent for `pbtInner`/`pbtOuter`/`ifShift` regardless of the capabilities STORE holding shape A / shape B / EMPTY (supersedes the old, weaker "self-consistent with whatever the store happens to hold" pin).
  - New coverage for malformed ranges (missing fields, `display_max: 0`, `raw_center: 0`, `NaN`).
  - `ifShiftControlStructural` — new case: PBT declared without a range, no real `if_shift` command → row stays hidden AND the underlying derived fact is now also structurally absent (previously it stayed "known" via the store fallback).
  - Existing supported-radio coverage (IC-7300/IC-7610-shaped fixtures) updated to declare the range explicitly and still passes unchanged.
- `frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.isolated.test.ts` (97 tests, +2 new):
  - **Handler-level no-command assertion**: `onPbtInnerChange`/`onPbtOuterChange`/`onPbtReset`/`onIfShiftChange` emit nothing when caps declares `pbt` with no usable range, and separately when the declared range is malformed (`display_max: 0`).
  - All pre-existing PBT command tests (raw↔Hz conversion, debounced ordering) pass unchanged.
- `frontend/src/lib/runtime/adapters/__tests__/scope-adapter.authority.isolated.test.ts` (43 tests) — fixture hardened to declare a realistic `controls.pbt_inner` range (matching what a real IC-7610/IC-7300 profile's capabilities payload provides), preserving the `#2424` trap test (`ifShiftHz` still derives from PBT for an IC-7300-shaped radio) and every other pre-existing assertion.

Verification run: `npx vitest run` → **330 files / 6991 tests, all green**. `npm run check` (svelte-check + tsc) → 0 errors. `npx eslint` on touched files → clean.

## Remaining risks / follow-up

- **Legacy v2 path untouched by design.** `frontend/src/lib/runtime/props/panel-props.ts`'s `toFilterProps` (consumed by the pre-V3 `FilterPanel.svelte`) still computes `pbtRawToHz(rx?.pbtInner ?? 128)` with no range argument at all, so it still falls back to the store/IC-7610 default and still renders the PBT sliders as if usable when a radio's caps omit the range. This is explicitly out of this ticket's scope (the ticket is about the "frontend fact/view-model path", i.e. V3) and touching it would have meant a 4th production file plus `FilterPanel.svelte` beyond the guardrail. **However**, the command-emission path is shared: `FilterPanel.svelte` wires to the *same* `panel-commands.ts` handlers this PR fixes (via `getFilterHandlers()`/`makeFilterHandlers()`), so no fabricated PBT *command* can be emitted from the legacy UI either — only its displayed *reading* can still be misleading. Recommend a follow-up ticket (MOR-1426, if that's the number already reserved for this) scoped to `panel-props.ts`/`FilterPanel.svelte` to apply the same "no range ⇒ hidden control" treatment there.
- `frontend/src/components-v2/panels/audio-scope/audio-spectrum-renderer.ts` has its own separate, hardcoded `pbtRawToHz(raw, center = 128, maxHz = 1200)` used purely for the audio-spectrum passband overlay's rendering math (no command emission). Left untouched per the rails' explicit "DO NOT TOUCH: audio/scope transport" — flagging for awareness only, not a MOR-1291 gap (never claimed as fact-layer output).
- `frontend/src/components-v2/panels/filter-controls.ts` is a second, near-duplicate of `$lib/radio/filter-controls.ts` (same functions, same store-fallback shape, no `range` params at all). It was left alone — the owner's instruction was to consolidate the duplicate legacy helper "ONLY if narrow and safe", and this file appears unused by any live import path I could find in this session; removing/merging it would be a separate, independently-verifiable cleanup rather than part of this fix.

**Is MOR-1291 complete?** Yes for its stated scope (the V3 fact/view-model path + the shared command-emission handlers) — every requirement in the owner's directive is implemented and tested. The legacy-v2 display-only gap above is a candidate for the MOR-1426 follow-up if that ticket doesn't already exist; I did not mark "Closes MOR-1291" pending owner confirmation that the legacy-path gap is intentionally out of scope (rather than silently missed) — happy to add it once confirmed.

## Test plan

- [x] `npx vitest run src/lib/runtime/adapters/__tests__/filter-passband-adapter.isolated.test.ts src/lib/runtime/adapters/__tests__/scope-adapter.authority.isolated.test.ts src/lib/runtime/commands/__tests__/panel-commands.intent.isolated.test.ts` — targeted, all green
- [x] `npx vitest run` (full frontend suite) — 330 files / 6991 tests green
- [x] `npm run check` (svelte-check + tsc) — 0 errors
- [x] `npx eslint` on touched files — clean
- [ ] Independent agent review (required before merge per repo CLAUDE.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)