### PR TITLE
feat: AGC option domain comes from profile data (MOR-1522)

### DIFF
--- a/frontend/src/components-v2/panels/__tests__/AgcPanel.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/AgcPanel.test.ts
@@ -3,39 +3,53 @@ import { buildAgcOptions } from '../agc-utils';
 
 // ---------------------------------------------------------------------------
 // buildAgcOptions
+//
+// MOR-1522: the AGC option set is radio-specific profile data. This function
+// must render ONLY the declared `modes` — never invent an option the profile
+// did not declare (the bug: IC-7300 has no AGC OFF, but the UI showed one).
 // ---------------------------------------------------------------------------
 
 describe('buildAgcOptions', () => {
-  // --- OFF prepending ---
+  // --- No synthetic options ---
 
-  it('prepends OFF (value 0) when 0 is not in modes', () => {
+  it('does not invent an OFF option for a domain that has none (IC-7300/IC-7610 FAST/MID/SLOW)', () => {
     const options = buildAgcOptions([1, 2, 3], { '1': 'FAST', '2': 'MID', '3': 'SLOW' });
-    expect(options[0]).toEqual({ value: 0, label: 'OFF' });
+    expect(options).toEqual([
+      { value: 1, label: 'FAST' },
+      { value: 2, label: 'MID' },
+      { value: 3, label: 'SLOW' },
+    ]);
+    expect(options.some((o) => o.value === 0)).toBe(false);
   });
 
-  it('does not duplicate OFF when 0 is already in modes', () => {
-    const options = buildAgcOptions([0, 1, 2], { '0': 'OFF', '1': 'FAST', '2': 'MID' });
-    const offOptions = options.filter((o) => o.value === 0);
-    expect(offOptions).toHaveLength(1);
-  });
-
-  it('uses the label from modes list when 0 is already present', () => {
-    const options = buildAgcOptions([0, 1], { '0': 'OFF', '1': 'FAST' });
-    expect(options[0]).toEqual({ value: 0, label: 'OFF' });
-  });
-
-  it('returns only OFF for empty modes list', () => {
+  it('returns an empty list for an empty modes list (no invented fallback)', () => {
     const options = buildAgcOptions([], {});
-    expect(options).toEqual([{ value: 0, label: 'OFF' }]);
+    expect(options).toEqual([]);
+  });
+
+  it('keeps a declared OFF option for a domain that has one (X6200 OFF/FAST/SLOW/AUTO)', () => {
+    const options = buildAgcOptions(
+      [0, 1, 2, 3],
+      { '0': 'OFF', '1': 'FAST', '2': 'SLOW', '3': 'AUTO' },
+    );
+    expect(options).toEqual([
+      { value: 0, label: 'OFF' },
+      { value: 1, label: 'FAST' },
+      { value: 2, label: 'SLOW' },
+      { value: 3, label: 'AUTO' },
+    ]);
+  });
+
+  it('renders exactly the declared set, nothing more, nothing less', () => {
+    const options = buildAgcOptions([2], { '2': 'MID' });
+    expect(options).toEqual([{ value: 2, label: 'MID' }]);
   });
 
   // --- Labels ---
 
   it('maps mode values to labels from the labels record', () => {
     const options = buildAgcOptions([1, 2, 3], { '1': 'FAST', '2': 'MID', '3': 'SLOW' });
-    expect(options.map((o) => o.label)).toContain('FAST');
-    expect(options.map((o) => o.label)).toContain('MID');
-    expect(options.map((o) => o.label)).toContain('SLOW');
+    expect(options.map((o) => o.label)).toEqual(['FAST', 'MID', 'SLOW']);
   });
 
   it('falls back to String(mode) when label is missing', () => {
@@ -46,9 +60,7 @@ describe('buildAgcOptions', () => {
 
   it('falls back to String(mode) for all modes when labels is empty', () => {
     const options = buildAgcOptions([1, 2], {});
-    // OFF is prepended, then 1 → '1', 2 → '2'
     expect(options).toEqual([
-      { value: 0, label: 'OFF' },
       { value: 1, label: '1' },
       { value: 2, label: '2' },
     ]);
@@ -56,22 +68,14 @@ describe('buildAgcOptions', () => {
 
   // --- Order preservation ---
 
-  it('preserves the order of modes', () => {
+  it('preserves the declared order of modes', () => {
     const options = buildAgcOptions([3, 1, 2], { '1': 'FAST', '2': 'MID', '3': 'SLOW' });
-    // OFF first, then modes in given order
-    expect(options.map((o) => o.value)).toEqual([0, 3, 1, 2]);
+    expect(options.map((o) => o.value)).toEqual([3, 1, 2]);
   });
 
-  it('returns correct total length: modes.length + 1 when 0 absent', () => {
+  it('returns a total length equal to modes.length', () => {
     const options = buildAgcOptions([1, 2, 3], { '1': 'FAST', '2': 'MID', '3': 'SLOW' });
-    expect(options).toHaveLength(4);
-  });
-
-  it('returns correct total length: modes.length when 0 is present', () => {
-    const options = buildAgcOptions([0, 1, 2, 3], {
-      '0': 'OFF', '1': 'FAST', '2': 'MID', '3': 'SLOW',
-    });
-    expect(options).toHaveLength(4);
+    expect(options).toHaveLength(3);
   });
 
   // --- Value types ---
@@ -81,31 +85,35 @@ describe('buildAgcOptions', () => {
     options.forEach((o) => expect(typeof o.value).toBe('number'));
   });
 
-  it('handles a single mode without 0', () => {
-    const options = buildAgcOptions([2], { '2': 'MID' });
-    expect(options).toEqual([
-      { value: 0, label: 'OFF' },
-      { value: 2, label: 'MID' },
-    ]);
+  // --- Per-profile domains (MOR-1522 domain table) ---
+
+  it('IC-7300/IC-7610/IC-705/IC-9700: exactly FAST/MID/SLOW, no OFF', () => {
+    const options = buildAgcOptions([1, 2, 3], { '1': 'FAST', '2': 'MID', '3': 'SLOW' });
+    expect(options.map((o) => o.value)).toEqual([1, 2, 3]);
   });
 
-  it('handles a single mode equal to 0', () => {
-    const options = buildAgcOptions([0], { '0': 'OFF' });
-    expect(options).toEqual([{ value: 0, label: 'OFF' }]);
-  });
-
-  // --- Standard IC-7610 AGC modes ---
-
-  it('produces expected options for standard IC-7610 AGC [1,2,3]', () => {
+  it('X6200: OFF/FAST/SLOW/AUTO (PDF page 8 domain, not the Icom FAST/MID/SLOW shape)', () => {
     const options = buildAgcOptions(
-      [1, 2, 3],
-      { '1': 'FAST', '2': 'MID', '3': 'SLOW' },
+      [0, 1, 2, 3],
+      { '0': 'OFF', '1': 'FAST', '2': 'SLOW', '3': 'AUTO' },
     );
-    expect(options).toEqual([
-      { value: 0, label: 'OFF' },
-      { value: 1, label: 'FAST' },
-      { value: 2, label: 'MID' },
-      { value: 3, label: 'SLOW' },
-    ]);
+    expect(options.map((o) => o.label)).toEqual(['OFF', 'FAST', 'SLOW', 'AUTO']);
+  });
+
+  it('FTX-1: full 7-value domain including manual OFF/FAST/MID/SLOW and auto variants', () => {
+    const options = buildAgcOptions(
+      [0, 1, 2, 3, 4, 5, 6],
+      {
+        '0': 'OFF',
+        '1': 'FAST',
+        '2': 'MID',
+        '3': 'SLOW',
+        '4': 'A-FAST',
+        '5': 'A-MID',
+        '6': 'A-SLOW',
+      },
+    );
+    expect(options).toHaveLength(7);
+    expect(options[0]).toEqual({ value: 0, label: 'OFF' });
   });
 });

--- a/frontend/src/components-v2/panels/agc-utils.ts
+++ b/frontend/src/components-v2/panels/agc-utils.ts
@@ -6,25 +6,19 @@ export interface AgcOption {
 /**
  * Builds the options array for the AGC mode SegmentedButton.
  *
- * Ensures OFF (value 0) is always the first option. If 0 is already present
- * in `modes`, it is used in place (not duplicated). Modes without a matching
- * label fall back to their string representation.
+ * MOR-1522: the AGC option set is radio-specific profile data (declared in
+ * the rig TOML's `[agc] modes`/`labels`) — this renders ONLY the declared
+ * options, in declaration order. It must NOT invent an OFF option: the
+ * IC-7300/IC-7610/IC-705/IC-9700 family has no AGC OFF at all (FAST/MID/SLOW
+ * only), while the X6200 and FTX-1 do declare OFF as one of their modes.
+ * Modes without a matching label fall back to their string representation.
  */
 export function buildAgcOptions(
   modes: number[],
   labels: Record<string, string>,
 ): AgcOption[] {
-  const options: AgcOption[] = [];
-
-  const hasOff = modes.includes(0);
-  if (!hasOff) {
-    options.push({ value: 0, label: 'OFF' });
-  }
-
-  for (const mode of modes) {
-    const label = labels[String(mode)] ?? String(mode);
-    options.push({ value: mode, label });
-  }
-
-  return options;
+  return modes.map((mode) => ({
+    value: mode,
+    label: labels[String(mode)] ?? String(mode),
+  }));
 }

--- a/frontend/src/semantic/__tests__/DspSurface.test.ts
+++ b/frontend/src/semantic/__tests__/DspSurface.test.ts
@@ -357,10 +357,11 @@ describe('notchMode renders as a three-way choice', () => {
 // ── 7. agcMode: dynamic choice set from the fact group + caps-echoed labels ──
 
 describe('agcMode renders the capability-derived choice set with caps-echoed labels', () => {
-  it('renders one button per agcModes entry plus OFF, labelled from agcLabels', () => {
-    // withDsp(): agcModes [1, 2, 3], agcMode known(2).
+  it('renders exactly the declared agcModes entries, labelled from agcLabels — no invented OFF', () => {
+    // MOR-1522: withDsp()'s agcModes [1, 2, 3] is the IC-7300/IC-7610 domain
+    // (FAST/MID/SLOW, no OFF at all) — the surface must not synthesize one.
     withSurface(base(), (s) => {
-      expect(s.agcButton(0)!.textContent).toBe('OFF');
+      expect(s.agcButton(0)).toBeNull();
       expect(s.agcButton(1)!.textContent).toBe('FAST');
       expect(s.agcButton(2)!.textContent).toBe('MID');
       expect(s.agcButton(3)!.textContent).toBe('SLOW');

--- a/rigs/ic7610.toml
+++ b/rigs/ic7610.toml
@@ -657,7 +657,10 @@ values = [0, 3, 6, 9, 12, 15, 18, 21, 24, 27, 30, 33, 36, 39, 42, 45]
 values = [0, 1, 2]
 
 [agc]
-# CI-V 0x16 0x12: 1=FAST, 2=MID, 3=SLOW
+# CI-V 0x16 0x12: 1=FAST, 2=MID, 3=SLOW, NO OFF (MOR-1522). IC-7610 hardware
+# retired 2026-08-04 — no live verification possible, so this rides the
+# documented CI-V Reference Guide command table only (same disclosure basis
+# as the filter_shape state_acquisition note above).
 modes = [1, 2, 3]
 labels = { "1" = "FAST", "2" = "MID", "3" = "SLOW" }
 

--- a/src/rigplane/backends/yaesu_cat/radio.py
+++ b/src/rigplane/backends/yaesu_cat/radio.py
@@ -2320,7 +2320,17 @@ class YaesuCatRadio:
         rejected and the value sticks at the prior setting. Manual modes
         (0–3) are sent verbatim; any AUTO request (4, 5, or 6) is collapsed
         to ``GT04;`` (AUTO), letting the radio re-derive the auto speed.
+
+        ``mode`` must be one of the profile's declared ``[agc] modes``
+        (MOR-1522) — an out-of-domain value raises instead of being sent
+        to the radio unchecked.
         """
+        agc_modes = self._config.agc_modes
+        if agc_modes is not None and mode not in agc_modes:
+            raise CommandError(
+                f"AGC mode must be one of {sorted(agc_modes)} for "
+                f"{self._config.model!r}, got {mode}"
+            )
         wire_mode = 4 if mode >= 4 else mode
         await self._write("set_agc", mode=str(wire_mode))
 

--- a/src/rigplane/commands/dsp.py
+++ b/src/rigplane/commands/dsp.py
@@ -411,12 +411,19 @@ def set_agc(
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
 ) -> bytes:
-    """Build a set AGC mode command."""
+    """Build a set AGC mode command.
+
+    Encodes the raw single-BCD-byte AGC mode value. Which mode values are
+    legal for a given radio (IC-7300's FAST/MID/SLOW vs. the X6200's
+    OFF/FAST/SLOW/AUTO) is a per-profile domain, not a universal one — this
+    builder only enforces the wire-format's single-BCD-byte range and
+    leaves domain validation to the profile-aware caller (MOR-1522).
+    """
     return _build_function_value_set(
         _SUB_AGC,
-        int(AgcMode(mode)),
-        minimum=int(AgcMode.FAST),
-        maximum=int(AgcMode.SLOW),
+        int(mode),
+        minimum=0,
+        maximum=99,
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -1221,6 +1221,8 @@ def load_rig(path: Path) -> RigConfig:
             f"{filename}: [agc].modes must be a non-empty list of integers"
         )
     agc_labels = dict(agc_section["labels"]) if "labels" in agc_section else None
+    if agc_labels is not None and agc_modes is None:
+        raise RigLoadError(f"{filename}: [agc].labels declared without [agc].modes")
     if agc_labels is not None and agc_modes is not None:
         declared = {str(m) for m in agc_modes}
         orphan_labels = sorted(set(agc_labels) - declared)

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -1208,8 +1208,27 @@ def load_rig(path: Path) -> RigConfig:
     pre_labels = dict(pre_section["labels"]) if "labels" in pre_section else None
 
     agc_section = data.get("agc", {})
+    if agc_section:
+        _reject_unknown_keys(
+            filename, "[agc]", agc_section, frozenset({"modes", "labels"})
+        )
     agc_modes = tuple(agc_section["modes"]) if "modes" in agc_section else None
+    if agc_modes is not None and (
+        not agc_modes
+        or any(isinstance(m, bool) or not isinstance(m, int) for m in agc_modes)
+    ):
+        raise RigLoadError(
+            f"{filename}: [agc].modes must be a non-empty list of integers"
+        )
     agc_labels = dict(agc_section["labels"]) if "labels" in agc_section else None
+    if agc_labels is not None and agc_modes is not None:
+        declared = {str(m) for m in agc_modes}
+        orphan_labels = sorted(set(agc_labels) - declared)
+        if orphan_labels:
+            raise RigLoadError(
+                f"{filename}: [agc].labels key {orphan_labels[0]!r} has no "
+                f"matching entry in [agc].modes {sorted(agc_modes)}"
+            )
 
     # Parse [data_mode] (optional)
     # If data_mode is in features but no [data_mode] section, default to 1 mode (OFF/DATA)

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -3053,15 +3053,29 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         return AgcMode(value)
 
     async def set_agc(self, mode: AgcMode | int, receiver: int = RECEIVER_MAIN) -> None:
-        """Set AGC mode."""
+        """Set AGC mode.
+
+        Valid values are declared per radio by the profile's ``[agc] modes``
+        (e.g. IC-7300/IC-7610 offer FAST/MID/SLOW only; the X6200
+        additionally declares OFF/AUTO). ``AgcMode`` is the IC-7610/generic
+        Icom FAST/MID/SLOW enum and is no longer used to gate the value —
+        a profile-declared value outside that enum (e.g. X6200's OFF=0)
+        must not be rejected just because it isn't an IC-7610 mode (MOR-1522).
+        """
         self._require_receiver(receiver, operation="set_agc")
         if receiver != RECEIVER_MAIN:
             self._require_cmd29_route(
                 0x16, 0x12, receiver=receiver, operation="set_agc"
             )
-        agc = AgcMode(mode)
+        mode_int = int(mode)
+        agc_modes = self._profile.agc_modes
+        if agc_modes is not None and mode_int not in agc_modes:
+            raise ValueError(
+                f"AGC mode must be one of {sorted(agc_modes)} for "
+                f"{self._profile.model}, got {mode_int}"
+            )
         await self._send_fire_and_forget(
-            set_agc(agc, to_addr=self._radio_addr, receiver=receiver)
+            set_agc(mode_int, to_addr=self._radio_addr, receiver=receiver)
         )
 
     async def get_audio_peak_filter(

--- a/tests/test_ftx1_radio.py
+++ b/tests/test_ftx1_radio.py
@@ -1439,6 +1439,18 @@ async def test_set_agc_auto_modes_map_to_gt04(connected_radio, mode):
     connected_radio._transport.write.assert_called_once_with("GT04;")
 
 
+@pytest.mark.parametrize("mode", [-1, 7, 99])
+@pytest.mark.asyncio
+async def test_set_agc_rejects_out_of_domain_value(connected_radio, mode):
+    """MOR-1522: FTX-1 declares AGC modes 0-6 in ``[agc] modes``; a value
+    outside that domain must raise instead of being written to the radio
+    unchecked (the pre-fix behavior sent any int through verbatim/collapsed)."""
+    connected_radio._transport.write = AsyncMock()
+    with pytest.raises(CommandError):
+        await connected_radio.set_agc(mode)
+    connected_radio._transport.write.assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # Profile property (issue #392)
 # ---------------------------------------------------------------------------

--- a/tests/test_operator_toggles.py
+++ b/tests/test_operator_toggles.py
@@ -125,15 +125,20 @@ class TestAGCStatus:
     def test_set_agc_accepts_int(self) -> None:
         assert commands.set_agc(1) == commands.set_agc(AgcMode.FAST)
 
-    def test_set_agc_rejects_value_below_minimum(self) -> None:
-        with pytest.raises(ValueError):
-            commands.set_agc(0)
+    def test_set_agc_builder_accepts_values_outside_the_ic7610_enum(self) -> None:
+        """MOR-1522: the raw wire-command builder no longer polices the
+        IC-7610 FAST/MID/SLOW enum's range — which AGC values are legal is
+        a per-profile domain (e.g. the X6200 legitimately sends 0=OFF and
+        3=AUTO), enforced one layer up in ``IcomRadio.set_agc`` /
+        ``YaesuCatRadio.set_agc`` against the profile's declared
+        ``[agc] modes`` (see ``TestAgcDomainValidation`` in
+        ``tests/test_radio.py``). This builder only encodes the raw
+        single-BCD-byte value.
+        """
+        assert commands.set_agc(0) == _simple_set(_SUB_AGC, 0x00)
+        assert commands.set_agc(4) == _simple_set(_SUB_AGC, 0x04)
 
-    def test_set_agc_rejects_value_above_maximum(self) -> None:
-        with pytest.raises(ValueError):
-            commands.set_agc(4)
-
-    def test_set_agc_rejects_invalid_enum_int(self) -> None:
+    def test_set_agc_rejects_value_outside_single_bcd_byte_range(self) -> None:
         with pytest.raises(ValueError):
             commands.set_agc(999)
 

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -2632,6 +2632,69 @@ class TestTransceiverStatusParity:
         assert mock_transport.sent_packets[-1].endswith(expected_tail)
 
 
+class TestAgcDomainValidation:
+    """MOR-1522: the AGC mode domain is profile data, not a universal enum.
+
+    IC-7300/IC-7610 declare FAST/MID/SLOW only (no OFF); the X6200 declares
+    OFF/FAST/SLOW/AUTO. ``set_agc`` must accept exactly what the profile
+    declares for that radio and reject anything else with a visible error,
+    not a silent write of an illegal byte.
+    """
+
+    @pytest.mark.asyncio
+    async def test_ic7300_rejects_off_not_in_its_domain(
+        self, mock_transport: MockTransport
+    ) -> None:
+        radio = IcomRadio("192.168.1.100", model="IC-7300")
+        radio._civ_transport = mock_transport
+        radio._ctrl_transport = mock_transport
+        radio._connected = True
+        with pytest.raises(ValueError, match=r"AGC mode must be one of"):
+            await radio.set_agc(0)
+        assert mock_transport.sent_packets == []
+        radio._connected = False
+
+    @pytest.mark.asyncio
+    async def test_ic7300_accepts_its_declared_domain(
+        self, mock_transport: MockTransport
+    ) -> None:
+        radio = IcomRadio("192.168.1.100", model="IC-7300")
+        radio._civ_transport = mock_transport
+        radio._ctrl_transport = mock_transport
+        radio._connected = True
+        for legal in (1, 2, 3):
+            await radio.set_agc(legal)
+        assert len(mock_transport.sent_packets) == 3
+        radio._connected = False
+
+    @pytest.mark.asyncio
+    async def test_x6200_accepts_declared_off_that_ic7300_lacks(
+        self, mock_transport: MockTransport
+    ) -> None:
+        """The X6200's declared OFF=0 must not be rejected just because it
+        falls outside the IC-7610 ``AgcMode`` enum (FAST=1/MID=2/SLOW=3)."""
+        radio = IcomRadio("192.168.1.100", model="X6200")
+        radio._civ_transport = mock_transport
+        radio._ctrl_transport = mock_transport
+        radio._connected = True
+        await radio.set_agc(0)
+        assert mock_transport.sent_packets[-1].endswith(b"\x16\x12\x00\xfd")
+        radio._connected = False
+
+    @pytest.mark.asyncio
+    async def test_x6200_rejects_value_outside_its_declared_domain(
+        self, mock_transport: MockTransport
+    ) -> None:
+        radio = IcomRadio("192.168.1.100", model="X6200")
+        radio._civ_transport = mock_transport
+        radio._ctrl_transport = mock_transport
+        radio._connected = True
+        with pytest.raises(ValueError, match=r"AGC mode must be one of"):
+            await radio.set_agc(9)
+        assert mock_transport.sent_packets == []
+        radio._connected = False
+
+
 class TestBreakInModeRoundTrip:
     """Issue #1100 — CwControlCapable.get_break_in/set_break_in type contract.
 

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -238,6 +238,26 @@ labels = { "1" = "FAST", "2" = "MID", "3" = "SLOW", "9" = "PHANTOM" }
         with pytest.raises(RigLoadError, match=r"\[agc\]\.labels.*9"):
             load_rig(p)
 
+    def test_agc_labels_rejects_declared_without_modes(self, tmp_path):
+        """MOR-1522 R1 (B2): [agc].labels with no [agc].modes must not load
+        silently — that would yield a capability-present radio with an
+        empty domain, short-circuiting both runtime validation seats
+        (``agc_modes is not None`` in ``IcomRadio.set_agc`` /
+        ``YaesuCatRadio.set_agc``)."""
+        p = _write_toml(
+            tmp_path,
+            _MINIMAL_TOML
+            + """
+
+[agc]
+labels = { "1" = "FAST", "2" = "MID", "3" = "SLOW" }
+""",
+        )
+        with pytest.raises(
+            RigLoadError, match=r"\[agc\]\.labels declared without \[agc\]\.modes"
+        ):
+            load_rig(p)
+
     def test_agc_capability_absent_declares_no_domain(self, tmp_path):
         """A radio that never mentions AGC at all — no capability, no
         [agc] section — is valid: capability-absent hides the selector

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -168,6 +168,85 @@ provider = 123
         with pytest.raises(RigLoadError, match="vfo.*scheme"):
             load_rig(p)
 
+    # ── [agc] domain declaration (MOR-1522) ─────────────────────────
+
+    def test_agc_modes_and_labels_load(self, tmp_path):
+        p = _write_toml(
+            tmp_path,
+            _MINIMAL_TOML
+            + """
+
+[agc]
+modes = [1, 2, 3]
+labels = { "1" = "FAST", "2" = "MID", "3" = "SLOW" }
+""",
+        )
+        rig = load_rig(p)
+        assert rig.agc_modes == (1, 2, 3)
+        assert rig.agc_labels == {"1": "FAST", "2": "MID", "3": "SLOW"}
+
+    def test_agc_section_rejects_unknown_key(self, tmp_path):
+        p = _write_toml(
+            tmp_path,
+            _MINIMAL_TOML
+            + """
+
+[agc]
+mode = [1, 2, 3]
+""",
+        )
+        with pytest.raises(RigLoadError, match=r"\[agc\].*unknown key"):
+            load_rig(p)
+
+    def test_agc_modes_rejects_empty_list(self, tmp_path):
+        p = _write_toml(
+            tmp_path,
+            _MINIMAL_TOML
+            + """
+
+[agc]
+modes = []
+""",
+        )
+        with pytest.raises(RigLoadError, match=r"\[agc\]\.modes"):
+            load_rig(p)
+
+    def test_agc_modes_rejects_non_integer_entries(self, tmp_path):
+        p = _write_toml(
+            tmp_path,
+            _MINIMAL_TOML
+            + """
+
+[agc]
+modes = [1, "FAST", 3]
+""",
+        )
+        with pytest.raises(RigLoadError, match=r"\[agc\]\.modes"):
+            load_rig(p)
+
+    def test_agc_labels_rejects_orphan_key_not_in_modes(self, tmp_path):
+        p = _write_toml(
+            tmp_path,
+            _MINIMAL_TOML
+            + """
+
+[agc]
+modes = [1, 2, 3]
+labels = { "1" = "FAST", "2" = "MID", "3" = "SLOW", "9" = "PHANTOM" }
+""",
+        )
+        with pytest.raises(RigLoadError, match=r"\[agc\]\.labels.*9"):
+            load_rig(p)
+
+    def test_agc_capability_absent_declares_no_domain(self, tmp_path):
+        """A radio that never mentions AGC at all — no capability, no
+        [agc] section — is valid: capability-absent hides the selector
+        (MOR-1494 pattern), it is not a malformed declaration."""
+        p = _write_toml(tmp_path, _MINIMAL_TOML)
+        rig = load_rig(p)
+        assert rig.agc_modes is None
+        assert rig.agc_labels is None
+
     def test_rf_sql_control_model_defaults_to_separate(self, tmp_path):
         p = _write_toml(tmp_path, _MINIMAL_TOML)
         rig = load_rig(p)
@@ -1004,3 +1083,100 @@ class TestWriteOnlyControls:
         assert "filter_width" not in caps
         # Unrelated caps stay untouched.
         assert {"rit", "xit", "notch", "nr", "nb", "compressor"} <= caps
+
+
+# ── AGC domain declaration, table-driven over every shipped profile ──────
+# (MOR-1522). "Shipped profile" = every rigs/*.toml except the UI-only
+# _keyboard-default.toml, taken from the directory listing itself rather
+# than a hand-maintained name list, so a new profile can't silently land
+# in the ambiguous middle this test forbids.
+
+_SHIPPED_RIG_TOMLS = sorted(
+    p for p in RIGS_DIR.glob("*.toml") if p.name != "_keyboard-default.toml"
+)
+
+
+class TestAgcDomainDeclaredOrCapabilityAbsent:
+    """Every shipped profile must land on one of exactly two sides:
+
+    (a) it does not declare the ``agc`` capability at all — the
+        capability-absent selector-hiding pattern (MOR-1494) — or
+    (b) it declares ``agc`` AND a non-empty ``[agc] modes`` domain that
+        every declared value can be encoded into a legal wire command.
+
+    No profile may declare the capability without a domain, or a domain
+    without the capability.
+    """
+
+    @pytest.mark.parametrize("toml_path", _SHIPPED_RIG_TOMLS, ids=lambda p: p.stem)
+    def test_agc_capability_and_domain_agree(self, toml_path):
+        rig = load_rig(toml_path)
+        has_agc_capability = "agc" in rig.capabilities
+
+        if not has_agc_capability:
+            assert rig.agc_modes is None, (
+                f"{toml_path.name}: declares [agc] modes without the "
+                f"'agc' capability feature"
+            )
+            return
+
+        assert rig.agc_modes, (
+            f"{toml_path.name}: declares the 'agc' capability but no "
+            f"(or an empty) [agc] modes domain"
+        )
+
+    @pytest.mark.parametrize(
+        "toml_path",
+        [p for p in _SHIPPED_RIG_TOMLS if load_rig(p).protocol_type == "civ"],
+        ids=lambda p: p.stem,
+    )
+    def test_civ_agc_modes_encode_to_a_legal_command(self, toml_path):
+        """Every declared mode for a CI-V family radio must round-trip
+        through the real wire-command builder without raising — the
+        profile's domain must map to a legal command, not just a legal
+        Python int (MOR-1522)."""
+        from rigplane.commands.dsp import set_agc
+
+        rig = load_rig(toml_path)
+        if rig.agc_modes is None:
+            pytest.skip(f"{toml_path.name}: no agc capability")
+        for mode in rig.agc_modes:
+            civ = set_agc(mode, to_addr=rig.civ_addr)
+            # All shipped AGC domains are single-digit (0-9), so the BCD
+            # byte equals the raw mode value — this is both the
+            # "encodes without raising" check and a byte-shape pin.
+            assert civ.endswith(bytes([0x16, 0x12, mode, 0xFD])), (
+                f"{toml_path.name}: mode {mode} did not encode to the "
+                f"expected 0x16 0x12 {mode:#04x} wire command"
+            )
+
+    def test_ic7300_declares_exactly_fast_mid_slow_no_off(self):
+        """The MOR-1522 regression pin: IC-7300 must show FAST/MID/SLOW
+        only. Confirmed against docs/validation/cat-audits/ic7300.md
+        (CI-V 0x16 0x12: 1=FAST, 2=MID, 3=SLOW, no OFF)."""
+        rig = load_rig(RIGS_DIR / "ic7300.toml")
+        assert rig.agc_modes == (1, 2, 3)
+        assert 0 not in rig.agc_modes
+
+    def test_x6200_keeps_its_declared_off(self):
+        """A profile that DOES have AGC OFF must keep it — the fix must not
+        over-correct into dropping OFF everywhere. X6200 CI-V doc (PDF page
+        8): 0x16 0x12 0x00..0x03 = off/fast/slow/auto."""
+        rig = load_rig(RIGS_DIR / "x6200.toml")
+        assert 0 in rig.agc_modes
+        assert rig.agc_labels["0"] == "OFF"
+
+    def test_ftx1_keeps_its_declared_off(self):
+        """FTX-1 (live bench hardware) also legitimately has AGC OFF."""
+        rig = load_rig(RIGS_DIR / "ftx1.toml")
+        assert 0 in rig.agc_modes
+        assert rig.agc_labels["0"] == "OFF"
+
+    def test_x6100_and_tx500_declare_no_agc_capability(self):
+        """Neither has AGC wired at all today (X6100: no confirmed hardware
+        capture; TX-500: no backend/CAT implementation at all) — capability-
+        absent is correct for both, not an empty/invented domain."""
+        for name in ("x6100", "tx500"):
+            rig = load_rig(RIGS_DIR / f"{name}.toml")
+            assert "agc" not in rig.capabilities
+            assert rig.agc_modes is None


### PR DESCRIPTION
## Summary

The AGC mode selector always offered OFF, even on radios whose real CI-V/CAT
domain has no OFF value (IC-7300/IC-7610/IC-705/IC-9700 offer FAST/MID/SLOW
only). Owner ruling: the AGC option set is radio-specific **profile data**;
the UI renders only declared options, and the backend enforces the same
declared domain on every write path. No hardcoded universal AGC list
anywhere in the stack.

Two independent bugs produced the reported symptom:

- **Frontend** (`frontend/src/components-v2/panels/agc-utils.ts`):
  `buildAgcOptions()` unconditionally synthesized an `OFF` (value 0) option
  whenever the declared `modes` array didn't already contain `0`. Fixed for
  both production consumers of this shared utility: `AgcPanel.svelte`
  (components-v2) and `DspSurface.svelte` (semantic surface layer).
- **Backend**: `IcomRadio.set_agc()` (`src/rigplane/runtime/radio.py`) cast
  every value through the IC-7610 `AgcMode` enum (FAST=1/MID=2/SLOW=3),
  which rejects `0` universally — accidentally correct for the
  IC-7300/IC-7610/IC-705/IC-9700 family, but it also rejected the X6200's
  legitimately-declared `OFF=0` and silently mislabeled its `AUTO=3` as
  `SLOW`. `YaesuCatRadio.set_agc()` (FTX-1, `src/rigplane/backends/yaesu_cat/radio.py`)
  had **no domain validation at all** — any int was written to the radio
  unchecked.

## Single validation seat per radio family

Every AGC write path (web `radio_poller.py`'s `SetAgc` handler, and
`rigctld/routing.py`'s `FUNC AGC` boolean toggle for FTX-1) already
converges on the same high-level `radio.set_agc()` method per radio class —
there is no separate rigctld numeric AGC level path in this codebase (only
the FUNC on/off toggle exists, and only for Yaesu routing). So the domain
check lives in exactly two seats, not duplicated per entry path:

- `IcomRadio.set_agc()` (`runtime/radio.py`) — covers ic7300/ic7610/ic705/ic9700/x6200 (all share this CI-V code path).
- `YaesuCatRadio.set_agc()` (`backends/yaesu_cat/radio.py`) — covers ftx1.

`commands.dsp.set_agc()` (the raw wire-command builder) no longer enforces
the IC-7610 enum range either — it only bounds the wire format's single BCD
byte (0-99); domain legality is entirely the profile-aware caller's job.

## Per-profile AGC domain table

| Profile | `agc` capability | `[agc] modes` | Source | Notes |
|---|---|---|---|---|
| **ic7300** | yes | `[1,2,3]` FAST/MID/SLOW | [ic7300.md](../blob/main/docs/validation/cat-audits/ic7300.md) row 51 (CI-V `0x16 0x12`) | Live bench hardware. **No OFF** — this is the reported bug. |
| **ic7610** | yes | `[1,2,3]` FAST/MID/SLOW | [ic7610.md](../blob/main/docs/validation/cat-audits/ic7610.md) rows 53/74/141 (`0x16 0x12` / `0x1A 0x04`) | Retired 2026-08-04 — doc-sourced only; disclosure comment added to `rigs/ic7610.toml` this PR (matches the existing `filter_shape` disclosure precedent). |
| **ic705** | yes | `[1,2,3]` FAST/MID/SLOW | no dedicated cat-audit; pre-existing TOML comment cites wfview `IC-7300.rig` Min/Max 1-3 | Not on live bench; declaration unchanged, already correct. |
| **ic9700** | yes | `[1,2,3]` FAST/MID/SLOW | no dedicated cat-audit; pre-existing TOML comment cites wfview `IC-7300.rig` | Not on live bench; declaration unchanged, already correct. |
| **x6200** | yes | `[0,1,2,3]` OFF/FAST/SLOW/AUTO | [x6200.md](../blob/main/docs/validation/cat-audits/x6200.md) row 30 (`agc.set` RMVR · **not run** live); TOML cites "PDF page 8: `0x16 0x12 0x00..0x03` — off/fast/slow/auto" | Domain shape differs from the Icom FAST/MID/SLOW family (index 2 = SLOW not MID, index 3 = AUTO not SLOW). Backend previously rejected its declared OFF — **fixed here**. |
| **x6100** | no | — (none declared) | no cat-audit for x6100; no `agc` in `[capabilities] features` | Capability absent entirely, consistent with the existing MOR-634 shared-firmware-inference caution already on this profile (tone/pbt). Selector hides via capability-absent (MOR-1494 pattern) — nothing to fix. |
| **ftx1** | yes | `[0..6]` OFF/FAST/MID/SLOW/A-FAST/A-MID/A-SLOW | pre-existing `[agc]`/`[agc.labels]` in `rigs/ftx1.toml:667-677`, sourced from the Yaesu FTX-1 CAT reference `GT` command — **not** covered by [ftx1.md](../blob/main/docs/validation/cat-audits/ftx1.md) (that audit has zero AGC content) and **not** live-validated. The only other artifact, `docs/validation/templates/ftx1.json`'s `agc.set` check, says "via CI-V write" — the wrong protocol for a Yaesu radio — and carries no live result either. | Live bench hardware, but the AGC domain itself is doc-sourced only, not live-confirmed. SET side collapses read-side pseudo-values 4/5/6 to an identical `GT04;` wire command (`yaesu_cat/radio.py:2334`, pre-existing, documented) — those three are unverified as *distinct* SET targets. Previously had **zero** out-of-domain validation on SET — **fixed here**. |
| **tx500** | no | — (none declared) | [tx500.md](../blob/main/docs/validation/cat-audits/tx500.md) line 38 ("GT AGC time constant 01–10 — not declared") | No backend/CAT implementation at all (Kenwood-CAT unimplemented) — capability absent, nothing to fix. |

Table-driven test (`tests/test_rig_loader.py::TestAgcDomainDeclaredOrCapabilityAbsent`)
globs the actual `rigs/*.toml` directory listing (not a hand-maintained
name list) and asserts every profile lands on exactly one of the two valid
sides — capability+domain together, or neither — no profile left in the
ambiguous middle.

## Before / after UI behavior

- **Before**: IC-7300's AGC panel showed 4 buttons — OFF (fake), FAST, MID,
  SLOW. Selecting OFF sent a `set_agc(0)` write that the backend then
  actually rejected with an opaque `AgcMode` `ValueError` deep in the
  poller (the frontend never should have offered it in the first place).
- **After**: IC-7300 shows exactly 3 buttons (FAST/MID/SLOW), matching its
  real CI-V domain. X6200 and FTX-1 keep their OFF button and it now
  actually works end-to-end (previously X6200's OFF was silently
  unreachable due to the hardcoded `AgcMode` enum cast).

## Tests

- `frontend/src/components-v2/panels/__tests__/AgcPanel.test.ts` — rewritten:
  `buildAgcOptions` renders exactly the declared set (no synthetic OFF),
  per-profile domain shapes (ic7300/ic7610/ic705/ic9700 vs x6200 vs ftx1).
- `frontend/src/semantic/__tests__/DspSurface.test.ts` — fixed the stale
  "renders ... plus OFF" assertion that baked in the same bug.
- `tests/test_radio.py::TestAgcDomainValidation` — ic7300 rejects its
  undeclared OFF; ic7300 accepts its declared FAST/MID/SLOW; x6200 accepts
  its declared OFF (fixed); x6200 rejects a value outside its domain.
- `tests/test_ftx1_radio.py::test_set_agc_rejects_out_of_domain_value` —
  FTX-1 rejects values outside its declared 0-6 domain (previously
  unchecked).
- `tests/test_operator_toggles.py::TestAGCStatus` — updated the two tests
  that pinned the old (incorrect) builder-level IC-7610 range enforcement;
  the builder is now permissive (0-99 BCD bound only).
- `tests/test_rig_loader.py` — new `[agc]` malformed-declaration tests
  (unknown key, empty/non-integer modes, orphaned label key) plus the
  table-driven all-profiles test described above.

## Verification

- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 9208
  passed, 13 skipped, 5 deselected, 14 xfailed, 1 xpassed (pre-existing,
  unrelated `test_naming_parity.py::test_toml_commands_in_radio[x6100]`).
- `uv run ruff check src/ tests/` / `uv run ruff format src/ tests/` — clean.
- `uv run mypy src/` — identical 13 pre-existing errors, none in touched files.
- `uv run lint-imports` — 5 contracts kept, 0 broken.
- `frontend`: `npx vitest run` — 6980 passed. `npx svelte-check` — 0 errors.
  `npx eslint src/` (+ boundary config) — clean on touched files.

## Read-only pins for the coordinator (not fixed here, out of scope)

- **PREAMP has the same disease as AGC had**: hardcoded option/validation
  paths that don't consult the profile's declared preamp domain. Flagged
  for a sibling ticket per the coordinator's instruction — not touched in
  this diff.
- `AmberCockpit.svelte`/`AmberScope.svelte` (amber-lcd skin) carry their own
  hardcoded `AGC_LABELS` dict (explicitly commented "FTX-1 AGC": 0=OFF,
  1=FAST, 2=MID, 3=SLOW, 4=AUTO-F...) used only for a read-only status
  token, not a write-capable selector — so it can't offer an illegal SET
  option the way `buildAgcOptions` could. It IS a latent mislabeling for
  X6200 read-only display (X6200's real domain is OFF/FAST/**SLOW**/AUTO —
  index 2/3 differ from this dict's MID/SLOW), separate from this PR's
  SET-domain bug. Left alone to keep this diff bounded to the reported
  selector/write-domain issue.
- `IcomRadio.get_agc()` still casts its read value through the `AgcMode`
  enum and would raise if a live X6200 ever reported AGC=0 (OFF) or
  AGC=3 (AUTO) over CI-V. Not exercised by the current polling path (state
  acquisition reads AGC generically via overlays, not this typed method)
  and X6200's AGC RMVR validation is marked "not run" per its audit, so
  this is dormant rather than live-observed. Left alone — read-path fix
  would change a public return-type contract multiple callers assert
  against (`AgcMode` equality in `test_get_enum_operator_toggle`), which is
  bigger than this PR's SET-domain scope.

## R1 (post-verifier fixes)

Independent verifier ruled BLOCKED on the initial head (`22505c50`). Held up
under review: validation seat has no bypass (rigctld `set_func` is genuinely
Yaesu-only), wire collisions are clean, the loader bricks nothing, capability-
absent HIDE is honored, and the witnesses discriminate on both legs. Two
findings, both applied, new head `98d6a4b5`:

- **B1 (provenance correction, no code):** the ftx1 row above previously
  cited `docs/validation/cat-audits/ftx1.md` with a ✅ live-validated badge.
  That file has **zero** AGC content — it's the only one of the five
  cat-audits without an AGC row. The only other artifact,
  `docs/validation/templates/ftx1.json` entry `agc.set`, claims "via CI-V
  write" (wrong protocol for a Yaesu radio) and carries no live result
  either. The table now cites the real provenance: the pre-existing
  `[agc]`/`[agc.labels]` declaration in `rigs/ftx1.toml:667-677`, sourced
  from the Yaesu FTX-1 CAT reference's `GT` command, explicitly marked as
  NOT covered by the cat-audit and NOT live-validated — including for the
  4/5/6 pseudo-values that collapse to an identical `GT04;` wire command
  (`yaesu_cat/radio.py:2334`). The ✅ badge is dropped.
- **B2 (code fix):** `rig_loader.py`'s orphan-label check was guarded by
  `agc_labels is not None and agc_modes is not None`, so `[agc]` with
  `labels` but no `modes` loaded silently — a capability-present radio with
  an empty domain, which short-circuits both runtime validation seats
  (`agc_modes is not None` in `IcomRadio.set_agc` / `YaesuCatRadio.set_agc`)
  into permissive no-ops. Added the missing guard:
  ```python
  if agc_labels is not None and agc_modes is None:
      raise RigLoadError(f"{filename}: [agc].labels declared without [agc].modes")
  ```
  plus `tests/test_rig_loader.py::TestLoadRig::test_agc_labels_rejects_declared_without_modes`.

Verified after R1: `uv run pytest tests/test_rig_loader.py tests/test_radio.py
tests/test_ftx1_radio.py tests/test_commands.py tests/test_operator_toggles.py -q`
— 1074 passed, 1 skipped. `uv run ruff check src/ tests/` + `ruff format` —
clean.

Closes MOR-1522.
