### PR TITLE
fix: gate cmd29 wrapping on profile support for PBT/filter-shape and siblings (MOR-1517)

### DIFF
--- a/src/rigplane/commands/dsp.py
+++ b/src/rigplane/commands/dsp.py
@@ -431,6 +431,8 @@ def get_audio_peak_filter(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Build a read audio peak filter mode command."""
     return _build_function_get(
@@ -438,7 +440,7 @@ def get_audio_peak_filter(
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
-        command29=True,
+        command29=command29,
         cmd_map=cmd_map,
         cmd_name="get_audio_peak_filter",
     )
@@ -450,6 +452,8 @@ def set_audio_peak_filter(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Build a set audio peak filter mode command."""
     return _build_function_value_set(
@@ -460,7 +464,7 @@ def set_audio_peak_filter(
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
-        command29=True,
+        command29=command29,
         cmd_map=cmd_map,
         cmd_name="set_audio_peak_filter",
     )
@@ -471,6 +475,8 @@ def get_auto_notch(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Build a read auto-notch status command."""
     return _build_function_get(
@@ -478,7 +484,7 @@ def get_auto_notch(
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
-        command29=True,
+        command29=command29,
         cmd_map=cmd_map,
         cmd_name="get_auto_notch",
     )
@@ -490,6 +496,8 @@ def set_auto_notch(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Build a set auto-notch status command."""
     return _build_function_bool_set(
@@ -498,7 +506,7 @@ def set_auto_notch(
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
-        command29=True,
+        command29=command29,
         cmd_map=cmd_map,
         cmd_name="set_auto_notch",
     )
@@ -623,13 +631,15 @@ def get_manual_notch(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     return _build_function_get(
         _SUB_MANUAL_NOTCH,
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
-        command29=True,
+        command29=command29,
         cmd_map=cmd_map,
         cmd_name="get_manual_notch",
     )
@@ -641,6 +651,8 @@ def set_manual_notch(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     return _build_function_bool_set(
         _SUB_MANUAL_NOTCH,
@@ -648,7 +660,7 @@ def set_manual_notch(
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
-        command29=True,
+        command29=command29,
         cmd_map=cmd_map,
         cmd_name="set_manual_notch",
     )
@@ -659,6 +671,8 @@ def get_manual_notch_width(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Build a 'get manual notch width' CI-V command (0x16 0x57)."""
     return _build_function_get(
@@ -666,7 +680,7 @@ def get_manual_notch_width(
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
-        command29=True,
+        command29=command29,
         cmd_map=cmd_map,
         cmd_name="get_manual_notch_width",
     )
@@ -678,6 +692,8 @@ def set_manual_notch_width(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Build a 'set manual notch width' CI-V command (0x16 0x57). 0=WIDE, 1=MID, 2=NAR."""
     return _build_function_value_set(
@@ -688,7 +704,7 @@ def set_manual_notch_width(
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
-        command29=True,
+        command29=command29,
         cmd_map=cmd_map,
         cmd_name="set_manual_notch_width",
     )
@@ -699,13 +715,15 @@ def get_twin_peak_filter(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     return _build_function_get(
         _SUB_TWIN_PEAK_FILTER,
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
-        command29=True,
+        command29=command29,
         cmd_map=cmd_map,
         cmd_name="get_twin_peak_filter",
     )
@@ -717,6 +735,8 @@ def set_twin_peak_filter(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     return _build_function_bool_set(
         _SUB_TWIN_PEAK_FILTER,
@@ -724,7 +744,7 @@ def set_twin_peak_filter(
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
-        command29=True,
+        command29=command29,
         cmd_map=cmd_map,
         cmd_name="set_twin_peak_filter",
     )

--- a/src/rigplane/commands/levels.py
+++ b/src/rigplane/commands/levels.py
@@ -262,6 +262,8 @@ def get_apf_type_level(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Build a read APF Type Level command."""
     return _build_level_get(
@@ -269,7 +271,7 @@ def get_apf_type_level(
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
-        command29=True,
+        command29=command29,
         cmd_map=cmd_map,
         cmd_name="get_apf_type_level",
     )
@@ -281,6 +283,8 @@ def set_apf_type_level(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Build a set APF Type Level command."""
     return _build_level_set(
@@ -289,7 +293,7 @@ def set_apf_type_level(
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
-        command29=True,
+        command29=command29,
         cmd_map=cmd_map,
         cmd_name="set_apf_type_level",
     )
@@ -300,6 +304,8 @@ def get_nr_level(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Build a read NR Level command."""
     return _build_level_get(
@@ -307,7 +313,7 @@ def get_nr_level(
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
-        command29=True,
+        command29=command29,
         cmd_map=cmd_map,
         cmd_name="get_nr_level",
     )
@@ -319,6 +325,8 @@ def set_nr_level(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Build a set NR Level command."""
     return _build_level_set(
@@ -327,7 +335,7 @@ def set_nr_level(
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
-        command29=True,
+        command29=command29,
         cmd_map=cmd_map,
         cmd_name="set_nr_level",
     )
@@ -338,6 +346,8 @@ def get_pbt_inner(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Build a read PBT Inner command."""
     return _build_level_get(
@@ -345,7 +355,7 @@ def get_pbt_inner(
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
-        command29=True,
+        command29=command29,
         cmd_map=cmd_map,
         cmd_name="get_pbt_inner",
     )
@@ -357,6 +367,8 @@ def set_pbt_inner(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Build a set PBT Inner command."""
     return _build_level_set(
@@ -365,7 +377,7 @@ def set_pbt_inner(
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
-        command29=True,
+        command29=command29,
         cmd_map=cmd_map,
         cmd_name="set_pbt_inner",
     )
@@ -376,6 +388,8 @@ def get_pbt_outer(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Build a read PBT Outer command."""
     return _build_level_get(
@@ -383,7 +397,7 @@ def get_pbt_outer(
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
-        command29=True,
+        command29=command29,
         cmd_map=cmd_map,
         cmd_name="get_pbt_outer",
     )
@@ -395,6 +409,8 @@ def set_pbt_outer(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Build a set PBT Outer command."""
     return _build_level_set(
@@ -403,7 +419,7 @@ def set_pbt_outer(
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
-        command29=True,
+        command29=command29,
         cmd_map=cmd_map,
         cmd_name="set_pbt_outer",
     )
@@ -612,6 +628,8 @@ def get_nb_level(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Build a read NB Level command."""
     return _build_level_get(
@@ -619,7 +637,7 @@ def get_nb_level(
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
-        command29=True,
+        command29=command29,
         cmd_map=cmd_map,
         cmd_name="get_nb_level",
     )
@@ -631,6 +649,8 @@ def set_nb_level(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Build a set NB Level command."""
     return _build_level_set(
@@ -639,7 +659,7 @@ def set_nb_level(
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
-        command29=True,
+        command29=command29,
         cmd_map=cmd_map,
         cmd_name="set_nb_level",
     )
@@ -650,6 +670,8 @@ def get_digisel_shift(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Build a read DIGI-SEL Shift command."""
     return _build_level_get(
@@ -657,7 +679,7 @@ def get_digisel_shift(
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
-        command29=True,
+        command29=command29,
         cmd_map=cmd_map,
         cmd_name="get_digisel_shift",
     )
@@ -669,6 +691,8 @@ def set_digisel_shift(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Build a set DIGI-SEL Shift command."""
     return _build_level_set(
@@ -677,7 +701,7 @@ def set_digisel_shift(
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
-        command29=True,
+        command29=command29,
         cmd_map=cmd_map,
         cmd_name="set_digisel_shift",
     )

--- a/src/rigplane/commands/meters.py
+++ b/src/rigplane/commands/meters.py
@@ -84,6 +84,8 @@ def get_s_meter_sql_status(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Build a read S-meter squelch status command."""
     return _build_meter_bool_get(
@@ -91,7 +93,7 @@ def get_s_meter_sql_status(
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
-        command29=True,
+        command29=command29,
         cmd_map=cmd_map,
         cmd_name="get_s_meter_sql_status",
     )
@@ -119,6 +121,8 @@ def get_various_squelch(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Build a read various-squelch status command (0x15 0x05, Command29)."""
     return _build_meter_bool_get(
@@ -126,7 +130,7 @@ def get_various_squelch(
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
-        command29=True,
+        command29=command29,
         cmd_map=cmd_map,
         cmd_name="get_various_squelch",
     )

--- a/src/rigplane/commands/mode.py
+++ b/src/rigplane/commands/mode.py
@@ -189,6 +189,8 @@ def get_filter_shape(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Build a read DSP IF filter shape command."""
     return _build_function_get(
@@ -196,7 +198,7 @@ def get_filter_shape(
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
-        command29=True,
+        command29=command29,
         cmd_map=cmd_map,
         cmd_name="get_filter_shape",
     )
@@ -208,6 +210,8 @@ def set_filter_shape(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Build a set DSP IF filter shape command."""
     return _build_function_value_set(
@@ -218,7 +222,7 @@ def set_filter_shape(
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
-        command29=True,
+        command29=command29,
         cmd_map=cmd_map,
         cmd_name="set_filter_shape",
     )
@@ -360,6 +364,8 @@ def get_agc_time_constant(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Build a read AGC time constant command."""
     return _build_ctl_mem_single_bcd_get(
@@ -367,7 +373,7 @@ def get_agc_time_constant(
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
-        command29=True,
+        command29=command29,
         cmd_map=cmd_map,
         cmd_name="get_agc_time_constant",
     )
@@ -379,6 +385,8 @@ def set_agc_time_constant(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Build a set AGC time constant command."""
     return _build_ctl_mem_single_bcd_set(
@@ -389,7 +397,7 @@ def set_agc_time_constant(
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
-        command29=True,
+        command29=command29,
         cmd_map=cmd_map,
         cmd_name="set_agc_time_constant",
     )

--- a/src/rigplane/commands/tone.py
+++ b/src/rigplane/commands/tone.py
@@ -15,6 +15,7 @@ from ._frame import (
     _SUB_TONE_FREQ,
     _SUB_TSQL_FREQ,
     _build_from_map,
+    build_civ_frame,
     build_cmd29_frame,
 )
 
@@ -50,6 +51,8 @@ def get_repeater_tone(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Build CI-V command to get repeater tone status (0x16 0x42)."""
     return _build_function_get(
@@ -57,7 +60,7 @@ def get_repeater_tone(
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
-        command29=True,
+        command29=command29,
         cmd_map=cmd_map,
         cmd_name="get_repeater_tone",
     )
@@ -69,6 +72,8 @@ def set_repeater_tone(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Build CI-V command to set repeater tone (0x16 0x42)."""
     return _build_function_bool_set(
@@ -77,7 +82,7 @@ def set_repeater_tone(
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
-        command29=True,
+        command29=command29,
         cmd_map=cmd_map,
         cmd_name="set_repeater_tone",
     )
@@ -88,6 +93,8 @@ def get_repeater_tsql(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Build CI-V command to get repeater TSQL status (0x16 0x43)."""
     return _build_function_get(
@@ -95,7 +102,7 @@ def get_repeater_tsql(
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
-        command29=True,
+        command29=command29,
         cmd_map=cmd_map,
         cmd_name="get_repeater_tsql",
     )
@@ -107,6 +114,8 @@ def set_repeater_tsql(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Build CI-V command to set repeater TSQL (0x16 0x43)."""
     return _build_function_bool_set(
@@ -115,7 +124,7 @@ def set_repeater_tsql(
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
-        command29=True,
+        command29=command29,
         cmd_map=cmd_map,
         cmd_name="set_repeater_tsql",
     )
@@ -126,6 +135,8 @@ def get_tone_freq(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Build CI-V command to get tone frequency (0x1B 0x00)."""
     if cmd_map is not None:
@@ -134,12 +145,14 @@ def get_tone_freq(
             "get_tone_freq",
             to_addr=to_addr,
             from_addr=from_addr,
-            command29=True,
+            command29=command29,
             receiver=receiver,
         )
-    return build_cmd29_frame(
-        to_addr, from_addr, _CMD_TONE, sub=_SUB_TONE_FREQ, receiver=receiver
-    )
+    if command29:
+        return build_cmd29_frame(
+            to_addr, from_addr, _CMD_TONE, sub=_SUB_TONE_FREQ, receiver=receiver
+        )
+    return build_civ_frame(to_addr, from_addr, _CMD_TONE, sub=_SUB_TONE_FREQ)
 
 
 def set_tone_freq(
@@ -148,6 +161,8 @@ def set_tone_freq(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Build CI-V command to set tone frequency (0x1B 0x00)."""
     if cmd_map is not None:
@@ -156,17 +171,25 @@ def set_tone_freq(
             "set_tone_freq",
             to_addr=to_addr,
             from_addr=from_addr,
-            command29=True,
+            command29=command29,
             receiver=receiver,
             data=_encode_tone_freq(freq_hz),
         )
-    return build_cmd29_frame(
+    if command29:
+        return build_cmd29_frame(
+            to_addr,
+            from_addr,
+            _CMD_TONE,
+            sub=_SUB_TONE_FREQ,
+            data=_encode_tone_freq(freq_hz),
+            receiver=receiver,
+        )
+    return build_civ_frame(
         to_addr,
         from_addr,
         _CMD_TONE,
         sub=_SUB_TONE_FREQ,
         data=_encode_tone_freq(freq_hz),
-        receiver=receiver,
     )
 
 
@@ -175,6 +198,8 @@ def get_tsql_freq(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Build CI-V command to get TSQL frequency (0x1B 0x01)."""
     if cmd_map is not None:
@@ -183,12 +208,14 @@ def get_tsql_freq(
             "get_tsql_freq",
             to_addr=to_addr,
             from_addr=from_addr,
-            command29=True,
+            command29=command29,
             receiver=receiver,
         )
-    return build_cmd29_frame(
-        to_addr, from_addr, _CMD_TONE, sub=_SUB_TSQL_FREQ, receiver=receiver
-    )
+    if command29:
+        return build_cmd29_frame(
+            to_addr, from_addr, _CMD_TONE, sub=_SUB_TSQL_FREQ, receiver=receiver
+        )
+    return build_civ_frame(to_addr, from_addr, _CMD_TONE, sub=_SUB_TSQL_FREQ)
 
 
 def set_tsql_freq(
@@ -197,6 +224,8 @@ def set_tsql_freq(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Build CI-V command to set TSQL frequency (0x1B 0x01)."""
     if cmd_map is not None:
@@ -205,17 +234,25 @@ def set_tsql_freq(
             "set_tsql_freq",
             to_addr=to_addr,
             from_addr=from_addr,
-            command29=True,
+            command29=command29,
             receiver=receiver,
             data=_encode_tone_freq(freq_hz),
         )
-    return build_cmd29_frame(
+    if command29:
+        return build_cmd29_frame(
+            to_addr,
+            from_addr,
+            _CMD_TONE,
+            sub=_SUB_TSQL_FREQ,
+            data=_encode_tone_freq(freq_hz),
+            receiver=receiver,
+        )
+    return build_civ_frame(
         to_addr,
         from_addr,
         _CMD_TONE,
         sub=_SUB_TSQL_FREQ,
         data=_encode_tone_freq(freq_hz),
-        receiver=receiver,
     )
 
 

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -2632,7 +2632,10 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._require_cmd29_route(
             0x14, 0x05, receiver=receiver, operation="get_apf_type_level"
         )
-        civ = get_apf_type_level(to_addr=self._radio_addr, receiver=receiver)
+        cmd29 = self._profile.supports_cmd29(0x14, 0x05)
+        civ = get_apf_type_level(
+            to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+        )
         return await self._get_bcd_level(
             civ,
             key=f"get_apf_type_level:{receiver}",
@@ -2648,8 +2651,11 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._require_cmd29_route(
             0x14, 0x05, receiver=receiver, operation="set_apf_type_level"
         )
+        cmd29 = self._profile.supports_cmd29(0x14, 0x05)
         await self._send_fire_and_forget(
-            set_apf_type_level(level, to_addr=self._radio_addr, receiver=receiver)
+            set_apf_type_level(
+                level, to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+            )
         )
 
     async def get_nr_level(self, receiver: int = RECEIVER_MAIN) -> int:
@@ -2658,7 +2664,8 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._require_cmd29_route(
             0x14, 0x06, receiver=receiver, operation="get_nr_level"
         )
-        civ = get_nr_level(to_addr=self._radio_addr, receiver=receiver)
+        cmd29 = self._profile.supports_cmd29(0x14, 0x06)
+        civ = get_nr_level(to_addr=self._radio_addr, receiver=receiver, command29=cmd29)
         return await self._get_bcd_level(
             civ, key=f"get_nr_level:{receiver}", command=0x14, sub=0x06
         )
@@ -2669,8 +2676,11 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._require_cmd29_route(
             0x14, 0x06, receiver=receiver, operation="set_nr_level"
         )
+        cmd29 = self._profile.supports_cmd29(0x14, 0x06)
         await self._send_fire_and_forget(
-            set_nr_level(level, to_addr=self._radio_addr, receiver=receiver)
+            set_nr_level(
+                level, to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+            )
         )
 
     async def get_pbt_inner(self, receiver: int = RECEIVER_MAIN) -> int:
@@ -2679,7 +2689,10 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._require_cmd29_route(
             0x14, 0x07, receiver=receiver, operation="get_pbt_inner"
         )
-        civ = get_pbt_inner(to_addr=self._radio_addr, receiver=receiver)
+        cmd29 = self._profile.supports_cmd29(0x14, 0x07)
+        civ = get_pbt_inner(
+            to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+        )
         return await self._get_bcd_level(
             civ, key=f"get_pbt_inner:{receiver}", command=0x14, sub=0x07
         )
@@ -2690,8 +2703,11 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._require_cmd29_route(
             0x14, 0x07, receiver=receiver, operation="set_pbt_inner"
         )
+        cmd29 = self._profile.supports_cmd29(0x14, 0x07)
         await self._send_fire_and_forget(
-            set_pbt_inner(level, to_addr=self._radio_addr, receiver=receiver)
+            set_pbt_inner(
+                level, to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+            )
         )
 
     async def get_pbt_outer(self, receiver: int = RECEIVER_MAIN) -> int:
@@ -2700,7 +2716,10 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._require_cmd29_route(
             0x14, 0x08, receiver=receiver, operation="get_pbt_outer"
         )
-        civ = get_pbt_outer(to_addr=self._radio_addr, receiver=receiver)
+        cmd29 = self._profile.supports_cmd29(0x14, 0x08)
+        civ = get_pbt_outer(
+            to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+        )
         return await self._get_bcd_level(
             civ, key=f"get_pbt_outer:{receiver}", command=0x14, sub=0x08
         )
@@ -2711,8 +2730,11 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._require_cmd29_route(
             0x14, 0x08, receiver=receiver, operation="set_pbt_outer"
         )
+        cmd29 = self._profile.supports_cmd29(0x14, 0x08)
         await self._send_fire_and_forget(
-            set_pbt_outer(level, to_addr=self._radio_addr, receiver=receiver)
+            set_pbt_outer(
+                level, to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+            )
         )
 
     async def get_cw_pitch(self) -> int:
@@ -2817,7 +2839,8 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._require_cmd29_route(
             0x14, 0x12, receiver=receiver, operation="get_nb_level"
         )
-        civ = get_nb_level(to_addr=self._radio_addr, receiver=receiver)
+        cmd29 = self._profile.supports_cmd29(0x14, 0x12)
+        civ = get_nb_level(to_addr=self._radio_addr, receiver=receiver, command29=cmd29)
         return await self._get_bcd_level(
             civ, key=f"get_nb_level:{receiver}", command=0x14, sub=0x12
         )
@@ -2828,8 +2851,11 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._require_cmd29_route(
             0x14, 0x12, receiver=receiver, operation="set_nb_level"
         )
+        cmd29 = self._profile.supports_cmd29(0x14, 0x12)
         await self._send_fire_and_forget(
-            set_nb_level(level, to_addr=self._radio_addr, receiver=receiver)
+            set_nb_level(
+                level, to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+            )
         )
 
     async def get_digisel_shift(self, receiver: int = RECEIVER_MAIN) -> int:
@@ -2838,7 +2864,10 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._require_cmd29_route(
             0x14, 0x13, receiver=receiver, operation="get_digisel_shift"
         )
-        civ = get_digisel_shift(to_addr=self._radio_addr, receiver=receiver)
+        cmd29 = self._profile.supports_cmd29(0x14, 0x13)
+        civ = get_digisel_shift(
+            to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+        )
         return await self._get_bcd_level(
             civ, key=f"get_digisel_shift:{receiver}", command=0x14, sub=0x13
         )
@@ -2851,8 +2880,11 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._require_cmd29_route(
             0x14, 0x13, receiver=receiver, operation="set_digisel_shift"
         )
+        cmd29 = self._profile.supports_cmd29(0x14, 0x13)
         await self._send_fire_and_forget(
-            set_digisel_shift(level, to_addr=self._radio_addr, receiver=receiver)
+            set_digisel_shift(
+                level, to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+            )
         )
 
     async def get_drive_gain(self) -> int:
@@ -3017,7 +3049,10 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._require_cmd29_route(
             0x15, 0x01, receiver=receiver, operation="get_s_meter_sql_status"
         )
-        civ = get_s_meter_sql_status(to_addr=self._radio_addr, receiver=receiver)
+        cmd29 = self._profile.supports_cmd29(0x15, 0x01)
+        civ = get_s_meter_sql_status(
+            to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+        )
         return await self._get_bool_value(
             civ,
             key=f"get_s_meter_sql_status:{receiver}",
@@ -3072,8 +3107,11 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._require_cmd29_route(
             0x16, 0x32, receiver=receiver, operation="get_audio_peak_filter"
         )
+        cmd29 = self._profile.supports_cmd29(0x16, 0x32)
         value = await self._get_bcd_level(
-            get_audio_peak_filter(to_addr=self._radio_addr, receiver=receiver),
+            get_audio_peak_filter(
+                to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+            ),
             key=f"get_audio_peak_filter:{receiver}",
             command=0x16,
             sub=0x32,
@@ -3091,9 +3129,12 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._require_cmd29_route(
             0x16, 0x32, receiver=receiver, operation="set_audio_peak_filter"
         )
+        cmd29 = self._profile.supports_cmd29(0x16, 0x32)
         apf = AudioPeakFilter(mode)
         await self._send_fire_and_forget(
-            set_audio_peak_filter(apf, to_addr=self._radio_addr, receiver=receiver)
+            set_audio_peak_filter(
+                apf, to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+            )
         )
 
     async def get_auto_notch(self, receiver: int = RECEIVER_MAIN) -> bool:
@@ -3102,7 +3143,10 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._require_cmd29_route(
             0x16, 0x41, receiver=receiver, operation="get_auto_notch"
         )
-        civ = get_auto_notch(to_addr=self._radio_addr, receiver=receiver)
+        cmd29 = self._profile.supports_cmd29(0x16, 0x41)
+        civ = get_auto_notch(
+            to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+        )
         return await self._get_bool_value(
             civ,
             key=f"get_auto_notch:{receiver}",
@@ -3116,8 +3160,11 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._require_cmd29_route(
             0x16, 0x41, receiver=receiver, operation="set_auto_notch"
         )
+        cmd29 = self._profile.supports_cmd29(0x16, 0x41)
         await self._send_fire_and_forget(
-            set_auto_notch(on, to_addr=self._radio_addr, receiver=receiver)
+            set_auto_notch(
+                on, to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+            )
         )
 
     async def get_compressor(self) -> bool:
@@ -3175,7 +3222,10 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._require_cmd29_route(
             0x16, 0x48, receiver=receiver, operation="get_manual_notch"
         )
-        civ = get_manual_notch(to_addr=self._radio_addr, receiver=receiver)
+        cmd29 = self._profile.supports_cmd29(0x16, 0x48)
+        civ = get_manual_notch(
+            to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+        )
         return await self._get_bool_value(
             civ,
             key=f"get_manual_notch:{receiver}",
@@ -3189,8 +3239,11 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._require_cmd29_route(
             0x16, 0x48, receiver=receiver, operation="set_manual_notch"
         )
+        cmd29 = self._profile.supports_cmd29(0x16, 0x48)
         await self._send_fire_and_forget(
-            set_manual_notch(on, to_addr=self._radio_addr, receiver=receiver)
+            set_manual_notch(
+                on, to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+            )
         )
 
     async def get_manual_notch_width(self, receiver: int = RECEIVER_MAIN) -> int:
@@ -3199,7 +3252,10 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._require_cmd29_route(
             0x16, 0x57, receiver=receiver, operation="get_manual_notch_width"
         )
-        civ = get_manual_notch_width(to_addr=self._radio_addr, receiver=receiver)
+        cmd29 = self._profile.supports_cmd29(0x16, 0x57)
+        civ = get_manual_notch_width(
+            to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+        )
         return await self._get_bcd_level(
             civ,
             key=f"get_manual_notch_width:{receiver}",
@@ -3216,8 +3272,11 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._require_cmd29_route(
             0x16, 0x57, receiver=receiver, operation="set_manual_notch_width"
         )
+        cmd29 = self._profile.supports_cmd29(0x16, 0x57)
         await self._send_fire_and_forget(
-            set_manual_notch_width(value, to_addr=self._radio_addr, receiver=receiver)
+            set_manual_notch_width(
+                value, to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+            )
         )
 
     async def get_twin_peak_filter(self, receiver: int = RECEIVER_MAIN) -> bool:
@@ -3226,7 +3285,10 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._require_cmd29_route(
             0x16, 0x4F, receiver=receiver, operation="get_twin_peak_filter"
         )
-        civ = get_twin_peak_filter(to_addr=self._radio_addr, receiver=receiver)
+        cmd29 = self._profile.supports_cmd29(0x16, 0x4F)
+        civ = get_twin_peak_filter(
+            to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+        )
         return await self._get_bool_value(
             civ,
             key=f"get_twin_peak_filter:{receiver}",
@@ -3242,8 +3304,11 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._require_cmd29_route(
             0x16, 0x4F, receiver=receiver, operation="set_twin_peak_filter"
         )
+        cmd29 = self._profile.supports_cmd29(0x16, 0x4F)
         await self._send_fire_and_forget(
-            set_twin_peak_filter(on, to_addr=self._radio_addr, receiver=receiver)
+            set_twin_peak_filter(
+                on, to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+            )
         )
 
     async def get_dial_lock(self) -> bool:
@@ -3263,8 +3328,11 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._require_cmd29_route(
             0x16, 0x56, receiver=receiver, operation="get_filter_shape"
         )
+        cmd29 = self._profile.supports_cmd29(0x16, 0x56)
         value = await self._get_bcd_level(
-            get_filter_shape(to_addr=self._radio_addr, receiver=receiver),
+            get_filter_shape(
+                to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+            ),
             key=f"get_filter_shape:{receiver}",
             command=0x16,
             sub=0x56,
@@ -3282,12 +3350,14 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._require_cmd29_route(
             0x16, 0x56, receiver=receiver, operation="set_filter_shape"
         )
+        cmd29 = self._profile.supports_cmd29(0x16, 0x56)
         filter_shape = FilterShape(shape)
         await self._send_fire_and_forget(
             set_filter_shape(
                 filter_shape,
                 to_addr=self._radio_addr,
                 receiver=receiver,
+                command29=cmd29,
             )
         )
 
@@ -3328,8 +3398,11 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._require_cmd29_route(
             0x1A, 0x04, receiver=receiver, operation="get_agc_time_constant"
         )
+        cmd29 = self._profile.supports_cmd29(0x1A, 0x04)
         return await self._get_bcd_level(
-            get_agc_time_constant(to_addr=self._radio_addr, receiver=receiver),
+            get_agc_time_constant(
+                to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+            ),
             key=f"get_agc_time_constant:{receiver}",
             command=0x1A,
             sub=0x04,
@@ -3344,11 +3417,13 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._require_cmd29_route(
             0x1A, 0x04, receiver=receiver, operation="set_agc_time_constant"
         )
+        cmd29 = self._profile.supports_cmd29(0x1A, 0x04)
         await self._send_fire_and_forget(
             set_agc_time_constant(
                 value,
                 to_addr=self._radio_addr,
                 receiver=receiver,
+                command29=cmd29,
             )
         )
 
@@ -3475,7 +3550,10 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._require_cmd29_route(
             0x15, 0x05, receiver=receiver, operation="get_various_squelch"
         )
-        civ = get_various_squelch(to_addr=self._radio_addr, receiver=receiver)
+        cmd29 = self._profile.supports_cmd29(0x15, 0x05)
+        civ = get_various_squelch(
+            to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+        )
         return await self._get_bool_value(
             civ,
             key=f"get_various_squelch:{receiver}",
@@ -4028,56 +4106,80 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
 
     async def get_repeater_tone(self, receiver: int = 0) -> bool:
         """Read repeater tone status (0x16 0x42)."""
-        civ = _get_repeater_tone_cmd(to_addr=self._radio_addr, receiver=receiver)
+        cmd29 = self._profile.supports_cmd29(0x16, _SUB_REPEATER_TONE)
+        civ = _get_repeater_tone_cmd(
+            to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+        )
         return await self._get_bool_value(
             civ, key="get_repeater_tone", command=0x16, sub=_SUB_REPEATER_TONE
         )
 
     async def set_repeater_tone(self, on: bool, receiver: int = 0) -> None:
         """Set repeater tone on/off (0x16 0x42)."""
+        cmd29 = self._profile.supports_cmd29(0x16, _SUB_REPEATER_TONE)
         await self._send_fire_and_forget(
-            _set_repeater_tone_cmd(on, to_addr=self._radio_addr, receiver=receiver)
+            _set_repeater_tone_cmd(
+                on, to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+            )
         )
 
     async def get_repeater_tsql(self, receiver: int = 0) -> bool:
         """Read repeater TSQL status (0x16 0x43)."""
-        civ = _get_repeater_tsql_cmd(to_addr=self._radio_addr, receiver=receiver)
+        cmd29 = self._profile.supports_cmd29(0x16, _SUB_REPEATER_TSQL)
+        civ = _get_repeater_tsql_cmd(
+            to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+        )
         return await self._get_bool_value(
             civ, key="get_repeater_tsql", command=0x16, sub=_SUB_REPEATER_TSQL
         )
 
     async def set_repeater_tsql(self, on: bool, receiver: int = 0) -> None:
         """Set repeater TSQL on/off (0x16 0x43)."""
+        cmd29 = self._profile.supports_cmd29(0x16, _SUB_REPEATER_TSQL)
         await self._send_fire_and_forget(
-            _set_repeater_tsql_cmd(on, to_addr=self._radio_addr, receiver=receiver)
+            _set_repeater_tsql_cmd(
+                on, to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+            )
         )
 
     async def get_tone_freq(self, receiver: int = 0) -> float:
         """Read CTCSS tone frequency in Hz (0x1B 0x00)."""
         self._check_connected()
-        civ = _get_tone_freq_cmd(to_addr=self._radio_addr, receiver=receiver)
+        cmd29 = self._profile.supports_cmd29(0x1B, 0x00)
+        civ = _get_tone_freq_cmd(
+            to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+        )
         resp = await self._send_civ_expect(civ, label="get_tone_freq")
         _, freq = parse_tone_freq_response(resp)
         return freq
 
     async def set_tone_freq(self, freq_hz: float, receiver: int = 0) -> None:
         """Set CTCSS tone frequency in Hz (0x1B 0x00)."""
+        cmd29 = self._profile.supports_cmd29(0x1B, 0x00)
         await self._send_fire_and_forget(
-            _set_tone_freq_cmd(freq_hz, to_addr=self._radio_addr, receiver=receiver)
+            _set_tone_freq_cmd(
+                freq_hz, to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+            )
         )
 
     async def get_tsql_freq(self, receiver: int = 0) -> float:
         """Read TSQL frequency in Hz (0x1B 0x01)."""
         self._check_connected()
-        civ = _get_tsql_freq_cmd(to_addr=self._radio_addr, receiver=receiver)
+        cmd29 = self._profile.supports_cmd29(0x1B, 0x01)
+        civ = _get_tsql_freq_cmd(
+            to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+        )
         resp = await self._send_civ_expect(civ, label="get_tsql_freq")
         _, freq = parse_tsql_freq_response(resp)
         return freq
 
     async def set_tsql_freq(self, freq_hz: float, receiver: int = 0) -> None:
         """Set TSQL frequency in Hz (0x1B 0x01)."""
+        cmd29 = self._profile.supports_cmd29(0x1B, 0x01)
         await self._send_fire_and_forget(
-            _set_tsql_freq_cmd(freq_hz, to_addr=self._radio_addr, receiver=receiver)
+            _set_tsql_freq_cmd(
+                freq_hz, to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+            )
         )
 
     # ------------------------------------------------------------------

--- a/tests/test_mor1517_cmd29_gating.py
+++ b/tests/test_mor1517_cmd29_gating.py
@@ -1,0 +1,741 @@
+"""Tests for MOR-1517 — cmd29 wrapping must be gated on profile support.
+
+Root cause: several IcomRadio SET/GET methods called their CI-V builders
+without threading the profile's actual Command29 support through, so the
+builder's ``command29=True`` default always fired. On profiles that declare
+no ``[cmd29]`` routes at all (IC-7300), every affected command was silently
+sent 0x29-wrapped and the radio ignored it — for SET methods this is a fully
+silent failure since they are fire-and-forget.
+
+``set_filter_width`` already had the correct pattern (branch on
+``self._profile.supports_cmd29(cmd, sub)``). This test file locks in the same
+pattern for PBT inner/outer and filter shape (the pinned defect) plus every
+other sibling instance found by auditing radio.py for the same class of bug:
+nb_level, nr_level, apf_type_level, digisel_shift, audio_peak_filter,
+auto_notch, manual_notch, manual_notch_width, twin_peak_filter,
+agc_time_constant, s_meter_sql_status, various_squelch, repeater_tone,
+repeater_tsql, tone_freq, tsql_freq.
+
+IC-7300 declares no ``[cmd29]`` section at all (single receiver) -> every
+affected command must go out as a bare, unwrapped CI-V frame.
+IC-7610 declares cmd29 routes for most of these commands -> existing wrapped
+behavior must be unchanged for those. apf_type_level/digisel_shift are not
+reachable on IC-7300 (it doesn't declare those commands at all) but IC-705
+does declare them and also has no ``[cmd29]`` section, so IC-705 is used as
+the unwrapped case for those two. manual_notch_width (0x16/0x57) turns out to
+be absent from IC-7610's own cmd29 routes too, so it must be unwrapped on
+*both* profiles -- see TestManualNotchWidthGating.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from rigplane.commands import (
+    get_agc_time_constant,
+    get_filter_shape,
+    get_pbt_inner,
+    get_pbt_outer,
+    get_s_meter_sql_status,
+    get_tone_freq,
+    get_tsql_freq,
+    get_various_squelch,
+    set_agc_time_constant,
+    set_apf_type_level,
+    set_audio_peak_filter,
+    set_auto_notch,
+    set_digisel_shift,
+    set_filter_shape,
+    set_manual_notch,
+    set_manual_notch_width,
+    set_nb_level,
+    set_nr_level,
+    set_pbt_inner,
+    set_pbt_outer,
+    set_repeater_tone,
+    set_repeater_tsql,
+    set_tone_freq,
+    set_tsql_freq,
+    set_twin_peak_filter,
+)
+from rigplane.radio import IcomRadio
+from rigplane.types import AudioPeakFilter, CivFrame, FilterShape
+
+_IC7300_ADDR = 0x94
+_IC7610_ADDR = 0x98
+_IC705_ADDR = 0xA4
+
+
+def _connected_icom(*, model: str) -> IcomRadio:
+    """Build a minimally-connected IcomRadio for a given profile."""
+    radio = IcomRadio(host="127.0.0.1", username="x", password="y", model=model)
+    radio._civ_runtime._check_connected = lambda: None  # type: ignore[method-assign]
+    radio._civ_runtime._connected = True  # type: ignore[attr-defined]
+    return radio
+
+
+def _mock_raw(radio: IcomRadio) -> AsyncMock:
+    """Mock the fire-and-forget send path and return the mock for assertions."""
+    mock = AsyncMock(return_value=None)
+    radio._send_civ_raw = mock  # type: ignore[method-assign]
+    return mock
+
+
+def _mock_expect(radio: IcomRadio, response: CivFrame) -> AsyncMock:
+    """Mock the request/response send path to return a canned response."""
+    mock = AsyncMock(return_value=response)
+    radio._send_civ_expect = mock  # type: ignore[method-assign]
+    return mock
+
+
+def _sent_civ(mock: AsyncMock) -> bytes:
+    """Extract the outgoing CI-V frame bytes from a mocked send call."""
+    args, kwargs = mock.call_args
+    return args[0] if args else kwargs["civ_frame"]
+
+
+# ---------------------------------------------------------------------------
+# Pinned defect: PBT inner / PBT outer / filter shape (GET + SET)
+# ---------------------------------------------------------------------------
+
+
+class TestPbtInnerGating:
+    @pytest.mark.asyncio
+    async def test_set_pbt_inner_unwrapped_on_ic7300(self) -> None:
+        radio = _connected_icom(model="IC-7300")
+        mock = _mock_raw(radio)
+        await radio.set_pbt_inner(75, receiver=0)
+        expected = set_pbt_inner(75, to_addr=_IC7300_ADDR, receiver=0, command29=False)
+        assert _sent_civ(mock) == expected
+        assert b"\x29" not in expected[: len(expected)][2:5]
+
+    @pytest.mark.asyncio
+    async def test_set_pbt_inner_wrapped_on_ic7610(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        mock = _mock_raw(radio)
+        await radio.set_pbt_inner(75, receiver=0)
+        expected = set_pbt_inner(75, to_addr=_IC7610_ADDR, receiver=0, command29=True)
+        assert _sent_civ(mock) == expected
+
+    @pytest.mark.asyncio
+    async def test_get_pbt_inner_unwrapped_on_ic7300(self) -> None:
+        radio = _connected_icom(model="IC-7300")
+        response = CivFrame(
+            to_addr=0xE0,
+            from_addr=_IC7300_ADDR,
+            command=0x14,
+            sub=0x07,
+            data=b"\x00\x64",
+        )
+        mock = _mock_expect(radio, response)
+        value = await radio.get_pbt_inner(receiver=0)
+        expected = get_pbt_inner(to_addr=_IC7300_ADDR, receiver=0, command29=False)
+        assert _sent_civ(mock) == expected
+        assert value == 64
+
+    @pytest.mark.asyncio
+    async def test_get_pbt_inner_wrapped_on_ic7610(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        response = CivFrame(
+            to_addr=0xE0,
+            from_addr=_IC7610_ADDR,
+            command=0x14,
+            sub=0x07,
+            data=b"\x00\x64",
+        )
+        mock = _mock_expect(radio, response)
+        value = await radio.get_pbt_inner(receiver=0)
+        expected = get_pbt_inner(to_addr=_IC7610_ADDR, receiver=0, command29=True)
+        assert _sent_civ(mock) == expected
+        assert value == 64
+
+
+class TestPbtOuterGating:
+    @pytest.mark.asyncio
+    async def test_set_pbt_outer_unwrapped_on_ic7300(self) -> None:
+        radio = _connected_icom(model="IC-7300")
+        mock = _mock_raw(radio)
+        await radio.set_pbt_outer(80, receiver=0)
+        expected = set_pbt_outer(80, to_addr=_IC7300_ADDR, receiver=0, command29=False)
+        assert _sent_civ(mock) == expected
+
+    @pytest.mark.asyncio
+    async def test_set_pbt_outer_wrapped_on_ic7610(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        mock = _mock_raw(radio)
+        await radio.set_pbt_outer(80, receiver=0)
+        expected = set_pbt_outer(80, to_addr=_IC7610_ADDR, receiver=0, command29=True)
+        assert _sent_civ(mock) == expected
+
+    @pytest.mark.asyncio
+    async def test_get_pbt_outer_unwrapped_on_ic7300(self) -> None:
+        radio = _connected_icom(model="IC-7300")
+        response = CivFrame(
+            to_addr=0xE0,
+            from_addr=_IC7300_ADDR,
+            command=0x14,
+            sub=0x08,
+            data=b"\x00\x50",
+        )
+        mock = _mock_expect(radio, response)
+        value = await radio.get_pbt_outer(receiver=0)
+        expected = get_pbt_outer(to_addr=_IC7300_ADDR, receiver=0, command29=False)
+        assert _sent_civ(mock) == expected
+        assert value == 50
+
+    @pytest.mark.asyncio
+    async def test_get_pbt_outer_wrapped_on_ic7610(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        response = CivFrame(
+            to_addr=0xE0,
+            from_addr=_IC7610_ADDR,
+            command=0x14,
+            sub=0x08,
+            data=b"\x00\x50",
+        )
+        mock = _mock_expect(radio, response)
+        value = await radio.get_pbt_outer(receiver=0)
+        expected = get_pbt_outer(to_addr=_IC7610_ADDR, receiver=0, command29=True)
+        assert _sent_civ(mock) == expected
+        assert value == 50
+
+
+class TestFilterShapeGating:
+    @pytest.mark.asyncio
+    async def test_set_filter_shape_unwrapped_on_ic7300(self) -> None:
+        radio = _connected_icom(model="IC-7300")
+        mock = _mock_raw(radio)
+        await radio.set_filter_shape(FilterShape.SOFT, receiver=0)
+        expected = set_filter_shape(
+            FilterShape.SOFT, to_addr=_IC7300_ADDR, receiver=0, command29=False
+        )
+        assert _sent_civ(mock) == expected
+
+    @pytest.mark.asyncio
+    async def test_set_filter_shape_wrapped_on_ic7610(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        mock = _mock_raw(radio)
+        await radio.set_filter_shape(FilterShape.SOFT, receiver=0)
+        expected = set_filter_shape(
+            FilterShape.SOFT, to_addr=_IC7610_ADDR, receiver=0, command29=True
+        )
+        assert _sent_civ(mock) == expected
+
+    @pytest.mark.asyncio
+    async def test_get_filter_shape_unwrapped_on_ic7300(self) -> None:
+        radio = _connected_icom(model="IC-7300")
+        response = CivFrame(
+            to_addr=0xE0, from_addr=_IC7300_ADDR, command=0x16, sub=0x56, data=b"\x01"
+        )
+        mock = _mock_expect(radio, response)
+        value = await radio.get_filter_shape(receiver=0)
+        expected = get_filter_shape(to_addr=_IC7300_ADDR, receiver=0, command29=False)
+        assert _sent_civ(mock) == expected
+        assert value == FilterShape.SOFT
+
+    @pytest.mark.asyncio
+    async def test_get_filter_shape_wrapped_on_ic7610(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        response = CivFrame(
+            to_addr=0xE0, from_addr=_IC7610_ADDR, command=0x16, sub=0x56, data=b"\x01"
+        )
+        mock = _mock_expect(radio, response)
+        value = await radio.get_filter_shape(receiver=0)
+        expected = get_filter_shape(to_addr=_IC7610_ADDR, receiver=0, command29=True)
+        assert _sent_civ(mock) == expected
+        assert value == FilterShape.SOFT
+
+
+# ---------------------------------------------------------------------------
+# Sibling audit fixes: same defect class found in other level/DSP/tone
+# commands that hardcoded command29=True the same way PBT/filter-shape did.
+# ---------------------------------------------------------------------------
+
+
+class TestNrLevelGating:
+    @pytest.mark.asyncio
+    async def test_set_nr_level_unwrapped_on_ic7300(self) -> None:
+        radio = _connected_icom(model="IC-7300")
+        mock = _mock_raw(radio)
+        await radio.set_nr_level(120, receiver=0)
+        expected = set_nr_level(120, to_addr=_IC7300_ADDR, receiver=0, command29=False)
+        assert _sent_civ(mock) == expected
+
+    @pytest.mark.asyncio
+    async def test_set_nr_level_wrapped_on_ic7610(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        mock = _mock_raw(radio)
+        await radio.set_nr_level(120, receiver=0)
+        expected = set_nr_level(120, to_addr=_IC7610_ADDR, receiver=0, command29=True)
+        assert _sent_civ(mock) == expected
+
+
+class TestNbLevelGating:
+    @pytest.mark.asyncio
+    async def test_set_nb_level_unwrapped_on_ic7300(self) -> None:
+        radio = _connected_icom(model="IC-7300")
+        mock = _mock_raw(radio)
+        await radio.set_nb_level(90, receiver=0)
+        expected = set_nb_level(90, to_addr=_IC7300_ADDR, receiver=0, command29=False)
+        assert _sent_civ(mock) == expected
+
+    @pytest.mark.asyncio
+    async def test_set_nb_level_wrapped_on_ic7610(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        mock = _mock_raw(radio)
+        await radio.set_nb_level(90, receiver=0)
+        expected = set_nb_level(90, to_addr=_IC7610_ADDR, receiver=0, command29=True)
+        assert _sent_civ(mock) == expected
+
+
+class TestApfTypeLevelGating:
+    """IC-7300 doesn't declare apf_type_level at all, but IC-705 does (and
+    has no [cmd29] section) -- IC-705 is the unwrapped case here."""
+
+    @pytest.mark.asyncio
+    async def test_set_apf_type_level_unwrapped_on_ic705(self) -> None:
+        radio = _connected_icom(model="IC-705")
+        mock = _mock_raw(radio)
+        await radio.set_apf_type_level(3, receiver=0)
+        expected = set_apf_type_level(
+            3, to_addr=_IC705_ADDR, receiver=0, command29=False
+        )
+        assert _sent_civ(mock) == expected
+
+    @pytest.mark.asyncio
+    async def test_set_apf_type_level_wrapped_on_ic7610(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        mock = _mock_raw(radio)
+        await radio.set_apf_type_level(3, receiver=0)
+        expected = set_apf_type_level(
+            3, to_addr=_IC7610_ADDR, receiver=0, command29=True
+        )
+        assert _sent_civ(mock) == expected
+
+
+class TestDigiselShiftGating:
+    """Same IC-705-vs-IC-7610 shape as apf_type_level."""
+
+    @pytest.mark.asyncio
+    async def test_set_digisel_shift_unwrapped_on_ic705(self) -> None:
+        radio = _connected_icom(model="IC-705")
+        mock = _mock_raw(radio)
+        await radio.set_digisel_shift(10, receiver=0)
+        expected = set_digisel_shift(
+            10, to_addr=_IC705_ADDR, receiver=0, command29=False
+        )
+        assert _sent_civ(mock) == expected
+
+    @pytest.mark.asyncio
+    async def test_set_digisel_shift_wrapped_on_ic7610(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        mock = _mock_raw(radio)
+        await radio.set_digisel_shift(10, receiver=0)
+        expected = set_digisel_shift(
+            10, to_addr=_IC7610_ADDR, receiver=0, command29=True
+        )
+        assert _sent_civ(mock) == expected
+
+
+class TestAudioPeakFilterGating:
+    @pytest.mark.asyncio
+    async def test_set_audio_peak_filter_unwrapped_on_ic7300(self) -> None:
+        radio = _connected_icom(model="IC-7300")
+        mock = _mock_raw(radio)
+        await radio.set_audio_peak_filter(AudioPeakFilter.WIDE, receiver=0)
+        expected = set_audio_peak_filter(
+            AudioPeakFilter.WIDE, to_addr=_IC7300_ADDR, receiver=0, command29=False
+        )
+        assert _sent_civ(mock) == expected
+
+    @pytest.mark.asyncio
+    async def test_set_audio_peak_filter_wrapped_on_ic7610(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        mock = _mock_raw(radio)
+        await radio.set_audio_peak_filter(AudioPeakFilter.WIDE, receiver=0)
+        expected = set_audio_peak_filter(
+            AudioPeakFilter.WIDE, to_addr=_IC7610_ADDR, receiver=0, command29=True
+        )
+        assert _sent_civ(mock) == expected
+
+
+class TestAutoNotchGating:
+    @pytest.mark.asyncio
+    async def test_set_auto_notch_unwrapped_on_ic7300(self) -> None:
+        radio = _connected_icom(model="IC-7300")
+        mock = _mock_raw(radio)
+        await radio.set_auto_notch(True, receiver=0)
+        expected = set_auto_notch(
+            True, to_addr=_IC7300_ADDR, receiver=0, command29=False
+        )
+        assert _sent_civ(mock) == expected
+
+    @pytest.mark.asyncio
+    async def test_set_auto_notch_wrapped_on_ic7610(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        mock = _mock_raw(radio)
+        await radio.set_auto_notch(True, receiver=0)
+        expected = set_auto_notch(
+            True, to_addr=_IC7610_ADDR, receiver=0, command29=True
+        )
+        assert _sent_civ(mock) == expected
+
+
+class TestManualNotchGating:
+    @pytest.mark.asyncio
+    async def test_set_manual_notch_unwrapped_on_ic7300(self) -> None:
+        radio = _connected_icom(model="IC-7300")
+        mock = _mock_raw(radio)
+        await radio.set_manual_notch(True, receiver=0)
+        expected = set_manual_notch(
+            True, to_addr=_IC7300_ADDR, receiver=0, command29=False
+        )
+        assert _sent_civ(mock) == expected
+
+    @pytest.mark.asyncio
+    async def test_set_manual_notch_wrapped_on_ic7610(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        mock = _mock_raw(radio)
+        await radio.set_manual_notch(True, receiver=0)
+        expected = set_manual_notch(
+            True, to_addr=_IC7610_ADDR, receiver=0, command29=True
+        )
+        assert _sent_civ(mock) == expected
+
+
+class TestManualNotchWidthGating:
+    """0x16/0x57 (manual notch width) is not in IC-7610's [cmd29] routes
+    either — it must go out unwrapped on BOTH profiles. Before this fix it
+    was silently broken on IC-7610 too, not just IC-7300."""
+
+    @pytest.mark.asyncio
+    async def test_set_manual_notch_width_unwrapped_on_ic7300(self) -> None:
+        radio = _connected_icom(model="IC-7300")
+        mock = _mock_raw(radio)
+        await radio.set_manual_notch_width(2, receiver=0)
+        expected = set_manual_notch_width(
+            2, to_addr=_IC7300_ADDR, receiver=0, command29=False
+        )
+        assert _sent_civ(mock) == expected
+
+    @pytest.mark.asyncio
+    async def test_set_manual_notch_width_unwrapped_on_ic7610(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        mock = _mock_raw(radio)
+        await radio.set_manual_notch_width(2, receiver=0)
+        expected = set_manual_notch_width(
+            2, to_addr=_IC7610_ADDR, receiver=0, command29=False
+        )
+        assert _sent_civ(mock) == expected
+        assert radio._profile.supports_cmd29(0x16, 0x57) is False
+
+
+class TestTwinPeakFilterGating:
+    @pytest.mark.asyncio
+    async def test_set_twin_peak_filter_unwrapped_on_ic7300(self) -> None:
+        radio = _connected_icom(model="IC-7300")
+        mock = _mock_raw(radio)
+        await radio.set_twin_peak_filter(True, receiver=0)
+        expected = set_twin_peak_filter(
+            True, to_addr=_IC7300_ADDR, receiver=0, command29=False
+        )
+        assert _sent_civ(mock) == expected
+
+    @pytest.mark.asyncio
+    async def test_set_twin_peak_filter_wrapped_on_ic7610(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        mock = _mock_raw(radio)
+        await radio.set_twin_peak_filter(True, receiver=0)
+        expected = set_twin_peak_filter(
+            True, to_addr=_IC7610_ADDR, receiver=0, command29=True
+        )
+        assert _sent_civ(mock) == expected
+
+
+class TestAgcTimeConstantGating:
+    @pytest.mark.asyncio
+    async def test_set_agc_time_constant_unwrapped_on_ic7300(self) -> None:
+        radio = _connected_icom(model="IC-7300")
+        mock = _mock_raw(radio)
+        await radio.set_agc_time_constant(5, receiver=0)
+        expected = set_agc_time_constant(
+            5, to_addr=_IC7300_ADDR, receiver=0, command29=False
+        )
+        assert _sent_civ(mock) == expected
+
+    @pytest.mark.asyncio
+    async def test_set_agc_time_constant_wrapped_on_ic7610(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        mock = _mock_raw(radio)
+        await radio.set_agc_time_constant(5, receiver=0)
+        expected = set_agc_time_constant(
+            5, to_addr=_IC7610_ADDR, receiver=0, command29=True
+        )
+        assert _sent_civ(mock) == expected
+
+    @pytest.mark.asyncio
+    async def test_get_agc_time_constant_unwrapped_on_ic7300(self) -> None:
+        radio = _connected_icom(model="IC-7300")
+        response = CivFrame(
+            to_addr=0xE0, from_addr=_IC7300_ADDR, command=0x1A, sub=0x04, data=b"\x05"
+        )
+        mock = _mock_expect(radio, response)
+        value = await radio.get_agc_time_constant(receiver=0)
+        expected = get_agc_time_constant(
+            to_addr=_IC7300_ADDR, receiver=0, command29=False
+        )
+        assert _sent_civ(mock) == expected
+        assert value == 5
+
+    @pytest.mark.asyncio
+    async def test_get_agc_time_constant_wrapped_on_ic7610(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        response = CivFrame(
+            to_addr=0xE0, from_addr=_IC7610_ADDR, command=0x1A, sub=0x04, data=b"\x05"
+        )
+        mock = _mock_expect(radio, response)
+        value = await radio.get_agc_time_constant(receiver=0)
+        expected = get_agc_time_constant(
+            to_addr=_IC7610_ADDR, receiver=0, command29=True
+        )
+        assert _sent_civ(mock) == expected
+        assert value == 5
+
+
+class TestSMeterSqlStatusGating:
+    """GET-only command (no SET twin)."""
+
+    @pytest.mark.asyncio
+    async def test_get_s_meter_sql_status_unwrapped_on_ic7300(self) -> None:
+        radio = _connected_icom(model="IC-7300")
+        response = CivFrame(
+            to_addr=0xE0, from_addr=_IC7300_ADDR, command=0x15, sub=0x01, data=b"\x01"
+        )
+        mock = _mock_expect(radio, response)
+        value = await radio.get_s_meter_sql_status(receiver=0)
+        expected = get_s_meter_sql_status(
+            to_addr=_IC7300_ADDR, receiver=0, command29=False
+        )
+        assert _sent_civ(mock) == expected
+        assert value is True
+
+    @pytest.mark.asyncio
+    async def test_get_s_meter_sql_status_wrapped_on_ic7610(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        response = CivFrame(
+            to_addr=0xE0, from_addr=_IC7610_ADDR, command=0x15, sub=0x01, data=b"\x01"
+        )
+        mock = _mock_expect(radio, response)
+        value = await radio.get_s_meter_sql_status(receiver=0)
+        expected = get_s_meter_sql_status(
+            to_addr=_IC7610_ADDR, receiver=0, command29=True
+        )
+        assert _sent_civ(mock) == expected
+        assert value is True
+
+
+class TestVariousSquelchGating:
+    """GET-only command (no SET twin)."""
+
+    @pytest.mark.asyncio
+    async def test_get_various_squelch_unwrapped_on_ic7300(self) -> None:
+        radio = _connected_icom(model="IC-7300")
+        response = CivFrame(
+            to_addr=0xE0, from_addr=_IC7300_ADDR, command=0x15, sub=0x05, data=b"\x01"
+        )
+        mock = _mock_expect(radio, response)
+        value = await radio.get_various_squelch(receiver=0)
+        expected = get_various_squelch(
+            to_addr=_IC7300_ADDR, receiver=0, command29=False
+        )
+        assert _sent_civ(mock) == expected
+        assert value is True
+
+    @pytest.mark.asyncio
+    async def test_get_various_squelch_wrapped_on_ic7610(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        response = CivFrame(
+            to_addr=0xE0, from_addr=_IC7610_ADDR, command=0x15, sub=0x05, data=b"\x01"
+        )
+        mock = _mock_expect(radio, response)
+        value = await radio.get_various_squelch(receiver=0)
+        expected = get_various_squelch(to_addr=_IC7610_ADDR, receiver=0, command29=True)
+        assert _sent_civ(mock) == expected
+        assert value is True
+
+
+class TestRepeaterToneGating:
+    @pytest.mark.asyncio
+    async def test_set_repeater_tone_unwrapped_on_ic7300(self) -> None:
+        radio = _connected_icom(model="IC-7300")
+        mock = _mock_raw(radio)
+        await radio.set_repeater_tone(True, receiver=0)
+        expected = set_repeater_tone(
+            True, to_addr=_IC7300_ADDR, receiver=0, command29=False
+        )
+        assert _sent_civ(mock) == expected
+
+    @pytest.mark.asyncio
+    async def test_set_repeater_tone_wrapped_on_ic7610(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        mock = _mock_raw(radio)
+        await radio.set_repeater_tone(True, receiver=0)
+        expected = set_repeater_tone(
+            True, to_addr=_IC7610_ADDR, receiver=0, command29=True
+        )
+        assert _sent_civ(mock) == expected
+
+
+class TestRepeaterTsqlGating:
+    @pytest.mark.asyncio
+    async def test_set_repeater_tsql_unwrapped_on_ic7300(self) -> None:
+        radio = _connected_icom(model="IC-7300")
+        mock = _mock_raw(radio)
+        await radio.set_repeater_tsql(True, receiver=0)
+        expected = set_repeater_tsql(
+            True, to_addr=_IC7300_ADDR, receiver=0, command29=False
+        )
+        assert _sent_civ(mock) == expected
+
+    @pytest.mark.asyncio
+    async def test_set_repeater_tsql_wrapped_on_ic7610(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        mock = _mock_raw(radio)
+        await radio.set_repeater_tsql(True, receiver=0)
+        expected = set_repeater_tsql(
+            True, to_addr=_IC7610_ADDR, receiver=0, command29=True
+        )
+        assert _sent_civ(mock) == expected
+
+
+class TestToneFreqGating:
+    """tone.py's get/set_tone_freq required a new command29 branch (they
+    previously called build_cmd29_frame directly with no way to opt out)."""
+
+    @pytest.mark.asyncio
+    async def test_set_tone_freq_unwrapped_on_ic7300(self) -> None:
+        radio = _connected_icom(model="IC-7300")
+        mock = _mock_raw(radio)
+        await radio.set_tone_freq(100.0, receiver=0)
+        expected = set_tone_freq(
+            100.0, to_addr=_IC7300_ADDR, receiver=0, command29=False
+        )
+        assert _sent_civ(mock) == expected
+
+    @pytest.mark.asyncio
+    async def test_set_tone_freq_wrapped_on_ic7610(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        mock = _mock_raw(radio)
+        await radio.set_tone_freq(100.0, receiver=0)
+        expected = set_tone_freq(
+            100.0, to_addr=_IC7610_ADDR, receiver=0, command29=True
+        )
+        assert _sent_civ(mock) == expected
+
+    @pytest.mark.asyncio
+    async def test_get_tone_freq_unwrapped_on_ic7300(self) -> None:
+        radio = _connected_icom(model="IC-7300")
+        response = CivFrame(
+            to_addr=0xE0,
+            from_addr=_IC7300_ADDR,
+            command=0x1B,
+            sub=0x00,
+            data=b"\x01\x00\x00",
+        )
+        mock = _mock_expect(radio, response)
+        value = await radio.get_tone_freq(receiver=0)
+        expected = get_tone_freq(to_addr=_IC7300_ADDR, receiver=0, command29=False)
+        assert _sent_civ(mock) == expected
+        assert value == 100.0
+
+    @pytest.mark.asyncio
+    async def test_get_tone_freq_wrapped_on_ic7610(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        response = CivFrame(
+            to_addr=0xE0,
+            from_addr=_IC7610_ADDR,
+            command=0x1B,
+            sub=0x00,
+            data=b"\x01\x00\x00",
+        )
+        mock = _mock_expect(radio, response)
+        value = await radio.get_tone_freq(receiver=0)
+        expected = get_tone_freq(to_addr=_IC7610_ADDR, receiver=0, command29=True)
+        assert _sent_civ(mock) == expected
+        assert value == 100.0
+
+
+class TestTsqlFreqGating:
+    @pytest.mark.asyncio
+    async def test_set_tsql_freq_unwrapped_on_ic7300(self) -> None:
+        radio = _connected_icom(model="IC-7300")
+        mock = _mock_raw(radio)
+        await radio.set_tsql_freq(100.0, receiver=0)
+        expected = set_tsql_freq(
+            100.0, to_addr=_IC7300_ADDR, receiver=0, command29=False
+        )
+        assert _sent_civ(mock) == expected
+
+    @pytest.mark.asyncio
+    async def test_set_tsql_freq_wrapped_on_ic7610(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        mock = _mock_raw(radio)
+        await radio.set_tsql_freq(100.0, receiver=0)
+        expected = set_tsql_freq(
+            100.0, to_addr=_IC7610_ADDR, receiver=0, command29=True
+        )
+        assert _sent_civ(mock) == expected
+
+    @pytest.mark.asyncio
+    async def test_get_tsql_freq_unwrapped_on_ic7300(self) -> None:
+        radio = _connected_icom(model="IC-7300")
+        response = CivFrame(
+            to_addr=0xE0,
+            from_addr=_IC7300_ADDR,
+            command=0x1B,
+            sub=0x01,
+            data=b"\x01\x00\x00",
+        )
+        mock = _mock_expect(radio, response)
+        value = await radio.get_tsql_freq(receiver=0)
+        expected = get_tsql_freq(to_addr=_IC7300_ADDR, receiver=0, command29=False)
+        assert _sent_civ(mock) == expected
+        assert value == 100.0
+
+    @pytest.mark.asyncio
+    async def test_get_tsql_freq_wrapped_on_ic7610(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        response = CivFrame(
+            to_addr=0xE0,
+            from_addr=_IC7610_ADDR,
+            command=0x1B,
+            sub=0x01,
+            data=b"\x01\x00\x00",
+        )
+        mock = _mock_expect(radio, response)
+        value = await radio.get_tsql_freq(receiver=0)
+        expected = get_tsql_freq(to_addr=_IC7610_ADDR, receiver=0, command29=True)
+        assert _sent_civ(mock) == expected
+        assert value == 100.0
+
+
+# ---------------------------------------------------------------------------
+# IC-7610 hard protocol rule sanity check (CLAUDE.md): cmd29 must remain
+# untouched for freq/mode (0x05/0x06) — this fix must not disturb that.
+# ---------------------------------------------------------------------------
+
+
+class TestFreqModeUnaffected:
+    @pytest.mark.asyncio
+    async def test_ic7610_set_freq_still_direct_not_cmd29(self) -> None:
+        """0x05 (freq) is never cmd29-wrapped on IC-7610, per CLAUDE.md."""
+        radio = _connected_icom(model="IC-7610")
+        assert radio._profile.supports_cmd29(0x05) is False
+
+    @pytest.mark.asyncio
+    async def test_ic7610_set_mode_still_direct_not_cmd29(self) -> None:
+        """0x06 (mode) is never cmd29-wrapped on IC-7610, per CLAUDE.md."""
+        radio = _connected_icom(model="IC-7610")
+        assert radio._profile.supports_cmd29(0x06) is False


### PR DESCRIPTION
## Root cause

`set_pbt_inner`, `set_pbt_outer`, `set_filter_shape` (and their GET twins) called their CI-V command builders with the builder's default `command29=True` baked in, with no way for the caller to override it. `rigs/ic7300.toml` declares **no `[cmd29]` section at all**, so `profile.supports_cmd29(...)` is always `False` for it — every one of these commands went out 0x29-wrapped anyway, and the IC-7300 silently ignored the wrapped frame. Since the SET paths are fire-and-forget, this was a **fully silent** failure: SHARP/SOFT and PBT writes had no effect and nothing indicated why.

`set_filter_width` already had the correct pattern:

```python
if self._profile.supports_cmd29(0x1A, 0x03):
    await self.send_civ(0x29, data=..., wait_response=False)
else:
    await self.send_civ(0x1A, sub=0x03, data=..., wait_response=False)
```

The asymmetry that exposed the bug: `get_filter_width`/`set_filter_width` (frequency Hz) branch on `supports_cmd29` at the **radio.py call site**, but `get_filter_shape`/`set_filter_shape` (SHARP/SOFT) called their builder with cmd29 hardcoded *inside the builder itself*, with no `command29` parameter exposed to override it. Same class of bug, opposite exposure — one method in the pair got the profile-aware treatment and the sibling method next to it didn't.

## Fix

Added a keyword-only `command29: bool = True` parameter to every affected builder (mirroring the parameter the attenuator/preamp builders already had), and updated every radio.py call site to compute `cmd29 = self._profile.supports_cmd29(cmd, sub)` and pass it through — the exact idiom `set_filter_width` already used. `tone.py`'s `get/set_tone_freq` and `get/set_tsql_freq` had no `command29` parameter at all (they called `build_cmd29_frame` directly); those needed a new `if command29: ... else: build_civ_frame(...)` branch, matching the shape already used by every other builder in the file.

## Full audit — every hardcoded `command29=True` builder call site

Grepped `commands/*.py` for `command29=True` and cross-referenced each hit against whether radio.py's corresponding method threads `self._profile.supports_cmd29(...)` through (the safe pattern) or not, and whether the affected command is actually declared (reachable) on any profile with no `[cmd29]` section.

### Fixed (profile-gated, same pattern as `set_filter_width`)

| Command | CI-V (cmd/sub) | Files | Notes |
|---|---|---|---|
| PBT Inner (get/set) | 0x14/0x07 | `levels.py`, `radio.py` | Pinned defect |
| PBT Outer (get/set) | 0x14/0x08 | `levels.py`, `radio.py` | Pinned defect |
| Filter Shape (get/set) | 0x16/0x56 | `mode.py`, `radio.py` | Pinned defect |
| NB Level (get/set) | 0x14/0x12 | `levels.py`, `radio.py` | |
| NR Level (get/set) | 0x14/0x06 | `levels.py`, `radio.py` | |
| APF Type Level (get/set) | 0x14/0x05 | `levels.py`, `radio.py` | Not declared on IC-7300; IC-705 declares it *and* has no `[cmd29]` section — broken there too, not IC-7300-specific |
| DIGI-SEL Shift (get/set) | 0x14/0x13 | `levels.py`, `radio.py` | Same shape as APF Type Level (IC-705) |
| Audio Peak Filter (get/set) | 0x16/0x32 | `dsp.py`, `radio.py` | |
| Auto Notch (get/set) | 0x16/0x41 | `dsp.py`, `radio.py` | |
| Manual Notch (get/set) | 0x16/0x48 | `dsp.py`, `radio.py` | |
| Manual Notch Width (get/set) | 0x16/0x57 | `dsp.py`, `radio.py` | **Also absent from IC-7610's own `[cmd29]` routes** — this command was silently broken on IC-7610 too, not just IC-7300. Now unwrapped on both. |
| Twin Peak Filter (get/set) | 0x16/0x4F | `dsp.py`, `radio.py` | |
| AGC Time Constant (get/set) | 0x1A/0x04 | `mode.py`, `radio.py` | |
| S-meter Squelch Status (get) | 0x15/0x01 | `meters.py`, `radio.py` | GET-only, no SET twin |
| Various Squelch (get) | 0x15/0x05 | `meters.py`, `radio.py` | GET-only, no SET twin |
| Repeater Tone (get/set) | 0x16/0x42 | `tone.py`, `radio.py` | radio.py had **no** `_require_cmd29_route` guard at all for this family |
| Repeater TSQL (get/set) | 0x16/0x43 | `tone.py`, `radio.py` | Same |
| Tone Frequency (get/set) | 0x1B/0x00 | `tone.py`, `radio.py` | Builder had no `command29` param at all — new branch added |
| TSQL Frequency (get/set) | 0x1B/0x01 | `tone.py`, `radio.py` | Same |

### Flagged, not fixed (unreachable / dead code today — no guessing)

| Site | Why not touched |
|---|---|
| `get_attenuator`/`set_attenuator_level`/`get_preamp`/`set_preamp` `cmd_map is not None` branch (`dsp.py`) | These builders already correctly honor a caller-supplied `command29` on the direct (no-`cmd_map`) path radio.py actually uses — and radio.py's attenuator/preamp methods already call `self._profile.supports_cmd29(...)` correctly (pre-existing, not new). But the `cmd_map is not None` branch inside each builder still hardcodes `command29=True` regardless of the parameter. `CoreRadio` never passes `cmd_map=` to these builders (grepped, zero hits), so this is dead code from the runtime's perspective — flagged for a follow-up rather than changed here without a live call site to test against. |
| `get_digisel`/`set_digisel` (`dsp.py`, 0x16/0x4E) | Hardcode cmd29 unconditionally with no override param, but `get_digisel` explicitly raises `CommandError` when `not supports_cmd29(0x16, 0x4E)` before ever building the frame, and the `"digisel"` capability is only declared on IC-7610 (which *does* support cmd29 for this route) — no reachable profile hits the unguarded path. |
| `get_af_mute`/`set_af_mute` (`dsp.py`, 0x1A/0x09) | Hardcoded cmd29, no override param. Only IC-7610 and IC-9700 declare `af_mute` in `[commands]`, and both declare `[0x1A, 0x09]` in `[cmd29]` — no profile without cmd29 support declares this command, so the broken path is unreachable with current profile data. |
| `get_filter_width`/`set_filter_width` builders (`mode.py`) | Also hardcode cmd29 (in the `cmd_map` branch / unconditional fallback), but the `get_filter_width` builder is only ever invoked from radio.py's `get_filter_width` inside its own already-correct `if supports_cmd29(...): ... else: ...` branch, and the `set_filter_width` *builder* is entirely unused in `src/` (radio.py's `set_filter_width` method builds its raw frame manually, never calling this builder). Confirmed dead/already-safe by grep. |

### Confirmed already correct (not part of this bug class)

`get_agc`/`set_agc`, `get_nb`/`set_nb`, `get_nr`/`set_nr`, `get_ip_plus`/`set_ip_plus`, `get_notch_filter`/`set_notch_filter` — all already use the `command29=(receiver != RECEIVER_MAIN)` idiom (never wrap for MAIN). `get_attenuator`/`set_attenuator`/`set_attenuator_level`, `get_preamp`/`set_preamp`, `get_digisel` — radio.py already computes `cmd29 = self._profile.supports_cmd29(...)` at these call sites (someone fixed these previously). `set_mode`/`set_data_mode` (0x06 / 0x1A·0x06) branch on `supports_cmd29` correctly. Freq (0x05) and mode (0x06) cmd29 handling on IC-7610 — untouched, per CLAUDE.md's hard rule that cmd29 does not work for freq/mode on IC-7610.

## Wire-frame before/after (PBT Inner SET, level=75, IC-7300)

- **Before**: `FE FE 94 E0 29 00 14 07 75 FD` (cmd29-wrapped — IC-7300 silently drops it)
- **After**: `FE FE 94 E0 14 07 75 FD` (raw, matches every other IC-7300 level command)

IC-7610 (cmd29 declared for 0x14/0x07) is unchanged: `FE FE 98 E0 29 00 14 07 75 FD`.

## Tests

New file `tests/test_mor1517_cmd29_gating.py` — 52 tests, wrapped/unwrapped pairs per command family (IC-7300 or IC-705 for the unwrapped case depending on which profile declares the command; IC-7610 for the wrapped case). Verified TDD-red: reverting the six source files while keeping the test file fails 46/48 of the original tests with the exact defect (either wrong wire bytes or `TypeError: unexpected keyword argument 'command29'` for the tone.py branch additions).

Test classes: `TestPbtInnerGating`, `TestPbtOuterGating`, `TestFilterShapeGating` (GET+SET, full coverage — pinned defect), `TestNrLevelGating`, `TestNbLevelGating`, `TestApfTypeLevelGating`, `TestDigiselShiftGating`, `TestAudioPeakFilterGating`, `TestAutoNotchGating`, `TestManualNotchGating`, `TestManualNotchWidthGating`, `TestTwinPeakFilterGating`, `TestAgcTimeConstantGating` (GET+SET), `TestSMeterSqlStatusGating`, `TestVariousSquelchGating`, `TestRepeaterToneGating`, `TestRepeaterTsqlGating`, `TestToneFreqGating` (GET+SET — new branch), `TestTsqlFreqGating` (GET+SET — new branch), plus `TestFreqModeUnaffected` sanity-checking the IC-7610 freq/mode hard rule is untouched.

## Verification

- `uv run pytest tests/test_mor1517_cmd29_gating.py -q` — 52 passed
- `uv run pytest tests/ -q --ignore=tests/integration` — full suite green, zero new failures
- `uv run ruff check src/ tests/` — zero violations
- `uv run ruff format src/ tests/` — clean
- `git diff` — no unintended changes; boundary grep (internal hostnames/paths) clean

Closes MOR-1517.
