### PR TITLE
fix: radio-link chip derives from live facts; reconnect events overlay only (MOR-1526)

### DIFF
--- a/frontend/src/__tests__/presentation-switch-resources.component.test.ts
+++ b/frontend/src/__tests__/presentation-switch-resources.component.test.ts
@@ -139,6 +139,7 @@ vi.mock('$lib/stores/connection.svelte', () => ({
   isStale: vi.fn(() => false),
   isReconnecting: vi.fn(() => false),
   getRadioStatus: vi.fn(() => ''),
+  getRadioLinkState: vi.fn(() => ''),
   getRadioPowerOn: vi.fn(() => null),
   setWsConnected: vi.fn(),
   setRadioStatus: vi.fn(),

--- a/frontend/src/components-v2/layout/StatusBar.svelte
+++ b/frontend/src/components-v2/layout/StatusBar.svelte
@@ -59,7 +59,7 @@
   import { runtime } from '$lib/runtime';
   import { t } from '$lib/i18n';
   import {
-    getRadioStatus,
+    getRadioLinkState,
     getConnectionStatus,
     isAudioConnected,
     getWsConnected,
@@ -128,8 +128,14 @@
         : t('core.statusbar.power.toggleUnknown')
   );
 
-  // When radio is powered off, override statuses that depend on the radio
-  let radioState = $derived(isPoweredOff ? 'disconnected' : getRadioStatus());
+  // When radio is powered off, override statuses that depend on the radio.
+  // MOR-1526: `radioState` is the "Radio ↔ Server" chip's steady state,
+  // derived from live per-field facts (rigConnected/radioReady/radioHealth),
+  // overlaid by the reconnect-edge event stream only while a reconnect is
+  // actively in flight — see `getRadioLinkState` in connection.svelte.ts for
+  // the precedence rationale. Fixes: a fresh, healthy, no-reconnect session
+  // used to read the event-only default ('disconnected') forever.
+  let radioState = $derived(isPoweredOff ? 'disconnected' : getRadioLinkState());
   let controlState = $derived(getConnectionStatus()); // server link — always real
   let scopeState = $derived(
     deriveScopeIndicatorState(runtime.defaultScopeStatus, isPoweredOff),

--- a/frontend/src/components-v2/layout/StatusBar.svelte
+++ b/frontend/src/components-v2/layout/StatusBar.svelte
@@ -176,10 +176,14 @@
       case 'server_unreachable':
         return t('core.statusbar.health.serverUnreachable');
       default:
-        if (!rigConnected && radioState === 'connected') {
+        // MOR-1526 F4: `radioState` now emits 'degraded' itself (not
+        // 'connected') for this exact combination — see `radioLinkSteady`
+        // in connection.svelte.ts — so these checks key off 'degraded' to
+        // keep both MOR-620 labels reachable instead of dead.
+        if (!rigConnected && radioState === 'degraded') {
           return t('core.statusbar.health.rigOffline');
         }
-        if (!radioReady && radioState === 'connected') {
+        if (!radioReady && radioState === 'degraded') {
           return t('core.statusbar.health.radioNotReady');
         }
         return '';

--- a/frontend/src/components-v2/layout/StatusBar.svelte
+++ b/frontend/src/components-v2/layout/StatusBar.svelte
@@ -159,9 +159,11 @@
     if (radioHealth?.readiness === 'delayed' || radioHealth?.readiness === 'stalled') {
       return 'degraded';
     }
-    // MOR-620: a session that is connected but not radio-ready (CI-V link
-    // degraded) must be visibly degraded, not silently green.
-    return radioState === 'connected' && (!rigConnected || !radioReady) ? 'degraded' : radioState;
+    // MOR-620's "connected but not radio-ready" downgrade now lives in the
+    // store's own steady-state derivation (getRadioLinkState in
+    // connection.svelte.ts) — `radioState` already reads 'degraded' for
+    // that combination, so there is nothing left to downgrade here.
+    return radioState;
   });
   let radioHealthLabel = $derived.by(() => {
     switch (radioHealth?.likelyCause) {

--- a/frontend/src/components-v2/layout/__tests__/LcdLayout.autostep-lifecycle.isolated.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/LcdLayout.autostep-lifecycle.isolated.test.ts
@@ -57,6 +57,7 @@ vi.mock('$lib/stores/connection.svelte', () => ({
   getWsConnected: vi.fn(() => false),
   getRadioPowerOn: vi.fn(() => null),
   getRadioStatus: vi.fn(() => 'disconnected'),
+  getRadioLinkState: vi.fn(() => 'disconnected'),
   isScopeConnected: vi.fn(() => false),
   isAudioConnected: vi.fn(() => false),
   getRigConnected: vi.fn(() => false),

--- a/frontend/src/components-v2/layout/__tests__/LcdLayout.command-bus-migration.isolated.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/LcdLayout.command-bus-migration.isolated.test.ts
@@ -36,6 +36,7 @@ vi.mock('$lib/stores/connection.svelte', () => ({
   getWsConnected: vi.fn(() => false),
   getRadioPowerOn: vi.fn(() => null),
   getRadioStatus: vi.fn(() => 'disconnected'),
+  getRadioLinkState: vi.fn(() => 'disconnected'),
   isScopeConnected: vi.fn(() => false),
   isAudioConnected: vi.fn(() => false),
   getRigConnected: vi.fn(() => false),

--- a/frontend/src/components-v2/layout/__tests__/RadioLayout.command-bus-migration.isolated.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/RadioLayout.command-bus-migration.isolated.test.ts
@@ -84,6 +84,7 @@ vi.mock('$lib/stores/connection.svelte', () => ({
   getWsConnected: vi.fn(() => false),
   getRadioPowerOn: vi.fn(() => null),
   getRadioStatus: vi.fn(() => 'disconnected'),
+  getRadioLinkState: vi.fn(() => 'disconnected'),
   isScopeConnected: vi.fn(() => false),
   isAudioConnected: vi.fn(() => false),
   getRigConnected: vi.fn(() => false),

--- a/frontend/src/components-v2/layout/__tests__/RadioLayout.isolated.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/RadioLayout.isolated.test.ts
@@ -87,6 +87,7 @@ vi.mock('$lib/stores/connection.svelte', () => ({
   getWsConnected: vi.fn(() => false),
   getRadioPowerOn: vi.fn(() => null),
   getRadioStatus: vi.fn(() => 'disconnected'),
+  getRadioLinkState: vi.fn(() => 'disconnected'),
   isScopeConnected: vi.fn(() => false),
   isAudioConnected: vi.fn(() => false),
   getRigConnected: vi.fn(() => false),

--- a/frontend/src/components-v2/layout/__tests__/StatusBar.radio-link-chip.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/StatusBar.radio-link-chip.component.test.ts
@@ -1,0 +1,98 @@
+/**
+ * MOR-1526 F3 (verifier review round 1) — the store-level tests in
+ * `lib/stores/__tests__/connection.test.ts` pin `getRadioLinkState()`'s
+ * derivation logic, but nothing pinned that `StatusBar.svelte` actually
+ * *calls* it. The verifier's Witness B reverted only the StatusBar rewire
+ * (back to `getRadioStatus()`) and the full suite stayed green — the store
+ * fix was correct but unwired-to-the-DOM regressions were invisible.
+ *
+ * This test mounts the real `StatusBar.svelte` with a DISCRIMINATING mock:
+ * `getRadioLinkState` says 'connected', `getRadioStatus` (the old,
+ * event-only source) says 'disconnected'. Only a build that reads
+ * `getRadioLinkState()` can render the radio indicator as connected/green;
+ * a build that still reads `getRadioStatus()` renders it disconnected/red.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mount, unmount, flushSync } from 'svelte';
+
+vi.mock('$lib/stores/connection.svelte', () => ({
+  getRadioLinkState: vi.fn(() => 'connected'),
+  getRadioStatus: vi.fn(() => 'disconnected'),
+  getConnectionStatus: vi.fn(() => 'connected'),
+  isAudioConnected: vi.fn(() => false),
+  getWsConnected: vi.fn(() => true),
+  getRadioPowerOn: vi.fn(() => true),
+  getRigConnected: vi.fn(() => true),
+  getRadioReady: vi.fn(() => true),
+  getRadioHealth: vi.fn(() => null),
+}));
+
+vi.mock('$lib/stores/capabilities.svelte', () => ({
+  hasAnyScope: vi.fn(() => false),
+  hasAudio: vi.fn(() => false),
+  hasSpectrum: vi.fn(() => false),
+}));
+
+vi.mock('$lib/stores/layout.svelte', () => ({
+  getLayoutMode: vi.fn(() => 'standard'),
+  setLayoutMode: vi.fn(),
+}));
+
+vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
+  getActiveFrequencyHz: vi.fn(() => null),
+}));
+
+vi.mock('$lib/runtime', () => ({
+  runtime: {
+    defaultScopeStatus: {
+      source: null,
+      available: false,
+      resourceSelected: false,
+      demand: 0,
+      lifecycle: 'inactive',
+      transport: 'disconnected',
+      frameSeen: false,
+    },
+    system: {
+      disconnect: vi.fn(),
+      connect: vi.fn(),
+      powerOn: vi.fn(async () => {}),
+      powerOff: vi.fn(async () => {}),
+      identifyFrequency: vi.fn(async () => null),
+    },
+  },
+}));
+
+import StatusBar from '../StatusBar.svelte';
+
+describe('StatusBar radio-link chip wiring (MOR-1526 F3)', () => {
+  let target: HTMLElement | null = null;
+  let instance: object | null = null;
+
+  afterEach(() => {
+    if (instance) unmount(instance);
+    instance = null;
+    target?.remove();
+    target = null;
+  });
+
+  it('DISCRIMINATING: renders the radio indicator connected/green from getRadioLinkState, not the stale getRadioStatus() event value', () => {
+    target = document.createElement('div');
+    document.body.appendChild(target);
+    instance = mount(StatusBar, { target }) as object;
+    flushSync();
+
+    const radioIndicator = target.querySelector('.status-indicators .indicator');
+    expect(radioIndicator, 'expected the radio indicator to render').not.toBeNull();
+
+    // Exact match, not `.toContain('connected')` — 'disconnected' also
+    // contains the substring 'connected', which would silently pass under
+    // the reverted (Witness B) wiring and defeat the discrimination.
+    expect(radioIndicator!.getAttribute('title')).toBe('Radio ↔ Server: connected');
+    // Independent, non-overlapping confirmation via the rendered tone:
+    // green (#4ade80) only when the mocked getRadioLinkState() value wins;
+    // a build still reading getRadioStatus() renders red (#ef4444) instead.
+    expect(radioIndicator!.getAttribute('style')).toContain('#4ade80');
+    expect(radioIndicator!.getAttribute('style')).not.toContain('#ef4444');
+  });
+});

--- a/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
@@ -70,6 +70,7 @@ vi.mock('$lib/stores/connection.svelte', () => ({
   getWsConnected: vi.fn(() => false),
   getRadioPowerOn: vi.fn(() => null),
   getRadioStatus: vi.fn(() => 'disconnected'),
+  getRadioLinkState: vi.fn(() => 'disconnected'),
   isScopeConnected: vi.fn(() => false),
   isAudioConnected: vi.fn(() => false),
   getRigConnected: vi.fn(() => false),

--- a/frontend/src/components-v2/layout/__tests__/semantic-lcd-migration.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-lcd-migration.component.test.ts
@@ -132,6 +132,7 @@ vi.mock('$lib/stores/connection.svelte', () => ({
   getWsConnected: vi.fn(() => false),
   getRadioPowerOn: vi.fn(() => null),
   getRadioStatus: vi.fn(() => 'disconnected'),
+  getRadioLinkState: vi.fn(() => 'disconnected'),
   isScopeConnected: vi.fn(() => false),
   isAudioConnected: vi.fn(() => false),
   getRigConnected: vi.fn(() => false),

--- a/frontend/src/components-v2/layout/__tests__/tab-traversal.isolated.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/tab-traversal.isolated.test.ts
@@ -79,6 +79,7 @@ vi.mock('$lib/stores/connection.svelte', () => ({
   getWsConnected: vi.fn(() => false),
   getRadioPowerOn: vi.fn(() => null),
   getRadioStatus: vi.fn(() => 'disconnected'),
+  getRadioLinkState: vi.fn(() => 'disconnected'),
   isScopeConnected: vi.fn(() => false),
   isAudioConnected: vi.fn(() => false),
   getRigConnected: vi.fn(() => false),

--- a/frontend/src/components-v2/layout/__tests__/top-row-visual-regression.isolated.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/top-row-visual-regression.isolated.test.ts
@@ -53,6 +53,7 @@ vi.mock('$lib/stores/connection.svelte', () => ({
   getWsConnected: vi.fn(() => false),
   getRadioPowerOn: vi.fn(() => null),
   getRadioStatus: vi.fn(() => 'disconnected'),
+  getRadioLinkState: vi.fn(() => 'disconnected'),
   isScopeConnected: vi.fn(() => false),
   isAudioConnected: vi.fn(() => false),
   getRigConnected: vi.fn(() => false),

--- a/frontend/src/lib/stores/__tests__/connection.test.ts
+++ b/frontend/src/lib/stores/__tests__/connection.test.ts
@@ -145,13 +145,14 @@ describe('radio-link chip steady state (MOR-1526)', () => {
     store.setRadioStatus('reconnecting');
     expect(store.getRadioLinkState()).toBe('reconnecting');
 
-    // ws-client's onStateChange 'disconnected' branch (the F1/F2 delta)
-    // resets all four fields unconditionally, regardless of whether a
-    // terminal connection_status event ever arrived.
+    // ws-client's onStateChange 'disconnected' branch (the F1 delta) resets
+    // `radioStatus` unconditionally, regardless of whether a terminal
+    // connection_status event ever arrived. (R2 ruling: rigConnected/
+    // radioReady/radioHealth are deliberately NOT reset here — see F2
+    // below and the R2 comment in ws-client.ts — resetting them would be
+    // visible to isLiveRadioAvailable()/sendCommand, a command-gate change
+    // this display fix must not make.)
     store.setRadioStatus('disconnected');
-    store.setRigConnected(false);
-    store.setRadioReady(false);
-    store.setRadioHealth(null);
     store.setWsConnected(false);
     expect(store.getRadioLinkState()).toBe('disconnected');
 
@@ -188,25 +189,35 @@ describe('radio-link chip steady state (MOR-1526)', () => {
     });
     expect(store.getRadioLinkState()).toBe('connected');
 
-    // ws drops — the F1/F2 reset clears the facts, not just wsConnected.
+    // ws drops. R2 ruling: rigConnected/radioReady/radioHealth are NOT
+    // reset (unlike an earlier revision of this fix) — only wsConnected
+    // flips, which is what real transport-level onclose observes. The
+    // steady-state formula's `wsConnected &&` gate on both the 'connected'
+    // and 'degraded' branches is what actually produces 'disconnected'
+    // here, not a fact reset.
     store.setWsConnected(false);
-    store.setRigConnected(false);
-    store.setRadioReady(false);
-    store.setRadioHealth(null);
     expect(store.getRadioLinkState()).toBe('disconnected');
 
     // Up-edge: the transport reconnects (setWsConnected(true) fires
     // synchronously at ws-client.ts:550) before any fresh state_update has
-    // refreshed rigConnected/radioReady/radioHealth. Without the F1/F2
-    // reset above, those would still carry the pre-drop true/true/connected
-    // values and this would read 'connected' — a transient green flash for
-    // a radio that isn't actually back yet. With the reset, rigConnected/
-    // radioReady are false, so the F4 formula correctly reports 'degraded'
-    // (link up, rig/ready not yet confirmed) — NEVER 'connected'. That's
-    // the assertion this test exists to pin.
+    // refreshed rigConnected/radioReady/radioHealth on THIS session.
+    // `setWsConnected(false)` above cleared `factsObservedThisSession`, and
+    // nothing has set it back to true yet — so even though rigConnected/
+    // radioReady/radioHealth still carry the pre-drop true/true/connected
+    // values (stale, never reset), the chip must not read them as current
+    // truth. It reports 'degraded' (link up, facts not yet reconfirmed on
+    // this session) — NEVER 'connected'. That's the assertion this test
+    // exists to pin.
     store.setWsConnected(true);
     expect(store.getRadioLinkState()).not.toBe('connected');
     expect(store.getRadioLinkState()).toBe('degraded');
+
+    // And the command gate is untouched by any of this: rigConnected/
+    // radioReady/radioHealth were never reset, so isLiveRadioAvailable()
+    // (which sendCommand() gates on) still reads the session as available.
+    // The chip fix must not move the command gate — this is the pin for
+    // that isolation.
+    expect(store.isLiveRadioAvailable()).toBe(true);
   });
 
   it('F4: emits degraded (MOR-620 vocabulary), not connected or disconnected, when the link is up but rigConnected/radioReady have not both caught up', () => {

--- a/frontend/src/lib/stores/__tests__/connection.test.ts
+++ b/frontend/src/lib/stores/__tests__/connection.test.ts
@@ -56,3 +56,82 @@ describe('connection store', () => {
     expect(store.isStale()).toBe(false);
   });
 });
+
+// MOR-1526: the "Radio ↔ Server" chip's steady state must come from live
+// per-field facts (rigConnected/radioReady/radioHealth — synced on every
+// state_update, same as the MOR-1419 httpState derivation above), never
+// from the reconnect-edge `connection_status` event alone. That event's
+// ONLY writer is `radioStatus` (default 'disconnected'), which never fires
+// on a healthy session with no reconnects — the exact bug this derivation
+// fixes.
+describe('radio-link chip steady state (MOR-1526)', () => {
+  let store: typeof import('../connection.svelte');
+
+  beforeEach(async () => {
+    vi.resetModules();
+    store = await import('../connection.svelte');
+  });
+
+  it('BUG REPRO: fresh session, no reconnect events, live facts connected -> green', () => {
+    store.setWsConnected(true);
+    store.setRigConnected(true);
+    store.setRadioReady(true);
+    store.setRadioHealth({
+      serverReachable: true,
+      radioLink: 'connected',
+      readiness: 'ready',
+      likelyCause: 'unknown',
+      sinceMs: 0,
+      lastError: null,
+    });
+
+    expect(store.getRadioLinkState()).toBe('connected');
+  });
+
+  it('fails closed on genuine link-down facts (MOR-1440 radioLink != connected)', () => {
+    store.setWsConnected(true);
+    store.setRigConnected(true);
+    store.setRadioReady(true);
+    store.setRadioHealth({
+      serverReachable: true,
+      radioLink: 'disconnected',
+      readiness: 'stalled',
+      likelyCause: 'radio_network_lost',
+      sinceMs: 9000,
+      lastError: null,
+    });
+
+    expect(store.getRadioLinkState()).toBe('disconnected');
+  });
+
+  it('an active reconnect event overlays the steady state while in flight', () => {
+    // Live facts still look "connected" (stale, pre-drop) but a reconnect
+    // is actively underway — the event stream is the only source that
+    // knows that, and it must win.
+    store.setWsConnected(true);
+    store.setRigConnected(true);
+    store.setRadioReady(true);
+    store.setRadioStatus('reconnecting');
+
+    expect(store.getRadioLinkState()).toBe('reconnecting');
+  });
+
+  it('cold start: no events and no facts observed yet -> fail-closed disconnected', () => {
+    expect(store.getRadioLinkState()).toBe('disconnected');
+  });
+
+  it('a stale "connected" reconnect-status event does not survive a real ws drop', () => {
+    // Regression guard: rigConnected/radioReady are only ever refreshed by
+    // state_update messages, so they go stale (not reset) the instant the
+    // WS drops. The steady state must not read them as current truth once
+    // the transport itself is down.
+    store.setWsConnected(true);
+    store.setRigConnected(true);
+    store.setRadioReady(true);
+    store.setRadioStatus('connected');
+    expect(store.getRadioLinkState()).toBe('connected');
+
+    store.setWsConnected(false);
+    expect(store.getRadioLinkState()).toBe('disconnected');
+  });
+});

--- a/frontend/src/lib/stores/__tests__/connection.test.ts
+++ b/frontend/src/lib/stores/__tests__/connection.test.ts
@@ -134,4 +134,94 @@ describe('radio-link chip steady state (MOR-1526)', () => {
     store.setWsConnected(false);
     expect(store.getRadioLinkState()).toBe('disconnected');
   });
+
+  // ── Round 1 (verifier review): F1/F2/F4 findings ──────────────────────
+
+  it('F1: a reconnect overlay stuck mid-flight (no terminal event) is cleared by the disconnect reset, not left stuck across a ws down/up cycle', () => {
+    // A reconnect starts but never resolves with a terminal event — e.g.
+    // a server restart, or reconnect_loop hitting asyncio.CancelledError on
+    // either exit path (radio_reconnect.py:207) — so `radioStatus` never
+    // advances past 'reconnecting' on its own.
+    store.setRadioStatus('reconnecting');
+    expect(store.getRadioLinkState()).toBe('reconnecting');
+
+    // ws-client's onStateChange 'disconnected' branch (the F1/F2 delta)
+    // resets all four fields unconditionally, regardless of whether a
+    // terminal connection_status event ever arrived.
+    store.setRadioStatus('disconnected');
+    store.setRigConnected(false);
+    store.setRadioReady(false);
+    store.setRadioHealth(null);
+    store.setWsConnected(false);
+    expect(store.getRadioLinkState()).toBe('disconnected');
+
+    // Reconnect to a healthy server that — per the ticket's own premise —
+    // never emits connection_status on a session with no further
+    // reconnects. Without the reset above, the overlay would still be
+    // 'reconnecting' and would suppress these live facts forever.
+    store.setWsConnected(true);
+    store.setRigConnected(true);
+    store.setRadioReady(true);
+    store.setRadioHealth({
+      serverReachable: true,
+      radioLink: 'connected',
+      readiness: 'ready',
+      likelyCause: 'unknown',
+      sinceMs: 0,
+      lastError: null,
+    });
+
+    expect(store.getRadioLinkState()).toBe('connected');
+  });
+
+  it('F2: the up-edge (wsConnected flips true again) does not paint green from stale pre-drop facts', () => {
+    store.setWsConnected(true);
+    store.setRigConnected(true);
+    store.setRadioReady(true);
+    store.setRadioHealth({
+      serverReachable: true,
+      radioLink: 'connected',
+      readiness: 'ready',
+      likelyCause: 'unknown',
+      sinceMs: 0,
+      lastError: null,
+    });
+    expect(store.getRadioLinkState()).toBe('connected');
+
+    // ws drops — the F1/F2 reset clears the facts, not just wsConnected.
+    store.setWsConnected(false);
+    store.setRigConnected(false);
+    store.setRadioReady(false);
+    store.setRadioHealth(null);
+    expect(store.getRadioLinkState()).toBe('disconnected');
+
+    // Up-edge: the transport reconnects (setWsConnected(true) fires
+    // synchronously at ws-client.ts:550) before any fresh state_update has
+    // refreshed rigConnected/radioReady/radioHealth. Without the F1/F2
+    // reset above, those would still carry the pre-drop true/true/connected
+    // values and this would read 'connected' — a transient green flash for
+    // a radio that isn't actually back yet. With the reset, rigConnected/
+    // radioReady are false, so the F4 formula correctly reports 'degraded'
+    // (link up, rig/ready not yet confirmed) — NEVER 'connected'. That's
+    // the assertion this test exists to pin.
+    store.setWsConnected(true);
+    expect(store.getRadioLinkState()).not.toBe('connected');
+    expect(store.getRadioLinkState()).toBe('degraded');
+  });
+
+  it('F4: emits degraded (MOR-620 vocabulary), not connected or disconnected, when the link is up but rigConnected/radioReady have not both caught up', () => {
+    store.setWsConnected(true);
+    store.setRigConnected(true);
+    store.setRadioReady(false);
+    store.setRadioHealth({
+      serverReachable: true,
+      radioLink: 'connected',
+      readiness: 'stalled',
+      likelyCause: 'unknown',
+      sinceMs: 500,
+      lastError: null,
+    });
+
+    expect(store.getRadioLinkState()).toBe('degraded');
+  });
 });

--- a/frontend/src/lib/stores/connection.svelte.ts
+++ b/frontend/src/lib/stores/connection.svelte.ts
@@ -161,6 +161,47 @@ export function getRadioHealth(): RadioHealth | null {
   return radioHealth;
 }
 
+// MOR-1526: "Radio ↔ Server" chip honesty. `radioStatus` above is an
+// event-only field — its ONLY writer is the reconnect-edge `connection_status`
+// WS event (ws-client.ts), which the backend emits solely on reconnect edges
+// (watchdog-timeout / attempt / success / permanent-failure — see
+// runtime/radio_reconnect.py). A session that never reconnects never
+// receives that event, so `radioStatus` sits at its default 'disconnected'
+// forever — red on a perfectly healthy link. This is the same class of bug
+// MOR-1419 fixed for the neighboring `httpState` chip by switching it to a
+// live, continuously-synced fact instead of an edge-triggered one; applied
+// here to the radio-link chip, additively — `radioStatus`/`setRadioStatus`/
+// `getRadioStatus` are unchanged and still drive the reconnect overlay.
+//
+// Precedence: while a reconnect is actively in flight, the event stream is
+// the only source that knows it ("still trying", attempt N) — overlay it.
+// Otherwise (including first render, before any reconnect has ever fired)
+// the steady state comes from live per-field facts synced on every
+// state_update (rigConnected/radioReady/radioHealth — radio.svelte.ts),
+// never from an event that may simply never arrive. `wsConnected` gates the
+// whole thing because rigConnected/radioReady/radioHealth are themselves
+// only refreshed by state_update messages and go stale (not reset) the
+// instant the transport drops — without this gate a real disconnect would
+// keep showing the last-known-good facts, reproducing the same class of lie
+// this fix removes.
+let radioLinkSteady = $derived<'connected' | 'disconnected'>(
+  wsConnected
+    && rigConnected
+    && radioReady
+    && radioHealth?.serverReachable !== false
+    && (radioHealth == null || radioHealth.radioLink === 'connected')
+    ? 'connected'
+    : 'disconnected',
+);
+
+let radioLinkState = $derived<'connected' | 'connecting' | 'reconnecting' | 'disconnected'>(
+  radioStatus === 'connecting' || radioStatus === 'reconnecting' ? radioStatus : radioLinkSteady,
+);
+
+export function getRadioLinkState(): 'connected' | 'connecting' | 'reconnecting' | 'disconnected' {
+  return radioLinkState;
+}
+
 export function isLiveRadioAvailable(): boolean {
   if (!radioHealth) {
     return radioReady;

--- a/frontend/src/lib/stores/connection.svelte.ts
+++ b/frontend/src/lib/stores/connection.svelte.ts
@@ -184,21 +184,30 @@ export function getRadioHealth(): RadioHealth | null {
 // instant the transport drops — without this gate a real disconnect would
 // keep showing the last-known-good facts, reproducing the same class of lie
 // this fix removes.
-let radioLinkSteady = $derived<'connected' | 'disconnected'>(
+// F4 (verifier review round 1): `radioState === 'connected'` now implies
+// `rigConnected && radioReady` by construction, which silently starved
+// MOR-620's "connected but not radio-ready (CI-V link degraded)" signal —
+// StatusBar could never observe that combination to downgrade to
+// 'degraded' anymore. Owner ruling: keep MOR-620's vocabulary alive by
+// having the steady state emit 'degraded' itself, rather than retiring
+// the distinction.
+let radioLinkSteady = $derived<'connected' | 'degraded' | 'disconnected'>(
   wsConnected
     && rigConnected
     && radioReady
     && radioHealth?.serverReachable !== false
     && (radioHealth == null || radioHealth.radioLink === 'connected')
     ? 'connected'
-    : 'disconnected',
+    : wsConnected && radioHealth?.serverReachable !== false && (!rigConnected || !radioReady)
+      ? 'degraded'
+      : 'disconnected',
 );
 
-let radioLinkState = $derived<'connected' | 'connecting' | 'reconnecting' | 'disconnected'>(
+let radioLinkState = $derived<'connected' | 'connecting' | 'reconnecting' | 'degraded' | 'disconnected'>(
   radioStatus === 'connecting' || radioStatus === 'reconnecting' ? radioStatus : radioLinkSteady,
 );
 
-export function getRadioLinkState(): 'connected' | 'connecting' | 'reconnecting' | 'disconnected' {
+export function getRadioLinkState(): 'connected' | 'connecting' | 'reconnecting' | 'degraded' | 'disconnected' {
   return radioLinkState;
 }
 

--- a/frontend/src/lib/stores/connection.svelte.ts
+++ b/frontend/src/lib/stores/connection.svelte.ts
@@ -15,6 +15,14 @@ let controlConnected = $state(false);
 let radioHealth = $state<RadioHealth | null>(null);
 let lastResponseTime = $state<number | null>(null);
 
+// MOR-1526 F2: rigConnected/radioReady/radioHealth are refreshed only by
+// state_update and go stale (not reset) on a transport drop. Clearing them
+// would be visible to isLiveRadioAvailable()/sendCommand — a command-gate
+// change this display fix must not make. Instead, track whether the facts
+// have been observed on the CURRENT transport session; the chip refuses to
+// go green until they have.
+let factsObservedThisSession = $state(false);
+
 let lastStateUpdate = $state(0);
 const STALE_THRESHOLD_MS = 5000;
 let staleState = $state(false);
@@ -43,6 +51,7 @@ let connectionStatus = $derived<'connected' | 'partial' | 'disconnected'>(
 
 export function setWsConnected(v: boolean): void {
   wsConnected = v;
+  if (!v) factsObservedThisSession = false;
 }
 
 export function setReconnecting(v: boolean): void {
@@ -131,6 +140,7 @@ export function getRadioPowerOn(): boolean | null {
 
 export function setRigConnected(v: boolean): void {
   rigConnected = v;
+  factsObservedThisSession = true;
 }
 
 export function getRigConnected(): boolean {
@@ -191,14 +201,24 @@ export function getRadioHealth(): RadioHealth | null {
 // 'degraded' anymore. Owner ruling: keep MOR-620's vocabulary alive by
 // having the steady state emit 'degraded' itself, rather than retiring
 // the distinction.
+//
+// F2 (verifier review round 2): the up-edge honesty guard is
+// `factsObservedThisSession`, not a reset of rigConnected/radioReady/
+// radioHealth themselves (see setWsConnected/setRigConnected above and the
+// R2 comment in ws-client.ts) — those three must stay untouched by this
+// display fix because isLiveRadioAvailable()/sendCommand() also read them
+// for command-gating. Until a fresh state_update lands on the CURRENT
+// transport session, the steady state can never claim 'connected' — at
+// worst it reads 'degraded' off the pre-drop facts, never green.
 let radioLinkSteady = $derived<'connected' | 'degraded' | 'disconnected'>(
   wsConnected
+    && factsObservedThisSession
     && rigConnected
     && radioReady
     && radioHealth?.serverReachable !== false
     && (radioHealth == null || radioHealth.radioLink === 'connected')
     ? 'connected'
-    : wsConnected && radioHealth?.serverReachable !== false && (!rigConnected || !radioReady)
+    : wsConnected && radioHealth?.serverReachable !== false && (!factsObservedThisSession || !rigConnected || !radioReady)
       ? 'degraded'
       : 'disconnected',
 );

--- a/frontend/src/lib/transport/__tests__/ws-client.isolated.test.ts
+++ b/frontend/src/lib/transport/__tests__/ws-client.isolated.test.ts
@@ -20,12 +20,6 @@ vi.mock('../../stores/connection.svelte', () => ({
   markStateUpdated: vi.fn(),
   setReconnecting: vi.fn(),
   setRadioStatus: vi.fn(),
-  // MOR-1526 F1/F2: ws-client's onStateChange now resets these three on a
-  // 'disconnected' transition too — must be present or every test that
-  // fires simulateClose() throws "setRigConnected is not a function".
-  setRigConnected: vi.fn(),
-  setRadioReady: vi.fn(),
-  setRadioHealth: vi.fn(),
   isLiveRadioAvailable: vi.fn(() => true),
   // Under the fast pool's ``isolate: false`` this hoisted mock is shared
   // module-wide; scope-controller.svelte (loaded by a sibling fast-pool
@@ -81,9 +75,6 @@ import {
   isLiveRadioAvailable,
   setRadioStatus,
   setWsConnected,
-  setRigConnected,
-  setRadioReady,
-  setRadioHealth,
 } from '../../stores/connection.svelte';
 import { resetRadioState, setRadioState } from '../../stores/radio.svelte';
 
@@ -1322,11 +1313,8 @@ describe('control channel singleton', () => {
     expect(setRadioStatus).not.toHaveBeenCalled();
   });
 
-  it('resets radioStatus/rigConnected/radioReady/radioHealth on every ws disconnect, even without a terminal connection_status event (MOR-1526 F1/F2)', async () => {
+  it('resets radioStatus on every ws disconnect, even without a terminal connection_status event (MOR-1526 F1)', async () => {
     vi.mocked(setRadioStatus).mockClear();
-    vi.mocked(setRigConnected).mockClear();
-    vi.mocked(setRadioReady).mockClear();
-    vi.mocked(setRadioHealth).mockClear();
     const { connect, disconnect } = await import('../ws-client');
     connect('ws://test/api/v1/ws');
     instances[0].simulateOpen();
@@ -1345,9 +1333,11 @@ describe('control channel singleton', () => {
     instances[0].simulateClose();
 
     expect(setRadioStatus).toHaveBeenLastCalledWith('disconnected');
-    expect(setRigConnected).toHaveBeenCalledWith(false);
-    expect(setRadioReady).toHaveBeenCalledWith(false);
-    expect(setRadioHealth).toHaveBeenCalledWith(null);
+    // R2 ruling: rigConnected/radioReady/radioHealth are deliberately NOT
+    // reset by this handler — see the R2 comment in ws-client.ts. Resetting
+    // them would be visible to isLiveRadioAvailable()/sendCommand, a
+    // command-gate change this display fix must not make. Their isolation
+    // is pinned at the store level instead (connection.test.ts's F2 case).
 
     // simulateClose() drives the singleton `_ctrl` into its own real-timer
     // reconnect loop (this describe block runs with real timers). Without

--- a/frontend/src/lib/transport/__tests__/ws-client.isolated.test.ts
+++ b/frontend/src/lib/transport/__tests__/ws-client.isolated.test.ts
@@ -807,8 +807,14 @@ describe('control channel singleton', () => {
   });
 
   it('rejects degraded-health non-PTT dispatch with a truthful delivery error', async () => {
+    // The health gate is scoped to a LIVE transport (MOR-1526 R2): with the
+    // socket open, `!isLiveRadioAvailable()` reflects continuously refreshed
+    // facts, so the refusal is honest. (Offline dispatch is governed by the
+    // transport queue policy instead — see the queue-verdict cases.)
     vi.mocked(isLiveRadioAvailable).mockReturnValue(false);
-    const { onCommandDelivery, sendCommand } = await import('../ws-client');
+    const { connect, onCommandDelivery, sendCommand } = await import('../ws-client');
+    connect('ws://test/api/v1/ws');
+    instances[0].simulateOpen();
     const events: CommandDeliveryEvent[] = [];
     const unsubscribe = onCommandDelivery((event) => events.push(event));
 
@@ -817,11 +823,40 @@ describe('control channel singleton', () => {
     expect(events).toEqual([{
       commandId: 'degraded-freq',
       kind: 'error',
-      originalEpoch: 0,
-      eventEpoch: 0,
+      originalEpoch: 1,
+      eventEpoch: 1,
       error: 'radio health is degraded',
     }]);
+    expect(instances[0].sent.map((frame) => JSON.parse(frame))).toEqual([]);
     unsubscribe();
+  });
+
+  it('queues idempotent offline dispatch under the transport policy even while health facts are reset (MOR-1526 R2)', async () => {
+    // Transport-offline is NOT the health gate's jurisdiction: after a real
+    // disconnect the 'disconnected' transition resets rigConnected/radioReady/
+    // radioHealth (F1/F2), so `isLiveRadioAvailable()` is false — but the
+    // command must still ride WsChannel.send's offline policy (idempotent
+    // keep-latest queue), not be refused as "health degraded". This is what
+    // keeps the reconnect-dekey matrix's OFF-first ordering assertion
+    // non-vacuous and preserves queued tuning across brief WS blips.
+    vi.mocked(isLiveRadioAvailable).mockReturnValue(false);
+    const { onCommandDelivery, onMessage, sendCommand, connect } = await import('../ws-client');
+    const events: CommandDeliveryEvent[] = [];
+    const notices: unknown[] = [];
+    onCommandDelivery((event) => events.push(event));
+    onMessage((msg) => { if (msg.type === 'notification') notices.push(msg); });
+
+    expect(sendCommand('set_freq', { freq: 14_074_000 }, 'offline-freq')).toBe(false);
+
+    // No health refusal, no toast — the command is queued, not rejected.
+    expect(events).toEqual([]);
+    expect(notices).toEqual([]);
+
+    connect('ws://test/api/v1/ws');
+    instances[0].simulateOpen();
+    expect(instances[0].sent.map((frame) => JSON.parse(frame))).toMatchObject([
+      { type: 'cmd', name: 'set_freq', id: 'offline-freq' },
+    ]);
   });
 
   it('propagates the transport queue verdict for offline non-idempotent dispatch', async () => {
@@ -925,11 +960,14 @@ describe('control channel singleton', () => {
 
   it('sendCommand blocks live-radio commands while radio health is degraded', async () => {
     vi.mocked(isLiveRadioAvailable).mockReturnValue(false);
-    const { sendCommand } = await import('../ws-client');
+    const { connect, sendCommand } = await import('../ws-client');
+    connect('ws://test/api/v1/ws');
+    instances[0].simulateOpen();
 
     const result = sendCommand('set_freq', { freq: 14074000, receiver: 0 });
 
     expect(result).toBe(false);
+    expect(instances[0].sent.map((frame) => JSON.parse(frame))).toEqual([]);
   });
 
   it('allows open-socket PTT release aliases while radio health is degraded', async () => {
@@ -1365,7 +1403,9 @@ describe('sendCommand surfaces a refused command exactly once per burst (MOR-142
 
   it('emits exactly one notification for a burst of refused commands', async () => {
     vi.mocked(isLiveRadioAvailable).mockReturnValue(false);
-    const { onMessage, sendCommand } = await import('../ws-client');
+    const { connect, onMessage, sendCommand } = await import('../ws-client');
+    connect('ws://test/api/v1/ws');
+    instances[0].simulateOpen();
     const notices: unknown[] = [];
     onMessage((msg) => { if (msg.type === 'notification') notices.push(msg); });
 
@@ -1381,7 +1421,9 @@ describe('sendCommand surfaces a refused command exactly once per burst (MOR-142
 
   it('emits a second notification once the debounce window has elapsed', async () => {
     vi.mocked(isLiveRadioAvailable).mockReturnValue(false);
-    const { onMessage, sendCommand } = await import('../ws-client');
+    const { connect, onMessage, sendCommand } = await import('../ws-client');
+    connect('ws://test/api/v1/ws');
+    instances[0].simulateOpen();
     const notices: unknown[] = [];
     onMessage((msg) => { if (msg.type === 'notification') notices.push(msg); });
 

--- a/frontend/src/lib/transport/__tests__/ws-client.isolated.test.ts
+++ b/frontend/src/lib/transport/__tests__/ws-client.isolated.test.ts
@@ -20,6 +20,12 @@ vi.mock('../../stores/connection.svelte', () => ({
   markStateUpdated: vi.fn(),
   setReconnecting: vi.fn(),
   setRadioStatus: vi.fn(),
+  // MOR-1526 F1/F2: ws-client's onStateChange now resets these three on a
+  // 'disconnected' transition too — must be present or every test that
+  // fires simulateClose() throws "setRigConnected is not a function".
+  setRigConnected: vi.fn(),
+  setRadioReady: vi.fn(),
+  setRadioHealth: vi.fn(),
   isLiveRadioAvailable: vi.fn(() => true),
   // Under the fast pool's ``isolate: false`` this hoisted mock is shared
   // module-wide; scope-controller.svelte (loaded by a sibling fast-pool
@@ -71,7 +77,14 @@ vi.mock('../http-client', () => ({
   fetchCapabilities: vi.fn(() => new Promise(() => {})),
 }));
 
-import { isLiveRadioAvailable, setRadioStatus, setWsConnected } from '../../stores/connection.svelte';
+import {
+  isLiveRadioAvailable,
+  setRadioStatus,
+  setWsConnected,
+  setRigConnected,
+  setRadioReady,
+  setRadioHealth,
+} from '../../stores/connection.svelte';
 import { resetRadioState, setRadioState } from '../../stores/radio.svelte';
 
 beforeEach(() => {
@@ -1269,6 +1282,41 @@ describe('control channel singleton', () => {
     instances[0].simulateMessage(JSON.stringify({ type: 'event', name: 'connection_status' }));
     instances[0].simulateMessage(JSON.stringify({ type: 'event', name: 'connection_status', data: { state: 7 } }));
     expect(setRadioStatus).not.toHaveBeenCalled();
+  });
+
+  it('resets radioStatus/rigConnected/radioReady/radioHealth on every ws disconnect, even without a terminal connection_status event (MOR-1526 F1/F2)', async () => {
+    vi.mocked(setRadioStatus).mockClear();
+    vi.mocked(setRigConnected).mockClear();
+    vi.mocked(setRadioReady).mockClear();
+    vi.mocked(setRadioHealth).mockClear();
+    const { connect, disconnect } = await import('../ws-client');
+    connect('ws://test/api/v1/ws');
+    instances[0].simulateOpen();
+
+    // A reconnect starts but the server just vanishes (no terminal event —
+    // radio_reconnect.py's reconnect_loop can exit via CancelledError on
+    // either its watchdog-triggered or attempt-loop path without ever
+    // emitting a final connection_status).
+    instances[0].simulateMessage(JSON.stringify({
+      type: 'event',
+      name: 'connection_status',
+      data: { state: 'reconnecting', attempt: 1, next_retry_seconds: 1 },
+    }));
+    expect(setRadioStatus).toHaveBeenLastCalledWith('reconnecting');
+
+    instances[0].simulateClose();
+
+    expect(setRadioStatus).toHaveBeenLastCalledWith('disconnected');
+    expect(setRigConnected).toHaveBeenCalledWith(false);
+    expect(setRadioReady).toHaveBeenCalledWith(false);
+    expect(setRadioHealth).toHaveBeenCalledWith(null);
+
+    // simulateClose() drives the singleton `_ctrl` into its own real-timer
+    // reconnect loop (this describe block runs with real timers). Without
+    // an explicit disconnect() here, that dangling backoff timer can fire
+    // mid-run and create a stray MockWebSocket instance that pollutes the
+    // shared `instances` registry for unrelated later tests in this file.
+    disconnect();
   });
 
   it('rejects a same-session full snapshot that rolls revision truth backward', async () => {

--- a/frontend/src/lib/transport/ws-client.ts
+++ b/frontend/src/lib/transport/ws-client.ts
@@ -1,6 +1,6 @@
 import type { WsCommand, WsIncoming } from '../types/protocol';
 import { makeCommandId } from '../types/protocol';
-import { isLiveRadioAvailable, setWsConnected, markStateUpdated, setReconnecting, setRadioStatus, setRigConnected, setRadioReady, setRadioHealth } from '../stores/connection.svelte';
+import { isLiveRadioAvailable, setWsConnected, markStateUpdated, setReconnecting, setRadioStatus } from '../stores/connection.svelte';
 import { isValidServerState, matchesCurrentCapabilityTopology, resetRadioState, setRadioState } from '../stores/radio.svelte';
 import { capabilitiesMatchGeneration, clearCapabilities, setCapabilities } from '../stores/capabilities.svelte';
 import { fetchCapabilities } from './http-client';
@@ -557,24 +557,27 @@ _ctrl.onStateChange((s) => {
     _capabilityRefreshGeneration = null;
     resetRadioState();
     clearCapabilities();
-    // MOR-1526 (F1/F2 verifier findings): a WS drop that never gets a
-    // terminal `connection_status` event (server restart; reconnect_loop
-    // hitting asyncio.CancelledError on either exit path in
-    // radio_reconnect.py) used to leave `radioStatus` stuck at
-    // 'connecting'/'reconnecting' forever — the reconnect overlay then
-    // permanently suppressed the honest steady-state facts once the
-    // session reconnected to a server that (by the ticket's own premise)
-    // never emits `connection_status` on a healthy session. It also left
-    // rigConnected/radioReady/radioHealth at their last-known-good values,
-    // which `setWsConnected(true)` on the up-edge could briefly pair with
-    // before the first full state envelope refreshes them — a transient
-    // false-green flash for a radio that isn't actually back yet. Reset
-    // all four here so the chip fails closed across every disconnect path,
-    // not just the ones that happen to emit a terminal event.
+    // MOR-1526 (F1 verifier finding): a WS drop that never gets a terminal
+    // `connection_status` event (server restart; reconnect_loop hitting
+    // asyncio.CancelledError on either exit path in radio_reconnect.py)
+    // used to leave `radioStatus` stuck at 'connecting'/'reconnecting'
+    // forever — the reconnect overlay then permanently suppressed the
+    // honest steady-state facts once the session reconnected to a server
+    // that (by the ticket's own premise) never emits `connection_status`
+    // on a healthy session. Reset it here so the overlay clears across
+    // every disconnect path, not just the ones that happen to emit a
+    // terminal event.
+    //
+    // R2 ruling: rigConnected/radioReady/radioHealth are deliberately NOT
+    // reset here (unlike an earlier revision of this fix) — those three
+    // also gate `isLiveRadioAvailable()`/`sendCommand()`'s offline
+    // queue-and-replay path (below, IDEMPOTENT_TYPES dedup, MAX_QUEUE_SIZE,
+    // sendQueue replay), and forcing them false for the whole offline
+    // window made that command-safety path unreachable in production — a
+    // side effect this display fix must not cause. The chip's up-edge
+    // honesty (F2) is instead handled by `factsObservedThisSession` in
+    // connection.svelte.ts, which does not touch these fields' values.
     setRadioStatus('disconnected');
-    setRigConnected(false);
-    setRadioReady(false);
-    setRadioHealth(null);
   }
 });
 // Delta state tracking for incremental updates

--- a/frontend/src/lib/transport/ws-client.ts
+++ b/frontend/src/lib/transport/ws-client.ts
@@ -884,7 +884,16 @@ export function sendCommand(
   id?: string,
 ): boolean {
   const commandId = id ?? makeCommandId();
-  if (!isLiveRadioAvailable() && pttIntent(name, params) !== 'off') {
+  // This health gate only speaks for a LIVE transport. While the socket is
+  // open, rigConnected/radioReady/radioHealth are continuously refreshed by
+  // state_update, so `!isLiveRadioAvailable()` means the radio link is
+  // known-bad — refuse loudly rather than send into a black hole. While the
+  // socket is down those same facts were just reset by the 'disconnected'
+  // transition above (MOR-1526 F1/F2) and say nothing about the radio; the
+  // transport-offline case is governed by WsChannel.send's own offline
+  // policy (idempotent keep-latest queue / non-idempotent reject /
+  // pendingPttRelease), which predates this gate and stays authoritative.
+  if (_ctrl.isConnected() && !isLiveRadioAvailable() && pttIntent(name, params) !== 'off') {
     console.warn('[cmd] blocked while radio health is degraded', name);
     if (pttIntent(name, params) === null) {
       _ctrl.rejectNonPtt(commandId, 'radio health is degraded');

--- a/frontend/src/lib/transport/ws-client.ts
+++ b/frontend/src/lib/transport/ws-client.ts
@@ -891,11 +891,19 @@ export function sendCommand(
   // open, rigConnected/radioReady/radioHealth are continuously refreshed by
   // state_update, so `!isLiveRadioAvailable()` means the radio link is
   // known-bad — refuse loudly rather than send into a black hole. While the
-  // socket is down those same facts were just reset by the 'disconnected'
-  // transition above (MOR-1526 F1/F2) and say nothing about the radio; the
-  // transport-offline case is governed by WsChannel.send's own offline
-  // policy (idempotent keep-latest queue / non-idempotent reject /
-  // pendingPttRelease), which predates this gate and stays authoritative.
+  // socket is down, jurisdiction hands off entirely to WsChannel.send's own
+  // offline policy (idempotent keep-latest queue / non-idempotent reject /
+  // pendingPttRelease), which predates this gate and stays authoritative —
+  // a queued command ships (or doesn't) on the transport's terms, not a
+  // stale health snapshot from before the drop. (MOR-1526 R2: an earlier
+  // revision of the display fix in the 'disconnected' branch above reset
+  // rigConnected/radioReady/radioHealth on every disconnect, which would
+  // have made `!isLiveRadioAvailable()` unconditionally true for the whole
+  // offline window and this gate redundant with the transport's own
+  // policy; that reset was reverted, so these fields keep their real,
+  // request-driven values across a disconnect — this `_ctrl.isConnected()`
+  // guard is what keeps the two policies from double-judging the same
+  // command.)
   if (_ctrl.isConnected() && !isLiveRadioAvailable() && pttIntent(name, params) !== 'off') {
     console.warn('[cmd] blocked while radio health is degraded', name);
     if (pttIntent(name, params) === null) {

--- a/frontend/src/lib/transport/ws-client.ts
+++ b/frontend/src/lib/transport/ws-client.ts
@@ -1,6 +1,6 @@
 import type { WsCommand, WsIncoming } from '../types/protocol';
 import { makeCommandId } from '../types/protocol';
-import { isLiveRadioAvailable, setWsConnected, markStateUpdated, setReconnecting, setRadioStatus } from '../stores/connection.svelte';
+import { isLiveRadioAvailable, setWsConnected, markStateUpdated, setReconnecting, setRadioStatus, setRigConnected, setRadioReady, setRadioHealth } from '../stores/connection.svelte';
 import { isValidServerState, matchesCurrentCapabilityTopology, resetRadioState, setRadioState } from '../stores/radio.svelte';
 import { capabilitiesMatchGeneration, clearCapabilities, setCapabilities } from '../stores/capabilities.svelte';
 import { fetchCapabilities } from './http-client';
@@ -557,6 +557,24 @@ _ctrl.onStateChange((s) => {
     _capabilityRefreshGeneration = null;
     resetRadioState();
     clearCapabilities();
+    // MOR-1526 (F1/F2 verifier findings): a WS drop that never gets a
+    // terminal `connection_status` event (server restart; reconnect_loop
+    // hitting asyncio.CancelledError on either exit path in
+    // radio_reconnect.py) used to leave `radioStatus` stuck at
+    // 'connecting'/'reconnecting' forever — the reconnect overlay then
+    // permanently suppressed the honest steady-state facts once the
+    // session reconnected to a server that (by the ticket's own premise)
+    // never emits `connection_status` on a healthy session. It also left
+    // rigConnected/radioReady/radioHealth at their last-known-good values,
+    // which `setWsConnected(true)` on the up-edge could briefly pair with
+    // before the first full state envelope refreshes them — a transient
+    // false-green flash for a radio that isn't actually back yet. Reset
+    // all four here so the chip fails closed across every disconnect path,
+    // not just the ones that happen to emit a terminal event.
+    setRadioStatus('disconnected');
+    setRigConnected(false);
+    setRadioReady(false);
+    setRadioHealth(null);
   }
 });
 // Delta state tracking for incremental updates


### PR DESCRIPTION
## Root cause

The StatusBar "Radio ↔ Server" chip (`StatusBar.svelte:132`, `radioState = getRadioStatus()`) read `connection.svelte.ts`'s `radioStatus`. That field's **only writer** is the reconnect-edge `connection_status` WS event (`ws-client.ts:806`), which the backend (`runtime/radio_reconnect.py:33-136`) emits solely on reconnect edges — watchdog-timeout, each retry attempt, success, or permanent failure. A session that never reconnects never receives that event, so the store's default (`'disconnected'`) never advances.

**Result:** a fully healthy session with zero reconnects shows this chip red forever — it lies.

Meanwhile `connection.rigConnected`/`radioReady` and `radioHealth.serverReachable`/`radioLink` are synced on **every** `state_update` (`radio.svelte.ts:295-302`) and already back the honest `httpState` chip next to it (MOR-1419's pattern). This PR applies the same honesty fix to the radio-link chip, purely additively — MOR-1419's `httpState` derivation and tests are untouched.

## Precedence design

- **Steady state** (no active reconnect): `connected` when `wsConnected && rigConnected && radioReady && radioHealth.serverReachable !== false && radioHealth.radioLink === 'connected'` (when `radioHealth` is present). `wsConnected` gates the whole thing. As of R2 below, `rigConnected`/`radioReady`/`radioHealth` themselves are **not** reset on disconnect — the up-edge honesty guard is a separate session-observation flag instead, so these facts stay the command gate's exclusive business.
- **Overlay**: while `radioStatus` reports an active reconnect (`'connecting'` / `'reconnecting'`), the event stream is the only source that knows a reconnect is in flight — it wins over the steady-state facts. Any other event value (including the terminal `'connected'`/`'disconnected'` edges) defers back to live facts, so the overlay can never get stuck once a reconnect resolves.
- Fail-closed on cold start (no event, no facts observed yet) — both default to falsy, so the steady state is `'disconnected'` until proven otherwise, never the reverse.
- **Degraded tier** (added in R1, see F4 below): when the link is up but `rigConnected`/`radioReady` haven't both caught up yet, the steady state emits `'degraded'` (MOR-620's vocabulary) rather than silently falling between `'connected'` and `'disconnected'`.

New: `getRadioLinkState()` in `frontend/src/lib/stores/connection.svelte.ts`. `StatusBar.svelte`'s `radioState` now reads it instead of `getRadioStatus()`. `radioStatus`/`setRadioStatus`/`getRadioStatus` are unchanged and still drive the overlay.

## Test-mock fallout

Test files that fully replace `$lib/stores/connection.svelte` (no `importOriginal`) needed `getRadioLinkState` added alongside the existing `getRadioStatus` mock, matching the same mocked value, wherever the mounted tree includes `RadioLayout` or `LcdLayout` (both render `StatusBar`) — otherwise the new call throws `TypeError: getRadioLinkState is not a function`. `MobileRadioLayout` doesn't render `StatusBar`, so its honesty test was left alone.

## Out of scope (noted, not done here)

Per owner direction, this PR does **not** extract a shared "live-facts → chip state" helper covering both `httpState` (chip: server) and this new radio-link derivation, even though the underlying facts overlap. That consolidation is left for a separate follow-up if wanted.

## Tests (TDD, red-first)

New `describe('radio-link chip steady state (MOR-1526)')` in `frontend/src/lib/stores/__tests__/connection.test.ts`:
- `BUG REPRO: fresh session, no reconnect events, live facts connected -> green`
- `fails closed on genuine link-down facts (MOR-1440 radioLink != connected)`
- `an active reconnect event overlays the steady state while in flight`
- `cold start: no events and no facts observed yet -> fail-closed disconnected`
- `a stale "connected" reconnect-status event does not survive a real ws drop`

312 targeted tests pass (connection stores, StatusBar/RadioLayout/LcdLayout mounts, ws-client), broadened to 485 across all files importing `connection.svelte`. `eslint`, `lint:boundaries`, `svelte-check`, and `tsc -p tsconfig.node.json` are all clean on touched files.

---

## R1 — independent review round 1 (verifier findings F1-F4)

An independent verifier reviewed the original commit and ruled BLOCKED with four findings. The core derivation and additivity from the original PR held up (zero deletions, non-vacuous mocks, `wsConnected`-gate witness killed) — these four deltas close the remaining gaps, applied as prescribed.

**F1 — stuck overlay.** `radioStatus ∈ {connecting, reconnecting}` had unconditional overlay precedence, but nothing cleared it when the WS dropped before a terminal `connection_status` event arrived (e.g. a server restart, or `reconnect_loop` hitting `asyncio.CancelledError` on either exit path — `radio_reconnect.py:207`, neither path emits a terminal event). After reconnecting to a healthy server — which, per this ticket's own premise, never emits `connection_status` on a session with no further reconnects — the chip would stay stuck yellow forever, now actively suppressing the honest live facts underneath it.

**F2 — up-edge green flash.** On a ws drop, `rigConnected`/`radioReady`/`radioHealth` kept their last-known-good values (their sole writer is `radio.svelte.ts`'s `state_update` handler, which stops firing while disconnected). `setWsConnected(true)` fires synchronously on reconnect (`ws-client.ts:550`), before those facts get a chance to refresh from a fresh `state_update` — so the chip could flash green for a radio that wasn't actually back yet.

**R1's fix for F1+F2 (superseded by R2 below):** the initial fix reset `rigConnected`/`radioReady`/`radioHealth` to false/null alongside `radioStatus` on every disconnect. That created the command-gating regression R2 addresses — see the R2 section for what actually shipped.

**F3 — the chip itself was unpinned.** The verifier's "Witness B" reverted only the `StatusBar.svelte` rewire (back to `getRadioStatus()` at the two call sites) and the full suite stayed green — the store-level fix was correct but nothing proved the component actually used it. Added `StatusBar.radio-link-chip.component.test.ts`: mounts the real `StatusBar.svelte` with a **discriminating** connection-store mock (`getRadioLinkState` → `'connected'`, `getRadioStatus` → `'disconnected'`, `rigConnected`/`radioReady` → `true`) and asserts the rendered radio indicator's `title` and color resolve to connected/green (exact match, not `.toContain`, since `'disconnected'` substring-contains `'connected'`). Verified locally to fail under the Witness-B revert before landing it, and again after R2 (still fails the same way).

**F4 — `degraded` silently narrowed.** `radioState === 'connected'` now implies `rigConnected && radioReady` by construction, which quietly starved MOR-620's "connected but not radio-ready (CI-V link degraded)" signal: the `StatusBar.svelte` branch that downgraded the indicator to `'degraded'` for that combination could never observe it again, and the two health-label branches (`health.rigOffline` / `health.radioNotReady`) went dead alongside it — live but unreachable code plus orphaned i18n strings.

**Coordinator decision — option (a):** keep MOR-620's vocabulary alive rather than retire it (owner's additive doctrine: don't quietly drop ticketed behavior). The steady-state derivation itself now emits `'degraded'` when the link is up but `rigConnected`/`radioReady` haven't both caught up (exact condition below, in R2). `StatusBar.svelte`'s two label checks were updated from `radioState === 'connected'` to `radioState === 'degraded'` to match this new emission. Pinned with a store test asserting the `'degraded'` emission directly. In R2, the now-fully-redundant MOR-620 downgrade ternary at the indicator-color derivation (it could only ever pass through `radioState` unchanged once the store supplies `'degraded'` itself) was simplified to a plain passthrough; its comment folded into the store's derivation instead.

**Incidental fixes needed to land F1/F2 cleanly:**
- `ws-client.isolated.test.ts`'s full-factory mock of `$lib/stores/connection.svelte` needed the new setters stubbed, or every existing test that simulates a ws close throws e.g. `setRigConnected is not a function`.
- The new F1/F2 integration test drives a real disconnect through the singleton `_ctrl`, which (in that describe block, running with real timers) schedules a genuine reconnect backoff timer. Left uncancelled, it could fire mid-run and leak a stray `MockWebSocket` into the shared `instances` registry, intermittently polluting an unrelated later test's instance count (`WsChannel visibility-aware reconnect + close observability`) — caught during verification, fixed by calling `disconnect()` at the end of the new test. This fix carried through R2 unchanged.

---

## R2 — independent review round 2 (verifier findings, ruling: option (b))

A second verifier pass ruled BLOCKED again: R1's fact-reset for F1/F2 (`setRigConnected(false)` / `setRadioReady(false)` / `setRadioHealth(null)` on every disconnect) retired the offline queue-and-replay subsystem as a side effect. With `radioReady=false` and `radioHealth=null` for the whole offline window, `isLiveRadioAvailable()` was false, so the non-PTT command queue (`ws-client.ts`'s `IDEMPOTENT_TYPES` dedup, `MAX_QUEUE_SIZE`, the `sendQueue` replay on reconnect) became unreachable in production — a previously-queued command like `set_freq` was rejected at enqueue time instead of queued while briefly offline. De-key/PTT safety itself was verified **not** at risk either way: `ptt intent 'off'` always short-circuits the health gate, and `pendingPttRelease` always drains before `sendQueue` on reconnect.

**Ruling: option (b) — isolate the display fix from the command gate entirely.**

- `ws-client.ts`'s `s === 'disconnected'` branch: kept `setRadioStatus('disconnected')` (still fixes F1 — the overlay clears on every disconnect path); reverted the other three resets. `rigConnected`/`radioReady`/`radioHealth` now keep their real, request-driven values across a disconnect, so `isLiveRadioAvailable()`/`sendCommand()` are completely untouched by this display fix.
- `connection.svelte.ts`: F2's up-edge honesty is now a session-observation guard, not a fact reset — `factsObservedThisSession`, a file-local flag that starts `false`, clears on every `setWsConnected(false)`, and flips `true` the next time `setRigConnected` runs (i.e. the first `state_update` on the new session). The steady-state `'connected'` branch requires it; the `'degraded'` branch treats "not yet observed on this session" the same as "observed but not ready": `wsConnected && serverReachable !== false && (!factsObservedThisSession || !rigConnected || !radioReady) → 'degraded'`. The up-edge now reads `'degraded'`, never a false green — same assertion as R1's F2 test, only its setup changed (no more manual fact resets).
- Tests: `connection.test.ts`'s F1/F2 cases keep every assertion, just with the three setter calls removed from their setup. F2 gained a new pin: `expect(isLiveRadioAvailable()).toBe(true)` after the up-edge, proving the chip fix does not move the command gate. `ws-client.isolated.test.ts` drops the three setter mocks/imports/assertions, keeping the `setRadioStatus` assertion and the `disconnect()` leak fix. `integration-reconnect-dekey-matrix.isolated.test.ts` needed **no change** and is green again unmodified — the acceptance signal for this ruling.
- `StatusBar.svelte`: the now-fully-dead MOR-620 downgrade ternary simplified to a plain passthrough (see F4 above).

**Reconciling with a concurrently-landed fix:** while this round was in flight, a separately-dispatched session (working from the R1 state, before this ruling was known) independently pushed `f0259f33`, scoping `sendCommand`'s health gate to `_ctrl.isConnected() && !isLiveRadioAvailable() && ...` — a different mechanism aimed at the same root problem. Rebased this round's commit on top of it rather than overwriting it. The two are compatible: with R2's revert in place, `rigConnected`/`radioReady`/`radioHealth` are never artificially false during an outage, so `_ctrl.isConnected()` mostly agrees with what `isLiveRadioAvailable()` would already say — it only diverges (deliberately, and safely) in the narrow case where the radio's last-known health was *already* bad before the transport dropped, in which case jurisdiction now hands off entirely to the transport's own offline queue policy rather than the health gate re-litigating a stale snapshot. Updated that gate's comment, which had described the (now-reverted) R1 fact-reset as current behavior. Verified: the full `tx-controller/` directory is 103/103 green with both fixes combined, and both witnesses (StatusBar rewire reverted; `factsObservedThisSession` removed) still fail red as expected.

Closes MOR-1526.
