### PR TITLE
fix: reconfirm-after-write for the remaining scope controls; receiver mirror; rbw fetch retry (MOR-1524)

### DIFF
--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -1075,18 +1075,35 @@ class RadioPoller:
             ("get_scope_rbw", radio.get_scope_rbw),
         )
         for label, getter in scope_getters:
-            try:
-                await asyncio.wait_for(getter(), timeout=self._SCOPE_GETTER_TIMEOUT)
-            except asyncio.TimeoutError:
-                logger.debug(
-                    "radio-poller: %s timed out after %.0f ms (response dropped)",
-                    label,
-                    self._SCOPE_GETTER_TIMEOUT * 1000,
-                )
-            except Exception:
-                logger.debug("radio-poller: %s failed", label, exc_info=True)
+            ok = await self._scope_getter_attempt(label, getter)
+            if not ok and label == "get_scope_rbw":
+                # rbw's fieldStatus intermittently reports "missing" on the
+                # live stand (MOR-1524) — one bounded retry, still within
+                # this getter's own timeout budget, recovers most drops
+                # without extending the overall fetch cadence.
+                await self._scope_getter_attempt(label, getter)
             await asyncio.sleep(self._adaptive_gap())
         logger.info("radio-poller: scope controls fetched (receiver=%d)", scope_rx)
+
+    async def _scope_getter_attempt(self, label: str, getter: Any) -> bool:
+        """Run one bounded scope-control GET; return ``True`` on success.
+
+        Shared by ``_fetch_scope_controls`` so a dropped response (common on
+        busy scope streams) only costs ``_SCOPE_GETTER_TIMEOUT`` before the
+        caller decides whether to retry or move on.
+        """
+        try:
+            await asyncio.wait_for(getter(), timeout=self._SCOPE_GETTER_TIMEOUT)
+            return True
+        except asyncio.TimeoutError:
+            logger.debug(
+                "radio-poller: %s timed out after %.0f ms (response dropped)",
+                label,
+                self._SCOPE_GETTER_TIMEOUT * 1000,
+            )
+        except Exception:
+            logger.debug("radio-poller: %s failed", label, exc_info=True)
+        return False
 
     async def _reconfirm_scope_field(self, label: str, getter: Any) -> None:
         """Force a fresh confirmed observation for one scope-control leaf.
@@ -2585,6 +2602,12 @@ class RadioPoller:
                     operation="switch_scope_receiver",
                 )
                 await self._civ(0x27, sub=0x12, data=bytes([receiver]))
+                if self._radio_state:
+                    self._radio_state.scope_controls.receiver = receiver
+                if CAP_SCOPE in self._caps:
+                    await self._reconfirm_scope_field(
+                        "get_scope_receiver", radio.get_scope_receiver
+                    )
                 logger.info(
                     "radio-poller: scope receiver → %s",
                     "SUB" if receiver else "MAIN",
@@ -2594,11 +2617,17 @@ class RadioPoller:
                     await radio.set_scope_during_tx(on)
                     if self._radio_state:
                         self._radio_state.scope_controls.during_tx = on
+                    await self._reconfirm_scope_field(
+                        "get_scope_during_tx", radio.get_scope_during_tx
+                    )
             case SetScopeCenterType(center_type=center_type):
                 if CAP_SCOPE in self._caps:
                     await radio.set_scope_center_type(center_type)
                     if self._radio_state:
                         self._radio_state.scope_controls.center_type = center_type
+                    await self._reconfirm_scope_field(
+                        "get_scope_center_type", radio.get_scope_center_type
+                    )
             case SetScopeFixedEdge(edge=edge, start_hz=start_hz, end_hz=end_hz):
                 if CAP_SCOPE in self._caps:
                     await radio.set_scope_fixed_edge(
@@ -2611,11 +2640,17 @@ class RadioPoller:
                     await radio.set_scope_dual(dual)
                     if self._radio_state:
                         self._radio_state.scope_controls.dual = dual
+                    await self._reconfirm_scope_field(
+                        "get_scope_dual", radio.get_scope_dual
+                    )
             case SetScopeMode(mode=mode):
                 if CAP_SCOPE in self._caps:
                     await radio.set_scope_mode(mode)
                     if self._radio_state:
                         self._radio_state.scope_controls.mode = mode
+                    await self._reconfirm_scope_field(
+                        "get_scope_mode", radio.get_scope_mode
+                    )
             case SetScopeSpan(span=span):
                 if CAP_SCOPE in self._caps:
                     await radio.set_scope_span(span)
@@ -2645,21 +2680,33 @@ class RadioPoller:
                     await radio.set_scope_hold(on)
                     if self._radio_state:
                         self._radio_state.scope_controls.hold = on
+                    await self._reconfirm_scope_field(
+                        "get_scope_hold", radio.get_scope_hold
+                    )
             case SetScopeEdge(edge=edge):
                 if CAP_SCOPE in self._caps:
                     await radio.set_scope_edge(edge)
                     if self._radio_state:
                         self._radio_state.scope_controls.edge = edge
+                    await self._reconfirm_scope_field(
+                        "get_scope_edge", radio.get_scope_edge
+                    )
             case SetScopeVbw(narrow=narrow):
                 if CAP_SCOPE in self._caps:
                     await radio.set_scope_vbw(narrow)
                     if self._radio_state:
                         self._radio_state.scope_controls.vbw_narrow = narrow
+                    await self._reconfirm_scope_field(
+                        "get_scope_vbw", radio.get_scope_vbw
+                    )
             case SetScopeRbw(rbw=rbw):
                 if CAP_SCOPE in self._caps:
                     await radio.set_scope_rbw(rbw)
                     if self._radio_state:
                         self._radio_state.scope_controls.rbw = rbw
+                    await self._reconfirm_scope_field(
+                        "get_scope_rbw", radio.get_scope_rbw
+                    )
             case SetPowerstat(on=on):
                 if CAP_POWER_CONTROL in self._caps:
                     await radio.set_powerstat(on)

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -76,7 +76,12 @@ from rigplane.web.radio_poller import (
     SetPower,
     SetPreamp,
     SetRfGain,
+    SetScopeCenterType,
+    SetScopeDual,
+    SetScopeDuringTx,
     SetScopeEdge,
+    SetScopeHold,
+    SetScopeMode,
     SetScopeRbw,
     SetScopeRef,
     SetScopeSpan,
@@ -2001,6 +2006,206 @@ async def test_execute_set_scope_span_reconfirm_timeout_does_not_raise() -> None
 
 
 @pytest.mark.asyncio
+async def test_execute_set_scope_mode_updates_state_and_reconfirms() -> None:
+    """MOR-1524: SetScopeMode must reconfirm exactly like SPAN/SPEED/REF
+    (MOR-1446) — without the GET the StateStore keeps replaying the stale
+    pre-write mode observation."""
+    radio = _make_radio()
+    state = RadioState()
+    poller = RadioPoller(radio, StateCache(), CommandQueue(), radio_state=state)
+
+    await poller._execute(SetScopeMode(mode=1))  # noqa: SLF001
+
+    radio.set_scope_mode.assert_awaited_once_with(1)
+    assert state.scope_controls.mode == 1
+    radio.get_scope_mode.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_execute_set_scope_edge_updates_state_and_reconfirms() -> None:
+    """MOR-1524: SetScopeEdge must reconfirm — same MOR-1446 desync class."""
+    radio = _make_radio()
+    state = RadioState()
+    poller = RadioPoller(radio, StateCache(), CommandQueue(), radio_state=state)
+
+    await poller._execute(SetScopeEdge(edge=3))  # noqa: SLF001
+
+    radio.set_scope_edge.assert_awaited_once_with(3)
+    assert state.scope_controls.edge == 3
+    radio.get_scope_edge.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_execute_set_scope_hold_updates_state_and_reconfirms() -> None:
+    """MOR-1524: SetScopeHold must reconfirm — same MOR-1446 desync class."""
+    radio = _make_radio()
+    state = RadioState()
+    poller = RadioPoller(radio, StateCache(), CommandQueue(), radio_state=state)
+
+    await poller._execute(SetScopeHold(on=True))  # noqa: SLF001
+
+    radio.set_scope_hold.assert_awaited_once_with(True)
+    assert state.scope_controls.hold is True
+    radio.get_scope_hold.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_execute_set_scope_dual_updates_state_and_reconfirms() -> None:
+    """MOR-1524: SetScopeDual must reconfirm — same MOR-1446 desync class."""
+    radio = _make_radio()
+    state = RadioState()
+    poller = RadioPoller(radio, StateCache(), CommandQueue(), radio_state=state)
+
+    await poller._execute(SetScopeDual(dual=True))  # noqa: SLF001
+
+    radio.set_scope_dual.assert_awaited_once_with(True)
+    assert state.scope_controls.dual is True
+    radio.get_scope_dual.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_execute_set_scope_during_tx_updates_state_and_reconfirms() -> None:
+    """MOR-1524: SetScopeDuringTx must reconfirm — same MOR-1446 desync class."""
+    radio = _make_radio()
+    state = RadioState()
+    poller = RadioPoller(radio, StateCache(), CommandQueue(), radio_state=state)
+
+    await poller._execute(SetScopeDuringTx(on=True))  # noqa: SLF001
+
+    radio.set_scope_during_tx.assert_awaited_once_with(True)
+    assert state.scope_controls.during_tx is True
+    radio.get_scope_during_tx.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_execute_set_scope_center_type_updates_state_and_reconfirms() -> None:
+    """MOR-1524: SetScopeCenterType must reconfirm — same MOR-1446 desync
+    class."""
+    radio = _make_radio()
+    state = RadioState()
+    poller = RadioPoller(radio, StateCache(), CommandQueue(), radio_state=state)
+
+    await poller._execute(SetScopeCenterType(center_type=2))  # noqa: SLF001
+
+    radio.set_scope_center_type.assert_awaited_once_with(2)
+    assert state.scope_controls.center_type == 2
+    radio.get_scope_center_type.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_execute_set_scope_vbw_updates_state_and_reconfirms() -> None:
+    """MOR-1524: SetScopeVbw must reconfirm — same MOR-1446 desync class."""
+    radio = _make_radio()
+    state = RadioState()
+    poller = RadioPoller(radio, StateCache(), CommandQueue(), radio_state=state)
+
+    await poller._execute(SetScopeVbw(narrow=True))  # noqa: SLF001
+
+    radio.set_scope_vbw.assert_awaited_once_with(True)
+    assert state.scope_controls.vbw_narrow is True
+    radio.get_scope_vbw.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_execute_set_scope_rbw_updates_state_and_reconfirms() -> None:
+    """MOR-1524: SetScopeRbw must reconfirm — same MOR-1446 desync class."""
+    radio = _make_radio()
+    state = RadioState()
+    poller = RadioPoller(radio, StateCache(), CommandQueue(), radio_state=state)
+
+    await poller._execute(SetScopeRbw(rbw=2))  # noqa: SLF001
+
+    radio.set_scope_rbw.assert_awaited_once_with(2)
+    assert state.scope_controls.rbw == 2
+    radio.get_scope_rbw.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_execute_switch_scope_receiver_mirrors_state_and_reconfirms() -> None:
+    """MOR-1524: SwitchScopeReceiver previously only sent the fire-and-forget
+    0x27 0x12 CI-V frame — it never mirrored ``scope_controls.receiver``
+    optimistically nor reconfirmed it, so the receiver readout desynced the
+    same way span/speed/ref did before MOR-1446."""
+    radio = _make_radio()
+    state = RadioState()
+    poller = RadioPoller(radio, StateCache(), CommandQueue(), radio_state=state)
+
+    await poller._execute(SwitchScopeReceiver(1))  # noqa: SLF001
+
+    scope_calls = [c for c in radio.send_civ.call_args_list if c.args[0] == 0x27]
+    assert any(
+        c.kwargs.get("sub") == 0x12 and c.kwargs.get("data") == bytes([1])
+        for c in scope_calls
+    ), "Expected CI-V 0x27/0x12/0x01 for SUB scope"
+    assert state.scope_controls.receiver == 1
+    radio.get_scope_receiver.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_execute_set_scope_span_reconfirm_timeout_does_not_raise_for_other_leaves() -> (
+    None
+):
+    """A dropped confirm response on any of the newly-wired leaves must not
+    fail the command, same guarantee as span/speed/ref."""
+    radio = _make_radio()
+    state = RadioState()
+
+    async def _never_resolves() -> int:
+        await asyncio.sleep(10)
+        return 0
+
+    radio.get_scope_mode = _never_resolves
+    poller = RadioPoller(radio, StateCache(), CommandQueue(), radio_state=state)
+
+    await poller._execute(SetScopeMode(mode=1))  # noqa: SLF001
+
+    radio.set_scope_mode.assert_awaited_once_with(1)
+    assert state.scope_controls.mode == 1
+
+
+@pytest.mark.asyncio
+async def test_fetch_scope_controls_rbw_retries_once_on_dropped_response() -> None:
+    """MOR-1524: the live stand observed ``get_scope_rbw`` fieldStatus as
+    "missing" on the first response of an otherwise-healthy fetch. A single
+    bounded retry (still within ``_SCOPE_GETTER_TIMEOUT`` per attempt)
+    recovers the value without a retry loop or extending the overall fetch
+    budget for the other 11 getters."""
+    radio = _make_radio()
+    state = RadioState()
+    poller = RadioPoller(radio, StateCache(), CommandQueue(), radio_state=state)
+
+    calls = 0
+
+    async def _rbw_first_drop() -> int:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise TimeoutError("simulated dropped fieldStatus")
+        return 4
+
+    radio.get_scope_rbw = AsyncMock(side_effect=_rbw_first_drop)
+
+    await poller._fetch_scope_controls()  # noqa: SLF001
+
+    assert calls == 2
+    assert radio.get_scope_rbw.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_fetch_scope_controls_rbw_no_retry_when_first_get_succeeds() -> None:
+    """The retry must only fire on a dropped/failed first attempt — a
+    healthy rbw response is fetched exactly once, same as every other
+    scope-control leaf."""
+    radio = _make_radio()
+    state = RadioState()
+    poller = RadioPoller(radio, StateCache(), CommandQueue(), radio_state=state)
+
+    await poller._fetch_scope_controls()  # noqa: SLF001
+
+    radio.get_scope_rbw.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
 async def test_enable_scope_deferred_during_initial_fetch() -> None:
     """EnableScope must be re-queued (not block) when initial fetch is in progress.
 
@@ -3031,14 +3236,18 @@ async def test_fetch_scope_controls_bounds_latency_on_dropped_response() -> None
     await poller._fetch_scope_controls()  # noqa: SLF001
     elapsed = asyncio.get_event_loop().time() - start
 
-    # 12 getters * (0.02 s timeout + ~0 s gap) ≈ 0.24 s.  Allow generous
-    # slack so the test is not flaky on slow CI; the important property
-    # is that we are NOT blocked for 12 * 2.0 s = 24 s.
+    # 13 attempts (11 single-shot getters + rbw's 2, MOR-1524) * (0.02 s
+    # timeout + ~0 s gap) ≈ 0.26 s.  Allow generous slack so the test is not
+    # flaky on slow CI; the important property is that we are NOT blocked
+    # for 12 * 2.0 s = 24 s.
     assert elapsed < 2.0, f"poller stalled for {elapsed:.2f}s on dropped responses"
 
-    # Every getter was attempted exactly once even though they all hung.
+    # Every getter was attempted exactly once even though they all hung,
+    # except rbw which gets one bounded retry on a dropped response
+    # (MOR-1524 — the live stand observed rbw fieldStatus intermittently
+    # missing).
     radio.get_scope_receiver.assert_awaited_once()
-    radio.get_scope_rbw.assert_awaited_once()
+    assert radio.get_scope_rbw.await_count == 2
 
 
 @pytest.mark.asyncio
@@ -3111,14 +3320,16 @@ async def test_fetch_scope_controls_repeated_timeouts_do_not_accumulate() -> Non
         await poller._fetch_scope_controls()  # noqa: SLF001
     elapsed = loop.time() - start
 
-    # 3 calls * 12 getters * 0.01 s = 0.36 s nominal.  Generous upper
-    # bound so the test is robust on slow CI but still rejects the
-    # 3 * 24 s = 72 s blowup.
+    # 3 calls * 13 attempts (11 single-shot getters + rbw's 2, MOR-1524) *
+    # 0.01 s = 0.39 s nominal.  Generous upper bound so the test is robust
+    # on slow CI but still rejects the 3 * 24 s = 72 s blowup.
     assert elapsed < 3.0, f"3 successive calls took {elapsed:.2f}s — accumulated"
 
-    # Each getter was attempted exactly 3 times (no early exit).
+    # Each getter was attempted exactly 3 times (no early exit), except rbw
+    # which gets one bounded retry per call on a dropped response
+    # (MOR-1524), so 3 calls * 2 attempts = 6.
     assert radio.get_scope_receiver.await_count == 3
-    assert radio.get_scope_rbw.await_count == 3
+    assert radio.get_scope_rbw.await_count == 6
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

MOR-1446 fixed the reconfirm-after-write desync for SPAN/SPEED/REF only. Every other scope control still mutated only the optimistic `RadioState.scope_controls` mirror on a `Set*` write, leaving the StateStore's confirmed observation stuck at its pre-write value and re-overwriting the fresh optimistic value on every subsequent snapshot — the same MOR-1446 desync class, just unaddressed for the rest of the family.

## Conformance matrix — verdicts implemented

| Control | Before | After |
|---|---|---|
| `SetScopeMode` | no reconfirm | `_reconfirm_scope_field("get_scope_mode", ...)` added |
| `SetScopeEdge` | no reconfirm | `_reconfirm_scope_field("get_scope_edge", ...)` added |
| `SetScopeHold` | no reconfirm | `_reconfirm_scope_field("get_scope_hold", ...)` added |
| `SetScopeDual` | no reconfirm | `_reconfirm_scope_field("get_scope_dual", ...)` added |
| `SetScopeDuringTx` | no reconfirm | `_reconfirm_scope_field("get_scope_during_tx", ...)` added |
| `SetScopeCenterType` | no reconfirm | `_reconfirm_scope_field("get_scope_center_type", ...)` added |
| `SetScopeVbw` | no reconfirm | `_reconfirm_scope_field("get_scope_vbw", ...)` added |
| `SetScopeRbw` | no reconfirm | `_reconfirm_scope_field("get_scope_rbw", ...)` added |
| `SwitchScopeReceiver` | fire-and-forget 0x27/0x12 CI-V only, no `scope_controls.receiver` mirror, no reconfirm | optimistic mirror write + `_reconfirm_scope_field("get_scope_receiver", ...)` added |
| `_fetch_scope_controls`'s `get_scope_rbw` GET | single-shot, no retry (live stand: rbw `fieldStatus` intermittently `missing`) | one bounded retry via new shared `_scope_getter_attempt` helper, same `_SCOPE_GETTER_TIMEOUT` budget per attempt, no retry loop |
| `dual`/`receiver` hidden on single-RX radios via `hasDualReceiver()` | — | verified: pre-existing frontend regression test `SpectrumToolbar.component.test.ts::'hides physical SUB controls for a normal one-receiver topology'` already covers this exact gate and passes; no duplicate test added |
| `commands/scope.py` builders | — | untouched (scope family uses the receiver-prefix byte, not cmd29) |
| `runtime/radio.py` | — | untouched (owned by another builder for MOR-1517) |

## Test plan

- [x] TDD red-first: stashed the `radio_poller.py` fix and confirmed all 10 new/changed-behavior tests fail against the unpatched code, then restored the fix and re-ran green.
- [x] `uv run pytest tests/test_radio_poller_coverage.py -q --tb=short` — 190 passed
- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 9191 passed, 12 skipped, 5 deselected, 14 xfailed, 1 xpassed, 0 failed
- [x] `uv run ruff format src/ tests/` — 656 files unchanged (already formatted)
- [x] `uv run ruff check src/ tests/` — all checks passed
- [x] `uv run mypy src/rigplane/web/radio_poller.py` — no issues
- [x] `uv run lint-imports` — 5 contracts kept, 0 broken
- [x] `npx vitest run` on `SpectrumToolbar.component.test.ts -t "hides physical SUB controls"` — 1 passed (verifies dual/receiver hiding, unchanged)
- [x] Boundary grep: `git diff --cached --name-only | grep -E "commands/scope\.py|runtime/radio\.py"` — no matches

Closes MOR-1524