### PR TITLE
fix: hide filter-shape controls on radios without the capability (MOR-1502)

### DIFF
--- a/frontend/src/lib/runtime/adapters/__tests__/filter-passband-adapter.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/filter-passband-adapter.isolated.test.ts
@@ -523,6 +523,44 @@ describe('ifShiftControlStructural — the presentation-only IF-shift control ga
 });
 
 /**
+ * `filterShapeControlStructural` (MOR-1502) — a SEPARATE, presentation-only
+ * flag `FilterSurface.svelte` uses to decide whether to show the SHARP/SOFT
+ * shape ROW, deliberately independent of `filterShape.availability.
+ * structural` above (which is `hasFilters` alone — see the "per-field
+ * structural gates" block — because `scope-adapter.ts` still needs the
+ * derived reading for ANY radio with a declared filter catalog, filter_shape-
+ * capable or not). `filterShapeControlStructural` answers the narrower
+ * question: does the radio have a REAL `filter_shape` command
+ * (`hasCap(caps, 'filter_shape')`).
+ */
+describe('filterShapeControlStructural — the presentation-only filter-shape control gate (MOR-1502)', () => {
+  it('FTX-1-shaped (filters, no filter_shape): false, even though the derived fact stays structural', () => {
+    const view = model(bareState({
+      main: { ...bareState().main, filterShape: 1 },
+      fieldStatus: { ...bareState().fieldStatus, 'main.filterShape': fresh },
+    }), caps({ filters: ['FIL1', 'FIL2', 'FIL3'] }));
+    expect(view.filterPassband!.filterShapeControlStructural).toBe(false);
+    // The trap: a naive fix that reused `hasFilters` for this flag too
+    // would silently break `scope-adapter.ts`'s derived reading for exactly
+    // this radio shape (the FTX-1). It must stay untouched.
+    expect(view.filterPassband!.filterShape.availability.structural).toBe(true);
+    expect(view.filterPassband!.filterShape.reading).toEqual({ status: 'known', value: 1 });
+  });
+
+  it('IC-7300-shaped (filters + filter_shape): true', () => {
+    const view = model(bareState(), caps({
+      filters: ['FIL1', 'FIL2', 'FIL3'], capabilities: ['filter_shape'],
+    }));
+    expect(view.filterPassband!.filterShapeControlStructural).toBe(true);
+  });
+
+  it('neither filters nor filter_shape: false', () => {
+    const view = model(bareState(), caps({ capabilities: ['pbt'], controls: { pbt_inner: DEFAULT_PBT_RANGE } }));
+    expect(view.filterPassband!.filterShapeControlStructural).toBe(false);
+  });
+});
+
+/**
  * HONESTY GATE (MOR-1284, following the 4A F2 lesson). `ifShift`'s derived
  * branch must never fabricate a reading from ONE observed PBT field and the
  * other's silently-defaulted value — the same "never emit a known value

--- a/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
@@ -396,9 +396,13 @@ function deriveModeFilter(
  *    always present) — same story as 4A's `mode`/`filter`: structural is
  *    `hasCap(caps, 'data_mode')` (`toModeProps`'s own `hasDataMode` gate),
  *    never "was it observed".
- *  - `filterShape` is OPTIONAL and undeclared by any capability tag of its
- *    own; it is part of the same filter subsystem 4A's `filterWidth` is, so
- *    its structural gate is the SAME `hasFilters` signal that field uses.
+ *  - `filterShape` the FACT is part of the same filter subsystem 4A's
+ *    `filterWidth` is, so its structural gate is the SAME `hasFilters`
+ *    signal that field uses — it is NOT re-gated on the `filter_shape`
+ *    capability tag. `filterShapeControlStructural` (MOR-1502) is the
+ *    separate, presentation-only flag that IS gated on `hasCap(caps,
+ *    'filter_shape')` — see its doc comment on `FilterPassbandViewModel`
+ *    for the ifShiftControlStructural-mirroring split.
  *  - `pbtInner`/`pbtOuter` are OPTIONAL, gated on `hasCap(caps, 'pbt')` AND a
  *    usable `pbt_inner` range declared by THIS `caps` argument itself
  *    (`pbtRangeFromCaps`, MOR-1291) — `toFilterProps`'s own `hasPbt`
@@ -431,6 +435,7 @@ function deriveFilterPassband(
   const hasPbtCap = hasCap(caps, 'pbt');
   const hasIfShiftCap = hasCap(caps, 'if_shift');
   const hasDataModeCap = hasCap(caps, 'data_mode');
+  const hasFilterShapeCap = hasCap(caps, 'filter_shape');
   if (!hasFilters && !hasPbtCap && !hasIfShiftCap && !hasDataModeCap) return undefined;
 
   const onSub = state?.active === 'SUB';
@@ -495,6 +500,22 @@ function deriveFilterPassband(
 
   return {
     filterShape: txAuxField(hasFilters, filterShapeObserved, numOrUndef(rx?.filterShape)),
+    // MOR-1502 review round. Deliberately NOT `hasFilters` above.
+    // `filterShape`'s own structural/operational/value stay exactly as they
+    // were — a radio with filters but no `filter_shape` command still gets
+    // an honest derived `filterShape` READING for any consumer of the raw
+    // fact (`scope-adapter.ts` reads `filterPassband.filterShape` directly).
+    // This flag answers a DIFFERENT question — does the radio have a REAL
+    // `filter_shape` COMMAND of its own — for `FilterSurface.svelte` to
+    // decide whether to show the SHARP/SOFT shape CONTROL at all. The FTX-1
+    // (filters, no filter_shape) has no such command; showing the control
+    // permanently disabled is a dead control, not a usable one (the owner's
+    // MOR-1494 ruling, applied here per MOR-1502: hide capability-absent
+    // controls, don't show them dead). See
+    // `FilterPassbandViewModel.filterShapeControlStructural`'s doc comment
+    // (`radio-view-model.ts`) for the full split. Mirrors
+    // `ifShiftControlStructural` immediately below, byte-for-byte doctrine.
+    filterShapeControlStructural: hasFilterShapeCap,
     ifShift: txAuxField(ifShiftStructural, ifShiftOperational, ifShiftValue),
     // MOR-1494 review round. Deliberately NOT `ifShiftStructural` above.
     // `ifShiftStructural`/`ifShiftOperational`/`ifShiftValue` stay exactly as

--- a/frontend/src/semantic/FilterSurface.svelte
+++ b/frontend/src/semantic/FilterSurface.svelte
@@ -24,7 +24,7 @@
       never substitutes one field's gate for another's.
 
   CAPABILITY-ABSENT CONTROLS ARE HIDDEN, NOT SHOWN DEAD (MOR-1494 review
-  round). The `ifShift` ROW is the ONE exception to rule (2) above: it gates
+  round). The `ifShift` ROW is an exception to rule (2) above: it gates
   on `filterPassband.ifShiftControlStructural`, NOT on
   `filterPassband.ifShift.availability.structural`. The latter stays `true`
   for any radio with EITHER `if_shift` OR `pbt` (a PBT-only radio like
@@ -34,6 +34,15 @@
   MOR-1494 fixed. `ifShiftControlStructural` answers the narrower question
   this row needs: does the radio have a REAL `if_shift` command. See
   `radio-view-model.ts`'s `FilterPassbandViewModel` doc comment.
+
+  MOR-1502 applies the SAME split to the `filter-shape` ROW: it gates on
+  `filterPassband.filterShapeControlStructural`, NOT on
+  `filterPassband.filterShape.availability.structural`. The latter stays
+  `true` for any radio with a declared filter catalog at all (the FTX-1 has
+  filters but no `filter_shape` command — showing SHARP/SOFT permanently
+  disabled is the same "shown dead" defect). `filterShapeControlStructural`
+  answers whether the radio has a REAL `filter_shape` command; see
+  `FilterPassbandViewModel.filterShapeControlStructural`'s doc comment.
 
   PENDING AFFORDANCE (MOR-1441 leg 2). `pendingFilter` is a plain, command-
   bus-blind display prop — same "read at the wiring seam, hand down a plain
@@ -184,7 +193,7 @@
     {/if}
 
     {#if filterPassband}
-      {#if filterPassband.filterShape.availability.structural}
+      {#if filterPassband.filterShapeControlStructural}
         <div
           class="filter-choice-group" data-testid="filter-shape"
           data-disabled-reason={reasonOf(filterPassband.filterShape)}

--- a/frontend/src/semantic/__tests__/FilterSurface.test.ts
+++ b/frontend/src/semantic/__tests__/FilterSurface.test.ts
@@ -76,6 +76,19 @@ function withIfShiftControlStructural(view: RadioViewModel, value: boolean): Rad
   };
 }
 
+/**
+ * MOR-1502 review round. `filterShapeControlStructural` is a plain boolean
+ * SIBLING of `filterShape` on `filterPassband` (same idiom as
+ * `withIfShiftControlStructural` above, for the same reason
+ * `withPassbandField` cannot set it).
+ */
+function withFilterShapeControlStructural(view: RadioViewModel, value: boolean): RadioViewModel {
+  return {
+    ...view,
+    filterPassband: { ...view.filterPassband!, filterShapeControlStructural: value } as FilterPassbandViewModel,
+  };
+}
+
 let target: HTMLDivElement;
 beforeEach(() => { target = document.createElement('div'); document.body.appendChild(target); });
 afterEach(() => { target.remove(); });
@@ -156,10 +169,12 @@ describe('structural availability decides whether a control EXISTS', () => {
     withSurface(view, (s) => expect(s.group('filter-width')).toBeNull());
   });
 
-  it('renders no shape control when filterShape is structurally absent', () => {
-    const view = withPassbandField(base(), 'filterShape', { availability: ABSENT });
-    withSurface(view, (s) => expect(s.group('filter-shape')).toBeNull());
-  });
+  // `filterShape` is deliberately excluded from this generic sweep (MOR-1502
+  // review round) — its ROW gates on the separate
+  // `filterShapeControlStructural` flag, not on its OWN field's
+  // `availability.structural`, so setting that to ABSENT here would no
+  // longer hide it. See the dedicated "filter-shape control gate is
+  // separate from the derived fact" block below.
 
   it('renders no dataMode readout when dataMode is structurally absent', () => {
     const view = withPassbandField(base(), 'dataMode', { availability: ABSENT });
@@ -235,6 +250,65 @@ describe('IF-shift control gate is separate from the derived fact (MOR-1494)', (
       expect(s.group('filter-ifShift')).not.toBeNull();
       expect(s.input('filter-ifShift')!.disabled).toBe(true);
       expect(s.group('filter-ifShift')!.dataset.disabledReason).toBe('field-not-observed');
+    });
+  });
+});
+
+// ── 2c. filter-shape control gate is separate from the derived fact (MOR-1502) ─
+
+/**
+ * MOR-1502. The FTX-1 (no `filter_shape` command) rendered the SHARP/SOFT
+ * shape row permanently disabled — a dead control shown instead of hidden,
+ * same class of defect MOR-1494 fixed for the IF-shift row. The fix splits
+ * the presentation gate (`filterShapeControlStructural`, this block) from
+ * the derived-fact gate (`filterShape.availability.structural`, UNCHANGED —
+ * pinned untouched by the second test below, which is the trap a naive fix
+ * would have missed: `scope-adapter.ts` reads `filterPassband.filterShape`
+ * directly and must keep getting the reading for any radio whose capability
+ * set declares filters at all, filter_shape-capable or not).
+ */
+describe('filter-shape control gate is separate from the derived fact (MOR-1502)', () => {
+  it('FTX-1-shaped (filters, no filter_shape): hides the filter-shape row', () => {
+    const view = withFilterShapeControlStructural(base(), false);
+    withSurface(view, (s) => expect(s.group('filter-shape')).toBeNull());
+  });
+
+  it('FTX-1-shaped (filters, no filter_shape): the underlying derived filterShape FACT stays structural and known — scope-adapter.ts still gets it', () => {
+    const view = withFilterShapeControlStructural(base(), false);
+    // `filterShapeControlStructural: false` here mirrors what the adapter
+    // would compute for an FTX-1-shaped radio; `filterShape`'s OWN field is
+    // UNTOUCHED by this override and stays exactly what `base()` (a "fully
+    // observed" fixture) gives it — the row-hiding change above must never
+    // reach into this field.
+    expect(view.filterPassband!.filterShape.availability.structural).toBe(true);
+    expect(view.filterPassband!.filterShape.reading).toEqual({ status: 'known', value: 1 });
+  });
+
+  it('IC-7300-shaped (filter_shape): renders the filter-shape row, enabled, bound to the real value', () => {
+    // base() defaults filterShapeControlStructural to true (see fixtures/
+    // topologies.ts) — the IC-7300-shaped case, no override needed.
+    withSurface(base(), (s) => {
+      expect(s.group('filter-shape')).not.toBeNull();
+      expect(s.button('filter-shape', 1)!.disabled).toBe(false);
+    });
+  });
+
+  it('no filters at all: hides the filter-shape row, no crash', () => {
+    let view = withFilterShapeControlStructural(base(), false);
+    view = withPassbandField(view, 'filterShape', {
+      availability: { structural: false, operational: false },
+    });
+    withSurface(view, (s) => expect(s.group('filter-shape')).toBeNull());
+  });
+
+  it('still applies operational gating (disabled + reason) to a structurally-shown filter-shape row', () => {
+    const view = withPassbandField(base(), 'filterShape', {
+      availability: { structural: true, operational: false },
+    });
+    withSurface(view, (s) => {
+      expect(s.group('filter-shape')).not.toBeNull();
+      expect(s.button('filter-shape', 1)!.disabled).toBe(true);
+      expect(s.group('filter-shape')!.dataset.disabledReason).toBe('field-not-observed');
     });
   });
 });

--- a/frontend/src/semantic/fixtures/topologies.ts
+++ b/frontend/src/semantic/fixtures/topologies.ts
@@ -284,6 +284,12 @@ export function withFilterPassband(fixture: RadioViewModel): RadioViewModel {
     ({ reading: { status: 'known', value }, availability: avail });
   const filterPassband: FilterPassbandViewModel = {
     filterShape: known(1),
+    // MOR-1502 review round: "fully observed" means a radio with a REAL
+    // filter_shape command (e.g. IC-7300), so this base fixture defaults
+    // the control-presentation gate to true — tests exercising the FTX-1-
+    // shaped (no filter_shape) case override it explicitly via
+    // `withFilterShapeControlStructural` in the consuming test file.
+    filterShapeControlStructural: true,
     ifShift: known(0),
     // MOR-1494 review round: "fully observed" means a radio with a REAL
     // if_shift command (e.g. FTX-1), so this base fixture defaults the

--- a/frontend/src/semantic/radio-view-model.ts
+++ b/frontend/src/semantic/radio-view-model.ts
@@ -335,6 +335,26 @@ export type FilterPassbandField<T> = TxAuxField<T>;
  */
 export interface FilterPassbandViewModel {
   filterShape: FilterPassbandField<number>;
+  /**
+   * MOR-1502 review round. `filterShape.availability.structural` above is a
+   * fact-derivation gate — `hasFilters` (part of the same filter subsystem
+   * `modeFilter.filterWidth` is), true for ANY radio with a declared filter
+   * catalog. A radio with filters but no `filter_shape` COMMAND (the FTX-1)
+   * still gets an honest derived `filterShape` READING for consumers of the
+   * raw fact (e.g. `scope-adapter.ts`). This is a SEPARATE, presentation-only
+   * gate: whether the radio has a REAL `filter_shape` command of its own.
+   * The FTX-1 has none — showing its SHARP/SOFT shape CONTROL permanently
+   * disabled is a dead control (same class of defect `ifShiftControlStructural`
+   * fixed, MOR-1494 ruling: hide capability-absent controls, don't show them
+   * dead). `FilterSurface.svelte` gates the filter-shape ROW on this flag,
+   * and ONLY this flag — never on `filterShape.availability.structural`,
+   * which stays reserved for consumers of the derived fact itself (see
+   * `deriveFilterPassband`'s doc comment). A plain boolean, not
+   * `FilterPassbandField`-wrapped, for the same reason `ifShiftControlStructural`
+   * isn't: a structural fact about the radio MODEL, not a live reading that
+   * can itself go stale.
+   */
+  filterShapeControlStructural: boolean;
   ifShift: FilterPassbandField<number>;
   /**
    * MOR-1494 review round. `ifShift.availability.structural` above is a
@@ -1407,11 +1427,15 @@ function validateFilterPassband(value: unknown, path: string): FilterPassbandVie
   const v = record(value, path);
   exactKeys(
     v,
-    ['filterShape', 'ifShift', 'ifShiftControlStructural', 'pbtInner', 'pbtOuter', 'dataMode'],
+    [
+      'filterShape', 'filterShapeControlStructural', 'ifShift', 'ifShiftControlStructural',
+      'pbtInner', 'pbtOuter', 'dataMode',
+    ],
     path,
   );
   return {
     filterShape: validateTxAuxField(v.filterShape, `${path}.filterShape`, num),
+    filterShapeControlStructural: bool(v.filterShapeControlStructural, `${path}.filterShapeControlStructural`),
     ifShift: validateTxAuxField(v.ifShift, `${path}.ifShift`, num),
     ifShiftControlStructural: bool(v.ifShiftControlStructural, `${path}.ifShiftControlStructural`),
     pbtInner: validateTxAuxField(v.pbtInner, `${path}.pbtInner`, num),


### PR DESCRIPTION
## Verification (per the #2413/#2424 dead-path lesson: identify what actually renders, per live path)

**Data first — is `filter_shape` genuinely absent on FTX-1?**
`rigs/ftx1.toml`'s `[capabilities]` list is `agc, if_shift, contour, filter_width, tx, split, vox, ...` — no `filter_shape`. Confirmed absent.

**Desktop-v2 (`frontend/src/semantic/FilterSurface.svelte`, the bench IC-7300 screenshot's live path):** REPRODUCED. The SHARP/SOFT row gated on `filterPassband.filterShape.availability.structural`, which is `hasFilters` in `radio-view-model-adapter.ts::deriveFilterPassband` — true for any radio with a declared filter catalog, not tied to a real `filter_shape` command. The FTX-1 declares filters (FIL1/FIL2/FIL3) but no `filter_shape` capability, so the row rendered permanently disabled — a dead control, same class MOR-1494 fixed for the IF-shift row.

**Mobile (`frontend/src/components-v2/panels/FilterPanel.svelte` settings modal):** Already fixed by MOR-1503 (#2427, merged before this branch was cut) — `hasFilterShape` (`hasCap(caps, 'filter_shape')`) already gates the modal's shape section. No change needed there; verified by reading current `main` and confirming the `hasFilterShape` gate and its dedicated test block (`FilterPanel.isolated.test.ts`, "filter shape visibility (MOR-1503)") are in place.

So the owner's report was reproduced on exactly one of the two live paths — the desktop-v2 `FilterSurface.svelte` mount — which this PR fixes.

## Fix

Follows the `ifShiftControlStructural` precedent (MOR-1494/#2424) byte-for-byte:

- `radio-view-model.ts`: new `filterShapeControlStructural: boolean` on `FilterPassbandViewModel`, sibling of `ifShiftControlStructural`. Added to `validateFilterPassband`'s `exactKeys` + return.
- `radio-view-model-adapter.ts`: `filterShapeControlStructural: hasCap(caps, 'filter_shape')`. `filterShape`'s own fact (`availability`/`reading`, gated on `hasFilters`) is **left untouched** — `scope-adapter.ts` reads `filterPassband.filterShape` directly for its passband-center overlay and must keep getting the derived reading for any radio with a filter catalog, `filter_shape`-capable or not (verified via grep before touching anything; pinned by a dedicated test).
- `FilterSurface.svelte`: the shape row now gates on `filterPassband.filterShapeControlStructural` instead of `filterPassband.filterShape.availability.structural`.
- `fixtures/topologies.ts`: `withFilterPassband` defaults `filterShapeControlStructural: true` (fully-observed = IC-7300-shaped, real command).

## Tests (red-first)

- `frontend/src/semantic/__tests__/FilterSurface.test.ts` — new `describe('filter-shape control gate is separate from the derived fact (MOR-1502)')`: FTX-1-shaped (filters, no filter_shape) hides the row; the underlying derived `filterShape` fact stays structural+known (scope-adapter trap, pinned); IC-7300-shaped renders enabled; no-filters-at-all hides with no crash; operational gating (disabled + reason) still applies when structurally shown. Also updated the generic structural-absence sweep to exclude `filterShape` (same treatment `ifShift` already got).
- `frontend/src/lib/runtime/adapters/__tests__/filter-passband-adapter.isolated.test.ts` — new `describe('filterShapeControlStructural — the presentation-only filter-shape control gate (MOR-1502)')`: FTX-1-shaped false (fact stays structural — the trap), IC-7300-shaped true, neither-cap false.

All new tests were red before the production change (confirmed by running before touching `radio-view-model.ts`/`radio-view-model-adapter.ts`/`FilterSurface.svelte`), green after.

## Verification run

```
npx vitest run                    # 330 files, 6998 tests passed
npx eslint <touched files>        # 0 problems
npx svelte-check                  # 0 errors, 0 warnings
```

Closes MOR-1502.